### PR TITLE
harness: orchestrator summary cleanup 2026-04-17

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -119,11 +119,19 @@ agents on tracks where work is in flight.
 
 ```bash
 # For each eligible track (substitute the actual branch pattern):
-GH_TOKEN=$GH_TOKEN gh pr list \
-  --state open \
-  --json number,headRefName,mergeable,statusCheckRollup \
-  --jq '.[] | select(.headRefName | startswith("feat/<track>"))' \
-  2>/dev/null
+# gh is not available in the devcontainer — use curl against the REST API.
+REPO="${GITHUB_REPOSITORY:-dayfine/trading}"
+OWNER="${REPO%/*}"
+curl -sSL \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${REPO}/pulls?head=${OWNER}:feat/<track>&state=open" \
+  | python3 -c '
+import json,sys
+prs = json.load(sys.stdin)
+for pr in prs:
+    print(pr["number"], pr["head"]["ref"], pr["head"]["sha"])
+'
 ```
 
 **Decision rules per track:**
@@ -131,7 +139,7 @@ GH_TOKEN=$GH_TOKEN gh pr list \
 ```
 FOR each eligible track from Step 1:
   IF any open PRs found on feat/<track> or feat/<track>/* branches:
-    tip_sha = $(GH_TOKEN=$GH_TOKEN gh pr view <pr_number> --json headRefOid --jq .headRefOid)
+    tip_sha = (SHA from the curl output above for that PR)
     last_review_sha = (parse "Reviewed SHA:" line from dev/reviews/<track>.md, if it exists)
 
     IF track status is READY_FOR_REVIEW AND tip_sha != last_review_sha:
@@ -479,18 +487,18 @@ COMMIT DISCIPLINE — this is critical for reviewability AND for surviving rate-
   - **Open a DRAFT PR as soon as the first real commit is pushed** — do
     not wait until session end. If the session is killed mid-flight
     (rate-limit, timeout), at least the PR exists with whatever was
-    pushed. Use:
-      GH_TOKEN=$GH_TOKEN gh pr create --base main --head feat/<feature> \
-        --draft --title "feat(<area>): <one-line summary>" \
-        --body "WIP — opened early so work is not lost on kill."
+    pushed. Use jst to open the PR (jst is on PATH in trading-devcontainer):
+      GH_TOKEN=$GH_TOKEN jst submit feat/<feature>
     Subsequent pushes update the PR automatically (same branch).
-  - At session end, mark the PR ready for review via jst:
+    If jst is not available, use the URL printed by `jj git push`:
+      remote: Create a pull request for '<branch>' on GitHub by visiting:
+      remote:      https://github.com/dayfine/trading/pull/new/<branch>
+  - At session end, mark the PR ready for review:
       GH_TOKEN=$GH_TOKEN jst submit feat/<feature>
     jst is on PATH in the orchestrator runtime (trading-devcontainer image
-    + dev/run.sh assumes both). If GH_TOKEN isn't set, jst will fail with
-    a clear error and the branch is still pushed — the draft PR is still
-    there. The orchestrator can then fall back to marking it ready in
-    Step 7.
+    + dev/run.sh). If GH_TOKEN isn't set, jst will fail with a clear error
+    and the branch is still pushed — the orchestrator's Step 4.5 will
+    retry PR creation via the curl fallback.
 
 MAX ITERATIONS — build-fix cycles:
   - If you have attempted 3 consecutive build-fix cycles without passing
@@ -504,10 +512,10 @@ Stop at a natural boundary (a passing build, a completed module).
 CRITICAL — before returning, do all of these (in this order, so a kill during the last step still leaves the PR open):
   1. Ensure dune build && dune runtest passes **on a clean checkout** of your branch (your worktree is isolated, so this is the local state — but verify nothing relies on files from sibling subagents' workspaces; only content tracked in your commits should matter)
   2. All changes committed and pushed (nothing uncommitted)
-  3. Draft PR already open from first push (see commit discipline); if not, open it now via `gh pr create --draft`
+  3. Draft PR already open from first push (see commit discipline); if not, open it now via `GH_TOKEN=$GH_TOKEN jst submit feat/<feature>`
   4. Update dev/status/<feature>.md (status, interface-stable, completed, in-progress, next-steps, commits)
   5. Do NOT edit dev/status/_index.md — I (the orchestrator) reconcile it in Step 5.5. Editing it from a feature PR collides with every sibling PR touching the same row. Exception: if this PR introduces a brand-new tracked work item (new status file), add the corresponding row to _index.md in this PR — I can't invent one.
-  6. If all work is done and tests pass: mark the PR ready for review via `jst submit` or `gh pr ready`, and set status to READY_FOR_REVIEW in the status file
+  6. If all work is done and tests pass: mark the PR ready for review via `GH_TOKEN=$GH_TOKEN jst submit feat/<feature>`, and set status to READY_FOR_REVIEW in the status file
 
 <FEATURE-SPECIFIC CONSTRAINT IF ANY>
 
@@ -570,15 +578,21 @@ Recovery flow:
 
 ```bash
 # For each branch the subagent reported pushing:
