### PR TITLE
feat(backtest): 3f-part3 tiered runner Friday cycle + per-transition bookkeeping

### DIFF
--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -7,9 +7,7 @@ READY_FOR_REVIEW
 
 structural_qc: APPROVED (2026-04-20) — feat/backtest-scale-3e SHA c51d42bee97618ab3b67679943094fc20baa66d3. All hard gates pass. See dev/reviews/backtest-scale.md.
 
-behavioral_qc (3f-part3): APPROVED (2026-04-20) — feat/backtest-scale-3f-part3 SHA d493f2a9da4d7f5cc5cd6715878bfd2e8872c5bc. Wrapper is purely additive tier bookkeeping; inner Weinstein strategy untouched (adapter-only per plan Resolutions #3); Legacy path byte-identical. See dev/reviews/backtest-scale.md §"Behavioral QC — backtest-scale 3f-part3".
-
-Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447; 3d (tracer phases) merged as #452; 3e (runner + scenario plumbing for `loader_strategy`) merged as #459; 3f-part1 (shadow_screener adapter) merged as #463; 3f-part2 (tiered runner skeleton) merged as #466. 3f-part3 (Friday Summary-promote → Shadow_screener → Full-promote cycle + per-transition promote/demote) ready for review on `feat/backtest-scale-3f-part3` (#474). Next outstanding increment is 3g (parity gate).
+Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447; 3d (tracer phases) merged as #452; 3e (runner + scenario plumbing for `loader_strategy`) merged as #459; 3f-part1 (shadow_screener adapter) merged as #463; 3f-part2 (tiered runner skeleton) merged as #466. 3f-part3 (originally PR #474, 1070/86 LoC) was split into two stacked PRs to keep each reviewable slice small: 3f-part3a (refactor-only Tiered_runner extraction, ~152/78 LoC) on `feat/backtest-scale-3f-part3a`; 3f-part3b (Friday Summary-promote → Shadow_screener → Full-promote cycle + per-transition promote/demote via a new `Tiered_strategy_wrapper`, stacked on part3a) on `feat/backtest-scale-3f-part3b`. #474 closed in favour of the stack. Next outstanding increment is 3g (parity gate).
 
 ## Interface stable
 NO
@@ -17,13 +15,11 @@ NO
 All three tier getters return their proper typed option: `get_metadata : Metadata.t option`, `get_summary : Summary.t option`, `get_full : Full.t option`. Core `Bar_loader.create` / `promote` / `demote` / `tier_of` / `stats` signatures remain stable; `create` gained optional `?full_config` in 3c and `?trace_hook` in 3d. Remaining churn will come from 3e (runner wiring) and 3f (tiered runner path).
 
 ## Open PR
-- feat/backtest-tiered-loader-3d-tracer-phases — 3d based on main; tier-op tracer phases + callback hook. Ready for QC.
-- feat/backtest-scale-3e — 3e based on main; runner + scenario plumbing for `loader_strategy`. Ready for QC.
-- feat/backtest-scale-3f — 3f-part1 (#463) based on main; shadow_screener adapter only. QC APPROVED.
-- feat/backtest-scale-3f-part2 — 3f-part2 (DRAFT #466) stacked on feat/backtest-scale-3f; tiered runner skeleton (Bar_loader create + bulk Metadata promote + trace bridge, raises at simulator-cycle step). Ready for QC on the skeleton scope.
+- feat/backtest-scale-3f-part3a — 3f-part3a based on main; refactor-only extraction of `Tiered_runner` module out of `runner.ml` (byte-identical behaviour — the Tiered path still raises at the simulator-cycle step). Ready for QC.
+- feat/backtest-scale-3f-part3b — 3f-part3b stacked on `feat/backtest-scale-3f-part3a`; flips `Tiered_runner`'s simulator-cycle `failwith` to a real `Simulator.run` driven by `Weinstein_strategy` wrapped in a new `Tiered_strategy_wrapper`. Friday Summary-promote → Shadow_screener → Full-promote cycle + per-transition promote/demote. Ready for QC.
 
 ## Blocked on
-- None. 3f-part3 (Friday cycle + per-transition promote/demote) is the next outstanding increment; depends on 3f-part2 merging.
+- None. 3g (parity acceptance test) is the next outstanding increment; depends on 3f-part3b merging.
 
 ## Goal
 
@@ -91,10 +87,88 @@ Build alongside existing `Bar_history` — don't modify it.
 2. QC review of 3e (feat/backtest-scale-3e head).
 3. QC review of 3f-part1 (feat/backtest-scale-3f head, PR #463) — shadow_screener adapter in isolation.
 4. QC review of 3f-part2 (feat/backtest-scale-3f-part2 head, PR #466) — tiered runner skeleton (Bar_loader create + bulk Metadata promote + trace bridge + failwith at simulator-cycle step).
-5. Dispatch 3f-part3 — Friday cycle + per-transition promote/demote. On each Friday (per `Weinstein_strategy` cadence): promote universe to Summary, run `Shadow_screener.screen`, promote top candidates to Full, feed into `Weinstein_strategy.entries_from_candidates`. On `Entering` transition: promote to Full. On `Closed` transition: demote to Metadata. Will likely require a thin wrapper that runs the Weinstein strategy with `universe=[]` so its in-strategy screener no-ops, then injects screener-sourced candidates via `entries_from_candidates`. Target ~300 lines per plan §3f Commit 2 (after the skeleton).
-6. Subsequent increment 3g (parity acceptance test) is the merge gate; cannot run until 3f-part3 lands.
+5. QC review of 3f-part3a (feat/backtest-scale-3f-part3a head) — refactor-only extraction of `Tiered_runner`. Byte-identical behaviour; the Tiered path still raises at the simulator-cycle step.
+6. QC review of 3f-part3b (feat/backtest-scale-3f-part3b head, stacked on 3f-part3a) — flips the `failwith` to a real `Simulator.run`, adds `Tiered_strategy_wrapper`, Friday cycle, per-transition promote/demote, and the 8-test `test_runner_tiered_cycle` suite.
+7. Dispatch 3g (parity acceptance test) — merge gate on `smoke/tiered-loader-parity.sexp`. Runs both `loader_strategy = Legacy` and `Tiered` paths on a shared scenario and asserts trade count / total P&L / final portfolio value / pinned metrics match within float ε. Cannot run until 3f-part3b lands.
 
 ## Completed
+
+- **3f-part3 — Tiered runner Friday cycle + per-transition promote/demote**
+  (2026-04-20). Completes the Tiered path first opened in 3f-part2 by
+  replacing the simulator-cycle `failwith` with a live `Simulator.run`
+  driven by the Weinstein strategy wrapped in a new
+  `Tiered_strategy_wrapper`. The wrapper sits between the simulator and
+  `Weinstein_strategy` and layers tier-bookkeeping on top of the
+  unchanged inner strategy per plan §3f Commit 2:
+  1. **Friday cycle** — on each bar where the primary-index date is a
+     Friday (same heuristic as `Weinstein_strategy._is_screening_day`),
+     promote the full universe to `Summary_tier`, harvest the summary
+     values from the loader, run `Bar_loader.Shadow_screener.screen`
+     over them (sector map empty — Neutral default per adapter
+     contract; `macro_trend` = `Neutral` for now), then promote the top
+     `max_buy_candidates + max_short_candidates` (= `full_candidate_limit`)
+     to `Full_tier`. The inner Weinstein strategy still runs its own
+     screener on the `universe=full_list` it received at construction —
+     that's fine because the inner screener sees cached bar history for
+     Full-tier symbols; non-Full symbols stay absent from its Stage2/4
+     promotions.
+  2. **Per-`CreateEntering` transition** — each new entering position
+     triggers a `Full_tier` promote on that symbol so the simulator has
+     OHLCV for the stop state machine on the next bar.
+  3. **Per newly-`Closed` transition** — the wrapper holds a snapshot of
+     prior-step position states keyed by `position_id` (not symbol —
+     the same symbol can cycle `Closed` → fresh `Entering` under a new
+     id), and on each step computes the symbols that transitioned into
+     `Closed` since the previous call, then demotes them to
+     `Metadata_tier`. Idempotent: a symbol already at Metadata is a
+     no-op.
+  The wrapper also records every transition via `Stop_log.record_transitions`
+  and uses a wrapper-local `prior_stages` Hashtbl for the Shadow_screener
+  so its stage-transition detection stays independent from the inner
+  strategy's own `prior_stages` closure (otherwise the two shadows fight
+  over writes).
+
+  **File-length split and PR split.** To keep `runner.ml` under the
+  300-line soft limit, the Tiered-path plumbing was extracted into a new
+  `tiered_runner.ml{,i}` module. `Runner._run_tiered_backtest` now
+  builds a `Tiered_runner.input` record from `_deps` and delegates to
+  `Tiered_runner.run`, which returns the same `(sim_result, stop_log)`
+  shape the Legacy path produces. `Runner.tier_op_to_phase` is re-exported
+  as `Tiered_runner.tier_op_to_phase` so existing tests that asserted on
+  the public mapping still pass unchanged. The original PR (#474) was
+  then split into two reviewable slices:
+
+  - **3f-part3a** (`feat/backtest-scale-3f-part3a`) — refactor-only
+    extraction of `Tiered_runner`. The Tiered path still raises at the
+    simulator-cycle step; observable behaviour is byte-identical to
+    the post-#466 main.
+  - **3f-part3b** (`feat/backtest-scale-3f-part3b`, stacked on
+    part3a) — adds `Tiered_strategy_wrapper`, flips the `failwith` to
+    a live `Simulator.run`, wires the Friday cycle + per-transition
+    promote/demote, and ships the 8-test `test_runner_tiered_cycle`
+    suite.
+
+  **Legacy parity preserved.** The Legacy path is untouched; all
+  additions are guarded behind `loader_strategy = Tiered`. 3g (parity
+  acceptance test) can now run — it is the next merge gate.
+
+  - Files: `backtest/lib/{dune,runner.mli,runner.ml,tiered_runner.mli,tiered_runner.ml,tiered_strategy_wrapper.mli,tiered_strategy_wrapper.ml}` +
+    `backtest/test/{dune,test_runner_tiered_cycle.ml}`.
+  - Tests: 8 new `test_runner_tiered_cycle` tests covering Friday-cadence
+    Summary+Full promotion, non-Friday no-op, `CreateEntering` → Full
+    promote (incl. multi-symbol), newly-`Closed` → Metadata demote
+    (incl. symbol re-entering under a new position id, incl. idempotency
+    across repeated calls), pass-through of inner-strategy `Ok` output,
+    and error-path skip (inner `Error` does not trigger any loader
+    bookkeeping). Each test builds a small temp-dir Bar_loader seeded
+    with synthetic CSVs and a stub `STRATEGY` module that emits
+    scripted transitions.
+  - Verify:
+    `dev/lib/run-in-env.sh dune build &&
+     dev/lib/run-in-env.sh dune runtest trading/backtest --force` —
+    31 tests pass (3 runner_filter + 5 runner_tiered_skeleton +
+    8 runner_tiered_cycle + 6 stop_log + 9 trace); all linters clean;
+    `dune fmt` produces no diff.
 
 - **3f-part2 — Tiered runner skeleton** (2026-04-20).
   Implements the pre-simulator portion of the Tiered `Loader_strategy`

--- a/trading/trading/backtest/lib/tiered_runner.ml
+++ b/trading/trading/backtest/lib/tiered_runner.ml
@@ -1,6 +1,7 @@
 (** Tiered loader_strategy path — see [tiered_runner.mli]. *)
 
 open Core
+open Trading_simulation
 
 type input = {
   data_dir_fpath : Fpath.t;
@@ -45,14 +46,68 @@ let _promote_universe_metadata loader (input : input) ~as_of =
            "Backtest.Tiered_runner: loader failed during Metadata promote: %s"
            (Status.show e))
 
-let run ~(input : input) ~start_date:_ ~end_date ~warmup_days:_ ~initial_cash:_
-    ~commission:_ ?trace () =
+(** [_full_candidate_limit config] caps how many Shadow_screener candidates the
+    Tiered wrapper promotes to Full on a single Friday. Matches the inner
+    screener's own post-rank cut so we don't Full-promote more than the strategy
+    would consider. *)
+let _full_candidate_limit (config : Weinstein_strategy.config) =
+  config.screening_config.max_buy_candidates
+  + config.screening_config.max_short_candidates
+
+let _make_wrapper_config (input : input) ~loader ~stop_log :
+    Tiered_strategy_wrapper.config =
+  {
+    bar_loader = loader;
+    universe = input.all_symbols;
+    screening_config = input.config.screening_config;
+    full_candidate_limit = _full_candidate_limit input.config;
+    stop_log;
+    primary_index = input.config.indices.primary;
+  }
+
+let _make_simulator (input : input) ~loader ~stop_log ~start_date ~end_date
+    ~warmup_days ~initial_cash ~commission =
+  let inner_strategy =
+    Weinstein_strategy.make ~ad_bars:input.ad_bars
+      ~ticker_sectors:input.ticker_sectors input.config
+  in
+  let wrapper_config = _make_wrapper_config input ~loader ~stop_log in
+  let strategy =
+    Tiered_strategy_wrapper.wrap ~config:wrapper_config inner_strategy
+  in
+  let warmup_start = Date.add_days start_date (-warmup_days) in
+  let metric_suite = Metric_computers.default_metric_suite () in
+  let sim_deps =
+    Simulator.create_deps ~symbols:input.all_symbols
+      ~data_dir:input.data_dir_fpath ~strategy ~commission ~metric_suite ()
+  in
+  let sim_config =
+    Simulator.
+      {
+        start_date = warmup_start;
+        end_date;
+        initial_cash;
+        commission;
+        strategy_cadence = Types.Cadence.Daily;
+      }
+  in
+  match Simulator.create ~config:sim_config ~deps:sim_deps with
+  | Ok s -> s
+  | Error e ->
+      failwith
+        (sprintf "Backtest.Tiered_runner: failed to create simulator: %s"
+           (Status.show e))
+
+let _run_simulator sim =
+  match Simulator.run sim with
+  | Ok r -> r
+  | Error e ->
+      failwith
+        (sprintf "Backtest.Tiered_runner: simulation failed: %s" (Status.show e))
+
+let run ~input ~start_date ~end_date ~warmup_days ~initial_cash ~commission
+    ?trace () =
   let loader = _create_bar_loader input ?trace () in
-  (* Bulk-promote at the backtest end date. The Metadata-tier semantics are
-     "last close on or before as_of" — for the pre-simulator bootstrap this
-     is the most information-rich snapshot the loader can hold without
-     walking the timeline. 3f-part3b will re-promote per-symbol at each
-     simulator step [as_of = current bar date]. *)
   let as_of = end_date in
   let n_all_symbols = List.length input.all_symbols in
   Trace.record ?trace ~symbols_in:n_all_symbols ~symbols_out:n_all_symbols
@@ -63,9 +118,17 @@ let run ~(input : input) ~start_date:_ ~end_date ~warmup_days:_ ~initial_cash:_
     "Tiered loader: Metadata=%d Summary=%d Full=%d after bulk Metadata promote\n\
      %!"
     stats.metadata stats.summary stats.full;
-  failwith
-    "Backtest.Tiered_runner: simulator-cycle step not yet implemented (lands \
-     in 3f-part3b of the backtest-tiered-loader plan). The pre-simulator \
-     Metadata promote succeeded and emitted its Load_bars trace phase, so the \
-     trace up to this point is usable for debugging. Pass \
-     loader_strategy=Legacy or omit the argument to run the existing path."
+  let stop_log = Stop_log.create () in
+  let sim =
+    _make_simulator input ~loader ~stop_log ~start_date ~end_date ~warmup_days
+      ~initial_cash ~commission
+  in
+  let sim_result =
+    Trace.record ?trace ~symbols_in:n_all_symbols Trace.Phase.Fill (fun () ->
+        _run_simulator sim)
+  in
+  let final_stats = Bar_loader.stats loader in
+  eprintf
+    "Tiered loader: Metadata=%d Summary=%d Full=%d at end of simulator run\n%!"
+    final_stats.metadata final_stats.summary final_stats.full;
+  (sim_result, stop_log)

--- a/trading/trading/backtest/lib/tiered_runner.mli
+++ b/trading/trading/backtest/lib/tiered_runner.mli
@@ -4,14 +4,19 @@
     the Legacy vs Tiered paths are obviously parallel at the module boundary.
     The public entry point is {!run} — everything else is private to the module.
 
-    This extraction (3f-part3a) is a refactor-only slice: the body of [run] is
-    byte-identical in observable behaviour to the previous inline
-    [Runner._run_tiered_backtest] — it bulk-promotes to Metadata under a
-    [Load_bars] trace wrap and then raises [Failure] at the simulator-cycle
-    step. The real Friday Summary-promote / Shadow_screener / Full-promote cycle
-    and the per-transition promote/demote bookkeeping land in 3f-part3b via a
-    [Tiered_strategy_wrapper] atop [Weinstein_strategy]. See
-    [dev/plans/backtest-tiered-loader-2026-04-19.md]. *)
+    Flow per plan §3f-part3 (see
+    [dev/plans/backtest-tiered-loader-2026-04- 19.md]):
+
+    1. Build a [Bar_loader] over the runner-provided universe with a
+    [trace_hook] that bridges [Bar_loader.tier_op] onto [Trace.Phase.t]. 2.
+    Bulk-promote the universe to [Metadata_tier] under a [Load_bars] wrap. 3.
+    Drive the simulator with a [Tiered_strategy_wrapper]-wrapped Weinstein
+    strategy. The wrapper adds Friday Summary-promote + Shadow_screener +
+    Full-promote-top-N, per-[CreateEntering] Full promote, and
+    per-newly-[Closed] Metadata demote.
+
+    The simulator transitions are byte-identical to the Legacy path — the
+    wrapper is purely additive. The 3g parity gate locks this in. *)
 
 open Core
 
@@ -24,9 +29,7 @@ type input = {
 }
 (** Minimal [_deps] subset Tiered_runner needs. Kept as a plain record so
     [Runner] can build it without threading its private [_deps] type through the
-    public surface. [ad_bars] and [config] are unused in 3f-part3a (the
-    simulator cycle is still [failwith]'d) but part of the stable shape — they
-    get threaded into the inner Weinstein strategy once 3f-part3b lands. *)
+    public surface. *)
 
 val tier_op_to_phase : Bar_loader.tier_op -> Trace.Phase.t
 (** Map a [Bar_loader.tier_op] (the library-internal tier-op tag) onto the
@@ -48,13 +51,12 @@ val run :
     runs the Tiered simulator cycle and returns [(sim_result, stop_log)] — the
     same shape [Runner] expects from the Legacy path.
 
-    In 3f-part3a this function only performs the pre-simulator bootstrap —
-    builds a [Bar_loader] with a [trace_hook] bridging [tier_op] → phase,
-    bulk-promotes [input.all_symbols] to Metadata under a [Load_bars] trace
-    wrap, and then raises [Failure] at the simulator-cycle step. The
-    [warmup_days], [initial_cash], and [commission] arguments are accepted as
-    part of the stable interface but unused until 3f-part3b drops the [failwith]
-    and wires a real [Simulator.run] through a [Tiered_strategy_wrapper].
+    Internally:
+    - Builds a [Bar_loader] with a trace_hook bridging [tier_op] → phase.
+    - Bulk-promotes [input.all_symbols] to Metadata under a [Load_bars] trace
+      wrap.
+    - Constructs a Weinstein strategy wrapped by [Tiered_strategy_wrapper] and
+      runs [Simulator.run] under a [Fill] trace wrap.
 
-    Raises [Failure] on any of: loader bulk-promote hard error, the intentional
-    simulator-cycle step placeholder. *)
+    Raises [Failure] if the loader's bulk promote fails with a hard data error,
+    or if [Simulator.create] / [Simulator.run] errors. *)

--- a/trading/trading/backtest/lib/tiered_strategy_wrapper.ml
+++ b/trading/trading/backtest/lib/tiered_strategy_wrapper.ml
@@ -1,0 +1,216 @@
+(** Tier-bookkeeping wrapper around a [STRATEGY] — see
+    [tiered_strategy_wrapper.mli]. *)
+
+open Core
+open Trading_strategy
+
+type config = {
+  bar_loader : Bar_loader.t;
+  universe : string list;
+  screening_config : Screener.config;
+  full_candidate_limit : int;
+  stop_log : Stop_log.t;
+  primary_index : string;
+}
+
+(** [_is_friday ~get_price ~primary_index] reads today's primary index bar and
+    checks whether its date is a Friday. Same Friday-detection heuristic
+    [Weinstein_strategy] uses internally — when the benchmark bar is missing we
+    default to [false] (no promotion that day), matching [_is_screening_day]'s
+    behaviour in [weinstein_strategy.ml]. *)
+let _is_friday ~(get_price : Strategy_interface.get_price_fn) ~primary_index =
+  match get_price primary_index with
+  | None -> false
+  | Some bar ->
+      Date.day_of_week bar.Types.Daily_price.date
+      |> Day_of_week.equal Day_of_week.Fri
+
+(** [_current_date] reads today's date from the primary index bar. When the
+    benchmark bar is missing we fall back to [Date.today] so the wrapper can
+    still make a forward-progress decision — this path is only exercised on days
+    the strategy itself would consider degenerate. *)
+let _current_date ~(get_price : Strategy_interface.get_price_fn) ~primary_index
+    =
+  match get_price primary_index with
+  | Some bar -> bar.Types.Daily_price.date
+  | None -> Date.today ~zone:Time_float.Zone.utc
+
+(** [_summary_values_of s] projects a [Bar_loader.Summary.t] onto the
+    [summary_values] record the [Shadow_screener] consumes. Separated out so
+    [_summaries_for] stays a flat filter_map over the loader state. *)
+let _summary_values_of (s : Bar_loader.Summary.t) :
+    Bar_loader.Summary_compute.summary_values =
+  {
+    ma_30w = s.ma_30w;
+    atr_14 = s.atr_14;
+    rs_line = s.rs_line;
+    stage = s.stage;
+    as_of = s.as_of;
+  }
+
+(** [_summaries_for t ~universe] extracts [(symbol, summary_values)] pairs for
+    every symbol in [universe] that the loader has at Summary tier or higher.
+    Symbols at Metadata tier (insufficient history for the tail window) or
+    absent from the loader are silently dropped — the [Shadow_screener] only
+    wants the ones it can actually score. *)
+let _summaries_for (bar_loader : Bar_loader.t) ~universe :
+    (string * Bar_loader.Summary_compute.summary_values) list =
+  List.filter_map universe ~f:(fun symbol ->
+      Bar_loader.get_summary bar_loader ~symbol
+      |> Option.map ~f:(fun s -> (symbol, _summary_values_of s)))
+
+(** [_take_n xs n] is a head-trimmed prefix of [xs]. Used to cap the candidate
+    list by [full_candidate_limit] without materializing the full tail. *)
+let _take_n xs n =
+  if n <= 0 then []
+  else
+    let rec loop acc k = function
+      | [] -> List.rev acc
+      | _ when k = 0 -> List.rev acc
+      | x :: rest -> loop (x :: acc) (k - 1) rest
+    in
+    loop [] n xs
+
+(** [_swallow_err ~ctx result] logs a promote failure to stderr and returns
+    unit. A single symbol's load failure must not abort the backtest — the
+    loader contract says failed symbols are simply absent from [entries]. *)
+let _swallow_err ~ctx = function
+  | Ok () -> ()
+  | Error (err : Status.t) ->
+      eprintf
+        "Tiered_strategy_wrapper: [%s] Bar_loader.promote error (continuing): %s\n\
+         %!"
+        ctx (Status.show err)
+
+(** [_promote_candidates_to_full] takes [buy_candidates @ short_candidates] from
+    a [Shadow_screener.result], caps by [full_candidate_limit], and promotes
+    those symbols to Full tier. Idempotent for symbols already at Full. *)
+let _promote_candidates_to_full t ~(result : Screener.result) ~as_of =
+  let combined = result.buy_candidates @ result.short_candidates in
+  let capped = _take_n combined t.full_candidate_limit in
+  let symbols =
+    List.map capped ~f:(fun (c : Screener.scored_candidate) -> c.ticker)
+  in
+  if not (List.is_empty symbols) then
+    Bar_loader.promote t.bar_loader ~symbols ~to_:Full_tier ~as_of
+    |> _swallow_err ~ctx:"promote candidates to Full"
+
+(** [_run_friday_cycle] is the Summary-promote → Shadow_screener →
+    Full-promote-top-N pipeline. Called once per Friday via the wrapper's
+    [on_market_close]. Uses a wrapper-local [prior_stages] table so the shadow
+    screener's transition detection is independent from the inner strategy's own
+    [prior_stages] — the two tables otherwise fight over writes. *)
+let _run_friday_cycle t ~prior_stages ~portfolio ~as_of =
+  (* Step 1: promote every universe symbol to Summary. Per promote contract,
+     symbols with insufficient history stay at Metadata — no error surface. *)
+  Bar_loader.promote t.bar_loader ~symbols:t.universe ~to_:Summary_tier ~as_of
+  |> _swallow_err ~ctx:"promote universe to Summary";
+  (* Step 2: collect summaries and run shadow cascade. Sector map is empty
+     because building one requires bar history we deliberately don't hold at
+     the Tiered level; the screener defaults missing sectors to Neutral. *)
+  let summaries = _summaries_for t.bar_loader ~universe:t.universe in
+  let sector_map = Hashtbl.create (module String) in
+  let held_tickers = Weinstein_strategy.held_symbols portfolio in
+  let result =
+    Bar_loader.Shadow_screener.screen ~summaries ~config:t.screening_config
+      ~macro_trend:Weinstein_types.Neutral ~sector_map ~prior_stages
+      ~held_tickers ~as_of
+  in
+  (* Step 3: promote the top-N (buy + short) to Full tier. *)
+  _promote_candidates_to_full t ~result ~as_of
+
+(** [_promote_new_entries] promotes every symbol referenced by a
+    [CreateEntering] transition to Full tier. Ensures the loader has OHLCV ready
+    the first time the strategy reads bars for the newly-tracked position on
+    subsequent steps. *)
+let _promote_new_entries t ~transitions ~as_of =
+  let symbols =
+    List.filter_map transitions ~f:(fun (trans : Position.transition) ->
+        match trans.kind with
+        | CreateEntering { symbol; _ } -> Some symbol
+        | _ -> None)
+  in
+  if not (List.is_empty symbols) then
+    Bar_loader.promote t.bar_loader ~symbols ~to_:Full_tier ~as_of
+    |> _swallow_err ~ctx:"promote new entries to Full"
+
+(** [_is_newly_closed ~prev id pos] — a position is newly closed iff its current
+    state is [Closed] AND the previous snapshot either didn't know the id or had
+    it in a non-[Closed] state. Keyed by position_id because a symbol can cycle
+    Closed → fresh [Entering] under a new id. *)
+let _is_newly_closed ~(prev : Position.position_state String.Map.t) id
+    (pos : Position.t) =
+  match pos.state with
+  | Closed _ -> (
+      match Map.find prev id with
+      | Some (Closed _) -> false (* already demoted on a prior step *)
+      | Some _ | None -> true)
+  | Entering _ | Holding _ | Exiting _ -> false
+
+(** [_newly_closed_symbols ~prev ~curr] diffs the previous portfolio positions
+    against the current one and returns the symbols whose state has become
+    [Closed] since the previous call. Symbols returned here are what the wrapper
+    should demote to Metadata. *)
+let _newly_closed_symbols ~(prev : Position.position_state String.Map.t)
+    ~(curr : Position.t String.Map.t) : string list =
+  Map.fold curr ~init:[] ~f:(fun ~key:id ~data:pos acc ->
+      if _is_newly_closed ~prev id pos then pos.symbol :: acc else acc)
+
+(** [_demote_closed t ~symbols] demotes every closed symbol to Metadata.
+    Idempotent when called twice on the same symbol. *)
+let _demote_closed t ~symbols =
+  if not (List.is_empty symbols) then
+    Bar_loader.demote t.bar_loader ~symbols ~to_:Metadata_tier
+
+(** [_handle_ok_output] is the per-call bookkeeping body that runs when the
+    inner strategy returns [Ok]: stop-log recording, per-Closed demote, Friday
+    cycle, per-Entering promote, and the prior-positions snapshot update.
+    Factored out of [wrap]'s [on_market_close] so the closure body stays flat.
+*)
+let _handle_ok_output t ~prior_positions ~shadow_prior_stages ~get_price
+    ~portfolio ~(transitions : Position.transition list) =
+  Stop_log.record_transitions t.stop_log transitions;
+  let as_of = _current_date ~get_price ~primary_index:t.primary_index in
+  let closed_symbols =
+    _newly_closed_symbols ~prev:!prior_positions
+      ~curr:portfolio.Portfolio_view.positions
+  in
+  _demote_closed t ~symbols:closed_symbols;
+  if _is_friday ~get_price ~primary_index:t.primary_index then
+    _run_friday_cycle t ~prior_stages:shadow_prior_stages ~portfolio ~as_of;
+  _promote_new_entries t ~transitions ~as_of;
+  prior_positions := Map.map portfolio.positions ~f:(fun pos -> pos.state)
+
+(** [_on_market_close_wrapped] is the per-call body [wrap]'s [on_market_close]
+    delegates to. Extracting it keeps [wrap]'s closure flat — otherwise the
+    local module + nested match pushes nesting over the linter's limit. *)
+let _on_market_close_wrapped ~inner ~t ~prior_positions ~shadow_prior_stages
+    ~get_price ~get_indicator ~portfolio =
+  let result = inner ~get_price ~get_indicator ~portfolio in
+  (match result with
+  | Error _ -> ()
+  | Ok { Strategy_interface.transitions } ->
+      _handle_ok_output t ~prior_positions ~shadow_prior_stages ~get_price
+        ~portfolio ~transitions);
+  result
+
+let wrap ~config:t (module S : Strategy_interface.STRATEGY) =
+  (* [prior_positions] is the wrapper-local memory of each position's state
+     from the previous call — used to detect transitions into [Closed]. *)
+  let prior_positions : Position.position_state String.Map.t ref =
+    ref String.Map.empty
+  in
+  (* [shadow_prior_stages] is the wrapper-local prior-stage table for the
+     Shadow_screener. Kept separate from the inner strategy's own prior_stages
+     closure so the two shadowings don't overwrite each other. *)
+  let shadow_prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  let module Wrapped = struct
+    let name = S.name
+
+    let on_market_close =
+      _on_market_close_wrapped ~inner:S.on_market_close ~t ~prior_positions
+        ~shadow_prior_stages
+  end in
+  (module Wrapped : Strategy_interface.STRATEGY)

--- a/trading/trading/backtest/lib/tiered_strategy_wrapper.mli
+++ b/trading/trading/backtest/lib/tiered_strategy_wrapper.mli
@@ -1,0 +1,88 @@
+(** Tier-bookkeeping wrapper around a [STRATEGY] module for the Tiered loader
+    path.
+
+    Step 3f-part3 of the backtest-tiered-loader plan
+    (dev/plans/backtest-tiered-loader-2026-04-19.md §3f). The wrapper observes
+    each [on_market_close] call and drives [Bar_loader] tier transitions so the
+    Tiered runner path actually promotes / demotes as the strategy moves through
+    the simulator loop:
+
+    - On Fridays (weekly cadence, detected via the primary index bar's
+      day-of-week): promote every universe symbol to [Summary_tier], run the
+      [Shadow_screener] cascade on the resulting summaries, and promote the
+      top-[full_candidate_limit] candidates to [Full_tier]. The shadow screener
+      output is used for tier promotion decisions and emits a [Promote_full]
+      trace phase for the candidates.
+    - On any [CreateEntering] transition emitted by the wrapped strategy:
+      promote the entering symbol to [Full_tier]. Ensures Full-tier OHLCV is
+      available the first time stops/indicators read it for a new position.
+    - On any position that has just transitioned to [Closed] (detected by
+      diffing the portfolio state across calls): demote the symbol to
+      [Metadata_tier]. Frees the Full-tier bars now that the strategy no longer
+      tracks the position.
+
+    The wrapper is {b purely additive} with respect to the wrapped strategy —
+    all of the underlying strategy's transitions pass through unchanged. This
+    keeps the 3g parity gate clean: the wrapper adds [Bar_loader] bookkeeping
+    but never changes the set of transitions the simulator sees. The
+    [Shadow_screener] output on Fridays is used for tier promotion only in this
+    increment; replacing the inner screener's candidates with shadow output is a
+    follow-on step the plan explicitly scopes outside 3f-part3.
+
+    The [stop_log] hook replicates {!Strategy_wrapper}'s behaviour — the Tiered
+    path uses this wrapper {b instead of} [Strategy_wrapper], not on top of it,
+    so transition capture composes into one place. *)
+
+open Trading_strategy
+
+type config = {
+  bar_loader : Bar_loader.t;  (** Shared tier-aware bar loader. *)
+  universe : string list;
+      (** Symbols eligible for Summary promotion on Friday. Typically
+          [deps.all_symbols] from the runner. *)
+  screening_config : Screener.config;
+      (** Cascade config forwarded verbatim to [Shadow_screener.screen]. *)
+  full_candidate_limit : int;
+      (** Maximum number of Shadow_screener buy + short candidates to promote to
+          Full tier on a single Friday. Protects against a runaway promotion
+          batch when the shadow cascade admits many candidates. Typical values
+          track
+          [screening_config.max_buy_candidates +
+           screening_config.max_short_candidates]. *)
+  stop_log : Stop_log.t;
+      (** Shared stop-log collector. The wrapper records transitions to it on
+          every call, same contract as {!Strategy_wrapper}. *)
+  primary_index : string;
+      (** Primary benchmark ticker used to read the "current bar" for Friday
+          detection and as-of date resolution. Typically
+          [config.indices.primary]. *)
+}
+
+val wrap :
+  config:config ->
+  (module Strategy_interface.STRATEGY) ->
+  (module Strategy_interface.STRATEGY)
+(** [wrap ~config inner] returns a [STRATEGY] module that delegates to [inner]
+    and layers tier bookkeeping on top.
+
+    Precondition: [config.bar_loader] has already been populated with Metadata
+    tier for [config.universe] (the runner does this in its initial [Load_bars]
+    wrap before calling the simulator). [wrap] itself does not load bars; it
+    only promotes / demotes existing entries.
+
+    The returned module's [on_market_close]: 1. Delegates to
+    [inner.on_market_close]. 2. Records the resulting transitions to
+    [config.stop_log]. 3. Demotes any symbols whose positions transitioned to
+    [Closed] since the previous call. 4. If today is a Friday (per the primary
+    index bar's day-of-week): promotes [config.universe] to Summary, runs
+    [Shadow_screener.screen] over the summaries, and promotes the
+    top-[config.full_candidate_limit] buy+short candidates to Full. 5. Promotes
+    any [CreateEntering] transition's symbol to Full.
+
+    The transition list returned to the simulator is unchanged — step (4) is
+    pure bookkeeping; step (5) is also pure bookkeeping, not an emission.
+
+    Any [Bar_loader.promote] error is logged to stderr and swallowed so a data
+    issue on a single symbol doesn't abort the entire backtest; the simulator
+    continues on whatever tier the symbol reached. Demotion is infallible so no
+    error path. *)

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -3,7 +3,8 @@
   test_stop_log
   test_runner_filter
   test_trace
-  test_runner_tiered_skeleton)
+  test_runner_tiered_skeleton
+  test_runner_tiered_cycle)
  (libraries
   ounit2
   core
@@ -20,5 +21,6 @@
   trading.simulation
   trading.simulation.types
   trading.strategy
+  weinstein.screener
   status
   matchers))

--- a/trading/trading/backtest/test/test_runner_tiered_cycle.ml
+++ b/trading/trading/backtest/test/test_runner_tiered_cycle.ml
@@ -1,0 +1,468 @@
+(** Tests for [Backtest.Tiered_strategy_wrapper] — the piece that turns the
+    3f-part2 skeleton into a full Tiered simulator cycle.
+
+    3f-part3 ships the wrapper that observes each [on_market_close] call and
+    drives [Bar_loader] tier transitions. The observable contracts we pin here:
+
+    1. On a Friday call, the wrapper promotes the universe to [Summary_tier] and
+    (if the shadow screener admits candidates) further promotes them to
+    [Full_tier]. On a non-Friday call, no Summary / Full promote is issued.
+    Friday detection reads the primary index bar's day-of-week. 2. On a
+    [CreateEntering] transition the wrapper promotes that symbol to [Full_tier]
+    regardless of cadence. 3. When a portfolio's position transitions to
+    [Closed] between calls, the wrapper demotes that symbol to [Metadata_tier]
+    on the next call. 4. The wrapper is {b purely additive}: the inner
+    strategy's transitions flow through unchanged, and errors from the inner
+    strategy bypass all tier bookkeeping.
+
+    These tests drive the wrapper directly with a stub [STRATEGY] module and a
+    synthetic [Bar_loader] rooted in a temp data dir — no production data
+    required. The full [run_backtest ~loader_strategy:Tiered] acceptance test
+    lands in 3g alongside the Legacy-vs-Tiered parity gate. *)
+
+open OUnit2
+open Core
+open Matchers
+open Trading_strategy
+module Bar_loader = Bar_loader
+
+(* -------------------------------------------------------------------- *)
+(* Fixtures                                                             *)
+(* -------------------------------------------------------------------- *)
+
+(** Fresh temp data dir + empty sector map. Combined with a universe of symbols
+    with no CSVs on disk, [Bar_loader.promote] succeeds for Metadata (the
+    bootstrap path) and then short-circuits for Summary / Full (no bars), but
+    the [trace_hook] still fires per Bar_loader semantics. Good enough to
+    observe the wrapper's tier-op issuance. *)
+let _make_loader ~universe =
+  let tmp_dir = Filename_unix.temp_dir "runner_tiered_cycle_" "" in
+  let data_dir = Fpath.v tmp_dir in
+  let sector_map = Hashtbl.create (module String) in
+  let trace = Backtest.Trace.create () in
+  let trace_hook : Bar_loader.trace_hook =
+    let record :
+        'a. tier_op:Bar_loader.tier_op -> symbols:int -> (unit -> 'a) -> 'a =
+     fun ~tier_op ~symbols f ->
+      let phase = Backtest.Runner.tier_op_to_phase tier_op in
+      Backtest.Trace.record ~trace ~symbols_in:symbols phase f
+    in
+    { record }
+  in
+  let loader =
+    Bar_loader.create ~data_dir ~sector_map ~universe ~trace_hook ()
+  in
+  (loader, trace)
+
+(** Stub STRATEGY module that returns a prescribed list of transitions from an
+    external ref. Lets tests inject [CreateEntering] / [TriggerExit] transitions
+    and observe the wrapper's bookkeeping response. *)
+let _stub_strategy ~transitions_ref =
+  let module Stub = struct
+    let name = "Stub"
+
+    let on_market_close ~get_price:_ ~get_indicator:_ ~portfolio:_ =
+      Ok { Strategy_interface.transitions = !transitions_ref }
+  end in
+  (module Stub : Strategy_interface.STRATEGY)
+
+(** Build a [get_price] closure that returns a daily bar with the given date for
+    a configured symbol. Every other symbol resolves to [None]. Used so the
+    wrapper can look up the "current date" via the primary index. *)
+let _make_get_price ~primary_index ~date : Strategy_interface.get_price_fn =
+  let bar : Types.Daily_price.t =
+    {
+      date;
+      open_price = 100.0;
+      high_price = 100.0;
+      low_price = 100.0;
+      close_price = 100.0;
+      adjusted_close = 100.0;
+      volume = 0;
+    }
+  in
+  fun sym -> if String.equal sym primary_index then Some bar else None
+
+let _no_indicator : Strategy_interface.get_indicator_fn = fun _ _ _ _ -> None
+
+let _empty_portfolio : Portfolio_view.t =
+  { cash = 0.0; positions = String.Map.empty }
+
+let _screening_config : Screener.config = Screener.default_config
+
+let _wrapper_config ~loader ~universe ~primary_index :
+    Backtest.Tiered_strategy_wrapper.config =
+  {
+    bar_loader = loader;
+    universe;
+    screening_config = _screening_config;
+    full_candidate_limit = 5;
+    stop_log = Backtest.Stop_log.create ();
+    primary_index;
+  }
+
+let _phases_from trace =
+  Backtest.Trace.snapshot trace
+  |> List.map ~f:(fun (m : Backtest.Trace.phase_metrics) -> m.phase)
+
+let _friday = Date.create_exn ~y:2024 ~m:Jan ~d:5 (* 2024-01-05 is a Friday *)
+let _tuesday = Date.create_exn ~y:2024 ~m:Jan ~d:9
+(* 2024-01-09 is a Tuesday *)
+
+(* -------------------------------------------------------------------- *)
+(* 1. Friday cadence isolation                                          *)
+(* -------------------------------------------------------------------- *)
+
+(** On a Friday call, the wrapper issues a [Promote_to_summary] tier-op for the
+    universe. No promote is issued on a non-Friday call. Held only to the "at
+    least one Summary promote on Friday; zero Summary promotes off- Friday"
+    contract because the rest of the Full-promote path depends on shadow
+    screener output which requires real bars. *)
+let test_friday_triggers_summary_promote _ =
+  let universe = [ "AAA"; "BBB" ] in
+  let primary_index = "SPY.INDX" in
+  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
+  let transitions_ref = ref [] in
+  let stub = _stub_strategy ~transitions_ref in
+  let config = _wrapper_config ~loader ~universe ~primary_index in
+  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
+  let _ =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_friday)
+      ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
+  in
+  let phases = _phases_from trace in
+  assert_that
+    (List.exists phases ~f:(fun p ->
+         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Promote_summary))
+    (equal_to true)
+
+let test_non_friday_skips_summary_promote _ =
+  let universe = [ "AAA"; "BBB" ] in
+  let primary_index = "SPY.INDX" in
+  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
+  let transitions_ref = ref [] in
+  let stub = _stub_strategy ~transitions_ref in
+  let config = _wrapper_config ~loader ~universe ~primary_index in
+  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
+  let _ =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
+      ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
+  in
+  let phases = _phases_from trace in
+  assert_that
+    (List.exists phases ~f:(fun p ->
+         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Promote_summary))
+    (equal_to false)
+
+(* -------------------------------------------------------------------- *)
+(* 2. Per-CreateEntering promote to Full                                *)
+(* -------------------------------------------------------------------- *)
+
+(** A [CreateEntering] transition emitted by the inner strategy triggers a
+    Full-tier promote for the entering symbol on every call, regardless of
+    day-of-week. *)
+let test_create_entering_promotes_to_full _ =
+  let universe = [ "AAA" ] in
+  let primary_index = "SPY.INDX" in
+  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
+  let transitions_ref =
+    ref
+      [
+        {
+          Position.position_id = "pos-1";
+          date = _tuesday;
+          kind =
+            CreateEntering
+              {
+                symbol = "AAA";
+                side = Position.Long;
+                target_quantity = 10.0;
+                entry_price = 100.0;
+                reasoning =
+                  Position.TechnicalSignal
+                    { indicator = "Stub"; description = "test" };
+              };
+        };
+      ]
+  in
+  let stub = _stub_strategy ~transitions_ref in
+  let config = _wrapper_config ~loader ~universe ~primary_index in
+  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
+  let _ =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
+      ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
+  in
+  let phases = _phases_from trace in
+  assert_that
+    (List.exists phases ~f:(fun p ->
+         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Promote_full))
+    (equal_to true)
+
+(* -------------------------------------------------------------------- *)
+(* 3. Per-Closed demote                                                 *)
+(* -------------------------------------------------------------------- *)
+
+let _closed_position ~id ~symbol : Position.t =
+  {
+    id;
+    symbol;
+    side = Long;
+    entry_reasoning =
+      TechnicalSignal { indicator = "Stub"; description = "test" };
+    exit_reason = None;
+    state =
+      Closed
+        {
+          quantity = 10.0;
+          entry_price = 100.0;
+          exit_price = 110.0;
+          gross_pnl = None;
+          entry_date = _tuesday;
+          exit_date = _tuesday;
+          days_held = 0;
+        };
+    last_updated = _tuesday;
+    portfolio_lot_ids = [];
+  }
+
+let _holding_position ~id ~symbol : Position.t =
+  {
+    id;
+    symbol;
+    side = Long;
+    entry_reasoning =
+      TechnicalSignal { indicator = "Stub"; description = "test" };
+    exit_reason = None;
+    state =
+      Holding
+        {
+          quantity = 10.0;
+          entry_price = 100.0;
+          entry_date = _tuesday;
+          risk_params =
+            {
+              stop_loss_price = Some 90.0;
+              take_profit_price = None;
+              max_hold_days = None;
+            };
+        };
+    last_updated = _tuesday;
+    portfolio_lot_ids = [];
+  }
+
+(** A position that transitioned from [Holding] to [Closed] between calls
+    triggers a Demote tier-op on the next call. The wrapper detects the
+    transition via its own [prior_positions] memo — keyed by position_id — so
+    the first call with a Holding position doesn't issue a demote, and the
+    second call with the same id now in [Closed] does. *)
+let test_newly_closed_position_triggers_demote _ =
+  let universe = [ "AAA" ] in
+  let primary_index = "SPY.INDX" in
+  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
+  let transitions_ref = ref [] in
+  let stub = _stub_strategy ~transitions_ref in
+  let config = _wrapper_config ~loader ~universe ~primary_index in
+  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
+  (* Step 1: position is Holding. No demote should happen. *)
+  let holding_portfolio : Portfolio_view.t =
+    {
+      cash = 0.0;
+      positions =
+        String.Map.of_alist_exn
+          [ ("pos-1", _holding_position ~id:"pos-1" ~symbol:"AAA") ];
+    }
+  in
+  let _ =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
+      ~get_indicator:_no_indicator ~portfolio:holding_portfolio
+  in
+  let phases_after_step_1 = _phases_from trace in
+  assert_that
+    (List.exists phases_after_step_1 ~f:(fun p ->
+         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Demote))
+    (equal_to false);
+  (* Step 2: same position_id now in Closed. Demote fires. *)
+  let closed_portfolio : Portfolio_view.t =
+    {
+      cash = 0.0;
+      positions =
+        String.Map.of_alist_exn
+          [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ];
+    }
+  in
+  let _ =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
+      ~get_indicator:_no_indicator ~portfolio:closed_portfolio
+  in
+  let phases_after_step_2 = _phases_from trace in
+  assert_that
+    (List.exists phases_after_step_2 ~f:(fun p ->
+         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Demote))
+    (equal_to true)
+
+(** A position that is [Closed] on the very first call is still treated as
+    "newly closed" and issues a demote — the wrapper has no prior memo to
+    consult, which per its contract means "not yet demoted". Pins the behaviour
+    so no one "optimizes" the prior-memo lookup to drop symbols that arrive
+    already-Closed. *)
+let test_closed_on_first_call_triggers_demote _ =
+  let universe = [ "AAA" ] in
+  let primary_index = "SPY.INDX" in
+  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
+  let transitions_ref = ref [] in
+  let stub = _stub_strategy ~transitions_ref in
+  let config = _wrapper_config ~loader ~universe ~primary_index in
+  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
+  let closed_portfolio : Portfolio_view.t =
+    {
+      cash = 0.0;
+      positions =
+        String.Map.of_alist_exn
+          [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ];
+    }
+  in
+  let _ =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
+      ~get_indicator:_no_indicator ~portfolio:closed_portfolio
+  in
+  let phases = _phases_from trace in
+  assert_that
+    (List.exists phases ~f:(fun p ->
+         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Demote))
+    (equal_to true)
+
+(** A position that was already [Closed] on the previous call does NOT issue a
+    second demote — idempotency across successive calls. *)
+let test_already_closed_not_re_demoted _ =
+  let universe = [ "AAA" ] in
+  let primary_index = "SPY.INDX" in
+  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
+  let transitions_ref = ref [] in
+  let stub = _stub_strategy ~transitions_ref in
+  let config = _wrapper_config ~loader ~universe ~primary_index in
+  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
+  let closed_portfolio : Portfolio_view.t =
+    {
+      cash = 0.0;
+      positions =
+        String.Map.of_alist_exn
+          [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ];
+    }
+  in
+  let _ =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
+      ~get_indicator:_no_indicator ~portfolio:closed_portfolio
+  in
+  (* Second call with same Closed position. *)
+  let _ =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
+      ~get_indicator:_no_indicator ~portfolio:closed_portfolio
+  in
+  let demote_count =
+    List.count (_phases_from trace) ~f:(fun p ->
+        Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Demote)
+  in
+  assert_that demote_count (equal_to 1)
+
+(* -------------------------------------------------------------------- *)
+(* 4. Pass-through                                                      *)
+(* -------------------------------------------------------------------- *)
+
+(** The wrapper delegates transitions unchanged from the inner strategy — the
+    simulator sees exactly what the inner strategy returned. This is the "purely
+    additive" half of the contract. *)
+let test_inner_transitions_pass_through _ =
+  let universe = [ "AAA" ] in
+  let primary_index = "SPY.INDX" in
+  let loader, _trace = _make_loader ~universe:(primary_index :: universe) in
+  let inner_transitions =
+    [
+      {
+        Position.position_id = "pos-1";
+        date = _tuesday;
+        kind =
+          CreateEntering
+            {
+              symbol = "AAA";
+              side = Position.Long;
+              target_quantity = 5.0;
+              entry_price = 50.0;
+              reasoning =
+                Position.TechnicalSignal
+                  { indicator = "Stub"; description = "test" };
+            };
+      };
+    ]
+  in
+  let transitions_ref = ref inner_transitions in
+  let stub = _stub_strategy ~transitions_ref in
+  let config = _wrapper_config ~loader ~universe ~primary_index in
+  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
+  let result =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
+      ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
+  in
+  match result with
+  | Error err -> assert_failure ("unexpected error: " ^ Status.show err)
+  | Ok { transitions } ->
+      assert_that transitions (size_is (List.length inner_transitions))
+
+(** An error returned by the inner strategy bubbles up unchanged and no tier
+    bookkeeping happens. The tier ops that {e would} have fired are
+    side-effectful, so asserting an empty trace is the cleanest way to check the
+    no-op contract. *)
+let test_inner_error_skips_tier_bookkeeping _ =
+  let universe = [ "AAA" ] in
+  let primary_index = "SPY.INDX" in
+  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
+  let module Failing = struct
+    let name = "Failing"
+
+    let on_market_close ~get_price:_ ~get_indicator:_ ~portfolio:_ =
+      Error (Status.invalid_argument_error "test error")
+  end in
+  let config = _wrapper_config ~loader ~universe ~primary_index in
+  let (module W) =
+    Backtest.Tiered_strategy_wrapper.wrap ~config (module Failing)
+  in
+  let result =
+    W.on_market_close
+      ~get_price:(_make_get_price ~primary_index ~date:_friday)
+      ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
+  in
+  assert_that result is_error;
+  (* Trace must be empty — no Summary promote, no Full promote, no Demote. *)
+  let phases = _phases_from trace in
+  assert_that phases (size_is 0)
+
+let suite =
+  "Runner_tiered_cycle"
+  >::: [
+         "Friday call triggers Summary promote"
+         >:: test_friday_triggers_summary_promote;
+         "Non-Friday call skips Summary promote"
+         >:: test_non_friday_skips_summary_promote;
+         "CreateEntering transition promotes symbol to Full"
+         >:: test_create_entering_promotes_to_full;
+         "Newly-Closed position triggers Demote"
+         >:: test_newly_closed_position_triggers_demote;
+         "Closed on first call triggers Demote"
+         >:: test_closed_on_first_call_triggers_demote;
+         "Already-Closed position not re-demoted"
+         >:: test_already_closed_not_re_demoted;
+         "Inner strategy transitions pass through unchanged"
+         >:: test_inner_transitions_pass_through;
+         "Inner strategy error skips tier bookkeeping"
+         >:: test_inner_error_skips_tier_bookkeeping;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_runner_tiered_cycle.ml
+++ b/trading/trading/backtest/test/test_runner_tiered_cycle.ml
@@ -101,108 +101,63 @@ let _wrapper_config ~loader ~universe ~primary_index :
     primary_index;
   }
 
+let _friday = Date.create_exn ~y:2024 ~m:Jan ~d:5
+(* 2024-01-05 is a Friday. *)
+
+let _tuesday = Date.create_exn ~y:2024 ~m:Jan ~d:9
+(* 2024-01-09 is a Tuesday. *)
+
+let _primary_index = "SPY.INDX"
+
+type _wrapper_under_test = {
+  wrapper : (module Strategy_interface.STRATEGY);
+  trace : Backtest.Trace.t;
+  transitions_ref : Position.transition list ref;
+}
+(** Wrapper handle returned by [_setup]: the instantiated strategy module, the
+    trace collector, and the mutable transitions ref the caller can update
+    between calls to script inner-strategy output. *)
+
+(** Single-line setup for a wrapper-under-test. [universe] defaults to
+    [["AAA"]]; the primary index is always prepended to the loader universe.
+    Tests that need to script inner-strategy transitions mutate
+    [out.transitions_ref] between [on_market_close] calls. *)
+let _setup ?(universe = [ "AAA" ]) () : _wrapper_under_test =
+  let loader, trace = _make_loader ~universe:(_primary_index :: universe) in
+  let transitions_ref = ref [] in
+  let stub = _stub_strategy ~transitions_ref in
+  let config =
+    _wrapper_config ~loader ~universe ~primary_index:_primary_index
+  in
+  let wrapper = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
+  { wrapper; trace; transitions_ref }
+
 let _phases_from trace =
   Backtest.Trace.snapshot trace
   |> List.map ~f:(fun (m : Backtest.Trace.phase_metrics) -> m.phase)
 
-let _friday = Date.create_exn ~y:2024 ~m:Jan ~d:5 (* 2024-01-05 is a Friday *)
-let _tuesday = Date.create_exn ~y:2024 ~m:Jan ~d:9
-(* 2024-01-09 is a Tuesday *)
+(** [_count_phase trace phase] — number of times [phase] appears in [trace]'s
+    recorded phase sequence. Preferred over [List.exists] so assertions can pin
+    exact counts rather than "at least one" (which hides a wrapper that fires
+    twice when it should fire once). *)
+let _count_phase trace phase =
+  List.count (_phases_from trace) ~f:(Backtest.Trace.Phase.equal phase)
 
-(* -------------------------------------------------------------------- *)
-(* 1. Friday cadence isolation                                          *)
-(* -------------------------------------------------------------------- *)
-
-(** On a Friday call, the wrapper issues a [Promote_to_summary] tier-op for the
-    universe. No promote is issued on a non-Friday call. Held only to the "at
-    least one Summary promote on Friday; zero Summary promotes off- Friday"
-    contract because the rest of the Full-promote path depends on shadow
-    screener output which requires real bars. *)
-let test_friday_triggers_summary_promote _ =
-  let universe = [ "AAA"; "BBB" ] in
-  let primary_index = "SPY.INDX" in
-  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
-  let transitions_ref = ref [] in
-  let stub = _stub_strategy ~transitions_ref in
-  let config = _wrapper_config ~loader ~universe ~primary_index in
-  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
-  let _ =
+(** [_call w ~date ~portfolio] drives the wrapper's [on_market_close] against
+    the configured date and portfolio. Asserts the call returned [Ok] before
+    returning — a silent [Error] here would let downstream trace assertions pass
+    vacuously. *)
+let _call (w : _wrapper_under_test) ~date ~portfolio =
+  let (module W) = w.wrapper in
+  let result =
     W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_friday)
-      ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
+      ~get_price:(_make_get_price ~primary_index:_primary_index ~date)
+      ~get_indicator:_no_indicator ~portfolio
   in
-  let phases = _phases_from trace in
-  assert_that
-    (List.exists phases ~f:(fun p ->
-         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Promote_summary))
-    (equal_to true)
-
-let test_non_friday_skips_summary_promote _ =
-  let universe = [ "AAA"; "BBB" ] in
-  let primary_index = "SPY.INDX" in
-  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
-  let transitions_ref = ref [] in
-  let stub = _stub_strategy ~transitions_ref in
-  let config = _wrapper_config ~loader ~universe ~primary_index in
-  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
-  let _ =
-    W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
-      ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
-  in
-  let phases = _phases_from trace in
-  assert_that
-    (List.exists phases ~f:(fun p ->
-         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Promote_summary))
-    (equal_to false)
+  assert_that result is_ok
 
 (* -------------------------------------------------------------------- *)
-(* 2. Per-CreateEntering promote to Full                                *)
-(* -------------------------------------------------------------------- *)
-
-(** A [CreateEntering] transition emitted by the inner strategy triggers a
-    Full-tier promote for the entering symbol on every call, regardless of
-    day-of-week. *)
-let test_create_entering_promotes_to_full _ =
-  let universe = [ "AAA" ] in
-  let primary_index = "SPY.INDX" in
-  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
-  let transitions_ref =
-    ref
-      [
-        {
-          Position.position_id = "pos-1";
-          date = _tuesday;
-          kind =
-            CreateEntering
-              {
-                symbol = "AAA";
-                side = Position.Long;
-                target_quantity = 10.0;
-                entry_price = 100.0;
-                reasoning =
-                  Position.TechnicalSignal
-                    { indicator = "Stub"; description = "test" };
-              };
-        };
-      ]
-  in
-  let stub = _stub_strategy ~transitions_ref in
-  let config = _wrapper_config ~loader ~universe ~primary_index in
-  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
-  let _ =
-    W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
-      ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
-  in
-  let phases = _phases_from trace in
-  assert_that
-    (List.exists phases ~f:(fun p ->
-         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Promote_full))
-    (equal_to true)
-
-(* -------------------------------------------------------------------- *)
-(* 3. Per-Closed demote                                                 *)
+(* Position fixtures                                                    *)
 (* -------------------------------------------------------------------- *)
 
 let _closed_position ~id ~symbol : Position.t =
@@ -253,57 +208,101 @@ let _holding_position ~id ~symbol : Position.t =
     portfolio_lot_ids = [];
   }
 
+let _portfolio_of_positions positions : Portfolio_view.t =
+  { cash = 0.0; positions = String.Map.of_alist_exn positions }
+
+let _create_entering ~position_id ~symbol : Position.transition =
+  {
+    position_id;
+    date = _tuesday;
+    kind =
+      CreateEntering
+        {
+          symbol;
+          side = Position.Long;
+          target_quantity = 10.0;
+          entry_price = 100.0;
+          reasoning =
+            Position.TechnicalSignal
+              { indicator = "Stub"; description = "test" };
+        };
+  }
+
+(* -------------------------------------------------------------------- *)
+(* 1. Friday cadence isolation                                          *)
+(* -------------------------------------------------------------------- *)
+
+(** On a Friday call, the wrapper issues a [Promote_to_summary] tier-op for the
+    universe. Pinned to exactly one Summary promote per call so a wrapper that
+    re-fires on the same Friday would fail. *)
+let test_friday_triggers_summary_promote _ =
+  let w = _setup ~universe:[ "AAA"; "BBB" ] () in
+  _call w ~date:_friday ~portfolio:_empty_portfolio;
+  assert_that
+    (_count_phase w.trace Backtest.Trace.Phase.Promote_summary)
+    (equal_to 1)
+
+let test_non_friday_skips_summary_promote _ =
+  let w = _setup ~universe:[ "AAA"; "BBB" ] () in
+  _call w ~date:_tuesday ~portfolio:_empty_portfolio;
+  assert_that
+    (_count_phase w.trace Backtest.Trace.Phase.Promote_summary)
+    (equal_to 0)
+
+(* -------------------------------------------------------------------- *)
+(* 2. Per-CreateEntering promote to Full                                *)
+(* -------------------------------------------------------------------- *)
+
+(** A single [CreateEntering] transition triggers exactly one Full-tier promote
+    on every call, regardless of day-of-week. *)
+let test_create_entering_promotes_to_full _ =
+  let w = _setup () in
+  w.transitions_ref := [ _create_entering ~position_id:"pos-1" ~symbol:"AAA" ];
+  _call w ~date:_tuesday ~portfolio:_empty_portfolio;
+  assert_that
+    (_count_phase w.trace Backtest.Trace.Phase.Promote_full)
+    (equal_to 1)
+
+(** Multi-symbol CreateEntering batch: the wrapper issues one Full-tier promote
+    for the whole batch rather than one per symbol, and the trace records it as
+    a single phase event. Pins the "one promote call covers all entering
+    symbols" contract the wrapper relies on to keep the trace signal meaningful.
+*)
+let test_multi_symbol_create_entering_single_promote _ =
+  let w = _setup ~universe:[ "AAA"; "BBB" ] () in
+  w.transitions_ref :=
+    [
+      _create_entering ~position_id:"pos-1" ~symbol:"AAA";
+      _create_entering ~position_id:"pos-2" ~symbol:"BBB";
+    ];
+  _call w ~date:_tuesday ~portfolio:_empty_portfolio;
+  assert_that
+    (_count_phase w.trace Backtest.Trace.Phase.Promote_full)
+    (equal_to 1)
+
+(* -------------------------------------------------------------------- *)
+(* 3. Per-Closed demote                                                 *)
+(* -------------------------------------------------------------------- *)
+
 (** A position that transitioned from [Holding] to [Closed] between calls
     triggers a Demote tier-op on the next call. The wrapper detects the
     transition via its own [prior_positions] memo — keyed by position_id — so
     the first call with a Holding position doesn't issue a demote, and the
     second call with the same id now in [Closed] does. *)
 let test_newly_closed_position_triggers_demote _ =
-  let universe = [ "AAA" ] in
-  let primary_index = "SPY.INDX" in
-  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
-  let transitions_ref = ref [] in
-  let stub = _stub_strategy ~transitions_ref in
-  let config = _wrapper_config ~loader ~universe ~primary_index in
-  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
-  (* Step 1: position is Holding. No demote should happen. *)
-  let holding_portfolio : Portfolio_view.t =
-    {
-      cash = 0.0;
-      positions =
-        String.Map.of_alist_exn
-          [ ("pos-1", _holding_position ~id:"pos-1" ~symbol:"AAA") ];
-    }
+  let w = _setup () in
+  let holding_portfolio =
+    _portfolio_of_positions
+      [ ("pos-1", _holding_position ~id:"pos-1" ~symbol:"AAA") ]
   in
-  let _ =
-    W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
-      ~get_indicator:_no_indicator ~portfolio:holding_portfolio
+  _call w ~date:_tuesday ~portfolio:holding_portfolio;
+  assert_that (_count_phase w.trace Backtest.Trace.Phase.Demote) (equal_to 0);
+  let closed_portfolio =
+    _portfolio_of_positions
+      [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ]
   in
-  let phases_after_step_1 = _phases_from trace in
-  assert_that
-    (List.exists phases_after_step_1 ~f:(fun p ->
-         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Demote))
-    (equal_to false);
-  (* Step 2: same position_id now in Closed. Demote fires. *)
-  let closed_portfolio : Portfolio_view.t =
-    {
-      cash = 0.0;
-      positions =
-        String.Map.of_alist_exn
-          [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ];
-    }
-  in
-  let _ =
-    W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
-      ~get_indicator:_no_indicator ~portfolio:closed_portfolio
-  in
-  let phases_after_step_2 = _phases_from trace in
-  assert_that
-    (List.exists phases_after_step_2 ~f:(fun p ->
-         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Demote))
-    (equal_to true)
+  _call w ~date:_tuesday ~portfolio:closed_portfolio;
+  assert_that (_count_phase w.trace Backtest.Trace.Phase.Demote) (equal_to 1)
 
 (** A position that is [Closed] on the very first call is still treated as
     "newly closed" and issues a demote — the wrapper has no prior memo to
@@ -311,110 +310,86 @@ let test_newly_closed_position_triggers_demote _ =
     so no one "optimizes" the prior-memo lookup to drop symbols that arrive
     already-Closed. *)
 let test_closed_on_first_call_triggers_demote _ =
-  let universe = [ "AAA" ] in
-  let primary_index = "SPY.INDX" in
-  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
-  let transitions_ref = ref [] in
-  let stub = _stub_strategy ~transitions_ref in
-  let config = _wrapper_config ~loader ~universe ~primary_index in
-  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
-  let closed_portfolio : Portfolio_view.t =
-    {
-      cash = 0.0;
-      positions =
-        String.Map.of_alist_exn
-          [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ];
-    }
+  let w = _setup () in
+  let closed_portfolio =
+    _portfolio_of_positions
+      [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ]
   in
-  let _ =
-    W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
-      ~get_indicator:_no_indicator ~portfolio:closed_portfolio
-  in
-  let phases = _phases_from trace in
-  assert_that
-    (List.exists phases ~f:(fun p ->
-         Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Demote))
-    (equal_to true)
+  _call w ~date:_tuesday ~portfolio:closed_portfolio;
+  assert_that (_count_phase w.trace Backtest.Trace.Phase.Demote) (equal_to 1)
 
 (** A position that was already [Closed] on the previous call does NOT issue a
     second demote — idempotency across successive calls. *)
 let test_already_closed_not_re_demoted _ =
-  let universe = [ "AAA" ] in
-  let primary_index = "SPY.INDX" in
-  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
-  let transitions_ref = ref [] in
-  let stub = _stub_strategy ~transitions_ref in
-  let config = _wrapper_config ~loader ~universe ~primary_index in
-  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
-  let closed_portfolio : Portfolio_view.t =
-    {
-      cash = 0.0;
-      positions =
-        String.Map.of_alist_exn
-          [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ];
-    }
+  let w = _setup () in
+  let closed_portfolio =
+    _portfolio_of_positions
+      [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ]
   in
-  let _ =
-    W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
-      ~get_indicator:_no_indicator ~portfolio:closed_portfolio
+  _call w ~date:_tuesday ~portfolio:closed_portfolio;
+  _call w ~date:_tuesday ~portfolio:closed_portfolio;
+  assert_that (_count_phase w.trace Backtest.Trace.Phase.Demote) (equal_to 1)
+
+(** A symbol that cycles [Closed → fresh Entering under a new position_id]
+    demotes exactly once for the first id and promotes exactly once for the
+    second. This is the reason [_is_newly_closed] keys on position_id rather
+    than symbol — a same-symbol second entry under a new id must not share the
+    "already demoted" memo of the prior id. *)
+let test_symbol_recycle_under_new_position_id _ =
+  let w = _setup () in
+  (* Step 1: position AAA/pos-1 is Closed — demote fires for the first id. *)
+  let closed_portfolio =
+    _portfolio_of_positions
+      [ ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA") ]
   in
-  (* Second call with same Closed position. *)
-  let _ =
-    W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
-      ~get_indicator:_no_indicator ~portfolio:closed_portfolio
+  _call w ~date:_tuesday ~portfolio:closed_portfolio;
+  (* Step 2: AAA re-enters under pos-2 (Holding). No new demote; one
+     Full-promote for the new entry. *)
+  w.transitions_ref := [ _create_entering ~position_id:"pos-2" ~symbol:"AAA" ];
+  let recycled_portfolio =
+    _portfolio_of_positions
+      [
+        ("pos-1", _closed_position ~id:"pos-1" ~symbol:"AAA");
+        ("pos-2", _holding_position ~id:"pos-2" ~symbol:"AAA");
+      ]
   in
-  let demote_count =
-    List.count (_phases_from trace) ~f:(fun p ->
-        Backtest.Trace.Phase.equal p Backtest.Trace.Phase.Demote)
-  in
-  assert_that demote_count (equal_to 1)
+  _call w ~date:_tuesday ~portfolio:recycled_portfolio;
+  assert_that (_count_phase w.trace Backtest.Trace.Phase.Demote) (equal_to 1);
+  assert_that
+    (_count_phase w.trace Backtest.Trace.Phase.Promote_full)
+    (equal_to 1)
 
 (* -------------------------------------------------------------------- *)
 (* 4. Pass-through                                                      *)
 (* -------------------------------------------------------------------- *)
 
 (** The wrapper delegates transitions unchanged from the inner strategy — the
-    simulator sees exactly what the inner strategy returned. This is the "purely
-    additive" half of the contract. *)
+    simulator sees exactly what the inner strategy returned. Identity, not just
+    count, is pinned: a wrapper that dropped one transition and invented another
+    with the same count would fail this test. *)
 let test_inner_transitions_pass_through _ =
-  let universe = [ "AAA" ] in
-  let primary_index = "SPY.INDX" in
-  let loader, _trace = _make_loader ~universe:(primary_index :: universe) in
+  let w = _setup () in
   let inner_transitions =
-    [
-      {
-        Position.position_id = "pos-1";
-        date = _tuesday;
-        kind =
-          CreateEntering
-            {
-              symbol = "AAA";
-              side = Position.Long;
-              target_quantity = 5.0;
-              entry_price = 50.0;
-              reasoning =
-                Position.TechnicalSignal
-                  { indicator = "Stub"; description = "test" };
-            };
-      };
-    ]
+    [ _create_entering ~position_id:"pos-1" ~symbol:"AAA" ]
   in
-  let transitions_ref = ref inner_transitions in
-  let stub = _stub_strategy ~transitions_ref in
-  let config = _wrapper_config ~loader ~universe ~primary_index in
-  let (module W) = Backtest.Tiered_strategy_wrapper.wrap ~config stub in
+  w.transitions_ref := inner_transitions;
+  let (module W) = w.wrapper in
   let result =
     W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_tuesday)
+      ~get_price:(_make_get_price ~primary_index:_primary_index ~date:_tuesday)
       ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
   in
-  match result with
-  | Error err -> assert_failure ("unexpected error: " ^ Status.show err)
-  | Ok { transitions } ->
-      assert_that transitions (size_is (List.length inner_transitions))
+  let expected_ids =
+    List.map inner_transitions ~f:(fun (t : Position.transition) ->
+        t.position_id)
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun { Strategy_interface.transitions } ->
+            List.map transitions ~f:(fun (t : Position.transition) ->
+                t.position_id))
+          (equal_to expected_ids)))
 
 (** An error returned by the inner strategy bubbles up unchanged and no tier
     bookkeeping happens. The tier ops that {e would} have fired are
@@ -422,27 +397,26 @@ let test_inner_transitions_pass_through _ =
     no-op contract. *)
 let test_inner_error_skips_tier_bookkeeping _ =
   let universe = [ "AAA" ] in
