### PR TITLE
feat(backtest-perf): trade-audit collector + types (PR-1 of trade-audit)

### DIFF
--- a/trading/trading/backtest/lib/dune
+++ b/trading/trading/backtest/lib/dune
@@ -12,6 +12,8 @@
   trading.simulation.types
   trading.strategy
   weinstein_trading.strategy
-  weinstein.macro)
+  weinstein.macro
+  weinstein.screener
+  weinstein.types)
  (preprocess
   (pps ppx_let ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -106,6 +106,18 @@ let _write_equity_curve ~output_dir
       fprintf oc "%s,%.2f\n" (Date.to_string s.date) s.portfolio_value);
   Out_channel.close oc
 
+(** Persist [result.audit] as [trade_audit.sexp] when the collector captured any
+    records. No file is written when the list is empty — that's the pre-PR-2
+    default (capture sites not yet wired) and any consumer of the artefact must
+    tolerate its absence. *)
+let _write_trade_audit ~output_dir ~(audit : Trade_audit.audit_record list) =
+  match audit with
+  | [] -> ()
+  | _ ->
+      Sexp.save_hum
+        (output_dir ^ "/trade_audit.sexp")
+        (Trade_audit.sexp_of_audit_records audit)
+
 let write ~output_dir (result : Runner.result) =
   _write_params ~output_dir result;
   Sexp.save_hum
@@ -113,4 +125,5 @@ let write ~output_dir (result : Runner.result) =
     (Summary.sexp_of_t result.summary);
   _write_trades ~output_dir ~round_trips:result.round_trips
     ~stop_infos:result.stop_infos;
-  _write_equity_curve ~output_dir ~steps:result.steps
+  _write_equity_curve ~output_dir ~steps:result.steps;
+  _write_trade_audit ~output_dir ~audit:result.audit

--- a/trading/trading/backtest/lib/result_writer.mli
+++ b/trading/trading/backtest/lib/result_writer.mli
@@ -4,4 +4,9 @@
 
 val write : output_dir:string -> Runner.result -> unit
 (** Write [params.sexp], [summary.sexp], [trades.csv], and [equity_curve.csv]
-    into [output_dir]. The directory must already exist. *)
+    into [output_dir]. The directory must already exist.
+
+    Additionally writes [trade_audit.sexp] iff [result.audit] is non-empty.
+    Empty audit lists (the pre-PR-2 default, capture sites not yet wired)
+    produce no file rather than a sexp containing [()] — consumers must tolerate
+    the file's absence. *)

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -24,6 +24,7 @@ type result = {
   steps : Trading_simulation_types.Simulator_types.step_result list;
   overrides : Sexp.t list;
   stop_infos : Stop_log.stop_info list;
+  audit : Trade_audit.audit_record list;
 }
 
 (* Trading-day filter *)
@@ -289,4 +290,8 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
       ~sim_result
   in
-  { summary; round_trips; steps; overrides; stop_infos }
+  (* PR-1 of trade-audit: empty audit list. PR-2 will create a
+     [Trade_audit.t] here, thread it through [_run_panel_backtest], and
+     drain it into [audit] alongside [stop_infos]. *)
+  let audit = [] in
+  { summary; round_trips; steps; overrides; stop_infos; audit }

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -22,6 +22,11 @@ type result = {
           records the initial stop level, the stop level at exit, and the exit
           trigger (stop-loss, take-profit, etc.). Keyed by position_id; joinable
           with [round_trips] via symbol + entry_date. *)
+  audit : Trade_audit.audit_record list;
+      (** Per-trade decision-trail records captured by the strategy. Empty until
+          PR-2 of the trade-audit plan wires capture sites in [_run_screen] /
+          [entries_from_candidates] / the exit path. When non-empty,
+          [Result_writer.write] persists it as [trade_audit.sexp]. *)
 }
 
 val is_trading_day :

