### PR TITLE
ci: cache _build/ between PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Cache _build/ between runs. dune is incremental: when the source +
+      # dune files + opam dep set haven't changed, restoring _build turns
+      # `dune build` into a near-instant no-op (was ~40s cold).
+      #
+      # Key strategy: hash everything dune sees as input. On a hit we get
+      # the prior build artefacts; on a miss (any source/dep file changed)
+      # we fall back to restore-keys for a partial cache, then dune does
+      # incremental work from there.
+      - name: Cache _build
+        uses: actions/cache@v4
+        with:
+          path: trading/_build
+          key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
+          restore-keys: |
+            dune-${{ runner.os }}-
+
       - name: dune build
         run: |
           eval $(opam env)


### PR DESCRIPTION
## Summary

Latest CI run breakdown:

| Step | Time |
|---|---|
| Initialize containers | 119s (66%) |
| **dune build** | **41s** |
| dune runtest | 12s |
| dune fmt check | 2s |
| Other | <5s |

Cache `trading/_build/` between runs keyed on a hash of everything dune sees as input (`*.opam`, `dune`, `dune-project`, `*.ml`, `*.mli`).

## Expected

- **Doc-only PRs** (most of recent batch — agent defs, status files) → cache hit → near-zero build time, ~30-40s saved.
- **Real source PRs** → cache miss; `restore-keys` gives a partial cache, dune does incremental compilation from there. Save varies — maybe 10-20s on small touches.

## Notes

- GHA cache caps: 10 GB per repo, 7-day idle eviction.
- `_build/` compresses well; cache entries should be a few hundred MB.
- **Container init (119s) is unaffected** — that is the real elephant. Reducing it further needs image slimming (drop `plplot` — requires splitting `trend` lib so `regression`/`segmentation` don't pull it in — or audit redundant apt deps like `liblapack-dev` vs `libopenblas-dev`). Tracked separately.

## Test plan

- [x] First merged PR after this lands shows the cache being populated (`Cache _build` step in workflow run)
- [ ] Second PR (a doc-only one) shows the cache hit and `dune build` taking <5s