### PR TITLE
fix(orchestrator-workflow): bash post-steps + show_full_output + date fix

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -77,13 +77,22 @@ jobs:
           # Full history so jj can see main@origin and rebase properly.
           fetch-depth: 0
 
+      - name: Compute today's date
+        id: today
+        run: echo "date=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - name: Run lead-orchestrator
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          # show_full_output: true surfaces tool-call details in the workflow
+          # log so we can see what subagents (if any) were dispatched. The
+          # action's default (false) hides this "for security"; we accept the
+          # tradeoff because this repo is public and single-developer.
+          show_full_output: true
           prompt: |
-            Run the daily orchestrator session. Today is $(date +%Y-%m-%d).
+            Run the daily orchestrator session. Today is ${{ steps.today.outputs.date }}.
             Read .claude/agents/lead-orchestrator.md and follow it end to end.
           claude_args: |
             --agent lead-orchestrator
@@ -94,6 +103,7 @@ jobs:
         id: publish-summary
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        shell: bash
         run: |
           set -euo pipefail
           DATE="$(date +%F)"
@@ -144,6 +154,7 @@ jobs:
       - name: Fail on escalations
         env:
           SUMMARY: ${{ steps.publish-summary.outputs.summary_path }}
+        shell: bash
         run: |
           set -euo pipefail
           # Extract the ## Escalations section body (up to the next H2) and


### PR DESCRIPTION
## Three fixes observed from run 24494353361

### 1. bash for post-steps (sh rejects set -o pipefail)
Previously `Push daily summary branch + open PR` ran under sh by default and died immediately:
`/__w/_temp/...sh: 1: set: Illegal option -o pipefail`
Adding `shell: bash` to both post-steps preserves `set -euo pipefail` semantics.

### 2. show_full_output: true
The action hides Claude's tool-call stream by default. Run 1's logs had zero `"tool_use"` events and zero `"subagent_type"` references — we couldn't tell whether subagents dispatched or not. $4.37 cost + 61 turns + no artifacts produced (no daily summary file, no `ops/daily-*` branch) is consistent with "Claude read state files but never invoked the Agent tool." Visibility is the first thing to fix before we can diagnose further.

### 3. Fix date interpolation in the prompt
Previous: `Today is $(date +%Y-%m-%d)` — YAML strings don't expand shell. Claude literally saw the string `$(date +%Y-%m-%d)`. Now a preceding step exports today's date via GITHUB_OUTPUT and the prompt uses `${{ steps.today.outputs.date }}`.

## Known-good from run 1 (worth documenting)
- Auth, container setup, action invocation: all worked
- Cost observability: `total_cost_usd` available in action result JSON
- No rate-limit issues in 9.5 min

## Test plan
- [ ] Re-run `workflow_dispatch`. Expect: post-steps complete, log shows tool_use events (can now see what Claude did), daily summary PR appears, date in summary is a real date.