### PR TITLE
feat(backtest-perf): tier-3 weekly perf workflow

### DIFF
--- a/.github/workflows/perf-weekly.yml
+++ b/.github/workflows/perf-weekly.yml
@@ -1,0 +1,94 @@
+# Tier-3 perf weekly: weekly large-scope perf coverage (≤2 h budget per cell)
+# for the perf catalog.
+#
+# Runs every scenario tagged `;; perf-tier: 3` under
+# trading/test_data/backtest_scenarios/ via dev/scripts/perf_tier3_weekly.sh,
+# captures wall-time + peak RSS, and writes the result into the GHA job
+# summary so the human can read off perf at a glance.
+#
+# Non-blocking by design (continue-on-error: true) — same rationale as
+# perf-tier1.yml + perf-nightly.yml: VISIBILITY first, gating later. Flip
+# continue-on-error off once the budgets in
+# dev/plans/perf-scenario-catalog-2026-04-25.md tier 3 are pinned (~10
+# weekly cycles of data).
+#
+# Tier-3 scenarios covered (kept in sync via
+# trading/devtools/checks/perf_catalog_check.sh — `;; perf-tier: 3` tag is
+# the source of truth, the discovery in the runner script auto-matches):
+#   trading/test_data/backtest_scenarios/perf-sweep/bull-1y.sexp
+#   trading/test_data/backtest_scenarios/perf-sweep/bull-3y.sexp
+name: perf-weekly
+
+on:
+  # Weekly cron at 07:00 UTC Monday = 00:00 PT (PDT) / 23:00 PT Sunday (PST).
+  # Chosen because:
+  #   - Daily perf-nightly runs at 05:00 UTC; this is 2 hours later, so no
+  #     concurrency overlap with that runner.
+  #   - Daily orchestrator runs at 07:17 UTC (00:17 PT). This slot starts 17
+  #     minutes earlier; tier-3 jobs can take hours, but the orchestrator's
+  #     workload is independent (different repos / different PR queues), so
+  #     the only contention is GHA scheduler queueing — acceptable.
+  #   - image.yml runs at 06:00 UTC Mon; this is 1 hour later, so the
+  #     trading-ci:latest image being pulled is at most 1 hour stale.
+  #   - deps-update.yml runs at 08:00 UTC Mon; that's 1 hour later, no
+  #     overlap.
+  #   - health-deep-weekly.yml runs at 15:17 UTC Mon (08:17 PT); 8 hours
+  #     later, no overlap.
+  #   - GitHub cron is UTC-only, no DST awareness; this drifts back
+  #     1 hour PT during PST months (i.e. 23:00 PT Sunday).
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+jobs:
+  perf-tier3-weekly:
+    runs-on: ubuntu-latest
+    # Per-cell budget is 2 h; two tier-3 cells run sequentially, so the
+    # job-level ceiling is ~4 h with some build/setup overhead. 300 min
+    # gives headroom for the 3y cell plus the _build cache restore cost
+    # on a cold runner. (GHA job-level max is 360 min on ubuntu-latest.)
+    timeout-minutes: 300
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/trading-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 0
+    env:
+      HOME: /home/opam
+      TRADING_IN_CONTAINER: "1"
+      TRADING_DATA_DIR: ${{ github.workspace }}/trading/test_data
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache _build
+        uses: actions/cache@v4
+        with:
+          path: trading/_build
+          key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
+          restore-keys: |
+            dune-${{ runner.os }}-
+
+      - name: Run tier-3 perf weekly
+        id: tier3
+        continue-on-error: true
+        run: dev/scripts/perf_tier3_weekly.sh
+
+      - name: Publish summary
+        if: always()
+        run: |
+          summary_file=$(ls -1t dev/perf/tier3-weekly-*/summary.txt 2>/dev/null | head -1)
+          if [ -n "$summary_file" ] && [ -f "$summary_file" ]; then
+            {
+              echo "## Tier-3 perf weekly"
+              echo ""
+              echo '```'
+              cat "$summary_file"
+              echo '```'
+            } >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "Tier-3 perf weekly: no summary produced." >>"$GITHUB_STEP_SUMMARY"
+          fi

