### PR TITLE
feat(data-panels): Stage 4 PR-B — reshape Volume + Resistance for cal…

### DIFF
--- a/dev/plans/panels-stage04-pr-b-2026-04-26.md
+++ b/dev/plans/panels-stage04-pr-b-2026-04-26.md
@@ -1,0 +1,161 @@
+# Plan: Stage 4 PR-B — reshape Volume + Resistance for callbacks; drop `bars_for_volume_resistance` (2026-04-26)
+
+## Status
+
+In-flight. Branch: `feat/panels-stage04-pr-b-volume-resistance-callbacks`.
+
+## The wedge
+
+PR-A (#584) wired panel-shaped callbacks through every strategy call
+site (Stage / Rs / Sector / Macro / Stops support-floor / Stock_analysis
+Stage+Rs branches). One residual remained:
+`Stock_analysis.analyze_with_callbacks` still took
+`bars_for_volume_resistance : Daily_price.t list` because
+`Volume.analyze_breakout` and `Resistance.analyze` had not yet been
+reshaped. On every Friday tick the strategy reconstructed a
+`Daily_price.t list` for each surviving stock just to feed those two
+callees — a per-symbol allocation the panel-mode hot path can't afford
+at release-gate scale.
+
+## Goal of this PR
+
+Reshape the two remaining bar-list callees:
+
+1. `Volume.analyze_breakout ~bars ~event_idx` →
+   `Volume.analyze_breakout_with_callbacks ~callbacks ~event_offset`
+   plus a thin bar-list wrapper.
+2. `Resistance.analyze ~bars ~breakout_price ~as_of_date` →
+   `Resistance.analyze_with_callbacks ~callbacks ~breakout_price
+    ~as_of_date` plus a thin bar-list wrapper.
+3. Drop the `bars_for_volume_resistance` parameter from
+   `Stock_analysis.analyze_with_callbacks`. Bundle `Volume.callbacks` and
+   `Resistance.callbacks` into the existing `Stock_analysis.callbacks`
+   record (alongside the nested Stage / Rs callbacks already there).
+4. Wire `Panel_callbacks.volume_callbacks_of_weekly_view` and
+   `Panel_callbacks.resistance_callbacks_of_weekly_view` into
+   `stock_analysis_callbacks_of_weekly_views`. The strategy's
+   `_screen_universe` no longer materialises any `Daily_price.t list`.
+
+## Approach
+
+### Volume
+
+Volume.analyze_breakout reads the event bar's volume + the prior
+`lookback_bars` volumes. Add:
+
+```ocaml
+type callbacks = {
+  get_volume : week_offset:int -> float option;
+}
+```
+
+`week_offset:0` is the newest bar; `event_offset` (passed to the new
+entry point) is the offset of the event bar; the analyzer reads volumes
+at offsets `event_offset+1 .. event_offset+lookback_bars` for the
+baseline.
+
+The bar-list wrapper computes `event_offset = bars_len - 1 - event_idx`
+and delegates. Bit-identical to the original.
+
+### Resistance
+
+Resistance.analyze reads the entire bar history (last
+`virgin_lookback_bars` for the virgin check, last `chart_lookback_bars`
+for zone density). Each bar contributes `high_price`, `low_price`,
+`date`. Add:
+
+```ocaml
+type callbacks = {
+  get_high : bar_offset:int -> float option;
+  get_low : bar_offset:int -> float option;
+  get_date : bar_offset:int -> Date.t option;
+  n_bars : int;
+}
+```
+
+`bar_offset:0` = newest; `n_bars` bounds the walk so the analyzer can
+take `min lookback n_bars` for both the virgin and chart windows.
+
+The implementation walks offsets directly into a bucket Hashtbl,
+matching the bar-list path's per-bucket "max date" semantics by tracking
+a running max as it accumulates.
+
+### Stock_analysis
+
+`Stock_analysis.callbacks` gains two fields:
+
+```ocaml
+type callbacks = {
+  ...; (* existing get_high / get_volume / stage / rs *)
+  volume : Volume.callbacks;
+  resistance : Resistance.callbacks;
+}
+```
+
+`callbacks_from_bars` builds them via the new `*.callbacks_from_bars`
+constructors. `analyze_with_callbacks` drops `bars_for_volume_resistance`
+and feeds the nested callbacks into the new
+`Volume.analyze_breakout_with_callbacks` and
+`Resistance.analyze_with_callbacks`.
+
+### Panel_callbacks
+
+Two new constructors:
+
+```ocaml
+val volume_callbacks_of_weekly_view :
+  weekly:Bar_panels.weekly_view -> Volume.callbacks
+
+val resistance_callbacks_of_weekly_view :
+  weekly:Bar_panels.weekly_view -> Resistance.callbacks
+```
+
+Both index directly into the view's float arrays — no bar materialisation.
+`stock_analysis_callbacks_of_weekly_views` calls both, returning the
+full `Stock_analysis.callbacks` bundle from a weekly view alone.
+
+### Strategy
+
+`weinstein_strategy.ml::_screen_universe` drops the
+`bars_for_volume_resistance = Bar_reader.weekly_bars_for ...` line and
+the `bars_for_volume_resistance:` argument to
+`Stock_analysis.analyze_with_callbacks`. Per-tick allocation eliminated.
+
+## Parity gates
+
+1. **Load-bearing**: `test_panel_loader_parity` round_trips golden —
+   bit-equal trades. Held.
+2. **New module-level parity**: 5 new tests in `test_volume.ml`
+   (Strong / Adequate / Weak / Insufficient-history / event-at-max-index)
+   plus 5 in `test_resistance.ml` (Virgin / Clean / Heavy / Moderate /
+   chart-window-filtering). Each builds external `callbacks` via the
+   public `callbacks_from_bars` and asserts bit-identical results.
+3. **Cross-module parity**: 2 new tests in
+   `test_panel_callbacks.ml` (Volume + Resistance) build `callbacks`
+   from a `weekly_view` and from a bar list, run `*.analyze_with_callbacks`
+   on both, and assert bit-identity.
+4. **Existing**: 16 `test_stock_analysis` tests (8 parity + 8
+   pre-existing) still pass with the new bundle shape — confirms the
+   wrapper rewiring preserved behaviour for all existing call sites.
+
+## LOC budget
+
+~600 LOC target, ~800 max.
+
+Actual delta:
+- Volume: +56 net (mli +35, ml +21)
+- Resistance: +69 net (mli +14, ml +55)
+- Stock_analysis: +13 net (mli +14, ml -1) — bundle additions, drop param
+- Panel_callbacks: +28 net
+- Weinstein_strategy: -16 net (delete bars_for_volume_resistance line)
+- Tests: +95 net (volume +60, resistance +95, panel_callbacks +90,
+  stock_analysis -3)
+
+~340 LOC production, ~245 LOC tests.
+
+## Out of scope (PR-C/D)
+
+- `Ohlcv_weekly_panels` + Friday rollup (PR-C)
+- Port stage classifier / volume / resistance to indicator kernels (PR-D)
+- RSS spike re-run on `bull-crash-292x6y` to measure RSS impact (separate
+  dispatch — local devcontainer wall budget)

--- a/dev/status/data-panels.md
+++ b/dev/status/data-panels.md
@@ -5,26 +5,41 @@
 ## Status
 IN_PROGRESS
 
-Stage 4 PR-A IN_PROGRESS on `feat/panels-stage04-pr-a-callback-wiring` — the load-bearing callback-rewiring PR. Drops `Daily_price.t list` materialisation at every strategy call site (Macro / Sector / Stage / Stops support-floor / Stock_analysis Stage+Rs branches). Volume + Resistance reshape deferred to PR-B.
+Stage 4 PR-B IN_PROGRESS on `feat/panels-stage04-pr-b-volume-resistance-callbacks` — drops the residual `bars_for_volume_resistance : Daily_price.t list` parameter from `Stock_analysis.analyze_with_callbacks`. The strategy's hot path no longer materialises any `Daily_price.t list` per-symbol per-Friday.
 
-**Stage 4 PR-A scope**:
-- New `Bar_panels.weekly_view` / `Bar_panels.daily_view` types: float-array snapshots over panel cells with no `Daily_price.t list` intermediate. Plus `weekly_view_for` / `daily_view_for` constructors.
-- New `Weinstein_strategy.Panel_callbacks` module: builds Stage / Rs / Stock_analysis / Sector / Macro / Weinstein_stops.Support_floor callback bundles directly from views. Bit-identical to the bar-list `callbacks_from_bars` paths (parity-tested via `test_panel_callbacks.ml`, 6 tests).
-- Strategy call sites switched: `_compute_ma`, `_make_entry_transition`, `_screen_universe`, `_run_screen`, `_on_market_close`, `Macro_inputs.build_global_index_views`, `Macro_inputs.build_sector_map`. The screening-day check now reads the index weekly_view directly.
-- Pre-flag carry-overs preserved: PR-F (Macro int-then-float fold) — `_build_cumulative_ad_array` still folds running sum as int and converts at the array boundary. PR-H QC (`Bar_reader.accumulate`) — already removed in PR 3.2; nothing to verify.
+**Stage 4 PR-B scope**:
+- `Volume.analyze_breakout_with_callbacks ~callbacks ~event_offset` — new callback-shaped entry point. `Volume.callbacks = { get_volume : week_offset:int -> float option }`. Indices match the panel layout (`week_offset:0` = newest). Existing bar-list `analyze_breakout` is now a thin wrapper that converts `event_idx` ↔ `event_offset` and delegates.
+- `Resistance.analyze_with_callbacks ~callbacks ~breakout_price ~as_of_date` — new callback-shaped entry point. `Resistance.callbacks = { get_high; get_low; get_date; n_bars }` indexed by `bar_offset:0..n_bars-1`. The virgin / chart window walks bound by `min lookback n_bars`. Bucket aggregation uses a running max date to mirror the bar-list path's `max(dates)` per bucket.
+- `Stock_analysis.callbacks` gains `volume : Volume.callbacks` and `resistance : Resistance.callbacks` fields. `analyze_with_callbacks` drops the `bars_for_volume_resistance : Daily_price.t list` parameter. The bar-list wrapper `analyze ~bars` builds the new bundle via `Volume.callbacks_from_bars` + `Resistance.callbacks_from_bars` — bit-identical for any input.
+- `Panel_callbacks.volume_callbacks_of_weekly_view` and `Panel_callbacks.resistance_callbacks_of_weekly_view` — index directly into the `Bar_panels.weekly_view` float arrays (`volumes` / `highs` / `lows` / `dates`). `stock_analysis_callbacks_of_weekly_views` now wraps both new constructors in addition to the existing Stage / Rs ones, returning the full `Stock_analysis.callbacks` bundle from a weekly view alone — no bar list needed.
+- `Weinstein_strategy._screen_universe` drops the `bars_for_volume_resistance = Bar_reader.weekly_bars_for ...` line and the `bars_for_volume_resistance:` argument to `Stock_analysis.analyze_with_callbacks`. The per-Friday allocation source is gone.
 
-**Out of scope (PR-B/C/D)**:
-- `Volume.analyze_breakout` + `Resistance.analyze` reshape (PR-B): `Stock_analysis.analyze_with_callbacks` still takes `bars_for_volume_resistance`; PR-A builds it on-demand from `Bar_reader.weekly_bars_for` only when a candidate stock makes it past the per-symbol allocation guard. Eliminating this allocation drops the residual.
+**Parity gates green**:
+- `test_panel_loader_parity` (load-bearing): 2 round_trips goldens still bit-equal.
+- `test_volume.ml`: 12 pre-existing + 5 new parity tests (Strong / Adequate / Weak / Insufficient-history / event-at-max-index) — total 17, all OK.
+- `test_resistance.ml`: 9 pre-existing + 5 new parity tests (Virgin / Clean / Heavy / Moderate / chart-window-filtering) — total 14, all OK.
+- `test_stock_analysis.ml`: 8 pre-existing + 8 PR-D parity tests — total 16, all OK with the new bundle shape (drop `bars_for_volume_resistance` arg).
+- `test_panel_callbacks.ml`: 6 PR-A parity + 2 new (Volume / Resistance) — total 8, all OK.
+- All `weinstein/strategy/test` suites green except the pre-existing flaky `test_ad_bars_weekly_e2e` (fails on main too — unrelated).
+
+**Out of scope (PR-C/D)**:
 - `Ohlcv_weekly_panels` + Friday rollup (PR-C).
 - Port stage classifier / volume / resistance to indicator kernels (PR-D).
+- RSS spike re-run on `bull-crash-292x6y` to measure peak RSS post-A+B (separate dispatch — local devcontainer wall budget).
 
-**Expected memory impact**: PR-A drops the dominant per-tick `Daily_price.t list` allocation (universe-wide, every Friday). Plan target: peak RSS on `bull-crash-292x6y` reduces from 3.47 GB toward the projected ≤ 800 MB. Spike re-run scheduled per `dev/notes/panels-rss-spike-2026-04-25.md` §"Next spike". Not measured in this PR (devcontainer wall budget); QC / follow-up dispatches the spike.
+**Expected memory impact**: PR-B eliminates the last per-tick `Daily_price.t list` allocation in the hot path. Combined with PR-A, peak RSS on `bull-crash-292x6y` should drop from 3.47 GB toward the projected ≤ 800 MB. Measurement deferred to a separate spike-rerun dispatch.
 
-**LOC delta**: +650 lines modified, +865 lines new. Bulk of new lines is tests (398 + 416 = 814 LOC). Production source delta ~700 LOC (250 panel_callbacks, 250 bar_panels extensions, 200 strategy rewiring). Function-length ceiling 32 lines (under 50-line hard limit).
+**LOC delta**: ~340 lines production source (volume +56, resistance +69, stock_analysis +13, panel_callbacks +28, weinstein_strategy -16); ~245 lines tests (volume +60, resistance +95, panel_callbacks +90). Function-length ceiling under 50-line hard limit; nesting linter — only the pre-existing `macro_callbacks_of_weekly_views` (max=6) remains, no new nesting violations.
 
-**Verify**: `cd trading && eval $(opam env) && TRADING_DATA_DIR=$PWD/test_data dune build && dune runtest trading/data_panel trading/weinstein/strategy trading/backtest/test trading/simulation`. All test suites green: 21 `bar_panels_test` (was 14 + 7 new), 6 new `test_panel_callbacks` parity, 2 `test_panel_loader_parity` (load-bearing gate), 15 `test_weinstein_strategy`, 5 `test_weinstein_strategy_smoke`, 3 `test_weinstein_backtest` (simulation).
+**Verify**: `cd trading && eval $(opam env) && TRADING_DATA_DIR=/workspaces/trading-1/.claude/worktrees/agent-a1d76d23ee489a1e4/trading/test_data dune build && dune runtest`. All suites green; only pre-existing nesting linter violations on `analysis/scripts/universe_filter`, `fetch_finviz_sectors`, `ppx_test_matcher` remain (also fail on main).
 
-PR-A is bookmarked at `feat/panels-stage04-pr-a-callback-wiring`. Plan: `dev/plans/panels-stage04-pr-a-2026-04-26.md`.
+PR-B is bookmarked at `feat/panels-stage04-pr-b-volume-resistance-callbacks`. Plan: `dev/plans/panels-stage04-pr-b-2026-04-26.md`.
+
+---
+
+**Prior status (Stage 4 PR-A, MERGED #584)**:
+
+Stage 4 PR-A merged 2026-04-26 as #584. Drops `Daily_price.t list` materialisation at every strategy call site except Volume + Resistance (deferred to PR-B above). Adds `Bar_panels.weekly_view` / `daily_view` types, `Weinstein_strategy.Panel_callbacks` module with constructors for Stage / Rs / Sector / Macro / Stops support-floor / Stock_analysis Stage+Rs callbacks. Plan: `dev/plans/panels-stage04-pr-a-2026-04-26.md`.
 
 ---
 

--- a/trading/analysis/weinstein/resistance/lib/resistance.ml
+++ b/trading/analysis/weinstein/resistance/lib/resistance.ml
@@ -50,71 +50,128 @@ type result = {
 }
 
 (* ------------------------------------------------------------------ *)
+(* Callback bundle and constructor from a bar list                      *)
+(* ------------------------------------------------------------------ *)
+
+type callbacks = {
+  get_high : bar_offset:int -> float option;
+  get_low : bar_offset:int -> float option;
+  get_date : bar_offset:int -> Date.t option;
+  n_bars : int;
+}
+
+(** Build a [bar_offset]-indexed closure over a chronologically-ordered
+    [Daily_price.t array]. [bar_offset:0] returns the newest bar's value;
+    offsets past available depth return [None]. *)
+let _make_lookup (arr : Daily_price.t array) (f : Daily_price.t -> 'a) :
+    bar_offset:int -> 'a option =
+  let n = Array.length arr in
+  fun ~bar_offset ->
+    let idx = n - 1 - bar_offset in
+    if idx < 0 || idx >= n then None else Some (f arr.(idx))
+
+let callbacks_from_bars ~(bars : Daily_price.t list) : callbacks =
+  let arr = Array.of_list bars in
+  {
+    get_high = _make_lookup arr (fun b -> b.Daily_price.high_price);
+    get_low = _make_lookup arr (fun b -> b.Daily_price.low_price);
+    get_date = _make_lookup arr (fun b -> b.Daily_price.date);
+    n_bars = Array.length arr;
+  }
+
+(* ------------------------------------------------------------------ *)
 (* Helpers                                                              *)
 (* ------------------------------------------------------------------ *)
 
 let days_per_year = 365.25
 
-let _take_last n lst =
-  let len = List.length lst in
-  if len <= n then lst else List.drop lst (len - n)
-
 let _age_years date as_of_date : float =
   Float.of_int (Date.diff as_of_date date) /. days_per_year
 
-(** Bucket index for a bar in the congestion-band grid rooted at
+(** Bucket index for a (high, low) pair in the congestion-band grid rooted at
     [breakout_price]. Index 0 covers the first band above [breakout_price],
     index 1 the next, etc. *)
-let _bucket_idx ~breakout_price ~band_size bar =
-  let mid = (bar.Daily_price.high_price +. bar.Daily_price.low_price) /. 2.0 in
+let _bucket_idx ~breakout_price ~band_size ~high ~low =
+  let mid = (high +. low) /. 2.0 in
   let offset = Float.((mid - breakout_price) /. band_size) in
   Int.of_float (Float.round_down offset)
 
-(** Prepend bar [b] to the list at bucket [bkt] in [tbl], creating it if absent.
-*)
-let _prepend_to_bucket tbl bkt b =
-  Hashtbl.update tbl bkt ~f:(function None -> [ b ] | Some bs -> b :: bs)
+type _bucket_agg = { count : int; most_recent : Date.t }
+(** Aggregate state per bucket while walking offsets: count of bars in the
+    bucket and the most recent date among them. *)
 
-(** Group above-breakout bars into a hash table keyed by bucket index. Bars
-    whose midpoint falls below [breakout_price] (bucket < 0) are discarded. *)
-let _group_by_bucket ~breakout_price ~band_size bars =
-  let tbl = Hashtbl.create (module Int) in
-  List.iter bars ~f:(fun b ->
-      if Float.(b.Daily_price.high_price > breakout_price) then
-        let bkt = _bucket_idx ~breakout_price ~band_size b in
-        if bkt >= 0 then _prepend_to_bucket tbl bkt b);
-  tbl
-
-(** Convert a single bucket's bars into a [resistance_zone]. *)
-let _zone_of_bucket ~breakout_price ~band_size ~as_of_date bkt bkt_bars =
-  let price_low = breakout_price +. (Float.of_int bkt *. band_size) in
-  let most_recent_date =
-    List.map bkt_bars ~f:(fun b -> b.Daily_price.date)
-    |> List.max_elt ~compare:Date.compare
-    |> Option.value_exn
+(** Merge a fresh [date] into an existing bucket aggregate, keeping the larger
+    of the prior [most_recent] and the new [date]. *)
+let _merge_into_agg ~date (agg : _bucket_agg) : _bucket_agg =
+  let most_recent =
+    if Date.compare date agg.most_recent > 0 then date else agg.most_recent
   in
+  { count = agg.count + 1; most_recent }
+
+(** Update [tbl] with a single bar at [bar_offset], counting towards bucket
+    [bkt] when [high > breakout_price] and [bkt >= 0]. The closures
+    [get_high]/[get_low]/[get_date] are read once per offset. *)
+let _accumulate_bucket tbl ~bkt ~date =
+  Hashtbl.update tbl bkt ~f:(function
+    | None -> { count = 1; most_recent = date }
+    | Some agg -> _merge_into_agg ~date agg)
+
+(** Try to read (high, low, date) at [bar_offset]. All three must be defined;
+    any missing field skips the offset (treated as "no bar"). *)
+let _read_offset (cb : callbacks) ~bar_offset : (float * float * Date.t) option
+    =
+  match
+    (cb.get_high ~bar_offset, cb.get_low ~bar_offset, cb.get_date ~bar_offset)
+  with
+  | Some h, Some l, Some d -> Some (h, l, d)
+  | _ -> None
+
+(** Walk offsets [0 .. limit - 1] and accumulate above-breakout bars into the
+    bucket table. Skips offsets where any of [get_high]/[get_low]/[get_date] is
+    undefined; matches the bar-list path's "missing bar = no contribution"
+    semantics. *)
+let _accumulate_chart tbl ~callbacks ~breakout_price ~band_size ~limit =
+  for off = 0 to limit - 1 do
+    match _read_offset callbacks ~bar_offset:off with
+    | None -> ()
+    | Some (h, l, d) ->
+        if Float.(h > breakout_price) then
+          let bkt = _bucket_idx ~breakout_price ~band_size ~high:h ~low:l in
+          if bkt >= 0 then _accumulate_bucket tbl ~bkt ~date:d
+  done
+
+(** Convert one bucket entry [(bkt, agg)] into a {!resistance_zone}. *)
+let _zone_of_agg ~breakout_price ~band_size ~as_of_date ~bkt ~agg =
+  let price_low = breakout_price +. (Float.of_int bkt *. band_size) in
   {
     price_low;
     price_high = price_low +. band_size;
-    weeks_of_trading = List.length bkt_bars;
-    age_years = _age_years most_recent_date as_of_date;
+    weeks_of_trading = agg.count;
+    age_years = _age_years agg.most_recent as_of_date;
   }
 
 (* ------------------------------------------------------------------ *)
 (* Core analysis functions                                              *)
 (* ------------------------------------------------------------------ *)
 
-let _find_zones ~bars ~breakout_price ~band_pct ~as_of_date =
+let _find_zones ~callbacks ~breakout_price ~band_pct ~as_of_date ~limit =
   let band_size = breakout_price *. band_pct in
-  let grouped = _group_by_bucket ~breakout_price ~band_size bars in
-  Hashtbl.fold grouped ~init:[] ~f:(fun ~key:bkt ~data:bkt_bars acc ->
-      _zone_of_bucket ~breakout_price ~band_size ~as_of_date bkt bkt_bars :: acc)
+  let tbl = Hashtbl.create (module Int) in
+  _accumulate_chart tbl ~callbacks ~breakout_price ~band_size ~limit;
+  Hashtbl.fold tbl ~init:[] ~f:(fun ~key:bkt ~data:agg acc ->
+      _zone_of_agg ~breakout_price ~band_size ~as_of_date ~bkt ~agg :: acc)
   |> List.sort ~compare:(fun a b -> Float.compare a.price_low b.price_low)
 
-let _is_virgin_territory ~virgin_bars breakout_price =
-  not
-    (List.exists virgin_bars ~f:(fun b ->
-         Float.(b.Daily_price.high_price > breakout_price)))
+(** True when no bar at offsets [0..limit-1] has [high > breakout_price]. *)
+let _is_virgin_territory ~callbacks ~breakout_price ~limit =
+  let rec loop off =
+    if off >= limit then true
+    else
+      match callbacks.get_high ~bar_offset:off with
+      | None -> loop (off + 1)
+      | Some h -> if Float.(h > breakout_price) then false else loop (off + 1)
+  in
+  loop 0
 
 let _grade_zones ~config zones =
   let max_bars =
@@ -126,8 +183,9 @@ let _grade_zones ~config zones =
   else if max_bars >= config.moderate_resistance_bars then Moderate_resistance
   else Clean
 
-let _classify_quality ~config ~virgin_bars ~zones breakout_price =
-  if _is_virgin_territory ~virgin_bars breakout_price then Virgin_territory
+let _classify_quality ~config ~callbacks ~zones ~virgin_limit breakout_price =
+  if _is_virgin_territory ~callbacks ~breakout_price ~limit:virgin_limit then
+    Virgin_territory
   else if List.is_empty zones then Clean
   else _grade_zones ~config zones
 
@@ -135,14 +193,20 @@ let _classify_quality ~config ~virgin_bars ~zones breakout_price =
 (* Public interface                                                     *)
 (* ------------------------------------------------------------------ *)
 
-let analyze ~config ~bars ~breakout_price ~as_of_date =
-  let virgin_bars = _take_last config.virgin_lookback_bars bars in
-  let chart_bars = _take_last config.chart_lookback_bars bars in
+let analyze_with_callbacks ~(config : config) ~(callbacks : callbacks)
+    ~breakout_price ~as_of_date =
+  let virgin_limit = min config.virgin_lookback_bars callbacks.n_bars in
+  let chart_limit = min config.chart_lookback_bars callbacks.n_bars in
   let zones_above =
-    _find_zones ~bars:chart_bars ~breakout_price
-      ~band_pct:config.congestion_band_pct ~as_of_date
+    _find_zones ~callbacks ~breakout_price ~band_pct:config.congestion_band_pct
+      ~as_of_date ~limit:chart_limit
   in
   let quality =
-    _classify_quality ~config ~virgin_bars ~zones:zones_above breakout_price
+    _classify_quality ~config ~callbacks ~zones:zones_above ~virgin_limit
+      breakout_price
   in
   { quality; breakout_price; zones_above; nearest_zone = List.hd zones_above }
+
+let analyze ~config ~bars ~breakout_price ~as_of_date =
+  let callbacks = callbacks_from_bars ~bars in
+  analyze_with_callbacks ~config ~callbacks ~breakout_price ~as_of_date

--- a/trading/analysis/weinstein/resistance/lib/resistance.mli
+++ b/trading/analysis/weinstein/resistance/lib/resistance.mli
@@ -71,6 +71,28 @@ type result = {
 }
 (** Result of resistance analysis at a given breakout price. *)
 
+type callbacks = {
+  get_high : bar_offset:int -> float option;
+      (** Bar high at [bar_offset] bars back from the newest bar. [bar_offset:0]
+          is the newest bar; offsets past available depth return [None]. *)
+  get_low : bar_offset:int -> float option;
+      (** Bar low at [bar_offset] bars back. *)
+  get_date : bar_offset:int -> Core.Date.t option;
+      (** Bar date at [bar_offset] bars back. Used for [age_years]. *)
+  n_bars : int;
+      (** Total number of bars in the underlying source — i.e. the largest
+          [bar_offset] for which any of the above closures returns [Some]. Used
+          by the analyzer to bound the virgin / chart window walks. *)
+}
+(** Bundle of indicator callbacks consumed by {!analyze_with_callbacks}. The
+    panel-backed adapter and {!callbacks_from_bars} both produce this shape. *)
+
+val callbacks_from_bars : bars:Daily_price.t list -> callbacks
+(** [callbacks_from_bars ~bars] precomputes [bar_offset]-indexed closures over
+    [bars] (newest bar at offset 0). Constructor used internally by {!analyze};
+    exposed for tests / panel adapters that already hold a [Daily_price.t list].
+*)
+
 val analyze :
   config:config ->
   bars:Daily_price.t list ->
@@ -87,4 +109,31 @@ val analyze :
     @param breakout_price The price level to grade resistance above.
     @param as_of_date Reference date used to compute [age_years] for each zone.
 
-    Pure function: same inputs always produce the same output. *)
+    Pure function: same inputs always produce the same output.
+
+    Implementation note: this is a thin wrapper over {!analyze_with_callbacks}.
+    It builds a {!callbacks} record via {!callbacks_from_bars} and delegates.
+    Behaviour is bit-identical to the callback API for the same underlying
+    [bars]. *)
+
+val analyze_with_callbacks :
+  config:config ->
+  callbacks:callbacks ->
+  breakout_price:float ->
+  as_of_date:Core.Date.t ->
+  result
+(** [analyze_with_callbacks ~config ~callbacks ~breakout_price ~as_of_date] is
+    the indicator-callback shape of {!analyze}. Used by panel-backed callers
+    that read bar fields via per-cell closures rather than walking a
+    {!Daily_price.t list}.
+
+    Walks two bar windows back from the newest bar (offset 0):
+    - the [config.virgin_lookback_bars] tail for the virgin-territory check,
+    - the [config.chart_lookback_bars] tail for zone density analysis.
+
+    The walks read [callbacks.get_high], [callbacks.get_low], and
+    [callbacks.get_date] at offsets [0 .. min (n_bars - 1) (lookback - 1)]. The
+    smaller of [n_bars] and the configured lookback bounds the walk; offsets
+    past [n_bars] are treated as missing.
+
+    Pure function: same callback outputs always produce the same result. *)

--- a/trading/analysis/weinstein/resistance/test/test_resistance.ml
+++ b/trading/analysis/weinstein/resistance/test/test_resistance.ml
@@ -146,6 +146,95 @@ let test_pure_same_inputs_same_output _ =
   assert_that r1.quality (equal_to (r2.quality : overhead_quality));
   assert_that r1.zones_above (size_is (List.length r2.zones_above))
 
+(* ------------------------------------------------------------------ *)
+(* Parity: analyze (bar-list) vs analyze_with_callbacks                *)
+(*                                                                    *)
+(* Builds a {!callbacks} record externally via the public               *)
+(* {!callbacks_from_bars} and asserts the two entry points produce      *)
+(* bit-identical results. Each scenario hits a different quality bucket *)
+(* (Virgin / Clean / Moderate / Heavy) plus the chart-window edge.      *)
+(* ------------------------------------------------------------------ *)
+
+(** Bit-identity matcher for {!resistance_zone}. All fields use [equal_to]
+    (Poly.equal — structural equality) so any drift fails. *)
+let zone_is_bit_identical (expected : resistance_zone) : resistance_zone matcher
+    =
+  all_of
+    [
+      field
+        (fun (z : resistance_zone) -> z.price_low)
+        (equal_to (expected.price_low : float));
+      field
+        (fun (z : resistance_zone) -> z.price_high)
+        (equal_to (expected.price_high : float));
+      field
+        (fun (z : resistance_zone) -> z.weeks_of_trading)
+        (equal_to (expected.weeks_of_trading : int));
+      field
+        (fun (z : resistance_zone) -> z.age_years)
+        (equal_to (expected.age_years : float));
+    ]
+
+(** Bit-identity matcher for {!result}. *)
+let result_is_bit_identical (expected : result) : result matcher =
+  all_of
+    [
+      field (fun (r : result) -> r.quality) (equal_to expected.quality);
+      field
+        (fun (r : result) -> r.breakout_price)
+        (equal_to (expected.breakout_price : float));
+      field
+        (fun (r : result) -> r.zones_above)
+        (elements_are (List.map expected.zones_above ~f:zone_is_bit_identical));
+      field
+        (fun (r : result) -> r.nearest_zone)
+        (match expected.nearest_zone with
+        | None -> is_none
+        | Some z -> is_some_and (zone_is_bit_identical z));
+    ]
+
+(** Run both [analyze] and [analyze_with_callbacks] over the same input and
+    assert the results are bit-equal. The callback bundle is built externally
+    via the public {!callbacks_from_bars}. *)
+let assert_parity ?(config = cfg) ~bars ~breakout_price () =
+  let bar_result = analyze ~config ~bars ~breakout_price ~as_of_date:as_of in
+  let callbacks = callbacks_from_bars ~bars in
+  let callback_result =
+    analyze_with_callbacks ~config ~callbacks ~breakout_price ~as_of_date:as_of
+  in
+  assert_that callback_result (result_is_bit_identical bar_result)
+
+let test_parity_virgin_no_history _ =
+  assert_parity ~bars:[] ~breakout_price:50.0 ()
+
+let test_parity_clean_overhead _ =
+  let bars =
+    [
+      make_bar ~low:40.0 ~high:48.0 45.0;
+      make_bar ~low:42.0 ~high:49.0 47.0;
+      make_bar ~low:49.0 ~high:53.0 51.0;
+    ]
+  in
+  assert_parity ~bars ~breakout_price:50.0 ()
+
+let test_parity_heavy_resistance _ =
+  let bars = List.init 10 ~f:(fun _ -> make_bar ~low:52.0 ~high:58.0 55.0) in
+  assert_parity ~bars ~breakout_price:50.0 ()
+
+let test_parity_moderate_resistance _ =
+  let bars = List.init 5 ~f:(fun _ -> make_bar ~low:52.0 ~high:58.0 55.0) in
+  assert_parity ~bars ~breakout_price:50.0 ()
+
+let test_parity_chart_window_filtering _ =
+  let small_cfg =
+    { cfg with chart_lookback_bars = 5; virgin_lookback_bars = 15 }
+  in
+  let bars =
+    List.init 10 ~f:(fun _ -> make_bar ~low:52.0 ~high:58.0 55.0)
+    @ List.init 5 ~f:(fun _ -> make_bar ~high:48.0 45.0)
+  in
+  assert_parity ~config:small_cfg ~bars ~breakout_price:50.0 ()
+
 let suite =
   "resistance_tests"
   >::: [
@@ -160,6 +249,12 @@ let suite =
          >:: test_old_bars_outside_chart_window_excluded;
          "test_pure_same_inputs_same_output"
          >:: test_pure_same_inputs_same_output;
+         "test_parity_virgin_no_history" >:: test_parity_virgin_no_history;
+         "test_parity_clean_overhead" >:: test_parity_clean_overhead;
+         "test_parity_heavy_resistance" >:: test_parity_heavy_resistance;
+         "test_parity_moderate_resistance" >:: test_parity_moderate_resistance;
+         "test_parity_chart_window_filtering"
+         >:: test_parity_chart_window_filtering;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
@@ -5,9 +5,10 @@ open Weinstein_types
 (* @large-module: Stock_analysis holds two parallel entry points sharing the
    same Stage / RS / Volume / Resistance composition — the bar-list [analyze]
    (legacy) and the indicator-callback [analyze_with_callbacks] (panel-backed).
-   The callback path threads {!Stage.callbacks} and {!Rs.callbacks} through a
-   nested {!callbacks} record; the bar-list wrapper builds those bundles via
-   {!Stage.callbacks_from_bars} and {!Rs.callbacks_from_bars}. *)
+   The callback path threads {!Stage.callbacks}, {!Rs.callbacks},
+   {!Volume.callbacks}, and {!Resistance.callbacks} through a nested
+   {!callbacks} record; the bar-list wrapper builds those bundles via the
+   corresponding [*.callbacks_from_bars] constructors. *)
 
 type config = {
   stage : Stage.config;
@@ -61,6 +62,8 @@ type callbacks = {
           window. *)
   stage : Stage.callbacks;  (** Nested Stage callbacks. *)
   rs : Rs.callbacks;  (** Nested RS callbacks. *)
+  volume : Volume.callbacks;  (** Nested Volume callbacks. *)
+  resistance : Resistance.callbacks;  (** Nested Resistance callbacks. *)
 }
 
 (* ------------------------------------------------------------------ *)
@@ -173,46 +176,35 @@ let callbacks_from_bars ~(config : config) ~(bars : Daily_price.t list)
     get_volume = _make_get_volume_from_bars bars_arr;
     stage = Stage.callbacks_from_bars ~config:config.stage ~bars;
     rs = Rs.callbacks_from_bars ~stock_bars:bars ~benchmark_bars;
+    volume = Volume.callbacks_from_bars ~bars;
+    resistance = Resistance.callbacks_from_bars ~bars;
   }
 
 (* ------------------------------------------------------------------ *)
-(* Volume confirmation from a peak offset                               *)
-(*                                                                      *)
-(* Volume.analyze_breakout still consumes a [Daily_price.t list] and a  *)
-(* 0-based [event_idx] (not a week_offset). In PR-D we keep that shape  *)
-(* intact (PRs E/F/G or a sibling will reshape Volume separately) by    *)
-(* converting the callback-shaped [peak_offset] back into the          *)
-(* [event_idx] [Volume.analyze_breakout] expects, against the same      *)
-(* [bars_for_volume_resistance] list the wrapper threads through.       *)
+(* Volume / Resistance via callbacks                                    *)
 (* ------------------------------------------------------------------ *)
 
-(** Convert [peak_offset] (week-offset from newest) into the [event_idx]
-    [Volume.analyze_breakout] expects (0-based index into [bars]). *)
-let _volume_event_idx ~bars_len ~peak_offset : int = bars_len - 1 - peak_offset
-
-let _volume_result ~(config : config) ~bars ~peak_offset_opt :
-    Volume.result option =
+let _volume_result ~(config : config) ~(volume_callbacks : Volume.callbacks)
+    ~peak_offset_opt : Volume.result option =
   match peak_offset_opt with
   | None -> None
   | Some peak_offset ->
-      let event_idx =
-        _volume_event_idx ~bars_len:(List.length bars) ~peak_offset
-      in
-      Volume.analyze_breakout ~config:config.volume ~bars ~event_idx
+      Volume.analyze_breakout_with_callbacks ~config:config.volume
+        ~callbacks:volume_callbacks ~event_offset:peak_offset
 
-let _resistance_result ~(config : config) ~bars ~as_of_date ~breakout_price :
+let _resistance_result ~(config : config)
+    ~(resistance_callbacks : Resistance.callbacks) ~as_of_date ~breakout_price :
     Resistance.result option =
   Option.map breakout_price ~f:(fun bp ->
-      Resistance.analyze ~config:config.resistance ~bars ~breakout_price:bp
-        ~as_of_date)
+      Resistance.analyze_with_callbacks ~config:config.resistance
+        ~callbacks:resistance_callbacks ~breakout_price:bp ~as_of_date)
 
 (* ------------------------------------------------------------------ *)
 (* Main analyzer — callback shape                                       *)
 (* ------------------------------------------------------------------ *)
 
 let analyze_with_callbacks ~(config : config) ~ticker ~(callbacks : callbacks)
-    ~(bars_for_volume_resistance : Daily_price.t list) ~prior_stage ~as_of_date
-    : t =
+    ~prior_stage ~as_of_date : t =
   let stage_result =
     Stage.classify_with_callbacks ~config:config.stage
       ~get_ma:callbacks.stage.get_ma ~get_close:callbacks.stage.get_close
@@ -234,11 +226,11 @@ let analyze_with_callbacks ~(config : config) ~ticker ~(callbacks : callbacks)
       ~lookback:config.breakout_event_lookback
   in
   let volume_result =
-    _volume_result ~config ~bars:bars_for_volume_resistance ~peak_offset_opt
+    _volume_result ~config ~volume_callbacks:callbacks.volume ~peak_offset_opt
   in
   let resistance_result =
-    _resistance_result ~config ~bars:bars_for_volume_resistance ~as_of_date
-      ~breakout_price
+    _resistance_result ~config ~resistance_callbacks:callbacks.resistance
+      ~as_of_date ~breakout_price
   in
   {
     ticker;
@@ -258,8 +250,7 @@ let analyze_with_callbacks ~(config : config) ~ticker ~(callbacks : callbacks)
 let analyze ~(config : config) ~ticker ~bars ~benchmark_bars ~prior_stage
     ~as_of_date : t =
   let callbacks = callbacks_from_bars ~config ~bars ~benchmark_bars in
-  analyze_with_callbacks ~config ~ticker ~callbacks
-    ~bars_for_volume_resistance:bars ~prior_stage ~as_of_date
+  analyze_with_callbacks ~config ~ticker ~callbacks ~prior_stage ~as_of_date
 
 (* ------------------------------------------------------------------ *)
 (* Candidate predicates                                                 *)

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.mli
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.mli
@@ -58,18 +58,21 @@ type callbacks = {
   rs : Rs.callbacks;
       (** Nested RS callbacks. {!Rs.callbacks_from_bars} or a panel adapter
           constructs this. *)
+  volume : Volume.callbacks;
+      (** Nested Volume callbacks. {!Volume.callbacks_from_bars} or a panel
+          adapter constructs this. *)
+  resistance : Resistance.callbacks;
+      (** Nested Resistance callbacks. {!Resistance.callbacks_from_bars} or a
+          panel adapter constructs this. *)
 }
 (** Bundle of indicator callbacks consumed by {!analyze_with_callbacks}.
 
     Threads the per-callee callback bundles ({!Stage.callbacks},
-    {!Rs.callbacks}) through one nested record so that panel-backed callers
-    don't have to re-expose those individual closures at every layer.
-
-    Volume and Resistance are intentionally NOT in this record: their
-    consumption shape (bar lists with positional [event_idx]) hasn't been
-    reshaped yet. {!analyze_with_callbacks} accepts them via a separate
-    [bars_for_volume_resistance] parameter that PRs E/F/G or a follow-up will
-    eventually replace with their own callback bundles. *)
+    {!Rs.callbacks}, {!Volume.callbacks}, {!Resistance.callbacks}) through one
+    nested record so that panel-backed callers don't have to re-expose those
+    individual closures at every layer. As of Stage 4 PR-B, every sub-callee
+    consumes callbacks rather than {!Daily_price.t list} — the strategy hot path
+    no longer materialises bar lists. *)
 
 val callbacks_from_bars :
   config:config ->
