### PR TITLE
harness: deep scan Check 12 — stale local jj bookmarks

### DIFF
--- a/dev/health/2026-04-19-deep.md
+++ b/dev/health/2026-04-19-deep.md
@@ -1,7 +1,7 @@
 # Health Report -- 2026-04-19 -- deep
 
 ## Summary
-- Findings: 26  (critical: 0  warnings: 5  info: 21)
+- Findings: 27  (critical: 0  warnings: 5  info: 22)
 - Action required: NO
 
 ## Warnings (should be addressed within 1 week)
@@ -33,6 +33,7 @@
 19. QC calibration: could not extract verdict from `dev/reviews/strategy-wiring-held-symbols.md`
 20. QC calibration: could not extract verdict from `dev/reviews/strategy-wiring.md`
 21. QC calibration: could not extract verdict from `dev/reviews/support-floor-stops.md`
+22. Stale local jj bookmarks: 5 local-only candidate(s), 0 behind-origin bookmark(s) -- see ## Stale Local Bookmarks
 
 ## Metrics
 - Dead code candidates: 0
@@ -44,6 +45,7 @@
 - Architecture graph violations (monitored): 0
 - Status file template violations (forbidden ## Recent Commits): 0
 - Linter exception expiry: 2 expired/unknown, 0 missing review_at
+- Stale local jj bookmarks: local-only=5 behind-origin=0 (jj available: true)
 
 ## TODO/FIXME/HACK Detail
 
@@ -74,6 +76,7 @@ PASS: `arch_layer_test.sh` — referenced
 PASS: `deep_scan_arch_graph_check.sh` — referenced
 PASS: `deep_scan_linter_expiry_check.sh` — referenced
 PASS: `deep_scan_recent_commits_check.sh` — referenced
+PASS: `deep_scan_stale_bookmarks_check.sh` — referenced
 PASS: `deep_scan_trends_check.sh` — referenced
 PASS: `fmt_check.sh` — referenced
 PASS: `linter_file_length.sh` — referenced
@@ -92,6 +95,32 @@ Checks dev/status/*.md for the forbidden '## Recent Commits' heading.
 The template requires omitting this section (content drifts; use git log instead).
 
 No violations found.
+
+## Stale Local Bookmarks
+
+Checks local jj bookmarks for refs no longer needed after PR merges.
+Severity: INFO -- housekeeping only; no false-positive failures.
+
+### Local-only candidates
+
+Bookmarks that exist locally but have no matching @origin entry.
+Protected names (main, master, HEAD, trunk) are excluded.
+
+| Name | Local commit | Last commit description |
+|---|---|---|
+| `feat/backtest-tiered-loader-3b-i-summary-compute` | `sxpkqmns` | feat(bar_loader): add Summary_compute pure indicator helpers (3b-i) |
+| `feat/backtest-tiered-loader-3b-ii-summary-tier` | `knxoxkkn` | feat(bar_loader): Summary tier wiring + integration tests (3b-ii) |
+| `harness/deep-scan-linter-expiry` | `mnktxxkl` | harness: mark deep-scan linter-expiry check complete in status |
+| `harness/deep-scan-stale-bookmarks` | `ttkwrnyk` | harness(deep-scan): bump header count to eleven + list Check 11 |
+| `worktree-agent-a7bbd5c5` | `kqvruspx` | feat(backtest): bar_loader scaffold + Metadata tier (Step 3a) (#434) |
+
+### Behind origin
+
+Bookmarks where local commit is an ancestor of the origin commit
+(origin has moved on -- usually means PR merged, local never refreshed).
+
+No stale local bookmarks found.
+
 
 ## Architecture Graph
 

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -142,10 +142,17 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
      when the milestone lands. Add a check that compares current
      milestone in `weinstein-trading-system-v2.md` against the
      `review_at:` values.~~ — DONE: see Completed section below
-  4. [~] **Stale local jj bookmarks** — bookmarks left around after PRs
-     merge accumulate. Surface them with
-     `jj bookmark list 'glob:*'` filtered against origin.
-     IN_PROGRESS: branch `harness/deep-scan-stale-bookmarks`.
+  4. ~~**Stale local jj bookmarks**~~ — DONE: Check 12 added to
+     `trading/devtools/checks/deep_scan.sh`; enumerates local jj bookmarks
+     via `jj bookmark list --all 'glob:*'`, classifies as (a) local-only
+     (no @origin entry) or (b) behind origin (local is ancestor of remote).
+     Findings emitted under `## Stale Local Bookmarks` in
+     `dev/health/YYYY-MM-DD-deep.md`. Protected names (main/master/HEAD/trunk)
+     excluded. Severity: INFO. Degrades gracefully if jj absent.
+     Smoke test: `trading/devtools/checks/deep_scan_stale_bookmarks_check.sh`.
+     Verify: `dune runtest devtools/checks/` — prints OK; run
+     `sh trading/devtools/checks/deep_scan.sh` — report contains
+     `## Stale Local Bookmarks`.
   Source: `dev/daily/2026-04-14.md` end-of-day audit.
 
 ---

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -142,9 +142,10 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
      when the milestone lands. Add a check that compares current
      milestone in `weinstein-trading-system-v2.md` against the
      `review_at:` values.~~ — DONE: see Completed section below
-  4. **Stale local jj bookmarks** — bookmarks left around after PRs
+  4. [~] **Stale local jj bookmarks** — bookmarks left around after PRs
      merge accumulate. Surface them with
      `jj bookmark list 'glob:*'` filtered against origin.
+     IN_PROGRESS: branch `harness/deep-scan-stale-bookmarks`.
   Source: `dev/daily/2026-04-14.md` end-of-day audit.
 
 ---

--- a/trading/devtools/checks/deep_scan.sh
+++ b/trading/devtools/checks/deep_scan.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Deep scan for health-scanner agent (T3-A).
 #
-# Runs weekly (not on every PR). Performs ten read-only analyses:
+# Runs weekly (not on every PR). Performs twelve read-only analyses:
 #   1. Dead code detection — .ml files not referenced in any dune file
 #   2. Design doc drift — module structure vs eng-design docs
 #   3. TODO/FIXME/HACK accumulation
@@ -12,6 +12,8 @@
 #   8. Trends — followup-item delta + CC distribution delta (T3-G)
 #   9. Architecture graph — import edges vs dependency-rules.md (T3-F)
 #  10. Status file template enforcement — forbidden ## Recent Commits heading
+#  11. Linter exception expiry — review_at annotations vs current milestone/date (T1-K)
+#  12. Stale local jj bookmarks — local refs no longer needed after PR merges
 #
 # Output: dev/health/YYYY-MM-DD-deep.md
 #
@@ -983,6 +985,137 @@ RCEOF
   fi
 done
 
+
+# ────────────────────────────────────────────────────────────────
+# --- Check 12 --- (harness gap sub-item 4: stale local jj bookmarks)
+# Check 12: Stale local jj bookmarks
+#
+# Local jj bookmarks that have no matching remote entry accumulate after
+# PRs merge and the local ref is never cleaned up. This check surfaces:
+#
+#   a) Local-only bookmarks -- exist locally but have no @origin counterpart.
+#      Protected prefixes (main, master, HEAD, trunk) are skipped.
+#      All others are candidates for cleanup.
+#
+#   b) Local bookmarks behind origin -- the bookmark exists on both local
+#      and origin, but the local commit is an ancestor of the origin commit.
+#
+# Local-ahead (unpushed work) and in-sync bookmarks are silently skipped.
+#
+# Severity: INFO (housekeeping; no false-positive FAILs).
+# Degrades gracefully when jj is absent or .jj/ does not exist.
+# Section "## Stale Local Bookmarks" is always emitted in the report.
+# ────────────────────────────────────────────────────────────────
+
+STALE_LOCAL_ONLY_DETAILS=""
+STALE_BEHIND_ORIGIN_DETAILS=""
+STALE_LOCAL_ONLY_COUNT=0
+STALE_BEHIND_COUNT=0
+JJ_AVAILABLE=false
+JJ_SKIP_REASON=""
+
+# Graceful degradation: jj and .jj/ must both be present.
+if ! command -v jj >/dev/null 2>&1; then
+  JJ_SKIP_REASON="jj not available on PATH"
+elif [ ! -d "${REPO_ROOT}/.jj" ]; then
+  JJ_SKIP_REASON=".jj/ directory not found (not a jj repository)"
+else
+  JJ_AVAILABLE=true
+fi
+
+if $JJ_AVAILABLE; then
+  # Enumerate bookmarks. Output format (colocated mode):
+  #   name: CHANGE_ID GIT_HASH description        <- local bookmark
+  #     @git: CHANGE_ID GIT_HASH description      <- git alias (indented, skip)
+  #   name@origin: CHANGE_ID GIT_HASH description <- remote tracking ref
+  #
+  # Parsing rules:
+  #   Local: non-indented line, name portion (before ": ") has no @.
+  #   Remote: line contains "@origin: ".
+  #   Skip: lines starting with whitespace.
+
+  JJ_RAW="$(jj bookmark list --all 'glob:*' 2>/dev/null || true)"
+
+  # Extract local bookmarks: non-indented lines whose name has no @.
+  LOCAL_MAP="$(printf '%s\n' "$JJ_RAW" \
+    | awk '
+      /^[^ \t]/ && !/^[^ \t]*@[^ \t]*:/ {
+        colon = index($0, ": ")
+        if (colon == 0) next
+        name = substr($0, 1, colon - 1)
+        rest = substr($0, colon + 2)
+        n = split(rest, tok, " ")
+        if (n >= 1) print name "=" tok[1]
+      }
+    ' 2>/dev/null || true)"
+
+  # Extract remote tracking entries: lines containing "@origin: ".
+  ORIGIN_MAP="$(printf '%s\n' "$JJ_RAW" \
+    | awk '
+      /@origin: / {
+        at_pos = index($0, "@origin: ")
+        name = substr($0, 1, at_pos - 1)
+        rest = substr($0, at_pos + 9)
+        n = split(rest, tok, " ")
+        if (n >= 1) print name "=" tok[1]
+      }
+    ' 2>/dev/null || true)"
+
+  # Protected bookmark names -- skip even if local-only.
+  _is_protected_bookmark() {
+    case "$1" in
+      main|master|HEAD|trunk) return 0 ;;
+    esac
+    return 1
+  }
+
+  # Process each local bookmark.
+  while IFS='=' read -r bm_name bm_commit; do
+    [ -z "$bm_name" ] && continue
+    _is_protected_bookmark "$bm_name" && continue
+
+    # Look for a matching origin entry.
+    origin_commit="$(printf '%s\n' "$ORIGIN_MAP" \
+      | awk -F'=' -v name="$bm_name" '$1 == name {print $2; exit}' 2>/dev/null || true)"
+
+    if [ -z "$origin_commit" ]; then
+      # Local-only bookmark -- no @origin tracking ref found.
+      STALE_LOCAL_ONLY_COUNT=$((STALE_LOCAL_ONLY_COUNT + 1))
+      desc="$(jj log -r "${bm_commit}" --no-graph \
+        -T 'description.first_line()' 2>/dev/null | head -1 || echo "(unknown)")"
+      STALE_LOCAL_ONLY_DETAILS="${STALE_LOCAL_ONLY_DETAILS}| \`${bm_name}\` | \`${bm_commit}\` | ${desc} |\n"
+    else
+      # Both local and origin exist -- check relative position.
+      if [ "$bm_commit" = "$origin_commit" ]; then
+        : # in-sync -- skip
+      else
+        # Check if local is behind origin: jj log on range local..origin;
+        # non-empty output means local is behind (is an ancestor of origin).
+        # Errors (unrelated histories) are skipped silently.
+        is_behind=false
+        range_out="$(jj log -r "${bm_commit}..${origin_commit}" \
+          --no-graph -T 'change_id' 2>/dev/null || true)"
+        if [ -n "$range_out" ]; then
+          is_behind=true
+        fi
+
+        if $is_behind; then
+          STALE_BEHIND_COUNT=$((STALE_BEHIND_COUNT + 1))
+          STALE_BEHIND_ORIGIN_DETAILS="${STALE_BEHIND_ORIGIN_DETAILS}| \`${bm_name}\` | \`${bm_commit}\` | \`${origin_commit}\` |\n"
+        fi
+        # Local-ahead (unpushed) or unrelated -> silently skip.
+      fi
+    fi
+  done << JJEOF
+$(printf '%s\n' "$LOCAL_MAP")
+JJEOF
+
+  STALE_TOTAL=$((STALE_LOCAL_ONLY_COUNT + STALE_BEHIND_COUNT))
+  if [ "$STALE_TOTAL" -gt 0 ]; then
+    add_info "Stale local jj bookmarks: ${STALE_LOCAL_ONLY_COUNT} local-only candidate(s), ${STALE_BEHIND_COUNT} behind-origin bookmark(s) -- see ## Stale Local Bookmarks"
+  fi
+fi
+
 # ────────────────────────────────────────────────────────────────
 # Check 11: Linter Exception Expiry vs milestone/date (T1-K)
 #
@@ -1185,6 +1318,7 @@ cat >> "$OUTPUT_FILE" <<METRICS_EOF
 - Architecture graph violations (monitored): ${ARCH_GRAPH_VIOLATION_COUNT}
 - Status file template violations (forbidden ## Recent Commits): ${RECENT_COMMITS_COUNT}
 - Linter exception expiry: ${EXPIRY_COUNT} expired/unknown, ${EXPIRY_MISSING_COUNT} missing review_at
+- Stale local jj bookmarks: local-only=${STALE_LOCAL_ONLY_COUNT} behind-origin=${STALE_BEHIND_COUNT} (jj available: ${JJ_AVAILABLE})
 METRICS_EOF
 
 # Append detail sections if non-empty
@@ -1219,6 +1353,39 @@ fi
   else
     printf "**${RECENT_COMMITS_COUNT} violation(s):**\n\n"
     printf '%b' "$RECENT_COMMITS_DETAILS"
+  fi
+} >> "$OUTPUT_FILE"
+
+# Always emit the Stale Local Bookmarks section (Check 12).
+{
+  printf "\n## Stale Local Bookmarks\n\n"
+  printf "Checks local jj bookmarks for refs no longer needed after PR merges.\n"
+  printf "Severity: INFO -- housekeeping only; no false-positive failures.\n\n"
+
+  if ! $JJ_AVAILABLE; then
+    printf "jj not available -- skipping stale bookmark check. (%s)\n" "$JJ_SKIP_REASON"
+  else
+    printf "### Local-only candidates\n\n"
+    printf "Bookmarks that exist locally but have no matching @origin entry.\n"
+    printf "Protected names (main, master, HEAD, trunk) are excluded.\n\n"
+    if [ "$STALE_LOCAL_ONLY_COUNT" -eq 0 ]; then
+      printf "No stale local bookmarks found.\n\n"
+    else
+      printf "| Name | Local commit | Last commit description |\n|---|---|---|\n"
+      printf '%b' "$STALE_LOCAL_ONLY_DETAILS"
+      printf "\n"
+    fi
+
+    printf "### Behind origin\n\n"
+    printf "Bookmarks where local commit is an ancestor of the origin commit\n"
+    printf "(origin has moved on -- usually means PR merged, local never refreshed).\n\n"
+    if [ "$STALE_BEHIND_COUNT" -eq 0 ]; then
+      printf "No stale local bookmarks found.\n\n"
+    else
+      printf "| Name | Local commit | Origin commit |\n|---|---|---|\n"
+      printf '%b' "$STALE_BEHIND_ORIGIN_DETAILS"
+      printf "\n"
+    fi
   fi
 } >> "$OUTPUT_FILE"
 

--- a/trading/devtools/checks/deep_scan_stale_bookmarks_check.sh
+++ b/trading/devtools/checks/deep_scan_stale_bookmarks_check.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Structural smoke test for the deep-scan Stale Local Bookmarks section
+# (sub-item 4 of "Deep scan heuristic gaps" in dev/status/harness.md).
+#
+# Does NOT invoke deep_scan.sh from dune runtest because:
+#   - deep_scan.sh runs weekly (not on every PR) and writes outside the
+#     dune sandbox (dev/health/).
+#
+# Instead, this verifies two things:
+#   1. deep_scan.sh contains the required Check 12 implementation markers
+#      (the stale bookmark detection logic and ## Stale Local Bookmarks
+#      section emission).
+#   2. The most-recent dev/health/*-deep.md report contains a
+#      ## Stale Local Bookmarks section, confirming the script has been
+#      run at least once successfully.
+#
+# How to re-verify the output by hand:
+#   sh trading/devtools/checks/deep_scan.sh
+#   grep '## Stale Local Bookmarks' dev/health/$(date +%Y-%m-%d)-deep.md
+
+set -e
+
+. "$(dirname "$0")/_check_lib.sh"
+
+REPO_ROOT="$(repo_root)"
+DEEP_SCAN="${REPO_ROOT}/trading/devtools/checks/deep_scan.sh"
+[ -f "$DEEP_SCAN" ] || die "deep_scan_stale_bookmarks_check: $DEEP_SCAN does not exist"
+
+fail() {
+  echo "FAIL: deep_scan_stale_bookmarks_check -- $1" >&2
+  exit 1
+}
+
+# -- Part 1: structural check of deep_scan.sh ---------------------------------
+
+# Check 12 marker comment
+grep -qF '# --- Check 12 ---' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing '# --- Check 12 ---' marker comment"
+
+# Check 12 header
+grep -qF 'Check 12: Stale local jj bookmarks' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing 'Check 12: Stale local jj bookmarks' header"
+
+# jj graceful degradation
+grep -qF 'jj not available' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing graceful-degradation message for jj not available"
+
+# Accumulator variables
+grep -qF 'STALE_LOCAL_ONLY_COUNT' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing STALE_LOCAL_ONLY_COUNT accumulator"
+
+grep -qF 'STALE_BEHIND_COUNT' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing STALE_BEHIND_COUNT accumulator"
+
+# jj bookmark list invocation
+grep -qF 'jj bookmark list' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing 'jj bookmark list' invocation"
+
+# Report emits ## Stale Local Bookmarks section
+grep -qF '## Stale Local Bookmarks' "$DEEP_SCAN" \
+  || fail "deep_scan.sh does not emit '## Stale Local Bookmarks' section in report"
+
+# Section has Local-only candidates and Behind origin sub-sections
+grep -qF 'Local-only candidates' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing 'Local-only candidates' sub-section"
+
+grep -qF 'Behind origin' "$DEEP_SCAN" \
+  || fail "deep_scan.sh missing 'Behind origin' sub-section"
+
+# -- Part 2: most-recent deep report has ## Stale Local Bookmarks -------------
+
+HEALTH_DIR="${REPO_ROOT}/dev/health"
+LATEST_DEEP=""
+for f in $(ls -1 "${HEALTH_DIR}"/*-deep.md 2>/dev/null | sort); do
+  LATEST_DEEP="$f"
+done
+
+if [ -z "$LATEST_DEEP" ]; then
+  # No deep report exists yet -- acceptable if deep_scan.sh has never run.
+  echo "INFO: no dev/health/*-deep.md found; skipping report content check."
+else
+  grep -qF '## Stale Local Bookmarks' "$LATEST_DEEP" \
+    || fail "$(basename "$LATEST_DEEP") does not contain '## Stale Local Bookmarks' section -- run: sh trading/devtools/checks/deep_scan.sh"
+fi
+
+echo "OK: deep scan Stale Local Bookmarks section (harness gap sub-item 4) structural check passed."

--- a/trading/devtools/checks/dune
+++ b/trading/devtools/checks/dune
@@ -163,3 +163,14 @@
  (deps _check_lib.sh)
  (action
   (run sh %{dep:deep_scan_linter_expiry_check.sh})))
+
+; Deep scan Stale Local Bookmarks section (harness gap sub-item 4): structural smoke test.
+; Verifies deep_scan.sh contains the Check 12 stale-bookmark detection markers
+; and that the most-recent deep scan report has ## Stale Local Bookmarks.
+; Does NOT run deep_scan.sh (weekly tool, not a per-PR gate).
+
+(rule
+ (alias runtest)
+ (deps _check_lib.sh)
+ (action
+  (run sh %{dep:deep_scan_stale_bookmarks_check.sh})))


### PR DESCRIPTION
## Summary
- Adds Check 12 to `trading/devtools/checks/deep_scan.sh` that surfaces stale local jj bookmarks left around after PRs merge
- Reports two categories: local-only bookmarks (no @origin entry) and local bookmarks behind origin (local is ancestor of remote)
- Emits `## Stale Local Bookmarks` section in `dev/health/YYYY-MM-DD-deep.md` with sub-tables for each category
- Companion smoke test `deep_scan_stale_bookmarks_check.sh` wired into `dune runtest`
- Severity: INFO (housekeeping); degrades gracefully when jj is absent
- **Stacked on #435** (linter-expiry = Check 11; stale-bookmarks = Check 12)

## Renumbering note
Originally both PRs (#435 and #439) added a "Check 11" section, causing a naming collision. After restacking #439 on top of #435: #435 keeps Check 11 (linter exception expiry), #439 becomes Check 12 (stale jj bookmarks). Header count bumped from eleven → twelve.

## Test plan
- [ ] `dune runtest devtools/checks/` — stale bookmarks smoke test prints `OK: ...`
- [ ] `sh trading/devtools/checks/deep_scan.sh` — report contains both `## Stale Local Bookmarks` and `## Linter Exception Expiry` sections
- [ ] Pre-existing fn_length_linter and nesting_linter failures are unrelated to this PR

## Files changed
- `trading/devtools/checks/deep_scan.sh` — Check 12 implementation; header updated to twelve analyses
- `trading/devtools/checks/deep_scan_stale_bookmarks_check.sh` — smoke test (new, references Check 12)
- `trading/devtools/checks/dune` — wires smoke test into `dune runtest`
- `dev/health/2026-04-19-deep.md` — updated report with ## Stale Local Bookmarks section
- `dev/status/harness.md` — marks sub-item 4 DONE (Check 12)

Resolves: dev/status/harness.md "Deep scan heuristic gaps" sub-item 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)