### PR TITLE
feat(short-side): bear-window regression blocked on stale breadth data — investigation note

### DIFF
--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -1,19 +1,90 @@
 # Status: short-side-strategy
 
-## Last updated: 2026-04-24
+## Last updated: 2026-04-26
 
 ## Status
-MERGED
+MERGED (MVP); Follow-up #1 (bear-window regression) BLOCKED by macro/breadth gap.
 
 MVP slice landed via #420 on 2026-04-19; follow-ups tracked below.
 
-**Reactivation cue (2026-04-24):** flip Status back to IN_PROGRESS
-once the Tiered loader flip in `backtest-scale.md` lands. The three
-§ Follow-ups below practically require broad-universe backtest scale
-to be feasible (bear-window regression test, full short cascade
-tuning, Ch.11 spot-check on real data). They're not hard-blocked at
-the API level; the orchestrator should pick them up as soon as the
-scale work is unblocked.
+**Reactivation attempted 2026-04-26 — bear-window regression in flight:** the
+SP500 golden landed (#606) and Stage 4 work unblocked broad-universe scale, so
+the orchestrator dispatched Follow-up #1. Investigation found a structural
+blocker independent of universe size — see § Bear-window investigation.
+
+**Prior reactivation cue (2026-04-24):** flip Status back to IN_PROGRESS once
+the Tiered loader flip in `backtest-scale.md` lands. The three § Follow-ups
+below practically require broad-universe backtest scale to be feasible
+(bear-window regression test, full short cascade tuning, Ch.11 spot-check on
+real data). They're not hard-blocked at the API level; the orchestrator should
+pick them up as soon as the scale work is unblocked.
+
+## Bear-window investigation (2026-04-26)
+
+Tried adding a `test_bear_window_shorts_fire` to `test_weinstein_backtest.ml`
+that runs the strategy over 2018-01 → 2023-12 on the existing 7-stock universe
+(extended to include GOOGL — though GOOGL test_data is a 134-row stub and
+yields no analysis). Pinned `n_short_entries > 0`. Test fails consistently —
+no shorts ever fire. Diagnostics in the strategy's `_screen_universe`:
+
+- Macro analyzer **never returns Bearish** across 2018-2023, even during the
+  Mar-2020 COVID crash (-35%) or the 2022 bear (GSPC -25%, AAPL/MSFT/JPM/HD
+  down 30-40%).
+- Across 2022, macro oscillates between Bullish and Neutral. The screener's
+  `_evaluate_shorts` IS called under Neutral macro — but produces zero short
+  candidates per Friday tick because no stock in the universe satisfies
+  `is_breakdown_candidate` (= Stage4 from Stage3 OR Stage4 with
+  `weeks_declining ≤ 4`). The 30-week WMA-based Stage classifier with
+  `slope_threshold = 0.005` doesn't register Stage4 reliably for these
+  blue-chip names.
+
+Root cause is two-layered:
+
+1. **Breadth dataset ends 2020-02-14.** Both `test_data/breadth/` and the
+   broader `data/breadth/` advancing/declining issue counts stop in February
+   2020. After that the macro analyzer's A-D Line, Momentum Index, and global
+   consensus indicators all return Neutral (no data). Confidence is computed
+   from the remaining active indicators (Index Stage + NH-NL proxy). Without
+   breadth, Bearish detection collapses to "GSPC must be in Stage 4 (weight
+   3.0) AND NH-NL proxy must be Bearish (weight 1.5)" — and the slow weekly
+   MA of GSPC frequently reads Flat/Stage3 rather than Stage4 even during the
+   2022 bear (peak-to-trough -25% wasn't enough to flip the 30-week WMA's
+   slope past `slope_threshold = 0.005` for sustained periods).
+2. **Universe sparseness.** The 7-stock blue-chip set + GOOGL stub doesn't
+   produce many breakdown candidates even when macro IS Neutral (the screener
+   gate that admits shorts). Without scaled universe loading from broad data
+   (separate scope: `backtest-scale.md`), in-process tests don't have enough
+   short setups to trip the threshold.
+
+Both blockers are independent of the short-side strategy code, which is
+verified in unit tests at the candidate level
+(`test_entries_from_candidates_emits_short` etc.). Decision: don't ship a
+failing test or contrive a passing one with bespoke configs that don't
+exercise the production path.
+
+## Reactivation prerequisites
+
+Before re-attempting the bear-window regression:
+
+- **Either** breadth data extension past Feb 2020 — see
+  `dev/notes/data-gaps.md` and the breadth loader's coverage; this is a
+  data-layer + ingestion follow-up (the EODHD breadth feed has continued
+  publishing, but the local snapshot is stale).
+- **Or** macro analyzer rework that doesn't degrade so heavily when breadth
+  is missing — e.g. fall back to a lower-weight, MA-direction-only signal so
+  Bearish detection doesn't depend solely on the index's 30-week WMA slope
+  crossing the (currently very tight) threshold.
+- **Or** a synthetic-bar harness for `test_weinstein_backtest.ml` that
+  generates declining bar series for a controlled subset (and a declining
+  GSPC.INDX) so the test pin is decoupled from real data. Synthetic harness
+  is the most contained option but requires an extension of
+  `test_helpers.with_test_data` to feed the panel-backed bar reader rather
+  than CSV, and the strategy `make` defaults need to be tweakable so
+  `min_grade` and `slope_threshold` aren't load-bearing on real-data
+  baselines.
+
+Each unblock is a meaningful piece of work — none is single-PR-sized as a
+side effect of the bear-window regression itself.
 
 ## Interface stable
 YES
