### PR TITLE
perf(csv_storage): stream-parse get with in-range filtering (H7)

### DIFF
--- a/trading/analysis/data/storage/csv/lib/csv_storage.ml
+++ b/trading/analysis/data/storage/csv/lib/csv_storage.ml
@@ -173,23 +173,55 @@ let _in_date_range ~start_date ~end_date (price : Types.Daily_price.t) =
   in
   after_start && before_end
 
+(* Streaming reader: parse one line at a time and only retain rows that fall
+   within the requested date range. Avoids materializing the full file
+   contents (lines list) or the full parsed-prices list, which previously
+   dominated allocation churn during repeated reads of large symbol CSVs. *)
+let _stream_in_range_prices chan ~start_date ~end_date =
+  let result = ref [] in
+  let error = ref None in
+  let rec loop () =
+    match !error with
+    | Some _ -> ()
+    | None -> (
+        match In_channel.input_line chan with
+        | None -> ()
+        | Some line ->
+            (match Parser.parse_line line with
+            | Ok price ->
+                if _in_date_range ~start_date ~end_date price then
+                  result := price :: !result
+            | Error msg -> error := Some (Status.invalid_argument_error msg));
+            loop ())
+  in
+  loop ();
+  match !error with Some err -> Error err | None -> Ok (List.rev !result)
+
+let _read_streaming t ~start_date ~end_date =
+  In_channel.with_file t.path ~f:(fun chan ->
+      (* An empty file (no header) matches the legacy `Parser.parse_lines []`
+         behavior, which raised "Empty file". *)
+      match In_channel.input_line chan with
+      | None -> Status.error_invalid_argument "Empty file"
+      | Some _header -> _stream_in_range_prices chan ~start_date ~end_date)
+
 let get t ?start_date ?end_date () =
   let open Result.Let_syntax in
-  (* Check if file exists before trying to read *)
-  let%bind lines =
+  let%bind () =
     match Sys_unix.file_exists t.path with
-    | `Yes -> (
-        try Ok (In_channel.read_lines t.path)
-        with Sys_error msg -> Status.error_not_found msg)
+    | `Yes -> Ok ()
     | `No | `Unknown ->
         Status.error_not_found (Printf.sprintf "Data file not found: %s" t.path)
   in
-  let%bind prices = Parser.parse_lines lines in
+  let%bind prices =
+    try _read_streaming t ~start_date ~end_date
+    with Sys_error msg -> Status.error_not_found msg
+  in
   match (start_date, end_date) with
   | Some start, Some end_ when Date.compare start end_ > 0 ->
       Status.error_invalid_argument
         "start_date must be before or equal to end_date"
-  | _ -> Ok (List.filter prices ~f:(_in_date_range ~start_date ~end_date))
+  | _ -> Ok prices
 
 let save t ?(override = false) prices =
   let open Result.Let_syntax in

--- a/trading/analysis/data/storage/csv/lib/parser.mli
+++ b/trading/analysis/data/storage/csv/lib/parser.mli
@@ -1,3 +1,7 @@
+val parse_line : string -> (Types.Daily_price.t, string) Result.t
+(** Parse a single (non-header) CSV line into a price record. Returns Ok with
+    the record or Error with a message if the line is malformed. *)
+
 val parse_lines : string list -> Types.Daily_price.t list Status.status_or
 (** Parse a list of lines of CSV data into a list of price_data records. Returns
     Ok with the list of records or Error with a message if something goes wrong.

--- a/trading/analysis/data/storage/csv/test/test_csv_storage.ml
+++ b/trading/analysis/data/storage/csv/test/test_csv_storage.ml
@@ -243,6 +243,56 @@ let test_empty_list_after_write_without_override _ =
       String.concat ~sep:"\n" (List.map ps ~f:Types.Daily_price.show))
     prices saved_prices
 
