### PR TITLE
feat(backtest): bar_loader scaffold + Metadata tier (Step 3a)

### DIFF
--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -3,17 +3,17 @@
 ## Last updated: 2026-04-19
 
 ## Status
-APPROVED
+READY_FOR_REVIEW
 
-Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a dispatches on next orchestrator run.
+Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata tier) implemented and pushed on `feat/backtest-tiered-loader`; 3b (Summary) is the next increment.
 
 ## Interface stable
-NO
+PARTIAL — 3a landed
 
-Implementation not yet started; plan decomposes Step 3 into 8 increments (3a–3h) each with its own interface. `Bar_loader` types stabilize incrementally as 3a/3b/3c land.
+`Bar_loader.create` / `promote` / `demote` / `tier_of` / `get_metadata` / `stats` signatures are stable. `get_summary` and `get_full` currently return `unit option` placeholders; their return type becomes `Summary.t option` / `Full.t option` in 3b / 3c respectively.
 
 ## Open PR
-- #433 (feat/backtest-tiered-loader) — plan PR, approved, awaiting merge.
+- feat/backtest-tiered-loader — 3a open at https://github.com/dayfine/trading/pull/new/feat/backtest-tiered-loader (draft, awaiting QC).
 
 ## Blocked on
 - None. Plan approved; 3a unblocked once #433 merges.
@@ -80,15 +80,33 @@ Build alongside existing `Bar_history` — don't modify it.
 
 ## Next Steps
 
