### PR TITLE
feat(backtest-perf): trade-audit cascade-rejection counts (extension to PR-2)

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -73,6 +73,21 @@ mechanics + release-gate procedure.
 
 ## Open work
 
+- **`feat/trade-audit-cascade-rejections`** (trade-audit cascade-rejection
+  counts, extension to PR-2) — open for review. Extends the per-trade audit
+  shipped in #642 with per-Friday cascade-phase admission counts. Lets the
+  audit answer "did the macro gate ever block a candidate", "was the sector
+  filter trivially permissive", "did the RS hard gate ever filter shorts" —
+  questions the per-trade audit alone can't answer because filtered
+  candidates never reach the per-entry alternatives bucket. `Screener.result`
+  gains a `cascade_diagnostics` field (additive); `Audit_recorder` gains a
+  `record_cascade_summary` callback fired at the end of each Friday's
+  `_screen_universe`; `Trade_audit.t` gains a `cascade_summaries` queue and
+  the `audit_blob` envelope persists both lists in `trade_audit.sexp`. 13
+  new tests (5 screener diagnostic + 5 trade_audit cascade + 3 e2e capture).
+  Bit-exact behavioural parity — pure observer extension. Verify:
+  `dune build && dune build @fmt` clean; existing parity tests
+  (`test_panel_loader_parity`, `test_runner_hypothesis_overrides`) unchanged.
 - **PR #550** (plan, doc-only) — MERGED 2026-04-25.
 - **`feat/backtest-perf-tier1-catalog`** (Steps 1+2) — open for review.
   Adds tier headers to all 15 catalog scenarios, the

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -102,11 +102,30 @@ type scored_candidate = {
   rationale : string list;
 }
 
+type cascade_diagnostics = {
+  total_stocks : int;
+  candidates_after_held : int;
+  macro_trend : market_trend;
+  long_macro_admitted : int;
+  long_breakout_admitted : int;
+  long_sector_admitted : int;
+  long_grade_admitted : int;
+  long_top_n_admitted : int;
+  short_macro_admitted : int;
+  short_breakdown_admitted : int;
+  short_sector_admitted : int;
+  short_rs_hard_gate_admitted : int;
+  short_grade_admitted : int;
+  short_top_n_admitted : int;
+}
+[@@deriving sexp]
+
 type result = {
   buy_candidates : scored_candidate list;
   short_candidates : scored_candidate list;
   watchlist : (string * string) list;
   macro_trend : market_trend;
+  cascade_diagnostics : cascade_diagnostics;
 }
 
 (* ------------------------------------------------------------------ *)
@@ -410,6 +429,59 @@ let _top_n n lst =
   List.sort lst ~compare:(fun a b -> Int.compare b.score a.score) |> fun l ->
   List.sub l ~pos:0 ~len:(min n (List.length l))
 
+(** Long-side admission predicates: per-pair, returns one bool per phase that
+    actually got evaluated. Phases short-circuit (a [false] earlier means later
+    bools are [false]) so [(true, true, true)] means the pair passed all three
+    gates. *)
+let _long_admission ~weights ~thresholds ~min_grade (a, sector) =
+  let passes_breakout = Stock_analysis.is_breakout_candidate a in
+  let passes_sector =
+    passes_breakout && not (equal_sector_rating sector.rating Weak)
+  in
+  let passes_grade =
+    if not passes_sector then false
+    else
+      let score, _ = _score_long ~weights ~sector a in
+      compare_grade (_grade_of_score ~thresholds score) min_grade <= 0
+  in
+  (passes_breakout, passes_sector, passes_grade)
+
+(** Bump the counter by one when [b] is [true]. *)
+let _bump n b = if b then n + 1 else n
+
+(** Long-side phase counts for the cascade-diagnostics record. Folds the
+    per-pair predicate triple into running counts. *)
+let _count_long_phases ~weights ~thresholds ~min_grade ~candidates =
+  List.fold candidates ~init:(0, 0, 0)
+    ~f:(fun (breakout, sector_ok, grade_ok) pair ->
+      let pb, ps, pg = _long_admission ~weights ~thresholds ~min_grade pair in
+      (_bump breakout pb, _bump sector_ok ps, _bump grade_ok pg))
+
+(** Short-side admission predicates. Mirrors [_long_admission] with the RS hard
+    gate inserted between sector and grade — see [_short_candidate]. *)
+let _short_admission ~weights ~thresholds ~min_grade (a, sector) =
+  let passes_breakdown = Stock_analysis.is_breakdown_candidate a in
+  let passes_sector =
+    passes_breakdown && not (equal_sector_rating sector.rating Strong)
+  in
+  let passes_rs = passes_sector && not (_rs_blocks_short a.Stock_analysis.rs) in
+  let passes_grade =
+    if not passes_rs then false
+    else
+      let score, _ = _score_short ~weights ~sector a in
+      compare_grade (_grade_of_score ~thresholds score) min_grade <= 0
+  in
+  (passes_breakdown, passes_sector, passes_rs, passes_grade)
+
+(** Short-side phase counts mirroring [_count_long_phases]. *)
+let _count_short_phases ~weights ~thresholds ~min_grade ~candidates =
+  List.fold candidates ~init:(0, 0, 0, 0)
+    ~f:(fun (breakdown, sector_ok, rs_ok, grade_ok) pair ->
+      let pb, ps, pr, pg =
+        _short_admission ~weights ~thresholds ~min_grade pair
+      in
+      (_bump breakdown pb, _bump sector_ok ps, _bump rs_ok pr, _bump grade_ok pg))
+
 (** Filter, score, grade, sort, and cap long candidates. *)
 let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~max_buy_candidates
     ~candidates ~macro_trend : scored_candidate list =
@@ -456,6 +528,60 @@ let _resolve_sector ~sector_map ticker =
         stage = Stage1 { weeks_in_base = 0 };
       }
 
