### PR TITLE
feat(data-panels): PR-F — reshape Macro.analyze with callbacks

### DIFF
--- a/dev/status/data-panels.md
+++ b/dev/status/data-panels.md
@@ -1,11 +1,11 @@
 # Status: data-panels
 
-## Last updated: 2026-04-25 (PR-E pushed)
+## Last updated: 2026-04-25
 
 ## Status
 READY_FOR_REVIEW
 
-Stage 0 MERGED as #555. Stage 1 MERGED as #557. Stage 2 foundation (Bar_panels reader + adjusted_close panel) MERGED as #558. Stage 2 PR-B (Stage.classify reshape) MERGED as #559. Stage 2 PR-C (Rs.analyze reshape) MERGED as #560. Stage 2 PR-D (Stock_analysis.analyze reshape) MERGED as #561. Stage 2 PR-E (Sector.analyze reshape) on `feat/panels-stage02-pr-e-sector-analyze` READY_FOR_REVIEW as PR #562: adds `analyze_with_callbacks ~callbacks` plus `Sector.callbacks` bundle wrapping `Stage.callbacks` + `Rs.callbacks`; the wrapper `analyze ~sector_bars ~benchmark_bars` builds the bundle via `callbacks_from_bars` and delegates. Sector itself reads no bar fields — it's a thin combinator over Stage.classify_with_callbacks and Rs.analyze_with_callbacks. 4 new parity tests cover high-confidence Stage2 + strong RS, low-confidence Stage4, mixed-stage constituents, and insufficient bars; each runs both entry points over the same input and asserts bit-identical `Sector.result` records via composed matchers. Net diff: 4 files, 257+/11-.
+Stage 0 MERGED as #555. Stage 1 MERGED as #557. Stage 2 foundation MERGED as #558. Stage 2 PR-B (Stage.classify reshape) MERGED as #559. Stage 2 PR-C (Rs.analyze reshape) MERGED as #560. Stage 2 PR-D (Stock_analysis.analyze reshape) MERGED as #561. Stage 2 PR-E (Sector.analyze reshape) MERGED as #562. Stage 2 PR-F (Macro.analyze reshape) on `feat/panels-stage02-pr-f-macro-analyze` READY_FOR_REVIEW: adds `Macro.analyze_with_callbacks ~callbacks ~prior_stage ~prior` plus `Macro.callbacks` bundle that threads `Stage.callbacks` for the primary index, `(string * Stage.callbacks) list` for global indices, and three offset-indexed callbacks (`get_index_close`, `get_cumulative_ad`, `get_ad_momentum_ma`). Bar-list `Macro.analyze` is now a wrapper that pre-computes the cumulative A-D float array and the momentum MA scalar via `callbacks_from_bars` and delegates. Module split: `macro.ml` (orchestrator + bar-list wrapper plumbing, 187 lines) + new `macro_indicators.ml` (per-indicator helpers, 277 lines), keeping each file under the 300-line limit. 5 new parity tests cover bullish (Stage2 + positive A-D divergence), bearish (Stage4 + negative A-D), neutral-flat-no-AD, insufficient bars, and partial-global-indices (mixed regimes); each asserts bit-identical `Macro.result` via composed matchers (Stage float fields, indicator-by-indicator readings, structural equal_to over rationale / trend / confidence). Net diff: 7 files, 696+/221-.
 
 ## Interface stable
 NO

--- a/trading/analysis/weinstein/macro/lib/macro.ml
+++ b/trading/analysis/weinstein/macro/lib/macro.ml
@@ -4,7 +4,7 @@ open Weinstein_types
 include Macro_types
 
 (* ------------------------------------------------------------------ *)
