### PR TITLE
feat(data-panels): Stage 4.5 PR-B — sector pre-filter as third early-exit gate

### DIFF
--- a/dev/plans/panels-stage045-pr-b-2026-04-26.md
+++ b/dev/plans/panels-stage045-pr-b-2026-04-26.md
@@ -1,0 +1,149 @@
+# Plan: Stage 4.5 PR-B — sector pre-filter as third early-exit gate (2026-04-26)
+
+## Status
+
+IMPLEMENTING. Companion to
+`dev/plans/panels-stage045-lazy-tier-cascade-2026-04-26.md` §"PR-B".
+Branch: `feat/panels-stage045-pr-b-sector-prefilter`. Builds on PR-A (#599)
+which split `_screen_universe` into Phase 1 (cheap stage classify) +
+Phase 2 (full Stock_analysis on survivors).
+
+## Wedge (recap)
+
+PR-A landed the two-phase cascade but the post-PR-A RSS matrix
+(`dev/notes/panels-rss-matrix-postA-2026-04-26.md`) showed `β` unchanged
+at ~5.12 MB/symbol. Memtrace
+(`dev/notes/panels-memtrace-postA-2026-04-26.md`) located the wedge in
+simulation/engine, not strategy. **PR-B's expected RSS impact at the
+small-302 scale is therefore minimal**; main value is cleaner laziness
+(the cascade is more honest about what it skips), not memory. RSS gains
+should compound at larger universes / weaker macro regimes where Stage 4
++ Strong-sector stocks are abundant.
+
+## Cascade after PR-B
+
+```
+1. Stage classify (cheap, all N).
+2. Stage filter (drop Stage 1 / Stage 3) — PR-A.
+3. Sector pre-filter (drop Stage2-in-Weak / Stage4-in-Strong) — PR-B.
+4. Full Stock_analysis for symbols that survive both — PR-A.
+```
+
+The `sector_map` is already computed in `_run_screen` before
+`_screen_universe`; PR-B threads it into the cascade rather than letting
+the screener-internal sector check do the rejection downstream.
+
+## Filter predicate
+
+Mirrors the screener exactly. Reading
+`trading/analysis/weinstein/screener/lib/screener.ml`:
+
+- `_long_candidate` (line 320): `if equal_sector_rating sector.rating
+  Weak then None` — drops Weak sectors.
+- `_short_candidate` (line 341): `if equal_sector_rating sector.rating
+  Strong then None` — drops Strong sectors.
+
+So the side-aware predicate is:
+
+```ocaml
+match (stage_result.stage, sector_ctx.rating) with
+| Stage2 _, Weak -> false   (* would-be long candidate; drop *)
+| Stage4 _, Strong -> false (* would-be short candidate; drop *)
+| _ -> true
+```
+
+A ticker absent from `sector_map` defaults to PASS, matching
+`Screener._resolve_sector` which falls through to a `Neutral` context for
+unknown tickers.
+
+The dispatch's "Strong/Neutral pass; Weak drop" rule is asymmetric
+(applies to longs only) and would accidentally drop Stage4 shorts that
+the screener would accept. The side-aware version above is correct.
+
+## Pragmatic deviations from dispatch
+
+1. **Survivors-list shape**, not `(loaded, stage_pass, sector_pass)`
+   triple. The dispatch suggested changing `survivors_for_screening`'s
+   return type to a counts triple. I instead added a public
+   `?sector_map` argument: when omitted, returns Phase-1-only survivors
+   (preserves the PR-A test contract); when supplied, also applies the
+   sector pre-filter. The PR-B counter test invokes
+   `survivors_for_screening` twice on the same fixture (once without
+   `sector_map` → `stage_pass`, once with → `sector_pass`) and computes
+   `loaded` from `cfg.universe`. This avoids breaking PR-A's existing
+   tests and keeps the production call site (`_screen_universe`) using
+   the value directly.
+
+2. **No `Macro` early-exit in this PR.** Dispatch explicitly said skip;
+   confirmed.
+
+## Files
+
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy.ml` —
+  - New `_survives_sector_filter ~sector_map (ticker, view, sr)` private
+    helper.
+  - `survivors_for_screening` gains optional `?sector_map` and trailing
+    `()`.
+  - `_screen_universe` threads the sector_map through the cascade
+    (chained `|>` style; preserves the `(ticker, view, prior, sr)`
+    four-tuple shape so `prior_stage` stays threaded into Phase 2).
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy.mli` —
+  signature change on `survivors_for_screening`.
+- `trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml` —
+  4 new tests:
+  - PR-B sector filter drops Weak-sector longs.
+  - PR-B sector filter drops Strong-sector shorts.
+  - PR-B sector filter: ticker absent from sector_map passes.
+  - PR-B counter test: `(loaded, stage_pass, sector_pass) = (6, 6, 3)`
+    on a six-symbol fixture; surviving tickers match the expected set.
+- 3 existing PR-A tests updated for the new `unit` trailing argument.
+
+## Parity gates
+
+- `test_panel_loader_parity` round_trips golden — bit-equal trades
+  (load-bearing). The two scenarios under
+  `test_data/backtest_scenarios/smoke/{tiered-loader-parity,panel-golden-2019-full}.sexp`
+  both pass — sector pre-filter only drops symbols the screener would
+  have rejected anyway, so trade output is bit-identical.
+- All `weinstein/strategy/test` suites: 22 tests, all OK (was 18 pre-PR-B).
+- `test_weinstein_backtest`, `test_macro_inputs`, `test_stops_runner`,
+  `test_panel_callbacks`, `test_weekly_ma_cache` — green.
+- File length linter: `weinstein_strategy.ml` exactly 500 lines (at the
+  declared-large hard limit). PR-B added the sector predicate +
+  cascade-extension but trimmed PR-A's docstrings to compensate; the
+  filter logic is captured in the .mli's `survivors_for_screening` doc.
+- Magic number, nesting, `dune fmt`, `dune build @fmt` linters all
+  silent.
+
+## LOC
+
+~+30 production (sector predicate + cascade pipe), ~+170 tests (4 new
+tests + helper for building synthetic sector_maps). Net minor change to
+`_screen_universe`.
+
+## Risk
+
+### Parity drift on the round_trips golden
+
+The sector pre-filter could in principle drop a symbol the screener
+would have accepted via some non-obvious code path. Mitigation: the
+filter mirrors `Screener._long_candidate` / `_short_candidate`'s sector
+gate exactly (those are the only screener call sites that read
+`sector.rating`). The round_trips golden test catches any divergence —
+it's bit-equal post-PR-B.
+
+### Production sector_map behaviour vs tests
+
+The production cascade always passes the real `sector_map` (which may be
+empty when `sector_etfs = []` is configured). Empty `sector_map` → all
+tickers default to PASS, equivalent to PR-A behaviour. This matches the
+behaviour of the two parity-test scenarios (which provide their own
+sector maps).
+
+## Recommendation
+
+Skip the post-PR-B matrix re-run. PR-A's matrix already pinned that the
+wedge is in simulation/engine (`dev/notes/panels-memtrace-postA-2026-04-26.md`).
+PR-B's expected impact at small-302 is minimal; the value is correctness
+of the lazy cascade. Pick up the simulation/engine wedge as the next
+dispatch (the memtrace document already names the call sites).

--- a/dev/status/data-panels.md
+++ b/dev/status/data-panels.md
@@ -5,7 +5,46 @@
 ## Status
 READY_FOR_REVIEW
 
-Stage 4-5 PR-A READY_FOR_REVIEW on `feat/panels-stage045-pr-a-lazy-stage-filter` — restructures `_screen_universe` into a two-phase lazy cascade. Phase 1 runs cheap stage-only `Stage.classify_with_callbacks` (cache-aware via PR-D `Weekly_ma_cache`) over every loaded symbol. Phase 2 — the load-bearing allocation site (`Panel_callbacks.stock_analysis_callbacks_of_weekly_views` + `Stock_analysis.analyze_with_callbacks`) — runs only for survivors whose stage classification can yield a screener candidate (Stage2 longs / Stage4 shorts). Stage1 / Stage3 symbols are dropped after Phase 1; the screener would have rejected them after the full analysis anyway. `prior_stages` updates batch at end-of-pass to preserve pre-PR-A semantics where every per-symbol analysis on a Friday observed the previous Friday's snapshot.
+Stage 4-5 PR-B READY_FOR_REVIEW on `feat/panels-stage045-pr-b-sector-prefilter` — adds the sector pre-filter as the third early-exit gate in the lazy cascade between PR-A's Phase 1 (cheap stage classify) and Phase 2 (full Stock_analysis). New private `_survives_sector_filter` mirrors the screener's `_long_candidate` / `_short_candidate` sector gate exactly: drops Stage2 candidates whose sector is rated `Weak` (the screener rejects them on the same predicate downstream) and Stage4 candidates whose sector is rated `Strong` (same). Tickers absent from `sector_map` default to PASS, matching `Screener._resolve_sector`'s `Neutral` fallback. The filter is bit-identical to letting these symbols flow into Phase 2 and being rejected by `Screener.screen` — but skips the Phase 2 `Stock_analysis.analyze_with_callbacks` cost for each.
+
+**Stage 4-5 PR-B scope**:
+- `weinstein_strategy.{ml,mli}` — new `_survives_sector_filter`; `survivors_for_screening` gains optional `?sector_map` (and a trailing `()` for the optional-arg unerasable rule). When `?sector_map` is omitted, returns Phase-1-only survivors (preserves the PR-A test contract); when supplied, applies the sector pre-filter.
+- `_screen_universe` threads the existing `sector_map` (already computed in `_run_screen` before this call) into the cascade. The four-tuple `(ticker, view, prior, stage_result)` shape is preserved through the new filter so PR-A's `prior_stage` threading into Phase 2 still holds.
+- 4 new tests in `test_weinstein_strategy.ml`: drops Weak-sector longs, drops Strong-sector shorts, ticker-absent passes, and a PR-B counter test asserting `(loaded, stage_pass, sector_pass) = (6, 6, 3)` on a six-symbol fixture (4 Stage2 + 2 Stage4) where the dropped set matches the expected (Weak-sector longs and Strong-sector shorts).
+
+**Filter predicate (exact rule)**:
+```ocaml
+match (stage_result.stage, sector_ctx.rating) with
+| Stage2 _, Weak -> false   (* drop: Stage2 long candidate in Weak sector *)
+| Stage4 _, Strong -> false (* drop: Stage4 short candidate in Strong sector *)
+| _ -> true                 (* pass: Strong/Neutral longs, Weak/Neutral shorts *)
+```
+
+This is **side-aware**, not a uniform "drop Weak". The dispatch suggested "Strong/Neutral pass; Weak drop" but reading `Screener._long_candidate` / `_short_candidate` showed the rule must be asymmetric — Stage4 shorts in Weak sectors would be wrongly dropped by a uniform rule. The side-aware version mirrors the screener exactly.
+
+**Pragmatic deviation from dispatch**: dispatch suggested changing `survivors_for_screening`'s return type to a `(loaded, stage_pass, sector_pass)` triple. Instead, the function gains optional `?sector_map`: when omitted, returns Phase-1-only survivors (PR-A behaviour, kept for tests that exercise the stage filter in isolation); when supplied, applies the sector filter and returns the post-sector survivors list. The PR-B counter test invokes the function twice on the same fixture (once without `sector_map` → `stage_pass`, once with → `sector_pass`) and computes `loaded` from `cfg.universe`. This avoids breaking PR-A tests and keeps the production call site direct.
+
+**Bit-equality + parity**:
+- Load-bearing `test_panel_loader_parity` round_trips golden: 2 tests, all OK. Both `tiered-loader-parity` and `panel-golden-2019-full` round-trip lists are bit-equal — sector pre-filter only drops symbols the screener would have rejected on the same `sector.rating` predicate downstream, so trade output is identical.
+- All `weinstein/strategy/test` suites: 22 tests, all OK (was 18 pre-PR-B). Magic number, nesting, file length, `dune fmt`, `dune build @fmt` linters all silent.
+- `weinstein_strategy.ml` is at exactly 500 lines (declared-large hard limit). PR-B added ~30 production lines + cascade extension but trimmed some of PR-A's docstrings to compensate; the filter contract is captured in the `.mli`'s `survivors_for_screening` doc.
+
+**LOC delta**: ~+30 production, ~+170 tests; net new public surface: `survivors_for_screening` gains `?sector_map:(string, Screener.sector_context) Hashtbl.t` and a trailing `()`.
+
+**Out of scope** (deferred or skipped):
+- `Macro` early-exit (skip the loop on bearish macro). Dispatch explicitly skipped — the screener's macro gate runs after `_screen_universe` and adding a macro pre-filter is a separate optimization.
+- Tunable filter thresholds in config (PR-C, optional).
+- The post-PR-B RSS matrix re-run is **not recommended**. PR-A's matrix already pinned that the wedge is in simulation/engine (`dev/notes/panels-memtrace-postA-2026-04-26.md`); PR-B's expected impact at small-302 is minimal (per dispatch). The next dispatch should pick up the simulation/engine wedge.
+
+**Verify**: `cd trading && eval $(opam env) && TRADING_DATA_DIR=$PWD/test_data dune build && dune runtest && dune build @fmt`. All suites green; formatter clean; nesting linter clean (max ≤5, avg 1.44 across 928 functions); file length linter passes (12 declared-large of 113 total).
+
+PR-B is bookmarked at `feat/panels-stage045-pr-b-sector-prefilter`. Plan: `dev/plans/panels-stage045-pr-b-2026-04-26.md` (companion to `dev/plans/panels-stage045-lazy-tier-cascade-2026-04-26.md`).
+
+**Recommended next dispatch**: simulation/engine wedge investigation per `dev/notes/panels-memtrace-postA-2026-04-26.md`. Skip the post-PR-B matrix re-run (minimal expected impact at small-302 scale; PR-A pinned the wedge is outside `_screen_universe`).
+
+---
+
+**Prior status (Stage 4-5 PR-A, READY_FOR_REVIEW on `feat/panels-stage045-pr-a-lazy-stage-filter`)**: restructures `_screen_universe` into a two-phase lazy cascade. Phase 1 runs cheap stage-only `Stage.classify_with_callbacks` (cache-aware via PR-D `Weekly_ma_cache`) over every loaded symbol. Phase 2 — the load-bearing allocation site (`Panel_callbacks.stock_analysis_callbacks_of_weekly_views` + `Stock_analysis.analyze_with_callbacks`) — runs only for survivors whose stage classification can yield a screener candidate (Stage2 longs / Stage4 shorts). Stage1 / Stage3 symbols are dropped after Phase 1; the screener would have rejected them after the full analysis anyway. `prior_stages` updates batch at end-of-pass to preserve pre-PR-A semantics where every per-symbol analysis on a Friday observed the previous Friday's snapshot.
 
 **Stage 4-5 PR-A scope**:
 - `weinstein_strategy.{ml,mli}` — split `_analyze_ticker` into `_classify_stage_for_screening` (Phase 1, cheap) + `_full_analysis_of_survivor` (Phase 2, heavy). New `_classify_all` builds the universe-wide stage classification list; `_commit_prior_stages` advances the table after the screening pass. `_screen_universe` now: (a) Phase 1 over universe, (b) filter survivors by `_survives_phase1`, (c) Phase 2 over survivors, (d) commit prior_stages, (e) screener cascade as before.

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -219,22 +219,31 @@ let entries_from_candidates ~config ~candidates ~stop_states ~bar_reader
       | Some kept -> kept :: acc)
   |> List.rev
 
