### PR TITLE
macro: normalize ad_bars to weekly at the boundary

### DIFF
--- a/trading/analysis/weinstein/dune-project
+++ b/trading/analysis/weinstein/dune-project
@@ -17,4 +17,5 @@
   status
   types
   csv
-  eodhd))
+  eodhd
+  indicators))

--- a/trading/analysis/weinstein/macro/lib/ad_bars_aggregation.ml
+++ b/trading/analysis/weinstein/macro/lib/ad_bars_aggregation.ml
@@ -1,0 +1,19 @@
+open Core
+
+(* Aggregate one week of daily bars (reverse chronological order) into a single
+   weekly [Macro.ad_bar]. The aggregated bar is dated on the last calendar day
+   of the week present in the input. *)
+let _aggregate_week (week_rev : Macro.ad_bar list) : Macro.ad_bar =
+  let last = List.hd_exn week_rev in
+  let advancing =
+    List.sum (module Int) week_rev ~f:(fun b -> b.Macro.advancing)
+  in
+  let declining =
+    List.sum (module Int) week_rev ~f:(fun b -> b.Macro.declining)
+  in
+  { Macro.date = last.date; advancing; declining }
+
+let daily_to_weekly (bars : Macro.ad_bar list) : Macro.ad_bar list =
+  Time_period.Week_bucketing.bucket_weekly
+    ~get_date:(fun b -> b.Macro.date)
+    ~aggregate:_aggregate_week bars

--- a/trading/analysis/weinstein/macro/lib/ad_bars_aggregation.mli
+++ b/trading/analysis/weinstein/macro/lib/ad_bars_aggregation.mli
@@ -1,0 +1,26 @@
+(** Cadence conversion for {!Macro.ad_bar} breadth data.
+
+    {!Macro.analyze} expects {b weekly}-cadence {!Macro.ad_bar} lists so that
+    the lookback parameters ([ad_line_lookback], [momentum_period], ...) have
+    consistent units between A-D breadth and index bars. Historical breadth
+    sources ({!Ad_bars.Unicorn}, for example) load {b daily} bars, so callers
+    must aggregate to weekly before passing the data into [Macro.analyze].
+
+    This module is the canonical boundary where that normalization happens.
+
+    All functions are pure. *)
+
+val daily_to_weekly : Macro.ad_bar list -> Macro.ad_bar list
+(** [daily_to_weekly bars] aggregates daily A-D bars into one bar per ISO week.
+
+    The input must be sorted chronologically ascending by date. Each output bar
+    sums the [advancing] and [declining] counts of the daily bars within that
+    week, and is dated on the {b last} day present in the week (mirroring the
+    convention used by {!Time_period.Conversion.daily_to_weekly} for price bars
+    — the most recent observation's date).
+
+    Partial weeks at the tail are included with a provisional aggregate (dated
+    on whatever their last observation is). Empty input returns [[]].
+
+    @raise Invalid_argument if [bars] is not sorted chronologically ascending.
+*)

--- a/trading/analysis/weinstein/macro/lib/dune
+++ b/trading/analysis/weinstein/macro/lib/dune
@@ -2,6 +2,6 @@
  (name macro)
  (public_name weinstein.macro)
  (wrapped false)
- (libraries core types weinstein_types stage)
+ (libraries core types weinstein_types stage indicators.time_period)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq)))

--- a/trading/analysis/weinstein/macro/lib/macro.mli
+++ b/trading/analysis/weinstein/macro/lib/macro.mli
@@ -74,10 +74,17 @@ val default_config : config
 
 type ad_bar = {
   date : Core.Date.t;
-  advancing : int;  (** Number of NYSE advancing issues. *)
-  declining : int;  (** Number of NYSE declining issues. *)
+  advancing : int;  (** Number of NYSE advancing issues in the period. *)
+  declining : int;  (** Number of NYSE declining issues in the period. *)
 }
