### PR TITLE
chore: reopen feat-weinstein scope + scrub stale decisions

### DIFF
--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -1,60 +1,65 @@
 ---
 name: feat-weinstein
-description: Implements remaining Weinstein Trading System feature work — order_gen (portfolio-stops) and Simulation Slice 2. Works on feat/portfolio-stops and feat/simulation branches using TDD.
+description: Implements remaining Weinstein Trading System feature work — strategy-wiring (Synthetic_adl façade composition + default_global_indices). Works on feat/strategy-wiring branch using TDD.
 ---
 
-You are building the remaining Weinstein Trading System feature work. Two active tracks remain:
+You are building the remaining Weinstein Trading System feature work. The base strategy (order_gen, Simulation Slice 1-3, screener, stops, portfolio_risk) is complete and merged. One scope remains:
 
-1. **order_gen** (`feat/portfolio-stops` branch) — the last unimplemented module in portfolio-stops
-2. **Simulation Slice 2** (`feat/simulation` branch) — wiring real bar history into the Weinstein strategy
+**strategy-wiring** (`feat/strategy-wiring` branch) — two narrow items that hand off already-cached data to macro inputs already declared in `Weinstein_strategy.config`.
 
 ## At the start of every session
 
 1. Read `dev/agent-feature-workflow.md` — shared workflow, commit discipline, session procedures
 2. Read `CLAUDE.md` — code patterns, OCaml idioms, workflow
-3. Read `dev/decisions.md` — human guidance; **critical for order_gen** (two prior attempts closed)
-4. Read `dev/status/portfolio-stops.md` — order_gen status
-5. Read `dev/status/simulation.md` — Slice 2 status and design plan (see `## Next Steps`)
-6. Read the relevant design docs:
-   - `docs/design/eng-design-3-portfolio-stops.md` §"Order Generation" — order_gen interface and decision table
-   - `docs/design/eng-design-4-simulation-tuning.md` — simulation context
-7. State your plan for this session before writing any code
+3. Read `dev/decisions.md` — human guidance
+4. Read `dev/status/strategy-wiring.md` — current scope, work items, references
+5. Read the relevant design docs:
+   - `docs/design/eng-design-2-screener-analysis.md` §"Macro analyzer"
+   - `docs/design/weinstein-book-reference.md` §"Macro Indicators" — for the global-index set rationale
+   - `dev/notes/adl-sources.md` — source history and synthetic decision
+6. State your plan for this session before writing any code
 
-## Track 1: order_gen
+## Scope: strategy-wiring
 
-**Branch:** `feat/portfolio-stops`
+**Branch:** `feat/strategy-wiring` (create off `main@origin`)
 
-Order_gen is a pure formatter — translates `Position.transition list` from `strategy.on_market_close` into broker order suggestions. Read `dev/decisions.md` carefully before starting: two prior implementations were closed for violating the spec.
+Two independent items, either can land first. Both read cached data already on disk. **Do not modify** base strategy/screener/stops/portfolio_risk code — work is confined to `Ad_bars.load` and `Macro_inputs`.
 
-**The correct spec (from decisions.md):**
-- Location: `trading/weinstein/order_gen/` (NOT `analysis/`)
-- Input: `Position.transition list` — NOT screener candidates
-- Role: pure formatter only — no sizing decisions, no `Portfolio_risk` calls
-- Strategy-agnostic: any strategy using `Position.transition` gets order formatting for free
-- Reference: `eng-design-3-portfolio-stops.md` §"Order Generation"
+### Item 1 — compose Synthetic ADL into `Ad_bars.load` façade
 
-**Critical constraint:** Do **not** modify existing `Portfolio`, `Orders`, or `Position` modules.
+Goal: extend `Ad_bars.load` to merge Unicorn (1965-02-10 → 2020-02-10) with `Synthetic_adl`-computed counts (2020-02-11 → present), so post-2020 backtests receive non-empty `ad_bars`.
 
