### PR TITLE
feat(weinstein/strategy): wire Bar_history.trim_before into on_market_close (PR 3)

### DIFF
--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -17,11 +17,14 @@
     exercises the runner's pre-simulator paths without dragging in a broad
     universe.
 
-    [bar_history_max_lookback_days] is config-only in C1: setting it must NOT
-    change observable strategy behaviour. The wiring lives in PR 3 of
-    [dev/plans/bar-history-trim-2026-04-24.md]. The test here pins the no-op-now
-    contract so a future change can flip the test in the same PR that flips the
-    runtime behaviour. *)
+    [bar_history_max_lookback_days] became live in PR 3 of
+    [dev/plans/bar-history-trim-2026-04-24.md]: setting it to [Some n] now
+    triggers a per-day [Bar_history.trim_before] inside the strategy. The parity
+    contract here ([Some 365] == [None]) survives the wiring because every
+    production reader caps at <= 365 calendar days (see
+    [dev/notes/bar-history-readers-2026-04-24.md]). If this assertion ever
+    breaks, a reader has started to reach past 365 days and either the audit is
+    stale or the default needs to grow. *)
 
 open OUnit2
 open Core
@@ -141,11 +144,12 @@ let test_override_universe_cap _ =
 (* Runner integration: each toggle drives the right code path            *)
 (* -------------------------------------------------------------------- *)
 
-(** [bar_history_max_lookback_days = Some n] must NOT change observable
-    behaviour in C1 — the strategy doesn't yet read the field. Pin trade count
-    and final portfolio value against the baseline so a future runtime wiring
-    forces this test to be updated in the same PR. *)
-let test_bar_history_lookback_is_no_op_in_c1 _ =
+(** [bar_history_max_lookback_days = Some 365] must produce bit-identical output
+    (trade count + final portfolio value) vs the unset baseline. After PR 3's
+    wiring, the field actually trims [Bar_history] every day; this test pins the
+    parity contract that gives the audit (every reader <= 365 days) its teeth.
+*)
+let test_bar_history_lookback_some_365_preserves_baseline _ =
   let s = _load_scenario () in
   let baseline = _run s ~overrides:[] in
   let with_lookback =
@@ -220,8 +224,9 @@ let suite =
          >:: test_override_skip_sector_etf_load;
          "override: universe_cap round-trips through sexp"
          >:: test_override_universe_cap;
-         "bar_history_max_lookback_days is a no-op in C1 (deferred wiring)"
-         >:: test_bar_history_lookback_is_no_op_in_c1;
+         "bar_history_max_lookback_days = Some 365 preserves Legacy baseline \
+          bit-identically"
+         >:: test_bar_history_lookback_some_365_preserves_baseline;
          "universe_cap = Some 3 truncates 7-symbol universe to 3"
          >:: test_universe_cap_truncates_universe;
          "universe_cap above universe size is a no-op"

--- a/trading/trading/backtest/test/test_tiered_loader_parity.ml
+++ b/trading/trading/backtest/test/test_tiered_loader_parity.ml
@@ -60,15 +60,20 @@ let _sector_map_override (s : Scenario.t) =
 (* Run both strategies                                                   *)
 (* -------------------------------------------------------------------- *)
 
-(** Run the scenario under the given [loader_strategy]. Assert [Ok] loudly — any
-    [Failure] raised by the Tiered path means 3f-part3b's simulator-cycle is
-    incomplete for this scenario shape, which is a real bug and not a parity
-    concern. *)
-let _run (s : Scenario.t) ~loader_strategy =
+(** Run the scenario under the given [loader_strategy], optionally appending
+    [extra_overrides] to the scenario's own [config_overrides]. The Legacy/
+    Tiered parity contract holds for any override set — extras are how the same
+    parity assertions are reused under
+    [bar_history_max_lookback_days = Some 365] (PR 3 of the trim plan). Assert
+    [Ok] loudly — any [Failure] raised by the Tiered path means 3f-part3b's
+    simulator-cycle is incomplete for this scenario shape, which is a real bug
+    and not a parity concern. *)
+let _run (s : Scenario.t) ~loader_strategy ?(extra_overrides = []) () =
   let sector_map_override = _sector_map_override s in
   try
     Backtest.Runner.run_backtest ~start_date:s.period.start_date
