### PR TITLE
feat(backtest-perf): per-symbol scratch buffer for Price_path (PR-2 of engine-pooling)

### DIFF
--- a/trading/trading/engine/lib/price_path.ml
+++ b/trading/trading/engine/lib/price_path.ml
@@ -27,6 +27,35 @@ let default_config =
     degrees_of_freedom = 4.0;
   }
 
+(** {1 Scratch Buffer}
+
+    See [.mli] for the public contract. *)
+
+(* [_capacity_slack_for_config] +8 absorbs the rounding overshoot from
+   segment generation (4 waypoints plus interpolated points between each
+   pair). *)
+let _capacity_slack_for_config = 8
+let _min_scratch_capacity = 4
+
+module Scratch = struct
+  type t = { path_points : float array }
+
+  let create ~capacity =
+    if capacity < _min_scratch_capacity then
+      invalid_arg
+        (Printf.sprintf "Price_path.Scratch.create: capacity %d < min %d"
+           capacity _min_scratch_capacity);
+    { path_points = Array.create ~len:capacity 0.0 }
+
+  let for_config (c : path_config) =
+    create
+      ~capacity:
+        (Int.max _min_scratch_capacity
+           (c.total_points + _capacity_slack_for_config))
+
+  let capacity t = Array.length t.path_points
+end
+
 (** {1 Utility Functions} *)
 
 (** Clamp a value to a range [min_val, max_val] *)
@@ -114,12 +143,10 @@ let _decide_high_first_directional random_state bar body =
      - High volatility (~1.5): reduced confidence, bias ≈ 0.2
      - Very high volatility (~2.0): low confidence, bias ≈ 0.15 *)
   let confidence_factor = 1.0 /. Float.max volatility_scale 1.0 in
-  let direction_bias =
-    let raw_bias =
-      if Float.(body > 0.0) then max_direction_bias else -.max_direction_bias
-    in
-    raw_bias *. confidence_factor
+  let raw_bias =
+    if Float.(body > 0.0) then max_direction_bias else -.max_direction_bias
   in
+  let direction_bias = raw_bias *. confidence_factor in
   let prob_clamped =
     _clamp ~min_val:min_prob ~max_val:max_prob (neutral_prob +. direction_bias)
   in
@@ -247,13 +274,14 @@ let _ensure_unique_waypoints (resolution : int) (t1 : int) (t2 : int) :
     - Uniform: Random placement in middle 60% (skip early/late extremes for
       robustness)
 
-    Returns [idx_open; idx_first_extreme; idx_second_extreme; idx_close] as bar
+    Returns (idx_open, idx_first_extreme, idx_second_extreme, idx_close) as bar
     indices in [0, resolution-1].
 
     Note: The order of high vs low is determined separately by
     _decide_high_first. *)
 let _generate_waypoint_indices (random_state : Random.State.t)
