### PR TITLE
feat(backtest): bar_loader Summary tier (Step 3b)

### DIFF
--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -8,9 +8,9 @@ READY_FOR_REVIEW
 Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata tier) and 3b (Summary tier) implemented; 3c (Full tier) is next.
 
 ## Interface stable
-PARTIAL — 3a + 3b landed
+NO
 
-`Bar_loader.create` / `promote` / `demote` / `tier_of` / `get_metadata` / `get_summary` / `stats` signatures are stable. `create` takes `?benchmark_symbol` / `?summary_config` optional args introduced with 3b. `get_full` still returns `unit option`; its return type becomes `Full.t option` in 3c.
+3a and 3b have landed (Metadata + Summary tiers). `Bar_loader.create` / `promote` / `demote` / `tier_of` / `get_metadata` / `get_summary` / `stats` signatures are stable; `create` takes `?benchmark_symbol` / `?summary_config` optional args introduced with 3b. `get_full` still returns `unit option` and becomes `Full.t option` in 3c, so the full `Bar_loader` interface is not yet frozen.
 
 ## Open PR
 - feat/backtest-tiered-loader — 3a open at https://github.com/dayfine/trading/pull/new/feat/backtest-tiered-loader (draft, awaiting QC).

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -5,15 +5,16 @@
 ## Status
 READY_FOR_REVIEW
 
-Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata tier) implemented and pushed on `feat/backtest-tiered-loader`; 3b (Summary) is the next increment.
+Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata tier) and 3b (Summary tier) implemented; 3c (Full tier) is next.
 
 ## Interface stable
-PARTIAL — 3a landed
+PARTIAL — 3a + 3b landed
 
-`Bar_loader.create` / `promote` / `demote` / `tier_of` / `get_metadata` / `stats` signatures are stable. `get_summary` and `get_full` currently return `unit option` placeholders; their return type becomes `Summary.t option` / `Full.t option` in 3b / 3c respectively.
+`Bar_loader.create` / `promote` / `demote` / `tier_of` / `get_metadata` / `get_summary` / `stats` signatures are stable. `create` takes `?benchmark_symbol` / `?summary_config` optional args introduced with 3b. `get_full` still returns `unit option`; its return type becomes `Full.t option` in 3c.
 
 ## Open PR
 - feat/backtest-tiered-loader — 3a open at https://github.com/dayfine/trading/pull/new/feat/backtest-tiered-loader (draft, awaiting QC).
+- feat/backtest-tiered-loader-3b-summary — 3b stacked on 3a, PR #438 (draft, ready to flip to ready at end of session).
 
 ## Blocked on
 - None. Plan approved; 3a unblocked once #433 merges.
@@ -56,8 +57,8 @@ Build alongside existing `Bar_history` — don't modify it.
 
 | # | Name | Scope | Size est. |
 |---|---|---|---|
-| 3a | Metadata tier | `Bar_loader` types + Metadata loader + tests | ~180 |
-| 3b | Summary tier | `Summary.t` + summary_compute + promote/demote | ~220 |
+| 3a | Metadata tier | `Bar_loader` types + Metadata loader + tests | ~180 (done) |
+| 3b | Summary tier | `Summary.t` + summary_compute + promote/demote | ~480 (done) |
 | 3c | Full tier | `Full.t` + promotion/demotion semantics | ~150 |
 | 3d | Tracer phases | `Promote_summary`/`Promote_full`/`Demote` in `Trace.Phase.t` | ~120 |
 | 3e | Runner flag plumbing | `loader_strategy` on Runner + Scenario + CLI | ~150 |
@@ -80,11 +81,31 @@ Build alongside existing `Bar_history` — don't modify it.
 
 ## Next Steps
 
-1. QC review of 3a (feat/backtest-tiered-loader head).
-2. Dispatch 3b — Summary tier. Adds `Summary.t`, `summary_compute.{ml,mli}` (30w MA, ATR, stage heuristic, RS line from bounded bar tail), extends `promote ~to_:Summary_tier` and `get_summary` to return `Summary.t option`. ~220 lines per plan §3b.
-3. Subsequent increments 3c–3g follow per plan §Dependency graph.
+1. QC review of 3a (feat/backtest-tiered-loader head) and 3b (stacked PR #438).
+2. Dispatch 3c — Full tier. Adds `Full.t` + promotion/demotion semantics (retain raw OHLCV for actively traded symbols). ~150 lines per plan §3c.
+3. Subsequent increments 3d–3g follow per plan §Dependency graph.
 
 ## Completed
+
+- **3b — Summary tier** (2026-04-19). Added `Summary.t` record
+  (ma_30w / atr_14 / rs_line / stage / as_of) + `summary_compute.{ml,mli}`
+  with pure helpers (30w MA on weekly-aggregated closes, ATR-14,
+  Mansfield normalized RS line, Weinstein stage heuristic, composed via
+  `compute_values`). `Bar_loader.promote ~to_:Summary_tier` auto-promotes
+  through Metadata, reads a bounded 250-day tail via `Csv_storage`
+  (bypassing `Price_cache` so raw bars don't leak into the shared cache),
+  computes scalars, then drops the bars — the memory footprint per
+  Summary-tier symbol is fixed at a handful of floats. Insufficient
+  history leaves the symbol at Metadata (no error surfaced). Benchmark
+  bars are lazy-loaded and cached on the loader itself. `demote
+  ~to_:Metadata_tier` drops Summary scalars; `demote ~to_:Summary_tier`
+  is a no-op in 3b (Full lands in 3c). `Summary_compute` is re-exported
+  from the top-level `Bar_loader` module for external callers and tests.
+  Also folds in the 3a docstring cleanup (module-level comment said
+  "raise [Failure]" but impl returned `Error Status.Unimplemented`).
+  - Files: `bar_loader/{bar_loader.mli,bar_loader.ml,summary_compute.mli,summary_compute.ml,dune}` +
+    `bar_loader/test/{dune,test_metadata.ml,test_summary_compute.ml,test_summary.ml}`.
+  - Verify: `dune build trading/backtest/bar_loader && dune runtest trading/backtest/bar_loader` — 7 Metadata + 11 Summary_compute + 8 Summary tests pass.
 
 - **3a — Metadata tier + types scaffold** (2026-04-19). New library at
   `trading/trading/backtest/bar_loader/`. Exposes the full

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -3,17 +3,17 @@
 ## Last updated: 2026-04-19
 
 ## Status
-APPROVED
+READY_FOR_REVIEW
 
-Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a dispatches on next orchestrator run.
+Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata tier) implemented and pushed on `feat/backtest-tiered-loader`; 3b (Summary) is the next increment.
 
 ## Interface stable
-NO
+PARTIAL — 3a landed
 
-Implementation not yet started; plan decomposes Step 3 into 8 increments (3a–3h) each with its own interface. `Bar_loader` types stabilize incrementally as 3a/3b/3c land.
+`Bar_loader.create` / `promote` / `demote` / `tier_of` / `get_metadata` / `stats` signatures are stable. `get_summary` and `get_full` currently return `unit option` placeholders; their return type becomes `Summary.t option` / `Full.t option` in 3b / 3c respectively.
 
 ## Open PR
-- #433 (feat/backtest-tiered-loader) — plan PR, approved, awaiting merge.
+- feat/backtest-tiered-loader — 3a open at https://github.com/dayfine/trading/pull/new/feat/backtest-tiered-loader (draft, awaiting QC).
 
 ## Blocked on
 - None. Plan approved; 3a unblocked once #433 merges.
@@ -80,15 +80,33 @@ Build alongside existing `Bar_history` — don't modify it.
 
 ## Next Steps
 
-1. Human reviews `dev/plans/backtest-tiered-loader-2026-04-19.md` and resolves §Open questions (ε threshold, scenario selection, screener-refactor scope, module placement, demotion semantics).
-2. On approval, orchestrator dispatches `feat-backtest` to implement 3a.
-3. Each subsequent GHA run picks up the next increment.
+1. QC review of 3a (feat/backtest-tiered-loader head).
+2. Dispatch 3b — Summary tier. Adds `Summary.t`, `summary_compute.{ml,mli}` (30w MA, ATR, stage heuristic, RS line from bounded bar tail), extends `promote ~to_:Summary_tier` and `get_summary` to return `Summary.t option`. ~220 lines per plan §3b.
+3. Subsequent increments 3c–3g follow per plan §Dependency graph.
+
+## Completed
+
+- **3a — Metadata tier + types scaffold** (2026-04-19). New library at
+  `trading/trading/backtest/bar_loader/`. Exposes the full
+  `Metadata_tier | Summary_tier | Full_tier` variant up front so
+  3b/3c don't churn it. `Metadata.t` carries sector + last_close;
+  `market_cap` and `avg_vol_30d` stay `float option = None` until a
+  consumer needs them (plan §Risks #4). `promote ~to_:Metadata_tier`
+  reads the last bar ≤ `as_of` via the existing `Price_cache` and
+  joins a caller-supplied sector table — idempotent, surfaces
+  per-symbol errors without inserting failed symbols. Higher-tier
+  promotes return `Status.Unimplemented`. `Bar_history`,
+  `Weinstein_strategy`, `Simulator`, `Price_cache`, and `Screener`
+  untouched (plan §Out of scope).
+  - Files: `bar_loader/{dune,bar_loader.mli,bar_loader.ml}` +
+    `bar_loader/test/{dune,test_metadata.ml}`.
+  - Verify: `dev/lib/run-in-env.sh dune build trading/backtest/bar_loader && dev/lib/run-in-env.sh dune runtest trading/backtest/bar_loader/test` — 7 tests pass.
 
 ## QC
 
-overall_qc: PENDING
-structural_qc: PENDING
-behavioral_qc: PENDING
+overall_qc: PENDING (3a ready for review)
+structural_qc: PENDING (3a)
+behavioral_qc: N/A (3a — no strategy behavior change; parity test arrives with 3g)
 
 Reviewers when work lands:
 - qc-structural — module boundaries between tiers; `Bar_history` untouched; parity test runs both strategies.

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -17,29 +17,64 @@ module Metadata = struct
   [@@deriving show, eq, sexp]
 end
 
+module Summary = struct
+  type t = {
+    symbol : string;
+    ma_30w : float;
+    atr_14 : float;
+    rs_line : float;
+    stage : Weinstein_types.stage;
+    as_of : Date.t;
+  }
+  [@@deriving show, eq, sexp]
+end
+
 type stats_counts = { metadata : int; summary : int; full : int }
 [@@deriving show, eq, sexp]
 
-type entry = { tier : tier; metadata : Metadata.t option }
-(** Per-symbol entry. Held in a mutable hashtable keyed on symbol. The [tier]
-    field reflects the highest tier this symbol has been promoted to; the
-    tier-specific data fields are [Some _] at that tier and below. In 3a only
-    [metadata] is ever populated. *)
+type entry = {
+  tier : tier;
+  metadata : Metadata.t option;
+  summary : Summary.t option;
+}
+(** Per-symbol entry. Held in a mutable hashtable keyed on symbol. [tier] is the
+    highest tier this symbol has been promoted to; the tier-specific data fields
+    are populated at and below that tier. [summary] is [None] for Metadata-only
+    entries. Full-tier data will live in a separate field added in 3c. *)
+
+(** [_default_benchmark_symbol] is the canonical RS benchmark used by the
+    backtest runner. Bar_loader doesn't care which ticker it is, but keeping a
+    sensible default means most callers don't need to pass it explicitly. *)
+let _default_benchmark_symbol = "SPY"
 
 type t = {
   sector_map : string String.Table.t;
   entries : (string, entry) Hashtbl.t;
   price_cache : Price_cache.t;
+  data_dir : Fpath.t;
+  benchmark_symbol : string;
+  summary_config : Summary_compute.config;
+  mutable benchmark_bars : Types.Daily_price.t list option;
+      (** Lazily loaded on the first Summary promotion. Benchmark bars are read
+          via [Csv_storage] directly (bypassing [Price_cache]) so they don't
+          inflate the shared cache — but we keep them here because the benchmark
+          is the one symbol every Summary promotion needs. *)
 }
 
-let create ~data_dir ~sector_map ~universe:_ =
+let create ~data_dir ~sector_map ~universe:_
+    ?(benchmark_symbol = _default_benchmark_symbol)
+    ?(summary_config = Summary_compute.default_config) () =
   (* [universe] is accepted in the signature so 3b/3c/3f can drive tier-wide
      operations ("promote every universe symbol to Metadata on startup")
-     without a signature churn. Not consumed yet in 3a. *)
+     without a signature churn. Not consumed yet. *)
   {
     sector_map;
     entries = Hashtbl.create (module String);
     price_cache = Price_cache.create ~data_dir;
+    data_dir;
+    benchmark_symbol;
+    summary_config;
+    benchmark_bars = None;
   }
 
 let tier_of t ~symbol =
@@ -48,7 +83,9 @@ let tier_of t ~symbol =
 let get_metadata t ~symbol =
   Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.metadata)
 
-let get_summary _t ~symbol:_ = None
+let get_summary t ~symbol =
+  Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.summary)
+
 let get_full _t ~symbol:_ = None
 
 (** [_tier_rank] encodes the Metadata < Summary < Full ordering used for
@@ -95,32 +132,142 @@ let _promote_one_to_metadata t ~symbol ~as_of : (unit, Status.t) Result.t =
       | Error err -> Error err
       | Ok metadata ->
           Hashtbl.set t.entries ~key:symbol
-            ~data:{ tier = Metadata_tier; metadata = Some metadata };
+            ~data:
+              { tier = Metadata_tier; metadata = Some metadata; summary = None };
+          Ok ())
+
+(** [_load_bars_tail] reads the most recent [tail_days] daily bars for [symbol]
+    ending on or before [as_of], {e bypassing} [Price_cache]. Summary promotion
+    drops these bars immediately after computing scalars; keeping them out of
+    [Price_cache] prevents the raw history from leaking into the shared cache
+    and surviving past the promotion. *)
+let _load_bars_tail t ~symbol ~as_of :
+    (Types.Daily_price.t list, Status.t) Result.t =
+  let%bind.Result storage =
+    Csv.Csv_storage.create ~data_dir:t.data_dir symbol
+  in
+  let start_date = Date.add_days as_of (-t.summary_config.tail_days) in
+  Csv.Csv_storage.get storage ~start_date ~end_date:as_of ()
+
+(** [_benchmark_bars_for] returns the bounded-tail bars for the benchmark
+    symbol, loading them lazily on the first Summary promotion. The loaded
+    series covers from the earliest [as_of] a caller has ever asked about minus
+    [tail_days] through the latest [as_of] — in practice the backtest replays
+    forward so this cache grows monotonically.
+
+    In 3b we keep it simple: load once on first use for the given [as_of],
+    reload if subsequent calls need a different window. For the current
+    batch-promote-all-symbols-on-Friday workflow this is fine because every
+    symbol within the batch shares the same [as_of]. *)
+let _benchmark_bars_for t ~as_of : (Types.Daily_price.t list, Status.t) Result.t
+    =
+  let load () =
+    let%map.Result bars = _load_bars_tail t ~symbol:t.benchmark_symbol ~as_of in
+    t.benchmark_bars <- Some bars;
+    bars
+  in
+  match t.benchmark_bars with
+  | None -> load ()
+  | Some bars -> (
+      match List.last bars with
+      | None -> load ()
+      | Some last when Date.(last.date < as_of) -> load ()
+      | Some _ -> Ok bars)
+
+(** [_promote_one_to_summary] auto-promotes through Metadata first, then fetches
+    a bounded tail, computes the Summary scalars, and drops the raw bars. A
+    symbol with insufficient history is left at its current tier (Metadata after
+    the auto-promote) — no error surfaced, because insufficient history is a
+    pre-condition for Summary, not a load failure. *)
+let _promote_one_to_summary t ~symbol ~as_of : (unit, Status.t) Result.t =
+  match Hashtbl.find t.entries symbol with
+  | Some entry when _tier_rank entry.tier >= _tier_rank Summary_tier -> Ok ()
+  | _ -> (
+      let%bind.Result () = _promote_one_to_metadata t ~symbol ~as_of in
+      let%bind.Result stock_bars = _load_bars_tail t ~symbol ~as_of in
+      let%bind.Result benchmark_bars = _benchmark_bars_for t ~as_of in
+      match
+        Summary_compute.compute_values ~config:t.summary_config ~stock_bars
+          ~benchmark_bars ~as_of
+      with
+      | None ->
+          (* Insufficient history — leave at Metadata tier. *)
+          Ok ()
+      | Some values ->
+          let existing_metadata =
+            Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.metadata)
+          in
+          let summary : Summary.t =
+            {
+              symbol;
+              ma_30w = values.ma_30w;
+              atr_14 = values.atr_14;
+              rs_line = values.rs_line;
+              stage = values.stage;
+              as_of = values.as_of;
+            }
+          in
+          Hashtbl.set t.entries ~key:symbol
+            ~data:
+              {
+                tier = Summary_tier;
+                metadata = existing_metadata;
+                summary = Some summary;
+              };
           Ok ())
 
 let _unimplemented_tier tier : Status.t =
   {
     code = Status.Unimplemented;
     message =
-      Printf.sprintf "Bar_loader.promote: tier %s not yet implemented (3a only)"
+      Printf.sprintf
+        "Bar_loader.promote: tier %s not yet implemented (Full_tier lands in \
+         3c)"
         (show_tier tier);
   }
 