-(** Stage 4-5 PR-A: a symbol survives Phase 1 if its current stage
-    classification could in principle yield a screener candidate. Long
-    candidates require [Stage2 _] (per [Stock_analysis.is_breakout_candidate]);
-    short candidates require [Stage4 _] (per
-    [Stock_analysis.is_breakdown_candidate]). [Stage1] and [Stage3] cannot
-    satisfy either predicate, so the screener would reject them after the full
-    analysis anyway — they are safe to skip in Phase 2.
-
-    The predicate is intentionally over-broad relative to the screener's actual
-    eligibility rules (which also require volume / RS / prior-stage matches);
-    keeping the gate on stage alone preserves bit-equality with the bar-list
-    output while still cutting the dominant per-symbol allocation. *)
+(** Stage 4-5 PR-A: a symbol survives Phase 1 only when its stage could in
+    principle yield a screener candidate ([Stage2 _] for longs; [Stage4 _] for
+    shorts). [Stage1] / [Stage3] cannot satisfy
+    {!Stock_analysis.is_breakout_candidate} or {!is_breakdown_candidate}, so the
+    screener would reject them downstream. Filter is over-broad versus the
+    screener's full rules (volume / RS / prior_stage); staying broad on stage
+    alone preserves bit-equality with the bar-list output. *)
 let _survives_phase1 (stage_result : Stage.result) : bool =
   match stage_result.stage with
   | Weinstein_types.Stage2 _ | Weinstein_types.Stage4 _ -> true
   | Weinstein_types.Stage1 _ | Weinstein_types.Stage3 _ -> false
