### PR TITLE
cleanup(panels): flatten macro_callbacks_of_weekly_views nesting

### DIFF
--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
@@ -178,30 +178,27 @@ let _compute_momentum_ma_scalar ~momentum_period (ad_bars : Macro.ad_bar list) :
 let _get_ad_momentum_ma (ma : float option) : week_offset:int -> float option =
  fun ~week_offset -> if week_offset = 0 then ma else None
 
+let _named_global_stage (config : Macro.config)
+    ((name, view) : string * Bar_panels.weekly_view) : string * Stage.callbacks
+    =
+  (name, stage_callbacks_of_weekly_view ~config:config.stage_config ~weekly:view)
+
 let macro_callbacks_of_weekly_views ~(config : Macro.config)
     ~(index : Bar_panels.weekly_view)
     ~(globals : (string * Bar_panels.weekly_view) list)
     ~(ad_bars : Macro.ad_bar list) : Macro.callbacks =
-  let index_stage =
-    stage_callbacks_of_weekly_view ~config:config.stage_config ~weekly:index
-  in
   let cum_ad_arr = _build_cumulative_ad_array ad_bars in
   let ma_scalar =
     _compute_momentum_ma_scalar
       ~momentum_period:config.indicator_thresholds.momentum_period ad_bars
   in
-  let global_index_stages =
-    List.map globals ~f:(fun (name, view) ->
-        ( name,
-          stage_callbacks_of_weekly_view ~config:config.stage_config
-            ~weekly:view ))
-  in
   {
-    index_stage;
+    index_stage =
+      stage_callbacks_of_weekly_view ~config:config.stage_config ~weekly:index;
     get_index_close = _get_from_float_array index.closes;
     get_cumulative_ad = _get_from_float_array cum_ad_arr;
     get_ad_momentum_ma = _get_ad_momentum_ma ma_scalar;
-    global_index_stages;
+    global_index_stages = List.map globals ~f:(_named_global_stage config);
   }
 
 (* ------------------------------------------------------------------ *)


### PR DESCRIPTION
Stage 4 PR-A (#584) tripped the nesting linter (max=5 limit) at depth 6 on `Panel_callbacks.macro_callbacks_of_weekly_views`: the chain of let-bindings plus the inner `List.map ~f:(fun (name, view) -> (name, ...))` stacked indentation past the cap. Added pre-emptive nesting fix to PR-A's local branch but #584 squash-merged before the fixup pushed; surfacing it now as a separate cleanup so `dune runtest` is green on main.

Approach: extract the per-pair builder into `_named_global_stage`, so the call site collapses to `List.map globals ~f:(_named_global_stage config)`. Inline the few one-shot let-bindings (`index_stage`, `global_index_stages`) into the record literal. Behaviour unchanged — same float kernels, same fold order. Parity gates (test_panel_loader_parity round_trips, test_panel_callbacks 6 tests, test_weinstein_strategy{,_smoke}, test_weinstein_backtest) still hold.

Verify (in /workspaces/trading-1/trading): TRADING_DATA_DIR=$PWD/test_data dune build && dune runtest. Nesting linter clean (898 functions OK).

Pre-existing failure on main: status_file_integrity linter on backtest-perf.md (unrelated, addressed separately).