### PR TITLE
feat: add profit factor, CAGR, Calmar, and portfolio metrics

### DIFF
--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -165,6 +165,11 @@ IN_PROGRESS
 
 - [x] T1-Q: CC linter — `trading/devtools/cc_linter/cc_linter.ml`; OCaml AST via `compiler-libs`; CC > 10 = warning (not failure); exits 0 always; optional JSON output to `dev/metrics/cc-YYYY-MM-DD.json`. Wired into `dune runtest` via `trading/devtools/checks/dune`. Verify: `dune runtest trading/devtools/checks/` — exits 0; prints OK or warning list.
 
+### T2-B: Reference backtest config and expected metrics
+
+- [x] T2-B: Reference backtest config — `dev/benchmarks/reference_backtest.sexp`; captures all default strategy parameters from `backtest_runner.ml`, `weinstein_strategy.ml`, `stage.ml`, `macro_types.ml`, `screener.ml`, `portfolio_risk.ml`, and `stop_types.ml`. Verify: `cat dev/benchmarks/reference_backtest.sexp` — should have sections for runner, strategy, stage, macro, screener, portfolio_risk, and stops.
+- [x] T2-B: Expected metrics — `dev/benchmarks/expected_metrics.sexp`; metric ranges from 3 golden scenarios (2018-2023, 2015-2020, 2020-2024) on 1,654 stocks. Includes per-scenario observed values and aggregate expected ranges with margin for Hashtbl non-determinism. Verify: `cat dev/benchmarks/expected_metrics.sexp` — should have scenarios list and expected_ranges section.
+
 ### T3-B and T3-F
 
 - [x] T3-B: AVR loop closure already in `lead-orchestrator` Step 5 — auto-dispatches QC for any READY_FOR_REVIEW feature in the same orchestrator run. Verify: grep "READY_FOR_REVIEW\|auto.*QC\|Step 5" in `lead-orchestrator.md`.

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -165,11 +165,6 @@ IN_PROGRESS
 
 - [x] T1-Q: CC linter — `trading/devtools/cc_linter/cc_linter.ml`; OCaml AST via `compiler-libs`; CC > 10 = warning (not failure); exits 0 always; optional JSON output to `dev/metrics/cc-YYYY-MM-DD.json`. Wired into `dune runtest` via `trading/devtools/checks/dune`. Verify: `dune runtest trading/devtools/checks/` — exits 0; prints OK or warning list.
 
-### T2-B: Reference backtest config and expected metrics
-
-- [x] T2-B: Reference backtest config — `dev/benchmarks/reference_backtest.sexp`; captures all default strategy parameters from `backtest_runner.ml`, `weinstein_strategy.ml`, `stage.ml`, `macro_types.ml`, `screener.ml`, `portfolio_risk.ml`, and `stop_types.ml`. Verify: `cat dev/benchmarks/reference_backtest.sexp` — should have sections for runner, strategy, stage, macro, screener, portfolio_risk, and stops.
-- [x] T2-B: Expected metrics — `dev/benchmarks/expected_metrics.sexp`; metric ranges from 3 golden scenarios (2018-2023, 2015-2020, 2020-2024) on 1,654 stocks. Includes per-scenario observed values and aggregate expected ranges with margin for Hashtbl non-determinism. Verify: `cat dev/benchmarks/expected_metrics.sexp` — should have scenarios list and expected_ranges section.
-
 ### T3-B and T3-F
 
 - [x] T3-B: AVR loop closure already in `lead-orchestrator` Step 5 — auto-dispatches QC for any READY_FOR_REVIEW feature in the same orchestrator run. Verify: grep "READY_FOR_REVIEW\|auto.*QC\|Step 5" in `lead-orchestrator.md`.

--- a/trading/analysis/weinstein/macro/lib/dune
+++ b/trading/analysis/weinstein/macro/lib/dune
@@ -4,4 +4,4 @@
  (wrapped false)
  (libraries core types weinstein_types stage indicators.time_period)
  (preprocess
-  (pps ppx_deriving.show ppx_deriving.eq)))
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/scripts/backtest_runner/backtest_runner.ml
+++ b/trading/trading/scripts/backtest_runner/backtest_runner.ml
@@ -112,42 +112,22 @@ let _write_params ~output_dir ~start_date ~end_date ~universe_size ~data_dir =
   Sexp.save_hum (output_dir ^ "/params.sexp") sexp
 
 let _build_summary_sexp
-    ~(metrics : Trading_simulation_types.Metric_types.metric_set)
-    ~(summary : Metrics.summary_stats option) ~final_value ~start_date ~end_date
-    ~universe_size ~n_steps ~n_round_trips =
-  let open Trading_simulation_types.Metric_types in
-  let get key = Map.find metrics key |> Option.value ~default:0.0 in
-  let max_drawdown_pct = get MaxDrawdown in
-  let total_pnl = match summary with Some s -> s.total_pnl | None -> 0.0 in
-  let win_count = match summary with Some s -> s.win_count | None -> 0 in
-  let loss_count = match summary with Some s -> s.loss_count | None -> 0 in
-  let win_rate = match summary with Some s -> s.win_rate | None -> 0.0 in
-  let avg_hold =
-    match summary with Some s -> s.avg_holding_days | None -> 0.0
-  in
-  Sexp.List
+    ~(metrics : Trading_simulation_types.Metric_types.metric_set) ~final_value
+    ~start_date ~end_date ~universe_size ~n_steps ~n_round_trips =
+  let run_info =
     [
       _sexp_of_pair "start_date" (_sexp_of_string (Date.to_string start_date));
       _sexp_of_pair "end_date" (_sexp_of_string (Date.to_string end_date));
       _sexp_of_pair "universe_size" (_sexp_of_int universe_size);
       _sexp_of_pair "steps" (_sexp_of_int n_steps);
       _sexp_of_pair "final_portfolio_value" (_sexp_of_float final_value);
-      _sexp_of_pair "total_pnl" (_sexp_of_float total_pnl);
-      _sexp_of_pair "win_count" (_sexp_of_int win_count);
-      _sexp_of_pair "loss_count" (_sexp_of_int loss_count);
-      _sexp_of_pair "win_rate" (_sexp_of_float win_rate);
-      _sexp_of_pair "sharpe_ratio" (_sexp_of_float (get SharpeRatio));
-      _sexp_of_pair "max_drawdown_pct" (_sexp_of_float max_drawdown_pct);
-      _sexp_of_pair "total_trades" (_sexp_of_int (win_count + loss_count));
       _sexp_of_pair "round_trips" (_sexp_of_int n_round_trips);
-      _sexp_of_pair "avg_holding_days" (_sexp_of_float avg_hold);
-      _sexp_of_pair "profit_factor" (_sexp_of_float (get ProfitFactor));
-      _sexp_of_pair "cagr" (_sexp_of_float (get CAGR));
-      _sexp_of_pair "calmar_ratio" (_sexp_of_float (get CalmarRatio));
-      _sexp_of_pair "open_positions" (_sexp_of_float (get OpenPositionCount));
-      _sexp_of_pair "unrealized_pnl" (_sexp_of_float (get UnrealizedPnl));
-      _sexp_of_pair "trade_frequency" (_sexp_of_float (get TradeFrequency));
     ]