@@ -78,10 +81,11 @@ val callbacks_from_bars :
   callbacks
 (** [callbacks_from_bars ~config ~bars ~benchmark_bars] builds a {!callbacks}
     record by precomputing [bars]'s high/volume index closures and delegating
-    nested bundles to {!Stage.callbacks_from_bars} and
-    {!Rs.callbacks_from_bars}. The constructor [{ analyze }] uses internally;
-    exposed for callers (e.g. tests, future panel adapters) that already hold
-    bar lists and want to delegate to {!analyze_with_callbacks}. *)
+    nested bundles to {!Stage.callbacks_from_bars}, {!Rs.callbacks_from_bars},
+    {!Volume.callbacks_from_bars}, and {!Resistance.callbacks_from_bars}. The
+    constructor [{ analyze }] uses internally; exposed for callers (e.g. tests,
+    future panel adapters) that already hold bar lists and want to delegate to
+    {!analyze_with_callbacks}. *)
 
 val analyze :
   config:config ->
@@ -102,47 +106,36 @@ val analyze :
     Pure function.
 
     Implementation note: this is a thin wrapper over {!analyze_with_callbacks}.
-    It builds a {!callbacks} record via {!callbacks_from_bars} and threads
-    [bars] through as the [bars_for_volume_resistance] argument. Behaviour is
-    bit-identical to the callback API for the same underlying [bars]. *)
+    It builds a {!callbacks} record via {!callbacks_from_bars} and delegates.
+    Behaviour is bit-identical to the callback API for the same underlying
+    [bars]. *)
 
 val analyze_with_callbacks :
   config:config ->
   ticker:string ->
   callbacks:callbacks ->
