### PR TITLE
docs(backtest-perf): track release_perf_report OCaml exe as Step 5

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -93,6 +93,16 @@ mechanics + release-gate procedure.
 4. After ~10 PR cycles of tier-1 perf data: pin per-cell budgets and
    flip `continue-on-error: false` on `perf-tier1.yml` and
    `PERF_CATALOG_CHECK_STRICT=1` on the catalog check.
+5. **`release_perf_report` OCaml exe.** Markdown report comparing the
+   current release's tier-3/4 scenario results vs the prior release —
+   N×T peak-RSS matrix, wall-time matrix, regression flags. Drives
+   release-gate Step 3 in `dev/plans/perf-scenario-catalog-2026-04-25.md`.
+   Replaces the deleted `dev/scripts/perf_sweep_report.py` (Legacy-vs-
+   Tiered axis is gone post-PR #575; need single-mode N×T tables instead).
+   Per `.claude/rules/no-python.md`: write fresh in OCaml, do not port.
+   Lands together with or just before tier-3 weekly workflow (Step 2)
+   so the weekly run produces a useful diff vs the prior week. ~150 LOC
+   exe + .mli + tests.
 
 ## Ownership
 


### PR DESCRIPTION
## Summary

Adds an explicit Step 5 to `dev/status/backtest-perf.md` `## Next steps`: build a `release_perf_report` OCaml exe that produces a Markdown N×T peak-RSS / wall-time matrix + regression flags. Drives release-gate Step 3 in `dev/plans/perf-scenario-catalog-2026-04-25.md`.

## Why

Replaces the deleted `dev/scripts/perf_sweep_report.py` (per PR #582). The Python's value-add was the 2D N×T matrix × 2 strategies; the "× 2 strategies" axis is gone post-#575 (Legacy + Tiered both deleted). Single-mode N×T tables are still useful for tier-3 weekly + tier-4 release-gate runs.

Per `.claude/rules/no-python.md`: write fresh in OCaml; do not port the Python.

## Scheduling

Lands together with or just before the tier-3 weekly workflow (currently Step 2 in the same `## Next steps`) so the weekly run produces a useful diff vs the prior week. Estimated ~150 LOC exe + .mli + tests.

## Test plan

- [x] No code change; `dune build && dune runtest` unaffected
- [x] `status_file_integrity` linter still passes (status file structure preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)