### PR TITLE
harness: pin model per agent (opus / sonnet / haiku split)

### DIFF
--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -1,6 +1,7 @@
 ---
 name: feat-backtest
 description: Implements experiments + analysis features on the backtest-infra track (stop-buffer tuning, drawdown circuit breaker, per-trade stop logging, segmentation-based stage classifier). Works on feat/backtest branches.
+model: opus
 ---
 
 You are implementing the backtest-infra feature track for the Weinstein

--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -1,6 +1,7 @@
 ---
 name: feat-weinstein
 description: Implements remaining Weinstein Trading System feature work — strategy-wiring (Synthetic_adl façade composition + default_global_indices). Works on feat/strategy-wiring branch using TDD.
+model: opus
 ---
 
 You are building the remaining Weinstein Trading System feature work. The base strategy (order_gen, Simulation Slice 1-3, screener, stops, portfolio_risk) is complete and merged. One scope remains:

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -1,6 +1,7 @@
 ---
 name: harness-maintainer
 description: Implements harness tooling improvements for the Weinstein Trading System. Works on harness/ branches. Assigned to open T1/T3 items in dev/status/harness.md that are not directly related to feature code.
+model: sonnet
 ---
 
 You are the harness maintainer for the Weinstein Trading System. Your job is to implement tooling, linting, process improvements, and agent definition updates — not feature code.

--- a/.claude/agents/health-scanner.md
+++ b/.claude/agents/health-scanner.md
@@ -1,6 +1,7 @@
 ---
 name: health-scanner
 description: Read-only health check agent for the Weinstein Trading System. Runs in fast mode (post-orchestrator-run) or deep mode (weekly). Writes findings to dev/health/. Never modifies source or agent files.
+model: haiku
 ---
 
 You are the health scanner for the Weinstein Trading System. You read; you never write to source code, agent definitions, or status files. Your only output is a health report written to `dev/health/`.

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -1,6 +1,7 @@
 ---
 name: lead-orchestrator
 description: Orchestrates daily parallel feature development for the Weinstein Trading System. Spawns feature and QC agents as subagents, coordinates integration order, and writes daily summaries for human review. Runs non-interactively via claude -p.
+model: opus
 ---
 
 You are the lead orchestrator for the Weinstein Trading System build. You run once per day, coordinate all work, and exit. The human reads your output in `dev/daily/YYYY-MM-DD.md`.

--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -1,6 +1,7 @@
 ---
 name: ops-data
 description: On-demand data fetching and inventory maintenance for the Weinstein Trading System. Fetches symbols via EODHD API, rebuilds the local inventory and universe. Operational agent — not a feature builder.
+model: sonnet
 ---
 
 You are the data operations agent for the Weinstein Trading System. You fetch market data on demand, maintain the local data inventory, and ensure data coverage is sufficient for agent runs and regression tests.

--- a/.claude/agents/qc-behavioral.md
+++ b/.claude/agents/qc-behavioral.md
@@ -1,6 +1,7 @@
 ---
 name: qc-behavioral
 description: Domain correctness QC reviewer for the Weinstein Trading System. Checks that trading logic, stage classification, stop-loss rules, and screener cascade match the Weinstein book and design specs. Only runs after qc-structural APPROVED.
+model: opus
 ---
 
 You are the **QC Behavioral Reviewer** for the Weinstein Trading System. You check domain correctness only — whether the implementation faithfully encodes Weinstein's trading rules and the design specifications. You do NOT check code style, formatting, or architecture patterns; those are qc-structural's responsibility.

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -1,6 +1,7 @@
 ---
 name: qc-structural
 description: Structural and mechanical QC reviewer for the Weinstein Trading System. Checks build health, code patterns, and architecture constraints. Runs before qc-behavioral — if this agent FAILs, behavioral review does not run.
+model: sonnet
 ---
 
 You are the **QC Structural Reviewer** for the Weinstein Trading System. You check structural and mechanical correctness only — you do not evaluate domain behavior or trading logic. That is qc-behavioral's responsibility.


### PR DESCRIPTION
## Summary
Adds a \`model:\` field to each agent frontmatter so the orchestrator's \`Agent\` tool dispatches each subagent on the right model instead of everything on Opus.

### Assignments
| Model | Agents | Why |
|--|--|--|
| **opus** | lead-orchestrator, feat-weinstein, feat-backtest, qc-behavioral | domain reasoning, multi-file synthesis, Weinstein-spec correctness |
| **sonnet** | qc-structural, harness-maintainer, ops-data | mechanical work with some judgement — lint/build checks, shell + dune edits, fetch scripts |
| **haiku** | health-scanner | pure checklist against existing linters |

### Expected impact
- **Cost per run**: health-scanner + qc-structural + harness-maintainer + ops-data consumed ~$7 of yesterday's $16 daily run. Haiku/Sonnet are 80-90% cheaper → ~$5 saved per run.
- **Opus quota**: the shared 5-hour Opus bucket is now spent only on the 4 agents that actually need it. This is the more important win given the kill-by-rate-limit incident two days ago.
- **Risk**: Sonnet occasionally loses the thread on deep file trees or subtle pattern violations. Signals to watch: qc-structural missing lint issues that qc-behavioral then catches; harness-maintainer producing shallow fixes. Easy revert — delete the \`model:\` line.

\`feat-agent-template.md\` intentionally left without a model pin — each concrete feat-agent sets its own.

## Test plan
- [ ] Next orchestrator run's cost table shows lower per-agent cost for the four non-Opus agents
- [ ] \`dune runtest devtools/checks/\` still passes (agent compliance check has never cared about \`model:\`)