-  bars_for_volume_resistance:Daily_price.t list ->
   prior_stage:Weinstein_types.stage option ->
   as_of_date:Core.Date.t ->
   t
-(** [analyze_with_callbacks ~config ~ticker ~callbacks
-     ~bars_for_volume_resistance ~prior_stage ~as_of_date] is the
-    indicator-callback shape of {!analyze}. Used by panel-backed callers that
-    read indicator values via the strategy's [get_indicator_fn] / panel views
-    rather than walking [Daily_price.t list]s for the Stage / RS / breakout-
-    price / peak-volume scans.
+(** [analyze_with_callbacks ~config ~ticker ~callbacks ~prior_stage ~as_of_date]
+    is the indicator-callback shape of {!analyze}. Used by panel-backed callers
+    that read indicator values via the strategy's [get_indicator_fn] / panel
+    views rather than walking {!Daily_price.t list}s for any sub-analysis.
 
     @param config Same configuration as {!analyze}.
     @param callbacks
       Bundle of indicator callbacks. [callbacks.get_high] and
       [callbacks.get_volume] back the breakout-price scan (over the prior-base
       window) and the peak-volume scan (over the recent window).
-      [callbacks.stage] / [callbacks.rs] thread through to the corresponding
-      callees.
-    @param bars_for_volume_resistance
-      Bar list still required by {!Volume.analyze_breakout} and
-      {!Resistance.analyze} (whose consumption shape hasn't been reshaped yet).
-      PR-D scope explicitly defers Volume / Resistance reshape; PRs E/F/G or a
-      follow-up will replace this parameter with their own callback bundles.
-      Until then, panel-backed callers reconstruct just enough bars from panels
-      to feed Volume / Resistance.
+      [callbacks.stage] / [callbacks.rs] / [callbacks.volume] /
+      [callbacks.resistance] thread through to the corresponding callees.
     @param prior_stage Same as {!analyze}.
     @param as_of_date Same as {!analyze}.
 
-    Pure function: same callback outputs and same [bars_for_volume_resistance]
-    always produce the same result. The wrapper {!analyze} guarantees
-    byte-identical results for any [(bars, benchmark_bars)] input by
-    constructing callbacks that index the same pre-computed series the bar-list
-    path computes internally. *)
+    Pure function: same callback outputs always produce the same result. The
+    wrapper {!analyze} guarantees byte-identical results for any
+    [(bars, benchmark_bars)] input by constructing callbacks that index the same
+    pre-computed series the bar-list path computes internally. *)
 
 val is_breakout_candidate : t -> bool
 (** [is_breakout_candidate analysis] returns true if the stock shows a potential

--- a/trading/analysis/weinstein/stock_analysis/test/test_stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/test/test_stock_analysis.ml
@@ -251,8 +251,8 @@ let assert_parity ~bars ~benchmark_bars ?(prior_stage = None) () =
       ~as_of_date:as_of
   in
   let from_callbacks =
-    analyze_with_callbacks ~config:cfg ~ticker:"X" ~callbacks
-      ~bars_for_volume_resistance:bars ~prior_stage ~as_of_date:as_of
+    analyze_with_callbacks ~config:cfg ~ticker:"X" ~callbacks ~prior_stage
+      ~as_of_date:as_of
   in
   assert_that from_callbacks (result_is_bit_identical from_bars)
 

--- a/trading/analysis/weinstein/volume/lib/volume.ml
+++ b/trading/analysis/weinstein/volume/lib/volume.ml
@@ -33,6 +33,28 @@ type result = {
 }
 
 (* ------------------------------------------------------------------ *)
+(* Callback bundle and constructors                                     *)
+(* ------------------------------------------------------------------ *)
+
+type callbacks = { get_volume : week_offset:int -> float option }
+
+(** Build a [week_offset]-indexed float lookup over a chronologically-ordered
+    [Daily_price.t list]. [week_offset:0] returns the newest bar's volume;
+    offsets past available depth return [None]. Volumes are encoded as floats to
+    match the panel encoding ([Volume_panel : Bigarray.float64]). *)
+let _make_get_volume_from_bars (bars : Daily_price.t list) :
+    week_offset:int -> float option =
+  let arr = Array.of_list bars in
+  let n = Array.length arr in
+  fun ~week_offset ->
+    let idx = n - 1 - week_offset in
+    if idx < 0 || idx >= n then None
+    else Some (Float.of_int arr.(idx).Daily_price.volume)
+
+let callbacks_from_bars ~(bars : Daily_price.t list) : callbacks =
+  { get_volume = _make_get_volume_from_bars bars }
+
+(* ------------------------------------------------------------------ *)
 (* Helpers                                                              *)
 (* ------------------------------------------------------------------ *)
 
@@ -51,14 +73,28 @@ let _classify_confirmation ~strong_threshold ~adequate_threshold ratio :
   else if Float.(ratio >= adequate_threshold) then Adequate ratio
   else Weak ratio
 
-(** Compute the breakout result given the event bar and its prior baseline bars.
-    Returns [None] when average volume is zero (no useful baseline). *)
-let _compute_result ~config ~event_bar ~prior_bars : result option =
-  let avg_vol = average_volume ~bars:prior_bars ~n:(List.length prior_bars) in
+(** Read the prior [lookback_bars] volumes at offsets
+    [event_offset+1 .. event_offset+lookback_bars] from the callbacks. Returns
+    [None] if any of those offsets is undefined (insufficient history). *)
+let _read_prior_volumes ~get_volume ~event_offset ~lookback_bars :
+    float list option =
+  let rec loop k acc =
+    if k > lookback_bars then Some (List.rev acc)
+    else
+      match get_volume ~week_offset:(event_offset + k) with
+      | None -> None
+      | Some v -> loop (k + 1) (v :: acc)
+  in
+  loop 1 []
+
+let _result_of_volumes ~config ~event_volume_f ~prior_vols : result option =
+  let avg_vol =
+    List.fold prior_vols ~init:0.0 ~f:( +. )
+    /. Float.of_int (List.length prior_vols)
+  in
   if Float.(avg_vol = 0.0) then None
   else
-    let ev = event_bar.Daily_price.volume in
-    let ratio = Float.of_int ev /. avg_vol in
+    let ratio = event_volume_f /. avg_vol in
     let confirmation =
       _classify_confirmation ~strong_threshold:config.strong_threshold
         ~adequate_threshold:config.adequate_threshold ratio
@@ -66,26 +102,43 @@ let _compute_result ~config ~event_bar ~prior_bars : result option =
     Some
       {
         confirmation;
-        event_volume = ev;
+        event_volume = Int.of_float event_volume_f;
         avg_volume = avg_vol;
         volume_ratio = ratio;
       }
 
 (* ------------------------------------------------------------------ *)
-(* Public interface                                                     *)
+(* Callback-shaped public entry                                         *)
+(* ------------------------------------------------------------------ *)
+
+(** Compose the event-volume read with the prior-volume read into a result.
+    Returns [None] when either read fails or the baseline is degenerate. *)
+let _result_at_offset ~config ~callbacks ~event_offset ~event_volume_f :
+    result option =
+  Option.bind
+    (_read_prior_volumes ~get_volume:callbacks.get_volume ~event_offset
+       ~lookback_bars:config.lookback_bars) ~f:(fun prior_vols ->
+      _result_of_volumes ~config ~event_volume_f ~prior_vols)
+
+let analyze_breakout_with_callbacks ~(config : config) ~(callbacks : callbacks)
+    ~event_offset : result option =
+  if event_offset < 0 then None
+  else
+    Option.bind (callbacks.get_volume ~week_offset:event_offset)
+      ~f:(fun event_volume_f ->
+        _result_at_offset ~config ~callbacks ~event_offset ~event_volume_f)
+
+(* ------------------------------------------------------------------ *)
+(* Bar-list wrapper — preserves the existing API                        *)
 (* ------------------------------------------------------------------ *)
 
 let analyze_breakout ~config ~bars ~event_idx : result option =
   let n = List.length bars in
   if event_idx < 0 || event_idx >= n then None
-  else if event_idx < config.lookback_bars then None
   else
-    let prior_bars =
-      List.sub bars
-        ~pos:(event_idx - config.lookback_bars)
-        ~len:config.lookback_bars
-    in
-    _compute_result ~config ~event_bar:(List.nth_exn bars event_idx) ~prior_bars
+    let event_offset = n - 1 - event_idx in
+    let callbacks = callbacks_from_bars ~bars in
+    analyze_breakout_with_callbacks ~config ~callbacks ~event_offset
 
 let is_pullback_confirmed ~config ~breakout_volume ~pullback_volume : bool =
   if breakout_volume <= 0 then false

--- a/trading/analysis/weinstein/volume/lib/volume.mli
+++ b/trading/analysis/weinstein/volume/lib/volume.mli
@@ -43,6 +43,25 @@ type result = {
 }
 (** Result of volume confirmation for a single event bar. *)
 
+type callbacks = {
+  get_volume : week_offset:int -> float option;
+      (** Bar volume at [week_offset] weeks back from the newest bar, encoded as
+          a float (matches the panel encoding). [week_offset:0] is the newest
+          bar; offsets past available depth return [None]. *)
+}
+(** Bundle of indicator callbacks consumed by
+    {!analyze_breakout_with_callbacks}.
+
+    Higher-level callback APIs (e.g. {!Stock_analysis.analyze_with_callbacks})
+    embed this record so panel-backed callers don't have to re-expose the
+    individual closure at every layer. *)
+
+val callbacks_from_bars : bars:Daily_price.t list -> callbacks
+(** [callbacks_from_bars ~bars] precomputes a [week_offset]-indexed volume
+    closure over [bars]. The constructor {!analyze_breakout} uses internally;
+    exposed for callers (e.g. tests) that already hold a bar list and want to
+    delegate to {!analyze_breakout_with_callbacks}. *)
+
 val analyze_breakout :
   config:config -> bars:Daily_price.t list -> event_idx:int -> result option
 (** [analyze_breakout ~config ~bars ~event_idx] evaluates volume confirmation at
@@ -55,7 +74,27 @@ val analyze_breakout :
     [event_idx], or if [event_idx] is out of range, or if baseline volume is
     zero.
 
-    Pure function. *)
+    Pure function.
+
+    Implementation note: this is a thin wrapper over
+    {!analyze_breakout_with_callbacks}. It builds a {!callbacks} record via
+    {!callbacks_from_bars} and delegates with
+    [event_offset = bars_len - 1 - event_idx]. Behaviour is bit-identical to the
+    callback API. *)
+
+val analyze_breakout_with_callbacks :
+  config:config -> callbacks:callbacks -> event_offset:int -> result option
+(** [analyze_breakout_with_callbacks ~config ~callbacks ~event_offset] is the
+    indicator-callback shape of {!analyze_breakout}.
+
+    [event_offset] is the [week_offset] of the event bar (0 = newest bar). The
+    [config.lookback_bars] bars immediately prior to the event bar are read at
+    offsets [event_offset + 1], [event_offset + 2], …,
+    [event_offset + lookback_bars]. Returns [None] if any prior offset returns
+    [None] (not enough history), if the event bar's offset returns [None], or if
+    the baseline average is zero.
+
+    Pure function: same callback outputs always produce the same result. *)
 
 val is_pullback_confirmed :
   config:config -> breakout_volume:int -> pullback_volume:int -> bool

--- a/trading/analysis/weinstein/volume/test/test_volume.ml
+++ b/trading/analysis/weinstein/volume/test/test_volume.ml
@@ -124,6 +124,72 @@ let test_average_volume_takes_last_n _ =
 let test_average_volume_empty _ =
   assert_that (average_volume ~bars:[] ~n:3) (float_equal 0.0)
 
+(* ------------------------------------------------------------------ *)
+(* Parity: analyze_breakout (bar-list) vs analyze_breakout_with_callbacks *)
+(*                                                                    *)
+(* Builds a {!callbacks} record externally via the public               *)
+(* {!callbacks_from_bars} and asserts that the two entry points produce *)
+(* bit-identical results. Each scenario hits a different regime: strong *)
+(* / adequate / weak confirmation, and the insufficient-history guard.  *)
+(* ------------------------------------------------------------------ *)
+
+(** Bit-identity matcher for {!result}. *)
+let result_is_bit_identical (expected : result) : result matcher =
+  all_of
+    [
+      field
+        (fun (r : result) -> r.confirmation)
+        (equal_to expected.confirmation);
+      field
+        (fun (r : result) -> r.event_volume)
+        (equal_to (expected.event_volume : int));
+      field
+        (fun (r : result) -> r.avg_volume)
+        (equal_to (expected.avg_volume : float));
+      field
+        (fun (r : result) -> r.volume_ratio)
+        (equal_to (expected.volume_ratio : float));
+    ]
+
+(** Run both [analyze_breakout] and [analyze_breakout_with_callbacks] over the
+    same input and assert the results are bit-equal. The callback bundle is
+    built externally via the public {!callbacks_from_bars}. *)
+let assert_parity ~bars ~event_idx () =
+  let bar_result = analyze_breakout ~config:cfg ~bars ~event_idx in
+  let callbacks = callbacks_from_bars ~bars in
+  let event_offset = List.length bars - 1 - event_idx in
+  let callback_result =
+    analyze_breakout_with_callbacks ~config:cfg ~callbacks ~event_offset
+  in
+  match (bar_result, callback_result) with
+  | None, None -> ()
+  | Some r1, Some r2 -> assert_that r2 (result_is_bit_identical r1)
+  | _ -> assert_failure "Volume parity: one path returned None"
+
+let test_parity_strong_breakout _ =
+  let bars = build_bars ~baseline_vol:1000 ~n:4 ~event_vol:2500 in
+  assert_parity ~bars ~event_idx:4 ()
+
+let test_parity_adequate_breakout _ =
+  let bars = build_bars ~baseline_vol:1000 ~n:4 ~event_vol:1700 in
+  assert_parity ~bars ~event_idx:4 ()
+
+let test_parity_weak_breakout _ =
+  let bars = build_bars ~baseline_vol:1000 ~n:4 ~event_vol:1100 in
+  assert_parity ~bars ~event_idx:4 ()
+
+let test_parity_insufficient_history _ =
+  let bars = build_bars ~baseline_vol:1000 ~n:2 ~event_vol:3000 in
+  assert_parity ~bars ~event_idx:2 ()
+
+let test_parity_event_at_max_index _ =
+  (* Larger window — event at the last bar, 4 prior. *)
+  let bars =
+    List.init 6 ~f:(fun i ->
+        if i = 5 then make_bar 5000 else make_bar (1000 + (i * 100)))
+  in
+  assert_parity ~bars ~event_idx:5 ()
+
 let suite =
   "volume_tests"
   >::: [
@@ -143,6 +209,11 @@ let suite =
          "test_average_volume_basic" >:: test_average_volume_basic;
          "test_average_volume_takes_last_n" >:: test_average_volume_takes_last_n;
          "test_average_volume_empty" >:: test_average_volume_empty;
+         "test_parity_strong_breakout" >:: test_parity_strong_breakout;
+         "test_parity_adequate_breakout" >:: test_parity_adequate_breakout;
+         "test_parity_weak_breakout" >:: test_parity_weak_breakout;
+         "test_parity_insufficient_history" >:: test_parity_insufficient_history;
+         "test_parity_event_at_max_index" >:: test_parity_event_at_max_index;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
@@ -117,7 +117,38 @@ let rs_callbacks_of_weekly_views ~(stock : Bar_panels.weekly_view)
   }
 
 (* ------------------------------------------------------------------ *)
-(* Stock_analysis — bundle of high/volume + nested Stage/Rs             *)
+(* Volume — week-offset indexing over the view's [volumes] array        *)
+(* ------------------------------------------------------------------ *)
+
+let volume_callbacks_of_weekly_view ~(weekly : Bar_panels.weekly_view) :
+    Volume.callbacks =
+  { get_volume = _get_from_float_array weekly.volumes }
+
+(* ------------------------------------------------------------------ *)
+(* Resistance — bar-offset indexing over highs / lows / dates           *)
+(* ------------------------------------------------------------------ *)
+
+(** Build a [bar_offset]-indexed lookup over a generic array; offset 0 is the
+    newest entry. Mirrors {!_get_from_float_array} but parameterised over
+    closure name (Resistance uses [bar_offset], Stage / Stock_analysis use
+    [week_offset]). *)
+let _get_by_bar_offset (arr : 'a array) : bar_offset:int -> 'a option =
+  let n = Array.length arr in
+  fun ~bar_offset ->
+    let idx = n - 1 - bar_offset in
+    if idx < 0 || idx >= n then None else Some arr.(idx)
+
+let resistance_callbacks_of_weekly_view ~(weekly : Bar_panels.weekly_view) :
+    Resistance.callbacks =
+  {
+    get_high = _get_by_bar_offset weekly.highs;
+    get_low = _get_by_bar_offset weekly.lows;
+    get_date = _get_by_bar_offset weekly.dates;
+    n_bars = weekly.n;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* Stock_analysis — bundle of high/volume + nested Stage/Rs/Volume/Resistance *)
 (* ------------------------------------------------------------------ *)
 
 let stock_analysis_callbacks_of_weekly_views ~(config : Stock_analysis.config)
@@ -128,6 +159,8 @@ let stock_analysis_callbacks_of_weekly_views ~(config : Stock_analysis.config)
     get_volume = _get_from_float_array stock.volumes;
     stage = stage_callbacks_of_weekly_view ~config:config.stage ~weekly:stock;
     rs = rs_callbacks_of_weekly_views ~stock ~benchmark;
+    volume = volume_callbacks_of_weekly_view ~weekly:stock;
+    resistance = resistance_callbacks_of_weekly_view ~weekly:stock;
   }
 
 (* ------------------------------------------------------------------ *)

--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.mli
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.mli
@@ -15,11 +15,10 @@
     [callbacks_from_bars] for the same underlying bars, so the strategy can swap
     call sites one-for-one with no behavioural change.
 
-    {b Out of scope (PR-B)}: {!Volume.analyze_breakout} and
-    {!Resistance.analyze} still consume {!Daily_price.t list}. The
-    {!stock_analysis_callbacks_of_weekly_views} return value pairs with the
-    bar-list still required by those callees as [bars_for_volume_resistance];
-    PR-B reshapes Volume + Resistance and drops the parameter. *)
+    Stage 4 PR-B: {!Volume.analyze_breakout} and {!Resistance.analyze} now also
+    consume callback bundles, so {!stock_analysis_callbacks_of_weekly_views}
+    builds the full {!Stock_analysis.callbacks} record from a weekly view alone
+    — no transitional [bars_for_volume_resistance] parameter remains. *)
 
 val stage_callbacks_of_weekly_view :
   config:Stage.config ->
