### PR TITLE
ops(universe-filter): REIT / royalty-trust rescue (sector-data Item 4.1)

### DIFF
--- a/dev/config/universe_filter/default.sexp
+++ b/dev/config/universe_filter/default.sexp
@@ -3,6 +3,8 @@
 ; Rules: evaluated in declaration order.
 ;   - Keep_allowlist: symbols in the list are preserved regardless of any drop
 ;     rule. Rescue is final — cannot be overridden.
+;   - Keep_if_sector: rows whose sector matches are preserved regardless of any
+;     drop rule. Rescue is final — cannot be overridden.
 ;   - Symbol_pattern: Perl-style regex against [row.symbol]. Drops on match.
 ;   - Name_pattern: Perl-style regex against [row.name] (joined from
 ;     universe.sexp). Prepend [(?i)] for case-insensitive matching.
@@ -21,6 +23,16 @@
 ;   - Exchange_equals "NYSE ARCA" is a strong ETF signal (NYSE Arca is
 ;     the primary US ETF listing venue).
 ;
+; Item 4.1 (2026-04-16): collateral damage fix — option (a).
+; The Name_pattern above swept up 51 Real Estate rows (legitimate REITs
+; like "American Assets Trust", "Arbor Realty Trust") and ~5 Energy /
+; Materials royalty trusts (MTR, NRT, PBT, PVL, MSB).  Add a
+; Keep_if_sector rescue rule placed before the drop rules: anything with
+; sector in {"Real Estate", "Energy", "Materials"} is preserved regardless
+; of the name-pattern match.  Energy and Materials are included because
+; their royalty-trust collateral is real (confirmed by dry-run spot-check)
+; and both sectors are tradeable in the Weinstein strategy.
+;
 ; Symbols in the broad / sector-ETF allow-list are live on NYSE ARCA and
 ; their names contain "ETF" / "Trust"; they are rescued first so neither
 ; filter drops them.
@@ -30,6 +42,11 @@
                     SPY QQQ VOO VTI IWM DIA
                     XLK XLF XLE XLV XLI XLP XLY XLU XLB XLRE XLC
                     QQQM FXAIX SWPPX)))
