### PR TITLE
session: 2026-04-11 daily log + macro cadence design note

### DIFF
--- a/dev/daily/2026-04-11.md
+++ b/dev/daily/2026-04-11.md
@@ -1,0 +1,83 @@
+# Status — 2026-04-11
+
+## Merged since last session
+- #244 M1+M2 milestone integration tests
+- #245 revert of test-file leak into #243
+- #246 simulation: prior_stage accumulation + breakout smoke test
+- #248 session/2026-04-10 orchestrator artifacts + research docs
+
+## Integration Queue (7 open, all MERGEABLE)
+
+### Root PRs (base = main)
+- **#249** `ops/2026-04-10` — data fetch report (reproducibility doc)
+- **#250** `sectors-wikipedia/portfolio-risk-unknown` — unknown-sector position cap (base of sectors-wikipedia stack)
+- **#254** `data/fetch-empty-result` — harden `fetch_symbols.exe` against empty EODHD responses (includes small refactor: library split + CLI wrapper so fetch_one is unit-testable)
+- **#255** `feat/strategy-wiring` — ADL Phase C + sector map wiring + global indices (single PR, uses git worktree not jj so jst was not usable)
+
+### Stacked (sectors-wikipedia)
+- #251 `sector-map` → on #250
+- #252 `portfolio-risk-refactor` → on #251
+- #253 `enrich-script` → on #252
+
+## Feature progress
+
+### sectors-wikipedia (feat-data agent, parallel)
+- Python stdlib-only scraper for S&P 500 / 400 / 600 / Russell 1000 → 1,654 unique symbols (1,646 match the cached universe)
+- `Sector_map` OCaml loader (10 tests)
+- `Instrument_info.sector` enrichment via `enrich_universe_sectors.exe`
+- `Portfolio_risk` `max_unknown_sector_positions = 2` cap + 5 new tests
+- **Not wired**: `Screener.screen` sector_map consumption still keyed by ticker, and `ticker→sector→ETF` join depends on `Instrument_info.sector` being populated (which is what this stack does). Closing the loop requires #250–#253 to merge first, then a tiny follow-up in `_build_sector_map`.
+
+### strategy-wiring (feat-weinstein agent, parallel)
+- `Ad_bars` loader module (8 tests including real-data integration against cached 13.8k-row CSV)
+- ADL wiring via new `?ad_bars` optional param on `make`
+- `spdr_sector_etfs` constant + `_build_sector_map` runs `Sector.analyze` per ETF
+- `default_global_indices` = GDAXI/N225/ISF.LSE (GSPC omitted — already passed as `~index_bars`)
+- `_build_global_index_bars` produces `(label, weekly_bars)` pairs for `Macro.analyze`
+- **Caveat**: sector_map is ETF-keyed but `Screener.screen` looks up by stock ticker — same gap as the sectors-wikipedia wiring note above.
+
+### fetch_symbols hardening (parallel agent)
+- Split into `fetch_symbols_lib.ml/.mli` + thin CLI wrapper for testability
+- `fetch_one` returns `Error symbol` on empty response instead of crashing `Metadata.generate_metadata`
+- 2 unit tests with mocked EODHD fetch function
+- Added linter exception for the thin glue file (2 top-level bindings trips nesting averages)
+
+## Data Operations
+
+### Cached 2026-04-10 (captured in #249 for reproducibility)
+- **11 SPDR sector ETFs**: XLK/XLF/XLE/XLV/XLI/XLP/XLY/XLU/XLB/XLRE/XLC — 1998-12-22 to 2026-04-10 (XLRE and XLC shorter)
+- **FTSE proxy ISF.LSE**: 6,552 bars, 2000-05-02 to 2026-04-10 — `UKX.INDX` returned empty, fell back as designed
+- **ADL historical** (Phase A): unicorn.us.com NYSE adv/dec CSVs, 13,873 rows, 1965-03-01 to 2020-02-10
+
+## Follow-up Queue
+
+### Unblocked by merge, not yet scheduled
+- **Sector map key resolution** — rebuild `_build_sector_map` in strategy to produce a ticker-keyed map (lookup via `Instrument_info.sector`) once #250–#253 merge. Single-commit follow-up.
+- **ADL Phase B** — live coverage for 2020-02-11 → present. Candidates in `dev/status/adl-sources.md` (StockCharts `$NYAD`, WSJ, Barchart, Nasdaq Data Link, FRED, Russell 3000 compute-from-universe). Needs human to pick.
+- **EODHD fundamentals upgrade decision** — $59.99/mo standalone or $99.99/mo All-In-One. The Wikipedia scrape covers the S&P 1500 + Russell 1000 union (~1,650 names) which is probably the entire trade-relevant universe — deferral is viable per the research plan.
+
+### Newly discovered
+
+- **Macro.analyze cadence mismatch** — `ad_bars` are daily but `index_bars` are weekly. Lookbacks are treated as bar-counts regardless of cadence. The macro module should either normalize to a single cadence or make lookbacks cadence-aware. Needs a design note + follow-up fix.
+
+- **`.claude/worktrees/` gitignore gap** — `EnterWorktree` creates git worktrees that jj can't track (the path is gitignored in main repo). Parallel agents can't use `jst submit` from git-worktree layouts. Consider either making EnterWorktree produce jj worktrees, or relaxing the gitignore.
+
+- **Pre-existing nesting linter failures**: `fetch_universe.ml:main`, `test_data_loader.ml:load_daily_bars`, `weinstein_strategy.ml` (320 lines — the strategy-wiring PR added an `@large-module` marker). All pre-existed on main, now getting flagged when touched.
+
+## Milestone status
+
+**M4/M5 track** — Position Management / Historical Backtesting
+- Sector pipeline now has data (ETFs + Wikipedia sectors) — the last missing piece was metadata, which #250–#253 address
+- ADL backtest coverage 1965-2020 unlocked once #255 lands (Phase A data + Phase C loader)
+- Live ADL coverage 2020→present still needs Phase B source decision
+- Macro `Sector.analyze` + `Macro.analyze` + `Screener.screen` can now run with real inputs
+
+## Escalations
+
+None — all PRs mergeable, no blockers on agent work.
+
+## Questions for You
+
+1. Merge order for the 7 open PRs? My suggestion: #249 (docs-only), #254 (fetch_symbols hardening, self-contained), #250→#251→#252→#253 (sectors stack), #255 (strategy-wiring, rebases on sectors-wikipedia landing).
+2. ADL Phase B source — do you want to research alternatives or stick with Phase A only for now?
+3. EODHD fundamentals tier upgrade — defer per research, or upgrade?