-## Track 2: Simulation Slice 2
+Files: `trading/trading/weinstein/strategy/lib/ad_bars.{ml,mli}`.
 
-**Branch:** `feat/simulation`
+- Add `Synthetic` submodule (or direct call) to `Ad_bars`. Input path convention from `compute_synthetic_adl.exe`:
+  `data/breadth/synthetic_nyse_advn.csv` + `synthetic_nyse_decln.csv`
+- `load ~data_dir` composes Unicorn + Synthetic: Unicorn wins for the overlap window (dates it covers), Synthetic fills the tail. Dedupe by date. Return single chronologically-sorted `Macro.ad_bar list`.
+- Tests: date ranges don't overlap, correct source wins on overlap, ordering correct, missing files degrade gracefully.
+- Validation gate: run `Synthetic_adl.validate_against_golden` over the Unicorn overlap window; require correlation ≥0.85. Record numbers in `dev/notes/synthetic-adl-validation.md`.
 
-The Weinstein strategy currently has 4 placeholder gaps. The design plan for all 4 is in `dev/status/simulation.md` `## Next Steps`. Key points:
+Estimate: ~80 lines + tests.
 
-- Bar accumulation: per-symbol buffer in `make` closure (same pattern as `stop_states`), aggregate to weekly via `Time_period.Conversion.daily_to_weekly` on Fridays
-- `?portfolio_value:float` optional param to `on_market_close` — existing strategies ignore it with `?portfolio_value:_`; simulator passes `portfolio.current_cash`; Weinstein uses it in `_entries_from_candidates`
-- `ma_direction`: derive from `Stage.classify` on the bar buffer
-- Simulation date: use current bar's date instead of `Date.today`
+### Item 2 — populate `indices.global`
 
-After all 4 changes, extend smoke test: `hist_start` to `2022-01-01`, add assertions for trades made, open AAPL position, realized PnL ≥ 0, unrealized PnL > 0.
+Goal: default config ships a non-empty `indices.global` list so `Macro.analyze` receives global breadth input.
 
-## Sequencing
+Files: `trading/trading/weinstein/strategy/lib/macro_inputs.{ml,mli}`, `trading/trading/backtest/lib/runner.ml`.
 
-Do **order_gen first** (smaller, self-contained), then Simulation Slice 2. They are independent — order_gen does not block Slice 2 and vice versa.
+- Define `default_global_indices : (string * string) list` in `Macro_inputs`. Verify each symbol has cached bars under `data/` before including it. Canonical candidates: FTSE proxy (`ISF.LSE`), DAX (`GDAXI.INDX`), Nikkei (`N225.INDX`). See `dev/status/data-layer.md` §Known gaps for original symbol research.
+- Runner override in `runner.ml`: `indices = { primary = index_symbol; global = Macro_inputs.default_global_indices }`.
+- Tests: smoke test that `Macro.analyze` receives non-empty `global_index_bars` when strategy is booted with the default.
+
+Estimate: ~40 lines + tests + symbol-list verification against cached data.
+
+## Not in scope
+
+- Pinnacle Data purchase — human decided synthetic-only (see `dev/notes/adl-sources.md`).
+- Sector metadata Phase 1 (SSGA XLSX holdings fetcher) — ops-data scope.
+- Stop-buffer / stops tuning — feat-backtest scope.
 
 ## At the start of every session — check for follow-up items
 
-After reading the status files, check for `## Follow-up` sections. Address follow-up items before any new feature work.
+After reading `dev/status/strategy-wiring.md`, check the `## Follow-up` section (if present). Address follow-up items before any new wiring work.
 
 ## Allowed Tools
 
@@ -63,28 +68,24 @@ Do not use the Agent tool (no subagent spawning).
 
 ## Max-Iterations Policy
 