+  in
+  let metrics_sexp =
+    Trading_simulation_types.Metric_types.metric_set_to_sexp_pairs metrics
+  in
+  Sexp.List (run_info @ [ _sexp_of_pair "metrics" metrics_sexp ])
 
 let _write_summary ~output_dir ~summary_sexp =
   Sexp.save_hum (output_dir ^ "/summary.sexp") summary_sexp
@@ -221,10 +201,10 @@ let () =
     (Date.to_string start_date)
     (Date.to_string end_date)
     (Date.to_string warmup_start);
-  let computers = Metric_computers.default_computers () in
+  let metric_suite = Metric_computers.default_metric_suite () in
   let deps =
     Simulator.create_deps ~symbols:all_symbols ~data_dir:data_dir_fpath
-      ~strategy ~commission ~computers ()
+      ~strategy ~commission ~metric_suite ()
   in
   let sim_config =
     Simulator.
@@ -261,13 +241,12 @@ let () =
   in
   let final_value = (List.last_exn steps).portfolio_value in
   let round_trips = Metrics.extract_round_trips steps in
-  let summary = Metrics.compute_summary round_trips in
 
   let output_dir = _make_output_dir ~data_dir_fpath in
   eprintf "Writing output to %s/\n%!" output_dir;
   let summary_sexp =
-    _build_summary_sexp ~metrics:result.metrics ~summary ~final_value
-      ~start_date ~end_date ~universe_size ~n_steps:(List.length steps)
+    _build_summary_sexp ~metrics:result.metrics ~final_value ~start_date
+      ~end_date ~universe_size ~n_steps:(List.length steps)
       ~n_round_trips:(List.length round_trips)
   in
   _write_params ~output_dir ~start_date ~end_date ~universe_size ~data_dir;

--- a/trading/trading/scripts/backtest_runner/backtest_runner.ml
+++ b/trading/trading/scripts/backtest_runner/backtest_runner.ml
@@ -141,6 +141,12 @@ let _build_summary_sexp
       _sexp_of_pair "total_trades" (_sexp_of_int (win_count + loss_count));
       _sexp_of_pair "round_trips" (_sexp_of_int n_round_trips);
       _sexp_of_pair "avg_holding_days" (_sexp_of_float avg_hold);
+      _sexp_of_pair "profit_factor" (_sexp_of_float (get ProfitFactor));
+      _sexp_of_pair "cagr" (_sexp_of_float (get CAGR));
+      _sexp_of_pair "calmar_ratio" (_sexp_of_float (get CalmarRatio));
+      _sexp_of_pair "open_positions" (_sexp_of_float (get OpenPositionCount));
+      _sexp_of_pair "unrealized_pnl" (_sexp_of_float (get UnrealizedPnl));
+      _sexp_of_pair "trade_frequency" (_sexp_of_float (get TradeFrequency));
     ]
 
 let _write_summary ~output_dir ~summary_sexp =

--- a/trading/trading/simulation/lib/metric_computers.ml
+++ b/trading/trading/simulation/lib/metric_computers.ml
@@ -1,3 +1,4 @@
+(* @large-module: 7 metric computers with distinct state types and logic *)
 (** Pre-built metric computers for common performance metrics. *)
 
 open Core

--- a/trading/trading/simulation/lib/metric_computers.ml
+++ b/trading/trading/simulation/lib/metric_computers.ml
@@ -150,19 +150,22 @@ let _update_drawdown state value =
     has_data = true;
   }
 
+let _init_drawdown value = { peak = value; max_drawdown = 0.0; has_data = true }
+
+let _drawdown_update ~state ~step =
+  if not (_is_trading_day_step step) then state
+  else
+    let value = step.Simulator_types.portfolio_value in
+    match state.has_data with
+    | false -> _init_drawdown value
+    | true -> _update_drawdown state value
+
 let _drawdown_computer_impl : drawdown_state Simulator_types.metric_computer =
   {
     name = "max_drawdown";
     init =
       (fun ~config:_ -> { peak = 0.0; max_drawdown = 0.0; has_data = false });
-    update =
-      (fun ~state ~step ->
-        if not (_is_trading_day_step step) then state
-        else
-          let value = step.Simulator_types.portfolio_value in
-          if not state.has_data then
-            { peak = value; max_drawdown = 0.0; has_data = true }
-          else _update_drawdown state value);
+    update = _drawdown_update;
     finalize =
       (fun ~state ~config:_ ->
         Metric_types.singleton MaxDrawdown state.max_drawdown);
@@ -177,35 +180,39 @@ type cagr_state = { first_value : float option; last_value : float option }
 
 let _days_per_year = 365.25
 
+let _cagr_update ~state ~step =
+  if not (_is_trading_day_step step) then state
+  else
+    let value = step.Simulator_types.portfolio_value in
+    let first_value =
+      match state.first_value with None -> Some value | some -> some
+    in
+    { first_value; last_value = Some value }
+
+let _compute_cagr ~first ~last ~start_date ~end_date =
+  let days = Float.of_int (Date.diff end_date start_date) in
+  let years = days /. _days_per_year in
+  if Float.(years <= 0.0) || Float.(first <= 0.0) then 0.0
+  else
+    let ratio = last /. first in
+    (Float.( ** ) ratio (1.0 /. years) -. 1.0) *. 100.0
+
+let _cagr_finalize ~state ~(config : Simulator_types.config) =
+  let cagr =
+    match (state.first_value, state.last_value) with
+    | Some first, Some last ->
+        _compute_cagr ~first ~last ~start_date:config.start_date
+          ~end_date:config.end_date
+    | _ -> 0.0
+  in
+  Metric_types.singleton CAGR cagr
+
 let _cagr_computer_impl : cagr_state Simulator_types.metric_computer =
   {
     name = "cagr";
     init = (fun ~config:_ -> { first_value = None; last_value = None });
-    update =
-      (fun ~state ~step ->
-        if not (_is_trading_day_step step) then state
-        else
-          let value = step.Simulator_types.portfolio_value in
-          let first_value =
-            match state.first_value with None -> Some value | some -> some
-          in
-          { first_value; last_value = Some value });
-    finalize =
-      (fun ~state ~config ->
-        let cagr =
-          match (state.first_value, state.last_value) with
-          | Some first, Some last ->
-              let days =
-                Float.of_int (Date.diff config.end_date config.start_date)
-              in
-              let years = days /. _days_per_year in
-              if Float.(years <= 0.0) || Float.(first <= 0.0) then 0.0
-              else
-                let ratio = last /. first in
-                (Float.( ** ) ratio (1.0 /. years) -. 1.0) *. 100.0
-          | _ -> 0.0
-        in
-        Metric_types.singleton CAGR cagr);
+    update = _cagr_update;
+    finalize = _cagr_finalize;
   }
 
 let cagr_computer () = Simulator_types.wrap_computer _cagr_computer_impl
@@ -217,6 +224,32 @@ type portfolio_state = {
   total_trades : int;
 }
 
+let _compute_trade_frequency ~total_trades ~start_date ~end_date =
+  let days = Float.of_int (Date.diff end_date start_date) in
+  let months = days /. 30.44 in
+  if Float.(months <= 0.0) then 0.0 else Float.of_int total_trades /. months
+
+let _portfolio_metrics_from_step ~(step : Simulator_types.step_result)
+    ~total_trades ~start_date ~end_date =
+  let open_count = Float.of_int (List.length step.portfolio.positions) in
+  let unrealized_pnl = step.portfolio_value -. step.portfolio.current_cash in
+  let trade_freq =
+    _compute_trade_frequency ~total_trades ~start_date ~end_date
+  in
+  Metric_types.of_alist_exn
+    [
+      (OpenPositionCount, open_count);
+      (UnrealizedPnl, unrealized_pnl);
+      (TradeFrequency, trade_freq);
+    ]
+
+let _portfolio_finalize ~state ~(config : Simulator_types.config) =
+  match state.last_step with
+  | None -> Metric_types.empty
+  | Some step ->
+      _portfolio_metrics_from_step ~step ~total_trades:state.total_trades
+        ~start_date:config.start_date ~end_date:config.end_date
+
 let _portfolio_computer_impl : portfolio_state Simulator_types.metric_computer =
   {
     name = "portfolio_state";
@@ -227,38 +260,29 @@ let _portfolio_computer_impl : portfolio_state Simulator_types.metric_computer =
           last_step = Some step;
           total_trades = state.total_trades + List.length step.trades;
         });
