### PR TITLE
harness: T3-A QC calibration audit in deep scan

### DIFF
--- a/dev/health/2026-04-14-deep.md
+++ b/dev/health/2026-04-14-deep.md
@@ -1,0 +1,48 @@
+# Health Report -- 2026-04-14 -- deep
+
+## Summary
+- Findings: 11  (critical: 0  warnings: 1  info: 10)
+- Action required: NO
+
+## Warnings (should be addressed within 1 week)
+1. Follow-up accumulation: 16 open items across status files (threshold: 10)
+
+## Info (no immediate action; awareness only)
+1. TODO/FIXME/HACK annotations: 7 total (TODO: 7, FIXME: 0, HACK: 0)
+2. Near size limit: `analysis/technical/trend/lib/segmentation.ml` — 322 lines (declared-large, limit: 500)
+3. Near size limit: `analysis/weinstein/screener/lib/screener.ml` — 437 lines (declared-large, limit: 500)
+4. Near size limit: `trading/engine/lib/price_path.ml` — 459 lines (declared-large, limit: 500)
+5. Near size limit: `trading/portfolio/lib/portfolio.ml` — 410 lines (declared-large, limit: 500)
+6. Near size limit: `trading/simulation/lib/simulator.ml` — 327 lines (declared-large, limit: 500)
+7. Near size limit: `trading/strategy/lib/position.ml` — 410 lines (declared-large, limit: 500)
+8. Near size limit: `trading/weinstein/stops/lib/weinstein_stops.ml` — 413 lines (declared-large, limit: 500)
+9. QC calibration: `data-layer` has review (verdict: APPROVED) but no audit trail in `dev/audit/`
+10. QC calibration: `screener` has review (verdict: APPROVED) but no audit trail in `dev/audit/`
+
+## Metrics
+- Dead code candidates: 0
+- Design doc drift items: 0
+- TODO/FIXME/HACK annotations: 7 (TODO: 7, FIXME: 0, HACK: 0)
+- Files >300 lines: 0
+- Open follow-up items: 16 (maintenance threshold: 10)
+- QC calibration findings: 2 (dune available: true)
+
+## TODO/FIXME/HACK Detail
+
+### TODO
+  - `analysis/technical/trend/lib/segmentation.ml:228:  (* TODO(screener/segmentation-weights): move score weights into params for`
+  - `trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml:23:    TODO(simulation/price-cache-data-source): remove the tmpdir round-trip once`
+  - `trading/simulation/test/test_time_series.ml:296:  (* TODO(simulation/monthly-cadence): Monthly conversion returns empty. *)`
+  - `trading/simulation/lib/order_generator.ml:3:    TODO(simulation/stoplimit-orders): Orders should be StopLimit orders instead`
+  - `trading/simulation/lib/order_generator.mli:13:    TODO(simulation/stoplimit-orders): Orders should be StopLimit orders instead`
+  - `trading/simulation/lib/data/time_series.ml:22:      (* TODO(simulation/monthly-cadence): Monthly conversion not yet`
+  - `trading/engine/lib/types.mli:11:    TODO(simulation/bar-granularity): Add configurable bar granularity (daily,`
+
+## Size Violation Detail
+  - `analysis/technical/trend/lib/segmentation.ml`: 322 lines (declared-large)
+  - `analysis/weinstein/screener/lib/screener.ml`: 437 lines (declared-large)
+  - `trading/engine/lib/price_path.ml`: 459 lines (declared-large)
+  - `trading/portfolio/lib/portfolio.ml`: 410 lines (declared-large)
+  - `trading/simulation/lib/simulator.ml`: 327 lines (declared-large)
+  - `trading/strategy/lib/position.ml`: 410 lines (declared-large)
+  - `trading/weinstein/stops/lib/weinstein_stops.ml`: 413 lines (declared-large)

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -58,7 +58,7 @@ IN_PROGRESS
 ## Tier 3 — After M5 stable
 
 - [x] T3-A: `health-scanner` agent — deep scan (weekly: dead code, design doc drift, TODO accumulation, size violations) — DONE: see completion note below