-If after **3 consecutive build-fix cycles** `dune build && dune runtest` is still failing: stop, report the blocker, update the relevant status file to BLOCKED, and end the session.
+If after **3 consecutive build-fix cycles** `dune build && dune runtest` is still failing: stop, report the blocker, update `dev/status/strategy-wiring.md` to BLOCKED, and end the session.
 
 ## Acceptance Checklist
 
-### order_gen
-- [ ] Located at `trading/weinstein/order_gen/` (not `analysis/`)
-- [ ] Input is `Position.transition list` — no screener candidates, no sizing logic
-- [ ] Pure formatter: same input → same output, no hidden state
-- [ ] Does not modify `Portfolio`, `Orders`, or `Position` modules
-- [ ] Every public function exported in `.mli` with doc comment
-- [ ] No function exceeds 50 lines
+### Item 1 — Synthetic ADL façade
+- [ ] `Ad_bars.load` returns a composed series: Unicorn for pre-2020-02-11 dates, Synthetic for later dates
+- [ ] Missing Synthetic CSVs degrade gracefully (Unicorn-only, empty tail) — never raise
+- [ ] Correlation ≥0.85 recorded in `dev/notes/synthetic-adl-validation.md`
+- [ ] Unit tests cover overlap precedence, gap handling, ordering, missing files
+- [ ] Ad_bars.mli documentation updated — no stale "delegates to Unicorn only" claim
 - [ ] `dune build && dune runtest` passes, `dune fmt --check` passes
 
-### Simulation Slice 2
-- [ ] Per-symbol bar buffer accumulates in `make` closure
-- [ ] Weekly aggregation uses `Time_period.Conversion.daily_to_weekly`
-- [ ] `?portfolio_value` is optional — existing strategies compile without it
-- [ ] `ma_direction` computed from bar buffer, not hardcoded `Flat`
-- [ ] `_make_entry_transition` uses simulation date, not `Date.today`
-- [ ] Smoke test extended: `hist_start` 2022-01-01, trade/position/PnL assertions added
+### Item 2 — Global indices
+- [ ] `Macro_inputs.default_global_indices` defined; each symbol verified present in `data/`
+- [ ] Runner wires the default through `Macro_inputs.default_global_indices`
+- [ ] Smoke test asserts `Macro.analyze` sees non-empty `global_index_bars` under default config
 - [ ] `dune build && dune runtest` passes, `dune fmt --check` passes
 
 ## Status file updates
 
-Update `dev/status/portfolio-stops.md` and `dev/status/simulation.md` at the end of every session with current Status, Completed, In Progress, and Next Steps.
+Update `dev/status/strategy-wiring.md` at the end of every session with current Status, Completed, In Progress, and Next Steps.

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ _opam/
 # Agent runtime files (logs, lock files, worktrees)
 dev/logs/*.log
 dev/logs/*.running
+dev/logs/*.jsonl
 
 # Backtest equity curves (large, regenerable) — ** matches any depth
 dev/backtest/**/equity_curve.csv

