### PR TITLE
feat(simulation): date-indexed Price_cache for O(1) per-tick lookups

### DIFF
--- a/trading/trading/simulation/lib/data/market_data_adapter.ml
+++ b/trading/trading/simulation/lib/data/market_data_adapter.ml
@@ -11,11 +11,14 @@ let create ~data_dir =
   { price_cache; indicator_manager }
 
 let get_price t ~symbol ~date =
-  match Price_cache.get_prices t.price_cache ~symbol ~end_date:date () with
-  | Error _ -> None
-  | Ok prices ->
-      List.find prices ~f:(fun (p : Types.Daily_price.t) ->
-          Date.equal p.date date)
+  (* Direct date-indexed lookup. The previous implementation went through
+     [get_prices ~end_date:date] which allocates a fresh [List.filter]'d copy
+     of the full price history per call, then walks it again with [List.find].
+     For a per-tick simulation loop (many [get_price] calls per (symbol, day)
+     cell at universe-scale per memtrace), that compounded into billions of
+     cons-cell allocations per run. [Price_cache.get_price_on_date] is O(1)
+     after first symbol load, with no per-call allocation. *)
+  Price_cache.get_price_on_date t.price_cache ~symbol ~date
 
 let get_indicator t ~symbol ~indicator_name ~period ~cadence ~date =
   let spec = Indicator_manager.{ name = indicator_name; period; cadence } in

--- a/trading/trading/simulation/lib/data/price_cache.ml
+++ b/trading/trading/simulation/lib/data/price_cache.ml
@@ -5,9 +5,19 @@ open Core
 type t = {
   data_dir : Fpath.t;
   cache : (string, Types.Daily_price.t list) Hashtbl.t;
+  (* Date-indexed lookup table per symbol, built lazily on first
+     [get_price_on_date] call. Lets the per-tick hot path (one
+     [get_price] per (symbol, day)) avoid the [List.filter] +
+     [List.find] scan that allocates a fresh list per call. *)
+  by_date : (string, (Date.t, Types.Daily_price.t) Hashtbl.t) Hashtbl.t;
 }
 
-let create ~data_dir = { data_dir; cache = Hashtbl.create (module String) }
+let create ~data_dir =
+  {
+    data_dir;
+    cache = Hashtbl.create (module String);
+    by_date = Hashtbl.create (module String);
+  }
 
 let _load_symbol t symbol =
   match Csv.Csv_storage.create ~data_dir:t.data_dir symbol with
@@ -44,6 +54,32 @@ let get_prices t ~symbol ?start_date ?end_date () =
   let filtered = _filter_by_date_range prices ~start_date ~end_date in
   Ok filtered
 
+(* Build (or fetch) the per-symbol date-indexed table. Returns [None] if
+   the symbol's CSV failed to load (collapses the [Result] error path —
+   callers that need the error use [get_prices] directly). *)
+let _by_date_table t symbol : (Date.t, Types.Daily_price.t) Hashtbl.t option =
+  match Hashtbl.find t.by_date symbol with
+  | Some tbl -> Some tbl
+  | None -> (
+      let prices_result =
+        match Hashtbl.find t.cache symbol with
+        | Some cached -> Ok cached
+        | None -> _load_symbol t symbol
+      in
+      match prices_result with
+      | Error _ -> None
+      | Ok prices ->
+          let tbl = Hashtbl.create (module Date) in
+          List.iter prices ~f:(fun (p : Types.Daily_price.t) ->
+              Hashtbl.set tbl ~key:p.date ~data:p);
+          Hashtbl.set t.by_date ~key:symbol ~data:tbl;
+          Some tbl)
+
+let get_price_on_date t ~symbol ~date =
+  match _by_date_table t symbol with
+  | None -> None
+  | Some tbl -> Hashtbl.find tbl date
+
 let preload_symbols t symbols =
   let results =
     List.map symbols ~f:(fun symbol ->
@@ -66,5 +102,8 @@ let preload_symbols t symbols =
       (Status.internal_error
          (Printf.sprintf "Failed to load symbols: %s" error_messages))
 
-let clear_cache t = Hashtbl.clear t.cache
+let clear_cache t =
+  Hashtbl.clear t.cache;
+  Hashtbl.clear t.by_date
+
 let get_cached_symbols t = Hashtbl.keys t.cache

--- a/trading/trading/simulation/lib/data/price_cache.mli
+++ b/trading/trading/simulation/lib/data/price_cache.mli
@@ -36,6 +36,20 @@ val get_prices :
     @param end_date Optional end date (inclusive)
     @return List of daily prices sorted by date (oldest first), or error *)
 
