### PR TITLE
docs: strip stale Recent Commits + document Backtest subsystem + queue deep-scan gaps

### DIFF
--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -112,6 +112,29 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
   environment (see `dev/status/orchestrator-automation.md`), this part
   needs to land together with the automation work. Source:
   `dev/daily/2026-04-14.md` (refreshed end-of-day).
+- **Deep scan heuristic gaps** — `trading/devtools/checks/deep_scan.sh`
+  (T3-A, see #331) is missing several useful checks. Today's manual
+  audit found four real issues the script didn't surface:
+  1. **Drift coverage too narrow** — only checks `analysis/weinstein/`,
+     `trading/weinstein/`, `analysis/weinstein/data_source/` against
+     specific eng-design docs. New subsystems like
+     `trading/trading/backtest/` (added today via #315/#316) are
+     invisible. Either generalise the check or add per-subsystem
+     coverage.
+  2. **Status file template enforcement** — three status files
+     (`portfolio-stops.md`, `screener.md`, `simulation.md`) had stale
+     `## Recent Commits` sections in violation of the template's
+     "omit" rule. Stripped in this PR; deep scan should grep for the
+     forbidden heading and warn.
+  3. **Linter exception expiry** — `linter_exceptions.conf` entries
+     with `review_at: <milestone>` (e.g. M5) are never re-surfaced
+     when the milestone lands. Add a check that compares current
+     milestone in `weinstein-trading-system-v2.md` against the
+     `review_at:` values.
+  4. **Stale local jj bookmarks** — bookmarks left around after PRs
+     merge accumulate. Surface them with
+     `jj bookmark list 'glob:*'` filtered against origin.
+  Source: `dev/daily/2026-04-14.md` end-of-day audit.
 
 ---
 

--- a/dev/status/portfolio-stops.md
+++ b/dev/status/portfolio-stops.md
@@ -1,6 +1,6 @@
 # Status: portfolio-stops
 
-## Last updated: 2026-04-08
+## Last updated: 2026-04-14
 
 ## Status
 APPROVED
@@ -35,11 +35,3 @@ YES
 - Portfolio risk management (`weinstein/portfolio_risk/`): snapshot_of_portfolio, compute_position_size, check_limits — MERGED (#137)
 - Trading state persistence (`weinstein/trading_state/`): JSON save/load, stop states, stage history, trade log — 25 tests
 - `order_gen` (`trading/weinstein/order_gen/`): pure formatter — translates `Position.transition list` → `suggested_order list`; 11 tests; branch feat/weinstein, commit 8057a07b
-
-## Recent Commits
-- #147 Add stop state types, config, and basic API
-- #148 Add stop update machinery (merged into #147 PR)
-- #149 Improve stop module: configurable buffers, unified bar extreme, extracted dispatch
-- #137 Add Portfolio risk management module
-- portfolio-stops/trading-state: Add Weinstein trading state persistence (25 tests)
-- feat/weinstein: order_gen — Position.transition → broker order translation (11 tests)

--- a/dev/status/screener.md
+++ b/dev/status/screener.md
@@ -1,6 +1,6 @@
 # Status: screener
 
-## Last updated: 2026-04-07
+## Last updated: 2026-04-14
 
 ## Status
 MERGED
@@ -82,12 +82,3 @@ existing `classify` stays as the cold-start entry point. See module comment in
 composite that's awkward for downstream consumers). Unblocks once the upstream
 data-fetching work (originally #250–#253) lands or is closed. Source:
 `dev/daily/2026-04-11.md`.
-
-## Recent Commits
-- screener/rs: Add Relative Strength (RS) analyzer
-- screener/volume-resistance: Add Resistance and Volume analysis modules
-- screener/stock-analysis: Add StockAnalysis module
-- screener/stock-screener: Add Screener module with cascade filter
-- screener/macro: Add Macro market analyzer
-- screener/sector: Add Sector analyzer
-- feat/screener: Refactor SMA, share impl with WMA

--- a/dev/status/simulation.md
+++ b/dev/status/simulation.md
@@ -103,13 +103,3 @@ Both Slice 2 (merged PRs #237, #240, #241, #242) and Slice 3 (feat/simulation br
 - Walk-forward backtest (M5): parameter tuner with validation period
 - Performance gate test (T2-B)
 
-## Recent Commits
-
-- #195 simulation: Add strategy_cadence to simulator dependencies
-- #196 simulation: Weinstein strategy skeleton (STRATEGY impl) — merged 2026-04-07
-- feat/simulation: Add Synthetic_source and Weinstein strategy smoke tests (pending PR)
-- feat/simulation: add ?portfolio_value optional param to STRATEGY interface (2026-04-09)
-- feat/simulation: bar accumulation, MA direction, and simulation date (2026-04-09)
-- feat/simulation: extend smoke tests with 2022-01-01 history start (2026-04-09)
-- feat/simulation: accumulate prior_stage per symbol for Stage1->Stage2 detection (2026-04-10)
-- feat/simulation: add breakout pattern smoke test with trade assertions (2026-04-10)

--- a/docs/design/eng-design-4-simulation-tuning.md
+++ b/docs/design/eng-design-4-simulation-tuning.md
@@ -185,3 +185,75 @@ val run : config:tuner_config -> symbols:string list ->
 | Strategy state in closure | Mutable ref in factory | Thread through simulator types | Minimal changes to existing simulator interface |
 | Grid search first | Exhaustive + simple | Bayesian from start | Simpler to implement and interpret. Upgrade path clear. |
 | Walk-forward validation | K-fold train/test split | In-sample only | Detects overfitting before applying config to live trading |
+
+---
+
+## 4.4 Backtest infrastructure
+
+Built atop the simulator (above) and consumed by the `feat-backtest` agent.
+Lives at `trading/trading/backtest/`.
+
+### Modules
+
+- **`Backtest.Summary`** (`lib/summary.{ml,mli}`) — typed run summary
+  (start/end dates, universe size, n_steps, initial/final cash,
+  n_round_trips, metric_set). `[@@deriving sexp_of]` for human-readable
+  output; custom converters preserve `%.2f` formatting on money fields
+  and the lowercased `(metric_name value)` shape on the metrics map.
+- **`Backtest.Runner`** (`lib/runner.{ml,mli}`) — `run_backtest`
+  orchestrates: load universe + AD bars + sector map, build a fresh
+  Weinstein strategy, run the simulator from `start_date - warmup` to
+  `end_date`, filter to trading days only, return a `result` (summary +
+  round_trips + filtered steps + the override sexps used).
+- **`Backtest.Result_writer`** (`lib/result_writer.{ml,mli}`) — `write`
+  emits `params.sexp`, `summary.sexp`, `trades.csv`, `equity_curve.csv`
+  into a caller-provided directory. Separated from Runner so callers
+  (CLI, scenario_runner) can run a backtest without writing anything.
+- **`bin/backtest_runner.ml`** — thin CLI wrapper. Parses
+  `--override '<sexp>'` flags (deep-merged into the default Weinstein
+  config), invokes `Backtest.Runner.run_backtest`, calls
+  `Backtest.Result_writer.write`.
+- **`scenarios/scenario.{ml,mli}`** — declarative scenario data model:
+  `range`, `period`, `expected`, `t = { name; description; period;
+  config_overrides; expected }`. Loaded from sexp files via
+  `[@@deriving sexp]` (with custom range converter to preserve the
+  `(min X) (max Y)` file format and `[@@sexp.allow_extra_fields]` for
+  tolerated info fields like `universe_size`).
+- **`scenarios/scenario_runner.ml`** — runs N scenarios in **parallel
+  child processes** via `Core_unix.fork`. Bounded pool (`--parallel N`,
+  default 4). Each child writes `actual.sexp` plus the standard
+  artefacts; parent reads back and prints the pass/fail table in
+  declaration order.
+
+### Config override mechanism
+
+`--override '((field value))'` partial sexps are deep-merged into the
+default `Weinstein_strategy.config` via
+`sexp_of_config → merge → config_of_sexp`. Generic — works for any
+nested config field without code changes. See `Backtest.Runner._merge_sexp`
+and `_apply_overrides`.
+
+### Scenario file format
+
+Files at `trading/test_data/backtest_scenarios/{goldens,smoke}/*.sexp`:
+
+```scheme
+((name "six-year-2018-2023")
+ (description "...")
+ (period ((start_date 2018-01-02) (end_date 2023-12-29)))
+ (universe_size 1654)         ; informational; tolerated by allow_extra_fields
+ (config_overrides ())        ; list of partial config sexps
+ (expected
+   ((total_return_pct ((min 30.0) (max 90.0)))
+    (total_trades     ((min 60)   (max 100)))
+    ...)))
+```
+
+Goldens are long-horizon regression scenarios (6-year runs); smoke are
+short-window sanity scenarios for fast iteration.
+
+### Owner
+
+`feat-backtest` agent (see `.claude/agents/feat-backtest.md`).
+Entry-point items live in `dev/status/backtest-infra.md` — flagship
+Immediate item is the stop-buffer tuning experiment.


### PR DESCRIPTION
Three sub-fixes from a manual audit of the deep scan output (#331). None block work; together they keep status files honest and design docs in sync with code.

## 1. Strip `## Recent Commits` from 3 status files

`portfolio-stops.md`, `screener.md`, `simulation.md` had stale `## Recent Commits` sections in violation of `feat-agent-template.md`:

> Omit `## Recent Commits` — git log is authoritative; PR numbers belong in `## Completed`

Lists went back to original PRs from weeks ago — pure drift.

## 2. Document the Backtest subsystem in `eng-design-4-simulation-tuning.md`

New `§4.4` covers `trading/trading/backtest/` (added today via #315/#316): `Backtest.{Summary, Runner, Result_writer}`, scenario_runner with fork-pool parallelism, the deep-merge `--override` mechanism, the scenario sexp file format. Folded into eng-design-4 since it sits directly atop the simulator. Owner: `feat-backtest`.

## 3. Queue deep-scan heuristic gaps in `harness.md`

Today's audit found 4 useful checks the deep scan currently misses:

- **Drift coverage too narrow** — only 3 specific dirs vs 3 specific eng-design docs; new subsystems like `trading/trading/backtest/` are invisible
- **No template enforcement** — should warn on `## Recent Commits` headings in feat status files
- **Linter exception expiry** — `review_at: <milestone>` values never re-surfaced when the milestone lands
- **Stale local jj bookmarks** — bookmarks left around after PR merges accumulate

Tagged for harness-maintainer to extend `deep_scan.sh` in a follow-up.

## Test plan

- [x] `dune runtest devtools/checks/` — green; status-file integrity check passes (Last updated dates bumped)
- [x] No source code touched (docs + status files only)