### PR TITLE
docs: refresh status files after today's merges

### DIFF
--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,7 +4,7 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-14
+Last updated: 2026-04-15
 
 ## Active + complete tracks
 

--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -1,6 +1,6 @@
 # Status: Backtest Infrastructure
 
-## Last updated: 2026-04-14
+## Last updated: 2026-04-15
 
 ## Status
 IN_PROGRESS
@@ -70,6 +70,11 @@ None.
   at `dev/experiments/stop-buffer/report.md`. Outputs:
   `dev/backtest/scenarios-2026-04-14-222425/` (smoke) and
   `dev/backtest/scenarios-2026-04-14-225929/` (golden).
+- [x] **Per-trade stop logging** (#350, 2026-04-15) — `Stop_log`
+  observer + `Strategy_wrapper` capture stop levels and exit-trigger
+  type on each transition; `Result_writer` emits `entry_stop`,
+  `exit_stop`, `exit_trigger` columns in `trades.csv`. Unblocks
+  post-mortem of individual whipsaw exits.
 
 ## In progress
 None.
@@ -85,9 +90,9 @@ Alternatives ranked by expected value:
    place stops at prior correction lows. Adapts to each stock's structure.
 2. **Regime-aware stops**: use `Macro.analyze` trend to pick buffer width
    (tighter in bear, wider in bull). Testable via existing macro output.
-3. **Per-trade stop logging**: emit stop level + trigger type to
-   trades.csv so follow-up experiments can diagnose remaining stop-outs
-   at the per-trade level.
+
+Per-trade stop logging landed in #350 — now available as a diagnostic
+input for any of the above experiments.
 
 ### Immediate: experiment framework
 
@@ -109,8 +114,6 @@ is informed by actual needs.
 - **Drawdown circuit breaker** (Weinstein Ch. 7 — 20% threshold) — new
   feature, order_gen side. See
   `TODO(backtest-infra/drawdown-circuit-breaker)` when added.
-- **Per-trade stop logging** — augment `trades.csv` with the stop level
-  and which rule triggered. Enables post-mortem on whipsaws.
 - **Experiment framework formalization** — once 1-2 experiments show the
   shape.
 - **Token/cost tracking** (T3-E from harness.md) — unrelated to this track


### PR DESCRIPTION
## Summary
Post-merge audit of \`dev/status/*.md\` against actual main state. Staleness found and fixed:

- **\`backtest-infra.md\`**:
  - Last updated: 2026-04-14 → 2026-04-15
  - §Completed: added per-trade stop logging (#350, 2026-04-15) — \`Stop_log\` + \`Strategy_wrapper\` + \`Result_writer\` emits \`entry_stop\` / \`exit_stop\` / \`exit_trigger\` columns
  - §Next Actions > Stop-buffer follow-ups: dropped \"Per-trade stop logging\" (merged); added a note that it's now available as a diagnostic input for the remaining experiments
  - §Medium-term: dropped \"Per-trade stop logging\"
- **\`_index.md\`**: Last updated → 2026-04-15

Everything else verified current:
- sector-data.md: IN_PROGRESS, Item 1 merged (#349), correct Next task cell (\"One-shot run of fetch_finviz_sectors.exe (Item 2)\")
- strategy-wiring.md: IN_PROGRESS, no work started, Next task still accurate
- harness.md, orchestrator-automation.md: IN_PROGRESS, no change needed
- data-layer, portfolio-stops, screener, simulation: MERGED, correct

## Test plan
- [ ] \`dune runtest devtools/checks/\` passes status-file integrity linter