### PR TITLE
fix(bar_loader): bump default Summary tail_days (F2 closure)

### DIFF
--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -1,6 +1,6 @@
 # Status: backtest-scale
 
-## Last updated: 2026-04-21
+## Last updated: 2026-04-22
 
 ## Status
 READY_FOR_REVIEW
@@ -89,6 +89,20 @@ Build alongside existing `Bar_history` — don't modify it.
 
 ## Follow-up / escalation
 
+- **F2 (CLOSED 2026-04-22) — Summary_compute default tail_days too short.**
+  The 3g QC behavioral review flagged that parity was holding for the
+  wrong reason: Tiered reported `Summary=0 Full=0` on every Friday
+  because `Summary_compute.compute_values` returned `None` for every
+  universe symbol. Root cause: `default_config.tail_days = 250` is below
+  `rs_ma_period * 7 = 364` calendar days, so 250 days of daily bars
+  aggregate to only ~36 weekly bars — strictly under the 52-bar
+  Mansfield zero-line threshold that `Relative_strength.analyze` checks.
+  `rs_line` returns `None`, `compute_values` short-circuits on the first
+  `None` in its Option chain, and the symbol stays at Metadata. Fixed
+  by bumping `default_config.tail_days` from 250 to 420 (~60 weekly
+  bars after aggregation). Branch `feat/backtest-scale-f2`, see
+  §Completed.
+
 - **`Tiered_runner._promote_universe_metadata` is strictly intolerant of missing CSVs.**
   Surfaced by the 3g parity scenario: Legacy's `Simulator` silently
   skips any symbol whose `data.csv` is absent, while
@@ -122,6 +136,52 @@ Build alongside existing `Bar_history` — don't modify it.
   to `Bar_loader.create ~benchmark_symbol:_`.
 
 ## Completed
+
+- **F2 — Summary-tier default tail_days fix** (2026-04-22). Closes the
+  residual gap the 3g behavioral QC flagged: under the Tiered path the
+  parity test was reporting `Tiered loader: Metadata=22 Summary=0
+  Full=0 at end of simulator run`, meaning the Shadow_screener pipeline
+  and per-transition promote/demote bookkeeping never saw any real
+  data. Parity held only because both paths fell through to the
+  simulator's pre-loaded bar cache.
+  **Diagnosis.** `Summary_compute.default_config.tail_days = 250` is
+  below the minimum needed for the 52-weekly-bar Mansfield RS window.
+  250 calendar days of daily input aggregate to ~36 weekly bars via
+  `Time_period.Conversion.daily_to_weekly` — strictly under the 52-bar
+  threshold `Relative_strength.analyze` checks with `n < rs_ma_period`.
+  `rs_line` returns `None`, `compute_values` short-circuits on the
+  first `None` in its Option monadic chain, and the symbol is left at
+  its prior tier (Metadata after the auto-promote cascade). Neither
+  the Shadow_screener cascade nor the Summary→Full pipeline sees any
+  input.
+  **Fix.** Bump `default_config.tail_days` from 250 to 420 (~60 weekly
+  bars after aggregation, covering `rs_ma_period = 52` with headroom
+  for market-holiday gaps and partial-week edges). Updated both
+  `summary_compute.ml`'s `default_config` binding and the
+  `summary_compute.mli` doc comment to spell out that the binding
+  constraint is `rs_ma_period * 7` calendar days, not the 30-week MA
+  (which only needs ~210 days). No strategy / screener / runner code
+  touched — fix is scoped to `bar_loader/summary_compute.ml`.
+  **Verification.** The parity scenario now reports
+  `Tiered loader: Metadata=0 Summary=19 Full=3 at end of simulator
+  run`, meaning all 19 symbols with sufficient history reach Summary
+  and the Shadow_screener's top-3 candidates reach Full tier. All
+  three parity assertions (round-trip count exact, final value within
+  $0.01, sampled step values within $0.01) still hold — now for the
+  right reason. Added a regression test
+  `test_promote_to_summary_with_default_config` that pins the contract
+  "with defaults only, a stock with exactly `default_config.tail_days`
+  of history must promote to Summary tier" — it fails loudly if
+  anyone ever reduces `tail_days` below the RS threshold again.
+  - Files: `trading/backtest/bar_loader/{summary_compute.ml,summary_compute.mli,test/test_summary.ml}`.
+  - Verify:
+    `dev/lib/run-in-env.sh dune build &&
+     dev/lib/run-in-env.sh dune runtest trading/backtest --force` —
+    3 parity tests (test_tiered_loader_parity) pass with Tiered loader
+    reporting `Summary=19 Full=3` at sim-run end (was 0/0 before);
+    9 test_summary tests pass (was 8 before — 1 new regression test);
+    all other backtest tests still green; full-workspace `dune runtest`
+    passes; `dune build @fmt` clean.
 
 - **3g — Parity acceptance test (merge gate)** (2026-04-21). New
   test binary at `trading/trading/backtest/test/test_tiered_loader_parity.ml`

