### PR TITLE
feat(backtest): add --trace flag to backtest_runner.exe (B4)

### DIFF
--- a/trading/trading/backtest/bin/backtest_runner.ml
+++ b/trading/trading/backtest/bin/backtest_runner.ml
@@ -1,7 +1,7 @@
 (** Backtest runner CLI — thin wrapper around the {!Backtest} library.
 
     Usage: backtest_runner <start_date> \[end_date\] \[--override '<sexp>'\]
-    \[--loader-strategy legacy\|tiered\]
+    \[--loader-strategy legacy\|tiered\] \[--trace <path>\]
 
     - start_date: required (e.g. 2018-01-02)
     - end_date: optional, defaults to today
@@ -10,6 +10,14 @@
       [legacy] (current production path). [tiered] currently raises a [Failure]
       in the runner since the implementation lands in increment 3f of
       [dev/plans/backtest-tiered-loader-2026-04-19.md].
+    - --trace: when given, instruments the run with per-phase timing + memory
+      measurements via {!Backtest.Trace} and writes the trace sexp at [<path>]
+      after the result is written. Without this flag, no trace is captured (the
+      default code path is unchanged). The output sexp is a list of
+      [Backtest.Trace.phase_metrics] records, parseable via
+      [Backtest.Trace.phase_metrics_of_sexp]. Workstream B4 of
+      [dev/plans/backtest-perf-2026-04-24.md] — closes the gap that previously
+      forced trace capture through [scenario_runner.exe] only.
 
     Example:
     {[
@@ -18,66 +26,44 @@
         --override '((stage_config ((ma_period 40))))'
     ]}
 
+    Manual repro for the [--trace] flag:
+    {[
+      backtest_runner 2015-01-02 2015-12-31 \
+        --loader-strategy legacy \
+        --trace /tmp/sample-trace.sexp
+      head /tmp/sample-trace.sexp
+    ]}
+
     Writes params.sexp, summary.sexp, trades.csv, equity_curve.csv to a
     timestamped directory under dev/backtest/ and prints the summary sexp to
     stdout. *)
 
 open Core
 
-(** Split argv (excluding argv[0]) into positional args, override sexps, and the
-    optional [--loader-strategy] flag value. *)
-let _extract_flags argv =
-  let rec loop args positional overrides loader_strategy =
-    match args with
-    | [] -> (List.rev positional, List.rev overrides, loader_strategy)
-    | "--override" :: sexp_str :: rest ->
-        loop rest positional
-          (Sexp.of_string sexp_str :: overrides)
-          loader_strategy
-    | "--override" :: [] ->
-        eprintf "Error: --override requires a sexp argument\n";
-        Stdlib.exit 1
-    | "--loader-strategy" :: value :: rest ->
-        let parsed =
-          try Loader_strategy.of_string value
-          with Failure msg ->
-            eprintf "Error: %s\n" msg;
-            Stdlib.exit 1
-        in
-        loop rest positional overrides (Some parsed)
-    | "--loader-strategy" :: [] ->
-        eprintf "Error: --loader-strategy requires a value (legacy or tiered)\n";
-        Stdlib.exit 1
-    | arg :: rest -> loop rest (arg :: positional) overrides loader_strategy
-  in
-  loop (Array.to_list argv |> List.tl_exn) [] [] None
-
 let _parse_args () =
   let argv = Sys.get_argv () in
   if Array.length argv < 2 then (
     eprintf
       "Usage: backtest_runner <start_date> [end_date] [--override '<sexp>'] \
-       [--loader-strategy legacy|tiered]\n";
+       [--loader-strategy legacy|tiered] [--trace <path>]\n";
     Stdlib.exit 1);
