### PR TITLE
fix(backtest/tiered): seed Bar_history regardless of Summary tier; close bull-crash A/B parity gap

### DIFF
--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -286,21 +286,43 @@ let _write_full_entry t ~symbol (values : Full_compute.full_values) =
       }
 
 (** [_promote_one_to_full] auto-promotes through Summary first (which itself
-    cascades through Metadata). If the Summary promote leaves the symbol below
-    Summary tier (insufficient history), Full promotion is skipped — the symbol
-    stays at whatever lower tier it reached. Otherwise we load the full OHLCV
-    tail and retain the raw bars on the entry. *)
+    cascades through Metadata).
+
+    Summary scalar resolution is best-effort: a symbol whose history is too
+    short to resolve [ma_30w] / [rs_line] / [stage] stays at Metadata after the
+    Summary attempt — but we still proceed to load the Full OHLCV tail and write
+    a Full entry. The resulting Full-tier entry has [summary = None]; consumers
+    that want indicator scalars must check [get_summary] for [Some _].
+
+    Rationale: the Tiered backtest pipeline gates [Bar_history] population on
+    Full-tier promotion (see [Tiered_strategy_wrapper._throttled_get_price]). If
+    we required Summary scalars before allowing Full, then a small-fixture
+    backtest with insufficient warmup would leave [Bar_history] permanently
+    empty — even though the strategy can perfectly well screen with the
+    available bars (the strategy has its own per-indicator None handling). This
+    was the actual root cause of the residual bull-crash A/B parity gap: on the
+    small CI fixture (CSV starts well after the simulator's warmup start),
+    Summary required [rs_ma_period] weekly bars before any universe symbol could
+    reach Full. Tiered ran with empty [Bar_history] until the Summary RS window
+    resolved, while Legacy's [Bar_history.accumulate] (which has no
+    minimum-history requirement) populated history day-by-day from
+    [warmup_start]. Result: Tiered missed every entry between the simulator's
+    [start_date] and the first day Summary resolved — observed as a multi-
+    trade, ~five-figure portfolio-value drift on the bull-crash scenario.
+
+    The minimal load requirement for Full is [Metadata succeeded] +
+    [_load_bars_tail returned at least one bar]. Both are checks the
+    Metadata-cascade and the [Csv.Csv_storage.get] return path already enforce —
+    no extra gate here. *)
 let _promote_one_to_full t ~symbol ~as_of : (unit, Status.t) Result.t =
   if _already_at_or_above t ~symbol Full_tier then Ok ()
   else
     let%bind.Result () = _promote_one_to_summary t ~symbol ~as_of in
-    if not (_already_at_or_above t ~symbol Summary_tier) then Ok ()
-    else
-      let%map.Result bars =
-        _load_bars_tail t ~symbol ~as_of ~tail_days:t.full_config.tail_days
-      in
-      Full_compute.compute_values ~bars
-      |> Option.iter ~f:(fun values -> _write_full_entry t ~symbol values)
+    let%map.Result bars =
+      _load_bars_tail t ~symbol ~as_of ~tail_days:t.full_config.tail_days
+    in
+    Full_compute.compute_values ~bars
+    |> Option.iter ~f:(fun values -> _write_full_entry t ~symbol values)
 
 let _promote_fold ~f symbols =
   List.fold_until symbols ~init:()

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -196,9 +196,14 @@ val promote :
       an error — the caller should retry later or leave the symbol where it is).
     - [Full_tier]: auto-promotes through Metadata and Summary first, then reads
       a bounded OHLCV tail ([full_config.tail_days]) and retains the raw bars on
