### PR TITLE
harness(cc_linter): route JSON output to --out flag, never to a positional .ml argument

### DIFF
--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -167,18 +167,7 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
      `## Stale Local Bookmarks`.
   Source: `dev/daily/2026-04-14.md` end-of-day audit.
 - ~~**POSIX shell portability linter**~~ — DONE (harness/posix-sh-linter): `trading/devtools/checks/posix_sh_check.sh` runs `dash -n` over all #!/bin/sh scripts in `trading/devtools/checks/`, `trading/devtools/checks/deep_scan/`, and `dev/lib/`. Scripts with `#!/usr/bin/env bash` shebang are exempt. Smoke test: `trading/devtools/checks/posix_sh_check_test.sh`. Wired into `dune runtest`. Verify: `dune runtest devtools/checks/` — prints `OK: posix-sh linter -- N scripts clean.` Pre-existing violations found: `dev/lib/cleanup-stale-worktrees.sh` and `dev/run.sh` use `#!/usr/bin/env bash` and are exempt (intentionally bash). Source: run-4 daily summary follow-up.
-- **`cc_linter.exe` overwrites its first `.ml` argument with the JSON report** —
-  `trading/devtools/cc_linter/cc_linter.ml`. When invoked with multiple `.ml`
-  paths (e.g. `cc_linter.exe a.ml b.ml`), the tool writes its JSON output INTO
-  `a.ml`, destroying the source file. Hit during data-panels Stage 3 PR 3.1
-  (2026-04-25) — agent ran `cc_linter.exe trading/backtest/lib/panel_runner.ml
-  trading/backtest/test/test_panel_loader_parity.ml` and `panel_runner.ml`
-  was clobbered with the JSON report; restored from a saved copy.
-  Fix: route JSON output to a flag (`--out path` or stdout when no path given)
-  and never to a positional `.ml` argument. Add a smoke test that invokes the
-  linter on two paths in a tmpdir and asserts both files are byte-identical
-  before and after. Source: data-panels Stage 3 PR 3.1 dispatch transcript
-  (agent a2800bc7).
+- ~~**`cc_linter.exe` overwrites its first `.ml` argument with the JSON report**~~ — DONE (PR-#570): JSON output now requires explicit `--out <path>` flag; extra positional args after the trading-root are silently ignored and never written to. Smoke test `trading/devtools/cc_linter/test/test_no_overwrite.ml` invokes the linter with two `.ml` paths and asserts byte-equality before/after. Verify: `dune runtest devtools/cc_linter/`.
 
 ---
 

--- a/trading/devtools/cc_linter/cc_linter.ml
+++ b/trading/devtools/cc_linter/cc_linter.ml
@@ -8,14 +8,17 @@
    - Each when guard: +1
    - Boolean operators && and ||: +1 each
 
-   Usage: cc_linter <trading-root> [<output-json-path>]
+   Usage: cc_linter <trading-root> [--out <output-json-path>]
 
    Scans all lib/*.ml and scripts/**/*.ml files under <trading-root>,
    excluding _build/ and ta_ocaml/ directories.
 
    Exits 0 always — CC is a quality signal, not a hard gate. Warnings are
-   printed to stdout. If a JSON output path is provided, per-function CC
-   data is written there for trend analysis. *)
+   printed to stdout. If --out <path> is provided, per-function CC data is
+   written there for trend analysis.
+
+   NOTE: positional arguments after <trading-root> are ignored. JSON output
+   must be requested explicitly with --out to avoid clobbering source files. *)
 
 (* --- Utility --------------------------------------------------------------- *)
 
@@ -265,16 +268,34 @@ let write_json path root date all_results =
 
 let cc_warn_limit = 10
 
+(* Parse CLI arguments: extract --out <path> flag and return (trading_root, json_out).
+   All positional arguments beyond trading_root are silently ignored; JSON output
+   must be requested with --out to prevent accidental source-file clobbering. *)
+let _parse_args () =
+  let args = Array.to_list (Array.sub Sys.argv 1 (Array.length Sys.argv - 1)) in
+  let rec go remaining root json_out =
+    match remaining with
+    | [] -> (root, json_out)
+    | "--out" :: path :: rest -> go rest root (Some path)
+    | "--out" :: [] ->
+        Printf.eprintf "cc_linter: --out requires a path argument\n";
+        exit 2
+    | arg :: rest -> (
+        match root with
+        | None -> go rest (Some arg) json_out
+        | Some _ ->
+            (* Additional positional args are ignored; do not write to them *)
+            go rest root json_out)
+  in
+  match go args None None with
+  | None, _ ->
+      Printf.eprintf
+        "Usage: cc_linter <trading-root> [--out <output-json-path>]\n";
+      exit 2
+  | Some root, json_out -> (root, json_out)
+
 let () =
-  let trading_root =
-    if Array.length Sys.argv > 1 then Sys.argv.(1)
-    else (
-      Printf.eprintf "Usage: cc_linter <trading-root> [<output-json-path>]\n";
-      exit 2)
-  in
-  let json_output =
-    if Array.length Sys.argv > 2 then Some Sys.argv.(2) else None
-  in
+  let trading_root, json_output = _parse_args () in
   let files = collect_lib_ml_files trading_root |> List.sort String.compare in
   let all_results = List.concat_map (fun f -> check_file f) files in
   let warnings =

