### PR TITLE
fix: seed price_path RNG in engine tests for determinism

### DIFF
--- a/trading/trading/engine/test/test_engine.ml
+++ b/trading/trading/engine/test/test_engine.ml
@@ -51,7 +51,8 @@ let setup_order_test ~order_type ~side ?(symbol = "AAPL") ?(quantity = 100.0)
     | Error err -> failwith ("Failed to create order: " ^ Status.show err)
   in
   submit_single_order order_mgr order;
-  update_market engine [ quote ];
+  let path_config = { default_config with seed = Some 42 } in
+  update_market ~path_config engine [ quote ];
   (engine, order_mgr, order)
 
 (* Assert that order was not executed and remains pending *)


### PR DESCRIPTION
## Summary
- Seed the price path RNG (`seed = Some 42`) in `setup_order_test` so all engine tests using that helper produce deterministic intraday paths
- Fixes intermittent CI failure in `test_buy_stop_limit_executes_when_ask_at_limit` caused by unseeded `Random` state varying across platforms

## Test plan
- [x] All 77 engine tests pass locally (47 + 18 + 12)
- [x] All 77 engine tests pass in CI image (`ghcr.io/dayfine/trading-ci:latest`, linux/amd64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)