### PR TITLE
refactor(backtest-perf): remove Panel_strategy_wrapper feedback into panel (prep for #641)

### DIFF
--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -88,7 +88,6 @@ let _build_strategy (input : input) ~bar_panels ~ohlcv ~indicators ~calendar
       indicators;
       calendar;
       primary_index = input.config.indices.primary;
-      universe = input.all_symbols;
     }
   in
   Panel_strategy_wrapper.wrap ~config:panel_config inner_strategy

--- a/trading/trading/backtest/lib/panel_strategy_wrapper.ml
+++ b/trading/trading/backtest/lib/panel_strategy_wrapper.ml
@@ -1,6 +1,5 @@
 open Core
 open Trading_strategy
-module Symbol_index = Data_panel.Symbol_index
 module Ohlcv_panels = Data_panel.Ohlcv_panels
 module Indicator_panels = Data_panel.Indicator_panels
 module Get_indicator_adapter = Data_panel.Get_indicator_adapter
@@ -10,7 +9,6 @@ type config = {
   indicators : Indicator_panels.t;
   calendar : Date.t array;
   primary_index : string;
-  universe : string list;
 }
 
 (* Date -> column lookup. The same calendar drives [Ohlcv_panels.load_from_csv_calendar] and the
@@ -29,24 +27,20 @@ let _today_date_opt ~(get_price : Strategy_interface.get_price_fn)
   Option.map (get_price primary_index) ~f:(fun bar ->
       bar.Types.Daily_price.date)
 
-let _write_symbol_bar ~ohlcv ~symbol_index ~get_price ~day sym =
-  match Symbol_index.to_row symbol_index sym with
-  | None -> () (* symbol not in panel universe — skip *)
-  | Some row -> (
-      match get_price sym with
-      | None -> ()
-      | Some bar -> Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day bar)
+(* The OHLCV panels are fully pre-populated at runner startup from the universe
+   CSVs (see [Panel_runner._build_ohlcv] -> [Ohlcv_panels.load_from_csv_calendar]).
+   Per-tick writes from the simulator's [get_price] used to live here, but they
+   formed a feedback loop: the simulator's per-step output (potentially
+   adjusted, e.g. the split-day MtM fix in #641) flowed back into the panel
+   that the screener and indicators read from, which in turn drifted the
+   downstream signals away from the canonical CSV-loaded reference.
 
-let _write_today_bars ~ohlcv ~symbol_index ~get_price ~universe ~day =
-  List.iter universe ~f:(_write_symbol_bar ~ohlcv ~symbol_index ~get_price ~day)
-
+   The panel is the authoritative reference; the simulator never writes into
+   it. Indicators are computed directly from the pre-populated panel. *)
 let _advance_panels_and_run ~(config : config)
     ~(module_ : (module Strategy_interface.STRATEGY)) ~get_price ~portfolio ~day
     =
   let (module S) = module_ in
-  let symbol_index = Ohlcv_panels.symbol_index config.ohlcv in
-  _write_today_bars ~ohlcv:config.ohlcv ~symbol_index ~get_price
-    ~universe:config.universe ~day;
   Indicator_panels.advance_all config.indicators ~ohlcv:config.ohlcv ~t:day;
   let get_indicator = Get_indicator_adapter.make config.indicators ~t:day in
   S.on_market_close ~get_price ~get_indicator ~portfolio

--- a/trading/trading/backtest/lib/panel_strategy_wrapper.mli
+++ b/trading/trading/backtest/lib/panel_strategy_wrapper.mli
@@ -6,11 +6,17 @@
     [on_market_close] call, it:
 
     1. Reads today's date from [get_price] for the primary index symbol. 2.
-    Resolves the date to a panel column [t]. 3. Writes today's OHLCV bars into
-    the panels for the universe symbols. 4. Calls
-    [Indicator_panels.advance_all ~t]. 5. Builds a panel-backed
-    [get_indicator_fn] via [Get_indicator_adapter.make] and substitutes it into
-    the inner strategy's [on_market_close] call.
+    Resolves the date to a panel column [t]. 3. Calls
+    [Indicator_panels.advance_all ~t] using the pre-populated OHLCV panel. 4.
+    Builds a panel-backed [get_indicator_fn] via [Get_indicator_adapter.make]
+    and substitutes it into the inner strategy's [on_market_close] call.
+
+    The OHLCV panel is fully pre-populated at runner startup
+    ([Panel_runner._build_ohlcv] -> [Ohlcv_panels.load_from_csv_calendar]). The
+    wrapper does NOT write the simulator's per-tick [get_price] results back
+    into the panel: the panel is the authoritative reference and the simulator's
+    per-step output (potentially adjusted for splits/dividends — see #641's MtM
+    fix) must not flow back into the screener's view of the market.
 
     Stage 1 invariant: [Bar_history] inside the inner Weinstein strategy stays
     alive and untouched. The Weinstein strategy does not consume [get_indicator]
@@ -20,11 +26,10 @@
     consume from it.
 
     On dates not present in the calendar (e.g., holidays where the simulator
-    still calls the strategy with stale prices) the wrapper writes nothing and
-    uses the most recent in-range column for [t]. On dates falling completely
-    outside the calendar (before [calendar.(0)] or after the last entry) the
-    wrapper falls back to passing the simulator's original [get_indicator]
-    through unchanged — the panel state is undefined for those dates. *)
+    still calls the strategy with stale prices) or falling completely outside
+    the calendar, the wrapper falls back to passing the simulator's original
+    [get_indicator] through unchanged — the panel state is undefined for those
+    dates. *)
 
 open Trading_strategy
 