--- a/trading/trading/backtest/lib/trade_audit.ml
+++ b/trading/trading/backtest/lib/trade_audit.ml
@@ -1,0 +1,121 @@
+(** Per-trade decision-trail logging for backtest diagnostics.
+
+    See [trade_audit.mli] for the API contract. *)
+
+open Core
+
+(* Types ------------------------------------------------------------------ *)
+
+type skip_reason =
+  | Insufficient_cash
+  | Already_held
+  | Below_min_grade
+  | Sized_to_zero
+  | Sector_concentration
+  | Top_n_cutoff
+[@@deriving sexp]
+
+type alternative_candidate = {
+  symbol : string;
+  side : Trading_base.Types.position_side;
+  score : int;
+  grade : Weinstein_types.grade;
+  reason_skipped : skip_reason;
+}
+[@@deriving sexp]
+
+type stop_floor_kind = Support_floor | Buffer_fallback [@@deriving sexp]
+
+type entry_decision = {
+  symbol : string;
+  entry_date : Date.t;
+  position_id : string;
+  macro_trend : Weinstein_types.market_trend;
+  macro_confidence : float;
+  macro_indicators : Macro.indicator_reading list;
+  stage : Weinstein_types.stage;
+  ma_direction : Weinstein_types.ma_direction;
+  ma_slope_pct : float;
+  rs_trend : Weinstein_types.rs_trend option;
+  rs_value : float option;
+  volume_quality : Weinstein_types.volume_confirmation option;
+  resistance_quality : Weinstein_types.overhead_quality option;
+  support_quality : Weinstein_types.overhead_quality option;
+  sector_name : string;
+  sector_rating : Screener.sector_rating;
+  cascade_score : int;
+  cascade_grade : Weinstein_types.grade;
+  cascade_score_components : (string * int) list;
+  cascade_rationale : string list;
+  side : Trading_base.Types.position_side;
+  suggested_entry : float;
+  suggested_stop : float;
+  installed_stop : float;
+  stop_floor_kind : stop_floor_kind;
+  risk_pct : float;
+  initial_position_value : float;
+  initial_risk_dollars : float;
+  alternatives_considered : alternative_candidate list;
+}
+[@@deriving sexp]
+
+type exit_decision = {
+  symbol : string;
+  exit_date : Date.t;
+  position_id : string;
+  exit_trigger : Stop_log.exit_trigger;
+  macro_trend_at_exit : Weinstein_types.market_trend;
+  macro_confidence_at_exit : float;
+  stage_at_exit : Weinstein_types.stage;
+  rs_trend_at_exit : Weinstein_types.rs_trend option;
+  distance_from_ma_pct : float;
+  max_favorable_excursion_pct : float;
+  max_adverse_excursion_pct : float;
+  weeks_macro_was_bearish : int;
+  weeks_stage_left_2 : int;
+}
+[@@deriving sexp]
+
+type audit_record = { entry : entry_decision; exit_ : exit_decision option }
+[@@deriving sexp]
+
+(* Collector -------------------------------------------------------------- *)
+
+type _bucket = {
+  bucket_entry : entry_decision;
+  mutable bucket_exit : exit_decision option;
+}
+(** Internal mutable bucket. [exit_] is added to a record when the matching
+    entry has already been recorded; otherwise the exit is dropped. *)
+
+type t = { records : (string, _bucket) Hashtbl.t }
+
+let create () = { records = Hashtbl.create (module String) }
+
+let record_entry t (entry : entry_decision) =
+  Hashtbl.set t.records ~key:entry.position_id
+    ~data:{ bucket_entry = entry; bucket_exit = None }
+
+let record_exit t (exit_ : exit_decision) =
+  match Hashtbl.find t.records exit_.position_id with
+  | None -> ()
+  | Some bucket -> bucket.bucket_exit <- Some exit_
+
+let _bucket_to_record (bucket : _bucket) : audit_record =
+  { entry = bucket.bucket_entry; exit_ = bucket.bucket_exit }
+
+let _compare_by_position_id (a : audit_record) (b : audit_record) =
+  String.compare a.entry.position_id b.entry.position_id
+
+let get_audit_records t : audit_record list =
+  Hashtbl.fold t.records ~init:[] ~f:(fun ~key:_ ~data:bucket acc ->
+      _bucket_to_record bucket :: acc)
+  |> List.sort ~compare:_compare_by_position_id
+
+(* Sexp persistence ------------------------------------------------------- *)
+
+let sexp_of_audit_records (records : audit_record list) : Sexp.t =
+  [%sexp_of: audit_record list] records
+
+let audit_records_of_sexp (sexp : Sexp.t) : audit_record list =
+  [%of_sexp: audit_record list] sexp

