### PR TITLE
status(backtest-scale): new track for tier-aware loader (PENDING)

### DIFF
--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -14,6 +14,7 @@ Each row: one line; deeper task detail in the linked status file.
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
 | [backtest-infra](backtest-infra.md) | READY_FOR_REVIEW | feat-backtest | feat/metrics-scenario-unrealized-pin | Pin per-scenario `unrealized_pnl` range (follow-up to merged #393). Still blocked on #382 for support-floor experiment |
+| [backtest-scale](backtest-scale.md) | PENDING | feat-backtest | — | Blocked on PR #396 (plan merge) + step 2 tracing under backtest-infra. Target: tier-aware bar loader (Metadata/Summary/Full) |
 | [support-floor-stops](support-floor-stops.md) | READY_FOR_REVIEW | feat-weinstein | #390 | Merge #390 (wrapper + wiring; PR A #382 already merged) |
 | [short-side-strategy](short-side-strategy.md) | PENDING | — | — | Blocked on PR A of support-floor split (`feat/support-floor-stops`) — primitive widening to long+short |
 | [sector-data](sector-data.md) | IN_PROGRESS | ops-data | — | One-shot run of `fetch_finviz_sectors.exe` + filter with updated default.sexp (Item 2) |

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -1,0 +1,74 @@
+# Status: backtest-scale
+
+## Last updated: 2026-04-17
+
+## Status
+PENDING
+
+## Interface stable
+N/A — not started
+
+## Open PR
+—
+
+## Blocked on
+- PR #396 (plan) reviewed + merged — decisions locked there, including flag-gated rollout with automated parity test as acceptance gate.
+- Step 2 tracing (tracked under `backtest-infra.md`) — needed for A/B empiricism on the Legacy vs Tiered cutover.
+
+## Goal
+
+Tier-aware bar loader. Backtest working set scales with actively tracked symbols (~20-200), not inventory (10k+). Today's loader materializes all inventory bars; step 3 introduces three data-shape tiers so Memory budget becomes ~29 MB vs today's >7 GB.
+
+## Scope
+
+See `dev/plans/backtest-scale-optimization-2026-04-17.md` §Step 3 for the full spec. Summary:
+
+1. **Three tiers defined as types, not subsets.**
+   - `Metadata.t` — all inventory (~10k) — last_close, sector, cap, 30d_avg_volume
+   - `Summary.t` — sector-ranked subset (~2k) — 30w MA, RS line, stage heuristic, ATR
+   - `Full.t` — breakout candidates + held positions (~20-200) — complete OHLCV
+
+2. **`Bar_loader` module** with `promote : t -> symbols:string list -> to_:tier -> t`. Screener cascade calls promote as symbols advance through stages. Demotion on exit/liquidation frees Full-tier memory.
+
+3. **Runner flag `loader_strategy = Legacy | Tiered`.** Default `Legacy` at merge time. Acceptance gate = parity test on golden-small scenario (diffs trade count / total P&L / final portfolio value / each pinned metric within float ε). Merge blocked until parity holds.
+
+4. **Post-merge ramp:** flip default to `Tiered` in a tiny follow-up PR after a few weeks; retire `Legacy` in the one after.
+
+## Scope boundary
+
+Do NOT touch in this track:
+- Strategy, screener cascade logic (orchestrate calls, don't rewrite)
+- Incremental indicators (separate axis; likely unnecessary once tiers cut the 10k loop)
+- Parallel backtest workers (orthogonal)
+
+Build alongside existing `Bar_history` — don't modify it.
+
+## Branch
+`feat/backtest-tiered-loader`
+
+## Ownership
+`feat-backtest` agent (architectural scope). See `.claude/agents/feat-backtest.md`.
+
+## References
+
+- Plan: `dev/plans/backtest-scale-optimization-2026-04-17.md` (PR #396)
+- Engineering design: `docs/design/eng-design-4-simulation-tuning.md` — note that tier-aware loading is a pragmatic optimization over the design, not a change to the DATA_SOURCE abstraction
+- Prerequisite: `backtest-infra.md` step 2 (tracing) must land first
+
+## Size estimate
+
+~500-800 lines total. Split across 2-3 commits:
+- Bar_loader types + Metadata/Summary loaders (~200 LOC)
+- Full tier + promotion logic (~200 LOC)
+- Runner integration + screener cascade wiring (~200-300 LOC)
+- Tests + parity acceptance gate (~100 LOC)
+
+## QC
+
+overall_qc: PENDING
+structural_qc: PENDING
+behavioral_qc: PENDING
+
+Reviewers when work lands:
+- qc-structural — module boundaries between tiers; `Bar_history` untouched; parity test runs both strategies.
+- qc-behavioral — does strategy output (trades, metrics) actually match Legacy within ε? Any regression is a behavior bug, not a perf win.


### PR DESCRIPTION
## Summary

Register `backtest-scale` as a new track in the orchestrator's status directory so step 3 (tier-aware bar loader) from PR #396 can be picked up automatically once prerequisites land.

## Contents

- `dev/status/backtest-scale.md` — new track file (Status: PENDING; blocked on PR #396 merge + step 2 tracing)
- `dev/status/_index.md` — new row between `backtest-infra` and `support-floor-stops`

## Why a separate track (not a follow-up on `backtest-infra`)

Step 3 is architectural (~500-800 LOC introducing a new loader module, flag-gated rollout with automated parity acceptance gate). Different branch, different PR lifecycle, different ownership cadence. Step 1 (small universe) and Step 2 (tracing) stay under `backtest-infra.md` since they're smaller and naturally belong.

## Why PENDING, not IN_PROGRESS

Two prerequisites must land first:
1. PR #396 (plan + decisions) merged — locks `loader_strategy = Legacy | Tiered` flag design and the parity-test acceptance gate.
2. Step 2 tracing (tracked under `backtest-infra`) — step 3 needs `Trace.record` for Legacy-vs-Tiered empirical comparison.

Once both land, this track flips to IN_PROGRESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)