### PR TITLE
feat(bar_loader): Full tier + promotion semantics (3c)

### DIFF
--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -5,7 +5,7 @@
 ## Status
 READY_FOR_REVIEW
 
-Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) at #447 (draft, based on main). 3d (tracer phases) is the next increment.
+Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) at #447 (awaiting merge; QC APPROVED run-4). 3d (tracer phases) is the next increment.
 
 ## Interface stable
 NO
@@ -13,7 +13,7 @@ NO
 All three tier getters now return their proper typed option: `get_metadata : Metadata.t option`, `get_summary : Summary.t option`, `get_full : Full.t option`. Core `Bar_loader.create` / `promote` / `demote` / `tier_of` / `stats` signatures remain stable; `create` gained optional `?full_config` in 3c. Remaining churn will come from 3d (tracer phase plumbing may add an optional trace arg to `create`), 3e (runner wiring), and 3f (tiered runner path).
 
 ## Open PR
-- #447 — feat/backtest-tiered-loader-3c-full-tier — 3c based on main (draft, awaiting QC).
+- #447 — feat/backtest-tiered-loader-3c-full-tier — 3c based on main, QC APPROVED run-4, awaiting human merge.
 
 ## Blocked on
 - None. 3d depends on 3c merging.

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -3,6 +3,7 @@
 open Core
 module Price_cache = Trading_simulation_data.Price_cache
 module Summary_compute = Summary_compute
+module Full_compute = Full_compute
 
 type tier = Metadata_tier | Summary_tier | Full_tier
 [@@deriving show, eq, sexp]
@@ -30,6 +31,11 @@ module Summary = struct
   [@@deriving show, eq, sexp]
 end
 
+module Full = struct
+  type t = { symbol : string; bars : Types.Daily_price.t list; as_of : Date.t }
+  [@@deriving show, eq]
+end
+
 type stats_counts = { metadata : int; summary : int; full : int }
 [@@deriving show, eq, sexp]
 
