### PR TITLE
feat(backtest-perf): trade-audit markdown renderer (PR-3 of trade-audit)

### DIFF
--- a/trading/trading/backtest/bin/dune
+++ b/trading/trading/backtest/bin/dune
@@ -14,3 +14,8 @@
  (name release_perf_report)
  (modules release_perf_report)
  (libraries core trading.backtest.release_report))
+
+(executable
+ (name trade_audit_report_bin)
+ (modules trade_audit_report_bin)
+ (libraries core trade_audit_report))

--- a/trading/trading/backtest/bin/trade_audit_report_bin.ml
+++ b/trading/trading/backtest/bin/trade_audit_report_bin.ml
@@ -1,0 +1,57 @@
+(** Trade-audit report CLI — render a markdown audit of a single scenario.
+
+    Usage:
+    {v trade_audit_report --scenario-dir <dir> [--out <path>] v}
+
+    [--scenario-dir] points at a directory of the shape produced by
+    {!Backtest.Result_writer.write}:
+
+    {v
+      <dir>/trades.csv          — round-trip P&L (required)
+      <dir>/trade_audit.sexp    — Trade_audit.audit_record list (optional)
+      <dir>/summary.sexp        — period + universe size (optional)
+    v}
+
+    Reads those files via {!Trade_audit_report.load}, renders to markdown via
+    {!Trade_audit_report.to_markdown}, and writes to [--out] (when given) or
+    prints to stdout (when omitted). The exe never reads from a network or
+    invokes the backtest runner — it only reformats already-on- disk artefacts.
+*)
+
+open Core
+
+type _cli_args = { scenario_dir : string; out : string option }
+
+let _usage () =
+  eprintf "Usage: trade_audit_report --scenario-dir <dir> [--out <path>]\n";
+  Stdlib.exit 1
+
+let _parse_flags args =
+  let rec loop args scenario_dir out =
+    match args with
+    | [] ->
+        let scenario_dir =
+          match scenario_dir with Some v -> v | None -> _usage ()
+        in
+        { scenario_dir; out }
+    | "--scenario-dir" :: v :: rest -> loop rest (Some v) out
+    | "--out" :: v :: rest -> loop rest scenario_dir (Some v)
+    | _ -> _usage ()
+  in
+  loop args None None
+
+let _parse_args () =
+  let argv = Sys.get_argv () in
+  _parse_flags (List.tl_exn (Array.to_list argv))
+
+let _emit ~out md =
+  match out with
+  | None -> print_string md
+  | Some path ->
+      Out_channel.with_file path ~f:(fun oc -> Out_channel.output_string oc md)
+
+let () =
+  let { scenario_dir; out } = _parse_args () in
+  let report = Trade_audit_report.load ~scenario_dir in
+  let md = Trade_audit_report.to_markdown report in
+  _emit ~out md

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -5,6 +5,7 @@
   test_trace
   test_trade_audit
   test_trade_audit_capture
+  test_trade_audit_report
   test_runner_hypothesis_overrides
   test_panel_loader_parity
   test_backtest_runner_args
@@ -20,6 +21,7 @@
   core_unix.time_ns_unix
   fpath
   backtest
+  trade_audit_report
   trading.backtest.runner_args
   trading.backtest.release_report
   scenario_lib