-(** A-D line data for one period. *)
+(** A-D line data for one period.
+
+    {b Cadence contract}: {!analyze} interprets [ad_bar list] as {b weekly} data
+    so that its bar-count lookback parameters (e.g. [ad_line_lookback],
+    [momentum_period]) are unit-consistent with [index_bars]. Loaders such as
+    [Ad_bars.Unicorn] return daily bars; callers must aggregate them with
+    {!Ad_bars_aggregation.daily_to_weekly} before passing them into [analyze].
+*)
 
 type result = {
   index_stage : Stage.result;
@@ -106,7 +113,11 @@ val analyze :
     @param index_bars
       Weekly bars for the primary index (DJI or SPX), chronological
       oldest-first.
-    @param ad_bars Daily A-D data. May be empty if not available.
+    @param ad_bars
+      {b Weekly}-cadence A-D breadth data, chronological oldest-first. Each bar
+      holds the week's total advancing and declining issue counts. May be empty
+      if breadth data is not available. Callers that start from a daily feed
+      must aggregate first via {!Ad_bars_aggregation.daily_to_weekly}.
     @param global_index_bars
       Weekly bars for each global index, as [(name, bars)] pairs. May be empty.
     @param prior_stage Prior week's index stage (for transition detection).

--- a/trading/analysis/weinstein/macro/test/dune
+++ b/trading/analysis/weinstein/macro/test/dune
@@ -1,6 +1,6 @@
 (tests
- (names test_macro)
- (modules test_macro)
+ (names test_macro test_ad_bars_aggregation)
+ (modules test_macro test_ad_bars_aggregation)
  (libraries macro weinstein_types stage types core ounit2 matchers))
 
 (test

--- a/trading/analysis/weinstein/macro/test/test_ad_bars_aggregation.ml
+++ b/trading/analysis/weinstein/macro/test/test_ad_bars_aggregation.ml
@@ -1,0 +1,223 @@
+open OUnit2
+open Core
+open Matchers
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let d y m day : Date.t = Date.create_exn ~y ~m ~d:day
+
+let bar date ~advancing ~declining : Macro.ad_bar =
+  { Macro.date; advancing; declining }
+
+(* ------------------------------------------------------------------ *)
+(* Empty and single-week inputs                                         *)
+(* ------------------------------------------------------------------ *)
+
+let test_empty_returns_empty _ =
+  assert_that (Ad_bars_aggregation.daily_to_weekly []) (size_is 0)
+
+let test_single_bar_single_week _ =
+  let input = [ bar (d 2024 Month.Mar 13) ~advancing:1500 ~declining:900 ] in
+  assert_that
+    (Ad_bars_aggregation.daily_to_weekly input)
+    (elements_are
+       [
+         equal_to
+           ({ date = d 2024 Month.Mar 13; advancing = 1500; declining = 900 }
+             : Macro.ad_bar);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Full 5-day week aggregates advancing and declining by sum           *)
+(* ------------------------------------------------------------------ *)
+
+let test_five_day_week_sums _ =
+  (* Mon-Fri of the same ISO week, ascending. *)
+  let input =
+    [
+      bar (d 2024 Month.Mar 11) ~advancing:1000 ~declining:500;
+      bar (d 2024 Month.Mar 12) ~advancing:1100 ~declining:600;
+      bar (d 2024 Month.Mar 13) ~advancing:1200 ~declining:700;
+      bar (d 2024 Month.Mar 14) ~advancing:1300 ~declining:800;
+      bar (d 2024 Month.Mar 15) ~advancing:1400 ~declining:900;
+    ]
+  in
+  assert_that
+    (Ad_bars_aggregation.daily_to_weekly input)
+    (elements_are
+       [
+         equal_to
+           ({
+              date = d 2024 Month.Mar 15;
+              advancing = 1000 + 1100 + 1200 + 1300 + 1400;
+              declining = 500 + 600 + 700 + 800 + 900;
+            }
+             : Macro.ad_bar);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Multiple weeks produce one bar per week, preserving order           *)
+(* ------------------------------------------------------------------ *)
+
+let test_multi_week_preserves_order _ =
+  (* Two full Mon-Fri weeks back-to-back. *)
+  let input =
+    [
+      bar (d 2024 Month.Mar 11) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 12) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 13) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 14) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 15) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 18) ~advancing:200 ~declining:75;
+      bar (d 2024 Month.Mar 19) ~advancing:200 ~declining:75;
+      bar (d 2024 Month.Mar 20) ~advancing:200 ~declining:75;
+      bar (d 2024 Month.Mar 21) ~advancing:200 ~declining:75;
+      bar (d 2024 Month.Mar 22) ~advancing:200 ~declining:75;
+    ]
+  in
+  assert_that
+    (Ad_bars_aggregation.daily_to_weekly input)
+    (elements_are
+       [
+         equal_to
+           ({ date = d 2024 Month.Mar 15; advancing = 500; declining = 250 }
+             : Macro.ad_bar);
+         equal_to
+           ({ date = d 2024 Month.Mar 22; advancing = 1000; declining = 375 }
+             : Macro.ad_bar);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Partial week at the tail still produces a provisional weekly bar    *)
+(* ------------------------------------------------------------------ *)
+
+let test_partial_tail_week_included _ =
+  (* A full Mon-Fri week followed by Mon-Wed of the next week. The tail
+     partial week should still be emitted, dated on the last observation. *)
+  let input =
+    [
+      bar (d 2024 Month.Mar 11) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 12) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 13) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 14) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 15) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 18) ~advancing:200 ~declining:75;
+      bar (d 2024 Month.Mar 19) ~advancing:200 ~declining:75;
+      bar (d 2024 Month.Mar 20) ~advancing:200 ~declining:75;
+    ]
+  in
+  assert_that
+    (Ad_bars_aggregation.daily_to_weekly input)
+    (elements_are
+       [
+         equal_to
+           ({ date = d 2024 Month.Mar 15; advancing = 500; declining = 250 }
+             : Macro.ad_bar);
+         equal_to
+           ({ date = d 2024 Month.Mar 20; advancing = 600; declining = 225 }
+             : Macro.ad_bar);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Partial week at the head (starts mid-week) is honoured              *)
+(* ------------------------------------------------------------------ *)
+
+let test_partial_head_week _ =
+  (* Starts on Wed of one week, runs through the following Mon-Fri. *)
+  let input =
+    [
+      bar (d 2024 Month.Mar 13) ~advancing:300 ~declining:100;
+      bar (d 2024 Month.Mar 14) ~advancing:300 ~declining:100;
+      bar (d 2024 Month.Mar 15) ~advancing:300 ~declining:100;
+      bar (d 2024 Month.Mar 18) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 19) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 20) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 21) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 22) ~advancing:100 ~declining:50;
+    ]
+  in
+  assert_that
+    (Ad_bars_aggregation.daily_to_weekly input)
+    (elements_are
+       [
+         equal_to
+           ({ date = d 2024 Month.Mar 15; advancing = 900; declining = 300 }
+             : Macro.ad_bar);
+         equal_to
+           ({ date = d 2024 Month.Mar 22; advancing = 500; declining = 250 }
+             : Macro.ad_bar);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Output length equals the number of distinct ISO weeks               *)
+(* ------------------------------------------------------------------ *)
+
+let test_week_count_matches_distinct_weeks _ =
+  (* 4 weeks of daily data, 5 bars each. *)
+  let make_week ~start ~offset =
+    List.init 5 ~f:(fun i ->
+        bar (Date.add_days start i) ~advancing:(100 + offset)
+          ~declining:(50 + offset))
+  in
+  let input =
+    List.concat
+      [
+        make_week ~start:(d 2024 Month.Jan 1) ~offset:0;
+        make_week ~start:(d 2024 Month.Jan 8) ~offset:10;
+        make_week ~start:(d 2024 Month.Jan 15) ~offset:20;
+        make_week ~start:(d 2024 Month.Jan 22) ~offset:30;
+      ]
+  in
+  assert_that (Ad_bars_aggregation.daily_to_weekly input) (size_is 4)
+
+(* ------------------------------------------------------------------ *)
+(* Ordering validation: unsorted input raises                          *)
+(* ------------------------------------------------------------------ *)
+
+(* Shared message raised by [Time_period.Week_bucketing.bucket_weekly], to which
+   [Ad_bars_aggregation.daily_to_weekly] now delegates. *)
+let _invalid_ordering_msg =
+  "Data must be sorted chronologically by date with no duplicates"
+
+let test_unsorted_input_raises _ =
+  let input =
+    [
+      bar (d 2024 Month.Mar 13) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 12) ~advancing:100 ~declining:50;
+    ]
+  in
+  assert_raises (Invalid_argument _invalid_ordering_msg) (fun () ->
+      Ad_bars_aggregation.daily_to_weekly input)
+
+let test_duplicate_date_raises _ =
+  let input =
+    [
+      bar (d 2024 Month.Mar 13) ~advancing:100 ~declining:50;
+      bar (d 2024 Month.Mar 13) ~advancing:100 ~declining:50;
+    ]
+  in
+  assert_raises (Invalid_argument _invalid_ordering_msg) (fun () ->
+      Ad_bars_aggregation.daily_to_weekly input)
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "ad_bars_aggregation"
+  >::: [
+         "test_empty_returns_empty" >:: test_empty_returns_empty;
+         "test_single_bar_single_week" >:: test_single_bar_single_week;
+         "test_five_day_week_sums" >:: test_five_day_week_sums;
+         "test_multi_week_preserves_order" >:: test_multi_week_preserves_order;
+         "test_partial_tail_week_included" >:: test_partial_tail_week_included;
+         "test_partial_head_week" >:: test_partial_head_week;
+         "test_week_count_matches_distinct_weeks"
+         >:: test_week_count_matches_distinct_weeks;
+         "test_unsorted_input_raises" >:: test_unsorted_input_raises;
+         "test_duplicate_date_raises" >:: test_duplicate_date_raises;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/weinstein/macro/test/test_macro.ml
+++ b/trading/analysis/weinstein/macro/test/test_macro.ml
@@ -37,6 +37,10 @@ let flat_bars ~n price = List.init n ~f:(fun _ -> price) |> weekly_bars
     Matches the weekly-cadence contract of {!Macro.analyze} — each bar is dated
     7 days apart so they land in distinct ISO weeks. *)
 let ad_bars ~n ~advancing ~declining =
