### PR TITLE
feat(backtest-perf): tier-4 release-gate workflow at N=1000

### DIFF
--- a/.github/workflows/perf-release-gate.yml
+++ b/.github/workflows/perf-release-gate.yml
@@ -1,0 +1,101 @@
+# Tier-4 perf release-gate: on-demand large-scope perf certification (≤8 h
+# budget per cell) for cutting a release.
+#
+# Runs every scenario tagged `;; perf-tier: 4` under
+# trading/test_data/backtest_scenarios/ via
+# dev/scripts/perf_tier4_release_gate.sh, captures wall-time + peak RSS, and
+# writes the result into the GHA job summary so the human can read off perf
+# at a glance.
+#
+# UNLIKE perf-tier1 / perf-nightly / perf-weekly, this workflow is
+# manual-only (`workflow_dispatch`). Tier-4 is the heaviest tier (decade-long
+# at N=1000, ~5.7 GB RSS, multiple-hour wall per cell — the FOUR existing
+# tier-4 cells together can run for >24 h on one runner). Running this on a
+# cron would burn a meaningful slice of the GHA minute budget for very
+# little marginal signal — the trading metrics are essentially flat
+# day-to-day, and infra-perf changes that affect tier 4 also show up in
+# tier-2 / tier-3. Per dev/plans/perf-scenario-catalog-2026-04-25.md
+# §"Release-gate strategy", this workflow is dispatched at release-cut time
+# and its output feeds the release-perf-report comparison.
+#
+# Non-blocking by design (continue-on-error: true) — same VISIBILITY-first
+# posture as tier-1/2/3. Flip continue-on-error off once budgets in
+# dev/plans/perf-scenario-catalog-2026-04-25.md tier 4 are pinned (after
+# the first 1-2 manual dispatches produce baseline numbers).
+#
+# Tier-4 scenarios covered (kept in sync via
+# trading/devtools/checks/perf_catalog_check.sh — `;; perf-tier: 4` tag is
+# the source of truth, the discovery in the runner script auto-matches):
+#   trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
+#   trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
+#   trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
+#   trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
+#
+# All four currently target N=1000 (cap via `(config_overrides
+# ((universe_cap 1000)))`). The N>=5000 release-gate cells stay deferred
+# pending daily-snapshot streaming (dev/plans/daily-snapshot-streaming-2026-04-27.md)
+# — at the post-engine-pool β=3.94 MB/symbol, N=5000×10y projects to
+# ~28 GB RSS, far beyond the 8 GB ubuntu-latest ceiling.
+name: perf-release-gate
+
+on:
+  # Manual-only — see header comment for why no cron schedule.
+  workflow_dispatch:
+
+jobs:
+  perf-tier4-release-gate:
+    runs-on: ubuntu-latest
+    # Per-cell budget is 8 h; four tier-4 cells run sequentially, so the
+    # job-level ceiling could in principle hit ~32 h. GHA caps job runtime
+    # at 360 min (6 h) on ubuntu-latest hosted runners, so we set
+    # timeout-minutes: 350 to give a margin under the platform ceiling. If
+    # in practice the four cells together exceed that, the per-cell
+    # `timeout 28800` in the shell script enforces the 8-h cap — but the
+    # job will still get killed at the platform ceiling. Acceptable for
+    # now because the operator runs this manually and can split into
+    # multiple dispatches if needed (PERF_TIER4_TIMEOUT can scope down).
+    timeout-minutes: 350
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/trading-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 0
+    env:
+      HOME: /home/opam
+      TRADING_IN_CONTAINER: "1"
+      TRADING_DATA_DIR: ${{ github.workspace }}/trading/test_data
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache _build
+        uses: actions/cache@v4
+        with:
+          path: trading/_build
+          key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
+          restore-keys: |
+            dune-${{ runner.os }}-
+
+      - name: Run tier-4 perf release-gate
+        id: tier4
+        continue-on-error: true
+        run: dev/scripts/perf_tier4_release_gate.sh
+
+      - name: Publish summary
+        if: always()
+        run: |
+          summary_file=$(ls -1t dev/perf/tier4-release-gate-*/summary.txt 2>/dev/null | head -1)
+          if [ -n "$summary_file" ] && [ -f "$summary_file" ]; then
+            {
+              echo "## Tier-4 perf release-gate"
+              echo ""
+              echo '```'
+              cat "$summary_file"
+              echo '```'
+            } >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "Tier-4 perf release-gate: no summary produced." >>"$GITHUB_STEP_SUMMARY"
+          fi