--- a/trading/trading/backtest/bar_loader/summary_compute.ml
+++ b/trading/trading/backtest/bar_loader/summary_compute.ml
@@ -10,8 +10,17 @@ type config = {
 }
 [@@deriving sexp, show, eq]
 
+(** [default_config.tail_days] must cover the longest indicator window after
+    daily→weekly aggregation. The Mansfield RS line uses [rs_ma_period = 52]
+    WEEKLY bars, which requires ~52 × 7 = 364 calendar days of daily input at a
+    minimum; we pad to 420 (~60 weekly bars) so market-holiday gaps and the
+    aggregation's partial-week edge don't trip the [n < rs_ma_period] threshold
+    inside [Relative_strength.analyze]. Below that threshold [rs_line] returns
+    [None] and [compute_values] returns [None] via its Option monadic chain,
+    which silently leaves callers at the prior tier — the F2 regression the
+    parity test was quietly masking before the bump. *)
 let default_config =
-  { ma_weeks = 30; atr_days = 14; rs_ma_period = 52; tail_days = 250 }
+  { ma_weeks = 30; atr_days = 14; rs_ma_period = 52; tail_days = 420 }
 
 type summary_values = {
   ma_30w : float;

--- a/trading/trading/backtest/bar_loader/summary_compute.mli
+++ b/trading/trading/backtest/bar_loader/summary_compute.mli
@@ -24,13 +24,17 @@ type config = {
   tail_days : int;
       (** Upper bound on the daily-bar tail the Summary loader fetches per
           symbol. Must be large enough to cover the longest indicator window
-          plus warmup. Default: 250 (~ [ma_weeks] × 7 + ATR warmup). *)
+          plus warmup AFTER daily→weekly aggregation. The binding constraint is
+          [rs_ma_period] weekly bars, which requires ~[rs_ma_period] × 7
+          calendar days of daily input plus a buffer for market-holiday gaps and
+          partial-week aggregation edge. Default: 420 (~60 weekly bars, covering
+          the default [rs_ma_period = 52] with headroom). *)
 }
 [@@deriving sexp, show, eq]
 
 val default_config : config
 (** Sensible defaults for Weinstein-style analysis:
-    [{ ma_weeks = 30; atr_days = 14; rs_ma_period = 52; tail_days = 250 }]. *)
+    [{ ma_weeks = 30; atr_days = 14; rs_ma_period = 52; tail_days = 420 }]. *)
 
 (** {1 Indicator primitives}
 

--- a/trading/trading/backtest/bar_loader/test/test_summary.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary.ml
@@ -114,6 +114,44 @@ let _summary_fixture ?(stock_step = 1.0) ?(benchmark_step = 1.0) () =
   in
   (loader, as_of)
 
+(** Default-config fixture: exactly [default_config.tail_days] daily bars of
+    history — the realistic input shape the runner produces on the first Friday
+    of a backtest. This fixture does NOT override [tail_days], so it pins the
+    contract "with defaults only, a stock that has exactly [tail_days] worth of
+    bars must promote to Summary tier".
+
+    This is the regression fixture for the F2 follow-up (see
+    [dev/reviews/backtest-scale.md]): before the fix, the default
+    [tail_days = 250] is too short for [rs_ma_period = 52] weekly bars (~36
+    weekly bars aggregate from 250 calendar days, below the 52-bar Mansfield
+    zero-line threshold), so [rs_line] returns [None] and the symbol never
+    reaches Summary tier. *)
+let _default_config_fixture () =
+  let as_of = Date.create_exn ~y:2023 ~m:Dec ~d:29 in
+  (* Use [default_config.tail_days] bars so the CSV tail is exactly what the
+     loader will read back. If we wrote FEWER than [tail_days] calendar days of
+     bars the test would also fail (not enough input), so sizing it to the
+     default is the honest reproduction of the runner path. *)
+  let history_days = Bar_loader.Summary_compute.default_config.tail_days in
+  let start_date = Date.add_days as_of (-history_days) in
+  let data_dir = _fresh_data_dir () in
+  let stock_bars =
+    _daily_series ~start_date ~n:history_days ~base:100.0 ~step:1.0
+  in
+  let benchmark_bars =
+    _daily_series ~start_date ~n:history_days ~base:100.0 ~step:1.0
+  in
+  _write_symbol ~data_dir ~symbol:"STOCK" ~bars:stock_bars;
+  _write_symbol ~data_dir ~symbol:"SPY" ~bars:benchmark_bars;
+  let sector_map = String.Table.create () in
+  Hashtbl.set sector_map ~key:"STOCK" ~data:"Tech";
+  (* Intentionally NO [summary_config] override — the point of this fixture is
+     to exercise the defaults. *)
+  let loader =
+    Bar_loader.create ~data_dir ~sector_map ~universe:[ "STOCK" ] ()
+  in
+  (loader, as_of)
+
 (** Short-history fixture: 10 daily bars — not enough for any Summary indicator.
     Used to verify "insufficient history leaves symbol at Metadata". *)
 let _short_fixture () =
@@ -256,6 +294,40 @@ let test_get_summary_none_for_unknown_symbol _ =
   assert_that (Bar_loader.get_summary loader ~symbol:"NOPE") is_none;
   assert_that (Bar_loader.tier_of loader ~symbol:"NOPE") is_none
 
+(** Regression for the F2 follow-up (see [dev/reviews/backtest-scale.md]): with
+    the default summary config and exactly [default_config.tail_days] daily
+    bars available, a Summary promotion must succeed.
+
+    Before the fix, [default_config.tail_days = 250] is too short for
+    [rs_ma_period = 52] (weekly): 250 daily bars aggregate to ~36 weekly bars
+    (strictly below the 52-bar Mansfield zero-line threshold), so
+    [Relative_strength.analyze] returns [None], [Summary_compute.rs_line]
+    returns [None], [Summary_compute.compute_values] returns [None], and the
+    symbol is left at Metadata tier. This silently broke the Tiered runner's
+    parity with Legacy because no universe symbol ever reached Summary (and
+    therefore no symbol ever reached Full) on the parity scenario.
+
+    The fix is to bump [default_config.tail_days] so it covers
+    [max(ma_weeks, rs_ma_period)] weekly bars plus warmup. *)
+let test_promote_to_summary_with_default_config _ =
+  let loader, as_of = _default_config_fixture () in
+  let result =
+    Bar_loader.promote loader ~symbols:[ "STOCK" ] ~to_:Summary_tier ~as_of
+  in
+  assert_that result is_ok;
+  (* The critical observation: tier advances past Metadata. If [tail_days] is
+     too short, tier stays at Metadata_tier and this assertion fails loudly. *)
+  assert_that
+    (Bar_loader.tier_of loader ~symbol:"STOCK")
+    (is_some_and (equal_to Bar_loader.Summary_tier));
+  assert_that
+    (Bar_loader.get_summary loader ~symbol:"STOCK")
+    (is_some_and
+       (* Stock and benchmark move in lockstep → normalized RS = 1.0. *)
+       (match_summary ~symbol:(equal_to "STOCK") ~as_of:(equal_to as_of)
+          ~ma_30w:(is_between (module Float_ord) ~low:100.0 ~high:800.0)
+          ~atr_14:(float_equal 1.0) ~rs_line:(float_equal 1.0) ~stage:__))
+
 let suite =
   "Bar_loader.Summary"
   >::: [
@@ -273,6 +345,8 @@ let suite =
          >:: test_demote_summary_to_summary_is_noop;
          "get_summary_none_for_unknown_symbol"
          >:: test_get_summary_none_for_unknown_symbol;
+         "promote_to_summary_with_default_config"
+         >:: test_promote_to_summary_with_default_config;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/bar_loader/test/test_summary.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary.ml
@@ -87,9 +87,9 @@ let _fresh_data_dir () =
 
     The loader only looks at bars in [as_of - tail_days, as_of]. With
     [tail_days = 420] the tail is ~420 calendar days ≈ ~60 ISO weeks after
-    daily→weekly aggregation, which covers [rs_ma_period = 52] WEEKLY bars
-    with headroom. We still pass an explicit [summary_config] override here
-    so the fixture continues to work even if the production default shifts. *)
+    daily→weekly aggregation, which covers [rs_ma_period = 52] WEEKLY bars with
+    headroom. We still pass an explicit [summary_config] override here so the
+    fixture continues to work even if the production default shifts. *)
 let _summary_fixture ?(stock_step = 1.0) ?(benchmark_step = 1.0) () =
   let as_of = Date.create_exn ~y:2023 ~m:Dec ~d:29 in
   let history_days = 420 in

