### PR TITLE
fix(backtest-perf): tier-4 release-gate — pass --fixtures-root (mirror #634)

### DIFF
--- a/dev/scripts/perf_tier4_release_gate.sh
+++ b/dev/scripts/perf_tier4_release_gate.sh
@@ -127,6 +127,9 @@ _run_one() {
 
   start_epoch=$(date +%s)
   rc=0
+  # Pass --fixtures-root so the runner resolves the scenario's [universe_path]
+  # against the original fixtures dir, not the per-cell `_stage_<name>/`
+  # scratch dir. Tier-1/2/3 pass this same flag (#634).
   if [ "$HAVE_GNU_TIME" = "1" ]; then
     /usr/bin/time -o "$rss_path" -f '%M' \
       timeout "$TIMEOUT" \
@@ -134,6 +137,7 @@ _run_one() {
         dune exec --no-build \
           trading/backtest/scenarios/scenario_runner.exe -- \
           --dir "$stage_dir" --parallel 1 \
+          --fixtures-root "$SCENARIO_ROOT" \
         >"$log_path" 2>&1 || rc=$?
   else
     timeout "$TIMEOUT" \
@@ -141,6 +145,7 @@ _run_one() {
         dune exec --no-build \
           trading/backtest/scenarios/scenario_runner.exe -- \
           --dir "$stage_dir" --parallel 1 \
+          --fixtures-root "$SCENARIO_ROOT" \
         >"$log_path" 2>&1 || rc=$?
     printf 'UNAVAILABLE\n' >"$rss_path"
   fi


### PR DESCRIPTION
## Summary

PR #635 added `dev/scripts/perf_tier4_release_gate.sh` based on the tier-3 sibling **before** PR #634 added the `--fixtures-root` flag, then the rebase merge missed the propagation. First manual `workflow_dispatch` of `perf-release-gate.yml` (run [25031618293](https://github.com/dayfine/trading/actions/runs/25031618293)) hit the same 4/4 instant-fail pattern that #634 fixed for tier-1/2/3:

```
FAIL    bull-crash-2015-2020              0s        Command
FAIL    covid-recovery-2020-2024          0s        Command
FAIL    decade-2014-2023                  1s        Command
FAIL    six-year-2018-2023                0s        Command
```

## Fix

Add `--fixtures-root "$SCENARIO_ROOT"` to both `scenario_runner.exe` invocations in `perf_tier4_release_gate.sh`, mirroring the tier-1/2/3 sister scripts.

## Test plan

- [x] Diff is exactly the same shape as #634 added to tier-1/2/3 scripts
- [ ] Re-dispatch perf-release-gate.yml after merge; expect 4/4 PASS (or budget overruns, but not insta-FAIL)