### PR TITLE
ci(tiered-ab): capture peak RSS per backtest run

### DIFF
--- a/dev/scripts/tiered_loader_ab_compare.sh
+++ b/dev/scripts/tiered_loader_ab_compare.sh
@@ -121,15 +121,34 @@ _scenario_end() {
 # directory per run so this is race-free as long as the two invocations are
 # at least 1 second apart (enforced by the wall-clock gap between two full
 # backtest runs).
+#
+# Peak RSS capture: when GNU time (/usr/bin/time) is available, wraps the
+# dune exec and writes the run's maximum resident set size to
+# $log_path.peak_rss_kb (integer, kilobytes). When absent, writes the string
+# "UNAVAILABLE" instead — the comparison path treats that like any other
+# missing value and emits an annotation without failing the job. We probe
+# /usr/bin/time once at module load (see _have_gnu_time below) to avoid
+# per-run fork overhead.
 _run_backtest() {
   strategy="$1"
   log_path="$2"
+  peak_rss_path="$log_path.peak_rss_kb"
   set +e
-  (
-    cd "$DUNE_ROOT"
-    dune exec --no-build -- trading/backtest/bin/backtest_runner.exe \
-      "$START_DATE" "$END_DATE" --loader-strategy "$strategy"
-  ) >"$log_path.stdout" 2>"$log_path.stderr"
+  if [ "$_HAVE_GNU_TIME" = "1" ]; then
+    (
+      cd "$DUNE_ROOT"
+      /usr/bin/time -o "$peak_rss_path" -f '%M' \
+        dune exec --no-build -- trading/backtest/bin/backtest_runner.exe \
+          "$START_DATE" "$END_DATE" --loader-strategy "$strategy"
+    ) >"$log_path.stdout" 2>"$log_path.stderr"
+  else
+    (
+      cd "$DUNE_ROOT"
+      dune exec --no-build -- trading/backtest/bin/backtest_runner.exe \
+        "$START_DATE" "$END_DATE" --loader-strategy "$strategy"
+    ) >"$log_path.stdout" 2>"$log_path.stderr"
+    printf 'UNAVAILABLE\n' >"$peak_rss_path"
+  fi
   rc=$?
   set -e
   cat "$log_path.stdout" >"$log_path"
@@ -149,6 +168,15 @@ _run_backtest() {
   fi
   printf '%s\n' "$output_dir"
 }
+
+# Peak-RSS tooling probe. /usr/bin/time -f '%M' is a GNU-time extension; the
+# shell builtin `time` has no -f / -o flags. We require the binary at the
+# canonical path — probing $(command -v time) would pick up the builtin.
+if [ -x /usr/bin/time ]; then
+  _HAVE_GNU_TIME=1
+else
+  _HAVE_GNU_TIME=0
+fi
 
 # Count data rows (excluding header) in trades.csv. Returns [MISSING] if
 # the file is absent.
@@ -252,6 +280,12 @@ TIERED_TRADES=$(_trade_count "$TIERED_DIR/trades.csv")
 LEGACY_PV=$(_final_portfolio_value "$LEGACY_DIR/summary.sexp")
 TIERED_PV=$(_final_portfolio_value "$TIERED_DIR/summary.sexp")
 
+# Peak-RSS read (written by _run_backtest via /usr/bin/time -f '%M'). When
+# GNU time is unavailable the file contains "UNAVAILABLE" — treat that as a
+# soft signal, no gating. Values from /usr/bin/time -f '%M' are in kilobytes.
+LEGACY_RSS=$(head -1 "$OUT_DIR_ABS/legacy.log.peak_rss_kb" 2>/dev/null || echo UNAVAILABLE)
+TIERED_RSS=$(head -1 "$OUT_DIR_ABS/tiered.log.peak_rss_kb" 2>/dev/null || echo UNAVAILABLE)
+
 DIFF_FILE="$OUT_DIR_ABS/diff.txt"
 {
   printf 'Scenario       : %s\n' "$SCENARIO_NAME"
@@ -260,6 +294,8 @@ DIFF_FILE="$OUT_DIR_ABS/diff.txt"
   printf 'Tiered trades  : %s\n' "$TIERED_TRADES"
   printf 'Legacy final PV: %s\n' "$LEGACY_PV"
   printf 'Tiered final PV: %s\n' "$TIERED_PV"
+  printf 'Legacy peak RSS: %s KB\n' "$LEGACY_RSS"
+  printf 'Tiered peak RSS: %s KB\n' "$TIERED_RSS"
 } | tee "$DIFF_FILE"
 
 # Hard gate: trades.csv must exist on both sides.
@@ -300,6 +336,31 @@ if _gt "$PV_DELTA" "$PV_WARN"; then
     >>"$DIFF_FILE"
 else
   printf 'OK: PV drift within threshold\n' | tee -a "$DIFF_FILE"
+fi
+
+# Observational: peak RSS comparison. This is the whole point of Tiered —
+# `Bar_history` should grow for only `full_candidate_limit + held_positions`
+# symbols instead of the full universe. Not a gate: we report the delta and
+# the Tiered/Legacy ratio as a `::notice::` annotation so post-merge we can
+# eyeball whether the expected ~30× reduction is materializing on broad
+# goldens. Gating would require calibrated thresholds per scenario, which
+# we don't have yet.
+if [ "$LEGACY_RSS" = "UNAVAILABLE" ] || [ "$TIERED_RSS" = "UNAVAILABLE" ]; then
+  printf 'RSS            : UNAVAILABLE (/usr/bin/time not installed in container)\n' \
+    | tee -a "$DIFF_FILE"
+elif ! echo "$LEGACY_RSS$TIERED_RSS" | grep -qE '^[0-9]+[0-9]+$'; then
+  printf 'RSS            : MALFORMED (legacy=%s tiered=%s)\n' "$LEGACY_RSS" "$TIERED_RSS" \
+    | tee -a "$DIFF_FILE"
+else
+  # Ratio = tiered / legacy, formatted to 3 decimal places. <1.0 is a win.
+  RSS_RATIO=$(awk -v t="$TIERED_RSS" -v l="$LEGACY_RSS" 'BEGIN {
+    if (l == 0) { printf "n/a (legacy=0)"; exit }
+    printf "%.3f", t / l
+  }')
+  printf 'Peak RSS ratio : %s (tiered/legacy; <1.0 is a memory win)\n' "$RSS_RATIO" \
+    | tee -a "$DIFF_FILE"
+  printf '::notice::A/B compare %s — peak RSS legacy=%s KB tiered=%s KB ratio=%s\n' \
+    "$SCENARIO_NAME" "$LEGACY_RSS" "$TIERED_RSS" "$RSS_RATIO"
 fi
 
 printf 'OK: trade-count parity holds for %s\n' "$SCENARIO_NAME"


### PR DESCRIPTION
## Summary

Adds peak-RSS capture to the nightly tiered-loader A/B compare. Post-#507, Tiered actually throttles `Bar_history` growth for non-Full-tier symbols + seeds from `Bar_loader.Full.t.bars` on Full promote — the memory reduction Tiered was designed for. But the A/B script only measured trade-count + portfolio-value deltas; no way to see whether the memory savings actually materialized on broad goldens.

This PR wraps each `backtest_runner` invocation with `/usr/bin/time -f '%M'`, writes peak RSS (KB) to a sibling file, and reports both sides + a ratio in `diff.txt` and as a `::notice::` GHA annotation.

## Contract

| Signal | Legacy | Tiered | Gate |
|---|---:|---:|---|
| Trade count | N | N | **Hard fail** on diff (unchanged) |
| Final PV | $X | $Y | Warn on drift > `max($1.00, 0.001% × legacy_pv)` (unchanged) |
| Peak RSS | L KB | T KB | **Observational only** (`::notice::` annotation; no gate) |

Gating RSS would require calibrated thresholds per scenario. We don't have them yet — observation post-merge tells us whether Tiered ratio is ~0.03 (the theoretical ~30× reduction), ~0.5 (partial win), or ~1.0 (no win). Once a signal pattern stabilizes across nights, we can add a gate with real numbers.

## Implementation notes

- **Probe `/usr/bin/time` once at script load.** The shell builtin `time` doesn't support `-f` / `-o`; we require the GNU binary at the canonical path and skip cleanly if absent (writing `UNAVAILABLE` to the peak-rss file and reporting gracefully).
- **Artefact layout unchanged.** Peak-RSS files live alongside the existing `legacy.log` / `tiered.log` in each scenario's output tree, so the workflow's `actions/upload-artifact` covers them for free.
- **POSIX-compliant** — passes `dash -n` and the `posix-sh` linter from #493.

## Test plan

- [x] `dash -n dev/scripts/tiered_loader_ab_compare.sh` → PARSE OK
- [x] `dune runtest trading/devtools/checks --force` — posix-sh linter clean (42 scripts)
- [ ] First post-merge nightly (04:17 UTC) produces RSS numbers for all 3 broad goldens

## Pre-existing drift (not caused by this PR)

Local `dune runtest` surfaces a `status_file_integrity` failure ("`## Last updated: 2026-04-22 (run 2)` is not YYYY-MM-DD"). `dev/status/backtest-scale.md` carries that value on `main@origin` today; main's CI passes because the failing test runs in a different env config. Orthogonal to this PR; leaving for the next orchestrator run to reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
