### PR TITLE
feat(stops): support-floor primitive (long + short)

### DIFF
--- a/dev/plans/support-floor-stops-2026-04-16.md
+++ b/dev/plans/support-floor-stops-2026-04-16.md
@@ -1,0 +1,191 @@
+# Plan: support-floor-based stops (2026-04-16)
+
+Track: [support-floor-stops](../status/support-floor-stops.md)
+Branch: `feat/support-floor-stops`
+
+## Context
+
+Today's `Weinstein_stops.compute_initial_stop` accepts a `reference_level`
+parameter which the caller (`Weinstein_strategy._make_entry_transition`)
+currently derives via a fixed-buffer proxy:
+
+```ocaml
+let initial_stop =
+  Weinstein_stops.compute_initial_stop ~config:config.stops_config
+    ~side:Trading_base.Types.Long
+    ~reference_level:(cand.suggested_stop *. config.initial_stop_buffer)
+```
+
+That proxy — `suggested_stop *. initial_stop_buffer` — is a coarse placeholder.
+Weinstein Ch. 6 §5.1 is explicit:
+
+> Place below the significant support floor (prior correction low) BEFORE the breakout.
+
+This track replaces the proxy with a real primitive that walks recent price
+history, identifies the prior correction low, and returns it when the pullback
+depth is meaningful (default 8%, per Ch. 6). The existing state machine
+(Initial → Trailing → Tightened) is untouched.
+
+Downstream, `feat-backtest` is blocked on this primitive to run the
+fixed-buffer vs support-floor experiment on the golden scenarios
+(see `dev/status/backtest-infra.md`).
+
+## Approach
+
+### Module shape
+
+New module `Support_floor` in `trading/trading/weinstein/stops/lib/`, exposing:
+
+```ocaml
+val find_recent_low :
+  bars:Types.Daily_price.t list ->
+  as_of:Core.Date.t ->
+  min_pullback_pct:float ->
+  lookback_bars:int ->
+  float option
+```
+
+- `bars` are daily bars in chronological order (oldest first — matching
+  `Bar_history.t`). The function slices them to bars with date ≤ `as_of`,
+  then takes the last `lookback_bars` of that slice.
+- Identifies the **highest high** in the window as the "peak".
+- Identifies the **lowest low** among bars strictly **after** the peak bar
+  (i.e. the drawdown that followed the peak), extending through `as_of`.
+- Returns `Some low` when `(peak_high - low) / peak_high >= min_pullback_pct`.
+- Returns `None` when:
+  - the slice is empty (no bars at or before `as_of`),
+  - the peak is at the last bar (no bars after it — no pullback has occurred yet),
+  - the depth threshold is not met.
+
+Tie-breaking: if multiple bars share the same high, the **latest** peak date
+is used (conservative — ensures the "pullback" is strictly the decline that
+followed the most recent extreme). If multiple bars share the same low after
+the peak, the first one wins (doesn't matter — only the float value is returned).
+
+### Rationale for highest-high-then-lowest-low
+
+Alternatives considered:
+
+1. **Scan for local peaks** (a bar whose high exceeds `k` neighbours on each side)
+   and then find the lowest low between the latest such peak and `as_of`. More
+   faithful to "prior peak" intuition, but adds a `k`-parameter and depends on
+   bar granularity. Overkill for a weekly-entry use case where we only care about
+   the deepest recent pullback, not multi-peak topography.
+
+2. **Lowest low in window**, period, regardless of peak. Too loose — would return
+   a low from a prior uptrend rather than a drawdown, and the depth threshold
+   would fire against noise rather than a real correction.
+
+The chosen "highest-high then lowest-low-after" approach captures the single
+most recent significant drawdown, which is what §5.1 refers to as "the significant
+support floor." It's O(n) and parameter-free beyond the two documented knobs.
+
+### Wiring into `compute_initial_stop`
+
+Add a thin wrapper:
+
+```ocaml
+val compute_initial_stop_with_floor :
+  config:config ->
+  side:position_side ->
+  entry_price:float ->
+  bars:Types.Daily_price.t list ->
+  as_of:Core.Date.t ->
+  fallback_buffer:float ->
+  stop_state
+```
+
+- When `Support_floor.find_recent_low` returns `Some floor`, call
+  `compute_initial_stop` with `reference_level = floor`.
+- When it returns `None`, call `compute_initial_stop` with
+  `reference_level = entry_price *. fallback_buffer` — behaviour identical to
+  today's call site.
+- The existing `compute_initial_stop` keeps its signature unchanged.
+- `min_pullback_pct` and `lookback_bars` read from `stops_config` (add fields
+  to `config` with defaults matching Weinstein book: 0.08 and 52 weeks ≈ 260
+  trading days; but we'll use a sensible default like 60 or 90 bars to match
+  what `Bar_history` typically accumulates at entry time).
+
+Actually — to keep the wrapper minimal and keep all config in one place, I'll
+add `support_floor_lookback_bars` and reuse `min_correction_pct` (already in
+`config`, value 0.08) as `min_pullback_pct`. Weinstein's 8% rule is the same
+concept in both places; using two independent knobs would be a refactor hazard.
+
+### Callers
+
+The `weinstein_strategy.ml` call site swaps from `compute_initial_stop` to
+`compute_initial_stop_with_floor`, passing the accumulated bar history for the
+candidate ticker. No changes to the state machine, screener, portfolio_risk,
+order_gen, or trading_state.
+
+## Files to change
+
+| File | Purpose |
+|---|---|
+| `trading/trading/weinstein/stops/lib/support_floor.mli` | new — interface for `find_recent_low` |
+| `trading/trading/weinstein/stops/lib/support_floor.ml` | new — implementation |
+| `trading/trading/weinstein/stops/lib/stop_types.mli` | add `support_floor_lookback_bars` to `config` |
+| `trading/trading/weinstein/stops/lib/stop_types.ml` | update `default_config` |
+| `trading/trading/weinstein/stops/lib/weinstein_stops.mli` | expose `compute_initial_stop_with_floor` |
+| `trading/trading/weinstein/stops/lib/weinstein_stops.ml` | implement wrapper |
+| `trading/trading/weinstein/stops/test/test_support_floor.ml` | new — unit tests |
+| `trading/trading/weinstein/stops/test/dune` | add new test binary |
+| `trading/trading/weinstein/strategy/lib/weinstein_strategy.ml` | swap to `compute_initial_stop_with_floor` at the entry call site (minimal touch) |
+| `dev/status/support-floor-stops.md` | status updates |
+| `dev/status/_index.md` | row update for this track |
+
+## Risks / unknowns
+
+- **Empty bars**: returns `None` — caller falls back to fixed buffer. Verified
+  by unit test.
+- **Single bar**: peak = only bar, no bars after → `None`. Verified by unit
+  test.
+- **Monotonic advance with no pullback**: highest high is the last bar → `None`.
+  Verified by unit test.
+- **Multiple equal highs / equal lows**: latest high wins; first-encountered low
+  wins (irrelevant — float value is the same). Documented.
+- **`as_of` before all bars**: slice empty → `None`. Documented.
+- **`lookback_bars <= 0`**: undefined; we'll treat as "no bars considered" → `None`.
+- **Stops config change is additive**: new field has a default, no consumer
+  breaks.
+
+## Acceptance
+
+Mirrors `.claude/agents/feat-weinstein.md` §Acceptance Checklist:
+
+- [ ] `Support_floor.find_recent_low` implemented with unit tests:
+  peak+pullback identification, depth threshold, lookback truncation,
+  no-pullback → None, empty bars → None, single bar, monotonic series
+- [ ] `Stops.compute_initial_stop_with_floor` accepts bar history; `None`
+  path is behaviourally identical to today's fixed-buffer code path
+  (unit test compares both outputs for a tickless history)
+- [ ] `weinstein_strategy.ml` call site swapped; downstream tests still green
+- [ ] `dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest`
+  passes
+- [ ] `dev/lib/run-in-env.sh dune build @fmt` clean
+- [ ] No changes to screener, portfolio_risk, order_gen, or trading_state
+
+Smoke check: the strategy's e2e tests (`test_weinstein_strategy`,
+`test_stops_runner`, `test_portfolio_risk_e2e`) already feed the strategy
+cached-like bar histories. Confirm at least one entry placement runs through
+`Support_floor.find_recent_low` returning `Some _` in those fixtures. If none
+of the existing fixtures exercise the "support-floor present" path, add a
+targeted strategy-level test that seeds bar history with a clear
+peak+correction pattern and verifies the initial stop tracks the correction
+low rather than `entry_price * fallback_buffer`.
+
+## Out of scope
+
+- **Round-number shading of the support-floor value** (§5.1). The existing
+  `nudge_round_number` in `weinstein_stops.ml` already applies to the computed
+  stop level; no new nudge layer is added at the support-floor step. Parked in
+  status §Follow-ups.
+- **Fixed-buffer vs support-floor backtest experiment** — `feat-backtest`'s
+  follow-on.
+- **Regime-aware buffers** — separate exploration listed in
+  `dev/status/backtest-infra.md`.
+- **Pinnacle / external data source for synthetic ADL** — already decided
+  (synthetic-only) per `dev/decisions.md` 2026-04-16.
+- **Weinstein Ch. 6 15% max-risk rejection rule** (§5.1: "If stop requires
+  >15% risk from entry → prefer other candidates"). Screener concern, not
+  a stop-primitive concern.

--- a/dev/status/support-floor-stops.md
+++ b/dev/status/support-floor-stops.md
@@ -3,31 +3,53 @@
 ## Last updated: 2026-04-16
 
 ## Status
-NOT_STARTED
+IN_PROGRESS
 
 ## Interface stable
-NO
+YES (primitive)
+
+## Open PR
+- PR A (primitive, long + short) — #382 (see `feat/support-floor-stops`)
+- PR B (wrapper + strategy wiring, long side) — pending (stacked on PR A as `feat/support-floor-wiring`)
+
+## Completed
+
+- `dev/plans/support-floor-stops-2026-04-16.md` — plan committed (first-deliverable plan-first trigger)
+- `Support_floor.find_recent_level` primitive (long + short) — implemented in `trading/trading/weinstein/stops/lib/support_floor.{ml,mli}` with 23 unit tests. Long returns the prior correction low (support floor); short returns the prior counter-rally high (resistance ceiling). Short-side lands with no caller yet; future short-side strategy will consume it.
+
+## In Progress (PR B)
+
+- `Weinstein_stops.compute_initial_stop_with_floor` wrapper — thread `~side` through to the primitive.
+- `Bar_history.daily_bars_for` helper.
+- Wire `compute_initial_stop_with_floor` into `Weinstein_strategy._make_entry_transition` (one call-site swap), long side only.
+- Backtest regression pin updates on 2018-2023 cached data.
 
 ## Ownership
 `feat-weinstein` agent — see `.claude/agents/feat-weinstein.md`. Dispatched per the 2026-04-16 direction change in `dev/decisions.md` to unblock feat-backtest's support-floor stops experiment (see `dev/status/backtest-infra.md` §Blocked on).
 
 ## Goal
 
-Replace the fixed-buffer proxy (`entry_price *. (1.0 /. buffer)`) with a real support-floor value derived from price history. Weinstein Ch. 6 §5.1: "Place below the significant support floor (prior correction low) BEFORE the breakout."
+Replace the fixed-buffer proxy (`entry_price *. (1.0 /. buffer)`) with a real support-floor value derived from price history. Weinstein Ch. 6 §5.1: "Place below the significant support floor (prior correction low) BEFORE the breakout." Short-side mirror: place ABOVE the prior counter-rally high (resistance ceiling).
 
 ## Scope
 
-Two items, both in `trading/trading/weinstein/stops/lib/`:
+Split into two stacked PRs:
 
-1. **`Support_floor.find_recent_low`** — new module. Pure function that, given a daily-bar series and `as_of`, returns the most recent qualifying correction low. Depth threshold default 8%; lookback configurable. Returns `None` if no qualifying pullback — caller falls back to fixed buffer.
+**PR A — primitive (long + short)** in `trading/trading/weinstein/stops/lib/`:
+- `Support_floor.find_recent_level` — pure function with a `~side` parameter. For long it returns the prior correction low; for short the prior counter-rally high. Depth threshold shared with `min_correction_pct`; lookback configurable. Returns `None` when no qualifying counter-move exists — caller falls back to fixed buffer.
 
-2. **Wire into `Stops.compute_initial_stop`** — accept the new value; behaviour under `None` identical to today. State machine itself (Initial → FirstCorrection → Trailing) unchanged.
+**PR B — wrapper + strategy wiring** (stacked on A):
+- `Weinstein_stops.compute_initial_stop_with_floor` — threads `~side` through; behaviour under `None` identical to pre-primitive direct call.
+- `Bar_history.daily_bars_for` helper.
+- `Weinstein_strategy._make_entry_transition` wiring — long side only (short-side strategy is a separate track).
+- Backtest parity regression tests updated.
 
-See `.claude/agents/feat-weinstein.md` §"Scope: support-floor-based stops" for signature sketch + acceptance checklist.
+State machine itself (Initial → Trailing → Tightened) unchanged.
 
 ## Not in scope
 
 - The fixed-buffer vs support-floor experiment — feat-backtest follow-on.
+- Short-side strategy wiring — short-side strategy is a separate track (`dev/status/short-side-strategy.md`). The primitive lands here with both sides so the wrapper doesn't need a second API churn when the short-side strategy begins.
 - Round-number shading of the stop value — §Follow-ups below.
 - Regime-aware buffers — separate exploration in `dev/status/backtest-infra.md`.
 
@@ -37,6 +59,7 @@ See `.claude/agents/feat-weinstein.md` §"Scope: support-floor-based stops" for 
 - `docs/design/eng-design-3-portfolio-stops.md` §Stop state machine
 - `dev/status/backtest-infra.md` §Blocked on — downstream experiment
 - `dev/status/portfolio-stops.md` — prior base-strategy stops work (merged, interface stable)
+- `dev/status/short-side-strategy.md` — consumes the short-side primitive
 
 ## Follow-ups
 
@@ -44,10 +67,10 @@ See `.claude/agents/feat-weinstein.md` §"Scope: support-floor-based stops" for 
 
 ## QC
 
-overall_qc: NOT_STARTED
-structural_qc: NOT_STARTED
-behavioral_qc: NOT_STARTED
+overall_qc: PENDING
+structural_qc: PENDING
+behavioral_qc: PENDING
 
 Reviewers when work lands:
-- qc-structural — module boundaries, pure-function discipline, test coverage for degenerate inputs (empty bars, single bar, all-flat prices).
-- qc-behavioral — spot-check against Weinstein Ch. 6 examples (Merck, Anthony Industries, National Semiconductor) — does the identified correction low match what the book calls out?
+- qc-structural — module boundaries, pure-function discipline, test coverage for degenerate inputs (empty bars, single bar, all-flat prices); symmetry of long/short branches in the primitive.
+- qc-behavioral — spot-check against Weinstein Ch. 6 examples (Merck, Anthony Industries, National Semiconductor) — does the identified correction low match what the book calls out? For the short side, spot-check against Ch. 11 short-sell examples (resistance ceiling identification).

--- a/trading/trading/weinstein/stops/lib/support_floor.ml
+++ b/trading/trading/weinstein/stops/lib/support_floor.ml
@@ -1,0 +1,99 @@
+open Core
+open Trading_base.Types
+
+(* Bars eligible for the window: those dated on or before [as_of]. *)
+let _eligible ~bars ~as_of =
+  List.filter bars ~f:(fun (b : Types.Daily_price.t) ->
+      Date.( <= ) b.date as_of)
+
+(* Trailing [lookback_bars] of [eligible]. Assumes chronological order. *)
+let _trim_to_lookback eligible lookback_bars =
+  let n = List.length eligible in
+  if n <= lookback_bars then eligible else List.drop eligible (n - lookback_bars)
+
+(* Bars in the window dated on or before [as_of], trimmed to the trailing
+   [lookback_bars]. Assumes [bars] is chronological (oldest first). *)
+let _window ~bars ~as_of ~lookback_bars =
+  if lookback_bars <= 0 then []
+  else _trim_to_lookback (_eligible ~bars ~as_of) lookback_bars
+
+(* Anchor extreme for the given side:
+   Long  → highest [high_price] (the peak from which price fell).
+   Short → lowest  [low_price]  (the trough from which price rallied). *)
+let _anchor_extreme ~side (b : Types.Daily_price.t) =
+  match side with Long -> b.high_price | Short -> b.low_price
+
+(* Counter-move extreme for the given side — the extreme measured on bars
+   strictly after the anchor:
+   Long  → lowest  [low_price]  across the correction.
+   Short → highest [high_price] across the counter-rally. *)
+let _counter_extreme ~side (b : Types.Daily_price.t) =
+  match side with Long -> b.low_price | Short -> b.high_price
+
+(* Anchor index in the window: latest date among bars whose anchor-extreme ties
+   the window's extremum. Using the latest tie keeps the "after-anchor" slice
+   as short and recent as possible — a second equal anchor later in the window
+   means the first anchor's counter-move already healed, so we anchor to the
+   later one. *)
+let _anchor_index ~side window =
+  let init, ties =
+    match side with
+    | Long -> (Float.neg_infinity, Float.( >= ))
+    | Short -> (Float.infinity, Float.( <= ))
+  in
+  let extremum =
+    List.fold window ~init ~f:(fun acc b ->
+        match side with
+        | Long -> Float.max acc (_anchor_extreme ~side b)
+        | Short -> Float.min acc (_anchor_extreme ~side b))
+  in
+  let idx =
+    List.foldi window ~init:(-1) ~f:(fun i best b ->
+        if ties (_anchor_extreme ~side b) extremum then i else best)
+  in
+  (extremum, idx)
+
+(* Counter-move extreme across [bars]:
+   Long  → lowest  low  ([Float.infinity] if empty).
+   Short → highest high ([Float.neg_infinity] if empty). *)
+let _counter_move_extreme ~side bars =
+  let init =
+    match side with Long -> Float.infinity | Short -> Float.neg_infinity
+  in
+  List.fold bars ~init ~f:(fun acc b ->
+      match side with
+      | Long -> Float.min acc (_counter_extreme ~side b)
+      | Short -> Float.max acc (_counter_extreme ~side b))
+
+(* Relative counter-move depth:
+   Long  → (anchor_high - correction_low) / anchor_high — drawdown from peak.
+   Short → (rally_high - anchor_low)     / anchor_low   — rally from trough.
+
+   Zero when the anchor is non-positive — a pathological input that callers
+   should not pass but we guard against to avoid division-by-zero or negative
+   depths. *)
+let _depth_pct ~side ~anchor ~counter =
+  if Float.( <= ) anchor 0.0 then 0.0
+  else
+    match side with
+    | Long -> (anchor -. counter) /. anchor
+    | Short -> (counter -. anchor) /. anchor
+
+(* Post-anchor slice logic: given an anchor and the bars after it, return
+   [Some extreme] if the counter-move is deep enough, else [None]. *)
+let _qualifying_level ~side ~anchor ~after_anchor ~min_pullback_pct =
+  match after_anchor with
+  | [] -> None
+  | _ ->
+      let counter = _counter_move_extreme ~side after_anchor in
+      if Float.( >= ) (_depth_pct ~side ~anchor ~counter) min_pullback_pct then
+        Some counter
+      else None
+
+let find_recent_level ~bars ~as_of ~side ~min_pullback_pct ~lookback_bars =
+  match _window ~bars ~as_of ~lookback_bars with
+  | [] -> None
+  | window ->
+      let anchor, anchor_idx = _anchor_index ~side window in
+      let after_anchor = List.drop window (anchor_idx + 1) in
+      _qualifying_level ~side ~anchor ~after_anchor ~min_pullback_pct

--- a/trading/trading/weinstein/stops/lib/support_floor.mli
+++ b/trading/trading/weinstein/stops/lib/support_floor.mli
@@ -1,0 +1,70 @@
+(** Support/resistance primitive: derives the prior correction extreme from a
+    daily bar history.
+
+    Weinstein, Ch. 6 §5.1 ("Initial Stop Placement"):
+
+    {v
+      Long:  Place BELOW the significant support floor (prior correction low)
+             BEFORE the breakout.
+      Short: Place ABOVE the significant resistance ceiling (prior
+             counter-rally high) BEFORE the breakdown.
+    v}
+
+    Callers pipe the output into {!Weinstein_stops.compute_initial_stop}'s
+    [reference_level] argument. When no qualifying move exists in the lookback
+    window, the function returns [None] and the caller falls back to the
+    fixed-buffer proxy.
+
+    All computation is pure — same input gives the same output. *)
+
+val find_recent_level :
+  bars:Types.Daily_price.t list ->
+  as_of:Core.Date.t ->
+  side:Trading_base.Types.position_side ->
+  min_pullback_pct:float ->
+  lookback_bars:int ->
+  float option
+(** [find_recent_level ~bars ~as_of ~side ~min_pullback_pct ~lookback_bars]
+    returns the reference level of the most recent qualifying counter-trend move
+    ending at or before [as_of].
+
+    Long side:
+    - Identify the {b peak}: the bar in the window with the highest
+      [high_price]. Ties are broken by taking the latest date.
+    - Identify the {b correction low}: the minimum [low_price] across bars
+      strictly after the peak date, through [as_of].
+    - Qualify when
+      [(peak_high -. correction_low) /. peak_high >= min_pullback_pct].
+
+    Short side (mirror):
+    - Identify the {b trough}: the bar in the window with the lowest
+      [low_price]. Ties are broken by taking the latest date.
+    - Identify the {b rally high}: the maximum [high_price] across bars strictly
+      after the trough date, through [as_of].
+    - Qualify when
+      [(rally_high -. trough_low) /. trough_low >= min_pullback_pct].
+
+    [min_pullback_pct] is symmetric — it is the depth threshold on either side.
+    Long scales drawdown by the peak high; short scales the counter-rally by the
+    trough low.
+
+    Returns [None] when:
+    - [bars] is empty, or no bars are dated at or on [as_of];
+    - the anchor (peak for long, trough for short) falls on the last bar of the
+      window — no counter-move observed;
+    - the counter-move depth is below [min_pullback_pct];
+    - [lookback_bars <= 0].
+
+    Parameters:
+    - [bars] — daily price bars in chronological order (oldest first), matching
+      the layout produced by {!Bar_history}. Bars outside the [as_of] window are
+      ignored.
+    - [as_of] — the date at which the caller is computing a stop (usually the
+      entry date). Bars strictly after this date are excluded.
+    - [side] — [Long] returns a support floor (correction low); [Short] returns
+      a resistance ceiling (rally high).
+    - [min_pullback_pct] — minimum counter-move depth required to qualify.
+      Weinstein's book default is [0.08] (8%).
+    - [lookback_bars] — maximum window size (in bars, not calendar days). Chosen
+      to capture the most recent counter-move without reaching back into an
+      older regime. *)

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.ml
@@ -3,6 +3,7 @@ open Core
 open Weinstein_types
 open Trading_base.Types
 include Stop_types
+module Support_floor = Support_floor
 
 (* ---- Nudge functions ---- *)
 

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.mli
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.mli
@@ -14,6 +14,11 @@ open Trading_base.Types
 include module type of Stop_types
 (** @inline *)
 
+module Support_floor = Support_floor
+(** Derives the prior correction extreme from a bar history — correction low for
+    longs, counter-rally high for shorts. Feeds the [reference_level] argument
+    to {!compute_initial_stop}. See the module doc for algorithm details. *)
+
 (** {1 Core Functions} *)
 
 val compute_initial_stop :

--- a/trading/trading/weinstein/stops/test/dune
+++ b/trading/trading/weinstein/stops/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_weinstein_stops regression_test)
+ (names test_weinstein_stops regression_test test_support_floor)
  (libraries
   weinstein_trading.stops
   weinstein.types

--- a/trading/trading/weinstein/stops/test/test_support_floor.ml
+++ b/trading/trading/weinstein/stops/test/test_support_floor.ml
@@ -1,0 +1,464 @@
+(** Tests for [Support_floor.find_recent_level].
+
+    Scenarios cover peak/trough + counter-move identification, depth
+    thresholding, lookback truncation, tie-breaking, and degenerate inputs
+    (empty, single bar, monotonic series, flat prices).
+
+    Long and short sides are covered symmetrically: long looks for a prior
+    correction low (support floor); short looks for a prior counter-rally high
+    (resistance ceiling). *)
+
+open OUnit2
+open Core
+open Matchers
+open Trading_base.Types
+module Support_floor = Weinstein_stops.Support_floor
+
+(* ---- Test helpers ---- *)
+
+(* Build a daily bar; defaults produce a non-gapping bar centred on [close]. *)
+let make_bar ~date ~high ~low ~close =
+  {
+    Types.Daily_price.date = Date.of_string date;
+    open_price = close;
+    high_price = high;
+    low_price = low;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+(* ==================================================================== *)
+(*                           Long-side tests                            *)
+(* ==================================================================== *)
+
+(* ---- Peak + pullback identification ---- *)
+
+let test_long_happy_path _ =
+  (* Clean peak + correction pattern:
+       bar 1: low 100 high 102  (base)
+       bar 2: low 108 high 110  (<- peak: high=110)
+       bar 3: low  99 high 101  (correction: low=99)
+       bar 4: low  98 high 103  (correction: low=98 — the overall correction low)
+       bar 5: low 100 high 105  (recovery)
+     Depth: (110 - 98) / 110 = 10.9% >= 8% -> Some 98.0 *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:102.0 ~low:100.0 ~close:101.0;
+      make_bar ~date:"2024-01-02" ~high:110.0 ~low:108.0 ~close:109.0;
+      make_bar ~date:"2024-01-03" ~high:101.0 ~low:99.0 ~close:100.0;
+      make_bar ~date:"2024-01-04" ~high:103.0 ~low:98.0 ~close:102.0;
+      make_bar ~date:"2024-01-05" ~high:105.0 ~low:100.0 ~close:104.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-05")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    (is_some_and (float_equal 98.0))
+
+(* ---- Depth threshold ---- *)
+
+let test_long_below_threshold_returns_none _ =
+  (* Peak 110; lowest low after peak is 103. Depth 6.4% < 8% -> None. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:102.0 ~low:100.0 ~close:101.0;
+      make_bar ~date:"2024-01-02" ~high:110.0 ~low:108.0 ~close:109.0;
+      make_bar ~date:"2024-01-03" ~high:106.0 ~low:103.0 ~close:104.0;
+      make_bar ~date:"2024-01-04" ~high:107.0 ~low:104.0 ~close:106.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-04")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+let test_long_threshold_boundary _ =
+  (* Exactly at threshold: peak 100, low 92. Depth 8.0% == 8% -> Some 92.0. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-02" ~high:100.0 ~low:99.0 ~close:100.0;
+      make_bar ~date:"2024-01-03" ~high:95.0 ~low:92.0 ~close:93.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-03")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    (is_some_and (float_equal 92.0))
+
+(* ---- Peak at last bar: no pullback yet ---- *)
+
+let test_long_peak_at_end_returns_none _ =
+  (* Monotonically rising — the peak is the last bar, so there is no drawdown
+     to measure. Expected: None. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:100.0 ~low:99.0 ~close:99.5;
+      make_bar ~date:"2024-01-02" ~high:105.0 ~low:100.0 ~close:104.0;
+      make_bar ~date:"2024-01-03" ~high:110.0 ~low:105.0 ~close:109.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-03")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+(* ---- Lookback truncation ---- *)
+
+let test_long_truncates_to_lookback_window _ =
+  (* Earlier correction (peak 200 / low 160) is outside the lookback window;
+     the recent quiet zone has no pullback > 8%. With lookback_bars=3 we
+     should only see bars 4..6 and get None. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:202.0 ~low:199.0 ~close:200.0;
+      make_bar ~date:"2024-01-02" ~high:200.0 ~low:160.0 ~close:165.0;
+      make_bar ~date:"2024-01-03" ~high:172.0 ~low:168.0 ~close:170.0;
+      make_bar ~date:"2024-01-04" ~high:171.0 ~low:169.0 ~close:170.5;
+      make_bar ~date:"2024-01-05" ~high:172.0 ~low:170.0 ~close:171.5;
+      make_bar ~date:"2024-01-06" ~high:173.0 ~low:170.5 ~close:172.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-06")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:3)
+    is_none
+
+let test_long_lookback_brings_pullback_into_view _ =
+  (* Peak bar on 01-01, correction low on 01-02. With lookback=2 we capture
+     both bars and the correction qualifies. With lookback=1 only 01-02 is
+     in the window, the peak is the last bar, so None. *)
+  let bars =
+    [
+      make_bar ~date:"2023-12-20" ~high:80.0 ~low:78.0 ~close:79.0;
+      make_bar ~date:"2024-01-01" ~high:100.0 ~low:98.0 ~close:99.0;
+      make_bar ~date:"2024-01-02" ~high:95.0 ~low:85.0 ~close:86.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-02")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:2)
+    (is_some_and (float_equal 85.0));
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-02")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:1)
+    is_none
+
+(* ---- Equal-high tie-breaking: latest peak wins ---- *)
+
+let test_long_tie_breaks_to_latest_peak _ =
+  (* Two equal highs (100.0) on days 1 and 3. Later peak anchors the pullback,
+     so only bars after day 3 count. Day 4 low=94 -> depth 6% < 8% -> None. If
+     tie-break used the earlier peak we'd see day 2's low=85 and return Some. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:100.0 ~low:98.0 ~close:99.0;
+      make_bar ~date:"2024-01-02" ~high:95.0 ~low:85.0 ~close:88.0;
+      make_bar ~date:"2024-01-03" ~high:100.0 ~low:90.0 ~close:99.0;
+      make_bar ~date:"2024-01-04" ~high:98.0 ~low:94.0 ~close:96.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-04")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+(* ---- as_of excludes future bars ---- *)
+
+let test_long_respects_as_of _ =
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:110.0 ~low:108.0 ~close:109.0;
+      make_bar ~date:"2024-01-02" ~high:103.0 ~low:98.0 ~close:100.0;
+      make_bar ~date:"2024-01-03" ~high:115.0 ~low:105.0 ~close:114.0;
+      make_bar ~date:"2024-01-04" ~high:118.0 ~low:90.0 ~close:92.0;
+    ]
+  in
+  (* as_of = 01-02: only first two bars considered. Peak 110, low 98, depth
+     10.9% -> Some 98.0. The post-01-02 drop is invisible. *)
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-02")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    (is_some_and (float_equal 98.0))
+
+(* ---- Configurable depth threshold ---- *)
+
+let test_long_custom_threshold _ =
+  (* Peak 100, low 97. 3% depth. Strict 8% rejects; 2% accepts. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:100.0 ~low:99.0 ~close:99.5;
+      make_bar ~date:"2024-01-02" ~high:99.0 ~low:97.0 ~close:98.0;
+    ]
+  in
+  let as_of = Date.of_string "2024-01-02" in
+  assert_that
+    (Support_floor.find_recent_level ~bars ~as_of ~side:Long
+       ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none;
+  assert_that
+    (Support_floor.find_recent_level ~bars ~as_of ~side:Long
+       ~min_pullback_pct:0.02 ~lookback_bars:52)
+    (is_some_and (float_equal 97.0))
+
+(* ==================================================================== *)
+(*                           Short-side tests                           *)
+(* ==================================================================== *)
+
+(* ---- Trough + rally identification ---- *)
+
+let test_short_happy_path _ =
+  (* Mirror of long happy path — a trough with a counter-rally afterwards:
+       bar 1: low  99 high 100 (base near 100)
+       bar 2: low  90 high  92 (<- trough: low=90)
+       bar 3: low  98 high 100 (rally: high=100)
+       bar 4: low  97 high 102 (rally: high=102 — overall rally peak)
+       bar 5: low  95 high  99 (fade)
+     Depth: (102 - 90) / 90 = 13.3% >= 8% -> Some 102.0 *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:100.0 ~low:99.0 ~close:99.5;
+      make_bar ~date:"2024-01-02" ~high:92.0 ~low:90.0 ~close:91.0;
+      make_bar ~date:"2024-01-03" ~high:100.0 ~low:98.0 ~close:99.0;
+      make_bar ~date:"2024-01-04" ~high:102.0 ~low:97.0 ~close:98.0;
+      make_bar ~date:"2024-01-05" ~high:99.0 ~low:95.0 ~close:96.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-05")
+       ~side:Short ~min_pullback_pct:0.08 ~lookback_bars:52)
+    (is_some_and (float_equal 102.0))
+
+(* ---- Depth threshold ---- *)
+
+let test_short_below_threshold_returns_none _ =
+  (* Trough 90; highest high after trough is 95. Depth 5.6% < 8% -> None. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:100.0 ~low:99.0 ~close:99.5;
+      make_bar ~date:"2024-01-02" ~high:92.0 ~low:90.0 ~close:91.0;
+      make_bar ~date:"2024-01-03" ~high:94.0 ~low:92.0 ~close:93.0;
+      make_bar ~date:"2024-01-04" ~high:95.0 ~low:93.0 ~close:94.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-04")
+       ~side:Short ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+let test_short_threshold_boundary _ =
+  (* Exactly at threshold: trough 100, rally high 108. Depth 8.0% == 8% ->
+     Some 108.0. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-02" ~high:101.0 ~low:100.0 ~close:100.5;
+      make_bar ~date:"2024-01-03" ~high:108.0 ~low:105.0 ~close:107.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-03")
+       ~side:Short ~min_pullback_pct:0.08 ~lookback_bars:52)
+    (is_some_and (float_equal 108.0))
+
+(* ---- Trough at last bar: no rally yet ---- *)
+
+let test_short_trough_at_end_returns_none _ =
+  (* Monotonically falling — the trough is the last bar, so there is no
+     counter-rally to measure. Expected: None. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:110.0 ~low:109.0 ~close:109.5;
+      make_bar ~date:"2024-01-02" ~high:108.0 ~low:105.0 ~close:106.0;
+      make_bar ~date:"2024-01-03" ~high:105.0 ~low:100.0 ~close:101.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-03")
+       ~side:Short ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+(* ---- Equal-low tie-breaking: latest trough wins ---- *)
+
+let test_short_tie_breaks_to_latest_trough _ =
+  (* Two equal lows (90.0) on days 1 and 3. Later trough anchors the rally,
+     so only bars after day 3 count. Day 4 high=95 -> depth 5.6% < 8% -> None.
+     If tie-break used the earlier trough we'd see day 2's high=105 and
+     return Some 105.0. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:92.0 ~low:90.0 ~close:91.0;
+      make_bar ~date:"2024-01-02" ~high:105.0 ~low:95.0 ~close:100.0;
+      make_bar ~date:"2024-01-03" ~high:100.0 ~low:90.0 ~close:92.0;
+      make_bar ~date:"2024-01-04" ~high:95.0 ~low:92.0 ~close:94.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-04")
+       ~side:Short ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+(* ---- Lookback truncation ---- *)
+
+let test_short_truncates_to_lookback_window _ =
+  (* Earlier rally (trough 100 / high 130) is outside the lookback window;
+     the recent quiet zone has no rally > 8%. With lookback_bars=3 we should
+     only see bars 4..6 and get None. *)
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:102.0 ~low:100.0 ~close:101.0;
+      make_bar ~date:"2024-01-02" ~high:130.0 ~low:100.0 ~close:129.0;
+      make_bar ~date:"2024-01-03" ~high:129.0 ~low:125.0 ~close:127.0;
+      make_bar ~date:"2024-01-04" ~high:128.0 ~low:126.0 ~close:127.0;
+      make_bar ~date:"2024-01-05" ~high:127.5 ~low:126.0 ~close:126.5;
+      make_bar ~date:"2024-01-06" ~high:127.0 ~low:125.5 ~close:126.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-06")
+       ~side:Short ~min_pullback_pct:0.08 ~lookback_bars:3)
+    is_none
+
+(* ==================================================================== *)
+(*                          Degenerate inputs                           *)
+(* ==================================================================== *)
+
+let test_empty_bars_returns_none_long _ =
+  assert_that
+    (Support_floor.find_recent_level ~bars:[]
+       ~as_of:(Date.of_string "2024-01-05")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+let test_empty_bars_returns_none_short _ =
+  assert_that
+    (Support_floor.find_recent_level ~bars:[]
+       ~as_of:(Date.of_string "2024-01-05")
+       ~side:Short ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+let test_single_bar_returns_none_long _ =
+  (* Single bar: anchor is also the last bar; no counter-move. *)
+  let bars =
+    [ make_bar ~date:"2024-01-01" ~high:100.0 ~low:90.0 ~close:95.0 ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-01")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+let test_single_bar_returns_none_short _ =
+  let bars =
+    [ make_bar ~date:"2024-01-01" ~high:100.0 ~low:90.0 ~close:95.0 ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-01")
+       ~side:Short ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+let test_flat_prices_returns_none_long _ =
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:100.0 ~low:100.0 ~close:100.0;
+      make_bar ~date:"2024-01-02" ~high:100.0 ~low:100.0 ~close:100.0;
+      make_bar ~date:"2024-01-03" ~high:100.0 ~low:100.0 ~close:100.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-03")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+let test_flat_prices_returns_none_short _ =
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:100.0 ~low:100.0 ~close:100.0;
+      make_bar ~date:"2024-01-02" ~high:100.0 ~low:100.0 ~close:100.0;
+      make_bar ~date:"2024-01-03" ~high:100.0 ~low:100.0 ~close:100.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-03")
+       ~side:Short ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+let test_as_of_before_all_bars_returns_none _ =
+  let bars =
+    [
+      make_bar ~date:"2024-02-01" ~high:100.0 ~low:90.0 ~close:95.0;
+      make_bar ~date:"2024-02-02" ~high:102.0 ~low:88.0 ~close:90.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-01")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:52)
+    is_none
+
+let test_zero_lookback_returns_none _ =
+  let bars =
+    [
+      make_bar ~date:"2024-01-01" ~high:110.0 ~low:108.0 ~close:109.0;
+      make_bar ~date:"2024-01-02" ~high:103.0 ~low:98.0 ~close:100.0;
+    ]
+  in
+  assert_that
+    (Support_floor.find_recent_level ~bars
+       ~as_of:(Date.of_string "2024-01-02")
+       ~side:Long ~min_pullback_pct:0.08 ~lookback_bars:0)
+    is_none
+
+let suite =
+  "support_floor"
+  >::: [
+         (* Long side *)
+         "long_happy_path" >:: test_long_happy_path;
+         "long_below_threshold" >:: test_long_below_threshold_returns_none;
+         "long_threshold_boundary" >:: test_long_threshold_boundary;
+         "long_peak_at_end" >:: test_long_peak_at_end_returns_none;
+         "long_truncates_to_lookback" >:: test_long_truncates_to_lookback_window;
+         "long_lookback_brings_pullback_into_view"
+         >:: test_long_lookback_brings_pullback_into_view;
+         "long_tie_breaks_to_latest_peak"
+         >:: test_long_tie_breaks_to_latest_peak;
+         "long_respects_as_of" >:: test_long_respects_as_of;
+         "long_custom_threshold" >:: test_long_custom_threshold;
+         (* Short side *)
+         "short_happy_path" >:: test_short_happy_path;
+         "short_below_threshold" >:: test_short_below_threshold_returns_none;
+         "short_threshold_boundary" >:: test_short_threshold_boundary;
+         "short_trough_at_end" >:: test_short_trough_at_end_returns_none;
+         "short_tie_breaks_to_latest_trough"
+         >:: test_short_tie_breaks_to_latest_trough;
+         "short_truncates_to_lookback"
+         >:: test_short_truncates_to_lookback_window;
+         (* Degenerate inputs *)
+         "empty_bars_long" >:: test_empty_bars_returns_none_long;
+         "empty_bars_short" >:: test_empty_bars_returns_none_short;
+         "single_bar_long" >:: test_single_bar_returns_none_long;
+         "single_bar_short" >:: test_single_bar_returns_none_short;
+         "flat_prices_long" >:: test_flat_prices_returns_none_long;
+         "flat_prices_short" >:: test_flat_prices_returns_none_short;
+         "as_of_before_bars" >:: test_as_of_before_all_bars_returns_none;
+         "zero_lookback" >:: test_zero_lookback_returns_none;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Why

Replaces the long-only primitive that shipped in prior revisions of this PR. Same Weinstein Ch. 6 §5.1 support-floor rule for the long side, plus the Ch. 11 mirror for the short side (prior counter-rally high = resistance ceiling). The wrapper + strategy-wiring are split into #390 stacked on top of this PR, keeping each side of the review focused and under the 500-line soft cap.

State machine (Initial → Trailing → Tightened) untouched.

See plan: `dev/plans/support-floor-stops-2026-04-16.md`.

## What

- `Support_floor.find_recent_level` — pure function with a `~side` parameter:
  - Long: peak (highest high in window) → correction low (lowest low strictly after peak). Return `Some` when `(peak - low) / peak >= min_pullback_pct`.
  - Short (mirror): trough (lowest low in window) → rally high (highest high strictly after trough). Return `Some` when `(high - trough) / trough >= min_pullback_pct`.
  - Ties broken by taking the latest anchor date (keeps the after-anchor slice short and recent).
- No caller yet for the short-side branch — lands here so the wrapper doesn't need a second API churn when the short-side strategy begins (see `dev/status/short-side-strategy.md`).
- 23 unit tests:
  - Long: happy path, depth boundary, below-threshold None, peak-at-end None, lookback truncation, lookback-brings-pullback-into-view, tie-breaks-to-latest-peak, respects-as_of, custom-threshold.
  - Short: happy path, below-threshold None, threshold boundary, trough-at-end None, tie-breaks-to-latest-trough, lookback truncation.
  - Degenerate: empty bars (both sides), single bar (both sides), flat prices (both sides), as_of-before-bars, zero-lookback.

## Stacked

PR B (#390) — `feat/support-floor-wiring`: adds `compute_initial_stop_with_floor` wrapper, `Bar_history.daily_bars_for`, and wires the primitive into `Weinstein_strategy._make_entry_transition` (long side only). Short-side wiring is a separate follow-up.

## QC status

- overall_qc PENDING — re-QC required after the rewrite (prior APPROVED was burnt by widening the primitive to both sides).
- structural — pure function, module boundary clean, no state.
- behavioral — long-side semantics unchanged from prior APPROVED review; short-side mirror is symmetric (verify against Ch. 11 short-sell examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)