--- a/dev/status/macro-cadence.md
+++ b/dev/status/macro-cadence.md
@@ -1,0 +1,134 @@
+# Macro.analyze — Cadence Mismatch Design Note
+
+Last updated: 2026-04-11
+
+## Problem
+
+`Macro.analyze` accepts `ad_bars` (daily) and `index_bars` (weekly) in the same call. The A-D divergence indicator compares them directly via bar-count lookbacks, which is nonsensical because the units don't match.
+
+### The bug
+
+In `_ad_divergence_signal` (`macro/lib/macro.ml:72`):
+
+```ocaml
+let lookback = min ad_line_lookback (min n_ad n_idx) in
+if lookback < ad_min_bars then (`Neutral, "Insufficient A-D data")
+else
+  let ad_recent = List.last_exn cum_ad in
+  let ad_prior = List.nth_exn cum_ad (n_ad - lookback) in
+  let idx_recent = (List.last_exn index_bars).Daily_price.adjusted_close in
+  let idx_prior =
+    (List.nth_exn index_bars (n_idx - lookback)).Daily_price.adjusted_close
+  in
+  (* ... compare ad_rising vs idx_rising over "lookback" bars ... *)
+```
+
+With `ad_line_lookback = 50` (a config default):
+- For the daily `ad_bars` list: 50 bars = ~10 weeks ≈ 2.5 months lookback
+- For the weekly `index_bars` list: 50 bars = 50 weeks ≈ 1 year lookback
+
+The function then asks "is the A-D line rising over 2.5 months consistent with the index rising over 1 year?" — that's not the question the divergence indicator should be answering.
+
+### Similar issue in `_compute_momentum_ma`
+
+`momentum_period` is also a bar count, applied to daily ad_bars:
+
+```ocaml
+let period = min momentum_period (List.length nets) in
+```
+
+Isolated to the A-D list, so not a comparison bug — but the "momentum period" semantics are weekly in the Weinstein book (Ch. 4 refers to weekly momentum), while we're computing it over daily bars.
+
+### Why this wasn't caught earlier
+
+Before #255, `ad_bars` was always `[]` and both indicators returned `Neutral`. The mismatch only surfaces now that real ADL data flows through the pipeline.
+
+## Options
+
+### Option A: Normalize to weekly at the boundary (preferred)
+
+Add a `daily_to_weekly_ad` conversion in `Ad_bars` (or `Macro`) that aggregates daily adv/dec counts into weekly buckets:
+
+```ocaml
+type weekly_ad = { date : Date.t; advancing_total : int; declining_total : int }
+```
+
+`advancing_total` = sum of daily `advancing` values within the week.
+
+**Pros**:
+- Clean, single cadence throughout `Macro.analyze`
+- Existing lookback config values (50, 100, etc.) are interpretable as weeks
+- Matches the pattern used for price bars (`daily_to_weekly`)
+
+**Cons**:
+- Loses intraweek resolution (probably fine — Weinstein is weekly)
+- One-time conversion cost at load (trivial)
+
+**Affected code**:
+- New aggregator in `Ad_bars` (or `Time_period.Conversion`)
+- `Macro.analyze` signature: `ad_bars : ad_bar list` stays the same, just interpret as weekly
+- `Weinstein_strategy` loads `Ad_bars` once in the `make` closure (already done), passes to `Macro.analyze`
+- Any tests using hand-crafted daily `ad_bar` lists need regeneration
+
+### Option B: Make lookbacks cadence-aware
+
+Split the single `ad_line_lookback` into two fields:
+
+```ocaml
+type thresholds = {
+  ...
+  ad_line_lookback_days : int;   (* applied to ad_bars *)
+  index_lookback_weeks : int;    (* applied to index_bars *)
+  ...
+}
+```
+
+**Pros**:
+- Preserves daily ad_bars resolution
+- Backwards-compatible with existing tests (rename one field, add another)
+
+**Cons**:
+- More config surface
+- Each indicator needs to be reviewed for "does this param make sense as days or weeks?"
+- The divergence comparison is still awkward: "last 50 days of A-D vs last 10 weeks of index" requires careful conversion
+
+### Option C: Resample in the caller
+
+`Weinstein_strategy` converts `ad_bars` to weekly before passing to `Macro.analyze`:
+
+```ocaml
+let weekly_ad = Ad_bars.to_weekly daily_ad in
+Macro.analyze ~ad_bars:weekly_ad ~index_bars:weekly_index ...
+```
+
+Basically Option A but the conversion lives in the strategy, not `Macro` or `Ad_bars`. Same net effect but worse locality — `Macro.analyze` still claims to accept "ad_bars" without specifying cadence.
+
+## Recommendation
+
+**Option A**. Add `Ad_bars.to_weekly : ad_bar list -> ad_bar list` (or define a separate `weekly_ad_bar` type if we want type-level cadence tracking). Update `Macro.analyze` docstring to require weekly cadence for both inputs.
+
+### Migration steps
+
+1. Add `to_weekly` in `Ad_bars` module (or wherever the type lives)
+2. Update `Macro.analyze` docstring: "both `ad_bars` and `index_bars` must be weekly-aggregated"
+3. Update `Weinstein_strategy._on_market_close` to call `Ad_bars.to_weekly` on the cached daily list once per `make` invocation (or memoize more aggressively)
+4. Regenerate test fixtures in `test_macro.ml` that used daily cadences
+5. Re-run the macro e2e tests to verify divergence signals still fire correctly
+
+### Test plan
+
+- Unit test `Ad_bars.to_weekly`: 5 daily bars per week aggregate correctly, partial weeks handled, empty input returns empty
+- `test_macro.ml` regression: divergence test with weekly ad_bars should produce the same signal as before (since the test data was effectively already weekly)
+- `test_macro_e2e.ml`: verify real data passes through without crashing
+
+## Open questions
+
+1. Should `weekly_ad` be a distinct type from `ad_bar` for type safety, or stay the same type with a documented invariant?
+2. `_compute_momentum_ma` — is the Weinstein book's "momentum" definition weekly or shorter-timeframe? If weekly, normalization fixes it. If shorter, we might want to keep a daily-cadence internal view.
+3. Do we need to backfill the `_build_cum_ad` function to work on weekly-aggregated inputs, or does summing weekly nets match daily cumulative? (Math: `sum_weekly(net) = sum(sum_daily(net))` — they should agree by week boundaries.)
+
+## Status
+
+- **Severity**: Medium — currently produces correct structure but incorrect semantics. Not a crash, but a silent accuracy bug in macro trend detection.
+- **Owner**: Follow-up to #255 (strategy-wiring). Can be a small PR after #255 lands.
+- **Estimate**: ~100-150 lines including `to_weekly` + tests + signature doc update.


### PR DESCRIPTION
## Summary

Two docs:

1. **`dev/daily/2026-04-11.md`** — daily status log capturing the 7 open PRs, cross-branch interactions, and follow-up queue. Written outside of an orchestrator run so it's a point-in-time snapshot of where we are heading into the next session.

2. **`dev/status/macro-cadence.md`** — design note for the `Macro.analyze` ad_bars/index_bars cadence mismatch discovered while reviewing #255. The bug: A-D divergence indicator compares daily `ad_bars` and weekly `index_bars` using a single `lookback` bar count, so with `ad_line_lookback = 50` you compare "A-D over 2.5 months" against "index over 1 year" — silently wrong semantics. Recommends normalizing to weekly at the boundary (Option A in the doc), ~100-150 LoC follow-up after #255 lands.

## Why separate from orchestrator daily

The orchestrator wasn't run today — this session was agent-driven follow-ups. Logging the state now preserves context before multiple parallel PR reviews start landing.

## Test plan
- [x] Docs-only, no code changes
- [ ] Human review of merge-order suggestions in daily log