### PR TITLE
feat(backtest/trace): add Promote_metadata phase + wrap Tiered bulk Metadata-promote

### DIFF
--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -94,10 +94,10 @@ val run_backtest :
 
     [loader_strategy] selects how universe bars are loaded:
     - [Legacy] (default) — current production path: simulator materializes all
-      universe bars up-front via per-symbol bar loaders.
-    - [Tiered] — partial implementation as of 3f-part2. Runs the
-      [Bar_loader.create] + bulk Metadata-tier promotion inside [Load_bars] so
-      the [Promote_*]/[Demote] phases are emitted on the trace, then raises
-      [Failure] at the simulator-cycle step that 3f-part3 will fill in. Callers
-      that pass [Tiered] today see a clear pointer to the unfinished step;
-      [Legacy] remains byte-identical to the pre-flag runner. *)
+      universe bars up-front via per-symbol bar loaders. The [Load_bars] phase
+      records simulator allocation here.
+    - [Tiered] — full Tiered execution path (see {!Tiered_runner}). Builds a
+      [Bar_loader] then bulk-promotes the universe to Metadata under a
+      [Promote_metadata] trace wrap (no [Load_bars] phase emitted on this path);
+      per-bar tier transitions emit [Promote_summary] / [Promote_full] /
+      [Demote] records via the loader's tier-op trace hook. *)

--- a/trading/trading/backtest/lib/tiered_runner.ml
+++ b/trading/trading/backtest/lib/tiered_runner.ml
@@ -91,20 +91,27 @@ let _log_metadata_failures failures ~n_total =
     symbol.
 
     Implementation: iterate per-symbol with single-symbol [promote] calls so we
-    can collect {e every} failure rather than stopping at the first. The
-    Metadata tier does not fire the trace hook (see the [promote] match arm for
-    [Metadata_tier] in [bar_loader.ml]), so per-symbol batching is
-    observationally equivalent to the batch call at the tier / trace layer.
+    can collect {e every} failure rather than stopping at the first. Per-symbol
+    Metadata promotes do not fire the [Bar_loader] trace hook (see the [promote]
+    match arm for [Metadata_tier] in [bar_loader.ml]), so the per-symbol detail
+    is invisible at the tier-op layer. The bulk phase as a whole is, however,
+    traced here as [Trace.Phase.Promote_metadata] when [?trace] is supplied —
+    that single record is the canonical observable for Metadata-promote elapsed
+    time + peak RSS.
 
     Never raises on per-symbol failure. Never raises if every symbol fails, e.g.
     a misconfigured [data_dir] — the symmetry with Legacy (which would simply
     produce an empty backtest in that case) is the whole point. Callers can
     still observe the tier counts via [Bar_loader.stats] after return. *)
