### PR TITLE
harness: T3-A harness scaffolding review (Check 7 in deep_scan.sh)

### DIFF
--- a/.claude/agents/health-scanner.md
+++ b/.claude/agents/health-scanner.md
@@ -124,7 +124,15 @@ Scan `dev/reviews/*.md` for NEEDS_REWORK findings that were subsequently re-revi
 
 **Step 8: Harness scaffolding review**
 
-Read `dev/status/harness.md` T1 Completed section. For each completed item, assess whether the verification step is still being exercised (e.g., the linter still runs, the compliance check still fires on violations). Flag any harness component whose underlying assumption may have been superseded.
+Check 7 in `trading/devtools/checks/deep_scan.sh` (already run in Phase 1) performs this check automatically and appends a `## Harness Scaffolding` section to the report. It covers three heuristics:
+
+- **H1** — shell scripts in `trading/devtools/checks/` not referenced in any dune file, GitHub workflow YAML, other script in the same directory, or any `.claude/agents/*.md`. Exempt: `_check_lib.sh`, `deep_scan.sh`, `write_audit.sh`.
+- **H2** — OCaml linter binaries (`fn_length_linter.exe`, `cc_linter.exe`, `nesting_linter.exe`) that are built but whose `%{exe:...}` reference does not appear in `trading/devtools/checks/dune`.
+- **H3** — `.claude/agents/*.md` files that reference a `devtools/checks/*.sh` path that no longer exists on disk.
+
+Output format: one line per component — `PASS: <name>` if referenced/wired, `WARNING: <name> — <reason>` if not. No FAILs (advisory only).
+
+If Phase 1 produced a `## Harness Scaffolding` section with WARNING lines, include those in the `## Warnings` section of this report. If all lines are PASS, record it as an Info item: "Harness scaffolding: all N components pass."
 
 **Step 9: Append agentic findings**
 

