### PR TITLE
docs(notes): H1 result — Bar_history trim does NOT close +95% Tiered RSS gap (2 surprises)

### DIFF
--- a/dev/notes/h1-result-2026-04-24.md
+++ b/dev/notes/h1-result-2026-04-24.md
@@ -1,0 +1,162 @@
+# H1 result: Bar_history trim does NOT close the +95% Tiered RSS gap (2026-04-24)
+
+## Hypothesis (from `dev/plans/backtest-perf-2026-04-24.md`)
+
+> **H1**: Bar_history trim closes the +95% Tiered RSS gap on the
+> 292-symbol bull-crash scenario.
+> Test: A/B with `--override '(bar_history_max_lookback_days 365)'`.
+> Expected if true: both RSS drop ~3×; Tiered/Legacy ratio approaches
+> 1.0 + small bounded `Full.t.bars` overhead.
+
+## Setup
+
+- Branch: `main` post-#530 (`feat/backtest-bar-history-trim-wired` merged at 2026-04-24T06:30Z)
+- Build: `dune build` clean inside docker
+- Scoped data dir: `/tmp/data-small-302` (filtered `data/sectors.csv` to
+  the 292 small.sexp universe symbols, symlinked per-letter dirs)
+- Scenario: 6-year (`2015-01-02` to `2020-12-31`), 292 stocks + 15
+  index/ETF = 307 total
+- Wrapping: `/usr/bin/time -f '%M'` per `--loader-strategy` invocation
+- Override applied to BOTH sides: `--override '((bar_history_max_lookback_days (365)))'`
+
+## Result
+
+| | Baseline (no trim, PR #524) | H1 (trim 365) | Δ |
+|---|---|---|---|
+| Legacy peak RSS | 1,871,240 KB (1.87 GB) | 1,846,364 KB (1.85 GB) | **-24,876 KB (-1.3%)** |
+| Tiered peak RSS | 3,652,852 KB (3.65 GB) | 3,597,272 KB (3.60 GB) | **-55,580 KB (-1.5%)** |
+| Tiered/Legacy ratio | 1.95× | 1.95× | **unchanged** |
+
+**H1 NOT confirmed.** RSS reductions are below noise. The +95% Tiered/Legacy ratio is **unchanged**.
+
+The savings ARE consistent with the byte count of the trimmed bars
+(~340K bars × ~75 bytes ≈ 25 MB on Legacy, similar on Tiered). The
+trim is doing what the audit predicted at the bytes-per-bar level.
+But the bytes-per-bar level is **not** the dominant memory term —
+something else accounts for the other ~1.8 GB / ~3.6 GB.
+
+## Surprise: strategy outputs diverge from baseline
+
+The trim was supposed to be behavior-preserving (per `dev/notes/bar-history-readers-2026-04-24.md`
+audit conclusion: "365 days is a safe trim window — no production
+reader will ever observe a bar dropped"). Both #530's `test_tiered_loader_parity`
+addition and the integration test in `test_runner_hypothesis_overrides.ml`
+verified bit-identical output on `smoke/tiered-loader-parity.sexp` (7
+symbols, 6 months) and on a small synthetic baseline.
+
+But on the 292-symbol × 6-year scoped scenario, BOTH strategies' PnL
+flipped sign:
+
+| | Baseline (no trim) | H1 (trim 365) |
+|---|---|---|
+| Legacy final PV | $1,873,648.70 (-$80,956 PnL, **losing**) | $2,628,908.37 (+$164,863 PnL, **winning**) |
+| Tiered final PV | $2,670,361.59 (+$184,640 PnL, **winning**) | $1,927,522.81 (-$82,266 PnL, **losing**) |
+| Legacy round trips | 608 | 583 |
+| Tiered round trips | 613 | 593 |
+| Legacy Sharpe | 0.66 | 0.90 |
+| Tiered Sharpe | 0.92 | 0.68 |
+
+The same magnitude of effect (~$250k PnL swing) hits both strategies
+in opposite directions. The Legacy/Tiered divergence (~$700k absolute)
+remains roughly unchanged.
+
+**Most likely cause: Hashtbl iteration-order noise.** The
+`goldens-small/bull-crash-2015-2020.sexp` scenario header explicitly
+cites "Hashtbl iteration ordering noise (see PR #298)". The trim
+modifies the underlying `Bar_history` Hashtbl's bucket layout (drops
+entries → changes load factor → may re-bucket on next insert). At
+7-symbol×6-month parity-test scale this is invisible. At
+292-symbol×6-year scale, iteration order changes propagate through
+strategy candidate selection (sorted lists with ties resolved by
+iteration order) and cascade into different entries / exits / sizes
+over 1510 days. The audit's correctness conclusion holds — no reader
+sees stale bars — but determinism does NOT hold under
+container-rehashing across the trim/no-trim boundary.
+
+## Implications
+
+1. **PR 5 of `dev/plans/bar-history-trim-2026-04-24.md` (flip default
+   to `Some 365`) MUST NOT proceed.** The flip would silently change
+   strategy outputs for any production scenario larger than the
+   parity-test fixture. Even though no reader sees stale bars, the
+   strategy is NOT iteration-order-stable, so the trim is not
+   semantically a no-op at scale.
+
+2. **The Bar_history trim is technically correct but not useful for
+   the memory goal.** ~25 MB savings is ~1% of the budget. The "+95%
+   Tiered RSS" finding from PR #524 has a different root cause that
+   the trim doesn't address.
+
+3. **Where IS the memory going?** Per the design, Tiered should add
+   only ~5.6 MB of `Full.t.bars` overhead (250 bars × 302 symbols ×
+   ~75 bytes). Actual overhead is ~1.78 GB. Candidate explanations
+   to test next:
+   - **Hashtbl slack at scale.** Both Legacy and Tiered use the same
+     `Bar_history` Hashtbl, but Tiered's seed pattern (eager fill of
+     all 292 symbols on Friday) may cause a different rehash cadence
+     than Legacy's lazy accumulate.
+   - **Bar_loader internal state**: Metadata.t / Summary.t / Full.t
+     records may carry more than just bars. Need to inspect the
+     types.
+   - **Shadow screener intermediate state**: the wrapper's per-Friday
+     scan over 292 symbols may build large intermediate structures.
+   - **OCaml minor-heap pressure / fragmentation**: GC behavior under
+     Tiered's allocation pattern may differ from Legacy's.
+
+   To distinguish these, workstream B's GC-stat / per-phase-RSS
+   instrumentation (B2 + B5) is needed. H2 (Full.t.bars duplication
+   dominates) can be tested by halving `Full_compute.tail_days` once
+   that hypothesis becomes runnable.
+
+4. **The Tiered loader flip is now blocked on TWO findings:**
+   - Original PR #524 PV-divergence finding (Tiered ≠ Legacy at
+     292-symbol scale, even without trim) — separate concern,
+     possibly same Hashtbl-iteration-order class of bug
+   - This H1 result (trim breaks scale-determinism) — confirms that
+     `Bar_history` operations have non-bit-identical behavior across
+     bucket-layout changes, which is a wider correctness concern
+     than the trim itself
+
+## Recommended next steps
+
+1. **Do NOT dispatch PR 5.** PR plan amended.
+2. **Investigate H2** (Full.t.bars duplication) once C1's
+   `Full_compute.tail_days` toggle is added. Currently no override
+   for that — would need extending C1 or adding a sibling field.
+3. **Investigate Hashtbl iteration-order sensitivity** as a
+   first-class correctness concern. The strategy code probably
+   shouldn't depend on iteration order; if it does, that's a bug
+   independent of the trim. Audit candidate-selection sort+tiebreak
+   logic in `weinstein_strategy.ml`.
+4. **Workstream B (memory attribution)** rises in priority. Without
+   per-phase / per-data-structure RSS, we're guessing.
+5. **CI 7-symbol verification** confirmed (run [24876358975](https://github.com/dayfine/trading/actions/runs/24876358975), 06:50Z). Pre-#530 vs post-#530 RSS by scenario: bull-crash 46620→46592 (Δ-28KB), covid-recovery 49120→49040 (Δ-80KB), six-year 51984→51944 (Δ-40KB). Tiered/Legacy ratios essentially unchanged (1.32→1.33, 1.41→1.42, 1.34→1.34). Confirms the trim's effect at this scale is below noise — as predicted, the 7-symbol fixture has trivial Bar_history accumulation. Same conclusion as the local 292-symbol measurement: H1 not confirmed, the +95% Tiered RSS regression has a different root cause.
+
+## What survives
+
+- `Bar_history.trim_before` primitive (#525) — correct, well-tested,
+  zero overhead when unused. Keep on shelf for future use cases.
+- Wired call site (#530) — gated by `bar_history_max_lookback_days =
+  None` default. Zero behavior change in production. Keep wired so
+  future H-experiments can toggle it cheaply via `--override`.
+- C1 config infrastructure (#528) — the `--override` path itself
+  worked perfectly. Other H-series toggles
+  (`skip_ad_breadth`, `universe_cap`) are still useful for
+  hypothesis testing.
+- `dev/plans/bar-history-trim-2026-04-24.md` — preserve as
+  historical record; mark PR 5 cancelled with pointer to this note.
+
+## What's gone wrong methodologically
+
+The audit (`dev/notes/bar-history-readers-2026-04-24.md`) was
+correct on its narrow question (no reader needs >365 days). It was
+not the right question. The right question was "is the strategy
+iteration-order-stable when Hashtbl bucket layout changes?" The
+parity test on the small fixture didn't catch this because it's too
+small for Hashtbl-rehash effects to surface. **Lesson**: parity
+tests must include at least one scenario at production-scale
+universe-size before claiming a primitive is behavior-preserving.
+The 302-symbol goldens-small was a known-suspect scale per the
+existing scenario-header note about "Hashtbl iteration ordering
+noise"; running #530's parity assertion on that scenario rather
+than only the 7-symbol fixture would have caught this before merge.


### PR DESCRIPTION
## Summary

Doc-only PR recording H1's measurement result + two surprises. Per the hypothesis-testing protocol in `dev/plans/backtest-perf-2026-04-24.md`, every H-series test gets a `dev/notes/h*-result-*.md` write-up regardless of outcome.

## H1 not confirmed

| | Baseline (no trim) | H1 (trim 365) | Δ |
|---|---|---|---|
| Legacy RSS | 1.87 GB | 1.85 GB | -1.3% |
| Tiered RSS | 3.65 GB | 3.60 GB | -1.5% |
| Ratio | 1.95× | **1.95×** | **unchanged** |

Bar_history trim is technically correct (saves ~25 MB matching the byte count of dropped bars) but Bar_history is NOT the dominant memory term. Other ~1.8 GB / ~3.6 GB is unaccounted for.

## Surprise: trim breaks scale-determinism

PnL flipped sign for both Legacy and Tiered. Most likely cause: Hashtbl iteration-order noise (cited in `goldens-small/bull-crash-2015-2020.sexp` header, PR #298). The 7-symbol parity test passed; the 292-symbol scoped scenario doesn't.

## Implications

1. **PR 5 of `dev/plans/bar-history-trim-2026-04-24.md` (flip default to `Some 365`) MUST NOT proceed.** The flip would silently change strategy outputs at production scale.
2. The Bar_history-leak diagnosis from PR #524 is wrong on the dominant-term question.
3. Workstream B (per-phase memory attribution) rises in priority — without it we're guessing what the other 1.8 GB / 3.6 GB is.
4. **Investigate Hashtbl iteration-order sensitivity** as a first-class correctness concern (independent of trim).

## What survives

- `Bar_history.trim_before` primitive (#525) — keep on shelf
- Wired call site (#530) — gated by `None` default; zero behavior change in production
- C1 config overrides (#528) — `--override` path works; other H-series toggles still useful

## Methodological lesson

Audit (`dev/notes/bar-history-readers-2026-04-24.md`) was correct on its narrow question (no reader needs >365 days) but wrong question. Right question: "is the strategy iteration-order-stable when Hashtbl bucket layout changes?" The 7-symbol parity fixture was too small to catch this. **Lesson**: parity assertions must include at least one scenario at production-scale universe-size before claiming a primitive is behavior-preserving.

## Test plan

- [x] `trading/devtools/checks/status_file_integrity.sh` passes.
- [x] No code touched; doc-only addition under `dev/notes/`.
- [ ] CI 7-symbol verification dispatched at 06:48Z (run [24876358975](https://github.com/dayfine/trading/actions/runs/24876358975)) — expected: trim has negligible effect at this scale.