### PR TITLE
refactor: extract Week_bucketing helper shared by Conversion and Ad_bars_aggregation

### DIFF
--- a/trading/analysis/technical/indicators/time_period/lib/conversion.ml
+++ b/trading/analysis/technical/indicators/time_period/lib/conversion.ml
@@ -1,10 +1,6 @@
 open Core
 open Types.Daily_price
 
-(* Check if two dates are in the same week *)
-let _is_same_week (d1 : Date.t) (d2 : Date.t) : bool =
-  Date.week_number d1 = Date.week_number d2 && Date.year d1 = Date.year d2
-
 (* Check if a date is a weekend *)
 let _is_weekend (date : Date.t) : bool =
   let day = Date.day_of_week date in
@@ -14,30 +10,28 @@ let _is_weekend (date : Date.t) : bool =
 let _is_friday (date : Date.t) : bool =
   Day_of_week.equal (Date.day_of_week date) Day_of_week.Fri
 
-(* Validate date based on weekdays_only setting *)
-let _validate_weekday ~weekdays_only date =
-  if weekdays_only && _is_weekend date then
+let _reject_weekend bar =
+  if _is_weekend bar.date then
     raise
       (Invalid_argument "Weekend dates not allowed when weekdays_only is true")
 
-(* Validate chronological ordering *)
-let _validate_ordering prev curr =
-  if Date.compare prev curr >= 0 then
-    raise
-      (Invalid_argument
-         "Data must be sorted chronologically by date with no duplicates")
+(* Validate weekday-only setting before delegating to the generic bucketer.
+   Done as a pre-pass so [Week_bucketing] can stay domain-agnostic. *)
+let _validate_weekdays_only data = List.iter data ~f:_reject_weekend
 
-(* Build a weekly bar from a list of daily bars in reverse chronological order *)
-let _build_weekly_bar week_data =
-  let last = List.hd_exn week_data in
-  let first = List.last_exn week_data in
+(* Aggregate one week of daily bars (reverse chronological order) into a single
+   weekly bar. The bar is dated on the most recent day in the week, the open
+   comes from the earliest day, and high/low/volume are reduced over the week. *)
+let _aggregate_week (week_rev : t list) : t =
+  let last = List.hd_exn week_rev in
+  let first = List.last_exn week_rev in
   let high_price =
-    List.map week_data ~f:(fun d -> d.high_price)
+    List.map week_rev ~f:(fun d -> d.high_price)
     |> List.max_elt ~compare:Float.compare
     |> Option.value_exn
   in
   let low_price =
-    List.map week_data ~f:(fun d -> d.low_price)
+    List.map week_rev ~f:(fun d -> d.low_price)
     |> List.min_elt ~compare:Float.compare
     |> Option.value_exn
   in
@@ -47,63 +41,25 @@ let _build_weekly_bar week_data =
     high_price;
     low_price;
     close_price = last.close_price;
-    volume = List.sum (module Int) week_data ~f:(fun d -> d.volume);
+    volume = List.sum (module Int) week_rev ~f:(fun d -> d.volume);
     adjusted_close = last.adjusted_close;
   }
 
