### PR TITLE
ops: daily orchestrator summary 2026-04-19-run5

### DIFF
--- a/dev/daily/2026-04-19-run5.md
+++ b/dev/daily/2026-04-19-run5.md
@@ -1,0 +1,124 @@
+# Status — 2026-04-19
+Run timestamp: 2026-04-19T22:47:00Z
+Run ID: 2026-04-19-run-5
+
+Filename uses user-specified `-run1.md` suffix (override of convention to
+avoid clobbering the pre-existing `2026-04-19.md` / `run2` / `run3` / `run4`
+files — all four already on disk). Internal run-id remains run-5 (fifth
+orchestrator session this UTC day).
+
+## Pending work
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| backtest-scale | awaiting-merge | feat/backtest-tiered-loader-3d-tracer-phases | #452 | QC APPROVED (structural + behavioral, quality 5). After merge: 3e runner + scenario `loader_strategy` plumbing (~150 LOC). |
+| harness | awaiting-merge | harness/weekly-deep-scan-cron | #451 | `.github/workflows/health-deep-weekly.yml` — cron `17 15 * * 1`. Advisory PR, no auto-merge. |
+| cleanup | awaiting-merge | cleanup/weinstein-strategy-large-module | #453 | `@large-module` annotation; file-length linter OK. Backlog empty after merge. |
+| orchestrator-automation | blocked | — | — | Phase 2 (background execution) pending empirical tests — see status file. Human-only. |
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| backtest-scale | feat-backtest | completed | 3d tracer phases; PR #452; `Trace.Phase.t` adds `Promote_summary` / `Promote_full` / `Demote`; `Bar_loader.create ?trace_hook`; 7 new tests including `test_no_hook_promote_is_silent`. |
+| backtest-scale | qc-structural | APPROVED | `dev/reviews/backtest-scale-3d.md`; Reviewed SHA recorded. |
+| backtest-scale | qc-behavioral | APPROVED | Quality 5 — infrastructure-only, no Weinstein domain logic touched; no-trace path observably silent for all three tier ops. |
+| harness | harness-maintainer | completed | T3-A+ sub-item 1 — weekly cron. PR #451 (144 LOC workflow). |
+| cleanup | code-health | completed | `@large-module` annotation on `weinstein_strategy.ml` (320 → 324 lines). Chose annotation over split per CLAUDE.md "minimize changes to existing code". |
+| (step 6) | (deterministic) | CLEAN | Build gate + status_file_integrity both exit 0; no agentic fast-scan dispatch. |
+
+No tracks skipped. PR-open guard (Step 1.5) ran against zero open PRs at
+session start — all inherited PRs (#447, #448, #449, #450) merged between
+run-4 and run-5.
+
+## Feature Progress
+
+### backtest-scale [READY_FOR_REVIEW]
+- Done today: 3d tracer phases — `Trace.Phase.t` + `Bar_loader` `tier_op` + `trace_hook` + `?trace_hook` on `create`. 7 new trace-integration tests. Structural + behavioral QC APPROVED.
+- In progress: — (3d complete; 3e dispatch blocked on #452 merge).
+- Blocked: No.
+
+### harness [READY_FOR_REVIEW]
+- Done today: T3-A+ sub-item 1 — `.github/workflows/health-deep-weekly.yml` with cron `17 15 * * 1` dispatching `health-scanner` in deep mode. PR opens advisory; no auto-merge.
+- In progress: — (remaining open T3 items are advisory: T3-C, T3-F rule-promotion, T3-G audit-trail quality score, T3-H commit-level QC + Tier 4 end-state).
+- Blocked: No.
+
+### cleanup [IN_PROGRESS]
+- Done today: `@large-module` annotation for `trading/trading/weinstein/strategy/lib/weinstein_strategy.ml`. File-length linter now passes.
+- In progress: Backlog empties once #453 merges; next run re-scans fast-health for a new finding.
+- Blocked: No.
+
+### orchestrator-automation [IN_PROGRESS]
+- Done today: — (not touched this run).
+- In progress: Phase 1 live — daily cron producing summary PRs.
+- Blocked: Yes — Phase 2 (background scrapers, golden re-runs, cross-feature QC) human-only pending empirical test design.
+
+## QC Status
+- backtest-scale (3d): APPROVED (structural + behavioral) — `dev/reviews/backtest-scale-3d.md`.
+- harness (#451): PENDING — advisory PR; no QC dispatch (deterministic workflow file only, nothing to behaviorally review).
+- cleanup (#453): PENDING — no QC dispatched (code-health scope: ≤200 LOC, no behavior change; verified by dune build @runtest exit 0).
+
+## Budget
+- Budget cap: $50.00 (from merge-policy.json)
+- Target utilization: 60%–80%
+- Subagents spawned: 5 (feat-backtest, harness-maintainer, code-health, qc-structural, qc-behavioral) + orchestrator overhead
+- Per-subagent breakdown (estimates; precise accounting unavailable in local run):
+
+  | Agent | Model | Status | Est. cost |
+  |-------|-------|--------|-----------|
+  | feat-backtest (3d) | sonnet | completed | ~$4 |
+  | harness-maintainer (weekly cron) | sonnet | completed | ~$2 |
+  | code-health (weinstein large-module) | sonnet | completed | ~$1 |
+  | qc-structural (3d) | sonnet | completed (APPROVED) | ~$2 |
+  | qc-behavioral (3d) | sonnet | completed (APPROVED) | ~$2 |
+  | orchestrator overhead | — | — | ~$1 |
+
+- Any subagent killed mid-flight: No.
+- Budget utilization: ~$12 / $50 (≈24%).
+- Utilization assessment: UNDER_TARGET. All eligible tracks dispatched — no remaining work in this window. No backtest-scale 3e dispatch because it hard-depends on #452 merge (downstream increment). No harness T3 advisory item started because advisory dispatch is gated on human promotion decision. No new cleanup items because backlog drained.
+- Scope reduced due to budget: No.
+
+## Data Operations
+ops-data not dispatched. `dev/notes/data-gaps.md` unchanged since run-4; skip per Step 2d sentinel check.
+
+## Harness Work
+- Item worked on: T3-A+ sub-item 1 — weekly GHA cron for deep health-scan.
+- Status: READY_FOR_REVIEW (PR #451 open).
+- Branch: harness/weekly-deep-scan-cron.
+
+## Health Scan
+- Result: CLEAN (dev/health/2026-04-19-fast-run1.md).
+- Critical items: none.
+- Build gate exit 0; status_file_integrity exit 0. Advisory `FAIL:` lines from magic-number linter at `trace.ml:1024` and `weinstein_strategy.ml:11` — pre-existing, not gates.
+
+## Follow-up Queue
+- backtest-scale: 3e runner + scenario `loader_strategy` plumbing (~150 LOC); 3f tiered runner path; 3g parity acceptance test (merge gate); 3h nightly A/B comparison (post-merge).
+- harness: remaining advisory T3 items (T3-C, T3-F rule-promotion, T3-G audit-trail quality score, T3-H commit-level QC); Tier 4 end-state.
+- cleanup: empty after #453 merges.
+- short-side-strategy (merged 2026-04-19): bear-window backtest regression, full short cascade, Ch.11 behavioural spot-check.
+
+## Integration Queue
+Features awaiting human merge:
+- #452 (backtest-scale 3d tracer phases) — QC APPROVED; clean merge.
+- #451 (harness weekly-deep-scan cron) — advisory; human review + merge.
+- #453 (cleanup weinstein @large-module annotation) — mechanical; human review + merge.
+
+## Current Milestone Target
+M5 — backtest-scale tiered loader (in flight). 3c merged; 3d QC APPROVED this
+run. Remaining to the merge gate: 3e, 3f, 3g (parity acceptance). 3h (nightly
+A/B) is post-merge follow-on.
+
+## Dependency Unlocks
+- #452 (3d) merge unlocks 3e dispatch on `backtest-scale`.
+- #451 (weekly cron) merge unlocks cron-driven deep scans starting next Monday 15:17 UTC (covers T3-A+ sub-item 2 dependency on a scheduled deep scan having real output).
+
+## Escalations
+None. No drift detected in Step 1b; no `[critical]` carried forward from run-4 (Step 1c verified all prior criticals resolved between runs).
+
+## Questions for You
+1. Budget utilization landed at ~24% this run. All eligible tracks were dispatched; under-target is structural (no more work this window, not skipped work). Anything you want me to proactively queue so the next run has warmer material — e.g., bump `backtest-scale 3e` to plan-first now so it's ready the moment #452 lands?
+2. `_index.md` row for backtest-scale still shows `READY_FOR_REVIEW` with `Open PR: #452` — note that **two open PRs** exist on that track counting #447 (pre-run-4 3c) and #452 (this run's 3d). #447 merged to main between run-4 and run-5, so the index correctly reflects only #452. Flagging for sanity-check only.
+
+---
+## Your Response
+(Edit this section. Run dev/run.sh after editing to start the next session.)

--- a/dev/health/2026-04-19-fast-run5.md
+++ b/dev/health/2026-04-19-fast-run5.md
@@ -1,0 +1,51 @@
+# Health Scan — 2026-04-19 (fast, run-5 post-orchestrator)
+
+Mode: fast (deterministic — post-PR #448 rewrite of Step 6)
+Run suffix: `-run1` (user-specified; filename preserves orchestrator convention `fast-run1` to avoid clobber of earlier run-1 fast scan)
+
+## Summary
+
+Result: CLEAN
+
+Fast scan is now three deterministic gates run directly by the orchestrator
+(no agentic dispatch) — see lead-orchestrator.md Step 6.1–6.3.
+
+## 6.1 Build gate
+
+```
+cd trading && dune build @runtest --force
+```
+
+Exit: 0. Build + tests green on current `@` (parented on `main@origin` tip
+`48bfea18`).
+
+Advisory `FAIL:` output from `linter_magic_numbers`:
+- `trading/backtest/lib/trace.ml:1024` — advisory only (linter exits 0)
+- `trading/weinstein/strategy/lib/weinstein_strategy.ml:11` — advisory only
+
+Neither is a hard gate. Magic-numbers linter is advisory track (see prior
+run-3 deep scan classification). Both lines are longstanding and not
+introduced by today's dispatches.
+
+## 6.2 Status-file integrity
+
+```
+cd trading && sh devtools/checks/status_file_integrity.sh
+```
+
+Exit: 0. Output: `OK: all dev/status/*.md files have required fields.`
+
+All tracked status files carry the required headers (`Status`, `Ownership`,
+`Branch`, `Interface stable`, `Next Steps`).
+
+## 6.3 Findings
+
+None of note this run. No new `[medium]` / `[high]` items. `dev/status/cleanup.md`
+Backlog is empty pending #453 merge; next run's fast scan will produce a new
+backlog item if it surfaces one.
+
+## Follow-ups for future deep-scan
+
+- Magic-number linter: two advisory sites above. Not auto-dispatched (advisory),
+  but worth tracking toward promotion when the linter graduates to hard gate.
+  (See harness status §Remaining advisory T3 items, T3-F rule-promotion.)

--- a/dev/reviews/backtest-scale-3d.md
+++ b/dev/reviews/backtest-scale-3d.md
@@ -1,0 +1,97 @@
+Reviewed SHA: 36311b6dc3d71e68c802b3a3a26e83f2fe99e4b5
+
+## Structural Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| H1 | dune build @fmt (format check) | PASS | No format errors in this branch's files |
+| H2 | dune build | PASS | Clean build |
+| H3 | dune runtest | PASS | All test failures are pre-existing on main@origin (fn_length linter: runner.ml line 193 run_backtest 56 lines; file-length linter: weinstein_strategy.ml 320 lines; magic-number linter: trace.ml:1024 comment, weinstein_strategy.ml:11; nesting linter: analysis/scripts violations; arch-layer linter: weinstein/screener violations). None introduced by this branch. New test_trace_integration.ml: 7 tests pass. |
+| P1 | Functions ≤ 50 lines — covered by fn_length_linter (dune runtest) | PASS | No new function in this branch exceeds 50 lines. _maybe_trace: 4 lines; promote: 27 lines; _demote_one: 23 lines; demote: 4 lines. |
+| P2 | No magic numbers — covered by linter_magic_numbers.sh (dune runtest) | PASS | No bare numeric literals introduced in lib/ files. Test fixture uses named constant history_days = 420. |
+| P3 | All configurable thresholds/periods/weights in config record | PASS | No tunable thresholds introduced. The trace_hook is a callback injection point, not a tunable parameter. |
+| P4 | .mli files cover all public symbols — covered by linter_mli_coverage.sh (dune runtest) | PASS | tier_op, trace_hook types fully documented in bar_loader.mli. Promote_summary, Promote_full, Demote variants documented with inline comments in trace.mli. |
+| P5 | Internal helpers prefixed with _ | PASS | _maybe_trace is correctly prefixed. All other new let bindings are either type definitions or existing public functions (promote, demote) that already existed in the interface. |
+| P6 | Tests use the matchers library (per CLAUDE.md) | PASS | test_trace_integration.ml: open Matchers; uses assert_that, elements_are, equal_to, size_is, ge, match_phase_metrics throughout. test_trace.ml (extended): same pattern. |
+| A1 | Core module modifications (Portfolio/Orders/Position/Strategy/Engine) | PASS | No modifications to any core trading modules. Changed files: bar_loader.{ml,mli}, lib/trace.{ml,mli}, test/test_trace.ml, test/dune, dev/status/backtest-scale.md. |
+| A2 | No imports from analysis/ into trading/trading/ | PASS | No analysis/ imports in any changed file. |
+| A3 | No unnecessary modifications to existing (non-feature) modules | PASS | trace.ml/trace.mli modifications are precisely scoped to add 3 Phase.t variants — this is the stated feature. test_trace.ml sexp round-trip test extended by 3 lines to cover the new variants. All in-scope. |
+
+## Dependency cycle rationale (A2 extension)
+
+The local `tier_op` type in `bar_loader.mli` avoids a future `bar_loader → backtest` dependency that would cycle once 3e makes `backtest → bar_loader`. The test file (`test_trace_integration.ml`) imports both `trading.backtest.bar_loader` and `backtest` — this is correct: tests sit outside the lib dependency graph and serve as the wire site that validates the adapter contract. The `_hook_forwarding_to` adapter in the test mirrors exactly what 3e's runner will implement.
+
+## No-trace path coverage
+
+`test_no_hook_promote_is_silent` exercises all three operations (promote Summary, promote Full, demote) without a registered hook and asserts the separately-owned Trace.t contains zero records. The `_maybe_trace` implementation's `None` branch is a direct `f ()` passthrough with no side effects, satisfying the parity guarantee precondition for 3g.
+
+## Verdict
+
+APPROVED
+
+## Staleness note
+
+Branch is 7 commits behind main@origin by the staleness check formula. This count includes commits that are ancestors of both branches (the formula counts `main@origin ~ ancestors(feat/...)` which includes shared ancestors). Actual divergence point is one commit (main@origin = HEAD~1 of this branch). No rebasing needed.
+
+---
+
+# Behavioral QC — backtest-scale 3d (tracer phases for tier operations)
+Date: 2026-04-19
+Reviewer: qc-behavioral
+
+## Scope note
+
+3d is infrastructure-only — a tracer hook + three `Phase.t` variants plumbed through `Bar_loader.promote` / `.demote`. No Weinstein trading logic is introduced or modified. No `Bar_history`, `Weinstein_strategy`, `Portfolio`, `Simulator`, or `Screener` changes. Most Weinstein-domain checklist axes are therefore NA. The behavioral review focuses on:
+1. **Plan faithfulness** — trace emission rules match the §3d contract in the plan doc.
+2. **No-trace silent-path property** — `trace_hook = None` produces observable behaviour identical to the pre-hook version (precondition for the 3g parity gate).
+3. **No domain-logic leakage** — the hook payload is an opaque `tier_op` tag + batch size; no strategy-relevant mutation happens inside the callback boundary.
+
+## Behavioral Checklist
+
+| # | Check | Status | Notes (cite authority doc section) |
+|---|-------|--------|------------------------------------|
+| A1 | Core module modification is strategy-agnostic | NA | qc-structural marked A1 PASS — no core module (Portfolio/Orders/Position/Strategy/Engine) modified; `Bar_loader` and `Backtest.Trace` are already-new infrastructure libraries for this plan. |
+| S1 | Stage 1 definition matches book | NA | No stage-classification logic touched. |
+| S2 | Stage 2 definition matches book | NA | No stage-classification logic touched. |
+| S3 | Stage 3 definition matches book | NA | No stage-classification logic touched. |
+| S4 | Stage 4 definition matches book | NA | No stage-classification logic touched. |
+| S5 | Buy criteria: Stage 2 entry on breakout with volume | NA | No signal generation touched. |
+| S6 | No buy signals in Stage 1/3/4 | NA | No signal generation touched. |
+| L1 | Initial stop below base | NA | No stop logic touched. |
+| L2 | Trailing stop never lowered | NA | No stop logic touched. |
+| L3 | Stop triggers on weekly close | NA | No stop logic touched. |
+| L4 | Stop state machine transitions | NA | No stop logic touched. |
+| C1 | Screener cascade order | NA | No screener logic touched. |
+| C2 | Bearish macro blocks all buys | NA | No macro/screener logic touched. |
+| C3 | Sector RS vs. market, not absolute | NA | No sector analysis touched. |
+| T1 | Tests cover all 4 stage transitions | NA | Not a stage-classification feature. |
+| T2 | Bearish macro → zero buy candidates test | NA | Not a screener feature. |
+| T3 | Stop trailing tests | NA | Not a stops feature. |
+| T4 | Tests assert domain outcomes, not "no error" | PASS | `test_trace_integration.ml` asserts the exact `Phase.t` variant, batch `symbols_in` count, and insertion order via `elements_are [match_phase_metrics ~phase:... ~symbols_in:...]`. Each test pins the observable contract, not simply that the call returned Ok. |
+
+## Plan-faithfulness checks (3d-specific, supplementing the standard axes)
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| PF1 | Plan §3d "Trace emission rules" match implementation | PASS | `bar_loader.ml` `promote` dispatches: `Metadata_tier` → `run_metadata ()` direct (not traced); `Summary_tier` → `_maybe_trace … ~tier_op:Promote_to_summary`; `Full_tier` → `_maybe_trace … ~tier_op:Promote_to_full`. `demote` → `_maybe_trace … ~tier_op:Demote_op ~symbols:(List.length symbols)`. Matches the four bullets in the commit message and plan §3d. |
+| PF2 | Metadata promotion stays silent (owned by legacy Load_bars) | PASS | `bar_loader.ml` `promote ~to_:Metadata_tier` calls `run_metadata ()` directly with no `_maybe_trace` wrapper. `test_promote_metadata_is_silent` verifies `snapshot = []` after a Metadata promote with hook attached. Matches plan §3d commit message bullet 1. |
+| PF3 | No-hook path is observably silent | PASS | `_maybe_trace`'s `None` branch is a direct `f ()` pass-through with no side effects (`bar_loader.ml` lines 315-318). `test_no_hook_promote_is_silent` exercises Summary-promote + Full-promote + demote with **no** hook attached and asserts a separately-owned `Trace.t` records zero phases. This is the observable-behaviour-equivalence precondition for the 3g parity gate. |
+| PF4 | Full promote emits exactly one `Promote_full` phase (internal Metadata/Summary cascade bypasses the outer wrapper) | PASS | `_promote_one_to_full` calls `_promote_one_to_summary` (and transitively `_promote_one_to_metadata`) directly, not through `promote`; only the outer `promote` dispatch enters `_maybe_trace`. `test_promote_full_emits_one_phase` confirms a single `Promote_full` record after Full-tier promotion — no cascading records. |
+| PF5 | Demote emits by batch size, not by count of symbols that actually changed tier | PASS | `demote` wraps the entire `List.iter` in one `_maybe_trace` call with `~symbols:(List.length symbols)`. `test_demote_noop_still_emits` confirms a Summary→Summary demote (no-op tier-wise) still emits one `Demote` phase with `symbols_in = Some 1`. Matches plan §3d commit message bullet 4 and .mli documentation. |
+| PF6 | Callback boundary keeps `bar_loader` independent of `Backtest.Trace` | PASS | `bar_loader.mli` declares `tier_op = Promote_to_summary | Promote_to_full | Demote_op` distinct from `Trace.Phase.t`. The test's `_hook_forwarding_to` adapter maps `tier_op → Trace.Phase.t`, mirroring the wiring 3e's runner will install. Neither `.ml` nor `.mli` for `bar_loader` imports `Backtest.Trace`. Prevents the future cycle once 3e makes `backtest → bar_loader`. |
+| PF7 | Hook is a polymorphic `(unit -> 'a) -> 'a` wrapper matching `Trace.record`'s shape | PASS | `trace_hook.record : 'a. tier_op:tier_op -> symbols:int -> (unit -> 'a) -> 'a` preserves the `Result.t` return of `promote` through the hook (the bar_loader code does `_maybe_trace t ~tier_op ~symbols run_summary` where `run_summary : unit -> (unit, Status.t) Result.t`). Rank-2 polymorphism needed because `demote` returns `unit` and `promote` returns `Result.t`. Correctly typed. |
+| PF8 | Tests assert on observable Phase.t mapping via test-matchers (not just call count) | PASS | Each test pins the specific `Phase.t` variant via `equal_to Backtest.Trace.Phase.Promote_summary/Promote_full/Demote` and the `symbols_in` count via `equal_to (Some 1)`. `test_multiple_calls_in_insertion_order` additionally pins the ordered sequence. This is the T4-equivalent domain-outcome assertion for this infrastructure feature. |
+
+## Quality Score
+
+5 — Exemplary for an infrastructure increment. The callback-boundary design is principled (avoids the future `bar_loader ↔ backtest` cycle flagged in the commit message), the no-hook silent-path contract is explicitly tested for all three operations, and the tests pin the exact `Phase.t` → `tier_op` mapping that 3e's runner will depend on. The `_hook_forwarding_to` helper in the test is effectively an executable specification of the 3e wire site. `match_phase_metrics` + `test_matcher` derivation forces the test to be kept in sync with the `phase_metrics` record at compile time.
+
+## Verdict
+
+APPROVED
+
+(All applicable items PASS. No FAILs. All Weinstein-domain axes correctly NA — this increment introduces no trading logic.)
+
+## Domain findings
+
+None. No behavioural change to Weinstein stage analysis, stops, screener, or portfolio logic. The 3g parity gate (next-but-one increment) is the test that will confirm end-to-end behavioural equivalence; 3d contributes the silent no-hook path that makes that gate achievable.

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,7 +4,7 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-19 (run-4 reconcile: #434, #435, #436, #439, #444, #445, #446 all merged since run-3; #438 closed (split into #444+#445); #447 3c-Full-tier and #448 harness-retire-fast-scan dispatched this run)
+Last updated: 2026-04-19 (run-5 reconcile: #447 3c Full tier, #448 retire inline fast scan, #449 run-4 summary, #450 draft→ready flip all merged since run-4; #451 harness weekly-deep-scan-cron, #452 backtest-scale 3d tracer phases (QC APPROVED), #453 cleanup weinstein_strategy @large-module all dispatched this run)
 
 ## Active + complete tracks
 
@@ -14,14 +14,14 @@ Each row: one line; deeper task detail in the linked status file.
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
 | [backtest-infra](backtest-infra.md) | MERGED | — | — | — (#419 per-phase tracing merged 2026-04-19) |
-| [backtest-scale](backtest-scale.md) | READY_FOR_REVIEW | feat-backtest | #447 | 3a (#434), 3b-i (#444), 3b-ii (#445) all merged 2026-04-19. #447 (3c Full tier) dispatched run-4, structural QC APPROVED, behavioral QC N/A (no strategy behavior change until 3g parity test). Next: 3d (tracer phases) after #447 lands. |
+| [backtest-scale](backtest-scale.md) | READY_FOR_REVIEW | feat-backtest | #452 | #447 (3c Full tier) merged 2026-04-19. #452 (3d tracer phases) dispatched run-5, structural + behavioral QC APPROVED (quality 5). Next: 3e (runner + scenario `loader_strategy` plumbing, ~150 LOC) after #452 lands. |
 | [support-floor-stops](support-floor-stops.md) | MERGED | — | — | — (PRs #382 primitive + #390 wiring both merged 2026-04-17) |
 | [short-side-strategy](short-side-strategy.md) | MERGED | — | — | — (#420 merged 2026-04-19). Follow-ups carried to own tracks: bear-window backtest regression, full short cascade, Ch.11 behavioural spot-check. |
 | [strategy-wiring](strategy-wiring.md) | MERGED | — | — | — (#408 + #409 both merged 2026-04-18) |
 | [sector-data](sector-data.md) | MERGED | — | — | — (#436 merged 2026-04-19). GHA orchestrator runs continue to consume `trading/test_data/sectors.csv`. |
-| [harness](harness.md) | READY_FOR_REVIEW | harness-maintainer | #448 | #435, #439, #446 all merged 2026-04-19. #448 (T3-A+ sub-item 2: retire inline health-scanner fast scan; fold `dune runtest` + `status_file_integrity.sh` into orchestrator Step 6 deterministic checks) dispatched run-4. Next after #448 lands: T3-A+ sub-item 1 (weekly GHA cron for deep scan). |
+| [harness](harness.md) | READY_FOR_REVIEW | harness-maintainer | #451 | #448 (T3-A+ sub-item 2) merged 2026-04-19. #451 (T3-A+ sub-item 1: weekly GHA cron `.github/workflows/health-deep-weekly.yml` dispatching `health-scanner` in deep mode on Mondays 15:17 UTC; PR opens advisory, no auto-merge) dispatched run-5. After #451 lands: remaining open T3 items are advisory (T3-C, T3-F rule-promotion, T3-G audit-trail quality score, T3-H commit-level QC) + Tier 4 end-state. |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Phase 1 live (daily cron runs producing summary PRs). Phase 2 (background execution for scrapers, golden re-runs, cross-feature QC) pending empirical tests per status file. |
-| [cleanup](cleanup.md) | IN_PROGRESS | code-health | — | Backlog populates from `dev/health/*-deep.md` and `*-fast.md` via lead-orchestrator Step 2e. One dispatch per run, ≤200 LOC, no behavior change. |
+| [cleanup](cleanup.md) | IN_PROGRESS | code-health | #453 | #453 (annotate `weinstein_strategy.ml` as `@large-module` — 320 lines → 324 lines with annotation; file-length linter now OK) dispatched run-5. Backlog empty after this PR merges; next run will re-scan fast-health for a new finding. |
 | [data-layer](data-layer.md) | MERGED | — | — | — |
 | [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |
 | [screener](screener.md) | MERGED | — | — | — |

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -136,6 +136,10 @@ overall_qc: APPROVED (3c — structural + behavioral, 2026-04-19)
 structural_qc: APPROVED (3c, 2026-04-19 — dev/reviews/backtest-scale-3c.md)
 behavioral_qc: APPROVED (3c, 2026-04-19 — data-loading increment; no strategy behavior change; tier-shape + demote/promote invariants verified against plan §Resolutions #6. Parity acceptance gate arrives with 3g — dev/reviews/backtest-scale-3c.md)
 
+structural_qc: APPROVED (3d, 2026-04-19 — dev/reviews/backtest-scale-3d.md)
+behavioral_qc: APPROVED (3d, 2026-04-19 — infrastructure-only tracer hook; no Weinstein domain logic touched; no-trace path observably silent for all three tier operations, verified by test_no_hook_promote_is_silent — dev/reviews/backtest-scale-3d.md)
+overall_qc: APPROVED (3d — structural + behavioral, 2026-04-19)
+
 Reviewers when work lands:
 - qc-structural — module boundaries between tiers; `Bar_history` untouched; parity test runs both strategies.
 - qc-behavioral — does strategy output (trades, metrics) actually match Legacy within ε? Any regression is a behavior bug, not a perf win.

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -19,7 +19,7 @@ Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here 
 
 ## Completed
 
-- [x] fn_length / file_length: weinstein_strategy.ml — added @large-module annotation; file length linter now passes. (source: 2026-04-19-fast.md, branch: cleanup/weinstein-strategy-320-lines, 2026-04-19)
+- [x] fn_length / file_length: weinstein_strategy.ml — added @large-module annotation; file length linter now passes. (source: 2026-04-19-fast.md, PR #453, 2026-04-19)
 
 ## Out of scope
 


### PR DESCRIPTION
Daily orchestrator summary for run-5 on 2026-04-19 (local `run.sh` invocation, ~22:47 UTC).
The orchestrator wrote the summary to `run1.md` instead of `run5.md` — renamed on checkin; Step 7 naming fix queued in #454.

## What ran
- **feat-backtest** → 3d tracer phases (PR #452, QC APPROVED q5)
- **harness-maintainer** → weekly deep-scan cron (PR #451)
- **code-health** → weinstein_strategy.ml @large-module annotation (PR #453)
- **qc-structural + qc-behavioral** on #452

## Budget
~$12 / $50 (24%, under-target — all eligible tracks dispatched, no remaining work in this window).

## Notes
- Daily summary was previously only pushed by GHA Step 8; local `run.sh` dropped this on the floor. Manually pushing here for the record.
- `-run1` naming anomaly fixed in #454.
- Empty-body PRs on #451/#452 flagged as regression; fix also in #454.
