### PR TITLE
perf(weinstein): single-pass refactor of List.filter hot paths

### DIFF
--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -194,10 +194,17 @@ let _stage_short_signal ~w ~(a : Stock_analysis.t) =
   | _ -> []
 
 (** Reduce a list of (points, label) signals to (total_score, rationale list).
-    Zero-point entries are dropped from both the total and the rationale. *)
+    Zero-point entries are dropped from both the total and the rationale. Was:
+    List.filter materialised a [non_zero] intermediate, then List.sum walked it
+    once for points and List.map walked it again for labels — three list
+    traversals and two intermediate lists per call. Now: a single
+    List.fold_right accumulates both the total score and the rationale list in
+    one pass with no intermediate. fold_right preserves the original signal
+    order in the rationale, matching the prior List.map behaviour. Called twice
+    per scored candidate (long + short). *)
 let _tally signals =
-  let non_zero = List.filter signals ~f:(fun (pts, _) -> pts <> 0) in
-  (List.sum (module Int) non_zero ~f:fst, List.map non_zero ~f:snd)
+  List.fold_right signals ~init:(0, []) ~f:(fun (pts, label) (sum, labels) ->
+      if pts = 0 then (sum, labels) else (sum + pts, label :: labels))
 
 (* ------------------------------------------------------------------ *)
 (* Scoring                                                              *)
@@ -431,12 +438,14 @@ let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
   let buys_active =
     match macro_trend with Bullish | Neutral -> true | Bearish -> false
   in
+  (* Was: chained filter |> map allocated two lists (one for the held-set
+     filter, one for the (analysis, sector) pairs). Now: single-pass
+     filter_map keeps only one output list. Runs every Friday over the full
+     screened universe (potentially thousands of symbols). *)
   let candidates =
-    stocks
-    |> List.filter ~f:(fun (a : Stock_analysis.t) ->
-        not (Set.mem held_set a.ticker))
-    |> List.map ~f:(fun (a : Stock_analysis.t) ->
-        (a, _resolve_sector ~sector_map a.ticker))
+    List.filter_map stocks ~f:(fun (a : Stock_analysis.t) ->
+        if Set.mem held_set a.ticker then None
+        else Some (a, _resolve_sector ~sector_map a.ticker))
   in
   let buy_candidates =
     _evaluate_longs ~weights ~thresholds:grade_thresholds

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
@@ -58,6 +58,30 @@ let _find_peak_volume_idx ~lookback (bars : Daily_price.t list) : int option =
     in
     Some (start + max_vol_idx)
 
+(** Tail-recursive scan returning the max [high_price] across the slice
+    [\[base_start, base_end\)] of [bars]. Returns [None] when the slice is empty
+    (no bars fall in the index range).
+
+    Was: List.sub allocated a [base_bars] sub-list, then List.map allocated a
+    fresh float list of [high_price]s, then List.max_elt walked it — three
+    traversals and two intermediate lists per call. Now: one walk, no
+    intermediate. Runs once per universe symbol per Friday screen. *)
+let _scan_max_high (bars : Daily_price.t list) ~base_start ~base_end :
+    float option =
+  let rec loop i best = function
+    | [] -> best
+    | _ when i >= base_end -> best
+    | _ :: rest when i < base_start -> loop (i + 1) best rest
+    | (b : Daily_price.t) :: rest ->
+        let best' =
+          match best with
+          | None -> Some b.high_price
+          | Some best -> Some (Float.max best b.high_price)
+        in
+        loop (i + 1) best' rest
+  in
+  loop 0 None bars
+
 (** Estimate the breakout price: highest high in the prior base region.
 
     The base region is [base_lookback_weeks] bars back, excluding the most
@@ -69,12 +93,7 @@ let _estimate_breakout_price ~base_lookback_weeks ~base_end_offset_weeks
   let base_start = max 0 (n - base_lookback_weeks) in
   let base_end = max 0 (n - base_end_offset_weeks) in
   if base_end <= base_start then None
-  else
-    let base_bars =
-      List.sub bars ~pos:base_start ~len:(base_end - base_start)
-    in
-    List.map base_bars ~f:(fun b -> b.Daily_price.high_price)
-    |> List.max_elt ~compare:Float.compare
+  else _scan_max_high bars ~base_start ~base_end
 
 let analyze ~(config : config) ~ticker ~bars ~benchmark_bars ~prior_stage
     ~as_of_date : t =

--- a/trading/trading/weinstein/stops/lib/support_floor.ml
+++ b/trading/trading/weinstein/stops/lib/support_floor.ml
@@ -1,21 +1,37 @@
 open Core
 open Trading_base.Types
 
-(* Bars eligible for the window: those dated on or before [as_of]. *)
-let _eligible ~bars ~as_of =
-  List.filter bars ~f:(fun (b : Types.Daily_price.t) ->
-      Date.( <= ) b.date as_of)
+(* Single-pass collector: walks [bars] once accumulating eligible bars
+   (date <= as_of) into a reversed list and counting them. The reversed
+   layout means the trailing [lookback_bars] of the original chronological
+   sequence is the [List.take lookback_bars] prefix of the reversed list. *)
+let _collect_eligible_rev ~bars ~as_of =
+  List.fold bars ~init:([], 0) ~f:(fun (acc, n) (b : Types.Daily_price.t) ->
+      if Date.( <= ) b.date as_of then (b :: acc, n + 1) else (acc, n))
 
-(* Trailing [lookback_bars] of [eligible]. Assumes chronological order. *)
-let _trim_to_lookback eligible lookback_bars =
-  let n = List.length eligible in
-  if n <= lookback_bars then eligible else List.drop eligible (n - lookback_bars)
+(* Trim a reversed eligible list (newest first) to the trailing [lookback_bars]
+   and restore chronological order. *)
+let _trim_rev_to_lookback eligible_rev ~n_eligible ~lookback_bars =
+  let truncated =
+    if n_eligible <= lookback_bars then eligible_rev
+    else List.take eligible_rev lookback_bars
+  in
+  List.rev truncated
 
 (* Bars in the window dated on or before [as_of], trimmed to the trailing
-   [lookback_bars]. Assumes [bars] is chronological (oldest first). *)
+   [lookback_bars]. Assumes [bars] is chronological (oldest first).
+
+   Was: List.filter allocated an [eligible] intermediate, then List.length
+   measured it (O(n) spine walk), then List.drop allocated a suffix copy —
+   three list traversals and two intermediate lists per call. Now: a single
+   fold accumulates eligible bars (reversed) with a count, then we either
+   reverse-the-whole-thing or take-then-reverse the trailing window. One
+   call per held position per stop adjustment day. *)
 let _window ~bars ~as_of ~lookback_bars =
   if lookback_bars <= 0 then []
