### PR TITLE
ops(universe-filter): configurable sectors.csv filter library + binary

### DIFF
--- a/dev/config/universe_filter/default.sexp
+++ b/dev/config/universe_filter/default.sexp
@@ -1,0 +1,32 @@
+; universe_filter default rule-set.
+;
+; Rules: evaluated in declaration order.
+;   - Symbol_pattern: Perl-style regex matched against the *symbol* column.
+;     A row whose symbol matches ANY Symbol_pattern is dropped, unless
+;     rescued by a Keep_allowlist.
+;   - Keep_allowlist: symbols in the list are preserved regardless.
+;
+; Starting point based on dev/status/sector-data.md §Item 4:
+;   - exchange-suffix noise: .U (units), .W / .WS (warrants),
+;     -P* (preferreds), .INDX (indexes)
+;   - "length > 3 ending in W" as a tight warrant heuristic
+;   - allow-list for the sector/broad-market ETFs the Weinstein strategy
+;     depends on (so they survive any rule).
+;
+; Note: Finviz (our current sectors.csv source) appears to already strip
+; most of these exchange-suffix forms, so the suffix rules may hit zero
+; rows on the current file. That's expected and documented as a follow-up
+; in Item 4 §Completed. Keep the rules — they still guard against future
+; sources (EODHD, Yahoo) that emit raw exchange-suffix forms.
+((rules (
+  (Symbol_pattern (name "suffix_units_.U")     (pattern "\\.U$"))
+  (Symbol_pattern (name "suffix_warrant_.W")   (pattern "\\.W$"))
+  (Symbol_pattern (name "suffix_warrant_.WS")  (pattern "\\.WS$"))
+  (Symbol_pattern (name "preferred_-P")        (pattern "-P"))
+  (Symbol_pattern (name "index_.INDX")         (pattern "\\.INDX$"))
+  (Symbol_pattern (name "warrant_len>3_endsW") (pattern "^.{3,}W$"))
+  (Keep_allowlist (name "sector_and_broad_ETFs")
+                  (symbols (
+                    SPY QQQ VOO VTI IWM DIA
+                    XLK XLF XLE XLV XLI XLP XLY XLU XLB XLRE XLC
+                    QQQM FXAIX SWPPX))))))

--- a/dev/config/universe_filter/default.sexp
+++ b/dev/config/universe_filter/default.sexp
@@ -1,32 +1,36 @@
 ; universe_filter default rule-set.
 ;
 ; Rules: evaluated in declaration order.
-;   - Symbol_pattern: Perl-style regex matched against the *symbol* column.
-;     A row whose symbol matches ANY Symbol_pattern is dropped, unless
-;     rescued by a Keep_allowlist.
-;   - Keep_allowlist: symbols in the list are preserved regardless.
+;   - Keep_allowlist: symbols in the list are preserved regardless of any drop
+;     rule. Rescue is final — cannot be overridden.
+;   - Symbol_pattern: Perl-style regex against [row.symbol]. Drops on match.
+;   - Name_pattern: Perl-style regex against [row.name] (joined from
+;     universe.sexp). Prepend [(?i)] for case-insensitive matching.
+;   - Exchange_equals: exact (case-sensitive) match against [row.exchange]
+;     (joined from universe.sexp).
 ;
-; Starting point based on dev/status/sector-data.md §Item 4:
-;   - exchange-suffix noise: .U (units), .W / .WS (warrants),
-;     -P* (preferreds), .INDX (indexes)
-;   - "length > 3 ending in W" as a tight warrant heuristic
-;   - allow-list for the sector/broad-market ETFs the Weinstein strategy
-;     depends on (so they survive any rule).
+; Iteration 2 (2026-04-16): the exchange-suffix rules (.U / .W / .WS / -P*
+; / .INDX) fired zero rows on Finviz-sourced sectors.csv (Finviz strips
+; these forms before we ingest), and the [warrant_len>3_endsW] heuristic
+; caught only 12 rows — all legitimate common stocks (SCHW, SNOW, PANW, …).
+; Replaced the symbol-suffix filters with name- and exchange-based filters
+; that use universe.sexp metadata:
+;   - Name_pattern drops "ETF" / "Fund" / "Trust" / "Notes" instruments
+;     (bond ETFs, leveraged / inverse ETFs, unit trusts, closed-end funds
+;     — the "Financials" bloat identified in Item 4).
+;   - Exchange_equals "NYSE ARCA" is a strong ETF signal (NYSE Arca is
+;     the primary US ETF listing venue).
 ;
-; Note: Finviz (our current sectors.csv source) appears to already strip
-; most of these exchange-suffix forms, so the suffix rules may hit zero
-; rows on the current file. That's expected and documented as a follow-up
-; in Item 4 §Completed. Keep the rules — they still guard against future
-; sources (EODHD, Yahoo) that emit raw exchange-suffix forms.
+; Symbols in the broad / sector-ETF allow-list are live on NYSE ARCA and
+; their names contain "ETF" / "Trust"; they are rescued first so neither
+; filter drops them.
 ((rules (
-  (Symbol_pattern (name "suffix_units_.U")     (pattern "\\.U$"))
-  (Symbol_pattern (name "suffix_warrant_.W")   (pattern "\\.W$"))
-  (Symbol_pattern (name "suffix_warrant_.WS")  (pattern "\\.WS$"))
-  (Symbol_pattern (name "preferred_-P")        (pattern "-P"))
-  (Symbol_pattern (name "index_.INDX")         (pattern "\\.INDX$"))
-  (Symbol_pattern (name "warrant_len>3_endsW") (pattern "^.{3,}W$"))
   (Keep_allowlist (name "sector_and_broad_ETFs")
                   (symbols (
                     SPY QQQ VOO VTI IWM DIA
                     XLK XLF XLE XLV XLI XLP XLY XLU XLB XLRE XLC
-                    QQQM FXAIX SWPPX))))))
+                    QQQM FXAIX SWPPX)))
+  (Name_pattern (name "etf_fund_trust_notes")
+                (pattern "(?i)(\\bETF\\b|\\bFund\\b|\\bTrust\\b|\\bNotes\\b)"))
+  (Exchange_equals (name "nyse_arca")
+                   (exchange "NYSE ARCA")))))

--- a/dev/status/sector-data.md
+++ b/dev/status/sector-data.md
@@ -129,6 +129,100 @@ EODHD stays available as a drop-in upgrade if Finviz becomes unstable.
     Keeping it as-is would silently drop SCHW, SNOW, PANW from the
     universe.
 
