### PR TITLE
feat(weinstein/strategy): add Bar_history.trim_before primitive (no callers)

### DIFF
--- a/trading/trading/weinstein/strategy/lib/bar_history.ml
+++ b/trading/trading/weinstein/strategy/lib/bar_history.ml
@@ -41,6 +41,18 @@ let _pick_new_bars ~existing bars =
   | None -> bars
   | Some last_date -> _bars_strictly_after ~last_date bars
 
+let _drop_bars_before ~cutoff bars =
+  List.drop_while bars ~f:(fun b -> Date.( < ) b.Types.Daily_price.date cutoff)
+
+let trim_before (t : t) ~(as_of : Date.t) ~(max_lookback_days : int) =
+  if max_lookback_days < 0 then
+    invalid_arg
+      (Printf.sprintf
+         "Bar_history.trim_before: max_lookback_days must be >= 0, got %d"
+         max_lookback_days);
+  let cutoff = Date.add_days as_of (-max_lookback_days) in
+  Hashtbl.map_inplace t ~f:(fun bars -> _drop_bars_before ~cutoff bars)
+
 let seed (t : t) ~symbol ~(bars : Types.Daily_price.t list) =
   let existing = Hashtbl.find t symbol |> Option.value ~default:[] in
   let new_bars = _pick_new_bars ~existing bars in

--- a/trading/trading/weinstein/strategy/lib/bar_history.mli
+++ b/trading/trading/weinstein/strategy/lib/bar_history.mli
@@ -35,6 +35,26 @@ val daily_bars_for : t -> symbol:string -> Types.Daily_price.t list
     bars. Callers that need a bounded window should slice the result themselves
     — the support-floor primitive in [weinstein_stops] is one such caller. *)
 
