### PR TITLE
harness: add .github/workflows/orchestrator.yml (workflow_dispatch-only scaffold)

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -1,0 +1,177 @@
+# Daily orchestrator run on GitHub Actions.
+#
+# Runs `lead-orchestrator` via anthropics/claude-code-action inside the prebuilt
+# `trading-devcontainer` image (already has jj, jst, opam env baked in). The
+# orchestrator writes its daily summary to `dev/daily/<date>-runN.md` and
+# whatever subagent work it dispatched to branches + PRs. A post-step pushes
+# the daily summary branch, opens a PR, then fails the job if the summary has
+# any entries in the `## Escalations` section — that's our partial-failure
+# signal (see dev/status/orchestrator-automation.md § "Partial-failure
+# reporting").
+#
+# ----------------------------------------------------------------------------
+# SECRETS REQUIRED BEFORE THIS WORKFLOW CAN RUN
+# ----------------------------------------------------------------------------
+# The first `workflow_dispatch` run will fail at the "Run lead-orchestrator"
+# step until the human completes the following one-time setup (tracked in
+# dev/status/orchestrator-automation.md § "Implementation sequencing" step 2):
+#
+#   1. BOT_GITHUB_TOKEN — fine-grained Personal Access Token scoped to
+#      this repo only. Create at
+#      https://github.com/settings/tokens?type=beta
+#      Permissions: Contents R+W, Pull requests R+W. Expiration: 1 year
+#      (or whatever; set a calendar reminder to rotate).
+#      Store as repo secret `BOT_GITHUB_TOKEN`.
+#
+#      Why a PAT and not the default GITHUB_TOKEN: pushes using the built-in
+#      token do not trigger downstream workflows (GitHub safety feature),
+#      so CI would not re-run on branches this orchestrator pushes.
+#      PAT-issued pushes do trigger them.
+#
+#      Why a PAT and not a custom GitHub App: both work; an App auto-
+#      rotates short-lived tokens and is the Claude Code docs' recommended
+#      path, but requires one-time registration + install. For a single-
+#      developer setup the PAT is simpler. Swap to an App later if
+#      rotation burden hurts.
+#
+#   2. CLAUDE_CODE_OAUTH_TOKEN — generated on a subscription-authenticated
+#      machine via `claude setup-token`. The Pro/Max subscription's session
+#      limits act as the effective cost ceiling for this workflow.
+#
+# DO NOT enable the `schedule:` cron below until a successful manual
+# dogfood run via `workflow_dispatch` has been observed end-to-end.
+# ----------------------------------------------------------------------------
+name: Daily orchestrator
+
+on:
+  # workflow_dispatch only, for now. Flip on `schedule: cron: "0 14 * * *"`
+  # (07:00 Pacific) once a manual dogfood run succeeds end-to-end.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  orchestrator:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/trading-devcontainer:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # See ci.yml for the rationale: the base image has USER opam, but
+      # Actions' post-step file bookkeeping needs root. HOME stays pointed at
+      # /home/opam so the opam switch is still discoverable.
+      options: --user 0
+    env:
+      HOME: /home/opam
+      # run-in-env.sh takes the native path (cd + opam env, no docker
+      # wrapping) when this is set. Agent prompts invoke the wrapper so they
+      # work identically in local-docker and in-container (GHA) environments.
+      TRADING_IN_CONTAINER: "1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so jj can see main@origin and rebase properly.
+          fetch-depth: 0
+
+      - name: Run lead-orchestrator
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          prompt: |
+            Run the daily orchestrator session. Today is $(date +%Y-%m-%d).
+            Read .claude/agents/lead-orchestrator.md and follow it end to end.
+          claude_args: |
+            --agent lead-orchestrator
+            --allowedTools Agent,Bash,Read,Write,Edit,Glob,Grep
+            --max-turns 200
+
+      - name: Push daily summary branch + open PR
+        id: publish-summary
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DATE="$(date +%F)"
+
+          # Find the most recent daily summary the orchestrator just wrote.
+          # Prefer today's dated file (today.md or today-runN.md). Fall back
+          # to the most recently modified dev/daily/*.md if the orchestrator
+          # chose a different naming convention.
+          SUMMARY=""
+          for candidate in \
+            "dev/daily/${DATE}-run1.md" \
+            "dev/daily/${DATE}.md"; do
+            if [ -f "$candidate" ]; then
+              SUMMARY="$candidate"
+              break
+            fi
+          done
+          if [ -z "$SUMMARY" ]; then
+            SUMMARY="$(ls -t dev/daily/*.md 2>/dev/null | head -n 1 || true)"
+          fi
+          if [ -z "$SUMMARY" ] || [ ! -f "$SUMMARY" ]; then
+            echo "::error::No daily summary file found under dev/daily/."
+            exit 1
+          fi
+          echo "Using daily summary: $SUMMARY"
+          echo "summary_path=$SUMMARY" >> "$GITHUB_OUTPUT"
+
+          # Push a branch with everything the orchestrator changed in the
+          # working copy. Subagents create their own feat/harness branches
+          # separately; this branch is specifically for the daily summary
+          # file + any top-level status file ticks.
+          BRANCH="ops/daily-${DATE}-run${GITHUB_RUN_NUMBER}"
+          jj bookmark set "$BRANCH" -r @
+          jj git push --bookmark "$BRANCH" --allow-new
+
+          # Open a PR for human review. --fill would reuse the commit
+          # message; we'd rather give a predictable title.
+          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+            echo "PR for $BRANCH already exists; skipping create."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "ops: daily orchestrator summary ${DATE} (run ${GITHUB_RUN_NUMBER})" \
+              --body "Automated daily orchestrator run. See \`$SUMMARY\` for the full summary."
+          fi
+
+      - name: Fail on escalations
+        env:
+          SUMMARY: ${{ steps.publish-summary.outputs.summary_path }}
+        run: |
+          set -euo pipefail
+          # Extract the ## Escalations section body (up to the next H2) and
+          # count bullet lines that aren't the empty-case placeholder.
+          # Accepted empty-case forms across existing summaries:
+          #   - None
+          #   - None — ...
+          #   None — all PRs mergeable, no blockers...
+          #   (empty)
+          section="$(awk '
+            /^## Escalations/ { in_section=1; next }
+            /^## / && in_section { exit }
+            in_section { print }
+          ' "$SUMMARY")"
+
+          # Keep lines that look like bullet items (start with "- " or "* "),
+          # then drop the empty-case placeholder where the first word of the
+          # bullet content is literally "None" (covers "- None", "- None.",
+          # "- None — ...", "- None - ...", etc.).
+          escalations="$(printf '%s\n' "$section" \
+            | grep -E '^[[:space:]]*[-*][[:space:]]' \
+            | grep -Ev '^[[:space:]]*[-*][[:space:]]+None\b' \
+            || true)"
+
+          if [ -n "$escalations" ]; then
+            echo "::error::Daily summary has escalations; marking run as failed."
+            echo "Escalations found in $SUMMARY:"
+            printf '%s\n' "$escalations"
+            exit 1
+          fi
+          echo "No escalations in $SUMMARY — clean run."