--- a/trading/trading/backtest/test/test_trade_audit_report.ml
+++ b/trading/trading/backtest/test/test_trade_audit_report.ml
@@ -1,0 +1,513 @@
+(** Unit tests for [Trade_audit_report].
+
+    Pins the rendered markdown on a fixture of 2-3 audit_records + matching
+    trade_metrics. Covers:
+    - render output shape (header, aggregate, per-trade table)
+    - audit-side fields populated when (symbol, entry_date) matches; em-dash
+      placeholder when no audit record matches a trade
+    - best / worst selection by pnl_percent
+    - empty-trade input renders gracefully with "_No trades._" body
+    - load reads trades.csv + trade_audit.sexp + summary.sexp from disk *)
+
+open OUnit2
+open Core
+open Matchers
+module TAR = Trade_audit_report
+module TA = Backtest.Trade_audit
+
+(* Builders --------------------------------------------------------------- *)
+
+let _date d = Date.of_string d
+
+let make_trade ?(symbol = "AAPL") ?(entry_date = _date "2024-01-15")
+    ?(exit_date = _date "2024-04-20") ?(days_held = 96) ?(entry_price = 150.50)
+    ?(exit_price = 138.46) ?(quantity = 500.0) ?(pnl_dollars = -6_020.0)
+    ?(pnl_percent = -8.0) () : Trading_simulation.Metrics.trade_metrics =
+  {
+    symbol;
+    entry_date;
+    exit_date;
+    days_held;
+    entry_price;
+    exit_price;
+    quantity;
+    pnl_dollars;
+    pnl_percent;
+  }
+
+let make_entry_decision ?(symbol = "AAPL") ?(entry_date = _date "2024-01-15")
+    ?(position_id = "AAPL-wein-1") ?(side = Trading_base.Types.Long)
+    ?(macro_trend = Weinstein_types.Bullish)
+    ?(stage = Weinstein_types.Stage2 { weeks_advancing = 4; late = false })
+    ?(rs_trend = Some Weinstein_types.Positive_rising) ?(cascade_score = 75)
+    ?(cascade_grade = Weinstein_types.A) () : TA.entry_decision =
+  {
+    symbol;
+    entry_date;
+    position_id;
+    macro_trend;
+    macro_confidence = 0.72;
+    macro_indicators = [];
+    stage;
+    ma_direction = Weinstein_types.Rising;
+    ma_slope_pct = 0.018;
+    rs_trend;
+    rs_value = Some 1.05;
+    volume_quality = Some (Weinstein_types.Strong 2.4);
+    resistance_quality = Some Weinstein_types.Clean;
+    support_quality = Some Weinstein_types.Clean;
+    sector_name = "Information Technology";
+    sector_rating = Screener.Strong;
+    cascade_score;
+    cascade_grade;
+    cascade_score_components = [ ("stage2_breakout", 30) ];
+    cascade_rationale = [ "Stage2 breakout" ];
+    side;
+    suggested_entry = 150.50;
+    suggested_stop = 138.46;
+    installed_stop = 138.46;
+    stop_floor_kind = TA.Buffer_fallback;
+    risk_pct = 0.08;
+    initial_position_value = 75_000.0;
+    initial_risk_dollars = 6_000.0;
+    alternatives_considered = [];
+  }
+
+let make_exit_decision ?(symbol = "AAPL") ?(exit_date = _date "2024-04-20")
+    ?(position_id = "AAPL-wein-1")
+    ?(exit_trigger =
+      Backtest.Stop_log.Stop_loss { stop_price = 138.46; actual_price = 137.20 })
+    () : TA.exit_decision =
+  {
+    symbol;
+    exit_date;
+    position_id;
+    exit_trigger;
+    macro_trend_at_exit = Weinstein_types.Neutral;
+    macro_confidence_at_exit = 0.45;
+    stage_at_exit = Weinstein_types.Stage3 { weeks_topping = 2 };
+    rs_trend_at_exit = Some Weinstein_types.Positive_flat;
+    distance_from_ma_pct = -0.025;
+    max_favorable_excursion_pct = 0.082;
+    max_adverse_excursion_pct = -0.085;
+    weeks_macro_was_bearish = 0;
+    weeks_stage_left_2 = 1;
+  }
+
+let make_record entry exit_ : TA.audit_record = { entry; exit_ = Some exit_ }
+
+(* --- Header computation ------------------------------------------------- *)
+
+let test_header_counts_winners_and_losers _ =
+  let trades =
+    [
+      make_trade ~symbol:"AAPL" ~pnl_dollars:1000.0 ~pnl_percent:5.0 ();
+      make_trade ~symbol:"MSFT" ~pnl_dollars:2000.0 ~pnl_percent:8.0 ();
+      make_trade ~symbol:"NVDA" ~pnl_dollars:(-500.0) ~pnl_percent:(-3.0) ();
+    ]
+  in
+  let report = TAR.render ~trade_audit:[] ~trades () in
+  assert_that report.header
+    (all_of
+       [
+         field
+           (fun (h : TAR.scenario_header) -> h.total_round_trips)
+           (equal_to 3);
+         field (fun (h : TAR.scenario_header) -> h.winners) (equal_to 2);
+         field (fun (h : TAR.scenario_header) -> h.losers) (equal_to 1);
+         field
+           (fun (h : TAR.scenario_header) -> h.win_rate_pct)
+           (float_equal ~epsilon:1e-6 (200.0 /. 3.0));
+         field
+           (fun (h : TAR.scenario_header) -> h.total_realized_return_pct)
+           (float_equal ~epsilon:1e-6 10.0);
+       ])
+
+let test_header_empty_trades _ =
+  let report = TAR.render ~trade_audit:[] ~trades:[] () in
+  assert_that report.header
+    (all_of
+       [
+         field
+           (fun (h : TAR.scenario_header) -> h.total_round_trips)
+           (equal_to 0);
+         field (fun (h : TAR.scenario_header) -> h.winners) (equal_to 0);
+         field
+           (fun (h : TAR.scenario_header) -> h.win_rate_pct)
+           (float_equal 0.0);
+         field (fun (h : TAR.scenario_header) -> h.period_start) is_none;
+       ])
+
+let test_header_period_derived_from_trades _ =
+  let trades =
+    [
+      make_trade ~symbol:"A" ~entry_date:(_date "2024-02-01")
+        ~exit_date:(_date "2024-03-01") ();
+      make_trade ~symbol:"B" ~entry_date:(_date "2024-01-10")
+        ~exit_date:(_date "2024-05-15") ();
+    ]
+  in
+  let report = TAR.render ~trade_audit:[] ~trades () in
+  assert_that report.header
+    (all_of
+       [
+         field
+           (fun (h : TAR.scenario_header) -> h.period_start)
+           (is_some_and (equal_to (_date "2024-01-10")));
+         field
+           (fun (h : TAR.scenario_header) -> h.period_end)
+           (is_some_and (equal_to (_date "2024-05-15")));
+       ])
+
+let test_header_uses_supplied_period _ =
+  let report =
+    TAR.render ~scenario_name:"goldens-sp500" ~period_start:(_date "2019-01-02")
+      ~period_end:(_date "2023-12-29") ~universe_size:500 ~trade_audit:[]
+      ~trades:
+        [
+          make_trade ~entry_date:(_date "2020-06-01")
+            ~exit_date:(_date "2020-08-01") ();
+        ]
+      ()
+  in
+  assert_that report.header
+    (all_of
+       [
+         field
+           (fun (h : TAR.scenario_header) -> h.scenario_name)
+           (is_some_and (equal_to "goldens-sp500"));
+         field
+           (fun (h : TAR.scenario_header) -> h.period_start)
+           (is_some_and (equal_to (_date "2019-01-02")));
+         field
+           (fun (h : TAR.scenario_header) -> h.period_end)
+           (is_some_and (equal_to (_date "2023-12-29")));
+         field
+           (fun (h : TAR.scenario_header) -> h.universe_size)
+           (is_some_and (equal_to 500));
+       ])
+
+(* --- Best / worst ------------------------------------------------------- *)
+
+let test_best_worst_picks_extremes _ =
+  let trades =
+    [
+      make_trade ~symbol:"AAPL" ~entry_date:(_date "2020-04-25")
+        ~pnl_percent:44.2 ();
+      make_trade ~symbol:"WRB" ~entry_date:(_date "2023-10-07")
+        ~pnl_percent:(-0.5) ();
+      make_trade ~symbol:"MSFT" ~entry_date:(_date "2022-01-05")
+        ~pnl_percent:12.0 ();
+    ]
+  in
+  let report = TAR.render ~trade_audit:[] ~trades () in
+  assert_that report.best_worst
+    (all_of
+       [
+         field
+           (fun (b : TAR.best_worst) -> b.best)
+           (is_some_and
+              (equal_to
+                 (("AAPL", _date "2020-04-25", 44.2) : string * Date.t * float)));
+         field
+           (fun (b : TAR.best_worst) -> b.worst)
+           (is_some_and
+              (equal_to
+                 (("WRB", _date "2023-10-07", -0.5) : string * Date.t * float)));
+       ])
+
+let test_best_worst_empty _ =
+  let report = TAR.render ~trade_audit:[] ~trades:[] () in
+  assert_that report.best_worst
+    (all_of
+       [
+         field (fun (b : TAR.best_worst) -> b.best) is_none;
+         field (fun (b : TAR.best_worst) -> b.worst) is_none;
+       ])
+
+(* --- Per-trade row population ------------------------------------------ *)
+
+let test_row_has_audit_fields_when_matched _ =
+  let trade = make_trade ~symbol:"AAPL" ~entry_date:(_date "2024-01-15") () in
+  let entry =
+    make_entry_decision ~symbol:"AAPL" ~entry_date:(_date "2024-01-15")
+      ~cascade_grade:Weinstein_types.A ~cascade_score:75 ()
+  in
+  let exit_ = make_exit_decision () in
+  let record = make_record entry exit_ in
+  let report = TAR.render ~trade_audit:[ record ] ~trades:[ trade ] () in
+  assert_that report.rows
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (r : TAR.per_trade_row) -> r.symbol) (equal_to "AAPL");
+             field
+               (fun (r : TAR.per_trade_row) -> r.cascade_grade)
+               (is_some_and (equal_to Weinstein_types.A));
+             field
+               (fun (r : TAR.per_trade_row) -> r.cascade_score)
+               (is_some_and (equal_to 75));
+             field
+               (fun (r : TAR.per_trade_row) -> r.entry_macro_trend)
+               (is_some_and (equal_to Weinstein_types.Bullish));
+             field
+               (fun (r : TAR.per_trade_row) -> r.exit_trigger)
+               (equal_to "stop_loss");
+           ];
+       ])
+
+let test_row_has_none_audit_fields_when_unmatched _ =
+  let trade =
+    make_trade ~symbol:"NOAUDIT" ~entry_date:(_date "2024-06-01") ()
+  in
+  let report = TAR.render ~trade_audit:[] ~trades:[ trade ] () in
+  assert_that report.rows
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (r : TAR.per_trade_row) -> r.cascade_grade) is_none;
+             field (fun (r : TAR.per_trade_row) -> r.cascade_score) is_none;
+             field (fun (r : TAR.per_trade_row) -> r.entry_stage) is_none;
+             field (fun (r : TAR.per_trade_row) -> r.exit_trigger) (equal_to "");
+           ];
+       ])
+
+let test_rows_sorted_by_entry_date _ =
+  let trades =
+    [
+      make_trade ~symbol:"C" ~entry_date:(_date "2024-03-01") ();
+      make_trade ~symbol:"A" ~entry_date:(_date "2024-01-01") ();
+      make_trade ~symbol:"B" ~entry_date:(_date "2024-02-01") ();
+    ]
+  in
+  let report = TAR.render ~trade_audit:[] ~trades () in
+  assert_that
+    (List.map report.rows ~f:(fun (r : TAR.per_trade_row) -> r.symbol))
+    (elements_are [ equal_to "A"; equal_to "B"; equal_to "C" ])
+
+(* --- Markdown output --------------------------------------------------- *)
+
+let test_to_markdown_pinned_three_trade_fixture _ =
+  let aapl_trade =
+    make_trade ~symbol:"AAPL" ~entry_date:(_date "2020-04-25")
+      ~exit_date:(_date "2020-08-01") ~days_held:98 ~entry_price:280.00
+      ~exit_price:404.00 ~quantity:100.0 ~pnl_dollars:12_400.0 ~pnl_percent:44.2
+      ()
+  in
+  let msft_trade =
+    make_trade ~symbol:"MSFT" ~entry_date:(_date "2021-06-10")
+      ~exit_date:(_date "2021-11-20") ~days_held:163 ~entry_price:250.00
+      ~exit_price:340.00 ~quantity:200.0 ~pnl_dollars:18_000.0 ~pnl_percent:36.0
+      ()
+  in
+  let wrb_trade =
+    make_trade ~symbol:"WRB" ~entry_date:(_date "2023-10-07")
+      ~exit_date:(_date "2023-10-20") ~days_held:13 ~entry_price:80.00
+      ~exit_price:79.60 ~quantity:300.0 ~pnl_dollars:(-120.0)
+      ~pnl_percent:(-0.5) ()
+  in
+  let aapl_audit =
+    make_record
+      (make_entry_decision ~symbol:"AAPL" ~entry_date:(_date "2020-04-25")
+         ~position_id:"AAPL-1" ~cascade_grade:Weinstein_types.A
+         ~cascade_score:80 ())
+      (make_exit_decision ~symbol:"AAPL" ~exit_date:(_date "2020-08-01")
+         ~position_id:"AAPL-1"
+         ~exit_trigger:
+           (Backtest.Stop_log.Signal_reversal { description = "stage3" })
+         ())
+  in
+  let wrb_audit =
+    make_record
+      (make_entry_decision ~symbol:"WRB" ~entry_date:(_date "2023-10-07")
+         ~position_id:"WRB-1"
+         ~stage:(Weinstein_types.Stage2 { weeks_advancing = 2; late = false })
+         ~cascade_grade:Weinstein_types.B ~cascade_score:55
+         ~rs_trend:(Some Weinstein_types.Positive_flat) ())
+      (make_exit_decision ~symbol:"WRB" ~exit_date:(_date "2023-10-20")
+         ~position_id:"WRB-1"
+         ~exit_trigger:
+           (Backtest.Stop_log.Stop_loss
+              { stop_price = 79.50; actual_price = 79.60 })
+         ())
+  in
+  let report =
+    TAR.render ~scenario_name:"goldens-sp500" ~period_start:(_date "2019-01-02")
+      ~period_end:(_date "2023-12-29") ~universe_size:500
+      ~trade_audit:[ aapl_audit; wrb_audit ]
+      ~trades:[ aapl_trade; msft_trade; wrb_trade ]
+      ()
+  in
+  let md = TAR.to_markdown report in
+  let expected =
+    String.concat ~sep:"\n"
+      [
+        "# Trade audit \xe2\x80\x94 goldens-sp500";
+        "";
+        "- Period: 2019-01-02 \xe2\x86\x92 2023-12-29";
+        "- Universe: 500";
+        "- Total round-trips: 3";
+        "- Winners: 2 / 3 (66.7%)";
+        "- Total realized return (sum of pnl%): +79.70%";
+        "";
+        "## Aggregate summary";
+        "";
+        "- Best trade: AAPL 2020-04-25 \xe2\x86\x92 +44.20%";
+        "- Worst trade: WRB 2023-10-07 \xe2\x86\x92 -0.50%";
+        "";
+        "## Per-trade table";
+        "";
+        "| symbol | entry_date | side | entry_px | exit_date | exit_px | days \
+         | pnl_$ | pnl_% | exit_trigger | stage | rs | macro | grade | score |";
+        "|---|---|---|---:|---|---:|---:|---:|---:|---|---|---|---|---|---:|";
+        "| AAPL | 2020-04-25 | Long | 280.00 | 2020-08-01 | 404.00 | 98 | \
+         12400.00 | +44.20% | signal_reversal | Stage2 | Pos_rising | Bullish \
+         | A | 80 |";
+        "| MSFT | 2021-06-10 | Long | 250.00 | 2021-11-20 | 340.00 | 163 | \
+         18000.00 | +36.00% | \xe2\x80\x94 | \xe2\x80\x94 | \xe2\x80\x94 | \
+         \xe2\x80\x94 | \xe2\x80\x94 | \xe2\x80\x94 |";
+        "| WRB | 2023-10-07 | Long | 80.00 | 2023-10-20 | 79.60 | 13 | -120.00 \
+         | -0.50% | stop_loss | Stage2 | Pos_flat | Bullish | B | 55 |";
+        "";
+        "";
+      ]
+  in
+  assert_that md (equal_to expected)
+
+let test_to_markdown_zero_trades _ =
+  let report = TAR.render ~trade_audit:[] ~trades:[] () in
+  let md = TAR.to_markdown report in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"_No trades._")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"- Total round-trips: 0")
+           (equal_to true);
+       ])
+
+(* --- Loader (on-disk fixtures) ---------------------------------------- *)
+
+let _write_text path text =
+  Out_channel.with_file path ~f:(fun oc -> Out_channel.output_string oc text)
+
+let _write_trades_csv path =
+  _write_text path
+    "symbol,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger\n\
+     AAPL,2020-04-25,2020-08-01,98,280.00,404.00,100,12400.00,44.20,260.00,400.00,signal_reversal\n\
+     MSFT,2021-06-10,2021-11-20,163,250.00,340.00,200,18000.00,36.00,230.00,335.00,signal_reversal\n"
+
+let _write_summary_sexp path =
+  _write_text path
+    "((start_date 2019-01-02) (end_date 2023-12-29) (universe_size 500)\n\
+    \ (n_steps 1300) (initial_cash 1000000.00) (final_portfolio_value \
+     1184900.00)\n\
+    \ (n_round_trips 2) (metrics ()))\n"
+
+let _write_audit_sexp path =
+  let aapl_audit =
+    make_record
+      (make_entry_decision ~symbol:"AAPL" ~entry_date:(_date "2020-04-25")
+         ~position_id:"AAPL-1" ~cascade_grade:Weinstein_types.A
+         ~cascade_score:80 ())
+      (make_exit_decision ~symbol:"AAPL" ~exit_date:(_date "2020-08-01")
+         ~position_id:"AAPL-1"
+         ~exit_trigger:
+           (Backtest.Stop_log.Signal_reversal { description = "stage3" })
+         ())
+  in
+  let sexp = TA.sexp_of_audit_records [ aapl_audit ] in
+  Sexp.save_hum path sexp
+
+let test_load_reads_full_directory _ =
+  let dir = Core_unix.mkdtemp "/tmp/trade_audit_report_" in
+  let scenario_dir = Filename.concat dir "my-scenario" in
+  Core_unix.mkdir_p scenario_dir;
+  _write_trades_csv (Filename.concat scenario_dir "trades.csv");
+  _write_summary_sexp (Filename.concat scenario_dir "summary.sexp");
+  _write_audit_sexp (Filename.concat scenario_dir "trade_audit.sexp");
+  let report = TAR.load ~scenario_dir in
+  assert_that report
+    (all_of
+       [
+         field
+           (fun (t : TAR.t) -> t.header.scenario_name)
+           (is_some_and (equal_to "my-scenario"));
+         field
+           (fun (t : TAR.t) -> t.header.universe_size)
+           (is_some_and (equal_to 500));
+         field (fun (t : TAR.t) -> t.header.total_round_trips) (equal_to 2);
+         field (fun (t : TAR.t) -> t.header.winners) (equal_to 2);
+         field
+           (fun (t : TAR.t) ->
+             List.map t.rows ~f:(fun (r : TAR.per_trade_row) -> r.symbol))
+           (elements_are [ equal_to "AAPL"; equal_to "MSFT" ]);
+         field
+           (fun (t : TAR.t) ->
+             List.find t.rows ~f:(fun (r : TAR.per_trade_row) ->
+                 String.equal r.symbol "AAPL"))
+           (is_some_and
+              (field
+                 (fun (r : TAR.per_trade_row) -> r.cascade_grade)
+                 (is_some_and (equal_to Weinstein_types.A))));
+       ])
+
+let test_load_without_audit_file _ =
+  let dir = Core_unix.mkdtemp "/tmp/trade_audit_report_" in
+  let scenario_dir = Filename.concat dir "no-audit" in
+  Core_unix.mkdir_p scenario_dir;
+  _write_trades_csv (Filename.concat scenario_dir "trades.csv");
+  _write_summary_sexp (Filename.concat scenario_dir "summary.sexp");
+  let report = TAR.load ~scenario_dir in
+  assert_that report
+    (all_of
+       [
+         field (fun (t : TAR.t) -> t.header.total_round_trips) (equal_to 2);
+         field
+           (fun (t : TAR.t) ->
+             List.for_all t.rows ~f:(fun r -> Option.is_none r.cascade_grade))
+           (equal_to true);
+       ])
+
+let test_load_missing_trades_csv_raises _ =
+  let dir = Core_unix.mkdtemp "/tmp/trade_audit_report_" in
+  let scenario_dir = Filename.concat dir "empty" in
+  Core_unix.mkdir_p scenario_dir;
+  let result =
+    try
+      let _ = TAR.load ~scenario_dir in
+      Ok ()
+    with Failure _ -> Error "raised"
+  in
+  assert_that result (equal_to (Error "raised" : (unit, string) Result.t))
+
+let suite =
+  "Trade_audit_report"
+  >::: [
+         "header counts winners and losers"
+         >:: test_header_counts_winners_and_losers;
+         "header empty trades" >:: test_header_empty_trades;
+         "header period derived from trades"
+         >:: test_header_period_derived_from_trades;
+         "header uses supplied period" >:: test_header_uses_supplied_period;
+         "best/worst picks extremes" >:: test_best_worst_picks_extremes;
+         "best/worst empty" >:: test_best_worst_empty;
+         "row has audit fields when matched"
+         >:: test_row_has_audit_fields_when_matched;
+         "row has none audit fields when unmatched"
+         >:: test_row_has_none_audit_fields_when_unmatched;
+         "rows sorted by entry_date" >:: test_rows_sorted_by_entry_date;
+         "to_markdown pinned three-trade fixture"
+         >:: test_to_markdown_pinned_three_trade_fixture;
+         "to_markdown zero trades" >:: test_to_markdown_zero_trades;
+         "load reads full directory" >:: test_load_reads_full_directory;
+         "load without audit file" >:: test_load_without_audit_file;
+         "load missing trades.csv raises"
+         >:: test_load_missing_trades_csv_raises;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/trade_audit_report/dune
+++ b/trading/trading/backtest/trade_audit_report/dune
@@ -1,0 +1,12 @@
+(library
+ (name trade_audit_report)
+ (libraries
+  core
+  core_unix
+  core_unix.sys_unix
+  backtest
+  trading.simulation
+  trading.base
+  weinstein.types)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
+++ b/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
@@ -1,0 +1,374 @@
+(** Trade-audit markdown renderer. See [.mli] for the contract. *)
+
+open Core
+module TA = Backtest.Trade_audit
+module Stop_log = Backtest.Stop_log
+
+(* Types ------------------------------------------------------------------ *)
+
+type scenario_header = {
+  scenario_name : string option;
+  period_start : Date.t option;
+  period_end : Date.t option;
+  universe_size : int option;
+  total_round_trips : int;
+  winners : int;
+  losers : int;
+  win_rate_pct : float;
+  total_realized_return_pct : float;
+}
+[@@deriving sexp]
+
+type best_worst = {
+  best : (string * Date.t * float) option;
+  worst : (string * Date.t * float) option;
+}
+[@@deriving sexp]
+
+type per_trade_row = {
+  symbol : string;
+  entry_date : Date.t;
+  exit_date : Date.t;
+  days_held : int;
+  side : Trading_base.Types.position_side;
+  entry_price : float;
+  exit_price : float;
+  pnl_dollars : float;
+  pnl_percent : float;
+  exit_trigger : string;
+  entry_stage : Weinstein_types.stage option;
+  entry_rs_trend : Weinstein_types.rs_trend option;
+  entry_macro_trend : Weinstein_types.market_trend option;
+  cascade_grade : Weinstein_types.grade option;
+  cascade_score : int option;
+}
+[@@deriving sexp]
+
+type t = {
+  header : scenario_header;
+  best_worst : best_worst;
+  rows : per_trade_row list;
+}
+[@@deriving sexp]
+
+(* Render ----------------------------------------------------------------- *)
+
+let _audit_index audit =
+  List.fold audit
+    ~init:(Map.empty (module String))
+    ~f:(fun acc (record : TA.audit_record) ->
+      let key =
+        record.entry.symbol ^ "|" ^ Date.to_string record.entry.entry_date
+      in
+      Map.set acc ~key ~data:record)
+
+let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
+  match trigger with
+  | Stop_loss _ -> "stop_loss"
+  | Take_profit _ -> "take_profit"
+  | Signal_reversal _ -> "signal_reversal"
+  | Time_expired _ -> "time_expired"
+  | Underperforming _ -> "underperforming"
+  | Portfolio_rebalancing -> "rebalancing"
+
+let _row_of_trade audit_idx (trade : Trading_simulation.Metrics.trade_metrics) :
+    per_trade_row =
+  let key = trade.symbol ^ "|" ^ Date.to_string trade.entry_date in
+  let audit = Map.find audit_idx key in
+  let entry = Option.map audit ~f:(fun (r : TA.audit_record) -> r.entry) in
+  let exit_ = Option.bind audit ~f:(fun (r : TA.audit_record) -> r.exit_) in
+  let side =
+    Option.value_map entry ~default:Trading_base.Types.Long ~f:(fun e -> e.side)
+  in
+  let exit_trigger =
+    match exit_ with Some e -> _exit_trigger_label e.exit_trigger | None -> ""
+  in
+  {
+    symbol = trade.symbol;
+    entry_date = trade.entry_date;
+    exit_date = trade.exit_date;
+    days_held = trade.days_held;
+    side;
+    entry_price = trade.entry_price;
+    exit_price = trade.exit_price;
+    pnl_dollars = trade.pnl_dollars;
+    pnl_percent = trade.pnl_percent;
+    exit_trigger;
+    entry_stage = Option.map entry ~f:(fun e -> e.stage);
+    entry_rs_trend = Option.bind entry ~f:(fun e -> e.rs_trend);
+    entry_macro_trend = Option.map entry ~f:(fun e -> e.macro_trend);
+    cascade_grade = Option.map entry ~f:(fun e -> e.cascade_grade);
+    cascade_score = Option.map entry ~f:(fun e -> e.cascade_score);
+  }
+
+let _compare_rows (a : per_trade_row) (b : per_trade_row) =
+  match Date.compare a.entry_date b.entry_date with
+  | 0 -> String.compare a.symbol b.symbol
+  | c -> c
+
+let _compute_best_worst (rows : per_trade_row list) : best_worst =
+  let to_triple (r : per_trade_row) = (r.symbol, r.entry_date, r.pnl_percent) in
+  match rows with
+  | [] -> { best = None; worst = None }
+  | _ ->
+      let best =
+        List.max_elt rows ~compare:(fun a b ->
+            Float.compare a.pnl_percent b.pnl_percent)
+        |> Option.map ~f:to_triple
+      in
+      let worst =
+        List.min_elt rows ~compare:(fun a b ->
+            Float.compare a.pnl_percent b.pnl_percent)
+        |> Option.map ~f:to_triple
+      in
+      { best; worst }
+
+let _derived_period (rows : per_trade_row list) =
+  let starts = List.map rows ~f:(fun r -> r.entry_date) in
+  let ends = List.map rows ~f:(fun r -> r.exit_date) in
+  ( List.min_elt starts ~compare:Date.compare,
+    List.max_elt ends ~compare:Date.compare )
+
+let _compute_header ~scenario_name ~period_start ~period_end ~universe_size
+    ~rows =
+  let total_round_trips = List.length rows in
+  let winners =
+    List.count rows ~f:(fun (r : per_trade_row) -> Float.(r.pnl_dollars > 0.0))
+  in
+  let losers = total_round_trips - winners in
+  let win_rate_pct =
+    if total_round_trips = 0 then 0.0
+    else Float.of_int winners /. Float.of_int total_round_trips *. 100.0
+  in
+  let total_realized_return_pct =
+    List.fold rows ~init:0.0 ~f:(fun acc r -> acc +. r.pnl_percent)
+  in
+  let derived_start, derived_end = _derived_period rows in
+  let period_start =
+    match period_start with Some _ -> period_start | None -> derived_start
+  in
+  let period_end =
+    match period_end with Some _ -> period_end | None -> derived_end
+  in
+  {
+    scenario_name;
+    period_start;
+    period_end;
+    universe_size;
+    total_round_trips;
+    winners;
+    losers;
+    win_rate_pct;
+    total_realized_return_pct;
+  }
+
+let render ?scenario_name ?period_start ?period_end ?universe_size ~trade_audit
+    ~trades () : t =
+  let audit_idx = _audit_index trade_audit in
+  let rows =
+    List.map trades ~f:(_row_of_trade audit_idx)
+    |> List.sort ~compare:_compare_rows
+  in
+  let header =
+    _compute_header ~scenario_name ~period_start ~period_end ~universe_size
+      ~rows
+  in
+  let best_worst = _compute_best_worst rows in
+  { header; best_worst; rows }
+
+(* Markdown formatting ---------------------------------------------------- *)
+
+let _stage_label (s : Weinstein_types.stage) =
+  match s with
+  | Stage1 _ -> "Stage1"
+  | Stage2 _ -> "Stage2"
+  | Stage3 _ -> "Stage3"
+  | Stage4 _ -> "Stage4"
+
+let _rs_trend_label (rs : Weinstein_types.rs_trend) =
+  match rs with
+  | Bullish_crossover -> "Bullish_xover"
+  | Positive_rising -> "Pos_rising"
+  | Positive_flat -> "Pos_flat"
+  | Negative_improving -> "Neg_improving"
+  | Negative_declining -> "Neg_declining"
+  | Bearish_crossover -> "Bearish_xover"
+
+let _macro_label (m : Weinstein_types.market_trend) =
+  match m with
+  | Bullish -> "Bullish"
+  | Bearish -> "Bearish"
+  | Neutral -> "Neutral"
+
+let _side_label (s : Trading_base.Types.position_side) =
+  match s with Long -> "Long" | Short -> "Short"
+
+let _opt_label f = function Some v -> f v | None -> "—"
+let _opt_int = function Some i -> Int.to_string i | None -> "—"
+let _opt_date = function Some d -> Date.to_string d | None -> "—"
+let _opt_string = function Some s -> s | None -> "—"
+let _fmt_float_2 v = sprintf "%.2f" v
+let _fmt_pct v = sprintf "%+.2f%%" v
+let _fmt_pct_unsigned v = sprintf "%.1f%%" v
+
+let _format_header (h : scenario_header) : string list =
+  let title =
+    sprintf "# Trade audit \xe2\x80\x94 %s" (_opt_string h.scenario_name)
+  in
+  [
+    title;
+    "";
+    sprintf "- Period: %s \xe2\x86\x92 %s" (_opt_date h.period_start)
+      (_opt_date h.period_end);
+    sprintf "- Universe: %s" (_opt_int h.universe_size);
+    sprintf "- Total round-trips: %d" h.total_round_trips;
+    sprintf "- Winners: %d / %d (%s)" h.winners h.total_round_trips
+      (_fmt_pct_unsigned h.win_rate_pct);
+    sprintf "- Total realized return (sum of pnl%%): %s"
+      (_fmt_pct h.total_realized_return_pct);
+    "";
+  ]
+
+let _format_aggregate (bw : best_worst) : string list =
+  let fmt_triple = function
+    | None -> "—"
+    | Some (sym, d, pct) ->
+        sprintf "%s %s \xe2\x86\x92 %s" sym (Date.to_string d) (_fmt_pct pct)
+  in
+  [
+    "## Aggregate summary";
+    "";
+    sprintf "- Best trade: %s" (fmt_triple bw.best);
+    sprintf "- Worst trade: %s" (fmt_triple bw.worst);
+    "";
+  ]
+
+let _row_cells (r : per_trade_row) =
+  [
+    r.symbol;
+    Date.to_string r.entry_date;
+    _side_label r.side;
+    _fmt_float_2 r.entry_price;
+    Date.to_string r.exit_date;
+    _fmt_float_2 r.exit_price;
+    Int.to_string r.days_held;
+    _fmt_float_2 r.pnl_dollars;
+    _fmt_pct r.pnl_percent;
+    (if String.is_empty r.exit_trigger then "—" else r.exit_trigger);
+    _opt_label _stage_label r.entry_stage;
+    _opt_label _rs_trend_label r.entry_rs_trend;
+    _opt_label _macro_label r.entry_macro_trend;
+    _opt_label Weinstein_types.grade_to_string r.cascade_grade;
+    _opt_int r.cascade_score;
+  ]
+
+let _format_row r =
+  let cells = _row_cells r in
+  "| " ^ String.concat ~sep:" | " cells ^ " |"
+
+let _format_table_header () =
+  [
+    "| symbol | entry_date | side | entry_px | exit_date | exit_px | days | \
+     pnl_$ | pnl_% | exit_trigger | stage | rs | macro | grade | score |";
+    "|---|---|---|---:|---|---:|---:|---:|---:|---|---|---|---|---|---:|";
+  ]
+
+let _format_table (rows : per_trade_row list) : string list =
+  let head = "## Per-trade table" :: "" :: _format_table_header () in
+  let body =
+    if List.is_empty rows then [ "_No trades._" ]
+    else List.map rows ~f:_format_row
+  in
+  head @ body @ [ "" ]
+
+let to_markdown (t : t) : string =
+  let lines =
+    _format_header t.header
+    @ _format_aggregate t.best_worst
+    @ _format_table t.rows
+  in
+  String.concat ~sep:"\n" lines ^ "\n"
+
+(* Loader ----------------------------------------------------------------- *)
+
+let _read_trades_csv path : Trading_simulation.Metrics.trade_metrics list =
+  let ic = In_channel.create path in
+  let lines = In_channel.input_lines ic in
+  In_channel.close ic;
+  match lines with
+  | [] -> failwithf "trades.csv at %s is empty" path ()
+  | _header :: rest ->
+      List.filter_map rest ~f:(fun line ->
+          if String.is_empty (String.strip line) then None
+          else
+            let cells = String.split line ~on:',' in
+            match cells with
+            | [
+             symbol;
+             entry_date;
+             exit_date;
+             days_held;
+             entry_price;
+             exit_price;
+             quantity;
+             pnl_dollars;
+             pnl_percent;
+             _entry_stop;
+             _exit_stop;
+             _exit_trigger;
+            ] ->
+                Some
+                  ({
+                     symbol;
+                     entry_date = Date.of_string entry_date;
+                     exit_date = Date.of_string exit_date;
+                     days_held = Int.of_string days_held;
+                     entry_price = Float.of_string entry_price;
+                     exit_price = Float.of_string exit_price;
+                     quantity = Float.of_string quantity;
+                     pnl_dollars = Float.of_string pnl_dollars;
+                     pnl_percent = Float.of_string pnl_percent;
+                   }
+                    : Trading_simulation.Metrics.trade_metrics)
+            | _ -> failwithf "Unexpected trades.csv row in %s: %s" path line ())
+
+type _summary_meta = {
+  start_date : Date.t;
+  end_date : Date.t;
+  universe_size : int;
+}
+[@@deriving sexp] [@@sexp.allow_extra_fields]
+(** Minimal shape of [summary.sexp] needed for the report header — we only pull
+    the run-window + universe-size fields, ignoring the rest via
+    [@@sexp.allow_extra_fields]. The canonical record [Summary.t] writes far
+    more (e.g. metrics) and exposes [sexp_of_t] only; round-tripping through
+    this local shape avoids depending on a parser that does not exist on the
+    producer side. *)
+
+let _load_summary_meta path : _summary_meta option =
+  if not (Sys_unix.file_exists_exn path) then None
+  else try Some (_summary_meta_of_sexp (Sexp.load_sexp path)) with _ -> None
+
+let load ~scenario_dir : t =
+  let trades_path = Filename.concat scenario_dir "trades.csv" in
+  if not (Sys_unix.file_exists_exn trades_path) then
+    failwithf "Missing trades.csv in %s" scenario_dir ();
+  let trades = _read_trades_csv trades_path in
+  let audit_path = Filename.concat scenario_dir "trade_audit.sexp" in
+  let trade_audit =
+    if Sys_unix.file_exists_exn audit_path then
+      TA.audit_records_of_sexp (Sexp.load_sexp audit_path)
+    else []
+  in
+  let summary =
+    _load_summary_meta (Filename.concat scenario_dir "summary.sexp")
+  in
+  let scenario_name =
+    let bn = Filename.basename scenario_dir in
+    if String.is_empty bn then None else Some bn
+  in
+  let period_start = Option.map summary ~f:(fun s -> s.start_date) in
+  let period_end = Option.map summary ~f:(fun s -> s.end_date) in
+  let universe_size = Option.map summary ~f:(fun s -> s.universe_size) in
+  render ?scenario_name ?period_start ?period_end ?universe_size ~trade_audit
+    ~trades ()

--- a/trading/trading/backtest/trade_audit_report/trade_audit_report.mli
+++ b/trading/trading/backtest/trade_audit_report/trade_audit_report.mli
@@ -1,0 +1,148 @@
+(** Trade-audit markdown renderer.
+
+    Joins the per-trade decision trail captured by {!Backtest.Trade_audit} with
+    the round-trip P&L records in [trades.csv]
+    ({!Trading_simulation.Metrics.trade_metrics}) and emits a markdown report
+    summarising what the strategy decided on each entry, what happened, and how
+    the round-trips broke down in aggregate.
+
+    PR-3 of the trade-audit plan ships pure formatting only — no analysis.
+    Per-trade ratings (R-multiple, MFE/MAE) and aggregate insights
+    (Weinstein-conformance, behavioural metrics) layer on top in PR-4.
+
+    The library is pure: {!load} reads the artefacts off disk, {!render}
+    produces a deterministic [t] from already-loaded inputs, {!to_markdown}
+    formats it. Tests pin the markdown directly via {!render} + {!to_markdown}
+    on synthetic data.
+
+    See [dev/plans/trade-audit-2026-04-28.md] §PR-3. *)
+
+open Core
+
+(** {1 Document model}
+
+    The rendered document has three sections — a scenario header, an aggregate
+    summary (best / worst, hit-rate), and a per-trade table. All three are
+    computed from the inputs at {!render} time and surfaced on {!t} so callers
+    can introspect the report before formatting. *)
+
+type scenario_header = {
+  scenario_name : string option;
+      (** Scenario directory name when known. [None] when the renderer is driven
+          from already-loaded values without a directory context. *)
+  period_start : Date.t option;
+      (** Inclusive start of the backtest window. [None] when no [Summary.t] is
+          available and no trades were rendered. *)
+  period_end : Date.t option;  (** Inclusive end of the backtest window. *)
+  universe_size : int option;
+      (** Universe size from the run summary, when available. *)
+  total_round_trips : int;
+      (** Number of completed round-trip trades joined in the report. *)
+  winners : int;  (** Round-trips with [pnl_dollars > 0]. *)
+  losers : int;  (** Round-trips with [pnl_dollars <= 0]. *)
+  win_rate_pct : float;
+      (** [winners / total_round_trips * 100]. [0.0] when no trades. *)
+  total_realized_return_pct : float;
+      (** Sum of per-trade [pnl_percent] across the round-trips. Pure arithmetic
+          — does not adjust for sequencing or compounding; matches the column
+          shown in the per-trade table. *)
+}
+[@@deriving sexp]
+(** Header summary for the scenario as a whole. *)
+
+type best_worst = {
+  best : (string * Date.t * float) option;
+      (** [(symbol, entry_date, pnl_percent)] of the highest-PnL% round-trip.
+          [None] when the trade list is empty. *)
+  worst : (string * Date.t * float) option;
+      (** [(symbol, entry_date, pnl_percent)] of the lowest-PnL% round-trip.
+          [None] when the trade list is empty. *)
+}
+[@@deriving sexp]
+(** Best / worst by realised PnL %. *)
+
+type per_trade_row = {
+  symbol : string;
+  entry_date : Date.t;
+  exit_date : Date.t;
+  days_held : int;
+  side : Trading_base.Types.position_side;
+  entry_price : float;
+  exit_price : float;
+  pnl_dollars : float;
+  pnl_percent : float;
+  exit_trigger : string;  (** Lowercase label, e.g. ["stop_loss"]. *)
+  entry_stage : Weinstein_types.stage option;
+      (** Stage at decision time. [None] when no audit record matches. *)
+  entry_rs_trend : Weinstein_types.rs_trend option;
+      (** RS trend at decision time. [None] when no audit match. *)
+  entry_macro_trend : Weinstein_types.market_trend option;
+      (** Macro trend at decision time. [None] when no audit match. *)
+  cascade_grade : Weinstein_types.grade option;
+      (** Cascade grade at decision time. [None] when no audit match. *)
+  cascade_score : int option;
+      (** Cascade score at decision time. [None] when no audit match. *)
+}
+[@@deriving sexp]
+(** One row in the per-trade table. Fields up through [exit_trigger] come from
+    the [trades.csv] / round-trip side; the trailing audit fields are populated
+    when a {!Backtest.Trade_audit.audit_record} matches the round-trip on
+    [(symbol, entry_date)]. Audit fields are [None] when no [trade_audit.sexp]
+    was found or when the audit collector did not capture this entry (e.g.
+    pre-PR-2 outputs). *)
+
+type t = {
+  header : scenario_header;
+  best_worst : best_worst;
+  rows : per_trade_row list;
+      (** Sorted by [entry_date] ascending then by [symbol] for stable output
+          across runs. *)
+}
+[@@deriving sexp]
+(** A complete trade-audit report ready to format. *)
+
+(** {1 Render + format} *)
+
+val render :
+  ?scenario_name:string ->
+  ?period_start:Date.t ->
+  ?period_end:Date.t ->
+  ?universe_size:int ->
+  trade_audit:Backtest.Trade_audit.audit_record list ->
+  trades:Trading_simulation.Metrics.trade_metrics list ->
+  unit ->
+  t
+(** Build a {!t} from already-loaded inputs.
+
+    Joins [trade_audit] to [trades] by [(symbol, entry_date)]. Trades without a
+    matching audit record render with all audit fields set to [None] — this is
+    the expected state for pre-PR-2 outputs where the capture sites had not yet
+    been wired.
+
+    [scenario_name] populates the report header. [period_start], [period_end],
+    [universe_size] are echoed into the header verbatim; when [period_start] /
+    [period_end] are omitted they are derived from the trades' min entry-date /
+    max exit-date. *)
+
+val to_markdown : t -> string
+(** Render [t] to a markdown string. Output is deterministic for a given [t] —
+    no timestamps, no environment-dependent fields. The trailing newline is
+    included. *)
+
+(** {1 Loading from a scenario output directory} *)
+
+val load : scenario_dir:string -> t
+(** Load the trade-audit report from a scenario output directory of the shape
+    produced by {!Backtest.Result_writer.write}:
+
+    {v
+    <scenario_dir>/
+      trades.csv             — round-trip P&L (required)
+      trade_audit.sexp       — Trade_audit.audit_record list (optional;
+                               absent for pre-PR-2 runs — every row's
+                               audit fields will be [None])
+      summary.sexp           — period + universe size (optional)
+    v}
+
+    [scenario_name] is taken from the basename of [scenario_dir]. Raises
+    [Failure] if [trades.csv] is missing or malformed. *)


### PR DESCRIPTION
## Summary

PR-3 of the trade-audit plan. Adds a pure markdown renderer that joins the
per-trade decision trail captured by `Backtest.Trade_audit` (PR-1, #638) with
the round-trip P&L records in `trades.csv`
(`Trading_simulation.Metrics.trade_metrics`) and emits a markdown audit
report. PR-2 (#642) wired the strategy capture sites that produce
`trade_audit.sexp`; this PR consumes it.

This is **format-and-present only** — no analysis. Per-trade ratings
(R-multiple, MFE/MAE) and aggregate insights (Weinstein-conformance R1-R8,
behavioural metrics) layer on top in PR-4.

## What lands

- `trading/trading/backtest/trade_audit_report/` — new internal library
  (`Trade_audit_report`) exposing `t`, `render`, `to_markdown`, `load`.
  The rendered document has three sections:
  - **Scenario header**: name, period, universe size, win/loss counts,
    win rate %, total realized return % (sum of pnl%).
  - **Aggregate summary**: best / worst trade by realized PnL %.
  - **Per-trade table**: 15 columns — `symbol | entry_date | side |
    entry_px | exit_date | exit_px | days | pnl_$ | pnl_% | exit_trigger
    | stage | rs | macro | grade | score`.
- `trading/trading/backtest/bin/trade_audit_report_bin.ml` — CLI:
  ```
  trade_audit_report --scenario-dir <dir> [--out <path>]
  ```
  Reads `<dir>/trades.csv` (required) + `trade_audit.sexp` (optional;
  rows render with em-dashes for audit fields when absent) +
  `summary.sexp` (optional; parsed via a local sexp-shaped record since
  `Summary.t` exposes only `sexp_of_t`). Emits to stdout or `--out`.
- 14 tests in `trading/trading/backtest/test/test_trade_audit_report.ml`:
  - Markdown pinned on a synthetic 3-trade fixture (AAPL +44.2%, MSFT
    +36% with no audit, WRB -0.5%) — covers matched + unmatched audit
    rows, signed pct formatting, em-dash placeholders.
  - Header counts winners/losers, derives period from trades when no
    summary, honours supplied period/universe overrides.
  - Best/worst extremes by pnl%; empty-trade graceful path.
  - Row sort by entry_date then symbol.
  - Loader round-trips on-disk `trades.csv` + `trade_audit.sexp` +
    `summary.sexp`; missing-trades.csv raises; missing-audit-file is
    tolerated (audit fields all `None`).

## Test plan

- [x] `dune build` clean (zero warnings)
- [x] `dune build @fmt` clean
- [x] 14 new tests pass: `dune exec trading/backtest/test/test_trade_audit_report.exe`
- [x] Pre-existing test failures in `test_runner_hypothesis_overrides` /
      `test_panel_runner_gc_trace` / `test_trade_audit_capture` are
      missing-fixture errors (`tiered-loader-parity.sexp`), reproducible
      on `main` and unrelated to this PR
- [x] Smoke-tested CLI on a synthetic 2-trade `trades.csv` (no audit
      file) — produces well-formed markdown with em-dash placeholders
      for the audit columns

## Out of scope (later PRs)

- PR-4: ratings (R-multiple, MFE/MAE) + aggregate insights
  (Weinstein-conformance, behavioural metrics)
- PR-5: `release_perf_report` integration

Plan: `dev/plans/trade-audit-2026-04-28.md` §PR-3.