### PR TITLE
cleanup: fix pre-existing fn-length and nesting linter failures

### DIFF
--- a/trading/analysis/weinstein/portfolio_risk/lib/portfolio_risk.ml
+++ b/trading/analysis/weinstein/portfolio_risk/lib/portfolio_risk.ml
@@ -149,56 +149,57 @@ let compute_position_size ~config ~portfolio_value ~entry_price ~stop_price
 (* Each check returns a (possibly empty) list of violations. check_limits
    combines them — the monoid is list concatenation over the empty list. *)
 
+let _check_max_positions ~config ~snapshot =
+  if snapshot.position_count >= config.max_positions then
+    [ Max_positions_exceeded snapshot.position_count ]
+  else []
+
+let _check_exposure ~config ~snapshot ~proposed_side ~proposed_value =
+  match proposed_side with
+  | `Long ->
+      let new_pct =
+        (snapshot.long_exposure +. proposed_value) /. snapshot.total_value
+      in
+      if Float.( > ) new_pct config.max_long_exposure_pct then
+        [ Long_exposure_exceeded new_pct ]
+      else []
+  | `Short ->
+      let new_pct =
+        (snapshot.short_exposure +. proposed_value) /. snapshot.total_value
+      in
+      if Float.( > ) new_pct config.max_short_exposure_pct then
+        [ Short_exposure_exceeded new_pct ]
+      else []
+
+let _check_cash ~config ~snapshot ~proposed_value =
+  let cash_pct_after =
+    if Float.( <= ) snapshot.total_value 0.0 then 0.0
+    else (snapshot.cash -. proposed_value) /. snapshot.total_value
+  in
+  if Float.( < ) cash_pct_after config.min_cash_pct then
+    [ Cash_below_minimum cash_pct_after ]
+  else []
+
+let _check_sector ~config ~snapshot ~proposed_sector =
+  let count =
+    List.Assoc.find snapshot.sector_counts ~equal:String.equal proposed_sector
+    |> Option.value ~default:0
+  in
+  let new_count = count + 1 in
+  if String.is_empty proposed_sector then
+    if new_count > config.max_unknown_sector_positions then
+      [ Unknown_sector_exceeded new_count ]
+    else []
+  else if new_count > config.max_sector_concentration then
+    [ Sector_concentration (proposed_sector, new_count) ]
+  else []
+
 let check_limits ~config ~snapshot ~proposed_side ~proposed_value
     ~proposed_sector =
-  let check_max_positions () =
-    if snapshot.position_count >= config.max_positions then
-      [ Max_positions_exceeded snapshot.position_count ]
-    else []
-  in
-  let check_exposure () =
-    match proposed_side with
-    | `Long ->
-        let new_pct =
-          (snapshot.long_exposure +. proposed_value) /. snapshot.total_value
-        in
-        if Float.( > ) new_pct config.max_long_exposure_pct then
-          [ Long_exposure_exceeded new_pct ]
-        else []
-    | `Short ->
-        let new_pct =
-          (snapshot.short_exposure +. proposed_value) /. snapshot.total_value
-        in
-        if Float.( > ) new_pct config.max_short_exposure_pct then
-          [ Short_exposure_exceeded new_pct ]
-        else []
-  in
-  let check_cash () =
-    let cash_pct_after =
-      if Float.( <= ) snapshot.total_value 0.0 then 0.0
-      else (snapshot.cash -. proposed_value) /. snapshot.total_value
-    in
-    if Float.( < ) cash_pct_after config.min_cash_pct then
-      [ Cash_below_minimum cash_pct_after ]
-    else []
-  in
-  let check_sector () =
-    let count =
-      List.Assoc.find snapshot.sector_counts ~equal:String.equal proposed_sector
-      |> Option.value ~default:0
-    in
-    let new_count = count + 1 in
-    if String.is_empty proposed_sector then
-      if new_count > config.max_unknown_sector_positions then
-        [ Unknown_sector_exceeded new_count ]
-      else []
-    else if new_count > config.max_sector_concentration then
-      [ Sector_concentration (proposed_sector, new_count) ]
-    else []
-  in
   let violations =
