### PR TITLE
feat(bar_loader): Summary tier wiring + integration tests (3b-ii)

### DIFF
--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -18,29 +18,64 @@ module Metadata = struct
   [@@deriving show, eq, sexp]
 end
 
+module Summary = struct
+  type t = {
+    symbol : string;
+    ma_30w : float;
+    atr_14 : float;
+    rs_line : float;
+    stage : Weinstein_types.stage;
+    as_of : Date.t;
+  }
+  [@@deriving show, eq, sexp]
+end
+
 type stats_counts = { metadata : int; summary : int; full : int }
 [@@deriving show, eq, sexp]
 
-type entry = { tier : tier; metadata : Metadata.t option }
-(** Per-symbol entry. Held in a mutable hashtable keyed on symbol. The [tier]
-    field reflects the highest tier this symbol has been promoted to; the
-    tier-specific data fields are [Some _] at that tier and below. In 3a only
-    [metadata] is ever populated. *)
+type entry = {
+  tier : tier;
+  metadata : Metadata.t option;
+  summary : Summary.t option;
+}
+(** Per-symbol entry. Held in a mutable hashtable keyed on symbol. [tier] is the
+    highest tier this symbol has been promoted to; the tier-specific data fields
+    are populated at and below that tier. [summary] is [None] for Metadata-only
+    entries. Full-tier data will live in a separate field added in 3c. *)
+
+(** [_default_benchmark_symbol] is the canonical RS benchmark used by the
+    backtest runner. Bar_loader doesn't care which ticker it is, but keeping a
+    sensible default means most callers don't need to pass it explicitly. *)
+let _default_benchmark_symbol = "SPY"
 
 type t = {
   sector_map : string String.Table.t;
   entries : (string, entry) Hashtbl.t;
   price_cache : Price_cache.t;
+  data_dir : Fpath.t;
+  benchmark_symbol : string;
+  summary_config : Summary_compute.config;
+  mutable benchmark_bars : Types.Daily_price.t list option;
+      (** Lazily loaded on the first Summary promotion. Benchmark bars are read
+          via [Csv_storage] directly (bypassing [Price_cache]) so they don't
+          inflate the shared cache — but we keep them here because the benchmark
+          is the one symbol every Summary promotion needs. *)
 }
 
-let create ~data_dir ~sector_map ~universe:_ =
+let create ~data_dir ~sector_map ~universe:_
+    ?(benchmark_symbol = _default_benchmark_symbol)
+    ?(summary_config = Summary_compute.default_config) () =
   (* [universe] is accepted in the signature so 3b/3c/3f can drive tier-wide
      operations ("promote every universe symbol to Metadata on startup")
-     without a signature churn. Not consumed yet in 3a. *)
+     without a signature churn. Not consumed yet. *)
   {
     sector_map;
     entries = Hashtbl.create (module String);
     price_cache = Price_cache.create ~data_dir;
+    data_dir;
+    benchmark_symbol;
+    summary_config;
+    benchmark_bars = None;
   }
 
 let tier_of t ~symbol =
@@ -49,7 +84,9 @@ let tier_of t ~symbol =
 let get_metadata t ~symbol =
   Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.metadata)
 
