### PR TITLE
harness: fix cross-agent contamination, add rate-limit awareness, run counter

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -79,7 +79,7 @@ status to READY_FOR_REVIEW.
 - [ ] Every public function in every `.ml` is exported in the corresponding `.mli` with a doc comment
 - [ ] No function exceeds 50 lines
 - [ ] All configurable parameters routed through config record — no magic numbers
-- [ ] `dune build && dune runtest` passes with zero warnings
+- [ ] `dune build && dune runtest` passes with zero warnings **on a clean checkout of the branch** — not just on your local worktree. If you are running in `isolation: "worktree"` (the orchestrator default), your working copy already is a clean checkout, so the local pass is sufficient. If you are NOT in a worktree (rare, legacy runs), re-verify by checking that every module your branch references is either in your commits or already on `main@origin` — do not rely on files sitting in the shared working copy that you did not explicitly commit.
 - [ ] `dune fmt --check` passes (or: `dune fmt` produces no diff)
 - [ ] `Interface stable: YES` is set in `dev/status/<feature>.md` once `.mli` is finalized
 ```

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -293,9 +293,25 @@ If no trigger fires, dispatch normally without this paragraph.
 
 ---
 
+## Step 3.75: Budget check before parallel dispatch
+
+Before spawning any subagent batch, sanity-check the budget situation:
+
+- The previous same-day run log (`dev/logs/<YYYY-MM-DD>-run<N-1>.jsonl` or the most recent date) is the best signal. If that run terminated with `"error":"rate_limit"` or `"terminal_reason"` other than `"completed"`, the 5-hour quota was hit last time. Assume it's still constrained until the next reset.
+- If the last run's total cost was ≥ $30 or output tokens ≥ 200k, the combined cost of today's full eligible set is likely similar.
+
+When either of those is true, **reduce scope rather than spawn everything**:
+- Pick the 2 highest-priority tracks per `dev/status/_index.md` (skip MERGED, prefer tracks with open PRs awaiting follow-up > ready-to-pick-up > idle)
+- Defer the rest to the next run by leaving them idle in the index
+- Note the deferral in the daily summary's Escalations section so the human can see what was skipped
+
+On an otherwise clean budget (last run completed, cost < $20), dispatching up to 2 subagents in parallel is fine. Never dispatch more than 2 at once.
+
 ## Step 4: Spawn feature agents as parallel subagents
 
-For each feature that should run today, spawn it as a subagent using the Agent tool (no worktree isolation — agents work directly on their feature branch so Docker can see their changes). Run all eligible features in parallel (single message, multiple Agent tool calls).
+For each feature that should run today, spawn it as a subagent using the Agent tool with `isolation: "worktree"`. Each subagent works on its own git worktree so that (a) commits from one agent cannot pollute another agent's branch via the shared working copy, and (b) `jj new main@origin` inside a subagent produces a clean starting point.
+
+**Parallelism cap**: run at most **2 subagents in parallel** in a single Agent message. More than 2 Opus subagents in parallel reliably drains the 5-hour quota before PRs can be opened. If more than 2 features are eligible, batch into two messages: dispatch the higher-priority 2, await results, then dispatch the next 2.
 
 **Parallel write conflict policy**: parallel feat-agents must not write to any shared file.
 The files `dev/decisions.md`, `CLAUDE.md`, and `docs/design/*.md` are read-only during
@@ -332,6 +348,8 @@ Read these files first:
 6. dev/status/<feature>.md  ← pick up where you left off
 
 Your branch: feat/<feature>
+  # You are running in an isolated git worktree — your working copy
+  # is independent of other subagents' workspaces.
   jj git init --colocate 2>/dev/null || true
   jj git fetch
   jj new feat/<feature>@origin
@@ -347,7 +365,7 @@ Work using TDD (CLAUDE.md workflow):
 Build/test inside Docker:
   docker exec <container-name> bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && <cmd>'
 
-COMMIT DISCIPLINE — this is critical for reviewability:
+COMMIT DISCIPLINE — this is critical for reviewability AND for surviving rate-limit kills:
   - Commit after each logical unit: one module, one interface, one test suite
   - Target 200–300 lines per commit (absolute max 400 including tests)
   - Never batch multiple modules into one commit
@@ -361,13 +379,21 @@ COMMIT DISCIPLINE — this is critical for reviewability:
       jj describe -m "commit message"
       jj bookmark set feat/<feature> -r @
       jj git push --bookmark feat/<feature>
-  - At session end, ALSO open the PR via jst (don't leave branches PR-less
-    for the human to chase down):
+  - **Open a DRAFT PR as soon as the first real commit is pushed** — do
+    not wait until session end. If the session is killed mid-flight
+    (rate-limit, timeout), at least the PR exists with whatever was
+    pushed. Use:
+      GH_TOKEN=$GH_TOKEN gh pr create --base main --head feat/<feature> \
+        --draft --title "feat(<area>): <one-line summary>" \
+        --body "WIP — opened early so work is not lost on kill."
+    Subsequent pushes update the PR automatically (same branch).
+  - At session end, mark the PR ready for review via jst:
       GH_TOKEN=$GH_TOKEN jst submit feat/<feature>
     jst is on PATH in the orchestrator runtime (trading-devcontainer image
     + dev/run.sh assumes both). If GH_TOKEN isn't set, jst will fail with
-    a clear error and the branch is still pushed — the orchestrator can
-    then fall back to opening the PR manually in Step 7.
+    a clear error and the branch is still pushed — the draft PR is still
+    there. The orchestrator can then fall back to marking it ready in
+    Step 7.
 
 MAX ITERATIONS — build-fix cycles:
   - If you have attempted 3 consecutive build-fix cycles without passing
@@ -378,11 +404,13 @@ MAX ITERATIONS — build-fix cycles:
 Do as much meaningful work as you can in one session.
 Stop at a natural boundary (a passing build, a completed module).
 
-CRITICAL — before returning, do all of these:
-  1. Ensure dune build && dune runtest passes on your branch
+CRITICAL — before returning, do all of these (in this order, so a kill during the last step still leaves the PR open):
+  1. Ensure dune build && dune runtest passes **on a clean checkout** of your branch (your worktree is isolated, so this is the local state — but verify nothing relies on files from sibling subagents' workspaces; only content tracked in your commits should matter)
   2. All changes committed and pushed (nothing uncommitted)
-  3. Update dev/status/<feature>.md (status, interface-stable, completed, in-progress, next-steps, commits)
-  4. If all work is done and tests pass: set status to READY_FOR_REVIEW
+  3. Draft PR already open from first push (see commit discipline); if not, open it now via `gh pr create --draft`
+  4. Update dev/status/<feature>.md (status, interface-stable, completed, in-progress, next-steps, commits)
+  5. Update your row in dev/status/_index.md (Status, Owner, Open PR, Next task) — only touch your own row
+  6. If all work is done and tests pass: mark the PR ready for review via `jst submit` or `gh pr ready`, and set status to READY_FOR_REVIEW in the status file
 
 <FEATURE-SPECIFIC CONSTRAINT IF ANY>
 

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -29,10 +29,22 @@ done
 
 DATE="$(date +%Y-%m-%d)"
 LOG_DIR="$REPO_ROOT/dev/logs"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/$DATE.log"
-JSONL_FILE="$LOG_DIR/$DATE.jsonl"
-SUMMARY_FILE="$REPO_ROOT/dev/daily/$DATE${PLAN_FLAG:+-plan}.md"
+DAILY_DIR="$REPO_ROOT/dev/daily"
+mkdir -p "$LOG_DIR" "$DAILY_DIR"
+
+# Pick a same-day run suffix so multiple runs on the same date don't
+# clobber one another. Plan-mode always writes to <date>-plan.md
+# (overwrites on rerun — planning is idempotent anyway).
+if [ -n "$PLAN_FLAG" ]; then
+  RUN_SUFFIX="-plan"
+else
+  N=1
+  while [ -f "$DAILY_DIR/$DATE-run$N.md" ]; do N=$((N+1)); done
+  RUN_SUFFIX="-run$N"
+fi
+LOG_FILE="$LOG_DIR/$DATE$RUN_SUFFIX.log"
+JSONL_FILE="$LOG_DIR/$DATE$RUN_SUFFIX.jsonl"
+SUMMARY_FILE="$DAILY_DIR/$DATE$RUN_SUFFIX.md"
 JQ_FILTER="$REPO_ROOT/dev/lib/format-event.jq"
 
 # GH_TOKEN is required so subagents (feat-*, harness-maintainer) can run
@@ -62,7 +74,9 @@ else
 fi
 
 PROMPT="Run the daily development session for the Weinstein Trading System.
-Today's date is $DATE.${PLAN_FLAG}
+Today's date is $DATE.
+Write the daily summary to: $SUMMARY_FILE
+(this is run suffix \"$RUN_SUFFIX\" — pass it through to any log / artifact paths you create so same-day reruns do not overwrite earlier ones).${PLAN_FLAG}
 
 Follow your instructions in .claude/agents/lead-orchestrator.md exactly."
 


### PR DESCRIPTION
## Summary
Fixes exposed by the 2026-04-14 22:35 PT orchestrator run, which drained the 5-hour Opus quota (\$46.60, 291k output tokens) and left three subagent branches PR-less + one PR (#348) full of foreign content.

Five changes:

1. **Run counter** in \`dev/run.sh\` — same-day reruns no longer clobber \`dev/daily/<date>.md\`. Suffix is \`-run1\`, \`-run2\`, …; plan-mode keeps \`-plan\`. Log/jsonl files get the same suffix. Run suffix passed to orchestrator prompt so Step 7 writes to the right file.

2. **Worktree isolation** for every subagent. \`lead-orchestrator.md\` Step 4 now specifies \`isolation: \"worktree\"\` so each subagent gets an independent working copy. Fixes the root cause of PR #348's \`Unbound module Stop_log\` failure: sibling agents' in-progress files were visible in the orchestrator's shared jj workspace.

3. **Parallelism cap of 2**. Four Opus subagents in parallel is what drained the quota. Hard cap at 2; if more are eligible, batch sequentially.

4. **Budget check step** (new Step 3.75). Orchestrator reads the prior same-day run log; if it hit a rate-limit or cost ≥ \$30, reduce scope to 2 highest-priority tracks and defer the rest to next run. Noted in Escalations.

5. **Draft PR on first commit**, not session end. If a subagent is killed mid-flight, the PR already exists. \`jst submit\` at session end just flips draft → ready.

6. **Clean-checkout verification** added to \`feat-agent-template.md\` §6 — acceptance now explicit that \`dune build && dune runtest\` must pass on the branch's actual commits, not on the agent's polluted local workspace.

## Sibling PRs opened from killed subagent work
- **#349** \`ops/sector-finviz-scraper\` (draft) — resumed ops-data subagent, contamination stripped
- **#350** \`feat/backtest-stop-logging\` (draft) — resumed feat-backtest subagent, contamination stripped

## Closed
- **#348** \`harness/t3a-scaffolding-review\` — branch had no salvageable harness content; the described T3-A deep-scan extensions were never committed

## Test plan
- [ ] Next orchestrator run uses \`dev/daily/<date>-run1.md\` (not \`<date>.md\`); second same-day run uses \`-run2\`
- [ ] Subagents dispatched with \`isolation: \"worktree\"\` don't see each other's uncommitted changes
- [ ] Draft PRs appear after first commit/push, not only at session end