### PR TITLE
feat(simulation): split detector primitive (PR-1 of #656)

### DIFF
--- a/trading/analysis/data/types/lib/dune
+++ b/trading/analysis/data/types/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name types)
  (public_name types)
- (modules daily_price cadence instrument_info)
+ (modules daily_price cadence instrument_info split_detector)
  (libraries core ppx_deriving.runtime sexplib)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_hash ppx_sexp_conv ppx_compare)))

--- a/trading/analysis/data/types/lib/split_detector.ml
+++ b/trading/analysis/data/types/lib/split_detector.ml
@@ -1,0 +1,74 @@
+open Core
+
+(* ------------------------------------------------------------------ *)
+(* Defaults                                                             *)
+(* ------------------------------------------------------------------ *)
+
+(* Minimum |split_factor -. 1.0| to treat the day as a split candidate.
+   Splits are always >= 1.5x or <= 0.67x; dividends are typically < 1%. A
+   5% band cleanly separates the two while leaving headroom for thin-bar
+   noise on illiquid names. *)
+let default_dividend_threshold = 0.05
+
+(* Tolerance when matching the raw ratio against [N/M]. Floating-point
+   ratios from real EODHD bars are accurate to several decimals; 1e-3 is
+   tight enough to reject coincidences and loose enough to accept
+   real-world numerical noise. *)
+let default_rational_snap_tolerance = 1e-3
+
+(* Largest denominator considered when snapping. Real splits are tiny
+   rationals — 4:1, 1:5, 3:2, 2:3, 1:10, 1:20. 20 is comfortably above
+   anything we expect to see in practice. *)
+let default_max_denominator = 20
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+(* Guard against degenerate bars: zero or negative prices break the
+   ratio computation and shouldn't ever appear in real data. We treat
+   them as "no detectable split" rather than raising — a bad bar in the
+   feed is not the detector's problem. *)
+let _is_positive x = Float.( > ) x 0.0
+
+let _has_valid_prices ~(prev : Daily_price.t) ~(curr : Daily_price.t) =
+  _is_positive prev.close_price
+  && _is_positive curr.close_price
+  && _is_positive prev.adjusted_close
+  && _is_positive curr.adjusted_close
+
+(* Snap [x] to the nearest rational [N/M] with [1 <= M <= max_denominator]
+   and any positive [N], requiring [|x -. N/M| <= tolerance]. Returns the
+   matched rational as a float, or [None] if no candidate is within
+   tolerance. We pick the smallest denominator that works (lowest
+   complexity), matching how splits are conventionally written. *)
+let _snap_to_rational ~tolerance ~max_denominator x =
+  let best = ref None in
+  for m = 1 to max_denominator do
+    let n = Float.round_nearest (x *. Float.of_int m) in
+    let candidate = n /. Float.of_int m in
+    if Float.( <= ) (Float.abs (x -. candidate)) tolerance then
+      match !best with None -> best := Some candidate | Some _ -> ()
+  done;
+  !best
+
+(* ------------------------------------------------------------------ *)
+(* Detection                                                            *)
+(* ------------------------------------------------------------------ *)
+
+let detect_split ?(dividend_threshold = default_dividend_threshold)
+    ?(rational_snap_tolerance = default_rational_snap_tolerance)
+    ?(max_denominator = default_max_denominator) ~(prev : Daily_price.t)
+    ~(curr : Daily_price.t) () =
+  if not (_has_valid_prices ~prev ~curr) then None
+  else
+    let raw_ratio = curr.close_price /. prev.close_price in
+    let adj_ratio = curr.adjusted_close /. prev.adjusted_close in
+    if Float.( = ) raw_ratio 0.0 then None
+    else
+      let split_factor = adj_ratio /. raw_ratio in
+      if Float.( <= ) (Float.abs (split_factor -. 1.0)) dividend_threshold then
+        None
+      else
+        _snap_to_rational ~tolerance:rational_snap_tolerance ~max_denominator
+          split_factor

--- a/trading/analysis/data/types/lib/split_detector.mli
+++ b/trading/analysis/data/types/lib/split_detector.mli
@@ -1,0 +1,46 @@
+(** Detect stock-split events between consecutive {!Daily_price.t} bars.
+
+    This is the broker-model {b detection} primitive. EODHD daily bars carry
+    both a raw [close_price] (as printed on the day) and an [adjusted_close]
+    that is back-rolled for every future corporate action (splits {e and}
+    dividends). On any non-corporate-action day the ratio
+    [adjusted_close /. close_price] is constant; on a split day it jumps by
+    exactly [1 /. split_factor]. By comparing the day-over-day {b raw} return
+    against the day-over-day {b adjusted} return we can recover [split_factor]
+    without a second data feed.
+
+    The detector discriminates splits from dividends using a tolerance band
+    (dividends produce a small drift, splits produce a {e large} jump that snaps
+    to a small rational [N/M] with [N, M ≤ max_denominator]).
+
+    See [dev/plans/split-day-ohlc-redesign-2026-04-28.md] §Detection. *)
+
+val detect_split :
+  ?dividend_threshold:float ->
+  ?rational_snap_tolerance:float ->
+  ?max_denominator:int ->
+  prev:Daily_price.t ->
+  curr:Daily_price.t ->
+  unit ->
+  float option
+(** Detect a split between two consecutive daily bars.
+
+    Returns [Some factor] where [factor = new_shares /. old_shares] for forward
+    splits ([factor > 1.0], e.g. [4.0] for a 4:1) and reverse splits
+    ([factor < 1.0], e.g. [0.2] for a 1:5). Returns [None] when no split is
+    detected — that includes pure-dividend days, no-corporate-action days, and
+    any day where the implied ratio fails to snap to a small rational [N/M] with
+    [N, M <= max_denominator].
+
+    The caller is responsible for skipping the very first bar of a series (no
+    prior bar to compare against).
+
+    Optional parameters:
+    - [dividend_threshold]: minimum [|split_factor -. 1.0|] required to even
+      consider the day a split candidate. Below this we treat the deviation as a
+      dividend or noise. Default [0.05] (5%).
+    - [rational_snap_tolerance]: maximum absolute distance between the raw ratio
+      and the candidate rational [N/M] for the snap to succeed. Default [1e-3].
+    - [max_denominator]: largest denominator [M] considered when searching for
+      [N/M] approximations. Default [20]. Splits in practice are tiny rationals
+      (4:1, 1:5, 3:2, 2:3, 1:10, etc.). *)

--- a/trading/analysis/data/types/test/dune
+++ b/trading/analysis/data/types/test/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_split_detector)
+ (modules test_split_detector)
+ (libraries core ounit2 matchers types))