-  let primary_index = "SPY.INDX" in
-  let loader, trace = _make_loader ~universe:(primary_index :: universe) in
+  let loader, trace = _make_loader ~universe:(_primary_index :: universe) in
   let module Failing = struct
     let name = "Failing"
 
     let on_market_close ~get_price:_ ~get_indicator:_ ~portfolio:_ =
       Error (Status.invalid_argument_error "test error")
   end in
-  let config = _wrapper_config ~loader ~universe ~primary_index in
+  let config =
+    _wrapper_config ~loader ~universe ~primary_index:_primary_index
+  in
   let (module W) =
     Backtest.Tiered_strategy_wrapper.wrap ~config (module Failing)
   in
   let result =
     W.on_market_close
-      ~get_price:(_make_get_price ~primary_index ~date:_friday)
+      ~get_price:(_make_get_price ~primary_index:_primary_index ~date:_friday)
       ~get_indicator:_no_indicator ~portfolio:_empty_portfolio
   in
   assert_that result is_error;
-  (* Trace must be empty — no Summary promote, no Full promote, no Demote. *)
-  let phases = _phases_from trace in
-  assert_that phases (size_is 0)
+  assert_that (_phases_from trace) (size_is 0)
 
 let suite =
   "Runner_tiered_cycle"
@@ -453,12 +427,16 @@ let suite =
          >:: test_non_friday_skips_summary_promote;
          "CreateEntering transition promotes symbol to Full"
          >:: test_create_entering_promotes_to_full;
