### PR TITLE
ops(finviz): single-line-per-symbol progress with result

### DIFF
--- a/trading/analysis/scripts/fetch_finviz_sectors/lib/fetch_finviz_sectors_lib.ml
+++ b/trading/analysis/scripts/fetch_finviz_sectors/lib/fetch_finviz_sectors_lib.ml
@@ -198,20 +198,20 @@ let run ~data_dir ~rate_limit_rps ~force ?(fetch = _default_fetch) ?symbols () =
     else
       let errors = ref [] in
       let success_count = ref 0 in
+      let total = List.length to_fetch in
       let%bind _results =
         Deferred.List.map ~how:`Sequential to_fetch ~f:(fun sym ->
-            let idx = !success_count + List.length !errors + 1 in
-            printf "  [%d/%d] %s ...\n%!" idx (List.length to_fetch) sym;
             fetch_one ~fetch ~rate_limit_rps sym >>| fun r ->
+            let idx = !success_count + List.length !errors + 1 in
             (match r.sector with
             | Some sector ->
                 Hashtbl.set existing ~key:r.symbol ~data:sector;
-                Int.incr success_count
-            | None -> (
+                Int.incr success_count;
+                printf "  [%d/%d] %s → %s\n%!" idx total sym sector
+            | None ->
                 errors := r.symbol :: !errors;
-                match r.error with
-                | Some e -> eprintf "  WARN [%s]: %s\n%!" r.symbol e
-                | None -> ()));
+                let msg = Option.value r.error ~default:"unknown error" in
+                eprintf "  [%d/%d] %s → WARN: %s\n%!" idx total sym msg);
             r)
       in
       let rows =


### PR DESCRIPTION
## Summary
Improve per-fetch progress output from \`fetch_finviz_sectors.exe\` so successful fetches aren't silent.

**Before:**
\`\`\`
  [1/7000] AAPL ...              (printed before the 1s rate-limit wait)
  WARN [ZZZZ]: HTTP 404          (only on failure, after the wait)
\`\`\`
Successful symbols only showed the pre-fetch line; no confirmation the fetch worked.

**After** (single line per symbol, after result is known):
\`\`\`
  [1/7000] AAPL → Technology
  [2/7000] MSFT → Technology
  [3/7000] ZZZZ → WARN: HTTP 404
\`\`\`

Error tracking was already comprehensive (errors ref list, manifest.errors persistence, <80% success-rate end-of-run warning) — unchanged.

## Test plan
- [x] \`dune build\` passes
- [x] \`dune runtest analysis/scripts/fetch_finviz_sectors/\` passes (10 tests)
- [x] \`dune fmt\` clean
- [ ] Run \`dune exec ... fetch_finviz_sectors.exe -- --symbols AAPL,MSFT,ZZZZ\` manually to eyeball output