--- a/dev/plans/t3a-harness-scaffolding-review-2026-04-16.md
+++ b/dev/plans/t3a-harness-scaffolding-review-2026-04-16.md
@@ -1,0 +1,141 @@
+# Plan: T3-A Harness Scaffolding Review (Check 7 in deep_scan.sh)
+
+**Date:** 2026-04-16
+**Item:** T3-A — `health-scanner` deep scan, harness scaffolding review
+**Branch:** `harness/t3a-harness-scaffolding-review`
+
+---
+
+## 1. Context
+
+`trading/devtools/checks/deep_scan.sh` currently implements six checks:
+1. Dead code detection
+2. Design doc drift
+3. TODO/FIXME/HACK accumulation
+4. Size violations
+5. Follow-up item count
+6. QC calibration audit
+
+T3-A in `dev/status/harness.md` has one remaining open sub-item:
+"harness scaffolding review (flag unused harness components)".
+
+The design in `docs/design/harness-engineering-plan.md` §T3-A states:
+> **Harness scaffolding review**: flag harness components (QC checklist items,
+> orchestrator steps) that have not triggered a correction in the last N runs —
+> candidates for removal as model capability grows.
+
+The task prompt narrows the definition of "harness components" to:
+- Shell scripts in `trading/devtools/checks/`
+- OCaml linter binaries in `trading/devtools/{fn_length_linter,cc_linter,nesting_linter,...}`
+- Agent-compliance helpers
+
+"Unused" = not referenced from dune files, GitHub workflow YAMLs, other
+`devtools/checks/*.sh` scripts, or any `.claude/agents/*.md` definition.
+
+Output shape: Check 7 appends to `dev/health/<DATE>-deep.md` under
+`## Harness Scaffolding` with per-item PASS or WARNING lines.
+No FAILs — this is a heuristic audit, not a gate.
+
+---
+
+## 2. Approach
+
+Implement Check 7 as a shell function block inside `deep_scan.sh`, following
+the same pattern as Checks 1–6: iterate over harness component files, test
+each one against the heuristics, accumulate findings into `WARNINGS`/`INFO`
+via `add_warning`/`add_info`, and write a dedicated detail section
+`## Harness Scaffolding` at report-generation time.
+
+**Three heuristics (kept minimal to avoid noise):**
+
+### H1: Shell script not referenced anywhere meaningful
+A script in `trading/devtools/checks/` is "unused" if its filename does not
+appear in:
+- Any `dune` file under `trading/devtools/checks/`
+- Any `.github/workflows/*.yml` file
+- Any other `*.sh` file under `trading/devtools/checks/` (source/called chain)
+- Any `.claude/agents/*.md` agent definition
+
+`_check_lib.sh` is exempt — it's a library, not a standalone script.
+`deep_scan.sh` is also exempt — it's run manually/externally, not from dune.
+
+### H2: OCaml linter binary not attached to any dune runtest rule
+A linter binary (`fn_length_linter.exe`, `cc_linter.exe`, etc.) is unused if
+its basename does not appear in the `dune` file under `trading/devtools/checks/`
+as a `%{exe:...}` reference.
+
+### H3: Agent definitions referencing a harness script path that no longer exists
+Scan `.claude/agents/*.md` for path patterns like `devtools/checks/*.sh`,
+`trading/devtools/checks/*.sh`, or similar. For each match, check whether the
+path resolves to a real file from repo root.
+
+**Why these three and not others:**
+- H1 and H2 cover the primary "dead harness component" risk — scripts/binaries
+  that were scaffolded but never wired in.
+- H3 covers the inverse — agent definitions that refer to deleted paths (broken
+  references). These are operationally dangerous: the health-scanner might try
+  to invoke a script that no longer exists.
+- We do NOT invent a "hasn't triggered a correction in N runs" metric because
+  there is no audit trail that records which harness check fired and caused a
+  rework. That metric would require T3-D audit trail integration and is out of
+  scope for this item.
+
+**Output:** `## Harness Scaffolding` section appended to the existing deep
+report. Each harness component gets one line:
+- `PASS: <component>` — all heuristics clear
+- `WARNING: <component> — <reason>`
+
+No FAIL lines (this is advisory, not a gate).
+
+---
+
+## 3. Files to change
+
+| File | Change |
+|---|---|
+| `trading/devtools/checks/deep_scan.sh` | Add Check 7 block + `## Harness Scaffolding` section in report |
+| `.claude/agents/health-scanner.md` | Update Phase 2 Step 8 to describe Check 7 and its output format |
+| `docs/design/harness-engineering-plan.md` | Annotate T3-A harness-scaffolding-review as complete |
+| `dev/status/harness.md` | Flip `[~]` → `[x]` with completion note |
+| `dev/plans/t3a-harness-scaffolding-review-2026-04-16.md` | This plan file |
+
+No dune file changes required — `deep_scan.sh` is not wired into `dune runtest`
+(it runs weekly, standalone).
+
+---
+
+## 4. Risks / unknowns
+
+- **False positives on H1**: `write_audit.sh` and `deep_scan.sh` are run
+  by humans or the health-scanner agent directly, not from dune or workflows.
+  These must be explicitly exempted from H1.
+- **Sandboxing**: The `deep_scan.sh` script uses `repo_root` from `_check_lib.sh`
+  when run standalone. Check 7 uses the same `$REPO_ROOT` that the rest of the
+  script already computes.
+- **`TRADING_IN_CONTAINER` vs local paths**: The script already handles this
+  via `_check_lib.sh`'s `repo_root()` function. No new path logic needed.
+
+---
+
+## 5. Acceptance criteria
+
+- `sh trading/devtools/checks/deep_scan.sh` produces a `dev/health/YYYY-MM-DD-deep.md`
+  that contains a `## Harness Scaffolding` section.
+- All current scripts in `trading/devtools/checks/` that ARE referenced get
+  PASS lines.
+- The section reports WARNING for any component that genuinely matches a
+  heuristic.
+- `dune build && dune runtest` continues to pass (no changes to dune-tracked
+  files that could break the build).
+- health-scanner.md Phase 2 Step 8 describes what Check 7 does and what
+  output format it produces.
+
+---
+
+## 6. Out of scope
+
+- Wiring Check 7 into `dune runtest` — deep_scan.sh is intentionally standalone
+- Heuristic for "hasn't triggered a correction in N runs" (requires audit trail integration)
+- Checking `write_audit.sh` or `ops-data` agent scripts beyond what H1 covers
+- Any changes to feature code under `trading/trading/`, `trading/analysis/`, or
+  `analysis/`

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -1,6 +1,6 @@
 # Status: harness
 
-## Last updated: 2026-04-14
+## Last updated: 2026-04-16
 
 ## Status
 IN_PROGRESS
