### PR TITLE
ci(health-deep-weekly): set working-directory + safe.directory so post-action git commands work

### DIFF
--- a/.github/workflows/health-deep-weekly.yml
+++ b/.github/workflows/health-deep-weekly.yml
@@ -91,11 +91,21 @@ jobs:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         shell: bash
+        working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
 
           BRANCH="ops/health-deep-${DATE}"
           REPORT="dev/health/${DATE}-deep.md"
+
+          # Inside containers run as --user 0, git warns about "dubious
+          # ownership" on repos not owned by root; the claude-code-action
+          # step above also seems to leave cwd in a state where `git config`
+          # fails with "fatal: not in a git directory" (observed in run
+          # 24676096493 on 2026-04-20). Re-add the workspace as a safe
+          # directory explicitly so the git commands below work from this
+          # step regardless of what the action did upstream.
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
           # Stage and commit whatever the agent wrote (partial reports are
           # valuable too, hence `if: always()` above).


### PR DESCRIPTION
First weekly deep-scan cron run (from #451) fired at 15:17 UTC and failed at the `Push branch and open PR` step with `fatal: not in a git directory`. Log: https://github.com/dayfine/trading/actions/runs/24676096493

## Root cause

Inside the GHA container, after `anthropics/claude-code-action@v1` runs its internal `prepareAgentMode` (which tries `git config user.name` and prints the same "not in a git directory" error as a warning but continues), our subsequent shell step inherits a git state where the workspace isn't recognized as a safe directory.

orchestrator.yml has the same action-internal warning but succeeds because its final steps don't invoke `git` directly — the lead-orchestrator agent does pushes through `jj` inside its own logic. Our weekly-scan workflow runs a direct shell step with `git config user.email` — which hits the dubious-ownership / safe.directory check and fails.

## Fix

Two-line addition to the push step:
1. `working-directory: ${{ github.workspace }}` on the step — be explicit about cwd even though GHA defaults here.
2. `git config --global --add safe.directory "${GITHUB_WORKSPACE}"` at the top of the script — re-establishes the workspace as trusted under `--user 0`.

## Test plan

- [ ] Manual workflow_dispatch to verify the fix before next Monday's cron. Safe to test — workflow only pushes to `ops/health-deep-<date>` branches.
- [ ] Next Monday (2026-04-27) cron fires successfully.

## Known side-effect

No impact on orchestrator.yml — unrelated workflow file.
