### PR TITLE
feat(backtest): runner + scenario plumbing for loader_strategy flag (3e)

### DIFF
--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -7,7 +7,7 @@ READY_FOR_REVIEW
 
 structural_qc: APPROVED (2026-04-20) — feat/backtest-scale-3e SHA c51d42bee97618ab3b67679943094fc20baa66d3. All hard gates pass. See dev/reviews/backtest-scale.md.
 
-Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447. 3d (tracer phases) ready for review. 3e (runner + scenario plumbing for `loader_strategy`) ready for review on `feat/backtest-scale-3e`. 3f (tiered runner path) is the next increment.
+Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447; 3d (tracer phases) merged as #452. 3e (runner + scenario plumbing for `loader_strategy`) ready for review on `feat/backtest-scale-3e` (#459, rebased onto main post-#457). 3f (tiered runner path) is the next increment.
 
 ## Interface stable
 NO

--- a/trading/trading/backtest/bin/backtest_runner.ml
+++ b/trading/trading/backtest/bin/backtest_runner.ml
@@ -1,10 +1,15 @@
 (** Backtest runner CLI — thin wrapper around the {!Backtest} library.
 
-    Usage: backtest_runner <start_date> [end_date] [--override '<sexp>']
+    Usage: backtest_runner <start_date> \[end_date\] \[--override '<sexp>'\]
+    \[--loader-strategy legacy\|tiered\]
 
     - start_date: required (e.g. 2018-01-02)
     - end_date: optional, defaults to today
     - --override: partial config sexp, deep-merged into the default. Can repeat.
+    - --loader-strategy: which bar-loader execution strategy to use. Defaults to
+      [legacy] (current production path). [tiered] currently raises a [Failure]
+      in the runner since the implementation lands in increment 3f of
+      [dev/plans/backtest-tiered-loader-2026-04-19.md].
 
     Example:
     {[
@@ -19,27 +24,42 @@
 
 open Core
 
-(** Split argv (excluding argv[0]) into positional args and override sexps. *)
-let _extract_overrides argv =
-  let rec loop args positional overrides =
+(** Split argv (excluding argv[0]) into positional args, override sexps, and the
+    optional [--loader-strategy] flag value. *)
+let _extract_flags argv =
+  let rec loop args positional overrides loader_strategy =
     match args with
-    | [] -> (List.rev positional, List.rev overrides)
+    | [] -> (List.rev positional, List.rev overrides, loader_strategy)
     | "--override" :: sexp_str :: rest ->
-        loop rest positional (Sexp.of_string sexp_str :: overrides)
+        loop rest positional
+          (Sexp.of_string sexp_str :: overrides)
+          loader_strategy
     | "--override" :: [] ->
         eprintf "Error: --override requires a sexp argument\n";
         Stdlib.exit 1
-    | arg :: rest -> loop rest (arg :: positional) overrides
+    | "--loader-strategy" :: value :: rest ->
+        let parsed =
+          try Loader_strategy.of_string value
+          with Failure msg ->
+            eprintf "Error: %s\n" msg;
+            Stdlib.exit 1
+        in
+        loop rest positional overrides (Some parsed)
+    | "--loader-strategy" :: [] ->
+        eprintf "Error: --loader-strategy requires a value (legacy or tiered)\n";
+        Stdlib.exit 1
+    | arg :: rest -> loop rest (arg :: positional) overrides loader_strategy
   in
-  loop (Array.to_list argv |> List.tl_exn) [] []
+  loop (Array.to_list argv |> List.tl_exn) [] [] None
 
 let _parse_args () =
   let argv = Sys.get_argv () in
   if Array.length argv < 2 then (
     eprintf
-      "Usage: backtest_runner <start_date> [end_date] [--override '<sexp>']\n";
+      "Usage: backtest_runner <start_date> [end_date] [--override '<sexp>'] \
+       [--loader-strategy legacy|tiered]\n";
     Stdlib.exit 1);
-  let positional, overrides = _extract_overrides argv in
+  let positional, overrides, loader_strategy = _extract_flags argv in
   let start_str, end_str =
     match positional with
     | [] ->
@@ -57,7 +77,7 @@ let _parse_args () =
     | Some s -> Date.of_string s
     | None -> Date.today ~zone:Time_float.Zone.utc
   in
-  (start_date, end_date, overrides)
+  (start_date, end_date, overrides, loader_strategy)
 
 let _make_output_dir () =
   let data_dir_fpath = Data_path.default_data_dir () in
@@ -73,9 +93,10 @@ let _make_output_dir () =
   path
 
 let () =
-  let start_date, end_date, overrides = _parse_args () in
+  let start_date, end_date, overrides, loader_strategy = _parse_args () in
   let result =
-    Backtest.Runner.run_backtest ~start_date ~end_date ~overrides ()
+    Backtest.Runner.run_backtest ~start_date ~end_date ~overrides
+      ?loader_strategy ()
   in
   let output_dir = _make_output_dir () in
   eprintf "Writing output to %s/\n%!" output_dir;

--- a/trading/trading/backtest/bin/dune
+++ b/trading/trading/backtest/bin/dune
@@ -1,3 +1,9 @@
 (executable
  (name backtest_runner)
- (libraries core core_unix fpath weinstein.data_source backtest))
+ (libraries
+  core
+  core_unix
+  fpath
+  weinstein.data_source
+  trading.backtest.loader_strategy
+  backtest))

--- a/trading/trading/backtest/lib/dune
+++ b/trading/trading/backtest/lib/dune
@@ -5,6 +5,7 @@
   core_unix
   fpath
   weinstein.data_source
+  trading.backtest.loader_strategy
   trading.base
   trading.engine
   trading.simulation

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -236,10 +236,9 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     | Loader_strategy.Tiered ->
         failwith
           "Backtest.Runner: Tiered loader_strategy not yet implemented (lands \
-           in increment 3f of \
-           dev/plans/backtest-tiered-loader-2026-04-19.md). Pass \
-           loader_strategy=Legacy or omit the argument to use the existing \
-           path."
+           in increment 3f of dev/plans/backtest-tiered-loader-2026-04-19.md). \
+           Pass loader_strategy=Legacy or omit the argument to use the \
+           existing path."
   in
   (* Steps in the requested date range, all days included. Round-trip
      extraction derives trades from position-state transitions recorded on

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -203,16 +203,7 @@ let _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
     metrics = sim_result.Trading_simulation_types.Simulator_types.metrics;
   }
 
-let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
-    ?trace () =
-  let deps = _load_deps ?trace ~overrides ~sector_map_override () in
-  eprintf "Total symbols (universe + index + sector ETFs): %d\n%!"
-    (List.length deps.all_symbols);
-  let warmup_start = Date.add_days start_date (-warmup_days) in
-  eprintf "Running backtest (%s to %s, warmup from %s)...\n%!"
-    (Date.to_string start_date)
-    (Date.to_string end_date)
-    (Date.to_string warmup_start);
+let _run_legacy ~deps ~start_date ~end_date ?trace () =
   let stop_log = Stop_log.create () in
   let n_all_symbols = List.length deps.all_symbols in
   let sim =
@@ -223,6 +214,32 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
   let sim_result =
     Trace.record ?trace ~symbols_in:n_all_symbols Trace.Phase.Fill (fun () ->
         _run_simulator sim)
+  in
+  (sim_result, stop_log)
+
+let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
+    ?trace ?(loader_strategy = Loader_strategy.Legacy) () =
+  let deps = _load_deps ?trace ~overrides ~sector_map_override () in
+  eprintf "Total symbols (universe + index + sector ETFs): %d\n%!"
+    (List.length deps.all_symbols);
+  let warmup_start = Date.add_days start_date (-warmup_days) in
+  eprintf
+    "Running backtest (%s to %s, warmup from %s, loader_strategy=%s)...\n%!"
+    (Date.to_string start_date)
+    (Date.to_string end_date)
+    (Date.to_string warmup_start)
+    (Loader_strategy.to_string loader_strategy);
+  let sim_result, stop_log =
+    match loader_strategy with
+    | Loader_strategy.Legacy ->
+        _run_legacy ~deps ~start_date ~end_date ?trace ()
+    | Loader_strategy.Tiered ->
+        failwith
+          "Backtest.Runner: Tiered loader_strategy not yet implemented (lands \
+           in increment 3f of \
+           dev/plans/backtest-tiered-loader-2026-04-19.md). Pass \
+           loader_strategy=Legacy or omit the argument to use the existing \
+           path."
   in
   (* Steps in the requested date range, all days included. Round-trip
      extraction derives trades from position-state transitions recorded on

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -228,7 +228,7 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     (Date.to_string start_date)
     (Date.to_string end_date)
     (Date.to_string warmup_start)
-    (Loader_strategy.to_string loader_strategy);
+    (Loader_strategy.show loader_strategy);
   let sim_result, stop_log =
     match loader_strategy with
     | Loader_strategy.Legacy ->

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -44,6 +44,7 @@ val run_backtest :
   ?overrides:Sexp.t list ->
   ?sector_map_override:(string, string) Core.Hashtbl.t ->
   ?trace:Trace.t ->
+  ?loader_strategy:Loader_strategy.t ->
   unit ->
   result
 (** Run the simulator from [start_date - warmup] to [end_date], filter to the
@@ -77,4 +78,13 @@ val run_backtest :
     Finer-grained wrap points for the per-bar phases inside [Simulator.run]
     (Sector_rank / Rs_rank / Stage_classify / Screener / Stop_update /
     Order_gen) require strategy-level instrumentation and are tracked as a
-    follow-up. When [trace] is omitted, instrumentation is a no-op. *)
+    follow-up. When [trace] is omitted, instrumentation is a no-op.
+
+    [loader_strategy] selects how universe bars are loaded:
+    - [Legacy] (default) — current production path: simulator materializes all
+      universe bars up-front via per-symbol bar loaders.
+    - [Tiered] — placeholder. The actual Tiered execution path lands in
+      increment 3f of [dev/plans/backtest-tiered-loader-2026-04-19.md]; calling
+      [run_backtest] with [Tiered] today raises [Failure] with a clear message
+      so the absence of an implementation surfaces loudly rather than silently
+      falling back to [Legacy]. *)

--- a/trading/trading/backtest/loader_strategy/dune
+++ b/trading/trading/backtest/loader_strategy/dune
@@ -1,0 +1,6 @@
+(library
+ (public_name trading.backtest.loader_strategy)
+ (name loader_strategy)
+ (libraries core)
+ (preprocess
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/loader_strategy/loader_strategy.ml
+++ b/trading/trading/backtest/loader_strategy/loader_strategy.ml
@@ -2,8 +2,6 @@ open Core
 
 type t = Legacy | Tiered [@@deriving sexp, show, eq]
 
-let to_string = function Legacy -> "legacy" | Tiered -> "tiered"
-
 let of_string s =
   match String.lowercase s with
   | "legacy" -> Legacy

--- a/trading/trading/backtest/loader_strategy/loader_strategy.ml
+++ b/trading/trading/backtest/loader_strategy/loader_strategy.ml
@@ -1,0 +1,14 @@
+open Core
+
+type t = Legacy | Tiered [@@deriving sexp, show, eq]
+
+let to_string = function Legacy -> "legacy" | Tiered -> "tiered"
+
+let of_string s =
+  match String.lowercase s with
+  | "legacy" -> Legacy
+  | "tiered" -> Tiered
+  | other ->
+      failwith
+        (sprintf "Loader_strategy.of_string: expected legacy|tiered, got %S"
+           other)

--- a/trading/trading/backtest/loader_strategy/loader_strategy.mli
+++ b/trading/trading/backtest/loader_strategy/loader_strategy.mli
@@ -16,8 +16,8 @@ type t =
           behaviour. *)
   | Tiered
       (** New path: [Bar_loader] keeps the working set bounded by tiering
-          symbols across Metadata / Summary / Full and promoting/demoting
-          on demand. Not yet wired through the runner — see 3f. *)
+          symbols across Metadata / Summary / Full and promoting/demoting on
+          demand. Not yet wired through the runner — see 3f. *)
 [@@deriving sexp, show, eq]
 
 val to_string : t -> string

--- a/trading/trading/backtest/loader_strategy/loader_strategy.mli
+++ b/trading/trading/backtest/loader_strategy/loader_strategy.mli
@@ -1,0 +1,29 @@
+(** Selector for the bar-loading strategy used by {!Backtest.Runner}.
+
+    Lives in its own tiny library so that both [backtest] (the runner) and
+    [scenario_lib] (the scenario sexp parser) can reference the same type
+    without introducing a circular dependency between them.
+
+    See [dev/plans/backtest-tiered-loader-2026-04-19.md] §"Legacy vs Tiered
+    flag" for the rationale. The concrete Tiered execution path arrives in
+    increment 3f; today this is plumbing only. *)
+
+type t =
+  | Legacy
+      (** Pre-existing path: [Backtest.Runner] materializes every universe
+          symbol's bars up-front via [Simulator.create]'s per-symbol bar
+          loaders. Memory grows with universe size; current production
+          behaviour. *)
+  | Tiered
+      (** New path: [Bar_loader] keeps the working set bounded by tiering
+          symbols across Metadata / Summary / Full and promoting/demoting
+          on demand. Not yet wired through the runner — see 3f. *)
+[@@deriving sexp, show, eq]
+
+val to_string : t -> string
+(** Lowercase string form ([Legacy] -> ["legacy"], [Tiered] -> ["tiered"]).
+    Stable, used by CLI flag parsing. *)
+
+val of_string : string -> t
+(** Inverse of {!to_string}. Accepts ["legacy"] / ["tiered"] (case-insensitive).
+    Raises [Failure] on any other input. *)

--- a/trading/trading/backtest/loader_strategy/loader_strategy.mli
+++ b/trading/trading/backtest/loader_strategy/loader_strategy.mli
@@ -20,10 +20,8 @@ type t =
           demand. Not yet wired through the runner — see 3f. *)
 [@@deriving sexp, show, eq]
 