+### Iteration 2 — rule-set rewrite using universe.sexp metadata (2026-04-16)
+
+Root-cause fix for Item 4's Iteration 1 finding (the default rule-set
+dropped only 12 rows — all false positives):
+
+- Extended `row` with `name` + `exchange` fields, joined from
+  `data/universe.sexp` at load time (new
+  `load_rows_with_universe ~sectors_csv ~universe_sexp`).
+- Added `Name_pattern` (Perl regex over `row.name`, supports `(?i)`
+  leading flag for case-insensitive match) and `Exchange_equals`
+  (exact match on `row.exchange`) rule variants.
+- Replaced the default `default.sexp` with a three-rule set:
+  - `Keep_allowlist` — SPY QQQ VOO VTI IWM DIA, XL\* sector ETFs,
+    QQQM FXAIX SWPPX (listed first so rescue is final).
+  - `Name_pattern "(?i)(\bETF\b|\bFund\b|\bTrust\b|\bNotes\b)"` —
+    catches bond / leveraged / inverse ETFs, closed-end funds,
+    trust preferreds. Word-boundary anchors avoid matching "etfr" or
+    "fundamentals" embedded in other words.
+  - `Exchange_equals "NYSE ARCA"` — NYSE Arca is the primary US ETF
+    listing venue; this catches ETFs whose display name elides the
+    "ETF" token (e.g. "ProShares Ultra Silver", "ALPS Clean Energy").
+
+Dry-run against live `data/sectors.csv` (9,041 rows as of 2026-04-16):
+
+| rule | raw hits |
+|---|---:|
+| `etf_fund_trust_notes` (Name_pattern) | 3,864 |
+| `nyse_arca` (Exchange_equals) | 2,079 |
+| Rescued by allow-list | 16 |
+| **total dropped** | **4,125** |
+
+Sector breakdown before -> after:
+
+| sector | before | after | Δ |
+|---|---:|---:|---:|
+| Financials | 5,096 | 1,036 | **-4,060** |
+| Health Care | 959 | 959 | 0 |
+| Information Technology | 638 | 636 | -2 |
+| Industrials | 626 | 626 | 0 |
+| Consumer Discretionary | 482 | 482 | 0 |
+| Materials | 251 | 250 | -1 |
+| Real Estate | 235 | 184 | **-51** |
+| Communication Services | 221 | 221 | 0 |
+| Energy | 214 | 213 | -1 |
+| Consumer Staples | 213 | 213 | 0 |
+| Utilities | 106 | 106 | 0 |
+| **total** | **9,041** | **4,916** | **-4,125** |
+
+**Spot check — 5 dropped symbols (each shows name + exchange so the
+reader can sanity-check):**
+
+| symbol | name | exchange | rule that hit |
+|---|---|---|---|
+| AAAA | Amplius Aggressive Asset Allocation ETF | NYSE | `etf_fund_trust_notes` |
+| ABLS | Abacus FCF Small Cap Leaders ETF | NYSE | `etf_fund_trust_notes` |
+| AAPY | Kurv Yield Premium Strategy Apple (AAPL) ETF | BATS | `etf_fund_trust_notes` |
+| AGQ | ProShares Ultra Silver | NYSE ARCA | `nyse_arca` only |
+| ACES | ALPS Clean Energy | NYSE ARCA | `nyse_arca` only |
+
+**Spot check — 5 allow-list symbols preserved** (SPY, QQQ, XLK, XLF,
+XLE are all on NYSE ARCA with names containing ETF/Fund/Trust; the
+`Keep_allowlist` rescue prevents both drop rules from firing):
+
+| symbol | name | exchange |
+|---|---|---|
+| SPY | SPDR S&P 500 ETF Trust | NYSE ARCA |
+| QQQ | Invesco QQQ Trust | NASDAQ |
+| XLK | Technology Select Sector SPDR Fund | NYSE ARCA |
+| XLF | Financial Select Sector SPDR Fund | NYSE ARCA |
+| XLE | Energy Select Sector SPDR Fund | NYSE ARCA |
+
+**Known collateral damage** — 51 Real Estate rows are dropped because
+many legitimate REITs have "Trust" in their display name (AAT
+"American Assets Trust Inc", ABR "Arbor Realty Trust", AKR "Acadia
+Realty Trust", BRT "BRT Realty Trust", …). A small number of royalty
+trusts in Energy (MTR, NRT, PBT, PVL — ~4 rows) and Materials (MSB)
+also fall under the `Trust` keyword. Item 4.1 (below) tracks tightening
+the rule to exclude these.
+
+**Follow-up items:**
+
+- Item 4.1 — tighten `Trust` match so legitimate REITs and royalty
+  trusts are not swept up. Options: (a) add an REIT-sector allow-list
+  clause (preserve anything with `sector = "Real Estate"` regardless
+  of name), (b) change the regex from `\bTrust\b` to
+  `\b(ETF Trust|Unit Trust|Statutory Trust|ETF)\b` targeting the
+  fund-style Trust phrases only, (c) move `Trust` behind a second
+  filter that also checks `exchange ∈ {NYSE ARCA, BATS}`. Option (a)
+  is the cheapest and safest.
+- Items 5-7 (original follow-ups from Iteration 1) remain open —
+  industry_pattern, volume/market-cap gate, and the `warrant_len>3_endsW`
+  cleanup are still relevant if we want to drive the filter beyond
+  the name/exchange signal.
+
 ## In Progress
 - None — waiting for Item 1 PR merge before Item 2 (one-shot run).
 

--- a/dev/status/sector-data.md
+++ b/dev/status/sector-data.md
@@ -68,6 +68,66 @@ EODHD stays available as a drop-in upgrade if Finviz becomes unstable.
   and tested. 7 files, ~250 lines OCaml + ~170 lines tests. Uses
   `cohttp-async` + `re` (regex) for HTML parsing. Builds and all 10
   unit tests pass. Branch: `ops/sector-finviz-scraper`.
+- **Item 4 — universe_filter library + binary** (2026-04-14) —
+  `trading/analysis/scripts/universe_filter/` with
+  `Symbol_pattern` / `Keep_allowlist` rules loaded from
+  `dev/config/universe_filter/<name>.sexp`. 10 unit tests pass.
+  Branch: `ops/universe-filter`.
+
+  Dry-run against `data/sectors.csv` (8,255 rows as of 2026-04-14):
+
+  | rule | raw hits |
+  |---|---:|
+  | `suffix_units_.U` | 0 |
+  | `suffix_warrant_.W` | 0 |
+  | `suffix_warrant_.WS` | 0 |
+  | `preferred_-P` | 0 |
+  | `index_.INDX` | 0 |
+  | `warrant_len>3_endsW` | 12 |
+  | **total dropped** | **12** |
+
+  Sector breakdown before → after:
+
+  | sector | before | after | Δ |
+  |---|---:|---:|---:|
+  | Financials | 4,585 | 4,582 | -3 |
+  | Health Care | 886 | 886 | 0 |
+  | Information Technology | 593 | 590 | -3 |
+  | Industrials | 579 | 575 | -4 |
+  | Consumer Discretionary | 457 | 456 | -1 |
+  | Energy | 197 | 196 | -1 |
+  | others | unchanged | | |
+
+  **Finding — the default rule-set barely dents Financials.** The
+  exchange-suffix rules (`.U`, `.W`, `.WS`, `-P*`, `.INDX`) match
+  zero rows because Finviz already strips those forms before we
+  ingest. The `warrant_len>3_endsW` rule fires 12 times but on
+  legitimate common stocks (SCHW, PANW, SNOW, TROW, ACIW, CHRW,
+  DNOW, EZPW, HAYW, INSW, MATW, SKYW) — all real tickers, no
+  warrants. In the current source, that rule is a false-positive
+  trap rather than a useful filter.
+
+  The Financials bloat (4,585 rows, 55%) is almost entirely
+  **bond / fixed-income ETFs, leveraged / inverse ETFs, trust
+  preferreds, and closed-end funds** that Finviz classifies under
+  "Financial Services" → normalized to Financials. None of those
+  carry distinctive symbol-suffix markers; they look like ordinary
+  4-letter tickers (AAAU, AACB, AADR, ACEP, ACES, …).
+
+  **Follow-up items (new, add to "Next Steps"):**
+
+  - Item 5 — add an `Industry_pattern` rule variant so we can drop
+    e.g. "Exchange Traded Fund", "Shell Companies", "Asset
+    Management" subsets directly, using the Finviz industry cell
+    (requires extending the scrape to capture industry and
+    plumbing it through the CSV — currently we only store sector).
+  - Item 6 — optional volume / market-cap gate: drop symbols whose
+    cached bars show `avg_dollar_volume < $1M/day` or
+    `market_cap < $100M`. Needs the bars cache populated first.
+  - Item 7 — reconsider `warrant_len>3_endsW` — either remove it
+    or tighten to "ends-in-W AND not-in-known-common-stock-list".
+    Keeping it as-is would silently drop SCHW, SNOW, PANW from the
+    universe.
 
 ## In Progress
 - None — waiting for Item 1 PR merge before Item 2 (one-shot run).

--- a/trading/analysis/scripts/universe_filter/dune
+++ b/trading/analysis/scripts/universe_filter/dune
@@ -1,0 +1,5 @@
+(executable
+ (name universe_filter)
+ (libraries core core_unix.command_unix universe_filter_lib)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/scripts/universe_filter/lib/dune
+++ b/trading/analysis/scripts/universe_filter/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name universe_filter_lib)
+ (libraries core core_unix.sys_unix re)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.ml
+++ b/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.ml
@@ -1,0 +1,158 @@
+open Core
+
+type row = { symbol : string; sector : string } [@@deriving sexp, equal]
+
+type rule =
+  | Symbol_pattern of { name : string; pattern : string }
+  | Keep_allowlist of { name : string; symbols : string list }
+[@@deriving sexp]
+
+type config = { rules : rule list } [@@deriving sexp]
+type rule_stat = { rule_name : string; drop_count : int } [@@deriving sexp]
+
+type filter_result = {
+  kept : row list;
+  dropped : row list;
+  rule_stats : rule_stat list;
+  rescued_by_allowlist : int;
+}
+[@@deriving sexp]
+
+(* --- Compiled rule-set ---------------------------------------------------- *)
+
+(* A separate internal representation so we compile regexes once, up-front,
+   rather than per-row. *)
+type compiled = {
+  patterns : (string * Re.re) list; (* name, compiled regex *)
+  allowlist : String.Hash_set.t;
+}
+
+let _compile (cfg : config) : compiled =
+  let patterns =
+    List.filter_map cfg.rules ~f:(function
+      | Symbol_pattern { name; pattern } ->
+          Some (name, Re.compile (Re.Perl.re pattern))
+      | Keep_allowlist _ -> None)
+  in
+  let allowlist = String.Hash_set.create () in
+  List.iter cfg.rules ~f:(function
+    | Keep_allowlist { symbols; _ } ->
+        List.iter symbols ~f:(fun s -> Hash_set.add allowlist s)
+    | Symbol_pattern _ -> ());
+  { patterns; allowlist }
+
+(* --- Core filter --------------------------------------------------------- *)
+
+(* Matches [row] against every compiled pattern. Returns the list of
+   matched-pattern names (possibly empty). Allow-list rescue is applied
+   later, so this helper stays pure and the per-rule drop stats remain a
+   raw count of matches. *)
+let _matches (c : compiled) (sym : string) : string list =
+  List.filter_map c.patterns ~f:(fun (name, re) ->
+      if Re.execp re sym then Some name else None)
+
+let filter (cfg : config) (rows : row list) : filter_result =
+  let c = _compile cfg in
+  let stats = String.Table.create () in
+  let kept = ref [] in
+  let dropped = ref [] in
+  let rescued = ref 0 in
+  List.iter rows ~f:(fun row ->
+      let matched = _matches c row.symbol in
+      List.iter matched ~f:(fun name ->
+          Hashtbl.update stats name ~f:(function None -> 1 | Some n -> n + 1));
+      let would_drop = not (List.is_empty matched) in
+      let on_allowlist = Hash_set.mem c.allowlist row.symbol in
+      if would_drop && on_allowlist then (
+        Int.incr rescued;
+        kept := row :: !kept)
+      else if would_drop then dropped := row :: !dropped
+      else kept := row :: !kept);
+  let rule_stats =
+    (* Emit one stat per Symbol_pattern rule in declaration order — even if
+       the drop count is zero, so the caller sees that the rule exists and
+       fired nothing, rather than silently missing. *)
+    List.filter_map cfg.rules ~f:(function
+      | Symbol_pattern { name; _ } ->
+          let count = Hashtbl.find stats name |> Option.value ~default:0 in
+          Some { rule_name = name; drop_count = count }
+      | Keep_allowlist _ -> None)
+  in
+  {
+    kept = List.rev !kept;
+    dropped = List.rev !dropped;
+    rule_stats;
+    rescued_by_allowlist = !rescued;
+  }
+
+(* --- Config I/O ----------------------------------------------------------- *)
+
+let load_config path =
+  match Sys_unix.file_exists path with
+  | `No | `Unknown -> Error (Printf.sprintf "Config file not found: %s" path)
+  | `Yes -> (
+      try
+        let contents =
+          Stdlib.In_channel.with_open_text path Stdlib.In_channel.input_all
+        in
+        let sexp = Sexp.of_string contents in
+        try Ok (config_of_sexp sexp)
+        with exn ->
+          Error
+            (Printf.sprintf "Malformed config at %s: %s" path
+               (Exn.to_string exn))
+      with exn ->
+        Error
+          (Printf.sprintf "Cannot read config at %s: %s" path
+             (Exn.to_string exn)))
+
+(* --- CSV I/O -------------------------------------------------------------- *)
+
+let read_csv path =
+  try
+    let ic = Stdlib.In_channel.open_text path in
+    let rows = ref [] in
+    (match Stdlib.In_channel.input_line ic with
+    | None -> ()
+    | Some _header ->
+        let rec loop () =
+          match Stdlib.In_channel.input_line ic with
+          | None -> ()
+          | Some line ->
+              let line = String.strip line in
+              (if not (String.is_empty line) then
+                 match String.split line ~on:',' with
+                 | symbol :: sector :: _ ->
+                     let sym = String.strip symbol in
+                     let sec = String.strip sector in
+                     if not (String.is_empty sym) then
+                       rows := { symbol = sym; sector = sec } :: !rows
+                 | _ -> ());
+              loop ()
+        in
+        loop ());
+    Stdlib.In_channel.close ic;
+    Ok (List.rev !rows)
+  with exn ->
+    Error (Printf.sprintf "Cannot read CSV at %s: %s" path (Exn.to_string exn))
+
+let write_csv path rows =
+  let tmp = path ^ ".tmp" in
+  try
+    let oc = Stdlib.Out_channel.open_text tmp in
+    Stdlib.Out_channel.output_string oc "symbol,sector\n";
+    List.iter rows ~f:(fun { symbol; sector } ->
+        Stdlib.Out_channel.output_string oc (symbol ^ "," ^ sector ^ "\n"));
+    Stdlib.Out_channel.close oc;
+    Stdlib.Sys.rename tmp path;
+    Ok ()
+  with exn -> Error (Exn.to_string exn)
+
+(* --- Summaries ------------------------------------------------------------ *)
+
+let sector_breakdown rows =
+  let tbl = String.Table.create () in
+  List.iter rows ~f:(fun { sector; _ } ->
+      Hashtbl.update tbl sector ~f:(function None -> 1 | Some n -> n + 1));
+  Hashtbl.to_alist tbl
+  |> List.sort ~compare:(fun (_, a) (_, b) -> Int.descending a b)

--- a/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.ml
+++ b/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.ml
@@ -1,9 +1,17 @@
 open Core
 
-type row = { symbol : string; sector : string } [@@deriving sexp, equal]
+type row = {
+  symbol : string;
+  sector : string;
+  name : string;
+  exchange : string;
+}
+[@@deriving sexp, equal]
 
 type rule =
   | Symbol_pattern of { name : string; pattern : string }
+  | Name_pattern of { name : string; pattern : string }
+  | Exchange_equals of { name : string; exchange : string }
   | Keep_allowlist of { name : string; symbols : string list }
 [@@deriving sexp]
 
@@ -20,36 +28,66 @@ type filter_result = {
 
 (* --- Compiled rule-set ---------------------------------------------------- *)
 
-(* A separate internal representation so we compile regexes once, up-front,
-   rather than per-row. *)
+(* Internal representation: regexes compiled once up-front, allow-list flattened
+   into a set. Each drop rule keeps a closure that decides whether [row] matches.
+   Keeping the closure uniform across variants keeps the per-row loop simple. *)
+type drop_rule_compiled = { name : string; matches : row -> bool }
+
 type compiled = {
-  patterns : (string * Re.re) list; (* name, compiled regex *)
+  drop_rules : drop_rule_compiled list;
   allowlist : String.Hash_set.t;
 }
 
+(* [Re.Perl] does not support inline flag groups like [(?i)…]. To keep the sexp
+   syntax friendly (the docs-facing "perl regex" story), we hand-parse a
+   leading [(?i)] flag group off the pattern and translate it to the
+   [`Caseless] opt that [Re.Perl.re] does accept. More inline flags can be
+   added here as needed; unknown flag groups fall through unchanged and will
+   raise at compile time. *)
+let _extract_inline_flags (pattern : string) : Re.Perl.opt list * string =
+  match String.chop_prefix pattern ~prefix:"(?i)" with
+  | Some rest -> ([ `Caseless ], rest)
+  | None -> ([], pattern)
+
+let _compile_pattern pattern =
+  let opts, body = _extract_inline_flags pattern in
+  Re.compile (Re.Perl.re ~opts body)
+
+let _compile_drop_rule = function
+  | Symbol_pattern { name; pattern } ->
+      let re = _compile_pattern pattern in
+      Some { name; matches = (fun row -> Re.execp re row.symbol) }
+  | Name_pattern { name; pattern } ->
+      let re = _compile_pattern pattern in
+      Some { name; matches = (fun row -> Re.execp re row.name) }
+  | Exchange_equals { name; exchange } ->
+      Some { name; matches = (fun row -> String.equal row.exchange exchange) }
+  | Keep_allowlist _ -> None
+
 let _compile (cfg : config) : compiled =
-  let patterns =
-    List.filter_map cfg.rules ~f:(function
-      | Symbol_pattern { name; pattern } ->
-          Some (name, Re.compile (Re.Perl.re pattern))
-      | Keep_allowlist _ -> None)
-  in
+  let drop_rules = List.filter_map cfg.rules ~f:_compile_drop_rule in
   let allowlist = String.Hash_set.create () in
   List.iter cfg.rules ~f:(function
     | Keep_allowlist { symbols; _ } ->
         List.iter symbols ~f:(fun s -> Hash_set.add allowlist s)
-    | Symbol_pattern _ -> ());
-  { patterns; allowlist }
+    | Symbol_pattern _ | Name_pattern _ | Exchange_equals _ -> ());
+  { drop_rules; allowlist }
 
 (* --- Core filter --------------------------------------------------------- *)
 
-(* Matches [row] against every compiled pattern. Returns the list of
-   matched-pattern names (possibly empty). Allow-list rescue is applied
-   later, so this helper stays pure and the per-rule drop stats remain a
-   raw count of matches. *)
-let _matches (c : compiled) (sym : string) : string list =
-  List.filter_map c.patterns ~f:(fun (name, re) ->
-      if Re.execp re sym then Some name else None)
+(* Returns the list of matched drop-rule names (possibly empty). Allow-list
+   rescue is applied by the caller, so this helper stays pure and the per-rule
+   drop stats remain raw match counts. *)
+let _matches (c : compiled) (row : row) : string list =
+  List.filter_map c.drop_rules ~f:(fun { name; matches } ->
+      if matches row then Some name else None)
+
+let _extract_drop_rule_name = function
+  | Symbol_pattern { name; _ }
+  | Name_pattern { name; _ }
+  | Exchange_equals { name; _ } ->
+      Some name
+  | Keep_allowlist _ -> None
 
 let filter (cfg : config) (rows : row list) : filter_result =
   let c = _compile cfg in
@@ -58,7 +96,7 @@ let filter (cfg : config) (rows : row list) : filter_result =
   let dropped = ref [] in
   let rescued = ref 0 in
   List.iter rows ~f:(fun row ->
-      let matched = _matches c row.symbol in
+      let matched = _matches c row in
       List.iter matched ~f:(fun name ->
           Hashtbl.update stats name ~f:(function None -> 1 | Some n -> n + 1));
       let would_drop = not (List.is_empty matched) in
@@ -69,14 +107,13 @@ let filter (cfg : config) (rows : row list) : filter_result =
       else if would_drop then dropped := row :: !dropped
       else kept := row :: !kept);
   let rule_stats =
-    (* Emit one stat per Symbol_pattern rule in declaration order — even if
-       the drop count is zero, so the caller sees that the rule exists and
-       fired nothing, rather than silently missing. *)
-    List.filter_map cfg.rules ~f:(function
-      | Symbol_pattern { name; _ } ->
-          let count = Hashtbl.find stats name |> Option.value ~default:0 in
-          Some { rule_name = name; drop_count = count }
-      | Keep_allowlist _ -> None)
+    (* Emit one stat per drop rule in declaration order — even if the drop
+       count is zero, so the caller sees that the rule exists and fired
+       nothing, rather than silently missing. *)
+    List.filter_map cfg.rules ~f:(fun rule ->
+        Option.map (_extract_drop_rule_name rule) ~f:(fun name ->
+            let count = Hashtbl.find stats name |> Option.value ~default:0 in
+            { rule_name = name; drop_count = count }))
   in
   {
     kept = List.rev !kept;
@@ -126,7 +163,14 @@ let read_csv path =
                      let sym = String.strip symbol in
                      let sec = String.strip sector in
                      if not (String.is_empty sym) then
-                       rows := { symbol = sym; sector = sec } :: !rows
+                       rows :=
+                         {
+                           symbol = sym;
+                           sector = sec;
+                           name = "";
+                           exchange = "";
+                         }
+                         :: !rows
                  | _ -> ());
               loop ()
         in
@@ -141,12 +185,82 @@ let write_csv path rows =
   try
     let oc = Stdlib.Out_channel.open_text tmp in
     Stdlib.Out_channel.output_string oc "symbol,sector\n";
-    List.iter rows ~f:(fun { symbol; sector } ->
+    List.iter rows ~f:(fun { symbol; sector; _ } ->
         Stdlib.Out_channel.output_string oc (symbol ^ "," ^ sector ^ "\n"));
     Stdlib.Out_channel.close oc;
     Stdlib.Sys.rename tmp path;
     Ok ()
   with exn -> Error (Exn.to_string exn)
+
+(* --- Universe sexp join --------------------------------------------------- *)
+
+(* Shape expected per entry in universe.sexp:
+     ((symbol X) (name Y) (sector S) (industry I) (market_cap M) (exchange E))
+   Fields may appear in any order. We only need symbol, name, exchange —
+   other fields are ignored. Parsing by hand (rather than by deriving a full
+   Instrument_info type) keeps this library free of a cross-subproject
+   dependency on [analysis/data/types]. *)
+
+let _atom_to_string = function
+  | Sexp.Atom s -> s
+  | List _ -> (* fields we care about are always atoms *) ""
+
+let _parse_universe_entry (sexp : Sexp.t) :
+    (string * string * string) option (* (symbol, name, exchange) *) =
+  match sexp with
+  | List fields ->
+      let sym = ref "" in
+      let nm = ref "" in
+      let ex = ref "" in
+      List.iter fields ~f:(function
+        | Sexp.List [ Atom key; v ] -> (
+            match key with
+            | "symbol" -> sym := _atom_to_string v
+            | "name" -> nm := _atom_to_string v
+            | "exchange" -> ex := _atom_to_string v
+            | _ -> ())
+        | _ -> ());
+      if String.is_empty !sym then None else Some (!sym, !nm, !ex)
+  | Atom _ -> None
+
+let _load_universe_metadata path :
+    (string, string * string) Hashtbl.t Or_error.t =
+  try
+    let sexp = Sexp.load_sexp path in
+    match sexp with
+    | List entries ->
+        let tbl = String.Table.create () in
+        List.iter entries ~f:(fun entry ->
+            match _parse_universe_entry entry with
+            | Some (sym, name, exchange) ->
+                (* Last write wins; in practice symbols are unique in
+                   universe.sexp so this is fine. *)
+                Hashtbl.set tbl ~key:sym ~data:(name, exchange)
+            | None -> ());
+        Ok tbl
+    | Atom _ ->
+        Or_error.error_string
+          (Printf.sprintf
+             "universe.sexp at %s is a single atom, expected a list" path)
+  with exn -> Or_error.of_exn exn
+
+let load_rows_with_universe ~sectors_csv ~universe_sexp =
+  match read_csv sectors_csv with
+  | Error e -> Error e
+  | Ok rows -> (
+      match _load_universe_metadata universe_sexp with
+      | Error err ->
+          Error
+            (Printf.sprintf "Cannot read universe at %s: %s" universe_sexp
+               (Error.to_string_hum err))
+      | Ok meta ->
+          let enriched =
+            List.map rows ~f:(fun row ->
+                match Hashtbl.find meta row.symbol with
+                | Some (name, exchange) -> { row with name; exchange }
+                | None -> row (* name="", exchange="" from read_csv *))
+          in
+          Ok enriched)
 
 (* --- Summaries ------------------------------------------------------------ *)
 

--- a/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.mli
+++ b/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.mli
@@ -1,0 +1,87 @@
+(** Universe composition cleanup filter.
+
+    Drops noise symbols (SPACs, warrants, preferreds, unit trusts, indexes,
+    etc.) from a flat [(symbol, sector)] row list without touching legitimate
+    common stocks or allow-listed ETFs.
+
+    The filter is config-driven so the rule-set can evolve without code changes.
+    Configs live under [dev/config/universe_filter/<name>.sexp] and parse into
+    {!config} values via {!load_config}. *)
+
+type row = { symbol : string; sector : string } [@@deriving sexp, equal]
+(** One row of [data/sectors.csv]. *)
+
+(** A drop rule. Variants are open for extension, but today we only need two:
+    regex-based symbol filters and a simple allow-list override. *)
+type rule =
+  | Symbol_pattern of {
+      name : string;  (** Short label used in stats output. *)
+      pattern : string;
+          (** POSIX / Perl-style regex matched against the symbol. A row is
+              dropped when this regex matches [row.symbol]. *)
+    }
+  | Keep_allowlist of {
+      name : string;
+      symbols : string list;
+          (** Symbols in this list are preserved even if another rule would drop
+              them. *)
+    }
+[@@deriving sexp]
+
+type config = { rules : rule list } [@@deriving sexp]
+(** A rule-set. Rules are evaluated per-row in order: the first matching
+    [Symbol_pattern] drops the row, unless any [Keep_allowlist] contains the
+    symbol, in which case the row is preserved regardless.
+
+    Empty [rules] means no-op — everything is kept. *)
+
+type rule_stat = {
+  rule_name : string;
+  drop_count : int;
+      (** How many rows would have been dropped by this rule, before allow-list
+          override. Rows rescued by an allow-list are counted here (so per-rule
+          stats show the raw hit count) and the rescue itself is counted
+          separately in {!filter_result.rescued_by_allowlist}. *)
+}
+[@@deriving sexp]
+
+type filter_result = {
+  kept : row list;
+  dropped : row list;
+  rule_stats : rule_stat list;
+      (** Per-rule drop counts (raw, pre-rescue). See {!rule_stat.drop_count}.
+      *)
+  rescued_by_allowlist : int;
+      (** Count of rows that at least one [Symbol_pattern] would have dropped
+          but were preserved because an allow-list matched. *)
+}
+[@@deriving sexp]
+
+val filter : config -> row list -> filter_result
+(** [filter config rows] applies [config.rules] to [rows] and partitions them
+    into kept / dropped with per-rule stats.
+
+    Pure: same input, same output. Does no I/O. *)
+
+val load_config : string -> (config, string) Result.t
+(** [load_config path] loads and parses a sexp config file.
+
+    Returns [Error msg] with a descriptive message on:
+    - file not found / not readable
+    - malformed sexp
+    - sexp shape does not match [config_of_sexp]
+
+    Does not silently return an empty / default config on parse failure —
+    callers should surface the error. *)
+
+val read_csv : string -> (row list, string) Result.t
+(** [read_csv path] reads a [symbol,sector] CSV (with header row). Skips blank
+    lines. Returns [Error msg] if the file cannot be opened. *)
+
+val write_csv : string -> row list -> (unit, string) Result.t
+(** [write_csv path rows] writes [rows] to [path] with header [symbol,sector].
+    Writes atomically via [path.tmp] + rename. *)
+
+val sector_breakdown : row list -> (string * int) list
+(** Count rows per sector, sorted by descending count. Convenience for
+    before/after summaries. *)

--- a/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.mli
+++ b/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.mli
@@ -1,37 +1,74 @@
 (** Universe composition cleanup filter.
 
     Drops noise symbols (SPACs, warrants, preferreds, unit trusts, indexes,
-    etc.) from a flat [(symbol, sector)] row list without touching legitimate
+    ETFs, bond funds, etc.) from a flat row list without touching legitimate
     common stocks or allow-listed ETFs.
 
     The filter is config-driven so the rule-set can evolve without code changes.
     Configs live under [dev/config/universe_filter/<name>.sexp] and parse into
-    {!config} values via {!load_config}. *)
+    {!config} values via {!load_config}.
 
-type row = { symbol : string; sector : string } [@@deriving sexp, equal]
-(** One row of [data/sectors.csv]. *)
+    Row enrichment — the row type carries {!name} and {!exchange} in addition to
+    sector, loaded by joining [data/sectors.csv] against [data/universe.sexp]
+    (see {!load_rows_with_universe}). This lets rules target instrument names
+    ("ETF" / "Fund" / "Trust" / "Notes") and primary exchange ("NYSE ARCA" ≈ ETF
+    listing venue), not just the symbol ticker. *)
 
-(** A drop rule. Variants are open for extension, but today we only need two:
-    regex-based symbol filters and a simple allow-list override. *)
+type row = {
+  symbol : string;
+  sector : string;
+  name : string;
+      (** Instrument display name from [data/universe.sexp]; [""] if the symbol
+          is absent from the universe file. *)
+  exchange : string;
+      (** Primary exchange from [data/universe.sexp]; [""] if absent. Typical
+          values: [NYSE], [NASDAQ], ["NYSE ARCA"]. *)
+}
+[@@deriving sexp, equal]
+(** One enriched row. Symbol + sector come from [data/sectors.csv]; name and
+    exchange come from [data/universe.sexp]. *)
+
+(** A drop rule. Each {b non-allowlist} rule decides independently whether to
+    drop a row. A row survives only if no non-allowlist rule matches {i and/or}
+    an allow-list matches the symbol. *)
 type rule =
   | Symbol_pattern of {
       name : string;  (** Short label used in stats output. *)
       pattern : string;
-          (** POSIX / Perl-style regex matched against the symbol. A row is
-              dropped when this regex matches [row.symbol]. *)
+          (** Perl-style regex matched against [row.symbol]. A row is dropped
+              when this regex matches the symbol. *)
+    }
+  | Name_pattern of {
+      name : string;  (** Short label used in stats output. *)
+      pattern : string;
+          (** Perl-style regex matched against [row.name]. Prepend [(?i)] to
+              make the match case-insensitive (this prefix is stripped and
+              translated to the [`Caseless] flag — the rest of the pattern is
+              compiled as normal Perl syntax). A row is dropped when the regex
+              matches the instrument name. *)
+    }
+  | Exchange_equals of {
+      name : string;  (** Short label used in stats output. *)
+      exchange : string;
+          (** Exact (case-sensitive) match against [row.exchange]. A row is
+              dropped when [row.exchange = exchange]. *)
     }
   | Keep_allowlist of {
       name : string;
       symbols : string list;
-          (** Symbols in this list are preserved even if another rule would drop
-              them. *)
+          (** Symbols in this list are preserved even if a drop rule matches.
+              Allow-list rescue is final — it cannot be overridden by any other
+              rule. *)
     }
 [@@deriving sexp]
 
 type config = { rules : rule list } [@@deriving sexp]
