### PR TITLE
feat(backtest-perf): C1 hypothesis-toggle config fields

### DIFF
--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -1,3 +1,10 @@
+(* @large-module: backtest orchestration covers config-override deep-merge,
+   universe + sector-map resolution, AD-breadth + sector-ETF loading (each
+   gated by hypothesis-testing toggles in [Weinstein_strategy.config]), and
+   the Legacy/Tiered loader-strategy split. Splitting any of these would
+   either duplicate the small helpers or leak the [_deps] record's shape
+   across modules; the Tiered path already lives in [tiered_runner.ml] for
+   the same reason. *)
 open Core
 open Trading_simulation
 
@@ -103,6 +110,80 @@ let _resolve_ticker_sectors ~data_dir sector_map_override =
       eprintf "Loading universe from sectors.csv...\n%!";
       Sector_map.load ~data_dir
 
+(** Apply [config.universe_cap] to the (sorted) universe + sector map.
+
+    [universe_cap = Some n] truncates the universe to the first [n] symbols
+    after the existing [String.compare] sort and rebuilds [ticker_sectors] with
+    only the kept symbols. Hypothesis-testing field — see [config] doc. [None]
+    (default) returns the inputs unchanged. *)
+let _apply_universe_cap ~ticker_sectors ~universe ~cap =
+  match cap with
+  | None -> (ticker_sectors, universe)
+  | Some n when n >= List.length universe -> (ticker_sectors, universe)
+  | Some n ->
+      let kept = List.take universe n in
+      let kept_set = String.Set.of_list kept in
+      let trimmed = Hashtbl.create (module String) in
+      Hashtbl.iteri ticker_sectors ~f:(fun ~key ~data ->
+          if Set.mem kept_set key then Hashtbl.set trimmed ~key ~data);
+      eprintf
+        "universe_cap = Some %d: truncated universe from %d to %d symbols\n%!" n
+        (List.length universe) (List.length kept);
+      (trimmed, kept)
+
+(** Load AD breadth bars unless [config.skip_ad_breadth = true]. The skip path
+    short-circuits to the same [[]] value [Ad_bars.load] returns when the
+    underlying CSVs are absent, so downstream macro readers experience the same
+    degraded mode. Hypothesis-testing flag — see [config] doc. *)
+let _load_ad_bars ?trace ~data_dir ~universe_size
+    ~(config : Weinstein_strategy.config) () =
+  if config.skip_ad_breadth then (
+    eprintf "skip_ad_breadth = true: AD breadth bars NOT loaded (degraded)\n%!";
+    [])
+  else (
+    eprintf "Loading AD breadth bars...\n%!";
+    Trace.record ?trace ~symbols_out:universe_size Trace.Phase.Macro (fun () ->
+        Weinstein_strategy.Ad_bars.load ~data_dir))
+
+(** Honor [config.skip_sector_etf_load] by clearing [config.sector_etfs] so no
+    sector-ETF bars are loaded downstream. Hypothesis-testing flag — see
+    [config] doc. *)
+let _maybe_clear_sector_etfs (config : Weinstein_strategy.config) =
+  if config.skip_sector_etf_load then (
+    eprintf "skip_sector_etf_load = true: sector ETFs NOT loaded (degraded)\n%!";
+    { config with sector_etfs = [] })
+  else config
+
+(** Build the runner's base config: defaults + the canonical macro pipeline
+    (full SPDR sector ETF list + global indices). Returns a config that still
+    has the C1 hypothesis-testing toggles at their defaults; [_load_deps]
+    threads [overrides] through this and then honors any toggles set there. *)
+let _runner_base_config ~universe =
+  let cfg = Weinstein_strategy.default_config ~universe ~index_symbol in
+  {
+    cfg with
+    indices =
+      {
+        primary = index_symbol;
+        global = Weinstein_strategy.Macro_inputs.default_global_indices;
+      };
+    sector_etfs = Weinstein_strategy.Macro_inputs.spdr_sector_etfs;
+  }
+
+(** Union of all symbols the runner needs bar data for: primary index, the
+    (post-cap) universe, and every sector ETF + global index that survived the
+    [skip_sector_etf_load] toggle. Deduped + sorted so callers can rely on a
+    stable order. *)
+let _all_runner_symbols ~(config : Weinstein_strategy.config) ~universe =
+  let sector_etf_symbols =
+    List.map config.sector_etfs ~f:(fun (sym, _) -> sym)
+  in
+  let global_index_symbols =
+    List.map config.indices.global ~f:(fun (sym, _) -> sym)
+  in
+  (index_symbol :: universe) @ sector_etf_symbols @ global_index_symbols
+  |> List.dedup_and_sort ~compare:String.compare
+
 let _load_deps ?trace ~overrides ~sector_map_override () =
   let data_dir_fpath = Data_path.default_data_dir () in
   let data_dir = Fpath.to_string data_dir_fpath in
