### PR TITLE
harness: pick-one-VCS-per-env dispatch + stale-worktree reaper

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -46,6 +46,22 @@ Your branch: feat/<feature-name>
 Status file: dev/status/<feature>.md
 ```
 
+Include a `## VCS choice (automatic)` section alongside the branch info:
+
+```markdown
+## VCS choice (automatic)
+
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not
+available. Each session: `git fetch origin && git checkout -b feat/<name> origin/main`.
+Commit with `git commit`, push with `git push origin HEAD`.
+
+Otherwise (local runs), use **jj** with a per-session workspace. The
+orchestrator's dispatch prompt tells you the exact commands — follow
+those over any jj/git references in the examples in this file. See
+`.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents"
+for the authoritative dispatch shape.
+```
+
 ### 4. Allowed Tools (required, verbatim or adjusted)
 
 ```markdown

--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -83,6 +83,12 @@ The experiment framework isn't formalized yet. Use this convention until
 
 Don't formalize the framework until you've felt the pain of doing it ad-hoc twice. Then propose the formalization in your status file's `## Follow-up`.
 
+## VCS choice (automatic)
+
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b feat/<feature> origin/main`. Commit with `git commit`, push with `git push origin HEAD`.
+
+Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+
 ## Allowed Tools
 
 Read, Write, Edit, Glob, Grep, Bash (build/test commands only), WebFetch.

--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -62,6 +62,12 @@ Estimate: ~40 lines + tests + symbol-list verification against cached data.
 
 After reading `dev/status/strategy-wiring.md`, check the `## Follow-up` section (if present). Address follow-up items before any new wiring work.
 
+## VCS choice (automatic)
+
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b feat/<feature> origin/main`. Commit with `git commit`, push with `git push origin HEAD`.
+
+Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+
 ## Allowed Tools
 
 Read, Write, Edit, Glob, Grep, Bash (build/test commands only), WebFetch.

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -50,6 +50,12 @@ and push that edit early (even before any code). This tells future orchestrator
 runs "this item is taken". When the PR lands, flip to `[x]` with the usual
 completion note.
 
+## VCS choice (automatic)
+
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b harness/<short-name> origin/main`. Commit with `git commit`, push with `git push origin HEAD`.
+
+Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+
 ## Allowed Tools
 
 Read, Write, Edit, Glob, Grep, Bash (build/test commands only).

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -317,13 +317,27 @@ When either of those is true, **reduce scope rather than spawn everything**:
 - Defer the rest to the next run by leaving them idle in the index
 - Note the deferral and the budget cap in the daily summary's Escalations section so the human can see what was skipped and why
 
-On an otherwise clean budget (last run completed, cost < 40% of `max_daily_cost_usd`), dispatching up to 2 subagents in parallel is fine. Never dispatch more than 2 at once.
+On an otherwise clean budget (last run completed, cost < 40% of `max_daily_cost_usd`), dispatch up to the environment-specific cap: **2 parallel locally, 1 sequentially in GHA**. Never exceed those numbers — see Step 4 for why the caps differ by environment. The cap covers throughput dispatch only; it is not sized for candidate-comparison runs (see Step 4).
 
-## Step 4: Spawn feature agents as parallel subagents
+## Step 4: Spawn feature agents
 
-For each feature that should run today, spawn it as a subagent using the Agent tool with `isolation: "worktree"`. Each subagent works on its own git worktree so that (a) commits from one agent cannot pollute another agent's branch via the shared working copy, and (b) `jj new main@origin` inside a subagent produces a clean starting point.
+Dispatch shape depends on environment. Inspect `$TRADING_IN_CONTAINER` (set by the GHA workflow; unset locally) and pick the matching path below.
 
