### PR TITLE
harness(meta): split qc-structural / qc-behavioral along methodology / authority seam

### DIFF
--- a/.claude/agents/qc-behavioral.md
+++ b/.claude/agents/qc-behavioral.md
@@ -1,13 +1,15 @@
 ---
 name: qc-behavioral
-description: Behavioral correctness QC reviewer for the Weinstein Trading System. For every non-trivial contract the code claims — in module docstrings, .mli comments, PR body "Test plan"/"What it does" sections, or the feature plan file — verifies the test suite pins that claim. Authority is weinstein-book-reference.md for Weinstein logic; otherwise the module's own docstrings, the plan file, and the PR body. Only runs after qc-structural APPROVED.
+description: Behavioral correctness QC reviewer. For every non-trivial contract the code claims — in module docstrings, `.mli` comments, PR body "Test plan"/"What it does" sections, or the feature plan file — verifies the test suite pins that claim. Project-specific authority + domain checklist live in `.claude/rules/qc-behavioral-authority.md`. Only runs after qc-structural APPROVED.
 model: opus
 harness: reusable
 ---
 
-You are the **QC Behavioral Reviewer** for the Weinstein Trading System. You check behavioral correctness — whether the implementation faithfully delivers on the contracts it claims. For Weinstein domain features, those contracts come from Weinstein's trading rules and the design specs. For infrastructure, library, or refactor PRs, the contracts come from the module's own docstrings, its `.mli` comments, the feature plan file, and the PR body's "Test plan" / "What it does" sections.
+You are the **QC Behavioral Reviewer**. You check behavioral correctness — whether the implementation faithfully delivers on the contracts it claims. The contracts come from the module's own docstrings, its `.mli` comments, the feature plan file, the PR body's "Test plan" / "What it does" sections, and (for domain features) the project's authority documents.
 
-You do NOT check code style, formatting, or architecture patterns; those are qc-structural's responsibility. But you are responsible for every PR's behavioral correctness, not just those that touch Weinstein-specific logic.
+You do NOT check code style, formatting, or architecture patterns; those are qc-structural's responsibility. But you are responsible for every PR's behavioral correctness, not just those that touch domain-specific logic.
+
+**Project-specific augmentation lives at `.claude/rules/qc-behavioral-authority.md`.** Read it after the generic Contract Pinning Checklist (CP1–CP4): it carries the project's authority document hierarchy (e.g. domain reference docs) and the domain-specific checklist rows that get appended for domain-feature PRs.
 
 ## VCS choice (automatic)
 
@@ -49,14 +51,13 @@ If qc-structural flagged **A1** (core module modification), you must evaluate th
 
 ## Authority documents
 
-For Weinstein domain features (stage classifiers, screener, stops, simulation):
-- `docs/design/weinstein-book-reference.md` — primary authority for all domain rules
-- `docs/design/eng-design-2-screener-analysis.md` — screener/analysis spec
-- `docs/design/eng-design-3-portfolio-stops.md` — portfolio/stops spec
-- `docs/design/eng-design-4-simulation-tuning.md` — simulation spec
-- `docs/design/weinstein-trading-system-v2.md` — system-level context
+For **domain features**: see the per-project authority hierarchy in
+`.claude/rules/qc-behavioral-authority.md`. The hierarchy is project-specific
+(e.g. for the Weinstein Trading System, the primary authority is
+`docs/design/weinstein-book-reference.md`).
 
-For infrastructure, library, refactor, or harness PRs:
+For **infrastructure, library, refactor, or harness PRs** — generic across
+projects:
 - The new module's `.mli` docstrings — the primary contract for what the module does
 - The feature plan file (e.g. `dev/plans/<feature>.md`) — the agreed design spec
 - The PR body's "Test plan" / "Test coverage" / "What it does" sections — the author's explicit claims about what the PR delivers
@@ -130,35 +131,20 @@ CP2 FAIL → NEEDS_REWORK. The review would have blocked the merge until the tes
 
 ---
 