-    finalize =
-      (fun ~state ~config ->
-        match state.last_step with
-        | None -> Metric_types.empty
-        | Some step ->
-            let open_count =
-              Float.of_int (List.length step.portfolio.positions)
-            in
-            (* Unrealized P&L = market value of positions = final_value -
-               cash. This captures mark-to-market gains/losses on open
-               positions. *)
-            let unrealized_pnl =
-              step.portfolio_value -. step.portfolio.current_cash
-            in
-            let days =
-              Float.of_int (Date.diff config.end_date config.start_date)
-            in
-            let months = days /. 30.44 in
-            let trade_freq =
-              if Float.(months <= 0.0) then 0.0
-              else Float.of_int state.total_trades /. months
-            in
-            Metric_types.of_alist_exn
-              [
-                (OpenPositionCount, open_count);
-                (UnrealizedPnl, unrealized_pnl);
-                (TradeFrequency, trade_freq);
-              ]);
+    finalize = _portfolio_finalize;
   }
 
 let portfolio_state_computer () =
   Simulator_types.wrap_computer _portfolio_computer_impl
+
+(** {1 Calmar Ratio Stub}
+
+    CalmarRatio is derived post-hoc from CAGR and MaxDrawdown. This stub
+    computer produces 0.0 as a fallback when the metric is requested
+    individually. *)
+
+let _calmar_stub_impl : unit Simulator_types.metric_computer =
+  {
+    name = "calmar_ratio_stub";
+    init = (fun ~config:_ -> ());
+    update = (fun ~state:() ~step:_ -> ());
+    finalize =
+      (fun ~state:() ~config:_ -> Metric_types.singleton CalmarRatio 0.0);
+  }
+
+let calmar_ratio_stub_computer () =
+  Simulator_types.wrap_computer _calmar_stub_impl
 
 (** {1 Factory} *)
 
@@ -270,17 +294,7 @@ let create_computer (metric_type : Metric_types.metric_type) :
   | SharpeRatio -> sharpe_ratio_computer ()
   | MaxDrawdown -> max_drawdown_computer ()
   | CAGR -> cagr_computer ()
-  | CalmarRatio ->
-      (* CalmarRatio is derived post-hoc from CAGR and MaxDrawdown.
-         Return a stub computer that produces 0.0 as a fallback. *)
-      Simulator_types.wrap_computer
-        {
-          name = "calmar_ratio_stub";
-          init = (fun ~config:_ -> ());
-          update = (fun ~state:() ~step:_ -> ());
-          finalize =
-            (fun ~state:() ~config:_ -> Metric_types.singleton CalmarRatio 0.0);
-        }
+  | CalmarRatio -> calmar_ratio_stub_computer ()
   | OpenPositionCount | UnrealizedPnl | TradeFrequency ->
       portfolio_state_computer ()
 

--- a/trading/trading/simulation/lib/metric_computers.ml
+++ b/trading/trading/simulation/lib/metric_computers.ml
@@ -267,25 +267,32 @@ let _portfolio_computer_impl : portfolio_state Simulator_types.metric_computer =
 let portfolio_state_computer () =
   Simulator_types.wrap_computer _portfolio_computer_impl
 
-(** {1 Calmar Ratio Stub}
+(** {1 Derived Metric Computers} *)
 
-    CalmarRatio is derived post-hoc from CAGR and MaxDrawdown. This stub
-    computer produces 0.0 as a fallback when the metric is requested
-    individually. *)
-
-let _calmar_stub_impl : unit Simulator_types.metric_computer =
+let calmar_ratio_derived : Simulator_types.derived_metric_computer =
   {
-    name = "calmar_ratio_stub";
-    init = (fun ~config:_ -> ());
-    update = (fun ~state:() ~step:_ -> ());
-    finalize =
-      (fun ~state:() ~config:_ -> Metric_types.singleton CalmarRatio 0.0);
+    name = "calmar_ratio";
+    depends_on = [ CAGR; MaxDrawdown ];
+    compute =
+      (fun ~config:_ ~base_metrics ->
+        let get k = Map.find base_metrics k |> Option.value ~default:0.0 in
+        let cagr = get CAGR in
+        let max_dd = get MaxDrawdown in
+        let calmar = if Float.( = ) max_dd 0.0 then 0.0 else cagr /. max_dd in
+        Metric_types.singleton CalmarRatio calmar);
   }
 
-let calmar_ratio_stub_computer () =
-  Simulator_types.wrap_computer _calmar_stub_impl
-
 (** {1 Factory} *)
