### PR TITLE
docs(notes): H7 disproved at top — Promote_full carrier still elusive (4th disproof)

### DIFF
--- a/dev/notes/h7-result-2026-04-24.md
+++ b/dev/notes/h7-result-2026-04-24.md
@@ -1,0 +1,112 @@
+# H7 result: streaming Csv_storage.get saves 130 MB on Metadata phase, Promote_full unchanged (2026-04-24)
+
+## Hypothesis (from `dev/notes/h2-result-2026-04-24.md`)
+
+> **H7**: `Csv_storage.get` re-reads + re-parses entire CSV per call;
+> Tiered calls this 91K times across a 6-year run. Stream-parsing with
+> inline date filter should drop Tiered RSS substantially because peak
+> allocation churn drives heap to 3.5 GB.
+> Test: refactor `Csv_storage.get` to stream + filter inline (no full
+> materialization), then re-run baseline A/B.
+
+## Setup
+
+- Branch: `main` post-#543 (csv_storage stream-parse landed).
+- Tooling: `dev/scripts/run_perf_hypothesis.sh H7-verify ...` (no override).
+- Scoped data dir: `/tmp/data-small-302` (292 symbols).
+- Scenario: `goldens-small/bull-crash-2015-2020.sexp`.
+
+## Result
+
+| | Pre-fix baseline (PR #524) | H7 (post-fix) | Δ |
+|---|---|---|---|
+| Legacy peak RSS | 1,871,240 KB | 1,869,236 KB | -2,004 KB (noise) |
+| Tiered peak RSS | 3,652,852 KB | **3,747,576 KB** | **+94,724 KB (+2.6%, slight regression in noise)** |
+| Tiered/Legacy ratio | 1.95× | 2.00× | unchanged |
+
+**Total Tiered RSS: essentially unchanged.** H7 disproved at the top level.
+
+## Per-phase report
+
+```
+| Phase            | Pre-fix Tiered RSS kB | H7 Tiered RSS kB | Δ      |
+|------------------|-----------------------|------------------|--------|
+| Promote_metadata |               666,980 |          538,140 | -128,840 (-19%) |
+| Promote_full     |             3,562,324 |        3,636,032 | +73,708 (+2%)   |
+| Fill             |             3,562,348 |        3,641,240 | +78,892 (noise) |
+| Demote / Teardown|             3,562,348 |        3,641,244 | (carried)       |
+```
+
+**The streaming fix worked where I expected:**
+- `Promote_metadata` dropped 130 MB (-19%). This phase calls `Csv_storage.get` for the metadata-only path; streaming reduces per-call peak.
+
+**But it didn't help where I expected:**
+- `Promote_full` still climbs to ~3.6 GB. The streaming fix made no visible difference here.
+
+## Why H7 didn't move the Promote_full needle
+
+Promote_full does more than just call `Csv_storage.get`. After loading bars, it:
+1. Builds a `Full.t = { bars; summary; metadata }` per symbol — `bars` is `tail_days` long (default 1800).
+2. Computes `summary` = `Summary_compute.compute_values` — RS line, 30-week MA, ATR, stage heuristic. Each indicator allocates intermediate weekly aggregations.
+3. Stores in the loader's per-symbol map.
+4. The wrapper's `_promote_universe_to_full` then calls `_seed_from_full` per symbol, which:
+   - Calls `_truncate_bars` — `List.filter` over the loaded bars
+   - Calls `Bar_history.seed` — `existing @ new_bars` allocates a new combined list
+5. For 292 symbols × 312 Friday cycles over the run.
+
+Streaming the CSV READ helped phase 1 a bit (130 MB on Metadata which is just the read), but phases 2-5 are ALSO Tiered-only and allocate substantially. They're downstream of the CSV.
+
+Specifically the smoking-gun callsite from the peak memtrace analysis was `Base.List.filter` (+773 MB Tiered overhead) — that's `_truncate_bars` AND `_in_date_range` filtering AND `Summary_compute`'s indicator iterations, not just Csv_storage.get.
+
+## Hypothesis status
+
+| ID | Status |
+|---|---|
+| H1 (Bar_history trim) | DISPROVED #531 |
+| H2 (Full.t.bars cap) | DISPROVED #542 |
+| H3 (skip_ad_breadth) | DISPROVED #539 |
+| H7 (CSV stream-parse) | DISPROVED at top level; +130 MB on Metadata phase only (this note) |
+
+We've ruled out four hypotheses. The +95% Tiered RSS gap is **not** in:
+- Bar_history's monotonic growth
+- Full.t.bars retention
+- AD-breadth load
+- Csv_storage.get materialization
+
+The actual carrier is **somewhere in the per-symbol Promote_full work AFTER the CSV read**. Candidates remaining:
+- `Summary_compute.compute_values` intermediate state (weekly aggregations × indicators × symbols)
+- `_seed_from_full` → `_truncate_bars` (List.filter on loaded bars)
+- `Bar_history.seed` → `existing @ new_bars` (List.append churn × Friday cycles)
+- Some Bar_loader bookkeeping per symbol (the `t.full_map` Hashtbl plus internal state)
+
+## What now
+
+Three options for next H-test:
+
+1. **H8 — Skip Summary scalar computation in Promote_full.** Add a config field that promotes to Full WITHOUT computing Summary scalars (just bars + metadata). If RSS drops substantially, the indicator computations are the carrier.
+
+2. **H9 — Refactor `Bar_history.seed` to share lists rather than copy.** Currently `existing @ new_bars` allocates a fresh combined list each Friday. Could mutate or use a more efficient deque. ~50 LOC change to bar_history.ml.
+
+3. **H10 — Memtrace-only investigation.** Now that we have memtrace working (PR #538), open the H7-verify .ctf in `memtrace_viewer` (requires `opam install memtrace_viewer` on user's host — not currently available in our docker due to OCaml 5 conflict). The flamegraph would directly show the Promote_full callsite tree.
+
+Recommended order: **H8 first** (cheap to test — config toggle exists pattern). H9 is a code change that needs design care.
+
+## Methodological note
+
+This is the 4th disproved hypothesis. The diagnosis-fix-measure cycle has been productive but the +95% gap is genuinely elusive. Three insights from these disproofs:
+
+1. **Memtrace's "live at peak" attribution by callsite** points correctly (CSV._build_price 2.3× more in Tiered) but the FIX target needs more care — the byte attribution is for ALLOCATION sites, not RETENTION carriers. Just because callsite X allocates 2× more doesn't mean fixing X drops RSS.
+
+2. **OCaml's heap doesn't shrink** — once expanded to peak, RSS stays there. So fixing a churn source mid-run that's NOT at the peak phase doesn't help.
+
+3. **The phase-by-phase RSS view is more diagnostic than total RSS** — H7 dropped 130 MB on Metadata but added 75 MB on Promote_full (probably noise). Total = unchanged. Without per-phase view we'd have called this a complete null.
+
+## Cumulative day's track
+
+- H1 (Bar_history trim) — DISPROVED, fix reverted (#531/#532)
+- H2 (Full.t.bars cap) — DISPROVED (#542)
+- H3 (skip_ad_breadth) — DISPROVED (#539)
+- H7 (CSV stream-parse) — DISPROVED top-level, modest 130 MB win on Metadata phase (this note)
+- 4 hypotheses tested in ~6 hours of measurement loop. Each cycle now ~30 min thanks to the C2 harness + B7 memtrace.
+
+The carrier remains unknown but the bisection has narrowed the search to "what allocates during Promote_full after the CSV read."


### PR DESCRIPTION
## Summary

H7 (CSV stream-parse) verification result: **disproved at top level**. Tiered RSS unchanged (3.65 → 3.75 GB, +2.6% noise).

## Per-phase win is real but small

| Phase | Pre-fix Tiered RSS | H7 Tiered RSS | Δ |
|---|---|---|---|
| Promote_metadata | 666,980 KB | 538,140 KB | **-128,840 (-19%)** |
| Promote_full | 3,562,324 KB | 3,636,032 KB | +73,708 (noise) |

Streaming worked exactly where I expected (Metadata phase reads CSVs and the streaming reduces churn). But Promote_full is dominated by what happens AFTER the CSV read — Summary scalar computation + `_seed_from_full` + `Bar_history.seed` — none of which H7 addresses.

## Status: 4 hypotheses ruled out

| ID | Status |
|---|---|
| H1 Bar_history trim | DISPROVED #531 |
| H2 Full.t.bars cap | DISPROVED #542 |
| H3 skip_ad_breadth | DISPROVED #539 |
| H7 CSV stream-parse | DISPROVED top, +130 MB Metadata win (this) |

## Next test candidates

1. **H8** — Skip Summary scalar computation in Promote_full. New config field `skip_summary_compute`. ~30 LOC.
2. **H9** — Refactor `Bar_history.seed` to share lists rather than `existing @ new_bars`.
3. **H10** — Open the H7-verify .ctf in `memtrace_viewer` (requires `opam install memtrace_viewer` on host; OCaml 5 conflict in our docker).

Recommended: H8 first (cheap, follows the C1 override pattern).

## Methodological notes

- Memtrace per-callsite attribution shows where ALLOCATIONS happen. Doesn't directly show what's RETAINED — those can differ.
- OCaml's heap doesn't shrink once expanded to peak. Fixing a churn source mid-run that's NOT at the peak phase doesn't move RSS.
- Per-phase RSS view caught the partial win that total-RSS would have missed.

## Test plan

- [x] `trading/devtools/checks/status_file_integrity.sh` passes.
- [x] No code touched; doc-only addition.