--- a/trading/trading/backtest/lib/trade_audit.mli
+++ b/trading/trading/backtest/lib/trade_audit.mli
@@ -1,0 +1,172 @@
+(** Per-trade decision-trail logging for backtest diagnostics.
+
+    Captures, for every position the strategy enters:
+    - The macro / stage / RS / volume / resistance state at decision time.
+    - The cascade score + grade + rationale that produced the entry.
+    - The alternative candidates considered at the same screen call but not
+      chosen (with a reason).
+    - The state at exit time (macro/stage/RS at exit, MAE/MFE during the hold,
+      counters for how long macro was bearish or stage left 2 during the hold).
+
+    Mirrors the shape of {!Stop_log}: a mutable, in-strategy observer collector
+    seeded by capture sites in the strategy + simulator path, then drained at
+    end-of-run into [Runner.result.audit]. Persisted as [trade_audit.sexp]
+    alongside [trades.csv] when non-empty.
+
+    PR-1 of the trade-audit plan ships the module + persistence plumbing.
+    Capture-site wiring lives in PR-2; until then the collector is always empty
+    and no [trade_audit.sexp] file is written.
+
+    See [dev/plans/trade-audit-2026-04-28.md]. *)
+
+open Core
+
+(** {1 Types} *)
+
+(** Why a candidate the screener returned was not actually entered.
+
+    Populated by the strategy at sizing time, when it walks the screener's
+    ranked candidate list and skips entries for portfolio-level reasons (cash,
+    sector caps) or quality-floor reasons (sized to zero, below min grade). *)
+type skip_reason =
+  | Insufficient_cash
+      (** Skipped because the portfolio did not have cash to size a meaningful
+          position. *)
+  | Already_held
+      (** Skipped because the symbol was already in the portfolio. *)
+  | Below_min_grade
+      (** Skipped because the candidate's grade fell below the configured min.
+      *)
+  | Sized_to_zero
+      (** Skipped because position-sizing rounded the share count down to 0. *)
+  | Sector_concentration
+      (** Skipped because the sector was at or above its concentration cap. *)
+  | Top_n_cutoff
+      (** Skipped because the candidate fell outside the top-N cap. *)
+[@@deriving sexp]
+
+type alternative_candidate = {
+  symbol : string;
+  side : Trading_base.Types.position_side;
+  score : int;
+  grade : Weinstein_types.grade;
+  reason_skipped : skip_reason;
+}
+[@@deriving sexp]
+(** A screener candidate that was scored at decision time but not entered. *)
+
+(** Whether the installed initial stop sat on a support floor or fell back to a
+    fixed-buffer stop below the screener's suggested level. Routed from
+    [Weinstein_stops.compute_initial_stop_with_floor]. *)
+type stop_floor_kind = Support_floor | Buffer_fallback [@@deriving sexp]
+
+type entry_decision = {
+  symbol : string;
+  entry_date : Date.t;
+  position_id : string;  (** Matches [Stop_log.stop_info.position_id]. *)
+  (* Macro state at decision time. *)
+  macro_trend : Weinstein_types.market_trend;
+  macro_confidence : float;
+  macro_indicators : Macro.indicator_reading list;
+  (* Symbol-level analysis at decision time. *)
+  stage : Weinstein_types.stage;
+  ma_direction : Weinstein_types.ma_direction;
+  ma_slope_pct : float;
+  rs_trend : Weinstein_types.rs_trend option;
+  rs_value : float option;
+  volume_quality : Weinstein_types.volume_confirmation option;
+  resistance_quality : Weinstein_types.overhead_quality option;
+  support_quality : Weinstein_types.overhead_quality option;
+  sector_name : string;
+  sector_rating : Screener.sector_rating;
+  (* Cascade outcome. *)
+  cascade_score : int;
+  cascade_grade : Weinstein_types.grade;
+  cascade_score_components : (string * int) list;
+      (** Itemised score breakdown — e.g.
+          [("stage2_breakout", 30); ("strong_volume", 20)]. Built at the
+          screener boundary in PR-2. *)
+  cascade_rationale : string list;
+  side : Trading_base.Types.position_side;
+  (* Sizing + stop. *)
+  suggested_entry : float;
+  suggested_stop : float;  (** From the screener. *)
+  installed_stop : float;
+      (** After [Weinstein_stops.compute_initial_stop_with_floor] applies the
+          initial-stop buffer. *)
+  stop_floor_kind : stop_floor_kind;
+  risk_pct : float;
+  initial_position_value : float;
+  initial_risk_dollars : float;  (** [(entry - stop) * qty]. *)
+  alternatives_considered : alternative_candidate list;
+      (** Top-N candidates from the same screen call that were not entered.
+          Empty when the screener returned no other candidates that round. *)
+}
+[@@deriving sexp]
+(** Decision trail captured at entry. *)
+
+type exit_decision = {
+  symbol : string;
+  exit_date : Date.t;
+  position_id : string;
+  exit_trigger : Stop_log.exit_trigger;
+  (* Macro state at exit. *)
+  macro_trend_at_exit : Weinstein_types.market_trend;
+  macro_confidence_at_exit : float;
+  (* Symbol-level state at exit. *)
+  stage_at_exit : Weinstein_types.stage;
+  rs_trend_at_exit : Weinstein_types.rs_trend option;
+  distance_from_ma_pct : float;  (** [(close - ma) / ma]. *)
+  (* Holding-period summary captured by the simulator step stream. *)
+  max_favorable_excursion_pct : float;
+      (** Peak unrealized gain during the hold, as a fraction of entry price. *)
+  max_adverse_excursion_pct : float;
+      (** Trough unrealized loss during the hold, as a fraction of entry price.
+      *)
+  weeks_macro_was_bearish : int;
+      (** Friday count where macro flipped Bearish during the hold. *)
+  weeks_stage_left_2 : int;
+      (** Friday count where stage was not Stage 2 during the hold. *)
+}
+[@@deriving sexp]
+(** State captured at exit. *)
+
+type audit_record = { entry : entry_decision; exit_ : exit_decision option }
+[@@deriving sexp]
+(** A paired entry + exit record. [exit_] is [None] for positions that were
+    still open at end-of-run.
+
+    Field name [exit_] (rather than [exit]) avoids shadowing [Stdlib.exit]. *)
+
+(** {1 Collector} *)
+
+type t
+(** Mutable collector of audit records. One per backtest run. Not safe to share
+    across threads. *)
+
+val create : unit -> t
+(** Create an empty collector. *)
+
+val record_entry : t -> entry_decision -> unit
+(** Record an entry decision. Keyed by [decision.position_id]; recording the
+    same id twice overwrites the prior entry. *)
+
+val record_exit : t -> exit_decision -> unit
+(** Record an exit decision. Looks up the matching [entry] by
+    [decision.position_id]; if no entry was previously recorded for that id the
+    exit is dropped (the strategy never entered the position via this audit
+    surface). *)
+
+val get_audit_records : t -> audit_record list
+(** Return all audit records, sorted by [position_id]. Records with no exit yet
+    recorded (positions still open) carry [exit_ = None]. *)
+
+(** {1 Sexp persistence} *)
+
+val sexp_of_audit_records : audit_record list -> Sexp.t
+(** Serialize an audit-record list as a single sexp. Round-trips with
+    [audit_records_of_sexp]. *)
+
+val audit_records_of_sexp : Sexp.t -> audit_record list
+(** Parse an audit-record list from a sexp. Inverse of [sexp_of_audit_records].
+*)

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -3,6 +3,7 @@
   test_stop_log
   test_runner_filter
   test_trace
