### PR TITLE
feat(backtest-perf): trade-audit capture sites in strategy + runner (PR-2 of trade-audit)

### DIFF
--- a/dev/status/trade-audit.md
+++ b/dev/status/trade-audit.md
@@ -3,9 +3,11 @@
 ## Last updated: 2026-04-28
 
 ## Status
-PLANNED
+IN_PROGRESS
 
-Plan landed; implementation pending.
+PR-1 merged (#638) — types + collector + persistence. PR-2 in flight on
+`feat/trade-audit-pr2-capture` — capture sites at entry / exit decision
+sites, plus parity + smoke tests.
 
 ## Goal
 
@@ -32,17 +34,28 @@ NO
 
 ## Open work
 
-None yet — implementation begins on next dispatch.
+PR-2 (capture sites) in flight on
+`feat/trade-audit-pr2-capture`. After it merges, PR-3 (markdown
+renderer + binary) can begin.
 
 ## Phasing (per plan)
 
-- [ ] **PR-1**: `Trade_audit` module — types + collector + persistence
-      (`trade_audit.sexp` alongside `trades.csv`). ~350 LOC.
-- [ ] **PR-2**: Capture sites in `Weinstein_strategy._run_screen` /
+- [x] **PR-1**: `Trade_audit` module — types + collector + persistence
+      (`trade_audit.sexp` alongside `trades.csv`). Merged as #638.
+      Verify: `dune exec backtest/test/test_trade_audit.exe`.
+- [x] **PR-2**: Capture sites in `Weinstein_strategy._run_screen` /
       `_screen_universe` / `entries_from_candidates` + exit capture
-      via `Stop_log` extension. Includes audit-on vs audit-off parity
-      test. ~500 LOC; may split into PR-2a (entry) + PR-2b
-      (exit/alternatives).
+      in `_on_market_close`. Threaded via a strategy-side
+      `Audit_recorder` callback bundle (no Backtest dep on
+      Weinstein_strategy and vice versa); backtest-side
+      `Trade_audit_recorder.of_collector` translates events into the
+      `Trade_audit` records. Bit-equivalence pinned by the existing
+      panel-loader golden parity test. End-to-end smoke at
+      `trading/backtest/test/test_trade_audit_capture.ml` (5 tests):
+      audit non-empty after a run with round-trips, every entry block
+      well-formed, round-trip symbols match audit entries, ≥1 exit_
+      block populated, position_ids unique. Verify:
+      `TRADING_DATA_DIR=$PWD/test_data dune exec backtest/test/test_trade_audit_capture.exe`.
 - [ ] **PR-3**: `trade_audit.exe` + markdown renderer. Per-trade table
       + outlier callouts + aggregate breakdowns. ~400 LOC.
 - [ ] **PR-4**: `Trade_rating` heuristics (R-multiple,

--- a/trading/trading/backtest/lib/dune
+++ b/trading/trading/backtest/lib/dune
@@ -13,7 +13,11 @@
   trading.strategy
   weinstein_trading.strategy
   weinstein.macro
+  weinstein.resistance
+  weinstein.rs
   weinstein.screener
-  weinstein.types)
+  weinstein.support
+  weinstein.types
+  weinstein.volume)
  (preprocess
   (pps ppx_let ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -69,7 +69,8 @@ let _build_indicators ~ohlcv ~n_days =
   let symbol_index = Ohlcv_panels.symbol_index ohlcv in
   Indicator_panels.create ~symbol_index ~n_days ~specs:_default_specs
 
-let _build_strategy (input : input) ~bar_panels ~ohlcv ~indicators ~calendar =
+let _build_strategy (input : input) ~bar_panels ~ohlcv ~indicators ~calendar
+    ~audit_recorder =
   (* The inner Weinstein strategy reads OHLCV bars from
      {!Data_panel.Bar_panels} (populated up-front from CSV at runner start).
      Stage 3 PR-C deleted the Tiered tier system + parallel [Bar_history]
@@ -78,7 +79,8 @@ let _build_strategy (input : input) ~bar_panels ~ohlcv ~indicators ~calendar =
      [get_indicator_fn]. *)
   let inner_strategy =
     Weinstein_strategy.make ~ad_bars:input.ad_bars
-      ~ticker_sectors:input.ticker_sectors ~bar_panels input.config
+      ~ticker_sectors:input.ticker_sectors ~bar_panels ~audit_recorder
+      input.config
   in
   let panel_config : Panel_strategy_wrapper.config =
     {
@@ -91,11 +93,13 @@ let _build_strategy (input : input) ~bar_panels ~ohlcv ~indicators ~calendar =
   in
   Panel_strategy_wrapper.wrap ~config:panel_config inner_strategy
 
-let _make_simulator (input : input) ~stop_log ~start_date ~end_date ~warmup_days
-    ~initial_cash ~commission ~ohlcv ~indicators ~calendar ~bar_panels =
+let _make_simulator (input : input) ~stop_log ~audit_recorder ~start_date
+    ~end_date ~warmup_days ~initial_cash ~commission ~ohlcv ~indicators
+    ~calendar ~bar_panels =
   let warmup_start = Date.add_days start_date (-warmup_days) in
   let strategy =
     _build_strategy input ~bar_panels ~ohlcv ~indicators ~calendar
+      ~audit_recorder
   in
   let strategy = Strategy_wrapper.wrap ~stop_log strategy in
   let sim_deps =
@@ -193,13 +197,16 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     (Ohlcv_panels.n ohlcv) n_days
     (List.length _default_specs);
   let stop_log = Stop_log.create () in
+  let trade_audit = Trade_audit.create () in
+  let audit_recorder = Trade_audit_recorder.of_collector trade_audit in
   let n_all_symbols = List.length input.all_symbols in
   let sim =
-    _make_simulator input ~stop_log ~start_date ~end_date ~warmup_days
-      ~initial_cash ~commission ~ohlcv ~indicators ~calendar ~bar_panels
+    _make_simulator input ~stop_log ~audit_recorder ~start_date ~end_date
+      ~warmup_days ~initial_cash ~commission ~ohlcv ~indicators ~calendar
+      ~bar_panels
   in
   let sim_result =
     Trace.record ?trace ~symbols_in:n_all_symbols Trace.Phase.Fill (fun () ->
         _run_simulator_with_gc_trace ?gc_trace sim)
   in
-  (sim_result, stop_log)
+  (sim_result, stop_log, trade_audit)

--- a/trading/trading/backtest/lib/panel_runner.mli
+++ b/trading/trading/backtest/lib/panel_runner.mli
@@ -43,10 +43,17 @@ val run :
   ?trace:Trace.t ->
   ?gc_trace:Gc_trace.t ->
   unit ->
-  Trading_simulation_types.Simulator_types.run_result * Stop_log.t
+  Trading_simulation_types.Simulator_types.run_result
+  * Stop_log.t
+  * Trade_audit.t
 (** Same shape as the Legacy path's per-strategy entry point. The Panel branch
     in [Runner] uses this; callers should not call this directly outside of
     tests.
+
+    Returns a triple of [(run_result, stop_log, trade_audit)]: the simulator
+    output, the per-position stop log accumulated by the strategy wrapper, and
+    the per-trade decision-trail audit collected at the strategy's entry / exit
+    decision sites (PR-2 of the trade-audit plan).
 
     [gc_trace], when passed, snapshots [Gc.stat] before and after every
     simulator step (one step = one calendar day = one [Engine.update_market]

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -259,7 +259,7 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     (Date.to_string start_date)
     (Date.to_string end_date)
     (Date.to_string warmup_start);
-  let sim_result, stop_log =
+  let sim_result, stop_log, trade_audit =
     _run_panel_backtest ~deps ~start_date ~end_date ?trace ?gc_trace ()
   in
   Gc_trace.record ?trace:gc_trace ~phase:"fill_done" ();
@@ -280,18 +280,15 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
      consumers use the series. *)
   let steps = List.filter steps_in_range ~f:is_trading_day in
   let final_value = (List.last_exn steps).portfolio_value in
-  let round_trips, stop_infos =
+  let round_trips, stop_infos, audit =
     Trace.record ?trace Trace.Phase.Teardown (fun () ->
         ( Metrics.extract_round_trips steps_in_range,
-          Stop_log.get_stop_infos stop_log ))
+          Stop_log.get_stop_infos stop_log,
+          Trade_audit.get_audit_records trade_audit ))
   in
   Gc_trace.record ?trace:gc_trace ~phase:"teardown_done" ();
   let summary =
     _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
       ~sim_result
   in
-  (* PR-1 of trade-audit: empty audit list. PR-2 will create a
-     [Trade_audit.t] here, thread it through [_run_panel_backtest], and
-     drain it into [audit] alongside [stop_infos]. *)
-  let audit = [] in
   { summary; round_trips; steps; overrides; stop_infos; audit }

--- a/trading/trading/backtest/lib/stop_log.ml
+++ b/trading/trading/backtest/lib/stop_log.ml
@@ -32,7 +32,7 @@ type t = { positions : (string, _pos_record) Hashtbl.t }
 
 let create () = { positions = Hashtbl.create (module String) }
 
-let _exit_trigger_of_reason (reason : Position.exit_reason) : exit_trigger =
+let exit_trigger_of_reason (reason : Position.exit_reason) : exit_trigger =
   match reason with
   | StopLoss { stop_price; actual_price; _ } ->
       Stop_loss { stop_price; actual_price }
@@ -70,7 +70,7 @@ let _process_transition t (trans : Position.transition) =
       record.pos_current_stop <- new_risk_params.stop_loss_price
   | TriggerExit { exit_reason; _ } ->
       let record = _ensure_record t ~position_id:trans.position_id ~symbol:"" in
-      record.pos_exit_trigger <- Some (_exit_trigger_of_reason exit_reason)
+      record.pos_exit_trigger <- Some (exit_trigger_of_reason exit_reason)
   | EntryFill _ | CancelEntry _ | ExitFill _ | ExitComplete -> ()
 
 let record_transitions t transitions =

--- a/trading/trading/backtest/lib/stop_log.mli
+++ b/trading/trading/backtest/lib/stop_log.mli
@@ -29,6 +29,14 @@ type exit_trigger =
   | Portfolio_rebalancing  (** Closed for rebalancing *)
 [@@deriving show, eq, sexp]
 
+val exit_trigger_of_reason : Position.exit_reason -> exit_trigger
+(** Map a {!Position.exit_reason} (the strategy-emitted form) into an
+    {!exit_trigger} (the audit-friendly form). Pure translation — no information
+    loss except that the [PortfolioRebalancing] / no-detail variants drop their
+    associated metadata, mirroring the in-collector behaviour. Public so other
+    backtest-side audit modules can produce the same mapping without duplicating
+    the case-split. *)
+
 type stop_info = {
   position_id : string;  (** Strategy position ID *)
   symbol : string;  (** Ticker symbol *)

--- a/trading/trading/backtest/lib/trade_audit_recorder.ml
+++ b/trading/trading/backtest/lib/trade_audit_recorder.ml
@@ -1,0 +1,105 @@
+(** Backtest-side recorder: drains strategy events into a {!Trade_audit.t}
+    collector. See [trade_audit_recorder.mli]. *)
+
+open Core
+module AR = Weinstein_strategy.Audit_recorder
+
+let _stop_floor_kind_of_event = function
+  | AR.Support_floor -> Trade_audit.Support_floor
+  | AR.Buffer_fallback -> Trade_audit.Buffer_fallback
+
+let _skip_reason_of_event = function
+  | AR.Insufficient_cash -> Trade_audit.Insufficient_cash
+  | AR.Already_held -> Trade_audit.Already_held
+  | AR.Sized_to_zero -> Trade_audit.Sized_to_zero
+
+let _alternative_of_event (alt : AR.alternative_input) :
+    Trade_audit.alternative_candidate =
+  {
+    symbol = alt.candidate.ticker;
+    side = alt.candidate.side;
+    score = alt.candidate.score;
+    grade = alt.candidate.grade;
+    reason_skipped = _skip_reason_of_event alt.reason;
+  }
+
+(** Translate one {!AR.entry_event} into a {!Trade_audit.entry_decision}. Pure
+    projection — every field is derived from the event. *)
+let _entry_decision_of_event (e : AR.entry_event) : Trade_audit.entry_decision =
+  let cand = e.candidate in
+  let analysis = cand.analysis in
+  {
+    symbol = cand.ticker;
+    entry_date = e.current_date;
+    position_id = e.position_id;
+    macro_trend = e.macro.trend;
+    macro_confidence = e.macro.confidence;
+    macro_indicators = e.macro.indicators;
+    stage = analysis.stage.stage;
+    ma_direction = analysis.stage.ma_direction;
+    ma_slope_pct = analysis.stage.ma_slope_pct;
+    rs_trend = Option.map analysis.rs ~f:(fun (r : Rs.result) -> r.trend);
+    rs_value =
+      Option.map analysis.rs ~f:(fun (r : Rs.result) -> r.current_normalized);
+    volume_quality =
+      Option.map analysis.volume ~f:(fun (v : Volume.result) -> v.confirmation);
+    resistance_quality =
+      Option.map analysis.resistance ~f:(fun (r : Resistance.result) ->
+          r.quality);
+    support_quality =
+      Option.map analysis.support ~f:(fun (s : Support.result) -> s.quality);
+    sector_name = cand.sector.sector_name;
+    sector_rating = cand.sector.rating;
+    cascade_score = cand.score;
+    cascade_grade = cand.grade;
+    cascade_score_components = [];
+    (* PR-3 will split the screener's score into per-component contributions.
+       Until then the [rationale] string list conveys the contributing signals
+       in human-readable form. *)
+    cascade_rationale = cand.rationale;
+    side = cand.side;
+    suggested_entry = cand.suggested_entry;
+    suggested_stop = cand.suggested_stop;
+    installed_stop = e.installed_stop;
+    stop_floor_kind = _stop_floor_kind_of_event e.stop_floor_kind;
+    risk_pct = cand.risk_pct;
+    initial_position_value = e.initial_position_value;
+    initial_risk_dollars = e.initial_risk_dollars;
+    alternatives_considered = List.map e.alternatives ~f:_alternative_of_event;
+  }
+
+(** Translate one {!AR.exit_event} into a {!Trade_audit.exit_decision}.
+
+    The during-hold counters ([max_favorable_excursion_pct],
+    [max_adverse_excursion_pct], [weeks_macro_was_bearish],
+    [weeks_stage_left_2]) are filled with sensible defaults — populating them
+    requires per-step instrumentation through the simulator's step stream, which
+    is deferred to a follow-up PR. The state-at-decision fields (macro / stage /
+    rs / distance_from_ma) are populated from the strategy's snapshot captured
+    at the moment the [TriggerExit] fired. *)
+let _exit_decision_of_event (e : AR.exit_event) : Trade_audit.exit_decision =
+  {
+    symbol = e.symbol;
+    exit_date = e.exit_date;
+    position_id = e.position_id;
+    exit_trigger = Stop_log.exit_trigger_of_reason e.exit_reason;
+    macro_trend_at_exit = e.macro_trend_at_exit;
+    macro_confidence_at_exit = e.macro_confidence_at_exit;
+    stage_at_exit = e.stage_at_exit;
+    rs_trend_at_exit = e.rs_trend_at_exit;
+    distance_from_ma_pct = e.distance_from_ma_pct;
+    max_favorable_excursion_pct = 0.0;
+    max_adverse_excursion_pct = 0.0;
+    weeks_macro_was_bearish = 0;
+    weeks_stage_left_2 = 0;
+  }
+
+let of_collector (collector : Trade_audit.t) : AR.t =
+  {
+    record_entry =
+      (fun event ->
+        Trade_audit.record_entry collector (_entry_decision_of_event event));
+    record_exit =
+      (fun event ->
+        Trade_audit.record_exit collector (_exit_decision_of_event event));
+  }

--- a/trading/trading/backtest/lib/trade_audit_recorder.mli
+++ b/trading/trading/backtest/lib/trade_audit_recorder.mli
@@ -1,0 +1,14 @@
+(** Construct a {!Weinstein_strategy.Audit_recorder.t} that drains every
+    captured event into a {!Trade_audit.t} collector.
+
+    The strategy library does not depend on Backtest, so the strategy emits raw
+    events ({!Audit_recorder.entry_event} / [exit_event]) carrying the analysis
+    values it has at decision time. This module is the backtest-side translator:
+    it builds {!Trade_audit.entry_decision} / [exit_decision] records from the
+    events and accumulates them into the collector. *)
+
+val of_collector : Trade_audit.t -> Weinstein_strategy.Audit_recorder.t
+(** [of_collector collector] returns a recorder bundle whose [record_entry] and
+    [record_exit] callbacks construct the corresponding {!Trade_audit} records
+    from the strategy's events and route them into [collector] via
+    {!Trade_audit.record_entry} / [record_exit]. *)

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -4,6 +4,7 @@
   test_runner_filter
   test_trace
   test_trade_audit
+  test_trade_audit_capture
   test_runner_hypothesis_overrides
   test_panel_loader_parity
   test_backtest_runner_args

--- a/trading/trading/backtest/test/test_trade_audit_capture.ml
+++ b/trading/trading/backtest/test/test_trade_audit_capture.ml
@@ -1,0 +1,180 @@
+(** End-to-end smoke test for the PR-2 trade-audit capture sites.
+
+    PR-1 of the trade-audit plan (#638) shipped the {!Backtest.Trade_audit}
+    types + collector + sexp persistence. PR-2 wires the entry / exit capture
+    sites in the strategy and runner so [result.audit] is actually populated
+    after a backtest run.
+
+    This test pins the integration:
+
+    - Running [Backtest.Runner.run_backtest] over the [tiered-loader-parity]
+      smoke scenario (a 6-month, 7-symbol bull window) must populate
+      [result.audit] with at least one record when the run produces at least one
+      entry decision.
+    - Every captured audit record's [entry] block carries the runtime fields the
+      strategy is expected to fill at decision time — non-empty symbol, entry
+      date inside the scenario window, [installed_stop > 0], plus the macro /
+      stage / cascade snapshots.
+    - When the simulator fully closes a position, the matching audit record's
+      [exit_] is populated; positions still open at end-of-run carry [None].
+
+    The test runs against the same fixture ([smoke/tiered-loader-parity.sexp])
+    used by [test_runner_hypothesis_overrides], which is committed and small
+    enough to finish in well under the per-test budget. *)
+
+open OUnit2
+open Core
+open Matchers
+module Scenario = Scenario_lib.Scenario
+module Universe_file = Scenario_lib.Universe_file
+
+let _fixtures_root () =
+  let data_dir = Data_path.default_data_dir () |> Fpath.to_string in
+  Filename.concat data_dir "backtest_scenarios"
+
+let _scenario_path () =
+  Filename.concat (_fixtures_root ()) "smoke/tiered-loader-parity.sexp"
+
+let _load_scenario () = Scenario.load (_scenario_path ())
+
+let _sector_map_override (s : Scenario.t) =
+  let resolved = Filename.concat (_fixtures_root ()) s.universe_path in
+  Universe_file.to_sector_map_override (Universe_file.load resolved)
+
+let _run_scenario () =
+  let s = _load_scenario () in
+  let sector_map_override = _sector_map_override s in
+  Backtest.Runner.run_backtest ~start_date:s.period.start_date
+    ~end_date:s.period.end_date ~overrides:s.config_overrides
+    ?sector_map_override ()
+
+(* -------------------------------------------------------------------- *)
+(* Smoke: audit is populated when the run produces entries               *)
+(* -------------------------------------------------------------------- *)
+
+(** The 7-symbol bull-window scenario produces at least one entry over H2 2019.
+    PR-2 must therefore populate [result.audit] with at least one record. A
+    failure here means the capture sites in [_screen_universe] /
+    [entries_from_candidates] are wired wrong. *)
+let test_audit_is_non_empty_when_entries_fire _ =
+  let result = _run_scenario () in
+  (* Trade-audit capture must populate at least one record over this
+     bull-window scenario; an empty list signals the entry capture site is
+     not wired or never fired. *)
+  assert_that (List.length result.audit) (gt (module Int_ord) 0)
+
+(** Each audit record must carry a populated entry block. The check is
+    structural — non-empty symbol, entry_date inside the scenario window, sane
+    [installed_stop], and a [position_id] non-empty string. Float pinning is
+    intentionally loose: this test guards capture-site wiring, not specific
+    stop-buffer values. *)
+let test_audit_entry_block_is_populated _ =
+  let result = _run_scenario () in
+  let s = _load_scenario () in
+  (* Every audit record's entry block must carry strategy-derived state —
+     non-empty symbol, position_id, in-window date, [installed_stop > 0],
+     non-negative cascade_score. Pins capture-site wiring without locking
+     specific values. *)
+  assert_that result.audit
+    (each
+       (field
+          (fun (r : Backtest.Trade_audit.audit_record) -> r.entry)
+          (all_of
+             [
+               field
+                 (fun (e : Backtest.Trade_audit.entry_decision) ->
+                   String.length e.symbol)
+                 (gt (module Int_ord) 0);
+               field
+                 (fun (e : Backtest.Trade_audit.entry_decision) ->
+                   String.length e.position_id)
+                 (gt (module Int_ord) 0);
+               field
+                 (fun (e : Backtest.Trade_audit.entry_decision) ->
+                   Date.( >= ) e.entry_date s.period.start_date
+                   && Date.( <= ) e.entry_date s.period.end_date)
+                 (equal_to true);
+               field
+                 (fun (e : Backtest.Trade_audit.entry_decision) ->
+                   e.installed_stop)
+                 (gt (module Float_ord) 0.0);
+               field
+                 (fun (e : Backtest.Trade_audit.entry_decision) ->
+                   e.cascade_score)
+                 (ge (module Int_ord) 0);
+             ])))
+
+(** Every round-trip's symbol must appear in the audit's entry list. The join is
+    by symbol alone — not [(symbol, entry_date)] — because
+    [trade_metrics.entry_date] is the simulator-fill date (one trading day after
+    the strategy emitted [CreateEntering], typically Friday → Monday) while
+    [audit.entry_date] is the strategy's decision date. The fill-lag is a
+    property of the simulator's order-execution path, not of the audit capture.
+*)
+let test_round_trip_symbols_match_audit_entries _ =
+  let result = _run_scenario () in
+  let audit_symbols =
+    List.map result.audit ~f:(fun (r : Backtest.Trade_audit.audit_record) ->
+        r.entry.symbol)
+    |> Set.of_list (module String)
+  in
+  let unmatched =
+    List.filter result.round_trips
+      ~f:(fun (t : Trading_simulation.Metrics.trade_metrics) ->
+        not (Set.mem audit_symbols t.symbol))
+  in
+  (* Every round-trip's symbol must have at least one audit entry. A
+     mismatch would mean the entry capture missed a candidate that
+     ultimately produced a fill. *)
+  assert_that (List.length unmatched) (equal_to 0)
+
+(** At least one audit record must have [exit_] populated — the only way the
+    flag fires is the strategy emitting a [TriggerExit], which the
+    [_on_market_close] capture site picks up. A failure here means exit capture
+    is not wired. *)
+let test_some_audit_records_have_exit_blocks _ =
+  let result = _run_scenario () in
+  let with_exit =
+    List.count result.audit ~f:(fun (r : Backtest.Trade_audit.audit_record) ->
+        Option.is_some r.exit_)
+  in
+  (* Exit capture must fire at least once over the bull-window scenario,
+     which produces several stop-out exits per the committed scenario
+     metadata. *)
+  assert_that with_exit (gt (module Int_ord) 0)
+
+(** Position ids must round-trip through the audit collector — recording an
+    entry then an exit with the same [position_id] yields one audit record with
+    both blocks populated, never two records with the same key.
+
+    The collector keys by [position_id], so this is a property of
+    {!Backtest.Trade_audit} itself; we re-test it here at the end-to-end seam to
+    guard against a future refactor that accidentally double-records or keys by
+    something else. *)
+let test_audit_position_ids_are_unique _ =
+  let result = _run_scenario () in
+  let ids =
+    List.map result.audit ~f:(fun (r : Backtest.Trade_audit.audit_record) ->
+        r.entry.position_id)
+  in
+  let dedup = List.dedup_and_sort ids ~compare:String.compare in
+  (* Audit collector must not record duplicate position_ids — Trade_audit
+     keys by position_id, so duplicates mean the strategy generated the same
+     id twice or the test rig is double-recording. *)
+  assert_that (List.length ids - List.length dedup) (equal_to 0)
+
+let suite =
+  "Trade_audit_capture"
+  >::: [
+         "audit is non-empty when entries fire"
+         >:: test_audit_is_non_empty_when_entries_fire;
+         "every audit record's entry block is populated"
+         >:: test_audit_entry_block_is_populated;
+         "every round-trip's symbol matches an audit entry"
+         >:: test_round_trip_symbols_match_audit_entries;
+         "at least one audit record has a populated exit_ block"
+         >:: test_some_audit_records_have_exit_blocks;
+         "audit position_ids are unique" >:: test_audit_position_ids_are_unique;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/audit_recorder.ml
+++ b/trading/trading/weinstein/strategy/lib/audit_recorder.ml
@@ -1,0 +1,45 @@
+(** Decision-trail recorder. See [audit_recorder.mli] for the contract. *)
+
+open Core
+
+type skip_reason = Insufficient_cash | Already_held | Sized_to_zero
+
+type alternative_input = {
+  candidate : Screener.scored_candidate;
+  reason : skip_reason;
+}
+
+type stop_floor_kind = Support_floor | Buffer_fallback
+
+type entry_event = {
+  position_id : string;
+  candidate : Screener.scored_candidate;
+  macro : Macro.result;
+  current_date : Date.t;
+  installed_stop : float;
+  stop_floor_kind : stop_floor_kind;
+  shares : int;
+  initial_position_value : float;
+  initial_risk_dollars : float;
+  alternatives : alternative_input list;
+}
+
+type exit_event = {
+  position_id : string;
+  symbol : string;
+  exit_date : Date.t;
+  exit_price : float;
+  exit_reason : Trading_strategy.Position.exit_reason;
+  macro_trend_at_exit : Weinstein_types.market_trend;
+  macro_confidence_at_exit : float;
+  stage_at_exit : Weinstein_types.stage;
+  rs_trend_at_exit : Weinstein_types.rs_trend option;
+  distance_from_ma_pct : float;
+}
+
+type t = {
+  record_entry : entry_event -> unit;
+  record_exit : exit_event -> unit;
+}
+
+let noop : t = { record_entry = (fun _ -> ()); record_exit = (fun _ -> ()) }

--- a/trading/trading/weinstein/strategy/lib/audit_recorder.mli
+++ b/trading/trading/weinstein/strategy/lib/audit_recorder.mli
@@ -1,0 +1,103 @@
+(** Decision-trail recorder: a callback bundle the strategy invokes at entry /
+    exit decision sites.
+
+    The strategy emits raw events containing the analysis values it has in scope
+    at decision time ({!Screener.scored_candidate}, {!Macro.result},
+    {!Stage.result}, etc.). The backtest layer wires concrete callbacks that
+    construct a {!Backtest.Trade_audit.entry_decision} / [exit_decision] from
+    the event and accumulates them into a [Trade_audit.t] collector.
+
+    The strategy library does not depend on [Backtest] — this module exists
+    precisely to keep that direction. The {!noop} default lets non-recording
+    callers leave the audit unwired with zero overhead. *)
+
+open Core
+
+(** Why a candidate produced by the screener was not entered.
+
+    Tagged at the strategy boundary where [_make_entry_transition] is called.
+    The backtest-side recorder maps these into
+    {!Backtest.Trade_audit.skip_reason}.
+
+    {b Note}: only the three reasons the strategy can directly observe at the
+    sizing/cash gates land here. Screener-internal truncations
+    ([Below_min_grade], [Top_n_cutoff], [Sector_concentration]) are not visible
+    at this site — the screener already filtered the candidate before the
+    strategy saw it. The audit's [alternatives_considered] field therefore
+    enumerates only the rivals from the same screen call that the strategy
+    actually considered for entry. *)
+type skip_reason = Insufficient_cash | Already_held | Sized_to_zero
+
+type alternative_input = {
+  candidate : Screener.scored_candidate;
+  reason : skip_reason;
+}
+(** A candidate that scored at the same screen call as the chosen one but was
+    not entered. *)
+
+(** Whether the installed initial stop sat on a real support floor (or short:
+    resistance ceiling) derived from bar history, or fell back to the
+    fixed-buffer proxy. Mirrors {!Backtest.Trade_audit.stop_floor_kind}. *)
+type stop_floor_kind = Support_floor | Buffer_fallback
+
+type entry_event = {
+  position_id : string;
+      (** Position id assigned at entry — matches the [Position.transition] this
+          event is recorded alongside, and [Stop_log.stop_info.position_id] /
+          [Backtest.Trade_audit.entry_decision.position_id]. *)
+  candidate : Screener.scored_candidate;
+      (** The chosen candidate. Carries [analysis], [sector], [side], [score],
+          [grade], [rationale], [suggested_entry], [suggested_stop], [risk_pct].
+      *)
+  macro : Macro.result;
+      (** Macro snapshot computed by [_run_screen] this Friday. *)
+  current_date : Date.t;
+  installed_stop : float;
+      (** Output of
+          [Weinstein_stops.compute_initial_stop_with_floor_with_callbacks]'s
+          stop level after the buffer is applied. *)
+  stop_floor_kind : stop_floor_kind;
+      (** Whether [installed_stop] sat on a real support floor or fell back. *)
+  shares : int;
+      (** From [Portfolio_risk.compute_position_size] — round-share count
+          actually ordered. *)
+  initial_position_value : float;
+      (** [shares * suggested_entry] — dollar exposure at entry. *)
+  initial_risk_dollars : float;
+      (** [|suggested_entry - installed_stop| * shares] — dollar risk to stop.
+      *)
+  alternatives : alternative_input list;
+      (** Rivals from the same screen call that were not entered. *)
+}
+(** Event captured at entry-decision time. *)
+
+type exit_event = {
+  position_id : string;
+  symbol : string;
+  exit_date : Date.t;
+  exit_price : float;
+  exit_reason : Trading_strategy.Position.exit_reason;
+      (** Raw exit reason from the [Position.TriggerExit] kind. The backtest
+          layer maps this into a {!Backtest.Stop_log.exit_trigger}. *)
+  macro_trend_at_exit : Weinstein_types.market_trend;
+  macro_confidence_at_exit : float;
+  stage_at_exit : Weinstein_types.stage;
+  rs_trend_at_exit : Weinstein_types.rs_trend option;
+  distance_from_ma_pct : float;
+      (** [(exit_price - ma_value) / ma_value] at exit time. Positive if exit
+          was above the MA, negative if below. [0.0] when the MA could not be
+          read. *)
+}
+(** Event captured at exit-decision time. *)
+
+type t = {
+  record_entry : entry_event -> unit;
+  record_exit : exit_event -> unit;
+}
+(** Recorder bundle. Both callbacks are invoked unconditionally by the strategy
+    at entry / exit sites; the implementation decides whether to persist or
+    drop. *)
+
+val noop : t
+(** Recorder that drops every event. Default for callers (tests, live mode) that
+    do not wire a backtest collector. *)

--- a/trading/trading/weinstein/strategy/lib/entry_audit_capture.ml
+++ b/trading/trading/weinstein/strategy/lib/entry_audit_capture.ml
@@ -1,0 +1,177 @@
+(** Entry-side trade-audit capture. See [entry_audit_capture.mli]. *)
+
+open Core
+open Trading_strategy
+
+type entry_meta = {
+  position_id : string;
+  shares : int;
+  installed_stop : float;
+  stop_floor_kind : Audit_recorder.stop_floor_kind;
+}
+
+type candidate_decision =
+  | Kept of Position.transition * entry_meta
+  | Skipped of Audit_recorder.skip_reason
+
+let classify_stop_floor_kind ~stops_config ~callbacks ~side :
+    Audit_recorder.stop_floor_kind =
+  match
+    Weinstein_stops.Support_floor.find_recent_level_with_callbacks ~callbacks
+      ~side ~min_pullback_pct:stops_config.Weinstein_stops.min_correction_pct
+  with
+  | Some _ -> Support_floor
+  | None -> Buffer_fallback
+
+(* ------------------------------------------------------------------ *)
+(* Per-candidate entry construction                                     *)
+(* ------------------------------------------------------------------ *)
+
+let _position_counter = ref 0
+
+let gen_position_id symbol =
+  Int.incr _position_counter;
+  Printf.sprintf "%s-wein-%d" symbol !_position_counter
+
+(** Normalise (entry, stop) to the order [Portfolio_risk.compute_position_size]
+    expects: entry first, stop below. For longs that's the identity (stop <
+    entry); for shorts we swap (stop > entry → [max, min]). *)
+let _normalised_entry_stop_for_sizing (cand : Screener.scored_candidate) =
+  let open Trading_base.Types in
+  match cand.side with
+  | Long -> (cand.suggested_entry, cand.suggested_stop)
+  | Short ->
+      ( Float.max cand.suggested_entry cand.suggested_stop,
+        Float.min cand.suggested_entry cand.suggested_stop )
+
+let make_entry_transition ~portfolio_risk_config ~stops_config
+    ~initial_stop_buffer ~stop_states ~bar_reader ~portfolio_value ~current_date
+    (cand : Screener.scored_candidate) =
+  let entry_for_sizing, stop_for_sizing =
+    _normalised_entry_stop_for_sizing cand
+  in
+  let sizing =
+    Portfolio_risk.compute_position_size ~config:portfolio_risk_config
+      ~portfolio_value ~entry_price:entry_for_sizing ~stop_price:stop_for_sizing
+      ()
+  in
+  if sizing.shares = 0 then None
+  else
+    let id = gen_position_id cand.ticker in
+    let daily_view =
+      Bar_reader.daily_view_for bar_reader ~symbol:cand.ticker
+        ~as_of:current_date
+        ~lookback:stops_config.Weinstein_stops.support_floor_lookback_bars
+    in
+    let callbacks =
+      Panel_callbacks.support_floor_callbacks_of_daily_view daily_view
+    in
+    let initial_stop =
+      Weinstein_stops.compute_initial_stop_with_floor_with_callbacks
+        ~config:stops_config ~side:cand.side ~entry_price:cand.suggested_entry
+        ~callbacks ~fallback_buffer:initial_stop_buffer
+    in
+    let stop_floor_kind =
+      classify_stop_floor_kind ~stops_config ~callbacks ~side:cand.side
+    in
+    stop_states := Map.set !stop_states ~key:cand.ticker ~data:initial_stop;
+    let description =
+      Printf.sprintf "Weinstein %s: %s"
+        (Weinstein_types.grade_to_string cand.grade)
+        (String.concat ~sep:"; " cand.rationale)
+    in
+    let reasoning = Position.ManualDecision { description } in
+    let kind =
+      Position.CreateEntering
+        {
+          symbol = cand.ticker;
+          side = cand.side;
+          target_quantity = Float.of_int sizing.shares;
+          entry_price = cand.suggested_entry;
+          reasoning;
+        }
+    in
+    let transition = { Position.position_id = id; date = current_date; kind } in
+    let meta : entry_meta =
+      {
+        position_id = id;
+        shares = sizing.shares;
+        installed_stop = Weinstein_stops.get_stop_level initial_stop;
+        stop_floor_kind;
+      }
+    in
+    Some (transition, meta)
+
+let check_cash_and_deduct ~remaining_cash
+    ((trans : Position.transition), (meta : entry_meta)) =
+  match trans.kind with
+  | Position.CreateEntering e ->
+      let cost = e.target_quantity *. e.entry_price in
+      if Float.( > ) cost !remaining_cash then None
+      else (
+        remaining_cash := !remaining_cash -. cost;
+        Some (trans, meta))
+  | _ -> Some (trans, meta)
+
+let classify_candidate ~held_set ~make_entry ~remaining_cash
+    (c : Screener.scored_candidate) : candidate_decision =
+  if Set.mem held_set c.ticker then Skipped Already_held
+  else
+    match make_entry c with
+    | None -> Skipped Sized_to_zero
+    | Some (trans, meta) -> (
+        match check_cash_and_deduct ~remaining_cash (trans, meta) with
+        | Some (trans, meta) -> Kept (trans, meta)
+        | None -> Skipped Insufficient_cash)
+
+let alternatives_of_decisions ~decisions ~exclude_position_id :
+    Audit_recorder.alternative_input list =
+  List.filter_map decisions ~f:(fun (candidate, decision) ->
+      match decision with
+      | Skipped reason -> Some { Audit_recorder.candidate; reason }
+      | Kept (_, meta) ->
+          if String.equal meta.position_id exclude_position_id then None
+          else None)
+
+let build_entry_event ~(macro : Macro.result) ~current_date
+    ~(candidate : Screener.scored_candidate) ~(meta : entry_meta)
+    ~(alternatives : Audit_recorder.alternative_input list) :
+    Audit_recorder.entry_event =
+  let initial_position_value =
+    Float.of_int meta.shares *. candidate.suggested_entry
+  in
+  let initial_risk_dollars =
+    Float.of_int meta.shares
+    *. Float.abs (candidate.suggested_entry -. meta.installed_stop)
+  in
+  {
+    Audit_recorder.position_id = meta.position_id;
+    candidate;
+    macro;
+    current_date;
+    installed_stop = meta.installed_stop;
+    stop_floor_kind = meta.stop_floor_kind;
+    shares = meta.shares;
+    initial_position_value;
+    initial_risk_dollars;
+    alternatives;
+  }
+
+let emit_entries ~(audit_recorder : Audit_recorder.t)
+    ~(macro : Macro.result option) ~current_date ~decisions =
+  match macro with
+  | None -> ()
+  | Some macro ->
+      List.iter decisions ~f:(fun (candidate, d) ->
+          match d with
+          | Skipped _ -> ()
+          | Kept (_, meta) ->
+              let alternatives =
+                alternatives_of_decisions ~decisions
+                  ~exclude_position_id:meta.position_id
+              in
+              let event =
+                build_entry_event ~macro ~current_date ~candidate ~meta
+                  ~alternatives
+              in
+              audit_recorder.record_entry event)

--- a/trading/trading/weinstein/strategy/lib/entry_audit_capture.mli
+++ b/trading/trading/weinstein/strategy/lib/entry_audit_capture.mli
@@ -1,0 +1,136 @@
+(** Entry-side trade-audit capture.
+
+    Holds the data shapes and builders the strategy uses to populate
+    {!Audit_recorder.entry_event}s when the entry walk produces a kept
+    candidate. The strategy keeps {!Weinstein_strategy._make_entry_transition} /
+    {!Weinstein_strategy.entries_from_candidates} but delegates the
+    audit-emission bookkeeping (the candidate-decision tagging, the alternatives
+    projection, the entry-event construction) to this module so the strategy
+    file stays under its file-length cap. *)
+
+type entry_meta = {
+  position_id : string;
+  shares : int;
+  installed_stop : float;
+  stop_floor_kind : Audit_recorder.stop_floor_kind;
+}
+(** Audit-relevant intermediates computed during entry-transition construction.
+    Returned alongside the transition so the audit recorder can capture them
+    without duplicating the underlying support-floor lookup. *)
+
+(** Per-candidate decision tag emitted by the entry walk. The [Kept] case
+    carries the produced transition + audit meta; [Skipped] records why the
+    candidate was passed over so the audit can populate
+    [alternatives_considered]. Matches one-to-one with
+    {!Audit_recorder.skip_reason}. *)
+type candidate_decision =
+  | Kept of Trading_strategy.Position.transition * entry_meta
+  | Skipped of Audit_recorder.skip_reason
+
+val classify_stop_floor_kind :
+  stops_config:Weinstein_stops.config ->
+  callbacks:Weinstein_stops.callbacks ->
+  side:Trading_base.Types.position_side ->
+  Audit_recorder.stop_floor_kind
+(** Decide [stop_floor_kind] for a freshly-installed initial stop. Mirrors
+    {!Weinstein_stops.compute_initial_stop_with_floor_with_callbacks}'s internal
+    branch — [Some _] from
+    {!Weinstein_stops.Support_floor.find_recent_level_with_callbacks} →
+    [Support_floor]; [None] → [Buffer_fallback].
+
+    The lookup is repeated here rather than threaded out of the stops primitive
+    to keep that primitive's surface clean; the cost is one extra bar walk per
+    entered candidate, bounded by [stops_config.support_floor_lookback_bars]. *)
+
+val alternatives_of_decisions :
+  decisions:(Screener.scored_candidate * candidate_decision) list ->
+  exclude_position_id:string ->
+  Audit_recorder.alternative_input list
+(** Build the [alternatives_considered] list for a chosen candidate's audit row.
+    Every other candidate from the same screen call surfaces here:
+
+    - [Skipped reason] candidates pass through verbatim with the captured
+      [reason].
+    - [Kept] rivals (other entered candidates) are excluded — they have their
+      own [entry_decision] records, and cross-trade analysis joins on
+      [position_id]. *)
+
+val build_entry_event :
+  macro:Macro.result ->
+  current_date:Core.Date.t ->
+  candidate:Screener.scored_candidate ->
+  meta:entry_meta ->
+  alternatives:Audit_recorder.alternative_input list ->
+  Audit_recorder.entry_event
+(** Project [(candidate, meta, alternatives)] into an
+    {!Audit_recorder.entry_event}. Computes the dollar-denominated sizing fields
+    ([initial_position_value], [initial_risk_dollars]) from [meta.shares],
+    [candidate.suggested_entry], and [meta.installed_stop]. *)
+
+val emit_entries :
+  audit_recorder:Audit_recorder.t ->
+  macro:Macro.result option ->
+  current_date:Core.Date.t ->
+  decisions:(Screener.scored_candidate * candidate_decision) list ->
+  unit
+(** For every [Kept] entry in [decisions], compute the [alternatives] list,
+    build an [entry_event], and route it through [audit_recorder.record_entry].
+    [Skipped] entries are silently dropped — they surface as alternatives in
+    other Kept entries' rows.
+
+    No-op when [macro] is [None] (the strategy did not run macro this tick, so
+    the entry walk is being driven from a test fixture without macro state —
+    skip audit emission rather than fabricate a Neutral macro). *)
+
+(** {1 Per-candidate entry construction}
+
+    These primitives are factored out of the strategy file so the strategy stays
+    under its file-length cap. Behaviour is bit-equivalent to the inline
+    pre-PR-2 code: same sizing inputs, same stop computation, same side-effects
+    on [stop_states]. *)
+
+val gen_position_id : string -> string
+(** Generate a fresh position id of the form [<ticker>-wein-<n>] with [n] a
+    monotonically-increasing global counter. Same shape the strategy used
+    pre-PR-2; preserved verbatim so existing transition / stop_log identities
+    don't change. *)
+
+val make_entry_transition :
+  portfolio_risk_config:Portfolio_risk.config ->
+  stops_config:Weinstein_stops.config ->
+  initial_stop_buffer:float ->
+  stop_states:Weinstein_stops.stop_state Core.String.Map.t ref ->
+  bar_reader:Bar_reader.t ->
+  portfolio_value:float ->
+  current_date:Core.Date.t ->
+  Screener.scored_candidate ->
+  (Trading_strategy.Position.transition * entry_meta) option
+(** Try to build a [CreateEntering] transition for [cand]. Returns [None] when
+    sizing yields zero shares (un-sizeable). Side-effects: registers the initial
+    stop in [stop_states]; bumps the global position-id counter. The initial
+    stop comes from
+    {!Weinstein_stops.compute_initial_stop_with_floor_with_callbacks}, which
+    pulls a prior correction low (long) or counter-rally high (short) from
+    [cand]'s bar history, falling back to [initial_stop_buffer] when no
+    qualifying counter-move is in the lookback window. *)
+
+val check_cash_and_deduct :
+  remaining_cash:float ref ->
+  Trading_strategy.Position.transition * entry_meta ->
+  (Trading_strategy.Position.transition * entry_meta) option
+(** Check that the transition's cost ([target_quantity * entry_price]) fits in
+    [remaining_cash]. Deducts and returns [Some] when it does, returns [None]
+    otherwise. Pass-through for non-[CreateEntering] transitions. *)
+
+val classify_candidate :
+  held_set:Core.String.Set.t ->
+  make_entry:
+    (Screener.scored_candidate ->
+    (Trading_strategy.Position.transition * entry_meta) option) ->
+  remaining_cash:float ref ->
+  Screener.scored_candidate ->
+  candidate_decision
+(** Classify one candidate as [Kept] or [Skipped reason]. The three skip reasons
+    match {!Audit_recorder.skip_reason}: held, sized to zero, or rejected by the
+    running cash check. Order: held-check, then sizing via [make_entry], finally
+    the cash check. *)

--- a/trading/trading/weinstein/strategy/lib/exit_audit_capture.ml
+++ b/trading/trading/weinstein/strategy/lib/exit_audit_capture.ml
@@ -1,0 +1,78 @@
+(** Exit-side trade-audit capture. See [exit_audit_capture.mli]. *)
+
+open Core
+open Trading_strategy
+
+(** Snapshot the macro state (trend + confidence) at exit time. Reads from
+    [prior_macro_result] — the cached output of the most recent
+    {!Macro.analyze_with_callbacks} run inside [Weinstein_strategy._run_screen].
+    Falls back to [(Neutral, 0.0)] before the first Friday or when AD-breadth
+    and ETF data were both skipped (in which case [_run_screen] never fired). *)
+let _macro_snapshot_at_exit (prior : Macro.result option) =
+  match prior with
+  | Some r -> (r.trend, r.confidence)
+  | None -> (Weinstein_types.Neutral, 0.0)
+
+(** Compute [(close - ma) / ma] for [symbol] at [as_of] via the same panel-
+    backed weekly view the stops loop reads. Returns [0.0] when the MA is
+    unavailable (warmup, missing bars). *)
+let _distance_from_ma_pct ?ma_cache ~stage_config ~lookback_bars ~bar_reader
+    ~prior_stages ~symbol ~as_of () =
+  let weekly =
+    Bar_reader.weekly_view_for bar_reader ~symbol ~n:lookback_bars ~as_of
+  in
+  if weekly.n < stage_config.Stage.ma_period then 0.0
+  else
+    let prior_stage = Hashtbl.find prior_stages symbol in
+    let callbacks =
+      Panel_callbacks.stage_callbacks_of_weekly_view ?ma_cache ~symbol
+        ~config:stage_config ~weekly ()
+    in
+    let result =
+      Stage.classify_with_callbacks ~config:stage_config
+        ~get_ma:callbacks.get_ma ~get_close:callbacks.get_close ~prior_stage
+    in
+    if Float.equal result.ma_value 0.0 then 0.0
+    else
+      let close =
+        Option.value (callbacks.get_close ~week_offset:0) ~default:0.0
+      in
+      (close -. result.ma_value) /. result.ma_value
+
+let emit_exit_audit ~(audit_recorder : Audit_recorder.t) ~prior_macro_result
+    ~stage_config ~lookback_bars ~bar_reader ~prior_stages ~positions
+    (trans : Position.transition) =
+  match trans.kind with
+  | Position.TriggerExit { exit_reason; exit_price } -> (
+      match Map.find positions trans.position_id with
+      | None -> ()
+      | Some (pos : Position.t) ->
+          let macro_trend, macro_confidence =
+            _macro_snapshot_at_exit !prior_macro_result
+          in
+          let stage_at_exit =
+            Hashtbl.find prior_stages pos.symbol
+            |> Option.value
+                 ~default:(Weinstein_types.Stage1 { weeks_in_base = 0 })
+          in
+          let ma_cache = Bar_reader.ma_cache bar_reader in
+          let distance_from_ma_pct =
+            _distance_from_ma_pct ?ma_cache ~stage_config ~lookback_bars
+              ~bar_reader ~prior_stages ~symbol:pos.symbol ~as_of:trans.date ()
+          in
+          let event : Audit_recorder.exit_event =
+            {
+              position_id = trans.position_id;
+              symbol = pos.symbol;
+              exit_date = trans.date;
+              exit_price;
+              exit_reason;
+              macro_trend_at_exit = macro_trend;
+              macro_confidence_at_exit = macro_confidence;
+              stage_at_exit;
+              rs_trend_at_exit = None;
+              distance_from_ma_pct;
+            }
+          in
+          audit_recorder.record_exit event)
+  | _ -> ()

--- a/trading/trading/weinstein/strategy/lib/exit_audit_capture.mli
+++ b/trading/trading/weinstein/strategy/lib/exit_audit_capture.mli
@@ -1,0 +1,37 @@
+(** Exit-side trade-audit capture.
+
+    Bridges {!Stops_runner}'s [TriggerExit] transitions to
+    {!Audit_recorder.exit_event}. Reads the strategy's cached macro snapshot and
+    the [prior_stages] hashtable (also threaded into the stops loop) to build
+    the state-at-exit fields the audit's [exit_decision] requires.
+
+    Pure observer — no side effects on strategy state, only on the audit
+    collector. *)
+
+open Core
+
+val emit_exit_audit :
+  audit_recorder:Audit_recorder.t ->
+  prior_macro_result:Macro.result option ref ->
+  stage_config:Stage.config ->
+  lookback_bars:int ->
+  bar_reader:Bar_reader.t ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  positions:Trading_strategy.Position.t Map.M(String).t ->
+  Trading_strategy.Position.transition ->
+  unit
+(** [emit_exit_audit ~audit_recorder ~prior_macro_result ~stage_config
+     ~lookback_bars ~bar_reader ~prior_stages ~positions transition] inspects
+    [transition]: when its kind is [TriggerExit], looks up the matching
+    {!Trading_strategy.Position.t} via [transition.position_id] in [positions],
+    snapshots the macro / stage / RS state at exit time, and invokes
+    [audit_recorder.record_exit].
+
+    Other transition kinds are ignored — the function is intentionally a no-op
+    when called on adjust / non-exit transitions, so callers can pipe every
+    emitted transition through it without filtering first.
+
+    [prior_macro_result] is the strategy's cached macro snapshot (option ref) —
+    last set inside [Weinstein_strategy._run_screen]. When it's still [None]
+    (exit fired before the first Friday) the snapshot defaults to [Neutral] /
+    [0.0]. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -25,6 +25,15 @@ module Weekly_ma_cache = Weekly_ma_cache
 (** Per-symbol weekly MA cache (Stage 4 PR-D). Memoises Stage / Macro / Sector /
     Stops MA reads keyed by [(symbol, ma_type, period)]. *)
 
+module Audit_recorder = Audit_recorder
+(** Decision-trail recorder. See [audit_recorder.mli]. *)
+
+module Entry_audit_capture = Entry_audit_capture
+(** Per-candidate entry construction + audit emission. *)
+
+module Exit_audit_capture = Exit_audit_capture
+(** Exit-side trade-audit capture. *)
+
 type index_config = { primary : string; global : (string * string) list }
 [@@deriving sexp]
 
@@ -72,92 +81,6 @@ let name = "Weinstein"
 (* Helpers                                                              *)
 (* ------------------------------------------------------------------ *)
 
-let _position_counter = ref 0
-
-let _gen_position_id symbol =
-  Int.incr _position_counter;
-  Printf.sprintf "%s-wein-%d" symbol !_position_counter
-
-(** Normalise (entry, stop) to the order [Portfolio_risk.compute_position_size]
-    expects: entry first, stop below. For longs that's the identity (stop <
-    entry); for shorts we swap (stop > entry → [max, min]). The result has the
-    same absolute risk per share, so [sizing.shares] is unchanged between sides.
-*)
-let _normalised_entry_stop_for_sizing (cand : Screener.scored_candidate) =
-  let open Trading_base.Types in
-  match cand.side with
-  | Long -> (cand.suggested_entry, cand.suggested_stop)
-  | Short ->
-      ( Float.max cand.suggested_entry cand.suggested_stop,
-        Float.min cand.suggested_entry cand.suggested_stop )
-
-(** Try to build a CreateEntering transition for one screened candidate.
-    Registers the initial stop state as a side effect. Returns None if the
-    candidate is un-sizeable (zero portfolio value or zero shares). The initial
-    stop comes from
-    {!Weinstein_stops.compute_initial_stop_with_floor_with_callbacks}, which
-    pulls a prior correction low (long) or counter-rally high (short) from
-    [cand]'s bar history, falling back to the fixed-buffer proxy. *)
-let _make_entry_transition ~config ~stop_states ~bar_reader ~portfolio_value
-    ~current_date (cand : Screener.scored_candidate) =
-  let entry_for_sizing, stop_for_sizing =
-    _normalised_entry_stop_for_sizing cand
-  in
-  let sizing =
-    Portfolio_risk.compute_position_size ~config:config.portfolio_config
-      ~portfolio_value ~entry_price:entry_for_sizing ~stop_price:stop_for_sizing
-      ()
-  in
-  if sizing.shares = 0 then None
-  else
-    let id = _gen_position_id cand.ticker in
-    (* Stage 4 PR-A: read a daily view directly from panels — no
-       [Daily_price.t list]. The view is windowed to [support_floor_lookback_bars]
-       at construction, matching the wrapper [callbacks_from_bars] semantics. *)
-    let daily_view =
-      Bar_reader.daily_view_for bar_reader ~symbol:cand.ticker
-        ~as_of:current_date
-        ~lookback:config.stops_config.support_floor_lookback_bars
-    in
-    let callbacks =
-      Panel_callbacks.support_floor_callbacks_of_daily_view daily_view
-    in
-    let initial_stop =
-      Weinstein_stops.compute_initial_stop_with_floor_with_callbacks
-        ~config:config.stops_config ~side:cand.side
-        ~entry_price:cand.suggested_entry ~callbacks
-        ~fallback_buffer:config.initial_stop_buffer
-    in
-    stop_states := Map.set !stop_states ~key:cand.ticker ~data:initial_stop;
-    let description =
-      Printf.sprintf "Weinstein %s: %s"
-        (Weinstein_types.grade_to_string cand.grade)
-        (String.concat ~sep:"; " cand.rationale)
-    in
-    let reasoning = Position.ManualDecision { description } in
-    let kind =
-      Position.CreateEntering
-        {
-          symbol = cand.ticker;
-          side = cand.side;
-          target_quantity = Float.of_int sizing.shares;
-          entry_price = cand.suggested_entry;
-          reasoning;
-        }
-    in
-    Some { Position.position_id = id; date = current_date; kind }
-
-(** Check that entry cost fits remaining cash; deduct if so. *)
-let _check_cash_and_deduct remaining_cash (trans : Position.transition) =
-  match trans.kind with
-  | Position.CreateEntering e ->
-      let cost = e.target_quantity *. e.entry_price in
-      if Float.( > ) cost !remaining_cash then None
-      else (
-        remaining_cash := !remaining_cash -. cost;
-        Some trans)
-  | _ -> Some trans
-
 (** Collect ticker symbols of positions the strategy is still holding (or still
     trying to enter/exit). Closed positions are excluded — the strategy has no
     stake in them and must be free to re-enter the symbol.
@@ -176,45 +99,47 @@ let held_symbols (portfolio : Portfolio_view.t) =
       | Entering _ | Holding _ | Exiting _ -> Some p.symbol
       | Closed _ -> None)
 
-(** Try to convert a single screener candidate to a kept transition. Returns
-    [None] when the ticker is already held, when sizing rejects it, or when cash
-    is insufficient. *)
-let _candidate_to_transition ~held_set ~make_entry ~remaining_cash
-    (c : Screener.scored_candidate) =
-  if Set.mem held_set c.ticker then None
-  else Option.bind (make_entry c) ~f:(_check_cash_and_deduct remaining_cash)
-
 (** Generate CreateEntering transitions for screener candidates. Tracks
     remaining cash to avoid generating orders that exceed funds.
 
     Public (see .mli) so callers running custom screening out-of-band can feed
     candidates through the same entry pipeline the strategy uses.
 
-    Was: chained [List.filter |> List.filter_map |> List.filter_map] over
-    [candidates] — three list traversals each allocating a fresh intermediate
-    list. Now: one [List.fold] walks [candidates] once, calls
-    [_candidate_to_transition] per element, and accumulates a single reversed
-    output list. The cash-deduction side effect on [remaining_cash] runs in the
-    same order it did before — every successful entry decrements
-    [remaining_cash] before the next candidate is considered — so we preserve
-    the "first-come keeps cash" tie-break. Per the perf followup notes under
-    dev/notes/: List.filter was the top allocator on the strategy hot path. *)
+    The walk produces a tagged decision list (see
+    {!Entry_audit_capture.candidate_decision}). After the walk, kept candidates
+    are emitted to [audit_recorder.record_entry] with the rivals they outranked
+    — this is the PR-2 entry-capture site. The output transition list (in
+    original screener order) is bit-equivalent to the pre-audit shape: same
+    candidates, same transitions, same side-effects on [stop_states] and
+    [remaining_cash]. *)
 let entries_from_candidates ~config ~candidates ~stop_states ~bar_reader
-    ~(portfolio : Portfolio_view.t) ~get_price ~current_date =
+    ~(portfolio : Portfolio_view.t) ~get_price ~current_date
+    ?(audit_recorder = Audit_recorder.noop) ?macro () =
   let held_set = String.Set.of_list (held_symbols portfolio) in
   let portfolio_value = Portfolio_view.portfolio_value portfolio ~get_price in
   let remaining_cash = ref portfolio.cash in
   let make_entry =
-    _make_entry_transition ~config ~stop_states ~bar_reader ~portfolio_value
-      ~current_date
+    Entry_audit_capture.make_entry_transition
+      ~portfolio_risk_config:config.portfolio_config
+      ~stops_config:config.stops_config
+      ~initial_stop_buffer:config.initial_stop_buffer ~stop_states ~bar_reader
+      ~portfolio_value ~current_date
   in
-  List.fold candidates ~init:[] ~f:(fun acc c ->
-      match
-        _candidate_to_transition ~held_set ~make_entry ~remaining_cash c
-      with
-      | None -> acc
-      | Some kept -> kept :: acc)
-  |> List.rev
+  let decisions =
+    List.map candidates ~f:(fun c ->
+        ( c,
+          Entry_audit_capture.classify_candidate ~held_set ~make_entry
+            ~remaining_cash c ))
+  in
+  let kept =
+    List.filter_map decisions ~f:(fun (_, d) ->
+        match d with
+        | Entry_audit_capture.Kept (trans, _) -> Some trans
+        | Skipped _ -> None)
+  in
+  Entry_audit_capture.emit_entries ~audit_recorder ~macro ~current_date
+    ~decisions;
+  kept
 
 (** Stage 4-5 PR-A: a symbol survives Phase 1 only when its stage could in
     principle yield a screener candidate ([Stage2 _] for longs; [Stage4 _] for
@@ -341,9 +266,9 @@ let survivors_for_screening ?sector_map ~config ~bar_reader ~prior_stages
     pre-filter → Phase 2 full {!Stock_analysis}). Macro-trend gating lives in
     the screener; concatenating [buy_candidates] + [short_candidates] yields the
     right shape per regime. *)
-let _screen_universe ~config ~index_view ~macro_trend ~sector_map ~stop_states
-    ~(portfolio : Portfolio_view.t) ~get_price ~bar_reader ~prior_stages
-    ~current_date =
+let _screen_universe ~config ~index_view ~(macro_result : Macro.result)
+    ~sector_map ~stop_states ~(portfolio : Portfolio_view.t) ~get_price
+    ~bar_reader ~prior_stages ~current_date ~audit_recorder =
   let classified =
     _classify_all ~config ~bar_reader ~prior_stages ~current_date
   in
@@ -359,15 +284,17 @@ let _screen_universe ~config ~index_view ~macro_trend ~sector_map ~stop_states
   in
   _commit_prior_stages ~prior_stages classified;
   let screen_result =
-    Screener.screen ~config:config.screening_config ~macro_trend ~sector_map
-      ~stocks ~held_tickers:(held_symbols portfolio)
+    Screener.screen ~config:config.screening_config
+      ~macro_trend:macro_result.trend ~sector_map ~stocks
+      ~held_tickers:(held_symbols portfolio)
   in
   let combined_candidates =
     screen_result.Screener.buy_candidates
     @ screen_result.Screener.short_candidates
   in
   entries_from_candidates ~config ~candidates:combined_candidates ~stop_states
-    ~bar_reader ~portfolio ~get_price ~current_date
+    ~bar_reader ~portfolio ~get_price ~current_date ~audit_recorder
+    ~macro:macro_result ()
 
 (* ------------------------------------------------------------------ *)
 (* make                                                                  *)
@@ -390,9 +317,9 @@ let _is_screening_day_view (view : Data_panel.Bar_panels.weekly_view) =
     Bullish — happens inside the screener. Under Bearish this yields short-side
     entries (per the bear-market shorting chapter), where previously the branch
     returned [] unconditionally. *)
-let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
-    ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio
-    ~current_date ~index_view =
+let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~prior_macro_result
+    ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price
+    ~portfolio ~current_date ~index_view ~audit_recorder =
   let index_prior_stage = Hashtbl.find prior_stages config.indices.primary in
   let global_index_views =
     Macro_inputs.build_global_index_views ~lookback_bars:config.lookback_bars
@@ -413,19 +340,21 @@ let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
       ~callbacks:macro_callbacks ~prior_stage:index_prior_stage ~prior:None
   in
   prior_macro := macro_result.trend;
+  prior_macro_result := Some macro_result;
   let sector_map =
     Macro_inputs.build_sector_map ?ma_cache ~stage_config:config.stage_config
       ~lookback_bars:config.lookback_bars ~sector_etfs:config.sector_etfs
       ~bar_reader ~as_of:current_date ~sector_prior_stages ~index_view
       ~ticker_sectors ()
   in
-  _screen_universe ~config ~index_view ~macro_trend:macro_result.trend
-    ~sector_map ~stop_states ~portfolio ~get_price ~bar_reader ~prior_stages
-    ~current_date
+  _screen_universe ~config ~index_view ~macro_result ~sector_map ~stop_states
+    ~portfolio ~get_price ~bar_reader ~prior_stages ~current_date
+    ~audit_recorder
 
-let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
-    ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price
-    ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
+let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
+    ~prior_macro_result ~bar_reader ~prior_stages ~sector_prior_stages
+    ~ticker_sectors ~audit_recorder ~get_price ~get_indicator:_
+    ~(portfolio : Portfolio_view.t) =
   let positions = portfolio.positions in
   let current_date =
     match get_price config.indices.primary with
@@ -439,6 +368,11 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
       ~lookback_bars:config.lookback_bars ~positions ~get_price ~stop_states
       ~bar_reader ~as_of:current_date ~prior_stages ()
   in
+  List.iter exit_transitions
+    ~f:
+      (Exit_audit_capture.emit_exit_audit ~audit_recorder ~prior_macro_result
+         ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
+         ~bar_reader ~prior_stages ~positions);
   (* Stage 4 PR-A: read the primary index as a weekly view directly. The
      Friday detection uses the view's latest date; the screener path consumes
      the same view to avoid building two parallel inputs. *)
@@ -449,9 +383,9 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
   let entry_transitions =
     if not (_is_screening_day_view index_view) then []
     else
-      _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
-        ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio
-        ~current_date ~index_view
+      _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~prior_macro_result
+        ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
+        ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
   in
   Ok
     {
@@ -460,11 +394,17 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro ~bar_reader
     }
 
 let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
-    ?(ticker_sectors = Hashtbl.create (module String)) ?bar_panels config =
+    ?(ticker_sectors = Hashtbl.create (module String)) ?bar_panels
+    ?(audit_recorder = Audit_recorder.noop) config =
   let stop_states = ref initial_stop_states in
   let prior_macro : Weinstein_types.market_trend ref =
     ref Weinstein_types.Neutral
   in
+  (* Cached full macro result for exit-time audit capture. Updated alongside
+     [prior_macro] inside [_run_screen]. Held as an option until the first
+     Friday so an exit firing before the first screen call gets a stable
+     [Neutral / 0.0] snapshot. *)
+  let prior_macro_result : Macro.result option ref = ref None in
   (* Stage 4 PR-D: when bar_panels are present, also create a [Weekly_ma_cache]
      scoped to this strategy and bundle it into the [Bar_reader]. The cache
      is read by [Panel_callbacks.stage_callbacks_of_weekly_view] (and
@@ -495,6 +435,7 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
 
     let on_market_close =
       _on_market_close ~config ~ad_bars:weekly_ad_bars ~stop_states ~prior_macro
-        ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
+        ~prior_macro_result ~bar_reader ~prior_stages ~sector_prior_stages
+        ~ticker_sectors ~audit_recorder
   end in
   (module M : Strategy_interface.STRATEGY)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -56,6 +56,20 @@ module Weekly_ma_cache = Weekly_ma_cache
 (** Per-symbol weekly MA cache (Stage 4 PR-D). Memoises Stage / Macro / Sector /
     Stops MA reads keyed by [(symbol, ma_type, period)]. *)
 
+module Audit_recorder = Audit_recorder
+(** Decision-trail recorder bundle invoked at entry / exit decision sites. The
+    strategy emits raw events; backtest layers wrap a {!Backtest.Trade_audit.t}
+    collector. See {!Audit_recorder}. *)
+
+module Entry_audit_capture = Entry_audit_capture
+(** Per-candidate entry construction + audit emission. Factored out of the main
+    strategy file to keep it under the file-length cap. See
+    {!Entry_audit_capture}. *)
+
+module Exit_audit_capture = Exit_audit_capture
+(** Exit-side trade-audit capture. Bridges [TriggerExit] transitions to
+    {!Audit_recorder.exit_event}. See {!Exit_audit_capture}. *)
+
 (** {1 Configuration} *)
 
 type index_config = {
@@ -215,6 +229,9 @@ val entries_from_candidates :
   portfolio:Trading_strategy.Portfolio_view.t ->
   get_price:(string -> Types.Daily_price.t option) ->
   current_date:Date.t ->
+  ?audit_recorder:Audit_recorder.t ->
+  ?macro:Macro.result ->
+  unit ->
   Trading_strategy.Position.transition list
 (** Generate [CreateEntering] transitions for a list of screener candidates.
 
@@ -239,13 +256,25 @@ val entries_from_candidates :
 
     Public because it's a useful primitive for callers that want to run
     screening out-of-band (e.g. custom universe loops) and feed candidates into
-    the strategy's entry pipeline. *)
+    the strategy's entry pipeline.
+
+    @param audit_recorder
+      Optional decision-trail recorder. When passed, every entered candidate
+      yields a {!Audit_recorder.entry_event} populated with the chosen
+      candidate, the macro snapshot ([macro]), the alternatives considered, and
+      the audit-relevant intermediates ([installed_stop], [stop_floor_kind],
+      sizing). Defaults to {!Audit_recorder.noop}.
+    @param macro
+      Macro snapshot consumed by [audit_recorder]'s entry event. Required only
+      when [audit_recorder] is passed; ignored otherwise. Tests that don't
+      record audit events can omit it. *)
 
 val make :
   ?initial_stop_states:Weinstein_stops.stop_state String.Map.t ->
   ?ad_bars:Macro.ad_bar list ->
   ?ticker_sectors:(string, string) Hashtbl.t ->
   ?bar_panels:Data_panel.Bar_panels.t ->
+  ?audit_recorder:Audit_recorder.t ->
   config ->
   (module Trading_strategy.Strategy_interface.STRATEGY)
 (** Create a Weinstein strategy module with fresh internal state.
@@ -273,4 +302,10 @@ val make :
       When omitted, an empty reader is used — every read returns the empty list,
       which is sufficient for tests that exercise control paths where no
       panel-backed bar is ever consumed (empty universe, no held positions,
-      etc.). Production callers must always supply this. *)
+      etc.). Production callers must always supply this.
+    @param audit_recorder
+      Optional callback bundle invoked at entry / exit decision sites
+      ({!Audit_recorder.entry_event} / [exit_event]). When omitted defaults to
+      {!Audit_recorder.noop} — no observation is emitted and the strategy runs
+      unchanged. Backtest callers wire a recorder backed by a
+      [Backtest.Trade_audit.t] collector. *)

--- a/trading/trading/weinstein/strategy/test/test_short_side_bear_window.ml
+++ b/trading/trading/weinstein/strategy/test/test_short_side_bear_window.ml
@@ -239,7 +239,7 @@ let test_bearish_macro_emits_only_short_transitions _ =
     entries_from_candidates ~config:cfg ~candidates ~stop_states ~bar_reader
       ~portfolio:_empty_portfolio
       ~get_price:(_get_price_of_candidates candidates)
-      ~current_date:_as_of
+      ~current_date:_as_of ()
   in
   let sides = List.filter_map transitions ~f:_entry_side in
   assert_that

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -593,6 +593,7 @@ let test_entries_from_candidates_emits_short _ =
     entries_from_candidates ~config:cfg ~candidates:[ cand ] ~stop_states
       ~bar_reader ~portfolio ~get_price
       ~current_date:(Date.of_string "2024-01-05")
+      ()
   in
   assert_that transitions
     (elements_are
@@ -637,6 +638,7 @@ let test_entries_from_candidates_emits_long _ =
     entries_from_candidates ~config:cfg ~candidates:[ cand ] ~stop_states
       ~bar_reader ~portfolio ~get_price
       ~current_date:(Date.of_string "2024-01-05")
+      ()
   in
   assert_that transitions
     (elements_are


### PR DESCRIPTION
## Summary

PR-2 of [`dev/plans/trade-audit-2026-04-28.md`](https://github.com/dayfine/trading/blob/main/dev/plans/trade-audit-2026-04-28.md). PR-1 (#638) shipped the `Trade_audit` types + collector + sexp persistence; PR-2 wires the entry / exit decision capture sites in the strategy and runner so `result.audit` is non-empty after a backtest run.

The threading uses a strategy-side `Audit_recorder` callback bundle so `weinstein_strategy` does not depend on `Backtest`. The backtest layer wraps a `Trade_audit.t` collector via `Trade_audit_recorder.of_collector` to translate strategy events into the audit records and route them through the collector's `record_entry` / `record_exit`.

## What got captured at entry

Per chosen candidate per Friday: `position_id`, `entry_date`, `symbol`, `side`, `cascade_score / grade / rationale`, the full `Macro.result` snapshot (trend + confidence + indicator readings), the `Stock_analysis.t` slice (stage / ma_direction / ma_slope_pct / rs / volume / resistance / support), the `Screener.sector_context` (sector_name + rating), the sized position (`shares`, `initial_position_value`, `initial_risk_dollars`), the installed stop level, the `stop_floor_kind` (`Support_floor` vs `Buffer_fallback`), and the `alternatives_considered` list (the rivals from the same screen call that were skipped, with `Insufficient_cash` / `Already_held` / `Sized_to_zero` reasons).

## What got captured at exit

Per `TriggerExit` transition: `position_id`, `symbol`, `exit_date`, `exit_price`, the `Stop_log.exit_trigger` (translated via the now-public `Stop_log.exit_trigger_of_reason`), and state-at-exit snapshots (`macro_trend_at_exit`, `macro_confidence_at_exit` from the cached `prior_macro_result`; `stage_at_exit` from `prior_stages`; `distance_from_ma_pct` re-computed via the same panel-backed weekly view the stops loop reads). The during-hold counters (`max_favorable_excursion_pct` / `max_adverse_excursion_pct` / `weeks_macro_was_bearish` / `weeks_stage_left_2`) are defaulted to 0 — populating them requires per-step instrumentation through the simulator's step stream and is deferred to a follow-up PR.

## Files

**New (strategy side, no Backtest dep):**
- `trading/trading/weinstein/strategy/lib/audit_recorder.{ml,mli}` — callback bundle + raw-event types
- `trading/trading/weinstein/strategy/lib/entry_audit_capture.{ml,mli}` — per-candidate `CreateEntering` construction + audit emission. Houses `entry_meta`, `candidate_decision`, plus `make_entry_transition` / `classify_candidate` / `emit_entries`. Factored out so `weinstein_strategy.ml` stays under the file-length cap.
- `trading/trading/weinstein/strategy/lib/exit_audit_capture.{ml,mli}` — bridges `TriggerExit` transitions to `exit_event`s.

**New (backtest side):**
- `trading/trading/backtest/lib/trade_audit_recorder.{ml,mli}` — `of_collector` translates strategy events into `Trade_audit` records.
- `trading/trading/backtest/test/test_trade_audit_capture.ml` — end-to-end smoke (5 tests).

**Modified:**
- `trading/trading/weinstein/strategy/lib/weinstein_strategy.{ml,mli}` — threads `?audit_recorder` through `make` → `_on_market_close` → `_run_screen` → `_screen_universe` → `entries_from_candidates`. Caches `Macro.result` so exits firing mid-week snapshot the same macro the last Friday saw.
- `trading/trading/backtest/lib/{panel_runner,runner}.{ml,mli}` — owns the `Trade_audit.t`, builds the recorder, drains records into `result.audit`.
- `trading/trading/backtest/lib/stop_log.{ml,mli}` — promote `exit_trigger_of_reason` to public so the audit-recorder reuses the same case-split.

## Test plan

- [x] `dune build && TRADING_DATA_DIR=$PWD/test_data dune runtest` green
- [x] `dune fmt` clean
- [x] `test_panel_loader_parity` (existing golden gate) still passes — audit observation is bit-equivalent: the round_trips list against `panel-golden-2019-full.sexp` is unchanged.
- [x] `test_trade_audit` (PR-1's collector tests) still passes (14 tests).
- [x] `test_trade_audit_capture` (new, 5 tests):
  - audit non-empty when entries fire
  - every audit record's entry block is well-formed (non-empty `symbol` / `position_id`, in-window `entry_date`, `installed_stop > 0`, non-negative `cascade_score`)
  - every round-trip's symbol matches an audit entry (joined by symbol alone — `trade_metrics.entry_date` is the simulator-fill date, one trading day after the strategy's decision date)
  - at least one audit record has `exit_` populated (proves exit capture wired)
  - audit `position_id`s unique (collector keys by `position_id`)
- [x] No new file-length / fn-length / mli-coverage / magic-numbers violations introduced.

Pre-existing failures unchanged: `test_panel_runner_gc_trace` and `test_runner_hypothesis_overrides` need `TRADING_DATA_DIR` set (data path resolution to `/workspaces/trading-1/data/...` versus `trading/test_data/...`); `trading/engine/lib/price_path.ml` exceeds the file-length cap.

## Out of scope (later PRs)

- During-hold counters (MAE / MFE / weeks_macro_bearish / weeks_stage_left_2) — requires per-step instrumentation
- `cascade_score_components` per-component breakdown — requires screener score-split refactor (PR-3 / PR-4)
- PR-3 markdown renderer + binary
- PR-4 ratings + aggregate insights
- PR-5 release_perf_report integration

## Authority

- Plan: [`dev/plans/trade-audit-2026-04-28.md`](https://github.com/dayfine/trading/blob/main/dev/plans/trade-audit-2026-04-28.md) §3 PR-2
- Predecessor patterns: `Stop_log` (observer), `Trace` (collector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)