### PR TITLE
feat(backtest-perf): tier-2 nightly perf workflow

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -1,0 +1,92 @@
+# Tier-2 perf nightly: every-night perf coverage (≤30 min budget per cell)
+# for the perf catalog.
+#
+# Runs every scenario tagged `;; perf-tier: 2` under
+# trading/test_data/backtest_scenarios/ via dev/scripts/perf_tier2_nightly.sh,
+# captures wall-time + peak RSS, and writes the result into the GHA job
+# summary so the human can read off perf at a glance.
+#
+# Non-blocking by design (continue-on-error: true) — same rationale as
+# perf-tier1.yml: VISIBILITY first, gating later. Flip continue-on-error
+# off once the budgets in dev/plans/perf-scenario-catalog-2026-04-25.md
+# tier 2 are pinned (~10 weeks of nightly data).
+#
+# Tier-2 scenarios covered (kept in sync via
+# trading/devtools/checks/perf_catalog_check.sh — `;; perf-tier: 2` tag is
+# the source of truth, the discovery in the runner script auto-matches):
+#   trading/test_data/backtest_scenarios/goldens-small/bull-crash-2015-2020.sexp
+#   trading/test_data/backtest_scenarios/goldens-small/covid-recovery-2020-2024.sexp
+#   trading/test_data/backtest_scenarios/goldens-small/six-year-2018-2023.sexp
+#   trading/test_data/backtest_scenarios/smoke/bull-2019h2.sexp
+#   trading/test_data/backtest_scenarios/smoke/crash-2020h1.sexp
+#   trading/test_data/backtest_scenarios/smoke/recovery-2023.sexp
+name: perf-nightly
+
+on:
+  # Nightly cron at 05:00 UTC = 22:00 PT (PDT) / 21:00 PT (PST). Chosen
+  # because:
+  #   - Daily orchestrator runs at 07:17 UTC (00:17 PT) and 12:17 UTC
+  #     (05:17 PT). Both are hours after this slot, so no concurrency
+  #     contention with the BOT_GITHUB_TOKEN-authenticated orchestrator
+  #     pushes. (See orchestrator.yml for that schedule.)
+  #   - Top-of-hour minutes (`:00`) generally see more GHA scheduler load
+  #     than `:17`, but for an isolated, non-orchestrator workflow that's
+  #     fine — worst case a scheduled run starts a few minutes late.
+  #   - GitHub cron is UTC-only, no DST awareness; this drifts back
+  #     1 hour PT during PST months.
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  perf-tier2-nightly:
+    runs-on: ubuntu-latest
+    # Per-cell budget is 30 min; six tier-2 cells run sequentially, so the
+    # job-level ceiling is ~3.5 h with some build/setup overhead. 240 min
+    # gives headroom for the slowest cell (six-year-2018-2023) plus the
+    # _build cache restore cost on a cold runner.
+    timeout-minutes: 240
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/trading-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 0
+    env:
+      HOME: /home/opam
+      TRADING_IN_CONTAINER: "1"
+      TRADING_DATA_DIR: ${{ github.workspace }}/trading/test_data
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache _build
+        uses: actions/cache@v4
+        with:
+          path: trading/_build
+          key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
+          restore-keys: |
+            dune-${{ runner.os }}-
+
+      - name: Run tier-2 perf nightly
+        id: tier2
+        continue-on-error: true
+        run: dev/scripts/perf_tier2_nightly.sh
+
+      - name: Publish summary
+        if: always()
+        run: |
+          summary_file=$(ls -1t dev/perf/tier2-nightly-*/summary.txt 2>/dev/null | head -1)
+          if [ -n "$summary_file" ] && [ -f "$summary_file" ]; then
+            {
+              echo "## Tier-2 perf nightly"
+              echo ""
+              echo '```'
+              cat "$summary_file"
+              echo '```'
+            } >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "Tier-2 perf nightly: no summary produced." >>"$GITHUB_STEP_SUMMARY"
+          fi

