### PR TITLE
cleanup(nesting): extract helpers in _stream_in_range_prices to flatten nesting

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -17,7 +17,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
-- [ ] nesting: trading/analysis/data/storage/csv/lib/csv_storage.ml — `_stream_in_range_prices` (line 180) avg=3.61 max=9 from PR #543 H7 stream-parse refactor (source: 2026-04-26-fast.md)
+- [~] nesting: trading/analysis/data/storage/csv/lib/csv_storage.ml — `_stream_in_range_prices` (line 180) avg=3.61 max=9 from PR #543 H7 stream-parse refactor (source: 2026-04-26-fast.md)
 
 ## Completed
 

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -17,10 +17,9 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
-- [~] nesting: trading/analysis/data/storage/csv/lib/csv_storage.ml — `_stream_in_range_prices` (line 180) avg=3.61 max=9 from PR #543 H7 stream-parse refactor (source: 2026-04-26-fast.md)
-
 ## Completed
 
+- [x] nesting: trading/analysis/data/storage/csv/lib/csv_storage.ml — extracted `_parse_and_accumulate` and `_read_next_line` helpers; nesting linter now passes (835 fns, all OK). (source: 2026-04-26-fast.md, PR TBD, 2026-04-26)
 - [x] fn_length / file_length: weinstein_strategy.ml — added @large-module annotation; file length linter now passes. (source: 2026-04-19-fast.md, PR #453, 2026-04-19)
 
 ## Out of scope

--- a/trading/analysis/data/storage/csv/lib/csv_storage.ml
+++ b/trading/analysis/data/storage/csv/lib/csv_storage.ml
@@ -177,22 +177,32 @@ let _in_date_range ~start_date ~end_date (price : Types.Daily_price.t) =
    within the requested date range. Avoids materializing the full file
    contents (lines list) or the full parsed-prices list, which previously
    dominated allocation churn during repeated reads of large symbol CSVs. *)
+
+(* Parse [line] and accumulate into [result] if it falls in the date range.
+   Returns an error status on a parse failure. *)
+let _parse_and_accumulate line ~start_date ~end_date ~result =
+  match Parser.parse_line line with
+  | Error msg -> Error (Status.invalid_argument_error msg)
+  | Ok price ->
+      if _in_date_range ~start_date ~end_date price then
+        result := price :: !result;
+      Ok ()
+
+(* Read the next line from [chan] and process it.
+   Returns [None] on EOF, [Some (Ok ())] on success, [Some (Error _)] on parse failure. *)
+let _read_next_line chan ~start_date ~end_date ~result =
+  match In_channel.input_line chan with
+  | None -> None
+  | Some line -> Some (_parse_and_accumulate line ~start_date ~end_date ~result)
+
 let _stream_in_range_prices chan ~start_date ~end_date =
   let result = ref [] in
   let error = ref None in
   let rec loop () =
-    match !error with
-    | Some _ -> ()
-    | None -> (
-        match In_channel.input_line chan with
-        | None -> ()
-        | Some line ->
-            (match Parser.parse_line line with
-            | Ok price ->
-                if _in_date_range ~start_date ~end_date price then
-                  result := price :: !result
-            | Error msg -> error := Some (Status.invalid_argument_error msg));
-            loop ())
+    match _read_next_line chan ~start_date ~end_date ~result with
+    | None -> ()
+    | Some (Error e) -> error := Some e
+    | Some (Ok ()) -> loop ()
   in
   loop ();
   match !error with Some err -> Error err | None -> Ok (List.rev !result)


### PR DESCRIPTION
Cleanup of nesting linter finding from `dev/health/2026-04-26-fast.md`:

**Before (FAIL):**
```
avg    max  else why        location                                            function
3.61   9    0    avg+max    analysis/data/storage/csv/lib/csv_storage.ml:180    _stream_in_range_prices
```

**After (PASS):**
```
OK: nesting linter — all 835 functions within limits.
Codebase avg nesting: 1.40  |  835 functions scanned  |  99 files
```

## Fix shape

Extracted two private `_`-prefixed helpers (`_parse_and_accumulate`, `_read_next_line`) so `_stream_in_range_prices` becomes a flat single-`match` loop. No new public symbols; behavior unchanged.

## Verification

- `dune build` exit 0, `dune build @fmt` exit 0
- `dune runtest`: nesting linter OK; csv_storage tests 15/15 pass; no test newly fails or passes
- Diff: ~37 LOC

(Generated by orchestrator run-2 on 2026-04-26.)