### PR TITLE
harness: revise dispatch flow — inline plan-first + jst submit + PR fallback

### DIFF
--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -40,21 +40,23 @@ Status file: dev/status/backtest-infra.md
 - Harness tooling (`devtools/`, agent definitions) — that's `harness-maintainer`
 - Data fetching / inventory (`fetch_universe`, `bootstrap_universe`) — that's `ops-data` if it needs fresh fetch, else feature-internal if it's a one-time script
 
-## Plan-first on your first experiment
+## Plan-first inline (when applicable)
 
-This agent has no merged work yet. Per `.claude/agents/lead-orchestrator.md`
-§Step 3.5 (triggers 1 "first deliverable from a new agent" and 4
-"experiment design"), your first experiment is plan-first: the
-orchestrator will dispatch the built-in `Plan` subagent to produce
-`dev/plans/stop-buffer-<YYYY-MM-DD>.md`, a human reviews and merges it,
-and only then will you be dispatched with the approved plan as pre-flight
-context.
+If the dispatch prompt includes a `## Plan-first` paragraph (set by
+the orchestrator per `.claude/agents/lead-orchestrator.md` §Step 3.5
+when triggers like "first deliverable" or "experiment design" fire),
+write your plan to `dev/plans/<item-slug>-<YYYY-MM-DD>.md` as your
+first commit on the branch (shape: see `dev/plans/README.md`). Then
+**implement in the same session** — plan and implementation land
+together in a single PR. There is no human-review gate between them.
 