-(* Aggregate a week of data into a single weekly bar *)
-let _aggregate_week (week_data : t list) : t =
-  match week_data with
-  | [] -> failwith "Cannot aggregate empty week"
-  | [ single ] -> single
-  | _ :: _ -> _build_weekly_bar week_data
-
-(* Process a new data point *)
-let _process_data_point ~weekdays_only ~prev_date ~curr_week data =
-  _validate_weekday ~weekdays_only data.date;
-  Option.iter prev_date ~f:(fun prev -> _validate_ordering prev data.date);
-  match curr_week with
-  | [] -> ([ data ], Some data.date)
-  | last :: _ ->
-      if _is_same_week last.date data.date then
-        (data :: curr_week, Some data.date)
-      else ([ data ], Some data.date)
-
-(* Recursively process data points, maintaining:
-   - acc: list of completed weekly bars (aggregated)
-   - curr_week: entries in the current week being processed (reverse chronological)
-   - prev_date: last processed date (for chronological validation) *)
-let _finalize_partial_week ~include_partial_week acc week_data =
-  let last = List.hd_exn week_data in
-  if include_partial_week || _is_friday last.date then
-    List.rev (_aggregate_week week_data :: acc)
-  else List.rev acc
-
-let _advance_week ~weekdays_only acc curr_week prev_date data =
-  let curr_week', prev_date' =
-    _process_data_point ~weekdays_only ~prev_date ~curr_week data
-  in
-  let acc' =
-    match curr_week with
-    | _ :: _ when not (_is_same_week (List.hd_exn curr_week).date data.date) ->
-        _aggregate_week curr_week :: acc
-    | _ -> acc
-  in
-  (acc', curr_week', prev_date')
-
-let rec _weekly_aux ~weekdays_only ~include_partial_week acc curr_week prev_date
-    = function
-  | [] -> (
-      match curr_week with
-      | [] -> List.rev acc
-      | week_data -> _finalize_partial_week ~include_partial_week acc week_data)
-  | data :: rest ->
-      let acc', curr_week', prev_date' =
-        _advance_week ~weekdays_only acc curr_week prev_date data
-      in
-      _weekly_aux ~weekdays_only ~include_partial_week acc' curr_week'
-        prev_date' rest
+(* Drop a trailing partial week if its last observed day is not a Friday. The
+   weekly buckets returned by [Week_bucketing] preserve chronological order, so
+   "trailing" is just the last element. *)
+let _drop_trailing_partial weekly =
+  match List.rev weekly with
+  | [] -> []
+  | last :: _ when _is_friday last.date -> weekly
+  | _ :: rest_rev -> List.rev rest_rev
 
 let daily_to_weekly ?(weekdays_only = false) ?(include_partial_week = true) data
     =
-  _weekly_aux ~weekdays_only ~include_partial_week [] [] None data
+  if weekdays_only then _validate_weekdays_only data;
+  let weekly =
+    Week_bucketing.bucket_weekly
+      ~get_date:(fun (b : t) -> b.date)
+      ~aggregate:_aggregate_week data
+  in
+  if include_partial_week then weekly else _drop_trailing_partial weekly

--- a/trading/analysis/technical/indicators/time_period/lib/week_bucketing.ml
+++ b/trading/analysis/technical/indicators/time_period/lib/week_bucketing.ml
@@ -1,0 +1,51 @@
+open Core
+
+(* Two dates are in the same ISO week iff they share (year, week_number). *)
+let _is_same_week (d1 : Date.t) (d2 : Date.t) : bool =
+  Date.week_number d1 = Date.week_number d2 && Date.year d1 = Date.year d2
+
+let _ordering_error_msg =
+  "Data must be sorted chronologically by date with no duplicates"
+
+let _validate_ordering (prev : Date.t) (curr : Date.t) : unit =
+  if Date.compare prev curr >= 0 then
+    raise (Invalid_argument _ordering_error_msg)
+
+type 'a _state = {
+  acc : 'a list;
+  curr_week_rev : 'a list;
+  prev_date : Date.t option;
+}
+(** Fold state: completed buckets (reverse chronological), the current week's
+    items (also reverse chronological), and the last seen date (for ordering
+    checks). *)
+
+let _empty_state = { acc = []; curr_week_rev = []; prev_date = None }
+
+let _flush_week ~aggregate state =
+  match state.curr_week_rev with
+  | [] -> state
+  | week_rev ->
+      { state with acc = aggregate week_rev :: state.acc; curr_week_rev = [] }
+
+let _step ~get_date ~aggregate state item =
+  let date = get_date item in
+  Option.iter state.prev_date ~f:(fun prev -> _validate_ordering prev date);
+  let state =
+    match state.curr_week_rev with
+    | last :: _ when not (_is_same_week (get_date last) date) ->
+        _flush_week ~aggregate state
+    | _ -> state
+  in
+  {
+    acc = state.acc;
+    curr_week_rev = item :: state.curr_week_rev;
+    prev_date = Some date;
+  }
+
+let bucket_weekly ~get_date ~aggregate items =
+  let final =
+    List.fold items ~init:_empty_state ~f:(_step ~get_date ~aggregate)
+    |> _flush_week ~aggregate
+  in
+  List.rev final.acc