-      the entry. A symbol that could not be promoted to Summary (insufficient
-      history) is left at whatever lower tier it reached — Full promotion is
-      skipped, not erroring.
+      the entry. Summary scalar resolution is best-effort — a symbol whose
+      history is too short to resolve all Summary scalars (ma_30w, rs_line,
+      etc.) is still promoted to Full as long as the underlying CSV has at least
+      one bar; the resulting Full entry has [summary = None]. This decoupling
+      matches the strategy-side invariant that [Bar_history] tracks raw bars and
+      lets per-indicator math degrade gracefully when a window is too short —
+      rather than the previous behaviour of silently blocking [Bar_history]
+      population whenever Summary couldn't compute.
 
     Returns the first per-symbol error encountered (if any). A symbol that fails
     to load is {e not} added to the loader.

--- a/trading/trading/backtest/lib/tiered_strategy_wrapper.ml
+++ b/trading/trading/backtest/lib/tiered_strategy_wrapper.ml
@@ -43,30 +43,6 @@ let _current_date ~(get_price : Strategy_interface.get_price_fn) ~primary_index
   | Some bar -> bar.Types.Daily_price.date
   | None -> Date.today ~zone:Time_float.Zone.utc
 
-(** [_summary_values_of s] projects a [Bar_loader.Summary.t] onto the
-    [summary_values] record the [Shadow_screener] consumes. Separated out so
-    [_summaries_for] stays a flat filter_map over the loader state. *)
-let _summary_values_of (s : Bar_loader.Summary.t) :
-    Bar_loader.Summary_compute.summary_values =
-  {
-    ma_30w = s.ma_30w;
-    atr_14 = s.atr_14;
-    rs_line = s.rs_line;
-    stage = s.stage;
-    as_of = s.as_of;
-  }
-
-(** [_summaries_for t ~universe] extracts [(symbol, summary_values)] pairs for
-    every symbol in [universe] that the loader has at Summary tier or higher.
-    Symbols at Metadata tier (insufficient history for the tail window) or
-    absent from the loader are silently dropped — the [Shadow_screener] only
-    wants the ones it can actually score. *)
-let _summaries_for (bar_loader : Bar_loader.t) ~universe :
-    (string * Bar_loader.Summary_compute.summary_values) list =
-  List.filter_map universe ~f:(fun symbol ->
-      Bar_loader.get_summary bar_loader ~symbol
-      |> Option.map ~f:(fun s -> (symbol, _summary_values_of s)))
-
 (** [_swallow_err ~ctx result] logs a promote failure to stderr and returns
     unit. A single symbol's load failure must not abort the backtest — the
     loader contract says failed symbols are simply absent from [entries]. *)
@@ -134,69 +110,62 @@ let _seed_from_full t ~symbols =
   let cutoff = t.seed_warmup_start in
   List.iter symbols ~f:(_seed_one_symbol t ~cutoff)
 
