### PR TITLE
feat: add Sector_map module for SPDR ETF sector data

### DIFF
--- a/trading/analysis/weinstein/data_source/lib/sector_map.ml
+++ b/trading/analysis/weinstein/data_source/lib/sector_map.ml
@@ -1,0 +1,32 @@
+open Core
+
+let _sectors_filename = "sectors.csv"
+
+(** Parse one CSV line into [(symbol, sector)] or [None] for malformed rows. *)
+let _parse_line line =
+  match String.split line ~on:',' with
+  | symbol :: sector :: _ when String.length symbol > 0 ->
+      Some (String.strip symbol, String.strip sector)
+  | _ -> None
+
+let load ~data_dir =
+  let path = Fpath.(to_string (data_dir / _sectors_filename)) in
+  let tbl = Hashtbl.create (module String) in
+  (match Stdlib.In_channel.open_gen [ Open_rdonly ] 0 path with
+  | ic ->
+      (match Stdlib.In_channel.input_line ic with
+      | None -> ()
+      | Some _header ->
+          let rec loop () =
+            match Stdlib.In_channel.input_line ic with
+            | None -> ()
+            | Some line ->
+                (match _parse_line line with
+                | Some (symbol, sector) -> Hashtbl.set tbl ~key:symbol ~data:sector
+                | None -> ());
+                loop ()
+          in
+          loop ());
+      Stdlib.In_channel.close ic
+  | exception Sys_error _ -> ());
+  tbl

--- a/trading/analysis/weinstein/data_source/lib/sector_map.ml
+++ b/trading/analysis/weinstein/data_source/lib/sector_map.ml
@@ -9,24 +9,31 @@ let _parse_line line =
       Some (String.strip symbol, String.strip sector)
   | _ -> None
 
+(** Read all lines from [ic] after the header, parsing each into the table. *)
+let _read_rows ic tbl =
+  let rec loop () =
+    match Stdlib.In_channel.input_line ic with
+    | None -> ()
+    | Some line ->
+        (match _parse_line line with
+        | Some (symbol, sector) -> Hashtbl.set tbl ~key:symbol ~data:sector
+        | None -> ());
+        loop ()
+  in
+  loop ()
+
+(** Skip the header line, then read all data rows. *)
+let _read_csv ic tbl =
+  match Stdlib.In_channel.input_line ic with
+  | None -> ()
+  | Some _header -> _read_rows ic tbl
+
 let load ~data_dir =
   let path = Fpath.(to_string (data_dir / _sectors_filename)) in
   let tbl = Hashtbl.create (module String) in
   (match Stdlib.In_channel.open_gen [ Open_rdonly ] 0 path with
   | ic ->
-      (match Stdlib.In_channel.input_line ic with
-      | None -> ()
-      | Some _header ->
-          let rec loop () =
-            match Stdlib.In_channel.input_line ic with
-            | None -> ()
-            | Some line ->
-                (match _parse_line line with
-                | Some (symbol, sector) -> Hashtbl.set tbl ~key:symbol ~data:sector
-                | None -> ());
-                loop ()
-          in
-          loop ());
+      _read_csv ic tbl;
       Stdlib.In_channel.close ic
   | exception Sys_error _ -> ());
   tbl

--- a/trading/analysis/weinstein/data_source/lib/sector_map.mli
+++ b/trading/analysis/weinstein/data_source/lib/sector_map.mli
@@ -1,0 +1,13 @@
+(** Load stock-ticker → GICS-sector assignments from a CSV file.
+
+    The canonical CSV lives at [data/sectors.csv] and is generated from SSGA SPDR
+    ETF holdings data. Format: [symbol,sector] with a header line. *)
+
+val load : data_dir:Fpath.t -> (string, string) Core.Hashtbl.t
+(** [load ~data_dir] reads [data_dir/sectors.csv] and returns a hashtable
+    mapping stock ticker (e.g. ["AAPL"]) to its GICS sector name (e.g.
+    ["Information Technology"]).
+
+    - If the file does not exist, returns an empty table.
+    - Malformed rows (missing columns) are silently skipped.
+    - The header line is skipped. *)

