### PR TITLE
harness: add dev/lib/run-in-env.sh wrapper script

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -80,7 +80,7 @@ status to READY_FOR_REVIEW.
 - [ ] No function exceeds 50 lines
 - [ ] All configurable parameters routed through config record — no magic numbers
 - [ ] `dune build && dune runtest` passes with zero warnings **on a clean checkout of the branch** — not just on your local worktree. If you are running in `isolation: "worktree"` (the orchestrator default), your working copy already is a clean checkout, so the local pass is sufficient. If you are NOT in a worktree (rare, legacy runs), re-verify by checking that every module your branch references is either in your commits or already on `main@origin` — do not rely on files sitting in the shared working copy that you did not explicitly commit.
-- [ ] `dune fmt --check` passes (or: `dune fmt` produces no diff)
+- [ ] `dune build @fmt` passes (formatter in check mode; equivalent: `dune fmt` produces no diff)
 - [ ] `Interface stable: YES` is set in `dev/status/<feature>.md` once `.mli` is finalized
 ```
 

--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -106,7 +106,7 @@ status to READY_FOR_REVIEW.
 - [ ] If experiment: scenario files parse via `Scenario.load` (run `dune build`)
 - [ ] If experiment: `dev/experiments/<name>/report.md` includes a comparative table + falsifiable conclusion
 - [ ] `dune build && dune runtest` passes with zero warnings
-- [ ] `dune fmt --check` passes (or: `dune fmt` produces no diff)
+- [ ] `dune build @fmt` passes (formatter in check mode; equivalent: `dune fmt` produces no diff)
 - [ ] `dev/status/backtest-infra.md` updated: tick off the item under the relevant subsection, add a Completed entry with what was built, where it lives, and how to verify
 - [ ] Trading-behaviour-impact items also link back to `## Potential experiments` if they originated there
 

--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -79,13 +79,13 @@ If after **3 consecutive build-fix cycles** `dune build && dune runtest` is stil
 - [ ] Correlation ≥0.85 recorded in `dev/notes/synthetic-adl-validation.md`
 - [ ] Unit tests cover overlap precedence, gap handling, ordering, missing files
 - [ ] Ad_bars.mli documentation updated — no stale "delegates to Unicorn only" claim
-- [ ] `dune build && dune runtest` passes, `dune fmt --check` passes
+- [ ] `dune build && dune runtest` passes, `dune build @fmt` passes
 
 ### Item 2 — Global indices
 - [ ] `Macro_inputs.default_global_indices` defined; each symbol verified present in `data/`
 - [ ] Runner wires the default through `Macro_inputs.default_global_indices`
 - [ ] Smoke test asserts `Macro.analyze` sees non-empty `global_index_bars` under default config
-- [ ] `dune build && dune runtest` passes, `dune fmt --check` passes
+- [ ] `dune build && dune runtest` passes, `dune build @fmt` passes
 
 ## Status file updates
 

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -94,12 +94,10 @@ The health-scanner is read-only — it never modifies source or agent files. It 
 ## Verification
 
 ```bash
-docker exec <container-name> bash -c \
-  'cd /workspaces/trading-1/trading && eval $(opam env) && dune build && dune runtest'
+dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest
 
 # For agent definition compliance:
-docker exec <container-name> bash -c \
-  'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest trading/devtools/checks/'
+dev/lib/run-in-env.sh dune runtest trading/devtools/checks/
 ```
 
 ## When done with each item

--- a/.claude/agents/health-scanner.md
+++ b/.claude/agents/health-scanner.md
@@ -34,8 +34,7 @@ cat /Users/difan/Projects/trading-1/dev/status/<feature>.md
 Run the full build and test suite on `main@origin` to confirm it is clean:
 
 ```bash
-docker exec trading-1-dev bash -c \
-  'cd /workspaces/trading-1/trading && eval $(opam env) && dune build && dune runtest 2>&1; echo "EXIT:$?"'
+dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest 2>&1; echo "EXIT:$?"
 ```
 
 Report PASSING if exit code is 0. Report FAILING with full output if non-zero.
