### PR TITLE
ops: daily orchestrator summary 2026-04-22-run5

### DIFF
--- a/dev/daily/2026-04-22-run5.md
+++ b/dev/daily/2026-04-22-run5.md
@@ -1,0 +1,181 @@
+# Status — 2026-04-22 [run 5]
+
+**Run ID:** 2026-04-22-run-5
+**Run timestamp:** 2026-04-22T15:51:14Z
+**Mode:** Inline orchestrator fix (status-file integrity drift) — no subagent dispatch
+
+## Step 0.5 saturated-queue check result
+
+The four nominal Step 0.5 conditions all PASS in the strict letter:
+
+- **Condition 1** PASS — 0 open PRs on `origin` (vacuously: no `tip_sha != last_review_sha` drift possible).
+- **Condition 2** PASS — no `dev/status/*.md` commits since prior summary
+  (only commit since run-4 was `45ab602` orchestrator summary 2026-04-22-run4 (#502),
+  which is exempt per Step 0.5 rule).
+- **Condition 3** PASS — no `[drift]` warnings from Step 1b. Run-4 had only `blocked` /
+  `skipped` rows in §Pending work, no `dispatched`/`awaiting-merge` rows.
+- **Condition 4** PASS — `dev/status/harness.md` and `dev/status/cleanup.md` unchanged
+  since prior summary (0 commits touching either since `2026-04-22T10:50:00Z`).
+
+**However**, this run did NOT take the fast-exit path. While preparing the
+Step 1c live-evidence verification, `bash dev/lib/run-in-env.sh dune runtest --force`
+exited 1, revealing that main was actually RED on entry — a status-file-integrity
+schema drift that the four Step 0.5 conditions do not detect (drift was
+introduced inside the prior orchestrator's own summary commit, which is exempt
+from Condition 2). Surfacing and fixing the drift inline is described below;
+see also `[info]` escalation about the broader Step 0.5 gap.
+
+## Step 1c carried-forward critical verification
+
+Run-4 §Escalations had no `[critical]` items (only two `[info]`), so no
+inherited critical to verify. **However**, an independent
+`dune runtest --force` invocation this run surfaced a NEW critical:
+
+```
+(cd _build/default/devtools/checks && /usr/bin/sh status_file_integrity.sh)
+FAIL: status file integrity linter — malformed or missing fields in dev/status/:
+backtest-scale.md: '## Last updated' is not YYYY-MM-DD: '2026-04-22 (run-3 reconcile: #496 + #498 both merged; nightly A/B workflow live)'
+
+Schema: ## Status (IN_PROGRESS|READY_FOR_REVIEW|APPROVED|MERGED|BLOCKED|PENDING),
+        ## Last updated: YYYY-MM-DD,
+        ## Interface stable (YES|NO|N/A) — required except for: harness.md backtest-infra.md
+        (N/A for Interface stable only valid when Status is PENDING)
+```
+
+(exit 1 on the full `dune runtest --force` invocation, captured this run on
+post-#502 tip `45ab602`.)
+
+Root cause: run-3's auto-merged orchestrator summary commit `db2c449` rewrote
+`dev/status/backtest-scale.md` `## Last updated:` from a bare date into a
+multi-clause narrative; the integrity linter (wired into `dune runtest` via
+`trading/devtools/checks/dune` lines 93–97) requires `YYYY-MM-DD` only. Run-4
+was a Step 0.5 NO-OP fast-exit, so it skipped Step 6 (`dune build && runtest`)
+and the drift slipped through to today.
+
+**Inline fix** (deterministic edit by orchestrator, scope=1 line, no agent
+dispatch): `dev/status/backtest-scale.md` `## Last updated:` line scrubbed to
+the bare date `2026-04-22`. The orchestrator is the canonical writer of
+`## Last updated:` per Step 5.5 ("Flip the per-track `## Status` to `MERGED`
+(and update its `## Last updated:`)"), so the edit lands in the orchestrator's
+own summary PR rather than dispatching `code-health`.
+
+Post-fix re-verification this run:
+- `bash dev/lib/run-in-env.sh sh devtools/checks/status_file_integrity.sh` exit 0
+  (`OK: all dev/status/*.md files have required fields.`).
+- `bash dev/lib/run-in-env.sh dune runtest --force` exit 0; zero `FAIL:` lines
+  in stdout; full suite (~80 test binaries + all linters + `fmt_check`) green.
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| backtest-scale | — | inline fix (no dispatch) | scrubbed parenthetical from `dev/status/backtest-scale.md` `## Last updated:` to satisfy `status_file_integrity.sh` schema (orchestrator-owned per Step 5.5); main re-verified green. |
+| (all other tracks) | — | skipped (no-change) | queue saturated; same state as run-4. See §Pending work. |
+
+No subagent dispatched. No QC pipeline runs (no PRs to review).
+
+## Pending work
+
+Carried forward from run-4 — no changes (queue state identical to run-4 modulo
+the inline fix above).
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| backtest-scale | blocked | — | — | Flip `loader_strategy` default Legacy→Tiered gated on empirical nightly A/B data. Tiered-loader-ab cron (04:17 UTC) fired at least once since run-4 — re-evaluate after ~3 clean nightly runs. |
+| harness | skipped (no-change) | — | — | Backlog saturated — T1 done; T2 milestone-gated (M5/M6/M7); T3-C superseded; T3-H low-priority. |
+| orchestrator-automation | blocked | — | — | Phase 2 scheduling decisions are human-scoped. |
+| cleanup | skipped (no-change) | — | — | Backlog empty; no new medium/high findings. |
+| cost-tracking | skipped (no-change) | — | — | Observational track. |
+| ops-data | skipped (no-change) | — | — | `dev/notes/data-gaps.md` sentinel unchanged since 2026-04-14. |
+
+## QC Status
+
+(Carried forward — no QC activity this run.)
+
+- No QC runs this cycle (no dispatches). Last QC artifacts on main:
+  - backtest-scale-3h: APPROVED (structural + behavioral, quality 5/5) — `dev/reviews/backtest-scale-3h.md`; audit `dev/audit/2026-04-22-backtest-scale-3h.json`.
+
+## Health Scan
+
+(From `dev/health/2026-04-22-fast-run5.md`.)
+
+- Result: FINDINGS-then-CLEAN — drift detected on entry (status_file_integrity
+  failure), fixed inline this run, re-verified clean.
+- Critical items: 1 detected and resolved this run. None outstanding.
+
+## Budget
+
+- Budget cap: $50.00 (from `dev/config/merge-policy.json`)
+- Target utilization: 60%–80%
+- Subagents spawned: 0 this run (state-read + integrity verify + 1-line status
+  edit + summary write).
+- Per-subagent breakdown: none.
+
+**Measured cost (from GHA execution file):** `dev/budget/2026-04-22-run5.json`
+will be written by the GHA "Capture run cost" step after this run exits.
+
+- Total (estimated): ~$0.50 orchestrator overhead + ~$0.20 dune runtest
+  invocation cost = **~$0.70 / $50 (1.4%)**.
+- Utilization assessment: UNDER_TARGET (<60%) — **all-work-done**: every
+  eligible track re-evaluated; queue state unchanged since run-4; only real
+  action this run was the inline integrity fix. Not actionable by the
+  orchestrator.
+- Scope reduced due to budget: No.
+
+## Escalations
+
+- **[critical] (RESOLVED this run)** — Main baseline was RED on entry on tip
+  `45ab602`. Evidence (verbatim from this session's
+  `bash dev/lib/run-in-env.sh dune runtest --force`):
+
+  ```
+  (cd _build/default/devtools/checks && /usr/bin/sh status_file_integrity.sh)
+  FAIL: status file integrity linter — malformed or missing fields in dev/status/:
+  backtest-scale.md: '## Last updated' is not YYYY-MM-DD: '2026-04-22 (run-3 reconcile: #496 + #498 both merged; nightly A/B workflow live)'
+  ```
+  exit=1 on the full dune runtest invocation. Resolved inline this run by
+  scrubbing the offending parenthetical (1-line edit to
+  `dev/status/backtest-scale.md`); re-verified `dune runtest --force` exit 0
+  immediately after. Tagged `[critical]` per the live-evidence rule because
+  evidence was captured in this session, but resolution is in the SAME PR
+  as this summary, so no human follow-up is required to clear the gate.
+
+- **[info] Step 0.5 fast-exit blind to integrity-linter drift introduced by
+  the orchestrator's own summary commits.** The four Step 0.5 conditions
+  guard against external drift (open PRs, status-file commits since prior
+  summary, etc.) but Condition 2 explicitly exempts commits whose subject is
+  `ops: daily orchestrator summary ` — and that's exactly the commit shape
+  that introduced today's drift (run-3 summary commit `db2c449` rewrote the
+  `## Last updated:` line). Run-4 fast-exited and skipped `dune runtest`,
+  so the drift was invisible until today's run independently invoked the
+  build. Possible mitigations for `harness-maintainer` to consider:
+  (a) add a lightweight `status_file_integrity.sh` invocation as a 5th
+  Step 0.5 condition (it runs in <1s with no compilation cost), or
+  (b) tighten the orchestrator's own `## Last updated:` writer (Step 5.5)
+  to enforce bare `YYYY-MM-DD` regardless of incoming text. Either fix is
+  small. Logging here as `[info]` rather than `[critical]` because main is
+  green right now and the same-shape drift requires another orchestrator
+  edit to recur.
+
+- **[info] Carried-forward verification: no still-real `[critical]` items
+  from run-4.** Run-4's two `[info]` escalations both carried forward
+  (queue-saturation context + green-main confirmation); both still apply.
+
+## Integration Queue
+
+(Carried forward from run-4 — unchanged.)
+
+No open PRs; integration queue empty.
+
+Auto-merge remains disabled (`auto_merge_enabled: false` in
+`dev/config/merge-policy.json`) for feature PRs; the orchestrator's own
+summary PRs auto-merge per Step 8a.
+
+## Per-run links
+
+- [run 1] `dev/daily/2026-04-22.md`
+- [run 2] `dev/daily/2026-04-22-run2.md`
+- [run 3] `dev/daily/2026-04-22-run3.md`
+- [run 4] `dev/daily/2026-04-22-run4.md`
+- [run 5] `dev/daily/2026-04-22-run5.md` (this file)
+- [consolidated] `dev/daily/2026-04-22-summary.md` (refreshed this run per Step 8b)

--- a/dev/daily/2026-04-22-summary.md
+++ b/dev/daily/2026-04-22-summary.md
@@ -1,14 +1,15 @@
 # Consolidated Summary — 2026-04-22
-Runs included: run-1, run-2, run-3, run-4 (4 total)
-Generated: 2026-04-22T10:52:28Z
+Runs included: run-1, run-2, run-3, run-4, run-5 (5 total)
+Generated: 2026-04-22T15:58:53Z
 
 ## Pending work (from last run)
 
-(Carried forward from run-3 — no changes; consolidation view at `dev/daily/2026-04-22-summary.md`.)
+Carried forward from run-4 — no changes (queue state identical to run-4 modulo
+the inline fix above).
 
 | Track | State | Branch | PR | Next step |
 |-------|-------|--------|----|-----------|
-| backtest-scale | blocked | — | — | Flip `loader_strategy` default Legacy→Tiered gated on empirical nightly A/B data. First nightly cron fires 04:17 UTC tonight; re-evaluate after ~3 clean nightly runs. |
+| backtest-scale | blocked | — | — | Flip `loader_strategy` default Legacy→Tiered gated on empirical nightly A/B data. Tiered-loader-ab cron (04:17 UTC) fired at least once since run-4 — re-evaluate after ~3 clean nightly runs. |
 | harness | skipped (no-change) | — | — | Backlog saturated — T1 done; T2 milestone-gated (M5/M6/M7); T3-C superseded; T3-H low-priority. |
 | orchestrator-automation | blocked | — | — | Phase 2 scheduling decisions are human-scoped. |
 | cleanup | skipped (no-change) | — | — | Backlog empty; no new medium/high findings. |
@@ -31,7 +32,9 @@ Generated: 2026-04-22T10:52:28Z
 | ops-data | — | skipped | `dev/notes/data-gaps.md` sentinel unchanged since 2026-04-14. |
 | cleanup | — | skipped | `dev/status/cleanup.md` §Backlog empty; no new medium/high findings in `dev/health/2026-04-22-fast-run2.md`. |
 | — | — | — | No dispatches this run. |
-| backtest-scale | — | skipped | Next increment (flip-default) explicitly gated on nightly A/B data per status §Next Steps item 3 and run-2 Question 3. First nightly cron fires 04:17 UTC tonight — defer until data lands. Not a reviewer-queue concern; a genuine empirical block. |
+| backtest-scale | — | skipped | Next increment (flip-default) explicitly gated on nightly A/B data per status §Next Steps item 3 and run-2 Question 3. First nightly cron fires 04:17 UTC tonight — defer until data lands. Not a reviewer-queue concern; a genuine empirical block. (run-3) |
+| backtest-scale | — | inline fix (no dispatch) | scrubbed parenthetical from `dev/status/backtest-scale.md` `## Last updated:` to satisfy `status_file_integrity.sh` schema (orchestrator-owned per Step 5.5); main re-verified green. (run-5) |
+| (all other tracks) | — | skipped (no-change) | queue saturated; same state as run-4. See §Pending work. |
 
 ## QC across all runs
 - backtest-scale: APPROVED (structural + behavioral, quality 4) — see `dev/reviews/backtest-scale.md`
@@ -51,18 +54,23 @@ Generated: 2026-04-22T10:52:28Z
 - [info] Zero-dispatch run. Root cause: the queue is genuinely processed — run-2 landed the last dispatchable item (3h compare, #496), the human merged it + its activation (#498) + a cost-capture follow-on (#499) between run-2 and this run, and the next backtest-scale increment (flip-default) is gated on empirical nightly A/B data that starts accumulating tonight. Utilization ~1% of cap. Not actionable by the orchestrator; a no-op run is the correct output when no track is eligible.
 - [info] `dev/status/_index.md` reconciled this run to reflect #496/#498/#499 all merged on 2026-04-22. `dev/status/backtest-scale.md` flipped from `READY_FOR_REVIEW` to `IN_PROGRESS` with `Open PR: None` now that 3h is merged.
 - [info] Zero-dispatch NO-OP run via Step 0.5 fast-exit. Same root cause as run-3:
+- **[critical] (RESOLVED this run)** — Main baseline was RED on entry on tip
+- **[info] Step 0.5 fast-exit blind to integrity-linter drift introduced by
+- **[info] Carried-forward verification: no still-real `[critical]` items
 
 ## Integration Queue (last run's view)
 
-(Carried forward from run-3 — unchanged.)
+(Carried forward from run-4 — unchanged.)
 
 No open PRs; integration queue empty.
 
-Auto-merge remains disabled (`auto_merge_enabled: false` in `dev/config/merge-policy.json`)
-for feature PRs; the orchestrator's own summary PRs auto-merge per Step 8a.
+Auto-merge remains disabled (`auto_merge_enabled: false` in
+`dev/config/merge-policy.json`) for feature PRs; the orchestrator's own
+summary PRs auto-merge per Step 8a.
 
 ## Per-run links
 - run-1 -> `2026-04-22.md`
 - run-2 -> `2026-04-22-run2.md`
 - run-3 -> `2026-04-22-run3.md`
 - run-4 -> `2026-04-22-run4.md`
+- run-5 -> `2026-04-22-run5.md`

--- a/dev/health/2026-04-22-fast-run5.md
+++ b/dev/health/2026-04-22-fast-run5.md
@@ -1,0 +1,34 @@
+# Health Report -- 2026-04-22 -- fast (run-5)
+
+## Summary
+- Main build: PASSING (exit 0)
+- Status file integrity: PASSING (exit 0) — **after inline fix this run** (was FAILING on entry; see Notes)
+- Action required: NO (drift resolved; next-run gate is clean)
+
+## Metrics
+- Checks run: 2 (deterministic; no agentic fast scan)
+- Advisory linter output: not checked here -- covered by `dune runtest` exit code
+- Deep scan: see `dev/health/*-deep.md` (weekly GHA cron)
+
+## Notes — drift detected and fixed this run
+
+On entry to this run, `bash dev/lib/run-in-env.sh dune runtest --force` exited 1
+because `dev/status/backtest-scale.md` `## Last updated:` carried a
+parenthetical comment (`2026-04-22 (run-3 reconcile: …)`) that the
+`status_file_integrity.sh` linter rejects (schema = bare `YYYY-MM-DD`). The
+linter runs as a `dune runtest` rule (`devtools/checks/dune` lines 93–97),
+so this presented as a hard `dune runtest` failure even though no code
+behavior was wrong.
+
+Root cause: run-3's auto-merged orchestrator summary commit (db2c449) edited
+the date line into a multi-clause narrative. Run-4 was a NO-OP fast-exit,
+so it never ran `dune runtest` and the drift slipped through to today.
+
+Fix: scrubbed the parenthetical to `## Last updated: 2026-04-22`.
+Re-verified: `status_file_integrity.sh` exit 0; full `dune runtest --force`
+exit 0; no `FAIL:` lines.
+
+The same-shape drift is potentially possible on any per-track status file
+that an orchestrator summary edits. The narrow guard is the integrity
+linter; the broader gap (Step 0.5 fast-exit doesn't run `dune runtest`)
+is logged as an `[info]` escalation in today's daily summary.

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,7 +4,7 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-22 run-3 (orchestrator reconcile post-prior-run merge wave: PR #496 3h nightly A/B compare merged 03:38Z; PR #498 activated tiered-loader-ab workflow via `git mv` to `.github/workflows/` at 03:41Z; PR #499 orchestrator cost-capture post-run commit + auto-merge at 03:50Z; all human-merged between run-2 and this run. Run-3: no dispatches — queue fully saturated, next backtest-scale increment gated on empirical nightly A/B data (first nightly fires 04:17Z tonight). Main baseline green (build + runtest + status-integrity all exit 0).)
+Last updated: 2026-04-22 run-5 (orchestrator detected status-file integrity drift introduced by run-3's `dev/status/backtest-scale.md` `## Last updated:` line — the parenthetical comment after the date violated the YYYY-MM-DD schema enforced by `status_file_integrity.sh`, which is wired into `dune runtest`. Inline fix scrubbed the parenthetical; main re-verified green (`dune runtest --force` exit 0, integrity check OK, no `FAIL:` lines). Otherwise queue state unchanged since run-4: 0 open PRs, no dispatches; backtest-scale flip-default still gated on empirical nightly A/B data.)
 
 ## Active + complete tracks
 

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -1,6 +1,6 @@
 # Status: backtest-scale
 
-## Last updated: 2026-04-22 (run-3 reconcile: #496 + #498 both merged; nightly A/B workflow live)
+## Last updated: 2026-04-22
 
 ## Status
 IN_PROGRESS


### PR DESCRIPTION
Automated daily orchestrator run (run-5). See `dev/daily/2026-04-22-run5.md`.

Detected and resolved a status-file integrity drift introduced by run-3's auto-merged summary commit (`db2c449`). The `dev/status/backtest-scale.md` `## Last updated:` line carried a parenthetical comment after the date, violating the YYYY-MM-DD schema enforced by `status_file_integrity.sh` (wired into `dune runtest`). Run-4 fast-exited via Step 0.5 and never invoked `dune runtest`, so the drift slipped through.

This run independently ran `dune runtest --force` during state inspection (exit 1 with the integrity FAIL above), scrubbed the parenthetical to bare `2026-04-22` inline, and re-verified main green (`dune runtest --force` exit 0).

[info] escalation logged for `harness-maintainer` to consider hardening Step 0.5 — either add a 5th condition invoking `status_file_integrity.sh` (sub-second cost), or tighten the orchestrator's own Step 5.5 `## Last updated:` writer.

No subagent dispatched; otherwise queue state unchanged since run-4 (0 open PRs; backtest-scale flip-default still gated on empirical nightly A/B data).