### PR TITLE
feat(weinstein): full short-side screener cascade — Stage-4 mirror of long-side rules

### DIFF
--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -1,6 +1,6 @@
 # Status: short-side-strategy
 
-## Last updated: 2026-04-27 (run-2)
+## Last updated: 2026-04-27
 
 ## Status
 IN_PROGRESS
@@ -86,7 +86,7 @@ Wire short-side entries into `Weinstein_strategy` so the simulation emits short 
 ## Follow-ups
 
 1. ~~**Bear-window backtest regression** (item 6 above)~~ — landed in PR #617 (`feat/short-side-bear-window-regression`). New file `trading/trading/weinstein/strategy/test/test_short_side_bear_window.ml` pins both directions of the bear-window contract through the public `Screener.screen` -> `Weinstein_strategy.entries_from_candidates` seam (synthetic-mocked candidates, not full simulator). Pivoted from the `test_weinstein_backtest.ml` end-to-end approach because the synthetic Declining pattern still does not trigger a clean Stage 3 → Stage 4 transition under the default screener — the right primitive seam is the screener -> entries_from_candidates pipeline, which catches regressions deterministically. Live-cascade gap (PR #612 — 0 short trades and 37 long entries opened in 2022 bear on real SP500 data) remains; diagnosis is upstream of this seam, in `_run_screen`'s `macro_callbacks` construction. Tracked separately.
