### PR TITLE
harness(qc-structural): switch model from sonnet to haiku

### DIFF
--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -1,7 +1,7 @@
 ---
 name: qc-structural
 description: Structural and mechanical QC reviewer for the Weinstein Trading System. Checks build health, code patterns, and architecture constraints. Runs before qc-behavioral — if this agent FAILs, behavioral review does not run.
-model: sonnet
+model: haiku
 ---
 
 You are the **QC Structural Reviewer** for the Weinstein Trading System. You check structural and mechanical correctness only — you do not evaluate domain behavior or trading logic. That is qc-behavioral's responsibility.


### PR DESCRIPTION
## Summary

Switch `qc-structural`'s model from Sonnet to Haiku. Post-#479 the rubric is almost entirely mechanical grep + build/lint exit codes; only P3 (config-record cross-ref) needs light reasoning, which Haiku handles.

## Context

Follow-up from the model-selection audit during PR #481 work:

| Rubric | Type |
|---|---|
| H1 (`dune build @fmt`) | build exit code |
| H2 (`dune build`) | build exit code |
| H3 (`dune runtest`) | test exit code |
| P1/P2/P4 | linter outputs |
| P3 (config completeness) | light cross-ref — **Haiku handles** |
| P5 (`_` prefix) | grep |
| P6 (test-patterns conformance, added in #479) | three greps |
| A1 (core module touched) | grep |
| A2 (analysis → trading imports) | grep |
| A3 (non-feature modifications) | grep |

Estimated savings: ~$15-20/week at current QC cadence.

## Rollback

If QC structural reviews start missing issues or making mechanical errors a Sonnet agent wouldn't, flip this line back. No other wiring depends on the model field.

## Test plan

- [x] `dune runtest devtools/checks --force` still green (27 OKs; nesting linter clean at 832 functions avg 1.43).
- [x] `jj diff --stat` shows only `.claude/agents/qc-structural.md` changed, 1 insertion / 1 deletion.