### PR TITLE
ops: sector-data Item 3 — manifest-staleness preflight for ops-data

### DIFF
--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -12,9 +12,48 @@ You own the full data infrastructure stack: if a required data source lacks a pa
 
 1. Read your invocation to understand what's needed (symbols to fetch, coverage check, inventory refresh, etc.)
 2. Read `dev/notes/data-gaps.md` to understand known data gaps (ADL, sector metadata, global indices) and their resolution status
-3. Read `data/inventory.sexp` to understand current coverage — or summarize from the output of `build_inventory.exe` if the sexp is large
-4. Build the project if needed: `dune build`
-5. Report current data state before taking any action
+3. Check sector manifest freshness (see "Sector manifest preflight" below)
+4. Read `data/inventory.sexp` to understand current coverage — or summarize from the output of `build_inventory.exe` if the sexp is large
+5. Build the project if needed: `dune build`
+6. Report current data state before taking any action
+
+### Sector manifest preflight
+
+Run this check after step 2, before any fetch work:
+
+1. If `data/sectors.csv.manifest` does not exist, print:
+   `[sector-data] manifest missing -- run fetch_finviz_sectors.exe to populate`
+2. If it exists, parse `fetched_at` (ISO 8601 UTC string in the sexp field).
+   Compute age in days: `(now_epoch - fetched_at_epoch) / 86400`.
+3. If age > 30 days, print a WARN:
+   `[sector-data] WARN: manifest is <N>d old (fetched <date>) -- consider running fetch_finviz_sectors.exe`
+4. Otherwise print:
+   `[sector-data] manifest OK -- fetched <date> (<N>d ago)`
+
+The manifest sexp shape (written by `fetch_finviz_sectors.exe`):
+
+    (fetched_at "2026-04-18T20:00:00Z")
+    (source finviz)
+    (row_count 9041)
+    (rate_limit_rps 1.0)
+    (errors 0)
+
+Shell snippet to compute age and print the appropriate message:
+
+    MANIFEST=data/sectors.csv.manifest
+    if [ ! -f "$MANIFEST" ]; then
+      echo "[sector-data] manifest missing -- run fetch_finviz_sectors.exe to populate"
+    else
+      FETCHED=$(grep -oP '(?<=fetched_at ").*(?=")' "$MANIFEST")
+      FETCHED_EPOCH=$(date -d "$FETCHED" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$FETCHED" +%s)
+      NOW_EPOCH=$(date +%s)
+      AGE_DAYS=$(( (NOW_EPOCH - FETCHED_EPOCH) / 86400 ))
+      if [ "$AGE_DAYS" -gt 30 ]; then
+        echo "[sector-data] WARN: manifest is ${AGE_DAYS}d old (fetched $FETCHED) -- consider running fetch_finviz_sectors.exe"
+      else
+        echo "[sector-data] manifest OK -- fetched $FETCHED (${AGE_DAYS}d ago)"
+      fi
+    fi
 
 ## Data scripts
 

--- a/dev/status/sector-data.md
+++ b/dev/status/sector-data.md
@@ -1,11 +1,11 @@
 # Status: sector-data
 
-## Last updated: 2026-04-18
+## Last updated: 2026-04-19
 
 ## Status
-IN_PROGRESS
+MERGED-candidate
 
-Items 1, 2, 4, 4.1 done. Only Item 3 (refresh cadence hook) remains.
+All items done. Item 3 (refresh cadence hook) completed 2026-04-19.
 
 Item 1 merged (#349, 2026-04-15). Item 2 (one-shot fetch) ran locally
 on the operator's workstation and populated `data/sectors.csv`
@@ -166,6 +166,16 @@ EODHD stays available as a drop-in upgrade if Finviz becomes unstable.
     Keeping it as-is would silently drop SCHW, SNOW, PANW from the
     universe.
 
+- **Item 3 — refresh cadence hook** (2026-04-19) — added "Sector manifest
+  preflight" section to `.claude/agents/ops-data.md`. Future ops-data
+  sessions check `data/sectors.csv.manifest` freshness at startup: missing
+  manifest prints a populate reminder; age >30 days prints a WARN with the
+  `fetch_finviz_sectors.exe` command; otherwise prints an OK line. Shell
+  snippet included for direct copy-paste in the agent runbook. Branch:
+  `ops/sector-data-item-3`.
+  Verification: read `.claude/agents/ops-data.md` §"Sector manifest
+  preflight" and confirm the four-step check and shell snippet are present.
+
 ### Iteration 2 — rule-set rewrite using universe.sexp metadata (2026-04-16)
 
 Root-cause fix for Item 4's Iteration 1 finding (the default rule-set
@@ -257,10 +267,7 @@ the rule to exclude these.
   the name/exchange signal.
 
 ## In Progress
-- Item 3 — refresh cadence hook (ops-data preflight reads
-  `data/sectors.csv.manifest` at session start, warns / offers refresh
-  if >30 days stale). Small agent-definition edit (~20 lines). Not
-  blocking any downstream work.
+- (none — all items complete)
 
 ## Next Steps (work items — ops-data)
 

--- a/dev/status/sector-data.md
+++ b/dev/status/sector-data.md
@@ -3,9 +3,12 @@
 ## Last updated: 2026-04-19
 
 ## Status
-MERGED-candidate
+READY_FOR_REVIEW
 
-All items done. Item 3 (refresh cadence hook) completed 2026-04-19.
+All items done. Item 3 (refresh cadence hook) completed 2026-04-19 on
+`ops/sector-data-item-3` (PR #436) — awaiting human merge. Flips to
+MERGED once #436 lands; the orchestrator reconciles `dev/status/_index.md`
+on that run.
 
 Item 1 merged (#349, 2026-04-15). Item 2 (one-shot fetch) ran locally
 on the operator's workstation and populated `data/sectors.csv`


### PR DESCRIPTION
## Summary

Closes the final item on the sector-data track (`dev/status/sector-data.md` Item 3).

- Adds a `Sector manifest preflight` subsection to `.claude/agents/ops-data.md` describing the four-step check every ops-data session should run at start: manifest presence, `fetched_at` parse, age-in-days vs 30-day threshold, WARN/OK output.
- Flips `dev/status/sector-data.md` `## Status` to MERGED-candidate; Item 3 moves from `## In Progress` to `## Completed`.

Once this lands, the sector-data track is fully complete. The orchestrator reconciles `dev/status/_index.md` to MERGED in a follow-up run.

This PR does not change any OCaml code — agent-definition + status-file edits only. Consistent with #426 (agent-template alignment) — pending a human decision on whether harness-adjacent agent-def PRs should get a lightweight QC pass.

## Test plan
- [x] `dune build && dune runtest devtools/checks/` unaffected (no OCaml changed)
- [x] `agent_compliance_check.sh` still passes (ops-data.md not in the strict required-sections list; edit preserves existing headings)
- [ ] Human review — this is operational/runbook content