### PR TITLE
harness: arch graph analyzer MVP in deep scan (T3-F)

### DIFF
--- a/dev/health/2026-04-18-deep.md
+++ b/dev/health/2026-04-18-deep.md
@@ -1,0 +1,134 @@
+# Health Report -- 2026-04-18 -- deep
+
+## Summary
+- Findings: 16  (critical: 0  warnings: 1  info: 15)
+- Action required: NO
+
+## Warnings (should be addressed within 1 week)
+1. Follow-up accumulation: 17 open items across status files (threshold: 10)
+
+## Info (no immediate action; awareness only)
+1. TODO/FIXME/HACK annotations: 7 total (TODO: 7, FIXME: 0, HACK: 0)
+2. Near size limit: `analysis/technical/trend/lib/segmentation.ml` — 322 lines (declared-large, limit: 500)
+3. Near size limit: `analysis/weinstein/screener/lib/screener.ml` — 437 lines (declared-large, limit: 500)
+4. Near size limit: `trading/engine/lib/price_path.ml` — 459 lines (declared-large, limit: 500)
+5. Near size limit: `trading/portfolio/lib/portfolio.ml` — 410 lines (declared-large, limit: 500)
+6. Near size limit: `trading/simulation/lib/simulator.ml` — 327 lines (declared-large, limit: 500)
+7. Near size limit: `trading/strategy/lib/position.ml` — 410 lines (declared-large, limit: 500)
+8. Near size limit: `trading/weinstein/stops/lib/weinstein_stops.ml` — 435 lines (declared-large, limit: 500)
+9. QC calibration: `backtest-infra` has review (verdict: **APPROVED**) but no audit trail in `dev/audit/`
+10. QC calibration: no test directory mapping for feature `backtest-infra`
+11. QC calibration: `data-layer` has review (verdict: APPROVED) but no audit trail in `dev/audit/`
+12. QC calibration: `screener` has review (verdict: APPROVED) but no audit trail in `dev/audit/`
+13. QC calibration: could not extract verdict from `dev/reviews/strategy-wiring-held-symbols.md`
+14. QC calibration: could not extract verdict from `dev/reviews/strategy-wiring.md`
+15. QC calibration: could not extract verdict from `dev/reviews/support-floor-stops.md`
+
+## Metrics
+- Dead code candidates: 0
+- Design doc drift items: 0
+- TODO/FIXME/HACK annotations: 7 (TODO: 7, FIXME: 0, HACK: 0)
+- Files >300 lines: 0
+- Open follow-up items: 17 (maintenance threshold: 10)
+- QC calibration findings: 7 (dune available: true)
+- Architecture graph violations (monitored): 0
+
+## TODO/FIXME/HACK Detail
+
+### TODO
+  - `analysis/technical/trend/lib/segmentation.ml:228:  (* TODO(screener/segmentation-weights): move score weights into params for`
+  - `trading/simulation/test/test_time_series.ml:296:  (* TODO(simulation/monthly-cadence): Monthly conversion returns empty. *)`
+  - `trading/simulation/lib/order_generator.mli:13:    TODO(simulation/stoplimit-orders): Orders should be StopLimit orders instead`
+  - `trading/simulation/lib/order_generator.ml:3:    TODO(simulation/stoplimit-orders): Orders should be StopLimit orders instead`
+  - `trading/simulation/lib/data/time_series.ml:22:      (* TODO(simulation/monthly-cadence): Monthly conversion not yet`
+  - `trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml:23:    TODO(simulation/price-cache-data-source): remove the tmpdir round-trip once`
+  - `trading/engine/lib/types.mli:11:    TODO(simulation/bar-granularity): Add configurable bar granularity (daily,`
+
+## Size Violation Detail
+  - `analysis/technical/trend/lib/segmentation.ml`: 322 lines (declared-large)
+  - `analysis/weinstein/screener/lib/screener.ml`: 437 lines (declared-large)
+  - `trading/engine/lib/price_path.ml`: 459 lines (declared-large)
+  - `trading/portfolio/lib/portfolio.ml`: 410 lines (declared-large)
+  - `trading/simulation/lib/simulator.ml`: 327 lines (declared-large)
+  - `trading/strategy/lib/position.ml`: 410 lines (declared-large)
+  - `trading/weinstein/stops/lib/weinstein_stops.ml`: 435 lines (declared-large)
+
+## Harness Scaffolding
+Per-component audit (PASS = referenced/wired, WARNING = unused or broken reference):
+
+PASS: `agent_compliance_check.sh` — referenced
+PASS: `arch_layer_test.sh` — referenced
+PASS: `deep_scan_arch_graph_check.sh` — referenced
+PASS: `deep_scan_trends_check.sh` — referenced
+PASS: `fmt_check.sh` — referenced
+PASS: `linter_file_length.sh` — referenced
+PASS: `linter_magic_numbers.sh` — referenced
+PASS: `linter_mli_coverage.sh` — referenced
+PASS: `orchestrator_plan_check.sh` — referenced
+PASS: `status_file_integrity.sh` — referenced
+PASS: `testing_only_check.sh` — referenced
+PASS: `cc_linter/cc_linter.exe` — wired into dune runtest
+PASS: `fn_length_linter/fn_length_linter.exe` — wired into dune runtest
+PASS: `nesting_linter/nesting_linter.exe` — wired into dune runtest
+
+## Architecture Graph
+
+Import-edge violations vs `docs/design/dependency-rules.md` (monitored rules only).
+Enforced rules are checked by `dune runtest`; this section covers monitored rules.
+
+### R2 — trading/trading/weinstein/ must not import analysis modules
+
+Rule state: `monitored`
+
+No violations found.
+
+### R3 — trading.simulation must not be imported by live execution paths
+
+Rule state: `monitored`
+
+No violations found.
+
+
+## Trends
+
+### Followup items — now vs previous deep scan
+
+Baseline: `2026-04-16-deep.md`
+
+| File | Today | Prev (2026-04-16) | Delta |
+|---|---|---|---|
+| `data-layer.md` | 4 | 4 | 0 |
+| `harness.md` | 4 | 4 | 0 |
+| `portfolio-stops.md` | 1 | 1 | 0 |
+| `simulation.md` | 7 | 7 | 0 |
+| `support-floor-stops.md` | 1 | 1 | 0 |
+
+### CC distribution — now vs previous snapshot
+
+| CC range | Today | Prev (c06f033) | Delta |
+|---|---|---|---|
+| 1–5 (low) | 804 | 783 | +21 |
+| 6–10 (medium) | 8 | 8 | 0 |
+| >10 (high) | 0 | 0 | 0 |
+
+**Top-5 highest-CC functions today:**
+
+| CC | Location | Function |
+|---|---|---|
+| 9 | `analysis/weinstein/stage/lib/stage.ml:196` | `_classify_new_stage` |
+| 8 | `analysis/weinstein/rs/lib/rs.ml:45` | `_classify_trend` |
+| 7 | `analysis/scripts/fetch_finviz_sectors/lib/fetch_finviz_sectors_lib.ml:39` | `_is_likely_etf_or_index` |
+| 6 | `analysis/scripts/fetch_finviz_sectors/lib/fetch_finviz_sectors_lib.ml:55` | `load_existing_sectors` |
+| 6 | `analysis/scripts/universe_filter/lib/universe_filter_lib.ml:158` | `read_csv` |
+
+CC JSON written to: `cc-latest.json`
+
+## Followup Count Detail
+
+| File | Count |
+|---|---|
+| `data-layer.md` | 4 |
+| `harness.md` | 4 |
+| `portfolio-stops.md` | 1 |
+| `simulation.md` | 7 |
+| `support-floor-stops.md` | 1 |

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -1,6 +1,6 @@
 # Status: harness
 
