### PR TITLE
ci: explicitly forward EODHD_API_KEY from dev/run.sh

### DIFF
--- a/dev/run.sh
+++ b/dev/run.sh
@@ -50,6 +50,17 @@ if [ -z "${GH_TOKEN:-}" ]; then
   export GH_TOKEN
 fi
 
+# EODHD_API_KEY is optional; ops-data uses it for fetches (sector ETF bars,
+# symbol updates) but can still do a lot without it (scrape-source validation,
+# sector-data-plan execution, inventory rebuilds, coverage checks). Forward
+# explicitly so the orchestrator subprocess + downstream `docker exec -e ...`
+# all see the same value.
+if [ -n "${EODHD_API_KEY:-}" ]; then
+  export EODHD_API_KEY
+else
+  echo "NOTE: EODHD_API_KEY not set — ops-data will skip API-dependent fetches" >&2
+fi
+
 PROMPT="Run the daily development session for the Weinstein Trading System.
 Today's date is $DATE.${PLAN_FLAG}
 


### PR DESCRIPTION
Verified `EODHD_API_KEY` is set in your host env (23 chars). It's probably inherited implicitly by child processes today, but making it explicit:

- Prints a `NOTE` when unset so the ops-data skip reason shows up at script start, not mid-run
- Matches the existing `GH_TOKEN` pattern (symmetry + forward-proofing against future env sandboxing)
- No behavior change when the key IS set

One-file change, 10 lines added.