-2. **Full short screener cascade** — current implementation emits short candidates via the existing cascade with the Ch.11 hard RS gate added. Full mirror of the long cascade (positive weight for negative RS trend, resistance-ceiling clean-space weighting for shorts, short-side volume confirmation rules) is a follow-up.
+2. ~~**Full short screener cascade**~~ — DONE via `feat/short-side-cascade-rules` (this PR). Adds three weighted signals to the short cascade: (a) `_volume_short_signal` boosts Strong / Adequate breakdown volume by `w_strong_volume` / `w_adequate_volume`, mirroring the long-side breakout-volume signal; (b) new `Support` module under `analysis/weinstein/support/` grades below-breakdown clean space (Virgin / Clean / Moderate_resistance / Heavy_resistance) and `Screener._support_signal` weights Virgin and Clean by `w_clean_resistance`, Moderate by half; (c) the Ch.11 hard RS gate stays load-bearing, with `_rs_short_signal` already weighting `Bearish_crossover > Negative_declining > Negative_improving` from prior MVP. Stock_analysis.t now carries `support : Support.result option` and `breakdown_price : float option`. Pinned values updated: VOL_STRONG synthetic 70→85 (+Clean), e2e bear-window JPM 65→72 / CVX 45→52 (+Moderate support), backtest 6-year n_buys/n_sells 36/33→39/36 (+3 trades, symbols unchanged). 22 screener unit tests + 8 new Support tests + 5 e2e tests all pass.
 3. **Ch.11 spot-check** — qc-behavioral review against book examples (never-short-Stage-2 verified in unit tests; confirm Stage 4 + negative RS + bearish macro combination on real data).
 4. ~~**Live-cascade Bearish macro plumbing** (new, ex-#612)~~ — fixed
    in `feat/short-side-bear-window-fix-cascade-plumbing`. Root cause was

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -184,6 +184,24 @@ let _resistance_signal ~w ~(a : Stock_analysis.t) =
       [ (w.w_clean_resistance / 2, "Moderate resistance") ]
   | _ -> []
 
+(** Below-breakdown clean-space signal for short setups. Mirror of
+    [_resistance_signal] for the short-side cascade. Per Weinstein, the Short
+    Entry Checklist requires "minimal nearby support below breakdown point" — a
+    steep prior advance with small congestion is ideal. Heavy support below
+    means the decline will struggle through prior congestion zones; minimal /
+    virgin support below means the stock can fall freely. The shared
+    [overhead_quality] variant carries side-flipped semantics — see [Support]
+    module-level doc. *)
+let _support_signal ~w ~(a : Stock_analysis.t) =
+  match a.support with
+  | Some { quality = Virgin_territory; _ } ->
+      [ (w.w_clean_resistance, "Virgin support below") ]
+  | Some { quality = Clean; _ } ->
+      [ (w.w_clean_resistance, "Clean support below") ]
+  | Some { quality = Moderate_resistance; _ } ->
+      [ (w.w_clean_resistance / 2, "Moderate support below") ]
+  | _ -> []
+
 (** Sector bonus/penalty for long setups. *)
 let _sector_long_signal ~w ~sector =
   match sector.rating with
@@ -237,7 +255,7 @@ let _score_short ~weights ~sector (a : Stock_analysis.t) : int * string list =
   let w = weights in
   _tally
     (_stage_short_signal ~w ~a @ _volume_short_signal ~w ~a
-   @ _rs_short_signal ~w ~a
+   @ _rs_short_signal ~w ~a @ _support_signal ~w ~a
     @ _sector_short_signal ~w ~sector)
 
 (** Convert score to grade using configurable thresholds. *)

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -129,13 +129,27 @@ let _late_stage2_signal ~w ~(a : Stock_analysis.t) =
       [ (w.w_late_stage2_penalty, "Late Stage2 (penalty)") ]
   | _ -> []
 
-(** Volume confirmation signal. *)
+(** Volume confirmation signal for long setups (Stage 2 breakout). *)
 let _volume_signal ~w ~(a : Stock_analysis.t) =
   match a.volume with
   | Some { confirmation = Strong _; _ } ->
       [ (w.w_strong_volume, "Strong volume") ]
   | Some { confirmation = Adequate _; _ } ->
       [ (w.w_adequate_volume, "Adequate volume") ]
+  | _ -> []
+
+(** Volume confirmation signal for short setups (Stage 4 breakdown). Per
+    Weinstein, volume is NOT required for a valid breakdown — stocks can fall of
+    their own weight. Volume increase on breakdown is even more bearish, but
+    absence doesn't invalidate the setup. Therefore [Strong] / [Adequate] add
+    positive weight; [Weak] / no-data adds zero — never a penalty. Mirrors
+    [_volume_signal]'s shape with breakdown-specific rationale labels. *)
+let _volume_short_signal ~w ~(a : Stock_analysis.t) =
+  match a.volume with
+  | Some { confirmation = Strong _; _ } ->
+      [ (w.w_strong_volume, "Strong breakdown volume") ]
+  | Some { confirmation = Adequate _; _ } ->
+      [ (w.w_adequate_volume, "Adequate breakdown volume") ]
   | _ -> []
 
 (** Bullish RS signal for long setups. *)
@@ -222,7 +236,8 @@ let _score_long ~weights ~sector (a : Stock_analysis.t) : int * string list =
 let _score_short ~weights ~sector (a : Stock_analysis.t) : int * string list =
   let w = weights in
   _tally
-    (_stage_short_signal ~w ~a @ _rs_short_signal ~w ~a
+    (_stage_short_signal ~w ~a @ _volume_short_signal ~w ~a
+   @ _rs_short_signal ~w ~a
     @ _sector_short_signal ~w ~sector)
 
 (** Convert score to grade using configurable thresholds. *)

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -387,6 +387,134 @@ let test_short_candidates_are_short _ =
   | c :: _ -> assert_that c.side (equal_to Trading_base.Types.Short)
 
 (* ------------------------------------------------------------------ *)
+(* Short-side volume confirmation (mirror of long-side)                *)
+(* ------------------------------------------------------------------ *)
+
+(** Short-side cascade weights breakdown volume the same way the long-side
+    cascade weights breakout volume: Strong adds [w_strong_volume], Adequate
+    adds [w_adequate_volume], Weak adds 0. Mirrors the test patterns in
+    {!test_candidate_grade_matches_score} but on the short path. The
+    declining-bars-with-spike helper places a 3000-volume bar at offset 55,
+    surrounded by 1000-volume bars; the peak-volume scanner picks it up and
+    {!Volume.analyze_breakout} classifies the spike vs the prior 4-bar average
+    (1000) as Strong (ratio = 3.0). The score then tallies stage (30) + Strong
+    breakdown volume (20) + bearish RS [Negative_declining] (20) = 70 → A. *)
+let test_short_side_volume_confirmation_strong _ =
+  let bars = declining_bars_with_spike ~n:60 100.0 30.0 ~spike_idx:55 in
+  let prior = Some (Stage3 { weeks_topping = 8 }) in
+  let base = make_analysis "VOL_STRONG" prior bars in
+  let neg_rs : Rs.result =
+    {
+      current_rs = 0.8;
+      current_normalized = -10.0;
+      trend = Negative_declining;
+      history = [];
+    }
+  in
+  let with_neg_rs = { base with rs = Some neg_rs } in
+  let result =
+    screen ~config:cfg ~macro_trend:Bearish ~sector_map:(empty_sector_map ())
+      ~stocks:[ with_neg_rs ] ~held_tickers:[]
+  in
+  match result.short_candidates with
+  | [] -> assert_failure "Expected a short candidate"
+  | c :: _ ->
+      assert_that c
+        (all_of
+           [
+             field (fun c -> c.ticker) (equal_to "VOL_STRONG");
+             field (fun c -> c.score) (equal_to 70);
+             field (fun c -> c.grade) (equal_to (A : grade));
+             field
+               (fun c -> c.rationale)
+               (matching ~msg:"rationale contains breakdown-volume label"
+                  (fun rs ->
+                    if
+                      List.exists rs ~f:(fun r ->
+                          String.is_substring r ~substring:"breakdown volume")
+                    then Some ()
+                    else None)
+                  (equal_to ()));
+           ])
+
+(** Adequate breakdown volume (1.5x average) adds [w_adequate_volume = 10]
+    points, lifting a Stage-4 candidate that would otherwise score 30 + 0 + 0
+    (Negative_improving = half of w_positive_rs = 10) = 40 to 50, but the
+    important assertion is that the rationale labels reflect the short-side
+    breakdown context, not generic "volume". *)
+let test_short_side_volume_adequate_label _ =
+  let bars =
+    let step = (100.0 -. 30.0) /. Float.of_int (60 - 1) in
+    List.init 60 ~f:(fun i ->
+        let p = 100.0 -. (Float.of_int i *. step) in
+        let v = if i = 55 then 1500 else 1000 in
+        (p, v))
+    |> weekly_bars_with_volumes
+  in
+  let prior = Some (Stage3 { weeks_topping = 8 }) in
+  let base = make_analysis "VOL_ADQ" prior bars in
+  let neg_rs : Rs.result =
+    {
+      current_rs = 0.8;
+      current_normalized = -10.0;
+      trend = Negative_declining;
+      history = [];
+    }
+  in
+  let with_neg_rs = { base with rs = Some neg_rs } in
+  let result =
+    screen ~config:cfg ~macro_trend:Bearish ~sector_map:(empty_sector_map ())
+      ~stocks:[ with_neg_rs ] ~held_tickers:[]
+  in
+  match result.short_candidates with
+  | [] -> assert_failure "Expected a short candidate"
+  | c :: _ ->
+      assert_that c.rationale
+        (matching ~msg:"contains 'Adequate breakdown volume'"
+           (fun rs ->
+             List.find rs ~f:(fun r ->
+                 String.equal r "Adequate breakdown volume"))
+           (equal_to "Adequate breakdown volume"))
+
+(** Negative-RS scoring (already wired prior to this PR) is a positive signal
+    for shorts: [Bearish_crossover] adds
+    [w_positive_rs + w_bullish_rs_crossover = 30], [Negative_declining] adds
+    [w_positive_rs = 20], and [Negative_improving] adds
+    [w_positive_rs / 2 = 10]. This regression test pins the relative ordering by
+    injecting three otherwise-identical Stage-4 candidates differing only on RS
+    trend and asserting the bearish-crossover score > negative-declining score >
+    negative-improving score. *)
+let test_negative_rs_scoring_order _ =
+  let bars = declining_bars_with_spike ~n:60 100.0 30.0 ~spike_idx:55 in
+  let prior = Some (Stage3 { weeks_topping = 8 }) in
+  let make_with_rs ticker trend =
+    let base = make_analysis ticker prior bars in
+    let rs : Rs.result =
+      { current_rs = 0.8; current_normalized = -10.0; trend; history = [] }
+    in
+    { base with rs = Some rs }
+  in
+  let stocks =
+    [
+      make_with_rs "BX" Bearish_crossover;
+      make_with_rs "ND" Negative_declining;
+      make_with_rs "NI" Negative_improving;
+    ]
+  in
+  let result =
+    screen ~config:cfg ~macro_trend:Bearish ~sector_map:(empty_sector_map ())
+      ~stocks ~held_tickers:[]
+  in
+  let by_ticker t =
+    List.find_exn result.short_candidates ~f:(fun c -> String.(c.ticker = t))
+  in
+  let bx = by_ticker "BX" in
+  let nd = by_ticker "ND" in
+  let ni = by_ticker "NI" in
+  assert_that bx.score (gt (module Int_ord) nd.score);
+  assert_that nd.score (gt (module Int_ord) ni.score)
+
+(* ------------------------------------------------------------------ *)
 (* Ch. 11 rule: positive RS blocks short candidates                   *)
 (* ------------------------------------------------------------------ *)
 
@@ -445,6 +573,11 @@ let suite =
          "test_buy_candidates_are_long" >:: test_buy_candidates_are_long;
          "test_short_candidates_are_short" >:: test_short_candidates_are_short;
          "test_positive_rs_blocks_short" >:: test_positive_rs_blocks_short;
+         "test_short_side_volume_confirmation_strong"
+         >:: test_short_side_volume_confirmation_strong;
+         "test_short_side_volume_adequate_label"
+         >:: test_short_side_volume_adequate_label;
+         "test_negative_rs_scoring_order" >:: test_negative_rs_scoring_order;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -397,8 +397,16 @@ let test_short_candidates_are_short _ =
     declining-bars-with-spike helper places a 3000-volume bar at offset 55,
     surrounded by 1000-volume bars; the peak-volume scanner picks it up and
     {!Volume.analyze_breakout} classifies the spike vs the prior 4-bar average
-    (1000) as Strong (ratio = 3.0). The score then tallies stage (30) + Strong
-    breakdown volume (20) + bearish RS [Negative_declining] (20) = 70 → A. *)
+    (1000) as Strong (ratio = 3.0).
+
+    The synthetic Support analysis on the same declining bars yields Clean
+    support below (the bars between [breakdown_price] and the most recent bar
+    are spread across multiple congestion bands, so no single band hits the
+    moderate-resistance threshold of 3). Clean adds [w_clean_resistance = 15].
+    The score tallies stage (30) + Strong breakdown volume (20) + bearish RS
+    [Negative_declining] (20) + Clean support below (15) = 85 → A+. The test
+    pins both the score and the presence of the breakdown-volume rationale
+    label. *)
 let test_short_side_volume_confirmation_strong _ =
   let bars = declining_bars_with_spike ~n:60 100.0 30.0 ~spike_idx:55 in
   let prior = Some (Stage3 { weeks_topping = 8 }) in
@@ -423,8 +431,8 @@ let test_short_side_volume_confirmation_strong _ =
         (all_of
            [
              field (fun c -> c.ticker) (equal_to "VOL_STRONG");
-             field (fun c -> c.score) (equal_to 70);
-             field (fun c -> c.grade) (equal_to (A : grade));
+             field (fun c -> c.score) (equal_to 85);
+             field (fun c -> c.grade) (equal_to (A_plus : grade));
              field
                (fun c -> c.rationale)
                (matching ~msg:"rationale contains breakdown-volume label"
@@ -475,6 +483,52 @@ let test_short_side_volume_adequate_label _ =
              List.find rs ~f:(fun r ->
                  String.equal r "Adequate breakdown volume"))
            (equal_to "Adequate breakdown volume"))
+
+(** Inject a [Support.result] directly onto an otherwise-identical candidate and
+    assert the screener's [_support_signal] picks it up as a clean-space- below
+    bonus. Pins the contract that mirrors [_resistance_signal] for the short
+    side: Virgin / Clean → [w_clean_resistance], Moderate → halved, Heavy / None
+    → 0. The candidate's other signals contribute a fixed baseline so the
+    support delta is the only thing varying across cases. Mirrors
+    {!test_negative_rs_scoring_order}'s injection-and-compare shape. *)
+let test_support_below_scoring_order _ =
+  let bars = declining_bars_with_spike ~n:60 100.0 30.0 ~spike_idx:55 in
+  let prior = Some (Stage3 { weeks_topping = 8 }) in
+  let neg_rs : Rs.result =
+    {
+      current_rs = 0.8;
+      current_normalized = -10.0;
+      trend = Negative_declining;
+      history = [];
+    }
+  in
+  let make_with_support ticker quality =
+    let base = make_analysis ticker prior bars in
+    let support : Support.result = { quality; breakdown_price = 50.0 } in
+    { base with rs = Some neg_rs; support = Some support }
+  in
+  let stocks =
+    [
+      make_with_support "VIRGIN" Virgin_territory;
+      make_with_support "CLEAN" Clean;
+      make_with_support "MOD" Moderate_resistance;
+      make_with_support "HEAVY" Heavy_resistance;
+    ]
+  in
+  let result =
+    screen ~config:cfg ~macro_trend:Bearish ~sector_map:(empty_sector_map ())
+      ~stocks ~held_tickers:[]
+  in
+  let by_ticker t =
+    List.find_exn result.short_candidates ~f:(fun c -> String.(c.ticker = t))
+  in
+  let virgin = by_ticker "VIRGIN" in
+  let clean = by_ticker "CLEAN" in
+  let mod_ = by_ticker "MOD" in
+  let heavy = by_ticker "HEAVY" in
+  assert_that virgin.score (equal_to clean.score);
+  assert_that clean.score (gt (module Int_ord) mod_.score);
+  assert_that mod_.score (gt (module Int_ord) heavy.score)
 
 (** Negative-RS scoring (already wired prior to this PR) is a positive signal
     for shorts: [Bearish_crossover] adds
@@ -578,6 +632,7 @@ let suite =
          "test_short_side_volume_adequate_label"
          >:: test_short_side_volume_adequate_label;
          "test_negative_rs_scoring_order" >:: test_negative_rs_scoring_order;
+         "test_support_below_scoring_order" >:: test_support_below_scoring_order;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/analysis/weinstein/screener/test/test_screener_e2e.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener_e2e.ml
@@ -213,14 +213,16 @@ let test_candidate_fields_populated _ =
 
 (** Runs the screener over the same 7-stock universe at the COVID crash low
     (2018-01-01 → 2020-03-20) under [Bearish] macro. JPM, KO, and CVX are in
-    early Stage 4 with breakdown-volume confirmation: JPM scores 65 (Stage 4 +
-    Strong breakdown volume + bearish RS crossover), KO scores 55 (Stage 4 +
-    Adequate breakdown volume + bearish RS crossover), and CVX scores 45 (Stage
-    4 + Adequate breakdown volume + RS negative & declining), all clearing the
-    grade-C floor. The remaining four tickers fail the short-side gate. The test
-    pins the exact short_candidates list and shape (entry, stop>entry, risk_pct)
-    and asserts that no buy candidates leak through under Bearish macro. This is
-    the deterministic counterpart to the bullish test. *)
+    early Stage 4 with breakdown-volume confirmation: JPM scores 72 (Stage 4 +
+    Strong breakdown volume + bearish RS crossover + Moderate support below), KO
+    scores 55 (Stage 4 + Adequate breakdown volume + bearish RS crossover; Heavy
+    support below contributes no clean-space bonus), and CVX scores 52 (Stage 4
+    \+ Adequate breakdown volume + RS negative & declining + Moderate support
+    below), all clearing the grade-C floor. The remaining four tickers fail the
+    short-side gate. The test pins the exact short_candidates list and shape
+    (entry, stop>entry, risk_pct) and asserts that no buy candidates leak
+    through under Bearish macro. This is the deterministic counterpart to the
+    bullish test. *)
 let test_short_candidate_populated _ =
   let stocks =
     _analyze_universe
@@ -236,13 +238,13 @@ let test_short_candidate_populated _ =
   assert_that result.Screener.short_candidates
     (elements_are
        [
-         _candidate_matcher ~side:`Short ~ticker:"JPM" ~score:65
+         _candidate_matcher ~side:`Short ~ticker:"JPM" ~score:72
            ~entry_low:139.0 ~entry_high:144.0 ~stop_low:151.0 ~stop_high:155.0
            ~risk_low:0.075 ~risk_high:0.085;
          _candidate_matcher ~side:`Short ~ticker:"KO" ~score:55 ~entry_low:56.0
            ~entry_high:60.0 ~stop_low:61.0 ~stop_high:65.0 ~risk_low:0.075
            ~risk_high:0.085;
-         _candidate_matcher ~side:`Short ~ticker:"CVX" ~score:45
+         _candidate_matcher ~side:`Short ~ticker:"CVX" ~score:52
            ~entry_low:125.0 ~entry_high:130.0 ~stop_low:135.0 ~stop_high:141.0
            ~risk_low:0.075 ~risk_high:0.085;
        ])

--- a/trading/analysis/weinstein/screener/test/test_screener_e2e.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener_e2e.ml
@@ -212,9 +212,12 @@ let test_candidate_fields_populated _ =
 (* ------------------------------------------------------------------ *)
 
 (** Runs the screener over the same 7-stock universe at the COVID crash low
-    (2018-01-01 → 2020-03-20) under [Bearish] macro. JPM and KO are in early
-    Stage 4 with a bearish RS crossover at this date, scoring 45 and clearing
-    the grade-C floor; the other five tickers fail the short-side gate. The test
+    (2018-01-01 → 2020-03-20) under [Bearish] macro. JPM, KO, and CVX are in
+    early Stage 4 with breakdown-volume confirmation: JPM scores 65 (Stage 4 +
+    Strong breakdown volume + bearish RS crossover), KO scores 55 (Stage 4 +
+    Adequate breakdown volume + bearish RS crossover), and CVX scores 45 (Stage
+    4 + Adequate breakdown volume + RS negative & declining), all clearing the
+    grade-C floor. The remaining four tickers fail the short-side gate. The test
     pins the exact short_candidates list and shape (entry, stop>entry, risk_pct)
     and asserts that no buy candidates leak through under Bearish macro. This is
     the deterministic counterpart to the bullish test. *)
@@ -233,12 +236,15 @@ let test_short_candidate_populated _ =
   assert_that result.Screener.short_candidates
     (elements_are
        [
-         _candidate_matcher ~side:`Short ~ticker:"JPM" ~score:45
+         _candidate_matcher ~side:`Short ~ticker:"JPM" ~score:65
            ~entry_low:139.0 ~entry_high:144.0 ~stop_low:151.0 ~stop_high:155.0
            ~risk_low:0.075 ~risk_high:0.085;
-         _candidate_matcher ~side:`Short ~ticker:"KO" ~score:45 ~entry_low:56.0
+         _candidate_matcher ~side:`Short ~ticker:"KO" ~score:55 ~entry_low:56.0
            ~entry_high:60.0 ~stop_low:61.0 ~stop_high:65.0 ~risk_low:0.075
            ~risk_high:0.085;
+         _candidate_matcher ~side:`Short ~ticker:"CVX" ~score:45
+           ~entry_low:125.0 ~entry_high:130.0 ~stop_low:135.0 ~stop_high:141.0
+           ~risk_low:0.075 ~risk_high:0.085;
        ])
 
 (* ------------------------------------------------------------------ *)

--- a/trading/analysis/weinstein/stock_analysis/lib/dune
+++ b/trading/analysis/weinstein/stock_analysis/lib/dune
@@ -2,6 +2,6 @@
  (name stock_analysis)
  (public_name weinstein.stock_analysis)
  (wrapped false)
- (libraries core types weinstein_types stage rs volume resistance)
+ (libraries core types weinstein_types stage rs volume resistance support)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq)))

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
@@ -43,7 +43,9 @@ type t = {
   rs : Rs.result option;
   volume : Volume.result option;
   resistance : Resistance.result option;
+  support : Support.result option;
   breakout_price : float option;
+  breakdown_price : float option;
   prior_stage : stage option;
   as_of_date : Date.t;
 }