--- a/dev/daily/2026-04-14-plan.md
+++ b/dev/daily/2026-04-14-plan.md
@@ -1,0 +1,112 @@
+# Status — 2026-04-14 (plan mode)
+
+## 2a: Blocking Refactors
+
+None. All feature status files show no unchecked blocking refactors.
+
+- portfolio-stops: MERGED, no `## Blocking Refactors` section (complete)
+- simulation: MERGED, `## Blocking Refactors — None`
+- backtest-infra: IN_PROGRESS, no blocking refactors listed
+
+**Result**: no refactor dispatches, all feature slots available.
+
+## 2b: Followup Accumulation
+
+| Status file | Open followup items |
+|---|---|
+| portfolio-stops | 0 (closed) |
+| simulation | ~13 items (volume dilution, test assertions, 6 TODO slugs, macro cadence, perf) |
+| backtest-infra | ~7 items (stop follow-ups, experiment framework, medium-term items) |
+| harness | ~6 items (worktree gitignore, nesting linter, daily summary drift, deep scan gaps) |
+| **Total** | **~26 items** |
+
+Threshold: 10 (from `dev/config/merge-policy.json`). **Exceeded (26 > 10).**
+
+Maintenance cycle ratio: every 3rd run. This would be run #8 (prior dailies: 03-24, 03-30, 04-07, 04-09, 04-10, 04-11, 04-14). 8 % 3 ≠ 0 → **not a maintenance cycle**.
+
+**Result**: followup count recorded but no maintenance pass swapped in this run.
+
+## 2c: Harness Backlog
+
+All T1 items complete. T2 items milestone-gated (M5/M7). Scanning T3:
+
+**Highest-priority unchecked T3 items:**
+
+1. `T3-A`: health-scanner deep scan — harness scaffolding review (flag unused harness components)
+2. `T3-C`: Cross-feature context injection
+3. `T3-E`: Cost/token budget visibility in daily summary
+4. `T3-F`: Architecture graph analyzer in health-scanner deep scan
+5. `T3-F`: Rule promotion path (generate dune checks from enforced rules)
+6. `T3-G`: followup-item count + CC trend analysis in weekly report
+7. `T3-G`: Audit trail — include qc-behavioral quality score
+8. `T3-H`: Commit-level QC mode
+
+**In-progress check:**
+- No remote harness bookmarks on origin
+- No open harness PRs on GitHub
+- Local `harness/dispatch-flow-revise` and `harness/run-sh-hardening` exist but are stale (no origin push, no open PR)
+
+**Stale bookmarks to flag**: `harness/dispatch-flow-revise` (local only, no PR), `harness/run-sh-hardening` (local only, `@origin (not created yet)`). Both >24h old. Flag for human cleanup.
+
+**Would dispatch**: `harness-maintainer` for **T3-E** (cost/token budget visibility).
+- Rationale: T3-A scaffolding review is investigative with unclear output; T3-C is superseded for basic case; T3-E produces concrete visible value (daily summary improvement) and is self-contained.
+- Branch: `harness/t3e-cost-visibility`
+
+## 2d: Data Operations (ops-data)
+
+### ADL — SKIP (human input required)
+EODData registration needed to check `INDEX:ADVN`/`INDEX:DECL`. Genuinely blocked on human action.
+
+### Sector instrument metadata — WOULD DISPATCH
+- Plan exists: `dev/notes/sector-data-plan.md` Phase 0 validated (2026-04-11)
+- Phase 1 ready: SSGA XLSX fetcher — download 11 ETF holdings files, parse XLSX (minimal reader via camlzip + xmlm), write `data/sectors.csv`
+- EODHD_API_KEY is set (not needed for this task, but env is healthy)
+- The plan IS the spec. No human decision required.
+
+**Would dispatch**: ops-data to execute Phase 1 of `dev/notes/sector-data-plan.md`
+
+### Global index bars — SKIP (escalation)
+Data cached. Strategy wiring needed but feat-weinstein scope is closed. Escalation: "feat-weinstein needs a reopened scope or a new agent to wire global index bars + sector data into strategy."
+
+### Strategy wiring (sector + global index) — ESCALATION
+Both sector and global index data are cached/cacheable, but `Weinstein_strategy.on_market_close` wiring is feature work. feat-weinstein's scope is closed. Need human decision: reopen feat-weinstein scope, or create a new agent track.
+
+## 2e: Feature Agents
+
+| Feature | Agent | Can run? | Would dispatch? |
+|---|---|---|---|
+| portfolio-stops | feat-weinstein | MERGED, no followup | **No** — complete |
+| simulation | feat-weinstein | MERGED, no blocking refactors | **No** — complete |
+| backtest-infra | feat-backtest | IN_PROGRESS, stop-buffer done | **Yes** |
+
+### backtest-infra dispatch plan
+
+**Next item**: "Support-floor-based stops" — ranked #1 in §Stop-buffer follow-ups. Weinstein's actual prescription: place stops at prior correction lows. Adapts to each stock's structure.
+
+**Plan-first applies**: trigger 4 (experiment design — success is empirical, not unit-testable). Would inject `## Plan-first` paragraph into feat-backtest prompt. Agent writes plan to `dev/plans/support-floor-stops-2026-04-14.md` as first commit, then implements in same session.
+
+**Alternative next items** (if support-floor is too large):
+1. Per-trade stop logging (not experiment, no plan-first needed, smaller scope)
+2. Regime-aware stops (experiment, plan-first)
+
+## Dispatch Summary
+
+If this were a real run, dispatches would be (in order):
+
+1. **ops-data** — sector instrument metadata Phase 1 (SSGA holdings fetcher). Runs before feat-agents.
+2. **feat-backtest** — support-floor-based stops experiment, with plan-first. Parallel with harness.
+3. **harness-maintainer** — T3-E cost/token budget visibility. Parallel with feat-backtest.
+4. **qc-structural → qc-behavioral** — if feat-backtest reaches READY_FOR_REVIEW.
+5. **health-scanner** — fast scan post-completion.
+
+## Escalations (would appear in real daily summary)
+
+1. **Strategy wiring blocked**: feat-weinstein scope is closed but 3 data gaps need wiring:
+   - Global index bars (cached, needs `~global_index_bars` wiring)
+   - Sector map (after ops-data Phase 1, needs `~sector_map` wiring)
+   - ADL bars (blocked on source, but wiring also needed)
+   Human decision: reopen feat-weinstein for a "data wiring" slice, or create dedicated agent.
+
+2. **Stale local harness bookmarks**: `harness/dispatch-flow-revise` and `harness/run-sh-hardening` — local only, no PRs, no recent commits. Clean up with `jj bookmark delete`.
+
+3. **ADL source**: human registration at EODData needed to check `INDEX:ADVN`/`INDEX:DECL` availability.

