### PR TITLE
fix: trailing stop tracks 30-week MA per Weinstein Ch. 6

### DIFF
--- a/docs/design/weinstein-book-reference.md
+++ b/docs/design/weinstein-book-reference.md
@@ -224,12 +224,17 @@ STATE: FIRST_CORRECTION
     TRANSITION to TRAILING
 
 STATE: TRAILING (repeat for each correction cycle)
-  AFTER each correction + recovery:
-    WHEN stock rallies back near prior peak:
-      new_stop = below(min(correction_low, MA))
-      -- always below round numbers
-    KEY: give stock plenty of room while MA is rising sharply
-    KEY: don't raise stop until stock rallies well off the low
+  AFTER each correction (8-10%+) + recovery back near prior peak:
+    new_stop = below(min(correction_low, MA))
+    -- "the sell-stop was always kept below the MA even if the correction
+       low held above it" (Ch. 6, Merck example)
+    -- "Continue moving the sell-stop up as the MA advances (points E, G, I)"
+       — each successive ratchet uses the current (risen) MA, so stops
+       trend upward across correction cycles
+    -- always below round numbers
+  BETWEEN corrections: stop stays put
+    -- "give stock plenty of room while MA is rising sharply"
+    -- "don't raise stop until stock rallies well off the low"
 
 STATE: STAGE3_TIGHTENING
   TRIGGER: MA flattens out, stock oscillating around MA

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.ml
@@ -297,9 +297,16 @@ let _advance_tracking ~side ~last_correction_extreme ~last_trend_extreme ~bar =
   (new_trend_extreme, new_correction_extreme)
 
 (* Returns [Some new_stop] if a correction cycle just completed and the
-   candidate stop is better than the current stop, otherwise [None]. *)
+   candidate stop is better than the current stop, otherwise [None].
+
+   Per Weinstein Ch. 6: the stop is placed below min(correction_low, MA) —
+   "the sell-stop was always kept below the MA even if the correction low
+   held above it." When the correction dips below the MA (common in a
+   healthy Stage 2), the correction low is the binding constraint.  When
+   the correction holds above the MA (shallow pullback), the MA is lower
+   and becomes the reference. Either way, the stop stays below BOTH. *)
 let _completed_cycle_stop ~config ~side ~stop_level ~trend_extreme
-    ~correction_extreme ~bar =
+    ~correction_extreme ~ma_value ~bar =
   let had_correction =
     _is_correction ~config ~side ~trend_extreme ~correction_extreme
   in
@@ -307,7 +314,15 @@ let _completed_cycle_stop ~config ~side ~stop_level ~trend_extreme
     _is_recovery ~side ~close:bar.Types.Daily_price.close_price ~trend_extreme
   in
   if had_correction && recovered then
-    let candidate = _stop_candidate ~config ~side ~correction_extreme in
+    (* Use whichever reference is more conservative: correction low or MA *)
+    let effective_ref =
+      match side with
+      | Long -> Float.min correction_extreme ma_value
+      | Short -> Float.max correction_extreme ma_value
+    in
+    let candidate =
+      _stop_candidate ~config ~side ~correction_extreme:effective_ref
+    in
     if _is_better_stop ~side ~current:stop_level ~candidate then Some candidate
     else None
   else None
@@ -344,7 +359,7 @@ let _raise_after_cycle ~config ~side ~ma_value ~correction_count ~stop_level
   match
     _completed_cycle_stop ~config ~side ~stop_level
       ~trend_extreme:last_trend_extreme
-      ~correction_extreme:new_correction_extreme ~bar
+      ~correction_extreme:new_correction_extreme ~ma_value ~bar
   with
   | None -> (no_change, No_change)
   | Some new_stop ->

--- a/trading/trading/weinstein/stops/test/regression_test.ml
+++ b/trading/trading/weinstein/stops/test/regression_test.ml
@@ -61,8 +61,9 @@ let stage4 = Stage4 { weeks_declining = 3 }
 
    Phase B (5 bars): price continues up through 131→140, pulls back to 122,
    recovers to 143. One more cycle completes:
-     cycle 3 at c=143: trend=140, corr=122 (reset by fix), (140-122)/140=13%,
-       stop 102.96→120.78 *)
+     cycle 3 at c=143: trend=140, corr=122, MA=120.
+       Per min(correction, MA) rule: min(122, 120)=120.
+       stop = 120 * 0.99 = 118.80. (102.96→118.80) *)
 
 let stage2_trailing_stop_raised_phase_a _ =
   let state0 =
@@ -146,16 +147,16 @@ let stage2_trailing_stop_raised_phase_b _ =
   in
   let final_state, last_event = run_sequence initial_state Long steps in
   assert_that last_event
-    (matching ~msg:"cycle 3: stop raised to 120.78"
+    (matching ~msg:"cycle 3: stop raised to 118.80"
        (function Stop_raised { new_level; _ } -> Some new_level | _ -> None)
-       (float_equal 120.78));
+       (float_equal 118.80));
   assert_that final_state
-    (matching ~msg:"Trailing: stop=120.78, count=3"
+    (matching ~msg:"Trailing: stop=118.80, count=3"
        (function
          | Trailing { stop_level; correction_count; _ } ->
              Some (stop_level, correction_count)
          | _ -> None)
-       (pair (float_equal 120.78) (equal_to 3)))
+       (pair (float_equal 118.80) (equal_to 3)))
 
 (* ------------------------------------------------------------------ *)
 (* Stage 3 transition — flat MA triggers tightening                     *)