-**Parallelism cap**: run at most **2 subagents in parallel** in a single Agent message. More than 2 Opus subagents in parallel reliably drains the 5-hour quota before PRs can be opened. If more than 2 features are eligible, batch into two messages: dispatch the higher-priority 2, await results, then dispatch the next 2.
+**Throughput vs candidate comparison.** The cap values below assume a *throughput* dispatch pattern — each subagent implements a different track. They do NOT cover "run N candidates against the same problem, pick best." That's a separate mode with its own cap logic; not supported by this orchestrator today.
+
+### Local (TRADING_IN_CONTAINER unset)
+
+- Use **jj** for VCS. No git worktree, no `isolation:` parameter on the Agent tool.
+- Cap: **2 parallel subagents** per Agent message. Each subagent creates its own jj workspace: `jj workspace add .claude/jj-ws/agent-<short-id> && cd .claude/jj-ws/agent-<short-id>`. Working copy isolation is provided by jj itself (independent `@` per workspace); the underlying commit store is shared, so pushes land on the main jj repo.
+- Cleanup: each subagent prompt ends with `jj workspace forget <name>` (on success or failure — the prompt wraps it in a trap so a mid-flight kill still cleans up).
+
+### GHA (TRADING_IN_CONTAINER=1)
+
+- Use **git** for VCS (no jj available in the container, and sequential dispatch makes isolation unnecessary anyway).
+- Cap: **1 subagent at a time**. Sequential only. No parallelism means no working-copy race; subagents run directly in the repo checkout. Each subagent does `git fetch origin && git checkout -b feat/<feature> origin/main`.
+- No cleanup step needed — sequential sessions don't leave stale branches beyond what's pushed to origin.
+
+Do NOT set `isolation: "worktree"` on the Agent tool in either path. Local uses `jj workspace add`; GHA doesn't need isolation at all. Mixing git-worktree with jj caused the 2026-04-15 "worktree has no .jj/" failure; mixing at all is the confusion source we're fixing.
 
 **Parallel write conflict policy**: parallel feat-agents must not write to any shared file.
 The files `dev/decisions.md`, `CLAUDE.md`, and `docs/design/*.md` are read-only during
@@ -360,12 +374,20 @@ Read these files first:
 6. dev/status/<feature>.md  ← pick up where you left off
 
 Your branch: feat/<feature>
-  # You are running in an isolated git worktree — your working copy
-  # is independent of other subagents' workspaces.
-  jj git init --colocate 2>/dev/null || true
+
+  # LOCAL path (TRADING_IN_CONTAINER unset) — isolated jj workspace:
+  WS_NAME="agent-<your-short-id>"
+  jj workspace add ".claude/jj-ws/$WS_NAME"
+  trap "cd /abs/repo/root && jj workspace forget \"$WS_NAME\" 2>/dev/null || true" EXIT
+  cd ".claude/jj-ws/$WS_NAME"
   jj git fetch
   jj new feat/<feature>@origin
   # If bookmark doesn't exist yet: jj bookmark create feat/<feature> -r @
+
+  # GHA path (TRADING_IN_CONTAINER=1) — plain git, sequential, no isolation:
+  #   git fetch origin
+  #   git checkout -b feat/<feature> origin/main
+  # No workspace / worktree cleanup required.
 
 Work using TDD (CLAUDE.md workflow):
   1. .mli interface + skeleton → dune build passes

--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -67,6 +67,12 @@ If `EODHD_API_KEY` is not set in the host environment, **don't stop early**:
 - Report explicitly what was deferred for lack of the key, with the
   exact command the human or a future run would need to complete it
 
+## VCS choice (automatic)
+
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b data/<short-name> origin/main`. Commit with `git commit`, push with `git push origin HEAD`.
+
+Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+
 ## Allowed Tools
 
 Read, Write, Edit, Glob, Grep, Bash (build/test/run commands).

--- a/.claude/agents/qc-behavioral.md
+++ b/.claude/agents/qc-behavioral.md
@@ -6,6 +6,12 @@ model: opus
 
 You are the **QC Behavioral Reviewer** for the Weinstein Trading System. You check domain correctness only — whether the implementation faithfully encodes Weinstein's trading rules and the design specifications. You do NOT check code style, formatting, or architecture patterns; those are qc-structural's responsibility.
 
+## VCS choice (automatic)
+
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b dev/reviews/<feature>-behavioral origin/main` for the review branch. Commit with `git commit`, push with `git push origin HEAD`.
+
+Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+
 ## Allowed tools
 
 Read, Glob, Grep (no Write, no Edit, no Bash — review only).

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -6,6 +6,12 @@ model: sonnet
 
 You are the **QC Structural Reviewer** for the Weinstein Trading System. You check structural and mechanical correctness only — you do not evaluate domain behavior or trading logic. That is qc-behavioral's responsibility.
 