--- a/dev/scripts/perf_tier2_nightly.sh
+++ b/dev/scripts/perf_tier2_nightly.sh
@@ -1,0 +1,198 @@
+#!/bin/sh
+# Tier-2 perf nightly runner.
+#
+# Discovers all scenarios with `;; perf-tier: 2` under
+# trading/test_data/backtest_scenarios/{goldens-small,goldens-broad,perf-sweep,smoke}/,
+# runs each via the scenario_runner binary with a per-scenario timeout
+# (default 1800s = 30 min, per dev/plans/perf-scenario-catalog-2026-04-25.md
+# tier 2 budget), and prints a compact wall-time + peak-RSS table.
+#
+# Mirrors dev/scripts/perf_tier1_smoke.sh — same discovery + output layout,
+# same OCAMLRUNPARAM tuning, same scratch-dir staging trick. Differences:
+#   - tier filter is `perf-tier: 2`
+#   - per-cell timeout default is 1800s (vs 120s for tier 1)
+#   - artefact dir is dev/perf/tier2-nightly-<timestamp>/
+#   - env var override is PERF_TIER2_TIMEOUT / PERF_TIER2_OCAMLRUNPARAM
+#
+# Exit status:
+#   0 if every tier-2 scenario completes within budget
+#   1 if any scenario exits non-zero, errors, or times out
+#
+# Usage:
+#   dev/scripts/perf_tier2_nightly.sh                       -- run all tier-2 cells
+#   PERF_TIER2_TIMEOUT=3600 dev/scripts/perf_tier2_nightly.sh  -- bump per-cell timeout
+#
+# Designed to run inside the trading-1-dev container or under GHA where
+# TRADING_IN_CONTAINER=1; uses dev/lib/run-in-env.sh to wrap dune exec.
+#
+# Output artefacts under dev/perf/tier2-nightly-<timestamp>/:
+#   <scenario-name>.log        scenario_runner stdout/stderr
+#   <scenario-name>.peak_rss   integer kB from /usr/bin/time -f '%M'
+#   <scenario-name>.wall_sec   seconds (real time) — best-effort
+#   <scenario-name>.error      present iff the run errored / timed out
+#   summary.txt                aggregate table written at the end
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCENARIO_ROOT="${REPO_ROOT}/trading/test_data/backtest_scenarios"
+RUN_IN_ENV="${REPO_ROOT}/dev/lib/run-in-env.sh"
+TIMEOUT="${PERF_TIER2_TIMEOUT:-1800}"
+
+# Aggressive major-GC + smaller minor heap. Same rationale as tier-1
+# (dev/notes/panels-rss-matrix-post602-gc-tuned-2026-04-26.md): without
+# this, the GC steady-state high-water mark inflates peak RSS by ~25-37%
+# for runs with low allocation rates. Override via
+# PERF_TIER2_OCAMLRUNPARAM=... if a specific scenario needs a different
+# heap shape; pass empty to use the OCaml defaults.
+export OCAMLRUNPARAM="${PERF_TIER2_OCAMLRUNPARAM:-o=60,s=512k}"
+
+if [ ! -x "$RUN_IN_ENV" ]; then
+  printf 'FAIL: %s not found / not executable\n' "$RUN_IN_ENV" >&2
+  exit 1
+fi
+
+if [ ! -d "$SCENARIO_ROOT" ]; then
+  printf 'FAIL: scenario root not found: %s\n' "$SCENARIO_ROOT" >&2
+  exit 1
+fi
+
+# Probe for GNU /usr/bin/time. The shell builtin has no -f / -o; we need
+# the GNU binary for peak-RSS reporting. macOS hosts won't have it.
+if [ -x /usr/bin/time ]; then
+  HAVE_GNU_TIME=1
+else
+  HAVE_GNU_TIME=0
+fi
+
+# Output dir keyed by timestamp so re-runs don't clobber each other.
+TS="$(date -u +%Y-%m-%dT%H%M%SZ)"
+OUT_DIR="${REPO_ROOT}/dev/perf/tier2-nightly-${TS}"
+mkdir -p "$OUT_DIR"
+
+printf 'Tier-2 perf nightly run.\n'
+printf '  Scenario root : %s\n' "$SCENARIO_ROOT"
+printf '  Output dir    : %s\n' "$OUT_DIR"
+printf '  Per-cell timeout : %ss\n' "$TIMEOUT"
+printf '  GNU /usr/bin/time : %s\n\n' "$HAVE_GNU_TIME"
+
+# Discover tier-2 scenarios (full paths, sorted for determinism).
+TIER2_PATHS=""
+for sub in goldens-small goldens-broad perf-sweep smoke; do
+  dir="${SCENARIO_ROOT}/${sub}"
+  [ -d "$dir" ] || continue
+  for sexp in "$dir"/*.sexp; do
+    [ -f "$sexp" ] || continue
+    if grep -q '^;; perf-tier: 2' "$sexp"; then
+      TIER2_PATHS="${TIER2_PATHS}${sexp}
+"
+    fi
+  done
+done
+
+if [ -z "$TIER2_PATHS" ]; then
+  printf 'WARNING: no scenarios found with [;; perf-tier: 2] -- nothing to do.\n'
+  exit 0
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TABLE_ROWS=""
+
+# Run a single scenario. Stages it into a one-element scratch dir so the
+# scenario_runner --dir entry point picks up exactly one cell. Captures
+# wall time + peak RSS from GNU /usr/bin/time.
+_run_one() {
+  scenario_path="$1"
+  base_name="$(basename "$scenario_path" .sexp)"
+  log_path="${OUT_DIR}/${base_name}.log"
+  rss_path="${OUT_DIR}/${base_name}.peak_rss"
+  wall_path="${OUT_DIR}/${base_name}.wall_sec"
+  error_path="${OUT_DIR}/${base_name}.error"
+
+  # Stage into a scratch dir; scenario_runner --dir consumes ALL .sexp in
+  # the dir, so we put just this one scenario in a fresh subdir.
+  stage_dir="${OUT_DIR}/_stage_${base_name}"
+  mkdir -p "$stage_dir"
+  cp "$scenario_path" "$stage_dir/"
+
+  printf '[run]  %s\n' "$base_name"
+
+  start_epoch=$(date +%s)
+  rc=0
+  if [ "$HAVE_GNU_TIME" = "1" ]; then
+    /usr/bin/time -o "$rss_path" -f '%M' \
+      timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" \
+        dune exec --no-build \
+          trading/backtest/scenarios/scenario_runner.exe -- \
+          --dir "$stage_dir" --parallel 1 \
+        >"$log_path" 2>&1 || rc=$?
+  else
+    timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" \
+        dune exec --no-build \
+          trading/backtest/scenarios/scenario_runner.exe -- \
+          --dir "$stage_dir" --parallel 1 \
+        >"$log_path" 2>&1 || rc=$?
+    printf 'UNAVAILABLE\n' >"$rss_path"
+  fi
+  end_epoch=$(date +%s)
+  wall_sec=$((end_epoch - start_epoch))
+  printf '%s\n' "$wall_sec" >"$wall_path"
+
+  rss_value="?"
+  if [ -f "$rss_path" ]; then
+    rss_value=$(tr -d '\n' <"$rss_path")
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    printf 'exit=%s — see %s\n' "$rc" "$log_path" >"$error_path"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}FAIL  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  else
+    PASS_COUNT=$((PASS_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}PASS  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  fi
+
+  # Clean up stage dir; keep logs.
+  rm -rf "$stage_dir"
+}
+
+# Pre-build the scenario_runner so per-cell wall numbers don't include build
+# time. Best-effort: if the build fails, _run_one will surface it.
+"$RUN_IN_ENV" dune build trading/backtest/scenarios/scenario_runner.exe \
+  >"${OUT_DIR}/_prebuild.log" 2>&1 || true
+
+# IFS-by-newline iteration — TIER2_PATHS is newline-separated.
+OLD_IFS="$IFS"
+IFS='
+'
+for path in $TIER2_PATHS; do
+  IFS="$OLD_IFS"
+  _run_one "$path"
+  IFS='
+'
+done
+IFS="$OLD_IFS"
+
+SUMMARY="${OUT_DIR}/summary.txt"
+{
+  printf 'Tier-2 perf nightly summary (%s)\n' "$TS"
+  printf '  passed: %d\n' "$PASS_COUNT"
+  printf '  failed: %d\n' "$FAIL_COUNT"
+  printf '\n'
+  printf '%-6s  %-32s  %-8s  %s\n' "STATUS" "SCENARIO" "WALL" "PEAK_RSS"
+  printf '%s\n' "----------------------------------------------------------------------"
+  printf '%b' "$TABLE_ROWS" | awk 'NF { printf "%-6s  %-32s  %-8s  %s\n", $1, $2, $3, $4 }'
+} >"$SUMMARY"
+
+cat "$SUMMARY"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -8,17 +8,19 @@ IN_PROGRESS
 Steps 1+2 (`feat/backtest-perf-tier1-catalog`, PR #574) merged
 2026-04-26T16:07Z. **`perf-tier1.yml` landed via PR #616 on 2026-04-27**
 — per-PR perf smoke is now wired (continue-on-error: true for now;
-gate later). **Engine-layer-pooling PR-1 (Gc.stat instrumentation,
-panel_runner per-step snapshots) merged via PR #618 on 2026-04-27**;
-PR-2..PR-4 (per-symbol scratch + float-array buffers + buffer
-pooling) gated on a 3-month full-universe gc-trace run that confirms
-the engine-update-market wedge. Tier-2 nightly + tier-3 weekly
-workflows outstanding (token scope confirmed; previous PAT-blocker
-no longer applies post-#616). Step 5 (release_perf_report OCaml exe)
-tracked separately; landed via #585 / #606 on the test-data +
-perf-runner side. Tier-4 release-gate scenarios structurally
-unblocked since data-panels Stage 4.5 PR-B (#604) merged
-2026-04-27T02:33Z.
+gate later). **Tier-2 nightly workflow landed via PR #622 on
+2026-04-27**: `perf_tier2_nightly.sh` +
+`.github/workflows/perf-nightly.yml`, six tier-2 cells, 30 min/cell
+budget, cron `0 5 * * *` (22:00 PT). **Engine-layer-pooling PR-1
+(Gc.stat instrumentation, panel_runner per-step snapshots) merged
+via PR #618 on 2026-04-27**; PR-2..PR-4 (per-symbol scratch +
+float-array buffers + buffer pooling) gated on a 3-month
+full-universe gc-trace run that confirms the engine-update-market
+wedge. Tier-3 weekly workflow still outstanding. Step 5
+(release_perf_report OCaml exe) tracked separately; landed via #585
+/ #606 on the test-data + perf-runner side. Tier-4 release-gate
+scenarios structurally unblocked since data-panels Stage 4.5 PR-B
+(#604) merged 2026-04-27T02:33Z.
 
 ## Interface stable
 NO
@@ -58,8 +60,38 @@ mechanics + release-gate procedure.
   `Engine.update_market` is the dominant per-tick allocator before
   the buffer-reuse refactors land (PR-2..PR-4 per
   `dev/plans/engine-layer-pooling-2026-04-27.md`).
+- **`feat/backtest-perf-tier2-nightly`** (Step 3 — tier-2 nightly) —
+  open for review. Adds `dev/scripts/perf_tier2_nightly.sh` +
+  `.github/workflows/perf-nightly.yml`. Auto-discovers all six
+  `;; perf-tier: 2` scenarios under
+  `trading/test_data/backtest_scenarios/{goldens-small,smoke}/`,
+  runs each via `scenario_runner.exe --parallel 1` with `timeout 1800`,
+  publishes wall + peak-RSS table to `$GITHUB_STEP_SUMMARY`. Cron
+  `0 5 * * *` (22:00 PT PDT / 21:00 PT PST), well clear of the
+  orchestrator's 07:17/12:17 UTC slots. Non-blocking
+  (`continue-on-error: true`) — same VISIBILITY-first posture as
+  tier-1. Tier-3 weekly + tier-4 release-gate workflows remain
+  outstanding (separate PRs).
 
 ## Completed
+
+- **Step 3 — tier-2 nightly perf workflow** (2026-04-27, PR pending).
+  Mirrors the tier-1 pattern. Adds
+  `dev/scripts/perf_tier2_nightly.sh` (POSIX-sh runner that
+  auto-discovers `;; perf-tier: 2` scenarios via grep, runs each via
+  `scenario_runner.exe --parallel 1` with `timeout 1800`, captures
+  wall + peak RSS, writes `summary.txt`) and
+  `.github/workflows/perf-nightly.yml` (cron `0 5 * * *` = 22:00 PT
+  PDT / 21:00 PT PST, well clear of the orchestrator's 07:17/12:17
+  UTC slots; same `trading-ci:latest` container, same `_build` cache,
+  same `continue-on-error: true` posture as tier-1; publishes summary
+  to `$GITHUB_STEP_SUMMARY`). Six tier-2 cells covered:
+  `goldens-small/{bull-crash-2015-2020, covid-recovery-2020-2024,
+  six-year-2018-2023}` and `smoke/{bull-2019h2, crash-2020h1,
+  recovery-2023}`. Verify locally: `dev/scripts/perf_tier2_nightly.sh`
+  inside the devcontainer (or with `TRADING_IN_CONTAINER=1`); the
+  workflow itself is exercised on its first scheduled run / manual
+  `workflow_dispatch`.
 
 - **Engine-pooling PR-1 — Gc.stat instrumentation** (2026-04-27, PR #618).
   Per-step `Gc.stat` snapshots in `Panel_runner.run`, gated by the
@@ -116,11 +148,14 @@ mechanics + release-gate procedure.
 
 ## Next steps
 
-1. (NEXT) Define tier 2 (nightly, 5 cells per the plan, mapped onto the
-   6 currently-tagged tier-2 scenarios) + create `perf-nightly.yml`.
-   ~80 LOC YAML.
-2. Define tier 3 (weekly, 4 cells per the plan, mapped onto the 2
-   currently-tagged tier-3 scenarios — may need to expand) + sibling
+1. (IN_PROGRESS) Tier 2 (nightly) — `perf-nightly.yml` +
+   `perf_tier2_nightly.sh` open at `feat/backtest-perf-tier2-nightly`.
+   Auto-discovers all six `;; perf-tier: 2` scenarios:
+   `goldens-small/{bull-crash-2015-2020, covid-recovery-2020-2024,
+   six-year-2018-2023}` and `smoke/{bull-2019h2, crash-2020h1,
+   recovery-2023}`. 30 min budget per cell. Cron `0 5 * * *` (22:00 PT).
+2. (NEXT) Define tier 3 (weekly, 4 cells per the plan, mapped onto the
+   2 currently-tagged tier-3 scenarios — may need to expand) + sibling
    weekly workflow. ~80 LOC YAML.
 3. Tier 4 (release-gate, 5000-stock decade-long) — was blocked on the
    `data-panels` refactor (`dev/status/data-panels.md`); stages 0-3
@@ -130,7 +165,9 @@ mechanics + release-gate procedure.
    8 GB ceiling.
 4. After ~10 PR cycles of tier-1 perf data: pin per-cell budgets and
    flip `continue-on-error: false` on `perf-tier1.yml` and
-   `PERF_CATALOG_CHECK_STRICT=1` on the catalog check.
+   `PERF_CATALOG_CHECK_STRICT=1` on the catalog check. Same flip
+   applies to `perf-nightly.yml` once tier-2 budgets are pinned
+   (~10 weeks of nightly data).
 5. **`release_perf_report` OCaml exe.** Markdown report comparing the
    current release's tier-3/4 scenario results vs the prior release —
    N×T peak-RSS matrix, wall-time matrix, regression flags. Drives
@@ -151,7 +188,8 @@ generators.
 ## Branch
 
 `feat/backtest-perf-<step>` per item above. Active:
-`feat/backtest-perf-tier1-catalog` (Steps 1+2).
+`feat/backtest-perf-tier2-nightly` (Step 3) and
+`feat/backtest-perf-engine-pool-instrument` (engine-pooling PR-1).
 
 ## Blocked on
 


### PR DESCRIPTION
## Summary

Mirrors the tier-1 pattern (PR #616) for tier-2 nightly perf coverage.
Two new files, one status update.

- `dev/scripts/perf_tier2_nightly.sh` — POSIX-sh runner that
  auto-discovers all `;; perf-tier: 2` scenarios under
  `trading/test_data/backtest_scenarios/{goldens-small,smoke}/`,
  stages each into a single-cell scratch dir, runs via
  `scenario_runner.exe --parallel 1` with `timeout 1800` (30 min/cell
  per the plan's tier-2 budget), captures wall + peak RSS, writes
  `summary.txt`. Same OCAMLRUNPARAM defaults as tier-1.
- `.github/workflows/perf-nightly.yml` — GHA workflow. Cron
  `0 5 * * *` (= 22:00 PT PDT / 21:00 PT PST), well clear of the
  orchestrator's 07:17 / 12:17 UTC slots. Same `trading-ci:latest`
  container, same `_build` cache strategy, same
  `continue-on-error: true` (visibility first; gating later) as
  `perf-tier1.yml`. Publishes the latest summary.txt to
  `\$GITHUB_STEP_SUMMARY`.
- `dev/status/backtest-perf.md` — Step 3 marked IN_PROGRESS, six
  tier-2 scenarios enumerated, completion entry added, branch line
  updated.

Six tier-2 cells covered:
- `goldens-small/bull-crash-2015-2020.sexp`
- `goldens-small/covid-recovery-2020-2024.sexp`
- `goldens-small/six-year-2018-2023.sexp`
- `smoke/bull-2019h2.sexp`
- `smoke/crash-2020h1.sexp`
- `smoke/recovery-2023.sexp`

What runs nightly: those six scenarios, sequentially, each with a
30 min budget; results land in the GHA job summary.

## What's NOT in this PR

- Tier-3 weekly workflow (separate PR; needs the tier-3 cell list
  expanded — currently only 2 cells tagged but plan calls for 4).
- Tier-4 release-gate workflow.
- `release_perf_report` OCaml exe.
- Pinned per-cell budgets / flipping `continue-on-error: false`.

## Test plan

- [x] `sh trading/devtools/checks/posix_sh_check.sh` — 45 scripts
      clean (was 44; new script picked up by the linter).
- [x] `sh trading/devtools/checks/perf_catalog_check.sh` — 15
      scenarios all carry tier tags.
- [x] `sh trading/devtools/checks/no_python_check.sh` — no \*.py
      files added.
- [x] `dune build` — clean.
- [x] `dune runtest` — all green (with `TRADING_DATA_DIR` set as in
      the GHA workflows).
- [x] `dune build @fmt` — clean.
- [ ] First scheduled / manual `workflow_dispatch` run on
      `perf-nightly.yml` exercises the workflow end-to-end on the
      GHA runner. (Not exercisable pre-merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)