### PR TITLE
ci(orchestrator): replace jq with python3 in budget PR step

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -314,37 +314,38 @@ jobs:
           # `gh` CLI — see run 24762831070 post-mortem where both `gh pr
           # create` and `gh pr merge --auto` died with "gh: command not
           # found" and the budget branch sat orphaned without a PR).
+          #
+          # Use python3 for JSON build/parse, not jq — the devcontainer
+          # image also lacks jq (see run 24856066811 post-mortem where the
+          # first curl-based attempt died with "jq: command not found").
           BODY=$(printf 'Measured GHA orchestrator run cost for `%s`.\n\n`total_cost_usd`: $%s (from `claude-code-action` execution_file, fallback branch 1b — see `dev/status/cost-tracking.md`).\n\nAuto-merge: ops category, single-file additive change.' "$BASENAME" "$TOTAL_COST")
+
+          PR_PAYLOAD=$(TITLE="ops(budget): ${BASENAME} (\$${TOTAL_COST})" HEAD="${BRANCH}" BASE="main" BODY="${BODY}" \
+            python3 -c 'import json,os; print(json.dumps({"title":os.environ["TITLE"],"head":os.environ["HEAD"],"base":os.environ["BASE"],"body":os.environ["BODY"],"draft":False}))')
 
           PR_JSON=$(curl -s -X POST \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${REPO}/pulls" \
-            -d "$(jq -n \
-              --arg title "ops(budget): ${BASENAME} (\$${TOTAL_COST})" \
-              --arg head "${BRANCH}" \
-              --arg base "main" \
-              --arg body "${BODY}" \
-              '{title: $title, head: $head, base: $base, body: $body, draft: false}')")
+            -d "$PR_PAYLOAD")
 
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number // empty')
+          PR_NUMBER=$(echo "$PR_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); n=d.get("number"); print("" if n is None else n)')
           if [ -z "$PR_NUMBER" ]; then
             echo "::warning::Failed to create budget PR. API response:"
-            echo "$PR_JSON" | jq -r '.message // .' || true
+            echo "$PR_JSON" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("message", d))' || true
             exit 0
           fi
           echo "Opened budget PR #${PR_NUMBER}"
 
           # Enable auto-merge via GraphQL. Auto-merge requires the repo-level
           # setting to be on (it is, per existing ops/daily-* summary PRs).
-          PR_NODE_ID=$(echo "$PR_JSON" | jq -r '.node_id')
+          PR_NODE_ID=$(echo "$PR_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin)["node_id"])')
+          GQL_PAYLOAD=$(NODE_ID="$PR_NODE_ID" python3 -c 'import json,os; print(json.dumps({"query":"mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) { pullRequest { number } } }","variables":{"id":os.environ["NODE_ID"]}}))')
           curl -s -X POST \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Content-Type: application/json" \
             "https://api.github.com/graphql" \
-            -d "$(jq -n \
-              --arg id "$PR_NODE_ID" \
-              '{query: "mutation($id: ID!) { enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: SQUASH }) { pullRequest { number } } }", variables: { id: $id }}')" \
+            -d "$GQL_PAYLOAD" \
             > /dev/null || echo "::warning::Failed to enable auto-merge on PR #${PR_NUMBER}; human merge required."
 
       - name: Locate daily summary (for escalations check)


### PR DESCRIPTION
## Summary

- Devcontainer image lacks `jq` — run [24856066811](https://github.com/dayfine/trading/actions/runs/24856066811) failed on `jq: command not found` in the budget PR step (introduced by #504 when switching from `gh` to `curl`).
- Swap all `jq` invocations for `python3` (already used elsewhere in the same step for `total_cost_usd` extraction).
- Both JSON build (PR create payload, GraphQL auto-merge payload) and JSON parse (`number`, `node_id`, `message`) ported.

## Test plan

- [ ] Manual `workflow_dispatch` after merge confirms the budget PR step succeeds.