--- a/dev/status/data-layer.md
+++ b/dev/status/data-layer.md
@@ -87,10 +87,12 @@ All four items from `docs/design/eng-design-data-management.md` are implemented 
 **AAPL coverage verified:** inventory shows AAPL from 1980-12-12 to 2025-05-16, covering the 2017–2024 range required by T2-A golden scenarios.
 ## Known gaps
 
-**Macro data feeds** — required before `Macro.analyze` can run from real data; not needed for regression tests (construct `Macro.result` directly — see `docs/design/t2a-golden-scenarios.md`):
+**Macro data feeds** — data presence status as of 2026-04-14. Strategy-wiring track (`dev/status/strategy-wiring.md`) covers the remaining runtime composition work; data layer itself is complete for these feeds.
 
-- **Primary index bars** (`~index_bars`): EODHD symbols `GSPC.INDX` or `DJI.INDX`. `GSPCX` (cached at `data/G/X/GSPCX/`, daily from 1997) is a usable stand-in.
-- **NYSE A-D breadth** (`~ad_bars`): daily advancing/declining counts — not derivable from price bars. EODHD symbols likely `ADV.NYSE` / `DEC.NYSE`; verify. Requires a new parser (not OHLCV format).
-- **Global index bars** (`~global_index_bars`): FTSE 100 via `ISF.LSE` (iShares ETF proxy — EODHD does not carry `FTSE.INDX`), DAX (`GDAXI.INDX`), Nikkei 225 (`N225.INDX`). `IWM` (cached at `data/I/M/IWM/`) usable as interim US small-cap proxy.
-
-Until cached: call with `ad_bars:[]` and `global_index_bars:[]`; analyzer degrades gracefully.
+- **Primary index bars** (`~index_bars`): `GSPCX` cached at `data/G/X/GSPCX/` (daily from 1997). Wired via `runner.ml`. ✓
+- **NYSE A-D breadth** (`~ad_bars`): CACHED in two sources.
+  - Unicorn historical: `data/breadth/nyse_{advn,decln}.csv` (1965-03-01 → 2020-02-10). Wired via `Ad_bars.Unicorn.load`. ✓
+  - Synthetic post-2020: computed by `Synthetic_adl` module + `compute_synthetic_adl.exe` script; output convention `data/breadth/synthetic_nyse_{advn,decln}.csv`. Façade composition into `Ad_bars.load` is pending — tracked in `dev/status/strategy-wiring.md` Item 1.
+  - EODHD verified NOT a source: `ADV.NYSE`/`DEC.NYSE` return Ticker Not Found. Pinnacle Data evaluated ($39 one-time, 1940-present) but declined — synthetic-only chosen for live coverage.
+- **Sector ETF bars**: all 11 SPDRs cached. Wired via `Macro_inputs.spdr_sector_etfs` in `runner.ml`. ✓
+- **Global index bars** (`~global_index_bars`): FTSE proxy (`ISF.LSE`), DAX (`GDAXI.INDX`), Nikkei (`N225.INDX`) — data status per symbol needs to be re-checked at wiring time. Wiring is pending — tracked in `dev/status/strategy-wiring.md` Item 2 (needs `default_global_indices` constant + runner override).

