### PR TITLE
feat(backtest-perf): integrate trade-audit ratings into release_perf_report (PR-5 of trade-audit)

### DIFF
--- a/trading/trading/backtest/bin/dune
+++ b/trading/trading/backtest/bin/dune
@@ -13,7 +13,7 @@
 (executable
  (name release_perf_report)
  (modules release_perf_report)
- (libraries core trading.backtest.release_report))
+ (libraries core release_report))
 
 (executable
  (name trade_audit_report_bin)

--- a/trading/trading/backtest/release_report/dune
+++ b/trading/trading/backtest/release_report/dune
@@ -1,6 +1,5 @@
 (library
  (name release_report)
- (public_name trading.backtest.release_report)
- (libraries core core_unix core_unix.sys_unix)
+ (libraries core core_unix core_unix.sys_unix trade_audit_report)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/release_report/release_report.ml
+++ b/trading/trading/backtest/release_report/release_report.ml
@@ -27,6 +27,7 @@ type scenario_run = {
   summary : summary_meta;
   peak_rss_kb : int option;
   wall_seconds : float option;
+  trade_quality : Trade_audit_report.t option;
 }
 [@@deriving sexp]
 
@@ -64,6 +65,15 @@ let _read_optional_float path =
   Option.bind (_read_first_line path) ~f:(fun s ->
       try Some (Float.of_string s) with _ -> None)
 
+let _try_load_trade_quality ~dir : Trade_audit_report.t option =
+  (* The audit-report loader requires [trades.csv]; [trade_audit.sexp] is
+     optional. If [trades.csv] is missing we skip silently — the section
+     simply renders as N/A in the comparison. Any malformed input is also
+     swallowed: the audit is auxiliary, never a hard requirement. *)
+  let trades_path = Filename.concat dir "trades.csv" in
+  if not (Sys_unix.file_exists_exn trades_path) then None
+  else try Some (Trade_audit_report.load ~scenario_dir:dir) with _ -> None
+
 let load_scenario_run ~dir =
   let name = Filename.basename dir in
   let actual_path = Filename.concat dir "actual.sexp" in
@@ -80,7 +90,8 @@ let load_scenario_run ~dir =
   let wall_seconds =
     _read_optional_float (Filename.concat dir "wall_seconds.txt")
   in
-  { name; actual; summary; peak_rss_kb; wall_seconds }
+  let trade_quality = _try_load_trade_quality ~dir in
+  { name; actual; summary; peak_rss_kb; wall_seconds; trade_quality }
 
 let _list_scenario_subdirs root =
   if not (Sys_unix.is_directory_exn root) then
@@ -267,11 +278,204 @@ let _one_sided_section ~title names =
     let body = List.map names ~f:(fun n -> sprintf "- `%s`" n) in
     header @ body @ [ "" ]
 
+(* --- Trade quality summary ---
+
+   For each paired scenario where at least one side has a [trade_quality]
+   record, surface the headline behavioural / Weinstein-conformance numbers
+   and the per-side delta. This complements the trading-metrics table: a
+   scenario can show flat returns while its trade quality regresses (e.g.
+   higher exit-losers-too-late or a falling Weinstein spirit score). *)
+
+type _quality_summary = {
+  spirit_score : float option;
+      (* avg per-trade Weinstein score [[0,1]]; None when no analysis *)
+  mean_r_multiple : float option;
+  median_r_multiple : float option;
+  trades_per_year : float option;
+  over_trading_flag : bool;
+  exit_winners_flagged : int;
+  winners_evaluated : int;
+  exit_losers_flagged : int;
+  losers_evaluated : int;
+  decision_quality_win_rate_pct : float;
+}
+
+let _finite_or_none v = if Float.is_finite v then Some v else None
+
+let _r_multiple_stats
+    (ratings : Trade_audit_report.Trade_audit_ratings.rating list) =
+  let rs =
+    List.filter_map ratings ~f:(fun r ->
+        if Float.is_finite r.Trade_audit_report.Trade_audit_ratings.r_multiple
+        then Some r.r_multiple
+        else None)
+  in
+  if List.is_empty rs then (None, None)
+  else
+    let sorted = List.sort rs ~compare:Float.compare in
+    let n = List.length sorted in
+    let mean = List.fold sorted ~init:0.0 ~f:( +. ) /. Float.of_int n in
+    let median =
+      if n mod 2 = 1 then List.nth_exn sorted (n / 2)
+      else
+        let a = List.nth_exn sorted ((n / 2) - 1) in
+        let b = List.nth_exn sorted (n / 2) in
+        (a +. b) /. 2.0
+    in
+    (Some mean, Some median)
+
+let _summarize_quality (q : Trade_audit_report.t option) : _quality_summary =
+  let empty =
+    {
+      spirit_score = None;
+      mean_r_multiple = None;
+      median_r_multiple = None;
+      trades_per_year = None;
+      over_trading_flag = false;
+      exit_winners_flagged = 0;
+      winners_evaluated = 0;
+      exit_losers_flagged = 0;
+      losers_evaluated = 0;
+      decision_quality_win_rate_pct = 0.0;
+    }
+  in
+  match q with
+  | None -> empty
+  | Some t -> (
+      match t.analysis with
+      | None -> empty
+      | Some a ->
+          let mean, median = _r_multiple_stats a.ratings in
+          {
+            spirit_score = _finite_or_none a.weinstein.spirit_score;
+            mean_r_multiple = mean;
+            median_r_multiple = median;
+            trades_per_year =
+              _finite_or_none a.behavioral.over_trading.trades_per_year;
+            over_trading_flag = a.behavioral.over_trading.exceeds_threshold;
+            exit_winners_flagged =
+              a.behavioral.exit_winners_too_early.flagged_count;
+            winners_evaluated =
+              a.behavioral.exit_winners_too_early.winners_evaluated;
+            exit_losers_flagged =
+              a.behavioral.exit_losers_too_late.flagged_count;
+            losers_evaluated =
+              a.behavioral.exit_losers_too_late.losers_evaluated;
+            decision_quality_win_rate_pct =
+              a.decision_quality.overall_win_rate_pct;
+          })
+
+let _fmt_opt_float fmt = function Some v -> sprintf fmt v | None -> "n/a"
+let _fmt_opt_score = _fmt_opt_float "%.3f"
+let _fmt_opt_r = _fmt_opt_float "%+.2f"
+let _fmt_opt_tpy = _fmt_opt_float "%.1f"
+let _fmt_count_of n_total n_eval = sprintf "%d / %d" n_total n_eval
+
+let _delta_opt_float ~current ~prior =
+  match (current, prior) with Some c, Some p -> Some (c -. p) | _ -> None
+
+let _fmt_delta_signed = function None -> "n/a" | Some d -> sprintf "%+.3f" d
+
+let _row_quality_metric ~label ~current_str ~prior_str ~delta_str =
+  sprintf "| %s | %s | %s | %s |" label current_str prior_str delta_str
+
+let _fmt_delta_float_opt = function
+  | None -> "n/a"
+  | Some d -> sprintf "%+.1f" d
+
+let _over_trading_str (s : _quality_summary) =
+  sprintf "%s%s"
+    (_fmt_opt_tpy s.trades_per_year)
+    (if s.over_trading_flag then " :rotating_light:" else "")
+
+let _score_rows ~(cur : _quality_summary) ~(prior : _quality_summary) =
+  (* Float metrics with optional values: spirit score, R-multiple stats. *)
+  let delta name f fmt =
+    _row_quality_metric ~label:name
+      ~current_str:(fmt (f cur))
+      ~prior_str:(fmt (f prior))
+      ~delta_str:
+        (_fmt_delta_signed (_delta_opt_float ~current:(f cur) ~prior:(f prior)))
+  in
+  [
+    delta "Weinstein spirit score" (fun s -> s.spirit_score) _fmt_opt_score;
+    delta "Mean R-multiple" (fun s -> s.mean_r_multiple) _fmt_opt_r;
+    delta "Median R-multiple" (fun s -> s.median_r_multiple) _fmt_opt_r;
+  ]
+
+let _count_rows ~(cur : _quality_summary) ~(prior : _quality_summary) =
+  (* Integer counts + win rate — deltas are always-defined arithmetic. *)
+  let delta_tpy =
+    _delta_opt_float ~current:cur.trades_per_year ~prior:prior.trades_per_year
+  in
+  [
+    _row_quality_metric ~label:"Trades / year"
+      ~current_str:(_over_trading_str cur) ~prior_str:(_over_trading_str prior)
+      ~delta_str:(_fmt_delta_float_opt delta_tpy);
+    _row_quality_metric ~label:"Exit winners too early (flagged / evaluated)"
+      ~current_str:
+        (_fmt_count_of cur.exit_winners_flagged cur.winners_evaluated)
+      ~prior_str:
+        (_fmt_count_of prior.exit_winners_flagged prior.winners_evaluated)
+      ~delta_str:
+        (sprintf "%+d" (cur.exit_winners_flagged - prior.exit_winners_flagged));
+    _row_quality_metric ~label:"Exit losers too late (flagged / evaluated)"
+      ~current_str:(_fmt_count_of cur.exit_losers_flagged cur.losers_evaluated)
+      ~prior_str:
+        (_fmt_count_of prior.exit_losers_flagged prior.losers_evaluated)
+      ~delta_str:
+        (sprintf "%+d" (cur.exit_losers_flagged - prior.exit_losers_flagged));
+    _row_quality_metric ~label:"Decision-quality win rate %"
+      ~current_str:(sprintf "%.1f" cur.decision_quality_win_rate_pct)
+      ~prior_str:(sprintf "%.1f" prior.decision_quality_win_rate_pct)
+      ~delta_str:
+        (sprintf "%+.1f"
+           (cur.decision_quality_win_rate_pct
+          -. prior.decision_quality_win_rate_pct));
+  ]
+
+let _quality_rows ~(cur : _quality_summary) ~(prior : _quality_summary) =
+  _score_rows ~cur ~prior @ _count_rows ~cur ~prior
+
+let _row_quality_for_pair (cur, prior) =
+  let cur_q = _summarize_quality cur.trade_quality in
+  let prior_q = _summarize_quality prior.trade_quality in
+  [
+    sprintf "### %s" cur.name;
+    "";
+    "| Metric | Current | Prior | Δ |";
+    "|---|---:|---:|---:|";
+  ]
+  @ _quality_rows ~cur:cur_q ~prior:prior_q
+  @ [ "" ]
+
+let _trade_quality_section paired =
+  let with_quality =
+    List.filter paired ~f:(fun (c, p) ->
+        Option.is_some c.trade_quality || Option.is_some p.trade_quality)
+  in
+  if List.is_empty with_quality then []
+  else
+    let header =
+      [
+        "## Trade quality";
+        "";
+        "Behavioural metrics + Weinstein conformance per scenario \
+         (`trade_audit.sexp` required). Δ is current minus prior — lower \
+         exit-winners-flagged / exit-losers-flagged is better; higher spirit \
+         score and mean R-multiple is better.";
+        "";
+      ]
+    in
+    let body = List.concat_map with_quality ~f:_row_quality_for_pair in
+    header @ body
+
 let render ?(thresholds = default_thresholds) (t : t) =
   let lines =
     _section_header ~title:"Release perf report" ~current:t.current_label
       ~prior:t.prior_label
     @ _trading_section t.paired
+    @ _trade_quality_section t.paired
     @ _rss_section ~thresholds t.paired
     @ _wall_section ~thresholds t.paired
     @ _one_sided_section ~title:"Current-only scenarios" t.current_only

--- a/trading/trading/backtest/release_report/release_report.mli
+++ b/trading/trading/backtest/release_report/release_report.mli
@@ -66,12 +66,20 @@ type scenario_run = {
   summary : summary_meta;
   peak_rss_kb : int option;
   wall_seconds : float option;
+  trade_quality : Trade_audit_report.t option;
+      (** Loaded from [trade_audit.sexp] + [trades.csv] in the scenario dir when
+          present. [None] for pre-PR-2 outputs that did not capture an audit
+          trail, or when [trades.csv] is missing. The report renders an
+          additional "Trade quality" section for paired scenarios where at least
+          one side has [Some _]. *)
 }
 [@@deriving sexp]
 (** One scenario's per-run readings — the [actual] block plus optional
-    infra-perf measurements. Both [peak_rss_kb] and [wall_seconds] are [None]
-    when the corresponding sibling files are absent in the batch dir; the report
-    still renders trading metrics in that case. *)
+    infra-perf measurements and an optional trade-audit summary. Both
+    [peak_rss_kb] and [wall_seconds] are [None] when the corresponding sibling
+    files are absent in the batch dir; the report still renders trading metrics
+    in that case. [trade_quality] is [None] when no audit artefacts were found
+    or when the audit was empty (no trades). *)
 
 type t = {
   current_label : string;

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -25,7 +25,7 @@
   backtest
   trade_audit_report
   trading.backtest.runner_args
-  trading.backtest.release_report
+  release_report
   scenario_lib
   weinstein.data_source
   weinstein.types

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -35,10 +35,11 @@ let _make_summary ?(start_date = Date.of_string "2023-01-02")
   }
 
 let _make_run ?(name = "scenario") ?actual ?summary ?(peak_rss_kb = None)
-    ?(wall_seconds = None) () : Release_report.scenario_run =
+    ?(wall_seconds = None) ?(trade_quality = None) () :
+    Release_report.scenario_run =
   let actual = Option.value actual ~default:(_make_actual ()) in
   let summary = Option.value summary ~default:(_make_summary ()) in
-  { name; actual; summary; peak_rss_kb; wall_seconds }
+  { name; actual; summary; peak_rss_kb; wall_seconds; trade_quality }
 
 (* --- default_thresholds --- *)
 
@@ -355,6 +356,269 @@ let test_load_pairs_and_one_sided _ =
            (elements_are [ equal_to "prior-only" ]);
        ])
 