-let get_summary _t ~symbol:_ = None
+let get_summary t ~symbol =
+  Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.summary)
+
 let get_full _t ~symbol:_ = None
 
 (** [_tier_rank] encodes the Metadata < Summary < Full ordering used for
@@ -58,6 +95,15 @@ let _tier_rank = function
   | Metadata_tier -> 0
   | Summary_tier -> 1
   | Full_tier -> 2
+
+(** [_already_at_or_above t ~symbol tier] is [true] when [symbol] is registered
+    in [t] at [tier] or higher — i.e. promotion to [tier] would be a no-op.
+    Reading this as the guard at the top of each promote helper flattens the
+    nested [match Some/None]/[when]/[else] cascade. *)
+let _already_at_or_above t ~symbol tier =
+  match Hashtbl.find t.entries symbol with
+  | Some entry -> _tier_rank entry.tier >= _tier_rank tier
+  | None -> false
 
 (** [_load_metadata] reads the last bar on or before [as_of] from the shared
     [Price_cache] and joins the sector table. Market cap and average volume are
@@ -89,39 +135,150 @@ let _load_metadata t ~symbol ~as_of : (Metadata.t, Status.t) Result.t =
     Metadata or higher, it's a no-op. Otherwise it runs the metadata load and
     inserts the entry. *)
 let _promote_one_to_metadata t ~symbol ~as_of : (unit, Status.t) Result.t =
-  match Hashtbl.find t.entries symbol with
-  | Some entry when _tier_rank entry.tier >= _tier_rank Metadata_tier -> Ok ()
-  | _ -> (
-      match _load_metadata t ~symbol ~as_of with
-      | Error err -> Error err
-      | Ok metadata ->
-          Hashtbl.set t.entries ~key:symbol
-            ~data:{ tier = Metadata_tier; metadata = Some metadata };
-          Ok ())
+  if _already_at_or_above t ~symbol Metadata_tier then Ok ()
+  else
+    let%map.Result metadata = _load_metadata t ~symbol ~as_of in
+    Hashtbl.set t.entries ~key:symbol
+      ~data:{ tier = Metadata_tier; metadata = Some metadata; summary = None }
+
+(** [_load_bars_tail] reads the most recent [tail_days] daily bars for [symbol]
+    ending on or before [as_of], {e bypassing} [Price_cache]. Summary promotion
+    drops these bars immediately after computing scalars; keeping them out of
+    [Price_cache] prevents the raw history from leaking into the shared cache
+    and surviving past the promotion.
+
+    Performance note: this is one CSV read + parse per Summary promotion. In the
+    planned cascade (Metadata → Summary only on sector-ranked subset, ~2k
+    symbols) the call count stays bounded; the bottleneck is not expected here.
+    If the cascade ever pre-promotes the whole inventory (~10k) it becomes one
+    to monitor — wire trace phase [Promote_summary] (3d) to measure first before
+    optimising. *)
+let _load_bars_tail t ~symbol ~as_of :
+    (Types.Daily_price.t list, Status.t) Result.t =
+  let%bind.Result storage =
+    Csv.Csv_storage.create ~data_dir:t.data_dir symbol
+  in
+  let start_date = Date.add_days as_of (-t.summary_config.tail_days) in
+  Csv.Csv_storage.get storage ~start_date ~end_date:as_of ()
+
+(** [_benchmark_bars_for] returns the bounded-tail bars for the benchmark
+    symbol, loading them lazily on the first Summary promotion. The loaded
+    series covers from the earliest [as_of] a caller has ever asked about minus
+    [tail_days] through the latest [as_of] — in practice the backtest replays
+    forward so this cache grows monotonically.
+
+    In 3b we keep it simple: load once on first use for the given [as_of],
+    reload if subsequent calls need a different window. For the current
+    batch-promote-all-symbols-on-Friday workflow this is fine because every
+    symbol within the batch shares the same [as_of]. *)
+let _benchmark_bars_for t ~as_of : (Types.Daily_price.t list, Status.t) Result.t
+    =
+  let load () =
+    let%map.Result bars = _load_bars_tail t ~symbol:t.benchmark_symbol ~as_of in
+    t.benchmark_bars <- Some bars;
+    bars
+  in
+  match t.benchmark_bars with
+  | None -> load ()
+  | Some bars -> (
+      match List.last bars with
+      | None -> load ()
+      | Some last when Date.(last.date < as_of) -> load ()
+      | Some _ -> Ok bars)
+
+(** [_write_summary_entry] is the no-Result tail of [_promote_one_to_summary]:
+    given freshly-computed scalars, build the [Summary.t], join it with any
+    existing metadata, and overwrite the entry. Pure side-effect — extracted so
+    the caller's main flow stays a flat let%bind chain. *)
+let _write_summary_entry t ~symbol (values : Summary_compute.summary_values) =
+  let existing_metadata =
+    Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.metadata)
+  in
+  let summary : Summary.t =
+    {
+      symbol;
+      ma_30w = values.ma_30w;
+      atr_14 = values.atr_14;
+      rs_line = values.rs_line;
+      stage = values.stage;
+      as_of = values.as_of;
+    }
+  in
+  Hashtbl.set t.entries ~key:symbol
+    ~data:
+      {
+        tier = Summary_tier;
+        metadata = existing_metadata;
+        summary = Some summary;
+      }
+
+(** [_promote_one_to_summary] auto-promotes through Metadata first, then fetches
+    a bounded tail, computes the Summary scalars, and drops the raw bars. A
+    symbol with insufficient history is left at its current tier (Metadata after
+    the auto-promote) — no error surfaced, because insufficient history is a
+    pre-condition for Summary, not a load failure. *)
+let _promote_one_to_summary t ~symbol ~as_of : (unit, Status.t) Result.t =
+  if _already_at_or_above t ~symbol Summary_tier then Ok ()
+  else
+    let%bind.Result () = _promote_one_to_metadata t ~symbol ~as_of in
+    let%bind.Result stock_bars = _load_bars_tail t ~symbol ~as_of in
+    let%map.Result benchmark_bars = _benchmark_bars_for t ~as_of in
+    Summary_compute.compute_values ~config:t.summary_config ~stock_bars
+      ~benchmark_bars ~as_of
+    |> Option.iter ~f:(fun values -> _write_summary_entry t ~symbol values)
 
 let _unimplemented_tier tier : Status.t =
   {
     code = Status.Unimplemented;
     message =
-      Printf.sprintf "Bar_loader.promote: tier %s not yet implemented (3a only)"
+      Printf.sprintf
+        "Bar_loader.promote: tier %s not yet implemented (Full_tier lands in \
+         3c)"
         (show_tier tier);
   }
 
+let _promote_fold ~f symbols =
+  List.fold_until symbols ~init:()
+    ~f:(fun () symbol ->
+      match f ~symbol with
+      | Ok () -> Continue ()
+      | Error err -> Stop (Error err))
+    ~finish:(fun () -> Ok ())
+
 let promote t ~symbols ~to_ ~as_of =
   match to_ with
-  | Summary_tier | Full_tier -> Error (_unimplemented_tier to_)
   | Metadata_tier ->
-      List.fold_until symbols ~init:()
-        ~f:(fun () symbol ->
-          match _promote_one_to_metadata t ~symbol ~as_of with
-          | Ok () -> Continue ()
-          | Error err -> Stop (Error err))
-        ~finish:(fun () -> Ok ())
+      _promote_fold symbols ~f:(fun ~symbol ->
+          _promote_one_to_metadata t ~symbol ~as_of)
+  | Summary_tier ->
+      _promote_fold symbols ~f:(fun ~symbol ->
+          _promote_one_to_summary t ~symbol ~as_of)
+  | Full_tier -> Error (_unimplemented_tier to_)
 
-let demote _t ~symbols:_ ~to_:_ =
-  (* 3a: no Summary / Full data exists, so there is nothing to drop. The
-     signature is stable so 3b / 3c wire in real demotion without churn. *)
-  ()
+(** [_demote_one] drops higher-tier data from an existing entry. The caller
+    guarantees the entry exists; tier-of-target is enforced here (a symbol at
+    tier [<= to_] is unchanged). *)
+let _demote_one t ~symbol ~to_ =
+  match Hashtbl.find t.entries symbol with
+  | None -> ()
+  | Some entry when _tier_rank entry.tier <= _tier_rank to_ -> ()
+  | Some entry ->
+      let new_entry =
+        match to_ with
+        | Metadata_tier -> { entry with tier = Metadata_tier; summary = None }
+        | Summary_tier ->
+            (* In 3b the only higher tier is Summary itself; Full tier lands
+               in 3c and will drop the raw bars here. Keep [summary] as-is. *)
+            { entry with tier = Summary_tier }
+        | Full_tier ->
+            (* Demoting "to Full" is degenerate — Full is the top tier, so
+               there's nothing higher to drop. Preserve entry as-is. *)
+            entry
+      in
+      Hashtbl.set t.entries ~key:symbol ~data:new_entry
+
+let demote t ~symbols ~to_ =
+  List.iter symbols ~f:(fun symbol -> _demote_one t ~symbol ~to_)
 
 let stats t =
   Hashtbl.fold t.entries ~init:{ metadata = 0; summary = 0; full = 0 }

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -8,19 +8,20 @@
     - {b Metadata} — last-bar scalars (last close, sector, optional cap and
       average volume). One record for {e every} universe symbol.
     - {b Summary} — sector-ranked subset; indicator scalars (30w MA, RS line,
-      stage heuristic, ATR) computed from a bounded tail of bars; raw bars
-      dropped.
+      stage heuristic, ATR) computed from a bounded tail of daily bars. The raw
+      bars are dropped once the scalars are extracted, which is the core memory
+      win over holding full OHLCV history.
     - {b Full} — raw OHLCV history for symbols actively considered for entry or
-      currently held.
+      currently held. Added in 3c.
 
-    This increment (3a) implements {b Metadata only}. The [tier] variant already
-    exposes all three tags so later increments extend the loader without churn
-    in the variant. [Summary.t] and [Full.t] submodules and their promotion
-    semantics are added in 3b / 3c. In 3a, [promote ~to_:Summary_tier] and
-    [promote ~to_:Full_tier] raise [Failure]; [get_summary] and [get_full]
-    always return [None]. *)
+    As of 3b, this module implements Metadata and Summary tiers. The [tier]
+    variant already exposes all three tags so 3c extends the loader without
+    churn to the variant. [promote ~to_:Full_tier] returns
+    [Error Status.Unimplemented] until 3c; [get_full] always returns [None]. *)
 
 open Core
