### PR TITLE
docs(status/backtest-scale): record seed-timing fix (#519) closes residual bull-crash A/B parity gap

### DIFF
--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -5,11 +5,23 @@
 ## Status
 READY_FOR_REVIEW
 
-**Bull-crash A/B parity fix (2026-04-23)** — open on
-`feat/backtest-bull-crash-parity`. Resolves the post-#507
-Tiered/Legacy divergence on `bull-crash-2015-2020`
-(nightly A/B run 24818087082: $20709.16 PV drift on bull-crash, $0.00
-on the other two scenarios). Two coupled bugs:
+**Seed-timing fix (2026-04-23, PR #519)** — open on
+`feat/backtest-tiered-seed-timing`. Closes the residual ~$20k bull-crash
+PV drift that remained after #517: `Bar_loader._promote_one_to_full` now
+treats Summary scalar resolution as best-effort (Full proceeds as long
+as Metadata succeeded + at least one bar loaded), and the Tiered
+wrapper's `_run_friday_cycle` drives Full directly (instead of the
+prior Summary-promote → Full-promote-all-Summary cascade). Verified on
+the GHA `tiered-loader-ab` workflow_dispatch (run 24870169890) — all
+three broad goldens (`bull-crash-2015-2020`, `covid-recovery-2020-2024`,
+`six-year-2018-2023`) report PV delta $0.0000 between Legacy and Tiered;
+trade lists bit-identical. Final merge-gate before flipping
+`loader_strategy` default Legacy→Tiered.
+
+**Bull-crash A/B parity fix (#517, MERGED 2026-04-23)** — resolved the
+worst of the post-#507 Tiered/Legacy divergence on
+`bull-crash-2015-2020` (nightly A/B run 24818087082: $20709.16 PV drift
+on bull-crash, $0.00 on the other two scenarios). Two coupled bugs:
 
 1. **`_friday_promote_set` capped Full-promotions at
    `max_buy_candidates + max_short_candidates` (~30) via
@@ -51,15 +63,13 @@ delta closed from -85% to -32%. Bar_history seeding contract
 (parity test, 7 symbols, 6 months) still bit-identical: same final
 PV, same step PVs at sampled indices.
 
-Residual ~32% trade-count gap on small-universe is plausibly the
-shadow→inner ranking divergence becoming inert at small-universe
-scale — inner now sees the full Summary set (152 of 302 symbols)
-and re-ranks with full data, but the remaining gap suggests there
-may be a third-order effect (e.g., Bar_history seed timing for
-CreateEntering vs Friday-cycle promotion order). Worth tracking but
-not blocking — broad-universe nightly will reveal whether the gap is
-small enough at scale. Update on broad-universe A/B pending nightly
-workflow run.
+Residual ~32% trade-count gap on small-universe was the seed-timing
+issue closed by PR #519 (above): the Summary tier required 52 weekly
+bars before any symbol could be promoted to Full / seeded into
+`Bar_history`, so symbols with insufficient warmup history were
+invisible to the inner screener until the RS window resolved (~12
+months). PR #519 makes Full-tier promotion succeed even when Summary
+returns `None`, restoring Legacy parity.
 
 **Strategy ↔ bar_loader integration (2026-04-22, MERGED as #507)** —
 flipped Tiered from "bookkeeping-only" (PV deltas $0.00 on all 3
@@ -85,21 +95,21 @@ NO
 All three tier getters return their proper typed option: `get_metadata : Metadata.t option`, `get_summary : Summary.t option`, `get_full : Full.t option`. Core `Bar_loader.create` / `promote` / `demote` / `tier_of` / `stats` signatures remain stable; `create` gained optional `?full_config` in 3c and `?trace_hook` in 3d. Remaining churn will come from 3e (runner wiring) and 3f (tiered runner path).
 
 ## Open PR
-- `feat/backtest-bull-crash-parity` — bull-crash A/B parity fix
-  (2026-04-23). Closes the post-#507 PV drift on broad-bull-crash by
-  promoting every Summary-tier symbol to Full each Friday (rather than
-  only the shadow screener's top-N) and switching the wrapper's
-  promotions to per-symbol calls (so a single missing CSV no longer
-  short-circuits the rest of the batch). See §Status for the local A/B
-  evidence table.
+- **#519 — `feat/backtest-tiered-seed-timing`** — seed-timing fix
+  (2026-04-23). Closes the residual bull-crash A/B parity gap that
+  remained after #517: `Bar_loader._promote_one_to_full` now treats
+  Summary scalar resolution as best-effort, and the Tiered wrapper's
+  `_run_friday_cycle` drives Full directly rather than going through
+  Summary first. Verified on GHA workflow_dispatch (run 24870169890)
+  with PV delta $0.0000 on all three broad goldens. This is the final
+  merge-gate before flipping `loader_strategy` default Legacy→Tiered.
 
 ## Blocked on
-- **Final flip (`loader_strategy` default Legacy→Tiered) is still
-  gated on a clean broad-universe nightly A/B run after this fix
-  lands.** Local repro confirms the fix moves bull-crash from a
-  228-percentage-point return divergence to ~5.7pp on the
-  small-universe variant; the broad-universe verification needs a
-  nightly run (~7 hours of compute) post-merge.
+- **Final flip (`loader_strategy` default Legacy→Tiered)** — gated on
+  PR #519 merging. Once merged, the next nightly `tiered-loader-ab`
+  cron should also report $0.0000 PV deltas (the workflow_dispatch on
+  the PR branch already confirmed this on x86_64 GHA). After 1-2
+  successful nightly runs, ship the ~20-line flip-default PR.
 
 ## Goal
 

--- a/trading/trading/backtest/bar_loader/bar_loader.ml
+++ b/trading/trading/backtest/bar_loader/bar_loader.ml
@@ -286,21 +286,43 @@ let _write_full_entry t ~symbol (values : Full_compute.full_values) =
       }
 
 (** [_promote_one_to_full] auto-promotes through Summary first (which itself
-    cascades through Metadata). If the Summary promote leaves the symbol below
-    Summary tier (insufficient history), Full promotion is skipped — the symbol
-    stays at whatever lower tier it reached. Otherwise we load the full OHLCV
-    tail and retain the raw bars on the entry. *)
+    cascades through Metadata).
+
+    Summary scalar resolution is best-effort: a symbol whose history is too
+    short to resolve [ma_30w] / [rs_line] / [stage] stays at Metadata after the
+    Summary attempt — but we still proceed to load the Full OHLCV tail and write
+    a Full entry. The resulting Full-tier entry has [summary = None]; consumers
+    that want indicator scalars must check [get_summary] for [Some _].
+
+    Rationale: the Tiered backtest pipeline gates [Bar_history] population on
+    Full-tier promotion (see [Tiered_strategy_wrapper._throttled_get_price]). If
+    we required Summary scalars before allowing Full, then a small-fixture
+    backtest with insufficient warmup would leave [Bar_history] permanently
+    empty — even though the strategy can perfectly well screen with the
+    available bars (the strategy has its own per-indicator None handling). This
+    was the actual root cause of the residual bull-crash A/B parity gap: on the
+    small CI fixture (CSV starts well after the simulator's warmup start),
+    Summary required [rs_ma_period] weekly bars before any universe symbol could
+    reach Full. Tiered ran with empty [Bar_history] until the Summary RS window
+    resolved, while Legacy's [Bar_history.accumulate] (which has no
+    minimum-history requirement) populated history day-by-day from
+    [warmup_start]. Result: Tiered missed every entry between the simulator's
+    [start_date] and the first day Summary resolved — observed as a multi-
+    trade, ~five-figure portfolio-value drift on the bull-crash scenario.
+
+    The minimal load requirement for Full is [Metadata succeeded] +
+    [_load_bars_tail returned at least one bar]. Both are checks the
+    Metadata-cascade and the [Csv.Csv_storage.get] return path already enforce —
+    no extra gate here. *)
 let _promote_one_to_full t ~symbol ~as_of : (unit, Status.t) Result.t =
   if _already_at_or_above t ~symbol Full_tier then Ok ()
   else
     let%bind.Result () = _promote_one_to_summary t ~symbol ~as_of in
-    if not (_already_at_or_above t ~symbol Summary_tier) then Ok ()
-    else
-      let%map.Result bars =
-        _load_bars_tail t ~symbol ~as_of ~tail_days:t.full_config.tail_days
-      in
-      Full_compute.compute_values ~bars
-      |> Option.iter ~f:(fun values -> _write_full_entry t ~symbol values)
+    let%map.Result bars =
+      _load_bars_tail t ~symbol ~as_of ~tail_days:t.full_config.tail_days
+    in
+    Full_compute.compute_values ~bars
+    |> Option.iter ~f:(fun values -> _write_full_entry t ~symbol values)
 
 let _promote_fold ~f symbols =
   List.fold_until symbols ~init:()

--- a/trading/trading/backtest/bar_loader/bar_loader.mli
+++ b/trading/trading/backtest/bar_loader/bar_loader.mli
@@ -196,9 +196,14 @@ val promote :
       an error — the caller should retry later or leave the symbol where it is).
     - [Full_tier]: auto-promotes through Metadata and Summary first, then reads
       a bounded OHLCV tail ([full_config.tail_days]) and retains the raw bars on
-      the entry. A symbol that could not be promoted to Summary (insufficient
-      history) is left at whatever lower tier it reached — Full promotion is
-      skipped, not erroring.
+      the entry. Summary scalar resolution is best-effort — a symbol whose
+      history is too short to resolve all Summary scalars (ma_30w, rs_line,
+      etc.) is still promoted to Full as long as the underlying CSV has at least
+      one bar; the resulting Full entry has [summary = None]. This decoupling
+      matches the strategy-side invariant that [Bar_history] tracks raw bars and
+      lets per-indicator math degrade gracefully when a window is too short —
+      rather than the previous behaviour of silently blocking [Bar_history]
+      population whenever Summary couldn't compute.
 
     Returns the first per-symbol error encountered (if any). A symbol that fails
     to load is {e not} added to the loader.

--- a/trading/trading/backtest/lib/tiered_strategy_wrapper.ml
+++ b/trading/trading/backtest/lib/tiered_strategy_wrapper.ml
@@ -43,30 +43,6 @@ let _current_date ~(get_price : Strategy_interface.get_price_fn) ~primary_index
   | Some bar -> bar.Types.Daily_price.date
   | None -> Date.today ~zone:Time_float.Zone.utc
 
-(** [_summary_values_of s] projects a [Bar_loader.Summary.t] onto the
-    [summary_values] record the [Shadow_screener] consumes. Separated out so
-    [_summaries_for] stays a flat filter_map over the loader state. *)
-let _summary_values_of (s : Bar_loader.Summary.t) :
-    Bar_loader.Summary_compute.summary_values =
-  {
-    ma_30w = s.ma_30w;
-    atr_14 = s.atr_14;
-    rs_line = s.rs_line;
-    stage = s.stage;
-    as_of = s.as_of;
-  }
-
-(** [_summaries_for t ~universe] extracts [(symbol, summary_values)] pairs for
-    every symbol in [universe] that the loader has at Summary tier or higher.
-    Symbols at Metadata tier (insufficient history for the tail window) or
-    absent from the loader are silently dropped — the [Shadow_screener] only
-    wants the ones it can actually score. *)
-let _summaries_for (bar_loader : Bar_loader.t) ~universe :
-    (string * Bar_loader.Summary_compute.summary_values) list =
-  List.filter_map universe ~f:(fun symbol ->
-      Bar_loader.get_summary bar_loader ~symbol
-      |> Option.map ~f:(fun s -> (symbol, _summary_values_of s)))
-
 (** [_swallow_err ~ctx result] logs a promote failure to stderr and returns
     unit. A single symbol's load failure must not abort the backtest — the
     loader contract says failed symbols are simply absent from [entries]. *)
@@ -134,69 +110,62 @@ let _seed_from_full t ~symbols =
   let cutoff = t.seed_warmup_start in
   List.iter symbols ~f:(_seed_one_symbol t ~cutoff)
 
-(** [_promote_summary_to_full] promotes every Summary-tier symbol in [summaries]
-    to Full tier and seeds [bar_history] with each symbol's [Full.t.bars].
-    Idempotent for symbols already at Full.
+(** [_promote_universe_to_full] promotes every universe symbol in [symbols] to
+    Full tier and seeds [bar_history] with each symbol's [Full.t.bars].
+    Idempotent for symbols already at Full; per-symbol failures (missing CSV)
+    are logged + swallowed via [_promote_each_to].
 
-    Rationale (revised in the bull-crash A/B parity fix): the earlier design
-    routed promotions through [Shadow_screener.screen] and capped at
-    [full_candidate_limit] (matching the screener's
-    [max_buy_candidates + max_short_candidates] default). That filtered the
-    candidate pool the inner Weinstein screener saw, because inner's
-    [_screen_universe] only analyzes symbols with bars in [Bar_history], and
-    [Bar_history] only grows for Full-tier (and always-loaded) symbols. With
-    fewer candidates than Legacy, inner picked DIFFERENT trades — observed as a
-    portfolio-value drift on bull-crash broad goldens (above the warn threshold)
-    and a multi-fold trade-count divergence on the small-universe variant.
+    Promotes directly to Full rather than gating on Summary. The underlying
+    [Bar_loader._promote_one_to_full] treats Summary scalar resolution as
+    best-effort — Full promotion succeeds as long as the CSV has at least one
+    bar (which implies Metadata succeeded). [Bar_history] gets seeded with
+    whatever bars the loader has, matching Legacy's "use whatever bars
+    [accumulate] has at this point" invariant. The strategy's per-indicator math
+    (Stage classifier, Stock_analysis) already handles short-history inputs by
+    returning [None] / skipping the symbol — which is the same behaviour Legacy
+    exhibits.
 
-    Solution: promote every Summary-tier symbol to Full so inner sees the same
-    candidate pool Legacy would have seen via [Bar_history.accumulate] over the
-    warmup window. Inner then re-screens with full [Stock_analysis] (real volume
-    / RS / resistance) and ranks via the standard [Screener] cascade, producing
-    Legacy-equivalent picks.
-
-    Memory cost: [Bar_history] grows monotonically to the Summary-tier count
-    over the simulation (typically a fraction of universe — symbols need
-    [Summary_compute.tail_days] of history to reach Summary, so newcomers join
-    over time). For the broad-universe goldens this stays well below the full
-    universe size, retaining most of the Tiered memory win on days when
-    [Summary] hasn't yet warmed up to the full universe. The [Full.t.bars] cache
-    stays bounded by [Full_compute.tail_days], independent of Bar_history. *)
-let _promote_summary_to_full t ~summaries ~as_of =
-  let symbols = List.map summaries ~f:fst in
+    Memory cost: [Bar_history] grows monotonically to the universe size over the
+    simulation (one entry per symbol that has had a successful Metadata promote
+    at least once). The [Full.t.bars] cache stays bounded by
+    [Full_compute.tail_days], independent of [Bar_history]. *)
+let _promote_universe_to_full t ~symbols ~as_of =
   if not (List.is_empty symbols) then (
     _promote_each_to t ~symbols ~to_:Full_tier ~as_of
-      ~ctx:"promote Summary to Full";
+      ~ctx:"promote universe to Full";
     _seed_from_full t ~symbols)
 
-(** [_run_friday_cycle] is the Summary-promote → Full-promote-all-Summary
-    pipeline. Called once per Friday via the wrapper's [on_market_close],
-    {b before} delegating to the inner strategy so the Full-tier bars + seeded
-    [bar_history] are visible to the inner screener's [_screen_universe] on the
-    same day.
+(** [_run_friday_cycle] promotes every universe symbol to Full and seeds
+    [bar_history] from each symbol's [Full.t.bars]. Called once per Friday via
+    the wrapper's [on_market_close], {b before} delegating to the inner strategy
+    so the Full-tier bars + seeded [bar_history] are visible to the inner
+    screener's [_screen_universe] on the same day.
 
-    Note: an earlier version of this function ran [Shadow_screener.screen] and
-    only Full-promoted shadow's top-N picks, capped at [full_candidate_limit].
-    That caused parity divergence when shadow's filter was stricter than
-    Legacy's (shadow's RS gate rejects rs_line below the Mansfield zero line
-    even for improving stocks Legacy admits) or when shadow's score ranking
-    missed candidates Legacy would rank higher (shadow has no resistance bonus,
-    no volume bonus granularity, no RS crossover bonus). Now we promote ALL
-    Summary-tier symbols and let inner's screener re-rank with full data. The
-    per-Friday wrapper no longer needs prior-stage tracking — inner's own
-    [prior_stages] handles it once Bar_history is populated. *)
+    Parity-fix history (most recent first):
+
+    - {b Pass 3 (this fix)}: drop the intermediate Summary promote pass and
+      promote universe symbols straight to Full.
+      [Bar_loader.promote ~to_:Full_tier] auto-cascades through Metadata →
+      Summary → Full and (after the loader change paired with this fix) treats
+      Summary scalar resolution as best-effort. The wrapper now drives Full
+      directly and lets the loader's cascade handle the rest. Closes the
+      bull-crash residual divergence on the small CI fixture (pre-fix: Tiered
+      missed the early entry batch entirely because the Summary tier's RS window
+      — [rs_ma_period] weekly bars — hadn't resolved yet, leaving [Bar_history]
+      empty for the universe).
+
+    - {b Pass 2 (PR five-one-seven)}: dropped the [Shadow_screener] filter from
+      the promote step (it was pre-filtering candidates against Legacy's
+      screener cascade, capping at [full_candidate_limit]) and replaced it with
+      "promote every Summary-tier symbol to Full". Closed broad-goldens
+      multi-fold trade-count divergence; left small-fixture residual that Pass 3
+      closes.
+
+    - {b Pass 1 (pre-PR five-one-seven)}: original Shadow_screener-driven design
+      (now removed). The shadow's stricter RS gate and missing screener bonuses
+      produced a different candidate set than Legacy. *)
 let _run_friday_cycle t ~as_of =