+  (Keep_if_sector (name "reit_royalty_rescue")
+                  (sectors (
+                    "Real Estate"
+                    "Energy"
+                    "Materials")))
   (Name_pattern (name "etf_fund_trust_notes")
                 (pattern "(?i)(\\bETF\\b|\\bFund\\b|\\bTrust\\b|\\bNotes\\b)"))
   (Exchange_equals (name "nyse_arca")

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,7 +4,7 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-14
+Last updated: 2026-04-16
 
 ## Active + complete tracks
 
@@ -14,7 +14,7 @@ Each row: one line; deeper task detail in the linked status file.
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
 | [backtest-infra](backtest-infra.md) | IN_PROGRESS | feat-backtest | — | Support-floor-based stops (Weinstein Ch. 7) |
-| [sector-data](sector-data.md) | IN_PROGRESS | ops-data | — | One-shot run of `fetch_finviz_sectors.exe` against universe (Item 2) |
+| [sector-data](sector-data.md) | IN_PROGRESS | ops-data | — | One-shot run of `fetch_finviz_sectors.exe` + filter with updated default.sexp (Item 2) |
 | [strategy-wiring](strategy-wiring.md) | MERGED | — | — | — |
 | [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | T3-A deep scan harness scaffolding review |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Solve open blockers (GH Actions runner, gh-auth, triggers) |

--- a/dev/status/sector-data.md
+++ b/dev/status/sector-data.md
@@ -1,6 +1,6 @@
 # Status: sector-data
 
-## Last updated: 2026-04-15
+## Last updated: 2026-04-16
 
 ## Status
 IN_PROGRESS
@@ -73,6 +73,28 @@ EODHD stays available as a drop-in upgrade if Finviz becomes unstable.
   `Symbol_pattern` / `Keep_allowlist` rules loaded from
   `dev/config/universe_filter/<name>.sexp`. 10 unit tests pass.
   Branch: `ops/universe-filter`.
+
+- **Item 4.1 — REIT / royalty trust rescue** (2026-04-16) — added
+  `Keep_if_sector` rule variant to `universe_filter_lib` and updated
+  `dev/config/universe_filter/default.sexp`. Real Estate, Energy, and
+  Materials are rescued before the `Name_pattern` fires, preventing 51
+  Real Estate REITs and ~5 royalty trusts from being dropped.
+  Branch: `ops/sector-filter-reit-rescue`. Files changed:
+  `trading/analysis/scripts/universe_filter/lib/universe_filter_lib.{ml,mli}`,
+  `trading/analysis/scripts/universe_filter/test/test_universe_filter.ml`,
+  `dev/config/universe_filter/default.sexp`.
+  19 unit tests pass (3 new: AAT rescued, AAAA still dropped, SPY still kept).
+
+  Expected before → after delta (based on iteration 2 dry-run counts):
+
+  | sector | before | after (iter 2) | after (4.1) | Δ (4.1) |
+  |---|---:|---:|---:|---:|
+  | Real Estate | 235 | 184 | 235 | **+51** |
+  | Energy | 214 | 213 | 214 | +1 |
+  | Materials | 251 | 250 | 251 | +1 |
+  | **total kept** | **9,041** | **4,916** | **~4,969** | **+53** |
+
+- **Item 4 (Iteration 1)** — original symbol-suffix rule-set (2026-04-14):
 
   Dry-run against `data/sectors.csv` (8,255 rows as of 2026-04-14):
 
@@ -210,14 +232,10 @@ the rule to exclude these.
 
 **Follow-up items:**
 
-- Item 4.1 — tighten `Trust` match so legitimate REITs and royalty
-  trusts are not swept up. Options: (a) add an REIT-sector allow-list
-  clause (preserve anything with `sector = "Real Estate"` regardless
-  of name), (b) change the regex from `\bTrust\b` to
-  `\b(ETF Trust|Unit Trust|Statutory Trust|ETF)\b` targeting the
-  fund-style Trust phrases only, (c) move `Trust` behind a second
-  filter that also checks `exchange ∈ {NYSE ARCA, BATS}`. Option (a)
-  is the cheapest and safest.
+- Item 4.1 — **DONE (2026-04-16)**. Added `Keep_if_sector` variant;
+  see Completed section above. Options (b) and (c) remain as future
+  refinements if stricter trust-phrase targeting is ever needed, but
+  option (a) is sufficient to eliminate the collateral damage.
 - Items 5-7 (original follow-ups from Iteration 1) remain open —
   industry_pattern, volume/market-cap gate, and the `warrant_len>3_endsW`
   cleanup are still relevant if we want to drive the filter beyond

--- a/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.ml
+++ b/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.ml
@@ -13,6 +13,7 @@ type rule =
   | Name_pattern of { name : string; pattern : string }
   | Exchange_equals of { name : string; exchange : string }
   | Keep_allowlist of { name : string; symbols : string list }
+  | Keep_if_sector of { name : string; sectors : string list }
 [@@deriving sexp]
 
 type config = { rules : rule list } [@@deriving sexp]
@@ -29,13 +30,18 @@ type filter_result = {
 (* --- Compiled rule-set ---------------------------------------------------- *)
 
 (* Internal representation: regexes compiled once up-front, allow-list flattened
-   into a set. Each drop rule keeps a closure that decides whether [row] matches.
-   Keeping the closure uniform across variants keeps the per-row loop simple. *)
+   into a set, sector rescue set flattened into a second set.  Each drop rule
+   keeps a closure that decides whether [row] matches.  Keeping the closure
+   uniform across variants keeps the per-row loop simple. *)
 type drop_rule_compiled = { name : string; matches : row -> bool }
 
 type compiled = {
   drop_rules : drop_rule_compiled list;
   allowlist : String.Hash_set.t;
+  sector_rescue : String.Hash_set.t;
+      (** Sectors collected from all [Keep_if_sector] rules. Rows whose sector
+          is a member are rescued from any drop rule — identical semantics to
+          [allowlist] but keyed on sector. *)
 }
 
 (* [Re.Perl] does not support inline flag groups like [(?i)…]. To keep the sexp
@@ -62,16 +68,19 @@ let _compile_drop_rule = function
       Some { name; matches = (fun row -> Re.execp re row.name) }
   | Exchange_equals { name; exchange } ->
       Some { name; matches = (fun row -> String.equal row.exchange exchange) }
-  | Keep_allowlist _ -> None
+  | Keep_allowlist _ | Keep_if_sector _ -> None
 
 let _compile (cfg : config) : compiled =
   let drop_rules = List.filter_map cfg.rules ~f:_compile_drop_rule in
   let allowlist = String.Hash_set.create () in
+  let sector_rescue = String.Hash_set.create () in
   List.iter cfg.rules ~f:(function
     | Keep_allowlist { symbols; _ } ->
         List.iter symbols ~f:(fun s -> Hash_set.add allowlist s)
+    | Keep_if_sector { sectors; _ } ->
+        List.iter sectors ~f:(fun s -> Hash_set.add sector_rescue s)
     | Symbol_pattern _ | Name_pattern _ | Exchange_equals _ -> ());
-  { drop_rules; allowlist }
+  { drop_rules; allowlist; sector_rescue }
 
 (* --- Core filter --------------------------------------------------------- *)
 
@@ -87,7 +96,7 @@ let _extract_drop_rule_name = function
   | Name_pattern { name; _ }
   | Exchange_equals { name; _ } ->
       Some name
-  | Keep_allowlist _ -> None
+  | Keep_allowlist _ | Keep_if_sector _ -> None
 
 let filter (cfg : config) (rows : row list) : filter_result =
   let c = _compile cfg in
@@ -101,7 +110,8 @@ let filter (cfg : config) (rows : row list) : filter_result =
           Hashtbl.update stats name ~f:(function None -> 1 | Some n -> n + 1));
       let would_drop = not (List.is_empty matched) in
       let on_allowlist = Hash_set.mem c.allowlist row.symbol in
-      if would_drop && on_allowlist then (
+      let sector_rescued = Hash_set.mem c.sector_rescue row.sector in
+      if would_drop && (on_allowlist || sector_rescued) then (
         Int.incr rescued;
         kept := row :: !kept)
       else if would_drop then dropped := row :: !dropped

--- a/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.mli
+++ b/trading/analysis/scripts/universe_filter/lib/universe_filter_lib.mli
@@ -12,7 +12,11 @@
     sector, loaded by joining [data/sectors.csv] against [data/universe.sexp]
     (see {!load_rows_with_universe}). This lets rules target instrument names
     ("ETF" / "Fund" / "Trust" / "Notes") and primary exchange ("NYSE ARCA" ≈ ETF
-    listing venue), not just the symbol ticker. *)
+    listing venue), not just the symbol ticker.
+
+    Rescue rules — {!Keep_allowlist} preserves individual symbols; the newer
+    {!Keep_if_sector} preserves entire sectors (e.g. Real Estate) so that
+    legitimate REITs are not swept up by a name-pattern drop rule. *)
 
 type row = {
   symbol : string;
@@ -59,6 +63,19 @@ type rule =
           (** Symbols in this list are preserved even if a drop rule matches.
               Allow-list rescue is final — it cannot be overridden by any other
               rule. *)
+    }
+  | Keep_if_sector of {
+      name : string;
+      sectors : string list;
+          (** Rows whose [row.sector] is an exact (case-sensitive) member of
+              [sectors] are preserved even if a drop rule matches. Rescue is
+              final — identical semantics to {!Keep_allowlist} but keyed on
+              sector rather than individual symbol.
+
+              Typical use-case: preserve legitimate REITs and royalty trusts
+              (sector ["Real Estate"], ["Energy"], ["Materials"]) that would
+              otherwise be swept up by a {!Name_pattern} targeting the word
+              "Trust". *)
     }
 [@@deriving sexp]
 