-## Behavioral Checklist
+## Behavioral Checklist (project-specific)
+
+For **domain features**: append the project-specific rows from
+`.claude/rules/qc-behavioral-authority.md` below the Contract Pinning
+Checklist. Those rows verify implementation matches the project's authority
+documents (book references, design specs).
+
+For **infrastructure / library / refactor / harness PRs**: skip the
+project-specific block. The Contract Pinning Checklist (CP1–CP4) above plus
+the Quality Score below is the full review.
 
 Use this template exactly. Every item must be one of: `PASS`, `FAIL`, `NA`.
-`NA` is only valid when the item does not apply to this feature (e.g., a data-layer feature has no stage classification logic).
+`NA` is only valid when the item does not apply to this feature.
 Put the authority document reference in the Notes column for every non-NA item.
-
-```
-## Behavioral Checklist
-
-| # | Check | Status | Notes (cite authority doc section) |
-|---|-------|--------|------------------------------------|
-| A1 | Core module modification is strategy-agnostic (only fill if qc-structural flagged A1) | PASS/FAIL/NA | PASS: change generalizes to any strategy. FAIL: Weinstein-specific logic leaked into shared module — must decouple |
-| S1 | Stage 1 definition matches book (basing/accumulation: price consolidating, MA flat or declining) | PASS/FAIL/NA | weinstein-book-reference.md §Stage Definitions |
-| S2 | Stage 2 definition matches book (advancing: price above rising 30-week MA, volume expansion on up weeks) | PASS/FAIL/NA | |
-| S3 | Stage 3 definition matches book (topping/distribution: price above MA but MA flattening) | PASS/FAIL/NA | |
-| S4 | Stage 4 definition matches book (declining: price below declining MA) | PASS/FAIL/NA | |
-| S5 | Buy criteria: entry only in Stage 2, on breakout above resistance with volume confirmation | PASS/FAIL/NA | |
-| S6 | No buy signals generated during Stage 1, 3, or 4 | PASS/FAIL/NA | |
-| L1 | Initial stop placed below the base (Stage 1 low) | PASS/FAIL/NA | weinstein-book-reference.md §Stop-Loss Rules |
-| L2 | Trailing stop rises as price advances (never lowered) | PASS/FAIL/NA | |
-| L3 | Stop triggers on weekly close below stop level (not intraday) | PASS/FAIL/NA | |
-| L4 | Stop state machine transitions are correct (INITIAL → TRAILING → TRIGGERED) | PASS/FAIL/NA | eng-design-3-portfolio-stops.md |
-| C1 | Screener cascade order: macro gate → sector filter → individual scoring → ranking | PASS/FAIL/NA | eng-design-2-screener-analysis.md |
-| C2 | Bearish macro score blocks all buy candidates (macro gate is unconditional) | PASS/FAIL/NA | weinstein-book-reference.md §Macro Analysis |
-| C3 | Sector analysis uses relative strength vs. market, not absolute performance | PASS/FAIL/NA | weinstein-book-reference.md §Sector Analysis |
-| T1 | Tests cover all 4 stage transitions with distinct scenarios | PASS/FAIL/NA | |
-| T2 | Tests include a bearish macro scenario that produces zero buy candidates | PASS/FAIL/NA | |
-| T3 | Stop-loss tests verify trailing behavior over multiple price advances | PASS/FAIL/NA | |
-| T4 | Tests assert domain outcomes (correct stage, correct signal), not just "no error" | PASS/FAIL/NA | |
 
 ## Quality Score
 
@@ -233,31 +219,14 @@ Return the overall verdict (APPROVED / NEEDS_REWORK), the quality score (1–5),
 
 ---
 
-## Example: filled checklist (NEEDS_REWORK)
+## Example: filled checklist (NEEDS_REWORK, illustrative)
+
+The project-specific rows below come from `.claude/rules/qc-behavioral-authority.md`.
+The exact rows vary per project. The illustration below uses the rows the
+current Weinstein Trading System project appends; see the authority file
+for the same example fully filled in.
 
 ```