@@ -37,11 +43,12 @@ type entry = {
   tier : tier;
   metadata : Metadata.t option;
   summary : Summary.t option;
+  full : Full.t option;
 }
 (** Per-symbol entry. Held in a mutable hashtable keyed on symbol. [tier] is the
     highest tier this symbol has been promoted to; the tier-specific data fields
     are populated at and below that tier. [summary] is [None] for Metadata-only
-    entries. Full-tier data will live in a separate field added in 3c. *)
+    entries. [full] is [None] for everything below Full tier. *)
 
 (** [_default_benchmark_symbol] is the canonical RS benchmark used by the
     backtest runner. Bar_loader doesn't care which ticker it is, but keeping a
@@ -55,6 +62,7 @@ type t = {
   data_dir : Fpath.t;
   benchmark_symbol : string;
   summary_config : Summary_compute.config;
+  full_config : Full_compute.config;
   mutable benchmark_bars : Types.Daily_price.t list option;
       (** Lazily loaded on the first Summary promotion. Benchmark bars are read
           via [Csv_storage] directly (bypassing [Price_cache]) so they don't
@@ -64,7 +72,8 @@ type t = {
 
 let create ~data_dir ~sector_map ~universe:_
     ?(benchmark_symbol = _default_benchmark_symbol)
-    ?(summary_config = Summary_compute.default_config) () =
+    ?(summary_config = Summary_compute.default_config)
+    ?(full_config = Full_compute.default_config) () =
   (* [universe] is accepted in the signature so 3b/3c/3f can drive tier-wide
      operations ("promote every universe symbol to Metadata on startup")
      without a signature churn. Not consumed yet. *)
@@ -75,6 +84,7 @@ let create ~data_dir ~sector_map ~universe:_
     data_dir;
     benchmark_symbol;
     summary_config;
+    full_config;
     benchmark_bars = None;
   }
 
@@ -87,7 +97,8 @@ let get_metadata t ~symbol =
 let get_summary t ~symbol =
   Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.summary)
 
-let get_full _t ~symbol:_ = None
+let get_full t ~symbol =
+  Option.bind (Hashtbl.find t.entries symbol) ~f:(fun e -> e.full)
 
 (** [_tier_rank] encodes the Metadata < Summary < Full ordering used for
     idempotent promotion: a symbol at tier [>= to_] is left alone. *)
@@ -139,7 +150,13 @@ let _promote_one_to_metadata t ~symbol ~as_of : (unit, Status.t) Result.t =
   else
     let%map.Result metadata = _load_metadata t ~symbol ~as_of in
     Hashtbl.set t.entries ~key:symbol
-      ~data:{ tier = Metadata_tier; metadata = Some metadata; summary = None }
+      ~data:
+        {
+          tier = Metadata_tier;
+          metadata = Some metadata;
+          summary = None;
+          full = None;
+        }
 
 (** [_load_bars_tail] reads the most recent [tail_days] daily bars for [symbol]
     ending on or before [as_of], {e bypassing} [Price_cache]. Summary promotion
@@ -147,18 +164,21 @@ let _promote_one_to_metadata t ~symbol ~as_of : (unit, Status.t) Result.t =
     [Price_cache] prevents the raw history from leaking into the shared cache
     and surviving past the promotion.
 
-    Performance note: this is one CSV read + parse per Summary promotion. In the
-    planned cascade (Metadata → Summary only on sector-ranked subset, ~2k
-    symbols) the call count stays bounded; the bottleneck is not expected here.
-    If the cascade ever pre-promotes the whole inventory (~10k) it becomes one
-    to monitor — wire trace phase [Promote_summary] (3d) to measure first before
-    optimising. *)
-let _load_bars_tail t ~symbol ~as_of :
+    Parameterized on [tail_days] so Full-tier promotion (which wants a larger
+    window for complete strategy analysis) can reuse the same CSV path without
+    duplicating the load logic.
+
+    Performance note: this is one CSV read + parse per promote. In the planned
+    cascade (Metadata → Summary only on sector-ranked subset, ~2k symbols; Full
+    on ~200 candidates) the call count stays bounded; the bottleneck is not
+    expected here. Wire trace phase [Promote_summary]/[Promote_full] (3d) to
+    measure first before optimising. *)
+let _load_bars_tail t ~symbol ~as_of ~tail_days :
     (Types.Daily_price.t list, Status.t) Result.t =
   let%bind.Result storage =
     Csv.Csv_storage.create ~data_dir:t.data_dir symbol
   in
-  let start_date = Date.add_days as_of (-t.summary_config.tail_days) in
+  let start_date = Date.add_days as_of (-tail_days) in
   Csv.Csv_storage.get storage ~start_date ~end_date:as_of ()
 
 (** [_benchmark_bars_for] returns the bounded-tail bars for the benchmark
@@ -174,7 +194,10 @@ let _load_bars_tail t ~symbol ~as_of :
 let _benchmark_bars_for t ~as_of : (Types.Daily_price.t list, Status.t) Result.t
     =
   let load () =
-    let%map.Result bars = _load_bars_tail t ~symbol:t.benchmark_symbol ~as_of in
+    let%map.Result bars =
+      _load_bars_tail t ~symbol:t.benchmark_symbol ~as_of
+        ~tail_days:t.summary_config.tail_days
+    in
     t.benchmark_bars <- Some bars;
     bars
   in
@@ -210,6 +233,7 @@ let _write_summary_entry t ~symbol (values : Summary_compute.summary_values) =
         tier = Summary_tier;
         metadata = existing_metadata;
         summary = Some summary;
+        full = None;
       }
 
 (** [_promote_one_to_summary] auto-promotes through Metadata first, then fetches
@@ -221,21 +245,48 @@ let _promote_one_to_summary t ~symbol ~as_of : (unit, Status.t) Result.t =
   if _already_at_or_above t ~symbol Summary_tier then Ok ()
   else
     let%bind.Result () = _promote_one_to_metadata t ~symbol ~as_of in
-    let%bind.Result stock_bars = _load_bars_tail t ~symbol ~as_of in
+    let%bind.Result stock_bars =
+      _load_bars_tail t ~symbol ~as_of ~tail_days:t.summary_config.tail_days
+    in
     let%map.Result benchmark_bars = _benchmark_bars_for t ~as_of in
     Summary_compute.compute_values ~config:t.summary_config ~stock_bars
       ~benchmark_bars ~as_of
     |> Option.iter ~f:(fun values -> _write_summary_entry t ~symbol values)
 
-let _unimplemented_tier tier : Status.t =
-  {
-    code = Status.Unimplemented;
-    message =
-      Printf.sprintf
-        "Bar_loader.promote: tier %s not yet implemented (Full_tier lands in \
-         3c)"
-        (show_tier tier);
-  }
+(** [_write_full_entry] is the no-Result tail of [_promote_one_to_full]: builds
+    the [Full.t] from freshly-loaded bars, joins with any existing metadata /
+    summary, and overwrites the entry. Pure side-effect — extracted so the
+    caller's main flow stays a flat let%bind chain. *)
+let _write_full_entry t ~symbol (values : Full_compute.full_values) =
+  let existing = Hashtbl.find t.entries symbol in
+  let existing_metadata = Option.bind existing ~f:(fun e -> e.metadata) in
+  let existing_summary = Option.bind existing ~f:(fun e -> e.summary) in
+  let full : Full.t = { symbol; bars = values.bars; as_of = values.as_of } in
+  Hashtbl.set t.entries ~key:symbol
+    ~data:
+      {
+        tier = Full_tier;
+        metadata = existing_metadata;
+        summary = existing_summary;
+        full = Some full;
+      }
+
+(** [_promote_one_to_full] auto-promotes through Summary first (which itself
+    cascades through Metadata). If the Summary promote leaves the symbol below
+    Summary tier (insufficient history), Full promotion is skipped — the symbol
+    stays at whatever lower tier it reached. Otherwise we load the full OHLCV
+    tail and retain the raw bars on the entry. *)
+let _promote_one_to_full t ~symbol ~as_of : (unit, Status.t) Result.t =
+  if _already_at_or_above t ~symbol Full_tier then Ok ()
+  else
+    let%bind.Result () = _promote_one_to_summary t ~symbol ~as_of in
+    if not (_already_at_or_above t ~symbol Summary_tier) then Ok ()
+    else
+      let%map.Result bars =
+        _load_bars_tail t ~symbol ~as_of ~tail_days:t.full_config.tail_days
+      in
+      Full_compute.compute_values ~bars
+      |> Option.iter ~f:(fun values -> _write_full_entry t ~symbol values)
 
 let _promote_fold ~f symbols =
   List.fold_until symbols ~init:()
@@ -253,7 +304,9 @@ let promote t ~symbols ~to_ ~as_of =
   | Summary_tier ->
       _promote_fold symbols ~f:(fun ~symbol ->
           _promote_one_to_summary t ~symbol ~as_of)
-  | Full_tier -> Error (_unimplemented_tier to_)
+  | Full_tier ->
+      _promote_fold symbols ~f:(fun ~symbol ->
+          _promote_one_to_full t ~symbol ~as_of)
 
 (** [_demote_one] drops higher-tier data from an existing entry. The caller
     guarantees the entry exists; tier-of-target is enforced here (a symbol at
@@ -265,11 +318,15 @@ let _demote_one t ~symbol ~to_ =
   | Some entry ->
       let new_entry =
         match to_ with
-        | Metadata_tier -> { entry with tier = Metadata_tier; summary = None }
+        | Metadata_tier ->
+            (* Drop both Summary scalars and Full bars. Per plan §Resolutions
+               #6: Full → Metadata is a full drop; re-promotion recomputes
+               Summary. *)
+            { entry with tier = Metadata_tier; summary = None; full = None }
         | Summary_tier ->
-            (* In 3b the only higher tier is Summary itself; Full tier lands
-               in 3c and will drop the raw bars here. Keep [summary] as-is. *)
-            { entry with tier = Summary_tier }
+            (* Drop Full bars, keep Summary scalars. Cheap reversal for
+               "candidate no longer held but may re-enter soon". *)
+            { entry with tier = Summary_tier; full = None }
         | Full_tier ->
             (* Demoting "to Full" is degenerate — Full is the top tier, so
                there's nothing higher to drop. Preserve entry as-is. *)

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -12,12 +12,14 @@
       bars are dropped once the scalars are extracted, which is the core memory
       win over holding full OHLCV history.
     - {b Full} — raw OHLCV history for symbols actively considered for entry or
-      currently held. Added in 3c.
+      currently held. Full-tier promotions load a bounded tail of daily bars and
+      retain them in the loader's own cache; demotion drops the bars.
 
-    As of 3b, this module implements Metadata and Summary tiers. The [tier]
-    variant already exposes all three tags so 3c extends the loader without
-    churn to the variant. [promote ~to_:Full_tier] returns
-    [Error Status.Unimplemented] until 3c; [get_full] always returns [None]. *)
+    As of 3c, the loader implements all three tiers. Full-tier promotion
+    auto-promotes through Metadata and Summary first; demotion of a Full-tier
+    symbol to Summary drops the raw bars (and keeps the Summary scalars), and
+    demotion to Metadata drops both (per plan §Resolutions #6: Full → Metadata
+    is a full drop; re-promotion recomputes). *)
 
 open Core
 
@@ -27,6 +29,10 @@ module Summary_compute = Summary_compute
 (** Pure compute helpers used by the Summary tier. Re-exported so callers and
     tests can reach the compute layer through the library's main module without
     depending on the internal module directly. *)
+
+module Full_compute = Full_compute
+(** Pure compute helpers used by the Full tier. Re-exported for the same reason
+    as {!Summary_compute}. *)
 
 (** {1 Tier tag} *)
 
@@ -74,6 +80,25 @@ module Summary : sig
       is fixed at a handful of floats rather than the full history. *)
 end
 
+module Full : sig
+  type t = {
+    symbol : string;
+    bars : Types.Daily_price.t list;
+        (** OHLCV history loaded from CSV, covering
+            [[as_of - full_config.tail_days, as_of]]. Ordered ascending by date.
+        *)
+    as_of : Date.t;  (** Date of the last bar in [bars]. *)
+  }
+  [@@deriving show, eq]
+  (** Complete-history tier data for symbols under active consideration. Unlike
+      {!Summary.t}, the raw bars are retained so callers can drive the full
+      Weinstein analysis pipeline (daily price path, weekly aggregation,
+      breakout detection). Memory cost is proportional to [List.length bars];
+      callers control the fleet size via {!promote} / {!demote}.
+      [Types.Daily_price.t] has no sexp converters, so this record omits [sexp]
+      — use [show] for test/debug output. *)
+end
+
 (** {1 Loader} *)
 
 type t
@@ -91,13 +116,14 @@ val create :
   universe:string list ->
   ?benchmark_symbol:string ->
   ?summary_config:Summary_compute.config ->
+  ?full_config:Full_compute.config ->
   unit ->
   t
 (** [create ~data_dir ~sector_map ~universe ?benchmark_symbol ?summary_config
-     ()] returns a fresh loader. [universe] is the full set of symbols the
-    backtest may promote; it is recorded but does {b not} load any bars
-    (Metadata-tier loads happen in [promote]). [sector_map] is a symbol → sector
-    lookup; symbols missing from the map get [sector = ""] on promotion.
+     ?full_config ()] returns a fresh loader. [universe] is the full set of
+    symbols the backtest may promote; it is recorded but does {b not} load any
+    bars (Metadata-tier loads happen in [promote]). [sector_map] is a symbol →
+    sector lookup; symbols missing from the map get [sector = ""] on promotion.
     [data_dir] is forwarded to an internal [Price_cache] used for Metadata-tier
     last-close lookups.
 
@@ -107,7 +133,11 @@ val create :
 
     [summary_config] controls the windows used to compute Summary scalars (see
     {!Summary_compute.default_config}). Default:
-    {!Summary_compute.default_config}. *)
+    {!Summary_compute.default_config}.
+
+    [full_config] controls the length of the OHLCV tail fetched on Full-tier
+    promotion (see {!Full_compute.default_config}). Default:
+    {!Full_compute.default_config}. *)
 
 val promote :
   t ->
@@ -129,7 +159,11 @@ val promote :
       subsequent Summary promotions in the same session. A symbol whose history
       is too short to produce all Summary scalars is left at Metadata tier (not
       an error — the caller should retry later or leave the symbol where it is).
-    - [Full_tier]: returns [Error Status.Unimplemented] until 3c.
+    - [Full_tier]: auto-promotes through Metadata and Summary first, then reads
+      a bounded OHLCV tail ([full_config.tail_days]) and retains the raw bars on
+      the entry. A symbol that could not be promoted to Summary (insufficient
+      history) is left at whatever lower tier it reached — Full promotion is
+      skipped, not erroring.
 
     Returns the first per-symbol error encountered (if any). A symbol that fails
     to load is {e not} added to the loader. *)