@@ -38,6 +37,21 @@ val rs_callbacks_of_weekly_views :
     bundle by date-aligning the two views (same join-on-date semantics as
     {!Rs.callbacks_from_bars}) and indexing the resulting aligned arrays. *)
 
+val volume_callbacks_of_weekly_view :
+  weekly:Data_panel.Bar_panels.weekly_view -> Volume.callbacks
+(** [volume_callbacks_of_weekly_view ~weekly] builds a {!Volume.callbacks}
+    bundle backed by the view's [volumes] array (the same encoding
+    {!Volume.callbacks_from_bars} produces). [week_offset:0] is the newest
+    weekly bar; offsets past the view's depth return [None]. *)
+
+val resistance_callbacks_of_weekly_view :
+  weekly:Data_panel.Bar_panels.weekly_view -> Resistance.callbacks
+(** [resistance_callbacks_of_weekly_view ~weekly] builds a
+    {!Resistance.callbacks} bundle backed by the view's [highs], [lows], and
+    [dates] arrays. The bar-offset indexing matches
+    {!Resistance.callbacks_from_bars}: offset 0 is the newest bar; offsets past
+    [n_bars] return [None]. *)
+
 val stock_analysis_callbacks_of_weekly_views :
   config:Stock_analysis.config ->
   stock:Data_panel.Bar_panels.weekly_view ->
