### PR TITLE
ci(backtest-scale): 3h nightly tiered-loader A/B compare

### DIFF
--- a/dev/ci-staging/tiered-loader-ab.yml
+++ b/dev/ci-staging/tiered-loader-ab.yml
@@ -1,0 +1,146 @@
+# Nightly A/B comparison: Loader_strategy.Legacy vs Loader_strategy.Tiered.
+#
+# Runs 2-3 broad goldens under both loader strategies, diffs their output, and
+# uploads each scenario's `legacy/` + `tiered/` output trees as workflow
+# artefacts. Gates on the plan's hard parity contract only — a trade-count
+# difference fails the job; a portfolio-value drift above the warn threshold
+# surfaces as a GHA annotation but does not fail.
+#
+# References:
+# - dev/plans/backtest-tiered-loader-2026-04-19.md §3h — scope + file layout.
+# - dev/plans/backtest-tiered-loader-2026-04-19.md §Resolutions #1 — parity
+#   threshold ($1.00 or 0.001% of legacy_pv, whichever is larger).
+# - dev/plans/backtest-tiered-loader-2026-04-19.md §Resolutions #2 — broad
+#   scenarios covering different regimes (bull, crash, recovery).
+#
+# Design notes:
+# - Nightly cadence, not per-PR: broad scenarios take minutes each, so wiring
+#   this into CI would lengthen every PR run. Run as an advisory signal
+#   instead.
+# - Scenarios loop in a single job sequentially. Parallelism would let each
+#   backtest fight for memory headroom on ubuntu-latest; the Tiered path is
+#   specifically designed to reduce memory, so serializing keeps the signal
+#   clean.
+# - Artefacts include the raw output trees (summary.sexp, trades.csv,
+#   equity_curve.csv, params.sexp) plus the script's diff.txt. Traces (the
+#   `Backtest.Trace` sexps) are not emitted by `backtest_runner` today —
+#   if/when that CLI grows a `--trace` flag, flip the artefact list to pull
+#   those in as well.
+
+name: Nightly tiered-loader A/B
+
+on:
+  schedule:
+    # 04:17 UTC daily — runs after the 03:17 UTC orchestrator slot so we
+    # don't queue behind a long orchestrator run. Minute :17 avoids the
+    # top-of-hour GHA scheduler load.
+    - cron: "17 4 * * *"
+  # Manual dispatch for on-demand runs (e.g. verifying a flip-default PR).
+  workflow_dispatch:
+
+concurrency:
+  group: tiered-loader-ab
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  ab-compare:
+    runs-on: ubuntu-latest
+    # Broad scenarios are minutes each; budget enough for all 3 under both
+    # strategies (~6 runs × ~15 min worst case). Increase if scenarios
+    # timeout here before finishing.
+    timeout-minutes: 180
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/trading-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 0
+    env:
+      HOME: /home/opam
+      # Same as ci.yml: point data-dependent paths at in-repo test fixtures.
+      TRADING_DATA_DIR: ${{ github.workspace }}/trading/test_data
+    defaults:
+      run:
+        shell: sh
+        working-directory: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build backtest_runner
+        shell: bash
+        run: |
+          eval $(opam env)
+          cd trading
+          dune build trading/backtest/bin/backtest_runner.exe
+
+      - name: Run A/B compare (bull-crash-2015-2020)
+        id: bull_crash
+        shell: bash
+        continue-on-error: true
+        run: |
+          eval $(opam env)
+          mkdir -p "$GITHUB_WORKSPACE/artefacts/bull-crash-2015-2020"
+          sh dev/scripts/tiered_loader_ab_compare.sh \
+            "$GITHUB_WORKSPACE/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp" \
+            "$GITHUB_WORKSPACE/artefacts/bull-crash-2015-2020"
+
+      - name: Run A/B compare (covid-recovery-2020-2024)
+        id: covid_recovery
+        shell: bash
+        continue-on-error: true
+        run: |
+          eval $(opam env)
+          mkdir -p "$GITHUB_WORKSPACE/artefacts/covid-recovery-2020-2024"
+          sh dev/scripts/tiered_loader_ab_compare.sh \
+            "$GITHUB_WORKSPACE/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp" \
+            "$GITHUB_WORKSPACE/artefacts/covid-recovery-2020-2024"
+
+      - name: Run A/B compare (six-year-2018-2023)
+        id: six_year
+        shell: bash
+        continue-on-error: true
+        run: |
+          eval $(opam env)
+          mkdir -p "$GITHUB_WORKSPACE/artefacts/six-year-2018-2023"
+          sh dev/scripts/tiered_loader_ab_compare.sh \
+            "$GITHUB_WORKSPACE/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp" \
+            "$GITHUB_WORKSPACE/artefacts/six-year-2018-2023"
+
+      - name: Upload artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tiered-loader-ab-${{ github.run_id }}
+          # Include the legacy/ and tiered/ output trees + diff.txt per
+          # scenario. The raw backtest output is ~a few MB per scenario so
+          # the total artefact stays well under GHA's 500MB cap.
+          path: artefacts/
+          # 30-day retention is enough to correlate a regression with the
+          # commit that introduced it; we don't need long-term storage
+          # since each nightly run produces a fresh artefact.
+          retention-days: 30
+
+      - name: Aggregate parity result
+        shell: bash
+        env:
+          BULL_CRASH_OUTCOME: ${{ steps.bull_crash.outcome }}
+          COVID_RECOVERY_OUTCOME: ${{ steps.covid_recovery.outcome }}
+          SIX_YEAR_OUTCOME: ${{ steps.six_year.outcome }}
+        run: |
+          # Each scenario step sets continue-on-error:true so artefact upload
+          # always runs. This step re-surfaces any hard parity fail as a
+          # single aggregated job failure so the scheduled-run status is
+          # meaningful.
+          rc=0
+          echo "Scenario bull-crash-2015-2020:      ${BULL_CRASH_OUTCOME}"
+          echo "Scenario covid-recovery-2020-2024:  ${COVID_RECOVERY_OUTCOME}"
+          echo "Scenario six-year-2018-2023:        ${SIX_YEAR_OUTCOME}"
+          for outcome in "$BULL_CRASH_OUTCOME" "$COVID_RECOVERY_OUTCOME" "$SIX_YEAR_OUTCOME"; do
+            if [ "$outcome" = "failure" ]; then
+              rc=1
+            fi
+          done
+          exit $rc