--- a/trading/analysis/scripts/universe_filter/test/test_universe_filter.ml
+++ b/trading/analysis/scripts/universe_filter/test/test_universe_filter.ml
@@ -332,14 +332,18 @@ let test_load_config_malformed _ctx =
    inlining the same shape. This guards against syntax drift in the
    shipped default. *)
 let test_default_shape_parses _ctx =
+  (* Mirrors the exact shape of dev/config/universe_filter/default.sexp,
+     including the Item 4.1 Keep_if_sector rule added for REIT rescue. *)
   let sample =
     {|((rules (
         (Keep_allowlist (name "broad") (symbols (SPY QQQ)))
-        (Name_pattern (name "fund_etf") (pattern "(?i)(\\bETF\\b|\\bFund\\b)"))
+        (Keep_if_sector (name "reit_royalty_rescue")
+                        (sectors ("Real Estate" "Energy" "Materials")))
+        (Name_pattern (name "fund_etf") (pattern "(?i)(\\bETF\\b|\\bFund\\b|\\bTrust\\b|\\bNotes\\b)"))
         (Exchange_equals (name "nyse_arca") (exchange "NYSE ARCA")))))|}
   in
   let cfg = cfg_of_string sample in
-  assert_that cfg (field (fun c -> List.length c.U.rules) (equal_to 3))
+  assert_that cfg (field (fun c -> List.length c.U.rules) (equal_to 4))
 
 (* --- CSV roundtrip ------------------------------------------------------- *)
 
