### PR TITLE
ci(orchestrator): drop jj git fetch (needs git>=2.41)

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -98,8 +98,13 @@ jobs:
           # giving agents the jj local-commit UX they use locally.
           # Decided 2026-04-16 (see dev/decisions.md) — option (2) over
           # adding gh CLI to the container.
+          #
+          # We skip `jj git fetch`: jj 0.39 shells to `git fetch --porcelain`
+          # which requires git >= 2.41, but the ubuntu-22.04 devcontainer base
+          # ships git 2.34. actions/checkout@v4 (fetch-depth: 0 above) already
+          # populated origin refs in .git/, and `jj git init --colocate`
+          # auto-imports them — so no remote fetch is needed here.
           jj git init --colocate
-          jj git fetch
 
       - name: Run lead-orchestrator
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Why

Daily orchestrator run 24500922760 failed at the new `Colocate jj` step:

```
Error: Git does not recognize required option: porcelain (note: supported version is 2.41.0)
```

jj 0.39 shells out to `git fetch --porcelain` for `jj git fetch`, which requires git >= 2.41. The devcontainer base (`ocaml/opam:ubuntu-22.04-ocaml-5.3`) ships git 2.34.

## What

Drop `jj git fetch`. `actions/checkout@v4` with `fetch-depth: 0` already populated origin refs in `.git/`, and `jj git init --colocate` auto-imports them — no remote fetch needed in the step.

If we later need tracked remote bookmarks for `jst submit`, add `jj bookmark track main@origin` (local-only, no git shell-out).

## Test plan

- [ ] Manual `workflow_dispatch` after merge — confirm Colocate step succeeds.