### PR TITLE
feat: add gics_sector enum and normalize sector names

### DIFF
--- a/trading/analysis/weinstein/data_source/test/dune
+++ b/trading/analysis/weinstein/data_source/test/dune
@@ -7,6 +7,7 @@
   async_unix
   ounit2
   types
+  weinstein.types
   csv
   file.sexp
   core_unix

--- a/trading/analysis/weinstein/data_source/test/test_sector_map.ml
+++ b/trading/analysis/weinstein/data_source/test/test_sector_map.ml
@@ -21,12 +21,26 @@ let test_load_all_rows _ =
   (* CI uses test_data/ (7 rows); dev container uses data/ (1654 rows) *)
   assert_that (Hashtbl.length tbl) (gt (module Int_ord) 0)
 
+(* Every sector name in the CSV must be a recognized GICS sector. This catches
+   drift between the CSV data and the canonical enum. *)
+let test_all_sector_names_are_valid_gics _ =
+  let tbl = Sector_map.load ~data_dir:test_data_dir in
+  let invalid =
+    Hashtbl.fold tbl ~init:[] ~f:(fun ~key:ticker ~data:sector_name acc ->
+        match Weinstein_types.gics_sector_of_string_opt sector_name with
+        | Some _ -> acc
+        | None -> (ticker, sector_name) :: acc)
+  in
+  assert_that invalid is_empty
+
 let suite =
   "Sector_map"
   >::: [
          "load valid CSV" >:: test_load_valid_csv;
          "load missing file returns empty" >:: test_load_missing_file;
          "load all rows" >:: test_load_all_rows;
+         "all sector names are valid GICS"
+         >:: test_all_sector_names_are_valid_gics;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/analysis/weinstein/types/lib/weinstein_types.ml
+++ b/trading/analysis/weinstein/types/lib/weinstein_types.ml
@@ -29,6 +29,65 @@ type volume_confirmation = Strong of float | Adequate of float | Weak of float
 [@@deriving show, eq, sexp]
 
 type market_trend = Bullish | Bearish | Neutral [@@deriving show, eq, sexp]
+
+(** The 11 GICS sectors used by S&P/MSCI classification. *)
+type gics_sector =
+  | Information_technology
+  | Financials
+  | Health_care
+  | Energy
+  | Industrials
+  | Consumer_staples
+  | Consumer_discretionary
+  | Utilities
+  | Materials
+  | Real_estate
+  | Communication_services
+[@@deriving show, eq, ord, sexp]
+
+let all_gics_sectors =
+  [
+    Information_technology;
+    Financials;
+    Health_care;
+    Energy;
+    Industrials;
+    Consumer_staples;
+    Consumer_discretionary;
+    Utilities;
+    Materials;
+    Real_estate;
+    Communication_services;
+  ]
+
+let gics_sector_to_string = function
+  | Information_technology -> "Information Technology"
+  | Financials -> "Financials"
+  | Health_care -> "Health Care"
+  | Energy -> "Energy"
+  | Industrials -> "Industrials"
+  | Consumer_staples -> "Consumer Staples"
+  | Consumer_discretionary -> "Consumer Discretionary"
+  | Utilities -> "Utilities"
+  | Materials -> "Materials"
+  | Real_estate -> "Real Estate"
+  | Communication_services -> "Communication Services"
+
+let gics_sector_of_string_opt s =
+  match String.lowercase s with
+  | "information technology" -> Some Information_technology
+  | "financials" -> Some Financials
+  | "health care" -> Some Health_care
+  | "energy" -> Some Energy
+  | "industrials" -> Some Industrials
+  | "consumer staples" -> Some Consumer_staples
+  | "consumer discretionary" -> Some Consumer_discretionary
+  | "utilities" -> Some Utilities
+  | "materials" -> Some Materials
+  | "real estate" -> Some Real_estate
+  | "communication services" -> Some Communication_services
+  | _ -> None
+
 type grade = A_plus | A | B | C | D | F [@@deriving show, eq, ord, sexp]
 
 let grade_to_string = function

--- a/trading/analysis/weinstein/types/lib/weinstein_types.mli
+++ b/trading/analysis/weinstein/types/lib/weinstein_types.mli
@@ -79,3 +79,33 @@ type grade = A_plus | A | B | C | D | F [@@deriving show, eq, ord, sexp]
 
 val grade_to_string : grade -> string
 (** Convert grade to a human-readable string (e.g. [A_plus] → ["A+"]). *)
+
+(** {1 GICS Sectors} *)
+
+(** The 11 GICS (Global Industry Classification Standard) sectors used by
+    S&P/MSCI. These are the canonical sector names used throughout the system —
+    in [sectors.csv], in the SPDR sector ETF mapping, and in screener output. *)
+type gics_sector =
+  | Information_technology
+  | Financials
+  | Health_care
+  | Energy
+  | Industrials
+  | Consumer_staples
+  | Consumer_discretionary
+  | Utilities
+  | Materials
+  | Real_estate
+  | Communication_services
+[@@deriving show, eq, ord, sexp]
+
+val all_gics_sectors : gics_sector list
+(** All 11 GICS sectors in standard order. *)
+
+val gics_sector_to_string : gics_sector -> string
+(** Canonical display name (e.g. [Information_technology] →
+    ["Information Technology"]). *)
+
+val gics_sector_of_string_opt : string -> gics_sector option
+(** Parse a sector name (case-insensitive). Returns [None] for unrecognized
+    names. *)

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.ml
@@ -2,7 +2,7 @@ open Core
 
 let spdr_sector_etfs =
   [
-    ("XLK", "Technology");
+    ("XLK", "Information Technology");
     ("XLF", "Financials");
     ("XLE", "Energy");
     ("XLV", "Health Care");

--- a/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
@@ -49,7 +49,7 @@ let test_spdr_sector_etfs_is_canonical_11_sector_list _ =
   assert_that Macro_inputs.spdr_sector_etfs
     (equal_to
        [
-         ("XLK", "Technology");
+         ("XLK", "Information Technology");
          ("XLF", "Financials");
          ("XLE", "Energy");
          ("XLV", "Health Care");
@@ -61,6 +61,15 @@ let test_spdr_sector_etfs_is_canonical_11_sector_list _ =
          ("XLRE", "Real Estate");
          ("XLC", "Communication Services");
        ])
+
+(* Every sector label in spdr_sector_etfs must parse to a valid gics_sector.
+   This catches mismatches like "Technology" vs "Information Technology". *)
+let test_spdr_sector_etfs_names_are_valid_gics _ =
+  let invalid =
+    List.filter Macro_inputs.spdr_sector_etfs ~f:(fun (_, name) ->
+        Option.is_none (Weinstein_types.gics_sector_of_string_opt name))
+  in
+  assert_that invalid is_empty
 
 let test_default_global_indices_is_canonical_triple _ =
   (* GSPC.INDX is intentionally excluded — it is passed to Macro.analyze as
@@ -132,10 +141,12 @@ let test_build_sector_map_drops_etfs_with_insufficient_bars _ =
   let result =
     Macro_inputs.build_sector_map ~stage_config:Stage.default_config
       ~lookback_bars:52
-      ~sector_etfs:[ ("XLK", "Technology") ]
+      ~sector_etfs:[ ("XLK", "Information Technology") ]
       ~bar_history:t ~sector_prior_stages ~index_bars
       ~ticker_sectors:
-        (Hashtbl.of_alist_exn (module String) [ ("XLK", "Technology") ])
+        (Hashtbl.of_alist_exn
+           (module String)
+           [ ("XLK", "Information Technology") ])
   in
   assert_that (Hashtbl.to_alist result) is_empty
 
@@ -150,10 +161,12 @@ let test_build_sector_map_drops_etfs_when_index_bars_empty _ =
   let result =
     Macro_inputs.build_sector_map ~stage_config:Stage.default_config
       ~lookback_bars:52
-      ~sector_etfs:[ ("XLK", "Technology") ]
+      ~sector_etfs:[ ("XLK", "Information Technology") ]
       ~bar_history:t ~sector_prior_stages ~index_bars:[]
       ~ticker_sectors:
-        (Hashtbl.of_alist_exn (module String) [ ("XLK", "Technology") ])
+        (Hashtbl.of_alist_exn
+           (module String)
+           [ ("XLK", "Information Technology") ])
   in
   assert_that (Hashtbl.to_alist result) is_empty
 
@@ -175,10 +188,12 @@ let test_build_sector_map_populates_entry_for_valid_etf _ =
   let result =
     Macro_inputs.build_sector_map ~stage_config:Stage.default_config
       ~lookback_bars:52
-      ~sector_etfs:[ ("XLK", "Technology") ]
+      ~sector_etfs:[ ("XLK", "Information Technology") ]
       ~bar_history:t ~sector_prior_stages ~index_bars
       ~ticker_sectors:
-        (Hashtbl.of_alist_exn (module String) [ ("XLK", "Technology") ])
+        (Hashtbl.of_alist_exn
+           (module String)
+           [ ("XLK", "Information Technology") ])
   in
   assert_that (Hashtbl.to_alist result)
     (elements_are
@@ -188,7 +203,7 @@ let test_build_sector_map_populates_entry_for_valid_etf _ =
              field fst (equal_to "XLK");
              field
                (fun (_, (ctx : Screener.sector_context)) -> ctx.sector_name)
-               (equal_to "Technology");
+               (equal_to "Information Technology");
            ];
        ]);
   (* Sector_prior_stages was updated as a side effect so subsequent calls can
@@ -207,6 +222,8 @@ let () =
     >::: [
            "spdr_sector_etfs is the canonical 11-sector list"
            >:: test_spdr_sector_etfs_is_canonical_11_sector_list;
+           "spdr_sector_etfs names are valid GICS"
+           >:: test_spdr_sector_etfs_names_are_valid_gics;
            "default_global_indices is the canonical triple"
            >:: test_default_global_indices_is_canonical_triple;
            "build_global_index_bars returns empty for empty bar history"


### PR DESCRIPTION
## Summary

- Add `gics_sector` variant type to `Weinstein_types` with all 11 GICS sectors, `to_string`/`of_string_opt` converters, and `all_gics_sectors` list
- Fix sector name mismatch: `spdr_sector_etfs` used `"Technology"` but `sectors.csv` uses the canonical GICS name `"Information Technology"` — now both use the canonical name
- Fix `XLK,Technology` entry in `data/sectors.csv` → `XLK,Information Technology`
- Add validation tests:
  - `test_all_sector_names_are_valid_gics` — every sector name in `sectors.csv` must parse to a valid `gics_sector`
  - `test_spdr_sector_etfs_names_are_valid_gics` — every sector label in `spdr_sector_etfs` must be a recognized GICS name

The `gics_sector` type is the source of truth for sector names. The CSV and ETF config both use `gics_sector_to_string` names, and tests catch any drift.

## Test plan
- [x] `dune build` passes
- [x] All existing tests pass (sector_map, macro_inputs, strategy smoke)
- [x] New validation tests catch invalid sector names
- [x] `dune fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)