+
+let _calmar_stub () =
+  Simulator_types.wrap_computer
+    {
+      name = "calmar_stub";
+      init = (fun ~config:_ -> ());
+      update = (fun ~state:() ~step:_ -> ());
+      finalize =
+        (fun ~state:() ~config:_ -> Metric_types.singleton CalmarRatio 0.0);
+    }
 
 let create_computer (metric_type : Metric_types.metric_type) :
     Simulator_types.any_metric_computer =
@@ -295,7 +302,7 @@ let create_computer (metric_type : Metric_types.metric_type) :
   | SharpeRatio -> sharpe_ratio_computer ()
   | MaxDrawdown -> max_drawdown_computer ()
   | CAGR -> cagr_computer ()
-  | CalmarRatio -> calmar_ratio_stub_computer ()
+  | CalmarRatio -> _calmar_stub ()
   | OpenPositionCount | UnrealizedPnl | TradeFrequency ->
       portfolio_state_computer ()
 
@@ -309,3 +316,12 @@ let default_computers ?(risk_free_rate = 0.0) () =
     cagr_computer ();
     portfolio_state_computer ();
   ]
+
+let default_derived_computers () = [ calmar_ratio_derived ]
+
+let default_metric_suite ?(risk_free_rate = 0.0) () :
+    Simulator_types.metric_suite =
+  {
+    computers = default_computers ~risk_free_rate ();
+    derived = default_derived_computers ();
+  }

--- a/trading/trading/simulation/lib/metric_computers.ml
+++ b/trading/trading/simulation/lib/metric_computers.ml
@@ -25,6 +25,20 @@ let _is_trading_day_step (step : Simulator_types.step_result) =
 
 type summary_state = { steps : Simulator_types.step_result list }
 
+let _compute_profit_factor (round_trips : Metrics.trade_metrics list) =
+  let gross_profit =
+    List.fold round_trips ~init:0.0 ~f:(fun acc (m : Metrics.trade_metrics) ->
+        if Float.(m.pnl_dollars > 0.0) then acc +. m.pnl_dollars else acc)
+  in
+  let gross_loss =
+    List.fold round_trips ~init:0.0 ~f:(fun acc (m : Metrics.trade_metrics) ->
+        if Float.(m.pnl_dollars < 0.0) then acc +. Float.abs m.pnl_dollars
+        else acc)
+  in
+  if Float.(gross_loss = 0.0) then
+    if Float.(gross_profit > 0.0) then Float.infinity else 0.0
+  else gross_profit /. gross_loss
+
 let _summary_computer_impl : summary_state Simulator_types.metric_computer =
   {
     name = "summary";
@@ -34,9 +48,14 @@ let _summary_computer_impl : summary_state Simulator_types.metric_computer =
       (fun ~state ~config:_ ->
         let steps = List.rev state.steps in
         let round_trips = Metrics.extract_round_trips steps in
-        match Metrics.compute_summary round_trips with
-        | None -> Metric_types.empty
-        | Some stats -> Metrics.summary_stats_to_metrics stats);
+        let base_metrics =
+          match Metrics.compute_summary round_trips with
+          | None -> Metric_types.empty
+          | Some stats -> Metrics.summary_stats_to_metrics stats
+        in
+        let profit_factor = _compute_profit_factor round_trips in
+        Metric_types.merge base_metrics
+          (Metric_types.singleton ProfitFactor profit_factor));
   }
 
 let summary_computer () = Simulator_types.wrap_computer _summary_computer_impl
@@ -152,15 +171,118 @@ let _drawdown_computer_impl : drawdown_state Simulator_types.metric_computer =
 let max_drawdown_computer () =
   Simulator_types.wrap_computer _drawdown_computer_impl
 
+(** {1 CAGR Computer} *)
+
+type cagr_state = { first_value : float option; last_value : float option }
+
+let _days_per_year = 365.25
+
+let _cagr_computer_impl : cagr_state Simulator_types.metric_computer =
+  {
+    name = "cagr";
+    init = (fun ~config:_ -> { first_value = None; last_value = None });
+    update =
+      (fun ~state ~step ->
+        if not (_is_trading_day_step step) then state
+        else
+          let value = step.Simulator_types.portfolio_value in
+          let first_value =
+            match state.first_value with None -> Some value | some -> some
+          in
+          { first_value; last_value = Some value });
+    finalize =
+      (fun ~state ~config ->
+        let cagr =
+          match (state.first_value, state.last_value) with
+          | Some first, Some last ->
+              let days =
+                Float.of_int (Date.diff config.end_date config.start_date)
+              in
+              let years = days /. _days_per_year in
+              if Float.(years <= 0.0) || Float.(first <= 0.0) then 0.0
+              else
+                let ratio = last /. first in
+                (Float.( ** ) ratio (1.0 /. years) -. 1.0) *. 100.0
+          | _ -> 0.0
+        in
+        Metric_types.singleton CAGR cagr);
+  }
+
+let cagr_computer () = Simulator_types.wrap_computer _cagr_computer_impl
+
+(** {1 Portfolio State Computer} *)
+
+type portfolio_state = {
+  last_step : Simulator_types.step_result option;
+  total_trades : int;
+}
+
+let _portfolio_computer_impl : portfolio_state Simulator_types.metric_computer =
+  {
+    name = "portfolio_state";
+    init = (fun ~config:_ -> { last_step = None; total_trades = 0 });
+    update =
+      (fun ~state ~step ->
+        {
+          last_step = Some step;
+          total_trades = state.total_trades + List.length step.trades;
+        });
+    finalize =
+      (fun ~state ~config ->
+        match state.last_step with
+        | None -> Metric_types.empty
+        | Some step ->
+            let open_count =
+              Float.of_int (List.length step.portfolio.positions)
+            in
+            (* Unrealized P&L = market value of positions = final_value -
+               cash. This captures mark-to-market gains/losses on open
+               positions. *)
+            let unrealized_pnl =
+              step.portfolio_value -. step.portfolio.current_cash
+            in
+            let days =
+              Float.of_int (Date.diff config.end_date config.start_date)
+            in
+            let months = days /. 30.44 in
+            let trade_freq =
+              if Float.(months <= 0.0) then 0.0
+              else Float.of_int state.total_trades /. months
+            in
+            Metric_types.of_alist_exn
+              [
+                (OpenPositionCount, open_count);
+                (UnrealizedPnl, unrealized_pnl);
+                (TradeFrequency, trade_freq);
+              ]);
+  }
+
+let portfolio_state_computer () =
+  Simulator_types.wrap_computer _portfolio_computer_impl
+
 (** {1 Factory} *)
 
 let create_computer (metric_type : Metric_types.metric_type) :
     Simulator_types.any_metric_computer =
   match metric_type with
