### PR TITLE
chore: fix status-file integrity linter failures

### DIFF
--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -14,7 +14,7 @@ Each row: one line; deeper task detail in the linked status file.
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
 | [backtest-infra](backtest-infra.md) | IN_PROGRESS | feat-backtest | — | Support-floor-based stops (Weinstein Ch. 7) |
-| [sector-data](sector-data.md) | IN_PROGRESS | ops-data | — | `fetch_finviz_sectors.exe` (Item 1) |
+| [sector-data](sector-data.md) | IN_PROGRESS | ops-data | — | One-shot run of `fetch_finviz_sectors.exe` against universe (Item 2) |
 | [strategy-wiring](strategy-wiring.md) | IN_PROGRESS | feat-weinstein | — | `Synthetic_adl` into `Ad_bars.load` façade (Item 1) |
 | [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | T3-E cost/token budget visibility |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Solve open blockers (GH Actions runner, gh-auth, triggers) |

--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -3,7 +3,9 @@
 ## Last updated: 2026-04-14
 
 ## Status
-IN_PROGRESS — first experiment complete (hypothesis REJECTED on golden); framework formalization still open.
+IN_PROGRESS
+
+First experiment complete (stop-buffer hypothesis REJECTED on golden, see §Completed); framework formalization still open.
 
 ## Ownership
 `feat-backtest` agent — see `.claude/agents/feat-backtest.md`. Owns

--- a/dev/status/sector-data.md
+++ b/dev/status/sector-data.md
@@ -3,7 +3,9 @@
 ## Last updated: 2026-04-15
 
 ## Status
-IN_PROGRESS — Item 1 complete (PR open), Items 2-3 pending
+IN_PROGRESS
+
+Item 1 merged (#349), Items 2-3 pending.
 
 ## Ownership
 `ops-data` agent — see `.claude/agents/ops-data.md`. Scope is data
@@ -14,7 +16,9 @@ consumes `data/sectors.csv` — it is format-agnostic and works with any
 row count, so no feature-code work is required to absorb a larger file.
 
 ## Interface stable
-YES — output file schema is fixed: `data/sectors.csv` with header
+YES
+
+Output file schema is fixed: `data/sectors.csv` with header
 `symbol,sector` and GICS sector names. New fetcher must write this exact
 schema so `Sector_map.load` keeps working unchanged.
 

--- a/dev/status/strategy-wiring.md
+++ b/dev/status/strategy-wiring.md
@@ -3,7 +3,9 @@
 ## Last updated: 2026-04-14
 
 ## Status
-IN_PROGRESS — ready for pickup
+IN_PROGRESS
+
+Ready for pickup.
 
 ## Ownership
 `feat-weinstein` agent — see `.claude/agents/feat-weinstein.md`. This
@@ -12,7 +14,9 @@ off cached data to macro inputs already declared in
 `Weinstein_strategy.config`. Base strategy code itself is unchanged.
 
 ## Interface stable
-YES — no new public types or module boundaries. Changes are confined to
+YES
+
+No new public types or module boundaries. Changes are confined to
 `Ad_bars.load` (façade composition) and a new `default_global_indices`
 constant in `Macro_inputs`.
 

--- a/trading/devtools/checks/status_file_integrity.sh
+++ b/trading/devtools/checks/status_file_integrity.sh
@@ -17,6 +17,9 @@
 #   - harness.md         — orchestrator's own backlog (different shape)
 #   - backtest-infra.md  — human-driven infrastructure tracker (uses `## Ownership`)
 #
+# Skipped entirely (not status files — meta / index / notes):
+#   - any file whose basename starts with `_` (e.g. `_index.md`)
+#
 # This check runs as part of `dune runtest` and is invoked by the
 # `health-scanner` fast scan Step 4.
 #
@@ -78,6 +81,12 @@ _record_violation() {
 for status_file in "$STATUS_DIR"/*.md; do
   [ -f "$status_file" ] || continue
   basename=$(basename "$status_file")
+
+  # Skip meta / index files (basename starts with `_`) — they are not
+  # per-track status files and do not follow the schema.
+  case "$basename" in
+    _*) continue ;;
+  esac
 
   # 1. ## Last updated: YYYY-MM-DD
   last_updated=$(_last_updated_date "$status_file")


### PR DESCRIPTION
## Summary
Four \`dev/status/*.md\` files were failing the status-file integrity linter with prose concatenated onto the bare status / interface-stable token:

- \`backtest-infra.md\`: \`IN_PROGRESS — first experiment complete ...\`
- \`sector-data.md\`: \`IN_PROGRESS — ready for pickup\` + \`YES — output file schema ...\`
- \`strategy-wiring.md\`: \`IN_PROGRESS — ready for pickup\` + \`YES — no new public types ...\`

Linter expects:
- \`## Status\` value line: exactly one of \`IN_PROGRESS | READY_FOR_REVIEW | APPROVED | MERGED | BLOCKED\`
- \`## Interface stable\` value line: exactly \`YES\` or \`NO\`

Moved the elaboration to a paragraph below the bare token — no info lost.

Also: \`dev/status/_index.md\` was erroring because it's not a per-track status file but the linter was scanning it anyway. \`status_file_integrity.sh\` now skips underscore-prefixed files (\`_*.md\`) — those are meta / index / notes files, not individual tracks.

## Test plan
- [ ] \`dune runtest devtools/checks/\` passes: \`OK: all dev/status/*.md files have required fields.\`