-  else _trim_to_lookback (_eligible ~bars ~as_of) lookback_bars
+  else
+    let eligible_rev, n_eligible = _collect_eligible_rev ~bars ~as_of in
+    _trim_rev_to_lookback eligible_rev ~n_eligible ~lookback_bars
 
 (* Anchor extreme for the given side:
    Long  → highest [high_price] (the peak from which price fell).

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -163,25 +163,45 @@ let held_symbols (portfolio : Portfolio_view.t) =
       | Entering _ | Holding _ | Exiting _ -> Some p.symbol
       | Closed _ -> None)
 
+(** Try to convert a single screener candidate to a kept transition. Returns
+    [None] when the ticker is already held, when sizing rejects it, or when cash
+    is insufficient. *)
+let _candidate_to_transition ~held_set ~make_entry ~remaining_cash
+    (c : Screener.scored_candidate) =
+  if Set.mem held_set c.ticker then None
+  else Option.bind (make_entry c) ~f:(_check_cash_and_deduct remaining_cash)
+
 (** Generate CreateEntering transitions for screener candidates. Tracks
     remaining cash to avoid generating orders that exceed funds.
 
     Public (see .mli) so callers running custom screening out-of-band can feed
-    candidates through the same entry pipeline the strategy uses. *)
+    candidates through the same entry pipeline the strategy uses.
+
+    Was: chained [List.filter |> List.filter_map |> List.filter_map] over
+    [candidates] — three list traversals each allocating a fresh intermediate
+    list. Now: one [List.fold] walks [candidates] once, calls
+    [_candidate_to_transition] per element, and accumulates a single reversed
+    output list. The cash-deduction side effect on [remaining_cash] runs in the
+    same order it did before — every successful entry decrements
+    [remaining_cash] before the next candidate is considered — so we preserve
+    the "first-come keeps cash" tie-break. Per the perf followup notes under
+    dev/notes/: List.filter was the top allocator on the strategy hot path. *)
 let entries_from_candidates ~config ~candidates ~stop_states ~bar_history
     ~(portfolio : Portfolio_view.t) ~get_price ~current_date =
-  let held = held_symbols portfolio in
+  let held_set = String.Set.of_list (held_symbols portfolio) in
   let portfolio_value = Portfolio_view.portfolio_value portfolio ~get_price in
   let remaining_cash = ref portfolio.cash in
   let make_entry =
     _make_entry_transition ~config ~stop_states ~bar_history ~portfolio_value
       ~current_date
   in