-  let positional, overrides, loader_strategy = _extract_flags argv in
-  let start_str, end_str =
-    match positional with
-    | [] ->
-        eprintf "Error: start_date is required\n";
-        Stdlib.exit 1
-    | [ s ] -> (s, None)
-    | [ s; e ] -> (s, Some e)
-    | _ ->
-        eprintf "Error: too many positional arguments\n";
-        Stdlib.exit 1
-  in
-  let start_date = Date.of_string start_str in
-  let end_date =
-    match end_str with
-    | Some s -> Date.of_string s
-    | None -> Date.today ~zone:Time_float.Zone.utc
-  in
-  (start_date, end_date, overrides, loader_strategy)
+  let args = Array.to_list argv |> List.tl_exn in
+  match Backtest_runner_args.parse args with
+  | Error status ->
+      eprintf "Error: %s\n" status.message;
+      Stdlib.exit 1
+  | Ok parsed ->
+      let start_date = Date.of_string parsed.start_date in
+      let end_date =
+        match parsed.end_date with
+        | Some s -> Date.of_string s
+        | None -> Date.today ~zone:Time_float.Zone.utc
+      in
+      ( start_date,
+        end_date,
+        parsed.overrides,
+        parsed.loader_strategy,
+        parsed.trace_path )
 
 let _make_output_dir () =
   let data_dir_fpath = Data_path.default_data_dir () in
@@ -92,16 +78,31 @@ let _make_output_dir () =
   Core_unix.mkdir_p path;
   path
 
+(** Write the captured trace sexp at [path] and report the location on stderr.
+    Pulled out of [main] to keep the side-effect explicit at the call site. *)
+let _write_trace ~path ~trace =
+  let metrics = Backtest.Trace.snapshot trace in
+  Backtest.Trace.write ~out_path:path metrics;
+  eprintf "Trace written to: %s\n%!" path
+
 let () =
-  let start_date, end_date, overrides, loader_strategy = _parse_args () in
+  let start_date, end_date, overrides, loader_strategy, trace_path =
+    _parse_args ()
+  in
+  (* When [--trace <path>] is passed, pre-allocate a [Trace.t] so the runner
+     records into it; otherwise [trace = None] and tracing is a no-op (the
+     default code path is unchanged). *)
+  let trace = Option.map trace_path ~f:(fun _ -> Backtest.Trace.create ()) in
   let result =
     Backtest.Runner.run_backtest ~start_date ~end_date ~overrides
-      ?loader_strategy ()
+      ?loader_strategy ?trace ()
   in
   let output_dir = _make_output_dir () in
   eprintf "Writing output to %s/\n%!" output_dir;
   Backtest.Result_writer.write ~output_dir result;
   eprintf "Output written to: %s/\n%!" output_dir;
+  Option.iter (Option.both trace_path trace) ~f:(fun (path, trace) ->
+      _write_trace ~path ~trace);
   Out_channel.output_string stdout
     (Sexp.to_string_hum (Backtest.Summary.sexp_of_t result.summary));
   Out_channel.newline stdout

--- a/trading/trading/backtest/bin/dune
+++ b/trading/trading/backtest/bin/dune
@@ -6,4 +6,5 @@
   fpath
   weinstein.data_source
   trading.backtest.loader_strategy
+  trading.backtest.runner_args
   backtest))

