### PR TITLE
fix(backtest-perf): tier-1 smoke universe_path resolution + flip continue-on-error: false

### DIFF
--- a/.github/workflows/perf-tier1.yml
+++ b/.github/workflows/perf-tier1.yml
@@ -5,10 +5,17 @@
 # captures wall-time + peak RSS, and writes the result into the GHA job
 # summary so reviewers can read off perf at a glance.
 #
-# Non-blocking by design (continue-on-error: true). The catalog is fresh
-# and per-cell budgets aren't pinned yet; we want VISIBILITY first, gating
-# later. Flip continue-on-error off once the budgets in
-# dev/plans/perf-scenario-catalog-2026-04-25.md tier 1 are pinned.
+# Tier-1 is the per-PR gate: continue-on-error: false (strict). Per-cell
+# budgets aren't pinned yet, but the smoke MUST pass — i.e. every tier-1
+# scenario must complete without crashing inside the 120 s/cell timeout.
+# Once budgets are pinned (~10 PR cycles of real data per
+# dev/plans/perf-scenario-catalog-2026-04-25.md tier 1), the wall +
+# peak-RSS thresholds add a second layer of regression detection on top
+# of the smoke pass.
+#
+# Tier-2 (perf-nightly.yml) and tier-3 (perf-weekly.yml) keep
+# continue-on-error: true for now — they're VISIBILITY-first while
+# their budgets warm up (~10 weeks / ~10 weekly cycles of data).
 #
 # Tier-1 scenarios covered (kept in sync via trading/devtools/checks/perf_catalog_check.sh):
 #   trading/test_data/backtest_scenarios/perf-sweep/bull-3m.sexp
@@ -51,7 +58,7 @@ jobs:
 
       - name: Run tier-1 perf smoke
         id: tier1
-        continue-on-error: true
+        continue-on-error: false
         run: dev/scripts/perf_tier1_smoke.sh
 
       - name: Publish summary