-val to_string : t -> string
-(** Lowercase string form ([Legacy] -> ["legacy"], [Tiered] -> ["tiered"]).
-    Stable, used by CLI flag parsing. *)
-
 val of_string : string -> t
-(** Inverse of {!to_string}. Accepts ["legacy"] / ["tiered"] (case-insensitive).
-    Raises [Failure] on any other input. *)
+(** Accepts ["legacy"] / ["tiered"] (case-insensitive). Raises [Failure] on any
+    other input. Used by the [--loader-strategy] CLI flag parser in
+    [backtest_runner]. For the reverse direction (value → string, e.g. for log
+    formatting) use the ppx-derived [show] / [pp]. *)

--- a/trading/trading/backtest/scenarios/dune
+++ b/trading/trading/backtest/scenarios/dune
@@ -1,7 +1,7 @@
 (library
  (name scenario_lib)
  (modules scenario universe_file)
- (libraries core)
+ (libraries core trading.backtest.loader_strategy)
  (preprocess
   (pps ppx_sexp_conv)))
 

--- a/trading/trading/backtest/scenarios/scenario.ml
+++ b/trading/trading/backtest/scenarios/scenario.ml
@@ -54,6 +54,7 @@ type t = {
   period : period;
   universe_path : string; [@sexp.default default_universe_path]
   config_overrides : Sexp.t list;
+  loader_strategy : Loader_strategy.t option; [@sexp.option]
   expected : expected;
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]

