### PR TITLE
harness: POSIX shell portability linter (dash -n gate)

### DIFF
--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -1,6 +1,6 @@
 # Status: harness
 
-## Last updated: 2026-04-21
+## Last updated: 2026-04-22
 
 ## Status
 IN_PROGRESS
@@ -166,6 +166,7 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
      `sh trading/devtools/checks/deep_scan.sh` — report contains
      `## Stale Local Bookmarks`.
   Source: `dev/daily/2026-04-14.md` end-of-day audit.
+- ~~**POSIX shell portability linter**~~ — DONE (harness/posix-sh-linter): `trading/devtools/checks/posix_sh_check.sh` runs `dash -n` over all #!/bin/sh scripts in `trading/devtools/checks/`, `trading/devtools/checks/deep_scan/`, and `dev/lib/`. Scripts with `#!/usr/bin/env bash` shebang are exempt. Smoke test: `trading/devtools/checks/posix_sh_check_test.sh`. Wired into `dune runtest`. Verify: `dune runtest devtools/checks/` — prints `OK: posix-sh linter -- N scripts clean.` Pre-existing violations found: `dev/lib/cleanup-stale-worktrees.sh` and `dev/run.sh` use `#!/usr/bin/env bash` and are exempt (intentionally bash). Source: run-4 daily summary follow-up.
 
 ---
 
@@ -323,3 +324,7 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
 ### Deep scan heuristic gap sub-item 1: Drift coverage extension (backtest)
 
 - [x] `trading/trading/backtest/` subsystem added to `trading/devtools/checks/deep_scan/check_02_design_doc_drift.sh` — checks top-level subdirectories of `trading/trading/backtest/` against `dev/plans/backtest-scale-optimization-2026-04-17.md` using the same heuristic as the existing Weinstein subsystem checks (grep for dir name in plan doc; missing = WARNING). Plan document is the active backtest design spec. Current live finding: `trading/trading/backtest/bin/` is not mentioned in the plan (expected — runner binary added post-plan). Smoke test: `trading/devtools/checks/deep_scan_drift_coverage_check.sh` — verifies BACKTEST_PLAN, BACKTEST_DIR, and the plan filename markers are present in `check_02`, and that the most-recent deep scan report references drift. Wired into `dune runtest` via `trading/devtools/checks/dune`. Verify: `sh trading/devtools/checks/deep_scan_drift_coverage_check.sh` — prints OK; `sh trading/devtools/checks/deep_scan.sh` — report shows `Design doc drift items: 1` and warns about `backtest/bin/`.
+
+### POSIX shell portability linter
+
+- [x] POSIX shell portability linter — `trading/devtools/checks/posix_sh_check.sh`; runs `dash -n` (syntax-only parse) over all #!/bin/sh scripts in `trading/devtools/checks/`, `trading/devtools/checks/deep_scan/`, and `dev/lib/`. Scripts with `#!/usr/bin/env bash` or `#!/bin/bash` shebang are exempt. Approach: `dash` is pre-installed in the devcontainer base image; `shellcheck` is not. Catches parse-time bash-isms: bash arrays `arr=(...)`, here-strings `<<<`, and process substitution `<(...)` — exactly the class that caused rework on PR #483. Smoke test: `trading/devtools/checks/posix_sh_check_test.sh` (3 assertions: bad-fixture FAIL, clean-fixture OK, bash-exempt OK). Both wired into `dune runtest` via `trading/devtools/checks/dune`. Pre-existing violations found at survey time: `dev/lib/cleanup-stale-worktrees.sh` and `dev/run.sh` have `#!/usr/bin/env bash` and are correctly exempt (intentionally bash). Follow-up: add shellcheck to the devcontainer image for richer coverage of runtime bash-isms ([[ ]], mapfile, ${BASH_SOURCE[0]}). Verify: `dune runtest devtools/checks/` — prints `OK: posix-sh linter -- N scripts clean.` and `OK: posix_sh_check_test -- all 3 assertions passed.`; `sh trading/devtools/checks/posix_sh_check.sh` from repo root.

--- a/trading/devtools/checks/dune
+++ b/trading/devtools/checks/dune
@@ -226,3 +226,26 @@
  (deps _check_lib.sh)
  (action
   (run sh %{dep:budget_rollup_check.sh})))