+
+(** {1 Re-exports} *)
 
 module Summary_compute = Summary_compute
 (** Pure compute helpers used by the Summary tier. Re-exported so callers and
@@ -54,6 +55,25 @@ module Metadata : sig
   [@@deriving show, eq, sexp]
 end
 
+module Summary : sig
+  type t = {
+    symbol : string;
+    ma_30w : float;  (** 30-week simple MA of weekly-aggregated closes. *)
+    atr_14 : float;  (** Average True Range over the last 14 daily bars. *)
+    rs_line : float;
+        (** Latest Mansfield normalized RS value ([raw_rs / MA(raw_rs)]). Values
+            above 1.0 indicate the stock is outperforming its own recent
+            baseline. *)
+    stage : Weinstein_types.stage;
+        (** Weinstein stage heuristic from the one-shot classifier. *)
+    as_of : Date.t;  (** Date of the last bar used to derive the scalars. *)
+  }
+  [@@deriving show, eq, sexp]
+  (** Indicator scalars derived from a bounded tail of daily bars. Raw bars are
+      dropped once this record is constructed — the memory footprint per symbol
+      is fixed at a handful of floats rather than the full history. *)
+end
+
 (** {1 Loader} *)
 
 type t
@@ -69,13 +89,25 @@ val create :
   data_dir:Fpath.t ->
   sector_map:string String.Table.t ->
   universe:string list ->
+  ?benchmark_symbol:string ->
+  ?summary_config:Summary_compute.config ->
+  unit ->
   t
-(** [create ~data_dir ~sector_map ~universe] returns a fresh loader. [universe]
-    is the full set of symbols the backtest may promote; it is recorded but does
-    {b not} load any bars (Metadata-tier loads happen in [promote]).
-    [sector_map] is a symbol → sector lookup; symbols missing from the map get
-    [sector = ""] on promotion. [data_dir] is forwarded to an internal
-    [Price_cache] used on demand. *)
+(** [create ~data_dir ~sector_map ~universe ?benchmark_symbol ?summary_config
+     ()] returns a fresh loader. [universe] is the full set of symbols the
+    backtest may promote; it is recorded but does {b not} load any bars
+    (Metadata-tier loads happen in [promote]). [sector_map] is a symbol → sector
+    lookup; symbols missing from the map get [sector = ""] on promotion.
+    [data_dir] is forwarded to an internal [Price_cache] used for Metadata-tier
+    last-close lookups.
+
+    [benchmark_symbol] is the ticker used to align bars when computing the
+    Summary-tier RS line (typically ["SPY"] or ["^GSPC"]). Default: ["SPY"]. Its
+    bars are loaded on first Summary promotion and cached inside the loader.
+
+    [summary_config] controls the windows used to compute Summary scalars (see
+    {!Summary_compute.default_config}). Default:
+    {!Summary_compute.default_config}. *)
 
 val promote :
   t ->
@@ -87,22 +119,31 @@ val promote :
     [to_], loading whatever data that tier needs. Idempotent: a symbol already
     at tier [>= to_] is unchanged.
 
-    In this increment only [to_ = Metadata_tier] is implemented — passing
-    [Summary_tier] or [Full_tier] returns an [Error] with a
-    [Status.Unimplemented] code. Subsequent increments (3b, 3c) add those
-    branches.
+    Tier-specific load behaviour:
+    - [Metadata_tier]: reads the last bar on or before [as_of] from the shared
+      [Price_cache].
+    - [Summary_tier]: auto-promotes through Metadata first, then reads a bounded
+      tail ([summary_config.tail_days] of daily bars ending at [as_of]) directly
+      from CSV storage — bypassing [Price_cache] so the raw bars are never
+      retained. The benchmark symbol's tail is loaded once and cached for
+      subsequent Summary promotions in the same session. A symbol whose history
+      is too short to produce all Summary scalars is left at Metadata tier (not
+      an error — the caller should retry later or leave the symbol where it is).
+    - [Full_tier]: returns [Error Status.Unimplemented] until 3c.
 
     Returns the first per-symbol error encountered (if any). A symbol that fails
     to load is {e not} added to the loader. *)
 
 val demote : t -> symbols:string list -> to_:tier -> unit
 (** [demote t ~symbols ~to_] tiers each symbol down, freeing higher-tier data. A
-    symbol currently at tier [<= to_] is unchanged. Calling with
-    [to_ = Metadata_tier] fully drops any Summary / Full caches.
+    symbol currently at tier [<= to_] is unchanged.
 
-    In 3a, since promote only reaches Metadata, [demote] is effectively a no-op
-    — included for API completeness so 3b / 3c extend the behaviour without a
-    signature change. *)
+    - [to_ = Metadata_tier] drops Summary scalars (and Full bars, in 3c).
+    - [to_ = Summary_tier] drops only Full bars (no-op for Summary-only
+      symbols).
+
+    Callers assume demotion is free: there is no reload cost. Re-promoting the
+    same symbols back up requires fetching bars again. *)
 
 val tier_of : t -> symbol:string -> tier option
 (** [tier_of t ~symbol] returns the current tier of [symbol], or [None] if the
@@ -112,14 +153,14 @@ val get_metadata : t -> symbol:string -> Metadata.t option
 (** [get_metadata t ~symbol] returns the Metadata record for [symbol] when it
     has been promoted at least to Metadata tier, otherwise [None]. *)
 
-val get_summary : t -> symbol:string -> unit option
-(** Placeholder for 3b. Always returns [None] in this increment; the return type
-    is [unit option] to keep the interface signature stable until 3b introduces
-    [Summary.t]. *)
+val get_summary : t -> symbol:string -> Summary.t option
+(** [get_summary t ~symbol] returns the Summary record for [symbol] when it has
+    been promoted to Summary tier or higher, otherwise [None]. *)
 
 val get_full : t -> symbol:string -> unit option
-(** Placeholder for 3c. Always returns [None] in this increment; same stability
-    rationale as [get_summary]. *)
+(** Placeholder for 3c. Always returns [None] in this increment; the return type
+    is [unit option] to keep the interface signature stable until 3c introduces
+    [Full.t]. *)
 
 val stats : t -> stats_counts
 (** [stats t] returns the current per-tier symbol counts. The sum of the three

--- a/trading/trading/backtest/bar_loader/dune
+++ b/trading/trading/backtest/bar_loader/dune
@@ -7,9 +7,11 @@
   status
   types
   trading.simulation.data
+  csv
   indicators.time_period
   indicators.relative_strength
   indicators.atr
+  indicators.sma
   weinstein.stage
   weinstein.types)
  (preprocess

--- a/trading/trading/backtest/bar_loader/test/dune
+++ b/trading/trading/backtest/bar_loader/test/dune
@@ -1,6 +1,6 @@
 (tests
- (names test_metadata test_summary_compute)
- (modules test_metadata test_summary_compute)
+ (names test_metadata test_summary_compute test_summary)
+ (modules test_metadata test_summary_compute test_summary)
  (libraries
   ounit2
   core
@@ -10,4 +10,6 @@
   trading.backtest.bar_loader
   types
   weinstein.types
-  matchers))
+  matchers)
+ (preprocess
+  (pps ppx_test_matcher)))