--- a/trading/trading/backtest/runner_args/backtest_runner_args.ml
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.ml
@@ -1,0 +1,78 @@
+open Core
+
+type t = {
+  start_date : string;
+  end_date : string option;
+  overrides : Sexp.t list;
+  loader_strategy : Loader_strategy.t option;
+  trace_path : string option;
+}
+
+type acc = {
+  positional : string list;
+  overrides : Sexp.t list;
+  loader_strategy : Loader_strategy.t option;
+  trace_path : string option;
+}
+(** Accumulator for [_extract_flags]. Carries every flag the parser recognises
+    plus the running list of positional args. Kept private so callers see the
+    immutable {!t} only. *)
+
+let _empty_acc =
+  { positional = []; overrides = []; loader_strategy = None; trace_path = None }
+
+let _err msg = Error (Status.invalid_argument_error msg)
+
+let _parse_loader_strategy value =
+  try Ok (Loader_strategy.of_string value) with Failure msg -> _err msg
+
+let rec _extract_flags args (acc : acc) =
+  match args with
+  | [] ->
+      Ok
+        {
+          acc with
+          positional = List.rev acc.positional;
+          overrides = List.rev acc.overrides;
+        }
+  | "--override" :: sexp_str :: rest -> (
+      match Or_error.try_with (fun () -> Sexp.of_string sexp_str) with
+      | Ok sexp ->
+          _extract_flags rest { acc with overrides = sexp :: acc.overrides }
+      | Error err ->
+          _err
+            (sprintf "--override value is not a valid sexp: %s"
+               (Error.to_string_hum err)))
+  | [ "--override" ] -> _err "--override requires a sexp argument"
+  | "--loader-strategy" :: value :: rest -> (
+      match _parse_loader_strategy value with
+      | Ok parsed ->
+          _extract_flags rest { acc with loader_strategy = Some parsed }
+      | Error _ as e -> e)
+  | [ "--loader-strategy" ] ->
+      _err "--loader-strategy requires a value (legacy or tiered)"
+  | "--trace" :: value :: rest ->
+      _extract_flags rest { acc with trace_path = Some value }
+  | [ "--trace" ] -> _err "--trace requires a path argument"
+  | arg :: rest ->
+      _extract_flags rest { acc with positional = arg :: acc.positional }
+
+let _split_positional positional =
+  match positional with
+  | [] -> _err "start_date is required"
+  | [ s ] -> Ok (s, None)
+  | [ s; e ] -> Ok (s, Some e)
+  | _ -> _err "too many positional arguments"
+
+let parse args =
+  Result.bind (_extract_flags args _empty_acc) ~f:(fun (acc : acc) ->
+      Result.bind (_split_positional acc.positional)
+        ~f:(fun (start_date, end_date) ->
+          Ok
+            {
+              start_date;
+              end_date;
+              overrides = acc.overrides;
+              loader_strategy = acc.loader_strategy;
+              trace_path = acc.trace_path;
+            }))