--- a/dev/status/orchestrator-automation.md
+++ b/dev/status/orchestrator-automation.md
@@ -88,8 +88,18 @@ Six specific questions sent to the Claude Code guide. Results:
 
 The default `GITHUB_TOKEN` can push branches but won't trigger downstream
 workflows (CI won't run on `feat/*` branches created by the orchestrator's
-subagents). Need a **custom GitHub App** with `contents:write` so that pushes
-from the orchestrator re-trigger CI gates.
+subagents). Need a token whose pushes DO trigger downstream workflows.
+
+**Chosen approach: fine-grained Personal Access Token.** Simpler than a
+custom GitHub App for a single-developer setup; swap to an App later if
+the manual rotation burden (1 year expiration) becomes annoying.
+
+Setup steps (human, one-time):
+1. https://github.com/settings/tokens?type=beta → Generate new token
+2. Scope: `dayfine/trading` only
+3. Permissions: Contents R+W, Pull requests R+W
+4. Expiration: 1 year (set calendar reminder to rotate)
+5. Store as repo secret `BOT_GITHUB_TOKEN`
 
 ### 2. `docker exec <container-name>` in agent prompts
 
@@ -192,15 +202,10 @@ jobs:
       HOME: /home/opam
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
           prompt: |
             Run the daily orchestrator session. Today is $(date +%Y-%m-%d).
             Read .claude/agents/lead-orchestrator.md and follow it.