+(** Build the cascade-diagnostics record from the per-side phase counts and the
+    final top-N counts. Pure projection. *)
+let _build_cascade_diagnostics ~total_stocks ~candidates_after_held ~macro_trend
+    ~long_phases ~short_phases ~buy_candidates ~short_candidates =
+  let long_breakout, long_sector, long_grade = long_phases in
+  let short_breakdown, short_sector, short_rs, short_grade = short_phases in
+  let long_macro_admitted =
+    match macro_trend with
+    | Bearish -> 0
+    | Bullish | Neutral -> candidates_after_held
+  in
+  let short_macro_admitted =
+    match macro_trend with
+    | Bullish -> 0
+    | Bearish | Neutral -> candidates_after_held
+  in
+  (* When the macro gate closes the side, downstream phase counts collapse to
+     0 — the screener never evaluates them. The fold above runs over all
+     candidates regardless of macro, so we reset here to keep the post-macro
+     phases consistent with what the screener actually emitted. *)
+  let zero_if (gate : int) (n : int) = if gate = 0 then 0 else n in
+  {
+    total_stocks;
+    candidates_after_held;
+    macro_trend;
+    long_macro_admitted;
+    long_breakout_admitted = zero_if long_macro_admitted long_breakout;
+    long_sector_admitted = zero_if long_macro_admitted long_sector;
+    long_grade_admitted = zero_if long_macro_admitted long_grade;
+    long_top_n_admitted = List.length buy_candidates;
+    short_macro_admitted;
+    short_breakdown_admitted = zero_if short_macro_admitted short_breakdown;
+    short_sector_admitted = zero_if short_macro_admitted short_sector;
+    short_rs_hard_gate_admitted = zero_if short_macro_admitted short_rs;
+    short_grade_admitted = zero_if short_macro_admitted short_grade;
+    short_top_n_admitted = List.length short_candidates;
+  }
+
+(** Compute the cascade-diagnostics record for one screen call. Decoupled from
+    [screen] so the latter stays within the 50-line linter cap. *)
+let _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade ~total_stocks
+    ~candidates_after_held ~macro_trend ~candidates ~buy_candidates
+    ~short_candidates =
+  let long_phases =
+    _count_long_phases ~weights ~thresholds:grade_thresholds ~min_grade
+      ~candidates
+  in
+  let short_phases =
+    _count_short_phases ~weights ~thresholds:grade_thresholds ~min_grade
+      ~candidates
+  in
+  _build_cascade_diagnostics ~total_stocks ~candidates_after_held ~macro_trend
+    ~long_phases ~short_phases ~buy_candidates ~short_candidates
+
 let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
   let held_set = String.Set.of_list held_tickers in
   let {
@@ -471,6 +597,7 @@ let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
   let buys_active =
     match macro_trend with Bullish | Neutral -> true | Bearish -> false
   in
+  let total_stocks = List.length stocks in
   (* Was: chained filter |> map allocated two lists (one for the held-set
      filter, one for the (analysis, sector) pairs). Now: single-pass
      filter_map keeps only one output list. Runs every Friday over the full
@@ -480,6 +607,7 @@ let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
         if Set.mem held_set a.ticker then None
         else Some (a, _resolve_sector ~sector_map a.ticker))
   in
+  let candidates_after_held = List.length candidates in
   let buy_candidates =
     _evaluate_longs ~weights ~thresholds:grade_thresholds
       ~params:candidate_params ~min_grade ~max_buy_candidates ~candidates
@@ -494,4 +622,15 @@ let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
     _build_watchlist ~weights ~thresholds:grade_thresholds ~candidates
       ~buy_candidates ~buys_active
   in
-  { buy_candidates; short_candidates; watchlist; macro_trend }
+  let cascade_diagnostics =
+    _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade ~total_stocks
+      ~candidates_after_held ~macro_trend ~candidates ~buy_candidates
+      ~short_candidates
+  in
+  {
+    buy_candidates;
+    short_candidates;
+    watchlist;
+    macro_trend;
+    cascade_diagnostics;
+  }

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -120,6 +120,58 @@ type scored_candidate = {
 }
 (** A scored and graded candidate ready for the weekly report. *)
 
+type cascade_diagnostics = {
+  total_stocks : int;
+      (** Number of stocks input to {!screen} this run (post strategy-side phase
+          1
+          + sector pre-filter; pre held-ticker exclusion). *)
+  candidates_after_held : int;
+      (** [total_stocks] minus tickers in [held_tickers]. *)
+  macro_trend : Weinstein_types.market_trend;
+      (** The macro trend that gated this cascade — same value as
+          [result.macro_trend]. Carried in the diagnostics record so consumers
+          can read the regime without cross-referencing the parent {!result}. *)
+  long_macro_admitted : int;
+      (** [candidates_after_held] when [macro_trend <> Bearish], else [0]. The
+          macro gate is binary across all candidates per side. *)
+  long_breakout_admitted : int;
+      (** Of [long_macro_admitted], how many satisfied
+          [Stock_analysis.is_breakout_candidate]. *)
+  long_sector_admitted : int;
+      (** Of [long_breakout_admitted], how many sat in a sector that was not
+          [Weak]. *)
+  long_grade_admitted : int;
+      (** Of [long_sector_admitted], how many scored at or above [min_grade]. *)
+  long_top_n_admitted : int;
+      (** [List.length buy_candidates] — survivors after the
+          [max_buy_candidates] cap. *)
+  short_macro_admitted : int;
+      (** [candidates_after_held] when [macro_trend <> Bullish], else [0]. *)
+  short_breakdown_admitted : int;
+      (** Of [short_macro_admitted], how many satisfied
+          [Stock_analysis.is_breakdown_candidate]. *)
+  short_sector_admitted : int;
+      (** Of [short_breakdown_admitted], how many sat in a sector that was not
+          [Strong]. *)
+  short_rs_hard_gate_admitted : int;
+      (** Of [short_sector_admitted], how many were not blocked by the RS hard
+          gate (Weinstein Ch. 11 — never short a stock with strong relative
+          strength). *)
+  short_grade_admitted : int;
+      (** Of [short_rs_hard_gate_admitted], how many scored at or above
+          [min_grade]. *)
+  short_top_n_admitted : int;
+      (** [List.length short_candidates] — survivors after the
+          [max_short_candidates] cap. *)
+}
+[@@deriving sexp]
+(** Per-cascade-phase admission counts for one {!screen} call.
+
+    Captured pure-functionally — same input → same diagnostics. Pairs with the
+    backtest-side per-Friday cascade-summary record so analyses can answer "how
+    often did the macro gate filter everything" / "did the RS hard gate ever
+    block shorts" without re-running the strategy. *)
+
 type result = {
   buy_candidates : scored_candidate list;  (** Ranked by score descending. *)
   short_candidates : scored_candidate list;  (** Ranked by score descending. *)
@@ -128,6 +180,10 @@ type result = {
           [(ticker, reason)]. *)
   macro_trend : Weinstein_types.market_trend;
       (** The macro trend used by the cascade gate. *)
+  cascade_diagnostics : cascade_diagnostics;
+      (** Per-phase admission counts. Populated unconditionally — has zero cost
+          when ignored, and unblocks per-Friday cascade-rejection tracking on
+          the backtest side without requiring a parallel pass. *)
 }
 (** Screener output. *)
 

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -599,6 +599,138 @@ let test_positive_rs_blocks_short _ =
   in
   assert_that result.short_candidates is_empty
 
+(* ------------------------------------------------------------------ *)
+(* Cascade diagnostics                                                 *)
+(* ------------------------------------------------------------------ *)
+
+(** Bullish-macro Stage-2 setup: rising bars across a 35-week window from $50 to
+    $100 with a Strong volume spike late in the run. The same fixture used by
+    several existing buy-side tests; reused here so the diagnostic-count
+    expectations stay aligned with the rest of the suite. *)
+let _stage2_breakout_setup ticker =
+  let bars = rising_bars_with_spike ~n:35 50.0 100.0 ~spike_idx:30 in
+  make_analysis ticker (Some (Stage1 { weeks_in_base = 12 })) bars
+
+let test_diagnostics_empty_universe _ =
+  let result =
+    screen ~config:cfg ~macro_trend:Neutral ~sector_map:(empty_sector_map ())
+      ~stocks:[] ~held_tickers:[]
+  in
+  assert_that result.cascade_diagnostics
+    (all_of
+       [
+         field (fun (d : cascade_diagnostics) -> d.total_stocks) (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.candidates_after_held)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.long_macro_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.short_macro_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.long_top_n_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.short_top_n_admitted)
+           (equal_to 0);
+       ])
+
+let test_diagnostics_total_stocks_and_held _ =
+  let stocks =
+    [
+      _stage2_breakout_setup "AAPL";
+      _stage2_breakout_setup "MSFT";
+      _stage2_breakout_setup "NVDA";
+    ]
+  in
+  let result =
+    screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
+      ~stocks ~held_tickers:[ "MSFT" ]
+  in
+  (* total_stocks counts the input list; candidates_after_held drops the held
+     ticker. *)
+  assert_that result.cascade_diagnostics
+    (all_of
+       [
+         field (fun (d : cascade_diagnostics) -> d.total_stocks) (equal_to 3);
+         field
+           (fun (d : cascade_diagnostics) -> d.candidates_after_held)
+           (equal_to 2);
+         field
+           (fun (d : cascade_diagnostics) -> d.macro_trend)
+           (equal_to Bullish);
+       ])
+
+let test_diagnostics_bearish_macro_blocks_longs _ =
+  let result =
+    screen ~config:cfg ~macro_trend:Bearish ~sector_map:(empty_sector_map ())
+      ~stocks:[ _stage2_breakout_setup "AAPL" ]
+      ~held_tickers:[]
+  in
+  (* Macro=Bearish closes the long side: every long-side phase must read 0. *)
+  assert_that result.cascade_diagnostics
+    (all_of
+       [
+         field
+           (fun (d : cascade_diagnostics) -> d.long_macro_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.long_breakout_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.long_sector_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.long_grade_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.long_top_n_admitted)
+           (equal_to 0);
+       ])
+
+let test_diagnostics_bullish_macro_blocks_shorts _ =
+  let result =
+    screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
+      ~stocks:[ _stage2_breakout_setup "AAPL" ]
+      ~held_tickers:[]
+  in
+  assert_that result.cascade_diagnostics
+    (all_of
+       [
+         field
+           (fun (d : cascade_diagnostics) -> d.short_macro_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.short_breakdown_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.short_sector_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.short_rs_hard_gate_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.short_grade_admitted)
+           (equal_to 0);
+         field
+           (fun (d : cascade_diagnostics) -> d.short_top_n_admitted)
+           (equal_to 0);
+       ])
+
+let test_diagnostics_long_top_n_matches_buy_candidates _ =
+  let stocks =
+    List.init 5 ~f:(fun i -> _stage2_breakout_setup (sprintf "T%d" i))
+  in
+  let result =
+    screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
+      ~stocks ~held_tickers:[]
+  in
+  (* long_top_n_admitted is by definition [List.length buy_candidates]. *)
+  assert_that result.cascade_diagnostics.long_top_n_admitted
+    (equal_to (List.length result.buy_candidates))
+
 let suite =
   "screener_tests"
   >::: [
@@ -633,6 +765,15 @@ let suite =
          >:: test_short_side_volume_adequate_label;
          "test_negative_rs_scoring_order" >:: test_negative_rs_scoring_order;
          "test_support_below_scoring_order" >:: test_support_below_scoring_order;
+         "test_diagnostics_empty_universe" >:: test_diagnostics_empty_universe;
+         "test_diagnostics_total_stocks_and_held"
+         >:: test_diagnostics_total_stocks_and_held;
+         "test_diagnostics_bearish_macro_blocks_longs"
+         >:: test_diagnostics_bearish_macro_blocks_longs;
+         "test_diagnostics_bullish_macro_blocks_shorts"
+         >:: test_diagnostics_bullish_macro_blocks_shorts;
+         "test_diagnostics_long_top_n_matches_buy_candidates"
+         >:: test_diagnostics_long_top_n_matches_buy_candidates;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -106,17 +106,25 @@ let _write_equity_curve ~output_dir
       fprintf oc "%s,%.2f\n" (Date.to_string s.date) s.portfolio_value);
   Out_channel.close oc
 
-(** Persist [result.audit] as [trade_audit.sexp] when the collector captured any
-    records. No file is written when the list is empty — that's the pre-PR-2
-    default (capture sites not yet wired) and any consumer of the artefact must
-    tolerate its absence. *)
-let _write_trade_audit ~output_dir ~(audit : Trade_audit.audit_record list) =
-  match audit with
-  | [] -> ()
-  | _ ->
+(** Persist [result.audit] + [result.cascade_summaries] as [trade_audit.sexp]
+    when either is non-empty. No file is written when both are empty — that's
+    the live-mode / unwired-capture default and downstream consumers must
+    tolerate its absence.
+
+    The on-disk format is the {!Trade_audit.audit_blob} envelope, which holds
+    both lists in a single sexp record so a single file load returns both the
+    per-trade decision trail and the per-Friday cascade activity. *)
+let _write_trade_audit ~output_dir ~(audit : Trade_audit.audit_record list)
+    ~(cascade_summaries : Trade_audit.cascade_summary list) =
+  match (audit, cascade_summaries) with
+  | [], [] -> ()
+  | _, _ ->
+      let blob : Trade_audit.audit_blob =
+        { audit_records = audit; cascade_summaries }
+      in
       Sexp.save_hum
         (output_dir ^ "/trade_audit.sexp")
-        (Trade_audit.sexp_of_audit_records audit)
+        (Trade_audit.sexp_of_audit_blob blob)
 
 let write ~output_dir (result : Runner.result) =
   _write_params ~output_dir result;
@@ -127,3 +135,4 @@ let write ~output_dir (result : Runner.result) =
     ~stop_infos:result.stop_infos;
   _write_equity_curve ~output_dir ~steps:result.steps;
   _write_trade_audit ~output_dir ~audit:result.audit
+    ~cascade_summaries:result.cascade_summaries

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -25,6 +25,7 @@ type result = {
   overrides : Sexp.t list;
   stop_infos : Stop_log.stop_info list;
   audit : Trade_audit.audit_record list;
+  cascade_summaries : Trade_audit.cascade_summary list;
 }
 
 (* Trading-day filter *)
@@ -280,15 +281,24 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
      consumers use the series. *)
   let steps = List.filter steps_in_range ~f:is_trading_day in
   let final_value = (List.last_exn steps).portfolio_value in
