### PR TITLE
harness: stream live events from dev/run.sh + heartbeat

### DIFF
--- a/dev/lib/format-event.jq
+++ b/dev/lib/format-event.jq
@@ -1,0 +1,27 @@
+# jq filter for `claude -p --output-format stream-json` events.
+#
+# Usage:
+#   claude -p --output-format stream-json ... | jq -r --unbuffered -f format-event.jq
+#
+# Produces one human-readable line per event, dropping types we don't
+# care to surface in the live ticker. Unknown event shapes return empty
+# (degrade to silence rather than crash).
+#
+# Test by hand against a fixture:
+#   echo '{"type":"tool_use","name":"Agent","input":{"subagent_type":"feat-backtest"}}' \
+#     | jq -r -f dev/lib/format-event.jq
+
+def ts: (now | strftime("%H:%M:%S"));
+
+if .type == "tool_use" then
+  "[\(ts)] tool: \(.name // "?")"
+    + (if .input.subagent_type then "  (subagent: \(.input.subagent_type))" else "" end)
+elif .type == "text" then
+  .text
+elif .type == "result" then
+  "[\(ts)] === orchestrator returned ==="
+elif .type == "system" then
+  "[\(ts)] system: \(.subtype // .message // "?")"
+else
+  empty
+end

--- a/dev/lib/heartbeat.sh
+++ b/dev/lib/heartbeat.sh
@@ -1,0 +1,38 @@
+# Heartbeat helper for long-running scripts.
+#
+# Use:
+#   . "$REPO_ROOT/dev/lib/heartbeat.sh"
+#   heartbeat_start "$LOG_FILE"   # echoes elapsed time every 30s
+#   ... long-running command ...
+#   heartbeat_stop                # tear down
+#
+# heartbeat_start also installs an EXIT trap so the heartbeat dies even
+# if the parent script crashes. Caller may override the interval via
+# HEARTBEAT_INTERVAL=<seconds> before calling.
+
+_HEARTBEAT_PID=""
+_HEARTBEAT_START=0
+
+heartbeat_start() {
+  local log_file="$1"
+  local interval="${HEARTBEAT_INTERVAL:-30}"
+  _HEARTBEAT_START=$SECONDS
+  (
+    while true; do
+      sleep "$interval"
+      local elapsed=$(($SECONDS - _HEARTBEAT_START))
+      printf '[heartbeat] still running, t+%dm%02ds\n' \
+        $((elapsed / 60)) $((elapsed % 60)) | tee -a "$log_file"
+    done
+  ) &
+  _HEARTBEAT_PID=$!
+  trap 'heartbeat_stop' EXIT
+}
+
+heartbeat_stop() {
+  if [ -n "$_HEARTBEAT_PID" ]; then
+    kill "$_HEARTBEAT_PID" 2>/dev/null || true
+    _HEARTBEAT_PID=""
+  fi
+  trap - EXIT
+}

--- a/dev/lib/preflight.sh
+++ b/dev/lib/preflight.sh
@@ -1,0 +1,34 @@
+# Pre-flight checks for any script that invokes the lead-orchestrator via
+# `claude -p`. Source this; on failure it prints `FAIL: ...` to stderr and
+# exits non-zero so the caller dies at the shell, not silently inside the
+# orchestrator.
+#
+# Required environment when sourcing:
+#   REPO_ROOT — absolute path to the repo root (the script's caller sets this).
+#
+# Checks:
+#   1. claude binary on PATH
+#   2. lead-orchestrator agent definition exists at the expected location
+#   3. agent definition has a ## Allowed Tools section
+#   4. that section mentions the Agent tool (catches silent toolset drift)
+
+: "${REPO_ROOT:?preflight.sh: REPO_ROOT must be set by the caller}"
+
+_orch_def="$REPO_ROOT/.claude/agents/lead-orchestrator.md"
+
+command -v claude >/dev/null \
+  || { echo "FAIL: claude CLI not found on PATH" >&2; exit 1; }
+
+[ -f "$_orch_def" ] \
+  || { echo "FAIL: agent definition missing at $_orch_def" >&2; exit 1; }
+
+grep -q '^## Allowed Tools' "$_orch_def" \
+  || { echo "FAIL: lead-orchestrator missing '## Allowed Tools' section" >&2; exit 1; }
+
+awk '/^## Allowed Tools/{f=1; next} /^## /{f=0} f' "$_orch_def" \
+  | grep -q 'Agent' \
+  || { echo "FAIL: lead-orchestrator '## Allowed Tools' does not list Agent" >&2; exit 1; }
+
+if ! command -v jq >/dev/null; then
+  echo "WARN: jq not found — stream events will pass through unformatted" >&2
+fi

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -1,52 +1,80 @@
 #!/usr/bin/env bash