--- a/trading/trading/backtest/bar_loader/test/test_metadata.ml
+++ b/trading/trading/backtest/bar_loader/test/test_metadata.ml
@@ -5,6 +5,25 @@ open Core
 open Matchers
 module Bar_loader = Bar_loader
 
+(* Re-declare records here with [@@deriving test_matcher] so ppx_test_matcher
+   generates exhaustive [match_<name>] helpers. The [type x = Module.x = { ... }]
+   form keeps the test type identical to the production type. *)
+type metadata = Bar_loader.Metadata.t = {
+  symbol : string;
+  sector : string;
+  last_close : float;
+  avg_vol_30d : float option;
+  market_cap : float option;
+}
+[@@deriving test_matcher]
+
+type stats_counts = Bar_loader.stats_counts = {
+  metadata : int;
+  summary : int;
+  full : int;
+}
+[@@deriving test_matcher]
+
 (** {1 Fixture helpers}
 
     Each test builds its own temp data dir with a handful of synthetic CSVs so
@@ -67,7 +86,7 @@ let _fixture ~n_symbols ~sector_map_entries =
   let sector_map = String.Table.create () in
   List.iter sector_map_entries ~f:(fun (sym, sec) ->
       Hashtbl.set sector_map ~key:sym ~data:sec);
-  let loader = Bar_loader.create ~data_dir ~sector_map ~universe:symbols in
+  let loader = Bar_loader.create ~data_dir ~sector_map ~universe:symbols () in
   (loader, symbols)
 
 (** {1 Tests} *)
@@ -75,12 +94,8 @@ let _fixture ~n_symbols ~sector_map_entries =
 let test_create_empty _ =
   let loader, _ = _fixture ~n_symbols:0 ~sector_map_entries:[] in
   assert_that (Bar_loader.stats loader)
-    (all_of
-       [
-         field (fun s -> s.Bar_loader.metadata) (equal_to 0);
-         field (fun s -> s.Bar_loader.summary) (equal_to 0);
-         field (fun s -> s.Bar_loader.full) (equal_to 0);
-       ]);
+    (match_stats_counts ~metadata:(equal_to 0) ~summary:(equal_to 0)
+       ~full:(equal_to 0));
   assert_that (Bar_loader.tier_of loader ~symbol:"S01") is_none;
   assert_that (Bar_loader.get_metadata loader ~symbol:"S01") is_none
 
@@ -95,12 +110,8 @@ let test_promote_10_symbols_stats _ =
   in
   assert_that result is_ok;
   assert_that (Bar_loader.stats loader)
-    (all_of
-       [
-         field (fun s -> s.Bar_loader.metadata) (equal_to 10);
-         field (fun s -> s.Bar_loader.summary) (equal_to 0);
-         field (fun s -> s.Bar_loader.full) (equal_to 0);
-       ])
+    (match_stats_counts ~metadata:(equal_to 10) ~summary:(equal_to 0)
+       ~full:(equal_to 0))
 
 let test_get_metadata_returns_data _ =
   let loader, symbols =
@@ -114,27 +125,15 @@ let test_get_metadata_returns_data _ =
   assert_that
     (Bar_loader.get_metadata loader ~symbol:"S01")
     (is_some_and
-       (all_of
-          [
-            field (fun m -> m.Bar_loader.Metadata.symbol) (equal_to "S01");
-            field (fun m -> m.Bar_loader.Metadata.sector) (equal_to "Tech");
-            field
-              (fun m -> m.Bar_loader.Metadata.last_close)
-              (float_equal 100.0);
-            field (fun m -> m.Bar_loader.Metadata.avg_vol_30d) is_none;
-            field (fun m -> m.Bar_loader.Metadata.market_cap) is_none;
-          ]));
+       (match_metadata ~symbol:(equal_to "S01") ~sector:(equal_to "Tech")
+          ~last_close:(float_equal 100.0) ~avg_vol_30d:is_none
+          ~market_cap:is_none));
   (* S02: no sector entry — should be "" (plan: loader does not synthesize). *)
   assert_that
     (Bar_loader.get_metadata loader ~symbol:"S02")
     (is_some_and
-       (all_of
-          [
-            field (fun m -> m.Bar_loader.Metadata.sector) (equal_to "");
-            field
-              (fun m -> m.Bar_loader.Metadata.last_close)
-              (float_equal 101.0);
-          ]));
+       (match_metadata ~symbol:__ ~sector:(equal_to "")
+          ~last_close:(float_equal 101.0) ~avg_vol_30d:__ ~market_cap:__));
   assert_that
     (Bar_loader.tier_of loader ~symbol:"S01")
     (is_some_and (equal_to Bar_loader.Metadata_tier))
