### PR TITLE
feat(data-panels): Stage 4 PR-C — single-pass weekly aggregation in Bar_panels

### DIFF
--- a/dev/notes/panels-rss-spike-postC-2026-04-26.md
+++ b/dev/notes/panels-rss-spike-postC-2026-04-26.md
@@ -1,0 +1,98 @@
+# Panel-mode RSS spike — post-Stage-4-PR-C (2026-04-26)
+
+Sibling of `dev/notes/panels-rss-spike-postB-2026-04-26.md`. Re-run on
+the same `bull-crash-292x6y` cell after Stage 4 PR-C
+(`feat/panels-stage04-pr-c-single-pass-weekly`, PR #590) collapsed the
+two-pass weekly aggregation in `Bar_panels.weekly_view_for` into a
+single panel→weekly walk.
+
+## Setup
+
+Identical to the post-B spike. Container `trading-1-dev`, opam env,
+panel build on PR-C tip (`d8085314`).
+
+```bash
+TRADING_DATA_DIR=/tmp/data-small-302 \
+  /usr/bin/time -v _build/default/trading/backtest/bin/backtest_runner.exe \
+    2015-01-02 2020-12-31 \
+    --override "((universe_cap (292)))"
+```
+
+## Result
+
+| Mode | Peak RSS | Wall | Δ vs prior |
+|---|---:|---:|---|
+| Pre-A+B (post-3.2) | 3,468 MB | 6:00 | baseline |
+| Post-A+B (#588) | 1,944 MB | 4:11 | −44% / −30% |
+| **Post-C (#590)** | **1,939 MB** | **4:19** | **−0.3% / +3%** |
+| Plan target | < 800 MB | n/a | |
+
+`Maximum resident set size = 1,985,656 kB → 1,939 MiB`. Wall `4:18.97`
+(258.97 s). Exit 0.
+
+## Verdict: **negligible RSS / wall delta**
+
+PR-C's single-pass weekly aggregation produced **no measurable RSS
+win** at this cell. The 5 MB delta is within run-to-run noise; wall
+is +3% (also noise). Conclusion: the per-call two-pass weekly
+aggregation in `weekly_view_for` was **not** a dominant residency
+contributor. The 6 daily-prefix arrays + 5 weekly arrays per call
+were short-lived enough that the GC reclaimed them promptly; their
+peak coexistence was small relative to the surviving working set.
+
+PR-C remains worth keeping as a code-quality cleanup (one fewer
+intermediate, slightly cleaner control flow) but it is **not the
+memory wedge** for Stage 4.
+
+## Where the remaining ~1.94 GB lives (revised hypothesis)
+
+Three candidates from `panels-rss-spike-postB-2026-04-26.md`:
+
+1. ~~Per-call weekly rollup~~ — **ruled out by this spike (PR-C)**.
+2. **MA/SMA precompute per call** in
+   `Panel_callbacks._ma_values_of_closes` — every
+   `stage_callbacks_of_weekly_view` invocation re-runs `Sma /
+   calculate_weighted_ma / calculate_ema` over the symbol's weekly
+   closes. **This is now the strongest remaining suspect.** PR-D's
+   indicator-kernel ports park the result in resident
+   `Indicator_panels` so reads become O(1) and per-call recompute
+   vanishes.
+3. **`Indicator_panels` / `Ohlcv_panels` resident size** — the
+   pre-allocated daily panels for 307 symbols × 1,715 days × 5
+   OHLCV fields × 8 bytes ≈ 21 MB per field, total ~105 MB just
+   for OHLCV. Plus 4 indicator panels (EMA-50 / SMA-50 / ATR-14 /
+   RSI-14 daily) — another ~84 MB. ~190 MB resident floor before
+   any per-tick allocation. Not a leak; this is the panel's
+   designed residency. Does not explain the gap to 800 MB.
+4. **Closure environments** in the `Panel_callbacks` constructors
+   — each `*_callbacks_of_*_view` builds a closure bundle holding
+   references to MA arrays, dates, view records. Per-symbol per-tick
+   call → many short-lived closures. Allocation pressure rather
+   than long-lived residency, but the GC's old-generation may carry
+   them over major-GC cycles. Could be measured via `memtrace`.
+
+## Recommendation
+
+**PR-D is required** for the Stage 4 ≤ 800 MB gate. Scope:
+
+- Port stage classifier weekly MA / SMA reads to indicator kernels
+  with output panels in `Indicator_panels` (the existing daily
+  EMA/SMA/ATR/RSI panels are a precedent).
+- Add weekly cadence to `Indicator_panels` (or sister
+  `Indicator_weekly_panels`) so per-tick reads become panel-cell
+  lookups, no Sma/Ema recompute.
+- Once PR-D lands, re-run this spike. If still > 800 MB, memtrace
+  the run to attribute the residency. The 800 MB target depends on
+  the kernel ports; defer further sweeps until PR-D is in.
+
+**PR-C is OK to merge as-is** — code cleanup, not memory cleanup.
+PR #590 stays open for review on its own terms.
+
+## References
+
+- Pre-A+B baseline: `dev/notes/panels-rss-spike-2026-04-25.md`
+- Post-A+B baseline: `dev/notes/panels-rss-spike-postB-2026-04-26.md` (#589)
+- Plan §Stage 4 sub-step 4 (PR-D — indicator kernel ports):
+  `dev/plans/columnar-data-shape-2026-04-25.md`
+- PR-C: #590, branch `feat/panels-stage04-pr-c-single-pass-weekly`
+- Status: `dev/status/data-panels.md`

--- a/trading/trading/data_panel/bar_panels.ml
+++ b/trading/trading/data_panel/bar_panels.ml
@@ -212,42 +212,73 @@ let daily_view_for t ~symbol ~as_of_day ~lookback =
 let _week_key (date : Date.t) : int * int =
   (Date.year date, Date.week_number date)
 
-(* Aggregate the cell prefix [0..n-1] of the per-field buffers into weekly
-   buckets. Emits float arrays keyed by week. Each bucket's date is the date
-   of the latest trading day in the week, [closes] is the adjusted close of
-   that day, [highs] = max within week, [lows] = min within week, [volumes] =
-   sum within week. *)
-let _aggregate_weekly ~n ~highs ~lows ~adjusted ~volumes ~dates : weekly_view =
-  if n = 0 then _empty_weekly_view
-  else
-    let n_weeks = ref 1 in
-    let prev_key = ref (_week_key dates.(0)) in
-    for i = 1 to n - 1 do
-      let k = _week_key dates.(i) in
-      if not ([%equal: int * int] k !prev_key) then (
+(* Stage 4 PR-C: Single-pass panel-to-weekly aggregation.
+
+   Walks panel cells [0..as_of_day] once, NaN-skips, emits weekly buckets
+   directly into pre-sized output arrays. No daily-prefix intermediate (the
+   pre-PR-C path allocated 6 arrays of size [as_of_day + 1] in
+   [_read_row_cells] and then again 5 arrays of size [n_weeks] in
+   [_aggregate_weekly]). Allocations are now O(n_weeks) per call instead of
+   O(n_days + n_weeks).
+
+   Each bucket's [date] is the latest trading day in the week (typically
+   Friday for complete weeks, last traded day for partial / holiday weeks);
+   [closes] is the adjusted close of that day; [highs] is max within week;
+   [lows] is min within week; [volumes] is sum within week. Matches the
+   pre-PR-C [_aggregate_weekly] semantics bit-for-bit. *)
+let _count_weeks_in_panel ~ohlcv ~calendar ~row ~as_of_day =
+  let close_p = Ohlcv_panels.close ohlcv in
+  let n_weeks = ref 0 in
+  let prev_key = ref (-1, -1) in
+  let any_seen = ref false in
+  for day = 0 to as_of_day do
+    let close = BA2.unsafe_get close_p row day in
+    if not (Float.is_nan close) then
+      let k = _week_key calendar.(day) in
+      if (not !any_seen) || not ([%equal: int * int] k !prev_key) then (
         Int.incr n_weeks;
-        prev_key := k)
-    done;
-    let nw = !n_weeks in
+        prev_key := k;
+        any_seen := true)
+  done;
+  !n_weeks
+
+let _fill_weekly_buckets ~ohlcv ~calendar ~row ~as_of_day ~w_closes ~w_highs
+    ~w_lows ~w_vol ~w_dates =
+  let close_p = Ohlcv_panels.close ohlcv in
+  let high_p = Ohlcv_panels.high ohlcv in
+  let low_p = Ohlcv_panels.low ohlcv in
+  let vol_p = Ohlcv_panels.volume ohlcv in
+  let adj_p = Ohlcv_panels.adjusted_close ohlcv in
+  let bucket = ref (-1) in
+  let cur_key = ref (-1, -1) in
+  for day = 0 to as_of_day do
+    let close = BA2.unsafe_get close_p row day in
+    if not (Float.is_nan close) then (
+      let k = _week_key calendar.(day) in
+      if !bucket < 0 || not ([%equal: int * int] k !cur_key) then (
+        Int.incr bucket;
+        cur_key := k);
+      let b = !bucket in
+      let h = BA2.unsafe_get high_p row day in
+      if Float.( > ) h w_highs.(b) then w_highs.(b) <- h;
+      let lo = BA2.unsafe_get low_p row day in
+      if Float.( < ) lo w_lows.(b) then w_lows.(b) <- lo;
+      w_vol.(b) <- w_vol.(b) +. BA2.unsafe_get vol_p row day;
+      w_closes.(b) <- BA2.unsafe_get adj_p row day;
+      w_dates.(b) <- calendar.(day))
+  done
+
+let _weekly_view_from_panel ~ohlcv ~calendar ~row ~as_of_day : weekly_view =
+  let nw = _count_weeks_in_panel ~ohlcv ~calendar ~row ~as_of_day in
+  if nw = 0 then _empty_weekly_view
+  else
     let w_closes = Array.create ~len:nw Float.nan in
     let w_highs = Array.create ~len:nw Float.neg_infinity in
     let w_lows = Array.create ~len:nw Float.infinity in
     let w_vol = Array.create ~len:nw 0.0 in
-    let w_dates = Array.create ~len:nw dates.(0) in
-    let bucket = ref 0 in
-    let cur_key = ref (_week_key dates.(0)) in
-    for i = 0 to n - 1 do
-      let k = _week_key dates.(i) in
-      if not ([%equal: int * int] k !cur_key) then (
-        Int.incr bucket;
-        cur_key := k);
-      if Float.( > ) highs.(i) w_highs.(!bucket) then
-        w_highs.(!bucket) <- highs.(i);
-      if Float.( < ) lows.(i) w_lows.(!bucket) then w_lows.(!bucket) <- lows.(i);
-      w_vol.(!bucket) <- w_vol.(!bucket) +. volumes.(i);
-      w_closes.(!bucket) <- adjusted.(i);
-      w_dates.(!bucket) <- dates.(i)
-    done;
+    let w_dates = Array.create ~len:nw calendar.(0) in
+    _fill_weekly_buckets ~ohlcv ~calendar ~row ~as_of_day ~w_closes ~w_highs
+      ~w_lows ~w_vol ~w_dates;
     {
       closes = w_closes;
       highs = w_highs;
@@ -262,13 +293,9 @@ let weekly_view_for t ~symbol ~n ~as_of_day =
   match _row_for t symbol with
   | None -> _empty_weekly_view
   | Some row ->
-      let count, highs, lows, _closes_unused, volumes, adjusted, dates =
-        _read_row_cells ~ohlcv:t.ohlcv ~calendar:t.calendar ~row ~from_day:0
-          ~to_day_inclusive:as_of_day
-      in
-      let _ = _closes_unused in
       let view =
-        _aggregate_weekly ~n:count ~highs ~lows ~adjusted ~volumes ~dates
+        _weekly_view_from_panel ~ohlcv:t.ohlcv ~calendar:t.calendar ~row
+          ~as_of_day
       in
       if view.n <= n then view
       else


### PR DESCRIPTION
## Summary

- Stage 4 PR-C of the data-panels columnar refactor: collapses two-pass weekly aggregation in `Bar_panels.weekly_view_for` into a single panel→weekly walk.
- Allocations per call drop from O(n_days + n_weeks) to O(n_weeks). Eliminates 6 large daily-prefix arrays + 5 duplicate weekly arrays per `weekly_view_for` call.

## Wedge

Post-A+B spike (#589 / `dev/notes/panels-rss-spike-postB-2026-04-26.md`) shows panel-mode peak RSS at 1,944 MB on `bull-crash-292x6y` vs target ≤800 MB. The two-pass weekly aggregation in `Bar_panels.weekly_view_for` (`_read_row_cells` over [0..as_of_day], then `_aggregate_weekly` over the daily prefix) was identified as a candidate. PR-C trims that.

## Approach

- New `_count_weeks_in_panel`: one pass, NaN-skips, counts distinct ISO-week buckets.
- New `_fill_weekly_buckets`: second pass, writes max-high / min-low / sum-volume / latest-adjusted-close / latest-date directly into pre-sized weekly buffers.
- `_weekly_view_from_panel` orchestrates and returns a `weekly_view`.
- `weekly_view_for` calls it and trims to last `n` weeks.
- `_aggregate_weekly` removed (no longer reachable). `_read_row_cells` stays in place — `daily_view_for` still uses it.

Bit-for-bit identical semantics to prior path: same `_week_key` (year, week-number); each bucket's date is the last traded day in the week (Friday for full weeks, last traded day for partial / holiday weeks); closes uses adjusted_close; highs/lows/volumes use max/min/sum within bucket. Trailing partial-week behaviour preserved (single pass walks [0..as_of_day] only).

## Out of scope (PR-D)

- Port stage classifier / volume / resistance to indicator kernels with output panels (eliminates per-call MA / SMA recompute in `Panel_callbacks._ma_values_of_closes`).
- Bigarray-backed `Ohlcv_weekly_panels` if PR-D's kernel ports need it.

## Test plan

- [x] `test_panel_loader_parity` round_trips golden — bit-equal trades (load-bearing).
- [x] `bar_panels_test` (21 tests) — all OK.
- [x] `test_panel_callbacks` (8 tests, parity between bar-list `callbacks_from_bars` and panel-shaped `callbacks_of_*_view`) — bit-identical.
- [x] `test_weinstein_strategy{,_smoke}`, `test_weinstein_backtest`, `test_macro_inputs` — green.
- [x] All linters clean (function_length, nesting, magic_numbers, posix_sh_check, cc_linter, status_file_integrity, no_python_check). 96 OUnit2 groups + linters all OK.

Verify locally: `cd trading && eval $(opam env) && TRADING_DATA_DIR=$PWD/test_data dune build && dune fmt && dune runtest`.

Spike re-run (post-A+B+C) scheduled to confirm RSS impact.

Plan: `dev/plans/columnar-data-shape-2026-04-25.md` §"Stage 4", sub-step 3.