-  | TotalPnl | AvgHoldingDays | WinCount | LossCount | WinRate ->
+  | TotalPnl | AvgHoldingDays | WinCount | LossCount | WinRate | ProfitFactor ->
       summary_computer ()
   | SharpeRatio -> sharpe_ratio_computer ()
   | MaxDrawdown -> max_drawdown_computer ()
+  | CAGR -> cagr_computer ()
+  | CalmarRatio ->
+      (* CalmarRatio is derived post-hoc from CAGR and MaxDrawdown.
+         Return a stub computer that produces 0.0 as a fallback. *)
+      Simulator_types.wrap_computer
+        {
+          name = "calmar_ratio_stub";
+          init = (fun ~config:_ -> ());
+          update = (fun ~state:() ~step:_ -> ());
+          finalize =
+            (fun ~state:() ~config:_ -> Metric_types.singleton CalmarRatio 0.0);
+        }
+  | OpenPositionCount | UnrealizedPnl | TradeFrequency ->
+      portfolio_state_computer ()
 
 (** {1 Default Computer Set} *)
 
@@ -169,4 +291,6 @@ let default_computers ?(risk_free_rate = 0.0) () =
     summary_computer ();
     sharpe_ratio_computer ~risk_free_rate ();
     max_drawdown_computer ();
+    cagr_computer ();
+    portfolio_state_computer ();
   ]

--- a/trading/trading/simulation/lib/metric_computers.mli
+++ b/trading/trading/simulation/lib/metric_computers.mli
@@ -13,7 +13,8 @@ val summary_computer : unit -> Simulator.any_metric_computer
     - avg_holding_days: Average holding period
     - win_count: Number of winning trades
     - loss_count: Number of losing trades
-    - win_rate: Win percentage *)
+    - win_rate: Win percentage
+    - profit_factor: Gross profit / gross loss *)
 
 (** {1 Sharpe Ratio Computer} *)
 
@@ -40,12 +41,33 @@ val max_drawdown_computer : unit -> Simulator.any_metric_computer
     Metrics produced:
     - max_drawdown: Maximum percentage decline from peak (0-100 scale) *)
 
+(** {1 CAGR Computer} *)
+
+val cagr_computer : unit -> Simulator.any_metric_computer
+(** Metric computer that calculates compound annual growth rate.
+
+    Metrics produced:
+    - CAGR: Annualized return as percentage *)
+
+(** {1 Portfolio State Computer} *)
+
+val portfolio_state_computer : unit -> Simulator.any_metric_computer
+(** Metric computer that captures end-of-simulation portfolio state.
+
+    Metrics produced:
+    - OpenPositionCount: Number of open positions at end
+    - UnrealizedPnl: Unrealized P&L (final value - current cash)
+    - TradeFrequency: Average trades per month *)
+
 (** {1 Default Computer Set} *)
 
 val default_computers :
   ?risk_free_rate:float -> unit -> Simulator.any_metric_computer list
-(** Returns all default metric computers: summary, Sharpe ratio, and max
-    drawdown.
+(** Returns all default metric computers: summary (including profit factor),
+    Sharpe ratio, max drawdown, CAGR, and portfolio state.
+
+    Note: CalmarRatio is a derived metric computed by the simulator from CAGR
+    and MaxDrawdown after all computers have run.
 
     @param risk_free_rate
       Annual risk-free rate for Sharpe calculation (default: 0.0) *)
@@ -57,6 +79,6 @@ val create_computer :
   Simulator.any_metric_computer
 (** Create a metric computer from a metric type.
 
-    Note: Only SharpeRatio and MaxDrawdown are supported as individual
-    computers. Summary metrics (TotalPnl, AvgHoldingDays, WinCount, LossCount,
-    WinRate) are produced together by summary_computer. *)
+    Note: Summary metrics (TotalPnl, AvgHoldingDays, WinCount, LossCount,
+    WinRate, ProfitFactor) are produced together by summary_computer.
+    CalmarRatio is a derived metric computed post-hoc by the simulator. *)

--- a/trading/trading/simulation/lib/metric_computers.mli
+++ b/trading/trading/simulation/lib/metric_computers.mli
@@ -63,14 +63,25 @@ val portfolio_state_computer : unit -> Simulator.any_metric_computer
 
 val default_computers :
   ?risk_free_rate:float -> unit -> Simulator.any_metric_computer list