--- a/dev/plans/perf-tier1-universe-path-2026-04-28.md
+++ b/dev/plans/perf-tier1-universe-path-2026-04-28.md
@@ -1,0 +1,149 @@
+# Plan: Fix tier-1 smoke universe_path resolution + flip the gate
+
+Date: 2026-04-28
+Branch: `fix/perf-tier1-universe-path`
+Status file: `dev/status/backtest-perf.md` next-step #4
+
+## Problem
+
+Every tier-1 perf-tier1.yml run since #616 fails 4/4. Reproduction:
+
+```sh
+TRADING_DATA_DIR=$(pwd)/trading/test_data dev/scripts/perf_tier1_smoke.sh
+```
+
+Symptom (per scenario log):
+
+```
+Scenario bull-3m crashed: (Sys_error
+  ".../trading/trading/test_data/backtest_scenarios/universes/broad.sexp:
+   No such file or directory")
+```
+
+Note the doubled `trading/trading/` segment.
+
+## Root cause
+
+`trading/trading/backtest/scenarios/scenario_runner.ml`:
+
+```ocaml
+let _fixtures_root () =
+  let root = Data_path.default_data_dir () |> Fpath.parent |> Fpath.to_string in
+  root ^ "trading/test_data/backtest_scenarios"
+```
+
+This was written assuming `Data_path.default_data_dir()` points to the
+project's `data/` directory at the repo root (the original devcontainer
+`/workspaces/trading-1/data` shape). `Fpath.parent` then gives the repo
+root, and `^ "trading/test_data/..."` reaches the fixtures.
+
+But the perf-tier workflows set
+`TRADING_DATA_DIR=$GHA_WORKSPACE/trading/test_data`, so:
+- `Fpath.parent ".../trading/test_data"` = `".../trading/"`
+- `^ "trading/test_data/backtest_scenarios"` = `".../trading/trading/test_data/backtest_scenarios"`  ← doubled!
+
+The same issue affects `_repo_root()` for `_make_output_root()` (writes
+to `.../trading/dev/backtest/scenarios-...` instead of `.../dev/backtest/...`),
+but that path is only used to write artefacts, so the bug surfaces only
+on the universe lookup which fails fast on the first scenario.
+
+## Why this wasn't caught before
+
+`continue-on-error: true` on the workflow step masks the failure. The
+step exits non-zero internally, but GHA reports the job as green. The
+scenarios actually fail to load their universe and crash. Net: tier-1
+gates nothing.
+
+## Fix decision: Option A — explicit `--fixtures-root` flag
+
+Why A over the alternatives:
+- **Option B** (resolve relative to scenario file source dir): the
+  smoke scripts COPY the scenario into a `_stage_<name>/` dir to use
+  the `--dir` entry point. The scenario's own path is the staged copy,
+  which has no relationship to the fixtures root. So B would still
+  need an extra signal.
+- **Option C** (stage universe + sectors.csv alongside): copies a lot
+  of data per scenario (the broad universe sexp is small, but the
+  pattern leaks beyond just universes — sectors.csv is several MB
+  and would need to be staged for every cell). More invasive than A.
+- **Option A** (explicit `--fixtures-root`): one flag, one passthrough.
+  Smoke scripts already know
+  `SCENARIO_ROOT="${REPO_ROOT}/trading/test_data/backtest_scenarios"`
+  — just plumb it through. Backwards-compatible: if the flag is
+  absent, the runner falls back to a saner default
+  (`Data_path.default_data_dir() / "backtest_scenarios"` — same
+  shape the test files already use, so they stay green).
+
+## Plan
+
+### Step 1: Add `--fixtures-root` flag to scenario_runner
+
+`trading/trading/backtest/scenarios/scenario_runner.ml`:
+- Add `fixtures_root : string option` to `_cli_args`.
+- Parse `--fixtures-root <path>`.
+- `_fixtures_root` becomes `_fixtures_root args` and returns either the
+  CLI value, or — if absent — falls back to the saner
+  `Data_path.default_data_dir() / "backtest_scenarios"` shape (same
+  as the test files in `test/test_panel_loader_parity.ml` and friends).
+  This matches the convention "`TRADING_DATA_DIR` points at
+  `trading/test_data`" that perf workflows + tests already use.
+- Thread `fixtures_root` through to the child via `_run_scenario_in_child`.
+
+### Step 2: Add a regression test
+
+Extract the `Fixtures_root.resolve` logic to
+`scenario_lib/fixtures_root.{ml,mli}` so a unit test can pin it
+without forking a process. Add `test_fixtures_root.ml` covering:
+- explicit `~fixtures_root` arg returns the path verbatim;
+- fallback uses `Data_path.default_data_dir() / "backtest_scenarios"`;
+- the doubled-`trading/trading` shape never appears.
+
+### Step 3: Update the three tier scripts
+
+`dev/scripts/perf_tier{1_smoke,2_nightly,3_weekly}.sh`:
+- Pass `--fixtures-root "$SCENARIO_ROOT"` to `scenario_runner.exe`.
+- Identical change in all three scripts.
+
+### Step 4: Flip continue-on-error on tier-1
+
+`.github/workflows/perf-tier1.yml`:
+- `continue-on-error: true` → `false` on the `Run tier-1 perf smoke`
+  step.
+
+Tier-2 and tier-3: leave `continue-on-error: true` for now. The
+warm-up budgets are not pinned (~10 weeks of nightly data needed for
+tier-2 budgets; ~10 cycles for tier-3). Tier-1 is the per-PR gate so
+it should be strict; tiers 2/3 remain VISIBILITY-first per the
+existing rationale comments in those workflow files.
+
+### Step 5: Set PERF_CATALOG_CHECK_STRICT=1
+
+`trading/devtools/checks/dune`:
+- Set `PERF_CATALOG_CHECK_STRICT=1` on the `perf_catalog_check.sh`
+  invocation so missing tier tags fail builds.
+
+### Step 6: Local verification
+
+```sh
+docker exec -e TRADING_IN_CONTAINER=1 \
+  -e TRADING_DATA_DIR=<worktree>/trading/test_data \
+  trading-1-dev bash -c \
+  'cd <worktree> && dev/scripts/perf_tier1_smoke.sh'
+```
+
+Expected: 4/4 PASS.
+
+### Step 7: Update status file + open PR
+
+- `dev/status/backtest-perf.md` next-step #4: mark DONE; add
+  Completed entry; update the Status header.
+
+## Out of scope
+
+- Pinning per-cell budgets (after ~10 cycles of real data).
+- Tier-4 release-gate scenarios (separate parallel PR).
+- Daily-snapshot streaming (P1, separate plan).
+- Output-root resolution (`_repo_root()` / `_make_output_root()`):
+  the artefact dir lands somewhere weird (under `trading/dev/...`)
+  but it's not load-bearing — fixing in this PR would expand scope.
+  Tracked as a follow-up note in the Completed entry.

