### PR TITLE
fix(backtest): round-trips for trades.csv bypass is_trading_day filter

### DIFF
--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -24,9 +24,19 @@ type result = {
 
 (** True if [step] represents a real trading day. On non-trading days (weekends,
     holidays) the simulator has no price bars and reports
-    [portfolio_value = cash] even when positions are open. *)
-let _is_trading_day
-    (step : Trading_simulation_types.Simulator_types.step_result) =
+    [portfolio_value = cash] even when positions are open.
+
+    Important: this heuristic exists only for mark-to-market aware consumers
+    such as [UnrealizedPnl] (see PR #393). It must NOT be applied to round-trip
+    extraction — round-trips are derived from position-state transitions
+    (fills), which are recorded independently of whether the portfolio's
+    mark-to-market view is populated that day. Applying this filter before
+    [Metrics.extract_round_trips] silently drops every trade whose entry *and*
+    exit landed on steps where [portfolio_value ~ cash], which happens for
+    instance when the only non-[Holding] positions are [Entering]/[Closed] (they
+    contribute 0.0 to [Portfolio_view.portfolio_value]). *)
+let is_trading_day (step : Trading_simulation_types.Simulator_types.step_result)
+    =
   let has_positions =
     not (List.is_empty step.portfolio.Trading_portfolio.Portfolio.positions)
   in
@@ -177,13 +187,23 @@ let run_backtest ~start_date ~end_date ?(overrides = []) () =
   let stop_log = Stop_log.create () in
   let sim = _make_simulator deps ~stop_log ~start_date ~end_date in
   let sim_result = _run_simulator sim in
-  let steps =
+  (* Steps in the requested date range, all days included. Round-trip
+     extraction derives trades from position-state transitions recorded on
+     these steps, so it must see *every* step where a trade fill happened —
+     including days the [is_trading_day] mark-to-market heuristic would
+     otherwise discard. *)
+  let steps_in_range =
     List.filter sim_result.steps
       ~f:(fun (s : Trading_simulation_types.Simulator_types.step_result) ->
-        Date.( >= ) s.date start_date && _is_trading_day s)
+        Date.( >= ) s.date start_date)
   in
+  (* Steps on real trading days only — used for [UnrealizedPnl] consumers and
+     anything else that needs a meaningful mark-to-market portfolio value.
+     See PR #393 context: the simulator reports [portfolio_value = cash] on
+     weekends/holidays even when positions are open. *)
+  let steps = List.filter steps_in_range ~f:is_trading_day in
   let final_value = (List.last_exn steps).portfolio_value in
