### PR TITLE
harness: fix daily-summary naming + require non-empty PR bodies

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -141,6 +141,7 @@ status to READY_FOR_REVIEW.
 - [ ] `dune build && dune runtest` passes with zero warnings **on a clean checkout of the branch** — not just on your local worktree. If you are running in `isolation: "worktree"` (the orchestrator default), your working copy is usually but not always a clean checkout — follow `.claude/rules/worktree-isolation.md` to verify (`jj diff --stat` pre-commit, branch ancestry check pre-push, PR file list post-push). If you are NOT in a worktree (rare, legacy runs), re-verify by checking that every module your branch references is either in your commits or already on `main@origin` — do not rely on files sitting in the shared working copy that you did not explicitly commit.
 - [ ] `dune build @fmt` passes (formatter in check mode; equivalent: `dune fmt` produces no diff)
 - [ ] `Interface stable: YES` is set in `dev/status/<feature>.md` once `.mli` is finalized
+- [ ] **PR description is non-empty.** `jst submit` does NOT populate the PR body from commit messages — the body field stays empty unless you write it explicitly. After `jst submit`, run `gh pr edit <N> --body-file <path>` (or `curl PATCH /pulls/<N> -d '{"body":"..."}'`) to set the body. The description should mirror the extended commit message: what changed, why, test plan. Bodies matter for reviewers scanning `gh pr list` and for future archaeology. Empty-body PRs were an observed gap — see run-5 on 2026-04-19.
 ```
 
 ### 7. Status file format (required, feature-specific fields)

--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -116,6 +116,7 @@ status to READY_FOR_REVIEW.
 - [ ] `dune build @fmt` passes (formatter in check mode; equivalent: `dune fmt` produces no diff)
 - [ ] `dev/status/backtest-infra.md` updated: tick off the item under the relevant subsection, add a Completed entry with what was built, where it lives, and how to verify
 - [ ] Trading-behaviour-impact items also link back to `## Potential experiments` if they originated there
+- [ ] PR body is non-empty — after `jst submit`, write the PR description (what/why/test plan) via `gh pr edit <N> --body-file <path>`. `jst submit` does not populate the body.
 
 ## Architecture constraint
 

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -171,6 +171,15 @@ dev/lib/run-in-env.sh dune runtest trading/devtools/checks/
    + `dev/run.sh` provides both jst and `GH_TOKEN`). If jst fails, surface
    the error in your return value rather than silently leaving the branch
    PR-less.
-5. Include in your return value: item completed, what changed, any follow-up or escalation items, and the PR URL.
+5. **Set the PR body.** `jst submit` creates the PR but leaves `body: ""`.
+   Write the PR description immediately after submit so reviewers see
+   what/why without diffing:
+   ```
+   # Write a pr-body.md locally — short description, what changed, verify command.
+   GH_TOKEN=$GH_TOKEN gh pr edit <N> --body-file pr-body.md
+   ```
+   Empty-body PRs were observed in run-5 on 2026-04-19 (#451, #452) —
+   don't repeat.
+6. Include in your return value: item completed, what changed, any follow-up or escalation items, and the PR URL.
 
 Return a concise summary: which items completed, which are in progress, any blockers, and the PR URLs.

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -1062,7 +1062,25 @@ in the daily summary's `## Health Scan` section and `## Escalations`.
 Determine the per-day session number N by counting existing `dev/daily/${DATE}*.md`
 files (ignoring `-plan.md` files). First session of the day writes
 `dev/daily/${DATE}.md`; subsequent sessions write `dev/daily/${DATE}-runN.md`
-starting at `-run2`.
+**starting at `-run2` and incrementing monotonically** — N is the next unused
+integer, not 1.
+
+```bash
+DATE=$(date +%F)
+EXISTING_COUNT=$(ls dev/daily/${DATE}*.md 2>/dev/null | grep -v '\-plan\.md' | wc -l | tr -d ' ')
+N=$((EXISTING_COUNT + 1))
+if [ "$N" -eq 1 ]; then
+  SUMMARY_FILE="dev/daily/${DATE}.md"
+else
+  SUMMARY_FILE="dev/daily/${DATE}-run${N}.md"
+fi
+```
+
+If `${DATE}.md` / `run2` / `run3` / `run4` already exist, the next session
+writes `run5`, NOT `run1`. The `-run1` suffix is never valid — the first
+run uses the un-suffixed filename. If you find yourself writing a `-run1`
+suffix "to avoid collision with existing files", re-read this step: the
+right answer is `-run(count+1)`.
 
 Write `dev/daily/<YYYY-MM-DD>[-runN].md`:
 


### PR DESCRIPTION
Two fixes from the run-5 postmortem on 2026-04-19.

## 1. Step 7 daily-summary naming

Run-5 wrote `dev/daily/2026-04-19-run1.md` instead of `2026-04-19-run5.md` even though `2026-04-19.md` + `run2` + `run3` + `run4` were already on disk. The orchestrator misread "count existing files + 1" as "write `run1.md` to avoid collision."

**Fix:** Rewrote Step 7's naming rule with an explicit shell snippet computing `N = existing_count + 1`. Added prose: `-run1` is never valid — the first run of the day uses the un-suffixed filename.

## 2. Empty PR bodies

`jst submit` creates PRs with `body: ""`. #451 and #452 from run-5 both shipped empty. #453 (code-health) had a full body because its agent checklist explicitly requires "PR description quotes the original finding" — pattern-match working.

**Fix:** Added a PR-body requirement to:
- `feat-agent-template.md` `## Acceptance Checklist` — inherited by all feat-* agents.
- `feat-backtest.md` checklist — since it doesn't re-use the template item verbatim.
- `harness-maintainer.md` "When you're done" — new Step 5 between `jst submit` and "include in return value."

Pattern: after `jst submit`, write `pr-body.md` and run `gh pr edit <N> --body-file pr-body.md`.

## Verification

- [x] `agent_compliance_check.sh` → OK
- [x] `status_file_integrity.sh` → OK
- [ ] Next orchestrator run's feat-* / harness dispatches exercise the checklist item end-to-end.
