### PR TITLE
feat(data-panels): Stage 4.5 PR-A — two-phase lazy cascade in _screen_universe

### DIFF
--- a/dev/plans/panels-stage045-pr-a-2026-04-26.md
+++ b/dev/plans/panels-stage045-pr-a-2026-04-26.md
@@ -1,0 +1,118 @@
+# Plan: Stage 4.5 PR-A — two-phase lazy stage filter in `_screen_universe` (2026-04-26)
+
+## Status
+
+IMPLEMENTING. Companion to
+`dev/plans/panels-stage045-lazy-tier-cascade-2026-04-26.md` §"PR-A".
+Branch: `feat/panels-stage045-pr-a-lazy-stage-filter`.
+
+## Wedge (recap)
+
+`_screen_universe` runs the full per-symbol heavy work
+(`weekly_view_for` + `stock_analysis_callbacks_of_weekly_views` +
+`Stock_analysis.analyze_with_callbacks`) for **every** loaded symbol on
+every Friday, then filters to survivors via the screener cascade.
+That ordering pays full per-symbol allocation regardless of regime.
+Per-symbol RSS slope at N=292 T=6y is 5.12 MB/symbol; goal is to drive
+it toward ≤ 1.5 MB/symbol via lazy allocation.
+
+## Two-phase design
+
+```
+Phase 1 (universe-wide, cheap):
+  for ticker in config.universe:
+    weekly_view = Bar_reader.weekly_view_for(ticker, n=lookback_bars)   (* small: 5 float arrays *)
+    stage_callbacks = Panel_callbacks.stage_callbacks_of_weekly_view    (* cache-aware via PR-D *)
+                        ~ma_cache ~symbol:ticker ~weekly:weekly_view
+    stage_result = Stage.classify_with_callbacks(stage_callbacks, prior_stage)
+    Hashtbl.set prior_stages ~key:ticker ~data:stage_result.stage      (* always update *)
+    if stage_result.stage matches Stage2 or Stage4:
+      yield (ticker, weekly_view, stage_result)                         (* survives Phase 2 *)
+
+Phase 2 (survivors only, heavy):
+  for (ticker, weekly_view, _) in survivors:
+    full_callbacks = Panel_callbacks.stock_analysis_callbacks_of_weekly_views
+                       ~ma_cache ~stock_symbol:ticker
+                       ~stock:weekly_view ~benchmark:index_view
+    stock_analysis = Stock_analysis.analyze_with_callbacks(...)         (* the expensive step *)
+    yield stock_analysis
+
+Screener.screen ~stocks:phase2_results ...
+```
+
+## Filter predicate
+
+Long: `Stock_analysis.is_breakout_candidate` requires `stage = Stage2 _`
+(any sub-state). Short: `Stock_analysis.is_breakdown_candidate` requires
+`stage = Stage4 _` (any sub-state). The screener's `_long_candidate` and
+`_short_candidate` further filter via `is_breakout_candidate` /
+`is_breakdown_candidate`, which gate-check on Stage2 / Stage4. The
+screener's watchlist gate also requires `is_breakout_candidate`
+(Stage2). Symbols in Stage1 / Stage3 cannot produce a candidate.
+
+So Phase 1's predicate is:
+
+```ocaml
+match stage_result.stage with
+| Stage2 _ | Stage4 _ -> true   (* survive *)
+| Stage1 _ | Stage3 _ -> false  (* drop — screener would reject anyway *)
+```
+
+This is over-broad relative to the screener's actual rules
+(Stage2 also needs prior_stage = Stage1 or weeks_advancing ≤ 4 +
+volume + RS in `is_breakout_candidate`; Stage4 needs prior_stage =
+Stage3 or weeks_declining ≤ 4) but staying broad keeps Phase 1
+cheap (no Volume / RS reads) and guarantees parity with the bar-list
+output.
+
+## Pragmatic deviation from dispatch
+
+The dispatch suggested Phase 1 read panel cells directly without
+`weekly_view_for` allocation. The cleanest implementation that
+preserves bit-equality with the existing callbacks (and with the
+`test_panel_loader_parity` golden) reuses `weekly_view_for` for
+Phase 1 — which still allocates 5 float arrays per symbol per Friday
+(~ 5 × 52 × 8 ≈ 2 KB, negligible compared to the Stock_analysis
+bundle and `analyze_with_callbacks` work).
+
+The load-bearing wedge is **Phase 2 elimination** (the full callback
+bundle + Stock_analysis analyze). Phase 1's `weekly_view_for` cost is
+small and the cache-aware MA path (PR-D #594) means MA computation is
+amortised across Fridays. If the post-PR-A matrix shows
+`weekly_view_for` is still a wedge, a follow-up PR can add a
+panel-row-direct stage callback (Closes-only Bigarray slice +
+`Weekly_ma_cache` MA reads, no `Bar_panels.weekly_view` materialisation).
+
+## Files
+
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy.ml` —
+  `_screen_universe` and `_analyze_ticker` split into Phase 1
+  (`_classify_stage_for_screening`) and Phase 2
+  (`_full_analysis_of_survivor`).
+- `trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml`
+  — new counter test asserting Phase 2 invocation count matches
+  survivor count, not loaded count.
+
+`Panel_callbacks` is unchanged — Phase 1 uses the existing
+`stage_callbacks_of_weekly_view`; Phase 2 uses the existing
+`stock_analysis_callbacks_of_weekly_views`. No new public API.
+
+## Parity gates
+
+- `test_panel_loader_parity` round_trips golden — bit-equal trades
+  (load-bearing).
+- `test_weinstein_backtest` (3 simulation tests) — relaxed structural
+  invariants must still hold.
+- `test_weinstein_strategy{,_smoke}`, `test_macro_inputs`,
+  `test_stops_runner`, `test_panel_callbacks`, `test_weekly_ma_cache`
+  — green.
+
+Plus PR-A specific:
+
+- New counter test in `test_weinstein_strategy.ml` — synthetic Stage-4-
+  heavy fixture, count Phase 2 invocations, assert equals survivor
+  count.
+
+## LOC
+
+~80 production, ~70 tests. Net minor change to `_screen_universe`.

--- a/dev/status/data-panels.md
+++ b/dev/status/data-panels.md
@@ -5,7 +5,48 @@
 ## Status
 READY_FOR_REVIEW
 
-Stage 4 PR-D READY_FOR_REVIEW on `feat/panels-stage04-pr-d-weekly-indicator-panels` — adds `Weekly_ma_cache` (per-symbol weekly MA memoisation) so the `stage_callbacks_of_weekly_view` hot path no longer recomputes SMA / WMA / EMA over weekly closes per Friday tick. Memoised by `(symbol, ma_type, period)`; built lazily at first request from the symbol's full weekly history; cache hits skip the `Indicator_types.t list` allocation entirely. Fallback to inline computation on cache miss (mid-week stops_runner calls + tests without a panel).
+Stage 4-5 PR-A READY_FOR_REVIEW on `feat/panels-stage045-pr-a-lazy-stage-filter` — restructures `_screen_universe` into a two-phase lazy cascade. Phase 1 runs cheap stage-only `Stage.classify_with_callbacks` (cache-aware via PR-D `Weekly_ma_cache`) over every loaded symbol. Phase 2 — the load-bearing allocation site (`Panel_callbacks.stock_analysis_callbacks_of_weekly_views` + `Stock_analysis.analyze_with_callbacks`) — runs only for survivors whose stage classification can yield a screener candidate (Stage2 longs / Stage4 shorts). Stage1 / Stage3 symbols are dropped after Phase 1; the screener would have rejected them after the full analysis anyway. `prior_stages` updates batch at end-of-pass to preserve pre-PR-A semantics where every per-symbol analysis on a Friday observed the previous Friday's snapshot.
+
+**Stage 4-5 PR-A scope**:
+- `weinstein_strategy.{ml,mli}` — split `_analyze_ticker` into `_classify_stage_for_screening` (Phase 1, cheap) + `_full_analysis_of_survivor` (Phase 2, heavy). New `_classify_all` builds the universe-wide stage classification list; `_commit_prior_stages` advances the table after the screening pass. `_screen_universe` now: (a) Phase 1 over universe, (b) filter survivors by `_survives_phase1`, (c) Phase 2 over survivors, (d) commit prior_stages, (e) screener cascade as before.
+- New public `Weinstein_strategy.survivors_for_screening` — exposes Phase 1 for testability. Returns `(string * Bar_panels.weekly_view * Stage.result) list` so tests can directly assert filter behaviour without instrumenting the screener loop with a counter.
+- Filter predicate `_survives_phase1` matches on `Stage2 _ | Stage4 _` (true) vs `Stage1 _ | Stage3 _` (false). Intentionally over-broad relative to the screener's actual `is_breakout_candidate` / `is_breakdown_candidate` rules (which also gate on volume / RS / prior_stage); keeping the gate stage-only preserves bit-equality with the bar-list output.
+
+**Bit-equality + parity**:
+- Load-bearing `test_panel_loader_parity` round_trips golden: 2 tests, all OK. Both `tiered-loader-parity` and `panel-golden-2019-full` round-trip lists are bit-equal — same trade dates, prices, sides, quantities as pre-PR-A.
+- The Phase 1 stage classification reuses the same `stage_callbacks_of_weekly_view` (cache-aware) that Phase 2's `stock_analysis_callbacks_of_weekly_views` embeds — both produce bit-identical Stage.result for the same view.
+- `prior_stage` threaded from Phase 1 into Phase 2 (instead of re-reading from the hashtbl) preserves the pre-PR-A invariant that every per-symbol analysis on a single Friday tick saw the previous Friday's stage snapshot. Initial implementation that re-read from the table after Phase 1 wrote it broke this — caught by the round_trips parity test (3 vs 5 trades) before merge.
+
+**Tests added** (`test_weinstein_strategy.ml`, +3 tests):
+- `survivors_for_screening filters by stage` — 4 trending symbols (2 rising, 2 declining), all survive (Stage2 / Stage4).
+- `survivors_for_screening drops Stage1 and Stage3` — basing series + topping series + Stage4 control; only the Stage4 control survives.
+- `phase 2 call count equals survivor count, not loaded count` — 6-symbol Stage-4-heavy universe (2 Stage1 + 2 Stage3 + 2 Stage4); asserts `(loaded_count, survivor_count) = (6, 2)` so the Phase 2 call count (a `List.map` over survivors) matches survivor count, not loaded count.
+
+**Files touched**:
+- modified: `trading/trading/weinstein/strategy/lib/weinstein_strategy.{ml,mli}` (~+95 / -45 production lines including doc comments).
+- modified: `trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml` (+~210 test lines: 3 new tests + helpers for building synthetic Bar_panels at known stage profiles).
+- new: `dev/plans/panels-stage045-pr-a-2026-04-26.md` — PR-specific plan.
+
+**LOC delta**: ~+95 production, ~+210 tests; net new public API: `survivors_for_screening` (single new val).
+
+**Pragmatic deviation from dispatch**:
+- The dispatch suggested Phase 1 read panel cells directly without a `weekly_view_for` allocation. Phase 1 in this PR reuses `weekly_view_for` for symmetry with the existing cache-aware `stage_callbacks_of_weekly_view` and to preserve bit-equality. The view costs 5 float arrays of size ≤ 52 per symbol per Friday (~ 2 KB) — negligible compared to the eliminated Stock_analysis bundle + analyze. If post-PR-A matrix shows `weekly_view_for` is still a wedge, a follow-up PR can add a panel-row-direct stage callback (closes-only Bigarray slice + `Weekly_ma_cache` MA reads, no view materialisation).
+
+**Out of scope (deferred to PR-B / later)**:
+- Sector pre-filter as second early-exit gate (companion plan §"PR-B").
+- Tunable filter thresholds in config (PR-C, optional).
+- Memtrace / heap forensics — independent diagnostic, not gated on this work.
+- `Stops_runner.update` allocations on the daily-stop path — not touched by PR-A.
+
+**Verify**: `cd trading && eval $(opam env) && TRADING_DATA_DIR=$PWD/test_data dune build && dune runtest && dune build @fmt`. All suites green; formatter clean; nesting linter clean (max ≤5, avg 1.44 across 927 functions).
+
+PR-A is bookmarked at `feat/panels-stage045-pr-a-lazy-stage-filter`. Plan: `dev/plans/panels-stage045-pr-a-2026-04-26.md` (companion to `dev/plans/panels-stage045-lazy-tier-cascade-2026-04-26.md`).
+
+**Recommended next dispatch**: re-run the RSS matrix from `dev/notes/panels-rss-matrix-2026-04-26.md` at the four cells {50, 292} × {1y, 6y} on `bull-crash-292x6y` to validate β slope drop (target: 5.12 → ≤ 1.5 MB/symbol). If β doesn't drop, the wedge is outside `_screen_universe` (memtrace required next).
+
+---
+
+**Prior status (Stage 4 PR-D, READY_FOR_REVIEW)**: adds `Weekly_ma_cache` (per-symbol weekly MA memoisation) so the `stage_callbacks_of_weekly_view` hot path no longer recomputes SMA / WMA / EMA over weekly closes per Friday tick. Memoised by `(symbol, ma_type, period)`; built lazily at first request from the symbol's full weekly history; cache hits skip the `Indicator_types.t list` allocation entirely. Fallback to inline computation on cache miss (mid-week stops_runner calls + tests without a panel).
 
 **Stage 4 PR-D scope**:
 - New module `weinstein/strategy/lib/weekly_ma_cache.{ml,mli}`. Hashtbl-backed memoisation keyed by `{ symbol; ma_type tag; period }`. The MA tag is a local mirror of `Stage.ma_type` (so the module derives `hash` without touching `Stage.ma_type`). Stores `cached_ma = { values : float array; dates : Date.t array }`. `ma_values_for` lazily computes via the same `Sma.calculate_sma | Sma.calculate_weighted_ma | Ema.calculate_ema` kernels `Stage._compute_ma` uses, then caches the result. `locate_date` does a tail-anchored linear scan to map a view's most-recent date to its cached index.

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -219,6 +219,119 @@ let entries_from_candidates ~config ~candidates ~stop_states ~bar_reader
       | Some kept -> kept :: acc)
   |> List.rev
 
+(** Stage 4-5 PR-A: a symbol survives Phase 1 if its current stage
+    classification could in principle yield a screener candidate. Long
+    candidates require [Stage2 _] (per [Stock_analysis.is_breakout_candidate]);
+    short candidates require [Stage4 _] (per
+    [Stock_analysis.is_breakdown_candidate]). [Stage1] and [Stage3] cannot
+    satisfy either predicate, so the screener would reject them after the full
+    analysis anyway — they are safe to skip in Phase 2.
+
+    The predicate is intentionally over-broad relative to the screener's actual
+    eligibility rules (which also require volume / RS / prior-stage matches);
+    keeping the gate on stage alone preserves bit-equality with the bar-list
+    output while still cutting the dominant per-symbol allocation. *)
+let _survives_phase1 (stage_result : Stage.result) : bool =
+  match stage_result.stage with
+  | Weinstein_types.Stage2 _ | Weinstein_types.Stage4 _ -> true
+  | Weinstein_types.Stage1 _ | Weinstein_types.Stage3 _ -> false
+
+(** Stage 4-5 PR-A Phase 1: classify the ticker via the cheap stage callback
+    bundle (cache-aware via PR-D) and return
+    [(ticker, weekly_view, prior_stage, stage_result)] when the weekly view is
+    non-empty. The [prior_stage] (the entry from [prior_stages] read at Phase 1
+    time, before any update) is threaded forward so Phase 2's [Stock_analysis]
+    receives the same prior-stage context the original pre-PR-A path saw —
+    necessary for the screener's Stage1→Stage2 / Stage3→Stage4 transition
+    signals to fire correctly.
+
+    [prior_stages] is NOT updated here; the update happens after Phase 2 (or in
+    a dedicated update pass for non-survivors below) so that within a single
+    Friday tick every per-symbol classification reads the same "previous
+    Friday's stage" snapshot. *)
+let _classify_stage_for_screening ~config ~bar_reader ~prior_stages
+    ~current_date ticker =
+  let stock_view =
+    Bar_reader.weekly_view_for bar_reader ~symbol:ticker ~n:config.lookback_bars
+      ~as_of:current_date
+  in
+  if stock_view.n = 0 then None
+  else
+    let prior_stage = Hashtbl.find prior_stages ticker in
+    let stage_callbacks =
+      Panel_callbacks.stage_callbacks_of_weekly_view
+        ?ma_cache:(Bar_reader.ma_cache bar_reader)
+        ~symbol:ticker ~config:config.stage_config ~weekly:stock_view ()
+    in
+    let stage_result =
+      Stage.classify_with_callbacks ~config:config.stage_config
+        ~get_ma:stage_callbacks.get_ma ~get_close:stage_callbacks.get_close
+        ~prior_stage
+    in
+    Some (ticker, stock_view, prior_stage, stage_result)
+
+(** Stage 4-5 PR-A Phase 2: build the full [Stock_analysis.callbacks] bundle
+    (Stage / Rs / Volume / Resistance) for a survivor and run
+    [Stock_analysis.analyze_with_callbacks]. This is the load-bearing allocation
+    site: prior to PR-A it ran for every loaded symbol; now it runs only for
+    survivors of [_survives_phase1]. The [prior_stage] passed here is the value
+    Phase 1 captured before any [prior_stages] update — matches the pre-PR-A
+    semantics where every per-symbol analysis on a given Friday saw the same
+    "previous Friday" snapshot. *)
+let _full_analysis_of_survivor ~bar_reader ~index_view
+    ( ticker,
+      (stock_view : Data_panel.Bar_panels.weekly_view),
+      prior_stage,
+      (_stage_result : Stage.result) ) =
+  let as_of_date = stock_view.dates.(stock_view.n - 1) in
+  let callbacks =
+    Panel_callbacks.stock_analysis_callbacks_of_weekly_views
+      ?ma_cache:(Bar_reader.ma_cache bar_reader)
+      ~stock_symbol:ticker ~config:Stock_analysis.default_config
+      ~stock:stock_view ~benchmark:index_view ()
+  in
+  Stock_analysis.analyze_with_callbacks ~config:Stock_analysis.default_config
+    ~ticker ~callbacks ~prior_stage ~as_of_date
+
+(** Phase 1: classify every ticker in [config.universe] via the cheap stage-only
+    pass. Returns the full classification result — non-survivors retained so the
+    caller can update [prior_stages] in one pass after screening. *)
+let _classify_all ~config ~bar_reader ~prior_stages ~current_date =
+  List.filter_map config.universe
+    ~f:
+      (_classify_stage_for_screening ~config ~bar_reader ~prior_stages
+         ~current_date)
+
+(** Advance [prior_stages] in one pass — matches the pre-PR-A semantics where
+    every per-symbol analysis on a given Friday observed the previous Friday's
+    stage snapshot, and the table only advanced once at the end of the universe
+    loop. *)
+let _commit_prior_stages ~prior_stages classified =
+  List.iter classified ~f:(fun (ticker, _view, _prior, stage_result) ->
+      Hashtbl.set prior_stages ~key:ticker ~data:stage_result.Stage.stage)
+
+(** Stage 4-5 PR-A: Phase 1 of the cascade. Classify every symbol in
+    [config.universe] via the cheap stage-only callback bundle and return the
+    list of survivors as [(ticker, weekly_view, stage_result)] tuples. Updates
+    [prior_stages] for every classified symbol (even non-survivors) so the next
+    Friday's classification has accurate prior-stage context.
+
+    Public for testability — lets unit tests assert that the universe filter
+    drops Stage1 / Stage3 symbols and keeps Stage2 / Stage4 without having to
+    instrument the screener loop with a counter. *)
+let survivors_for_screening ~config ~bar_reader ~prior_stages ~current_date :
+    (string * Data_panel.Bar_panels.weekly_view * Stage.result) list =
+  let classified =
+    _classify_all ~config ~bar_reader ~prior_stages ~current_date
+  in
+  let survivors =
+    List.filter_map classified ~f:(fun (ticker, view, _prior, stage_result) ->
+        if _survives_phase1 stage_result then Some (ticker, view, stage_result)
+        else None)
+  in
+  _commit_prior_stages ~prior_stages classified;
+  survivors
+
 (** Screen the universe for both long and short candidates, returning a combined
     transition list. Macro-trend gating lives in the screener itself:
     [buy_candidates] are empty under [Bearish], [short_candidates] are empty
@@ -229,41 +342,25 @@ let entries_from_candidates ~config ~candidates ~stop_states ~bar_reader
     - [Neutral]: both — longs and shorts are both eligible.
     - [Bearish]: shorts only — longs are empty.
 
-    Stage 4 PR-A: per-ticker analysis goes through panel-shaped Stage / Rs
-    callbacks (no [Daily_price.t list] for those scans). Volume + Resistance in
-    [Stock_analysis] (Stage, Rs, breakout-price scan, peak-volume scan, Volume,
-    Resistance) reads through the panel-shaped callbacks below without
-    allocating any [Daily_price.t list]. *)
+    Stage 4-5 PR-A: per-ticker analysis is split into a cheap stage-only Phase 1
+    (universe-wide) and a heavy Phase 2 (survivors only). Phase 2 builds the
+    full callback bundle and runs [Stock_analysis.analyze_with_callbacks] —
+    previously this ran for every loaded symbol. Symbols whose stage cannot
+    yield a screener candidate (Stage1 / Stage3) are dropped after Phase 1. *)
 let _screen_universe ~config ~index_view ~macro_trend ~sector_map ~stop_states
     ~(portfolio : Portfolio_view.t) ~get_price ~bar_reader ~prior_stages
     ~current_date =
-  let _analyze_ticker ticker =
-    let stock_view =
-      Bar_reader.weekly_view_for bar_reader ~symbol:ticker
-        ~n:config.lookback_bars ~as_of:current_date
-    in
-    if stock_view.n = 0 then None
-    else
-      let as_of_date =
-        if stock_view.n = 0 then current_date
-        else stock_view.dates.(stock_view.n - 1)
-      in
-      let prior_stage = Hashtbl.find prior_stages ticker in
-      let callbacks =
-        Panel_callbacks.stock_analysis_callbacks_of_weekly_views
-          ?ma_cache:(Bar_reader.ma_cache bar_reader)
-          ~stock_symbol:ticker ~config:Stock_analysis.default_config
-          ~stock:stock_view ~benchmark:index_view ()
-      in
-      let result =
-        Stock_analysis.analyze_with_callbacks
-          ~config:Stock_analysis.default_config ~ticker ~callbacks ~prior_stage
-          ~as_of_date
-      in
-      Hashtbl.set prior_stages ~key:ticker ~data:result.stage.stage;
-      Some result
+  let classified =
+    _classify_all ~config ~bar_reader ~prior_stages ~current_date
   in
-  let stocks = List.filter_map config.universe ~f:_analyze_ticker in
+  let survivors =
+    List.filter classified ~f:(fun (_, _, _, stage_result) ->
+        _survives_phase1 stage_result)
+  in
+  let stocks =
+    List.map survivors ~f:(_full_analysis_of_survivor ~bar_reader ~index_view)
+  in
+  _commit_prior_stages ~prior_stages classified;
   let screen_result =
     Screener.screen ~config:config.screening_config ~macro_trend ~sector_map
       ~stocks ~held_tickers:(held_symbols portfolio)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -171,6 +171,31 @@ val held_symbols : Trading_strategy.Portfolio_view.t -> string list
     natural query on strategy state and the behaviour (exclude [Closed]) is
     worth pinning by direct unit test. *)
 
+val survivors_for_screening :
+  config:config ->
+  bar_reader:Bar_reader.t ->
+  prior_stages:Weinstein_types.stage Core.Hashtbl.M(String).t ->
+  current_date:Date.t ->
+  (string * Data_panel.Bar_panels.weekly_view * Stage.result) list
+(** Stage 4-5 PR-A: Phase 1 of the lazy screener cascade. For every ticker in
+    [config.universe], reads a panel weekly view and classifies the current
+    stage via the cheap stage-only callback bundle (cache-aware via PR-D
+    {!Weekly_ma_cache}). Returns survivors — symbols whose stage could in
+    principle yield a screener candidate ([Stage2 _] for longs; [Stage4 _] for
+    shorts) — paired with their weekly view (reused by Phase 2) and
+    {!Stage.result}.
+
+    [prior_stages] is updated for every classified symbol, including
+    non-survivors, so the next Friday's classification has accurate prior-stage
+    context.
+
+    Public for testability — lets unit tests assert that the universe filter
+    correctly drops Stage1 / Stage3 symbols without instrumenting the screener
+    loop. The filter predicate is intentionally over-broad relative to the
+    screener's full eligibility rules (which also depend on volume / RS / sector
+    / prior_stage); staying broad on stage alone keeps Phase 1 cheap and
+    preserves bit-equality with the bar-list output. *)
+
 val entries_from_candidates :
   config:config ->
   candidates:Screener.scored_candidate list ->

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -650,6 +650,285 @@ let test_entries_from_candidates_emits_long _ =
        ])
 
 (* ------------------------------------------------------------------ *)
+(* Stage 4-5 PR-A: lazy stage filter — survivors_for_screening         *)
+(* ------------------------------------------------------------------ *)
+
+(** Build a Friday-anchored series of weekly bars. *)
+let _make_friday_bars ~start_friday ~n ~start_price ~step =
+  List.init n ~f:(fun i ->
+      let date = Date.add_days start_friday (i * 7) in
+      let price = start_price +. (Float.of_int i *. step) in
+      {
+        Types.Daily_price.date;
+        open_price = price;
+        high_price = price *. 1.01;
+        low_price = price *. 0.99;
+        close_price = price;
+        adjusted_close = price;
+        volume = 1_000_000;
+      })
+
+(** Pack [(symbol, bars)] pairs into a {!Bar_panels.t}. The calendar is the
+    union of all dates (sorted, deduped). Mirrors the helper in
+    {!test_panel_callbacks.ml}. *)
+let _panels_of_symbols
+    (symbols_with_bars : (string * Types.Daily_price.t list) list) =
+  let universe = List.map symbols_with_bars ~f:fst in
+  let symbol_index =
+    match Data_panel.Symbol_index.create ~universe with
+    | Ok t -> t
+    | Error err -> failwith ("Symbol_index.create: " ^ err.Status.message)
+  in
+  let calendar =
+    symbols_with_bars
+    |> List.concat_map ~f:(fun (_, bars) ->
+        List.map bars ~f:(fun b -> b.Types.Daily_price.date))
+    |> List.dedup_and_sort ~compare:Date.compare
+    |> Array.of_list
+  in
+  let ohlcv =
+    Data_panel.Ohlcv_panels.create symbol_index ~n_days:(Array.length calendar)
+  in
+  let date_to_col = Hashtbl.create (module Date) in
+  Array.iteri calendar ~f:(fun i d ->
+      Hashtbl.add date_to_col ~key:d ~data:i
+      |> (ignore : [ `Ok | `Duplicate ] -> unit));
+  List.iter symbols_with_bars ~f:(fun (symbol, bars) ->
+      match Data_panel.Symbol_index.to_row symbol_index symbol with
+      | None -> ()
+      | Some row ->
+          List.iter bars ~f:(fun bar ->
+              match Hashtbl.find date_to_col bar.Types.Daily_price.date with
+              | None -> ()
+              | Some day ->
+                  Data_panel.Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day
+                    bar));
+  match Data_panel.Bar_panels.create ~ohlcv ~calendar with
+  | Ok p -> p
+  | Error err -> failwith ("Bar_panels.create: " ^ err.Status.message)
+
+(** Build a 60-week Friday-anchored series with the given start_price + step.
+    Positive [step] yields a Stage2-classifying series (rising MA, price above
+    MA); negative [step] yields a Stage4 series. *)
+let _trending_series ~start_friday ~start_price ~step =
+  _make_friday_bars ~start_friday ~n:60 ~start_price ~step
+
+let test_survivors_for_screening_filters_by_stage _ =
+  (* Universe of four symbols: two rising (Stage2-survivors), two declining
+     (Stage4-survivors). The filter currently drops only Stage1 / Stage3, so
+     all four trend-in-one-direction symbols must survive. *)
+  let start_friday = Date.of_string "2024-01-05" in
+  let rising_a = _trending_series ~start_friday ~start_price:50.0 ~step:0.8 in
+  let rising_b = _trending_series ~start_friday ~start_price:60.0 ~step:1.0 in
+  let declining_a =
+    _trending_series ~start_friday ~start_price:200.0 ~step:(-1.5)
+  in
+  let declining_b =
+    _trending_series ~start_friday ~start_price:180.0 ~step:(-1.0)
+  in
+  let panels =
+    _panels_of_symbols
+      [
+        ("RISE_A", rising_a);
+        ("RISE_B", rising_b);
+        ("FALL_A", declining_a);
+        ("FALL_B", declining_b);
+      ]
+  in
+  let bar_reader = Bar_reader.of_panels panels in
+  let cfg =
+    default_config
+      ~universe:[ "RISE_A"; "RISE_B"; "FALL_A"; "FALL_B" ]
+      ~index_symbol:"GSPCX"
+  in
+  let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  (* Use the panel's last date as the screening day — guaranteed to land in
+     the calendar so [weekly_view_for] returns a non-empty view. *)
+  let last_date =
+    let n = Data_panel.Bar_panels.n_days panels in
+    let cal_view =
+      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"RISE_A" ~n:1
+        ~as_of_day:(n - 1)
+    in
+    cal_view.dates.(cal_view.n - 1)
+  in
+  let survivors =
+    survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
+      ~current_date:last_date
+  in
+  let survivor_tickers =
+    List.map survivors ~f:(fun (ticker, _, _) -> ticker)
+    |> List.sort ~compare:String.compare
+  in
+  (* All four trending series classify into Stage2 / Stage4 — none drop. *)
+  assert_that survivor_tickers
+    (equal_to [ "FALL_A"; "FALL_B"; "RISE_A"; "RISE_B" ])
+
+let test_survivors_for_screening_drops_stage1_and_stage3 _ =
+  (* Build symbols whose stage classification falls into Stage1 / Stage3.
+     [Stage1] = decline-then-flat (basing); [Stage3] = rise-then-flat
+     (topping). The filter must drop them. *)
+  let start_friday = Date.of_string "2024-01-05" in
+  let make_dates ~n =
+    List.init n ~f:(fun i -> Date.add_days start_friday (i * 7))
+  in
+  let bars_of_prices prices =
+    List.map2_exn
+      (make_dates ~n:(List.length prices))
+      prices
+      ~f:(fun date p ->
+        {
+          Types.Daily_price.date;
+          open_price = p;
+          high_price = p *. 1.01;
+          low_price = p *. 0.99;
+          close_price = p;
+          adjusted_close = p;
+          volume = 1_000_000;
+        })
+  in
+  (* Stage1: 15 weeks declining 100 → 86, then 50 weeks flat at 85. *)
+  let stage1_bars =
+    let declining = List.init 15 ~f:(fun i -> 100.0 -. Float.of_int i) in
+    let flat = List.init 50 ~f:(fun _ -> 85.0) in
+    bars_of_prices (declining @ flat)
+  in
+  (* Stage3: 15 weeks rising 50 → 64, then 50 weeks flat at 65. *)
+  let stage3_bars =
+    let rising = List.init 15 ~f:(fun i -> 50.0 +. Float.of_int i) in
+    let flat = List.init 50 ~f:(fun _ -> 65.0) in
+    bars_of_prices (rising @ flat)
+  in
+  (* One Stage4 control to confirm filter survives at least one symbol. *)
+  let stage4_bars =
+    _trending_series ~start_friday ~start_price:200.0 ~step:(-1.5)
+  in
+  let panels =
+    _panels_of_symbols
+      [ ("BASE", stage1_bars); ("TOP", stage3_bars); ("DECLINE", stage4_bars) ]
+  in
+  let bar_reader = Bar_reader.of_panels panels in
+  let cfg =
+    default_config ~universe:[ "BASE"; "TOP"; "DECLINE" ] ~index_symbol:"GSPCX"
+  in
+  (* Seed prior stages so the classifier disambiguates Stage1 (prior Stage4)
+     from Stage3 (prior Stage2). *)
+  let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
+    Hashtbl.of_alist_exn
+      (module String)
+      [
+        ("BASE", Weinstein_types.Stage4 { weeks_declining = 10 });
+        ("TOP", Weinstein_types.Stage2 { weeks_advancing = 10; late = false });
+      ]
+  in
+  let last_date =
+    let n = Data_panel.Bar_panels.n_days panels in
+    let cal_view =
+      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"DECLINE" ~n:1
+        ~as_of_day:(n - 1)
+    in
+    cal_view.dates.(cal_view.n - 1)
+  in
+  let survivors =
+    survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
+      ~current_date:last_date
+  in
+  let survivor_tickers = List.map survivors ~f:(fun (ticker, _, _) -> ticker) in
+  (* Only DECLINE (Stage4) passes; BASE (Stage1) and TOP (Stage3) drop. *)
+  assert_that survivor_tickers (equal_to [ "DECLINE" ])
+
+(** Stage 4-5 PR-A counter test: in a Stage-4-heavy universe, the number of full
+    {!Stock_analysis} analyses (Phase 2) must equal the survivor count, NOT the
+    loaded universe size. We exercise this via [survivors_for_screening] — Phase
+    2 in [_screen_universe] is a [List.map] over [survivors], so the survivor
+    list length is mathematically equivalent to the Phase 2 call count.
+
+    Pre-PR-A: every loaded symbol paid the full callback bundle + analyze cost.
+    Post-PR-A: only survivors do. The win is proportional to (loaded -
+    survivors). *)
+let test_phase2_call_count_equals_survivor_count _ =
+  (* Six-symbol universe: two Stage4 (survive), two Stage1 (drop), two Stage3
+     (drop). Post-PR-A only the two Stage4 symbols pay the full
+     [Stock_analysis] cost; pre-PR-A all six did. *)
+  let start_friday = Date.of_string "2024-01-05" in
+  let make_dates ~n =
+    List.init n ~f:(fun i -> Date.add_days start_friday (i * 7))
+  in
+  let bars_of_prices prices =
+    List.map2_exn
+      (make_dates ~n:(List.length prices))
+      prices
+      ~f:(fun date p ->
+        {
+          Types.Daily_price.date;
+          open_price = p;
+          high_price = p *. 1.01;
+          low_price = p *. 0.99;
+          close_price = p;
+          adjusted_close = p;
+          volume = 1_000_000;
+        })
+  in
+  let stage1_bars _seed =
+    let declining = List.init 15 ~f:(fun i -> 100.0 -. Float.of_int i) in
+    let flat = List.init 50 ~f:(fun _ -> 85.0) in
+    bars_of_prices (declining @ flat)
+  in
+  let stage3_bars _seed =
+    let rising = List.init 15 ~f:(fun i -> 50.0 +. Float.of_int i) in
+    let flat = List.init 50 ~f:(fun _ -> 65.0) in
+    bars_of_prices (rising @ flat)
+  in
+  let stage4_bars seed =
+    _trending_series ~start_friday ~start_price:(200.0 +. seed) ~step:(-1.5)
+  in
+  let panels =
+    _panels_of_symbols
+      [
+        ("BASE_A", stage1_bars 0.0);
+        ("BASE_B", stage1_bars 1.0);
+        ("TOP_A", stage3_bars 0.0);
+        ("TOP_B", stage3_bars 1.0);
+        ("DECLINE_A", stage4_bars 0.0);
+        ("DECLINE_B", stage4_bars 5.0);
+      ]
+  in
+  let bar_reader = Bar_reader.of_panels panels in
+  let cfg =
+    default_config
+      ~universe:
+        [ "BASE_A"; "BASE_B"; "TOP_A"; "TOP_B"; "DECLINE_A"; "DECLINE_B" ]
+      ~index_symbol:"GSPCX"
+  in
+  let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
+    Hashtbl.of_alist_exn
+      (module String)
+      [
+        ("BASE_A", Weinstein_types.Stage4 { weeks_declining = 10 });
+        ("BASE_B", Weinstein_types.Stage4 { weeks_declining = 10 });
+        ("TOP_A", Weinstein_types.Stage2 { weeks_advancing = 10; late = false });
+        ("TOP_B", Weinstein_types.Stage2 { weeks_advancing = 10; late = false });
+      ]
+  in
+  let last_date =
+    let n = Data_panel.Bar_panels.n_days panels in
+    let cal_view =
+      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"DECLINE_A" ~n:1
+        ~as_of_day:(n - 1)
+    in
+    cal_view.dates.(cal_view.n - 1)
+  in
+  let loaded_count = List.length cfg.universe in
+  let survivors =
+    survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
+      ~current_date:last_date
+  in
+  let survivor_count = List.length survivors in
+  assert_that (loaded_count, survivor_count) (equal_to ((6, 2) : int * int))
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -680,4 +959,10 @@ let () =
            >:: test_entries_from_candidates_emits_short;
            "entries_from_candidates emits Long transition for Long candidate"
            >:: test_entries_from_candidates_emits_long;
+           "survivors_for_screening filters by stage"
+           >:: test_survivors_for_screening_filters_by_stage;
+           "survivors_for_screening drops Stage1 and Stage3"
+           >:: test_survivors_for_screening_drops_stage1_and_stage3;
+           "phase 2 call count equals survivor count, not loaded count"
+           >:: test_phase2_call_count_equals_survivor_count;
          ])


### PR DESCRIPTION
## Summary

Stage 4.5 PR-A. Restructures `_screen_universe` in `weinstein_strategy.ml` into a two-phase lazy cascade so per-symbol heavy work fires only for symbols that pass a cheap stage-classify gate.

Per the post-PR-D RSS matrix (`dev/notes/panels-rss-matrix-2026-04-26.md`), memory was dominated by N — `RSS ≈ 86 + 5.12·N + 0.22·N·(T−1)` MB. Code inspection showed full per-symbol Stock_analysis ran for every loaded symbol on every Friday regardless of regime. This PR adds the early exit.

## Approach

**Phase 1 (universe-wide, cheap)**: `Stage.classify_with_callbacks` only, using the panel-cached `Weekly_ma_cache` from PR-D. Returns (ticker, stage_result) per symbol.

**Phase 2 (survivors only)**: full callback bundle + `Stock_analysis.analyze_with_callbacks`. Volume + Resistance kernels (the most expensive) only fire here.

**Filter predicate**: `Stage2 _ | Stage4 _` survive Phase 1; `Stage1 _ | Stage3 _` drop. Matches the screener's `is_breakout_candidate` (Stage2) and `is_breakdown_candidate` (Stage4) gates exactly.

## Parity gates

- [x] **Load-bearing** `test_panel_loader_parity` round_trips golden (2 tests: `tiered-loader-parity`, `panel-golden-2019-full`): bit-equal.
- [x] New counter test in `test_weinstein_strategy.ml`: asserts `survivors_for_screening` returns 2 of 6 on a Stage-4-heavy universe.
- [x] All other suites green.

## Subtle bug caught + fixed

Initial implementation updated `prior_stages` immediately after Phase 1 classification, then Phase 2 re-read the updated value as `prior_stage` — broke Stage1→Stage2 / Stage3→Stage4 transition signals (test_panel_loader_parity failed 3 vs 5 trades). Fix: thread `prior_stage` from Phase 1 into Phase 2 directly; commit `prior_stages` in one batch after the universe pass. Documented in plan §'Pragmatic deviation'.

## LOC

5 files changed, +598 / −32. Production: ~+95. Tests: ~+210. Plan: +199. Status: ~+45.

## Pragmatic deviation from plan

Phase 1 reuses `weekly_view_for` (~2 KB/symbol/Friday) instead of reading panel cells directly. Reason: keeps bit-equality with cache-aware stage callbacks; the load-bearing wedge (Phase 2's full Stock_analysis bundle) is eliminated regardless. Documented in the per-PR plan.

## Next: validate β drop

Re-run RSS matrix at {50, 292} × {1y, 6y} on `bull-crash-292x6y`. Target: β 5.12 → ≤1.5 MB/symbol. If β doesn't drop meaningfully → wedge is outside `_screen_universe`; memtrace next.

Plan: `dev/plans/panels-stage045-lazy-tier-cascade-2026-04-26.md` §PR-A. Per-PR plan in `dev/plans/panels-stage045-pr-a-2026-04-26.md`.