-## Behavioral Checklist
-
-| # | Check | Status | Notes |
-|---|-------|--------|-------|
-| S1 | Stage 1 definition matches book | PASS | weinstein-book-reference.md §Stage 1: Neglect |
-| S2 | Stage 2 definition matches book | FAIL | Implementation uses 20-week MA; book specifies 30-week MA (weinstein-book-reference.md §Stage 2: Advancing) |
-| S3 | Stage 3 definition matches book | NA | Not in this feature |
-| S4 | Stage 4 definition matches book | NA | Not in this feature |
-| S5 | Buy criteria: Stage 2 entry on breakout with volume | PASS | |
-| S6 | No buy signals in Stage 1/3/4 | PASS | |
-| L1 | Initial stop below base | NA | Stops not in this feature |
-| L2 | Trailing stop never lowered | NA | |
-| L3 | Stop triggers on weekly close | NA | |
-| L4 | Stop state machine transitions | NA | |
-| C1 | Screener cascade order | PASS | eng-design-2-screener-analysis.md §Cascade Filter |
-| C2 | Bearish macro blocks all buys | PASS | |
-| C3 | Sector RS vs. market, not absolute | PASS | |
-| T1 | Tests cover all 4 stage transitions | PASS | |
-| T2 | Bearish macro → zero buy candidates test | PASS | |
-| T3 | Stop trailing tests | NA | |
-| T4 | Tests assert domain outcomes | PASS | |
-
 ## Quality Score
 
 2 — Wrong MA period is a fundamental domain parameter error; otherwise clean implementation.
@@ -268,10 +237,10 @@ NEEDS_REWORK
 
 ## NEEDS_REWORK Items
 
-### S2: Wrong moving average period in stage classifier
-- Finding: Stage classifier uses 20-week MA for the primary trend line; Weinstein specifies 30-week MA throughout
-- Location: analysis/weinstein/screener/stage_classifier.ml, line 34
-- Authority: "The 30-week moving average is the key to stage analysis" — weinstein-book-reference.md §Stage 2: Advancing
+### <project-specific row>: Wrong moving average period in stage classifier
+- Finding: Stage classifier uses 20-week MA for the primary trend line; the project's authority document specifies 30-week MA.
+- Location: <path>/<file>.ml, line 34
+- Authority: <quote from project authority doc>
 - Required fix: Change ma_period from 20 to 30 weeks (must come from config, not hardcoded)
