### PR TITLE
ops(budget): 2026-04-26-24954463993 ($51.7881)

### DIFF
--- a/dev/budget/2026-04-26-24954463993.json
+++ b/dev/budget/2026-04-26-24954463993.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-04-26-24954463993",
+  "timestamp": "2026-04-26T11:38:38Z",
+  "commit_sha": "1e921de23908a5467d85d1a9dd552ae9b72fa60a",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output \u2014 see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 51.788088499999986,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}


### PR DESCRIPTION
Measured GHA orchestrator run cost for `2026-04-26-24954463993`.

`total_cost_usd`: $51.7881 (from `claude-code-action` execution_file, fallback branch 1b — see `dev/status/cost-tracking.md`).

Auto-merge: ops category, single-file additive change.