@@ -74,6 +76,10 @@ type callbacks = {
 let _max_opt (best : float option) (h : float) : float option =
   match best with None -> Some h | Some b -> Some (Float.max b h)
 
+(** Combine a running minimum with a fresh sample. Mirror of [_max_opt]. *)
+let _min_opt (best : float option) (l : float) : float option =
+  match best with None -> Some l | Some b -> Some (Float.min b l)
+
 (** Walk back from [week_offset = base_end_offset .. base_lookback - 1] reading
     [get_high] at each offset. Returns the maximum defined high. Stops the walk
     at the first [None] (treated as "no more bars"). Returns [None] when the
@@ -88,6 +94,27 @@ let _scan_max_high_callback ~get_high ~base_end_offset ~base_lookback :
         match get_high ~week_offset:off with
         | None -> best
         | Some h -> loop (off + 1) (_max_opt best h)
+    in
+    loop base_end_offset None
+
+(** Mirror of {!_scan_max_high_callback} for the short-side cascade: walks
+    [bar_offset = base_end_offset .. base_lookback - 1] reading [get_low] at
+    each offset and returns the {b minimum} defined low. The base low is the
+    short-side analogue of the breakout price.
+
+    Note: [get_low] is consumed via the Resistance callback bundle, which uses
+    [~bar_offset] rather than [~week_offset]. Both indexing conventions mean
+    "offset from the newest bar"; only the labelled-arg name differs. *)
+let _scan_min_low_callback ~get_low ~base_end_offset ~base_lookback :
+    float option =
+  if base_end_offset >= base_lookback then None
+  else
+    let rec loop off best =
+      if off >= base_lookback then best
+      else
+        match get_low ~bar_offset:off with
+        | None -> best
+        | Some l -> loop (off + 1) (_min_opt best l)
     in
     loop base_end_offset None
 
@@ -199,6 +226,17 @@ let _resistance_result ~(config : config)
       Resistance.analyze_with_callbacks ~config:config.resistance
         ~callbacks:resistance_callbacks ~breakout_price:bp ~as_of_date)
 
+(** Compute the short-side mirror of [_resistance_result]: support density below
+    [breakdown_price]. Reuses [resistance_callbacks] (same per-bar fields, only
+    the comparison flips inside [Support.analyze_with_callbacks]). Reuses
+    [config.resistance] so the same defaults govern both directions. *)
+let _support_result ~(config : config)
+    ~(resistance_callbacks : Resistance.callbacks) ~as_of_date ~breakdown_price
+    : Support.result option =
+  Option.map breakdown_price ~f:(fun bp ->
+      Support.analyze_with_callbacks ~config:config.resistance
+        ~callbacks:resistance_callbacks ~breakdown_price:bp ~as_of_date)
+
 (* ------------------------------------------------------------------ *)
 (* Main analyzer — callback shape                                       *)
 (* ------------------------------------------------------------------ *)
@@ -221,6 +259,11 @@ let analyze_with_callbacks ~(config : config) ~ticker ~(callbacks : callbacks)
       ~base_end_offset:config.base_end_offset_weeks
       ~base_lookback:config.base_lookback_weeks
   in
+  let breakdown_price =
+    _scan_min_low_callback ~get_low:callbacks.resistance.get_low
+      ~base_end_offset:config.base_end_offset_weeks
+      ~base_lookback:config.base_lookback_weeks
+  in
   let peak_offset_opt =
     _find_peak_volume_offset_callback ~get_volume:callbacks.get_volume
       ~lookback:config.breakout_event_lookback
@@ -232,13 +275,19 @@ let analyze_with_callbacks ~(config : config) ~ticker ~(callbacks : callbacks)
     _resistance_result ~config ~resistance_callbacks:callbacks.resistance
       ~as_of_date ~breakout_price
   in
+  let support_result =
+    _support_result ~config ~resistance_callbacks:callbacks.resistance
+      ~as_of_date ~breakdown_price
+  in
   {
     ticker;
     stage = stage_result;
     rs = rs_result;
     volume = volume_result;
     resistance = resistance_result;
+    support = support_result;
     breakout_price;
+    breakdown_price;
     prior_stage;
     as_of_date;
   }

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.mli
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.mli
@@ -35,9 +35,20 @@ type t = {
       (** None if there is no identifiable breakout bar in the recent window. *)
   resistance : Resistance.result option;
       (** None if no breakout price can be determined from the bars. *)
+  support : Support.result option;
+      (** Below-breakdown support density grade. Mirror of [resistance] for the
+          short-side cascade — measures how much prior trading sits below the
+          breakdown floor (heavy support = decline will struggle through; virgin
+          support = stock falls freely). [None] when no breakdown price can be
+          determined. *)
   breakout_price : float option;
       (** Detected breakout price (top of prior base / resistance zone). Used by
           the screener to set suggested entry. *)
+  breakdown_price : float option;
+      (** Detected breakdown price (bottom of prior base / support floor).
+          Mirror of [breakout_price] for the short-side cascade. Computed as the
+          minimum [low_price] over the prior-base window
+          [(base_end_offset_weeks .. base_lookback_weeks)]. *)
   prior_stage : Weinstein_types.stage option;
       (** Stage from the previous week, passed forward for transition tracking.
       *)

--- a/trading/analysis/weinstein/support/lib/dune
+++ b/trading/analysis/weinstein/support/lib/dune
@@ -1,0 +1,7 @@
+(library
+ (name support)
+ (public_name weinstein.support)
+ (wrapped false)
+ (libraries core types weinstein_types resistance)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq)))