--- a/trading/trading/backtest/scenarios/scenario.mli
+++ b/trading/trading/backtest/scenarios/scenario.mli
@@ -51,6 +51,18 @@ type t = {
   config_overrides : Sexp.t list;
       (** Partial config sexps deep-merged into the default Weinstein config, in
           order. Empty list means the default config. *)
+  loader_strategy : Loader_strategy.t option; [@sexp.option]
+      (** Selects the bar-loader execution strategy used for this scenario:
+          - [None] (default) — Runner falls back to its own default
+            ([Loader_strategy.Legacy] today). Pre-3e scenario files have no
+            field and continue to behave exactly as before.
+          - [Some Legacy] — explicit opt-in to the legacy path. Useful for
+            scenarios that should pin the legacy behaviour even after the global
+            default flips.
+          - [Some Tiered] — opt-in to the tiered loader. Today this raises
+            inside the runner since the implementation lands in increment 3f of
+            [dev/plans/backtest-tiered-loader-2026-04-19.md]; once available,
+            scenarios will use this to exercise it. *)
   expected : expected;
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -161,7 +161,7 @@ let _run_scenario_in_child ~output_root (s : Scenario.t) =
   let result =
     Backtest.Runner.run_backtest ~start_date:s.period.start_date
       ~end_date:s.period.end_date ~overrides:s.config_overrides
-      ?sector_map_override ()
+      ?sector_map_override ?loader_strategy:s.loader_strategy ()
   in
   Backtest.Result_writer.write ~output_dir:scenario_dir result;
   let a = _actual_of_result result in

--- a/trading/trading/backtest/scenarios/test/dune
+++ b/trading/trading/backtest/scenarios/test/dune
@@ -1,4 +1,9 @@
 (tests
  (names test_scenario test_universe_file)
  (modules test_scenario test_universe_file)
- (libraries ounit2 core scenario_lib matchers))
+ (libraries
+  ounit2
+  core
+  scenario_lib
+  trading.backtest.loader_strategy
+  matchers))

