### PR TITLE
ci(health-deep): replace jq with python3 in PR step

### DIFF
--- a/.github/workflows/health-deep-weekly.yml
+++ b/.github/workflows/health-deep-weekly.yml
@@ -142,13 +142,13 @@ jobs:
           fi
 
           # Open the PR via GH REST API (claude-code-action does not open PRs).
+          # Use python3 for JSON build — devcontainer image lacks jq (see
+          # orchestrator.yml's budget step, where the same bug surfaced in
+          # run 24856066811 and was fixed in #510).
+          PR_PAYLOAD=$(TITLE="ops: weekly deep health scan ${DATE}" HEAD="${BRANCH}" BASE="main" BODY="${BODY}" \
+            python3 -c 'import json,os; print(json.dumps({"title":os.environ["TITLE"],"head":os.environ["HEAD"],"base":os.environ["BASE"],"body":os.environ["BODY"],"draft":False}))')
           curl -s -X POST \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${REPO}/pulls" \
-            -d "$(jq -n \
-              --arg title "ops: weekly deep health scan ${DATE}" \
-              --arg head "${BRANCH}" \
-              --arg base "main" \
-              --arg body "${BODY}" \
-              '{title: $title, head: $head, base: $base, body: $body, draft: false}')"
+            -d "$PR_PAYLOAD"


### PR DESCRIPTION
## Summary

- Same root cause as #510: devcontainer image lacks `jq`. `health-deep-weekly.yml` line 149 still uses `jq -n` to build the PR-creation payload.
- Pre-emptive: the bug only bites once the agent step succeeds (run 24676096493 failed earlier, at the agent step, before reaching this line). Next clean weekly run would otherwise repeat the orchestrator failure.
- Mirror the orchestrator fix exactly — env-var wrapped `python3 -c json.dumps(...)`.

## Test plan

- [ ] Next scheduled weekly run lands the PR cleanly.