+let _promote_fold ~f symbols =
+  List.fold_until symbols ~init:()
+    ~f:(fun () symbol ->
+      match f ~symbol with
+      | Ok () -> Continue ()
+      | Error err -> Stop (Error err))
+    ~finish:(fun () -> Ok ())
+
 let promote t ~symbols ~to_ ~as_of =
   match to_ with
-  | Summary_tier | Full_tier -> Error (_unimplemented_tier to_)
   | Metadata_tier ->
-      List.fold_until symbols ~init:()
-        ~f:(fun () symbol ->
-          match _promote_one_to_metadata t ~symbol ~as_of with
-          | Ok () -> Continue ()
-          | Error err -> Stop (Error err))
-        ~finish:(fun () -> Ok ())
+      _promote_fold symbols ~f:(fun ~symbol ->
+          _promote_one_to_metadata t ~symbol ~as_of)
+  | Summary_tier ->
+      _promote_fold symbols ~f:(fun ~symbol ->
+          _promote_one_to_summary t ~symbol ~as_of)
+  | Full_tier -> Error (_unimplemented_tier to_)
 
-let demote _t ~symbols:_ ~to_:_ =
-  (* 3a: no Summary / Full data exists, so there is nothing to drop. The
-     signature is stable so 3b / 3c wire in real demotion without churn. *)
-  ()
+(** [_demote_one] drops higher-tier data from an existing entry. The caller
+    guarantees the entry exists; tier-of-target is enforced here (a symbol at
+    tier [<= to_] is unchanged). *)
+let _demote_one t ~symbol ~to_ =
+  match Hashtbl.find t.entries symbol with
+  | None -> ()
+  | Some entry when _tier_rank entry.tier <= _tier_rank to_ -> ()
+  | Some entry ->
+      let new_entry =
+        match to_ with
+        | Metadata_tier -> { entry with tier = Metadata_tier; summary = None }
+        | Summary_tier ->
+            (* In 3b the only higher tier is Summary itself; Full tier lands
+               in 3c and will drop the raw bars here. Keep [summary] as-is. *)
+            { entry with tier = Summary_tier }
+        | Full_tier ->
+            (* Demoting "to Full" is degenerate — Full is the top tier, so
+               there's nothing higher to drop. Preserve entry as-is. *)
+            entry
+      in
+      Hashtbl.set t.entries ~key:symbol ~data:new_entry
+
+let demote t ~symbols ~to_ =
+  List.iter symbols ~f:(fun symbol -> _demote_one t ~symbol ~to_)
 
 let stats t =
   Hashtbl.fold t.entries ~init:{ metadata = 0; summary = 0; full = 0 }

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -2,6 +2,7 @@
 
 open Core
 module Price_cache = Trading_simulation_data.Price_cache
+module Summary_compute = Summary_compute
 
 type tier = Metadata_tier | Summary_tier | Full_tier
 [@@deriving show, eq, sexp]

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -20,11 +20,11 @@ end
 type stats_counts = { metadata : int; summary : int; full : int }
 [@@deriving show, eq, sexp]
 
+type entry = { tier : tier; metadata : Metadata.t option }
 (** Per-symbol entry. Held in a mutable hashtable keyed on symbol. The [tier]
     field reflects the highest tier this symbol has been promoted to; the
     tier-specific data fields are [Some _] at that tier and below. In 3a only
     [metadata] is ever populated. *)
-type entry = { tier : tier; metadata : Metadata.t option }
 
 type t = {
   sector_map : string String.Table.t;
@@ -59,9 +59,9 @@ let _tier_rank = function
   | Full_tier -> 2
 
 (** [_load_metadata] reads the last bar on or before [as_of] from the shared
-    [Price_cache] and joins the sector table. Market cap and average volume
-    are [None] on this increment — wired when the first consumer needs them
-    (§Risks #4 of the plan). *)
+    [Price_cache] and joins the sector table. Market cap and average volume are
+    [None] on this increment — wired when the first consumer needs them (§Risks
+    #4 of the plan). *)
 let _load_metadata t ~symbol ~as_of : (Metadata.t, Status.t) Result.t =
   match Price_cache.get_prices t.price_cache ~symbol ~end_date:as_of () with
   | Error err -> Error err
@@ -85,8 +85,8 @@ let _load_metadata t ~symbol ~as_of : (Metadata.t, Status.t) Result.t =
         }
 
 (** [_promote_one_to_metadata] is idempotent: if the symbol is already at
-    Metadata or higher, it's a no-op. Otherwise it runs the metadata load
-    and inserts the entry. *)
+    Metadata or higher, it's a no-op. Otherwise it runs the metadata load and
+    inserts the entry. *)
 let _promote_one_to_metadata t ~symbol ~as_of : (unit, Status.t) Result.t =
   match Hashtbl.find t.entries symbol with
   | Some entry when _tier_rank entry.tier >= _tier_rank Metadata_tier -> Ok ()
@@ -123,8 +123,7 @@ let demote _t ~symbols:_ ~to_:_ =
   ()
 
 let stats t =
-  Hashtbl.fold t.entries
-    ~init:{ metadata = 0; summary = 0; full = 0 }
+  Hashtbl.fold t.entries ~init:{ metadata = 0; summary = 0; full = 0 }
     ~f:(fun ~key:_ ~data acc ->
       match data.tier with
       | Metadata_tier -> { acc with metadata = acc.metadata + 1 }

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -1,0 +1,132 @@
+(** Tier-aware bar loader — see [bar_loader.mli]. *)
+
+open Core
+module Price_cache = Trading_simulation_data.Price_cache
+
+type tier = Metadata_tier | Summary_tier | Full_tier
+[@@deriving show, eq, sexp]
+
+module Metadata = struct
+  type t = {
+    symbol : string;
+    sector : string;
+    last_close : float;
+    avg_vol_30d : float option;
+    market_cap : float option;
+  }
+  [@@deriving show, eq, sexp]
+end
+
+type stats_counts = { metadata : int; summary : int; full : int }
+[@@deriving show, eq, sexp]
+
+(** Per-symbol entry. Held in a mutable hashtable keyed on symbol. The [tier]
+    field reflects the highest tier this symbol has been promoted to; the
+    tier-specific data fields are [Some _] at that tier and below. In 3a only
+    [metadata] is ever populated. *)
+type entry = { tier : tier; metadata : Metadata.t option }
+
+type t = {
+  sector_map : string String.Table.t;
+  entries : (string, entry) Hashtbl.t;
+  price_cache : Price_cache.t;
+}
+
+let create ~data_dir ~sector_map ~universe:_ =
+  (* [universe] is accepted in the signature so 3b/3c/3f can drive tier-wide
+     operations ("promote every universe symbol to Metadata on startup")
+     without a signature churn. Not consumed yet in 3a. *)
+  {
+    sector_map;
+    entries = Hashtbl.create (module String);
+    price_cache = Price_cache.create ~data_dir;
+  }
+
+let tier_of t ~symbol =
+  Hashtbl.find t.entries symbol |> Option.map ~f:(fun e -> e.tier)
+
+let get_metadata t ~symbol =
+  Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.metadata)
+
+let get_summary _t ~symbol:_ = None
+let get_full _t ~symbol:_ = None
+
+(** [_tier_rank] encodes the Metadata < Summary < Full ordering used for
+    idempotent promotion: a symbol at tier [>= to_] is left alone. *)
+let _tier_rank = function
+  | Metadata_tier -> 0
+  | Summary_tier -> 1
+  | Full_tier -> 2
+
+(** [_load_metadata] reads the last bar on or before [as_of] from the shared
+    [Price_cache] and joins the sector table. Market cap and average volume
+    are [None] on this increment — wired when the first consumer needs them
+    (§Risks #4 of the plan). *)
+let _load_metadata t ~symbol ~as_of : (Metadata.t, Status.t) Result.t =
+  match Price_cache.get_prices t.price_cache ~symbol ~end_date:as_of () with
+  | Error err -> Error err
+  | Ok [] ->
+      Error
+        (Status.not_found_error
+           (Printf.sprintf "No bars for %s on or before %s" symbol
+              (Date.to_string as_of)))
+  | Ok bars ->
+      let last = List.last_exn bars in
+      let sector =
+        Hashtbl.find t.sector_map symbol |> Option.value ~default:""
+      in
+      Ok
+        {
+          Metadata.symbol;
+          sector;
+          last_close = last.close_price;
+          avg_vol_30d = None;
+          market_cap = None;
+        }
+
+(** [_promote_one_to_metadata] is idempotent: if the symbol is already at
+    Metadata or higher, it's a no-op. Otherwise it runs the metadata load
+    and inserts the entry. *)
+let _promote_one_to_metadata t ~symbol ~as_of : (unit, Status.t) Result.t =
+  match Hashtbl.find t.entries symbol with
+  | Some entry when _tier_rank entry.tier >= _tier_rank Metadata_tier -> Ok ()
+  | _ -> (
+      match _load_metadata t ~symbol ~as_of with
+      | Error err -> Error err
+      | Ok metadata ->
+          Hashtbl.set t.entries ~key:symbol
+            ~data:{ tier = Metadata_tier; metadata = Some metadata };
+          Ok ())
+
+let _unimplemented_tier tier : Status.t =
+  {
+    code = Status.Unimplemented;
+    message =
+      Printf.sprintf "Bar_loader.promote: tier %s not yet implemented (3a only)"
+        (show_tier tier);
+  }
+
+let promote t ~symbols ~to_ ~as_of =
+  match to_ with
+  | Summary_tier | Full_tier -> Error (_unimplemented_tier to_)
+  | Metadata_tier ->
+      List.fold_until symbols ~init:()
+        ~f:(fun () symbol ->
+          match _promote_one_to_metadata t ~symbol ~as_of with
+          | Ok () -> Continue ()
+          | Error err -> Stop (Error err))
+        ~finish:(fun () -> Ok ())
+
+let demote _t ~symbols:_ ~to_:_ =
+  (* 3a: no Summary / Full data exists, so there is nothing to drop. The
+     signature is stable so 3b / 3c wire in real demotion without churn. *)
+  ()
+
+let stats t =
+  Hashtbl.fold t.entries
+    ~init:{ metadata = 0; summary = 0; full = 0 }
+    ~f:(fun ~key:_ ~data acc ->
+      match data.tier with
+      | Metadata_tier -> { acc with metadata = acc.metadata + 1 }
+      | Summary_tier -> { acc with summary = acc.summary + 1 }
+      | Full_tier -> { acc with full = acc.full + 1 })

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -8,17 +8,16 @@
     - {b Metadata} — last-bar scalars (last close, sector, optional cap and
       average volume). One record for {e every} universe symbol.
     - {b Summary} — sector-ranked subset; indicator scalars (30w MA, RS line,
-      stage heuristic, ATR) computed from a bounded tail of bars; raw bars
-      dropped.
+      stage heuristic, ATR) computed from a bounded tail of daily bars. The raw
+      bars are dropped once the scalars are extracted, which is the core memory
+      win over holding full OHLCV history.
     - {b Full} — raw OHLCV history for symbols actively considered for entry or
-      currently held.
+      currently held. Added in 3c.
 
-    This increment (3a) implements {b Metadata only}. The [tier] variant already
-    exposes all three tags so later increments extend the loader without churn
-    in the variant. [Summary.t] and [Full.t] submodules and their promotion
-    semantics are added in 3b / 3c. In 3a, [promote ~to_:Summary_tier] and
-    [promote ~to_:Full_tier] raise [Failure]; [get_summary] and [get_full]
-    always return [None]. *)
+    As of 3b, this module implements Metadata and Summary tiers. The [tier]
+    variant already exposes all three tags so 3c extends the loader without
+    churn to the variant. [promote ~to_:Full_tier] returns
+    [Error Status.Unimplemented] until 3c; [get_full] always returns [None]. *)
 
 open Core
 
@@ -49,6 +48,25 @@ module Metadata : sig
   [@@deriving show, eq, sexp]
 end
 
+module Summary : sig
+  type t = {
+    symbol : string;
+    ma_30w : float;  (** 30-week simple MA of weekly-aggregated closes. *)
+    atr_14 : float;  (** Average True Range over the last 14 daily bars. *)
+    rs_line : float;
+        (** Latest Mansfield normalized RS value ([raw_rs / MA(raw_rs)]). Values
+            above 1.0 indicate the stock is outperforming its own recent
+            baseline. *)
+    stage : Weinstein_types.stage;
+        (** Weinstein stage heuristic from the one-shot classifier. *)
+    as_of : Date.t;  (** Date of the last bar used to derive the scalars. *)
+  }
+  [@@deriving show, eq, sexp]
+  (** Indicator scalars derived from a bounded tail of daily bars. Raw bars are
+      dropped once this record is constructed — the memory footprint per symbol
+      is fixed at a handful of floats rather than the full history. *)
+end
+
 (** {1 Loader} *)
 
 type t
@@ -64,13 +82,25 @@ val create :
   data_dir:Fpath.t ->
   sector_map:string String.Table.t ->
   universe:string list ->
+  ?benchmark_symbol:string ->
+  ?summary_config:Summary_compute.config ->
+  unit ->
   t
-(** [create ~data_dir ~sector_map ~universe] returns a fresh loader. [universe]
-    is the full set of symbols the backtest may promote; it is recorded but does
-    {b not} load any bars (Metadata-tier loads happen in [promote]).
-    [sector_map] is a symbol → sector lookup; symbols missing from the map get
-    [sector = ""] on promotion. [data_dir] is forwarded to an internal
-    [Price_cache] used on demand. *)
+(** [create ~data_dir ~sector_map ~universe ?benchmark_symbol ?summary_config
+     ()] returns a fresh loader. [universe] is the full set of symbols the
+    backtest may promote; it is recorded but does {b not} load any bars
+    (Metadata-tier loads happen in [promote]). [sector_map] is a symbol → sector
+    lookup; symbols missing from the map get [sector = ""] on promotion.
+    [data_dir] is forwarded to an internal [Price_cache] used for Metadata-tier
+    last-close lookups.
+
+    [benchmark_symbol] is the ticker used to align bars when computing the
+    Summary-tier RS line (typically ["SPY"] or ["^GSPC"]). Default: ["SPY"]. Its
+    bars are loaded on first Summary promotion and cached inside the loader.
+
+    [summary_config] controls the windows used to compute Summary scalars (see
+    {!Summary_compute.default_config}). Default:
+    {!Summary_compute.default_config}. *)
 
 val promote :
   t ->
@@ -82,22 +112,31 @@ val promote :
     [to_], loading whatever data that tier needs. Idempotent: a symbol already
     at tier [>= to_] is unchanged.
 
-    In this increment only [to_ = Metadata_tier] is implemented — passing
-    [Summary_tier] or [Full_tier] returns an [Error] with a
-    [Status.Unimplemented] code. Subsequent increments (3b, 3c) add those
-    branches.
+    Tier-specific load behaviour:
+    - [Metadata_tier]: reads the last bar on or before [as_of] from the shared
+      [Price_cache].
+    - [Summary_tier]: auto-promotes through Metadata first, then reads a bounded
+      tail ([summary_config.tail_days] of daily bars ending at [as_of]) directly
+      from CSV storage — bypassing [Price_cache] so the raw bars are never
+      retained. The benchmark symbol's tail is loaded once and cached for
+      subsequent Summary promotions in the same session. A symbol whose history
+      is too short to produce all Summary scalars is left at Metadata tier (not
+      an error — the caller should retry later or leave the symbol where it is).
+    - [Full_tier]: returns [Error Status.Unimplemented] until 3c.
 
     Returns the first per-symbol error encountered (if any). A symbol that fails
     to load is {e not} added to the loader. *)
 
 val demote : t -> symbols:string list -> to_:tier -> unit
 (** [demote t ~symbols ~to_] tiers each symbol down, freeing higher-tier data. A
-    symbol currently at tier [<= to_] is unchanged. Calling with
-    [to_ = Metadata_tier] fully drops any Summary / Full caches.
+    symbol currently at tier [<= to_] is unchanged.
 
-    In 3a, since promote only reaches Metadata, [demote] is effectively a no-op
-    — included for API completeness so 3b / 3c extend the behaviour without a
-    signature change. *)
+    - [to_ = Metadata_tier] drops Summary scalars (and Full bars, in 3c).
+    - [to_ = Summary_tier] drops only Full bars (no-op for Summary-only
+      symbols).
+
+    Callers assume demotion is free: there is no reload cost. Re-promoting the
+    same symbols back up requires fetching bars again. *)
 
 val tier_of : t -> symbol:string -> tier option
 (** [tier_of t ~symbol] returns the current tier of [symbol], or [None] if the
@@ -107,14 +146,14 @@ val get_metadata : t -> symbol:string -> Metadata.t option
 (** [get_metadata t ~symbol] returns the Metadata record for [symbol] when it
     has been promoted at least to Metadata tier, otherwise [None]. *)
 
-val get_summary : t -> symbol:string -> unit option
-(** Placeholder for 3b. Always returns [None] in this increment; the return type
-    is [unit option] to keep the interface signature stable until 3b introduces
-    [Summary.t]. *)
+val get_summary : t -> symbol:string -> Summary.t option
+(** [get_summary t ~symbol] returns the Summary record for [symbol] when it has
+    been promoted to Summary tier or higher, otherwise [None]. *)
 
 val get_full : t -> symbol:string -> unit option
-(** Placeholder for 3c. Always returns [None] in this increment; same stability
-    rationale as [get_summary]. *)
+(** Placeholder for 3c. Always returns [None] in this increment; the return type
+    is [unit option] to keep the interface signature stable until 3c introduces
+    [Full.t]. *)
 
 val stats : t -> stats_counts
 (** [stats t] returns the current per-tier symbol counts. The sum of the three

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -21,6 +21,13 @@
 
 open Core
 
+(** {1 Re-exports} *)
+
+module Summary_compute = Summary_compute
+(** Pure compute helpers used by the Summary tier. Re-exported so callers and
+    tests can reach the compute layer through the library's main module without
+    depending on the internal module directly. *)
+
 (** {1 Tier tag} *)
 
 (** Discrete ordering of tiers by information content: [Metadata_tier] <

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -10,25 +10,25 @@
     - {b Summary} — sector-ranked subset; indicator scalars (30w MA, RS line,
       stage heuristic, ATR) computed from a bounded tail of bars; raw bars
       dropped.
-    - {b Full} — raw OHLCV history for symbols actively considered for entry
-      or currently held.
+    - {b Full} — raw OHLCV history for symbols actively considered for entry or
+      currently held.
 
-    This increment (3a) implements {b Metadata only}. The [tier] variant
-    already exposes all three tags so later increments extend the loader
-    without churn in the variant. [Summary.t] and [Full.t] submodules and
-    their promotion semantics are added in 3b / 3c. In 3a,
-    [promote ~to_:Summary_tier] and [promote ~to_:Full_tier] raise
-    [Failure]; [get_summary] and [get_full] always return [None]. *)
+    This increment (3a) implements {b Metadata only}. The [tier] variant already
+    exposes all three tags so later increments extend the loader without churn
+    in the variant. [Summary.t] and [Full.t] submodules and their promotion
+    semantics are added in 3b / 3c. In 3a, [promote ~to_:Summary_tier] and
+    [promote ~to_:Full_tier] raise [Failure]; [get_summary] and [get_full]
+    always return [None]. *)
 
 open Core
 
 (** {1 Tier tag} *)
 
+(** Discrete ordering of tiers by information content: [Metadata_tier] <
+    [Summary_tier] < [Full_tier]. Promotion moves a symbol to a higher tier;
+    demotion moves it back down. *)
 type tier = Metadata_tier | Summary_tier | Full_tier
 [@@deriving show, eq, sexp]
-(** Discrete ordering of tiers by information content:
-    [Metadata_tier] < [Summary_tier] < [Full_tier]. Promotion moves a symbol
-    to a higher tier; demotion moves it back down. *)
 
 (** {1 Tier-shaped data} *)
 
@@ -38,10 +38,11 @@ module Metadata : sig
     sector : string;
         (** Sector name as loaded from the sector table. [""] when the symbol
             has no sector entry — the loader does not synthesize a sector. *)
-    last_close : float;  (** Close price of the last bar on or before [as_of]. *)
+    last_close : float;
+        (** Close price of the last bar on or before [as_of]. *)
     avg_vol_30d : float option;
-        (** 30-day average volume. [None] on this increment — wired in a
-            later PR when the screener needs it. *)
+        (** 30-day average volume. [None] on this increment — wired in a later
+            PR when the screener needs it. *)
     market_cap : float option;
         (** Market capitalization. [None] on this increment. *)
   }