-(** A rule-set. Rules are evaluated per-row in order: the first matching
-    [Symbol_pattern] drops the row, unless any [Keep_allowlist] contains the
-    symbol, in which case the row is preserved regardless.
+(** A rule-set.
+
+    Evaluation: for each row, collect matches from every non-allow-list rule in
+    declaration order. If any drop rule matches, the row is dropped — unless a
+    [Keep_allowlist] contains its symbol, in which case the row is preserved
+    regardless.
 
     Empty [rules] means no-op — everything is kept. *)
 
@@ -52,8 +89,8 @@ type filter_result = {
       (** Per-rule drop counts (raw, pre-rescue). See {!rule_stat.drop_count}.
       *)
   rescued_by_allowlist : int;
-      (** Count of rows that at least one [Symbol_pattern] would have dropped
-          but were preserved because an allow-list matched. *)
+      (** Count of rows that at least one drop rule would have dropped but were
+          preserved because an allow-list matched. *)
 }
 [@@deriving sexp]
 
@@ -76,11 +113,29 @@ val load_config : string -> (config, string) Result.t
 
 val read_csv : string -> (row list, string) Result.t
 (** [read_csv path] reads a [symbol,sector] CSV (with header row). Skips blank
-    lines. Returns [Error msg] if the file cannot be opened. *)
+    lines. Returns [Error msg] if the file cannot be opened. Rows loaded this
+    way have [name = ""] and [exchange = ""]; use {!load_rows_with_universe}
+    when those fields are needed. *)
+
+val load_rows_with_universe :
+  sectors_csv:string -> universe_sexp:string -> (row list, string) Result.t
+(** [load_rows_with_universe ~sectors_csv ~universe_sexp] reads [sectors_csv] as
+    the source of truth for the row set (one row per symbol with its sector) and
+    enriches each row with [name] + [exchange] pulled from [universe_sexp].
+
+    Symbols present in [sectors_csv] but absent from [universe_sexp] get
+    [name = ""] and [exchange = ""] — they are {i not} dropped; the filter is
+    applied downstream.
+
+    Returns [Error msg] on I/O / parse failures. [universe_sexp] is expected to
+    be a sexp-serialized [Types.Instrument_info.t list]; malformed or missing
+    universe sexp yields an error (not a silent fallback). *)
 
 val write_csv : string -> row list -> (unit, string) Result.t
 (** [write_csv path rows] writes [rows] to [path] with header [symbol,sector].
-    Writes atomically via [path.tmp] + rename. *)
+    Only [symbol] + [sector] are persisted — [name] and [exchange] come from
+    universe.sexp and are not part of the sectors schema. Writes atomically via
+    [path.tmp] + rename. *)
 
 val sector_breakdown : row list -> (string * int) list
 (** Count rows per sector, sorted by descending count. Convenience for

--- a/trading/analysis/scripts/universe_filter/test/dune
+++ b/trading/analysis/scripts/universe_filter/test/dune
@@ -1,0 +1,5 @@
+(test
+ (name test_universe_filter)
+ (libraries core ounit2 matchers universe_filter_lib)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/scripts/universe_filter/test/test_universe_filter.ml
+++ b/trading/analysis/scripts/universe_filter/test/test_universe_filter.ml
@@ -1,0 +1,236 @@
+open Core
+open OUnit2
+open Matchers
+module U = Universe_filter_lib
+
+(* --- Helpers ------------------------------------------------------------- *)
+
+let row symbol sector : U.row = { symbol; sector }
+let cfg_of_string s = s |> Sexp.of_string |> U.config_of_sexp
+
+(* --- filter tests -------------------------------------------------------- *)
+
+let test_empty_config_is_noop _ctx =
+  let cfg : U.config = { rules = [] } in
+  let rows = [ row "AAPL" "Information Technology"; row "JPM" "Financials" ] in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.U.kept) (elements_are (List.map rows ~f:equal_to));
+         field (fun r -> r.U.dropped) (elements_are []);
+         field (fun r -> r.U.rule_stats) (elements_are []);
+         field (fun r -> r.U.rescued_by_allowlist) (equal_to 0);
+       ])
+
+let test_symbol_pattern_drops_matches _ctx =
+  let cfg : U.config =
+    { rules = [ U.Symbol_pattern { name = "units"; pattern = "\\.U$" } ] }
+  in
+  let rows =
+    [ row "AAPL" "IT"; row "FOO.U" "Financials"; row "BAR.U" "Financials" ]
+  in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.U.kept) (elements_are [ equal_to (row "AAPL" "IT") ]);
+         field
+           (fun r -> r.U.dropped)
+           (elements_are
+              [
+                equal_to (row "FOO.U" "Financials");
+                equal_to (row "BAR.U" "Financials");
+              ]);
+         field
+           (fun r -> r.U.rule_stats)
+           (elements_are
+              [
+                equal_to ({ rule_name = "units"; drop_count = 2 } : U.rule_stat);
+              ]);
+         field (fun r -> r.U.rescued_by_allowlist) (equal_to 0);
+       ])
+
+let test_allowlist_rescues_match _ctx =
+  (* The regex matches 'SPY', but the allow-list should preserve it.
+     A different symbol 'ZZPY' that matches the same regex should still
+     be dropped. *)
+  let cfg : U.config =
+    {
+      rules =
+        [
+          U.Symbol_pattern { name = "ends_py"; pattern = "PY$" };
+          U.Keep_allowlist { name = "broad"; symbols = [ "SPY" ] };
+        ];
+    }
+  in
+  let rows = [ row "SPY" "Financials"; row "ZZPY" "Financials" ] in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun r -> r.U.kept)
+           (elements_are [ equal_to (row "SPY" "Financials") ]);
+         field
+           (fun r -> r.U.dropped)
+           (elements_are [ equal_to (row "ZZPY" "Financials") ]);
+         field
+           (fun r -> r.U.rule_stats)
+           (elements_are
+              [
+                equal_to
+                  ({ rule_name = "ends_py"; drop_count = 2 } : U.rule_stat);
+              ]);
+         field (fun r -> r.U.rescued_by_allowlist) (equal_to 1);
+       ])
+
+let test_multiple_rules_independent_counts _ctx =
+  (* A row matching two patterns counts once in each rule's stat; the row
+     is still dropped once (appears in `dropped` exactly once). *)
+  let cfg : U.config =
+    {
+      rules =
+        [
+          U.Symbol_pattern { name = "ends_W"; pattern = "W$" };
+          U.Symbol_pattern { name = "starts_A"; pattern = "^A" };
+        ];
+    }
+  in
+  (* AW matches both; AB matches starts_A; BW matches ends_W; ZZ matches neither. *)
+  let rows = [ row "AW" ""; row "AB" ""; row "BW" ""; row "ZZ" "" ] in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.U.kept) (elements_are [ equal_to (row "ZZ" "") ]);
+         field
+           (fun r -> r.U.dropped)
+           (elements_are
+              [
+                equal_to (row "AW" "");
+                equal_to (row "AB" "");
+                equal_to (row "BW" "");
+              ]);
+         field
+           (fun r -> r.U.rule_stats)
+           (elements_are
+              [
+                equal_to
+                  ({ rule_name = "ends_W"; drop_count = 2 } : U.rule_stat);
+                equal_to
+                  ({ rule_name = "starts_A"; drop_count = 2 } : U.rule_stat);
+              ]);
+       ])
+
+let test_stats_zero_for_nonmatching_rule _ctx =
+  (* A rule that matches nothing still shows up with count 0, so the
+     operator sees that the rule is present but inert. *)
+  let cfg : U.config =
+    { rules = [ U.Symbol_pattern { name = "inert"; pattern = "ZZZZ$" } ] }
+  in
+  let rows = [ row "AAPL" ""; row "MSFT" "" ] in
+  let result = U.filter cfg rows in
+  assert_that result
+    (field
+       (fun r -> r.U.rule_stats)
+       (elements_are
+          [ equal_to ({ rule_name = "inert"; drop_count = 0 } : U.rule_stat) ]))
+
+(* --- load_config tests --------------------------------------------------- *)
+
+let _write_tmp contents =
+  let tmp = Stdlib.Filename.temp_file "universe_filter_test" ".sexp" in
+  Stdlib.Out_channel.with_open_text tmp (fun oc ->
+      Stdlib.Out_channel.output_string oc contents);
+  tmp
+
+(* load_config returns (config, string) Result.t — not Status.status_or — so
+   we pattern-match instead of using is_ok_and_holds / is_error matchers. *)
+let test_load_config_ok _ctx =
+  let tmp =
+    _write_tmp
+      {|((rules (
+  (Symbol_pattern (name "u") (pattern "\\.U$"))
+  (Keep_allowlist (name "broad") (symbols (SPY QQQ))))))|}
+  in
+  let result = U.load_config tmp in
+  Stdlib.Sys.remove tmp;
+  match result with
+  | Error e -> assert_failure ("expected Ok, got Error: " ^ e)
+  | Ok cfg ->
+      assert_that cfg (field (fun c -> List.length c.U.rules) (equal_to 2))
+
+let test_load_config_missing_file _ctx =
+  let result = U.load_config "/nonexistent/does-not-exist.sexp" in
+  match result with
+  | Ok _ -> assert_failure "expected Error for missing file, got Ok"
+  | Error _ -> ()
+
+let test_load_config_malformed _ctx =
+  let tmp = _write_tmp "(this is (not a valid config))" in
+  let result = U.load_config tmp in
+  Stdlib.Sys.remove tmp;
+  match result with
+  | Ok _ -> assert_failure "expected Error for malformed sexp, got Ok"
+  | Error _ -> ()
+
+(* --- default.sexp smoke test --------------------------------------------- *)
+
+(* The default sexp that ships under dev/config/universe_filter is not
+   directly addressable from the test cwd, so we exercise its content by
+   inlining the same shape. This guards against syntax drift in the
+   shipped default. *)
+let test_default_shape_parses _ctx =
+  let sample =
+    {|((rules (
+        (Symbol_pattern (name "suffix_units_.U") (pattern "\\.U$"))
+        (Keep_allowlist (name "broad") (symbols (SPY QQQ))))))|}
+  in
+  let cfg = cfg_of_string sample in
+  assert_that cfg (field (fun c -> List.length c.U.rules) (equal_to 2))
+
+(* --- CSV roundtrip ------------------------------------------------------- *)
+
+let test_csv_roundtrip _ctx =
+  let tmp_dir = Stdlib.Filename.temp_dir "universe_filter_csv" "" in
+  let path = tmp_dir ^ "/test.csv" in
+  let rows = [ row "AAPL" "IT"; row "JPM" "Financials" ] in
+  (match U.write_csv path rows with
+  | Ok () -> ()
+  | Error e -> assert_failure ("write failed: " ^ e));
+  let loaded =
+    match U.read_csv path with
+    | Ok r -> r
+    | Error e -> assert_failure ("read failed: " ^ e)
+  in
+  Stdlib.Sys.remove path;
+  Stdlib.Sys.rmdir tmp_dir;
+  assert_that loaded (elements_are (List.map rows ~f:equal_to))
+
+(* --- Test runner --------------------------------------------------------- *)
+
+let () =
+  run_test_tt_main
+    ("universe_filter"
+    >::: [
+           "filter"
+           >::: [
+                  "empty config is no-op" >:: test_empty_config_is_noop;
+                  "symbol pattern drops matches"
+                  >:: test_symbol_pattern_drops_matches;
+                  "allowlist rescues match" >:: test_allowlist_rescues_match;
+                  "multiple rules independent counts"
+                  >:: test_multiple_rules_independent_counts;
+                  "stats show zero for nonmatching rule"
+                  >:: test_stats_zero_for_nonmatching_rule;
+                ];
+           "load_config"
+           >::: [
+                  "parses valid file" >:: test_load_config_ok;
+                  "missing file is error" >:: test_load_config_missing_file;
+                  "malformed sexp is error" >:: test_load_config_malformed;
+                  "default-sexp shape parses" >:: test_default_shape_parses;
+                ];
+           "csv_io" >::: [ "roundtrip" >:: test_csv_roundtrip ];
+         ])