--- a/trading/trading/backtest/scenarios/test/test_scenario.ml
+++ b/trading/trading/backtest/scenarios/test/test_scenario.ml
@@ -181,6 +181,42 @@ let test_universe_path_roundtrip _ =
   let roundtripped = Scenario.t_of_sexp (Scenario.sexp_of_t original) in
   assert_that roundtripped.universe_path (equal_to "universes/custom.sexp")
 
+(* A scenario sexp that omits [loader_strategy] should round-trip with
+   [loader_strategy = None], preserving backward compat with all existing
+   scenario files that pre-date increment 3e. *)
+let test_loader_strategy_field_absent _ =
+  let s =
+    Scenario.t_of_sexp (Sexp.of_string (_make_sexp ~extra_expected_fields:""))
+  in
+  assert_that s.loader_strategy is_none
+
+let _make_sexp_with_loader_strategy ~loader_strategy =
+  sprintf
+    {|
+  ((name "test-scenario")
+   (description "Unit-test fixture")
+   (period ((start_date 2023-01-02) (end_date 2023-12-31)))
+   (config_overrides ())
+   (loader_strategy %s)
+   (expected
+    (%s)))
+  |}
+    loader_strategy _base_expected_fields
+
+(* When [loader_strategy = Tiered] is present, the value must round-trip
+   through [sexp_of_t] / [t_of_sexp] unchanged. *)
+let test_loader_strategy_tiered_roundtrip _ =
+  let original =
+    Scenario.t_of_sexp
+      (Sexp.of_string
+         (_make_sexp_with_loader_strategy ~loader_strategy:"Tiered"))
+  in
+  assert_that original.loader_strategy
+    (is_some_and (equal_to Loader_strategy.Tiered));
+  let roundtripped = Scenario.t_of_sexp (Scenario.sexp_of_t original) in
+  assert_that roundtripped.loader_strategy
+    (is_some_and (equal_to Loader_strategy.Tiered))
+
 let suite =
   "Scenario"
   >::: [
@@ -194,6 +230,9 @@ let suite =
          >:: test_universe_path_absent_uses_default;
          "universe_path present => round-trips" >:: test_universe_path_present;
          "universe_path sexp round-trips" >:: test_universe_path_roundtrip;
+         "loader_strategy absent => None" >:: test_loader_strategy_field_absent;
+         "loader_strategy=Tiered round-trips"
+         >:: test_loader_strategy_tiered_roundtrip;
          "all scenario files parse" >:: test_all_scenario_files_parse;
        ]
 