+val get_price_on_date :
+  t -> symbol:string -> date:Date.t -> Types.Daily_price.t option
+(** Direct lookup: return the bar for [symbol] on exactly [date], or [None] if
+    the symbol failed to load or has no bar on that date.
+
+    On first access for [symbol], loads the CSV file and builds an internal
+    date-indexed table; subsequent calls are O(1) with no allocation. Use this
+    in hot-path per-tick price lookups instead of {!get_prices} + filter + find
+    — the latter allocates a fresh list per call.
+
+    Errors during load (missing CSV, malformed file) collapse to [None]. The
+    [Result]-based load path is in {!get_prices}; callers that need the load
+    error still go through that one. *)
+
 val preload_symbols : t -> string list -> (unit, Status.t) Result.t
 (** Preload data for multiple symbols upfront.
 

--- a/trading/trading/simulation/test/test_price_cache.ml
+++ b/trading/trading/simulation/test/test_price_cache.ml
@@ -228,6 +228,38 @@ let test_nonexistent_symbol _ =
 
   teardown_test_data test_data_dir
 
+let test_get_price_on_date_hit _ =
+  let test_data_dir = setup_test_data "get_price_on_date_hit" in
+  let backend = create ~data_dir:test_data_dir in
+
+  let date = Date.of_string "2024-01-02" in
+  assert_that
+    (get_price_on_date backend ~symbol:"AAPL" ~date)
+    (is_some_and
+       (field
+          (fun (p : Types.Daily_price.t) -> p.close_price)
+          (float_equal 102.0)));
+
+  teardown_test_data test_data_dir
+
+let test_get_price_on_date_miss _ =
+  let test_data_dir = setup_test_data "get_price_on_date_miss" in
+  let backend = create ~data_dir:test_data_dir in
+
+  let date = Date.of_string "1999-01-01" in
+  assert_that (get_price_on_date backend ~symbol:"AAPL" ~date) is_none;
+
+  teardown_test_data test_data_dir
+
+let test_get_price_on_date_unknown_symbol _ =
+  let test_data_dir = setup_test_data "get_price_on_date_unknown" in
+  let backend = create ~data_dir:test_data_dir in
+
+  let date = Date.of_string "2024-01-01" in
+  assert_that (get_price_on_date backend ~symbol:"NONEXISTENT" ~date) is_none;
+
+  teardown_test_data test_data_dir
+
 let suite =
   "Price cache tests"
   >::: [
@@ -239,6 +271,10 @@ let suite =
          "test_preload_symbols" >:: test_preload_symbols;
          "test_clear_cache" >:: test_clear_cache;
          "test_nonexistent_symbol" >:: test_nonexistent_symbol;
+         "test_get_price_on_date_hit" >:: test_get_price_on_date_hit;
+         "test_get_price_on_date_miss" >:: test_get_price_on_date_miss;
+         "test_get_price_on_date_unknown_symbol"
+         >:: test_get_price_on_date_unknown_symbol;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Memtrace (#601) identified `Price_cache.get_prices.(fun)` as the dominant allocator: ~9 billion sampled cons-cell allocations in a 4-min run, driven by per-tick `get_price ~symbol ~date` lookups going through `get_prices ~end_date:date` → `List.filter` → `List.find`.

This PR adds an O(1) date-indexed accessor:

- `Price_cache.t` gains `by_date : (symbol, (Date.t, Daily_price.t) Hashtbl.t) Hashtbl.t`, lazily built on first `get_price_on_date` call. Hashtbl values share `Daily_price.t` records with the existing list cache — no duplication.
- New `Price_cache.get_price_on_date` accessor.
- `Market_data_adapter.get_price` switches to it.
- `get_prices` (list API) unchanged for callers that need the full series.

## Impact (single-sample, bull-crash-292x6y)

| Metric | Pre (post-PR-A) | Post | Δ |
|---|---:|---:|---:|
| Wall | 4:05 | 2:01 | **−50%** |
| Peak RSS | 1,866 MB | 2,330 MB | +25% |

**Wall halves** — the memtrace-identified hotspot was primarily a CPU hotspot; the allocation churn was dominating GC time. RSS regression is likely a GC steady-state shift (less alloc rate → less compaction → larger major-heap residency). The new `by_date` table itself is small (~6 MB at this scale).

Recommend a matrix re-run to confirm the RSS delta is stable + decide whether to tune GC params (`OCAMLRUNPARAM` major-heap-increment) or accept the trade-off. The wall savings are large and real; they buy budget for tier-3/4 release-gate runs regardless.

## Test plan

- [x] `dune build && dune fmt && dune runtest` — 97 OK (was 96 + 1 new `test_price_cache` group with 11 tests, was 8).
- [x] 3 new tests in `test_price_cache.ml`: hit (existing date), miss (date outside history), unknown-symbol (collapses error to `None`).
- [x] Quick smoke: N=292 T=1y wall 1:01 → 0:33 (−46%); RSS 1,581 → 1,668 MB (+5%, noise-band).
- [x] T=6y: wall 4:05 → 2:01 (−50%); RSS 1,866 → 2,330 MB (+25%).
- [ ] Full RSS matrix re-run (4 cells {50, 292} × {1y, 6y}) — recommended follow-up.

Memtrace findings: `dev/notes/panels-memtrace-postA-2026-04-26.md` (#601).