--- a/trading/analysis/scripts/universe_filter/test/test_universe_filter.ml
+++ b/trading/analysis/scripts/universe_filter/test/test_universe_filter.ml
@@ -5,7 +5,9 @@ module U = Universe_filter_lib
 
 (* --- Helpers ------------------------------------------------------------- *)
 
-let row symbol sector : U.row = { symbol; sector }
+let row ?(name = "") ?(exchange = "") symbol sector : U.row =
+  { symbol; sector; name; exchange }
+
 let cfg_of_string s = s |> Sexp.of_string |> U.config_of_sexp
 
 (* --- filter tests -------------------------------------------------------- *)
@@ -51,6 +53,119 @@ let test_symbol_pattern_drops_matches _ctx =
          field (fun r -> r.U.rescued_by_allowlist) (equal_to 0);
        ])
 
+let test_name_pattern_drops_etf_fund_etc _ctx =
+  (* Case-sensitive match of "ETF" / "Fund" / "Trust" / "Notes" at word
+     boundaries. A common stock ("Apple Inc") must survive. *)
+  let cfg : U.config =
+    {
+      rules =
+        [
+          U.Name_pattern
+            {
+              name = "etf_fund_trust_notes";
+              pattern = "(\\bETF\\b|\\bFund\\b|\\bTrust\\b|\\bNotes\\b)";
+            };
+        ];
+    }
+  in
+  let rows =
+    [
+      row ~name:"Apple Inc" "AAPL" "IT";
+      row ~name:"SPDR S&P 500 ETF Trust" "SPY" "Financials";
+      row ~name:"Vanguard Total Stock Market Index Fund" "VTSAX" "Financials";
+      row ~name:"ProShares Trust II" "UCO" "Energy";
+      row ~name:"BlackRock Senior Floating Rate Notes" "XYZ" "Financials";
+    ]
+  in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun r -> r.U.kept)
+           (elements_are [ equal_to (row ~name:"Apple Inc" "AAPL" "IT") ]);
+         field (fun r -> r.U.dropped) (size_is 4);
+         field
+           (fun r -> r.U.rule_stats)
+           (elements_are
+              [
+                equal_to
+                  ({ rule_name = "etf_fund_trust_notes"; drop_count = 4 }
+                    : U.rule_stat);
+              ]);
+         field (fun r -> r.U.rescued_by_allowlist) (equal_to 0);
+       ])
+
+let test_name_pattern_case_insensitive _ctx =
+  (* [(?i)…] flag in the regex makes it case-insensitive — lowercase "etf"
+     should match uppercase "ETF" in the name and vice versa. *)
+  let cfg : U.config =
+    {
+      rules = [ U.Name_pattern { name = "etf_ci"; pattern = "(?i)\\bETF\\b" } ];
+    }
+  in
+  let rows =
+    [
+      row ~name:"SPDR S&P 500 ETF Trust" "SPY" "Financials";
+      row ~name:"iShares Core S&P 500 etf" "IVV" "Financials";
+      row ~name:"Apple Inc" "AAPL" "IT";
+    ]
+  in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.U.kept) (size_is 1);
+         field (fun r -> r.U.dropped) (size_is 2);
+         field
+           (fun r -> r.U.rule_stats)
+           (elements_are
+              [
+                equal_to
+                  ({ rule_name = "etf_ci"; drop_count = 2 } : U.rule_stat);
+              ]);
+       ])
+
+let test_exchange_equals_drops_nyse_arca _ctx =
+  (* Exchange_equals is exact-match; "NYSE ARCA" should drop only rows whose
+     exchange is exactly "NYSE ARCA", not NASDAQ / NYSE / NYSEARCA (one-word). *)
+  let cfg : U.config =
+    {
+      rules =
+        [ U.Exchange_equals { name = "nyse_arca"; exchange = "NYSE ARCA" } ];
+    }
+  in
+  let rows =
+    [
+      row ~exchange:"NYSE ARCA" "XLK" "IT";
+      row ~exchange:"NYSE ARCA" "XLF" "Financials";
+      row ~exchange:"NASDAQ" "AAPL" "IT";
+      row ~exchange:"NYSE" "JPM" "Financials";
+      row ~exchange:"NYSEARCA" "BAR" "Financials";
+      (* one-word variant — should NOT drop *)
+    ]
+  in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.U.kept) (size_is 3);
+         field
+           (fun r -> r.U.dropped)
+           (elements_are
+              [
+                equal_to (row ~exchange:"NYSE ARCA" "XLK" "IT");
+                equal_to (row ~exchange:"NYSE ARCA" "XLF" "Financials");
+              ]);
+         field
+           (fun r -> r.U.rule_stats)
+           (elements_are
+              [
+                equal_to
+                  ({ rule_name = "nyse_arca"; drop_count = 2 } : U.rule_stat);
+              ]);
+       ])
+
 let test_allowlist_rescues_match _ctx =
   (* The regex matches 'SPY', but the allow-list should preserve it.
      A different symbol 'ZZPY' that matches the same regex should still
@@ -85,9 +200,42 @@ let test_allowlist_rescues_match _ctx =
          field (fun r -> r.U.rescued_by_allowlist) (equal_to 1);
        ])
 
