### PR TITLE
feat(backtest/trace): flush-on-record so SIGKILL'd runs leave a partial trace (B3)

### DIFF
--- a/trading/trading/backtest/bin/backtest_runner.ml
+++ b/trading/trading/backtest/bin/backtest_runner.ml
@@ -11,13 +11,16 @@
       in the runner since the implementation lands in increment 3f of
       [dev/plans/backtest-tiered-loader-2026-04-19.md].
     - --trace: when given, instruments the run with per-phase timing + memory
-      measurements via {!Backtest.Trace} and writes the trace sexp at [<path>]
-      after the result is written. Without this flag, no trace is captured (the
-      default code path is unchanged). The output sexp is a list of
+      measurements via {!Backtest.Trace} and writes the trace sexp at [<path>],
+      atomically flushed after every recorded phase. So a SIGKILL'd run (e.g.
+      OOM mid-backtest) leaves the smoking-gun phase on disk — not just the
+      end-of-run trace. Without this flag, no trace is captured (the default
+      code path is unchanged). The output sexp is a list of
       [Backtest.Trace.phase_metrics] records, parseable via
       [Backtest.Trace.phase_metrics_of_sexp]. Workstream B4 of
       [dev/plans/backtest-perf-2026-04-24.md] — closes the gap that previously