@@ -51,64 +52,71 @@ end
 (** {1 Loader} *)
 
 type t
-(** Mutable bag of per-symbol tier assignments + computed data. Opaque —
-    callers go through [promote] / [get_*] / [stats]. Not safe to share
-    across threads. *)
+(** Mutable bag of per-symbol tier assignments + computed data. Opaque — callers
+    go through [promote] / [get_*] / [stats]. Not safe to share across threads.
+*)
 
 type stats_counts = { metadata : int; summary : int; full : int }
 [@@deriving show, eq, sexp]
 (** Current per-tier symbol counts; used by tracer / parity harness. *)
 
 val create :
-  data_dir:Fpath.t -> sector_map:string String.Table.t -> universe:string list -> t
+  data_dir:Fpath.t ->
+  sector_map:string String.Table.t ->
+  universe:string list ->
+  t
 (** [create ~data_dir ~sector_map ~universe] returns a fresh loader. [universe]
-    is the full set of symbols the backtest may promote; it is recorded but
-    does {b not} load any bars (Metadata-tier loads happen in [promote]).
-    [sector_map] is a symbol → sector lookup; symbols missing from the map
-    get [sector = ""] on promotion. [data_dir] is forwarded to an internal
+    is the full set of symbols the backtest may promote; it is recorded but does
+    {b not} load any bars (Metadata-tier loads happen in [promote]).
+    [sector_map] is a symbol → sector lookup; symbols missing from the map get
+    [sector = ""] on promotion. [data_dir] is forwarded to an internal
     [Price_cache] used on demand. *)
 
 val promote :
-  t -> symbols:string list -> to_:tier -> as_of:Date.t -> (unit, Status.t) Result.t
-(** [promote t ~symbols ~to_ ~as_of] moves every symbol in [symbols] up to
-    tier [to_], loading whatever data that tier needs. Idempotent: a symbol
-    already at tier [>= to_] is unchanged.
+  t ->
+  symbols:string list ->
+  to_:tier ->
+  as_of:Date.t ->
+  (unit, Status.t) Result.t
+(** [promote t ~symbols ~to_ ~as_of] moves every symbol in [symbols] up to tier
+    [to_], loading whatever data that tier needs. Idempotent: a symbol already
+    at tier [>= to_] is unchanged.
 
     In this increment only [to_ = Metadata_tier] is implemented — passing
     [Summary_tier] or [Full_tier] returns an [Error] with a
     [Status.Unimplemented] code. Subsequent increments (3b, 3c) add those
     branches.
 
-    Returns the first per-symbol error encountered (if any). A symbol that
-    fails to load is {e not} added to the loader. *)
+    Returns the first per-symbol error encountered (if any). A symbol that fails
+    to load is {e not} added to the loader. *)
 
 val demote : t -> symbols:string list -> to_:tier -> unit