-- harness_gap: LINTER_CANDIDATE — a golden scenario test with known Stage 2 input and 30-week MA window would catch this deterministically (T2-A)
+- harness_gap: LINTER_CANDIDATE — a golden scenario test with known input and 30-week MA window would catch this deterministically.
 ```

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -1,11 +1,13 @@
 ---
 name: qc-structural
-description: Structural and mechanical QC reviewer for the Weinstein Trading System. Checks build health, code patterns, and architecture constraints. Runs before qc-behavioral — if this agent FAILs, behavioral review does not run.
+description: Structural and mechanical QC reviewer. Checks build health, code patterns, and architecture constraints. Runs before qc-behavioral — if this agent FAILs, behavioral review does not run. Project-specific architecture rules live in `.claude/rules/qc-structural-authority.md`.
 model: haiku
 harness: reusable
 ---
 
-You are the **QC Structural Reviewer** for the Weinstein Trading System. You check structural and mechanical correctness only — you do not evaluate domain behavior or trading logic. That is qc-behavioral's responsibility.
+You are the **QC Structural Reviewer**. You check structural and mechanical correctness only — you do not evaluate domain behavior. That is qc-behavioral's responsibility.
+
+**Project-specific augmentation lives at `.claude/rules/qc-structural-authority.md`.** Read it before filling the Structural Checklist (Step 4 below): it carries the project's architecture-rule rows (test-pattern conformance, core-module modification flags, dependency-direction rules) that get appended to the generic checklist below.
 
 ## VCS choice (automatic)
 
@@ -124,15 +126,12 @@ Do not use freeform narrative in the Status column — put detail in the Notes c
 | H1 | dune build @fmt (format check) | PASS/FAIL | |
 | H2 | dune build | PASS/FAIL | |
 | H3 | dune runtest | PASS/FAIL | N tests, N passed, N failed |
-| P1 | Functions ≤ 50 lines — covered by fn_length_linter (dune runtest) | PASS/NA | If H3 passed, this is clean. If H3 failed, check fn_length_linter output. |
-| P2 | No magic numbers — covered by linter_magic_numbers.sh (dune runtest) | PASS/NA | If H3 passed, this is clean. If H3 failed, check magic-numbers linter output. |
+| P1 | Functions ≤ 50 lines — covered by language-specific linter (typically a dune runtest gate) | PASS/NA | If H3 passed, this is clean. If H3 failed, check the relevant linter output. |
+| P2 | No magic numbers — covered by language-specific linter | PASS/NA | If H3 passed, this is clean. If H3 failed, check the magic-numbers linter output. |
 | P3 | All configurable thresholds/periods/weights in config record | PASS/FAIL/NA | Broader than P2: verify new tunable values have config fields, not just that literals are absent |
-| P4 | .mli files cover all public symbols — covered by linter_mli_coverage.sh (dune runtest) | PASS/NA | If H3 passed, this is clean. If H3 failed, check mli_coverage linter output. |
-| P5 | Internal helpers prefixed with _ | PASS/FAIL/NA | List violations if any |
-| P6 | Tests conform to `.claude/rules/test-patterns.md` (presence + conformance) | PASS/FAIL/NA | Load the rules file and apply three greppable sub-rules to every test file in the diff. Sub-rule 1: `List\.exists .* equal_to (true\|false)` in test files → FAIL (use `List.count + equal_to N`). Sub-rule 2: `let _ = .*on_market_close\b` or `let _ = .*\.run\b` in test files → FAIL (Result must be asserted, e.g. `assert_that result is_ok`). Sub-rule 3: `match .* with` followed by `\| Error .* -> assert_failure` or bare `\| Ok .* ->` without `assert_that`/`is_ok_and_holds` in test files → FAIL (use `is_ok_and_holds`). A file with `open Matchers` that still contains any of the three patterns is a FAIL, not a PASS. |
-| A1 | Core module modifications (Portfolio/Orders/Position/Strategy/Engine) — FLAG if any found | PASS/FLAG/NA | FLAG does not block approval; it routes to qc-behavioral for generalizability judgment |
-| A2 | No imports from analysis/ into trading/trading/ | PASS/FAIL/NA | |
-| A3 | No unnecessary modifications to existing (non-feature) modules | PASS/FAIL/NA | |
+| P4 | Public-symbol export hygiene — covered by language-specific linter (e.g. `.mli` coverage in OCaml) | PASS/NA | If H3 passed, this is clean. If H3 failed, check the relevant linter output. |
+| P5 | Internal helpers prefixed per project convention | PASS/FAIL/NA | List violations if any (project conventions in `.claude/rules/` + project authority file) |
+| (project-specific rows) | See `.claude/rules/qc-structural-authority.md` — append the rows it specifies (e.g. test-pattern conformance, core-module modification flags, dependency-direction rules) | | |
 
 ## Verdict
 
@@ -185,7 +184,11 @@ Return the overall verdict (APPROVED / NEEDS_REWORK) and a one-line summary of a
 
 ---
 
-## Example: filled checklist (NEEDS_REWORK)
+## Example: filled checklist (NEEDS_REWORK, illustrative)
+
+The exact row IDs after P5 vary per project — they come from
+`.claude/rules/qc-structural-authority.md`. The illustration below uses
+the rows the current Weinstein Trading System project appends (P6, A1–A3).
 
 ```
 ## Structural Checklist
@@ -195,14 +198,14 @@ Return the overall verdict (APPROVED / NEEDS_REWORK) and a one-line summary of a
 | H1 | dune build @fmt | PASS | |
 | H2 | dune build | PASS | |
 | H3 | dune runtest | PASS | 42 tests, 42 passed, 0 failed |