--- a/trading/analysis/weinstein/support/lib/support.ml
+++ b/trading/analysis/weinstein/support/lib/support.ml
@@ -1,0 +1,126 @@
+open Core
+open Types
+open Weinstein_types
+
+(* ------------------------------------------------------------------ *)
+(* Config and result                                                    *)
+(* ------------------------------------------------------------------ *)
+
+(* Reuses Resistance's config so the same defaults govern both
+   directions and the screener doesn't need to maintain a parallel
+   tuning surface. *)
+type config = Resistance.config
+
+let default_config = Resistance.default_config
+
+type result = { quality : overhead_quality; breakdown_price : float }
+
+(* ------------------------------------------------------------------ *)
+(* Algorithm — callback-shaped, bar_offset:0 = newest                   *)
+(* ------------------------------------------------------------------ *)
+
+(* Bucket index for a (high, low) pair in the congestion-band grid
+   rooted at [breakdown_price] and extending DOWNWARD. Index 0 covers
+   the first band immediately below [breakdown_price], index 1 the
+   next band further below, etc. Bars whose midpoint sits at or above
+   [breakdown_price] yield a negative bucket and are filtered out by
+   [_accumulate_below]. Mirror of [Resistance._bucket_idx]. *)
+let _bucket_idx_below ~breakdown_price ~band_size ~high ~low =
+  let mid = (high +. low) /. 2.0 in
+  (* (breakdown - mid) is positive when the bar is below breakdown. *)
+  let offset = (breakdown_price -. mid) /. band_size in
+  Int.of_float (Float.round_down offset)
+
+(* Try to read (high, low) at [bar_offset]. Both must be defined; any
+   missing field skips the offset (treated as "no bar"). *)
+let _read_offset (cb : Resistance.callbacks) ~bar_offset :
+    (float * float) option =
+  match (cb.get_high ~bar_offset, cb.get_low ~bar_offset) with
+  | Some h, Some l -> Some (h, l)
+  | _ -> None
+
+(* Increment the count for [bkt] in [tbl]. *)
+let _bump_bucket tbl ~bkt =
+  Hashtbl.update tbl bkt ~f:(function None -> 1 | Some n -> n + 1)
+
+(* Process a single bar reading at [bar_offset] — accumulate it into
+   [tbl] when it qualifies (low pierced breakdown_price and bucket
+   index is non-negative). Skip otherwise. *)
+let _accumulate_one tbl ~breakdown_price ~band_size ~h ~l =
+  if Float.(l < breakdown_price) then
+    let bkt = _bucket_idx_below ~breakdown_price ~band_size ~high:h ~low:l in
+    if bkt >= 0 then _bump_bucket tbl ~bkt
+
+(* Walk offsets [0..limit-1] and accumulate below-breakdown bars into
+   the bucket count table. Mirrors [Resistance._accumulate_chart] with
+   the comparison flipped. *)
+let _accumulate_below tbl ~callbacks ~breakdown_price ~band_size ~limit =
+  for off = 0 to limit - 1 do
+    match _read_offset callbacks ~bar_offset:off with
+    | None -> ()
+    | Some (h, l) -> _accumulate_one tbl ~breakdown_price ~band_size ~h ~l
+  done
+
+(* True when no bar at offsets [0..limit-1] has low below
+   [breakdown_price]. The stock has never traded down to this level in
+   the virgin window. Mirror of [Resistance._is_virgin_territory]. *)
+let _is_virgin_below ~callbacks ~breakdown_price ~limit =
+  let rec loop off =
+    if off >= limit then true
+    else
+      match callbacks.Resistance.get_low ~bar_offset:off with
+      | None -> loop (off + 1)
+      | Some l -> if Float.(l < breakdown_price) then false else loop (off + 1)
+  in
+  loop 0
+
+let _grade_count ~(config : config) ~max_bars : overhead_quality =
+  if max_bars >= config.heavy_resistance_bars then Heavy_resistance
+  else if max_bars >= config.moderate_resistance_bars then Moderate_resistance
+  else Clean
+
+(* ------------------------------------------------------------------ *)
+(* Public entries                                                       *)
+(* ------------------------------------------------------------------ *)
+
+(* Compute the chart-density quality given the analysis is past the
+   virgin check. Walks the chart-lookback window into a bucket table
+   and grades the densest bucket. *)
+let _classify_chart_density ~(config : config) ~callbacks ~breakdown_price =
+  let chart_limit =
+    min config.chart_lookback_bars callbacks.Resistance.n_bars
+  in
+  let band_size = breakdown_price *. config.congestion_band_pct in
+  let tbl = Hashtbl.create (module Int) in
+  _accumulate_below tbl ~callbacks ~breakdown_price ~band_size
+    ~limit:chart_limit;
+  let max_bars =
+    Hashtbl.fold tbl ~init:0 ~f:(fun ~key:_ ~data:n acc -> max acc n)
+  in
+  if max_bars = 0 then Clean else _grade_count ~config ~max_bars
+
+(* Compute quality given a non-degenerate (positive breakdown,
+   non-empty callbacks) input. Splits virgin-territory short-circuit
+   from chart density classification to keep the entry point flat. *)
+let _quality_for_valid_input ~(config : config) ~callbacks ~breakdown_price =
+  let virgin_limit =
+    min config.virgin_lookback_bars callbacks.Resistance.n_bars
+  in
+  if _is_virgin_below ~callbacks ~breakdown_price ~limit:virgin_limit then
+    Virgin_territory
+  else _classify_chart_density ~config ~callbacks ~breakdown_price
+
+let analyze_with_callbacks ~(config : config)
+    ~(callbacks : Resistance.callbacks) ~breakdown_price ~as_of_date : result =
+  let _ = as_of_date in
+  let quality =
+    if Float.(breakdown_price <= 0.0) || callbacks.n_bars <= 0 then
+      Virgin_territory
+    else _quality_for_valid_input ~config ~callbacks ~breakdown_price
+  in
+  { quality; breakdown_price }
+
+let analyze ~(config : config) ~(bars : Daily_price.t list) ~breakdown_price
+    ~as_of_date : result =
+  let callbacks = Resistance.callbacks_from_bars ~bars in
+  analyze_with_callbacks ~config ~callbacks ~breakdown_price ~as_of_date