-## Last updated: 2026-04-16
+## Last updated: 2026-04-18
 
 ## Status
 IN_PROGRESS
@@ -66,7 +66,7 @@ IN_PROGRESS
 - [x] T3-D: Audit trail — `dev/audit/YYYY-MM-DD-<feature>.json` with `harness_gap` field on NEEDS_REWORK
 - [x] T3-E: Cost/token budget visibility in daily summary + budget cap in `merge-policy.json`
 - [x] T3-F: Create `docs/design/dependency-rules.md` with initial known boundaries + state lifecycle
-- [ ] T3-F: Architecture graph analyzer in health-scanner deep scan (import graph vs. rules doc)
+- [x] T3-F: Architecture graph analyzer in health-scanner deep scan (import graph vs. rules doc) — DONE: see completion note below
 - [ ] T3-F: Rule promotion path — generate dune checks from `enforced` rules automatically
 - [x] T3-G: Status file integrity check in health-scanner fast scan — verify required fields present (Status, Last updated, Interface stable) in each `dev/status/<feature>.md`; flag missing or malformed entries (part of T1-O fast scan). Done: see Completed section.
 - [x] T3-G: `health-scanner` deep scan extension — followup-item count + CC trend analysis in weekly report (extends T1-Q CC linter output)
@@ -243,6 +243,7 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
 - [x] T3-B: AVR loop closure already in `lead-orchestrator` Step 5 — auto-dispatches QC for any READY_FOR_REVIEW feature in the same orchestrator run. Verify: grep "READY_FOR_REVIEW\|auto.*QC\|Step 5" in `lead-orchestrator.md`.
 - [x] qc-structural: P1/P2/P4 items updated to "verified by linter (H3)" — QC no longer manually re-scans these; linters are the deterministic gate. Verify: read `qc-structural.md` checklist — P1/P2/P4 items reference linter gates.
 - [x] T3-F: `docs/design/dependency-rules.md` created — R1–R6 rules with lifecycle states (`proposed` / `monitored` / `enforced`); R1, R4, R6 enforced via dune tests; R2, R3 monitored; R5 proposed. Verify: file exists; `dune runtest trading/devtools/checks/` enforces R1.
