### PR TITLE
fix(metrics): UnrealizedPnl uses last mark-to-market step, clarify CAGR docstring

### DIFF
--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -13,7 +13,7 @@ Each row: one line; deeper task detail in the linked status file.
 
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
-| [backtest-infra](backtest-infra.md) | BLOCKED | feat-backtest | — | Waiting on support-floor-stops PR #382 to merge; then pick up fixed-buffer vs support-floor experiment |
+| [backtest-infra](backtest-infra.md) | READY_FOR_REVIEW | feat-backtest | feat/metrics-unrealized-fix | UnrealizedPnl=0 bug fix + CAGR/annualized-return docstring (follow-up items 1+2). Still blocked on #382 for support-floor experiment |
 | [support-floor-stops](support-floor-stops.md) | READY_FOR_REVIEW | feat-weinstein | #382 | Merge #382 (overall_qc APPROVED this run) |
 | [short-side-strategy](short-side-strategy.md) | PENDING | — | — | Blocked on PR A of support-floor split (`feat/support-floor-stops`) — primitive widening to long+short |
 | [sector-data](sector-data.md) | IN_PROGRESS | ops-data | — | One-shot run of `fetch_finviz_sectors.exe` + filter with updated default.sexp (Item 2) |

--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -1,11 +1,11 @@
 # Status: Backtest Infrastructure
 
-## Last updated: 2026-04-15
+## Last updated: 2026-04-16
 
 ## Status
-IN_PROGRESS
+READY_FOR_REVIEW
 
-First experiment complete (stop-buffer hypothesis REJECTED on golden, see §Completed); framework formalization still open.
+UnrealizedPnl=0 bug fixed + CAGR annualized-return docstring clarified (follow-up items 1+2) on `feat/metrics-unrealized-fix`. First experiment (stop-buffer) complete and REJECTED on golden — see §Completed. Framework formalization still open; support-floor experiment still blocked on `feat-weinstein` #382.
 
 ## Ownership
 `feat-backtest` agent — see `.claude/agents/feat-backtest.md`. Owns
@@ -60,6 +60,14 @@ None.
 
 ## Completed
 
+- [x] **UnrealizedPnl=0 bug + annualized-return clarification**
+  (2026-04-16, `feat/metrics-unrealized-fix`) — see Follow-up items 1
+  and 2 for full root-cause writeup. Fix: `portfolio_state_computer.ml`
+  now tracks last mark-to-market step separately from last step, so
+  `UnrealizedPnl` no longer collapses to 0 when the sim ends on a
+  weekend. CAGR docstring clarified as the canonical annualized-return
+  metric. Verify: `dune runtest trading/simulation/test` (metrics
+  suite grew from 33 → 35 tests).
 - [x] **Stop-buffer tuning experiment** — full smoke + golden complete.
   Smoke (recovery-2023, 1yr) looked strongly positive for wider buffers
   (1.15 → +38.9%, Sharpe 1.78). **Golden (2018-2023, 6yr) reversed the
@@ -124,27 +132,35 @@ is informed by actual needs.
 
 ## Follow-up items (queued 2026-04-16)
 
