### PR TITLE
docs: update decisions.md with today's direction changes

### DIFF
--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -43,10 +43,63 @@ _(None yet — system just initialized.)_
 
 ## Direction Changes
 
-_(None yet.)_
+### 2026-04-14 — Backtest infrastructure has its own agent + Plan-first dispatch
+
+- **`feat-backtest` agent now owns the backtest-infra track.** Previously
+  human-driven. Definition at `.claude/agents/feat-backtest.md`. Status
+  file at `dev/status/backtest-infra.md`. Scope: experiments + strategy-
+  tuning features (stop-buffer tuning, drawdown circuit breaker,
+  per-trade stop logging, segmentation-based stage classifier, universe
+  filter, sector-data scrape integration). Distinct from `feat-weinstein`
+  (which owns the base strategy code, currently complete).
+
+- **Flagship Immediate item: stop-buffer tuning experiment.** The entire
+  #306/#315/#316 infrastructure was built specifically to unblock it.
+  See `dev/status/backtest-infra.md` §Next Actions.
+
+- **Plan-first applies to feat-backtest's first deliverable.** Per
+  `.claude/agents/lead-orchestrator.md` §Step 3.5 (triggers 1 "first
+  deliverable from a new agent" and 4 "experiment design"), the
+  orchestrator dispatches the built-in `Plan` subagent to produce
+  `dev/plans/stop-buffer-<YYYY-MM-DD>.md` BEFORE dispatching feat-backtest.
+  Human reviews the plan PR and merges it; feat-backtest is then
+  dispatched on the next run with the approved plan as binding pre-flight
+  context.
+
+- **Lead-orchestrator has Plan Mode.** `./dev/run.sh --plan` short-circuits
+  Steps 2-6 and emits a dispatch plan to `dev/daily/<DATE>-plan.md`
+  without spawning any subagents. Use for dry runs.
+
+- **`dev/run.sh` is now hardened**: pre-flight asserts (`claude` on PATH,
+  agent file present, `## Allowed Tools` lists Agent), live event ticker
+  via stream-json + jq, heartbeat every 30s. Helpers in `dev/lib/`.
+
+- **Orchestrator daily summary drift is a known issue.** Sections like
+  `## Integration Queue` get copied forward from prior dailies rather
+  than reconciled against current GH state. Fix tracked in
+  `dev/status/harness.md` Follow-up; gated on `gh` auth in the runtime
+  environment (see `dev/status/orchestrator-automation.md`).
 
 ---
 
 ## Notes for Specific Agents
 
-_(Add per-agent notes here as needed, prefixed with the agent name.)_
+### feat-backtest
+
+- Your first session must check the dispatch prompt for `### Approved plan`.
+  If present, treat the referenced `dev/plans/...md` file's §Approach and
+  §Out of scope as binding; QC will verify. If absent and the item you're
+  about to work on matches a Step 3.5 trigger, **stop and return an
+  escalation** instead of implementing.
+- Don't modify `weinstein_strategy.ml` or core stop-machine code — build
+  alongside, or surface the proposed change in your status file for
+  feat-weinstein review.
+
+### lead-orchestrator
+
+- Per §Step 3.5: invoke the `Plan` subagent before dispatching any feat-agent
+  whose status file §Completed is empty (e.g. feat-backtest today),
+  whose item is tagged `plan_required: true`, has prior closed/rejected
+  PR attempts, or is an empirical experiment.
+- Plan-mode invocations (`--plan` token in prompt) MUST NOT dispatch
+  any subagent. Read state, write `dev/daily/<DATE>-plan.md`, exit.


### PR DESCRIPTION
Brings `dev/decisions.md` current with today's structural changes that agents should pick up next session.

The orchestrator reads `dev/decisions.md` first in Step 1 as "human guidance from last session". Without this update the file last spoke about order_gen design lessons and made no mention of:

- `feat-backtest` agent ownership of backtest-infra (#329)
- Plan-first dispatch trigger applying to feat-backtest's first deliverable (#333)
- `dev/run.sh --plan` mode for dry runs (#323)
- run.sh hardening (pre-flight, ticker, heartbeat) (#323/#328)
- Daily-summary drift status + gating on gh auth (#332)

Plus per-agent notes:

- **feat-backtest**: must check pre-flight for `### Approved plan`; escalate if absent and Step 3.5 trigger applies; do not modify `weinstein_strategy.ml`
- **lead-orchestrator**: invoke `Plan` subagent on triggers per §Step 3.5; `--plan` mode must not dispatch any subagent

## Test plan

- [x] Status-file integrity check still passes (no schema changes; only added Direction Changes + Notes for Specific Agents content)
- [x] Next orchestrator run reads these decisions before dispatching feat-backtest
