### PR TITLE
ops(budget): 2026-04-26-24960244278 ($6.5786)

### DIFF
--- a/dev/budget/2026-04-26-24960244278.json
+++ b/dev/budget/2026-04-26-24960244278.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-04-26-24960244278",
+  "timestamp": "2026-04-26T15:49:58Z",
+  "commit_sha": "bb4e4a66629e8298fceb5744bd2d132b689701e1",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output \u2014 see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 6.578562599999999,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/daily/2026-04-26-run2.md
+++ b/dev/daily/2026-04-26-run2.md
@@ -1,0 +1,181 @@
+# Status — 2026-04-26 [run 2]
+
+**Run ID:** 2026-04-26-run-2
+**Run timestamp:** 2026-04-26T15:33:11Z
+**Mode:** FULL (Step 0.5 fast-exit declined: cleanup.md gained a new dispatchable `[ ]` item via the prior-run summary commit; Condition 4 fails by design — that item is the explicit "Dispatch on next run" handoff from run-1)
+
+## Pending work
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| data-panels | awaiting-merge | feat/panels-stage03-pr-d-delete-legacy | #575 | QC APPROVED 5/5 (run-1) — awaiting human merge; PR #575 also fixes the `data-panels.md` integrity violation that's keeping main RED. Then Stage 4 dispatches off main. |
+| backtest-perf | awaiting-merge | feat/backtest-perf-tier1-catalog | #574 | QC APPROVED 5/5 (run-1) — awaiting human merge; held-out `.github/workflows/perf-tier1.yml` needs `workflow`-scoped token to commit. After merge: Steps 3+4 (tier-2 nightly + tier-3 weekly workflows). |
+| cleanup | dispatched | cleanup/csv-storage-nesting | #578 | code-health PR opened this run; helper-extraction fix; nesting linter empirically verified clean on the branch. Awaiting human merge to land the build-gate fix. |
+| short-side-strategy | blocked | — | — | Practical block on broad-universe scale; gated on data-panels Stage 4 memory-win materialization. |
+| harness | blocked | — | — | T1 done; T2 milestone-gated; T3-C superseded; T3-H low-priority. No dispatchable items this run. |
+| orchestrator-automation | blocked | — | — | Phase 2 background-execution items pending empirical tests. No dispatchable items this run. |
+| cost-tracking | blocked | — | — | Awaiting next budget JSON to verify cost-capture wiring; nothing actionable this run. |
+
+## Dispatched this run
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| cleanup | code-health | completed | csv_storage.ml `_stream_in_range_prices` nesting violation. Extracted 2 `_`-prefixed helpers (`_parse_and_accumulate`, `_read_next_line`); diff +23/-14 LOC. Empirically: nesting linter clean on branch (`OK: nesting linter — all 886 functions within limits` vs 833+1 fail on main). Branch tip 6a5b5f06. |
+| cleanup | — | PR opened | #578 created via curl fallback (Step 4.5) — agent reported `gh CLI not available in container`, branch was pushed but no PR. Fallback worked. |
+| cleanup | — | QC skipped | Cleanup PRs are mechanical no-behavior-change refactors; structural QC adds cost without signal. Step 6 deterministically re-verifies build gate (see §Health Scan). |
+| data-panels | — | skipped (in-flight) | PR #575 tip 8c733ac3 == `Reviewed SHA: 8c733ac35caf...` from run-1 review. No new commits → no re-QC needed. |
+| backtest-perf | — | skipped (in-flight) | PR #574 tip 6f689d62 == `Reviewed SHA: 6f689d62c7fd...` from run-1 review. No new commits → no re-QC needed. |
+| harness | — | skipped | No dispatchable items: T1 done; T2 milestone-gated; T3-C superseded; T3-H low-priority. |
+| ops-data | — | skipped | data-gaps.md unchanged since 2026-04-14 (sentinel rule). |
+| short-side-strategy | — | skipped | Practical block on data-panels Stage 4 memory-win. Not dispatchable. |
+
+## Feature Progress
+
+### cleanup [IN_PROGRESS — PR #578 awaiting merge]
+- Done today: code-health dispatch addressed the only Backlog item (csv_storage nesting). Two helpers extracted via path (a) of run-1's escalation suggestion; behavior preserved (15/15 csv_storage tests pass identically); diff well under the 200-LOC cap.
+- In progress: PR #578 awaiting human merge.
+- Blocked: No.
+- **Next dispatch (post-merge):** Backlog drains to empty unless the next fast scan or weekly deep scan surfaces new medium/high findings.
+
+### data-panels [READY_FOR_REVIEW — Stage 3 PR 3.4 awaiting merge]
+- No new work this run (PR #575 unchanged since run-1).
+- Blocked: No.
+- **Next dispatch (post-merge):** Stage 4 — callbacks-through-runner wiring (per `dev/notes/panels-rss-spike-2026-04-25.md`). Load-bearing memory-win work: post-3.2 Panel-mode RSS at N=292 T=6y is 3.47 GB vs <800 MB projection because every reader site rebuilds `Daily_price.t list` per tick. Stage 4 wires `*_with_callbacks` through `Panel_runner` so production no longer materializes lists. Estimated ~600 LOC, 3-4 working days.
+
+### backtest-perf [READY_FOR_REVIEW — Steps 1+2 awaiting merge]
+- No new work this run (PR #574 unchanged since run-1).
+- Blocked: No, but held-out `.github/workflows/perf-tier1.yml` needs maintainer with `workflow`-scoped token.
+- **Next dispatch (post-merge):** Steps 3+4 (tier-2 nightly + tier-3 weekly workflows). Tier-4 release-gate scenarios structurally unblocked but practically gated on data-panels Stage 4.
+
+## QC Status
+
+| Track | Structural | Behavioral | Quality | Audit |
+|-------|------------|------------|---------|-------|
+| cleanup | (skipped — code-health) | (skipped — no domain logic) | n/a | (no audit — cleanup PR; build-gate verification subsumes structural review) |
+| data-panels | APPROVED (8c733ac3) — run-1 | APPROVED — run-1 | 5 / 5 | dev/audit/2026-04-26-data-panels.json (carried) |
+| backtest-perf | APPROVED (6f689d62) — run-1 | APPROVED — run-1 | 5 / 5 | dev/audit/2026-04-26-backtest-perf.json (carried) |
+
+Review files unchanged since run-1: `dev/reviews/data-panels.md`, `dev/reviews/backtest-perf.md`. Tip SHAs on both open PRs match Reviewed SHAs → re-QC correctly skipped.
+
+## Budget
+
+- Budget cap: $50.00 (from `dev/config/merge-policy.json`)
+- Target utilization: 60%–80%
+- Subagents dispatched: 1 (code-health)
+- Per-subagent breakdown:
+  | Agent | Model | Status | Est. tokens | Est. cost |
+  |-------|-------|--------|-------------|-----------|
+  | code-health (cleanup csv_storage nesting) | sonnet | completed | ~40K total (29 tool uses, 216s wall) | ~$0.30 |
+- Any subagent killed mid-flight: No
+- Estimated cost this run: ~$0.30 + ~$1.00 orchestrator overhead = **~$1.30 / $50 (3%)**.
+- Measured cost: not yet available — `dev/budget/2026-04-26-run2*.json` is written by the GHA "Capture run cost" step post-orchestrator-exit; refer to that file once present.
+- Utilization assessment: **UNDER_TARGET (<60%)** — but **all-eligible-tracks-dispatched**. No actionable work beyond the one cleanup item:
+  - data-panels: PR #575 in flight, tip == reviewed SHA → no re-dispatch (Step 1.5).
+  - backtest-perf: PR #574 in flight, tip == reviewed SHA → no re-dispatch (Step 1.5).
+  - data-panels Stage 4: explicitly gated on PR #575 merging (would collide on `runner.ml`/`panel_runner.ml`); also the work is large enough (~600 LOC, 3-4 days) that fresh-stack dispatch is not appropriate without plan refinement.
+  - backtest-perf Steps 3+4: gated on PR #574 merging (workflow files would collide).
+  - harness backlog: drained.
+  - ops-data: data-gaps.md unchanged (sentinel skip).
+  - short-side-strategy: practically gated on data-panels Stage 4.
+- Scope reduced due to budget: No.
+
+## Data Operations
+
+(ops-data did not run today — `dev/notes/data-gaps.md` unchanged since 2026-04-14 sentinel skip; verified via `git log --since="$PREV_ISO" -- dev/notes/data-gaps.md` returning empty.)
+
+## Harness Work
+
+(harness-maintainer did not run today — backlog has no dispatchable T1/T3 items; T1 fully done, T2 milestone-gated, T3-C superseded, T3-H low-priority.)
+
+## Health Scan
+
+From `dev/health/2026-04-26-fast-run2.md`:
+- Result: **FINDINGS** (both checks RED on main)
+- Critical items:
+  1. **Build/test gate RED** — nesting linter on `_stream_in_range_prices` (PR #578 fixes; verified clean on the cleanup branch).
+  2. **Status file integrity RED** — `data-panels.md '## Last updated' is not YYYY-MM-DD` (PR #575 fixes).
+- After merging both PRs (#578 + #575), main returns to green. Both PRs are awaiting human merge — orchestrator cannot land them itself (orchestrator-summary auto-merge is for ops/daily-* branches only per `merge-policy.json`'s `auto_merge_enabled: false` for feature PRs).
+
+## Follow-up Queue
+
+(Top-level items only — see per-track status files for full lists.)
+
+- **data-panels**: Stage 4 (callbacks-through-runner; load-bearing memory-win work) is the next dispatch after PR #575 merges.
+- **backtest-perf**: Steps 3+4 (tier-2 nightly workflow, tier-3 weekly workflow). Maintainer must commit held-out `.github/workflows/perf-tier1.yml` from PR #574's body.
+- **cleanup**: Backlog empty after PR #578 lands (subject to next fast-scan / deep-scan findings).
+- **short-side-strategy**: 3 follow-ups (bear-window backtest regression, full short cascade, Ch.11 spot-check) still practically gated on broad-universe scale → data-panels Stage 4.
+- **cost-tracking**: verify `dev/budget/2026-04-26-run*.json` lands with `total_cost_usd`; compare costs pre/post #482 (qc-structural → Haiku).
+
+## Integration Queue
+
+Three PRs awaiting human merge:
+- **#575** — data-panels Stage 3 PR 3.4 (delete Legacy + Loader_strategy enum). −271 LOC. QC APPROVED 5/5 from run-1. Also resolves the data-panels.md integrity violation keeping main RED.
+- **#574** — backtest-perf catalog + tier-1 smoke gate. +280 LOC. QC APPROVED 5/5 from run-1. Held-out `.github/workflows/perf-tier1.yml` needs `workflow`-scoped token.
+- **#578** — cleanup csv_storage nesting (this run). +37 LOC, no behavior change. Resolves the nesting-linter side of the build gate.
+
+Auto-merge remains disabled (`auto_merge_enabled: false` in `dev/config/merge-policy.json`) for feature PRs; orchestrator's own summary PRs auto-merge per Step 8a.
+
+## Current Milestone Target
+
+M5 (backtest infrastructure complete + tunable) — requires data-panels Stage 4 (memory-win materialization) + backtest-perf tiers 1-3 wired in CI.
+
+## Dependency Unlocks
+
+(No new "Interface stable: YES" transitions this run.)
+
+## Escalations
+
+[critical] **Main baseline RED on `dev/lib/run-in-env.sh dune runtest`.** Verbatim from this run (BUILD passed but TEST_EXIT=1; output captured pre-cleanup-branch checkout):
+
+```
+FAIL: nesting linter — 1 function(s) exceed limits:
+
+  avg    max  else why        location                                            function
+  ----------------------------------------------------------------------------------------
+  3.61   9    0    avg+max    analysis/data/storage/csv/lib/csv_storage.ml:180    _stream_in_range_prices
+
+Limits: avg > 3.0, max > 5, nested-else > 0.
+Codebase avg nesting: 1.41  |  833 functions scanned  |  99 files
+```
+
+```
+FAIL: status file integrity linter — malformed or missing fields in dev/status/:
+data-panels.md: '## Last updated' is not YYYY-MM-DD: '2026-04-25 (PR 3.3 pushed)'
+```
+
+Both findings inherited from run-1's [critical]; **both verified per Step 1c** as still real on `main@bb4e4a6`. Both have fix PRs in flight (#578 for nesting, #575 for integrity). After both merge, the build returns to green. PR #578 is the orchestrator's response this run; PR #575 is awaiting human merge from run-1.
+
+Empirical proof for #578's fix: this run checked out the cleanup branch tip and ran `dune build @runtest --force`:
+- Nesting linter: `OK: nesting linter — all 886 functions within limits.` (vs 833 + 1 fail on main)
+- Status file integrity: still FAIL on data-panels.md (orthogonal; #575's territory)
+
+[info] **GHA-path single-working-tree dispatch friction (continued).** code-health agent reported `gh CLI not available in container; URL printed by `git push`` and did not call jst. Step 4.5 fallback (curl-based PR creation) worked correctly and opened #578. The agent's verbal report says it didn't realize jst was on PATH; the agent prompt referenced `jst submit` explicitly but the agent fell back to `git push`. Not a regression — Step 4.5 exists for exactly this case. Long-term fix is per-agent isolated worktrees (tracked in `dev/status/orchestrator-automation.md` §"BG-owns-branch convention").
+
+## Step 1b drift cross-reference
+
+Most recent prior summary `dev/daily/2026-04-26.md` (run-1, committed bb4e4a6 at 2026-04-26T11:38:07Z) was a FULL run with two `awaiting-merge` rows:
+- data-panels (PR #575): still open at the same SHA → not drift, normal lag.
+- backtest-perf (PR #574): still open at the same SHA → not drift, normal lag.
+
+The status file `dev/status/backtest-perf.md` still shows `Status: PENDING` and `Last updated: 2026-04-25` despite the in-flight #574 PR — this is **normal lag, not drift**, because the agent's status-file update is on the PR branch, not main, and main is what the orchestrator reads. Once #574 merges the status-file update lands.
+
+No `[drift]` warnings emitted.
+
+## Step 1c carried-forward critical verification
+
+Prior summary `dev/daily/2026-04-26.md` carried two `[critical]` items:
+
+1. **[critical] Build/test gate RED — nesting on csv_storage.ml**: re-verified this run via `dune build @runtest --force` from `/__w/trading/trading/trading`; exit 1 with the exact same `FAIL: nesting linter ... _stream_in_range_prices avg=3.61 max=9` line. **Still real on main; carried forward** (and addressed by this run's PR #578).
+
+2. **[critical] Status file integrity RED — data-panels.md malformed Last updated**: re-verified this run via the same dune runtest invocation; exit 1 with the same `data-panels.md: '## Last updated' is not YYYY-MM-DD: '2026-04-25 (PR 3.3 pushed)'` line. **Still real on main; carried forward** (PR #575 fixes; awaiting human merge).
+
+Both items verified with verbatim output above per the live-evidence rule. No carried-forward critical was found resolved.
+
+## Per-run links
+
+- [run 1] dev/daily/2026-04-26.md
+- [run 2] dev/daily/2026-04-26-run2.md (this file)
+
+---
+## Your Response
+(Edit this section. Run dev/run.sh after editing to start the next session.)

--- a/dev/health/2026-04-26-fast-run2.md
+++ b/dev/health/2026-04-26-fast-run2.md
@@ -1,0 +1,38 @@
+# Health Report — 2026-04-26 — fast (run-2)
+
+## Summary
+- Main build: FAILING (exit 1)
+- Status file integrity: FAILING (exit 1)
+- Action required: YES (already in flight — PRs #578 + #575 cover both findings)
+
+## Findings (verbatim from this run)
+
+### 1. Nesting linter — RED on main, PR #578 fixes
+
+```
+FAIL: nesting linter — 1 function(s) exceed limits:
+
+  avg    max  else why        location                                            function
+  ----------------------------------------------------------------------------------------
+  3.61   9    0    avg+max    analysis/data/storage/csv/lib/csv_storage.ml:180    _stream_in_range_prices
+
+Limits: avg > 3.0, max > 5, nested-else > 0.
+Codebase avg nesting: 1.41  |  833 functions scanned  |  99 files
+```
+
+Carried forward from `dev/health/2026-04-26-fast.md` (run-1). PR #578 (this run) extracts two `_`-prefixed helpers (`_parse_and_accumulate`, `_read_next_line`) so the loop body becomes a single flat `match`. After-state on the cleanup branch verified empirically (this run): `OK: nesting linter — all 886 functions within limits.` Function will resolve once #578 merges.
+
+### 2. Status file integrity — RED on main, PR #575 fixes
+
+```
+FAIL: status file integrity linter — malformed or missing fields in dev/status/:
+data-panels.md: '## Last updated' is not YYYY-MM-DD: '2026-04-25 (PR 3.3 pushed)'
+```
+
+Carried forward from `dev/health/2026-04-26-fast.md` (run-1). PR #575 (data-panels Stage 3 PR 3.4) sets `## Last updated: 2026-04-26`. Awaiting human merge. **Third recurrence** of the "human-merged PR introduces status-file-template drift" pattern; the structural fix is GitHub branch-protection requiring CI to pass before merge — outside orchestrator scope.
+
+## Metrics
+- Checks run: 2 (deterministic; no agentic fast scan)
+- Build gate: exit 1 (both findings)
+- After-cleanup-branch projection: exit 1 (only data-panels integrity remains; clears on #575 merge)
+- Deep scan: see dev/health/*-deep.md (weekly GHA cron)

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -4,7 +4,7 @@ Single-source view of all tracked work. Update when a status file flips
 state, an owner changes, or a PR opens / merges / closes. Keep the table
 terse; detail belongs in the per-track status files linked in column 1.
 
-Last updated: 2026-04-26 (Stage 3 PR 3.4 of `data-panels` opens on `feat/panels-stage03-pr-d-delete-legacy` as PR #575 — deletes Legacy runner + `Loader_strategy` enum; QC APPROVED structural+behavioral, quality 5/5. `backtest-perf` Steps 1+2 (catalog 15 scenarios into 4 perf tiers + tier-1 smoke gate) opens as PR #574; QC APPROVED structural+behavioral, quality 5/5. Stage 3 PRs 3.1 #567, 3.2 #569, 3.3 #573 all MERGED 2026-04-25/26. Stage 4 (callbacks-through-runner wiring; load-bearing memory-win work per `dev/notes/panels-rss-spike-2026-04-25.md`) is the next dispatch.)
+Last updated: 2026-04-26-run2 (cleanup PR #578 opens on `cleanup/csv-storage-nesting` — extracts two `_`-prefixed helpers in `csv_storage.ml:_stream_in_range_prices` to flatten nesting; no behavior change, ~37 LOC. Verified empirically on the cleanup branch: `OK: nesting linter — all 886 functions within limits` (was: 833 + 1 fail). Build gate still exits 1 on main due to the unrelated `data-panels.md` `## Last updated:` integrity violation, which PR #575 fixes — that PR remains awaiting human merge. data-panels Stage 3 PR 3.4 (#575) and backtest-perf catalog (#574) both unchanged since run-1: tip SHAs match Reviewed SHAs in `dev/reviews/*` so re-QC was correctly skipped per Step 1.5.)
 
 ## Active + complete tracks
 
@@ -23,7 +23,7 @@ Each row: one line; deeper task detail in the linked status file.
 | [sector-data](sector-data.md) | MERGED | — | — | — (#436 merged 2026-04-19). GHA orchestrator runs continue to consume `trading/test_data/sectors.csv`. |
 | [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | No open harness PR. Recent merges: #493 POSIX-sh linter, #495 cost-capture new-day fix, #499 cost-capture commit+auto-merge, #504 budget PR creation via curl, #505 budget rescue (all 2026-04-22). Backlog remains saturated — T1 done; T2 milestone-gated; T3-C superseded; T3-H low-priority. Recurring status-file integrity drift from human-merged PRs is a [info] follow-up — linter already exits 1 on violation; requires branch-protection config to enforce. |
 | [orchestrator-automation](orchestrator-automation.md) | IN_PROGRESS | harness-adjacent | — | Phase 1 live (daily cron runs producing summary PRs). Phase 2 (background execution for scrapers, golden re-runs, cross-feature QC) pending empirical tests per status file. |
-| [cleanup](cleanup.md) | IN_PROGRESS | code-health | — | Backlog remains empty (no new medium/high findings from latest deep scan or today's fast health check). No code-health dispatch this run. |
+| [cleanup](cleanup.md) | IN_PROGRESS | code-health | #578 (csv_storage nesting fix on `cleanup/csv-storage-nesting`) | Item `[~]` in flight: `_stream_in_range_prices` nested-match cleanup. PR #578 opened this run (run-2); helper-extraction approach. Awaiting human merge. After merge: backlog empty until next health-scan finding. |
 | [cost-tracking](cost-tracking.md) | IN_PROGRESS | harness-maintainer | — | GHA cost capture step landed (#483). Cost-capture new-day bug fixed via #495 + #499 (both 2026-04-22). Next: verify measured `total_cost_usd` now lands correctly on this run's `dev/budget/2026-04-22-run3.json`; compare costs pre/post #481/#482/#495/#499. |
 | [data-layer](data-layer.md) | MERGED | — | — | — |
 | [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |


### PR DESCRIPTION
Measured GHA orchestrator run cost for `2026-04-26-24960244278`.

`total_cost_usd`: $6.5786 (from `claude-code-action` execution_file, fallback branch 1b — see `dev/status/cost-tracking.md`).

Auto-merge: ops category, single-file additive change.