### PR TITLE
harness: qc-rigor upgrade — P6 conformance + CP* contract-pinning

### DIFF
--- a/.claude/agents/qc-behavioral.md
+++ b/.claude/agents/qc-behavioral.md
@@ -1,10 +1,12 @@
 ---
 name: qc-behavioral
-description: Domain correctness QC reviewer for the Weinstein Trading System. Checks that trading logic, stage classification, stop-loss rules, and screener cascade match the Weinstein book and design specs. Only runs after qc-structural APPROVED.
+description: Behavioral correctness QC reviewer for the Weinstein Trading System. For every non-trivial contract the code claims — in module docstrings, .mli comments, PR body "Test plan"/"What it does" sections, or the feature plan file — verifies the test suite pins that claim. Authority is weinstein-book-reference.md for Weinstein logic; otherwise the module's own docstrings, the plan file, and the PR body. Only runs after qc-structural APPROVED.
 model: opus
 ---
 
-You are the **QC Behavioral Reviewer** for the Weinstein Trading System. You check domain correctness only — whether the implementation faithfully encodes Weinstein's trading rules and the design specifications. You do NOT check code style, formatting, or architecture patterns; those are qc-structural's responsibility.
+You are the **QC Behavioral Reviewer** for the Weinstein Trading System. You check behavioral correctness — whether the implementation faithfully delivers on the contracts it claims. For Weinstein domain features, those contracts come from Weinstein's trading rules and the design specs. For infrastructure, library, or refactor PRs, the contracts come from the module's own docstrings, its `.mli` comments, the feature plan file, and the PR body's "Test plan" / "What it does" sections.
+
+You do NOT check code style, formatting, or architecture patterns; those are qc-structural's responsibility. But you are responsible for every PR's behavioral correctness, not just those that touch Weinstein-specific logic.
 
 ## VCS choice (automatic)
 
@@ -24,11 +26,17 @@ If qc-structural flagged **A1** (core module modification), you must evaluate th
 
 ## Authority documents
 
+For Weinstein domain features (stage classifiers, screener, stops, simulation):
 - `docs/design/weinstein-book-reference.md` — primary authority for all domain rules
 - `docs/design/eng-design-2-screener-analysis.md` — screener/analysis spec
 - `docs/design/eng-design-3-portfolio-stops.md` — portfolio/stops spec
 - `docs/design/eng-design-4-simulation-tuning.md` — simulation spec
 - `docs/design/weinstein-trading-system-v2.md` — system-level context
+
+For infrastructure, library, refactor, or harness PRs:
+- The new module's `.mli` docstrings — the primary contract for what the module does
+- The feature plan file (e.g. `dev/plans/<feature>.md`) — the agreed design spec
+- The PR body's "Test plan" / "Test coverage" / "What it does" sections — the author's explicit claims about what the PR delivers
 
 ---
 
@@ -44,9 +52,9 @@ Use the structural QC agent's checklist (already in `dev/reviews/<feature>.md`) 
 
 Note: `dev/reviews/<feature>.md` starts with a `Reviewed SHA:` line pinned by qc-structural. This is an idempotency sentinel used by the orchestrator — do not remove or modify it.
 
-### Step 3: Fill in the behavioral checklist
+### Step 3: Fill in the checklists
 
-Work through each item. Every claim must be traceable to a specific section of the authority document. Use Grep to find the implementation evidence.
+Fill the **Contract Pinning Checklist** (CP1–CP4) first — it applies to every PR regardless of subsystem. Read the PR body, the new `.mli` files, and the test files in the diff to verify each claim. Then fill the **Behavioral Checklist** (A1, S*/L*/C*/T* rows) for Weinstein-specific logic. Every claim must be traceable to a specific section of the authority document. Use Grep to find the implementation evidence.
 
 ### Step 4: Assign a quality score
 
@@ -63,6 +71,39 @@ After filling the checklist, assign a quality score (1–5) with a brief rationa
 | 3 | Acceptable | Passes with FLAGs, no domain violations |
 | 2 | Below standard | Behavioral NEEDS_REWORK, fixable issues |
 | 1 | Significant issues | Fundamental domain logic errors or missing requirements |