@@ -138,8 +172,8 @@ val demote : t -> symbols:string list -> to_:tier -> unit
 (** [demote t ~symbols ~to_] tiers each symbol down, freeing higher-tier data. A
     symbol currently at tier [<= to_] is unchanged.
 
-    - [to_ = Metadata_tier] drops Summary scalars (and Full bars, in 3c).
-    - [to_ = Summary_tier] drops only Full bars (no-op for Summary-only
+    - [to_ = Metadata_tier] drops Summary scalars {e and} any Full-tier bars.
+    - [to_ = Summary_tier] drops only Full-tier bars (no-op for Summary-only
       symbols).
 
     Callers assume demotion is free: there is no reload cost. Re-promoting the
@@ -157,10 +191,9 @@ val get_summary : t -> symbol:string -> Summary.t option
 (** [get_summary t ~symbol] returns the Summary record for [symbol] when it has
     been promoted to Summary tier or higher, otherwise [None]. *)
 
-val get_full : t -> symbol:string -> unit option
-(** Placeholder for 3c. Always returns [None] in this increment; the return type
-    is [unit option] to keep the interface signature stable until 3c introduces
-    [Full.t]. *)
+val get_full : t -> symbol:string -> Full.t option
+(** [get_full t ~symbol] returns the Full-tier record for [symbol] when it has
+    been promoted to Full tier, otherwise [None]. *)
 
 val stats : t -> stats_counts
 (** [stats t] returns the current per-tier symbol counts. The sum of the three

--- a/trading/trading/backtest/bar_loader/full_compute.ml
+++ b/trading/trading/backtest/bar_loader/full_compute.ml
@@ -1,0 +1,18 @@
+(** Pure compute helpers for the Full tier — see [full_compute.mli]. *)
+
+open Core
+
+type config = { tail_days : int } [@@deriving sexp, show, eq]
+
+(** Default tail: ~7 years of trading days. Enough to hold a 30-week MA plus
+    several years of daily path history — the shape the Weinstein pipeline
+    expects for breakout detection and path simulation. *)
+let default_config = { tail_days = 1800 }
+
+type full_values = { bars : Types.Daily_price.t list; as_of : Date.t }
+[@@deriving show, eq]
+
+let compute_values ~bars =
+  match List.last bars with
+  | None -> None
+  | Some last -> Some { bars; as_of = last.Types.Daily_price.date }

--- a/trading/trading/backtest/bar_loader/full_compute.mli
+++ b/trading/trading/backtest/bar_loader/full_compute.mli
@@ -1,0 +1,49 @@
+(** Pure compute helpers for the Full tier of {!Bar_loader}.
+
+    A Full-tier record is a raw OHLCV tail for one symbol — the shape the
+    strategy pipeline needs for breakout detection, daily path simulation, and
+    weekly aggregation. This module is the pure build step that turns a list of
+    bars into the scalars {!Bar_loader.Full.t} needs (validates non-emptiness,
+    captures the final bar's date as [as_of]).
+
+    Keeping the build logic here mirrors {!Summary_compute}: the integration
+    layer in {!Bar_loader} handles CSV loading and tier bookkeeping, while this
+    module stays free of I/O and is unit-testable against synthetic bar lists.
+
+    All functions in this module are pure. *)
+
+open Core
+
+(** {1 Configuration} *)
+
+type config = {
+  tail_days : int;
+      (** Upper bound on the daily-bar tail the Full loader fetches per symbol.
+          Must be large enough to cover the longest analysis window the strategy
+          uses. Default: 1800 (~ 7 years of trading days — enough for a 30-week
+          MA plus several years of path history). *)
+}
+[@@deriving sexp, show, eq]
+
+val default_config : config
+(** Sensible default: [{ tail_days = 1800 }]. *)
+
+(** {1 Build step} *)
+
+type full_values = {
+  bars : Types.Daily_price.t list;
+      (** The input bars, retained verbatim. Ordered ascending by date. *)
+  as_of : Date.t;  (** Date of the last bar in [bars]. *)
+}
+[@@deriving show, eq]
+(** Mirrors {!Bar_loader.Full.t} minus the [symbol] key. [Types.Daily_price.t]
+    has no sexp converters, so this record omits [sexp]. *)
+
+val compute_values : bars:Types.Daily_price.t list -> full_values option
+(** [compute_values ~bars] returns [Some { bars; as_of }] when [bars] is
+    non-empty, where [as_of] is the date of the last element. Returns [None]
+    when [bars] is empty — the caller should leave the symbol at its current
+    tier in that case.
+
+    Mirrors the shape of {!Summary_compute.compute_values} so the Bar_loader
+    integration layer can treat the two tiers symmetrically. *)

--- a/trading/trading/backtest/bar_loader/test/dune
+++ b/trading/trading/backtest/bar_loader/test/dune
@@ -1,6 +1,6 @@
 (tests
- (names test_metadata test_summary_compute test_summary)
- (modules test_metadata test_summary_compute test_summary)
+ (names test_metadata test_summary_compute test_summary test_full)
+ (modules test_metadata test_summary_compute test_summary test_full)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/bar_loader/test/test_full.ml
+++ b/trading/trading/backtest/bar_loader/test/test_full.ml
@@ -1,0 +1,279 @@
+(** Integration tests for Bar_loader — 3c (Full tier).
+
+    These tests exercise Full-tier promotion / demotion end-to-end against CSV
+    fixtures. The Summary scalar math is covered by [test_summary_compute.ml]
+    and [test_summary.ml]; here we focus on the Full-specific plumbing:
+
+    - promote Metadata → Full cascades through Summary
+    - [get_full] returns the raw bar tail
+    - demote Full → Summary keeps Summary scalars, drops the bars
+    - demote Full → Metadata drops both higher tiers *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_loader = Bar_loader
+
+(* Re-declare records here with [@@deriving test_matcher] so ppx_test_matcher
+   generates exhaustive [match_<name>] helpers. The [type x = Module.x = {...}]
+   form keeps the test type identical to the production type — adding a field
+   in production fails compilation here, forcing the test to be updated. *)
+type full = Bar_loader.Full.t = {
+  symbol : string;
+  bars : Types.Daily_price.t list;
+  as_of : Date.t;
+}
+[@@deriving test_matcher]
+
+type summary = Bar_loader.Summary.t = {
+  symbol : string;
+  ma_30w : float;
+  atr_14 : float;
+  rs_line : float;
+  stage : Weinstein_types.stage;
+  as_of : Date.t;
+}
+[@@deriving test_matcher]
+
+type metadata = Bar_loader.Metadata.t = {
+  symbol : string;
+  sector : string;
+  last_close : float;
+  avg_vol_30d : float option;
+  market_cap : float option;
+}
+[@@deriving test_matcher]
+
+type stats_counts = Bar_loader.stats_counts = {
+  metadata : int;
+  summary : int;
+  full : int;
+}
+[@@deriving test_matcher]
+
+(** {1 Fixture helpers} *)
+
+let _mk_bar ~date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close;
+    low_price = close;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+let _daily_series ~start_date ~n ~base ~step =
+  List.init n ~f:(fun i ->
+      let date = Date.add_days start_date i in
+      let close = base +. (step *. Float.of_int i) in
+      _mk_bar ~date ~close)
+
+let _ok_or_fail ~context = function
+  | Ok v -> v
+  | Error (err : Status.t) ->
+      assert_failure (Printf.sprintf "%s: %s" context (Status.show err))
+
+let _write_symbol ~data_dir ~symbol ~bars =
+  let storage =
+    Csv.Csv_storage.create ~data_dir symbol
+    |> _ok_or_fail ~context:("Csv_storage.create " ^ symbol)
+  in
+  Csv.Csv_storage.save storage bars
+  |> _ok_or_fail ~context:("Csv_storage.save " ^ symbol)
+
+let _fresh_data_dir () =
+  let dir = Filename_unix.temp_dir "bar_loader_full_test_" "" in
+  Fpath.v dir
+
+(** Full-tier fixture: ~420 days of synthetic history so both Summary and Full
+    promotions have enough bars to resolve. Summary tail defaults to 250 days;
+    we override both tail configs to 420 so the entire synthetic history is
+    retained on Full promotion, making [List.length bars] testable against the
+    generated count. *)
+let _full_fixture () =
+  let as_of = Date.create_exn ~y:2023 ~m:Dec ~d:29 in
+  let history_days = 420 in
+  let start_date = Date.add_days as_of (-history_days) in
+  let data_dir = _fresh_data_dir () in
+  let stock_bars =
+    _daily_series ~start_date ~n:history_days ~base:100.0 ~step:1.0
+  in
+  let benchmark_bars =
+    _daily_series ~start_date ~n:history_days ~base:100.0 ~step:1.0
+  in
+  _write_symbol ~data_dir ~symbol:"STOCK" ~bars:stock_bars;
+  _write_symbol ~data_dir ~symbol:"SPY" ~bars:benchmark_bars;
+  let sector_map = String.Table.create () in
+  Hashtbl.set sector_map ~key:"STOCK" ~data:"Tech";
+  let summary_config =
+    { Bar_loader.Summary_compute.default_config with tail_days = history_days }
+  in
+  let full_config : Bar_loader.Full_compute.config =
+    { tail_days = history_days }
+  in
+  let loader =
+    Bar_loader.create ~data_dir ~sector_map ~universe:[ "STOCK" ]
+      ~summary_config ~full_config ()
+  in
+  (loader, as_of, history_days)
+
+(** {1 Tests} *)
+
+let test_promote_to_full_populates_record _ =
+  let loader, as_of, history_days = _full_fixture () in
+  let result =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Full_tier ~as_of
+  in
+  assert_that result is_ok;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Full_tier));
+  assert_that
+    (Bar_loader.get_full loader ~symbol:"STOCK")
+    (is_some_and
+       (* [as_of]: matches the date of the last CSV bar ≤ the promote
+          [as_of]. Since we generated bars up to the day before [as_of],
+          [Full.as_of] sits at [as_of - 1] — pin ≤ rather than strict-equal.
+          [bars]: exact count depends on [Csv_storage.get]'s inclusive
+          boundary semantics; pin only that most bars landed. *)
+       (match_full ~symbol:(equal_to "STOCK")
+          ~as_of:(field (fun d -> Date.(d <= as_of)) (equal_to true))
+          ~bars:
+            (field
+               (fun bs -> List.length bs)
+               (gt (module Int_ord) (history_days / 2)))))
+
+let test_promote_to_full_auto_promotes_summary _ =
+  (* Full promotion should cascade through Summary, so [get_summary] returns
+     the scalars (and Metadata is joined too, via the Summary cascade). *)
+  let loader, as_of, _ = _full_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Full_tier ~as_of
+    |> _ok_or_fail ~context:"promote Full"
+  in
+  assert_that
+    (Bar_loader.get_summary loader ~symbol:"STOCK")
+    (is_some_and
+       (match_summary ~symbol:(equal_to "STOCK") ~ma_30w:__ ~atr_14:__
+          ~rs_line:__ ~stage:__ ~as_of:__));
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"STOCK")
+    (is_some_and
+       (match_metadata ~symbol:__ ~sector:(equal_to "Tech") ~last_close:__
+          ~avg_vol_30d:__ ~market_cap:__))
+
+let test_promote_full_stats_counts _ =
+  let loader, as_of, _ = _full_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Full_tier ~as_of
+    |> _ok_or_fail ~context:"promote Full"
+  in
+  assert_that (Bar_loader.stats loader)
+    (match_stats_counts ~metadata:(equal_to 0) ~summary:(equal_to 0)
+       ~full:(equal_to 1))
+
+let test_promote_full_is_idempotent _ =
+  let loader, as_of, _ = _full_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Full_tier ~as_of
+    |> _ok_or_fail ~context:"promote 1"
+  in
+  let full_before = Bar_loader.get_full loader ~symbol:"STOCK" in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Full_tier ~as_of
+    |> _ok_or_fail ~context:"promote 2"
+  in
+  assert_that
+    (Bar_loader.get_full loader ~symbol:"STOCK")
+    (equal_to full_before)
+
+let test_demote_full_to_summary_keeps_summary_drops_bars _ =
+  let loader, as_of, _ = _full_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Full_tier ~as_of
+    |> _ok_or_fail ~context:"promote Full"
+  in
+  let summary_before = Bar_loader.get_summary loader ~symbol:"STOCK" in
+  Bar_loader.demote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Summary_tier));
+  assert_that (Bar_loader.get_full loader ~symbol:"STOCK") is_none;
+  (* Summary scalars survive the demotion — that's the point of the
+     keep-Summary path (cheap re-promote to Full if needed). *)
+  assert_that
+    (Bar_loader.get_summary loader ~symbol:"STOCK")
+    (equal_to summary_before);
+  assert_that (Bar_loader.stats loader)
+    (match_stats_counts ~metadata:(equal_to 0) ~summary:(equal_to 1)
+       ~full:(equal_to 0))
+
+let test_demote_full_to_metadata_drops_both _ =
+  let loader, as_of, _ = _full_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Full_tier ~as_of
+    |> _ok_or_fail ~context:"promote Full"
+  in
+  Bar_loader.demote loader ~symbols:[ "STOCK" ] ~to_:Metadata_tier;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Metadata_tier));
+  assert_that (Bar_loader.get_full loader ~symbol:"STOCK") is_none;
+  assert_that (Bar_loader.get_summary loader ~symbol:"STOCK") is_none;
+  (* Metadata survives — per plan §Resolutions #6, Full → Metadata is a full
+     drop of higher-tier data; Metadata stays put. *)
+  assert_that
+    (Bar_loader.get_metadata loader ~symbol:"STOCK")
+    (is_some_and
+       (match_metadata ~symbol:(equal_to "STOCK") ~sector:__ ~last_close:__
+          ~avg_vol_30d:__ ~market_cap:__));
+  assert_that (Bar_loader.stats loader)
+    (match_stats_counts ~metadata:(equal_to 1) ~summary:(equal_to 0)
+       ~full:(equal_to 0))
+
+let test_demote_full_to_full_is_noop _ =
+  let loader, as_of, _ = _full_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Full_tier ~as_of
+    |> _ok_or_fail ~context:"promote Full"
+  in
+  let full_before = Bar_loader.get_full loader ~symbol:"STOCK" in
+  Bar_loader.demote loader ~symbols:[ "STOCK" ] ~to_:Full_tier;
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Full_tier));
+  assert_that
+    (Bar_loader.get_full loader ~symbol:"STOCK")
+    (equal_to full_before)
+
+let test_get_full_none_for_lower_tier_symbol _ =
+  (* A symbol promoted only to Summary should return [None] from [get_full]. *)
+  let loader, as_of, _ = _full_fixture () in
+  let _ =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+    |> _ok_or_fail ~context:"promote Summary"
+  in
+  assert_that (Bar_loader.get_full loader ~symbol:"STOCK") is_none;
+  assert_that (Bar_loader.get_full loader ~symbol:"NOPE") is_none
+
+let suite =
+  "Bar_loader.Full"
+  >::: [
+         "promote_to_full_populates_record"
+         >:: test_promote_to_full_populates_record;
+         "promote_to_full_auto_promotes_summary"
+         >:: test_promote_to_full_auto_promotes_summary;
+         "promote_full_stats_counts" >:: test_promote_full_stats_counts;
+         "promote_full_is_idempotent" >:: test_promote_full_is_idempotent;
+         "demote_full_to_summary_keeps_summary_drops_bars"
+         >:: test_demote_full_to_summary_keeps_summary_drops_bars;
+         "demote_full_to_metadata_drops_both"
+         >:: test_demote_full_to_metadata_drops_both;
+         "demote_full_to_full_is_noop" >:: test_demote_full_to_full_is_noop;
+         "get_full_none_for_lower_tier_symbol"
+         >:: test_get_full_none_for_lower_tier_symbol;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/bar_loader/test/test_metadata.ml
+++ b/trading/trading/backtest/bar_loader/test/test_metadata.ml
@@ -167,19 +167,12 @@ let test_promote_missing_symbol_errors _ =
   assert_that (Bar_loader.stats loader)
     (match_stats_counts ~metadata:(equal_to 0) ~summary:__ ~full:__)
 
-let test_full_promotion_unimplemented _ =
-  let loader, symbols = _fixture ~n_symbols:2 ~sector_map_entries:[] in
-  let full_result =
-    Bar_loader.promote loader ~symbols ~to_:Full_tier ~as_of:_as_of
-  in
-  assert_that full_result (is_error_with Unimplemented)
-
-(** Symmetry counterpart to [test_full_promotion_unimplemented]: the supported
-    higher tier (Summary) must NOT return Unimplemented from this same call
-    surface. End-to-end Summary behaviour with full benchmark data is in
-    [test_summary.ml]; here the fixture has no benchmark series, so the call may
-    legitimately fail with NotFound — what we pin is only that the failure code
-    is *not* Unimplemented. *)
+(** Sanity guard: the supported higher tier (Summary) must NOT return
+    [Unimplemented] from this call surface. End-to-end Summary behaviour with
+    full benchmark data is in [test_summary.ml]; Full-tier semantics are in
+    [test_full.ml]. Here the fixture has no benchmark series, so the call may
+    legitimately fail with [NotFound] — what we pin is only that the failure
+    code is *not* [Unimplemented]. *)
 let test_summary_promotion_supported _ =
   let loader, symbols =
     _fixture ~n_symbols:1 ~sector_map_entries:[ ("S01", "Tech") ]
@@ -197,9 +190,9 @@ let test_summary_promotion_supported _ =
              err.message)
 
 let test_summary_getter_none_on_metadata_only _ =