--- a/dev/scripts/perf_tier3_weekly.sh
+++ b/dev/scripts/perf_tier3_weekly.sh
@@ -1,0 +1,198 @@
+#!/bin/sh
+# Tier-3 perf weekly runner.
+#
+# Discovers all scenarios with `;; perf-tier: 3` under
+# trading/test_data/backtest_scenarios/{goldens-small,goldens-broad,perf-sweep,smoke}/,
+# runs each via the scenario_runner binary with a per-scenario timeout
+# (default 7200s = 2 hours, per dev/plans/perf-scenario-catalog-2026-04-25.md
+# tier 3 budget), and prints a compact wall-time + peak-RSS table.
+#
+# Mirrors dev/scripts/perf_tier2_nightly.sh — same discovery + output layout,
+# same OCAMLRUNPARAM tuning, same scratch-dir staging trick. Differences:
+#   - tier filter is `perf-tier: 3`
+#   - per-cell timeout default is 7200s (vs 1800s for tier 2)
+#   - artefact dir is dev/perf/tier3-weekly-<timestamp>/
+#   - env var override is PERF_TIER3_TIMEOUT / PERF_TIER3_OCAMLRUNPARAM
+#
+# Exit status:
+#   0 if every tier-3 scenario completes within budget
+#   1 if any scenario exits non-zero, errors, or times out
+#
+# Usage:
+#   dev/scripts/perf_tier3_weekly.sh                          -- run all tier-3 cells
+#   PERF_TIER3_TIMEOUT=10800 dev/scripts/perf_tier3_weekly.sh -- bump per-cell timeout
+#
+# Designed to run inside the trading-1-dev container or under GHA where
+# TRADING_IN_CONTAINER=1; uses dev/lib/run-in-env.sh to wrap dune exec.
+#
+# Output artefacts under dev/perf/tier3-weekly-<timestamp>/:
+#   <scenario-name>.log        scenario_runner stdout/stderr
+#   <scenario-name>.peak_rss   integer kB from /usr/bin/time -f '%M'
+#   <scenario-name>.wall_sec   seconds (real time) — best-effort
+#   <scenario-name>.error      present iff the run errored / timed out
+#   summary.txt                aggregate table written at the end
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCENARIO_ROOT="${REPO_ROOT}/trading/test_data/backtest_scenarios"
+RUN_IN_ENV="${REPO_ROOT}/dev/lib/run-in-env.sh"
+TIMEOUT="${PERF_TIER3_TIMEOUT:-7200}"
+
+# Aggressive major-GC + smaller minor heap. Same rationale as tier-1/tier-2
+# (dev/notes/panels-rss-matrix-post602-gc-tuned-2026-04-26.md): without
+# this, the GC steady-state high-water mark inflates peak RSS by ~25-37%
+# for runs with low allocation rates. Override via
+# PERF_TIER3_OCAMLRUNPARAM=... if a specific scenario needs a different
+# heap shape; pass empty to use the OCaml defaults.
+export OCAMLRUNPARAM="${PERF_TIER3_OCAMLRUNPARAM:-o=60,s=512k}"
+
+if [ ! -x "$RUN_IN_ENV" ]; then
+  printf 'FAIL: %s not found / not executable\n' "$RUN_IN_ENV" >&2
+  exit 1
+fi
+
+if [ ! -d "$SCENARIO_ROOT" ]; then
+  printf 'FAIL: scenario root not found: %s\n' "$SCENARIO_ROOT" >&2
+  exit 1
+fi
+
+# Probe for GNU /usr/bin/time. The shell builtin has no -f / -o; we need
+# the GNU binary for peak-RSS reporting. macOS hosts won't have it.
+if [ -x /usr/bin/time ]; then
+  HAVE_GNU_TIME=1
+else
+  HAVE_GNU_TIME=0
+fi
+
+# Output dir keyed by timestamp so re-runs don't clobber each other.
+TS="$(date -u +%Y-%m-%dT%H%M%SZ)"
+OUT_DIR="${REPO_ROOT}/dev/perf/tier3-weekly-${TS}"
+mkdir -p "$OUT_DIR"
+
+printf 'Tier-3 perf weekly run.\n'
+printf '  Scenario root : %s\n' "$SCENARIO_ROOT"
+printf '  Output dir    : %s\n' "$OUT_DIR"
+printf '  Per-cell timeout : %ss\n' "$TIMEOUT"
+printf '  GNU /usr/bin/time : %s\n\n' "$HAVE_GNU_TIME"
+
+# Discover tier-3 scenarios (full paths, sorted for determinism).
+TIER3_PATHS=""
+for sub in goldens-small goldens-broad perf-sweep smoke; do
+  dir="${SCENARIO_ROOT}/${sub}"
+  [ -d "$dir" ] || continue
+  for sexp in "$dir"/*.sexp; do
+    [ -f "$sexp" ] || continue
+    if grep -q '^;; perf-tier: 3' "$sexp"; then
+      TIER3_PATHS="${TIER3_PATHS}${sexp}
+"
+    fi
+  done
+done
+
+if [ -z "$TIER3_PATHS" ]; then
+  printf 'WARNING: no scenarios found with [;; perf-tier: 3] -- nothing to do.\n'
+  exit 0
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TABLE_ROWS=""
+
+# Run a single scenario. Stages it into a one-element scratch dir so the
+# scenario_runner --dir entry point picks up exactly one cell. Captures
+# wall time + peak RSS from GNU /usr/bin/time.
+_run_one() {
+  scenario_path="$1"
+  base_name="$(basename "$scenario_path" .sexp)"
+  log_path="${OUT_DIR}/${base_name}.log"
+  rss_path="${OUT_DIR}/${base_name}.peak_rss"
+  wall_path="${OUT_DIR}/${base_name}.wall_sec"
+  error_path="${OUT_DIR}/${base_name}.error"
+
+  # Stage into a scratch dir; scenario_runner --dir consumes ALL .sexp in
+  # the dir, so we put just this one scenario in a fresh subdir.
+  stage_dir="${OUT_DIR}/_stage_${base_name}"
+  mkdir -p "$stage_dir"
+  cp "$scenario_path" "$stage_dir/"
+
+  printf '[run]  %s\n' "$base_name"
+
+  start_epoch=$(date +%s)
+  rc=0
+  if [ "$HAVE_GNU_TIME" = "1" ]; then
+    /usr/bin/time -o "$rss_path" -f '%M' \
+      timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" \
+        dune exec --no-build \
+          trading/backtest/scenarios/scenario_runner.exe -- \
+          --dir "$stage_dir" --parallel 1 \
+        >"$log_path" 2>&1 || rc=$?
+  else
+    timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" \
+        dune exec --no-build \
+          trading/backtest/scenarios/scenario_runner.exe -- \
+          --dir "$stage_dir" --parallel 1 \
+        >"$log_path" 2>&1 || rc=$?
+    printf 'UNAVAILABLE\n' >"$rss_path"
+  fi
+  end_epoch=$(date +%s)
+  wall_sec=$((end_epoch - start_epoch))
+  printf '%s\n' "$wall_sec" >"$wall_path"
+
+  rss_value="?"
+  if [ -f "$rss_path" ]; then
+    rss_value=$(tr -d '\n' <"$rss_path")
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    printf 'exit=%s — see %s\n' "$rc" "$log_path" >"$error_path"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}FAIL  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  else
+    PASS_COUNT=$((PASS_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}PASS  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  fi
+
+  # Clean up stage dir; keep logs.
+  rm -rf "$stage_dir"
+}
+
+# Pre-build the scenario_runner so per-cell wall numbers don't include build
+# time. Best-effort: if the build fails, _run_one will surface it.
+"$RUN_IN_ENV" dune build trading/backtest/scenarios/scenario_runner.exe \
+  >"${OUT_DIR}/_prebuild.log" 2>&1 || true
+
+# IFS-by-newline iteration — TIER3_PATHS is newline-separated.
+OLD_IFS="$IFS"
+IFS='
+'
+for path in $TIER3_PATHS; do
+  IFS="$OLD_IFS"
+  _run_one "$path"
+  IFS='
+'
+done
+IFS="$OLD_IFS"
+
+SUMMARY="${OUT_DIR}/summary.txt"
+{
+  printf 'Tier-3 perf weekly summary (%s)\n' "$TS"
+  printf '  passed: %d\n' "$PASS_COUNT"
+  printf '  failed: %d\n' "$FAIL_COUNT"
+  printf '\n'
+  printf '%-6s  %-32s  %-8s  %s\n' "STATUS" "SCENARIO" "WALL" "PEAK_RSS"
+  printf '%s\n' "----------------------------------------------------------------------"
+  printf '%b' "$TABLE_ROWS" | awk 'NF { printf "%-6s  %-32s  %-8s  %s\n", $1, $2, $3, $4 }'
+} >"$SUMMARY"
+
+cat "$SUMMARY"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -11,16 +11,19 @@ Steps 1+2 (`feat/backtest-perf-tier1-catalog`, PR #574) merged
 gate later). **Tier-2 nightly workflow landed via PR #622 on
 2026-04-27**: `perf_tier2_nightly.sh` +
 `.github/workflows/perf-nightly.yml`, six tier-2 cells, 30 min/cell
-budget, cron `0 5 * * *` (22:00 PT). **Engine-layer-pooling PR-1
+budget, cron `0 5 * * *` (22:00 PT). **Tier-3 weekly workflow open
+at `feat/backtest-perf-tier3-weekly` on 2026-04-27**:
+`perf_tier3_weekly.sh` + `.github/workflows/perf-weekly.yml`, two
+tier-3 cells (`perf-sweep/{bull-1y, bull-3y}`), 2 h/cell budget,
+cron `0 7 * * 1` (Monday 00:00 PT). **Engine-layer-pooling PR-1
 (Gc.stat instrumentation, panel_runner per-step snapshots) merged
 via PR #618 on 2026-04-27**; PR-2..PR-4 (per-symbol scratch +
 float-array buffers + buffer pooling) gated on a 3-month
 full-universe gc-trace run that confirms the engine-update-market
-wedge. Tier-3 weekly workflow still outstanding. Step 5
-(release_perf_report OCaml exe) tracked separately; landed via #585
-/ #606 on the test-data + perf-runner side. Tier-4 release-gate
-scenarios structurally unblocked since data-panels Stage 4.5 PR-B
-(#604) merged 2026-04-27T02:33Z.
+wedge. Step 5 (release_perf_report OCaml exe) tracked separately;
+landed via #585 / #606 on the test-data + perf-runner side. Tier-4
+release-gate scenarios structurally unblocked since data-panels
+Stage 4.5 PR-B (#604) merged 2026-04-27T02:33Z.
 
 ## Interface stable
 NO
@@ -60,22 +63,42 @@ mechanics + release-gate procedure.
   `Engine.update_market` is the dominant per-tick allocator before
   the buffer-reuse refactors land (PR-2..PR-4 per
   `dev/plans/engine-layer-pooling-2026-04-27.md`).
-- **`feat/backtest-perf-tier2-nightly`** (Step 3 — tier-2 nightly) —
-  open for review. Adds `dev/scripts/perf_tier2_nightly.sh` +
-  `.github/workflows/perf-nightly.yml`. Auto-discovers all six
-  `;; perf-tier: 2` scenarios under
-  `trading/test_data/backtest_scenarios/{goldens-small,smoke}/`,
-  runs each via `scenario_runner.exe --parallel 1` with `timeout 1800`,
-  publishes wall + peak-RSS table to `$GITHUB_STEP_SUMMARY`. Cron
-  `0 5 * * *` (22:00 PT PDT / 21:00 PT PST), well clear of the
-  orchestrator's 07:17/12:17 UTC slots. Non-blocking
+- **`feat/backtest-perf-tier3-weekly`** (Step 4 — tier-3 weekly) —
+  open for review. Adds `dev/scripts/perf_tier3_weekly.sh` +
+  `.github/workflows/perf-weekly.yml`. Auto-discovers both
+  `;; perf-tier: 3` scenarios under
+  `trading/test_data/backtest_scenarios/perf-sweep/{bull-1y,bull-3y}.sexp`,
+  runs each via `scenario_runner.exe --parallel 1` with
+  `timeout 7200`, publishes wall + peak-RSS table to
+  `$GITHUB_STEP_SUMMARY`. Cron `0 7 * * 1` (Monday 00:00 PT PDT /
+  23:00 PT Sunday PST), 2 h after perf-nightly's 05:00 UTC slot and
+  17 min before the orchestrator's 07:17 UTC slot. Non-blocking
   (`continue-on-error: true`) — same VISIBILITY-first posture as
-  tier-1. Tier-3 weekly + tier-4 release-gate workflows remain
-  outstanding (separate PRs).
+  tier-1/tier-2. Tier-4 release-gate workflow remains outstanding
+  (separate PR; gated on engine-pool PR-2..PR-5).
 
 ## Completed
 
-- **Step 3 — tier-2 nightly perf workflow** (2026-04-27, PR pending).
+- **Step 4 — tier-3 weekly perf workflow** (2026-04-27, PR pending).
+  Mirrors the tier-1/tier-2 pattern. Adds
+  `dev/scripts/perf_tier3_weekly.sh` (POSIX-sh runner that
+  auto-discovers `;; perf-tier: 3` scenarios via grep, runs each via
+  `scenario_runner.exe --parallel 1` with `timeout 7200` = 2 h,
+  captures wall + peak RSS, writes `summary.txt`) and
+  `.github/workflows/perf-weekly.yml` (cron `0 7 * * 1` = 00:00 PT
+  Monday PDT / 23:00 PT Sunday PST; 2 h after perf-nightly's 05:00
+  UTC and 17 min before the orchestrator's 07:17 UTC; same
+  `trading-ci:latest` container, same `_build` cache, same
+  `continue-on-error: true` posture as tier-1/tier-2; publishes
+  summary to `$GITHUB_STEP_SUMMARY`; `timeout-minutes: 300` job
+  ceiling). Two tier-3 cells covered:
+  `perf-sweep/{bull-1y, bull-3y}`. Verify locally:
+  `dev/scripts/perf_tier3_weekly.sh` inside the devcontainer (or
+  with `TRADING_IN_CONTAINER=1`); the workflow itself is exercised
+  on its first scheduled run (next Monday 07:00 UTC) or via manual
+  `workflow_dispatch`.
+
+- **Step 3 — tier-2 nightly perf workflow** (2026-04-27, PR #622 merged).
   Mirrors the tier-1 pattern. Adds
   `dev/scripts/perf_tier2_nightly.sh` (POSIX-sh runner that
   auto-discovers `;; perf-tier: 2` scenarios via grep, runs each via
@@ -148,15 +171,18 @@ mechanics + release-gate procedure.
 
 ## Next steps
 
-1. (IN_PROGRESS) Tier 2 (nightly) — `perf-nightly.yml` +
-   `perf_tier2_nightly.sh` open at `feat/backtest-perf-tier2-nightly`.
-   Auto-discovers all six `;; perf-tier: 2` scenarios:
-   `goldens-small/{bull-crash-2015-2020, covid-recovery-2020-2024,
-   six-year-2018-2023}` and `smoke/{bull-2019h2, crash-2020h1,
-   recovery-2023}`. 30 min budget per cell. Cron `0 5 * * *` (22:00 PT).
-2. (NEXT) Define tier 3 (weekly, 4 cells per the plan, mapped onto the
-   2 currently-tagged tier-3 scenarios — may need to expand) + sibling
-   weekly workflow. ~80 LOC YAML.
+1. (DONE) Tier 2 (nightly) — `perf-nightly.yml` +
+   `perf_tier2_nightly.sh` merged in PR #622 on 2026-04-27. Six
+   tier-2 cells, 30 min budget per cell, cron `0 5 * * *` (22:00 PT).
+2. (DONE on this PR) Tier 3 (weekly) — `perf-weekly.yml` +
+   `perf_tier3_weekly.sh`, two tier-3 cells
+   (`perf-sweep/{bull-1y, bull-3y}`), 2 h budget per cell, cron
+   `0 7 * * 1` (Monday 00:00 PT). The tier-3 cell count is below
+   the original plan's 4 because tagged tier-3 scenarios are
+   currently 2; expanding the catalog (e.g., bull-crash 1000×6y,
+   covid-recovery 300×4y, six-year 300×6y per the plan's Tier 3
+   table) is a follow-up scenario-authoring task, not gating on
+   the workflow itself.
 3. Tier 4 (release-gate, 5000-stock decade-long) — was blocked on the
    `data-panels` refactor (`dev/status/data-panels.md`); stages 0-3
    landed (PRs #555, #557, #558, #559-565, #567, #569, #573).
@@ -167,7 +193,8 @@ mechanics + release-gate procedure.
    flip `continue-on-error: false` on `perf-tier1.yml` and
    `PERF_CATALOG_CHECK_STRICT=1` on the catalog check. Same flip
    applies to `perf-nightly.yml` once tier-2 budgets are pinned
-   (~10 weeks of nightly data).
+   (~10 weeks of nightly data) and to `perf-weekly.yml` once
+   tier-3 budgets are pinned (~10 weekly cycles).
 5. **`release_perf_report` OCaml exe.** Markdown report comparing the
    current release's tier-3/4 scenario results vs the prior release —
    N×T peak-RSS matrix, wall-time matrix, regression flags. Drives
@@ -175,9 +202,8 @@ mechanics + release-gate procedure.
    Replaces the deleted `dev/scripts/perf_sweep_report.py` (Legacy-vs-
    Tiered axis is gone post-PR #575; need single-mode N×T tables instead).
    Per `.claude/rules/no-python.md`: write fresh in OCaml, do not port.
-   Lands together with or just before tier-3 weekly workflow (Step 2)
-   so the weekly run produces a useful diff vs the prior week. ~150 LOC
-   exe + .mli + tests.
+   Now lands as a follow-up after tier-3 weekly so the weekly run
+   has data to diff against. ~150 LOC exe + .mli + tests.
 
 ## Ownership
 
@@ -188,7 +214,7 @@ generators.
 ## Branch
 
 `feat/backtest-perf-<step>` per item above. Active:
-`feat/backtest-perf-tier2-nightly` (Step 3) and
+`feat/backtest-perf-tier3-weekly` (Step 4) and
 `feat/backtest-perf-engine-pool-instrument` (engine-pooling PR-1).
 
 ## Blocked on


### PR DESCRIPTION
## Summary

Adds the tier-3 weekly perf workflow per `dev/status/backtest-perf.md` Next Steps #2. Mirrors the tier-1 (#616) and tier-2 (#622) pattern: POSIX-sh runner that auto-discovers `;; perf-tier: 3` scenarios + GHA workflow that publishes wall-time + peak-RSS to `$GITHUB_STEP_SUMMARY`.

- `dev/scripts/perf_tier3_weekly.sh` — runner. Per-cell timeout 7200s (2 h, per the tier-3 plan budget). Discovers two cells today: `perf-sweep/{bull-1y, bull-3y}.sexp`. Output dir `dev/perf/tier3-weekly-<timestamp>/`. Env overrides `PERF_TIER3_TIMEOUT` / `PERF_TIER3_OCAMLRUNPARAM`. Same `OCAMLRUNPARAM=o=60,s=512k` heap-shape default as tier-1/tier-2 (post-#602 GC tuning).
- `.github/workflows/perf-weekly.yml` — workflow. Cron `0 7 * * 1` = Monday 00:00 PT (PDT) / Sunday 23:00 PT (PST). Slot picked to clear: `perf-nightly` (`0 5 * * *`, 2 h earlier), orchestrator (`17 7 * * *`, 17 min later, but isolated workload so contention only at GHA scheduler level), `image.yml` (`0 6 * * 1`, 1 h earlier on Mondays), `deps-update.yml` (`0 8 * * 1`, 1 h later), `health-deep-weekly.yml` (`17 15 * * 1`, 8 h later). Job `timeout-minutes: 300` covers the worst-case 2 cells × 2 h plus build/cache overhead. `continue-on-error: true` — VISIBILITY first, gating later (flip after ~10 weekly cycles per the plan).
- `dev/status/backtest-perf.md` — Next Steps #2 marked DONE on this PR; tier-2 #1 marked DONE (PR #622 merged); status preamble + Open work + Branch line updated.

## What runs weekly

Two tier-3 perf-sweep cells (`bull-1y`, `bull-3y`) auto-discovered via `;; perf-tier: 3` tag, run sequentially via `scenario_runner.exe --parallel 1` with a 2 h per-cell timeout, with wall-time + peak-RSS published to the GHA job summary every Monday 00:00 PT (`workflow_dispatch` for ad-hoc).

## Test plan

- [x] `sh trading/devtools/checks/posix_sh_check.sh` — 46 scripts clean (includes the new `perf_tier3_weekly.sh`).
- [x] `sh trading/devtools/checks/perf_catalog_check.sh` — 15 scenarios all carry tier tags (no scenario file changes; tier-3 tag still present on the 2 perf-sweep cells).
- [x] `sh trading/devtools/checks/no_python_check.sh` — clean (no `*.py` added).
- [x] `sh -n dev/scripts/perf_tier3_weekly.sh` — POSIX shell parse OK.
- [x] `dune build && dune runtest` — green inside the trading-1-dev container.
- [x] `dune build @fmt` — clean.
- [ ] First scheduled run (next Monday 07:00 UTC) or manual `workflow_dispatch` to validate the GHA pipeline end-to-end. Non-blocking by design.

## Out of scope

- Tier-4 release-gate workflow (separate PR; gated on engine-pool PR-2..PR-5 landing).
- `release_perf_report` OCaml exe (separate PR, ~150 LOC; will diff weekly tier-3 output against the prior week).
- Pinning per-cell budgets / flipping `continue-on-error: false` (after ~10 weekly cycles of data).

## References

- Plan: `dev/plans/perf-scenario-catalog-2026-04-25.md` §Tier 3 weekly
- Sibling PRs: #616 (tier-1 workflow), #622 (tier-2 nightly)
- Status: `dev/status/backtest-perf.md`