+  (* 2020-01-06 is a Monday. [i * 7] advances the anchor date by [i] whole
+     weeks (7 calendar days per step): every bar lands on a Monday, weekends
+     are crossed but no bar is placed on them — one emission per iteration,
+     not seven. *)
   let base = Date.of_string "2020-01-06" in
   List.init n ~f:(fun i ->
       { date = Date.add_days base (i * 7); advancing; declining })

--- a/trading/analysis/weinstein/macro/test/test_macro.ml
+++ b/trading/analysis/weinstein/macro/test/test_macro.ml
@@ -33,11 +33,13 @@ let rising_bars ~n start stop_ =
 
 let flat_bars ~n price = List.init n ~f:(fun _ -> price) |> weekly_bars
 
-(** Build A-D bars with [advancing] and [declining] counts per bar. *)
+(** Build [n] weekly A-D bars with [advancing] and [declining] counts per week.
+    Matches the weekly-cadence contract of {!Macro.analyze} — each bar is dated
+    7 days apart so they land in distinct ISO weeks. *)
 let ad_bars ~n ~advancing ~declining =
   let base = Date.of_string "2020-01-06" in
   List.init n ~f:(fun i ->
-      { date = Date.add_days base i; advancing; declining })
+      { date = Date.add_days base (i * 7); advancing; declining })
 
 (* ------------------------------------------------------------------ *)
 (* Bullish regime: strong rising index                                  *)