+- [x] T3-F: Architecture graph analyzer — Check 9 added to `trading/devtools/checks/deep_scan.sh`; grep-based MVP covering the two monitored rules: R2 (trading/trading/weinstein/ must not open analysis modules) and R3 (trading.simulation must not be a library dependency of live execution paths). Findings emitted under `## Architecture Graph` in `dev/health/YYYY-MM-DD-deep.md`; violations are INFO (monitored — human decides to promote to enforced). Companion smoke test at `trading/devtools/checks/deep_scan_arch_graph_check.sh` wired into `dune runtest`. Verify: `sh trading/devtools/checks/deep_scan.sh` — report contains `## Architecture Graph` with R2 and R3 sub-sections; `dune runtest devtools/checks/` — prints `OK: deep scan Architecture Graph section (T3-F) structural check passed.`
 
 ### T3-E: Cost/token budget visibility
 

--- a/trading/devtools/checks/deep_scan.sh
+++ b/trading/devtools/checks/deep_scan.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Deep scan for health-scanner agent (T3-A).
 #
-# Runs weekly (not on every PR). Performs seven read-only analyses:
+# Runs weekly (not on every PR). Performs nine read-only analyses:
 #   1. Dead code detection — .ml files not referenced in any dune file
 #   2. Design doc drift — module structure vs eng-design docs
 #   3. TODO/FIXME/HACK accumulation
@@ -9,6 +9,8 @@
 #   5. Follow-up item count (from status files)
 #   6. QC calibration audit — verdicts vs current test health
 #   7. Harness scaffolding review — flag unused or broken harness components
+#   8. Trends — followup-item delta + CC distribution delta (T3-G)
+#   9. Architecture graph — import edges vs dependency-rules.md (T3-F)
 #
 # Output: dev/health/YYYY-MM-DD-deep.md
 #