+let test_allowlist_rescues_from_exchange_rule _ctx =
+  (* SPY is listed on NYSE ARCA; an Exchange_equals "NYSE ARCA" rule would
+     drop it. The allow-list must rescue SPY regardless. *)
+  let cfg : U.config =
+    {
+      rules =
+        [
+          U.Keep_allowlist { name = "broad"; symbols = [ "SPY" ] };
+          U.Exchange_equals { name = "nyse_arca"; exchange = "NYSE ARCA" };
+        ];
+    }
+  in
+  let rows =
+    [
+      row ~exchange:"NYSE ARCA" "SPY" "Financials";
+      row ~exchange:"NYSE ARCA" "AAAA" "Financials";
+    ]
+  in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun r -> r.U.kept)
+           (elements_are
+              [ equal_to (row ~exchange:"NYSE ARCA" "SPY" "Financials") ]);
+         field
+           (fun r -> r.U.dropped)
+           (elements_are
+              [ equal_to (row ~exchange:"NYSE ARCA" "AAAA" "Financials") ]);
+         field (fun r -> r.U.rescued_by_allowlist) (equal_to 1);
+       ])
+
 let test_multiple_rules_independent_counts _ctx =
-  (* A row matching two patterns counts once in each rule's stat; the row
-     is still dropped once (appears in `dropped` exactly once). *)
+  (* A row matching two drop rules counts once in each rule's stat; the row
+     is still dropped once (appears in [dropped] exactly once). *)
   let cfg : U.config =
     {
       rules =
@@ -139,8 +287,8 @@ let test_stats_zero_for_nonmatching_rule _ctx =
 
 (* --- load_config tests --------------------------------------------------- *)
 
-let _write_tmp contents =
-  let tmp = Stdlib.Filename.temp_file "universe_filter_test" ".sexp" in
+let _write_tmp ?(suffix = ".sexp") contents =
+  let tmp = Stdlib.Filename.temp_file "universe_filter_test" suffix in
   Stdlib.Out_channel.with_open_text tmp (fun oc ->
       Stdlib.Out_channel.output_string oc contents);
   tmp
@@ -152,6 +300,8 @@ let test_load_config_ok _ctx =
     _write_tmp
       {|((rules (
   (Symbol_pattern (name "u") (pattern "\\.U$"))
+  (Name_pattern (name "etf") (pattern "\\bETF\\b"))
+  (Exchange_equals (name "arca") (exchange "NYSE ARCA"))
   (Keep_allowlist (name "broad") (symbols (SPY QQQ))))))|}
   in
   let result = U.load_config tmp in
@@ -159,7 +309,7 @@ let test_load_config_ok _ctx =
   match result with
   | Error e -> assert_failure ("expected Ok, got Error: " ^ e)
   | Ok cfg ->
-      assert_that cfg (field (fun c -> List.length c.U.rules) (equal_to 2))
+      assert_that cfg (field (fun c -> List.length c.U.rules) (equal_to 4))
 
 let test_load_config_missing_file _ctx =
   let result = U.load_config "/nonexistent/does-not-exist.sexp" in
@@ -184,17 +334,20 @@ let test_load_config_malformed _ctx =
 let test_default_shape_parses _ctx =
   let sample =
     {|((rules (
-        (Symbol_pattern (name "suffix_units_.U") (pattern "\\.U$"))
-        (Keep_allowlist (name "broad") (symbols (SPY QQQ))))))|}
+        (Keep_allowlist (name "broad") (symbols (SPY QQQ)))
+        (Name_pattern (name "fund_etf") (pattern "(?i)(\\bETF\\b|\\bFund\\b)"))
+        (Exchange_equals (name "nyse_arca") (exchange "NYSE ARCA")))))|}
   in
   let cfg = cfg_of_string sample in