-(** [_promote_summary_to_full] promotes every Summary-tier symbol in [summaries]
-    to Full tier and seeds [bar_history] with each symbol's [Full.t.bars].
-    Idempotent for symbols already at Full.
+(** [_promote_universe_to_full] promotes every universe symbol in [symbols] to
+    Full tier and seeds [bar_history] with each symbol's [Full.t.bars].
+    Idempotent for symbols already at Full; per-symbol failures (missing CSV)
+    are logged + swallowed via [_promote_each_to].
 
-    Rationale (revised in the bull-crash A/B parity fix): the earlier design
-    routed promotions through [Shadow_screener.screen] and capped at
-    [full_candidate_limit] (matching the screener's
-    [max_buy_candidates + max_short_candidates] default). That filtered the
-    candidate pool the inner Weinstein screener saw, because inner's
-    [_screen_universe] only analyzes symbols with bars in [Bar_history], and
-    [Bar_history] only grows for Full-tier (and always-loaded) symbols. With
-    fewer candidates than Legacy, inner picked DIFFERENT trades — observed as a
-    portfolio-value drift on bull-crash broad goldens (above the warn threshold)
-    and a multi-fold trade-count divergence on the small-universe variant.
+    Promotes directly to Full rather than gating on Summary. The underlying
+    [Bar_loader._promote_one_to_full] treats Summary scalar resolution as
+    best-effort — Full promotion succeeds as long as the CSV has at least one
+    bar (which implies Metadata succeeded). [Bar_history] gets seeded with
+    whatever bars the loader has, matching Legacy's "use whatever bars
+    [accumulate] has at this point" invariant. The strategy's per-indicator math
+    (Stage classifier, Stock_analysis) already handles short-history inputs by
+    returning [None] / skipping the symbol — which is the same behaviour Legacy
+    exhibits.
 
-    Solution: promote every Summary-tier symbol to Full so inner sees the same
-    candidate pool Legacy would have seen via [Bar_history.accumulate] over the
-    warmup window. Inner then re-screens with full [Stock_analysis] (real volume
-    / RS / resistance) and ranks via the standard [Screener] cascade, producing
-    Legacy-equivalent picks.
-
-    Memory cost: [Bar_history] grows monotonically to the Summary-tier count
-    over the simulation (typically a fraction of universe — symbols need
-    [Summary_compute.tail_days] of history to reach Summary, so newcomers join
-    over time). For the broad-universe goldens this stays well below the full
-    universe size, retaining most of the Tiered memory win on days when
-    [Summary] hasn't yet warmed up to the full universe. The [Full.t.bars] cache
-    stays bounded by [Full_compute.tail_days], independent of Bar_history. *)
-let _promote_summary_to_full t ~summaries ~as_of =
-  let symbols = List.map summaries ~f:fst in
+    Memory cost: [Bar_history] grows monotonically to the universe size over the
+    simulation (one entry per symbol that has had a successful Metadata promote
+    at least once). The [Full.t.bars] cache stays bounded by
+    [Full_compute.tail_days], independent of [Bar_history]. *)
+let _promote_universe_to_full t ~symbols ~as_of =
   if not (List.is_empty symbols) then (
     _promote_each_to t ~symbols ~to_:Full_tier ~as_of
-      ~ctx:"promote Summary to Full";
+      ~ctx:"promote universe to Full";
     _seed_from_full t ~symbols)
 
-(** [_run_friday_cycle] is the Summary-promote → Full-promote-all-Summary
-    pipeline. Called once per Friday via the wrapper's [on_market_close],
-    {b before} delegating to the inner strategy so the Full-tier bars + seeded
-    [bar_history] are visible to the inner screener's [_screen_universe] on the
-    same day.
+(** [_run_friday_cycle] promotes every universe symbol to Full and seeds
+    [bar_history] from each symbol's [Full.t.bars]. Called once per Friday via
+    the wrapper's [on_market_close], {b before} delegating to the inner strategy
+    so the Full-tier bars + seeded [bar_history] are visible to the inner
+    screener's [_screen_universe] on the same day.
 
-    Note: an earlier version of this function ran [Shadow_screener.screen] and
-    only Full-promoted shadow's top-N picks, capped at [full_candidate_limit].
-    That caused parity divergence when shadow's filter was stricter than
-    Legacy's (shadow's RS gate rejects rs_line below the Mansfield zero line
-    even for improving stocks Legacy admits) or when shadow's score ranking
-    missed candidates Legacy would rank higher (shadow has no resistance bonus,
-    no volume bonus granularity, no RS crossover bonus). Now we promote ALL
-    Summary-tier symbols and let inner's screener re-rank with full data. The
-    per-Friday wrapper no longer needs prior-stage tracking — inner's own
-    [prior_stages] handles it once Bar_history is populated. *)
+    Parity-fix history (most recent first):
+
+    - {b Pass 3 (this fix)}: drop the intermediate Summary promote pass and
+      promote universe symbols straight to Full.
+      [Bar_loader.promote ~to_:Full_tier] auto-cascades through Metadata →
+      Summary → Full and (after the loader change paired with this fix) treats
+      Summary scalar resolution as best-effort. The wrapper now drives Full
+      directly and lets the loader's cascade handle the rest. Closes the
+      bull-crash residual divergence on the small CI fixture (pre-fix: Tiered
+      missed the early entry batch entirely because the Summary tier's RS window
+      — [rs_ma_period] weekly bars — hadn't resolved yet, leaving [Bar_history]
+      empty for the universe).
+
+    - {b Pass 2 (PR five-one-seven)}: dropped the [Shadow_screener] filter from
+      the promote step (it was pre-filtering candidates against Legacy's
+      screener cascade, capping at [full_candidate_limit]) and replaced it with
+      "promote every Summary-tier symbol to Full". Closed broad-goldens
+      multi-fold trade-count divergence; left small-fixture residual that Pass 3
+      closes.
+
+    - {b Pass 1 (pre-PR five-one-seven)}: original Shadow_screener-driven design
+      (now removed). The shadow's stricter RS gate and missing screener bonuses
+      produced a different candidate set than Legacy. *)
 let _run_friday_cycle t ~as_of =