-(* Internal helpers                                                     *)
+(* Internal helpers — confidence + trend                                *)
 (* ------------------------------------------------------------------ *)
 
 (** Compute composite confidence from weighted indicator readings.
@@ -35,241 +35,153 @@ let _classify_trend ~bullish_threshold ~bearish_threshold confidence :
   else if Float.(confidence < bearish_threshold) then Bearish
   else Neutral
 
-let _stage1_detail transition =
-  match transition with
-  | Some (Stage4 _, _) -> (`Neutral, "Index entering Stage 1 base after Stage 4")
-  | _ -> (`Neutral, "Index in Stage 1 base")
-
-let _stage3_detail transition =
-  match transition with
-  | Some (Stage2 _, Stage3 _) ->
-      (`Bearish, "Index entering Stage 3 top — caution")
-  | _ -> (`Bearish, "Index in Stage 3 top")
-
-(** Analyze index stage signal. *)
-let _index_stage_signal ~weight (stage_result : Stage.result) :
-    indicator_reading =
-  let signal, detail =
-    match stage_result.stage with
-    | Stage2 { late = false; _ } -> (`Bullish, "Index in Stage 2 (advancing)")
-    | Stage2 { late = true; _ } ->
-        (`Neutral, "Index in late Stage 2 (decelerating)")
-    | Stage1 _ -> _stage1_detail stage_result.transition
-    | Stage4 _ -> (`Bearish, "Index in Stage 4 (declining)")
-    | Stage3 _ -> _stage3_detail stage_result.transition
-  in
-  { name = "Index Stage"; signal; weight; detail }
-
-(** Build cumulative A-D line from daily advance/decline bars. *)
-let _build_cum_ad ad_bars =
-  List.fold ad_bars ~init:[] ~f:(fun acc bar ->
-      let net = bar.advancing - bar.declining in
-      let prev = Option.value (List.hd acc) ~default:0 in
-      (prev + net) :: acc)
-  |> List.rev
-
-(** Compute A-D divergence signal given a pre-built cumulative A-D list. *)
-let _ad_divergence_signal ~ad_min_bars ~ad_line_lookback ~cum_ad
-    ~(index_bars : Daily_price.t list) =
-  let n_ad = List.length cum_ad in
-  let n_idx = List.length index_bars in
-  let lookback = min ad_line_lookback (min n_ad n_idx) in
-  if lookback < ad_min_bars then (`Neutral, "Insufficient A-D data")
-  else
-    let ad_recent = List.last_exn cum_ad in
-    let ad_prior = List.nth_exn cum_ad (n_ad - lookback) in
-    let idx_recent = (List.last_exn index_bars).Daily_price.adjusted_close in
-    let idx_prior =
-      (List.nth_exn index_bars (n_idx - lookback)).Daily_price.adjusted_close
-    in
-    let ad_rising = ad_recent > ad_prior in
-    let idx_rising = Float.(idx_recent > idx_prior) in
-    match (idx_rising, ad_rising) with
-    | true, true -> (`Bullish, "A-D line confirming index advance")
-    | false, false -> (`Bearish, "A-D line confirming index decline")
-    | true, false ->
-        (`Bearish, "A-D line diverging bearishly (index up, A-D down)")
-    | false, true ->
-        (`Bullish, "A-D line diverging bullishly (index down, A-D up)")
-
-(** Compute A-D cumulative line and detect divergence vs index. *)
-let _ad_line_signal ~weight ~ad_min_bars ~ad_line_lookback ~ad_bars
-    ~(index_bars : Daily_price.t list) : indicator_reading =
-  if List.is_empty ad_bars || List.is_empty index_bars then
-    { name = "A-D Line"; signal = `Neutral; weight; detail = "No A-D data" }
-  else
-    let cum_ad = _build_cum_ad ad_bars in
-    let signal, detail =
-      _ad_divergence_signal ~ad_min_bars ~ad_line_lookback ~cum_ad ~index_bars
-    in
-    { name = "A-D Line"; signal; weight; detail }
-
-(** Compute simple moving average of the A-D net series. *)
-let _compute_momentum_ma ~momentum_period ~ad_bars =
-  let nets = List.map ad_bars ~f:(fun b -> b.advancing - b.declining) in
-  let period = min momentum_period (List.length nets) in
-  let recent_nets =
-    List.rev nets |> (fun l -> List.sub l ~pos:0 ~len:period) |> List.rev
-  in
-  let sum = List.sum (module Int) recent_nets ~f:Fn.id in
-  Float.of_int sum /. Float.of_int period
-
-(** Signal zero-line crossing of the A-D momentum MA. *)
-let _momentum_index_signal ~weight ~momentum_period ~ad_bars : indicator_reading
-    =
-  if List.is_empty ad_bars then
-    {
-      name = "Momentum Index";
-      signal = `Neutral;
-      weight;
-      detail = "No A-D data";
-    }
-  else
-    let ma = _compute_momentum_ma ~momentum_period ~ad_bars in
-    let signal, detail =
-      if Float.(ma > 0.0) then
-        (`Bullish, Printf.sprintf "Momentum index positive (%.1f)" ma)
-      else (`Bearish, Printf.sprintf "Momentum index negative (%.1f)" ma)
-    in
-    { name = "Momentum Index"; signal; weight; detail }
-
-(** Compute NH-NL proxy signal from index price trend. *)
-let _nh_nl_trend_signal ~nh_nl_lookback ~nh_nl_up_threshold
-    ~nh_nl_down_threshold ~(index_bars : Daily_price.t list) =
-  let n = List.length index_bars in
-  let lookback = min nh_nl_lookback (n - 1) in
-  let recent = (List.last_exn index_bars).Daily_price.adjusted_close in
-  let prior =
-    (List.nth_exn index_bars (n - 1 - lookback)).Daily_price.adjusted_close
-  in
-  if Float.(recent > prior *. nh_nl_up_threshold) then
-    (`Bullish, "Index trending higher over 3 months (NH-NL proxy positive)")
-  else if Float.(recent < prior *. nh_nl_down_threshold) then
-    (`Bearish, "Index trending lower over 3 months (NH-NL proxy negative)")
-  else (`Neutral, "Index flat over 3 months (NH-NL proxy neutral)")
-
-(** Check NH-NL indicator: ratio of new highs to (new highs + new lows). *)
-let _nh_nl_signal ~weight ~nh_nl_min_bars ~nh_nl_lookback ~nh_nl_up_threshold
-    ~nh_nl_down_threshold ~(index_bars : Daily_price.t list) : indicator_reading
-    =
-  (* We don't have NH-NL data directly; approximate using index MA slope as proxy *)
-  if List.length index_bars < nh_nl_min_bars then
-    { name = "NH-NL"; signal = `Neutral; weight; detail = "Insufficient data" }
-  else
-    let signal, detail =
-      _nh_nl_trend_signal ~nh_nl_lookback ~nh_nl_up_threshold
-        ~nh_nl_down_threshold ~index_bars
-    in
-    { name = "NH-NL"; signal; weight; detail }
-
-(** Classify each global index and compute the consensus signal. *)
-let _global_consensus_signal ~stage_config ~global_consensus_threshold
-    ~global_index_bars =
-  let classify_index bars =
-    let result = Stage.classify ~config:stage_config ~bars ~prior_stage:None in
-    match result.stage with
-    | Stage2 _ -> `Bullish
-    | Stage4 _ -> `Bearish
-    | _ -> `Neutral
-  in
-  let signals =
-    List.map global_index_bars ~f:(fun (_, bars) -> classify_index bars)
-  in
-  let bullish_count =
-    List.count signals ~f:(fun s ->
-        match s with `Bullish -> true | _ -> false)
-  in
-  let bearish_count =
-    List.count signals ~f:(fun s ->
-        match s with `Bearish -> true | _ -> false)
-  in
-  let total = List.length signals in
-  let bullish_frac = Float.of_int bullish_count /. Float.of_int total in
-  let bearish_frac = Float.of_int bearish_count /. Float.of_int total in
-  if Float.(bullish_frac > global_consensus_threshold) then
-    ( `Bullish,
-      Printf.sprintf "Global consensus bullish (%d/%d markets Stage2)"
-        bullish_count total )
-  else if Float.(bearish_frac > global_consensus_threshold) then
-    ( `Bearish,
-      Printf.sprintf "Global consensus bearish (%d/%d markets Stage4)"
-        bearish_count total )
-  else
-    ( `Neutral,
-      Printf.sprintf "Global markets mixed (%d bullish, %d bearish)"
-        bullish_count bearish_count )
-
-(** Check global index consensus: majority of world indices in bullish stages.
-*)
-let _global_signal ~weight ~stage_config ~global_consensus_threshold
-    ~(global_index_bars : (string * Daily_price.t list) list) :
-    indicator_reading =
-  if List.is_empty global_index_bars then
-    {
-      name = "Global Markets";
-      signal = `Neutral;
-      weight;
-      detail = "No global data";
-    }
-  else
-    let signal, detail =
-      _global_consensus_signal ~stage_config ~global_consensus_threshold
-        ~global_index_bars
-    in
-    { name = "Global Markets"; signal; weight; detail }
-
-(* ------------------------------------------------------------------ *)
-(* Main function                                                        *)
-(* ------------------------------------------------------------------ *)
-
-let _build_indicators ~config ~index_stage ~ad_bars ~index_bars
-    ~global_index_bars =
-  let { stage_config; indicator_weights = iw; indicator_thresholds = it; _ } =
-    config
-  in
-  [
-    _index_stage_signal ~weight:iw.w_index_stage index_stage;
-    _ad_line_signal ~weight:iw.w_ad_line ~ad_min_bars:it.ad_min_bars
-      ~ad_line_lookback:it.ad_line_lookback ~ad_bars ~index_bars;
-    _momentum_index_signal ~weight:iw.w_momentum_index
-      ~momentum_period:it.momentum_period ~ad_bars;
-    _nh_nl_signal ~weight:iw.w_nh_nl ~nh_nl_min_bars:it.nh_nl_min_bars
-      ~nh_nl_lookback:it.nh_nl_lookback
-      ~nh_nl_up_threshold:it.nh_nl_up_threshold
-      ~nh_nl_down_threshold:it.nh_nl_down_threshold ~index_bars;
-    _global_signal ~weight:iw.w_global ~stage_config
-      ~global_consensus_threshold:it.global_consensus_threshold
-      ~global_index_bars;
-  ]
-
-let analyze ~config ~index_bars ~ad_bars ~global_index_bars ~prior_stage ~prior
-    : result =
-  let { stage_config; bullish_threshold; bearish_threshold; _ } = config in
-  let index_stage =
-    Stage.classify ~config:stage_config ~bars:index_bars ~prior_stage
-  in
-  let indicators =
-    _build_indicators ~config ~index_stage ~ad_bars ~index_bars
-      ~global_index_bars
-  in
-  let confidence = _compute_confidence indicators in
-  let trend =
-    _classify_trend ~bullish_threshold ~bearish_threshold confidence
-  in
-  let regime_changed =
-    match prior with
-    | None -> false
-    | Some p -> not (equal_market_trend trend p.trend)
-  in
-  let rationale =
+(** Build the rationale list from indicator readings and regime-change flag. *)
+let _build_rationale ~indicators ~regime_changed ~trend : string list =
+  let per_indicator =
     List.filter_map indicators ~f:(fun r ->
         match r.signal with
         | `Neutral -> None
         | `Bullish -> Some (Printf.sprintf "[Bullish] %s: %s" r.name r.detail)
         | `Bearish -> Some (Printf.sprintf "[Bearish] %s: %s" r.name r.detail))