-  let round_trips, stop_infos, audit =
+  let round_trips, stop_infos, audit, cascade_summaries =
     Trace.record ?trace Trace.Phase.Teardown (fun () ->
         ( Metrics.extract_round_trips steps_in_range,
           Stop_log.get_stop_infos stop_log,
-          Trade_audit.get_audit_records trade_audit ))
+          Trade_audit.get_audit_records trade_audit,
+          Trade_audit.get_cascade_summaries trade_audit ))
   in
   Gc_trace.record ?trace:gc_trace ~phase:"teardown_done" ();
   let summary =
     _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
       ~sim_result
   in
-  { summary; round_trips; steps; overrides; stop_infos; audit }
+  {
+    summary;
+    round_trips;
+    steps;
+    overrides;
+    stop_infos;
+    audit;
+    cascade_summaries;
+  }

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -27,6 +27,13 @@ type result = {
           PR-2 of the trade-audit plan wires capture sites in [_run_screen] /
           [entries_from_candidates] / the exit path. When non-empty,
           [Result_writer.write] persists it as [trade_audit.sexp]. *)
+  cascade_summaries : Trade_audit.cascade_summary list;
+      (** Per-Friday cascade-rejection counts captured by the strategy at the
+          end of every screen call. Complements [audit] — where [audit] only
+          covers candidates that were ENTERED (plus immediate rivals), this
+          field records the per-cascade-phase activity for every Friday,
+          including those where the cascade filtered everything. Persisted
+          alongside [audit] in [trade_audit.sexp] when either is non-empty. *)
 }
 
 val is_trading_day :

