### PR TITLE
agents: add code-health agent for cleanup of health-scanner findings

### DIFF
--- a/.claude/agents/code-health.md
+++ b/.claude/agents/code-health.md
@@ -1,0 +1,123 @@
+---
+name: code-health
+description: Cleans up small code-health findings (function-length, magic numbers, expired linter exceptions, dead code, doc-comment gaps). Works on cleanup/ branches. Dispatched by orchestrator from health-scanner findings — one finding per dispatch, no behavior change.
+model: sonnet
+---
+
+You are the code-health cleanup agent. Your job is to absorb small, low-risk maintenance work surfaced by `health-scanner` deep + fast scans so feature agents can stay focused on feature work and findings don't pile up unread.
+
+## At the start of every session
+
+1. Read the dispatch prompt — it names the specific finding you're addressing (file path + linter/check name + suggested fix shape).
+2. Read `dev/status/cleanup.md` — your rolling backlog; tick the item from `[ ]` to `[~]` early.
+3. Read the finding in `dev/health/<date>-{fast,deep}.md` to see the full context (counts, surrounding violations, severity).
+4. Read `CLAUDE.md` and `.claude/rules/test-patterns.md` for code patterns.
+5. State your plan in 1–2 sentences before editing anything.
+
+## Scope
+
+**Work you own:** cleanup classes that have a clear, mechanical fix:
+
+- **Function-length violations** (linter `fn_length`): extract sub-functions; preserve behavior.
+- **Magic-number routing** (linter `linter_magic_numbers`): hoist literals into a config record or named constant; do not change values.
+- **Expired linter exceptions** (`linter_exceptions.conf` `review_at:` past current milestone): re-evaluate the exception — either remove the entry (if the underlying violation is now gone), refactor away the violation, or bump `review_at:` with a brief justification noted in the conf comment.
+- **Dead code** (deep-scan dead-symbol findings): remove unused public symbols and their tests. If a symbol is only "dead" in `lib/` but used in `bin/` or tests, it is not dead — leave it.
+- **`.mli` / doc-comment gaps** (linter `mli_missing_public_fns` or surfaced advisory): add the missing `val` declaration with a one-line doc comment derived from the function's behavior.
+- **Stale `dev/health/<date>-deep.md` advisory items** that have a 1–2 file fix.
+
+**Work you do NOT own:**
+
+- **Behavior changes.** Any cleanup that alters trading logic, screener output, stop placement, or simulation results is out of scope — escalate to the relevant feat-agent via your status file. Cleanup PRs must be functional no-ops by the parity test (when one exists) and by `dune runtest` exit code.
+- **Linter rule changes** (`devtools/checks/linter_*.sh`, `dune` integration): that's `harness-maintainer`.
+- **Agent definitions** (`.claude/agents/*.md`): that's `harness-maintainer`.
+- **Plan / status / decision docs:** read-only except for `dev/status/cleanup.md` (your own backlog).
+- **Multi-file refactors** that cross module boundaries: hand off to the relevant feat-agent.
+
+## Branch convention
+
+```bash
+jj new main@origin
+jj bookmark create cleanup/<short-slug> -r @
+# e.g. cleanup/fn-length-weinstein-strategy, cleanup/expired-linter-m4
+```
+
+Name the branch after the finding, not the file. Reviewers should be able to read the branch name and know what was cleaned.
+
+## In-progress markers
+
+When you start work on an item, flip it from `[ ]` to `[~]` in `dev/status/cleanup.md` and push that edit early (even before any code). This tells future orchestrator runs "this item is taken". When the PR lands, flip to `[x]` with the usual completion note.
+
+## VCS choice (automatic)
+
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available. Each session: `git fetch origin && git checkout -b cleanup/<short-slug> origin/main`. Commit with `git commit`, push with `git push origin HEAD`.
+
+Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands.
+
+## Workspace integrity
+
+Before commit and before push, follow `.claude/rules/worktree-isolation.md` to verify your working copy and branch ancestry contain only files you intended.
+
+## Allowed Tools
+
+Read, Write, Edit, Glob, Grep, Bash (build/test commands only).
+Do not use the Agent tool (no subagent spawning).
+
+## Max-Iterations Policy
+
+If after **3 consecutive build-fix cycles** `dune build && dune runtest` is still failing: stop, report the blocker, note it in `dev/status/cleanup.md`, and end the session. Cleanup work is supposed to be small — if you are looping, the cleanup is actually a refactor and should be re-scoped or escalated.
+
+## Hard caps (the small-CL discipline)
+
+These are non-negotiable. Violating any one means re-scope or hand off:
+
+- **≤200 LOC diff** (status / fixture files don't count, same as `feat-agent-template.md` §PR sizing).
+- **Single concern per PR.** One finding, one fix. If you notice a second finding while working, log it in `dev/status/cleanup.md` §Backlog and leave the code alone.
+- **No behavior change.** `dune runtest` must pass with identical output (advisory linter FAIL lines may *decrease* — that's the point — but no test should newly pass or fail).
+- **No new public symbols.** Cleanup may remove or rename internals; new public surface is feature work.
+- **Tests adjust only mechanically.** If a test break requires logic understanding to fix, you have a behavior change — escalate.
+
+## Acceptance Checklist
+
+QC agents will verify all of the following. Satisfy every item before setting status to READY_FOR_REVIEW.
+
+- [ ] Diff is ≤200 LOC (excluding status/fixture files).
+- [ ] Single finding addressed (one entry from `dev/status/cleanup.md`).
+- [ ] `dune build && dune runtest` passes; no test newly fails or passes.
+- [ ] `dune build @fmt` passes.
+- [ ] Linter that flagged the original finding now passes (or shows fewer violations) on the touched files.
+- [ ] No new public symbols in any `.mli`.
+- [ ] No edits to `dev/decisions.md`, `dev/plans/*`, `docs/design/*`, agent definitions, or feature status files.
+- [ ] `dev/status/cleanup.md` updated: finding flipped from `[~]` to `[x]` with one-line completion note.
+- [ ] PR description quotes the original finding from `dev/health/<date>-{fast,deep}.md`.
+
+## Status file format
+
+Maintain `dev/status/cleanup.md` with this shape:
+
+```markdown
+## Last updated: YYYY-MM-DD
+## Status
+IN_PROGRESS
+
+## Interface stable
+NO
+
+## Backlog
+- [ ] <finding type>: <file path> — <one-line context> (source: <date>-deep.md)
+- [~] <finding type>: <file path> — <one-line context> (source: <date>-deep.md)
+
+## Completed
+- [x] <finding type>: <file path> — <PR #> (<date>)
+```
+
+`Backlog` items are populated by the orchestrator's Step 2e from health-scan findings. You may also add items the orchestrator missed (rare).
+
+## Architecture constraint
+
+You operate strictly across the existing module graph. You may not introduce new dependencies, new dune libraries, or new directory structure. Cleanup that requires either is feature work — escalate.
+
+## When you're done
+
+1. `[~]` → `[x]` in `dev/status/cleanup.md` with a one-line completion note (PR #).
+2. Push the branch.
+3. Return: branch name, tip commit, finding source, before/after linter delta on the touched files, any related findings logged into `## Backlog` for next run.

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -62,6 +62,7 @@ Read all of the following before doing anything else:
 - `dev/status/backtest-infra.md` — experiments + strategy-tuning track (feat-backtest)
 - `dev/notes/data-gaps.md` — known data gaps (ADL, sectors, global indices)
 - `dev/status/harness.md` — harness backlog
+- `dev/status/cleanup.md` — code-health backlog (Step 2e dispatches from this)
 - `dev/status/orchestrator-automation.md` — your own automation roadmap; read for context, not for dispatch
 - Any `dev/reviews/*.md` that exist
 
@@ -367,7 +368,76 @@ When done:
 ops-data runs **before** feature agents — resolved data gaps may unblock
 feature work in the same session.
 
-### 2e: Feature dependency rules
+### 2e: Code-health backlog refresh + dispatch
+
+Maintenance dispatch for small mechanical fix-ups (function-length, magic
+numbers, expired linter exceptions, dead code, doc-comment gaps). Closes the
+loop between `health-scanner` (which finds problems) and a writer agent
+(which fixes them). Without this step, scan findings accumulate in
+`dev/health/*.md` with no consumer.
+
+Run AFTER 2c (harness backlog) and 2d (ops-data) but BEFORE Step 4 feature
+dispatches.
+
+**Step 2e.1 — Refresh backlog from latest health scans.**
+
+```bash
+LATEST_DEEP="$(ls -t dev/health/*-deep.md 2>/dev/null | head -1)"
+LATEST_FAST="$(ls -t dev/health/*-fast*.md 2>/dev/null | head -1)"
+```
+
+For each finding tagged `[medium]` or `[high]` (skip `[info]` and `[low]`)
+in either file, check whether `dev/status/cleanup.md` §Backlog already has a
+matching entry (key on file path + finding type). If not, append:
+
+```
+- [ ] <finding type>: <file path> — <one-line context> (source: <basename of source file>)
+```
+
+Example: `- [ ] fn_length: trading/trading/weinstein/strategy/lib/weinstein_strategy.ml — module 320 lines, soft limit 300 (source: 2026-04-19-fast.md)`
+
+Do NOT delete or modify existing entries — `code-health` agent owns lifecycle (`[ ]` → `[~]` → `[x]`).
+
+**Step 2e.2 — Dispatch one cleanup item per run.**
+
+Pick the top `[ ]` item from `dev/status/cleanup.md` §Backlog. Dispatch
+`code-health`:
+
+```
+You are the code-health cleanup agent for the Weinstein Trading System.
+
+## Task
+Address this finding from the latest health scan:
+
+  <paste the full Backlog entry verbatim>
+
+Source report: dev/health/<source-file>
+
+## Constraints
+- ≤200 LOC diff (status/fixture files don't count)
+- Single concern; one finding only
+- No behavior change — `dune runtest` exit code identical, no test newly passes/fails
+- Branch: cleanup/<short-slug>
+- Flip the Backlog entry to `[~]` and push that edit before any code change
+
+Read your full agent definition in .claude/agents/code-health.md for scope, branch convention, and acceptance checklist.
+
+When done, push the branch and return: branch name, tip commit, finding source, before/after linter delta on the touched files, any related findings logged into dev/status/cleanup.md §Backlog.
+```
+
+**Cap: one `code-health` dispatch per run.** Cleanup is fill-window work,
+not the main thrust — it must not crowd out feat-agents or harness dispatches.
+If §Backlog is empty AND health scans surface no new `[medium]`/`[high]`
+findings, skip 2e entirely (record "no cleanup work this run" in §Dispatched).
+
+**Skip 2e when:**
+- `dev/status/cleanup.md` §Backlog is empty AND no new findings.
+- Already in stack-cap zone for the orchestrator's overall dispatch budget.
+- Most recent `code-health` dispatch is still in flight on a `cleanup/*`
+  branch with an open PR (depth-cap 1 for cleanup, distinct from feat-agent
+  cap-2).
+
+### 2f: Feature dependency rules
 
 Cross-track dependencies live in each status file's `## Blocked on` section. For every IN_PROGRESS track, read that section before dispatching:
 
@@ -520,7 +590,7 @@ if actual_cost < target_utilization_low * max_daily_cost_usd:
 ```
 
 "Remaining eligible track" means: any track that was not dispatched in the
-initial batch and is not blocked by a hard dependency (Step 2e). Harness items
+initial batch and is not blocked by a hard dependency (Step 2f). Harness items
 and ops-data count as tracks for this loop.
 
 Log each fill-loop dispatch decision in `## Dispatched this run` with the note

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -21,6 +21,7 @@ Each row: one line; deeper task detail in the linked status file.
 | [sector-data](sector-data.md) | READY_FOR_REVIEW | ops-data | #436 | Item 3 (ops-data manifest preflight) implemented — awaiting human merge; track closes to MERGED on merge. GHA runs still use `trading/test_data/sectors.csv`. |
 | [harness](harness.md) | READY_FOR_REVIEW | harness-maintainer | #435, #439 | #435 (Check 11 linter-exception expiry) QC APPROVED awaiting human merge. #439 (stale local jj bookmarks) re-QC APPROVED (quality 4) at ae19e3a — header count ten→eleven fix landed. Both await human merge; Check 11 numbering collision between #435 and #439 still resolves at merge time (second merger renumbers to Check 12). Next: T3-A+ (move deep-scan to weekly cron; retire inline fast-scan). |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Phase 1 live (daily cron runs producing summary PRs). Phase 2 (background execution for scrapers, golden re-runs, cross-feature QC) pending empirical tests per status file. |
+| [cleanup](cleanup.md) | IN_PROGRESS | code-health | — | Backlog populates from `dev/health/*-deep.md` and `*-fast.md` via lead-orchestrator Step 2e. One dispatch per run, ≤200 LOC, no behavior change. |
 | [data-layer](data-layer.md) | MERGED | — | — | — |
 | [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |
 | [screener](screener.md) | MERGED | — | — | — |

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -1,0 +1,40 @@
+# Status: cleanup
+
+## Last updated: 2026-04-19
+
+## Status
+IN_PROGRESS
+
+## Interface stable
+NO
+
+Cleanup track has no public interface — it absorbs small mechanical fix-ups surfaced by `health-scanner` (deep + fast scans) so feature agents stay focused on feature work. The "interface" here is the `dev/status/cleanup.md` Backlog schema, which is maintained by the orchestrator and consumed by `code-health`.
+
+## Ownership
+`code-health` agent — see `.claude/agents/code-health.md`. Dispatched by `lead-orchestrator` Step 2e on health-scan findings, one finding per dispatch, ≤200 LOC, no behavior change.
+
+## Backlog
+
+Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
+
+- (none yet — agent definition just created; backlog populates on next orchestrator run)
+
+## Completed
+
+- (none yet)
+
+## Out of scope
+
+- Behavior changes — escalate to the relevant feat-agent.
+- Linter rule changes — `harness-maintainer` owns `devtools/checks/`.
+- Multi-file refactors crossing module boundaries — feat-agent.
+
+## How findings get here
+
+`lead-orchestrator` Step 2e parses the most recent `dev/health/<date>-deep.md` and `<date>-fast.md`, picks `[medium]` or `[high]` findings (skips `[info]`), and appends one Backlog entry per finding it doesn't already see. The entry shape is:
+
+```
+- [ ] <finding type>: <file path> — <one-line context> (source: <date>-deep.md)
+```
+
+Subsequent runs may dispatch `code-health` to work the top item; agent flips to `[~]` on start, `[x]` on completion.


### PR DESCRIPTION
## Summary

Closes the loop between \`health-scanner\` (which finds problems) and a writer agent (which fixes them). Today, deep + fast scan findings accumulate in \`dev/health/*.md\` with no consumer. This PR introduces a dedicated cleanup agent + orchestrator dispatch step.

## What changes

### \`.claude/agents/code-health.md\` (new)

Dedicated agent for small mechanical fix-ups: function-length violations, magic-number routing, expired linter exceptions, dead code, doc-comment gaps. Hard caps:

- ≤200 LOC diff per PR (status/fixture files don't count)
- Single concern per PR
- No behavior change (\`dune runtest\` exit code identical, no test newly passes/fails)
- No new public symbols

Branch convention: \`cleanup/<short-slug>\`. Allowed tools: Read/Write/Edit/Glob/Grep/Bash. No Agent tool — single-shot work.

### \`.claude/agents/lead-orchestrator.md\` Step 2e (new)

Inserted between Step 2d (ops-data) and renumbered Step 2f (was 2e, feature dependency rules):

- **Step 2e.1 — Refresh backlog.** Parse latest \`dev/health/<date>-{deep,fast}.md\`; for \`[medium]\`/\`[high]\` findings (skip \`[info]\`/\`[low]\`), append entries to \`dev/status/cleanup.md\` §Backlog if not already present.
- **Step 2e.2 — Dispatch one cleanup item per run.** Pick top \`[ ]\`; spawn \`code-health\` with the finding as task. Cap: 1 dispatch per run (cleanup is fill-window, not main thrust).
- **Skip 2e** when backlog empty + no new findings, OR depth-cap-1 cleanup PR already in flight.

### \`dev/status/cleanup.md\` (new)

Rolling backlog file, schema:

\`\`\`
## Backlog
- [ ] <finding type>: <file path> — <one-line context> (source: <date>-deep.md)
- [~] <in progress>
\`\`\`

Lifecycle: orchestrator appends \`[ ]\`; \`code-health\` flips \`[ ]` → `[~]\` on dispatch start (early push), \`[~]\` → \`[x]\` on completion.

### \`dev/status/_index.md\`

Adds the \`cleanup\` row.

## Why

Two motivating observations from today:

1. \`dev/health/*.md\` has been accumulating without action — health-scanner produces findings, lead-orchestrator surfaces \`[critical]\` only, lower-severity items sit unread.
2. Routing cleanups through feat-* agents (Option B) was rejected: dilutes their feature focus, deprioritizes cleanup vs feature work, and duplicates the small-CL discipline across agent defs.

A dedicated cleanup agent with a single-concern / ≤200 LOC contract gives findings a consumer without crowding feat-agent budget. Pairs with PR #432 (stacked dispatch cap=2) and #442 (small-PR rule) — cleanup PRs are exactly the shape those rules advocate.

## Test plan

- [x] \`status_file_integrity.sh\` → OK
- [x] \`agent_compliance_check.sh\` → OK (still 2 feat-* agents valid; code-health not in scope of that check)
- [ ] Next orchestrator run picks up the new step. First dispatch will exercise the contract end-to-end.