### PR DESCRIPTION
Increment 3e of `dev/plans/backtest-tiered-loader-2026-04-19.md` — runner + scenario plumbing for the `loader_strategy` flag. Default `Legacy`; `Tiered` branch is a placeholder that raises (real implementation lands in 3f).

## Commits

1. `61339d0` feat(backtest): add Loader_strategy scaffold module (3e)
2. `c0418f2` feat(backtest): wire ?loader_strategy through Runner.run_backtest (3e)
3. `f4466a0` feat(backtest): add Scenario.loader_strategy field + plumb through runner (3e)
4. `dca862a` feat(backtest): add --loader-strategy CLI flag to backtest_runner (3e)
5. `c51d42b` docs(status): mark 3e ready for review (backtest-scale)

## Scope

+218 / -33 across 15 files (well within ≤500 LOC budget).

- New `trading/trading/backtest/loader_strategy/` lib (Legacy | Tiered variant + sexp round-trip)
- `Runner.run_backtest` accepts `?loader_strategy:Loader_strategy.t` (default Legacy); Tiered branch raises with pointer to 3f
- `Scenario.loader_strategy : Loader_strategy.t option [@sexp.option]` field with sexp round-trip
- `bin/backtest_runner.ml` accepts `--loader-strategy {legacy|tiered}` CLI flag
- 2 new sexp round-trip tests in `test_scenario.ml`

## Verification

`dune runtest trading/backtest --force` passes 11 scenario tests (9 existing + 2 new) + 3 runner_filter tests. Pre-existing nesting-linter failures elsewhere in the repo (analysis/scripts) are unrelated.

## Merge gate

**Not this PR** — the merge gate for default-flip is 3g (parity acceptance test). 3e is dormant plumbing; observable behaviour unchanged because no scenario file in the repo sets the new field today.

## Plan reference

`dev/plans/backtest-tiered-loader-2026-04-19.md` §3e (lines ~423-441).