@@ -220,10 +225,12 @@ jobs:
 ## Implementation sequencing
 
 1. Land #325 (publishes `trading-devcontainer:latest`) — **DONE**
-2. Create GitHub App via the action repo's [Quick Setup
-   Tool](https://github.com/anthropics/claude-code-action/blob/main/docs/create-app.html)
-   + set `APP_ID` / `APP_PRIVATE_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` repo
-   secrets (human, one-time)
+2. Human, one-time setup:
+   - Create fine-grained PAT at https://github.com/settings/tokens?type=beta
+     (scope: `dayfine/trading`, perms: Contents R+W + Pull requests R+W)
+     → store as repo secret `BOT_GITHUB_TOKEN`.
+   - Run `claude setup-token` on a subscription-authenticated machine
+     → store result as repo secret `CLAUDE_CODE_OAUTH_TOKEN`.
 3. Strip `docker exec` from agent prompts — add `dev/lib/run-in-env.sh`
    wrapper (see blocker §2), replace every hardcoded docker-exec +
    cd + opam-env prelude in the 7 agent definitions with a call to


### PR DESCRIPTION
## Summary
Scaffolds a `workflow_dispatch`-only GitHub Actions workflow that runs `lead-orchestrator` via `anthropics/claude-code-action@v1`. Lands in a disabled state so the human can complete the one-time secrets setup at their pace.

### What you need to do before this runs successfully

1. **Create fine-grained PAT** at https://github.com/settings/tokens?type=beta
   - Scope: this repo only (dayfine/trading)
   - Permissions: Contents (R+W), Pull requests (R+W)
   - Expiration: 1 year (set a calendar reminder to rotate)
   - Store as repo secret **`BOT_GITHUB_TOKEN`**
   - Why PAT, not default GITHUB_TOKEN: pushes from the built-in token do not trigger downstream workflows (GitHub safety feature), so CI would not re-run on orchestrator-pushed branches.
   - Why PAT, not a GitHub App: App is more secure (auto-rotating tokens) but requires one-time registration + install. For a single-developer setup the PAT is simpler. Swap later if rotation becomes annoying.

2. **Get a Claude OAuth token**
   - On a subscription-authenticated machine, run `claude setup-token` (prints an `oat_...` token)
   - Store as repo secret **`CLAUDE_CODE_OAUTH_TOKEN`**
   - This uses the Pro/Max subscription's 5-hour session limits as the cost ceiling

3. **Trigger the workflow manually** once
   - Actions tab → "Daily orchestrator" → "Run workflow"
   - Watch for rate-limit behavior + timing
   - If it completes cleanly, uncomment the `schedule:` cron inside the YAML
   - If it fails: the Escalations post-step is designed to surface issues cleanly; look at the daily summary PR the job opens

### What the workflow contains
- `workflow_dispatch` trigger only (no cron yet — manually dogfood first)
- Container: `ghcr.io/dayfine/trading-devcontainer:latest` (from PR #325, already live)
- `TRADING_IN_CONTAINER=1` so `dev/lib/run-in-env.sh` (landed #365) takes the native path
- Auth: BOT_GITHUB_TOKEN (PAT) for git push + PR create; CLAUDE_CODE_OAUTH_TOKEN for Claude API
- Post-step: push `ops/daily-<date>-runN` branch, open a PR with the daily summary
- Escalation gate: greps the daily summary for §Escalations — if non-empty, job exits 1 (surfaces as a failed run even if the orchestrator itself returned 0)

### What's changed vs the initial version
- **Removed App auth** (APP_ID / APP_PRIVATE_KEY / create-github-app-token step). PAT path is simpler for this use case; App remains an option if rotation becomes a pain.
- Docstring updated to match the PAT-based setup.
- Also updated `dev/status/orchestrator-automation.md` §"Open blockers #1" and §"Implementation sequencing" step 2 to match.

## Test plan
- [ ] Human creates BOT_GITHUB_TOKEN + CLAUDE_CODE_OAUTH_TOKEN
- [ ] Manual workflow_dispatch run completes (or fails cleanly if rate-limited)
- [ ] Daily summary PR opens with sensible content
- [ ] Escalations post-step correctly fails the run when §Escalations has content (validated manually against a prior daily)