-- [ ] T3-A: `health-scanner` deep scan — QC calibration audit (verdicts vs regression history)
+- [x] T3-A: `health-scanner` deep scan — QC calibration audit (verdicts vs regression history) — DONE: see completion note below
 - [ ] T3-A: `health-scanner` deep scan — harness scaffolding review (flag unused harness components)
 - [x] T3-A: `health-scanner` deep scan — feat-agent template compliance check (covered by T1-I: `agent_compliance_check.sh`)
 - [x] T3-B: AVR loop closure in `lead-orchestrator` (auto-dispatch QC on READY_FOR_REVIEW)
@@ -227,6 +227,8 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
 ### T3-A: Deep scan
 
 - [x] T3-A: Deep scan deterministic script — `trading/devtools/checks/deep_scan.sh`; standalone shell script (not wired into `dune runtest` — runs weekly, not on every PR). Covers 5 checks: (1) dead code detection (`.ml` files not in any dune library), (2) design doc drift (`analysis/weinstein/` and `trading/weinstein/` modules vs `eng-design-{1,2,3}` docs), (3) TODO/FIXME/HACK accumulation across `.ml`/`.mli` files, (4) size violations (files >300 lines without `@large-module`), (5) follow-up item count across `dev/status/*.md`. Writes report to `dev/health/YYYY-MM-DD-deep.md`. Health-scanner agent definition updated with Phase 1 (deterministic script) and Phase 2 (agentic steps: architecture drift, QC calibration, harness scaffolding review). Verify: `sh trading/devtools/checks/deep_scan.sh` from repo root produces `dev/health/YYYY-MM-DD-deep.md` with Metrics section.
+
+- [x] T3-A: QC calibration audit — Check 6 in `trading/devtools/checks/deep_scan.sh`. For each `dev/reviews/*.md`, extracts the most recent overall verdict (APPROVED/NEEDS_REWORK) via three patterns (`overall_qc:`, `Status:`, `## Verdict`), then: (a) flags features with reviews but no audit trail record in `dev/audit/`, (b) if `dune` is on PATH, runs `dune runtest` on each feature's test directories and flags mismatches (APPROVED + failing tests = regression; NEEDS_REWORK + passing tests = stale review). Feature-to-test-directory mapping covers screener, data-layer, portfolio-stops, simulation. Output appears in the deep scan report under `## QC Calibration Detail`. Verify: `eval $(opam env) && sh trading/devtools/checks/deep_scan.sh` — report includes `QC calibration findings` in Metrics section.
 
 ### T3-D: Audit trail
 

--- a/trading/devtools/checks/deep_scan.sh
+++ b/trading/devtools/checks/deep_scan.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 # Deep scan for health-scanner agent (T3-A).
 #
-# Runs weekly (not on every PR). Performs four read-only analyses:
+# Runs weekly (not on every PR). Performs six read-only analyses:
 #   1. Dead code detection — .ml files not referenced in any dune file
 #   2. Design doc drift — module structure vs eng-design docs
 #   3. TODO/FIXME/HACK accumulation
 #   4. Size violations — files >300 lines without @large-module
+#   5. Follow-up item count (from status files)
+#   6. QC calibration audit — verdicts vs current test health
 #
 # Output: dev/health/YYYY-MM-DD-deep.md
 #
@@ -281,6 +283,139 @@ elif [ "$FOLLOWUP_COUNT" -gt 0 ]; then
 fi
 
 # ────────────────────────────────────────────────────────────────
