### PR TITLE
ops: add consolidated summary 2026-04-22

### DIFF
--- a/dev/daily/2026-04-22-summary.md
+++ b/dev/daily/2026-04-22-summary.md
@@ -1,0 +1,61 @@
+# Consolidated Summary — 2026-04-22
+Runs included: run-1, run-2, run-3 (3 total)
+Generated: 2026-04-22T06:13:03Z
+
+## Pending work (from last run)
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| backtest-scale | blocked | — | — | Next increment (flip `loader_strategy` default Legacy→Tiered) gated on empirical nightly A/B data. First nightly run fires 04:17 UTC tonight; re-evaluate after ~3 clean nightly runs. |
+| harness | skipped (no-change) | — | — | Backlog saturated — T1 done; T2 milestone-gated (M5/M6/M7); T3-C superseded; T3-H low-priority. No eligible target today. |
+| orchestrator-automation | blocked | — | — | Phase 2 empirical tests complete; remaining work is rollout of three concrete wins (scrapers, golden re-runs, cross-feature QC) plus per-agent isolated worktrees in the GHA path — all human-scoped scheduling decisions. |
+| cleanup | skipped (no-change) | — | — | Backlog empty; no new medium/high findings in today's fast health scan (only build + integrity checks run, both green). |
+| cost-tracking | skipped (no-change) | — | — | Observational track. #495 + #499 closed the new-day capture bug; verification signal is the presence of `dev/budget/2026-04-22-run3.json` after this run. |
+| ops-data | skipped (no-change) | — | — | `dev/notes/data-gaps.md` unchanged since 2026-04-14 sentinel. |
+
+## Dispatched across all runs (deduped)
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| backtest-scale | feat-backtest | completed | F2 diagnosed: `Summary_compute.compute_values` returned None because `default_config.tail_days=250` but Mansfield RS needs 52×7=420 calendar days. Fix: bumped default to 420 + regression test. PR #492. |
+| harness | harness-maintainer | completed | Added `posix_sh_check.sh` with `dash -n` over 40 #!/bin/sh scripts; 3-assertion smoke test; wired into dune runtest. PR #493. |
+| backtest-scale | qc-structural | APPROVED | Clean structural — focused diff, reproducible regression test, no core module impact |
+| backtest-scale | qc-behavioral | APPROVED | Quality score: 4. Domain-correct: matches Mansfield 52-week lookback documented in weinstein-book-reference.md §6. |
+| harness | qc-structural | APPROVED | Quality score: 4. Harness utility, behavioral QC skipped (no domain logic). |
+| ops-data | ops-data | skipped | dev/notes/data-gaps.md unchanged since last run |
+| cleanup | code-health | skipped | `dev/status/cleanup.md` §Backlog empty; no new medium/high findings from 2026-04-22-fast health scan |
+| orchestrator-automation | — | skipped | Phase 2 is human-only (requires empirical tests) |
+| — (audit) | — | written | `dev/audit/2026-04-22-backtest-scale-3h.json` — overall APPROVED, quality 5, consecutive_rework_count 0. |
+| harness | — | skipped | No eligible follow-up: `.claude/worktrees/` gap already resolved in `.gitignore:49`; "Orchestrator daily summary drifts" follow-up is medium-risk (edits orchestrator itself); other open items are milestone-gated or marked superseded/low-priority. |
+| ops-data | — | skipped | `dev/notes/data-gaps.md` sentinel unchanged since 2026-04-14. |
+| cleanup | — | skipped | `dev/status/cleanup.md` §Backlog empty; no new medium/high findings in `dev/health/2026-04-22-fast-run2.md`. |
+| — | — | — | No dispatches this run. |
+| backtest-scale | — | skipped | Next increment (flip-default) explicitly gated on nightly A/B data per status §Next Steps item 3 and run-2 Question 3. First nightly cron fires 04:17 UTC tonight — defer until data lands. Not a reviewer-queue concern; a genuine empirical block. |
+
+## QC across all runs
+- backtest-scale: APPROVED (structural + behavioral, quality 4) — see `dev/reviews/backtest-scale.md`
+- harness: APPROVED (structural, behavioral NA — harness utility, quality 4) — see `dev/reviews/harness.md`
+- backtest-scale-3h: APPROVED (structural + behavioral, quality 5/5) — see `dev/reviews/backtest-scale-3h.md`; audit at `dev/audit/2026-04-22-backtest-scale-3h.json`.
+- No QC runs this cycle (no dispatches). Last QC artifacts on main:
+
+## Budget (summed across runs)
+- Total subagents spawned: 8
+- Killed mid-flight: None reported across all runs.
+
+## Escalations (merged)
+- [info] Carried-forward verification: no still-real `[critical]` items from 2026-04-21-run4; main green (exit 0) on post-#491 tip `5502f0f` (seen in: run-1,run-2,run-3)
+- [info] Utilization 18% is under the 60% target because the eligible queue is near-saturated (only two non-blocked IN_PROGRESS tracks had actionable next steps). Not a skip issue — all eligible tracks dispatched. See `## Budget` Utilization assessment.
+- [info] Under-target utilization (~8% of $50). Root cause: eligible queue is saturated beyond one dispatch. backtest-scale's next increment (flip-default) is gated on #496 producing real nightly-A/B data, which requires human to `git mv` the workflow first. No new harness targets at today's backlog. Not actionable by the orchestrator.
+- [info] PR #496's workflow is staged at `dev/ci-staging/tiered-loader-ab.yml` rather than `.github/workflows/`. This is a **persistent constraint**, not a one-off: the bot GitHub App / PAT installation lacks `workflow` scope. Options: (a) widen the PAT scope once (human one-time), (b) accept the one-line `git mv` ritual on every GHA-workflow-touching PR, (c) teach a harness item to flag this on PR open. Today's workaround (staging + doc) is fine for merge; medium-term decision deferred.
+- [info] Zero-dispatch run. Root cause: the queue is genuinely processed — run-2 landed the last dispatchable item (3h compare, #496), the human merged it + its activation (#498) + a cost-capture follow-on (#499) between run-2 and this run, and the next backtest-scale increment (flip-default) is gated on empirical nightly A/B data that starts accumulating tonight. Utilization ~1% of cap. Not actionable by the orchestrator; a no-op run is the correct output when no track is eligible.
+- [info] `dev/status/_index.md` reconciled this run to reflect #496/#498/#499 all merged on 2026-04-22. `dev/status/backtest-scale.md` flipped from `READY_FOR_REVIEW` to `IN_PROGRESS` with `Open PR: None` now that 3h is merged.
+
+## Integration Queue (last run's view)
+
+No open PRs; integration queue empty. All three PRs awaiting merge at the end of run-2 (and the one that opened between run-1 and run-2) are now on main (#496, #498, #499).
+
+Auto-merge remains disabled (`auto_merge_enabled: false` in `dev/config/merge-policy.json`) for feature PRs; the orchestrator's own summary PRs auto-merge per Step 8a.
+
+## Per-run links
+- run-1 -> `2026-04-22.md`
+- run-2 -> `2026-04-22-run2.md`
+- run-3 -> `2026-04-22-run3.md`


### PR DESCRIPTION
Per lead-orchestrator Step 8b — N >= 3, write consolidated same-day summary merging runs 1, 2, and 3 into `dev/daily/2026-04-22-summary.md`.

Follow-up to PR #500 (run-3 summary); landed as a separate PR because the run-3 summary auto-merged before consolidation was generated.