### PR TITLE
ci(orchestrator): use BOT_GITHUB_TOKEN for checkout so subagent pushes trigger CI

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -95,6 +95,16 @@ jobs:
         with:
           # Full history so jj can see main@origin and rebase properly.
           fetch-depth: 0
+          # Use the PAT so actions/checkout writes BOT_GITHUB_TOKEN into
+          # origin's http.extraheader. Subagent `jj git push` calls then
+          # authenticate as the PAT owner, which is what makes the
+          # downstream CI workflow fire on the pushed branch (GitHub
+          # suppresses workflow triggers for pushes authenticated with
+          # the ephemeral GITHUB_TOKEN — see the secrets block above for
+          # the full rationale). Without this override, checkout defaults
+          # to GITHUB_TOKEN and every subagent push ends up in "Action
+          # required" limbo instead of running CI.
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Compute today's date
         id: today


### PR DESCRIPTION
## Summary

Pass `token: ${{ secrets.BOT_GITHUB_TOKEN }}` to `actions/checkout@v4` in the daily-orchestrator workflow so that subagent `jj git push` calls authenticate as the PAT owner and trigger downstream CI on feat/harness PRs.

## Symptom

Today's orchestrator run opened three PRs. CI status varied per PR with no code-level reason:

| PR | Branch | CI |
|---|---|---|
| [#421](https://github.com/dayfine/trading/pull/421) | `harness/deep-scan-recent-commits-guard` | ✅ `build-and-test` succeeded |
| [#420](https://github.com/dayfine/trading/pull/420) | `feat/short-side-strategy` | ⏸ "Action required", zero check runs registered |
| [#419](https://github.com/dayfine/trading/pull/419) | `feat/backtest-phase-tracing` | ⏸ "Action required", zero check runs registered |

All three were opened by the same actor, all three target `main`, all three authored by the generic `Docker <docker@example.com>` identity. `ci.yml` has no path filters or branch filters that would explain the split.

## Root cause

GitHub suppresses downstream workflow triggers for pushes authenticated with the ephemeral `GITHUB_TOKEN` (a documented [safety feature](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)). The orchestrator workflow already acknowledges this in its header comment (`.github/workflows/orchestrator.yml:19-35`) and requires a `BOT_GITHUB_TOKEN` PAT for exactly this reason:

> Why a PAT and not the default GITHUB_TOKEN: pushes using the built-in token do not trigger downstream workflows (GitHub safety feature), so CI would not re-run on branches this orchestrator pushes. PAT-issued pushes do trigger them.

However, the PAT was only plumbed into `claude-code-action` as the `github_token` input (`:126`), which scopes it to whatever the action does internally (posting comments, opening PRs via REST). **It does not rewrite git's credential helper or the `http.extraheader` that `actions/checkout@v4` installs at checkout time.**

Consequence: when a subagent runs `jj git push -b <bookmark>`, the push reuses the extraheader — which carries the ephemeral `GITHUB_TOKEN`, not the PAT. The push succeeds (the token has `contents: write` per the `permissions:` block at `:64-66`), but no downstream workflow fires, and the PR lands in "Action required" limbo.

The harness/* PR that did run CI was likely approved manually at some prior point by the repo owner — once GitHub has approved a commit author's workflow once, subsequent runs from the same author on the same branch pattern auto-approve, which can mask the underlying misconfiguration for specific branches.

## Fix

```yaml
- uses: actions/checkout@v4
  with:
    fetch-depth: 0
    token: ${{ secrets.BOT_GITHUB_TOKEN }}   # ← added
```

With the `token:` override, `actions/checkout@v4` writes `http.https://github.com/.extraheader` with `Authorization: basic <base64(x-access-token:BOT_GITHUB_TOKEN)>`. Every `jj git push` / `git push` inside the container then authenticates as the PAT owner, which:

1. Triggers the `pull_request` / `push` events on the orchestrator-created branches → `ci.yml` runs automatically.
2. If the PAT owner is a recognized collaborator on the repo, bypasses the "first-time contributor" approval gate — which is what's currently catching commits authored by the unverified `docker@example.com` identity.

## Out of scope / follow-ups

- **Adding `actions: write` scope to `BOT_GITHUB_TOKEN`** would additionally let the orchestrator programmatically approve any runs that do land in "Action required" state (e.g., if the PAT owner isn't a collaborator or the approval gate fires for another reason) and re-run failed CI as a self-heal. Not strictly needed for this fix to work, but worth considering separately.
- **Pinning the commit author identity.** The `Docker <docker@example.com>` author on all orchestrator commits is unrelated to CI triggering but does trip first-time-contributor gates on fresh branch patterns. Setting `user.name` / `user.email` to a recognized identity in `dev/run.sh` or the devcontainer image would eliminate that class of gate entirely.
- **No test coverage for workflow YAML.** This change can only be validated by observing the next orchestrator run. After merge, the next feat-branch PR opened by the orchestrator should show `build-and-test` running without manual approval. If it doesn't, the next diagnostic step is `git config --get-all http.https://github.com/.extraheader` inside a failing run to confirm which token the checkout step actually wrote.

## Test plan

- [ ] After merge, trigger the orchestrator (either via cron or `workflow_dispatch`) and confirm the next feat-branch PR it opens shows `build-and-test` check run firing automatically, not stuck in "Action required".
- [ ] If CI still doesn't trigger, verify `BOT_GITHUB_TOKEN` is present and unexpired in repo secrets, and that its owner has write access to the repo.