+(* Streaming-refactor coverage: confirm filtering happens during the per-line
+   read (not as a post-pass over the full price list). *)
+
+let test_stream_start_date_only_filter _ =
+  let storage = create ~data_dir:test_dir "STREAM1" |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  let start_date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:21 in
+  let filtered = get storage ~start_date () |> ok_or_failwith_status in
+  assert_equal
+    ~printer:(fun ps ->
+      String.concat ~sep:"\n" (List.map ps ~f:Types.Daily_price.show))
+    (List.drop prices 2) filtered
+
+let test_stream_bad_line_propagates_error _ =
+  let storage = create ~data_dir:test_dir "STREAM2" |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  (* Corrupt the file: append a malformed row after the valid data. The
+     streaming reader should still surface the parse error. *)
+  let path =
+    Fpath.(test_dir / "S" / "2" / "STREAM2" / "data.csv") |> Fpath.to_string
+  in
+  let oc = Stdlib.open_out_gen [ Open_append ] 0o666 path in
+  Out_channel.output_string oc "not,enough,columns\n";
+  Out_channel.close oc;
+  match get storage () with
+  | Ok _ -> assert_failure "Expected parse error from corrupted CSV row"
+  | Error status ->
+      assert_equal ~printer:Status.show status
+        (Status.invalid_argument_error
+           "Expected 7 columns, line: not,enough,columns")
+
+let test_stream_header_only_returns_empty _ =
+  let storage = create ~data_dir:test_dir "STREAM3" |> ok_or_failwith_status in
+  (* `save` with an empty list is a no-op (see
+     test_empty_list_after_write_with_override), so write the header-only file
+     by hand to exercise the header-only branch directly. `create` has already
+     made the symbol directory. *)
+  let path =
+    Fpath.(test_dir / "S" / "3" / "STREAM3" / "data.csv") |> Fpath.to_string
+  in
+  let oc = Stdlib.open_out path in
+  Out_channel.output_string oc
+    "date,open,high,low,close,adjusted_close,volume\n";
+  Out_channel.close oc;
+  let result = get storage () |> ok_or_failwith_status in
+  assert_equal
+    ~printer:(fun ps ->
+      String.concat ~sep:"\n" (List.map ps ~f:Types.Daily_price.show))
+    [] result
+
 let suite =
   "CSV Storage tests"
   >::: [
@@ -264,6 +314,12 @@ let suite =
          >:: test_empty_list_after_write_with_override;
          "test_empty_list_after_write_without_override"
          >:: test_empty_list_after_write_without_override;
+         "test_stream_start_date_only_filter"
+         >:: test_stream_start_date_only_filter;
+         "test_stream_bad_line_propagates_error"
+         >:: test_stream_bad_line_propagates_error;
+         "test_stream_header_only_returns_empty"
+         >:: test_stream_header_only_returns_empty;
        ]
 
 let () =


### PR DESCRIPTION
## Summary

`Csv_storage.get` previously read the entire CSV into a `string list`, parsed every row into a `Daily_price.t list`, and only then applied the date-range filter. For 292 symbols x 312 Fridays across a Tiered backtest that's ~91K full-file reads of ~11K-row CSVs — dominating the OCaml heap's high-water mark during `Promote_full`.

H2 (PR #541) confirmed `tail_days` (1800 -> 50) alone had zero effect on Tiered RSS, because the parameter only narrowed the filter, not the read. This PR cuts the per-call peak from ~11K Daily_price records to just the in-range rows (typically <=365 for tail_days=365). See `dev/notes/h2-result-2026-04-24.md` for the H7 hypothesis.

## What changed

- `Csv_storage.get` now opens the file via `In_channel.with_file`, consumes one line at a time with `In_channel.input_line`, parses each line with the existing `Parser.parse_line`, and skips out-of-range rows in the streaming loop.
- `Parser.parse_line` was already defined but not exported; added to `parser.mli`.
- 3 new tests covering streaming behavior (start-date-only filter, bad-line propagation, header-only file).

## Behavior

Bit-identical to the previous `get`:
- Same list contents and ordering (in-range rows, sorted-ascending by date).
- Same error precedence: file-not-found, then "Empty file" (no header), then parse error, then `start_date > end_date`.
- All 12 existing `Csv_storage` tests pass unchanged.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest analysis/data/storage/csv` — 15/15 pass (12 existing + 3 new)
- [x] `dune build @fmt` clean
- [x] Diff stat shows only 3 files: csv_storage.ml, parser.mli, test_csv_storage.ml
- [ ] Optional follow-up: run `dev/scripts/run_perf_hypothesis.sh H7 ...` to measure post-fix Tiered RSS vs. baseline 3,652,852 KB (deferred to lead session per task budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)