@@ -113,36 +194,18 @@ let _load_deps ?trace ~overrides ~sector_map_override () =
   let universe =
     Hashtbl.keys ticker_sectors |> List.sort ~compare:String.compare
   in
+  (* Build the base config + apply overrides FIRST so the hypothesis-testing
+     toggles are populated before we use them to gate AD-breadth +
+     sector-ETF loads and to apply the universe cap. *)
+  let config = _apply_overrides (_runner_base_config ~universe) overrides in
+  let ticker_sectors, universe =
+    _apply_universe_cap ~ticker_sectors ~universe ~cap:config.universe_cap
+  in
   let universe_size = List.length universe in
   eprintf "Universe: %d stocks\n%!" universe_size;
-  eprintf "Loading AD breadth bars...\n%!";
-  let ad_bars =
-    Trace.record ?trace ~symbols_out:universe_size Trace.Phase.Macro (fun () ->
-        Weinstein_strategy.Ad_bars.load ~data_dir)
-  in
-  let base_config = Weinstein_strategy.default_config ~universe ~index_symbol in
-  let config =
-    {
-      base_config with
-      indices =
-        {
-          primary = index_symbol;
-          global = Weinstein_strategy.Macro_inputs.default_global_indices;
-        };
-      sector_etfs = Weinstein_strategy.Macro_inputs.spdr_sector_etfs;
-    }
-  in
-  let config = _apply_overrides config overrides in
-  let sector_etf_symbols =
-    List.map config.sector_etfs ~f:(fun (sym, _) -> sym)
-  in
-  let global_index_symbols =
-    List.map config.indices.global ~f:(fun (sym, _) -> sym)
-  in
-  let all_symbols =
-    (index_symbol :: universe) @ sector_etf_symbols @ global_index_symbols
-    |> List.dedup_and_sort ~compare:String.compare
-  in
+  let config = _maybe_clear_sector_etfs { config with universe } in
+  let ad_bars = _load_ad_bars ?trace ~data_dir ~universe_size ~config () in
+  let all_symbols = _all_runner_symbols ~config ~universe in
   {
     data_dir_fpath;
     ticker_sectors;

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -6,6 +6,7 @@
   test_runner_tiered_skeleton
   test_runner_tiered_cycle
   test_runner_tiered_metadata_tolerance
+  test_runner_hypothesis_overrides
   test_tiered_loader_parity)
  (libraries
   ounit2

--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -1,0 +1,235 @@
+(** Tests for the perf workstream C1 hypothesis-toggle config fields:
+    [bar_history_max_lookback_days], [skip_ad_breadth], [skip_sector_etf_load],
+    and [universe_cap].
+
+    These fields land in [Weinstein_strategy.config] together; their unifying
+    contract is "default value = current behaviour, set via [--override]". Tests
+    pin two layers:
+
+    1. {b Sexp round-trip} — each field survives [Sexp.t_of_sexp] /
+    [Sexp.sexp_of_t] from a partial-config sexp the same way [--override]
+    deep-merges them. Pins the wiring needed for hypothesis tests like
+    [--override '(bar_history_max_lookback_days 365)'] to actually land the
+    value into the running config. 2. {b Runner integration} — running
+    [Backtest.Runner.run_backtest] with each toggle set drives the runner down
+    the toggled code path. We use the committed parity scenario fixture
+    ([smoke/tiered-loader-parity.sexp], 7-symbol universe) so the cycle fully
+    exercises the runner's pre-simulator paths without dragging in a broad
+    universe.
+
+    [bar_history_max_lookback_days] is config-only in C1: setting it must NOT
+    change observable strategy behaviour. The wiring lives in PR 3 of
+    [dev/plans/bar-history-trim-2026-04-24.md]. The test here pins the no-op-now
+    contract so a future change can flip the test in the same PR that flips the
+    runtime behaviour. *)
+
+open OUnit2
+open Core
+open Matchers
+module Scenario = Scenario_lib.Scenario
+module Universe_file = Scenario_lib.Universe_file
+
+(* -------------------------------------------------------------------- *)
+(* Fixture loading (mirrors test_tiered_loader_parity)                   *)
+(* -------------------------------------------------------------------- *)
+
+let _fixtures_root () =
+  let data_dir = Data_path.default_data_dir () |> Fpath.to_string in
+  Filename.concat data_dir "backtest_scenarios"
+
+let _scenario_path () =
+  Filename.concat (_fixtures_root ()) "smoke/tiered-loader-parity.sexp"
+
+let _load_scenario () = Scenario.load (_scenario_path ())
+
+let _sector_map_override (s : Scenario.t) =
+  let resolved = Filename.concat (_fixtures_root ()) s.universe_path in
+  Universe_file.to_sector_map_override (Universe_file.load resolved)
+
+let _run (s : Scenario.t) ~overrides =
+  let sector_map_override = _sector_map_override s in
+  Backtest.Runner.run_backtest ~start_date:s.period.start_date
+    ~end_date:s.period.end_date ~overrides ?sector_map_override
+    ~loader_strategy:Loader_strategy.Legacy ()
+
+(* -------------------------------------------------------------------- *)
+(* Sexp round-trip                                                       *)
+(* -------------------------------------------------------------------- *)
+
+(** Apply a single override sexp the same way [Backtest.Runner._apply_overrides]
+    does, then read the named field back out. Mirrors what happens when a user
+    passes [--override '<sexp>'] on the CLI. *)
+let _apply_one_override config override_sexp =
+  let base = Weinstein_strategy.sexp_of_config config in
+  (* Inline copy of the deep-merge logic exercised by the runner — the
+     production helper is private. *)
+  let is_record fields =
+    List.for_all fields ~f:(function
+      | Sexp.List [ Sexp.Atom _; _ ] -> true
+      | _ -> false)
+  in
+  let rec merge base overlay =
+    match (base, overlay) with
+    | Sexp.List bf, Sexp.List of_ when is_record bf && is_record of_ ->
+        let overlay_map =
+          List.filter_map of_ ~f:(function
+            | Sexp.List [ Sexp.Atom k; v ] -> Some (k, v)
+            | _ -> None)
+          |> String.Map.of_alist_exn
+        in
+        Sexp.List
+          (List.map bf ~f:(function
+            | Sexp.List [ Sexp.Atom k; v ] as pair -> (
+                match Map.find overlay_map k with
+                | Some v' -> Sexp.List [ Sexp.Atom k; merge v v' ]
+                | None -> pair)
+            | other -> other))
+    | _, _ -> overlay
+  in
+  Weinstein_strategy.config_of_sexp (merge base override_sexp)
+
+let _default_config () =
+  Weinstein_strategy.default_config ~universe:[ "AAPL" ] ~index_symbol:"GSPCX"
+
+let test_default_preserves_current_behaviour _ =
+  let cfg = _default_config () in
+  assert_that cfg
+    (all_of
+       [
+         field
+           (fun (c : Weinstein_strategy.config) ->
+             c.bar_history_max_lookback_days)
+           is_none;
+         field
+           (fun (c : Weinstein_strategy.config) -> c.skip_ad_breadth)
+           (equal_to false);
+         field
+           (fun (c : Weinstein_strategy.config) -> c.skip_sector_etf_load)
+           (equal_to false);
+         field (fun (c : Weinstein_strategy.config) -> c.universe_cap) is_none;
+       ])
+
+let test_override_bar_history_max_lookback_days _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string "((bar_history_max_lookback_days (365)))")
+  in
+  assert_that merged.bar_history_max_lookback_days (is_some_and (equal_to 365))
+
+let test_override_skip_ad_breadth _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string "((skip_ad_breadth true))")
+  in
+  assert_that merged.skip_ad_breadth (equal_to true)
+
+let test_override_skip_sector_etf_load _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string "((skip_sector_etf_load true))")
+  in
+  assert_that merged.skip_sector_etf_load (equal_to true)
+
+let test_override_universe_cap _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string "((universe_cap (3)))")
+  in
+  assert_that merged.universe_cap (is_some_and (equal_to 3))
+
+(* -------------------------------------------------------------------- *)
+(* Runner integration: each toggle drives the right code path            *)
+(* -------------------------------------------------------------------- *)
+
+(** [bar_history_max_lookback_days = Some n] must NOT change observable
+    behaviour in C1 — the strategy doesn't yet read the field. Pin trade count
+    and final portfolio value against the baseline so a future runtime wiring
+    forces this test to be updated in the same PR. *)
+let test_bar_history_lookback_is_no_op_in_c1 _ =
+  let s = _load_scenario () in
+  let baseline = _run s ~overrides:[] in
+  let with_lookback =
+    _run s
+      ~overrides:[ Sexp.of_string "((bar_history_max_lookback_days (365)))" ]
+  in
+  assert_that with_lookback.summary
+    (all_of
+       [
+         field
+           (fun (sm : Backtest.Summary.t) -> sm.n_round_trips)
+           (equal_to baseline.summary.n_round_trips);
+         field
+           (fun (sm : Backtest.Summary.t) -> sm.final_portfolio_value)
+           (float_equal ~epsilon:0.01 baseline.summary.final_portfolio_value);
+       ])
+
+(** [universe_cap = Some n] truncates the loaded universe. The parity fixture
+    has 7 symbols; capping to 3 should leave the runner's effective universe at
+    3. We assert [summary.universe_size = 3] and that the run completes
+    successfully. The cap is applied before [Total symbols] logging, so the
+    runner sees the capped universe. *)
+let test_universe_cap_truncates_universe _ =
+  let s = _load_scenario () in
+  let result = _run s ~overrides:[ Sexp.of_string "((universe_cap (3)))" ] in
+  assert_that result.summary
+    (field (fun (sm : Backtest.Summary.t) -> sm.universe_size) (equal_to 3))
+
+(** [universe_cap = Some n] when [n >= |universe|] is a no-op — the runner
+    leaves the universe untouched. Pinning this avoids a regression where a
+    naive [List.take] truncates to the cap regardless of size. *)
+let test_universe_cap_above_universe_is_no_op _ =
+  let s = _load_scenario () in
+  let baseline = _run s ~overrides:[] in
+  let result = _run s ~overrides:[ Sexp.of_string "((universe_cap (1000)))" ] in
+  assert_that result.summary
+    (field
+       (fun (sm : Backtest.Summary.t) -> sm.universe_size)
+       (equal_to baseline.summary.universe_size))
+
+(** [skip_ad_breadth = true] must run to completion. We don't pin PV — the
+    degraded-mode strategy is expected to take different decisions when
+    AD-breadth indicators see [[]] instead of real data. The contract this test
+    pins is: the strategy doesn't crash on empty AD bars. *)
+let test_skip_ad_breadth_runs_to_completion _ =
+  let s = _load_scenario () in
+  let result =
+    _run s ~overrides:[ Sexp.of_string "((skip_ad_breadth true))" ]
+  in
+  assert_that (List.length result.steps) (gt (module Int_ord) 0)
+
+(** [skip_sector_etf_load = true] must run to completion. Same degraded-mode
+    semantics as [skip_ad_breadth] — the screener's sector gate falls back to
+    Neutral when no sector ETFs are loaded. *)
+let test_skip_sector_etf_load_runs_to_completion _ =
+  let s = _load_scenario () in
+  let result =
+    _run s ~overrides:[ Sexp.of_string "((skip_sector_etf_load true))" ]
+  in
+  assert_that (List.length result.steps) (gt (module Int_ord) 0)
+
+let suite =
+  "Runner_hypothesis_overrides"
+  >::: [
+         "default config preserves current behaviour"
+         >:: test_default_preserves_current_behaviour;
+         "override: bar_history_max_lookback_days round-trips through sexp"
+         >:: test_override_bar_history_max_lookback_days;
+         "override: skip_ad_breadth round-trips through sexp"
+         >:: test_override_skip_ad_breadth;
+         "override: skip_sector_etf_load round-trips through sexp"
+         >:: test_override_skip_sector_etf_load;
+         "override: universe_cap round-trips through sexp"
+         >:: test_override_universe_cap;
+         "bar_history_max_lookback_days is a no-op in C1 (deferred wiring)"
+         >:: test_bar_history_lookback_is_no_op_in_c1;
+         "universe_cap = Some 3 truncates 7-symbol universe to 3"
+         >:: test_universe_cap_truncates_universe;
+         "universe_cap above universe size is a no-op"
+         >:: test_universe_cap_above_universe_is_no_op;
+         "skip_ad_breadth = true runs to completion (degraded mode)"
+         >:: test_skip_ad_breadth_runs_to_completion;
+         "skip_sector_etf_load = true runs to completion (degraded mode)"
+         >:: test_skip_sector_etf_load_runs_to_completion;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -31,6 +31,10 @@ type config = {
   stops_config : Weinstein_stops.config;
   initial_stop_buffer : float;
   lookback_bars : int;
+  bar_history_max_lookback_days : int option;
+  skip_ad_breadth : bool;
+  skip_sector_etf_load : bool;
+  universe_cap : int option;
 }
 [@@deriving sexp]
 
@@ -46,6 +50,10 @@ let default_config ~universe ~index_symbol =
     stops_config = Weinstein_stops.default_config;
     initial_stop_buffer = 1.02;
     lookback_bars = 52;
+    bar_history_max_lookback_days = None;
+    skip_ad_breadth = false;
+    skip_sector_etf_load = false;
+    universe_cap = None;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -92,10 +92,46 @@ type config = {
   lookback_bars : int;
       (** Number of weekly bars to pass to stage/macro analysers (default: 52).
           Must be >= 30 (one MA period). *)
+  bar_history_max_lookback_days : int option;
+      (** Hypothesis-testing field (perf workstream C1). When [Some n], strategy
+          callers can use this as the upper bound on Bar_history retention (drop
+          bars older than [as_of - n] days). [None] (default) preserves current
+          behaviour — Bar_history grows unbounded for the run. The strategy
+          itself does NOT yet call [Bar_history.trim_before] on this field;
+          wiring is deferred to PR 3 of the Bar_history trim sequence (see
+          [dev/plans/bar-history-trim-2026-04-24.md]). C1 only ships the field
+          so downstream PRs and the [--override] mechanism can use it. *)
+  skip_ad_breadth : bool;
+      (** Hypothesis-testing field (perf workstream C1). When [true], the runner
+          does NOT call [Weinstein_strategy.Ad_bars.load]; macro indicators that
+          depend on AD-breadth fall through to a degraded mode (treat AD-breadth
+          as constant). Default [false] — current behaviour. Used for hypothesis
+          tests like H3 (does AD-breadth load dominate RSS at 10K-symbol
+          scale?). NOT safe to flip on in production. *)
+  skip_sector_etf_load : bool;
+      (** Hypothesis-testing field (perf workstream C1). When [true], the runner
+          clears [sector_etfs] before strategy construction so sector-ETF bars
+          are not loaded. Sector classification falls back to whatever
+          [Sector_map] alone provides. Default [false] — current behaviour. Used
+          for hypothesis tests like H4 (are sector ETF + index loads bounded?).
+          NOT safe to flip on in production. *)
+  universe_cap : int option;
+      (** Hypothesis-testing field (perf workstream C1). When [Some n], the
+          runner truncates the loaded universe to the first [n] symbols (after
+          the existing [String.compare] sort) before strategy construction.
+          [None] (default) uses the full universe. Used for hypothesis tests
+          like H5 (how does RSS scale with universe size?). NOT safe to flip on
+          in production. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for
-    backtesting. *)
+    backtesting.
+
+    The four hypothesis-testing fields ([bar_history_max_lookback_days],
+    [skip_ad_breadth], [skip_sector_etf_load], [universe_cap]) all default to
+    behaviour-preserving values. Setting any of them changes runner / strategy
+    behaviour and is intended for perf measurement A/Bs only — see the H-series
+    in [dev/plans/backtest-perf-2026-04-24.md]. *)
 
 val default_config : universe:string list -> index_symbol:string -> config
 (** Build a default config with Weinstein book values. The resulting config has


### PR DESCRIPTION
## Summary

Workstream C1 of `dev/plans/backtest-perf-2026-04-24.md`. Adds four
hypothesis-testing fields to `Weinstein_strategy.config`, each with a
behaviour-preserving default and `--override`-driven activation, so the
H-series perf experiments can be run with a one-line config flip
instead of a hand-rolled harness.

- `bar_history_max_lookback_days : int option` — config-only in C1;
  consumed by PR 3 of `dev/plans/bar-history-trim-2026-04-24.md`.
- `skip_ad_breadth : bool` — when true, `Backtest.Runner._load_deps`
  skips `Ad_bars.load` and substitutes `[]` (the same value
  `Ad_bars.load` returns when underlying CSVs are absent).
- `skip_sector_etf_load : bool` — when true, `_load_deps` clears
  `config.sector_etfs` so no sector-ETF bars are loaded; sector
  classification falls back to `Sector_map`.
- `universe_cap : int option` — when `Some n`, `_load_deps` truncates
  the loaded universe to the first `n` symbols (after the existing
  `String.compare` sort) and rebuilds `ticker_sectors` accordingly.
  Applied BEFORE the `Universe: N stocks` log line.

Runner restructure: `_load_deps` now applies overrides FIRST so the
toggles are populated before they gate AD-breadth + sector-ETF loads
and apply the universe cap. Five small helpers extracted; `_load_deps`
shrinks from 48 to 30 lines. `runner.ml` grows from 287 to 350 lines;
declared `@large-module` with a rationale comment.

## Acceptance

- [x] Defaults preserve current behaviour
  (`test_tiered_loader_parity` still passes — Legacy vs Tiered
  bit-identical on `smoke/tiered-loader-parity.sexp`).
- [x] All four fields round-trip through the runner's
  `--override`-style sexp deep-merge.
- [x] `bar_history_max_lookback_days = Some 365` is a no-op in C1
  (n_round_trips + final_portfolio_value bit-identical to baseline);
  test pins this so PR 3 of the trim sequence updates both atomically.
- [x] `universe_cap = Some 3` truncates the 7-symbol parity fixture
  to 3 (and `cap >= |universe|` is a no-op).
- [x] `skip_ad_breadth = true` and `skip_sector_etf_load = true` both
  run to completion (no PV pin — degraded mode is expected to differ).

## Test plan

- [ ] CI: `dune build && dune runtest` clean on this branch
- [ ] CI: `dune build @fmt` exits 0 inside the dev container
  (ocamlformat 0.29.0)
- [ ] CI: `tiered-loader-parity` job stays green (defaults unchanged)
- [ ] CI: file-length linter green (`runner.ml` declared
  `@large-module`)

## Hypotheses unblocked

| ID | Hypothesis | Test command (once C1 lands) |
|---|---|---|
| H1 | Bar_history trim closes the +95% Tiered RSS gap | `--override '(bar_history_max_lookback_days 365)'` (gated on the trim PR sequence) |
| H3 | AD-breadth load dominates upstream RSS at >=10K-symbol scale | `--override '(skip_ad_breadth true)'` |
| H4 | Sector ETF + index loads are bounded | `--override '(skip_sector_etf_load true)'` |
| H5 | RSS scales linearly with universe size | `--override '(universe_cap N)'` for N in {100, 300, 1000, ...} |

See `dev/plans/backtest-perf-2026-04-24.md` for the full hypothesis
catalog and workstream sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)