-GH_TOKEN=$GH_TOKEN gh api "repos/dayfine/trading/pulls?head=dayfine:<branch>&state=open" \
-  --jq 'length' \
-  | grep -q '^0$' && \
-  GH_TOKEN=$GH_TOKEN jst submit <branch>
+# gh is not available in the devcontainer — use curl against the REST API.
+REPO="${GITHUB_REPOSITORY:-dayfine/trading}"
+OWNER="${REPO%/*}"
+PR_COUNT=$(curl -sSL \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${REPO}/pulls?head=${OWNER}:<branch>&state=open" \
+  | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
+[ "$PR_COUNT" -eq 0 ] && GH_TOKEN=$GH_TOKEN jst submit <branch>
 ```
 
 If jst still fails, surface the branch + jst error in the daily summary
-under §Escalations so the human can open the PR manually with one
-`gh pr create` call. Don't loop on it.
+under §Escalations with the GitHub PR-creation URL:
+  https://github.com/dayfine/trading/pull/new/<branch>
+so the human can open the PR manually with one click. Don't loop on it.
 
 This catches the "agent pushed branch but no PR" gap that would
 otherwise leave work invisible until the human reads the daily summary
@@ -679,7 +693,7 @@ For each row in `dev/status/_index.md`:
 2. Compare against the row:
    - **Status** — must match the `## Status` heading value (IN_PROGRESS / READY_FOR_REVIEW / MERGED / APPROVED / BLOCKED).
    - **Owner** — must match `## Ownership` (or be `—` if the track has no active owner).
-   - **Open PR(s)** — cross-reference against `gh pr list` filtered to that track's branches; each currently-open PR targeting main that carries this track's work should appear.
+   - **Open PR(s)** — cross-reference against the GitHub REST API (via `curl -sSL -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY:-dayfine/trading}/pulls?state=open"`) filtered to that track's branches; each currently-open PR targeting main that carries this track's work should appear.
    - **Next task** — must be the top item from `## Next Steps` (or an equivalent synthesis of the most concrete pending item).
 3. If any cell drifts, fix it. Do not touch unrelated rows.
 4. Update the `Last updated:` line to today's date.

--- a/.claude/agents/qc-behavioral.md
+++ b/.claude/agents/qc-behavioral.md
@@ -8,7 +8,7 @@ You are the **QC Behavioral Reviewer** for the Weinstein Trading System. You che
 
 ## VCS choice (automatic)
 
-If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b dev/reviews/<feature>-behavioral origin/main` for the review branch. Commit with `git commit`, push with `git push origin HEAD`.
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Write `dev/reviews/<feature>.md` in-place; do NOT commit or push. The orchestrator reads the file directly from your worktree.
 
 Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
 
@@ -128,14 +128,9 @@ APPROVED | NEEDS_REWORK
 
 Append your behavioral checklist to the existing `dev/reviews/<feature>.md` written by qc-structural. The file already begins with a `Reviewed SHA:` line written by qc-structural — do not overwrite it or move it. Append only below the existing structural checklist content.
 
-Use a new branch off `main@origin`:
+**IMPORTANT: Do NOT push your changes to origin.** The review file is written in-place in your worktree for the lead-orchestrator to read directly. Pushing creates orphan `dev/reviews/*` branches on origin that accumulate as clutter. Write the file and return — the orchestrator reads your output text and the file you wrote.
 
-```bash
-jj new main@origin
-jj describe -m "QC behavioral review: <feature-name>"
-```
-
-Append to the file:
+Write the review file using the Edit/Write tool (do not run jj or git push):
 
 ```markdown
 ---
@@ -152,13 +147,6 @@ Reviewer: qc-behavioral
 
 ## Verdict
 APPROVED | NEEDS_REWORK
-```
-
-Then:
-
-```bash
-jj bookmark set dev/reviews/<feature-name>-behavioral -r @
-jj git push --bookmark dev/reviews/<feature-name>-behavioral
 ```
 
 ### Update status

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -8,7 +8,7 @@ You are the **QC Structural Reviewer** for the Weinstein Trading System. You che
 
 ## VCS choice (automatic)
 
-If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b dev/reviews/<feature>-structural origin/main` for the review branch. Commit with `git commit`, push with `git push origin HEAD`.
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Write `dev/reviews/<feature>.md` in-place; do NOT commit or push. The orchestrator reads the file directly from your worktree.
 
 Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
 
@@ -147,12 +147,9 @@ jj new main@origin
 jj describe -m "QC structural review: <feature-name>"
 ```
 
-Write the file, then:
+Write the file using the Edit/Write tool.
 
-```bash
-jj bookmark set dev/reviews/<feature-name>-structural -r @
-jj git push --bookmark dev/reviews/<feature-name>-structural
-```
+**IMPORTANT: Do NOT push your changes to origin.** The review file is written in-place in your worktree for the lead-orchestrator to read directly. Pushing creates orphan `dev/reviews/*` branches on origin that accumulate as clutter. Write the file and return — the orchestrator reads your output text and the file you wrote.
 
 ### Update status
 

--- a/dev/lib/run-in-env.sh
+++ b/dev/lib/run-in-env.sh
@@ -10,10 +10,20 @@
 #
 # In GHA / devcontainer: set TRADING_IN_CONTAINER=1 and the script
 # runs natively (cd + opam env, no docker wrapping).
+#
+# Project root resolution (in-container path):
+#   GHA:   ${GITHUB_WORKSPACE}/trading  — repo checks out at GITHUB_WORKSPACE;
+#          the dune workspace root is one level deeper at trading/.
+#   Local container / other: resolve relative to this script's location.
+#          The script lives at <repo-root>/dev/lib/; climb two levels to reach
+#          the repo root, then descend into trading/ (the dune workspace root).
+#
+# Both paths verify that dune-workspace exists at the resolved root and fail
+# loudly if it doesn't — this catches path mismatches rather than silently
+# running dune in the wrong directory.
 
 set -euo pipefail
 
-TRADING_ROOT="/workspaces/trading-1/trading"
 CONTAINER_NAME="${TRADING_CONTAINER_NAME:-trading-1-dev}"
 
 if [ $# -eq 0 ]; then
@@ -22,16 +32,43 @@ if [ $# -eq 0 ]; then
 fi
 
 if [ -n "${TRADING_IN_CONTAINER:-}" ]; then
-  cd "$TRADING_ROOT"
+  # --- In-container path (GHA or devcontainer) ---
+
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    # GHA: the repo is checked out at $GITHUB_WORKSPACE (e.g. /__w/trading/trading).
+    # The dune workspace root is one level deeper at trading/.
+    PROJECT_ROOT="${GITHUB_WORKSPACE}/trading"
+  else
+    # Devcontainer / fallback: resolve relative to this script's location.
+    # The script lives at <repo-root>/dev/lib/run-in-env.sh.
+    # Climb two levels to reach the repo root, then descend into trading/.
+    script_dir="$(cd "$(dirname "$0")" && pwd)"
+    PROJECT_ROOT="$(cd "${script_dir}/../.." && pwd)/trading"
+  fi
+
+  # Fail loudly rather than run dune in the wrong directory.
+  if [ ! -f "${PROJECT_ROOT}/dune-workspace" ]; then
+    echo "run-in-env.sh: no dune-workspace at ${PROJECT_ROOT}" >&2
+    echo "  (expected dune workspace root; check PROJECT_ROOT derivation)" >&2
+    echo "  PROJECT_ROOT=${PROJECT_ROOT}" >&2
+    exit 1
+  fi
+
+  cd "$PROJECT_ROOT"
   eval "$(opam env)"
   exec "$@"
 else
-  # Build a single string for bash -c inside docker.
+  # --- Local path: delegate to docker exec ---
+
+  # The container mounts the repo at /workspaces/trading-1/.
+  # The dune workspace root is at /workspaces/trading-1/trading/ (has dune-workspace).
+  DOCKER_TRADING_ROOT="/workspaces/trading-1/trading"
+
   # Forward EODHD_API_KEY if set.
   DOCKER_ENV_FLAGS=""
   if [ -n "${EODHD_API_KEY:-}" ]; then
     DOCKER_ENV_FLAGS="-e EODHD_API_KEY"
   fi
   exec docker exec $DOCKER_ENV_FLAGS "$CONTAINER_NAME" bash -c \
-    "cd $TRADING_ROOT && eval \$(opam env) && $*"
+    "cd $DOCKER_TRADING_ROOT && eval \$(opam env) && $*"
 fi

--- a/dev/status/orchestrator-automation.md
+++ b/dev/status/orchestrator-automation.md
@@ -352,6 +352,14 @@ Changes landed:
 
 Verify: `grep -n "Step 1.5\|Pending work\|Dispatched this run\|Reviewed SHA\|Run timestamp\|Run ID:" .claude/agents/lead-orchestrator.md` — all should match; `grep "Reviewed SHA" .claude/agents/qc-structural.md .claude/agents/qc-behavioral.md` — both should match.
 
+## Resolved escalations log
+
+### 2026-04-17
+
+- **§2 (orphan `dev/reviews/backtest-infra-behavioral@origin`)**: qc-behavioral agent pushed its review file as a separate branch to origin (instructions in `qc-behavioral.md` "Writing the review file" section told it to `jj git push`). Branch was deleted manually. Root cause fixed: both `qc-structural.md` and `qc-behavioral.md` now explicitly say "do NOT push" and instruct agents to write the file in-place for the orchestrator to read directly. See `harness/orchestrator-summary-cleanup-2026-04-17`.
+
+- **§3 (carried-forward `harness/t3g-trend-analysis@origin`, `ops/daily-2026-04-16-run4@origin`)**: both already gone (HTTP 404 on origin) before this run. Resolved by the originating session cleanup.
+
 ## References
 
 - Research transcript: research agent run 2026-04-14 (see Escalations in

--- a/trading/devtools/checks/status_file_integrity.sh
+++ b/trading/devtools/checks/status_file_integrity.sh
@@ -7,11 +7,14 @@
 # Schema:
 #   All status files must declare:
 #     - `## Status` followed on the next non-empty line by one of:
-#       IN_PROGRESS | READY_FOR_REVIEW | APPROVED | MERGED | BLOCKED
+#       IN_PROGRESS | READY_FOR_REVIEW | APPROVED | MERGED | BLOCKED | PENDING
+#       PENDING = designed/specced but not yet dispatched to an agent
+#       BLOCKED = work started but blocked by a runtime dependency
 #     - `## Last updated: YYYY-MM-DD`
 #
 #   Feature status files must additionally declare:
-#     - `## Interface stable` followed on the next non-empty line by YES or NO
+#     - `## Interface stable` followed on the next non-empty line by YES, NO,
+#       or N/A (N/A is only valid when Status is PENDING — no code written yet)
 #
 # Exempt files (do not require `## Interface stable`):
 #   - harness.md         — orchestrator's own backlog (different shape)
@@ -33,7 +36,7 @@ set -e
 
 . "$(dirname "$0")/_check_lib.sh"
 
-VALID_STATUSES='IN_PROGRESS|READY_FOR_REVIEW|APPROVED|MERGED|BLOCKED'
+VALID_STATUSES='IN_PROGRESS|READY_FOR_REVIEW|APPROVED|MERGED|BLOCKED|PENDING'
 INTERFACE_EXEMPT='harness.md backtest-infra.md'
 VIOLATIONS=""
 
@@ -105,14 +108,20 @@ for status_file in "$STATUS_DIR"/*.md; do
   fi
 
   # 3. ## Interface stable (feature status files only)
+  # N/A is accepted when Status is PENDING (no code written yet).
   if _is_interface_exempt "$basename"; then
     :
   else
     interface_value=$(_value_after_heading "$status_file" "Interface stable")
     if [ -z "$interface_value" ]; then
       _record_violation "$basename: missing '## Interface stable' section (required for feature status files; add to $INTERFACE_EXEMPT to exempt)"
+    elif printf '%s' "$interface_value" | grep -qE '^N/A'; then
+      # N/A is only valid when the track is PENDING (not yet started).
+      if ! printf '%s' "$status_value" | grep -qE '^PENDING$'; then
+        _record_violation "$basename: '## Interface stable' is N/A but Status is '$status_value' (N/A only valid for PENDING tracks)"
+      fi
     elif ! printf '%s' "$interface_value" | grep -qE '^(YES|NO)$'; then
-      _record_violation "$basename: '## Interface stable' value '$interface_value' is not YES or NO"
+      _record_violation "$basename: '## Interface stable' value '$interface_value' is not YES, NO, or N/A (N/A only for PENDING)"
     fi
   fi
 done
@@ -121,8 +130,10 @@ if [ -n "$VIOLATIONS" ]; then
   echo "FAIL: status file integrity linter — malformed or missing fields in dev/status/:"
   printf '%b' "$VIOLATIONS"
   echo ""
-  echo "Schema: ## Status (valid value), ## Last updated: YYYY-MM-DD,"
-  echo "        ## Interface stable (YES|NO) — required except for: $INTERFACE_EXEMPT"
+  echo "Schema: ## Status (IN_PROGRESS|READY_FOR_REVIEW|APPROVED|MERGED|BLOCKED|PENDING),"
+  echo "        ## Last updated: YYYY-MM-DD,"
+  echo "        ## Interface stable (YES|NO|N/A) — required except for: $INTERFACE_EXEMPT"
+  echo "        (N/A for Interface stable only valid when Status is PENDING)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- **Fix 1** `dev/lib/run-in-env.sh`: Detect project root dynamically — use `$GITHUB_WORKSPACE` in GHA, script-relative upward search locally; add `dune-workspace` guard to fail loudly on path errors instead of silently running in wrong dir
- **Fix 2** `status_file_integrity.sh`: Add `PENDING` to valid statuses; allow `N/A` for Interface stable on PENDING tracks only. Fixes schema violations in `backtest-scale.md` and `short-side-strategy.md`
- **Fix 3** `lead-orchestrator.md`: Replace all `gh api`/`gh pr` calls with `curl` + REST API (gh is not in devcontainer). Replace `gh pr create --draft` pattern with `jst submit` throughout
- **Bookkeeping 1** `qc-structural.md` + `qc-behavioral.md`: Add explicit "do NOT push to origin" guardrail in Writing the review file section — prevents orphan `dev/reviews/*` branches (root cause of 2026-04-17 §2 escalation)
- **Bookkeeping 2** `orchestrator-automation.md`: Add Resolved escalations log section for 2026-04-17 §2 and §3

## Test plan

- [x] `sh trading/devtools/checks/status_file_integrity.sh` passes from worktree
- [x] `dune runtest devtools/checks/` exits 0 from worktree in container
- [x] `bash -n dev/lib/run-in-env.sh` passes syntax check
- [x] No remaining `gh api`/`gh pr` calls in lead-orchestrator.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)