@@ -807,6 +809,147 @@ TOP5EOF
 fi
 
 # ────────────────────────────────────────────────────────────────
+# Check 9: Architecture graph — import edges vs dependency-rules.md
+#
+# MVP: grep-based edge detection for the two monitored rules.
+#
+# R2 (monitored): trading/trading/weinstein/ must not import from
+#   analysis/weinstein/ modules other than weinstein.types.
+#   Detects: "open <Analysis_module>" in .ml files under
+#   trading/trading/weinstein/ where <Analysis_module> is one of the
+#   known analysis/weinstein library top-level modules.
+#   Exception: weinstein.types is allowed (stops + trading_state use it).
+#
+# R3 (monitored): trading/trading/simulation/ must not be imported by
+#   the live execution path.
+#   Detects: dune files outside simulation/ and backtest/ that list
+#   trading.simulation or trading_simulation as a dependency.
+#   Exemptions: simulation/ itself, simulation tests, backtest/ (backtesting
+#   is not a live execution path), weinstein strategy test (integration test).
+#
+# Findings are INFO (monitored rules → awareness only; human decides to
+# promote to enforced).  The report section is always emitted.
+# ────────────────────────────────────────────────────────────────
+
+ARCH_GRAPH_CONTENT=""
+ARCH_GRAPH_VIOLATION_COUNT=0
+
+# ── R2: trading/trading/weinstein/ must not import analysis modules ──
+#
+# Analysis module names as they appear after "open " in OCaml source
+# (these are the top-level modules exposed by each weinstein.* library).
+# weinstein.types exposes Weinstein_types — explicitly excluded from the
+# violation list because stops and trading_state are allowed to use it.
+#
+# Known analysis module top-level names (from analysis/weinstein/*/lib/*.mli):
+#   Stage, Screener, Macro, Sector, Rs, Volume, Resistance, Stock_analysis,
+#   Data_source, Historical_source, Live_source, Universe, Inventory,
+#   Data_path, Sector_map, Macro_types, Ad_bars_aggregation, Synthetic_adl
+#
+ANALYSIS_OPEN_PATTERN='open \(Stage\|Screener\|Macro\|Sector\|Rs\|Volume\|Resistance\|Stock_analysis\|Data_source\|Historical_source\|Live_source\|Universe\|Inventory\|Data_path\|Sector_map\|Macro_types\|Ad_bars_aggregation\|Synthetic_adl\)'
+
+WEINSTEIN_TRADING_DIR="${TRADING_DIR}/trading/weinstein"
+R2_FINDINGS=""
+R2_COUNT=0
+
+if [ -d "$WEINSTEIN_TRADING_DIR" ]; then
+  for ml_file in $(find "$WEINSTEIN_TRADING_DIR" \
+      -name "*.ml" \
+      -not -path "*/_build/*" \
+      -not -path "*/.formatted/*" | sort); do
+    matches="$(grep -n "$ANALYSIS_OPEN_PATTERN" "$ml_file" 2>/dev/null || true)"
+    if [ -n "$matches" ]; then
+      rel_path="${ml_file#"$TRADING_DIR"/}"
+      while IFS= read -r match_line; do
+        [ -z "$match_line" ] && continue
+        R2_COUNT=$((R2_COUNT + 1))
+        ARCH_GRAPH_VIOLATION_COUNT=$((ARCH_GRAPH_VIOLATION_COUNT + 1))
+        R2_FINDINGS="${R2_FINDINGS}  - \`${rel_path}\`: ${match_line}\n"
+      done << R2EOF
+${matches}
+R2EOF
+    fi
+  done
+fi
+
+ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}### R2 — trading/trading/weinstein/ must not import analysis modules\n\n"
+ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}Rule state: \`monitored\`\n\n"
+if [ "$R2_COUNT" -eq 0 ]; then
+  ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}No violations found.\n\n"
+else
+  ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}**${R2_COUNT} violation(s)** (open imports of analysis modules in trading/weinstein):\n\n"
+  ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}${R2_FINDINGS}\n"
+  add_info "Architecture graph (R2): ${R2_COUNT} monitored-rule violation(s) — trading/weinstein imports analysis module(s); see ## Architecture Graph"
+fi
+
+# ── R3: trading.simulation must not be used by live execution paths ──
+#
+# Live execution paths are modules under trading/trading/ that are NOT:
+#   - simulation/ itself and its subdirectories
+#   - backtest/ (purely a backtesting tool, not a live execution path)
+#
+# The weinstein strategy test (strategy/test/dune) uses simulation for
+# integration tests — this is also excluded as a test-only usage.
+#
+TRADING_CORE_DIR="${TRADING_DIR}/trading"
+R3_FINDINGS=""
+R3_COUNT=0
+
+if [ -d "$TRADING_CORE_DIR" ]; then
+  for dune_file in $(find "$TRADING_CORE_DIR" \
+      -name "dune" \
+      -not -path "*/_build/*" \
+      -not -path "*/simulation/*" \
+      -not -path "*/backtest/*" | sort); do
+    # Skip if this is a test stanza that mentions simulation
+    # (test integration is acceptable; library/executable stanzas are not)
+    if ! grep -q 'trading[._]simulation\|trading\.simulation' "$dune_file" 2>/dev/null; then
+      continue
+    fi
+    # Check if any non-test stanza references simulation
+    # A "test" or "tests" stanza is OK — only library/executable stanzas are flagged
+    has_lib_ref=false
+    in_lib_stanza=false
+    while IFS= read -r dline; do
+      case "$dline" in
+        *'(library'*|*'(executable'*)
+          in_lib_stanza=true ;;
+        *'(test'*|*'(tests'*)
+          in_lib_stanza=false ;;
+        *')'*)
+          # Closing paren — heuristic: top-level close ends a stanza
+          # Only reset if at col 0 (start of line)
+          case "$dline" in
+            ')'*) in_lib_stanza=false ;;
+          esac
+          ;;
+      esac
+      if $in_lib_stanza && echo "$dline" | grep -q 'trading[._]simulation\|trading\.simulation' 2>/dev/null; then
+        has_lib_ref=true
+        break
+      fi
+    done < "$dune_file"
+
+    if $has_lib_ref; then
+      rel_path="${dune_file#"$TRADING_DIR"/}"
+      R3_COUNT=$((R3_COUNT + 1))
+      ARCH_GRAPH_VIOLATION_COUNT=$((ARCH_GRAPH_VIOLATION_COUNT + 1))
+      R3_FINDINGS="${R3_FINDINGS}  - \`${rel_path}\`: depends on \`trading.simulation\`\n"
+    fi
+  done
+fi
+
+ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}### R3 — trading.simulation must not be imported by live execution paths\n\n"
+ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}Rule state: \`monitored\`\n\n"
+if [ "$R3_COUNT" -eq 0 ]; then
+  ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}No violations found.\n\n"
+else
+  ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}**${R3_COUNT} violation(s)** (live execution dune files depending on simulation):\n\n"
+  ARCH_GRAPH_CONTENT="${ARCH_GRAPH_CONTENT}${R3_FINDINGS}\n"
+  add_info "Architecture graph (R3): ${R3_COUNT} monitored-rule violation(s) — live execution path imports simulation; see ## Architecture Graph"
+fi
+
+# ────────────────────────────────────────────────────────────────
 # Generate report
 # ────────────────────────────────────────────────────────────────
 
@@ -855,6 +998,7 @@ cat >> "$OUTPUT_FILE" <<METRICS_EOF
 - Files >300 lines: ${SIZE_VIOLATION_COUNT}
 - Open follow-up items: ${FOLLOWUP_COUNT} (maintenance threshold: 10)
 - QC calibration findings: ${QC_CAL_COUNT} (dune available: ${DUNE_AVAILABLE})
+- Architecture graph violations (monitored): ${ARCH_GRAPH_VIOLATION_COUNT}
 METRICS_EOF
 
 # Append detail sections if non-empty
@@ -878,6 +1022,13 @@ if [ -n "$SCAFFOLD_DETAILS" ]; then
   printf "Per-component audit (PASS = referenced/wired, WARNING = unused or broken reference):\n\n" >> "$OUTPUT_FILE"
   printf '%b' "$SCAFFOLD_DETAILS" >> "$OUTPUT_FILE"
 fi
+
+# Always emit the Architecture Graph section (Check 9).
+# Monitored-rule violations are INFO (not failures) — human decides to promote.
+printf "\n## Architecture Graph\n\n" >> "$OUTPUT_FILE"
+printf "Import-edge violations vs \`docs/design/dependency-rules.md\` (monitored rules only).\n" >> "$OUTPUT_FILE"
+printf "Enforced rules are checked by \`dune runtest\`; this section covers monitored rules.\n\n" >> "$OUTPUT_FILE"
+printf '%b' "$ARCH_GRAPH_CONTENT" >> "$OUTPUT_FILE"
 
 # Always emit the Trends section (Check 8).
 printf "\n## Trends\n\n" >> "$OUTPUT_FILE"

--- a/trading/devtools/checks/deep_scan_arch_graph_check.sh
+++ b/trading/devtools/checks/deep_scan_arch_graph_check.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Structural smoke test for the deep-scan Architecture Graph section (T3-F).
+#
+# Does NOT invoke deep_scan.sh from dune runtest because:
+#   - deep_scan.sh runs weekly (not on every PR) and writes outside the
+#     dune sandbox (dev/health/).
+#
+# Instead, this verifies two things:
+#   1. deep_scan.sh contains the required Check 9 implementation markers
+#      (both R2 and R3 sub-sections).
+#   2. The most-recent dev/health/*-deep.md report contains a
+#      ## Architecture Graph section, confirming the script has been run
+#      at least once successfully.
+#
+# How to re-verify the output by hand:
+#   sh trading/devtools/checks/deep_scan.sh
+#   grep '## Architecture Graph' dev/health/$(date +%Y-%m-%d)-deep.md
+
+set -e
+
+. "$(dirname "$0")/_check_lib.sh"
+
+REPO_ROOT="$(repo_root)"
+DEEP_SCAN="${REPO_ROOT}/trading/devtools/checks/deep_scan.sh"
+[ -f "$DEEP_SCAN" ] || die "deep_scan_arch_graph_check: $DEEP_SCAN does not exist"
+
+fail() {
+  echo "FAIL: deep_scan_arch_graph_check — $1" >&2
+  exit 1
+}
+
+# ── Part 1: structural check of deep_scan.sh ─────────────────────
+
+# Check 9 header
+grep -qF 'Check 9: Architecture graph' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing 'Check 9: Architecture graph' header"
+
+# R2 implementation markers
+grep -qF 'ANALYSIS_OPEN_PATTERN' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing ANALYSIS_OPEN_PATTERN variable (R2 check)"
+grep -qF 'R2 — trading/trading/weinstein/ must not import analysis modules' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing R2 section header"
+grep -qF 'WEINSTEIN_TRADING_DIR' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing WEINSTEIN_TRADING_DIR scan loop (R2)"
+
+# R3 implementation markers
+grep -qF 'R3 — trading.simulation must not be imported by live execution paths' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing R3 section header"
+grep -qF 'ARCH_GRAPH_VIOLATION_COUNT' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing ARCH_GRAPH_VIOLATION_COUNT accumulator"
+
+# Report emits ## Architecture Graph section
+grep -qF '## Architecture Graph' "$DEEP_SCAN" \
+  || fail "deep_scan.sh does not emit '## Architecture Graph' section in report"
+
+# ── Part 2: most-recent deep report has ## Architecture Graph ────
+
+HEALTH_DIR="${REPO_ROOT}/dev/health"
+LATEST_DEEP=""
+for f in $(ls -1 "${HEALTH_DIR}"/*-deep.md 2>/dev/null | sort); do
+  LATEST_DEEP="$f"
+done
+
+if [ -z "$LATEST_DEEP" ]; then
+  # No deep report exists yet — acceptable if deep_scan.sh has never run.
+  echo "INFO: no dev/health/*-deep.md found; skipping report content check."
+else
+  grep -qF '## Architecture Graph' "$LATEST_DEEP" \
+    || fail "$(basename "$LATEST_DEEP") does not contain '## Architecture Graph' section — run: sh trading/devtools/checks/deep_scan.sh"
+  grep -qF '### R2' "$LATEST_DEEP" \
+    || fail "$(basename "$LATEST_DEEP") ## Architecture Graph section missing R2 sub-section"
+  grep -qF '### R3' "$LATEST_DEEP" \
+    || fail "$(basename "$LATEST_DEEP") ## Architecture Graph section missing R3 sub-section"
+fi
+
+echo "OK: deep scan Architecture Graph section (T3-F) structural check passed."

--- a/trading/devtools/checks/dune
+++ b/trading/devtools/checks/dune
@@ -127,3 +127,15 @@
  (deps _check_lib.sh)
  (action
   (run sh %{dep:deep_scan_trends_check.sh})))
+
+; Deep scan Architecture Graph section (T3-F): structural smoke test.
+; Verifies deep_scan.sh contains the Check 9 Architecture Graph
+; implementation (R2 + R3 monitored rules) and that the most-recent
+; deep scan report has ## Architecture Graph.
+; Does NOT run deep_scan.sh (weekly tool, not a per-PR gate).
+
+(rule
+ (alias runtest)
+ (deps _check_lib.sh)
+ (action
+  (run sh %{dep:deep_scan_arch_graph_check.sh})))


### PR DESCRIPTION
## Summary

T3-F (Tier 3) — initial MVP of the architecture graph analyzer in the deep-scan script, reporting-only. Closes the T3-F bullet in `dev/status/harness.md`.

- Check 9 in `trading/devtools/checks/deep_scan.sh` — grep-based scan covering the two monitored rules from `docs/design/dependency-rules.md`:
  - **R2**: `trading/trading/weinstein/` `.ml` files importing analysis-layer modules (Stage, Screener, Macro, Sector, Rs, Volume, Resistance, Stock_analysis, Data_source, Historical_source, Live_source, Universe, Inventory, Data_path, Sector_map, Macro_types, Ad_bars_aggregation, Synthetic_adl). `Weinstein_types` excluded.
  - **R3**: dune files outside `simulation/` and `backtest/` declaring `trading.simulation` / `trading_simulation` as non-test library dep.
  - Emitted under `## Architecture Graph` as INFO — monitored rules only; enforced rules stay on `dune runtest`.
- `trading/devtools/checks/deep_scan_arch_graph_check.sh` — structural smoke test wired into `dune runtest`.
- `dev/health/2026-04-18-deep.md` — fresh deep-scan report (R2 and R3 both report "No violations found").
- `dev/status/harness.md` — T3-F bullet marked `[x]`.

## Test plan

- [x] `sh trading/devtools/checks/deep_scan.sh` from repo root produces a report under `dev/health/` with a `## Architecture Graph` section containing R2 and R3 sub-sections
- [x] `dune runtest` — new `deep_scan_arch_graph_check.sh` passes
- [ ] Intentional violation check (manual): add `open Analysis.Weinstein.Stage` to a `trading/trading/weinstein/*.ml` file, re-run deep scan; verify the violation is listed under R2. Revert before merging.

Future work (tracked in harness backlog): promote the grep MVP to a proper dune-graph-based analyzer that parses `dune` stanzas programmatically.

Generated by `harness-maintainer` under the daily orchestrator; Step 4.5 fallback PR creation by lead-orchestrator (jst failed in the devcontainer due to a jj/git version skew).
