### PR TITLE
feat(backtest-perf): release_perf_report OCaml exe

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -82,6 +82,14 @@ mechanics + release-gate procedure.
   See `dev/notes/engine-pool-pr3-impact-2026-04-27.md` for the
   per-call allocation breakdown (~3.2 KB float-array alloc dropped
   per `update_market` call after the symbol's first day).
+- **`feat/backtest-perf-release-report`** (Step 6 — release_perf_report
+  OCaml exe) — open for review. Adds
+  `trading/trading/backtest/release_report/` library +
+  `trading/trading/backtest/bin/release_perf_report.ml` binary +
+  11-test fixture (`test_release_perf_report.ml`). Replaces the
+  deleted Python `perf_sweep_report.py`. End-to-end smoke verified:
+  feeding two synthetic scenario dirs reproduces the full markdown
+  shape including the `:rotating_light:` flag on +20% RSS regression.
 - **`feat/backtest-perf-tier3-weekly`** (Step 4 — tier-3 weekly) —
   open for review. Adds `dev/scripts/perf_tier3_weekly.sh` +
   `.github/workflows/perf-weekly.yml`. Auto-discovers both
@@ -227,15 +235,28 @@ mechanics + release-gate procedure.
    `perf-nightly.yml` once tier-2 budgets are pinned (~10 weeks of
    nightly data) and to `perf-weekly.yml` once tier-3 budgets are
    pinned (~10 weekly cycles).
-6. **`release_perf_report` OCaml exe.** Markdown report comparing the
-   current release's tier-3/4 scenario results vs the prior release —
-   N×T peak-RSS matrix, wall-time matrix, regression flags. Drives
-   release-gate Step 3 in `dev/plans/perf-scenario-catalog-2026-04-25.md`.
-   Replaces the deleted `dev/scripts/perf_sweep_report.py` (Legacy-vs-
-   Tiered axis is gone post-PR #575; need single-mode N×T tables instead).
-   Per `.claude/rules/no-python.md`: write fresh in OCaml, do not port.
-   Now lands as a follow-up after tier-3 weekly so the weekly run
-   has data to diff against. ~150 LOC exe + .mli + tests.
+6. (DONE on `feat/backtest-perf-release-report`) **`release_perf_report`
+   OCaml exe.** New library
+   `trading/trading/backtest/release_report/` (`release_report.{ml,mli}`,
+   `dune`) + binary `trading/trading/backtest/bin/release_perf_report.ml`
+   + 11 tests in `trading/trading/backtest/test/test_release_perf_report.ml`.
+   Reads two release `dev/backtest/scenarios-<ts>/` directories (each
+   subdirectory = one scenario with `actual.sexp`, `summary.sexp`, and
+   optional `peak_rss_kb.txt` / `wall_seconds.txt` sidecars from the
+   perf-tier runners), pairs scenarios by name, and emits a markdown
+   report with three matrices: trading metrics (return %, Sharpe, win
+   rate, max DD, trades, avg holding) side-by-side; peak-RSS (current
+   vs prior, ∆%); wall-time (current vs prior, ∆%). PR-level regression
+   flags fire when ∆% exceeds defaults from
+   `dev/plans/perf-scenario-catalog-2026-04-25.md` (RSS > +10%, wall
+   > +25%); both thresholds are CLI-overridable via
+   `--threshold-rss-pct N` / `--threshold-wall-pct M`. Verify:
+   `dune build trading/backtest/release_report
+   trading/backtest/bin/release_perf_report.exe` then run
+   `_build/default/trading/backtest/bin/release_perf_report.exe
+   --current <dir> --prior <dir>`; tests via
+   `dune test trading/backtest/test/test_release_perf_report.exe`
+   (11/11 PASS). Pure OCaml per `.claude/rules/no-python.md`.
 
 ## Ownership
 

--- a/trading/trading/backtest/bin/dune
+++ b/trading/trading/backtest/bin/dune
@@ -1,5 +1,6 @@
 (executable
  (name backtest_runner)
+ (modules backtest_runner)
  (libraries
   core
   core_unix
@@ -8,3 +9,8 @@
   weinstein.data_source
   trading.backtest.runner_args
   backtest))
+
+(executable
+ (name release_perf_report)
+ (modules release_perf_report)
+ (libraries core trading.backtest.release_report))

--- a/trading/trading/backtest/bin/release_perf_report.ml
+++ b/trading/trading/backtest/bin/release_perf_report.ml
@@ -1,0 +1,70 @@
+(** Release perf report — compare scenario outputs from two batch directories
+    and print a markdown comparison report.
+
+    Usage: release_perf_report --current <dir> --prior <dir>
+    [--threshold-rss-pct N] [--threshold-wall-pct M]
+
+    Both [--current] and [--prior] are required. Each must point at a directory
+    of the shape produced by [scenario_runner.ml] —
+    {v
+      <dir>/<scenario>/actual.sexp
+      <dir>/<scenario>/summary.sexp
+      <dir>/<scenario>/peak_rss_kb.txt    (optional)
+      <dir>/<scenario>/wall_seconds.txt   (optional)
+    v}
+
+    Markdown is written to stdout. The exe never reads from a network or invokes
+    the backtest runner — it only diffs already-on-disk batches. *)
+
+open Core
+
+type _cli_args = {
+  current : string;
+  prior : string;
+  thresholds : Release_report.thresholds;
+}
+
+let _usage () =
+  eprintf
+    "Usage: release_perf_report --current <dir> --prior <dir> \
+     [--threshold-rss-pct N] [--threshold-wall-pct M]\n";
+  Stdlib.exit 1
+
+let _parse_flag args =
+  let rec loop args current prior thresholds =
+    match args with
+    | [] ->
+        let current = match current with Some v -> v | None -> _usage () in
+        let prior = match prior with Some v -> v | None -> _usage () in
+        { current; prior; thresholds }
+    | "--current" :: v :: rest -> loop rest (Some v) prior thresholds
+    | "--prior" :: v :: rest -> loop rest current (Some v) thresholds
+    | "--threshold-rss-pct" :: v :: rest ->
+        let thresholds =
+          {
+            thresholds with
+            Release_report.threshold_rss_pct = Float.of_string v;
+          }
+        in
+        loop rest current prior thresholds
+    | "--threshold-wall-pct" :: v :: rest ->
+        let thresholds =
+          {
+            thresholds with
+            Release_report.threshold_wall_pct = Float.of_string v;
+          }
+        in
+        loop rest current prior thresholds
+    | _ -> _usage ()
+  in
+  loop args None None Release_report.default_thresholds
+
+let _parse_args () =
+  let argv = Sys.get_argv () in
+  _parse_flag (List.tl_exn (Array.to_list argv))
+
+let () =
+  let { current; prior; thresholds } = _parse_args () in
+  let comparison = Release_report.load ~current ~prior in
+  let md = Release_report.render ~thresholds comparison in
+  print_string md

--- a/trading/trading/backtest/release_report/dune
+++ b/trading/trading/backtest/release_report/dune
@@ -1,0 +1,6 @@
+(library
+ (name release_report)
+ (public_name trading.backtest.release_report)
+ (libraries core core_unix core_unix.sys_unix)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/release_report/release_report.ml
+++ b/trading/trading/backtest/release_report/release_report.ml
@@ -1,0 +1,280 @@
+open Core
+
+type actual = {
+  total_return_pct : float;
+  total_trades : float;
+  win_rate : float;
+  sharpe_ratio : float;
+  max_drawdown_pct : float;
+  avg_holding_days : float;
+  unrealized_pnl : float option; [@sexp.option]
+}
+[@@deriving sexp] [@@sexp.allow_extra_fields]
+
+type summary_meta = {
+  start_date : Date.t;
+  end_date : Date.t;
+  universe_size : int;
+  n_steps : int;
+  initial_cash : float;
+  final_portfolio_value : float;
+}
+[@@deriving sexp] [@@sexp.allow_extra_fields]
+
+type scenario_run = {
+  name : string;
+  actual : actual;
+  summary : summary_meta;
+  peak_rss_kb : int option;
+  wall_seconds : float option;
+}
+[@@deriving sexp]
+
+type t = {
+  current_label : string;
+  prior_label : string;
+  paired : (scenario_run * scenario_run) list;
+  current_only : string list;
+  prior_only : string list;
+}
+[@@deriving sexp]
+
+type thresholds = { threshold_rss_pct : float; threshold_wall_pct : float }
+[@@deriving sexp]
+
+let default_thresholds = { threshold_rss_pct = 10.0; threshold_wall_pct = 25.0 }
+
+(* --- File helpers --- *)
+
+let _read_first_line path =
+  try
+    let ic = In_channel.create path in
+    let line = In_channel.input_line ic in
+    In_channel.close ic;
+    Option.bind line ~f:(fun s ->
+        let s = String.strip s in
+        if String.is_empty s then None else Some s)
+  with _ -> None
+
+let _read_optional_int path =
+  Option.bind (_read_first_line path) ~f:(fun s ->
+      try Some (Int.of_string s) with _ -> None)
+
+let _read_optional_float path =
+  Option.bind (_read_first_line path) ~f:(fun s ->
+      try Some (Float.of_string s) with _ -> None)
+
+let load_scenario_run ~dir =
+  let name = Filename.basename dir in
+  let actual_path = Filename.concat dir "actual.sexp" in
+  let summary_path = Filename.concat dir "summary.sexp" in
+  if not (Sys_unix.file_exists_exn actual_path) then
+    failwithf "Missing actual.sexp in %s" dir ();
+  if not (Sys_unix.file_exists_exn summary_path) then
+    failwithf "Missing summary.sexp in %s" dir ();
+  let actual = actual_of_sexp (Sexp.load_sexp actual_path) in
+  let summary = summary_meta_of_sexp (Sexp.load_sexp summary_path) in
+  let peak_rss_kb =
+    _read_optional_int (Filename.concat dir "peak_rss_kb.txt")
+  in
+  let wall_seconds =
+    _read_optional_float (Filename.concat dir "wall_seconds.txt")
+  in
+  { name; actual; summary; peak_rss_kb; wall_seconds }
+
+let _list_scenario_subdirs root =
+  if not (Sys_unix.is_directory_exn root) then
+    failwithf "Batch dir is not a directory: %s" root ();
+  Sys_unix.ls_dir root
+  |> List.sort ~compare:String.compare
+  |> List.filter_map ~f:(fun entry ->
+      let path = Filename.concat root entry in
+      if
+        Sys_unix.is_directory_exn path
+        && Sys_unix.file_exists_exn (Filename.concat path "actual.sexp")
+      then Some entry
+      else None)
+
+let _label_of_dir dir =
+  match Filename.basename dir with "" -> dir | name -> name
+
+let _pair_scenarios ~current_runs ~prior_runs =
+  let by_name runs =
+    List.map runs ~f:(fun (r : scenario_run) -> (r.name, r))
+    |> Map.of_alist_exn (module String)
+  in
+  let current_map = by_name current_runs in
+  let prior_map = by_name prior_runs in
+  let names_current = Map.key_set current_map in
+  let names_prior = Map.key_set prior_map in
+  let common = Set.inter names_current names_prior |> Set.to_list in
+  let only_current = Set.diff names_current names_prior |> Set.to_list in
+  let only_prior = Set.diff names_prior names_current |> Set.to_list in
+  let paired =
+    List.map common ~f:(fun name ->
+        (Map.find_exn current_map name, Map.find_exn prior_map name))
+  in
+  (paired, only_current, only_prior)
+
+let load ~current ~prior =
+  let load_batch root =
+    let subdirs = _list_scenario_subdirs root in
+    List.map subdirs ~f:(fun name ->
+        load_scenario_run ~dir:(Filename.concat root name))
+  in
+  let current_runs = load_batch current in
+  let prior_runs = load_batch prior in
+  let paired, current_only, prior_only =
+    _pair_scenarios ~current_runs ~prior_runs
+  in
+  {
+    current_label = _label_of_dir current;
+    prior_label = _label_of_dir prior;
+    paired;
+    current_only;
+    prior_only;
+  }
+
+(* --- Rendering helpers --- *)
+
+let _delta_pct ~current ~prior =
+  if Float.equal prior 0.0 then None
+  else Some ((current -. prior) /. prior *. 100.0)
+
+let _fmt_delta_pct = function None -> "n/a" | Some d -> sprintf "%+.1f%%" d
+let _fmt_float_2 v = sprintf "%.2f" v
+let _fmt_float_1 v = sprintf "%.1f" v
+let _fmt_int_opt = function Some i -> Int.to_string i | None -> "n/a"
+let _fmt_float_opt_1 = function Some f -> sprintf "%.1f" f | None -> "n/a"
+
+let _delta_int_pct ~current ~prior =
+  match (current, prior) with
+  | Some c, Some p ->
+      _delta_pct ~current:(Float.of_int c) ~prior:(Float.of_int p)
+  | _ -> None
+
+let _delta_float_pct ~current ~prior =
+  match (current, prior) with
+  | Some c, Some p -> _delta_pct ~current:c ~prior:p
+  | _ -> None
+
+(* --- Section renderers ---
+
+   Each renderer returns a list of lines (no trailing newline). The top-level
+   [render] joins everything with "\n" and adds a final newline. *)
+
+let _section_header ~title ~current ~prior =
+  [
+    sprintf "# %s" title;
+    "";
+    sprintf "- Current: `%s`" current;
+    sprintf "- Prior:   `%s`" prior;
+    "";
+  ]
+
+let _flag ~delta_pct ~threshold =
+  match delta_pct with
+  | Some d when Float.(d > threshold) -> " :rotating_light:"
+  | _ -> ""
+
+let _row_trading_metrics (cur, prior) =
+  let row label fmt get =
+    sprintf "| %s | %s | %s | %s |" label
+      (fmt (get cur.actual))
+      (fmt (get prior.actual))
+      (_fmt_delta_pct
+         (_delta_pct ~current:(get cur.actual) ~prior:(get prior.actual)))
+  in
+  [
+    sprintf "### %s" cur.name;
+    "";
+    sprintf "Period: %s → %s · Universe: %d · Steps: %d"
+      (Date.to_string cur.summary.start_date)
+      (Date.to_string cur.summary.end_date)
+      cur.summary.universe_size cur.summary.n_steps;
+    "";
+    "| Metric | Current | Prior | Δ% |";
+    "|---|---:|---:|---:|";
+    row "Return %" _fmt_float_2 (fun a -> a.total_return_pct);
+    row "Sharpe" _fmt_float_2 (fun a -> a.sharpe_ratio);
+    row "Win rate %" _fmt_float_1 (fun a -> a.win_rate);
+    row "Max DD %" _fmt_float_2 (fun a -> a.max_drawdown_pct);
+    row "Trades" _fmt_float_1 (fun a -> a.total_trades);
+    row "Avg hold (d)" _fmt_float_2 (fun a -> a.avg_holding_days);
+    "";
+  ]
+
+let _trading_section paired =
+  if List.is_empty paired then
+    [ "## Trading metrics"; ""; "_No paired scenarios._"; "" ]
+  else
+    let header = [ "## Trading metrics"; "" ] in
+    let body = List.concat_map paired ~f:_row_trading_metrics in
+    header @ body
+
+let _row_rss ~thresholds (cur, prior) =
+  let cur_rss = cur.peak_rss_kb in
+  let prior_rss = prior.peak_rss_kb in
+  let delta = _delta_int_pct ~current:cur_rss ~prior:prior_rss in
+  let flag = _flag ~delta_pct:delta ~threshold:thresholds.threshold_rss_pct in
+  sprintf "| %s | %s | %s | %s%s |" cur.name (_fmt_int_opt cur_rss)
+    (_fmt_int_opt prior_rss) (_fmt_delta_pct delta) flag
+
+let _rss_section ~thresholds paired =
+  let header =
+    [
+      "## Peak RSS (kB)";
+      "";
+      sprintf "Regression flag: Δ%% > %.0f%%" thresholds.threshold_rss_pct;
+      "";
+      "| Scenario | Current | Prior | Δ% |";
+      "|---|---:|---:|---:|";
+    ]
+  in
+  let body = List.map paired ~f:(_row_rss ~thresholds) in
+  let footer = [ "" ] in
+  header @ body @ footer
+
+let _row_wall ~thresholds (cur, prior) =
+  let cur_wall = cur.wall_seconds in
+  let prior_wall = prior.wall_seconds in
+  let delta = _delta_float_pct ~current:cur_wall ~prior:prior_wall in
+  let flag = _flag ~delta_pct:delta ~threshold:thresholds.threshold_wall_pct in
+  sprintf "| %s | %s | %s | %s%s |" cur.name
+    (_fmt_float_opt_1 cur_wall)
+    (_fmt_float_opt_1 prior_wall)
+    (_fmt_delta_pct delta) flag
+
+let _wall_section ~thresholds paired =
+  let header =
+    [
+      "## Wall time (s)";
+      "";
+      sprintf "Regression flag: Δ%% > %.0f%%" thresholds.threshold_wall_pct;
+      "";
+      "| Scenario | Current | Prior | Δ% |";
+      "|---|---:|---:|---:|";
+    ]
+  in
+  let body = List.map paired ~f:(_row_wall ~thresholds) in
+  let footer = [ "" ] in
+  header @ body @ footer
+
+let _one_sided_section ~title names =
+  if List.is_empty names then []
+  else
+    let header = [ sprintf "## %s" title; "" ] in
+    let body = List.map names ~f:(fun n -> sprintf "- `%s`" n) in
+    header @ body @ [ "" ]
+
+let render ?(thresholds = default_thresholds) (t : t) =
+  let lines =
+    _section_header ~title:"Release perf report" ~current:t.current_label
+      ~prior:t.prior_label
+    @ _trading_section t.paired
+    @ _rss_section ~thresholds t.paired
+    @ _wall_section ~thresholds t.paired
+    @ _one_sided_section ~title:"Current-only scenarios" t.current_only
+    @ _one_sided_section ~title:"Prior-only scenarios" t.prior_only
+  in
+  String.concat ~sep:"\n" lines ^ "\n"

--- a/trading/trading/backtest/release_report/release_report.mli
+++ b/trading/trading/backtest/release_report/release_report.mli
@@ -1,0 +1,115 @@
+(** Release perf report — compare two batches of scenario runs (a "current" and
+    a "prior" release-gate run) and emit a markdown report.
+
+    Each batch is a directory of the shape produced by
+    {!Backtest.Result_writer.write} alongside [scenario_runner.ml]'s
+    [actual.sexp]:
+
+    {v
+    <batch-dir>/
+      <scenario-name>/
+        actual.sexp        — total_return_pct, sharpe_ratio, ...
+        summary.sexp       — start/end dates, universe size, metrics
+        peak_rss_kb.txt    — optional, integer kB (one line)
+        wall_seconds.txt   — optional, integer or float seconds (one line)
+    v}
+
+    The report compares scenario-by-scenario:
+
+    - Trading metrics (return %, Sharpe, win rate, max DD) — current vs prior
+      side-by-side, with a delta column.
+    - Peak RSS matrix — current vs prior, ∆%, with a regression flag when ∆%
+      exceeds [threshold_rss_pct].
+    - Wall-time matrix — current vs prior, ∆%, with a regression flag when ∆%
+      exceeds [threshold_wall_pct].
+
+    Only scenarios present in both batches are diffed; scenarios in only one
+    side are listed under "current-only" / "prior-only".
+
+    The library is pure: [load] reads from disk, [render] is a deterministic
+    pure function on the loaded value. Tests pin the markdown by feeding
+    synthetic [t] values directly into [render]. *)
+
+open Core
+
+type actual = {
+  total_return_pct : float;
+  total_trades : float;
+  win_rate : float;
+  sharpe_ratio : float;
+  max_drawdown_pct : float;
+  avg_holding_days : float;
+  unrealized_pnl : float option;
+}
+[@@deriving sexp]
+(** Trading metrics extracted from a scenario's [actual.sexp]. Mirrors the
+    fields written by [scenario_runner.ml]'s [_actual_of_result], with
+    [unrealized_pnl] optional for backward-compat with pre-#393 actuals that
+    omit the field. *)
+
+type summary_meta = {
+  start_date : Date.t;
+  end_date : Date.t;
+  universe_size : int;
+  n_steps : int;
+  initial_cash : float;
+  final_portfolio_value : float;
+}
+[@@deriving sexp]
+(** Run-shape metadata extracted from a scenario's [summary.sexp]. We only pull
+    the run-identifying fields that are useful in a comparison header; detailed
+    per-metric data is already in [actual]. *)
+
+type scenario_run = {
+  name : string;
+  actual : actual;
+  summary : summary_meta;
+  peak_rss_kb : int option;
+  wall_seconds : float option;
+}
+[@@deriving sexp]
+(** One scenario's per-run readings — the [actual] block plus optional
+    infra-perf measurements. Both [peak_rss_kb] and [wall_seconds] are [None]
+    when the corresponding sibling files are absent in the batch dir; the report
+    still renders trading metrics in that case. *)
+
+type t = {
+  current_label : string;
+      (** Display label for the current side of the comparison (e.g. the batch
+          dir name). *)
+  prior_label : string;  (** Display label for the prior side. *)
+  paired : (scenario_run * scenario_run) list;
+      (** Scenarios with a run on both sides, sorted by name. *)
+  current_only : string list;
+      (** Scenario names found only in the current batch, sorted. *)
+  prior_only : string list;
+      (** Scenario names found only in the prior batch, sorted. *)
+}
+[@@deriving sexp]
+(** A loaded comparison: a list of (current, prior) pairs for scenarios present
+    in both batches, plus the names of any one-sided scenarios. *)
+
+type thresholds = { threshold_rss_pct : float; threshold_wall_pct : float }
+[@@deriving sexp]
+(** Regression-flag thresholds — a per-scenario regression is flagged if
+    [(current - prior) / prior * 100 > threshold]. Defaults match the
+    release-gate procedure in [dev/plans/perf-scenario-catalog-2026-04-25.md]:
+    RSS regression > 10%, wall regression > 25%. *)
+
+val default_thresholds : thresholds
+(** [{ threshold_rss_pct = 10.0; threshold_wall_pct = 25.0 }]. *)
+
+val load_scenario_run : dir:string -> scenario_run
+(** Read [actual.sexp], [summary.sexp], and (optionally) [peak_rss_kb.txt] and
+    [wall_seconds.txt] from a single scenario subdirectory. The scenario name is
+    taken from the basename of [dir]. Raises [Failure] if [actual.sexp] or
+    [summary.sexp] is missing or malformed. *)
+
+val load : current:string -> prior:string -> t
+(** Load both batch directories and pair scenarios by name. Each batch directory
+    is expected to contain one subdirectory per scenario. *)
+
+val render : ?thresholds:thresholds -> t -> string
+(** Render the comparison as a markdown report (returned as a string). Defaults
+    to {!default_thresholds}. The output is deterministic for a given [t] — no
+    timestamps, no environment-dependent fields. *)

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -7,7 +7,8 @@
   test_panel_loader_parity
   test_backtest_runner_args
   test_gc_trace
-  test_panel_runner_gc_trace)
+  test_panel_runner_gc_trace
+  test_release_perf_report)
  (libraries
   ounit2
   core
@@ -18,6 +19,7 @@
   fpath
   backtest
   trading.backtest.runner_args
+  trading.backtest.release_report
   scenario_lib
   weinstein.data_source
   trading.base

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -1,0 +1,379 @@
+open OUnit2
+open Core
+open Matchers
+
+(* --- Synthetic builders ---
+
+   Inline trivial record constructors per .claude/rules/test-patterns.md —
+   simple test data, no helper module. *)
+
+let _make_actual ?(total_return_pct = 12.0) ?(total_trades = 39.0)
+    ?(win_rate = 50.0) ?(sharpe_ratio = 0.58) ?(max_drawdown_pct = 13.77)
+    ?(avg_holding_days = 6.07) ?(unrealized_pnl = None) () :
+    Release_report.actual =
+  {
+    total_return_pct;
+    total_trades;
+    win_rate;
+    sharpe_ratio;
+    max_drawdown_pct;
+    avg_holding_days;
+    unrealized_pnl;
+  }
+
+let _make_summary ?(start_date = Date.of_string "2023-01-02")
+    ?(end_date = Date.of_string "2023-12-31") ?(universe_size = 1654)
+    ?(n_steps = 251) ?(initial_cash = 1_000_000.0)
+    ?(final_portfolio_value = 1_122_915.42) () : Release_report.summary_meta =
+  {
+    start_date;
+    end_date;
+    universe_size;
+    n_steps;
+    initial_cash;
+    final_portfolio_value;
+  }
+
+let _make_run ?(name = "scenario") ?actual ?summary ?(peak_rss_kb = None)
+    ?(wall_seconds = None) () : Release_report.scenario_run =
+  let actual = Option.value actual ~default:(_make_actual ()) in
+  let summary = Option.value summary ~default:(_make_summary ()) in
+  { name; actual; summary; peak_rss_kb; wall_seconds }
+
+(* --- default_thresholds --- *)
+
+let test_default_thresholds_match_plan _ =
+  assert_that Release_report.default_thresholds
+    (all_of
+       [
+         field
+           (fun (t : Release_report.thresholds) -> t.threshold_rss_pct)
+           (float_equal 10.0);
+         field
+           (fun (t : Release_report.thresholds) -> t.threshold_wall_pct)
+           (float_equal 25.0);
+       ])
+
+(* --- Render: trading section --- *)
+
+let test_render_trading_section_pinned _ =
+  let cur =
+    _make_run ~name:"recovery-2023"
+      ~actual:
+        (_make_actual ~total_return_pct:12.0 ~sharpe_ratio:0.60
+           ~max_drawdown_pct:14.0 ~total_trades:40.0 ~win_rate:55.0
+           ~avg_holding_days:6.5 ())
+      ()
+  in
+  let prior =
+    _make_run ~name:"recovery-2023"
+      ~actual:
+        (_make_actual ~total_return_pct:10.0 ~sharpe_ratio:0.50
+           ~max_drawdown_pct:15.0 ~total_trades:35.0 ~win_rate:50.0
+           ~avg_holding_days:7.0 ())
+      ()
+  in
+  let comparison : Release_report.t =
+    {
+      current_label = "scenarios-cur";
+      prior_label = "scenarios-prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  (* Pin the full markdown so any rendering drift surfaces in review. *)
+  let expected =
+    String.concat ~sep:"\n"
+      [
+        "# Release perf report";
+        "";
+        "- Current: `scenarios-cur`";
+        "- Prior:   `scenarios-prior`";
+        "";
+        "## Trading metrics";
+        "";
+        "### recovery-2023";
+        "";
+        "Period: 2023-01-02 \xe2\x86\x92 2023-12-31 \xc2\xb7 Universe: 1654 \
+         \xc2\xb7 Steps: 251";
+        "";
+        "| Metric | Current | Prior | \xce\x94% |";
+        "|---|---:|---:|---:|";
+        "| Return % | 12.00 | 10.00 | +20.0% |";
+        "| Sharpe | 0.60 | 0.50 | +20.0% |";
+        "| Win rate % | 55.0 | 50.0 | +10.0% |";
+        "| Max DD % | 14.00 | 15.00 | -6.7% |";
+        "| Trades | 40.0 | 35.0 | +14.3% |";
+        "| Avg hold (d) | 6.50 | 7.00 | -7.1% |";
+        "";
+        "## Peak RSS (kB)";
+        "";
+        "Regression flag: \xce\x94% > 10%";
+        "";
+        "| Scenario | Current | Prior | \xce\x94% |";
+        "|---|---:|---:|---:|";
+        "| recovery-2023 | n/a | n/a | n/a |";
+        "";
+        "## Wall time (s)";
+        "";
+        "Regression flag: \xce\x94% > 25%";
+        "";
+        "| Scenario | Current | Prior | \xce\x94% |";
+        "|---|---:|---:|---:|";
+        "| recovery-2023 | n/a | n/a | n/a |";
+        "";
+        "";
+      ]
+  in
+  assert_that md (equal_to expected)
+
+(* --- Render: RSS regression flagged --- *)
+
+let test_render_flags_rss_regression _ =
+  let cur = _make_run ~name:"big-run" ~peak_rss_kb:(Some 1_200_000) () in
+  let prior = _make_run ~name:"big-run" ~peak_rss_kb:(Some 1_000_000) () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  (* +20% RSS exceeds default 10% threshold — expect the rotating-light flag. *)
+  assert_that
+    (String.is_substring md
+       ~substring:"| big-run | 1200000 | 1000000 | +20.0% :rotating_light: |")
+    (equal_to true)
+
+(* --- Render: RSS within threshold --- *)
+
+let test_render_no_flag_within_threshold _ =
+  let cur = _make_run ~name:"steady" ~peak_rss_kb:(Some 1_050_000) () in
+  let prior = _make_run ~name:"steady" ~peak_rss_kb:(Some 1_000_000) () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  (* +5% is under 10% — no flag *)
+  assert_that
+    (String.is_substring md ~substring:"| steady | 1050000 | 1000000 | +5.0% |")
+    (equal_to true);
+  assert_that
+    (String.is_substring md ~substring:":rotating_light:")
+    (equal_to false)
+
+(* --- Render: wall regression flagged --- *)
+
+let test_render_flags_wall_regression _ =
+  let cur = _make_run ~name:"slow" ~wall_seconds:(Some 200.0) () in
+  let prior = _make_run ~name:"slow" ~wall_seconds:(Some 100.0) () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  (* +100% wall — well past 25% threshold *)
+  assert_that
+    (String.is_substring md
+       ~substring:"| slow | 200.0 | 100.0 | +100.0% :rotating_light: |")
+    (equal_to true)
+
+(* --- Render: custom thresholds --- *)
+
+let test_render_custom_threshold_suppresses_flag _ =
+  let cur = _make_run ~name:"loose" ~peak_rss_kb:(Some 1_200_000) () in
+  let prior = _make_run ~name:"loose" ~peak_rss_kb:(Some 1_000_000) () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md =
+    Release_report.render
+      ~thresholds:{ threshold_rss_pct = 50.0; threshold_wall_pct = 50.0 }
+      comparison
+  in
+  (* +20% under loosened 50% threshold — no flag *)
+  assert_that
+    (String.is_substring md ~substring:":rotating_light:")
+    (equal_to false);
+  assert_that
+    (String.is_substring md ~substring:"Regression flag: \xce\x94% > 50%")
+    (equal_to true)
+
+(* --- Render: empty pairing --- *)
+
+let test_render_no_pairs _ =
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that
+    (String.is_substring md ~substring:"_No paired scenarios._")
+    (equal_to true)
+
+(* --- Render: one-sided scenarios listed --- *)
+
+let test_render_one_sided_scenarios _ =
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [];
+      current_only = [ "new-scenario" ];
+      prior_only = [ "removed-scenario" ];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that
+    (String.is_substring md ~substring:"## Current-only scenarios")
+    (equal_to true);
+  assert_that
+    (String.is_substring md ~substring:"- `new-scenario`")
+    (equal_to true);
+  assert_that
+    (String.is_substring md ~substring:"## Prior-only scenarios")
+    (equal_to true);
+  assert_that
+    (String.is_substring md ~substring:"- `removed-scenario`")
+    (equal_to true)
+
+(* --- Loader: round-trip via on-disk fixtures --- *)
+
+let _write_text path text =
+  Out_channel.with_file path ~f:(fun oc -> Out_channel.output_string oc text)
+
+let _write_actual_sexp path =
+  _write_text path
+    "((total_return_pct 12.29) (total_trades 39) (win_rate 50)\n\
+    \ (sharpe_ratio 0.58) (max_drawdown_pct 13.77)\n\
+    \ (avg_holding_days 6.07))\n"
+
+let _write_summary_sexp path =
+  _write_text path
+    "((start_date 2023-01-02) (end_date 2023-12-31) (universe_size 1654)\n\
+    \ (n_steps 251) (initial_cash 1000000.00) (final_portfolio_value 1122915.42)\n\
+    \ (n_round_trips 39) (metrics ()))\n"
+
+let _make_scenario_dir ~root name ~with_perf =
+  let dir = Filename.concat root name in
+  Core_unix.mkdir_p dir;
+  _write_actual_sexp (Filename.concat dir "actual.sexp");
+  _write_summary_sexp (Filename.concat dir "summary.sexp");
+  if with_perf then begin
+    _write_text (Filename.concat dir "peak_rss_kb.txt") "123456\n";
+    _write_text (Filename.concat dir "wall_seconds.txt") "42.5\n"
+  end
+
+let test_load_scenario_run_reads_all_fields _ =
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_" in
+  _make_scenario_dir ~root:dir "recovery-2023" ~with_perf:true;
+  let scenario_dir = Filename.concat dir "recovery-2023" in
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run
+    (all_of
+       [
+         field
+           (fun (r : Release_report.scenario_run) -> r.name)
+           (equal_to "recovery-2023");
+         field
+           (fun (r : Release_report.scenario_run) -> r.actual.total_return_pct)
+           (float_equal 12.29);
+         field
+           (fun (r : Release_report.scenario_run) -> r.summary.universe_size)
+           (equal_to 1654);
+         field
+           (fun (r : Release_report.scenario_run) -> r.peak_rss_kb)
+           (equal_to (Some 123_456));
+         field
+           (fun (r : Release_report.scenario_run) -> r.wall_seconds)
+           (is_some_and (float_equal 42.5));
+       ])
+
+let test_load_scenario_run_missing_perf_files_is_none _ =
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_" in
+  _make_scenario_dir ~root:dir "no-perf" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "no-perf" in
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run
+    (all_of
+       [
+         field
+           (fun (r : Release_report.scenario_run) -> r.peak_rss_kb)
+           (equal_to None);
+         field
+           (fun (r : Release_report.scenario_run) -> r.wall_seconds)
+           (equal_to None);
+       ])
+
+let test_load_pairs_and_one_sided _ =
+  let cur_root = Core_unix.mkdtemp "/tmp/rel_perf_cur_" in
+  let prior_root = Core_unix.mkdtemp "/tmp/rel_perf_prior_" in
+  _make_scenario_dir ~root:cur_root "shared" ~with_perf:true;
+  _make_scenario_dir ~root:cur_root "current-only" ~with_perf:false;
+  _make_scenario_dir ~root:prior_root "shared" ~with_perf:true;
+  _make_scenario_dir ~root:prior_root "prior-only" ~with_perf:false;
+  let comparison = Release_report.load ~current:cur_root ~prior:prior_root in
+  assert_that comparison
+    (all_of
+       [
+         field
+           (fun (t : Release_report.t) ->
+             List.map t.paired ~f:(fun (c, _) -> c.name))
+           (elements_are [ equal_to "shared" ]);
+         field
+           (fun (t : Release_report.t) -> t.current_only)
+           (elements_are [ equal_to "current-only" ]);
+         field
+           (fun (t : Release_report.t) -> t.prior_only)
+           (elements_are [ equal_to "prior-only" ]);
+       ])
+
+let suite =
+  "release_perf_report"
+  >::: [
+         "default_thresholds match plan" >:: test_default_thresholds_match_plan;
+         "render trading section pinned" >:: test_render_trading_section_pinned;
+         "render flags rss regression" >:: test_render_flags_rss_regression;
+         "render no flag within threshold"
+         >:: test_render_no_flag_within_threshold;
+         "render flags wall regression" >:: test_render_flags_wall_regression;
+         "render custom threshold suppresses flag"
+         >:: test_render_custom_threshold_suppresses_flag;
+         "render no pairs" >:: test_render_no_pairs;
+         "render one-sided scenarios listed" >:: test_render_one_sided_scenarios;
+         "load_scenario_run reads all fields"
+         >:: test_load_scenario_run_reads_all_fields;
+         "load_scenario_run missing perf files -> None"
+         >:: test_load_scenario_run_missing_perf_files_is_none;
+         "load pairs scenarios and tracks one-sided"
+         >:: test_load_pairs_and_one_sided;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Step 6 of `dev/status/backtest-perf.md`. New library + binary that diffs two release-gate scenario batches (current vs prior) and emits a markdown report covering both regression dimensions tracked by the perf catalog (`dev/plans/perf-scenario-catalog-2026-04-25.md`).

- **Trading metrics** — return %, Sharpe, win rate, max DD, trades, avg holding — side-by-side with Δ% per metric, per scenario
- **Peak-RSS matrix** — current MB vs prior MB vs Δ%, with a `:rotating_light:` flag when Δ% exceeds the threshold (default +10%)
- **Wall-time matrix** — current s vs prior s vs Δ%, with a flag at +25%
- Scenarios that exist on only one side are listed under "current-only" / "prior-only"

Both thresholds are CLI-overridable via `--threshold-rss-pct N` and `--threshold-wall-pct M`.

Replaces the deleted Python `dev/scripts/perf_sweep_report.py` — fresh OCaml per `.claude/rules/no-python.md`, not a port. The Legacy-vs-Tiered axis the Python report rendered is gone post-PR #575; this report is single-mode N×T tables.

## What it consumes

`<batch>/<scenario>/`:
- `actual.sexp`  — required, the `_actual_of_result` shape from `scenario_runner.ml`
- `summary.sexp` — required, the `Backtest.Summary.t` shape from `Result_writer.write`
- `peak_rss_kb.txt`  — optional, integer kB written by perf-tier runners (`/usr/bin/time -f '%M'`)
- `wall_seconds.txt` — optional, float seconds, also from perf-tier runners

When the optional sidecars are absent, RSS / wall cells render as `n/a` and never trigger flags. Trading metrics still render.

## Files

- `trading/trading/backtest/release_report/{release_report.ml,release_report.mli,dune}` — the library
- `trading/trading/backtest/bin/release_perf_report.ml` — the binary
- `trading/trading/backtest/test/test_release_perf_report.ml` — 11 tests

## Test plan

- [x] `dune build` clean (zero warnings)
- [x] `dune build @fmt` clean
- [x] `dune test trading/backtest/test/test_release_perf_report.exe` — 11/11 PASS
- [x] End-to-end smoke: feeding two synthetic batch dirs through `release_perf_report.exe` reproduces the full markdown shape, including the `:rotating_light:` flag on a +20% RSS regression
- [x] One pinned-markdown test (`test_render_trading_section_pinned`) — surfaces any rendering drift in review
- [x] On-disk fixture round-trip tests cover `load_scenario_run` + `load` (paired + one-sided)

## PR sizing

8 files, 889+/10− insertions. Single new library + bin + test triple; no edits to existing modules other than two `dune` files (adding the new targets). Status file edited under §"Open work" + §"Next steps" #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)