### PR TITLE
docs: refresh stale daily summary + add reconcile followup

### DIFF
--- a/dev/daily/2026-04-14.md
+++ b/dev/daily/2026-04-14.md
@@ -1,0 +1,83 @@
+# Status — 2026-04-14
+
+> Note: the earlier version of this file (written by the 12:35 UTC
+> orchestrator run) carried forward stale content from 2026-04-11 daily
+> summaries. Rewritten at end of day with reconciled current state.
+
+## Feature Progress
+
+### weinstein/order_gen  [MERGED]
+- `feat/weinstein` branch no longer exists on origin; order_gen work absorbed into main. No further action.
+
+### weinstein/simulation  [MERGED]
+- All slices merged. No open work. Follow-up items tracked in `dev/status/simulation.md`.
+
+### backtest-infra  [IN_PROGRESS]
+- `feat-backtest` agent created today (#329). Not yet exercised.
+- Immediate item: stop-buffer tuning experiment (still open, flagship).
+
+## QC Status
+- portfolio-stops (order_gen): APPROVED — see `dev/reviews/portfolio-stops.md`
+- simulation: APPROVED — see `dev/reviews/simulation.md`
+
+No new QC work today.
+
+## Harness Work
+
+**Dispatched earlier today:**
+- `harness-maintainer` on **T3-A** (health-scanner deep scan) — PR **#331 OPEN**, branch `harness/t3a-deep-scan`. Output lives at `trading/devtools/checks/deep_scan.sh` + agent definition rewritten.
+
+**Completed via human-driven PRs today (8 merged):**
+- #320 T3-G status-file integrity check
+- #323 lead-orchestrator runner hardening (pre-flight + plan mode + smoke test)
+- #325 Dockerfile split (ci + devcontainer images, both published to GHCR)
+- #326 orchestrator-automation status file (research + decisions)
+- #327 capture follow-ups (simulation perf, sector scraping, universe cleanup)
+- #328 run.sh streaming + heartbeat + helper extraction (`dev/lib/`)
+- #329 feat-backtest agent definition
+- #330 `_build/` cache in CI
+
+## Health Scan
+Not run in this refresh. Last scan: `dev/health/2026-04-08-fast.md`.
+
+## Follow-up Queue
+
+Counts reconciled against current status files after today's changes:
+
+- **simulation** (7 items, incl. new "Simulation loop performance" from #327)
+- **screener** (5 items, incl. new "Sector map key resolution")
+- **data-layer** (3 items, incl. new "Sector coverage expansion" + "Universe composition cleanup")
+- **harness** (3 items, incl. "Orchestrator should reconcile Integration Queue against reality" — new, see below)
+- **portfolio-stops** (0 items)
+- **backtest-infra** (handled via the status file's own §Next Actions)
+
+Total: ~18. Above threshold (10), but maintenance-cycle check was not enforced this run.
+
+## Integration Queue
+
+| PR | Status |
+|---|---|
+| **#331** | OPEN — harness/t3a-deep-scan (T3-A deep scan implementation) |
+
+Nothing else open.
+
+## Current Milestone Target
+**M5 — Historical Backtesting**. The infrastructure is in (backtest_runner lib, scenario_runner with fork pool, config overrides, shared Backtest library). First experiment (stop-buffer tuning) is the flagship and is now an agent-eligible track via `feat-backtest`.
+
+## Dependency Unlocks
+- `feat-backtest` agent track is live (#329 merged) — orchestrator can now dispatch backtest-infra feature work
+
+## Escalations
+
+1. **Daily summary drift**: prior orchestrator runs carried forward stale content from 2026-04-11. Fix queued as a harness follow-up (see §Follow-up Queue > harness).
+2. **T3-A (#331) is open and unreviewed**: that's today's only real queue item.
+3. **Orchestrator has no `gh` auth** inside its run environment (noted in morning escalations). Prevents it from reconciling current PR state deterministically. Part of the orchestrator-automation plan in `dev/status/orchestrator-automation.md`.
+
+## Questions for You
+1. Review + merge **#331** (T3-A deep scan)?
+2. Ready to dispatch `feat-backtest` on the stop-buffer experiment? The flagship Immediate item is now agent-eligible.
+3. Any preference on whether the next orchestrator run should be manual (`./dev/run.sh`) or wait for the GHA automation in `dev/status/orchestrator-automation.md`?
+
+---
+## Your Response
+(Edit this section. Run dev/run.sh after editing to start the next session.)

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -1,6 +1,6 @@
 # Status: harness
 
-## Last updated: 2026-04-12
+## Last updated: 2026-04-14
 
 ## Status
 IN_PROGRESS
@@ -98,6 +98,20 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
   pre-flight block that fast-fails if `claude` is missing, the
   lead-orchestrator agent file is missing, or its `## Allowed Tools` section
   no longer lists `Agent`. See `### run-sh hardening` in Completed.
+- **Orchestrator daily summary drifts against reality** — sections like
+  `## Integration Queue`, `## Recent Commits`, and `## Questions for You`
+  get copied forward from prior daily summaries rather than derived from
+  current state. Example: the 2026-04-14 12:35 run carried forward a "7
+  open PRs from 2026-04-11" list that had been stale for 3 days; several
+  questions referenced PRs long since merged.
+  Fix: add a deterministic reconciliation step to `lead-orchestrator.md`
+  Step 7 (Write daily summary) that queries the actual open-PR list
+  (via `gh pr list` or the GH API) before writing `## Integration Queue`,
+  and derives `## Recent Commits` from `jj log main@origin..main@origin`
+  since the last daily summary date. Without `gh` auth in the runtime
+  environment (see `dev/status/orchestrator-automation.md`), this part
+  needs to land together with the automation work. Source:
+  `dev/daily/2026-04-14.md` (refreshed end-of-day).
 
 ---
 


### PR DESCRIPTION
## Summary

The 12:35 UTC orchestrator run today wrote `dev/daily/2026-04-14.md` with stale content copied forward from `2026-04-11.md` — `## Integration Queue` listed 7 PRs that had been closed for 3 days, several `## Questions for You` pointed at already-merged work, and `## Recent Commits` was not reconciled against truth.

**Root cause:** the orchestrator has no `gh` auth inside its run environment (noted in its own escalations), and the daily-summary template has no instruction to derive these sections from actual state rather than prior-summary content.

## Changes

1. `dev/daily/2026-04-14.md` — rewritten end-of-day with reconciled state. Banner at top noting it supersedes the morning run. Reflects the 8 PRs merged today (#320, #323, #325, #326, #327, #328, #329, #330) and the single currently-open PR (#331, T3-A deep scan).

2. `dev/status/harness.md` — new Follow-up entry capturing the underlying drift. The real fix needs `gh` auth or equivalent in the orchestrator runtime; that prerequisite is tracked in `dev/status/orchestrator-automation.md`, so this follow-up is tagged to land alongside that work.

## Test plan

- `dune runtest devtools/checks/` — `OK: all dev/status/*.md files have required fields` still passes (status-file integrity schema unchanged).