### PR TITLE
docs: add dev/status/_index.md + wire maintenance through agents

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -122,6 +122,23 @@ the orchestrator does not act on this section)
 - `## Blocking Refactors` takes priority over feature work on the next run
 - `## Known gaps` is never empty-checked by automation; it is for human awareness only
 
+### 8. Index row update (required)
+
+At the end of every session, in addition to updating the track's own
+status file, update the corresponding row in `dev/status/_index.md`:
+
+- **Status** cell — mirrors the status file's `## Status`
+- **Owner** cell — this agent's name (usually unchanged)
+- **Open PR(s)** cell — PRs currently open against this track
+- **Next task** cell — the top-of-queue item from the status file's
+  `## Next Steps`
+
+Agents only touch their own row. Adding a new track to the system means
+creating the status file **and** adding a row to the index in the same
+commit. `lead-orchestrator` reconciles the index against all status
+files at end-of-run and flags drift, but agents should keep the row
+fresh so the index is usable between orchestrator runs.
+
 ---
 
 ## Architecture constraint

--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -127,4 +127,5 @@ status to READY_FOR_REVIEW.
 1. Set the item's checkbox to `[x]` in `dev/status/backtest-infra.md`, with a one-line completion note (what was built, where, verify command).
 2. If the work is feature code that ships an interface change, update `## Interface stable` if needed.
 3. Set `## Status` to READY_FOR_REVIEW only if you've finished a complete deliverable; otherwise leave it as IN_PROGRESS with progress notes.
-4. Push your branch via jj. The orchestrator picks up READY_FOR_REVIEW status files and dispatches QC.
+4. Update the **backtest-infra** row in `dev/status/_index.md` — align Status, Owner, Open PR, and Next task with the changes above. Only touch your own row.
+5. Push your branch via jj. The orchestrator picks up READY_FOR_REVIEW status files and dispatches QC.

--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -88,4 +88,7 @@ If after **3 consecutive build-fix cycles** `dune build && dune runtest` is stil
 
 ## Status file updates
 
-Update `dev/status/strategy-wiring.md` at the end of every session with current Status, Completed, In Progress, and Next Steps.
+At the end of every session, update **both**:
+
+1. `dev/status/strategy-wiring.md` — current Status, Completed, In Progress, Next Steps.
+2. `dev/status/_index.md` — the row for this track. Keep Status, Owner, Open PR, and Next task aligned with (1). Only touch your own row.

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -104,13 +104,14 @@ docker exec <container-name> bash -c \
 ## When done with each item
 
 1. Mark `[x]` in `dev/status/harness.md` with a note: what was built, where it lives, how to verify
-2. Commit and push:
+2. Update the **harness** row in `dev/status/_index.md` — align Status, Owner, Open PR, and Next task with the change. Only touch your own row.
+3. Commit and push:
    ```
    jj describe -m "harness: <short description>"
    jj bookmark set harness/<short-name> -r @
    jj git push -b harness/<short-name> --allow-new
    ```
-3. **Open the PR** so the human doesn't have to chase down PR-less branches:
+4. **Open the PR** so the human doesn't have to chase down PR-less branches:
    ```
    GH_TOKEN=$GH_TOKEN jst submit harness/<short-name>
    ```
@@ -118,6 +119,6 @@ docker exec <container-name> bash -c \
    + `dev/run.sh` provides both jst and `GH_TOKEN`). If jst fails, surface
    the error in your return value rather than silently leaving the branch
    PR-less.
