### PR TITLE
ci(orchestrator): enable nightly cron at 1:05 AM PT

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -38,14 +38,15 @@
 #      machine via `claude setup-token`. The Pro/Max subscription's session
 #      limits act as the effective cost ceiling for this workflow.
 #
-# DO NOT enable the `schedule:` cron below until a successful manual
-# dogfood run via `workflow_dispatch` has been observed end-to-end.
 # ----------------------------------------------------------------------------
 name: Daily orchestrator
 
 on:
-  # workflow_dispatch only, for now. Flip on `schedule: cron: "0 14 * * *"`
-  # (07:00 Pacific) once a manual dogfood run succeeds end-to-end.
+  # 1:05 AM Pacific. GitHub cron is UTC-only, no DST awareness — this is
+  # set for UTC-7 (PDT). During PST months (roughly Nov–Mar) the run
+  # drifts to 12:05 AM PT. Acceptable for a daily cadence.
+  schedule:
+    - cron: "5 8 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

First GHA orchestrator run (2026-04-16) completed end-to-end — subagents dispatched, PRs opened, daily summary landed, escalations surfaced. Per `dev/status/orchestrator-automation.md` §"Implementation sequencing" step 6: "Enable nightly cron once manual run is reliable."

## What

```yaml
schedule:
  - cron: "5 8 * * *"
```

`5 8 * * *` UTC = 1:05 AM PDT. GitHub cron is UTC-only with no DST awareness, so during PST months (~Nov–Mar) the run will drift to 12:05 AM PT. Acceptable for a daily cadence.

## Test plan

- [ ] First scheduled run fires at the expected time
- [ ] Subsequent runs happen daily without manual dispatch