### PR TITLE
fix: spread breakout volume across 3 days + add position-level assertions

### DIFF
--- a/trading/analysis/weinstein/data_source/testing/lib/synthetic_source.ml
+++ b/trading/analysis/weinstein/data_source/testing/lib/synthetic_source.ml
@@ -131,7 +131,8 @@ let _next_start_after bars fallback =
 let _breakout_spike_days = 3
 
 (** Apply the breakout volume multiplier to the first [_breakout_spike_days]
-    bars in [bars], so the weekly aggregate retains a meaningful volume ratio. *)
+    bars in [bars], so the weekly aggregate retains a meaningful volume ratio.
+*)
 let _mark_breakout_bars base_volume breakout_volume_mult bars =
   let vol = Float.to_int (Float.of_int base_volume *. breakout_volume_mult) in
   List.mapi bars ~f:(fun i bar ->

--- a/trading/analysis/weinstein/data_source/testing/lib/synthetic_source.ml
+++ b/trading/analysis/weinstein/data_source/testing/lib/synthetic_source.ml
@@ -124,15 +124,20 @@ let _next_start_after bars fallback =
   | Some b -> _next_weekday b.Types.Daily_price.date
   | None -> fallback
 
-(** Apply the breakout volume multiplier to the first bar in [bars]. *)
-let _mark_breakout_bar base_volume breakout_volume_mult bars =
-  match bars with
-  | [] -> []
-  | first :: rest ->
-      let vol =
-        Float.to_int (Float.of_int base_volume *. breakout_volume_mult)
-      in
-      { first with Types.Daily_price.volume = vol } :: rest
+(* Number of trading days in the breakout week that receive elevated volume.
+   Spreading the spike across 3 of 5 days avoids dilution when daily bars are
+   summed into weekly bars: 3 × mult + 2 × base gives a realistic weekly ratio
+   (e.g. mult=3 → weekly ratio ≈ 2.2×). *)
+let _breakout_spike_days = 3
+
+(** Apply the breakout volume multiplier to the first [_breakout_spike_days]
+    bars in [bars], so the weekly aggregate retains a meaningful volume ratio. *)
+let _mark_breakout_bars base_volume breakout_volume_mult bars =
+  let vol = Float.to_int (Float.of_int base_volume *. breakout_volume_mult) in
+  List.mapi bars ~f:(fun i bar ->
+      if i < _breakout_spike_days then
+        { bar with Types.Daily_price.volume = vol }
+      else bar)
 
 let _gen_breakout ~start_date ~base_price ~base_weeks ~weekly_gain_pct
     ~breakout_volume_mult ~base_volume ~n =
@@ -149,7 +154,7 @@ let _gen_breakout ~start_date ~base_price ~base_weeks ~weekly_gain_pct
       _gen_trending ~start_date:trending_start
         ~start_price:(base_price *. _breakout_start_factor)
         ~weekly_gain_pct ~volume:base_volume ~n:remaining
-      |> _mark_breakout_bar base_volume breakout_volume_mult
+      |> _mark_breakout_bars base_volume breakout_volume_mult
     in
     basing_bars @ trending_bars
 

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml
@@ -310,7 +310,7 @@ let test_weinstein_breakout_trade _ =
                       base_price = 150.0;
                       base_weeks = 40;
                       weekly_gain_pct = 0.02;
-                      breakout_volume_mult = 8.0;
+                      breakout_volume_mult = 3.0;
                       base_volume = 50_000_000;
                     } );
                 ( "GSPCX",
@@ -436,7 +436,7 @@ let test_weinstein_bearish_index_suppresses_entries _ =
                       base_price = 150.0;
                       base_weeks = 40;
                       weekly_gain_pct = 0.02;
-                      breakout_volume_mult = 8.0;
+                      breakout_volume_mult = 3.0;
                       base_volume = 50_000_000;
                     } );
                 ( "GSPCX",

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml
@@ -396,7 +396,19 @@ let test_weinstein_breakout_trade _ =
          through continued 2%/wk trend for the remainder of the year). *)
       let final_value = (List.last_exn result.steps).portfolio_value in
       assert_that final_value
-        (is_between (module Float_ord) ~low:125_000.0 ~high:128_000.0))
+        (is_between (module Float_ord) ~low:125_000.0 ~high:128_000.0);
+      (* Verify the final portfolio holds an AAPL position. *)
+      let final_portfolio = (List.last_exn result.steps).portfolio in
+      let aapl_position =
+        List.find final_portfolio.Trading_portfolio.Portfolio.positions
+          ~f:(fun p -> String.equal p.Trading_portfolio.Types.symbol "AAPL")
+      in
+      assert_that aapl_position
+        (is_some_and
+           (field (fun p -> p.Trading_portfolio.Types.lots) (not_ is_empty)));
+      (* Portfolio value exceeds initial cash — positive PnL from the
+         rising breakout trend. *)
+      assert_that final_value (gt (module Float_ord) 100_000.0))
 
 (* ------------------------------------------------------------------ *)
 (* Decision test: bearish macro suppresses entries                      *)


### PR DESCRIPTION
## Summary

Two simulation follow-ups from `dev/status/simulation.md`:

### Volume dilution fix
A single high-volume daily breakout bar was getting averaged with 4 normal-volume bars in the weekly sum, requiring unrealistic 8x `breakout_volume_mult` to hit the 2x weekly "Strong" threshold.

Fix: `_mark_breakout_bars` now applies elevated volume to the first 3 days of the breakout week. With mult=3x and 3 elevated days: weekly ratio = (3×3 + 2) / 5 = 2.2x, comfortably above 2.0. Smoke tests updated from 8x → 3x.

### Position-level assertions
The breakout smoke test confirmed trades execute but didn't verify position contents. Added:
- Assert final portfolio contains an AAPL position with non-empty lots
- Assert portfolio value > initial cash ($100k), confirming positive PnL from the breakout trend

## Files changed
- `synthetic_source.ml`: `_mark_breakout_bars` spreads volume spike across 3 days
- `test_weinstein_strategy_smoke.ml`: lower mult 8→3, add position + PnL assertions

## Test plan
- [x] `dune build` clean
- [x] `dune runtest` all pass
- [x] `dune fmt` clean