-1. **Verify unrealized gain is meaningful in `summary.sexp`.** The
-   `UnrealizedPnl` metric is already emitted (from #304) and reads `0`
-   for the 2026-04-14 stop-buffer golden runs. That's suspicious for a
-   6-year simulation — either no positions are open at end-of-sim (by
-   coincidence? always?) or the computation has a bug. Read
-   `trading/simulation/lib/portfolio_state_computer.ml:23`
-   (`step.portfolio_value -. step.portfolio.current_cash`) and confirm
-   the final `step_result` actually carries open-position value. If the
-   metric is correct but simulations really do fully liquidate, add a
-   note to that effect — otherwise it looks like a logic gap every time
-   someone reads the summary.
+1. ~~**Verify unrealized gain is meaningful in `summary.sexp`.**~~ **[x]
+   RESOLVED 2026-04-16** — bug confirmed, fix landed on
+   `feat/metrics-unrealized-fix`. Root cause: the simulator produces a
+   `step_result` every calendar day, but `_compute_portfolio_value`
+   (at `trading/trading/simulation/lib/simulator.ml:123-134`) falls
+   back to `portfolio_value = current_cash` whenever any portfolio
+   position's price bar is missing for that date — including all
+   weekend/holiday steps. The portfolio-state computer was using the
+   absolute last step, which in 6-year backtests ending 2023-12-31
+   (Sunday) is 2023-12-30 (Saturday) — a non-trading day, hence
+   `portfolio_value == current_cash` and `UnrealizedPnl = 0` even with
+   `OpenPositionCount = 3`. Fix: track a `last_marked_step` alongside
+   `last_step`; `UnrealizedPnl` derives from the last mark-to-market
+   step (same heuristic as `Backtest.Runner._is_trading_day` at
+   `trading/trading/backtest/lib/runner.ml:28-36`); `OpenPositionCount`
+   still uses the absolute last step (positions are independent of
+   price-bar availability). Two new unit tests at
+   `trading/trading/simulation/test/test_metrics.ml` lock in the
+   behaviour. Verify: `dune runtest trading/simulation/test` → 35
+   metrics tests pass.
 
-2. **Add annualized-return metric for apples-to-apples comparison
-   across scenarios.** CAGR already ships (compound annual growth rate
-   — strictly the annualized *compound* return). What we don't have is
-   a simple annualized simple-return variant, or a per-scenario
-   "annualized return" field in the summary table that's visible
-   without computation. Decide: (a) is CAGR enough and we just surface
-   it more prominently in the scenario-runner output, or (b) do we
-   need a second metric. Probably (a) — but pick consciously, document
-   the decision in Metric_types docstring, and close the ticket.
+2. ~~**Add annualized-return metric for apples-to-apples comparison
+   across scenarios.**~~ **[x] RESOLVED 2026-04-16** — picked option
+   (a). CAGR already *is* the annualized-return metric — it's the
+   constant yearly rate that compounds initial to final portfolio
+   value over the backtest period. Clarified the docstring in
+   `trading/trading/simulation/lib/types/metric_types.ml:144-154` to
+   state this explicitly so future readers don't re-queue this. No
+   second metric added; no code behaviour change.
 
 3. **Rerun smoke + golden simulations once the Finviz sector mapping
    is promoted.** The 2026-04-14 stop-buffer results were produced

--- a/trading/trading/simulation/lib/portfolio_state_computer.ml
+++ b/trading/trading/simulation/lib/portfolio_state_computer.ml
@@ -7,41 +7,86 @@ module Simulator_types = Trading_simulation_types.Simulator_types
 
 type state = {
   last_step : Simulator_types.step_result option;
+      (** Last step seen, regardless of whether it is a trading day. Drives
+          [OpenPositionCount], which is independent of price-bar availability.
+      *)
+  last_marked_step : Simulator_types.step_result option;
+      (** Last step whose [portfolio_value] is a real mark-to-market (cash +
+          position market values). On non-trading days (weekends, holidays) or
+          when price bars for open-position symbols are missing, the simulator
+          falls back to [portfolio_value = current_cash] — such steps are
+          excluded here so [UnrealizedPnl] reflects actual end-of-sim unrealized
+          P&L. See [_is_marked_to_market]. *)
   total_trades : int;
 }
+
+(** True if [step] has a trustworthy mark-to-market [portfolio_value].
+
+    Heuristic (mirrors [Backtest.Runner._is_trading_day] at
+    [trading/trading/backtest/lib/runner.ml]): when there are no open positions,
+    [portfolio_value = cash] is trivially correct. When there are open
+    positions, [portfolio_value] should differ measurably from cash — otherwise
+    the simulator's [_compute_portfolio_value] fell back to cash because no
+    price bars were available for that date. *)
+let _is_marked_to_market (step : Simulator_types.step_result) =
+  let cash = step.portfolio.Trading_portfolio.Portfolio.current_cash in
+  let has_positions =
+    not (List.is_empty step.portfolio.Trading_portfolio.Portfolio.positions)
+  in
+  (not has_positions) || Float.(abs (step.portfolio_value -. cash) > 1e-2)
 
 let _trade_frequency ~total_trades ~start_date ~end_date =
   let days = Float.of_int (Date.diff end_date start_date) in
   let months = days /. 30.44 in
   if Float.(months <= 0.0) then 0.0 else Float.of_int total_trades /. months
 
-let _metrics_from_step ~(step : Simulator_types.step_result) ~total_trades
-    ~start_date ~end_date =
+(** Build metric set. [position_step] is the step that determines
+    [OpenPositionCount] (always the absolute last step). [marked_step] is the
+    step that determines [UnrealizedPnl] (the last mark-to-market step, which
+    may or may not equal [position_step]). *)
+let _metrics_from_step ~(position_step : Simulator_types.step_result)
+    ~(marked_step : Simulator_types.step_result) ~total_trades ~start_date
+    ~end_date =
   Metric_types.of_alist_exn
     [
-      (OpenPositionCount, Float.of_int (List.length step.portfolio.positions));
-      (UnrealizedPnl, step.portfolio_value -. step.portfolio.current_cash);
+      ( OpenPositionCount,
+        Float.of_int (List.length position_step.portfolio.positions) );
+      ( UnrealizedPnl,
+        marked_step.portfolio_value
+        -. marked_step.portfolio.Trading_portfolio.Portfolio.current_cash );
       (TradeFrequency, _trade_frequency ~total_trades ~start_date ~end_date);
     ]
 
 let _update ~state ~step =
   {
     last_step = Some step;
+    last_marked_step =
+      (if _is_marked_to_market step then Some step else state.last_marked_step);
     total_trades = state.total_trades + List.length step.trades;
   }
 
 let _finalize ~state ~(config : Simulator_types.config) =
   match state.last_step with
   | None -> Metric_types.empty
-  | Some step ->
-      _metrics_from_step ~step ~total_trades:state.total_trades
-        ~start_date:config.start_date ~end_date:config.end_date
+  | Some position_step ->
+      (* If no step in the sim was marked-to-market (degenerate: e.g. all
+         steps were non-trading days with open positions), fall back to the
+         last step. UnrealizedPnl will then be 0 as before — not great, but
+         consistent with pre-fix behaviour for that edge case. *)
+      let marked_step =
+        Option.value state.last_marked_step ~default:position_step
+      in
+      _metrics_from_step ~position_step ~marked_step
+        ~total_trades:state.total_trades ~start_date:config.start_date
+        ~end_date:config.end_date
 
 let computer () : Simulator_types.any_metric_computer =
   Simulator_types.wrap_computer
     {
       name = "portfolio_state";
-      init = (fun ~config:_ -> { last_step = None; total_trades = 0 });
+      init =
+        (fun ~config:_ ->
+          { last_step = None; last_marked_step = None; total_trades = 0 });
       update = _update;
       finalize = _finalize;
     }

--- a/trading/trading/simulation/lib/types/metric_types.ml
+++ b/trading/trading/simulation/lib/types/metric_types.ml
@@ -145,7 +145,11 @@ let get_metric_info = function
       {
         display_name = "CAGR";
         description =
-          "Compound annual growth rate: annualized return as a percentage";
+          "Compound annual growth rate — this IS the annualized-return metric. \
+           Expressed as a percent, it is the constant yearly rate that \
+           compounds initial portfolio value to final portfolio value over the \
+           backtest period. Use this to compare scenarios of different lengths \
+           apples-to-apples.";
         unit = Percent;
       }
   | CalmarRatio ->
@@ -166,8 +170,12 @@ let get_metric_info = function
       {
         display_name = "Unrealized P&L";
         description =
-          "Total unrealized profit/loss at end of simulation: final value - \
-           initial cash - realized P&L";
+          "Total unrealized profit/loss at end of simulation: \
+           last-marked-to-market portfolio_value minus current_cash on that \
+           step. Computed from the most recent step whose portfolio_value \
+           actually reflects position mark-to-market — non-trading days \
+           (weekends, holidays, missing bars) are skipped because the \
+           simulator falls back to portfolio_value = cash on those days.";
         unit = Dollars;
       }
   | TradeFrequency ->

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -582,6 +582,106 @@ let test_portfolio_state_with_trades _ =
     (is_some_and (float_equal 0.0));
   assert_that metrics (contains_entry UnrealizedPnl (float_equal 50.0))
 
+(** Build a portfolio with one open long position by applying a buy trade. *)
+let _portfolio_with_open_position ~symbol ~quantity ~price =
+  let base = Trading_portfolio.Portfolio.create ~initial_cash:10000.0 () in
+  let buy =
+    {
+      Trading_base.Types.id = "t1";
+      order_id = "o1";
+      symbol;
+      side = Buy;
+      quantity;
+      price;
+      commission = 0.0;
+      timestamp = Time_ns_unix.now ();
+    }
+  in
+  match Trading_portfolio.Portfolio.apply_single_trade base buy with
+  | Ok p -> p
+  | Error err ->
+      OUnit2.assert_failure
+        ("failed to build test portfolio: " ^ Status.show err)
+
+(** Reproduces the UnrealizedPnl=0 bug. The simulator produces a step every
+    calendar day. On the final day (often a weekend), price bars are missing, so
+    [_compute_portfolio_value] falls back to [portfolio_value = cash] even
+    though positions are open — leaving a spurious [UnrealizedPnl = 0] in the
+    summary. The computer must skip those steps and use the last real
+    mark-to-market step. *)
+let test_portfolio_state_skips_non_trading_final_step _ =
+  let config = make_config () in
+  let portfolio =
+    _portfolio_with_open_position ~symbol:"AAPL" ~quantity:10.0 ~price:100.0
+  in
+  let cash = portfolio.current_cash in
+  let mtm_value = cash +. (10.0 *. 105.0) in
+  let steps =
+    [
+      {
+        (* Trading day — position marked to market at $105: MTM = $1050. *)
+        date = date_of_string "2024-01-05";
+        portfolio;
+        portfolio_value = mtm_value;
+        trades = [];
+        orders_submitted = [];
+      };
+      {
+        (* Non-trading day — simulator fell back to cash. *)
+        date = date_of_string "2024-01-06";
+        portfolio;
+        portfolio_value = cash;
+        trades = [];
+        orders_submitted = [];
+      };
+    ]
+  in
+  let computer = portfolio_state_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  assert_that metrics
+    (map_includes
+       [
+         (* OpenPositionCount still comes from the absolute final step
+            (positions don't depend on price bars). *)
+         (OpenPositionCount, float_equal 1.0);
+         (* UnrealizedPnl derived from the last marked-to-market step. *)
+         (UnrealizedPnl, float_equal (mtm_value -. cash));
+       ])
+
+(** Guard: when every step is marked-to-market, the final step wins unchanged.
+*)
+let test_portfolio_state_uses_last_step_when_all_trading_days _ =
+  let config = make_config () in
+  let portfolio =
+    _portfolio_with_open_position ~symbol:"AAPL" ~quantity:10.0 ~price:100.0
+  in
+  let cash = portfolio.current_cash in
+  let steps =
+    [
+      {
+        date = date_of_string "2024-01-05";
+        portfolio;
+        portfolio_value = cash +. 500.0;
+        trades = [];
+        orders_submitted = [];
+      };
+      {
+        date = date_of_string "2024-01-06";
+        portfolio;
+        portfolio_value = cash +. 800.0;
+        trades = [];
+        orders_submitted = [];
+      };
+    ]
+  in
+  let computer = portfolio_state_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  assert_that metrics
+    (map_includes
+       [
+         (OpenPositionCount, float_equal 1.0); (UnrealizedPnl, float_equal 800.0);
+       ])
+
 (* ==================== Test Suite ==================== *)
 
 let suite =
@@ -641,6 +741,10 @@ let suite =
          (* Portfolio state tests *)
          "portfolio state no steps" >:: test_portfolio_state_no_steps;
          "portfolio state with trades" >:: test_portfolio_state_with_trades;
+         "portfolio state skips non-trading final step"
+         >:: test_portfolio_state_skips_non_trading_final_step;
+         "portfolio state uses last step when all trading days"
+         >:: test_portfolio_state_uses_last_step_when_all_trading_days;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Fix for `UnrealizedPnl = 0` in golden runs despite `OpenPositionCount > 0`, plus docstring clarification that `CAGR` is the annualized-return metric.

## Root cause

Bug is **not** in the metric formula at `portfolio_state_computer.ml:23`. Bug is in `Simulator._compute_portfolio_value` (`simulator.ml:123-134`): when any portfolio-position symbol lacks a price bar for the step's date, it falls back to `portfolio.current_cash`. The simulator emits a `step_result` every calendar day, so weekends/holidays always hit that fallback.

For 6-year goldens ending 2023-12-31 (Sunday), the final step is 2023-12-30 (Saturday) → `portfolio_value == current_cash` → `UnrealizedPnl = 0` regardless of open positions.

`Backtest.Runner._is_trading_day` (`runner.ml:28-36`) already filters this at the summary layer using `|portfolio_value - cash| > 1e-2`; the metric layer was just unaware.

## Fix

`portfolio_state_computer.ml` now tracks a separate `last_marked_step` pointer using the same heuristic as `Runner._is_trading_day`:
- `UnrealizedPnl` reads from the last mark-to-market step (trading day).
- `OpenPositionCount` continues to use the absolute last step (count is independent of price bars).
- Degenerate fallback preserved when no step was ever marked-to-market.

Both layers now apply the same trading-day filter. Worth extracting a shared helper in a follow-up — noted but not taken here to keep the diff tight.

## CAGR docstring

`metric_types.ml:144-154` now states explicitly that `CAGR` IS the annualized-return metric, and contrasts it as apples-to-apples across scenarios of different lengths. No new metric added (avoids duplicating CAGR).

## Tests

- `test_portfolio_state_skips_non_trading_final_step` — reproduces the bug (Sat-final step with open positions → `UnrealizedPnl > 0`).
- `test_portfolio_state_uses_last_step_when_all_trading_days` — guards against overcorrection on windows that end on a trading day.

Metric suite: 33 → 35. `dune build`, full simulation suite, and `dune build @fmt` all clean.

## Closes

- `dev/status/backtest-infra.md` Follow-up items 1 (UnrealizedPnl bug) and 2 (annualized-return metric clarification).

## Test plan

- [x] `dune build && dune runtest` green
- [x] `dune build @fmt` clean
- [ ] Spot-check one golden run post-merge: `UnrealizedPnl` non-zero for scenarios with open positions at end-of-window

🤖 Generated with [Claude Code](https://claude.com/claude-code)