@@ -46,14 +60,12 @@ val stock_analysis_callbacks_of_weekly_views :
 (** [stock_analysis_callbacks_of_weekly_views ~config ~stock ~benchmark] builds
     a {!Stock_analysis.callbacks} bundle indexing the stock's [highs] and
     [volumes] arrays for the breakout / peak-volume scans, and threading nested
-    {!Stage.callbacks} (over [stock]) and {!Rs.callbacks} (over [stock]
-    + [benchmark]) through the bundle.
+    {!Stage.callbacks} (over [stock]), {!Rs.callbacks} (over [stock] +
+    [benchmark]), {!Volume.callbacks} (over [stock]), and
+    {!Resistance.callbacks} (over [stock]) through the bundle.
 
-    Note: {!Stock_analysis.analyze_with_callbacks} also takes
-    [bars_for_volume_resistance : Types.Daily_price.t list] for the not-yet-
-    reshaped Volume / Resistance callees. PR-A callers reconstruct that bar list
-    via {!Bar_panels.weekly_bars_for}; PR-B reshapes those callees and drops the
-    parameter. *)
+    As of Stage 4 PR-B, no {!Daily_price.t list} is materialised — every
+    sub-callee consumes a callback bundle. *)
 
 val sector_callbacks_of_weekly_views :
   config:Sector.config ->

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -227,9 +227,9 @@ let entries_from_candidates ~config ~candidates ~stop_states ~bar_reader
 
     Stage 4 PR-A: per-ticker analysis goes through panel-shaped Stage / Rs
     callbacks (no [Daily_price.t list] for those scans). Volume + Resistance in
