### PR TITLE
harness: same-day summary consolidation script (dev/lib/consolidate_day.sh)

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -1317,6 +1317,43 @@ fi
 
 Flag in §Escalations when auto-merge fails: note the PR number and the GitHub response so the human can diagnose (most common cause: required status check that didn't run, or `main` branch-protection requiring a human reviewer).
 
+### Step 8b: Consolidated summary (N >= 3)
+
+When this is the third or later run of the day (N >= 3), generate a same-day
+consolidated summary and include it in the summary PR before pushing.
+
+**Why amend into the same PR rather than a separate branch:** the consolidated
+summary is a view over the same day's runs -- it belongs with the run-N summary
+rather than requiring a separate PR lifecycle. Including it in the same commit
+keeps Step 8's PR flow unchanged and avoids a second round of auto-merge.
+
+```bash
+# N was computed by Step 7 (basename suffix: run-2 -> N=2, no suffix -> N=1).
+# Re-derive N from the BASENAME set at the top of Step 8.
+if echo "$BASENAME" | grep -qE '\-run[0-9]+$'; then
+  _N="${BASENAME##*-run}"
+else
+  _N=1
+fi
+
+if [ "$_N" -ge 3 ]; then
+  # Run consolidation -- writes dev/daily/${DATE}-summary.md
+  sh dev/lib/consolidate_day.sh "$DATE" 2>&1 \
+    || echo "WARN: consolidate_day.sh failed -- summary not included in PR"
+  # The output file will be auto-snapshotted by jj into @ before the push;
+  # in git-mode (GHA) we must add it explicitly.
+  if [ -n "${TRADING_IN_CONTAINER:-}" ]; then
+    git add "dev/daily/${DATE}-summary.md" 2>/dev/null || true
+    git commit --amend --no-edit 2>/dev/null \
+      || git commit -m "ops: add consolidated summary ${DATE}"
+  fi
+fi
+```
+
+If `consolidate_day.sh` fails (malformed files, missing sections), it warns to
+stderr and the per-run files remain intact -- no data loss. Do not block the
+summary PR on a consolidation failure.
+
 ---
 
 ## Escalation policy

--- a/dev/lib/consolidate_day.sh
+++ b/dev/lib/consolidate_day.sh
@@ -1,0 +1,384 @@
+#!/bin/sh
+# consolidate_day.sh — merge all per-run daily summaries for a date into a
+# single ${DATE}-summary.md file under dev/daily/.
+#
+# Usage: sh dev/lib/consolidate_day.sh YYYY-MM-DD
+#
+# Inputs:  dev/daily/${DATE}.md (run-1) and dev/daily/${DATE}-run*.md
+#          Excludes *-plan.md and the output target itself.
+# Output:  dev/daily/${DATE}-summary.md (overwritten on re-run — idempotent)
+# Exit 0 on success; exit 1 with FAIL: message on bad args or no inputs.
+#
+# Section extraction helpers warn to stderr and continue on malformed input.
+# POSIX sh — no bash-isms.
+
+set -eu
+
+# ── arg check ────────────────────────────────────────────────────────────────
+DATE="${1:-}"
+if [ -z "$DATE" ]; then
+  echo "FAIL: consolidate_day.sh — missing required argument DATE (YYYY-MM-DD)" >&2
+  exit 1
+fi
+# POSIX-safe date format check (grep -E is widely available but use -E explicitly)
+if ! echo "$DATE" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+  echo "FAIL: consolidate_day.sh — malformed DATE argument (expected YYYY-MM-DD, got: $DATE)" >&2
+  exit 1
+fi
+
+# ── locate daily dir ─────────────────────────────────────────────────────────
+# If CONSOLIDATE_DAY_DIR is set (tests use this), use it directly.
+# Otherwise walk up from the script's directory to find the .git root.
+if [ -n "${CONSOLIDATE_DAY_DIR:-}" ]; then
+  DAILY_DIR="$CONSOLIDATE_DAY_DIR"
+else
+  _dir="$(cd "$(dirname "$0")" && pwd)"
+  while [ "$_dir" != "/" ] && [ ! -d "$_dir/.git" ]; do
+    _dir="$(dirname "$_dir")"
+  done
+  if [ ! -d "$_dir/.git" ]; then
+    echo "FAIL: consolidate_day.sh — could not locate .git root from $(dirname "$0")" >&2
+    exit 1
+  fi
+  DAILY_DIR="$_dir/dev/daily"
+fi
+
+OUTPUT="${DAILY_DIR}/${DATE}-summary.md"
+OUTPUT_BASENAME="$(basename "$OUTPUT")"
+
+# ── enumerate input files in chronological order ─────────────────────────────
+# run-1 = ${DATE}.md, then -run2, -run3, ... by numeric suffix.
+# Enumerate into a newline-delimited temp file to avoid word-splitting issues.
+TMP_INPUTS="$(mktemp)"
+if [ -f "${DAILY_DIR}/${DATE}.md" ]; then
+  echo "${DAILY_DIR}/${DATE}.md" >> "$TMP_INPUTS"
+fi
+# run-N files — sort -V sorts version-style (numeric suffix order).
+# grep -v guards against -plan.md and the output file itself.
+for f in "${DAILY_DIR}/${DATE}-run"*.md; do
+  [ -f "$f" ] || continue
+  case "$(basename "$f")" in
+    *-plan.md)          continue ;;
+    "$OUTPUT_BASENAME") continue ;;
+  esac
+  echo "$f"
+done | sort -V >> "$TMP_INPUTS"
+
+# Count inputs
+INPUT_COUNT=0
+while IFS= read -r _line; do
+  INPUT_COUNT=$((INPUT_COUNT + 1))
+done < "$TMP_INPUTS"
+
+if [ "$INPUT_COUNT" -eq 0 ]; then
+  rm -f "$TMP_INPUTS"
+  echo "FAIL: consolidate_day.sh — no input files found for date $DATE in $DAILY_DIR" >&2
+  exit 1
+fi
+
+# ── helper: extract_section FILE HEADING ─────────────────────────────────────
+# Prints the body of a section from "## HEADING" to the next "## " (exclusive).
+# Warns to stderr and prints nothing if section is absent.
+extract_section() {
+  _es_file="$1"
+  _es_heading="$2"
+  _es_result="$(awk -v h="$_es_heading" '
+    /^## / { if (found) { exit } if ($0 == h) { found=1; next } }
+    found  { print }
+  ' "$_es_file")"
+  if [ -z "$_es_result" ]; then
+    echo "WARN: $_es_file: section '$_es_heading' not found or empty" >&2
+  fi
+  printf '%s\n' "$_es_result"
+}
+
+# ── helper: run_label FILEPATH → "run-N" ─────────────────────────────────────
+run_label() {
+  _rl_base="$(basename "$1" .md)"
+  # If basename ends in -runN, extract N; otherwise this is run-1.
+  case "$_rl_base" in
+    *-run[0-9]*)
+      _rl_n="${_rl_base##*-run}"
+      echo "run-${_rl_n}"
+      ;;
+    *)
+      echo "run-1"
+      ;;
+  esac
+}
+
+# ── build run inventory ───────────────────────────────────────────────────────
+TMP_LABELS="$(mktemp)"
+LAST_FILE=""
+N=0
+while IFS= read -r f; do
+  lbl="$(run_label "$f")"
+  echo "$lbl" >> "$TMP_LABELS"
+  LAST_FILE="$f"
+  N=$((N + 1))
+done < "$TMP_INPUTS"
+
+# comma-separated run list for header line
+RUNS_DISPLAY="$(tr '\n' ',' < "$TMP_LABELS" | sed 's/,$//' | sed 's/,/, /g')"
+rm -f "$TMP_LABELS"
+
+GENERATED="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u)"
+
+# ── section 1: Pending work — from last run ───────────────────────────────────
+PENDING="$(extract_section "$LAST_FILE" "## Pending work")"
+
+# ── section 2: Dispatched — deduped union ────────────────────────────────────
+# Strategy: tag every dispatch row with its run label, then use awk to dedup
+# on (Track, Agent, Outcome). When (Track, Agent) appears with conflicting
+# Outcomes in different runs, emit both rows with (run-N) appended to Notes.
+
+TMP_DISPATCHED="$(mktemp)"
+while IFS= read -r f; do
+  lbl="$(run_label "$f")"
+  awk -v h="## Dispatched this run" -v lbl="$lbl" '
+    /^## / { if (found) { exit } if ($0 == h) { found=1; next } }
+    found && /^\|/ && !/^\|[[:space:]]*Track[[:space:]]*\|/ && !/^\|[-|]+\|/ {
+      print lbl"\t"$0
+    }
+  ' "$f"
+done < "$TMP_INPUTS" > "$TMP_DISPATCHED"
+
+DISPATCHED_ROWS="$(awk -F'\t' '
+{
+  run = $1
+  row = $2
+  # Parse pipe-delimited row: | Track | Agent | Outcome | Notes |
+  n = split(row, fields, "|")
+  if (n < 5) next
+  track   = fields[2]; gsub(/^[[:space:]]+|[[:space:]]+$/, "", track)
+  agent   = fields[3]; gsub(/^[[:space:]]+|[[:space:]]+$/, "", agent)
+  outcome = fields[4]; gsub(/^[[:space:]]+|[[:space:]]+$/, "", outcome)
+  notes   = fields[5]; gsub(/^[[:space:]]+|[[:space:]]+$/, "", notes)
+
+  key_full = track "|" agent "|" outcome
+  key_ta   = track "|" agent
+
+  if (key_full in seen) next   # identical row — skip
+  seen[key_full] = 1
+
+  if (key_ta in ta_seen) {
+    # Same (Track, Agent) appeared before with a different outcome.
+    # Suffix this row Notes with its run label.
+    if (notes == "") { notes = "(" run ")" } else { notes = notes " (" run ")" }
+    needs_suffix[key_ta] = 1
+    ta_run[key_ta] = ta_run[key_ta] "," run
+  } else {
+    ta_seen[key_ta]  = outcome
+    ta_run[key_ta]   = run
+  }
+
+  order[++count] = key_full
+  row_track[key_full]   = track
+  row_agent[key_full]   = agent
+  row_outcome[key_full] = outcome
+  row_notes[key_full]   = notes
+  row_run[key_full]     = run
+  row_ta[key_full]      = key_ta
+}
+END {
+  for (i = 1; i <= count; i++) {
+    k     = order[i]
+    ta    = row_ta[k]
+    notes = row_notes[k]
+    # Also suffix the first occurrence if its sibling got a suffix
+    if (ta in needs_suffix) {
+      if (notes !~ /[(]run-/) {
+        if (notes == "") { notes = "(" row_run[k] ")" } else { notes = notes " (" row_run[k] ")" }
+      }
+    }
+    printf "| %s | %s | %s | %s |\n",
+      row_track[k], row_agent[k], row_outcome[k], notes
+  }
+}
+' "$TMP_DISPATCHED")"
+rm -f "$TMP_DISPATCHED"
+
+# ── section 3: QC Status — latest per track ─────────────────────────────────
+TMP_QC="$(mktemp)"
+while IFS= read -r f; do
+  awk -v h="## QC Status" '
+    /^## / { if (found) { exit } if ($0 == h) { found=1; next } }
+    found && /^-/ { print }
+  ' "$f"
+done < "$TMP_INPUTS" > "$TMP_QC"
+
+QC_ROWS="$(awk '
+{
+  # Key = text before the first colon on the line (POSIX awk compatible)
+  line = $0
+  key = line
+  sub(/^- /, "", key)
+  # Everything before the first colon
+  if (index(key, ":") > 0) {
+    key = substr(key, 1, index(key, ":") - 1)
+  }
+  gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+  if (key == "") { key = $0 }
+  if (!(key in seen)) { seen[key] = 1; order[++count] = key }
+  rows[key] = $0
+}
+END {
+  for (i = 1; i <= count; i++) {
+    print rows[order[i]]
+  }
+}
+' "$TMP_QC")"
+rm -f "$TMP_QC"
+
+# ── section 4: Budget — sum across runs ──────────────────────────────────────
+TOTAL_SUBAGENTS=0
+TOTAL_COST_NOTES=""
+KILLED_EVENTS=""
+
+while IFS= read -r f; do
+  lbl="$(run_label "$f")"
+  # extract_section may warn to stderr — that's fine, we handle empty gracefully
+  BUDGET_SECTION="$(extract_section "$f" "## Budget" 2>/dev/null)" || true
+  if [ -z "$BUDGET_SECTION" ]; then
+    TOTAL_COST_NOTES="${TOTAL_COST_NOTES}
+- Budget not parseable from $lbl (section missing)"
+    continue
+  fi
+  spawned="$(printf '%s\n' "$BUDGET_SECTION" \
+    | grep -i 'subagents spawned' | grep -oE '[0-9]+' | head -1)" || true
+  if [ -n "$spawned" ]; then
+    TOTAL_SUBAGENTS=$((TOTAL_SUBAGENTS + spawned))
+  fi
+  util="$(printf '%s\n' "$BUDGET_SECTION" \
+    | grep -i 'Budget utilization:' | head -1)" || true
+  if [ -n "$util" ]; then
+    TOTAL_COST_NOTES="${TOTAL_COST_NOTES}
+- $lbl: $util"
+  fi
+  killed="$(printf '%s\n' "$BUDGET_SECTION" \
+    | grep -i 'killed mid-flight' | head -1)" || true
+  if printf '%s\n' "$killed" | grep -qi 'yes'; then
+    KILLED_EVENTS="${KILLED_EVENTS}
+- $lbl: $killed"
+  fi
+done < "$TMP_INPUTS"
+
+# Strip leading newlines from accumulated strings
+TOTAL_COST_NOTES="$(printf '%s' "$TOTAL_COST_NOTES" | sed '1{/^$/d}')"
+KILLED_EVENTS="$(printf '%s' "$KILLED_EVENTS" | sed '1{/^$/d}')"
+[ -z "$KILLED_EVENTS" ] && KILLED_EVENTS="None reported across all runs."
+
+# ── section 5: Escalations — deduped union ───────────────────────────────────
+TMP_ESC="$(mktemp)"
+while IFS= read -r f; do
+  lbl="$(run_label "$f")"
+  awk -v h="## Escalations" -v lbl="$lbl" '
+    /^## / { if (found) { exit } if ($0 == h) { found=1; next } }
+    found && /^[0-9]+\. |^- / { print lbl"\t"$0 }
+  ' "$f"
+done < "$TMP_INPUTS" > "$TMP_ESC"
+
+ESC_ITEMS="$(awk -F'\t' '
+{
+  run  = $1
+  line = $2
+  # Strip leading markers and severity tags for the dedup key
+  key = line
+  sub(/^[0-9]+\. /,    "", key)
+  sub(/^- /,           "", key)
+  sub(/^\*\*\[.*\]\*\* /, "", key)
+  sub(/^\[.*\] /,      "", key)
+  short_key = substr(key, 1, 60)
+
+  if (short_key in seen) {
+    seen_runs[short_key] = seen_runs[short_key] "," run
+  } else {
+    seen[short_key]      = run
+    seen_runs[short_key] = run
+    order[++count]       = short_key
+    full_line[short_key] = line
+  }
+}
+END {
+  for (i = 1; i <= count; i++) {
+    k    = order[i]
+    line = full_line[k]
+    runs = seen_runs[k]
+    n    = split(runs, r, ",")
+    if (n > 1) {
+      sub(/\.$/, "", line)
+      line = line " (seen in: " runs ")"
+    }
+    print line
+  }
+}
+' "$TMP_ESC")"
+rm -f "$TMP_ESC"
+
+# ── section 6: Integration Queue — from last run ─────────────────────────────
+INT_QUEUE="$(extract_section "$LAST_FILE" "## Integration Queue")"
+
+# ── section 7: Per-run links ─────────────────────────────────────────────────
+TMP_LINKS="$(mktemp)"
+while IFS= read -r f; do
+  lbl="$(run_label "$f")"
+  fname="$(basename "$f")"
+  echo "- $lbl -> \`$fname\`"
+done < "$TMP_INPUTS" > "$TMP_LINKS"
+
+# ── write output ─────────────────────────────────────────────────────────────
+{
+  echo "# Consolidated Summary — ${DATE}"
+  echo "Runs included: ${RUNS_DISPLAY} (${N} total)"
+  echo "Generated: ${GENERATED}"
+  echo ""
+  echo "## Pending work (from last run)"
+  if [ -n "$PENDING" ]; then
+    printf '%s\n' "$PENDING"
+  else
+    echo "(section not found in last run)"
+  fi
+  echo ""
+  echo "## Dispatched across all runs (deduped)"
+  echo "| Track | Agent | Outcome | Notes |"
+  echo "|-------|-------|---------|-------|"
+  if [ -n "$DISPATCHED_ROWS" ]; then
+    printf '%s\n' "$DISPATCHED_ROWS"
+  else
+    echo "| — | — | — | No dispatched rows found |"
+  fi
+  echo ""
+  echo "## QC across all runs"
+  if [ -n "$QC_ROWS" ]; then
+    printf '%s\n' "$QC_ROWS"
+  else
+    echo "(no QC entries found)"
+  fi
+  echo ""
+  echo "## Budget (summed across runs)"
+  echo "- Total subagents spawned: ${TOTAL_SUBAGENTS}"
+  if [ -n "$TOTAL_COST_NOTES" ]; then
+    printf '%s\n' "$TOTAL_COST_NOTES"
+  fi
+  echo "- Killed mid-flight: ${KILLED_EVENTS}"
+  echo ""
+  echo "## Escalations (merged)"
+  if [ -n "$ESC_ITEMS" ]; then
+    printf '%s\n' "$ESC_ITEMS"
+  else
+    echo "(no escalation items found)"
+  fi
+  echo ""
+  echo "## Integration Queue (last run's view)"
+  if [ -n "$INT_QUEUE" ]; then
+    printf '%s\n' "$INT_QUEUE"
+  else
+    echo "(no Integration Queue section in last run)"
+  fi
+  echo ""
+  echo "## Per-run links"
+  cat "$TMP_LINKS"
+} > "$OUTPUT"
+
+rm -f "$TMP_INPUTS" "$TMP_LINKS"
+echo "OK: consolidated summary written to $OUTPUT (${N} runs)"

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -119,14 +119,12 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
   environment (see `dev/status/orchestrator-automation.md`), this part
   needs to land together with the automation work. Source:
   `dev/daily/2026-04-14.md` (refreshed end-of-day).
-- **Same-day summary consolidation** — multi-run days produce
-  `2026-04-18.md`, `-run2.md`, `-run3.md`, `-run4.md` with no
-  end-of-day roll-up. A plan-mode reader has to stitch four files to
-  answer "what happened today." Low severity. Fix sketch: add a
-  `dev/lib/consolidate_day.sh` that merges all `${DATE}*.md` (non-plan)
-  into `${DATE}-summary.md` with deduped §Dispatched + merged
-  §Escalations; wire into `lead-orchestrator` Step 8 post-merge when
-  `N >= 3`. Source: 2026-04-18 plan-mode audit.
+- ~~**Same-day summary consolidation**~~ — DONE (#467): `dev/lib/consolidate_day.sh` added;
+  merges all `${DATE}*.md` (non-plan) into `${DATE}-summary.md` with deduped
+  §Dispatched, merged §Escalations (with "(seen in: run-N)" suffix), summed §Budget,
+  latest §QC per track, and per-run links. Wired into `lead-orchestrator` Step 8b
+  (runs post-auto-merge when N >= 3). Smoke test: `trading/devtools/checks/consolidate_day_check.sh`.
+  Source: 2026-04-18 plan-mode audit.
 - **Deep scan heuristic gaps** — `trading/devtools/checks/deep_scan.sh`
   (T3-A, see #331) is missing several useful checks. Today's manual
   audit found four real issues the script didn't surface:
@@ -294,6 +292,22 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
 - [x] `dev/run.sh` pre-flight — fast-fails at the shell (not inside the orchestrator) if `claude` isn't on PATH, `.claude/agents/lead-orchestrator.md` is missing, or its `## Allowed Tools` section no longer lists `Agent`. Each failure prints `FAIL: <what>` to stderr and exits 1. Block is placed immediately after `REPO_ROOT=...` and uses only POSIX-compatible constructs (works with `set -euo pipefail`). Verify: `sh -n dev/run.sh` passes syntax check; temporarily rename `.claude/agents/lead-orchestrator.md` and re-run `dev/run.sh` — it exits 1 with a clear `FAIL:` message.
 - [x] `dev/config/merge-policy.json` — default merge-policy config committed with inline defaults (`followup_threshold: 10`, `maintenance_cycle_ratio: 3`, `auto_merge_enabled: false`). Matches the inline defaults previously embedded in `lead-orchestrator.md` Step 2b — now visible and tweakable without editing the agent definition. Intent documented in `dev/config/README.md`. Verify: `jq . dev/config/merge-policy.json` parses cleanly.
 - [x] Orchestrator `## Plan Mode` — added to `.claude/agents/lead-orchestrator.md`; triggered by a `--plan` token in the prompt, short-circuits Steps 2–6, writes `dev/daily/<YYYY-MM-DD>-plan.md` with `(plan mode)` marker, never mutates branches or status files. Structural smoke test at `trading/devtools/checks/orchestrator_plan_check.sh` wired into `dune runtest` — grep-asserts the required Plan Mode contract pieces in the agent definition. Does NOT invoke `claude -p` from dune runtest (credentials/network/flakiness). Verify: `dune runtest trading/devtools/checks/` — prints `OK: lead-orchestrator plan mode contract present.`
+
+### Same-day summary consolidation
+
+- [x] `dev/lib/consolidate_day.sh` — merges all `${DATE}*.md` (non-plan) in `dev/daily/` into
+  `${DATE}-summary.md`. Sections: Pending work (last run), Dispatched (deduped union — same
+  (Track, Agent, Outcome) appears once; conflicting Outcomes get "(run-N)" suffix), QC per track
+  (latest per track), Budget (summed subagents + per-run utilization), Escalations (deduped union
+  with "(seen in: run-N, run-M)" suffix), Integration Queue (last run), Per-run links. Idempotent;
+  graceful on malformed sections (warns to stderr, continues). PR #467.
+  Wired into `lead-orchestrator.md` Step 8b — runs after auto-merge when N >= 3; consolidated
+  file committed into the same ops/daily-${DATE}-runN branch.
+  Smoke test: `trading/devtools/checks/consolidate_day_check.sh` (9 assertions: run header,
+  escalation dedup, distinct-outcome preservation, per-run links, budget sum, idempotency,
+  error cases for missing arg / malformed date / no files).
+  Verify: `dune runtest devtools/checks/` — prints `OK: consolidate_day_check — all assertions passed.`;
+  `sh dev/lib/consolidate_day.sh 2026-04-20` with three 2026-04-20 daily files present.
 
 ### Deep scan heuristic gap sub-item 1: Drift coverage extension (backtest)
 

--- a/trading/devtools/checks/consolidate_day_check.sh
+++ b/trading/devtools/checks/consolidate_day_check.sh
@@ -1,0 +1,208 @@
+#!/bin/sh
+# Smoke test for dev/lib/consolidate_day.sh.
+#
+# Generates a minimal three-run fixture in /tmp/consolidate_day_test/,
+# runs consolidate_day.sh against it, and verifies the output contains:
+#   - "Runs included: run-1, run-2, run-3"
+#   - dedup of a repeated Escalation (with "(seen in: ...)" suffix)
+#   - distinct-outcome rows both preserved with (run-N) suffix
+#   - all three per-run links
+#
+# Does NOT invoke the orchestrator or touch real dev/daily/ files.
+
+set -e
+
+. "$(dirname "$0")/_check_lib.sh"
+
+REPO_ROOT="$(repo_root)"
+SCRIPT="${REPO_ROOT}/dev/lib/consolidate_day.sh"
+
+[ -f "$SCRIPT" ] || die "consolidate_day_check: $SCRIPT does not exist"
+
+fail() {
+  echo "FAIL: consolidate_day_check — $1" >&2
+  exit 1
+}
+
+# ── fixture setup ─────────────────────────────────────────────────────────────
+TMP_DIR="/tmp/consolidate_day_test_$$"
+rm -rf "$TMP_DIR"
+mkdir -p "$TMP_DIR"
+
+DATE="2099-01-15"
+
+# run-1
+cat > "${TMP_DIR}/${DATE}.md" <<'EOF'
+# Status — 2099-01-15
+Run timestamp: 2099-01-15T01:00:00Z
+Run ID: 2099-01-15-run-1
+
+## Pending work
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| feat-alpha | in-progress | feat/alpha | #1 | Awaiting QC |
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| feat-alpha | feat-weinstein | completed | Initial slice. |
+| feat-beta | qc-structural | APPROVED | Clean pass. |
+
+## QC Status
+- feat-alpha: PENDING
+- feat-beta: **APPROVED** @ abc1234
+
+## Budget
+- Budget cap: $50.0
+- Subagents spawned: 2
+- Budget utilization: ~$3 / $50 (~6%)
+- Any subagent killed mid-flight: No
+
+## Escalations
+
+1. [critical] Main build is red — dune runtest exits 1 on main.
+2. [info] Orchestrator under-utilized budget.
+
+## Integration Queue
+- feat-beta (#2) — APPROVED, ready to merge.
+EOF
+
+# run-2
+cat > "${TMP_DIR}/${DATE}-run2.md" <<'EOF'
+# Status — 2099-01-15
+Run timestamp: 2099-01-15T05:00:00Z
+Run ID: 2099-01-15-run-2
+
+## Pending work
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| feat-alpha | dispatched | feat/alpha | #1 | QC in progress |
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| feat-alpha | qc-structural | NEEDS_REWORK | P2: magic number violation. |
+| feat-beta | qc-behavioral | APPROVED | Quality 4. |
+
+## QC Status
+- feat-alpha: **NEEDS_REWORK (P2)** @ def5678
+- feat-beta: **APPROVED** @ abc1234 (structural + behavioral)
+
+## Budget
+- Budget cap: $50.0
+- Subagents spawned: 2
+- Budget utilization: ~$3 / $50 (~6%)
+- Any subagent killed mid-flight: No
+
+## Escalations
+
+1. [critical] Main build is red — dune runtest exits 1 on main.
+3. [medium] Magic number linter trips on date string in comment.
+
+## Integration Queue
+- feat-beta (#2) — APPROVED (structural + behavioral), ready to merge.
+EOF
+
+# run-3
+cat > "${TMP_DIR}/${DATE}-run3.md" <<'EOF'
+# Status — 2099-01-15
+Run timestamp: 2099-01-15T10:00:00Z
+Run ID: 2099-01-15-run-3
+
+## Pending work
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| feat-alpha | re-QC | feat/alpha | #1 | Fixed magic number; re-QC dispatched |
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| feat-alpha | qc-structural | APPROVED | Magic number fix confirmed. |
+| feat-alpha | qc-behavioral | APPROVED | Quality 5. |
+
+## QC Status
+- feat-alpha: **APPROVED** @ feed9012 (structural + behavioral)
+- feat-beta: **APPROVED** @ abc1234 (merged)
+
+## Budget
+- Budget cap: $50.0
+- Subagents spawned: 2
+- Budget utilization: ~$3 / $50 (~6%)
+- Any subagent killed mid-flight: No
+
+## Escalations
+
+2. [info] Orchestrator under-utilized budget.
+
+## Integration Queue
+- feat-alpha (#1) — APPROVED, ready to merge.
+EOF
+
+# ── run the script ─────────────────────────────────────────────────────────────
+OUTPUT="${TMP_DIR}/${DATE}-summary.md"
+
+# Pass the test dir as CONSOLIDATE_DAY_DIR so the script doesn't need .git root
+CONSOLIDATE_DAY_DIR="$TMP_DIR" sh "$SCRIPT" "$DATE" \
+  || fail "consolidate_day.sh exited non-zero"
+
+[ -f "$OUTPUT" ] || fail "output file $OUTPUT not created"
+
+# ── assertions ─────────────────────────────────────────────────────────────────
+
+# 1. Runs included header
+grep -q "Runs included: run-1, run-2, run-3" "$OUTPUT" \
+  || fail "output missing 'Runs included: run-1, run-2, run-3'"
+
+# 2. Deduped escalation — the critical main-build line appears in both run-1 and
+#    run-2; the consolidated output should show it ONCE with "(seen in: ...)" suffix.
+grep -q "seen in:" "$OUTPUT" \
+  || fail "output missing dedup '(seen in: ...)' suffix for repeated escalation"
+
+# 3. Distinct outcomes for feat-alpha / qc-structural: run-2 = NEEDS_REWORK,
+#    run-3 = APPROVED; both rows should be present in the Dispatched table.
+grep -q "NEEDS_REWORK" "$OUTPUT" \
+  || fail "output missing NEEDS_REWORK row from run-2 feat-alpha qc-structural"
+grep -q "APPROVED" "$OUTPUT" \
+  || fail "output missing APPROVED row from run-3 feat-alpha qc-structural"
+
+# 4. Per-run links section contains all three files
+grep -q "run-1" "$OUTPUT" && grep -q "run-2" "$OUTPUT" && grep -q "run-3" "$OUTPUT" \
+  || fail "output missing one or more per-run links"
+grep -q "${DATE}.md" "$OUTPUT" \
+  || fail "output missing link to ${DATE}.md (run-1)"
+grep -q "${DATE}-run2.md" "$OUTPUT" \
+  || fail "output missing link to ${DATE}-run2.md"
+grep -q "${DATE}-run3.md" "$OUTPUT" \
+  || fail "output missing link to ${DATE}-run3.md"
+
+# 5. Budget totals — 3 runs × 2 subagents each = 6
+grep -q "Total subagents spawned: 6" "$OUTPUT" \
+  || fail "output total subagents should be 6 (3 runs × 2 each)"
+
+# 6. Idempotency — re-run should overwrite without error and produce same output
+FIRST_OUTPUT="$(cat "$OUTPUT")"
+CONSOLIDATE_DAY_DIR="$TMP_DIR" sh "$SCRIPT" "$DATE" \
+  || fail "consolidate_day.sh idempotent re-run exited non-zero"
+SECOND_OUTPUT="$(cat "$OUTPUT")"
+[ "$FIRST_OUTPUT" = "$SECOND_OUTPUT" ] \
+  || fail "output is not idempotent — re-run produced different content"
+
+# 7. Error on missing date arg
+CONSOLIDATE_DAY_DIR="$TMP_DIR" sh "$SCRIPT" 2>/dev/null && fail "should fail on missing date arg" || true
+
+# 8. Error on bad date format
+CONSOLIDATE_DAY_DIR="$TMP_DIR" sh "$SCRIPT" "not-a-date" 2>/dev/null && fail "should fail on malformed date" || true
+
+# 9. Error on date with no files
+CONSOLIDATE_DAY_DIR="$TMP_DIR" sh "$SCRIPT" "2099-12-31" 2>/dev/null && fail "should fail when no files exist for date" || true
+
+# ── cleanup ────────────────────────────────────────────────────────────────────
+rm -rf "$TMP_DIR"
+
+echo "OK: consolidate_day_check — all assertions passed."

--- a/trading/devtools/checks/dune
+++ b/trading/devtools/checks/dune
@@ -186,3 +186,13 @@
  (deps _check_lib.sh)
  (action
   (run sh %{dep:deep_scan_drift_coverage_check.sh})))
+
+; Same-day summary consolidation smoke test: generates a 3-run fixture in /tmp/,
+; runs dev/lib/consolidate_day.sh, and verifies deduped output sections.
+; Does NOT touch real dev/daily/ files.
+
+(rule
+ (alias runtest)
+ (deps _check_lib.sh)
+ (action
+  (run sh %{dep:consolidate_day_check.sh})))


### PR DESCRIPTION
## Summary

- Adds `dev/lib/consolidate_day.sh` to merge per-run daily summaries (`${DATE}.md`, `-run2.md`, ...) into a single `${DATE}-summary.md` with deduped §Dispatched (run-N suffix on conflicting outcomes), merged §Escalations (seen-in suffix on repeats), summed §Budget, latest §QC per track, and per-run links
- Adds smoke test `trading/devtools/checks/consolidate_day_check.sh` wired into `dune runtest` (9 assertions: ordering, dedup, distinct-outcome preservation, budget sum, idempotency, error cases)
- Wires into `lead-orchestrator.md` Step 8b — runs when N >= 3 after auto-merge, appends consolidated file into the same summary PR branch
- Updates `dev/status/harness.md` §Follow-up bullet to strikethrough DONE and adds §Completed entry

## What changed and why

Three commits, each dune-clean:
1. `dev/lib/consolidate_day.sh` + smoke test + dune wiring
2. `lead-orchestrator.md` Step 8b (simpler path: amend into existing summary branch vs separate ops/daily-consolidated branch)
3. `dev/status/harness.md` completion notes

## Test plan

- [ ] `dune runtest devtools/checks/` exits 0 — smoke test passes (prints `OK: consolidate_day_check — all assertions passed.`)
- [ ] Manual: `sh dev/lib/consolidate_day.sh 2026-04-20` with the three 2026-04-20 daily files present → `dev/daily/2026-04-20-summary.md` created with all 6 sections
- [ ] Verify diff against main: only 5 expected files changed (consolidate_day.sh, consolidate_day_check.sh, dune, lead-orchestrator.md, harness.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