--- a/dev/scripts/perf_tier4_release_gate.sh
+++ b/dev/scripts/perf_tier4_release_gate.sh
@@ -1,0 +1,204 @@
+#!/bin/sh
+# Tier-4 perf release-gate runner.
+#
+# Discovers all scenarios with `;; perf-tier: 4` under
+# trading/test_data/backtest_scenarios/{goldens-small,goldens-broad,perf-sweep,smoke}/,
+# runs each via the scenario_runner binary with a per-scenario timeout
+# (default 28800s = 8 hours, per dev/plans/perf-scenario-catalog-2026-04-25.md
+# tier 4 budget), and prints a compact wall-time + peak-RSS table.
+#
+# Mirrors dev/scripts/perf_tier3_weekly.sh — same discovery + output layout,
+# same OCAMLRUNPARAM tuning, same scratch-dir staging trick. Differences:
+#   - tier filter is `perf-tier: 4`
+#   - per-cell timeout default is 28800s (vs 7200s for tier 3)
+#   - artefact dir is dev/perf/tier4-release-gate-<timestamp>/
+#   - env var override is PERF_TIER4_TIMEOUT / PERF_TIER4_OCAMLRUNPARAM
+#
+# Designed to run on-demand at release-cut time, not on a recurring schedule —
+# tier-4 is the heaviest tier (≤8 h per cell, decade-long at N=1000). The
+# accompanying GHA workflow (.github/workflows/perf-release-gate.yml) is
+# manual-only (workflow_dispatch). See dev/plans/perf-scenario-catalog-2026-04-25.md
+# §"Release-gate strategy" for the cut procedure.
+#
+# Exit status:
+#   0 if every tier-4 scenario completes within budget
+#   1 if any scenario exits non-zero, errors, or times out
+#
+# Usage:
+#   dev/scripts/perf_tier4_release_gate.sh                          -- run all tier-4 cells
+#   PERF_TIER4_TIMEOUT=14400 dev/scripts/perf_tier4_release_gate.sh -- bump per-cell timeout
+#
+# Designed to run inside the trading-1-dev container or under GHA where
+# TRADING_IN_CONTAINER=1; uses dev/lib/run-in-env.sh to wrap dune exec.
+#
+# Output artefacts under dev/perf/tier4-release-gate-<timestamp>/:
+#   <scenario-name>.log        scenario_runner stdout/stderr
+#   <scenario-name>.peak_rss   integer kB from /usr/bin/time -f '%M'
+#   <scenario-name>.wall_sec   seconds (real time) — best-effort
+#   <scenario-name>.error      present iff the run errored / timed out
+#   summary.txt                aggregate table written at the end
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCENARIO_ROOT="${REPO_ROOT}/trading/test_data/backtest_scenarios"
+RUN_IN_ENV="${REPO_ROOT}/dev/lib/run-in-env.sh"
+TIMEOUT="${PERF_TIER4_TIMEOUT:-28800}"
+
+# Aggressive major-GC + smaller minor heap. Same rationale as tier-1/tier-2/tier-3
+# (dev/notes/panels-rss-matrix-post602-gc-tuned-2026-04-26.md): without this,
+# the GC steady-state high-water mark inflates peak RSS by ~25-37% for runs
+# with low allocation rates. Override via PERF_TIER4_OCAMLRUNPARAM=... if a
+# specific scenario needs a different heap shape; pass empty to use the OCaml
+# defaults.
+export OCAMLRUNPARAM="${PERF_TIER4_OCAMLRUNPARAM:-o=60,s=512k}"
+
+if [ ! -x "$RUN_IN_ENV" ]; then
+  printf 'FAIL: %s not found / not executable\n' "$RUN_IN_ENV" >&2
+  exit 1
+fi
+
+if [ ! -d "$SCENARIO_ROOT" ]; then
+  printf 'FAIL: scenario root not found: %s\n' "$SCENARIO_ROOT" >&2
+  exit 1
+fi
+
+# Probe for GNU /usr/bin/time. The shell builtin has no -f / -o; we need
+# the GNU binary for peak-RSS reporting. macOS hosts won't have it.
+if [ -x /usr/bin/time ]; then
+  HAVE_GNU_TIME=1
+else
+  HAVE_GNU_TIME=0
+fi
+
+# Output dir keyed by timestamp so re-runs don't clobber each other.
+TS="$(date -u +%Y-%m-%dT%H%M%SZ)"
+OUT_DIR="${REPO_ROOT}/dev/perf/tier4-release-gate-${TS}"
+mkdir -p "$OUT_DIR"
+
+printf 'Tier-4 perf release-gate run.\n'
+printf '  Scenario root : %s\n' "$SCENARIO_ROOT"
+printf '  Output dir    : %s\n' "$OUT_DIR"
+printf '  Per-cell timeout : %ss\n' "$TIMEOUT"
+printf '  GNU /usr/bin/time : %s\n\n' "$HAVE_GNU_TIME"
+
+# Discover tier-4 scenarios (full paths, sorted for determinism).
+TIER4_PATHS=""
+for sub in goldens-small goldens-broad perf-sweep smoke; do
+  dir="${SCENARIO_ROOT}/${sub}"
+  [ -d "$dir" ] || continue
+  for sexp in "$dir"/*.sexp; do
+    [ -f "$sexp" ] || continue
+    if grep -q '^;; perf-tier: 4' "$sexp"; then
+      TIER4_PATHS="${TIER4_PATHS}${sexp}
+"
+    fi
+  done
+done
+
+if [ -z "$TIER4_PATHS" ]; then
+  printf 'WARNING: no scenarios found with [;; perf-tier: 4] -- nothing to do.\n'
+  exit 0
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TABLE_ROWS=""
+
+# Run a single scenario. Stages it into a one-element scratch dir so the
+# scenario_runner --dir entry point picks up exactly one cell. Captures
+# wall time + peak RSS from GNU /usr/bin/time.
+_run_one() {
+  scenario_path="$1"
+  base_name="$(basename "$scenario_path" .sexp)"
+  log_path="${OUT_DIR}/${base_name}.log"
+  rss_path="${OUT_DIR}/${base_name}.peak_rss"
+  wall_path="${OUT_DIR}/${base_name}.wall_sec"
+  error_path="${OUT_DIR}/${base_name}.error"
+
+  # Stage into a scratch dir; scenario_runner --dir consumes ALL .sexp in
+  # the dir, so we put just this one scenario in a fresh subdir.
+  stage_dir="${OUT_DIR}/_stage_${base_name}"
+  mkdir -p "$stage_dir"
+  cp "$scenario_path" "$stage_dir/"
+
+  printf '[run]  %s\n' "$base_name"
+
+  start_epoch=$(date +%s)
+  rc=0
+  if [ "$HAVE_GNU_TIME" = "1" ]; then
+    /usr/bin/time -o "$rss_path" -f '%M' \
+      timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" \
+        dune exec --no-build \
+          trading/backtest/scenarios/scenario_runner.exe -- \
+          --dir "$stage_dir" --parallel 1 \
+        >"$log_path" 2>&1 || rc=$?
+  else
+    timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" \
+        dune exec --no-build \
+          trading/backtest/scenarios/scenario_runner.exe -- \
+          --dir "$stage_dir" --parallel 1 \
+        >"$log_path" 2>&1 || rc=$?
+    printf 'UNAVAILABLE\n' >"$rss_path"
+  fi
+  end_epoch=$(date +%s)
+  wall_sec=$((end_epoch - start_epoch))
+  printf '%s\n' "$wall_sec" >"$wall_path"
+
+  rss_value="?"
+  if [ -f "$rss_path" ]; then
+    rss_value=$(tr -d '\n' <"$rss_path")
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    printf 'exit=%s — see %s\n' "$rc" "$log_path" >"$error_path"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}FAIL  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  else
+    PASS_COUNT=$((PASS_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}PASS  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  fi
+
+  # Clean up stage dir; keep logs.
+  rm -rf "$stage_dir"
+}
+
+# Pre-build the scenario_runner so per-cell wall numbers don't include build
+# time. Best-effort: if the build fails, _run_one will surface it.
+"$RUN_IN_ENV" dune build trading/backtest/scenarios/scenario_runner.exe \
+  >"${OUT_DIR}/_prebuild.log" 2>&1 || true
+
+# IFS-by-newline iteration — TIER4_PATHS is newline-separated.
+OLD_IFS="$IFS"
+IFS='
+'
+for path in $TIER4_PATHS; do
+  IFS="$OLD_IFS"
+  _run_one "$path"
+  IFS='
+'
+done
+IFS="$OLD_IFS"
+
+SUMMARY="${OUT_DIR}/summary.txt"
+{
+  printf 'Tier-4 perf release-gate summary (%s)\n' "$TS"
+  printf '  passed: %d\n' "$PASS_COUNT"
+  printf '  failed: %d\n' "$FAIL_COUNT"
+  printf '\n'
+  printf '%-6s  %-32s  %-8s  %s\n' "STATUS" "SCENARIO" "WALL" "PEAK_RSS"
+  printf '%s\n' "----------------------------------------------------------------------"
+  printf '%b' "$TABLE_ROWS" | awk 'NF { printf "%-6s  %-32s  %-8s  %s\n", $1, $2, $3, $4 }'
+} >"$SUMMARY"
+
+cat "$SUMMARY"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -37,7 +37,15 @@ or in flight. See `dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md`**
 Step 5 (release_perf_report OCaml exe) tracked separately;
 landed via #585 / #606 on the test-data + perf-runner side. Tier-4
 release-gate scenarios structurally unblocked since data-panels
-Stage 4.5 PR-B (#604) merged 2026-04-27T02:33Z.
+Stage 4.5 PR-B (#604) merged 2026-04-27T02:33Z. **Tier-4 release-gate
+workflow at N=1000 open at `feat/backtest-perf-tier4-release-gate` on
+2026-04-28**: `perf_tier4_release_gate.sh` +
+`.github/workflows/perf-release-gate.yml` (manual-only — no cron),
+four `goldens-broad/` cells (`bull-crash-2015-2020`,
+`covid-recovery-2020-2024`, `decade-2014-2023` (NEW),
+`six-year-2018-2023`) all baking `(config_overrides
+((universe_cap 1000)))`, 8 h/cell budget. **N≥5000 release-gate stays
+P1** pending daily-snapshot streaming.
 
 ## Interface stable
 NO
@@ -138,13 +146,32 @@ mechanics + release-gate procedure.
   23:00 PT Sunday PST), 2 h after perf-nightly's 05:00 UTC slot and
   17 min before the orchestrator's 07:17 UTC slot. Non-blocking
   (`continue-on-error: true`) — same VISIBILITY-first posture as
-  tier-1/tier-2. Tier-4 release-gate workflow remains outstanding
-  (separate PR; gated on engine-pool PR-2..PR-5).
+  tier-1/tier-2.
+- **`feat/backtest-perf-tier4-release-gate`** (Step 5 — tier-4
+  release-gate at N=1000) — open for review. Adds
+  `dev/scripts/perf_tier4_release_gate.sh` +
+  `.github/workflows/perf-release-gate.yml` (**manual-only** —
+  `workflow_dispatch` only, no cron schedule). Auto-discovers four
+  `;; perf-tier: 4` scenarios under
+  `trading/test_data/backtest_scenarios/goldens-broad/{bull-crash-2015-2020,covid-recovery-2020-2024,decade-2014-2023,six-year-2018-2023}.sexp`,
+  runs each via `scenario_runner.exe --parallel 1` with
+  `timeout 28800` (8 h), publishes wall + peak-RSS table to
+  `$GITHUB_STEP_SUMMARY`. All four sexps now bake
+  `(config_overrides ((universe_cap 1000)))` so each cell runs at
+  N=1000 self-contained. The four sexps had been SKIPPED placeholders
+  pinned to the 1,654-symbol era; this PR resets them to
+  BASELINE_PENDING (wide ranges) for the first manual dispatch to
+  fill in. The new `decade-2014-2023.sexp` is the canonical 10-year
+  release-gate cell. Per
+  `dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md`,
+  N=1000×10y projects to ~5.7 GB (fits 8 GB ceiling). N≥5000 stays
+  blocked on daily-snapshot streaming. First manual dispatch is
+  **not yet scheduled** — out-of-PR follow-up.
 
 ## Completed
 
 - **Tier-1 smoke universe_path resolution + flip continue-on-error: false**
-  (2026-04-28, on `fix/perf-tier1-universe-path`). Fix for next-step #4.
+  (2026-04-28, PR #634). Fix for next-step #4.
   Root cause: `scenario_runner._fixtures_root` did
   `Data_path.default_data_dir() |> Fpath.parent ^ "trading/test_data/..."`
   which assumed `TRADING_DATA_DIR` pointed at the legacy `data/` location
@@ -192,6 +219,39 @@ mechanics + release-gate procedure.
   instead of `<ws>/dev/backtest/...`); the path resolves and the dir
   is created, just lands one level too deep. Not load-bearing —
   separate clean-up.
+
+- **Step 5 — tier-4 release-gate workflow at N=1000** (2026-04-28, PR pending).
+  Mirrors the tier-1/2/3 pattern but is **manual-only**
+  (`workflow_dispatch` — no cron). Adds
+  `dev/scripts/perf_tier4_release_gate.sh` (POSIX-sh runner that
+  auto-discovers `;; perf-tier: 4` scenarios via grep, runs each via
+  `scenario_runner.exe --parallel 1` with `timeout 28800` = 8 h,
+  captures wall + peak RSS, writes `summary.txt`) and
+  `.github/workflows/perf-release-gate.yml` (manual-only via
+  `workflow_dispatch`; same `trading-ci:latest` container, same
+  `_build` cache, same `continue-on-error: true` posture as tier-1/2/3;
+  publishes summary to `$GITHUB_STEP_SUMMARY`; `timeout-minutes: 350`
+  job ceiling, just under the 360 min platform ceiling on
+  ubuntu-latest). Four tier-4 cells covered, all under
+  `goldens-broad/`: `bull-crash-2015-2020` (~6y), `covid-recovery-2020-2024`
+  (~5y), `decade-2014-2023` (~10y, NEW canonical decade-long cell),
+  `six-year-2018-2023` (6y). All four bake
+  `(config_overrides ((universe_cap 1000)))` so each cell is
+  self-contained at N=1000 (the largest size that fits the 8 GB
+  ubuntu-latest ceiling at decade-length per β=3.94 MB/symbol). Expected
+  ranges intentionally wide (BASELINE_PENDING) — first manual
+  dispatch produces the canonical baseline; tighten ranges via
+  follow-up PR. **N≥5000 release-gate stays P1** awaiting
+  daily-snapshot streaming
+  (`dev/plans/daily-snapshot-streaming-2026-04-27.md`). First manual
+  dispatch is **not yet scheduled**; operator triggers when ready to
+  cut a release. Verify locally:
+  `dev/scripts/perf_tier4_release_gate.sh` inside the devcontainer
+  (or with `TRADING_IN_CONTAINER=1`); the workflow itself is
+  exercised on its first manual `workflow_dispatch` invocation.
+  Files: `dev/scripts/perf_tier4_release_gate.sh`,
+  `.github/workflows/perf-release-gate.yml`,
+  `trading/test_data/backtest_scenarios/goldens-broad/{bull-crash-2015-2020,covid-recovery-2020-2024,decade-2014-2023,six-year-2018-2023}.sexp`.
 
 - **Step 4 — tier-3 weekly perf workflow** (2026-04-27, PR pending).
   Mirrors the tier-1/tier-2 pattern. Adds
@@ -319,35 +379,37 @@ mechanics + release-gate procedure.
    covid-recovery 300×4y, six-year 300×6y per the plan's Tier 3
    table) is a follow-up scenario-authoring task, not gating on
    the workflow itself.
-3. Tier 4 (release-gate, 5000-stock decade-long) — was blocked on the
-   `data-panels` refactor (`dev/status/data-panels.md`); stages 0-3
-   landed (PRs #555, #557, #558, #559-565, #567, #569, #573).
-   Likely follows Stage 4 too. Current Tiered would extrapolate to
-   ~31 GB at 5000×10y; columnar projects to ~1.2 GB, well under the
-   8 GB ceiling.
+3. **(DONE on `feat/backtest-perf-tier4-release-gate`)** Tier 4
+   (release-gate) at **N=1000 × decade-long** — `perf-release-gate.yml`
+   + `perf_tier4_release_gate.sh`, four tier-4 cells under
+   `goldens-broad/` (`bull-crash-2015-2020`, `covid-recovery-2020-2024`,
+   `decade-2014-2023` (NEW), `six-year-2018-2023`), 8 h budget per
+   cell, **manual-only** (`workflow_dispatch`; no cron — release-gate
+   runs at release-cut time, not on a recurring schedule). The four
+   sexps now bake `(config_overrides ((universe_cap 1000)))` so each
+   cell is self-contained — no CLI override needed. Per
+   `dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md` (β=3.94
+   MB/symbol), N=1000×10y projects to ~5.7 GB peak RSS, fits the 8 GB
+   ubuntu-latest ceiling. **N≥5000 release-gate stays P1 awaiting
+   daily-snapshot streaming** (`dev/plans/daily-snapshot-streaming-2026-04-27.md`):
+   at β=3.94, N=5000×10y projects to ~28 GB, far beyond the runner
+   ceiling. Expected ranges are intentionally wide for the four cells
+   (BASELINE_PENDING) — first manual dispatch produces the canonical
+   baseline; tighten ranges via follow-up PR after that run lands.
 4. **(DONE on `fix/perf-tier1-universe-path`)** Tier-1 smoke
    universe_path resolution + flip the gate. Added
-   `Scenario_lib.Fixtures_root.resolve` (saner default than the old
-   `Fpath.parent + "trading/test_data/..."` heuristic — uses
-   `Data_path.default_data_dir() / "backtest_scenarios"`, the same
-   shape `test/test_panel_loader_parity.ml` and the perf workflows
-   already assume) plus a new `--fixtures-root` CLI flag on
-   `scenario_runner.exe` that the three tier scripts now pass
-   explicitly so the per-cell `_stage_<name>/` scratch dir doesn't
-   confuse universe-path resolution. Flipped
-   `.github/workflows/perf-tier1.yml` `continue-on-error: false`
-   (tier-1 is the per-PR gate; tier-2/3 stay VISIBILITY-first while
-   their warm-up budgets accumulate). Set
-   `PERF_CATALOG_CHECK_STRICT=1` in `trading/devtools/checks/dune`
-   so missing tier tags fail the build. Verified: 4/4 PASS via
-   `TRADING_DATA_DIR=<repo>/trading/test_data
-   dev/scripts/perf_tier1_smoke.sh` (post-fix). Plan:
+   `Scenario_lib.Fixtures_root.resolve` plus `--fixtures-root` CLI
+   flag on `scenario_runner.exe` that the three tier scripts pass
+   explicitly. Flipped `.github/workflows/perf-tier1.yml`
+   `continue-on-error: false` (tier-1 is the per-PR gate; tier-2/3
+   stay VISIBILITY-first). Set `PERF_CATALOG_CHECK_STRICT=1` in
+   `trading/devtools/checks/dune`. Verified: 4/4 PASS post-fix. Plan:
    `dev/plans/perf-tier1-universe-path-2026-04-28.md`.
-5. After ~10 PR cycles of *real* tier-1 perf data (i.e. post
-   smoke-fix above): pin per-cell budgets. Same flip applies to
-   `perf-nightly.yml` once tier-2 budgets are pinned (~10 weeks of
-   nightly data) and to `perf-weekly.yml` once tier-3 budgets are
-   pinned (~10 weekly cycles).
+5. After ~10 PR cycles of *real* tier-1 perf data: pin per-cell
+   budgets. Same flip applies to `perf-nightly.yml` once tier-2
+   budgets are pinned (~10 weeks of nightly data) and to
+   `perf-weekly.yml` once tier-3 budgets are pinned (~10 weekly
+   cycles).
 6. (DONE on `feat/backtest-perf-release-report`) **`release_perf_report`
    OCaml exe.** New library
    `trading/trading/backtest/release_report/` (`release_report.{ml,mli}`,
@@ -380,14 +442,16 @@ generators.
 ## Branch
 
 `feat/backtest-perf-<step>` per item above. Active:
-`feat/backtest-perf-tier3-weekly` (Step 4) and
-`feat/backtest-perf-engine-pool-instrument` (engine-pooling PR-1).
+`feat/backtest-perf-tier4-release-gate` (Step 5 — tier-4 release-gate
+at N=1000) and `feat/backtest-perf-tier3-weekly` (Step 4).
 
 ## Blocked on
 
-- **Tier 4 release-gate scenarios** are blocked on the `data-panels`
-  refactor (stages 0-3 at minimum) landing. Tiers 1-3 can proceed
-  independently.
+- **Tier 4 release-gate at N≥5000** stays blocked on daily-snapshot
+  streaming (`dev/plans/daily-snapshot-streaming-2026-04-27.md`). At
+  the post-engine-pool β=3.94 MB/symbol, N=5000×10y projects to ~28 GB
+  RSS, far beyond the 8 GB ubuntu-latest ceiling. Tier-4 at N=1000 is
+  **unblocked** and shipped on `feat/backtest-perf-tier4-release-gate`.
 
 ## Decision items (need human or QC sign-off)
 
@@ -396,10 +460,13 @@ Carried verbatim from `dev/plans/perf-scenario-catalog-2026-04-25.md`:
 1. Are the tier costs (per-PR ≤2min, nightly ≤30min, weekly ≤2h,
    release ≤8h) the right budget?
 2. Tier 4 pass criteria — what RSS / wall budget defines a passing
-   release? Today's bull-crash 1000-symbol Tiered = 3.7 GB; 5000
-   stocks would extrapolate to ~31 GB Tiered. The `data-panels`
-   refactor (PR #554) projects ~1.2 GB at the same scale, so
-   tier-4 criteria can stay tight (~8 GB ceiling) once it lands.
+   release? Per `dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md`,
+   post-engine-pool β=3.94 MB/symbol; tier-4 at N=1000×10y projects
+   to ~5.7 GB (fits 8 GB ceiling). N≥5000 release-gate still requires
+   daily-snapshot streaming
+   (`dev/plans/daily-snapshot-streaming-2026-04-27.md`). Initial
+   tier-4 ranges are intentionally wide (BASELINE_PENDING); first
+   manual dispatch produces the canonical baseline.
 3. Should `perf_catalog_check` fail builds or annotate-only?
    Initial: annotate-only.
 4. Tracking format: CSV in repo (auditable, grows) vs external store.

--- a/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
@@ -1,31 +1,36 @@
 ;; perf-tier: 4
-;; perf-tier-rationale: Full sector-map (broad) universe over 6 years incl. 2020 crash; release-gate cadence (≤8 h). Currently SKIPPED placeholder pending re-pin and data-panels Stage-4 (5000-symbol broadening). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 4.
+;; perf-tier-rationale: Tier-4 release-gate cell at N=1000 × ~6y (2015-2020 incl. 2020 crash). Run on-demand via `.github/workflows/perf-release-gate.yml` when cutting a release. Per dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md (β=3.94 MB/symbol), N=1000×6y projects to ~5.0 GB peak RSS, fits the 8 GB ceiling. N>=5000 release-gate stays P1 awaiting daily-snapshot streaming (dev/plans/daily-snapshot-streaming-2026-04-27.md).
 ;;
-;; STATUS: SKIPPED — ranges stale (1,654-symbol era); re-pin pending a GHA
-;; workflow. Do not treat as a regression gate until re-pinned. See
-;; `dev/status/backtest-infra.md` follow-up.
+;; STATUS: BASELINE_PENDING — expected ranges are intentionally wide because no
+;; fresh N=1000 baseline run has been recorded yet. The first manual dispatch
+;; of `perf-release-gate.yml` produces the canonical baseline; tighten ranges
+;; via a follow-up PR after that run lands. Until ranges are tightened, this
+;; cell catches catastrophic regressions only (sign flips, wholesale wipeouts,
+;; OOM); fine-grained perf gating happens in tier-1/tier-2/tier-3.
 ;;
-;; Golden (broad): strong bull market through 2020 crash, against the full
-;; sector-map universe.
+;; Golden (broad-1000): strong bull market through 2020 crash, run against the
+;; full sector-map with universe_cap=1000.
 ;;
-;; Intended for nightly/GHA scale runs — ≤3 broad goldens are kept for
-;; full-universe regression coverage; see
-;; dev/plans/backtest-scale-optimization-2026-04-17.md §Step 1.
+;; Why universe_cap=1000 here (vs Full_sector_map):
+;;   1. RSS/wall budget: at β=3.94 MB/symbol, the full sector map (~10,472
+;;      symbols today) projects to ~42 GB at 6y — does not fit any single
+;;      runner. N=1000 is the largest cell that fits 8 GB at decade-length.
+;;   2. Self-contained: previously the cap came from `--override` at the CLI;
+;;      baking it into the scenario makes the release-gate cell reproducible
+;;      from the .sexp alone.
 ;;
-;; Expected ranges inherited from the 2026-04-13 baseline (1,654 stocks);
-;; will shift under the expanded sector map (follow-up #3 in
-;; dev/status/backtest-infra.md).
+;; Trading-metric expected ranges are wide pending the first manual-dispatch
+;; baseline; see STATUS above.
 ((name "bull-crash-2015-2020")
- (description "Strong bull market through the 2020 crash (broad universe)")
+ (description "Strong bull market through the 2020 crash (broad-1000 universe)")
  (period ((start_date 2015-01-02) (end_date 2020-12-31)))
  (universe_path "universes/broad.sexp")
- (universe_size 1654)
- (config_overrides ())
+ (universe_size 1000)
+ (config_overrides (((universe_cap 1000))))
  (expected
-  ((total_return_pct   ((min 200.0) (max 400.0)))
-   (total_trades       ((min 70)    (max 110)))
-   (win_rate           ((min 25.0)  (max 45.0)))
-   (sharpe_ratio       ((min 0.50)  (max 1.20)))
-   (max_drawdown_pct   ((min 30.0)  (max 50.0)))
-   (avg_holding_days   ((min 35.0)  (max 65.0)))
-   (unrealized_pnl     ((min 1000.0) (max 8000000.0))))))
+  ((total_return_pct   ((min -100.0)  (max 1000.0)))
+   (total_trades       ((min 0)       (max 1000)))
+   (win_rate           ((min 0.0)     (max 100.0)))
+   (sharpe_ratio       ((min -10.0)   (max 10.0)))
+   (max_drawdown_pct   ((min 0.0)     (max 100.0)))
+   (avg_holding_days   ((min 0.0)     (max 1000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
@@ -1,31 +1,27 @@
 ;; perf-tier: 4
-;; perf-tier-rationale: Full sector-map (broad) universe over 5 years incl. COVID; release-gate cadence (≤8 h). Currently SKIPPED placeholder pending re-pin and data-panels Stage-4 (5000-symbol broadening). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 4.
+;; perf-tier-rationale: Tier-4 release-gate cell at N=1000 × ~5y (2020 COVID crash through 2024 recovery). Run on-demand via `.github/workflows/perf-release-gate.yml` when cutting a release. Per dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md (β=3.94 MB/symbol), N=1000×5y projects to ~4.8 GB peak RSS, fits the 8 GB ceiling. N>=5000 release-gate stays P1 awaiting daily-snapshot streaming (dev/plans/daily-snapshot-streaming-2026-04-27.md).
 ;;
-;; STATUS: SKIPPED — ranges stale (1,654-symbol era); re-pin pending a GHA
-;; workflow. Do not treat as a regression gate until re-pinned. See
-;; `dev/status/backtest-infra.md` follow-up.
+;; STATUS: BASELINE_PENDING — expected ranges are intentionally wide because no
+;; fresh N=1000 baseline run has been recorded yet. The first manual dispatch
+;; of `perf-release-gate.yml` produces the canonical baseline; tighten ranges
+;; via a follow-up PR after that run lands. Until ranges are tightened, this
+;; cell catches catastrophic regressions only (sign flips, wholesale wipeouts,
+;; OOM); fine-grained perf gating happens in tier-1/tier-2/tier-3.
 ;;
-;; Golden (broad): COVID crash and recovery through 2024, against the full
-;; sector-map universe.
+;; Golden (broad-1000): COVID crash and recovery through 2024, run against the
+;; full sector-map with universe_cap=1000.
 ;;
-;; Intended for nightly/GHA scale runs — ≤3 broad goldens are kept for
-;; full-universe regression coverage; see
-;; dev/plans/backtest-scale-optimization-2026-04-17.md §Step 1.
-;;
-;; Expected ranges inherited from the 2026-04-13 baseline (1,654 stocks);
-;; will shift under the expanded sector map (follow-up #3 in
-;; dev/status/backtest-infra.md).
+;; See bull-crash-2015-2020.sexp for the rationale on universe_cap=1000.
 ((name "covid-recovery-2020-2024")
- (description "COVID crash and recovery through 2024 (broad universe)")
+ (description "COVID crash and recovery through 2024 (broad-1000 universe)")
  (period ((start_date 2020-01-02) (end_date 2024-12-31)))
  (universe_path "universes/broad.sexp")
- (universe_size 1654)
- (config_overrides ())
+ (universe_size 1000)
+ (config_overrides (((universe_cap 1000))))
  (expected
-  ((total_return_pct   ((min 15.0)  (max 45.0)))
-   (total_trades       ((min 90)    (max 130)))
-   (win_rate           ((min 40.0)  (max 55.0)))
-   (sharpe_ratio       ((min 0.70)  (max 1.40)))
-   (max_drawdown_pct   ((min 30.0)  (max 45.0)))
-   (avg_holding_days   ((min 25.0)  (max 45.0)))
-   (unrealized_pnl     ((min 1000.0) (max 3000000.0))))))
+  ((total_return_pct   ((min -100.0)  (max 1000.0)))
+   (total_trades       ((min 0)       (max 1000)))
+   (win_rate           ((min 0.0)     (max 100.0)))
+   (sharpe_ratio       ((min -10.0)   (max 10.0)))
+   (max_drawdown_pct   ((min 0.0)     (max 100.0)))
+   (avg_holding_days   ((min 0.0)     (max 1000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
@@ -1,0 +1,31 @@
+;; perf-tier: 4
+;; perf-tier-rationale: Tier-4 release-gate cell — full decade (2014-2023, ~10y) at N=1000. The flagship "can we run a decade-long backtest at scale?" cell. Per dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md (RSS ≈ 67 + 3.94·N + 0.19·N·(T−1)), projects to ~5.7 GB peak at N=1000×10y — fits the 8 GB ceiling. Run on-demand via `.github/workflows/perf-release-gate.yml` when cutting a release. N>=5000 release-gate stays P1 awaiting daily-snapshot streaming (dev/plans/daily-snapshot-streaming-2026-04-27.md).
+;;
+;; STATUS: BASELINE_PENDING — expected ranges are intentionally wide because no
+;; fresh baseline run has been recorded yet. The first manual dispatch of
+;; `perf-release-gate.yml` produces the canonical baseline; tighten ranges via
+;; a follow-up PR after that run lands. Until ranges are tightened, this cell
+;; catches catastrophic regressions only (sign flips, wholesale wipeouts, OOM);
+;; fine-grained perf gating happens in tier-1/tier-2/tier-3.
+;;
+;; Golden (broad-1000): full 10-year run spanning the post-2014 bull, 2018
+;; correction, 2020 COVID crash, 2021 reflation rally, and 2022 bear. Run
+;; against the full sector-map with universe_cap=1000. This is the single most
+;; demanding cell in the catalog and the canonical "release-shippable"
+;; certification: a regression here means the system can't reliably run the
+;; longest-window scenario we care about.
+;;
+;; See bull-crash-2015-2020.sexp for the rationale on universe_cap=1000.
+((name "decade-2014-2023")
+ (description "10-year decade run spanning multiple regimes (broad-1000 universe)")
+ (period ((start_date 2014-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/broad.sexp")
+ (universe_size 1000)
+ (config_overrides (((universe_cap 1000))))
+ (expected
+  ((total_return_pct   ((min -100.0)  (max 2000.0)))
+   (total_trades       ((min 0)       (max 2000)))
+   (win_rate           ((min 0.0)     (max 100.0)))
+   (sharpe_ratio       ((min -10.0)   (max 10.0)))
+   (max_drawdown_pct   ((min 0.0)     (max 100.0)))
+   (avg_holding_days   ((min 0.0)     (max 1000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
@@ -1,41 +1,30 @@
 ;; perf-tier: 4
-;; perf-tier-rationale: Full sector-map (broad) universe over 6 years incl. COVID; release-gate cadence (≤8 h). Currently SKIPPED placeholder pending re-pin and data-panels Stage-4 (5000-symbol broadening). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 4.
+;; perf-tier-rationale: Tier-4 release-gate cell at N=1000 × 6y (2018-2023 incl. COVID crash and recovery). Run on-demand via `.github/workflows/perf-release-gate.yml` when cutting a release. Per dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md (β=3.94 MB/symbol), N=1000×6y projects to ~5.0 GB peak RSS, fits the 8 GB ceiling. N>=5000 release-gate stays P1 awaiting daily-snapshot streaming (dev/plans/daily-snapshot-streaming-2026-04-27.md).
 ;;
-;; STATUS: SKIPPED — ranges stale (1,654-symbol era); re-pin pending a GHA
-;; workflow. Do not treat as a regression gate until re-pinned. See
-;; `dev/status/backtest-infra.md` follow-up.
+;; STATUS: BASELINE_PENDING — expected ranges are intentionally wide because no
+;; fresh N=1000 baseline run has been recorded yet. The first manual dispatch
+;; of `perf-release-gate.yml` produces the canonical baseline; tighten ranges
+;; via a follow-up PR after that run lands. Until ranges are tightened, this
+;; cell catches catastrophic regressions only (sign flips, wholesale wipeouts,
+;; OOM); fine-grained perf gating happens in tier-1/tier-2/tier-3.
 ;;
-;; Golden (broad): 6-year run covering COVID crash and recovery, against the
-;; full sector-map universe.
+;; Golden (broad-1000): 6-year run covering COVID crash and recovery, run
+;; against the full sector-map with universe_cap=1000.
 ;;
-;; Intended for nightly/GHA scale runs — ≤3 broad goldens are kept for
-;; full-universe regression coverage; see
-;; dev/plans/backtest-scale-optimization-2026-04-17.md §Step 1 and
-;; dev/decisions.md 2026-04-17 item 2.
+;; Shares the same name as the small-universe counterpart under goldens-small/
+;; for easy A/B; the runner keys by [name + universe_path].
 ;;
-;; Shares the same name as the small-universe counterpart under
-;; goldens-small/ for easy A/B; the runner keys by [name + universe_path].
-;; Expected ranges here are inherited from the 2026-04-13 baseline
-;; (1,654-symbol universe) and remain the apples-to-apples reference
-;; until a post-Finviz baseline re-run updates them
-;; (dev/status/backtest-infra.md follow-up #3).
-;;
-;; [unrealized_pnl] range is wide: the goal is to catch regression to
-;; exactly 0 (the bug PR #393 fixed). The universe has grown from 1,654 to
-;; ~10,472 stocks, so the exact value at the upper end will shift when
-;; the goldens are rerun; pick a ceiling high enough to tolerate that
-;; without re-pinning per sector-map refresh.
+;; See bull-crash-2015-2020.sexp for the rationale on universe_cap=1000.
 ((name "six-year-2018-2023")
- (description "6-year run covering COVID crash and recovery (broad universe)")
+ (description "6-year run covering COVID crash and recovery (broad-1000 universe)")
  (period ((start_date 2018-01-02) (end_date 2023-12-29)))
  (universe_path "universes/broad.sexp")
- (universe_size 1654)
- (config_overrides ())
+ (universe_size 1000)
+ (config_overrides (((universe_cap 1000))))
  (expected
-  ((total_return_pct   ((min 30.0)  (max 90.0)))
-   (total_trades       ((min 60)    (max 100)))
-   (win_rate           ((min 22.0)  (max 40.0)))
-   (sharpe_ratio       ((min 0.80)  (max 1.80)))
-   (max_drawdown_pct   ((min 25.0)  (max 45.0)))
-   (avg_holding_days   ((min 20.0)  (max 45.0)))
-   (unrealized_pnl     ((min 1000.0) (max 3000000.0))))))
+  ((total_return_pct   ((min -100.0)  (max 1000.0)))
+   (total_trades       ((min 0)       (max 1000)))
+   (win_rate           ((min 0.0)     (max 100.0)))
+   (sharpe_ratio       ((min -10.0)   (max 10.0)))
+   (max_drawdown_pct   ((min 0.0)     (max 100.0)))
+   (avg_holding_days   ((min 0.0)     (max 1000.0))))))


### PR DESCRIPTION
## Summary

Closes Step 3 of `dev/status/backtest-perf.md` — the on-demand large-scope perf certification workflow at release-cut time. Per `dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md`, the post-engine-pool fit `RSS ≈ 67 + 3.94·N + 0.19·N·(T−1)` MB projects N=1000×10y to ~5.7 GB peak — fits the 8 GB ubuntu-latest ceiling. **N≥5000 release-gate stays P1** awaiting daily-snapshot streaming (`dev/plans/daily-snapshot-streaming-2026-04-27.md`) — at β=3.94 it'd project to ~28 GB, far beyond the runner ceiling.

- `dev/scripts/perf_tier4_release_gate.sh` — POSIX-sh runner mirroring `perf_tier3_weekly.sh`. Auto-discovers `;; perf-tier: 4` scenarios, per-cell timeout 28800s (8 h), env-overridable via `PERF_TIER4_TIMEOUT`.
- `.github/workflows/perf-release-gate.yml` — **manual-only** (`workflow_dispatch` — no cron, since release-gate runs at release-cut time only). `timeout-minutes: 350` (just under the 360 min platform ceiling on hosted ubuntu-latest). Same `trading-ci:latest` container, same `_build` cache, same `continue-on-error: true` posture as tier-1/2/3 (visibility first, gate later).
- `goldens-broad/{bull-crash-2015-2020, covid-recovery-2020-2024, six-year-2018-2023}.sexp` — were SKIPPED placeholders pinned to the 1,654-symbol era; now reset to BASELINE_PENDING (wide ranges) with `(config_overrides ((universe_cap 1000)))` baked in so each cell runs at N=1000 self-contained — no CLI override needed.
- `goldens-broad/decade-2014-2023.sexp` — **NEW** canonical 10-year decade-long release-gate cell.
- `dev/status/backtest-perf.md` — Step 3 marked DONE; \`Blocked on\` updated; new Completed entry.

## PR sizing
- Net +504 / −102 LOC across 7 files.
- One new shell script + one new workflow + one new scenario + 3 scenario rewrites + status update. No new OCaml modules.

## Test plan
- [x] \`dune build && dune runtest\` (passes; the four updated/new sexps are exercised by \`test_scenario.test_all_scenario_files_parse\`)
- [x] \`dune build @fmt\` clean
- [x] \`sh trading/devtools/checks/posix_sh_check.sh\` — 47 scripts clean (the new runner is the +1)
- [x] \`sh trading/devtools/checks/perf_catalog_check.sh\` — 16 scenarios all carry tier tags (was 15 before this PR's new decade cell)
- [x] \`sh trading/devtools/checks/no_python_check.sh\` — clean
- [ ] First manual dispatch of \`perf-release-gate.yml\` — **not yet scheduled**; operator triggers when ready to cut a release. Output then feeds tightening of expected ranges via follow-up PR.

## Notes / trade-offs

**Why \`timeout-minutes: 350\` (not 600).** The task brief suggested 600 (10h). However GHA hosted ubuntu-latest caps job runtime at 360 min. 350 leaves a small margin under the platform ceiling. With four cells × 8h-each per-cell budget, the entire suite cannot run in a single dispatch — operator splits via \`PERF_TIER4_TIMEOUT\` or runs cells sequentially across multiple dispatches if total wall exceeds 6h. Sister tier-3 weekly workflow uses the same pattern (\`timeout-minutes: 300\`).

**Why expected ranges are wide (BASELINE_PENDING).** No fresh N=1000 baseline run exists; pre-existing ranges were stale (1,654-symbol era). The brief allowed Path A (one-shot baseline) but tier-4 wall costs (>30 min for the smallest cell) made that impractical inside this PR; sexps ship with wide ranges for the first manual dispatch to fill in. This is called out explicitly in each sexp's STATUS comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)