### PR TITLE
cleanup: fix pre-existing nesting linter failures

### DIFF
--- a/trading/analysis/scripts/fetch_universe/fetch_universe.ml
+++ b/trading/analysis/scripts/fetch_universe/fetch_universe.ml
@@ -69,6 +69,21 @@ let _to_instrument (entry : symbol_entry) : Types.Instrument_info.t =
     exchange = entry.exchange;
   }
 
+let _filter_entries ~allowed_types entries =
+  List.filter entries ~f:(fun e -> Set.mem allowed_types e.symbol_type)
+
+let _save_universe ~data_dir ~types ~total_fetched ~instruments =
+  printf "Fetched %d symbols, %d match type filter [%s]\n%!" total_fetched
+    (List.length instruments)
+    (String.concat ~sep:", " types);
+  match Universe.save ~data_dir instruments with
+  | Ok () ->
+      printf "Wrote universe.sexp: %d instruments\n%!" (List.length instruments);
+      return ()
+  | Error e ->
+      eprintf "Error writing universe: %s\n%!" (Status.show e);
+      Async.exit 1
+
 let main ~api_key ~exchange ~types ~data_dir_str () =
   let data_dir = Fpath.v data_dir_str in
   let allowed_types = String.Set.of_list types in
@@ -77,22 +92,11 @@ let main ~api_key ~exchange ~types ~data_dir_str () =
   | Error e ->
       eprintf "Error fetching symbols: %s\n%!" (Status.show e);
       Async.exit 1
-  | Ok entries -> (
-      let filtered =
-        List.filter entries ~f:(fun e -> Set.mem allowed_types e.symbol_type)
-      in
-      printf "Fetched %d symbols, %d match type filter [%s]\n%!"
-        (List.length entries) (List.length filtered)
-        (String.concat ~sep:", " types);
+  | Ok entries ->
+      let filtered = _filter_entries ~allowed_types entries in
       let instruments = List.map filtered ~f:_to_instrument in
-      match Universe.save ~data_dir instruments with
-      | Ok () ->
-          printf "Wrote universe.sexp: %d instruments\n%!"
-            (List.length instruments);
-          return ()
-      | Error e ->
-          eprintf "Error writing universe: %s\n%!" (Status.show e);
-          Async.exit 1)
+      _save_universe ~data_dir ~types ~total_fetched:(List.length entries)
+        ~instruments
 
 let command =
   Command.async

--- a/trading/analysis/weinstein/data_source/testing/lib/test_data_loader.ml
+++ b/trading/analysis/weinstein/data_source/testing/lib/test_data_loader.ml
@@ -2,31 +2,37 @@ open Core
 
 let _run_deferred d = Async.Thread_safe.block_on_async_exn (fun () -> d)
 
-let load_daily_bars ~symbol ~start_date ~end_date =
+let _make_data_source ~end_date =
   let data_dir = Fpath.to_string (Data_path.default_data_dir ()) in
   let config : Historical_source.config =
     { data_dir; simulation_date = end_date }
   in
-  let ds = Historical_source.make config in
+  Historical_source.make config
+
+let _make_query ~symbol ~start_date ~end_date : Data_source.bar_query =
+  {
+    symbol;
+    period = Types.Cadence.Daily;
+    start_date = Some start_date;
+    end_date = Some end_date;
+  }
+
+let _format_load_failure ~symbol ~start_date ~end_date ~error =
+  Printf.sprintf
+    "Failed to load %s (%s to %s): %s\n\
+     Fix: run fetch_symbols.exe --symbols %s --api-key <key>"
+    symbol
+    (Date.to_string start_date)
+    (Date.to_string end_date) (Status.show error) symbol
+
+let load_daily_bars ~symbol ~start_date ~end_date =
+  let ds = _make_data_source ~end_date in
   let module DS = (val ds : Data_source.DATA_SOURCE) in
-  let query : Data_source.bar_query =
-    {
-      symbol;
-      period = Types.Cadence.Daily;
-      start_date = Some start_date;
-      end_date = Some end_date;
-    }
-  in
+  let query = _make_query ~symbol ~start_date ~end_date in
   match _run_deferred (DS.get_bars ~query ()) with
   | Ok bars -> bars
-  | Error e ->
-      failwith
-        (Printf.sprintf
-           "Failed to load %s (%s to %s): %s\n\
-            Fix: run fetch_symbols.exe --symbols %s --api-key <key>"
-           symbol
-           (Date.to_string start_date)
-           (Date.to_string end_date) (Status.show e) symbol)
+  | Error error ->
+      failwith (_format_load_failure ~symbol ~start_date ~end_date ~error)
 
 let load_weekly_bars ~symbol ~start_date ~end_date =
   let daily = load_daily_bars ~symbol ~start_date ~end_date in


### PR DESCRIPTION
## Summary

Two functions were failing the nesting linter on main:
- \`analysis/scripts/fetch_universe/fetch_universe.ml:main\` — avg 3.09, max 6
- \`analysis/weinstein/data_source/testing/lib/test_data_loader.ml:load_daily_bars\` — avg 2.54, max 6

Both were flagged by parallel agents in recent sessions as pre-existing failures they couldn't fix in their scope. Fixing now to unblock clean CI.

## Changes

### fetch_universe.ml
Extracted two helpers:
- \`_filter_entries\` — the Set.mem filter pass
- \`_save_universe\` — the inner \`match Universe.save\` block

The main function is now flat with a single top-level \`match\` on the fetch result.

### test_data_loader.ml
Extracted three helpers:
- \`_make_data_source\` — the Historical_source config + construction
- \`_make_query\` — the bar_query record literal
- \`_format_load_failure\` — the multi-arg Printf.sprintf error message

The main function is now flat with a single \`match\` on the deferred result.

## Verification

\`\`\`
dune exec ./devtools/nesting_linter/nesting_linter.exe -- . ./devtools/checks/linter_exceptions.conf
OK: nesting linter — all 595 functions within limits.
\`\`\`

Codebase avg nesting dropped from 1.40 → 1.38.

## Test plan
- [x] \`dune build\` clean
- [x] \`dune runtest\` all suites pass
- [x] \`dune fmt\` clean
- [x] Nesting linter clean (0 failures, down from 2)