-# Daily development run for the Weinstein Trading System.
-# Runs the lead orchestrator non-interactively.
-# Usage: ./dev/run.sh
-#        or via cron: 0 7 * * * /home/user/trading/dev/run.sh
+# Daily lead-orchestrator run.
+#
+# Usage:
+#   ./dev/run.sh             — full run (dispatches subagents)
+#   ./dev/run.sh --plan      — dry run (read state + print plan, no dispatch;
+#                              see lead-orchestrator.md `## Plan Mode`)
+#   via cron: 0 7 * * * /home/user/trading/dev/run.sh
+#
+# The script keeps you informed during long quiet stretches:
+#   - intermediate tool calls + subagent dispatches stream live
+#   - a heartbeat prints elapsed time every 30s
+# Raw stream-json goes to dev/logs/<date>.jsonl for forensics; the
+# human-readable view also lands in dev/logs/<date>.log.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$REPO_ROOT/dev/lib/preflight.sh"
+. "$REPO_ROOT/dev/lib/heartbeat.sh"
 
-# Pre-flight: fast-fail if the invocation environment is broken.
-# These checks catch common misconfigurations (missing CLI, relocated agent
-# file, silently-drifted Allowed Tools section) at the shell level, before
-# we burn tokens spinning up the orchestrator only for it to bail out.
-_ORCH_AGENT="$REPO_ROOT/.claude/agents/lead-orchestrator.md"
-command -v claude >/dev/null 2>&1 \
-  || { echo "FAIL: 'claude' binary not on PATH" >&2; exit 1; }
-[ -f "$_ORCH_AGENT" ] \
-  || { echo "FAIL: lead-orchestrator agent definition missing at $_ORCH_AGENT" >&2; exit 1; }
-# Soft grep: the Allowed Tools section must mention Agent. Plain-text match
-# is sufficient — catches the drift case where someone edits the file and
-# drops Agent from the tool list.
-grep -q '^## Allowed Tools' "$_ORCH_AGENT" \
-  || { echo "FAIL: lead-orchestrator missing '## Allowed Tools' section" >&2; exit 1; }
-awk '/^## Allowed Tools/{flag=1; next} /^## /{flag=0} flag' "$_ORCH_AGENT" | grep -q 'Agent' \
-  || { echo "FAIL: lead-orchestrator '## Allowed Tools' section does not list Agent" >&2; exit 1; }
-
-LOG_DIR="$REPO_ROOT/dev/logs"
-mkdir -p "$LOG_DIR"
+PLAN_FLAG=""
+for arg in "$@"; do
+  case "$arg" in
+    --plan) PLAN_FLAG=" --plan" ;;
+    *) echo "Usage: $0 [--plan]" >&2; exit 1 ;;
+  esac
+done
 
 DATE="$(date +%Y-%m-%d)"
+LOG_DIR="$REPO_ROOT/dev/logs"
+mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/$DATE.log"
+JSONL_FILE="$LOG_DIR/$DATE.jsonl"
+SUMMARY_FILE="$REPO_ROOT/dev/daily/$DATE${PLAN_FLAG:+-plan}.md"
+JQ_FILTER="$REPO_ROOT/dev/lib/format-event.jq"
 
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting daily run" | tee -a "$LOG_FILE"
+PROMPT="Run the daily development session for the Weinstein Trading System.
+Today's date is $DATE.${PLAN_FLAG}
+
+Follow your instructions in .claude/agents/lead-orchestrator.md exactly."
+
+PIPE_FILTER='cat'
+command -v jq >/dev/null && PIPE_FILTER="jq -r --unbuffered -f $JQ_FILTER"
+
+echo "[$(date '+%H:%M:%S')] Starting daily run${PLAN_FLAG:+ (plan mode)}" \
+  | tee -a "$LOG_FILE"
+echo "[$(date '+%H:%M:%S')] Log: $LOG_FILE  Stream: $JSONL_FILE" \
+  | tee -a "$LOG_FILE"
 
 cd "$REPO_ROOT"
