### PR TITLE
ci(orchestrator): run 3x daily (1/7/12 PT); concurrency:queue

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -42,12 +42,24 @@
 name: Daily orchestrator
 
 on:
-  # 1:05 AM Pacific. GitHub cron is UTC-only, no DST awareness — this is
-  # set for UTC-7 (PDT). During PST months (roughly Nov–Mar) the run
-  # drifts to 12:05 AM PT. Acceptable for a daily cadence.
+  # Three runs per day (1 AM / 7 AM / 12 PM Pacific) to amortize the
+  # rolling 5-hour Claude quota window. Minute `:17` avoids top-of-hour
+  # GHA load (scheduled jobs at :00 – :05 get delayed or silently
+  # dropped). GitHub cron is UTC-only, no DST awareness — these are set
+  # for UTC-7 (PDT); during PST months they drift back 1 hour.
   schedule:
-    - cron: "5 8 * * *"
+    - cron: "17 8 * * *"    # 01:17 PT
+    - cron: "17 14 * * *"   # 07:17 PT
+    - cron: "17 19 * * *"   # 12:17 PT
   workflow_dispatch:
+
+# Queue, do not cancel, if a previous run is still executing when the
+# next cron fires. A run mid-dispatch must not be killed — in-flight
+# subagents would leave branches half-pushed. Max overlap window is
+# bounded by timeout-minutes (180) below.
+concurrency:
+  group: daily-orchestrator
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Run the orchestrator 3 times/day (1 AM / 7 AM / 12 PM PT) instead of once, to amortize the rolling 5-hour Claude quota across the day and make more progress between human reviews.

## Changes

- `.github/workflows/orchestrator.yml`:
  - Schedule: 1 cron → 3 crons at `:17` UTC past 08/14/19 (minute offset dodges top-of-hour GHA load; bare `:05` is routinely dropped).
  - New `concurrency` block: queue new run if prior is still executing (180-min timeout caps overlap). **`cancel-in-progress: false`** — a run mid-dispatch must not be killed; in-flight subagents would leave branches half-pushed.

## Why this is safe now (not before PR #391)

- **PR #391** (merged): Step 1.5 dispatch guard — a subsequent run skips dispatch for any track whose PR is still open. No duplicate work.
- **PR #391's second commit**: Step 8a auto-merges the daily summary PR. Next run's Step 1b actually sees prior run's dispatch context (otherwise the summary would sit open, invisible to the next run).
- Filename format `dev/daily/${DATE}-runN.md` already supported by Step 7/8; `ls -t | head -n 1` picks the newest.

## Trade-offs

- 3× daily summary PRs, all auto-merged. Cluttery but fine — they're observational.
- If GHA still drops a scheduled job at one of the three slots, the day gets 2 runs instead of 3. Degradation, not failure.
- DST: these are UTC-locked, so PST (Nov–Mar) shifts everything back 1 hour. Acceptable.

## Test plan

- [ ] Post-merge, next cron fires without overlap issue
- [ ] Two runs within the same day produce `dev/daily/<date>.md` and `dev/daily/<date>-run2.md` cleanly, both auto-merged
- [ ] Second run's Step 1b reads the first run's merged summary from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)