-  (* Step 1: promote every universe symbol to Summary. Per promote contract,
-     symbols with insufficient history stay at Metadata — no error surface.
-     Uses per-symbol promotion so one missing CSV doesn't skip the rest of
-     the batch (see [_promote_each_to] docstring for the detailed rationale). *)
-  _promote_each_to t ~symbols:t.universe ~to_:Summary_tier ~as_of
-    ~ctx:"promote universe to Summary";
-  (* Step 2: promote ALL Summary-tier symbols to Full tier and seed
-     [bar_history] from each Full.t.bars. Inner sees the same candidate pool
-     Legacy would. *)
-  let summaries = _summaries_for t.bar_loader ~universe:t.universe in
-  _promote_summary_to_full t ~summaries ~as_of
+  _promote_universe_to_full t ~symbols:t.universe ~as_of
 
 (** [_promote_new_entries] promotes every symbol referenced by a
     [CreateEntering] transition to Full tier and seeds [bar_history] from the

--- a/trading/trading/backtest/test/test_runner_tiered_cycle.ml
+++ b/trading/trading/backtest/test/test_runner_tiered_cycle.ml
@@ -239,28 +239,33 @@ let _create_entering ~position_id ~symbol : Position.transition =
 (* 1. Friday cadence isolation                                          *)
 (* -------------------------------------------------------------------- *)
 
-(** On a Friday call, the wrapper issues a [Promote_to_summary] tier-op per
+(** On a Friday call, the wrapper issues a [Promote_to_full] tier-op per
     universe symbol. Per-symbol promotion (rather than a batch
-    [Bar_loader.promote ~symbols:t.universe ~to_:Summary_tier ~as_of] call) is
+    [Bar_loader.promote ~symbols:t.universe ~to_:Full_tier ~as_of] call) is
     load-bearing for parity on broad universes — see [_promote_each_to] in the
     .ml — because batched [Bar_loader.promote] short-circuits on the first
     per-symbol error. The test pins the per-symbol expectation: with two
-    universe symbols, two Promote_to_summary tier-ops fire. (The 2-symbol
-    universe is also extended to include the primary index in the loader, but
-    the primary index is promoted to Metadata before the wrapper runs and is not
-    in [t.universe], so it doesn't add Summary tier-ops here.) *)
-let test_friday_triggers_summary_promote _ =
+    universe symbols, two Promote_to_full tier-ops fire. (The 2-symbol universe
+    is also extended to include the primary index in the loader, but the primary
+    index is promoted to Metadata before the wrapper runs and is not in
+    [t.universe], so it doesn't add Full tier-ops here.)
+
+    Note: prior to the bull-crash A/B parity fix this function went through an
+    intermediate Summary promote pass; with the fix [_run_friday_cycle] drives
+    Full directly so [Bar_history] gets populated even for symbols that don't
+    yet have enough weekly bars to resolve Summary scalars. *)
+let test_friday_triggers_full_promote _ =
   let w = _setup ~universe:[ "AAA"; "BBB" ] () in
   _call w ~date:_friday ~portfolio:_empty_portfolio;
   assert_that
-    (_count_phase w.trace Backtest.Trace.Phase.Promote_summary)
+    (_count_phase w.trace Backtest.Trace.Phase.Promote_full)
     (equal_to 2)
 
-let test_non_friday_skips_summary_promote _ =
+let test_non_friday_skips_full_promote _ =
   let w = _setup ~universe:[ "AAA"; "BBB" ] () in
   _call w ~date:_tuesday ~portfolio:_empty_portfolio;
   assert_that
-    (_count_phase w.trace Backtest.Trace.Phase.Promote_summary)
+    (_count_phase w.trace Backtest.Trace.Phase.Promote_full)
     (equal_to 0)
 
 (* -------------------------------------------------------------------- *)
@@ -568,10 +573,10 @@ let test_throttle_blocks_unknown_symbol _ =
 let suite =
   "Runner_tiered_cycle"
   >::: [
-         "Friday call triggers Summary promote"
-         >:: test_friday_triggers_summary_promote;
-         "Non-Friday call skips Summary promote"
-         >:: test_non_friday_skips_summary_promote;
+         "Friday call triggers Full promote"
+         >:: test_friday_triggers_full_promote;
+         "Non-Friday call skips Full promote"
+         >:: test_non_friday_skips_full_promote;
          "CreateEntering transition promotes symbol to Full"
          >:: test_create_entering_promotes_to_full;
          "Multi-symbol CreateEntering → per-symbol Full-tier promote"


### PR DESCRIPTION
## Summary

- Status-doc-only update for `dev/status/backtest-scale.md`.
- Records that PR #519 (`feat/backtest-tiered-seed-timing`) closes the residual bull-crash A/B parity gap that remained after PR #517.
- Updates §Status, §Open PR, and §Blocked on to reflect the new state. The seed-timing fix is now the final merge-gate before flipping `loader_strategy` default Legacy→Tiered.

This PR can be reviewed in isolation — no code changes.

## Test plan

- [x] No code changes; nothing to build or test.