### PR TITLE
feat(simulation): split-day PR-2 — Split_event ledger primitive

### DIFF
--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -31,7 +31,7 @@ Each row: one line; deeper task detail in the linked status file.
 | [data-layer](data-layer.md) | MERGED | — | — | — |
 | [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |
 | [screener](screener.md) | MERGED | — | — | — |
-| [simulation](simulation.md) | MERGED | — | — | PR #641 (`fix/split-day-mtm`) closed-without-merge 2026-04-28T12:50Z — band-aid was over-broad per `dev/notes/session-followups-2026-04-28.md` §1. Recommended fix is a broker-model redesign (track positions in split-adjusted shares, multiply quantity on actual split day, leave raw OHLC alone); next session should open `dev/plans/split-day-ohlc-redesign-<date>.md`. Not on the orchestrator dispatch surface — human authorship task. |
+| [simulation](simulation.md) | IN_PROGRESS | feat-backtest | feat/split-day-pr2 | Split-day OHLC redesign (`dev/plans/split-day-ohlc-redesign-2026-04-28.md`) in flight. PR-1 (`Split_detector` primitive) merged 2026-04-28 as #658. PR-2 (`Split_event` ledger primitive in `Trading_portfolio`) opened 2026-04-28 on `feat/split-day-pr2` — pure broker-model adjustment, preserves total cost basis, keeps fractional shares. No simulator wiring yet (PR-3). Existing goldens stay bit-identical. |
 
 ## How to use
 

--- a/dev/status/simulation.md
+++ b/dev/status/simulation.md
@@ -1,9 +1,9 @@
 # Status: simulation
 
-## Last updated: 2026-04-14
+## Last updated: 2026-04-28 (split-day OHLC redesign PR-2)
 
 ## Status
-MERGED
+IN_PROGRESS (split-day OHLC redesign in flight on `feat/split-day-pr1..pr4`; previous slices remain MERGED)
 
 ## QC
 overall_qc: APPROVED (Slice 1 + Slice 3)
@@ -53,6 +53,27 @@ The Weinstein work in eng-design-4 adds Weinstein-specific components **on top**
 All slices merged: Slice 1 (#196), Slice 2 (#237, #240, #241, #242), Slice 3 (#246).
 
 ## In Progress
+
+### Split-day OHLC redesign (broker-model approach, supersedes PR #641)
+
+Plan: `dev/plans/split-day-ohlc-redesign-2026-04-28.md`. Four-PR sequence
+landing the broker-model fix to phantom MtM drops on split days.
+
+- PR-1 (split-detector primitive) — MERGED 2026-04-28 as #658
+  (`trading/analysis/data/types/lib/split_detector.{ml,mli}`).
+- PR-2 (split-event ledger primitive) — IN_FLIGHT on `feat/split-day-pr2`.
+  Adds `Trading_portfolio.Split_event` with `apply_to_position` /
+  `apply_to_portfolio`. Pure; preserves total cost basis; keeps
+  fractional shares (matches `Position.quantity : float`). 5 tests cover
+  forward 4:1, reverse 1:5, fractional 3:2, no-op when symbol not held,
+  end-to-end portfolio adjustment. Existing goldens remain bit-identical
+  — no simulator wiring yet.
+- PR-3 (wire detector + ledger into the simulator step) — pending PR-2
+  merge. Will re-enable the regression test from closed #641.
+- PR-4 (sp500 + perf-tier3 verification + status updates) — pending PR-3.
+
+### Other in-flight
+
 - M5 (walk-forward backtest, parameter tuner) is next
 
 ## Blocking Refactors

--- a/trading/trading/portfolio/lib/dune
+++ b/trading/trading/portfolio/lib/dune
@@ -2,6 +2,6 @@
  (public_name trading.portfolio)
  (name trading_portfolio)
  (libraries core trading.base core_unix.time_ns_unix status)
- (modules types portfolio calculations)
+ (modules types portfolio calculations split_event)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/portfolio/lib/split_event.ml
+++ b/trading/trading/portfolio/lib/split_event.ml
@@ -1,0 +1,28 @@
+open Core
+open Types
+
+type t = { symbol : string; date : Date.t; factor : float }
+[@@deriving show, eq, sexp]
+
+(* Multiply a single lot's quantity by [factor]. The lot's [cost_basis] is
+   a TOTAL (not per-share) and stays constant across a split — total dollars
+   committed to the position do not change. The implied per-share cost
+   ([cost_basis /. abs quantity]) therefore divides by [factor], matching
+   broker reality. [acquisition_date] and [lot_id] are unchanged. *)
+let _scale_lot (factor : float) (lot : position_lot) : position_lot =
+  { lot with quantity = lot.quantity *. factor }
+
+let apply_to_position (event : t) (position : portfolio_position) :
+    portfolio_position =
+  { position with lots = List.map position.lots ~f:(_scale_lot event.factor) }
+
+let apply_to_portfolio (event : t) (portfolio : Portfolio.t) : Portfolio.t =
+  match Portfolio.get_position portfolio event.symbol with
+  | None -> portfolio
+  | Some existing ->
+      let updated = apply_to_position event existing in
+      let new_positions =
+        List.map portfolio.positions ~f:(fun p ->
+            if String.equal p.symbol event.symbol then updated else p)
+      in
+      { portfolio with positions = new_positions }

--- a/trading/trading/portfolio/lib/split_event.mli
+++ b/trading/trading/portfolio/lib/split_event.mli
@@ -1,0 +1,42 @@
+(** Split-event ledger primitive — broker-model adjustment for stock splits.
+
+    A {!t} records a corporate-action split for a single symbol: on [date] the
+    issuer multiplied outstanding shares by [factor]
+    ([factor = new_shares /. old_shares]). For a 4:1 forward split, [factor] is
+    [4.0]; for a 1:5 reverse split it is [0.2]; for fractional splits like 3:2
+    it is [1.5].
+
+    Applying a split event to a held position multiplies the share count by
+    [factor] and divides the per-share cost basis by [factor], preserving total
+    cost basis. Fractional shares are kept as-is — {!Types.position_lot}'s
+    [quantity] is a [float]. The lots' [acquisition_date] is unchanged.
+
+    PR-2 establishes this primitive but does not invoke it from the simulator.
+    The simulator wiring is PR-3 of the broker-model redesign — see
+    [dev/plans/split-day-ohlc-redesign-2026-04-28.md] §PR-3. *)
+
+open Trading_base.Types
+open Types
+
+type t = {
+  symbol : symbol;
+  date : Core.Date.t;
+  factor : float;  (** [new_shares /. old_shares]; positive, non-zero. *)
+}
+[@@deriving show, eq, sexp]
+
+val apply_to_position : t -> portfolio_position -> portfolio_position
+(** [apply_to_position event position] applies a split to a single position.
+    Each lot's [quantity] is multiplied by [event.factor]; each lot's
+    [cost_basis] (a {e total}, not per-share) is unchanged because total cost
+    basis is preserved across a split. The per-share cost (recoverable as
+    [cost_basis /. abs quantity]) is therefore divided by [factor]. The
+    position's [symbol], [accounting_method], and each lot's [lot_id] +
+    [acquisition_date] are unchanged. Pure. *)
+
+val apply_to_portfolio : t -> Portfolio.t -> Portfolio.t
+(** [apply_to_portfolio event portfolio] applies the split to the portfolio's
+    held position for [event.symbol], if any. If no position is held for that
+    symbol, returns the portfolio unchanged (cash, positions, trade history,
+    accounting method all preserved). Pure; returns a new portfolio. Cash and
+    [trade_history] are never modified — splits do not generate trades. *)

--- a/trading/trading/portfolio/test/dune
+++ b/trading/trading/portfolio/test/dune
@@ -8,4 +8,6 @@
 
 (test
  (name test_split_event)
- (libraries ounit2 trading.portfolio trading.base matchers))
+ (libraries ounit2 trading.portfolio trading.base matchers)
+ (preprocess
+  (pps ppx_test_matcher)))

--- a/trading/trading/portfolio/test/dune
+++ b/trading/trading/portfolio/test/dune
@@ -5,3 +5,7 @@
 (test
  (name test_calculations)
  (libraries ounit2 trading.portfolio trading.base matchers))
+
+(test
+ (name test_split_event)
+ (libraries ounit2 trading.portfolio trading.base matchers))

--- a/trading/trading/portfolio/test/test_split_event.ml
+++ b/trading/trading/portfolio/test/test_split_event.ml
@@ -1,0 +1,187 @@
+open Core
+open OUnit2
+open Trading_base.Types
+open Trading_portfolio.Types
+open Trading_portfolio.Calculations
+module Portfolio = Trading_portfolio.Portfolio
+module Split_event = Trading_portfolio.Split_event
+open Matchers
+
+(* Test fixture: synthesize a single-lot position with the given quantity and
+   per-share cost. Mirrors the helper in test_calculations.ml. *)
+let make_position ~symbol ~quantity ~avg_cost =
+  let total_cost_basis = Float.abs quantity *. avg_cost in
+  let lot =
+    {
+      lot_id = "lot1";
+      quantity;
+      cost_basis = total_cost_basis;
+      acquisition_date = Date.create_exn ~y:2024 ~m:Jan ~d:15;
+    }
+  in
+  { symbol; lots = [ lot ]; accounting_method = AverageCost }
+
+let split_date = Date.create_exn ~y:2024 ~m:Jun ~d:10
+
+(* Forward 4:1 split on a held position: quantity ×4, per-share cost ÷4,
+   total cost basis preserved. Lot metadata (lot_id, acquisition_date)
+   unchanged. *)
+let test_forward_4_to_1 _ =
+  let position = make_position ~symbol:"AAPL" ~quantity:100.0 ~avg_cost:150.0 in
+  let event =
+    { Split_event.symbol = "AAPL"; date = split_date; factor = 4.0 }
+  in
+  let result = Split_event.apply_to_position event position in
+  assert_that result
+    (all_of
+       [
+         field (fun p -> p.symbol) (equal_to "AAPL");
+         field (fun p -> p.accounting_method) (equal_to AverageCost);
+         field position_quantity (float_equal 400.0);
+         field avg_cost_of_position (float_equal 37.5);
+         field position_cost_basis (float_equal 15000.0);
+         field
+           (fun p -> p.lots)
+           (elements_are
+              [
+                all_of
+                  [
+                    field (fun l -> l.lot_id) (equal_to "lot1");
+                    field (fun l -> l.quantity) (float_equal 400.0);
+                    field (fun l -> l.cost_basis) (float_equal 15000.0);
+                    field
+                      (fun l -> l.acquisition_date)
+                      (equal_to (Date.create_exn ~y:2024 ~m:Jan ~d:15));
+                  ];
+              ]);
+       ])
+
+(* Reverse 1:5 split: 500 → 100 shares; per-share cost $10 → $50; total
+   cost basis preserved at $5,000. *)
+let test_reverse_1_to_5 _ =
+  let position = make_position ~symbol:"BRKB" ~quantity:500.0 ~avg_cost:10.0 in
+  let event =
+    { Split_event.symbol = "BRKB"; date = split_date; factor = 0.2 }
+  in
+  let result = Split_event.apply_to_position event position in
+  assert_that result
+    (all_of
+       [
+         field position_quantity (float_equal 100.0);
+         field avg_cost_of_position (float_equal 50.0);
+         field position_cost_basis (float_equal 5000.0);
+       ])
+
+(* Split applied to a portfolio that does not hold the symbol: portfolio is
+   returned unchanged (cash, positions, trade history, accounting method
+   all preserved). *)
+let test_no_op_when_symbol_not_held _ =
+  let portfolio =
+    Portfolio.create ~accounting_method:AverageCost ~initial_cash:10000.0 ()
+  in
+  let buy_trade =
+    {
+      id = "t1";
+      order_id = "o1";
+      symbol = "MSFT";
+      side = Buy;
+      quantity = 50.0;
+      price = 200.0;
+      commission = 0.0;
+      timestamp = Time_ns_unix.now ();
+    }
+  in
+  let portfolio_with_msft =
+    match Portfolio.apply_trades portfolio [ buy_trade ] with
+    | Ok p -> p
+    | Error err -> assert_failure ("Failed to apply trade: " ^ Status.show err)
+  in
+  let event =
+    { Split_event.symbol = "AAPL"; date = split_date; factor = 4.0 }
+  in
+  let result = Split_event.apply_to_portfolio event portfolio_with_msft in
+  assert_that result (equal_to portfolio_with_msft)
+
+(* Fractional 3:2 split (factor 1.5): 100 shares → 150 shares (integer in
+   this case), per-share cost $60 → $40. Pin a non-integer outcome too:
+   75 shares × 1.5 = 112.5 fractional shares, with cost basis preserved. *)
+let test_fractional_3_to_2_split _ =
+  let position = make_position ~symbol:"GOOG" ~quantity:75.0 ~avg_cost:60.0 in
+  let event =
+    { Split_event.symbol = "GOOG"; date = split_date; factor = 1.5 }
+  in
+  let result = Split_event.apply_to_position event position in
+  assert_that result
+    (all_of
+       [
+         field position_quantity (float_equal 112.5);
+         field avg_cost_of_position (float_equal 40.0);
+         field position_cost_basis (float_equal 4500.0);
+       ])
+
+(* End-to-end portfolio adjustment: held position is rescaled, cash
+   unchanged, trade_history unchanged, accounting_method unchanged. *)
+let test_apply_to_portfolio_rescales_held_position _ =
+  let portfolio =
+    Portfolio.create ~accounting_method:AverageCost ~initial_cash:20000.0 ()
+  in
+  let buy_trade =
+    {
+      id = "t1";
+      order_id = "o1";
+      symbol = "AAPL";
+      side = Buy;
+      quantity = 100.0;
+      price = 150.0;
+      commission = 0.0;
+      timestamp = Time_ns_unix.now ();
+    }
+  in
+  let portfolio_with_aapl =
+    match Portfolio.apply_trades portfolio [ buy_trade ] with
+    | Ok p -> p
+    | Error err -> assert_failure ("Failed to apply trade: " ^ Status.show err)
+  in
+  let event =
+    { Split_event.symbol = "AAPL"; date = split_date; factor = 4.0 }
+  in
+  let result = Split_event.apply_to_portfolio event portfolio_with_aapl in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (p : Portfolio.t) -> p.current_cash)
+           (float_equal portfolio_with_aapl.current_cash);
+         field
+           (fun (p : Portfolio.t) -> p.initial_cash)
+           (float_equal portfolio_with_aapl.initial_cash);
+         field
+           (fun (p : Portfolio.t) -> p.accounting_method)
+           (equal_to AverageCost);
+         field
+           (fun (p : Portfolio.t) -> List.length p.trade_history)
+           (equal_to (List.length portfolio_with_aapl.trade_history));
+         field
+           (fun (p : Portfolio.t) ->
+             Portfolio.get_position p "AAPL"
+             |> Option.value_map ~default:0.0 ~f:position_quantity)
+           (float_equal 400.0);
+         field
+           (fun (p : Portfolio.t) ->
+             Portfolio.get_position p "AAPL"
+             |> Option.value_map ~default:0.0 ~f:avg_cost_of_position)
+           (float_equal 37.5);
+       ])
+
+let suite =
+  "test_split_event"
+  >::: [
+         "test_forward_4_to_1" >:: test_forward_4_to_1;
+         "test_reverse_1_to_5" >:: test_reverse_1_to_5;
+         "test_no_op_when_symbol_not_held" >:: test_no_op_when_symbol_not_held;
+         "test_fractional_3_to_2_split" >:: test_fractional_3_to_2_split;
+         "test_apply_to_portfolio_rescales_held_position"
+         >:: test_apply_to_portfolio_rescales_held_position;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/portfolio/test/test_split_event.ml
+++ b/trading/trading/portfolio/test/test_split_event.ml
@@ -7,6 +7,26 @@ module Portfolio = Trading_portfolio.Portfolio
 module Split_event = Trading_portfolio.Split_event
 open Matchers
 
+(* Re-declare the production records to get exhaustive matcher generation
+   via [ppx_test_matcher]. If a field is added or removed in
+   [Trading_portfolio.Types], these declarations stop compiling — that's
+   the exhaustiveness guarantee, and every call to [match_*] below has to
+   handle the new field explicitly (or with [__]). *)
+type position_lot = Trading_portfolio.Types.position_lot = {
+  lot_id : lot_id;
+  quantity : quantity;
+  cost_basis : float;
+  acquisition_date : Date.t;
+}
+[@@deriving test_matcher]
+
+type portfolio_position = Trading_portfolio.Types.portfolio_position = {
+  symbol : symbol;
+  lots : position_lot list;
+  accounting_method : accounting_method;
+}
+[@@deriving test_matcher]
+
 (* Test fixture: synthesize a single-lot position with the given quantity and
    per-share cost. Mirrors the helper in test_calculations.ml. *)
 let make_position ~symbol ~quantity ~avg_cost =
@@ -33,28 +53,16 @@ let test_forward_4_to_1 _ =
   in
   let result = Split_event.apply_to_position event position in
   assert_that result
-    (all_of
-       [
-         field (fun p -> p.symbol) (equal_to "AAPL");
-         field (fun p -> p.accounting_method) (equal_to AverageCost);
-         field position_quantity (float_equal 400.0);
-         field avg_cost_of_position (float_equal 37.5);
-         field position_cost_basis (float_equal 15000.0);
-         field
-           (fun p -> p.lots)
-           (elements_are
-              [
-                all_of
-                  [
-                    field (fun l -> l.lot_id) (equal_to "lot1");
-                    field (fun l -> l.quantity) (float_equal 400.0);
-                    field (fun l -> l.cost_basis) (float_equal 15000.0);
-                    field
-                      (fun l -> l.acquisition_date)
-                      (equal_to (Date.create_exn ~y:2024 ~m:Jan ~d:15));
-                  ];
-              ]);
-       ])
+    (match_portfolio_position ~symbol:(equal_to "AAPL")
+       ~accounting_method:(equal_to AverageCost)
+       ~lots:
+         (elements_are
+            [
+              match_position_lot ~lot_id:(equal_to "lot1")
+                ~quantity:(float_equal 400.0) ~cost_basis:(float_equal 15000.0)
+                ~acquisition_date:
+                  (equal_to (Date.create_exn ~y:2024 ~m:Jan ~d:15));
+            ]))
 
 (* Reverse 1:5 split: 500 → 100 shares; per-share cost $10 → $50; total
    cost basis preserved at $5,000. *)


### PR DESCRIPTION
## Summary

PR-2 of the split-day OHLC redesign — adds the broker-model **position-adjustment ledger primitive** alongside `Portfolio` (per CLAUDE.md "build alongside, don't modify"). Pairs with `Split_detector` from PR-1 (#658). Plan: `dev/plans/split-day-ohlc-redesign-2026-04-28.md` §PR-2.

- New module `Trading_portfolio.Split_event`:
  - `type t = { symbol; date; factor }`
  - `apply_to_position : t -> portfolio_position -> portfolio_position` — multiplies each lot's `quantity` by `factor`. `cost_basis` is a total (not per-share) and is preserved across a split, so the implied per-share cost (`cost_basis / abs quantity`) divides by `factor` automatically. `lot_id` and `acquisition_date` are unchanged.
  - `apply_to_portfolio : t -> Portfolio.t -> Portfolio.t` — applies to the held position iff symbol matches; cash, trade history, and accounting method are never touched (splits do not generate trades). Pure; returns a new portfolio.
- **Fractional shares** are kept (matches existing `Position.quantity : float`). Pinned by `test_fractional_3_to_2_split`: `75.0 * 1.5 = 112.5`, no rounding.

## What's not in this PR

PR-2 establishes the ledger primitive but does **not invoke it from the simulator**. Existing `test_weinstein_backtest`, `test_panel_loader_parity`, and all goldens stay bit-identical to `main`. Wiring is PR-3 (per plan §PR-3).

## Test plan

5 new tests in `trading/trading/portfolio/test/test_split_event.ml`:

- [x] `test_forward_4_to_1` — 4:1 forward split: 100 → 400 shares, $150 → $37.50/share, total cost basis preserved at $15,000. Lot metadata (`lot_id`, `acquisition_date`) unchanged.
- [x] `test_reverse_1_to_5` — 1:5 reverse split: 500 → 100 shares, $10 → $50/share, total cost basis preserved at $5,000.
- [x] `test_no_op_when_symbol_not_held` — split for a symbol the portfolio doesn't hold returns the portfolio unchanged (full structural equality).
- [x] `test_fractional_3_to_2_split` — fractional 3:2 (factor 1.5) on 75 shares: 112.5 fractional shares preserved, $60 → $40/share, total cost basis preserved at $4,500.
- [x] `test_apply_to_portfolio_rescales_held_position` — end-to-end: applies a 4:1 split via `apply_to_portfolio` on a portfolio holding 100 AAPL @ $150. Verifies cash, `initial_cash`, `accounting_method`, `trade_history` length all unchanged, and the held position rescales to 400 @ $37.50.

Verify locally:

```bash
dune build && dune runtest trading/portfolio
dune build @fmt
```

Followed `.claude/rules/test-patterns.md`: one `assert_that` per value, composed via `all_of` + `field`, no nested asserts.
