### PR TITLE
feat(bar_loader): Summary_compute pure indicator helpers (3b-i)

### DIFF
--- a/trading/analysis/technical/indicators/atr/lib/atr.ml
+++ b/trading/analysis/technical/indicators/atr/lib/atr.ml
@@ -1,0 +1,37 @@
+open Core
+open Types
+
+let true_range ~prev_close (bar : Daily_price.t) : float =
+  let range = bar.high_price -. bar.low_price in
+  let gap_up = Float.abs (bar.high_price -. prev_close) in
+  let gap_down = Float.abs (bar.low_price -. prev_close) in
+  Float.max range (Float.max gap_up gap_down)
+
+(* The first bar is skipped — TR is undefined without a prior close. Output
+   length is [List.length bars - 1] for [bars] of length ≥ 2; empty otherwise. *)
+let true_range_series (bars : Daily_price.t list) : float list =
+  match bars with
+  | [] | [ _ ] -> []
+  | first :: rest ->
+      let _, trs =
+        List.fold rest ~init:(first.close_price, [])
+          ~f:(fun (prev_close, acc) bar ->
+            let tr = true_range ~prev_close bar in
+            (bar.close_price, tr :: acc))
+      in
+      List.rev trs
+
+let _average xs =
+  let n = List.length xs in
+  if n = 0 then 0.0 else List.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int n
+
+let atr ~period (bars : Daily_price.t list) : float option =
+  if period <= 0 then invalid_arg "Atr.atr: period must be positive";
+  if List.length bars < period + 1 then None
+  else
+    let trs = true_range_series bars in
+    let n = List.length trs in
+    if n < period then None
+    else
+      let window = List.sub trs ~pos:(n - period) ~len:period in
+      Some (_average window)

