### PR TITLE
harness: trim lead-orchestrator.md; add periodic-simplification rule

### DIFF
--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -101,6 +101,49 @@ The health-scanner is read-only — it never modifies source or agent files. It 
 1. Extend `trading/devtools/fn_length_linter/fn_length_linter.ml` (already uses `compiler-libs`) to compute CC per function (branches in match/if/when + 1); CC > 10 = warning (not failure); output to rolling `dev/metrics/cc-latest.json` (overwritten each deep-scan run; history in git log)
 2. Add `## Quality Score` (1–5 integer + one-sentence rationale) to `qc-behavioral.md` output format and checklist
 
+## Periodic simplification of agent definitions
+
+Agent instructions (`.claude/agents/*.md`) accumulate. Every fix adds a
+rule; every edge case adds a paragraph. Past ~800 lines an agent file
+starts diluting attention — the agent reads the whole file every
+session, and what was a clear rule gets buried.
+
+**When to run a simplification pass:**
+
+- Any `.claude/agents/*.md` exceeds 800 lines of operational content
+  (check periodically; once a month at minimum).
+- After a sequence of ≥3 PRs that each added rules to the same agent —
+  the cumulative effect is usually worse than the sum.
+- When a real-run escalation traces back to the agent following
+  redundant / conflicting instructions (rules contradicting or
+  duplicating each other).
+
+**What to trim:**
+
+- **Redundant rules.** Same "don't do X" repeated across sections →
+  consolidate into one canonical statement in the most relevant section.
+- **Historical rationale.** Prose like "Prior pattern matched X but that
+  failed because..." explaining a now-fixed bug. Move to a companion doc
+  `docs/design/<agent>-rationale.md` if worth preserving, otherwise
+  delete — the current rule stands on its own.
+- **Verbose examples.** Code samples longer than ~15 lines that could be
+  a single rule sentence + a pointer to a reference doc.
+- **Dead sections.** Instructions for tools or workflows no longer in
+  use (e.g. legacy shell scripts the repo replaced with dune aliases).
+
+**What NOT to trim:**
+
+- Operational rules (do-this-when-that conditions).
+- Path conventions (bookmark names, file layouts, env-var usage).
+- Workspace-isolation / contamination guards.
+- Acceptance checklists and non-obvious gotchas.
+
+Treat this as a standalone harness task when triggered — branch
+`harness/simplify-<agent-name>`, one agent per PR. Target a 20–40%
+line reduction per pass; more is fine if operational meaning is
+preserved. Re-run the most recent orchestrator-plan mode or dispatch a
+smoke-test subagent after merging to verify no behavioral regression.
+
 ## Verification
 
 ```bash

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -16,37 +16,12 @@ Required: **Agent** (for dispatching `feat-*`, `harness-maintainer`, `health-sca
 
 ## Plan Mode
 
-If the prompt contains the token `--plan` (e.g. `dev/run.sh` or an operator
-passes `--plan` as part of the invocation prompt), run in **plan mode**:
-
-- **Do NOT dispatch any subagents.** Skip Steps 2 through 6 entirely —
-  no feat-agent, qc-structural, qc-behavioral, harness-maintainer,
-  health-scanner, or ops-data spawns. Plan mode is read-only.
-- **Do all of Step 1** (read current state — `dev/decisions.md`, every
-  `dev/status/*.md`, `dev/notes/data-gaps.md`, existing `dev/reviews/*.md`).
-  This is cheap and the plan depends on it.
-- **Emit the dispatch plan** — what *would* have been dispatched, why, and on
-  which branch. Organise it as the same sections the daily summary uses, but
-  fill them with plan-mode content instead of results:
-  - Which blocking refactors (2a) would run, from which status files
-  - Whether the followup accumulation threshold (2b) is met and whether
-    this run would swap in a maintenance pass
-  - Which harness backlog item (2c) is highest-priority open, with its
-    proposed branch name (e.g. `harness/t3g-status-integrity`)
-  - Whether ops-data (2d) would run, and against which gap
-  - Which feat-agents (2e) are eligible, in what order
-- **Write** `dev/daily/<YYYY-MM-DD>-plan.md` (note the `-plan` suffix — do NOT
-  overwrite the real daily summary) with a header tagged `(plan mode)` and
-  the sections above. The header line should be exactly:
-  `# Status — YYYY-MM-DD (plan mode)`.
-- **Exit 0** after writing the plan. Plan mode never mutates branches,
-  never pushes bookmarks, never writes to `dev/status/*.md` or
-  `dev/reviews/*.md`.
-
-Plan mode is the safe way to inspect what an orchestrator run would do
-before committing tokens to a real run — useful for operator dry-runs and
-for smoke-testing the orchestrator definition itself without a full
-environment.
+If the dispatch prompt contains `--plan`, run in plan mode: read state
+(Step 1 + 1b + 1c), emit a dispatch plan to `dev/daily/<date>-plan.md`
+with header `# Status — YYYY-MM-DD (plan mode)`, exit 0. **Do not dispatch
+subagents, push bookmarks, or write to `dev/status/*.md` or
+`dev/reviews/*.md`.** Full contract:
+`docs/design/orchestrator-plan-mode.md`.
 
 ## References
 