-      forced trace capture through [scenario_runner.exe] only.
+      forced trace capture through [scenario_runner.exe] only. Workstream B3
+      (flush-on-record) makes mid-run kills observable.
 
     Example:
     {[
@@ -78,21 +81,19 @@ let _make_output_dir () =
   Core_unix.mkdir_p path;
   path
 
-(** Write the captured trace sexp at [path] and report the location on stderr.
-    Pulled out of [main] to keep the side-effect explicit at the call site. *)
-let _write_trace ~path ~trace =
-  let metrics = Backtest.Trace.snapshot trace in
-  Backtest.Trace.write ~out_path:path metrics;
-  eprintf "Trace written to: %s\n%!" path
-
 let () =
   let start_date, end_date, overrides, loader_strategy, trace_path =
     _parse_args ()
   in
-  (* When [--trace <path>] is passed, pre-allocate a [Trace.t] so the runner
-     records into it; otherwise [trace = None] and tracing is a no-op (the
-     default code path is unchanged). *)
-  let trace = Option.map trace_path ~f:(fun _ -> Backtest.Trace.create ()) in
+  (* When [--trace <path>] is passed, pre-allocate a [Trace.t] with [flush_path]
+     so the runner records into it AND atomically rewrites the file after every
+     phase. This way a SIGKILL'd run (OOM, etc.) still leaves the most recent
+     entries on disk. Without [--trace], [trace = None] and tracing is a no-op
+     (the default code path is unchanged). *)
+  let trace =
+    Option.map trace_path ~f:(fun path ->
+        Backtest.Trace.create ~flush_path:path ())
+  in
   let result =
     Backtest.Runner.run_backtest ~start_date ~end_date ~overrides
       ?loader_strategy ?trace ()
@@ -101,8 +102,11 @@ let () =
   eprintf "Writing output to %s/\n%!" output_dir;
   Backtest.Result_writer.write ~output_dir result;
   eprintf "Output written to: %s/\n%!" output_dir;
-  Option.iter (Option.both trace_path trace) ~f:(fun (path, trace) ->
-      _write_trace ~path ~trace);
+  (* No explicit [Trace.write] needed: when [flush_path] is set, the file is
+     already current as of the most recent [Trace.record] call. Just announce
+     the path so users can find it. *)
+  Option.iter trace_path ~f:(fun path ->
+      eprintf "Trace written to: %s\n%!" path);
   Out_channel.output_string stdout
     (Sexp.to_string_hum (Backtest.Summary.sexp_of_t result.summary));
   Out_channel.newline stdout

--- a/trading/trading/backtest/lib/trace.ml
+++ b/trading/trading/backtest/lib/trace.ml
@@ -32,9 +32,14 @@ type phase_metrics = {
 }
 [@@deriving show, eq, sexp]
 
-type t = { mutable entries : phase_metrics list }
+type t = {
+  mutable entries : phase_metrics list;
+  flush_path : string option;
+      (** When [Some path], every {!record} call atomically rewrites the trace
+          file at [path]. See [trace.mli] for rationale. *)
+}
 
-let create () = { entries = [] }
+let create ?flush_path () = { entries = []; flush_path }
 
 (** Parse a [VmHWM: NNNN kB] line. Returns kB (native unit from
     [/proc/self/status]; do not pre-divide to MB — short-lived or small
@@ -73,6 +78,31 @@ let _read_peak_rss_kb () : int option =
   if not (_status_file_readable ()) then None
   else try In_channel.with_file _status_path ~f:_scan_for_vmhwm with _ -> None
 
+let _ensure_parent_dir path =
+  let dir = Filename.dirname path in
+  if not (String.equal dir "" || String.equal dir ".") then
+    (* core_unix provides mkdir_p via Core_unix *)
+    Core_unix.mkdir_p dir
+
+(** Atomically write [metrics] as a sexp at [path]. Writes to [path ^ ".tmp"]
+    first, then renames; a SIGKILL between open and rename leaves the previous
+    valid file untouched, never a truncated one. *)
+let _atomic_write_sexp ~path metrics =
+  _ensure_parent_dir path;
+  let sexp = [%sexp_of: phase_metrics list] metrics in
+  let tmp_path = path ^ ".tmp" in
+  Out_channel.with_file tmp_path ~f:(fun oc ->
+      Out_channel.output_string oc (Sexp.to_string_hum sexp);
+      Out_channel.output_char oc '\n');
+  Core_unix.rename ~src:tmp_path ~dst:path
+
+(** Flush the cumulative trace to [t.flush_path] if a path is configured. No-op
+    when [flush_path = None] — keeps the in-memory-only path zero-cost. *)
+let _flush_if_needed t =
+  match t.flush_path with
+  | None -> ()
+  | Some path -> _atomic_write_sexp ~path (List.rev t.entries)
+
 let _append_entry t ~phase ~elapsed_ms ~symbols_in ~symbols_out ~bar_loads =
   let entry =
     {
@@ -84,7 +114,8 @@ let _append_entry t ~phase ~elapsed_ms ~symbols_in ~symbols_out ~bar_loads =
       bar_loads;
     }
   in
-  t.entries <- entry :: t.entries
+  t.entries <- entry :: t.entries;
+  _flush_if_needed t
 
 let record ?trace ?symbols_in ?symbols_out ?bar_loads phase f =
   match trace with
@@ -99,16 +130,4 @@ let record ?trace ?symbols_in ?symbols_out ?bar_loads phase f =
       result
 
 let snapshot t = List.rev t.entries
-
-let _ensure_parent_dir path =
-  let dir = Filename.dirname path in
-  if not (String.equal dir "" || String.equal dir ".") then
-    (* core_unix provides mkdir_p via Core_unix *)
-    Core_unix.mkdir_p dir
-
-let write ~out_path metrics =
-  _ensure_parent_dir out_path;
-  let sexp = [%sexp_of: phase_metrics list] metrics in
-  Out_channel.with_file out_path ~f:(fun oc ->
-      Out_channel.output_string oc (Sexp.to_string_hum sexp);
-      Out_channel.output_char oc '\n')
+let write ~out_path metrics = _atomic_write_sexp ~path:out_path metrics

--- a/trading/trading/backtest/lib/trace.mli
+++ b/trading/trading/backtest/lib/trace.mli
@@ -90,8 +90,26 @@ type t
     across threads — the single-threaded backtest runner is the only expected
     caller. *)
 
-val create : unit -> t
-(** Create a fresh collector with no recorded phases. *)
+val create : ?flush_path:string -> unit -> t
+(** Create a fresh collector with no recorded phases.
+
+    When [?flush_path] is [Some path], every subsequent {!record} call rewrites
+    the file at [path] with the cumulative trace sexp (same format as {!write}).
+    This ensures a partial trace survives a SIGKILL'd run (e.g. an OOM
+    mid-backtest) — the smoking-gun phase is on disk by the time the process
+    dies. The write is atomic via a [<path>.tmp] sibling + [Core_unix.rename],
+    so a kill mid-flush leaves either the previous valid trace or the new one —
+    never a truncated file. Parent directories are created on the first flush.
+
+    Cost: one full sexp rewrite per [record] call. For a typical backtest (~5–20
+    phases per call × ~1500 days = ~30K records, low single-digit MB final size)
+    this is cheap relative to the work being measured. If profiling shows flush
+    dominates wall-time the implementation can switch to append-only without an
+    API change.
+
+    Without [?flush_path], the collector is in-memory only and behaves
+    identically to the pre-flush version — the caller is expected to call
+    {!write} explicitly at end-of-run to persist. *)
 
 val record :
   ?trace:t ->

--- a/trading/trading/backtest/test/test_trace.ml
+++ b/trading/trading/backtest/test/test_trace.ml
@@ -145,6 +145,86 @@ let test_write_creates_parent_dir _ =
   Backtest.Trace.write ~out_path [];
   assert_that (Sys_unix.file_exists_exn out_path) (equal_to true)
 
+(** {1 Flush-on-record (B3)}
+
+    These tests cover [?flush_path]: every [record] call rewrites the file.
+    Critical for SIGKILL'd OOM runs — without flush-on-record, only end-of-run
+    [Trace.write] persists, so a killed mid-run produces no observable trace. *)
+
+(** Load a trace file written by [?flush_path] and parse back to a list of
+    [phase_metrics]. Sharing this helper keeps the assertions symmetric across
+    the three flush tests below. *)
+let _load_trace_file path : Backtest.Trace.phase_metrics list =
+  Sexp.load_sexp path |> List.t_of_sexp Backtest.Trace.phase_metrics_of_sexp
+
+let test_flush_path_writes_after_first_record _ =
+  let dir = Core_unix.mkdtemp "/tmp/trace_test_" in
+  let path = Filename.concat dir "flush.sexp" in
+  let t = Backtest.Trace.create ~flush_path:path () in
+  let _ =
+    Backtest.Trace.record ~trace:t Backtest.Trace.Phase.Load_universe (fun () ->
+        ())
+  in
+  (* File exists and parses as a 1-entry trace whose phase matches. *)
+  assert_that (_load_trace_file path)
+    (elements_are
+       [
+         field
+           (fun (m : Backtest.Trace.phase_metrics) -> m.phase)
+           (equal_to Backtest.Trace.Phase.Load_universe);
+       ])
+
+let test_flush_path_is_incremental _ =
+  let dir = Core_unix.mkdtemp "/tmp/trace_test_" in
+  let path = Filename.concat dir "flush.sexp" in
+  let t = Backtest.Trace.create ~flush_path:path () in
+  let phases : Backtest.Trace.Phase.t list = [ Macro; Load_bars; Screener ] in
+  List.iter phases ~f:(fun phase ->
+      let _ = Backtest.Trace.record ~trace:t phase (fun () -> ()) in
+      ());
+  (* After 3 records, the file holds all 3 entries — not just the last. *)
+  assert_that
+    (_load_trace_file path
+    |> List.map ~f:(fun (m : Backtest.Trace.phase_metrics) -> m.phase))
+    (elements_are
+       [
+         equal_to Backtest.Trace.Phase.Macro;
+         equal_to Backtest.Trace.Phase.Load_bars;
+         equal_to Backtest.Trace.Phase.Screener;
+       ])
+
+let test_flush_path_leaves_no_tmp_artifact _ =
+  let dir = Core_unix.mkdtemp "/tmp/trace_test_" in
+  let path = Filename.concat dir "flush.sexp" in
+  let t = Backtest.Trace.create ~flush_path:path () in
+  let _ =
+    Backtest.Trace.record ~trace:t Backtest.Trace.Phase.Macro (fun () -> ())
+  in
+  (* The atomic-write dance writes [path ^ ".tmp"] then renames. After a
+     successful flush, no [.tmp] sibling should remain. *)
+  assert_that (Sys_unix.file_exists_exn (path ^ ".tmp")) (equal_to false)
+
+let test_create_without_flush_path_writes_no_file _ =
+  let dir = Core_unix.mkdtemp "/tmp/trace_test_" in
+  let path = Filename.concat dir "should-not-exist.sexp" in
+  (* No [?flush_path] — pre-flush behaviour preserved. *)
+  let t = Backtest.Trace.create () in
+  let _ =
+    Backtest.Trace.record ~trace:t Backtest.Trace.Phase.Macro (fun () -> ())
+  in
+  assert_that (Sys_unix.file_exists_exn path) (equal_to false)
+
+let test_flush_path_creates_parent_dir _ =
+  let root = Core_unix.mkdtemp "/tmp/trace_test_" in
+  (* Nest the flush target under an unmade directory. The first flush should
+     create the parents (mkdir -p) — same contract as {!Backtest.Trace.write}. *)
+  let path = Filename.concat root "a/b/c/flush.sexp" in
+  let t = Backtest.Trace.create ~flush_path:path () in
+  let _ =
+    Backtest.Trace.record ~trace:t Backtest.Trace.Phase.Macro (fun () -> ())
+  in
+  assert_that (Sys_unix.file_exists_exn path) (equal_to true)
+
 let suite =
   "Trace"
   >::: [
@@ -159,6 +239,16 @@ let suite =
          "record measures elapsed ms" >:: test_record_measures_elapsed;
          "write round-trips via sexp" >:: test_write_sexp_round_trip;
          "write creates parent dir" >:: test_write_creates_parent_dir;
+         "flush_path writes after first record"
+         >:: test_flush_path_writes_after_first_record;
+         "flush_path is incremental across records"
+         >:: test_flush_path_is_incremental;
+         "flush_path leaves no .tmp artifact after success"
+         >:: test_flush_path_leaves_no_tmp_artifact;
+         "create without flush_path writes no file"
+         >:: test_create_without_flush_path_writes_no_file;
+         "flush_path creates parent dir on first flush"
+         >:: test_flush_path_creates_parent_dir;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Workstream **B3** of `dev/plans/backtest-perf-2026-04-24.md`. The 10K-symbol OOM (PR #523) and the 292-symbol Tiered RSS regression (PR #524) both happen mid-run. We can't see WHICH phase consumed the memory because the SIGKILL skips end-of-run cleanup, so no trace file is ever written. After this PR, every `Trace.record` call atomically rewrites the trace file on disk — so even a killed run leaves a partial sexp pinning the smoking-gun phase.

## What changed

- **`Trace.create`** now takes an optional `?flush_path:string`. When set, every `record` call atomically rewrites `<path>` with the cumulative trace sexp. Atomic via `<path>.tmp` + `Core_unix.rename`, so a kill mid-flush leaves either the previous valid trace or the new one — never a truncated file. Backward-compatible: existing callers of `Trace.create ()` see zero behaviour change.
- **`Trace.write`** internally factored to share the atomic-rename helper with the flush path. The public API is unchanged but writes are now atomic by default.
- **`backtest_runner.ml`** wires `--trace <path>` through `Trace.create ~flush_path:path ()` so killed runs leave partial traces. The explicit final `Trace.write` is dropped — the file is already current as of the last `record` call.
- **5 new tests** in `test_trace.ml` covering: flush-on-first-record, incremental flush across 3 records, no `.tmp` artifact after success, no-flush default still writes nothing, and `mkdir -p` of nested parents on the first flush.

## Cost / risk

One full sexp rewrite per `record` call. For a typical backtest (~5-20 phases per call × ~1500 days = ~30K records, low single-digit MB final size) this is cheap relative to the work being measured. If profiling shows flush dominates wall-time the implementation can switch to append-only without an API change.

## Unblocks

When re-running the OOM scenario locally with `--trace /tmp/oom-trace.sexp`, we will now see the per-phase RSS climb up to the killed phase. This is workstream B's investigation purpose.

## Test plan

- [x] `dune build` clean (zero warnings)
- [x] `dune fmt` stable (no diff after run)
- [x] `dune exec backtest/test/test_trace.exe` — 14/14 pass (9 existing + 5 new flush-on-record tests)
- [x] `dune exec backtest/bar_loader/test/test_trace_integration.exe` — 7/7 pass (no regression in trace-touching paths)
- [x] `dune exec backtest/test/test_runner_tiered_skeleton.exe` — 5/5 pass
- [x] `dune exec backtest/test/test_backtest_runner_args.exe` — 12/12 pass
- [x] Pre-existing `Tiered_loader_parity` and `Runner_hypothesis_overrides` failures confirmed identical to plain `origin/main` (fixture path issue, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)