-    List.concat_map
-      [ check_max_positions; check_exposure; check_cash; check_sector ]
-      ~f:(fun check -> check ())
+    _check_max_positions ~config ~snapshot
+    @ _check_exposure ~config ~snapshot ~proposed_side ~proposed_value
+    @ _check_cash ~config ~snapshot ~proposed_value
+    @ _check_sector ~config ~snapshot ~proposed_sector
   in
   match violations with [] -> Result.Ok () | vs -> Result.Error vs

--- a/trading/trading/weinstein/strategy/lib/ad_bars.ml
+++ b/trading/trading/weinstein/strategy/lib/ad_bars.ml
@@ -1,66 +1,75 @@
 open Core
 
+(* ------------------------------------------------------------------ *)
+(* Unicorn CSV parser — module-private helpers                          *)
+(* ------------------------------------------------------------------ *)
+
+(** Parse a [YYYYMMDD] integer-as-string into a Date. Returns [None] on any
+    parse error. *)
+let _parse_yyyymmdd s =
+  let s = String.strip s in
+  if String.length s <> 8 then None
+  else
+    try
+      let y = Int.of_string (String.sub s ~pos:0 ~len:4) in
+      let m = Int.of_string (String.sub s ~pos:4 ~len:2) in
+      let d = Int.of_string (String.sub s ~pos:6 ~len:2) in
+      Some (Date.create_exn ~y ~m:(Month.of_int_exn m) ~d)
+    with _ -> None
+
+(** Parse one CSV line into [(date, count)]. Returns [None] for malformed or
+    unparseable rows. *)
+let _parse_unicorn_row line =
+  match String.split line ~on:',' with
+  | [ date_s; count_s ] -> (
+      match
+        (_parse_yyyymmdd date_s, Int.of_string_opt (String.strip count_s))
+      with
+      | Some date, Some count -> Some (date, count)
+      | _ -> None)
+  | _ -> None
+
+let _insert_parsed_row tbl line =
+  match _parse_unicorn_row line with
+  | Some (date, count) -> Hashtbl.set tbl ~key:date ~data:count
+  | None -> ()
+
+let _read_unicorn_lines tbl ic =
+  In_channel.iter_lines ic ~f:(_insert_parsed_row tbl)
+
+(** Read one A/D count CSV from disk into a (date -> count) hashtable. Missing
+    or unreadable files return an empty table. *)
+let _read_unicorn_count_file path =
+  let tbl = Hashtbl.create (module Date) in
+  if not (Stdlib.Sys.file_exists path) then tbl
+  else
+    try
+      In_channel.with_file path ~f:(_read_unicorn_lines tbl);
+      tbl
+    with _ -> tbl
+
+(** Join the two count tables on date. A row with both [advancing] and
+    [declining] equal to zero is treated as a placeholder and dropped — the
+    upstream source pads the tail of the file with such rows. *)
+let _join_unicorn_counts ~advn ~decln : Macro.ad_bar list =
+  Hashtbl.fold advn ~init:[] ~f:(fun ~key:date ~data:advancing acc ->
+      match Hashtbl.find decln date with
+      | Some declining when advancing = 0 && declining = 0 -> acc
+      | Some declining -> { Macro.date; advancing; declining } :: acc
+      | None -> acc)
+  |> List.sort ~compare:(fun (a : Macro.ad_bar) b -> Date.compare a.date b.date)
+
+let _unicorn_load ~data_dir =
+  let breadth_dir = Filename.concat data_dir "breadth" in
+  let advn_path = Filename.concat breadth_dir "nyse_advn.csv" in
+  let decln_path = Filename.concat breadth_dir "nyse_decln.csv" in
+  let advn = _read_unicorn_count_file advn_path in
+  let decln = _read_unicorn_count_file decln_path in
+  if Hashtbl.is_empty advn || Hashtbl.is_empty decln then []
+  else _join_unicorn_counts ~advn ~decln
+
 module Unicorn = struct