-      ~end_date:s.period.end_date ~overrides:s.config_overrides
+      ~end_date:s.period.end_date
+      ~overrides:(s.config_overrides @ extra_overrides)
       ?sector_map_override ~loader_strategy ()
   with e ->
     OUnit2.assert_failure
@@ -171,20 +176,43 @@ let _assert_metrics_in_range ~label (r : Backtest.Runner.result)
 
 let test_legacy_runs_ok _ =
   let s = _load_scenario () in
-  let legacy = _run s ~loader_strategy:Loader_strategy.Legacy in
+  let legacy = _run s ~loader_strategy:Loader_strategy.Legacy () in
   (* Non-empty steps is the minimum bar — a zero-step run means we loaded no
      data at all and every parity diff below is meaningless. *)
   assert_that (List.length legacy.steps) (gt (module Int_ord) 0)
 
 let test_tiered_runs_ok _ =
   let s = _load_scenario () in
-  let tiered = _run s ~loader_strategy:Loader_strategy.Tiered in
+  let tiered = _run s ~loader_strategy:Loader_strategy.Tiered () in
   assert_that (List.length tiered.steps) (gt (module Int_ord) 0)
 
 let test_parity_legacy_vs_tiered _ =
   let s = _load_scenario () in
-  let legacy = _run s ~loader_strategy:Loader_strategy.Legacy in
-  let tiered = _run s ~loader_strategy:Loader_strategy.Tiered in
+  let legacy = _run s ~loader_strategy:Loader_strategy.Legacy () in
+  let tiered = _run s ~loader_strategy:Loader_strategy.Tiered () in
+  _assert_trade_count_match ~legacy ~tiered;
+  _assert_final_value_match ~legacy ~tiered;
+  _assert_step_samples_match ~legacy ~tiered;
+  _assert_metrics_in_range ~label:"legacy" legacy s.expected;
+  _assert_metrics_in_range ~label:"tiered" tiered s.expected
+
+(** Parity with the trim wired ON ([bar_history_max_lookback_days = Some 365]).
+    Same merge-gate guarantees as [test_parity_legacy_vs_tiered] — Legacy and
+    Tiered must produce identical trade counts, equity curve samples, and final
+    portfolio value — but with the rolling-window trim applied each strategy
+    day. PR 3 of [dev/plans/bar-history-trim-2026-04-24.md] requires this to
+    pass before the trim default can flip in PR 5. *)
+let test_parity_legacy_vs_tiered_with_trim _ =
+  let s = _load_scenario () in
+  let extra_overrides =
+    [ Sexp.of_string "((bar_history_max_lookback_days (365)))" ]
+  in
+  let legacy =
+    _run s ~loader_strategy:Loader_strategy.Legacy ~extra_overrides ()
+  in
+  let tiered =
+    _run s ~loader_strategy:Loader_strategy.Tiered ~extra_overrides ()
+  in
   _assert_trade_count_match ~legacy ~tiered;
   _assert_final_value_match ~legacy ~tiered;
   _assert_step_samples_match ~legacy ~tiered;
@@ -198,6 +226,8 @@ let suite =
          "tiered path runs successfully" >:: test_tiered_runs_ok;
          "legacy vs tiered: trades + final value + step samples + metrics"
          >:: test_parity_legacy_vs_tiered;
+         "legacy vs tiered with bar_history_max_lookback_days = Some 365"
+         >:: test_parity_legacy_vs_tiered_with_trim;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -272,17 +272,43 @@ let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
     ~sector_map ~stop_states ~portfolio ~get_price ~bar_history ~prior_stages
     ~current_date
 
