### PR TITLE
ci(orchestrator): add jj git init --colocate pre-step

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -87,6 +87,20 @@ jobs:
         id: today
         run: echo "date=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
+      - name: Colocate jj on the git checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          # actions/checkout@v4 produces a git-only tree. `jst submit`
+          # (stacked-PR tool used by feat-agents) requires .jj/, so we
+          # colocate jj on top of the existing git repo. This keeps git
+          # as the wire format (pushes, remotes, CI triggers) while
+          # giving agents the jj local-commit UX they use locally.
+          # Decided 2026-04-16 (see dev/decisions.md) — option (2) over
+          # adding gh CLI to the container.
+          jj git init --colocate
+          jj git fetch
+
       - name: Run lead-orchestrator
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Why

Daily-summary escalation #2: `actions/checkout@v4` produces a git-only tree. `jst submit` (stacked-PR tool used by feat-agents) requires `.jj/`, so the orchestrator's subagents have to fall back to raw `curl` + REST to open PRs. The first GHA orchestrator run (2026-04-16-run1) opened #373 and #374 via that fallback — noisy.

Per `dev/decisions.md` 2026-04-16 direction change, we picked option (2): colocate jj on top of the git checkout. This keeps git as the wire format (pushes, remotes, CI triggers) while giving agents the jj local-commit UX they use locally.

## What

New workflow step between the date-compute and the Claude step:

```yaml
- name: Colocate jj on the git checkout
  shell: bash
  run: |
    set -euo pipefail
    jj git init --colocate
    jj git fetch
```

## Test plan

- [ ] Manual `workflow_dispatch` — confirm `jj git init --colocate` succeeds inside the container (jj is in the base image already, per CLAUDE.md)
- [ ] Observe subagent PR-opening: should use `jst submit` (or `jj git push -b <branch>`) instead of REST fallback