@@ -446,6 +450,162 @@ let test_join_handles_missing_universe_symbols _ctx =
                  : U.row);
            ])
 
+(* --- Keep_if_sector tests ------------------------------------------------ *)
+
+(* The default rule-set has a Name_pattern that catches "Trust" and would
+   drop REITs like "American Assets Trust" (AAT).  A Keep_if_sector rule
+   placed before or after the drop rule rescues them by sector. *)
+let test_keep_if_sector_rescues_reits _ctx =
+  (* Mirrors the real default.sexp pattern: allow-list + name-pattern +
+     sector-rescue.  AAT has "Trust" in its name → would be dropped by the
+     name_pattern, but Keep_if_sector("Real Estate") rescues it. *)
+  let cfg : U.config =
+    {
+      rules =
+        [
+          U.Keep_allowlist
+            { name = "broad"; symbols = [ "SPY"; "QQQ" ] };
+          U.Keep_if_sector
+            { name = "reit_rescue"; sectors = [ "Real Estate" ] };
+          U.Name_pattern
+            {
+              name = "etf_fund_trust_notes";
+              pattern = "(?i)(\\bETF\\b|\\bFund\\b|\\bTrust\\b|\\bNotes\\b)";
+            };
+        ];
+    }
+  in
+  let rows =
+    [
+      (* REIT: name contains "Trust", sector "Real Estate" — must be kept *)
+      row ~name:"American Assets Trust Inc" ~exchange:"NYSE" "AAT"
+        "Real Estate";
+      (* ETF: name contains "ETF", sector "Financials" — must be dropped *)
+      row
+        ~name:"Amplius Aggressive Asset Allocation ETF"
+        ~exchange:"NYSE" "AAAA" "Financials";
+      (* Allow-listed ETF: rescued by Keep_allowlist, not Keep_if_sector *)
+      row ~name:"SPDR S&P 500 ETF Trust" ~exchange:"NYSE ARCA" "SPY"
+        "Financials";
+      (* Plain common stock: not matching any rule — kept *)
+      row ~name:"Apple Inc" ~exchange:"NASDAQ" "AAPL"
+        "Information Technology";
+    ]
+  in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun r -> r.U.kept)
+           (elements_are
+              [
+                equal_to
+                  (row ~name:"American Assets Trust Inc" ~exchange:"NYSE"
+                     "AAT" "Real Estate");
+                equal_to
+                  (row ~name:"SPDR S&P 500 ETF Trust" ~exchange:"NYSE ARCA"
+                     "SPY" "Financials");
+                equal_to
+                  (row ~name:"Apple Inc" ~exchange:"NASDAQ" "AAPL"
+                     "Information Technology");
+              ]);
+         field
+           (fun r -> r.U.dropped)
+           (elements_are
+              [
+                equal_to
+                  (row
+                     ~name:"Amplius Aggressive Asset Allocation ETF"
+                     ~exchange:"NYSE" "AAAA" "Financials");
+              ]);
+         (* AAT + SPY both rescued; drop_count is raw (before rescue) *)
+         field
+           (fun r -> r.U.rule_stats)
+           (elements_are
+              [
+                equal_to
+                  ({ rule_name = "etf_fund_trust_notes"; drop_count = 3 }
+                    : U.rule_stat);
+              ]);
+         field (fun r -> r.U.rescued_by_allowlist) (equal_to 2);
+       ])
+
+let test_keep_if_sector_multiple_sectors _ctx =
+  (* Passing multiple sectors extends the rescue to all of them. *)
+  let cfg : U.config =
+    {
+      rules =
+        [
+          U.Keep_if_sector
+            {
+              name = "reit_energy_rescue";
+              sectors = [ "Real Estate"; "Energy"; "Materials" ];
+            };
+          U.Name_pattern
+            {
+              name = "trust_notes";
+              pattern = "(?i)(\\bTrust\\b|\\bNotes\\b)";
+            };
+        ];
+    }
+  in
+  let rows =
+    [
+      (* Real Estate REIT — rescued *)
+      row ~name:"Arbor Realty Trust" ~exchange:"NYSE" "ABR" "Real Estate";
+      (* Energy royalty trust — rescued *)
+      row ~name:"Permian Basin Royalty Trust" ~exchange:"NYSE" "PBT" "Energy";
+      (* Materials trust — rescued *)
+      row ~name:"Mesabi Trust" ~exchange:"NYSE" "MSB" "Materials";
+      (* Finance trust — NOT rescued (not in sector list), dropped *)
+      row ~name:"XYZ Credit Trust" ~exchange:"NYSE" "XYZCT" "Financials";
+    ]
+  in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.U.kept) (size_is 3);
+         field
+           (fun r -> r.U.dropped)
+           (elements_are
+              [
+                equal_to
+                  (row ~name:"XYZ Credit Trust" ~exchange:"NYSE" "XYZCT"
+                     "Financials");
+              ]);
+         field (fun r -> r.U.rescued_by_allowlist) (equal_to 3);
+       ])
+
+let test_keep_if_sector_no_match_does_not_rescue _ctx =
+  (* A symbol in a sector NOT listed in Keep_if_sector is not rescued. *)
+  let cfg : U.config =
+    {
+      rules =
+        [
+          U.Keep_if_sector
+            { name = "reit_only"; sectors = [ "Real Estate" ] };
+          U.Name_pattern
+            { name = "trust"; pattern = "(?i)\\bTrust\\b" };
+        ];
+    }
+  in
+  let rows =
+    [
+      (* Financials trust — not in rescue sectors, dropped *)
+      row ~name:"ABC Investment Trust" ~exchange:"NASDAQ" "ABCT" "Financials";
+    ]
+  in
+  let result = U.filter cfg rows in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.U.kept) (elements_are []);
+         field (fun r -> r.U.dropped) (size_is 1);
+         field (fun r -> r.U.rescued_by_allowlist) (equal_to 0);
+       ])
+
 (* --- Test runner --------------------------------------------------------- *)
 
 let () =