@@ -254,18 +255,20 @@ let short_stage4_stop_lowered _ =
   in
   let final_state, last_event = run_sequence initial_state Short steps in
   (* After the fix, cycle 1 resets corr to close=88 (not bar high=90).
-     Cycle 2's corr tracks up to 89 (bar5 high=89 > 88), so stop = 89*1.01≈90.125. *)
+     Cycle 2's corr tracks up to 89 (bar5 high=89 > 88). Per the
+     min/max(correction, MA) rule for shorts: max(89, 98)=98, so
+     stop = 98 * 1.01 = 98.98 → nudged above 99 to 99.125. *)
   assert_that last_event
-    (matching ~msg:"cycle 2: stop lowered to 90.125"
+    (matching ~msg:"cycle 2: stop lowered to 99.125"
        (function Stop_raised { new_level; _ } -> Some new_level | _ -> None)
-       (float_equal 90.125));
+       (float_equal 99.125));
   assert_that final_state
-    (matching ~msg:"Trailing: stop=90.125, count=2"
+    (matching ~msg:"Trailing: stop=99.125, count=2"
        (function
          | Trailing { stop_level; correction_count; _ } ->
              Some (stop_level, correction_count)
          | _ -> None)
-       (pair (float_equal 90.125) (equal_to 2)))
+       (pair (float_equal 99.125) (equal_to 2)))
 
 (* ------------------------------------------------------------------ *)
 (* Full lifecycle long — Initial → Trailing → Tightened → Stop_hit      *)
@@ -273,7 +276,8 @@ let short_stage4_stop_lowered _ =
 (* Complete long position lifecycle:
    1. Entry: Initial stop at 49.92 (= 52 × 0.96)
    2. First advance bar transitions to Trailing (stop unchanged)
-   3. Four-bar sequence: 2 correction cycles raise stop 49.92→52.375→59.4
+   3. Four-bar sequence: 2 correction cycles raise stop 49.92→52.375→56.43
+      (cycle 2: min(correction_low=60, MA=57) = 57, stop = 57×0.99 = 56.43)
    4. Flat MA + Stage 3 → Tightened at 69.3 (corr reset to close=70 by fix)
    5. Price drops through tightened stop → Stop_hit: trigger=67.3, stop=69.3 *)
 
@@ -306,12 +310,12 @@ let full_lifecycle_long _ =
   in
   let state2, _ = run_sequence state1 Long steps_to_raise in
   assert_that state2
-    (matching ~msg:"Trailing: stop=59.4, count=2 after raise steps"
+    (matching ~msg:"Trailing: stop=56.43, count=2 after raise steps"
        (function
          | Trailing { stop_level; correction_count; _ } ->
              Some (stop_level, correction_count)
          | _ -> None)
-       (pair (float_equal 59.4) (equal_to 2)));
+       (pair (float_equal 56.43) (equal_to 2)));
   let bar_top = make_bar ~low_price:68.0 ~high_price:72.0 70.0 in
   let state3, event3 =
     update ~config:cfg ~side:Long ~state:state2 ~current_bar:bar_top
@@ -415,7 +419,7 @@ let () =
     >::: [
            "stage2 trailing stop raised — phase A (2 cycles, stop→102.96)"
            >:: stage2_trailing_stop_raised_phase_a;
-           "stage2 trailing stop raised — phase B (1 more cycle, stop→120.78)"
+           "stage2 trailing stop raised — phase B (1 more cycle, stop→118.80)"
            >:: stage2_trailing_stop_raised_phase_b;
            "stage3 tightening on flat MA" >:: stage3_tightening;
            "stop hit on long position" >:: stop_hit_long;


### PR DESCRIPTION
## Summary

The trailing stop placed new stops below the correction extreme only, ignoring the 30-week MA. Weinstein Ch. 6 is explicit:

> "the sell-stop was always kept below the MA even if the correction low held above it" (Merck example, p. 190)

The rule: at each correction-completion ratchet, place the stop below `min(correction_low, MA)` for longs / `max(correction_high, MA)` for shorts.

- When the correction dips **below** the MA (common in a healthy Stage 2), the correction low is binding — same as before.
- When the correction holds **above** the MA (shallow pullback), the MA is lower and becomes the reference — **this is the new behavior.**

The stop adjustment fires only at correction-completion points, NOT continuously between corrections:

> "don't actually change it until your stock ends its correction and moves back toward its prior high" (p. 184)

> "give stock plenty of room while MA is rising sharply" (p. 188)

## Changes

- `weinstein_stops.ml`: `_completed_cycle_stop` now takes `~ma_value` and computes `min(correction_extreme, ma_value)` for longs / `max(...)` for shorts as the effective reference
- `regression_test.ml`: 3 expected values updated + comments clarified with the `min/max` computation
- `weinstein-book-reference.md`: §5.2 TRAILING state clarified with direct Ch. 6 quotes

## Test plan

- [x] `dune build` clean
- [x] `dune runtest trading/weinstein/stops/test/` — 25 unit + 7 regression = 32 tests pass
- [x] `dune fmt` clean