### PR TITLE
ops(finviz): regex fix + --limit flag + GICS normalization

### DIFF
--- a/trading/analysis/scripts/fetch_finviz_sectors/fetch_finviz_sectors.ml
+++ b/trading/analysis/scripts/fetch_finviz_sectors/fetch_finviz_sectors.ml
@@ -25,6 +25,11 @@ let command =
      and force =
        flag "force" no_arg
          ~doc:" Re-fetch all symbols even if manifest is fresh"
+     and limit =
+       flag "limit" (optional int)
+         ~doc:
+           "N Only fetch the first N symbols (after --force / skip filter); \
+            useful for dry-run / test runs"
      in
      let symbols =
        match symbols_flag with
@@ -38,6 +43,6 @@ let command =
      in
      fun () ->
        Fetch_finviz_sectors_lib.run ~data_dir ~rate_limit_rps:rate_limit ~force
-         ?symbols ())
+         ?symbols ?limit ())
 
 let () = Command_unix.run command

--- a/trading/analysis/scripts/fetch_finviz_sectors/lib/dune
+++ b/trading/analysis/scripts/fetch_finviz_sectors/lib/dune
@@ -8,6 +8,7 @@
   re
   status
   types
-  weinstein.data_source)
+  weinstein.data_source
+  weinstein.types)
  (preprocess
   (pps ppx_jane)))

--- a/trading/analysis/scripts/fetch_finviz_sectors/lib/fetch_finviz_sectors_lib.ml
+++ b/trading/analysis/scripts/fetch_finviz_sectors/lib/fetch_finviz_sectors_lib.ml
@@ -20,14 +20,18 @@ type fetch_fn = Uri.t -> string Status.status_or Deferred.t
 
 (* --- HTML parsing -------------------------------------------------------- *)
 
+(* Matches Finviz's current sector link: an anchor with the screener
+   filter query f=sec_<slug>, whose inner text is the sector display
+   name. Finviz's older snapshot-table layout with a td/b/a cell is
+   gone post-refactor. *)
 let _sector_re =
