### PR TITLE
orchestrator: allow stacked dispatch up to cap-2 per plan-first track

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -163,19 +163,61 @@ for pr in prs:
 
 ```
 FOR each eligible track from Step 1:
-  IF any open PRs found on feat/<track> or feat/<track>/* branches:
-    tip_sha = (SHA from the curl output above for that PR)
+  open_prs = (open PRs on feat/<track> or feat/<track>/*)
+  N = len(open_prs)
+
+  IF N == 0:
+    → dispatch feat-agent normally (proceed to Step 2)
+
+  IF N > 0 (work in flight):
+    tip_sha = (SHA of the newest-by-created-at open PR)
     last_review_sha = (parse "Reviewed SHA:" line from dev/reviews/<track>.md, if it exists)
 
-    IF track status is READY_FOR_REVIEW AND tip_sha != last_review_sha:
-      → dispatch re-QC only (Step 5 pipeline); skip feat-agent dispatch
-      → note in summary: "re-QC only — new commits since last review (SHA changed)"
+    # First: handle QC on any READY_FOR_REVIEW PR with new commits.
+    IF tip PR status is READY_FOR_REVIEW AND tip_sha != last_review_sha:
+      → dispatch re-QC only (Step 5 pipeline)
+      → note: "re-QC — new commits on PR #<N_tip>"
+
+    # Second: decide whether to stack additional work ahead.
+    # Stacked dispatch = new feat-agent work on top of the existing open PR(s),
+    # producing a stacked PR via `jst submit`. Only enabled for plan-first tracks
+    # so "what's next" is unambiguous (next unstarted increment from the plan).
+    stack_eligible =
+      - track has a merged plan at dev/plans/<track>-*.md,
+      - plan has explicit un-implemented increments (not yet landed on main),
+      - N < 2 (cap: at most one root PR + one stacked follow-up),
+      - root PR (oldest open PR on the track) is not stale:
+          - age < 3 days (older signals review bottleneck; stop stacking),
+          - last CI check is not "failure",
+          - no `changes_requested` review outstanding.
+
+    IF stack_eligible:
+      → dispatch feat-agent in "continue-from-plan" mode:
+          inject `## Plan context` with the path to the plan,
+          the already-landed increments (root PR's diff summary),
+          and "pick the next un-implemented increment".
+      → agent opens a stacked PR via `jst submit` on
+        feat/<track>/<increment-slug>.
+      → note in summary: "stacked dispatch — increment <X> (depth 2/2)".
     ELSE:
-      → SKIP dispatch entirely (feat-agent and QC)
-      → record reason in summary: "skipped — open PR #<N> in flight, no new commits"
-  ELSE (no open PRs):
-    → dispatch feat-agent normally (proceed to Step 2)
+      → SKIP feat-agent dispatch (keep any re-QC dispatched above).
+      → record reason: one of
+          "skipped — open PR #<N> in flight, no new commits"          (non-plan-first)
+          "skipped — depth cap reached (<N> open PRs on track)"       (cap hit)
+          "skipped — root PR stale (age/CI/review; see <reason>)"     (escape hatch)
+          "skipped — no un-implemented increments in plan"            (plan complete)
 ```
+
+**Per-track override.** A plan file may declare `## Max stacked PRs: <K>`
+(default 2) to widen or narrow the cap for that specific track. Bug-fix
+chains and hot-path refactors may set higher; risky refactors may set 1.
+
+**Observability.** When the cap is hit *and* the root PR is less than 3 days
+old (i.e., stacking would be safe but the cap says stop), log as `[info]`
+escalation "track <X> hitting stack cap with fresh root PR — consider raising
+`Max stacked PRs`". When the root PR is stale (review bottleneck), log as
+`[info]` "track <X> root PR #<N> open > 3 days — stacked dispatch paused".
+These keep review queue backup visible without surprising the human.
 
 **This guard is PER TRACK, not per agent.** An agent that owns multiple
 tracks (e.g. `feat-weinstein` owns `portfolio-stops`, `simulation`,

--- a/dev/status/orchestrator-automation.md
+++ b/dev/status/orchestrator-automation.md
@@ -318,6 +318,20 @@ From a Claude Code guide research session:
    QC for feature A can run in parallel with implementation for
    feature B — that's the pattern background Agent dispatch enables.
 
+4. **Stacked dispatch per track (Step 1.5 cap=2).** Today Step 1.5
+   hard-skips feat-agent re-dispatch whenever any open PR exists on
+   the track. For plan-first tracks with explicit un-implemented
+   increments, the next run is blocked on human review of the first
+   PR — forcing a serial one-PR-per-run pace per track. Relax to a
+   depth cap (default 2) so the orchestrator can produce the next
+   increment's PR on top of the first, stacked via `jst submit`.
+   Escape hatches: age > 3 days, CI failure, or `changes_requested`
+   review on the root PR all pause stacking. Plan files may override
+   the cap per-track via `## Max stacked PRs: <K>`. Pairs with win #3
+   (cross-feature QC parallelism): once the stacked second PR opens,
+   its QC can run while the first PR awaits human merge. See Step 1.5
+   in `.claude/agents/lead-orchestrator.md` for the full contract.
+
 ### Environment split (hypothesis — confirm before committing)
 
 | Env | Background `Bash` | Background `Agent` | Confidence |


### PR DESCRIPTION
## Summary

Relax Step 1.5 (PR-open dispatch guard) from "hard skip whenever any open PR exists" to "skip when depth cap is hit." Unblocks the orchestrator from producing the next increment's PR on top of an in-flight first PR, so consecutive GHA runs can land sequential increments on plan-first tracks instead of idling until a human merges the first PR.

## What changes

### \`.claude/agents/lead-orchestrator.md\` Step 1.5

- Computes open-PR count \`N\` per track.
- \`N == 0\` → dispatch as today.
- \`N > 0\` AND stack-eligible → dispatch feat-agent in "continue-from-plan" mode, producing a stacked PR via \`jst submit\`.
- \`N >= cap\` OR stack-not-eligible → skip.

### Stack eligibility (conservative defaults)

- Track has a merged plan file at \`dev/plans/<track>-*.md\` with explicit un-implemented increments.
- \`N < 2\` (cap: one root + one stacked follow-up).
- Root PR is fresh: age < 3 days, CI not failing, no \`changes_requested\` review outstanding.

### Per-track override

Plan file may declare \`## Max stacked PRs: <K>\` to widen or narrow the cap.

### Observability

- Cap-hit with fresh root → \`[info]\` "consider raising \`Max stacked PRs\`".
- Cap-not-hit but root stale → \`[info]\` "root PR #<N> open > 3 days — stacked dispatch paused".

Surfaces review-queue backup without silently piling up work.

### \`dev/status/orchestrator-automation.md\` Phase 2

Adds win #4 under "Three concrete wins" (now four). Pairs with existing win #3 (cross-feature QC parallelism): once stacked PR opens, its QC can run while the first PR awaits merge.

## Rationale

- Current behavior: runs 2–4 across 2026-04-17/18 marked #419/#420/#421 as \`skipped — open PR in flight, no new commits\` across every slot. That's correct under cap=1 but wastes throughput when plan-first tracks have a clear "next increment."
- Cap=2 + plan-first-only is the smallest relaxation: strictly more throughput than today, no change for non-plan-first tracks.
- Escape hatches (age/CI/review) keep the depth cap from masking actual review bottlenecks.

## Test plan

- [ ] Merge #429 (status-reconcile) first so integrity linter is green baseline.
- [ ] Dry-run: next GHA fire with the new Step 1.5 should still produce \`cap reached\` skips for any track already at depth 2 (there aren't any today).
- [ ] On the next plan-first track reaching depth 1 open PR: verify Step 1.5 dispatches the stacked increment instead of skipping.
- [ ] Confirm \`jst submit\` creates the PR targeting the root PR's branch correctly.