### PR TITLE
feat: add sexp deriving to Weinstein config types

### DIFF
--- a/trading/analysis/weinstein/macro/lib/macro.mli
+++ b/trading/analysis/weinstein/macro/lib/macro.mli
@@ -24,6 +24,7 @@ type indicator_reading = {
   weight : float;
   detail : string;
 }
+[@@deriving sexp]
 (** One indicator reading with its signal and weight. *)
 
 type indicator_weights = {
@@ -35,6 +36,7 @@ type indicator_weights = {
       (** Weight for New Highs - New Lows divergence. Default: 1.5. *)
   w_global : float;  (** Weight for global market consensus. Default: 1.5. *)
 }
+[@@deriving sexp]
 
 type indicator_thresholds = {
   ad_line_lookback : int;
@@ -53,6 +55,7 @@ type indicator_thresholds = {
   global_consensus_threshold : float;
       (** Fraction of markets for a global consensus signal. Default: 0.6. *)
 }
+[@@deriving sexp]
 
 type config = {
   stage_config : Stage.config;  (** Config for classifying the index stage. *)
@@ -61,6 +64,7 @@ type config = {
   indicator_weights : indicator_weights;
   indicator_thresholds : indicator_thresholds;
 }
+[@@deriving sexp]
 (** Configuration for macro analysis. *)
 
 val default_indicator_weights : indicator_weights

--- a/trading/analysis/weinstein/macro/lib/macro_types.ml
+++ b/trading/analysis/weinstein/macro/lib/macro_types.ml
@@ -7,6 +7,7 @@ type indicator_reading = {
   weight : float;
   detail : string;
 }
+[@@deriving sexp]
 
 type indicator_weights = {
   w_index_stage : float;
@@ -15,6 +16,7 @@ type indicator_weights = {
   w_nh_nl : float;
   w_global : float;
 }
+[@@deriving sexp]
 
 type indicator_thresholds = {
   ad_line_lookback : int;
@@ -26,6 +28,7 @@ type indicator_thresholds = {
   nh_nl_min_bars : int;
   global_consensus_threshold : float;
 }
+[@@deriving sexp]
 
 type config = {
   stage_config : Stage.config;
@@ -34,6 +37,7 @@ type config = {
   indicator_weights : indicator_weights;
   indicator_thresholds : indicator_thresholds;
 }
+[@@deriving sexp]
 
 type ad_bar = { date : Date.t; advancing : int; declining : int }
 

--- a/trading/analysis/weinstein/macro/lib/macro_types.mli
+++ b/trading/analysis/weinstein/macro/lib/macro_types.mli
@@ -11,6 +11,7 @@ type indicator_reading = {
   weight : float;
   detail : string;
 }
+[@@deriving sexp]
 
 type indicator_weights = {
   w_index_stage : float;
@@ -19,6 +20,7 @@ type indicator_weights = {
   w_nh_nl : float;
   w_global : float;
 }
+[@@deriving sexp]
 
 type indicator_thresholds = {
   ad_line_lookback : int;
@@ -30,6 +32,7 @@ type indicator_thresholds = {
   nh_nl_min_bars : int;
   global_consensus_threshold : float;
 }
+[@@deriving sexp]
 
 type config = {
   stage_config : Stage.config;
@@ -38,6 +41,7 @@ type config = {
   indicator_weights : indicator_weights;
   indicator_thresholds : indicator_thresholds;
 }
+[@@deriving sexp]
 
 type ad_bar = { date : Core.Date.t; advancing : int; declining : int }
 

--- a/trading/analysis/weinstein/screener/lib/dune
+++ b/trading/analysis/weinstein/screener/lib/dune
@@ -4,4 +4,4 @@
  (wrapped false)
  (libraries core types weinstein_types stock_analysis)
  (preprocess
-  (pps ppx_deriving.show ppx_deriving.eq)))
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -2,13 +2,14 @@
 open Core
 open Weinstein_types
 
-type sector_rating = Strong | Neutral | Weak [@@deriving show, eq]
+type sector_rating = Strong | Neutral | Weak [@@deriving show, eq, sexp]
 
 type sector_context = {
   sector_name : string;
   rating : sector_rating;
   stage : stage;
 }
+[@@deriving sexp]
 
 type scoring_weights = {
   w_stage2_breakout : int;
@@ -20,6 +21,7 @@ type scoring_weights = {
   w_sector_strong : int;
   w_late_stage2_penalty : int;
 }
+[@@deriving sexp]
 
 let default_scoring_weights =
   {
@@ -34,6 +36,7 @@ let default_scoring_weights =
   }
 
 type grade_thresholds = { a_plus : int; a : int; b : int; c : int; d : int }
+[@@deriving sexp]
 (** Score cutoffs for each grade. All are configurable. *)
 
 let default_grade_thresholds = { a_plus = 85; a = 70; b = 55; c = 40; d = 25 }
@@ -53,6 +56,7 @@ type candidate_params = {
       (** Fraction above MA used as breakout price when none is detected.
           Default: 0.05. *)
 }
+[@@deriving sexp]
 (** Per-candidate price computation parameters. All configurable. *)
 
 let default_candidate_params =
@@ -72,6 +76,7 @@ type config = {
   max_buy_candidates : int;
   max_short_candidates : int;
 }
+[@@deriving sexp]
 
 let default_config =
   {

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -13,13 +13,14 @@
     All functions are pure. *)
 
 (** Sector health rating used by the screener gate. *)
-type sector_rating = Strong | Neutral | Weak [@@deriving show, eq]
+type sector_rating = Strong | Neutral | Weak [@@deriving show, eq, sexp]
 
 type sector_context = {
   sector_name : string;
   rating : sector_rating;
   stage : Weinstein_types.stage;
 }
+[@@deriving sexp]
 (** Minimal sector context the screener needs per stock. *)
 
 type scoring_weights = {
@@ -41,12 +42,14 @@ type scoring_weights = {
   w_late_stage2_penalty : int;
       (** Negative weight for late Stage2 flag. Default: -15. *)
 }
+[@@deriving sexp]
 (** Scoring weights for each positive signal. All are configurable. *)
 
 val default_scoring_weights : scoring_weights
 (** [default_scoring_weights] provides the reference weights. *)
 
 type grade_thresholds = { a_plus : int; a : int; b : int; c : int; d : int }
+[@@deriving sexp]
 (** Score cutoffs for each grade. All are configurable. *)
 
 val default_grade_thresholds : grade_thresholds
@@ -67,6 +70,7 @@ type candidate_params = {
       (** Fraction above MA used as breakout price when none is detected.
           Default: 0.05. *)
 }
+[@@deriving sexp]
 (** Per-candidate price computation parameters. All configurable. *)
 
 val default_candidate_params : candidate_params
@@ -86,6 +90,7 @@ type config = {
   max_short_candidates : int;
       (** Maximum number of short candidates returned. Default: 10. *)
 }
+[@@deriving sexp]
 (** Main screener configuration. *)
 
 val default_config : config

--- a/trading/analysis/weinstein/stage/lib/dune
+++ b/trading/analysis/weinstein/stage/lib/dune
@@ -9,4 +9,4 @@
   indicators.ema
   indicators.types)
  (preprocess
-  (pps ppx_deriving.show ppx_deriving.eq)))
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/analysis/weinstein/stage/lib/stage.ml
+++ b/trading/analysis/weinstein/stage/lib/stage.ml
@@ -6,7 +6,7 @@ open Weinstein_types
 (* Config and defaults                                                  *)
 (* ------------------------------------------------------------------ *)
 
-type ma_type = Sma | Wma | Ema [@@deriving show, eq]
+type ma_type = Sma | Wma | Ema [@@deriving show, eq, sexp]
 
 type config = {
   ma_period : int;
@@ -16,6 +16,7 @@ type config = {
   confirm_weeks : int;
   late_stage2_decel : float;
 }
+[@@deriving sexp]
 
 let default_config =
   {

--- a/trading/analysis/weinstein/stage/lib/stage.mli
+++ b/trading/analysis/weinstein/stage/lib/stage.mli
@@ -7,7 +7,7 @@ open Types
     Weinstein's book specifies a plain 30-week SMA, but [Wma] is a common
     practical substitute; [Ema] is available for parameter-tuning experiments.
 *)
-type ma_type = Sma | Wma | Ema [@@deriving show, eq]
+type ma_type = Sma | Wma | Ema [@@deriving show, eq, sexp]
 
 (** Stage classifier for the Weinstein methodology.
 
@@ -33,6 +33,7 @@ type config = {
           reading this much below the recent peak slope triggers [late=true].
           Default: 0.5 (50% deceleration from recent peak). *)
 }
+[@@deriving sexp]
 (** Configuration for stage classification. All thresholds are configurable to
     enable parameter tuning via backtesting. *)
 

--- a/trading/trading/weinstein/portfolio_risk/lib/dune
+++ b/trading/trading/weinstein/portfolio_risk/lib/dune
@@ -3,4 +3,4 @@
  (public_name weinstein_trading.portfolio_risk)
  (libraries core weinstein.types trading.portfolio status)
  (preprocess
-  (pps ppx_deriving.show ppx_deriving.eq)))
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
@@ -41,7 +41,7 @@ type config = {
   max_unknown_sector_positions : int;
   big_winner_multiplier : float;
 }
-[@@deriving show, eq]
+[@@deriving show, eq, sexp]
 
 let default_config =
   {

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
@@ -120,7 +120,7 @@ type config = {
   big_winner_multiplier : float;
       (** Size multiplier for high-conviction trades (default: 1.5x) *)
 }
-[@@deriving show, eq]
+[@@deriving show, eq, sexp]
 (** All risk management parameters — nothing hardcoded. *)
 
 val default_config : config

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -16,4 +16,4 @@
   weinstein.screener
   indicators.time_period)
  (preprocess
-  (pps ppx_let ppx_deriving.show ppx_deriving.eq)))
+  (pps ppx_let ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -14,6 +14,7 @@ module Macro_inputs = Macro_inputs
     callers to use in {!config}. *)
 
 type index_config = { primary : string; global : (string * string) list }
+[@@deriving sexp]
 
 type config = {
   universe : string list;
@@ -27,6 +28,7 @@ type config = {
   initial_stop_buffer : float;
   lookback_bars : int;
 }
+[@@deriving sexp]
 
 let default_config ~universe ~index_symbol =
   {

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -63,6 +63,7 @@ type index_config = {
           ISF.LSE) triple. [primary] is intentionally excluded from this list —
           it is already passed via [~index_bars]. *)
 }
+[@@deriving sexp]
 (** Indices consumed by the macro analyser. The primary index is the US
     benchmark; globals are additional markets used only for the global consensus
     indicator. *)
@@ -92,6 +93,7 @@ type config = {
       (** Number of weekly bars to pass to stage/macro analysers (default: 52).
           Must be >= 30 (one MA period). *)
 }
+[@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for
     backtesting. *)
 


### PR DESCRIPTION
## Summary

Prerequisite for generic sexp-based config override (PR #306 rework). Adds `[@@deriving sexp]` to all Weinstein strategy config types so they can be serialized/deserialized via s-expressions.

Purely additive — no behavior changes. All default config values, record structures, and fields are untouched; only the deriving attribute list is extended.

## Types updated

- `Stage.config`, `Stage.ma_type`
- `Macro.config`, `Macro.indicator_weights`, `Macro.indicator_thresholds`, `Macro.indicator_reading` (and their `Macro_types` counterparts)
- `Screener.config`, `Screener.sector_rating`, `Screener.sector_context`, `Screener.scoring_weights`, `Screener.grade_thresholds`, `Screener.candidate_params`
- `Portfolio_risk.config`
- `Weinstein_strategy.config`, `Weinstein_strategy.index_config`

`Weinstein_stops.config` and `Weinstein_types.*` already had `sexp`. `ppx_sexp_conv` added to dune preprocess lists where missing (`stage`, `screener`, `portfolio_risk`, `weinstein_strategy`). `macro` and `stops` already had it.

## Test plan

- [x] `dune build` — full project compiles
- [x] `dune runtest` — all tests pass
- [x] `dune fmt` — no formatting changes needed
- [x] `dune runtest devtools/checks/` — mli coverage, nesting, cc, fmt, magic-numbers, file-length all pass