### PR TITLE
status: reconcile index + per-track files post #419/#420/#421 merge

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -800,13 +800,24 @@ has no other signal to invent one.
 For each row in `dev/status/_index.md`:
 
 1. Read the corresponding `dev/status/<track>.md`.
-2. Compare against the row:
-   - **Status** — must match the `## Status` heading value (IN_PROGRESS / READY_FOR_REVIEW / MERGED / APPROVED / BLOCKED).
+2. **Merge-watch first.** Before trusting the status file's `## Status`
+   heading, cross-reference the GH API for every PR the row/file
+   references. If a referenced PR has state `closed` + `merged: true` on
+   `main`, treat that track as `MERGED` regardless of what the local
+   status file still says — per-track files are stale between runs
+   because feature PRs merge without touching them. In that case:
+   - Flip the per-track `## Status` to `MERGED` (and update its
+     `## Last updated:`) so the next run doesn't need to re-discover.
+   - Move any still-relevant follow-ups from `## Follow-ups` to a child
+     track's status file if one exists; otherwise leave them in place
+     and note "follow-ups carry over" in the row's next-task cell.
+3. Compare against the row:
+   - **Status** — must match the (possibly just-updated) `## Status` heading value (IN_PROGRESS / READY_FOR_REVIEW / MERGED / APPROVED / BLOCKED).
    - **Owner** — must match `## Ownership` (or be `—` if the track has no active owner).
-   - **Open PR(s)** — cross-reference against the GitHub REST API (via `curl -sSL -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY:-dayfine/trading}/pulls?state=open"`) filtered to that track's branches; each currently-open PR targeting main that carries this track's work should appear.
-   - **Next task** — must be the top item from `## Next Steps` (or an equivalent synthesis of the most concrete pending item).
-3. If any cell drifts, fix it. Do not touch unrelated rows.
-4. Update the `Last updated:` line to today's date.
+   - **Open PR(s)** — cross-reference against the GitHub REST API (via `curl -sSL -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY:-dayfine/trading}/pulls?state=open"`) filtered to that track's branches; each currently-open PR targeting main that carries this track's work should appear. Merged PRs must not appear in this column.
+   - **Next task** — must be the top item from `## Next Steps` (or an equivalent synthesis of the most concrete pending item). For MERGED rows, use `—` plus a short parenthetical noting the merge date + PR number.
+4. If any cell drifts, fix it. Do not touch unrelated rows.
+5. Update the `Last updated:` line to today's date **at the end of Step 5.5**, not earlier — the timestamp must reflect the reconcile, not whatever the last feature agent happened to write.
 
 If an IN_PROGRESS track has no Owner or no Next task, surface it in the
 daily summary's §Escalations as "unassigned work." Silent drift is the

--- a/dev/notes/data-gaps.md
+++ b/dev/notes/data-gaps.md
@@ -79,8 +79,8 @@ Probe scripts under `dev/scripts/probes/`. Full writeup in `dev/notes/adl-valida
 
 ## Global Index Bars
 
-**Status**: Cached and verified (2026-04-10)  
-**Blocks**: Strategy wiring only (data is available)  
+**Status**: Cached and wired into strategy (PR #355, 2026-04-12)  
+**Blocks**: None — data is fetched and consumed.  
 **Affects**: `Macro.analyze ~global_index_bars`
 
 ### Current state
@@ -89,11 +89,9 @@ Probe scripts under `dev/scripts/probes/`. Full writeup in `dev/notes/adl-valida
 - N225.INDX (Nikkei 225): cached, 1965-01-05 to 2026-04-10 — VERIFIED
 - **FTSE 100 via `ISF.LSE` (iShares Core FTSE 100 UCITS ETF)** — **DECISION: use as proxy** (2026-04-10). Physical-replication tracker, ~bps tracking error, functionally indistinguishable from the index at weekly cadence. `UKX.INDX` returned empty; `ISF.LSE` fetched successfully (6,552 bars, 2000-05-02 to 2026-04-10) — VERIFIED (2026-04-11).
 
