### PR TITLE
ops: daily orchestrator summary 2026-04-20-run4

### DIFF
--- a/dev/daily/2026-04-20-run4.md
+++ b/dev/daily/2026-04-20-run4.md
@@ -1,0 +1,106 @@
+# Status — 2026-04-20
+Run timestamp: 2026-04-20T15:55:50Z
+Run ID: 2026-04-20-run-4
+
+## Pending work
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| backtest-scale | awaiting-merge | feat/backtest-scale-3f | #463 | 3f-part1 shadow_screener adapter — APPROVED since run-2, unchanged. Awaiting human merge. |
+| backtest-scale | awaiting-merge | feat/backtest-scale-3f-part2 | #466 | 3f-part2 tiered runner path SKELETON — APPROVED run-3 (quality 4/5), unchanged. Stacked on #463 — merge #463 first. |
+| harness | awaiting-merge | harness/audit-quality-score-wiring | #464 | T3-G audit trail + quality-score wiring — qc-structural APPROVED since run-2, unchanged. Awaiting human merge. |
+| harness | awaiting-merge | harness/consolidate-day | #467 | Same-day summary consolidation (`dev/lib/consolidate_day.sh` + Step 8b wiring) — qc-structural APPROVED run-3, unchanged. |
+| backtest-scale | blocked | — | — | 3f-part3 (Friday Summary-promote → Shadow_screener.screen → Full-promote cycle + per-transition promote/demote) deferred until #463 + #466 land. |
+| orchestrator-automation | blocked | — | — | Phase 2 background execution pending empirical tests; no code dispatch needed. |
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| backtest-scale | — | skipped | plan-first stack cap reached (#463 root + #466 stacked = 2/2); no new dispatch until one lands |
+| backtest-scale | re-QC | skipped | PR #463 tip SHA == Reviewed SHA from run-2; PR #466 tip SHA == Reviewed SHA from run-3; no new commits on either |
+| harness | — | skipped | 2 open PRs in flight (#464, #467), non-plan-first — Step 1.5 skips further dispatch |
+| harness | re-QC | skipped | PR #464 tip SHA == Reviewed SHA from run-2; PR #467 tip SHA == Reviewed SHA from run-3; no new commits on either |
+| ops-data | ops-data | skipped | `dev/notes/data-gaps.md` unchanged since run-2 |
+| cleanup | code-health | skipped | `dev/status/cleanup.md` §Backlog empty; no new medium/high findings from today's fast scan or latest deep scan |
+
+## Feature Progress
+
+### backtest-scale [READY_FOR_REVIEW]
+- Done today: Nothing — stack at depth 2/2; no new commits on #463 or #466 since run-3.
+- In progress: —
+- Blocked: No — throttled by human-review queue, not by orchestrator capacity. Once #463 (and, ideally, #466) land, the next run can dispatch 3f-part3.
+
+### harness [READY_FOR_REVIEW]
+- Done today: Nothing — #464 and #467 both APPROVED, unchanged since run-3.
+- In progress: —
+- Blocked: No — throttled by human-review queue. Next eligible items after #464/#467 merge: T3-F rule-promotion (generate dune checks from enforced rules) and the pre-existing nesting linter refactor follow-up.
+
+### orchestrator-automation [IN_PROGRESS]
+- Done today: Nothing (Phase 2 is human-gated per status file).
+- In progress: —
+- Blocked: Yes — Phase 2 (background execution for scrapers, golden re-runs, cross-feature QC) requires empirical runtime tests the orchestrator cannot perform; human decision per status file.
+
+## QC Status
+- backtest-scale: APPROVED (PR #463 run-2; PR #466 run-3 quality 4/5) — unchanged this run (see dev/reviews/backtest-scale.md)
+- harness: APPROVED structural (PR #464 run-2; PR #467 run-3) — unchanged this run (see dev/reviews/harness.md). Behavioral review not required for harness tracks.
+- short-side-strategy, strategy-wiring, sector-data, support-floor-stops, simulation, portfolio-stops, screener, data-layer: MERGED — no fresh QC this run.
+
+## Budget
+- Budget cap: $50.00 (from merge-policy.json)
+- Target utilization: 60%–80% (from merge-policy.json)
+- Subagents spawned: 0 total
+- Per-subagent breakdown: — (none)
+- Orchestrator overhead: ~$1.00 (state reads, health checks, index reconcile, summary write, push + PR + auto-merge curl calls)
+- Any subagent killed mid-flight: No
+- Budget utilization: ~$1.00 / $50.00 (~2%)
+- Utilization assessment: UNDER_TARGET (<60%) — all-work-done: the 4 in-flight PRs (2 backtest-scale + 2 harness) are the throttle. Review queue depth is the bottleneck, not agent capacity. No eligible tracks were skipped beyond the explicit Step 1.5 guards on open PRs. Not a scope-reduction problem; capacity unused because there's nothing to dispatch that isn't already awaiting human merge.
+- Scope reduced due to budget: No
+
+## Data Operations
+(skipped — `dev/notes/data-gaps.md` unchanged since run-2)
+
+## Harness Work
+(no dispatch — 2 open harness PRs in flight; see §Pending work)
+
+## Health Scan
+(From `dev/health/2026-04-20-fast-run4.md`)
+- Result: CLEAN
+- Critical items: none
+- Build gate: dune build && dune runtest exit 0
+- Status file integrity: exit 0
+
+## Follow-up Queue
+- backtest-scale: 3f-part3 (Summary-promote → Shadow_screener.screen → Full-promote cycle + per-transition promote/demote) — blocks 3f completion; 3g (parity acceptance test) is the merge gate after 3f-part3 lands.
+- simulation: 6 open items unchanged from prior runs (volume dilution in weekly aggregation, Stage.classify O(n) hot path, TODOs for price-cache-data-source / stoplimit-orders / monthly-cadence / bar-granularity).
+- short-side-strategy: bear-window backtest regression, full short cascade, Ch.11 behavioural spot-check (carried from run-2).
+- harness: T3-C superseded, T3-F rule-promotion, T3-H commit-level QC; Tier 4 end-state long-running items; pre-existing nesting linter refactors (fetch_universe.ml, test_data_loader.ml).
+- cleanup: backlog empty; latest deep scan has no new medium/high findings.
+- Total open follow-up items across tracks: ~18 (unchanged since run-2).
+
+## Integration Queue
+- PR #463 — backtest-scale 3f-part1 (APPROVED since run-2; merge first)
+- PR #466 — backtest-scale 3f-part2 (APPROVED run-3; stacked on #463 — merge after #463)
+- PR #464 — harness T3-G audit trail + quality-score (APPROVED since run-2)
+- PR #467 — harness consolidate_day + Step 8b (APPROVED run-3; independent of #464)
+
+## Current Milestone Target
+M5 — Backtest tiered loader path + walk-forward foundation. Requires: 3f-part1 (#463) + 3f-part2 (#466) + 3f-part3 (new) + 3g parity acceptance test all landed.
+
+## Dependency Unlocks
+- None this run. No new commits on any track since run-3.
+
+## Escalations
+- [info] **Review queue is the throttle, not the orchestrator.** 4 open PRs (#463, #464, #466, #467) all APPROVED and awaiting human merge — 2 of them (#463, #464) have been APPROVED since run-2 on 2026-04-20 morning. Today's 4 runs have dispatched all readily-available work; capacity will stay under-utilized until merges resume. Merging the oldest two (#463 then #466 in stack order; #464 independently) unblocks 3f-part3 + T3-F for the next run.
+- [info] **Merge ordering for stacked PRs (carried from run-3).** #466 is stacked on #463 (`feat/backtest-scale-3f-part2` branches off `feat/backtest-scale-3f`, not main). Merge **#463 first**, then #466. Same-track non-blocker between #464 and #467 — both target main independently.
+- [info] **record_qc_audit.sh still not on main.** T3-G audit recording (Stage 4 of QC pipeline) remains gated on #464 merging. No audit row to record this run (no QC dispatched).
+- [info] **Same-day summary consolidation (Step 8b) not yet live.** #467 ships `dev/lib/consolidate_day.sh` + Step 8b wiring but hasn't merged. Today is run-4 on the same date — once #467 lands, future N ≥ 3 same-day runs will produce a `${DATE}-summary.md` roll-up.
+
+## Questions for You
+1. Please merge the 4 open PRs — the backtest-scale stack (**#463 then #466**) and the two independent harness PRs (**#464**, **#467**). All have been APPROVED (some for ≥1 day) and are cleanly mergeable per the GH API. Every additional orchestrator run until these merge will be a near no-op like this one.
+2. Confirm whether the current Step 1.5 "skip when N > 0 open PRs on a non-plan-first track" rule should be relaxed for `harness`, which is a backlog of independent T1/T3 items (not a PR stack). Today that rule prevented dispatching T3-F rule-promotion while #464 and #467 were in review. Option (a) keep as-is — queue depth discipline; option (b) add a carve-out for `harness` that allows dispatch when no existing open PR touches the same T-item scope.
+3. Is Phase 2 of orchestrator-automation still worth keeping open in the status index, or should it be collapsed to a single §Potential item until you have bandwidth to spec it? (Carried from run-3 — still unanswered.)
+
+---
+## Your Response
+(Edit this section. Run dev/run.sh after editing to start the next session.)

--- a/dev/health/2026-04-20-fast-run4.md
+++ b/dev/health/2026-04-20-fast-run4.md
@@ -1,0 +1,11 @@
+# Health Report — 2026-04-20-run4 — fast
+
+## Summary
+- Main build: PASSING (dune build exit 0; dune runtest exit 0)
+- Status file integrity: PASSING (status_file_integrity.sh exit 0)
+- Action required: NO
+
+## Metrics
+- Checks run: 2 (deterministic; no agentic fast scan)
+- Advisory linter output: not checked here — covered by dune runtest exit code
+- Deep scan: see dev/health/2026-04-20-deep.md (weekly GHA cron; latest)

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,7 +4,7 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-20 (run-3 reconcile: #463 and #464 still awaiting human merge since run-2 (no new commits, CI green). New dispatches this run: #466 backtest-scale 3f-part2 tiered runner path skeleton stacked on #463 — overall_qc APPROVED (structural + behavioral quality 4/5) with an explicit split to 3f-part3; #467 harness consolidate_day.sh + Step 8b wiring — qc-structural APPROVED, behavioral N/A. Both drafts flipped to ready-for-review.)
+Last updated: 2026-04-20 (run-4 reconcile: no new commits on any open PR since run-3. PR tip SHAs match Reviewed SHAs in dev/reviews/*.md, so no re-QC needed. All 4 PRs (#463, #464, #466, #467) remain APPROVED and awaiting human merge — the throttle this window is review queue depth, not orchestrator capacity. No new feat/harness/ops-data/cleanup dispatches this run: backtest-scale is at the plan-first stack cap (#463 root + #466 stacked = 2/2); harness has 2 PRs in flight, and §Step 1.5 skips further dispatch while non-plan-first work is in review; data-gaps.md unchanged; cleanup backlog empty.)
 
 ## Active + complete tracks
 
@@ -14,14 +14,14 @@ Each row: one line; deeper task detail in the linked status file.
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
 | [backtest-infra](backtest-infra.md) | MERGED | — | — | — (#419 per-phase tracing merged 2026-04-19) |
-| [backtest-scale](backtest-scale.md) | READY_FOR_REVIEW | feat-backtest | #463, #466 | #463 (3f-part1 shadow_screener adapter) unchanged since run-2 — APPROVED, awaiting human merge. #466 (3f-part2 tiered runner path skeleton, stacked on #463) dispatched run-3, overall_qc APPROVED (quality 4/5), draft flipped to ready. Ships steps 1-2 of plan §3f (Bar_loader build + Metadata promote under Load_bars); raises loudly at simulator cycle with a pointer to 3f-part3. Next: 3f-part3 — Friday Summary-promote → Shadow_screener.screen → Full-promote cycle + per-transition promote/demote. Then 3g (parity acceptance test) is the merge gate. |
+| [backtest-scale](backtest-scale.md) | READY_FOR_REVIEW | feat-backtest | #463, #466 | #463 (3f-part1 shadow_screener adapter) and #466 (3f-part2 tiered runner path skeleton, stacked on #463) both APPROVED and unchanged since run-3. Stack is at depth 2/2 (plan-first cap), so no new dispatch until one lands. Next: 3f-part3 — Friday Summary-promote → Shadow_screener.screen → Full-promote cycle + per-transition promote/demote. Then 3g (parity acceptance test) is the merge gate. |
 | [support-floor-stops](support-floor-stops.md) | MERGED | — | — | — (PRs #382 primitive + #390 wiring both merged 2026-04-17) |
 | [short-side-strategy](short-side-strategy.md) | MERGED | — | — | — (#420 merged 2026-04-19). Follow-ups carried to own tracks: bear-window backtest regression, full short cascade, Ch.11 behavioural spot-check. |
 | [strategy-wiring](strategy-wiring.md) | MERGED | — | — | — (#408 + #409 both merged 2026-04-18) |
 | [sector-data](sector-data.md) | MERGED | — | — | — (#436 merged 2026-04-19). GHA orchestrator runs continue to consume `trading/test_data/sectors.csv`. |
-| [harness](harness.md) | READY_FOR_REVIEW | harness-maintainer | #464, #467 | #464 (T3-G audit trail quality-score wiring) unchanged since run-2 — qc-structural APPROVED, awaiting human merge. #467 (Same-day summary consolidation — `dev/lib/consolidate_day.sh` + Step 8b wiring into lead-orchestrator) dispatched run-3, qc-structural APPROVED, behavioral N/A, draft flipped to ready. Remaining open: advisory T3 items (T3-C superseded, T3-F rule-promotion, T3-H commit-level QC) + Tier 4 end-state. |
+| [harness](harness.md) | READY_FOR_REVIEW | harness-maintainer | #464, #467 | #464 (T3-G audit trail quality-score wiring) and #467 (Same-day summary consolidation — `dev/lib/consolidate_day.sh` + Step 8b wiring) both APPROVED and unchanged since run-3 — two open harness PRs in flight, so Step 1.5 skips further dispatch. Remaining open after these land: advisory T3 items (T3-C superseded, T3-F rule-promotion, T3-H commit-level QC) + Tier 4 end-state. |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Phase 1 live (daily cron runs producing summary PRs). Phase 2 (background execution for scrapers, golden re-runs, cross-feature QC) pending empirical tests per status file. |
-| [cleanup](cleanup.md) | IN_PROGRESS | code-health | — | #453 + #457 + #461 (baseline nesting-linter cleanup, orchestrator-authored) merged 2026-04-20. Backlog currently empty — run-2 deep scan shows 0 critical, 5 warnings (all low-severity: design doc drift, followup accumulation at 18, milestone-pinned linter exceptions unknown). No code-health dispatch this run. |
+| [cleanup](cleanup.md) | IN_PROGRESS | code-health | — | Backlog remains empty (no new medium/high findings from latest deep scan or today's fast-run4). No code-health dispatch this run. |
 | [data-layer](data-layer.md) | MERGED | — | — | — |
 | [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |
 | [screener](screener.md) | MERGED | — | — | — |


### PR DESCRIPTION
Automated daily orchestrator run. See `dev/daily/2026-04-20-run4.md` for the full summary.