@@ -59,7 +59,7 @@ IN_PROGRESS
 
 - [x] T3-A: `health-scanner` agent — deep scan (weekly: dead code, design doc drift, TODO accumulation, size violations) — DONE: see completion note below
 - [x] T3-A: `health-scanner` deep scan — QC calibration audit (verdicts vs regression history) — DONE: see completion note below
-- [~] T3-A: `health-scanner` deep scan — harness scaffolding review (flag unused harness components)
+- [x] T3-A: `health-scanner` deep scan — harness scaffolding review (flag unused harness components) — DONE: Check 7 in `trading/devtools/checks/deep_scan.sh`; three heuristics (script not referenced, linter binary not wired, broken agent path ref); output under `## Harness Scaffolding` in `dev/health/YYYY-MM-DD-deep.md`. Verify: `sh trading/devtools/checks/deep_scan.sh` — report contains `## Harness Scaffolding` section.
 - [x] T3-A: `health-scanner` deep scan — feat-agent template compliance check (covered by T1-I: `agent_compliance_check.sh`)
 - [x] T3-B: AVR loop closure in `lead-orchestrator` (auto-dispatch QC on READY_FOR_REVIEW)
 - [ ] T3-C: Cross-feature context injection (beyond T1-E baseline — superseded for basic case)

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -59,7 +59,7 @@ IN_PROGRESS
 
 - [x] T3-A: `health-scanner` agent — deep scan (weekly: dead code, design doc drift, TODO accumulation, size violations) — DONE: see completion note below
 - [x] T3-A: `health-scanner` deep scan — QC calibration audit (verdicts vs regression history) — DONE: see completion note below
-- [ ] T3-A: `health-scanner` deep scan — harness scaffolding review (flag unused harness components)
+- [~] T3-A: `health-scanner` deep scan — harness scaffolding review (flag unused harness components)
 - [x] T3-A: `health-scanner` deep scan — feat-agent template compliance check (covered by T1-I: `agent_compliance_check.sh`)
 - [x] T3-B: AVR loop closure in `lead-orchestrator` (auto-dispatch QC on READY_FOR_REVIEW)
 - [ ] T3-C: Cross-feature context injection (beyond T1-E baseline — superseded for basic case)

--- a/docs/design/harness-engineering-plan.md
+++ b/docs/design/harness-engineering-plan.md
@@ -381,6 +381,12 @@ Writes to: `dev/health/<YYYY-MM-DD>-fast.md`. Agent definition: `.claude/agents/
   candidates for removal as model capability grows. Principle: *every harness
   component encodes an assumption about what the model cannot do on its own;*
   review those assumptions periodically.
+  **DONE (2026-04-16)**: Implemented as Check 7 in `trading/devtools/checks/deep_scan.sh`.
+  Three heuristics: H1 (shell script not referenced in dune/workflows/agents),
+  H2 (OCaml linter binary not wired into dune runtest), H3 (agent definition
+  references a harness script path that no longer exists). Output appended to
+  `dev/health/YYYY-MM-DD-deep.md` under `## Harness Scaffolding` — per-component
+  PASS/WARNING lines, no FAILs. See `dev/plans/t3a-harness-scaffolding-review-2026-04-16.md`.
 
 ### T3-B: AVR loop closure in `lead-orchestrator`
 

--- a/trading/devtools/checks/deep_scan.sh
+++ b/trading/devtools/checks/deep_scan.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 # Deep scan for health-scanner agent (T3-A).
 #
-# Runs weekly (not on every PR). Performs six read-only analyses:
+# Runs weekly (not on every PR). Performs seven read-only analyses:
 #   1. Dead code detection — .ml files not referenced in any dune file
 #   2. Design doc drift — module structure vs eng-design docs
 #   3. TODO/FIXME/HACK accumulation
 #   4. Size violations — files >300 lines without @large-module
 #   5. Follow-up item count (from status files)
 #   6. QC calibration audit — verdicts vs current test health
+#   7. Harness scaffolding review — flag unused or broken harness components
 #
 # Output: dev/health/YYYY-MM-DD-deep.md
 #
