### PR TITLE
chore: pin ocamlformat to 0.29.0 and drop redundant nested config

### DIFF
--- a/trading/.ocamlformat
+++ b/trading/.ocamlformat
@@ -1,1 +1,2 @@
 profile = default
+version = 0.29.0

--- a/trading/analysis/weinstein/.ocamlformat
+++ b/trading/analysis/weinstein/.ocamlformat
@@ -1,1 +1,0 @@
-profile = default

--- a/trading/analysis/weinstein/data_source/testing/lib/test_data_loader.mli
+++ b/trading/analysis/weinstein/data_source/testing/lib/test_data_loader.mli
@@ -12,9 +12,7 @@
     - [GSPC.INDX] — daily bars from at least 2020-01-01
 
     If data is missing, run:
-    {v
-      fetch_symbols.exe --symbols AAPL,GSPC.INDX --api-key <key>
-    v}
+    {v   fetch_symbols.exe --symbols AAPL,GSPC.INDX --api-key <key> v}
 
     See also: [ops-data] agent for data inventory management. *)
 

--- a/trading/analysis/weinstein/stage/lib/stage.mli
+++ b/trading/analysis/weinstein/stage/lib/stage.mli
@@ -95,8 +95,8 @@ val classify :
     bottleneck, add:
 
     {[
-      val classify_step :
-        config:config -> prev_result:result -> new_bar:Daily_price.t -> result
+    val classify_step :
+      config:config -> prev_result:result -> new_bar:Daily_price.t -> result
     ]}
 
     [classify_step] would maintain an incremental MA state (e.g. a sliding
@@ -122,11 +122,11 @@ val classify :
     [analysis/technical/indicators/] with a [slope] function:
 
     {[
-      val slope :
-        lookback:int ->
-        threshold:float ->
-        (Date.t * float) list ->
-        ma_direction * float
+    val slope :
+      lookback:int ->
+      threshold:float ->
+      (Date.t * float) list ->
+      ma_direction * float
     ]}
 
     This would eliminate the per-module slope implementations and give a single


### PR DESCRIPTION
## Summary

Two linked cleanups to the formatting setup:

1. **Pin `version = 0.29.0`** in `trading/.ocamlformat`. The Dockerfile doesn't pin a specific ocamlformat version, so image rebuilds pick whichever version the opam snapshot currently offers. That caused the CI image (built today) to land on 0.29.0 while dev containers built earlier were still on 0.28.1 — their layout rules differ on nested signatures and verbatim blocks, so `stage.mli` and `test_data_loader.mli` fail the fmt gate under 0.29.0 even though they pass under 0.28.1. Pinning makes ocamlformat refuse to run unless the installed binary matches — future drift fails loud instead of silently diverging.
2. **Apply the 0.29.0 reformat** to the two affected files (signature indentation + verbatim-block collapsing).
3. **Remove `analysis/weinstein/.ocamlformat`** — its content was byte-identical to the root config, and ocamlformat walks up from each source file to find the nearest `.ocamlformat`, so the nested file provided no override, just drift risk.

## Prerequisite for `#270` (CI)

`#270` introduces the GitHub Actions pipeline that runs `dune runtest` inside the GHCR image. That image has ocamlformat 0.29.0. Without this PR, the `fmt_check.sh` linter fails on the two `.mli` files above. Landing this first is what makes `#270`'s CI actually pass the formatting gate.

## Local dev note

After this lands, dev containers need to upgrade ocamlformat:

```
opam update
opam install ocamlformat.0.29.0
```

ocamlformat will refuse to run otherwise, with a clear "version mismatch" error. The dev container Dockerfile should eventually also pin the version to match — tracked as follow-up.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest devtools/checks/` — all linters pass including the fmt gate
- [x] `dune fmt` no-op (tree already matches 0.29.0)
