### PR TITLE
feat(bar_loader): shadow screener adapter for Summary-tier stubs

### DIFF
--- a/dev/plans/backtest-scale-3f-2026-04-20.md
+++ b/dev/plans/backtest-scale-3f-2026-04-20.md
@@ -1,0 +1,159 @@
+# Plan: backtest-scale-3f — Tiered runner path + shadow screener (2026-04-20)
+
+Track: [backtest-scale](../status/backtest-scale.md)
+Branch: `feat/backtest-scale-3f`
+Parent plan: `dev/plans/backtest-tiered-loader-2026-04-19.md` §3f
+
+## Context
+
+3a–3e landed on main. 3e (#459) added the `Loader_strategy.Legacy | Tiered`
+flag to `Backtest.Runner.run_backtest` but the `Tiered` branch currently
+raises `Failure`. This increment implements the actual Tiered execution
+path behind that flag.
+
+## Approach
+
+Split 3f into two logical commits under one PR:
+
+### Commit 1 — Shadow screener adapter (`shadow_screener.ml{,i}`)
+
+Pure, testable module that synthesizes `Stock_analysis.t` stubs from
+`Bar_loader.Summary.t` values and feeds them to the existing
+`Screener.screen`. The adapter approach is preferred over changing
+`Screener.screen`'s signature (plan §Open questions, decision: adapter).
+
+**Synthesis rules** (documented on the .mli so the divergence with the
+Legacy path is explicit):
+- `Stage.result` — reconstructed from `Summary.stage` and `Summary.ma_30w`.
+  `ma_direction` / `ma_slope_pct` use a conservative proxy (Rising when
+  stage is Stage2; Declining when Stage4; Flat otherwise). Prior stage
+  tracked in a caller-supplied `(string, stage) Hashtbl.t` — same mechanism
+  as `_screen_universe` in `weinstein_strategy.ml`.
+- `Rs.result` — synthesized from `Summary.rs_line` (Mansfield-normalized).
+  Trend classified by comparing `rs_line` to the threshold 1.0: > 1.0 →
+  `Positive_rising`; < 1.0 → `Negative_declining`. `Positive_flat` /
+  `Negative_improving` / crossovers are unreachable without an RS history
+  series (captured as a known divergence).
+- `Volume.result` — always `None`. The Summary tier does not retain
+  breakout-volume information.
+- `Resistance.result` — always `None`.
+- `breakout_price` — `None`. Screener's `_build_candidate` falls back to
+  `ma_value * (1 + breakout_fallback_pct)`.
+
+**Expected divergence from Legacy** — documented in the .mli:
+- Missing volume signal → every candidate scores ~20-30 points lower (no
+  Strong/Adequate volume contribution). This means `min_grade = C` becomes
+  the functional floor for most candidates.
+- Missing resistance signal → no Virgin/Clean bonus.
+- RS trend can never produce `Bullish_crossover` / `Bearish_crossover` →
+  no A+ crossover bonus.
+- `prior_stage` tracking is caller-managed; if the caller forgets to pass
+  in a prior-stage table, every candidate looks like a non-transition.
+
+The parity test in 3g is the ultimate gate; if the divergence is too wide
+on the smoke scenario, the parity test will fail and we iterate.
+
+**Public surface:**
+
+```ocaml
+val screen :
+  loader:Bar_loader.t ->
+  config:Screener.config ->
+  macro_trend:Weinstein_types.market_trend ->
+  sector_map:(string, Screener.sector_context) Core.Hashtbl.t ->
+  universe:string list ->
+  prior_stages:(string, Weinstein_types.stage) Core.Hashtbl.t ->
+  held_tickers:string list ->
+  as_of:Core.Date.t ->
+  Screener.result
+```
+
+`universe` is the subset of symbols currently at Summary+ tier. Symbols
+below Summary are silently skipped — the caller is responsible for having
+promoted them via `Bar_loader.promote`.
+
+Prior-stage table is mutated in place (matches `_screen_universe`'s
+contract).
+
+### Commit 2 — `_run_tiered_backtest` in runner.ml
+
+Tiered runner path. Orchestrates:
+
+1. Build `Bar_loader` with the full universe + sector map.
+2. Promote every universe symbol to Metadata up front (inside `Load_bars`
+   phase).
+3. Create the simulator with **only** the "always full" symbols — the
+   primary index + sector ETFs + global indices. These get full OHLCV
+   because the strategy's macro / sector analysis needs them. The universe
+   symbols do NOT get bars in the simulator's Price_cache until they are
+   promoted to Full tier by the tiered path.
+4. Build a custom strategy module inline (bypasses `Weinstein_strategy.make`'s
+   `_on_market_close`). On each daily call:
+   - Run `Stops_runner.update` for held positions (reuses
+     `Weinstein_strategy.Stops_runner`).
+   - On Fridays only: promote universe to Summary, compute macro + sector
+     map via existing helpers, run shadow_screener, promote candidate
+     tickers to Full, and emit `entries_from_candidates` transitions.
+   - On position-open (CreateEntering) emit a Bar_loader.promote call to
+     Full for the candidate.
+   - On position-close (Closed state transitions visible in next step's
+     portfolio) demote back to Metadata.
+5. Trace hooks wire through Bar_loader — Summary/Full/Demote phases.
+
+**Scope boundary**: this increment wires Tiered but does NOT flip the
+default. The parity test in 3g is the merge gate.
+
+**Line budget ceiling**: If commit 2 balloons past ~300 lines, defer the
+position-open/close promotion logic to a follow-up and land a simpler
+version that just runs the Legacy simulator with Bar_loader running
+alongside as an observability instrument (still promotes to Metadata on
+boot, to Summary on Fridays — tracks memory/timing for the A/B harness
+in 3h). This is still useful — the shadow screener is tested in isolation,
+and the `Tiered` flag starts emitting trace phases for the scale/A/B team.
+
+## Out of scope
+
+- 3g parity acceptance test — separate PR.
+- Flipping default to Tiered — separate PR.
+- Modifying `Bar_history`, `Weinstein_strategy` internals, `Simulator`,
+  `Price_cache`, `Screener.screen` signature (plan §Out of scope).
+- Perfect parity with Legacy — known divergences on volume/resistance/RS
+  crossover signals documented in shadow_screener.mli. 3g will tell us
+  whether the divergence is small enough for the flag ramp.
+
+## Risks
+
+- **Shadow screener synthesis loses signal.** The three missing signals
+  (volume, resistance, RS crossover) lower candidate scores and may
+  change the top-N ranking. 3g will catch this if the diff exceeds the
+  agreed parity ε.
+- **Simulator's Price_cache not fed by Bar_loader.** In this increment
+  the simulator still owns its own Price_cache for the "always full"
+  symbols (index, sector ETFs, global indices). Universe-symbol bars
+  live only in Bar_loader's Full-tier storage. If the strategy's
+  `get_price` path is called for a universe symbol, the simulator will
+  try to load via its own Price_cache and miss. Mitigation: drive the
+  Tiered path through a custom strategy wrapper that routes
+  universe-symbol `get_price` calls through Bar_loader's Full-tier bars
+  when available, and returns `None` otherwise.
+- **CSV-per-promote cost.** Each Summary promote on Friday reads 250-day
+  tails from CSV for every universe symbol. With 10k symbols that's 10k
+  CSV reads per Friday, once per week for the backtest horizon. 3d
+  trace phases will expose whether this is the bottleneck; if so,
+  incremental indicators (parent plan §Out of scope) become a real
+  follow-up.
+
+## Verify
+
+Per commit:
+
+```
+dev/lib/run-in-env.sh dune build
+dev/lib/run-in-env.sh dune runtest trading/backtest
+```
+
+Session end:
+
+```
+dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest
+```

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -7,7 +7,7 @@ READY_FOR_REVIEW
 
 structural_qc: APPROVED (2026-04-20) — feat/backtest-scale-3e SHA c51d42bee97618ab3b67679943094fc20baa66d3. All hard gates pass. See dev/reviews/backtest-scale.md.
 
-Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447; 3d (tracer phases) merged as #452. 3e (runner + scenario plumbing for `loader_strategy`) ready for review on `feat/backtest-scale-3e` (#459, rebased onto main post-#457). 3f (tiered runner path) is the next increment.
+Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447; 3d (tracer phases) merged as #452. 3e (runner + scenario plumbing for `loader_strategy`) ready for review on `feat/backtest-scale-3e` (#459, rebased onto main post-#457). 3f split into two parts: 3f-part1 (shadow_screener adapter) shipped as draft #463 on `feat/backtest-scale-3f`; 3f-part2 (runner integration / `_run_tiered_backtest`) deferred to a follow-up increment due to concurrent-agent workspace contention consuming iteration budget during this session.
 
 ## Interface stable
 NO
@@ -17,9 +17,10 @@ All three tier getters return their proper typed option: `get_metadata : Metadat
 ## Open PR
 - feat/backtest-tiered-loader-3d-tracer-phases — 3d based on main; tier-op tracer phases + callback hook. Ready for QC.
 - feat/backtest-scale-3e — 3e based on main; runner + scenario plumbing for `loader_strategy`. Ready for QC.
+- feat/backtest-scale-3f — 3f-part1 (draft #463) based on main; shadow_screener adapter only. Runner integration (`_run_tiered_backtest`) deferred to a follow-up PR. Ready for QC on the adapter scope.
 
 ## Blocked on
-- None. 3f depends on 3e merging.
+- None. 3f-part2 (runner integration) depends on 3e merging; shadow_screener adapter (3f-part1, #463) is independently reviewable.
 
 ## Goal
 
@@ -85,10 +86,40 @@ Build alongside existing `Bar_history` — don't modify it.
 
 1. QC review of 3d (feat/backtest-tiered-loader-3d-tracer-phases head).
 2. QC review of 3e (feat/backtest-scale-3e head).
-3. Dispatch 3f — tiered runner path. Implements the `Loader_strategy.Tiered` branch in `Backtest.Runner._run_tiered_backtest`, wires the screener to drive `Bar_loader.promote`/`demote`, and emits the tracer phases added in 3d. ~300 lines per plan §3f.
-4. Subsequent increment 3g (parity acceptance test) is the merge gate.
+3. QC review of 3f-part1 (feat/backtest-scale-3f head, PR #463) — shadow_screener adapter in isolation.
+4. Dispatch 3f-part2 — runner integration (`_run_tiered_backtest`). Implements the `Loader_strategy.Tiered` branch in `Backtest.Runner`, wires the screener to drive `Bar_loader.promote`/`demote` on Friday cadence, and emits the tracer phases added in 3d. Uses the `Shadow_screener` adapter landed in 3f-part1. Target ~200-250 lines per plan §3f Commit 2.
+5. Subsequent increment 3g (parity acceptance test) is the merge gate.
 
 ## Completed
+
+- **3f-part1 — Shadow screener adapter** (2026-04-20).
+  Pure adapter at `trading/trading/backtest/bar_loader/shadow_screener.ml{,i}`
+  that synthesizes `Stock_analysis.t` stubs from `Bar_loader.Summary.t`
+  values and drives the existing `Screener.screen` without changing its
+  signature (plan §Open questions, adapter decision). Synthesis rules
+  per plan §3f Commit 1: `Stage.result` reconstructed from
+  `Summary.stage` + `Summary.ma_30w` with a conservative `ma_direction`
+  proxy (Rising for Stage2 / Declining for Stage4 / Flat otherwise);
+  `Rs.result` from `Summary.rs_line` thresholded at 1.0 (Mansfield
+  normalization) into `Positive_rising` / `Negative_declining`;
+  `Volume.result` set to `Adequate 1.5` for Stage2/4 (the floor that
+  satisfies `is_breakout_candidate`) and `None` otherwise;
+  `Resistance.result = None`; `breakout_price = None` (Screener
+  falls back to `ma_value * (1 + breakout_fallback_pct)`). Prior-stage
+  tracking is caller-managed via a `(string, stage) Hashtbl.t` — same
+  mechanism as `_screen_universe` in `weinstein_strategy.ml`. Known
+  divergences from Legacy documented on the .mli: missing volume
+  contribution lowers scores ~20-30 pts (C becomes functional floor),
+  missing resistance bonus, no RS `Bullish_crossover` / `Bearish_crossover`.
+  3g parity test will quantify whether the divergence is within ε.
+  Re-exported through `Bar_loader.Shadow_screener`.
+  - Files: `bar_loader/{dune,bar_loader.mli,bar_loader.ml,shadow_screener.mli,shadow_screener.ml}`
+    + `bar_loader/test/{dune,test_shadow_screener.ml}`.
+  - Verify: `dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest trading/backtest/bar_loader --force` — 17 shadow_screener tests (9 synthesize_analysis + 8 screen-cascade) + 42 pre-existing bar_loader tests pass; `dune build @fmt` clean.
+  - Note: 3f Commit 2 (`_run_tiered_backtest` runner integration) was planned to
+    ship in the same PR but was deferred due to concurrent-agent workspace
+    contention (sibling agent racing on git HEAD) that exhausted the
+    Max-Iterations Policy budget. Follow-up increment tracked in §Next Steps.
 
 - **3e — Runner + scenario plumbing for `loader_strategy`** (2026-04-20).
   Adds a tiny `Loader_strategy.t = Legacy | Tiered` library at

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -4,6 +4,7 @@ open Core
 module Price_cache = Trading_simulation_data.Price_cache
 module Summary_compute = Summary_compute
 module Full_compute = Full_compute
+module Shadow_screener = Shadow_screener
 
 type tier = Metadata_tier | Summary_tier | Full_tier
 [@@deriving show, eq, sexp]

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -34,6 +34,11 @@ module Full_compute = Full_compute
 (** Pure compute helpers used by the Full tier. Re-exported for the same reason
     as {!Summary_compute}. *)
 
+module Shadow_screener = Shadow_screener
+(** Adapter that drives the existing [Screener.screen] from Summary-tier scalars
+    — the shadow screener the Tiered runner path uses on Fridays. Re-exported so
+    the Tiered runner can reach it through the library's main module. *)
+
 (** {1 Tier tag} *)
 
 (** Discrete ordering of tiers by information content: [Metadata_tier] <

--- a/trading/trading/backtest/bar_loader/dune
+++ b/trading/trading/backtest/bar_loader/dune
@@ -13,6 +13,10 @@
   indicators.atr
   indicators.sma
   weinstein.stage
+  weinstein.rs
+  weinstein.volume
+  weinstein.stock_analysis
+  weinstein.screener
   weinstein.types)
  (preprocess
   (pps ppx_let ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/bar_loader/shadow_screener.ml
+++ b/trading/trading/backtest/bar_loader/shadow_screener.ml
@@ -1,0 +1,109 @@
+(** Shadow screener adapter — see [shadow_screener.mli]. *)
+
+open Core
+
+(** [_ma_direction_of_stage] is the conservative proxy for MA direction when the
+    only stage signal we have is the Weinstein stage variant. A Stage2 stock has
+    a rising MA by definition; a Stage4 stock has a falling MA; Stage1 and
+    Stage3 are base-building or distribution respectively, both with a flat MA.
+    The screener does not read [ma_direction] directly — it reads [stage] and
+    [prior_stage] — so this value is largely cosmetic but we keep it consistent
+    so debug output is not misleading. *)
+let _ma_direction_of_stage (stage : Weinstein_types.stage) :
+    Weinstein_types.ma_direction =
+  match stage with
+  | Stage2 _ -> Rising
+  | Stage4 _ -> Declining
+  | Stage1 _ | Stage3 _ -> Flat
+
+(** [_synthesize_stage_result] builds a [Stage.result] from Summary data. The
+    placeholder fields ([ma_slope_pct], [above_ma_count]) are documented in the
+    .mli as unused by the screener. [transition] is populated when [prior_stage]
+    differs from the current stage — matches [Stage.classify]'s contract. *)
+let _synthesize_stage_result ~(summary : Summary_compute.summary_values)
+    ~prior_stage : Stage.result =
+  let transition =
+    match prior_stage with
+    | None -> None
+    | Some prev when not (Weinstein_types.equal_stage prev summary.stage) ->
+        Some (prev, summary.stage)
+    | Some _ -> None
+  in
+  {
+    stage = summary.stage;
+    ma_value = summary.ma_30w;
+    ma_direction = _ma_direction_of_stage summary.stage;
+    ma_slope_pct = 0.0;
+    transition;
+    above_ma_count = 0;
+  }
+
+(** [_synthesize_rs_result] projects [rs_line] into an [Rs.result]. The
+    classification is binary — values at or above the Mansfield zero line (1.0)
+    are treated as [Positive_rising], values below as [Negative_declining]. The
+    [Positive_flat] / [Negative_improving] / crossover variants are unreachable
+    by design; see the .mli "Known divergence" section. [history] is [[]]
+    because the screener does not read it. *)
+let _synthesize_rs_result ~(summary : Summary_compute.summary_values) :
+    Rs.result =
+  let trend : Weinstein_types.rs_trend =
+    if Float.(summary.rs_line >= 1.0) then Positive_rising
+    else Negative_declining
+  in
+  {
+    current_rs = summary.rs_line;
+    current_normalized = summary.rs_line;
+    trend;
+    history = [];
+  }
+
+(** [_synthesize_volume_result] returns a placeholder [Adequate 1.5]
+    confirmation for Stage2 / Stage4 stubs, and [None] for Stage1 / Stage3. The
+    floor of the Adequate band is the minimum value
+    [Stock_analysis.is_breakout_candidate] / [is_breakdown_candidate] accept —
+    without it the shadow screener would never produce candidates because volume
+    data isn't retained at the Summary tier. The synthesis deliberately
+    collapses Strong/Adequate/Weak into a single value; see the .mli "Known
+    divergence" section. *)
+let _synthesize_volume_result ~(summary : Summary_compute.summary_values) :
+    Volume.result option =
+  let open Weinstein_types in
+  match summary.stage with
+  | Stage2 _ | Stage4 _ ->
+      Some
+        {
+          confirmation = Adequate 1.5;
+          event_volume = 0;
+          avg_volume = 0.0;
+          volume_ratio = 1.5;
+        }
+  | Stage1 _ | Stage3 _ -> None
+
+let synthesize_analysis ~summary ~ticker ~prior_stage ~as_of : Stock_analysis.t
+    =
+  {
+    ticker;
+    stage = _synthesize_stage_result ~summary ~prior_stage;
+    rs = Some (_synthesize_rs_result ~summary);
+    volume = _synthesize_volume_result ~summary;
+    resistance = None;
+    breakout_price = None;
+    prior_stage;
+    as_of_date = as_of;
+  }
+
+(** [_collect_analyses] walks the requested universe of summaries and builds
+    synthesized analyses, updating [prior_stages] in place so the next call sees
+    the current stage as the prior — same contract as [_screen_universe] in the
+    Legacy path. *)
+let _collect_analyses ~summaries ~prior_stages ~as_of : Stock_analysis.t list =
+  List.map summaries ~f:(fun (ticker, summary) ->
+      let prior_stage = Hashtbl.find prior_stages ticker in
+      let analysis = synthesize_analysis ~summary ~ticker ~prior_stage ~as_of in
+      Hashtbl.set prior_stages ~key:ticker ~data:summary.Summary_compute.stage;
+      analysis)
+
+let screen ~summaries ~config ~macro_trend ~sector_map ~prior_stages
+    ~held_tickers ~as_of =
+  let stocks = _collect_analyses ~summaries ~prior_stages ~as_of in
+  Screener.screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers

--- a/trading/trading/backtest/bar_loader/shadow_screener.mli
+++ b/trading/trading/backtest/bar_loader/shadow_screener.mli
@@ -1,0 +1,101 @@
+(** Shadow screener adapter — drives [Screener.screen] from Summary-tier
+    scalars.
+
+    Lets the [Tiered] [Loader_strategy] path run the Friday screener without
+    materializing raw bars for every universe symbol. The adapter synthesizes
+    minimal [Stock_analysis.t] stubs from a list of
+    [(symbol, Summary_compute.summary_values)] pairs and hands them to
+    [Screener.screen].
+
+    {1 Synthesis strategy}
+
+    - {b Stage.result}: [ma_value] comes from [summary_values.ma_30w]; [stage]
+      comes from [summary_values.stage]; [ma_direction] is a conservative proxy
+      — [Rising] when [stage] is [Stage2 _], [Declining] when [Stage4 _], [Flat]
+      otherwise. [ma_slope_pct = 0.0] and [above_ma_count = 0] are placeholders
+      (the screener does not read them). [transition] is reconstructed by
+      comparing against [prior_stages].
+    - {b Rs.result}: synthesized from [summary_values.rs_line]. Trend is
+      classified by comparing against [1.0]: values [>= 1.0] →
+      [Positive_rising], values [< 1.0] → [Negative_declining]. [current_rs] /
+      [current_normalized] share the [rs_line] value; [history] is an empty
+      list.
+    - {b Volume.result}: Stage2 and Stage4 stubs get a synthetic [Adequate]
+      confirmation (ratio [1.5] — the floor of the [Adequate] band). This is the
+      minimum signal required for [Stock_analysis.is_breakout_candidate] /
+      [is_breakdown_candidate] to accept a transition; without it, the shadow
+      screener would return zero candidates for every universe (the Summary tier
+      does not retain volume bars). Stage1 / Stage3 get [None]. This synthesis
+      deliberately collapses the Strong/Adequate/Weak spectrum to a single value
+      — the volume scoring weight becomes a constant bonus rather than a
+      discriminator.
+    - {b Resistance.result}: always [None].
+    - {b breakout_price}: [None]. The screener's candidate builder falls back to
+      [ma_value * (1 + breakout_fallback_pct)].
+
+    {1 Known divergence from the Legacy [_screen_universe] path}
+
+    The synthesis loses three signals:
+
+    - {b Volume}: the synthesis always returns [Adequate 1.5] for
+      breakout/breakdown stages; the Strong/Adequate/Weak spectrum of the Legacy
+      path collapses to a single value. Candidates with a genuine Strong volume
+      signal score ~10 points lower in shadow than in Legacy.
+    - {b Resistance}: no [Virgin_territory] / [Clean] bonus → a further ~10–15
+      point reduction.
+    - {b RS crossover}: [Bullish_crossover] / [Bearish_crossover] are never
+      emitted because the synthesis lacks an RS history series — the crossover
+      bonus is unreachable.
+
+    These are documented, accepted gaps. The 3g parity test (separate PR) will
+    tell us whether the resulting candidate list diverges from Legacy enough to
+    matter in practice.
+
+    {1 Purity}
+
+    [screen] mutates [prior_stages] in place — the same contract as the Legacy
+    screener path. Every other input is treated as read-only. *)
+
+open Core
+
+val synthesize_analysis :
+  summary:Summary_compute.summary_values ->
+  ticker:string ->
+  prior_stage:Weinstein_types.stage option ->
+  as_of:Date.t ->
+  Stock_analysis.t
+(** [synthesize_analysis ~summary ~ticker ~prior_stage ~as_of] builds a minimal
+    [Stock_analysis.t] from the Summary-tier scalars. Exposed so tests and debug
+    tooling can inspect the synthesis without going through the full cascade.
+    See the module doc-comment for the exact synthesis rules. *)
+
+val screen :
+  summaries:(string * Summary_compute.summary_values) list ->
+  config:Screener.config ->
+  macro_trend:Weinstein_types.market_trend ->
+  sector_map:(string, Screener.sector_context) Hashtbl.t ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  held_tickers:string list ->
+  as_of:Date.t ->
+  Screener.result
+(** [screen ~summaries ~config ~macro_trend ~sector_map ~prior_stages
+     ~held_tickers ~as_of] runs the screener cascade on the synthesized stubs.
+
+    @param summaries
+      [(ticker, summary_values)] pairs, one per symbol the caller wants
+      screened. Typically sourced from [Bar_loader.get_summary] for every ticker
+      at Summary tier or higher. Ordering is preserved through the screener
+      (which itself sorts by score).
+    @param config Screener parameters. Forwarded verbatim to [Screener.screen].
+    @param macro_trend Macro regime used by the cascade gate.
+    @param sector_map Ticker → [Screener.sector_context].
+    @param prior_stages
+      Mutable hashtable of previous [Weinstein_types.stage] per ticker. Read to
+      fill [Stock_analysis.t.prior_stage] and [Stage.result.transition]; written
+      with each ticker's new stage on the way out. Same contract as
+      [Weinstein_strategy._screen_universe].
+    @param held_tickers Positions already held — excluded by [Screener.screen].
+    @param as_of Analysis date; forwarded to the synthesized stubs.
+
+    Returns the standard [Screener.result] so the caller can feed it straight
+    into {!Weinstein_strategy.entries_from_candidates}. *)

--- a/trading/trading/backtest/bar_loader/test/dune
+++ b/trading/trading/backtest/bar_loader/test/dune
@@ -4,13 +4,15 @@
   test_summary_compute
   test_summary
   test_full
-  test_trace_integration)
+  test_trace_integration
+  test_shadow_screener)
  (modules
   test_metadata
   test_summary_compute
   test_summary
   test_full
-  test_trace_integration)
+  test_trace_integration
+  test_shadow_screener)
  (libraries
   ounit2
   core
@@ -22,6 +24,11 @@
   csv
   types
   weinstein.types
+  weinstein.screener
+  weinstein.stock_analysis
+  weinstein.rs
+  weinstein.volume
+  trading.base
   matchers)
  (preprocess
   (pps ppx_test_matcher)))

--- a/trading/trading/backtest/bar_loader/test/test_shadow_screener.ml
+++ b/trading/trading/backtest/bar_loader/test/test_shadow_screener.ml
@@ -1,0 +1,370 @@
+(** Tests for Bar_loader.Shadow_screener. *)
+
+open OUnit2
+open Core
+open Matchers
+module Shadow_screener = Bar_loader.Shadow_screener
+module Summary_compute = Bar_loader.Summary_compute
+
+let _as_of = Date.create_exn ~y:2023 ~m:Dec ~d:29
+
+let _mk_summary ?(ma_30w = 100.0) ?(atr_14 = 1.0) ?(rs_line = 1.0)
+    ?(stage : Weinstein_types.stage = Stage1 { weeks_in_base = 8 }) () :
+    Summary_compute.summary_values =
+  { ma_30w; atr_14; rs_line; stage; as_of = _as_of }
+
+let _mk_sector_map ~entries =
+  let tbl = Hashtbl.create (module String) in
+  List.iter entries ~f:(fun (ticker, ctx) ->
+      Hashtbl.set tbl ~key:ticker ~data:ctx);
+  tbl
+
+let _strong_sector : Screener.sector_context =
+  {
+    sector_name = "Tech";
+    rating = Strong;
+    stage = Stage2 { weeks_advancing = 5; late = false };
+  }
+
+let test_synthesize_rising_stage_maps_to_positive_rs _ =
+  let summary = _mk_summary ~rs_line:1.2 () in
+  let analysis =
+    Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
+      ~prior_stage:None ~as_of:_as_of
+  in
+  assert_that analysis.rs
+    (is_some_and
+       (field
+          (fun (r : Rs.result) -> r.trend)
+          (equal_to Weinstein_types.Positive_rising)))
+
+let test_synthesize_below_zero_line_maps_to_negative_declining _ =
+  let summary = _mk_summary ~rs_line:0.8 () in
+  let analysis =
+    Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
+      ~prior_stage:None ~as_of:_as_of
+  in
+  assert_that analysis.rs
+    (is_some_and
+       (field
+          (fun (r : Rs.result) -> r.trend)
+          (equal_to Weinstein_types.Negative_declining)))
+
+let test_synthesize_stage2_sets_ma_direction_rising _ =
+  let summary =
+    _mk_summary ~stage:(Stage2 { weeks_advancing = 3; late = false }) ()
+  in
+  let analysis =
+    Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
+      ~prior_stage:None ~as_of:_as_of
+  in
+  assert_that analysis.stage.ma_direction (equal_to Weinstein_types.Rising)
+
+let test_synthesize_stage4_sets_ma_direction_declining _ =
+  let summary = _mk_summary ~stage:(Stage4 { weeks_declining = 2 }) () in
+  let analysis =
+    Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
+      ~prior_stage:None ~as_of:_as_of
+  in
+  assert_that analysis.stage.ma_direction (equal_to Weinstein_types.Declining)
+
+let test_synthesize_stage1_and_stage3_use_flat _ =
+  let s1 =
+    Shadow_screener.synthesize_analysis
+      ~summary:(_mk_summary ~stage:(Stage1 { weeks_in_base = 8 }) ())
+      ~ticker:"S1" ~prior_stage:None ~as_of:_as_of
+  in
+  let s3 =
+    Shadow_screener.synthesize_analysis
+      ~summary:(_mk_summary ~stage:(Stage3 { weeks_topping = 2 }) ())
+      ~ticker:"S3" ~prior_stage:None ~as_of:_as_of
+  in
+  assert_that s1.stage.ma_direction (equal_to Weinstein_types.Flat);
+  assert_that s3.stage.ma_direction (equal_to Weinstein_types.Flat)
+
+let test_synthesize_transition_detected_when_prior_stage_differs _ =
+  let summary =
+    _mk_summary ~stage:(Stage2 { weeks_advancing = 1; late = false }) ()
+  in
+  let analysis =
+    Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
+      ~prior_stage:(Some (Weinstein_types.Stage1 { weeks_in_base = 10 }))
+      ~as_of:_as_of
+  in
+  assert_that analysis.stage.transition
+    (is_some_and
+       (equal_to
+          ( (Weinstein_types.Stage1 { weeks_in_base = 10 }
+              : Weinstein_types.stage),
+            (Weinstein_types.Stage2 { weeks_advancing = 1; late = false }
+              : Weinstein_types.stage) )))
+
+let test_synthesize_no_transition_when_prior_matches _ =
+  let summary = _mk_summary ~stage:(Stage1 { weeks_in_base = 8 }) () in
+  let analysis =
+    Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
+      ~prior_stage:(Some (Weinstein_types.Stage1 { weeks_in_base = 8 }))
+      ~as_of:_as_of
+  in
+  assert_that analysis.stage.transition is_none
+
+let test_synthesize_stage1_has_no_volume_and_no_resistance _ =
+  let summary = _mk_summary () in
+  let analysis =
+    Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
+      ~prior_stage:None ~as_of:_as_of
+  in
+  assert_that analysis.volume is_none;
+  assert_that analysis.resistance is_none;
+  assert_that analysis.breakout_price is_none
+
+let test_synthesize_stage2_gets_adequate_volume_floor _ =
+  let summary =
+    _mk_summary ~stage:(Stage2 { weeks_advancing = 1; late = false }) ()
+  in
+  let analysis =
+    Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
+      ~prior_stage:None ~as_of:_as_of
+  in
+  assert_that analysis.volume
+    (is_some_and
+       (field
+          (fun (v : Volume.result) -> v.confirmation)
+          (equal_to (Weinstein_types.Adequate 1.5))));
+  assert_that analysis.resistance is_none;
+  assert_that analysis.breakout_price is_none
+
+let test_screen_empty_summaries_returns_empty_result _ =
+  let prior_stages = Hashtbl.create (module String) in
+  let result =
+    Shadow_screener.screen ~summaries:[] ~config:Screener.default_config
+      ~macro_trend:Bullish
+      ~sector_map:(_mk_sector_map ~entries:[])
+      ~prior_stages ~held_tickers:[] ~as_of:_as_of
+  in
+  assert_that result.buy_candidates (size_is 0);
+  assert_that result.short_candidates (size_is 0);
+  assert_that result.watchlist (size_is 0);
+  assert_that result.macro_trend (equal_to Weinstein_types.Bullish)
+
+let test_screen_bearish_macro_produces_no_buys _ =
+  let summaries =
+    [
+      ( "STOCK",
+        _mk_summary
+          ~stage:(Stage2 { weeks_advancing = 2; late = false })
+          ~rs_line:1.2 () );
+    ]
+  in
+  let sector_map = _mk_sector_map ~entries:[ ("STOCK", _strong_sector) ] in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"STOCK"
+    ~data:(Weinstein_types.Stage1 { weeks_in_base = 10 });
+  let result =
+    Shadow_screener.screen ~summaries ~config:Screener.default_config
+      ~macro_trend:Bearish ~sector_map ~prior_stages ~held_tickers:[]
+      ~as_of:_as_of
+  in
+  assert_that result.buy_candidates (size_is 0)
+
+let test_screen_stage2_transition_produces_buy_candidate _ =
+  let summaries =
+    [
+      ( "STOCK",
+        _mk_summary
+          ~stage:(Stage2 { weeks_advancing = 1; late = false })
+          ~rs_line:1.2 ~ma_30w:100.0 () );
+    ]
+  in
+  let sector_map = _mk_sector_map ~entries:[ ("STOCK", _strong_sector) ] in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"STOCK"
+    ~data:(Weinstein_types.Stage1 { weeks_in_base = 10 });
+  let result =
+    Shadow_screener.screen ~summaries ~config:Screener.default_config
+      ~macro_trend:Bullish ~sector_map ~prior_stages ~held_tickers:[]
+      ~as_of:_as_of
+  in
+  assert_that result.buy_candidates
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : Screener.scored_candidate) -> c.ticker)
+               (equal_to "STOCK");
+             field
+               (fun (c : Screener.scored_candidate) -> c.side)
+               (equal_to Trading_base.Types.Long);
+           ];
+       ])
+
+let test_screen_updates_prior_stages_in_place _ =
+  let summaries =
+    [
+      ( "STOCK",
+        _mk_summary ~stage:(Stage2 { weeks_advancing = 1; late = false }) () );
+    ]
+  in
+  let prior_stages = Hashtbl.create (module String) in
+  let _ =
+    Shadow_screener.screen ~summaries ~config:Screener.default_config
+      ~macro_trend:Bullish
+      ~sector_map:(_mk_sector_map ~entries:[])
+      ~prior_stages ~held_tickers:[] ~as_of:_as_of
+  in
+  assert_that
+    (Hashtbl.find prior_stages "STOCK")
+    (is_some_and
+       (equal_to (Weinstein_types.Stage2 { weeks_advancing = 1; late = false })))
+
+let test_screen_held_tickers_excluded _ =
+  let summaries =
+    [
+      ( "HELD",
+        _mk_summary
+          ~stage:(Stage2 { weeks_advancing = 1; late = false })
+          ~rs_line:1.3 () );
+    ]
+  in
+  let sector_map = _mk_sector_map ~entries:[ ("HELD", _strong_sector) ] in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"HELD"
+    ~data:(Weinstein_types.Stage1 { weeks_in_base = 10 });
+  let result =
+    Shadow_screener.screen ~summaries ~config:Screener.default_config
+      ~macro_trend:Bullish ~sector_map ~prior_stages ~held_tickers:[ "HELD" ]
+      ~as_of:_as_of
+  in
+  assert_that result.buy_candidates (size_is 0)
+
+let test_screen_stage4_transition_produces_short_candidate _ =
+  let weak_sector : Screener.sector_context =
+    {
+      sector_name = "Tech";
+      rating = Weak;
+      stage = Stage4 { weeks_declining = 2 };
+    }
+  in
+  let summaries =
+    [
+      ( "STOCK",
+        _mk_summary ~stage:(Stage4 { weeks_declining = 1 }) ~rs_line:0.7 () );
+    ]
+  in
+  let sector_map = _mk_sector_map ~entries:[ ("STOCK", weak_sector) ] in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"STOCK"
+    ~data:(Weinstein_types.Stage3 { weeks_topping = 3 });
+  let result =
+    Shadow_screener.screen ~summaries ~config:Screener.default_config
+      ~macro_trend:Neutral ~sector_map ~prior_stages ~held_tickers:[]
+      ~as_of:_as_of
+  in
+  assert_that result.short_candidates
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : Screener.scored_candidate) -> c.ticker)
+               (equal_to "STOCK");
+             field
+               (fun (c : Screener.scored_candidate) -> c.side)
+               (equal_to Trading_base.Types.Short);
+           ];
+       ])
+
+let test_screen_preserves_synthesis_on_analysis_field _ =
+  let summaries =
+    [
+      ( "STOCK",
+        _mk_summary
+          ~stage:(Stage2 { weeks_advancing = 1; late = false })
+          ~rs_line:1.2 () );
+    ]
+  in
+  let sector_map = _mk_sector_map ~entries:[ ("STOCK", _strong_sector) ] in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"STOCK"
+    ~data:(Weinstein_types.Stage1 { weeks_in_base = 10 });
+  let result =
+    Shadow_screener.screen ~summaries ~config:Screener.default_config
+      ~macro_trend:Bullish ~sector_map ~prior_stages ~held_tickers:[]
+      ~as_of:_as_of
+  in
+  assert_that result.buy_candidates
+    (elements_are
+       [
+         field
+           (fun (c : Screener.scored_candidate) -> c.analysis)
+           (all_of
+              [
+                field
+                  (fun (a : Stock_analysis.t) -> a.volume)
+                  (is_some_and
+                     (field
+                        (fun (v : Volume.result) -> v.confirmation)
+                        (equal_to (Weinstein_types.Adequate 1.5))));
+                field (fun (a : Stock_analysis.t) -> a.resistance) is_none;
+                field (fun (a : Stock_analysis.t) -> a.breakout_price) is_none;
+              ]);
+       ])
+
+let test_screen_rejects_mid_stage2_without_prior_stage1 _ =
+  let summaries =
+    [
+      ( "STOCK",
+        _mk_summary
+          ~stage:(Stage2 { weeks_advancing = 10; late = false })
+          ~rs_line:1.2 () );
+    ]
+  in
+  let sector_map = _mk_sector_map ~entries:[ ("STOCK", _strong_sector) ] in
+  let prior_stages = Hashtbl.create (module String) in
+  let result =
+    Shadow_screener.screen ~summaries ~config:Screener.default_config
+      ~macro_trend:Bullish ~sector_map ~prior_stages ~held_tickers:[]
+      ~as_of:_as_of
+  in
+  assert_that result.buy_candidates (size_is 0)
+
+let suite =
+  "Shadow_screener"
+  >::: [
+         "synthesize_rising_stage_maps_to_positive_rs"
+         >:: test_synthesize_rising_stage_maps_to_positive_rs;
+         "synthesize_below_zero_line_maps_to_negative_declining"
+         >:: test_synthesize_below_zero_line_maps_to_negative_declining;
+         "synthesize_stage2_sets_ma_direction_rising"
+         >:: test_synthesize_stage2_sets_ma_direction_rising;
+         "synthesize_stage4_sets_ma_direction_declining"
+         >:: test_synthesize_stage4_sets_ma_direction_declining;
+         "synthesize_stage1_and_stage3_use_flat"
+         >:: test_synthesize_stage1_and_stage3_use_flat;
+         "synthesize_transition_detected_when_prior_stage_differs"
+         >:: test_synthesize_transition_detected_when_prior_stage_differs;
+         "synthesize_no_transition_when_prior_matches"
+         >:: test_synthesize_no_transition_when_prior_matches;
+         "synthesize_stage1_has_no_volume_and_no_resistance"
+         >:: test_synthesize_stage1_has_no_volume_and_no_resistance;
+         "synthesize_stage2_gets_adequate_volume_floor"
+         >:: test_synthesize_stage2_gets_adequate_volume_floor;
+         "screen_empty_summaries_returns_empty_result"
+         >:: test_screen_empty_summaries_returns_empty_result;
+         "screen_bearish_macro_produces_no_buys"
+         >:: test_screen_bearish_macro_produces_no_buys;
+         "screen_stage2_transition_produces_buy_candidate"
+         >:: test_screen_stage2_transition_produces_buy_candidate;
+         "screen_updates_prior_stages_in_place"
+         >:: test_screen_updates_prior_stages_in_place;
+         "screen_held_tickers_excluded" >:: test_screen_held_tickers_excluded;
+         "screen_stage4_transition_produces_short_candidate"
+         >:: test_screen_stage4_transition_produces_short_candidate;
+         "screen_preserves_synthesis_on_analysis_field"
+         >:: test_screen_preserves_synthesis_on_analysis_field;
+         "screen_rejects_mid_stage2_without_prior_stage1"
+         >:: test_screen_rejects_mid_stage2_without_prior_stage1;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/bar_loader/test/test_shadow_screener.ml
+++ b/trading/trading/backtest/bar_loader/test/test_shadow_screener.ml
@@ -114,9 +114,13 @@ let test_synthesize_stage1_has_no_volume_and_no_resistance _ =
     Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
       ~prior_stage:None ~as_of:_as_of
   in
-  assert_that analysis.volume is_none;
-  assert_that analysis.resistance is_none;
-  assert_that analysis.breakout_price is_none
+  assert_that analysis
+    (all_of
+       [
+         field (fun (a : Stock_analysis.t) -> a.volume) is_none;
+         field (fun (a : Stock_analysis.t) -> a.resistance) is_none;
+         field (fun (a : Stock_analysis.t) -> a.breakout_price) is_none;
+       ])
 
 let test_synthesize_stage2_gets_adequate_volume_floor _ =
   let summary =
@@ -126,13 +130,18 @@ let test_synthesize_stage2_gets_adequate_volume_floor _ =
     Shadow_screener.synthesize_analysis ~summary ~ticker:"STOCK"
       ~prior_stage:None ~as_of:_as_of
   in
-  assert_that analysis.volume
-    (is_some_and
-       (field
-          (fun (v : Volume.result) -> v.confirmation)
-          (equal_to (Weinstein_types.Adequate 1.5))));
-  assert_that analysis.resistance is_none;
-  assert_that analysis.breakout_price is_none
+  assert_that analysis
+    (all_of
+       [
+         field
+           (fun (a : Stock_analysis.t) -> a.volume)
+           (is_some_and
+              (field
+                 (fun (v : Volume.result) -> v.confirmation)
+                 (equal_to (Weinstein_types.Adequate 1.5))));
+         field (fun (a : Stock_analysis.t) -> a.resistance) is_none;
+         field (fun (a : Stock_analysis.t) -> a.breakout_price) is_none;
+       ])
 
 let test_screen_empty_summaries_returns_empty_result _ =
   let prior_stages = Hashtbl.create (module String) in


### PR DESCRIPTION
## Summary

Adds `Bar_loader.Shadow_screener` — an adapter that synthesizes minimal
`Stock_analysis.t` stubs from Summary-tier scalars (`Summary_compute.summary_values`)
and drives the existing `Screener.screen` cascade.

This unblocks the Tiered runner path's Friday screener without materializing
raw bars for every universe symbol. It is part of backtest-scale increment
**3f**; the runner-side integration (`_run_tiered_backtest` in `runner.ml`)
will follow in a subsequent commit.

## What's in this PR

- `trading/trading/backtest/bar_loader/shadow_screener.{ml,mli}` — adapter module
- `trading/trading/backtest/bar_loader/test/test_shadow_screener.ml` — 17 unit tests
- `bar_loader.{ml,mli}` + `dune` — re-export the adapter and add `weinstein.{rs,volume,stock_analysis,screener}` library deps
- `test/dune` — register the test binary

## Synthesis rules (documented on the .mli)

- **Stage.result** — reconstructed from `summary.stage` + `summary.ma_30w`. `ma_direction` uses a conservative proxy (`Rising` for Stage2, `Declining` for Stage4, else `Flat`). `transition` reconstructed by comparing against caller-supplied `prior_stages`.
- **Rs.result** — binary classification: `rs_line >= 1.0` → `Positive_rising`, otherwise `Negative_declining`.
- **Volume.result** — `Some Adequate 1.5` (the floor required by `is_breakout_candidate`) for Stage2/Stage4; `None` otherwise. Collapses the Strong/Adequate/Weak spectrum to one value.
- **Resistance / breakout_price** — always `None`; the candidate builder falls back to `ma_value * (1 + breakout_fallback_pct)`.

## Known divergence from Legacy `_screen_universe`

Three signals are lost (all documented in the .mli):
- Volume band collapse → candidates score ~10 pts lower than Legacy.
- No resistance → no `Virgin_territory`/`Clean` bonus (~10-15 pts).
- No RS history → `Bullish_crossover`/`Bearish_crossover` never emitted.

The **3g parity test (separate PR)** will quantify whether this divergence matters in practice.

## Test plan

- [x] `dune build trading/backtest/bar_loader` — clean
- [x] `dune runtest trading/backtest/bar_loader` — 17/17 new tests pass; all pre-existing tests still green
- [x] `dune build @fmt` — clean
- [x] Full-project `dune build` — clean
- [ ] Integration test via `_run_tiered_backtest` — follow-up commit
- [ ] Parity vs Legacy — 3g (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