--- a/dev/status/simulation.md
+++ b/dev/status/simulation.md
@@ -66,9 +66,7 @@ All slices merged: Slice 1 (#196), Slice 2 (#237, #240, #241, #242), Slice 3 (#2
 - `TODO(simulation/stoplimit-orders)` — `order_generator` uses Market orders; should be StopLimit orders with entry/exit prices from transitions. See `simulation/lib/order_generator.ml` and `.mli`.
 - `TODO(simulation/monthly-cadence)` — Monthly cadence conversion not implemented in `time_series.ml` — currently returns empty. See `simulation/lib/data/time_series.ml`.
 - `TODO(simulation/bar-granularity)` — Engine `price_bar` type lacks configurable bar granularity (daily/hourly/minute) and volume data. See `engine/lib/types.mli`.
-- **Macro.analyze cadence mismatch** — `Macro.analyze` consumes daily `ad_bars`
-  but weekly `index_bars`; needs a design note + fix so the two inputs share a
-  cadence. Source: `dev/daily/2026-04-11.md`.
+- ~~**Macro.analyze cadence mismatch**~~ — RESOLVED. `Ad_bars_aggregation.daily_to_weekly` is now called at `make` time (see `weinstein_strategy.ml:254`), so `Macro.analyze` receives weekly-cadence `ad_bars` matching the weekly `index_bars`.
 - **Simulation loop performance** — current 6-year / 1654-stock backtest takes
   ~40 min and ~7 GB RAM (see `dev/status/backtest-infra.md` §Performance).
   Bottlenecks worth profiling before attempting optimization:


### PR DESCRIPTION
## Summary
- Rewrite \`.claude/agents/feat-weinstein.md\` — drop completed order_gen (#227) and Simulation Slice 2 (#246) tracks; point agent to strategy-wiring scope (Synthetic_adl façade composition + \`default_global_indices\` population) per \`dev/status/strategy-wiring.md\`.
- Scrub stale decisions from adjacent status files:
  - \`dev/status/data-layer.md\` §Known gaps — ADL now cached (Unicorn + synthetic); sector ETFs wired; Pinnacle declined; only global-index wiring remains. Drop stale 'EODHD likely ADV.NYSE, verify' claim.
  - \`dev/status/simulation.md\` §Follow-up — mark 'Macro.analyze cadence mismatch' RESOLVED (fixed via \`Ad_bars_aggregation.daily_to_weekly\` in \`make\`).
- Archive plan-mode orchestrator artifact at \`dev/daily/2026-04-14-plan.md\`.
- \`.gitignore\` — ignore \`dev/logs/*.jsonl\` (session log, regenerable).

## Test plan
- [ ] Agent definition still passes \`devtools/checks/agent_compliance_check.sh\` required-sections check (Acceptance Checklist, Allowed Tools, Max-Iterations Policy sections present)
- [ ] No code / build affected — documentation and configuration only