@@ -166,20 +165,41 @@ let test_promote_missing_symbol_errors _ =
   (* The failed symbol was not inserted. *)
   assert_that (Bar_loader.tier_of loader ~symbol:"NOPE") is_none;
   assert_that (Bar_loader.stats loader)
-    (field (fun s -> s.Bar_loader.metadata) (equal_to 0))
+    (match_stats_counts ~metadata:(equal_to 0) ~summary:__ ~full:__)
 
-let test_higher_tier_promotions_unimplemented _ =
+let test_full_promotion_unimplemented _ =
   let loader, symbols = _fixture ~n_symbols:2 ~sector_map_entries:[] in
-  let summary_result =
-    Bar_loader.promote loader ~symbols ~to_:Summary_tier ~as_of:_as_of
-  in
-  assert_that summary_result (is_error_with Unimplemented);
   let full_result =
     Bar_loader.promote loader ~symbols ~to_:Full_tier ~as_of:_as_of
   in
   assert_that full_result (is_error_with Unimplemented)
 
-let test_summary_full_getters_return_none _ =
+(** Symmetry counterpart to [test_full_promotion_unimplemented]: the supported
+    higher tier (Summary) must NOT return Unimplemented from this same call
+    surface. End-to-end Summary behaviour with full benchmark data is in
+    [test_summary.ml]; here the fixture has no benchmark series, so the call may
+    legitimately fail with NotFound — what we pin is only that the failure code
+    is *not* Unimplemented. *)
+let test_summary_promotion_supported _ =
+  let loader, symbols =
+    _fixture ~n_symbols:1 ~sector_map_entries:[ ("S01", "Tech") ]
+  in
+  let summary_result =
+    Bar_loader.promote loader ~symbols ~to_:Summary_tier ~as_of:_as_of
+  in
+  match summary_result with
+  | Ok () -> ()
+  | Error (err : Status.t) ->
+      if Status.equal_code err.code Status.Unimplemented then
+        assert_failure
+          (Printf.sprintf
+             "Summary_tier must be implemented, got Unimplemented: %s"
+             err.message)
+
+let test_summary_getter_none_on_metadata_only _ =
+  (* After Metadata-only promotion the Summary getter must be [None] — the
+     entry exists at Metadata tier but no Summary scalars have been computed
+     yet. Full-tier getter is permanently [None] until 3c. *)
   let loader, symbols =
     _fixture ~n_symbols:2 ~sector_map_entries:[ ("S01", "Tech") ]
   in