--- a/trading/analysis/technical/indicators/time_period/lib/week_bucketing.mli
+++ b/trading/analysis/technical/indicators/time_period/lib/week_bucketing.mli
@@ -1,0 +1,37 @@
+open Core
+
+(** Generic ISO-week bucketing for date-stamped data.
+
+    {!bucket_weekly} groups a chronologically ascending list of items into one
+    bucket per ISO week, then collapses each bucket via a caller-supplied
+    aggregator. It exists so that domain-specific cadence converters (price
+    bars, A-D breadth bars, ...) can share the same week-boundary logic and
+    chronological-ordering invariants without duplicating the fold.
+
+    Two items are considered to be in the same week iff they agree on both
+    {!Date.week_number} and {!Date.year} (so the ISO week number, scoped by
+    year, is the bucket key). The first and last week of the input may be
+    partial — both are emitted.
+
+    All functions are pure. *)
+
+val bucket_weekly :
+  get_date:('a -> Date.t) -> aggregate:('a list -> 'a) -> 'a list -> 'a list
+(** [bucket_weekly ~get_date ~aggregate items] groups [items] by ISO week and
+    collapses each week into a single item.
+
+    [get_date] extracts the date used for bucketing. [aggregate] receives the
+    items belonging to one week in {b reverse chronological order} (most recent
+    first) and is guaranteed to be called with a non-empty list. The result of
+    [aggregate] is what appears in the output for that week.
+
+    The output preserves chronological order: bucket [k] comes before bucket
+    [k+1] iff the items in [k] are dated earlier than the items in [k+1].
+
+    Partial head and tail weeks are emitted (i.e. a week with only Wed-Fri at
+    the start, or only Mon-Wed at the end, still produces one bucket). Empty
+    input produces empty output.
+
+    @raise Invalid_argument
+      if [items] is not strictly chronologically ascending (duplicate dates are
+      also rejected). *)

--- a/trading/analysis/technical/indicators/time_period/test/dune
+++ b/trading/analysis/technical/indicators/time_period/test/dune
@@ -1,6 +1,6 @@
 (tests
- (names test_conversion)
- (modules test_conversion)
- (libraries time_period ounit2 ppx_deriving)
+ (names test_conversion test_week_bucketing)
+ (modules test_conversion test_week_bucketing)
+ (libraries time_period matchers ounit2 ppx_deriving)
  (preprocess
-  (pps ppx_deriving.show)))
+  (pps ppx_deriving.show ppx_deriving.eq)))

