### PR TITLE
cleanup: annotate weinstein_strategy.ml as @large-module

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -17,11 +17,9 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
-- [ ] fn_length / file_length: trading/trading/weinstein/strategy/lib/weinstein_strategy.ml — module 320 lines, soft limit 300. Either annotate with `(* @large-module: <reason> *)` at the top (acceptable if the module is a cohesive whole and no obvious split exists) or extract a sub-module (e.g., stage-transition helpers or risk helpers) to drop back below 300. (source: 2026-04-19-fast.md)
-
 ## Completed
 
-- (none yet)
+- [x] fn_length / file_length: weinstein_strategy.ml — added @large-module annotation; file length linter now passes. (source: 2026-04-19-fast.md, branch: cleanup/weinstein-strategy-320-lines, 2026-04-19)
 
 ## Out of scope
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -1,3 +1,7 @@
+(* @large-module: strategy composition point — wires screener, macro, stops,
+   bar history, and portfolio into one cohesive weekly cadence; splitting any
+   of these concerns into a sibling module would create artificial boundaries
+   between tightly coupled wiring logic. *)
 open Core
 open Trading_strategy
 module Bar_history = Bar_history


### PR DESCRIPTION
## Finding

File length violation: \`trading/weinstein/strategy/lib/weinstein_strategy.ml\` — 320 lines exceeds 300-line limit.

Source: \`dev/health/2026-04-19-fast.md\`

> File length violation: \`trading/weinstein/strategy/lib/weinstein_strategy.ml\` — 320 lines exceeds 300-line limit; add \`(* @large-module: <reason> *)\` annotation or refactor

## Fix

Added the \`@large-module\` annotation at the top of the file. The module is a strategy composition point that wires screener, macro analysis, stops runner, bar history, and portfolio management into one cohesive weekly cadence. No clean extraction exists — splitting any of these concerns into a sibling module would create artificial boundaries between tightly coupled wiring logic.

**Path chosen:** Option 1 (annotate). 8 declared-large of 108 total files = 7.4%, well within the 11% cap.

## Before / After

- Before: 320 lines, file length linter FAIL
- After: 324 lines (4-line annotation comment added), file length linter OK (declared-large, allowed up to 500 lines)

## Acceptance Checklist

- [x] Diff is ≤200 LOC (8 lines changed)
- [x] Single finding addressed
- [x] \`dune build\` passes; all unit tests pass
- [x] File length linter now passes for \`weinstein_strategy.ml\`
- [x] No new public symbols
- [x] No edits to design docs, agent definitions, or other feature status files
- [x] \`dev/status/cleanup.md\` updated: finding flipped to \`[x]\` with completion note