### PR TITLE
ops: daily orchestrator summary 2026-04-22-run3

### DIFF
--- a/dev/daily/2026-04-22-run3.md
+++ b/dev/daily/2026-04-22-run3.md
@@ -1,0 +1,137 @@
+# Status — 2026-04-22 [run 3]
+
+**Run ID:** 2026-04-22-run-3
+**Run timestamp:** 2026-04-22T06:10:42Z
+**Mode:** full pass (not fast-exit)
+
+## Step 0.5 saturated-queue check result
+
+Full pass: Condition 2 failed — `dev/status/backtest-scale.md` was modified by PR #496 (subject `ci(backtest-scale): 3h nightly tiered-loader A/B compare`) merging between run-2 and this run, which is a non-summary commit touching `dev/status/`. Condition 1 (0 open PRs at start-of-run → vacuously PASS), Condition 3 (no Step 1b drift warnings), and Condition 4 (harness.md / cleanup.md unchanged) all passed — Condition 2 alone triggered the full-pass decision.
+
+The #496 merge is not "new drift" in the hidden-progress sense — the run-2 summary flagged #496 as awaiting-merge. The Condition 2 rule is a literal file-modification check and fires on the mechanical fact of the merge commit, not on whether the orchestrator "already knew." Expected behaviour; no action needed.
+
+## Step 1c carried-forward critical verification
+
+No still-real `[critical]` items inherited from run-2 (run-2 §Escalations had `[info]` only). Main baseline independently re-verified green in Step 6: `dune build && dune runtest && status_file_integrity.sh` all exit 0.
+
+## Pending work
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| backtest-scale | blocked | — | — | Next increment (flip `loader_strategy` default Legacy→Tiered) gated on empirical nightly A/B data. First nightly run fires 04:17 UTC tonight; re-evaluate after ~3 clean nightly runs. |
+| harness | skipped (no-change) | — | — | Backlog saturated — T1 done; T2 milestone-gated (M5/M6/M7); T3-C superseded; T3-H low-priority. No eligible target today. |
+| orchestrator-automation | blocked | — | — | Phase 2 empirical tests complete; remaining work is rollout of three concrete wins (scrapers, golden re-runs, cross-feature QC) plus per-agent isolated worktrees in the GHA path — all human-scoped scheduling decisions. |
+| cleanup | skipped (no-change) | — | — | Backlog empty; no new medium/high findings in today's fast health scan (only build + integrity checks run, both green). |
+| cost-tracking | skipped (no-change) | — | — | Observational track. #495 + #499 closed the new-day capture bug; verification signal is the presence of `dev/budget/2026-04-22-run3.json` after this run. |
+| ops-data | skipped (no-change) | — | — | `dev/notes/data-gaps.md` unchanged since 2026-04-14 sentinel. |
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| — | — | — | No dispatches this run. |
+| backtest-scale | — | skipped | Next increment (flip-default) explicitly gated on nightly A/B data per status §Next Steps item 3 and run-2 Question 3. First nightly cron fires 04:17 UTC tonight — defer until data lands. Not a reviewer-queue concern; a genuine empirical block. |
+| harness | — | skipped | Saturated backlog — no eligible T1/T3 item. T1 complete; T2 items are M5/M6/M7 gated; T3-C superseded; T3-H explicitly low-priority. |
+| ops-data | — | skipped | `dev/notes/data-gaps.md` sentinel unchanged since 2026-04-14. No unblocked gap actionable this run. |
+| cleanup | — | skipped | `dev/status/cleanup.md` §Backlog empty; no new medium/high findings in `dev/health/2026-04-22-fast-run3.md` (build + integrity both green). |
+| orchestrator-automation | — | skipped | Phase 2 scheduling decisions are human-scoped. |
+
+## Feature Progress
+
+### backtest-scale [IN_PROGRESS, no open PR]
+- Done since run-2 (all merged by human after run-2 ended):
+  - #496 — 3h nightly A/B trace comparison (03:38Z 2026-04-22)
+  - #498 — `git mv dev/ci-staging/tiered-loader-ab.yml .github/workflows/` to activate the nightly cron (03:41Z, human-driven as noted in run-2 §Escalations)
+  - #499 — orchestrator cost-capture commit + auto-merge post-run (03:50Z, orchestrator-automation side-effect)
+- In flight: —
+- Blocked: Yes (empirical) — next merge-gate increment (flip `loader_strategy` default Legacy→Tiered) waits on nightly A/B data. First nightly run fires 04:17 UTC tonight; plan-specified dwell is "a few weeks" but the 3g parity test (#484) already pins per-bar identical output on the smoke scenario, so a 2–3 night dwell across the 3 broad goldens (bull-crash, covid-recovery, six-year) is likely sufficient.
+
+### harness [IN_PROGRESS, no open PR]
+- Done today (run-1 + human merges, already on main): #493 POSIX-sh portability linter; #495 cost-capture new-day fix; #499 cost-capture commit+auto-merge.
+- In progress: —
+- Blocked: No — queue is saturated (see Pending work row).
+
+### orchestrator-automation [IN_PROGRESS]
+- Phase 2 empirical confirmation complete (run 24644964113 on 2026-04-20). Rollout of background execution for scrapers / golden re-runs / cross-feature QC is pending; all three wins are documented in the status file's §"Three concrete wins." No orchestrator dispatch today; rollout cadence is a human-scoped decision.
+
+## QC Status
+
+- No QC runs this cycle (no dispatches). Last QC artifacts on main:
+  - backtest-scale-3h: APPROVED (structural + behavioral, quality 5/5) — `dev/reviews/backtest-scale-3h.md`; audit `dev/audit/2026-04-22-backtest-scale-3h.json`.
+
+## Budget
+
+- Budget cap: $50.00 (from `dev/config/merge-policy.json`)
+- Target utilization: 60%–80%
+- Subagents spawned: 0 this run (pure state-read + reconcile + summary)
+- Per-subagent breakdown: none.
+
+**Measured cost (from GHA execution file):** Pending. `dev/budget/2026-04-22-run3.json` will be written by the GHA "Capture run cost" step after this run exits (post-#495/#499 fix path).
+
+- Total (estimated): ~$0.50 orchestrator overhead only, no subagents = **~$0.50 / $50 (1%)**
+- Utilization assessment: UNDER_TARGET (<60%) — **all-work-done**: every eligible track evaluated, each either saturated, merged, or genuinely blocked on empirical signal. Not a skip-with-reason issue. This is the rational floor when the queue is fully processed: run-2 landed the last dispatchable item (3h compare), human merged it + its activation + the cost-capture fix between run-2 and run-3, and the next increment has an external empirical gate.
+- Scope reduced due to budget: No.
+
+## Data Operations
+
+(ops-data skipped — `dev/notes/data-gaps.md` unchanged since 2026-04-14.)
+
+## Harness Work
+
+No harness-maintainer dispatch this run. Saturated backlog; most recent merges (#493, #495, #499) all landed earlier today on run-1 / human paths. The only stale follow-up flagged across runs — `.claude/worktrees/` gitignore gap — is already resolved (present in `.gitignore:49`); `dev/status/harness.md` §Follow-up still lists it and can be struck in the next harness dispatch whenever one becomes eligible.
+
+## Health Scan
+
+(From `dev/health/2026-04-22-fast-run3.md`)
+
+- Result: CLEAN
+- Critical items: none
+- Main build: exit 0; `dune runtest`: exit 0 (Tiered loader parity still reporting `Summary=19 Full=3` across Legacy + Tiered passes post-#496); status-integrity: exit 0.
+
+## Follow-up Queue
+
+- backtest-scale:
+  - real-data fixtures to replace synthetic 100.00+drift macro CSVs (non-blocking; deferred)
+  - F1 (test tolerance refactor) — non-blocking
+  - `Tiered_runner._promote_universe_metadata` missing-CSV intolerance divergence vs Legacy (documented, deferred)
+  - `Bar_loader.create` benchmark_symbol default "SPY" vs Runner's `GSPC.INDX` (deferred)
+- harness:
+  - `.claude/worktrees/` gitignore gap follow-up is **stale** — verified present in `.gitignore:49`; next harness-maintainer dispatch should strike from `dev/status/harness.md` §Follow-up
+  - "Orchestrator daily summary drifts" follow-up remains current (medium-risk, touches orchestrator itself)
+- cost-tracking:
+  - Verify `total_cost_usd` now lands correctly on new-day runs post-#495/#499 (this run is the first post-#499 GHA run on a new calendar day — `dev/budget/2026-04-22-run3.json` will be the canary)
+  - Compare costs pre/post #481/#482/#495/#499 once a few more measured data points exist
+- short-side-strategy (MERGED track, follow-ups parked):
+  - bear-window backtest regression; full short cascade; Ch.11 behavioural spot-check.
+- sector-data (MERGED track, follow-up parked):
+  - live HTTP sector refresh is a human action, not an orchestrator dispatch.
+
+## Integration Queue
+
+No open PRs; integration queue empty. All three PRs awaiting merge at the end of run-2 (and the one that opened between run-1 and run-2) are now on main (#496, #498, #499).
+
+Auto-merge remains disabled (`auto_merge_enabled: false` in `dev/config/merge-policy.json`) for feature PRs; the orchestrator's own summary PRs auto-merge per Step 8a.
+
+## Current Milestone Target
+
+M5 — Backtesting & Tuning. Tiered loader path fully instrumented: 3g parity test merged (#484), F2 tail_days fix merged (#492), 3h nightly A/B compare + workflow activation merged (#496 + #498). Nightly A/B cron is now live. Remaining endgame: accumulate ~3 nights of clean A/B data → flip `loader_strategy` default to Tiered → retire Legacy codepath. All three steps are scoped and ready; the only blocker is calendar time for A/B signal accumulation.
+
+## Dependency Unlocks
+
+- Workflow activation (#498) unblocks the "accumulate A/B data → flip default" path on the natural schedule of the nightly cron. No inter-track unlocks this run.
+
+## Escalations
+
+- [info] Zero-dispatch run. Root cause: the queue is genuinely processed — run-2 landed the last dispatchable item (3h compare, #496), the human merged it + its activation (#498) + a cost-capture follow-on (#499) between run-2 and this run, and the next backtest-scale increment (flip-default) is gated on empirical nightly A/B data that starts accumulating tonight. Utilization ~1% of cap. Not actionable by the orchestrator; a no-op run is the correct output when no track is eligible.
+- [info] Carried-forward verification: no still-real `[critical]` items from run-2. Main green — `dune build && dune runtest` exit 0 on post-#499 tip `cad3863` (verified this run).
+- [info] `dev/status/_index.md` reconciled this run to reflect #496/#498/#499 all merged on 2026-04-22. `dev/status/backtest-scale.md` flipped from `READY_FOR_REVIEW` to `IN_PROGRESS` with `Open PR: None` now that 3h is merged.
+
+## Questions for You
+
+1. **Flip-default timing.** Do you want to dispatch the `loader_strategy` default flip (Legacy→Tiered) on the next run after you see the first clean nightly A/B report, or wait for 3 consecutive clean nights? The plan (`dev/plans/backtest-tiered-loader-2026-04-19.md`) says "after a few weeks of nightly A/B data"; the parity test (#484) already pins per-bar identical output on the smoke scenario, so the conservative fallback is a 2–3 night dwell across the 3 broad goldens.
+2. **Legacy retirement.** After the flip lands, do you want the retirement of `_run_legacy` in `runner.ml` to go out as a separate tiny PR (keeps the commit story clean) or folded into the flip PR (one-shot, removes the dead code immediately)?
+3. **Harness backlog — ready to open a new tier?** The current saturation will persist until M5 gates unlock T2 items. Either (a) continue to emit no-op runs until a milestone gate fires, (b) accept "under-target when queue empty" as the steady state and skip the `[info]` escalation, or (c) open a T5 / defer-later bucket so the orchestrator has fill-window targets during steady-state calendar gaps. Context: we now have ~4 consecutive runs finishing under 20% of cap.
+
+---
+## Your Response
+(Edit this section. Run dev/run.sh after editing to start the next session.)

--- a/dev/health/2026-04-22-fast-run3.md
+++ b/dev/health/2026-04-22-fast-run3.md
@@ -1,0 +1,19 @@
+# Health Report -- 2026-04-22 -- fast (run 3)
+
+## Summary
+- Main build: PASSING (exit 0)
+- Status file integrity: PASSING (exit 0)
+- Action required: NO
+
+## Metrics
+- Checks run: 2 (deterministic; no agentic fast scan)
+- Advisory linter output: not checked here -- covered by `dune runtest` exit code
+- Deep scan: see `dev/health/*-deep.md` (weekly GHA cron)
+
+## Detail
+
+- `dev/lib/run-in-env.sh dune build && dev/lib/run-in-env.sh dune runtest` → exit 0
+  (post-#496 merge on main; Tiered loader parity still green: `Summary=19 Full=3` at
+  end of simulator run across both Legacy + Tiered passes).
+- `dev/lib/run-in-env.sh sh devtools/checks/status_file_integrity.sh` → exit 0
+  (`OK: all dev/status/*.md files have required fields.`).

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,7 +4,7 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-22 run-2 (orchestrator reconcile post-dispatch: PR #492 F2 tail_days fix merged at 01:04Z; PR #493 POSIX-sh linter merged at 01:04Z; PR #495 cost-capture new-day fix merged at 01:46Z (human-driven CI fix). This run dispatched feat-backtest on 3h nightly A/B trace comparison — PR #496 open, QC APPROVED (structural + behavioral, quality 5/5), awaiting human merge. Main baseline green.)
+Last updated: 2026-04-22 run-3 (orchestrator reconcile post-prior-run merge wave: PR #496 3h nightly A/B compare merged 03:38Z; PR #498 activated tiered-loader-ab workflow via `git mv` to `.github/workflows/` at 03:41Z; PR #499 orchestrator cost-capture post-run commit + auto-merge at 03:50Z; all human-merged between run-2 and this run. Run-3: no dispatches — queue fully saturated, next backtest-scale increment gated on empirical nightly A/B data (first nightly fires 04:17Z tonight). Main baseline green (build + runtest + status-integrity all exit 0).)
 
 ## Active + complete tracks
 
@@ -14,15 +14,15 @@ Each row: one line; deeper task detail in the linked status file.
 | Track | Status | Owner | Open PR(s) | Next task |
 |---|---|---|---|---|
 | [backtest-infra](backtest-infra.md) | MERGED | — | — | — (#419 per-phase tracing merged 2026-04-19) |
-| [backtest-scale](backtest-scale.md) | IN_PROGRESS | feat-backtest | #496 | PR #496 awaiting-merge — 3h nightly A/B trace comparison (GHA workflow + POSIX-sh compare script; workflow staged in `dev/ci-staging/` pending human `git mv` at merge due to bot token lacking `workflow` scope). 3g parity test (#484) and F2 tail_days fix (#492) both merged 2026-04-22. Post-merge: human activates workflow via 1-line `git mv`; then flip `loader_strategy` default Legacy→Tiered; then retire Legacy codepath. |
+| [backtest-scale](backtest-scale.md) | IN_PROGRESS | feat-backtest | — | PRs #496 (3h A/B compare) + #498 (workflow activation via `git mv` to `.github/workflows/`) both merged 2026-04-22. 3g parity test (#484) + F2 tail_days fix (#492) both already on main. Nightly tiered-loader-ab cron now live (04:17 UTC). Next: accumulate a few nights of nightly A/B output before flipping `loader_strategy` default Legacy→Tiered in a ~20-line follow-up PR; then retire Legacy codepath. No dispatch this run — increment gated on empirical A/B data. |
 | [support-floor-stops](support-floor-stops.md) | MERGED | — | — | — (PRs #382 primitive + #390 wiring both merged 2026-04-17) |
 | [short-side-strategy](short-side-strategy.md) | MERGED | — | — | — (#420 merged 2026-04-19). Follow-ups carried to own tracks: bear-window backtest regression, full short cascade, Ch.11 behavioural spot-check. |
 | [strategy-wiring](strategy-wiring.md) | MERGED | — | — | — (#408 + #409 both merged 2026-04-18) |
 | [sector-data](sector-data.md) | MERGED | — | — | — (#436 merged 2026-04-19). GHA orchestrator runs continue to consume `trading/test_data/sectors.csv`. |
-| [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | No open harness PR. Recent merges: #493 POSIX-sh linter (today), #495 cost-capture new-day fix (today, human). Backlog remains saturated — T1 done; T2 milestone-gated; T3-C superseded; T3-H low-priority. Stale follow-up `.claude/worktrees/` already resolved (present in `.gitignore` line 49). |
+| [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | No open harness PR. Recent merges: #493 POSIX-sh linter (2026-04-22 run-1), #495 cost-capture new-day fix (2026-04-22 human-driven), #499 cost-capture commit+auto-merge (2026-04-22 03:50Z). Backlog remains saturated — T1 done; T2 milestone-gated; T3-C superseded; T3-H low-priority. Stale follow-up `.claude/worktrees/` already resolved (present in `.gitignore` line 49). |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Phase 1 live (daily cron runs producing summary PRs). Phase 2 (background execution for scrapers, golden re-runs, cross-feature QC) pending empirical tests per status file. |
 | [cleanup](cleanup.md) | IN_PROGRESS | code-health | — | Backlog remains empty (no new medium/high findings from latest deep scan or today's fast health check). No code-health dispatch this run. |
-| [cost-tracking](cost-tracking.md) | IN_PROGRESS | harness-maintainer | — | GHA cost capture step landed (#483). Cost-capture new-day bug fixed today via #495 (human-driven). Next: verify measured `total_cost_usd` on next full-pass GHA run; compare costs pre/post #481/#482/#495. |
+| [cost-tracking](cost-tracking.md) | IN_PROGRESS | harness-maintainer | — | GHA cost capture step landed (#483). Cost-capture new-day bug fixed via #495 + #499 (both 2026-04-22). Next: verify measured `total_cost_usd` now lands correctly on this run's `dev/budget/2026-04-22-run3.json`; compare costs pre/post #481/#482/#495/#499. |
 | [data-layer](data-layer.md) | MERGED | — | — | — |
 | [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |
 | [screener](screener.md) | MERGED | — | — | — |

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -1,13 +1,13 @@
 # Status: backtest-scale
 
-## Last updated: 2026-04-22
+## Last updated: 2026-04-22 (run-3 reconcile: #496 + #498 both merged; nightly A/B workflow live)
 
 ## Status
-READY_FOR_REVIEW
+IN_PROGRESS
 
-structural_qc: APPROVED (2026-04-20) — feat/backtest-scale-3e SHA c51d42bee97618ab3b67679943094fc20baa66d3. All hard gates pass. See dev/reviews/backtest-scale.md.
+structural_qc: APPROVED (2026-04-22 run-2) — feat/backtest-scale-3h; merged as #496. See dev/reviews/backtest-scale-3h.md.
 
-Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447; 3d (tracer phases) merged as #452; 3e (runner + scenario plumbing for `loader_strategy`) merged as #459; 3f-part1 (shadow_screener adapter) merged as #463; 3f-part2 (tiered runner skeleton) merged as #466; 3f-part3a (refactor-only Tiered_runner extraction) merged as #477; 3f-part3b (Tiered runner Friday cycle + per-transition promote/demote) merged as #478; F2 (Summary tail_days fix) merged as #492. 3g (parity acceptance test) merged earlier in the sequence; 3h (nightly A/B comparison) on `feat/backtest-scale-3h` — ready for review.
+Plan `dev/plans/backtest-tiered-loader-2026-04-19.md` reviewed + open questions resolved (2026-04-19). 3a (Metadata) merged; 3b-i (Summary_compute) merged; 3b-ii (Summary tier wiring) merged as #445; 3c (Full tier) merged as #447; 3d (tracer phases) merged as #452; 3e (runner + scenario plumbing for `loader_strategy`) merged as #459; 3f-part1 (shadow_screener adapter) merged as #463; 3f-part2 (tiered runner skeleton) merged as #466; 3f-part3a (refactor-only Tiered_runner extraction) merged as #477; 3f-part3b (Tiered runner Friday cycle + per-transition promote/demote) merged as #478; F2 (Summary tail_days fix) merged as #492; 3g (parity acceptance test) merged as #484; **3h (nightly A/B comparison) merged as #496 on 2026-04-22**; **workflow activated as `.github/workflows/tiered-loader-ab.yml` via #498 (2026-04-22)** — first nightly run fires at 04:17 UTC tonight. Next merge-gate increment: flip `loader_strategy` default Legacy→Tiered (~20-line PR) after a few nights of clean nightly A/B data confirms parity + savings.
 
 ## Interface stable
 NO
@@ -15,35 +15,19 @@ NO
 All three tier getters return their proper typed option: `get_metadata : Metadata.t option`, `get_summary : Summary.t option`, `get_full : Full.t option`. Core `Bar_loader.create` / `promote` / `demote` / `tier_of` / `stats` signatures remain stable; `create` gained optional `?full_config` in 3c and `?trace_hook` in 3d. Remaining churn will come from 3e (runner wiring) and 3f (tiered runner path).
 
 ## Open PR
-- feat/backtest-scale-3h — 3h nightly A/B trace comparison. Ships
-  `dev/scripts/tiered_loader_ab_compare.sh` (POSIX sh) + staged GHA
-  workflow at `dev/ci-staging/tiered-loader-ab.yml`. The script runs a
-  single scenario twice under `--loader-strategy legacy` and
-  `--loader-strategy tiered` via `backtest_runner.exe` and diffs the
-  resulting `trades.csv` / `summary.sexp` output trees. Hard gate on
-  trade-count diff; warn annotation on portfolio-value drift above
-  `max($1.00, 0.001% of legacy_pv)` per plan §Resolutions #1. Workflow
-  runs the compare against 3 broad goldens (bull-crash-2015-2020,
-  covid-recovery-2020-2024, six-year-2018-2023) nightly at 04:17 UTC,
-  uploads all output trees as a 30-day artefact. POSIX-sh linter
-  extended to scan `dev/scripts/` so the new script is covered by the
-  `dash -n` gate. Smoke-verified on `smoke/tiered-loader-parity.sexp`:
-  both strategies produce 3 trades / identical $1,096,397.65 final PV
-  (PV delta $0.00, within $10.96 warn threshold). Ready for QC.
+- None. 3h (#496) + workflow activation (#498) both merged 2026-04-22.
 
 ## Blocked on
-- **`.github/workflows/tiered-loader-ab.yml` manual install required at merge.**
-  The feat-backtest agent's GitHub token lacks the `workflow` scope, so
-  `.github/workflows/*.yml` paths are rejected by the remote with
-  "refusing to allow a Personal Access Token to create or update
-  workflow ... without `workflow` scope". The workflow content ships
-  in this PR as `dev/ci-staging/tiered-loader-ab.yml`; at merge time (or
-  as a tiny follow-up PR from a human or workflow-scoped agent) run
-  `git mv dev/ci-staging/tiered-loader-ab.yml .github/workflows/tiered-loader-ab.yml`
-  to activate the nightly schedule. Until then, the script
-  (`dev/scripts/tiered_loader_ab_compare.sh`) is fully functional and
-  can be invoked manually via `sh dev/scripts/tiered_loader_ab_compare.sh
-  <scenario> <out>`.
+- **Next increment (flip `loader_strategy` default Legacy→Tiered) is
+  gated on empirical nightly A/B data.** The tiered-loader-ab workflow
+  fires at 04:17 UTC on the nightly cron; the first run lands tonight.
+  Waiting for a few nights of clean runs (trade-count parity hard gate
+  + PV drift inside the warn threshold) before flipping the default is
+  a conservative safety policy — the parity test (#484) already pins
+  identical output per-bar on the smoke scenario, but the broad golden
+  scenarios exercise a much wider strategy surface. Holds rather than
+  dispatches this run; re-evaluate after ~3 consecutive clean nightly
+  runs.
 
 ## Goal
 


### PR DESCRIPTION
Automated daily orchestrator run (run-3). See `dev/daily/2026-04-22-run3.md` for the full summary.

Zero-dispatch run — queue fully processed after run-2's work landed. Next backtest-scale increment (flip `loader_strategy` default) is empirically gated on tonight's nightly A/B data. Main baseline green.