### PR TITLE
harness: prototype Plan-first trigger for high-risk dispatch

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -32,7 +32,12 @@ The agent must read these at the start of every session, in order:
 4. `dev/status/<feature>.md` — resume from where you left off
 5. `docs/design/<eng-design-N-feature>.md` — the feature's design doc
 6. Any additional design docs relevant to this feature
-7. State the session plan before writing any code
+7. **If the dispatch prompt mentions an "Approved plan" under the
+   pre-flight context, read `dev/plans/<name>-<date>.md` first — its
+   §Approach and §Out of scope are binding.** See
+   `.claude/agents/lead-orchestrator.md` §Step 3.5 for when plans
+   are produced.
+8. State the session plan before writing any code
 
 ### 3. Branch and status file
 

--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -40,6 +40,22 @@ Status file: dev/status/backtest-infra.md
 - Harness tooling (`devtools/`, agent definitions) — that's `harness-maintainer`
 - Data fetching / inventory (`fetch_universe`, `bootstrap_universe`) — that's `ops-data` if it needs fresh fetch, else feature-internal if it's a one-time script
 
+## Plan-first on your first experiment
+
+This agent has no merged work yet. Per `.claude/agents/lead-orchestrator.md`
+§Step 3.5 (triggers 1 "first deliverable from a new agent" and 4
+"experiment design"), your first experiment is plan-first: the
+orchestrator will dispatch the built-in `Plan` subagent to produce
+`dev/plans/stop-buffer-<YYYY-MM-DD>.md`, a human reviews and merges it,
+and only then will you be dispatched with the approved plan as pre-flight
+context.
+
+If the dispatch prompt says `### Approved plan` with a path, treat that
+path as the binding spec (§Approach and §Out of scope are binding; QC
+verifies). If no plan is cited in pre-flight and the item you're about to
+work on matches a Step 3.5 trigger, **stop and return an escalation**
+instead of implementing.
+
 ## Item selection priority
 
 Read `dev/status/backtest-infra.md` and pick the highest-leverage open item:

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -214,6 +214,69 @@ Assemble these three into the `<PREFLIGHT-CONTEXT>` block injected into the feat
 
 ---
 
+## Step 3.5: Plan-first trigger (for high-risk dispatches)
+
+**Prototype** — see `dev/plans/README.md` for the convention. Apply
+before the feat-agent dispatch in Step 4 for tasks meeting any of:
+
+1. **First deliverable from a new agent** — the target agent's status
+   file §Completed section is empty (or has only the status-file scaffold
+   itself). Detect by reading the status file.
+2. **Cross-cutting change** — the item the feat-agent will work on is
+   tagged `plan_required: true` in its status file's item entry, OR your
+   prior familiarity suggests the change will touch > 5 files.
+3. **Previously-failed work** — the status file's Follow-up or Completed
+   section references closed / rejected PR attempts for this item.
+4. **Experiment design** — item is under a §Potential experiments or
+   §Experiments section (e.g. the stop-buffer tuning experiment in
+   `dev/status/backtest-infra.md`), where success is empirical rather
+   than a unit-testable spec.
+
+If any trigger fires, dispatch the built-in `Plan` subagent BEFORE the
+feat-agent:
+
+```
+Agent(
+  subagent_type="Plan",
+  description="Plan <item>",
+  prompt="""
+  You are designing an implementation plan for <item> owned by the
+  <feat-agent> track.
+
+  Read:
+  - dev/status/<track>.md §<section> for the item description and
+    constraints
+  - <design doc paths from the track's startup sequence>
+  - any prior rejected attempts referenced in the status file
+  - dev/plans/README.md for the output shape
+
+  Produce a plan at dev/plans/<item-slug>-<YYYY-MM-DD>.md covering
+  context / approach / files-to-change / risks / acceptance / out-of-scope.
+
+  Commit and push the plan on a branch plan/<item-slug>. Do not
+  modify any other files. Open a PR so a human can review before
+  implementation.
+  """
+)
+```
+
+The feat-agent dispatch in Step 4 is **deferred** for this item until
+the plan PR is merged (reviewed and approved by the human). Record the
+deferral in today's daily summary under §Plan Queue with the plan PR
+number. On subsequent runs, if the plan is merged, the feat-agent
+prompt's `<PREFLIGHT-CONTEXT>` additionally includes:
+
+```
+### Approved plan
+Path: dev/plans/<item-slug>-<YYYY-MM-DD>.md
+Merged in: <PR number>
+The plan's §Approach and §Out of scope are binding. QC will verify.
+```
+
+If no trigger fires, skip to Step 4 as before.
+
+---
+
 ## Step 4: Spawn feature agents as parallel subagents
 
 For each feature that should run today, spawn it as a subagent using the Agent tool (no worktree isolation — agents work directly on their feature branch so Docker can see their changes). Run all eligible features in parallel (single message, multiple Agent tool calls).