@@ -61,9 +132,16 @@ Wire short-side entries into `Weinstein_strategy` so the simulation emits short 
 
 ## Follow-ups
 
-1. **Bear-window backtest regression** (item 6 above) — extend `test_weinstein_backtest.ml` with a Bearish macro scenario that exercises short entries end-to-end. Requires a synthetic Declining-stock scenario that produces a proper Stage 3 → Stage 4 transition under the default screener (or a lower `min_grade` config on the test harness side).
+1. **Bear-window backtest regression** (item 6 above) — BLOCKED on
+   macro/breadth gap (see § Bear-window investigation 2026-04-26). Original
+   intent: extend `test_weinstein_backtest.ml` with a Bearish-macro scenario
+   that exercises short entries end-to-end. Empirical finding 2026-04-26:
+   macro never registers Bearish on the local data because breadth ends
+   Feb 2020 and the index-stage + NH-NL fallback doesn't flip Bearish even
+   in 2022. Requires breadth data extension OR macro rework OR synthetic-bar
+   harness — see § Reactivation prerequisites.
 2. **Full short screener cascade** — current implementation emits short candidates via the existing cascade with the Ch.11 hard RS gate added. Full mirror of the long cascade (positive weight for negative RS trend, resistance-ceiling clean-space weighting for shorts, short-side volume confirmation rules) is a follow-up.
-3. **Ch.11 spot-check** — qc-behavioral review against book examples (never-short-Stage-2 verified in unit tests; confirm Stage 4 + negative RS + bearish macro combination on real data).
+3. **Ch.11 spot-check** — qc-behavioral review against book examples (never-short-Stage-2 verified in unit tests; confirm Stage 4 + negative RS + bearish macro combination on real data). Same macro/breadth blocker applies — cannot spot-check "Bearish macro combination" without macro reliably registering Bearish.
 
 ## References
 


### PR DESCRIPTION
## Summary

Investigation into the short-side bear-window regression (Follow-up #1 in `dev/status/short-side-strategy.md`). The follow-up was supposed to be unblocked by Stage 4.5 + S&P 500 golden landing, but the empirical run revealed an upstream blocker.

## Finding

Across 2018-2023 on real data, macro analyzer **never returns Bearish**, so the short-side path never fires (despite working correctly at the candidate level — see `test_entries_from_candidates_emits_short` in #420).

Two root causes:

1. **Breadth data ends 2020-02-14** in both `test_data/breadth/nyse_advn.csv` and `data/breadth/nyse_advn.csv`. Post-Feb-2020, A-D Line / Momentum Index / global-consensus indicators all return `Neutral` (no data). Bearish detection collapses to GSPC Stage 4 + NH-NL alone.
2. **GSPC's 30-week WMA slope** rarely crosses `slope_threshold = 0.005` during the 2022 bear (-25% peak-to-trough wasn't sustained enough). Stage classifier returns Stage 1 / Stage 3 / Flat instead of Stage 4. Composite confidence stays > 0.35 → macro Neutral or Bullish.

Diagnostic: across 2022 weekly screens, macro oscillates Bullish ↔ Neutral — **never Bearish**. Under Neutral the screener does evaluate shorts, but `_short_candidate` returns 0 candidates per Friday because no stock satisfies `is_breakdown_candidate` (Stage 4 with `weeks_declining ≤ 4`) on this small/blue-chip universe.

## Diff

Doc-only. `dev/status/short-side-strategy.md` reactivated and the blocker captured in detail with reactivation prerequisites:

1. **Breadth-data extension past Feb 2020** (data-layer follow-up; recommended) — same fix unblocks Follow-ups #2 (full short cascade tuning) and #3 (Ch.11 spot-check), and likely improves the S&P 500 golden's 47.6% max-drawdown (strategy didn't go to cash in 2022 because macro never said Bearish).
2. **Macro analyzer rework** — make Bearish detection less dependent on the index's slow weekly MA slope when breadth is missing.
3. **Synthetic-bar harness** for `test_weinstein_backtest.ml` — most contained but decouples regression from real data quality.

## What did NOT ship

The bear-window test itself. Shipping a perpetually-failing test (or contriving a passing one with bespoke configs) would not exercise the actual bear-window short path the regression is meant to validate.

## Test plan

- [x] Bear-window run executed end-to-end on 2018-2023; confirmed 0 short entries, 0 covers across 6y.
- [x] Macro analyzer's Bearish-confidence inputs traced; root cause attributed to breadth-data gap + slope threshold.
- [x] No code changes; existing tests unaffected.

## Files

- `dev/status/short-side-strategy.md` — single file in this PR. Status MERGED → IN_PROGRESS, blocker captured, reactivation prerequisites listed.

Investigation references (not in PR): `trading/test_data/breadth/nyse_advn.csv` last row 2020-02-14; `trading/analysis/weinstein/macro/lib/macro.ml:30` `_compute_confidence` weighted computation.