-If the dispatch prompt says `### Approved plan` with a path, treat that
-path as the binding spec (§Approach and §Out of scope are binding; QC
-verifies). If no plan is cited in pre-flight and the item you're about to
-work on matches a Step 3.5 trigger, **stop and return an escalation**
-instead of implementing.
+If during implementation the plan turns out to be wrong, **update the
+plan file in place** (it's on the same branch) and continue — don't
+drift silently.
+
+If no `## Plan-first` paragraph is in the dispatch but the item matches
+a Step 3.5 trigger anyway, write the plan as a courtesy. Cheap, and
+keeps the experiment record honest.
 
 ## Item selection priority
 

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -104,7 +104,20 @@ docker exec <container-name> bash -c \
 ## When done with each item
 
 1. Mark `[x]` in `dev/status/harness.md` with a note: what was built, where it lives, how to verify
-2. Commit and push: `jj describe -m "harness: <short description>"`
-3. Include in your return value: item completed, what changed, any follow-up or escalation items
+2. Commit and push:
+   ```
+   jj describe -m "harness: <short description>"
+   jj bookmark set harness/<short-name> -r @
+   jj git push -b harness/<short-name> --allow-new
+   ```
+3. **Open the PR** so the human doesn't have to chase down PR-less branches:
+   ```
+   GH_TOKEN=$GH_TOKEN jst submit harness/<short-name>
+   ```
+   jst is on PATH in the orchestrator runtime (`trading-devcontainer` image
+   + `dev/run.sh` provides both jst and `GH_TOKEN`). If jst fails, surface
+   the error in your return value rather than silently leaving the branch
+   PR-less.
+4. Include in your return value: item completed, what changed, any follow-up or escalation items, and the PR URL.
 
-Return a concise summary: which items completed, which are in progress, any blockers.
+Return a concise summary: which items completed, which are in progress, any blockers, and the PR URLs.

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -152,15 +152,40 @@ Harness items with external dependencies (e.g., T1-N golden scenarios require re
 
 ### 2d: Data operations (ops-data)
 
-Read `dev/notes/data-gaps.md`. If any gap has an actionable next step that
-does not require a human decision (e.g., "fetch sector ETFs" once the ETF list
-is known, "wire global index bars" once cached), spawn `ops-data` as a subagent:
+Read `dev/notes/data-gaps.md`. **Don't be defensive** — most gaps have an
+actionable next step that does NOT require a human decision. Common
+patterns the orchestrator should dispatch on, not skip:
+
+- **"fetch X"** when EODHD_API_KEY is set in the host env. Test:
+  `[ -n "$EODHD_API_KEY" ] && echo OK`. Skip only if truly absent.
+- **"validate candidate sources"** for a data feed (e.g. ADL): a
+  research/scraping task. Dispatch ops-data to write a small probe,
+  fetch a few days, validate the format. ops-data's scope explicitly
+  includes writing new parsers + scrape research (see
+  `.claude/agents/ops-data.md` §"When to write code").
+- **"execute a written plan"** (e.g. `dev/notes/sector-data-plan.md`).
+  Dispatch ops-data to follow the plan — the plan IS the spec; no
+  human decision needed.
+- **"wire cached data into strategy"** — if data is cached, this is
+  feature work for the appropriate feat-agent (not ops-data). Surface
+  in §Escalations if the agent track is closed.
+
+Skip ops-data only when:
+- The gap genuinely requires human input (e.g. "decide whether to
+  upgrade to the EODHD paid tier"), OR
+- A required precondition is missing AND there's no API-free fallback.
+
+Surface skipped gaps in §Escalations with **what's needed to unblock**,
+not just "human decision required" — be specific.
+
+When dispatching:
 
 ```
 You are the data operations agent for the Weinstein Trading System.
 
 ## Task
-<describe the specific data operation: fetch, parse, inventory rebuild, etc.>
+<describe the specific data operation: fetch, parse, inventory rebuild,
+ source validation, plan execution, etc.>
 
 ## Context
 <paste the relevant section from dev/notes/data-gaps.md>
@@ -172,13 +197,12 @@ Docker container: <container-name>
 When done:
 1. Update dev/notes/data-gaps.md to reflect what was resolved or what still blocks
 2. Run build_inventory.exe if any data was fetched
-3. Return: what changed, what still blocks, any errors
+3. Open the PR via `jst submit` for any branch you pushed
+4. Return: what changed, what still blocks, any errors, and the PR URL
 ```
 
 ops-data runs **before** feature agents — resolved data gaps may unblock
-feature work in the same session. If all gaps require human decisions (API tier
-upgrade, alternative data source), skip ops-data and note the blockers in the
-daily summary.
+feature work in the same session.
 
 ### 2e: Feature dependency rules
 
@@ -214,66 +238,58 @@ Assemble these three into the `<PREFLIGHT-CONTEXT>` block injected into the feat
 
 ---
 
-## Step 3.5: Plan-first trigger (for high-risk dispatches)
+## Step 3.5: Plan-first inline (for high-risk dispatches)
 
-**Prototype** — see `dev/plans/README.md` for the convention. Apply
-before the feat-agent dispatch in Step 4 for tasks meeting any of:
+**Revised 2026-04-14**: plan-first is now an **inline** discipline,
+not a separate dispatch + human-review cycle. The previous
+plan-PR-then-defer flow added a round-trip without a clear win — the
+human's signal of "go ahead" is already present in the orchestrator
+having dispatched the agent in the first place.
 
-1. **First deliverable from a new agent** — the target agent's status
-   file §Completed section is empty (or has only the status-file scaffold
-   itself). Detect by reading the status file.
-2. **Cross-cutting change** — the item the feat-agent will work on is
-   tagged `plan_required: true` in its status file's item entry, OR your
-   prior familiarity suggests the change will touch > 5 files.
-3. **Previously-failed work** — the status file's Follow-up or Completed
-   section references closed / rejected PR attempts for this item.
-4. **Experiment design** — item is under a §Potential experiments or
-   §Experiments section (e.g. the stop-buffer tuning experiment in
-   `dev/status/backtest-infra.md`), where success is empirical rather
-   than a unit-testable spec.
+The plan still gets written. It just gets written by the feat-agent
+itself as the first action of its session, and the implementation
+follows in the same session. The plan file is committed alongside the
+implementation in a single PR (or stacked, if the change is large).
 
-If any trigger fires, dispatch the built-in `Plan` subagent BEFORE the
-feat-agent:
+### When plan-first applies
 
-```
-Agent(
-  subagent_type="Plan",
-  description="Plan <item>",
-  prompt="""
-  You are designing an implementation plan for <item> owned by the
-  <feat-agent> track.
+Add a `## Plan` section to the dispatched feat-agent's prompt for tasks
+meeting any of:
 
-  Read:
-  - dev/status/<track>.md §<section> for the item description and
-    constraints
-  - <design doc paths from the track's startup sequence>
-  - any prior rejected attempts referenced in the status file
-  - dev/plans/README.md for the output shape
+1. **First deliverable from a new agent** — target agent's status
+   file §Completed section is empty (or has only the scaffold itself).
+2. **Cross-cutting change** — item is tagged `plan_required: true` in
+   its status file entry, OR your prior familiarity suggests the change
+   will touch > 5 files.
+3. **Previously-failed work** — the status file references closed /
+   rejected PR attempts for this item.
+4. **Experiment design** — item is under §Potential experiments or
+   §Experiments, where success is empirical rather than unit-testable.
 
-  Produce a plan at dev/plans/<item-slug>-<YYYY-MM-DD>.md covering
-  context / approach / files-to-change / risks / acceptance / out-of-scope.
+### What to inject
 
-  Commit and push the plan on a branch plan/<item-slug>. Do not
-  modify any other files. Open a PR so a human can review before
-  implementation.
-  """
-)
-```
-
-The feat-agent dispatch in Step 4 is **deferred** for this item until
-the plan PR is merged (reviewed and approved by the human). Record the
-deferral in today's daily summary under §Plan Queue with the plan PR
-number. On subsequent runs, if the plan is merged, the feat-agent
-prompt's `<PREFLIGHT-CONTEXT>` additionally includes:
+Append this paragraph to the feat-agent's prompt in Step 4:
 
 ```
-### Approved plan
-Path: dev/plans/<item-slug>-<YYYY-MM-DD>.md
-Merged in: <PR number>
-The plan's §Approach and §Out of scope are binding. QC will verify.
+## Plan-first
+
+This task matches a plan-first trigger. Before writing any code, write
+your implementation plan to dev/plans/<item-slug>-<YYYY-MM-DD>.md
+(see dev/plans/README.md for the shape: context, approach, files-to-
+change, risks, acceptance, out-of-scope). Commit it as the first commit
+on your branch.
+
+Then implement per the plan in the same session. The plan and
+implementation land in a single PR — no review gate between them.
+QC will verify the implementation against the plan's acceptance
+criteria.
+
+If during implementation you discover the plan is wrong, update the
+plan file (it lives on the same branch) and continue. Don't revise
+silently.
 ```
 
-If no trigger fires, skip to Step 4 as before.
+If no trigger fires, dispatch normally without this paragraph.
 
 ---
 
@@ -345,6 +361,13 @@ COMMIT DISCIPLINE — this is critical for reviewability:
       jj describe -m "commit message"
       jj bookmark set feat/<feature> -r @
       jj git push --bookmark feat/<feature>
+  - At session end, ALSO open the PR via jst (don't leave branches PR-less
+    for the human to chase down):
+      GH_TOKEN=$GH_TOKEN jst submit feat/<feature>
+    jst is on PATH in the orchestrator runtime (trading-devcontainer image
+    + dev/run.sh assumes both). If GH_TOKEN isn't set, jst will fail with
+    a clear error and the branch is still pushed — the orchestrator can
+    then fall back to opening the PR manually in Step 7.
 
 MAX ITERATIONS — build-fix cycles:
   - If you have attempted 3 consecutive build-fix cycles without passing
@@ -407,6 +430,34 @@ the blocking refactor item as complete (check the box).
 
 Return: what changed, what quality metric improved, any surprises.
 ```
+
+---
+
+## Step 4.5: PR-creation fallback (deterministic — runs after each subagent returns)
+
+After each spawned subagent completes (whether feat-* or harness-maintainer
+or ops-data), check that any branches it pushed have a corresponding open
+PR. The subagent's `When done` flow tells it to run `jst submit`, but if
+it forgot, jst failed silently, or its tool subset blocked the call, no PR
+exists and the branch sits invisible to the human.
+
+Recovery flow:
+
+```bash
+# For each branch the subagent reported pushing:
+GH_TOKEN=$GH_TOKEN gh api "repos/dayfine/trading/pulls?head=dayfine:<branch>&state=open" \
+  --jq 'length' \
+  | grep -q '^0$' && \
+  GH_TOKEN=$GH_TOKEN jst submit <branch>
+```
+
+If jst still fails, surface the branch + jst error in the daily summary
+under §Escalations so the human can open the PR manually with one
+`gh pr create` call. Don't loop on it.
+
+This catches the "agent pushed branch but no PR" gap that would
+otherwise leave work invisible until the human reads the daily summary
+and notices the missing PR.
 
 ---
 

--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -64,7 +64,13 @@ Read `data/inventory.sexp` and report: which symbols are present, their date ran
 
 `EODHD_API_KEY` must be set in the host environment before any fetch. It is forwarded into the container via `docker exec -e EODHD_API_KEY` and passed as `--api-key "$EODHD_API_KEY"` — the OCaml script only accepts the flag, never reads env vars directly.
 
-If `EODHD_API_KEY` is not set in the host environment, report what can be done without it (inventory rebuild, universe bootstrap from existing data, coverage checks) and stop.
+If `EODHD_API_KEY` is not set in the host environment, **don't stop early**:
+- Many data gaps don't need EODHD (scrape-source validation for ADL,
+  sector-data-plan execution, parser writing, inventory rebuild,
+  universe bootstrap, coverage checks)
+- Continue with whatever subset of the task doesn't require the key
+- Report explicitly what was deferred for lack of the key, with the
+  exact command the human or a future run would need to complete it
 
 ## Allowed Tools
 
@@ -74,7 +80,26 @@ Do not modify agent definitions, design docs, or feature code outside `analysis/
 
 ## When to write code vs just run scripts
 
-Run existing scripts when coverage is the only gap. Write new code when a data source requires it — e.g. a new EODHD endpoint with a non-OHLCV response format, a new symbol list parser, or a new fetch script for macro data (A-D breadth, global indices). Follow the same TDD workflow as feature agents (interface → tests → impl → `dune fmt`). Commit data infrastructure code to a `data/<short-name>` branch. Known gaps that need new code are listed in `dev/notes/data-gaps.md`. When you resolve a gap, update that file.
+Run existing scripts when coverage is the only gap.
+
+Write new code when a data source requires it — a new EODHD endpoint
+with a non-OHLCV response format, a new symbol list parser, or a new
+fetch script for macro data (A-D breadth, global indices, sector
+holdings). Follow the same TDD workflow as feature agents (interface →
+tests → impl → `dune fmt`). Commit data infrastructure code to a
+`data/<short-name>` branch.
+
+**Scrape-source validation** is also in scope. When `data-gaps.md` lists
+candidate sources for a feed (e.g. ADL — Yahoo `C:ISSU`, EODData
+`INDEX:ADRN`, Unicorn `advdec`, computed-from-universe), write a small
+probe script per candidate, fetch a few days of data, validate the
+format (parse-able? historical depth? license?), and write up findings
+in `dev/notes/<feed>-validation.md`. The probe script can be Python
+using `requests` or `yfinance` — no need to commit it as production
+code; treat it as a research artefact under `dev/scripts/probes/`.
+
+Known gaps that need new code or research are listed in
+`dev/notes/data-gaps.md`. When you resolve a gap, update that file.
 
 ## Standard workflow: fetch + refresh
 

--- a/dev/notes/data-gaps.md
+++ b/dev/notes/data-gaps.md
@@ -1,6 +1,6 @@
 # Data Gaps — features blocked on missing data
 
-Last updated: 2026-04-10 (FTSE decision made; ADL + fundamentals candidates identified)
+Last updated: 2026-04-14 (sharpened actionability per gap; scrape research moved into ops-data scope)
 
 ## A-D Breadth (ADL)
 
@@ -18,10 +18,17 @@ Last updated: 2026-04-10 (FTSE decision made; ADL + fundamentals candidates iden
 3. **Unicorn.us.com `advdec`** — comma-delimited historical A-D data for major indexes, free, computed from public sources. **Needs validation**: freshness, licence.
 4. **Compute from Russell 3000 universe** — count advancers/decliners across the cached universe each day. Tradeoffs: universe mismatch with official NYSE (no ETFs/ADRs/preferreds/CEFs), survivorship bias from current-constituents, but should correlate well. Fallback if scraper options fail. **Cost**: need Russell 3000 bars cached first (~3000 symbols × daily bars).
 
-### What's needed
-- **Next step**: research agent to validate each candidate and propose concrete fetch/parse plan
-- New parser for non-OHLCV response format (whatever source wins)
-- Once available: wire into `Weinstein_strategy.on_market_close` (line ~288, currently hardcoded `~ad_bars:[]`)
+### What's needed (orchestrator-actionable)
+- **ops-data**: write a probe script per candidate source under
+  `dev/scripts/probes/`, fetch 30 days of sample data, write findings
+  to `dev/notes/adl-validation.md` (parse-ability, historical depth,
+  rate limits, license). No EODHD key required for any of these
+  sources. **This is dispatchable today** — no human input needed.
+- After validation: write the production parser for the winning source,
+  add a fetch script alongside `fetch_symbols.exe`.
+- Once cached: feat-weinstein wires into `Weinstein_strategy.on_market_close`
+  (line ~288, currently hardcoded `~ad_bars:[]`). NOTE: feat-weinstein's
+  current scope is closed — surface as escalation if so.
 
 ### Impact of gap
 - Macro trend detection works but misses breadth divergence signals
@@ -36,9 +43,12 @@ Last updated: 2026-04-10 (FTSE decision made; ADL + fundamentals candidates iden
 **Blocks**: Screener sector filter, portfolio sector concentration limits  
 **Affects**: `Sector.analyze`, `Screener.screen` (receives empty `~sector_map`), `Portfolio_risk.check_sector_limits`
 
-### Three gaps
+### Three gaps (each with explicit ops-data dispatch criteria)
 
-1. **Sector ETF bars** — Need daily bars for sector index ETFs: XLK, XLF, XLE, XLV, XLI, XLP, XLY, XLU, XLB, XLRE, XLC. Not yet cached. **Blocked on `EODHD_API_KEY` not set in host environment.** Once key is available, fetch with:
+1. **Sector ETF bars** — daily bars for XLK, XLF, XLE, XLV, XLI, XLP,
+   XLY, XLU, XLB, XLRE, XLC. **Dispatchable when EODHD_API_KEY is set
+   in the host env** (`[ -n "$EODHD_API_KEY" ]`). Skip and surface as
+   escalation only if truly absent. Fetch:
    ```
    docker exec -e EODHD_API_KEY trading-1-dev bash -c \
      'cd /workspaces/trading-1/trading && eval $(opam env) && \
@@ -49,14 +59,28 @@ Last updated: 2026-04-10 (FTSE decision made; ADL + fundamentals candidates iden
    ```
    Then rebuild inventory with `build_inventory.exe`. Once cached, feed into `Sector.analyze ~sector_bars`.
 
-2. **Instrument sector metadata** — `Instrument_info.sector` is empty for all symbols.
-   - `bootstrap_universe.exe` leaves sector/industry blank by design (offline tool)
+2. **Instrument sector metadata** — `Instrument_info.sector` is empty
+   for all symbols. **Dispatchable today** — the plan exists and
+   doesn't require new human input.
+   - `bootstrap_universe.exe` leaves sector/industry blank by design
    - `fetch_universe.exe` populates name/exchange but not sector/industry
-   - **Plan**: See [`sector-data-plan.md`](./sector-data-plan.md) — fetch SPDR sector ETF holdings from State Street (SSGA) daily. One data provider, no Python, automatic refresh cadence tied to ETF fetch. Covers ~500 S&P 500 names; long-tail goes to the "unknown sector" bucket (`max_unknown_sector_positions = 2`, merged in #250).
-   - **Deprecated**: the Wikipedia scrape approach (PRs #251/#252/#253, now closed). See the deprecation note at the top of [`fundamentals-requirements.md`](./fundamentals-requirements.md).
-   - Until populated: screener cannot group stocks by sector, portfolio risk cannot enforce sector concentration limits for named sectors (but the unknown bucket is enforced)
+   - **Plan**: see [`sector-data-plan.md`](./sector-data-plan.md) —
+     fetch SPDR sector ETF holdings from SSGA. One data provider, no
+     Python, automatic refresh cadence tied to ETF fetch. Covers ~500
+     S&P 500 names; long-tail goes to the "unknown sector" bucket
+     (`max_unknown_sector_positions = 2`, merged in #250).
+   - **ops-data action**: execute the plan. The plan IS the spec.
+   - **Deprecated**: the Wikipedia scrape approach (PRs #251/#252/#253,
+     now closed). See deprecation note in
+     [`fundamentals-requirements.md`](./fundamentals-requirements.md).
+   - Until populated: screener can't group by sector; portfolio risk
+     can't enforce sector limits for named sectors (unknown bucket
+     enforced).
 
-3. **Strategy wiring** — `Weinstein_strategy.on_market_close` creates an empty `sector_map` (line ~213). Once sector data is available, build the map from `Sector.analyze` results and pass to `Screener.screen`.
+3. **Strategy wiring** — `Weinstein_strategy.on_market_close` creates an
+   empty `sector_map` (line ~213). Feature work, not ops-data. Owner:
+   feat-weinstein. NOTE: feat-weinstein's current scope is closed —
+   surface as escalation if dispatched.
 
 ### Impact of gap
 - Screener runs without sector context — a stock in a weak sector gets the same treatment as one in a strong sector
@@ -77,8 +101,11 @@ Last updated: 2026-04-10 (FTSE decision made; ADL + fundamentals candidates iden
 - N225.INDX (Nikkei 225): cached, 1965-01-05 to 2026-04-10 — VERIFIED
 - **FTSE 100 via `ISF.LSE` (iShares Core FTSE 100 UCITS ETF)** — **DECISION: use as proxy** (2026-04-10). Physical-replication tracker, ~bps tracking error, functionally indistinguishable from the index at weekly cadence. `UKX.INDX` returned empty; `ISF.LSE` fetched successfully (6,552 bars, 2000-05-02 to 2026-04-10) — VERIFIED (2026-04-11).
 
-### What's needed
-- **feat-weinstein**: wire cached global index bars into strategy (currently passes `~global_index_bars:[]`)
+### What's needed (escalation territory)
+- **feat-weinstein**: wire cached global index bars into strategy
+  (currently passes `~global_index_bars:[]`). Feature work, not
+  ops-data. NOTE: feat-weinstein's current scope is closed — surface
+  as escalation when dispatched.
 
 ---
 

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -35,6 +35,21 @@ JSONL_FILE="$LOG_DIR/$DATE.jsonl"
 SUMMARY_FILE="$REPO_ROOT/dev/daily/$DATE${PLAN_FLAG:+-plan}.md"
 JQ_FILTER="$REPO_ROOT/dev/lib/format-event.jq"
 
+# GH_TOKEN is required so subagents (feat-*, harness-maintainer) can run
+# `jst submit` to open PRs at session end. If the user has gh credentials
+# cached, harvest the token; otherwise warn and continue (the orchestrator
+# will surface "no PR opened" in the daily summary's escalations).
+if [ -z "${GH_TOKEN:-}" ]; then
+  GH_TOKEN=$(echo -e "protocol=https\nhost=github.com" \
+    | git credential fill 2>/dev/null \
+    | grep ^password | cut -d= -f2 || true)
+  if [ -z "$GH_TOKEN" ]; then
+    echo "WARN: GH_TOKEN unset and not derivable from git credentials." >&2
+    echo "WARN: subagents will push branches but cannot open PRs via jst." >&2
+  fi
+  export GH_TOKEN
+fi
+
 PROMPT="Run the daily development session for the Weinstein Trading System.
 Today's date is $DATE.${PLAN_FLAG}
 


### PR DESCRIPTION
Three changes informed by today's first real orchestrator run.

## 1. Plan-first is now inline (drops the deferral)

Previous flow (#333): Plan subagent → plan PR → human reviews → next-day feat-agent dispatch. Round-trip without a clear win — the human's "go ahead" signal is already in the orchestrator dispatching the agent in the first place.

**Revised**: feat-agents matching a Step 3.5 trigger write the plan themselves as the first commit on their branch, then implement in the same session. Plan and implementation land in a single PR. If the plan turns out wrong during implementation, update the plan in place rather than drifting silently.

Updates: `lead-orchestrator.md` §Step 3.5 rewritten; `feat-backtest.md` §Plan-first inline rewritten; the old "stop and escalate if no plan" instruction replaced with plan-then-execute.

## 2. `jst submit` from subagents (fixes "no PR opened" gap)

Today's morning orchestrator run pushed `harness/t3d-audit-trail` and `plan/stop-buffer` but didn't open PRs — the human had to chase down the missing PR creation.

`feat-*` and `harness-maintainer` agent definitions now explicitly call `jst submit <branch>` at session end (was implicit in `dev/agent-feature-workflow.md` but agents weren't picking it up). `lead-orchestrator.md` adds the same to its commit-discipline template.

## 3. PR-creation fallback in orchestrator

New `§Step 4.5`: after each subagent returns, the orchestrator checks if the pushed branch has an open PR; if not, runs `jst submit` itself. Catches the case where the subagent forgot or jst failed silently. If jst still fails, surface the error in the daily summary's §Escalations rather than looping.

## Plus

`dev/run.sh` now harvests `GH_TOKEN` from the user's git credentials cache and exports it to the orchestrator subprocess so jst can authenticate. Warns (doesn't fail) if no token is available.

## Test plan

- [x] `bash -n dev/run.sh` — clean
- [x] `dune runtest devtools/checks/` — all 12 OK (agent-compliance, plan-mode contract, status-file integrity, etc.)
- [ ] First real exercise: next orchestrator run should produce PRs (not just pushed branches) for any subagent dispatch
- [ ] feat-backtest's first dispatch should write `dev/plans/<item>-<date>.md` AND implement, both on the same branch, in the same session