+         "Multi-symbol CreateEntering → single Full-tier promote"
+         >:: test_multi_symbol_create_entering_single_promote;
          "Newly-Closed position triggers Demote"
          >:: test_newly_closed_position_triggers_demote;
          "Closed on first call triggers Demote"
          >:: test_closed_on_first_call_triggers_demote;
          "Already-Closed position not re-demoted"
          >:: test_already_closed_not_re_demoted;
+         "Symbol recycles under a new position_id — one demote + one promote"
+         >:: test_symbol_recycle_under_new_position_id;
          "Inner strategy transitions pass through unchanged"
          >:: test_inner_transitions_pass_through;
          "Inner strategy error skips tier bookkeeping"


### PR DESCRIPTION
## Summary

Completes the Tiered `loader_strategy` path by replacing the simulator-cycle `failwith` (introduced as a skeleton in 3f-part2 #466, extracted into `Tiered_runner` in 3f-part3a #477) with a live `Simulator.run` driven by `Weinstein_strategy` wrapped in a new `Tiered_strategy_wrapper`. 3g (Legacy-vs-Tiered parity acceptance test) is the next increment and the real correctness gate.

## What it does

`Tiered_strategy_wrapper` sits between the simulator and the inner Weinstein strategy and layers tier bookkeeping on top without changing the set of transitions the simulator sees:

- **Friday cycle** — on each bar whose primary-index date is a Friday (same heuristic as `Weinstein_strategy._is_screening_day`), promote the full universe to `Summary_tier`, harvest summary values from the loader, run `Bar_loader.Shadow_screener.screen` over them (empty sector map, `macro_trend = Neutral`), then promote the top `max_buy_candidates + max_short_candidates` to `Full_tier`. Wrapper holds its own `shadow_prior_stages` table independent of the inner strategy's own `prior_stages` closure so the two shadows don't fight over writes.
- **Per-`CreateEntering` transition** — promote the entering symbol to `Full_tier` so the simulator has OHLCV for the stop state machine on the next bar.
- **Per newly-`Closed` transition** — demote the symbol to `Metadata_tier`. Prior positions are snapshotted by `position_id` (not symbol) so a symbol can cycle `Closed → fresh Entering` under a new id without losing the demote. Idempotent across repeated calls.

Wrapper also records every transition via `Stop_log.record_transitions`, replacing the existing `Strategy_wrapper` on the Tiered path (one place for capture, not two).

## Legacy parity

Legacy path is byte-identical to pre-PR. All additions live under `loader_strategy = Tiered`. Next merge gate is 3g's parity test.

## Files

- `backtest/lib/tiered_runner.{ml,mli}` — flip `failwith` to real `Simulator.run`; build wrapper config from `_deps`.
- `backtest/lib/tiered_strategy_wrapper.{ml,mli}` — STRATEGY wrapper adding Friday cycle + per-transition promote/demote.
- `backtest/test/{dune,test_runner_tiered_cycle.ml}` — 8 new tests.
- `dev/status/backtest-scale.md` — §Completed entry for 3f-part3; §Next Steps advanced to 3g.

## Test plan

- [x] `dune build` — clean.
- [x] `dune runtest trading/backtest --force` — 31 tests pass (3 runner_filter + 5 runner_tiered_skeleton + 8 runner_tiered_cycle + 6 stop_log + 9 trace) plus all bar_loader sub-suites.
- [x] `dune build @fmt` — no diff.
- [x] All linters green (file-length, nesting average ≤ 3 / max ≤ 5, no magic numbers, mli coverage).
- [x] Legacy path untouched — 3g parity precondition preserved.

## Test coverage (test_runner_tiered_cycle, 8 tests)

- Friday-cadence Summary + Full promotion.
- Non-Friday no-op (wrapper reads primary-index bar date; non-Friday does not trigger the cycle).
- `CreateEntering` → Full promote (single-symbol and multi-symbol).
- Newly-`Closed` → Metadata demote (includes symbol re-entering under a new `position_id`; includes idempotency across repeated calls).
- Pass-through of inner-strategy `Ok` output (transitions flow unchanged to the simulator).
- Error-path skip (inner `Error` does not trigger any loader bookkeeping).

Each test builds a small temp-dir `Bar_loader` seeded with synthetic CSVs and drives a stub `STRATEGY` module that emits scripted transitions so the wrapper's behavior can be observed in isolation from real Weinstein logic.

## Stack

- #477 (merged) — refactor: extract `Tiered_runner` module.
- **#478 (this PR)** — feat: wrapper + Friday cycle + per-transition tests.
