### PR TITLE
feat(backtest-perf): catalog scenarios into 4 perf tiers + tier-1 smoke gate

### DIFF
--- a/dev/scripts/perf_tier1_smoke.sh
+++ b/dev/scripts/perf_tier1_smoke.sh
@@ -1,0 +1,182 @@
+#!/bin/sh
+# Tier-1 perf smoke runner.
+#
+# Discovers all scenarios with `;; perf-tier: 1` under
+# trading/test_data/backtest_scenarios/{goldens-small,goldens-broad,perf-sweep,smoke}/,
+# runs each via the scenario_runner binary with a per-scenario timeout
+# (default 120s), and prints a compact wall-time + peak-RSS table.
+#
+# Exit status:
+#   0 if every tier-1 scenario completes within budget
+#   1 if any scenario exits non-zero, errors, or times out
+#
+# Usage:
+#   dev/scripts/perf_tier1_smoke.sh                  -- run all tier-1 cells
+#   PERF_TIER1_TIMEOUT=180 dev/scripts/perf_tier1_smoke.sh  -- bump per-cell timeout
+#
+# Designed to run inside the trading-1-dev container or under GHA where
+# TRADING_IN_CONTAINER=1; uses dev/lib/run-in-env.sh to wrap dune exec.
+#
+# Output artefacts under dev/perf/tier1-smoke-<timestamp>/:
+#   <scenario-name>.log        scenario_runner stdout/stderr
+#   <scenario-name>.peak_rss   integer kB from /usr/bin/time -f '%M'
+#   <scenario-name>.wall_sec   seconds (real time) — best-effort
+#   <scenario-name>.error      present iff the run errored / timed out
+#   summary.txt                aggregate table written at the end
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCENARIO_ROOT="${REPO_ROOT}/trading/test_data/backtest_scenarios"
+RUN_IN_ENV="${REPO_ROOT}/dev/lib/run-in-env.sh"
+TIMEOUT="${PERF_TIER1_TIMEOUT:-120}"
+
+if [ ! -x "$RUN_IN_ENV" ]; then
+  printf 'FAIL: %s not found / not executable\n' "$RUN_IN_ENV" >&2
+  exit 1
+fi
+
+if [ ! -d "$SCENARIO_ROOT" ]; then
+  printf 'FAIL: scenario root not found: %s\n' "$SCENARIO_ROOT" >&2
+  exit 1
+fi
+
+# Probe for GNU /usr/bin/time. The shell builtin has no -f / -o; we need
+# the GNU binary for peak-RSS reporting. macOS hosts won't have it.
+if [ -x /usr/bin/time ]; then
+  HAVE_GNU_TIME=1
+else
+  HAVE_GNU_TIME=0
+fi
+
+# Output dir keyed by timestamp so re-runs don't clobber each other.
+TS="$(date -u +%Y-%m-%dT%H%M%SZ)"
+OUT_DIR="${REPO_ROOT}/dev/perf/tier1-smoke-${TS}"
+mkdir -p "$OUT_DIR"
+
+printf 'Tier-1 perf smoke run.\n'
+printf '  Scenario root : %s\n' "$SCENARIO_ROOT"
+printf '  Output dir    : %s\n' "$OUT_DIR"
+printf '  Per-cell timeout : %ss\n' "$TIMEOUT"
+printf '  GNU /usr/bin/time : %s\n\n' "$HAVE_GNU_TIME"
+
+# Discover tier-1 scenarios (full paths, sorted for determinism).
+TIER1_PATHS=""
+for sub in goldens-small goldens-broad perf-sweep smoke; do
+  dir="${SCENARIO_ROOT}/${sub}"
+  [ -d "$dir" ] || continue
+  for sexp in "$dir"/*.sexp; do
+    [ -f "$sexp" ] || continue
+    if grep -q '^;; perf-tier: 1' "$sexp"; then
+      TIER1_PATHS="${TIER1_PATHS}${sexp}
+"
+    fi
+  done
+done
+
+if [ -z "$TIER1_PATHS" ]; then
+  printf 'WARNING: no scenarios found with [;; perf-tier: 1] -- nothing to do.\n'
+  exit 0
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TABLE_ROWS=""
+
+# Run a single scenario. Stages it into a one-element scratch dir so the
+# scenario_runner --dir entry point picks up exactly one cell. Captures
+# wall time + peak RSS from GNU /usr/bin/time.
+_run_one() {
+  scenario_path="$1"
+  base_name="$(basename "$scenario_path" .sexp)"
+  log_path="${OUT_DIR}/${base_name}.log"
+  rss_path="${OUT_DIR}/${base_name}.peak_rss"
+  wall_path="${OUT_DIR}/${base_name}.wall_sec"
+  error_path="${OUT_DIR}/${base_name}.error"
+
+  # Stage into a scratch dir; scenario_runner --dir consumes ALL .sexp in
+  # the dir, so we put just this one scenario in a fresh subdir.
+  stage_dir="${OUT_DIR}/_stage_${base_name}"
+  mkdir -p "$stage_dir"
+  cp "$scenario_path" "$stage_dir/"
+
+  printf '[run]  %s\n' "$base_name"
+
+  start_epoch=$(date +%s)
+  rc=0
+  if [ "$HAVE_GNU_TIME" = "1" ]; then
+    /usr/bin/time -o "$rss_path" -f '%M' \
+      timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" \
+        dune exec --no-build \
+          trading/backtest/scenarios/scenario_runner.exe -- \
+          --dir "$stage_dir" --parallel 1 \
+        >"$log_path" 2>&1 || rc=$?
+  else
+    timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" \
+        dune exec --no-build \
+          trading/backtest/scenarios/scenario_runner.exe -- \
+          --dir "$stage_dir" --parallel 1 \
+        >"$log_path" 2>&1 || rc=$?
+    printf 'UNAVAILABLE\n' >"$rss_path"
+  fi
+  end_epoch=$(date +%s)
+  wall_sec=$((end_epoch - start_epoch))
+  printf '%s\n' "$wall_sec" >"$wall_path"
+
+  rss_value="?"
+  if [ -f "$rss_path" ]; then
+    rss_value=$(tr -d '\n' <"$rss_path")
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    printf 'exit=%s — see %s\n' "$rc" "$log_path" >"$error_path"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}FAIL  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  else
+    PASS_COUNT=$((PASS_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}PASS  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  fi
+
+  # Clean up stage dir; keep logs.
+  rm -rf "$stage_dir"
+}
+
+# Pre-build the scenario_runner so per-cell wall numbers don't include build
+# time. Best-effort: if the build fails, _run_one will surface it.
+"$RUN_IN_ENV" dune build trading/backtest/scenarios/scenario_runner.exe \
+  >"${OUT_DIR}/_prebuild.log" 2>&1 || true
+
+# IFS-by-newline iteration — TIER1_PATHS is newline-separated.
+OLD_IFS="$IFS"
+IFS='
+'
+for path in $TIER1_PATHS; do
+  IFS="$OLD_IFS"
+  _run_one "$path"
+  IFS='
+'
+done
+IFS="$OLD_IFS"
+
+SUMMARY="${OUT_DIR}/summary.txt"
+{
+  printf 'Tier-1 perf smoke summary (%s)\n' "$TS"
+  printf '  passed: %d\n' "$PASS_COUNT"
+  printf '  failed: %d\n' "$FAIL_COUNT"
+  printf '\n'
+  printf '%-6s  %-32s  %-8s  %s\n' "STATUS" "SCENARIO" "WALL" "PEAK_RSS"
+  printf '%s\n' "----------------------------------------------------------------------"
+  printf '%b' "$TABLE_ROWS" | awk 'NF { printf "%-6s  %-32s  %-8s  %s\n", $1, $2, $3, $4 }'
+} >"$SUMMARY"
+
+cat "$SUMMARY"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -1,9 +1,9 @@
 # Status: backtest-perf
 
-## Last updated: 2026-04-25
+## Last updated: 2026-04-26
 
 ## Status
-PENDING
+IN_PROGRESS — Steps 1+2 done on `feat/backtest-perf-tier1-catalog`; PR open for review. The `perf-tier1.yml` workflow file is **held out of this PR** (agent PAT lacks `workflow` scope) — needs maintainer follow-up to commit the drafted YAML. Steps 3+4 (tier-2 nightly + tier-3 weekly workflows) outstanding and have the same scope-blocker.
 
 ## Interface stable
 N/A
@@ -31,25 +31,68 @@ mechanics + release-gate procedure.
 
 ## Open work
 
-- **PR #550** (this plan, doc-only) — open for human review. Covers
-  scope + tier structure + decision items.
+- **PR #550** (plan, doc-only) — MERGED 2026-04-25.
+- **`feat/backtest-perf-tier1-catalog`** (Steps 1+2) — open for review.
+  Adds tier headers to all 15 catalog scenarios, the
+  `perf_catalog_check.sh` integrity gate (annotate-only), the
+  `perf_tier1_smoke.sh` runner, and the `perf-tier1.yml` GHA
+  workflow.
 
-## Next steps (post-#550 merge)
+## Completed
 
-1. Catalog the existing `goldens-small/`, `goldens-broad/`, and
-   `perf-sweep/` scenarios into the 4 tiers (header tags only).
-   ~1 LOC per scenario.
-2. Define tier 1 (per-PR smoke, 2 cells) + add fast CI step in
-   `ci.yml`. ~30 LOC YAML.
-3. Define tier 2 (nightly, 5 cells) + create `perf-nightly.yml`.
+- **Step 1 — scenario catalog headers** (2026-04-26).
+  Added `;; perf-tier: <1|2|3|4>` + `;; perf-tier-rationale: ...` to
+  every scenario sexp under `goldens-small/`, `goldens-broad/`,
+  `perf-sweep/`, `smoke/`. Tier breakdown:
+  - **Tier 1** (per-PR, ≤2 min): 4 scenarios —
+    `smoke/{tiered-loader-parity, panel-golden-2019-full}`,
+    `perf-sweep/{bull-3m, bull-6m}`.
+  - **Tier 2** (nightly, ≤30 min): 6 scenarios —
+    `goldens-small/*`, `smoke/{bull-2019h2, crash-2020h1, recovery-2023}`.
+  - **Tier 3** (weekly, ≤2 h): 2 scenarios —
+    `perf-sweep/{bull-1y, bull-3y}`.
+  - **Tier 4** (release-gate, ≤8 h): 3 scenarios —
+    `goldens-broad/*` (currently SKIPPED placeholders).
+
+  Verify: `sh trading/devtools/checks/perf_catalog_check.sh` -> "OK: 15
+  scenarios all carry tier tags."
+- **Step 2 — tier-1 smoke gate** (2026-04-26).
+  - `trading/devtools/checks/perf_catalog_check.sh` + dune wiring —
+    grep-based integrity check; annotate-only by default, strict via
+    `PERF_CATALOG_CHECK_STRICT=1`.
+  - `dev/scripts/perf_tier1_smoke.sh` — POSIX-sh runner that
+    auto-discovers `;; perf-tier: 1` scenarios, runs each via
+    `scenario_runner.exe` with `timeout 120`, captures wall-time + peak
+    RSS, prints a summary table.
+  - `.github/workflows/perf-tier1.yml` — **drafted but held out of this
+    PR** because the agent's PAT lacks the `workflow` scope required to
+    push GHA workflow files. The script + check + headers all land in
+    this PR; a maintainer follow-up needs to add the workflow file
+    using a workflow-scoped token. Draft YAML is in the PR body /
+    branch history for paste-and-commit. Sibling workflow design
+    (`pull_request` + `push: main` triggers, non-blocking
+    (`continue-on-error: true`), publishes summary to
+    `$GITHUB_STEP_SUMMARY`).
+  - Verify locally: `dev/scripts/perf_tier1_smoke.sh` (run inside the
+    devcontainer or with `TRADING_IN_CONTAINER=1`).
+
+## Next steps
+
+1. (NEXT) Define tier 2 (nightly, 5 cells per the plan, mapped onto the
+   6 currently-tagged tier-2 scenarios) + create `perf-nightly.yml`.
    ~80 LOC YAML.
-4. Define tier 3 (weekly, 4 cells) + sibling weekly workflow.
-   ~80 LOC YAML.
-5. Tier 4 (release-gate, 5000-stock decade-long) — gated on the
-   `data-panels` refactor (`dev/status/data-panels.md`) landing
-   stages 0-3 at minimum. Current Tiered would extrapolate to
-   ~31 GB at 5000×10y; columnar projects to ~1.2 GB, well under
-   the 8 GB ceiling.
+2. Define tier 3 (weekly, 4 cells per the plan, mapped onto the 2
+   currently-tagged tier-3 scenarios — may need to expand) + sibling
+   weekly workflow. ~80 LOC YAML.
+3. Tier 4 (release-gate, 5000-stock decade-long) — was blocked on the
+   `data-panels` refactor (`dev/status/data-panels.md`); stages 0-3
+   landed (PRs #555, #557, #558, #559-565, #567, #569, #573).
+   Likely follows Stage 4 too. Current Tiered would extrapolate to
+   ~31 GB at 5000×10y; columnar projects to ~1.2 GB, well under the
+   8 GB ceiling.
+4. After ~10 PR cycles of tier-1 perf data: pin per-cell budgets and
+   flip `continue-on-error: false` on `perf-tier1.yml` and
+   `PERF_CATALOG_CHECK_STRICT=1` on the catalog check.
 
 ## Ownership
 
@@ -59,7 +102,8 @@ generators.
 
 ## Branch
 
-`feat/backtest-perf-<step>` per item above.
+`feat/backtest-perf-<step>` per item above. Active:
+`feat/backtest-perf-tier1-catalog` (Steps 1+2).
 
 ## Blocked on
 

--- a/trading/devtools/checks/dune
+++ b/trading/devtools/checks/dune
@@ -249,3 +249,19 @@
  (deps _check_lib.sh)
  (action
   (run sh %{dep:posix_sh_check_test.sh})))
+
+; Perf-catalog integrity check: verifies every scenario sexp under
+; trading/test_data/backtest_scenarios/{goldens-small,goldens-broad,perf-sweep,smoke}/
+; carries a [;; perf-tier: <1|2|3|4>] header line, AND that paths
+; referenced from .github/workflows/perf-tier1.yml exist on disk and
+; carry [;; perf-tier: 1].
+;
+; Annotate-only by default (exits 0 with WARNING output on violations).
+; Set PERF_CATALOG_CHECK_STRICT=1 to gate the build instead. See
+; dev/plans/perf-scenario-catalog-2026-04-25.md §"Decision items" #3.
+
+(rule
+ (alias runtest)
+ (deps _check_lib.sh)
+ (action
+  (run sh %{dep:perf_catalog_check.sh})))

--- a/trading/devtools/checks/perf_catalog_check.sh
+++ b/trading/devtools/checks/perf_catalog_check.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+# Perf-catalog integrity check.
+#
+# Asserts every scenario sexp under trading/test_data/backtest_scenarios/
+# (excluding [universes/] and [experiments/], which are not catalog
+# entries) carries a [;; perf-tier: <1|2|3|4>] header line. The tier
+# system + format are documented in dev/plans/perf-scenario-catalog-2026-04-25.md.
+#
+# Also cross-checks that every scenario claimed by the perf tier-1
+# workflow actually exists on disk and has [perf-tier: 1] (so the
+# workflow can't silently drift away from the tag set).
+#
+# Failure semantics (see plan §"Decision items" #3):
+#   PERF_CATALOG_CHECK_STRICT=1 -> exit 1 on any violation (gate the build)
+#   default                     -> emit WARNING lines, exit 0 (annotate only)
+#
+# We start in annotate-only mode because the catalog will evolve; the
+# check exists primarily to prevent NEW scenarios from being added
+# without a tier tag. Flip strict mode on once the catalog is stable
+# (decision-items item #3 carried in dev/status/backtest-perf.md).
+
+set -e
+
+. "$(dirname "$0")/_check_lib.sh"
+
+REPO_ROOT="$(repo_root)"
+SCENARIO_ROOT="${REPO_ROOT}/trading/test_data/backtest_scenarios"
+TIER1_WORKFLOW="${REPO_ROOT}/.github/workflows/perf-tier1.yml"
+
+STRICT="${PERF_CATALOG_CHECK_STRICT:-0}"
+
+if [ ! -d "$SCENARIO_ROOT" ]; then
+  echo "OK: perf-catalog check skipped (no $SCENARIO_ROOT)."
+  exit 0
+fi
+
+VIOLATIONS=""
+TAGGED_COUNT=0
+UNTAGGED_COUNT=0
+
+# Scenario directories that are part of the catalog. Anything outside
+# these (universes/, experiments/, panel_goldens/, ...) is not a
+# tier-tagged scenario and is skipped.
+CATALOG_DIRS="goldens-small
+goldens-broad
+perf-sweep
+smoke"
+
+for sub in $CATALOG_DIRS; do
+  dir="${SCENARIO_ROOT}/${sub}"
+  [ -d "$dir" ] || continue
+  for sexp in "$dir"/*.sexp; do
+    [ -f "$sexp" ] || continue
+    rel="${sexp#${REPO_ROOT}/}"
+    if grep -q '^;; perf-tier:' "$sexp"; then
+      TAGGED_COUNT=$((TAGGED_COUNT + 1))
+    else
+      UNTAGGED_COUNT=$((UNTAGGED_COUNT + 1))
+      VIOLATIONS="${VIOLATIONS}MISSING_TAG ${rel}\n"
+    fi
+  done
+done
+
+# Cross-check: every scenario referenced from perf-tier1.yml must exist
+# AND carry [;; perf-tier: 1]. Format inside the workflow: paths
+# appear under a heredoc / list with full repo-relative path. We grep
+# the workflow file for any line ending in `.sexp` and validate each.
+WORKFLOW_VIOLATIONS=""
+if [ -f "$TIER1_WORKFLOW" ]; then
+  # Extract every .sexp basename or relative path mentioned in the workflow.
+  # Strip leading whitespace + comment markers, then look for tokens ending
+  # in .sexp.
+  workflow_paths=$(grep -oE '[A-Za-z0-9_./-]+\.sexp' "$TIER1_WORKFLOW" | sort -u)
+  for wp in $workflow_paths; do
+    # Resolve relative path -- the workflow paths are relative to repo root.
+    full_path="${REPO_ROOT}/${wp}"
+    if [ ! -f "$full_path" ]; then
+      WORKFLOW_VIOLATIONS="${WORKFLOW_VIOLATIONS}WORKFLOW_PATH_NOT_FOUND ${wp}\n"
+      continue
+    fi
+    if ! grep -q '^;; perf-tier: 1' "$full_path"; then
+      WORKFLOW_VIOLATIONS="${WORKFLOW_VIOLATIONS}WORKFLOW_PATH_NOT_TIER1 ${wp}\n"
+    fi
+  done
+fi
+
+TOTAL=$((TAGGED_COUNT + UNTAGGED_COUNT))
+
+if [ -n "$VIOLATIONS" ] || [ -n "$WORKFLOW_VIOLATIONS" ]; then
+  if [ "$STRICT" = "1" ]; then
+    LABEL="FAIL"
+  else
+    LABEL="WARNING"
+  fi
+  printf '%s: perf-catalog check -- %d tagged / %d untagged of %d scenarios.\n' \
+    "$LABEL" "$TAGGED_COUNT" "$UNTAGGED_COUNT" "$TOTAL"
+  if [ -n "$VIOLATIONS" ]; then
+    printf '\nMissing [;; perf-tier:] header:\n'
+    printf '%b' "$VIOLATIONS"
+  fi
+  if [ -n "$WORKFLOW_VIOLATIONS" ]; then
+    printf '\nWorkflow %s drift:\n' "$TIER1_WORKFLOW"
+    printf '%b' "$WORKFLOW_VIOLATIONS"
+  fi
+  printf '\nFix: add [;; perf-tier: <1|2|3|4>] + [;; perf-tier-rationale: ...]\n'
+  printf '     to the top of each scenario sexp. See\n'
+  printf '     dev/plans/perf-scenario-catalog-2026-04-25.md.\n'
+  if [ "$STRICT" = "1" ]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+echo "OK: perf-catalog check -- ${TAGGED_COUNT} scenarios all carry tier tags."

--- a/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 4
+;; perf-tier-rationale: Full sector-map (broad) universe over 6 years incl. 2020 crash; release-gate cadence (≤8 h). Currently SKIPPED placeholder pending re-pin and data-panels Stage-4 (5000-symbol broadening). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 4.
+;;
 ;; STATUS: SKIPPED — ranges stale (1,654-symbol era); re-pin pending a GHA
 ;; workflow. Do not treat as a regression gate until re-pinned. See
 ;; `dev/status/backtest-infra.md` follow-up.

--- a/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 4
+;; perf-tier-rationale: Full sector-map (broad) universe over 5 years incl. COVID; release-gate cadence (≤8 h). Currently SKIPPED placeholder pending re-pin and data-panels Stage-4 (5000-symbol broadening). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 4.
+;;
 ;; STATUS: SKIPPED — ranges stale (1,654-symbol era); re-pin pending a GHA
 ;; workflow. Do not treat as a regression gate until re-pinned. See
 ;; `dev/status/backtest-infra.md` follow-up.

--- a/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 4
+;; perf-tier-rationale: Full sector-map (broad) universe over 6 years incl. COVID; release-gate cadence (≤8 h). Currently SKIPPED placeholder pending re-pin and data-panels Stage-4 (5000-symbol broadening). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 4.
+;;
 ;; STATUS: SKIPPED — ranges stale (1,654-symbol era); re-pin pending a GHA
 ;; workflow. Do not treat as a regression gate until re-pinned. See
 ;; `dev/status/backtest-infra.md` follow-up.

--- a/trading/test_data/backtest_scenarios/goldens-small/bull-crash-2015-2020.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-small/bull-crash-2015-2020.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 2
+;; perf-tier-rationale: 302-symbol small universe over 6 years; nightly cadence (≤30 min budget). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 2.
+;;
 ;; Golden scenario: strong bull market through 2020 crash.
 ;;
 ;; Baseline re-pinned on 2026-04-18 post-PR #409 (`_held_symbols` now

--- a/trading/test_data/backtest_scenarios/goldens-small/covid-recovery-2020-2024.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-small/covid-recovery-2020-2024.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 2
+;; perf-tier-rationale: 302-symbol small universe over 5 years; nightly cadence (≤30 min budget). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 2.
+;;
 ;; Golden scenario: COVID crash and recovery through 2024.
 ;;
 ;; Baseline re-pinned on 2026-04-18 post-PR #409 (`_held_symbols` now

--- a/trading/test_data/backtest_scenarios/goldens-small/six-year-2018-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-small/six-year-2018-2023.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 2
+;; perf-tier-rationale: 302-symbol small universe over 6 years; nightly cadence (≤30 min budget). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 2.
+;;
 ;; Golden scenario: 6-year run covering COVID crash and recovery.
 ;;
 ;; Baseline re-pinned on 2026-04-18 post-PR #409 (`_held_symbols` now

--- a/trading/test_data/backtest_scenarios/perf-sweep/bull-1y.sexp
+++ b/trading/test_data/backtest_scenarios/perf-sweep/bull-1y.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 3
+;; perf-tier-rationale: Mid-scope perf-sweep cell (1 year / ~252 trading days at N=1000); weekly cadence (≤2 h budget). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 3.
+;;
 ;; Synthetic perf-sweep scenario — vary universe_cap via --override to extract
 ;; complexity curve. NOT a regression gate.
 ;;

--- a/trading/test_data/backtest_scenarios/perf-sweep/bull-3m.sexp
+++ b/trading/test_data/backtest_scenarios/perf-sweep/bull-3m.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 1
+;; perf-tier-rationale: Smallest perf-sweep cell (3 months / ~63 trading days). Per-PR smoke cadence (≤2 min budget) when run with a small universe_cap override. See dev/plans/perf-scenario-catalog-2026-04-25.md tier 1.
+;;
 ;; Synthetic perf-sweep scenario — vary universe_cap via --override to extract
 ;; complexity curve. NOT a regression gate.
 ;;

--- a/trading/test_data/backtest_scenarios/perf-sweep/bull-3y.sexp
+++ b/trading/test_data/backtest_scenarios/perf-sweep/bull-3y.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 3
+;; perf-tier-rationale: Largest perf-sweep cell (3 years / ~756 trading days at N=1000, includes 2020 crash); weekly cadence (≤2 h budget). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 3.
+;;
 ;; Synthetic perf-sweep scenario — vary universe_cap via --override to extract
 ;; complexity curve. NOT a regression gate.
 ;;

--- a/trading/test_data/backtest_scenarios/perf-sweep/bull-6m.sexp
+++ b/trading/test_data/backtest_scenarios/perf-sweep/bull-6m.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 1
+;; perf-tier-rationale: Small perf-sweep cell (6 months / ~126 trading days). Per-PR smoke cadence (≤2 min budget) when run with a small universe_cap override. See dev/plans/perf-scenario-catalog-2026-04-25.md tier 1.
+;;
 ;; Synthetic perf-sweep scenario — vary universe_cap via --override to extract
 ;; complexity curve. NOT a regression gate.
 ;;

--- a/trading/test_data/backtest_scenarios/smoke/bull-2019h2.sexp
+++ b/trading/test_data/backtest_scenarios/smoke/bull-2019h2.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 2
+;; perf-tier-rationale: 1654-symbol full-universe smoke over 6 months, ~5-10 min wall; too heavy for per-PR gate (≤2 min) — fits nightly cadence. See dev/plans/perf-scenario-catalog-2026-04-25.md tier 2.
+;;
 ;; Smoke scenario: bullish second half of 2019. Runs quickly (~5-10 min).
 ;; Ranges are broad sanity checks, not regression gates.
 ;;

--- a/trading/test_data/backtest_scenarios/smoke/crash-2020h1.sexp
+++ b/trading/test_data/backtest_scenarios/smoke/crash-2020h1.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 2
+;; perf-tier-rationale: 1654-symbol full-universe smoke over 6 months, ~5-10 min wall; too heavy for per-PR gate (≤2 min) — fits nightly cadence. See dev/plans/perf-scenario-catalog-2026-04-25.md tier 2.
+;;
 ;; Smoke scenario: first half of 2020 (COVID crash). Runs quickly (~5-10 min).
 ;; Ranges are broad sanity checks, not regression gates.
 ;;

--- a/trading/test_data/backtest_scenarios/smoke/panel-golden-2019-full.sexp
+++ b/trading/test_data/backtest_scenarios/smoke/panel-golden-2019-full.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 1
+;; perf-tier-rationale: 7-symbol panel-parity universe over ~8 months — small/fast, well under the per-PR ≤2 min budget. Already exercised by OUnit tests; tagging makes it eligible for the per-PR perf smoke too. See dev/plans/perf-scenario-catalog-2026-04-25.md tier 1.
+;;
 ;; Panel-mode golden parity scenario — second fixture for the
 ;; [test_panel_round_trips_golden] gate.
 ;;

--- a/trading/test_data/backtest_scenarios/smoke/recovery-2023.sexp
+++ b/trading/test_data/backtest_scenarios/smoke/recovery-2023.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 2
+;; perf-tier-rationale: 1654-symbol full-universe smoke over 12 months, ~5-10 min wall; too heavy for per-PR gate (≤2 min) — fits nightly cadence. See dev/plans/perf-scenario-catalog-2026-04-25.md tier 2.
+;;
 ;; Smoke scenario: calendar year 2023 recovery. Runs quickly (~5-10 min).
 ;; Ranges are broad sanity checks, not regression gates.
 ;;

--- a/trading/test_data/backtest_scenarios/smoke/tiered-loader-parity.sexp
+++ b/trading/test_data/backtest_scenarios/smoke/tiered-loader-parity.sexp
@@ -1,3 +1,6 @@
+;; perf-tier: 1
+;; perf-tier-rationale: 7-symbol parity universe over 6 months — fastest scenario in the catalog, well under the per-PR ≤2 min budget. Already exercised by OUnit tests; tagging makes it eligible for the per-PR perf smoke too. See dev/plans/perf-scenario-catalog-2026-04-25.md tier 1.
+;;
 ;; Merge-gate parity scenario for the tiered loader track.
 ;;
 ;; Runs under BOTH [loader_strategy = Legacy] and [loader_strategy = Tiered]


### PR DESCRIPTION
## Summary

Steps 1+2 of `dev/plans/perf-scenario-catalog-2026-04-25.md` (PR #550, MERGED).

- **Step 1 — catalog 15 scenarios into 4 perf tiers** via comment-only `;; perf-tier: <1|2|3|4>` + `;; perf-tier-rationale: ...` headers. No behaviour change; pure metadata.
- **Step 2a — `perf_catalog_check.sh`** + dune wiring. Annotate-only by default (exit 0 with WARNING on violations); strict via `PERF_CATALOG_CHECK_STRICT=1`. Per plan §"Decision items" #3.
- **Step 2b — `dev/scripts/perf_tier1_smoke.sh`**. POSIX-sh runner that auto-discovers `;; perf-tier: 1` scenarios, runs each via `scenario_runner.exe` with a `timeout 120`, captures wall-time + peak RSS, prints summary table. Exit 0 iff every cell completes within budget.
- **Step 2c — `.github/workflows/perf-tier1.yml`** is **held out of this PR**. The agent PAT lacks the `workflow` scope required to push GHA workflow files. A maintainer needs to commit the drafted YAML in a follow-up. Draft is appended to this PR description for paste-and-commit.

## Tier breakdown

| Tier | Cadence | Budget | Count | Scenarios |
|---|---|---|---:|---|
| 1 | per-PR smoke | ≤2 min | 4 | `smoke/{tiered-loader-parity, panel-golden-2019-full}`, `perf-sweep/{bull-3m, bull-6m}` |
| 2 | nightly | ≤30 min | 6 | `goldens-small/*` (3), `smoke/{bull-2019h2, crash-2020h1, recovery-2023}` |
| 3 | weekly | ≤2 h | 2 | `perf-sweep/{bull-1y, bull-3y}` |
| 4 | release-gate | ≤8 h | 3 | `goldens-broad/*` (currently SKIPPED placeholders) |

Tier-assignment judgment calls (where the plan didn't pre-assign):
- The 1654-symbol `smoke/*` files are too heavy for tier 1 (≤2 min budget per the plan); the existing headers admit ~5–10 min wall. Bumped to tier 2.
- The 7-symbol `tiered-loader-parity` and `panel-golden-2019-full` are explicitly tier 1 (smallest scenarios in the catalog). Already exercised by OUnit tests; tagging makes them eligible for the per-PR perf smoke too.
- The `goldens-broad/*` files are tier 4 (full-universe, multi-year) — currently SKIPPED placeholders pending Stage-4 of `data-panels`.

## Test plan

- [x] `dash -n` passes on both new shell scripts.
- [x] `sh trading/devtools/checks/perf_catalog_check.sh` -> "OK: 15 scenarios all carry tier tags."
- [x] `sh trading/devtools/checks/posix_sh_check.sh` -> "OK: 45 scripts clean."
- [x] `dev/lib/run-in-env.sh dune build` exits 0.
- [x] `dev/lib/run-in-env.sh dune build @fmt` exits 0.
- [ ] `dev/scripts/perf_tier1_smoke.sh` end-to-end run inside the devcontainer (deferred to maintainer; agent runs in container w/o full data fixtures).

## PR sizing

- Diff: 5 commits, 4 files of new/modified shell + 15 sexp header tweaks + status file. ~280 LOC of new code, ~45 LOC of headers.
- One new check (`perf_catalog_check.sh`), one new script (`perf_tier1_smoke.sh`). Within the ≤500 LOC + one-new-module guideline.

## Maintainer follow-up: draft `perf-tier1.yml`

Paste this into `.github/workflows/perf-tier1.yml` from a workflow-scoped token to wire up the per-PR perf smoke:

```yaml
# Tier-1 perf smoke: per-PR fast smoke (≤2 min budget) for the perf catalog.
#
# Runs every scenario tagged `;; perf-tier: 1` under
# trading/test_data/backtest_scenarios/ via dev/scripts/perf_tier1_smoke.sh,
# captures wall-time + peak RSS, and writes the result into the GHA job
# summary so reviewers can read off perf at a glance.
#
# Non-blocking by design (continue-on-error: true). The catalog is fresh
# and per-cell budgets aren't pinned yet; we want VISIBILITY first, gating
# later. Flip continue-on-error off once the budgets in
# dev/plans/perf-scenario-catalog-2026-04-25.md tier 1 are pinned.
#
# Tier-1 scenarios covered (kept in sync via trading/devtools/checks/perf_catalog_check.sh):
#   trading/test_data/backtest_scenarios/perf-sweep/bull-3m.sexp
#   trading/test_data/backtest_scenarios/perf-sweep/bull-6m.sexp
#   trading/test_data/backtest_scenarios/smoke/panel-golden-2019-full.sexp
#   trading/test_data/backtest_scenarios/smoke/tiered-loader-parity.sexp
name: perf-tier1

on:
  pull_request:
  push:
    branches: [main]

jobs:
  perf-tier1-smoke:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      packages: read
    container:
      image: ghcr.io/${{ github.repository_owner }}/trading-ci:latest
      credentials:
        username: ${{ github.actor }}
        password: ${{ secrets.GITHUB_TOKEN }}
      options: --user 0
    env:
      HOME: /home/opam
      TRADING_IN_CONTAINER: "1"
      TRADING_DATA_DIR: ${{ github.workspace }}/trading/test_data
    steps:
      - uses: actions/checkout@v4

      - name: Cache _build
        uses: actions/cache@v4
        with:
          path: trading/_build
          key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
          restore-keys: |
            dune-${{ runner.os }}-

      - name: Run tier-1 perf smoke
        id: tier1
        continue-on-error: true
        run: dev/scripts/perf_tier1_smoke.sh

      - name: Publish summary
        if: always()
        run: |
          summary_file=$(ls -1t dev/perf/tier1-smoke-*/summary.txt 2>/dev/null | head -1)
          if [ -n "$summary_file" ] && [ -f "$summary_file" ]; then
            {
              echo "## Tier-1 perf smoke"
              echo ""
              echo '```'
              cat "$summary_file"
              echo '```'
            } >>"$GITHUB_STEP_SUMMARY"
          else
            echo "Tier-1 perf smoke: no summary produced." >>"$GITHUB_STEP_SUMMARY"
          fi
```

Once that file lands, `perf_catalog_check.sh` will automatically start cross-validating the scenarios it references — no further changes needed to the check or the script.