-  Re.compile
-    (Re.Perl.re ~opts:[ `Caseless; `Dotall ]
-       {|>Sector<[^>]*>.*?<td[^>]*><b><a[^>]*>([^<]+)</a>|})
+  Re.compile (Re.Perl.re ~opts:[ `Caseless ] {|f=sec_[a-z]+"[^>]*>([^<]+)<|})
 
 let parse_sector html =
   match Re.exec_opt _sector_re html with
-  | Some group -> Some (String.strip (Re.Group.get group 1))
+  | Some group ->
+      let raw = String.strip (Re.Group.get group 1) in
+      Some (Weinstein_types.normalize_sector_name raw)
   | None -> None
 
 (* --- Universe filtering -------------------------------------------------- *)
@@ -160,7 +164,8 @@ let fetch_one ~fetch ~rate_limit_rps symbol =
 
 (* --- Orchestration ------------------------------------------------------- *)
 
-let run ~data_dir ~rate_limit_rps ~force ?(fetch = _default_fetch) ?symbols () =
+let run ~data_dir ~rate_limit_rps ~force ?(fetch = _default_fetch) ?symbols
+    ?limit () =
   let%bind sym_list =
     match symbols with
     | Some s -> return s
@@ -184,8 +189,13 @@ let run ~data_dir ~rate_limit_rps ~force ?(fetch = _default_fetch) ?symbols () =
        gate on resume — a stale manifest with a valid CSV still means
        the sectors we scraped before are still usable. *)
     let to_fetch =
-      if force then sym_list
-      else List.filter sym_list ~f:(fun sym -> not (Hashtbl.mem existing sym))
+      let filtered =
+        if force then sym_list
+        else List.filter sym_list ~f:(fun sym -> not (Hashtbl.mem existing sym))
+      in
+      match limit with
+      | Some n when n > 0 -> List.take filtered n
+      | _ -> filtered
     in
     (match load_manifest manifest_file with
     | Some m when not (manifest_is_fresh m ~max_age_days:30) ->

--- a/trading/analysis/scripts/fetch_finviz_sectors/lib/fetch_finviz_sectors_lib.mli
+++ b/trading/analysis/scripts/fetch_finviz_sectors/lib/fetch_finviz_sectors_lib.mli
@@ -39,5 +39,8 @@ val run :
   force:bool ->
   ?fetch:fetch_fn ->
   ?symbols:string list ->
+  ?limit:int ->
   unit ->
   unit Deferred.t
+(** [limit] caps the number of symbols fetched after skip-filter / --force is
+    applied. Intended for dry-run or small test runs. *)

--- a/trading/analysis/scripts/fetch_finviz_sectors/test/test_fetch_finviz_sectors.ml
+++ b/trading/analysis/scripts/fetch_finviz_sectors/test/test_fetch_finviz_sectors.ml
@@ -46,15 +46,16 @@ let _sample_html_no_sector =
 
 (* --- parse_sector tests -------------------------------------------------- *)
 
+(* parse_sector normalizes Finviz labels to canonical GICS spellings. *)
 let test_parse_sector_aapl _ctx =
   assert_that
     (Fetch_finviz_sectors_lib.parse_sector _sample_html_aapl)
-    (is_some_and (equal_to "Technology"))
+    (is_some_and (equal_to "Information Technology"))
 
 let test_parse_sector_jpm _ctx =
   assert_that
     (Fetch_finviz_sectors_lib.parse_sector _sample_html_jpm)
-    (is_some_and (equal_to "Financial Services"))
+    (is_some_and (equal_to "Financials"))
 
 let test_parse_sector_missing _ctx =
   assert_that

--- a/trading/analysis/weinstein/types/lib/weinstein_types.ml
+++ b/trading/analysis/weinstein/types/lib/weinstein_types.ml
@@ -73,20 +73,29 @@ let gics_sector_to_string = function
   | Real_estate -> "Real Estate"
   | Communication_services -> "Communication Services"
 
+(* Also accepts Finviz's labels as aliases, so sectors.csv rows written
+   from the Finviz scraper (e.g. "Technology", "Financial", "Healthcare")
+   parse to the same gics_sector variants as canonical GICS spellings. *)
 let gics_sector_of_string_opt s =
   match String.lowercase s with
-  | "information technology" -> Some Information_technology
-  | "financials" -> Some Financials
-  | "health care" -> Some Health_care
+  | "information technology" | "technology" -> Some Information_technology
+  | "financials" | "financial" | "financial services" -> Some Financials
+  | "health care" | "healthcare" -> Some Health_care
   | "energy" -> Some Energy
   | "industrials" -> Some Industrials
-  | "consumer staples" -> Some Consumer_staples
-  | "consumer discretionary" -> Some Consumer_discretionary
+  | "consumer staples" | "consumer defensive" -> Some Consumer_staples
+  | "consumer discretionary" | "consumer cyclical" ->
+      Some Consumer_discretionary
   | "utilities" -> Some Utilities
-  | "materials" -> Some Materials
+  | "materials" | "basic materials" -> Some Materials
   | "real estate" -> Some Real_estate
   | "communication services" -> Some Communication_services
   | _ -> None
+
+let normalize_sector_name s =
+  match gics_sector_of_string_opt s with
+  | Some g -> gics_sector_to_string g
+  | None -> s
 
 type grade = A_plus | A | B | C | D | F [@@deriving show, eq, ord, sexp]
 

--- a/trading/analysis/weinstein/types/lib/weinstein_types.mli
+++ b/trading/analysis/weinstein/types/lib/weinstein_types.mli
@@ -107,5 +107,13 @@ val gics_sector_to_string : gics_sector -> string
     ["Information Technology"]). *)
 
 val gics_sector_of_string_opt : string -> gics_sector option
-(** Parse a sector name (case-insensitive). Returns [None] for unrecognized
-    names. *)
+(** Parse a sector name (case-insensitive). Also accepts Finviz's labels
+    ("Technology", "Financial", "Healthcare", "Basic Materials", "Consumer
+    Cyclical", "Consumer Defensive") as aliases, mapping them to the
+    corresponding GICS variant. Returns [None] for unrecognized names. *)
+
+val normalize_sector_name : string -> string
+(** Normalize [s] to the canonical GICS display spelling when recognized
+    (including via Finviz aliases). Unknown names are returned unchanged so no
+    data is dropped. Callers that need strictness should use
+    {!gics_sector_of_string_opt} directly. *)

--- a/trading/analysis/weinstein/types/test/test_weinstein_types.ml
+++ b/trading/analysis/weinstein/types/test/test_weinstein_types.ml
@@ -15,11 +15,72 @@ let test_ma_direction_eq _ =
   assert_that (Rising : ma_direction) (equal_to Rising);
   assert_that (Rising : ma_direction) (not_ (equal_to Declining))
 
+(* GICS canonical spellings must parse. *)
+let test_gics_of_string_canonical _ =
+  assert_that
+    (gics_sector_of_string_opt "Information Technology")
+    (is_some_and (equal_to Information_technology));
+  assert_that
+    (gics_sector_of_string_opt "Health Care")
+    (is_some_and (equal_to Health_care));
+  assert_that
+    (gics_sector_of_string_opt "COMMUNICATION SERVICES")
+    (is_some_and (equal_to Communication_services))
+
+(* All 11 Finviz sector display labels (verified against
+   finviz.com/groups.ashx?g=sector) must map to a GICS variant. If
+   Finviz ever renames one, this test fails loudly. *)
+let test_gics_of_string_all_finviz_labels _ =
+  let finviz_to_gics =
+    [
+      ("Basic Materials", Materials);
+      ("Communication Services", Communication_services);
+      ("Consumer Cyclical", Consumer_discretionary);
+      ("Consumer Defensive", Consumer_staples);
+      ("Energy", Energy);
+      ("Financial", Financials);
+      ("Financial Services", Financials);
+      ("Healthcare", Health_care);
+      ("Industrials", Industrials);
+      ("Real Estate", Real_estate);
+      ("Technology", Information_technology);
+      ("Utilities", Utilities);
+    ]
+  in
+  List.iter
+    (fun (label, expected) ->
+      assert_that
+        (gics_sector_of_string_opt label)
+        (is_some_and (equal_to expected)))
+    finviz_to_gics
+
+let test_gics_of_string_unknown _ =
+  assert_that (gics_sector_of_string_opt "Bogus") is_none;
+  assert_that (gics_sector_of_string_opt "") is_none
+
+(* normalize_sector_name returns the canonical GICS spelling for known
+   names, passes unknowns through unchanged. *)
+let test_normalize_sector_name _ =
+  assert_that
+    (normalize_sector_name "Technology")
+    (equal_to "Information Technology");
+  assert_that (normalize_sector_name "Financial") (equal_to "Financials");
+  assert_that (normalize_sector_name "Healthcare") (equal_to "Health Care");
+  assert_that
+    (normalize_sector_name "Information Technology")
+    (equal_to "Information Technology");
+  assert_that (normalize_sector_name "Bogus") (equal_to "Bogus")
+
 let suite =
   "weinstein_types"
   >::: [
          "stage_eq" >:: test_stage_eq;
          "ma_direction_eq" >:: test_ma_direction_eq;
+         "gics_of_string canonical" >:: test_gics_of_string_canonical;
+         "gics_of_string all finviz labels"
+         >:: test_gics_of_string_all_finviz_labels;
+         "gics_of_string unknown" >:: test_gics_of_string_unknown;
+         "normalize_sector_name" >:: test_normalize_sector_name;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Three changes to fetch_finviz_sectors.exe + the types layer so sectors.csv is always canonically labeled.

### 1. Regex fix (critical — was failing 100% of live fetches)
Finviz refactored: sector name now lives in a tab-link anchor keyed by the screener filter query f=sec_<slug>. Updated _sector_re accordingly. Live run before this fix: 11,700 symbols attempted, 0 successes.

### 2. --limit N flag
New CLI flag + optional ?limit:int arg on Fetch_finviz_sectors_lib.run. Caps number of symbols fetched after skip / --force. Dry-run example: -limit 20 finishes in ~20 seconds.

### 3. GICS normalization
Finviz returns its own sector spellings (Technology, Financial, Healthcare, ...) which don't match the GICS labels already in data/sectors.csv. Without normalization the combined CSV would have two spellings for the same sector and downstream name lookups would treat them as distinct.

- Weinstein_types.gics_sector_of_string_opt now accepts Finviz aliases (Technology → Information_technology, Financial / Financial Services → Financials, Healthcare → Health_care, Basic Materials → Materials, Consumer Cyclical → Consumer_discretionary, Consumer Defensive → Consumer_staples). Backward-compatible: GICS spellings still parse.
- New Weinstein_types.normalize_sector_name : string -> string returns the canonical GICS display form for known names and passes unknowns through unchanged.
- fetch_finviz_sectors_lib.parse_sector calls normalize_sector_name before emitting, so sectors.csv always ends up with canonical GICS labels regardless of source.

## Live verification
  -symbols AAPL,MSFT,JPM,XOM,JNJ,NEE
  [1/6] AAPL → Information Technology
  [2/6] MSFT → Information Technology
  [3/6] JPM  → Financials
  [4/6] XOM  → Energy
  [5/6] JNJ  → Health Care
  [6/6] NEE  → Utilities

## Test plan
- [x] dune build passes
- [x] dune runtest analysis/weinstein/types/ passes (6 tests, +4 new)
- [x] dune runtest analysis/scripts/fetch_finviz_sectors/ passes (10 tests, fixtures updated for normalized output)
- [x] dune fmt clean
- [x] Live Finviz fetch verified against 6 canonical tickers