### PR TITLE
agents: add PR sizing rule to feat-agent-template (small-CL discipline)

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -85,6 +85,48 @@ looping — diminishing returns set in quickly and looping wastes budget.
 ### 6. Acceptance Checklist (required, feature-specific items)
 
 ```markdown
+## PR sizing
+
+Prefer **one new module per PR** — the unit is `(module.ml, module.mli,
+test/test_module.ml)` plus its `dune` entry. Three to four files,
+typically 200–500 LOC. This is the "small CL" discipline from
+https://google.github.io/eng-practices/review/developer/small-cls.html
+applied to OCaml: a module is the natural reviewable unit because its
+`.mli` is the contract, the `.ml` is the implementation against that
+contract, and the test pins the observable behavior — reviewing them
+together is high-signal; reviewing them apart is low-signal.
+
+**Rules:**
+
+- **One new module ⇒ one PR.** If your work introduces a new
+  `.ml` + `.mli` pair, that pair (plus its tests + dune entry) is the
+  PR. Wiring that consumes the new module belongs in a separate PR
+  stacked on top.
+- **Multiple new modules ⇒ stacked PRs.** Each module gets its own
+  branch + PR; second module's branch bases off the first module's
+  branch. Use `jst submit` so the stack is reviewable in order.
+- **Hard cap: ~500 LOC per PR.** If your draft commit exceeds 500
+  LOC, stop and look for a module boundary you crossed. Almost always
+  the right split is "the new module" vs "the wiring that consumes it."
+  Status-file edits, plan files, and test fixtures don't count toward
+  the cap — they're context, not implementation.
+- **Pre-PR self-check:** before pushing, run `jj diff --stat`. If
+  output crosses two new-module boundaries (or one new module + its
+  consumer wiring), split before pushing — not after review asks for
+  it. Splitting after a PR opens means re-doing CI, re-running QC,
+  and re-anchoring reviewer context; splitting before is a 10-minute
+  `jj` rearrange.
+- **Does not apply to:** small bug fixes (a 50-LOC patch touching one
+  module is a single PR by definition), single-file refactors, or
+  status-file-only updates. Apply when introducing new modules or
+  meaningfully extending existing ones.
+
+If your plan-file decomposition (per `dev/plans/*.md`) names increments
+that are 800+ LOC, that's a smell — the increment crosses a module
+boundary that should be its own increment. Surface it in the dispatch
+prompt's `## Plan context` so the orchestrator can re-decompose, or
+split it inline yourself if obvious.
+
 ## Acceptance Checklist
 
 QC agents will verify all of the following. Satisfy every item before setting
@@ -94,6 +136,7 @@ status to READY_FOR_REVIEW.
 - [ ] <...>
 - [ ] Every public function in every `.ml` is exported in the corresponding `.mli` with a doc comment
 - [ ] No function exceeds 50 lines
+- [ ] PR diff respects `## PR sizing` rules (≤500 LOC, one new module per PR; status / plan / fixtures don't count)
 - [ ] All configurable parameters routed through config record — no magic numbers
 - [ ] `dune build && dune runtest` passes with zero warnings **on a clean checkout of the branch** — not just on your local worktree. If you are running in `isolation: "worktree"` (the orchestrator default), your working copy is usually but not always a clean checkout — follow `.claude/rules/worktree-isolation.md` to verify (`jj diff --stat` pre-commit, branch ancestry check pre-push, PR file list post-push). If you are NOT in a worktree (rare, legacy runs), re-verify by checking that every module your branch references is either in your commits or already on `main@origin` — do not rely on files sitting in the shared working copy that you did not explicitly commit.
 - [ ] `dune build @fmt` passes (formatter in check mode; equivalent: `dune fmt` produces no diff)

--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -108,6 +108,7 @@ status to READY_FOR_REVIEW.
 
 - [ ] If feature: every public function in every `.ml` is exported in the corresponding `.mli` with a doc comment
 - [ ] If feature: no function exceeds 50 lines
+- [ ] PR diff respects the template's `## PR sizing` rules (≤500 LOC, one new module per PR; status / plan / fixtures don't count)
 - [ ] All configurable parameters routed through config record — no magic numbers
 - [ ] If experiment: scenario files parse via `Scenario.load` (run `dune build`)
 - [ ] If experiment: `dev/experiments/<name>/report.md` includes a comparative table + falsifiable conclusion

--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -59,6 +59,7 @@ Do **not** modify the state machine itself (Initial → FirstCorrection → Trai
 - [ ] `Stops.compute_initial_stop` accepts the output; behaviour under `None` is identical to today's fixed-buffer code path
 - [ ] Smoke test: run `Weinstein_strategy` on cached 2018-2023 data and confirm at least one Stage-2 entry places its initial stop based on a support-floor value (not the fixed-buffer proxy)
 - [ ] `dune build && dune runtest` passes, `dune build @fmt` passes
+- [ ] PR diff respects `## PR sizing` rules from `feat-agent-template.md` (≤500 LOC, one new module per PR)
 - [ ] No changes to screener, portfolio_risk, order_gen, or trading_state
 
 ## Not in scope


### PR DESCRIPTION
## Summary

Teach feat-agents to prefer "one new module per PR" — the natural reviewable unit in OCaml is \`(module.ml, module.mli, test/test_module.ml)\` plus the \`dune\` entry. ~3-4 files, 200-500 LOC.

Inspired by https://google.github.io/eng-practices/review/developer/small-cls.html. Concrete trigger: PR #438 came in at 1050 LOC bundling \`Summary_compute\` (pure indicator math) with the Bar_loader Summary tier wiring. Reviewable but not the smallest reviewable unit; the cleavage between primitive and consumer was obvious in retrospect.

## What changes

### \`feat-agent-template.md\` — new \`## PR sizing\` section

- One new module ⇒ one PR. Wiring that consumes it = separate stacked PR.
- Multiple new modules ⇒ stacked PRs (jst submit).
- Hard cap ~500 LOC; status / plan / fixtures don't count.
- Pre-PR self-check: \`jj diff --stat\` for module-boundary crossings.
- Doesn't apply to bug fixes / single-file refactors / status-only updates.
- If a plan-file increment is 800+ LOC, surface as a smell — re-decompose or split inline.

### Acceptance Checklist

New checklist item in feat-agent-template, feat-backtest, feat-weinstein:

> PR diff respects \`## PR sizing\` rules (≤500 LOC, one new module per PR; status / plan / fixtures don't count)

QC agents will start verifying this.

## Why now

Stacked-dispatch (PR #432, depth=2) makes per-increment sizing more important: each stacked PR is a review burden, and oversized stacks compound the problem. Aligning increment size with module boundaries means stacks stay reviewable at depth 2-3.

## Out of scope

- Hard-enforcing the cap via a linter — defer; the QC checklist is enough for now.
- Retroactive split of #438 — being done in a separate PR (split agent dispatched).

## Test plan

- [x] No code changes; agent definition only.
- [x] \`agent_compliance_check.sh\` will validate the template still has all required sections (no removals).