+heartbeat_start "$LOG_FILE"
 
+set +e
 claude -p \
+  --output-format stream-json \
+  --verbose \
   --allowedTools "Agent,Bash,Read,Write,Edit,Glob,Grep" \
   --agent lead-orchestrator \
-  "Run the daily development session for the Weinstein Trading System.
-Today's date is $(date +%Y-%m-%d).
+  "$PROMPT" \
+  2> >(tee -a "$LOG_FILE" >&2) \
+| tee -a "$JSONL_FILE" \
+| eval "$PIPE_FILTER" \
+| tee -a "$LOG_FILE"
+RC=${PIPESTATUS[0]}
+set -e
 
-Follow your instructions exactly:
-1. Read dev/decisions.md and all dev/status/*.md
-2. Spawn eligible feature agents as parallel subagents (isolation: worktree)
-3. Spawn QC agents for any READY_FOR_REVIEW features
-4. Write dev/daily/$(date +%Y-%m-%d).md with the full status summary" \
-  2>&1 | tee -a "$LOG_FILE"
+heartbeat_stop
 
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] Daily run complete. Summary: $REPO_ROOT/dev/daily/$DATE.md" \
+ELAPSED=$SECONDS
+echo "[$(date '+%H:%M:%S')] Daily run complete in ${ELAPSED}s (rc=$RC)" \
   | tee -a "$LOG_FILE"
+if [ -f "$SUMMARY_FILE" ]; then
+  echo "[$(date '+%H:%M:%S')] Summary: $SUMMARY_FILE" | tee -a "$LOG_FILE"
+else
+  echo "[$(date '+%H:%M:%S')] WARN: no summary written at $SUMMARY_FILE" \
+    | tee -a "$LOG_FILE"
+fi
+
+exit $RC


### PR DESCRIPTION
Two UX issues with the current `dev/run.sh` that made it feel dead during a real lead-orchestrator run:

1. Pipe buffering — claude -p emits intermediate events but the tee-pipe block-buffered them; terminal silent for tens of seconds.
2. Long quiet stretches — subagents take minutes; nothing on stdout meanwhile.

Fix:

- `--output-format stream-json` + `jq` one-line ticker. Each event becomes a single human-readable line:
  ```
  [HH:MM:SS] tool: Agent  (subagent: harness-maintainer)
  [HH:MM:SS] tool: Bash
  [HH:MM:SS] === orchestrator returned ===
  ```
- Free assistant text printed verbatim. Unknown event types degrade to silence rather than crash.
- Raw JSONL → `dev/logs/<DATE>.jsonl` for forensics; readable output → `dev/logs/<DATE>.log`.
- Heartbeat process prints `[heartbeat] still running, t+5m12s` every 30s; killed via trap on exit. Long quiet stretches now have a periodic alive-signal.

Also bundled (small):
- Pre-flight assertions: `claude` on PATH, agent definition exists, `## Allowed Tools` lists `Agent`. Fast-fails at the shell instead of bailing out inside the orchestrator.
- `--plan` flag forwarding so the same script drives plan-mode dry runs (uses the lead-orchestrator `## Plan Mode` contract from #323).
- Final `completed in Ns (rc=N)` line + summary-file path check.

Verified locally:
- `bash -n` parses cleanly
- Heartbeat smoke-test fires every 1s as expected
- jq filter formats fake stream-json events into the readable ticker shape

Note: this overlaps slightly with #323 on the pre-flight check — both add the same three asserts. Whichever lands second is a no-op modification on the same lines. Cleanest sequencing: land #323 first, this rebases trivially.