### PR TITLE
harness: orchestrator resolves cross-track dependencies automatically

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -206,13 +206,25 @@ feature work in the same session.
 
 ### 2e: Feature dependency rules
 
-| Feature | Agent | Can run when |
-|---------|-------|--------------|
-| weinstein (order_gen) | feat-weinstein | Always — no remaining blockers |
-| weinstein (Slice 2) | feat-weinstein | Always — no remaining blockers |
-| backtest-infra (experiments + tuning) | feat-backtest | Always — independent of feat-weinstein |
+Cross-track dependencies live in each status file's `## Blocked on` section. For every IN_PROGRESS track, read that section before dispatching:
 
-Run order: order_gen first (smaller, self-contained), then Slice 2, then backtest-infra. The backtest-infra track is independent of feat-weinstein's outputs and may run in parallel.
+- If the blocker names another track's work (e.g. "requires feat-weinstein to add `Stops.support_floor` first"), **do not dispatch this track's agent this run**. Instead:
+  1. Dispatch the upstream agent on the blocking item (the feat/ops/harness agent that owns the named work).
+  2. Skip the downstream agent this run — it will pick up next run once the upstream item lands.
+  3. Note the sequencing decision in the daily summary's §Dependency Unlocks section.
+- If `## Blocked on` says "None" or lists only external blockers (data purchases, human decisions), the track is eligible.
+
+This is the orchestrator's job — do not pass the coordination decision to the human unless the blocker itself is a human decision. Agents should not need to negotiate across tracks.
+
+Current tracks (as of status files at read time — re-read every run):
+
+| Track | Owner | Typical blockers |
+|-------|-------|------------------|
+| strategy-wiring | feat-weinstein | none — data is cached |
+| sector-data | ops-data | live HTTP runs that exceed agent session time are a human action item, not a blocker |
+| backtest-infra | feat-backtest | experiments that need new strategy primitives (e.g. support-floor stops) block on feat-weinstein |
+| harness | harness-maintainer | none between tracks |
+| orchestrator-automation | harness-adjacent | human-only (secrets, GitHub App) |
 
 Skip a track if its status file shows MERGED with no Blocking Refactors or Follow-up items, or APPROVED (awaiting human merge decision).
 