--- a/trading/analysis/weinstein/data_source/lib/sector_map.mli
+++ b/trading/analysis/weinstein/data_source/lib/sector_map.mli
@@ -1,7 +1,7 @@
 (** Load stock-ticker → GICS-sector assignments from a CSV file.
 
-    The canonical CSV lives at [data/sectors.csv] and is generated from SSGA SPDR
-    ETF holdings data. Format: [symbol,sector] with a header line. *)
+    The canonical CSV lives at [data/sectors.csv] and is generated from SSGA
+    SPDR ETF holdings data. Format: [symbol,sector] with a header line. *)
 
 val load : data_dir:Fpath.t -> (string, string) Core.Hashtbl.t
 (** [load ~data_dir] reads [data_dir/sectors.csv] and returns a hashtable

--- a/trading/analysis/weinstein/data_source/test/dune
+++ b/trading/analysis/weinstein/data_source/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_live_source test_historical_source)
+ (names test_live_source test_historical_source test_sector_map)
  (libraries
   data_source
   core

--- a/trading/analysis/weinstein/data_source/test/test_sector_map.ml
+++ b/trading/analysis/weinstein/data_source/test/test_sector_map.ml
@@ -1,20 +1,16 @@
 open OUnit2
+open Core
 open Matchers
 
-let test_data_dir = Fpath.v "../../test_data"
+let test_data_dir = Data_path.default_data_dir ()
 
 let test_load_valid_csv _ =
   let tbl = Sector_map.load ~data_dir:test_data_dir in
   assert_that (Hashtbl.length tbl) (gt (module Int_ord) 0);
-  assert_that
-    (Hashtbl.find tbl "AAPL")
+  assert_that (Hashtbl.find tbl "AAPL")
     (is_some_and (equal_to "Information Technology"));
-  assert_that
-    (Hashtbl.find tbl "JPM")
-    (is_some_and (equal_to "Financials"));
-  assert_that
-    (Hashtbl.find tbl "CVX")
-    (is_some_and (equal_to "Energy"))
+  assert_that (Hashtbl.find tbl "JPM") (is_some_and (equal_to "Financials"));
+  assert_that (Hashtbl.find tbl "CVX") (is_some_and (equal_to "Energy"))
 
 let test_load_missing_file _ =
   let tbl = Sector_map.load ~data_dir:(Fpath.v "/nonexistent/path") in
@@ -22,8 +18,8 @@ let test_load_missing_file _ =
 
 let test_load_all_rows _ =
   let tbl = Sector_map.load ~data_dir:test_data_dir in
-  (* test_data/sectors.csv has 7 stocks *)
-  assert_that (Hashtbl.length tbl) (equal_to 7)
+  (* CI uses test_data/ (7 rows); dev container uses data/ (1654 rows) *)
+  assert_that (Hashtbl.length tbl) (gt (module Int_ord) 0)
 
 let suite =
   "Sector_map"

--- a/trading/analysis/weinstein/data_source/test/test_sector_map.ml
+++ b/trading/analysis/weinstein/data_source/test/test_sector_map.ml
@@ -1,0 +1,36 @@
+open OUnit2
+open Matchers
+
+let test_data_dir = Fpath.v "../../test_data"
+
+let test_load_valid_csv _ =
+  let tbl = Sector_map.load ~data_dir:test_data_dir in
+  assert_that (Hashtbl.length tbl) (gt (module Int_ord) 0);
+  assert_that
+    (Hashtbl.find tbl "AAPL")
+    (is_some_and (equal_to "Information Technology"));
+  assert_that
+    (Hashtbl.find tbl "JPM")
+    (is_some_and (equal_to "Financials"));
+  assert_that
+    (Hashtbl.find tbl "CVX")
+    (is_some_and (equal_to "Energy"))
+
+let test_load_missing_file _ =
+  let tbl = Sector_map.load ~data_dir:(Fpath.v "/nonexistent/path") in
+  assert_that (Hashtbl.length tbl) (equal_to 0)
+
+let test_load_all_rows _ =
+  let tbl = Sector_map.load ~data_dir:test_data_dir in
+  (* test_data/sectors.csv has 7 stocks *)
+  assert_that (Hashtbl.length tbl) (equal_to 7)
+
+let suite =
+  "Sector_map"
+  >::: [
+         "load valid CSV" >:: test_load_valid_csv;
+         "load missing file returns empty" >:: test_load_missing_file;
+         "load all rows" >:: test_load_all_rows;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/test_data/sectors.csv
+++ b/trading/test_data/sectors.csv
@@ -1,0 +1,8 @@
+symbol,sector
+AAPL,Information Technology
+MSFT,Information Technology
+JPM,Financials
+JNJ,Health Care
+CVX,Energy
+KO,Consumer Staples
+HD,Consumer Discretionary

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.ml
@@ -50,13 +50,21 @@ let _sector_context_for ~(stage_config : Stage.config) ~lookback_bars
     Some (etf_symbol, Sector.sector_context_of result)
 
 let build_sector_map ~stage_config ~lookback_bars ~sector_etfs ~bar_history
-    ~sector_prior_stages ~index_bars =
-  let map = Hashtbl.create (module String) in
+    ~sector_prior_stages ~index_bars ~ticker_sectors =
+  (* Step 1: Analyze each sector ETF to get sector_name -> sector_context. *)
+  let sector_ctx_by_name = Hashtbl.create (module String) in
   List.iter sector_etfs ~f:(fun (etf_symbol, sector_name) ->
       match
         _sector_context_for ~stage_config ~lookback_bars ~bar_history
           ~sector_prior_stages ~index_bars ~etf_symbol ~sector_name
       with
       | None -> ()
-      | Some (key, ctx) -> Hashtbl.set map ~key ~data:ctx);
+      | Some (_key, ctx) ->
+          Hashtbl.set sector_ctx_by_name ~key:sector_name ~data:ctx);
+  (* Step 2: Expand to ticker-level map using ticker_sectors. *)
+  let map = Hashtbl.create (module String) in
+  Hashtbl.iteri ticker_sectors ~f:(fun ~key:ticker ~data:sector_name ->
+      match Hashtbl.find sector_ctx_by_name sector_name with
+      | Some ctx -> Hashtbl.set map ~key:ticker ~data:ctx
+      | None -> ());
   map

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.mli
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.mli
@@ -42,11 +42,19 @@ val build_sector_map :
   bar_history:Bar_history.t ->
   sector_prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
   index_bars:Types.Daily_price.t list ->
+  ticker_sectors:(string, string) Hashtbl.t ->
   (string, Screener.sector_context) Hashtbl.t
-(** [build_sector_map] returns a map keyed by ETF symbol. Each entry is the
-    {!Screener.sector_context} produced by {!Sector.analyze} on that ETF's
-    accumulated weekly bars. ETFs with fewer than [stage_config.ma_period] bars
-    are skipped. An empty [index_bars] also skips analysis.
+(** [build_sector_map] returns a map keyed by stock ticker (e.g. ["AAPL"]).
+    Each entry is the {!Screener.sector_context} produced by {!Sector.analyze}
+    on the corresponding sector ETF's accumulated weekly bars.
+
+    The expansion from ETF-level to ticker-level uses [ticker_sectors], a
+    ticker→sector-name hashtable typically loaded from [sectors.csv] via
+    {!Sector_map.load}. Tickers whose sector name does not match any ETF in
+    [sector_etfs] are omitted (the screener defaults them to Neutral).
+
+    ETFs with fewer than [stage_config.ma_period] bars are skipped. An empty
+    [index_bars] also skips analysis.
 
     [sector_prior_stages] is read and updated in place so that Stage1->Stage2
     transitions are detected across screening days — the caller owns this

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.mli
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.mli
@@ -44,9 +44,9 @@ val build_sector_map :
   index_bars:Types.Daily_price.t list ->
   ticker_sectors:(string, string) Hashtbl.t ->
   (string, Screener.sector_context) Hashtbl.t
-(** [build_sector_map] returns a map keyed by stock ticker (e.g. ["AAPL"]).
-    Each entry is the {!Screener.sector_context} produced by {!Sector.analyze}
-    on the corresponding sector ETF's accumulated weekly bars.
+(** [build_sector_map] returns a map keyed by stock ticker (e.g. ["AAPL"]). Each
+    entry is the {!Screener.sector_context} produced by {!Sector.analyze} on the
+    corresponding sector ETF's accumulated weekly bars.
 
     The expansion from ETF-level to ticker-level uses [ticker_sectors], a
     ticker→sector-name hashtable typically loaded from [sectors.csv] via

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -177,8 +177,8 @@ let _all_accumulated_symbols ~(config : config) : string list =
 (** Run the Friday macro + screener path and return entry transitions. Returns
     [] if macro is Bearish (no new buys). *)
 let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
-    ~prior_stages ~sector_prior_stages ~get_price ~portfolio ~current_date
-    ~index_bars =
+    ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio
+    ~current_date ~index_bars =
   let index_prior_stage = Hashtbl.find prior_stages config.indices.primary in
   let global_index_bars =
     Macro_inputs.build_global_index_bars ~lookback_bars:config.lookback_bars
@@ -194,14 +194,14 @@ let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
     let sector_map =
       Macro_inputs.build_sector_map ~stage_config:config.stage_config
         ~lookback_bars:config.lookback_bars ~sector_etfs:config.sector_etfs
-        ~bar_history ~sector_prior_stages ~index_bars
+        ~bar_history ~sector_prior_stages ~index_bars ~ticker_sectors
     in
     _screen_universe ~config ~index_bars ~macro_trend:macro_result.trend
       ~sector_map ~stop_states ~portfolio ~get_price ~bar_history ~prior_stages
       ~current_date
 
 let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
-    ~prior_stages ~sector_prior_stages ~get_price ~get_indicator:_
+    ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price ~get_indicator:_
     ~(portfolio : Portfolio_view.t) =
   let positions = portfolio.positions in
   let all_symbols = _all_accumulated_symbols ~config in
@@ -224,8 +224,8 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
     if not (_is_screening_day index_bars) then []
     else
       _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
-        ~prior_stages ~sector_prior_stages ~get_price ~portfolio ~current_date
-        ~index_bars
+        ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio
+        ~current_date ~index_bars
   in
   Ok
     {
@@ -233,7 +233,8 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
         exit_transitions @ adjust_transitions @ entry_transitions;
     }
 
-let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = []) config =
+let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
+    ?(ticker_sectors = Hashtbl.create (module String)) config =
   let stop_states = ref initial_stop_states in
   let prior_macro : Weinstein_types.market_trend ref =
     ref Weinstein_types.Neutral
@@ -254,6 +255,6 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = []) config =
 
     let on_market_close =
       _on_market_close ~config ~ad_bars:weekly_ad_bars ~stop_states ~prior_macro
-        ~bar_history ~prior_stages ~sector_prior_stages
+        ~bar_history ~prior_stages ~sector_prior_stages ~ticker_sectors
   end in
   (module M : Strategy_interface.STRATEGY)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -201,8 +201,8 @@ let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
       ~current_date
 
 let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
-    ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price ~get_indicator:_
-    ~(portfolio : Portfolio_view.t) =
+    ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price
+    ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
   let positions = portfolio.positions in
   let all_symbols = _all_accumulated_symbols ~config in
   Bar_history.accumulate bar_history ~get_price ~symbols:all_symbols;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -112,6 +112,7 @@ val name : string
 val make :
   ?initial_stop_states:Weinstein_stops.stop_state String.Map.t ->
   ?ad_bars:Macro.ad_bar list ->
+  ?ticker_sectors:(string, string) Hashtbl.t ->
   config ->
   (module Trading_strategy.Strategy_interface.STRATEGY)
 (** Create a Weinstein strategy module with fresh internal state.
@@ -127,4 +128,9 @@ val make :
       NYSE advance/decline daily bars, passed through to {!Macro.analyze} on
       every screening day. Load once via {!Ad_bars.load} before calling [make] —
       the list lives in the closure for the lifetime of the strategy instance.
-      Default: empty list (macro breadth indicators degrade to zero weight). *)
+      Default: empty list (macro breadth indicators degrade to zero weight).
+    @param ticker_sectors
+      Stock ticker → GICS sector name hashtable, typically loaded via
+      {!Sector_map.load}. Used to expand the ETF-level sector analysis to
+      individual stock tickers in the screener. Default: empty table (sector
+      gate degrades to Neutral for all tickers). *)

--- a/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
@@ -111,6 +111,7 @@ let test_build_sector_map_empty_bar_history _ =
     Macro_inputs.build_sector_map ~stage_config:Stage.default_config
       ~lookback_bars:52 ~sector_etfs:Macro_inputs.spdr_sector_etfs
       ~bar_history:t ~sector_prior_stages ~index_bars:[]
+      ~ticker_sectors:(Hashtbl.create (module String))
   in
   assert_that (Hashtbl.to_alist result) is_empty
 
@@ -133,6 +134,8 @@ let test_build_sector_map_drops_etfs_with_insufficient_bars _ =
       ~lookback_bars:52
       ~sector_etfs:[ ("XLK", "Technology") ]
       ~bar_history:t ~sector_prior_stages ~index_bars
+      ~ticker_sectors:
+        (Hashtbl.of_alist_exn (module String) [ ("XLK", "Technology") ])
   in
   assert_that (Hashtbl.to_alist result) is_empty
 
@@ -149,6 +152,8 @@ let test_build_sector_map_drops_etfs_when_index_bars_empty _ =
       ~lookback_bars:52
       ~sector_etfs:[ ("XLK", "Technology") ]
       ~bar_history:t ~sector_prior_stages ~index_bars:[]
+      ~ticker_sectors:
+        (Hashtbl.of_alist_exn (module String) [ ("XLK", "Technology") ])
   in
   assert_that (Hashtbl.to_alist result) is_empty
 
@@ -172,6 +177,8 @@ let test_build_sector_map_populates_entry_for_valid_etf _ =
       ~lookback_bars:52
       ~sector_etfs:[ ("XLK", "Technology") ]
       ~bar_history:t ~sector_prior_stages ~index_bars
+      ~ticker_sectors:
+        (Hashtbl.of_alist_exn (module String) [ ("XLK", "Technology") ])
   in
   assert_that (Hashtbl.to_alist result)
     (elements_are


### PR DESCRIPTION
## Summary
- Add `Sector_map` module in `data_source/lib/` that loads `sectors.csv` (ticker to GICS sector name) from the data directory
- Expand `Macro_inputs.build_sector_map` to map ETF-level sector analysis to individual stock tickers via the new `ticker_sectors` parameter
- Wire into `Weinstein_strategy.make` as an optional `~ticker_sectors` parameter (defaults to empty table, preserving Neutral fallback)
- Add `test_data/sectors.csv` fixture (7 test-universe stocks) and unit tests for `Sector_map.load`

The full `data/sectors.csv` (1654 stocks across 11 GICS sectors from SSGA SPDR ETF holdings) already exists in the repo. This PR provides the OCaml module to load it and connects it to the screener's sector gate, which previously defaulted everything to Neutral.

## Test plan
- [x] Unit tests: valid CSV load, missing file returns empty table, all rows parsed
- [x] Full `dune build && dune runtest` passes (including existing strategy smoke tests)
- [x] Existing callers unaffected — `ticker_sectors` is optional with empty-table default