-  (* After Metadata-only promotion the Summary getter must be [None] — the
-     entry exists at Metadata tier but no Summary scalars have been computed
-     yet. Full-tier getter is permanently [None] until 3c. *)
+  (* After Metadata-only promotion the Summary / Full getters must both be
+     [None] — the entry exists at Metadata tier but no higher-tier data has
+     been computed yet. Full-tier promotion semantics live in [test_full.ml]. *)
   let loader, symbols =
     _fixture ~n_symbols:2 ~sector_map_entries:[ ("S01", "Tech") ]
   in
@@ -218,7 +211,6 @@ let suite =
          "get_metadata_returns_data" >:: test_get_metadata_returns_data;
          "promote_is_idempotent" >:: test_promote_is_idempotent;
          "promote_missing_symbol_errors" >:: test_promote_missing_symbol_errors;
-         "full_promotion_unimplemented" >:: test_full_promotion_unimplemented;
          "summary_promotion_supported" >:: test_summary_promotion_supported;
          "summary_getter_none_on_metadata_only"
          >:: test_summary_getter_none_on_metadata_only;


### PR DESCRIPTION
## Summary

Increment 3c of the tiered bar loader. Adds the Full tier — complete OHLCV tails used by the strategy pipeline for breakout detection, daily path simulation, and weekly aggregation.