--- a/trading/analysis/weinstein/support/lib/support.mli
+++ b/trading/analysis/weinstein/support/lib/support.mli
@@ -1,0 +1,93 @@
+open Types
+
+(** Underneath-support mapping for Weinstein breakdown grading (short side).
+
+    Mirror of {!Resistance} for the short-side cascade: where {!Resistance}
+    measures trapped buyers {b above} a long-side breakout price, {!Support}
+    measures trapped longs {b below} a short-side breakdown price — i.e. where
+    prior buyers sit waiting for a bounce.
+
+    Per Weinstein's Short Entry Checklist: a strong short setup has minimal
+    nearby support below the breakdown point — a steep prior advance with small
+    congestion is ideal. Heavy support below a breakdown means the decline will
+    struggle through prior congestion zones (each acting as a temporary floor);
+    minimal / virgin support below means the stock can fall freely.
+
+    The grading reuses [overhead_quality] with a side-flipped semantic:
+    - [Virgin_territory]: no prior trading {b below} this price. The stock has
+      never traded down to this level (or hasn't in the virgin window). Most
+      explosive downside potential.
+    - [Clean]: no significant support on the chart. Minor old prior trading
+      only.
+    - [Moderate_resistance]: some prior trading below but not dense. The decline
+      can punch through.
+    - [Heavy_resistance]: dense prior trading zone just below the breakdown. The
+      stock will use up selling pressure working through this zone.
+
+    The shared variant name (overhead_quality) is intentional: the same four
+    grades describe both directions, the only difference is whether the trapped
+    traders are above (long) or below (short) the level. The screener attaches
+    the side via context.
+
+    All functions are pure. *)
+
+type config = Resistance.config
+(** Reuses {!Resistance.config} byte-for-byte. *)
+
+val default_config : config
+(** Same defaults as {!Resistance.default_config}. *)
+
+type result = {
+  quality : Weinstein_types.overhead_quality;
+      (** Graded quality of below-breakdown support — see module-level doc. *)
+  breakdown_price : float;  (** The price level being analysed. *)
+}
+(** Result of below-breakdown support analysis at a given breakdown price.
+
+    Lighter than {!Resistance.result}: the screener only consumes [quality]
+    today, so [zones] / [nearest_zone] are intentionally omitted to keep the
+    surface area small. They can be added in a later PR if a future analysis
+    needs the full zone list. *)
+
+val analyze :
+  config:config ->
+  bars:Daily_price.t list ->
+  breakdown_price:float ->
+  as_of_date:Core.Date.t ->
+  result
+(** [analyze ~config ~bars ~breakdown_price ~as_of_date] grades support
+    {b below} [breakdown_price].
+
+    @param bars
+      Price bars in chronological order (oldest first). Same window semantics as
+      {!Resistance.analyze}: the last [virgin_lookback_bars] tail is used for
+      the virgin check, the last [chart_lookback_bars] for zone density.
+    @param breakdown_price The price level to grade support below.
+    @param as_of_date Reference date used for zone-age computation.
+
+    Pure function: same inputs always produce the same output.
+
+    Implementation note: this is a thin wrapper over {!analyze_with_callbacks}.
+    It builds a {!Resistance.callbacks} record via
+    {!Resistance.callbacks_from_bars} and delegates. Behaviour is bit-identical
+    to the callback API for the same underlying [bars]. *)
+
+val analyze_with_callbacks :
+  config:config ->
+  callbacks:Resistance.callbacks ->
+  breakdown_price:float ->
+  as_of_date:Core.Date.t ->
+  result
+(** [analyze_with_callbacks ~config ~callbacks ~breakdown_price ~as_of_date] is
+    the indicator-callback shape of {!analyze}. Reuses {!Resistance.callbacks}
+    since both directions need the same per-bar fields (high, low, date) — only
+    the comparison flips. Used by panel-backed callers that read bar fields via
+    per-cell closures rather than walking a {!Daily_price.t list}.
+
+    Walks two bar windows back from the newest bar (offset 0):
+    - the [config.virgin_lookback_bars] tail for the virgin-territory check
+      below [breakdown_price],
+    - the [config.chart_lookback_bars] tail for zone density analysis below
+      [breakdown_price].
+
+    Pure function: same callback outputs always produce the same result. *)

--- a/trading/analysis/weinstein/support/test/dune
+++ b/trading/analysis/weinstein/support/test/dune
@@ -1,0 +1,4 @@
+(tests
+ (names test_support)
+ (modules test_support)
+ (libraries support resistance weinstein_types types core ounit2 matchers))

--- a/trading/analysis/weinstein/support/test/test_support.ml
+++ b/trading/analysis/weinstein/support/test/test_support.ml
@@ -1,0 +1,142 @@
+open OUnit2
+open Core
+open Matchers
+open Support
+open Weinstein_types
+open Types
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let cfg = default_config
+let as_of = Date.of_string "2024-01-01"
+
+(** Bar with optional low/high overrides; date is fixed (irrelevant to
+    bar-count-based window logic). *)
+let make_bar ?(low = 90.0) ?(high = 110.0) close =
+  {
+    Daily_price.date = Date.of_string "2023-06-01";
+    open_price = close;
+    high_price = high;
+    low_price = low;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1000;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* Virgin territory tests                                               *)
+(* ------------------------------------------------------------------ *)
+
+(** No bars → Virgin territory. Mirror of {!Resistance}'s no-bars test. *)
+let test_no_history_virgin _ =
+  let result =
+    analyze ~config:cfg ~bars:[] ~breakdown_price:50.0 ~as_of_date:as_of
+  in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun r -> r.quality)
+           (equal_to (Virgin_territory : overhead_quality));
+         field (fun r -> r.breakdown_price) (float_equal 50.0);
+       ])
+
+(** All bars trade above breakdown_price (i.e. no low ever pierced the breakdown
+    floor) → Virgin territory below. The stock has never traded down to this
+    level. *)
+let test_no_below_history_virgin _ =
+  let bars = List.init 50 ~f:(fun _ -> make_bar ~low:80.0 ~high:120.0 100.0) in
+  let result =
+    analyze ~config:cfg ~bars ~breakdown_price:60.0 ~as_of_date:as_of
+  in
+  assert_that result.quality (equal_to (Virgin_territory : overhead_quality))
+
+(** Below-breakdown bars older than [virgin_lookback_bars] are excluded from the
+    virgin check tail. Mirror of {!Resistance.test_old_history_virgin}. *)
+let test_old_below_history_virgin _ =
+  let small_cfg = { cfg with Resistance.virgin_lookback_bars = 10 } in
+  let bars =
+    List.init 5 ~f:(fun _ -> make_bar ~low:40.0 ~high:48.0 45.0)
+    @ List.init 10 ~f:(fun _ -> make_bar ~low:80.0 ~high:90.0 85.0)
+  in
+  let result =
+    analyze ~config:small_cfg ~bars ~breakdown_price:50.0 ~as_of_date:as_of
+  in
+  assert_that result.quality (equal_to (Virgin_territory : overhead_quality))
+
+(* ------------------------------------------------------------------ *)
+(* Heavy support below                                                 *)
+(* ------------------------------------------------------------------ *)
+
+(** Many bars trading in the same zone below breakdown → Heavy support. *)
+let test_heavy_support_many_bars _ =
+  let bars = List.init 10 ~f:(fun _ -> make_bar ~low:42.0 ~high:48.0 45.0) in
+  let result =
+    analyze ~config:cfg ~bars ~breakdown_price:50.0 ~as_of_date:as_of
+  in
+  assert_that result.quality (equal_to (Heavy_resistance : overhead_quality))
+
+(** A handful of bars below — clears the moderate threshold (3) but not heavy
+    (8). *)
+let test_moderate_support_few_bars _ =
+  let bars =
+    List.init 3 ~f:(fun _ -> make_bar ~low:42.0 ~high:48.0 45.0)
+    @ List.init 30 ~f:(fun _ -> make_bar ~low:55.0 ~high:65.0 60.0)
+  in
+  let result =
+    analyze ~config:cfg ~bars ~breakdown_price:50.0 ~as_of_date:as_of
+  in
+  assert_that result.quality (equal_to (Moderate_resistance : overhead_quality))
+
+(** Only 1 bar below breakdown — below the moderate threshold (3) → Clean. *)
+let test_clean_few_bars_below _ =
+  let bars =
+    [
+      make_bar ~low:55.0 ~high:65.0 60.0;
+      make_bar ~low:55.0 ~high:65.0 60.0;
+      make_bar ~low:42.0 ~high:48.0 45.0;
+    ]
+  in
+  let result =
+    analyze ~config:cfg ~bars ~breakdown_price:50.0 ~as_of_date:as_of
+  in
+  assert_that result.quality (equal_to (Clean : overhead_quality))
+
+let test_pure_same_inputs _ =
+  let bars = List.init 10 ~f:(fun _ -> make_bar ~low:42.0 ~high:48.0 45.0) in
+  let r1 = analyze ~config:cfg ~bars ~breakdown_price:50.0 ~as_of_date:as_of in
+  let r2 = analyze ~config:cfg ~bars ~breakdown_price:50.0 ~as_of_date:as_of in
+  assert_that r1.quality (equal_to (r2.quality : overhead_quality))
+
+(** [analyze] should produce the same quality grade as [analyze_with_callbacks]
+    when given equivalent bar / callback inputs. *)
+let test_analyze_matches_callback _ =
+  let bars = List.init 10 ~f:(fun _ -> make_bar ~low:42.0 ~high:48.0 45.0) in
+  let bar_list_result =
+    analyze ~config:cfg ~bars ~breakdown_price:50.0 ~as_of_date:as_of
+  in
+  let callbacks = Resistance.callbacks_from_bars ~bars in
+  let callback_result =
+    analyze_with_callbacks ~config:cfg ~callbacks ~breakdown_price:50.0
+      ~as_of_date:as_of
+  in
+  assert_that bar_list_result.quality
+    (equal_to (callback_result.quality : overhead_quality))
+
+let () =
+  run_test_tt_main
+    ("support_tests"
+    >::: [
+           "no history → virgin" >:: test_no_history_virgin;
+           "no bars below → virgin" >:: test_no_below_history_virgin;
+           "old bars below outside virgin window → virgin"
+           >:: test_old_below_history_virgin;
+           "heavy support below" >:: test_heavy_support_many_bars;
+           "moderate support below" >:: test_moderate_support_few_bars;
+           "clean: only 1 bar below" >:: test_clean_few_bars_below;
+           "pure: same inputs" >:: test_pure_same_inputs;
+           "analyze matches analyze_with_callbacks"
+           >:: test_analyze_matches_callback;
+         ])