--- a/docs/design/orchestrator-plan-mode.md
+++ b/docs/design/orchestrator-plan-mode.md
@@ -1,0 +1,43 @@
+# Orchestrator plan mode
+
+Reference for `.claude/agents/lead-orchestrator.md` § Plan Mode.
+
+When the dispatch prompt contains the token `--plan` (e.g. `dev/run.sh
+--plan`), the orchestrator runs in plan mode:
+
+## Contract
+
+- **Do NOT dispatch any subagents.** Skip Steps 2 through 6 entirely — no
+  feat-agent, qc-structural, qc-behavioral, harness-maintainer,
+  health-scanner, or ops-data spawns. Plan mode is read-only.
+- **Do all of Step 1** (read current state — `dev/decisions.md`, every
+  `dev/status/*.md`, `dev/notes/data-gaps.md`, existing `dev/reviews/*.md`).
+  This is cheap and the plan depends on it.
+- **Emit the dispatch plan** — what would have been dispatched, why, and on
+  which branch. Organise as the same sections the daily summary uses, filled
+  with plan-mode content:
+  - Which blocking refactors (2a) would run
+  - Whether the followup accumulation threshold (2b) is met
+  - Which harness backlog item (2c) is highest-priority open
+  - Whether ops-data (2d) would run, against which gap
+  - Which feat-agents (2e) are eligible, in what order
+- **Write** `dev/daily/<YYYY-MM-DD>-plan.md` (note the `-plan` suffix — do
+  NOT overwrite the real daily summary). Header line:
+  `# Status — YYYY-MM-DD (plan mode)`.
+- **Exit 0**. Plan mode never mutates branches, never pushes bookmarks,
+  never writes to `dev/status/*.md` or `dev/reviews/*.md`.
+
+## Use cases
+
+- Operator dry-runs before a real scheduled run
+- Smoke-testing changes to `.claude/agents/lead-orchestrator.md` without
+  committing Claude-API tokens
+- Verifying status-file changes land cleanly in Step 1 reads
+
+## Relationship to real runs
+
+Plan mode and real runs share Step 1 and Step 1b (drift cross-reference).
+They diverge at Step 1.5 (guard still evaluates eligibility but no
+dispatches fire). Step 1c (verify carried-forward `[critical]`) runs in
+both modes — a plan that carries forward a stale critical is as wrong as
+a real run that does.


### PR DESCRIPTION
## Summary

First-pass trim of `lead-orchestrator.md` + a durable **periodic-simplification rule** in `harness-maintainer.md` so attention-dilution stays bounded over time.

## Changes

### `lead-orchestrator.md` — Plan Mode trimmed (-25 lines)

The 30-line Plan Mode section was mostly contract-prose appropriate for a reference doc. Extracted to `docs/design/orchestrator-plan-mode.md`; the main file now has a 7-line pointer. Same operational semantics, less prose in the default-loaded file.

### `harness-maintainer.md` — new `## Periodic simplification of agent definitions` section

Defines triggers + approach for trimming any `.claude/agents/*.md` that drifts past operational utility:

**Triggers:**
- Any file > 800 lines of operational content (check monthly)
- ≥3 consecutive PRs adding rules to same agent
- A real-run escalation trace back to conflicting/duplicated rules

**What to trim:** redundant rules, historical rationale ("prior pattern X failed because..."), verbose examples, dead sections.

**What NOT to trim:** operational conditions, path conventions, workspace-isolation guards, acceptance checklists.

Target: 20–40% per pass. Branch convention: `harness/simplify-<agent-name>`. Smoke-test after merge (plan-mode orchestrator or dispatch a subagent) to verify no regression.

### `docs/design/orchestrator-plan-mode.md` (new)

Plan-mode contract + use cases + relationship to real runs. Referenced from `lead-orchestrator.md` §Plan Mode.

## Why not more aggressive

This PR is a modest first pass (net +61 / -31 in source, -25 lines in the agent's loaded file). Bigger trim candidates remain in `lead-orchestrator.md`:

- Step 1.5 PR-open guard (76 lines)
- Step 2 maintenance work (91 lines)
- Step 5 QC pipeline (70 lines)
- Step 8 push summary (76 lines)

I want the harness rule to land first so future trims are driven by the periodic-simplification protocol itself, not by one-off judgment. Next trim pass = a proper harness task dispatched per the new rule, scoped to a single step section with a 20–40% target.

## Test plan

- [ ] `./dev/run.sh --plan` runs cleanly (plan-mode agent can still follow the pointer to the reference doc)
- [ ] No CI check is added or removed
- [ ] Next orchestrator run doesn't lose any operational behavior

## Files

- `.claude/agents/lead-orchestrator.md` — Plan Mode section collapsed
- `.claude/agents/harness-maintainer.md` — new simplification rule
- `docs/design/orchestrator-plan-mode.md` — new reference doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)