-### What's needed (escalation territory)
-- **feat-weinstein**: wire cached global index bars into strategy
-  (currently passes `~global_index_bars:[]`). Feature work, not
-  ops-data. NOTE: feat-weinstein's current scope is closed — surface
-  as escalation when dispatched.
+### What's needed
+- Nothing. Strategy wiring landed via PR #355. Keep the cache fresh
+  via the weekly refresh — no outstanding data-gap action.
 
 ---
 

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,7 +4,7 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-18 (post-run-4 status refresh)
+Last updated: 2026-04-19 (post-merge reconcile: #419/#420/#421)
 
 ## Active + complete tracks
 
@@ -13,13 +13,13 @@ Each row: one line; deeper task detail in the linked status file.
 
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
-| [backtest-infra](backtest-infra.md) | APPROVED | feat-backtest | #419 (feat/backtest-phase-tracing) | QC APPROVED at tip 0381bde (re-verified run 4 — refactor-only delta; fmt fix landed). Awaiting human merge. Then Step 3 tier-aware bar loader (backtest-scale track). |
-| [backtest-scale](backtest-scale.md) | PENDING | feat-backtest | — | Unblocked once #419 merges; start Step 3 tier-aware bar loader on `feat/backtest-tiered-loader`. |
+| [backtest-infra](backtest-infra.md) | MERGED | — | — | — (#419 per-phase tracing merged 2026-04-19) |
+| [backtest-scale](backtest-scale.md) | PENDING | feat-backtest | — | Start Step 3 tier-aware bar loader on `feat/backtest-tiered-loader` (plan-first; cross-cutting). |
 | [support-floor-stops](support-floor-stops.md) | MERGED | — | — | — (PRs #382 primitive + #390 wiring both merged 2026-04-17) |
-| [short-side-strategy](short-side-strategy.md) | APPROVED | feat-weinstein | #420 (feat/short-side-strategy) | QC APPROVED at tip 937ec93 (re-verified run 4 — merge-only, zero OCaml delta). Awaiting human merge. Follow-ups: bear-window backtest regression, full short cascade, Ch.11 behavioural spot-check. |
+| [short-side-strategy](short-side-strategy.md) | MERGED | — | — | — (#420 merged 2026-04-19). Follow-ups carried to own tracks: bear-window backtest regression, full short cascade, Ch.11 behavioural spot-check. |
 | [strategy-wiring](strategy-wiring.md) | MERGED | — | — | — (#408 + #409 both merged 2026-04-18) |
 | [sector-data](sector-data.md) | IN_PROGRESS | ops-data | — | Items 1/2/4/4.1 DONE (Item 2 ran locally 2026-04-18; full sectors.csv intentionally out-of-tree). Only Item 3 (ops-data preflight cadence hook, ~20 lines) remains. Does NOT gate GHA runs — they use `trading/test_data/sectors.csv`. |
-| [harness](harness.md) | IN_PROGRESS | harness-maintainer | #421 (harness/deep-scan-recent-commits-guard) | Deep-scan Recent Commits guard (Check 10 + smoke test) — awaiting review. Next: deep-scan heuristic gaps sub-items 3 (linter exception expiry vs milestone) and 4 (stale local jj bookmarks). |
+| [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | #421 merged 2026-04-19. Next: deep-scan heuristic gaps sub-items 3 (linter exception expiry vs milestone) and 4 (stale local jj bookmarks). |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Phase 1 live (daily cron runs producing summary PRs). Phase 2 (background execution for scrapers, golden re-runs, cross-feature QC) pending empirical tests per status file. |
 | [data-layer](data-layer.md) | MERGED | — | — | — |
 | [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |

--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -1,9 +1,11 @@
 # Status: Backtest Infrastructure
 
-## Last updated: 2026-04-18
+## Last updated: 2026-04-19
 
 ## Status
-READY_FOR_REVIEW
+MERGED
+
+Step 1 (#399) + Step 2 (#419) both landed. Step 3 continues on the backtest-scale track.
 
 ## QC
 
@@ -82,20 +84,19 @@ strategy code (currently complete).
   - Fixture files at `trading/test_data/backtest_scenarios/{goldens,smoke}/`
 
 ## Open PRs
-- `feat/backtest-phase-tracing` — PR #419 (draft → ready 2026-04-18).
-  Step 2 of scale-optimization plan. See §Completed first entry.
-- `feat/metrics-scenario-unrealized-pin` — follow-up to PR #393 (now
-  merged) that pins `unrealized_pnl` as a per-scenario range check
-  (see §Completed). Branches off current `main`.
+None. Merged in main:
+- #399 Step 1 (two-tier universe) — 2026-04-17.
+- #393 unrealized_pnl pin fix — 2026-04-17.
+- #395 per-scenario `unrealized_pnl` range check — merged 2026-04-17.
+- #419 Step 2 (per-phase tracing) — 2026-04-19.
 
 ## Next Steps
 
-- **Step 3 (tier-aware bar loader)** is the unblock target for
-  everything under this PR. Separately tracked at
-  `dev/status/backtest-scale.md`; landing order: PR #419 merges →
-  Step 3 can A/B the Legacy vs Tiered loader against a traced Legacy
-  baseline. Do not pick up Step 3 from this track — it has its own
-  status file and branch (`feat/backtest-tiered-loader`).
+- **Step 3 (tier-aware bar loader)** now unblocked; separately tracked at
+  `dev/status/backtest-scale.md`. A/B the Legacy vs Tiered loader
+  against a traced Legacy baseline. Do not pick up Step 3 from this
+  track — it has its own status file and branch
+  (`feat/backtest-tiered-loader`).
 - **Per-bar phase instrumentation** (Sector_rank through Order_gen)
   can land as a follow-up without changing the trace sexp schema — the
   Phase variants are already defined. See §Follow-up item 6.

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -1,6 +1,6 @@
 # Status: backtest-scale
 
-## Last updated: 2026-04-17
+## Last updated: 2026-04-19
 
 ## Status
 PENDING
@@ -12,8 +12,8 @@ N/A — not started
 —
 
 ## Blocked on
-- PR #396 (plan) reviewed + merged — decisions locked there, including flag-gated rollout with automated parity test as acceptance gate.
-- Step 2 tracing (tracked under `backtest-infra.md`) — needed for A/B empiricism on the Legacy vs Tiered cutover.
+- None. PR #396 (plan) merged; #419 (Step 2 tracing) merged 2026-04-19
+  — A/B empiricism on Legacy vs Tiered cutover now has a trace schema.
 
 ## Goal
 

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -1,6 +1,6 @@
 # Status: harness
 
-## Last updated: 2026-04-18
+## Last updated: 2026-04-19
 
 ## Status
 IN_PROGRESS
@@ -112,6 +112,14 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
   environment (see `dev/status/orchestrator-automation.md`), this part
   needs to land together with the automation work. Source:
   `dev/daily/2026-04-14.md` (refreshed end-of-day).
+- **Same-day summary consolidation** — multi-run days produce
+  `2026-04-18.md`, `-run2.md`, `-run3.md`, `-run4.md` with no
+  end-of-day roll-up. A plan-mode reader has to stitch four files to
+  answer "what happened today." Low severity. Fix sketch: add a
+  `dev/lib/consolidate_day.sh` that merges all `${DATE}*.md` (non-plan)
+  into `${DATE}-summary.md` with deduped §Dispatched + merged
+  §Escalations; wire into `lead-orchestrator` Step 8 post-merge when
+  `N >= 3`. Source: 2026-04-18 plan-mode audit.
 - **Deep scan heuristic gaps** — `trading/devtools/checks/deep_scan.sh`
   (T3-A, see #331) is missing several useful checks. Today's manual
   audit found four real issues the script didn't surface:

--- a/dev/status/orchestrator-automation.md
+++ b/dev/status/orchestrator-automation.md
@@ -3,7 +3,9 @@
 ## Last updated: 2026-04-18
 
 ## Status
-IN_PROGRESS — Phase 1 live; Phase 2 (background execution) pending.
+IN_PROGRESS
+
+Phase 1 live; Phase 2 (background execution) pending.
 
 Phase 1 (scheduled daily orchestrator on GHA) has been producing daily
 summary PRs since 2026-04-16. See `.github/workflows/orchestrator.yml`

--- a/dev/status/sector-data.md
+++ b/dev/status/sector-data.md
@@ -3,8 +3,9 @@
 ## Last updated: 2026-04-18
 
 ## Status
-IN_PROGRESS — Items 1, 2, 4, 4.1 done. Only Item 3 (refresh cadence
-hook) remains.
+IN_PROGRESS
+
+Items 1, 2, 4, 4.1 done. Only Item 3 (refresh cadence hook) remains.
 
 Item 1 merged (#349, 2026-04-15). Item 2 (one-shot fetch) ran locally
 on the operator's workstation and populated `data/sectors.csv`

--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -1,18 +1,22 @@
 # Status: short-side-strategy
 
-## Last updated: 2026-04-18
+## Last updated: 2026-04-19
 
 ## Status
-READY_FOR_REVIEW (MVP slice)
+MERGED
+
+MVP slice landed via #420 on 2026-04-19; follow-ups tracked below.
 
 ## Interface stable
-YES — `Screener.scored_candidate.side` and public `Weinstein_strategy.entries_from_candidates` signature landed.
+YES
 
-## Open PR
+`Screener.scored_candidate.side` and public `Weinstein_strategy.entries_from_candidates` signature landed in main.
+
+## Merged PR
 - #420 (feat/short-side-strategy) — MVP vertical slice: side through screener → strategy → order_generator, with Ch.11 RS hard gate and unit tests for Short + Long entry transitions.
 
 ## Blocked on
-- None. Ready for QC. Pre-existing main-baseline nesting-linter red is unrelated to this scope (same failures on `feat/short-side-strategy` branch point as on `main`; no new failures introduced).
+- None.
 
 ## Goal
 
@@ -64,10 +68,8 @@ Wire short-side entries into `Weinstein_strategy` so the simulation emits short 
 `feat-weinstein` agent (dispatched 2026-04-18).
 
 ## QC
-overall_qc: PENDING
-structural_qc: PENDING
-behavioral_qc: PENDING
+overall_qc: APPROVED (merged)
+structural_qc: APPROVED
+behavioral_qc: APPROVED
 
-Reviewers when work lands:
-- qc-structural — side parameterisation clean through screener → strategy → order_generator; no hardcoded Long remaining.
-- qc-behavioral — Ch. 11 rules encoded faithfully (Stage 4 + negative RS + bearish macro); no shorting Stage 2 stocks. The Ch.11 hard RS gate is tested (`test_positive_rs_blocks_short`).
+Review artifacts (run-4): side parameterisation clean through screener → strategy → order_generator; no hardcoded Long remaining. Ch.11 hard RS gate tested via `test_positive_rs_blocks_short`.


### PR DESCRIPTION
## Summary

Clean-up pass after merging #419 (backtest phase tracing), #420 (short-side strategy MVP), and #421 (deep-scan Check 10). Root cause: per-track status files don't auto-update when a feature PR merges, so \`_index.md\` drifted against \`main\` between runs.

### What changed

- **Status files flipped to MERGED.** \`backtest-infra.md\`, \`short-side-strategy.md\` headers updated; stale PR pointer (#395) dropped from backtest-infra Open PRs.
- **\`_index.md\` rows reconciled.** Rows for the three merged tracks + \`Last updated\` bumped.
- **Pre-existing schema violations fixed.** \`orchestrator-automation.md\` + \`sector-data.md\` had inline prose after \`## Status\` that blocked \`status_file_integrity.sh\`. \`short-side-strategy.md\` \`## Interface stable\` likewise normalised.
- **\`lead-orchestrator\` Step 5.5: merge-watch sub-step.** Before trusting the local \`## Status\` heading, poll the GH API; if the referenced PR is \`closed + merged\`, promote the per-track status file to MERGED. This is the root-cause fix — without it, the index re-drifts after every merge window.
- **\`harness.md\` follow-up added:** same-day summary consolidation (surfaced by plan-mode audit — run1/2/3/4 produces no end-of-day roll-up).
- **\`backtest-scale.md\`:** drop Step 2 tracing as a blocker (#419 satisfied it).
- **\`dev/notes/data-gaps.md\`:** remove stale \"wire global index bars into strategy\" action — PR #355 landed it back on 2026-04-12.

### Validation

- \`sh trading/devtools/checks/status_file_integrity.sh\` → \`OK: all dev/status/*.md files have required fields.\`
- \`dune build @runtest\` exit 0.
- Re-ran plan mode after the reconcile: Step 5.5 merge-watch = 0 flips, Step 1b drift = clean across 12 rows.

## Test plan

- [x] Build + tests green
- [x] Integrity linter green
- [x] Plan-mode replay shows the drift is gone