@@ -49,8 +48,7 @@ Check the most recent commit on `main` for newly introduced bare numeric literal
 jj log -r 'main@origin' --no-graph --template 'commit_id ++ "\n"' | head -1
 
 # Check if the linter is passing (this catches any violations in the full tree)
-docker exec trading-1-dev bash -c \
-  'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest devtools/checks/ 2>&1; echo "EXIT:$?"'
+dev/lib/run-in-env.sh dune runtest devtools/checks/ 2>&1; echo "EXIT:$?"
 ```
 
 If the linter fails, that is a critical finding (the gate should have caught it before merge).
@@ -71,9 +69,7 @@ The deterministic check is wired into `dune runtest` as
 linters. Invoke it directly to get the report:
 
 ```bash
-docker exec trading-1-dev bash -c \
-  'cd /workspaces/trading-1/trading && eval $(opam env) && \
-   sh devtools/checks/status_file_integrity.sh 2>&1; echo "EXIT:$?"'
+dev/lib/run-in-env.sh sh devtools/checks/status_file_integrity.sh 2>&1; echo "EXIT:$?"
 ```
 
 If exit code is non-zero, quote the FAIL lines verbatim into the report as
@@ -102,12 +98,7 @@ Run once per week. The deep scan has two phases: a deterministic script and agen
 Run the standalone deep scan script. This covers dead code detection, design doc drift, TODO/FIXME/HACK accumulation, size violations, and follow-up item counting. It writes the report to `dev/health/YYYY-MM-DD-deep.md`.
 
 ```bash
-# From the repo root (local):
-sh trading/devtools/checks/deep_scan.sh
-
-# From Docker:
-docker exec trading-1-dev bash -c \
-  'cd /workspaces/trading-1 && sh trading/devtools/checks/deep_scan.sh'
+dev/lib/run-in-env.sh sh ../devtools/checks/deep_scan.sh
 ```
 
 The script performs five checks:

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -64,7 +64,7 @@ Each feature follows this explicit sequence of deterministic nodes (D) and agent
 ```
 [D] preflight: inject context (assemble dune failure summary + last QC findings + open follow-ups)
  → [A] feat-agent: implement feature
- → [D] dune fmt --check
+ → [D] dune build @fmt
  → [D] dune build && dune runtest
  → [A] qc-structural: structural + mechanical review
  → [A] qc-behavioral: domain correctness review (only if structural APPROVED)
@@ -237,8 +237,7 @@ For each feature that will run today, assemble the pre-flight context package **
 
 ```bash
 # 1. Current test failures for this feature's test directory
-docker exec <container-name> bash -c \
-  'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest <feature-test-dir> 2>&1 || true'
+dev/lib/run-in-env.sh dune runtest <feature-test-dir> 2>&1 || true
 
 # 2. Last QC review findings (if any)
 # Read: dev/reviews/<feature>.md (if it exists)
@@ -375,8 +374,8 @@ Work using TDD (CLAUDE.md workflow):
   4. dune fmt
   5. Commit and push (see commit discipline below)
 
-Build/test inside Docker:
-  docker exec <container-name> bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && <cmd>'
+Build/test:
+  dev/lib/run-in-env.sh <cmd>
 
 COMMIT DISCIPLINE — this is critical for reviewability AND for surviving rate-limit kills:
   - Commit after each logical unit: one module, one interface, one test suite
@@ -518,8 +517,8 @@ Branch: feat/<feature>
 
 Steps:
 1. jj git init --colocate 2>/dev/null || true && jj git fetch && jj new feat/<feature>@origin
-2. Run hard gates:
-   - dune fmt --check
+2. Run hard gates (via dev/lib/run-in-env.sh):
+   - dune build @fmt
    - dune build
    - dune runtest
 3. Read diff: jj diff --from main@origin --to feat/<feature>@origin

--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -23,25 +23,21 @@ All scripts run inside Docker. Build the project first if executables are stale.
 ### Fetch symbols
 
 ```bash