-  candidates
-  |> List.filter ~f:(fun (c : Screener.scored_candidate) ->
-      not (List.mem held c.ticker ~equal:String.equal))
-  |> List.filter_map ~f:make_entry
-  |> List.filter_map ~f:(_check_cash_and_deduct remaining_cash)
+  List.fold candidates ~init:[] ~f:(fun acc c ->
+      match
+        _candidate_to_transition ~held_set ~make_entry ~remaining_cash c
+      with
+      | None -> acc
+      | Some kept -> kept :: acc)
+  |> List.rev
 
 (** Screen the universe for both long and short candidates, returning a combined
     transition list. Macro-trend gating lives in the screener itself:


### PR DESCRIPTION
## Summary

Empirical memtrace investigation showed `Base.List.filter` as the #1 allocator in BOTH Legacy (~46% of 1.87 GB peak = 676 MB) and Tiered (~40% of 3.65 GB peak ≈ 1.4 GB) strategies. Five hypothesis tests recently disproved memory-side fixes (Bar_history trim, Full.t.bars cap, AD-breadth skip, CSV stream-parse, GC tuning). The +95% Tiered RSS gap and Legacy's own 1.87 GB are both dominated by the strategy's per-step allocation pattern: \`filter -> map -> sort -> take\` pipelines on bar/candidate/indicator lists, each step holding an intermediate until the next consumes it.

This PR replaces five hot-path chained filters with single-pass accumulators (folds, \`filter_map\`, tail-recursive walks). Each refactor preserves bit-identical strategy output — the parity test \`test_tiered_loader_parity\` remains green.

### Hotspots refactored (all on the strategy hot path, capped at 5 per the task spec)

| # | File | Function | LOC delta | Was | Now |
|---|------|----------|-----------|-----|-----|
| 1 | \`weinstein_strategy.ml\` | \`entries_from_candidates\` | +20 / -7 | \`filter \|> filter_map \|> filter_map\` (3 traversals, 3 lists) | one \`List.fold\` calling extracted \`_candidate_to_transition\` helper |
| 2 | \`screener.ml\` | \`screen\` (stocks → candidates) | +5 / -5 | \`stocks \|> filter \|> map\` (2 lists) | one \`List.filter_map\` |
| 3 | \`screener.ml\` | \`_tally\` | +9 / -3 | \`List.filter\` to materialise \`non_zero\`, then \`List.sum\` + \`List.map\` walked it twice (3 traversals, 2 lists) | single \`List.fold_right\` returning \`(sum, labels)\` in one pass |
| 4 | \`support_floor.ml\` | \`_window\` | +21 / -8 | \`List.filter\` eligible → \`List.length\` → \`List.drop\` (3 traversals, 2 lists) | one \`List.fold\` collects reversed eligible + count, then \`List.take\` + \`List.rev\` of trailing window |
| 5 | \`stock_analysis.ml\` | \`_estimate_breakout_price\` | +24 / -7 | \`List.sub\` base_bars → \`List.map\` high_prices → \`List.max_elt\` (3 traversals, 2 lists) | extracted \`_scan_max_high\` tail-recursive walk over \`[base_start, base_end)\` slice with no intermediate |

Total: 4 files, +95 / -31 lines.

### Parity preservation

- **\`test_tiered_loader_parity\` PASS** — Legacy and Tiered runs match exactly on \`n_round_trips\`, \`final_portfolio_value\`, and sampled \`steps[].portfolio_value\`. This is the merge gate per the parity contract on the tiered-loader track.
- Iteration order is preserved on every refactored hot path:
  - \`entries_from_candidates\`: candidates walked in original order; cash-deduction side effect on \`remaining_cash\` runs in the same order it did before, so the \"first-come keeps cash\" tie-break is preserved.
  - \`screener.screen\`: \`List.filter_map\` preserves order vs the \`filter |> map\` chain.
  - \`_tally\`: \`List.fold_right\` preserves the original signal order in the rationale, matching prior \`List.map\` behaviour.
  - \`_window\`: trailing-\`lookback_bars\` slice yields exactly the same bars in chronological order.
  - \`_scan_max_high\`: visits the same \`[base_start, base_end)\` slice; \`Float.max\` is associative so accumulator order doesnt change the output.

### Test plan

- [x] \`dune build\`: clean (no warnings)
- [x] \`dune runtest\`: 121 OK suites, 0 FAILED. Pre-existing path-resolution issues in \`test_runner_hypothesis_overrides.ml\` (looking for \`/workspaces/trading-1/data/...\`) and a \`csv_storage.ml\` nesting-linter violation are not introduced here.
- [x] \`dune runtest trading/backtest/test/test_tiered_loader_parity.exe\`: 3/3 OK in 4.19s
- [x] \`dune build @fmt\`: clean (verified via direct \`ocamlformat --check\` on all 4 changed files; no diff)
- [x] Magic-number linter: no new violations (pre-existing \`tiered_runner.ml\` violations remain)
- [x] Nesting linter: no new violations (added two helpers \`_candidate_to_transition\` and \`_trim_rev_to_lookback\` to keep depth under limits)
- [x] \`git diff --stat\` against main: only the 4 expected files

### Memory smoke measurement

Not included here — agent budget didnt permit running \`dev/scripts/run_perf_hypothesis.sh\` end-to-end on top of the parity-test runs and the rebuild churn from comment/format fixes. The lead session can run a smoke A/B post-merge against the baseline (Legacy 1,871,240 / Tiered 3,652,852). Even a 30% cut to the \`List.filter\` share would drop Legacy to ~1.66 GB and Tiered to ~3.2 GB.

### Out of scope / not touched

Per the task spec, tier-promotion code paths (\`tiered_strategy_wrapper.ml\`, \`tiered_runner.ml\`, \`bar_loader.ml\`) are untouched — they have load-bearing mutation invariants from the recent #519/#525/#530 work. \`bar_history.ml\` is also untouched (intentional mutation invariants on the strategy side; \`Hashtbl\` ops dominate, not \`List.filter\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)