### PR TITLE
ci(orchestrator): fix cost-capture step failing on new-day first run

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -179,7 +179,9 @@ jobs:
           mkdir -p "$BUDGET_DIR"
 
           # Determine run number: count existing budget files for today.
-          EXISTING=$(ls "${BUDGET_DIR}/${DATE}"*.json 2>/dev/null | wc -l | tr -d ' ')
+          # `find` exits 0 on zero matches (unlike `ls` under `set -o pipefail`),
+          # so this works on today's first run when dev/budget/<date>*.json is empty.
+          EXISTING=$(find "$BUDGET_DIR" -maxdepth 1 -name "${DATE}*.json" 2>/dev/null | wc -l | tr -d ' ')
           RUN_N=$((EXISTING + 1))
           OUT_FILE="${BUDGET_DIR}/${DATE}-run${RUN_N}.json"
           RUN_ID="${DATE}-run${RUN_N}"
@@ -206,6 +208,11 @@ jobs:
           fi
 
           TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          # Belt-and-suspenders: TOTAL_COST is initialized to "null" above and
+          # reassigned by the python3 -c block, but if any future edit leaves it
+          # as an empty string the heredoc below would emit `"total_cost_usd": ,`
+          # and crash Python at parse time. Coerce to "null" if empty.
+          TOTAL_COST="${TOTAL_COST:-null}"
 
           python3 - <<PYEOF
           import json, os


### PR DESCRIPTION
## Summary

Fixes the cost-capture step that failed on the first orchestrator run of 2026-04-22 (run [24752864169](https://github.com/dayfine/trading/actions/runs/24752864169/job/72419591308)) with exit code 2.

## Root cause

The step's run-number computation uses:
```bash
set -euo pipefail
...
EXISTING=$(ls "${BUDGET_DIR}/${DATE}"*.json 2>/dev/null | wc -l | tr -d ' ')
```

On a day's first run, `dev/budget/<date>*.json` matches zero files. `ls` exits non-zero, which `pipefail` propagates through the pipeline even though `wc -l` would otherwise mask it. Combined with `set -e`, the script aborts before reaching the Python heredoc that writes the budget record.

Why it worked before: PR #483 seeded `dev/budget/2026-04-20-run1.json` by hand, so every real run since then matched the glob. Today is the first "true first-run of the day" case in the wild.

## Fix

Swap `ls` for `find`, which exits 0 on empty matches:

```bash
EXISTING=$(find "$BUDGET_DIR" -maxdepth 1 -name "${DATE}*.json" 2>/dev/null | wc -l | tr -d ' ')
```

Plus a belt-and-suspenders coerce of `TOTAL_COST` before the Python heredoc, so a future edit that accidentally leaves `TOTAL_COST` empty can't produce `"total_cost_usd": ,` (Python syntax error).

## Verify

Simulated both cases locally under `set -euo pipefail`:

```
$ EXISTING=$(find /tmp/empty -maxdepth 1 -name "2026-04-22*.json" 2>/dev/null | wc -l | tr -d ' ')
$ echo $EXISTING
0
# (zero matches, exit 0 — was the bug)

$ touch /tmp/seeded/2026-04-22-run1.json /tmp/seeded/2026-04-22-run2.json
$ EXISTING=$(find /tmp/seeded -maxdepth 1 -name "2026-04-22*.json" 2>/dev/null | wc -l | tr -d ' ')
$ echo $EXISTING
2
# (two matches, correct count)
```

No `dune build` impact (workflow-only change). Harness `posix_sh_check` doesn't gate `.github/workflows/` scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