-  (** Parse a [YYYYMMDD] integer-as-string into a Date. Returns [None] on any
-      parse error. *)
-  let _parse_date s =
-    let s = String.strip s in
-    if String.length s <> 8 then None
-    else
-      try
-        let y = Int.of_string (String.sub s ~pos:0 ~len:4) in
-        let m = Int.of_string (String.sub s ~pos:4 ~len:2) in
-        let d = Int.of_string (String.sub s ~pos:6 ~len:2) in
-        Some (Date.create_exn ~y ~m:(Month.of_int_exn m) ~d)
-      with _ -> None
-
-  (** Parse one CSV line into [(date, count)]. Returns [None] for malformed or
-      unparseable rows. *)
-  let _parse_row line =
-    match String.split line ~on:',' with
-    | [ date_s; count_s ] -> (
-        match
-          (_parse_date date_s, Int.of_string_opt (String.strip count_s))
-        with
-        | Some date, Some count -> Some (date, count)
-        | _ -> None)
-    | _ -> None
-
-  (** Read one A/D count CSV from disk into a (date -> count) hashtable. Missing
-      or unreadable files return an empty table. *)
-  let _read_count_file path =
-    let tbl = Hashtbl.create (module Date) in
-    if not (Stdlib.Sys.file_exists path) then tbl
-    else
-      try
-        In_channel.with_file path ~f:(fun ic ->
-            In_channel.iter_lines ic ~f:(fun line ->
-                match _parse_row line with
-                | Some (date, count) -> Hashtbl.set tbl ~key:date ~data:count
-                | None -> ()));
-        tbl
-      with _ -> tbl
-
-  (** Join the two count tables on date. A row with both [advancing] and
-      [declining] equal to zero is treated as a placeholder and dropped — the
-      upstream source pads the tail of the file with such rows. *)
-  let _join ~advn ~decln : Macro.ad_bar list =
-    Hashtbl.fold advn ~init:[] ~f:(fun ~key:date ~data:advancing acc ->
-        match Hashtbl.find decln date with
-        | Some declining when advancing = 0 && declining = 0 -> acc
-        | Some declining -> { Macro.date; advancing; declining } :: acc
-        | None -> acc)
-    |> List.sort ~compare:(fun (a : Macro.ad_bar) b ->
-        Date.compare a.date b.date)
-
-  let load ~data_dir =
-    let breadth_dir = Filename.concat data_dir "breadth" in
-    let advn_path = Filename.concat breadth_dir "nyse_advn.csv" in
-    let decln_path = Filename.concat breadth_dir "nyse_decln.csv" in
-    let advn = _read_count_file advn_path in
-    let decln = _read_count_file decln_path in
-    if Hashtbl.is_empty advn || Hashtbl.is_empty decln then []
-    else _join ~advn ~decln
+  let load = _unicorn_load
 end
 
 let load ~data_dir = Unicorn.load ~data_dir


### PR DESCRIPTION
## Summary

Two pre-existing linter failures on main, flagged during the M3 PR review but pre-dating that work.

### 1. \`portfolio_risk.ml:check_limits\` — 53 lines (fn-length > 50)

Extract four private helpers (\`_check_max_positions\`, \`_check_exposure\`, \`_check_cash\`, \`_check_sector\`), each under 20 lines. \`check_limits\` becomes a flat concat of their results (~10 lines).

### 2. \`ad_bars.ml\` — file-avg nesting 2.91 > 2.5, plus \`_read_unicorn_count_file\` avg 3.55 > 3.0

The nesting was elevated because every helper lived inside \`module Unicorn = struct ... end\`, adding one level to every line. And \`_read_unicorn_count_file\` had nested \`In_channel.with_file\` + \`iter_lines\` + inline match.

**Fix**: move the source-specific helpers to top-level private functions (\`_parse_yyyymmdd\`, \`_parse_unicorn_row\`, \`_read_unicorn_count_file\`, \`_join_unicorn_counts\`), and keep \`module Unicorn\` as a thin re-export layer. Extract \`_insert_parsed_row\` and \`_read_unicorn_lines\` from the match body to flatten the read path.

- File-avg nesting: 2.91 → 1.8
- \`_read_unicorn_count_file\` avg: 3.55 → under 3.0
- Public API (\`Ad_bars.load\`, \`Ad_bars.Unicorn.load\`) unchanged — the nested module is still addressable from tests

## Verification

\`\`\`
dune exec ./devtools/fn_length_linter/fn_length_linter.exe -- .
OK: no functions exceed 50 lines.

dune exec ./devtools/nesting_linter/nesting_linter.exe -- . ./devtools/checks/linter_exceptions.conf
OK: nesting linter — all 620 functions within limits.
Codebase avg nesting: 1.38
\`\`\`

All 45 strategy-lib tests + 26 portfolio_risk tests still pass. No behaviour changes.

## Test plan
- [x] \`dune build && dune runtest\` clean
- [x] Both linters clean
- [x] \`dune fmt\` clean