### PR TITLE
feat(backtest-perf): optimal-strategy PR-1 — types + Stage_transition_scanner

### DIFF
--- a/dev/status/optimal-strategy.md
+++ b/dev/status/optimal-strategy.md
@@ -3,10 +3,11 @@
 ## Last updated: 2026-04-28
 
 ## Status
-PLANNING
+IN_PROGRESS
 
-Plan-only PR open against `docs/optimal-strategy-counterfactual-plan`.
-No implementation work yet.
+PR-1 (data model + `Stage_transition_scanner`) implemented and opened
+as draft PR #652 on branch `feat/optimal-strategy-pr1`. PR-2
+(`Outcome_scorer`) is the next slice.
 
 ## Goal
 
@@ -39,12 +40,28 @@ NO
 
 ## Open work
 
-Plan-only PR awaiting human review. No implementation branch yet.
+**PR-2 — `Outcome_scorer`** is next. Per plan §Phase B + §PR-2:
+
+- `trading/trading/backtest/optimal/lib/outcome_scorer.{ml,mli}` —
+  pure scorer. Input: `candidate_entry + Bar_panel.t`. Output:
+  `scored_candidate`. Implements the counterfactual exit rule
+  (`Stage3_transition` / `Stop_hit` / `End_of_run`, whichever first).
+  Reuses `Weinstein_stops.compute_initial_stop_with_floor` for the
+  initial stop and the existing trailing-stop walker for subsequent
+  weeks.
+- `trading/trading/backtest/optimal/test/test_outcome_scorer.ml` —
+  three exit-trigger fixtures + an R-multiple computation pin test.
+
+LOC estimate: 300.
+
+The `scored_candidate` schema already lives in `Optimal_types` (PR-1),
+so PR-2 is type-stable and can land independently.
 
 ## Phasing (per plan)
 
-- [ ] **PR-1**: `Optimal_types` data model + `Stage_transition_scanner`
-      (enumerate breakout candidates over the panel). ~300 LOC.
+- [x] **PR-1**: `Optimal_types` data model + `Stage_transition_scanner`
+      — PR #652 (draft), branch `feat/optimal-strategy-pr1`.
+      Verify: `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/`.
 - [ ] **PR-2**: `Outcome_scorer` — realized-outcome scorer per candidate
       (Stage3-transition vs stop-hit forward walk). ~300 LOC.
 - [ ] **PR-3**: `Optimal_portfolio_filler` — greedy sizing-constrained
@@ -65,16 +82,20 @@ pure-functional analysis layer over backtest outputs.
 
 ## Branch
 
-`docs/optimal-strategy-counterfactual-plan` for the plan.
-Implementation branches per phase: `feat/optimal-strategy-pr1`,
-`feat/optimal-strategy-pr2`, etc.
+Implementation branches per phase:
+
+- `feat/optimal-strategy-pr1` — PR #652 (draft, READY_FOR_REVIEW pending QC).
+- `feat/optimal-strategy-pr2` (next).
+
+Plan branch: `docs/optimal-strategy-counterfactual-plan` (merged via
+PR #650, 2026-04-28).
 
 ## Blocked on
 
-Human plan review before any implementation begins. Possibly: a
-pure-functional walker for `Weinstein_stops` (PR-2 §Risks item 4 — may
-require a small refactor of stops to expose a non-stateful API; that
-decision belongs to `feat-weinstein` if invoked).
+PR-2 may need a **pure-functional walker for `Weinstein_stops`** (plan
+§Risks item 4 — may require a small refactor of stops to expose a
+non-stateful API; that decision belongs to `feat-weinstein` if invoked).
+PR-1 does not touch stops, so PR-1 is unblocked.
 
 ## Authority docs
 
@@ -88,4 +109,22 @@ decision belongs to `feat-weinstein` if invoked).
 
 ## Completed
 
-(none yet — plan-only)
+- **PR-1** (2026-04-28): `Optimal_types` data model +
+  `Stage_transition_scanner`.
+  - Files added:
+    - `trading/trading/backtest/optimal/lib/dune`
+    - `trading/trading/backtest/optimal/lib/optimal_types.{ml,mli}`
+    - `trading/trading/backtest/optimal/lib/stage_transition_scanner.{ml,mli}`
+    - `trading/trading/backtest/optimal/test/dune`
+    - `trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml`
+  - Coverage: 13 OUnit2 cases — sexp round-trip on each record type;
+    scanner emits one per breakout in arrival order; non-breakouts
+    dropped; `passes_macro` tagging across Bullish/Neutral/Bearish;
+    missing-sector fallback to "Unknown"; entry/stop/risk match screener
+    formulas; multi-week scan_panel concatenation; empty-input edge
+    cases.
+  - Verify:
+    - `dev/lib/run-in-env.sh dune build`
+    - `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/`
+    - `dev/lib/run-in-env.sh dune build @fmt`
+  - Branch / PR: `feat/optimal-strategy-pr1` / PR #652.

--- a/dev/status/optimal-strategy.md
+++ b/dev/status/optimal-strategy.md
@@ -3,11 +3,12 @@
 ## Last updated: 2026-04-28
 
 ## Status
-IN_PROGRESS
+READY_FOR_REVIEW
 
 PR-1 (data model + `Stage_transition_scanner`) implemented and opened
-as draft PR #652 on branch `feat/optimal-strategy-pr1`. PR-2
-(`Outcome_scorer`) is the next slice.
+as PR #652 on branch `feat/optimal-strategy-pr1` — marked ready for
+review (13/13 tests pass; `dune build && dune build @fmt` clean). PR-2
+(`Outcome_scorer`) is the next slice; track stays open.
 
 ## Goal
 

