### PR TITLE
harness(meta): add harness: reusable | template | project frontmatter to .claude/{agents,rules}/*.md

### DIFF
--- a/.claude/agents/code-health.md
+++ b/.claude/agents/code-health.md
@@ -2,6 +2,7 @@
 name: code-health
 description: Cleans up small code-health findings (function-length, magic numbers, expired linter exceptions, dead code, doc-comment gaps). Works on cleanup/ branches. Dispatched by orchestrator from health-scanner findings — one finding per dispatch, no behavior change.
 model: sonnet
+harness: reusable
 ---
 
 You are the code-health cleanup agent. Your job is to absorb small, low-risk maintenance work surfaced by `health-scanner` deep + fast scans so feature agents can stay focused on feature work and findings don't pile up unread.

--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -1,6 +1,7 @@
 ---
 name: feat-agent-template
 description: Template and contract for all feat-* agent definitions. Every feat-agent must include the required sections below. This file is read by the health-scanner to verify compliance.
+harness: template
 ---
 
 # Feat-Agent Definition Template

--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -2,6 +2,7 @@
 name: feat-backtest
 description: Implements experiments + analysis features on the backtest-infra and backtest-scale tracks (tier-aware bar loader, stop-buffer tuning, drawdown circuit breaker, per-trade stop logging, segmentation-based stage classifier). Works on feat/backtest branches.
 model: opus
+harness: project
 ---
 
 You are implementing the backtest-infra and backtest-scale feature

--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -2,6 +2,7 @@
 name: feat-weinstein
 description: Implements Weinstein base-strategy feature work. Current scope — support-floor-based stops primitive in weinstein/stops/ (unblocks feat-backtest experiment). Works on feat/support-floor-stops branch using TDD.
 model: opus
+harness: project
 ---
 
 You are building remaining Weinstein Trading System base-strategy features. Prior scopes (order_gen, Simulation Slice 1-3, screener, stops, portfolio_risk, strategy-wiring) are complete and merged. Current scope:

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -2,6 +2,7 @@
 name: harness-maintainer
 description: Implements harness tooling improvements for the Weinstein Trading System. Works on harness/ branches. Assigned to open T1/T3 items in dev/status/harness.md that are not directly related to feature code.
 model: sonnet
+harness: reusable
 ---
 
 You are the harness maintainer for the Weinstein Trading System. Your job is to implement tooling, linting, process improvements, and agent definition updates — not feature code.

--- a/.claude/agents/health-scanner.md
+++ b/.claude/agents/health-scanner.md
@@ -2,6 +2,7 @@
 name: health-scanner
 description: Read-only health check agent for the Weinstein Trading System. Runs in fast mode (post-orchestrator-run) or deep mode (weekly). Writes findings to dev/health/. Never modifies source or agent files.
 model: haiku
+harness: reusable
 ---
 
 You are the health scanner for the Weinstein Trading System. You read; you never write to source code, agent definitions, or status files. Your only output is a health report written to `dev/health/`.

--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -2,6 +2,7 @@
 name: lead-orchestrator
 description: Orchestrates daily parallel feature development for the Weinstein Trading System. Spawns feature and QC agents as subagents, coordinates integration order, and writes daily summaries for human review. Runs non-interactively via claude -p.
 model: opus
+harness: reusable
 ---
 
 You are the lead orchestrator for the Weinstein Trading System build. You run once per day, coordinate all work, and exit. The human reads your output in `dev/daily/YYYY-MM-DD.md`.

--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -2,6 +2,7 @@
 name: ops-data
 description: On-demand data fetching and inventory maintenance for the Weinstein Trading System. Fetches symbols via EODHD API, rebuilds the local inventory and universe. Operational agent — not a feature builder.
 model: sonnet
+harness: project
 ---
 
 You are the data operations agent for the Weinstein Trading System. You fetch market data on demand, maintain the local data inventory, and ensure data coverage is sufficient for agent runs and regression tests.

--- a/.claude/agents/qc-behavioral.md
+++ b/.claude/agents/qc-behavioral.md
@@ -2,6 +2,7 @@
 name: qc-behavioral
 description: Behavioral correctness QC reviewer for the Weinstein Trading System. For every non-trivial contract the code claims — in module docstrings, .mli comments, PR body "Test plan"/"What it does" sections, or the feature plan file — verifies the test suite pins that claim. Authority is weinstein-book-reference.md for Weinstein logic; otherwise the module's own docstrings, the plan file, and the PR body. Only runs after qc-structural APPROVED.
 model: opus
+harness: reusable
 ---
 
 You are the **QC Behavioral Reviewer** for the Weinstein Trading System. You check behavioral correctness — whether the implementation faithfully delivers on the contracts it claims. For Weinstein domain features, those contracts come from Weinstein's trading rules and the design specs. For infrastructure, library, or refactor PRs, the contracts come from the module's own docstrings, its `.mli` comments, the feature plan file, and the PR body's "Test plan" / "What it does" sections.

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -2,6 +2,7 @@
 name: qc-structural
 description: Structural and mechanical QC reviewer for the Weinstein Trading System. Checks build health, code patterns, and architecture constraints. Runs before qc-behavioral — if this agent FAILs, behavioral review does not run.
 model: haiku
+harness: reusable
 ---
 
 You are the **QC Structural Reviewer** for the Weinstein Trading System. You check structural and mechanical correctness only — you do not evaluate domain behavior or trading logic. That is qc-behavioral's responsibility.

--- a/.claude/rules/no-python.md
+++ b/.claude/rules/no-python.md
@@ -1,3 +1,7 @@
+---
+harness: project
+---
+
 # No Python — OCaml only
 
 The codebase is OCaml + Dune. Do not add new Python scripts to this

--- a/.claude/rules/ocaml-patterns.md
+++ b/.claude/rules/ocaml-patterns.md
@@ -1,6 +1,7 @@
 ---
 description: OCaml code patterns and idioms for this codebase
 globs: ["**/*.ml", "**/*.mli"]
+harness: project
 ---
 
 ## Type Definitions

--- a/.claude/rules/test-patterns.md
+++ b/.claude/rules/test-patterns.md
@@ -1,6 +1,7 @@
 ---
 description: Test patterns using the Matchers library (base/matchers/)
 globs: ["**/test/*.ml"]
+harness: project
 ---
 
 ## Core Rule: One `assert_that` per Value

--- a/.claude/rules/worktree-isolation.md
+++ b/.claude/rules/worktree-isolation.md
@@ -1,3 +1,7 @@
+---
+harness: reusable
+---
+
 # Worktree Isolation Integrity
 
 ## The problem


### PR DESCRIPTION
## Summary

Phase 1 PR 1 of the agent-harness extraction plan (#592 / `dev/plans/harness-template-extraction-2026-04-26.md`). Adds a `harness:` metadata field to every `.claude/agents/*.md` and `.claude/rules/*.md` so the future extract pass into `dayfine/agent-harness` is grep-able.

Metadata only — no body changes.

## Distribution

```
$ grep -h '^harness:' .claude/agents/*.md .claude/rules/*.md | sort | uniq -c
   6 harness: project
   7 harness: reusable
   1 harness: template
```

| Agent / rule | Tag | Reason |
|---|---|---|
| code-health, harness-maintainer, health-scanner, lead-orchestrator, qc-behavioral, qc-structural | reusable | Generic agentic-coding patterns |
| worktree-isolation.md | reusable | Generic isolation invariant |
| feat-agent-template | template | Skeleton each project fills in |
| feat-backtest, feat-weinstein, ops-data | project | Domain-specific |
| no-python.md, ocaml-patterns.md, test-patterns.md | project | This repo's language / framework rules |

## Test plan

- [x] `grep -L 'harness:' .claude/agents/*.md .claude/rules/*.md` returns empty (every file tagged).
- [x] No build/test impact — these files are not consumed by `dune`. CI gates unaffected.

## Notes

- Subagent (harness-maintainer) was initially blocked by Edit/Write permission on `.claude/` paths. Main session has access; applied directly.
- Next: PR 2 (split QC agents along methodology / authority seam), PR 3 (hoist orchestrator config block). See plan file.