### PR TITLE
ops: daily orchestrator summary 2026-04-22-run2

### DIFF
--- a/dev/audit/2026-04-22-backtest-scale-3h.json
+++ b/dev/audit/2026-04-22-backtest-scale-3h.json
@@ -1,0 +1,17 @@
+{
+  "date": "2026-04-22",
+  "feature": "backtest-scale-3h",
+  "branch": "feat/backtest-scale-3h",
+  "structural_qc": "APPROVED",
+  "behavioral_qc": "APPROVED",
+  "overall_qc": "APPROVED",
+  "harness_gap": "",
+  "quality_score": 5,
+  "findings_count": {
+    "PASS": 0,
+    "FAIL": 0,
+    "FLAG": 0
+  },
+  "consecutive_rework_count": 0,
+  "notes": ""
+}

--- a/dev/daily/2026-04-22-run2.md
+++ b/dev/daily/2026-04-22-run2.md
@@ -1,0 +1,138 @@
+# Status — 2026-04-22 [run 2]
+
+**Run ID:** 2026-04-22-run-2
+**Run timestamp:** 2026-04-22T01:52:00Z
+**Mode:** full pass (not fast-exit)
+
+## Step 0.5 saturated-queue check result
+
+Full pass: Condition 2 failed — `dev/status/backtest-scale.md` and `dev/status/harness.md` were modified by non-summary commits since the prior summary (PRs #492 and #493 both merged between run-1 and run-2). Conditions 1 (no open PRs at start-of-run), 3 (no Step 1b drift warnings), and 4 (harness.md did change, so Cond 4 also failed) carried the decision: proceed to Step 2.
+
+## Step 1c carried-forward critical verification
+
+No still-real `[critical]` items inherited from run-1 (run-1 §Escalations had `[info]` only). Main baseline independently re-verified green in Step 6: `dune build && dune runtest` exit 0.
+
+## Pending work
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| backtest-scale | awaiting-merge | feat/backtest-scale-3h | #496 | 3h nightly A/B trace comparison — QC APPROVED (quality 5/5). Activation requires human `git mv dev/ci-staging/tiered-loader-ab.yml .github/workflows/` at merge (bot token lacks `workflow` scope). |
+| harness | skipped (no-change) | — | — | Backlog saturated — T1 done; T2 milestone-gated; T3-C superseded; T3-H low-priority. No eligible target today. |
+| orchestrator-automation | blocked | — | — | Phase 2 empirical tests pending (human-only). |
+| cleanup | skipped (no-change) | — | — | Backlog empty; no new medium/high findings. |
+| cost-tracking | skipped (no-change) | — | — | Observational. Cost-capture new-day bug resolved via #495 today (human-driven); next full-pass run will produce fresh `dev/budget/<date>-run2.json`. |
+| ops-data | skipped (no-change) | — | — | `dev/notes/data-gaps.md` unchanged since 2026-04-14. |
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| backtest-scale | feat-backtest | completed | 3h nightly A/B compare — `dev/scripts/tiered_loader_ab_compare.sh` (POSIX sh, 306 lines) + `dev/ci-staging/tiered-loader-ab.yml` (146 lines, staged pending workflow-scope) + `posix_sh_check.sh` SCAN_DIRS extension + `dev/status/backtest-scale.md` reconciled. PR #496. |
+| backtest-scale | qc-structural | APPROVED | All 13 checklist items PASS or NA. POSIX-sh parse OK; parity contract encoded per plan §Resolutions #1; scope-boundary clean (no OCaml touched). |
+| backtest-scale | qc-behavioral | APPROVED | Quality score 5/5. Plan §Resolutions #1 formula (`max($1.00, 0.001% of legacy_pv)`) encoded verbatim; §Resolutions #2 scenarios (bull-crash, covid-recovery, six-year) match nominal list; staging handoff documented in three independent locations. |
+| — (audit) | — | written | `dev/audit/2026-04-22-backtest-scale-3h.json` — overall APPROVED, quality 5, consecutive_rework_count 0. |
+| harness | — | skipped | No eligible follow-up: `.claude/worktrees/` gap already resolved in `.gitignore:49`; "Orchestrator daily summary drifts" follow-up is medium-risk (edits orchestrator itself); other open items are milestone-gated or marked superseded/low-priority. |
+| ops-data | — | skipped | `dev/notes/data-gaps.md` sentinel unchanged since 2026-04-14. |
+| cleanup | — | skipped | `dev/status/cleanup.md` §Backlog empty; no new medium/high findings in `dev/health/2026-04-22-fast-run2.md`. |
+| orchestrator-automation | — | skipped | Phase 2 is human-only (empirical tests). |
+
+## Feature Progress
+
+### backtest-scale [IN_PROGRESS, awaiting-merge on #496]
+- Done today (run 2): 3h nightly A/B trace comparison landed. POSIX-sh compare script runs `backtest_runner` twice (Legacy + Tiered) and diffs trade + summary outputs under the plan's parity contract — trade-count diff = hard fail, PV drift `> max($1.00, 0.001% of legacy_pv)` = warn-only. GHA workflow (nightly 04:17 UTC) exercises three broad goldens: bull-crash-2015-2020, covid-recovery-2020-2024, six-year-2018-2023. `posix_sh_check.sh` SCAN_DIRS extended to cover `dev/scripts/` (clean-count 41 → 42).
+- In flight: PR #496 awaiting human action — specifically a 1-line `git mv dev/ci-staging/tiered-loader-ab.yml .github/workflows/tiered-loader-ab.yml` at merge time. The workflow was staged because the bot token lacks GitHub `workflow` scope; the compare script itself is fully installable as-is and can be invoked manually today.
+- Blocked: No. Post-activation next increments: flip `loader_strategy` default Legacy→Tiered in a ~20-line follow-up PR; then retire the Legacy codepath.
+
+### harness [IN_PROGRESS, no open PR]
+- Done today (run 1, already merged): #493 POSIX-sh portability linter.
+- Done today (human-driven, merged outside orchestrator): #495 cost-capture new-day fix (orchestrator.yml, 9 lines).
+- In progress: —
+- Blocked: No — queue is saturated (see Pending work row).
+
+## QC Status
+
+- backtest-scale-3h: APPROVED (structural + behavioral, quality 5/5) — see `dev/reviews/backtest-scale-3h.md`; audit at `dev/audit/2026-04-22-backtest-scale-3h.json`.
+
+## Budget
+
+- Budget cap: $50.00 (from `dev/config/merge-policy.json`)
+- Target utilization: 60%–80%
+- Subagents spawned: 3 (measured by dispatch count)
+- Per-subagent breakdown (estimated — measured total lands in `dev/budget/2026-04-22-run2.json` post-run):
+
+  | Agent | Model | Status | Est. tokens | Est. cost |
+  |-------|-------|--------|-------------|-----------|
+  | feat-backtest (3h) | sonnet | completed | ~500K in / 40K out | ~$2.10 |
+  | qc-structural (#496) | haiku | completed | ~120K in / 8K out | ~$0.16 |
+  | qc-behavioral (#496) | sonnet | completed | ~200K in / 15K out | ~$0.83 |
+
+- Any subagent killed mid-flight: No.
+
+**Measured cost (from GHA execution file):** Pending. `dev/budget/2026-04-22-run2.json` will be written by the GHA "Capture run cost" step after this run exits.
+
+- Total (estimated): ~$3.09 + ~$1.00 orchestrator = **~$4.09 / $50 (8%)**
+- Utilization assessment: UNDER_TARGET (<60%) — queue saturated: only one non-blocked actionable track (backtest-scale) + one non-blocked IN_PROGRESS track with no eligible follow-up (harness). Not a skip issue — all eligible tracks dispatched. Run-1 today used 18% on two tracks; run-2 drops to ~8% because one of those two tracks has no next work until the human activates #496's workflow.
+- Scope reduced due to budget: No.
+
+## Data Operations
+
+(ops-data skipped — `dev/notes/data-gaps.md` unchanged since 2026-04-14.)
+
+## Harness Work
+
+No harness-maintainer dispatch this run. Prior runs' work landed as #493 (POSIX-sh linter, today at 01:04Z). Unrelated: PR #495 (cost-capture new-day fix) was merged today at 01:46Z by a human; it is noted here for completeness but was not orchestrator-dispatched.
+
+## Health Scan
+
+(From `dev/health/2026-04-22-fast-run2.md`)
+
+- Result: CLEAN
+- Critical items: none
+- Main build exit 0; status-integrity exit 0.
+
+## Follow-up Queue
+
+- backtest-scale:
+  - real-data fixtures to replace synthetic 100.00+drift macro CSVs (non-blocking; deferred — parity currently holds for right reason on synthetic but not real data)
+  - F1 (test tolerance refactor) — non-blocking
+  - `Tiered_runner._promote_universe_metadata` missing-CSV intolerance divergence vs Legacy (documented, deferred)
+  - `Bar_loader.create` benchmark_symbol default "SPY" vs Runner's `GSPC.INDX` (deferred)
+- harness:
+  - `.claude/worktrees/` gitignore gap follow-up is **stale** — verified present in `.gitignore:49`; next harness-maintainer dispatch should strike from `dev/status/harness.md` §Follow-up
+  - "Orchestrator daily summary drifts" follow-up remains current (medium-risk, touches orchestrator itself)
+- cost-tracking:
+  - Verify `total_cost_usd` now lands correctly on new-day runs post-#495
+  - Compare costs pre/post #481/#482/#495 once a few more measured data points exist
+
+## Integration Queue
+
+(Derived from live GitHub state + QC approvals this run.)
+
+- **PR #496** (feat/backtest-scale-3h) — 3h nightly A/B trace comparison. QC APPROVED (quality 5/5). **Requires human `git mv dev/ci-staging/tiered-loader-ab.yml .github/workflows/tiered-loader-ab.yml` at merge** — bot token lacks `workflow` scope.
+
+Auto-merge disabled (`auto_merge_enabled: false` in `dev/config/merge-policy.json`).
+
+## Current Milestone Target
+
+M5 — Backtesting & Tuning — Tiered loader path is end-to-end complete through the 3g parity gate (#484) and the F2 closure (#492). 3h (nightly A/B, #496) provides the data-driven signal for the default flip. Remaining endgame: human activates workflow → a few nights of nightly A/B data → flip Tiered to default → retire Legacy.
+
+## Dependency Unlocks
+
+- PR #496's compare script + staged workflow unblock the "flip Tiered to default" follow-up once the workflow is activated and produces a few nights of clean A/B runs.
+
+## Escalations
+
+- [info] Under-target utilization (~8% of $50). Root cause: eligible queue is saturated beyond one dispatch. backtest-scale's next increment (flip-default) is gated on #496 producing real nightly-A/B data, which requires human to `git mv` the workflow first. No new harness targets at today's backlog. Not actionable by the orchestrator.
+- [info] PR #496's workflow is staged at `dev/ci-staging/tiered-loader-ab.yml` rather than `.github/workflows/`. This is a **persistent constraint**, not a one-off: the bot GitHub App / PAT installation lacks `workflow` scope. Options: (a) widen the PAT scope once (human one-time), (b) accept the one-line `git mv` ritual on every GHA-workflow-touching PR, (c) teach a harness item to flag this on PR open. Today's workaround (staging + doc) is fine for merge; medium-term decision deferred.
+- [info] Carried-forward verification: no still-real `[critical]` items from run-1; main green (exit 0) on post-#495 tip `744d3a7`.
+
+## Questions for You
+
+1. Merge order: #496 first? (No other PRs open right now, so ordering is moot, but flagging because the `git mv` is mandatory at merge.)
+2. Do you want to widen the bot's token scope to include `workflow` (so `.github/workflows/*.yml` edits don't need the staging ritual), or keep the `dev/ci-staging/` convention as an intentional human-gate on CI changes?
+3. Next backtest-scale increment after #496 lands — dispatch "flip `loader_strategy` default Legacy→Tiered" (tiny ~20-line PR) in the next run, or hold until a few nightly A/B runs accumulate data first?
+4. Harness backlog is saturated — ready to open a new tier (T5?) or is the current plan intentionally parking until M5–M7 milestone gates unlock T2/T3 items? Status files list T2-B (M5 gated), T2-C (M7), T2-D (M6 gated before), T4-A..E (end-state); nothing near-term except T3-H (commit-level QC mode, explicitly low priority).
+
+---
+## Your Response
+(Edit this section. Run dev/run.sh after editing to start the next session.)

--- a/dev/health/2026-04-22-fast-run2.md
+++ b/dev/health/2026-04-22-fast-run2.md
@@ -1,0 +1,19 @@
+# Health Report -- 2026-04-22 -- fast (run 2)
+
+## Summary
+- Main build: PASSING (exit 0)
+- Status file integrity: PASSING (exit 0)
+- Action required: NO
+
+## Metrics
+- Checks run: 2 (deterministic; no agentic fast scan)
+- Advisory linter output: not checked here -- covered by `dune runtest` exit code
+- Deep scan: see `dev/health/*-deep.md` (weekly GHA cron)
+
+## Detail
+
+- `dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest` → exit 0
+  (F2 tail_days fix on main: `Tiered loader: Metadata=0 Summary=19 Full=3 at end
+  of simulator run` as expected).
+- `dev/lib/run-in-env.sh sh devtools/checks/status_file_integrity.sh` → exit 0
+  (`OK: all dev/status/*.md files have required fields.`).

--- a/dev/reviews/backtest-scale-3h.md
+++ b/dev/reviews/backtest-scale-3h.md
@@ -1,0 +1,148 @@
+Reviewed SHA: 5f485dd069a54ae74919686dc0c0d8eb800252d7
+
+## Structural Checklist — backtest-scale 3h (nightly A/B compare, PR #496)
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| H1 | dune build @fmt | PASS | |
+| H2 | dune build | PASS | |
+| H3 | dune runtest | PASS | Full test suite green; no new unit tests in this increment (3h is CI/scripting) |
+| P1 | Functions ≤ 50 lines (linter) | PASS | Shell script longest function `_run_backtest` is 27 lines; all helpers ≤ 9 lines |
+| P2 | No magic numbers (linter) | PASS | 0.00001 (0.001% tolerance) and 1.0 (floor) are documented in function headers and plan §Resolutions #1; not arbitrary |
+| P3 | Config completeness | NA | No new configurable thresholds introduced — parity tolerance is pinned in the plan and documented in code |
+| P4 | .mli coverage (linter) | NA | No OCaml .ml/.mli files added (shell script + GHA workflow only) |
+| P5 | Internal helpers prefixed with _ | PASS | All shell helpers (`_die`, `_usage`, `_scenario_name`, `_scenario_start`, `_scenario_end`, `_run_backtest`, `_trade_count`, `_final_portfolio_value`, `_abs_delta`, `_pv_warn_threshold`, `_gt`) correctly prefixed |
+| P6 | Tests conform to matchers library | NA | No new OCaml test files |
+| A1 | Core module modifications | PASS | Portfolio/Orders/Position/Strategy/Engine untouched; no changes to trading/trading/weinstein/ or bar_loader logic |
+| A2 | No imports from analysis/ into trading/ | PASS | No analysis imports in the diff |
+| A3 | No unnecessary existing module modifications | PASS | Only `trading/devtools/checks/posix_sh_check.sh` extended: added `dev/scripts` to `SCAN_DIRS` (+7/-2 lines), purely scope expansion for the linter itself |
+
+## Verdict
+
+APPROVED
+
+## Scope & Design Verification
+
+1. **Parity contract (plan §Resolutions #1):** Correctly encoded in `tiered_loader_ab_compare.sh`:
+   - Hard gate: trade-count diff == 0 → exit 1 (lines 274–281)
+   - Warn gate: |legacy_pv − tiered_pv| ≤ max($1.00, 0.001% of legacy_pv) → ::warning:: + exit 0 (lines 283–303)
+   - Threshold formula correct: `awk -v pv="$1" 'BEGIN { t = pv * 0.00001; if (t < 1.0) t = 1.0; printf "%.4f\n", t }'` (lines 190–196)
+
+2. **Broad scenarios (plan §Resolutions #2):** Workflow exercises the three goldens:
+   - `bull-crash-2015-2020.sexp` (lines 79–88)
+   - `covid-recovery-2020-2024.sexp` (lines 90–99)
+   - `six-year-2018-2023.sexp` (lines 101–110)
+
+3. **Staging path documented:** `dev/ci-staging/tiered-loader-ab.yml` is clearly marked as pending `git mv` to `.github/workflows/` at merge time:
+   - Documented in status file (lines 35–46)
+   - Referenced in script header (lines 10–12)
+   - GHA workflow includes design note (lines 16–20)
+   - Next steps pinpoint the handoff (lines 113–116)
+
+4. **POSIX-sh discipline:** 
+   - Script passes `dash -n` parse-only check ✓
+   - Linter extended to scan `dev/scripts/` (posix_sh_check.sh SCAN_DIRS, lines 54–57)
+   - Linter now reports 42 scripts clean (up from 41) ✓
+   - Script uses `set -eu` for error discipline (line 47)
+   - All functions in scope (shell helpers, grep/sed/awk utilities)
+
+5. **Error handling & cleanup:**
+   - Backtest failures captured in log files before rc check (lines 135–137); logs preserved for investigation
+   - Hard parity violations (trades.csv missing or count diff) trigger GHA `::error::` annotations and exit 1 (lines 265–281)
+   - Warn-only violations (PV drift above threshold, missing PV fields) trigger `::warning::` and exit 0 (lines 283–303)
+   - GHA workflow uses `continue-on-error: true` on individual scenario steps so all three run even if one fails (lines 82, 93, 104)
+   - Aggregate step re-surfaces any failure as job-level exit status (lines 126–147)
+   - Output trees copied to stable `<out>/legacy/` and `<out>/tiered/` for artefact upload (lines 240–244)
+
+6. **Scope boundary:** 
+   - Files touched: `dev/scripts/tiered_loader_ab_compare.sh` (new), `dev/ci-staging/tiered-loader-ab.yml` (new), `trading/devtools/checks/posix_sh_check.sh` (scope extension), `dev/status/backtest-scale.md` (status log)
+   - No OCaml code modified; no strategy/screener/loader refactors
+   - No changes to Bar_loader tier logic or the Tiered_runner/Tiered_strategy_wrapper implementations
+
+7. **Feature completeness:**
+   - Smoke verification (status file lines 207–212): both strategies produce 3 trades / identical $1,096,397.65 final PV (delta $0.00 within warn threshold $10.96) on tiered-loader-parity.sexp ✓
+   - Script documentation comprehensive (usage, parity contract, scenarios, exit status — lines 1–45)
+   - GHA workflow permissioning correct: no `workflow` scope required; runs under standard `GITHUB_TOKEN` (lines 45–46)
+
+---
+
+# Behavioral QC — backtest-scale 3h (nightly A/B compare, PR #496)
+Date: 2026-04-22
+Reviewer: qc-behavioral
+
+## Behavioral Checklist — backtest-scale 3h (nightly A/B compare, PR #496)
+
+### Contract Pinning Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| CP1 | Each non-trivial claim in new .mli docstrings has an identified test that pins it | NA | No new .mli files added — PR is shell script + GHA workflow + status log + linter scope extension. Script-header documentation is advisory, not an API contract |
+| CP2 | Each claim in PR body / commit messages vs committed artefacts | PASS | Commit `0f7b7add` (feat commit) claims: (a) hard gate on trade-count, (b) warn gate at max($1.00, 0.001% of legacy_pv), (c) missing trades.csv = hard fail, (d) uses backtest_runner.exe not scenario_runner, (e) extracts start_date/end_date via grep+sed, (f) output dir pinned via "Output written to: ..." stderr line, (g) no jq dependency, (h) posix_sh_check.sh extended to scan dev/scripts/. All 8 claims verified in the script (lines 123–151 for (d)/(e)/(f); 265–281 for (a)/(c); 283–303 for (b); no `jq` tokens anywhere; posix_sh_check.sh lines 54–57 for (h)). Commit `14bc61f5` (staged workflow) claims workflow lives at `dev/ci-staging/tiered-loader-ab.yml` with deferred `git mv` to `.github/workflows/` — verified (file exists at staged path, commented in workflow header lines 16–20 and status file lines 35–46) |
+| CP3 | Pass-through / identity / invariant tests pin identity (not just size) | NA | No OCaml-level pass-through tests. Smoke parity output identified in status file lines 207–212 pins exact PV ($1,096,397.65 both sides, delta $0.00) and exact trade count (3 both sides); this exceeds a size-only check |
+| CP4 | Each guard called out explicitly in docstrings has a test that exercises it | NA | Script-level guards (hard vs. warn gates, MISSING branches) are not unit-tested — 3h is explicitly a CI/visibility surface, not a test suite. The status file §Completed verification section describes a smoke run that exercises the happy path; failure-path coverage is by design deferred to the first nightly run. Plan §3h says "not a test (too slow), not a merge gate — just visibility" |
+
+### Weinstein Domain Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| A1 | Core module modification is strategy-agnostic | NA | qc-structural did not flag A1; no core module modifications in this diff |
+| S1 | Stage 1 definition matches book | NA | No stage classification code in 3h |
+| S2 | Stage 2 definition matches book | NA | No stage classification code in 3h |
+| S3 | Stage 3 definition matches book | NA | No stage classification code in 3h |
+| S4 | Stage 4 definition matches book | NA | No stage classification code in 3h |
+| S5 | Buy criteria: Stage 2 entry on breakout with volume | NA | No entry logic in 3h |
+| S6 | No buy signals in Stage 1/3/4 | NA | No entry logic in 3h |
+| L1 | Initial stop below base | NA | No stops in 3h |
+| L2 | Trailing stop never lowered | NA | No stops in 3h |
+| L3 | Stop triggers on weekly close | NA | No stops in 3h |
+| L4 | Stop state machine transitions | NA | No stops in 3h |
+| C1 | Screener cascade order | NA | No screener code in 3h |
+| C2 | Bearish macro blocks all buys | NA | No screener code in 3h |
+| C3 | Sector RS vs. market, not absolute | NA | No screener code in 3h |
+| T1 | Tests cover all 4 stage transitions | NA | No OCaml domain tests in 3h |
+| T2 | Bearish macro → zero buy candidates test | NA | No OCaml domain tests in 3h |
+| T3 | Stop trailing tests | NA | No OCaml domain tests in 3h |
+| T4 | Tests assert domain outcomes | NA | No OCaml domain tests in 3h |
+
+### Plan §Resolutions Conformance (primary authority for 3h)
+
+The relevant authority for this CI/scripting PR is `dev/plans/backtest-tiered-loader-2026-04-19.md`. The two contracts that matter:
+
+**§Resolutions #1 — Parity threshold:**
+> Zero trade-count diff is the hard gate. Any missing or extra trade fails parity.
+> Portfolio-value diff tolerance: max($1.00, 0.001% of final portfolio_value).
+
+Verification (script `dev/scripts/tiered_loader_ab_compare.sh`):
+- Hard gate (trade-count diff): lines 274–281. `if [ "$LEGACY_TRADES" != "$TIERED_TRADES" ]; then exit 1`. Emits `::error::` annotation. ✓ PASS
+- Hard gate (missing trades.csv): lines 265–272. Either side MISSING → exit 1 with `::error::`. ✓ PASS (stronger than the plan literally says; plan only mentions "missing or extra trade" — script treats a missing `trades.csv` file as a malformed run, a stronger invariant, which the feat commit message calls out explicitly. Consistent with the plan's intent.)
+- Warn gate (PV drift): lines 283–303. Threshold formula at lines 190–196: `t = pv * 0.00001; if (t < 1.0) t = 1.0` — equivalent to `max(1.0, 0.00001 * pv)`. 0.00001 is precisely 0.001% (`0.001/100 = 1e-5`). ✓ PASS — formula exact-matches the plan text.
+- Warn gate exits 0 (`::warning::` annotation): lines 296–303, and the "Warn gate (exit 0, ::warning::)" flow in status file lines 186–189. ✓ PASS
+- Warn gate when PV MISSING: lines 283–289 emit `::warning::` and `exit 0`. This is slightly softer than the hard gate — reasonable: summary.sexp can be present-without-final_portfolio_value if the simulator aborts mid-run, and that's a separate signal from trade-count divergence. Arguably this could be a hard fail (the spec is silent on this edge), but I don't think it violates the plan.
+
+**§Resolutions #2 — Broad A/B scenarios:**
+> Start with 2-3 scenarios covering different regimes (one bull, one bear, one choppy). Nominal picks: six-year (2018-2023 mixed), bull-crash (2015-2020, bullish → crash), covid-recovery (2020-2024, whipsaw).
+
+Verification (`dev/ci-staging/tiered-loader-ab.yml`):
+- 3 scenario steps (lines 79–110), each running one of:
+  - `goldens-broad/bull-crash-2015-2020.sexp` (bullish → crash regime) ✓
+  - `goldens-broad/covid-recovery-2020-2024.sexp` (whipsaw regime) ✓
+  - `goldens-broad/six-year-2018-2023.sexp` (mixed regime) ✓
+- All 3 scenarios verified present at `trading/test_data/backtest_scenarios/goldens-broad/`. ✓ PASS — matches the plan's nominal-pick list verbatim.
+
+**Rationale for the parity-contract implementation choices:**
+
+- The script parses the scenario sexp with grep+sed rather than a proper parser. This is documented in the feat commit and the script header. The scope is restricted to `(name ...)` and `(period (start_date ...) (end_date ...))`. For the three broad goldens this works — all three have the expected shape. Accepted: the plan's "line budget: ~100 lines" implicitly forbids a proper parser, and sexp parsing in pure shell would balloon the script.
+- The script ignores `universe_path` and `config_overrides`, relying on backtest_runner's default universe/sector-map behaviour. Documented in script header lines 14–18. Accepted: all three goldens ship without explicit universe/config overrides, so this is a safe restriction for the initial scope.
+- The GHA workflow uses `continue-on-error: true` on individual scenario steps + an aggregate step that re-surfaces any failure (lines 82/93/104 + 126–146). This ensures all 3 scenarios run on every nightly, so a regression in scenario 1 doesn't mask a separate regression in scenarios 2/3. ✓ Good design beyond what the plan strictly requires.
+
+## Quality Score
+
+5 — Faithful, economical implementation of plan §3h with all contract surfaces (hard gate, warn gate, threshold formula, 3 nominal scenarios, nightly cadence, artefact layout) exactly matching §Resolutions #1 & #2. POSIX-sh discipline maintained; linter scope extension is a principled side-effect that keeps the new script under the existing portability gate. Staging path (`dev/ci-staging/` → `.github/workflows/` via `git mv`) is well-documented in three independent locations (script header, workflow header, status file). No hardcoded thresholds — `0.00001` is the plan's `0.001%` constant verbatim, documented in the function header. Smoke verification on the parity scenario reports exact-match output.
+
+(Does not affect verdict. Tracked for quality trends over time.)
+
+## Verdict
+
+APPROVED
+
+(Derived mechanically: all applicable CP* items PASS, all S*/L*/C*/T* rows NA for this CI/scripting PR, and both plan-level contracts (§Resolutions #1 parity formula; §Resolutions #2 scenario picks) match verbatim.)

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,7 +4,7 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-22 (orchestrator reconcile post-dispatch: PR #492 feat/backtest-scale-f2 closes F2 root cause — `Summary_compute.compute_values` was returning `None` because `tail_days` default was 250 but Mansfield RS needs 52 weeks × 7 = 420 calendar days; bumped default to 420, added regression test. PR #493 harness/posix-sh-linter adds `dash -n` gate over 40 #!/bin/sh scripts. Both PRs APPROVED by QC and awaiting human merge. Main baseline green.)
+Last updated: 2026-04-22 run-2 (orchestrator reconcile post-dispatch: PR #492 F2 tail_days fix merged at 01:04Z; PR #493 POSIX-sh linter merged at 01:04Z; PR #495 cost-capture new-day fix merged at 01:46Z (human-driven CI fix). This run dispatched feat-backtest on 3h nightly A/B trace comparison — PR #496 open, QC APPROVED (structural + behavioral, quality 5/5), awaiting human merge. Main baseline green.)
 
 ## Active + complete tracks
 
@@ -14,15 +14,15 @@ Each row: one line; deeper task detail in the linked status file.
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
 | [backtest-infra](backtest-infra.md) | MERGED | — | — | — (#419 per-phase tracing merged 2026-04-19) |
-| [backtest-scale](backtest-scale.md) | IN_PROGRESS | feat-backtest | #492 | PR #492 awaiting-merge — F2 full closure (`tail_days` 250→420 so 52-week Mansfield RS window is reachable; Summary tier now populates for all 19 of 22 universe symbols). Next after merge: real-data fixtures to replace synthetic 100.00+drift macro CSVs, then 3h (nightly A/B comparison), then flip Tiered to default closing the M5 track. |
+| [backtest-scale](backtest-scale.md) | IN_PROGRESS | feat-backtest | #496 | PR #496 awaiting-merge — 3h nightly A/B trace comparison (GHA workflow + POSIX-sh compare script; workflow staged in `dev/ci-staging/` pending human `git mv` at merge due to bot token lacking `workflow` scope). 3g parity test (#484) and F2 tail_days fix (#492) both merged 2026-04-22. Post-merge: human activates workflow via 1-line `git mv`; then flip `loader_strategy` default Legacy→Tiered; then retire Legacy codepath. |
 | [support-floor-stops](support-floor-stops.md) | MERGED | — | — | — (PRs #382 primitive + #390 wiring both merged 2026-04-17) |
 | [short-side-strategy](short-side-strategy.md) | MERGED | — | — | — (#420 merged 2026-04-19). Follow-ups carried to own tracks: bear-window backtest regression, full short cascade, Ch.11 behavioural spot-check. |
 | [strategy-wiring](strategy-wiring.md) | MERGED | — | — | — (#408 + #409 both merged 2026-04-18) |
 | [sector-data](sector-data.md) | MERGED | — | — | — (#436 merged 2026-04-19). GHA orchestrator runs continue to consume `trading/test_data/sectors.csv`. |
-| [harness](harness.md) | IN_PROGRESS | harness-maintainer | #493 | PR #493 awaiting-merge — POSIX-sh portability linter (`dash -n` gate over 40 #!/bin/sh scripts, bash-exempt shebangs honored). Recent wave merged 2026-04-21: #473 T3-F, #480 live-evidence, #482 Haiku swap, #483 gha-cost-tracking, #488 orchestrator self-sabotage fixes, #490 consolidated-summary exclusion. |
+| [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | No open harness PR. Recent merges: #493 POSIX-sh linter (today), #495 cost-capture new-day fix (today, human). Backlog remains saturated — T1 done; T2 milestone-gated; T3-C superseded; T3-H low-priority. Stale follow-up `.claude/worktrees/` already resolved (present in `.gitignore` line 49). |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Phase 1 live (daily cron runs producing summary PRs). Phase 2 (background execution for scrapers, golden re-runs, cross-feature QC) pending empirical tests per status file. |
-| [cleanup](cleanup.md) | IN_PROGRESS | code-health | — | Backlog remains empty (no new medium/high findings from latest deep scan or today's fast-run5). No code-health dispatch this run. |
-| [cost-tracking](cost-tracking.md) | IN_PROGRESS | harness-maintainer | — | GHA cost capture step + budget_rollup.sh landed (harness/gha-cost-tracking). Next: verify measured total_cost_usd on next GHA run; compare costs pre/post #481/#482. |
+| [cleanup](cleanup.md) | IN_PROGRESS | code-health | — | Backlog remains empty (no new medium/high findings from latest deep scan or today's fast health check). No code-health dispatch this run. |
+| [cost-tracking](cost-tracking.md) | IN_PROGRESS | harness-maintainer | — | GHA cost capture step landed (#483). Cost-capture new-day bug fixed today via #495 (human-driven). Next: verify measured `total_cost_usd` on next full-pass GHA run; compare costs pre/post #481/#482/#495. |
 | [data-layer](data-layer.md) | MERGED | — | — | — |
 | [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |
 | [screener](screener.md) | MERGED | — | — | — |


### PR DESCRIPTION
Automated daily orchestrator run (run 2 of 2026-04-22). See `dev/daily/2026-04-22-run2.md` for the full summary.