### PR TITLE
ci(orchestrator): run 4x daily (22/03/08/13 PT); minute :17

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -42,15 +42,18 @@
 name: Daily orchestrator
 
 on:
-  # Three runs per day (1 AM / 7 AM / 12 PM Pacific) to amortize the
-  # rolling 5-hour Claude quota window. Minute `:17` avoids top-of-hour
-  # GHA load (scheduled jobs at :00 – :05 get delayed or silently
-  # dropped). GitHub cron is UTC-only, no DST awareness — these are set
-  # for UTC-7 (PDT); during PST months they drift back 1 hour.
+  # Four runs per day (10 PM / 3 AM / 8 AM / 1 PM Pacific) to amortize
+  # the rolling 5-hour Claude quota window. Gap of 9h between the 1 PM
+  # and 10 PM slots covers the evening window by design. Minute `:17`
+  # avoids top-of-hour GHA load (scheduled jobs at :00 – :05 get delayed
+  # or silently dropped). GitHub cron is UTC-only, no DST awareness —
+  # these are set for UTC-7 (PDT); during PST months they drift back 1
+  # hour.
   schedule:
-    - cron: "17 8 * * *"    # 01:17 PT
-    - cron: "17 14 * * *"   # 07:17 PT
-    - cron: "17 19 * * *"   # 12:17 PT
+    - cron: "17 5 * * *"    # 22:17 PT (prev day)
+    - cron: "17 10 * * *"   # 03:17 PT
+    - cron: "17 15 * * *"   # 08:17 PT
+    - cron: "17 20 * * *"   # 13:17 PT
   workflow_dispatch:
 
 # Queue, do not cancel, if a previous run is still executing when the


### PR DESCRIPTION
## Summary

Bump orchestrator cadence from 3x to 4x daily.

**New slots (PT):** 10 PM, 3 AM, 8 AM, 1 PM.
**UTC crons (PDT, UTC-7):** \`17 5 * * *\`, \`17 10 * * *\`, \`17 15 * * *\`, \`17 20 * * *\`.

Gap distribution: 5h / 5h / 5h / 9h — the 9h evening gap is by design (no one's awake to react to findings at 3 AM anyway; the 10 PM run covers the overnight window). Minute \`:17\` preserved for the same GHA top-of-hour-load reason as the existing schedule.

Note: GHA cron is UTC-only, no DST — these are pinned to PDT (currently in effect). During PST months the slots drift back 1 hour in PT (so 9 PM / 2 AM / 7 AM / 12 PM). Same drift behavior as the existing 3x schedule.

## Test plan

- [ ] Merge; watch the next scheduled slot fire (first scheduled run within 5h).
- [ ] Check \`workflow_dispatch\` still works as manual override.