-    @
+  in
+  let regime_line =
     if regime_changed then
       [ Printf.sprintf "Regime change: %s" (show_market_trend trend) ]
     else []
   in
+  per_indicator @ regime_line
+
+(** Detect whether [trend] differs from the prior result's trend. *)
+let _regime_changed_of ~trend ~prior =
+  match prior with
+  | None -> false
+  | Some p -> not (equal_market_trend trend p.trend)
+
+(* ------------------------------------------------------------------ *)
+(* Main function — callback shape                                       *)
+(* ------------------------------------------------------------------ *)
+
+let analyze_with_callbacks ~config ~(callbacks : callbacks) ~prior_stage ~prior
+    : result =
+  let { stage_config; bullish_threshold; bearish_threshold; _ } = config in
+  let index_stage =
+    Stage.classify_with_callbacks ~config:stage_config
+      ~get_ma:callbacks.index_stage.get_ma
+      ~get_close:callbacks.index_stage.get_close ~prior_stage
+  in
+  let indicators =
+    Macro_indicators.build_indicators_from_callbacks ~config ~index_stage
+      ~callbacks
+  in
+  let confidence = _compute_confidence indicators in
+  let trend =
+    _classify_trend ~bullish_threshold ~bearish_threshold confidence
+  in
+  let regime_changed = _regime_changed_of ~trend ~prior in
+  let rationale = _build_rationale ~indicators ~regime_changed ~trend in
   { index_stage; indicators; trend; confidence; regime_changed; rationale }
+
+(* ------------------------------------------------------------------ *)
+(* Bar-list wrapper — preserves the existing API                        *)
+(*                                                                      *)
+(* The wrapper precomputes the cumulative A-D float array and the       *)
+(* momentum-MA scalar once, then builds index closures for the          *)
+(* primary-index closes, the global-index Stage callbacks, and the      *)
+(* nested {!Stage.callbacks} for the primary index. Behaviour is        *)
+(* bit-identical to the bar-list path: the same MA, cumulative A-D,     *)
+(* momentum scalar, and index closes feed every signal.                 *)
+(* ------------------------------------------------------------------ *)
+
+(** Build the cumulative A-D float array from a list of A-D bars (oldest first).
+    Index [i] holds the running sum of [advancing - declining] over bars [0..i].
+    The float conversion happens at the boundary so the callback's contract
+    returns floats while the underlying arithmetic is integer (matching the
+    bar-list path's [int] fold). *)
+let _build_cumulative_ad_array (ad_bars : ad_bar list) : float array =
+  let _, rev_acc =
+    List.fold ad_bars ~init:(0, []) ~f:(fun (running, acc) bar ->
+        let running = running + bar.advancing - bar.declining in
+        (running, running :: acc))
+  in
+  rev_acc |> List.rev |> Array.of_list |> Array.map ~f:Float.of_int
+
+(** Compute the A-D momentum MA scalar from a list of A-D bars. Returns the
+    simple mean of the most recent [min momentum_period n] net values. Matches
+    the bar-list [_compute_momentum_ma] expression form: take the last [period]
+    elements, sum them as ints, divide as float. [None] when [ad_bars] is empty.
+*)
+let _compute_momentum_ma_scalar ~momentum_period (ad_bars : ad_bar list) :
+    float option =
+  if List.is_empty ad_bars then None
+  else
+    let nets = List.map ad_bars ~f:(fun b -> b.advancing - b.declining) in
+    let n = List.length nets in
+    let period = min momentum_period n in
+    let recent_nets =
+      List.rev nets |> (fun l -> List.sub l ~pos:0 ~len:period) |> List.rev
+    in
+    let sum = List.sum (module Int) recent_nets ~f:Fn.id in
+    Some (Float.of_int sum /. Float.of_int period)
+
+(** Build a [week_offset]-indexed float lookup over a chronologically-ordered
+    [float array]. [week_offset:0] returns the newest entry; offsets past the
+    array's depth return [None]. *)
+let _make_get_from_float_array (arr : float array) :
+    week_offset:int -> float option =
+  let n = Array.length arr in
+  fun ~week_offset ->
+    let idx = n - 1 - week_offset in
+    if idx < 0 || idx >= n then None else Some arr.(idx)
+
+(** Build [get_index_close] over [Daily_price.t array]. *)
+let _make_get_index_close_from_bars (bars : Daily_price.t array) :
+    week_offset:int -> float option =
+  let n = Array.length bars in
+  fun ~week_offset ->
+    let idx = n - 1 - week_offset in
+    if idx < 0 || idx >= n then None
+    else Some bars.(idx).Daily_price.adjusted_close
+
+(** Build the [get_ad_momentum_ma] closure: the precomputed scalar at offset 0,
+    [None] for any other offset (callers only read offset 0). *)
+let _make_get_ad_momentum_ma (ma : float option) :
+    week_offset:int -> float option =
+ fun ~week_offset -> if week_offset = 0 then ma else None
+
+(** Build per-global-index Stage callbacks from a list of [(name, bars)] pairs.
+*)
+let _global_index_callbacks ~stage_config
+    (global_index_bars : (string * Daily_price.t list) list) :
+    (string * Stage.callbacks) list =
+  List.map global_index_bars ~f:(fun (name, bars) ->
+      (name, Stage.callbacks_from_bars ~config:stage_config ~bars))
+
+let callbacks_from_bars ~(config : config) ~(index_bars : Daily_price.t list)
+    ~(ad_bars : ad_bar list)
+    ~(global_index_bars : (string * Daily_price.t list) list) : callbacks =
+  let index_stage =
+    Stage.callbacks_from_bars ~config:config.stage_config ~bars:index_bars
+  in
+  let index_arr = Array.of_list index_bars in
+  let cum_ad_arr = _build_cumulative_ad_array ad_bars in
+  let ma_scalar =
+    _compute_momentum_ma_scalar
+      ~momentum_period:config.indicator_thresholds.momentum_period ad_bars
+  in
+  let global_index_stages =
+    _global_index_callbacks ~stage_config:config.stage_config global_index_bars
+  in
+  {
+    index_stage;
+    get_index_close = _make_get_index_close_from_bars index_arr;
+    get_cumulative_ad = _make_get_from_float_array cum_ad_arr;
+    get_ad_momentum_ma = _make_get_ad_momentum_ma ma_scalar;
+    global_index_stages;
+  }
+
+let analyze ~config ~index_bars ~ad_bars ~global_index_bars ~prior_stage ~prior
+    : result =
+  let callbacks =
+    callbacks_from_bars ~config ~index_bars ~ad_bars ~global_index_bars
+  in
+  analyze_with_callbacks ~config ~callbacks ~prior_stage ~prior

--- a/trading/analysis/weinstein/macro/lib/macro.mli
+++ b/trading/analysis/weinstein/macro/lib/macro.mli
@@ -129,4 +129,96 @@ val analyze :
       Prior week's macro result (for regime_changed detection). [None] on first
       call.
 
-    Pure function. *)
+    Pure function.
+
+    Implementation note: this is a thin wrapper over {!analyze_with_callbacks}.
+    It builds a {!callbacks} record via {!callbacks_from_bars} (which
+    precomputes the cumulative A-D line, the momentum-MA scalar, and
+    per-global-index {!Stage.callbacks}) and threads it through. Behaviour is
+    bit-identical to the callback API for the same underlying bar lists. *)
+
+type callbacks = {
+  index_stage : Stage.callbacks;
+      (** Stage callbacks for the primary index. Threaded into
+          {!Stage.classify_with_callbacks} to compute [index_stage]. *)
+  get_index_close : week_offset:int -> float option;
+      (** Primary-index adjusted close at [week_offset] weeks back (offset 0 =
+          current week). Used by the A-D divergence and NH-NL proxy comparisons
+          (which read close at offset 0 and at the lookback offset). [None] = no
+          bar at that offset (warmup or out of range). *)
+  get_cumulative_ad : week_offset:int -> float option;
+      (** Cumulative A-D line value at [week_offset] weeks back. The cumulative
+          series is [sum_{i <= k} (advancing_i - declining_i)] stored as a float
+          for the panel-shaped layout (the bar-list constructor folds the same
+          int sum and converts at the boundary). [None] = no A-D bar at that
+          offset. *)
+  get_ad_momentum_ma : week_offset:int -> float option;
+      (** A-D momentum MA at [week_offset] weeks back. The MA is the simple mean
+          of the most recent [min momentum_period n] A-D net values (advancing −
+          declining) ending at [week_offset]. Only [week_offset:0] is consumed
+          by {!analyze_with_callbacks}; higher offsets are permitted to return
+          [None]. *)
+  global_index_stages : (string * Stage.callbacks) list;
+      (** Per-global-index Stage callbacks, as [(name, callbacks)] pairs. The
+          list shape mirrors [global_index_bars] in the bar-list API:
+          {!analyze_with_callbacks} iterates each entry, classifies its stage
+          via {!Stage.classify_with_callbacks}, and aggregates the consensus
+          signal. May be empty when no global breadth data is available. *)
+}
+(** Bundle of indicator callbacks consumed by {!analyze_with_callbacks}.
+
+    Macro analysis reads:
+    - The primary index Stage (via the nested {!index_stage} callbacks).
+    - Two index-close samples (recent + lookback) for A-D divergence and the
+      NH-NL proxy.
+    - Two cumulative A-D samples (recent + lookback) for the divergence check,
+      plus the depth of the cumulative series (walked by probing
+      {!get_cumulative_ad} until [None]).
+    - The momentum MA scalar at offset 0.
+    - One Stage classification per entry in {!global_index_stages}. *)
+
+val callbacks_from_bars :
+  config:config ->
+  index_bars:Daily_price.t list ->
+  ad_bars:ad_bar list ->
+  global_index_bars:(string * Daily_price.t list) list ->
+  callbacks
+(** [callbacks_from_bars ~config ~index_bars ~ad_bars ~global_index_bars] builds
+    a {!callbacks} record:
+
+    - {!index_stage} delegates to {!Stage.callbacks_from_bars} over
+      [index_bars].
+    - {!get_index_close} reads [index_bars] adjusted_close at the matching
+      offset.
+    - {!get_cumulative_ad} indexes a precomputed cumulative-A-D float array
+      built by folding [ad_bars] once.
+    - {!get_ad_momentum_ma} returns the precomputed scalar MA at offset 0
+      ([None] otherwise, and [None] when [ad_bars] is empty).
+    - {!global_index_stages} pairs each [(name, bars)] in [global_index_bars]
+      with [Stage.callbacks_from_bars ~config:config.stage_config ~bars].
+
+    Used internally by {!analyze}; exposed so that callers (e.g. tests or future
+    panel-backed paths) can build the bundle the same way the wrapper does. *)
+
+val analyze_with_callbacks :
+  config:config ->
+  callbacks:callbacks ->
+  prior_stage:Weinstein_types.stage option ->
+  prior:result option ->
+  result
+(** [analyze_with_callbacks ~config ~callbacks ~prior_stage ~prior] is the
+    indicator-callback shape of {!analyze}. Used by panel-backed callers that
+    read indicator values via the strategy's panel views rather than walking bar
+    lists.
+
+    @param config Same configuration as {!analyze}.
+    @param callbacks
+      Bundle of indicator callbacks. See the {!callbacks} record for the
+      contract on each closure.
+    @param prior_stage Same as {!analyze}.
+    @param prior Same as {!analyze}.
+
+    Pure function: same callback outputs and inputs always produce the same
+    [result]. The wrapper {!analyze} guarantees byte-identical results for any
+    bar-list inputs by constructing callbacks that index the same precomputed
+    series the bar-list path used to walk inline. *)

--- a/trading/analysis/weinstein/macro/lib/macro_indicators.ml
+++ b/trading/analysis/weinstein/macro/lib/macro_indicators.ml
@@ -1,0 +1,276 @@
+open Core
+open Weinstein_types
+open Macro_types
+
+(* ------------------------------------------------------------------ *)
+(* Index stage signal                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let _stage1_detail transition =
+  match transition with
+  | Some (Stage4 _, _) -> (`Neutral, "Index entering Stage 1 base after Stage 4")
+  | _ -> (`Neutral, "Index in Stage 1 base")
+
+let _stage3_detail transition =
+  match transition with
+  | Some (Stage2 _, Stage3 _) ->
+      (`Bearish, "Index entering Stage 3 top — caution")
+  | _ -> (`Bearish, "Index in Stage 3 top")
+
+(** Analyze index stage signal. *)
+let _index_stage_signal ~weight (stage_result : Stage.result) :
+    indicator_reading =
+  let signal, detail =
+    match stage_result.stage with
+    | Stage2 { late = false; _ } -> (`Bullish, "Index in Stage 2 (advancing)")
+    | Stage2 { late = true; _ } ->
+        (`Neutral, "Index in late Stage 2 (decelerating)")
+    | Stage1 _ -> _stage1_detail stage_result.transition
+    | Stage4 _ -> (`Bearish, "Index in Stage 4 (declining)")
+    | Stage3 _ -> _stage3_detail stage_result.transition
+  in
+  { name = "Index Stage"; signal; weight; detail }
+
+(* ------------------------------------------------------------------ *)
+(* Depth probing for callback walks                                     *)
+(*                                                                      *)
+(* The bar-list path computes lookback as                                *)
+(*   [min lookback (min n_ad n_idx)]                                    *)
+(* where [n_ad] / [n_idx] are list lengths. The callback path doesn't   *)
+(* know these lengths upfront, so we probe each callback by walking     *)
+(* offsets [0..max] and counting [Some] returns until the first [None]. *)
+(* The cap [max] is the configured lookback so we never walk further    *)
+(* than necessary.                                                      *)
+(* ------------------------------------------------------------------ *)
+
+(** Count consecutive [Some] returns from [get] starting at [week_offset:0],
+    stopping at the first [None] or after [max] probes. *)
+let _probe_depth ~max ~(get : week_offset:int -> _ option) : int =
+  let rec walk off =
+    if off >= max then off
+    else
+      match get ~week_offset:off with Some _ -> walk (off + 1) | None -> off
+  in
+  walk 0
+
+(* ------------------------------------------------------------------ *)
+(* A-D line signal                                                      *)
+(* ------------------------------------------------------------------ *)
+
+(** Decide A-D divergence given recent + prior cum_ad and index closes. The
+    four-way cross of [(idx_rising, ad_rising)] mirrors the bar-list path. *)
+let _ad_divergence_decision ~ad_recent ~ad_prior ~idx_recent ~idx_prior :
+    [ `Bullish | `Bearish | `Neutral ] * string =
+  let ad_rising = Float.(ad_recent > ad_prior) in
+  let idx_rising = Float.(idx_recent > idx_prior) in
+  match (idx_rising, ad_rising) with
+  | true, true -> (`Bullish, "A-D line confirming index advance")
+  | false, false -> (`Bearish, "A-D line confirming index decline")
+  | true, false ->
+      (`Bearish, "A-D line diverging bearishly (index up, A-D down)")
+  | false, true ->
+      (`Bullish, "A-D line diverging bullishly (index down, A-D up)")
+
+(** Compute A-D divergence signal given the precomputed cumulative-A-D callback
+    and the primary-index close callback. Walks each callback to determine the
+    available depth, caps the lookback at the smaller of the two, then samples
+    (recent, prior) from each. *)
+let _ad_divergence_signal ~ad_min_bars ~ad_line_lookback ~get_cumulative_ad
+    ~get_index_close : [ `Bullish | `Bearish | `Neutral ] * string =
+  let n_ad = _probe_depth ~max:ad_line_lookback ~get:get_cumulative_ad in
+  let n_idx = _probe_depth ~max:ad_line_lookback ~get:get_index_close in
+  let lookback = min ad_line_lookback (min n_ad n_idx) in
+  if lookback < ad_min_bars then (`Neutral, "Insufficient A-D data")
+  else
+    match
+      ( get_cumulative_ad ~week_offset:0,
+        get_cumulative_ad ~week_offset:(lookback - 1),
+        get_index_close ~week_offset:0,
+        get_index_close ~week_offset:(lookback - 1) )
+    with
+    | Some ad_recent, Some ad_prior, Some idx_recent, Some idx_prior ->
+        _ad_divergence_decision ~ad_recent ~ad_prior ~idx_recent ~idx_prior
+    | _ -> (`Neutral, "Insufficient A-D data")
+
+(** A-D line indicator using the callback bundle. Empty A-D series (depth 0) or
+    empty index series (depth 0) → Neutral with "No A-D data" — matches the
+    bar-list [List.is_empty] guard. *)
+let _ad_line_signal ~weight ~ad_min_bars ~ad_line_lookback ~get_cumulative_ad
+    ~get_index_close : indicator_reading =
+  let has_ad = Option.is_some (get_cumulative_ad ~week_offset:0) in
+  let has_idx = Option.is_some (get_index_close ~week_offset:0) in
+  if (not has_ad) || not has_idx then
+    { name = "A-D Line"; signal = `Neutral; weight; detail = "No A-D data" }
+  else
+    let signal, detail =
+      _ad_divergence_signal ~ad_min_bars ~ad_line_lookback ~get_cumulative_ad
+        ~get_index_close
+    in
+    { name = "A-D Line"; signal; weight; detail }
+
+(* ------------------------------------------------------------------ *)
+(* Momentum index signal                                                *)
+(* ------------------------------------------------------------------ *)
+
+(** Decide momentum-index signal from a non-missing MA scalar. *)
+let _momentum_index_decision (ma : float) :
+    [ `Bullish | `Bearish | `Neutral ] * string =
+  if Float.(ma > 0.0) then
+    (`Bullish, Printf.sprintf "Momentum index positive (%.1f)" ma)
+  else (`Bearish, Printf.sprintf "Momentum index negative (%.1f)" ma)
+
+(** Momentum-index signal from a precomputed MA scalar. [None] = empty A-D
+    series (matches the bar-list [List.is_empty] guard). *)
+let _momentum_index_signal ~weight ~get_ad_momentum_ma : indicator_reading =
+  match get_ad_momentum_ma ~week_offset:0 with
+  | None ->
+      {
+        name = "Momentum Index";
+        signal = `Neutral;
+        weight;
+        detail = "No A-D data";
+      }
+  | Some ma ->
+      let signal, detail = _momentum_index_decision ma in
+      { name = "Momentum Index"; signal; weight; detail }
+
+(* ------------------------------------------------------------------ *)
+(* NH-NL proxy signal                                                   *)
+(* ------------------------------------------------------------------ *)
+
+(** Decide NH-NL proxy signal from recent + prior index closes. *)
+let _nh_nl_decision ~nh_nl_up_threshold ~nh_nl_down_threshold ~recent ~prior :
+    [ `Bullish | `Bearish | `Neutral ] * string =
+  if Float.(recent > prior *. nh_nl_up_threshold) then
+    (`Bullish, "Index trending higher over 3 months (NH-NL proxy positive)")
+  else if Float.(recent < prior *. nh_nl_down_threshold) then
+    (`Bearish, "Index trending lower over 3 months (NH-NL proxy negative)")
+  else (`Neutral, "Index flat over 3 months (NH-NL proxy neutral)")
+
+(** Build the [NH-NL] insufficient-data reading. *)
+let _nh_nl_insufficient ~weight : indicator_reading =
+  { name = "NH-NL"; signal = `Neutral; weight; detail = "Insufficient data" }
+
+(** Sample [(recent, prior)] from the index-close callback once depth is known
+    to be sufficient and produce the resulting reading. *)
+let _nh_nl_sample_and_decide ~weight ~nh_nl_up_threshold ~nh_nl_down_threshold
+    ~lookback ~get_index_close : indicator_reading =
+  match
+    (get_index_close ~week_offset:0, get_index_close ~week_offset:lookback)
+  with
+  | Some recent, Some prior ->
+      let signal, detail =
+        _nh_nl_decision ~nh_nl_up_threshold ~nh_nl_down_threshold ~recent ~prior
+      in
+      { name = "NH-NL"; signal; weight; detail }
+  | _ -> _nh_nl_insufficient ~weight
+
+(** NH-NL proxy from index price trend. The bar-list path used [n - 1] lookback
+    steps from the newest bar, where [n = min nh_nl_lookback (n - 1)]. In offset
+    space the prior bar is at [week_offset = lookback]. *)
+let _nh_nl_signal ~weight ~nh_nl_min_bars ~nh_nl_lookback ~nh_nl_up_threshold
+    ~nh_nl_down_threshold ~get_index_close : indicator_reading =
+  let depth = _probe_depth ~max:(nh_nl_lookback + 1) ~get:get_index_close in
+  if depth < nh_nl_min_bars then _nh_nl_insufficient ~weight
+  else
+    let lookback = min nh_nl_lookback (depth - 1) in
+    _nh_nl_sample_and_decide ~weight ~nh_nl_up_threshold ~nh_nl_down_threshold
+      ~lookback ~get_index_close
+
+(* ------------------------------------------------------------------ *)
+(* Global consensus signal                                              *)
+(* ------------------------------------------------------------------ *)
+
+(** Classify a single global-index entry by stage signal. *)
+let _classify_global ~stage_config (cb : Stage.callbacks) :
+    [ `Bullish | `Bearish | `Neutral ] =
+  let result =
+    Stage.classify_with_callbacks ~config:stage_config ~get_ma:cb.get_ma
+      ~get_close:cb.get_close ~prior_stage:None
+  in
+  match result.stage with
+  | Stage2 _ -> `Bullish
+  | Stage4 _ -> `Bearish
+  | _ -> `Neutral
+
+(** Decide global consensus signal from the (bullish, bearish, total) counts. *)
+let _global_consensus_decision ~global_consensus_threshold ~bullish_count
+    ~bearish_count ~total : [ `Bullish | `Bearish | `Neutral ] * string =
+  let bullish_frac = Float.of_int bullish_count /. Float.of_int total in
+  let bearish_frac = Float.of_int bearish_count /. Float.of_int total in
+  if Float.(bullish_frac > global_consensus_threshold) then
+    ( `Bullish,
+      Printf.sprintf "Global consensus bullish (%d/%d markets Stage2)"
+        bullish_count total )
+  else if Float.(bearish_frac > global_consensus_threshold) then
+    ( `Bearish,
+      Printf.sprintf "Global consensus bearish (%d/%d markets Stage4)"
+        bearish_count total )
+  else
+    ( `Neutral,
+      Printf.sprintf "Global markets mixed (%d bullish, %d bearish)"
+        bullish_count bearish_count )
+
+(** Aggregate per-index Stage signals into a global consensus signal. *)
+let _global_consensus_signal ~stage_config ~global_consensus_threshold
+    ~global_index_stages : [ `Bullish | `Bearish | `Neutral ] * string =
+  let signals =
+    List.map global_index_stages ~f:(fun (_, cb) ->
+        _classify_global ~stage_config cb)
+  in
+  let bullish_count =
+    List.count signals ~f:(fun s ->
+        match s with `Bullish -> true | _ -> false)
+  in
+  let bearish_count =
+    List.count signals ~f:(fun s ->
+        match s with `Bearish -> true | _ -> false)
+  in
+  let total = List.length signals in
+  _global_consensus_decision ~global_consensus_threshold ~bullish_count
+    ~bearish_count ~total
+
+(** Global consensus indicator. Empty {!global_index_stages} → Neutral / "No
+    global data" (matches the bar-list [List.is_empty] guard). *)
+let _global_signal ~weight ~stage_config ~global_consensus_threshold
+    ~global_index_stages : indicator_reading =
+  if List.is_empty global_index_stages then
+    {
+      name = "Global Markets";
+      signal = `Neutral;
+      weight;
+      detail = "No global data";
+    }
+  else
+    let signal, detail =
+      _global_consensus_signal ~stage_config ~global_consensus_threshold
+        ~global_index_stages
+    in
+    { name = "Global Markets"; signal; weight; detail }
+
+(* ------------------------------------------------------------------ *)
+(* Public assembly                                                      *)
+(* ------------------------------------------------------------------ *)
+
+let build_indicators_from_callbacks ~config ~(index_stage : Stage.result)
+    ~(callbacks : callbacks) : indicator_reading list =
+  let { stage_config; indicator_weights = iw; indicator_thresholds = it; _ } =
+    config
+  in
+  [
+    _index_stage_signal ~weight:iw.w_index_stage index_stage;
+    _ad_line_signal ~weight:iw.w_ad_line ~ad_min_bars:it.ad_min_bars
+      ~ad_line_lookback:it.ad_line_lookback
+      ~get_cumulative_ad:callbacks.get_cumulative_ad
+      ~get_index_close:callbacks.get_index_close;
+    _momentum_index_signal ~weight:iw.w_momentum_index
+      ~get_ad_momentum_ma:callbacks.get_ad_momentum_ma;
+    _nh_nl_signal ~weight:iw.w_nh_nl ~nh_nl_min_bars:it.nh_nl_min_bars
+      ~nh_nl_lookback:it.nh_nl_lookback
+      ~nh_nl_up_threshold:it.nh_nl_up_threshold
+      ~nh_nl_down_threshold:it.nh_nl_down_threshold
+      ~get_index_close:callbacks.get_index_close;
+    _global_signal ~weight:iw.w_global ~stage_config
+      ~global_consensus_threshold:it.global_consensus_threshold
+      ~global_index_stages:callbacks.global_index_stages;
+  ]

--- a/trading/analysis/weinstein/macro/lib/macro_indicators.mli
+++ b/trading/analysis/weinstein/macro/lib/macro_indicators.mli
@@ -1,0 +1,26 @@
+open Macro_types
+
+(** Per-indicator signal helpers for [Macro.analyze_with_callbacks].
+
+    Separated from [Macro] to keep both files under the 300-line linter limit.
+    All functions are pure: same inputs (config + callbacks + index stage)
+    produce the same indicator readings.
+
+    The five Weinstein macro indicators are:
+    - Index Stage — derived from [Stage.classify_with_callbacks] on the primary
+      index (caller pre-computes and passes in [index_stage]).
+    - A-D Line — divergence signal from cumulative A-D vs index closes.
+    - Momentum Index — sign of the precomputed A-D momentum MA scalar.
+    - NH-NL — proxy from index price ratio over the configured lookback.
+    - Global Markets — consensus signal across the per-global-index Stage
+      callbacks bundled in [callbacks.global_index_stages]. *)
+
+val build_indicators_from_callbacks :
+  config:config ->
+  index_stage:Stage.result ->
+  callbacks:callbacks ->
+  indicator_reading list
+(** [build_indicators_from_callbacks ~config ~index_stage ~callbacks] returns
+    the five Weinstein indicator readings in the same order [Macro.analyze]
+    consumed them historically: [Index Stage], [A-D Line], [Momentum Index],
+    [NH-NL], [Global Markets]. *)

--- a/trading/analysis/weinstein/macro/lib/macro_types.ml
+++ b/trading/analysis/weinstein/macro/lib/macro_types.ml
@@ -50,6 +50,14 @@ type result = {
   rationale : string list;
 }
 
+type callbacks = {
+  index_stage : Stage.callbacks;
+  get_index_close : week_offset:int -> float option;
+  get_cumulative_ad : week_offset:int -> float option;
+  get_ad_momentum_ma : week_offset:int -> float option;
+  global_index_stages : (string * Stage.callbacks) list;
+}
+
 let default_indicator_weights =
   {
     w_index_stage = 3.0;

--- a/trading/analysis/weinstein/macro/lib/macro_types.mli
+++ b/trading/analysis/weinstein/macro/lib/macro_types.mli
@@ -54,6 +54,18 @@ type result = {
   rationale : string list;
 }
 
+type callbacks = {
+  index_stage : Stage.callbacks;
+  get_index_close : week_offset:int -> float option;
+  get_cumulative_ad : week_offset:int -> float option;
+  get_ad_momentum_ma : week_offset:int -> float option;
+  global_index_stages : (string * Stage.callbacks) list;
+}
+(** Bundle of indicator callbacks consumed by [Macro.analyze_with_callbacks].
+    Exposed at the [Macro_types] level so that the per-indicator helpers
+    (defined in [Macro_indicators]) and the bar-list wrapper (defined in
+    [Macro]) can share the type without circular references. *)
+
 val default_indicator_weights : indicator_weights
 val default_indicator_thresholds : indicator_thresholds
 val default_config : config

--- a/trading/analysis/weinstein/macro/test/test_macro.ml
+++ b/trading/analysis/weinstein/macro/test/test_macro.ml
@@ -314,6 +314,147 @@ let test_pure_same_inputs _ =
   assert_that r1.trend (equal_to (r2.trend : market_trend));
   assert_that r1.confidence (float_equal r2.confidence)
 
+(* ------------------------------------------------------------------ *)
+(* Parity: analyze (bar-list) vs analyze_with_callbacks                *)
+(*                                                                      *)
+(* Builds the {!callbacks} record externally over the same bars the   *)
+(* wrapper would compute internally, then asserts that the two entry   *)
+(* points produce bit-identical [result] records. Each scenario hits   *)
+(* a different regime: bullish (Stage2 + positive A-D divergence),     *)
+(* bearish (Stage4 + negative A-D divergence), neutral (flat),         *)
+(* insufficient bars, and partial global-index data.                   *)
+(* ------------------------------------------------------------------ *)
+
+(** Bit-identity matcher for {!Stage.result}. Float fields use [equal_to]
+    (Poly.equal — structural equality) so any drift fails. *)
+let stage_result_is_bit_identical (expected : Stage.result) :
+    Stage.result matcher =
+  all_of
+    [
+      field (fun (r : Stage.result) -> r.stage) (equal_to expected.stage);
+      field
+        (fun (r : Stage.result) -> r.ma_value)
+        (equal_to (expected.ma_value : float));
+      field
+        (fun (r : Stage.result) -> r.ma_direction)
+        (equal_to expected.ma_direction);
+      field
+        (fun (r : Stage.result) -> r.ma_slope_pct)
+        (equal_to (expected.ma_slope_pct : float));
+      field
+        (fun (r : Stage.result) -> r.transition)
+        (equal_to expected.transition);
+      field
+        (fun (r : Stage.result) -> r.above_ma_count)
+        (equal_to expected.above_ma_count);
+    ]
+
+(** Bit-identity matcher for one {!Macro.indicator_reading}. The closed-set
+    [signal] variant, [name], [weight], and [detail] string are all checked. Any
+    drift in float arithmetic that flips a signal or changes a printed detail
+    (e.g. [Printf.sprintf "%.1f"] of the momentum MA) will surface here. *)
+let indicator_reading_is_bit_identical (expected : indicator_reading) :
+    indicator_reading matcher =
+  all_of
+    [
+      field (fun (r : indicator_reading) -> r.name) (equal_to expected.name);
+      field (fun (r : indicator_reading) -> r.signal) (equal_to expected.signal);
+      field
+        (fun (r : indicator_reading) -> r.weight)
+        (equal_to (expected.weight : float));
+      field (fun (r : indicator_reading) -> r.detail) (equal_to expected.detail);
+    ]
+
+(** Bit-identity matcher for {!Macro.result}. The composite trend / confidence /
+    regime_changed / rationale plus the nested Stage result and
+    indicator-by-indicator readings are all checked. *)
+let result_is_bit_identical (expected : Macro.result) : Macro.result matcher =
+  all_of
+    [
+      field
+        (fun (r : Macro.result) -> r.index_stage)
+        (stage_result_is_bit_identical expected.index_stage);
+      field
+        (fun (r : Macro.result) -> r.indicators)
+        (elements_are
+           (List.map expected.indicators ~f:indicator_reading_is_bit_identical));
+      field
+        (fun (r : Macro.result) -> r.trend)
+        (equal_to (expected.trend : market_trend));
+      field
+        (fun (r : Macro.result) -> r.confidence)
+        (equal_to (expected.confidence : float));
+      field
+        (fun (r : Macro.result) -> r.regime_changed)
+        (equal_to expected.regime_changed);
+      field
+        (fun (r : Macro.result) -> r.rationale)
+        (equal_to expected.rationale);
+    ]
+
+(** Run both [analyze] and [analyze_with_callbacks] over the same input and
+    assert their results are bit-equal. The callback bundle is built externally
+    via {!Macro.callbacks_from_bars} (the same constructor the wrapper uses
+    internally, but we exercise it through the public API). *)
+let assert_parity ~index_bars ?(ad_bars = []) ?(global_index_bars = [])
+    ?(prior_stage = None) ?(prior = None) () =
+  let callbacks =
+    Macro.callbacks_from_bars ~config:cfg ~index_bars ~ad_bars
+      ~global_index_bars
+  in
+  let from_bars =
+    analyze ~config:cfg ~index_bars ~ad_bars ~global_index_bars ~prior_stage
+      ~prior
+  in
+  let from_callbacks =
+    analyze_with_callbacks ~config:cfg ~callbacks ~prior_stage ~prior
+  in
+  assert_that from_callbacks (result_is_bit_identical from_bars)
+
+(** Bullish macro: rising primary index + positive A-D divergence (advancing >
+    declining). Exercises the [Bullish] composite trend through the callback
+    path. *)
+let test_parity_bullish_stage2_positive_ad _ =
+  let index = rising_bars ~n:60 100.0 200.0 in
+  let ad = ad_bars ~n:200 ~advancing:2000 ~declining:1000 in
+  assert_parity ~index_bars:index ~ad_bars:ad ()
+
+(** Bearish macro: declining primary index + negative A-D divergence. Hits the
+    [Bearish] composite trend. *)
+let test_parity_bearish_stage4_negative_ad _ =
+  let index =
+    List.init 60 ~f:(fun i -> 200.0 -. (Float.of_int i *. 1.5)) |> weekly_bars
+  in
+  let ad = ad_bars ~n:60 ~advancing:800 ~declining:1500 in
+  assert_parity ~index_bars:index ~ad_bars:ad ()
+
+(** Neutral macro: flat index, no A-D, no global. The all-Neutral indicators
+    branch yields confidence = 0.5 → Neutral trend. *)
+let test_parity_neutral_flat_no_ad _ =
+  let index = flat_bars ~n:40 100.0 in
+  assert_parity ~index_bars:index ()
+
+(** Insufficient bars: too-short index list (fewer than [stage_config.ma_period]
+    bars and fewer than [nh_nl_min_bars]). Exercises the early-return /
+    "Insufficient data" branches in the NH-NL signal and the Stage1 default. *)
+let test_parity_insufficient_bars _ =
+  let index = List.init 5 ~f:(Fn.const 100.0) |> weekly_bars in
+  assert_parity ~index_bars:index ()
+
+(** Partial global-index data: 3 global indices with mixed regimes (one rising,
+    one declining, one flat). Exercises the per-index [Stage.classify] loop and
+    the consensus aggregation through the callback path. *)
+let test_parity_partial_global_indices _ =
+  let index = rising_bars ~n:60 100.0 150.0 in
+  let ad = ad_bars ~n:60 ~advancing:1500 ~declining:1000 in
+  let rising = rising_bars ~n:60 100.0 180.0 in
+  let declining =
+    List.init 60 ~f:(fun i -> 200.0 -. Float.of_int i) |> weekly_bars
+  in
+  let flat = flat_bars ~n:60 100.0 in
+  let global = [ ("DAX", rising); ("FTSE", declining); ("Nikkei", flat) ] in
+  assert_parity ~index_bars:index ~ad_bars:ad ~global_index_bars:global ()
+
 let suite =
   "macro_tests"
   >::: [
@@ -338,6 +479,14 @@ let suite =
          "test_index_stage_indicator_present"
          >:: test_index_stage_indicator_present;
          "test_pure_same_inputs" >:: test_pure_same_inputs;
+         "test_parity_bullish_stage2_positive_ad"
+         >:: test_parity_bullish_stage2_positive_ad;
+         "test_parity_bearish_stage4_negative_ad"
+         >:: test_parity_bearish_stage4_negative_ad;
+         "test_parity_neutral_flat_no_ad" >:: test_parity_neutral_flat_no_ad;
+         "test_parity_insufficient_bars" >:: test_parity_insufficient_bars;
+         "test_parity_partial_global_indices"
+         >:: test_parity_partial_global_indices;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
PR-F in the eight-PR A-H sequence (per `dev/plans/columnar-data-shape-2026-04-25.md`).
Sixth callee reshape; the bar-list `Macro.analyze` is now a thin wrapper over
`Macro.analyze_with_callbacks`. Existing call-sites unchanged.

## Summary

- Adds `Macro.analyze_with_callbacks ~config ~callbacks ~prior_stage ~prior` —
  the indicator-callback shape of `Macro.analyze`.
- New `Macro.callbacks` record bundles the nested `Stage.callbacks` for the
  primary index, the `(string * Stage.callbacks) list` for global indices, and
  three offset-indexed callbacks (`get_index_close`, `get_cumulative_ad`,
  `get_ad_momentum_ma`).
- `Macro.callbacks_from_bars ~config ~index_bars ~ad_bars ~global_index_bars`
  pre-computes the cumulative A-D float array and the momentum MA scalar
  once, then builds the offset closures over the resulting arrays. The
  bar-list arithmetic (int sum then float convert at the boundary) is
  preserved exactly, so float values are bit-identical to the legacy path.
- `Macro.analyze` is now a wrapper that builds a `callbacks` record via
  `callbacks_from_bars` and delegates to `analyze_with_callbacks`. Behaviour
  is byte-identical for all existing callers (`weinstein_strategy`,
  `macro_inputs`, `macro_e2e` tests).
- Module split: `macro.ml` (orchestrator + bar-list wrapper plumbing, 187
  lines) + new `macro_indicators.ml` (per-indicator helpers, 277 lines).
  Each file under the 300-line file-length limit.
- Adds 5 parity tests in `test_macro.ml` covering bullish (Stage 2 +
  positive A-D divergence), bearish (Stage 4 + negative A-D), neutral-flat,
  insufficient bars, and partial-global-indices (mixed regimes). Each test
  builds external callbacks via the public `callbacks_from_bars` and asserts
  bit-identical `Macro.result` records via composed matchers.

## Test plan

- [x] dune build && dune runtest analysis/weinstein/macro/ passes — 22
      tests in test_macro (17 pre-existing + 5 parity), 9 in
      test_ad_bars_aggregation, 3 in test_macro_e2e.
- [x] Full project dune build passes.
- [x] dune build @fmt clean.
- [x] All linter checks except 3 pre-existing failures (csv_storage nesting,
      tiered_runner magic numbers, and a non-related earlier status format
      issue that this PR fixes as a courtesy) pass.

## Macro.callbacks bundle

```ocaml
type callbacks = {
  index_stage : Stage.callbacks;
  get_index_close : week_offset:int -> float option;
  get_cumulative_ad : week_offset:int -> float option;
  get_ad_momentum_ma : week_offset:int -> float option;
  global_index_stages : (string * Stage.callbacks) list;
}
```

The bundle exposes only what analyze_with_callbacks reads. Raw
advance/decline reads are deliberately omitted in favour of the
pre-computed cumulative-A-D series and momentum-MA scalar — the bar-list
path also derived these once over the full ad_bars list.