### PR TITLE
harness(meta): hoist project-specific values into Configuration block in lead-orchestrator + orchestrator.yml

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -1,9 +1,68 @@
 ---
 name: lead-orchestrator
-description: Orchestrates daily parallel feature development for the Weinstein Trading System. Spawns feature and QC agents as subagents, coordinates integration order, and writes daily summaries for human review. Runs non-interactively via claude -p.
+description: Orchestrates daily parallel feature development. Spawns feature and QC agents as subagents, coordinates integration order, and writes daily summaries for human review. Runs non-interactively via claude -p. Project-specific config (track names, feat-agents, domain keyword) is in the Configuration block below.
 model: opus
 harness: reusable
 ---
+
+<!--
+====================================================================
+Configuration — project-specific values referenced throughout this
+file. When porting this agent to a new project, replace every
+occurrence of these literals body-wide. The list is the strip-pass
+checklist for the agent-harness extraction (see
+`dev/plans/harness-template-extraction-2026-04-26.md`).
+====================================================================
+
+  repo_name:           dayfine/trading
+  domain_keyword:      "Weinstein Trading System" (free-form,
+                       used in section headings + agent descriptions)
+  domain_short:        "Weinstein"
+
+  track_names:         backtest-infra, backtest-perf, backtest-scale,
+                       data-panels, data-layer, harness, screener,
+                       sector-data, simulation, support-floor-stops,
+                       cleanup, cost-tracking, orchestrator-automation,
+                       portfolio-stops, short-side-strategy,
+                       strategy-wiring
+
+  feat_agents:         feat-weinstein, feat-backtest
+                       (one agent per cluster of related tracks; see
+                       `dev/agent-feature-workflow.md` §"Agent map")
+
+  branch_prefixes:     feat/<track>-<short>     (feature work)
+                       harness/<short>          (harness-maintainer)
+                       cleanup/<short>          (code-health)
+                       data/<short>             (ops-data)
+                       fix/<short>              (post-merge fixes)
+
+  status_dir:          dev/status/
+  review_dir:          dev/reviews/
+  daily_dir:           dev/daily/
+  health_dir:          dev/health/
+  budget_dir:          dev/budget/
+  plan_dir:            dev/plans/
+  decisions_file:      dev/decisions.md
+
+  design_dir:          docs/design/
+  design_index:        docs/design/weinstein-trading-system-v2.md
+                       (the system-level overview every agent reads)
+
+  qc_authority_files:  .claude/rules/qc-{structural,behavioral}-authority.md
+                       (project rows the QC agents append to their
+                       generic checklists; see `.claude/agents/qc-*.md`)
+
+  build_wrapper:       dev/lib/run-in-env.sh
+                       (forwards opam env into the devcontainer; the
+                       wrapper script name varies per project)
+
+  build_cmd:           dune build
+  test_cmd:            dune runtest
+
+  (See `.github/workflows/orchestrator.yml` for the matching CI
+  configuration block — image refs, secret names, cron slots.)
+====================================================================
+-->
 
 You are the lead orchestrator for the Weinstein Trading System build. You run once per day, coordinate all work, and exit. The human reads your output in `dev/daily/YYYY-MM-DD.md`.
 

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -10,6 +10,37 @@
 # reporting").
 #
 # ----------------------------------------------------------------------------
+# Configuration — project-specific values referenced below.
+# When porting this workflow to a new project, replace every occurrence
+# of these literals body-wide. List doubles as the strip-pass checklist
+# for the agent-harness extraction (see
+# dev/plans/harness-template-extraction-2026-04-26.md).
+# ----------------------------------------------------------------------------
+#
+#   repo_name:               dayfine/trading
+#   container_image:         ghcr.io/${{ github.repository_owner }}/trading-devcontainer:latest
+#   container_image_short:   trading-devcontainer
+#   container_user:          opam
+#
+#   secret_names:
+#     - BOT_GITHUB_TOKEN          (fine-grained PAT for repo writes)
+#     - CLAUDE_CODE_OAUTH_TOKEN   (claude-code-action auth)
+#     - GITHUB_TOKEN              (auto-provided by GHA; used for ghcr login)
+#
+#   cron_slots:              "17 7 * * *"   (00:17 PT)
+#                            "17 12 * * *"  (05:17 PT)
+#                            (UTC times — GitHub cron is UTC-only, no DST)
+#
+#   branch_patterns:         feat/, harness/, cleanup/, data/, fix/, ops/
+#   daily_summary_branch:    ops/daily-<date>-runN
+#   summary_dir:             dev/daily/
+#   escalations_section:     ## Escalations
+#                            (orchestrator's marker for partial-failure;
+#                            post-step fails the job if non-empty)
+#
+# ----------------------------------------------------------------------------
+#
+# ----------------------------------------------------------------------------
 # SECRETS REQUIRED BEFORE THIS WORKFLOW CAN RUN
 # ----------------------------------------------------------------------------
 # The first `workflow_dispatch` run will fail at the "Run lead-orchestrator"


### PR DESCRIPTION
## Summary

Phase 1 PR 3 of the agent-harness extraction plan (`dev/plans/harness-template-extraction-2026-04-26.md`).

Adds a top-of-file Configuration block to two files. Each enumerates the project-specific literals (repo name, domain keyword, track names, feat-agents, branch prefixes, dir paths, secret names, cron slots, etc.) — body unchanged. The blocks are the strip-pass checklist: when porting to `dayfine/agent-harness`, replace every listed literal body-wide.

## What's in each block

### `.claude/agents/lead-orchestrator.md` (~60 lines, HTML comment)
- repo_name, domain_keyword, domain_short
- track_names (16 tracks), feat_agents (2)
- branch_prefixes (5)
- 7 dir paths (status, review, daily, health, budget, plan, decisions)
- design_dir, design_index
- qc_authority_files (the new `.claude/rules/qc-*-authority.md` from #595)
- build_wrapper, build_cmd, test_cmd

### `.github/workflows/orchestrator.yml` (~30 lines, YAML comments)
- repo_name, container_image, container_user
- 3 secret names
- 2 cron slots
- branch_patterns, summary_dir, escalations_section

## Why this shape

Per the plan: Configuration blocks are **documentation, not substitution markers**. Body retains literal values; the block doubles as (a) a self-documenting top-of-file index for human readers, (b) a strip-pass checklist for future extraction scripts. Future projects either grep-replace the literals body-wide or write a `bin/agent-harness init` substitution step that uses the block as the manifest.

## Test plan

- [x] No build / test impact — files not consumed by `dune`. CI gates unaffected.
- [x] Configuration block is a comment in both files (HTML in `.md`, `#` in YAML); doesn't change parsing.
- [ ] Manual: read both blocks; verify nothing project-specific is missing from the list.

## Phase 1 status

| PR | Scope | Status |
|---|---|---|
| 1 | Frontmatter pass | MERGED #593 |
| 2 | QC agent split | MERGED #595 |
| **3** | **Config hoist (this PR)** | **open** |
| 4 (optional) | `.claude/README.md` for layer model | not started — may skip |

After PR 3 lands, **Phase 2 (extraction)** is unblocked. The empty `dayfine/agent-harness` repo (created 2026-04-26) is ready for the one-shot extraction described in §Phase 2 of the plan.