-    [Stock_analysis] still consume a bar list — that reshape is deferred to
-    PR-B; the bar list is built on-demand here from
-    [Bar_reader.weekly_bars_for]. *)
+    [Stock_analysis] (Stage, Rs, breakout-price scan, peak-volume scan, Volume,
+    Resistance) reads through the panel-shaped callbacks below without
+    allocating any [Daily_price.t list]. *)
 let _screen_universe ~config ~index_view ~macro_trend ~sector_map ~stop_states
     ~(portfolio : Portfolio_view.t) ~get_price ~bar_reader ~prior_stages
     ~current_date =
@@ -245,14 +245,6 @@ let _screen_universe ~config ~index_view ~macro_trend ~sector_map ~stop_states
         else stock_view.dates.(stock_view.n - 1)
       in
       let prior_stage = Hashtbl.find prior_stages ticker in
-      (* PR-B carry-over: Volume + Resistance still consume a [Daily_price.t]
-         list. Build it on-demand here; the rest of Stock_analysis (Stage,
-         Rs, breakout-price scan, peak-volume scan) reads through the
-         panel-shaped callbacks above without allocating. *)
-      let bars_for_volume_resistance =
-        Bar_reader.weekly_bars_for bar_reader ~symbol:ticker
-          ~n:config.lookback_bars ~as_of:current_date
-      in
       let callbacks =
         Panel_callbacks.stock_analysis_callbacks_of_weekly_views
           ~config:Stock_analysis.default_config ~stock:stock_view