-(** [demote t ~symbols ~to_] tiers each symbol down, freeing higher-tier data.
-    A symbol currently at tier [<= to_] is unchanged. Calling with
+(** [demote t ~symbols ~to_] tiers each symbol down, freeing higher-tier data. A
+    symbol currently at tier [<= to_] is unchanged. Calling with
     [to_ = Metadata_tier] fully drops any Summary / Full caches.
 
-    In 3a, since promote only reaches Metadata, [demote] is effectively a
-    no-op — included for API completeness so 3b / 3c extend the behaviour
-    without a signature change. *)
+    In 3a, since promote only reaches Metadata, [demote] is effectively a no-op
+    — included for API completeness so 3b / 3c extend the behaviour without a
+    signature change. *)
 
 val tier_of : t -> symbol:string -> tier option
-(** [tier_of t ~symbol] returns the current tier of [symbol], or [None] if
-    the symbol has never been promoted in this loader. *)
+(** [tier_of t ~symbol] returns the current tier of [symbol], or [None] if the
+    symbol has never been promoted in this loader. *)
 
 val get_metadata : t -> symbol:string -> Metadata.t option
-(** [get_metadata t ~symbol] returns the Metadata record for [symbol] when
-    it has been promoted at least to Metadata tier, otherwise [None]. *)
+(** [get_metadata t ~symbol] returns the Metadata record for [symbol] when it
+    has been promoted at least to Metadata tier, otherwise [None]. *)
 
 val get_summary : t -> symbol:string -> unit option
-(** Placeholder for 3b. Always returns [None] in this increment; the return
-    type is [unit option] to keep the interface signature stable until 3b
-    introduces [Summary.t]. *)
+(** Placeholder for 3b. Always returns [None] in this increment; the return type
+    is [unit option] to keep the interface signature stable until 3b introduces
+    [Summary.t]. *)
 
 val get_full : t -> symbol:string -> unit option
-(** Placeholder for 3c. Always returns [None] in this increment; same
-    stability rationale as [get_summary]. *)
+(** Placeholder for 3c. Always returns [None] in this increment; same stability
+    rationale as [get_summary]. *)
 
 val stats : t -> stats_counts
-(** [stats t] returns the current per-tier symbol counts. The sum of the
-    three fields equals the number of symbols that have been promoted at
-    least once (and not subsequently demoted below Metadata). *)
+(** [stats t] returns the current per-tier symbol counts. The sum of the three
+    fields equals the number of symbols that have been promoted at least once
+    (and not subsequently demoted below Metadata). *)

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -1,0 +1,114 @@
+(** Tier-aware bar loader.
+
+    Step 3 of the backtest-scale plan
+    (dev/plans/backtest-tiered-loader-2026-04-19.md). The loader keeps
+    per-symbol data at one of three tiers so the backtest working set scales
+    with {e actively tracked} symbols rather than {e total inventory}:
+
+    - {b Metadata} — last-bar scalars (last close, sector, optional cap and
+      average volume). One record for {e every} universe symbol.
+    - {b Summary} — sector-ranked subset; indicator scalars (30w MA, RS line,
+      stage heuristic, ATR) computed from a bounded tail of bars; raw bars
+      dropped.
+    - {b Full} — raw OHLCV history for symbols actively considered for entry
+      or currently held.
+
+    This increment (3a) implements {b Metadata only}. The [tier] variant
+    already exposes all three tags so later increments extend the loader
+    without churn in the variant. [Summary.t] and [Full.t] submodules and
+    their promotion semantics are added in 3b / 3c. In 3a,
+    [promote ~to_:Summary_tier] and [promote ~to_:Full_tier] raise
+    [Failure]; [get_summary] and [get_full] always return [None]. *)
+
+open Core
+
+(** {1 Tier tag} *)
+
+type tier = Metadata_tier | Summary_tier | Full_tier
+[@@deriving show, eq, sexp]
+(** Discrete ordering of tiers by information content:
+    [Metadata_tier] < [Summary_tier] < [Full_tier]. Promotion moves a symbol
+    to a higher tier; demotion moves it back down. *)
+
+(** {1 Tier-shaped data} *)
+
+module Metadata : sig
+  type t = {
+    symbol : string;
+    sector : string;
+        (** Sector name as loaded from the sector table. [""] when the symbol
+            has no sector entry — the loader does not synthesize a sector. *)
+    last_close : float;  (** Close price of the last bar on or before [as_of]. *)
+    avg_vol_30d : float option;
+        (** 30-day average volume. [None] on this increment — wired in a
+            later PR when the screener needs it. *)
+    market_cap : float option;
+        (** Market capitalization. [None] on this increment. *)
+  }
+  [@@deriving show, eq, sexp]
+end
+
+(** {1 Loader} *)
+
+type t
+(** Mutable bag of per-symbol tier assignments + computed data. Opaque —
+    callers go through [promote] / [get_*] / [stats]. Not safe to share
+    across threads. *)
+
+type stats_counts = { metadata : int; summary : int; full : int }
+[@@deriving show, eq, sexp]
+(** Current per-tier symbol counts; used by tracer / parity harness. *)
+
+val create :
+  data_dir:Fpath.t -> sector_map:string String.Table.t -> universe:string list -> t
+(** [create ~data_dir ~sector_map ~universe] returns a fresh loader. [universe]
+    is the full set of symbols the backtest may promote; it is recorded but
+    does {b not} load any bars (Metadata-tier loads happen in [promote]).
+    [sector_map] is a symbol → sector lookup; symbols missing from the map
+    get [sector = ""] on promotion. [data_dir] is forwarded to an internal
+    [Price_cache] used on demand. *)
+
+val promote :
+  t -> symbols:string list -> to_:tier -> as_of:Date.t -> (unit, Status.t) Result.t
+(** [promote t ~symbols ~to_ ~as_of] moves every symbol in [symbols] up to
+    tier [to_], loading whatever data that tier needs. Idempotent: a symbol
+    already at tier [>= to_] is unchanged.
+
+    In this increment only [to_ = Metadata_tier] is implemented — passing
+    [Summary_tier] or [Full_tier] returns an [Error] with a
+    [Status.Unimplemented] code. Subsequent increments (3b, 3c) add those
+    branches.
+
+    Returns the first per-symbol error encountered (if any). A symbol that
+    fails to load is {e not} added to the loader. *)
+
+val demote : t -> symbols:string list -> to_:tier -> unit
+(** [demote t ~symbols ~to_] tiers each symbol down, freeing higher-tier data.
+    A symbol currently at tier [<= to_] is unchanged. Calling with
+    [to_ = Metadata_tier] fully drops any Summary / Full caches.
+
+    In 3a, since promote only reaches Metadata, [demote] is effectively a
+    no-op — included for API completeness so 3b / 3c extend the behaviour
+    without a signature change. *)
+
+val tier_of : t -> symbol:string -> tier option
+(** [tier_of t ~symbol] returns the current tier of [symbol], or [None] if
+    the symbol has never been promoted in this loader. *)
+
+val get_metadata : t -> symbol:string -> Metadata.t option
+(** [get_metadata t ~symbol] returns the Metadata record for [symbol] when
+    it has been promoted at least to Metadata tier, otherwise [None]. *)
+
+val get_summary : t -> symbol:string -> unit option
+(** Placeholder for 3b. Always returns [None] in this increment; the return
+    type is [unit option] to keep the interface signature stable until 3b
+    introduces [Summary.t]. *)
+
+val get_full : t -> symbol:string -> unit option
+(** Placeholder for 3c. Always returns [None] in this increment; same
+    stability rationale as [get_summary]. *)
+
+val stats : t -> stats_counts
+(** [stats t] returns the current per-tier symbol counts. The sum of the
+    three fields equals the number of symbols that have been promoted at
+    least once (and not subsequently demoted below Metadata). *)