--- a/trading/devtools/cc_linter/test/dune
+++ b/trading/devtools/cc_linter/test/dune
@@ -1,0 +1,9 @@
+; Smoke test: cc_linter must never overwrite positional .ml arguments.
+; Regression guard for the 2026-04-25 incident where the second positional
+; arg was treated as the JSON output path and clobbered with JSON content.
+
+(test
+ (name test_no_overwrite)
+ (libraries unix)
+ (deps
+  (file ../cc_linter.exe)))

--- a/trading/devtools/cc_linter/test/test_no_overwrite.ml
+++ b/trading/devtools/cc_linter/test/test_no_overwrite.ml
@@ -1,0 +1,68 @@
+(* Smoke test: cc_linter must never overwrite its input .ml files.
+   Regression for the 2026-04-25 incident where invoking
+   `cc_linter.exe a.ml b.ml` clobbered b.ml with the JSON report.
+
+   Steps:
+   1. Write two trivial OCaml files to a tmpdir.
+   2. Record their MD5 digests before running the linter.
+   3. Run cc_linter with both files as positional arguments (the bug pattern).
+   4. Assert each file has byte-identical content afterwards. *)
+
+let () = Random.self_init ()
+
+let write_file path content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let read_file path =
+  let ic = open_in path in
+  let n = in_channel_length ic in
+  let s = Bytes.create n in
+  really_input ic s 0 n;
+  close_in ic;
+  Bytes.to_string s
+
+let digest path = Digest.to_hex (Digest.file path)
+
+let () =
+  let tmpdir =
+    Filename.concat (Filename.get_temp_dir_name ()) "cc_linter_test"
+  in
+  (try Unix.mkdir tmpdir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let file_a = Filename.concat tmpdir "module_a.ml" in
+  let file_b = Filename.concat tmpdir "module_b.ml" in
+  write_file file_a "let f x = x + 1\n";
+  write_file file_b "let g x = x * 2\n";
+  let digest_a_before = digest file_a in
+  let digest_b_before = digest file_b in
+  (* Locate the cc_linter binary relative to the test executable.
+     Under dune runtest the binary is in the same _build tree. *)
+  let linter =
+    Filename.concat (Filename.dirname Sys.executable_name) "../cc_linter.exe"
+  in
+  (* Use tmpdir as trading_root (so scanner finds the two .ml files in lib/)
+     and also pass the two .ml paths as extra positional args to replicate
+     the bug pattern. The linter must NOT write to file_b even though it is
+     the second positional argument. *)
+  let cmd =
+    Printf.sprintf "%s %s %s %s > /dev/null 2>&1" linter tmpdir file_a file_b
+  in
+  let _exit_code = Sys.command cmd in
+  (* Assert byte-identity: neither file was overwritten *)
+  let digest_a_after = digest file_a in
+  let digest_b_after = digest file_b in
+  let content_b_after = read_file file_b in
+  if digest_a_before <> digest_a_after then (
+    Printf.eprintf
+      "FAIL: cc_linter overwrote module_a.ml (first positional arg / \
+       trading_root)\n";
+    exit 1);
+  if digest_b_before <> digest_b_after then (
+    Printf.eprintf
+      "FAIL: cc_linter overwrote module_b.ml (extra positional arg)\n\
+      \  Expected: let g x = x * 2\\n\n\
+      \  Got:      %s\n"
+      content_b_after;
+    exit 1);
+  Printf.printf "OK: cc_linter — no input files were overwritten.\n"


### PR DESCRIPTION
## Summary

Fixes the file-clobber bug reported in #568 (2026-04-25 incident: data-panels Stage 3 PR 3.1): invoking `cc_linter.exe a.ml b.ml` treated the second positional argument as the JSON output path and overwrote it with JSON content.

**Root cause** (`cc_linter.ml` line 276, before this fix):
```ocaml
let json_output =
  if Array.length Sys.argv > 2 then Some Sys.argv.(2) else None
```
Any second positional argument was silently treated as the JSON output path and written to via `write_json`.

**Fix:** JSON output now requires an explicit `--out <path>` flag. A `_parse_args` helper scans `argv` for `--out`; additional positional arguments after `<trading-root>` are silently ignored and never written to. The existing dune invocation (`cc_linter.exe %{workspace_root}`) passes no `--out` and is unaffected.

**Before / After CLI:**
```
# Before (buggy):
cc_linter <trading-root> [<output-json-path>]

# After (fixed):
cc_linter <trading-root> [--out <output-json-path>]
```

## Test plan

- [x] `dune build devtools/cc_linter/` — builds cleanly
- [x] `dune runtest devtools/cc_linter/` — new smoke test `test_no_overwrite` passes; creates two `.ml` files in tmpdir, records MD5 digests, invokes `cc_linter <root> <file_a> <file_b>` (exact bug pattern), asserts byte-equality before/after
- [x] `dune build @fmt` — clean
- [x] `jj diff --stat` shows only: `cc_linter.ml`, `test/dune`, `test/test_no_overwrite.ml`, `dev/status/harness.md`
- [x] Ancestry check: single commit off `main@origin`