### PR TITLE
harness(orchestrator): verify carried-forward [critical] escalations

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -108,6 +108,49 @@ If a prior summary exists:
 
 If no prior summary exists (first run), skip this step.
 
+### Step 1c: Verify carried-forward `[critical]` escalations
+
+For each `[critical]` item in the prior summary's `## Escalations` section,
+**re-verify it is still real** before carrying it forward into today's
+escalations. A critical that was resolved between runs (by a merged PR,
+by a parallel fix, or by a false-positive measurement) must not leak into
+today's plan and cascade into contingent skips.
+
+Common verifications:
+
+- **"Main baseline is red"** / linter failing:
+  ```bash
+  cd trading/trading && dune build @runtest --force 2>&1 | tail -10
+  echo "exit=$?"
+  ```
+  Run from the inner `trading/trading/` directory (the dune project root).
+  Exit 0 = baseline is green, inherited critical is **resolved** — drop.
+  **Do NOT invoke linter binaries directly** (e.g. `nesting_linter.exe
+  <path>`) — path-substitution bugs cause false positives (seen
+  2026-04-18). The dune alias is the source of truth because CI uses it.
+
+- **"Open PR #X is failing CI"**: re-check PR status via REST
+  (`/repos/<owner>/<repo>/pulls/<N>/commits/<sha>/check-runs`). If the
+  latest CI on the PR's tip is green, the critical is resolved.
+
+- **"Track X is blocked on Y"**: re-read `dev/status/X.md` + `dev/status/Y.md`
+  to confirm Y is still unmet. If Y landed between runs, the block is lifted.
+
+**Outcomes:**
+
+- If verified still real: carry forward into today's `## Escalations` with
+  the same `[critical]` tag, optionally updating the diagnostic if context
+  changed.
+- If resolved: **do not carry forward**. Add a line to today's
+  `## Step 1b drift cross-reference` classifying the item as
+  "resolved between runs" so the audit trail exists.
+- If ambiguous (verification inconclusive): carry forward as `[info]` with
+  a note asking the human to verify, not as `[critical]`.
+
+This step exists because carrying a stale `[critical]` causes downstream
+plan logic to cascade (skip tracks, queue corrective dispatches, warn
+humans) — all on a false premise. Always verify before carrying.
+
 ---
 
 ## Step 1.5: PR-open dispatch guard


### PR DESCRIPTION
## Summary

Adds **Step 1c** — verify carried-forward `[critical]` escalations before they cascade into today's plan. Mandates dune-based linter invocation (no direct binary calls) to avoid path-substitution false positives.

## Why now

Plan-mode run on 2026-04-17 (after all PRs merged) carried forward `[critical] Main baseline is red — nesting linter gating exit 1` from the 2026-04-18 summary. The baseline is **not red** — CI on `main` is all `success`. The original critical was a false positive from yesterday's subagent running `nesting_linter.exe` directly from the wrong cwd (outer `trading/` instead of inner `trading/trading/`), which scans `analysis/scripts/` with rules those files don't obey.

The stale critical cascaded:
- Plan dispatched a `harness-maintainer` for `harness/nesting-baseline-exceptions` — phantom work
- Plan deferred `short-side-strategy` "while main red" — already banned by PR #413, now triply wrong
- Humans told "critical blocker" via the gate fired on day-old data

## What Step 1c does

For each `[critical]` item from the prior summary:

1. Run a specific verification. Linter-red critical → `dune build @runtest --force` from `trading/trading/`. PR-CI critical → REST check-runs API on the tip. Blocked-on critical → re-read status files.
2. **Do NOT invoke linter binaries directly** — the dune alias is the source of truth because CI uses it. `nesting_linter.exe <path>` from any cwd produces different results and isn't what CI measures.
3. Outcomes: verified-real → carry forward; resolved → drop + note in drift section; ambiguous → downgrade to `[info]`.

## Out of scope (follow-up PR)

Trim `lead-orchestrator.md` (~900 lines, growing); add a harness-maintainer rule for periodic instruction-simplification. Separate PR to keep review surface small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)