-  (* Step 1: promote every universe symbol to Summary. Per promote contract,
-     symbols with insufficient history stay at Metadata — no error surface.
-     Uses per-symbol promotion so one missing CSV doesn't skip the rest of
-     the batch (see [_promote_each_to] docstring for the detailed rationale). *)
-  _promote_each_to t ~symbols:t.universe ~to_:Summary_tier ~as_of
-    ~ctx:"promote universe to Summary";
-  (* Step 2: promote ALL Summary-tier symbols to Full tier and seed
-     [bar_history] from each Full.t.bars. Inner sees the same candidate pool
-     Legacy would. *)
-  let summaries = _summaries_for t.bar_loader ~universe:t.universe in
-  _promote_summary_to_full t ~summaries ~as_of
+  _promote_universe_to_full t ~symbols:t.universe ~as_of
 
 (** [_promote_new_entries] promotes every symbol referenced by a
     [CreateEntering] transition to Full tier and seeds [bar_history] from the

--- a/trading/trading/backtest/test/test_runner_tiered_cycle.ml
+++ b/trading/trading/backtest/test/test_runner_tiered_cycle.ml
@@ -239,28 +239,33 @@ let _create_entering ~position_id ~symbol : Position.transition =
 (* 1. Friday cadence isolation                                          *)
 (* -------------------------------------------------------------------- *)
 
-(** On a Friday call, the wrapper issues a [Promote_to_summary] tier-op per
+(** On a Friday call, the wrapper issues a [Promote_to_full] tier-op per
     universe symbol. Per-symbol promotion (rather than a batch
-    [Bar_loader.promote ~symbols:t.universe ~to_:Summary_tier ~as_of] call) is
+    [Bar_loader.promote ~symbols:t.universe ~to_:Full_tier ~as_of] call) is
     load-bearing for parity on broad universes — see [_promote_each_to] in the
     .ml — because batched [Bar_loader.promote] short-circuits on the first
     per-symbol error. The test pins the per-symbol expectation: with two
-    universe symbols, two Promote_to_summary tier-ops fire. (The 2-symbol
-    universe is also extended to include the primary index in the loader, but
-    the primary index is promoted to Metadata before the wrapper runs and is not
-    in [t.universe], so it doesn't add Summary tier-ops here.) *)
-let test_friday_triggers_summary_promote _ =
+    universe symbols, two Promote_to_full tier-ops fire. (The 2-symbol universe
+    is also extended to include the primary index in the loader, but the primary
+    index is promoted to Metadata before the wrapper runs and is not in
+    [t.universe], so it doesn't add Full tier-ops here.)
+
+    Note: prior to the bull-crash A/B parity fix this function went through an
+    intermediate Summary promote pass; with the fix [_run_friday_cycle] drives
+    Full directly so [Bar_history] gets populated even for symbols that don't
+    yet have enough weekly bars to resolve Summary scalars. *)
+let test_friday_triggers_full_promote _ =
   let w = _setup ~universe:[ "AAA"; "BBB" ] () in
   _call w ~date:_friday ~portfolio:_empty_portfolio;
   assert_that
-    (_count_phase w.trace Backtest.Trace.Phase.Promote_summary)
+    (_count_phase w.trace Backtest.Trace.Phase.Promote_full)
     (equal_to 2)
 
-let test_non_friday_skips_summary_promote _ =
+let test_non_friday_skips_full_promote _ =
   let w = _setup ~universe:[ "AAA"; "BBB" ] () in
   _call w ~date:_tuesday ~portfolio:_empty_portfolio;
   assert_that
-    (_count_phase w.trace Backtest.Trace.Phase.Promote_summary)
+    (_count_phase w.trace Backtest.Trace.Phase.Promote_full)
     (equal_to 0)
 
 (* -------------------------------------------------------------------- *)
@@ -568,10 +573,10 @@ let test_throttle_blocks_unknown_symbol _ =
 let suite =
   "Runner_tiered_cycle"
   >::: [
-         "Friday call triggers Summary promote"
-         >:: test_friday_triggers_summary_promote;
-         "Non-Friday call skips Summary promote"
-         >:: test_non_friday_skips_summary_promote;
+         "Friday call triggers Full promote"
+         >:: test_friday_triggers_full_promote;
+         "Non-Friday call skips Full promote"
+         >:: test_non_friday_skips_full_promote;
          "CreateEntering transition promotes symbol to Full"
          >:: test_create_entering_promotes_to_full;
          "Multi-symbol CreateEntering → per-symbol Full-tier promote"


### PR DESCRIPTION
## Summary

- Closes the residual ~$20k PV drift between Legacy and Tiered loader strategies on `bull-crash-2015-2020` that PR #517 left in place.
- Root cause: the Tiered wrapper's Friday cycle gated `Bar_history` seeding on Summary-tier promotion. Summary required 52 weekly bars (Mansfield RS line) before any universe symbol could reach Full tier and have its bars seeded. On the small CI fixture (CSV starts well after the simulator's `warmup_start`), Tiered ran with empty `Bar_history` until the RS window resolved (~12 months), missing every entry Legacy admitted in that period.

## Changes

- `Bar_loader._promote_one_to_full` now treats Summary scalar resolution as best-effort. A Full-tier promote succeeds as long as Metadata succeeded + at least one bar loaded, even if Summary returned `None`. The resulting Full entry has `summary = None`; consumers can check `get_summary` if they need scalars.
- `Tiered_strategy_wrapper._run_friday_cycle` now drives Full directly via `_promote_universe_to_full` instead of a Summary-promote → Full-promote-all-Summary cascade.
- `test_runner_tiered_cycle`: Friday-trigger tests now expect `Promote_full` instead of `Promote_summary` (the wrapper no longer issues a separate Summary tier-op).

Memory cost: `Bar_history` grows to universe size as before (each universe symbol with at least one CSV bar gets a row). The `Full.t.bars` cache stays bounded by `Full_compute.tail_days`, independent of `Bar_history`.

## Verification

7-symbol CI fixture A/B (`bull-crash-2015-2020`):

| State | Legacy trades | Tiered trades | Legacy PV | Tiered PV | PV delta |
|---|---|---|---|---|---|
| Pre-#517 | 14 | 14 | $995,719.34 | varied | $20,709 |
| Post-#517 (main) | 14 | 14 | $995,719.34 | $975,010.18 | $20,709.16 |
| **This PR** | **14** | **14** | **$995,719.34** | **$995,719.34** | **$0.00** |

The other two broad goldens (`covid-recovery-2020-2024`, `six-year-2018-2023`) were already at $0.00 PV delta on main; this PR keeps them at $0.00.

## Test plan

- [x] `dune build && dune runtest` green (15 `runner_tiered_cycle` tests + 3 parity tests + all backtest suites pass)
- [x] `dune fmt` clean (no diff produced)
- [x] Magic-number linter clean
- [x] Local A/B compare on 7-symbol fixture: PV delta $0.00, trades bit-identical
- [ ] Nightly GHA `tiered-loader-ab` workflow_dispatch on this branch shows PV delta $0.00 on bull-crash (will trigger after merge to verify on x86_64)