--- a/trading/trading/backtest/lib/trade_audit.ml
+++ b/trading/trading/backtest/lib/trade_audit.ml
@@ -79,6 +79,32 @@ type exit_decision = {
 type audit_record = { entry : entry_decision; exit_ : exit_decision option }
 [@@deriving sexp]
 
+type cascade_summary = {
+  date : Date.t;
+  total_stocks : int;
+  candidates_after_held : int;
+  macro_trend : Weinstein_types.market_trend;
+  long_macro_admitted : int;
+  long_breakout_admitted : int;
+  long_sector_admitted : int;
+  long_grade_admitted : int;
+  long_top_n_admitted : int;
+  short_macro_admitted : int;
+  short_breakdown_admitted : int;
+  short_sector_admitted : int;
+  short_rs_hard_gate_admitted : int;
+  short_grade_admitted : int;
+  short_top_n_admitted : int;
+  entered : int;
+}
+[@@deriving sexp]
+
+type audit_blob = {
+  audit_records : audit_record list;
+  cascade_summaries : cascade_summary list;
+}
+[@@deriving sexp]
+
 (* Collector -------------------------------------------------------------- *)
 
 type _bucket = {
@@ -88,9 +114,20 @@ type _bucket = {
 (** Internal mutable bucket. [exit_] is added to a record when the matching
     entry has already been recorded; otherwise the exit is dropped. *)
 
-type t = { records : (string, _bucket) Hashtbl.t }
+type t = {
+  records : (string, _bucket) Hashtbl.t;
+  cascade_summaries : cascade_summary Queue.t;
+      (** Per-Friday cascade summaries, recorded in insertion order. Sorted by
+          [date] ascending on retrieval — the strategy emits one per Friday
+          screen call, but ordering across multiple backtests / threads is not
+          relied on. *)
+}
 
-let create () = { records = Hashtbl.create (module String) }
+let create () =
+  {
+    records = Hashtbl.create (module String);
+    cascade_summaries = Queue.create ();
+  }
 
 let record_entry t (entry : entry_decision) =
   Hashtbl.set t.records ~key:entry.position_id
@@ -101,16 +138,31 @@ let record_exit t (exit_ : exit_decision) =
   | None -> ()
   | Some bucket -> bucket.bucket_exit <- Some exit_
 
+let record_cascade_summary t (summary : cascade_summary) =
+  Queue.enqueue t.cascade_summaries summary
+
 let _bucket_to_record (bucket : _bucket) : audit_record =
   { entry = bucket.bucket_entry; exit_ = bucket.bucket_exit }
 
 let _compare_by_position_id (a : audit_record) (b : audit_record) =
   String.compare a.entry.position_id b.entry.position_id
 
+let _compare_by_date (a : cascade_summary) (b : cascade_summary) =
+  Date.compare a.date b.date
+
 let get_audit_records t : audit_record list =
   Hashtbl.fold t.records ~init:[] ~f:(fun ~key:_ ~data:bucket acc ->
       _bucket_to_record bucket :: acc)
   |> List.sort ~compare:_compare_by_position_id
+
+let get_cascade_summaries t : cascade_summary list =
+  Queue.to_list t.cascade_summaries |> List.sort ~compare:_compare_by_date
+
+let get_audit_blob t : audit_blob =
+  {
+    audit_records = get_audit_records t;
+    cascade_summaries = get_cascade_summaries t;
+  }
 
 (* Sexp persistence ------------------------------------------------------- *)
 
@@ -119,3 +171,9 @@ let sexp_of_audit_records (records : audit_record list) : Sexp.t =
 
 let audit_records_of_sexp (sexp : Sexp.t) : audit_record list =
   [%of_sexp: audit_record list] sexp
+
+let sexp_of_audit_blob (blob : audit_blob) : Sexp.t =
+  [%sexp_of: audit_blob] blob
+
+let audit_blob_of_sexp (sexp : Sexp.t) : audit_blob =
+  [%of_sexp: audit_blob] sexp

--- a/trading/trading/backtest/lib/trade_audit.mli
+++ b/trading/trading/backtest/lib/trade_audit.mli
@@ -138,6 +138,57 @@ type audit_record = { entry : entry_decision; exit_ : exit_decision option }
 
     Field name [exit_] (rather than [exit]) avoids shadowing [Stdlib.exit]. *)
 
+type cascade_summary = {
+  date : Date.t;
+      (** Friday on which the cascade ran — same date the strategy passed into
+          {!Screener.screen}. *)
+  total_stocks : int;
+      (** Number of stocks input to the screener post strategy-side phase 1 +
+          sector pre-filter. *)
+  candidates_after_held : int;
+      (** [total_stocks] minus already-held tickers. *)
+  macro_trend : Weinstein_types.market_trend;
+  long_macro_admitted : int;
+  long_breakout_admitted : int;
+  long_sector_admitted : int;
+  long_grade_admitted : int;
+  long_top_n_admitted : int;
+  short_macro_admitted : int;
+  short_breakdown_admitted : int;
+  short_sector_admitted : int;
+  short_rs_hard_gate_admitted : int;
+  short_grade_admitted : int;
+  short_top_n_admitted : int;
+  entered : int;
+      (** Of the screener's combined top-N candidates, how many actually got
+          entered (count of {!Position.transition}s emitted). Sits below
+          [long_top_n_admitted + short_top_n_admitted] because cash limits,
+          sector concentration, and round-share sizing all drop further
+          candidates between the screener output and actual entry. *)
+}
+[@@deriving sexp]
+(** Per-Friday cascade-rejection counts — complements [audit_record]'s per-trade
+    decision trail.
+
+    Where [audit_record] captures only the candidates that were ENTERED (plus
+    their immediate rivals via [alternatives_considered]), [cascade_summary]
+    captures the full per-phase admission-count history: candidates the cascade
+    EVALUATED but did NOT admit.
+
+    Lets the audit answer "did the macro gate ever block a candidate", "was the
+    sector filter trivially permissive", "did the RS hard gate ever filter
+    shorts" — questions [audit_record] alone cannot answer because filtered
+    candidates never reach the per-entry record's alternatives bucket. *)
+
+type audit_blob = {
+  audit_records : audit_record list;
+  cascade_summaries : cascade_summary list;
+}
+[@@deriving sexp]
+(** Combined persistence envelope for [trade_audit.sexp]. Holds both the
+    per-trade decision trail and the per-Friday cascade-rejection counts in a
+    single sexp file. *)
+
 (** {1 Collector} *)
 
 type t
@@ -157,9 +208,22 @@ val record_exit : t -> exit_decision -> unit
     exit is dropped (the strategy never entered the position via this audit
     surface). *)
 
+val record_cascade_summary : t -> cascade_summary -> unit
+(** Append a per-Friday cascade summary. Append-only — recording two summaries
+    with the same [date] keeps both. *)
+
 val get_audit_records : t -> audit_record list
 (** Return all audit records, sorted by [position_id]. Records with no exit yet
     recorded (positions still open) carry [exit_ = None]. *)
+
+val get_cascade_summaries : t -> cascade_summary list
+(** Return all per-Friday cascade summaries, sorted by [date] ascending. *)
+
+val get_audit_blob : t -> audit_blob
+(** Return the combined audit-records + cascade-summaries snapshot. Equivalent
+    to
+    [{ audit_records = get_audit_records t; cascade_summaries =
+     get_cascade_summaries t }]. *)
 
 (** {1 Sexp persistence} *)
 
@@ -170,3 +234,11 @@ val sexp_of_audit_records : audit_record list -> Sexp.t
 val audit_records_of_sexp : Sexp.t -> audit_record list
 (** Parse an audit-record list from a sexp. Inverse of [sexp_of_audit_records].
 *)
+
+val sexp_of_audit_blob : audit_blob -> Sexp.t
+(** Serialize the combined audit-records + cascade-summaries snapshot as a
+    single sexp. Inverse of {!audit_blob_of_sexp}. *)
+
+val audit_blob_of_sexp : Sexp.t -> audit_blob
+(** Parse a combined audit-records + cascade-summaries snapshot from sexp.
+    Inverse of {!sexp_of_audit_blob}. *)

--- a/trading/trading/backtest/lib/trade_audit_recorder.ml
+++ b/trading/trading/backtest/lib/trade_audit_recorder.ml
@@ -94,6 +94,31 @@ let _exit_decision_of_event (e : AR.exit_event) : Trade_audit.exit_decision =
     weeks_stage_left_2 = 0;
   }
 
+(** Translate one {!AR.cascade_event} into a {!Trade_audit.cascade_summary}.
+    Pure projection — copies the screener's diagnostic counts verbatim and adds
+    the strategy-side [entered] count. *)
+let _cascade_summary_of_event (e : AR.cascade_event) :
+    Trade_audit.cascade_summary =
+  let d = e.diagnostics in
+  {
+    date = e.date;
+    total_stocks = d.total_stocks;
+    candidates_after_held = d.candidates_after_held;
+    macro_trend = d.macro_trend;
+    long_macro_admitted = d.long_macro_admitted;
+    long_breakout_admitted = d.long_breakout_admitted;
+    long_sector_admitted = d.long_sector_admitted;
+    long_grade_admitted = d.long_grade_admitted;
+    long_top_n_admitted = d.long_top_n_admitted;
+    short_macro_admitted = d.short_macro_admitted;
+    short_breakdown_admitted = d.short_breakdown_admitted;
+    short_sector_admitted = d.short_sector_admitted;
+    short_rs_hard_gate_admitted = d.short_rs_hard_gate_admitted;
+    short_grade_admitted = d.short_grade_admitted;
+    short_top_n_admitted = d.short_top_n_admitted;
+    entered = e.entered;
+  }
+
 let of_collector (collector : Trade_audit.t) : AR.t =
   {
     record_entry =
@@ -102,4 +127,8 @@ let of_collector (collector : Trade_audit.t) : AR.t =
     record_exit =
       (fun event ->
         Trade_audit.record_exit collector (_exit_decision_of_event event));
+    record_cascade_summary =
+      (fun event ->
+        Trade_audit.record_cascade_summary collector
+          (_cascade_summary_of_event event));
   }

--- a/trading/trading/backtest/test/test_trade_audit.ml
+++ b/trading/trading/backtest/test/test_trade_audit.ml
@@ -285,6 +285,95 @@ let test_collector_round_trips_through_sexp _ =
   let parsed = TA.audit_records_of_sexp (TA.sexp_of_audit_records original) in
   assert_that parsed (elements_are (List.map original ~f:equal_to))
 
+(* Cascade summary builders + tests --------------------------------------- *)
+
+(** Minimal but realistic [cascade_summary] builder. Defaults model a typical
+    Bullish-macro Friday with modest long-side activity and one entry. *)
+let make_cascade_summary ?(date = _date "2024-01-19") ?(total_stocks = 20)
+    ?(candidates_after_held = 18) ?(macro_trend = Weinstein_types.Bullish)
+    ?(long_macro_admitted = 18) ?(long_breakout_admitted = 5)
+    ?(long_sector_admitted = 5) ?(long_grade_admitted = 3)
+    ?(long_top_n_admitted = 3) ?(short_macro_admitted = 18)
+    ?(short_breakdown_admitted = 0) ?(short_sector_admitted = 0)
+    ?(short_rs_hard_gate_admitted = 0) ?(short_grade_admitted = 0)
+    ?(short_top_n_admitted = 0) ?(entered = 1) () : TA.cascade_summary =
+  {
+    date;
+    total_stocks;
+    candidates_after_held;
+    macro_trend;
+    long_macro_admitted;
+    long_breakout_admitted;
+    long_sector_admitted;
+    long_grade_admitted;
+    long_top_n_admitted;
+    short_macro_admitted;
+    short_breakdown_admitted;
+    short_sector_admitted;
+    short_rs_hard_gate_admitted;
+    short_grade_admitted;
+    short_top_n_admitted;
+    entered;
+  }
+
+let test_cascade_summary_sexp_round_trip _ =
+  let s = make_cascade_summary () in
+  let parsed = TA.cascade_summary_of_sexp (TA.sexp_of_cascade_summary s) in
+  assert_that parsed (equal_to s)
+
+let test_record_cascade_summary_appears_in_collector _ =
+  let t = TA.create () in
+  let s = make_cascade_summary () in
+  TA.record_cascade_summary t s;
+  assert_that (TA.get_cascade_summaries t) (elements_are [ equal_to s ])
+
+let test_get_cascade_summaries_sorts_by_date _ =
+  let t = TA.create () in
+  let s1 = make_cascade_summary ~date:(_date "2024-03-15") () in
+  let s2 = make_cascade_summary ~date:(_date "2024-01-19") () in
+  let s3 = make_cascade_summary ~date:(_date "2024-02-09") () in
+  TA.record_cascade_summary t s1;
+  TA.record_cascade_summary t s2;
+  TA.record_cascade_summary t s3;
+  assert_that
+    (TA.get_cascade_summaries t)
+    (elements_are
+       [
+         field
+           (fun (s : TA.cascade_summary) -> Date.to_string s.date)
+           (equal_to "2024-01-19");
+         field
+           (fun (s : TA.cascade_summary) -> Date.to_string s.date)
+           (equal_to "2024-02-09");
+         field
+           (fun (s : TA.cascade_summary) -> Date.to_string s.date)
+           (equal_to "2024-03-15");
+       ])
+
+let test_audit_blob_round_trip _ =
+  let t = TA.create () in
+  TA.record_entry t (make_entry ());
+  TA.record_exit t (make_exit ());
+  TA.record_cascade_summary t (make_cascade_summary ());
+  TA.record_cascade_summary t
+    (make_cascade_summary ~date:(_date "2024-01-26")
+       ~macro_trend:Weinstein_types.Bearish ~long_macro_admitted:0
+       ~long_breakout_admitted:0 ~long_sector_admitted:0 ~long_grade_admitted:0
+       ~long_top_n_admitted:0 ~entered:0 ());
+  let blob = TA.get_audit_blob t in
+  let parsed = TA.audit_blob_of_sexp (TA.sexp_of_audit_blob blob) in
+  assert_that parsed (equal_to blob)
+
+let test_empty_collector_returns_empty_blob _ =
+  let t = TA.create () in
+  let blob = TA.get_audit_blob t in
+  assert_that blob
+    (all_of
+       [
+         field (fun (b : TA.audit_blob) -> b.audit_records) is_empty;
+         field (fun (b : TA.audit_blob) -> b.cascade_summaries) is_empty;
+       ])
+
 let suite =
   "Trade_audit"
   >::: [
@@ -311,6 +400,15 @@ let suite =
          >:: test_get_audit_records_sorts_by_position_id;
          "collector round-trips through sexp"
          >:: test_collector_round_trips_through_sexp;
+         "cascade_summary sexp round-trip"
+         >:: test_cascade_summary_sexp_round_trip;
+         "record_cascade_summary appears in collector"
+         >:: test_record_cascade_summary_appears_in_collector;
+         "get_cascade_summaries sorts by date"
+         >:: test_get_cascade_summaries_sorts_by_date;
+         "audit_blob round-trips through sexp" >:: test_audit_blob_round_trip;
+         "empty collector returns empty audit_blob"
+         >:: test_empty_collector_returns_empty_blob;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_trade_audit_capture.ml
+++ b/trading/trading/backtest/test/test_trade_audit_capture.ml
@@ -163,6 +163,79 @@ let test_audit_position_ids_are_unique _ =
      id twice or the test rig is double-recording. *)
   assert_that (List.length ids - List.length dedup) (equal_to 0)
 
+(** Per-Friday cascade summaries must populate over a multi-Friday scenario. The
+    6-month bull-window scenario has roughly ~26 Fridays; we don't pin a
+    specific count (depends on the calendar) but require [> 5] to confirm the
+    capture site fires each Friday and isn't a one-shot. A failure here means
+    the [_screen_universe] cascade-summary call site is not wired. *)
+let test_cascade_summaries_populate_per_friday _ =
+  let result = _run_scenario () in
+  assert_that (List.length result.cascade_summaries) (gt (module Int_ord) 5)
+
+(** Each cascade summary must carry coherent counts: [total_stocks] equals the
+    universe size after strategy-side filters, [candidates_after_held] never
+    exceeds it, and the per-side admission chain monotonically decreases (each
+    phase admits at most as many as the prior one). Pins capture-site
+    correctness without locking in specific values, which would drift with
+    universe / fixture changes. *)
+let test_cascade_summary_counts_are_coherent _ =
+  let result = _run_scenario () in
+  assert_that result.cascade_summaries
+    (each
+       (all_of
+          [
+            field
+              (fun (s : Backtest.Trade_audit.cascade_summary) -> s.total_stocks)
+              (ge (module Int_ord) 0);
+            field
+              (fun (s : Backtest.Trade_audit.cascade_summary) ->
+                s.candidates_after_held <= s.total_stocks)
+              (equal_to true);
+            field
+              (fun (s : Backtest.Trade_audit.cascade_summary) ->
+                s.long_breakout_admitted <= s.long_macro_admitted)
+              (equal_to true);
+            field
+              (fun (s : Backtest.Trade_audit.cascade_summary) ->
+                s.long_sector_admitted <= s.long_breakout_admitted)
+              (equal_to true);
+            field
+              (fun (s : Backtest.Trade_audit.cascade_summary) ->
+                s.long_grade_admitted <= s.long_sector_admitted)
+              (equal_to true);
+            field
+              (fun (s : Backtest.Trade_audit.cascade_summary) ->
+                s.short_breakdown_admitted <= s.short_macro_admitted)
+              (equal_to true);
+            field
+              (fun (s : Backtest.Trade_audit.cascade_summary) ->
+                s.short_sector_admitted <= s.short_breakdown_admitted)
+              (equal_to true);
+            field
+              (fun (s : Backtest.Trade_audit.cascade_summary) ->
+                s.short_rs_hard_gate_admitted <= s.short_sector_admitted)
+              (equal_to true);
+            field
+              (fun (s : Backtest.Trade_audit.cascade_summary) ->
+                s.short_grade_admitted <= s.short_rs_hard_gate_admitted)
+              (equal_to true);
+          ]))
+
+(** [entered] sums to the same universe of round-trips the audit captures.
+    Specifically: the total entered count across all cascade summaries must
+    equal the count of audit records (each entered candidate produces exactly
+    one audit record). Pins the wiring between the per-Friday [entered] count
+    and the per-trade audit collection. *)
+let test_cascade_entered_sum_matches_audit_records _ =
+  let result = _run_scenario () in
+  let total_entered =
+    List.sum
+      (module Int)
+      result.cascade_summaries
+      ~f:(fun (s : Backtest.Trade_audit.cascade_summary) -> s.entered)
+  in
+  assert_that total_entered (equal_to (List.length result.audit))
+
 let suite =
   "Trade_audit_capture"
   >::: [
@@ -175,6 +248,12 @@ let suite =
          "at least one audit record has a populated exit_ block"
          >:: test_some_audit_records_have_exit_blocks;
          "audit position_ids are unique" >:: test_audit_position_ids_are_unique;
+         "cascade summaries populate per Friday"
+         >:: test_cascade_summaries_populate_per_friday;
+         "cascade summary counts are coherent"
+         >:: test_cascade_summary_counts_are_coherent;
+         "cascade entered sum matches audit records"
+         >:: test_cascade_entered_sum_matches_audit_records;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/audit_recorder.ml
+++ b/trading/trading/weinstein/strategy/lib/audit_recorder.ml
@@ -37,9 +37,21 @@ type exit_event = {
   distance_from_ma_pct : float;
 }
 
+type cascade_event = {
+  date : Date.t;
+  diagnostics : Screener.cascade_diagnostics;
+  entered : int;
+}
+
 type t = {
   record_entry : entry_event -> unit;
   record_exit : exit_event -> unit;
+  record_cascade_summary : cascade_event -> unit;
 }
 
-let noop : t = { record_entry = (fun _ -> ()); record_exit = (fun _ -> ()) }
+let noop : t =
+  {
+    record_entry = (fun _ -> ());
+    record_exit = (fun _ -> ());
+    record_cascade_summary = (fun _ -> ());
+  }

--- a/trading/trading/weinstein/strategy/lib/audit_recorder.mli
+++ b/trading/trading/weinstein/strategy/lib/audit_recorder.mli
@@ -90,13 +90,36 @@ type exit_event = {
 }
 (** Event captured at exit-decision time. *)
 
+type cascade_event = {
+  date : Date.t;
+      (** Friday on which the screen ran — same as [current_date] passed into
+          [_screen_universe]. *)
+  diagnostics : Screener.cascade_diagnostics;
+      (** Per-cascade-phase admission counts. Carried through unchanged from
+          [Screener.result.cascade_diagnostics]. *)
+  entered : int;
+      (** How many of the {!Screener.scored_candidate}s the strategy actually
+          entered this Friday — the count of {!Position.transition}s emitted by
+          {!Weinstein_strategy.entries_from_candidates}. Sits below
+          [diagnostics.long_top_n_admitted + diagnostics.short_top_n_admitted]
+          because cash limits, sector concentration, and round-share sizing all
+          drop further candidates between the screener output and the actual
+          entry list. *)
+}
+(** Event captured at the end of one Friday's cascade. Complements
+    [entry_event]: where [entry_event] records a single chosen candidate plus
+    its rivals, [cascade_event] records the per-phase activity counts for the
+    whole cascade — including phases that filter out every candidate before any
+    rival comparison happens. *)
+
 type t = {
   record_entry : entry_event -> unit;
   record_exit : exit_event -> unit;
+  record_cascade_summary : cascade_event -> unit;
 }
-(** Recorder bundle. Both callbacks are invoked unconditionally by the strategy
-    at entry / exit sites; the implementation decides whether to persist or
-    drop. *)
+(** Recorder bundle. All callbacks are invoked unconditionally by the strategy
+    at entry / exit / per-Friday sites; the implementation decides whether to
+    persist or drop. *)
 
 val noop : t
 (** Recorder that drops every event. Default for callers (tests, live mode) that

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -292,9 +292,22 @@ let _screen_universe ~config ~index_view ~(macro_result : Macro.result)
     screen_result.Screener.buy_candidates
     @ screen_result.Screener.short_candidates
   in
-  entries_from_candidates ~config ~candidates:combined_candidates ~stop_states
-    ~bar_reader ~portfolio ~get_price ~current_date ~audit_recorder
-    ~macro:macro_result ()
+  let entries =
+    entries_from_candidates ~config ~candidates:combined_candidates ~stop_states
+      ~bar_reader ~portfolio ~get_price ~current_date ~audit_recorder
+      ~macro:macro_result ()
+  in
+  (* Per-Friday cascade-rejection capture. Fires after the entry walk so the
+     [entered] count reflects actual transitions emitted, not just the
+     screener's top-N output. Recorder is [Audit_recorder.noop] in non-audit
+     contexts (live mode, tests) — zero cost. *)
+  audit_recorder.Audit_recorder.record_cascade_summary
+    {
+      date = current_date;
+      diagnostics = screen_result.Screener.cascade_diagnostics;
+      entered = List.length entries;
+    };
+  entries
 
 (* ------------------------------------------------------------------ *)
 (* make                                                                  *)


### PR DESCRIPTION
## Summary

Extend the trade-audit (post-#642) to capture per-Friday cascade-rejection
counts — candidates the cascade EVALUATED but did NOT admit. Complements
the per-trade entry capture, which only records ADMITTED candidates plus
their immediate rivals; lets the audit answer "did the macro gate ever
block a candidate", "was the sector filter trivially permissive", "did the
RS hard gate ever filter shorts" — questions the per-trade audit alone
can't answer because filtered candidates never reach the per-entry
alternatives bucket.

## What's now captured per Friday

`Trade_audit.cascade_summary`:
- `total_stocks`, `candidates_after_held` (pre-cascade)
- `macro_trend` (regime gate)
- Long-side admission counts at each phase: `long_macro_admitted`,
  `long_breakout_admitted`, `long_sector_admitted`, `long_grade_admitted`,
  `long_top_n_admitted`
- Short-side admission counts: `short_macro_admitted`,
  `short_breakdown_admitted`, `short_sector_admitted`,
  `short_rs_hard_gate_admitted`, `short_grade_admitted`,
  `short_top_n_admitted`
- `entered` (count of transitions actually emitted; sits below
  `long_top_n + short_top_n` due to cash limits, sector concentration,
  round-share sizing)

## How

- `Screener.result` gains a `cascade_diagnostics : cascade_diagnostics`
  field (additive). New `_long_admission` / `_short_admission` helpers
  return per-pair phase predicates; `_count_long_phases` /
  `_count_short_phases` fold them into running counts. When the macro gate
  closes a side, downstream phase counts collapse to 0 to match what the
  screener actually emitted.
- `Audit_recorder` (in `weinstein_trading.strategy`) gains a
  `cascade_event` type and a `record_cascade_summary : cascade_event ->
  unit` callback in `t`. The strategy library still doesn't depend on
  `Backtest`; the noop recorder drops events with zero overhead.
- `_screen_universe` in `weinstein_strategy.ml` fires the cascade-summary
  event at the end of each Friday's screen, after `entries_from_candidates`,
  so the `entered` count reflects actual transitions.
- `Trade_audit.t` gains a `cascade_summaries : cascade_summary Queue.t`,
  `record_cascade_summary` / `get_cascade_summaries` / `get_audit_blob`
  ops. New `audit_blob = { audit_records; cascade_summaries }` envelope
  persists both lists in a single sexp. `Result_writer.write` emits the
  combined blob to `trade_audit.sexp` when either list is non-empty.

## Tests

13 new tests:

- 5 screener cascade-diagnostics tests covering empty universe, total
  stocks vs held filter, Bearish-macro long-side collapse, Bullish-macro
  short-side collapse, and `long_top_n_admitted == List.length
  buy_candidates`.
- 5 trade_audit cascade-summary tests covering sexp round-trip, collector
  behavior, date-sorted retrieval, combined blob round-trip, empty blob.
- 3 e2e capture tests on the existing `tiered-loader-parity` smoke
  scenario covering: per-Friday population over the bull window,
  monotonic phase counts (each phase admits at most as many as the
  prior), and `Σ entered == count of audit records`.

## Test plan

- [x] `dune build` clean
- [x] `dune build @fmt` clean
- [x] `dune runtest analysis/weinstein/screener/test` (22 → 27 cases)
- [x] `dune runtest trading/backtest/test` (existing 14 → 19 +
  capture 5 → 8)
- [x] No new nesting/length linter violations attributable to my code
- [x] Existing parity tests (`test_panel_loader_parity`,
  `test_runner_hypothesis_overrides`) unchanged

## Notes

- Pure observer extension — bit-exact behavioural parity with main; the
  only runtime work added is two list folds over the candidate list per
  Friday plus one `Queue.enqueue`.
- Out of scope (per task spec): markdown renderer integration (PR-3 of
  trade-audit, separate); per-symbol rejection logging (heavier
  follow-up); live mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)