### PR TITLE
feat(backtest-perf): full_compute_tail_days override (H2)

### DIFF
--- a/trading/trading/backtest/lib/tiered_runner.ml
+++ b/trading/trading/backtest/lib/tiered_runner.ml
@@ -26,8 +26,28 @@ let _make_trace_hook ?trace () : Bar_loader.trace_hook =
   in
   { record }
 
+(** Build the [Full_compute.config] passed to [Bar_loader.create].
+
+    When [config.full_compute_tail_days = Some n], override the default
+    [tail_days] (currently 1800) with [n]. Lower values cap the bar count
+    retained per Full-tier symbol, reducing the per-symbol memory cost of
+    [Full.t.bars] but possibly changing strategy behaviour (Bar_history is
+    seeded from [Full.t.bars] on promotion). Hypothesis-testing only — see the
+    H2 row in [dev/plans/backtest-perf-2026-04-24.md].
+
+    When [None] (default), returns [Full_compute.default_config] unchanged so
+    the Tiered path's per-symbol bar retention is byte-identical to the
+    pre-override behaviour. The parity test ([test_tiered_loader_parity]) relies
+    on this default-path identity. *)
+let _resolve_full_config (config : Weinstein_strategy.config) :
+    Bar_loader.Full_compute.config =
+  match config.full_compute_tail_days with
+  | None -> Bar_loader.Full_compute.default_config
+  | Some n -> { Bar_loader.Full_compute.tail_days = n }
+
 let _create_bar_loader (input : input) ?trace () =
   let trace_hook = _make_trace_hook ?trace () in
+  let full_config = _resolve_full_config input.config in
   (* Benchmark must match the Runner's primary index so Summary-tier RS line
      computation can find the benchmark's bars. Bar_loader's default "SPY" is
      not present in the parity fixtures (GSPC.INDX is the primary), so without
@@ -35,7 +55,7 @@ let _create_bar_loader (input : input) ?trace () =
      is a no-op on the parity scenario. *)
   Bar_loader.create ~data_dir:input.data_dir_fpath
     ~sector_map:input.ticker_sectors ~universe:input.all_symbols