-(** Returns all default metric computers: summary (including profit factor),
-    Sharpe ratio, max drawdown, CAGR, and portfolio state.
-
-    Note: CalmarRatio is a derived metric computed by the simulator from CAGR
-    and MaxDrawdown after all computers have run.
+(** Returns all default step-based metric computers: summary (including profit
+    factor), Sharpe ratio, max drawdown, CAGR, and portfolio state.
 
     @param risk_free_rate
       Annual risk-free rate for Sharpe calculation (default: 0.0) *)
+
+(** {1 Derived Metric Computers} *)
+
+val calmar_ratio_derived : Simulator.derived_metric_computer
+(** Computes CalmarRatio = CAGR / MaxDrawdown. Depends on CAGR and MaxDrawdown
+    being computed first by step-based computers. *)
+
+val default_derived_computers : unit -> Simulator.derived_metric_computer list
+(** Returns all default derived metric computers (currently: CalmarRatio). *)
+
+val default_metric_suite :
+  ?risk_free_rate:float -> unit -> Simulator.metric_suite
+(** Returns a complete metric suite with all step-based and derived computers.
+*)
 
 (** {1 Factory} *)
 

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -246,6 +246,14 @@ let _build_run_result t =
   let metrics =
     _compute_metrics ~computers:t.deps.computers ~config:t.config ~steps
   in
+  (* Compute CalmarRatio as a derived metric from CAGR and MaxDrawdown *)
+  let metrics =
+    let open Trading_simulation_types.Metric_types in
+    let cagr = Map.find metrics CAGR |> Option.value ~default:0.0 in
+    let max_dd = Map.find metrics MaxDrawdown |> Option.value ~default:0.0 in
+    let calmar = if Float.(max_dd = 0.0) then 0.0 else cagr /. max_dd in
+    merge metrics (singleton CalmarRatio calmar)
+  in
   { steps; metrics }
 
 (* Apply trades one at a time, skipping any that fail (e.g. insufficient

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -4,12 +4,25 @@
 open Core
 include Trading_simulation_types.Simulator_types
 
-(** Internal: compute metrics by running all computers over the steps *)
+(** Internal: compute metrics by running all step-based computers *)
 let _compute_metrics ~computers ~config ~steps =
   List.fold computers ~init:Trading_simulation_types.Metric_types.empty
     ~f:(fun acc (computer : any_metric_computer) ->
       Trading_simulation_types.Metric_types.merge acc
         (computer.run ~config ~steps))
+
+(** Internal: compute derived metrics from base metrics.
+
+    Derived computers are folded in list order — each sees the accumulated
+    metrics from prior computers. This means callers must list them in
+    dependency order. Currently sufficient (only CalmarRatio depends on CAGR +
+    MaxDrawdown). If multi-layer dependencies arise, replace with topological
+    sort over the [depends_on] declarations. *)
+let _compute_derived ~derived_computers ~config ~base_metrics =
+  List.fold derived_computers ~init:base_metrics
+    ~f:(fun acc (dc : derived_metric_computer) ->
+      Trading_simulation_types.Metric_types.merge acc
+        (dc.compute ~config ~base_metrics:acc))
 
 (** {1 Dependencies} *)
 
@@ -20,10 +33,11 @@ type dependencies = {
   engine : Trading_engine.Engine.t;
   order_manager : Trading_orders.Manager.order_manager;
   market_data_adapter : Trading_simulation_data.Market_data_adapter.t;
-  computers : any_metric_computer list;
+  metric_suite : metric_suite;
 }
 
-let create_deps ~symbols ~data_dir ~strategy ~commission ?(computers = []) () =
+let create_deps ~symbols ~data_dir ~strategy ~commission
+    ?(metric_suite = { computers = []; derived = [] }) () =
   let engine_config = { Trading_engine.Types.commission } in
   let engine = Trading_engine.Engine.create engine_config in
   let order_manager = Trading_orders.Manager.create () in
@@ -37,7 +51,7 @@ let create_deps ~symbols ~data_dir ~strategy ~commission ?(computers = []) () =
     engine;
     order_manager;
     market_data_adapter;
-    computers;
+    metric_suite;
   }
 
 (** {1 Simulator State} *)
@@ -243,16 +257,13 @@ let _apply_transitions ~positions ~transitions =
 (** Build run_result from accumulated state *)
 let _build_run_result t =
   let steps = List.rev t.step_history in
-  let metrics =
-    _compute_metrics ~computers:t.deps.computers ~config:t.config ~steps
+  let base_metrics =
+    _compute_metrics ~computers:t.deps.metric_suite.computers ~config:t.config
+      ~steps
   in
-  (* Compute CalmarRatio as a derived metric from CAGR and MaxDrawdown *)
   let metrics =
-    let open Trading_simulation_types.Metric_types in
-    let cagr = Map.find metrics CAGR |> Option.value ~default:0.0 in
-    let max_dd = Map.find metrics MaxDrawdown |> Option.value ~default:0.0 in
-    let calmar = if Float.(max_dd = 0.0) then 0.0 else cagr /. max_dd in
-    merge metrics (singleton CalmarRatio calmar)
+    _compute_derived ~derived_computers:t.deps.metric_suite.derived
+      ~config:t.config ~base_metrics
   in
   { steps; metrics }
 

--- a/trading/trading/simulation/lib/simulator.mli
+++ b/trading/trading/simulation/lib/simulator.mli
@@ -22,7 +22,7 @@ type dependencies = {
   engine : Trading_engine.Engine.t;
   order_manager : Trading_orders.Manager.order_manager;
   market_data_adapter : Trading_simulation_data.Market_data_adapter.t;
-  computers : any_metric_computer list;
+  metric_suite : metric_suite;
 }
 
 val create_deps :
@@ -30,7 +30,7 @@ val create_deps :
   data_dir:Fpath.t ->
   strategy:(module Trading_strategy.Strategy_interface.STRATEGY) ->
   commission:Trading_engine.Types.commission_config ->
-  ?computers:any_metric_computer list ->
+  ?metric_suite:metric_suite ->
   unit ->
   dependencies
 (** Create standard dependencies with default engine, order manager, and

--- a/trading/trading/simulation/lib/types/metric_types.ml
+++ b/trading/trading/simulation/lib/types/metric_types.ml
@@ -14,6 +14,12 @@ module Metric_type = struct
       | WinRate
       | SharpeRatio
       | MaxDrawdown
+      | ProfitFactor
+      | CAGR
+      | CalmarRatio
+      | OpenPositionCount
+      | UnrealizedPnl
+      | TradeFrequency
     [@@deriving show, eq, compare, sexp]
   end
 
@@ -29,6 +35,12 @@ type metric_type = Metric_type.t =
   | WinRate
   | SharpeRatio
   | MaxDrawdown
+  | ProfitFactor
+  | CAGR
+  | CalmarRatio
+  | OpenPositionCount
+  | UnrealizedPnl
+  | TradeFrequency
 [@@deriving show, eq, compare, sexp]
 
 include (Metric_type : Comparator.S with type t := metric_type)
@@ -104,6 +116,49 @@ let get_metric_info = function
           "Maximum percentage decline from peak portfolio value during \
            simulation";
         unit = Percent;
+      }
+  | ProfitFactor ->
+      {
+        display_name = "Profit Factor";
+        description =
+          "Gross profit divided by gross loss from round-trip trades. > 1 \
+           means profitable";
+        unit = Ratio;
+      }
+  | CAGR ->
+      {
+        display_name = "CAGR";
+        description =
+          "Compound annual growth rate: annualized return as a percentage";
+        unit = Percent;
+      }
+  | CalmarRatio ->
+      {
+        display_name = "Calmar Ratio";
+        description =
+          "CAGR divided by max drawdown. Higher values indicate better \
+           risk-adjusted returns";
+        unit = Ratio;
+      }
+  | OpenPositionCount ->
+      {
+        display_name = "Open Positions";
+        description = "Number of open positions at end of simulation";
+        unit = Count;
+      }
+  | UnrealizedPnl ->
+      {
+        display_name = "Unrealized P&L";
+        description =
+          "Total unrealized profit/loss at end of simulation: final value - \
+           initial cash - realized P&L";
+        unit = Dollars;
+      }
+  | TradeFrequency ->
+      {
+        display_name = "Trade Frequency";
+        description = "Average number of trades per month";
+        unit = Ratio;
       }
 
 (** {1 Formatting} *)

--- a/trading/trading/simulation/lib/types/metric_types.ml
+++ b/trading/trading/simulation/lib/types/metric_types.ml
@@ -57,6 +57,22 @@ let singleton metric_type value =
 let of_alist_exn alist = Map.of_alist_exn (module Metric_type) alist
 let merge m1 m2 = Map.merge_skewed m1 m2 ~combine:(fun ~key:_ _v1 v2 -> v2)
 
+let sexp_of_metric_set m =
+  Map.to_alist m
+  |> List.map ~f:(fun (k, v) ->
+      Sexp.List [ Metric_type.sexp_of_t k; Float.sexp_of_t v ])
+  |> fun l -> Sexp.List l
+
+let _format_value v =
+  if Float.is_integer v then sprintf "%.0f" v else sprintf "%.2f" v
+
+let metric_set_to_sexp_pairs m =
+  Map.to_alist m
+  |> List.map ~f:(fun (k, v) ->
+      let name = String.lowercase (Metric_type.show k) in
+      Sexp.List [ Sexp.Atom name; Sexp.Atom (_format_value v) ])
+  |> fun l -> Sexp.List l
+
 (** {1 Metric Unit} *)
 
 type metric_unit = Dollars | Percent | Days | Count | Ratio

--- a/trading/trading/simulation/lib/types/metric_types.mli
+++ b/trading/trading/simulation/lib/types/metric_types.mli
@@ -18,6 +18,12 @@ module Metric_type : sig
     | WinRate  (** Win percentage *)
     | SharpeRatio  (** Risk-adjusted return metric *)
     | MaxDrawdown  (** Maximum peak-to-trough decline *)
+    | ProfitFactor  (** Gross profit / gross loss *)
+    | CAGR  (** Compound annual growth rate *)
+    | CalmarRatio  (** CAGR / max drawdown *)
+    | OpenPositionCount  (** Open positions at end of simulation *)
+    | UnrealizedPnl  (** Unrealized P&L at end of simulation *)
+    | TradeFrequency  (** Trades per month *)
   [@@deriving show, eq, compare, sexp]
 
   include Comparator.S with type t := t
@@ -32,6 +38,12 @@ type metric_type = Metric_type.t =
   | WinRate
   | SharpeRatio
   | MaxDrawdown
+  | ProfitFactor
+  | CAGR
+  | CalmarRatio
+  | OpenPositionCount
+  | UnrealizedPnl
+  | TradeFrequency
 [@@deriving show, eq, compare, sexp]
 
 (** {1 Metric Set} *)

--- a/trading/trading/simulation/lib/types/metric_types.mli
+++ b/trading/trading/simulation/lib/types/metric_types.mli
@@ -63,6 +63,12 @@ val of_alist_exn : (metric_type * float) list -> metric_set
 val merge : metric_set -> metric_set -> metric_set
 (** Merge two metric sets. Later values override earlier ones. *)
 
+val sexp_of_metric_set : metric_set -> Sexp.t
+(** Serialize a metric set to sexp. *)
+
+val metric_set_to_sexp_pairs : metric_set -> Sexp.t
+(** Convert to a sexp list of [(key value)] pairs for human-readable output. *)
+
 (** {1 Metric Unit} *)
 
 (** Unit of measurement for formatting *)

--- a/trading/trading/simulation/lib/types/simulator_types.ml
+++ b/trading/trading/simulation/lib/types/simulator_types.ml
@@ -56,3 +56,19 @@ let wrap_computer (type s) (computer : s metric_computer) : any_metric_computer
         in
         computer.finalize ~state:final_state ~config);
   }