-    (profile : distribution_profile) (resolution : int) : int list =
+    (profile : distribution_profile) (resolution : int) : int * int * int * int
+    =
   match profile with
   | UShaped | JShaped | ReverseJ ->
       (* Sample from density using rejection sampling
@@ -272,7 +300,7 @@ let _generate_waypoint_indices (random_state : Random.State.t)
       let t_first, t_second =
         _ensure_unique_waypoints resolution t1_clamped t2_clamped
       in
-      [ 0; t_first; t_second; resolution - 1 ]
+      (0, t_first, t_second, resolution - 1)
   | Uniform ->
       (* Uniform: place extremes randomly in middle 60% to avoid edge effects
          - Skip first 20% (opening volatility/gaps)
@@ -287,7 +315,7 @@ let _generate_waypoint_indices (random_state : Random.State.t)
       let t2 = middle_start + Random.State.int random_state range in
       (* Ensure uniqueness and sort *)
       let t_first, t_second = _ensure_unique_waypoints resolution t1 t2 in
-      [ 0; t_first; t_second; resolution - 1 ]
+      (0, t_first, t_second, resolution - 1)
 
 (** {1 Brownian Bridge Segment Generation} *)
 
@@ -300,136 +328,145 @@ let _sample_standard_normal (random_state : Random.State.t) : float =
   let u2 = Random.State.float random_state 1.0 in
   Float.sqrt (-2.0 *. Float.log u1) *. Float.cos (2.0 *. Float.pi *. u2)
 
-(** Generate a single sample from Student's t-distribution with given degrees of
-    freedom.
-
-    Student's t has heavier tails than Gaussian, better modeling extreme moves
-    in financial markets. Lower df = heavier tails.
-
-    Algorithm: 1. Sample Z ~ N(0,1) 2. Sample V ~ Chi-squared(df) = sum of df
-    squared standard normals 3. Return T = Z / sqrt(V/df)
-
-    For df > 30, this closely approximates a Gaussian distribution. *)
+(** Sample Student's t-distribution: T = Z / sqrt(V/df), with Z ~ N(0,1) and V ~
+    Chi-squared(df). Heavier tails than Gaussian for low df. The chi- squared
+    sum is a [for] loop with a mutable accumulator (left-fold) — same FP order
+    as the previous recursive impl, so seeded goldens stay bit-equal. *)
 let _sample_student_t (random_state : Random.State.t) (df : float) : float =
-  (* Sample standard normal for numerator *)
   let z = _sample_standard_normal random_state in
-  (* Sample chi-squared(df) for denominator
-     Chi-squared(df) = sum of df independent squared standard normals *)
   let chi_squared =
-    let rec sum_squares count acc =
-      if count <= 0 then acc
-      else
-        let normal_sample = _sample_standard_normal random_state in
-        sum_squares (count - 1) (acc +. (normal_sample *. normal_sample))
-    in
-    sum_squares (Float.to_int df) 0.0
+    let acc = ref 0.0 in
+    for _ = 1 to Float.to_int df do
+      let s = _sample_standard_normal random_state in
+      acc := !acc +. (s *. s)
+    done;
+    !acc
   in
-  (* Student's t = Z / sqrt(V/df) *)
   z /. Float.sqrt (chi_squared /. df)
 
-(** Generate price segment between two waypoints using Brownian bridge.
-
-    The bridge ensures we hit the target price while adding realistic noise.
-    Noise is sampled from Student's t-distribution for fat tails.
-
-    @param start_price Starting price
-    @param end_price Ending price (must reach exactly)
-    @param n_points Number of intermediate points to generate
-    @param volatility_scale Scaling factor for noise amplitude
-    @param degrees_of_freedom
-      Student's t degrees of freedom (lower = heavier tails)
-    @param resolution
-      Total path resolution (waypoint indices are in [0, resolution-1])
-    @param low_bound Lower price bound (from bar)
-    @param high_bound Upper price bound (from bar)
-    @return List of path_points from start to end *)
-let _generate_bridge_segment ~random_state ~start_price ~end_price ~n_points
-    ~volatility_scale ~degrees_of_freedom ~resolution ~low_bound ~high_bound :
-    path_point list =
-  (* Noise scaling based on Brownian motion properties:
-     - Variance of Brownian motion scales linearly with time
-     - Standard deviation scales with sqrt(time)
-     - dt = fraction of full bar this segment spans (0.0 to 1.0)
-     - Each step covers time dt/(n_points+1), so noise ~ sqrt(dt/(n_points+1)) *)
+(** Brownian bridge: write [n_points] interpolated prices into
+    [out.(out_start .. out_start + n_points - 1)] from [start_price] toward
+    [end_price]. The endpoint is NOT written; callers append it. FP order
+    matches the previous list-based version. *)
+let _generate_bridge_segment_into ~random_state ~out ~out_start ~start_price
+    ~end_price ~n_points ~volatility_scale ~degrees_of_freedom ~resolution
+    ~low_bound ~high_bound =
+  (* Noise scales with sqrt(time): each step covers dt/(n_points+1) of the
+     bar's [dt = n_points/resolution] fraction. *)
   let dt = Float.of_int n_points /. Float.of_int resolution in
   let noise_scale =
     volatility_scale *. Float.sqrt (dt /. Float.of_int (n_points + 1))
   in
-  let rec generate_points i current_price acc =
-    if i > n_points then List.rev acc
-    else
-      (* Brownian bridge: adjust drift to ensure we reach endpoint *)
-      let remaining_steps = n_points + 1 - i in
-      let needed_drift =
-        (end_price -. current_price) /. Float.of_int remaining_steps
-      in
-      (* Add Student's t noise scaled by volatility for realistic fat tails *)
-      let noise =
-        _sample_student_t random_state degrees_of_freedom *. noise_scale
-      in
-      let new_price = current_price +. needed_drift +. noise in
-      (* Clamp to bar bounds using helper *)
-      let clamped_price =
-        _clamp ~min_val:low_bound ~max_val:high_bound new_price
-      in
-      let point : path_point = { price = clamped_price } in
-      generate_points (i + 1) clamped_price (point :: acc)
-  in
-  generate_points 1 start_price []
+  let current_price = ref start_price in
+  for i = 1 to n_points do
+    let remaining_steps = n_points + 1 - i in
+    let needed_drift =
+      (end_price -. !current_price) /. Float.of_int remaining_steps
+    in
+    let noise =
+      _sample_student_t random_state degrees_of_freedom *. noise_scale
+    in
+    let new_price = !current_price +. needed_drift +. noise in
+    let clamped_price =
+      _clamp ~min_val:low_bound ~max_val:high_bound new_price
+    in
+    out.(out_start + i - 1) <- clamped_price;
+    current_price := clamped_price
+  done
 
 (** {1 Main Path Generation} *)
 
-let _append_segment ~random_state ~volatility_scale ~degrees_of_freedom
-    ~total_points ~low_bound ~high_bound acc p1 p2 idx1 idx2 =
-  let acc' =
-    if List.is_empty acc then ({ price = p1 } : path_point) :: acc else acc
+(** Append one segment of prices to [out] from [cursor]; return the new cursor.
+    First segment writes [p1] as slot 0; subsequent ones inherit it from the
+    previous segment's endpoint. *)
+let _append_segment_into ~random_state ~volatility_scale ~degrees_of_freedom
+    ~total_points ~low_bound ~high_bound ~out ~cursor p1 p2 idx1 idx2 =
+  let cursor =
+    if cursor = 0 then (
+      out.(0) <- p1;
+      1)
+    else cursor
   in
-  let segment =
-    _generate_bridge_segment ~random_state ~start_price:p1 ~end_price:p2
-      ~n_points:(idx2 - idx1) ~volatility_scale ~degrees_of_freedom
-      ~resolution:total_points ~low_bound ~high_bound
+  let n_points = idx2 - idx1 in
+  _generate_bridge_segment_into ~random_state ~out ~out_start:cursor
+    ~start_price:p1 ~end_price:p2 ~n_points ~volatility_scale
+    ~degrees_of_freedom ~resolution:total_points ~low_bound ~high_bound;
+  let cursor = cursor + n_points in
+  out.(cursor) <- p2;
+  cursor + 1
+
+(** Interpolate three pairs of waypoints into [out]; return final cursor (=
+    total length written). *)
+let _generate_segments_into ~random_state ~volatility_scale ~degrees_of_freedom
+    ~total_points ~low_bound ~high_bound ~out ~waypoint_prices ~waypoint_indices
+    =
+  let p0, p1, p2, p3 = waypoint_prices in
+  let i0, i1, i2, i3 = waypoint_indices in
+  let append =
+    _append_segment_into ~random_state ~volatility_scale ~degrees_of_freedom
+      ~total_points ~low_bound ~high_bound ~out
   in
-  ({ price = p2 } : path_point) :: List.rev_append segment acc'
+  let cursor = append ~cursor:0 p0 p1 i0 i1 in
+  let cursor = append ~cursor p1 p2 i1 i2 in
+  append ~cursor p2 p3 i2 i3
 
-(* Interpolate between waypoints using Brownian bridge segments, accumulating
-   path points. Each segment is bridged from its start waypoint to its end
-   waypoint. The opening price is prepended on the first segment. *)
-let rec _generate_segments ~random_state ~volatility_scale ~degrees_of_freedom
-    ~total_points ~low_bound ~high_bound prices indices acc =
-  match (prices, indices) with
-  | p1 :: p2 :: rest_prices, idx1 :: idx2 :: rest_indices ->
-      let acc' =
-        _append_segment ~random_state ~volatility_scale ~degrees_of_freedom
-          ~total_points ~low_bound ~high_bound acc p1 p2 idx1 idx2
-      in
-      _generate_segments ~random_state ~volatility_scale ~degrees_of_freedom
-        ~total_points ~low_bound ~high_bound (p2 :: rest_prices)
-        (idx2 :: rest_indices) acc'
-  | _, _ -> List.rev acc
+(** Materialize the public [path_point list] from the populated prefix
+    [out.(0..len-1)]. This is the only required allocation per call. *)
+let _path_of_array (out : float array) ~len : intraday_path =
+  let acc = ref [] in
+  for i = len - 1 downto 0 do
+    acc := ({ price = out.(i) } : path_point) :: !acc
+  done;
+  !acc
 
-let generate_path ?(config = default_config) (bar : price_bar) : intraday_path =
+let _waypoint_prices_of_bar (bar : price_bar) ~high_first =
+  if high_first then
+    (bar.open_price, bar.high_price, bar.low_price, bar.close_price)
+  else (bar.open_price, bar.low_price, bar.high_price, bar.close_price)
+
+let _generate_path_with_scratch ~scratch ~config (bar : price_bar) :
+    intraday_path =
   let random_state =
     match config.seed with
     | Some seed -> Random.State.make [| seed |]
     | None -> Random.State.make_self_init ()
   in
   let high_first = _decide_high_first random_state bar in
-  let waypoint_prices =
-    if high_first then
-      [ bar.open_price; bar.high_price; bar.low_price; bar.close_price ]
-    else [ bar.open_price; bar.low_price; bar.high_price; bar.close_price ]
-  in
+  let waypoint_prices = _waypoint_prices_of_bar bar ~high_first in
   let waypoint_indices =
     _generate_waypoint_indices random_state config.profile config.total_points
   in
   let volatility_scale = _infer_volatility_scale bar in
   if config.total_points <= 4 then
-    List.map waypoint_prices ~f:(fun price -> ({ price } : path_point))
+    let p0, p1, p2, p3 = waypoint_prices in
+    [ { price = p0 }; { price = p1 }; { price = p2 }; { price = p3 } ]
   else
-    _generate_segments ~random_state ~volatility_scale
-      ~degrees_of_freedom:config.degrees_of_freedom
-      ~total_points:config.total_points ~low_bound:bar.low_price
-      ~high_bound:bar.high_price waypoint_prices waypoint_indices []
+    let len =
+      _generate_segments_into ~random_state ~volatility_scale
+        ~degrees_of_freedom:config.degrees_of_freedom
+        ~total_points:config.total_points ~low_bound:bar.low_price
+        ~high_bound:bar.high_price ~out:scratch.Scratch.path_points
+        ~waypoint_prices ~waypoint_indices
+    in
+    _path_of_array scratch.Scratch.path_points ~len
+
+let generate_path_into ~scratch ?(config = default_config) (bar : price_bar) :
+    intraday_path =
+  (* Required size matches [Scratch.for_config] so any buffer sized via that
+     helper is always accepted. *)
+  let required =
+    Int.max _min_scratch_capacity
+      (config.total_points + _capacity_slack_for_config)
+  in
+  if Scratch.capacity scratch < required then
+    invalid_arg
+      (Printf.sprintf
+         "Price_path.generate_path_into: scratch capacity %d < required %d"
+         (Scratch.capacity scratch) required);
+  _generate_path_with_scratch ~scratch ~config bar
+
+let generate_path ?(config = default_config) (bar : price_bar) : intraday_path =
+  _generate_path_with_scratch ~scratch:(Scratch.for_config config) ~config bar
 
 (** {1 Early Exit Optimization} *)
 

--- a/trading/trading/engine/lib/price_path.mli
+++ b/trading/trading/engine/lib/price_path.mli
@@ -54,6 +54,41 @@ val default_config : path_config
 (** Default path configuration: UShaped profile, 390 total points, no seed,
     df=4.0 *)
 
+(** {1 Reusable Scratch Buffer}
+
+    [Scratch.t] is a per-symbol mutable workspace for path generation. Allocate
+    one buffer at panel-build time (one per loaded symbol) and pass it to
+    [generate_path_into] on each tick — this avoids the per-tick allocation of
+    intermediate float arrays / list cells inside the Brownian bridge sampler.
+
+    The buffer is sized to hold any path up to a configured capacity.
+    [generate_path_into] writes only into the prefix it needs and returns a
+    fresh [intraday_path] of the appropriate length, so leftover state from
+    earlier calls is invisible to callers.
+
+    The buffer holds **only float prices** internally; the final
+    [path_point list] is materialized once per call as the return value.
+
+    Not thread-safe: a buffer must be owned by exactly one logical caller at a
+    time. The intended use pattern (one buffer per loaded symbol, threaded
+    through the simulator's per-tick loop) satisfies this naturally. *)
+module Scratch : sig
+  type t
+  (** Mutable scratch buffer for path generation. *)
+
+  val create : capacity:int -> t
+  (** Create a scratch buffer that can hold paths up to [capacity] points
+      (waypoints + interpolated points). Must be at least 4. *)
+
+  val for_config : path_config -> t
+  (** Convenience: create a scratch buffer sized for the given path config.
+      Capacity is set to [config.total_points + slack] to absorb the small
+      rounding overshoot from segment generation. *)
+
+  val capacity : t -> int
+  (** Return the buffer's capacity (max path length it can hold). *)
+end
+
 val generate_path : ?config:path_config -> price_bar -> intraday_path
 (** Generate realistic intraday price path from OHLC bar.
 
@@ -79,7 +114,22 @@ val generate_path : ?config:path_config -> price_bar -> intraday_path
     @return
       Intraday path with realistic microstructure. Length approximately matches
       config.total_points (default ~390), except when total_points <= 4 which
-      returns exactly 4 waypoints. *)
+      returns exactly 4 waypoints.
+
+    Allocates a fresh internal scratch buffer per call. For per-symbol hot-loop
+    callers, prefer [generate_path_into] with a reused buffer. *)
+
+val generate_path_into :
+  scratch:Scratch.t -> ?config:path_config -> price_bar -> intraday_path
+(** Same as [generate_path], but writes intermediate path samples into the given
+    [scratch] buffer instead of allocating fresh internal storage.
+
+    The output [intraday_path] is bit-identical to what [generate_path] would
+    produce for the same [config] and [bar] — buffer reuse only affects
+    allocation, not arithmetic.
+
+    @raise Invalid_argument
+      if [scratch] is too small to hold the path implied by [config]. *)
 
 val might_fill : price_bar -> side -> order_type -> bool
 (** Check if an order could possibly fill given OHLC bounds.

--- a/trading/trading/engine/test/dune
+++ b/trading/trading/engine/test/dune
@@ -18,3 +18,7 @@
 (test
  (name test_price_path)
  (libraries ounit2 core trading.engine trading.base matchers))
+
+(test
+ (name test_price_path_buffer_reuse)
+ (libraries ounit2 core trading.engine trading.base matchers))

--- a/trading/trading/engine/test/test_price_path_buffer_reuse.ml
+++ b/trading/trading/engine/test/test_price_path_buffer_reuse.ml
@@ -1,0 +1,199 @@
+(** Parity tests for the [Price_path.Scratch] buffer-reuse path.
+
+    These tests are the load-bearing parity gate for PR-2 of the engine-pooling
+    plan: any drift in [generate_path_into] vs [generate_path] (or any leftover
+    state across sequential calls sharing a scratch) shows up here as a
+    bit-equality failure.
+
+    The seeded golden tests in [test_price_path.ml] cover [generate_path] output
+    stability against pinned numeric values; this file complements them with the
+    *buffer reuse* invariants. *)
+
+open OUnit2
+open Core
+open Trading_engine.Types
+open Trading_engine.Price_path
+open Matchers
+
+(** {1 Helpers} *)
+
+let make_bar symbol ~open_price ~high_price ~low_price ~close_price =
+  { symbol; open_price; high_price; low_price; close_price }
+
+let bar_aapl =
+  make_bar "AAPL" ~open_price:100.0 ~high_price:110.0 ~low_price:95.0
+    ~close_price:105.0
+
+let bar_googl =
+  make_bar "GOOGL" ~open_price:200.0 ~high_price:215.0 ~low_price:198.0
+    ~close_price:212.0
+
+let bar_msft =
+  make_bar "MSFT" ~open_price:300.0 ~high_price:305.0 ~low_price:290.0
+    ~close_price:292.0
+
+let make_config ?(profile = Uniform) ?(total_points = 30) ~seed
+    ?(degrees_of_freedom = 4.0) () =
+  { profile; total_points; seed = Some seed; degrees_of_freedom }
+
+(** Compare two [intraday_path]s for bit-equal float prices. *)
+let path_bit_eq (a : intraday_path) (b : intraday_path) : bool =
+  List.equal
+    (fun (p1 : path_point) (p2 : path_point) -> Float.(p1.price = p2.price))
+    a b
+
+(** {1 R1: idempotence — same inputs + same scratch → same output} *)
+
+let test_buffer_reuse_idempotent _ =
+  (* Calling [generate_path_into] twice with the same scratch and the same
+     (seeded) inputs must yield bit-equal outputs. This pins the first-order
+     buffer-reuse invariant: no hidden state survives across calls. *)
+  let config = make_config ~seed:12345 ~total_points:30 () in
+  let scratch = Scratch.for_config config in
+  let path1 = generate_path_into ~scratch ~config bar_aapl in
+  let path2 = generate_path_into ~scratch ~config bar_aapl in
+  assert_that (path_bit_eq path1 path2) (equal_to true)
+
+(** {1 R2: no leftover state across different inputs} *)
+
+let test_buffer_reuse_different_inputs_match_fresh _ =
+  (* Sharing a scratch between two different bars must produce the same
+     output for the second bar as a fresh scratch would. This catches
+     leftover state from the first call leaking into the second. *)
+  let config = make_config ~seed:7 ~total_points:50 () in
+  let shared = Scratch.for_config config in
+  let _first = generate_path_into ~scratch:shared ~config bar_aapl in
+  let after_reuse = generate_path_into ~scratch:shared ~config bar_googl in
+  let fresh_scratch = Scratch.for_config config in
+  let from_fresh =
+    generate_path_into ~scratch:fresh_scratch ~config bar_googl
+  in
+  assert_that (path_bit_eq after_reuse from_fresh) (equal_to true)
+
+(** {1 R3: parity with the non-scratch entry point} *)
+
+let test_into_matches_generate_path _ =
+  (* [generate_path_into ~scratch] and [generate_path] must produce
+     bit-equal outputs for the same seeded config + bar. *)
+  let bars = [ bar_aapl; bar_googl; bar_msft ] in
+  let config = make_config ~seed:42 ~total_points:30 () in
+  let scratch = Scratch.for_config config in
+  List.iter bars ~f:(fun bar ->
+      let from_into = generate_path_into ~scratch ~config bar in
+      let from_plain = generate_path ~config bar in
+      assert_that (path_bit_eq from_into from_plain) (equal_to true))
+
+(** {1 R4: parity across all distribution profiles} *)
+
+let test_parity_all_profiles _ =
+  (* All four profiles must have generate_path_into ≡ generate_path. *)
+  let profiles = [ UShaped; JShaped; ReverseJ; Uniform ] in
+  List.iter profiles ~f:(fun profile ->
+      let config = make_config ~profile ~seed:99 ~total_points:40 () in
+      let scratch = Scratch.for_config config in
+      let from_into = generate_path_into ~scratch ~config bar_aapl in
+      let from_plain = generate_path ~config bar_aapl in
+      assert_that (path_bit_eq from_into from_plain) (equal_to true))
+
+(** {1 R5: parity at default (390-point) resolution} *)
+
+let test_parity_default_resolution _ =
+  (* The default config — what production uses — must round-trip through
+     scratch buffers. *)
+  let config = { default_config with seed = Some 2026 } in
+  let scratch = Scratch.for_config config in
+  let from_into = generate_path_into ~scratch ~config bar_aapl in
+  let from_plain = generate_path ~config bar_aapl in
+  assert_that (path_bit_eq from_into from_plain) (equal_to true)
+
+(** {1 R6: small-resolution edge case (total_points <= 4)} *)
+
+let test_waypoints_only_mode_reuse _ =
+  (* total_points <= 4 takes the "waypoints only" code path which doesn't
+     write to scratch. Reuse must still be safe and match the plain entry
+     point. *)
+  let config = make_config ~seed:42 ~total_points:4 () in
+  let scratch = Scratch.for_config config in
+  let path1 = generate_path_into ~scratch ~config bar_aapl in
+  let path2 = generate_path_into ~scratch ~config bar_aapl in
+  let from_plain = generate_path ~config bar_aapl in
+  assert_that
+    (path_bit_eq path1 path2 && path_bit_eq path1 from_plain)
+    (equal_to true)
+
+(** {1 R7: capacity validation} *)
+
+let test_too_small_scratch_raises _ =
+  (* If the user hands in a buffer too small for the requested config, we
+     must reject loudly (rather than silently writing past the end of the
+     array). *)
+  let small = Scratch.create ~capacity:10 in
+  let config = make_config ~seed:1 ~total_points:50 () in
+  let result =
+    try
+      let _ = generate_path_into ~scratch:small ~config bar_aapl in
+      `Ok
+    with Invalid_argument _ -> `Invalid_argument
+  in
+  assert_that result (equal_to `Invalid_argument)
+
+let test_create_below_min_raises _ =
+  let result =
+    try
+      let _ = Scratch.create ~capacity:2 in
+      `Ok
+    with Invalid_argument _ -> `Invalid_argument
+  in
+  assert_that result (equal_to `Invalid_argument)
+
+(** {1 R8: golden bit-equality with pinned values}
+
+    These bit-equality checks pin [generate_path_into] against the same golden
+    output asserted in [test_price_path.ml] for [generate_path]. If the refactor
+    drifted the floating-point order, this test would fail. *)
+
+let test_golden_bit_equality _ =
+  let bar = bar_aapl in
+  let config = make_config ~seed:12345 ~total_points:10 () in
+  let scratch = Scratch.for_config config in
+  let path = generate_path_into ~scratch ~config bar in
+  let expected : intraday_path =
+    [
+      { price = 100.0 };
+      { price = 100.86187228911206 };
+      { price = 102.40592847455183 };
+      { price = 103.76781747465134 };
+      { price = 106.35315965230939 };
+      { price = 108.0731149431833 };
+      { price = 109.94664616190269 };
+      { price = 110.0 };
+      { price = 95.0 };
+      { price = 95.0 };
+      { price = 100.10734547267361 };
+      { price = 104.09730483755989 };
+      { price = 105.0 };
+    ]
+  in
+  assert_that (path_bit_eq path expected) (equal_to true)
+
+(** {1 Test Suite} *)
+
+let suite =
+  "Price Path Buffer Reuse Tests"
+  >::: [
+         "buffer reuse: idempotent same inputs" >:: test_buffer_reuse_idempotent;
+         "buffer reuse: different inputs match fresh scratch"
+         >:: test_buffer_reuse_different_inputs_match_fresh;
+         "into matches generate_path" >:: test_into_matches_generate_path;
+         "parity across all distribution profiles" >:: test_parity_all_profiles;
+         "parity at default 390-point resolution"
+         >:: test_parity_default_resolution;
+         "waypoints-only mode reuse" >:: test_waypoints_only_mode_reuse;
+         "too-small scratch raises Invalid_argument"
+         >:: test_too_small_scratch_raises;
+         "Scratch.create below min capacity raises"
+         >:: test_create_below_min_raises;
+         "golden bit-equality with seed=12345" >:: test_golden_bit_equality;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR-2 of the engine-pooling plan (`dev/plans/engine-layer-pooling-2026-04-27.md`). Companion to PR #618 (PR-1, instrumentation).

Adds a per-symbol mutable scratch buffer for `Price_path` so the simulator's per-tick path generation stops allocating fresh `path_point list` accumulators inside `_generate_bridge_segment` / `_append_segment` / `_generate_segments`. The intermediate per-step price stream now writes directly into a pre-sized `float array` carried in `Price_path.Scratch.t`; the `path_point list` is materialized once at the end of generation as the return value.

`_sample_student_t`'s recursive sum-of-squares fold is rewritten as a `for` loop with a mutable accumulator. Same Random.State consumption order, same FP evaluation order — seeded goldens stay bit-equal.

## What pooled

- **`Price_path.Scratch.t`** — float-array workspace, one per loaded symbol (caller-owned). Sized via `Scratch.for_config` or directly via `Scratch.create ~capacity`.
- **`generate_path_into ~scratch ?config bar`** — new public entry that reuses the caller's buffer. Capacity-validated; raises `Invalid_argument` on undersized scratch rather than writing past the array.
- **`generate_path ?config bar`** — unchanged signature; now allocates a fresh scratch internally and delegates. No call-site break.

PR-2 stops at the engine module surface. Wiring `Engine.update_market` to actually thread one scratch per loaded symbol through the simulator loop is PR-3 scope per the plan §PR-3.

## What stayed the same

- Public path output (`intraday_path = path_point list`) and its content. Random.State consumption order. Floating-point evaluation order.
- All existing seeded goldens in `test_price_path.ml` (Uniform/UShaped/JShaped/ReverseJ at multiple `total_points`) remain bit-equal.
- `Engine.update_market` and its callers — unchanged.

## Test plan

New parity test `test_price_path_buffer_reuse.ml`:

- [x] **R1 — idempotence**: `generate_path_into` × 2 with same scratch + same seeded inputs → bit-equal output (no hidden state survives).
- [x] **R2 — no leftover state**: two different bars sharing one scratch; second-bar output matches a fresh-scratch run on the same bar (no first-call leakage).
- [x] **R3 — parity vs `generate_path`**: `generate_path_into` ≡ `generate_path` for AAPL / GOOGL / MSFT bars at `total_points = 30`.
- [x] **R4 — parity across all four distribution profiles** (Uniform / UShaped / JShaped / ReverseJ).
- [x] **R5 — parity at default 390-point resolution** (what production uses).
- [x] **R6 — small-resolution edge case** (`total_points <= 4`, waypoints-only path).
- [x] **R7 — capacity validation**: undersized scratch and below-min-capacity `Scratch.create` both raise `Invalid_argument`.
- [x] **R8 — golden bit-equality**: `generate_path_into` matches the seed=12345/total_points=10 golden pinned in `test_price_path.ml`.

Existing tests untouched — `test_price_path.ml`'s deterministic-with-seed goldens (the load-bearing FP-order parity check) all pass: `dune runtest trading/engine` is green.

Full suite: `TRADING_DATA_DIR=trading/test_data dune runtest` passes; `dune build @fmt` clean.

## PR sizing

- 4 files: `price_path.ml` (+97/-67), `price_path.mli` (+51/-1), `engine/test/dune` (+4/-0), new `test_price_path_buffer_reuse.ml` (+199/-0).
- Total ~400 LOC including the parity test (~200 LOC test). Within the plan's ~250 LOC PR-2 estimate (the parity test is the load-bearing gate, not optional).

## Branch note

Branch is `-v2` because a sibling agent session is still holding the original `feat/backtest-perf-engine-pool-scratch` worktree with identical in-flight (uncommitted) changes. This PR is the canonical landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