--- a/trading/trading/backtest/optimal/lib/dune
+++ b/trading/trading/backtest/optimal/lib/dune
@@ -1,0 +1,10 @@
+(library
+ (name backtest_optimal)
+ (libraries
+  core
+  trading.base
+  weinstein.screener
+  weinstein.stock_analysis
+  weinstein.types)
+ (preprocess
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/optimal/lib/optimal_types.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_types.ml
@@ -1,0 +1,64 @@
+(** Data model for the optimal-strategy counterfactual.
+
+    See [optimal_types.mli] for the API contract. *)
+
+open Core
+
+type candidate_entry = {
+  symbol : string;
+  entry_week : Date.t;
+  side : Trading_base.Types.position_side;
+  entry_price : float;
+  suggested_stop : float;
+  risk_pct : float;
+  sector : string;
+  cascade_grade : Weinstein_types.grade;
+  passes_macro : bool;
+}
+[@@deriving sexp]
+
+type exit_trigger = Stage3_transition | Stop_hit | End_of_run
+[@@deriving sexp]
+
+type scored_candidate = {
+  entry : candidate_entry;
+  exit_week : Date.t;
+  exit_price : float;
+  exit_trigger : exit_trigger;
+  raw_return_pct : float;
+  hold_weeks : int;
+  initial_risk_per_share : float;
+  r_multiple : float;
+}
+[@@deriving sexp]
+
+type optimal_round_trip = {
+  symbol : string;
+  side : Trading_base.Types.position_side;
+  entry_week : Date.t;
+  entry_price : float;
+  exit_week : Date.t;
+  exit_price : float;
+  exit_trigger : exit_trigger;
+  shares : float;
+  initial_risk_dollars : float;
+  pnl_dollars : float;
+  r_multiple : float;
+  cascade_grade : Weinstein_types.grade;
+  passes_macro : bool;
+}
+[@@deriving sexp]
+
+type optimal_summary = {
+  total_round_trips : int;
+  winners : int;
+  losers : int;
+  total_return_pct : float;
+  win_rate_pct : float;
+  avg_r_multiple : float;
+  profit_factor : float;
+  max_drawdown_pct : float;
+  variant : variant_label;
+}
+
+and variant_label = Constrained | Relaxed_macro [@@deriving sexp]

--- a/trading/trading/backtest/optimal/lib/optimal_types.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_types.mli
@@ -1,0 +1,178 @@
+(** Data model for the optimal-strategy counterfactual.
+
+    Captures the shapes consumed and produced across the four phases of the
+    counterfactual pipeline:
+
+    - Phase A (PR-1): {!Stage_transition_scanner} emits one {!candidate_entry}
+      per (symbol, week) where the system's structural breakout predicate fires.
+    - Phase B (PR-2): the outcome scorer enriches each candidate with the
+      realized exit week / price / R-multiple under the counterfactual exit
+      rule, producing a {!scored_candidate}.
+    - Phase C (PR-3): the greedy filler walks Fridays and produces
+      {!optimal_round_trip}s, which roll up into an {!optimal_summary}.
+
+    Every record derives [sexp_of] / [of_sexp] so that scenario-runner artefacts
+    on disk round-trip across processes — the renderer binary (PR-4) reads its
+    inputs from sibling sexp files alongside [trades.csv] and [summary.sexp].
+
+    Pure data — no I/O, no mutable state. Mirrors the shape discipline of
+    {!Backtest.Trade_audit}'s record types.
+
+    See [dev/plans/optimal-strategy-counterfactual-2026-04-28.md]. *)
+
+open Core
+
+(** {1 Phase A: candidate enumeration} *)
+
+type candidate_entry = {
+  symbol : string;
+  entry_week : Date.t;
+      (** Friday on which the breakout predicate fired. The week's close is the
+          counterfactual entry price. *)
+  side : Trading_base.Types.position_side;
+      (** [Long] for Stage 1 → 2 breakouts, [Short] for Stage 3 → 4 breakdowns.
+          PR-1 only enumerates longs; the [side] field is recorded here for
+          forward-compatibility with the short-side scanner. *)
+  entry_price : float;
+      (** Counterfactual entry price — the breakout-week close. Mirrors the
+          price the live strategy would have used had it acted. *)
+  suggested_stop : float;
+      (** Initial stop level for the counterfactual. Sourced from the same
+          {!Screener.scored_candidate.suggested_stop} computation the live
+          cascade uses, so the counterfactual respects the strategy's stop
+          discipline. *)
+  risk_pct : float;
+      (** [|entry_price - suggested_stop| /. entry_price]. Used by the sizing
+          envelope (Phase C) and the R-multiple computation (Phase B). *)
+  sector : string;
+      (** GICS sector display name. Used by the greedy filler's sector
+          concentration cap. *)
+  cascade_grade : Weinstein_types.grade;
+      (** Cascade grade the live screener would have assigned. Recorded for the
+          per-Friday divergence report (PR-4) so the renderer can attribute
+          missed entries to "filtered by grade threshold". *)
+  passes_macro : bool;
+      (** Whether the macro gate at [entry_week] would have admitted this
+          candidate. The scanner records both passes and fails so the renderer
+          can produce two report variants — constrained (macro gate kept) and
+          relaxed (macro gate dropped). *)
+}
+[@@deriving sexp]
+(** One row per (symbol, week) where the system's structural breakout condition
+    fires. Drops the screener's macro gate / top-N cap / grade threshold — keeps
+    only the breakout predicate plus the sizing-input fields. *)
+
+(** {1 Phase B: scored candidate (forward-declared shape)}
+
+    Filled in by PR-2's [Outcome_scorer]. Listed here because PR-3 / PR-4 need
+    to round-trip these via sexp from a sibling artefact file, so the schema
+    must be stable across PRs.
+
+    The scorer walks forward from [entry.entry_week] applying the counterfactual
+    exit rule (first Stage-3 transition, stop hit, or end-of-run, whichever
+    comes first) and fills in the post-entry fields. *)
+
+(** Why a counterfactual position closed. Mirrors the real strategy's exit
+    triggers but limited to the three the counterfactual can detect from a
+    forward walk over the panel. *)
+type exit_trigger = Stage3_transition | Stop_hit | End_of_run
+[@@deriving sexp]
+
+type scored_candidate = {
+  entry : candidate_entry;  (** The Phase-A row for this candidate. *)
+  exit_week : Date.t;
+      (** Friday on which the position closes under the counterfactual exit
+          rule. *)
+  exit_price : float;
+      (** Close on [exit_week]. The counterfactual exits at weekly closes
+          (mirrors the live stop's weekly-close trigger). *)
+  exit_trigger : exit_trigger;
+      (** Which of the three exit conditions fired first. *)
+  raw_return_pct : float;
+      (** [(exit_price - entry.entry_price) / entry.entry_price] for longs,
+          mirrored for shorts. Sign carries the direction. *)
+  hold_weeks : int;
+      (** Whole weeks between [entry.entry_week] and [exit_week]. *)
+  initial_risk_per_share : float;
+      (** [|entry.entry_price - entry.suggested_stop|]. Used to convert
+          [raw_return_pct] into an R-multiple. *)
+  r_multiple : float;
+      (** [(exit_price - entry.entry_price) / initial_risk_per_share] for longs.
+          Comparable across positions of different sizes / risk profiles — the
+          sort key the greedy filler uses. *)
+}
+[@@deriving sexp]
+(** A {!candidate_entry} enriched with realized counterfactual outcome. *)
+
+(** {1 Phase C: round-trip + summary} *)
+
+type optimal_round_trip = {
+  symbol : string;
+  side : Trading_base.Types.position_side;
+  entry_week : Date.t;
+  entry_price : float;
+  exit_week : Date.t;
+  exit_price : float;
+  exit_trigger : exit_trigger;
+  shares : float;
+      (** Position size the greedy filler chose under the sizing envelope —
+          [risk_per_trade_dollars / initial_risk_per_share], rounded down. *)
+  initial_risk_dollars : float;
+      (** [(entry_price - stop) * shares]. Sets the R-multiple denominator on a
+          dollar basis so [pnl_dollars / initial_risk_dollars] is comparable
+          across positions. *)
+  pnl_dollars : float;  (** [(exit_price - entry_price) * shares] for longs. *)
+  r_multiple : float;
+      (** [pnl_dollars /. initial_risk_dollars]. Equal to the
+          {!scored_candidate} R-multiple modulo rounding when [shares] is
+          bounded by risk only; may differ when cash or sector caps clipped the
+          position. *)
+  cascade_grade : Weinstein_types.grade;
+      (** Carried from the {!candidate_entry}. *)
+  passes_macro : bool;  (** Carried from the {!candidate_entry}. *)
+}
+[@@deriving sexp]
+(** A counterfactual round trip — a candidate that the greedy filler chose to
+    enter and that subsequently closed (or ran to end-of-run). One per closed
+    position in the counterfactual portfolio. *)
+
+type optimal_summary = {
+  total_round_trips : int;
+  winners : int;
+  losers : int;
+  total_return_pct : float;
+      (** Cumulative return on starting capital, expressed as a fraction (e.g.
+          [0.42] = +42%). *)
+  win_rate_pct : float;
+      (** [winners / total_round_trips], 0.0 when there are no round trips. *)
+  avg_r_multiple : float;
+      (** Mean of [round_trip.r_multiple] across closed positions. *)
+  profit_factor : float;
+      (** [sum(positive pnl_dollars) /. sum(|negative pnl_dollars|)]; infinite
+          when there are no losers (encoded as [Float.infinity]). *)
+  max_drawdown_pct : float;
+      (** Peak-to-trough drawdown of the counterfactual equity curve, as a
+          fraction (positive = drawdown). *)
+  variant : variant_label;
+      (** Which variant this summary describes — see {!variant_label}. *)
+}
+[@@deriving sexp]
+(** Aggregate metrics over an [optimal_round_trip list]. Renders into the
+    headline comparison table in [optimal_strategy.md]. *)
+
+(** Which variant of the counterfactual a summary / round-trip set describes.
+
+    The renderer (PR-4) emits a comparison table with columns for both variants;
+    the scanner (PR-1) tags each candidate with [passes_macro] so the downstream
+    pipeline can split rows by variant without re-running Phase A. *)
+and variant_label =
+  | Constrained
+      (** Macro gate honoured — counterfactual only enters candidates whose
+          [passes_macro] flag was [true] at the breakout week. The honest
+          comparison: "what's reachable if cascade ranking were perfect, all
+          else equal?" *)
+  | Relaxed_macro
+      (** Macro gate dropped — every candidate is eligible regardless of regime.
+          The upper bound: "what's reachable if we also relaxed the macro gate?"
+      *)
+[@@deriving sexp]

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -1,0 +1,84 @@
+(** Phase A scanner for the optimal-strategy counterfactual.
+
+    See [stage_transition_scanner.mli] for the API contract.
+
+    Implementation strategy: invoke {!Screener.screen} per Friday with a
+    *permissive* config — [min_grade = F], unlimited top-N, and a forced
+    [Neutral] macro trend — so the cascade emits one [scored_candidate] per
+    breakout-passing analysis without dropping any to grade / top-N / macro
+    gates. The actual macro trend ([week.macro_trend]) is consulted separately
+    to set [passes_macro] on each emitted candidate.
+
+    This keeps the scanner aligned with the live cascade's per-candidate price
+    and grade arithmetic byte-for-byte (it calls the same code) while bypassing
+    the gates the counterfactual deliberately relaxes. *)
+
+open Core
+
+type week_input = {
+  date : Date.t;
+  macro_trend : Weinstein_types.market_trend;
+  analyses : Stock_analysis.t list;
+  sector_map : (string, Screener.sector_context) Hashtbl.t;
+}
+
+type config = {
+  scoring_weights : Screener.scoring_weights;
+  grade_thresholds : Screener.grade_thresholds;
+  candidate_params : Screener.candidate_params;
+}
+
+let config_of_screener_config (c : Screener.config) : config =
+  {
+    scoring_weights = c.weights;
+    grade_thresholds = c.grade_thresholds;
+    candidate_params = c.candidate_params;
+  }
+
+(** Build the permissive {!Screener.config} the scanner uses internally. *)
+let _permissive_screener_config (config : config) : Screener.config =
+  {
+    weights = config.scoring_weights;
+    grade_thresholds = config.grade_thresholds;
+    candidate_params = config.candidate_params;
+    min_grade = F;
+    max_buy_candidates = Int.max_value;
+    max_short_candidates = Int.max_value;
+  }
+
+(** Whether [trend] would have admitted longs at the macro gate. *)
+let _passes_long_macro = function
+  | Weinstein_types.Bullish | Neutral -> true
+  | Bearish -> false
+
+(** Project one {!Screener.scored_candidate} (long side) into an
+    {!Optimal_types.candidate_entry}, stamping the actual macro at [date]. *)
+let _candidate_of_scored ~date ~passes_macro (sc : Screener.scored_candidate) :
+    Optimal_types.candidate_entry =
+  {
+    symbol = sc.ticker;
+    entry_week = date;
+    side = sc.side;
+    entry_price = sc.suggested_entry;
+    suggested_stop = sc.suggested_stop;
+    risk_pct = sc.risk_pct;
+    sector = sc.sector.sector_name;
+    cascade_grade = sc.grade;
+    passes_macro;
+  }
+
+let scan_week ~config (week : week_input) : Optimal_types.candidate_entry list =
+  let permissive = _permissive_screener_config config in
+  (* Force [Neutral] so both long and short cascades stay open; the actual
+     macro is captured per candidate via [passes_macro]. *)
+  let result =
+    Screener.screen ~config:permissive ~macro_trend:Neutral
+      ~sector_map:week.sector_map ~stocks:week.analyses ~held_tickers:[]
+  in
+  let passes_macro = _passes_long_macro week.macro_trend in
+  List.map result.buy_candidates
+    ~f:(_candidate_of_scored ~date:week.date ~passes_macro)
+
+let scan_panel ~config (weeks : week_input list) :
+    Optimal_types.candidate_entry list =
+  List.concat_map weeks ~f:(fun w -> scan_week ~config w)

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.mli
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.mli
@@ -1,0 +1,99 @@
+(** Phase A of the optimal-strategy counterfactual: enumerate breakout
+    candidates from a sequence of per-Friday screener inputs.
+
+    Walks the panel forward week by week. For each Friday and each symbol in the
+    universe, asks the existing {!Stock_analysis.is_breakout_candidate}
+    predicate the same question the live cascade asks today: *is this a breakout
+    candidate this week?*
+
+    Emits one {!Optimal_types.candidate_entry} per (symbol, week) where the
+    predicate fires. Tags each with [passes_macro] so the downstream pipeline
+    can split rows by report variant (constrained vs relaxed-macro) without
+    re-running this phase.
+
+    Drops the screener's macro gate, top-N cap, and grade threshold — keeps only
+    the breakout-condition predicate plus the {!Screener.scored_candidate}
+    sizing-input fields ([suggested_entry], [suggested_stop], [risk_pct]).
+
+    Pure function. The caller owns panel iteration; this module is invoked once
+    per (Friday, list-of-analyses) pair, accumulates candidates across weeks,
+    and returns the full list at the end. The PR-4 binary will wire panel
+    iteration on top.
+
+    See [dev/plans/optimal-strategy-counterfactual-2026-04-28.md] §Phase A. *)
+
+open Core
+
+type week_input = {
+  date : Date.t;  (** Friday on which the analyses below were computed. *)
+  macro_trend : Weinstein_types.market_trend;
+      (** Macro trend at [date]. Used to set [passes_macro] on each candidate
+          emitted from this Friday — does not gate enumeration. *)
+  analyses : Stock_analysis.t list;
+      (** Per-symbol screener inputs at [date]. The scanner consults the
+          breakout predicate ({!Stock_analysis.is_breakout_candidate}) and the
+          screener's per-candidate price helpers — it does NOT score, grade, or
+          rank these analyses. *)
+  sector_map : (string, Screener.sector_context) Hashtbl.t;
+      (** Symbol → sector context. The scanner attaches [sector.sector_name] to
+          each emitted candidate so the greedy filler (Phase C) can apply its
+          sector concentration cap. *)
+}
+(** One Friday's worth of input to the scanner.
+
+    Mirrors the shape the live screener already consumes — a [week_input] can be
+    constructed by the caller from the same panel-derived data the backtest
+    runner already builds when it invokes {!Screener.screen}. The scanner only
+    reads it; the panel-iteration machinery lives in PR-4's binary. *)
+
+type config = {
+  scoring_weights : Screener.scoring_weights;
+      (** Weights used to grade each emitted candidate. The grade is recorded on
+          {!Optimal_types.candidate_entry.cascade_grade} for the renderer (PR-4)
+          and for sanity-check assertions; it does NOT gate enumeration — every
+          breakout-passing candidate is emitted regardless of grade. *)
+  grade_thresholds : Screener.grade_thresholds;
+      (** Score → grade mapping. Same role as [scoring_weights] — used for the
+          recorded [cascade_grade] field, not for filtering. *)
+  candidate_params : Screener.candidate_params;
+      (** Per-candidate price computation parameters. The scanner derives
+          [entry_price], [suggested_stop], and [risk_pct] from these the same
+          way the live screener does. *)
+}
+(** Scanner configuration. Mirrors the relevant subset of {!Screener.config} so
+    the counterfactual can be invoked with byte-identical settings to the
+    backtest run it is comparing against. The omitted fields ([min_grade],
+    [max_buy_candidates], [max_short_candidates]) are precisely the cascade
+    constraints the counterfactual relaxes by design.
+
+    Constructed via {!config_of_screener_config} from a {!Screener.config}. *)
+
+val config_of_screener_config : Screener.config -> config
+(** [config_of_screener_config c] projects a {!Screener.config} down to the
+    subset the scanner needs. Used by the PR-4 binary to build a scanner config
+    from the same screener config the actual run used.
+
+    Drops [min_grade], [max_buy_candidates], and [max_short_candidates] — those
+    are the gates the counterfactual relaxes. *)
+
+val scan_week :
+  config:config -> week_input -> Optimal_types.candidate_entry list
+(** [scan_week ~config week] returns one {!Optimal_types.candidate_entry} per
+    analysis in [week.analyses] that satisfies
+    {!Stock_analysis.is_breakout_candidate}, in the order [week.analyses]
+    arrived.
+
+    Each candidate is enriched with sector context (from [week.sector_map]) and
+    with [passes_macro = (week.macro_trend <> Bearish)] for longs. The scanner
+    does not currently emit short candidates; the [side] field is fixed to
+    [Long]. (PR-1 covers the long-side scanner; the short-side variant is a
+    follow-up.)
+
+    Returns the empty list when [week.analyses] is empty. Pure function. *)
+
+val scan_panel :
+  config:config -> week_input list -> Optimal_types.candidate_entry list
+(** [scan_panel ~config weeks] applies {!scan_week} to every week and
+    concatenates the results in arrival order — equivalent to
+    [List.concat_map weeks ~f:(fun w -> scan_week ~config w)] but reads cleaner
+    at call sites. *)

--- a/trading/trading/backtest/optimal/test/dune
+++ b/trading/trading/backtest/optimal/test/dune
@@ -1,0 +1,16 @@
+(tests
+ (names test_stage_transition_scanner)
+ (libraries
+  ounit2
+  core
+  matchers
+  trading.base
+  weinstein.screener
+  weinstein.stock_analysis
+  weinstein.types
+  weinstein.stage
+  weinstein.rs
+  weinstein.volume
+  backtest_optimal)
+ (preprocess
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml
@@ -1,0 +1,507 @@
+(** Unit tests for [Backtest_optimal.Stage_transition_scanner].
+
+    Covers:
+    - Sexp round-trip on every [Optimal_types] record (forward-compat: PR-3 /
+      PR-4 read sibling artefacts via these schemas).
+    - Scanner emits exactly one [candidate_entry] per breakout-passing analysis,
+      in arrival order.
+    - Symbols whose breakout predicate fails are dropped.
+    - [passes_macro] is set from [week.macro_trend] (true for Bullish/Neutral,
+      false for Bearish), independent of whether the candidate is otherwise
+      admitted.
+    - Sector context is resolved through [sector_map]; missing entries fall back
+      to the "Unknown" stub.
+    - Multi-week scan via [scan_panel] preserves arrival order across weeks.
+    - Empty-universe / empty-week-list edge cases produce empty output. *)
+
+open OUnit2
+open Core
+open Matchers
+module S = Backtest_optimal.Stage_transition_scanner
+module OT = Backtest_optimal.Optimal_types
+
+(* ------------------------------------------------------------------ *)
+(* Builders                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let _date d = Date.of_string d
+
+(** Build a synthetic [Stock_analysis.t] with all required sub-records. The
+    optional parameters let each test override only the fields it cares about —
+    keeps assertions focused on the field(s) under test. *)
+let make_analysis ?(ticker = "AAPL")
+    ?(stage_value =
+      Weinstein_types.Stage2 { weeks_advancing = 2; late = false })
+    ?(prior_stage = Some (Weinstein_types.Stage1 { weeks_in_base = 8 }))
+    ?(ma_value = 100.0) ?(ma_direction = Weinstein_types.Rising)
+    ?(ma_slope_pct = 0.02) ?(volume_quality = Some (Weinstein_types.Strong 2.5))
+    ?(rs_trend = Some Weinstein_types.Positive_rising)
+    ?(breakout_price = Some 105.0) ?(as_of_date = _date "2024-01-19") () :
+    Stock_analysis.t =
+  let stage : Stage.result =
+    {
+      stage = stage_value;
+      ma_value;
+      ma_direction;
+      ma_slope_pct;
+      transition = None;
+      above_ma_count = 5;
+    }
+  in
+  let volume : Volume.result option =
+    Option.map volume_quality ~f:(fun confirmation ->
+        {
+          Volume.confirmation;
+          event_volume = 1_000_000;
+          avg_volume = 500_000.0;
+          volume_ratio =
+            (match confirmation with Strong r | Adequate r | Weak r -> r);
+        })
+  in
+  let rs : Rs.result option =
+    Option.map rs_trend ~f:(fun trend ->
+        { Rs.current_rs = 1.05; current_normalized = 0.5; trend; history = [] })
+  in
+  {
+    ticker;
+    stage;
+    rs;
+    volume;
+    resistance = None;
+    support = None;
+    breakout_price;
+    breakdown_price = None;
+    prior_stage;
+    as_of_date;
+  }
+
+(** Build an analysis that fails [is_breakout_candidate]: Stage 1, no
+    transition, no volume. *)
+let make_non_breakout ?(ticker = "FAIL") () : Stock_analysis.t =
+  make_analysis ~ticker
+    ~stage_value:(Stage1 { weeks_in_base = 4 })
+    ~prior_stage:None ~volume_quality:None ()
+
+(** Build a sector_map populated from [(symbol, sector_name, rating)] triples.
+*)
+let make_sector_map entries : (string, Screener.sector_context) Hashtbl.t =
+  let tbl = Hashtbl.create (module String) in
+  List.iter entries ~f:(fun (sym, sector_name, rating) ->
+      let ctx : Screener.sector_context =
+        {
+          sector_name;
+          rating;
+          stage = Stage2 { weeks_advancing = 4; late = false };
+        }
+      in
+      Hashtbl.set tbl ~key:sym ~data:ctx);
+  tbl
+
+(** Default scanner config — built from [Screener.default_config]. *)
+let default_config = S.config_of_screener_config Screener.default_config
+
+(* ------------------------------------------------------------------ *)
+(* Sexp round-trip — every record type must round-trip cleanly         *)
+(* ------------------------------------------------------------------ *)
+
+let test_candidate_entry_sexp_round_trip _ =
+  let entry : OT.candidate_entry =
+    {
+      symbol = "AAPL";
+      entry_week = _date "2024-01-19";
+      side = Long;
+      entry_price = 105.50;
+      suggested_stop = 97.06;
+      risk_pct = 0.08;
+      sector = "Information Technology";
+      cascade_grade = A;
+      passes_macro = true;
+    }
+  in
+  let round = OT.candidate_entry_of_sexp (OT.sexp_of_candidate_entry entry) in
+  assert_that round
+    (all_of
+       [
+         field (fun (e : OT.candidate_entry) -> e.symbol) (equal_to "AAPL");
+         field
+           (fun (e : OT.candidate_entry) -> e.entry_price)
+           (float_equal 105.50);
+         field
+           (fun (e : OT.candidate_entry) -> e.cascade_grade)
+           (equal_to Weinstein_types.A);
+         field (fun (e : OT.candidate_entry) -> e.passes_macro) (equal_to true);
+       ])
+
+let test_scored_candidate_sexp_round_trip _ =
+  let entry : OT.candidate_entry =
+    {
+      symbol = "MSFT";
+      entry_week = _date "2024-02-02";
+      side = Long;
+      entry_price = 200.0;
+      suggested_stop = 184.0;
+      risk_pct = 0.08;
+      sector = "Information Technology";
+      cascade_grade = B;
+      passes_macro = true;
+    }
+  in
+  let scored : OT.scored_candidate =
+    {
+      entry;
+      exit_week = _date "2024-05-03";
+      exit_price = 240.0;
+      exit_trigger = Stage3_transition;
+      raw_return_pct = 0.20;
+      hold_weeks = 13;
+      initial_risk_per_share = 16.0;
+      r_multiple = 2.5;
+    }
+  in
+  let round =
+    OT.scored_candidate_of_sexp (OT.sexp_of_scored_candidate scored)
+  in
+  assert_that round
+    (all_of
+       [
+         field
+           (fun (s : OT.scored_candidate) -> s.exit_trigger)
+           (equal_to OT.Stage3_transition);
+         field (fun (s : OT.scored_candidate) -> s.r_multiple) (float_equal 2.5);
+         field
+           (fun (s : OT.scored_candidate) -> s.entry.symbol)
+           (equal_to "MSFT");
+       ])
+
+let test_optimal_round_trip_sexp_round_trip _ =
+  let rt : OT.optimal_round_trip =
+    {
+      symbol = "GOOG";
+      side = Long;
+      entry_week = _date "2024-03-01";
+      entry_price = 140.0;
+      exit_week = _date "2024-06-07";
+      exit_price = 155.0;
+      exit_trigger = Stop_hit;
+      shares = 100.0;
+      initial_risk_dollars = 1_120.0;
+      pnl_dollars = 1_500.0;
+      r_multiple = 1.34;
+      cascade_grade = A_plus;
+      passes_macro = false;
+    }
+  in
+  let round =
+    OT.optimal_round_trip_of_sexp (OT.sexp_of_optimal_round_trip rt)
+  in
+  assert_that round
+    (all_of
+       [
+         field
+           (fun (r : OT.optimal_round_trip) -> r.exit_trigger)
+           (equal_to OT.Stop_hit);
+         field
+           (fun (r : OT.optimal_round_trip) -> r.passes_macro)
+           (equal_to false);
+         field
+           (fun (r : OT.optimal_round_trip) -> r.pnl_dollars)
+           (float_equal 1_500.0);
+       ])
+
+let test_optimal_summary_sexp_round_trip _ =
+  let summary : OT.optimal_summary =
+    {
+      total_round_trips = 50;
+      winners = 30;
+      losers = 20;
+      total_return_pct = 0.42;
+      win_rate_pct = 0.60;
+      avg_r_multiple = 1.8;
+      profit_factor = 2.1;
+      max_drawdown_pct = 0.18;
+      variant = Constrained;
+    }
+  in
+  let round = OT.optimal_summary_of_sexp (OT.sexp_of_optimal_summary summary) in
+  assert_that round
+    (all_of
+       [
+         field
+           (fun (s : OT.optimal_summary) -> s.variant)
+           (equal_to OT.Constrained);
+         field
+           (fun (s : OT.optimal_summary) -> s.total_round_trips)
+           (equal_to 50);
+         field
+           (fun (s : OT.optimal_summary) -> s.win_rate_pct)
+           (float_equal 0.60);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Scanner: scan_week                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let test_scan_week_emits_one_per_breakout _ =
+  (* Three analyses: AAPL passes, NOPE fails (Stage 1, no transition),
+     MSFT passes. Expect two candidates emitted, AAPL and MSFT only,
+     in that order. *)
+  let aapl = make_analysis ~ticker:"AAPL" () in
+  let nope = make_non_breakout ~ticker:"NOPE" () in
+  let msft = make_analysis ~ticker:"MSFT" ~breakout_price:(Some 200.0) () in
+  let week : S.week_input =
+    {
+      date = _date "2024-01-19";
+      macro_trend = Bullish;
+      analyses = [ aapl; nope; msft ];
+      sector_map =
+        make_sector_map
+          [
+            ("AAPL", "Information Technology", Strong);
+            ("MSFT", "Information Technology", Strong);
+          ];
+    }
+  in
+  let candidates = S.scan_week ~config:default_config week in
+  assert_that candidates
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (c : OT.candidate_entry) -> c.symbol) (equal_to "AAPL");
+             field
+               (fun (c : OT.candidate_entry) -> c.entry_week)
+               (equal_to (_date "2024-01-19"));
+             field
+               (fun (c : OT.candidate_entry) -> c.side)
+               (equal_to Trading_base.Types.Long);
+             field
+               (fun (c : OT.candidate_entry) -> c.passes_macro)
+               (equal_to true);
+             field
+               (fun (c : OT.candidate_entry) -> c.sector)
+               (equal_to "Information Technology");
+           ];
+         all_of
+           [
+             field (fun (c : OT.candidate_entry) -> c.symbol) (equal_to "MSFT");
+             field
+               (fun (c : OT.candidate_entry) -> c.passes_macro)
+               (equal_to true);
+           ];
+       ])
+
+let test_scan_week_drops_non_breakout _ =
+  let week : S.week_input =
+    {
+      date = _date "2024-01-19";
+      macro_trend = Bullish;
+      analyses =
+        [
+          make_non_breakout ~ticker:"FOO" (); make_non_breakout ~ticker:"BAR" ();
+        ];
+      sector_map = make_sector_map [];
+    }
+  in
+  assert_that (S.scan_week ~config:default_config week) (size_is 0)
+
+let test_scan_week_passes_macro_bearish _ =
+  (* Even when macro is Bearish, the scanner still emits the breakout
+     candidate — but tags [passes_macro = false]. The renderer uses this
+     tag to split between constrained and relaxed-macro variants. *)
+  let week : S.week_input =
+    {
+      date = _date "2024-01-19";
+      macro_trend = Bearish;
+      analyses = [ make_analysis ~ticker:"AAPL" () ];
+      sector_map =
+        make_sector_map [ ("AAPL", "Information Technology", Strong) ];
+    }
+  in
+  assert_that
+    (S.scan_week ~config:default_config week)
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (c : OT.candidate_entry) -> c.symbol) (equal_to "AAPL");
+             field
+               (fun (c : OT.candidate_entry) -> c.passes_macro)
+               (equal_to false);
+           ];
+       ])
+
+let test_scan_week_passes_macro_neutral _ =
+  let week : S.week_input =
+    {
+      date = _date "2024-01-19";
+      macro_trend = Neutral;
+      analyses = [ make_analysis ~ticker:"AAPL" () ];
+      sector_map =
+        make_sector_map [ ("AAPL", "Information Technology", Strong) ];
+    }
+  in
+  assert_that
+    (S.scan_week ~config:default_config week)
+    (elements_are
+       [
+         field (fun (c : OT.candidate_entry) -> c.passes_macro) (equal_to true);
+       ])
+
+let test_scan_week_unknown_sector_falls_back _ =
+  (* No sector_map entry for AAPL — sector should resolve to "Unknown".
+     The screener's defaulting policy is to admit (Neutral rating), so
+     the candidate is still emitted. *)
+  let week : S.week_input =
+    {
+      date = _date "2024-01-19";
+      macro_trend = Bullish;
+      analyses = [ make_analysis ~ticker:"AAPL" () ];
+      sector_map = make_sector_map [];
+    }
+  in
+  assert_that
+    (S.scan_week ~config:default_config week)
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (c : OT.candidate_entry) -> c.symbol) (equal_to "AAPL");
+             field
+               (fun (c : OT.candidate_entry) -> c.sector)
+               (equal_to "Unknown");
+           ];
+       ])
+
+let test_scan_week_empty_analyses _ =
+  let week : S.week_input =
+    {
+      date = _date "2024-01-19";
+      macro_trend = Bullish;
+      analyses = [];
+      sector_map = make_sector_map [];
+    }
+  in
+  assert_that (S.scan_week ~config:default_config week) (size_is 0)
+
+let test_scan_week_emits_entry_and_stop_consistent _ =
+  (* The scanner uses the same per-candidate price formulas as the live
+     screener: suggested_entry = breakout * (1 + entry_buffer_pct), then
+     suggested_stop = entry * (1 - initial_stop_pct), then
+     risk_pct = |entry - stop| / entry.
+     With defaults (0.005 entry buffer, 0.08 initial stop) and
+     breakout_price = 100.0, we expect entry = 100.50, stop = 92.46,
+     risk_pct ≈ 0.08. *)
+  let week : S.week_input =
+    {
+      date = _date "2024-01-19";
+      macro_trend = Bullish;
+      analyses =
+        [ make_analysis ~ticker:"AAPL" ~breakout_price:(Some 100.0) () ];
+      sector_map =
+        make_sector_map [ ("AAPL", "Information Technology", Strong) ];
+    }
+  in
+  assert_that
+    (S.scan_week ~config:default_config week)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : OT.candidate_entry) -> c.entry_price)
+               (float_equal 100.50);
+             field
+               (fun (c : OT.candidate_entry) -> c.suggested_stop)
+               (float_equal ~epsilon:0.01 92.46);
+             field
+               (fun (c : OT.candidate_entry) -> c.risk_pct)
+               (float_equal ~epsilon:0.001 0.08);
+           ];
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Scanner: scan_panel — multi-week aggregation                         *)
+(* ------------------------------------------------------------------ *)
+
+let test_scan_panel_concatenates_in_order _ =
+  let mk_week date_str ticker macro =
+    {
+      S.date = _date date_str;
+      macro_trend = macro;
+      analyses = [ make_analysis ~ticker () ];
+      sector_map =
+        make_sector_map [ (ticker, "Information Technology", Strong) ];
+    }
+  in
+  let weeks =
+    [
+      mk_week "2024-01-19" "AAPL" Bullish;
+      mk_week "2024-01-26" "MSFT" Bearish;
+      mk_week "2024-02-02" "GOOG" Neutral;
+    ]
+  in
+  let candidates = S.scan_panel ~config:default_config weeks in
+  assert_that candidates
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (c : OT.candidate_entry) -> c.symbol) (equal_to "AAPL");
+             field
+               (fun (c : OT.candidate_entry) -> c.passes_macro)
+               (equal_to true);
+           ];
+         all_of
+           [
+             field (fun (c : OT.candidate_entry) -> c.symbol) (equal_to "MSFT");
+             field
+               (fun (c : OT.candidate_entry) -> c.passes_macro)
+               (equal_to false);
+           ];
+         all_of
+           [
+             field (fun (c : OT.candidate_entry) -> c.symbol) (equal_to "GOOG");
+             field
+               (fun (c : OT.candidate_entry) -> c.passes_macro)
+               (equal_to true);
+           ];
+       ])
+
+let test_scan_panel_empty_weeks _ =
+  assert_that (S.scan_panel ~config:default_config []) (size_is 0)
+
+(* ------------------------------------------------------------------ *)
+(* Test suite                                                          *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "Stage_transition_scanner"
+  >::: [
+         "candidate_entry sexp round-trip"
+         >:: test_candidate_entry_sexp_round_trip;
+         "scored_candidate sexp round-trip"
+         >:: test_scored_candidate_sexp_round_trip;
+         "optimal_round_trip sexp round-trip"
+         >:: test_optimal_round_trip_sexp_round_trip;
+         "optimal_summary sexp round-trip"
+         >:: test_optimal_summary_sexp_round_trip;
+         "scan_week emits one per breakout in order"
+         >:: test_scan_week_emits_one_per_breakout;
+         "scan_week drops non-breakout analyses"
+         >:: test_scan_week_drops_non_breakout;
+         "scan_week tags passes_macro = false on Bearish"
+         >:: test_scan_week_passes_macro_bearish;
+         "scan_week tags passes_macro = true on Neutral"
+         >:: test_scan_week_passes_macro_neutral;
+         "scan_week falls back to Unknown sector"
+         >:: test_scan_week_unknown_sector_falls_back;
+         "scan_week empty analyses → empty output"
+         >:: test_scan_week_empty_analyses;
+         "scan_week entry/stop/risk match screener formulas"
+         >:: test_scan_week_emits_entry_and_stop_consistent;
+         "scan_panel concatenates per-week output in order"
+         >:: test_scan_panel_concatenates_in_order;
+         "scan_panel empty weeks → empty output" >:: test_scan_panel_empty_weeks;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

First slice of the optimal-strategy counterfactual track per [`dev/plans/optimal-strategy-counterfactual-2026-04-28.md`](dev/plans/optimal-strategy-counterfactual-2026-04-28.md). Adds the data model and Phase A scanner; PR-2 (Outcome_scorer) is the next slice.

- **`Optimal_types`** — pure data records used across all four phases (`candidate_entry`, `scored_candidate`, `optimal_round_trip`, `optimal_summary`). All round-trip via sexp so PR-4 renderer can read sibling artefacts.
- **`Stage_transition_scanner`** — pure Phase A scanner. Emits one `candidate_entry` per (symbol, week) where `Stock_analysis.is_breakout_candidate` fires. Drops the cascade macro/top-N/grade gates (records macro fact via `passes_macro` for the constrained-vs-relaxed split) but reuses `Screener.screen` so per-candidate price + grade arithmetic matches the live cascade byte-for-byte.
- **Tests** — 13 OUnit2 cases: sexp round-trip on each record type; scanner emits one per breakout in arrival order; non-breakouts dropped; passes_macro tagging across Bullish/Neutral/Bearish; missing-sector fallback to Unknown; entry/stop/risk match screener formulas; multi-week scan_panel concatenation; empty-input edge cases.

## Files added

- `trading/trading/backtest/optimal/lib/dune`
- `trading/trading/backtest/optimal/lib/optimal_types.{ml,mli}`
- `trading/trading/backtest/optimal/lib/stage_transition_scanner.{ml,mli}`
- `trading/trading/backtest/optimal/test/dune`
- `trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml`

## Test plan

- [x] `dev/lib/run-in-env.sh dune build` clean
- [x] `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/` — 13/13 pass
- [x] `dev/lib/run-in-env.sh dune build @fmt` clean
- [x] No edits to existing screener / strategy / portfolio code
- [x] No edits to `dev/status/_index.md`

## Out of scope

- Phase B `Outcome_scorer` — PR-2.
- Phase C `Optimal_portfolio_filler` — PR-3.
- Phase D renderer + binary — PR-4.
- Wiring into release_perf_report — PR-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)