+(* See dev/plans/bar-history-trim-2026-04-24.md PR 3 (this wiring) and
+   dev/notes/bar-history-readers-2026-04-24.md (audit). *)
+
+(** Apply [config.bar_history_max_lookback_days] to [bar_history], if set.
+    Called after [accumulate] (so today's bar is retained) and before any reader
+    (so they observe the trimmed state). [None] is a no-op — preserves the
+    pre-trim, append-only behaviour bit-for-bit. With [Some n], drops bars whose
+    date is older than [trim_as_of - n] for every symbol; idempotent across
+    replayed days, so the simulator's per-day cadence is safe.
+
+    [trim_as_of] must be the simulated date — never [Date.today] — otherwise on
+    sim days where the primary index lacks a bar (weekend / holiday / missing
+    data), trimming with the real-world date would drop every historical bar.
+    [None] for [trim_as_of] therefore skips the trim on those days; the next
+    valid sim day picks up the work, which is fine because [trim_before] is
+    idempotent. *)
+let _maybe_trim_bar_history ~(config : config) ~bar_history ~trim_as_of =
+  match (config.bar_history_max_lookback_days, trim_as_of) with
+  | None, _ | _, None -> ()
+  | Some max_lookback_days, Some as_of ->
+      Bar_history.trim_before bar_history ~as_of ~max_lookback_days
+
 let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_history
     ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price
     ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
   let positions = portfolio.positions in
   let all_symbols = _all_accumulated_symbols ~config in
   Bar_history.accumulate bar_history ~get_price ~symbols:all_symbols;
+  let primary_index_bar = get_price config.indices.primary in
   let current_date =
-    match get_price config.indices.primary with
+    match primary_index_bar with
     | Some bar -> bar.Types.Daily_price.date
     | None -> Date.today ~zone:Time_float.Zone.utc
   in
+  _maybe_trim_bar_history ~config ~bar_history
+    ~trim_as_of:
+      (Option.map primary_index_bar ~f:(fun b -> b.Types.Daily_price.date));
   let exit_transitions, adjust_transitions =
     Stops_runner.update ~stops_config:config.stops_config
       ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -7,7 +7,8 @@
   test_macro_inputs
   test_stops_runner
   test_weinstein_strategy
-  test_weinstein_strategy_smoke)
+  test_weinstein_strategy_smoke
+  test_weinstein_strategy_trim)
  (libraries
   core
   core_unix

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy_trim.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy_trim.ml
@@ -1,0 +1,268 @@
+(** Tests for the rolling-window trim wired into [Weinstein_strategy] in PR 3 of
+    [dev/plans/bar-history-trim-2026-04-24.md].
+
+    The trim ([Bar_history.trim_before], landed in #525) caps each per-symbol
+    daily-bar buffer at [config.bar_history_max_lookback_days] calendar days
+    relative to the simulated date. It runs once per [on_market_close], after
+    [Bar_history.accumulate] (so today's bar is retained) and before any reader
+    (so they observe the trimmed state).
+
+    What this file pins:
+
+    - {b Bound} — after a 2-year synthetic backtest with [Some 365], every
+      symbol's daily-bar buffer holds <= 366 entries (trimmed). Without the trim
+      a daily-cadence run accumulates ~520 entries.
+    - {b Sentinel safety} — when [get_price] returns [None] for the primary
+      index on a sim day (weekend / holiday), the strategy's
+      [Date.today]-fallback path must NOT trim; otherwise the real-world date
+      would be used as [as_of] and every bar in the buffer would be dropped.
+
+    Bit-identical parity assertions for the trim ([Some 365] vs unset baseline)
+    live in [test_runner_hypothesis_overrides.ml] alongside the other C1
+    hypothesis-toggle field tests; the Tiered/Legacy parity assertion under
+    [Some 365] lives in [test_tiered_loader_parity.ml]. *)
+
+open OUnit2
+open Core
+open Matchers
+
+let run_deferred d = Async.Thread_safe.block_on_async_exn (fun () -> d)
+let date_of_string s = Date.of_string s
+let sample_commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 }
+
+(** Generate bars for every symbol in [syn_config] and write them to [data_dir]
+    as CSV files. Mirrors the helper in [test_weinstein_strategy_smoke.ml] —
+    duplicated rather than extracted because the smoke test file is already at
+    its size budget. *)
+let write_synthetic_bars data_dir (syn_config : Synthetic_source.config) =
+  let ds = Synthetic_source.make syn_config in
+  let module DS = (val ds : Data_source.DATA_SOURCE) in
+  List.iter syn_config.symbols ~f:(fun (symbol, _) ->
+      let query : Data_source.bar_query =
+        {
+          symbol;
+          period = Types.Cadence.Daily;
+          start_date = Some syn_config.start_date;
+          end_date = None;
+        }
+      in
+      let bars =
+        match run_deferred (DS.get_bars ~query ()) with
+        | Ok b -> b
+        | Error e -> OUnit2.assert_failure ("get_bars failed: " ^ Status.show e)
+      in
+      match Csv.Csv_storage.create ~data_dir:(Fpath.v data_dir) symbol with
+      | Error e -> OUnit2.assert_failure ("csv create: " ^ Status.show e)
+      | Ok storage -> (
+          match Csv.Csv_storage.save storage ~override:true bars with
+          | Error e -> OUnit2.assert_failure ("csv save: " ^ Status.show e)
+          | Ok () -> ()))
+
+(* -------------------------------------------------------------------- *)
+(* Helpers — sim setup                                                   *)
+(* -------------------------------------------------------------------- *)
+
+let _trending price gain volume : Synthetic_source.symbol_pattern =
+  Trending { start_price = price; weekly_gain_pct = gain; volume }
+
+(** Build a simulator that exposes the strategy's internal [Bar_history.t] via a
+    caller-supplied buffer. Returns [(simulator, bar_history)]. *)
+let _build_sim ~data_dir ~start_date ~end_date ~lookback ~symbols =
+  let bar_history = Weinstein_strategy.Bar_history.create () in
+  let base_config =
+    Weinstein_strategy.default_config ~universe:[ "AAPL" ] ~index_symbol:"GSPCX"
+  in
+  let config = { base_config with bar_history_max_lookback_days = lookback } in
+  let strategy = Weinstein_strategy.make ~bar_history config in
+  let deps =
+    Trading_simulation.Simulator.create_deps ~symbols
+      ~data_dir:(Fpath.v data_dir) ~strategy ~commission:sample_commission ()
+  in
+  let sim_config =
+    Trading_simulation.Simulator.
+      {
+        start_date;
+        end_date;
+        initial_cash = 100_000.0;
+        commission = sample_commission;
+        strategy_cadence = Types.Cadence.Daily;
+      }
+  in
+  let sim =
+    match Trading_simulation.Simulator.create ~config:sim_config ~deps with
+    | Ok s -> s
+    | Error e -> OUnit2.assert_failure ("create failed: " ^ Status.show e)
+  in
+  (sim, bar_history)
+
+let _run_or_fail sim =
+  match Trading_simulation.Simulator.run sim with
+  | Ok r -> r
+  | Error e -> OUnit2.assert_failure ("run failed: " ^ Status.show e)
+
+(* -------------------------------------------------------------------- *)
+(* Test 1: trim caps daily-bar buffer length                             *)
+(* -------------------------------------------------------------------- *)
+
+(** With [Some 365], after a 2-year synthetic backtest, the AAPL daily-bar
+    buffer must hold <= 366 entries. The exact count depends on the trading
+    calendar (weekends + holidays + the trim's idempotency boundary), so we pin
+    only the upper bound — a 365-day calendar window can hold at most 366
+    entries (one for each of [as_of - 365 .. as_of] inclusive, if every day were
+    a trading day).
+
+    Without the trim, the same backtest accumulates ~520 entries (5 trading
+    days/week * 52 weeks * 2 years), so a [<= 366] bound is comfortably distinct
+    from the no-trim case. *)
+let test_trim_some_365_bounds_daily_buffer _ =
+  let data_dir = Core_unix.mkdtemp "/tmp/test_weinstein_trim_bounds" in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" data_dir) in
+      ())
+    (fun () ->
+      (* hist_start two years before sim_start so the synthetic source's
+         3-year ceiling (Synthetic_source._max_gen_bars = 252 * 3) covers
+         the full sim window with bars to spare. *)
+      let hist_start = date_of_string "2022-01-01" in
+      write_synthetic_bars data_dir
+        Synthetic_source.
+          {
+            start_date = hist_start;
+            symbols =
+              [
+                ("AAPL", _trending 180.0 0.005 50_000_000);
+                ("GSPCX", _trending 4500.0 0.005 1_000_000_000);
+              ];
+          };
+      let sim, bar_history =
+        _build_sim ~data_dir
+          ~start_date:(date_of_string "2023-01-02")
+          ~end_date:(date_of_string "2024-12-31")
+          ~lookback:(Some 365) ~symbols:[ "AAPL"; "GSPCX" ]
+      in
+      let _result = _run_or_fail sim in
+      let aapl_bars =
+        Weinstein_strategy.Bar_history.daily_bars_for bar_history ~symbol:"AAPL"
+      in
+      assert_that (List.length aapl_bars) (le (module Int_ord) 366))
+
+(** Companion to the bound test: with [None] (the default), no trim runs and the
+    same scenario accumulates substantially more bars (every trading day in the
+    2-year window). Asserts a strict lower bound that is impossible under
+    [Some 365] so the difference is observable.
+
+    Two trading years span ~520 weekdays minus ~10-15 US holidays per year =
+    ~490 entries. We pin [> 400] to leave wide margin against calendar quirks
+    while still being clearly above the trimmed cap of 366. *)
+let test_no_trim_accumulates_full_history _ =
+  let data_dir = Core_unix.mkdtemp "/tmp/test_weinstein_trim_none" in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" data_dir) in
+      ())
+    (fun () ->
+      let hist_start = date_of_string "2022-01-01" in
+      write_synthetic_bars data_dir
+        Synthetic_source.
+          {
+            start_date = hist_start;
+            symbols =
+              [
+                ("AAPL", _trending 180.0 0.005 50_000_000);
+                ("GSPCX", _trending 4500.0 0.005 1_000_000_000);
+              ];
+          };
+      let sim, bar_history =
+        _build_sim ~data_dir
+          ~start_date:(date_of_string "2023-01-02")
+          ~end_date:(date_of_string "2024-12-31")
+          ~lookback:None ~symbols:[ "AAPL"; "GSPCX" ]
+      in
+      let _result = _run_or_fail sim in
+      let aapl_bars =
+        Weinstein_strategy.Bar_history.daily_bars_for bar_history ~symbol:"AAPL"
+      in
+      assert_that (List.length aapl_bars) (gt (module Int_ord) 400))
+
+(* -------------------------------------------------------------------- *)
+(* Test 2: missing-primary-index sim day must NOT trim                   *)
+(* -------------------------------------------------------------------- *)
+
+(** Sentinel safety: if a sim day has no bar for the primary index (weekend,
+    holiday, or missing data), the strategy's existing [Date.today] fallback for
+    [current_date] would corrupt the trim's [as_of]. The wiring in PR 3 handles
+    this by skipping the trim on those days — confirmed by checking that a
+    buffer survives a strategy invocation where the primary index is absent.
+
+    We exercise this by calling [on_market_close] directly with a [get_price]
+    that returns [None] for the primary index but a valid bar for an entry
+    universe symbol. Pre-state: 100 bars seeded into the buffer, all dated well
+    within [Some 365]'s window. Post-state: the buffer must still hold 100 bars
+    (no trim happened). *)
+let test_missing_primary_index_skips_trim _ =
+  let bar_history = Weinstein_strategy.Bar_history.create () in
+  let base_date = date_of_string "2024-01-01" in
+  let make_bar offset price : Types.Daily_price.t =
+    {
+      date = Date.add_days base_date offset;
+      open_price = price;
+      high_price = price +. 1.0;
+      low_price = price -. 1.0;
+      close_price = price;
+      volume = 1_000;
+      adjusted_close = price;
+    }
+  in
+  let aapl_bars = List.init 100 ~f:(fun i -> make_bar i 100.0) in
+  Weinstein_strategy.Bar_history.seed bar_history ~symbol:"AAPL" ~bars:aapl_bars;
+  let config =
+    {
+      (Weinstein_strategy.default_config ~universe:[ "AAPL" ]
+         ~index_symbol:"GSPCX")
+      with
+      bar_history_max_lookback_days = Some 365;
+    }
+  in
+  let strategy = Weinstein_strategy.make ~bar_history config in
+  let module S = (val strategy : Trading_strategy.Strategy_interface.STRATEGY)
+  in
+  (* get_price: AAPL has a recent bar, GSPCX (the primary index) is absent.
+     [Bar_history.accumulate] therefore appends only AAPL's bar; the primary
+     index lookup downstream returns None and the trim must skip. *)
+  let get_price symbol =
+    if String.equal symbol "AAPL" then Some (make_bar 200 100.0) else None
+  in
+  let portfolio_view : Trading_strategy.Portfolio_view.t =
+    { cash = 100_000.0; positions = String.Map.empty }
+  in
+  let get_indicator _ _ _ _ = None in
+  let _ =
+    S.on_market_close ~get_price ~get_indicator ~portfolio:portfolio_view
+  in
+  let post =
+    Weinstein_strategy.Bar_history.daily_bars_for bar_history ~symbol:"AAPL"
+  in
+  (* Pre-call: 100 bars seeded. accumulate appends 1 (the new AAPL bar at
+     offset 200). Trim must NOT run, so post-call has 101 bars — none
+     dropped despite the buffer's earliest bar (offset 0) being only 200
+     days old, which under [Some 365] would be safe anyway, but the contract
+     is "no trim when primary index is absent". *)
+  assert_that (List.length post) (equal_to 101)
+
+(* -------------------------------------------------------------------- *)
+(* Suite                                                                 *)
+(* -------------------------------------------------------------------- *)
+
+let suite =
+  "weinstein_strategy_trim"
+  >::: [
+         "Some 365 caps AAPL daily-bar buffer at <= 366 after 2yr backtest"
+         >:: test_trim_some_365_bounds_daily_buffer;
+         "None accumulates >400 bars over the same 2yr backtest"
+         >:: test_no_trim_accumulates_full_history;
+         "primary-index-absent sim day does not trigger trim"
+         >:: test_missing_primary_index_skips_trim;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR 3 of `dev/plans/bar-history-trim-2026-04-24.md`. Connects the `Bar_history.trim_before` primitive (#525) to the strategy's per-day cycle, gated by `bar_history_max_lookback_days : int option` (#528). Default behaviour unchanged (`None` keeps the buffer append-only); setting `Some 365` caps each per-symbol daily-bar buffer at the audit window from #529.

The wiring lives in `Weinstein_strategy._on_market_close`: a new `_maybe_trim_bar_history` runs after `Bar_history.accumulate` (today's bar already appended) and before any reader (`Stops_runner.update`, `weekly_bars_for`, etc.). Sentinel safety: when `get_price config.indices.primary` returns `None` (weekend / holiday / missing data), the trim is skipped — using the existing `Date.today` fallback as `as_of` would erase the entire buffer.

## Tests

- `test_runner_hypothesis_overrides`: existing `[Some 365] == [None]` parity test (formerly framed as "no-op in C1") now exercises the real wiring; the same assertion holds because every production reader caps at <= 365 calendar days (per the audit).
- `test_tiered_loader_parity`: new parameterised case asserts Legacy == Tiered bit-identically under `bar_history_max_lookback_days = Some 365` (the existing merge-gate).
- `test_weinstein_strategy_trim` (new): bound check (<= 366 daily bars after a 2-year synthetic backtest with `Some 365`); companion check that `None` accumulates > 400 bars on the same scenario; sentinel-safety case where the primary index is absent.

## Test plan

- [x] `dune build && dune runtest` passes inside docker
- [x] `dune fmt` produces no diff
- [x] Magic-number / nesting / size linters all clean
- [x] `test_tiered_loader_parity` passes with both `None` (existing) and `Some 365` (new case)
- [ ] CI green on push (let CI confirm under GHA env / TRADING_IN_CONTAINER)

Do not merge — lead session merges after CI passes.