-4. Include in your return value: item completed, what changed, any follow-up or escalation items, and the PR URL.
+5. Include in your return value: item completed, what changed, any follow-up or escalation items, and the PR URL.
 
 Return a concise summary: which items completed, which are in progress, any blockers, and the PR URLs.

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -521,6 +521,32 @@ Write the combined result to `dev/reviews/<feature>.md` (structural writes the b
 
 ---
 
+## Step 5.5: Reconcile `dev/status/_index.md`
+
+After all feature / harness / ops agents have returned and before the
+health-scanner fast scan, reconcile the status index so it reflects the
+state of the per-track status files. The index is the single-source
+view of all tracked work (Track | Status | Owner | Open PR(s) | Next
+task) — agents are expected to update their own row, but this step is
+the safety net.
+
+For each row in `dev/status/_index.md`:
+
+1. Read the corresponding `dev/status/<track>.md`.
+2. Compare against the row:
+   - **Status** — must match the `## Status` heading value (IN_PROGRESS / READY_FOR_REVIEW / MERGED / APPROVED / BLOCKED).
+   - **Owner** — must match `## Ownership` (or be `—` if the track has no active owner).
+   - **Open PR(s)** — cross-reference against `gh pr list` filtered to that track's branches; each currently-open PR targeting main that carries this track's work should appear.
+   - **Next task** — must be the top item from `## Next Steps` (or an equivalent synthesis of the most concrete pending item).
+3. If any cell drifts, fix it. Do not touch unrelated rows.
+4. Update the `Last updated:` line to today's date.
+
+If an IN_PROGRESS track has no Owner or no Next task, surface it in the
+daily summary's §Escalations as "unassigned work." Silent drift is the
+failure mode this step exists to prevent.
+
+---
+
 ## Step 6: Health scanner fast scan
 
 After all feature agents and QC have completed (or if no agents ran today), spawn a `health-scanner` subagent in fast mode:

--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -132,3 +132,15 @@ When asked to fetch new symbols and update the inventory:
 ### Recommended next steps
 - <e.g. "Run fetch_universe.exe to populate sector metadata for universe.sexp">
 ```
+
+## Status file updates
+
+If your session advances a tracked data workstream (currently:
+`dev/status/sector-data.md`), at the end of the session update **both**:
+
+1. The relevant `dev/status/<track>.md` — Status, Completed, In Progress, Next Steps.
+2. `dev/status/_index.md` — the row for that track. Keep Status, Owner, Open PR, and Next task aligned with (1). Only touch your own row.
+
+Pure one-shot fetches that do not change a tracked workstream (e.g. a
+one-off symbol refresh) do not need index updates — write the Data
+Operations Report only.

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -1,0 +1,45 @@
+# Status Index
+
+Single-source view of all tracked work. Update when a status file flips
+state, an owner changes, or a PR opens / merges / closes. Keep the table
+terse; detail belongs in the per-track status files linked in column 1.
+
+Last updated: 2026-04-14
+
+## Active + complete tracks
+
+Each row: one line; deeper task detail in the linked status file.
+"Next task" = top-of-queue concrete item from that file's Next Steps.
+
+| Track | Status | Owner | Open PR(s) | Next task |
+|---|---|---|---|---|
+| [backtest-infra](backtest-infra.md) | IN_PROGRESS | feat-backtest | — | Support-floor-based stops (Weinstein Ch. 7) |
+| [sector-data](sector-data.md) | IN_PROGRESS | ops-data | — | `fetch_finviz_sectors.exe` (Item 1) |
+| [strategy-wiring](strategy-wiring.md) | IN_PROGRESS | feat-weinstein | — | `Synthetic_adl` into `Ad_bars.load` façade (Item 1) |
+| [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | T3-E cost/token budget visibility |
+| [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Solve open blockers (GH Actions runner, gh-auth, triggers) |
+| [data-layer](data-layer.md) | MERGED | — | — | — |
+| [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |
+| [screener](screener.md) | MERGED | — | — | — |
+| [simulation](simulation.md) | MERGED | — | — | — |
+
+## How to use
+
+- **Find what's in flight**: filter rows by Status = IN_PROGRESS.
+- **Find what needs an owner**: look for empty Owner cells on non-MERGED rows.
+- **Find what's awaiting review**: check the Open PR column.
+- **Find the next concrete task** for a track: read its "Next task" cell.
+- **Start a session**: open the linked status file to get full context.
+
+## Maintenance
+
+Agent-owned update: any agent that touches `dev/status/<track>.md`
+during a session must also update that track's row here if Status,
+Owner, Open PR, or Next task changed. Agents only touch their own row,
+so parallel write conflicts stay rare.
+
+Orchestrator reconciliation: `lead-orchestrator` diffs this index
+against the per-track status files at end-of-run and flags drift.
+
+Adding a new track means creating the status file AND adding a row
+here in the same commit.


### PR DESCRIPTION
## Summary
- New dev/status/_index.md — single-source view of all tracked work. One row per track: Track | Status | Owner | Open PR(s) | Next task.
- Maintenance wired through agents: each agent owns its row (feat-weinstein, feat-backtest, harness-maintainer, ops-data updated). feat-agent-template gains section 8. lead-orchestrator gains Step 5.5 that reconciles the index at end-of-run.

## Test plan
- [ ] Index seeded with current state: 5 MERGED + 5 IN_PROGRESS tracks
- [ ] Each active-agent file references dev/status/_index.md in end-of-session steps
- [ ] lead-orchestrator Step 5.5 includes drift-check specifics