-let promote_universe_metadata loader (input : input) ~as_of =
-  let failures =
-    List.filter_map input.all_symbols ~f:(_promote_one_metadata loader ~as_of)
-  in
-  _log_metadata_failures failures ~n_total:(List.length input.all_symbols)
+let promote_universe_metadata ?trace loader (input : input) ~as_of =
+  let n_total = List.length input.all_symbols in
+  Trace.record ?trace ~symbols_in:n_total Trace.Phase.Promote_metadata
+    (fun () ->
+      let failures =
+        List.filter_map input.all_symbols
+          ~f:(_promote_one_metadata loader ~as_of)
+      in
+      _log_metadata_failures failures ~n_total)
 
 (** [_always_loaded_symbols config] — the symbols whose [get_price] is passed
     through unconditionally by the Tiered wrapper's throttle: the primary index
@@ -182,9 +189,7 @@ let run ~input ~start_date ~end_date ~warmup_days ~initial_cash ~commission
   let loader = _create_bar_loader input ?trace () in
   let as_of = end_date in
   let n_all_symbols = List.length input.all_symbols in
-  Trace.record ?trace ~symbols_in:n_all_symbols ~symbols_out:n_all_symbols
-    Trace.Phase.Load_bars (fun () ->
-      promote_universe_metadata loader input ~as_of);
+  promote_universe_metadata ?trace loader input ~as_of;
   let stats = Bar_loader.stats loader in
   eprintf
     "Tiered loader: Metadata=%d Summary=%d Full=%d after bulk Metadata promote\n\

--- a/trading/trading/backtest/lib/tiered_runner.mli
+++ b/trading/trading/backtest/lib/tiered_runner.mli
@@ -9,10 +9,10 @@
 
     1. Build a [Bar_loader] over the runner-provided universe with a
     [trace_hook] that bridges [Bar_loader.tier_op] onto [Trace.Phase.t]. 2.
-    Bulk-promote the universe to [Metadata_tier] under a [Load_bars] wrap. 3.
-    Drive the simulator with a [Tiered_strategy_wrapper]-wrapped Weinstein
-    strategy. The wrapper adds Friday Summary-promote + Shadow_screener +
-    Full-promote-top-N, per-[CreateEntering] Full promote, and
+    Bulk-promote the universe to [Metadata_tier] under a [Promote_metadata]
+    trace wrap. 3. Drive the simulator with a [Tiered_strategy_wrapper]-wrapped
+    Weinstein strategy. The wrapper adds Friday Summary-promote +
+    Shadow_screener + Full-promote-top-N, per-[CreateEntering] Full promote, and
     per-newly-[Closed] Metadata demote.
 
     The simulator transitions are byte-identical to the Legacy path — the
@@ -38,7 +38,7 @@ val tier_op_to_phase : Bar_loader.tier_op -> Trace.Phase.t
     private helpers. Pure — depends only on the input variant. *)
 
 val promote_universe_metadata :
-  Bar_loader.t -> input -> as_of:Core.Date.t -> unit
+  ?trace:Trace.t -> Bar_loader.t -> input -> as_of:Core.Date.t -> unit
 (** Bulk-promote [input.all_symbols] to [Metadata_tier], tolerating per-symbol
     load failures so that a universe entry whose [data.csv] is absent does not
     abort the Tiered run. This matches the Legacy path's silent missing-CSV
@@ -51,6 +51,13 @@ val promote_universe_metadata :
     [Metadata_tier]; failed symbols are absent from the loader entirely (per
     [Bar_loader.promote]'s contract — see the [val promote] docstring in
     [bar_loader.mli]).
+
+    When [?trace] is supplied the bulk phase is recorded as a single
+    [Trace.Phase.Promote_metadata] entry with [symbols_in] = universe size.
+    Per-symbol promotes inside the wrap do {e not} emit individual trace records
+    — the [Bar_loader] tier-op trace hook fires only for Summary / Full /
+    Demote, so this bulk wrap is the canonical observable for Metadata-promote
+    cost.
 
     Exposed so a regression test can pin the "single missing CSV does not raise"
     contract without spinning up a full simulator. *)
@@ -71,8 +78,8 @@ val run :
 
     Internally:
     - Builds a [Bar_loader] with a trace_hook bridging [tier_op] → phase.
-    - Bulk-promotes [input.all_symbols] to Metadata under a [Load_bars] trace
-      wrap.
+    - Bulk-promotes [input.all_symbols] to Metadata under a [Promote_metadata]
+      trace wrap (see {!promote_universe_metadata}).
     - Constructs a Weinstein strategy wrapped by [Tiered_strategy_wrapper] and
       runs [Simulator.run] under a [Fill] trace wrap.
 

--- a/trading/trading/backtest/lib/trace.ml
+++ b/trading/trading/backtest/lib/trace.ml
@@ -18,6 +18,7 @@ module Phase = struct
     | Promote_summary
     | Promote_full
     | Demote
+    | Promote_metadata
   [@@deriving show, eq, sexp]
 end
 

