### PR TITLE
cleanup(status): repair backtest-perf.md schema (Status + Interface s…

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -3,10 +3,12 @@
 ## Last updated: 2026-04-26
 
 ## Status
-IN_PROGRESS — Steps 1+2 done on `feat/backtest-perf-tier1-catalog`; PR open for review. The `perf-tier1.yml` workflow file is **held out of this PR** (agent PAT lacks `workflow` scope) — needs maintainer follow-up to commit the drafted YAML. Steps 3+4 (tier-2 nightly + tier-3 weekly workflows) outstanding and have the same scope-blocker.
+IN_PROGRESS
+
+Steps 1+2 done on `feat/backtest-perf-tier1-catalog`; PR open for review. The `perf-tier1.yml` workflow file is **held out of this PR** (agent PAT lacks `workflow` scope) — needs maintainer follow-up to commit the drafted YAML. Steps 3+4 (tier-2 nightly + tier-3 weekly workflows) outstanding and have the same scope-blocker.
 
 ## Interface stable
-N/A
+NO
 
 ## Goal
 


### PR DESCRIPTION
…table)

The status_file_integrity linter (devtools/checks/status_file_integrity.sh) requires:
- `## Status` value to be exactly one of IN_PROGRESS | READY_FOR_REVIEW | APPROVED | MERGED | BLOCKED | PENDING.
- `## Interface stable` to be YES | NO; N/A only valid when Status is PENDING.

backtest-perf.md violated both: the Status line bundled an IN_PROGRESS-and-then-paragraph (failing the enum check) and Interface stable was N/A despite Status=IN_PROGRESS. Both have been on `main` since #574 landed and were tripping `dune runtest`.

Fix: keep `## Status` to the keyword IN_PROGRESS, move the in-flight detail to a paragraph below the keyword (matches the convention used by sibling status docs like `data-panels.md`). Set `## Interface stable` to NO since the perf-catalog interface is still evolving (tier definitions, gate thresholds).

Verify: `bash devtools/checks/status_file_integrity.sh` → OK.