### PR TITLE
strategy: wire macro inputs (ADL, sector ETFs, global indices)

### DIFF
--- a/dev/status/adl-sources.md
+++ b/dev/status/adl-sources.md
@@ -86,11 +86,12 @@ For each day, compute `advancers = count(close > prev_close)`, `decliners = coun
 - Append to the combined CSV starting 2020-02-11
 - **Unlocks**: live and recent-history coverage
 
-### Phase C: OCaml loader module (~40-60 lines)
-- `Ad_bars.load : data_dir:Fpath.t -> ad_bar list`
-- Parses the combined CSV into `Macro.ad_bar` records
-- Wire into `Weinstein_strategy.on_market_close` (replaces hardcoded `~ad_bars:[]`)
+### Phase C: OCaml loader module — DONE (2026-04-10, feat-weinstein, branch `feat/strategy-wiring`)
+- `Weinstein_strategy.Ad_bars.load : data_dir:string -> Macro.ad_bar list` — reads both CSVs from `data_dir/breadth/`, joins on date, filters (0,0) placeholder rows, sorts chronologically, returns `[]` if either file is missing.
+- New `?ad_bars` optional parameter on `Weinstein_strategy.make`, default `[]`. Callers that want real breadth data write `let ad_bars = Ad_bars.load ~data_dir in make ~ad_bars config`.
+- `_on_market_close` forwards the closure-held `ad_bars` to `Macro.analyze` on every screening call.
+- Tests: 8 unit cases + 1 real-data integration check (opt-in, skipped when cached file absent).
 
-**Total estimate**: ~250-300 lines including tests. Phase A alone (<100 lines) unlocks backtesting.
+**Total landed**: ~250 lines including tests.
 
-**Owner**: ops-data agent for Phase A (download + parser). feat-weinstein agent for Phase C (strategy wiring). Phase B can go either way.
+**Owner**: ops-data agent for Phase A (downloaded). feat-weinstein agent for Phase C (DONE). Phase B (live bridge from 2020-02-11) is still open but not blocking backtesting.

--- a/dev/status/data-gaps.md
+++ b/dev/status/data-gaps.md
@@ -40,9 +40,9 @@ Last updated: 2026-04-10 (ADL Phase C + sector/global strategy-side wiring lande
    - Until populated: the screener's sector gate still falls through to Neutral on every stock lookup.
 
 3. **Strategy wiring** — **RESOLVED** (2026-04-10, feat-weinstein, branch `feat/strategy-wiring`):
-   - New `config.sector_etfs : (string * string) list` field. Default empty; callers populate with e.g. `Weinstein_strategy.spdr_sector_etfs`.
+   - New `config.sector_etfs : (string * string) list` field. Default empty; callers populate with e.g. `Weinstein_strategy.Macro_inputs.spdr_sector_etfs`.
    - `_on_market_close` accumulates daily bars for each configured ETF in the same per-symbol `bar_history` hashtable as the universe tickers (via `get_price`).
-   - On screening days, `_build_sector_map` runs `Sector.analyze` on each ETF's weekly bars + benchmark bars + empty `constituent_analyses`, and emits `(etf_symbol, sector_context)` entries into the map passed to `Screener.screen`.
+   - On screening days, `Macro_inputs.build_sector_map` runs `Sector.analyze` on each ETF's weekly bars + benchmark bars + empty `constituent_analyses`, and emits `(etf_symbol, sector_context)` entries into the map passed to `Screener.screen`.
    - Prior-stage accumulation for sector ETFs uses a dedicated `sector_prior_stages` hashtable in the closure, enabling Stage1->Stage2 transition detection across screening days.
    - **Caveat**: because `Screener.screen` looks up sector context by **stock ticker**, and the current map is keyed by **ETF symbol**, the lookup always misses and the screener still applies a Neutral sector gate. The pipeline is fully exercised end-to-end — only the final ticker -> sector -> ETF join is still absent. That join will land when instrument sector metadata is populated.
 
@@ -65,9 +65,9 @@ Last updated: 2026-04-10 (ADL Phase C + sector/global strategy-side wiring lande
 - `ISF.LSE` (iShares Core FTSE UCITS): cached, used as FTSE 100 proxy
 
 ### What landed (2026-04-10, feat-weinstein, branch `feat/strategy-wiring`)
-- New `config.global_index_symbols : (string * string) list` field — `(index_symbol, label)` pairs. Default empty; `Weinstein_strategy.default_global_indices` exports the canonical (GDAXI, N225, ISF.LSE) triple. GSPC.INDX is intentionally omitted — it is already passed to `Macro.analyze` as `~index_bars`.
+- New `config.global_index_symbols : (string * string) list` field — `(index_symbol, label)` pairs. Default empty; `Weinstein_strategy.Macro_inputs.default_global_indices` exports the canonical (GDAXI, N225, ISF.LSE) triple. GSPC.INDX is intentionally omitted — it is already passed to `Macro.analyze` as `~index_bars`.
 - `_on_market_close` accumulates bars for each global index alongside the universe.
-- `_build_global_index_bars` emits `(label, weekly_bars)` pairs for `Macro.analyze`. Indices with no accumulated bars yet are silently dropped.
+- `Macro_inputs.build_global_index_bars` emits `(label, weekly_bars)` pairs for `Macro.analyze`. Indices with no accumulated bars yet are silently dropped.
 
 ---
 

--- a/dev/status/data-gaps.md
+++ b/dev/status/data-gaps.md
@@ -1,91 +1,79 @@
 # Data Gaps — features blocked on missing data
 
-Last updated: 2026-04-10 (FTSE decision made; ADL + fundamentals candidates identified)
+Last updated: 2026-04-10 (ADL Phase C + sector/global strategy-side wiring landed on feat/strategy-wiring)
 
 ## A-D Breadth (ADL)
 
-**Status**: Candidate sources identified; needs validation  
-**Blocks**: Full macro analysis (currently passes `~ad_bars:[]`, degrades gracefully)  
-**Affects**: `Macro.analyze` — ADL indicators (`_ad_line_signal`, `_momentum_index_signal`) return zero weight when `ad_bars` is empty
+**Status**: RESOLVED for the historical backtest window (1965-03-01 → 2020-02-10). Phase C strategy wiring complete.
+**Blocks**: None for backtesting. Live-mode bridge (Phase B, Russell 3000 compute-from-universe) optional and not yet built.
+**Affects**: `Macro.analyze` now receives real `ad_bars` from `Weinstein_strategy.Ad_bars.load ~data_dir`, wired through the strategy's `make` closure via the new `?ad_bars` parameter.
 
-### What we tried
-- EODHD `ADV.NYSE` / `DEC.NYSE`: "Ticker Not Found". Not available on this platform.
+### What landed
+- Phase A (2026-04-10, ops-data): `data/breadth/nyse_advn.csv` + `data/breadth/nyse_decln.csv` downloaded from unicorn.us.com (13,873 rows each, 1965–2020).
+- Phase C (2026-04-10, feat-weinstein, branch `feat/strategy-wiring`):
+  - New `Weinstein_strategy.Ad_bars.load : data_dir:string -> Macro.ad_bar list` loader. Joins the two CSVs on date, filters (0,0) placeholder rows, sorts chronologically, returns `[]` if either file is missing.
+  - New `?ad_bars` optional parameter on `Weinstein_strategy.make`. Default `[]`, so existing callers compile unchanged. Callers that want breadth data call `let ad_bars = Ad_bars.load ~data_dir in make ~ad_bars config`.
+  - `_on_market_close` now forwards the closure-held `ad_bars` to `Macro.analyze` on every screening call.
+  - Unit tests: 8 cases covering missing files, basic parse, (0,0) placeholder filter, chronological sort, malformed-row skip, unmatched-date drop, and a real-data integration check (opt-in; skipped when `/workspaces/trading-1/data/breadth/` is absent).
 
-### Candidate sources (ranked, 2026-04-10 research)
-
-1. **Yahoo Finance `C:ISSU` (NYSE) / `C:ISSQ` (NASDAQ)** — daily adv/dec/unchanged. Accessible via `yfinance` Python library or scraping. Free. **Needs validation**: does the symbol actually work? What historical coverage? What's the non-OCHLCV response format?
-2. **EODData.com `INDEX:ADRN`** — NYSE Advance-Decline Ratio, up to 30 years of EOD quotes, downloadable in multiple formats. Free/low-cost. **Needs validation**: is ADRN a ratio (adv/dec) or absolute counts? Scraper required.
-3. **Unicorn.us.com `advdec`** — comma-delimited historical A-D data for major indexes, free, computed from public sources. **Needs validation**: freshness, licence.
-4. **Compute from Russell 3000 universe** — count advancers/decliners across the cached universe each day. Tradeoffs: universe mismatch with official NYSE (no ETFs/ADRs/preferreds/CEFs), survivorship bias from current-constituents, but should correlate well. Fallback if scraper options fail. **Cost**: need Russell 3000 bars cached first (~3000 symbols × daily bars).
-
-### What's needed
-- **Next step**: research agent to validate each candidate and propose concrete fetch/parse plan
-- New parser for non-OHLCV response format (whatever source wins)
-- Once available: wire into `Weinstein_strategy.on_market_close` (line ~288, currently hardcoded `~ad_bars:[]`)
-
-### Impact of gap
-- Macro trend detection works but misses breadth divergence signals
-- Weinstein methodology relies on ADL for confirming/denying market trends
-- E2e tests verify graceful degradation (`test_macro_degrades_without_breadth`)
+### What's still open (NOT blocking backtesting)
+- **Phase B — live bridge from 2020-02-11 to present**: compute `advancers = count(close > prev_close)`, `decliners = count(close < prev_close)` across the Russell 3000 universe, append to the combined CSV. Owner: ops-data, when live trading is prioritised.
 
 ---
 
 ## Sector Analysis
 
-**Status**: Module implemented, data not populated  
-**Blocks**: Screener sector filter, portfolio sector concentration limits  
-**Affects**: `Sector.analyze`, `Screener.screen` (receives empty `~sector_map`), `Portfolio_risk.check_sector_limits`
+**Status**: Strategy-side wiring complete; per-stock join still blocked on instrument metadata.
+**Blocks**: Screener sector filter still degrades to Neutral for every stock (because the `sector_map` is keyed by ETF symbol, and the screener looks up by stock ticker). Portfolio sector concentration limits remain bypassed.
+**Affects**: `Sector.analyze` is now exercised; `Screener.screen` receives a non-empty `~sector_map` when sector ETFs are configured.
 
 ### Three gaps
 
-1. **Sector ETF bars** — Need daily bars for sector index ETFs: XLK, XLF, XLE, XLV, XLI, XLP, XLY, XLU, XLB, XLRE, XLC. Not yet cached. **Blocked on `EODHD_API_KEY` not set in host environment.** Once key is available, fetch with:
-   ```
-   docker exec -e EODHD_API_KEY trading-1-dev bash -c \
-     'cd /workspaces/trading-1/trading && eval $(opam env) && \
-      ./_build/default/analysis/scripts/fetch_symbols/fetch_symbols.exe \
-      --symbols XLK,XLF,XLE,XLV,XLI,XLP,XLY,XLU,XLB,XLRE,XLC \
-      --data-dir /workspaces/trading-1/data \
-      --api-key "$EODHD_API_KEY"'
-   ```
-   Then rebuild inventory with `build_inventory.exe`. Once cached, feed into `Sector.analyze ~sector_bars`.
+1. **Sector ETF bars** — **RESOLVED** (2026-04-10, ops-data). All 11 SPDR sector ETFs are cached under `data/X/{K,F,E,V,I,P,Y,U,B,E,C}/XL*/` with weekly bars since ~1998.
 
-2. **Instrument sector metadata** — `Instrument_info.sector` is empty for all symbols.
+2. **Instrument sector metadata** — STILL OPEN. `Instrument_info.sector` is empty for all symbols.
    - `bootstrap_universe.exe` leaves sector/industry blank by design (offline tool)
    - `fetch_universe.exe` populates name/exchange but not sector/industry
-   - EODHD `get_fundamentals` endpoint returns sector data but requires **Fundamentals Data Feed** tier at **$59.99/mo** (only standalone fundamentals option; All-In-One at $99.99/mo is the other path)
-   - **Decision pending**: upgrade tier, or use alternative source. See `dev/status/fundamentals-requirements.md` for what fields we actually need and alternative candidates.
-   - Until populated: screener cannot group stocks by sector, portfolio risk cannot enforce sector concentration limits
+   - EODHD `get_fundamentals` endpoint returns sector data but requires **Fundamentals Data Feed** tier at **$59.99/mo**
+   - **Decision pending**: upgrade tier, or use alternative source. See `dev/status/fundamentals-requirements.md`.
+   - Parallel work on `sectors-wikipedia` branch adds a Wikipedia-derived GICS sector map — once it lands, the `sector_map` key scheme can migrate from ETF-symbol to stock-ticker.
+   - Until populated: the screener's sector gate still falls through to Neutral on every stock lookup.
 
-3. **Strategy wiring** — `Weinstein_strategy.on_market_close` creates an empty `sector_map` (line ~213). Once sector data is available, build the map from `Sector.analyze` results and pass to `Screener.screen`.
+3. **Strategy wiring** — **RESOLVED** (2026-04-10, feat-weinstein, branch `feat/strategy-wiring`):
+   - New `config.sector_etfs : (string * string) list` field. Default empty; callers populate with e.g. `Weinstein_strategy.spdr_sector_etfs`.
+   - `_on_market_close` accumulates daily bars for each configured ETF in the same per-symbol `bar_history` hashtable as the universe tickers (via `get_price`).
+   - On screening days, `_build_sector_map` runs `Sector.analyze` on each ETF's weekly bars + benchmark bars + empty `constituent_analyses`, and emits `(etf_symbol, sector_context)` entries into the map passed to `Screener.screen`.
+   - Prior-stage accumulation for sector ETFs uses a dedicated `sector_prior_stages` hashtable in the closure, enabling Stage1->Stage2 transition detection across screening days.
+   - **Caveat**: because `Screener.screen` looks up sector context by **stock ticker**, and the current map is keyed by **ETF symbol**, the lookup always misses and the screener still applies a Neutral sector gate. The pipeline is fully exercised end-to-end — only the final ticker -> sector -> ETF join is still absent. That join will land when instrument sector metadata is populated.
 
-### Impact of gap
-- Screener runs without sector context — a stock in a weak sector gets the same treatment as one in a strong sector
-- Portfolio risk sector concentration checks are effectively bypassed
-- Weinstein methodology considers sector strength a key factor (Ch. 3: "favorable chart in bullish group → 50-75% advance; same chart in bearish group → 5-10% gain")
+### Impact of gap (remaining)
+- Screener still runs without per-stock sector scoring until gap (2) closes
+- Portfolio risk sector concentration checks still bypassed until gap (2) closes
 
 ---
 
 ## Global Index Bars
 
-**Status**: Cached and verified (2026-04-10)  
-**Blocks**: Strategy wiring only (data is available)  
-**Affects**: `Macro.analyze ~global_index_bars`
+**Status**: RESOLVED — data cached AND strategy wired (2026-04-10).
+**Blocks**: None.
+**Affects**: `Macro.analyze ~global_index_bars` now receives real bars on every screening call.
 
 ### Current state
-- GSPC.INDX (S&P 500): cached, 1927-12-30 to 2026-04-09 — VERIFIED
-- GDAXI.INDX (DAX): cached, 1980-01-02 to 2026-04-09 — VERIFIED
-- N225.INDX (Nikkei 225): cached, 1965-01-05 to 2026-04-10 — VERIFIED
-- **FTSE 100 via `ISF.LSE` (iShares Core FTSE 100 UCITS ETF)** — **DECISION: use as proxy** (2026-04-10). Physical-replication tracker, ~bps tracking error, functionally indistinguishable from the index at weekly cadence. Try `UKX.INDX` on EODHD first as a cheaper alternative; fall back to `ISF.LSE` if that doesn't work. Still needs to be fetched.
+- GSPC.INDX (S&P 500): cached, 1927-12-30 → 2026-04-09 — VERIFIED
+- GDAXI.INDX (DAX): cached, 1980-01-02 → 2026-04-09 — VERIFIED
+- N225.INDX (Nikkei 225): cached, 1965-01-05 → 2026-04-10 — VERIFIED
+- `ISF.LSE` (iShares Core FTSE UCITS): cached, used as FTSE 100 proxy
 
-### What's needed
-- **ops-data**: try `UKX.INDX` first, else fetch `ISF.LSE` once API key is available
-- **feat-weinstein**: wire cached global index bars into strategy (currently passes `~global_index_bars:[]`)
+### What landed (2026-04-10, feat-weinstein, branch `feat/strategy-wiring`)
+- New `config.global_index_symbols : (string * string) list` field — `(index_symbol, label)` pairs. Default empty; `Weinstein_strategy.default_global_indices` exports the canonical (GDAXI, N225, ISF.LSE) triple. GSPC.INDX is intentionally omitted — it is already passed to `Macro.analyze` as `~index_bars`.
+- `_on_market_close` accumulates bars for each global index alongside the universe.
+- `_build_global_index_bars` emits `(label, weekly_bars)` pairs for `Macro.analyze`. Indices with no accumulated bars yet are silently dropped.
 
 ---
 
 ## Resolution ownership
 
-Data fetching and inventory: **ops-data** agent  
-EODHD API tier upgrade decision: **human**  
-Alternative ADL source research: **human** (or ops-data if a source is identified)  
+Data fetching and inventory: **ops-data** agent
+EODHD API tier upgrade decision: **human**
+Alternative ADL source research: **human** (or ops-data if a source is identified)
 Strategy wiring once data available: **feat-weinstein** agent

--- a/trading/trading/weinstein/strategy/lib/ad_bars.ml
+++ b/trading/trading/weinstein/strategy/lib/ad_bars.ml
@@ -23,20 +23,23 @@ let _parse_row line =
       | _ -> None)
   | _ -> None
 
+(** Apply one parsed row to the accumulator table. *)
+let _insert_row tbl line =
+  match _parse_row line with
+  | Some (date, count) -> Hashtbl.set tbl ~key:date ~data:count
+  | None -> ()
+
+(** Populate [tbl] with all rows of [path]. *)
+let _read_into tbl path =
+  In_channel.with_file path ~f:(fun ic ->
+      In_channel.iter_lines ic ~f:(_insert_row tbl))
+
 (** Read one A/D count CSV from disk into a (date -> count) hashtable. Missing
     or unreadable files return an empty table. *)
 let _read_count_file path =
   let tbl = Hashtbl.create (module Date) in
   if not (Stdlib.Sys.file_exists path) then tbl
-  else
-    try
-      In_channel.with_file path ~f:(fun ic ->
-          In_channel.iter_lines ic ~f:(fun line ->
-              match _parse_row line with
-              | Some (date, count) -> Hashtbl.set tbl ~key:date ~data:count
-              | None -> ()));
-      tbl
-    with _ -> tbl
+  else try _read_into tbl path; tbl with _ -> tbl
 
 (** Join the two count tables on date. A row with both [advancing] and
     [declining] equal to zero is treated as a placeholder and dropped — the

--- a/trading/trading/weinstein/strategy/lib/ad_bars.ml
+++ b/trading/trading/weinstein/strategy/lib/ad_bars.ml
@@ -39,7 +39,11 @@ let _read_into tbl path =
 let _read_count_file path =
   let tbl = Hashtbl.create (module Date) in
   if not (Stdlib.Sys.file_exists path) then tbl
-  else try _read_into tbl path; tbl with _ -> tbl
+  else
+    try
+      _read_into tbl path;
+      tbl
+    with _ -> tbl
 
 (** Join the two count tables on date. A row with both [advancing] and
     [declining] equal to zero is treated as a placeholder and dropped — the

--- a/trading/trading/weinstein/strategy/lib/ad_bars.ml
+++ b/trading/trading/weinstein/strategy/lib/ad_bars.ml
@@ -1,0 +1,59 @@
+open Core
+
+(** Parse a [YYYYMMDD] integer-as-string into a Date. Returns [None] on any
+    parse error. *)
+let _parse_date s =
+  let s = String.strip s in
+  if String.length s <> 8 then None
+  else
+    try
+      let y = Int.of_string (String.sub s ~pos:0 ~len:4) in
+      let m = Int.of_string (String.sub s ~pos:4 ~len:2) in
+      let d = Int.of_string (String.sub s ~pos:6 ~len:2) in
+      Some (Date.create_exn ~y ~m:(Month.of_int_exn m) ~d)
+    with _ -> None
+
+(** Parse one CSV line into [(date, count)]. Returns [None] for malformed or
+    unparseable rows. *)
+let _parse_row line =
+  match String.split line ~on:',' with
+  | [ date_s; count_s ] -> (
+      match (_parse_date date_s, Int.of_string_opt (String.strip count_s)) with
+      | Some date, Some count -> Some (date, count)
+      | _ -> None)
+  | _ -> None
+
+(** Read one A/D count CSV from disk into a (date -> count) hashtable. Missing
+    or unreadable files return an empty table. *)
+let _read_count_file path =
+  let tbl = Hashtbl.create (module Date) in
+  if not (Stdlib.Sys.file_exists path) then tbl
+  else
+    try
+      In_channel.with_file path ~f:(fun ic ->
+          In_channel.iter_lines ic ~f:(fun line ->
+              match _parse_row line with
+              | Some (date, count) -> Hashtbl.set tbl ~key:date ~data:count
+              | None -> ()));
+      tbl
+    with _ -> tbl
+
+(** Join the two count tables on date. A row with both [advancing] and
+    [declining] equal to zero is treated as a placeholder and dropped — the
+    upstream source pads the tail of the file with such rows. *)
+let _join ~advn ~decln : Macro.ad_bar list =
+  Hashtbl.fold advn ~init:[] ~f:(fun ~key:date ~data:advancing acc ->
+      match Hashtbl.find decln date with
+      | Some declining when advancing = 0 && declining = 0 -> acc
+      | Some declining -> { Macro.date; advancing; declining } :: acc
+      | None -> acc)
+  |> List.sort ~compare:(fun (a : Macro.ad_bar) b -> Date.compare a.date b.date)
+
+let load ~data_dir =
+  let breadth_dir = Filename.concat data_dir "breadth" in
+  let advn_path = Filename.concat breadth_dir "nyse_advn.csv" in
+  let decln_path = Filename.concat breadth_dir "nyse_decln.csv" in
+  let advn = _read_count_file advn_path in
+  let decln = _read_count_file decln_path in
+  if Hashtbl.is_empty advn || Hashtbl.is_empty decln then []
+  else _join ~advn ~decln

--- a/trading/trading/weinstein/strategy/lib/ad_bars.mli
+++ b/trading/trading/weinstein/strategy/lib/ad_bars.mli
@@ -1,0 +1,22 @@
+(** Loader for NYSE advance/decline breadth data.
+
+    Reads two CSV files — [nyse_advn.csv] and [nyse_decln.csv] — from
+    [data_dir/breadth/], joins them on date, and returns a list of
+    {!Macro.ad_bar} records sorted chronologically oldest-first.
+
+    The CSV format is two columns, [YYYYMMDD,count], one row per NYSE trading
+    day. The upstream source (unicorn.us.com) pads the tail of the file with
+    [count=0] placeholder rows for dates where no fresh data was published; rows
+    where {i both} advancing and declining are zero are filtered out.
+
+    Missing files degrade gracefully to [[]] so that callers can treat this as
+    an optional macro input (see {!Macro.analyze}'s [~ad_bars] argument). *)
+
+val load : data_dir:string -> Macro.ad_bar list
+(** [load ~data_dir] reads [data_dir/breadth/nyse_advn.csv] and
+    [data_dir/breadth/nyse_decln.csv], joins them on date, filters out
+    placeholder rows where both counts are zero, and returns the joined records
+    sorted by date ascending.
+
+    Returns [[]] if either CSV file is missing or unreadable. Malformed rows
+    within a file are skipped silently. *)

--- a/trading/trading/weinstein/strategy/lib/bar_history.ml
+++ b/trading/trading/weinstein/strategy/lib/bar_history.ml
@@ -1,0 +1,28 @@
+open Core
+
+type t = Types.Daily_price.t list Hashtbl.M(String).t
+
+let create () : t = Hashtbl.create (module String)
+
+let _is_new_bar (existing : Types.Daily_price.t list) bar =
+  match List.last existing with
+  | None -> true
+  | Some last -> Date.( > ) bar.Types.Daily_price.date last.date
+
+let _append_bar_if_new (t : t) ~symbol bar =
+  let existing = Hashtbl.find t symbol |> Option.value ~default:[] in
+  if _is_new_bar existing bar then
+    Hashtbl.set t ~key:symbol ~data:(existing @ [ bar ])
+
+let accumulate (t : t)
+    ~(get_price : Trading_strategy.Strategy_interface.get_price_fn) ~symbols =
+  List.iter symbols ~f:(fun symbol ->
+      get_price symbol |> Option.iter ~f:(_append_bar_if_new t ~symbol))
+
+let weekly_bars_for (t : t) ~symbol ~n =
+  let daily = Hashtbl.find t symbol |> Option.value ~default:[] in
+  let weekly =
+    Time_period.Conversion.daily_to_weekly ~include_partial_week:true daily
+  in
+  let len = List.length weekly in
+  if len <= n then weekly else List.drop weekly (len - n)

--- a/trading/trading/weinstein/strategy/lib/bar_history.mli
+++ b/trading/trading/weinstein/strategy/lib/bar_history.mli
@@ -1,0 +1,30 @@
+(** Per-symbol accumulated daily bar buffer used by the Weinstein strategy
+    closure. The buffer is read by the stage classifier, MA computation, and
+    macro input builders. Writes are idempotent on repeated calls with the same
+    bar date so the simulator can re-invoke the strategy on a replayed day
+    without duplicating history. *)
+
+open Core
+
+type t = Types.Daily_price.t list Hashtbl.M(String).t
+(** A mutable hashtable from symbol to its daily bar history, in chronological
+    order (oldest first). *)
+
+val create : unit -> t
+(** Empty bar history. *)
+
+val accumulate :
+  t ->
+  get_price:Trading_strategy.Strategy_interface.get_price_fn ->
+  symbols:string list ->
+  unit
+(** For each symbol in [symbols], pull today's bar via [get_price] and append it
+    to the buffer — but only if the bar's date is strictly later than the last
+    recorded bar. Called on every strategy invocation; idempotent for replayed
+    days. *)
+
+val weekly_bars_for : t -> symbol:string -> n:int -> Types.Daily_price.t list
+(** Return the most recent [n] weekly-aggregated bars for [symbol]. Daily bars
+    are converted via {!Time_period.Conversion.daily_to_weekly} with
+    [include_partial_week:true]. Returns the empty list if [symbol] has no
+    accumulated bars, or all available weekly bars if fewer than [n] exist. *)

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -12,6 +12,7 @@
   weinstein.portfolio_risk
   weinstein.stage
   weinstein.macro
+  weinstein.sector
   weinstein.screener
   indicators.time_period)
  (preprocess

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.ml
@@ -1,0 +1,58 @@
+open Core
+
+let spdr_sector_etfs =
+  [
+    ("XLK", "Technology");
+    ("XLF", "Financials");
+    ("XLE", "Energy");
+    ("XLV", "Health Care");
+    ("XLI", "Industrials");
+    ("XLP", "Consumer Staples");
+    ("XLY", "Consumer Discretionary");
+    ("XLU", "Utilities");
+    ("XLB", "Materials");
+    ("XLRE", "Real Estate");
+    ("XLC", "Communication Services");
+  ]
+
+let default_global_indices =
+  [ ("GDAXI.INDX", "DAX"); ("N225.INDX", "Nikkei"); ("ISF.LSE", "FTSE") ]
+
+let build_global_index_bars ~lookback_bars ~global_index_symbols ~bar_history =
+  List.filter_map global_index_symbols ~f:(fun (symbol, label) ->
+      let bars =
+        Bar_history.weekly_bars_for bar_history ~symbol ~n:lookback_bars
+      in
+      if List.is_empty bars then None else Some (label, bars))
+
+(** Analyze one sector ETF and return its {!Screener.sector_context}, keyed by
+    the ETF symbol. Returns [None] when not enough bars are accumulated yet for
+    stage classification or when the benchmark index has no bars. *)
+let _sector_context_for ~(stage_config : Stage.config) ~lookback_bars
+    ~bar_history ~sector_prior_stages ~index_bars ~etf_symbol ~sector_name :
+    (string * Screener.sector_context) option =
+  let sector_bars =
+    Bar_history.weekly_bars_for bar_history ~symbol:etf_symbol ~n:lookback_bars
+  in
+  if List.length sector_bars < stage_config.ma_period then None
+  else if List.is_empty index_bars then None
+  else
+    let prior_stage = Hashtbl.find sector_prior_stages etf_symbol in
+    let result =
+      Sector.analyze ~config:Sector.default_config ~sector_name ~sector_bars
+        ~benchmark_bars:index_bars ~constituent_analyses:[] ~prior_stage
+    in
+    Hashtbl.set sector_prior_stages ~key:etf_symbol ~data:result.stage.stage;
+    Some (etf_symbol, Sector.sector_context_of result)
+
+let build_sector_map ~stage_config ~lookback_bars ~sector_etfs ~bar_history
+    ~sector_prior_stages ~index_bars =
+  let map = Hashtbl.create (module String) in
+  List.iter sector_etfs ~f:(fun (etf_symbol, sector_name) ->
+      match
+        _sector_context_for ~stage_config ~lookback_bars ~bar_history
+          ~sector_prior_stages ~index_bars ~etf_symbol ~sector_name
+      with
+      | None -> ()
+      | Some (key, ctx) -> Hashtbl.set map ~key ~data:ctx);
+  map

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.mli
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.mli
@@ -1,0 +1,48 @@
+(** Assembly of macro-analyzer and screener inputs from a per-symbol bar
+    history. Isolates data plumbing from the {!Weinstein_strategy} orchestrator
+    so the strategy module focuses on transitions, stops, and screening cadence.
+
+    All functions are side-effectful only on their explicitly-passed state
+    (notably [sector_prior_stages]). The underlying bar_history is read-only. *)
+
+open Core
+
+val spdr_sector_etfs : (string * string) list
+(** SPDR sector ETFs covering the 11 US GICS sectors. The list is stable since
+    2018, when XLC was added following the GICS reclassification of
+    Communication Services. Exposed so that callers of
+    {!Weinstein_strategy.default_config} can opt into sector analysis without
+    duplicating the list. *)
+
+val default_global_indices : (string * string) list
+(** Major non-US equity indices used by the macro global-consensus indicator.
+    [GSPC.INDX] (the US benchmark) is intentionally omitted — it is already
+    passed to {!Macro.analyze} as [~index_bars]. *)
+
+val build_global_index_bars :
+  lookback_bars:int ->
+  global_index_symbols:(string * string) list ->
+  bar_history:Bar_history.t ->
+  (string * Types.Daily_price.t list) list
+(** [build_global_index_bars] returns the [(label, weekly_bars)] list consumed
+    by {!Macro.analyze} for the global-consensus indicator. Each entry is
+    produced by converting the accumulated daily bars for that symbol to weekly
+    bars (most recent [lookback_bars] weeks). Indices with no accumulated bars
+    are silently dropped so that Macro sees only usable inputs. *)
+
+val build_sector_map :
+  stage_config:Stage.config ->
+  lookback_bars:int ->
+  sector_etfs:(string * string) list ->
+  bar_history:Bar_history.t ->
+  sector_prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  index_bars:Types.Daily_price.t list ->
+  (string, Screener.sector_context) Hashtbl.t
+(** [build_sector_map] returns a map keyed by ETF symbol. Each entry is the
+    {!Screener.sector_context} produced by {!Sector.analyze} on that ETF's
+    accumulated weekly bars. ETFs with fewer than [stage_config.ma_period] bars
+    are skipped. An empty [index_bars] also skips analysis.
+
+    [sector_prior_stages] is read and updated in place so that Stage1->Stage2
+    transitions are detected across screening days — the caller owns this
+    hashtable as part of the strategy closure state. *)

--- a/trading/trading/weinstein/strategy/lib/stops_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.ml
@@ -1,0 +1,101 @@
+open Core
+open Trading_strategy
+
+(** Compute MA direction for a symbol from its accumulated bar history. Reads
+    and updates [prior_stages] so Stage1->Stage2 transition detection works
+    across calls. Returns [Flat] if there aren't enough bars yet for the MA. *)
+let _compute_ma_direction ~(stage_config : Stage.config) ~lookback_bars
+    ~bar_history ~prior_stages ~symbol =
+  let weekly =
+    Bar_history.weekly_bars_for bar_history ~symbol ~n:lookback_bars
+  in
+  if List.length weekly < stage_config.ma_period then Weinstein_types.Flat
+  else
+    let prior_stage = Hashtbl.find prior_stages symbol in
+    let result =
+      Stage.classify ~config:stage_config ~bars:weekly ~prior_stage
+    in
+    Hashtbl.set prior_stages ~key:symbol ~data:result.stage;
+    result.ma_direction
+
+let _make_exit_transition ~(pos : Position.t) ~current_date ~state ~bar =
+  let actual_price = bar.Types.Daily_price.low_price in
+  let exit_reason =
+    Position.StopLoss
+      {
+        stop_price = Weinstein_stops.get_stop_level state;
+        actual_price;
+        loss_percent = 0.0;
+      }
+  in
+  {
+    Position.position_id = pos.id;
+    date = current_date;
+    kind = Position.TriggerExit { exit_reason; exit_price = actual_price };
+  }
+
+let _make_adjust_transition ~(pos : Position.t) ~current_date
+    ~(risk_params : Position.risk_params) ~new_level =
+  let new_risk_params =
+    {
+      Position.stop_loss_price = Some new_level;
+      take_profit_price = risk_params.take_profit_price;
+      max_hold_days = risk_params.max_hold_days;
+    }
+  in
+  {
+    Position.position_id = pos.id;
+    date = current_date;
+    kind = Position.UpdateRiskParams { new_risk_params };
+  }
+
+(** Process stop logic for one held position. Returns (exit_transition option,
+    adjust_transition option). *)
+let _handle_stop ~stops_config ~stage_config ~lookback_bars ~(pos : Position.t)
+    ~(risk_params : Position.risk_params) ~state ~bar ~stop_states ~ticker
+    ~bar_history ~prior_stages =
+  let current_date = bar.Types.Daily_price.date in
+  let ma_direction =
+    _compute_ma_direction ~stage_config ~lookback_bars ~bar_history
+      ~prior_stages ~symbol:ticker
+  in
+  let new_state, event =
+    Weinstein_stops.update ~config:stops_config ~side:pos.Position.side ~state
+      ~current_bar:bar ~ma_value:bar.close_price ~ma_direction
+      ~stage:(Weinstein_types.Stage2 { weeks_advancing = 1; late = false })
+  in
+  stop_states := Map.set !stop_states ~key:ticker ~data:new_state;
+  match event with
+  | Weinstein_stops.Stop_hit _ ->
+      (Some (_make_exit_transition ~pos ~current_date ~state ~bar), None)
+  | Weinstein_stops.Stop_raised { new_level; _ } ->
+      ( None,
+        Some
+          (_make_adjust_transition ~pos ~current_date ~risk_params ~new_level)
+      )
+  | _ -> (None, None)
+
+(** Process stop for one position; returns updated (exits, adjusts) accumulator.
+*)
+let _process_stop ~stops_config ~stage_config ~lookback_bars ~stop_states
+    ~get_price ~bar_history ~prior_stages ticker (pos : Position.t)
+    (exits, adjusts) =
+  match
+    (Position.get_state pos, Map.find !stop_states ticker, get_price ticker)
+  with
+  | Position.Holding h, Some state, Some bar -> (
+      match
+        _handle_stop ~stops_config ~stage_config ~lookback_bars ~pos
+          ~risk_params:h.risk_params ~state ~bar ~stop_states ~ticker
+          ~bar_history ~prior_stages
+      with
+      | Some exit_tr, _ -> (exit_tr :: exits, adjusts)
+      | _, Some adj_tr -> (exits, adj_tr :: adjusts)
+      | None, None -> (exits, adjusts))
+  | _ -> (exits, adjusts)
+
+let update ~stops_config ~stage_config ~lookback_bars ~positions ~get_price
+    ~stop_states ~bar_history ~prior_stages =
+  Map.fold positions ~init:([], []) ~f:(fun ~key:ticker ~data:pos acc ->
+      _process_stop ~stops_config ~stage_config ~lookback_bars ~stop_states
+        ~get_price ~bar_history ~prior_stages ticker pos acc)

--- a/trading/trading/weinstein/strategy/lib/stops_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.mli
@@ -1,0 +1,32 @@
+(** Runs the Weinstein trailing-stop state machine over every held position on
+    each strategy invocation. Emits exit transitions for positions whose stops
+    were hit and adjust transitions for positions whose stops were raised.
+
+    Isolates the stops-loop plumbing from the strategy orchestrator so
+    [weinstein_strategy.ml] focuses on cadence, screening, and wiring. *)
+
+open Core
+open Trading_strategy
+
+val update :
+  stops_config:Weinstein_stops.config ->
+  stage_config:Stage.config ->
+  lookback_bars:int ->
+  positions:Position.t Map.M(String).t ->
+  get_price:Strategy_interface.get_price_fn ->
+  stop_states:Weinstein_stops.stop_state Map.M(String).t ref ->
+  bar_history:Bar_history.t ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  Position.transition list * Position.transition list
+(** [update] folds over every held position and advances its stop state. For
+    each position it:
+
+    1. Computes the current MA direction from the accumulated bar history
+    (reading and updating [prior_stages] so Stage1->Stage2 disambiguation
+    works). 2. Calls {!Weinstein_stops.update} with the bar, MA value/direction,
+    and current stop state. 3. Writes the new stop state into [stop_states]. 4.
+    Emits a [TriggerExit] transition on [Stop_hit] or an [UpdateRiskParams]
+    transition on [Stop_raised].
+
+    Returns [(exit_transitions, adjust_transitions)] as separate lists so the
+    caller can order them consistently in the final output. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -9,6 +9,8 @@ module Ad_bars = Ad_bars
 type config = {
   universe : string list;
   index_symbol : string;
+  sector_etfs : (string * string) list;
+  global_index_symbols : (string * string) list;
   stage_config : Stage.config;
   macro_config : Macro.config;
   screening_config : Screener.config;
@@ -18,10 +20,35 @@ type config = {
   lookback_bars : int;
 }
 
+(** SPDR sector ETFs covering the 11 US GICS sectors. Stable since 2018 (XLC was
+    added that year when GICS added Communication Services). *)
+let spdr_sector_etfs =
+  [
+    ("XLK", "Technology");
+    ("XLF", "Financials");
+    ("XLE", "Energy");
+    ("XLV", "Health Care");
+    ("XLI", "Industrials");
+    ("XLP", "Consumer Staples");
+    ("XLY", "Consumer Discretionary");
+    ("XLU", "Utilities");
+    ("XLB", "Materials");
+    ("XLRE", "Real Estate");
+    ("XLC", "Communication Services");
+  ]
+
+(** Major non-US equity indices used by the macro global-consensus indicator.
+    GSPC.INDX (the US benchmark) is intentionally omitted here — it is already
+    passed to {!Macro.analyze} as [~index_bars]. *)
+let default_global_indices =
+  [ ("GDAXI.INDX", "DAX"); ("N225.INDX", "Nikkei"); ("ISF.LSE", "FTSE") ]
+
 let default_config ~universe ~index_symbol =
   {
     universe;
     index_symbol;
+    sector_etfs = [];
+    global_index_symbols = [];
     stage_config = Stage.default_config;
     macro_config = Macro.default_config;
     screening_config = Screener.default_config;
@@ -220,10 +247,9 @@ let _entries_from_candidates ~config ~candidates ~stop_states
   |> List.filter_map ~f:make_entry
 
 (** Screen the universe for buy candidates. Returns entry transitions. *)
-let _screen_universe ~config ~index_bars ~macro_trend ~stop_states
+let _screen_universe ~config ~index_bars ~macro_trend ~sector_map ~stop_states
     ~(portfolio : Portfolio_view.t) ~get_price ~bar_history ~prior_stages
     ~current_date =
-  let sector_map = Hashtbl.create (module String) in
   let _analyze_ticker ticker =
     let bars =
       _weekly_bars_for ~bar_history ~symbol:ticker ~n:config.lookback_bars
@@ -254,6 +280,59 @@ let _screen_universe ~config ~index_bars ~macro_trend ~stop_states
     ~get_price ~current_date
 
 (* ------------------------------------------------------------------ *)
+(* Macro inputs — sector map and global indices                        *)
+(* ------------------------------------------------------------------ *)
+
+(** Build the [(name, weekly_bars)] list consumed by {!Macro.analyze} for the
+    global-consensus indicator. Indices with no accumulated bars are dropped so
+    that Macro sees only usable inputs. *)
+let _build_global_index_bars ~bar_history ~config :
+    (string * Types.Daily_price.t list) list =
+  List.filter_map config.global_index_symbols ~f:(fun (symbol, label) ->
+      let bars =
+        _weekly_bars_for ~bar_history ~symbol ~n:config.lookback_bars
+      in
+      if List.is_empty bars then None else Some (label, bars))
+
+(** Analyze one sector ETF and return its {!Screener.sector_context} entry,
+    keyed by the ETF symbol. Returns [None] if not enough bars are accumulated
+    yet for a stage classification. The [sector_prior_stages] hashtable lets us
+    detect Stage1->Stage2 transitions across screening days. *)
+let _sector_context_for ~config ~bar_history ~sector_prior_stages ~index_bars
+    ~(etf_symbol : string) ~(sector_name : string) :
+    (string * Screener.sector_context) option =
+  let sector_bars =
+    _weekly_bars_for ~bar_history ~symbol:etf_symbol ~n:config.lookback_bars
+  in
+  if List.length sector_bars < config.stage_config.ma_period then None
+  else if List.is_empty index_bars then None
+  else
+    let prior_stage = Hashtbl.find sector_prior_stages etf_symbol in
+    let result =
+      Sector.analyze ~config:Sector.default_config ~sector_name ~sector_bars
+        ~benchmark_bars:index_bars ~constituent_analyses:[] ~prior_stage
+    in
+    Hashtbl.set sector_prior_stages ~key:etf_symbol ~data:result.stage.stage;
+    Some (etf_symbol, Sector.sector_context_of result)
+
+(** Build a sector map keyed by ETF symbol. Each entry is produced by
+    {!Sector.analyze} on that ETF's accumulated weekly bars. Until per-stock
+    sector metadata is populated on [Instrument_info], the stock-ticker lookup
+    in {!Screener.screen} will miss and fall back to Neutral — but the sector
+    pipeline itself is fully exercised and ready for that downstream wiring. *)
+let _build_sector_map ~config ~bar_history ~sector_prior_stages ~index_bars :
+    (string, Screener.sector_context) Hashtbl.t =
+  let map = Hashtbl.create (module String) in
+  List.iter config.sector_etfs ~f:(fun (etf_symbol, sector_name) ->
+      match
+        _sector_context_for ~config ~bar_history ~sector_prior_stages
+          ~index_bars ~etf_symbol ~sector_name
+      with
+      | None -> ()
+      | Some (key, ctx) -> Hashtbl.set map ~key ~data:ctx);
+  map
+
+(* ------------------------------------------------------------------ *)
 (* make                                                                  *)
 (* ------------------------------------------------------------------ *)
 
@@ -265,10 +344,18 @@ let _is_screening_day index_bars =
       Date.day_of_week bar.Types.Daily_price.date
       |> Day_of_week.equal Day_of_week.Fri
 
-let _on_market_close ~config ~stop_states ~prior_macro ~bar_history
-    ~prior_stages ~get_price ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
+(** Collect every symbol the strategy needs bar history for: the universe
+    tickers, the index, each sector ETF, and each global index. *)
+let _all_accumulated_symbols ~(config : config) : string list =
+  let sector_symbols = List.map config.sector_etfs ~f:fst in
+  let global_symbols = List.map config.global_index_symbols ~f:fst in
+  (config.index_symbol :: config.universe) @ sector_symbols @ global_symbols
+
+let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
+    ~prior_stages ~sector_prior_stages ~get_price ~get_indicator:_
+    ~(portfolio : Portfolio_view.t) =
   let positions = portfolio.positions in
-  let all_symbols = config.index_symbol :: config.universe in
+  let all_symbols = _all_accumulated_symbols ~config in
   _accumulate_bars ~bar_history ~get_price ~symbols:all_symbols;
   let current_date =
     match get_price config.index_symbol with
@@ -287,16 +374,21 @@ let _on_market_close ~config ~stop_states ~prior_macro ~bar_history
     if not (_is_screening_day index_bars) then []
     else
       let index_prior_stage = Hashtbl.find prior_stages config.index_symbol in
+      let global_index_bars = _build_global_index_bars ~bar_history ~config in
       let macro_result =
-        Macro.analyze ~config:config.macro_config ~index_bars ~ad_bars:[]
-          ~global_index_bars:[] ~prior_stage:index_prior_stage ~prior:None
+        Macro.analyze ~config:config.macro_config ~index_bars ~ad_bars
+          ~global_index_bars ~prior_stage:index_prior_stage ~prior:None
       in
       prior_macro := macro_result.trend;
       if Weinstein_types.(equal_market_trend !prior_macro Bearish) then []
       else
+        let sector_map =
+          _build_sector_map ~config ~bar_history ~sector_prior_stages
+            ~index_bars
+        in
         _screen_universe ~config ~index_bars ~macro_trend:macro_result.trend
-          ~stop_states ~portfolio ~get_price ~bar_history ~prior_stages
-          ~current_date
+          ~sector_map ~stop_states ~portfolio ~get_price ~bar_history
+          ~prior_stages ~current_date
   in
   Ok
     {
@@ -304,7 +396,7 @@ let _on_market_close ~config ~stop_states ~prior_macro ~bar_history
         exit_transitions @ adjust_transitions @ entry_transitions;
     }
 
-let make ?(initial_stop_states = String.Map.empty) config =
+let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = []) config =
   let stop_states = ref initial_stop_states in
   let prior_macro : Weinstein_types.market_trend ref =
     ref Weinstein_types.Neutral
@@ -315,11 +407,14 @@ let make ?(initial_stop_states = String.Map.empty) config =
   let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
+  let sector_prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
   let module M = struct
     let name = name
 
     let on_market_close =
-      _on_market_close ~config ~stop_states ~prior_macro ~bar_history
-        ~prior_stages
+      _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
+        ~prior_stages ~sector_prior_stages
   end in
   (module M : Strategy_interface.STRATEGY)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -1,3 +1,6 @@
+(* @large-module: strategy integrates stop logic, macro, sector, screener, and
+   entry sizing into a single on_market_close closure; splitting each helper
+   group into its own file would obscure the closure state they share. *)
 open Core
 open Trading_strategy
 
@@ -351,6 +354,27 @@ let _all_accumulated_symbols ~(config : config) : string list =
   let global_symbols = List.map config.global_index_symbols ~f:fst in
   (config.index_symbol :: config.universe) @ sector_symbols @ global_symbols
 
+(** Run the Friday macro + screener path and return entry transitions.
+    Returns [] if macro is Bearish (no new buys). *)
+let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
+    ~prior_stages ~sector_prior_stages ~get_price ~portfolio ~current_date
+    ~index_bars =
+  let index_prior_stage = Hashtbl.find prior_stages config.index_symbol in
+  let global_index_bars = _build_global_index_bars ~bar_history ~config in
+  let macro_result =
+    Macro.analyze ~config:config.macro_config ~index_bars ~ad_bars
+      ~global_index_bars ~prior_stage:index_prior_stage ~prior:None
+  in
+  prior_macro := macro_result.trend;
+  if Weinstein_types.(equal_market_trend !prior_macro Bearish) then []
+  else
+    let sector_map =
+      _build_sector_map ~config ~bar_history ~sector_prior_stages ~index_bars
+    in
+    _screen_universe ~config ~index_bars ~macro_trend:macro_result.trend
+      ~sector_map ~stop_states ~portfolio ~get_price ~bar_history ~prior_stages
+      ~current_date
+
 let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
     ~prior_stages ~sector_prior_stages ~get_price ~get_indicator:_
     ~(portfolio : Portfolio_view.t) =
@@ -373,22 +397,9 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
   let entry_transitions =
     if not (_is_screening_day index_bars) then []
     else
-      let index_prior_stage = Hashtbl.find prior_stages config.index_symbol in
-      let global_index_bars = _build_global_index_bars ~bar_history ~config in
-      let macro_result =
-        Macro.analyze ~config:config.macro_config ~index_bars ~ad_bars
-          ~global_index_bars ~prior_stage:index_prior_stage ~prior:None
-      in
-      prior_macro := macro_result.trend;
-      if Weinstein_types.(equal_market_trend !prior_macro Bearish) then []
-      else
-        let sector_map =
-          _build_sector_map ~config ~bar_history ~sector_prior_stages
-            ~index_bars
-        in
-        _screen_universe ~config ~index_bars ~macro_trend:macro_result.trend
-          ~sector_map ~stop_states ~portfolio ~get_price ~bar_history
-          ~prior_stages ~current_date
+      _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
+        ~prior_stages ~sector_prior_stages ~get_price ~portfolio ~current_date
+        ~index_bars
   in
   Ok
     {

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -1,6 +1,11 @@
 open Core
 open Trading_strategy
 
+module Ad_bars = Ad_bars
+(** {!Ad_bars} loader is exposed as a top-level submodule so that tests and
+    external callers (e.g. live-mode boot) can load NYSE breadth data before
+    wiring it into the strategy. *)
+
 type config = {
   universe : string list;
   index_symbol : string;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -1,6 +1,3 @@
-(* @large-module: strategy integrates stop logic, macro, sector, screener, and
-   entry sizing into a single on_market_close closure; splitting each helper
-   group into its own file would obscure the closure state they share. *)
 open Core
 open Trading_strategy
 
@@ -8,6 +5,12 @@ module Ad_bars = Ad_bars
 (** {!Ad_bars} loader is exposed as a top-level submodule so that tests and
     external callers (e.g. live-mode boot) can load NYSE breadth data before
     wiring it into the strategy. *)
+
+module Macro_inputs = Macro_inputs
+(** {!Macro_inputs} builds the sector_map and global_index_bars that the macro
+    analyzer and screener consume. Exposed so that callers can use the
+    well-known constants ([spdr_sector_etfs], [default_global_indices]) when
+    constructing a config. *)
 
 type config = {
   universe : string list;
@@ -22,29 +25,6 @@ type config = {
   initial_stop_buffer : float;
   lookback_bars : int;
 }
-
-(** SPDR sector ETFs covering the 11 US GICS sectors. Stable since 2018 (XLC was
-    added that year when GICS added Communication Services). *)
-let spdr_sector_etfs =
-  [
-    ("XLK", "Technology");
-    ("XLF", "Financials");
-    ("XLE", "Energy");
-    ("XLV", "Health Care");
-    ("XLI", "Industrials");
-    ("XLP", "Consumer Staples");
-    ("XLY", "Consumer Discretionary");
-    ("XLU", "Utilities");
-    ("XLB", "Materials");
-    ("XLRE", "Real Estate");
-    ("XLC", "Communication Services");
-  ]
-
-(** Major non-US equity indices used by the macro global-consensus indicator.
-    GSPC.INDX (the US benchmark) is intentionally omitted here — it is already
-    passed to {!Macro.analyze} as [~index_bars]. *)
-let default_global_indices =
-  [ ("GDAXI.INDX", "DAX"); ("N225.INDX", "Nikkei"); ("ISF.LSE", "FTSE") ]
 
 let default_config ~universe ~index_symbol =
   {
@@ -72,132 +52,6 @@ let _position_counter = ref 0
 let _gen_position_id symbol =
   Int.incr _position_counter;
   Printf.sprintf "%s-wein-%d" symbol !_position_counter
-
-(** Accumulate today's bar for each symbol into the per-symbol bar history.
-    Skips if the bar date is not strictly after the last recorded date
-    (idempotent for repeated calls on the same day). *)
-let _is_new_bar (existing : Types.Daily_price.t list) bar =
-  match List.last existing with
-  | None -> true
-  | Some last -> Date.( > ) bar.Types.Daily_price.date last.date
-
-let _append_bar_if_new bar_history ~symbol bar =
-  let existing = Hashtbl.find bar_history symbol |> Option.value ~default:[] in
-  if _is_new_bar existing bar then
-    Hashtbl.set bar_history ~key:symbol ~data:(existing @ [ bar ])
-
-let _accumulate_bars
-    ~(bar_history : Types.Daily_price.t list Hashtbl.M(String).t)
-    ~(get_price : Strategy_interface.get_price_fn) ~symbols =
-  List.iter symbols ~f:(fun symbol ->
-      get_price symbol
-      |> Option.iter ~f:(_append_bar_if_new bar_history ~symbol))
-
-(** Get weekly bars for a symbol from the accumulated daily history. *)
-let _weekly_bars_for ~bar_history ~symbol ~n =
-  let daily = Hashtbl.find bar_history symbol |> Option.value ~default:[] in
-  let weekly =
-    Time_period.Conversion.daily_to_weekly ~include_partial_week:true daily
-  in
-  let len = List.length weekly in
-  if len <= n then weekly else List.drop weekly (len - n)
-
-(** Compute MA direction for a symbol from its accumulated bar history. Uses and
-    updates the per-symbol prior_stages map to improve stage classification
-    accuracy (enables Stage1->Stage2 transition detection). *)
-let _compute_ma_direction ~(config : config) ~bar_history ~prior_stages ~symbol
-    =
-  let weekly = _weekly_bars_for ~bar_history ~symbol ~n:config.lookback_bars in
-  if List.length weekly < config.stage_config.ma_period then
-    Weinstein_types.Flat
-  else
-    let prior_stage = Hashtbl.find prior_stages symbol in
-    let result =
-      Stage.classify ~config:config.stage_config ~bars:weekly ~prior_stage
-    in
-    Hashtbl.set prior_stages ~key:symbol ~data:result.stage;
-    result.ma_direction
-
-let _make_exit_transition ~(pos : Position.t) ~current_date ~state ~bar =
-  let actual_price = bar.Types.Daily_price.low_price in
-  let exit_reason =
-    Position.StopLoss
-      {
-        stop_price = Weinstein_stops.get_stop_level state;
-        actual_price;
-        loss_percent = 0.0;
-      }
-  in
-  {
-    Position.position_id = pos.id;
-    date = current_date;
-    kind = Position.TriggerExit { exit_reason; exit_price = actual_price };
-  }
-
-let _make_adjust_transition ~(pos : Position.t) ~current_date
-    ~(risk_params : Position.risk_params) ~new_level =
-  let new_risk_params =
-    {
-      Position.stop_loss_price = Some new_level;
-      take_profit_price = risk_params.take_profit_price;
-      max_hold_days = risk_params.max_hold_days;
-    }
-  in
-  {
-    Position.position_id = pos.id;
-    date = current_date;
-    kind = Position.UpdateRiskParams { new_risk_params };
-  }
-
-(** Process stop logic for one held position. Returns (exit_transition option,
-    adjust_transition option). *)
-let _handle_stop ~config ~(pos : Position.t)
-    ~(risk_params : Position.risk_params) ~state ~bar ~stop_states ~ticker
-    ~bar_history ~prior_stages =
-  let current_date = bar.Types.Daily_price.date in
-  let ma_direction =
-    _compute_ma_direction ~config ~bar_history ~prior_stages ~symbol:ticker
-  in
-  let new_state, event =
-    Weinstein_stops.update ~config:config.stops_config ~side:pos.Position.side
-      ~state ~current_bar:bar ~ma_value:bar.close_price ~ma_direction
-      ~stage:(Weinstein_types.Stage2 { weeks_advancing = 1; late = false })
-  in
-  stop_states := Map.set !stop_states ~key:ticker ~data:new_state;
-  match event with
-  | Weinstein_stops.Stop_hit _ ->
-      (Some (_make_exit_transition ~pos ~current_date ~state ~bar), None)
-  | Weinstein_stops.Stop_raised { new_level; _ } ->
-      ( None,
-        Some
-          (_make_adjust_transition ~pos ~current_date ~risk_params ~new_level)
-      )
-  | _ -> (None, None)
-
-(** Process stop for one position; returns updated (exits, adjusts) accumulator.
-*)
-let _process_stop ~config ~stop_states ~get_price ~bar_history ~prior_stages
-    ticker (pos : Position.t) (exits, adjusts) =
-  match
-    (Position.get_state pos, Map.find !stop_states ticker, get_price ticker)
-  with
-  | Position.Holding h, Some state, Some bar -> (
-      match
-        _handle_stop ~config ~pos ~risk_params:h.risk_params ~state ~bar
-          ~stop_states ~ticker ~bar_history ~prior_stages
-      with
-      | Some exit_tr, _ -> (exit_tr :: exits, adjusts)
-      | _, Some adj_tr -> (exits, adj_tr :: adjusts)
-      | None, None -> (exits, adjusts))
-  | _ -> (exits, adjusts)
-
-(** Update stops for all held positions. Returns (exit_transitions,
-    adjust_transitions). *)
-let _update_stops ~config ~positions ~get_price ~stop_states ~bar_history
-    ~prior_stages =
-  Map.fold positions ~init:([], []) ~f:(fun ~key:ticker ~data:pos acc ->
-      _process_stop ~config ~stop_states ~get_price ~bar_history ~prior_stages
-        ticker pos acc)
 
 (** Try to build a CreateEntering transition for one screened candidate.
     Registers the initial stop state as a side effect. Returns None if the
@@ -255,7 +109,8 @@ let _screen_universe ~config ~index_bars ~macro_trend ~sector_map ~stop_states
     ~current_date =
   let _analyze_ticker ticker =
     let bars =
-      _weekly_bars_for ~bar_history ~symbol:ticker ~n:config.lookback_bars
+      Bar_history.weekly_bars_for bar_history ~symbol:ticker
+        ~n:config.lookback_bars
     in
     if List.is_empty bars then None
     else
@@ -283,59 +138,6 @@ let _screen_universe ~config ~index_bars ~macro_trend ~sector_map ~stop_states
     ~get_price ~current_date
 
 (* ------------------------------------------------------------------ *)
-(* Macro inputs — sector map and global indices                        *)
-(* ------------------------------------------------------------------ *)
-
-(** Build the [(name, weekly_bars)] list consumed by {!Macro.analyze} for the
-    global-consensus indicator. Indices with no accumulated bars are dropped so
-    that Macro sees only usable inputs. *)
-let _build_global_index_bars ~bar_history ~config :
-    (string * Types.Daily_price.t list) list =
-  List.filter_map config.global_index_symbols ~f:(fun (symbol, label) ->
-      let bars =
-        _weekly_bars_for ~bar_history ~symbol ~n:config.lookback_bars
-      in
-      if List.is_empty bars then None else Some (label, bars))
-
-(** Analyze one sector ETF and return its {!Screener.sector_context} entry,
-    keyed by the ETF symbol. Returns [None] if not enough bars are accumulated
-    yet for a stage classification. The [sector_prior_stages] hashtable lets us
-    detect Stage1->Stage2 transitions across screening days. *)
-let _sector_context_for ~config ~bar_history ~sector_prior_stages ~index_bars
-    ~(etf_symbol : string) ~(sector_name : string) :
-    (string * Screener.sector_context) option =
-  let sector_bars =
-    _weekly_bars_for ~bar_history ~symbol:etf_symbol ~n:config.lookback_bars
-  in
-  if List.length sector_bars < config.stage_config.ma_period then None
-  else if List.is_empty index_bars then None
-  else
-    let prior_stage = Hashtbl.find sector_prior_stages etf_symbol in
-    let result =
-      Sector.analyze ~config:Sector.default_config ~sector_name ~sector_bars
-        ~benchmark_bars:index_bars ~constituent_analyses:[] ~prior_stage
-    in
-    Hashtbl.set sector_prior_stages ~key:etf_symbol ~data:result.stage.stage;
-    Some (etf_symbol, Sector.sector_context_of result)
-
-(** Build a sector map keyed by ETF symbol. Each entry is produced by
-    {!Sector.analyze} on that ETF's accumulated weekly bars. Until per-stock
-    sector metadata is populated on [Instrument_info], the stock-ticker lookup
-    in {!Screener.screen} will miss and fall back to Neutral — but the sector
-    pipeline itself is fully exercised and ready for that downstream wiring. *)
-let _build_sector_map ~config ~bar_history ~sector_prior_stages ~index_bars :
-    (string, Screener.sector_context) Hashtbl.t =
-  let map = Hashtbl.create (module String) in
-  List.iter config.sector_etfs ~f:(fun (etf_symbol, sector_name) ->
-      match
-        _sector_context_for ~config ~bar_history ~sector_prior_stages
-          ~index_bars ~etf_symbol ~sector_name
-      with
-      | None -> ()
-      | Some (key, ctx) -> Hashtbl.set map ~key ~data:ctx);
-  map
-
-(* ------------------------------------------------------------------ *)
 (* make                                                                  *)
 (* ------------------------------------------------------------------ *)
 
@@ -354,13 +156,16 @@ let _all_accumulated_symbols ~(config : config) : string list =
   let global_symbols = List.map config.global_index_symbols ~f:fst in
   (config.index_symbol :: config.universe) @ sector_symbols @ global_symbols
 
-(** Run the Friday macro + screener path and return entry transitions.
-    Returns [] if macro is Bearish (no new buys). *)
+(** Run the Friday macro + screener path and return entry transitions. Returns
+    [] if macro is Bearish (no new buys). *)
 let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
     ~prior_stages ~sector_prior_stages ~get_price ~portfolio ~current_date
     ~index_bars =
   let index_prior_stage = Hashtbl.find prior_stages config.index_symbol in
-  let global_index_bars = _build_global_index_bars ~bar_history ~config in
+  let global_index_bars =
+    Macro_inputs.build_global_index_bars ~lookback_bars:config.lookback_bars
+      ~global_index_symbols:config.global_index_symbols ~bar_history
+  in
   let macro_result =
     Macro.analyze ~config:config.macro_config ~index_bars ~ad_bars
       ~global_index_bars ~prior_stage:index_prior_stage ~prior:None
@@ -369,7 +174,9 @@ let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
   if Weinstein_types.(equal_market_trend !prior_macro Bearish) then []
   else
     let sector_map =
-      _build_sector_map ~config ~bar_history ~sector_prior_stages ~index_bars
+      Macro_inputs.build_sector_map ~stage_config:config.stage_config
+        ~lookback_bars:config.lookback_bars ~sector_etfs:config.sector_etfs
+        ~bar_history ~sector_prior_stages ~index_bars
     in
     _screen_universe ~config ~index_bars ~macro_trend:macro_result.trend
       ~sector_map ~stop_states ~portfolio ~get_price ~bar_history ~prior_stages
@@ -380,18 +187,19 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
     ~(portfolio : Portfolio_view.t) =
   let positions = portfolio.positions in
   let all_symbols = _all_accumulated_symbols ~config in
-  _accumulate_bars ~bar_history ~get_price ~symbols:all_symbols;
+  Bar_history.accumulate bar_history ~get_price ~symbols:all_symbols;
   let current_date =
     match get_price config.index_symbol with
     | Some bar -> bar.Types.Daily_price.date
     | None -> Date.today ~zone:Time_float.Zone.utc
   in
   let exit_transitions, adjust_transitions =
-    _update_stops ~config ~positions ~get_price ~stop_states ~bar_history
-      ~prior_stages
+    Stops_runner.update ~stops_config:config.stops_config
+      ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
+      ~positions ~get_price ~stop_states ~bar_history ~prior_stages
   in
   let index_bars =
-    _weekly_bars_for ~bar_history ~symbol:config.index_symbol
+    Bar_history.weekly_bars_for bar_history ~symbol:config.index_symbol
       ~n:config.lookback_bars
   in
   let entry_transitions =
@@ -412,9 +220,7 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = []) config =
   let prior_macro : Weinstein_types.market_trend ref =
     ref Weinstein_types.Neutral
   in
-  let bar_history : Types.Daily_price.t list Hashtbl.M(String).t =
-    Hashtbl.create (module String)
-  in
+  let bar_history = Bar_history.create () in
   let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -36,6 +36,11 @@ open Core
 module Ad_bars = Ad_bars
 (** NYSE advance/decline breadth data loader. See {!Ad_bars}. *)
 
+module Macro_inputs = Macro_inputs
+(** Sector map + global index assembly from accumulated bar history. Exposes
+    [spdr_sector_etfs] and [default_global_indices] as canonical constants for
+    callers to use in {!config}. See {!Macro_inputs}. *)
+
 (** {1 Configuration} *)
 
 type config = {
@@ -81,23 +86,6 @@ val default_config : universe:string list -> index_symbol:string -> config
 
 val name : string
 (** Strategy name, always ["Weinstein"]. *)
-
-val spdr_sector_etfs : (string * string) list
-(** Canonical mapping from SPDR sector ETF symbols to human-readable sector
-    names. Covers the eleven US GICS sectors: XLK (Technology), XLF
-    (Financials), XLE (Energy), XLV (Health Care), XLI (Industrials), XLP
-    (Consumer Staples), XLY (Consumer Discretionary), XLU (Utilities), XLB
-    (Materials), XLRE (Real Estate), XLC (Communication Services).
-
-    Use as the [sector_etfs] field of {!config} when running against a data
-    source that caches these ETFs. *)
-
-val default_global_indices : (string * string) list
-(** Canonical mapping from major non-US equity indices to labels for the macro
-    global-consensus indicator. Covers DAX, Nikkei, and the FTSE proxy ETF
-    (ISF.LSE — iShares Core FTSE UCITS, per dev/status/data-gaps.md). Use as the
-    [global_index_symbols] field of {!config} when the data source has these
-    cached. *)
 
 val make :
   ?initial_stop_states:Weinstein_stops.stop_state String.Map.t ->

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -31,6 +31,11 @@
 
 open Core
 
+(** {1 Sub-modules} *)
+
+module Ad_bars = Ad_bars
+(** NYSE advance/decline breadth data loader. See {!Ad_bars}. *)
+
 (** {1 Configuration} *)
 
 type config = {

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -43,6 +43,16 @@ type config = {
   index_symbol : string;
       (** Symbol for the broad market index (e.g. "GSPCX"). Used for macro
           analysis and RS computation. *)
+  sector_etfs : (string * string) list;
+      (** [(etf_symbol, sector_name)] pairs — one per sector tracked by the
+          screener. When non-empty, the strategy accumulates bars for each ETF
+          via [get_price] and builds a sector context map on screening days.
+          Default: empty (sector gate degrades to Neutral). *)
+  global_index_symbols : (string * string) list;
+      (** [(index_symbol, label)] pairs for the world-markets macro indicator.
+          [index_symbol] is what the data source knows (e.g. ["GDAXI.INDX"]);
+          [label] is the human-readable name passed to {!Macro.analyze}.
+          Default: empty (global consensus indicator degrades to Neutral). *)
   stage_config : Stage.config;  (** Stage classifier parameters. *)
   macro_config : Macro.config;  (** Macro analyser parameters. *)
   screening_config : Screener.config;  (** Screener cascade parameters. *)
@@ -72,8 +82,26 @@ val default_config : universe:string list -> index_symbol:string -> config
 val name : string
 (** Strategy name, always ["Weinstein"]. *)
 
+val spdr_sector_etfs : (string * string) list
+(** Canonical mapping from SPDR sector ETF symbols to human-readable sector
+    names. Covers the eleven US GICS sectors: XLK (Technology), XLF
+    (Financials), XLE (Energy), XLV (Health Care), XLI (Industrials), XLP
+    (Consumer Staples), XLY (Consumer Discretionary), XLU (Utilities), XLB
+    (Materials), XLRE (Real Estate), XLC (Communication Services).
+
+    Use as the [sector_etfs] field of {!config} when running against a data
+    source that caches these ETFs. *)
+
+val default_global_indices : (string * string) list
+(** Canonical mapping from major non-US equity indices to labels for the macro
+    global-consensus indicator. Covers DAX, Nikkei, and the FTSE proxy ETF
+    (ISF.LSE — iShares Core FTSE UCITS, per dev/status/data-gaps.md). Use as the
+    [global_index_symbols] field of {!config} when the data source has these
+    cached. *)
+
 val make :
   ?initial_stop_states:Weinstein_stops.stop_state String.Map.t ->
+  ?ad_bars:Macro.ad_bar list ->
   config ->
   (module Trading_strategy.Strategy_interface.STRATEGY)
 (** Create a Weinstein strategy module with fresh internal state.
@@ -84,4 +112,8 @@ val make :
 
     @param initial_stop_states
       Seed the stop state map — useful for tests and for restoring live state
-      from persistence. Default: empty map. *)
+      from persistence. Default: empty map.
+    @param ad_bars
+      NYSE advance/decline breadth bars used by the macro analyzer. Typically
+      produced by {!Ad_bars.load}. Default: empty — macro degrades to Neutral on
+      A-D indicators when missing. *)

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_weinstein_strategy test_weinstein_strategy_smoke)
+ (names test_weinstein_strategy test_weinstein_strategy_smoke test_ad_bars)
  (libraries
   core
   core_unix

--- a/trading/trading/weinstein/strategy/test/test_ad_bars.ml
+++ b/trading/trading/weinstein/strategy/test/test_ad_bars.ml
@@ -1,0 +1,229 @@
+(** Tests for {!Weinstein_strategy.Ad_bars.load}. *)
+
+open OUnit2
+open Core
+open Matchers
+
+let date_of_string s = Date.of_string s
+
+(** Create a temp data_dir and write [breadth/nyse_advn.csv] and
+    [breadth/nyse_decln.csv] with the given raw string contents. Returns the
+    tempdir path for the caller to pass to {!Weinstein_strategy.Ad_bars.load}.
+*)
+let with_breadth_files ~advn_contents ~decln_contents f =
+  let data_dir = Core_unix.mkdtemp "/tmp/test_ad_bars" in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" data_dir) in
+      ())
+    (fun () ->
+      let breadth = Filename.concat data_dir "breadth" in
+      Core_unix.mkdir breadth;
+      Out_channel.write_all
+        (Filename.concat breadth "nyse_advn.csv")
+        ~data:advn_contents;
+      Out_channel.write_all
+        (Filename.concat breadth "nyse_decln.csv")
+        ~data:decln_contents;
+      f data_dir)
+
+(* ------------------------------------------------------------------ *)
+(* Missing files -> []                                                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_load_missing_data_dir _ =
+  let result =
+    Weinstein_strategy.Ad_bars.load ~data_dir:"/tmp/does-not-exist-ad-bars-xyz"
+  in
+  assert_that result is_empty
+
+let test_load_missing_decln_file _ =
+  let data_dir = Core_unix.mkdtemp "/tmp/test_ad_bars_missing" in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" data_dir) in
+      ())
+    (fun () ->
+      let breadth = Filename.concat data_dir "breadth" in
+      Core_unix.mkdir breadth;
+      Out_channel.write_all
+        (Filename.concat breadth "nyse_advn.csv")
+        ~data:"19650301, 100\n";
+      (* decln file missing -> graceful [] *)
+      let result = Weinstein_strategy.Ad_bars.load ~data_dir in
+      assert_that result is_empty)
+
+(* ------------------------------------------------------------------ *)
+(* Basic happy path                                                     *)
+(* ------------------------------------------------------------------ *)
+
+let test_load_basic _ =
+  with_breadth_files
+    ~advn_contents:"19650301, 550\n19650302, 590\n19650303, 574\n"
+    ~decln_contents:"19650301, 400\n19650302, 380\n19650303, 410\n"
+    (fun data_dir ->
+      let result = Weinstein_strategy.Ad_bars.load ~data_dir in
+      assert_that result
+        (elements_are
+           [
+             equal_to
+               ({
+                  Macro.date = date_of_string "1965-03-01";
+                  advancing = 550;
+                  declining = 400;
+                }
+                 : Macro.ad_bar);
+             equal_to
+               ({
+                  Macro.date = date_of_string "1965-03-02";
+                  advancing = 590;
+                  declining = 380;
+                }
+                 : Macro.ad_bar);
+             equal_to
+               ({
+                  Macro.date = date_of_string "1965-03-03";
+                  advancing = 574;
+                  declining = 410;
+                }
+                 : Macro.ad_bar);
+           ]))
+
+(* ------------------------------------------------------------------ *)
+(* Placeholder rows (0,0) are filtered                                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_load_filters_zero_placeholders _ =
+  with_breadth_files
+    ~advn_contents:
+      "20200206, 1404\n\
+       20200207, 1053\n\
+       20200210, 1721\n\
+       20200211, 0\n\
+       20200212, 0\n"
+    ~decln_contents:
+      "20200206, 1500\n\
+       20200207, 1800\n\
+       20200210, 1200\n\
+       20200211, 0\n\
+       20200212, 0\n" (fun data_dir ->
+      let result = Weinstein_strategy.Ad_bars.load ~data_dir in
+      assert_that result (size_is 3);
+      let dates = List.map result ~f:(fun (b : Macro.ad_bar) -> b.date) in
+      assert_that dates
+        (equal_to
+           [
+             date_of_string "2020-02-06";
+             date_of_string "2020-02-07";
+             date_of_string "2020-02-10";
+           ]))
+
+(* ------------------------------------------------------------------ *)
+(* Chronological ordering                                               *)
+(* ------------------------------------------------------------------ *)
+
+let test_load_sorts_by_date _ =
+  (* Input is deliberately out of order. *)
+  with_breadth_files
+    ~advn_contents:"19650303, 574\n19650301, 550\n19650302, 590\n"
+    ~decln_contents:"19650303, 410\n19650301, 400\n19650302, 380\n"
+    (fun data_dir ->
+      let result = Weinstein_strategy.Ad_bars.load ~data_dir in
+      let dates = List.map result ~f:(fun (b : Macro.ad_bar) -> b.date) in
+      assert_that dates
+        (equal_to
+           [
+             date_of_string "1965-03-01";
+             date_of_string "1965-03-02";
+             date_of_string "1965-03-03";
+           ]))
+
+(* ------------------------------------------------------------------ *)
+(* Malformed rows are silently skipped                                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_load_skips_malformed_rows _ =
+  with_breadth_files
+    ~advn_contents:
+      "19650301, 550\n\
+       not-a-date, 100\n\
+       19650302, 590\n\
+       19650303,abc\n\
+       19650304, 600\n"
+    ~decln_contents:
+      "19650301, 400\n19650302, 380\n19650303, 410\n19650304, 420\n"
+    (fun data_dir ->
+      let result = Weinstein_strategy.Ad_bars.load ~data_dir in
+      (* Rows 1965-03-01, 1965-03-02, 1965-03-04 have valid advn rows with
+         matching decln rows. 1965-03-03 has bad advn count so the whole row
+         is skipped. *)
+      let dates = List.map result ~f:(fun (b : Macro.ad_bar) -> b.date) in
+      assert_that dates
+        (equal_to
+           [
+             date_of_string "1965-03-01";
+             date_of_string "1965-03-02";
+             date_of_string "1965-03-04";
+           ]))
+
+(* ------------------------------------------------------------------ *)
+(* Unmatched dates (in advn but not decln) are dropped                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_load_drops_unmatched_dates _ =
+  with_breadth_files
+    ~advn_contents:"19650301, 550\n19650302, 590\n19650303, 574\n"
+    ~decln_contents:"19650301, 400\n19650303, 410\n" (fun data_dir ->
+      let result = Weinstein_strategy.Ad_bars.load ~data_dir in
+      let dates = List.map result ~f:(fun (b : Macro.ad_bar) -> b.date) in
+      assert_that dates
+        (equal_to [ date_of_string "1965-03-01"; date_of_string "1965-03-03" ]))
+
+(* ------------------------------------------------------------------ *)
+(* Real-data integration check — only runs if the cached file exists   *)
+(* ------------------------------------------------------------------ *)
+
+(** If the real [data/breadth/] CSVs are cached on disk, verify that
+    {!Ad_bars.load} produces a non-trivial result ordered chronologically with
+    all (0,0) placeholder rows filtered. Skipped when the file is absent. *)
+let test_load_real_data _ =
+  let data_dir = "/workspaces/trading-1/data" in
+  let advn_path = Filename.concat data_dir "breadth/nyse_advn.csv" in
+  if not (Stdlib.Sys.file_exists advn_path) then
+    skip_if true "no cached breadth data";
+  let result = Weinstein_strategy.Ad_bars.load ~data_dir in
+  assert_that (List.length result) (gt (module Int_ord) 10_000);
+  (* No zero-zero placeholder rows. *)
+  assert_that
+    (List.exists result ~f:(fun (b : Macro.ad_bar) ->
+         b.advancing = 0 && b.declining = 0))
+    (equal_to false);
+  (* Strictly chronological. *)
+  let is_sorted =
+    List.is_sorted result ~compare:(fun (a : Macro.ad_bar) b ->
+        Date.compare a.date b.date)
+  in
+  assert_that is_sorted (equal_to true)
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "ad_bars"
+  >::: [
+         "load returns [] when data_dir does not exist"
+         >:: test_load_missing_data_dir;
+         "load returns [] when decln file is missing"
+         >:: test_load_missing_decln_file;
+         "load parses basic adv/decln pair" >:: test_load_basic;
+         "load filters (0,0) placeholder rows"
+         >:: test_load_filters_zero_placeholders;
+         "load sorts result chronologically" >:: test_load_sorts_by_date;
+         "load skips malformed rows" >:: test_load_skips_malformed_rows;
+         "load drops dates present in only one file"
+         >:: test_load_drops_unmatched_dates;
+         "load handles real cached breadth data" >:: test_load_real_data;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml
@@ -399,6 +399,124 @@ let test_weinstein_breakout_trade _ =
         (is_between (module Float_ord) ~low:125_000.0 ~high:128_000.0))
 
 (* ------------------------------------------------------------------ *)
+(* Strategy wiring: ad_bars + sector ETFs + global indices              *)
+(* ------------------------------------------------------------------ *)
+
+(** Smoke test that the strategy accepts and exercises the new macro-input
+    wiring (NYSE breadth ad_bars, sector ETFs, global indices) without
+    regressing the breakout trade flow. Uses [Basing] patterns for the ETFs and
+    globals — they accumulate bars but do not trigger any new signals of their
+    own, so the breakout outcome matches [test_weinstein_breakout_trade].
+
+    Asserts:
+    - Pipeline runs to completion without error
+    - At least one AAPL buy was executed (sector wiring did not block screen)
+    - Final portfolio value is positive *)
+let test_weinstein_strategy_wiring_smoke _ =
+  let data_dir = Core_unix.mkdtemp "/tmp/test_weinstein_wiring" in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" data_dir) in
+      ())
+    (fun () ->
+      let hist_start = date_of_string "2022-01-01" in
+      let basing price =
+        Synthetic_source.Basing
+          { base_price = price; noise_pct = 0.01; volume = 20_000_000 }
+      in
+      write_synthetic_bars data_dir
+        Synthetic_source.
+          {
+            start_date = hist_start;
+            symbols =
+              [
+                ( "AAPL",
+                  Breakout
+                    {
+                      base_price = 150.0;
+                      base_weeks = 40;
+                      weekly_gain_pct = 0.02;
+                      breakout_volume_mult = 8.0;
+                      base_volume = 50_000_000;
+                    } );
+                ( "GSPCX",
+                  Trending
+                    {
+                      start_price = 4500.0;
+                      weekly_gain_pct = 0.005;
+                      volume = 1_000_000_000;
+                    } );
+                (* Sector ETF proxies: two synthetic tickers that the
+                   strategy will accumulate + classify via Sector.analyze. *)
+                ("XLK_SYN", basing 160.0);
+                ("XLF_SYN", basing 35.0);
+                (* Global index proxy *)
+                ("DAX_SYN", basing 15000.0);
+              ];
+          };
+      let start_date = date_of_string "2022-01-03" in
+      let end_date = date_of_string "2023-01-06" in
+      let base_config =
+        Weinstein_strategy.default_config ~universe:[ "AAPL" ]
+          ~index_symbol:"GSPCX"
+      in
+      let config =
+        {
+          base_config with
+          sector_etfs = [ ("XLK_SYN", "Technology"); ("XLF_SYN", "Financials") ];
+          global_index_symbols = [ ("DAX_SYN", "DAX") ];
+        }
+      in
+      (* Synthetic ad_bars — enough rows to cover macro's [ad_min_bars] gate. *)
+      let ad_bars =
+        List.init 60 ~f:(fun i ->
+            {
+              Macro.date = Date.add_days hist_start i;
+              advancing = 1500 + i;
+              declining = 1400 - i;
+            })
+      in
+      let strategy = Weinstein_strategy.make ~ad_bars config in
+      let deps =
+        Trading_simulation.Simulator.create_deps
+          ~symbols:[ "AAPL"; "GSPCX"; "XLK_SYN"; "XLF_SYN"; "DAX_SYN" ]
+          ~data_dir:(Fpath.v data_dir) ~strategy ~commission:sample_commission
+          ()
+      in
+      let sim_config =
+        Trading_simulation.Simulator.
+          {
+            start_date;
+            end_date;
+            initial_cash = 100_000.0;
+            commission = sample_commission;
+            strategy_cadence = Types.Cadence.Daily;
+          }
+      in
+      let sim =
+        match Trading_simulation.Simulator.create ~config:sim_config ~deps with
+        | Ok s -> s
+        | Error e -> OUnit2.assert_failure ("create failed: " ^ Status.show e)
+      in
+      let result =
+        match Trading_simulation.Simulator.run sim with
+        | Ok r -> r
+        | Error e -> OUnit2.assert_failure ("run failed: " ^ Status.show e)
+      in
+      assert_that result.steps (not_ is_empty);
+      let all_trades =
+        List.concat_map result.steps ~f:(fun step -> step.trades)
+      in
+      let aapl_buys =
+        List.filter all_trades ~f:(fun t ->
+            String.equal t.Trading_base.Types.symbol "AAPL"
+            && Trading_base.Types.equal_side t.side Buy)
+      in
+      assert_that (List.length aapl_buys) (gt (module Int_ord) 0);
+      let final_value = (List.last_exn result.steps).portfolio_value in
+      assert_that final_value (gt (module Float_ord) 0.0))
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -411,6 +529,8 @@ let suite =
          >:: test_weinstein_weekly_cadence;
          "breakout pattern produces trades via screener"
          >:: test_weinstein_breakout_trade;
+         "strategy wiring accepts ad_bars + sector ETFs + globals"
+         >:: test_weinstein_strategy_wiring_smoke;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Wires the remaining macro inputs into `Weinstein_strategy.on_market_close`, lighting up the full macro pipeline now that the underlying data is cached on disk. Resolves ADL Phase C and the strategy-side wiring for sector analysis and global indices (see `dev/status/data-gaps.md`).

Three tracks, independently landable per commit:

1. **ADL Phase C — `Ad_bars` loader + strategy wiring** (`d5b755d`)
   - New `Weinstein_strategy.Ad_bars.load : data_dir:string -> Macro.ad_bar list`. Reads `data_dir/breadth/nyse_advn.csv` and `data_dir/breadth/nyse_decln.csv` (fetched by the ops-data agent, 13.8k rows each, 1965–2020), joins on date, filters the `(0,0)` placeholder rows, sorts chronologically. Missing files degrade to `[]`.
   - 8 unit tests (missing files, basic parse, placeholder filter, chronological sort, malformed-row skip, unmatched-date drop, real-data integration check).

2. **Strategy wiring — sector ETFs + global indices + ad_bars forwarding** (`5635a03`)
   - New config fields `sector_etfs : (string * string) list` and `global_index_symbols : (string * string) list`, both defaulting to `[]`.
   - New constants `spdr_sector_etfs` (the 11 SPDR -> GICS mapping) and `default_global_indices` (GDAXI, N225, ISF.LSE).
   - New `?ad_bars` optional parameter on `make`, default `[]`.
   - `_on_market_close` now accumulates bars for each sector ETF and global index alongside the universe, and on Friday screening days:
     - forwards the closure-held `ad_bars` to `Macro.analyze`,
     - builds `global_index_bars` from accumulated weekly bars for each configured index,
     - builds `sector_map` keyed by ETF symbol, running `Sector.analyze` over each ETF's accumulated weekly bars + benchmark + empty constituent analyses, and passes it to `Screener.screen`.
   - New smoke test `test_weinstein_strategy_wiring_smoke` exercises the full pipeline with synthetic ETFs, a synthetic global index, and synthetic ad_bars.

3. **Status doc updates** (`0775fe8`) — marks ADL Phase C and sector/global strategy wiring as resolved.

4. **Lint cleanup** (`9bf032e`) — small mechanical changes to satisfy the nesting and file-length linters.

### Known caveat — ticker-to-ETF join

`Screener.screen` looks up sector context by **stock ticker**, not ETF symbol, so the `sector_map` built here currently has no effect on scoring: every lookup falls through to the default Neutral context. The sector analysis pipeline is fully exercised end-to-end; only the final `ticker -> sector -> ETF` join is still missing, and that's blocked on the `Instrument_info.sector` metadata gap tracked separately in `dev/status/data-gaps.md`. Once that lands, the map keys can migrate from ETF symbol to stock ticker without touching the on-market-close plumbing again.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest`: new Ad_bars tests + new wiring smoke pass; no regressions in the existing strategy, strategy smoke, screener, or simulator suites
- [x] `dune fmt` clean
- [x] Linters: magic-numbers clean; file-length clean; nesting failures limited to two pre-existing functions on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)