--- a/trading/trading/backtest/bar_loader/dune
+++ b/trading/trading/backtest/bar_loader/dune
@@ -1,0 +1,6 @@
+(library
+ (public_name trading.backtest.bar_loader)
+ (name bar_loader)
+ (libraries core fpath status types trading.simulation.data)
+ (preprocess
+  (pps ppx_let ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/bar_loader/dune
+++ b/trading/trading/backtest/bar_loader/dune
@@ -1,6 +1,17 @@
 (library
  (public_name trading.backtest.bar_loader)
  (name bar_loader)
- (libraries core fpath status types trading.simulation.data)
+ (libraries
+  core
+  fpath
+  status
+  types
+  trading.simulation.data
+  csv
+  indicators.time_period
+  indicators.relative_strength
+  indicators.sma
+  weinstein.stage
+  weinstein.types)
  (preprocess
   (pps ppx_let ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/bar_loader/summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/summary_compute.ml
@@ -85,11 +85,20 @@ let atr_14 ~config (bars : Types.Daily_price.t list) : float option =
       Some (_average window)
 
 let rs_line ~(config : config) ~stock_bars ~benchmark_bars : float option =
+  (* Weinstein §4.4 prescribes a weekly RS line with a long-term (52-week)
+     Mansfield zero line. [Relative_strength.analyze] is documented as taking
+     weekly bars, and [rs_ma_period = 52] means "52 weekly bars ≈ one year".
+     Aggregate daily inputs to weekly first so [rs_ma_period] is interpreted
+     in weeks — feeding daily bars directly would collapse the zero-line
+     window to ~2.5 months and distort the normalization. *)
   let rs_config : Relative_strength.config =
     { rs_ma_period = config.rs_ma_period }
   in
+  let stock_weekly = _weekly_bars stock_bars in
+  let benchmark_weekly = _weekly_bars benchmark_bars in
   match
-    Relative_strength.analyze ~config:rs_config ~stock_bars ~benchmark_bars
+    Relative_strength.analyze ~config:rs_config ~stock_bars:stock_weekly
+      ~benchmark_bars:benchmark_weekly
   with
   | None -> None
   | Some history -> (

--- a/trading/trading/backtest/bar_loader/summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/summary_compute.ml
@@ -45,8 +45,7 @@ let _true_range_series (bars : Types.Daily_price.t list) : float list =
   | [] | [ _ ] -> []
   | first :: rest ->
       let _, trs =
-        List.fold rest
-          ~init:(first.Types.Daily_price.close_price, [])
+        List.fold rest ~init:(first.Types.Daily_price.close_price, [])
           ~f:(fun (prev_close, acc) bar ->
             let tr = _true_range ~prev_close bar in
             (bar.Types.Daily_price.close_price, tr :: acc))
@@ -65,7 +64,9 @@ let ma_30w ~config (bars : Types.Daily_price.t list) : float option =
   let n = List.length weekly in
   if n < config.ma_weeks then None
   else
-    let last_n = List.sub weekly ~pos:(n - config.ma_weeks) ~len:config.ma_weeks in
+    let last_n =
+      List.sub weekly ~pos:(n - config.ma_weeks) ~len:config.ma_weeks
+    in
     let closes =
       List.map last_n ~f:(fun b -> b.Types.Daily_price.adjusted_close)
     in
@@ -78,7 +79,9 @@ let atr_14 ~config (bars : Types.Daily_price.t list) : float option =
     let n = List.length tr_series in
     if n < config.atr_days then None
     else
-      let window = List.sub tr_series ~pos:(n - config.atr_days) ~len:config.atr_days in
+      let window =
+        List.sub tr_series ~pos:(n - config.atr_days) ~len:config.atr_days
+      in
       Some (_average window)
 
 let rs_line ~(config : config) ~stock_bars ~benchmark_bars : float option =

--- a/trading/trading/backtest/bar_loader/summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/summary_compute.ml
@@ -1,0 +1,133 @@
+(** Pure compute helpers for the Summary tier — see [summary_compute.mli]. *)
+
+open Core
+
+type config = {
+  ma_weeks : int;
+  atr_days : int;
+  rs_ma_period : int;
+  tail_days : int;
+}
+[@@deriving sexp, show, eq]
+
+let default_config =
+  { ma_weeks = 30; atr_days = 14; rs_ma_period = 52; tail_days = 250 }
+
+type summary_values = {
+  ma_30w : float;
+  atr_14 : float;
+  rs_line : float;
+  stage : Weinstein_types.stage;
+  as_of : Date.t;
+}
+[@@deriving sexp, show, eq]
+
+(** {1 Internal helpers} *)
+
+(** [_weekly_bars bars] aggregates daily bars to weekly last-bar-of-week. Used
+    by [ma_30w] and [stage_heuristic]. *)
+let _weekly_bars (bars : Types.Daily_price.t list) : Types.Daily_price.t list =
+  Time_period.Conversion.daily_to_weekly ~include_partial_week:true bars
+
+(** [_true_range ~prev_close bar] is the Weinstein TR component — the greatest
+    of the range itself and the gap moves from the prior close. *)
+let _true_range ~prev_close (bar : Types.Daily_price.t) : float =
+  let range = bar.high_price -. bar.low_price in
+  let gap_up = Float.abs (bar.high_price -. prev_close) in
+  let gap_down = Float.abs (bar.low_price -. prev_close) in
+  Float.max range (Float.max gap_up gap_down)
+
+(** [_true_range_series bars] produces the TR series starting at the *second*
+    bar (the first has no prior close). Returns an empty list if [bars] has
+    fewer than 2 elements. *)
+let _true_range_series (bars : Types.Daily_price.t list) : float list =
+  match bars with
+  | [] | [ _ ] -> []
+  | first :: rest ->
+      let _, trs =
+        List.fold rest
+          ~init:(first.Types.Daily_price.close_price, [])
+          ~f:(fun (prev_close, acc) bar ->
+            let tr = _true_range ~prev_close bar in
+            (bar.Types.Daily_price.close_price, tr :: acc))
+      in
+      List.rev trs
+
+(** [_average xs] is the arithmetic mean of a non-empty float list. *)
+let _average xs =
+  let sum = List.fold xs ~init:0.0 ~f:( +. ) in
+  sum /. Float.of_int (List.length xs)
+
+(** {1 Indicator primitives} *)
+
+let ma_30w ~config (bars : Types.Daily_price.t list) : float option =
+  let weekly = _weekly_bars bars in
+  let n = List.length weekly in
+  if n < config.ma_weeks then None
+  else
+    let last_n = List.sub weekly ~pos:(n - config.ma_weeks) ~len:config.ma_weeks in
+    let closes =
+      List.map last_n ~f:(fun b -> b.Types.Daily_price.adjusted_close)
+    in
+    Some (_average closes)
+
+let atr_14 ~config (bars : Types.Daily_price.t list) : float option =
+  if List.length bars < config.atr_days + 1 then None
+  else
+    let tr_series = _true_range_series bars in
+    let n = List.length tr_series in
+    if n < config.atr_days then None
+    else
+      let window = List.sub tr_series ~pos:(n - config.atr_days) ~len:config.atr_days in
+      Some (_average window)
+
+let rs_line ~(config : config) ~stock_bars ~benchmark_bars : float option =
+  let rs_config : Relative_strength.config =
+    { rs_ma_period = config.rs_ma_period }
+  in
+  match
+    Relative_strength.analyze ~config:rs_config ~stock_bars ~benchmark_bars
+  with
+  | None -> None
+  | Some history -> (
+      match List.last history with
+      | None -> None
+      | Some last -> Some last.Relative_strength.rs_normalized)
+
+let stage_heuristic ~config (bars : Types.Daily_price.t list) :
+    Weinstein_types.stage option =
+  let weekly = _weekly_bars bars in
+  if List.length weekly < config.ma_weeks then None
+  else
+    let stage_config =
+      { Stage.default_config with ma_period = config.ma_weeks }
+    in
+    let result =
+      Stage.classify ~config:stage_config ~bars:weekly ~prior_stage:None
+    in
+    Some result.stage
+
+(** {1 Composition} *)
+
+let compute_values ~config ~stock_bars ~benchmark_bars ~as_of :
+    summary_values option =
+  match ma_30w ~config stock_bars with
+  | None -> None
+  | Some ma_30w_v -> (
+      match atr_14 ~config stock_bars with
+      | None -> None
+      | Some atr_14_v -> (
+          match rs_line ~config ~stock_bars ~benchmark_bars with
+          | None -> None
+          | Some rs_line_v -> (
+              match stage_heuristic ~config stock_bars with
+              | None -> None
+              | Some stage_v ->
+                  Some
+                    {
+                      ma_30w = ma_30w_v;
+                      atr_14 = atr_14_v;
+                      rs_line = rs_line_v;
+                      stage = stage_v;
+                      as_of;
+                    })))

--- a/trading/trading/backtest/bar_loader/summary_compute.mli
+++ b/trading/trading/backtest/bar_loader/summary_compute.mli
@@ -1,0 +1,96 @@
+(** Pure compute helpers for the Summary tier of {!Bar_loader}.
+
+    A [Summary.t] is a handful of indicator scalars (30-week MA, ATR-14, RS
+    line, stage heuristic) derived from a bounded tail of daily bars. Keeping
+    the compute logic in its own module means the math is unit-testable without
+    a [Price_cache] / CSV round-trip, and the [Bar_loader] integration layer
+    stays focused on tier bookkeeping.
+
+    All functions in this module are pure: same inputs always produce the same
+    output. Callers provide already-loaded daily bars; loading is the
+    responsibility of {!Bar_loader}. *)
+
+open Core
+
+(** {1 Configuration} *)
+
+type config = {
+  ma_weeks : int;  (** Weeks in the Weinstein MA. Default: 30. *)
+  atr_days : int;  (** Lookback days for ATR. Default: 14. *)
+  rs_ma_period : int;
+      (** Mansfield RS zero-line MA length in aligned bars. Default: 52 (~one
+          year weekly, or ~52 trading days if daily). *)
+  tail_days : int;
+      (** Upper bound on the daily-bar tail the Summary loader fetches per
+          symbol. Must be large enough to cover the longest indicator window
+          plus warmup. Default: 250 (~ [ma_weeks] × 7 + ATR warmup). *)
+}
+[@@deriving sexp, show, eq]
+
+val default_config : config
+(** Sensible defaults for Weinstein-style analysis:
+    [{ ma_weeks = 30; atr_days = 14; rs_ma_period = 52; tail_days = 250 }]. *)
+
+(** {1 Indicator primitives}
+
+    Each helper returns [None] when there are not enough bars to produce a
+    valid result — summary loaders treat [None] as "insufficient history;
+    leave this symbol at its current tier". *)
+
+val ma_30w : config:config -> Types.Daily_price.t list -> float option
+(** [ma_30w ~config bars] aggregates [bars] to weekly (last-bar-of-week) and
+    returns the simple moving average of the last [config.ma_weeks] weekly
+    closes. Returns [None] when there are fewer than [config.ma_weeks] weekly
+    bars available. *)
+
+val atr_14 : config:config -> Types.Daily_price.t list -> float option
+(** [atr_14 ~config bars] returns the Average True Range over the most recent
+    [config.atr_days] bars. True range for bar [i] is
+    [max (high - low, |high - prev_close|, |low - prev_close|)]. The first bar
+    has no prior close and is skipped. Returns [None] when there are fewer
+    than [config.atr_days + 1] bars. *)
+
+val rs_line :
+  config:config ->
+  stock_bars:Types.Daily_price.t list ->
+  benchmark_bars:Types.Daily_price.t list ->
+  float option
+(** [rs_line ~config ~stock_bars ~benchmark_bars] returns the latest Mansfield
+    normalized RS value for the stock against the benchmark, or [None] when
+    there are fewer than [config.rs_ma_period] aligned bars. The value is
+    [raw_rs / MA(raw_rs)] — values above 1.0 mean the stock is outperforming
+    its own recent baseline. *)
+
+val stage_heuristic :
+  config:config ->
+  Types.Daily_price.t list ->
+  Weinstein_types.stage option
+(** [stage_heuristic ~config bars] runs the {!Stage.classify} one-shot
+    classifier on weekly-aggregated bars and returns the resulting stage.
+    Returns [None] when aggregation yields fewer than [config.ma_weeks] weekly
+    bars (i.e. {!Stage.classify} would emit a degenerate Stage1 placeholder —
+    we surface that as "no heuristic available" instead). *)
+
+(** {1 Summary composition} *)
+
+type summary_values = {
+  ma_30w : float;
+  atr_14 : float;
+  rs_line : float;
+  stage : Weinstein_types.stage;
+  as_of : Date.t;
+}
+[@@deriving sexp, show, eq]
+(** Indicator scalars produced by {!compute_values}. Mirrors the fields of
+    [Bar_loader.Summary.t] minus the [symbol] key. *)
+
+val compute_values :
+  config:config ->
+  stock_bars:Types.Daily_price.t list ->
+  benchmark_bars:Types.Daily_price.t list ->
+  as_of:Date.t ->
+  summary_values option
+(** [compute_values ~config ~stock_bars ~benchmark_bars ~as_of] runs all four
+    helpers and assembles a {!summary_values}. Returns [None] when any helper
+    returns [None] — the caller should leave the symbol at Metadata tier in
+    that case. *)

--- a/trading/trading/backtest/bar_loader/summary_compute.mli
+++ b/trading/trading/backtest/bar_loader/summary_compute.mli
@@ -18,8 +18,9 @@ type config = {
   ma_weeks : int;  (** Weeks in the Weinstein MA. Default: 30. *)
   atr_days : int;  (** Lookback days for ATR. Default: 14. *)
   rs_ma_period : int;
-      (** Mansfield RS zero-line MA length in aligned bars. Default: 52 (~one
-          year weekly, or ~52 trading days if daily). *)
+      (** Mansfield RS zero-line MA length in WEEKLY bars. [rs_line] aggregates
+          daily input to weekly before normalizing, so [52] means "52 weekly
+          bars ≈ one year" per Weinstein §4.4. Default: 52. *)
   tail_days : int;
       (** Upper bound on the daily-bar tail the Summary loader fetches per
           symbol. Must be large enough to cover the longest indicator window
@@ -56,10 +57,13 @@ val rs_line :
   benchmark_bars:Types.Daily_price.t list ->
   float option
 (** [rs_line ~config ~stock_bars ~benchmark_bars] returns the latest Mansfield
-    normalized RS value for the stock against the benchmark, or [None] when
-    there are fewer than [config.rs_ma_period] aligned bars. The value is
-    [raw_rs / MA(raw_rs)] — values above 1.0 mean the stock is outperforming its
-    own recent baseline. *)
+    normalized RS value for the stock against the benchmark. Both inputs are
+    daily bars; the helper aggregates each to weekly (last-bar-of-week) before
+    invoking {!Relative_strength.analyze}, so [config.rs_ma_period] is
+    interpreted in WEEKLY bars (see {!config} for the default). Returns [None]
+    when fewer than [config.rs_ma_period] aligned weekly bars are available.
+    The value is [raw_rs / MA(raw_rs)] — values above 1.0 mean the stock is
+    outperforming its own recent baseline. *)
 
 val stage_heuristic :
   config:config -> Types.Daily_price.t list -> Weinstein_types.stage option

--- a/trading/trading/backtest/bar_loader/summary_compute.mli
+++ b/trading/trading/backtest/bar_loader/summary_compute.mli
@@ -33,9 +33,9 @@ val default_config : config
 
 (** {1 Indicator primitives}
 
-    Each helper returns [None] when there are not enough bars to produce a
-    valid result — summary loaders treat [None] as "insufficient history;
-    leave this symbol at its current tier". *)
+    Each helper returns [None] when there are not enough bars to produce a valid
+    result — summary loaders treat [None] as "insufficient history; leave this
+    symbol at its current tier". *)
 
 val ma_30w : config:config -> Types.Daily_price.t list -> float option
 (** [ma_30w ~config bars] aggregates [bars] to weekly (last-bar-of-week) and
@@ -47,8 +47,8 @@ val atr_14 : config:config -> Types.Daily_price.t list -> float option
 (** [atr_14 ~config bars] returns the Average True Range over the most recent
     [config.atr_days] bars. True range for bar [i] is
     [max (high - low, |high - prev_close|, |low - prev_close|)]. The first bar
-    has no prior close and is skipped. Returns [None] when there are fewer
-    than [config.atr_days + 1] bars. *)
+    has no prior close and is skipped. Returns [None] when there are fewer than
+    [config.atr_days + 1] bars. *)
 
 val rs_line :
   config:config ->
@@ -58,18 +58,16 @@ val rs_line :
 (** [rs_line ~config ~stock_bars ~benchmark_bars] returns the latest Mansfield
     normalized RS value for the stock against the benchmark, or [None] when
     there are fewer than [config.rs_ma_period] aligned bars. The value is
-    [raw_rs / MA(raw_rs)] — values above 1.0 mean the stock is outperforming
-    its own recent baseline. *)
+    [raw_rs / MA(raw_rs)] — values above 1.0 mean the stock is outperforming its
+    own recent baseline. *)
 
 val stage_heuristic :
-  config:config ->
-  Types.Daily_price.t list ->
-  Weinstein_types.stage option
+  config:config -> Types.Daily_price.t list -> Weinstein_types.stage option
 (** [stage_heuristic ~config bars] runs the {!Stage.classify} one-shot
     classifier on weekly-aggregated bars and returns the resulting stage.
     Returns [None] when aggregation yields fewer than [config.ma_weeks] weekly
-    bars (i.e. {!Stage.classify} would emit a degenerate Stage1 placeholder —
-    we surface that as "no heuristic available" instead). *)
+    bars (i.e. {!Stage.classify} would emit a degenerate Stage1 placeholder — we
+    surface that as "no heuristic available" instead). *)
 
 (** {1 Summary composition} *)
 
@@ -92,5 +90,5 @@ val compute_values :
   summary_values option
 (** [compute_values ~config ~stock_bars ~benchmark_bars ~as_of] runs all four
     helpers and assembles a {!summary_values}. Returns [None] when any helper
-    returns [None] — the caller should leave the symbol at Metadata tier in
-    that case. *)
+    returns [None] — the caller should leave the symbol at Metadata tier in that
+    case. *)

--- a/trading/trading/backtest/bar_loader/summary_compute.mli
+++ b/trading/trading/backtest/bar_loader/summary_compute.mli
@@ -61,8 +61,8 @@ val rs_line :
     daily bars; the helper aggregates each to weekly (last-bar-of-week) before
     invoking {!Relative_strength.analyze}, so [config.rs_ma_period] is
     interpreted in WEEKLY bars (see {!config} for the default). Returns [None]
-    when fewer than [config.rs_ma_period] aligned weekly bars are available.
-    The value is [raw_rs / MA(raw_rs)] — values above 1.0 mean the stock is
+    when fewer than [config.rs_ma_period] aligned weekly bars are available. The
+    value is [raw_rs / MA(raw_rs)] — values above 1.0 mean the stock is
     outperforming its own recent baseline. *)
 
 val stage_heuristic :

--- a/trading/trading/backtest/bar_loader/test/dune
+++ b/trading/trading/backtest/bar_loader/test/dune
@@ -1,6 +1,6 @@
 (tests
- (names test_metadata)
- (modules test_metadata)
+ (names test_metadata test_summary_compute test_summary)
+ (modules test_metadata test_summary_compute test_summary)
  (libraries
   ounit2
   core
@@ -9,4 +9,5 @@
   status
   trading.backtest.bar_loader
   types
+  weinstein.types
   matchers))

--- a/trading/trading/backtest/bar_loader/test/dune
+++ b/trading/trading/backtest/bar_loader/test/dune
@@ -1,0 +1,12 @@
+(tests
+ (names test_metadata)
+ (modules test_metadata)
+ (libraries
+  ounit2
+  core
+  core_unix.filename_unix
+  fpath
+  status
+  trading.backtest.bar_loader
+  types
+  matchers))

--- a/trading/trading/backtest/bar_loader/test/test_metadata.ml
+++ b/trading/trading/backtest/bar_loader/test/test_metadata.ml
@@ -67,7 +67,7 @@ let _fixture ~n_symbols ~sector_map_entries =
   let sector_map = String.Table.create () in
   List.iter sector_map_entries ~f:(fun (sym, sec) ->
       Hashtbl.set sector_map ~key:sym ~data:sec);
-  let loader = Bar_loader.create ~data_dir ~sector_map ~universe:symbols in
+  let loader = Bar_loader.create ~data_dir ~sector_map ~universe:symbols () in
   (loader, symbols)
 
 (** {1 Tests} *)
@@ -168,18 +168,17 @@ let test_promote_missing_symbol_errors _ =
   assert_that (Bar_loader.stats loader)
     (field (fun s -> s.Bar_loader.metadata) (equal_to 0))
 
-let test_higher_tier_promotions_unimplemented _ =
+let test_full_promotion_unimplemented _ =
   let loader, symbols = _fixture ~n_symbols:2 ~sector_map_entries:[] in
-  let summary_result =
-    Bar_loader.promote loader ~symbols ~to_:Summary_tier ~as_of:_as_of
-  in
-  assert_that summary_result (is_error_with Unimplemented);
   let full_result =
     Bar_loader.promote loader ~symbols ~to_:Full_tier ~as_of:_as_of
   in
   assert_that full_result (is_error_with Unimplemented)
 
-let test_summary_full_getters_return_none _ =
+let test_summary_getter_none_on_metadata_only _ =
+  (* After Metadata-only promotion the Summary getter must be [None] — the
+     entry exists at Metadata tier but no Summary scalars have been computed
+     yet. Full-tier getter is permanently [None] until 3c. *)
   let loader, symbols =
     _fixture ~n_symbols:2 ~sector_map_entries:[ ("S01", "Tech") ]
   in
@@ -198,10 +197,9 @@ let suite =
          "get_metadata_returns_data" >:: test_get_metadata_returns_data;
          "promote_is_idempotent" >:: test_promote_is_idempotent;
          "promote_missing_symbol_errors" >:: test_promote_missing_symbol_errors;
-         "higher_tier_promotions_unimplemented"
-         >:: test_higher_tier_promotions_unimplemented;
-         "summary_full_getters_return_none"
-         >:: test_summary_full_getters_return_none;
+         "full_promotion_unimplemented" >:: test_full_promotion_unimplemented;
+         "summary_getter_none_on_metadata_only"
+         >:: test_summary_getter_none_on_metadata_only;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/bar_loader/test/test_metadata.ml
+++ b/trading/trading/backtest/bar_loader/test/test_metadata.ml
@@ -1,0 +1,207 @@
+(** Unit tests for Bar_loader — 3a (Metadata tier). *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_loader = Bar_loader
+
+(** {1 Fixture helpers}
+
+    Each test builds its own temp data dir with a handful of synthetic CSVs so
+    we don't depend on checked-in fixtures. Symbols are chosen short and unique
+    (S01 .. S10) so they land in deterministic subdirectories under
+    [data_dir/<first>/<last>/<symbol>/data.csv]. *)
+
+let _mk_bar ~date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close;
+    low_price = close;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+(** Three consecutive daily bars ending on [2024-01-05]. Close on the last bar
+    is the distinguishing scalar we assert on in get_metadata tests. *)
+let _make_bars ~last_close =
+  [
+    _mk_bar
+      ~date:(Date.create_exn ~y:2024 ~m:Jan ~d:3)
+      ~close:(last_close -. 2.0);
+    _mk_bar
+      ~date:(Date.create_exn ~y:2024 ~m:Jan ~d:4)
+      ~close:(last_close -. 1.0);
+    _mk_bar ~date:(Date.create_exn ~y:2024 ~m:Jan ~d:5) ~close:last_close;
+  ]
+
+let _ok_or_fail ~context = function
+  | Ok v -> v
+  | Error (err : Status.t) ->
+      assert_failure (Printf.sprintf "%s: %s" context (Status.show err))
+
+let _write_symbol ~data_dir ~symbol ~last_close =
+  let storage =
+    Csv.Csv_storage.create ~data_dir symbol
+    |> _ok_or_fail ~context:("Csv_storage.create " ^ symbol)
+  in
+  Csv.Csv_storage.save storage (_make_bars ~last_close)
+  |> _ok_or_fail ~context:("Csv_storage.save " ^ symbol)
+
+let _fresh_data_dir () =
+  let dir = Filename_unix.temp_dir "bar_loader_test_" "" in
+  Fpath.v dir
+
+let _as_of = Date.create_exn ~y:2024 ~m:Jan ~d:31
+
+(** Build a fixture of [n] symbols, each with last close = 100 + index. Returns
+    the loader plus the list of symbols written (in insertion order). *)
+let _fixture ~n_symbols ~sector_map_entries =
+  let data_dir = _fresh_data_dir () in
+  let symbols =
+    List.init n_symbols ~f:(fun i -> Printf.sprintf "S%02d" (i + 1))
+  in
+  List.iteri symbols ~f:(fun i symbol ->
+      _write_symbol ~data_dir ~symbol ~last_close:(100.0 +. Float.of_int i));
+  let sector_map = String.Table.create () in
+  List.iter sector_map_entries ~f:(fun (sym, sec) ->
+      Hashtbl.set sector_map ~key:sym ~data:sec);
+  let loader = Bar_loader.create ~data_dir ~sector_map ~universe:symbols in
+  (loader, symbols)
+
+(** {1 Tests} *)
+
+let test_create_empty _ =
+  let loader, _ = _fixture ~n_symbols:0 ~sector_map_entries:[] in
+  assert_that (Bar_loader.stats loader)
+    (all_of
+       [
+         field (fun s -> s.Bar_loader.metadata) (equal_to 0);
+         field (fun s -> s.Bar_loader.summary) (equal_to 0);
+         field (fun s -> s.Bar_loader.full) (equal_to 0);
+       ]);
+  assert_that (Bar_loader.tier_of loader ~symbol:"S01") is_none;
+  assert_that (Bar_loader.get_metadata loader ~symbol:"S01") is_none
+
+let test_promote_10_symbols_stats _ =
+  let loader, symbols =
+    _fixture ~n_symbols:10
+      ~sector_map_entries:
+        [ ("S01", "Tech"); ("S02", "Tech"); ("S03", "Financials") ]
+  in
+  let result =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+  in
+  assert_that result is_ok;
+  assert_that (Bar_loader.stats loader)
+    (all_of
+       [
+         field (fun s -> s.Bar_loader.metadata) (equal_to 10);
+         field (fun s -> s.Bar_loader.summary) (equal_to 0);
+         field (fun s -> s.Bar_loader.full) (equal_to 0);
+       ])
+
+let test_get_metadata_returns_data _ =
+  let loader, symbols =
+    _fixture ~n_symbols:3 ~sector_map_entries:[ ("S01", "Tech") ]
+  in
+  let _ =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+    |> _ok_or_fail ~context:"Bar_loader.promote"
+  in
+  (* S01: sector set in map, last_close = 100.0 (index 0). *)
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"S01")
+    (is_some_and
+       (all_of
+          [
+            field (fun m -> m.Bar_loader.Metadata.symbol) (equal_to "S01");
+            field (fun m -> m.Bar_loader.Metadata.sector) (equal_to "Tech");
+            field
+              (fun m -> m.Bar_loader.Metadata.last_close)
+              (float_equal 100.0);
+            field (fun m -> m.Bar_loader.Metadata.avg_vol_30d) is_none;
+            field (fun m -> m.Bar_loader.Metadata.market_cap) is_none;
+          ]));
+  (* S02: no sector entry — should be "" (plan: loader does not synthesize). *)
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"S02")
+    (is_some_and
+       (all_of
+          [
+            field (fun m -> m.Bar_loader.Metadata.sector) (equal_to "");
+            field
+              (fun m -> m.Bar_loader.Metadata.last_close)
+              (float_equal 101.0);
+          ]));
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"S01")
+    (is_some_and (equal_to Bar_loader.Metadata_tier))
+
+let test_promote_is_idempotent _ =
+  let loader, symbols =
+    _fixture ~n_symbols:5 ~sector_map_entries:[ ("S01", "Tech") ]
+  in
+  let _ =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+    |> _ok_or_fail ~context:"Bar_loader.promote"
+  in
+  let stats_before = Bar_loader.stats loader in
+  (* Re-promote the same symbols to the same tier — must be a no-op. *)
+  let _ =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+    |> _ok_or_fail ~context:"Bar_loader.promote"
+  in
+  assert_that (Bar_loader.stats loader) (equal_to stats_before)
+
+let test_promote_missing_symbol_errors _ =
+  (* Symbol not in data_dir — Price_cache returns NotFound; promote surfaces it. *)
+  let loader, _ = _fixture ~n_symbols:0 ~sector_map_entries:[] in
+  let result =
+    Bar_loader.promote loader ~symbols:[ "NOPE" ] ~to_:Metadata_tier
+      ~as_of:_as_of
+  in
+  assert_that result is_error;
+  (* The failed symbol was not inserted. *)
+  assert_that (Bar_loader.tier_of loader ~symbol:"NOPE") is_none;
+  assert_that (Bar_loader.stats loader)
+    (field (fun s -> s.Bar_loader.metadata) (equal_to 0))
+
+let test_higher_tier_promotions_unimplemented _ =
+  let loader, symbols = _fixture ~n_symbols:2 ~sector_map_entries:[] in
+  let summary_result =
+    Bar_loader.promote loader ~symbols ~to_:Summary_tier ~as_of:_as_of
+  in
+  assert_that summary_result (is_error_with Unimplemented);
+  let full_result =
+    Bar_loader.promote loader ~symbols ~to_:Full_tier ~as_of:_as_of
+  in
+  assert_that full_result (is_error_with Unimplemented)
+
+let test_summary_full_getters_return_none _ =
+  let loader, symbols =
+    _fixture ~n_symbols:2 ~sector_map_entries:[ ("S01", "Tech") ]
+  in
+  let _ =
+    Bar_loader.promote loader ~symbols ~to_:Metadata_tier ~as_of:_as_of
+    |> _ok_or_fail ~context:"Bar_loader.promote"
+  in
+  assert_that (Bar_loader.get_summary loader ~symbol:"S01") is_none;
+  assert_that (Bar_loader.get_full loader ~symbol:"S01") is_none
+
+let suite =
+  "Bar_loader.Metadata"
+  >::: [
+         "create_empty" >:: test_create_empty;
+         "promote_10_symbols_stats" >:: test_promote_10_symbols_stats;
+         "get_metadata_returns_data" >:: test_get_metadata_returns_data;
+         "promote_is_idempotent" >:: test_promote_is_idempotent;
+         "promote_missing_symbol_errors" >:: test_promote_missing_symbol_errors;
+         "higher_tier_promotions_unimplemented"
+         >:: test_higher_tier_promotions_unimplemented;
+         "summary_full_getters_return_none"
+         >:: test_summary_full_getters_return_none;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/bar_loader/test/test_summary.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary.ml
@@ -52,17 +52,16 @@ let _fresh_data_dir () =
   Fpath.v dir
 
 (** Summary-tier fixture: enough daily bars ending at [as_of] for the loader's
-    default 250-day tail + 30-week MA to resolve.
+    default 250-day tail + 30-week MA + 52-week RS window to resolve.
 
     The loader only looks at bars in [as_of - tail_days, as_of]. With
-    [tail_days = 250] (default) that's ~250 calendar days ≈ ~35 ISO weeks, which
-    is enough to produce [ma_30w] (needs 30 weekly bars) and [rs_line] (needs
-    [rs_ma_period = 52] aligned bars — the loader aligns daily bars directly, so
-    250 aligned bars is plenty). We make the history go a bit past [tail_days]
-    to exercise the windowing. *)
+    [tail_days = 250] the tail is ~250 calendar days ≈ ~36 ISO weeks (before
+    aggregation); to produce [rs_line] we need [rs_ma_period = 52] WEEKLY bars
+    after aggregation, so we configure the loader to fetch a larger tail via
+    [summary_config] and generate ~420 days (~60 weeks) of history. *)
 let _summary_fixture ?(stock_step = 1.0) ?(benchmark_step = 1.0) () =
   let as_of = Date.create_exn ~y:2023 ~m:Dec ~d:29 in
-  let history_days = 350 in
+  let history_days = 420 in
   let start_date = Date.add_days as_of (-history_days) in
   let data_dir = _fresh_data_dir () in
   let stock_bars =
@@ -75,8 +74,12 @@ let _summary_fixture ?(stock_step = 1.0) ?(benchmark_step = 1.0) () =
   _write_symbol ~data_dir ~symbol:"SPY" ~bars:benchmark_bars;
   let sector_map = String.Table.create () in
   Hashtbl.set sector_map ~key:"STOCK" ~data:"Tech";
+  let summary_config =
+    { Bar_loader.Summary_compute.default_config with tail_days = history_days }
+  in
   let loader =
-    Bar_loader.create ~data_dir ~sector_map ~universe:[ "STOCK" ] ()
+    Bar_loader.create ~data_dir ~sector_map ~universe:[ "STOCK" ]
+      ~summary_config ()
   in
   (loader, as_of)
 

--- a/trading/trading/backtest/bar_loader/test/test_summary.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary.ml
@@ -1,0 +1,261 @@
+(** Integration tests for Bar_loader — 3b (Summary tier).
+
+    These tests exercise the loader's tier bookkeeping end-to-end: promote to
+    Summary from a CSV fixture, verify the indicator scalars land in the
+    [get_summary] record, check idempotency, demote and observe the drop. The
+    pure math is covered by [test_summary_compute.ml] — here we focus on the
+    plumbing. *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_loader = Bar_loader
+
+(** {1 Fixture helpers} *)
+
+let _mk_bar ~date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close;
+    low_price = close;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+(** [_daily_series ~start_date ~n ~base ~step] produces [n] consecutive daily
+    bars with close = [base +. step * i]. Weekend dates are kept — the bar
+    loader and [Time_period.Conversion] treat the series as a plain daily
+    stream, so this is fine for tests. *)
+let _daily_series ~start_date ~n ~base ~step =
+  List.init n ~f:(fun i ->
+      let date = Date.add_days start_date i in
+      let close = base +. (step *. Float.of_int i) in
+      _mk_bar ~date ~close)
+
+let _ok_or_fail ~context = function
+  | Ok v -> v
+  | Error (err : Status.t) ->
+      assert_failure (Printf.sprintf "%s: %s" context (Status.show err))
+
+let _write_symbol ~data_dir ~symbol ~bars =
+  let storage =
+    Csv.Csv_storage.create ~data_dir symbol
+    |> _ok_or_fail ~context:("Csv_storage.create " ^ symbol)
+  in
+  Csv.Csv_storage.save storage bars
+  |> _ok_or_fail ~context:("Csv_storage.save " ^ symbol)
+
+let _fresh_data_dir () =
+  let dir = Filename_unix.temp_dir "bar_loader_summary_test_" "" in
+  Fpath.v dir
+
+(** Summary-tier fixture: enough daily bars ending at [as_of] for the loader's
+    default 250-day tail + 30-week MA to resolve.
+
+    The loader only looks at bars in [as_of - tail_days, as_of]. With
+    [tail_days = 250] (default) that's ~250 calendar days ≈ ~35 ISO weeks, which
+    is enough to produce [ma_30w] (needs 30 weekly bars) and [rs_line] (needs
+    [rs_ma_period = 52] aligned bars — the loader aligns daily bars directly, so
+    250 aligned bars is plenty). We make the history go a bit past [tail_days]
+    to exercise the windowing. *)
+let _summary_fixture ?(stock_step = 1.0) ?(benchmark_step = 1.0) () =
+  let as_of = Date.create_exn ~y:2023 ~m:Dec ~d:29 in
+  let history_days = 350 in
+  let start_date = Date.add_days as_of (-history_days) in
+  let data_dir = _fresh_data_dir () in
+  let stock_bars =
+    _daily_series ~start_date ~n:history_days ~base:100.0 ~step:stock_step
+  in
+  let benchmark_bars =
+    _daily_series ~start_date ~n:history_days ~base:100.0 ~step:benchmark_step
+  in
+  _write_symbol ~data_dir ~symbol:"STOCK" ~bars:stock_bars;
+  _write_symbol ~data_dir ~symbol:"SPY" ~bars:benchmark_bars;
+  let sector_map = String.Table.create () in
+  Hashtbl.set sector_map ~key:"STOCK" ~data:"Tech";
+  let loader =
+    Bar_loader.create ~data_dir ~sector_map ~universe:[ "STOCK" ] ()
+  in
+  (loader, as_of)
+
+(** Short-history fixture: 10 daily bars — not enough for any Summary indicator.
+    Used to verify "insufficient history leaves symbol at Metadata". *)
+let _short_fixture () =
+  let data_dir = _fresh_data_dir () in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let as_of = Date.create_exn ~y:2023 ~m:Jan ~d:20 in
+  let bars = _daily_series ~start_date ~n:10 ~base:100.0 ~step:1.0 in
+  _write_symbol ~data_dir ~symbol:"SHORT" ~bars;
+  _write_symbol ~data_dir ~symbol:"SPY" ~bars;
+  let sector_map = String.Table.create () in
+  let loader =
+    Bar_loader.create ~data_dir ~sector_map ~universe:[ "SHORT" ] ()
+  in
+  (loader, as_of)
+
+(** {1 Tests} *)
+
+let test_promote_to_summary_populates_record _ =
+  let loader, as_of = _summary_fixture () in
+  let result =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+  in
+  assert_that result is_ok;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Summary_tier));
+  assert_that
+    (Bar_loader.get_summary loader ~symbol:"STOCK")
+    (is_some_and
+       (all_of
+          [
+            field (fun s -> s.Bar_loader.Summary.symbol) (equal_to "STOCK");
+            field (fun s -> s.Bar_loader.Summary.as_of) (equal_to as_of);
+            (* MA should be plausibly within the generated price band. *)
+            field
+              (fun s -> s.Bar_loader.Summary.ma_30w)
+              (is_between (module Float_ord) ~low:100.0 ~high:800.0);
+            (* With step=1.0 the bars are intraday-flat (h=l=c) but each
+               close is exactly 1.0 above the prior → TR per bar = 1.0 → ATR
+               = 1.0. *)
+            field (fun s -> s.Bar_loader.Summary.atr_14) (float_equal 1.0);
+            (* Stock and benchmark move identically → normalized RS = 1.0. *)
+            field (fun s -> s.Bar_loader.Summary.rs_line) (float_equal 1.0);
+          ]))
+
+let test_promote_to_summary_auto_promotes_metadata _ =
+  (* Summary promotion should populate the Metadata record too, so callers can
+     inspect sector / last_close on a Summary-tier symbol. *)
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote Summary"
+  in
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"STOCK")
+    (is_some_and
+       (all_of
+          [
+            field (fun m -> m.Bar_loader.Metadata.symbol) (equal_to "STOCK");
+            field (fun m -> m.Bar_loader.Metadata.sector) (equal_to "Tech");
+          ]))
+
+let test_promote_summary_stats_counts _ =
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote Summary"
+  in
+  assert_that (Bar_loader.stats loader)
+    (all_of
+       [
+         field (fun s -> s.Bar_loader.metadata) (equal_to 0);
+         field (fun s -> s.Bar_loader.summary) (equal_to 1);
+         field (fun s -> s.Bar_loader.full) (equal_to 0);
+       ])
+
+let test_promote_summary_insufficient_history_stays_at_metadata _ =
+  (* 10 bars is not enough for ma_30w / rs_line. The symbol should land at
+     Metadata tier (no error surfaced). *)
+  let loader, as_of = _short_fixture () in
+  let result =
+    Bar_loader.promote loader ~symbols:[ "SHORT" ] ~to_:Summary_tier ~as_of
+  in
+  assert_that result is_ok;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"SHORT")
+    (is_some_and (equal_to Bar_loader.Metadata_tier));
+  assert_that (Bar_loader.get_summary loader ~symbol:"SHORT") is_none;
+  (* Metadata is still there. *)
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"SHORT")
+    (is_some_and
+       (field (fun m -> m.Bar_loader.Metadata.symbol) (equal_to "SHORT")))
+
+let test_promote_summary_is_idempotent _ =
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote 1"
+  in
+  let stats_before = Bar_loader.stats loader in
+  let summary_before = Bar_loader.get_summary loader ~symbol:"STOCK" in
+  (* Second promote to the same tier is a no-op. *)
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote 2"
+  in
+  assert_that (Bar_loader.stats loader) (equal_to stats_before);
+  assert_that
+    (Bar_loader.get_summary loader ~symbol:"STOCK")
+    (equal_to summary_before)
+
+let test_demote_summary_to_metadata_drops_summary _ =
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote Summary"
+  in
+  Bar_loader.demote loader ~symbols:[ "STOCK" ] ~to_:Metadata_tier;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Metadata_tier));
+  assert_that (Bar_loader.get_summary loader ~symbol:"STOCK") is_none;
+  (* Metadata survives the demotion. *)
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"STOCK")
+    (is_some_and
+       (field (fun m -> m.Bar_loader.Metadata.symbol) (equal_to "STOCK")));
+  (* Stats reflect the move: summary count drops, metadata count rises. *)
+  assert_that (Bar_loader.stats loader)
+    (all_of
+       [
+         field (fun s -> s.Bar_loader.metadata) (equal_to 1);
+         field (fun s -> s.Bar_loader.summary) (equal_to 0);
+         field (fun s -> s.Bar_loader.full) (equal_to 0);
+       ])
+
+let test_demote_summary_to_summary_is_noop _ =
+  (* Demoting a Summary-tier symbol "to Summary" leaves it exactly where it
+     is. This exercises the _tier_rank guard. *)
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote Summary"
+  in
+  let summary_before = Bar_loader.get_summary loader ~symbol:"STOCK" in
+  Bar_loader.demote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Summary_tier));
+  assert_that
+    (Bar_loader.get_summary loader ~symbol:"STOCK")
+    (equal_to summary_before)
+
+let test_get_summary_none_for_unknown_symbol _ =
+  let loader, _ = _summary_fixture () in
+  assert_that (Bar_loader.get_summary loader ~symbol:"NOPE") is_none;
+  assert_that (Bar_loader.tier_of loader ~symbol:"NOPE") is_none
+
+let suite =
+  "Bar_loader.Summary"
+  >::: [
+         "promote_to_summary_populates_record"
+         >:: test_promote_to_summary_populates_record;
+         "promote_to_summary_auto_promotes_metadata"
+         >:: test_promote_to_summary_auto_promotes_metadata;
+         "promote_summary_stats_counts" >:: test_promote_summary_stats_counts;
+         "promote_summary_insufficient_history_stays_at_metadata"
+         >:: test_promote_summary_insufficient_history_stays_at_metadata;
+         "promote_summary_is_idempotent" >:: test_promote_summary_is_idempotent;
+         "demote_summary_to_metadata_drops_summary"
+         >:: test_demote_summary_to_metadata_drops_summary;
+         "demote_summary_to_summary_is_noop"
+         >:: test_demote_summary_to_summary_is_noop;
+         "get_summary_none_for_unknown_symbol"
+         >:: test_get_summary_none_for_unknown_symbol;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
@@ -125,14 +125,14 @@ let test_rs_line_none_when_too_short _ =
     (Summary_compute.rs_line ~config ~stock_bars ~benchmark_bars)
     is_none
 
-(** The Mansfield zero-line should normalize against a window of ~1 YEAR
-    (52 weekly bars), not ~2.5 months (52 daily bars). This test pins the
+(** The Mansfield zero-line should normalize against a window of ~1 YEAR (52
+    weekly bars), not ~2.5 months (52 daily bars). This test pins the
     aggregation boundary: we construct a series where stock = benchmark for
-    every bar except the final week (where stock doubles). Under correct
-    weekly aggregation the 52-week MA averages 51 weeks of raw_rs=1.0 with 1
-    week of raw_rs=2.0 → MA = 53/52. Under the buggy daily path the 52-day
-    MA would include 7 elevated days → MA ≈ 59/52 ≈ 1.1346, yielding a
-    meaningfully different normalized value. *)
+    every bar except the final week (where stock doubles). Under correct weekly
+    aggregation the 52-week MA averages 51 weeks of raw_rs=1.0 with 1 week of
+    raw_rs=2.0 → MA = 53/52. Under the buggy daily path the 52-day MA would
+    include 7 elevated days → MA ≈ 59/52 ≈ 1.1346, yielding a meaningfully
+    different normalized value. *)
 let test_rs_line_uses_weekly_52_window _ =
   let config = { Summary_compute.default_config with rs_ma_period = 52 } in
   (* 420 consecutive daily bars starting on a Monday → aggregates to 60 weekly
@@ -230,8 +230,7 @@ let suite =
          "atr_14_none_when_too_short" >:: test_atr_14_none_when_too_short;
          "rs_line_flat_ratio" >:: test_rs_line_flat_ratio;
          "rs_line_none_when_too_short" >:: test_rs_line_none_when_too_short;
-         "rs_line_uses_weekly_52_window"
-         >:: test_rs_line_uses_weekly_52_window;
+         "rs_line_uses_weekly_52_window" >:: test_rs_line_uses_weekly_52_window;
          "stage_heuristic_some_on_sufficient_history"
          >:: test_stage_heuristic_some_on_sufficient_history;
          "stage_heuristic_none_on_short_history"

--- a/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
@@ -105,12 +105,13 @@ let test_atr_14_none_when_too_short _ =
 (** {1 rs_line tests} *)
 
 let test_rs_line_flat_ratio _ =
-  (* Stock and benchmark move identically → raw_rs = 1.0 for every bar →
-     MA(raw_rs) = 1.0 → normalized = 1.0. *)
+  (* Stock and benchmark move identically → raw_rs = 1.0 for every weekly bar →
+     MA(raw_rs) = 1.0 → normalized = 1.0. Needs enough daily bars to aggregate
+     to at least [rs_ma_period] weekly bars. *)
   let config = { Summary_compute.default_config with rs_ma_period = 10 } in
   let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
-  let stock_bars = _linear_bars ~n:30 ~start_date ~base:100.0 ~step:1.0 in
-  let benchmark_bars = _linear_bars ~n:30 ~start_date ~base:100.0 ~step:1.0 in
+  let stock_bars = _linear_bars ~n:140 ~start_date ~base:100.0 ~step:1.0 in
+  let benchmark_bars = _linear_bars ~n:140 ~start_date ~base:100.0 ~step:1.0 in
   assert_that
     (Summary_compute.rs_line ~config ~stock_bars ~benchmark_bars)
     (is_some_and (float_equal 1.0))
@@ -123,6 +124,52 @@ let test_rs_line_none_when_too_short _ =
   assert_that
     (Summary_compute.rs_line ~config ~stock_bars ~benchmark_bars)
     is_none
+
+(** The Mansfield zero-line should normalize against a window of ~1 YEAR
+    (52 weekly bars), not ~2.5 months (52 daily bars). This test pins the
+    aggregation boundary: we construct a series where stock = benchmark for
+    every bar except the final week (where stock doubles). Under correct
+    weekly aggregation the 52-week MA averages 51 weeks of raw_rs=1.0 with 1
+    week of raw_rs=2.0 → MA = 53/52. Under the buggy daily path the 52-day
+    MA would include 7 elevated days → MA ≈ 59/52 ≈ 1.1346, yielding a
+    meaningfully different normalized value. *)
+let test_rs_line_uses_weekly_52_window _ =
+  let config = { Summary_compute.default_config with rs_ma_period = 52 } in
+  (* 420 consecutive daily bars starting on a Monday → aggregates to 60 weekly
+     bars (60 complete weeks, no partial week at the tail because 420/7 = 60).
+     Mon 2023-01-02 .. Sun 2024-02-25. *)
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let total_days = 420 in
+  let elevated_days = 7 in
+  let plateau_days = total_days - elevated_days in
+  let make_bars ~price_during_plateau ~price_during_elevated =
+    List.init total_days ~f:(fun i ->
+        let date = Date.add_days start_date i in
+        let close =
+          if i < plateau_days then price_during_plateau
+          else price_during_elevated
+        in
+        _mk_bar ~date ~close)
+  in
+  (* Benchmark flat at 100.0 throughout. Stock flat at 100.0 then doubles to
+     200.0 in the final 7-day block. *)
+  let stock_bars =
+    make_bars ~price_during_plateau:100.0 ~price_during_elevated:200.0
+  in
+  let benchmark_bars =
+    make_bars ~price_during_plateau:100.0 ~price_during_elevated:100.0
+  in
+  (* Hand-computed expected value for the weekly path: the 52-week window
+     contains 51 weeks where raw_rs = 1.0 and 1 week where raw_rs = 2.0. The
+     normalized value at the latest bar is raw_rs_last / MA = 2.0 / (53/52) =
+     104/53. *)
+  let expected_weekly = 104.0 /. 53.0 in
+  (* The buggy daily path would yield 2.0 / (59/52) = 104/59 ≈ 1.7627, which
+     is ~14% different. The epsilon here is tight enough to reject that
+     alternative. *)
+  assert_that
+    (Summary_compute.rs_line ~config ~stock_bars ~benchmark_bars)
+    (is_some_and (float_equal ~epsilon:1e-6 expected_weekly))
 
 (** {1 stage_heuristic tests} *)
 
@@ -183,6 +230,8 @@ let suite =
          "atr_14_none_when_too_short" >:: test_atr_14_none_when_too_short;
          "rs_line_flat_ratio" >:: test_rs_line_flat_ratio;
          "rs_line_none_when_too_short" >:: test_rs_line_none_when_too_short;
+         "rs_line_uses_weekly_52_window"
+         >:: test_rs_line_uses_weekly_52_window;
          "stage_heuristic_some_on_sufficient_history"
          >:: test_stage_heuristic_some_on_sufficient_history;
          "stage_heuristic_none_on_short_history"

--- a/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
@@ -1,0 +1,196 @@
+(** Unit tests for [Summary_compute] — the pure indicator helpers used by the
+    Summary tier. These tests never touch CSV storage or [Price_cache]; they
+    exercise the math directly on synthetic bars. *)
+
+open OUnit2
+open Core
+open Matchers
+module Summary_compute = Bar_loader.Summary_compute
+
+(** {1 Fixture helpers} *)
+
+(** [_mk_bar ~date ~close] produces a minimal flat bar (o=h=l=c=close). *)
+let _mk_bar ~date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close;
+    low_price = close;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+(** [_linear_bars ~n ~start_date ~base ~step] generates [n] consecutive daily
+    bars starting at [start_date]. Close on day [i] (0-indexed) is
+    [base +. step *. Float.of_int i]. Used to produce predictable sequences we
+    can hand-compute averages against. *)
+let _linear_bars ~n ~start_date ~base ~step : Types.Daily_price.t list =
+  List.init n ~f:(fun i ->
+      let date = Date.add_days start_date i in
+      let close = base +. (step *. Float.of_int i) in
+      _mk_bar ~date ~close)
+
+let _mk_ohlc_bar ~date ~o ~h ~l ~c : Types.Daily_price.t =
+  {
+    date;
+    open_price = o;
+    high_price = h;
+    low_price = l;
+    close_price = c;
+    adjusted_close = c;
+    volume = 1_000_000;
+  }
+
+(** {1 ma_30w tests} *)
+
+(** With 30 weekly bars, the MA equals the mean of their closes. We use a decade
+    of daily bars (~260 / year × 1 year = ~260), which [daily_to_weekly] reduces
+    to ~52 weekly bars — enough for 30w MA. *)
+let test_ma_30w_returns_mean _ =
+  let config = Summary_compute.default_config in
+  (* 300 consecutive daily bars starting on a Monday → ~60 weekly bars after
+     aggregation, which is more than [ma_weeks = 30]. *)
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  (* Monday *)
+  let bars = _linear_bars ~n:300 ~start_date ~base:100.0 ~step:1.0 in
+  let result = Summary_compute.ma_30w ~config bars in
+  (* Hand-check: the MA is the mean of the last 30 weekly last-bar closes. The
+     test doesn't need to compute the exact value — only that it's finite and
+     within the plausible range of the generated series. *)
+  assert_that result
+    (is_some_and (is_between (module Float_ord) ~low:100.0 ~high:400.0))
+
+let test_ma_30w_none_when_too_short _ =
+  let config = Summary_compute.default_config in
+  (* 30 daily bars → ~6 weekly bars after aggregation → under the 30-week
+     requirement. *)
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _linear_bars ~n:30 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that (Summary_compute.ma_30w ~config bars) is_none
+
+(** {1 atr_14 tests} *)
+
+(** Flat bars (o=h=l=c) have zero range and zero gap — ATR over 14 days is
+    exactly 0.0. *)
+let test_atr_14_zero_on_flat_bars _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _linear_bars ~n:20 ~start_date ~base:100.0 ~step:0.0 in
+  assert_that
+    (Summary_compute.atr_14 ~config bars)
+    (is_some_and (float_equal 0.0))
+
+(** Known TR sequence: bars with constant high-low range of 2.0 and no gaps →
+    ATR-14 = 2.0. *)
+let test_atr_14_constant_range _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars =
+    List.init 20 ~f:(fun i ->
+        let date = Date.add_days start_date i in
+        (* o=h-1, c=h-1, l=h-3 → range = 2; close = 50 consistently so no gap *)
+        _mk_ohlc_bar ~date ~o:50.0 ~h:51.0 ~l:49.0 ~c:50.0)
+  in
+  assert_that
+    (Summary_compute.atr_14 ~config bars)
+    (is_some_and (float_equal 2.0))
+
+let test_atr_14_none_when_too_short _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _linear_bars ~n:5 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that (Summary_compute.atr_14 ~config bars) is_none
+
+(** {1 rs_line tests} *)
+
+let test_rs_line_flat_ratio _ =
+  (* Stock and benchmark move identically → raw_rs = 1.0 for every bar →
+     MA(raw_rs) = 1.0 → normalized = 1.0. *)
+  let config = { Summary_compute.default_config with rs_ma_period = 10 } in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let stock_bars = _linear_bars ~n:30 ~start_date ~base:100.0 ~step:1.0 in
+  let benchmark_bars = _linear_bars ~n:30 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that
+    (Summary_compute.rs_line ~config ~stock_bars ~benchmark_bars)
+    (is_some_and (float_equal 1.0))
+
+let test_rs_line_none_when_too_short _ =
+  let config = { Summary_compute.default_config with rs_ma_period = 50 } in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let stock_bars = _linear_bars ~n:10 ~start_date ~base:100.0 ~step:1.0 in
+  let benchmark_bars = _linear_bars ~n:10 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that
+    (Summary_compute.rs_line ~config ~stock_bars ~benchmark_bars)
+    is_none
+
+(** {1 stage_heuristic tests} *)
+
+let test_stage_heuristic_some_on_sufficient_history _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2021 ~m:Jan ~d:4 in
+  (* 2 years of daily bars → ~100 weekly bars → enough for ma_period=30. *)
+  let bars = _linear_bars ~n:500 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that (Summary_compute.stage_heuristic ~config bars) (is_some_and __)
+
+let test_stage_heuristic_none_on_short_history _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _linear_bars ~n:20 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that (Summary_compute.stage_heuristic ~config bars) is_none
+
+(** {1 compute_values tests} *)
+
+let test_compute_values_assembles_all_four _ =
+  let config = { Summary_compute.default_config with rs_ma_period = 30 } in
+  let start_date = Date.create_exn ~y:2021 ~m:Jan ~d:4 in
+  let stock_bars = _linear_bars ~n:400 ~start_date ~base:100.0 ~step:1.0 in
+  let benchmark_bars = _linear_bars ~n:400 ~start_date ~base:100.0 ~step:1.0 in
+  let as_of = Date.create_exn ~y:2022 ~m:Feb ~d:5 in
+  let result =
+    Summary_compute.compute_values ~config ~stock_bars ~benchmark_bars ~as_of
+  in
+  assert_that result
+    (is_some_and
+       (all_of
+          [
+            field (fun v -> v.Summary_compute.as_of) (equal_to as_of);
+            field (fun v -> v.Summary_compute.rs_line) (float_equal 1.0);
+            (* Stock identical to benchmark → stage should be classifiable.
+               Just confirm it's present (non-placeholder check covered by
+               stage_heuristic tests). *)
+          ]))
+
+let test_compute_values_none_when_any_helper_fails _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let stock_bars = _linear_bars ~n:10 ~start_date ~base:100.0 ~step:1.0 in
+  let benchmark_bars = _linear_bars ~n:10 ~start_date ~base:100.0 ~step:1.0 in
+  let as_of = Date.create_exn ~y:2023 ~m:Jan ~d:12 in
+  assert_that
+    (Summary_compute.compute_values ~config ~stock_bars ~benchmark_bars ~as_of)
+    is_none
+
+(** {1 Suite} *)
+
+let suite =
+  "Summary_compute"
+  >::: [
+         "ma_30w_returns_mean" >:: test_ma_30w_returns_mean;
+         "ma_30w_none_when_too_short" >:: test_ma_30w_none_when_too_short;
+         "atr_14_zero_on_flat_bars" >:: test_atr_14_zero_on_flat_bars;
+         "atr_14_constant_range" >:: test_atr_14_constant_range;
+         "atr_14_none_when_too_short" >:: test_atr_14_none_when_too_short;
+         "rs_line_flat_ratio" >:: test_rs_line_flat_ratio;
+         "rs_line_none_when_too_short" >:: test_rs_line_none_when_too_short;
+         "stage_heuristic_some_on_sufficient_history"
+         >:: test_stage_heuristic_some_on_sufficient_history;
+         "stage_heuristic_none_on_short_history"
+         >:: test_stage_heuristic_none_on_short_history;
+         "compute_values_assembles_all_four"
+         >:: test_compute_values_assembles_all_four;
+         "compute_values_none_when_any_helper_fails"
+         >:: test_compute_values_none_when_any_helper_fails;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
Stacked on #434. Implements Step 3b (Summary tier) per dev/plans/backtest-tiered-loader-2026-04-19.md.

## Summary

- Adds pure indicator compute helpers in summary_compute.{ml,mli}: 30w MA, ATR-14, Mansfield RS line, stage heuristic.
- compute_values orchestrates and returns None when any indicator is short of data.
- Next commits extend bar_loader with Summary.t + promote/demote/get_summary, and add integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)