### PR TITLE
ci(orchestrator): set TRADING_DATA_DIR

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -71,6 +71,12 @@ jobs:
       # wrapping) when this is set. Agent prompts invoke the wrapper so they
       # work identically in local-docker and in-container (GHA) environments.
       TRADING_IN_CONTAINER: "1"
+      # Point data-dependent tests at the in-repo test fixtures (same as
+      # ci.yml). Without this, Data_path.default_data_dir() falls back to
+      # the Docker-workspace path /workspaces/trading-1/data which does not
+      # exist in the GHA runner — health-scanner reports 7 test suites /
+      # 38 assertion failures. See dev/daily/2026-04-16-run1.md escalation.
+      TRADING_DATA_DIR: ${{ github.workspace }}/trading/test_data
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

Health-scanner on first GHA orchestrator run reports 7 test suites / 38 assertion failures inside the container (`dev/daily/2026-04-16-run1.md` §Escalations item 3).

Root cause: `Data_path.default_data_dir()` falls back to `/workspaces/trading-1/data` (Docker workspace path) when `TRADING_DATA_DIR` is unset. That path does not exist in the GHA runner — runner root is `/__w/trading/trading`.

Not a code regression — same commits pass locally. Environment-only gap.

## What

Set `TRADING_DATA_DIR: \${{ github.workspace }}/trading/test_data` at the job env level — same value `ci.yml` already uses (line 44).

## Test plan

- [ ] Trigger `workflow_dispatch`, confirm health-scanner phase does not report the 38 failures