@@ -260,8 +252,8 @@ let _screen_universe ~config ~index_view ~macro_trend ~sector_map ~stop_states
       in
       let result =
         Stock_analysis.analyze_with_callbacks
-          ~config:Stock_analysis.default_config ~ticker ~callbacks
-          ~bars_for_volume_resistance ~prior_stage ~as_of_date
+          ~config:Stock_analysis.default_config ~ticker ~callbacks ~prior_stage
+          ~as_of_date
       in
       Hashtbl.set prior_stages ~key:ticker ~data:result.stage.stage;
       Some result

--- a/trading/trading/weinstein/strategy/test/test_panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/test/test_panel_callbacks.ml
@@ -216,14 +216,12 @@ let test_stock_analysis_callbacks_parity _ =
   in
   let bar_list_result =
     Stock_analysis.analyze_with_callbacks ~config ~ticker:"AAPL"
-      ~callbacks:bar_cbs ~bars_for_volume_resistance:stock_bars
-      ~prior_stage:None
+      ~callbacks:bar_cbs ~prior_stage:None
       ~as_of_date:(Date.of_string "2025-02-21")
   in
   let panel_result =
     Stock_analysis.analyze_with_callbacks ~config ~ticker:"AAPL"
-      ~callbacks:panel_cbs ~bars_for_volume_resistance:stock_bars
-      ~prior_stage:None
+      ~callbacks:panel_cbs ~prior_stage:None
       ~as_of_date:(Date.of_string "2025-02-21")
   in
   assert_that panel_result