+
+(** {1 Derived Metric Computers} *)
+
+type derived_metric_computer = {
+  name : string;
+  depends_on : Metric_types.metric_type list;
+  compute :
+    config:config ->
+    base_metrics:Metric_types.metric_set ->
+    Metric_types.metric_set;
+}
+
+type metric_suite = {
+  computers : any_metric_computer list;
+  derived : derived_metric_computer list;
+}

--- a/trading/trading/simulation/lib/types/simulator_types.mli
+++ b/trading/trading/simulation/lib/types/simulator_types.mli
@@ -64,3 +64,24 @@ type any_metric_computer = {
 
 val wrap_computer : 'state metric_computer -> any_metric_computer
 (** Wrap a typed metric computer for use in heterogeneous collections *)
+
+(** {1 Derived Metric Computers} *)
+
+type derived_metric_computer = {
+  name : string;
+  depends_on : Metric_types.metric_type list;
+      (** Metrics that must be computed before this one. *)
+  compute :
+    config:config ->
+    base_metrics:Metric_types.metric_set ->
+    Metric_types.metric_set;
+      (** Produce derived metrics from the base metric set. *)
+}
+(** A metric computed from other metrics, not from simulation steps. The
+    simulator runs these after all step-based computers, in dependency order. *)
+
+type metric_suite = {
+  computers : any_metric_computer list;
+  derived : derived_metric_computer list;
+}
+(** Bundle of step-based and derived metric computers. *)

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -316,7 +316,9 @@ let test_summary_computer_with_no_trades _ =
   in
   let computer = summary_computer () in
   let metrics = run_computers ~computers:[ computer ] ~config ~steps in
-  assert_that (Map.is_empty metrics) (equal_to true)
+  (* No round-trip trades, but ProfitFactor is always emitted (0.0) *)
+  assert_that (Map.length metrics) (equal_to 1);
+  assert_that (Map.find metrics ProfitFactor) (is_some_and (float_equal 0.0))
 
 (* ==================== Multiple Computers Tests ==================== *)
 
@@ -349,8 +351,8 @@ let test_run_computers_combines_results _ =
 
 let test_default_computers _ =
   let computers = default_computers () in
-  (* Default set: summary_computer, sharpe_ratio_computer, max_drawdown_computer *)
-  assert_that computers (size_is 3)
+  (* Default set: summary, sharpe, max_drawdown, cagr, portfolio_state *)
+  assert_that computers (size_is 5)
 
 (* ==================== Factory Tests ==================== *)
 
@@ -369,6 +371,212 @@ let test_create_computer_max_drawdown _ =
   let metrics = run_computers ~computers:[ computer ] ~config ~steps in
   assert_that (Map.length metrics) (equal_to 1);
   assert_that (Map.find metrics MaxDrawdown) (is_some_and (float_equal 0.0))
+
+(* ==================== Profit Factor Tests ==================== *)
+
+let test_profit_factor_all_winners _ =
+  let config = make_config () in
+  let portfolio = Trading_portfolio.Portfolio.create ~initial_cash:10000.0 () in
+  let buy_trade =
+    {
+      Trading_base.Types.id = "t1";
+      order_id = "o1";
+      symbol = "AAPL";
+      side = Buy;
+      quantity = 10.0;
+      price = 100.0;
+      commission = 0.0;
+      timestamp = Time_ns_unix.now ();
+    }
+  in
+  let sell_trade =
+    {
+      Trading_base.Types.id = "t2";
+      order_id = "o2";
+      symbol = "AAPL";
+      side = Sell;
+      quantity = 10.0;
+      price = 110.0;
+      commission = 0.0;
+      timestamp = Time_ns_unix.now ();
+    }
+  in
+  let steps =
+    [
+      {
+        date = date_of_string "2024-01-01";
+        portfolio;
+        portfolio_value = 10000.0;
+        trades = [ buy_trade ];
+        orders_submitted = [];
+      };
+      {
+        date = date_of_string "2024-01-10";
+        portfolio;
+        portfolio_value = 10100.0;
+        trades = [ sell_trade ];
+        orders_submitted = [];
+      };
+    ]
+  in
+  let computer = summary_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  assert_that
+    (Map.find metrics ProfitFactor)
+    (is_some_and (float_equal Float.infinity))
+
+let test_profit_factor_no_trades _ =
+  let config = make_config () in
+  let steps =
+    [
+      make_step_result
+        ~date:(date_of_string "2024-01-01")
+        ~portfolio_value:10000.0;
+    ]
+  in
+  let computer = summary_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  assert_that (Map.find metrics ProfitFactor) (is_some_and (float_equal 0.0))
+
+(* ==================== CAGR Tests ==================== *)
+
+let test_cagr_zero_with_no_data _ =
+  let config = make_config () in
+  let computer = cagr_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps:[] in
+  assert_that (Map.find metrics CAGR) (is_some_and (float_equal 0.0))
+
+let test_cagr_with_growth _ =
+  let config =
+    {
+      (make_config ()) with
+      start_date = date_of_string "2023-01-01";
+      end_date = date_of_string "2024-01-01";
+    }
+  in
+  let steps =
+    [
+      make_step_result
+        ~date:(date_of_string "2023-01-02")
+        ~portfolio_value:10000.0;
+      make_step_result
+        ~date:(date_of_string "2024-01-01")
+        ~portfolio_value:11000.0;
+    ]
+  in
+  let computer = cagr_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  (* 10% growth over ~1 year should give ~10% CAGR *)
+  assert_that (Map.find metrics CAGR)
+    (is_some_and (float_equal ~epsilon:0.5 10.0))
+
+let test_cagr_with_loss _ =
+  let config =
+    {
+      (make_config ()) with
+      start_date = date_of_string "2023-01-01";
+      end_date = date_of_string "2024-01-01";
+    }
+  in
+  let steps =
+    [
+      make_step_result
+        ~date:(date_of_string "2023-01-02")
+        ~portfolio_value:10000.0;
+      make_step_result
+        ~date:(date_of_string "2024-01-01")
+        ~portfolio_value:9000.0;
+    ]
+  in
+  let computer = cagr_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  assert_that (Map.find metrics CAGR) (is_some_and (lt (module Float_ord) 0.0))
+
+(* ==================== CalmarRatio Tests ==================== *)
+
+let test_calmar_ratio_inputs _ =
+  let config =
+    {
+      (make_config ()) with
+      start_date = date_of_string "2023-01-01";
+      end_date = date_of_string "2024-01-01";
+    }
+  in
+  let steps =
+    [
+      make_step_result
+        ~date:(date_of_string "2023-01-02")
+        ~portfolio_value:10000.0;
+      make_step_result
+        ~date:(date_of_string "2023-06-01")
+        ~portfolio_value:11000.0;
+      make_step_result
+        ~date:(date_of_string "2023-09-01")
+        ~portfolio_value:10500.0;
+      make_step_result
+        ~date:(date_of_string "2024-01-01")
+        ~portfolio_value:12000.0;
+    ]
+  in
+  let computers = [ cagr_computer (); max_drawdown_computer () ] in
+  let metrics = run_computers ~computers ~config ~steps in
+  let cagr = Map.find_exn metrics CAGR in
+  let max_dd = Map.find_exn metrics MaxDrawdown in
+  (* CalmarRatio is computed by simulator post-hoc; verify inputs are present *)
+  assert_that cagr (gt (module Float_ord) 0.0);
+  assert_that max_dd (gt (module Float_ord) 0.0)
+
+(* ==================== Portfolio State Tests ==================== *)
+
+let test_portfolio_state_no_steps _ =
+  let config = make_config () in
+  let computer = portfolio_state_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps:[] in
+  assert_that (Map.is_empty metrics) (equal_to true)
+
+let test_portfolio_state_with_trades _ =
+  let config = make_config () in
+  let portfolio = Trading_portfolio.Portfolio.create ~initial_cash:10000.0 () in
+  let trade =
+    {
+      Trading_base.Types.id = "t1";
+      order_id = "o1";
+      symbol = "AAPL";
+      side = Buy;
+      quantity = 10.0;
+      price = 100.0;
+      commission = 0.0;
+      timestamp = Time_ns_unix.now ();
+    }
+  in
+  let steps =
+    [
+      {
+        date = date_of_string "2024-01-01";
+        portfolio;
+        portfolio_value = 10000.0;
+        trades = [ trade ];
+        orders_submitted = [];
+      };
+      {
+        date = date_of_string "2024-01-05";
+        portfolio;
+        portfolio_value = 10050.0;
+        trades = [ trade; trade ];
+        orders_submitted = [];
+      };
+    ]
+  in
+  let computer = portfolio_state_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  (* 3 total trades across 2 steps *)
+  assert_that
+    (Map.find metrics TradeFrequency)
+    (is_some_and (gt (module Float_ord) 0.0));
+  assert_that
+    (Map.find metrics OpenPositionCount)
+    (is_some_and (float_equal 0.0));
+  assert_that (Map.find metrics UnrealizedPnl) (is_some_and (float_equal 50.0))
 
 (* ==================== Test Suite ==================== *)
 
@@ -417,6 +625,18 @@ let suite =
          (* Factory tests *)
          "create_computer SharpeRatio" >:: test_create_computer_sharpe;
          "create_computer MaxDrawdown" >:: test_create_computer_max_drawdown;
+         (* Profit factor tests *)
+         "profit factor all winners" >:: test_profit_factor_all_winners;
+         "profit factor no trades" >:: test_profit_factor_no_trades;
+         (* CAGR tests *)
+         "cagr zero with no data" >:: test_cagr_zero_with_no_data;
+         "cagr with growth" >:: test_cagr_with_growth;
+         "cagr with loss" >:: test_cagr_with_loss;
+         (* Calmar ratio tests *)
+         "calmar ratio inputs" >:: test_calmar_ratio_inputs;
+         (* Portfolio state tests *)
+         "portfolio state no steps" >:: test_portfolio_state_no_steps;
+         "portfolio state with trades" >:: test_portfolio_state_with_trades;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- Add 6 new metric types to the simulation metric system: ProfitFactor, CAGR, CalmarRatio, OpenPositionCount, UnrealizedPnl, and TradeFrequency
- Implement metric computers: summary_computer now also produces ProfitFactor; new cagr_computer and portfolio_state_computer
- CalmarRatio is computed as a derived metric (CAGR / MaxDrawdown) in the simulator after all computers run
- Update backtest runner summary output to include all new metrics
- Add 8 new tests covering all new metrics

## Test plan

- [x] All 33 metric tests pass (was 25, added 8 new)
- [x] Full test suite passes (dune runtest)
- [x] Code formatted (dune fmt)
- [x] Lint checks pass (dune runtest devtools/checks/)

Generated with [Claude Code](https://claude.com/claude-code)