### PR TITLE
ops: daily orchestrator summary 2026-04-22-run4

### DIFF
--- a/dev/daily/2026-04-22-run4.md
+++ b/dev/daily/2026-04-22-run4.md
@@ -1,0 +1,100 @@
+# Status — 2026-04-22 [run 4]
+
+**Run ID:** 2026-04-22-run-4
+**Run timestamp:** 2026-04-22T10:50:00Z
+**Mode:** NO-OP (saturated-queue fast-exit)
+
+## Saturated-queue check result
+
+All four Step 0.5 conditions passed — no dispatch this run:
+
+- **Condition 1** PASS — 0 open PRs on `origin` (vacuously: no `tip_sha != last_review_sha` drift possible).
+- **Condition 2** PASS — no `dev/status/*.md` changes since prior summary (checked via
+  `git log --since=<PREV_ISO> --name-only -- dev/status/ | grep -v '^ops: daily orchestrator summary '`; 0 matches).
+  Only commits on main since prior summary were #500 (run-3 summary) and #501 (consolidated summary), both exempt.
+- **Condition 3** PASS — no `[drift]` warnings from Step 1b. Prior summary (run-3)
+  had only `blocked` / `skipped` rows in §Pending work; earlier runs (run-1) had
+  `awaiting-merge` rows for PRs #492 and #493, both now merged on `main@origin`
+  (normal lag, not drift per Step 1b spec).
+- **Condition 4** PASS — `dev/status/harness.md` and `dev/status/cleanup.md` unchanged
+  since prior summary (0 commits touching either since `PREV_ISO`).
+
+First-run escape hatch not triggered (run-1 through run-3 already ran today).
+
+## Step 1c carried-forward critical verification
+
+No still-real `[critical]` items inherited from run-3 (run-3 §Escalations were all
+`[info]`). Main baseline independently re-verified green this run:
+`dune runtest` exit 0 on post-#501 tip `cd2e3ec`; `status_file_integrity.sh` exit 0.
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| — | — | — | No dispatches this run (NO-OP — queue state unchanged since run-3 exit). |
+
+## Pending work
+
+(Carried forward from run-3 — no changes; consolidation view at `dev/daily/2026-04-22-summary.md`.)
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| backtest-scale | blocked | — | — | Flip `loader_strategy` default Legacy→Tiered gated on empirical nightly A/B data. First nightly cron fires 04:17 UTC tonight; re-evaluate after ~3 clean nightly runs. |
+| harness | skipped (no-change) | — | — | Backlog saturated — T1 done; T2 milestone-gated (M5/M6/M7); T3-C superseded; T3-H low-priority. |
+| orchestrator-automation | blocked | — | — | Phase 2 scheduling decisions are human-scoped. |
+| cleanup | skipped (no-change) | — | — | Backlog empty; no new medium/high findings. |
+| cost-tracking | skipped (no-change) | — | — | Observational track. |
+| ops-data | skipped (no-change) | — | — | `dev/notes/data-gaps.md` sentinel unchanged since 2026-04-14. |
+
+## QC Status
+
+(Carried forward — no QC activity this run.)
+
+- No QC runs this cycle (no dispatches). Last QC artifacts on main:
+  - backtest-scale-3h: APPROVED (structural + behavioral, quality 5/5) — `dev/reviews/backtest-scale-3h.md`; audit `dev/audit/2026-04-22-backtest-scale-3h.json`.
+
+## Budget
+
+- Budget cap: $50.00 (from `dev/config/merge-policy.json`)
+- Target utilization: 60%–80%
+- Subagents spawned: 0 this run (pure state-read + summary write)
+- Per-subagent breakdown: none.
+
+**Measured cost (from GHA execution file):** `dev/budget/2026-04-22-run4.json` will be
+written by the GHA "Capture run cost" step after this run exits.
+
+- Total (estimated): ~$0.50 orchestrator overhead only, no subagents = **~$0.50 / $50 (1%)**
+- Utilization assessment: UNDER_TARGET (<60%) — **all-work-done**: every eligible
+  track re-evaluated this run, state unchanged since run-3, fast-exit fired correctly.
+  Not actionable by the orchestrator; a NO-OP is the correct output when the queue
+  is fully processed and no new drift has appeared.
+- Scope reduced due to budget: No.
+
+## Escalations
+
+- [info] Zero-dispatch NO-OP run via Step 0.5 fast-exit. Same root cause as run-3:
+  the queue is genuinely processed — run-2 landed the last dispatchable item (3h
+  compare, #496), run-3 plus the intervening human merges (#498, #499, #501)
+  closed out everything mergeable, and the next backtest-scale increment
+  (flip-default) is gated on empirical nightly A/B data that starts accumulating
+  tonight (first nightly cron fires 04:17 UTC, ~5.5h from now). Utilization ~1%
+  of cap. Ideal outcome for a saturated queue — fast-exit validated working.
+- [info] Carried-forward verification: no still-real `[critical]` items from run-3.
+  Main green — `dune runtest` exit 0 on post-#501 tip `cd2e3ec` (verified this run).
+
+## Integration Queue
+
+(Carried forward from run-3 — unchanged.)
+
+No open PRs; integration queue empty.
+
+Auto-merge remains disabled (`auto_merge_enabled: false` in `dev/config/merge-policy.json`)
+for feature PRs; the orchestrator's own summary PRs auto-merge per Step 8a.
+
+## Per-run links
+
+- [run 1] `dev/daily/2026-04-22.md`
+- [run 2] `dev/daily/2026-04-22-run2.md`
+- [run 3] `dev/daily/2026-04-22-run3.md`
+- [run 4] `dev/daily/2026-04-22-run4.md` (this file)
+- [consolidated] `dev/daily/2026-04-22-summary.md` (refreshed this run per Step 8b)

--- a/dev/daily/2026-04-22-summary.md
+++ b/dev/daily/2026-04-22-summary.md
@@ -1,17 +1,19 @@
 # Consolidated Summary — 2026-04-22
-Runs included: run-1, run-2, run-3 (3 total)
-Generated: 2026-04-22T06:13:03Z
+Runs included: run-1, run-2, run-3, run-4 (4 total)
+Generated: 2026-04-22T10:52:28Z
 
 ## Pending work (from last run)
 
+(Carried forward from run-3 — no changes; consolidation view at `dev/daily/2026-04-22-summary.md`.)
+
 | Track | State | Branch | PR | Next step |
 |-------|-------|--------|----|-----------|
-| backtest-scale | blocked | — | — | Next increment (flip `loader_strategy` default Legacy→Tiered) gated on empirical nightly A/B data. First nightly run fires 04:17 UTC tonight; re-evaluate after ~3 clean nightly runs. |
-| harness | skipped (no-change) | — | — | Backlog saturated — T1 done; T2 milestone-gated (M5/M6/M7); T3-C superseded; T3-H low-priority. No eligible target today. |
-| orchestrator-automation | blocked | — | — | Phase 2 empirical tests complete; remaining work is rollout of three concrete wins (scrapers, golden re-runs, cross-feature QC) plus per-agent isolated worktrees in the GHA path — all human-scoped scheduling decisions. |
-| cleanup | skipped (no-change) | — | — | Backlog empty; no new medium/high findings in today's fast health scan (only build + integrity checks run, both green). |
-| cost-tracking | skipped (no-change) | — | — | Observational track. #495 + #499 closed the new-day capture bug; verification signal is the presence of `dev/budget/2026-04-22-run3.json` after this run. |
-| ops-data | skipped (no-change) | — | — | `dev/notes/data-gaps.md` unchanged since 2026-04-14 sentinel. |
+| backtest-scale | blocked | — | — | Flip `loader_strategy` default Legacy→Tiered gated on empirical nightly A/B data. First nightly cron fires 04:17 UTC tonight; re-evaluate after ~3 clean nightly runs. |
+| harness | skipped (no-change) | — | — | Backlog saturated — T1 done; T2 milestone-gated (M5/M6/M7); T3-C superseded; T3-H low-priority. |
+| orchestrator-automation | blocked | — | — | Phase 2 scheduling decisions are human-scoped. |
+| cleanup | skipped (no-change) | — | — | Backlog empty; no new medium/high findings. |
+| cost-tracking | skipped (no-change) | — | — | Observational track. |
+| ops-data | skipped (no-change) | — | — | `dev/notes/data-gaps.md` sentinel unchanged since 2026-04-14. |
 
 ## Dispatched across all runs (deduped)
 | Track | Agent | Outcome | Notes |
@@ -42,20 +44,25 @@ Generated: 2026-04-22T06:13:03Z
 - Killed mid-flight: None reported across all runs.
 
 ## Escalations (merged)
-- [info] Carried-forward verification: no still-real `[critical]` items from 2026-04-21-run4; main green (exit 0) on post-#491 tip `5502f0f` (seen in: run-1,run-2,run-3)
+- [info] Carried-forward verification: no still-real `[critical]` items from 2026-04-21-run4; main green (exit 0) on post-#491 tip `5502f0f` (seen in: run-1,run-2,run-3,run-4)
 - [info] Utilization 18% is under the 60% target because the eligible queue is near-saturated (only two non-blocked IN_PROGRESS tracks had actionable next steps). Not a skip issue — all eligible tracks dispatched. See `## Budget` Utilization assessment.
 - [info] Under-target utilization (~8% of $50). Root cause: eligible queue is saturated beyond one dispatch. backtest-scale's next increment (flip-default) is gated on #496 producing real nightly-A/B data, which requires human to `git mv` the workflow first. No new harness targets at today's backlog. Not actionable by the orchestrator.
 - [info] PR #496's workflow is staged at `dev/ci-staging/tiered-loader-ab.yml` rather than `.github/workflows/`. This is a **persistent constraint**, not a one-off: the bot GitHub App / PAT installation lacks `workflow` scope. Options: (a) widen the PAT scope once (human one-time), (b) accept the one-line `git mv` ritual on every GHA-workflow-touching PR, (c) teach a harness item to flag this on PR open. Today's workaround (staging + doc) is fine for merge; medium-term decision deferred.
 - [info] Zero-dispatch run. Root cause: the queue is genuinely processed — run-2 landed the last dispatchable item (3h compare, #496), the human merged it + its activation (#498) + a cost-capture follow-on (#499) between run-2 and this run, and the next backtest-scale increment (flip-default) is gated on empirical nightly A/B data that starts accumulating tonight. Utilization ~1% of cap. Not actionable by the orchestrator; a no-op run is the correct output when no track is eligible.
 - [info] `dev/status/_index.md` reconciled this run to reflect #496/#498/#499 all merged on 2026-04-22. `dev/status/backtest-scale.md` flipped from `READY_FOR_REVIEW` to `IN_PROGRESS` with `Open PR: None` now that 3h is merged.
+- [info] Zero-dispatch NO-OP run via Step 0.5 fast-exit. Same root cause as run-3:
 
 ## Integration Queue (last run's view)
 
-No open PRs; integration queue empty. All three PRs awaiting merge at the end of run-2 (and the one that opened between run-1 and run-2) are now on main (#496, #498, #499).
+(Carried forward from run-3 — unchanged.)
 
-Auto-merge remains disabled (`auto_merge_enabled: false` in `dev/config/merge-policy.json`) for feature PRs; the orchestrator's own summary PRs auto-merge per Step 8a.
+No open PRs; integration queue empty.
+
+Auto-merge remains disabled (`auto_merge_enabled: false` in `dev/config/merge-policy.json`)
+for feature PRs; the orchestrator's own summary PRs auto-merge per Step 8a.
 
 ## Per-run links
 - run-1 -> `2026-04-22.md`
 - run-2 -> `2026-04-22-run2.md`
 - run-3 -> `2026-04-22-run3.md`
+- run-4 -> `2026-04-22-run4.md`


### PR DESCRIPTION
Automated daily orchestrator run (run-4). See `dev/daily/2026-04-22-run4.md` for the full summary.

NO-OP run via Step 0.5 saturated-queue fast-exit — all four conditions passed, zero subagents dispatched. Next backtest-scale increment (flip `loader_strategy` default Legacy→Tiered) is empirically gated on nightly A/B data that starts accumulating 04:17 UTC tonight. Main baseline green.