-1. Human reviews `dev/plans/backtest-tiered-loader-2026-04-19.md` and resolves §Open questions (ε threshold, scenario selection, screener-refactor scope, module placement, demotion semantics).
-2. On approval, orchestrator dispatches `feat-backtest` to implement 3a.
-3. Each subsequent GHA run picks up the next increment.
+1. QC review of 3a (feat/backtest-tiered-loader head).
+2. Dispatch 3b — Summary tier. Adds `Summary.t`, `summary_compute.{ml,mli}` (30w MA, ATR, stage heuristic, RS line from bounded bar tail), extends `promote ~to_:Summary_tier` and `get_summary` to return `Summary.t option`. ~220 lines per plan §3b.
+3. Subsequent increments 3c–3g follow per plan §Dependency graph.
+
+## Completed
+
+- **3a — Metadata tier + types scaffold** (2026-04-19). New library at
+  `trading/trading/backtest/bar_loader/`. Exposes the full
+  `Metadata_tier | Summary_tier | Full_tier` variant up front so
+  3b/3c don't churn it. `Metadata.t` carries sector + last_close;
+  `market_cap` and `avg_vol_30d` stay `float option = None` until a
+  consumer needs them (plan §Risks #4). `promote ~to_:Metadata_tier`
+  reads the last bar ≤ `as_of` via the existing `Price_cache` and
+  joins a caller-supplied sector table — idempotent, surfaces
+  per-symbol errors without inserting failed symbols. Higher-tier
+  promotes return `Status.Unimplemented`. `Bar_history`,
+  `Weinstein_strategy`, `Simulator`, `Price_cache`, and `Screener`
+  untouched (plan §Out of scope).
+  - Files: `bar_loader/{dune,bar_loader.mli,bar_loader.ml}` +
+    `bar_loader/test/{dune,test_metadata.ml}`.
+  - Verify: `dev/lib/run-in-env.sh dune build trading/backtest/bar_loader && dev/lib/run-in-env.sh dune runtest trading/backtest/bar_loader/test` — 7 tests pass.
 
 ## QC
 
-overall_qc: PENDING
-structural_qc: PENDING
-behavioral_qc: PENDING
+overall_qc: PENDING (3a ready for review)
+structural_qc: PENDING (3a)
+behavioral_qc: N/A (3a — no strategy behavior change; parity test arrives with 3g)
 
 Reviewers when work lands:
 - qc-structural — module boundaries between tiers; `Bar_history` untouched; parity test runs both strategies.

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -20,11 +20,11 @@ end
 type stats_counts = { metadata : int; summary : int; full : int }
 [@@deriving show, eq, sexp]
 
+type entry = { tier : tier; metadata : Metadata.t option }
 (** Per-symbol entry. Held in a mutable hashtable keyed on symbol. The [tier]
     field reflects the highest tier this symbol has been promoted to; the
     tier-specific data fields are [Some _] at that tier and below. In 3a only
     [metadata] is ever populated. *)
-type entry = { tier : tier; metadata : Metadata.t option }
 
 type t = {
   sector_map : string String.Table.t;
@@ -59,9 +59,9 @@ let _tier_rank = function
   | Full_tier -> 2
 
 (** [_load_metadata] reads the last bar on or before [as_of] from the shared
-    [Price_cache] and joins the sector table. Market cap and average volume
-    are [None] on this increment — wired when the first consumer needs them
-    (§Risks #4 of the plan). *)
+    [Price_cache] and joins the sector table. Market cap and average volume are
+    [None] on this increment — wired when the first consumer needs them (§Risks
+    #4 of the plan). *)
 let _load_metadata t ~symbol ~as_of : (Metadata.t, Status.t) Result.t =
   match Price_cache.get_prices t.price_cache ~symbol ~end_date:as_of () with
   | Error err -> Error err
@@ -85,8 +85,8 @@ let _load_metadata t ~symbol ~as_of : (Metadata.t, Status.t) Result.t =
         }
 
 (** [_promote_one_to_metadata] is idempotent: if the symbol is already at
-    Metadata or higher, it's a no-op. Otherwise it runs the metadata load
-    and inserts the entry. *)
+    Metadata or higher, it's a no-op. Otherwise it runs the metadata load and
+    inserts the entry. *)
 let _promote_one_to_metadata t ~symbol ~as_of : (unit, Status.t) Result.t =
   match Hashtbl.find t.entries symbol with
   | Some entry when _tier_rank entry.tier >= _tier_rank Metadata_tier -> Ok ()
@@ -123,8 +123,7 @@ let demote _t ~symbols:_ ~to_:_ =
   ()
 
 let stats t =
-  Hashtbl.fold t.entries
-    ~init:{ metadata = 0; summary = 0; full = 0 }
+  Hashtbl.fold t.entries ~init:{ metadata = 0; summary = 0; full = 0 }
     ~f:(fun ~key:_ ~data acc ->
       match data.tier with
       | Metadata_tier -> { acc with metadata = acc.metadata + 1 }

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -1,0 +1,132 @@
+(** Tier-aware bar loader — see [bar_loader.mli]. *)
+
+open Core
+module Price_cache = Trading_simulation_data.Price_cache
+
+type tier = Metadata_tier | Summary_tier | Full_tier
+[@@deriving show, eq, sexp]
+
+module Metadata = struct
+  type t = {
+    symbol : string;
+    sector : string;
+    last_close : float;
+    avg_vol_30d : float option;
+    market_cap : float option;
+  }
+  [@@deriving show, eq, sexp]
+end
+
+type stats_counts = { metadata : int; summary : int; full : int }
+[@@deriving show, eq, sexp]
+
+(** Per-symbol entry. Held in a mutable hashtable keyed on symbol. The [tier]
+    field reflects the highest tier this symbol has been promoted to; the
+    tier-specific data fields are [Some _] at that tier and below. In 3a only
+    [metadata] is ever populated. *)
+type entry = { tier : tier; metadata : Metadata.t option }
+
+type t = {
+  sector_map : string String.Table.t;
+  entries : (string, entry) Hashtbl.t;
+  price_cache : Price_cache.t;
+}
+
+let create ~data_dir ~sector_map ~universe:_ =
+  (* [universe] is accepted in the signature so 3b/3c/3f can drive tier-wide
+     operations ("promote every universe symbol to Metadata on startup")
+     without a signature churn. Not consumed yet in 3a. *)
+  {
+    sector_map;
+    entries = Hashtbl.create (module String);
+    price_cache = Price_cache.create ~data_dir;
+  }
+
+let tier_of t ~symbol =
+  Hashtbl.find t.entries symbol |> Option.map ~f:(fun e -> e.tier)
+
+let get_metadata t ~symbol =
+  Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.metadata)
+
+let get_summary _t ~symbol:_ = None
+let get_full _t ~symbol:_ = None
+
+(** [_tier_rank] encodes the Metadata < Summary < Full ordering used for
+    idempotent promotion: a symbol at tier [>= to_] is left alone. *)
+let _tier_rank = function
+  | Metadata_tier -> 0
+  | Summary_tier -> 1
+  | Full_tier -> 2
+
+(** [_load_metadata] reads the last bar on or before [as_of] from the shared
+    [Price_cache] and joins the sector table. Market cap and average volume
+    are [None] on this increment — wired when the first consumer needs them
+    (§Risks #4 of the plan). *)
+let _load_metadata t ~symbol ~as_of : (Metadata.t, Status.t) Result.t =
+  match Price_cache.get_prices t.price_cache ~symbol ~end_date:as_of () with
+  | Error err -> Error err
+  | Ok [] ->
+      Error
+        (Status.not_found_error
+           (Printf.sprintf "No bars for %s on or before %s" symbol
+              (Date.to_string as_of)))
+  | Ok bars ->
+      let last = List.last_exn bars in
+      let sector =
+        Hashtbl.find t.sector_map symbol |> Option.value ~default:""
+      in
+      Ok
+        {
+          Metadata.symbol;
+          sector;
+          last_close = last.close_price;
+          avg_vol_30d = None;
+          market_cap = None;
+        }
+
+(** [_promote_one_to_metadata] is idempotent: if the symbol is already at
+    Metadata or higher, it's a no-op. Otherwise it runs the metadata load
+    and inserts the entry. *)
+let _promote_one_to_metadata t ~symbol ~as_of : (unit, Status.t) Result.t =
+  match Hashtbl.find t.entries symbol with
+  | Some entry when _tier_rank entry.tier >= _tier_rank Metadata_tier -> Ok ()
+  | _ -> (
+      match _load_metadata t ~symbol ~as_of with
+      | Error err -> Error err
+      | Ok metadata ->
+          Hashtbl.set t.entries ~key:symbol
+            ~data:{ tier = Metadata_tier; metadata = Some metadata };
+          Ok ())
+
+let _unimplemented_tier tier : Status.t =
+  {
+    code = Status.Unimplemented;
+    message =
+      Printf.sprintf "Bar_loader.promote: tier %s not yet implemented (3a only)"
+        (show_tier tier);
+  }
+
+let promote t ~symbols ~to_ ~as_of =
+  match to_ with
+  | Summary_tier | Full_tier -> Error (_unimplemented_tier to_)
+  | Metadata_tier ->
+      List.fold_until symbols ~init:()
+        ~f:(fun () symbol ->
+          match _promote_one_to_metadata t ~symbol ~as_of with
+          | Ok () -> Continue ()
+          | Error err -> Stop (Error err))
+        ~finish:(fun () -> Ok ())
+
+let demote _t ~symbols:_ ~to_:_ =
+  (* 3a: no Summary / Full data exists, so there is nothing to drop. The
+     signature is stable so 3b / 3c wire in real demotion without churn. *)
+  ()
+
+let stats t =
+  Hashtbl.fold t.entries
+    ~init:{ metadata = 0; summary = 0; full = 0 }
+    ~f:(fun ~key:_ ~data acc ->
+      match data.tier with
+      | Metadata_tier -> { acc with metadata = acc.metadata + 1 }
+      | Summary_tier -> { acc with summary = acc.summary + 1 }
+      | Full_tier -> { acc with full = acc.full + 1 })

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -10,25 +10,25 @@
     - {b Summary} — sector-ranked subset; indicator scalars (30w MA, RS line,
       stage heuristic, ATR) computed from a bounded tail of bars; raw bars
       dropped.
-    - {b Full} — raw OHLCV history for symbols actively considered for entry
-      or currently held.
+    - {b Full} — raw OHLCV history for symbols actively considered for entry or
+      currently held.
 
-    This increment (3a) implements {b Metadata only}. The [tier] variant
-    already exposes all three tags so later increments extend the loader
-    without churn in the variant. [Summary.t] and [Full.t] submodules and
-    their promotion semantics are added in 3b / 3c. In 3a,
-    [promote ~to_:Summary_tier] and [promote ~to_:Full_tier] raise
-    [Failure]; [get_summary] and [get_full] always return [None]. *)
+    This increment (3a) implements {b Metadata only}. The [tier] variant already
+    exposes all three tags so later increments extend the loader without churn
+    in the variant. [Summary.t] and [Full.t] submodules and their promotion
+    semantics are added in 3b / 3c. In 3a, [promote ~to_:Summary_tier] and
+    [promote ~to_:Full_tier] raise [Failure]; [get_summary] and [get_full]
+    always return [None]. *)
 
 open Core
 
 (** {1 Tier tag} *)
 
+(** Discrete ordering of tiers by information content: [Metadata_tier] <
+    [Summary_tier] < [Full_tier]. Promotion moves a symbol to a higher tier;
+    demotion moves it back down. *)
 type tier = Metadata_tier | Summary_tier | Full_tier
 [@@deriving show, eq, sexp]
-(** Discrete ordering of tiers by information content:
-    [Metadata_tier] < [Summary_tier] < [Full_tier]. Promotion moves a symbol
-    to a higher tier; demotion moves it back down. *)
 
 (** {1 Tier-shaped data} *)
 
@@ -38,10 +38,11 @@ module Metadata : sig
     sector : string;
         (** Sector name as loaded from the sector table. [""] when the symbol
             has no sector entry — the loader does not synthesize a sector. *)
-    last_close : float;  (** Close price of the last bar on or before [as_of]. *)
+    last_close : float;
+        (** Close price of the last bar on or before [as_of]. *)
     avg_vol_30d : float option;
-        (** 30-day average volume. [None] on this increment — wired in a
-            later PR when the screener needs it. *)
+        (** 30-day average volume. [None] on this increment — wired in a later
+            PR when the screener needs it. *)
     market_cap : float option;
         (** Market capitalization. [None] on this increment. *)
   }
@@ -51,64 +52,71 @@ end
 (** {1 Loader} *)
 
 type t
-(** Mutable bag of per-symbol tier assignments + computed data. Opaque —
-    callers go through [promote] / [get_*] / [stats]. Not safe to share
-    across threads. *)
+(** Mutable bag of per-symbol tier assignments + computed data. Opaque — callers
+    go through [promote] / [get_*] / [stats]. Not safe to share across threads.
+*)
 
 type stats_counts = { metadata : int; summary : int; full : int }
 [@@deriving show, eq, sexp]
 (** Current per-tier symbol counts; used by tracer / parity harness. *)
 
 val create :
-  data_dir:Fpath.t -> sector_map:string String.Table.t -> universe:string list -> t
+  data_dir:Fpath.t ->
+  sector_map:string String.Table.t ->
+  universe:string list ->
+  t
 (** [create ~data_dir ~sector_map ~universe] returns a fresh loader. [universe]
-    is the full set of symbols the backtest may promote; it is recorded but
-    does {b not} load any bars (Metadata-tier loads happen in [promote]).
-    [sector_map] is a symbol → sector lookup; symbols missing from the map
-    get [sector = ""] on promotion. [data_dir] is forwarded to an internal
+    is the full set of symbols the backtest may promote; it is recorded but does
+    {b not} load any bars (Metadata-tier loads happen in [promote]).
+    [sector_map] is a symbol → sector lookup; symbols missing from the map get
+    [sector = ""] on promotion. [data_dir] is forwarded to an internal
     [Price_cache] used on demand. *)
 
 val promote :
-  t -> symbols:string list -> to_:tier -> as_of:Date.t -> (unit, Status.t) Result.t
-(** [promote t ~symbols ~to_ ~as_of] moves every symbol in [symbols] up to
-    tier [to_], loading whatever data that tier needs. Idempotent: a symbol
-    already at tier [>= to_] is unchanged.
+  t ->
+  symbols:string list ->
+  to_:tier ->
+  as_of:Date.t ->
+  (unit, Status.t) Result.t
+(** [promote t ~symbols ~to_ ~as_of] moves every symbol in [symbols] up to tier
+    [to_], loading whatever data that tier needs. Idempotent: a symbol already
+    at tier [>= to_] is unchanged.
 
     In this increment only [to_ = Metadata_tier] is implemented — passing
     [Summary_tier] or [Full_tier] returns an [Error] with a
     [Status.Unimplemented] code. Subsequent increments (3b, 3c) add those
     branches.
 
-    Returns the first per-symbol error encountered (if any). A symbol that
-    fails to load is {e not} added to the loader. *)
+    Returns the first per-symbol error encountered (if any). A symbol that fails
+    to load is {e not} added to the loader. *)
 
 val demote : t -> symbols:string list -> to_:tier -> unit
-(** [demote t ~symbols ~to_] tiers each symbol down, freeing higher-tier data.
-    A symbol currently at tier [<= to_] is unchanged. Calling with
+(** [demote t ~symbols ~to_] tiers each symbol down, freeing higher-tier data. A
+    symbol currently at tier [<= to_] is unchanged. Calling with
     [to_ = Metadata_tier] fully drops any Summary / Full caches.
 
-    In 3a, since promote only reaches Metadata, [demote] is effectively a
-    no-op — included for API completeness so 3b / 3c extend the behaviour
-    without a signature change. *)
+    In 3a, since promote only reaches Metadata, [demote] is effectively a no-op
+    — included for API completeness so 3b / 3c extend the behaviour without a
+    signature change. *)
 
 val tier_of : t -> symbol:string -> tier option
-(** [tier_of t ~symbol] returns the current tier of [symbol], or [None] if
-    the symbol has never been promoted in this loader. *)
+(** [tier_of t ~symbol] returns the current tier of [symbol], or [None] if the
+    symbol has never been promoted in this loader. *)
 
 val get_metadata : t -> symbol:string -> Metadata.t option
-(** [get_metadata t ~symbol] returns the Metadata record for [symbol] when
-    it has been promoted at least to Metadata tier, otherwise [None]. *)
+(** [get_metadata t ~symbol] returns the Metadata record for [symbol] when it
+    has been promoted at least to Metadata tier, otherwise [None]. *)
 
 val get_summary : t -> symbol:string -> unit option
-(** Placeholder for 3b. Always returns [None] in this increment; the return
-    type is [unit option] to keep the interface signature stable until 3b
-    introduces [Summary.t]. *)
+(** Placeholder for 3b. Always returns [None] in this increment; the return type
+    is [unit option] to keep the interface signature stable until 3b introduces
+    [Summary.t]. *)
 
 val get_full : t -> symbol:string -> unit option
-(** Placeholder for 3c. Always returns [None] in this increment; same
-    stability rationale as [get_summary]. *)
+(** Placeholder for 3c. Always returns [None] in this increment; same stability
+    rationale as [get_summary]. *)
 
 val stats : t -> stats_counts
-(** [stats t] returns the current per-tier symbol counts. The sum of the
-    three fields equals the number of symbols that have been promoted at
-    least once (and not subsequently demoted below Metadata). *)
+(** [stats t] returns the current per-tier symbol counts. The sum of the three
+    fields equals the number of symbols that have been promoted at least once
+    (and not subsequently demoted below Metadata). *)

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -1,0 +1,114 @@
+(** Tier-aware bar loader.
+
+    Step 3 of the backtest-scale plan
+    (dev/plans/backtest-tiered-loader-2026-04-19.md). The loader keeps
+    per-symbol data at one of three tiers so the backtest working set scales
+    with {e actively tracked} symbols rather than {e total inventory}:
+
+    - {b Metadata} — last-bar scalars (last close, sector, optional cap and
+      average volume). One record for {e every} universe symbol.
+    - {b Summary} — sector-ranked subset; indicator scalars (30w MA, RS line,
+      stage heuristic, ATR) computed from a bounded tail of bars; raw bars
+      dropped.
+    - {b Full} — raw OHLCV history for symbols actively considered for entry
+      or currently held.
+
+    This increment (3a) implements {b Metadata only}. The [tier] variant
+    already exposes all three tags so later increments extend the loader
+    without churn in the variant. [Summary.t] and [Full.t] submodules and
+    their promotion semantics are added in 3b / 3c. In 3a,
+    [promote ~to_:Summary_tier] and [promote ~to_:Full_tier] raise
+    [Failure]; [get_summary] and [get_full] always return [None]. *)
+
+open Core
+
+(** {1 Tier tag} *)
+
+type tier = Metadata_tier | Summary_tier | Full_tier
+[@@deriving show, eq, sexp]
+(** Discrete ordering of tiers by information content:
+    [Metadata_tier] < [Summary_tier] < [Full_tier]. Promotion moves a symbol
+    to a higher tier; demotion moves it back down. *)
+
+(** {1 Tier-shaped data} *)
+
+module Metadata : sig
+  type t = {
+    symbol : string;
+    sector : string;
+        (** Sector name as loaded from the sector table. [""] when the symbol
+            has no sector entry — the loader does not synthesize a sector. *)
+    last_close : float;  (** Close price of the last bar on or before [as_of]. *)
+    avg_vol_30d : float option;
+        (** 30-day average volume. [None] on this increment — wired in a
+            later PR when the screener needs it. *)
+    market_cap : float option;
+        (** Market capitalization. [None] on this increment. *)
+  }
+  [@@deriving show, eq, sexp]
+end
+
+(** {1 Loader} *)
+
+type t
+(** Mutable bag of per-symbol tier assignments + computed data. Opaque —
+    callers go through [promote] / [get_*] / [stats]. Not safe to share
+    across threads. *)
+
+type stats_counts = { metadata : int; summary : int; full : int }
+[@@deriving show, eq, sexp]
+(** Current per-tier symbol counts; used by tracer / parity harness. *)
+
+val create :
+  data_dir:Fpath.t -> sector_map:string String.Table.t -> universe:string list -> t
+(** [create ~data_dir ~sector_map ~universe] returns a fresh loader. [universe]
+    is the full set of symbols the backtest may promote; it is recorded but
+    does {b not} load any bars (Metadata-tier loads happen in [promote]).
+    [sector_map] is a symbol → sector lookup; symbols missing from the map
+    get [sector = ""] on promotion. [data_dir] is forwarded to an internal
+    [Price_cache] used on demand. *)
+
+val promote :
+  t -> symbols:string list -> to_:tier -> as_of:Date.t -> (unit, Status.t) Result.t
+(** [promote t ~symbols ~to_ ~as_of] moves every symbol in [symbols] up to
+    tier [to_], loading whatever data that tier needs. Idempotent: a symbol
+    already at tier [>= to_] is unchanged.
+
+    In this increment only [to_ = Metadata_tier] is implemented — passing
+    [Summary_tier] or [Full_tier] returns an [Error] with a
+    [Status.Unimplemented] code. Subsequent increments (3b, 3c) add those
+    branches.
+
+    Returns the first per-symbol error encountered (if any). A symbol that
+    fails to load is {e not} added to the loader. *)
+
+val demote : t -> symbols:string list -> to_:tier -> unit
+(** [demote t ~symbols ~to_] tiers each symbol down, freeing higher-tier data.
+    A symbol currently at tier [<= to_] is unchanged. Calling with
+    [to_ = Metadata_tier] fully drops any Summary / Full caches.
+
+    In 3a, since promote only reaches Metadata, [demote] is effectively a
+    no-op — included for API completeness so 3b / 3c extend the behaviour
+    without a signature change. *)
+
+val tier_of : t -> symbol:string -> tier option
+(** [tier_of t ~symbol] returns the current tier of [symbol], or [None] if
+    the symbol has never been promoted in this loader. *)
+
+val get_metadata : t -> symbol:string -> Metadata.t option
+(** [get_metadata t ~symbol] returns the Metadata record for [symbol] when
+    it has been promoted at least to Metadata tier, otherwise [None]. *)
+
+val get_summary : t -> symbol:string -> unit option
+(** Placeholder for 3b. Always returns [None] in this increment; the return
+    type is [unit option] to keep the interface signature stable until 3b
+    introduces [Summary.t]. *)
+
+val get_full : t -> symbol:string -> unit option
+(** Placeholder for 3c. Always returns [None] in this increment; same
+    stability rationale as [get_summary]. *)
+
+val stats : t -> stats_counts
+(** [stats t] returns the current per-tier symbol counts. The sum of the
+    three fields equals the number of symbols that have been promoted at
+    least once (and not subsequently demoted below Metadata). *)

--- a/trading/trading/backtest/bar_loader/dune
+++ b/trading/trading/backtest/bar_loader/dune
@@ -1,0 +1,6 @@
+(library
+ (public_name trading.backtest.bar_loader)
+ (name bar_loader)
+ (libraries core fpath status types trading.simulation.data)
+ (preprocess
+  (pps ppx_let ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/bar_loader/test/dune
+++ b/trading/trading/backtest/bar_loader/test/dune
@@ -1,0 +1,12 @@
+(tests
+ (names test_metadata)
+ (modules test_metadata)
+ (libraries
+  ounit2
+  core
+  core_unix.filename_unix
+  fpath
+  status
+  trading.backtest.bar_loader
+  types
+  matchers))

--- a/trading/trading/backtest/bar_loader/test/test_metadata.ml
+++ b/trading/trading/backtest/bar_loader/test/test_metadata.ml
@@ -1,0 +1,207 @@
+(** Unit tests for Bar_loader — 3a (Metadata tier). *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_loader = Bar_loader
+
+(** {1 Fixture helpers}
+
+    Each test builds its own temp data dir with a handful of synthetic CSVs so
+    we don't depend on checked-in fixtures. Symbols are chosen short and unique
+    (S01 .. S10) so they land in deterministic subdirectories under
+    [data_dir/<first>/<last>/<symbol>/data.csv]. *)
+
+let _mk_bar ~date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close;
+    low_price = close;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+(** Three consecutive daily bars ending on [2024-01-05]. Close on the last bar
+    is the distinguishing scalar we assert on in get_metadata tests. *)
+let _make_bars ~last_close =
+  [
+    _mk_bar
+      ~date:(Date.create_exn ~y:2024 ~m:Jan ~d:3)
+      ~close:(last_close -. 2.0);
+    _mk_bar
+      ~date:(Date.create_exn ~y:2024 ~m:Jan ~d:4)
+      ~close:(last_close -. 1.0);
+    _mk_bar ~date:(Date.create_exn ~y:2024 ~m:Jan ~d:5) ~close:last_close;
+  ]
+
+let _ok_or_fail ~context = function
+  | Ok v -> v
+  | Error (err : Status.t) ->
+      assert_failure (Printf.sprintf "%s: %s" context (Status.show err))
+
+let _write_symbol ~data_dir ~symbol ~last_close =
+  let storage =
+    Csv.Csv_storage.create ~data_dir symbol
+    |> _ok_or_fail ~context:("Csv_storage.create " ^ symbol)
+  in
+  Csv.Csv_storage.save storage (_make_bars ~last_close)
+  |> _ok_or_fail ~context:("Csv_storage.save " ^ symbol)
+
+let _fresh_data_dir () =
+  let dir = Filename_unix.temp_dir "bar_loader_test_" "" in
+  Fpath.v dir
+
+let _as_of = Date.create_exn ~y:2024 ~m:Jan ~d:31
+
+(** Build a fixture of [n] symbols, each with last close = 100 + index. Returns
+    the loader plus the list of symbols written (in insertion order). *)
+let _fixture ~n_symbols ~sector_map_entries =
+  let data_dir = _fresh_data_dir () in
+  let symbols =
+    List.init n_symbols ~f:(fun i -> Printf.sprintf "S%02d" (i + 1))
+  in
+  List.iteri symbols ~f:(fun i symbol ->
+      _write_symbol ~data_dir ~symbol ~last_close:(100.0 +. Float.of_int i));
+  let sector_map = String.Table.create () in
+  List.iter sector_map_entries ~f:(fun (sym, sec) ->
+      Hashtbl.set sector_map ~key:sym ~data:sec);
+  let loader = Bar_loader.create ~data_dir ~sector_map ~universe:symbols in
+  (loader, symbols)
+
+(** {1 Tests} *)
+
+let test_create_empty _ =
+  let loader, _ = _fixture ~n_symbols:0 ~sector_map_entries:[] in
+  assert_that (Bar_loader.stats loader)
+    (all_of
+       [
+         field (fun s -> s.Bar_loader.metadata) (equal_to 0);
+         field (fun s -> s.Bar_loader.summary) (equal_to 0);
+         field (fun s -> s.Bar_loader.full) (equal_to 0);
+       ]);
+  assert_that (Bar_loader.tier_of loader ~symbol:"S01") is_none;
+  assert_that (Bar_loader.get_metadata loader ~symbol:"S01") is_none
+
+let test_promote_10_symbols_stats _ =
+  let loader, symbols =
+    _fixture ~n_symbols:10
+      ~sector_map_entries:
+        [ ("S01", "Tech"); ("S02", "Tech"); ("S03", "Financials") ]
+  in
+  let result =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+  in
+  assert_that result is_ok;
+  assert_that (Bar_loader.stats loader)
+    (all_of
+       [
+         field (fun s -> s.Bar_loader.metadata) (equal_to 10);
+         field (fun s -> s.Bar_loader.summary) (equal_to 0);
+         field (fun s -> s.Bar_loader.full) (equal_to 0);
+       ])
+
+let test_get_metadata_returns_data _ =
+  let loader, symbols =
+    _fixture ~n_symbols:3 ~sector_map_entries:[ ("S01", "Tech") ]
+  in
+  let _ =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+    |> _ok_or_fail ~context:"Bar_loader.promote"
+  in
+  (* S01: sector set in map, last_close = 100.0 (index 0). *)
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"S01")
+    (is_some_and
+       (all_of
+          [
+            field (fun m -> m.Bar_loader.Metadata.symbol) (equal_to "S01");
+            field (fun m -> m.Bar_loader.Metadata.sector) (equal_to "Tech");
+            field
+              (fun m -> m.Bar_loader.Metadata.last_close)
+              (float_equal 100.0);
+            field (fun m -> m.Bar_loader.Metadata.avg_vol_30d) is_none;
+            field (fun m -> m.Bar_loader.Metadata.market_cap) is_none;
+          ]));
+  (* S02: no sector entry — should be "" (plan: loader does not synthesize). *)
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"S02")
+    (is_some_and
+       (all_of
+          [
+            field (fun m -> m.Bar_loader.Metadata.sector) (equal_to "");
+            field
+              (fun m -> m.Bar_loader.Metadata.last_close)
+              (float_equal 101.0);
+          ]));
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"S01")
+    (is_some_and (equal_to Bar_loader.Metadata_tier))
+
+let test_promote_is_idempotent _ =
+  let loader, symbols =
+    _fixture ~n_symbols:5 ~sector_map_entries:[ ("S01", "Tech") ]
+  in
+  let _ =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+    |> _ok_or_fail ~context:"Bar_loader.promote"
+  in
+  let stats_before = Bar_loader.stats loader in
+  (* Re-promote the same symbols to the same tier — must be a no-op. *)
+  let _ =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+    |> _ok_or_fail ~context:"Bar_loader.promote"
+  in
+  assert_that (Bar_loader.stats loader) (equal_to stats_before)
+
+let test_promote_missing_symbol_errors _ =
+  (* Symbol not in data_dir — Price_cache returns NotFound; promote surfaces it. *)
+  let loader, _ = _fixture ~n_symbols:0 ~sector_map_entries:[] in
+  let result =
+    Bar_loader.promote loader ~symbols:[ "NOPE" ] ~to_:Metadata_tier
+      ~as_of:_as_of
+  in
+  assert_that result is_error;
+  (* The failed symbol was not inserted. *)
+  assert_that (Bar_loader.tier_of loader ~symbol:"NOPE") is_none;
+  assert_that (Bar_loader.stats loader)
+    (field (fun s -> s.Bar_loader.metadata) (equal_to 0))
+
+let test_higher_tier_promotions_unimplemented _ =
+  let loader, symbols = _fixture ~n_symbols:2 ~sector_map_entries:[] in
+  let summary_result =
+    Bar_loader.promote loader ~symbols ~to_:Summary_tier ~as_of:_as_of
+  in
+  assert_that summary_result (is_error_with Unimplemented);
+  let full_result =
+    Bar_loader.promote loader ~symbols ~to_:Full_tier ~as_of:_as_of
+  in
+  assert_that full_result (is_error_with Unimplemented)
+
+let test_summary_full_getters_return_none _ =
+  let loader, symbols =
+    _fixture ~n_symbols:2 ~sector_map_entries:[ ("S01", "Tech") ]
+  in
+  let _ =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+    |> _ok_or_fail ~context:"Bar_loader.promote"
+  in
+  assert_that (Bar_loader.get_summary loader ~symbol:"S01") is_none;
+  assert_that (Bar_loader.get_full loader ~symbol:"S01") is_none
+
+let suite =
+  "Bar_loader.Metadata"
+  >::: [
+         "create_empty" >:: test_create_empty;
+         "promote_10_symbols_stats" >:: test_promote_10_symbols_stats;
+         "get_metadata_returns_data" >:: test_get_metadata_returns_data;
+         "promote_is_idempotent" >:: test_promote_is_idempotent;
+         "promote_missing_symbol_errors" >:: test_promote_missing_symbol_errors;
+         "higher_tier_promotions_unimplemented"
+         >:: test_higher_tier_promotions_unimplemented;
+         "summary_full_getters_return_none"
+         >:: test_summary_full_getters_return_none;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

First increment of the tier-aware bar-loader work (Step 3 of the scale-optimization plan, plan PR #433 merged 2026-04-19).

- New library `trading.backtest.bar_loader` at `trading/trading/backtest/bar_loader/`.
- Declares the full `tier = Metadata_tier | Summary_tier | Full_tier` variant up front so 3b/3c land without churn.
- Implements Metadata-tier promotion: reads last bar ≤ `as_of` via existing `Price_cache`, joins caller-supplied sector map. Market cap + avg_vol_30d are `float option = None` on this increment (plan §Risks #4, option a).
- Summary / Full promotion return `Status.Unimplemented` — lands in 3b / 3c.
- 7 unit tests (`test_metadata.ml`): create_empty, promote_10_symbols_stats, get_metadata_returns_data, promote_is_idempotent, promote_missing_symbol_errors, higher_tier_promotions_unimplemented, summary_full_getters_return_none.

Plan reference: `dev/plans/backtest-tiered-loader-2026-04-19.md` §Increments → 3a.

Not touched (plan §Out of scope): `Bar_history`, `Weinstein_strategy`, `Simulator`, `Price_cache`, `Screener`.

## Test plan
- [x] `dune build trading/backtest/bar_loader` clean
- [x] `dune runtest trading/backtest/bar_loader/test` — 7/7 pass
- [x] `dune build @fmt` clean
- [ ] Orchestrator QC pass (structural + behavioral)