### PR TITLE
ci(devcontainer): install GNU time so tiered-loader-ab can capture peak RSS

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,6 +55,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
     autoconf \
     automake \
     libtool \
+    time \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Devcontainer image lacks `/usr/bin/time` (the GNU coreutils variant), so `dev/scripts/tiered_loader_ab_compare.sh` falls through to its `_HAVE_GNU_TIME=0` branch and writes the literal string `UNAVAILABLE` for every per-strategy `peak_rss_kb` capture. Effect: the nightly `tiered-loader-ab` workflow has been emitting `Legacy peak RSS: UNAVAILABLE KB` / `Tiered peak RSS: UNAVAILABLE KB` since #508 landed (2026-04-22). See run [24870169890](https://github.com/dayfine/trading/actions/runs/24870169890) for the canonical example.

One-line apt fix: add `time` to the existing apt-install block.

After merge, the next image rebuild + cache invalidation makes `/usr/bin/time` available; subsequent `tiered-loader-ab` runs will report real RSS. This is the prerequisite for continuous CPU + memory monitoring on the Tiered loader (post-flip and beyond).

## Test plan

- [ ] Image rebuild completes via `.github/workflows/image.yml`.
- [ ] Next `tiered-loader-ab` run reports numeric peak RSS for both Legacy and Tiered (no `UNAVAILABLE`).