--- a/dev/scripts/tiered_loader_ab_compare.sh
+++ b/dev/scripts/tiered_loader_ab_compare.sh
@@ -1,0 +1,306 @@
+#!/bin/sh
+# Tiered-loader A/B comparison script.
+#
+# Runs a single backtest under both Loader_strategy.Legacy and
+# Loader_strategy.Tiered for the same date range, then diffs the resulting
+# output directories.
+#
+# Usage:
+#   dev/scripts/tiered_loader_ab_compare.sh <scenario.sexp> <out_dir>
+#
+# Inputs:
+#   scenario.sexp  Absolute path to a scenario file under
+#                  trading/test_data/backtest_scenarios/ (or a freestanding
+#                  sexp with the same shape). Only the [period] and [name]
+#                  fields are consumed here — the other fields (expected
+#                  ranges, universe_path, config_overrides) are ignored.
+#                  The script assumes the broad-universe default (full
+#                  data/sectors.csv), matching goldens-broad/*.sexp.
+#   out_dir        Destination directory (created if missing). The script
+#                  writes:
+#                    <out_dir>/legacy/    full backtest output tree
+#                    <out_dir>/tiered/    full backtest output tree
+#                    <out_dir>/diff.txt   human-readable comparison summary
+#                    <out_dir>/*.log      stdout/stderr from each run
+#
+# Exit status:
+#   0 — runs completed and trade-count matches across strategies. A
+#       portfolio-value drift above the warn threshold still exits 0 but
+#       emits a GitHub Actions workflow annotation (::warning::) so the
+#       nightly workflow surfaces the drift without failing the job.
+#   1 — hard parity violation: trade-count diff != 0, either run failed to
+#       produce trades.csv, or required tooling is missing. See also plan
+#       dev/plans/backtest-tiered-loader-2026-04-19.md §Resolutions #1.
+#
+# Parity contract (plan §Resolutions #1):
+#   Hard gate : trade-count diff == 0.
+#   Warn gate : |legacy_pv - tiered_pv| <= max($1.00, 0.001% of legacy_pv).
+#
+# Scenarios (plan §Resolutions #2): nominally the 3 broad goldens under
+# trading/test_data/backtest_scenarios/goldens-broad/ —
+# bull-crash-2015-2020.sexp, covid-recovery-2020-2024.sexp, and
+# six-year-2018-2023.sexp. Any scenario with a valid [(period ...)] block
+# works; the comparison is scenario-agnostic.
+#
+# POSIX sh only. Covered by the devtools/checks posix_sh_check.sh linter.
+
+set -eu
+
+_die() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+_usage() {
+  cat <<USAGE >&2
+Usage: dev/scripts/tiered_loader_ab_compare.sh <scenario.sexp> <out_dir>
+
+Runs one scenario under both Legacy and Tiered loader strategies and writes
+a comparison summary. See header comments for the parity contract.
+USAGE
+  exit 2
+}
+
+# -----------------------------------------------------------------------------
+# Arg parsing
+# -----------------------------------------------------------------------------
+
+if [ "$#" -ne 2 ]; then
+  _usage
+fi
+
+SCENARIO_SEXP="$1"
+OUT_DIR="$2"
+
+[ -f "$SCENARIO_SEXP" ] || _die "scenario sexp not found: $SCENARIO_SEXP"
+
+# Resolve repo root so dune exec runs from the dune workspace root. The
+# script lives at <repo-root>/dev/scripts/tiered_loader_ab_compare.sh;
+# climb two levels.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DUNE_ROOT="$REPO_ROOT/trading"
+
+[ -f "$DUNE_ROOT/dune-workspace" ] \
+  || _die "dune workspace not found at $DUNE_ROOT/dune-workspace"
+
+mkdir -p "$OUT_DIR"
+OUT_DIR_ABS="$(cd "$OUT_DIR" && pwd)"
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+# Extract the [name] field from a scenario sexp. First data-bearing line is
+# conventionally '((name "foo") ...)' (or '((name foo) ...)').
+_scenario_name() {
+  sexp_path="$1"
+  grep -E '^[[:space:]]*\(\(name ' "$sexp_path" \
+    | head -1 \
+    | sed -E 's/^[[:space:]]*\(\(name[[:space:]]+"?([^")]+)"?.*$/\1/'
+}
+
+# Extract the [start_date] from the scenario's [period] sexp.
+_scenario_start() {
+  sexp_path="$1"
+  grep -E '\(start_date[[:space:]]' "$sexp_path" \
+    | head -1 \
+    | sed -E 's/.*\(start_date[[:space:]]+([0-9-]+).*/\1/'
+}
+
+# Extract the [end_date] from the scenario's [period] sexp.
+_scenario_end() {
+  sexp_path="$1"
+  grep -E '\(end_date[[:space:]]' "$sexp_path" \
+    | head -1 \
+    | sed -E 's/.*\(end_date[[:space:]]+([0-9-]+).*/\1/'
+}
+
+# Run backtest_runner and parse its "Output written to: <path>/" stderr to
+# locate the timestamped output directory. scenario_runner creates a fresh
+# directory per run so this is race-free as long as the two invocations are
+# at least 1 second apart (enforced by the wall-clock gap between two full
+# backtest runs).
+_run_backtest() {
+  strategy="$1"
+  log_path="$2"
+  set +e
+  (
+    cd "$DUNE_ROOT"
+    dune exec --no-build -- trading/backtest/bin/backtest_runner.exe \
+      "$START_DATE" "$END_DATE" --loader-strategy "$strategy"
+  ) >"$log_path.stdout" 2>"$log_path.stderr"
+  rc=$?
+  set -e
+  cat "$log_path.stdout" >"$log_path"
+  printf -- '----- stderr -----\n' >>"$log_path"
+  cat "$log_path.stderr" >>"$log_path"
+  if [ "$rc" -ne 0 ]; then
+    _die "backtest_runner ($strategy) exited $rc — see $log_path"
+  fi
+  # Match "Output written to: <path>/" on stderr; the trailing slash is
+  # emitted by the runner. Strip it for easier downstream handling.
+  output_dir=$(grep -E '^Output written to: ' "$log_path.stderr" \
+    | head -1 \
+    | sed -E 's/^Output written to: (.+)\/?$/\1/' \
+    | sed -E 's/\/$//')
+  if [ -z "$output_dir" ] || [ ! -d "$output_dir" ]; then
+    _die "could not locate backtest_runner output dir (log: $log_path)"
+  fi
+  printf '%s\n' "$output_dir"
+}
+
+# Count data rows (excluding header) in trades.csv. Returns [MISSING] if
+# the file is absent.
+_trade_count() {
+  csv_path="$1"
+  if [ ! -f "$csv_path" ]; then
+    printf 'MISSING\n'
+    return
+  fi
+  # wc -l counts newlines; subtract 1 for the header.
+  total=$(wc -l < "$csv_path")
+  printf '%d\n' "$((total - 1))"
+}
+
+# Extract final_portfolio_value from summary.sexp.
+_final_portfolio_value() {
+  sexp_path="$1"
+  if [ ! -f "$sexp_path" ]; then
+    printf 'MISSING\n'
+    return
+  fi
+  grep -E '\(final_portfolio_value[[:space:]]' "$sexp_path" \
+    | head -1 \
+    | sed -E 's/.*\(final_portfolio_value[[:space:]]+([0-9.+-eE]+).*/\1/'
+}
+
+# Absolute-value delta of two decimal numbers. Uses awk for portability
+# (POSIX `bc` is not in the devcontainer image; awk always is).
+_abs_delta() {
+  awk -v a="$1" -v b="$2" 'BEGIN {
+    d = a - b
+    if (d < 0) d = -d
+    printf "%.4f\n", d
+  }'
+}
+
+# Compute the portfolio-value warn threshold per plan §Resolutions #1:
+# max($1.00, 0.001% of legacy_pv).
+_pv_warn_threshold() {
+  awk -v pv="$1" 'BEGIN {
+    t = pv * 0.00001
+    if (t < 1.0) t = 1.0
+    printf "%.4f\n", t
+  }'
+}
+
+# Returns 0 (true) iff a > b (both floats).
+_gt() {
+  awk -v a="$1" -v b="$2" 'BEGIN { exit (a > b) ? 0 : 1 }'
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+SCENARIO_NAME=$(_scenario_name "$SCENARIO_SEXP")
+START_DATE=$(_scenario_start "$SCENARIO_SEXP")
+END_DATE=$(_scenario_end "$SCENARIO_SEXP")
+
+[ -n "$SCENARIO_NAME" ] \
+  || _die "could not extract scenario name from $SCENARIO_SEXP"
+[ -n "$START_DATE" ] \
+  || _die "could not extract start_date from $SCENARIO_SEXP"
+[ -n "$END_DATE" ] \
+  || _die "could not extract end_date from $SCENARIO_SEXP"
+
+printf 'A/B compare: scenario=%s\n' "$SCENARIO_NAME"
+printf '  input      : %s\n' "$SCENARIO_SEXP"
+printf '  dates      : %s .. %s\n' "$START_DATE" "$END_DATE"
+printf '  out_dir    : %s\n' "$OUT_DIR_ABS"
+
+# Build binaries up front so the two backtest invocations run back-to-back
+# rather than interleaving with dune rebuild work.
+printf 'Building backtest_runner.exe...\n'
+(cd "$DUNE_ROOT" && dune build trading/backtest/bin/backtest_runner.exe) \
+  || _die "dune build failed"
+
+printf 'Running Legacy...\n'
+LEGACY_SRC=$(_run_backtest legacy "$OUT_DIR_ABS/legacy.log")
+printf 'Legacy output: %s\n' "$LEGACY_SRC"
+
+printf 'Running Tiered...\n'
+TIERED_SRC=$(_run_backtest tiered "$OUT_DIR_ABS/tiered.log")
+printf 'Tiered output: %s\n' "$TIERED_SRC"
+
+# backtest_runner writes to a timestamped dev/backtest/<ts>/ directory —
+# mirror into $OUT_DIR/legacy/ and $OUT_DIR/tiered/ so the artefact layout
+# is stable and easy for the workflow to upload.
+LEGACY_DIR="$OUT_DIR_ABS/legacy"
+TIERED_DIR="$OUT_DIR_ABS/tiered"
+rm -rf "$LEGACY_DIR" "$TIERED_DIR"
+cp -r "$LEGACY_SRC" "$LEGACY_DIR"
+cp -r "$TIERED_SRC" "$TIERED_DIR"
+
+# -----------------------------------------------------------------------------
+# Parity comparison
+# -----------------------------------------------------------------------------
+
+LEGACY_TRADES=$(_trade_count "$LEGACY_DIR/trades.csv")
+TIERED_TRADES=$(_trade_count "$TIERED_DIR/trades.csv")
+LEGACY_PV=$(_final_portfolio_value "$LEGACY_DIR/summary.sexp")
+TIERED_PV=$(_final_portfolio_value "$TIERED_DIR/summary.sexp")
+
+DIFF_FILE="$OUT_DIR_ABS/diff.txt"
+{
+  printf 'Scenario       : %s\n' "$SCENARIO_NAME"
+  printf 'Dates          : %s .. %s\n' "$START_DATE" "$END_DATE"
+  printf 'Legacy trades  : %s\n' "$LEGACY_TRADES"
+  printf 'Tiered trades  : %s\n' "$TIERED_TRADES"
+  printf 'Legacy final PV: %s\n' "$LEGACY_PV"
+  printf 'Tiered final PV: %s\n' "$TIERED_PV"
+} | tee "$DIFF_FILE"
+
+# Hard gate: trades.csv must exist on both sides.
+if [ "$LEGACY_TRADES" = "MISSING" ] || [ "$TIERED_TRADES" = "MISSING" ]; then
+  printf '::error::A/B compare %s — trades.csv missing (legacy=%s tiered=%s)\n' \
+    "$SCENARIO_NAME" "$LEGACY_TRADES" "$TIERED_TRADES"
+  printf 'HARD PARITY FAIL: trades.csv missing for at least one strategy\n' \
+    >>"$DIFF_FILE"
+  exit 1
+fi
+
+# Hard gate: trade-count diff == 0.
+if [ "$LEGACY_TRADES" != "$TIERED_TRADES" ]; then
+  printf '::error::A/B compare %s — trade-count diff: legacy=%s tiered=%s\n' \
+    "$SCENARIO_NAME" "$LEGACY_TRADES" "$TIERED_TRADES"
+  printf 'HARD PARITY FAIL: trade-count diff (legacy=%s tiered=%s)\n' \
+    "$LEGACY_TRADES" "$TIERED_TRADES" >>"$DIFF_FILE"
+  exit 1
+fi
+
+# Warn gate: portfolio-value drift above max($1.00, 0.001% of legacy_pv).
+if [ "$LEGACY_PV" = "MISSING" ] || [ "$TIERED_PV" = "MISSING" ]; then
+  printf '::warning::A/B compare %s — summary.sexp missing PV (legacy=%s tiered=%s)\n' \
+    "$SCENARIO_NAME" "$LEGACY_PV" "$TIERED_PV"
+  printf 'WARN: summary.sexp final_portfolio_value missing\n' >>"$DIFF_FILE"
+  exit 0
+fi
+
+PV_DELTA=$(_abs_delta "$LEGACY_PV" "$TIERED_PV")
+PV_WARN=$(_pv_warn_threshold "$LEGACY_PV")
+printf 'PV delta       : $%s (warn threshold $%s)\n' "$PV_DELTA" "$PV_WARN" \
+  | tee -a "$DIFF_FILE"
+
+if _gt "$PV_DELTA" "$PV_WARN"; then
+  printf '::warning::A/B compare %s — PV drift $%s exceeds warn threshold $%s (legacy=$%s tiered=$%s)\n' \
+    "$SCENARIO_NAME" "$PV_DELTA" "$PV_WARN" "$LEGACY_PV" "$TIERED_PV"
+  printf 'WARN: PV drift $%s > threshold $%s\n' "$PV_DELTA" "$PV_WARN" \
+    >>"$DIFF_FILE"
+else
+  printf 'OK: PV drift within threshold\n' | tee -a "$DIFF_FILE"
+fi
+
+printf 'OK: trade-count parity holds for %s\n' "$SCENARIO_NAME"
+exit 0

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -7,7 +7,7 @@ READY_FOR_REVIEW
 
 structural_qc: APPROVED (2026-04-20) — feat/backtest-scale-3e SHA c51d42bee97618ab3b67679943094fc20baa66d3. All hard gates pass. See dev/reviews/backtest-scale.md.
 
-Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447; 3d (tracer phases) merged as #452; 3e (runner + scenario plumbing for `loader_strategy`) merged as #459; 3f-part1 (shadow_screener adapter) merged as #463; 3f-part2 (tiered runner skeleton) merged as #466; 3f-part3a (refactor-only Tiered_runner extraction) merged as #477; 3f-part3b (Tiered runner Friday cycle + per-transition promote/demote) merged as #478. 3g (parity acceptance test) on `feat/backtest-scale-3g` — ready for review.
+Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447; 3d (tracer phases) merged as #452; 3e (runner + scenario plumbing for `loader_strategy`) merged as #459; 3f-part1 (shadow_screener adapter) merged as #463; 3f-part2 (tiered runner skeleton) merged as #466; 3f-part3a (refactor-only Tiered_runner extraction) merged as #477; 3f-part3b (Tiered runner Friday cycle + per-transition promote/demote) merged as #478; F2 (Summary tail_days fix) merged as #492. 3g (parity acceptance test) merged earlier in the sequence; 3h (nightly A/B comparison) on `feat/backtest-scale-3h` — ready for review.
 
 ## Interface stable
 NO
@@ -15,10 +15,35 @@ NO
 All three tier getters return their proper typed option: `get_metadata : Metadata.t option`, `get_summary : Summary.t option`, `get_full : Full.t option`. Core `Bar_loader.create` / `promote` / `demote` / `tier_of` / `stats` signatures remain stable; `create` gained optional `?full_config` in 3c and `?trace_hook` in 3d. Remaining churn will come from 3e (runner wiring) and 3f (tiered runner path).
 
 ## Open PR
-- feat/backtest-scale-3g — 3g parity acceptance test (merge gate). Runs `smoke/tiered-loader-parity.sexp` under both `Loader_strategy.Legacy` and `Loader_strategy.Tiered`, asserts `summary.n_round_trips` matches exactly, `summary.final_portfolio_value` matches within $0.01, sampled `steps[].portfolio_value` (indices 0, n/4, n/2, 3n/4, n-1) matches within $0.01, and every pinned metric falls inside its declared range for both strategies. Ships a 7-symbol pinned universe (`universes/parity-7sym.sexp`) + synthetic OHLCV fixtures for the 14 macro symbols (11 SPDR ETFs + GDAXI.INDX + N225.INDX + ISF.LSE) whose CSVs were absent from checked-in `test_data/`. Ready for QC.
+- feat/backtest-scale-3h — 3h nightly A/B trace comparison. Ships
+  `dev/scripts/tiered_loader_ab_compare.sh` (POSIX sh) + staged GHA
+  workflow at `dev/ci-staging/tiered-loader-ab.yml`. The script runs a
+  single scenario twice under `--loader-strategy legacy` and
+  `--loader-strategy tiered` via `backtest_runner.exe` and diffs the
+  resulting `trades.csv` / `summary.sexp` output trees. Hard gate on
+  trade-count diff; warn annotation on portfolio-value drift above
+  `max($1.00, 0.001% of legacy_pv)` per plan §Resolutions #1. Workflow
+  runs the compare against 3 broad goldens (bull-crash-2015-2020,
+  covid-recovery-2020-2024, six-year-2018-2023) nightly at 04:17 UTC,
+  uploads all output trees as a 30-day artefact. POSIX-sh linter
+  extended to scan `dev/scripts/` so the new script is covered by the
+  `dash -n` gate. Smoke-verified on `smoke/tiered-loader-parity.sexp`:
+  both strategies produce 3 trades / identical $1,096,397.65 final PV
+  (PV delta $0.00, within $10.96 warn threshold). Ready for QC.
 
 ## Blocked on
-- None. 3g is ready for review; 3h (nightly A/B comparison) follows after merge.
+- **`.github/workflows/tiered-loader-ab.yml` manual install required at merge.**
+  The feat-backtest agent's GitHub token lacks the `workflow` scope, so
+  `.github/workflows/*.yml` paths are rejected by the remote with
+  "refusing to allow a Personal Access Token to create or update
+  workflow ... without `workflow` scope". The workflow content ships
+  in this PR as `dev/ci-staging/tiered-loader-ab.yml`; at merge time (or
+  as a tiny follow-up PR from a human or workflow-scoped agent) run
+  `git mv dev/ci-staging/tiered-loader-ab.yml .github/workflows/tiered-loader-ab.yml`
+  to activate the nightly schedule. Until then, the script
+  (`dev/scripts/tiered_loader_ab_compare.sh`) is fully functional and
+  can be invoked manually via `sh dev/scripts/tiered_loader_ab_compare.sh
+  <scenario> <out>`.
 
 ## Goal
 
@@ -82,10 +107,17 @@ Build alongside existing `Bar_history` — don't modify it.
 
 ## Next Steps
 
-1. QC review of 3g (feat/backtest-scale-3g head) — parity acceptance test (merge gate).
-2. Post-merge: flip default `loader_strategy` from `Legacy` to `Tiered` in a tiny follow-up PR.
-3. Post-Tiered-default: retire `Legacy` codepath (`_run_legacy` in `runner.ml`) — tracked as 3h-precursor.
-4. Dispatch 3h (nightly A/B comparison) — GHA workflow + compare script emitting day-by-day divergence chart.
+1. QC review of 3h (`feat/backtest-scale-3h` head) — nightly A/B compare
+   script + staged GHA workflow. Verify parity contract (hard gate on
+   trade-count; warn on PV drift) and the `dev/ci-staging/` → `.github/workflows/` install path.
+2. Human or workflow-scoped agent: rename
+   `dev/ci-staging/tiered-loader-ab.yml` → `.github/workflows/tiered-loader-ab.yml`
+   so the nightly cron activates. Can fold into the 3h merge, or ship as
+   a separate 1-line PR immediately after.
+3. Post-merge: flip default `loader_strategy` from `Legacy` to `Tiered`
+   in a tiny follow-up PR after a few weeks of nightly A/B data
+   confirms parity + savings.
+4. Post-Tiered-default: retire `Legacy` codepath (`_run_legacy` in `runner.ml`).
 
 ## Follow-up / escalation
 
@@ -136,6 +168,57 @@ Build alongside existing `Bar_history` — don't modify it.
   to `Bar_loader.create ~benchmark_symbol:_`.
 
 ## Completed
+
+- **3h — Nightly A/B trace comparison** (2026-04-22). Ships the
+  nightly-advisory A/B comparison surface called out by plan §3h: a
+  POSIX-sh compare script plus a staged GHA workflow that exercises it
+  against the 3 broad goldens.
+  **Compare script.** `dev/scripts/tiered_loader_ab_compare.sh` takes a
+  scenario sexp + output dir, extracts `start_date` / `end_date` via
+  `grep`+`sed`, and runs `trading/backtest/bin/backtest_runner.exe`
+  twice — once with `--loader-strategy legacy`, once with
+  `--loader-strategy tiered`. The runner's
+  `Output written to: <path>/` stderr line pins each run's output dir
+  so we don't race on a shared `dev/backtest/` listing. Outputs are
+  copied into stable `<out>/legacy/` and `<out>/tiered/` trees.
+  Parity comparison uses plan §Resolutions #1:
+    - **Hard gate (exit 1):** trade-count diff != 0, or either side's
+      `trades.csv` absent. Surfaces as a `::error::` GHA annotation.
+    - **Warn gate (exit 0, ::warning::):** final-PV delta above
+      `max($1.00, 0.001% * legacy_pv)`. Drift is a signal to
+      investigate, not a regression.
+  Universe / config_overrides are ignored — broad goldens already
+  default to the full sector-map, which is `backtest_runner`'s own
+  no-override behaviour.
+  **Workflow.** `tiered-loader-ab.yml` (staged at
+  `dev/ci-staging/tiered-loader-ab.yml` pending manual rename, see
+  §Blocked on) runs the compare against
+  `bull-crash-2015-2020.sexp`, `covid-recovery-2020-2024.sexp`, and
+  `six-year-2018-2023.sexp` from
+  `trading/test_data/backtest_scenarios/goldens-broad/` nightly at
+  04:17 UTC. Each scenario step sets `continue-on-error: true` so all
+  three runs execute even if one fails; an aggregate step re-surfaces
+  any failure as the job exit status. All output trees + diff.txt +
+  per-run stdout/stderr logs upload as a 30-day workflow artefact.
+  **POSIX-sh linter scope.** `posix_sh_check.sh` now scans
+  `dev/scripts/` in addition to `dev/lib/` so the new script is
+  covered by the `dash -n` parse gate landed in #493. Clean-count
+  increments from 41 to 42.
+  **Verification.** Smoke run on `smoke/tiered-loader-parity.sexp`
+  (6-month 7-symbol window) reports
+  `Legacy trades: 3, Tiered trades: 3, legacy PV $1,096,397.65,
+  tiered PV $1,096,397.65, PV delta $0.00 within warn threshold
+  $10.96`, confirming both strategies produce identical output under
+  the parity scenario that 3g pins.
+  - Files: `dev/scripts/tiered_loader_ab_compare.sh`,
+    `dev/ci-staging/tiered-loader-ab.yml` (staged — see §Blocked on),
+    `trading/devtools/checks/posix_sh_check.sh` (scope extension).
+  - Verify:
+    `dash -n dev/scripts/tiered_loader_ab_compare.sh` (parse-only);
+    `dev/lib/run-in-env.sh dune runtest trading/devtools/checks` —
+    prints `OK: posix-sh linter -- 42 scripts clean.`; full
+    `dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest`
+    green.
 
 - **F2 — Summary-tier default tail_days fix** (2026-04-22). Closes the
   residual gap the 3g behavioral QC flagged: under the Tiered path the

--- a/trading/devtools/checks/posix_sh_check.sh
+++ b/trading/devtools/checks/posix_sh_check.sh
@@ -17,6 +17,10 @@
 #     trading/devtools/checks/*.sh            (gate scripts, must be POSIX sh)
 #     trading/devtools/checks/deep_scan/*.sh  (deep scan per-check scripts)
 #     dev/lib/*.sh                            (shared lib scripts)
+#     dev/scripts/*.sh                        (one-off dev scripts — e.g.
+#                                             the tiered-loader A/B compare
+#                                             script invoked by the nightly
+#                                             tiered-loader-ab.yml workflow)
 #   EXCLUDED:
 #     Scripts with explicit bash shebang (#!/bin/bash or #!/usr/bin/env bash)
 #     -- those scripts intentionally use bash features and are out of scope.
@@ -49,7 +53,8 @@ if [ -n "${POSIX_SH_CHECK_SCAN_DIRS:-}" ]; then
 else
   SCAN_DIRS="${TRADING_DIR}/devtools/checks
 ${TRADING_DIR}/devtools/checks/deep_scan
-${REPO_ROOT}/dev/lib"
+${REPO_ROOT}/dev/lib
+${REPO_ROOT}/dev/scripts"
 fi
 
 CLEAN_COUNT=0


### PR DESCRIPTION
## Summary

Delivers plan §3h — nightly A/B comparison between `Loader_strategy.Legacy` and `Loader_strategy.Tiered` against broad goldens — as three concrete artefacts:

1. **`dev/scripts/tiered_loader_ab_compare.sh`** — POSIX sh script that runs one scenario under both strategies via `backtest_runner.exe`, then diffs the resulting `trades.csv` / `summary.sexp`. Hard gate on trade-count diff per plan §Resolutions #1; warn annotation (exit 0) on portfolio-value drift above `max($1.00, 0.001% of legacy_pv)`.
2. **`dev/ci-staging/tiered-loader-ab.yml`** — GHA workflow (nightly at 04:17 UTC, `workflow_dispatch` enabled) that runs the compare against the 3 broad goldens (bull-crash-2015-2020, covid-recovery-2020-2024, six-year-2018-2023) and uploads the full output trees as a 30-day artefact. **Staged under `dev/ci-staging/` because the feat-backtest agent's GitHub token lacks the `workflow` scope** — at merge (or as a tiny 1-line follow-up PR from a workflow-scoped token), rename to `.github/workflows/tiered-loader-ab.yml` to activate. See the "Install workflow" section below.
3. **`trading/devtools/checks/posix_sh_check.sh`** — extended to scan `dev/scripts/` in addition to `dev/lib/` so the new script is covered by the `dash -n` parse gate from #493. Linter clean-count went 41 → 42.

## Why dev/ci-staging/ for the workflow

```
$ git push origin feat/backtest-scale-3h
remote: refusing to allow a Personal Access Token to create or update
remote: workflow `.github/workflows/tiered-loader-ab.yml` without
remote: `workflow` scope
```

The agent's `GH_TOKEN` is a fine-grained PAT without the `workflow` scope, so any path under `.github/workflows/` is rejected at push time regardless of filename. Staging the content under `dev/ci-staging/` keeps the reviewable content in the PR diff. **Before merge** (or as a tiny 1-line follow-up PR), run:

```sh
git mv dev/ci-staging/tiered-loader-ab.yml .github/workflows/tiered-loader-ab.yml
```

This is the only post-merge action required to activate the nightly schedule.

## Parity contract (plan §Resolutions #1)

| Condition | Gate | GHA annotation |
|---|---|---|
| `trade_count_diff != 0` | **Hard fail** (exit 1) | `::error::` |
| `trades.csv` missing on either side | **Hard fail** (exit 1) | `::error::` |
| PV drift `> max($1.00, 0.001% * legacy_pv)` | Warn only (exit 0) | `::warning::` |
| PV drift within threshold | Pass | none |

Each workflow step uses `continue-on-error: true` so artefact upload and remaining scenarios still execute even if one scenario hits a hard fail; an aggregate step re-surfaces the job exit status.

## Scope boundaries

- Does not modify `Bar_loader`, `Weinstein_strategy`, `Simulator`, `Price_cache`, `Screener`, or anything under `trading/trading/weinstein/`.
- Does not flip the `loader_strategy` default to `Tiered` — that's a tiny follow-up per the post-merge ramp in `dev/status/backtest-scale.md`.
- Does not wire 3h into `dune runtest` — it's a nightly advisory workflow, not a commit-time gate, per plan §3h.

## Test plan

- [x] `dash -n dev/scripts/tiered_loader_ab_compare.sh` → `PARSE OK`
- [x] `dev/lib/run-in-env.sh dune runtest trading/devtools/checks` → `OK: posix-sh linter -- 42 scripts clean.`
- [x] `dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest` — full workspace green
- [x] `dev/lib/run-in-env.sh dune build @fmt` — formatter clean
- [x] Smoke run on `smoke/tiered-loader-parity.sexp`: Legacy trades 3, Tiered trades 3, both PV $1,096,397.65, delta $0.00 within warn threshold $10.96
- [ ] After merge + workflow install: first nightly run uploads `tiered-loader-ab-<run_id>` artefact containing `artefacts/<scenario>/{legacy,tiered}/` + `diff.txt` for each broad golden

## Followups

- **(next)** Rename `dev/ci-staging/tiered-loader-ab.yml` → `.github/workflows/tiered-loader-ab.yml` via a workflow-scoped push to activate the schedule.
- After a few weeks of nightly data: flip `loader_strategy` default from `Legacy` to `Tiered`.
- After Tiered-default stable: retire `_run_legacy` in `runner.ml`.

Part of `dev/plans/backtest-tiered-loader-2026-04-19.md` §3h.