+  test_trade_audit
   test_runner_hypothesis_overrides
   test_panel_loader_parity
   test_backtest_runner_args
@@ -22,6 +23,7 @@
   trading.backtest.release_report
   scenario_lib
   weinstein.data_source
+  weinstein.types
   trading.base
   trading.engine
   trading.portfolio

--- a/trading/trading/backtest/test/test_trade_audit.ml
+++ b/trading/trading/backtest/test/test_trade_audit.ml
@@ -1,0 +1,316 @@
+(** Unit tests for [Backtest.Trade_audit].
+
+    Covers:
+    - sexp round-trip on every record type
+    - collector accumulates correctly across record_entry / record_exit
+    - exits are dropped when no matching entry was recorded
+    - get_audit_records returns position-id-sorted output
+    - empty collector returns [] *)
+
+open OUnit2
+open Core
+open Matchers
+module TA = Backtest.Trade_audit
+
+(* Builders --------------------------------------------------------------- *)
+
+let _date d = Date.of_string d
+
+(** Minimal but realistic [entry_decision] for round-trip + collector tests.
+
+    Optional parameters allow per-test overrides without forcing every test to
+    write a 30-field literal — keeps the assertions focused on the field(s) each
+    test actually cares about. *)
+let make_entry ?(symbol = "AAPL") ?(entry_date = _date "2024-01-15")
+    ?(position_id = "AAPL-wein-1") ?(side = Trading_base.Types.Long)
+    ?(macro_trend = Weinstein_types.Bullish) ?(macro_confidence = 0.72)
+    ?(macro_indicators = [])
+    ?(stage = Weinstein_types.Stage2 { weeks_advancing = 4; late = false })
+    ?(ma_direction = Weinstein_types.Rising) ?(ma_slope_pct = 0.018)
+    ?(rs_trend = Some Weinstein_types.Positive_rising) ?(rs_value = Some 1.05)
+    ?(volume_quality = Some (Weinstein_types.Strong 2.4))
+    ?(resistance_quality = Some Weinstein_types.Clean)
+    ?(support_quality = Some Weinstein_types.Clean)
+    ?(sector_name = "Information Technology") ?(sector_rating = Screener.Strong)
+    ?(cascade_score = 75) ?(cascade_grade = Weinstein_types.A)
+    ?(cascade_score_components =
+      [
+        ("stage2_breakout", 30);
+        ("strong_volume", 20);
+        ("positive_rs", 20);
+        ("clean_resistance", 15);
+        ("sector_strong", 10);
+      ]) ?(cascade_rationale = [ "Stage2 breakout"; "RS positive rising" ])
+    ?(suggested_entry = 150.50) ?(suggested_stop = 138.46)
+    ?(installed_stop = 138.46) ?(stop_floor_kind = TA.Buffer_fallback)
+    ?(risk_pct = 0.08) ?(initial_position_value = 75_000.0)
+    ?(initial_risk_dollars = 6_000.0) ?(alternatives_considered = []) () :
+    TA.entry_decision =
+  {
+    symbol;
+    entry_date;
+    position_id;
+    macro_trend;
+    macro_confidence;
+    macro_indicators;
+    stage;
+    ma_direction;
+    ma_slope_pct;
+    rs_trend;
+    rs_value;
+    volume_quality;
+    resistance_quality;
+    support_quality;
+    sector_name;
+    sector_rating;
+    cascade_score;
+    cascade_grade;
+    cascade_score_components;
+    cascade_rationale;
+    side;
+    suggested_entry;
+    suggested_stop;
+    installed_stop;
+    stop_floor_kind;
+    risk_pct;
+    initial_position_value;
+    initial_risk_dollars;
+    alternatives_considered;
+  }
+
+let make_exit ?(symbol = "AAPL") ?(exit_date = _date "2024-04-20")
+    ?(position_id = "AAPL-wein-1")
+    ?(exit_trigger =
+      Backtest.Stop_log.Stop_loss { stop_price = 138.46; actual_price = 137.20 })
+    ?(macro_trend_at_exit = Weinstein_types.Neutral)
+    ?(macro_confidence_at_exit = 0.45)
+    ?(stage_at_exit = Weinstein_types.Stage3 { weeks_topping = 2 })
+    ?(rs_trend_at_exit = Some Weinstein_types.Positive_flat)
+    ?(distance_from_ma_pct = -0.025) ?(max_favorable_excursion_pct = 0.082)
+    ?(max_adverse_excursion_pct = -0.085) ?(weeks_macro_was_bearish = 0)
+    ?(weeks_stage_left_2 = 1) () : TA.exit_decision =
+  {
+    symbol;
+    exit_date;
+    position_id;
+    exit_trigger;
+    macro_trend_at_exit;
+    macro_confidence_at_exit;
+    stage_at_exit;
+    rs_trend_at_exit;
+    distance_from_ma_pct;
+    max_favorable_excursion_pct;
+    max_adverse_excursion_pct;
+    weeks_macro_was_bearish;
+    weeks_stage_left_2;
+  }
+
+let _alt ~symbol ~score ~grade ~reason : TA.alternative_candidate =
+  {
+    symbol;
+    side = Trading_base.Types.Long;
+    score;
+    grade;
+    reason_skipped = reason;
+  }
+
+(* Sexp round-trip ------------------------------------------------------- *)
+
+let test_skip_reason_sexp_round_trip _ =
+  let all : TA.skip_reason list =
+    [
+      Insufficient_cash;
+      Already_held;
+      Below_min_grade;
+      Sized_to_zero;
+      Sector_concentration;
+      Top_n_cutoff;
+    ]
+  in
+  let parsed =
+    List.map all ~f:(fun r -> TA.skip_reason_of_sexp (TA.sexp_of_skip_reason r))
+  in
+  assert_that parsed (elements_are (List.map all ~f:equal_to))
+
+let test_stop_floor_kind_sexp_round_trip _ =
+  let all : TA.stop_floor_kind list = [ Support_floor; Buffer_fallback ] in
+  let parsed =
+    List.map all ~f:(fun k ->
+        TA.stop_floor_kind_of_sexp (TA.sexp_of_stop_floor_kind k))
+  in
+  assert_that parsed (elements_are (List.map all ~f:equal_to))
+
+let test_alternative_candidate_sexp_round_trip _ =
+  let alt =
+    _alt ~symbol:"MSFT" ~score:62 ~grade:Weinstein_types.B
+      ~reason:TA.Insufficient_cash
+  in
+  let parsed =
+    TA.alternative_candidate_of_sexp (TA.sexp_of_alternative_candidate alt)
+  in
+  assert_that parsed (equal_to alt)
+
+let test_entry_decision_sexp_round_trip _ =
+  let entry =
+    make_entry
+      ~alternatives_considered:
+        [
+          _alt ~symbol:"MSFT" ~score:62 ~grade:Weinstein_types.B
+            ~reason:TA.Insufficient_cash;
+          _alt ~symbol:"NVDA" ~score:55 ~grade:Weinstein_types.B
+            ~reason:TA.Sized_to_zero;
+        ]
+      ()
+  in
+  let parsed = TA.entry_decision_of_sexp (TA.sexp_of_entry_decision entry) in
+  assert_that parsed (equal_to entry)
+
+let test_exit_decision_sexp_round_trip _ =
+  let exit_ = make_exit () in
+  let parsed = TA.exit_decision_of_sexp (TA.sexp_of_exit_decision exit_) in
+  assert_that parsed (equal_to exit_)
+
+let test_audit_record_sexp_round_trip _ =
+  let record : TA.audit_record =
+    { entry = make_entry (); exit_ = Some (make_exit ()) }
+  in
+  let parsed = TA.audit_record_of_sexp (TA.sexp_of_audit_record record) in
+  assert_that parsed (equal_to record)
+
+let test_audit_records_sexp_round_trip_through_top_level_codec _ =
+  let records : TA.audit_record list =
+    [
+      { entry = make_entry (); exit_ = Some (make_exit ()) };
+      {
+        entry =
+          make_entry ~symbol:"MSFT" ~position_id:"MSFT-wein-1"
+            ~entry_date:(_date "2024-02-01") ();
+        exit_ = None;
+      };
+    ]
+  in
+  let sexp = TA.sexp_of_audit_records records in
+  let parsed = TA.audit_records_of_sexp sexp in
+  assert_that parsed (elements_are (List.map records ~f:equal_to))
+
+(* Collector behaviour --------------------------------------------------- *)
+
+let test_empty_collector_returns_empty _ =
+  let t = TA.create () in
+  assert_that (TA.get_audit_records t) is_empty
+
+let test_record_entry_appears_in_audit _ =
+  let t = TA.create () in
+  let entry = make_entry () in
+  TA.record_entry t entry;
+  assert_that (TA.get_audit_records t)
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (r : TA.audit_record) -> r.entry) (equal_to entry);
+             field (fun (r : TA.audit_record) -> r.exit_) is_none;
+           ];
+       ])
+
+let test_record_exit_attaches_to_existing_entry _ =
+  let t = TA.create () in
+  let entry = make_entry () in
+  let exit_ = make_exit () in
+  TA.record_entry t entry;
+  TA.record_exit t exit_;
+  assert_that (TA.get_audit_records t)
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (r : TA.audit_record) -> r.entry) (equal_to entry);
+             field
+               (fun (r : TA.audit_record) -> r.exit_)
+               (is_some_and (equal_to exit_));
+           ];
+       ])
+
+let test_record_exit_without_entry_is_dropped _ =
+  let t = TA.create () in
+  TA.record_exit t (make_exit ~position_id:"ORPHAN-1" ());
+  assert_that (TA.get_audit_records t) is_empty
+
+let test_record_entry_overwrites_same_position_id _ =
+  let t = TA.create () in
+  let first = make_entry ~cascade_score:50 () in
+  let second = make_entry ~cascade_score:80 () in
+  TA.record_entry t first;
+  TA.record_entry t second;
+  assert_that (TA.get_audit_records t)
+    (elements_are
+       [
+         field
+           (fun (r : TA.audit_record) -> r.entry.cascade_score)
+           (equal_to 80);
+       ])
+
+let test_get_audit_records_sorts_by_position_id _ =
+  let t = TA.create () in
+  TA.record_entry t (make_entry ~position_id:"ZZZ-wein-1" ~symbol:"ZZZ" ());
+  TA.record_entry t (make_entry ~position_id:"AAA-wein-1" ~symbol:"AAA" ());
+  TA.record_entry t (make_entry ~position_id:"MMM-wein-1" ~symbol:"MMM" ());
+  assert_that (TA.get_audit_records t)
+    (elements_are
+       [
+         field
+           (fun (r : TA.audit_record) -> r.entry.position_id)
+           (equal_to "AAA-wein-1");
+         field
+           (fun (r : TA.audit_record) -> r.entry.position_id)
+           (equal_to "MMM-wein-1");
+         field
+           (fun (r : TA.audit_record) -> r.entry.position_id)
+           (equal_to "ZZZ-wein-1");
+       ])
+
+let test_collector_round_trips_through_sexp _ =
+  let t = TA.create () in
+  TA.record_entry t
+    (make_entry
+       ~alternatives_considered:
+         [
+           _alt ~symbol:"MSFT" ~score:62 ~grade:Weinstein_types.B
+             ~reason:TA.Top_n_cutoff;
+         ]
+       ());
+  TA.record_exit t (make_exit ());
+  TA.record_entry t (make_entry ~symbol:"NVDA" ~position_id:"NVDA-wein-1" ());
+  let original = TA.get_audit_records t in
+  let parsed = TA.audit_records_of_sexp (TA.sexp_of_audit_records original) in
+  assert_that parsed (elements_are (List.map original ~f:equal_to))
+
+let suite =
+  "Trade_audit"
+  >::: [
+         "skip_reason sexp round-trip" >:: test_skip_reason_sexp_round_trip;
+         "stop_floor_kind sexp round-trip"
+         >:: test_stop_floor_kind_sexp_round_trip;
+         "alternative_candidate sexp round-trip"
+         >:: test_alternative_candidate_sexp_round_trip;
+         "entry_decision sexp round-trip"
+         >:: test_entry_decision_sexp_round_trip;
+         "exit_decision sexp round-trip" >:: test_exit_decision_sexp_round_trip;
+         "audit_record sexp round-trip" >:: test_audit_record_sexp_round_trip;
+         "audit_records list sexp round-trip"
+         >:: test_audit_records_sexp_round_trip_through_top_level_codec;
+         "empty collector returns []" >:: test_empty_collector_returns_empty;
+         "record_entry appears in audit" >:: test_record_entry_appears_in_audit;
+         "record_exit attaches to existing entry"
+         >:: test_record_exit_attaches_to_existing_entry;
+         "record_exit without entry is dropped"
+         >:: test_record_exit_without_entry_is_dropped;
+         "record_entry overwrites same position_id"
+         >:: test_record_entry_overwrites_same_position_id;
+         "get_audit_records sorts by position_id"
+         >:: test_get_audit_records_sorts_by_position_id;
+         "collector round-trips through sexp"
+         >:: test_collector_round_trips_through_sexp;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR-1 of [`dev/plans/trade-audit-2026-04-28.md`](https://github.com/dayfine/trading/blob/main/dev/plans/trade-audit-2026-04-28.md). Ships the data model, observer collector, and persistence plumbing for the per-trade decision-trail log. **No capture sites yet** — those land in PR-2.

The plan picks **Option A**: in-strategy `Trade_audit` observer mirroring `Stop_log` / `Trace`. Persists `trade_audit.sexp` alongside `trades.csv` when non-empty.

## What's new

- `trading/trading/backtest/lib/trade_audit.{ml,mli}` — new module:
  - Records (all `[@@deriving sexp]`): `skip_reason`, `alternative_candidate`, `stop_floor_kind`, `entry_decision`, `exit_decision`, `audit_record`.
  - Collector API: `create`, `record_entry`, `record_exit`, `get_audit_records`, plus top-level `sexp_of_audit_records` / `audit_records_of_sexp`.
  - Mirrors `Stop_log`'s shape: mutable hashtable keyed by `position_id`, sorted output, exit-without-entry is dropped.
- `Backtest.Runner.result` gains an `audit : Trade_audit.audit_record list` field (default `[]`). Same shape as the existing `stop_infos` field. PR-2 will replace the empty literal with a real collector drained at end-of-run.
- `Backtest.Result_writer.write` emits `trade_audit.sexp` **iff** `result.audit` is non-empty. Empty audit writes no file (the pre-PR-2 default), so consumers must tolerate the artefact's absence.

## What's not in this PR (per plan)

- PR-2: capture sites in screener / strategy / simulator (`_run_screen`, `_screen_universe`, `entries_from_candidates`, `Stops_runner`).
- PR-3: markdown renderer + `trade_audit.exe`.
- PR-4: `Trade_rating` heuristics + insight aggregator.
- PR-5 (optional): integrate into `release_perf_report`.

## Types now persisted

`trade_audit.sexp` round-trips a list of `audit_record = { entry : entry_decision; exit_ : exit_decision option }`, where `entry_decision` carries the macro / stage / RS / volume / resistance / support / sector context, the cascade score + components + rationale, the suggested vs installed stop with `stop_floor_kind`, the alternatives considered + reason-skipped, and the realised sizing. `exit_decision` carries the trigger (from `Stop_log.exit_trigger`), state-at-exit, MAE/MFE, and during-hold counters.

## PR sizing

~293 LOC in the new module + ~316 LOC tests = ~609 LOC total. Module-only sits well under the ≤500 LOC PR-sizing rule (tests don't count).

## Test plan

- [x] `dune build` — green
- [x] `dune build @fmt` — clean (formatter idempotent)
- [x] `dune exec backtest/test/test_trade_audit.exe` — 14/14 tests pass
  - sexp round-trip on every record type (`skip_reason`, `stop_floor_kind`, `alternative_candidate`, `entry_decision`, `exit_decision`, `audit_record`, `audit_records list`)
  - collector behaviour: empty → `[]`, `record_entry` appears, `record_exit` attaches to existing entry, exit-without-entry is dropped, same `position_id` overwrites, `get_audit_records` sorts by `position_id`, end-to-end collector → sexp round-trip
- [x] All other backtest tests that currently pass on `main` still pass
- [x] Pre-existing failures on `test_panel_runner_gc_trace` / `test_runner_hypothesis_overrides` (data-path resolution; expects `/workspaces/trading-1/data/backtest_scenarios/...` but fixtures live at `trading/test_data/backtest_scenarios/...`) are unchanged — not introduced or regressed by this PR
- [ ] PR-2 will pin bit-equivalence of audit-on vs audit-off via parity test (per plan §Risks item 4); not in scope here

## Authority

- Plan: [`dev/plans/trade-audit-2026-04-28.md`](https://github.com/dayfine/trading/blob/main/dev/plans/trade-audit-2026-04-28.md)
- Sister observer: `trading/trading/backtest/lib/stop_log.{ml,mli}` (exact pattern mirrored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)