+
+; POSIX shell portability linter: runs `dash -n` over #!/bin/sh scripts in
+; trading/devtools/checks/, trading/devtools/checks/deep_scan/, and dev/lib/.
+; Scripts with #!/usr/bin/env bash shebang are exempt (intentionally bash).
+; Catches parse-time bash-isms: arrays arr=(...), here-strings <<<, process
+; substitution <(...). Introduced to prevent the class of rework that hit
+; PR #483 (bash-isms in scripts expected to run under sh in GHA devcontainer).
+
+(rule
+ (alias runtest)
+ (deps _check_lib.sh)
+ (action
+  (run sh %{dep:posix_sh_check.sh})))
+
+; Smoke test for posix_sh_check.sh: verifies the linter exits non-zero on a
+; known-bad bash-array fixture, exits 0 on a clean POSIX sh script, and exits 0
+; on a !/usr/bin/env bash script (exemption check).
+
+(rule
+ (alias runtest)
+ (deps _check_lib.sh)
+ (action
+  (run sh %{dep:posix_sh_check_test.sh})))

--- a/trading/devtools/checks/posix_sh_check.sh
+++ b/trading/devtools/checks/posix_sh_check.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# POSIX shell portability linter.
+#
+# Runs `dash -n` (syntax-only parse) over shell scripts that are declared as
+# POSIX sh (no explicit bash shebang). Catches the class of bash-isms that
+# caused rework on PR #483: bash arrays, here-strings <<<, and process
+# substitution <(...) -- dash parse-fails on these with exit 2.
+#
+# Note: dash -n catches parse-time failures only. Runtime-only bash-isms
+# (mapfile, [[ ]], ${BASH_SOURCE[0]}) are NOT caught at syntax-check time.
+# shellcheck would catch these too; it is not installed in the
+# trading-devcontainer base image. Add shellcheck to the image for richer
+# coverage (see Follow-up in dev/status/harness.md).
+#
+# Scope:
+#   INCLUDED:
+#     trading/devtools/checks/*.sh            (gate scripts, must be POSIX sh)
+#     trading/devtools/checks/deep_scan/*.sh  (deep scan per-check scripts)
+#     dev/lib/*.sh                            (shared lib scripts)
+#   EXCLUDED:
+#     Scripts with explicit bash shebang (#!/bin/bash or #!/usr/bin/env bash)
+#     -- those scripts intentionally use bash features and are out of scope.
+#
+# Output:
+#   OK: posix-sh linter -- N scripts clean.
+#   FAIL: per-file errors with dash output; exits 1.
+#
+# Env override for testing:
+#   POSIX_SH_CHECK_SCAN_DIRS="<dir1> <dir2>" sh posix_sh_check.sh
+
+set -e
+
+. "$(dirname "$0")/_check_lib.sh"
+
+DASH="${DASH:-dash}"
+
+if ! command -v "$DASH" >/dev/null 2>&1; then
+  echo "FAIL: posix_sh_check: '$DASH' not found on PATH."
+  exit 1
+fi
+
+REPO_ROOT="$(repo_root)"
+TRADING_DIR="${REPO_ROOT}/trading"
+
+# Directories to scan. Override POSIX_SH_CHECK_SCAN_DIRS in tests to point
+# at temp fixtures instead of real source directories.
+if [ -n "${POSIX_SH_CHECK_SCAN_DIRS:-}" ]; then
+  SCAN_DIRS="$POSIX_SH_CHECK_SCAN_DIRS"
+else
+  SCAN_DIRS="${TRADING_DIR}/devtools/checks
+${TRADING_DIR}/devtools/checks/deep_scan
+${REPO_ROOT}/dev/lib"
+fi
+
+CLEAN_COUNT=0
+FAIL_COUNT=0
+VIOLATIONS=""
+
+# Returns 0 (true) if the script's first line declares bash.
+_is_bash_script() {
+  first_line=$(head -1 "$1" 2>/dev/null)
+  case "$first_line" in
+    "#!/bin/bash"*|"#!/usr/bin/env bash"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+for dir in $SCAN_DIRS; do
+  [ -d "$dir" ] || continue
+  for script in "$dir"/*.sh; do
+    [ -f "$script" ] || continue
+    if _is_bash_script "$script"; then
+      continue
+    fi
+    if err=$(dash -n "$script" 2>&1); then
+      CLEAN_COUNT=$((CLEAN_COUNT + 1))
+    else
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      rel="${script#${REPO_ROOT}/}"
+      VIOLATIONS="${VIOLATIONS}FAIL: ${rel}\n${err}\n\n"
+    fi
+  done
+done
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "FAIL: posix-sh linter -- $FAIL_COUNT script(s) have POSIX portability violations:"
+  echo ""
+  printf '%b' "$VIOLATIONS"
+  echo "Fix: remove bash-isms (arrays, <<<, process substitution <(...), etc.)"
+  echo "     or add #!/usr/bin/env bash shebang if bash is intentionally required."
+  exit 1
+fi
+
+echo "OK: posix-sh linter -- ${CLEAN_COUNT} scripts clean."

--- a/trading/devtools/checks/posix_sh_check_test.sh
+++ b/trading/devtools/checks/posix_sh_check_test.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# Smoke test for posix_sh_check.sh.
+#
+# Verifies that the linter catches bash-isms by running it against known-bad
+# fixtures in a temp directory. Proves the linter would have caught the PR #483
+# class of violations.
+#
+# What dash -n catches (parse-time failures):
+#   - bash arrays:           arr=(one two three)  -- Syntax error: "(" unexpected
+#   - here-strings:          cmd <<< "value"       -- Syntax error: redirection unexpected
+#   - process substitution:  cmd <(other-cmd)      -- Syntax error: redirection unexpected
+#
+# What dash -n does NOT catch (runtime failures -- not in scope for this linter):
+#   - mapfile:        runtime bash-builtin, not a parse error
+#   - [[ ... ]]:      dash parses as nested [ [ ... ] ], fails at runtime
+#   - ${BASH_SOURCE}: special variable, not caught at parse time
+#
+# Test structure:
+#   1. bad-fixture:   #!/bin/sh script with bash array -- linter must exit non-zero
+#   2. clean-fixture: #!/bin/sh script, POSIX only    -- linter must exit 0
+#   3. bash-exempt:   #!/usr/bin/env bash script      -- must be exempt (exit 0)
+
+set -e
+
+. "$(dirname "$0")/_check_lib.sh"
+
+LINTER="$(dirname "$0")/posix_sh_check.sh"
+[ -f "$LINTER" ] || die "posix_sh_check_test: linter not found at $LINTER"
+
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+# ---- Fixture 1: bad #!/bin/sh script with bash array ----
+
+BAD_DIR="${TMPDIR_BASE}/bad"
+mkdir -p "$BAD_DIR"
+cat > "${BAD_DIR}/bash_array.sh" << 'EOF'
+#!/bin/sh
+# Bad: bash array syntax is not valid POSIX sh.
+# dash -n exits 2: Syntax error: "(" unexpected
+FILES=(one two three)
+echo "${FILES[0]}"
+EOF
+
+ACTUAL_OUTPUT="$(POSIX_SH_CHECK_SCAN_DIRS="$BAD_DIR" sh "$LINTER" 2>&1)" && ACTUAL_EXIT=0 || ACTUAL_EXIT=$?
+
+if [ "$ACTUAL_EXIT" -eq 0 ]; then
+  echo "FAIL: posix_sh_check_test -- linter exited 0 on bash-array fixture (expected non-zero)"
+  echo "  output: $ACTUAL_OUTPUT"
+  exit 1
+fi
+
+if ! printf '%s' "$ACTUAL_OUTPUT" | grep -q "bash_array.sh"; then
+  echo "FAIL: posix_sh_check_test -- 'bash_array.sh' not in linter output"
+  echo "  output: $ACTUAL_OUTPUT"
+  exit 1
+fi
+
+if ! printf '%s' "$ACTUAL_OUTPUT" | grep -q "FAIL"; then
+  echo "FAIL: posix_sh_check_test -- 'FAIL' not in linter output"
+  echo "  output: $ACTUAL_OUTPUT"
+  exit 1
+fi
+
+# ---- Fixture 2: clean POSIX sh script ----
+
+CLEAN_DIR="${TMPDIR_BASE}/clean"
+mkdir -p "$CLEAN_DIR"
+cat > "${CLEAN_DIR}/posix_clean.sh" << 'EOF'
+#!/bin/sh
+# Clean POSIX sh -- no bash-isms.
+set -e
+x="hello"
+if [ -n "$x" ]; then echo "x is set"; fi
+EOF
+
+CLEAN_OUTPUT="$(POSIX_SH_CHECK_SCAN_DIRS="$CLEAN_DIR" sh "$LINTER" 2>&1)" && CLEAN_EXIT=0 || CLEAN_EXIT=$?
+
+if [ "$CLEAN_EXIT" -ne 0 ]; then
+  echo "FAIL: posix_sh_check_test -- linter failed on clean fixture (expected exit 0)"
+  echo "  output: $CLEAN_OUTPUT"
+  exit 1
+fi
+
+if ! printf '%s' "$CLEAN_OUTPUT" | grep -q "OK"; then
+  echo "FAIL: posix_sh_check_test -- 'OK' not in clean-fixture output"
+  echo "  output: $CLEAN_OUTPUT"
+  exit 1
+fi
+
+if ! printf '%s' "$CLEAN_OUTPUT" | grep -q "1 scripts clean"; then
+  echo "FAIL: posix_sh_check_test -- expected '1 scripts clean' in output"
+  echo "  output: $CLEAN_OUTPUT"
+  exit 1
+fi
+
+# ---- Fixture 3: #!/usr/bin/env bash script (must be exempt) ----
+
+BASH_DIR="${TMPDIR_BASE}/bash_exempt"
+mkdir -p "$BASH_DIR"
+cat > "${BASH_DIR}/explicit_bash.sh" << 'EOF'
+#!/usr/bin/env bash
+# Explicit bash -- exempt from POSIX linting.
+set -euo pipefail
+FILES=(one two three)
+echo "${FILES[@]}"
+EOF
+
+EXEMPT_OUTPUT="$(POSIX_SH_CHECK_SCAN_DIRS="$BASH_DIR" sh "$LINTER" 2>&1)" && EXEMPT_EXIT=0 || EXEMPT_EXIT=$?
+
+if [ "$EXEMPT_EXIT" -ne 0 ]; then
+  echo "FAIL: posix_sh_check_test -- linter failed on bash-exempt fixture (expected exit 0)"
+  echo "  output: $EXEMPT_OUTPUT"
+  exit 1
+fi
+
+if ! printf '%s' "$EXEMPT_OUTPUT" | grep -q "OK"; then
+  echo "FAIL: posix_sh_check_test -- 'OK' not in bash-exempt output"
+  echo "  output: $EXEMPT_OUTPUT"
+  exit 1
+fi
+
+echo "OK: posix_sh_check_test -- all 3 assertions passed (bad-fixture FAIL, clean-fixture OK, bash-exempt OK)."


### PR DESCRIPTION
## Summary

- Adds `dash -n` syntax linter over all `#!/bin/sh` scripts in `trading/devtools/checks/`, `trading/devtools/checks/deep_scan/`, and `dev/lib/`
- Scripts with `#!/usr/bin/env bash` shebang are exempt (intentionally bash)
- Catches parse-time bash-isms: bash arrays, here-strings `<<<`, process substitution `<(...)` — the exact class that caused PR #483 rework
- Smoke test verifies the linter exits non-zero on a bad fixture, 0 on a clean fixture, and 0 on a bash-exempt script
- Wired into `dune runtest` as always-on gate

## Files changed

- `trading/devtools/checks/posix_sh_check.sh` — linter (with `POSIX_SH_CHECK_SCAN_DIRS` env override for test isolation)
- `trading/devtools/checks/posix_sh_check_test.sh` — 3-assertion smoke test
- `trading/devtools/checks/dune` — wire both into `dune runtest`
- `dev/status/harness.md` — mark completed

## Pre-existing violations

`dev/lib/cleanup-stale-worktrees.sh` and `dev/run.sh` have `#!/usr/bin/env bash` shebangs and are correctly exempt (intentionally bash).

## Follow-up

Add `shellcheck` to the devcontainer image for richer coverage of runtime bash-isms (`[[ ]]`, `mapfile`, `${BASH_SOURCE[0]}`). `dash -n` only catches parse-time failures.

## Verify

```
dune runtest devtools/checks/
# → OK: posix-sh linter -- N scripts clean.
# → OK: posix_sh_check_test -- all 3 assertions passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)