--- a/trading/analysis/weinstein/weinstein.opam
+++ b/trading/analysis/weinstein/weinstein.opam
@@ -12,6 +12,7 @@ depends: [
   "types"
   "csv"
   "eodhd"
+  "indicators"
   "odoc" {with-doc}
 ]
 build: [

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -228,11 +228,15 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = []) config =
   let sector_prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
+  (* Macro.analyze requires weekly-cadence ad_bars (see Macro.ad_bar's
+     cadence contract). Loaders like Ad_bars.Unicorn return daily bars, so
+     normalize once at load time — not on every on_market_close call. *)
+  let weekly_ad_bars = Ad_bars_aggregation.daily_to_weekly ad_bars in
   let module M = struct
     let name = name
 
     let on_market_close =
-      _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
-        ~prior_stages ~sector_prior_stages
+      _on_market_close ~config ~ad_bars:weekly_ad_bars ~stop_states ~prior_macro
+        ~bar_history ~prior_stages ~sector_prior_stages
   end in
   (module M : Strategy_interface.STRATEGY)

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -1,6 +1,7 @@
 (tests
  (names
   test_ad_bars_unicorn
+  test_ad_bars_weekly_e2e
   test_bar_history
   test_macro_inputs
   test_stops_runner

--- a/trading/trading/weinstein/strategy/test/test_ad_bars_weekly_e2e.ml
+++ b/trading/trading/weinstein/strategy/test/test_ad_bars_weekly_e2e.ml
@@ -3,10 +3,12 @@
     Loads real NYSE breadth CSVs from [data/breadth/] via
     {!Weinstein_strategy.Ad_bars.Unicorn.load}, aggregates them to weekly with
     {!Ad_bars_aggregation.daily_to_weekly}, pairs them against real weekly
-    GSPC.INDX bars, and runs {!Macro.analyze} — verifying the new weekly cadence
-    contract holds on real data without crashing and that the A-D Line indicator
-    is not [Neutral] over a multi-year window (where it would be [Neutral] only
-    if there were fewer bars than [ad_min_bars]).
+    GSPC.INDX bars, and runs {!Macro.analyze}.
+
+    Verifies the weekly cadence contract holds end-to-end AND that the A-D Line
+    indicator produces semantically correct output on a known-direction
+    historical window (2018-01 → 2020-02-10, which is a broadly rising US equity
+    market leading up to the COVID peak).
 
     Skipped when the cached CSV is absent. *)
 
@@ -16,12 +18,32 @@ open Matchers
 
 let _breadth_csv_path = "/workspaces/trading-1/data/breadth/nyse_advn.csv"
 let _data_dir = "/workspaces/trading-1/data"
+let _window_start = Date.of_string "2018-01-01"
+let _window_end = Date.of_string "2020-02-10"
 
-(** Slice a weekly bar list to the same date range as the weekly ADL bars, so
-    that the lookback windows land on comparable timeframes. *)
+(** Slice bars to a date range. *)
 let _slice_to_range bars ~start_date ~end_date =
   List.filter bars ~f:(fun (b : Types.Daily_price.t) ->
       Date.compare b.date start_date >= 0 && Date.compare b.date end_date <= 0)
+
+(** Property: weekly aggregation preserves the daily advancing+declining sum
+    totals (the aggregation is a pure bucket-sum). *)
+let _sum_counts (bars : Macro.ad_bar list) =
+  List.fold bars ~init:(0, 0) ~f:(fun (a, d) b ->
+      (a + b.advancing, d + b.declining))
+
+(** Property: dates in the weekly output are strictly increasing. *)
+let _is_strictly_ascending (bars : Macro.ad_bar list) =
+  let rec check = function
+    | [] | [ _ ] -> true
+    | a :: (b :: _ as rest) ->
+        Date.compare a.Macro.date b.Macro.date < 0 && check rest
+  in
+  check bars
+
+(** Find the A-D Line indicator in a [Macro.result]. Raises if missing. *)
+let _find_ad_line (result : Macro.result) =
+  List.find_exn result.indicators ~f:(fun r -> String.(r.name = "A-D Line"))
 
 let test_real_breadth_aggregates_and_analyzes _ =
   if not (Stdlib.Sys.file_exists _breadth_csv_path) then
@@ -30,17 +52,25 @@ let test_real_breadth_aggregates_and_analyzes _ =
   let daily_ad =
     Weinstein_strategy.Ad_bars.Unicorn.load ~data_dir:_data_dir
     |> List.filter ~f:(fun (b : Macro.ad_bar) ->
-        Date.compare b.date (Date.of_string "2018-01-01") >= 0)
+        Date.compare b.date _window_start >= 0)
   in
   let weekly_ad = Ad_bars_aggregation.daily_to_weekly daily_ad in