+(* --- Trade quality section ---
+
+   The "Trade quality" section is only rendered for scenarios where at least
+   one side has a [trade_quality] record. These tests build synthetic
+   {!Trade_audit_report.t} values, drive the renderer end-to-end, and pin the
+   header text + at least one row each from the behavioural / Weinstein /
+   decision-quality sub-summaries. *)
+
+let _date d = Date.of_string d
+
+let _make_audit_record ~symbol ~entry_date
+    ?(stage = Weinstein_types.Stage2 { weeks_advancing = 4; late = false })
+    ?(macro_trend = Weinstein_types.Bullish)
+    ?(cascade_grade = Weinstein_types.A) ?(cascade_score = 75)
+    ?(initial_risk_dollars = 6_000.0)
+    ?(stop_floor_kind = Backtest.Trade_audit.Buffer_fallback)
+    ?(rs_trend = Some Weinstein_types.Positive_rising)
+    ?(side = Trading_base.Types.Long) () : Backtest.Trade_audit.audit_record =
+  let entry : Backtest.Trade_audit.entry_decision =
+    {
+      symbol;
+      entry_date;
+      position_id = symbol ^ "-1";
+      macro_trend;
+      macro_confidence = 0.72;
+      macro_indicators = [];
+      stage;
+      ma_direction = Weinstein_types.Rising;
+      ma_slope_pct = 0.018;
+      rs_trend;
+      rs_value = Some 1.05;
+      volume_quality = Some (Weinstein_types.Strong 2.4);
+      resistance_quality = Some Weinstein_types.Clean;
+      support_quality = Some Weinstein_types.Clean;
+      sector_name = "Tech";
+      sector_rating = Screener.Strong;
+      cascade_score;
+      cascade_grade;
+      cascade_score_components = [];
+      cascade_rationale = [];
+      side;
+      suggested_entry = 100.0;
+      suggested_stop = 90.0;
+      installed_stop = 90.0;
+      stop_floor_kind;
+      risk_pct = 0.10;
+      initial_position_value = 60_000.0;
+      initial_risk_dollars;
+      alternatives_considered = [];
+    }
+  in
+  let exit_ : Backtest.Trade_audit.exit_decision =
+    {
+      symbol;
+      exit_date = Date.add_days entry_date 100;
+      position_id = symbol ^ "-1";
+      exit_trigger =
+        Backtest.Stop_log.Stop_loss { stop_price = 90.0; actual_price = 89.0 };
+      macro_trend_at_exit = Weinstein_types.Neutral;
+      macro_confidence_at_exit = 0.45;
+      stage_at_exit = Weinstein_types.Stage3 { weeks_topping = 2 };
+      rs_trend_at_exit = Some Weinstein_types.Positive_flat;
+      distance_from_ma_pct = -0.025;
+      max_favorable_excursion_pct = 0.08;
+      max_adverse_excursion_pct = -0.05;
+      weeks_macro_was_bearish = 0;
+      weeks_stage_left_2 = 1;
+    }
+  in
+  { entry; exit_ = Some exit_ }
+
+let _make_trade ~symbol ~entry_date ?(days_held = 100) ?(entry_price = 100.0)
+    ?(exit_price = 110.0) ?(quantity = 100.0) ?(pnl_dollars = 1_000.0)
+    ?(pnl_percent = 10.0) () : Trading_simulation.Metrics.trade_metrics =
+  {
+    symbol;
+    entry_date;
+    exit_date = Date.add_days entry_date days_held;
+    days_held;
+    entry_price;
+    exit_price;
+    quantity;
+    pnl_dollars;
+    pnl_percent;
+  }
+
+let _make_trade_quality ~entries : Trade_audit_report.t =
+  (* [entries] is a list of (symbol, entry_date, pnl_dollars) triples — one
+     audit record + one matching round-trip per entry. *)
+  let trade_audit =
+    List.map entries ~f:(fun (symbol, entry_date, _pnl) ->
+        _make_audit_record ~symbol ~entry_date ())
+  in
+  let trades =
+    List.map entries ~f:(fun (symbol, entry_date, pnl) ->
+        _make_trade ~symbol ~entry_date ~pnl_dollars:pnl
+          ~pnl_percent:(pnl /. 100.0) ())
+  in
+  Trade_audit_report.render ~scenario_name:"recovery-2023" ~trade_audit ~trades
+    ()
+
+let test_render_omits_trade_quality_when_both_none _ =
+  let cur = _make_run ~name:"recovery-2023" () in
+  let prior = _make_run ~name:"recovery-2023" () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"## Trade quality")
+           (equal_to false);
+         field
+           (fun s -> String.is_substring s ~substring:"Weinstein spirit score")
+           (equal_to false);
+       ])
+
+let test_render_includes_trade_quality_when_present _ =
+  let entries =
+    [
+      ("AAPL", _date "2023-02-01", 1_500.0);
+      ("MSFT", _date "2023-04-15", 2_000.0);
+      ("WRB", _date "2023-09-20", -800.0);
+    ]
+  in
+  let prior_entries =
+    [
+      ("AAPL", _date "2023-02-01", 800.0);
+      ("MSFT", _date "2023-04-15", 1_200.0);
+      ("WRB", _date "2023-09-20", -1_500.0);
+    ]
+  in
+  let cur =
+    _make_run ~name:"recovery-2023"
+      ~trade_quality:(Some (_make_trade_quality ~entries))
+      ()
+  in
+  let prior =
+    _make_run ~name:"recovery-2023"
+      ~trade_quality:(Some (_make_trade_quality ~entries:prior_entries))
+      ()
+  in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"## Trade quality")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s ~substring:"| Weinstein spirit score |")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"| Mean R-multiple |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s ~substring:"| Decision-quality win rate % |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Exit winners too early (flagged / evaluated) |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Exit losers too late (flagged / evaluated) |")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"### recovery-2023")
+           (equal_to true);
+       ])
+
+let test_render_includes_trade_quality_when_only_current _ =
+  (* Section renders even when only one side has audit data; the absent side
+     surfaces "n/a" in the spirit-score / R-multiple cells. *)
+  let entries = [ ("AAPL", _date "2023-02-01", 1_500.0) ] in
+  let cur =
+    _make_run ~name:"recovery-2023"
+      ~trade_quality:(Some (_make_trade_quality ~entries))
+      ()
+  in
+  let prior = _make_run ~name:"recovery-2023" () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"## Trade quality")
+           (equal_to true);
+         (* Prior side has no audit -> spirit score column shows "n/a". *)
+         field
+           (fun s ->
+             String.is_substring s ~substring:"| Weinstein spirit score |")
+           (equal_to true);
+       ])
+
+(* --- Loader: trade_quality round-trip via on-disk fixtures --- *)
+
+let _write_trades_csv path =
+  _write_text path
+    "symbol,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger\n\
+     AAPL,2023-02-01,2023-05-01,90,100.00,110.00,100,1000.00,10.00,90.00,108.00,signal_reversal\n\
+     MSFT,2023-04-15,2023-07-15,90,250.00,275.00,50,1250.00,10.00,225.00,270.00,signal_reversal\n"
+
+let _write_trade_audit_sexp path =
+  let records =
+    [
+      _make_audit_record ~symbol:"AAPL" ~entry_date:(_date "2023-02-01") ();
+      _make_audit_record ~symbol:"MSFT" ~entry_date:(_date "2023-04-15") ();
+    ]
+  in
+  let sexp = Backtest.Trade_audit.sexp_of_audit_records records in
+  Sexp.save_hum path sexp
+
+let test_load_scenario_run_loads_trade_quality_when_present _ =
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_audit_" in
+  _make_scenario_dir ~root:dir "with-audit" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "with-audit" in
+  _write_trades_csv (Filename.concat scenario_dir "trades.csv");
+  _write_trade_audit_sexp (Filename.concat scenario_dir "trade_audit.sexp");
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.trade_quality
+    (is_some_and
+       (field
+          (fun (t : Trade_audit_report.t) -> t.header.total_round_trips)
+          (equal_to 2)))
+
+let test_load_scenario_run_no_trade_quality_when_trades_csv_missing _ =
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_audit_" in
+  _make_scenario_dir ~root:dir "no-audit" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "no-audit" in
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.trade_quality is_none
+
 let suite =
   "release_perf_report"
   >::: [
@@ -368,12 +632,22 @@ let suite =
          >:: test_render_custom_threshold_suppresses_flag;
          "render no pairs" >:: test_render_no_pairs;
          "render one-sided scenarios listed" >:: test_render_one_sided_scenarios;
+         "render omits trade quality when both none"
+         >:: test_render_omits_trade_quality_when_both_none;
+         "render includes trade quality when present"
+         >:: test_render_includes_trade_quality_when_present;
+         "render includes trade quality when only current"
+         >:: test_render_includes_trade_quality_when_only_current;
          "load_scenario_run reads all fields"
          >:: test_load_scenario_run_reads_all_fields;
          "load_scenario_run missing perf files -> None"
          >:: test_load_scenario_run_missing_perf_files_is_none;
          "load pairs scenarios and tracks one-sided"
          >:: test_load_pairs_and_one_sided;
+         "load_scenario_run loads trade_quality when present"
+         >:: test_load_scenario_run_loads_trade_quality_when_present;
+         "load_scenario_run no trade_quality when trades.csv missing"
+         >:: test_load_scenario_run_no_trade_quality_when_trades_csv_missing;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR-5 of `dev/plans/trade-audit-2026-04-28.md`. Wires the PR-3 markdown renderer
and PR-4 ratings (`Trade_audit_report` + `Trade_audit_ratings`) into the
existing `release_perf_report` exe so each scenario in a release-comparison
report includes a Trade quality summary, not just the metric tables.

## What it does

- `Release_report.scenario_run` gains an optional `trade_quality :
  Trade_audit_report.t option` field, populated by `load_scenario_run`
  whenever a scenario directory contains `trades.csv` (and optionally
  `trade_audit.sexp`). Pre-PR-2 outputs that lack the audit are gracefully
  reported as `None`.
- A new `## Trade quality` section renders per-paired-scenario when at least
  one side has `trade_quality`. The section surfaces:
  - Weinstein spirit score (avg per-trade conformance from PR-4).
  - Mean / median R-multiple distribution.
  - Trades / year (with the `:rotating_light:` flag from PR-4 over-trading
    detection).
  - Exit-winners-too-early flagged / evaluated count.
  - Exit-losers-too-late flagged / evaluated count.
  - Decision-quality overall win rate.
  Each row carries a current/prior diff so trade-quality regressions surface
  even when total return is flat.
- CLI shape unchanged. The exe still takes `--current <dir> --prior <dir>`;
  it just emits richer output when `trade_audit.sexp` is present.

## Why

The release-perf-report previously surfaced trading metrics + RSS + wall
time but said nothing about *trade quality* — a strategy can show flat
returns while dropping exit-discipline numbers or over-trading. With the
PR-1..PR-4 trade-audit chain landed, that data is sitting on disk in every
scenario output dir and it costs ~100 LOC of glue to surface it in the
release-gate report.

## Test plan

- [x] `dune build` clean
- [x] `dune build @fmt` clean
- [x] `dune exec test_release_perf_report.exe` — 16 tests pass (was 11; added
      5 new tests covering the new section, on-disk loader, and the both-
      sides-absent path).
- [x] `dune exec test_trade_audit_report.exe` — 14/14 pass (no regression on
      PR-3 module).
- [x] `dune exec test_trade_audit_ratings.exe` — 35/35 pass (no regression on
      PR-4 module).
- [x] `fn_length_linter` clean for the new file.
- [x] No magic numbers — all thresholds inherited from
      `Trade_audit_ratings.config.default_config`.

## PR sizing

~225 LOC of feature code (release_report.ml + .mli + 4 dune line-changes)
plus ~278 LOC of tests. Single new section in one library; no new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)