### PR TITLE
ci: publish dev container image to GHCR

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,57 @@
+# Build and publish the CI image used by .github/workflows/ci.yml.
+#
+# The image bakes in all system deps (ta-lib, openblas, plplot, …) and all
+# opam deps, so PR jobs can skip the multi-minute setup and run just
+# `dune build && dune runtest` inside a prebuilt container.
+#
+# Rebuilt when:
+#   * .devcontainer/Dockerfile changes (new system / opam dep)
+#   * any *.opam file changes (dependency graph changed)
+#   * weekly cron (pick up upstream base-image security patches)
+#   * manually via workflow_dispatch
+name: Build CI image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.devcontainer/Dockerfile'
+      - 'trading/**/*.opam'
+      - '.github/workflows/image.yml'
+  schedule:
+    - cron: '0 6 * * 1' # 06:00 UTC every Monday
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to push (default: latest)'
+        required: false
+        default: 'latest'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .devcontainer/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/trading-ci:${{ github.event.inputs.tag || 'latest' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Bootstrap PR for #270.

Adds `.github/workflows/image.yml`, which builds `.devcontainer/Dockerfile` and pushes the resulting image to `ghcr.io/dayfine/trading-ci:latest`. This must land first because #270 (the fast PR-gate workflow) pulls that image via the `container:` directive — and `ghcr.io/dayfine/trading-ci` does not exist yet (`gh api /users/dayfine/packages/container/trading-ci` → 404).

Merge order:
1. Merge this PR.
2. Trigger `Build CI image` via workflow_dispatch (or wait for the next push to `.devcontainer/Dockerfile` / `trading/**/*.opam`) so the `:latest` tag exists in GHCR.
3. Merge #270, which now contains only `ci.yml` and depends on the published image.

No functional changes other than adding the workflow file. Content is identical to what was previously bundled in #270.