### PR TITLE
docs(notes): sp500-2019-2023 canonical baseline 2026-04-28

### DIFF
--- a/dev/notes/sp500-2019-2023-baseline-canonical-2026-04-28.md
+++ b/dev/notes/sp500-2019-2023-baseline-canonical-2026-04-28.md
@@ -1,0 +1,105 @@
+# sp500-2019-2023 canonical baseline (2026-04-28)
+
+Resolves the multi-measurement conflict logged in
+`dev/notes/session-followups-2026-04-28.md` §3.
+
+## Result (canonical)
+
+Single fresh run on `main@origin = bfbd105f` (post-#651, post-#652, post-#653),
+in-repo fixtures, default config:
+
+| Metric | Value |
+|---|---:|
+| Trades | **134** |
+| Total return | **+70.80 %** |
+| Win rate | **38.06 %** |
+| Max drawdown | **97.69 %** † |
+| Avg holding days | 72.63 |
+| Unrealized PnL (open positions at end) | $1,675,243.14 |
+| Wall time | 2 m 40 s |
+
+† 97.69 % MaxDD is the split-day MtM bug (AAPL 2020-08-31 4:1 split phantom
+crash). Will resolve under the broker-model redesign tracked in PR #656
+(see "Action items" below).
+
+## How to reproduce
+
+```sh
+docker exec trading-1-dev bash -c '
+  cd /workspaces/trading-1/trading && eval $(opam env) &&
+  dune build trading/backtest/scenarios/scenario_runner.exe &&
+  _build/default/trading/backtest/scenarios/scenario_runner.exe \
+    --dir /workspaces/trading-1/trading/test_data/backtest_scenarios/goldens-sp500 \
+    --fixtures-root /workspaces/trading-1/trading/test_data/backtest_scenarios'
+```
+
+- Scenario sexp: `trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp`
+- Universe: `trading/test_data/backtest_scenarios/universes/sp500.sexp` (491 symbols)
+- Period: 2019-01-02 → 2023-12-29 (warmup from 2018-06-06)
+- Calendar: 1453 trading days
+- Panels: 506 symbols × 1453 days × 4 indicator specs
+
+Determinism is pinned by PR #648 (5× repeat → bit-identical). Same
+commit + same scenario reproduces these numbers exactly.
+
+## Reconciling the prior measurements
+
+From the followups note §3 table:
+
+| Prior source | Trades | Return | MaxDD | Status |
+|---|---:|---:|---:|---|
+| `sp500-golden-baseline-2026-04-26.md` | 133 | +18.5 % | 47.6 % | Different commit / pre-#641-bug-surface; trade count ≈ today (134) |
+| `goldens-performance-baselines-2026-04-28.md` | 478 | +70.8 % | 97.7 % | Return + MaxDD reproduce; trade count is the outlier (likely different counting method or scenario file at write time) |
+| Mid-session verify run | 298 | +45.8 % | 22.5 % | Unreproducible; not pursued further |
+| PR #647 bisect (4 SHAs) | 30 | +4.2 % | 5.05 % | Bisect SHAs were on a different scenario or different config; not the canonical scenario |
+| Rebase agent run with #641 applied | 30 | +9.3 % | 4.3 % | With (broken) split-day band-aid → MaxDD drops to 4.3 % but trade count drops to 30; band-aid was over-broad (see PR #641 close + item 1) |
+
+**Canonical interpretation.** The `goldens-performance-baselines-2026-04-28.md`
+return and MaxDD figures (+70.8 % / 97.7 %) reproduce on current main; its
+trade count (478) is the outlier and should be regarded as a measurement
+artefact. The Apr-26 baseline's trade count (133) reproduces (134 today,
+within ±1 — likely a calendar-edge effect). The PR #647 / rebase 30-trade
+results reflect either a different scenario or the broken `_split_adjust_bar`
+band-aid; neither is the canonical baseline.
+
+**Pinned ranges in the scenario sexp are stale.** The current
+`expected` block in `goldens-sp500/sp500-2019-2023.sexp` was authored against
+the Apr-26 baseline (133 / +18.5 % / 47.6 %). Today's run fails 5/5 pinned
+checks:
+
+```
+total_return_pct  high (70.80 > 22.00)
+win_rate          high (38.06 > 33.00)
+max_drawdown_pct  high (97.69 > 55.00)
+avg_holding_days  low  (72.63 <  75.00)
+unrealized_pnl    high (1675243.14 > 1300000.00)
+```
+
+Re-pinning is **deferred** until the split-day broker-model redesign
+(PR #656) lands, because 97.7 % MaxDD is the bug, not the strategy.
+Re-pinning now would freeze the bug into the contract.
+
+## Action items
+
+1. ⏳ **PR #656 (broker-model split-day redesign)** — when it merges,
+   re-run this scenario on the post-#656 main and capture the corrected
+   MaxDD as a new canonical baseline. That replaces this note.
+2. **Then re-pin** `goldens-sp500/sp500-2019-2023.sexp` `expected` ranges
+   against the post-fix numbers (±10–15 % per the scenario's own header
+   comment).
+3. **Trade-count counting method** — the 478 outlier and the 134/133
+   numbers being so close suggests two different counting conventions
+   (entries+exits vs round-trips, or with/without partial exits). Worth
+   a one-line comment in the scenario header next time the file is
+   touched, but not a separate task.
+
+## What this baseline does NOT establish
+
+- Strategy quality vs B&H — the 4/4-window underperformance noted in
+  `dev/notes/goldens-performance-baselines-2026-04-28.md` is independent
+  of the trade-count reconciliation. The trade-audit chain (PR-1..PR-5
+  merged this session) and the optimal-strategy counterfactual (plan
+  #650) are the next-step analysis tools.
+- Tier-4 (N=1000) baseline — that's a separate scenario family;
+  canonical baseline for it is established via the local-only release-gate
+  procedure (PR #655).


### PR DESCRIPTION
## Summary

Resolves the multi-measurement conflict logged in `dev/notes/session-followups-2026-04-28.md` §3.

Single fresh run on `main@origin = bfbd105f` (post-#651/#652/#653), default config, in-repo fixtures:

| Metric | Value |
|---|---:|
| Trades | **134** |
| Total return | **+70.80 %** |
| Win rate | **38.06 %** |
| Max drawdown | **97.69 %** † |
| Avg holding days | 72.63 |

† 97.7 % MaxDD is the split-day MtM bug — resolves under the broker-model redesign in PR #656.

## Reconciles

- `goldens-performance-baselines-2026-04-28.md` return + MaxDD reproduce; trade count 478 was the outlier (likely different counting method)
- `sp500-golden-baseline-2026-04-26.md` trade count 133 ≈ today's 134 (calendar-edge)
- PR #647 / rebase 30-trade results were on a different scenario or with the broken `_split_adjust_bar` band-aid; not canonical

## Action items (in note)

1. After PR #656 (broker-model) merges, re-run + capture corrected MaxDD as the new canonical baseline
2. Re-pin `goldens-sp500/sp500-2019-2023.sexp` `expected` ranges then (currently fails 5/5 against this run because the pins were authored against the Apr-26 measurement)

## Test plan

- [x] Scenario reproducible (PR #648 determinism contract)
- [x] No source code changed
- [x] No status file touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)