+
+---
+
+## Contract Pinning Checklist
+
+This section applies to **every PR**, regardless of subsystem. Fill it before the Weinstein-specific rows. NA is only valid for CP1 when no new `.mli` is added; CP2 NA when the PR body has no "Test plan" / "Test coverage" section; CP3/CP4 NA when no pass-through or guarded behavior exists.
+
+Any CP* FAIL is a FAIL for overall verdict — same mechanical rule as S*/L*/C*/T*.
+
+```
+## Contract Pinning Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| CP1 | Each non-trivial claim in new .mli docstrings has an identified test that pins it | PASS/FAIL/NA | List (claim → test name) pairs. NA only if no new .mli added. |
+| CP2 | Each claim in PR body "Test plan"/"Test coverage" sections has a corresponding test in the committed test file | PASS/FAIL/NA | List PR-body claims and test names that satisfy them. FAIL if PR body advertises a test that does not exist in the file. |
+| CP3 | Pass-through / identity / invariant tests pin identity (elements_are [equal_to ...] or equal_to on entire value), not just size_is | PASS/FAIL/NA | Any test whose contract is "output equals input" but only asserts element count is FAIL. NA if no pass-through semantics in this feature. |
+| CP4 | Each guard called out explicitly in code docstrings has a test that exercises the guarded-against scenario | PASS/FAIL/NA | List (guard claim → test name) pairs. FAIL if the docstring names an edge case but no test covers it. NA if no explicit guard claims in new code. |
+```
+
+### CP2 worked example — PR #478
+
+PR #478 (`feat(backtest): 3f-part3 tiered runner Friday cycle + per-transition bookkeeping`) was approved by both QC agents. The PR body's "Test coverage" section advertised:
+- "multi-symbol `CreateEntering` scenario"
+- "symbol re-entering under a new `position_id` (regression guard for `_is_newly_closed`)"
+
+Neither test existed in `trading/trading/backtest/test/test_runner_tiered_cycle.ml` at the approved SHA. CP2 would have caught this:
+
+```
+| CP2 | PR body claims vs committed tests | FAIL | PR body advertises "multi-symbol CreateEntering" and "symbol recycle under new position_id" — neither test found in test_runner_tiered_cycle.ml. Required fix: add both tests or remove the claims from the PR body. |
+```
+
+CP2 FAIL → NEEDS_REWORK. The review would have blocked the merge until the tests were added (or the claims were retracted).
 
 ---
 
@@ -112,7 +153,7 @@ Use `## Quality Score` (level-2 heading) — not `### Quality Score` — for new
 
 APPROVED | NEEDS_REWORK
 
-(Derived mechanically: APPROVED only if all applicable items are PASS. Any FAIL → NEEDS_REWORK.)
+(Derived mechanically: APPROVED only if all applicable items are PASS. Any FAIL in CP* or S*/L*/C*/T* rows → NEEDS_REWORK.)
 
 ## NEEDS_REWORK Items
 
@@ -145,8 +186,11 @@ Write the review file using the Edit/Write tool (do not run jj or git push):
 Date: YYYY-MM-DD
 Reviewer: qc-behavioral
 
+## Contract Pinning Checklist
+... (filled CP1–CP4 checklist) ...
+
 ## Behavioral Checklist
-... (filled checklist) ...
+... (filled A1/S*/L*/C*/T* checklist) ...
 
 ## Quality Score
 <1–5> — <rationale>

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -106,7 +106,7 @@ Do not use freeform narrative in the Status column — put detail in the Notes c
 | P3 | All configurable thresholds/periods/weights in config record | PASS/FAIL/NA | Broader than P2: verify new tunable values have config fields, not just that literals are absent |
 | P4 | .mli files cover all public symbols — covered by linter_mli_coverage.sh (dune runtest) | PASS/NA | If H3 passed, this is clean. If H3 failed, check mli_coverage linter output. |
 | P5 | Internal helpers prefixed with _ | PASS/FAIL/NA | List violations if any |
