### PR TITLE
feat(backtest-perf): thread Price_path.Scratch through per-tick loop (PR-3 of engine-pooling)

### DIFF
--- a/dev/notes/engine-pool-pr3-impact-2026-04-27.md
+++ b/dev/notes/engine-pool-pr3-impact-2026-04-27.md
@@ -1,0 +1,104 @@
+# PR-3 of engine-pooling — threading impact (2026-04-27)
+
+PR-3 (`feat/backtest-perf-engine-pool-thread`) wires `Price_path.Scratch.t`
+through `Engine.update_market` per-tick so the buffer-reuse path
+introduced in PR-2 (#626) is actually exercised on the hot loop.
+
+## What was threaded
+
+- `Engine.t` now owns a `(symbol, Price_path.Scratch.t) Hashtbl.t` —
+  one scratch buffer per loaded symbol, allocated lazily on first
+  sight of that symbol and re-used on every subsequent tick.
+- `Engine.update_market` replaces the single per-call
+  `Price_path.generate_path ~config:path_config bar` with
+  `Price_path.generate_path_into ~scratch ~config:path_config bar`
+  where `scratch` comes from the per-symbol table.
+- `Price_path.Scratch.required_capacity` was added to the public API so
+  the engine can decide whether an existing scratch is large enough
+  without allocating a throwaway scratch as a probe.
+- A new test `test_engine_scratch_threading_parity` pins bit-equality
+  between the reused-scratch path (one engine, N sequential
+  `update_market` calls) and the fresh-scratch path (N engines, one
+  call each) using a fixed seed. Catches any cross-call state leak
+  inside `Price_path` even though PR-2's tests already pin parity at
+  the `Price_path` level.
+
+## Per-call allocation reduction (architectural)
+
+Per the post-PR-A memtrace
+(`dev/notes/panels-memtrace-postA-2026-04-26.md`), the dominant
+per-tick allocators inside `Trading_engine.Price_path` were:
+
+| Allocator | sampled events | bytes allocated |
+|---|---|---|
+| `_decide_high_first_directional` | 1,034 | 4,183,712 |
+| `_sample_standard_normal` | 195,235 | 1,561,880 |
+| `_sample_student_t.sum_squares` | 84,951 | 1,463,808 |
+| `_append_segment` | 39,995 | 1,279,840 |
+| `_generate_bridge_segment.generate_points` | 45,766 | 1,464,512 |
+
+PR-2 already converted those allocators to write into `Scratch.t` —
+but only when the public API explicitly went through
+`generate_path_into`. The default `Engine.update_market` was still
+calling `generate_path`, which allocated a *fresh* `Scratch.t` per
+call (one float array of `total_points + slack ≈ 398` slots, plus the
+GC overhead of dropping it on the next tick).
+
+PR-3 promotes that scratch from a per-call alloc to a per-symbol
+field, so steady-state allocation inside `Price_path` per
+`update_market` call drops to:
+
+- **Before PR-3**: one fresh `Scratch.t` allocation
+  (`float array` of ~398 slots = 3,184 bytes) + the final
+  `path_point list` (~390 cons cells) per call, per symbol.
+- **After PR-3**: just the final `path_point list`. The `Scratch.t`
+  is touched in place; no float-array allocation per call after the
+  symbol's first day.
+
+## Sample size in production
+
+For the canonical `bull-crash-292x6y` matrix run (292 symbols, 6
+years ≈ 1,500 trading days), `update_market` is called
+292 × 1,500 ≈ 438,000 times. Each call previously allocated a
+`Scratch.t` (~3.2 KB float array + header). PR-3 collapses that to
+the 292 first-day allocations and zero thereafter — a reduction of
+**437,708 array allocations × ~3.2 KB ≈ 1.4 GB of array-only
+allocation traffic** moved off the per-tick path.
+
+That's not the full picture — the `path_point list` materialization
+inside `_path_of_array` still allocates per call (the public contract
+still returns a fresh list). PR-2's agent flagged that as the next
+target ("PR-4: transient buffer pool for one-off workspaces").
+
+## Verification
+
+- `dune build && dune runtest` green inside the worktree with
+  `TRADING_DATA_DIR=…/test_data`.
+- `dune build @fmt` clean.
+- `test_panel_loader_parity` (the load-bearing parity gate) passes
+  bit-equality on both `tiered-loader-parity` and
+  `panel-golden-2019-full` scenarios — confirming PR-3's threading
+  produces identical trade output to PR-2.
+- New `test_engine_scratch_threading_parity` pins the engine-level
+  reuse contract: same engine reused across N seeded calls produces
+  the same fill prices as N fresh engines, one call each.
+
+## Memtrace re-run (deferred)
+
+A full memtrace re-run on the 292×6y matrix would tell us how much of
+the cumulative `Price_path` allocation attribution drops post-PR-3.
+That requires the full `bull-crash-292x6y` data fixture and a wall
+budget of ~5 minutes. Deferred to PR-5 of the engine-pooling plan
+("matrix re-run validation") which lands all four PRs together.
+
+For now, the architectural argument above + the bit-equality parity
+gate are sufficient to confirm PR-3 is doing what it claims:
+threading the existing PR-2 buffer-reuse plumbing through to the
+actual per-tick callsite.
+
+## References
+
+- Plan: `dev/plans/engine-layer-pooling-2026-04-27.md` §PR-3
+- PR-2 (companion): #626
+- Triggering memtrace: `dev/notes/panels-memtrace-postA-2026-04-26.md`
+- Phase-1 GC instrumentation: #618

--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -1,6 +1,6 @@
 # Status: backtest-perf
 
-## Last updated: 2026-04-27
+## Last updated: 2026-04-27 (PR-3 of engine-pooling)
 
 ## Status
 IN_PROGRESS
@@ -17,10 +17,15 @@ at `feat/backtest-perf-tier3-weekly` on 2026-04-27**:
 tier-3 cells (`perf-sweep/{bull-1y, bull-3y}`), 2 h/cell budget,
 cron `0 7 * * 1` (Monday 00:00 PT). **Engine-layer-pooling PR-1
 (Gc.stat instrumentation, panel_runner per-step snapshots) merged
-via PR #618 on 2026-04-27**; PR-2..PR-4 (per-symbol scratch +
-float-array buffers + buffer pooling) gated on a 3-month
-full-universe gc-trace run that confirms the engine-update-market
-wedge. Step 5 (release_perf_report OCaml exe) tracked separately;
+via PR #618 on 2026-04-27**; **PR-2 (per-symbol Scratch type +
+buffer-reusing internal helpers + parity gate) merged via PR #626
+on 2026-04-27**; **PR-3 (thread Scratch through `Engine.update_market`
+per-tick loop) opened at `feat/backtest-perf-engine-pool-thread` on
+2026-04-27 — collapses per-tick float-array allocs to per-symbol-once;
+parity-tested via `test_panel_loader_parity` and
+`test_engine_scratch_threading_parity`**; PR-4 (transient buffer pool
+for one-off workspaces) and PR-5 (matrix re-run validation) still
+outstanding. Step 5 (release_perf_report OCaml exe) tracked separately;
 landed via #585 / #606 on the test-data + perf-runner side. Tier-4
 release-gate scenarios structurally unblocked since data-panels
 Stage 4.5 PR-B (#604) merged 2026-04-27T02:33Z.
@@ -63,6 +68,20 @@ mechanics + release-gate procedure.
   `Engine.update_market` is the dominant per-tick allocator before
   the buffer-reuse refactors land (PR-2..PR-4 per
   `dev/plans/engine-layer-pooling-2026-04-27.md`).
+- **`feat/backtest-perf-engine-pool-thread`** (engine-pooling PR-3) —
+  open for review. Threads `Price_path.Scratch.t` through
+  `Engine.update_market` per-tick by giving `Engine.t` a
+  `(symbol, Scratch.t) Hashtbl.t` and replacing the
+  `Price_path.generate_path` call site with `generate_path_into ~scratch`.
+  Adds `Price_path.Scratch.required_capacity` to make the per-symbol
+  re-allocation decision pure (no throwaway probe scratch). New
+  `test_engine_scratch_threading_parity` pins bit-equality between a
+  reused engine and N fresh engines. Bit-exact parity vs PR-2
+  validated by `test_panel_loader_parity` on both `tiered-loader-parity`
+  and `panel-golden-2019-full` scenarios.
+  See `dev/notes/engine-pool-pr3-impact-2026-04-27.md` for the
+  per-call allocation breakdown (~3.2 KB float-array alloc dropped
+  per `update_market` call after the symbol's first day).
 - **`feat/backtest-perf-tier3-weekly`** (Step 4 — tier-3 weekly) —
   open for review. Adds `dev/scripts/perf_tier3_weekly.sh` +
   `.github/workflows/perf-weekly.yml`. Auto-discovers both

--- a/trading/trading/engine/lib/engine.ml
+++ b/trading/trading/engine/lib/engine.ml
@@ -7,13 +7,52 @@ open Types
 type t = {
   config : engine_config;
   market_state : (symbol, intraday_path) Hashtbl.t;
+  path_scratches : (symbol, Price_path.Scratch.t) Hashtbl.t;
 }
+(** Per-symbol scratch buffers for [Price_path] path generation. PR-3 of the
+    engine-pooling plan ([dev/plans/engine-layer-pooling.md]) threads these
+    through the per-tick [update_market] loop so the dominant per-tick
+    allocation (Brownian-bridge intermediate float arrays inside [Price_path])
+    drops to zero after each symbol's first day.
 
-let create config = { config; market_state = Hashtbl.create (module String) }
+    Lazy creation: a scratch is allocated on first sight of a symbol, sized to
+    the [path_config] passed in that call. If a later [update_market] call
+    arrives with a larger [total_points] than the cached scratch can hold, the
+    scratch is grown lazily by re-allocation. Across a typical backtest
+    [path_config] is constant, so the post-warmup steady state is one
+    pre-allocated scratch per symbol and zero allocation per [update_market]
+    inside [Price_path].
+
+    Not thread-safe: see {!Price_path.Scratch} — one scratch per logical caller
+    (here, per symbol) and the engine is single-threaded by construction. *)
+
+let create config =
+  {
+    config;
+    market_state = Hashtbl.create (module String);
+    path_scratches = Hashtbl.create (module String);
+  }
+
+(* Look up (or lazily create) a [Price_path.Scratch.t] for [symbol] sized for
+   [path_config]. The capacity probe is pure — no scratch is allocated unless
+   one is actually missing or too small. *)
+let _scratch_for_symbol engine ~symbol ~path_config =
+  let required = Price_path.Scratch.required_capacity path_config in
+  match Hashtbl.find engine.path_scratches symbol with
+  | Some scratch when Price_path.Scratch.capacity scratch >= required -> scratch
+  | _ ->
+      let scratch = Price_path.Scratch.for_config path_config in
+      Hashtbl.set engine.path_scratches ~key:symbol ~data:scratch;
+      scratch
 
 let update_market ?(path_config = Price_path.default_config) engine bars =
   List.iter bars ~f:(fun bar ->
-      let path = Price_path.generate_path ~config:path_config bar in
+      let scratch =
+        _scratch_for_symbol engine ~symbol:bar.symbol ~path_config
+      in
+      let path =
+        Price_path.generate_path_into ~scratch ~config:path_config bar
+      in
       Hashtbl.set engine.market_state ~key:bar.symbol ~data:path)
 
 let _calculate_commission config quantity =

--- a/trading/trading/engine/lib/price_path.ml
+++ b/trading/trading/engine/lib/price_path.ml
@@ -47,12 +47,10 @@ module Scratch = struct
            capacity _min_scratch_capacity);
     { path_points = Array.create ~len:capacity 0.0 }
 
-  let for_config (c : path_config) =
-    create
-      ~capacity:
-        (Int.max _min_scratch_capacity
-           (c.total_points + _capacity_slack_for_config))
+  let required_capacity (c : path_config) =
+    Int.max _min_scratch_capacity (c.total_points + _capacity_slack_for_config)
 
+  let for_config (c : path_config) = create ~capacity:(required_capacity c)
   let capacity t = Array.length t.path_points
 end
 
@@ -454,10 +452,7 @@ let generate_path_into ~scratch ?(config = default_config) (bar : price_bar) :
     intraday_path =
   (* Required size matches [Scratch.for_config] so any buffer sized via that
      helper is always accepted. *)
-  let required =
-    Int.max _min_scratch_capacity
-      (config.total_points + _capacity_slack_for_config)
-  in
+  let required = Scratch.required_capacity config in
   if Scratch.capacity scratch < required then
     invalid_arg
       (Printf.sprintf

--- a/trading/trading/engine/lib/price_path.mli
+++ b/trading/trading/engine/lib/price_path.mli
@@ -85,6 +85,12 @@ module Scratch : sig
       Capacity is set to [config.total_points + slack] to absorb the small
       rounding overshoot from segment generation. *)
 
+  val required_capacity : path_config -> int
+  (** Capacity the buffer needs to hold the path implied by [config]. Pure —
+      does not allocate. Use this to compare against an existing scratch's
+      [capacity] before deciding whether to re-allocate (see
+      {!Engine.update_market}, which threads scratches per symbol). *)
+
   val capacity : t -> int
   (** Return the buffer's capacity (max path length it can hold). *)
 end

--- a/trading/trading/engine/test/test_engine.ml
+++ b/trading/trading/engine/test/test_engine.ml
@@ -954,10 +954,88 @@ let test_stop_order_deterministic_slippage _ =
       assert_that trade.price (float_equal ~epsilon:0.000001 103.143016)
   | _ -> assert_failure "Expected one filled report"
 
+(* PR-3 of the engine-pooling plan threads a per-symbol [Price_path.Scratch.t]
+   through [Engine.update_market] so that the path-generation scratch buffer
+   is reused across calls instead of being allocated fresh per tick. The
+   load-bearing constraint is bit-equality with the pre-PR-3 simulator output:
+   buffer reuse must only affect allocation, never arithmetic.
+
+   This test exercises the engine seam directly: with a fixed seed, a single
+   reused engine processing N consecutive bars must produce the same fill
+   prices that N independently-created engines would. Failure means scratch
+   reuse leaked state between calls. The test pairs with the lower-level
+   [test_price_path_buffer_reuse] which pins parity at the [Price_path]
+   level, and the higher-level [test_panel_loader_parity] which pins the
+   end-to-end backtest output. *)
+let _fill_price_for_market_buy ~engine ~order_mgr ~bar =
+  update_market
+    ~path_config:{ default_config with seed = Some 7 }
+    engine [ bar ];
+  match process_orders engine order_mgr with
+  | Ok [ report ] -> (
+      match report.trades with
+      | [ t ] -> t.price
+      | _ -> assert_failure "Expected exactly one trade in fill report")
+  | _ -> assert_failure "Expected exactly one filled report"
+
+let test_engine_scratch_threading_parity _ =
+  (* Three sequential bars on the same symbol. With seeded path generation,
+     the engine that reuses its per-symbol scratch must produce the same fill
+     prices as three fresh engines processing one bar each. *)
+  let bars =
+    [
+      make_bar "AAPL" ~open_price:100.0 ~high_price:110.0 ~low_price:95.0
+        ~close_price:105.0;
+      make_bar "AAPL" ~open_price:105.0 ~high_price:108.0 ~low_price:102.0
+        ~close_price:107.5;
+      make_bar "AAPL" ~open_price:107.5 ~high_price:115.0 ~low_price:106.0
+        ~close_price:113.0;
+    ]
+  in
+  let new_setup () =
+    let config = make_config () in
+    let engine = create config in
+    let order_mgr = OrderManager.create () in
+    (engine, order_mgr)
+  in
+  let submit_market_buy order_mgr =
+    let params =
+      make_order_params ~symbol:"AAPL" ~side:Buy ~order_type:Market
+        ~quantity:100.0 ()
+    in
+    let order =
+      match create_order ~now_time:test_timestamp params with
+      | Ok o -> o
+      | Error err -> failwith ("Failed to create order: " ^ Status.show err)
+    in
+    submit_single_order order_mgr order
+  in
+  (* Reused-scratch path: one engine, three sequential update_market calls. *)
+  let reused_prices =
+    let engine, order_mgr = new_setup () in
+    List.map bars ~f:(fun bar ->
+        submit_market_buy order_mgr;
+        _fill_price_for_market_buy ~engine ~order_mgr ~bar)
+  in
+  (* Fresh-scratch path: three engines, each processes one bar. *)
+  let fresh_prices =
+    List.map bars ~f:(fun bar ->
+        let engine, order_mgr = new_setup () in
+        submit_market_buy order_mgr;
+        _fill_price_for_market_buy ~engine ~order_mgr ~bar)
+  in
+  (* Bit-equal float comparison via [equal_to] (no epsilon). The path
+     generator is fully deterministic given the seed, so any drift here means
+     the scratch reuse leaked state across calls. *)
+  assert_that reused_prices
+    (elements_are (List.map fresh_prices ~f:(fun p -> equal_to p)))
+
 (* Test suite *)
 let suite =
   "Engine Tests"
   >::: [
+         "test_engine_scratch_threading_parity"
+         >:: test_engine_scratch_threading_parity;
          "test_create_engine" >:: test_create_engine;
          "test_create_engine_with_custom_commission"
          >:: test_create_engine_with_custom_commission;


### PR DESCRIPTION
## Summary

PR-2 (#626) shipped `Price_path.Scratch` + the buffer-reusing `generate_path_into` entry point. **But scratch wasn't yet wired into the simulator's per-tick loop** — every tick still allocated a fresh `Price_path.Scratch.t` because the public `generate_path` did its own internal alloc, and `Engine.update_market` was still calling `generate_path`. PR-2's agent flagged this:

> PR-3 wires `Engine.update_market` / `Panel_runner` to actually allocate one scratch per loaded symbol and thread it through the simulator's per-tick loop — that's where the per-tick allocation actually drops to zero.

PR-3 does that.

## What changed

- **`Engine.t`** gains a `(symbol, Price_path.Scratch.t) Hashtbl.t`. Each `update_market` call looks up (or lazily creates) a scratch sized for the path config, then routes through `generate_path_into`. Steady state across a backtest: one pre-allocated scratch per symbol, zero per-call float-array alloc inside `Price_path`.
- **`Price_path.Scratch.required_capacity`** added to the public API so the engine can probe whether an existing scratch is large enough without allocating a throwaway scratch as the comparator. (PR-2's `for_config` always allocates.)
- **`generate_path_into`** internally uses the new `required_capacity` helper; net no behaviour change.
- **`test_engine_scratch_threading_parity`** pins bit-equality between a reused engine processing N seeded bars vs N fresh engines processing one bar each. Catches any cross-call state leak inside `Price_path` even though PR-2's tests already pin parity at the `Price_path` level.

## Why threading this is safe

`Price_path.generate_path_into` is documented (PR-2) to be bit-identical to `generate_path` — buffer reuse only affects allocation, not arithmetic. PR-2 already has 9 buffer-reuse tests pinning that contract. PR-3 just changes who allocates the scratch (engine, once per symbol) without changing what gets generated.

The load-bearing parity gate `test_panel_loader_parity` (which compares `round_trips` against checked-in goldens via bit-equal float comparison) passes on both `tiered-loader-parity` and `panel-golden-2019-full` scenarios. No metric drift.

## Per-call allocation impact

Before PR-3, every `update_market` call allocated:
- One `Price_path.Scratch.t` (`float array` of ~398 slots ≈ 3.2 KB header included).
- The final `path_point list` (~390 cons cells).

After PR-3:
- Just the final `path_point list`. Scratch is per-symbol and reused.

For the canonical `bull-crash-292x6y` matrix run (292 symbols × ~1,500 trading days = ~438K `update_market` calls), that's **~1.4 GB of array-only allocation traffic** moved off the per-tick path. The `path_point list` materialization (`_path_of_array`) is the next target — PR-2's agent flagged that for PR-4.

See `dev/notes/engine-pool-pr3-impact-2026-04-27.md` for the full breakdown.

## Test plan

- [x] `dune build && dune runtest` green inside the worktree (with `TRADING_DATA_DIR=…/test_data`)
- [x] `dune build @fmt` clean
- [x] `test_panel_loader_parity` passes bit-equality on both checked-in golden scenarios
- [x] New `test_engine_scratch_threading_parity` pins engine-level reuse contract
- [x] PR diff is 153 LOC of changes (well under 500), one new test, no new module

## Out of scope (deferred)

- PR-4 of engine-pooling: transient buffer pool for the `path_point list` materialization (the remaining per-tick allocation).
- PR-5 of engine-pooling: matrix re-run validation — running `bull-crash-292x6y` with `--gc-trace` and pinning the new minor_words delta. Deferred per the plan since it requires a 5-min wall budget and the full data fixture; a separate ticket once PR-3 + PR-4 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)