--- a/dev/plans/README.md
+++ b/dev/plans/README.md
@@ -1,0 +1,62 @@
+# Implementation plans
+
+Prototype folder for agent-produced implementation plans. Populated by the
+built-in `Plan` subagent when the lead-orchestrator triggers plan-first
+dispatch for a high-risk task (see `.claude/agents/lead-orchestrator.md`
+Step 3.5).
+
+## File naming
+
+One file per plan:
+
+```
+dev/plans/<feature-or-item>-<YYYY-MM-DD>.md
+```
+
+Examples:
+- `backtest/stop-buffer-2026-04-15.md` — plan for the first stop-buffer tuning experiment
+- `weinstein/drawdown-breaker-2026-04-20.md` — plan for the drawdown circuit breaker
+
+## Shape
+
+Each plan should contain:
+
+1. **Context** — what is the task, what does the current code look like, what is the spec
+2. **Approach** — the chosen design, with rejected alternatives named and briefly justified
+3. **Files to change** — explicit list with per-file notes
+4. **Risks / unknowns** — what could go wrong, what we aren't sure about
+5. **Acceptance criteria** — what "done" looks like; must align with the feat-agent's checklist
+6. **Out of scope** — explicit non-goals so the agent doesn't drift
+
+Plans are short (aim ~100–300 lines). They are reviewed by a human before
+the feat-agent executes.
+
+## Lifecycle
+
+```
+[orchestrator detects high-risk task]
+  → [Plan subagent] writes dev/plans/<name>-<date>.md
+  → [human reviews] approves / requests changes / rejects
+  → [feat-agent] reads approved plan as part of its pre-flight context
+    (prompt includes "Approved plan: dev/plans/<name>-<date>.md")
+  → [feat-agent] implements
+  → [QC] reviews implementation against the plan's acceptance criteria
+```
+
+Archive decisions (architectural choices that survive the feature) belong
+in `dev/decisions.md` after the plan is executed — do not rely on plan
+files for long-term documentation. Plans are scaffolding, not history.
+
+## When plan-first fires
+
+See `.claude/agents/lead-orchestrator.md` §Step 3.5 for the trigger logic.
+Current triggers:
+
+1. **First deliverable from a new agent** — the agent's `dev/status/<track>.md`
+   §Completed is empty
+2. **Cross-cutting change** — agent's own status file says `plan_required: true`
+   for the item, or the change is expected to touch > 5 files
+3. **Previously-failed work** — item has a history of closed / rejected PR
+   attempts in the status file
+4. **Experiment design** — any item where the success criteria is empirical
+   (e.g. a backtest experiment) rather than a unit-testable spec


### PR DESCRIPTION
## Summary

Prototype integration of the built-in `Plan` subagent into the lead-orchestrator workflow for tasks where inline in-session planning is underpowered.

## Why

Current state:
- Design docs + feat-agent inline planning handle most feature work fine
- But: `order_gen` had 2 closed attempts for spec drift; cross-cutting refactors (Dockerfile split, `_check_lib` migration) relied on human real-time steering; `feat-backtest`'s first item is an empirical experiment without a unit-testable spec

For those three patterns, planning in advance with human review before implementation should prevent late-stage course corrections.

## Triggers (prose in `lead-orchestrator.md` §Step 3.5)

1. **First deliverable from a new agent** — target agent's status file §Completed is empty
2. **Cross-cutting change** — item tagged `plan_required: true`, or will touch > 5 files
3. **Previously-failed work** — status file references closed/rejected PR attempts
4. **Experiment design** — item under §Potential experiments / §Experiments with empirical success criteria

## What this lands

- **`dev/plans/`** directory + README — convention (`<name>-<YYYY-MM-DD>.md`), content shape, lifecycle
- **`lead-orchestrator.md` §Step 3.5** — triggers, Plan-subagent dispatch template, feat-agent deferral, approved-plan injection pattern
- **`feat-agent-template.md` §2** — new startup-sequence item: if dispatch says "Approved plan: <path>", read it first; its §Approach and §Out-of-scope are binding
- **`feat-backtest.md`** — explicit callout that its first experiment (stop-buffer tuning) is plan-first; escalate if no plan in pre-flight context

## Scope fences (deliberately not in this PR)

- **Prose-level triggers only**. No deterministic rule enforcement — correctness depends on orchestrator compliance. Worth formalizing later if drift shows up.
- **Only `feat-backtest` has trigger-1 applicability today** (empty Completed). `feat-weinstein` has prior merged work and doesn't need the callout unless it gets new scope.
- **No decisions.md migration logic** — plans are scaffolding; durable architectural decisions get moved to `decisions.md` post-execution by whoever lands them.

## Test plan

- [ ] `dune runtest devtools/checks/` — green (agent-compliance now scans 2 feat-*.md; status-file integrity unchanged)
- [ ] First real exercise: next orchestrator run that considers dispatching `feat-backtest` should produce a plan PR instead of a feat-agent dispatch. Worth a dry-run (`./dev/run.sh --plan`) after this merges to sanity-check the trigger fires as described.