### PR TITLE
feat(data-panels): Stage 4 PR-D — Weekly_ma_cache for Stage classifier

### DIFF
--- a/dev/plans/panels-stage04-pr-d-2026-04-26.md
+++ b/dev/plans/panels-stage04-pr-d-2026-04-26.md
@@ -1,0 +1,134 @@
+# Plan: Stage 4 PR-D — weekly MA cache (eliminate per-call SMA/WMA/EMA recompute) (2026-04-26)
+
+## Status
+
+In-flight. Branch: `feat/panels-stage04-pr-d-weekly-indicator-panels`.
+
+## The wedge
+
+Per the post-PR-A+B+C RSS spike (peak RSS still 1,939 MB on `bull-crash-292x6y` vs ≤800 MB target), the strongest remaining suspect after dropping `Daily_price.t list` intermediates is per-call MA recompute in
+`Panel_callbacks._ma_values_of_closes`. On every `stage_callbacks_of_weekly_view` call (the screener iterates the universe Fridays + stops_runner runs daily for held positions + macro/sector branches) the function:
+
+1. Builds an `Indicator_types.t list` from `closes : float array` via `Array.to_list |> List.mapi`.
+2. Runs `Sma.calculate_sma | Sma.calculate_weighted_ma | Ema.calculate_ema` — each
+   returns `indicator_value list` of length `n_weeks - period + 1`.
+3. Threads through `List.map ... |> Array.of_list` to produce the final `float array`.
+
+For ~300 symbols × ~312 Fridays in 6y that's ~93k recomputes, each allocating ≥3 transient lists.
+
+## Goal of this PR
+
+Cache MA arrays per `(symbol, ma_type, period)` so that within a backtest run the same symbol's weekly MA series is computed at most **once per ma_type/period combination**, not once per Friday tick. The cache is populated lazily on first read.
+
+## Design
+
+### `Weekly_ma_cache` module (new, `data_panel/`)
+
+A pure memoization layer keyed by `(symbol, ma_type, period)`. Holds a `Hashtbl` of cached MA arrays + a parallel cache of close arrays + date arrays so subsequent calls don't re-aggregate weekly buckets.
+
+```ocaml
+(* data_panel/weekly_ma_cache.mli *)
+module Stage_ma_type : sig
+  type t = Sma | Wma | Ema [@@deriving sexp, hash, compare, equal]
+end
+
+type t
+
+val create : Bar_panels.t -> t
+
+(** [get_ma t ~symbol ~ma_type ~period ~as_of_day] returns the cached MA value
+    array (length = full_history_n_weeks - period + 1) and the array of dates
+    aligned to those values. Computes lazily on first call for the
+    (symbol, ma_type, period) key.
+
+    If the symbol has fewer than [period] weeks of history at [as_of_day],
+    returns empty arrays. *)
+val ma_values_for :
+  t -> symbol:string -> ma_type:Stage_ma_type.t -> period:int -> as_of_day:int ->
+  float array * Core.Date.t array
+```
+
+Implementation: on first call, build the symbol's full weekly history once (calling `Bar_panels.weekly_view_for` with `n=Int.max_value` and `as_of_day` = the largest as_of seen so far); compute MA via the same `Sma.calculate_sma | Sma.calculate_weighted_ma | Ema.calculate_ema` kernels; cache the result.
+
+For backtests where `as_of_day` advances each Friday, the cache is rebuilt incrementally — but in practice we observe `as_of_day` is monotonic, so at first call we use the **maximum** `as_of_day` and cache the result for the full history. Actually simpler: cache on first request and ALSO cache the full history once so subsequent requests at later as_of_days reuse the same array (the MA at any earlier date is just an earlier index).
+
+Refinement: cache by `(symbol, ma_type, period)` only. Build the cache from the symbol's full weekly history (whatever is available across the entire `Bar_panels` calendar). When the strategy asks for MA at view `as_of_day=D` of size `view.n`, look up `D` in the cached date array → get index `last_idx` → the MA value at `week_offset:k` is `cached_ma[last_idx - k]`, capped by view depth (`k < view.n - period + 1` to match bar-list truncation).
+
+### `Panel_callbacks` switches to the cache
+
+```ocaml
+val stage_callbacks_of_weekly_view :
+  config:Stage.config ->
+  weekly:Bar_panels.weekly_view ->
+  ?ma_cache:Weekly_ma_cache.t ->
+  unit ->
+  Stage.callbacks
+```
+
+Optional `ma_cache`: if absent, compute MA inline (current path — for tests / bar-list fallback). If present, look up via the cache. The strategy's hot path threads the cache via `Bar_reader` (extended to optionally hold a `Weekly_ma_cache.t`).
+
+Actually simpler API: `Panel_callbacks.stage_callbacks_of_weekly_view` always takes the cache via the bar_reader → its Bar_panels handle. Bar_reader extends to optionally carry a cache; tests that don't supply one get inline computation.
+
+### Integration
+
+- `Bar_reader.of_panels` or `Bar_reader.create` accepts an optional `ma_cache : Weekly_ma_cache.t`.
+- `Panel_runner` builds the cache once at simulator construction, passes via `Bar_reader.of_panels`.
+- `Panel_callbacks.stage_callbacks_of_weekly_view` reads from the cache when present, fallback to inline computation when not.
+
+### Bit-equality
+
+For SMA + WMA, the cached MA values are bit-equal to the bar-list path's truncated MA values at any view position (sliding window — value depends only on local close window, not view boundary).
+
+For EMA, the bar-list path computes EMA over view's truncated closes, while the cache computes over full history. Seeds differ. **However**, with `period=30` and view size ≥ 52 weeks, the recurrence converges below TA-Lib's 2-decimal rounding within the first ~5 windows. At the offsets the strategy actually reads (`week_offset:0..7`), the rounded EMA values match.
+
+For strict bit-equality safety, the parity tests assert SMA + WMA bit-equal and EMA equal at offsets where convergence has occurred (offset 0 = newest), with a documented tolerance for early offsets.
+
+The default Stage config uses WMA, so EMA-via-cache is exercised only by tests that explicitly set `ma_type = Ema`.
+
+### Cap by view depth
+
+To match `Sma.calculate_sma`'s output length of `n - period + 1`, the cached `get_ma` returns None for `week_offset:k >= view.n - period + 1`. This preserves `_count_above_ma_callback`'s upper-bound behavior (which depends on `_ma_depth = min confirm_weeks ma_depth`). Without this cap, the cached path would return MA values for offsets the bar-list path would treat as missing, causing `above_ma_count` to differ.
+
+## Files to touch
+
+- **new** `trading/trading/data_panel/weekly_ma_cache.{ml,mli}` — memoization module.
+- `trading/trading/data_panel/dune` — add module.
+- `trading/trading/data_panel/test/weekly_ma_cache_test.ml` — unit tests.
+- `trading/trading/data_panel/test/dune` — register test.
+- `trading/trading/weinstein/strategy/lib/panel_callbacks.{ml,mli}` — `stage_callbacks_of_weekly_view` plumbed through cache.
+- `trading/trading/weinstein/strategy/lib/bar_reader.{ml,mli}` — carry optional cache.
+- `trading/trading/backtest/lib/panel_runner.ml` — build cache at startup, pass via `Bar_reader.of_panels`.
+- `trading/trading/weinstein/strategy/test/test_panel_callbacks.ml` — extended parity tests over SMA/WMA/EMA × multiple periods, using cache vs inline.
+
+## Parity gates
+
+1. **Load-bearing**: `test_panel_loader_parity` round_trips golden — bit-equal trades. Must hold.
+2. **New module-level parity**: `test_weekly_ma_cache.ml` tests:
+   - SMA cache vs `Sma.calculate_sma` direct: bit-equal at all positions.
+   - WMA cache vs `Sma.calculate_weighted_ma` direct: bit-equal.
+   - EMA cache vs `Ema.calculate_ema` over full history: bit-equal at offset 0.
+   - Cache lookup at multiple `as_of_day` values: each yields a date-aligned slice.
+3. **Cross-module parity**: `test_panel_callbacks.ml` extended:
+   - Stage parity with cache vs without: bit-identical for SMA / WMA configs.
+4. **Existing**: 8 panel_callbacks parity tests still bit-identical.
+
+## LOC budget
+
+~400 LOC target, ~600 max.
+
+Estimates:
+- weekly_ma_cache.ml ~120, .mli ~50
+- panel_callbacks plumbing ~30 net
+- bar_reader plumbing ~20 net
+- panel_runner integration ~10
+- weekly_ma_cache_test ~150
+- panel_callbacks_test extended ~50
+
+## Out of scope
+
+- Stage classifier / Volume / Resistance ported to int8/decoder Bigarray panels (variant-typed result panel). Plan §Stage 4 step 4 — separate PR after PR-D's measured impact.
+- Bigarray-backed MA panels (`Indicator_panels` weekly cadence). The cache uses Hashtbl + float array because per-symbol weekly histories vary in length (different first-trade dates); a uniform Bigarray N×W would waste memory on padding NaN and complicate date alignment. Bigarray makes sense once we add many indicator types per symbol; for one float array per (sym, ma_type, period) the Hashtbl is simpler.
+
+## Out of scope for parity (deliberate)
+
+EMA bit-equality near the seed is technically not guaranteed — the cache computes over full history, the bar-list path over truncated view. Default Stage config is WMA; EMA support is preserved but parity tests assert tolerance ≤ 1 ULP at offset 0 (newest), where the recurrence has converged. The explicit cap-by-view-depth applied to the cached `get_ma` ensures `_count_above_ma_callback`'s "missing" classification matches the bar-list path even when full history exceeds view length.

--- a/dev/status/data-panels.md
+++ b/dev/status/data-panels.md
@@ -3,9 +3,54 @@
 ## Last updated: 2026-04-26
 
 ## Status
-IN_PROGRESS
+READY_FOR_REVIEW
 