+# Check 6: QC calibration audit — verdicts vs current test health
+# ────────────────────────────────────────────────────────────────
+#
+# For each feature with a QC review (dev/reviews/*.md), extract the
+# most recent overall verdict and cross-reference against whether the
+# feature's test directories currently pass `dune runtest`.
+#
+# This detects two classes of drift:
+#   a) QC said APPROVED but tests now fail (regression since review)
+#   b) Missing audit trail record for a reviewed feature
+#
+# The dune check is skipped if `dune` is not on PATH (e.g. running
+# outside the dev container).
+
+QC_CAL_COUNT=0
+QC_CAL_DETAILS=""
+DUNE_AVAILABLE=false
+
+if command -v dune >/dev/null 2>&1; then
+  DUNE_AVAILABLE=true
+fi
+
+# Feature-name to test directory mapping.
+# Each feature maps to one or more dune-runtest-able paths (relative
+# to the trading/ workspace root).
+_test_dirs_for_feature() {
+  case "$1" in
+    screener)
+      echo "analysis/weinstein/stage/test analysis/weinstein/rs/test analysis/weinstein/volume/test analysis/weinstein/macro/test analysis/weinstein/sector/test analysis/weinstein/resistance/test analysis/weinstein/stock_analysis/test analysis/weinstein/screener/test"
+      ;;
+    data-layer)
+      echo "analysis/weinstein/data_source/test"
+      ;;
+    portfolio-stops)
+      echo "trading/weinstein/order_gen/test trading/weinstein/stops/test trading/weinstein/portfolio_risk/test trading/weinstein/trading_state/test"
+      ;;
+    simulation)
+      echo "trading/weinstein/strategy/test"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
+for review_file in "${REPO_ROOT}"/dev/reviews/*.md; do
+  [ -f "$review_file" ] || continue
+  feature="$(basename "$review_file" .md)"
+
+  # Extract the most recent overall verdict.
+  # Review files use "overall_qc: APPROVED" or standalone "APPROVED"
+  # after a "## Verdict" heading.  Take the last occurrence.
+  verdict=""
+
+  # First try "overall_qc:" lines (takes the last one in the file)
+  overall_line="$(grep -i '^overall_qc:' "$review_file" 2>/dev/null | tail -1 || true)"
+  if [ -n "$overall_line" ]; then
+    verdict="$(echo "$overall_line" | sed 's/^overall_qc:[[:space:]]*//' | tr -d '[:space:]')"
+  fi
+
+  # Fallback: try "Status: APPROVED" (older review format)
+  if [ -z "$verdict" ]; then
+    status_line="$(grep -i '^Status:' "$review_file" 2>/dev/null | tail -1 || true)"
+    if [ -n "$status_line" ]; then
+      case "$status_line" in
+        *APPROVED*) verdict="APPROVED" ;;
+        *NEEDS_REWORK*) verdict="NEEDS_REWORK" ;;
+      esac
+    fi
+  fi
+
+  # Fallback: look for standalone verdict lines after "## Verdict"
+  if [ -z "$verdict" ]; then
+    verdict_line="$(grep -A1 '^## Verdict' "$review_file" 2>/dev/null | tail -1 | tr -d '[:space:]' || true)"
+    case "$verdict_line" in
+      APPROVED|NEEDS_REWORK) verdict="$verdict_line" ;;
+    esac
+  fi
+
+  if [ -z "$verdict" ]; then
+    QC_CAL_COUNT=$((QC_CAL_COUNT + 1))
+    add_info "QC calibration: could not extract verdict from \`dev/reviews/${feature}.md\`"
+    continue
+  fi
+
+  # Check for audit trail record
+  has_audit=false
+  for audit_file in "${REPO_ROOT}"/dev/audit/*-"${feature}".json; do
+    if [ -f "$audit_file" ]; then
+      has_audit=true
+      break
+    fi
+  done
+  if ! $has_audit; then
+    QC_CAL_COUNT=$((QC_CAL_COUNT + 1))
+    add_info "QC calibration: \`${feature}\` has review (verdict: ${verdict}) but no audit trail in \`dev/audit/\`"
+  fi
+
+  # Cross-reference verdict against current test health
+  if $DUNE_AVAILABLE; then
+    test_dirs="$(_test_dirs_for_feature "$feature")"
+    if [ -z "$test_dirs" ]; then
+      QC_CAL_COUNT=$((QC_CAL_COUNT + 1))
+      add_info "QC calibration: no test directory mapping for feature \`${feature}\`"
+      continue
+    fi
+
+    tests_pass=true
+    failing_dir=""
+    for tdir in $test_dirs; do
+      # Check both the source and build paths
+      if [ -d "${REPO_ROOT}/trading/${tdir}" ]; then
+        if ! (cd "${REPO_ROOT}/trading" && dune runtest "$tdir" 2>/dev/null); then
+          tests_pass=false
+          failing_dir="$tdir"
+          break
+        fi
+      fi
+    done
+
+    if [ "$verdict" = "APPROVED" ] && ! $tests_pass; then
+      QC_CAL_COUNT=$((QC_CAL_COUNT + 1))
+      add_warning "QC calibration mismatch: \`${feature}\` review says APPROVED but \`dune runtest ${failing_dir}\` fails — regression since review"
+      QC_CAL_DETAILS="${QC_CAL_DETAILS}  - \`${feature}\`: verdict APPROVED, tests FAILING in \`${failing_dir}\`\n"
+    elif [ "$verdict" = "NEEDS_REWORK" ] && $tests_pass; then
+      QC_CAL_COUNT=$((QC_CAL_COUNT + 1))
+      add_info "QC calibration: \`${feature}\` review says NEEDS_REWORK but all tests currently pass — review may be stale"
+      QC_CAL_DETAILS="${QC_CAL_DETAILS}  - \`${feature}\`: verdict NEEDS_REWORK, tests PASSING\n"
+    fi
+  fi
+done
+
+# ────────────────────────────────────────────────────────────────
 # Generate report
 # ────────────────────────────────────────────────────────────────
 
@@ -328,6 +463,7 @@ cat >> "$OUTPUT_FILE" <<METRICS_EOF
 - TODO/FIXME/HACK annotations: ${TOTAL_ANNOTATIONS} (TODO: ${TODO_COUNT}, FIXME: ${FIXME_COUNT}, HACK: ${HACK_COUNT})
 - Files >300 lines: ${SIZE_VIOLATION_COUNT}
 - Open follow-up items: ${FOLLOWUP_COUNT} (maintenance threshold: 10)
+- QC calibration findings: ${QC_CAL_COUNT} (dune available: ${DUNE_AVAILABLE})
 METRICS_EOF
 
 # Append detail sections if non-empty
@@ -339,6 +475,11 @@ fi
 if [ -n "$SIZE_DETAILS" ]; then
   printf "\n## Size Violation Detail\n" >> "$OUTPUT_FILE"
   printf '%b' "$SIZE_DETAILS" >> "$OUTPUT_FILE"
+fi
+
+if [ -n "$QC_CAL_DETAILS" ]; then
+  printf "\n## QC Calibration Detail\n" >> "$OUTPUT_FILE"
+  printf '%b' "$QC_CAL_DETAILS" >> "$OUTPUT_FILE"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Add Check 6 (QC calibration audit) to `trading/devtools/checks/deep_scan.sh`
- For each `dev/reviews/*.md`, extracts verdict (APPROVED/NEEDS_REWORK) and cross-references against audit trail presence and current test health
- Flags: (a) features with reviews but no audit trail record, (b) APPROVED verdicts where tests now fail (regression), (c) NEEDS_REWORK verdicts where tests pass (stale review)
- Feature-to-test-directory mapping covers screener, data-layer, portfolio-stops, simulation

## Test plan
- [x] `sh -n trading/devtools/checks/deep_scan.sh` passes syntax check
- [x] `dune build && dune runtest` passes in Docker
- [x] `sh trading/devtools/checks/deep_scan.sh` produces report with QC calibration findings in Metrics section
- [x] Report correctly identifies 2 features with missing audit trail records (data-layer, screener)
- [x] With dune on PATH, test cross-reference runs and finds no mismatches (all APPROVED features have passing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)