-docker exec -e EODHD_API_KEY <container-name> bash -c \
-  'cd /workspaces/trading-1/trading && eval $(opam env) && \
-   ./_build/default/analysis/scripts/fetch_symbols/fetch_symbols.exe \
-   --symbols AAPL,GSPCX \
-   --data-dir /workspaces/trading-1/data \
-   --api-key "$EODHD_API_KEY"'
+dev/lib/run-in-env.sh ./_build/default/analysis/scripts/fetch_symbols/fetch_symbols.exe \
+  --symbols AAPL,GSPCX \
+  --data-dir /workspaces/trading-1/data \
+  --api-key "$EODHD_API_KEY"
 ```
 
-`EODHD_API_KEY` must be set in the host environment. The `-e EODHD_API_KEY` flag forwards it into the container; the script receives it via `--api-key`. The key value is never hardcoded.
+`EODHD_API_KEY` must be set in the host environment. `run-in-env.sh` forwards it into the container automatically.
 
 Idempotent: re-running for a cached symbol appends only new bars. Omit `--symbols` to fetch all symbols in `universe.sexp`.
 
 ### Rebuild inventory
 
 ```bash
-docker exec <container-name> bash -c \
-  'cd /workspaces/trading-1/trading && eval $(opam env) && \
-   ./_build/default/analysis/scripts/build_inventory/build_inventory.exe \
-   --data-dir /workspaces/trading-1/data'
+dev/lib/run-in-env.sh ./_build/default/analysis/scripts/build_inventory/build_inventory.exe \
+  --data-dir /workspaces/trading-1/data
 ```
 
 Walks `data/`, reads each `data.metadata.sexp`, writes `data/inventory.sexp`. Run after any fetch.
@@ -49,10 +45,8 @@ Walks `data/`, reads each `data.metadata.sexp`, writes `data/inventory.sexp`. Ru
 ### Bootstrap universe
 
 ```bash
-docker exec <container-name> bash -c \
-  'cd /workspaces/trading-1/trading && eval $(opam env) && \
-   ./_build/default/analysis/scripts/bootstrap_universe/bootstrap_universe.exe \
-   --data-dir /workspaces/trading-1/data'
+dev/lib/run-in-env.sh ./_build/default/analysis/scripts/bootstrap_universe/bootstrap_universe.exe \
+  --data-dir /workspaces/trading-1/data
 ```
 
 Builds `data/universe.sexp` from the local inventory. Sector/industry fields will be empty (use `fetch_universe.exe` for full metadata from EODHD fundamentals).
@@ -63,7 +57,7 @@ Read `data/inventory.sexp` and report: which symbols are present, their date ran
 
 ## API key
 
-`EODHD_API_KEY` must be set in the host environment before any fetch. It is forwarded into the container via `docker exec -e EODHD_API_KEY` and passed as `--api-key "$EODHD_API_KEY"` — the OCaml script only accepts the flag, never reads env vars directly.
+`EODHD_API_KEY` must be set in the host environment before any fetch. `dev/lib/run-in-env.sh` forwards it into the container automatically; the OCaml script receives it via the `--api-key` flag and never reads env vars directly.
 
 If `EODHD_API_KEY` is not set in the host environment, **don't stop early**:
 - Many data gaps don't need EODHD (scrape-source validation for ADL,

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -43,14 +43,9 @@ block APPROVED, but the orchestrator escalation policy should note it.
 Run each command and record PASS or FAIL with any error output:
 
 ```bash
