### PR TITLE
docs(status): scoped 292-symbol A/B finding — Tiered ~95% more RSS + PV diverges $796k (NEEDS INVESTIGATION)

### DIFF
--- a/dev/plans/bar-history-trim-2026-04-24.md
+++ b/dev/plans/bar-history-trim-2026-04-24.md
@@ -1,0 +1,163 @@
+# Plan: Bar_history rolling-window trim (2026-04-24)
+
+## Why
+
+Local A/B finding (PR #524 / `backtest-scale.md` § Follow-up): on a
+292-symbol bull-crash run, Tiered uses ~95% more RSS than Legacy
+(1.87 GB vs 3.65 GB). Diagnosis: `Bar_history` is `Daily_price.t list
+Hashtbl.M(String).t` — append-only, never trimmed, no `trim_before`
+function exists. Both strategies grow Bar_history forever within a
+run. Tiered additionally carries `Full.t.bars` (bounded at
+`Full_compute.tail_days` ≈ 250 bars per Full-tier symbol) on top of
+the same unbounded Bar_history. Result: Tiered pays Legacy's cache
+shape PLUS its own bounded one.
+
+Strategy readers only need ≤365 days of history (52-week RS line is
+the binding lookback). Bars older than 365 days are dead weight in
+both Legacy and Tiered.
+
+This trim is **not** required to flip the Tiered loader default —
+both strategies have the bug, and the flip is gated separately on the
+292-symbol PV divergence (also tracked in PR #524). But fixing
+Bar_history's monotonic growth delivers the design's "29 MB" memory
+target for the first time and benefits Legacy as much as Tiered.
+
+## Goal
+
+Cap per-symbol `Bar_history` at `max_lookback_days` daily bars
+(default 365 days = 52 weeks). End-of-run RSS on the 292-symbol
+bull-crash should drop by ~3× for Legacy (from ~1.87 GB) and by
+~2.5× for Tiered (from ~3.65 GB). Trade lists and final PV must
+remain bit-identical to the pre-trim baseline (no strategy reader
+should ever request bars older than `max_lookback_days`).
+
+## Risks
+
+1. **Some reader needs more than 365 days.** Audit every
+   `Bar_history.daily_bars_for` and `weekly_bars_for` caller before
+   adding the trim. The `weinstein_stops` support-floor primitive is
+   explicitly called out in the .mli as a window-slicing caller —
+   confirm its window is ≤365 days.
+2. **Idempotency on replay.** The simulator can re-invoke the
+   strategy on a replayed day. `accumulate` already handles this via
+   strict-greater-than-last-date check; `trim_before` must be
+   equally idempotent (calling it twice on the same `as_of` is a
+   no-op, never re-adds trimmed bars).
+3. **Parity gates.** `test_tiered_loader_parity` (`smoke/tiered-loader-parity.sexp`,
+   7 symbols × 6 months) and the GHA `tiered-loader-ab` workflow
+   must remain $0.00 PV delta after the trim lands.
+4. **Configurability.** Make `max_lookback_days` a config field on
+   `Weinstein_strategy.config` (default 365), not a hardcoded
+   constant. Future tunability via `--override`.
+
+## Sequence (each PR is independently reviewable, ≤500 LOC)
+
+### PR 1 — `Bar_history.trim_before` primitive + tests
+- Add `val trim_before : t -> as_of:Date.t -> max_lookback_days:int -> unit`
+  to `bar_history.mli` with full doc comment.
+- Implement: for each symbol, drop bars whose `date < as_of -
+  max_lookback_days`. Idempotent.
+- Tests in `test_bar_history.ml`: trim-then-add, trim-empty,
+  trim-twice-same-as_of, trim-with-future-as_of (no-op),
+  trim-with-zero-lookback (drops everything except today).
+- No callers wired yet. Pure dead code. Branch
+  `feat/backtest-bar-history-trim-primitive`.
+- Estimated size: ~80 LOC including tests.
+
+### PR 2 — Audit Bar_history readers + document binding window
+- Doc-only PR. Add a new section
+  `dev/notes/bar-history-readers-2026-04-24.md` listing every caller
+  of `Bar_history.daily_bars_for` / `weekly_bars_for` /
+  `Hashtbl.find` (direct map access) and their effective lookback.
+- Confirm 365 days (52 weeks) is the binding window. If a caller
+  needs more, surface it as a decision item — either make the
+  default bigger or refactor that caller.
+- Update `bar_history.mli` `daily_bars_for` doc comment to record
+  the bounded-by-`max_lookback_days` invariant once integration
+  lands.
+- Branch `docs/bar-history-readers-audit`. Estimated size: ~150
+  LOC of docs.
+
+### PR 3 — Wire `trim_before` into the strategy (feature-flagged off)
+- Add `bar_history_max_lookback_days : int option` to
+  `Weinstein_strategy.config`. `None` = current behavior (no trim);
+  `Some n` = call `Bar_history.trim_before` once per
+  `on_market_close` with `as_of = today`, `max_lookback_days = n`.
+- Default config: `None` (no behavior change).
+- Tests: integration test with `Some 365` confirming trade list +
+  final PV match the `None` baseline on
+  `smoke/tiered-loader-parity.sexp`.
+- Branch `feat/backtest-bar-history-trim-wired`. Estimated size:
+  ~120 LOC.
+
+### PR 4 — Local A/B with flag on, measure RSS savings, verify parity
+- No code change. Just a measurement run + doc update.
+- Run the same 292-symbol scoped A/B (per
+  `backtest-scale.md` § Follow-up repro recipe) with `--override
+  '(bar_history_max_lookback_days 365)'` and capture RSS.
+- Expected: Legacy RSS drops from ~1.87 GB to ~600 MB; Tiered RSS
+  drops from ~3.65 GB to ~1.5 GB. Trade lists bit-identical to
+  baseline (parity gate).
+- If parity holds, write findings into
+  `backtest-scale.md` § Follow-up. If parity breaks, the audit in
+  PR 2 missed a reader; iterate.
+
+### PR 5 — Flip default to 365 days
+- One-line change: `bar_history_max_lookback_days = Some 365` in
+  `Weinstein_strategy.default_config`.
+- Updates the `smoke/tiered-loader-parity.sexp` golden if needed
+  (it shouldn't change since the parity test uses identical
+  strategies on both sides).
+- Updates the goldens-small / goldens-broad expected metrics if any
+  changed (they shouldn't — readers don't reach that far back).
+- Branch `feat/backtest-bar-history-trim-default-on`. Estimated
+  size: ~30 LOC.
+
+### PR 6 (optional) — Drop the `option` wrapper
+- After PR 5 has been on main for some time and no one needed to
+  flip it back to `None`, simplify the config field from
+  `int option` to `int`. Remove dead `None` branch.
+- Branch `feat/backtest-bar-history-trim-cleanup`. Estimated size:
+  ~30 LOC.
+
+## Acceptance per PR
+
+Standard `feat-backtest` checklist applies (see
+`.claude/agents/feat-backtest.md` § Acceptance Checklist). Per-PR
+overrides:
+- PR 1: must include all 5 test cases listed.
+- PR 3: parity test on `smoke/tiered-loader-parity.sexp` must pass
+  with both `None` and `Some 365`.
+- PR 5: small-universe (302) bull-crash A/B must show bit-identical
+  trade lists vs the baseline measured in PR 4.
+
+## Decision items (need human or QC sign-off)
+
+1. **Default lookback value.** 365 days is the obvious starting
+   point given 52-week RS. Could be smaller (`Stops_runner` and the
+   30-week MA only need ~210 days). Bigger window = more memory but
+   safer against unknown future readers. Suggested 365 as a
+   compromise; revisit after PR 2's audit.
+
+2. **Trim cadence.** Per-day trim (in `on_market_close`) vs per-week
+   trim (Friday only) vs per-promote trim (Tiered only, on Full
+   promote). Per-day is the simplest and gives the steady RSS curve
+   we want; per-week amortizes the work but keeps a 7-day buffer of
+   stale bars. Suggested per-day; the cost (one Hashtbl iteration
+   per day) is trivial.
+
+3. **Where the trim call lives.** Inside `Weinstein_strategy.on_market_close`
+   itself (uniform across Legacy and Tiered) vs inside the wrapper
+   for Tiered only. Suggested inside `Weinstein_strategy` so Legacy
+   benefits too — that's the whole point.
+
+## Why this is multi-PR, not one
+
+- **Audit before integration.** PR 2 must complete before PR 3 lands
+  to avoid silently changing strategy outputs.
+- **Reversibility.** PR 3's flag-default-off lets us revert
+  instantly if a reader was missed in PR 2.
+- **Measurement isolation.** PR 4's RSS numbers must come from a
+  clean code state with the flag on, not bundled with implementation
+  changes.
+- **Each PR ≤500 LOC** per `feat-backtest` PR-sizing rules.

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -258,6 +258,69 @@ Build alongside existing `Bar_history` — don't modify it.
   becomes its own track (suggest: `dev/status/backtest-perf.md` for
   CPU + memory continuous monitoring + AD/inventory profiling).
 
+  **Scoped re-run (2026-04-24, 292-symbol universe via filtered
+  `sectors.csv` at `/tmp/data-small-302`).** Both ran to completion
+  (no OOM at this scope). But two unexpected results:
+
+  | | Legacy | Tiered | Δ |
+  |---|---|---|---|
+  | Peak RSS | 1,871,240 KB (~1.87 GB) | **3,652,852 KB (~3.65 GB)** | **+95% more** |
+  | Final PV | $1,873,648.70 | $2,670,361.59 | **+$796,712.89** |
+  | Round trips | 608 | 613 | +5 |
+  | Total PnL | -$80,956.12 (losing) | +$184,640.50 (winning) | flipped sign |
+  | Sharpe | 0.66 | 0.92 | +0.26 |
+  | Max DD | 33.62% | 33.34% | -0.28pp |
+
+  (1) **RSS regression.** Tiered uses ~1.78 GB more than Legacy at
+  this scope — opposite of the design hypothesis. Tiered's `Bar_history`
+  grows to universe size monotonically (per #519's docstring trade-off),
+  AND the loader keeps `Full.t.bars` bounded by `Full_compute.tail_days`
+  per Full-tier symbol. With 302 symbols going to Full at end-of-run
+  (`Tiered loader: Metadata=5 Summary=0 Full=302 at end of simulator
+  run`), the duplicated `Bar_history` + `Full.t.bars` may explain the
+  delta. Worth attributing exactly.
+
+  (2) **PV diverges by $796,713 — a parity break.** #519 verified
+  $0.0000 PV delta on the GHA `tiered-loader-ab` 7-symbol fixture and
+  on the goldens-broad scenarios; the agent's report explicitly noted
+  "302-symbol small-universe verification was not run as a separate
+  test". This run is the first 302-symbol verification post-#519 and
+  it's NOT bit-identical. Possible causes:
+  - Real Tiered bug at 292-symbol scale that the 7-symbol fixture
+    didn't expose (the seed-timing fix in #519 may have a different
+    boundary than tested);
+  - Synthesized data dir at `/tmp/data-small-302` may be missing
+    supporting fixtures (the symlink loop only linked top-level
+    `*.csv` files; ad_breadth subdirs / sector_etf paths might
+    resolve differently between Legacy and Tiered);
+  - Universe membership artifact: filtered sectors.csv has 292
+    symbols (9 of small.sexp's 302 weren't in the full sector map),
+    which may exercise different code paths.
+  
+  Repro: build `/tmp/data-small-302` per the synthesis script in this
+  doc's git history (filter `data/sectors.csv` to symbols in
+  `universes/small.sexp`, symlink per-letter dirs); then
+  ```
+  TRADING_DATA_DIR=/tmp/data-small-302 \
+    /usr/bin/time -o legacy.rss -f '%M' \
+    dune exec --no-build -- trading/backtest/bin/backtest_runner.exe \
+    2015-01-02 2020-12-31 --loader-strategy legacy
+  TRADING_DATA_DIR=/tmp/data-small-302 \
+    /usr/bin/time -o tiered.rss -f '%M' \
+    dune exec --no-build -- trading/backtest/bin/backtest_runner.exe \
+    2015-01-02 2020-12-31 --loader-strategy tiered
+  ```
+  
+  **Action required before flipping `loader_strategy` default:**
+  diagnose the 292-symbol PV divergence. Either:
+  - It's a fixture artifact (synthesized data dir is incomplete) →
+    rebuild a complete fixture and re-test; if still bit-identical,
+    Tiered flip is fine.
+  - It's a real Tiered bug → fix before flipping. The gate stated at
+    the top of this doc ("PV drift inside warn threshold") is broken
+    on 292-symbol; the GHA verification on 7-symbol is insufficient
+    coverage.
+
 - **Broad-universe goldens are testing on a 7-symbol fixture (2026-04-24).**
   `trading/test_data/sectors.csv` has 8 lines (~7 tickers); the broad
   scenarios under `trading/test_data/backtest_scenarios/goldens-broad/`

--- a/dev/status/backtest-scale.md
+++ b/dev/status/backtest-scale.md
@@ -321,6 +321,51 @@ Build alongside existing `Bar_history` — don't modify it.
     on 292-symbol; the GHA verification on 7-symbol is insufficient
     coverage.
 
+  **RSS regression diagnosis: Bar_history is append-only, never
+  trimmed.** From `bar_history.mli`:
+
+  > `accumulate` ... pull today's bar via [get_price] and append it
+  > to the buffer — but only if the bar's date is strictly later than
+  > the last recorded bar.
+  >
+  > `daily_bars_for` ... Return the **full** accumulated daily bar
+  > history for [symbol] in chronological order ... Callers that need
+  > a bounded window should slice the result themselves.
+
+  `Bar_history` is `Daily_price.t list Hashtbl.M(String).t` — a
+  hashmap from symbol to **append-only** bar list. No max-age trim,
+  no rolling window, no LRU eviction, no `trim_before` function
+  exists. Over 6 years × 292 symbols × 1510 trading days × ~64 bytes
+  per `Daily_price.t`: roughly **30 MB minimum** at the OCaml-record
+  level, multiplied by GC overhead and Hashtbl slack to easily reach
+  hundreds of MB. Both Legacy and Tiered keep this state forever
+  within a run. Strategy readers (52-week RS line, 30-week MA, ATR)
+  only need ≤365 days of history; the older bars are dead weight.
+
+  **Why Tiered shows MORE RSS than Legacy** despite both having the
+  same Bar_history growth pattern: Tiered post-#519 carries TWO
+  parallel caches per Full-tier symbol —
+  `Bar_history` (1510 bars after 6 years, never trimmed) PLUS
+  `Full.t.bars` (bounded at `Full_compute.tail_days` ≈ 250 bars).
+  Per the design intent, `Full.t.bars` is the bounded cache, but
+  `Bar_history` was never converted to a windowed view; it's the
+  same monotonic append-only list Legacy uses. So Tiered pays for
+  Legacy's cache shape PLUS its own bounded one. End-of-run state
+  for the 292-symbol scenario per the Tiered log: `Metadata=5
+  Summary=0 Full=302 at end of simulator run` — 302 symbols ×
+  (1510 + 250) bars each.
+
+  **Suggested fix (sequenced, NOT in this doc PR — see
+  `dev/plans/bar-history-trim-2026-04-24.md`):** add
+  `Bar_history.trim_before : t -> as_of:Date.t ->
+  max_lookback_days:int -> unit` and call it once per backtest day
+  with `max_lookback_days` derived from the longest-window strategy
+  reader (52 weeks × 7 days = 364 days). With a 365-day window the
+  per-symbol Bar_history caps at ~365 daily bars vs current ~1510
+  after 6 years — a ~4× reduction independent of the Tiered flip.
+  Both Legacy and Tiered benefit. Plan + start tracked in
+  `dev/plans/bar-history-trim-2026-04-24.md`.
+
 - **Broad-universe goldens are testing on a 7-symbol fixture (2026-04-24).**
   `trading/test_data/sectors.csv` has 8 lines (~7 tickers); the broad
   scenarios under `trading/test_data/backtest_scenarios/goldens-broad/`


### PR DESCRIPTION
## Summary

Doc-only update appending to the 10K-symbol OOM follow-up landed in #523. Records the result of running the local A/B against a scoped 292-symbol synthesized data dir (filtered `data/sectors.csv` by `universes/small.sexp` + symlinked per-letter dirs).

| | Legacy | Tiered | Δ |
|---|---|---|---|
| Peak RSS | 1,871,240 KB | **3,652,852 KB** | **+95%** |
| Final PV | $1,873,648.70 | $2,670,361.59 | **+$796,713** |
| Round trips | 608 | 613 | +5 |
| Total PnL | -$80,956.12 | +$184,640.50 | sign flip |

## Two surprising findings

**1. RSS regression.** Tiered uses ~95% MORE memory than Legacy at this scope (1.78 GB more). Opposite of the design hypothesis. `Bar_history` grows monotonically to universe size while `Full.t.bars` is also kept per Full-tier symbol — the duplicated retention may explain the delta. Worth attributing exactly.

**2. PV diverges by \$796k — a parity break.** #519 verified $0.00 PV delta on the GHA 7-symbol fixture and on goldens-broad scenarios; the agent explicitly said "302-symbol small-universe verification was not run as a separate test". This is the first 302-symbol post-#519 measurement and it's NOT bit-identical. Possible causes (need investigation, NOT addressed here):
- Real Tiered bug at 292-symbol scale that the 7-symbol fixture didn't expose
- Synthesized data dir at `/tmp/data-small-302` may be missing supporting fixtures (the symlink loop only linked top-level `*.csv`; ad_breadth subdirs / sector_etf paths might resolve differently between the two strategies)
- Universe-membership artifact (filtered sectors.csv has 292 symbols; small.sexp's 302 lost 9 to inventory mismatch)

## Action required

The Tiered flip should NOT proceed until this is diagnosed. Either:
- It's a fixture artifact → rebuild a complete `goldens-small/` test data fixture and re-test; if bit-identical, flip is fine.
- It's a real Tiered bug → fix before flipping. The GHA "PV drift inside warn threshold" gate on the 7-symbol fixture is insufficient coverage.

Document records the repro recipe so a future investigator (probably feat-backtest agent) can pick up cleanly.

## Test plan

- [x] `trading/devtools/checks/status_file_integrity.sh` passes.
- [x] No code touched; doc-only addition under § Follow-up / escalation in `dev/status/backtest-scale.md`.