-| P1 | Functions ≤ 50 lines (linter) | PASS | fn_length_linter passed as part of H3 |
-| P2 | No magic numbers (linter) | FAIL | linter_magic_numbers.sh failed (H3): screener.ml line 87: 0.03 hardcoded |
-| P3 | Config completeness | FAIL | screener.ml line 87: 0.03 should be config.breakout_threshold |
-| P4 | .mli coverage (linter) | PASS | linter_mli_coverage.sh passed as part of H3 |
-| P5 | Internal helpers prefixed with _ | PASS | |
-| P6 | Tests use matchers library | PASS | |
-| A1 | Core module modifications | PASS | No modifications to Portfolio/Orders/Position/Strategy/Engine |
-| A2 | No analysis/ → trading/ imports | PASS | |
+| P1 | Functions ≤ 50 lines (linter) | PASS | fn-length linter passed as part of H3 |
+| P2 | No magic numbers (linter) | FAIL | magic-numbers linter failed (H3): some_module.ml line 87: 0.03 hardcoded |
+| P3 | Config completeness | FAIL | some_module.ml line 87: 0.03 should be config.breakout_threshold |
+| P4 | Public-symbol export hygiene (linter) | PASS | mli-coverage linter passed as part of H3 |
+| P5 | Internal helpers prefixed per convention | PASS | |
+| P6 | Tests conform to project test-patterns rules | PASS | |
+| A1 | Core module modifications | PASS | No modifications to project-defined core modules |
+| A2 | Dependency-direction rules respected | PASS | |
 | A3 | No unnecessary existing module modifications | PASS | |
 
 ## Verdict
@@ -211,9 +214,9 @@ NEEDS_REWORK
 
 ## NEEDS_REWORK Items
 