-# Format check
-docker exec <container-name> bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune fmt --check'
-
-# Build
-docker exec <container-name> bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune build'
-
-# Tests
-docker exec <container-name> bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest'
+dev/lib/run-in-env.sh dune build @fmt
+dev/lib/run-in-env.sh dune build
+dev/lib/run-in-env.sh dune runtest
 ```
 
 If any of the three fail, the overall verdict is NEEDS_REWORK immediately. Proceed to fill in the remaining checklist items you can determine from static analysis, then write the output.
@@ -79,7 +74,7 @@ Do not use freeform narrative in the Status column — put detail in the Notes c
 
 | # | Check | Status | Notes |
 |---|-------|--------|-------|
-| H1 | dune fmt --check | PASS/FAIL | |
+| H1 | dune build @fmt (format check) | PASS/FAIL | |
 | H2 | dune build | PASS/FAIL | |
 | H3 | dune runtest | PASS/FAIL | N tests, N passed, N failed |
 | P1 | Functions ≤ 50 lines — covered by fn_length_linter (dune runtest) | PASS/NA | If H3 passed, this is clean. If H3 failed, check fn_length_linter output. |
@@ -147,7 +142,7 @@ Return the overall verdict (APPROVED / NEEDS_REWORK) and a one-line summary of a
 
 | # | Check | Status | Notes |
 |---|-------|--------|-------|
-| H1 | dune fmt --check | PASS | |
+| H1 | dune build @fmt | PASS | |
 | H2 | dune build | PASS | |
 | H3 | dune runtest | PASS | 42 tests, 42 passed, 0 failed |
 | P1 | Functions ≤ 50 lines (linter) | PASS | fn_length_linter passed as part of H3 |

--- a/dev/lib/run-in-env.sh
+++ b/dev/lib/run-in-env.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Run a command in the Trading dev environment.
+#
+# Usage:
+#   dev/lib/run-in-env.sh dune build
+#   dev/lib/run-in-env.sh dune runtest trading/backtest/test/
+#
+# Locally (default): wraps with `docker exec` into trading-1-dev,
+# cd's to the workspace, and sources opam env.
+#
+# In GHA / devcontainer: set TRADING_IN_CONTAINER=1 and the script
+# runs natively (cd + opam env, no docker wrapping).
+
+set -euo pipefail
+
+TRADING_ROOT="/workspaces/trading-1/trading"
+CONTAINER_NAME="${TRADING_CONTAINER_NAME:-trading-1-dev}"
+
+if [ $# -eq 0 ]; then
+  echo "Usage: dev/lib/run-in-env.sh <command> [args...]" >&2
+  exit 1
+fi
+
+if [ -n "${TRADING_IN_CONTAINER:-}" ]; then
+  cd "$TRADING_ROOT"
+  eval "$(opam env)"
+  exec "$@"
+else
+  # Build a single string for bash -c inside docker.
+  # Forward EODHD_API_KEY if set.
+  DOCKER_ENV_FLAGS=""
+  if [ -n "${EODHD_API_KEY:-}" ]; then
+    DOCKER_ENV_FLAGS="-e EODHD_API_KEY"
+  fi
+  exec docker exec $DOCKER_ENV_FLAGS "$CONTAINER_NAME" bash -c \
+    "cd $TRADING_ROOT && eval \$(opam env) && $*"
+fi


### PR DESCRIPTION
## Summary
Adds \`dev/lib/run-in-env.sh\` — a wrapper script that centralizes the \`cd\` + \`eval \$(opam env)\` + conditional \`docker exec\` pattern currently repeated in every agent prompt template.

**Locally** (no env var set): wraps with \`docker exec trading-1-dev bash -c '…'\`.
**In GHA / devcontainer**: set \`TRADING_IN_CONTAINER=1\` at the job env level → runs natively.

Tested locally:
- \`dune build\` ✓
- \`dune runtest <dir>\` ✓ (6 tests, single directory)
- \`dune runtest\` ✓ (full suite)
- \`dune fmt\` ✓
- Multi-arg passthrough (\`dune exec ... -- -help\`) ✓
- Exit code propagation (\`false\` → exit 1) ✓

Next step after this lands: replace all \`docker exec\` references in the 7 agent definitions with calls to this script. That's a separate mechanical PR.

## Test plan
- [x] All 6 tests above pass locally
- [ ] \`TRADING_IN_CONTAINER=1 dev/lib/run-in-env.sh dune build\` works inside the Docker container (native path)