@@ -416,6 +417,152 @@ for review_file in "${REPO_ROOT}"/dev/reviews/*.md; do
 done
 
 # ────────────────────────────────────────────────────────────────
+# Check 7: Harness scaffolding review
+#
+# Three heuristics (all advisory — WARNING or PASS, no FAIL):
+#
+#   H1: Shell script in trading/devtools/checks/ not referenced from any
+#       dune file, GitHub workflow YAML, other *.sh in the same dir, or
+#       any .claude/agents/*.md.  Exemptions: _check_lib.sh (library),
+#       deep_scan.sh (run manually/by agent), write_audit.sh (run by
+#       humans / ops-data agent, no dune rule).
+#
+#   H2: OCaml linter binary (fn_length_linter, cc_linter, nesting_linter)
+#       whose %{exe:...} reference does not appear in
+#       trading/devtools/checks/dune — built but never wired into runtest.
+#
+#   H3: .claude/agents/*.md references a harness script path
+#       (matching "devtools/checks/*.sh" pattern) that does not exist
+#       in the repo — broken reference in an agent definition.
+# ────────────────────────────────────────────────────────────────
+
+SCAFFOLD_DETAILS=""
+
+# Exempt scripts: library helper, the deep scan itself, audit writer.
+_is_exempt_script() {
+  case "$(basename "$1")" in
+    _check_lib.sh|deep_scan.sh|write_audit.sh) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# H1: shell scripts not referenced anywhere meaningful
+CHECKS_DIR="${TRADING_DIR}/devtools/checks"
+AGENTS_DIR="${REPO_ROOT}/.claude/agents"
+WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+CHECKS_DUNE="${CHECKS_DIR}/dune"
+
+for sh_file in "${CHECKS_DIR}"/*.sh; do
+  [ -f "$sh_file" ] || continue
+  _is_exempt_script "$sh_file" && continue
+
+  script_name="$(basename "$sh_file")"
+  found=false
+
+  # Check in dune file
+  if [ -f "$CHECKS_DUNE" ] && grep -q "$script_name" "$CHECKS_DUNE" 2>/dev/null; then
+    found=true
+  fi
+
+  # Check in GitHub workflow YAMLs
+  if ! $found && [ -d "$WORKFLOWS_DIR" ]; then
+    if grep -rl "$script_name" "$WORKFLOWS_DIR" 2>/dev/null | grep -q .; then
+      found=true
+    fi
+  fi
+
+  # Check in other *.sh files in the same directory (source/call chain)
+  if ! $found; then
+    for other_sh in "${CHECKS_DIR}"/*.sh; do
+      [ -f "$other_sh" ] || continue
+      [ "$other_sh" = "$sh_file" ] && continue
+      if grep -q "$script_name" "$other_sh" 2>/dev/null; then
+        found=true
+        break
+      fi
+    done
+  fi
+
+  # Check in agent definitions
+  if ! $found && [ -d "$AGENTS_DIR" ]; then
+    if grep -rl "$script_name" "$AGENTS_DIR" 2>/dev/null | grep -q .; then
+      found=true
+    fi
+  fi
+
+  if $found; then
+    SCAFFOLD_DETAILS="${SCAFFOLD_DETAILS}PASS: \`${script_name}\` — referenced\n"
+  else
+    add_warning "Harness scaffolding: \`${script_name}\` not referenced in dune, workflows, other scripts, or agent definitions"
+    SCAFFOLD_DETAILS="${SCAFFOLD_DETAILS}WARNING: \`${script_name}\` — not referenced in dune, workflows, other scripts, or agent definitions\n"
+  fi
+done
+
+# H2: OCaml linter binaries not wired into dune runtest
+for linter_dir in "${TRADING_DIR}/devtools"/*/; do
+  [ -d "$linter_dir" ] || continue
+  linter_name="$(basename "$linter_dir")"
+  # Only check directories with an OCaml executable (has a dune file with "executable")
+  linter_dune="${linter_dir}dune"
+  [ -f "$linter_dune" ] || continue
+  grep -q '(executable' "$linter_dune" 2>/dev/null || continue
+
+  # Extract the executable name from the dune file
+  exe_name="$(grep '(name ' "$linter_dune" 2>/dev/null | head -1 | sed 's/.*name[[:space:]]*//' | tr -d '()[:space:]')"
+  [ -z "$exe_name" ] && continue
+
+  # Skip the checks dir itself (it has no executables, only shell scripts)
+  [ "$linter_name" = "checks" ] && continue
+
+  # Check if %{exe:../<linter_name>/<exe_name>.exe} appears in the checks dune
+  if [ -f "$CHECKS_DUNE" ] && grep -q "${exe_name}[.]exe" "$CHECKS_DUNE" 2>/dev/null; then
+    SCAFFOLD_DETAILS="${SCAFFOLD_DETAILS}PASS: \`${linter_name}/${exe_name}.exe\` — wired into dune runtest\n"
+  else
+    add_warning "Harness scaffolding: \`${linter_name}/${exe_name}.exe\` built but not referenced in \`devtools/checks/dune\`"
+    SCAFFOLD_DETAILS="${SCAFFOLD_DETAILS}WARNING: \`${linter_name}/${exe_name}.exe\` — built but not referenced in devtools/checks/dune\n"
+  fi
+done
+
+# H3: agent definitions referencing a harness script path that no longer exists.
+# Only fires when the agent file explicitly mentions a devtools/checks/*.sh
+# path.  Relative paths used in code-block examples (e.g. ../devtools/…)
+# are normalised before the existence check so they don't produce noise.
+if [ -d "$AGENTS_DIR" ]; then
+  for agent_file in "${AGENTS_DIR}"/*.md; do
+    [ -f "$agent_file" ] || continue
+    agent_name="$(basename "$agent_file")"
+    # Extract paths matching *devtools/checks/*.sh from the agent definition.
+    # grep -o emits one match per line; filter empty lines defensively.
+    ref_paths="$(grep -o '[a-zA-Z0-9_./]*devtools/checks/[a-zA-Z0-9_.-]*\.sh' \
+      "$agent_file" 2>/dev/null | sort -u || true)"
+    [ -z "$ref_paths" ] && continue
+
+    while IFS= read -r ref_path; do
+      # Skip empty lines (defensive)
+      [ -z "$ref_path" ] && continue
+      # Normalize: strip leading "../" sequences and "trading/" prefix so
+      # paths like "../devtools/checks/foo.sh" resolve from TRADING_DIR.
+      norm_path="$ref_path"
+      while echo "$norm_path" | grep -q '^\.\./' 2>/dev/null; do
+        norm_path="${norm_path#../}"
+      done
+      norm_path="${norm_path#trading/}"
+      # Try resolving from TRADING_DIR and from REPO_ROOT
+      if [ -f "${TRADING_DIR}/${norm_path}" ] || \
+         [ -f "${REPO_ROOT}/${norm_path}" ] || \
+         [ -f "${REPO_ROOT}/trading/${norm_path}" ]; then
+        : # path exists — no finding
+      else
+        add_warning "Harness scaffolding: \`${agent_name}\` references \`${ref_path}\` which does not exist on disk"
+        SCAFFOLD_DETAILS="${SCAFFOLD_DETAILS}WARNING: \`${agent_name}\` — references missing path \`${ref_path}\`\n"
+      fi
+    done << EOF
+${ref_paths}
+EOF
+  done
+fi
+
+# ────────────────────────────────────────────────────────────────
 # Generate report
 # ────────────────────────────────────────────────────────────────
 
@@ -480,6 +627,12 @@ fi
 if [ -n "$QC_CAL_DETAILS" ]; then
   printf "\n## QC Calibration Detail\n" >> "$OUTPUT_FILE"
   printf '%b' "$QC_CAL_DETAILS" >> "$OUTPUT_FILE"
+fi
+
+if [ -n "$SCAFFOLD_DETAILS" ]; then
+  printf "\n## Harness Scaffolding\n" >> "$OUTPUT_FILE"
+  printf "Per-component audit (PASS = referenced/wired, WARNING = unused or broken reference):\n\n" >> "$OUTPUT_FILE"
+  printf '%b' "$SCAFFOLD_DETAILS" >> "$OUTPUT_FILE"
 fi
 
 echo ""


### PR DESCRIPTION
Extends `deep_scan.sh` with Check 7 — harness scaffolding review. Three heuristics flag unused harness components:

- H1: shell scripts in `trading/devtools/checks/` not referenced from any dune file, workflow, other check script, or agent definition
- H2: linter OCaml binaries defined but not attached to any `(test ...)` or `(rule ...)`
- H3: agent `.claude/agents/*.md` references to harness script paths that no longer exist

Output lands in a new `## Harness Scaffolding` section of `dev/health/<DATE>-deep.md`. Current inventory (12 components) all pass.

Also updates `.claude/agents/health-scanner.md` Phase 2 Step 8 and `docs/design/harness-engineering-plan.md` T3-A note.

Plan: `dev/plans/t3a-harness-scaffolding-review-2026-04-16.md` (committed first). See `dev/status/harness.md` for the item tick.

---
Opened by lead-orchestrator 2026-04-16 (jst fallback — container has git-only checkout).