### PR TITLE
harness: T2-B reference backtest config and expected metrics

### DIFF
--- a/dev/benchmarks/expected_metrics.sexp
+++ b/dev/benchmarks/expected_metrics.sexp
@@ -1,67 +1,82 @@
-;; Expected metric ranges for the Weinstein strategy baseline.
+;; Expected metric ranges per scenario for the Weinstein strategy baseline.
 ;; Derived from 3 golden scenarios run on 2026-04-13 against 1,654 stocks.
 ;; Code version: main@origin at commit rqytmwpz (post #291 merge).
+;;
+;; Each scenario has its own ranges reflecting the market regime it covers.
+;; A 2018-2023 run cannot be compared to a 2015-2020 run on the same scale —
+;; the latter includes a strong bull market and produces ~5x returns.
 ;;
 ;; Results are NOT fully deterministic due to Hashtbl iteration ordering in
 ;; strategy internals (PR #298). Ranges below are set wide enough to absorb
 ;; this variance while still catching genuine regressions.
 ;;
-;; Usage: future performance gate tests compare actual metrics against these
-;; ranges. A metric outside its range indicates a regression (or improvement
-;; that warrants updating this file).
+;; Usage: future performance gate tests match scenario name, then compare
+;; actual metrics against that scenario's ranges. A metric outside range
+;; indicates regression (or improvement that warrants updating this file).
 
 ((scenarios
-  ((scenario_1
-    ((period "2018-01-02 to 2023-12-29")
-     (universe_size 1654)
-     (observed
-      ((final_portfolio_value 1569627.07)
-       (total_return_pct 57.0)
-       (total_pnl -14984.72)
-       (win_count 22)
-       (loss_count 55)
-       (total_trades 77)
-       (win_rate 28.57)
-       (sharpe_ratio 1.28)
-       (max_drawdown_pct 34.04)
-       (avg_holding_days 29.87)))))
+  ((name "2018-2023-six-year")
+   (period ((start_date 2018-01-02) (end_date 2023-12-29)))
+   (universe_size 1654)
+   (observed
+    ((final_portfolio_value 1569627.07)
+     (total_return_pct 57.0)
+     (total_pnl -14984.72)
+     (win_count 22)
+     (loss_count 55)
+     (total_trades 77)
+     (win_rate 28.57)
+     (sharpe_ratio 1.28)
+     (max_drawdown_pct 34.04)
+     (avg_holding_days 29.87)))
+   (expected_ranges
+    ((total_return_pct   ((min 30.0)  (max 90.0)))
+     (total_trades       ((min 60)    (max 100)))
+     (win_rate           ((min 22.0)  (max 40.0)))
+     (sharpe_ratio       ((min 0.80)  (max 1.80)))
+     (max_drawdown_pct   ((min 25.0)  (max 45.0)))
+     (avg_holding_days   ((min 20.0)  (max 45.0))))))
 
-   (scenario_2
-    ((period "2015-01-02 to 2020-12-31")
-     (universe_size 1654)
-     (observed
-      ((final_portfolio_value 4054482.88)
-       (total_return_pct 305.0)
-       (total_pnl -5510.31)
-       (win_count 28)
-       (loss_count 56)
-       (total_trades 84)
-       (win_rate 33.33)
-       (sharpe_ratio 0.79)
-       (max_drawdown_pct 38.67)
-       (avg_holding_days 49.58)))))
+  ((name "2015-2020-bull-crash")
+   (period ((start_date 2015-01-02) (end_date 2020-12-31)))
+   (universe_size 1654)
+   (observed
+    ((final_portfolio_value 4054482.88)
+     (total_return_pct 305.0)
+     (total_pnl -5510.31)
+     (win_count 28)
+     (loss_count 56)
+     (total_trades 84)
+     (win_rate 33.33)
+     (sharpe_ratio 0.79)
+     (max_drawdown_pct 38.67)
+     (avg_holding_days 49.58)))
+   (expected_ranges
+    ((total_return_pct   ((min 200.0) (max 400.0)))
+     (total_trades       ((min 70)    (max 110)))
+     (win_rate           ((min 25.0)  (max 45.0)))
+     (sharpe_ratio       ((min 0.50)  (max 1.20)))
+     (max_drawdown_pct   ((min 30.0)  (max 50.0)))
+     (avg_holding_days   ((min 35.0)  (max 65.0))))))
 
-   (scenario_3
-    ((period "2020-01-02 to 2024-12-31")
-     (universe_size 1654)
-     (observed
-      ((final_portfolio_value 1268701.63)
-       (total_return_pct 27.0)
-       (total_pnl 38835.51)
-       (win_count 52)
-       (loss_count 57)
-       (total_trades 109)
-       (win_rate 47.71)
-       (sharpe_ratio 1.00)
-       (max_drawdown_pct 37.95)
-       (avg_holding_days 34.40)))))))
-
- ;; Acceptable ranges across all scenarios. A future run that falls outside
- ;; these ranges should be investigated as a potential regression.
- (expected_ranges
-  ((total_return_pct ((min 20.0) (max 350.0)))
-   (total_trades     ((min 70)   (max 120)))
-   (win_rate         ((min 25.0) (max 55.0)))
-   (sharpe_ratio     ((min 0.60) (max 1.50)))
-   (max_drawdown_pct ((min 25.0) (max 45.0)))
-   (avg_holding_days ((min 20.0) (max 60.0))))))
+  ((name "2020-2024-covid-recovery")
+   (period ((start_date 2020-01-02) (end_date 2024-12-31)))
+   (universe_size 1654)
+   (observed
+    ((final_portfolio_value 1268701.63)
+     (total_return_pct 27.0)
+     (total_pnl 38835.51)
+     (win_count 52)
+     (loss_count 57)
+     (total_trades 109)
+     (win_rate 47.71)
+     (sharpe_ratio 1.00)
+     (max_drawdown_pct 37.95)
+     (avg_holding_days 34.40)))
+   (expected_ranges
+    ((total_return_pct   ((min 15.0)  (max 45.0)))
+     (total_trades       ((min 90)    (max 130)))
+     (win_rate           ((min 40.0)  (max 55.0)))
+     (sharpe_ratio       ((min 0.70)  (max 1.40)))
+     (max_drawdown_pct   ((min 30.0)  (max 45.0)))
+     (avg_holding_days   ((min 25.0)  (max 45.0))))))))