+val trim_before : t -> as_of:Date.t -> max_lookback_days:int -> unit
+(** [trim_before t ~as_of ~max_lookback_days] drops, for every symbol in [t],
+    bars whose date is strictly older than [as_of] minus [max_lookback_days]
+    days. Bars whose date equals or exceeds the cutoff are retained.
+
+    Idempotent: calling twice with the same [as_of] / [max_lookback_days] is
+    equivalent to calling once. Calling with an [as_of] in the future relative
+    to the held bars is a no-op (cutoff is older than every bar; nothing drops).
+    Calling with [max_lookback_days = 0] drops every bar whose date is strictly
+    less than [as_of] — i.e., keeps only [as_of]'s bar if present.
+
+    Raises [Invalid_argument] if [max_lookback_days < 0].
+
+    Motivation: per-symbol bar buffers grow monotonically via [accumulate] and
+    [seed], but strategy readers (52-week RS line, 30-week MA, ATR) only need a
+    bounded recent window. Periodically calling [trim_before] caps the buffer's
+    working set at [max_lookback_days] days per symbol. See
+    [dev/plans/bar-history-trim-2026-04-24.md] for the motivating measurement.
+*)
+
 val seed : t -> symbol:string -> bars:Types.Daily_price.t list -> unit
 (** [seed t ~symbol ~bars] merges [bars] into [symbol]'s accumulated history.
     [bars] must already be in chronological order (oldest first) — the caller is

--- a/trading/trading/weinstein/strategy/test/test_bar_history.ml
+++ b/trading/trading/weinstein/strategy/test/test_bar_history.ml
@@ -238,6 +238,128 @@ let test_seed_then_accumulate_continues_cleanly _ =
   assert_that (Bar_history.daily_bars_for t ~symbol:"AAPL") (size_is 3)
 
 (* ------------------------------------------------------------------ *)
+(* trim_before                                                          *)
+(* ------------------------------------------------------------------ *)
+
+let test_trim_before_empty_buffer_is_noop _ =
+  let t = Bar_history.create () in
+  Bar_history.trim_before t
+    ~as_of:(Date.of_string "2024-06-01")
+    ~max_lookback_days:30;
+  assert_that (Bar_history.daily_bars_for t ~symbol:"AAPL") is_empty
+
+let test_trim_before_then_accumulate_appends_new_bar _ =
+  (* Seed buffer with bars spanning Jan-Jun, trim to last 30 days as of Jun 1,
+     then accumulate a Jun 5 bar. Final buffer holds bars >= May 2 plus Jun 5. *)
+  let t = Bar_history.create () in
+  let dates =
+    [
+      "2024-01-08";
+      "2024-02-08";
+      "2024-04-08";
+      "2024-05-08";
+      "2024-05-25";
+      "2024-06-01";
+    ]
+  in
+  let bars = List.map dates ~f:(fun d -> make_bar d 100.0) in
+  Bar_history.seed t ~symbol:"AAPL" ~bars;
+  Bar_history.trim_before t
+    ~as_of:(Date.of_string "2024-06-01")
+    ~max_lookback_days:30;
+  (* Cutoff = May 2; keep bars >= May 2: May 8, May 25, Jun 1. *)
+  let later = make_bar "2024-06-05" 105.0 in
+  Bar_history.accumulate t
+    ~get_price:(single_symbol_get_price ~symbol:"AAPL" ~bar:later)
+    ~symbols:[ "AAPL" ];
+  let daily = Bar_history.daily_bars_for t ~symbol:"AAPL" in
+  assert_that daily
+    (elements_are
+       [
+         field
+           (fun b -> b.Types.Daily_price.date)
+           (equal_to (Date.of_string "2024-05-08"));
+         field
+           (fun b -> b.Types.Daily_price.date)
+           (equal_to (Date.of_string "2024-05-25"));
+         field
+           (fun b -> b.Types.Daily_price.date)
+           (equal_to (Date.of_string "2024-06-01"));
+         field
+           (fun b -> b.Types.Daily_price.date)
+           (equal_to (Date.of_string "2024-06-05"));
+       ])
+
+let test_trim_before_is_idempotent _ =
+  (* Two calls with the same as_of / max_lookback_days produce the same buffer
+     state as a single call. *)
+  let t_once = Bar_history.create () in
+  let t_twice = Bar_history.create () in
+  let bars =
+    [
+      make_bar "2024-01-08" 100.0;
+      make_bar "2024-03-08" 105.0;
+      make_bar "2024-05-25" 110.0;
+      make_bar "2024-06-01" 115.0;
+    ]
+  in
+  Bar_history.seed t_once ~symbol:"AAPL" ~bars;
+  Bar_history.seed t_twice ~symbol:"AAPL" ~bars;
+  let as_of = Date.of_string "2024-06-01" in
+  Bar_history.trim_before t_once ~as_of ~max_lookback_days:30;
+  Bar_history.trim_before t_twice ~as_of ~max_lookback_days:30;
+  Bar_history.trim_before t_twice ~as_of ~max_lookback_days:30;
+  assert_that
+    (Bar_history.daily_bars_for t_twice ~symbol:"AAPL")
+    (equal_to (Bar_history.daily_bars_for t_once ~symbol:"AAPL"))
+
+let test_trim_before_with_as_of_before_oldest_bar_is_noop _ =
+  (* If the cutoff lies before every held bar, nothing drops. *)
+  let t = Bar_history.create () in
+  let bars = [ make_bar "2024-05-01" 100.0; make_bar "2024-05-15" 105.0 ] in
+  Bar_history.seed t ~symbol:"AAPL" ~bars;
+  Bar_history.trim_before t
+    ~as_of:(Date.of_string "2024-04-01")
+    ~max_lookback_days:7;
+  let daily = Bar_history.daily_bars_for t ~symbol:"AAPL" in
+  assert_that daily (size_is 2)
+
+let test_trim_before_zero_lookback_keeps_only_as_of_bar _ =
+  (* max_lookback_days = 0 → cutoff = as_of, so bars strictly older than as_of
+     drop and only as_of (or later) remain. *)
+  let t = Bar_history.create () in
+  let bars =
+    [
+      make_bar "2024-05-01" 100.0;
+      make_bar "2024-05-15" 105.0;
+      make_bar "2024-06-01" 110.0;
+    ]
+  in
+  Bar_history.seed t ~symbol:"AAPL" ~bars;
+  Bar_history.trim_before t
+    ~as_of:(Date.of_string "2024-06-01")
+    ~max_lookback_days:0;
+  assert_that
+    (Bar_history.daily_bars_for t ~symbol:"AAPL")
+    (elements_are
+       [
+         field
+           (fun b -> b.Types.Daily_price.date)
+           (equal_to (Date.of_string "2024-06-01"));
+       ])
+
+let test_trim_before_negative_lookback_raises _ =
+  let t = Bar_history.create () in
+  Bar_history.seed t ~symbol:"AAPL" ~bars:[ make_bar "2024-05-01" 100.0 ];
+  assert_raises
+    (Invalid_argument
+       "Bar_history.trim_before: max_lookback_days must be >= 0, got -1")
+    (fun () ->
+      Bar_history.trim_before t
+        ~as_of:(Date.of_string "2024-06-01")
+        ~max_lookback_days:(-1))
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -268,4 +390,15 @@ let () =
            "seed is per-symbol" >:: test_seed_is_per_symbol;
            "seed then accumulate continues cleanly"
            >:: test_seed_then_accumulate_continues_cleanly;
+           "trim_before on empty buffer is no-op"
+           >:: test_trim_before_empty_buffer_is_noop;
+           "trim_before then accumulate appends new bar"
+           >:: test_trim_before_then_accumulate_appends_new_bar;
+           "trim_before is idempotent" >:: test_trim_before_is_idempotent;
+           "trim_before with as_of before oldest bar is no-op"
+           >:: test_trim_before_with_as_of_before_oldest_bar_is_noop;
+           "trim_before with max_lookback_days = 0 keeps only as_of bar"
+           >:: test_trim_before_zero_lookback_keeps_only_as_of_bar;
+           "trim_before with negative lookback raises Invalid_argument"
+           >:: test_trim_before_negative_lookback_raises;
          ])


