### PR TITLE
ops(budget): 2026-04-23-24857778755 ($5.0940)

### DIFF
--- a/dev/budget/2026-04-23-24857778755.json
+++ b/dev/budget/2026-04-23-24857778755.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-04-23-24857778755",
+  "timestamp": "2026-04-23T21:00:53Z",
+  "commit_sha": "4e370ba8cca1f2cc4a0c4db85969cb76fb8335dd",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output \u2014 see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 5.09402975,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/daily/2026-04-23-summary.md
+++ b/dev/daily/2026-04-23-summary.md
@@ -1,0 +1,43 @@
+# Consolidated Summary — 2026-04-23
+Runs included: run-1, run-2, run-3 (3 total)
+Generated: 2026-04-23T21:00:01Z
+
+## Pending work (from last run)
+(section not found in last run)
+
+## Dispatched across all runs (deduped)
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| backtest-scale | — | inline fix (no dispatch) | scrubbed `(run 2)` parenthetical from `dev/status/backtest-scale.md` `## Last updated:` line and bumped date to `2026-04-23` to satisfy `status_file_integrity.sh` schema (orchestrator-owned per Step 5.5); main re-verified green. |
+| _index.md | — | Step 5.5 reconcile (no dispatch) | refreshed backtest-scale row: Open PR(s) `feat/backtest-scale-tiered-missing-csv-tolerance` → `—` (PR #506 merged 2026-04-22); Next task rewritten to "accumulate nightly A/B runs before flipping loader_strategy default". Bumped `_index.md` last-updated line to 2026-04-23 with drift diagnostic. Also refreshed harness row to list PRs #493/#495/#499/#504/#505 merged 2026-04-22. |
+| (all other tracks) | — | skipped (no-change) | queue saturated; same state as run-5 2026-04-22. See §Pending work. |
+| (all tracks) | — | skipped (no-op) | Step 0.5 saturated-queue fast-exit: 0 open PRs, no status drift, no harness/cleanup backlog change, no [drift] warnings from Step 1b. |
+
+## QC across all runs
+- No QC runs this cycle (no dispatches).
+- Last QC artifacts on main:
+- No QC runs this cycle (no dispatches, no open PRs).
+- Last QC artifact on main:
+
+## Budget (summed across runs)
+- Total subagents spawned: 0
+- Killed mid-flight: None reported across all runs.
+
+## Escalations (merged)
+- **[critical] (RESOLVED this run)** — Main baseline was RED on entry on
+- **[info] Status-file integrity drift recurred via human-merged PR #507.**
+- **[info] Carried-forward verification: no still-real `[critical]` items
+- `[info]` **Concurrent orchestrator invocations overlapped on 2026-04-23.**
+
+## Integration Queue (last run's view)
+
+No open PRs; integration queue empty (verified via GH REST API).
+
+Auto-merge remains disabled (`auto_merge_enabled: false` in
+`dev/config/merge-policy.json`) for feature PRs; the orchestrator's own
+summary PRs auto-merge per Step 8a.
+
+## Per-run links
+- run-1 -> `2026-04-23.md`
+- run-2 -> `2026-04-23-run2.md`
+- run-3 -> `2026-04-23-run3.md`


### PR DESCRIPTION
Measured GHA orchestrator run cost for `2026-04-23-24857778755`.

`total_cost_usd`: $5.0940 (from `claude-code-action` execution_file, fallback branch 1b — see `dev/status/cost-tracking.md`).

Auto-merge: ops category, single-file additive change.