### PR TITLE
chore: refresh stale status files + document ISF.LSE proxy for FTSE

### DIFF
--- a/dev/status/data-gaps.md
+++ b/dev/status/data-gaps.md
@@ -75,10 +75,9 @@ Last updated: 2026-04-10 (FTSE decision made; ADL + fundamentals candidates iden
 - GSPC.INDX (S&P 500): cached, 1927-12-30 to 2026-04-09 — VERIFIED
 - GDAXI.INDX (DAX): cached, 1980-01-02 to 2026-04-09 — VERIFIED
 - N225.INDX (Nikkei 225): cached, 1965-01-05 to 2026-04-10 — VERIFIED
-- **FTSE 100 via `ISF.LSE` (iShares Core FTSE 100 UCITS ETF)** — **DECISION: use as proxy** (2026-04-10). Physical-replication tracker, ~bps tracking error, functionally indistinguishable from the index at weekly cadence. Try `UKX.INDX` on EODHD first as a cheaper alternative; fall back to `ISF.LSE` if that doesn't work. Still needs to be fetched.
+- **FTSE 100 via `ISF.LSE` (iShares Core FTSE 100 UCITS ETF)** — **DECISION: use as proxy** (2026-04-10). Physical-replication tracker, ~bps tracking error, functionally indistinguishable from the index at weekly cadence. `UKX.INDX` returned empty; `ISF.LSE` fetched successfully (6,552 bars, 2000-05-02 to 2026-04-10) — VERIFIED (2026-04-11).
 
 ### What's needed
-- **ops-data**: try `UKX.INDX` first, else fetch `ISF.LSE` once API key is available
 - **feat-weinstein**: wire cached global index bars into strategy (currently passes `~global_index_bars:[]`)
 
 ---

--- a/dev/status/data-layer.md
+++ b/dev/status/data-layer.md
@@ -40,6 +40,6 @@ All four items from `docs/design/eng-design-data-management.md` are implemented 
 
 - **Primary index bars** (`~index_bars`): EODHD symbols `GSPC.INDX` or `DJI.INDX`. `GSPCX` (cached at `data/G/X/GSPCX/`, daily from 1997) is a usable stand-in.
 - **NYSE A-D breadth** (`~ad_bars`): daily advancing/declining counts — not derivable from price bars. EODHD symbols likely `ADV.NYSE` / `DEC.NYSE`; verify. Requires a new parser (not OHLCV format).
-- **Global index bars** (`~global_index_bars`): FTSE 100 (`FTSE.INDX`), DAX (`GDAXI.INDX`), Nikkei 225 (`N225.INDX`). `IWM` (cached at `data/I/M/IWM/`) usable as interim US small-cap proxy.
+- **Global index bars** (`~global_index_bars`): FTSE 100 via `ISF.LSE` (iShares ETF proxy — EODHD does not carry `FTSE.INDX`), DAX (`GDAXI.INDX`), Nikkei 225 (`N225.INDX`). `IWM` (cached at `data/I/M/IWM/`) usable as interim US small-cap proxy.
 
 Until cached: call with `ad_bars:[]` and `global_index_bars:[]`; analyzer degrades gracefully.

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -1,9 +1,15 @@
 # Status: harness
 
-## Last updated: 2026-04-09
+## Last updated: 2026-04-12
 
 ## Status
 IN_PROGRESS
+
+## CI
+
+- CI is now live (#270, #271) — `dune build && dune runtest && dune build @fmt` gates on every PR
+- Weekly deps-freshness workflow added
+- `test_data/` fixtures committed for CI reproducibility
 
 ## Design doc
 `docs/design/harness-engineering-plan.md`

--- a/dev/status/simulation.md
+++ b/dev/status/simulation.md
@@ -1,9 +1,9 @@
 # Status: simulation
 
-## Last updated: 2026-04-10
+## Last updated: 2026-04-12
 
 ## Status
-READY_FOR_REVIEW
+MERGED
 
 ## QC
 overall_qc: APPROVED (Slice 1 + Slice 3)
@@ -44,14 +44,16 @@ The Weinstein work in eng-design-4 adds Weinstein-specific components **on top**
 - **Simulation date** — `_make_entry_transition` uses current bar's date instead of `Date.today`.
 - **Smoke test extended** — `hist_start` moved to 2022-01-01 (100+ weekly bars warmup). Added `portfolio_value > 0` assertion.
 
-### Slice 3 (2026-04-10)
+### Slice 3 (2026-04-10) — merged (#246)
 
 - **Prior stage accumulation** — per-symbol `prior_stages` Hashtbl in the `make` closure. `Stage.classify` and `Stock_analysis.analyze` now receive accumulated prior stage instead of `None`. Enables accurate Stage1→Stage2 transition detection in `is_breakout_candidate`.
 - **Index prior stage** — `Macro.analyze` receives accumulated index prior stage instead of `None`.
 - **Breakout smoke test** — new test using `Breakout` synthetic pattern (40 weeks basing, 8x breakout volume, 1-year sim from data start). Asserts: orders submitted, trades executed, positive portfolio value. Full screener→order→trade pipeline verified end-to-end.
 
+All slices merged: Slice 1 (#196), Slice 2 (#237, #240, #241, #242), Slice 3 (#246).
+
 ## In Progress
-- None
+- M5 (walk-forward backtest, parameter tuner) is next
 
 ## Blocking Refactors
 - None

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.ml
@@ -15,6 +15,10 @@ let spdr_sector_etfs =
     ("XLC", "Communication Services");
   ]
 
+(* ISF.LSE (iShares Core FTSE UCITS ETF) proxies the UK large-cap index
+   because EODHD does not carry FTSE.INDX or UKX.INDX. Physical-replication
+   tracker with ~bps tracking error — functionally indistinguishable from the
+   index at weekly cadence. See dev/ops/2026-04-10-data-fetch.md. *)
 let default_global_indices =
   [ ("GDAXI.INDX", "DAX"); ("N225.INDX", "Nikkei"); ("ISF.LSE", "FTSE") ]
 

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.mli
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.mli
@@ -17,7 +17,12 @@ val spdr_sector_etfs : (string * string) list
 val default_global_indices : (string * string) list
 (** Major non-US equity indices used by the macro global-consensus indicator.
     [GSPC.INDX] (the US benchmark) is intentionally omitted — it is already
-    passed to {!Macro.analyze} as [~index_bars]. *)
+    passed to {!Macro.analyze} as [~index_bars].
+
+    Note: FTSE 100 is represented by [ISF.LSE] (iShares Core FTSE 100 UCITS ETF)
+    because EODHD does not carry [FTSE.INDX] or [UKX.INDX]. The ETF is a
+    physical-replication tracker with negligible tracking error at weekly
+    cadence. *)
 
 val build_global_index_bars :
   lookback_bars:int ->


### PR DESCRIPTION
## Summary

- Update `dev/status/simulation.md`: READY_FOR_REVIEW → MERGED, all slices landed
- Update `dev/status/harness.md`: note CI is live (#270/#271), deps workflow, test_data fixtures
- Update `dev/status/data-layer.md` + `data-gaps.md`: fix stale FTSE.INDX references → ISF.LSE
- Document the ISF.LSE proxy in `macro_inputs.ml{,i}` (code already used ISF.LSE, just added the explanation)

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` pass
- [x] No source logic changes — markdown + comments only