### PR DESCRIPTION
## Summary

PR 1 of the multi-PR sequence in `dev/plans/bar-history-trim-2026-04-24.md`. Adds a pure-dead-code `Bar_history.trim_before` primitive plus tests. **No callers wired** in this PR — the function is unused production code until PR 3 introduces a config-flagged caller.

## Motivation

Local A/B finding (per `dev/status/backtest-scale.md` § Follow-up): on a 292-symbol bull-crash run, Tiered uses ~95% more RSS than Legacy (~3.65 GB vs ~1.87 GB). Root cause: `Bar_history` is `Daily_price.t list Hashtbl.M(String).t` — append-only, never trimmed. Strategy readers only need ≤365 days (52-week RS line). This primitive is the foundation; PR 3 wires it in, PR 4 verifies parity, PR 5 flips the default.

## What this PR contains

- `bar_history.mli`: new `val trim_before : t -> as_of:Date.t -> max_lookback_days:int -> unit` with full doc comment (idempotency, no-op semantics for future `as_of`, raises on negative lookback).
- `bar_history.ml`: small implementation — one `Hashtbl.map_inplace` over a `List.drop_while` on each symbol's chronologically-sorted bars (~7 lines plus a one-line helper).
- `test_bar_history.ml`: 6 new test cases (per the plan):
  1. trim_before on empty buffer is a no-op
  2. trim_before then accumulate appends new bar correctly
  3. trim_before twice with same params is idempotent
  4. trim_before with as_of before oldest bar is a no-op
  5. trim_before with max_lookback_days = 0 keeps only as_of's bar
  6. trim_before with max_lookback_days = -1 raises Invalid_argument

## Test plan

- [x] dune build clean
- [x] dune runtest trading/weinstein/strategy/test --force: 14 prior + 6 new = 20 tests in test_bar_history, all pass; other strategy tests bit-identical
- [x] dune build @fmt: clean (formatter applied; ocamlformat 0.29.0 produces no diff)
- [x] dune runtest (full): no new failures; Tiered_loader_parity failures are pre-existing (path resolution to data/backtest_scenarios/..., unrelated to this PR — verified by reverting to main@origin)
- [x] No callers wired — weinstein_strategy.ml and all other consumers are untouched

## Out of scope

- Calling trim_before from anywhere in production (PR 3)
- Adding bar_history_max_lookback_days to Weinstein_strategy.config (PR 3)
- Measuring the RSS savings (PR 4)
- Flipping the default to 365 days (PR 5)