### PR TITLE
harness: agents stop touching _index.md (orchestrator Step 5.5 owns it)

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -138,22 +138,21 @@ the orchestrator does not act on this section)
 - `## Blocking Refactors` takes priority over feature work on the next run
 - `## Known gaps` is never empty-checked by automation; it is for human awareness only
 
-### 8. Index row update (required)
+### 8. Index row update — DO NOT EDIT `dev/status/_index.md` IN A FEATURE PR
 
-At the end of every session, in addition to updating the track's own
-status file, update the corresponding row in `dev/status/_index.md`:
+`dev/status/_index.md` is owned by the orchestrator. `lead-orchestrator`
+reconciles it in Step 5.5 against every `dev/status/*.md` at end-of-run.
 
-- **Status** cell — mirrors the status file's `## Status`
-- **Owner** cell — this agent's name (usually unchanged)
-- **Open PR(s)** cell — PRs currently open against this track
-- **Next task** cell — the top-of-queue item from the status file's
-  `## Next Steps`
+Feature PRs that also edit `_index.md` almost always collide with a
+sibling PR editing the same row, producing a merge conflict for every
+merge after the first. Don't cause that pain.
 
-Agents only touch their own row. Adding a new track to the system means
-creating the status file **and** adding a row to the index in the same
-commit. `lead-orchestrator` reconciles the index against all status
-files at end-of-run and flags drift, but agents should keep the row
-fresh so the index is usable between orchestrator runs.
+Only update your own `dev/status/<feature>.md`. The orchestrator will
+reflect it in the index on the next run.
+
+**Exception — adding a new track:** if this PR introduces a new track
+(new status file), add the corresponding row to `_index.md` in this PR
+too. The orchestrator won't know about the track otherwise.
 
 ---
 

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -113,7 +113,7 @@ dev/lib/run-in-env.sh dune runtest trading/devtools/checks/
 ## When done with each item
 
 1. Mark `[x]` in `dev/status/harness.md` with a note: what was built, where it lives, how to verify
-2. Update the **harness** row in `dev/status/_index.md` — align Status, Owner, Open PR, and Next task with the change. Only touch your own row.
+2. **Do NOT edit `dev/status/_index.md`** — the orchestrator reconciles it in Step 5.5. Editing the index in a harness PR causes merge conflicts with every sibling PR that touches the same row. Only touch `dev/status/harness.md`. Exception: if this PR adds a brand-new tracked work item that needs a new row (rare), add the row here since the orchestrator can't invent one.
 3. Commit and push:
    ```
    jj describe -m "harness: <short description>"

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -506,7 +506,7 @@ CRITICAL — before returning, do all of these (in this order, so a kill during 
   2. All changes committed and pushed (nothing uncommitted)
   3. Draft PR already open from first push (see commit discipline); if not, open it now via `gh pr create --draft`
   4. Update dev/status/<feature>.md (status, interface-stable, completed, in-progress, next-steps, commits)
-  5. Update your row in dev/status/_index.md (Status, Owner, Open PR, Next task) — only touch your own row
+  5. Do NOT edit dev/status/_index.md — I (the orchestrator) reconcile it in Step 5.5. Editing it from a feature PR collides with every sibling PR touching the same row. Exception: if this PR introduces a brand-new tracked work item (new status file), add the corresponding row to _index.md in this PR — I can't invent one.
   6. If all work is done and tests pass: mark the PR ready for review via `jst submit` or `gh pr ready`, and set status to READY_FOR_REVIEW in the status file
 
 <FEATURE-SPECIFIC CONSTRAINT IF ANY>
@@ -663,8 +663,15 @@ After all feature / harness / ops agents have returned and before the
 health-scanner fast scan, reconcile the status index so it reflects the
 state of the per-track status files. The index is the single-source
 view of all tracked work (Track | Status | Owner | Open PR(s) | Next
-task) — agents are expected to update their own row, but this step is
-the safety net.
+task).
+
+**Agents do NOT edit `_index.md` in their PRs** — this step is the sole
+writer. Feature PRs that touched the index caused a merge conflict on
+every subsequent merge, so the contract is now: agents write their own
+`dev/status/<track>.md`, orchestrator mirrors into the index. The only
+exception is a PR that introduces a brand-new tracked work item; the
+new row must come in with the new status file because the orchestrator
+has no other signal to invent one.
 
 For each row in `dev/status/_index.md`:
 

--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -141,11 +141,15 @@ When asked to fetch new symbols and update the inventory:
 ## Status file updates
 
 If your session advances a tracked data workstream (currently:
-`dev/status/sector-data.md`), at the end of the session update **both**:
+`dev/status/sector-data.md`), update only that file — Status, Completed,
+In Progress, Next Steps.
 
-1. The relevant `dev/status/<track>.md` — Status, Completed, In Progress, Next Steps.
-2. `dev/status/_index.md` — the row for that track. Keep Status, Owner, Open PR, and Next task aligned with (1). Only touch your own row.
+**Do NOT edit `dev/status/_index.md`.** The orchestrator reconciles it
+in Step 5.5 against every `dev/status/*.md` at end-of-run. Editing the
+index in a data PR causes merge conflicts with sibling PRs. Exception:
+if this PR introduces a brand-new tracked work item (new status file),
+add the corresponding row here since the orchestrator can't invent one.
 
 Pure one-shot fetches that do not change a tracked workstream (e.g. a
-one-off symbol refresh) do not need index updates — write the Data
+one-off symbol refresh) do not need status updates — write the Data
 Operations Report only.


### PR DESCRIPTION
## Summary

Stop agents from touching `dev/status/_index.md` in feature / harness / ops PRs. The orchestrator's Step 5.5 reconciles the index from each `dev/status/<track>.md`; agents editing the index themselves just generates merge conflicts.

## Motivation

Every recent merge has produced the same conflict in `dev/status/_index.md`:

- PR #390 needed 2 rebases (one per sibling merge that touched the same row)
- PR #399 needed a rebase for the same reason
- Pattern: sibling PRs concurrently edit their own row → first merge wins, second collides

The orchestrator already reads every `dev/status/*.md` in Step 1 and reconciles `_index.md` in Step 5.5. The agent-side "also update the index" instruction was redundant AND collision-prone.

## Changes

- `.claude/agents/feat-agent-template.md` §8 — flipped from "Index row update (required)" to "DO NOT EDIT `_index.md` in a feature PR" with new-track exception
- `.claude/agents/harness-maintainer.md` — same directive in "When done with each item"
- `.claude/agents/ops-data.md` — same directive in "Status file updates"
- `.claude/agents/lead-orchestrator.md`:
  - Step 4 dispatch prompt template — tell feat-agents not to touch the index
  - Step 5.5 — make explicit that the orchestrator is the sole writer (not "safety net")

## Exception preserved

PRs that introduce a brand-new tracked work item still add the row in the same commit — orchestrator can't invent a row for a track it's never seen.

## Test plan

- [ ] Next orchestrator run's Step 5.5 catches any drift on rows agents updated before this lands
- [ ] Next feat-agent PR leaves `_index.md` untouched; orchestrator's reconciliation is the only index edit in the summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)