-  let round_trips = Metrics.extract_round_trips steps in
+  let round_trips = Metrics.extract_round_trips steps_in_range in
   let stop_infos = Stop_log.get_stop_infos stop_log in
   let summary : Summary.t =
     {

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -7,8 +7,14 @@ open Core
 type result = {
   summary : Summary.t;
   round_trips : Trading_simulation.Metrics.trade_metrics list;
+      (** Completed round-trips derived from *every* step in
+          [start_date..end_date] — the [is_trading_day] mark-to-market filter is
+          NOT applied here, since trade fills are recorded independently of
+          mark-to-market portfolio valuation. *)
   steps : Trading_simulation_types.Simulator_types.step_result list;
-      (** Steps filtered to [start_date..end_date] on real trading days only *)
+      (** Steps filtered to [start_date..end_date] on real trading days only.
+          Used for the equity curve and any downstream consumer that needs a
+          meaningful mark-to-market portfolio value per row. *)
   overrides : Sexp.t list;
       (** The override sexps used for this run, echoed into params.sexp *)
   stop_infos : Stop_log.stop_info list;
@@ -17,6 +23,20 @@ type result = {
           trigger (stop-loss, take-profit, etc.). Keyed by position_id; joinable
           with [round_trips] via symbol + entry_date. *)
 }
+
+val is_trading_day :
+  Trading_simulation_types.Simulator_types.step_result -> bool
+(** True if [step] represents a real trading day — i.e. the portfolio's
+    mark-to-market value materially differs from its cash balance when any
+    positions are open, or if no positions are open. On non-trading days
+    (weekends, holidays) the simulator has no price bars and reports
+    [portfolio_value = cash] even when positions exist.
+
+    This filter is appropriate for mark-to-market aware consumers (the equity
+    curve, [UnrealizedPnl]) but MUST NOT be applied before round-trip extraction
+    — doing so silently drops trades whose entry/exit steps had no
+    mark-to-market view. See PR #393 (filter introduction) and the trades.csv
+    fix note in [runner.ml]. *)
 
 val run_backtest :
   start_date:Date.t ->

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -1,4 +1,15 @@
-(test
- (name test_stop_log)
- (modules test_stop_log)
- (libraries ounit2 core backtest trading.strategy status matchers))
+(tests
+ (names test_stop_log test_runner_filter)
+ (libraries
+  ounit2
+  core
+  core_unix.time_ns_unix
+  backtest
+  trading.base
+  trading.engine
+  trading.portfolio
+  trading.simulation
+  trading.simulation.types
+  trading.strategy
+  status
+  matchers))

--- a/trading/trading/backtest/test/test_runner_filter.ml
+++ b/trading/trading/backtest/test/test_runner_filter.ml
@@ -1,0 +1,185 @@
+(** Regression tests for the [Runner] step-filtering boundary.
+
+    The [is_trading_day] heuristic was introduced by PR #393 so that
+    mark-to-market aware metrics like [UnrealizedPnl] ignore weekend/holiday
+    steps where the simulator falls back to [portfolio_value = cash]. The
+    heuristic was subsequently mis-applied to round-trip extraction, silently
+    dropping ~95% of trades from [trades.csv] on large multi-year runs when
+    entry+exit happened to land on steps that look "non-trading" to the
+    heuristic (e.g. because the only non-[Holding] positions are
+    [Entering]/[Closed], which contribute 0.0 to the mark-to-market portfolio
+    value).
+
+    These tests pin the invariant that round-trip extraction must see steps
+    flagged as non-trading by [is_trading_day]. *)
+
+open OUnit2
+open Core
+open Matchers
+open Trading_simulation
+
+let date_of_string = Date.of_string
+
+let _sample_commission =
+  { Trading_engine.Types.per_share = 0.01; minimum = 1.0 }
+
+let _make_trade ~id ~order_id ~symbol ~side ~quantity ~price =
+  {
+    Trading_base.Types.id;
+    order_id;
+    symbol;
+    side;
+    quantity;
+    price;
+    commission = 0.0;
+    timestamp = Time_ns_unix.now ();
+  }
+
+(** Build a synthetic step with no mark-to-market signal
+    ([portfolio_value = current_cash]) — the exact shape [is_trading_day]
+    classifies as non-trading when positions are open. *)
+let _make_step_with_trades ~date ~portfolio ~trades =
+  {
+    Trading_simulation_types.Simulator_types.date;
+    portfolio;
+    portfolio_value = portfolio.Trading_portfolio.Portfolio.current_cash;
+    trades;
+    orders_submitted = [];
+  }
+
+(* -------------------------------------------------------------------- *)
+(* Phase 1: [is_trading_day] classifies our synthetic steps correctly    *)
+(* -------------------------------------------------------------------- *)
+
+(** An empty portfolio (no positions) is treated as a trading day — the
+    mark-to-market heuristic only kicks in once there is something to mark. *)
+let test_is_trading_day_empty_portfolio _ =
+  let portfolio = Trading_portfolio.Portfolio.create ~initial_cash:10000.0 () in
+  let step =
+    _make_step_with_trades
+      ~date:(date_of_string "2024-01-06") (* Saturday, no price bars *)
+      ~portfolio ~trades:[]
+  in
+  assert_that (Backtest.Runner.is_trading_day step) (equal_to true)
+
+(** Once we hold a real position but [portfolio_value = cash] (the simulator's
+    fallback on weekends/holidays), the heuristic marks the step as non-trading.
+    This is the exact state that used to hide trade fills from [trades.csv]. *)
+let test_is_trading_day_flat_value_with_positions _ =
+  let portfolio_with_position =
+    let initial = Trading_portfolio.Portfolio.create ~initial_cash:10000.0 () in
+    match
+      Trading_portfolio.Portfolio.apply_single_trade initial
+        (_make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL"
+           ~side:Trading_base.Types.Buy ~quantity:10.0 ~price:100.0)
+    with
+    | Ok p -> p
+    | Error err ->
+        OUnit2.assert_failure
+          ("portfolio apply_trades failed: " ^ Status.show err)
+  in
+  let step =
+    _make_step_with_trades
+      ~date:(date_of_string "2024-01-06")
+      ~portfolio:portfolio_with_position ~trades:[]
+  in
+  (* portfolio has an open position but portfolio_value = cash — the
+     heuristic classifies this as a non-trading day, which is the exact
+     gotcha that used to drop round-trips. *)
+  assert_that (Backtest.Runner.is_trading_day step) (equal_to false)
+
+(* -------------------------------------------------------------------- *)
+(* Phase 2: round-trip extraction must NOT be gated on is_trading_day    *)
+(* -------------------------------------------------------------------- *)
+
+(** The core regression. Build two steps, each with a trade fill on a step the
+    [is_trading_day] heuristic flags as non-trading. Pre-fix, pairing
+    [steps = List.filter ~f:is_trading_day] with [extract_round_trips] discards
+    both steps, so the resulting [round_trips] list is empty even though one
+    buy/sell pair completed. Post-fix, round-trip extraction operates on the
+    unfiltered in-range step list and returns the expected pair. *)
+let test_round_trip_extraction_survives_non_trading_day_filter _ =
+  let portfolio_flat =
+    Trading_portfolio.Portfolio.create ~initial_cash:10000.0 ()
+  in
+  let portfolio_with_position =
+    match
+      Trading_portfolio.Portfolio.apply_single_trade portfolio_flat
+        (_make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL"
+           ~side:Trading_base.Types.Buy ~quantity:10.0 ~price:100.0)
+    with
+    | Ok p -> p
+    | Error err ->
+        OUnit2.assert_failure ("apply_trade failed: " ^ Status.show err)
+  in
+  let steps_in_range =
+    [
+      _make_step_with_trades
+        ~date:(date_of_string "2024-01-02")
+        ~portfolio:portfolio_flat
+        ~trades:
+          [
+            _make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL"
+              ~side:Trading_base.Types.Buy ~quantity:10.0 ~price:100.0;
+          ];
+      _make_step_with_trades
+        ~date:(date_of_string "2024-01-15")
+        ~portfolio:portfolio_with_position
+        ~trades:
+          [
+            _make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAPL"
+              ~side:Trading_base.Types.Sell ~quantity:10.0 ~price:110.0;
+          ];
+    ]
+  in
+  (* Sanity: with positions open but portfolio_value = cash, the heuristic
+     rejects at least the second step — simulating the exact bug path. *)
+  let filtered_out =
+    List.filter steps_in_range ~f:(fun s ->
+        not (Backtest.Runner.is_trading_day s))
+  in
+  assert_that (List.length filtered_out) (gt (module Int_ord) 0);
+  (* The in-range (unfiltered) list still produces one round-trip. *)
+  let round_trips = Metrics.extract_round_trips steps_in_range in
+  assert_that round_trips
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Metrics.trade_metrics) -> t.symbol)
+               (equal_to "AAPL");
+             field
+               (fun (t : Metrics.trade_metrics) -> t.entry_price)
+               (float_equal 100.0);
+             field
+               (fun (t : Metrics.trade_metrics) -> t.exit_price)
+               (float_equal 110.0);
+             field
+               (fun (t : Metrics.trade_metrics) -> t.quantity)
+               (float_equal 10.0);
+           ];
+       ]);
+  (* The bug: applying is_trading_day before round-trip extraction drops
+     the pair entirely. Pinning the pre-fix behaviour here guards against
+     re-regression if someone "helpfully" reintroduces the filter. *)
+  let filtered_steps =
+    List.filter steps_in_range ~f:Backtest.Runner.is_trading_day
+  in
+  let buggy_round_trips = Metrics.extract_round_trips filtered_steps in
+  assert_that
+    (List.length round_trips - List.length buggy_round_trips)
+    (gt (module Int_ord) 0)
+
+let suite =
+  "Runner_filter"
+  >::: [
+         "is_trading_day: empty portfolio returns true"
+         >:: test_is_trading_day_empty_portfolio;
+         "is_trading_day: flat-value + open position returns false"
+         >:: test_is_trading_day_flat_value_with_positions;
+         "round-trip extraction must not be gated on is_trading_day"
+         >:: test_round_trip_extraction_survives_non_trading_day_filter;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- trades.csv was silently dropping ~95% of round-trips on multi-year runs because [Backtest.Runner._is_trading_day] (introduced in PR #393 for mark-to-market metrics on weekends) was being applied to the round-trip extraction path. Trade fills live on [step.trades] and are recorded independently of the mark-to-market portfolio valuation, so the filter has no business gating them.
- Split the in-range step list (fed to [Metrics.extract_round_trips], which drives [round_trips] + [trades.csv]) from the filtered step list (fed to the equity curve + UnrealizedPnl consumers). [is_trading_day] keeps its PR #393 behaviour on the latter.
- Rename [_is_trading_day] to [is_trading_day] and expose it from runner.mli so regression tests can pin the invariant directly.

## Evidence

From the trace in `dev/notes/strategy-dispatch-trace-2026-04-17.md` (PR #408), six-year goldens-small run `scenarios-2026-04-17-184456`:
- `trades.csv` contained 10 rows
- `summary.sexp` metrics: `wincount=89, losscount=157` → 246 round-trip legs
- Ratio: ~96% of trades were silently filtered out

Post-fix, `Runner.result.round_trips` (hence `trades.csv` row count and `summary.n_round_trips`) reflects every round-trip whose legs were posted in `[start_date, end_date]`, independent of mark-to-market.

## Test plan

- [x] `dune build && dune runtest` green
- [x] `dune build @fmt` clean
- [x] New regression test `test_runner_filter.ml` with 3 cases:
  - `is_trading_day` returns true on an empty portfolio
  - `is_trading_day` returns false on a step with a held position whose `portfolio_value = cash` (the pre-fix dropout condition)
  - Round-trip extraction over the unfiltered in-range steps returns the expected pair; the filtered variant strictly drops trades — pinning the invariant that the filter must never precede `Metrics.extract_round_trips`

## Notes

- Primary acceptance criterion (run `--goldens-small` and verify `trades.csv` row count ~= `summary.n_round_trips`) was infeasible to run in-session: on main (no `sector_map_override` plumbing yet), the runner hard-codes the full 10,472-stock sector map and OOMs my container. The unit test pins the precise invariant deterministically. The pre-fix evidence from PR #408 supplies the "before" side of the comparison.
- Scope discipline: no changes to `_held_symbols`, `UnrealizedPnl`, or anything outside `trading/trading/backtest/`.