### PR TITLE
agents: align feat-* files with template's no-edit-_index.md rule

### DIFF
--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -134,5 +134,5 @@ status to READY_FOR_REVIEW.
 1. Set the item's checkbox to `[x]` in `dev/status/backtest-infra.md`, with a one-line completion note (what was built, where, verify command).
 2. If the work is feature code that ships an interface change, update `## Interface stable` if needed.
 3. Set `## Status` to READY_FOR_REVIEW only if you've finished a complete deliverable; otherwise leave it as IN_PROGRESS with progress notes.
-4. Update the **backtest-infra** row in `dev/status/_index.md` — align Status, Owner, Open PR, and Next task with the changes above. Only touch your own row.
+4. **Do NOT edit `dev/status/_index.md`** — the orchestrator reconciles it in Step 5.5 against every `dev/status/*.md` at end-of-run. Editing the index from a feature PR causes merge conflicts with every sibling PR touching the same row (see `feat-agent-template.md` §8). Exception: if this PR introduces a brand-new tracked work item (new status file), add the row here since the orchestrator can't invent one.
 5. Push your branch via jj. The orchestrator picks up READY_FOR_REVIEW status files and dispatches QC.

--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -89,7 +89,6 @@ If after **3 consecutive build-fix cycles** `dune build && dune runtest` is stil
 
 ## Status file updates
 
-At the end of every session, update **both**:
+At the end of every session, update `dev/status/support-floor-stops.md` — current Status, Completed, In Progress, Next Steps.
 
-1. `dev/status/support-floor-stops.md` — current Status, Completed, In Progress, Next Steps.
-2. `dev/status/_index.md` — the row for this track. Keep Status, Owner, Open PR, and Next task aligned with (1). Only touch your own row.
+**Do NOT edit `dev/status/_index.md`** — the orchestrator reconciles it in Step 5.5 against every `dev/status/*.md` at end-of-run. Editing the index from a feature PR causes merge conflicts with every sibling PR touching the same row (see `feat-agent-template.md` §8). Exception: if this PR introduces a brand-new tracked work item (new status file), add the row here since the orchestrator can't invent one.


### PR DESCRIPTION
## Summary

Align `feat-backtest.md` and `feat-weinstein.md` with `feat-agent-template.md` §8 by removing the instruction to edit `dev/status/_index.md` from a feature PR. Both files currently contradict the template and the orchestrator's Step 5.5 contract.

## Motivation

The template and every other agent definition consistently forbid feature/data/harness PRs from touching `dev/status/_index.md`:

| File | Line | Says |
|---|---|---|
| `.claude/agents/feat-agent-template.md` | `:141` | **"### 8. Index row update — DO NOT EDIT `dev/status/_index.md` IN A FEATURE PR"** |
| `.claude/agents/lead-orchestrator.md` | `:627` | "Do NOT edit dev/status/_index.md — I (the orchestrator) reconcile it in Step 5.5" |
| `.claude/agents/lead-orchestrator.md` | `:792` | "Agents do NOT edit `_index.md` in their PRs" |
| `.claude/agents/ops-data.md` | `:147` | "Do NOT edit `dev/status/_index.md`" |
| `.claude/agents/harness-maintainer.md` | `:159` | "Do NOT edit `dev/status/_index.md`" |

The two feat-* agent files were the outliers, actively instructing the opposite:

| File | Line | Said |
|---|---|---|
| `.claude/agents/feat-backtest.md` | `:137` | "Update the **backtest-infra** row in `dev/status/_index.md` — align Status, Owner, Open PR, and Next task with the changes above. Only touch your own row." |
| `.claude/agents/feat-weinstein.md` | `:95` | "`dev/status/_index.md` — the row for this track. Keep Status, Owner, Open PR, and Next task aligned with (1). Only touch your own row." |

## Observed consequence

`feat-weinstein` followed its own agent file on PR [#420](https://github.com/dayfine/trading/pull/420) (short-side-strategy MVP) and edited its row in `_index.md`. Later the same day, `lead-orchestrator` run-3 also reconciled the row in Step 5.5, bringing `short-side-strategy` from `READY_FOR_REVIEW` → `APPROVED` after QC passed and also updating the harness row to `#421`. The two edits touched the same hunk → merge conflict on `feat/short-side-strategy` against `main`, manually resolved just now by dropping the feat-branch edit.

That resolution is exactly what the template already says should happen — the edit shouldn't have been there in the first place. This PR closes the gap between the template and the two concrete feat-agent definitions so the next session doesn't repeat the mistake.

## Change

Replace both instructions with the template's language, cross-reference `feat-agent-template.md §8`, and preserve the "new track" exception that every other agent file already uses verbatim:

```text
**Do NOT edit `dev/status/_index.md`** — the orchestrator reconciles it in
Step 5.5 against every `dev/status/*.md` at end-of-run. Editing the index
from a feature PR causes merge conflicts with every sibling PR touching
the same row (see `feat-agent-template.md` §8). Exception: if this PR
introduces a brand-new tracked work item (new status file), add the row
here since the orchestrator can't invent one.
```

Diff is 2 files, +3/−4 lines.

## Out of scope

- **Going back and stripping `_index.md` edits from in-flight PRs.** Not needed — existing conflicts resolve at merge time as they surface, and any new row added by a truly new track is the documented exception.
- **Lint/pre-commit check that feat-* branches don't touch `_index.md`.** Worth considering separately (harness-maintainer follow-up) as a belt-and-suspenders enforcement, but the agent-definition fix alone should prevent the common case. Not adding here to keep the PR to a single responsibility.
- **Template itself** — already correct, no change needed.

## Test plan

- [ ] No automated test — this is a prompt/docs change affecting agent behaviour on future dispatches. Validation happens on the next `feat-backtest` or `feat-weinstein` session: the agent should update only its own per-track status file and leave `dev/status/_index.md` untouched.
- [ ] After the next orchestrator run, confirm that neither feat-* agent's diff includes `dev/status/_index.md` (and that the orchestrator reconciled it in Step 5.5 as expected).