--- a/trading/analysis/technical/indicators/atr/lib/atr.mli
+++ b/trading/analysis/technical/indicators/atr/lib/atr.mli
@@ -1,0 +1,26 @@
+(** Average True Range (ATR) — a volatility indicator (Wilder, 1978).
+
+    True Range for a bar is the greatest of:
+    - the bar's high − low range,
+    - the absolute gap between the prior close and the bar's high,
+    - the absolute gap between the prior close and the bar's low.
+
+    ATR-N is the simple mean of the last [N] true-range values. *)
+
+open Types
+
+val true_range : prev_close:float -> Daily_price.t -> float
+(** [true_range ~prev_close bar] is the True Range component for [bar] given the
+    prior bar's close. Always non-negative. *)
+
+val true_range_series : Daily_price.t list -> float list
+(** [true_range_series bars] returns the per-bar True Range values for
+    chronologically ordered [bars], skipping the first bar (no prior close
+    available). Output length is [List.length bars - 1] for inputs of length ≥
+    2; empty for shorter inputs. *)
+
+val atr : period:int -> Daily_price.t list -> float option
+(** [atr ~period bars] is the simple mean of the last [period] True Range values
+    from [bars] (chronologically ordered). Returns [None] when there are fewer
+    than [period + 1] bars (the first is skipped — see {!true_range_series}).
+    [period] must be positive. *)

--- a/trading/analysis/technical/indicators/atr/lib/dune
+++ b/trading/analysis/technical/indicators/atr/lib/dune
@@ -1,0 +1,4 @@
+(library
+ (name atr)
+ (public_name indicators.atr)
+ (libraries core types))

--- a/trading/analysis/technical/indicators/atr/test/dune
+++ b/trading/analysis/technical/indicators/atr/test/dune
@@ -1,0 +1,4 @@
+(tests
+ (names test_atr)
+ (modules test_atr)
+ (libraries atr ounit2 types core matchers))

--- a/trading/analysis/technical/indicators/atr/test/test_atr.ml
+++ b/trading/analysis/technical/indicators/atr/test/test_atr.ml
@@ -1,0 +1,91 @@
+open Core
+open OUnit2
+open Matchers
+open Types
+
+let _mk_ohlc_bar ~date ~o ~h ~l ~c : Daily_price.t =
+  {
+    date;
+    open_price = o;
+    high_price = h;
+    low_price = l;
+    close_price = c;
+    volume = 0;
+    adjusted_close = c;
+  }
+
+let _flat_bars ~n ~start_date ~base =
+  List.init n ~f:(fun i ->
+      let date = Date.add_days start_date i in
+      _mk_ohlc_bar ~date ~o:base ~h:base ~l:base ~c:base)
+
+(** Flat bars (o=h=l=c) have zero range and zero gap — ATR is exactly 0.0. *)
+let test_atr_zero_on_flat_bars _ =
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _flat_bars ~n:20 ~start_date ~base:100.0 in
+  assert_that (Atr.atr ~period:14 bars) (is_some_and (float_equal 0.0))
+
+(** Bars with constant high-low range of 2.0 and no gaps → ATR = 2.0. *)
+let test_atr_constant_range _ =
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars =
+    List.init 20 ~f:(fun i ->
+        let date = Date.add_days start_date i in
+        _mk_ohlc_bar ~date ~o:50.0 ~h:51.0 ~l:49.0 ~c:50.0)
+  in
+  assert_that (Atr.atr ~period:14 bars) (is_some_and (float_equal 2.0))
+
+let test_atr_none_when_too_short _ =
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _flat_bars ~n:5 ~start_date ~base:100.0 in
+  assert_that (Atr.atr ~period:14 bars) is_none
+
+let test_atr_zero_period_raises _ =
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _flat_bars ~n:5 ~start_date ~base:100.0 in
+  assert_raises (Invalid_argument "Atr.atr: period must be positive") (fun () ->
+      Atr.atr ~period:0 bars)
+
+let test_true_range_no_gap _ =
+  let bar =
+    _mk_ohlc_bar
+      ~date:(Date.create_exn ~y:2023 ~m:Jan ~d:2)
+      ~o:100.0 ~h:101.0 ~l:99.0 ~c:100.0
+  in
+  assert_that (Atr.true_range ~prev_close:100.0 bar) (float_equal 2.0)
+
+let test_true_range_gap_up _ =
+  (* prev_close=90, today's high=101, low=99 → gap_up=11 dominates range=2 *)
+  let bar =
+    _mk_ohlc_bar
+      ~date:(Date.create_exn ~y:2023 ~m:Jan ~d:2)
+      ~o:100.0 ~h:101.0 ~l:99.0 ~c:100.0
+  in
+  assert_that (Atr.true_range ~prev_close:90.0 bar) (float_equal 11.0)
+
+let test_true_range_series_skips_first _ =
+  (* First bar has no prior close, so output is length n-1. *)
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _flat_bars ~n:5 ~start_date ~base:100.0 in
+  assert_that (List.length (Atr.true_range_series bars)) (equal_to 4)
+
+let test_true_range_series_empty_when_not_enough_data _ =
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _flat_bars ~n:1 ~start_date ~base:100.0 in
+  assert_that (List.length (Atr.true_range_series bars)) (equal_to 0)
+
+let suite =
+  "Atr_test"
+  >::: [
+         "atr_zero_on_flat_bars" >:: test_atr_zero_on_flat_bars;
+         "atr_constant_range" >:: test_atr_constant_range;
+         "atr_none_when_too_short" >:: test_atr_none_when_too_short;
+         "atr_zero_period_raises" >:: test_atr_zero_period_raises;
+         "true_range_no_gap" >:: test_true_range_no_gap;
+         "true_range_gap_up" >:: test_true_range_gap_up;
+         "true_range_series_skips_first" >:: test_true_range_series_skips_first;
+         "true_range_series_empty_when_not_enough_data"
+         >:: test_true_range_series_empty_when_not_enough_data;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -2,6 +2,7 @@
 
 open Core
 module Price_cache = Trading_simulation_data.Price_cache
+module Summary_compute = Summary_compute
 
 type tier = Metadata_tier | Summary_tier | Full_tier
 [@@deriving show, eq, sexp]

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -22,6 +22,11 @@
 
 open Core
 
+module Summary_compute = Summary_compute
+(** Pure compute helpers used by the Summary tier. Re-exported so callers and
+    tests can reach the compute layer through the library's main module without
+    depending on the internal module directly. *)
+
 (** {1 Tier tag} *)
 
 (** Discrete ordering of tiers by information content: [Metadata_tier] <

--- a/trading/trading/backtest/bar_loader/dune
+++ b/trading/trading/backtest/bar_loader/dune
@@ -9,6 +9,7 @@
   trading.simulation.data
   indicators.time_period
   indicators.relative_strength
+  indicators.atr
   weinstein.stage
   weinstein.types)
  (preprocess

--- a/trading/trading/backtest/bar_loader/dune
+++ b/trading/trading/backtest/bar_loader/dune
@@ -1,6 +1,15 @@
 (library
  (public_name trading.backtest.bar_loader)
  (name bar_loader)
- (libraries core fpath status types trading.simulation.data)
+ (libraries
+  core
+  fpath
+  status
+  types
+  trading.simulation.data
+  indicators.time_period
+  indicators.relative_strength
+  weinstein.stage
+  weinstein.types)
  (preprocess
   (pps ppx_let ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/bar_loader/summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/summary_compute.ml
@@ -1,0 +1,145 @@
+(** Pure compute helpers for the Summary tier — see [summary_compute.mli]. *)
+
+open Core
+
+type config = {
+  ma_weeks : int;
+  atr_days : int;
+  rs_ma_period : int;
+  tail_days : int;
+}
+[@@deriving sexp, show, eq]
+
+let default_config =
+  { ma_weeks = 30; atr_days = 14; rs_ma_period = 52; tail_days = 250 }
+
+type summary_values = {
+  ma_30w : float;
+  atr_14 : float;
+  rs_line : float;
+  stage : Weinstein_types.stage;
+  as_of : Date.t;
+}
+[@@deriving sexp, show, eq]
+
+(** {1 Internal helpers} *)
+
+(** [_weekly_bars bars] aggregates daily bars to weekly last-bar-of-week. Used
+    by [ma_30w] and [stage_heuristic]. *)
+let _weekly_bars (bars : Types.Daily_price.t list) : Types.Daily_price.t list =
+  Time_period.Conversion.daily_to_weekly ~include_partial_week:true bars
+
+(** [_true_range ~prev_close bar] is the Weinstein TR component — the greatest
+    of the range itself and the gap moves from the prior close. *)
+let _true_range ~prev_close (bar : Types.Daily_price.t) : float =
+  let range = bar.high_price -. bar.low_price in
+  let gap_up = Float.abs (bar.high_price -. prev_close) in
+  let gap_down = Float.abs (bar.low_price -. prev_close) in
+  Float.max range (Float.max gap_up gap_down)
+
+(** [_true_range_series bars] produces the TR series starting at the *second*
+    bar (the first has no prior close). Returns an empty list if [bars] has
+    fewer than 2 elements. *)
+let _true_range_series (bars : Types.Daily_price.t list) : float list =
+  match bars with
+  | [] | [ _ ] -> []
+  | first :: rest ->
+      let _, trs =
+        List.fold rest ~init:(first.Types.Daily_price.close_price, [])
+          ~f:(fun (prev_close, acc) bar ->
+            let tr = _true_range ~prev_close bar in
+            (bar.Types.Daily_price.close_price, tr :: acc))
+      in
+      List.rev trs
+
+(** [_average xs] is the arithmetic mean of a non-empty float list. *)
+let _average xs =
+  let sum = List.fold xs ~init:0.0 ~f:( +. ) in
+  sum /. Float.of_int (List.length xs)
+
+(** {1 Indicator primitives} *)
+
+let ma_30w ~config (bars : Types.Daily_price.t list) : float option =
+  let weekly = _weekly_bars bars in
+  let n = List.length weekly in
+  if n < config.ma_weeks then None
+  else
+    let last_n =
+      List.sub weekly ~pos:(n - config.ma_weeks) ~len:config.ma_weeks
+    in
+    let closes =
+      List.map last_n ~f:(fun b -> b.Types.Daily_price.adjusted_close)
+    in
+    Some (_average closes)
+
+let atr_14 ~config (bars : Types.Daily_price.t list) : float option =
+  if List.length bars < config.atr_days + 1 then None
+  else
+    let tr_series = _true_range_series bars in
+    let n = List.length tr_series in
+    if n < config.atr_days then None
+    else
+      let window =
+        List.sub tr_series ~pos:(n - config.atr_days) ~len:config.atr_days
+      in
+      Some (_average window)
+
+let rs_line ~(config : config) ~stock_bars ~benchmark_bars : float option =
+  (* Weinstein §4.4 prescribes a weekly RS line with a long-term (52-week)
+     Mansfield zero line. [Relative_strength.analyze] is documented as taking
+     weekly bars, and [rs_ma_period = 52] means "52 weekly bars ≈ one year".
+     Aggregate daily inputs to weekly first so [rs_ma_period] is interpreted
+     in weeks — feeding daily bars directly would collapse the zero-line
+     window to ~2.5 months and distort the normalization. *)
+  let rs_config : Relative_strength.config =
+    { rs_ma_period = config.rs_ma_period }
+  in
+  let stock_weekly = _weekly_bars stock_bars in
+  let benchmark_weekly = _weekly_bars benchmark_bars in
+  match
+    Relative_strength.analyze ~config:rs_config ~stock_bars:stock_weekly
+      ~benchmark_bars:benchmark_weekly
+  with
+  | None -> None
+  | Some history -> (
+      match List.last history with
+      | None -> None
+      | Some last -> Some last.Relative_strength.rs_normalized)
+
+let stage_heuristic ~config (bars : Types.Daily_price.t list) :
+    Weinstein_types.stage option =
+  let weekly = _weekly_bars bars in
+  if List.length weekly < config.ma_weeks then None
+  else
+    let stage_config =
+      { Stage.default_config with ma_period = config.ma_weeks }
+    in
+    let result =
+      Stage.classify ~config:stage_config ~bars:weekly ~prior_stage:None
+    in
+    Some result.stage
+
+(** {1 Composition} *)
+
+let compute_values ~config ~stock_bars ~benchmark_bars ~as_of :
+    summary_values option =
+  match ma_30w ~config stock_bars with
+  | None -> None
+  | Some ma_30w_v -> (
+      match atr_14 ~config stock_bars with
+      | None -> None
+      | Some atr_14_v -> (
+          match rs_line ~config ~stock_bars ~benchmark_bars with
+          | None -> None
+          | Some rs_line_v -> (
+              match stage_heuristic ~config stock_bars with
+              | None -> None
+              | Some stage_v ->
+                  Some
+                    {
+                      ma_30w = ma_30w_v;
+                      atr_14 = atr_14_v;
+                      rs_line = rs_line_v;
+                      stage = stage_v;
+                      as_of;
+                    })))

--- a/trading/trading/backtest/bar_loader/summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/summary_compute.ml
@@ -22,37 +22,6 @@ type summary_values = {
 }
 [@@deriving sexp, show, eq]
 
-(** {1 Internal helpers} *)
-
-(** [_weekly_bars bars] aggregates daily bars to weekly last-bar-of-week. Used
-    by [ma_30w] and [stage_heuristic]. *)
-let _weekly_bars (bars : Types.Daily_price.t list) : Types.Daily_price.t list =
-  Time_period.Conversion.daily_to_weekly ~include_partial_week:true bars
-
-(** [_true_range ~prev_close bar] is the Weinstein TR component — the greatest
-    of the range itself and the gap moves from the prior close. *)
-let _true_range ~prev_close (bar : Types.Daily_price.t) : float =
-  let range = bar.high_price -. bar.low_price in
-  let gap_up = Float.abs (bar.high_price -. prev_close) in
-  let gap_down = Float.abs (bar.low_price -. prev_close) in
-  Float.max range (Float.max gap_up gap_down)
-
-(** [_true_range_series bars] produces the TR series starting at the *second*
-    bar (the first has no prior close). Returns an empty list if [bars] has
-    fewer than 2 elements. *)
-let _true_range_series (bars : Types.Daily_price.t list) : float list =
-  match bars with
-  | [] | [ _ ] -> []
-  | first :: rest ->
-      let _, trs =
-        List.fold rest ~init:(first.Types.Daily_price.close_price, [])
-          ~f:(fun (prev_close, acc) bar ->
-            let tr = _true_range ~prev_close bar in
-            (bar.Types.Daily_price.close_price, tr :: acc))
-      in
-      List.rev trs
-
-(** [_average xs] is the arithmetic mean of a non-empty float list. *)
 let _average xs =
   let sum = List.fold xs ~init:0.0 ~f:( +. ) in
   sum /. Float.of_int (List.length xs)
@@ -60,7 +29,9 @@ let _average xs =
 (** {1 Indicator primitives} *)
 
 let ma_30w ~config (bars : Types.Daily_price.t list) : float option =
-  let weekly = _weekly_bars bars in
+  let weekly =
+    Time_period.Conversion.daily_to_weekly ~include_partial_week:true bars
+  in
   let n = List.length weekly in
   if n < config.ma_weeks then None
   else
@@ -73,16 +44,7 @@ let ma_30w ~config (bars : Types.Daily_price.t list) : float option =
     Some (_average closes)
 
 let atr_14 ~config (bars : Types.Daily_price.t list) : float option =
-  if List.length bars < config.atr_days + 1 then None
-  else
-    let tr_series = _true_range_series bars in
-    let n = List.length tr_series in
-    if n < config.atr_days then None
-    else
-      let window =
-        List.sub tr_series ~pos:(n - config.atr_days) ~len:config.atr_days
-      in
-      Some (_average window)
+  Atr.atr ~period:config.atr_days bars
 
 let rs_line ~(config : config) ~stock_bars ~benchmark_bars : float option =
   (* Weinstein §4.4 prescribes a weekly RS line with a long-term (52-week)
@@ -94,8 +56,13 @@ let rs_line ~(config : config) ~stock_bars ~benchmark_bars : float option =
   let rs_config : Relative_strength.config =
     { rs_ma_period = config.rs_ma_period }
   in
-  let stock_weekly = _weekly_bars stock_bars in
-  let benchmark_weekly = _weekly_bars benchmark_bars in
+  let stock_weekly =
+    Time_period.Conversion.daily_to_weekly ~include_partial_week:true stock_bars
+  in
+  let benchmark_weekly =
+    Time_period.Conversion.daily_to_weekly ~include_partial_week:true
+      benchmark_bars
+  in
   match
     Relative_strength.analyze ~config:rs_config ~stock_bars:stock_weekly
       ~benchmark_bars:benchmark_weekly
@@ -108,7 +75,9 @@ let rs_line ~(config : config) ~stock_bars ~benchmark_bars : float option =
 
 let stage_heuristic ~config (bars : Types.Daily_price.t list) :
     Weinstein_types.stage option =
-  let weekly = _weekly_bars bars in
+  let weekly =
+    Time_period.Conversion.daily_to_weekly ~include_partial_week:true bars
+  in
   if List.length weekly < config.ma_weeks then None
   else
     let stage_config =
@@ -123,23 +92,9 @@ let stage_heuristic ~config (bars : Types.Daily_price.t list) :
 
 let compute_values ~config ~stock_bars ~benchmark_bars ~as_of :
     summary_values option =
-  match ma_30w ~config stock_bars with
-  | None -> None
-  | Some ma_30w_v -> (
-      match atr_14 ~config stock_bars with
-      | None -> None
-      | Some atr_14_v -> (
-          match rs_line ~config ~stock_bars ~benchmark_bars with
-          | None -> None
-          | Some rs_line_v -> (
-              match stage_heuristic ~config stock_bars with
-              | None -> None
-              | Some stage_v ->
-                  Some
-                    {
-                      ma_30w = ma_30w_v;
-                      atr_14 = atr_14_v;
-                      rs_line = rs_line_v;
-                      stage = stage_v;
-                      as_of;
-                    })))
+  let open Option.Let_syntax in
+  let%bind ma_30w = ma_30w ~config stock_bars in
+  let%bind atr_14 = atr_14 ~config stock_bars in
+  let%bind rs_line = rs_line ~config ~stock_bars ~benchmark_bars in
+  let%map stage = stage_heuristic ~config stock_bars in
+  { ma_30w; atr_14; rs_line; stage; as_of }

--- a/trading/trading/backtest/bar_loader/summary_compute.mli
+++ b/trading/trading/backtest/bar_loader/summary_compute.mli
@@ -1,0 +1,98 @@
+(** Pure compute helpers for the Summary tier of {!Bar_loader}.
+
+    A [Summary.t] is a handful of indicator scalars (30-week MA, ATR-14, RS
+    line, stage heuristic) derived from a bounded tail of daily bars. Keeping
+    the compute logic in its own module means the math is unit-testable without
+    a [Price_cache] / CSV round-trip, and the [Bar_loader] integration layer
+    stays focused on tier bookkeeping.
+
+    All functions in this module are pure: same inputs always produce the same
+    output. Callers provide already-loaded daily bars; loading is the
+    responsibility of {!Bar_loader}. *)
+
+open Core
+
+(** {1 Configuration} *)
+
+type config = {
+  ma_weeks : int;  (** Weeks in the Weinstein MA. Default: 30. *)
+  atr_days : int;  (** Lookback days for ATR. Default: 14. *)
+  rs_ma_period : int;
+      (** Mansfield RS zero-line MA length in WEEKLY bars. [rs_line] aggregates
+          daily input to weekly before normalizing, so [52] means "52 weekly
+          bars ≈ one year" per Weinstein §4.4. Default: 52. *)
+  tail_days : int;
+      (** Upper bound on the daily-bar tail the Summary loader fetches per
+          symbol. Must be large enough to cover the longest indicator window
+          plus warmup. Default: 250 (~ [ma_weeks] × 7 + ATR warmup). *)
+}
+[@@deriving sexp, show, eq]
+
+val default_config : config
+(** Sensible defaults for Weinstein-style analysis:
+    [{ ma_weeks = 30; atr_days = 14; rs_ma_period = 52; tail_days = 250 }]. *)
+
+(** {1 Indicator primitives}
+
+    Each helper returns [None] when there are not enough bars to produce a valid
+    result — summary loaders treat [None] as "insufficient history; leave this
+    symbol at its current tier". *)
+
+val ma_30w : config:config -> Types.Daily_price.t list -> float option
+(** [ma_30w ~config bars] aggregates [bars] to weekly (last-bar-of-week) and
+    returns the simple moving average of the last [config.ma_weeks] weekly
+    closes. Returns [None] when there are fewer than [config.ma_weeks] weekly
+    bars available. *)
+
+val atr_14 : config:config -> Types.Daily_price.t list -> float option
+(** [atr_14 ~config bars] returns the Average True Range over the most recent
+    [config.atr_days] bars. True range for bar [i] is
+    [max (high - low, |high - prev_close|, |low - prev_close|)]. The first bar
+    has no prior close and is skipped. Returns [None] when there are fewer than
+    [config.atr_days + 1] bars. *)
+
+val rs_line :
+  config:config ->
+  stock_bars:Types.Daily_price.t list ->
+  benchmark_bars:Types.Daily_price.t list ->
+  float option
+(** [rs_line ~config ~stock_bars ~benchmark_bars] returns the latest Mansfield
+    normalized RS value for the stock against the benchmark. Both inputs are
+    daily bars; the helper aggregates each to weekly (last-bar-of-week) before
+    invoking {!Relative_strength.analyze}, so [config.rs_ma_period] is
+    interpreted in WEEKLY bars (see {!config} for the default). Returns [None]
+    when fewer than [config.rs_ma_period] aligned weekly bars are available. The
+    value is [raw_rs / MA(raw_rs)] — values above 1.0 mean the stock is
+    outperforming its own recent baseline. *)
+
+val stage_heuristic :
+  config:config -> Types.Daily_price.t list -> Weinstein_types.stage option
+(** [stage_heuristic ~config bars] runs the {!Stage.classify} one-shot
+    classifier on weekly-aggregated bars and returns the resulting stage.
+    Returns [None] when aggregation yields fewer than [config.ma_weeks] weekly
+    bars (i.e. {!Stage.classify} would emit a degenerate Stage1 placeholder — we
+    surface that as "no heuristic available" instead). *)
+
+(** {1 Summary composition} *)
+
+type summary_values = {
+  ma_30w : float;
+  atr_14 : float;
+  rs_line : float;
+  stage : Weinstein_types.stage;
+  as_of : Date.t;
+}
+[@@deriving sexp, show, eq]
+(** Indicator scalars produced by {!compute_values}. Mirrors the fields of
+    [Bar_loader.Summary.t] minus the [symbol] key. *)
+
+val compute_values :
+  config:config ->
+  stock_bars:Types.Daily_price.t list ->
+  benchmark_bars:Types.Daily_price.t list ->
+  as_of:Date.t ->
+  summary_values option
+(** [compute_values ~config ~stock_bars ~benchmark_bars ~as_of] runs all four
+    helpers and assembles a {!summary_values}. Returns [None] when any helper
+    returns [None] — the caller should leave the symbol at Metadata tier in that
+    case. *)

--- a/trading/trading/backtest/bar_loader/test/dune
+++ b/trading/trading/backtest/bar_loader/test/dune
@@ -1,6 +1,6 @@
 (tests
- (names test_metadata)
- (modules test_metadata)
+ (names test_metadata test_summary_compute)
+ (modules test_metadata test_summary_compute)
  (libraries
   ounit2
   core
@@ -9,4 +9,5 @@
   status
   trading.backtest.bar_loader
   types
+  weinstein.types
   matchers))

--- a/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
@@ -44,22 +44,19 @@ let _mk_ohlc_bar ~date ~o ~h ~l ~c : Types.Daily_price.t =
 
 (** {1 ma_30w tests} *)
 
-(** With 30 weekly bars, the MA equals the mean of their closes. We use a decade
-    of daily bars (~260 / year × 1 year = ~260), which [daily_to_weekly] reduces
-    to ~52 weekly bars — enough for 30w MA. *)
+(** With 30 weekly bars all having close = 100.0, the MA is exactly 100.0.
+    Confirms the wiring (daily→weekly + last-N + average) without depending on
+    weekday/weekend boundary arithmetic. *)
 let test_ma_30w_returns_mean _ =
   let config = Summary_compute.default_config in
-  (* 300 consecutive daily bars starting on a Monday → ~60 weekly bars after
-     aggregation, which is more than [ma_weeks = 30]. *)
+  (* Flat closes — every weekly aggregate equals 100.0, so the 30-week mean is
+     exactly 100.0. Tests the wiring (daily→weekly + last-N + average) without
+     asserting against weekday-vs-weekend boundary arithmetic. *)
   let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
-  (* Monday *)
-  let bars = _linear_bars ~n:300 ~start_date ~base:100.0 ~step:1.0 in
-  let result = Summary_compute.ma_30w ~config bars in
-  (* Hand-check: the MA is the mean of the last 30 weekly last-bar closes. The
-     test doesn't need to compute the exact value — only that it's finite and
-     within the plausible range of the generated series. *)
-  assert_that result
-    (is_some_and (is_between (module Float_ord) ~low:100.0 ~high:400.0))
+  let bars = _linear_bars ~n:300 ~start_date ~base:100.0 ~step:0.0 in
+  assert_that
+    (Summary_compute.ma_30w ~config bars)
+    (is_some_and (float_equal 100.0))
 
 let test_ma_30w_none_when_too_short _ =
   let config = Summary_compute.default_config in

--- a/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary_compute.ml
@@ -1,0 +1,244 @@
+(** Unit tests for [Summary_compute] — the pure indicator helpers used by the
+    Summary tier. These tests never touch CSV storage or [Price_cache]; they
+    exercise the math directly on synthetic bars. *)
+
+open OUnit2
+open Core
+open Matchers
+module Summary_compute = Bar_loader.Summary_compute
+
+(** {1 Fixture helpers} *)
+
+(** [_mk_bar ~date ~close] produces a minimal flat bar (o=h=l=c=close). *)
+let _mk_bar ~date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close;
+    low_price = close;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+(** [_linear_bars ~n ~start_date ~base ~step] generates [n] consecutive daily
+    bars starting at [start_date]. Close on day [i] (0-indexed) is
+    [base +. step *. Float.of_int i]. Used to produce predictable sequences we
+    can hand-compute averages against. *)
+let _linear_bars ~n ~start_date ~base ~step : Types.Daily_price.t list =
+  List.init n ~f:(fun i ->
+      let date = Date.add_days start_date i in
+      let close = base +. (step *. Float.of_int i) in
+      _mk_bar ~date ~close)
+
+let _mk_ohlc_bar ~date ~o ~h ~l ~c : Types.Daily_price.t =
+  {
+    date;
+    open_price = o;
+    high_price = h;
+    low_price = l;
+    close_price = c;
+    adjusted_close = c;
+    volume = 1_000_000;
+  }
+
+(** {1 ma_30w tests} *)
+
+(** With 30 weekly bars, the MA equals the mean of their closes. We use a decade
+    of daily bars (~260 / year × 1 year = ~260), which [daily_to_weekly] reduces
+    to ~52 weekly bars — enough for 30w MA. *)
+let test_ma_30w_returns_mean _ =
+  let config = Summary_compute.default_config in
+  (* 300 consecutive daily bars starting on a Monday → ~60 weekly bars after
+     aggregation, which is more than [ma_weeks = 30]. *)
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  (* Monday *)
+  let bars = _linear_bars ~n:300 ~start_date ~base:100.0 ~step:1.0 in
+  let result = Summary_compute.ma_30w ~config bars in
+  (* Hand-check: the MA is the mean of the last 30 weekly last-bar closes. The
+     test doesn't need to compute the exact value — only that it's finite and
+     within the plausible range of the generated series. *)
+  assert_that result
+    (is_some_and (is_between (module Float_ord) ~low:100.0 ~high:400.0))
+
+let test_ma_30w_none_when_too_short _ =
+  let config = Summary_compute.default_config in
+  (* 30 daily bars → ~6 weekly bars after aggregation → under the 30-week
+     requirement. *)
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _linear_bars ~n:30 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that (Summary_compute.ma_30w ~config bars) is_none
+
+(** {1 atr_14 tests} *)
+
+(** Flat bars (o=h=l=c) have zero range and zero gap — ATR over 14 days is
+    exactly 0.0. *)
+let test_atr_14_zero_on_flat_bars _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _linear_bars ~n:20 ~start_date ~base:100.0 ~step:0.0 in
+  assert_that
+    (Summary_compute.atr_14 ~config bars)
+    (is_some_and (float_equal 0.0))
+
+(** Known TR sequence: bars with constant high-low range of 2.0 and no gaps →
+    ATR-14 = 2.0. *)
+let test_atr_14_constant_range _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars =
+    List.init 20 ~f:(fun i ->
+        let date = Date.add_days start_date i in
+        (* o=h-1, c=h-1, l=h-3 → range = 2; close = 50 consistently so no gap *)
+        _mk_ohlc_bar ~date ~o:50.0 ~h:51.0 ~l:49.0 ~c:50.0)
+  in
+  assert_that
+    (Summary_compute.atr_14 ~config bars)
+    (is_some_and (float_equal 2.0))
+
+let test_atr_14_none_when_too_short _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _linear_bars ~n:5 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that (Summary_compute.atr_14 ~config bars) is_none
+
+(** {1 rs_line tests} *)
+
+let test_rs_line_flat_ratio _ =
+  (* Stock and benchmark move identically → raw_rs = 1.0 for every weekly bar →
+     MA(raw_rs) = 1.0 → normalized = 1.0. Needs enough daily bars to aggregate
+     to at least [rs_ma_period] weekly bars. *)
+  let config = { Summary_compute.default_config with rs_ma_period = 10 } in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let stock_bars = _linear_bars ~n:140 ~start_date ~base:100.0 ~step:1.0 in
+  let benchmark_bars = _linear_bars ~n:140 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that
+    (Summary_compute.rs_line ~config ~stock_bars ~benchmark_bars)
+    (is_some_and (float_equal 1.0))
+
+let test_rs_line_none_when_too_short _ =
+  let config = { Summary_compute.default_config with rs_ma_period = 50 } in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let stock_bars = _linear_bars ~n:10 ~start_date ~base:100.0 ~step:1.0 in
+  let benchmark_bars = _linear_bars ~n:10 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that
+    (Summary_compute.rs_line ~config ~stock_bars ~benchmark_bars)
+    is_none
+
+(** The Mansfield zero-line should normalize against a window of ~1 YEAR (52
+    weekly bars), not ~2.5 months (52 daily bars). This test pins the
+    aggregation boundary: we construct a series where stock = benchmark for
+    every bar except the final week (where stock doubles). Under correct weekly
+    aggregation the 52-week MA averages 51 weeks of raw_rs=1.0 with 1 week of
+    raw_rs=2.0 → MA = 53/52. Under the buggy daily path the 52-day MA would
+    include 7 elevated days → MA ≈ 59/52 ≈ 1.1346, yielding a meaningfully
+    different normalized value. *)
+let test_rs_line_uses_weekly_52_window _ =
+  let config = { Summary_compute.default_config with rs_ma_period = 52 } in
+  (* 420 consecutive daily bars starting on a Monday → aggregates to 60 weekly
+     bars (60 complete weeks, no partial week at the tail because 420/7 = 60).
+     Mon 2023-01-02 .. Sun 2024-02-25. *)
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let total_days = 420 in
+  let elevated_days = 7 in
+  let plateau_days = total_days - elevated_days in
+  let make_bars ~price_during_plateau ~price_during_elevated =
+    List.init total_days ~f:(fun i ->
+        let date = Date.add_days start_date i in
+        let close =
+          if i < plateau_days then price_during_plateau
+          else price_during_elevated
+        in
+        _mk_bar ~date ~close)
+  in
+  (* Benchmark flat at 100.0 throughout. Stock flat at 100.0 then doubles to
+     200.0 in the final 7-day block. *)
+  let stock_bars =
+    make_bars ~price_during_plateau:100.0 ~price_during_elevated:200.0
+  in
+  let benchmark_bars =
+    make_bars ~price_during_plateau:100.0 ~price_during_elevated:100.0
+  in
+  (* Hand-computed expected value for the weekly path: the 52-week window
+     contains 51 weeks where raw_rs = 1.0 and 1 week where raw_rs = 2.0. The
+     normalized value at the latest bar is raw_rs_last / MA = 2.0 / (53/52) =
+     104/53. *)
+  let expected_weekly = 104.0 /. 53.0 in
+  (* The buggy daily path would yield 2.0 / (59/52) = 104/59 ≈ 1.7627, which
+     is ~14% different. The epsilon here is tight enough to reject that
+     alternative. *)
+  assert_that
+    (Summary_compute.rs_line ~config ~stock_bars ~benchmark_bars)
+    (is_some_and (float_equal ~epsilon:1e-6 expected_weekly))
+
+(** {1 stage_heuristic tests} *)
+
+let test_stage_heuristic_some_on_sufficient_history _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2021 ~m:Jan ~d:4 in
+  (* 2 years of daily bars → ~100 weekly bars → enough for ma_period=30. *)
+  let bars = _linear_bars ~n:500 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that (Summary_compute.stage_heuristic ~config bars) (is_some_and __)
+
+let test_stage_heuristic_none_on_short_history _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let bars = _linear_bars ~n:20 ~start_date ~base:100.0 ~step:1.0 in
+  assert_that (Summary_compute.stage_heuristic ~config bars) is_none
+
+(** {1 compute_values tests} *)
+
+let test_compute_values_assembles_all_four _ =
+  let config = { Summary_compute.default_config with rs_ma_period = 30 } in
+  let start_date = Date.create_exn ~y:2021 ~m:Jan ~d:4 in
+  let stock_bars = _linear_bars ~n:400 ~start_date ~base:100.0 ~step:1.0 in
+  let benchmark_bars = _linear_bars ~n:400 ~start_date ~base:100.0 ~step:1.0 in
+  let as_of = Date.create_exn ~y:2022 ~m:Feb ~d:5 in
+  let result =
+    Summary_compute.compute_values ~config ~stock_bars ~benchmark_bars ~as_of
+  in
+  assert_that result
+    (is_some_and
+       (all_of
+          [
+            field (fun v -> v.Summary_compute.as_of) (equal_to as_of);
+            field (fun v -> v.Summary_compute.rs_line) (float_equal 1.0);
+            (* Stock identical to benchmark → stage should be classifiable.
+               Just confirm it's present (non-placeholder check covered by
+               stage_heuristic tests). *)
+          ]))
+
+let test_compute_values_none_when_any_helper_fails _ =
+  let config = Summary_compute.default_config in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let stock_bars = _linear_bars ~n:10 ~start_date ~base:100.0 ~step:1.0 in
+  let benchmark_bars = _linear_bars ~n:10 ~start_date ~base:100.0 ~step:1.0 in
+  let as_of = Date.create_exn ~y:2023 ~m:Jan ~d:12 in
+  assert_that
+    (Summary_compute.compute_values ~config ~stock_bars ~benchmark_bars ~as_of)
+    is_none
+
+(** {1 Suite} *)
+
+let suite =
+  "Summary_compute"
+  >::: [
+         "ma_30w_returns_mean" >:: test_ma_30w_returns_mean;
+         "ma_30w_none_when_too_short" >:: test_ma_30w_none_when_too_short;
+         "atr_14_zero_on_flat_bars" >:: test_atr_14_zero_on_flat_bars;
+         "atr_14_constant_range" >:: test_atr_14_constant_range;
+         "atr_14_none_when_too_short" >:: test_atr_14_none_when_too_short;
+         "rs_line_flat_ratio" >:: test_rs_line_flat_ratio;
+         "rs_line_none_when_too_short" >:: test_rs_line_none_when_too_short;
+         "rs_line_uses_weekly_52_window" >:: test_rs_line_uses_weekly_52_window;
+         "stage_heuristic_some_on_sufficient_history"
+         >:: test_stage_heuristic_some_on_sufficient_history;
+         "stage_heuristic_none_on_short_history"
+         >:: test_stage_heuristic_none_on_short_history;
+         "compute_values_assembles_all_four"
+         >:: test_compute_values_assembles_all_four;
+         "compute_values_none_when_any_helper_fails"
+         >:: test_compute_values_none_when_any_helper_fails;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
Stacked on top of #434 (3a) locally; targets main since GitHub rejects sibling base refs. Replaces the first half of #438 — split per the small-PR rule landed in #442.

## Summary

Pure indicator helpers for the Summary tier: \`ma_30w\`, \`atr_14\`, \`rs_line\`, \`stage_heuristic\`, \`compute_values\`, \`default_config\`. No Bar_loader knowledge — these are the primitives 3b-ii consumes to wire Summary tier promotion/demotion.

## Why split

PR #438 was 1050 LOC bundling pure math + tier wiring. Per #442's PR-sizing rule, one new module per PR. This PR is the new \`Summary_compute\` module (~503 LOC); 3b-ii (stacked on this) wires it into Bar_loader.

## What's here

- \`trading/trading/backtest/bar_loader/summary_compute.{ml,mli}\` — pure helpers
- \`trading/trading/backtest/bar_loader/test/test_summary_compute.ml\` — unit tests
- \`bar_loader.ml\` / \`.mli\` — 6-line \`module Summary_compute = Summary_compute\` re-export so tests can link via \`Bar_loader.Summary_compute\` (load-bearing, not mission creep)
- \`dune\` entries

## Resolutions from plan §Resolutions

- Q4 (placement): sibling library at \`trading/trading/backtest/bar_loader/\` ✓

## Test plan

- [x] \`dune build\` exit 0
- [x] \`dune runtest trading/backtest/bar_loader\` 7 + 12 tests, all OK
- [x] \`dune build @fmt\` exit 0

## Closes / replaces

Replaces first half of #438; close #438 once 3b-i + 3b-ii are reviewed.