@@ -37,8 +42,6 @@ type config = {
   primary_index : string;
       (** Symbol whose [get_price] result drives the per-tick date detection;
           must be present in [Ohlcv_panels.symbol_index ohlcv]. *)
-  universe : string list;
-      (** Symbols whose bars are written into the OHLCV panels each tick. *)
 }
 
 val wrap :


### PR DESCRIPTION
## Summary

Pure refactor preparing the way for the cleaner split-day MtM fix in PR #641.

The OHLCV panel is fully pre-populated at runner startup from CSV
(`Panel_runner._build_ohlcv` -> `Ohlcv_panels.load_from_csv_calendar`).
Per-tick writes from the simulator's `get_price` used to live in
`Panel_strategy_wrapper._write_today_bars`, but they formed a feedback loop:
the simulator's per-step output (potentially adjusted for splits/dividends —
e.g., the split-day MtM fix in #641) flowed back into the panel that the
screener and indicators read from, drifting the downstream signals away from
the canonical CSV-loaded reference.

This PR removes that feedback so #641 can land without dragging the panel
along. The architectural rule going forward: **the panel is pre-populated at
runner startup; the simulator never writes back into it**. Per-step state
the simulator needs for MtM lives in the simulator's own state.

## Changes

- `panel_strategy_wrapper.ml`: delete `_write_symbol_bar` / `_write_today_bars`
  and the corresponding call from `_advance_panels_and_run`; add comment
  explaining why the feedback was removed (cites #641).
- `panel_strategy_wrapper.mli`: drop the now-unused `universe` field from
  `config`; rewrite the module docstring to describe the new flow (no
  per-tick writes; panel is the authoritative reference).
- `panel_runner.ml`: drop `universe = input.all_symbols` from the
  `panel_config` record literal.

## Test plan

- [x] `dune build` clean (no warnings).
- [x] `dune fmt` produces no diff.
- [x] `test_panel_loader_parity` (panel-golden-2019-full + tiered-loader-parity)
      pass with **bit-identical goldens** — confirming on `main` (where the
      simulator's `get_price` returns raw CSV bars), removing the feedback is
      a pure refactor with zero behavioural drift.
- [x] `test_weinstein_backtest` (3 tests) pass.
- [x] No goldens re-pinned. The point of this PR is that the parity tests
      stay green without any update — that's how we know `_write_today_bars`
      was, on the current `main`, dead feedback.

## Notes for reviewer

- `_write_today_bars` was private (underscore-prefixed) and only called once
  from `_advance_panels_and_run`. No external caller, no test fixture.
- `Indicator_panels.advance_all` reads OHLCV from the same panel that
  `_write_today_bars` was writing to. With the panel pre-populated from CSV
  at startup, the indicator computation now reads canonical CSV data
  directly instead of whatever the simulator's `get_price` reflected back —
  on `main` they're identical (same CSV source for both); on #641's branch
  they would have diverged on split days, which is exactly the bug.
- The `universe` config field becomes dead with `_write_today_bars` gone;
  removed it to avoid the unused-field warning.