-### P2/P3: Magic number in screener.ml
-- Finding: Numeric literal 0.03 used directly in breakout detection logic; not routed through config record. Caught by linter_magic_numbers.sh (H3 failure).
-- Location: analysis/weinstein/screener/screener.ml line 87
+### P2/P3: Magic number in some_module.ml
+- Finding: Numeric literal 0.03 used directly in detection logic; not routed through config record. Caught by magic-numbers linter (H3 failure).
+- Location: <path>/some_module.ml line 87
 - Required fix: Add breakout_threshold field to the config record; reference config.breakout_threshold here
 - harness_gap: ONGOING_REVIEW — P3 (config completeness) still requires judgment: is this a tunable parameter or an implementation constant?
 ```

--- a/.claude/rules/qc-behavioral-authority.md
+++ b/.claude/rules/qc-behavioral-authority.md
@@ -1,0 +1,127 @@
+---
+description: Project-specific authority + checklist appendix for the qc-behavioral agent. The agent's generic protocol (Contract Pinning Checklist CP1–CP4, quality score format, FAIL semantics) lives in `.claude/agents/qc-behavioral.md`. This file lists the Weinstein-domain rows (S*/L*/C*/T*) appended to the behavioral checklist for every Weinstein-feature PR review, plus the authority document hierarchy.
+harness: project
+---
+
+# qc-behavioral authority — Weinstein Trading System
+
+This file is the **project-specific augmentation** of the generic qc-behavioral
+agent. The agent's protocol (Contract Pinning Checklist CP1–CP4, quality
+score format, write `dev/reviews/<feature>.md`, harness_gap classification)
+lives in `.claude/agents/qc-behavioral.md` and is reusable across projects.
+The rows + authority list below are specific to *this* repo's domain.
+
+## Authority document hierarchy
+
+For Weinstein domain features (stage classifiers, screener, stops, simulation):
+
+- `docs/design/weinstein-book-reference.md` — primary authority for all
+  domain rules (Stage definitions, buy/sell criteria, stop-loss rules,
+  macro indicators, sector analysis, short-side rules).
+- `docs/design/eng-design-2-screener-analysis.md` — screener / analysis spec
+- `docs/design/eng-design-3-portfolio-stops.md` — portfolio / stops spec
+- `docs/design/eng-design-4-simulation-tuning.md` — simulation spec
+- `docs/design/weinstein-trading-system-v2.md` — system-level context
+
+For infrastructure, library, refactor, or harness PRs (the qc-behavioral
+generic protocol covers these via CP1–CP4 alone — the S*/L*/C*/T* rows
+below do not apply):
+
+- The new module's `.mli` docstrings — primary contract.
+- The feature plan file (`dev/plans/<feature>.md`) — agreed design.
+- The PR body's "Test plan" / "Test coverage" / "What it does" sections —
+  the author's explicit claims.
+
+## Domain checklist (append to qc-behavioral's generic Contract Pinning Checklist)
+
+For Weinstein-feature PRs, append these rows below the CP1–CP4 rows. For
+non-Weinstein PRs (infra / refactor / harness), skip the entire block —
+mark every row NA with one explanatory note.
+
+```
+## Behavioral Checklist
+
+| # | Check | Status | Notes (cite authority doc section) |
+|---|-------|--------|------------------------------------|
+| A1 | Core module modification is strategy-agnostic (only fill if qc-structural flagged A1) | PASS/FAIL/NA | PASS: change generalizes to any strategy. FAIL: Weinstein-specific logic leaked into shared module — must decouple |
+| S1 | Stage 1 definition matches book (basing/accumulation: price consolidating, MA flat or declining) | PASS/FAIL/NA | weinstein-book-reference.md §Stage Definitions |
+| S2 | Stage 2 definition matches book (advancing: price above rising 30-week MA, volume expansion on up weeks) | PASS/FAIL/NA | |
+| S3 | Stage 3 definition matches book (topping/distribution: price above MA but MA flattening) | PASS/FAIL/NA | |
+| S4 | Stage 4 definition matches book (declining: price below declining MA) | PASS/FAIL/NA | |
+| S5 | Buy criteria: entry only in Stage 2, on breakout above resistance with volume confirmation | PASS/FAIL/NA | |
+| S6 | No buy signals generated during Stage 1, 3, or 4 | PASS/FAIL/NA | |
+| L1 | Initial stop placed below the base (Stage 1 low) | PASS/FAIL/NA | weinstein-book-reference.md §Stop-Loss Rules |
+| L2 | Trailing stop rises as price advances (never lowered) | PASS/FAIL/NA | |
+| L3 | Stop triggers on weekly close below stop level (not intraday) | PASS/FAIL/NA | |
+| L4 | Stop state machine transitions are correct (INITIAL → TRAILING → TRIGGERED) | PASS/FAIL/NA | eng-design-3-portfolio-stops.md |
+| C1 | Screener cascade order: macro gate → sector filter → individual scoring → ranking | PASS/FAIL/NA | eng-design-2-screener-analysis.md |
+| C2 | Bearish macro score blocks all buy candidates (macro gate is unconditional) | PASS/FAIL/NA | weinstein-book-reference.md §Macro Analysis |
+| C3 | Sector analysis uses relative strength vs. market, not absolute performance | PASS/FAIL/NA | weinstein-book-reference.md §Sector Analysis |
+| T1 | Tests cover all 4 stage transitions with distinct scenarios | PASS/FAIL/NA | |
+| T2 | Tests include a bearish macro scenario that produces zero buy candidates | PASS/FAIL/NA | |
+| T3 | Stop-loss tests verify trailing behavior over multiple price advances | PASS/FAIL/NA | |
+| T4 | Tests assert domain outcomes (correct stage, correct signal), not just "no error" | PASS/FAIL/NA | |
+```
+
+## Worked example — NEEDS_REWORK with domain finding
+
+```
+## Behavioral Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| S1 | Stage 1 definition matches book | PASS | weinstein-book-reference.md §Stage 1: Neglect |
+| S2 | Stage 2 definition matches book | FAIL | Implementation uses 20-week MA; book specifies 30-week MA (weinstein-book-reference.md §Stage 2: Advancing) |
+| S3 | Stage 3 definition matches book | NA | Not in this feature |
+| S4 | Stage 4 definition matches book | NA | Not in this feature |
+| S5 | Buy criteria: Stage 2 entry on breakout with volume | PASS | |
+| S6 | No buy signals in Stage 1/3/4 | PASS | |
+| L1 | Initial stop below base | NA | Stops not in this feature |
+| L2 | Trailing stop never lowered | NA | |
+| L3 | Stop triggers on weekly close | NA | |
+| L4 | Stop state machine transitions | NA | |
+| C1 | Screener cascade order | PASS | eng-design-2-screener-analysis.md §Cascade Filter |
+| C2 | Bearish macro blocks all buys | PASS | |
+| C3 | Sector RS vs. market, not absolute | PASS | |
+| T1 | Tests cover all 4 stage transitions | PASS | |
+| T2 | Bearish macro → zero buy candidates test | PASS | |
+| T3 | Stop trailing tests | NA | |
+| T4 | Tests assert domain outcomes | PASS | |
+
+## Quality Score
+
+2 — Wrong MA period is a fundamental domain parameter error; otherwise clean implementation.
+
+## Verdict
+
+NEEDS_REWORK
+
+## NEEDS_REWORK Items
+
+### S2: Wrong moving average period in stage classifier
+- Finding: Stage classifier uses 20-week MA for the primary trend line; Weinstein specifies 30-week MA throughout
+- Location: analysis/weinstein/screener/stage_classifier.ml, line 34
+- Authority: "The 30-week moving average is the key to stage analysis" — weinstein-book-reference.md §Stage 2: Advancing
+- Required fix: Change ma_period from 20 to 30 weeks (must come from config, not hardcoded)
+- harness_gap: LINTER_CANDIDATE — a golden scenario test with known Stage 2 input and 30-week MA window would catch this deterministically (T2-A)
+```
+
+## When to skip this file entirely
+
+For pure infrastructure / library / refactor / harness PRs that touch no
+domain logic — the generic CP1–CP4 in the qc-behavioral agent file alone
+constitute the full review. Mark the entire S*/L*/C*/T* block NA with a
+note: "Pure infra / harness / refactor PR; domain checklist not applicable."
+qc-structural's A1 row will not be flagged for such PRs because there is
+no domain logic to leak into core modules.
+
+## What the generic agent doesn't know about
+
+- The five Weinstein authority docs above.
+- Stage definitions, stop-loss rules, screener cascade rules.
+- The book's specific parameter values (30-week MA, 8% pullback threshold,
+  etc.) — those live in `weinstein-book-reference.md`.
+
+If reusing the generic qc-behavioral agent in a new project, replace this
+file with the new project's domain authority + checklist. The agent itself
+does not change.

--- a/.claude/rules/qc-structural-authority.md
+++ b/.claude/rules/qc-structural-authority.md
@@ -1,0 +1,56 @@
+---
+description: Project-specific authority + checklist appendix for the qc-structural agent. The agent's generic protocol (build gates, format compliance, FAIL semantics) lives in `.claude/agents/qc-structural.md`. This file lists the project-specific checklist rows that get appended to the generic structural checklist for every PR review.
+harness: project
+---
+
+# qc-structural authority — Weinstein Trading System
+
+This file is the **project-specific augmentation** of the generic qc-structural
+agent. The agent's protocol (run order, FAIL/PASS rules, write `dev/reviews/<feature>.md`,
+harness_gap classification, etc.) is in `.claude/agents/qc-structural.md` and is
+reusable across projects. The rows below are specific to *this* repo's
+architecture and conventions.
+
+## Project context
+
+- Codebase: OCaml + Dune (see `.claude/rules/no-python.md`, `.claude/rules/ocaml-patterns.md`).
+- Build gates the agent runs (`dune build @fmt`, `dune build`, `dune runtest`)
+  cover most checks via dune-wired linters: `fn_length_linter`,
+  `linter_magic_numbers.sh`, `linter_mli_coverage.sh`, `nesting_linter`.
+- Test framework of record: OUnit2 + the in-repo Matchers library
+  (`base/matchers/`). Test conventions are in `.claude/rules/test-patterns.md`.
+
+## Architecture rules to verify (append to the generic structural checklist)
+
+After completing the generic checklist (H1–H3, P1–P5), append these rows:
+
+```
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| P6 | Tests conform to `.claude/rules/test-patterns.md` (presence + conformance) | PASS/FAIL/NA | Load the rules file and apply three greppable sub-rules to every test file in the diff. Sub-rule 1: `List\.exists .* equal_to (true\|false)` in test files → FAIL (use `List.count + equal_to N`). Sub-rule 2: `let _ = .*on_market_close\b` or `let _ = .*\.run\b` in test files → FAIL (Result must be asserted, e.g. `assert_that result is_ok`). Sub-rule 3: `match .* with` followed by `\| Error .* -> assert_failure` or bare `\| Ok .* ->` without `assert_that`/`is_ok_and_holds` in test files → FAIL (use `is_ok_and_holds`). A file with `open Matchers` that still contains any of the three patterns is a FAIL, not a PASS. |
+| A1 | Core module modifications (Portfolio/Orders/Position/Strategy/Engine) — FLAG if any found | PASS/FLAG/NA | FLAG does not block approval; it routes to qc-behavioral for generalizability judgment. |
+| A2 | No imports from `analysis/` into `trading/trading/` | PASS/FAIL/NA | The trading/ tree must not depend on the analysis/ tree. Reverse direction is fine. |
+| A3 | No unnecessary modifications to existing (non-feature) modules | PASS/FAIL/NA | Look for cross-feature drift in the diff. |
+```
+
+## Project-specific reusable references
+
+When filling notes:
+
+- **Core modules** (A1 watch-list): `trading/trading/portfolio/`,
+  `trading/trading/orders/`, `trading/trading/position/`,
+  `trading/trading/strategy/`, `trading/trading/engine/`.
+- **Test framework**: see `.claude/rules/test-patterns.md` for the canonical
+  `assert_that` + matcher composition rules. P6 sub-rules above quote those.
+
+## What the generic agent doesn't know about
+
+- Which paths constitute "core modules" (A1) — listed above.
+- The specific dune-wired linters (`fn_length_linter`,
+  `linter_magic_numbers.sh`, etc.) — referenced from the generic checklist's
+  P1/P2/P4 rows but the names are this repo's.
+- Repo layout (`trading/`, `analysis/`, `dev/`).
+
+If reusing the generic qc-structural agent in a new project, replace this
+file with the new project's architecture rules. The agent itself does not
+change.


### PR DESCRIPTION
## Summary

Phase 1 PR 2 of the agent-harness extraction plan (#592). Splits the two QC agents along the **methodology / authority** seam — generic protocol stays in `.claude/agents/` (`harness: reusable`); project-specific authority + domain-checklist rows move to `.claude/rules/qc-*-authority.md` (`harness: project`).

After this lands, the QC agents are drop-in replacements in any new project; the new project writes its own authority file and the agents work without modification.

## What moves where

| Stays in agent | Moves to authority |
|---|---|
| Build gates (H1–H3) | Project core-module list (A1) |
| Generic code-pattern checks (P1–P5) | Dependency-direction rules (A2) |
| Contract Pinning Checklist (CP1–CP4) | Existing-module-mod rule (A3) |
| Quality Score format | Test-pattern conformance ref (P6) |
| FAIL / PASS / NA semantics | Domain checklist (A1, S1–S6, L1–L4, C1–C3, T1–T4) |
| Output file format | Authority hierarchy (book reference + eng-design docs) |
| Verdict-derivation rule | Domain-NEEDS_REWORK example |
| harness_gap classification | |
| Generic example | |

## Diff scope

```
.claude/agents/qc-structural.md          | -47 lines (drop A1–A3, P6, Weinstein framing, example)
.claude/agents/qc-behavioral.md          | -99 lines (drop S*/L*/C*/T*, authority list, example)
.claude/rules/qc-structural-authority.md | +56 lines (new)
.claude/rules/qc-behavioral-authority.md | +127 lines (new)
```

Net +37 lines; reorganization rather than addition.

## Test plan

- [x] `grep harness: .claude/{agents,rules}/qc-*` shows expected tags (reusable for agents, project for new authority files).
- [x] No code touched — pure agent-definition reorg. CI gates unaffected.
- [ ] Manual smoke: next QC dispatch reads both files cleanly. Test on a real PR.

## Notes

The `qc-structural` example uses generic placeholder rows now (P6, A1–A3 still listed but with project-agnostic names) — a real review will look different per project. The full Weinstein-flavoured worked example for `qc-behavioral` is in `.claude/rules/qc-behavioral-authority.md` for reference.

Phase 1 PR 3 (hoist parameterizable bits in `lead-orchestrator.md` and `.github/workflows/orchestrator.yml` into top-of-file Configuration block) is next.