+
+(** PR-B sector pre-filter: drop a Phase 1 survivor whose sector would cause an
+    automatic screener rejection ([Weak] for Stage2 longs per
+    {!Screener._long_candidate}; [Strong] for Stage4 shorts per
+    {!Screener._short_candidate}). Tickers absent from [sector_map] default to
+    PASS, matching {!Screener._resolve_sector}'s [Neutral] fallback. *)
+let _survives_sector_filter ~sector_map (ticker, _view, stage_result) =
+  match Hashtbl.find sector_map ticker with
+  | None -> true
+  | Some (sector_ctx : Screener.sector_context) -> (
+      match (stage_result.Stage.stage, sector_ctx.rating) with
+      | Weinstein_types.Stage2 _, Screener.Weak -> false
+      | Weinstein_types.Stage4 _, Screener.Strong -> false
+      | _ -> true)
 
 (** Stage 4-5 PR-A Phase 1: classify the ticker via the cheap stage callback
     bundle (cache-aware via PR-D) and return
@@ -310,55 +319,46 @@ let _commit_prior_stages ~prior_stages classified =
   List.iter classified ~f:(fun (ticker, _view, _prior, stage_result) ->
       Hashtbl.set prior_stages ~key:ticker ~data:stage_result.Stage.stage)
 
-(** Stage 4-5 PR-A: Phase 1 of the cascade. Classify every symbol in
-    [config.universe] via the cheap stage-only callback bundle and return the
-    list of survivors as [(ticker, weekly_view, stage_result)] tuples. Updates
-    [prior_stages] for every classified symbol (even non-survivors) so the next
-    Friday's classification has accurate prior-stage context.
-
-    Public for testability — lets unit tests assert that the universe filter
-    drops Stage1 / Stage3 symbols and keeps Stage2 / Stage4 without having to
-    instrument the screener loop with a counter. *)
-let survivors_for_screening ~config ~bar_reader ~prior_stages ~current_date :
+(** Public for testability. See {!Weinstein_strategy.survivors_for_screening} in
+    the .mli for the full contract. *)
+let survivors_for_screening ?sector_map ~config ~bar_reader ~prior_stages
+    ~current_date () :
     (string * Data_panel.Bar_panels.weekly_view * Stage.result) list =
   let classified =
     _classify_all ~config ~bar_reader ~prior_stages ~current_date
   in
-  let survivors =
-    List.filter_map classified ~f:(fun (ticker, view, _prior, stage_result) ->
-        if _survives_phase1 stage_result then Some (ticker, view, stage_result)
-        else None)
+  let final_survivors =
+    classified
+    |> List.filter_map ~f:(fun (ticker, view, _prior, sr) ->
+        if _survives_phase1 sr then Some (ticker, view, sr) else None)
+    |> fun stage_survivors ->
+    match sector_map with
+    | None -> stage_survivors
+    | Some m ->
+        List.filter stage_survivors ~f:(_survives_sector_filter ~sector_map:m)
   in
   _commit_prior_stages ~prior_stages classified;
-  survivors
+  final_survivors
 
-(** Screen the universe for both long and short candidates, returning a combined
-    transition list. Macro-trend gating lives in the screener itself:
-    [buy_candidates] are empty under [Bearish], [short_candidates] are empty
-    under [Bullish]. Concatenating the two lists gives the strategy-level
-    behaviour:
-
-    - [Bullish]: longs only — shorts are empty.
-    - [Neutral]: both — longs and shorts are both eligible.
-    - [Bearish]: shorts only — longs are empty.
-
-    Stage 4-5 PR-A: per-ticker analysis is split into a cheap stage-only Phase 1
-    (universe-wide) and a heavy Phase 2 (survivors only). Phase 2 builds the
-    full callback bundle and runs [Stock_analysis.analyze_with_callbacks] —
-    previously this ran for every loaded symbol. Symbols whose stage cannot
-    yield a screener candidate (Stage1 / Stage3) are dropped after Phase 1. *)
+(** Screen the universe via the lazy cascade (Phase 1 stage filter → PR-B sector
+    pre-filter → Phase 2 full {!Stock_analysis}). Macro-trend gating lives in
+    the screener; concatenating [buy_candidates] + [short_candidates] yields the
+    right shape per regime. *)
 let _screen_universe ~config ~index_view ~macro_trend ~sector_map ~stop_states
     ~(portfolio : Portfolio_view.t) ~get_price ~bar_reader ~prior_stages
     ~current_date =
   let classified =
     _classify_all ~config ~bar_reader ~prior_stages ~current_date
   in
-  let survivors =
-    List.filter classified ~f:(fun (_, _, _, stage_result) ->
-        _survives_phase1 stage_result)
-  in
+  (* Cascade: Phase 1 stage filter → PR-B sector pre-filter → Phase 2 full
+     analysis. The four-tuple shape is preserved through both filters so
+     [prior_stage] stays threaded into [_full_analysis_of_survivor]. *)
   let stocks =
-    List.map survivors ~f:(_full_analysis_of_survivor ~bar_reader ~index_view)
+    classified
+    |> List.filter ~f:(fun (_, _, _, sr) -> _survives_phase1 sr)
+    |> List.filter ~f:(fun (ticker, view, _prior, sr) ->
+        _survives_sector_filter ~sector_map (ticker, view, sr))
+    |> List.map ~f:(_full_analysis_of_survivor ~bar_reader ~index_view)
   in
   _commit_prior_stages ~prior_stages classified;
   let screen_result =

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -172,29 +172,40 @@ val held_symbols : Trading_strategy.Portfolio_view.t -> string list
     worth pinning by direct unit test. *)
 
 val survivors_for_screening :
+  ?sector_map:(string, Screener.sector_context) Core.Hashtbl.t ->
   config:config ->
   bar_reader:Bar_reader.t ->
   prior_stages:Weinstein_types.stage Core.Hashtbl.M(String).t ->
   current_date:Date.t ->
+  unit ->
   (string * Data_panel.Bar_panels.weekly_view * Stage.result) list
-(** Stage 4-5 PR-A: Phase 1 of the lazy screener cascade. For every ticker in
-    [config.universe], reads a panel weekly view and classifies the current
-    stage via the cheap stage-only callback bundle (cache-aware via PR-D
-    {!Weekly_ma_cache}). Returns survivors — symbols whose stage could in
+(** Stage 4-5 PR-A / PR-B: cheap-cascade survivors of the lazy screener. For
+    every ticker in [config.universe], reads a panel weekly view and classifies
+    the current stage via the cheap stage-only callback bundle (cache-aware via
+    PR-D {!Weekly_ma_cache}). Returns survivors — symbols whose stage could in
     principle yield a screener candidate ([Stage2 _] for longs; [Stage4 _] for
     shorts) — paired with their weekly view (reused by Phase 2) and
     {!Stage.result}.
+
+    When [?sector_map] is supplied, also applies the sector pre-filter (PR-B): a
+    Stage 2 candidate in a [Weak]-rated sector and a Stage 4 candidate in a
+    [Strong]-rated sector are dropped, mirroring {!Screener._long_candidate} /
+    {!Screener._short_candidate}'s downstream rejection rules. Tickers not
+    present in [sector_map] default to PASS (matches
+    {!Screener._resolve_sector}'s [Neutral] fallback for unknown tickers). When
+    [?sector_map] is omitted, returns stage-only survivors — the PR-A behaviour,
+    retained for tests that exercise the stage filter in isolation.
 
     [prior_stages] is updated for every classified symbol, including
     non-survivors, so the next Friday's classification has accurate prior-stage
     context.
 
     Public for testability — lets unit tests assert that the universe filter
-    correctly drops Stage1 / Stage3 symbols without instrumenting the screener
-    loop. The filter predicate is intentionally over-broad relative to the
-    screener's full eligibility rules (which also depend on volume / RS / sector
-    / prior_stage); staying broad on stage alone keeps Phase 1 cheap and
-    preserves bit-equality with the bar-list output. *)
+    correctly drops Stage1 / Stage3 symbols (PR-A) and weak-/strong-sector
+    symbols (PR-B) without instrumenting the screener loop. The filter
+    predicates are intentionally narrow (stage-only and sector-only); the
+    screener's full eligibility rules (volume / RS / prior_stage / quality)
+    still run inside Phase 2's [Stock_analysis] for the surviving symbols. *)
 
 val entries_from_candidates :
   config:config ->

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -756,7 +756,7 @@ let test_survivors_for_screening_filters_by_stage _ =
   in
   let survivors =
     survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
-      ~current_date:last_date
+      ~current_date:last_date ()
   in
   let survivor_tickers =
     List.map survivors ~f:(fun (ticker, _, _) -> ticker)
@@ -833,7 +833,7 @@ let test_survivors_for_screening_drops_stage1_and_stage3 _ =
   in
   let survivors =
     survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
-      ~current_date:last_date
+      ~current_date:last_date ()
   in
   let survivor_tickers = List.map survivors ~f:(fun (ticker, _, _) -> ticker) in
   (* Only DECLINE (Stage4) passes; BASE (Stage1) and TOP (Stage3) drop. *)
@@ -923,10 +923,235 @@ let test_phase2_call_count_equals_survivor_count _ =
   let loaded_count = List.length cfg.universe in
   let survivors =
     survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
-      ~current_date:last_date
+      ~current_date:last_date ()
   in
   let survivor_count = List.length survivors in
   assert_that (loaded_count, survivor_count) (equal_to ((6, 2) : int * int))
+
+(* ------------------------------------------------------------------ *)
+(* Stage 4-5 PR-B: sector pre-filter — survivors_for_screening          *)
+(* ------------------------------------------------------------------ *)
+
+(** Build a sector_map entry with the given rating for [ticker] under
+    [sector_name]. *)
+let _make_sector_entry ~ticker:_ ~sector_name ~rating =
+  ( sector_name,
+    {
+      Screener.sector_name;
+      rating;
+      stage = Weinstein_types.Stage1 { weeks_in_base = 0 };
+    } )
+
+(** Build a [sector_map : (string, sector_context) Hashtbl.t] from a list of
+    [(ticker, rating)] pairs. Each ticker gets its own one-off sector. *)
+let _sector_map_of_pairs (pairs : (string * Screener.sector_rating) list) =
+  let map = Hashtbl.create (module String) in
+  List.iter pairs ~f:(fun (ticker, rating) ->
+      let _name, ctx =
+        _make_sector_entry ~ticker ~sector_name:(ticker ^ "_sector") ~rating
+      in
+      Hashtbl.set map ~key:ticker ~data:ctx);
+  map
+
+let test_survivors_for_screening_sector_filter_drops_weak_long _ =
+  (* Universe: two Stage2 symbols. RISE_STRONG sits in a Strong sector
+     (passes). RISE_WEAK sits in a Weak sector (drops — screener's
+     [_long_candidate] would reject it on the same rating). *)
+  let start_friday = Date.of_string "2024-01-05" in
+  let rising_strong =
+    _trending_series ~start_friday ~start_price:50.0 ~step:0.8
+  in
+  let rising_weak =
+    _trending_series ~start_friday ~start_price:60.0 ~step:1.0
+  in
+  let panels =
+    _panels_of_symbols
+      [ ("RISE_STRONG", rising_strong); ("RISE_WEAK", rising_weak) ]
+  in
+  let bar_reader = Bar_reader.of_panels panels in
+  let cfg =
+    default_config
+      ~universe:[ "RISE_STRONG"; "RISE_WEAK" ]
+      ~index_symbol:"GSPCX"
+  in
+  let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  let last_date =
+    let n = Data_panel.Bar_panels.n_days panels in
+    let cal_view =
+      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"RISE_STRONG" ~n:1
+        ~as_of_day:(n - 1)
+    in
+    cal_view.dates.(cal_view.n - 1)
+  in
+  let sector_map =
+    _sector_map_of_pairs
+      [ ("RISE_STRONG", Screener.Strong); ("RISE_WEAK", Screener.Weak) ]
+  in
+  let survivors =
+    survivors_for_screening ~sector_map ~config:cfg ~bar_reader ~prior_stages
+      ~current_date:last_date ()
+  in
+  let survivor_tickers = List.map survivors ~f:(fun (ticker, _, _) -> ticker) in
+  assert_that survivor_tickers (equal_to [ "RISE_STRONG" ])
+
+let test_survivors_for_screening_sector_filter_drops_strong_short _ =
+  (* Universe: two Stage4 symbols. FALL_WEAK sits in a Weak sector
+     (passes — screener's [_short_candidate] accepts Weak/Neutral).
+     FALL_STRONG sits in a Strong sector (drops — screener's
+     [_short_candidate] rejects on Strong rating). *)
+  let start_friday = Date.of_string "2024-01-05" in
+  let declining_weak =
+    _trending_series ~start_friday ~start_price:200.0 ~step:(-1.5)
+  in
+  let declining_strong =
+    _trending_series ~start_friday ~start_price:180.0 ~step:(-1.0)
+  in
+  let panels =
+    _panels_of_symbols
+      [ ("FALL_WEAK", declining_weak); ("FALL_STRONG", declining_strong) ]
+  in
+  let bar_reader = Bar_reader.of_panels panels in
+  let cfg =
+    default_config
+      ~universe:[ "FALL_WEAK"; "FALL_STRONG" ]
+      ~index_symbol:"GSPCX"
+  in
+  let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  let last_date =
+    let n = Data_panel.Bar_panels.n_days panels in
+    let cal_view =
+      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"FALL_WEAK" ~n:1
+        ~as_of_day:(n - 1)
+    in
+    cal_view.dates.(cal_view.n - 1)
+  in
+  let sector_map =
+    _sector_map_of_pairs
+      [ ("FALL_WEAK", Screener.Weak); ("FALL_STRONG", Screener.Strong) ]
+  in
+  let survivors =
+    survivors_for_screening ~sector_map ~config:cfg ~bar_reader ~prior_stages
+      ~current_date:last_date ()
+  in
+  let survivor_tickers = List.map survivors ~f:(fun (ticker, _, _) -> ticker) in
+  assert_that survivor_tickers (equal_to [ "FALL_WEAK" ])
+
+let test_survivors_for_screening_sector_filter_unknown_ticker_passes _ =
+  (* Tickers absent from the sector_map default to PASS — matches
+     [Screener._resolve_sector]'s [Neutral] fallback. *)
+  let start_friday = Date.of_string "2024-01-05" in
+  let rising = _trending_series ~start_friday ~start_price:50.0 ~step:0.8 in
+  let panels = _panels_of_symbols [ ("UNKNOWN", rising) ] in
+  let bar_reader = Bar_reader.of_panels panels in
+  let cfg = default_config ~universe:[ "UNKNOWN" ] ~index_symbol:"GSPCX" in
+  let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  let last_date =
+    let n = Data_panel.Bar_panels.n_days panels in
+    let cal_view =
+      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"UNKNOWN" ~n:1
+        ~as_of_day:(n - 1)
+    in
+    cal_view.dates.(cal_view.n - 1)
+  in
+  (* Empty sector_map: every ticker is "unknown" → all PASS. *)
+  let sector_map = Hashtbl.create (module String) in
+  let survivors =
+    survivors_for_screening ~sector_map ~config:cfg ~bar_reader ~prior_stages
+      ~current_date:last_date ()
+  in
+  let survivor_tickers = List.map survivors ~f:(fun (ticker, _, _) -> ticker) in
+  assert_that survivor_tickers (equal_to [ "UNKNOWN" ])
+
+(** PR-B counter test: assert the (loaded, stage_pass, sector_pass) triple
+    monotonically narrows. The test runs [survivors_for_screening] twice on the
+    same fixture — once without [sector_map] (yields [stage_pass]) and once with
+    (yields [sector_pass]) — so we can read both counts directly without
+    instrumenting the screener loop. *)
+let test_survivors_for_screening_pr_b_counter _ =
+  (* Six-symbol universe: two Stage2-strong, two Stage2-weak, two Stage4-mixed
+     (one Strong-sector → drop, one Weak-sector → pass). Stage4 in Strong
+     sector: drops; Stage4 in Weak sector: passes. *)
+  let start_friday = Date.of_string "2024-01-05" in
+  let rising seed =
+    _trending_series ~start_friday ~start_price:(50.0 +. seed) ~step:0.8
+  in
+  let declining seed =
+    _trending_series ~start_friday ~start_price:(200.0 +. seed) ~step:(-1.5)
+  in
+  let panels =
+    _panels_of_symbols
+      [
+        ("RISE_STRONG_A", rising 0.0);
+        ("RISE_STRONG_B", rising 1.0);
+        ("RISE_WEAK_A", rising 2.0);
+        ("RISE_WEAK_B", rising 3.0);
+        ("FALL_STRONG", declining 0.0);
+        ("FALL_WEAK", declining 1.0);
+      ]
+  in
+  let bar_reader = Bar_reader.of_panels panels in
+  let cfg =
+    default_config
+      ~universe:
+        [
+          "RISE_STRONG_A";
+          "RISE_STRONG_B";
+          "RISE_WEAK_A";
+          "RISE_WEAK_B";
+          "FALL_STRONG";
+          "FALL_WEAK";
+        ]
+      ~index_symbol:"GSPCX"
+  in
+  let last_date =
+    let n = Data_panel.Bar_panels.n_days panels in
+    let cal_view =
+      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"RISE_STRONG_A" ~n:1
+        ~as_of_day:(n - 1)
+    in
+    cal_view.dates.(cal_view.n - 1)
+  in
+  let sector_map =
+    _sector_map_of_pairs
+      [
+        ("RISE_STRONG_A", Screener.Strong);
+        ("RISE_STRONG_B", Screener.Strong);
+        ("RISE_WEAK_A", Screener.Weak);
+        ("RISE_WEAK_B", Screener.Weak);
+        ("FALL_STRONG", Screener.Strong);
+        ("FALL_WEAK", Screener.Weak);
+      ]
+  in
+  let loaded = List.length cfg.universe in
+  (* First pass: no sector_map → stage-only filter. Use a fresh prior_stages
+     each time so the two calls don't interact. *)
+  let stage_pass =
+    let prior_stages = Hashtbl.create (module String) in
+    survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
+      ~current_date:last_date ()
+    |> List.length
+  in
+  let sector_pass_survivors =
+    let prior_stages = Hashtbl.create (module String) in
+    survivors_for_screening ~sector_map ~config:cfg ~bar_reader ~prior_stages
+      ~current_date:last_date ()
+  in
+  let sector_pass = List.length sector_pass_survivors in
+  let surviving_tickers =
+    List.map sector_pass_survivors ~f:(fun (ticker, _, _) -> ticker)
+    |> List.sort ~compare:String.compare
+  in
+  assert_that
+    (loaded, stage_pass, sector_pass)
+    (equal_to ((6, 6, 3) : int * int * int));
+  assert_that surviving_tickers
+    (equal_to [ "FALL_WEAK"; "RISE_STRONG_A"; "RISE_STRONG_B" ])
 
 (* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
@@ -965,4 +1190,12 @@ let () =
            >:: test_survivors_for_screening_drops_stage1_and_stage3;
            "phase 2 call count equals survivor count, not loaded count"
            >:: test_phase2_call_count_equals_survivor_count;
+           "PR-B sector filter drops Weak-sector longs"
+           >:: test_survivors_for_screening_sector_filter_drops_weak_long;
+           "PR-B sector filter drops Strong-sector shorts"
+           >:: test_survivors_for_screening_sector_filter_drops_strong_short;
+           "PR-B sector filter: ticker absent from sector_map passes"
+           >:: test_survivors_for_screening_sector_filter_unknown_ticker_passes;
+           "PR-B counter test: (loaded, stage_pass, sector_pass) narrows"
+           >:: test_survivors_for_screening_pr_b_counter;
          ])


### PR DESCRIPTION
## Summary

Adds the sector pre-filter as the third gate in the lazy cascade introduced by PR-A (#599).

### Cascade after this PR

1. Phase 1 (PR-A): `Stage.classify_with_callbacks` for all N → keeps Stage 2 / Stage 4 survivors.
2. **Phase 1.5 (this PR)**: For each Phase-1 survivor, look up its sector via `ticker_sectors` + `sector_map`. Drop based on **side-aware** rule (mirrors the screener exactly).
3. Phase 2 (PR-A): full `Stock_analysis.analyze_with_callbacks` only for symbols passing both gates.

### Filter predicate (side-aware)

Reading the screener showed the rule is **asymmetric**:

```
(Stage2 _, Weak)   → drop  (matches Screener._long_candidate)
(Stage4 _, Strong) → drop  (matches Screener._short_candidate)
otherwise          → pass
```

Tickers absent from `sector_map` default to PASS (matches `Screener._resolve_sector`'s Neutral fallback).

### Counter test

On a 6-symbol fixture (4 Stage2 + 2 Stage4, single-ticker sectors): `(loaded=6, stage_pass=6, sector_pass=3)`. Surviving tickers: `[FALL_WEAK, RISE_STRONG_A, RISE_STRONG_B]`. Dropped: `RISE_WEAK_A`, `RISE_WEAK_B` (Stage2-in-Weak), `FALL_STRONG` (Stage4-in-Strong).

### Plan deviations

1. **Survivors function shape**: `?sector_map` is optional; without it, returns Phase-1-only survivors (preserves PR-A test contract). With it, applies the sector pre-filter. Counter test invokes both shapes on the same fixture to compute the triple.
2. **Side-aware filter**: dispatch suggested uniform "drop Weak". Reading the screener showed Stage4 shorts also drop in Strong sectors — uniform rule would have wrongly dropped Stage4-in-Weak.

### Expected impact

**Minimal RSS impact at small-302 scale** — per the post-PR-A matrix and memtrace, the wedge is in simulation / engine, not the strategy cascade. PR-B's value is cleaner laziness (the cascade now matches the screener's filter logic ahead of time, not after); it compounds with PR-A on broader universes where Stage 1 / Stage 3 / weak-sector symbols are more numerous.

### LOC

5 files changed, +493 / −61. Production ~+30 (`weinstein_strategy.{ml,mli}`); tests ~+170. `weinstein_strategy.ml` now exactly 500 lines (declared-large hard limit).

### Test plan

- [x] Load-bearing `test_panel_loader_parity` round_trips golden — bit-equal trades.
- [x] Counter test on 6-symbol fixture confirms (loaded, stage_pass, sector_pass) = (6, 6, 3).
- [x] Existing PR-A tests still pass via the `?sector_map` optional shape.
- [x] All linters green.

### Recommendation

Skip the post-PR-B matrix re-run; pick up the simulation/engine wedge (per `dev/notes/panels-memtrace-postA-2026-04-26.md`) as the next dispatch. The Price_cache fix (#602) was the first piece of that.

Plan: `dev/plans/panels-stage045-lazy-tier-cascade-2026-04-26.md` §PR-B.