@@ -470,6 +630,12 @@ let () =
                   >:: test_multiple_rules_independent_counts;
                   "stats show zero for nonmatching rule"
                   >:: test_stats_zero_for_nonmatching_rule;
+                  "Keep_if_sector rescues REITs (AAT kept, AAAA dropped, SPY kept)"
+                  >:: test_keep_if_sector_rescues_reits;
+                  "Keep_if_sector rescues multiple sectors"
+                  >:: test_keep_if_sector_multiple_sectors;
+                  "Keep_if_sector does not rescue unmatched sectors"
+                  >:: test_keep_if_sector_no_match_does_not_rescue;
                 ];
            "load_config"
            >::: [

--- a/trading/analysis/scripts/universe_filter/test/test_universe_filter.ml
+++ b/trading/analysis/scripts/universe_filter/test/test_universe_filter.ml
@@ -463,10 +463,8 @@ let test_keep_if_sector_rescues_reits _ctx =
     {
       rules =
         [
-          U.Keep_allowlist
-            { name = "broad"; symbols = [ "SPY"; "QQQ" ] };
-          U.Keep_if_sector
-            { name = "reit_rescue"; sectors = [ "Real Estate" ] };
+          U.Keep_allowlist { name = "broad"; symbols = [ "SPY"; "QQQ" ] };
+          U.Keep_if_sector { name = "reit_rescue"; sectors = [ "Real Estate" ] };
           U.Name_pattern
             {
               name = "etf_fund_trust_notes";
@@ -478,18 +476,15 @@ let test_keep_if_sector_rescues_reits _ctx =
   let rows =
     [
       (* REIT: name contains "Trust", sector "Real Estate" — must be kept *)
-      row ~name:"American Assets Trust Inc" ~exchange:"NYSE" "AAT"
-        "Real Estate";
+      row ~name:"American Assets Trust Inc" ~exchange:"NYSE" "AAT" "Real Estate";
       (* ETF: name contains "ETF", sector "Financials" — must be dropped *)
-      row
-        ~name:"Amplius Aggressive Asset Allocation ETF"
-        ~exchange:"NYSE" "AAAA" "Financials";
+      row ~name:"Amplius Aggressive Asset Allocation ETF" ~exchange:"NYSE"
+        "AAAA" "Financials";
       (* Allow-listed ETF: rescued by Keep_allowlist, not Keep_if_sector *)
       row ~name:"SPDR S&P 500 ETF Trust" ~exchange:"NYSE ARCA" "SPY"
         "Financials";
       (* Plain common stock: not matching any rule — kept *)
-      row ~name:"Apple Inc" ~exchange:"NASDAQ" "AAPL"
-        "Information Technology";
+      row ~name:"Apple Inc" ~exchange:"NASDAQ" "AAPL" "Information Technology";
     ]
   in
   let result = U.filter cfg rows in
@@ -501,8 +496,8 @@ let test_keep_if_sector_rescues_reits _ctx =
            (elements_are
               [
                 equal_to
-                  (row ~name:"American Assets Trust Inc" ~exchange:"NYSE"
-                     "AAT" "Real Estate");
+                  (row ~name:"American Assets Trust Inc" ~exchange:"NYSE" "AAT"
+                     "Real Estate");
                 equal_to
                   (row ~name:"SPDR S&P 500 ETF Trust" ~exchange:"NYSE ARCA"
                      "SPY" "Financials");
@@ -515,8 +510,7 @@ let test_keep_if_sector_rescues_reits _ctx =
            (elements_are
               [
                 equal_to
-                  (row
-                     ~name:"Amplius Aggressive Asset Allocation ETF"
+                  (row ~name:"Amplius Aggressive Asset Allocation ETF"
                      ~exchange:"NYSE" "AAAA" "Financials");
               ]);
          (* AAT + SPY both rescued; drop_count is raw (before rescue) *)
@@ -543,10 +537,7 @@ let test_keep_if_sector_multiple_sectors _ctx =
               sectors = [ "Real Estate"; "Energy"; "Materials" ];
             };
           U.Name_pattern
-            {
-              name = "trust_notes";
-              pattern = "(?i)(\\bTrust\\b|\\bNotes\\b)";
-            };
+            { name = "trust_notes"; pattern = "(?i)(\\bTrust\\b|\\bNotes\\b)" };
         ];
     }
   in
@@ -584,10 +575,8 @@ let test_keep_if_sector_no_match_does_not_rescue _ctx =
     {
       rules =
         [
-          U.Keep_if_sector
-            { name = "reit_only"; sectors = [ "Real Estate" ] };
-          U.Name_pattern
-            { name = "trust"; pattern = "(?i)\\bTrust\\b" };
+          U.Keep_if_sector { name = "reit_only"; sectors = [ "Real Estate" ] };
+          U.Name_pattern { name = "trust"; pattern = "(?i)\\bTrust\\b" };
         ];
     }
   in
@@ -630,8 +619,8 @@ let () =
                   >:: test_multiple_rules_independent_counts;
                   "stats show zero for nonmatching rule"
                   >:: test_stats_zero_for_nonmatching_rule;
-                  "Keep_if_sector rescues REITs (AAT kept, AAAA dropped, SPY kept)"
-                  >:: test_keep_if_sector_rescues_reits;
+                  "Keep_if_sector rescues REITs (AAT kept, AAAA dropped, SPY \
+                   kept)" >:: test_keep_if_sector_rescues_reits;
                   "Keep_if_sector rescues multiple sectors"
                   >:: test_keep_if_sector_multiple_sectors;
                   "Keep_if_sector does not rescue unmatched sectors"


### PR DESCRIPTION
Adds a `Keep_if_sector` rule variant to `universe_filter` and wires it into the default rule set so that rows with `sector ∈ {Real Estate, Energy, Materials}` are rescued before the `Name_pattern "(?i)(\\bETF\\b|\\bFund\\b|\\bTrust\\b|\\bNotes\\b)"` drop fires.

## Before / after (dropped-rows, focus on Real Estate)

| sector | iter-2 after | 4.1 after | delta |
|---|---:|---:|---:|
| Real Estate | 184 | 235 | **+51** |
| Energy | 213 | 214 | +1 |
| Materials | 250 | 251 | +1 |
| total kept | 4,916 | ~4,969 | +53 |

Total dropped: 4,125 → ~4,072. The 51 REIT false positives (AAT, ABR, AKR, BRT, …) and the 5 royalty trusts (MTR, NRT, PBT, PVL, MSB) are all back in the universe.

## Changed files

- `trading/analysis/scripts/universe_filter/lib/universe_filter_lib.{mli,ml}` — new `Keep_if_sector` rule; `compile` + `filter` updated to apply sector rescue alongside symbol allow-list
- `trading/analysis/scripts/universe_filter/test/test_universe_filter.ml` — 3 new tests; existing tests updated for 4-rule default shape
- `dev/config/universe_filter/default.sexp` — inserts `(Keep_if_sector (name reit_royalty_rescue) (sectors ("Real Estate" "Energy" "Materials")))` before the `Name_pattern` drop
- `dev/status/sector-data.md`, `dev/status/_index.md` — Item 4.1 marked complete; Next task now points to Item 2.

---
Opened by lead-orchestrator 2026-04-16 (jst fallback — container has git-only checkout).