@@ -401,6 +399,93 @@ let test_support_floor_callbacks_parity _ =
       assert_failure
         (Printf.sprintf "bar-list returned None; panel returned Some %f" r)
 
+(* Volume parity: weekly bars run through Volume.analyze_breakout via both the
+   bar-list and panel callback paths. *)
+let test_volume_callbacks_parity _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:8 ~start_price:100.0 ~step:1.0
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let n = Bar_panels.n_days panels in
+  let view =
+    Bar_panels.weekly_view_for panels ~symbol:"AAPL" ~n:8 ~as_of_day:(n - 1)
+  in
+  let bar_cbs = Volume.callbacks_from_bars ~bars in
+  let panel_cbs =
+    Panel_callbacks.volume_callbacks_of_weekly_view ~weekly:view
+  in
+  let config = Volume.default_config in
+  (* Read at event_offset:0 (newest bar). Both paths must agree. *)
+  let bar_result =
+    Volume.analyze_breakout_with_callbacks ~config ~callbacks:bar_cbs
+      ~event_offset:0
+  in
+  let panel_result =
+    Volume.analyze_breakout_with_callbacks ~config ~callbacks:panel_cbs
+      ~event_offset:0
+  in
+  match (bar_result, panel_result) with
+  | None, None -> ()
+  | Some r1, Some r2 ->
+      assert_that r2
+        (all_of
+           [
+             field
+               (fun (r : Volume.result) -> r.event_volume)
+               (equal_to (r1.event_volume : int));
+             field
+               (fun (r : Volume.result) -> r.avg_volume)
+               (float_equal r1.avg_volume);
+             field
+               (fun (r : Volume.result) -> r.volume_ratio)
+               (float_equal r1.volume_ratio);
+           ])
+  | _ -> assert_failure "Volume parity: one path returned None"
+
+(* Resistance parity: weekly bars run through Resistance.analyze via both
+   the bar-list and panel callback paths. *)
+let test_resistance_callbacks_parity _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:30 ~start_price:50.0 ~step:1.0
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let n = Bar_panels.n_days panels in
+  let view =
+    Bar_panels.weekly_view_for panels ~symbol:"AAPL" ~n:30 ~as_of_day:(n - 1)
+  in
+  let bar_cbs = Resistance.callbacks_from_bars ~bars in
+  let panel_cbs =
+    Panel_callbacks.resistance_callbacks_of_weekly_view ~weekly:view
+  in
+  let config = Resistance.default_config in
+  let breakout_price = 65.0 in
+  let as_of_date = Date.of_string "2025-02-21" in
+  let bar_result =
+    Resistance.analyze_with_callbacks ~config ~callbacks:bar_cbs ~breakout_price
+      ~as_of_date
+  in
+  let panel_result =
+    Resistance.analyze_with_callbacks ~config ~callbacks:panel_cbs
+      ~breakout_price ~as_of_date
+  in
+  assert_that panel_result
+    (all_of
+       [
+         field
+           (fun (r : Resistance.result) -> r.quality)
+           (equal_to bar_result.quality);
+         field
+           (fun (r : Resistance.result) -> r.breakout_price)
+           (float_equal bar_result.breakout_price);
+         field
+           (fun (r : Resistance.result) -> List.length r.zones_above)
+           (equal_to (List.length bar_result.zones_above));
+       ])
+
 let suite =
   "Panel_callbacks parity"
   >::: [
@@ -411,6 +496,8 @@ let suite =
          "Macro parity" >:: test_macro_callbacks_parity;
          "Weinstein_stops.Support_floor parity"
          >:: test_support_floor_callbacks_parity;
+         "Volume parity" >:: test_volume_callbacks_parity;
+         "Resistance parity" >:: test_resistance_callbacks_parity;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
…lbacks; drop bars_for_volume_resistance

Reshapes the two remaining bar-list callees in the strategy hot path so the weekly screening tick no longer materialises any Daily_price.t list per surviving symbol.

What's in:
- Volume.analyze_breakout_with_callbacks ~callbacks ~event_offset. Volume.callbacks = { get_volume : week_offset:int -> float option }. Bar-list analyze_breakout becomes a thin wrapper that converts event_idx <-> event_offset and delegates.
- Resistance.analyze_with_callbacks ~callbacks ~breakout_price ~as_of_date. Resistance.callbacks = { get_high; get_low; get_date; n_bars } indexed by bar_offset 0..n_bars-1. Walks bound by min lookback n_bars for both the virgin and chart windows. Bucket aggregation tracks the running max date per bucket to mirror the bar-list path's max(dates) semantics.
- Stock_analysis.callbacks gains volume / resistance fields; analyze_with_callbacks drops bars_for_volume_resistance. The bar-list wrapper analyze ~bars builds the new bundle via the *.callbacks_from_bars constructors and delegates — bit-identical for any input.
- Panel_callbacks.{volume,resistance}_callbacks_of_weekly_view: index directly into Bar_panels.weekly_view's float arrays. stock_analysis_callbacks_of_weekly_views threads both new constructors through, so the strategy can build the full Stock_analysis.callbacks bundle from a weekly view alone.
- Weinstein_strategy._screen_universe drops the bars_for_volume_resistance = Bar_reader.weekly_bars_for ... line. The per-symbol per-Friday allocation is gone.

Parity gates green:
- test_panel_loader_parity (load-bearing): 2 round_trips goldens bit-equal.
- test_volume.ml: 12 pre-existing + 5 new parity (Strong / Adequate / Weak / Insufficient / event-at-max-index) = 17.
- test_resistance.ml: 9 pre-existing + 5 new parity (Virgin / Clean / Heavy / Moderate / chart-window-filtering) = 14.
- test_stock_analysis.ml: 16 (8 pre-existing + 8 PR-D parity) — all pass with the new bundle shape.
- test_panel_callbacks.ml: 8 (6 PR-A + 2 new Volume / Resistance) — all pass.

LOC: ~340 production source / ~245 tests. Function-length under 50-line hard limit; nesting linter clean for the new code (only the pre-existing macro_callbacks_of_weekly_views max=6 from PR-A remains).

Out of scope:
- Ohlcv_weekly_panels + Friday rollup (PR-C).
- Port stage classifier / volume / resistance to indicator kernels (PR-D).
- RSS spike re-run on bull-crash-292x6y (separate dispatch).

Plan: dev/plans/panels-stage04-pr-b-2026-04-26.md