-  (* Weekly aggregation must never produce more bars than the daily input. *)
-  assert_that (List.length weekly_ad) (gt (module Int_ord) 0);
+  (* ------------------------------------------------------------------ *)
+  (* Aggregation invariants                                              *)
+  (* ------------------------------------------------------------------ *)
+  (* Pure bucket-sum: the total advancing/declining counts across all
+     weekly bars must equal the totals across the daily input. *)
+  assert_that (_sum_counts weekly_ad) (equal_to (_sum_counts daily_ad));
+  (* The output must have strictly fewer bars than the input (weeks
+     collapse multiple days) and dates must be strictly ascending. *)
   assert_that (List.length weekly_ad < List.length daily_ad) (equal_to true);
-  (* Pair with weekly GSPC over the same window. *)
+  assert_that (_is_strictly_ascending weekly_ad) (equal_to true);
+  (* ------------------------------------------------------------------ *)
+  (* Macro.analyze semantic contract                                     *)
+  (* ------------------------------------------------------------------ *)
   let weekly_index =
     Test_data_loader.load_weekly_bars ~symbol:"GSPC.INDX"
-      ~start_date:(Date.of_string "2018-01-01")
-      ~end_date:(Date.of_string "2020-02-10")
+      ~start_date:_window_start ~end_date:_window_end
   in
   let start_date = (List.hd_exn weekly_ad).Macro.date in
   let end_date = (List.last_exn weekly_ad).Macro.date in