-    ~benchmark_symbol:input.config.indices.primary ~trace_hook ()
+    ~benchmark_symbol:input.config.indices.primary ~full_config ~trace_hook ()
 
 (** Max per-symbol Metadata-promote failure messages to emit on stderr before
     collapsing into a summary count. A universe where every symbol fails (e.g. a

--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -1,6 +1,7 @@
-(** Tests for the perf workstream C1 hypothesis-toggle config fields:
+(** Tests for the perf workstream hypothesis-toggle config fields:
     [bar_history_max_lookback_days], [skip_ad_breadth], [skip_sector_etf_load],
-    and [universe_cap].
+    [universe_cap] (all C1, PR #528), and [full_compute_tail_days] (H2,
+    extending the C1 surface).
 
     These fields land in [Weinstein_strategy.config] together; their unifying
     contract is "default value = current behaviour, set via [--override]". Tests
@@ -21,7 +22,11 @@
     change observable strategy behaviour. The wiring lives in PR 3 of
     [dev/plans/bar-history-trim-2026-04-24.md]. The test here pins the no-op-now
     contract so a future change can flip the test in the same PR that flips the
-    runtime behaviour. *)
+    runtime behaviour.
+
+    [full_compute_tail_days] only affects the Tiered loader_strategy path
+    (Legacy doesn't use [Full_compute] at all). The Tiered smoke test uses the
+    parity fixture under [Loader_strategy.Tiered] to drive the new code path. *)
 
 open OUnit2
 open Core
@@ -107,6 +112,9 @@ let test_default_preserves_current_behaviour _ =
            (fun (c : Weinstein_strategy.config) -> c.skip_sector_etf_load)
            (equal_to false);
          field (fun (c : Weinstein_strategy.config) -> c.universe_cap) is_none;
+         field
+           (fun (c : Weinstein_strategy.config) -> c.full_compute_tail_days)
+           is_none;
        ])
 
 let test_override_bar_history_max_lookback_days _ =
@@ -207,6 +215,65 @@ let test_skip_sector_etf_load_runs_to_completion _ =
   in
   assert_that (List.length result.steps) (gt (module Int_ord) 0)
 
+(* -------------------------------------------------------------------- *)
+(* full_compute_tail_days (H2) — Tiered loader_strategy path             *)
+(* -------------------------------------------------------------------- *)
+
+(** Sexp round-trip: an override sexp parses [full_compute_tail_days = Some 50]
+    correctly so [--override '((full_compute_tail_days (50)))'] lands the value
+    into the running config. *)
+let test_override_full_compute_tail_days _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string "((full_compute_tail_days (50)))")
+  in
+  assert_that merged.full_compute_tail_days (is_some_and (equal_to 50))
+
+(** Run the parity scenario under the Tiered loader_strategy. Mirrors [_run] but
+    flips the strategy — the Tiered path is where [full_compute_tail_days]
+    actually has an effect, since it threads into [Bar_loader.create]'s
+    [?full_config] parameter. *)
+let _run_tiered (s : Scenario.t) ~overrides =
+  let sector_map_override = _sector_map_override s in
+  Backtest.Runner.run_backtest ~start_date:s.period.start_date
+    ~end_date:s.period.end_date ~overrides ?sector_map_override
+    ~loader_strategy:Loader_strategy.Tiered ()
+
+(** [full_compute_tail_days = None] (the default) must produce identical output
+    to a backtest with no override at all. Pins the parity invariant: the
+    override only kicks in when explicitly set, so existing parity tests + any
+    A/B baseline run with [None] is bit-identical to pre-change behaviour. *)
+let test_full_compute_tail_days_none_matches_no_override _ =
+  let s = _load_scenario () in
+  let baseline = _run_tiered s ~overrides:[] in
+  let with_none =
+    _run_tiered s ~overrides:[ Sexp.of_string "((full_compute_tail_days ()))" ]
+  in
+  assert_that with_none.summary
+    (all_of
+       [
+         field
+           (fun (sm : Backtest.Summary.t) -> sm.n_round_trips)
+           (equal_to baseline.summary.n_round_trips);
+         field
+           (fun (sm : Backtest.Summary.t) -> sm.final_portfolio_value)
+           (float_equal ~epsilon:0.01 baseline.summary.final_portfolio_value);
+       ])
+
+(** [full_compute_tail_days = Some 50] must run to completion under the Tiered
+    loader. We do NOT pin PV or trade count — this is degraded mode (capping
+    [Full_compute.tail_days] at 50 starves Bar_history of the ~250-day MA
+    history it needs, so the strategy is expected to make different decisions).
+    The contract this test pins is: the Tiered runner doesn't crash when the
+    override is set to an unusually small value. *)
+let test_full_compute_tail_days_50_runs_to_completion _ =
+  let s = _load_scenario () in
+  let result =
+    _run_tiered s
+      ~overrides:[ Sexp.of_string "((full_compute_tail_days (50)))" ]
+  in
+  assert_that (List.length result.steps) (gt (module Int_ord) 0)
+
 let suite =
   "Runner_hypothesis_overrides"
   >::: [
@@ -230,6 +297,12 @@ let suite =
          >:: test_skip_ad_breadth_runs_to_completion;
          "skip_sector_etf_load = true runs to completion (degraded mode)"
          >:: test_skip_sector_etf_load_runs_to_completion;
+         "override: full_compute_tail_days round-trips through sexp"
+         >:: test_override_full_compute_tail_days;
+         "full_compute_tail_days = None matches no-override baseline (Tiered)"
+         >:: test_full_compute_tail_days_none_matches_no_override;
+         "full_compute_tail_days = Some 50 runs to completion (Tiered)"
+         >:: test_full_compute_tail_days_50_runs_to_completion;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -35,6 +35,7 @@ type config = {
   skip_ad_breadth : bool;
   skip_sector_etf_load : bool;
   universe_cap : int option;
+  full_compute_tail_days : int option;
 }
 [@@deriving sexp]
 
@@ -54,6 +55,7 @@ let default_config ~universe ~index_symbol =
     skip_ad_breadth = false;
     skip_sector_etf_load = false;
     universe_cap = None;
+    full_compute_tail_days = None;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -122,16 +122,34 @@ type config = {
           [None] (default) uses the full universe. Used for hypothesis tests
           like H5 (how does RSS scale with universe size?). NOT safe to flip on
           in production. *)
+  full_compute_tail_days : int option;
+      (** Hypothesis-testing field (perf workstream H2). When [Some n], the
+          Tiered loader's [Bar_loader.Full_compute.tail_days] is set to [n]
+          instead of the default. Caps the bar count retained per Full-tier
+          symbol. Lower values = less memory but possibly different strategy
+          behaviour, since [Stops_runner] / [Weinstein_stops] read bars from
+          [Bar_history], which is seeded from [Full.t.bars] on Full promotion.
+
+          [None] (default) uses [Full_compute.default_config.tail_days] (1800).
+          The Legacy [loader_strategy] does not use [Full_compute] at all, so
+          the override is a no-op on that path.
+
+          Hypothesis-testing only — like the other hypothesis toggles. Setting
+          this is expected to change strategy outputs at scale (PnL, trade
+          count). Use for A/B vs the [None] baseline only when measuring memory
+          attribution. NOT safe to flip on in production. See H2 in
+          [dev/plans/backtest-perf-2026-04-24.md]. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for
     backtesting.
 
-    The four hypothesis-testing fields ([bar_history_max_lookback_days],
-    [skip_ad_breadth], [skip_sector_etf_load], [universe_cap]) all default to
-    behaviour-preserving values. Setting any of them changes runner / strategy
-    behaviour and is intended for perf measurement A/Bs only — see the H-series
-    in [dev/plans/backtest-perf-2026-04-24.md]. *)
+    The five hypothesis-testing fields ([bar_history_max_lookback_days],
+    [skip_ad_breadth], [skip_sector_etf_load], [universe_cap],
+    [full_compute_tail_days]) all default to behaviour-preserving values.
+    Setting any of them changes runner / strategy behaviour and is intended for
+    perf measurement A/Bs only — see the H-series in
+    [dev/plans/backtest-perf-2026-04-24.md]. *)
 
 val default_config : universe:string list -> index_symbol:string -> config
 (** Build a default config with Weinstein book values. The resulting config has


### PR DESCRIPTION
## Summary

Adds the `full_compute_tail_days : int option` hypothesis-toggle to `Weinstein_strategy.config` and threads it into `Bar_loader.create`'s `?full_config` parameter on the Tiered runner path. This is the missing knob for **H2** in `dev/plans/backtest-perf-2026-04-24.md`: does `Full.t.bars` duplication account for Tiered's residual RSS after H1 was disproved?

If reducing `Full_compute.tail_days` from its default (1800) to ~50 cuts Tiered's `Promote_full` RSS by ~80%, then `Full.t.bars` is the carrier of the +95% Tiered RSS gap that C2's per-phase report from #539 pointed at.

## Why now

H3 measurement (#539) showed AD-breadth is NOT the source of the +95% Tiered RSS gap. The per-phase report fingered `Promote_full` as where ~3 GB lands during the Tiered run. Two carrier candidates remain:
- (a) `Full.t.bars` + `Bar_history` seeding-from-Full duplicating bar lists, or
- (b) some other retained state inside `Full.t` (Summary scalar cache, intermediate parse buffers).

H2 directly tests (a). The override is the cheapest possible test: cap `Full_compute.tail_days` 5x and watch the Tiered Promote_full RSS row.

## Default behaviour

- `full_compute_tail_days = None` (the default) keeps `Full_compute.default_config` (tail_days = 1800) — **byte-identical** to the pre-change Tiered path. `test_tiered_loader_parity` continues to hold.
- The Legacy `loader_strategy` does not use `Full_compute` at all, so the field is a no-op on that path (mirrors the other C1 hypothesis toggles).

## Tests

Added 3 tests to `trading/trading/backtest/test/test_runner_hypothesis_overrides.ml`:
1. **Sexp round-trip** — `((full_compute_tail_days (50)))` parses correctly via the same deep-merge logic the runner uses.
2. **`Some n = None` parity** — running the parity scenario under Tiered with `((full_compute_tail_days ()))` produces identical `n_round_trips` / `final_portfolio_value` to the no-override baseline.
3. **Smoke test** — `((full_compute_tail_days (50)))` runs to completion under Tiered. PV / trade-count NOT pinned — capping tail_days at 50 starves Bar_history of the ~250-day MA history the strategy needs (degraded mode by design, like `skip_ad_breadth`).

Plus extended the existing `test_default_preserves_current_behaviour` to cover the new field.

## Test plan

- [x] `dune build` passes (warning-free; only the harmless dune-project-not-found notice from the worktree path).
- [x] `dune runtest` passes — 57 test executables, 0 failures, including the 3 new + extended tests in `test_runner_hypothesis_overrides`.
- [x] `dune build @fmt` exits 0 (ocamlformat 0.29.0 in the dev container).
- [x] `test_tiered_loader_parity` passes (default-path identity preserved).
- [ ] H2 measurement: `dev/scripts/run_perf_hypothesis.sh H2 trading/test_data/backtest_scenarios/goldens-small/bull-crash-2015-2020.sexp '((full_compute_tail_days (50)))'` — deferred to lead session post-merge to keep this PR small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)