-  assert_that cfg (field (fun c -> List.length c.U.rules) (equal_to 2))
+  assert_that cfg (field (fun c -> List.length c.U.rules) (equal_to 3))
 
 (* --- CSV roundtrip ------------------------------------------------------- *)
 
 let test_csv_roundtrip _ctx =
   let tmp_dir = Stdlib.Filename.temp_dir "universe_filter_csv" "" in
   let path = tmp_dir ^ "/test.csv" in
+  (* CSV only stores symbol + sector; enriched fields ([name], [exchange])
+     round-trip as empty strings. *)
   let rows = [ row "AAPL" "IT"; row "JPM" "Financials" ] in
   (match U.write_csv path rows with
   | Ok () -> ()
@@ -208,6 +361,91 @@ let test_csv_roundtrip _ctx =
   Stdlib.Sys.rmdir tmp_dir;
   assert_that loaded (elements_are (List.map rows ~f:equal_to))
 
+(* --- load_rows_with_universe (join) ------------------------------------- *)
+
+let test_join_enriches_rows _ctx =
+  let tmp_dir = Stdlib.Filename.temp_dir "universe_filter_join" "" in
+  let csv = tmp_dir ^ "/sectors.csv" in
+  let sexp = tmp_dir ^ "/universe.sexp" in
+  Stdlib.Out_channel.with_open_text csv (fun oc ->
+      Stdlib.Out_channel.output_string oc
+        "symbol,sector\nAAPL,IT\nSPY,Financials\n");
+  Stdlib.Out_channel.with_open_text sexp (fun oc ->
+      Stdlib.Out_channel.output_string oc
+        {|(
+  ((symbol AAPL) (name "Apple Inc") (sector IT) (industry "") (market_cap 0) (exchange NASDAQ))
+  ((symbol SPY) (name "SPDR S&P 500 ETF Trust") (sector Financials) (industry "") (market_cap 0) (exchange "NYSE ARCA"))
+)|});
+  let result = U.load_rows_with_universe ~sectors_csv:csv ~universe_sexp:sexp in
+  Stdlib.Sys.remove csv;
+  Stdlib.Sys.remove sexp;
+  Stdlib.Sys.rmdir tmp_dir;
+  match result with
+  | Error e -> assert_failure ("join failed: " ^ e)
+  | Ok rows ->
+      assert_that rows
+        (elements_are
+           [
+             equal_to
+               ({
+                  symbol = "AAPL";
+                  sector = "IT";
+                  name = "Apple Inc";
+                  exchange = "NASDAQ";
+                }
+                 : U.row);
+             equal_to
+               ({
+                  symbol = "SPY";
+                  sector = "Financials";
+                  name = "SPDR S&P 500 ETF Trust";
+                  exchange = "NYSE ARCA";
+                }
+                 : U.row);
+           ])
+
+let test_join_handles_missing_universe_symbols _ctx =
+  (* Rows whose symbol is absent from universe.sexp keep empty name/exchange —
+     no crash, no data loss. *)
+  let tmp_dir = Stdlib.Filename.temp_dir "universe_filter_join_missing" "" in
+  let csv = tmp_dir ^ "/sectors.csv" in
+  let sexp = tmp_dir ^ "/universe.sexp" in
+  Stdlib.Out_channel.with_open_text csv (fun oc ->
+      Stdlib.Out_channel.output_string oc
+        "symbol,sector\nAAPL,IT\nUNKNOWN,Financials\n");
+  Stdlib.Out_channel.with_open_text sexp (fun oc ->
+      Stdlib.Out_channel.output_string oc
+        {|(
+  ((symbol AAPL) (name "Apple Inc") (sector IT) (industry "") (market_cap 0) (exchange NASDAQ))
+)|});
+  let result = U.load_rows_with_universe ~sectors_csv:csv ~universe_sexp:sexp in
+  Stdlib.Sys.remove csv;
+  Stdlib.Sys.remove sexp;
+  Stdlib.Sys.rmdir tmp_dir;
+  match result with
+  | Error e -> assert_failure ("join failed: " ^ e)
+  | Ok rows ->
+      assert_that rows
+        (elements_are
+           [
+             equal_to
+               ({
+                  symbol = "AAPL";
+                  sector = "IT";
+                  name = "Apple Inc";
+                  exchange = "NASDAQ";
+                }
+                 : U.row);
+             equal_to
+               ({
+                  symbol = "UNKNOWN";
+                  sector = "Financials";
+                  name = "";
+                  exchange = "";
+                }
+                 : U.row);
+           ])
+
 (* --- Test runner --------------------------------------------------------- *)
 
 let () =
@@ -219,7 +457,15 @@ let () =
                   "empty config is no-op" >:: test_empty_config_is_noop;
                   "symbol pattern drops matches"
                   >:: test_symbol_pattern_drops_matches;
+                  "name pattern drops ETF/Fund/Trust/Notes"
+                  >:: test_name_pattern_drops_etf_fund_etc;
+                  "name pattern is case-insensitive with (?i) flag"
+                  >:: test_name_pattern_case_insensitive;
+                  "exchange_equals drops NYSE ARCA only"
+                  >:: test_exchange_equals_drops_nyse_arca;
                   "allowlist rescues match" >:: test_allowlist_rescues_match;
+                  "allowlist rescues even when exchange rule fires"
+                  >:: test_allowlist_rescues_from_exchange_rule;
                   "multiple rules independent counts"
                   >:: test_multiple_rules_independent_counts;
                   "stats show zero for nonmatching rule"
@@ -233,4 +479,11 @@ let () =
                   "default-sexp shape parses" >:: test_default_shape_parses;
                 ];
            "csv_io" >::: [ "roundtrip" >:: test_csv_roundtrip ];