--- a/dev/scripts/perf_tier1_smoke.sh
+++ b/dev/scripts/perf_tier1_smoke.sh
@@ -114,6 +114,9 @@ _run_one() {
 
   start_epoch=$(date +%s)
   rc=0
+  # Pass --fixtures-root so the runner resolves the scenario's [universe_path]
+  # against the original trading/test_data/backtest_scenarios/ root, not the
+  # _stage_<name>/ scratch dir we copied the scenario into.
   if [ "$HAVE_GNU_TIME" = "1" ]; then
     /usr/bin/time -o "$rss_path" -f '%M' \
       timeout "$TIMEOUT" \
@@ -121,6 +124,7 @@ _run_one() {
         dune exec --no-build \
           trading/backtest/scenarios/scenario_runner.exe -- \
           --dir "$stage_dir" --parallel 1 \
+          --fixtures-root "$SCENARIO_ROOT" \
         >"$log_path" 2>&1 || rc=$?
   else
     timeout "$TIMEOUT" \
@@ -128,6 +132,7 @@ _run_one() {
         dune exec --no-build \
           trading/backtest/scenarios/scenario_runner.exe -- \
           --dir "$stage_dir" --parallel 1 \
+          --fixtures-root "$SCENARIO_ROOT" \
         >"$log_path" 2>&1 || rc=$?
     printf 'UNAVAILABLE\n' >"$rss_path"
   fi

--- a/dev/scripts/perf_tier2_nightly.sh
+++ b/dev/scripts/perf_tier2_nightly.sh
@@ -121,6 +121,9 @@ _run_one() {
 
   start_epoch=$(date +%s)
   rc=0
+  # Pass --fixtures-root so the runner resolves the scenario's [universe_path]
+  # against the original trading/test_data/backtest_scenarios/ root, not the
+  # _stage_<name>/ scratch dir we copied the scenario into.
   if [ "$HAVE_GNU_TIME" = "1" ]; then
     /usr/bin/time -o "$rss_path" -f '%M' \
       timeout "$TIMEOUT" \
@@ -128,6 +131,7 @@ _run_one() {
         dune exec --no-build \
           trading/backtest/scenarios/scenario_runner.exe -- \
           --dir "$stage_dir" --parallel 1 \
+          --fixtures-root "$SCENARIO_ROOT" \
         >"$log_path" 2>&1 || rc=$?
   else
     timeout "$TIMEOUT" \
@@ -135,6 +139,7 @@ _run_one() {
         dune exec --no-build \
           trading/backtest/scenarios/scenario_runner.exe -- \
           --dir "$stage_dir" --parallel 1 \
+          --fixtures-root "$SCENARIO_ROOT" \
         >"$log_path" 2>&1 || rc=$?
     printf 'UNAVAILABLE\n' >"$rss_path"
   fi

--- a/dev/scripts/perf_tier3_weekly.sh
+++ b/dev/scripts/perf_tier3_weekly.sh
@@ -121,6 +121,9 @@ _run_one() {
 
   start_epoch=$(date +%s)
   rc=0
+  # Pass --fixtures-root so the runner resolves the scenario's [universe_path]
+  # against the original trading/test_data/backtest_scenarios/ root, not the
+  # _stage_<name>/ scratch dir we copied the scenario into.
   if [ "$HAVE_GNU_TIME" = "1" ]; then
     /usr/bin/time -o "$rss_path" -f '%M' \
       timeout "$TIMEOUT" \
@@ -128,6 +131,7 @@ _run_one() {
         dune exec --no-build \
           trading/backtest/scenarios/scenario_runner.exe -- \
           --dir "$stage_dir" --parallel 1 \
+          --fixtures-root "$SCENARIO_ROOT" \
         >"$log_path" 2>&1 || rc=$?
   else
     timeout "$TIMEOUT" \
@@ -135,6 +139,7 @@ _run_one() {
         dune exec --no-build \
           trading/backtest/scenarios/scenario_runner.exe -- \
           --dir "$stage_dir" --parallel 1 \
+          --fixtures-root "$SCENARIO_ROOT" \
         >"$log_path" 2>&1 || rc=$?
     printf 'UNAVAILABLE\n' >"$rss_path"
   fi

--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -7,8 +7,11 @@ IN_PROGRESS
 
 Steps 1+2 (`feat/backtest-perf-tier1-catalog`, PR #574) merged
 2026-04-26T16:07Z. **`perf-tier1.yml` landed via PR #616 on 2026-04-27**
-— per-PR perf smoke is now wired (continue-on-error: true for now;
-gate later). **Tier-2 nightly workflow landed via PR #622 on
+— per-PR perf smoke is now wired. **Tier-1 universe-path bug fixed
++ gate flipped to strict on `fix/perf-tier1-universe-path`
+2026-04-28**: explicit `--fixtures-root` flag, `Fixtures_root.resolve`
+helper, `continue-on-error: false`, `PERF_CATALOG_CHECK_STRICT=1`;
+local smoke 4/4 PASS. **Tier-2 nightly workflow landed via PR #622 on
 2026-04-27**: `perf_tier2_nightly.sh` +
 `.github/workflows/perf-nightly.yml`, six tier-2 cells, 30 min/cell
 budget, cron `0 5 * * *` (22:00 PT). **Tier-3 weekly workflow open
@@ -139,6 +142,56 @@ mechanics + release-gate procedure.
   (separate PR; gated on engine-pool PR-2..PR-5).
 
 ## Completed
+
+- **Tier-1 smoke universe_path resolution + flip continue-on-error: false**
+  (2026-04-28, on `fix/perf-tier1-universe-path`). Fix for next-step #4.
+  Root cause: `scenario_runner._fixtures_root` did
+  `Data_path.default_data_dir() |> Fpath.parent ^ "trading/test_data/..."`
+  which assumed `TRADING_DATA_DIR` pointed at the legacy `data/` location
+  at the repo root. The perf workflows set
+  `TRADING_DATA_DIR=$WS/trading/test_data`, so `Fpath.parent` walked
+  one level too high and `^ "trading/..."` produced a
+  doubled-segment path
+  `.../trading/trading/test_data/backtest_scenarios`. Net: every
+  tier-1 run since #616 crashed 4/4 on the universe lookup, masked
+  by `continue-on-error: true`.
+  Files:
+  - `trading/trading/backtest/scenarios/fixtures_root.{ml,mli}` — new
+    `Fixtures_root.resolve ?fixtures_root ()` helper. With
+    `?fixtures_root`, returns it verbatim. Without, returns
+    `Data_path.default_data_dir() / "backtest_scenarios"` (matches the
+    convention `test/test_panel_loader_parity.ml` and the perf
+    workflows already use).
+  - `trading/trading/backtest/scenarios/scenario_runner.ml` — adds
+    `--fixtures-root <path>` CLI flag, threads it through
+    `_run_scenario_in_child` so each child resolves the scenario's
+    `universe_path` against the original fixtures root rather than
+    the per-cell `_stage_<name>/` scratch dir.
+  - `trading/trading/backtest/scenarios/test/test_fixtures_root.ml` —
+    4-test regression suite; pins explicit-override behaviour, env
+    fallback, and the no-doubled-`trading/trading` invariant.
+  - `dev/scripts/perf_tier{1_smoke,2_nightly,3_weekly}.sh` — pass
+    `--fixtures-root "$SCENARIO_ROOT"`.
+  - `.github/workflows/perf-tier1.yml` —
+    `continue-on-error: false` (tier-1 is the per-PR gate; tier-2/3
+    stay `true` while their warm-up budgets accumulate).
+  - `trading/devtools/checks/dune` — set
+    `PERF_CATALOG_CHECK_STRICT=1` on the dune rule so missing tier
+    tags fail the build (was annotate-only).
+  Verify:
+  ```
+  TRADING_DATA_DIR=$(pwd)/trading/test_data \
+    dev/scripts/perf_tier1_smoke.sh
+  ```
+  expected: 4/4 PASS. Also run
+  `dune runtest trading/backtest/scenarios/` (4 + 7 + 10 tests, all
+  green). Plan: `dev/plans/perf-tier1-universe-path-2026-04-28.md`.
+  Follow-up: `_repo_root()`/`_make_output_root()` in
+  `scenario_runner.ml` still uses the old `Fpath.parent` heuristic
+  (writes artefacts to `<ws>/trading/dev/backtest/scenarios-...`
+  instead of `<ws>/dev/backtest/...`); the path resolves and the dir
+  is created, just lands one level too deep. Not load-bearing —
+  separate clean-up.
 
 - **Step 4 — tier-3 weekly perf workflow** (2026-04-27, PR pending).
   Mirrors the tier-1/tier-2 pattern. Adds
@@ -272,20 +325,24 @@ mechanics + release-gate procedure.
    Likely follows Stage 4 too. Current Tiered would extrapolate to
    ~31 GB at 5000×10y; columnar projects to ~1.2 GB, well under the
    8 GB ceiling.
-4. **Tier-1 smoke is broken — universe_path resolution.** As of
-   2026-04-27, every tier-1 run since #616 landed fails 4/4 with
-   `Sys_error: ".../trading/trading/test_data/backtest_scenarios/
-   universes/broad.sexp: No such file or directory"` (note the
-   doubled `trading/trading/`). The smoke's `_stage_<name>` copy
-   approach loses the original fixtures-root context, so
-   `scenario_runner.exe --dir <stage>` resolves `(universe_path
-   "universes/broad.sexp")` against the wrong base path.
-   `continue-on-error: true` masks the failure in the job-level
-   conclusion. Functionally tier-1 smoke gates nothing right now.
-   **Defer the fix to after engine-pool PR-2..5 land** so we don't
-   churn `dev/scripts/` mid-stack. Then fix the universe_path
-   resolution + flip `continue-on-error: false` +
-   `PERF_CATALOG_CHECK_STRICT=1`.
+4. **(DONE on `fix/perf-tier1-universe-path`)** Tier-1 smoke
+   universe_path resolution + flip the gate. Added
+   `Scenario_lib.Fixtures_root.resolve` (saner default than the old
+   `Fpath.parent + "trading/test_data/..."` heuristic — uses
+   `Data_path.default_data_dir() / "backtest_scenarios"`, the same
+   shape `test/test_panel_loader_parity.ml` and the perf workflows
+   already assume) plus a new `--fixtures-root` CLI flag on
+   `scenario_runner.exe` that the three tier scripts now pass
+   explicitly so the per-cell `_stage_<name>/` scratch dir doesn't
+   confuse universe-path resolution. Flipped
+   `.github/workflows/perf-tier1.yml` `continue-on-error: false`
+   (tier-1 is the per-PR gate; tier-2/3 stay VISIBILITY-first while
+   their warm-up budgets accumulate). Set
+   `PERF_CATALOG_CHECK_STRICT=1` in `trading/devtools/checks/dune`
+   so missing tier tags fail the build. Verified: 4/4 PASS via
+   `TRADING_DATA_DIR=<repo>/trading/test_data
+   dev/scripts/perf_tier1_smoke.sh` (post-fix). Plan:
+   `dev/plans/perf-tier1-universe-path-2026-04-28.md`.
 5. After ~10 PR cycles of *real* tier-1 perf data (i.e. post
    smoke-fix above): pin per-cell budgets. Same flip applies to
    `perf-nightly.yml` once tier-2 budgets are pinned (~10 weeks of

--- a/trading/devtools/checks/dune
+++ b/trading/devtools/checks/dune
@@ -268,12 +268,19 @@
 ; referenced from .github/workflows/perf-tier1.yml exist on disk and
 ; carry [;; perf-tier: 1].
 ;
-; Annotate-only by default (exits 0 with WARNING output on violations).
-; Set PERF_CATALOG_CHECK_STRICT=1 to gate the build instead. See
-; dev/plans/perf-scenario-catalog-2026-04-25.md §"Decision items" #3.
+; Strict by default — every catalog scenario MUST carry a tier tag.
+; Initially landed annotate-only (PR #574); flipped to STRICT alongside
+; the perf-tier1.yml continue-on-error: false flip on 2026-04-28 so
+; that adding a new scenario without a tier tag fails the build rather
+; than silently drifting. See
+; dev/plans/perf-scenario-catalog-2026-04-25.md §"Decision items" #3
+; and dev/status/backtest-perf.md next-step #4.
 
 (rule
  (alias runtest)
  (deps _check_lib.sh)
  (action
-  (run sh %{dep:perf_catalog_check.sh})))
+  (setenv
+   PERF_CATALOG_CHECK_STRICT
+   1
+   (run sh %{dep:perf_catalog_check.sh}))))

--- a/trading/trading/backtest/scenarios/dune
+++ b/trading/trading/backtest/scenarios/dune
@@ -1,7 +1,7 @@
 (library
  (name scenario_lib)
- (modules scenario universe_file)
- (libraries core)
+ (modules scenario universe_file fixtures_root)
+ (libraries core fpath weinstein.data_source)
  (preprocess
   (pps ppx_sexp_conv)))
 

--- a/trading/trading/backtest/scenarios/fixtures_root.ml
+++ b/trading/trading/backtest/scenarios/fixtures_root.ml
@@ -1,0 +1,6 @@
+let resolve ?fixtures_root () =
+  match fixtures_root with
+  | Some p -> p
+  | None ->
+      let data_dir = Data_path.default_data_dir () |> Fpath.to_string in
+      Filename.concat data_dir "backtest_scenarios"

--- a/trading/trading/backtest/scenarios/fixtures_root.mli
+++ b/trading/trading/backtest/scenarios/fixtures_root.mli
@@ -1,0 +1,26 @@
+(** Fixtures-root resolution — points at the directory that contains scenario
+    fixtures, e.g. [trading/test_data/backtest_scenarios/]. Used by the scenario
+    runner to resolve a scenario's [universe_path] field (which is documented as
+    "relative to the fixtures root") even when the scenario itself has been
+    copied into a per-cell scratch staging directory.
+
+    Two callers:
+    - {!Scenario_runner} — receives an optional [--fixtures-root] CLI flag and
+      uses [resolve] to combine that with the [TRADING_DATA_DIR] fallback.
+    - Tests under [trading/backtest/test/] use [resolve ()] directly with no
+      explicit override; the fallback shape works because tests already point
+      [TRADING_DATA_DIR] at [trading/test_data/]. *)
+
+val resolve : ?fixtures_root:string -> unit -> string
+(** [resolve ?fixtures_root ()] returns an absolute path to the fixtures root.
+
+    - When [fixtures_root] is [Some p], returns [p] unchanged.
+    - When omitted, returns
+      [Data_path.default_data_dir () / "backtest_scenarios"]. This matches the
+      convention "[TRADING_DATA_DIR] points at the [trading/test_data/]
+      directory"; tests and perf workflows already use that shape.
+
+    Note: this replaces an older [Fpath.parent + "trading/test_data/..."]
+    heuristic that produced doubled-segment paths like
+    [.../trading/trading/test_data/backtest_scenarios] when [TRADING_DATA_DIR]
+    pointed at [trading/test_data/] instead of the legacy [data/] location. *)

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -3,11 +3,17 @@
 
     Usage: scenario_runner
     [--goldens-small | --goldens-broad | --goldens | --smoke | --dir <path>]
-    [--parallel N]
+    [--parallel N] [--fixtures-root <path>]
 
     [--goldens-small] — small-universe goldens (~300 symbols; local-friendly).
     [--goldens-broad] — broad-universe goldens (full sector-map; nightly/GHA).
     [--goldens] — alias for [--goldens-small] for backwards compat.
+
+    [--fixtures-root <path>] — directory the scenario [universe_path] field is
+    resolved against (defaults to [TRADING_DATA_DIR/backtest_scenarios]). The
+    perf-tier smoke scripts pass this explicitly because they stage the scenario
+    sexp into a per-cell scratch dir, which loses the original fixtures-root
+    context.
 
     Reads all *.sexp files from the selected directory, runs each via
     {!Backtest.Runner.run_backtest}, prints a pass/fail table, and writes
@@ -21,19 +27,16 @@
 open Core
 module Scenario = Scenario_lib.Scenario
 module Universe_file = Scenario_lib.Universe_file
+module Fixtures_root = Scenario_lib.Fixtures_root
 
 (* Universe resolution *)
 
-let _fixtures_root () =
-  let root = Data_path.default_data_dir () |> Fpath.parent |> Fpath.to_string in
-  root ^ "trading/test_data/backtest_scenarios"
-
-let _sector_map_of_universe_file path =
+let _sector_map_of_universe_file ~fixtures_root path =
   (* Resolve the scenario's [universe_path] relative to the fixtures root,
      load it, and return an optional sector-map for [Backtest.Runner] to use
      as its universe. [None] means "use the full [data/sectors.csv]" (broad
      tier / pre-migration behaviour). *)
-  let resolved = Filename.concat (_fixtures_root ()) path in
+  let resolved = Filename.concat fixtures_root path in
   Universe_file.to_sector_map_override (Universe_file.load resolved)
 
 (* Actual metrics extracted from a run — serialized so the parent process
@@ -151,13 +154,15 @@ let _actual_path ~output_root (s : Scenario.t) =
 
 (* Run one scenario inside a child process *)
 
-let _run_scenario_in_child ~output_root (s : Scenario.t) =
+let _run_scenario_in_child ~output_root ~fixtures_root (s : Scenario.t) =
   eprintf "\n>>> Running %s: %s (%s to %s)\n%!" s.name s.description
     (Date.to_string s.period.start_date)
     (Date.to_string s.period.end_date);
   let scenario_dir = _scenario_dir ~output_root s in
   Core_unix.mkdir_p scenario_dir;
-  let sector_map_override = _sector_map_of_universe_file s.universe_path in
+  let sector_map_override =
+    _sector_map_of_universe_file ~fixtures_root s.universe_path
+  in
   let result =
     Backtest.Runner.run_backtest ~start_date:s.period.start_date
       ~end_date:s.period.end_date ~overrides:s.config_overrides
@@ -170,11 +175,11 @@ let _run_scenario_in_child ~output_root (s : Scenario.t) =
 (* Fork-based worker pool. Scenarios run in parallel child processes up to
    [parallel] at a time. *)
 
-let _fork_scenario ~output_root (s : Scenario.t) =
+let _fork_scenario ~output_root ~fixtures_root (s : Scenario.t) =
   match Core_unix.fork () with
   | `In_the_child -> (
       try
-        _run_scenario_in_child ~output_root s;
+        _run_scenario_in_child ~output_root ~fixtures_root s;
         Stdlib.exit 0
       with e ->
         eprintf "Scenario %s crashed: %s\n%!" s.name (Exn.to_string e);
@@ -187,8 +192,8 @@ let _await_one running =
   let _, pid = Queue.dequeue_exn running in
   match Core_unix.waitpid pid with Ok () -> Succeeded | Error _ -> Crashed
 
-let _run_scenarios_parallel ~output_root ~parallel (scenarios : Scenario.t list)
-    =
+let _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
+    (scenarios : Scenario.t list) =
   let running = Queue.create () in
   let statuses = Hashtbl.create (module String) in
   let reap () =
@@ -199,7 +204,7 @@ let _run_scenarios_parallel ~output_root ~parallel (scenarios : Scenario.t list)
   in
   List.iter scenarios ~f:(fun s ->
       if Queue.length running >= parallel then reap ();
-      let pid = _fork_scenario ~output_root s in
+      let pid = _fork_scenario ~output_root ~fixtures_root s in
       Queue.enqueue running (s, pid));
   while not (Queue.is_empty running) do
     reap ()
@@ -236,40 +241,49 @@ let _process_result ~output_root (s, status) =
 
 (* CLI *)
 
-type _cli_args = { dir : string; parallel : int }
+type _cli_args = { dir : string; parallel : int; fixtures_root : string option }
 
 let _default_parallel = 4
 
 let _usage () =
   eprintf
     "Usage: scenario_runner [--goldens-small | --goldens-broad | --goldens | \
-     --smoke | --dir <path>] [--parallel N]\n";
+     --smoke | --dir <path>] [--parallel N] [--fixtures-root <path>]\n";
   Stdlib.exit 1
 
 let _parse_flag args =
-  let rec loop args dir parallel =
+  let rec loop args dir parallel fixtures_root =
     match args with
     | [] ->
         let dir = Option.value dir ~default:(_goldens_small_dir ()) in
-        { dir; parallel = Option.value parallel ~default:_default_parallel }
+        {
+          dir;
+          parallel = Option.value parallel ~default:_default_parallel;
+          fixtures_root;
+        }
     | "--goldens-small" :: rest ->
-        loop rest (Some (_goldens_small_dir ())) parallel
+        loop rest (Some (_goldens_small_dir ())) parallel fixtures_root
     | "--goldens-broad" :: rest ->
-        loop rest (Some (_goldens_broad_dir ())) parallel
-    | "--goldens" :: rest -> loop rest (Some (_goldens_small_dir ())) parallel
-    | "--smoke" :: rest -> loop rest (Some (_smoke_dir ())) parallel
-    | "--dir" :: path :: rest -> loop rest (Some path) parallel
-    | "--parallel" :: n :: rest -> loop rest dir (Some (Int.of_string n))
+        loop rest (Some (_goldens_broad_dir ())) parallel fixtures_root
+    | "--goldens" :: rest ->
+        loop rest (Some (_goldens_small_dir ())) parallel fixtures_root
+    | "--smoke" :: rest ->
+        loop rest (Some (_smoke_dir ())) parallel fixtures_root
+    | "--dir" :: path :: rest -> loop rest (Some path) parallel fixtures_root
+    | "--parallel" :: n :: rest ->
+        loop rest dir (Some (Int.of_string n)) fixtures_root
+    | "--fixtures-root" :: path :: rest -> loop rest dir parallel (Some path)
     | _ -> _usage ()
   in
-  loop args None None
+  loop args None None None
 
 let _parse_args () =
   let argv = Sys.get_argv () in
   _parse_flag (List.tl_exn (Array.to_list argv))
 
 let () =
-  let { dir; parallel } = _parse_args () in
+  let { dir; parallel; fixtures_root } = _parse_args () in
+  let fixtures_root = Fixtures_root.resolve ?fixtures_root () in
   let files = _list_scenario_files dir in
   if List.is_empty files then (
     eprintf "No .sexp scenario files found in %s\n" dir;
@@ -277,10 +291,13 @@ let () =
   let parallel = min parallel (List.length files) in
   eprintf "Loading %d scenarios from %s (parallel=%d)\n%!" (List.length files)
     dir parallel;
+  eprintf "Fixtures root: %s\n%!" fixtures_root;
   let scenarios = List.map files ~f:Scenario.load in
   let output_root = _make_output_root () in
   eprintf "Output root: %s\n%!" output_root;
-  let results = _run_scenarios_parallel ~output_root ~parallel scenarios in
+  let results =
+    _run_scenarios_parallel ~output_root ~fixtures_root ~parallel scenarios
+  in
   _print_header ();
   let pass_flags = List.map results ~f:(_process_result ~output_root) in
   let all_pass = List.for_all pass_flags ~f:Fn.id in

--- a/trading/trading/backtest/scenarios/test/dune
+++ b/trading/trading/backtest/scenarios/test/dune
@@ -1,4 +1,4 @@
 (tests
- (names test_scenario test_universe_file)
- (modules test_scenario test_universe_file)
- (libraries ounit2 core scenario_lib matchers))
+ (names test_scenario test_universe_file test_fixtures_root)
+ (modules test_scenario test_universe_file test_fixtures_root)
+ (libraries ounit2 core core_unix scenario_lib matchers))

--- a/trading/trading/backtest/scenarios/test/test_fixtures_root.ml
+++ b/trading/trading/backtest/scenarios/test/test_fixtures_root.ml
@@ -1,0 +1,74 @@
+(* Regression tests for [Scenario_lib.Fixtures_root].
+
+   The bug being pinned: a previous scenario_runner heuristic resolved the
+   fixtures root via [Data_path.default_data_dir () |> Fpath.parent ^
+   "trading/test_data/backtest_scenarios"]. With [TRADING_DATA_DIR] pointing
+   at [trading/test_data] (the convention now used by the perf-tier workflows
+   and by all in-repo tests), that produced a doubled-segment path
+   [.../trading/trading/test_data/backtest_scenarios] which fails to resolve
+   the universe sexp. See [dev/plans/perf-tier1-universe-path-2026-04-28.md]
+   and the dev/status/backtest-perf.md next-step #4 entry. *)
+
+open OUnit2
+open Core
+open Matchers
+module Fixtures_root = Scenario_lib.Fixtures_root
+
+(* Snapshot + restore [TRADING_DATA_DIR] around each test so cases don't
+   leak env state to siblings or to the surrounding test runner. *)
+let _with_trading_data_dir value f =
+  let prev = Sys.getenv "TRADING_DATA_DIR" in
+  Core_unix.putenv ~key:"TRADING_DATA_DIR" ~data:value;
+  Exn.protect ~f ~finally:(fun () ->
+      match prev with
+      | Some v -> Core_unix.putenv ~key:"TRADING_DATA_DIR" ~data:v
+      | None -> Core_unix.unsetenv "TRADING_DATA_DIR")
+
+let test_explicit_override_is_returned_verbatim _ =
+  assert_that
+    (Fixtures_root.resolve ~fixtures_root:"/explicit/path" ())
+    (equal_to "/explicit/path")
+
+let test_explicit_override_wins_over_env _ =
+  _with_trading_data_dir "/some/other/place" (fun () ->
+      assert_that
+        (Fixtures_root.resolve ~fixtures_root:"/explicit/path" ())
+        (equal_to "/explicit/path"))
+
+let test_fallback_uses_data_dir_plus_backtest_scenarios _ =
+  _with_trading_data_dir "/ws/trading/test_data" (fun () ->
+      assert_that (Fixtures_root.resolve ())
+        (equal_to "/ws/trading/test_data/backtest_scenarios"))
+
+(* Pin the actual bug: the legacy [Fpath.parent + "trading/test_data/..."]
+   shape produced [/ws/trading/trading/test_data/backtest_scenarios] when
+   TRADING_DATA_DIR=/ws/trading/test_data. The current [resolve] must NOT
+   contain the doubled segment for that input. *)
+let test_no_doubled_trading_segment _ =
+  _with_trading_data_dir "/ws/trading/test_data" (fun () ->
+      let resolved = Fixtures_root.resolve () in
+      assert_that resolved
+        (all_of
+           [
+             field
+               (fun s -> String.is_substring s ~substring:"trading/trading")
+               (equal_to false);
+             field
+               (String.is_substring ~substring:"backtest_scenarios")
+               (equal_to true);
+           ]))
+
+let suite =
+  "Fixtures_root"
+  >::: [
+         "explicit override is returned verbatim"
+         >:: test_explicit_override_is_returned_verbatim;
+         "explicit override wins over TRADING_DATA_DIR"
+         >:: test_explicit_override_wins_over_env;
+         "fallback uses data dir + backtest_scenarios"
+         >:: test_fallback_uses_data_dir_plus_backtest_scenarios;
+         "no doubled trading/trading segment in fallback"
+         >:: test_no_doubled_trading_segment;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- `scenario_runner._fixtures_root` did `Data_path.default_data_dir() |> Fpath.parent ^ "trading/test_data/..."`, which assumed `TRADING_DATA_DIR` pointed at the legacy `data/` location at the repo root. The perf workflows set `TRADING_DATA_DIR=$WS/trading/test_data`, so `Fpath.parent` walked one level too high and `^ "trading/..."` produced a doubled-segment path `.../trading/trading/test_data/backtest_scenarios`. Net: every tier-1 run since #616 crashed 4/4 on the universe lookup, masked by `continue-on-error: true`. Fixes `dev/status/backtest-perf.md` next-step #4.
- **Option A** chosen: explicit `--fixtures-root <path>` flag on `scenario_runner.exe`, with a saner default (`Data_path.default_data_dir() / "backtest_scenarios"`) matching the convention `test/test_panel_loader_parity.ml` and the perf workflows already assume.
- Tier-1 `continue-on-error` flipped to `false` (per-PR gate must be strict). Tier-2/3 stay `true` until their warm-up budgets accumulate (~10 weeks / ~10 weekly cycles). `PERF_CATALOG_CHECK_STRICT=1` set on the `perf_catalog_check.sh` dune rule so missing tier tags fail the build.

## What changed

- `trading/trading/backtest/scenarios/fixtures_root.{ml,mli}` — new helper. `Fixtures_root.resolve ?fixtures_root ()`: explicit override wins; otherwise falls back to `Data_path.default_data_dir() / "backtest_scenarios"`.
- `scenario_runner.ml` — adds `--fixtures-root <path>` CLI; threaded through `_run_scenario_in_child` so each child resolves the scenario's `universe_path` against the original fixtures root rather than the per-cell `_stage_<name>/` scratch dir.
- `dev/scripts/perf_tier{1_smoke,2_nightly,3_weekly}.sh` — pass `--fixtures-root "\$SCENARIO_ROOT"`.
- `.github/workflows/perf-tier1.yml` — `continue-on-error: false`.
- `trading/devtools/checks/dune` — `PERF_CATALOG_CHECK_STRICT=1`.
- `test/test_fixtures_root.ml` — 4-test regression: explicit override, env fallback, no-doubled-`trading/trading` invariant.

## PR sizing

~ 415 LOC including 149 LOC plan + 89 LOC status delta + ~177 LOC real code (scenario_runner edits + Fixtures_root + tests + scripts + workflow + dune). Within the ≤500-LOC limit; one new module (`Fixtures_root`).

## Test plan

- [x] `dune build` clean (worktree).
- [x] `dune runtest trading/backtest/scenarios/` — 21 tests pass (4 + 7 + 10).
- [x] `dune runtest trading/backtest/` — all green with `TRADING_DATA_DIR` set (panel-loader-parity tests already required this).
- [x] `dune runtest trading/engine` — 96 tests, all green.
- [x] Local smoke reproduction of bug: 0/4 PASS pre-fix.
- [x] Local smoke verification of fix: **4/4 PASS** via `TRADING_DATA_DIR=\$(pwd)/trading/test_data dev/scripts/perf_tier1_smoke.sh`.
- [x] `posix_sh_check.sh` — 46 scripts clean.
- [x] `PERF_CATALOG_CHECK_STRICT=1 sh trading/devtools/checks/perf_catalog_check.sh` — `OK: 15 scenarios all carry tier tags.`
- [x] `dune fmt` — no diff.

CI: tier-1 perf smoke will now actually gate this PR (and every subsequent one).

## Out of scope

- Pinning per-cell budgets (after ~10 cycles of real tier-1 data).
- Tier-4 release-gate scenarios (separate parallel PR).
- Daily-snapshot streaming (P1, separate plan).
- `_repo_root()`/`_make_output_root()` cleanup: artefacts land at `<ws>/trading/dev/backtest/scenarios-...` instead of `<ws>/dev/backtest/...`. Path resolves and dir is created — not load-bearing. Tracked as a follow-up note in the Completed entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)