--- a/trading/trading/backtest/bar_loader/test/test_summary.ml
+++ b/trading/trading/backtest/bar_loader/test/test_summary.ml
@@ -83,13 +83,13 @@ let _fresh_data_dir () =
   Fpath.v dir
 
 (** Summary-tier fixture: enough daily bars ending at [as_of] for the loader's
-    default 250-day tail + 30-week MA + 52-week RS window to resolve.
+    default [tail_days] + 30-week MA + 52-week RS window to resolve.
 
     The loader only looks at bars in [as_of - tail_days, as_of]. With
-    [tail_days = 250] the tail is ~250 calendar days ≈ ~36 ISO weeks (before
-    aggregation); to produce [rs_line] we need [rs_ma_period = 52] WEEKLY bars
-    after aggregation, so we configure the loader to fetch a larger tail via
-    [summary_config] and generate ~420 days (~60 weeks) of history. *)
+    [tail_days = 420] the tail is ~420 calendar days ≈ ~60 ISO weeks after
+    daily→weekly aggregation, which covers [rs_ma_period = 52] WEEKLY bars
+    with headroom. We still pass an explicit [summary_config] override here
+    so the fixture continues to work even if the production default shifts. *)
 let _summary_fixture ?(stock_step = 1.0) ?(benchmark_step = 1.0) () =
   let as_of = Date.create_exn ~y:2023 ~m:Dec ~d:29 in
   let history_days = 420 in