+           "universe_join"
+           >::: [
+                  "enriches rows with name + exchange"
+                  >:: test_join_enriches_rows;
+                  "missing universe symbols use empty fields"
+                  >:: test_join_handles_missing_universe_symbols;
+                ];
          ])

--- a/trading/analysis/scripts/universe_filter/universe_filter.ml
+++ b/trading/analysis/scripts/universe_filter/universe_filter.ml
@@ -1,0 +1,78 @@
+(** universe_filter — apply a sexp-driven rule-set to [data/sectors.csv].
+
+    Reads an input CSV, applies rules from
+    [dev/config/universe_filter/<name>.sexp], writes the kept rows to an output
+    CSV (separate from input by default so a human can diff and promote). Prints
+    a summary of rows in/out, per-rule drop counts, and before/after sector
+    breakdown. [-dry-run] prints only.
+
+    Example: universe_filter -input data/sectors.csv \ -output
+    data/sectors.filtered.csv \ -config dev/config/universe_filter/default.sexp
+    \ -dry-run *)
+
+open Core
+module U = Universe_filter_lib
+
+let _default_input = "data/sectors.csv"
+let _default_output = "data/sectors.filtered.csv"
+let _default_config = "dev/config/universe_filter/default.sexp"
+
+let _print_breakdown label rows =
+  printf "\n%s sector breakdown (%d rows):\n" label (List.length rows);
+  List.iter (U.sector_breakdown rows) ~f:(fun (sector, count) ->
+      let sector_disp = if String.is_empty sector then "(empty)" else sector in
+      printf "  %5d  %s\n" count sector_disp)
+
+let _print_rule_stats (result : U.filter_result) =
+  printf "\nPer-rule drop counts (raw matches, pre-allowlist rescue):\n";
+  if List.is_empty result.rule_stats then printf "  (no rules)\n"
+  else
+    List.iter result.rule_stats ~f:(fun { rule_name; drop_count } ->
+        printf "  %5d  %s\n" drop_count rule_name);
+  printf "Rescued by allow-list: %d\n" result.rescued_by_allowlist
+
+let _die msg =
+  eprintf "ERROR: %s\n%!" msg;
+  Stdlib.exit 1
+
+let _run ~input ~output ~config_path ~dry_run =
+  let cfg =
+    match U.load_config config_path with Ok c -> c | Error e -> _die e
+  in
+  let rows = match U.read_csv input with Ok r -> r | Error e -> _die e in
+  let result = U.filter cfg rows in
+  printf "Input:  %s (%d rows)\n" input (List.length rows);
+  printf "Config: %s\n" config_path;
+  _print_breakdown "BEFORE" rows;
+  _print_rule_stats result;
+  _print_breakdown "AFTER" result.kept;
+  printf "\nTotals: kept=%d dropped=%d (input=%d)\n" (List.length result.kept)
+    (List.length result.dropped)
+    (List.length rows);
+  if dry_run then printf "\n[dry-run] Not writing output.\n"
+  else
+    match U.write_csv output result.kept with
+    | Ok () -> printf "\nWrote %s (%d rows)\n" output (List.length result.kept)
+    | Error e -> _die (Printf.sprintf "write failed: %s" e)
+
+let command =
+  Command.basic ~summary:"Apply universe cleanup rules to data/sectors.csv"
+    (let%map_open.Command input =
+       flag "input"
+         (optional_with_default _default_input string)
+         ~doc:(Printf.sprintf "PATH Input CSV (default: %s)" _default_input)
+     and output =
+       flag "output"
+         (optional_with_default _default_output string)
+         ~doc:(Printf.sprintf "PATH Output CSV (default: %s)" _default_output)
+     and config_path =
+       flag "config"
+         (optional_with_default _default_config string)
+         ~doc:
+           (Printf.sprintf "PATH Rule-set sexp (default: %s)" _default_config)
+     and dry_run =
+       flag "dry-run" no_arg ~doc:" Print stats only; do not write output"
+     in
+     fun () -> _run ~input ~output ~config_path ~dry_run)
+
+let () = Command_unix.run command

