### PR TITLE
refactor: migrate remaining tests to ppx_test_matcher

### DIFF
--- a/trading/devtools/ppx_test_matcher/lib/dune
+++ b/trading/devtools/ppx_test_matcher/lib/dune
@@ -1,5 +1,6 @@
 (library
  (name ppx_test_matcher)
+ (public_name ppx_test_matcher)
  (kind ppx_rewriter)
  (libraries ppxlib)
  (preprocess

--- a/trading/trading/simulation/test/dune
+++ b/trading/trading/simulation/test/dune
@@ -125,4 +125,6 @@
   weinstein_trading.strategy
   weinstein_trading.portfolio_risk
   ounit2
-  matchers))
+  matchers)
+ (preprocess
+  (pps ppx_test_matcher)))

--- a/trading/trading/simulation/test/test_weinstein_backtest.ml
+++ b/trading/trading/simulation/test/test_weinstein_backtest.ml
@@ -13,6 +13,16 @@ open Core
 open Matchers
 open Trading_simulation
 
+(* Re-declare summary_stats for exhaustive ppx-generated matcher. *)
+type stats = Trading_simulation.Metrics.summary_stats = {
+  total_pnl : float;
+  avg_holding_days : float;
+  win_count : int;
+  loss_count : int;
+  win_rate : float;
+}
+[@@deriving test_matcher]
+
 (* ------------------------------------------------------------------ *)
 (* Constants                                                            *)
 (* ------------------------------------------------------------------ *)
@@ -115,11 +125,8 @@ let test_six_year_full_lifecycle _ =
   assert_that (List.length round_trips) (equal_to 7);
   assert_that summary
     (is_some_and
-       (all_of
-          [
-            field (fun (s : Metrics.summary_stats) -> s.win_count) (equal_to 1);
-            field (fun (s : Metrics.summary_stats) -> s.loss_count) (equal_to 6);
-          ]));
+       (match_stats ~total_pnl:__ ~avg_holding_days:__ ~win_count:(equal_to 1)
+          ~loss_count:(equal_to 6) ~win_rate:__));
   (* Final value ~$495k on $500k start — small loss from conservative sizing *)
   assert_that final_value
     (is_between (module Float_ord) ~low:490_000.0 ~high:500_000.0);
@@ -155,14 +162,10 @@ let test_entry_exit_cycle_around_covid _ =
   assert_that (List.length round_trips) (equal_to 4);
   assert_that summary
     (is_some_and
-       (all_of
-          [
-            field (fun (s : Metrics.summary_stats) -> s.win_count) (equal_to 0);
-            field (fun (s : Metrics.summary_stats) -> s.loss_count) (equal_to 4);
-            field
-              (fun (s : Metrics.summary_stats) -> s.total_pnl)
-              (lt (module Float_ord) 0.0);
-          ]));
+       (match_stats
+          ~total_pnl:(lt (module Float_ord) 0.0)
+          ~avg_holding_days:__ ~win_count:(equal_to 0) ~loss_count:(equal_to 4)
+          ~win_rate:__));
   (* Final value ~$496k — losses are small due to conservative sizing *)
   assert_that final_value
     (is_between (module Float_ord) ~low:490_000.0 ~high:500_000.0);


### PR DESCRIPTION
## Summary
Migrate `field (fun r -> r.xxx)` patterns to exhaustive `[@@deriving test_matcher]` matchers. All fields explicitly matched or ignored with `__`.

## Test plan
- [x] `dune build && dune runtest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)