### PR TITLE
docs: expand backtest analysis with TODOs and book references

### DIFF
--- a/dev/backtest/analysis.md
+++ b/dev/backtest/analysis.md
@@ -14,28 +14,41 @@ Code version: main@origin at commit rqytmwpz (post #291 merge).
 Initial cash: $1,000,000. Commission: $0.01/share + $1.00 minimum.
 30-week warmup applied before each start date.
 
+**Note:** Results are not fully deterministic due to Hashtbl iteration ordering
+in strategy internals (PR #298). Metrics may vary slightly between runs.
+
 ## Key Findings
 
-### 1. Huge unrealized gains, negative trade P&L
-
-The most striking pattern: the portfolio gains massively (+27% to +305%) but
-closed trade P&L is negative in 2 of 3 scenarios. This means:
-- The strategy enters positions that appreciate significantly while held
-- But when it exits (via trailing stops), the exits happen at a loss
-- The system's value comes from **holding winners**, not from the trading itself
-
-This is consistent with Weinstein's methodology — trailing stops let winners
-run. But it means the exit mechanism (stops) is triggered too early on many
-trades, locking in small losses.
-
-### 2. 74% of trades held < 7 days (whipsaw)
+### 1. Stop-loss exits too early — 74% of trades held < 7 days
 
 **258 of 375 total trades** (across all scenarios) were held 0-1 days. This is
-the critical weakness. The strategy enters on a breakout signal, but the
-trailing stop fires almost immediately. This suggests:
-- Initial stop is too tight relative to normal volatility
-- Or the entry happens at a point where the stock immediately retraces
-- The `initial_stop_buffer` of 1.02 (2%) may be insufficient for daily noise
+the critical finding. The strategy enters on a breakout signal, but the
+trailing stop fires almost immediately on most positions.
+
+**Book reference (Ch. 6):** Weinstein's initial stop goes "below the significant
+support floor (prior correction low)" — which is typically 5-15% below entry.
+He also says "if stop requires >15% risk from entry, prefer other candidates."
+Our current `initial_stop_buffer` of 1.02 (2%) is much tighter than what the
+book prescribes.
+
+However, widening stops is not automatically better:
+- Wider stops mean larger individual losses when they trigger
+- The current 2% stop limits per-trade risk but causes frequent whipsaws
+- Need to test: does widening to 5-8% improve win rate enough to offset
+  the larger per-trade losses?
+- The book's approach (support-floor-based, not fixed %) may be the right
+  direction — stops should be based on chart structure, not arbitrary buffers
+
+### 2. Trade P&L negative but portfolio gains huge
+
+The portfolio gains massively (+27% to +305%) but closed trade P&L is negative
+in 2 of 3 scenarios. This means:
+- Positions that remain open at period end carry unrealized gains
+- The trading system (entry → stop → exit) nets negative when completed
+- The value comes from **holding winners** that haven't triggered stops yet
+
+This raises questions about sustainability — are the unrealized gains just
+timing luck (where we sample the portfolio) or a real edge?
 
 ### 3. P&L distribution: many small losses, few big wins
 
@@ -71,50 +84,105 @@ trend-following), but the win rate is low even then.
 
 ## Weakest Links (Priority Order)
 
-### 1. Exit timing (trailing stops) — HIGHEST IMPACT
+### 1. Initial stop placement — HIGHEST IMPACT
 
-258/375 trades exit within 1 day. The trailing stop fires too quickly. Options:
-- Increase `initial_stop_buffer` from 2% to 5-8%
-- Use ATR-based stops instead of fixed percentage
-- Add a minimum holding period before stops activate
-- Widen the trailing stop threshold
+The 2% `initial_stop_buffer` doesn't match the book's prescription of placing
+stops below the support floor (Ch. 6). The book says initial stop goes below
+the prior correction low, and if that requires >15% risk, prefer other
+candidates. Our fixed 2% is causing immediate stop-outs on normal volatility.
 
 ### 2. Entry quality — MEDIUM IMPACT
 
-Many entries happen at points where the stock immediately retraces. Could be:
-- Breakout detection triggers on noise, not real breakouts
-- Volume confirmation threshold too low
-- Entering at market open after a breakout day means buying the gap-up
+Many entries may trigger on noise rather than genuine breakouts. Volume
+confirmation and breakout detection thresholds may need tuning.
 
 ### 3. Drawdown circuit breaker — NOT IMPLEMENTED
 
-The 34-39% drawdowns would be reduced by Weinstein's 20-25% rule.
-Implementing the circuit breaker would cap drawdown but also miss recovery.
+34-39% drawdowns would be reduced by Weinstein's 20-25% rule (Ch. 7).
 
-### 4. Position sizing — WORKING AS DESIGNED
+### 4. Portfolio health visibility — MISSING METRIC
 
-1% risk per trade keeps individual losses small ($100-$3K). The issue is
-frequency of losses, not their size.
+No metric for "% of open positions currently profitable." This would help
+distinguish a healthy portfolio (many positions in the green) from one that
+just happened to have one big unrealized winner at the sample point.
 
-## Recommendations
+## TODOs
 
-1. **Immediate**: Investigate why 74% of trades exit within 1 day. Add
-   intermediate logging — record entry price, initial stop level, and
-   first few days of price action per trade.
+### TODO 1: Investigate and tune initial stop placement
 
-2. **Short-term**: Experiment with wider initial stops (5%, 8%) and compare
-   win rates and holding periods. This is the single highest-impact change.
+The `initial_stop_buffer` (currently 2%) is much tighter than Weinstein Ch. 6
+prescribes (support floor, typically 5-15% below entry). Need to:
+- [ ] Test with wider fixed stops (5%, 8%, 12%) and compare win rate,
+  holding periods, and total P&L
+- [ ] Investigate support-floor-based stops (the book's actual method) —
+  the screener already computes `base_low` which could serve as the support
+  floor for stop placement
+- [ ] Analyze the 258 trades that exited within 1 day — were the stops hit
+  by normal intraday volatility, or were these genuine breakout failures?
+- [ ] Caution: widening stops increases per-trade risk. Need to verify that
+  position sizing (risk_per_trade_pct) still keeps total risk manageable
 
-3. **Medium-term**: Implement the drawdown circuit breaker (20% threshold).
+### TODO 2: Include stop analysis in backtest output
 
-4. **Investigate**: The gap between portfolio return (+57%) and trade P&L
-   (-$15K) means most value is from unrealized positions at period end.
-   Understand whether this is sustainable or just survivorship of long holds.
+- [ ] Add per-trade initial stop level and distance to entry in trades.csv
+- [ ] Add "days to first stop hit" metric
+- [ ] Log whether stop triggered on gap-down vs intraday move
+
+### TODO 3: Implement drawdown circuit breaker
+
+Per Weinstein Ch. 7: "if assets drop by 20-25%, move to the sidelines."
+- [ ] Add 20% drawdown threshold — halt new entries when breached
+- [ ] Design re-entry criteria (wait for macro bullish? drawdown recovery?)
+- [ ] Test impact on returns vs drawdown reduction across scenarios
+
+### TODO 4: Add portfolio health metrics
+
+- [ ] Track % of open positions with unrealized P&L > 0
+- [ ] Track total unrealized P&L as a separate metric in summary output
+- [ ] Track number of open positions over time
+- [ ] This distinguishes a portfolio gaining from broad winners vs one
+  lucky hold, and helps assess sustainability of returns
+
+### TODO 5: Test segmentation library for stage analysis
+
+The existing `analysis/technical/trend/segmentation.ml` library identifies
+trend segments. Test whether using it for Stage classification (instead of
+the current MA-slope-based approach) improves entry timing or reduces
+false breakouts.
+
+### TODO 6: Build experiment framework
+
+Currently each backtest run is ad-hoc. Need a structured way to:
+- [ ] Define a hypothesis (e.g. "wider stops improve win rate")
+- [ ] Run A/B backtests with one parameter changed
+- [ ] Compare metrics side-by-side in a standardized format
+- [ ] Track experiment history (what was tried, what worked)
+
+This could be a CLI extension to `backtest_runner` or a separate tool.
+
+### TODO 7: Add more metrics to backtest output
+
+- [ ] Profit factor (gross profit / gross loss)
+- [ ] CAGR (compound annual growth rate)
+- [ ] Calmar ratio (CAGR / max drawdown)
+- [ ] % of open positions profitable (see TODO 4)
+- [ ] Unrealized P&L at period end
+- [ ] Number of open positions at period end
+- [ ] Trade frequency (trades per month)
+
+### TODO 8: Add fast smoke-test scenarios
+
+The golden scenarios take ~40 min each. For quick iteration, add shorter
+representative windows:
+- [ ] 2019-06 to 2019-12 (6 months, bull market, ~5 min)
+- [ ] 2020-01 to 2020-06 (6 months, COVID crash, ~5 min)
+- [ ] 2023-01 to 2023-12 (1 year, recovery, ~10 min)
+
+These could run as CI tests or as a "smoke" mode in the runner.
 
 ## Performance Notes
 
 - Runtime: ~40 min per 6-year scenario with 1,654 stocks
 - Memory: 6-7 GB peak for 6-year runs
-- Non-deterministic: Hashtbl ordering in strategy internals causes slight
-  variation between runs (PR #298)
+- Non-deterministic: Hashtbl ordering in strategy internals (PR #298)
 - Total runtime for 3 scenarios: ~90 min


### PR DESCRIPTION
## Summary

Expands the baseline backtest analysis with:
- Book references for stop-loss placement (Ch. 6: support floor, not fixed %)
- Nuanced discussion of stop widening tradeoffs
- 4 concrete TODOs with actionable items
- Portfolio health metric proposal (% positions profitable)
- Non-determinism note (PR #298)

## Changes
- Updated `dev/backtest/analysis.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)