+## VCS choice (automatic)
+
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b dev/reviews/<feature>-structural origin/main` for the review branch. Commit with `git commit`, push with `git push origin HEAD`.
+
+Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+
 ## Allowed tools
 
 Read, Glob, Grep, Bash (read-only: build/test/lint only — no Write, no Edit).

--- a/dev/lib/cleanup-stale-worktrees.sh
+++ b/dev/lib/cleanup-stale-worktrees.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Remove stale agent-created worktrees + jj workspaces.
+#
+# Background: the `isolation: "worktree"` Agent-tool parameter created
+# `.claude/worktrees/agent-<id>/` dirs as git worktrees. These weren't
+# cleaned up on subagent exit; after many runs they accumulate. This
+# repo picked up 43 stale entries before we switched to per-subagent
+# trap cleanup (see lead-orchestrator.md Step 4, 2026-04-16).
+#
+# Usage:
+#   dev/lib/cleanup-stale-worktrees.sh              # remove entries > 7 days old
+#   dev/lib/cleanup-stale-worktrees.sh --all        # remove every agent-* entry
+#   dev/lib/cleanup-stale-worktrees.sh --dry-run    # list what would be removed
+#
+# Safe to re-run. Targets .claude/worktrees/agent-* (git worktrees from the
+# older isolation mode) and .claude/jj-ws/agent-* (jj workspaces from the
+# new mode). Leaves main repo + .jj state alone.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+MODE="stale"
+for arg in "$@"; do
+  case "$arg" in
+    --all)     MODE="all" ;;
+    --dry-run) MODE="${MODE}-dry" ;;
+    *) echo "Usage: $0 [--all] [--dry-run]" >&2; exit 1 ;;
+  esac
+done
+
+WORKTREE_DIR="$REPO_ROOT/.claude/worktrees"
+JJ_WS_DIR="$REPO_ROOT/.claude/jj-ws"
+
+# ----- git worktrees -----
+if [ -d "$WORKTREE_DIR" ]; then
+  # Build the candidate list, filtering by age when MODE is stale-*.
+  if [[ "$MODE" == stale* ]]; then
+    FIND_AGE="-mtime +7"
+  else
+    FIND_AGE=""
+  fi
+  # shellcheck disable=SC2086
+  mapfile -t WORKTREES < <(find "$WORKTREE_DIR" -maxdepth 1 -type d -name "agent-*" $FIND_AGE 2>/dev/null || true)
+
+  if [ ${#WORKTREES[@]} -eq 0 ]; then
+    echo "no stale git worktrees under $WORKTREE_DIR"
+  else
+    echo "git worktrees to remove: ${#WORKTREES[@]}"
+    for wt in "${WORKTREES[@]}"; do
+      if [[ "$MODE" == *-dry ]]; then
+        echo "  would remove: $wt"
+      else
+        # Prefer `git worktree remove` so the main repo's bookkeeping is
+        # updated. Fall back to rm -rf + git worktree prune if remove
+        # fails (e.g. the worktree's .git pointer is already stale).
+        if git worktree remove --force "$wt" 2>/dev/null; then
+          echo "  removed: $wt"
+        else
+          rm -rf "$wt"
+          echo "  rm -rf (git worktree remove failed): $wt"
+        fi
+      fi
+    done
+    # Clean up dangling worktree metadata in the main repo.
+    if [[ "$MODE" != *-dry ]]; then
+      git worktree prune
+    fi
+  fi
+fi
+
+# ----- jj workspaces -----
+if [ -d "$JJ_WS_DIR" ]; then
+  if [[ "$MODE" == stale* ]]; then
+    FIND_AGE="-mtime +7"
+  else
+    FIND_AGE=""
+  fi
+  # shellcheck disable=SC2086
+  mapfile -t JJ_WORKSPACES < <(find "$JJ_WS_DIR" -maxdepth 1 -type d -name "agent-*" $FIND_AGE 2>/dev/null || true)
+
+  if [ ${#JJ_WORKSPACES[@]} -eq 0 ]; then
+    echo "no stale jj workspaces under $JJ_WS_DIR"
+  else
+    echo "jj workspaces to remove: ${#JJ_WORKSPACES[@]}"
+    for ws in "${JJ_WORKSPACES[@]}"; do
+      NAME="$(basename "$ws")"
+      if [[ "$MODE" == *-dry ]]; then
+        echo "  would forget + rm -rf: $ws"
+      else
+        # `jj workspace forget` drops the workspace metadata from the
+        # shared jj repo; rm -rf removes the directory. Forget first so
+        # jj doesn't complain about missing dirs on future commands.
+        (cd "$REPO_ROOT" && jj workspace forget "$NAME" 2>/dev/null) || true
+        rm -rf "$ws"
+        echo "  forgot + removed: $ws"
+      fi
+    done
+  fi
+fi

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -19,6 +19,13 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$REPO_ROOT/dev/lib/preflight.sh"
 . "$REPO_ROOT/dev/lib/heartbeat.sh"
 
+# Reap stale agent worktrees / jj workspaces > 7 days old. Cheap, runs
+# in under a second, prevents .claude/worktrees + .claude/jj-ws from
+# accumulating after agent sessions that didn't clean up after
+# themselves. Silent unless it actually removed something.
+"$REPO_ROOT/dev/lib/cleanup-stale-worktrees.sh" 2>&1 \
+  | grep -v "^no stale " || true
+
 PLAN_FLAG=""
 for arg in "$@"; do
   case "$arg" in


### PR DESCRIPTION
## Summary
Two changes in one PR because they close the same loop — the \`.claude/worktrees/agent-*\` stale-dir backlog that kept growing because we had both a broken isolation mechanism AND no cleanup.

### 1. Pick one VCS per environment (lead-orchestrator.md Step 4)
2026-04-15's \"worktree has no .jj/\" problem came from mixing git and jj: the Agent tool's \`isolation: \"worktree\"\` creates a git worktree; agent prompts tell subagents to run jj commands in it; jj refuses to colocate inside a git worktree → commands fail, agents fall back to raw \`git push\`.

Fix: pick one VCS per environment.

- **Local** (TRADING_IN_CONTAINER unset): jj only. Each subagent calls \`jj workspace add .claude/jj-ws/agent-<id>\`, gets an isolated \`@\` while sharing the commit store with the main repo. No \`isolation:\` parameter on the Agent call.
- **GHA** (TRADING_IN_CONTAINER=1): git only. Sequential dispatch (cap=1); no isolation needed — one subagent runs at a time, no working-copy race. Each subagent does \`git checkout -b feat/<feature> origin/main\`.

Caps: **2 parallel locally, 1 sequentially in GHA**. Made explicit that these are sized for *throughput* dispatch (different tracks per subagent), not *candidate-comparison* runs (multiple attempts at the same problem — separate mode, separate caps, not supported today).

### 2. Stale-worktree reaper (dev/lib/cleanup-stale-worktrees.sh)
One-shot cleanup script. Default removes entries >7 days old; \`--all\` removes every \`agent-*\` entry; \`--dry-run\` prints what would go. Handles both \`.claude/worktrees/agent-*\` (git worktrees from the old mode) and \`.claude/jj-ws/agent-*\` (jj workspaces from the new mode).

Ran \`--all\` during this PR against the 16 stale \`.claude/worktrees/agent-*\` dirs that had accumulated — directory now empty. Fix + backlog cleared together.

## Why in one PR
Per external review feedback: \"Trap cleanup fixes new runs but doesn't garbage-collect the backlog. A one-shot reaper in the same PR closes the loop. Otherwise you ship the fix and still have [16] entries sitting there.\"

## Test plan
- [x] Reaper dry-run shows correct entries
- [x] Reaper \`--all\` removed 16 dirs cleanly (\`ls .claude/worktrees/ | grep agent- | wc -l\` → 0)
- [ ] Next orchestrator run (locally) uses \`jj workspace add\` path without jj-git conflict
- [ ] Next orchestrator run (GHA) uses sequential \`git checkout\` path