### PR TITLE
ci(orchestrator): anchor escalation gate to top-level [critical] bullets

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -180,21 +180,36 @@ jobs:
             in_section { print }
           ' "$SUMMARY")"
 
-          # Gate only on lines tagged [critical]. The summary template uses
-          # severity tags — [critical], [medium], [info] — so "gate iff the
-          # author tagged it critical" is the cleanest contract. [medium]
-          # and [info] items surface for visibility without failing the run.
+          # Gate only on top-level bullets tagged [critical]. The summary
+          # template uses severity tags — [critical], [medium], [info] — so
+          # "gate iff the author tagged a top-level escalation critical" is
+          # the cleanest contract. [medium] and [info] items surface for
+          # visibility without failing the run.
           #
           # Prior pattern matched any `- ` bullet and caught sub-bullets of
           # medium items (e.g. "- (a) Reword the comment" under a [medium]
           # linter-fix suggestion), failing the job on cosmetic notes.
+          #
+          # Next iteration moved to grep -Ei '\[critical\]' — but that
+          # matches the literal string anywhere in the Escalations section,
+          # including inside prose describing mitigations (e.g. "cross-check
+          # `[critical]` claims against dune build @runtest" in a [medium]
+          # bullet, which failed run 24606800779 on 2026-04-18 despite zero
+          # actual critical items).
+          #
+          # Current pattern anchors to a top-level bullet start:
+          #   ^-[[:space:]]+(\*\*)?\[critical\]
+          # matches `- [critical] ...` and `- **[critical] ...`, which is
+          # how the summary template formats escalation bullets. Sub-bullets
+          # (indented) and prose containing the literal token `[critical]`
+          # are correctly ignored.
           #
           # Positive `[critical]` match means an untagged escalation does
           # NOT gate. That's intentional: tags are a contract, and forcing
           # authors to tag encourages them to think about severity. If an
           # escalation genuinely warrants gating, tag it.
           escalations="$(printf '%s\n' "$section" \
-            | grep -Ei '\[critical\]' \
+            | grep -E '^-[[:space:]]+(\*\*)?\[critical\]' \
             || true)"
 
           if [ -n "$escalations" ]; then


### PR DESCRIPTION
## Summary

Tighten the `Fail on escalations` gate in the daily-orchestrator workflow to match only top-level `[critical]` bullets, not the literal token `[critical]` appearing anywhere in the Escalations section.

## Symptom

Run [24606800779](https://github.com/dayfine/trading/actions/runs/24606800779) (Daily orchestrator #10, scheduled cron 2026-04-18 14:30 UTC) ran 5 subagents successfully:

| Agent | Target | Outcome |
|---|---|---|
| qc-structural | #419 backtest-infra | APPROVED |
| qc-behavioral | #419 backtest-infra | APPROVED (5/5) |
| qc-structural | #420 short-side-strategy | APPROVED |
| qc-behavioral | #420 short-side-strategy | APPROVED (5/5) |
| health-scanner | fast | FINDINGS (no real criticals) |

…then failed on the `Fail on escalations` step with exit 1. The summary (`dev/daily/2026-04-18-run3.md`) contained **zero** `[critical]` escalations — only two `[medium]` and two `[info]` items. The workflow should have exited 0.

## Root cause

`orchestrator.yml:196-198` greps for `[critical]` with no anchor:

```bash
escalations="$(printf '%s\n' "$section" \
  | grep -Ei '\[critical\]' \
  || true)"
```

The Escalations section included a mitigation sub-bullet inside a `[medium]` item:

> 3. health-scanner verdict promotion rule: cross-check `` `[critical]` `` claims against `dune build @runtest` exit code on `origin/main` before propagating.

The literal string `[critical]` in that prose tripped the grep. The gate cannot tell a real escalation from the word appearing in a mitigation description, a clarification, or any other discussion of the concept.

The comment block above the grep already documents one prior regression of the same shape (old pattern over-matched sub-bullets of `[medium]` items). This is the second iteration of the same class of bug.

## Fix

Anchor the pattern to a top-level Markdown bullet start, which is the one and only shape the summary template uses for escalation items:

```bash
grep -E '^-[[:space:]]+(\*\*)?\[critical\]'
```

Matches:
- `- [critical] foo`  ✓
- `- **[critical] foo**`  ✓

Does NOT match:
- `  3. cross-check \`[critical]\` claims…`  (sub-bullet, indented)
- `No \`[critical]\` items in flight…`  (prose)
- `- **[medium] [critical] is actually…`  (tag-mismatched)

Verified locally against the 2026-04-18 run-3 summary (zero matches, as expected — run should have succeeded) and against synthetic inputs containing two real-shape `[critical]` bullets (both matched).

Also expanded the inline comment block to document the failure mode so the next maintainer doesn't regress this a third time.

## Out of scope

- **Dropping `-i`** (case-insensitive). The summary template and all authors consistently use lowercase `[critical]`. Case-insensitivity isn't needed, but removing it is a separate style cleanup — kept in for backward compatibility with any hand-edited summaries that might use `[CRITICAL]`. Actually, on reflection, `-i` is dropped in this PR since the anchored form is already strict about bullet shape; if someone types `[CRITICAL]` the template review process should catch that. (See diff.)
- **Tests for the workflow YAML itself.** Shell-gate behavior can only be exercised end-to-end inside GHA. The regex was verified by running `grep -E` against synthetic inputs locally; adding a unit-test harness for workflow-embedded shell is out of scope.
- **Related but separate: [#424](https://github.com/dayfine/trading/pull/424)** fixes checkout-token plumbing so subagent pushes trigger CI. That's an independent bug in the same workflow — the two PRs don't depend on each other and can land in either order.

## Test plan

- [ ] Regex validated locally against run-3 summary (zero matches) and synthetic `[critical]` bullets (all matched).
- [ ] After merge, next orchestrator run with no critical escalations should complete with exit 0.
- [ ] If a future summary genuinely has a `- **[critical] …` bullet, the gate should still fire — worth spot-checking the next time one appears, or by temporarily adding one to a test summary.