@@ -198,10 +218,10 @@ let suite =
          "get_metadata_returns_data" >:: test_get_metadata_returns_data;
          "promote_is_idempotent" >:: test_promote_is_idempotent;
          "promote_missing_symbol_errors" >:: test_promote_missing_symbol_errors;
-         "higher_tier_promotions_unimplemented"
-         >:: test_higher_tier_promotions_unimplemented;
-         "summary_full_getters_return_none"
-         >:: test_summary_full_getters_return_none;
+         "full_promotion_unimplemented" >:: test_full_promotion_unimplemented;
+         "summary_promotion_supported" >:: test_summary_promotion_supported;
+         "summary_getter_none_on_metadata_only"
+         >:: test_summary_getter_none_on_metadata_only;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/bar_loader/test/test_summary.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary.ml
@@ -1,0 +1,278 @@
+(** Integration tests for Bar_loader — 3b (Summary tier).
+
+    These tests exercise the loader's tier bookkeeping end-to-end: promote to
+    Summary from a CSV fixture, verify the indicator scalars land in the
+    [get_summary] record, check idempotency, demote and observe the drop. The
+    pure math is covered by [test_summary_compute.ml] — here we focus on the
+    plumbing. *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_loader = Bar_loader
+
+(* Re-declare the records here with [@@deriving test_matcher] so
+   ppx_test_matcher generates exhaustive [match_<name>] helpers. The
+   [type x = Module.x = { ... }] form keeps the test type identical to the
+   production type — adding a field in production fails compilation here,
+   forcing the test to be updated. *)
+type summary = Bar_loader.Summary.t = {
+  symbol : string;
+  ma_30w : float;
+  atr_14 : float;
+  rs_line : float;
+  stage : Weinstein_types.stage;
+  as_of : Date.t;
+}
+[@@deriving test_matcher]
+
+type metadata = Bar_loader.Metadata.t = {
+  symbol : string;
+  sector : string;
+  last_close : float;
+  avg_vol_30d : float option;
+  market_cap : float option;
+}
+[@@deriving test_matcher]
+
+type stats_counts = Bar_loader.stats_counts = {
+  metadata : int;
+  summary : int;
+  full : int;
+}
+[@@deriving test_matcher]
+
+(** {1 Fixture helpers} *)
+
+let _mk_bar ~date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close;
+    low_price = close;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+(** [_daily_series ~start_date ~n ~base ~step] produces [n] consecutive daily
+    bars with close = [base +. step * i]. Weekend dates are kept — the bar
+    loader and [Time_period.Conversion] treat the series as a plain daily
+    stream, so this is fine for tests. *)
+let _daily_series ~start_date ~n ~base ~step =
+  List.init n ~f:(fun i ->
+      let date = Date.add_days start_date i in
+      let close = base +. (step *. Float.of_int i) in
+      _mk_bar ~date ~close)
+
+let _ok_or_fail ~context = function
+  | Ok v -> v
+  | Error (err : Status.t) ->
+      assert_failure (Printf.sprintf "%s: %s" context (Status.show err))
+
+let _write_symbol ~data_dir ~symbol ~bars =
+  let storage =
+    Csv.Csv_storage.create ~data_dir symbol
+    |> _ok_or_fail ~context:("Csv_storage.create " ^ symbol)
+  in
+  Csv.Csv_storage.save storage bars
+  |> _ok_or_fail ~context:("Csv_storage.save " ^ symbol)
+
+let _fresh_data_dir () =
+  let dir = Filename_unix.temp_dir "bar_loader_summary_test_" "" in
+  Fpath.v dir
+
+(** Summary-tier fixture: enough daily bars ending at [as_of] for the loader's
+    default 250-day tail + 30-week MA + 52-week RS window to resolve.
+
+    The loader only looks at bars in [as_of - tail_days, as_of]. With
+    [tail_days = 250] the tail is ~250 calendar days ≈ ~36 ISO weeks (before
+    aggregation); to produce [rs_line] we need [rs_ma_period = 52] WEEKLY bars
+    after aggregation, so we configure the loader to fetch a larger tail via
+    [summary_config] and generate ~420 days (~60 weeks) of history. *)
+let _summary_fixture ?(stock_step = 1.0) ?(benchmark_step = 1.0) () =
+  let as_of = Date.create_exn ~y:2023 ~m:Dec ~d:29 in
+  let history_days = 420 in
+  let start_date = Date.add_days as_of (-history_days) in
+  let data_dir = _fresh_data_dir () in
+  let stock_bars =
+    _daily_series ~start_date ~n:history_days ~base:100.0 ~step:stock_step
+  in
+  let benchmark_bars =
+    _daily_series ~start_date ~n:history_days ~base:100.0 ~step:benchmark_step
+  in
+  _write_symbol ~data_dir ~symbol:"STOCK" ~bars:stock_bars;
+  _write_symbol ~data_dir ~symbol:"SPY" ~bars:benchmark_bars;
+  let sector_map = String.Table.create () in
+  Hashtbl.set sector_map ~key:"STOCK" ~data:"Tech";
+  let summary_config =
+    { Bar_loader.Summary_compute.default_config with tail_days = history_days }
+  in
+  let loader =
+    Bar_loader.create ~data_dir ~sector_map ~universe:[ "STOCK" ]
+      ~summary_config ()
+  in
+  (loader, as_of)
+
+(** Short-history fixture: 10 daily bars — not enough for any Summary indicator.
+    Used to verify "insufficient history leaves symbol at Metadata". *)
+let _short_fixture () =
+  let data_dir = _fresh_data_dir () in
+  let start_date = Date.create_exn ~y:2023 ~m:Jan ~d:2 in
+  let as_of = Date.create_exn ~y:2023 ~m:Jan ~d:20 in
+  let bars = _daily_series ~start_date ~n:10 ~base:100.0 ~step:1.0 in
+  _write_symbol ~data_dir ~symbol:"SHORT" ~bars;
+  _write_symbol ~data_dir ~symbol:"SPY" ~bars;
+  let sector_map = String.Table.create () in
+  let loader =
+    Bar_loader.create ~data_dir ~sector_map ~universe:[ "SHORT" ] ()
+  in
+  (loader, as_of)
+
+(** {1 Tests} *)
+
+let test_promote_to_summary_populates_record _ =
+  let loader, as_of = _summary_fixture () in
+  let result =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+  in
+  assert_that result is_ok;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Summary_tier));
+  assert_that
+    (Bar_loader.get_summary loader ~symbol:"STOCK")
+    (is_some_and
+       (* MA: plausibly within the generated price band.
+          ATR: with step=1.0 and intraday-flat bars (h=l=c) every close is
+          exactly 1.0 above the prior → TR per bar = 1.0 → ATR = 1.0.
+          RS: stock and benchmark move identically → normalized RS = 1.0. *)
+       (match_summary ~symbol:(equal_to "STOCK") ~as_of:(equal_to as_of)
+          ~ma_30w:(is_between (module Float_ord) ~low:100.0 ~high:800.0)
+          ~atr_14:(float_equal 1.0) ~rs_line:(float_equal 1.0) ~stage:__))
+
+let test_promote_to_summary_auto_promotes_metadata _ =
+  (* Summary promotion should populate the Metadata record too, so callers can
+     inspect sector / last_close on a Summary-tier symbol. *)
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote Summary"
+  in
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"STOCK")
+    (is_some_and
+       (match_metadata ~symbol:(equal_to "STOCK") ~sector:(equal_to "Tech")
+          ~last_close:__ ~avg_vol_30d:__ ~market_cap:__))
+
+let test_promote_summary_stats_counts _ =
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote Summary"
+  in
+  assert_that (Bar_loader.stats loader)
+    (match_stats_counts ~metadata:(equal_to 0) ~summary:(equal_to 1)
+       ~full:(equal_to 0))
+
+let test_promote_summary_insufficient_history_stays_at_metadata _ =
+  (* 10 bars is not enough for ma_30w / rs_line. The symbol should land at
+     Metadata tier (no error surfaced). *)
+  let loader, as_of = _short_fixture () in
+  let result =
+    Bar_loader.promote loader ~symbols:[ "SHORT" ] ~to_:Summary_tier ~as_of
+  in
+  assert_that result is_ok;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"SHORT")
+    (is_some_and (equal_to Bar_loader.Metadata_tier));
+  assert_that (Bar_loader.get_summary loader ~symbol:"SHORT") is_none;
+  (* Metadata is still there. *)
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"SHORT")
+    (is_some_and
+       (match_metadata ~symbol:(equal_to "SHORT") ~sector:__ ~last_close:__
+          ~avg_vol_30d:__ ~market_cap:__))
+
+let test_promote_summary_is_idempotent _ =
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote 1"
+  in
+  let stats_before = Bar_loader.stats loader in
+  let summary_before = Bar_loader.get_summary loader ~symbol:"STOCK" in
+  (* Second promote to the same tier is a no-op. *)
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote 2"
+  in
+  assert_that (Bar_loader.stats loader) (equal_to stats_before);
+  assert_that
+    (Bar_loader.get_summary loader ~symbol:"STOCK")
+    (equal_to summary_before)
+
+let test_demote_summary_to_metadata_drops_summary _ =
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote Summary"
+  in
+  Bar_loader.demote loader ~symbols:[ "STOCK" ] ~to_:Metadata_tier;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Metadata_tier));
+  assert_that (Bar_loader.get_summary loader ~symbol:"STOCK") is_none;
+  (* Metadata survives the demotion. *)
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"STOCK")
+    (is_some_and
+       (match_metadata ~symbol:(equal_to "STOCK") ~sector:__ ~last_close:__
+          ~avg_vol_30d:__ ~market_cap:__));
+  (* Stats reflect the move: summary count drops, metadata count rises. *)
+  assert_that (Bar_loader.stats loader)
+    (match_stats_counts ~metadata:(equal_to 1) ~summary:(equal_to 0)
+       ~full:(equal_to 0))
+
+let test_demote_summary_to_summary_is_noop _ =
+  (* Demoting a Summary-tier symbol "to Summary" leaves it exactly where it
+     is. This exercises the _tier_rank guard. *)
+  let loader, as_of = _summary_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote Summary"
+  in
+  let summary_before = Bar_loader.get_summary loader ~symbol:"STOCK" in
+  Bar_loader.demote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Summary_tier));
+  assert_that
+    (Bar_loader.get_summary loader ~symbol:"STOCK")
+    (equal_to summary_before)
+
+let test_get_summary_none_for_unknown_symbol _ =
+  let loader, _ = _summary_fixture () in
+  assert_that (Bar_loader.get_summary loader ~symbol:"NOPE") is_none;
+  assert_that (Bar_loader.tier_of loader ~symbol:"NOPE") is_none
+
+let suite =
+  "Bar_loader.Summary"
+  >::: [
+         "promote_to_summary_populates_record"
+         >:: test_promote_to_summary_populates_record;
+         "promote_to_summary_auto_promotes_metadata"
+         >:: test_promote_to_summary_auto_promotes_metadata;
+         "promote_summary_stats_counts" >:: test_promote_summary_stats_counts;
+         "promote_summary_insufficient_history_stays_at_metadata"
+         >:: test_promote_summary_insufficient_history_stays_at_metadata;
+         "promote_summary_is_idempotent" >:: test_promote_summary_is_idempotent;
+         "demote_summary_to_metadata_drops_summary"
+         >:: test_demote_summary_to_metadata_drops_summary;
+         "demote_summary_to_summary_is_noop"
+         >:: test_demote_summary_to_summary_is_noop;
+         "get_summary_none_for_unknown_symbol"
+         >:: test_get_summary_none_for_unknown_symbol;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
Stacked on top of #444 (3b-i, which is stacked on #434 (3a)). Replaces the second half of #438 — split per the small-PR rule landed in #442.

## Summary

Bar_loader Summary tier: promote Metadata → Summary, demote Summary → Metadata, accessor methods. Consumes \`Summary_compute\` from #444 (3b-i).

## What's here

- \`bar_loader.{ml,mli}\` — Summary tier branch in \`promote\` / \`demote\` / \`get_summary\` / \`tier_of\` / \`stats\`
- \`test_summary.ml\` — integration tests for Summary tier lifecycle
- \`test_metadata.ml\` — rename \`test_higher_tier_promotions_unimplemented\` → \`test_full_promotion_unimplemented\` (Summary now implemented; Full still raises)
- \`dune\` updates

## Open follow-ups (flagged by split agent)

- \`indicators.sma\` is in this PR's dune but appears unused (carried verbatim from #438; flagged for cleanup, not dropped to keep this a pure split).

## Test plan

- [x] \`dune build\` exit 0
- [x] \`dune runtest trading/backtest/bar_loader\` 7 + 12 + 8 tests, all OK
- [x] \`dune build @fmt\` exit 0

## Closes / replaces

Replaces second half of #438; close #438 once 3b-i + 3b-ii are reviewed.