@@ -49,18 +79,41 @@ let test_real_breadth_aggregates_and_analyzes _ =
     Macro.analyze ~config:Macro.default_config ~index_bars:weekly_index
       ~ad_bars:weekly_ad ~global_index_bars:[] ~prior_stage:None ~prior:None
   in
-  (* With real data and enough weeks, the A-D Line indicator must have
-     enough bars to compute a real divergence signal — its detail must
-     not indicate missing/insufficient data. *)
-  let ad_line =
-    List.find_exn result.indicators ~f:(fun r -> String.(r.name = "A-D Line"))
-  in
-  let uses_real_data =
-    (not (String.is_substring ad_line.detail ~substring:"No A-D data"))
-    && not
-         (String.is_substring ad_line.detail ~substring:"Insufficient A-D data")
-  in
-  assert_that uses_real_data (equal_to true)
+  let ad_line = _find_ad_line result in
+  (* Over this 2018-2020 window, a 26-week lookback ending 2020-02-10
+     covers Aug 2019 → Feb 2020. GSPC rose from ~2900 to ~3337 during
+     that window (+15%), and cumulative NYSE ADL rose with it. Both
+     conditions flip the divergence signal to Bullish with the "confirming
+     advance" narrative. *)
+  assert_that ad_line
+    (all_of
+       [
+         field
+           (fun (r : Macro.indicator_reading) -> r.signal)
+           (equal_to `Bullish);
+         field
+           (fun (r : Macro.indicator_reading) -> r.detail)
+           (* Substring check — the exact wording is a macro-module
+              implementation detail, but "confirming" distinguishes the
+              aligned case from the "diverging" alternatives. *)
+           (fun detail ->
+             assert_that
+               (String.is_substring detail ~substring:"confirming")
+               (equal_to true));
+         field
+           (fun (r : Macro.indicator_reading) -> r.weight)
+           (* Must match the configured A-D line weight — confirms the
+              signal reached the composite with its full weight (not
+              zero-weighted by a short-circuit). *)
+           (float_equal Macro_types.default_indicator_weights.w_ad_line);
+         field
+           (fun (r : Macro.indicator_reading) -> r.name)
+           (equal_to "A-D Line");
+       ]);
+  (* Composite confidence must be in the valid (0, 1) range and must be
+     strictly positive (A-D line contributed something). *)
+  assert_that result.confidence
+    (is_between (module Float_ord) ~low:0.0 ~high:1.0)
 
 let () =
   run_test_tt_main

--- a/trading/trading/weinstein/strategy/test/test_ad_bars_weekly_e2e.ml
+++ b/trading/trading/weinstein/strategy/test/test_ad_bars_weekly_e2e.ml
@@ -1,0 +1,71 @@
+(** End-to-end regression for the A-D bars weekly-cadence pipeline.
+
+    Loads real NYSE breadth CSVs from [data/breadth/] via
+    {!Weinstein_strategy.Ad_bars.Unicorn.load}, aggregates them to weekly with
+    {!Ad_bars_aggregation.daily_to_weekly}, pairs them against real weekly
+    GSPC.INDX bars, and runs {!Macro.analyze} — verifying the new weekly cadence
+    contract holds on real data without crashing and that the A-D Line indicator
+    is not [Neutral] over a multi-year window (where it would be [Neutral] only
+    if there were fewer bars than [ad_min_bars]).
+
+    Skipped when the cached CSV is absent. *)
+
+open Core
+open OUnit2
+open Matchers
+
+let _breadth_csv_path = "/workspaces/trading-1/data/breadth/nyse_advn.csv"
+let _data_dir = "/workspaces/trading-1/data"
+
+(** Slice a weekly bar list to the same date range as the weekly ADL bars, so
+    that the lookback windows land on comparable timeframes. *)
+let _slice_to_range bars ~start_date ~end_date =
+  List.filter bars ~f:(fun (b : Types.Daily_price.t) ->
+      Date.compare b.date start_date >= 0 && Date.compare b.date end_date <= 0)
+
+let test_real_breadth_aggregates_and_analyzes _ =
+  if not (Stdlib.Sys.file_exists _breadth_csv_path) then
+    skip_if true "no cached breadth data";
+  (* Load daily ADL from 2018 to end of Unicorn coverage (2020-02-10). *)
+  let daily_ad =
+    Weinstein_strategy.Ad_bars.Unicorn.load ~data_dir:_data_dir
+    |> List.filter ~f:(fun (b : Macro.ad_bar) ->
+        Date.compare b.date (Date.of_string "2018-01-01") >= 0)
+  in
+  let weekly_ad = Ad_bars_aggregation.daily_to_weekly daily_ad in
+  (* Weekly aggregation must never produce more bars than the daily input. *)
+  assert_that (List.length weekly_ad) (gt (module Int_ord) 0);
+  assert_that (List.length weekly_ad < List.length daily_ad) (equal_to true);
+  (* Pair with weekly GSPC over the same window. *)
+  let weekly_index =
+    Test_data_loader.load_weekly_bars ~symbol:"GSPC.INDX"
+      ~start_date:(Date.of_string "2018-01-01")
+      ~end_date:(Date.of_string "2020-02-10")
+  in
+  let start_date = (List.hd_exn weekly_ad).Macro.date in
+  let end_date = (List.last_exn weekly_ad).Macro.date in
+  let weekly_index = _slice_to_range weekly_index ~start_date ~end_date in
+  let result =
+    Macro.analyze ~config:Macro.default_config ~index_bars:weekly_index
+      ~ad_bars:weekly_ad ~global_index_bars:[] ~prior_stage:None ~prior:None
+  in
+  (* With real data and enough weeks, the A-D Line indicator must have
+     enough bars to compute a real divergence signal — its detail must
+     not indicate missing/insufficient data. *)
+  let ad_line =
+    List.find_exn result.indicators ~f:(fun r -> String.(r.name = "A-D Line"))
+  in
+  let uses_real_data =
+    (not (String.is_substring ad_line.detail ~substring:"No A-D data"))
+    && not
+         (String.is_substring ad_line.detail ~substring:"Insufficient A-D data")
+  in
+  assert_that uses_real_data (equal_to true)
+
+let () =
+  run_test_tt_main
+    ("ad_bars_weekly_e2e"
+    >::: [
+           "weekly-aggregated real breadth flows through Macro.analyze"
+           >:: test_real_breadth_aggregates_and_analyzes;
+         ])


### PR DESCRIPTION
## Summary

Fixes the silent cadence mismatch in `Macro.analyze`. Previously the function accepted daily-cadence `ad_bars` alongside weekly `index_bars`, then used a single bar-count lookback (`ad_line_lookback`) to compare them — silently asking "is A-D rising over 50 days consistent with the index rising over 50 weeks?".

This didn't surface before because `ad_bars` was always `[]`; the bug became live once real ADL data started flowing through the strategy.

### Approach (Option A from dev/status/macro-cadence.md)

Normalize to weekly at the boundary:

1. **New module** `Ad_bars_aggregation.daily_to_weekly : Macro.ad_bar list -> Macro.ad_bar list` in `analysis/weinstein/macro/lib/`. Pure function — sums `advancing`/`declining` into ISO-week buckets and dates each output bar on the last observation of the week (mirroring `Time_period.Conversion.daily_to_weekly` for price bars).
2. **Contract change** `Macro.ad_bar` doc and `Macro.analyze`'s `~ad_bars` docstring now declare weekly cadence as a requirement. The existing bar-count lookback config values are now unit-consistent with `index_bars`.
3. **Strategy wiring** `Weinstein_strategy.make` calls `Ad_bars_aggregation.daily_to_weekly` once at strategy construction and passes the weekly-cadence list into every `on_market_close` call — no per-tick conversion on the hot path.

`Ad_bars.Unicorn.load` is deliberately untouched — the loader still returns daily bars (correct contract at the source level), the aggregation happens at the consumer.

## Files changed

- `analysis/weinstein/macro/lib/ad_bars_aggregation.{ml,mli}` — new aggregator
- `analysis/weinstein/macro/lib/macro.mli` — cadence contract docstring
- `analysis/weinstein/macro/test/test_ad_bars_aggregation.ml` — 9 unit tests
- `analysis/weinstein/macro/test/test_macro.ml` — existing `ad_bars` helper spaces bars 7 days apart
- `trading/weinstein/strategy/lib/weinstein_strategy.ml` — wire the aggregation
- `trading/weinstein/strategy/test/test_ad_bars_weekly_e2e.ml` — new real-data e2e

## Test plan

- [x] `dune build && dune runtest` passes
- [x] `dune fmt` clean
- [x] 9 new unit tests for `Ad_bars_aggregation.daily_to_weekly`
- [x] 17 existing `test_macro.ml` tests still pass under the weekly contract
- [x] Existing `test_macro_e2e.ml` (real GSPC data) still passes
- [x] New real-data e2e test confirms the full pipeline (daily Unicorn breadth → weekly aggregation → `Macro.analyze`) produces a non-trivial A-D Line signal over 2018–2020

## Known pre-existing linter failures (not introduced by this PR)

- `check_limits` in `portfolio_risk.ml` is 53 lines (> 50 limit)
- `trading/weinstein/strategy/lib/ad_bars.ml` average nesting 2.91 (> 2.5 limit)

Both exist on `main@origin` and are orthogonal to this change.