--- a/trading/trading/backtest/runner_args/backtest_runner_args.mli
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.mli
@@ -1,0 +1,38 @@
+(** Argument parsing for [backtest_runner.exe]. Lives in its own library so the
+    parsing logic is unit-testable independently of the executable's
+    side-effecting [main]. *)
+
+open Core
+
+type t = {
+  start_date : string;
+  end_date : string option;
+      (** Raw end-date string as passed on the command line, or [None] when
+          omitted. Resolution to a {!Date.t} (defaulting to today) is the
+          caller's responsibility — the parser stays free of clock reads so it
+          remains a pure function. *)
+  overrides : Sexp.t list;
+      (** Override sexps in the order they were passed on the command line. Each
+          is the parsed sexp of one [--override <sexp>] argument. *)
+  loader_strategy : Loader_strategy.t option;
+      (** [None] when [--loader-strategy] was not passed; the runner then uses
+          its default. [Some _] when the flag was passed with a recognised
+          value. *)
+  trace_path : string option;
+      (** [None] when [--trace] was not passed (no trace file written).
+          [Some path] when [--trace <path>] was passed; the runner constructs a
+          {!Backtest.Trace.t}, threads it through
+          [Backtest.Runner.run_backtest ~trace], and writes the trace sexp at
+          [path] after the result is written. *)
+}
+(** Result of parsing the [backtest_runner.exe] command line. *)
+
+val parse : string list -> t Status.status_or
+(** [parse args] parses [args] (excluding the program name, e.g.
+    [Array.to_list (Sys.get_argv ()) |> List.tl_exn]) into a {!t}.
+
+    Returns [Error status] (with [Status.code = Invalid_argument]) on any
+    parsing problem (missing flag value, unknown loader strategy, missing
+    required positional, too many positionals). The executable's [main] turns
+    [Error _] into an [eprintf] + [Stdlib.exit 1]; tests assert via the
+    [Matchers] library's [is_ok_and_holds] / [is_error]. *)

--- a/trading/trading/backtest/runner_args/dune
+++ b/trading/trading/backtest/runner_args/dune
@@ -1,0 +1,4 @@
+(library
+ (public_name trading.backtest.runner_args)
+ (name backtest_runner_args)
+ (libraries core status trading.backtest.loader_strategy))

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -7,7 +7,8 @@
   test_runner_tiered_cycle
   test_runner_tiered_metadata_tolerance
   test_runner_hypothesis_overrides
-  test_tiered_loader_parity)
+  test_tiered_loader_parity
+  test_backtest_runner_args)
  (libraries
   ounit2
   core
@@ -19,6 +20,7 @@
   backtest
   trading.backtest.bar_loader
   trading.backtest.loader_strategy
+  trading.backtest.runner_args
   scenario_lib
   weinstein.data_source
   trading.base

--- a/trading/trading/backtest/test/test_backtest_runner_args.ml
+++ b/trading/trading/backtest/test/test_backtest_runner_args.ml
@@ -1,0 +1,199 @@
+(** Unit tests for {!Backtest_runner_args.parse}. The full executable
+    ([backtest_runner.exe]) reads real data files and is not exercised here;
+    these tests pin only the CLI flag-parsing logic — including the new
+    [--trace <path>] flag (workstream B4 of
+    [dev/plans/backtest-perf-2026-04-24.md]). *)
+
+open OUnit2
+open Core
+open Matchers
+
+let _ok = function
+  | Ok x -> x
+  | Error msg -> assert_failure ("parse failed unexpectedly: " ^ msg)
+
+let test_minimal_start_date_only _ =
+  let result = Backtest_runner_args.parse [ "2018-01-02" ] in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (a : Backtest_runner_args.t) -> a.start_date)
+              (equal_to "2018-01-02");
+            field
+              (fun (a : Backtest_runner_args.t) -> a.end_date)
+              (equal_to None);
+            field (fun (a : Backtest_runner_args.t) -> a.overrides) (size_is 0);
+            field
+              (fun (a : Backtest_runner_args.t) -> a.loader_strategy)
+              (equal_to None);
+            field
+              (fun (a : Backtest_runner_args.t) -> a.trace_path)
+              (equal_to None);
+          ]))
+
+let test_start_and_end_date _ =
+  let result = Backtest_runner_args.parse [ "2018-01-02"; "2019-12-31" ] in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (a : Backtest_runner_args.t) -> a.start_date)
+              (equal_to "2018-01-02");
+            field
+              (fun (a : Backtest_runner_args.t) -> a.end_date)
+              (equal_to (Some "2019-12-31"));
+          ]))
+
+let test_loader_strategy_legacy _ =
+  let result =
+    Backtest_runner_args.parse [ "2018-01-02"; "--loader-strategy"; "legacy" ]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (a : Backtest_runner_args.t) -> a.loader_strategy)
+          (equal_to (Some Loader_strategy.Legacy))))
+
+let test_loader_strategy_tiered _ =
+  let result =
+    Backtest_runner_args.parse [ "2018-01-02"; "--loader-strategy"; "tiered" ]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (a : Backtest_runner_args.t) -> a.loader_strategy)
+          (equal_to (Some Loader_strategy.Tiered))))
+
+let test_trace_flag _ =
+  let result =
+    Backtest_runner_args.parse [ "2018-01-02"; "--trace"; "/tmp/run.sexp" ]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (a : Backtest_runner_args.t) -> a.trace_path)
+          (equal_to (Some "/tmp/run.sexp"))))
+
+let test_trace_default_is_none _ =
+  let result = Backtest_runner_args.parse [ "2018-01-02" ] in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (a : Backtest_runner_args.t) -> a.trace_path)
+          (equal_to None)))
+
+let test_trace_with_other_flags _ =
+  (* Verify that --trace composes with --loader-strategy, --override, and
+     end_date in a single command. Order should not matter. *)
+  let result =
+    Backtest_runner_args.parse
+      [
+        "2018-01-02";
+        "2019-12-31";
+        "--loader-strategy";
+        "tiered";
+        "--override";
+        "((initial_stop_buffer 1.08))";
+        "--trace";
+        "/tmp/sample.sexp";
+      ]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (a : Backtest_runner_args.t) -> a.start_date)
+              (equal_to "2018-01-02");
+            field
+              (fun (a : Backtest_runner_args.t) -> a.end_date)
+              (equal_to (Some "2019-12-31"));
+            field
+              (fun (a : Backtest_runner_args.t) -> a.loader_strategy)
+              (equal_to (Some Loader_strategy.Tiered));
+            field (fun (a : Backtest_runner_args.t) -> a.overrides) (size_is 1);
+            field
+              (fun (a : Backtest_runner_args.t) -> a.trace_path)
+              (equal_to (Some "/tmp/sample.sexp"));
+          ]))
+
+let test_trace_missing_value _ =
+  let result = Backtest_runner_args.parse [ "2018-01-02"; "--trace" ] in
+  assert_that result is_error
+
+let test_missing_start_date _ =
+  let result = Backtest_runner_args.parse [] in
+  assert_that result is_error
+
+let test_too_many_positionals _ =
+  let result =
+    Backtest_runner_args.parse [ "2018-01-02"; "2019-12-31"; "extra" ]
+  in
+  assert_that result is_error
+
+let test_loader_strategy_invalid _ =
+  let result =
+    Backtest_runner_args.parse [ "2018-01-02"; "--loader-strategy"; "bogus" ]
+  in
+  assert_that result is_error
+
+(** End-to-end style test: simulate the executable's trace pipeline. Build a
+    [Trace.t], record the same coarse phases the runner wraps, write to a temp
+    path, then verify the file parses + contains the expected phases. Mirrors
+    the manual-repro contract documented on the [--trace] flag without needing
+    real data dirs to run a backtest. *)
+let test_trace_write_and_parse _ =
+  let trace = Backtest.Trace.create () in
+  let runner_phases : Backtest.Trace.Phase.t list =
+    [ Load_universe; Macro; Load_bars; Fill; Teardown ]
+  in
+  List.iter runner_phases ~f:(fun phase ->
+      let _ = Backtest.Trace.record ~trace phase (fun () -> ()) in
+      ());
+  let dir = Core_unix.mkdtemp "/tmp/backtest_runner_trace_" in
+  let out_path = Filename.concat dir "trace.sexp" in
+  Backtest.Trace.write ~out_path (Backtest.Trace.snapshot trace);
+  let sexp = Sexp.load_sexp out_path in
+  let parsed = List.t_of_sexp Backtest.Trace.phase_metrics_of_sexp sexp in
+  assert_that parsed
+    (elements_are
+       [
+         field
+           (fun (m : Backtest.Trace.phase_metrics) -> m.phase)
+           (equal_to Backtest.Trace.Phase.Load_universe);
+         field
+           (fun (m : Backtest.Trace.phase_metrics) -> m.phase)
+           (equal_to Backtest.Trace.Phase.Macro);
+         field
+           (fun (m : Backtest.Trace.phase_metrics) -> m.phase)
+           (equal_to Backtest.Trace.Phase.Load_bars);
+         field
+           (fun (m : Backtest.Trace.phase_metrics) -> m.phase)
+           (equal_to Backtest.Trace.Phase.Fill);
+         field
+           (fun (m : Backtest.Trace.phase_metrics) -> m.phase)
+           (equal_to Backtest.Trace.Phase.Teardown);
+       ])
+
+let suite =
+  "Backtest_runner_args"
+  >::: [
+         "minimal start_date only" >:: test_minimal_start_date_only;
+         "start and end date" >:: test_start_and_end_date;
+         "--loader-strategy legacy" >:: test_loader_strategy_legacy;
+         "--loader-strategy tiered" >:: test_loader_strategy_tiered;
+         "--trace flag captures path" >:: test_trace_flag;
+         "no --trace yields trace_path = None" >:: test_trace_default_is_none;
+         "--trace composes with other flags" >:: test_trace_with_other_flags;
+         "--trace without value is an error" >:: test_trace_missing_value;
+         "missing start_date is an error" >:: test_missing_start_date;
+         "too many positionals is an error" >:: test_too_many_positionals;
+         "invalid --loader-strategy value is an error"
+         >:: test_loader_strategy_invalid;
+         "trace pipeline write+parse round-trip" >:: test_trace_write_and_parse;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Workstream **B4** of `dev/plans/backtest-perf-2026-04-24.md`. Adds `--trace <path>` to `backtest_runner.exe` so the local A/B compare path (`dev/scripts/tiered_loader_ab_compare.sh`) and any direct invocation can produce per-phase trace data.

Previously the executable didn't pass `?trace` to `Backtest.Runner.run_backtest`, so all `Trace.record` calls inside the runner were no-ops; tracing only happened via `scenario_runner.exe`. This is the gap that made H1's RSS attribution impossible to do locally.

## What changed

- **New library** `trading.backtest.runner_args` (in `trading/trading/backtest/runner_args/`) — extracts CLI parsing from the executable so it's unit-testable without the side-effecting `main`. Returns a `Status.status_or` so existing matcher idioms work.
- **`backtest_runner.ml`** — recognises `--trace <path>`. When given, allocates a `Backtest.Trace.t`, threads it through `run_backtest ~trace`, and writes the trace sexp at `<path>` after `Result_writer.write`. Without `--trace`, no `Trace.t` is allocated and no file is written — **default code path is byte-identical**.
- **`test_backtest_runner_args.ml`** — 12 tests covering all flag combinations, trace path capture, error paths, and a write+parse round-trip on a synthetic `Trace.t` exercising the same 5 phases the runner wraps (Load_universe, Macro, Load_bars, Fill, Teardown).
- **Docstring + usage string** updated with manual repro example.

## Manual verification

```sh
dune exec trading/backtest/bin/backtest_runner.exe -- \
    2015-01-02 2015-06-30 --loader-strategy legacy \
    --override '((universe_cap (50)))' \
    --trace /tmp/sample-trace.sexp
# ... Trace written to: /tmp/sample-trace.sexp

head /tmp/sample-trace.sexp
# (((phase Load_universe) (elapsed_ms 5) (symbols_in ()) (symbols_out ())
#   (peak_rss_kb (22852)) (bar_loads ()))
#  ((phase Macro) (elapsed_ms 28) (symbols_in ()) (symbols_out (50))
#   (peak_rss_kb (26772)) (bar_loads ()))
#  ((phase Load_bars) (elapsed_ms 1) (symbols_in (65)) (symbols_out (65))
#   (peak_rss_kb (26776)) (bar_loads ()))
#  ((phase Fill) (elapsed_ms 4574) (symbols_in (65)) (symbols_out ())
#   (peak_rss_kb (177452)) (bar_loads ()))
#  ((phase Teardown) (elapsed_ms 0) (symbols_in ()) (symbols_out ())
#   (peak_rss_kb (177452)) (bar_loads ())))
```

The same invocation without `--trace` produces no trace file and identical summary metrics.

## Test plan

- [x] `dune build` green
- [x] `dune build @fmt` green (ocamlformat 0.29.0)
- [x] `dune runtest trading/backtest/test/test_backtest_runner_args.exe` — 12/12 tests pass
- [x] `dune runtest trading/backtest/test/test_trace.exe` — unchanged, 9/9 pass
- [x] Manual repro: `--trace /tmp/sample-trace.sexp` writes a sexp parseable as `list phase_metrics_of_sexp` containing all 5 expected phases
- [x] Manual repro without `--trace`: no trace file written, summary metrics unchanged from default behavior

(Pre-existing failures: `test_runner_hypothesis_overrides` and `test_tiered_loader_parity` fail on local because their fixtures expect `/workspaces/trading-1/data/backtest_scenarios/` to exist — confirmed identical failures on plain `origin/main` by stashing my changes; not introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)