@@ -295,8 +295,8 @@ let test_get_summary_none_for_unknown_symbol _ =
   assert_that (Bar_loader.tier_of loader ~symbol:"NOPE") is_none
 
 (** Regression for the F2 follow-up (see [dev/reviews/backtest-scale.md]): with
-    the default summary config and exactly [default_config.tail_days] daily
-    bars available, a Summary promotion must succeed.
+    the default summary config and exactly [default_config.tail_days] daily bars
+    available, a Summary promotion must succeed.
 
     Before the fix, [default_config.tail_days = 250] is too short for
     [rs_ma_period = 52] (weekly): 250 daily bars aggregate to ~36 weekly bars


### PR DESCRIPTION
## Summary

Closes the F2 follow-up from the 3g QC behavioral review (#484 residual gap): under `Loader_strategy.Tiered`, every Friday's Summary promotion silently left universe symbols at Metadata tier, so the Shadow_screener pipeline saw zero summary rows and no symbol reached Full tier. Parity with Legacy held only because both paths fell through to the simulator's pre-loaded bar cache.

**Root cause:** `Summary_compute.default_config.tail_days = 250` is below `rs_ma_period * 7 = 364` calendar days. 250 daily bars aggregate to only ~36 weekly bars — strictly under the 52-bar Mansfield zero-line threshold `Relative_strength.analyze` checks. `rs_line` returns `None`, `compute_values` short-circuits on the first `None` in its Option chain, and the symbol stays at Metadata.

**Fix:** Bump `default_config.tail_days` from 250 to 420 (~60 weekly bars after aggregation, covering `rs_ma_period = 52` with headroom). Updated the `.mli` doc to spell out that the binding constraint is `rs_ma_period * 7` calendar days.

**Scope:** Localized to `bar_loader/summary_compute.ml{,i}` — no strategy / screener / runner code touched. Follow-up items F1 (3g tolerance), F3 (`_promote_universe_metadata` tolerance), and 3h (nightly A/B) deliberately out of scope.

### Verification (before / after)

Before:
```
Tiered loader: Metadata=22 Summary=0 Full=0 at end of simulator run
```

After:
```
Tiered loader: Metadata=0 Summary=19 Full=3 at end of simulator run
```

All three parity assertions still hold — now for the right reason: the Tiered path actually exercises the Shadow_screener cascade and per-transition promote/demote bookkeeping.

## Test plan

- [x] New regression test `test_promote_to_summary_with_default_config` fails before the fix, passes after — pins "with defaults only, a stock with exactly `default_config.tail_days` of history must promote to Summary tier"
- [x] `dune build && dune runtest` passes workspace-wide
- [x] `dune build @fmt` clean
- [x] `test_tiered_loader_parity.exe` — all 3 parity tests pass (`Summary=19 Full=3` now reported at sim-run end, was 0/0)
- [x] All 60 bar_loader tests pass (was 59, +1 new regression)
- [x] PR diff ≤ 500 LOC (156 LOC across 4 files, status/fixture updates included)

## Commits

1. `test(bar_loader): regression test for F2 Summary-tier default config` — the failing test first
2. `fix(bar_loader): bump default Summary tail_days from 250 to 420 (F2)` — the behavior fix
3. `chore(bar_loader): apply dune fmt to test_summary doc comment` — formatter line-wrap
4. `docs(status): mark F2 closed in backtest-scale.md` — status-file update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