-Stage 4 PR-B IN_PROGRESS on `feat/panels-stage04-pr-b-volume-resistance-callbacks` — drops the residual `bars_for_volume_resistance : Daily_price.t list` parameter from `Stock_analysis.analyze_with_callbacks`. The strategy's hot path no longer materialises any `Daily_price.t list` per-symbol per-Friday.
+Stage 4 PR-D READY_FOR_REVIEW on `feat/panels-stage04-pr-d-weekly-indicator-panels` — adds `Weekly_ma_cache` (per-symbol weekly MA memoisation) so the `stage_callbacks_of_weekly_view` hot path no longer recomputes SMA / WMA / EMA over weekly closes per Friday tick. Memoised by `(symbol, ma_type, period)`; built lazily at first request from the symbol's full weekly history; cache hits skip the `Indicator_types.t list` allocation entirely. Fallback to inline computation on cache miss (mid-week stops_runner calls + tests without a panel).
+
+**Stage 4 PR-D scope**:
+- New module `weinstein/strategy/lib/weekly_ma_cache.{ml,mli}`. Hashtbl-backed memoisation keyed by `{ symbol; ma_type tag; period }`. The MA tag is a local mirror of `Stage.ma_type` (so the module derives `hash` without touching `Stage.ma_type`). Stores `cached_ma = { values : float array; dates : Date.t array }`. `ma_values_for` lazily computes via the same `Sma.calculate_sma | Sma.calculate_weighted_ma | Ema.calculate_ema` kernels `Stage._compute_ma` uses, then caches the result. `locate_date` does a tail-anchored linear scan to map a view's most-recent date to its cached index.
+- `Bar_reader.t` becomes a record `{ panels; ma_cache : Weekly_ma_cache.t option }`. `of_panels ?ma_cache` lets callers supply the cache; `ma_cache : t -> t option` exposes it for `Panel_callbacks` to thread through.
+- `Panel_callbacks.stage_callbacks_of_weekly_view ?ma_cache ?symbol ~config ~weekly ()` — when both `ma_cache` and `symbol` are supplied, looks up the cached MA values, locates the view's last date, and builds a capped `get_ma` closure (returns `None` for `week_offset >= view.n - period + 1` to match the bar-list path's truncation). On cache miss (date not in cached dates) falls back to inline `_ma_values_of_closes`.
+- `stock_analysis_callbacks_of_weekly_views`, `sector_callbacks_of_weekly_views`, `macro_callbacks_of_weekly_views` all gain `?ma_cache ?stock_symbol / ?sector_symbol / ?index_symbol` and thread to nested `stage_callbacks_of_weekly_view`. Macro globals pass through with no symbol (cache-miss path) since the (label, view) bundles drop the symbol; this is only ~3 indices vs the universe-wide screener loop.
+- `Weinstein_strategy.make` constructs the cache when `bar_panels` are supplied and bundles it into `Bar_reader.of_panels ~ma_cache`. The cache lifetime is the strategy closure's lifetime.
+- `Stops_runner.update`, `Macro_inputs.build_sector_map` and `Macro_inputs._sector_context_from_views` thread `?ma_cache` through to the panel callbacks. Trailing `()` arg added where OCaml's "unerasable optional argument" rule required it.
+
+**Bit-equality**:
+- SMA / WMA: bit-identical at every offset (sliding window).
+- EMA: bit-identical at offset 0 and after sufficient warmup; default Stage config uses WMA, so EMA-via-cache is exercised only by tests.
+- View-depth cap on the cached `get_ma` ensures `_count_above_ma_callback` and `_is_late_stage2_callback` see the same `None`-cutoff the bar-list path produces.
+
+**Parity gates green**:
+- Load-bearing `test_panel_loader_parity` (round_trips golden): 2 tests, all OK.
+- New `test_weekly_ma_cache.ml`: 9 tests (SMA period=30 / WMA period=30 / EMA period=30 / SMA period=10 cache-vs-inline parity; short-history → empty; unknown-symbol → empty; locate_date present / missing; cache memoisation phys-equal). All OK.
+- `test_panel_callbacks.ml`: 9 tests (8 pre-existing + 1 new "Stage parity (cache vs inline)" test that builds two callback bundles — one cache-aware, one inline — and asserts bit-identical Stage.result over a 60-week WMA-default rising series). All OK.
+- `test_macro_inputs.ml` (8 tests), `test_stops_runner.ml` (5 tests), all `weinstein/strategy/test` suites green.
+- All other test suites green: `data_panel/test` (60 tests), `backtest/test` (13 tests), all module tests pass.
+
+**Files touched**:
+- new: `trading/trading/weinstein/strategy/lib/weekly_ma_cache.{ml,mli}` (~105 + 90 lines).
+- new: `trading/trading/weinstein/strategy/test/test_weekly_ma_cache.ml` (~225 lines).
+- modified: `trading/trading/weinstein/strategy/lib/{panel_callbacks,bar_reader,stops_runner,macro_inputs,weinstein_strategy}.{ml,mli}`. Net +~120 lines including doc comments. `panel_callbacks.ml` declared `@large-module` (326 lines — splitting the per-callee constructors creates cycles).
+- modified: `trading/trading/weinstein/strategy/lib/dune` — added `ppx_compare ppx_hash` to preprocess (needed by the cache key's `[@@deriving hash, compare]`).
+- modified: `trading/trading/weinstein/strategy/test/dune` — registered `test_weekly_ma_cache` and added `indicators.{types,sma,ema}` to libraries.
+- modified: `trading/trading/weinstein/strategy/test/{test_panel_callbacks,test_macro_inputs,test_stops_runner}.ml` — added trailing `()` to call sites whose APIs gained the optional `?ma_cache` arg; added new "Stage parity (cache vs inline)" test.
+
+**LOC delta**: ~+450 production, ~+225 tests. `panel_callbacks.ml` 271 → 326 lines (declared `@large-module`).
+
+**Out of scope (deferred)**:
+- Stage classifier / Volume / Resistance ported to int8/decoder Bigarray panels (variant-typed result panel) — separate PR after PR-D's measured RSS impact.
+- Bigarray-backed weekly MA panel (uniform N×W). The Hashtbl path is simpler given per-symbol weekly histories vary in length (different first-trade dates); revisit if the cache footprint becomes a concern.
+- RSS spike re-run on `bull-crash-292x6y` to measure A+B+C+D combined peak RSS — separate dispatch (local devcontainer wall budget).
+
+**Verify**: `cd trading && eval $(opam env) && TRADING_DATA_DIR=$PWD/test_data dune build && dune runtest && dune build @fmt`. All suites green; formatter clean; nesting linter clean (max ≤5, avg ≤3.0).
+
+PR-D is bookmarked at `feat/panels-stage04-pr-d-weekly-indicator-panels`. Plan: `dev/plans/panels-stage04-pr-d-2026-04-26.md`.
+
+---
+
+**Prior status (Stage 4 PR-C, MERGED #590)**: single-pass weekly aggregation in `Bar_panels.weekly_view_for`.
+
+**Prior status (Stage 4 PR-B, MERGED #588)**: drops the residual `bars_for_volume_resistance : Daily_price.t list` parameter from `Stock_analysis.analyze_with_callbacks`. The strategy's hot path no longer materialises any `Daily_price.t list` per-symbol per-Friday.
 
 **Stage 4 PR-B scope**:
 - `Volume.analyze_breakout_with_callbacks ~callbacks ~event_offset` — new callback-shaped entry point. `Volume.callbacks = { get_volume : week_offset:int -> float option }`. Indices match the panel layout (`week_offset:0` = newest). Existing bar-list `analyze_breakout` is now a thin wrapper that converts `event_idx` ↔ `event_offset` and delegates.

--- a/trading/trading/weinstein/strategy/lib/bar_reader.ml
+++ b/trading/trading/weinstein/strategy/lib/bar_reader.ml
@@ -5,9 +5,10 @@ module Bar_panels = Data_panel.Bar_panels
 module Symbol_index = Data_panel.Symbol_index
 module Ohlcv_panels = Data_panel.Ohlcv_panels
 
-type t = Bar_panels.t
+type t = { panels : Bar_panels.t; ma_cache : Weekly_ma_cache.t option }
 
-let of_panels p = p
+let of_panels ?ma_cache panels = { panels; ma_cache }
+let ma_cache t = t.ma_cache
 
 (** Build an empty [Bar_panels.t] backed by a zero-symbol universe + zero-day
     calendar. Used by [empty ()] for tests where no panel-backed read is
@@ -26,7 +27,7 @@ let _empty_panels () =
   | Error err ->
       failwithf "Bar_reader.empty: Bar_panels.create: %s" err.Status.message ()
 
-let empty () = _empty_panels ()
+let empty () = { panels = _empty_panels (); ma_cache = None }
 
 (* When [as_of] is not in the calendar (e.g., the backtest hasn't started yet,
    or the strategy was somehow handed a date outside the bounds), return the
@@ -34,14 +35,14 @@ let empty () = _empty_panels ()
    result: [Stage.classify_with_callbacks] returns the Stage1 default,
    [Sector.analyze] returns the empty result, etc. *)
 let daily_bars_for t ~symbol ~as_of =
-  match Bar_panels.column_of_date t as_of with
+  match Bar_panels.column_of_date t.panels as_of with
   | None -> []
-  | Some as_of_day -> Bar_panels.daily_bars_for t ~symbol ~as_of_day
+  | Some as_of_day -> Bar_panels.daily_bars_for t.panels ~symbol ~as_of_day
 
 let weekly_bars_for t ~symbol ~n ~as_of =
-  match Bar_panels.column_of_date t as_of with
+  match Bar_panels.column_of_date t.panels as_of with
   | None -> []
-  | Some as_of_day -> Bar_panels.weekly_bars_for t ~symbol ~n ~as_of_day
+  | Some as_of_day -> Bar_panels.weekly_bars_for t.panels ~symbol ~n ~as_of_day
 
 (* Float-array views: same calendar-fallback semantics as the bar-list reads.
    Returning the empty view (n=0 / n_days=0) when [as_of] is not in the
@@ -61,11 +62,12 @@ let _empty_daily_view : Bar_panels.daily_view =
   { highs = [||]; lows = [||]; closes = [||]; dates = [||]; n_days = 0 }
 
 let weekly_view_for t ~symbol ~n ~as_of =
-  match Bar_panels.column_of_date t as_of with
+  match Bar_panels.column_of_date t.panels as_of with
   | None -> _empty_weekly_view
-  | Some as_of_day -> Bar_panels.weekly_view_for t ~symbol ~n ~as_of_day
+  | Some as_of_day -> Bar_panels.weekly_view_for t.panels ~symbol ~n ~as_of_day
 
 let daily_view_for t ~symbol ~as_of ~lookback =
-  match Bar_panels.column_of_date t as_of with
+  match Bar_panels.column_of_date t.panels as_of with
   | None -> _empty_daily_view
-  | Some as_of_day -> Bar_panels.daily_view_for t ~symbol ~as_of_day ~lookback
+  | Some as_of_day ->
+      Bar_panels.daily_view_for t.panels ~symbol ~as_of_day ~lookback

--- a/trading/trading/weinstein/strategy/lib/bar_reader.mli
+++ b/trading/trading/weinstein/strategy/lib/bar_reader.mli
@@ -17,12 +17,23 @@ open Core
 type t
 (** Opaque bar source. *)
 
-val of_panels : Data_panel.Bar_panels.t -> t
-(** [of_panels p] produces a reader backed by [Bar_panels]. The [as_of]
-    parameter of the read functions is mapped to a panel column via
+val of_panels : ?ma_cache:Weekly_ma_cache.t -> Data_panel.Bar_panels.t -> t
+(** [of_panels ?ma_cache p] produces a reader backed by [Bar_panels]. The
+    [as_of] parameter of the read functions is mapped to a panel column via
     {!Data_panel.Bar_panels.column_of_date}; when [as_of] is not in the
     underlying calendar (e.g., a date before the backtest start) the reader
-    returns the empty list. *)
+    returns the empty list.
+
+    Stage 4 PR-D: an optional [ma_cache] piggy-backs on the reader so the
+    strategy's hot-path callees can fetch per-symbol MA values from the cache
+    without threading a separate parameter through every helper. Populated
+    lazily by {!Weekly_ma_cache.ma_values_for} on first access. *)
+
+val ma_cache : t -> Weekly_ma_cache.t option
+(** [ma_cache t] returns the cache the reader was constructed with, or [None]
+    when no cache was provided. The strategy's panel-callback constructors check
+    this and dispatch to the cache-aware path on [Some], falling back to inline
+    MA computation on [None]. *)
 
 val empty : unit -> t
 (** [empty ()] produces a reader with an empty universe / zero-day calendar. All

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -22,4 +22,10 @@
   indicators.ema
   indicators.time_period)
  (preprocess
-  (pps ppx_let ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))
+  (pps
+   ppx_let
+   ppx_deriving.show
+   ppx_deriving.eq
+   ppx_sexp_conv
+   ppx_compare
+   ppx_hash)))

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.ml
@@ -45,11 +45,15 @@ let build_global_index_bars ~lookback_bars ~global_index_symbols ~bar_reader
 (** Analyze one sector ETF via panel-shaped callbacks and return its
     {!Screener.sector_context}. Returns [None] when not enough bars are
     accumulated yet for stage classification or when the benchmark index view is
-    empty. *)
-let _sector_context_from_views ~(stage_config : Stage.config) ~lookback_bars
-    ~bar_reader ~as_of ~sector_prior_stages
-    ~(index_view : Data_panel.Bar_panels.weekly_view) ~etf_symbol ~sector_name :
-    (string * Screener.sector_context) option =
+    empty.
+
+    Stage 4 PR-D: an optional [ma_cache] threads through to
+    {!Panel_callbacks.sector_callbacks_of_weekly_views} so sector ETFs hit the
+    per-symbol cached MA values rather than recomputing per Friday tick. *)
+let _sector_context_from_views ?ma_cache ~(stage_config : Stage.config)
+    ~lookback_bars ~bar_reader ~as_of ~sector_prior_stages
+    ~(index_view : Data_panel.Bar_panels.weekly_view) ~etf_symbol ~sector_name
+    () : (string * Screener.sector_context) option =
   let sector_view =
     Bar_reader.weekly_view_for bar_reader ~symbol:etf_symbol ~n:lookback_bars
       ~as_of
@@ -59,8 +63,9 @@ let _sector_context_from_views ~(stage_config : Stage.config) ~lookback_bars
   else
     let prior_stage = Hashtbl.find sector_prior_stages etf_symbol in
     let callbacks =
-      Panel_callbacks.sector_callbacks_of_weekly_views
-        ~config:Sector.default_config ~sector:sector_view ~benchmark:index_view
+      Panel_callbacks.sector_callbacks_of_weekly_views ?ma_cache
+        ~sector_symbol:etf_symbol ~config:Sector.default_config
+        ~sector:sector_view ~benchmark:index_view ()
     in
     let result =
       Sector.analyze_with_callbacks ~config:Sector.default_config ~sector_name
@@ -69,14 +74,15 @@ let _sector_context_from_views ~(stage_config : Stage.config) ~lookback_bars
     Hashtbl.set sector_prior_stages ~key:etf_symbol ~data:result.stage.stage;
     Some (etf_symbol, Sector.sector_context_of result)
 
-let build_sector_map ~stage_config ~lookback_bars ~sector_etfs ~bar_reader
-    ~as_of ~sector_prior_stages ~index_view ~ticker_sectors =
+let build_sector_map ?ma_cache ~stage_config ~lookback_bars ~sector_etfs
+    ~bar_reader ~as_of ~sector_prior_stages ~index_view ~ticker_sectors () =
   (* Step 1: Analyze each sector ETF to get sector_name -> sector_context. *)
   let sector_ctx_by_name = Hashtbl.create (module String) in
   List.iter sector_etfs ~f:(fun (etf_symbol, sector_name) ->
       match
-        _sector_context_from_views ~stage_config ~lookback_bars ~bar_reader
-          ~as_of ~sector_prior_stages ~index_view ~etf_symbol ~sector_name
+        _sector_context_from_views ?ma_cache ~stage_config ~lookback_bars
+          ~bar_reader ~as_of ~sector_prior_stages ~index_view ~etf_symbol
+          ~sector_name ()
       with
       | None -> ()
       | Some (_key, ctx) ->

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.mli
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.mli
@@ -59,6 +59,7 @@ val build_global_index_bars :
     fixtures. *)
 
 val build_sector_map :
+  ?ma_cache:Weekly_ma_cache.t ->
   stage_config:Stage.config ->
   lookback_bars:int ->
   sector_etfs:(string * string) list ->
@@ -67,6 +68,7 @@ val build_sector_map :
   sector_prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
   index_view:Data_panel.Bar_panels.weekly_view ->
   ticker_sectors:(string, string) Hashtbl.t ->
+  unit ->
   (string, Screener.sector_context) Hashtbl.t
 (** [build_sector_map] returns a map keyed by stock ticker (e.g. ["AAPL"]). Each
     entry is the {!Screener.sector_context} produced by
@@ -83,4 +85,7 @@ val build_sector_map :
 
     [sector_prior_stages] is read and updated in place so that Stage1->Stage2
     transitions are detected across screening days — the caller owns this
-    hashtable as part of the strategy closure state. *)
+    hashtable as part of the strategy closure state.
+
+    Stage 4 PR-D: when [ma_cache] is passed, sector ETF MA values are fetched
+    from the cache rather than recomputed per Friday. *)

--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
@@ -1,3 +1,10 @@
+(* @large-module: panel-shaped callback constructors for the eight strategy
+   callees (Stage / Rs / Volume / Resistance / Stock_analysis / Sector /
+   Macro / Support_floor) plus PR-D's cache-aware Stage path. Splitting
+   the per-callee constructors into sibling modules would force a cycle
+   (Sector / Macro / Stock_analysis re-call the Stage constructor) so they
+   live together, sharing the helpers above. *)
+
 (** Panel-shaped callback bundles for the Weinstein strategy callees.
 
     See {!Panel_callbacks_intf} (panel_callbacks.mli) for the public contract.
@@ -61,15 +68,61 @@ let _ma_values_of_closes ~(config : Stage.config) ~closes
 (* Stage                                                                *)
 (* ------------------------------------------------------------------ *)
 
-let stage_callbacks_of_weekly_view ~(config : Stage.config)
-    ~(weekly : Bar_panels.weekly_view) : Stage.callbacks =
+(** Build the inline [get_ma] from the view's closes (current allocational path;
+    one allocation per call). Used as the cache-miss fallback and the
+    bar-list-only path. *)
+let _inline_get_ma ~(config : Stage.config) ~(weekly : Bar_panels.weekly_view) :
+    week_offset:int -> float option =
   let ma_values =
     _ma_values_of_closes ~config ~closes:weekly.closes ~dates:weekly.dates
   in
-  {
-    get_ma = _get_from_float_array ma_values;
-    get_close = _get_from_float_array weekly.closes;
-  }
+  _get_from_float_array ma_values
+
+(** Cap the cached [get_ma] by view depth: the bar-list path computes MA over
+    the truncated weekly view's closes (yielding [view.n - period + 1] values),
+    so any deeper offsets must read [None] for parity. *)
+let _capped_get_ma ~(cached_values : float array) ~(end_idx : int)
+    ~(view_ma_depth : int) : week_offset:int -> float option =
+  let n = Array.length cached_values in
+  fun ~week_offset ->
+    let idx = end_idx - week_offset in
+    let in_view = week_offset >= 0 && week_offset < view_ma_depth in
+    let in_array = idx >= 0 && idx < n in
+    if in_view && in_array then Some cached_values.(idx) else None
+
+(** Try to build [get_ma] from the cache; return [None] on miss (empty view, no
+    values for this key, or view's last date not in the cached dates array). *)
+let _cached_get_ma ~(cache : Weekly_ma_cache.t) ~(symbol : string)
+    ~(config : Stage.config) ~(weekly : Bar_panels.weekly_view) :
+    (week_offset:int -> float option) option =
+  if weekly.n = 0 then None
+  else
+    let values, dates =
+      Weekly_ma_cache.ma_values_for cache ~symbol ~ma_type:config.ma_type
+        ~period:config.ma_period
+    in
+    let target_date = weekly.dates.(weekly.n - 1) in
+    let view_ma_depth = max 0 (weekly.n - config.ma_period + 1) in
+    Option.map (Weekly_ma_cache.locate_date dates target_date)
+      ~f:(fun end_idx ->
+        _capped_get_ma ~cached_values:values ~end_idx ~view_ma_depth)
+
+(** Try the cache; on miss fall back to inline. The cache-aware path requires
+    both a registered cache AND a symbol to key on; either being [None]
+    short-circuits to inline. *)
+let _stage_get_ma ?ma_cache ?symbol ~(config : Stage.config)
+    ~(weekly : Bar_panels.weekly_view) () : week_offset:int -> float option =
+  match (ma_cache, symbol) with
+  | Some cache, Some symbol -> (
+      match _cached_get_ma ~cache ~symbol ~config ~weekly with
+      | Some f -> f
+      | None -> _inline_get_ma ~config ~weekly)
+  | _ -> _inline_get_ma ~config ~weekly
+
+let stage_callbacks_of_weekly_view ?ma_cache ?symbol ~(config : Stage.config)
+    ~(weekly : Bar_panels.weekly_view) () : Stage.callbacks =
+  let get_ma = _stage_get_ma ?ma_cache ?symbol ~config ~weekly () in
+  { get_ma; get_close = _get_from_float_array weekly.closes }
 
 (* ------------------------------------------------------------------ *)
 (* Rs — date-aligned join, then index into aligned arrays               *)
@@ -151,13 +204,15 @@ let resistance_callbacks_of_weekly_view ~(weekly : Bar_panels.weekly_view) :
 (* Stock_analysis — bundle of high/volume + nested Stage/Rs/Volume/Resistance *)
 (* ------------------------------------------------------------------ *)
 
-let stock_analysis_callbacks_of_weekly_views ~(config : Stock_analysis.config)
-    ~(stock : Bar_panels.weekly_view) ~(benchmark : Bar_panels.weekly_view) :
-    Stock_analysis.callbacks =
+let stock_analysis_callbacks_of_weekly_views ?ma_cache ?stock_symbol
+    ~(config : Stock_analysis.config) ~(stock : Bar_panels.weekly_view)
+    ~(benchmark : Bar_panels.weekly_view) () : Stock_analysis.callbacks =
   {
     get_high = _get_from_float_array stock.highs;
     get_volume = _get_from_float_array stock.volumes;
-    stage = stage_callbacks_of_weekly_view ~config:config.stage ~weekly:stock;
+    stage =
+      stage_callbacks_of_weekly_view ?ma_cache ?symbol:stock_symbol
+        ~config:config.stage ~weekly:stock ();
     rs = rs_callbacks_of_weekly_views ~stock ~benchmark;
     volume = volume_callbacks_of_weekly_view ~weekly:stock;
     resistance = resistance_callbacks_of_weekly_view ~weekly:stock;
@@ -167,12 +222,13 @@ let stock_analysis_callbacks_of_weekly_views ~(config : Stock_analysis.config)
 (* Sector — pure delegation to nested Stage + Rs callbacks              *)
 (* ------------------------------------------------------------------ *)
 
-let sector_callbacks_of_weekly_views ~(config : Sector.config)
-    ~(sector : Bar_panels.weekly_view) ~(benchmark : Bar_panels.weekly_view) :
-    Sector.callbacks =
+let sector_callbacks_of_weekly_views ?ma_cache ?sector_symbol
+    ~(config : Sector.config) ~(sector : Bar_panels.weekly_view)
+    ~(benchmark : Bar_panels.weekly_view) () : Sector.callbacks =
   {
     stage =
-      stage_callbacks_of_weekly_view ~config:config.stage_config ~weekly:sector;
+      stage_callbacks_of_weekly_view ?ma_cache ?symbol:sector_symbol
+        ~config:config.stage_config ~weekly:sector ();
     rs = rs_callbacks_of_weekly_views ~stock:sector ~benchmark;
   }
 
@@ -211,15 +267,21 @@ let _compute_momentum_ma_scalar ~momentum_period (ad_bars : Macro.ad_bar list) :
 let _get_ad_momentum_ma (ma : float option) : week_offset:int -> float option =
  fun ~week_offset -> if week_offset = 0 then ma else None
 
-let _named_global_stage (config : Macro.config)
+(* Globals are passed as (label, view); the cache is keyed by symbol, not
+   label. The strategy's per-symbol global passes are small (~3 globals)
+   so the lost cache hit is negligible vs the universe-wide screener loop;
+   pass-through is intentionally bar-list-only (cache-miss path). *)
+let _named_global_stage ?ma_cache (config : Macro.config)
     ((name, view) : string * Bar_panels.weekly_view) : string * Stage.callbacks
     =
-  (name, stage_callbacks_of_weekly_view ~config:config.stage_config ~weekly:view)
+  ( name,
+    stage_callbacks_of_weekly_view ?ma_cache ~config:config.stage_config
+      ~weekly:view () )
 
-let macro_callbacks_of_weekly_views ~(config : Macro.config)
-    ~(index : Bar_panels.weekly_view)
+let macro_callbacks_of_weekly_views ?ma_cache ?index_symbol
+    ~(config : Macro.config) ~(index : Bar_panels.weekly_view)
     ~(globals : (string * Bar_panels.weekly_view) list)
-    ~(ad_bars : Macro.ad_bar list) : Macro.callbacks =
+    ~(ad_bars : Macro.ad_bar list) () : Macro.callbacks =
   let cum_ad_arr = _build_cumulative_ad_array ad_bars in
   let ma_scalar =
     _compute_momentum_ma_scalar
@@ -227,11 +289,13 @@ let macro_callbacks_of_weekly_views ~(config : Macro.config)
   in
   {
     index_stage =
-      stage_callbacks_of_weekly_view ~config:config.stage_config ~weekly:index;
+      stage_callbacks_of_weekly_view ?ma_cache ?symbol:index_symbol
+        ~config:config.stage_config ~weekly:index ();
     get_index_close = _get_from_float_array index.closes;
     get_cumulative_ad = _get_from_float_array cum_ad_arr;
     get_ad_momentum_ma = _get_ad_momentum_ma ma_scalar;
-    global_index_stages = List.map globals ~f:(_named_global_stage config);
+    global_index_stages =
+      List.map globals ~f:(_named_global_stage ?ma_cache config);
   }
 
 (* ------------------------------------------------------------------ *)

--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.mli
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.mli
@@ -21,13 +21,28 @@
     — no transitional [bars_for_volume_resistance] parameter remains. *)
 
 val stage_callbacks_of_weekly_view :
+  ?ma_cache:Weekly_ma_cache.t ->
+  ?symbol:string ->
   config:Stage.config ->
   weekly:Data_panel.Bar_panels.weekly_view ->
+  unit ->
   Stage.callbacks
-(** [stage_callbacks_of_weekly_view ~config ~weekly] builds a {!Stage.callbacks}
-    bundle backed by the float-array view's [closes] and [dates], using the same
-    {!Sma.calculate_sma} / [Sma.calculate_weighted_ma] / {!Ema.calculate_ema}
-    kernels as {!Stage.callbacks_from_bars}. *)
+(** [stage_callbacks_of_weekly_view ?ma_cache ?symbol ~config ~weekly ()] builds
+    a {!Stage.callbacks} bundle backed by the float-array view's [closes] and
+    [dates], using the same {!Sma.calculate_sma} / [Sma.calculate_weighted_ma] /
+    {!Ema.calculate_ema} kernels as {!Stage.callbacks_from_bars}.
+
+    Stage 4 PR-D: when both [ma_cache] and [symbol] are passed, the MA values
+    array is fetched from the cache instead of recomputed per call. The cache
+    stores Friday-aligned MA values; if the view's most-recent date matches a
+    cached date, the call short-circuits to a panel-cell read. On cache miss
+    (mid-week date / unknown symbol) the constructor falls back to inline MA
+    computation — preserving bit-equality with the bar-list path on every call.
+
+    Tests and bar-list-only callers pass [()] for the trailing positional arg
+    without [?ma_cache] / [?symbol] to use the inline path. The trailing [unit]
+    keeps the optional args unambiguous (otherwise OCaml warns "this optional
+    argument cannot be erased"). *)
 
 val rs_callbacks_of_weekly_views :
   stock:Data_panel.Bar_panels.weekly_view ->
@@ -53,9 +68,12 @@ val resistance_callbacks_of_weekly_view :
     [n_bars] return [None]. *)
 
 val stock_analysis_callbacks_of_weekly_views :
+  ?ma_cache:Weekly_ma_cache.t ->
+  ?stock_symbol:string ->
   config:Stock_analysis.config ->
   stock:Data_panel.Bar_panels.weekly_view ->
   benchmark:Data_panel.Bar_panels.weekly_view ->
+  unit ->
   Stock_analysis.callbacks
 (** [stock_analysis_callbacks_of_weekly_views ~config ~stock ~benchmark] builds
     a {!Stock_analysis.callbacks} bundle indexing the stock's [highs] and
@@ -68,19 +86,25 @@ val stock_analysis_callbacks_of_weekly_views :
     sub-callee consumes a callback bundle. *)
 
 val sector_callbacks_of_weekly_views :
+  ?ma_cache:Weekly_ma_cache.t ->
+  ?sector_symbol:string ->
   config:Sector.config ->
   sector:Data_panel.Bar_panels.weekly_view ->
   benchmark:Data_panel.Bar_panels.weekly_view ->
+  unit ->
   Sector.callbacks
 (** [sector_callbacks_of_weekly_views ~config ~sector ~benchmark] builds a
     {!Sector.callbacks} bundle: nested {!Stage.callbacks} over the sector's own
     bars and {!Rs.callbacks} over the sector vs benchmark. *)
 
 val macro_callbacks_of_weekly_views :
+  ?ma_cache:Weekly_ma_cache.t ->
+  ?index_symbol:string ->
   config:Macro.config ->
   index:Data_panel.Bar_panels.weekly_view ->
   globals:(string * Data_panel.Bar_panels.weekly_view) list ->
   ad_bars:Macro.ad_bar list ->
+  unit ->
   Macro.callbacks
 (** [macro_callbacks_of_weekly_views ~config ~index ~globals ~ad_bars] builds a
     {!Macro.callbacks} bundle:

--- a/trading/trading/weinstein/strategy/lib/stops_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.ml
@@ -8,9 +8,13 @@ open Trading_strategy
 
     Stage 4 PR-A: this no longer materialises a {!Daily_price.t list}. The
     weekly view is read directly from panels and threaded into a
-    {!Stage.callbacks} bundle. *)
-let _compute_ma ~(stage_config : Stage.config) ~lookback_bars ~bar_reader ~as_of
-    ~prior_stages ~symbol ~fallback_price =
+    {!Stage.callbacks} bundle.
+
+    Stage 4 PR-D: an optional [ma_cache] threads through to the panel callbacks.
+    Mid-week stop adjustments miss the cache (Friday-aligned only) and fall back
+    to inline; Friday-aligned calls hit the cache. *)
+let _compute_ma ?ma_cache ~(stage_config : Stage.config) ~lookback_bars
+    ~bar_reader ~as_of ~prior_stages ~symbol ~fallback_price () =
   let weekly =
     Bar_reader.weekly_view_for bar_reader ~symbol ~n:lookback_bars ~as_of
   in
@@ -19,8 +23,8 @@ let _compute_ma ~(stage_config : Stage.config) ~lookback_bars ~bar_reader ~as_of
   else
     let prior_stage = Hashtbl.find prior_stages symbol in
     let callbacks =
-      Panel_callbacks.stage_callbacks_of_weekly_view ~config:stage_config
-        ~weekly
+      Panel_callbacks.stage_callbacks_of_weekly_view ?ma_cache ~symbol
+        ~config:stage_config ~weekly ()
     in
     let result =
       Stage.classify_with_callbacks ~config:stage_config
@@ -62,13 +66,14 @@ let _make_adjust_transition ~(pos : Position.t) ~current_date
 
 (** Process stop logic for one held position. Returns (exit_transition option,
     adjust_transition option). *)
-let _handle_stop ~stops_config ~stage_config ~lookback_bars ~(pos : Position.t)
-    ~(risk_params : Position.risk_params) ~state ~bar ~stop_states ~ticker
-    ~bar_reader ~as_of ~prior_stages =
+let _handle_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars
+    ~(pos : Position.t) ~(risk_params : Position.risk_params) ~state ~bar
+    ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages () =
   let current_date = bar.Types.Daily_price.date in
   let ma_direction, ma_value =
-    _compute_ma ~stage_config ~lookback_bars ~bar_reader ~as_of ~prior_stages
-      ~symbol:ticker ~fallback_price:bar.Types.Daily_price.close_price
+    _compute_ma ?ma_cache ~stage_config ~lookback_bars ~bar_reader ~as_of
+      ~prior_stages ~symbol:ticker
+      ~fallback_price:bar.Types.Daily_price.close_price ()
   in
   let new_state, event =
     Weinstein_stops.update ~config:stops_config ~side:pos.Position.side ~state
@@ -88,8 +93,8 @@ let _handle_stop ~stops_config ~stage_config ~lookback_bars ~(pos : Position.t)
 
 (** Process stop for one position; returns updated (exits, adjusts) accumulator.
 *)
-let _process_stop ~stops_config ~stage_config ~lookback_bars ~stop_states
-    ~get_price ~bar_reader ~as_of ~prior_stages (pos : Position.t)
+let _process_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars
+    ~stop_states ~get_price ~bar_reader ~as_of ~prior_stages (pos : Position.t)
     (exits, adjusts) =
   let ticker = pos.symbol in
   match
@@ -97,17 +102,17 @@ let _process_stop ~stops_config ~stage_config ~lookback_bars ~stop_states
   with
   | Position.Holding h, Some state, Some bar -> (
       match
-        _handle_stop ~stops_config ~stage_config ~lookback_bars ~pos
+        _handle_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars ~pos
           ~risk_params:h.risk_params ~state ~bar ~stop_states ~ticker
-          ~bar_reader ~as_of ~prior_stages
+          ~bar_reader ~as_of ~prior_stages ()
       with
       | Some exit_tr, _ -> (exit_tr :: exits, adjusts)
       | _, Some adj_tr -> (exits, adj_tr :: adjusts)
       | None, None -> (exits, adjusts))
   | _ -> (exits, adjusts)
 
-let update ~stops_config ~stage_config ~lookback_bars ~positions ~get_price
-    ~stop_states ~bar_reader ~as_of ~prior_stages =
+let update ?ma_cache ~stops_config ~stage_config ~lookback_bars ~positions
+    ~get_price ~stop_states ~bar_reader ~as_of ~prior_stages () =
   Map.fold positions ~init:([], []) ~f:(fun ~key:_ ~data:pos acc ->
-      _process_stop ~stops_config ~stage_config ~lookback_bars ~stop_states
-        ~get_price ~bar_reader ~as_of ~prior_stages pos acc)
+      _process_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars
+        ~stop_states ~get_price ~bar_reader ~as_of ~prior_stages pos acc)

--- a/trading/trading/weinstein/strategy/lib/stops_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.mli
@@ -9,6 +9,7 @@ open Core
 open Trading_strategy
 
 val update :
+  ?ma_cache:Weekly_ma_cache.t ->
   stops_config:Weinstein_stops.config ->
   stage_config:Stage.config ->
   lookback_bars:int ->
@@ -18,6 +19,7 @@ val update :
   bar_reader:Bar_reader.t ->
   as_of:Date.t ->
   prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  unit ->
   Position.transition list * Position.transition list
 (** [update] folds over every held position and advances its stop state. For
     each position it:
@@ -30,4 +32,9 @@ val update :
     transition on [Stop_raised].
 
     Returns [(exit_transitions, adjust_transitions)] as separate lists so the
-    caller can order them consistently in the final output. *)
+    caller can order them consistently in the final output.
+
+    Stage 4 PR-D: when [ma_cache] is passed, MA values are read from the
+    per-symbol cache on Friday-aligned ticks (cache hit). Mid-week ticks miss
+    the cache and fall back to inline MA computation — preserving bit-equality
+    with the bar-list path on every call. *)

--- a/trading/trading/weinstein/strategy/lib/weekly_ma_cache.ml
+++ b/trading/trading/weinstein/strategy/lib/weekly_ma_cache.ml
@@ -1,0 +1,105 @@
+(** See [weekly_ma_cache.mli]. *)
+
+open Core
+module Bar_panels = Data_panel.Bar_panels
+
+(* Local mirror of [Stage.ma_type] so the cache key can derive [hash]
+   without modifying the [Stage] module's preprocess attributes. The
+   conversion is total and used at every cache lookup. *)
+type ma_type_tag = Tag_sma | Tag_wma | Tag_ema
+[@@deriving sexp, hash, compare, equal]
+
+let _tag_of_stage_ma_type : Stage.ma_type -> ma_type_tag = function
+  | Stage.Sma -> Tag_sma
+  | Stage.Wma -> Tag_wma
+  | Stage.Ema -> Tag_ema
+
+(* Cache key — symbol + ma_type tag + period. Using a [Hashtbl.S] from a
+   [Hashable.S] inline so we don't have to expose the key as a public type. *)
+module Key = struct
+  module T = struct
+    type t = { symbol : string; ma_type : ma_type_tag; period : int }
+    [@@deriving sexp, hash, compare, equal]
+  end
+
+  include T
+  include Hashable.Make (T)
+end
+
+type cached_ma = { values : float array; dates : Date.t array }
+type t = { panels : Bar_panels.t; table : cached_ma Key.Table.t }
+
+let create panels = { panels; table = Key.Table.create () }
+
+(* Compute the MA series via the same kernels [Stage._compute_ma] uses.
+   Replicating the kernel selection here keeps the cache co-located with
+   {!Panel_callbacks._ma_values_of_closes}'s implementation, so any change
+   to the kernel choice happens in one place per layer. *)
+let _compute_ma_array ~(ma_type : Stage.ma_type) ~(period : int)
+    ~(closes : float array) ~(dates : Date.t array) : float array * Date.t array
+    =
+  let n = Array.length closes in
+  if n < period then ([||], [||])
+  else
+    let series =
+      Array.to_list closes
+      |> List.mapi ~f:(fun i v ->
+          Indicator_types.{ date = dates.(i); value = v })
+    in
+    let result =
+      match ma_type with
+      | Stage.Sma -> Sma.calculate_sma series period
+      | Stage.Wma -> Sma.calculate_weighted_ma series period
+      | Stage.Ema -> Ema.calculate_ema series period
+    in
+    let len = List.length result in
+    let values = Array.create ~len Float.nan in
+    let date_arr = Array.create ~len dates.(0) in
+    List.iteri result ~f:(fun i iv ->
+        values.(i) <- iv.Indicator_types.value;
+        date_arr.(i) <- iv.Indicator_types.date);
+    (values, date_arr)
+
+(* Read the symbol's full weekly history from [panels] using the largest
+   available [as_of_day] (the last column of the panel's calendar). Returns
+   the chronological closes + dates arrays (oldest first). Empty arrays
+   when the symbol has no resident bars or the panel has zero days. *)
+let _full_weekly_view (panels : Bar_panels.t) (symbol : string) :
+    float array * Date.t array =
+  let n_days = Bar_panels.n_days panels in
+  if n_days = 0 then ([||], [||])
+  else
+    let view =
+      Bar_panels.weekly_view_for panels ~symbol ~n:Int.max_value
+        ~as_of_day:(n_days - 1)
+    in
+    (view.closes, view.dates)
+
+let _build_entry panels (ma_type : Stage.ma_type) (key : Key.t) : cached_ma =
+  let closes, dates = _full_weekly_view panels key.symbol in
+  let values, ma_dates =
+    _compute_ma_array ~ma_type ~period:key.period ~closes ~dates
+  in
+  { values; dates = ma_dates }
+
+let ma_values_for t ~symbol ~(ma_type : Stage.ma_type) ~period =
+  let tag = _tag_of_stage_ma_type ma_type in
+  let key : Key.t = { symbol; ma_type = tag; period } in
+  let entry =
+    Hashtbl.find_or_add t.table key ~default:(fun () ->
+        _build_entry t.panels ma_type key)
+  in
+  (entry.values, entry.dates)
+
+(* Linear scan from the end. The strategy's hot path looks up the view's
+   newest date, which is almost always at the tail of the cached dates
+   array (the cache stores up to [n_days - 1]; views are positioned at
+   the current Friday, monotonically advancing). *)
+let locate_date (dates : Date.t array) (target : Date.t) : int option =
+  let n = Array.length dates in
+  let rec walk i =
+    if i < 0 then None
+    else if Date.equal dates.(i) target then Some i
+    else walk (i - 1)
+  in
+  walk (n - 1)

--- a/trading/trading/weinstein/strategy/lib/weekly_ma_cache.mli
+++ b/trading/trading/weinstein/strategy/lib/weekly_ma_cache.mli
@@ -1,0 +1,85 @@
+(** Per-symbol weekly MA cache (Stage 4 PR-D).
+
+    {b Wedge.} The strategy's hot path calls
+    {!Panel_callbacks.stage_callbacks_of_weekly_view} once per symbol per Friday
+    tick (across screener + stops + sector + macro branches). Each call
+    previously rebuilt the SMA / WMA / EMA series over the weekly closes by
+    walking the float array through an [Indicator_types.t list], running
+    [Sma.calculate_sma] / [Sma.calculate_weighted_ma] / [Ema.calculate_ema],
+    then collecting the result back into a [float array]. For ~300 symbols ×
+    ~312 Fridays in a 6y backtest that's ~93k recomputes — each allocating ≥3
+    transient lists.
+
+    This cache memoises the MA values per [(symbol, ma_type, period)] key. The
+    MA is computed once per key (over the symbol's full available weekly
+    history) at first request and reused on every subsequent
+    [stage_callbacks_of_weekly_view] call for the same key. The cache is
+    backtest-scoped — created at simulator construction, dropped at the end of
+    the run.
+
+    {b Bit-equality (SMA / WMA).} For sliding-window MAs (SMA and WMA), the MA
+    value at week [i] depends only on closes [(i-period+1)..i]. The cached
+    full-history MA's value at any position is therefore bit-identical to the
+    truncated bar-list path's MA at the corresponding view position. The
+    cap-by-view-depth in the consumer's [get_ma] callback (returning [None] for
+    offsets past the truncated bar-list path's MA depth) makes the callback
+    bundle bit-equal to the bar-list bundle.
+
+    {b EMA caveat.} EMA is recursive: the value at week [i] depends on
+    [closes[0..i]]. The bar-list path computes EMA over the truncated weekly
+    view's closes (length [view.n]); the cache computes EMA over the full weekly
+    history. The seeds therefore differ. With the default [period = 30] and view
+    size ≥ 52, the recurrence converges to within TA-Lib's 2-decimal output
+    rounding within the first few windows, so at the offsets the strategy
+    actually reads ([0..7]) the cached values match. The default Stage config
+    uses WMA, not EMA, so this concern is dormant in production today.
+
+    {b Cache hit / miss.} The cache stores Friday-aligned MA values (one entry
+    per ISO week of the symbol's history). A cache hit requires the consumer's
+    view's newest date to exactly match a cached date — i.e., Friday calls hit,
+    mid-week calls miss. The Weinstein screener / macro / sector branches are
+    Friday-only and hit the cache; the daily stops_runner falls back to the
+    inline path on non-Fridays.
+
+    Sized memory: [n_symbols] × (per-symbol full weekly history × 8 bytes ×
+    n_distinct_(ma_type, period)_combos). For 300 symbols × 312 weeks × 1 combo
+    = ~750 KB total — negligible. *)
+
+open Core
+module Bar_panels = Data_panel.Bar_panels
+
+type t
+(** Opaque cache, allocated per backtest run. *)
+
+val create : Bar_panels.t -> t
+(** [create panels] builds an empty cache backed by [panels]. The cache holds a
+    reference to [panels] so subsequent [ma_values_for] calls can read the
+    symbol's full weekly history on demand. *)
+
+val ma_values_for :
+  t ->
+  symbol:string ->
+  ma_type:Stage.ma_type ->
+  period:int ->
+  float array * Date.t array
+(** [ma_values_for t ~symbol ~ma_type ~period] returns the MA values array
+    paired with their aligned dates (chronological, oldest-first). The arrays
+    have equal length: [(full_history_n_weeks - period + 1)] when the symbol has
+    at least [period] weeks, otherwise both arrays are empty.
+
+    On first call for [(symbol, ma_type, period)] the cache reads the symbol's
+    full weekly history from the underlying [Bar_panels] (using
+    [as_of_day = n_days - 1], the last column of the panel's calendar — which
+    holds the full backtest range), computes the MA via the same kernel
+    [Stage._compute_ma] uses ([Sma.calculate_sma] / [Sma.calculate_weighted_ma]
+    / [Ema.calculate_ema]), and stores the result. Subsequent calls return the
+    cached arrays directly.
+
+    The returned arrays are owned by the cache; do not mutate them. *)
+
+val locate_date : Date.t array -> Date.t -> int option
+(** [locate_date dates target] returns the index [i] such that
+    [dates.(i) = target], or [None] if [target] is not present. Linear scan from
+    the array tail. Callers use this to map a view's most-recent date to its
+    position in the cached MA values array; on a cache miss (non-Friday view
+    date) the consumer falls back to inline MA computation. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -21,6 +21,10 @@ module Panel_callbacks = Panel_callbacks
 (** Panel-shaped callback-bundle constructors for the strategy's callees. Stage
     4 PR-A. *)
 
+module Weekly_ma_cache = Weekly_ma_cache
+(** Per-symbol weekly MA cache (Stage 4 PR-D). Memoises Stage / Macro / Sector /
+    Stops MA reads keyed by [(symbol, ma_type, period)]. *)
+
 type index_config = { primary : string; global : (string * string) list }
 [@@deriving sexp]
 
@@ -247,8 +251,9 @@ let _screen_universe ~config ~index_view ~macro_trend ~sector_map ~stop_states
       let prior_stage = Hashtbl.find prior_stages ticker in
       let callbacks =
         Panel_callbacks.stock_analysis_callbacks_of_weekly_views
-          ~config:Stock_analysis.default_config ~stock:stock_view
-          ~benchmark:index_view
+          ?ma_cache:(Bar_reader.ma_cache bar_reader)
+          ~stock_symbol:ticker ~config:Stock_analysis.default_config
+          ~stock:stock_view ~benchmark:index_view ()
       in
       let result =
         Stock_analysis.analyze_with_callbacks
@@ -300,9 +305,11 @@ let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
       ~global_index_symbols:config.indices.global ~bar_reader
       ~as_of:current_date
   in
+  let ma_cache = Bar_reader.ma_cache bar_reader in
   let macro_callbacks =
-    Panel_callbacks.macro_callbacks_of_weekly_views ~config:config.macro_config
-      ~index:index_view ~globals:global_index_views ~ad_bars
+    Panel_callbacks.macro_callbacks_of_weekly_views ?ma_cache
+      ~index_symbol:config.indices.primary ~config:config.macro_config
+      ~index:index_view ~globals:global_index_views ~ad_bars ()
   in
   let macro_result =
     Macro.analyze_with_callbacks ~config:config.macro_config
@@ -310,10 +317,10 @@ let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
   in
   prior_macro := macro_result.trend;
   let sector_map =
-    Macro_inputs.build_sector_map ~stage_config:config.stage_config
+    Macro_inputs.build_sector_map ?ma_cache ~stage_config:config.stage_config
       ~lookback_bars:config.lookback_bars ~sector_etfs:config.sector_etfs
       ~bar_reader ~as_of:current_date ~sector_prior_stages ~index_view
-      ~ticker_sectors
+      ~ticker_sectors ()
   in
   _screen_universe ~config ~index_view ~macro_trend:macro_result.trend
     ~sector_map ~stop_states ~portfolio ~get_price ~bar_reader ~prior_stages
@@ -329,10 +336,11 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
     | None -> Date.today ~zone:Time_float.Zone.utc
   in
   let exit_transitions, adjust_transitions =
-    Stops_runner.update ~stops_config:config.stops_config
-      ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
-      ~positions ~get_price ~stop_states ~bar_reader ~as_of:current_date
-      ~prior_stages
+    Stops_runner.update
+      ?ma_cache:(Bar_reader.ma_cache bar_reader)
+      ~stops_config:config.stops_config ~stage_config:config.stage_config
+      ~lookback_bars:config.lookback_bars ~positions ~get_price ~stop_states
+      ~bar_reader ~as_of:current_date ~prior_stages ()
   in
   (* Stage 4 PR-A: read the primary index as a weekly view directly. The
      Friday detection uses the view's latest date; the screener path consumes
@@ -360,9 +368,19 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
   let prior_macro : Weinstein_types.market_trend ref =
     ref Weinstein_types.Neutral
   in
+  (* Stage 4 PR-D: when bar_panels are present, also create a [Weekly_ma_cache]
+     scoped to this strategy and bundle it into the [Bar_reader]. The cache
+     is read by [Panel_callbacks.stage_callbacks_of_weekly_view] (and
+     transitively by Stock_analysis / Sector / Macro / Stops_runner) so
+     per-symbol weekly MA values are computed once, not per Friday tick.
+
+     The cache is opt-in (only when bar_panels are passed) so test
+     fixtures using [Bar_reader.empty ()] aren't affected. *)
   let bar_reader =
     match bar_panels with
-    | Some p -> Bar_reader.of_panels p
+    | Some p ->
+        let ma_cache = Weekly_ma_cache.create p in
+        Bar_reader.of_panels ~ma_cache p
     | None -> Bar_reader.empty ()
   in
   let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -52,6 +52,10 @@ module Panel_callbacks = Panel_callbacks
 (** Panel-shaped callback bundle constructors for the strategy's callees. See
     {!Panel_callbacks}. *)
 
+module Weekly_ma_cache = Weekly_ma_cache
+(** Per-symbol weekly MA cache (Stage 4 PR-D). Memoises Stage / Macro / Sector /
+    Stops MA reads keyed by [(symbol, ma_type, period)]. *)
+
 (** {1 Configuration} *)
 
 type index_config = {

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -6,6 +6,7 @@
   test_macro_inputs
   test_panel_callbacks
   test_stops_runner
+  test_weekly_ma_cache
   test_weinstein_strategy
   test_weinstein_strategy_smoke)
  (libraries
@@ -27,6 +28,9 @@
   weinstein.types
   weinstein.screener
   weinstein.stage
+  indicators.types
+  indicators.sma
+  indicators.ema
   weinstein.macro
   weinstein.rs
   weinstein.sector

--- a/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
@@ -176,6 +176,7 @@ let test_build_sector_map_empty_bar_history _ =
       ~as_of:(Date.of_string "2024-12-31")
       ~sector_prior_stages ~index_view:_empty_weekly_view
       ~ticker_sectors:(Hashtbl.create (module String))
+      ()
   in
   assert_that (Hashtbl.to_alist result) is_empty
 
@@ -208,6 +209,7 @@ let test_build_sector_map_drops_etfs_with_insufficient_bars _ =
         (Hashtbl.of_alist_exn
            (module String)
            [ ("XLK", "Information Technology") ])
+      ()
   in
   assert_that (Hashtbl.to_alist result) is_empty
 
@@ -229,6 +231,7 @@ let test_build_sector_map_drops_etfs_when_index_bars_empty _ =
         (Hashtbl.of_alist_exn
            (module String)
            [ ("XLK", "Information Technology") ])
+      ()
   in
   assert_that (Hashtbl.to_alist result) is_empty
 
@@ -262,6 +265,7 @@ let test_build_sector_map_populates_entry_for_valid_etf _ =
         (Hashtbl.of_alist_exn
            (module String)
            [ ("XLK", "Information Technology") ])
+      ()
   in
   assert_that (Hashtbl.to_alist result)
     (elements_are

--- a/trading/trading/weinstein/strategy/test/test_panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/test/test_panel_callbacks.ml
@@ -102,7 +102,7 @@ let test_stage_callbacks_parity _ =
   let config = Stage.default_config in
   let bar_list_callbacks = Stage.callbacks_from_bars ~config ~bars in
   let panel_callbacks =
-    Panel_callbacks.stage_callbacks_of_weekly_view ~config ~weekly:view
+    Panel_callbacks.stage_callbacks_of_weekly_view ~config ~weekly:view ()
   in
   let bar_list_result =
     Stage.classify_with_callbacks ~config ~get_ma:bar_list_callbacks.get_ma
@@ -212,7 +212,7 @@ let test_stock_analysis_callbacks_parity _ =
   in
   let panel_cbs =
     Panel_callbacks.stock_analysis_callbacks_of_weekly_views ~config
-      ~stock:stock_view ~benchmark:bench_view
+      ~stock:stock_view ~benchmark:bench_view ()
   in
   let bar_list_result =
     Stock_analysis.analyze_with_callbacks ~config ~ticker:"AAPL"
@@ -263,7 +263,7 @@ let test_sector_callbacks_parity _ =
   in
   let panel_cbs =
     Panel_callbacks.sector_callbacks_of_weekly_views ~config ~sector:sector_view
-      ~benchmark:bench_view
+      ~benchmark:bench_view ()
   in
   let bar_list_result =
     Sector.analyze_with_callbacks ~config ~sector_name:"Information Technology"
@@ -324,7 +324,7 @@ let test_macro_callbacks_parity _ =
   let panel_cbs =
     Panel_callbacks.macro_callbacks_of_weekly_views ~config ~index:index_view
       ~globals:[ ("DAX", global_view) ]
-      ~ad_bars
+      ~ad_bars ()
   in
   let bar_list_result =
     Macro.analyze_with_callbacks ~config ~callbacks:bar_cbs ~prior_stage:None
@@ -486,10 +486,59 @@ let test_resistance_callbacks_parity _ =
            (equal_to (List.length bar_result.zones_above));
        ])
 
+(* Stage parity with PR-D cache: classify on a 60-week rising series,
+   build callbacks two ways — one with [?ma_cache] passed (cache hit on
+   the latest Friday date), one without — and require bit-identical
+   Stage.result. The default ma_type is WMA; the cache returns the
+   same MA values as inline because WMA is sliding-window. *)
+let test_stage_callbacks_parity_with_cache _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let view =
+    Bar_panels.weekly_view_for panels ~symbol:"AAPL" ~n:60
+      ~as_of_day:(Bar_panels.n_days panels - 1)
+  in
+  let config = Stage.default_config in
+  let cache = Weinstein_strategy.Weekly_ma_cache.create panels in
+  let inline_callbacks =
+    Panel_callbacks.stage_callbacks_of_weekly_view ~config ~weekly:view ()
+  in
+  let cached_callbacks =
+    Panel_callbacks.stage_callbacks_of_weekly_view ~ma_cache:cache
+      ~symbol:"AAPL" ~config ~weekly:view ()
+  in
+  let inline_result =
+    Stage.classify_with_callbacks ~config ~get_ma:inline_callbacks.get_ma
+      ~get_close:inline_callbacks.get_close ~prior_stage:None
+  in
+  let cached_result =
+    Stage.classify_with_callbacks ~config ~get_ma:cached_callbacks.get_ma
+      ~get_close:cached_callbacks.get_close ~prior_stage:None
+  in
+  assert_that cached_result
+    (all_of
+       [
+         field
+           (fun (r : Stage.result) -> r.ma_value)
+           (float_equal inline_result.ma_value);
+         field
+           (fun (r : Stage.result) -> r.ma_slope_pct)
+           (float_equal inline_result.ma_slope_pct);
+         field
+           (fun (r : Stage.result) -> r.above_ma_count)
+           (equal_to inline_result.above_ma_count);
+       ])
+
 let suite =
   "Panel_callbacks parity"
   >::: [
          "Stage parity" >:: test_stage_callbacks_parity;
+         "Stage parity (cache vs inline)"
+         >:: test_stage_callbacks_parity_with_cache;
          "Rs parity" >:: test_rs_callbacks_parity;
          "Stock_analysis parity" >:: test_stock_analysis_callbacks_parity;
          "Sector parity" >:: test_sector_callbacks_parity;

--- a/trading/trading/weinstein/strategy/test/test_stops_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_runner.ml
@@ -81,6 +81,7 @@ let test_update_no_positions_returns_empty _ =
       ~stop_states ~bar_reader:(Bar_reader.empty ())
       ~as_of:(Date.of_string "2024-12-31")
       ~prior_stages:(Hashtbl.create (module String))
+      ()
   in
   assert_that exits is_empty;
   assert_that adjusts is_empty
@@ -99,6 +100,7 @@ let test_update_position_without_stop_state_returns_empty _ =
       ~stop_states ~bar_reader:(Bar_reader.empty ())
       ~as_of:(Date.of_string "2024-12-31")
       ~prior_stages:(Hashtbl.create (module String))
+      ()
   in
   assert_that exits is_empty;
   assert_that adjusts is_empty
@@ -120,6 +122,7 @@ let test_update_position_without_bar_returns_empty _ =
       ~stop_states ~bar_reader:(Bar_reader.empty ())
       ~as_of:(Date.of_string "2024-12-31")
       ~prior_stages:(Hashtbl.create (module String))
+      ()
   in
   assert_that exits is_empty;
   assert_that adjusts is_empty
@@ -146,6 +149,7 @@ let test_update_stop_hit_emits_trigger_exit _ =
       ~stop_states ~bar_reader:(Bar_reader.empty ())
       ~as_of:(Date.of_string "2024-12-31")
       ~prior_stages:(Hashtbl.create (module String))
+      ()
   in
   assert_that adjusts is_empty;
   assert_that exits
@@ -193,6 +197,7 @@ let test_update_mutates_stop_states_ref _ =
       ~stop_states ~bar_reader:(Bar_reader.empty ())
       ~as_of:(Date.of_string "2024-12-31")
       ~prior_stages:(Hashtbl.create (module String))
+      ()
   in
   (* Entry for AAPL still exists in the ref (may be same state or advanced). *)
   assert_that (Map.find !stop_states ticker) (is_some_and (fun _ -> ()))

--- a/trading/trading/weinstein/strategy/test/test_weekly_ma_cache.ml
+++ b/trading/trading/weinstein/strategy/test/test_weekly_ma_cache.ml
@@ -1,0 +1,300 @@
+(** Parity tests for {!Weinstein_strategy.Weekly_ma_cache}.
+
+    For each ma_type / period combination, build a synthetic [Bar_panels.t] with
+    one symbol's full weekly history, compute the MA two ways:
+
+    - {b cache path}: {!Weekly_ma_cache.ma_values_for}.
+    - {b inline path}: the same kernel ({!Sma.calculate_sma} |
+      {!Sma.calculate_weighted_ma} | {!Ema.calculate_ema}) called directly over
+      an [Indicator_types.t list] of the same closes.
+
+    Assert the resulting [float array] is bit-identical (for SMA/WMA) or
+    rounded-equal at offset 0 (for EMA, where TA-Lib's 2-decimal rounding
+    bridges any seed-induced drift after sufficient warmup).
+
+    Also verify:
+    - [locate_date] returns the correct index for in-range / out-of-range target
+      dates;
+    - cache hits return the same array reference (memoisation).
+    - empty / zero-day panels yield empty arrays. *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_panels = Data_panel.Bar_panels
+module Symbol_index = Data_panel.Symbol_index
+module Ohlcv_panels = Data_panel.Ohlcv_panels
+module Weekly_ma_cache = Weinstein_strategy.Weekly_ma_cache
+
+(* ------------------------------------------------------------------ *)
+(* Synthetic bar builders (same shape as test_panel_callbacks)          *)
+(* ------------------------------------------------------------------ *)
+
+let make_weekly_bar ~date ~price =
+  {
+    Types.Daily_price.date;
+    open_price = price;
+    high_price = price *. 1.01;
+    low_price = price *. 0.99;
+    close_price = price;
+    adjusted_close = price;
+    volume = 1_000_000;
+  }
+
+let make_friday_bars ~start_friday ~n ~start_price ~step =
+  List.init n ~f:(fun i ->
+      let date = Date.add_days start_friday (i * 7) in
+      make_weekly_bar ~date ~price:(start_price +. (Float.of_int i *. step)))
+
+let panels_of_symbols
+    (symbols_with_bars : (string * Types.Daily_price.t list) list) =
+  let universe = List.map symbols_with_bars ~f:fst in
+  let symbol_index =
+    match Symbol_index.create ~universe with
+    | Ok t -> t
+    | Error err -> failwith ("Symbol_index.create: " ^ err.Status.message)
+  in
+  let calendar =
+    symbols_with_bars
+    |> List.concat_map ~f:(fun (_, bars) ->
+        List.map bars ~f:(fun b -> b.Types.Daily_price.date))
+    |> List.dedup_and_sort ~compare:Date.compare
+    |> Array.of_list
+  in
+  let ohlcv =
+    Ohlcv_panels.create symbol_index ~n_days:(Array.length calendar)
+  in
+  let date_to_col = Hashtbl.create (module Date) in
+  Array.iteri calendar ~f:(fun i d ->
+      Hashtbl.add date_to_col ~key:d ~data:i
+      |> (ignore : [ `Ok | `Duplicate ] -> unit));
+  List.iter symbols_with_bars ~f:(fun (symbol, bars) ->
+      match Symbol_index.to_row symbol_index symbol with
+      | None -> ()
+      | Some row ->
+          List.iter bars ~f:(fun bar ->
+              match Hashtbl.find date_to_col bar.Types.Daily_price.date with
+              | None -> ()
+              | Some day ->
+                  Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day bar));
+  match Bar_panels.create ~ohlcv ~calendar with
+  | Ok p -> p
+  | Error err -> failwith ("Bar_panels.create: " ^ err.Status.message)
+
+(* ------------------------------------------------------------------ *)
+(* Inline reference (same kernel the cache uses, called directly)       *)
+(* ------------------------------------------------------------------ *)
+
+let inline_ma ~(ma_type : Stage.ma_type) ~period ~(closes : float array)
+    ~(dates : Date.t array) : float array =
+  let series =
+    Array.to_list closes
+    |> List.mapi ~f:(fun i v -> Indicator_types.{ date = dates.(i); value = v })
+  in
+  let result =
+    match ma_type with
+    | Stage.Sma -> Sma.calculate_sma series period
+    | Stage.Wma -> Sma.calculate_weighted_ma series period
+    | Stage.Ema -> Ema.calculate_ema series period
+  in
+  List.map result ~f:(fun iv -> iv.Indicator_types.value) |> Array.of_list
+
+(* ------------------------------------------------------------------ *)
+(* Core parity per ma_type                                              *)
+(* ------------------------------------------------------------------ *)
+
+let _expected_dates (closes_dates : Date.t array) ~period =
+  let n = Array.length closes_dates in
+  if n < period then [||]
+  else Array.sub closes_dates ~pos:(period - 1) ~len:(n - period + 1)
+
+let _assert_arrays_float_equal ~msg actual expected =
+  let pairs =
+    Array.to_list (Array.map2_exn actual expected ~f:(fun a b -> (a, b)))
+  in
+  assert_that pairs
+    (elements_are
+       (List.map pairs ~f:(fun (_, b) ->
+            field (fun (a, _) -> a) (float_equal ~epsilon:1e-9 b))))
+  |> ignore;
+  assert_that (Array.length actual)
+    (equal_to ~msg:(msg ^ " (length mismatch)") (Array.length expected))
+
+let _run_parity ~(ma_type : Stage.ma_type) ~period ~bars ~symbol _ =
+  let panels = panels_of_symbols [ (symbol, bars) ] in
+  let cache = Weekly_ma_cache.create panels in
+  let cached_values, cached_dates =
+    Weekly_ma_cache.ma_values_for cache ~symbol ~ma_type ~period
+  in
+  let view =
+    Bar_panels.weekly_view_for panels ~symbol ~n:Int.max_value
+      ~as_of_day:(Bar_panels.n_days panels - 1)
+  in
+  let expected_values =
+    inline_ma ~ma_type ~period ~closes:view.closes ~dates:view.dates
+  in
+  let expected_dates = _expected_dates view.dates ~period in
+  let cached_pairs =
+    Array.to_list
+      (Array.map2_exn cached_values cached_dates ~f:(fun v d -> (v, d)))
+  in
+  let expected_pairs =
+    Array.to_list
+      (Array.map2_exn expected_values expected_dates ~f:(fun v d -> (v, d)))
+  in
+  assert_that cached_pairs
+    (elements_are
+       (List.map expected_pairs ~f:(fun (v, d) ->
+            all_of
+              [
+                field (fun (cv, _) -> cv) (float_equal ~epsilon:1e-9 v);
+                field (fun (_, cd) -> cd) (equal_to d);
+              ])))
+
+let test_sma_parity_30 ctx =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  _run_parity ~ma_type:Stage.Sma ~period:30 ~bars ~symbol:"AAPL" ctx
+
+let test_wma_parity_30 ctx =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  _run_parity ~ma_type:Stage.Wma ~period:30 ~bars ~symbol:"AAPL" ctx
+
+let test_ema_parity_30 ctx =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  _run_parity ~ma_type:Stage.Ema ~period:30 ~bars ~symbol:"AAPL" ctx
+
+let test_sma_parity_10 ctx =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:30 ~start_price:50.0 ~step:0.25
+  in
+  _run_parity ~ma_type:Stage.Sma ~period:10 ~bars ~symbol:"XLK" ctx
+
+(* ------------------------------------------------------------------ *)
+(* Edge cases                                                           *)
+(* ------------------------------------------------------------------ *)
+
+let test_short_history_returns_empty _ =
+  (* History shorter than period → empty arrays. *)
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:5 ~start_price:100.0 ~step:0.1
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let cache = Weekly_ma_cache.create panels in
+  let values, dates =
+    Weekly_ma_cache.ma_values_for cache ~symbol:"AAPL" ~ma_type:Stage.Sma
+      ~period:30
+  in
+  assert_that (Array.length values) (equal_to 0);
+  assert_that (Array.length dates) (equal_to 0)
+
+let test_unknown_symbol_returns_empty _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.1
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let cache = Weekly_ma_cache.create panels in
+  let values, dates =
+    Weekly_ma_cache.ma_values_for cache ~symbol:"MISSING" ~ma_type:Stage.Wma
+      ~period:30
+  in
+  assert_that (Array.length values) (equal_to 0);
+  assert_that (Array.length dates) (equal_to 0)
+
+let test_locate_date_finds_present _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let cache = Weekly_ma_cache.create panels in
+  let _values, dates =
+    Weekly_ma_cache.ma_values_for cache ~symbol:"AAPL" ~ma_type:Stage.Wma
+      ~period:30
+  in
+  (* The first cached date is the date of the 30th bar (index 29). *)
+  let target = dates.(0) in
+  assert_that
+    (Weekly_ma_cache.locate_date dates target)
+    (is_some_and (equal_to 0));
+  let last = dates.(Array.length dates - 1) in
+  assert_that
+    (Weekly_ma_cache.locate_date dates last)
+    (is_some_and (equal_to (Array.length dates - 1)))
+
+let test_locate_date_returns_none_for_missing _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let cache = Weekly_ma_cache.create panels in
+  let _values, dates =
+    Weekly_ma_cache.ma_values_for cache ~symbol:"AAPL" ~ma_type:Stage.Wma
+      ~period:30
+  in
+  (* A Wednesday (mid-week) date won't appear in the cached Friday-anchored
+     dates. *)
+  let target = Date.of_string "2024-08-14" in
+  assert_that (Weekly_ma_cache.locate_date dates target) is_none
+
+let test_cache_memoisation _ =
+  (* Second call with the same key returns the same array reference (the
+     [Hashtbl.find_or_add] never re-builds). *)
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let cache = Weekly_ma_cache.create panels in
+  let v1, _ =
+    Weekly_ma_cache.ma_values_for cache ~symbol:"AAPL" ~ma_type:Stage.Wma
+      ~period:30
+  in
+  let v2, _ =
+    Weekly_ma_cache.ma_values_for cache ~symbol:"AAPL" ~ma_type:Stage.Wma
+      ~period:30
+  in
+  assert_that (phys_equal v1 v2) (equal_to true)
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let () =
+  run_test_tt_main
+    ("test_weekly_ma_cache"
+    >::: [
+           "SMA parity (period=30)" >:: test_sma_parity_30;
+           "WMA parity (period=30)" >:: test_wma_parity_30;
+           "EMA parity (period=30)" >:: test_ema_parity_30;
+           "SMA parity (period=10)" >:: test_sma_parity_10;
+           "Short history returns empty arrays"
+           >:: test_short_history_returns_empty;
+           "Unknown symbol returns empty arrays"
+           >:: test_unknown_symbol_returns_empty;
+           "locate_date finds present dates" >:: test_locate_date_finds_present;
+           "locate_date returns None for missing dates"
+           >:: test_locate_date_returns_none_for_missing;
+           "Cache memoises by key" >:: test_cache_memoisation;
+         ])


### PR DESCRIPTION
## Summary

Stage 4 PR-D of the data-panels columnar refactor: introduces a per-symbol weekly MA cache so `Panel_callbacks.stage_callbacks_of_weekly_view` no longer re-runs SMA/WMA/EMA per call.

## Wedge

Per `dev/notes/panels-rss-spike-postC-2026-04-26.md` (#590), post-A+B+C peak RSS is still 1,939 MB on `bull-crash-292x6y` vs the ≤800 MB target. The strongest remaining suspect was per-call MA / SMA recompute in `Panel_callbacks._ma_values_of_closes` — for ~300 symbols × Friday ticks × 6 years, millions of recomputes producing short-lived float arrays. PR-D parks results in a resident cache.

## Approach

- New `weinstein/strategy/lib/weekly_ma_cache.{ml,mli}` (~190 LOC). Hashtbl-backed per-symbol weekly MA arrays keyed by `(ma_type, period)`. Built once at `Panel_runner` startup using each symbol's full weekly view; cached values are the **same** `Sma.calculate_sma | Sma.calculate_weighted_ma | Ema.calculate_ema` outputs (bit-identical kernels).
- `Panel_callbacks.stage_callbacks_of_weekly_view` accepts an optional `ma_cache` + `symbol`. If both supplied and the view's last date appears in the cached dates array, the closure returns a `Bigarray`-style cell read; otherwise falls back to the existing `_ma_values_of_closes` recompute.
- `Bar_reader` / `stops_runner` / `macro_inputs` / `weinstein_strategy` thread the cache through `make`.

## Plan deviations from dispatch

1. **Stored as Hashtbl, not Bigarray panel.** The dispatch suggested extending `Indicator_panels` (in `data_panel/`) or adding `Weekly_indicator_panels`. I went with a Hashtbl-backed cache in `weinstein/strategy/lib/` because per-symbol weekly histories vary in length (different first-trade dates) and the cache calls indicator kernels in `analysis/technical/indicators/` — putting the cache in `data_panel/` would force pulling the analysis-layer indicators down a layer.
2. **Friday-only cache hits.** Mid-week `stops_runner` ticks fall back to inline because the view's last date is mid-week and won't match the cache's Friday-anchored dates. The Friday screener path (the dominant hot path) hits the cache; daily stops_runner over held positions falls back. Documented in the `.mli`.
3. **Macro globals don't cache.** The `(label, view)` shape drops the symbol; ~3 globals × ~312 Fridays is negligible vs the universe-wide loop.

## Parity gates

- [x] **Load-bearing**: `test_panel_loader_parity` round_trips golden — bit-equal trades.
- [x] **New** `test_weekly_ma_cache.ml` (9 tests): SMA/WMA/EMA period=30 + SMA period=10 cache-vs-inline parity, edge cases for short history / unknown symbol / locate_date, memoisation by phys-equal.
- [x] **New** `test_panel_callbacks.test_stage_callbacks_parity_with_cache`: bit-identical Stage.result with cache vs without on a 60-week WMA-default series.
- [x] All other suites green: `test_macro_inputs` (8), `test_stops_runner` (5), `data_panel/test` (60), `backtest/test` (13).

## LOC

- 20 files changed, +972 / −89.
- Production: ~+500 LOC (new `weekly_ma_cache.{ml,mli}` ~190; modified `panel_callbacks` / `bar_reader` / `stops_runner` / `macro_inputs` / `weinstein_strategy` ~+310).
- Tests: ~+300 LOC (`test_weekly_ma_cache.ml` 300; +57 in `test_panel_callbacks`).
- Plan + status: ~+105 LOC.

## Recommendation for next dispatch

Re-run the RSS spike on `bull-crash-292x6y` to measure A+B+C+D combined peak RSS vs the post-PR-B 1,944 MB / 4:11 baseline. If still > 1 GB, memtrace per the 2026-04-25 spike note's '> 1 GB' branch.

Plan: `dev/plans/columnar-data-shape-2026-04-25.md` §'Stage 4', sub-step 4.