--- a/dev/benchmarks/expected_metrics.sexp
+++ b/dev/benchmarks/expected_metrics.sexp
@@ -1,0 +1,67 @@
+;; Expected metric ranges for the Weinstein strategy baseline.
+;; Derived from 3 golden scenarios run on 2026-04-13 against 1,654 stocks.
+;; Code version: main@origin at commit rqytmwpz (post #291 merge).
+;;
+;; Results are NOT fully deterministic due to Hashtbl iteration ordering in
+;; strategy internals (PR #298). Ranges below are set wide enough to absorb
+;; this variance while still catching genuine regressions.
+;;
+;; Usage: future performance gate tests compare actual metrics against these
+;; ranges. A metric outside its range indicates a regression (or improvement
+;; that warrants updating this file).
+
+((scenarios
+  ((scenario_1
+    ((period "2018-01-02 to 2023-12-29")
+     (universe_size 1654)
+     (observed
+      ((final_portfolio_value 1569627.07)
+       (total_return_pct 57.0)
+       (total_pnl -14984.72)
+       (win_count 22)
+       (loss_count 55)
+       (total_trades 77)
+       (win_rate 28.57)
+       (sharpe_ratio 1.28)
+       (max_drawdown_pct 34.04)
+       (avg_holding_days 29.87)))))
+
+   (scenario_2
+    ((period "2015-01-02 to 2020-12-31")
+     (universe_size 1654)
+     (observed
+      ((final_portfolio_value 4054482.88)
+       (total_return_pct 305.0)
+       (total_pnl -5510.31)
+       (win_count 28)
+       (loss_count 56)
+       (total_trades 84)
+       (win_rate 33.33)
+       (sharpe_ratio 0.79)
+       (max_drawdown_pct 38.67)
+       (avg_holding_days 49.58)))))
+
+   (scenario_3
+    ((period "2020-01-02 to 2024-12-31")
+     (universe_size 1654)
+     (observed
+      ((final_portfolio_value 1268701.63)
+       (total_return_pct 27.0)
+       (total_pnl 38835.51)
+       (win_count 52)
+       (loss_count 57)
+       (total_trades 109)
+       (win_rate 47.71)
+       (sharpe_ratio 1.00)
+       (max_drawdown_pct 37.95)
+       (avg_holding_days 34.40)))))))
+
+ ;; Acceptable ranges across all scenarios. A future run that falls outside
+ ;; these ranges should be investigated as a potential regression.
+ (expected_ranges
+  ((total_return_pct ((min 20.0) (max 350.0)))
+   (total_trades     ((min 70)   (max 120)))
+   (win_rate         ((min 25.0) (max 55.0)))
+   (sharpe_ratio     ((min 0.60) (max 1.50)))
+   (max_drawdown_pct ((min 25.0) (max 45.0)))
+   (avg_holding_days ((min 20.0) (max 60.0))))))

--- a/dev/benchmarks/reference_backtest.sexp
+++ b/dev/benchmarks/reference_backtest.sexp
@@ -1,0 +1,115 @@
+;; Reference backtest configuration — default Weinstein strategy parameters.
+;; Extracted from Weinstein_strategy.default_config and sub-module defaults.
+;; Used as the baseline for performance gate comparisons (T2-B).
+;;
+;; To reproduce: run backtest_runner with no --override flags.
+;; Any --override changes only the overridden field; all others stay at these
+;; defaults.
+
+((runner
+  ((initial_cash 1000000.0)
+   (index_symbol GSPC.INDX)
+   (commission ((per_share 0.01) (minimum 1.0)))
+   (warmup_days 210)
+   (strategy_cadence Daily)))
+
+ (strategy
+  ((initial_stop_buffer 1.02)
+   (lookback_bars 52)))
+
+ (stage
+  ((ma_period 30)
+   (ma_type Wma)
+   (slope_threshold 0.005)
+   (slope_lookback 4)
+   (confirm_weeks 6)
+   (late_stage2_decel 0.5)))
+
+ (macro
+  ((bullish_threshold 0.65)
+   (bearish_threshold 0.35)
+   (indicator_weights
+    ((w_index_stage 3.0)
+     (w_ad_line 2.0)
+     (w_momentum_index 2.0)
+     (w_nh_nl 1.5)
+     (w_global 1.5)))
+   (indicator_thresholds
+    ((ad_line_lookback 26)
+     (momentum_period 200)
+     (nh_nl_lookback 13)
+     (nh_nl_up_threshold 1.02)
+     (nh_nl_down_threshold 0.98)
+     (ad_min_bars 4)
+     (nh_nl_min_bars 10)
+     (global_consensus_threshold 0.6)))))
+
+ (screening
+  ((min_grade C)
+   (max_buy_candidates 20)
+   (max_short_candidates 10)
+   (weights
+    ((w_stage2_breakout 30)
+     (w_strong_volume 20)
+     (w_adequate_volume 10)
+     (w_positive_rs 20)
+     (w_bullish_rs_crossover 10)
+     (w_clean_resistance 15)
+     (w_sector_strong 10)
+     (w_late_stage2_penalty -15)))
+   (grade_thresholds
+    ((a_plus 85) (a 70) (b 55) (c 40) (d 25)))
+   (candidate_params
+    ((entry_buffer_pct 0.005)
+     (initial_stop_pct 0.08)
+     (short_stop_pct 0.08)
+     (base_low_proxy_pct 0.15)
+     (breakout_fallback_pct 0.05)))))
+
+ (portfolio_risk
+  ((risk_per_trade_pct 0.01)
+   (max_positions 20)
+   (max_long_exposure_pct 0.90)
+   (max_short_exposure_pct 0.30)
+   (min_cash_pct 0.10)
+   (max_sector_concentration 5)
+   (max_unknown_sector_positions 2)
+   (big_winner_multiplier 1.5)))
+
+ (stops
+  ((round_number_nudge 0.125)
+   (min_correction_pct 0.08)
+   (tighten_on_flat_ma true)
+   (ma_flat_threshold 0.002)
+   (trailing_stop_buffer_pct 0.01)
+   (tightened_stop_buffer_pct 0.005)))
+
+ (stock_analysis
+  ((breakout_event_lookback 8)
+   (base_lookback_weeks 52)
+   (base_end_offset_weeks 8)))
+
+ (rs
+  ((rs_ma_period 52)
+   (trend_lookback 4)
+   (flat_threshold 0.98)))
+
+ (volume
+  ((lookback_bars 4)
+   (strong_threshold 2.0)
+   (adequate_threshold 1.5)
+   (pullback_contraction 0.25)))
+
+ (resistance
+  ((chart_lookback_bars 130)
+   (virgin_lookback_bars 520)
+   (congestion_band_pct 0.05)
+   (heavy_resistance_bars 8)
+   (moderate_resistance_bars 3)))
+
+ (sector
+  ((strong_confidence 0.6)
+   (weak_confidence 0.4)
+   (stage_weight 0.40)
+   (rs_weight 0.35)
+   (constituent_weight 0.25))))

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -51,7 +51,7 @@ IN_PROGRESS
 ## Tier 2 — Milestone-gated
 
 - [ ] T2-B: Performance gate test (`trading/weinstein/simulation/test/performance_gate_test.ml`) (at M5)
-- [ ] T2-B: Reference backtest config + expected metrics (`dev/benchmarks/reference_backtest.json`) (at M5)
+- [x] T2-B: Reference backtest config + expected metrics (`dev/benchmarks/reference_backtest.sexp`, `dev/benchmarks/expected_metrics.sexp`) — DONE: see completion note below
 - [ ] T2-C: Walk-forward regression gate (`dev/benchmarks/best_config.json`) (at M7)
 - [ ] T2-D: Live trading gate + paper-trading validation period in `dev/milestones/m6-paper-trading.md` (before M6)
 
@@ -164,6 +164,11 @@ IN_PROGRESS
 ### T1-Q: Cyclomatic complexity linter
 
 - [x] T1-Q: CC linter — `trading/devtools/cc_linter/cc_linter.ml`; OCaml AST via `compiler-libs`; CC > 10 = warning (not failure); exits 0 always; optional JSON output to `dev/metrics/cc-YYYY-MM-DD.json`. Wired into `dune runtest` via `trading/devtools/checks/dune`. Verify: `dune runtest trading/devtools/checks/` — exits 0; prints OK or warning list.
+
+### T2-B: Reference backtest config + expected metrics
+
+- [x] T2-B: Reference backtest config — `dev/benchmarks/reference_backtest.sexp`; full default strategy config extracted from `Weinstein_strategy.default_config` and all sub-module defaults (stage, macro, screening, portfolio_risk, stops, stock_analysis, rs, volume, resistance, sector). Includes runner parameters (initial_cash, commission, warmup_days, strategy_cadence). Verify: `cat dev/benchmarks/reference_backtest.sexp` — should list all configurable parameters with their default values.
+- [x] T2-B: Expected metrics — `dev/benchmarks/expected_metrics.sexp`; observed metrics from 3 golden scenarios (2018-2023, 2015-2020, 2020-2024) on 1,654 stocks, plus acceptable ranges for regression detection: return 20-350%, trades 70-120, win rate 25-55%, Sharpe 0.60-1.50, max drawdown 25-45%, avg holding 20-60 days. Ranges set wide enough to absorb Hashtbl ordering non-determinism while catching genuine regressions. Verify: `cat dev/benchmarks/expected_metrics.sexp`.
 
 ### T3-B and T3-F
 


### PR DESCRIPTION
## Summary

Implements T2-B from harness status: reference backtest config + expected metrics baseline.

- `dev/benchmarks/reference_backtest.sexp` — full default strategy config (stage, macro, screener, portfolio risk, stops, runner params)
- `dev/benchmarks/expected_metrics.sexp` — observed metrics from 3 golden scenarios with acceptable regression ranges
- Updated `dev/status/harness.md` — T2-B marked complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)