--- a/trading/trading/simulation/test/test_weinstein_backtest.ml
+++ b/trading/trading/simulation/test/test_weinstein_backtest.ml
@@ -160,10 +160,16 @@ let test_six_year_full_lifecycle _ =
      counts shifted from the buggy pre-3.2 numbers (23/21 with 10W/11L)
      to the correct post-3.2 numbers captured below. The exact set of
      traded tickers, win/loss split, and a tight final-value band
-     guarantee the strategy path is reproducible end-to-end. *)
+     guarantee the strategy path is reproducible end-to-end.
+
+     Short-side cascade-rules update (2026-04): n_buys/n_sells bumped
+     from 36/33 → 39/36 after the support-below clean-space signal
+     joined the short-side score. Three additional short trades in
+     2018-2020 bear with no change to the round-trip count or
+     traded-symbol set; final value drift well inside the ±$3K band. *)
   assert_that (List.length result.steps) (equal_to 2187);
-  assert_that n_buys (equal_to 36);
-  assert_that n_sells (equal_to 33);
+  assert_that n_buys (equal_to 39);
+  assert_that n_sells (equal_to 36);
   assert_that symbols
     (elements_are
        [

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -548,7 +548,9 @@ let make_scored_candidate ~ticker ~side ~entry ~stop ~grade =
       rs = None;
       volume = None;
       breakout_price = Some entry;
+      breakdown_price = None;
       resistance = None;
+      support = None;
       prior_stage = Some (Stage3 { weeks_topping = 8 });
       as_of_date = Date.of_string "2024-01-05";
     }


### PR DESCRIPTION
## Summary

Completes the short-side screener cascade as a Stage-4 mirror of the long-side rules. Closes follow-up #2 in `dev/status/short-side-strategy.md`.

Three weighted signals added to `_score_short`:

1. **Short-side volume confirmation** — new `_volume_short_signal` mirrors `_volume_signal`. Strong / Adequate breakdown volume add `w_strong_volume` / `w_adequate_volume`; Weak / no-data adds 0 (per Weinstein Ch. 7: volume is NOT required for valid breakdown — stocks can fall of their own weight — but volume increase is even more bearish).

2. **Below-breakdown clean-space (`_support_signal`)** — new `Support` module under `analysis/weinstein/support/` mirrors Resistance for the short side. `Stock_analysis.t` now carries `support : Support.result option` + `breakdown_price : float option` (computed via new `_scan_min_low_callback`, mirror of `_scan_max_high_callback`). Reuses `Resistance.config` and `Resistance.callbacks` so the panel-mode plumbing is unchanged. Virgin / Clean → `w_clean_resistance`, Moderate → halved, Heavy / None → 0.

3. **Negative-RS scoring** — already wired prior via `_rs_short_signal` (PR #420 MVP). New regression test `test_negative_rs_scoring_order` pins the relative weight ordering: Bearish_crossover (30) > Negative_declining (20) > Negative_improving (10). Ch.11 hard RS gate (positive RS blocks shorts entirely) stays load-bearing; the new weighted signal stacks on top.

## Test plan

- [x] 8 new Support unit tests (virgin / heavy / moderate / clean / purity / bar-list-vs-callback parity)
- [x] 22 screener unit tests (was 18; +3 short-side volume + RS + 1 support-below scoring order)
- [x] 5 e2e tests pinning the bear-window short candidate set with the new scores
- [x] 3 backtest-lifecycle tests (n_buys/n_sells 36/33 → 39/36 in 2018-2023, round-trip count + symbols unchanged)
- [x] `dune build && dune runtest` passes with `TRADING_DATA_DIR`
- [x] `dune build @fmt` clean
- [x] `nesting_linter`, `magic_numbers`, `mli_coverage` pass

## Constraints respected

- Ch.11 hard RS gate untouched (positive RS still blocks shorts unconditionally)
- No changes to long-side scoring, Portfolio, Orders, or Position modules
- Pure functions throughout; same input → same output
- Reuses Resistance.config so the same defaults govern both directions

## Pinned-value updates (deliberate)

- `test_screener_e2e.ml` 2018-2020 short candidates: JPM 65→72 (+Moderate support below), KO 55 unchanged (Heavy support → 0 bonus), CVX 45→52 (+Moderate support below)
- `test_screener.ml` synthetic VOL_STRONG: 70→85 (+Clean support below; declining bars spread across multiple bands → Clean grade)
- `test_weinstein_backtest.ml` 6-year lifecycle: 36/33 → 39/36 buys/sells (3 additional short trades in 2018-2020 bear window)

## Out of scope

- Ch.11 spot-check (follow-up #3, separate PR)
- Buy-to-cover trailing stop tuning beyond what `Weinstein_stops` already does
- Margin / borrow cost modelling