--- a/dev/daily/2026-04-14-run1.md
+++ b/dev/daily/2026-04-14-run1.md
@@ -1,0 +1,82 @@
+# Status — 2026-04-14 (run1)
+
+## Feature Progress
+
+### strategy-wiring  [APPROVED]
+- Done today: Composed Synthetic ADL into `Ad_bars.load` facade (Item 1). Unicorn preferred for overlap dates, Synthetic fills tail. 9 unit tests. Item 2 (global indices) confirmed already on main.
+- PR: #355 — 3 commits (facade compose, status update, dune fmt fix)
+- QC: structural APPROVED, behavioral APPROVED (4/5 quality score)
+- Blocked: No
+- Next: awaiting human merge
+
+### backtest-infra  [IN_PROGRESS — deferred this run]
+- Done today: nothing (deferred)
+- Reason: next item (support-floor-based stops) requires stops-module changes in feat-weinstein territory. Coordinate next run after strategy-wiring merges.
+- Per-trade stop logging (#350) landed last run.
+- Next: support-floor-based stops experiment (needs plan-first + cross-module coordination)
+
+## QC Status
+- strategy-wiring: APPROVED (structural + behavioral, 2026-04-14). See dev/reviews/strategy-wiring.md.
+- backtest-infra: no review needed (deferred)
+
+## Budget
+- Budget cap: $50 (from merge-policy.json — field added this run by T3-E)
+- Subagents spawned: 4
+
+| Agent | Type | Status | Est. tokens | Est. cost |
+|---|---|---|---|---|
+| feat-weinstein | strategy-wiring | completed | ~76k | ~$3 |
+| harness-maintainer | T3-E | completed | ~96k | ~$4 |
+| qc-structural | strategy-wiring | completed | ~52k | ~$2 |
+| qc-behavioral | strategy-wiring | completed | ~67k | ~$3 |
+
+- Killed mid-flight: none
+- Budget utilization: ~$12 / $50 (24%)
+- Health scanner: ~22k tokens (~$1)
+- Orchestrator overhead: ~$3-4
+- Total estimated: ~$16-17
+
+## Harness Work
+- Item: T3-E — Cost/token budget visibility in daily summary
+- Status: DONE
+- Changes: added `max_daily_cost_usd` to merge-policy.json, `## Budget` section to lead-orchestrator Step 7, updated Step 3.75 to read from config
+- Branch: harness/t3e-budget-visibility
+- PR: #356
+
+## Health Scan
+- Result: CLEAN
+- All fast scan checks pass (build, tests, linter, status integrity, no stale reviews)
+- See: dev/health/2026-04-14-fast-run1.md
+
+## Follow-up Queue
+- **simulation** (12 items): Volume dilution, position assertions, price-cache TODO, stoplimit orders TODO, monthly cadence TODO, bar granularity TODO, simulation loop performance (6 sub-items)
+- **harness** (5 items): .claude/worktrees gitignore, nesting linter failures, orchestrator daily summary drift, deep scan heuristic gaps (4 sub-items)
+- **strategy-wiring** (1 item): Synthetic-vs-Unicorn correlation validation ≥0.85 (deferred, not blocking)
+- **Total: 18 items** (threshold: 10; maintenance cycle: run #9, IS a maintenance cycle — skipped because high-count track (simulation) has only milestone-deferred TODOs, not actionable refactoring)
+
+## Integration Queue
+- **PR #355** (feat/strategy-wiring): QC APPROVED — ready to merge
+- **PR #356** (harness/t3e-budget-visibility): harness work, ready for review
+
+## Current Milestone Target
+M5 — Walk-forward backtest + parameter tuner. Requires: backtest experiments infrastructure, support-floor stops.
+
+## Dependency Unlocks
+- Strategy-wiring APPROVED: once merged, `Ad_bars.load` provides full ADL coverage (1965-present) and `Macro.analyze` receives global index bars. Macro analysis is fully wired.
+
+## Escalations
+- **Sector metadata Item 2**: `fetch_finviz_sectors.exe` built (#349 merged) but the one-shot run (~2.2 hours, 8000 HTTP requests) needs manual execution or a long-running background job. Not suitable for subagent session.
+- **Support-floor-based stops**: feat-backtest can't implement this alone — requires stops-module changes owned by feat-weinstein. Need orchestrator coordination: either (a) dispatch feat-weinstein for the stops feature work, then feat-backtest for the experiment, or (b) expand feat-backtest scope to include stops-module changes with review. Human decision needed.
+- **ADL live source**: blocked on human action (EODData registration to check absolute count tickers). Current mitigation: Synthetic ADL provides adequate coverage for backtesting.
+- **Stale local bookmarks** (6 total, no open PRs): feat/backtest-stop-logging, feat/m3-milestone-tests, feat/macro-cadence-fix, feat/strategy-wiring-direct, harness/dispatch-flow-revise, harness/run-sh-hardening. Recommend cleanup: `jj bookmark delete <name>` for each.
+
+## Questions for You
+1. **PR #355** (strategy-wiring): QC APPROVED. Merge?
+2. **PR #356** (harness/T3-E budget visibility): Review + merge?
+3. **Support-floor stops coordination**: Should feat-backtest be allowed to modify `weinstein/stops/` for the support-floor experiment, or should feat-weinstein handle the stops-module changes first?
+4. **Sector data one-shot run**: Want to run `fetch_finviz_sectors.exe` manually (~2.2 hours)? Command: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune exec analysis/scripts/fetch_finviz_sectors/fetch_finviz_sectors.exe'`
+5. **Stale bookmarks**: OK to clean up the 6 listed stale local bookmarks?
+
+---
+## Your Response
+(Edit this section. Run dev/run.sh after editing to start the next session.)

--- a/dev/health/2026-04-14-fast-run1.md
+++ b/dev/health/2026-04-14-fast-run1.md
@@ -1,0 +1,13 @@
+# Health Report -- 2026-04-14 -- fast (run 1)
+
+## Summary
+- Findings: 0  (critical: 0  warnings: 0  info: 0)
+- Main build: PASSING
+- Action required: NO
+
+## Metrics
+- Open follow-up items: not counted (fast scan)
+- Linter exceptions past review date: 0
+- Stale READY_FOR_REVIEW items: 0
+- Status file integrity: PASSING
+- Magic numbers linter: PASSING (covered by dune runtest)

--- a/dev/reviews/strategy-wiring.md
+++ b/dev/reviews/strategy-wiring.md
@@ -1,0 +1,77 @@
+# QC Structural Review: strategy-wiring
+
+Reviewer: qc-structural
+Date: 2026-04-14
+PR: #355
+Branch: feat/strategy-wiring
+
+## Structural Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| H1 | dune fmt --check | PASS | Fixed in follow-up commit (style: run dune fmt on ad_bars files) |
+| H2 | dune build | PASS | |
+| H3 | dune runtest | PASS | 59 tests across 9 suites, all passed, 0 failed |
+| P1 | Functions <= 50 lines (linter) | PASS | Longest function is 18 lines (_synthetic_load). All well under limit. |
+| P2 | No magic numbers (linter) | PASS | H3 passed; no linter failures. Only structural constant is string length 8 for YYYYMMDD parsing. |
+| P3 | Config completeness | NA | No new tunable thresholds introduced. This is a data-loading/composition layer with no configurable parameters. |
+| P4 | .mli coverage (linter) | PASS | H3 passed. ad_bars.mli updated with Synthetic submodule and load documentation. |
+| P5 | Internal helpers prefixed with _ | PASS | All internal helpers use _ prefix: _parse_yyyymmdd, _parse_breadth_row, _insert_parsed_row, _read_breadth_lines, _read_count_file, _join_counts, _unicorn_load, _synthetic_load, _last_date, _compose |
+| P6 | Tests use matchers library | PASS | test_ad_bars_compose.ml opens Matchers and uses assert_that, elements_are, equal_to, all_of, field, size_is, is_empty, gt |
+| A1 | Core module modifications | PASS | No modifications to Portfolio/Orders/Position/Strategy/Engine |
+| A2 | No analysis/ -> trading/ imports | PASS | No cross-boundary imports found |
+| A3 | No unnecessary existing module modifications | PASS | Only ad_bars.ml/mli modified (the feature target). Refactored shared helpers (_parse_breadth_row, _read_count_file, _join_counts) from Unicorn-specific to generic. dune file updated to register new test. |
+
+## Verdict
+
+APPROVED
+
+---
+
+# Behavioral QC — strategy-wiring
+Date: 2026-04-14
+Reviewer: qc-behavioral
+
+## Behavioral Checklist
+
+| # | Check | Status | Notes (cite authority doc section) |
+|---|-------|--------|------------------------------------|
+| A1 | Core module modification is strategy-agnostic (only fill if qc-structural flagged A1) | NA | qc-structural A1 is PASS — no core module modifications. |
+| S1 | Stage 1 definition matches book | NA | No stage classification logic in this feature. |
+| S2 | Stage 2 definition matches book | NA | No stage classification logic in this feature. |
+| S3 | Stage 3 definition matches book | NA | No stage classification logic in this feature. |
+| S4 | Stage 4 definition matches book | NA | No stage classification logic in this feature. |
+| S5 | Buy criteria: entry only in Stage 2, on breakout with volume confirmation | NA | No buy signal logic in this feature. |
+| S6 | No buy signals generated during Stage 1, 3, or 4 | NA | No buy signal logic in this feature. |
+| L1 | Initial stop placed below the base | NA | No stop-loss logic in this feature. |
+| L2 | Trailing stop rises as price advances | NA | No stop-loss logic in this feature. |
+| L3 | Stop triggers on weekly close below stop level | NA | No stop-loss logic in this feature. |
+| L4 | Stop state machine transitions are correct | NA | No stop-loss logic in this feature. |
+| C1 | Screener cascade order | NA | No screener logic in this feature. |
+| C2 | Bearish macro score blocks all buy candidates | NA | No macro gate logic in this feature — `Ad_bars.load` only provides data to `Macro.analyze`. |
+| C3 | Sector analysis uses relative strength vs. market | NA | No sector analysis logic in this feature. |
+| T1 | Tests cover all 4 stage transitions | NA | No stage transitions in this feature. |
+| T2 | Tests include a bearish macro scenario that produces zero buy candidates | NA | No macro gating in this feature. |
+| T3 | Stop-loss tests verify trailing behavior | NA | No stop-loss logic in this feature. |
+| T4 | Tests assert domain outcomes, not just "no error" | PASS | Tests verify specific ad_bar values (advancing/declining counts), date ordering, overlap precedence (Unicorn wins with values 1053/1800, not Synthetic 9999/7777), list sizes, and sorted+deduplicated invariants. See test_ad_bars_compose.ml lines 41-218. |
+
+### Feature-specific domain checks
+
+| # | Check | Status | Notes |
+|---|-------|--------|------------------------------------|
+| F1 | Unicorn data preferred for dates where both sources overlap | PASS | `_compose` (ad_bars.ml:108-120) filters synthetic to dates strictly after Unicorn's last date via `Date.( > ) bar.date cutoff`. Tested in `test_compose_unicorn_wins_on_overlap` (line 116-147): Unicorn values 1053/1800 retained, Synthetic values 9999/7777 discarded for overlapping dates. |
+| F2 | Synthetic fills only dates AFTER Unicorn's last date | PASS | `_compose` uses strict `Date.( > )` comparison against `_last_date u` (ad_bars.ml:117-118). No Synthetic data can appear on or before Unicorn's last date. |
+| F3 | Result is chronologically sorted, no duplicates | PASS | Both sub-loaders sort via `_join_counts`. `_compose` appends tail (all dates > cutoff) to u, maintaining sort order. Tested in `test_compose_result_is_sorted` (line 153-163). Real-data integration test (line 195-217) asserts both sort order and uniqueness via `dedup_and_sort` count comparison. |
+| F4 | Graceful degradation when either source is missing | PASS | `_compose` handles `([], s) -> s` and `(u, []) -> u`. Each loader returns `[]` for missing files (`_read_count_file` returns empty table if file absent). Tested in `test_unicorn_only`, `test_synthetic_only`, `test_compose_both_missing`, `test_synthetic_load_missing_files`. |
+| F5 | `Ad_bars.load` facade maintains same return type `Macro.ad_bar list` | PASS | Signature unchanged in ad_bars.mli:62. Callers (e.g., runner.ml) require no changes. |
+| F6 | Composition does not change macro analysis behavior | PASS | `load` only provides more data to the same `Macro.analyze` function. The `ad_bar` type `{ date; advancing; declining }` matches weinstein-book-reference.md section 2.2 (NYSE Advance-Decline Line: cumulative daily advancing minus declining issues). |
+| F7 | Global indices wiring (Item 2) already on main | PASS | Verified: `macro_inputs.ml:22` defines `default_global_indices` with DAX, Nikkei, FTSE. `runner.ml:105` wires `global = Macro_inputs.default_global_indices`. Matches weinstein-book-reference.md section 2.5 (Global Market Confirmation: London, Japan, Germany). |
+| F8 | A-D data semantics match Weinstein's NYSE breadth definition | PASS | `Macro.ad_bar` = `{ date; advancing: int; declining: int }` maps directly to weinstein-book-reference.md section 2.2: "Cumulative daily figure: (advancing issues) - (declining issues), added to running total." The composition preserves these semantics — Unicorn provides exchange-official counts, Synthetic provides Russell 3000-derived counts as an approximation. |
+
+## Quality Score
+
+4 — All checks pass. Clean composition logic with thorough test coverage including overlap precedence, ordering, graceful degradation, and a real-data integration test. Minor note: the status file spec mentioned a validation gate (correlation >= 0.85 for Synthetic vs Unicorn overlap) that is deferred as a follow-up, not a code defect.
+
+## Verdict
+
+APPROVED

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -15,7 +15,7 @@ Each row: one line; deeper task detail in the linked status file.
 |---|---|---|---|---|
 | [backtest-infra](backtest-infra.md) | IN_PROGRESS | feat-backtest | — | Support-floor-based stops (Weinstein Ch. 7) |
 | [sector-data](sector-data.md) | IN_PROGRESS | ops-data | — | One-shot run of `fetch_finviz_sectors.exe` against universe (Item 2) |
-| [strategy-wiring](strategy-wiring.md) | READY_FOR_REVIEW | feat-weinstein | #355 | Awaiting QC review |
+| [strategy-wiring](strategy-wiring.md) | MERGED | — | — | — |
 | [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | T3-A deep scan harness scaffolding review |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Solve open blockers (GH Actions runner, gh-auth, triggers) |
 | [data-layer](data-layer.md) | MERGED | — | — | — |

--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -79,6 +79,9 @@ None.
 ## In progress
 None.
 
+## Blocked on
+- **Support-floor-based stops experiment** (next in Next Actions) requires a new primitive in `weinstein/stops/` — stop placement by prior correction lows. Owned by feat-weinstein, not feat-backtest. Until that primitive ships, this experiment cannot run as a config-override variant. Orchestrator should dispatch feat-weinstein for the stops primitive first; feat-backtest then follows next run with the experiment.
+
 ## Next Actions
 
 ### Stop-buffer follow-ups (pick one)

--- a/dev/status/strategy-wiring.md
+++ b/dev/status/strategy-wiring.md
@@ -3,9 +3,9 @@
 ## Last updated: 2026-04-14
 
 ## Status
-READY_FOR_REVIEW
+MERGED
 
-PR #355 open.
+PR #355 merged to main on 2026-04-15 — Synthetic ADL composed into `Ad_bars.load` façade, global indices wired via `Macro_inputs.default_global_indices`.
 
 ## Ownership
 `feat-weinstein` agent — see `.claude/agents/feat-weinstein.md`. This
@@ -70,9 +70,9 @@ All items complete. Awaiting QC review.
 - Sector metadata Phase 1 (SSGA XLSX holdings fetcher — separate agent).
 
 ## QC
-overall_qc: NOT_STARTED
-structural_qc: NOT_STARTED
-behavioral_qc: NOT_STARTED
+overall_qc: APPROVED
+structural_qc: APPROVED (2026-04-14)
+behavioral_qc: APPROVED (2026-04-14) — See dev/reviews/strategy-wiring.md
 
 Reviewers when work lands:
 - qc-structural — build / pattern check, façade-composition module boundaries


### PR DESCRIPTION
## Summary
Orchestrator now resolves cross-track dependencies automatically instead of asking the human to coordinate. Change in \`lead-orchestrator.md\` Step 2e:

- For every IN_PROGRESS track, read its \`## Blocked on\` section.
- If the blocker names another track's work (e.g. \"requires feat-weinstein to add \`Stops.support_floor\`\"): dispatch the upstream agent this run; skip the downstream agent (picks up next run once upstream lands); note the sequencing decision in §Dependency Unlocks.
- External blockers (human decisions, data purchases) stay as escalations.

Also populated \`backtest-infra.md\` \`## Blocked on\` with the support-floor-stops primitive dependency on feat-weinstein, so the next orchestrator run sees it.

## Test plan
- [ ] Next orchestrator run reads \`backtest-infra.md\` \`## Blocked on\`, sees \"requires new primitive in weinstein/stops/\", and dispatches feat-weinstein for the stops primitive instead of feat-backtest for the blocked experiment.