### PR TITLE
fix(orchestrator): poll mergeable before auto-merge to avoid 405 race

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -392,6 +392,22 @@ jobs:
           # now defers to this step so the merge happens after the budget
           # JSON is bundled.
           # ---------------------------------------------------------------
+          # GitHub needs a few seconds after a push to compute mergeability;
+          # an immediate PUT /merge in that window returns HTTP 405 "Pull
+          # Request is not mergeable" and the daily PR sits open. Poll until
+          # GitHub reports `mergeable=true` (or give up after ~30 s).
+          # See run 24996059895 for the original failure mode.
+          for _ in 1 2 3 4 5 6; do
+            MERGEABLE="$(curl -sSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/pulls/${DAILY_PR_NUMBER}" \
+              | jq -r '.mergeable // "null"')"
+            [ "$MERGEABLE" = "true" ] && break
+            echo "Waiting for GitHub to compute mergeability (current: ${MERGEABLE})..."
+            sleep 5
+          done
+
           MERGE_RESPONSE="$(curl -sSL -X PUT \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary

Follow-up to PR #615. The auto-merge step now finds the daily PR and tries to merge it, but GitHub returns HTTP 405 "Pull Request is not mergeable" because we PUT /merge immediately after pushing the budget commit — GH hasn't finished computing mergeability yet.

Run [24996059895](https://github.com/dayfine/trading/actions/runs/24996059895) (today's run-2) hit this:

```
Found ops/daily-* PR #619 on branch ops/daily-2026-04-27-run2; bundling budget JSON.
##[warning]Auto-merge failed for PR #619. Response: {"message": "Pull Request is not mergeable", "status": "405"}
```

So #619 sat open instead of auto-merging.

## Fix

Poll the PR's `mergeable` field every 5 s for up to 30 s before issuing PUT /merge. Break early once GH reports `mergeable=true`. If it's still null after 30 s, fall through to the merge call anyway (and the existing warning path handles a real failure).

## Test plan

- [x] `ruby -ryaml -e 'YAML.load_file(...)'` parses clean
- [x] Smoke-tested the polling logic locally (curl + jq path is the same one merged in #615)
- [ ] Next scheduled orchestrator run cleanly auto-merges its daily PR