### PR TITLE
feat(backtest-perf): buffer pool for transient workspaces (PR-4 of engine-pooling)

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -1,6 +1,6 @@
 # Status: backtest-perf
 
-## Last updated: 2026-04-27 (PR-3 of engine-pooling)
+## Last updated: 2026-04-27 (PR-4 of engine-pooling)
 
 ## Status
 IN_PROGRESS
@@ -23,9 +23,11 @@ on 2026-04-27**; **PR-3 (thread Scratch through `Engine.update_market`
 per-tick loop) opened at `feat/backtest-perf-engine-pool-thread` on
 2026-04-27 — collapses per-tick float-array allocs to per-symbol-once;
 parity-tested via `test_panel_loader_parity` and
-`test_engine_scratch_threading_parity`**; PR-4 (transient buffer pool
-for one-off workspaces) and PR-5 (matrix re-run validation) still
-outstanding. Step 5 (release_perf_report OCaml exe) tracked separately;
+`test_engine_scratch_threading_parity`**; **PR-4 (transient
+buffer pool for `_sample_student_t.sum_squares` accumulator +
+`Hashtbl.find_or_add` in `update_market`) opened at
+`feat/backtest-perf-engine-pool-pool` on 2026-04-27 — PR #632**;
+PR-5 (matrix re-run validation) still outstanding. Step 5 (release_perf_report OCaml exe) tracked separately;
 landed via #585 / #606 on the test-data + perf-runner side. Tier-4
 release-gate scenarios structurally unblocked since data-panels
 Stage 4.5 PR-B (#604) merged 2026-04-27T02:33Z.
@@ -82,6 +84,20 @@ mechanics + release-gate procedure.
   See `dev/notes/engine-pool-pr3-impact-2026-04-27.md` for the
   per-call allocation breakdown (~3.2 KB float-array alloc dropped
   per `update_market` call after the symbol's first day).
+- **`feat/backtest-perf-engine-pool-pool`** (engine-pooling PR-4) —
+  PR #632 open for review. Adds `Buffer_pool.{ml,mli}` (Stack-backed
+  pool of `float array` workspaces with `acquire ?capacity () /
+  release` API, bounded by `max_size`). Routes the per-call
+  `_sample_student_t` chi-squared accumulator (was `let acc = ref
+  0.0`) through a 1-slot float array borrowed from a per-`Scratch`
+  pool. Switches `Engine._scratch_for_symbol` from `match Hashtbl.find
+  … with Some …` to `Hashtbl.find_or_add … ~default` to remove the
+  per-call `Some` allocation that dominated `update_market.(fun)` per
+  the post-PR-A memtrace. FP order is unchanged — same left-fold for
+  loop, just a different storage location for the accumulator. New
+  9-test `test_buffer_pool.ml` pins the pool's API contract;
+  `test_golden_bit_equality` and `test_panel_loader_parity` (the
+  load-bearing parity gates) pass unchanged.
 - **`feat/backtest-perf-release-report`** (Step 6 — release_perf_report
   OCaml exe) — open for review. Adds
   `trading/trading/backtest/release_report/` library +
@@ -142,6 +158,28 @@ mechanics + release-gate procedure.
   inside the devcontainer (or with `TRADING_IN_CONTAINER=1`); the
   workflow itself is exercised on its first scheduled run / manual
   `workflow_dispatch`.
+
+- **Engine-pooling PR-4 — Buffer_pool for transient workspaces** (2026-04-27, PR #632 open).
+  New `trading/trading/engine/lib/buffer_pool.{ml,mli}` — Stack-backed
+  pool of `float array` workspace buffers; pre-seeds one buffer at
+  construction so the first `acquire` is allocation-free; bounded by
+  `max_size` (drops on overflow). `Price_path._sample_student_t` now
+  acquires a 1-slot float-array accumulator on entry and releases it
+  on exit, removing the `let acc = ref 0.0` per-call heap allocation
+  (~85K sampled events / ~850M real allocations on `bull-crash-292x6y`
+  per the post-PR-A memtrace). `Engine._scratch_for_symbol` now uses
+  `Hashtbl.find_or_add ~default`, removing the per-call `Some`
+  allocation that dominated `update_market.(fun)` (~316 KB / 19,800
+  sampled events). Bit-equality preserved: chi-squared accumulation
+  order is identical (same left-fold for-loop, just `acc.(0)` instead
+  of `!acc`); `test_golden_bit_equality` and `test_panel_loader_parity`
+  pass unchanged. Verify:
+  `dune runtest trading/engine/test` (96 tests) +
+  `TRADING_DATA_DIR=$(pwd)/test_data dune exec
+  trading/backtest/test/test_panel_loader_parity.exe`. Files:
+  `trading/trading/engine/lib/buffer_pool.{ml,mli}`,
+  `trading/trading/engine/lib/{price_path,engine,dune}.ml`,
+  `trading/trading/engine/test/test_buffer_pool.ml`.
 
 - **Engine-pooling PR-1 — Gc.stat instrumentation** (2026-04-27, PR #618).
   Per-step `Gc.stat` snapshots in `Panel_runner.run`, gated by the

--- a/trading/trading/engine/lib/buffer_pool.ml
+++ b/trading/trading/engine/lib/buffer_pool.ml
@@ -1,0 +1,38 @@
+open Core
+
+(** See [.mli] for the public contract. *)
+
+type t = { free : float array Stack.t; initial_size : int; max_size : int }
+
+let create ~initial_size ~max_size =
+  if initial_size < 1 then
+    invalid_arg
+      (Printf.sprintf "Buffer_pool.create: initial_size %d < 1" initial_size);
+  if max_size < 1 then
+    invalid_arg (Printf.sprintf "Buffer_pool.create: max_size %d < 1" max_size);
+  if max_size < initial_size then
+    invalid_arg
+      (Printf.sprintf "Buffer_pool.create: max_size %d < initial_size %d"
+         max_size initial_size);
+  let free = Stack.create () in
+  (* Pre-seed one buffer so the first [acquire] is allocation-free. *)
+  Stack.push free (Array.create ~len:initial_size 0.0);
+  { free; initial_size; max_size }
+
+let acquire t ?capacity () =
+  let needed = Option.value capacity ~default:t.initial_size in
+  match Stack.pop t.free with
+  | Some buf when Array.length buf >= needed -> buf
+  | Some _too_small ->
+      (* The popped buffer wasn't large enough. Drop it and allocate fresh
+         at the requested capacity. The undersized buffer is left to GC
+         rather than re-pushed: keeping it would just trigger the same
+         miss on the next [acquire ~capacity]. *)
+      Array.create ~len:needed 0.0
+  | None -> Array.create ~len:needed 0.0
+
+let release t buf =
+  if Stack.length t.free < t.max_size then Stack.push t.free buf
+(* else: drop [buf] to GC — the pool is already at its retention bound. *)
+
+let length t = Stack.length t.free

--- a/trading/trading/engine/lib/buffer_pool.mli
+++ b/trading/trading/engine/lib/buffer_pool.mli
@@ -1,0 +1,57 @@
+(** Stack-backed pool of reusable [float array] workspace buffers.
+
+    PR-4 of the engine-pooling plan
+    ([dev/plans/engine-layer-pooling-2026-04-27.md]) targets the residual
+    per-call allocations inside [Price_path] hot paths that aren't naturally
+    per-symbol. The dominant offender flagged by the post-PR-A memtrace
+    ([dev/notes/panels-memtrace-postA-2026-04-26.md]) is
+    [Price_path._sample_student_t.sum_squares], which on the [bull-crash-292x6y]
+    matrix run accounts for ~85K sampled allocations from a single [ref 0.0]
+    accumulator created per call (~850M real allocations on a 6y matrix).
+
+    [Buffer_pool.t] models that as a [Stack] of borrow-and-return [float array]
+    workspaces. Callers [acquire] a buffer on entry, mutate in place, then
+    [release] on exit. The stack discipline is **load-bearing**: callers must
+    release in LIFO order. Because the engine is single-threaded by
+    construction, no synchronization is needed.
+
+    The pool grows lazily. [acquire] returns either a recycled buffer (popped
+    from the stack) or a freshly-allocated one (sized to [capacity]). [release]
+    pushes the buffer back unless the stack is already full
+    ([Stack.length >= max_size]), in which case the buffer is dropped to GC —
+    bounding the pool's steady-state memory.
+
+    Not thread-safe. *)
+
+type t
+(** A pool of [float array] buffers. *)
+
+val create : initial_size:int -> max_size:int -> t
+(** [create ~initial_size ~max_size] creates an empty pool that will hold up to
+    [max_size] buffers in its free stack. [initial_size] is the default capacity
+    that [acquire] uses when no [capacity] argument is supplied; it also
+    pre-allocates one buffer at construction so the very first [acquire] is
+    allocation-free.
+
+    @raise Invalid_argument
+      if [initial_size < 1] or [max_size < 1] or [max_size < initial_size]. *)
+
+val acquire : t -> ?capacity:int -> unit -> float array
+(** [acquire pool ?capacity ()] returns a buffer of length at least [capacity]
+    (defaulting to the pool's [initial_size] when not specified).
+
+    If the pool's free stack has a buffer of sufficient length, that buffer is
+    popped and returned. Otherwise a fresh buffer of length [capacity] is
+    allocated. The returned buffer's contents are unspecified; callers must
+    initialise the slots they use. *)
+
+val release : t -> float array -> unit
+(** [release pool buf] returns [buf] to the pool. If the pool already holds
+    [max_size] buffers, [buf] is dropped (left to GC) instead — this bounds the
+    pool's steady-state retention.
+
+    Calling [release] on a buffer that wasn't obtained from this pool is
+    harmless but pointless. *)
+
+val length : t -> int
+(** Number of free buffers currently held by the pool. Diagnostic only. *)

--- a/trading/trading/engine/lib/dune
+++ b/trading/trading/engine/lib/dune
@@ -2,6 +2,6 @@
  (public_name trading.engine)
  (name trading_engine)
  (libraries trading.base trading.orders status)
- (modules types engine price_path)
+ (modules types engine price_path buffer_pool)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/engine/lib/engine.ml
+++ b/trading/trading/engine/lib/engine.ml
@@ -35,15 +35,25 @@ let create config =
 
 (* Look up (or lazily create) a [Price_path.Scratch.t] for [symbol] sized for
    [path_config]. The capacity probe is pure — no scratch is allocated unless
-   one is actually missing or too small. *)
+   one is actually missing or too small.
+
+   PR-4 of the engine-pooling plan: use [Hashtbl.find_or_add] (which calls
+   [default ()] only on miss) instead of [Hashtbl.find] + match on
+   [Some]/[None]. The earlier [match Hashtbl.find …] form allocated a fresh
+   [Some] tag on every call — the largest per-call cost left in
+   [Engine.update_market.(fun)] after PR-3 per the post-PR-A memtrace
+   ([dev/notes/panels-memtrace-postA-2026-04-26.md]). *)
 let _scratch_for_symbol engine ~symbol ~path_config =
   let required = Price_path.Scratch.required_capacity path_config in
-  match Hashtbl.find engine.path_scratches symbol with
-  | Some scratch when Price_path.Scratch.capacity scratch >= required -> scratch
-  | _ ->
-      let scratch = Price_path.Scratch.for_config path_config in
-      Hashtbl.set engine.path_scratches ~key:symbol ~data:scratch;
-      scratch
+  let scratch =
+    Hashtbl.find_or_add engine.path_scratches symbol ~default:(fun () ->
+        Price_path.Scratch.for_config path_config)
+  in
+  if Price_path.Scratch.capacity scratch >= required then scratch
+  else
+    let grown = Price_path.Scratch.for_config path_config in
+    Hashtbl.set engine.path_scratches ~key:symbol ~data:grown;
+    grown
 
 let update_market ?(path_config = Price_path.default_config) engine bars =
   List.iter bars ~f:(fun bar ->

--- a/trading/trading/engine/lib/price_path.ml
+++ b/trading/trading/engine/lib/price_path.ml
@@ -37,21 +37,36 @@ let default_config =
 let _capacity_slack_for_config = 8
 let _min_scratch_capacity = 4
 
+(* Pool tuning for transient workspaces inside [Price_path]. The hottest
+   pool consumer is [_sample_student_t], which acquires a 1-slot float
+   accumulator on every call (called once per interpolated bar point, ~390
+   times per [generate_path_into] call). With [max_size = 4] the pool
+   never grows past a handful of buffers in steady state, and
+   [initial_size = 1] keeps each buffer minimal. *)
+let _student_t_pool_initial_size = 1
+let _student_t_pool_max_size = 4
+
 module Scratch = struct
-  type t = { path_points : float array }
+  type t = { path_points : float array; student_t_pool : Buffer_pool.t }
 
   let create ~capacity =
     if capacity < _min_scratch_capacity then
       invalid_arg
         (Printf.sprintf "Price_path.Scratch.create: capacity %d < min %d"
            capacity _min_scratch_capacity);
-    { path_points = Array.create ~len:capacity 0.0 }
+    {
+      path_points = Array.create ~len:capacity 0.0;
+      student_t_pool =
+        Buffer_pool.create ~initial_size:_student_t_pool_initial_size
+          ~max_size:_student_t_pool_max_size;
+    }
 
   let required_capacity (c : path_config) =
     Int.max _min_scratch_capacity (c.total_points + _capacity_slack_for_config)
 
   let for_config (c : path_config) = create ~capacity:(required_capacity c)
   let capacity t = Array.length t.path_points
+  let student_t_pool t = t.student_t_pool
 end
 
 (** {1 Utility Functions} *)
@@ -327,28 +342,31 @@ let _sample_standard_normal (random_state : Random.State.t) : float =
   Float.sqrt (-2.0 *. Float.log u1) *. Float.cos (2.0 *. Float.pi *. u2)
 
 (** Sample Student's t-distribution: T = Z / sqrt(V/df), with Z ~ N(0,1) and V ~
-    Chi-squared(df). Heavier tails than Gaussian for low df. The chi- squared
-    sum is a [for] loop with a mutable accumulator (left-fold) — same FP order
-    as the previous recursive impl, so seeded goldens stay bit-equal. *)
-let _sample_student_t (random_state : Random.State.t) (df : float) : float =
+    Chi-squared(df). Heavier tails than Gaussian for low df. The chi-squared sum
+    uses a 1-slot [float array] accumulator borrowed from [pool] (PR-4 of the
+    engine-pooling plan); previously this was a [ref 0.0] allocated per call.
+    The accumulation order is the same left-fold [for] loop as before — seeded
+    goldens stay bit-equal. *)
+let _sample_student_t ~pool (random_state : Random.State.t) (df : float) : float
+    =
   let z = _sample_standard_normal random_state in
-  let chi_squared =
-    let acc = ref 0.0 in
-    for _ = 1 to Float.to_int df do
-      let s = _sample_standard_normal random_state in
-      acc := !acc +. (s *. s)
-    done;
-    !acc
-  in
+  let acc = Buffer_pool.acquire pool ~capacity:1 () in
+  acc.(0) <- 0.0;
+  for _ = 1 to Float.to_int df do
+    let s = _sample_standard_normal random_state in
+    acc.(0) <- acc.(0) +. (s *. s)
+  done;
+  let chi_squared = acc.(0) in
+  Buffer_pool.release pool acc;
   z /. Float.sqrt (chi_squared /. df)
 
 (** Brownian bridge: write [n_points] interpolated prices into
     [out.(out_start .. out_start + n_points - 1)] from [start_price] toward
     [end_price]. The endpoint is NOT written; callers append it. FP order
     matches the previous list-based version. *)
-let _generate_bridge_segment_into ~random_state ~out ~out_start ~start_price
-    ~end_price ~n_points ~volatility_scale ~degrees_of_freedom ~resolution
-    ~low_bound ~high_bound =
+let _generate_bridge_segment_into ~random_state ~pool ~out ~out_start
+    ~start_price ~end_price ~n_points ~volatility_scale ~degrees_of_freedom
+    ~resolution ~low_bound ~high_bound =
   (* Noise scales with sqrt(time): each step covers dt/(n_points+1) of the
      bar's [dt = n_points/resolution] fraction. *)
   let dt = Float.of_int n_points /. Float.of_int resolution in
@@ -362,7 +380,7 @@ let _generate_bridge_segment_into ~random_state ~out ~out_start ~start_price
       (end_price -. !current_price) /. Float.of_int remaining_steps
     in
     let noise =
-      _sample_student_t random_state degrees_of_freedom *. noise_scale
+      _sample_student_t ~pool random_state degrees_of_freedom *. noise_scale
     in
     let new_price = !current_price +. needed_drift +. noise in
     let clamped_price =
@@ -377,8 +395,9 @@ let _generate_bridge_segment_into ~random_state ~out ~out_start ~start_price
 (** Append one segment of prices to [out] from [cursor]; return the new cursor.
     First segment writes [p1] as slot 0; subsequent ones inherit it from the
     previous segment's endpoint. *)
-let _append_segment_into ~random_state ~volatility_scale ~degrees_of_freedom
-    ~total_points ~low_bound ~high_bound ~out ~cursor p1 p2 idx1 idx2 =
+let _append_segment_into ~random_state ~pool ~volatility_scale
+    ~degrees_of_freedom ~total_points ~low_bound ~high_bound ~out ~cursor p1 p2
+    idx1 idx2 =
   let cursor =
     if cursor = 0 then (
       out.(0) <- p1;
@@ -386,7 +405,7 @@ let _append_segment_into ~random_state ~volatility_scale ~degrees_of_freedom
     else cursor
   in
   let n_points = idx2 - idx1 in
-  _generate_bridge_segment_into ~random_state ~out ~out_start:cursor
+  _generate_bridge_segment_into ~random_state ~pool ~out ~out_start:cursor
     ~start_price:p1 ~end_price:p2 ~n_points ~volatility_scale
     ~degrees_of_freedom ~resolution:total_points ~low_bound ~high_bound;
   let cursor = cursor + n_points in
@@ -395,14 +414,14 @@ let _append_segment_into ~random_state ~volatility_scale ~degrees_of_freedom
 
 (** Interpolate three pairs of waypoints into [out]; return final cursor (=
     total length written). *)
-let _generate_segments_into ~random_state ~volatility_scale ~degrees_of_freedom
-    ~total_points ~low_bound ~high_bound ~out ~waypoint_prices ~waypoint_indices
-    =
+let _generate_segments_into ~random_state ~pool ~volatility_scale
+    ~degrees_of_freedom ~total_points ~low_bound ~high_bound ~out
+    ~waypoint_prices ~waypoint_indices =
   let p0, p1, p2, p3 = waypoint_prices in
   let i0, i1, i2, i3 = waypoint_indices in
   let append =
-    _append_segment_into ~random_state ~volatility_scale ~degrees_of_freedom
-      ~total_points ~low_bound ~high_bound ~out
+    _append_segment_into ~random_state ~pool ~volatility_scale
+      ~degrees_of_freedom ~total_points ~low_bound ~high_bound ~out
   in
   let cursor = append ~cursor:0 p0 p1 i0 i1 in
   let cursor = append ~cursor p1 p2 i1 i2 in
@@ -439,8 +458,9 @@ let _generate_path_with_scratch ~scratch ~config (bar : price_bar) :
     let p0, p1, p2, p3 = waypoint_prices in
     [ { price = p0 }; { price = p1 }; { price = p2 }; { price = p3 } ]
   else
+    let pool = Scratch.student_t_pool scratch in
     let len =
-      _generate_segments_into ~random_state ~volatility_scale
+      _generate_segments_into ~random_state ~pool ~volatility_scale
         ~degrees_of_freedom:config.degrees_of_freedom
         ~total_points:config.total_points ~low_bound:bar.low_price
         ~high_bound:bar.high_price ~out:scratch.Scratch.path_points

--- a/trading/trading/engine/test/dune
+++ b/trading/trading/engine/test/dune
@@ -22,3 +22,7 @@
 (test
  (name test_price_path_buffer_reuse)
  (libraries ounit2 core trading.engine trading.base matchers))
+
+(test
+ (name test_buffer_pool)
+ (libraries ounit2 trading.engine matchers))

--- a/trading/trading/engine/test/test_buffer_pool.ml
+++ b/trading/trading/engine/test/test_buffer_pool.ml
@@ -1,0 +1,127 @@
+(** Unit tests for [Trading_engine.Buffer_pool] — the Stack-backed pool of
+    [float array] workspace buffers introduced in PR-4 of the engine-pooling
+    plan.
+
+    The bit-equality parity gate that locks the pool's behaviour against
+    [Price_path] callers lives in [test_price_path_buffer_reuse.ml]
+    ([test_golden_bit_equality]) and [test_engine.ml]
+    ([test_engine_scratch_threading_parity]). This file pins the pool API
+    contract itself: acquire/release semantics, capacity guarantees, and the
+    [max_size] retention bound. *)
+
+open OUnit2
+open Trading_engine
+open Matchers
+
+(** {1 Construction validation} *)
+
+let test_create_rejects_zero_initial_size _ =
+  let result =
+    try
+      let _ = Buffer_pool.create ~initial_size:0 ~max_size:4 in
+      `Ok
+    with Invalid_argument _ -> `Invalid_argument
+  in
+  assert_that result (equal_to `Invalid_argument)
+
+let test_create_rejects_zero_max_size _ =
+  let result =
+    try
+      let _ = Buffer_pool.create ~initial_size:4 ~max_size:0 in
+      `Ok
+    with Invalid_argument _ -> `Invalid_argument
+  in
+  assert_that result (equal_to `Invalid_argument)
+
+let test_create_rejects_max_below_initial _ =
+  let result =
+    try
+      let _ = Buffer_pool.create ~initial_size:8 ~max_size:4 in
+      `Ok
+    with Invalid_argument _ -> `Invalid_argument
+  in
+  assert_that result (equal_to `Invalid_argument)
+
+(** {1 Pre-seeded buffer is allocation-free on first acquire} *)
+
+let test_create_pre_seeds_one_buffer _ =
+  (* The pool pre-allocates a single buffer at construction so the first
+     [acquire] doesn't allocate — verified here by [length = 1]. *)
+  let pool = Buffer_pool.create ~initial_size:4 ~max_size:8 in
+  assert_that (Buffer_pool.length pool) (equal_to 1)
+
+(** {1 Acquire / release round-trip} *)
+
+let test_acquire_release_round_trip _ =
+  (* Acquire pops, release pushes back. After one round-trip the pool's
+     length returns to its original value. *)
+  let pool = Buffer_pool.create ~initial_size:4 ~max_size:8 in
+  let buf = Buffer_pool.acquire pool () in
+  assert_that (Buffer_pool.length pool) (equal_to 0);
+  Buffer_pool.release pool buf;
+  assert_that (Buffer_pool.length pool) (equal_to 1)
+
+let test_acquire_returns_buffer_at_initial_size _ =
+  (* When [?capacity] is omitted, [acquire] uses the pool's [initial_size]. *)
+  let pool = Buffer_pool.create ~initial_size:7 ~max_size:8 in
+  let buf = Buffer_pool.acquire pool () in
+  assert_that (Array.length buf) (equal_to 7)
+
+let test_acquire_with_capacity_returns_at_least_capacity _ =
+  (* Re-using a pre-seeded buffer of size 4 to satisfy a capacity:5 request
+     would underflow — so [acquire] allocates fresh instead. *)
+  let pool = Buffer_pool.create ~initial_size:4 ~max_size:8 in
+  let buf = Buffer_pool.acquire pool ~capacity:5 () in
+  assert_that (Array.length buf >= 5) (equal_to true)
+
+(** {1 Max-size retention bound} *)
+
+let test_release_drops_when_pool_is_full _ =
+  (* When the pool already holds [max_size] buffers, [release] drops the
+     buffer rather than growing the stack unboundedly. *)
+  let pool = Buffer_pool.create ~initial_size:1 ~max_size:2 in
+  (* Pool starts with 1 pre-seeded buffer. *)
+  let b1 = Buffer_pool.acquire pool () in
+  let b2 = Buffer_pool.acquire pool () in
+  let b3 = Buffer_pool.acquire pool () in
+  Buffer_pool.release pool b1;
+  Buffer_pool.release pool b2;
+  Buffer_pool.release pool b3;
+  (* Three releases against max_size=2 → only two stick. *)
+  assert_that (Buffer_pool.length pool) (equal_to 2)
+
+(** {1 Pool reuse: same buffer returned on consecutive acquires} *)
+
+let test_release_then_acquire_reuses_same_buffer _ =
+  (* The Stack discipline guarantees LIFO reuse: a single acquire/release
+     pair returns the same array object on the next acquire. This is the
+     core invariant that makes pooling allocation-free. *)
+  let pool = Buffer_pool.create ~initial_size:4 ~max_size:8 in
+  let buf1 = Buffer_pool.acquire pool () in
+  Buffer_pool.release pool buf1;
+  let buf2 = Buffer_pool.acquire pool () in
+  assert_that (buf1 == buf2) (equal_to true)
+
+(** {1 Test Suite} *)
+
+let suite =
+  "Buffer Pool Tests"
+  >::: [
+         "create rejects initial_size=0"
+         >:: test_create_rejects_zero_initial_size;
+         "create rejects max_size=0" >:: test_create_rejects_zero_max_size;
+         "create rejects max_size<initial_size"
+         >:: test_create_rejects_max_below_initial;
+         "create pre-seeds one buffer" >:: test_create_pre_seeds_one_buffer;
+         "acquire/release round-trip" >:: test_acquire_release_round_trip;
+         "acquire returns buffer at initial_size"
+         >:: test_acquire_returns_buffer_at_initial_size;
+         "acquire ?capacity returns >= capacity"
+         >:: test_acquire_with_capacity_returns_at_least_capacity;
+         "release drops when pool is full"
+         >:: test_release_drops_when_pool_is_full;
+         "release then acquire reuses same buffer"
+         >:: test_release_then_acquire_reuses_same_buffer;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR-4 of `dev/plans/engine-layer-pooling-2026-04-27.md`. Adds a Stack-backed buffer pool for the residual per-call workspace allocations inside `Price_path` and `Engine.update_market` that PR-2 (#626) and PR-3 (#628) couldn't reach (because they aren't naturally per-symbol).

- **`Buffer_pool.{ml,mli}`** — new module: a `Stack` of borrow-and-return `float array` workspaces with `acquire ?capacity ()` / `release` / bounded `max_size` retention. Pre-seeds one buffer at construction so the first `acquire` is allocation-free.
- **`Price_path._sample_student_t`** — replaces the per-call `let acc = ref 0.0` chi-squared accumulator with a 1-slot float-array borrowed from a per-`Scratch` `Buffer_pool.t`. The 1-slot accumulator is acquired/released around every interpolated bar point (~390 calls per `generate_path_into`). Per the post-PR-A memtrace (`dev/notes/panels-memtrace-postA-2026-04-26.md`) this was the dominant remaining per-call alloc inside `Price_path` after PR-3: ~85K sampled allocations on the `bull-crash-292x6y` matrix run = ~850M real allocations on a 6y matrix.
- **`Engine._scratch_for_symbol`** — switches from `match Hashtbl.find … with Some … | _` to `Hashtbl.find_or_add … ~default`. Removes the per-call `Some` allocation that was the largest cost left in `Engine.update_market.(fun)` after PR-3 (~316 KB / 19,800 sampled events on the same memtrace).

The chi-squared accumulation is the same left-fold `for` loop as before, just storing into `acc.(0)` instead of `!acc`. **FP order is unchanged**, so seeded goldens stay bit-equal.

## Bit-equality parity gates

The load-bearing bit-equality tests pass unchanged with this refactor:

- `test_price_path_buffer_reuse.test_golden_bit_equality` — pins exact float values that depend on the chi-squared accumulator order. Would fail if `_sample_student_t` drifted.
- `test_panel_loader_parity` — end-to-end backtest output bit-equality on `tiered-loader-parity` and `panel-golden-2019-full` scenarios.
- `test_engine_scratch_threading_parity` — engine-level reuse contract (added in PR-3, exercises the pool indirectly).

## What it pools

- `Price_path._sample_student_t.sum_squares` accumulator (1 slot × per-bar-point × per-tick × per-symbol).
- The `Engine.update_market` `Hashtbl.find` `Some` allocation is removed structurally rather than pooled (different pattern; `find_or_add` is the idiomatic fix).

## Test plan

- [x] `dune build` clean (no warnings)
- [x] `dune build @fmt` clean
- [x] `dune runtest trading/engine/test` — 9 (Buffer_pool) + 9 (Price_path buffer-reuse golden) + 18 (Price_path) + 48 (Engine) + 12 (Types) = **96 tests pass**
- [x] `test_panel_loader_parity` (load-bearing end-to-end golden) — passes both scenarios in 1.4 s
- [x] `bash devtools/checks/linter_magic_numbers.sh` clean
- [x] `bash devtools/checks/fn_length_linter.sh` clean
- [x] `bash devtools/checks/linter_mli_coverage.sh` clean

## Files

```
trading/trading/engine/lib/buffer_pool.{ml,mli}        new (97 LOC)
trading/trading/engine/lib/price_path.ml               +52 / -33
trading/trading/engine/lib/engine.ml                   +20 / -8
trading/trading/engine/lib/dune                        +1 / -1
trading/trading/engine/test/test_buffer_pool.ml        new (127 LOC)
trading/trading/engine/test/dune                       +4
```

Total: **291 insertions, 35 deletions** across 7 files. ~150 LOC of production code (within the plan's "~100 LOC" estimate, slightly over due to thread-through plumbing for the new `~pool` argument).

## Memtrace re-run / per-step delta

Deferred to PR-5 of the engine-pooling plan ("matrix re-run validation"), which lands all four PRs together against the `bull-crash-292x6y` matrix and pins the new RSS slope (β ≈ 1-1.5 MB/symbol per the plan).

## Authority

- Plan: `dev/plans/engine-layer-pooling-2026-04-27.md` §PR-4
- Memtrace: `dev/notes/panels-memtrace-postA-2026-04-26.md`
- PR-3 follow-up: `dev/notes/engine-pool-pr3-impact-2026-04-27.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)