### PR TITLE
harness(orchestrator): remove phantom linter-invocation guard; focus Step 1c on verify-and-quote

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -123,11 +123,11 @@ Common verifications:
   cd trading/trading && dune build @runtest --force 2>&1 | tail -10
   echo "exit=$?"
   ```
-  Run from the inner `trading/trading/` directory (the dune project root).
-  Exit 0 = baseline is green, inherited critical is **resolved** — drop.
-  **Do NOT invoke linter binaries directly** (e.g. `nesting_linter.exe
-  <path>`) — path-substitution bugs cause false positives (seen
-  2026-04-18). The dune alias is the source of truth because CI uses it.
+  Run from the inner `trading/trading/` directory. Exit 0 = baseline is
+  green, inherited critical is **resolved** — drop. When carrying
+  forward, quote the original linter + violation count verbatim from the
+  prior summary (don't paraphrase — seen 2026-04-18 → today, a
+  `fn_length` finding got rewritten as `nesting` on carry-forward).
 
 - **"Open PR #X is failing CI"**: re-check PR status via REST
   (`/repos/<owner>/<repo>/pulls/<N>/commits/<sha>/check-runs`). If the


### PR DESCRIPTION
## Summary

Follow-up to #415. The `Do NOT invoke linter binaries directly` guard it introduced was based on my wrong diagnosis — an audit (grep for `_linter\.exe` across `.md`/`.sh`/`.yml`/`.ml`) found **zero actual direct invocations**. The rule was guarding a phantom.

Actual root cause of the 2026-04-18 → today stale-critical propagation was **paraphrasing on carry-forward**: yesterday the summary correctly reported `fn_length_linter: 2 violations`; todays plan rewrote it as `nesting linter gating exit 1` — different linter, different gate semantics.

This PR:
- Drops the phantom-guard paragraph from Step 1c
- Keeps Step 1c focused on the real fix: **verify + quote original finding verbatim**, dont paraphrase
- Net -5 lines (attention dilution cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)