--- a/trading/analysis/data/types/test/test_split_detector.ml
+++ b/trading/analysis/data/types/test/test_split_detector.ml
@@ -1,0 +1,161 @@
+open OUnit2
+open Core
+open Matchers
+open Types
+
+(* ------------------------------------------------------------------ *)
+(* Fixture builders                                                     *)
+(* ------------------------------------------------------------------ *)
+
+(* Build a Daily_price.t with the fields the detector reads pinned and
+   the others set to plausible defaults. Only [close_price] and
+   [adjusted_close] matter for detection; OHLV are filled to keep the
+   record well-formed. *)
+let make_bar ~date ~close_price ~adjusted_close : Daily_price.t =
+  {
+    date = Date.of_string date;
+    open_price = close_price;
+    high_price = close_price;
+    low_price = close_price;
+    close_price;
+    adjusted_close;
+    volume = 100_000;
+  }
+
+let detect prev curr = Split_detector.detect_split ~prev ~curr ()
+
+(* ------------------------------------------------------------------ *)
+(* AAPL 2020-08-31 4:1 forward split                                    *)
+(* ------------------------------------------------------------------ *)
+
+(* On 2020-08-28 (last day pre-split) AAPL closed at $499.23 raw, with
+   adjusted_close $124.81 (back-rolled by all post-Aug-2020 actions —
+   primarily the 4:1 itself, plus a few small dividends). On 2020-08-31
+   (split day) it closed at $129.04 both raw and adjusted (the back-roll
+   factor flipped to ~1.0 after the split). The detector should recover
+   factor = 4.0. *)
+let test_aapl_4_to_1_forward_split _ =
+  let prev =
+    make_bar ~date:"2020-08-28" ~close_price:499.23 ~adjusted_close:124.81
+  in
+  let curr =
+    make_bar ~date:"2020-08-31" ~close_price:129.04 ~adjusted_close:129.04
+  in
+  assert_that (detect prev curr) (is_some_and (float_equal 4.0))
+
+(* ------------------------------------------------------------------ *)
+(* TSLA 2020-08-31 5:1 forward split                                    *)
+(* ------------------------------------------------------------------ *)
+
+(* TSLA's 5:1 on the same date. We use a stylised pair where the raw
+   price falls by exactly 5x and adjusted_close is continuous, so the
+   detector recovers factor = 5.0 cleanly. (Real EODHD bars have the
+   same shape modulo ε from intraday move and dividend back-roll — that
+   ε is well within rational_snap_tolerance.) *)
+let test_tsla_5_to_1_forward_split _ =
+  let prev =
+    make_bar ~date:"2020-08-28" ~close_price:2213.40 ~adjusted_close:442.68
+  in
+  let curr =
+    make_bar ~date:"2020-08-31" ~close_price:442.68 ~adjusted_close:442.68
+  in
+  assert_that (detect prev curr) (is_some_and (float_equal 5.0))
+
+(* ------------------------------------------------------------------ *)
+(* 1:5 reverse split                                                    *)
+(* ------------------------------------------------------------------ *)
+
+(* Reverse split: 5 old shares → 1 new share. Raw price goes UP by 5x;
+   adjusted_close stays continuous. Factor = new/old = 1/5 = 0.2. *)
+let test_reverse_split_1_to_5 _ =
+  let prev =
+    make_bar ~date:"2024-01-02" ~close_price:10.00 ~adjusted_close:50.00
+  in
+  let curr =
+    make_bar ~date:"2024-01-03" ~close_price:50.00 ~adjusted_close:50.00
+  in
+  assert_that (detect prev curr) (is_some_and (float_equal 0.2))
+
+(* ------------------------------------------------------------------ *)
+(* 3:2 forward split (boundary)                                         *)
+(* ------------------------------------------------------------------ *)
+
+(* 3:2 means 2 old shares → 3 new shares. Raw price falls by factor 2/3.
+   Detected factor is new/old = 3/2 = 1.5. This is the smallest factor
+   the threshold (5% deviation from 1.0) accepts as a split. *)
+let test_boundary_3_to_2_split _ =
+  let prev =
+    make_bar ~date:"2023-06-01" ~close_price:300.00 ~adjusted_close:200.00
+  in
+  let curr =
+    make_bar ~date:"2023-06-02" ~close_price:200.00 ~adjusted_close:200.00
+  in
+  assert_that (detect prev curr) (is_some_and (float_equal 1.5))
+
+(* ------------------------------------------------------------------ *)
+(* Pure-dividend day (NOT a split)                                      *)
+(* ------------------------------------------------------------------ *)
+
+(* A $0.50 dividend on a $100 stock on the day after ex-div: raw moves
+   from 100.00 → 100.50 (price recovery), adjusted from 99.40 → 100.50
+   (the back-roll factor absorbed the dividend pre-event). The implied
+   "factor" is ~1.006 — well below the 5% threshold, so no split. *)
+let test_dividend_day_not_a_split _ =
+  let prev =
+    make_bar ~date:"2023-04-15" ~close_price:100.00 ~adjusted_close:99.40
+  in
+  let curr =
+    make_bar ~date:"2023-04-16" ~close_price:100.50 ~adjusted_close:100.50
+  in
+  assert_that (detect prev curr) is_none
+
+(* ------------------------------------------------------------------ *)
+(* Quiet day with no corporate action                                   *)
+(* ------------------------------------------------------------------ *)
+
+(* On a no-corporate-action day the back-roll factor is constant: raw
+   and adjusted move by the same percentage. split_factor ≈ 1.0 → None. *)
+let test_quiet_day_no_corporate_action _ =
+  let prev =
+    make_bar ~date:"2023-07-10" ~close_price:150.00 ~adjusted_close:148.50
+  in
+  let curr =
+    make_bar ~date:"2023-07-11" ~close_price:151.50 ~adjusted_close:149.985
+  in
+  assert_that (detect prev curr) is_none
+
+(* ------------------------------------------------------------------ *)
+(* Special-dividend-style large drift that does NOT snap to a small     *)
+(* rational (filtered out by max_denominator)                           *)
+(* ------------------------------------------------------------------ *)
+
+(* A large adjustment with no rational interpretation in [N/M, M ≤ 20]
+   is rejected. Here we engineer split_factor = 1.07 (above 5% threshold
+   but ≈ 15/14 = 1.0714 lies just outside the 1e-3 snap tolerance — and
+   lower-denom rationals like 11/10 = 1.1 are even further off). *)
+let test_unsnappable_drift_not_a_split _ =
+  let prev =
+    make_bar ~date:"2023-05-01" ~close_price:100.00 ~adjusted_close:100.00
+  in
+  let curr =
+    make_bar ~date:"2023-05-02" ~close_price:100.00 ~adjusted_close:107.00
+  in
+  assert_that (detect prev curr) is_none
+
+(* ------------------------------------------------------------------ *)
+(* Test suite registration                                              *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "split_detector"
+  >::: [
+         "aapl 4:1 forward split" >:: test_aapl_4_to_1_forward_split;
+         "tsla 5:1 forward split" >:: test_tsla_5_to_1_forward_split;
+         "1:5 reverse split" >:: test_reverse_split_1_to_5;
+         "boundary 3:2 forward split" >:: test_boundary_3_to_2_split;
+         "dividend day not a split" >:: test_dividend_day_not_a_split;
+         "quiet day no corporate action" >:: test_quiet_day_no_corporate_action;
+         "unsnappable drift not a split" >:: test_unsnappable_drift_not_a_split;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
PR-1 of the broker-model split-day OHLC redesign per [`dev/plans/split-day-ohlc-redesign-2026-04-28.md`](https://github.com/dayfine/trading/blob/main/dev/plans/split-day-ohlc-redesign-2026-04-28.md) (PR #656).

## Summary

- Adds `Split_detector` — a pure-functional primitive that recovers a split factor from two consecutive `Daily_price.t` bars by comparing the day-over-day raw close ratio against the day-over-day adjusted close ratio.
- Discriminates splits from dividends with a 5% deviation threshold and snaps to small rationals `N/M` with `N, M ≤ 20` (1e-3 tolerance) — both configurable via optional parameters.
- Self-contained in `trading/analysis/data/types/lib/`. No simulator/portfolio touches; PR-2 builds the `Split_event` ledger, PR-3 wires both into `Simulator.step`.

## API

```ocaml
val detect_split :
  ?dividend_threshold:float ->
  ?rational_snap_tolerance:float ->
  ?max_denominator:int ->
  prev:Daily_price.t ->
  curr:Daily_price.t ->
  unit ->
  float option
```

`Some 4.0` for a 4:1 forward split, `Some 0.2` for a 1:5 reverse, `None` for dividends, quiet days, or unsnappable drift.

## Test plan

7 OUnit2 cases covering the fixtures pinned in plan §PR-1:

- [x] AAPL 2020-08-31 4:1 forward split (real raw/adjusted pair: 499.23/124.81 → 129.04/129.04) detects `Some 4.0`
- [x] TSLA 2020-08-31 5:1 forward split detects `Some 5.0`
- [x] 1:5 reverse split detects `Some 0.2`
- [x] 3:2 boundary forward split detects `Some 1.5`
- [x] Pure-dividend day (raw `100.00 → 100.50`, adjusted `99.40 → 100.50`) returns `None`
- [x] Quiet no-corporate-action day returns `None`
- [x] Large drift (factor 1.07) that does not snap to any `N/M, M ≤ 20` returns `None`

`dune build && dune runtest analysis/data/types --force` and `dune build @fmt` are clean.

## Out of scope

- `Split_event` ledger (PR-2)
- Simulator integration + re-enabling `test_split_day_mtm.ml` from closed #641 (PR-3)
- sp500 verification + status updates (PR-4)