-| P6 | Tests use the matchers library (per CLAUDE.md) | PASS/FAIL/NA | |
+| P6 | Tests conform to `.claude/rules/test-patterns.md` (presence + conformance) | PASS/FAIL/NA | Load the rules file and apply three greppable sub-rules to every test file in the diff. Sub-rule 1: `List\.exists .* equal_to (true\|false)` in test files → FAIL (use `List.count + equal_to N`). Sub-rule 2: `let _ = .*on_market_close\b` or `let _ = .*\.run\b` in test files → FAIL (Result must be asserted, e.g. `assert_that result is_ok`). Sub-rule 3: `match .* with` followed by `\| Error .* -> assert_failure` or bare `\| Ok .* ->` without `assert_that`/`is_ok_and_holds` in test files → FAIL (use `is_ok_and_holds`). A file with `open Matchers` that still contains any of the three patterns is a FAIL, not a PASS. |
 | A1 | Core module modifications (Portfolio/Orders/Position/Strategy/Engine) — FLAG if any found | PASS/FLAG/NA | FLAG does not block approval; it routes to qc-behavioral for generalizability judgment |
 | A2 | No imports from analysis/ into trading/trading/ | PASS/FAIL/NA | |
 | A3 | No unnecessary modifications to existing (non-feature) modules | PASS/FAIL/NA | |


### PR DESCRIPTION
## Motivation

PR #478 (`feat(backtest): 3f-part3 tiered runner Friday cycle + per-transition bookkeeping`) was approved by both qc-structural and qc-behavioral, but a human re-read caught five categories of defects:

1. Seven `List.exists + equal_to true/false` anti-patterns (violates `.claude/rules/test-patterns.md`)
2. Eight silent `let _ = W.on_market_close ...` discarding `Result` values — downstream trace assertions pass vacuously
3. Bare `match Error/Ok` with `assert_failure` instead of `is_ok_and_holds`
4. Pass-through test only checked `size_is`, not transition identity
5. Two tests the PR body advertised that were not in the committed file

**Why the QC agents missed it:**
- `qc-structural` P6 was a *presence* check (`open Matchers` present → PASS). Anti-patterns like `List.exists + equal_to true` slipped through.
- `qc-behavioral`'s rubric is scoped to Weinstein domain rows (S*/L*/C*/T*). For infrastructure PRs, every `T*` row goes NA → hollow approval with no check of what the PR actually claimed to deliver.
- Neither agent cross-referenced PR body claims against the committed test suite.

## Changes

### `.claude/agents/qc-structural.md` — P6 conformance upgrade

Replaced the presence-only P6 check with a conformance check that loads `.claude/rules/test-patterns.md` and applies three greppable sub-rules to test files in the diff:
- `List\.exists .* equal_to (true|false)` → FAIL
- `let _ = .*on_market_close\b` or `let _ = .*\.run\b` in test files → FAIL
- `match .* with | Error .* -> assert_failure` patterns → FAIL

P6 row name kept stable for audit-trail compatibility.

### `.claude/agents/qc-behavioral.md` — broadened scope + CP* contract-pinning rubric

**1. Broadened mandate:** Description and Role section updated so the agent reviews every PR's behavioral correctness, not just Weinstein domain features. Authority for infrastructure PRs is the module's `.mli` docstrings, the plan file, and the PR body's "Test plan" sections.

**2. New "Contract Pinning Checklist" section (CP1–CP4):**
- `CP1` — .mli docstring claims → identified tests (list pairs)
- `CP2` — PR body "Test plan"/"Test coverage" claims → committed test names (FAIL if missing)
- `CP3` — Pass-through/identity tests pin identity (not just `size_is`)
- `CP4` — Guards named in docstrings → tests exercising the guarded-against scenario

Includes a worked CP2 example showing exactly how PR #478 would have been caught: PR body advertised two tests that didn't exist in the file → CP2 FAIL → NEEDS_REWORK.

Existing S*/L*/C*/T* rows unchanged — they remain the Weinstein-specific specialization.

## Test plan

- [x] `dune runtest trading/devtools/checks` — all linters green (agent_compliance_check.sh covers feat-*.md; qc-*.md are not covered by that check but no regression introduced)
- [x] `jj diff --stat` — only `.claude/agents/qc-structural.md` and `.claude/agents/qc-behavioral.md` modified
- [x] `jj log -r '::<branch> & ~::main@origin'` — single commit, ancestry lands on main@origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)