--- a/trading/analysis/technical/indicators/time_period/test/test_week_bucketing.ml
+++ b/trading/analysis/technical/indicators/time_period/test/test_week_bucketing.ml
@@ -1,0 +1,165 @@
+open OUnit2
+open Core
+open Matchers
+open Time_period
+
+(* Helper: ISO date constructor. *)
+let d ~y ~m ~day = Date.create_exn ~y ~m ~d:day
+
+(* Tuple-valued items so the tests prove [bucket_weekly] is generic over 'a. *)
+type tagged = Date.t * int [@@deriving show, eq]
+
+let tagged_get_date (d, _) = d
+
+let tagged_sum (rev : tagged list) : tagged =
+  let date, _ = List.hd_exn rev in
+  let total = List.sum (module Int) rev ~f:snd in
+  (date, total)
+
+let test_empty_input _ =
+  let result =
+    Week_bucketing.bucket_weekly ~get_date:tagged_get_date ~aggregate:tagged_sum
+      []
+  in
+  assert_that result (elements_are [])
+
+let test_single_element _ =
+  let item = (d ~y:2024 ~m:Month.Mar ~day:12, 7) in
+  let result =
+    Week_bucketing.bucket_weekly ~get_date:tagged_get_date ~aggregate:tagged_sum
+      [ item ]
+  in
+  assert_that result
+    (elements_are [ equal_to ((d ~y:2024 ~m:Month.Mar ~day:12, 7) : tagged) ])
+
+let test_multi_week_preserves_order _ =
+  (* Two ISO weeks with several weekdays each. *)
+  let items =
+    [
+      (d ~y:2024 ~m:Month.Mar ~day:11, 1);
+      (* Mon, week 11 *)
+      (d ~y:2024 ~m:Month.Mar ~day:13, 2);
+      (* Wed *)
+      (d ~y:2024 ~m:Month.Mar ~day:15, 3);
+      (* Fri *)
+      (d ~y:2024 ~m:Month.Mar ~day:18, 4);
+      (* Mon, week 12 *)
+      (d ~y:2024 ~m:Month.Mar ~day:20, 5);
+      (* Wed *)
+      (d ~y:2024 ~m:Month.Mar ~day:22, 6);
+      (* Fri *)
+    ]
+  in
+  let result =
+    Week_bucketing.bucket_weekly ~get_date:tagged_get_date ~aggregate:tagged_sum
+      items
+  in
+  assert_that result
+    (elements_are
+       [
+         equal_to ((d ~y:2024 ~m:Month.Mar ~day:15, 1 + 2 + 3) : tagged);
+         equal_to ((d ~y:2024 ~m:Month.Mar ~day:22, 4 + 5 + 6) : tagged);
+       ])
+
+let test_partial_head_and_tail_weeks_emitted _ =
+  (* Head week starts on Wed; tail week ends on Tue.  Both are partial and
+     should still produce one bucket each. *)
+  let items =
+    [
+      (d ~y:2024 ~m:Month.Mar ~day:13, 10);
+      (* Wed, week 11 — partial head *)
+      (d ~y:2024 ~m:Month.Mar ~day:15, 20);
+      (* Fri, week 11 *)
+      (d ~y:2024 ~m:Month.Mar ~day:18, 30);
+      (* Mon, week 12 — full middle *)
+      (d ~y:2024 ~m:Month.Mar ~day:22, 40);
+      (* Fri, week 12 *)
+      (d ~y:2024 ~m:Month.Mar ~day:25, 50);
+      (* Mon, week 13 — partial tail *)
+      (d ~y:2024 ~m:Month.Mar ~day:26, 60);
+      (* Tue, week 13 *)
+    ]
+  in
+  let result =
+    Week_bucketing.bucket_weekly ~get_date:tagged_get_date ~aggregate:tagged_sum
+      items
+  in
+  assert_that result
+    (elements_are
+       [
+         equal_to ((d ~y:2024 ~m:Month.Mar ~day:15, 10 + 20) : tagged);
+         equal_to ((d ~y:2024 ~m:Month.Mar ~day:22, 30 + 40) : tagged);
+         equal_to ((d ~y:2024 ~m:Month.Mar ~day:26, 50 + 60) : tagged);
+       ])
+
+let test_unsorted_input_raises _ =
+  let items =
+    [ (d ~y:2024 ~m:Month.Mar ~day:15, 1); (d ~y:2024 ~m:Month.Mar ~day:12, 2) ]
+  in
+  assert_raises
+    (Invalid_argument
+       "Data must be sorted chronologically by date with no duplicates")
+    (fun () ->
+      Week_bucketing.bucket_weekly ~get_date:tagged_get_date
+        ~aggregate:tagged_sum items)
+
+let test_duplicate_date_raises _ =
+  let items =
+    [ (d ~y:2024 ~m:Month.Mar ~day:15, 1); (d ~y:2024 ~m:Month.Mar ~day:15, 2) ]
+  in
+  assert_raises
+    (Invalid_argument
+       "Data must be sorted chronologically by date with no duplicates")
+    (fun () ->
+      Week_bucketing.bucket_weekly ~get_date:tagged_get_date
+        ~aggregate:tagged_sum items)
+
+(* Sanity check: the helper is generic over the item type — exercise it on a
+   record-flavoured input to confirm the API isn't accidentally constrained to
+   tuples or to the [Daily_price] type. *)
+type observation = { obs_date : Date.t; value : float } [@@deriving show, eq]
+
+let test_record_input _ =
+  let items =
+    [
+      { obs_date = d ~y:2024 ~m:Month.Mar ~day:11; value = 1.5 };
+      { obs_date = d ~y:2024 ~m:Month.Mar ~day:13; value = 2.5 };
+      { obs_date = d ~y:2024 ~m:Month.Mar ~day:18; value = 4.0 };
+    ]
+  in
+  let result =
+    Week_bucketing.bucket_weekly
+      ~get_date:(fun o -> o.obs_date)
+      ~aggregate:(fun rev ->
+        let last = List.hd_exn rev in
+        {
+          obs_date = last.obs_date;
+          value = List.sum (module Float) rev ~f:(fun o -> o.value);
+        })
+      items
+  in
+  assert_that result
+    (elements_are
+       [
+         equal_to
+           ({ obs_date = d ~y:2024 ~m:Month.Mar ~day:13; value = 4.0 }
+             : observation);
+         equal_to
+           ({ obs_date = d ~y:2024 ~m:Month.Mar ~day:18; value = 4.0 }
+             : observation);
+       ])
+
+let suite =
+  "Week_bucketing tests"
+  >::: [
+         "test_empty_input" >:: test_empty_input;
+         "test_single_element" >:: test_single_element;
+         "test_multi_week_preserves_order" >:: test_multi_week_preserves_order;
+         "test_partial_head_and_tail_weeks_emitted"
+         >:: test_partial_head_and_tail_weeks_emitted;
+         "test_unsorted_input_raises" >:: test_unsorted_input_raises;
+         "test_duplicate_date_raises" >:: test_duplicate_date_raises;
+         "test_record_input" >:: test_record_input;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Extracts the ISO-week bucketing logic that was duplicated in
`Time_period.Conversion.daily_to_weekly` (price bars) and
`Weinstein.Macro.Ad_bars_aggregation.daily_to_weekly` (A-D breadth bars) into a
single generic helper:

```ocaml
val Week_bucketing.bucket_weekly :
  get_date:('a -> Date.t) ->
  aggregate:('a list -> 'a) ->
  'a list -> 'a list
```

The helper enforces the chronological-ordering invariant once and feeds each
week of items (in reverse chronological order) to a caller-supplied
`aggregate` function. Both callers keep the same public API and error
messages.

This is a stacked prerequisite for #267 (`feat/macro-cadence-fix`). Once this
PR merges, #267 will be rebased on top so that
`Ad_bars_aggregation.daily_to_weekly` becomes a one-liner that delegates to
`Week_bucketing.bucket_weekly`.

### Changes

- New `Week_bucketing` module under `analysis/technical/indicators/time_period/lib/`
  with `.mli` documenting the contract.
- `Conversion.daily_to_weekly` refactored to delegate to `bucket_weekly`. The
  weekday-only validation is done as a pre-pass before calling the bucketer,
  and `include_partial_week=false` is implemented as a post-filter that drops
  the trailing bucket if it does not end on a Friday. All 12 existing
  conversion tests pass unchanged.
- New unit tests for `Week_bucketing` (`test_week_bucketing.ml`) covering empty
  input, single element, multi-week ordering, partial head/tail emission, the
  unsorted/duplicate error path, and a record-flavoured input that exercises
  the `'a` genericity.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` — all 12 existing `Conversion` tests pass; 7 new
      `Week_bucketing` tests pass
- [x] `dune fmt`
- [ ] CI green