--- a/trading/analysis/scripts/universe_filter/universe_filter.ml
+++ b/trading/analysis/scripts/universe_filter/universe_filter.ml
@@ -1,20 +1,21 @@
 (** universe_filter — apply a sexp-driven rule-set to [data/sectors.csv].
 
-    Reads an input CSV, applies rules from
+    Reads the input sectors CSV, joins it against [data/universe.sexp] to enrich
+    each row with instrument [name] + primary [exchange], applies rules from
     [dev/config/universe_filter/<name>.sexp], writes the kept rows to an output
     CSV (separate from input by default so a human can diff and promote). Prints
     a summary of rows in/out, per-rule drop counts, and before/after sector
     breakdown. [-dry-run] prints only.
 
-    Example: universe_filter -input data/sectors.csv \ -output
-    data/sectors.filtered.csv \ -config dev/config/universe_filter/default.sexp
-    \ -dry-run *)
+    If [-universe] is empty or missing, rows are loaded without enrichment —
+    useful for rule-sets that only need [symbol] + [sector]. *)
 
 open Core
 module U = Universe_filter_lib
 
 let _default_input = "data/sectors.csv"
 let _default_output = "data/sectors.filtered.csv"
+let _default_universe = "data/universe.sexp"
 let _default_config = "dev/config/universe_filter/default.sexp"
 
 let _print_breakdown label rows =
@@ -35,13 +36,21 @@ let _die msg =
   eprintf "ERROR: %s\n%!" msg;
   Stdlib.exit 1
 
-let _run ~input ~output ~config_path ~dry_run =
+let _load_rows ~input ~universe =
+  if String.is_empty universe then U.read_csv input
+  else U.load_rows_with_universe ~sectors_csv:input ~universe_sexp:universe
+
+let _run ~input ~output ~config_path ~universe ~dry_run =
   let cfg =
     match U.load_config config_path with Ok c -> c | Error e -> _die e
   in
-  let rows = match U.read_csv input with Ok r -> r | Error e -> _die e in
+  let rows =
+    match _load_rows ~input ~universe with Ok r -> r | Error e -> _die e
+  in
   let result = U.filter cfg rows in
   printf "Input:  %s (%d rows)\n" input (List.length rows);
+  printf "Universe: %s\n"
+    (if String.is_empty universe then "(none)" else universe);
   printf "Config: %s\n" config_path;
   _print_breakdown "BEFORE" rows;
   _print_rule_stats result;
@@ -70,9 +79,17 @@ let command =
          (optional_with_default _default_config string)
          ~doc:
            (Printf.sprintf "PATH Rule-set sexp (default: %s)" _default_config)
+     and universe =
+       flag "universe"
+         (optional_with_default _default_universe string)
+         ~doc:
+           (Printf.sprintf
+              "PATH universe.sexp for name/exchange join (default: %s; pass \
+               empty string to disable)"
+              _default_universe)
      and dry_run =
        flag "dry-run" no_arg ~doc:" Print stats only; do not write output"
      in
-     fun () -> _run ~input ~output ~config_path ~dry_run)
+     fun () -> _run ~input ~output ~config_path ~universe ~dry_run)
 
 let () = Command_unix.run command


### PR DESCRIPTION
## Summary

Implements Item 4 from `dev/status/sector-data.md` — universe composition cleanup — as a **reusable library + binary + sexp rule-set** so we iterate on rules without code changes.

This branch contains two commits:
1. `5f86dd63` — original library + binary + sexp plumbing, with a Symbol_pattern-only rule-set that dropped only 12 rows (all false positives). Kept for review diff readability.
2. `aeb54b45` — Iteration 2: pull in `name` + `exchange` from `data/universe.sexp`, add `Name_pattern` / `Exchange_equals` rule variants, replace the default rule-set. This is what actually cuts the Financials bloat.

### Library (`trading/analysis/scripts/universe_filter/lib/`)

- Pure `filter : config -> row list -> filter_result`. Rules are a four-variant ADT:
  - `Symbol_pattern` — Perl regex over `row.symbol` (unchanged from Iteration 1).
  - `Name_pattern` — Perl regex over `row.name` (new). Prepend `(?i)` for case-insensitive match; translated to `Re.Perl.`Caseless`` since `Re.Perl` does not support inline flag groups.
  - `Exchange_equals` — exact, case-sensitive match against `row.exchange` (new).
  - `Keep_allowlist` — symbols rescued unconditionally (final override).
- Per-rule raw drop counts and allow-list rescue counts are surfaced separately in `filter_result.rule_stats` / `rescued_by_allowlist`.
- `load_rows_with_universe ~sectors_csv ~universe_sexp` joins `data/sectors.csv` against `data/universe.sexp` to populate `row.name` + `row.exchange`. Symbols absent from `universe.sexp` get `name = "" ; exchange = ""` — not dropped.

### Binary (`trading/analysis/scripts/universe_filter/universe_filter.ml`)

- Flags: `-input` / `-output` / `-config` / `-universe` / `-dry-run`. `-universe` defaults to `data/universe.sexp`; pass an empty string to disable enrichment.
- Never overwrites `data/sectors.csv`; writes `data/sectors.filtered.csv` so the human can diff and promote.

### Default config (`dev/config/universe_filter/default.sexp`)

```
((rules (
  (Keep_allowlist (name "sector_and_broad_ETFs")
                  (symbols (
                    SPY QQQ VOO VTI IWM DIA
                    XLK XLF XLE XLV XLI XLP XLY XLU XLB XLRE XLC
                    QQQM FXAIX SWPPX)))
  (Name_pattern (name "etf_fund_trust_notes")
                (pattern "(?i)(\\bETF\\b|\\bFund\\b|\\bTrust\\b|\\bNotes\\b)"))
  (Exchange_equals (name "nyse_arca")
                   (exchange "NYSE ARCA")))))
```

### Tests — 16 unit tests, all green

New cases for: Name_pattern drops + case-insensitive flag, Exchange_equals exact match (NYSE ARCA drops, NYSEARCA one-word variant preserved), allow-list rescue from Exchange_equals, universe-join enrichment, missing-from-universe symbols.

## Dry-run against live `data/sectors.csv` (9,041 rows, 2026-04-16)

```
Per-rule drop counts (raw matches, pre-allowlist rescue):
   3864  etf_fund_trust_notes
   2079  nyse_arca
Rescued by allow-list: 16

Totals: kept=4916 dropped=4125 (input=9041)
```

Sector breakdown before → after:

| sector | before | after | Δ |
|---|---:|---:|---:|
| Financials | 5,096 | 1,036 | **-4,060** |
| Health Care | 959 | 959 | 0 |
| Information Technology | 638 | 636 | -2 |
| Industrials | 626 | 626 | 0 |
| Consumer Discretionary | 482 | 482 | 0 |
| Materials | 251 | 250 | -1 |
| Real Estate | 235 | 184 | **-51** |
| Communication Services | 221 | 221 | 0 |
| Energy | 214 | 213 | -1 |
| Consumer Staples | 213 | 213 | 0 |
| Utilities | 106 | 106 | 0 |
| **total** | **9,041** | **4,916** | **-4,125** |

### Spot check — 5 dropped symbols

| symbol | name | exchange | rule |
|---|---|---|---|
| AAAA | Amplius Aggressive Asset Allocation ETF | NYSE | `etf_fund_trust_notes` |
| ABLS | Abacus FCF Small Cap Leaders ETF | NYSE | `etf_fund_trust_notes` |
| AAPY | Kurv Yield Premium Strategy Apple (AAPL) ETF | BATS | `etf_fund_trust_notes` |
| AGQ | ProShares Ultra Silver | NYSE ARCA | `nyse_arca` only |
| ACES | ALPS Clean Energy | NYSE ARCA | `nyse_arca` only |

AGQ and ACES are the interesting cases: the `nyse_arca` rule catches ETFs whose display name elides the "ETF" / "Fund" / "Trust" tokens.

### Spot check — 5 allow-list rescues

All five are on NYSE ARCA with names containing ETF / Fund / Trust — both drop rules would fire, but `Keep_allowlist` rescue is final:

| symbol | name | exchange |
|---|---|---|
| SPY | SPDR S&P 500 ETF Trust | NYSE ARCA |
| QQQ | Invesco QQQ Trust | NASDAQ |
| XLK | Technology Select Sector SPDR Fund | NYSE ARCA |
| XLF | Financial Select Sector SPDR Fund | NYSE ARCA |
| XLE | Energy Select Sector SPDR Fund | NYSE ARCA |

## Known collateral damage

51 Real Estate rows are dropped because many legitimate REITs have "Trust" in their display name (AAT "American Assets Trust Inc", ABR "Arbor Realty Trust", AKR "Acadia Realty Trust", BRT "BRT Realty Trust", …). A handful of royalty trusts in Energy (MTR, NRT, PBT, PVL) and Materials (MSB) also fall under the `Trust` keyword.

This is documented as **Item 4.1** in `dev/status/sector-data.md` and is addressable in a follow-up (add a REIT-sector allow-list clause, or narrow the `Trust` regex to `ETF Trust` / `Unit Trust` / `Statutory Trust`).

## Follow-ups (filed in `dev/status/sector-data.md` Item 4 Completed)

- **Item 4.1** — tighten `Trust` match so legitimate REITs and royalty trusts are not dropped.
- **Item 5** — add `Industry_pattern` rule variant; requires extending the Finviz scrape to also capture industry cells.
- **Item 6** — optional volume / market-cap gate using the bars cache.
- **Item 7** — reconsider `warrant_len>3_endsW` (now dropped from the default, but may be worth reintroducing in a narrowed form).

## Test plan

- [x] `dune build` passes on both commits
- [x] `dune runtest analysis/scripts/universe_filter` — 16/16 green on Iteration 2
- [x] `dune fmt` applied
- [x] Dry-run against live `data/sectors.csv` — see stats above
- [x] Spot checks of 5 drops + 5 rescues
- [ ] Reviewer: decide whether to land Item 4.1 (REIT rescue) before promoting `data/sectors.filtered.csv` to `data/sectors.csv`

Generated with Claude Code.