- `Full.t = { symbol; bars; as_of }` with `[@@deriving show, eq]` only (`Types.Daily_price.t` has no sexp converters).
- `Full_compute` mirrors `Summary_compute`'s shape: pure `compute_values` + `config { tail_days }`, default 1800 (~7 years).
- `promote ~to_:Full_tier` cascades through Summary (→ Metadata), then loads a bounded OHLCV tail via the shared `_load_bars_tail` helper (parameterized on `tail_days` now so Summary's 250-day window and Full's 1800-day window share the CSV path).
- `get_full` returns `Full.t option`.
- Demotion per plan §Resolutions #6:
  - Full → Summary keeps Summary scalars, drops bars (cheap re-promotion path).
  - Full → Metadata drops both higher tiers.

`Bar_history`, `Weinstein_strategy`, `Simulator`, `Price_cache`, `Screener` untouched (plan §Out of scope).

## Files changed

- `trading/backtest/bar_loader/bar_loader.{mli,ml}` — `Full` module, `Full_compute` re-export, `?full_config` param, `get_full : Full.t option`, promote/demote Full branches
- `trading/backtest/bar_loader/full_compute.{mli,ml}` — new, pure
- `trading/backtest/bar_loader/test/test_full.ml` — 8 tests
- `trading/backtest/bar_loader/test/test_metadata.ml` — drop obsolete `test_full_promotion_unimplemented`
- `trading/backtest/bar_loader/test/dune` — wire `test_full`
- `dev/status/backtest-scale.md` — Completed §3c, Next Steps → 3d

## Test plan
- [x] `dune build trading/backtest/bar_loader` clean
- [x] `dune runtest trading/backtest/bar_loader --force` — 35 tests pass (7 Metadata + 12 Summary_compute + 8 Summary + 8 Full)
- [x] `dune fmt` applied
- [ ] QC structural — module boundaries, pure/impure split mirrors 3b-ii

## Stack

Based on `main` (PR #445 landed — 3b-ii is now upstream).

Next: 3d tracer phases (`Promote_summary`, `Promote_full`, `Demote` in `Trace.Phase.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)