--- a/trading/trading/backtest/lib/trace.mli
+++ b/trading/trading/backtest/lib/trace.mli
@@ -46,6 +46,15 @@ module Phase : sig
             emitted per [demote] call regardless of the target tier — the
             target-tier dimension is carried in logs/scenario metadata, not in
             the phase tag. *)
+    | Promote_metadata
+        (** A bulk Metadata-tier promote of the universe at the start of a
+            Tiered backtest. One record per
+            [Tiered_runner.promote_universe_metadata] call (typically once per
+            backtest). [symbols_in] is the universe size; per-symbol
+            Metadata-promote calls fire {e inside} this wrap but do not
+            themselves emit trace records — only this bulk wrap does. So this
+            single record is the canonical observable for the Metadata-promote
+            phase, not a per-symbol breakdown. *)
   [@@deriving show, eq, sexp]
 end
 

--- a/trading/trading/backtest/test/test_runner_tiered_metadata_tolerance.ml
+++ b/trading/trading/backtest/test/test_runner_tiered_metadata_tolerance.ml
@@ -143,6 +143,58 @@ let test_all_present_promotes_all _ =
   assert_that stats.summary (equal_to 0);
   assert_that stats.full (equal_to 0)
 
+(** When a [Trace.t] is attached, [promote_universe_metadata] emits exactly one
+    [Promote_metadata] record with [symbols_in] = universe size. Pins the trace
+    bridging added in workstream B1 of [dev/plans/backtest-perf-2026-04-24.md]:
+    before this PR the bulk Metadata-promote phase was unobservable in traces
+    (was implicitly under [Load_bars] at the runner level), and a 10K-symbol OOM
+    inside this function therefore left no smoking-gun phase record. *)
+let test_attached_trace_records_promote_metadata_phase _ =
+  let tmp_dir = Filename_unix.temp_dir "tiered_metadata_tolerance_" "" in
+  let data_dir = Fpath.v tmp_dir in
+  _write_symbol ~data_dir ~symbol:"AAA";
+  _write_symbol ~data_dir ~symbol:"BBB";
+  let all_symbols = [ "AAA"; "BBB"; "MISSING" ] in
+  let loader = _make_loader ~data_dir ~all_symbols in
+  let input = _make_input ~data_dir ~all_symbols in
+  let trace = Backtest.Trace.create () in
+  Backtest.Tiered_runner.promote_universe_metadata ~trace loader input
+    ~as_of:_as_of;
+  assert_that
+    (Backtest.Trace.snapshot trace)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (m : Backtest.Trace.phase_metrics) -> m.phase)
+               (equal_to Backtest.Trace.Phase.Promote_metadata);
+             field
+               (fun (m : Backtest.Trace.phase_metrics) -> m.symbols_in)
+               (equal_to (Some 3));
+             field
+               (fun (m : Backtest.Trace.phase_metrics) -> m.elapsed_ms)
+               (ge (module Int_ord) 0);
+           ];
+       ])
+
+(** Without a [Trace.t] attached, behaviour is unchanged and no record is
+    emitted on a sibling collector. Guards against accidentally making the trace
+    required. *)
+let test_no_trace_attached_is_passthrough _ =
+  let tmp_dir = Filename_unix.temp_dir "tiered_metadata_tolerance_" "" in
+  let data_dir = Fpath.v tmp_dir in
+  _write_symbol ~data_dir ~symbol:"AAA";
+  let all_symbols = [ "AAA" ] in
+  let loader = _make_loader ~data_dir ~all_symbols in
+  let input = _make_input ~data_dir ~all_symbols in
+  let sibling_trace = Backtest.Trace.create () in
+  (* Call WITHOUT ?trace. The sibling collector must remain empty. *)
+  Backtest.Tiered_runner.promote_universe_metadata loader input ~as_of:_as_of;
+  assert_that (Backtest.Trace.snapshot sibling_trace) (size_is 0);
+  let stats = Bar_loader.stats loader in
+  assert_that stats.metadata (equal_to 1)
+
 let suite =
   "Runner_tiered_metadata_tolerance"
   >::: [
@@ -153,6 +205,10 @@ let suite =
          >:: test_all_missing_does_not_raise;
          "all present: promotes all symbols to Metadata"
          >:: test_all_present_promotes_all;
+         "attached trace records one Promote_metadata phase"
+         >:: test_attached_trace_records_promote_metadata_phase;
+         "omitted trace is passthrough"
+         >:: test_no_trace_attached_is_passthrough;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_trace.ml
+++ b/trading/trading/backtest/test/test_trace.ml
@@ -19,6 +19,7 @@ let test_phase_sexp_round_trip _ =
       Promote_summary;
       Promote_full;
       Demote;
+      Promote_metadata;
     ]
   in
   List.iter all_phases ~f:(fun p ->


### PR DESCRIPTION
## Summary

Workstream B1 of [`dev/plans/backtest-perf-2026-04-24.md`](dev/plans/backtest-perf-2026-04-24.md). Closes the trace hole called out in [`dev/notes/memory-profiling-framework-2026-04-24.md`](dev/notes/memory-profiling-framework-2026-04-24.md): the bulk universe Metadata-promote inside `Tiered_runner.promote_universe_metadata` was only observable as a generic `Load_bars` phase, so the 10K-symbol OOM in PR #523 left no smoking-gun phase record at the location where it actually died.

After this PR, when a `Trace.t` is attached to a Tiered backtest, the trace contains a dedicated `Promote_metadata` record with elapsed time + peak RSS + universe size, which makes it possible to attribute OOM-time RSS to Metadata loading specifically (vs. simulator allocation, AD-breadth load, etc.).

## Changes

- `Trace.Phase.t` gains a `Promote_metadata` variant. Sexp/show/eq derivers propagate; `test_phase_sexp_round_trip` covers it.
- `Tiered_runner.promote_universe_metadata` gains an optional `?trace` parameter and wraps its body in `Trace.record ?trace ~symbols_in:n_total Promote_metadata`. The `Bar_loader` tier-op trace hook does not fire for per-symbol Metadata promotes (intentional, see `bar_loader.ml`), so this single bulk wrap is the canonical observable for Metadata-promote elapsed + RSS.
- `Tiered_runner.run` drops the outer `Load_bars` wrap around the call — the inner `Promote_metadata` wrap subsumes it, and Tiered's flow doesn't match Legacy's `Load_bars` semantics (Legacy uses `Load_bars` for simulator allocation; Tiered allocates lazily inside `Fill`).
- Doc updates: stale comment in `tiered_runner.ml` about per-symbol batching being trace-equivalent reworded to clarify the bulk phase IS now traced even though per-symbol detail isn't; `runner.mli` + `tiered_runner.mli` updated to reference `Promote_metadata` instead of `Load_bars` on the Tiered path.
- Two new tests in `test_runner_tiered_metadata_tolerance`:
  - `attached trace records exactly one Promote_metadata phase` — pins `symbols_in` = universe size and `elapsed_ms >= 0` after a real promote call (with one missing CSV mixed in to exercise the failure-tolerance + trace path together).
  - `omitted ?trace is passthrough` — guards against accidentally making the trace required.

## Compatibility

- No production trace consumers exist yet, so adding a variant is binary-compatible. Old sexp readers will fail on `Promote_metadata` records, but none are deployed.
- No behaviour change when `?trace` is omitted — `Trace.record ?trace:None` is a no-op per the existing `Trace` design.

## Test plan

- [x] `dune build` clean (no warnings beyond the pre-existing `dune-project` notice)
- [x] `dune runtest` clean — 93 OK, 0 FAILED
- [x] `dune build @fmt` clean
- [x] New unit tests pass: `test_attached_trace_records_promote_metadata_phase` + `test_no_trace_attached_is_passthrough`
- [x] Existing tests (`test_partial_missing_does_not_raise`, `test_all_missing_does_not_raise`, `test_all_present_promotes_all`, `test_phase_sexp_round_trip`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)