### PR TITLE
feat(simulation): PR-3 — split detection + ledger wired into simulator step

### DIFF
--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -31,7 +31,7 @@ Each row: one line; deeper task detail in the linked status file.
 | [data-layer](data-layer.md) | MERGED | — | — | — |
 | [portfolio-stops](portfolio-stops.md) | MERGED | — | — | — |
 | [screener](screener.md) | MERGED | — | — | — |
-| [simulation](simulation.md) | IN_PROGRESS | feat-backtest | feat/split-day-pr2 | Split-day OHLC redesign (`dev/plans/split-day-ohlc-redesign-2026-04-28.md`) in flight. PR-1 (`Split_detector` primitive) merged 2026-04-28 as #658. PR-2 (`Split_event` ledger primitive in `Trading_portfolio`) opened 2026-04-28 on `feat/split-day-pr2` — pure broker-model adjustment, preserves total cost basis, keeps fractional shares. No simulator wiring yet (PR-3). Existing goldens stay bit-identical. |
+| [simulation](simulation.md) | IN_PROGRESS | feat-backtest | feat/split-day-pr3 | Split-day OHLC redesign (`dev/plans/split-day-ohlc-redesign-2026-04-28.md`) in flight. PR-1 (`Split_detector` primitive) merged 2026-04-28 as #658. PR-2 (`Split_event` ledger primitive in `Trading_portfolio`) merged 2026-04-28 as #662. PR-3 (wire detector + ledger into `Simulator.step`) opened 2026-04-28 on `feat/split-day-pr3` — adds `Market_data_adapter.get_previous_bar`, a `splits_applied` field on `step_result`, and split detection at the start of each step before strategy invocation. Bars themselves untouched; existing goldens (`test_weinstein_backtest`, `test_panel_loader_parity`) stay bit-identical. PR-4 (sp500 + perf-tier3 verification) pending PR-3 merge. |
 
 ## How to use
 

--- a/dev/status/simulation.md
+++ b/dev/status/simulation.md
@@ -1,9 +1,9 @@
 # Status: simulation
 
-## Last updated: 2026-04-28 (split-day OHLC redesign PR-2)
+## Last updated: 2026-04-28
 
 ## Status
-IN_PROGRESS (split-day OHLC redesign in flight on `feat/split-day-pr1..pr4`; previous slices remain MERGED)
+IN_PROGRESS
 
 ## QC
 overall_qc: APPROVED (Slice 1 + Slice 3)
@@ -61,15 +61,20 @@ landing the broker-model fix to phantom MtM drops on split days.
 
 - PR-1 (split-detector primitive) — MERGED 2026-04-28 as #658
   (`trading/analysis/data/types/lib/split_detector.{ml,mli}`).
-- PR-2 (split-event ledger primitive) — IN_FLIGHT on `feat/split-day-pr2`.
-  Adds `Trading_portfolio.Split_event` with `apply_to_position` /
-  `apply_to_portfolio`. Pure; preserves total cost basis; keeps
-  fractional shares (matches `Position.quantity : float`). 5 tests cover
-  forward 4:1, reverse 1:5, fractional 3:2, no-op when symbol not held,
-  end-to-end portfolio adjustment. Existing goldens remain bit-identical
-  — no simulator wiring yet.
-- PR-3 (wire detector + ledger into the simulator step) — pending PR-2
-  merge. Will re-enable the regression test from closed #641.
+- PR-2 (split-event ledger primitive) — MERGED 2026-04-28 as #662
+  (`trading/trading/portfolio/lib/split_event.{ml,mli}`).
+- PR-3 (wire detector + ledger into the simulator step) — IN_FLIGHT on
+  `feat/split-day-pr3`. Adds `Price_cache.get_previous_bar` /
+  `Market_data_adapter.get_previous_bar`, a `splits_applied :
+  Split_event.t list` field on `step_result`, and a
+  `_detect_splits_for_held_positions` step in `Simulator.step` that
+  fires before strategy invocation. `_to_price_bar`,
+  `_compute_portfolio_value`, `_make_get_price` are unchanged — bars
+  themselves are untouched, only the position ledger is adjusted on
+  splits. New regression test `test_split_day_mtm.ml` (3 cases: 4:1
+  continuity, no-split window unchanged, split day with no held
+  position). Existing pinned goldens (`test_weinstein_backtest`,
+  `test_panel_loader_parity`) bit-identical; verified locally.
 - PR-4 (sp500 + perf-tier3 verification + status updates) — pending PR-3.
 
 ### Other in-flight

--- a/trading/trading/backtest/test/test_runner_filter.ml
+++ b/trading/trading/backtest/test/test_runner_filter.ml
@@ -45,6 +45,7 @@ let _make_step_with_trades ~date ~portfolio ~trades =
     portfolio_value = portfolio.Trading_portfolio.Portfolio.current_cash;
     trades;
     orders_submitted = [];
+    splits_applied = [];
   }
 
 (* -------------------------------------------------------------------- *)

--- a/trading/trading/simulation/lib/data/market_data_adapter.ml
+++ b/trading/trading/simulation/lib/data/market_data_adapter.ml
@@ -20,6 +20,9 @@ let get_price t ~symbol ~date =
      after first symbol load, with no per-call allocation. *)
   Price_cache.get_price_on_date t.price_cache ~symbol ~date
 
+let get_previous_bar t ~symbol ~date =
+  Price_cache.get_previous_bar t.price_cache ~symbol ~date
+
 let get_indicator t ~symbol ~indicator_name ~period ~cadence ~date =
   let spec = Indicator_manager.{ name = indicator_name; period; cadence } in
   match

--- a/trading/trading/simulation/lib/data/market_data_adapter.mli
+++ b/trading/trading/simulation/lib/data/market_data_adapter.mli
@@ -35,6 +35,12 @@ val get_price : t -> symbol:string -> date:Date.t -> Types.Daily_price.t option
 
     Returns None if symbol not found or no price for that date. *)
 
+val get_previous_bar :
+  t -> symbol:string -> date:Date.t -> Types.Daily_price.t option
+(** Get the most recent bar for [symbol] strictly before [date], or [None] if
+    none exists. Used by split detection in the simulator step to compare
+    today's bar against the prior trading day. *)
+
 val get_indicator :
   t ->
   symbol:string ->

--- a/trading/trading/simulation/lib/data/price_cache.ml
+++ b/trading/trading/simulation/lib/data/price_cache.ml
@@ -80,6 +80,29 @@ let get_price_on_date t ~symbol ~date =
   | None -> None
   | Some tbl -> Hashtbl.find tbl date
 
+(* Walk the cached price list (sorted oldest first) and return the last
+   bar with [bar.date < date], or [None] if no such bar exists. We use
+   the list rather than [by_date] because we need a "<" lookup, not "=".
+   The list is small enough per-symbol (a few thousand bars at most) and
+   the iteration is O(n) but bounded; in the simulator's hot loop this
+   is called at most once per (held symbol, day) pair. *)
+let get_previous_bar t ~symbol ~date =
+  let prices_result =
+    match Hashtbl.find t.cache symbol with
+    | Some cached -> Ok cached
+    | None -> _load_symbol t symbol
+  in
+  match prices_result with
+  | Error _ -> None
+  | Ok prices ->
+      List.fold prices ~init:None ~f:(fun acc (bar : Types.Daily_price.t) ->
+          if Date.( < ) bar.date date then
+            match acc with
+            | None -> Some bar
+            | Some prev when Date.( > ) bar.date prev.date -> Some bar
+            | Some _ -> acc
+          else acc)
+
 let preload_symbols t symbols =
   let results =
     List.map symbols ~f:(fun symbol ->

--- a/trading/trading/simulation/lib/data/price_cache.mli
+++ b/trading/trading/simulation/lib/data/price_cache.mli
@@ -50,6 +50,14 @@ val get_price_on_date :
     [Result]-based load path is in {!get_prices}; callers that need the load
     error still go through that one. *)
 
+val get_previous_bar :
+  t -> symbol:string -> date:Date.t -> Types.Daily_price.t option
+(** Return the most recent bar for [symbol] strictly before [date], or [None] if
+    no such bar exists (symbol failed to load, [date] precedes the first bar,
+    etc.). Used by split detection to compare today's bar against the prior
+    trading day, since calendar days without bars (weekends, holidays) must be
+    skipped. Errors during load collapse to [None]. *)
+
 val preload_symbols : t -> string list -> (unit, Status.t) Result.t
 (** Preload data for multiple symbols upfront.
 

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -275,22 +275,62 @@ let _apply_trades_best_effort portfolio trades =
       | Ok p -> (p, accepted @ [ trade ])
       | Error _ -> (portfolio, accepted))
 
+(* Detect a split for [symbol] between the prior trading day's bar and
+   today's bar. Returns [Some event] when both bars exist and the detector
+   fires, otherwise [None]. Pure with respect to the adapter's cache. *)
+let _detect_split_for_held_symbol ~adapter ~date ~symbol =
+  let curr =
+    Trading_simulation_data.Market_data_adapter.get_price adapter ~symbol ~date
+  in
+  let prev =
+    Trading_simulation_data.Market_data_adapter.get_previous_bar adapter ~symbol
+      ~date
+  in
+  let%bind.Option curr in
+  let%bind.Option prev in
+  let%map.Option factor = Types.Split_detector.detect_split ~prev ~curr () in
+  { Trading_portfolio.Split_event.symbol; date; factor }
+
+(* For every symbol currently held in [portfolio], compare the prior
+   trading day's bar against the current day's bar and return the list of
+   detected split events. Symbols with no current bar (weekends/holidays)
+   or no prior bar (first appearance) yield no event. Order follows
+   [portfolio.positions] (sorted by symbol). *)
+let _detect_splits_for_held_positions t =
+  let adapter = t.deps.market_data_adapter in
+  let date = t.current_date in
+  List.filter_map t.portfolio.Trading_portfolio.Portfolio.positions
+    ~f:(fun (pos : Trading_portfolio.Types.portfolio_position) ->
+      _detect_split_for_held_symbol ~adapter ~date ~symbol:pos.symbol)
+
+(* Apply each detected split event to [portfolio] in order. Pure: returns
+   the updated portfolio with all events folded in. *)
+let _apply_split_events portfolio events =
+  List.fold events ~init:portfolio ~f:(fun acc event ->
+      Trading_portfolio.Split_event.apply_to_portfolio event acc)
+
 let step t =
   if _is_complete t then Ok (Completed (_build_run_result t))
   else
     let open Result.Let_syntax in
+    (* Detect and apply split events before anything else in the step.
+       Splits multiply held quantities so MtM at today's (post-split) close
+       is continuous with yesterday's close × yesterday's quantity. The fix
+       is purely in the portfolio ledger; bars themselves are unchanged. *)
+    let split_events = _detect_splits_for_held_positions t in
+    let portfolio = _apply_split_events t.portfolio split_events in
     let today_bars = _get_today_bars t in
     Trading_engine.Engine.update_market t.deps.engine today_bars;
     let%bind execution_reports =
       Trading_engine.Engine.process_orders t.deps.engine t.deps.order_manager
     in
     let all_trades = _extract_trades execution_reports in
-    let portfolio, trades = _apply_trades_best_effort t.portfolio all_trades in
+    let portfolio, trades = _apply_trades_best_effort portfolio all_trades in
     let%bind positions =
       _update_positions_from_trades ~date:t.current_date ~positions:t.positions
         ~trades
     in
-    let%bind transitions = _call_strategy { t with positions } in
+    let%bind transitions = _call_strategy { t with portfolio; positions } in
     let%bind positions = _apply_transitions ~positions ~transitions in
     let%bind orders =
       Order_generator.transitions_to_orders ~positions transitions
@@ -302,6 +342,7 @@ let step t =
         portfolio_value = _compute_portfolio_value ~portfolio ~today_bars;
         trades;
         orders_submitted = _submit_orders t orders;
+        splits_applied = split_events;
       }
     in
     let t' =

--- a/trading/trading/simulation/lib/types/simulator_types.ml
+++ b/trading/trading/simulation/lib/types/simulator_types.ml
@@ -21,6 +21,7 @@ type step_result = {
   portfolio_value : float;
   trades : Trading_base.Types.trade list;
   orders_submitted : Trading_orders.Types.order list;
+  splits_applied : Trading_portfolio.Split_event.t list;
 }
 [@@deriving show, eq]
 

--- a/trading/trading/simulation/lib/types/simulator_types.mli
+++ b/trading/trading/simulation/lib/types/simulator_types.mli
@@ -31,6 +31,10 @@ type step_result = {
       (** Trades from orders that filled during this step *)
   orders_submitted : Trading_orders.Types.order list;
       (** Orders submitted for execution on the next step *)
+  splits_applied : Trading_portfolio.Split_event.t list;
+      (** Split events detected and applied to held positions at the start of
+          this step, in detection order. Empty on non-split days (the common
+          case). Used for diagnostics and parity checks. *)
 }
 [@@deriving show, eq]
 (** Result of a single simulation step *)

--- a/trading/trading/simulation/test/dune
+++ b/trading/trading/simulation/test/dune
@@ -127,3 +127,19 @@
   weinstein_trading.portfolio_risk
   ounit2
   matchers))
+
+(test
+ (name test_split_day_mtm)
+ (modules test_split_day_mtm)
+ (libraries
+  ounit2
+  core
+  trading.simulation
+  trading.simulation.types
+  trading.base
+  trading.engine
+  trading.portfolio
+  trading.strategy
+  types
+  matchers
+  simulation_test_helpers))

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -99,7 +99,14 @@ let test_summary_stats_to_metrics _ =
 (* Helper to create a mock step_result *)
 let make_step_result ~date ~portfolio_value =
   let portfolio = Trading_portfolio.Portfolio.create ~initial_cash:10000.0 () in
-  { date; portfolio; portfolio_value; trades = []; orders_submitted = [] }
+  {
+    date;
+    portfolio;
+    portfolio_value;
+    trades = [];
+    orders_submitted = [];
+    splits_applied = [];
+  }
 
 let make_config () =
   {
@@ -413,6 +420,7 @@ let test_profit_factor_all_winners _ =
         portfolio_value = 10000.0;
         trades = [ buy_trade ];
         orders_submitted = [];
+        splits_applied = [];
       };
       {
         date = date_of_string "2024-01-10";
@@ -420,6 +428,7 @@ let test_profit_factor_all_winners _ =
         portfolio_value = 10100.0;
         trades = [ sell_trade ];
         orders_submitted = [];
+        splits_applied = [];
       };
     ]
   in
@@ -561,6 +570,7 @@ let test_portfolio_state_with_trades _ =
         portfolio_value = 10000.0;
         trades = [ trade ];
         orders_submitted = [];
+        splits_applied = [];
       };
       {
         date = date_of_string "2024-01-05";
@@ -568,6 +578,7 @@ let test_portfolio_state_with_trades _ =
         portfolio_value = 10050.0;
         trades = [ trade; trade ];
         orders_submitted = [];
+        splits_applied = [];
       };
     ]
   in
@@ -625,6 +636,7 @@ let test_portfolio_state_skips_non_trading_final_step _ =
         portfolio_value = mtm_value;
         trades = [];
         orders_submitted = [];
+        splits_applied = [];
       };
       {
         (* Non-trading day — simulator fell back to cash. *)
@@ -633,6 +645,7 @@ let test_portfolio_state_skips_non_trading_final_step _ =
         portfolio_value = cash;
         trades = [];
         orders_submitted = [];
+        splits_applied = [];
       };
     ]
   in
@@ -664,6 +677,7 @@ let test_portfolio_state_uses_last_step_when_all_trading_days _ =
         portfolio_value = cash +. 500.0;
         trades = [];
         orders_submitted = [];
+        splits_applied = [];
       };
       {
         date = date_of_string "2024-01-06";
@@ -671,6 +685,7 @@ let test_portfolio_state_uses_last_step_when_all_trading_days _ =
         portfolio_value = cash +. 800.0;
         trades = [];
         orders_submitted = [];
+        splits_applied = [];
       };
     ]
   in

--- a/trading/trading/simulation/test/test_simulator.ml
+++ b/trading/trading/simulation/test/test_simulator.ml
@@ -54,7 +54,14 @@ let make_expected_step_result ~date ~portfolio ?portfolio_value ~trades
     Option.value portfolio_value
       ~default:portfolio.Trading_portfolio.Portfolio.current_cash
   in
-  { date; portfolio; portfolio_value; trades; orders_submitted }
+  {
+    date;
+    portfolio;
+    portfolio_value;
+    trades;
+    orders_submitted;
+    splits_applied = [];
+  }
 
 (* Custom matchers for step_outcome *)
 let is_stepped f = function

--- a/trading/trading/simulation/test/test_split_day_mtm.ml
+++ b/trading/trading/simulation/test/test_split_day_mtm.ml
@@ -1,0 +1,375 @@
+(** Regression: split-day mark-to-market on open positions.
+
+    Bug: prior to PR-3 of the broker-model split redesign,
+    [Simulator._compute_portfolio_value] used [Daily_price.close_price] (raw,
+    unadjusted) to mark held positions to market, but the position quantity
+    stored in [Trading_portfolio.Portfolio.positions] was the
+    pre-corporate-action share count. On the day of a stock split, the raw close
+    drops by the split factor (e.g. AAPL 4:1 on 2020-08-31: $499.23 → $129.04)
+    while the held quantity is still the pre-split count, so a position held
+    through the split sees a phantom one-day MtM crash even though the holder's
+    economic value is unchanged. Surfaced on the sp500-2019-2023 golden as a
+    2020-08-27..2020-08-31 equity-curve dip from ~$520K to ~$25K and back to
+    ~$1.06M.
+
+    Fix (PR-3): at the start of each daily step, before strategy invocation or
+    order processing, [Simulator] runs [Split_detector.detect_split] on every
+    held symbol's (yesterday, today) bar pair. When a split is detected, the
+    simulator builds a [Split_event.t] and applies it to the portfolio via
+    [Split_event.apply_to_portfolio], which multiplies the lot's quantity by the
+    split factor while preserving total cost basis. On the split day, the
+    post-split (×4) quantity multiplied by the post-split (÷4) close exactly
+    cancels — portfolio value is continuous.
+
+    The bar data itself is unchanged (no [_split_adjust_bar]); only the position
+    ledger is touched. This keeps non-split-day output bit-identical to
+    pre-broker-model main, so existing pinned goldens
+    ([test_weinstein_backtest], [test_panel_loader_parity]) are stable. *)
+
+open OUnit2
+open Core
+open Trading_simulation.Simulator
+open Matchers
+open Test_helpers
+module Split_event = Trading_portfolio.Split_event
+
+let _date s = Date.of_string s
+
+(** Build a [Daily_price.t] with explicit raw OHLC and adjusted close. *)
+let _make_bar ~date ~open_ ~high ~low ~close ~adjusted_close ~volume =
+  Types.Daily_price.
+    {
+      date;
+      open_price = open_;
+      high_price = high;
+      low_price = low;
+      close_price = close;
+      adjusted_close;
+      volume;
+    }
+
+(** Synthetic AAPL-like CSV spanning a 4:1 split.
+
+    Pre-split (4 days): closes around $500. The adjusted_close on every
+    pre-split day is split-back-rolled to ~$125, so the adjusted series is
+    monotonic and continuous through the split.
+
+    Split day (2020-08-31): raw close drops 4× to $125 while adjusted_close
+    stays continuous at $125. The detector reads
+    [adj_ratio /. raw_ratio = 1.0 / 0.25 = 4.0] and snaps it to the rational
+    [4/1].
+
+    Post-split (1 day): another flat $125 day to confirm continuity persists. *)
+let _split_aapl_prices =
+  [
+    _make_bar ~date:(_date "2020-08-25") ~open_:498.0 ~high:500.0 ~low:495.0
+      ~close:500.0 ~adjusted_close:125.0 ~volume:1_000_000;
+    _make_bar ~date:(_date "2020-08-26") ~open_:500.0 ~high:506.0 ~low:498.0
+      ~close:504.0 ~adjusted_close:126.0 ~volume:1_000_000;
+    _make_bar ~date:(_date "2020-08-27") ~open_:504.0 ~high:508.0 ~low:496.0
+      ~close:500.0 ~adjusted_close:125.0 ~volume:1_000_000;
+    _make_bar ~date:(_date "2020-08-28") ~open_:500.0 ~high:502.0 ~low:498.0
+      ~close:500.0 ~adjusted_close:125.0 ~volume:1_000_000;
+    (* Split day: 4:1 forward — raw ÷4, adjusted continuous. *)
+    _make_bar ~date:(_date "2020-08-31") ~open_:125.0 ~high:127.0 ~low:124.0
+      ~close:125.0 ~adjusted_close:125.0 ~volume:4_000_000;
+    _make_bar ~date:(_date "2020-09-01") ~open_:125.0 ~high:126.0 ~low:124.0
+      ~close:125.0 ~adjusted_close:125.0 ~volume:4_000_000;
+  ]
+
+(** Default config for the split-day scenario. 100,000 cash, zero commission so
+    we can pin portfolio_value precisely. *)
+let _split_config =
+  {
+    start_date = _date "2020-08-25";
+    end_date = _date "2020-09-02";
+    initial_cash = 100_000.0;
+    commission = { Trading_engine.Types.per_share = 0.0; minimum = 0.0 };
+    strategy_cadence = Types.Cadence.Daily;
+  }
+
+(** Strategy that buys [target_quantity] shares of [symbol] on its first
+    invocation (using today's bar as context) and then holds passively. No exits
+    — lets the simulator walk through every day so we can observe split-day MtM
+    behaviour on a held position. *)
+module Make_buy_and_hold (Cfg : sig
+  val symbol : string
+  val target_quantity : float
+end) : Trading_strategy.Strategy_interface.STRATEGY = struct
+  let name = "BuyAndHold"
+  let entered = ref false
+
+  let on_market_close ~get_price ~get_indicator:_ ~portfolio:_ =
+    if !entered then Ok { Trading_strategy.Strategy_interface.transitions = [] }
+    else
+      match get_price Cfg.symbol with
+      | None -> Ok { Trading_strategy.Strategy_interface.transitions = [] }
+      | Some (bar : Types.Daily_price.t) ->
+          entered := true;
+          let open Trading_strategy.Position in
+          let trans =
+            {
+              position_id = Cfg.symbol ^ "-hold";
+              date = bar.date;
+              kind =
+                CreateEntering
+                  {
+                    symbol = Cfg.symbol;
+                    side = Long;
+                    target_quantity = Cfg.target_quantity;
+                    entry_price = bar.close_price;
+                    reasoning =
+                      TechnicalSignal
+                        { indicator = "test"; description = "buy-and-hold" };
+                  };
+            }
+          in
+          Ok { Trading_strategy.Strategy_interface.transitions = [ trans ] }
+end
+
+(** Largest absolute one-day fractional drop in [step.portfolio_value] across
+    consecutive trading-day steps with open positions. Skips:
+    - steps where the portfolio holds no position (no MtM to check);
+    - steps where [portfolio_value ~ current_cash] (the simulator falls back to
+      [portfolio_value = cash] on non-trading days / when bars are missing, a
+      known artefact unrelated to the split bug). *)
+let _max_one_day_drop steps =
+  let values =
+    List.filter_map steps
+      ~f:(fun (s : Trading_simulation_types.Simulator_types.step_result) ->
+        let cash = s.portfolio.Trading_portfolio.Portfolio.current_cash in
+        let has_pos =
+          not (List.is_empty s.portfolio.Trading_portfolio.Portfolio.positions)
+        in
+        let is_marked = Float.(abs (s.portfolio_value -. cash) > 1e-2) in
+        if has_pos && is_marked && Float.(s.portfolio_value > 0.0) then
+          Some s.portfolio_value
+        else None)
+  in
+  match values with
+  | [] | [ _ ] -> 0.0
+  | first :: rest ->
+      let _, max_drop =
+        List.fold rest ~init:(first, 0.0) ~f:(fun (prev, max_d) curr ->
+            let drop = (prev -. curr) /. prev in
+            (curr, Float.max max_d drop))
+      in
+      max_drop
+
+(** Fetch the simulator step for a specific date. Fails the test if the date is
+    missing from [steps]. *)
+let _step_on ~date steps =
+  match
+    List.find steps
+      ~f:(fun (s : Trading_simulation_types.Simulator_types.step_result) ->
+        Date.equal s.date date)
+  with
+  | Some s -> s
+  | None ->
+      assert_failure
+        (Printf.sprintf "no step on %s; have %d steps" (Date.to_string date)
+           (List.length steps))
+
+(* ------------------------------------------------------------------ *)
+(* Test 1: portfolio value continuous through a 4:1 split              *)
+(* ------------------------------------------------------------------ *)
+
+(** With 100 shares held through a 4:1 split:
+
+    - Day 1 (08-25): strategy submits a 100-share entry; order pending.
+    - Day 2 (08-26): order fills at open=500, cash=100,000-50,000=50,000.
+      Position: 100 shares. Close=504. portfolio_value=50,000+50,400=100,400.
+    - Days 3-4: position unchanged at 100 shares × close.
+    - Day 5 (08-31, split day): detector fires. After
+      [Split_event.apply_to_portfolio], position becomes 400 shares with the
+      same total cost basis 50,000 (per-share cost: 500 → 125). Today's
+      close=125. portfolio_value = 50,000 + 400 × 125 = 100,000.
+    - Day 6 (09-01): 50,000 + 400 × 125 = 100,000 still.
+
+    Pre-fix: day 5's portfolio_value would have been 50,000 + 100 × 125 = 62,500
+    — a 37.5% one-day drop. Post-fix: 0% drop. The 5% threshold cleanly
+    separates the two regimes. *)
+let test_portfolio_value_continuous_through_split _ =
+  with_test_data "split_day_mtm_continuous"
+    [ ("AAPL", _split_aapl_prices) ]
+    ~f:(fun data_dir ->
+      let module Hold = Make_buy_and_hold (struct
+        let symbol = "AAPL"
+        let target_quantity = 100.0
+      end) in
+      let deps =
+        create_deps ~symbols:[ "AAPL" ] ~data_dir
+          ~strategy:(module Hold)
+          ~commission:_split_config.commission ()
+      in
+      let sim = create_exn ~config:_split_config ~deps in
+      let result =
+        match run sim with
+        | Ok r -> r
+        | Error err -> assert_failure ("simulation failed: " ^ Status.show err)
+      in
+      (* Smoke: simulation produced ≥ 6 trading days of output and the
+         held position survived to the end of the window. *)
+      let last = List.last_exn result.steps in
+      assert_that last.portfolio.positions (size_is 1);
+      (* No phantom MtM drop on the split day. Pre-fix this would be 37.5%;
+         post-fix it should be effectively zero. *)
+      assert_that (_max_one_day_drop result.steps) (lt (module Float_ord) 0.05);
+      (* Pinned values: split-day portfolio_value = $100,000 (50,000 cash +
+         400 shares × $125), continuous with day 4's $100,000. Post-split
+         day still $100,000. Both pinned to 1¢ tolerance. *)
+      let split_day = _step_on ~date:(_date "2020-08-31") result.steps in
+      assert_that split_day
+        (all_of
+           [
+             field
+               (fun s -> s.portfolio_value)
+               (float_equal ~epsilon:0.01 100_000.0);
+             field (fun s -> List.length s.splits_applied) (equal_to 1);
+             field
+               (fun s -> s.splits_applied)
+               (elements_are
+                  [
+                    all_of
+                      [
+                        field (fun e -> e.Split_event.symbol) (equal_to "AAPL");
+                        field (fun e -> e.Split_event.factor) (float_equal 4.0);
+                        field
+                          (fun e -> e.Split_event.date)
+                          (equal_to (_date "2020-08-31"));
+                      ];
+                  ]);
+           ]);
+      let post_split = _step_on ~date:(_date "2020-09-01") result.steps in
+      assert_that post_split
+        (all_of
+           [
+             field
+               (fun s -> s.portfolio_value)
+               (float_equal ~epsilon:0.01 100_000.0);
+             field (fun s -> List.length s.splits_applied) (equal_to 0);
+           ]))
+
+(* ------------------------------------------------------------------ *)
+(* Test 2: no-split window is bit-identical to pre-broker-model main   *)
+(* ------------------------------------------------------------------ *)
+
+(** When [adjusted_close = close_price] for every bar (no split, no dividend in
+    window), the broker-model fix is a no-op: the detector never fires, no
+    [Split_event] is produced, and the simulator's per-step output matches what
+    it would have been before PR-3.
+
+    Verifies bit-equality on a no-strategy run: 3 trading days of
+    [Noop_strategy], no positions,
+    [portfolio_value = current_cash = initial_cash] every step. The point of
+    this test is the negative result — [splits_applied] is empty on every step.
+*)
+let test_no_split_window_unchanged _ =
+  let no_split_prices =
+    [
+      _make_bar ~date:(_date "2024-01-02") ~open_:150.0 ~high:155.0 ~low:149.0
+        ~close:154.0 ~adjusted_close:154.0 ~volume:1_000_000;
+      _make_bar ~date:(_date "2024-01-03") ~open_:154.0 ~high:158.0 ~low:153.0
+        ~close:157.0 ~adjusted_close:157.0 ~volume:1_200_000;
+      _make_bar ~date:(_date "2024-01-04") ~open_:157.0 ~high:160.0 ~low:155.0
+        ~close:159.0 ~adjusted_close:159.0 ~volume:900_000;
+    ]
+  in
+  with_test_data "split_day_mtm_no_split"
+    [ ("AAPL", no_split_prices) ]
+    ~f:(fun data_dir ->
+      let config =
+        {
+          start_date = _date "2024-01-02";
+          end_date = _date "2024-01-05";
+          initial_cash = 10_000.0;
+          commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 };
+          strategy_cadence = Types.Cadence.Daily;
+        }
+      in
+      let deps =
+        create_deps ~symbols:[ "AAPL" ] ~data_dir
+          ~strategy:(module Noop_strategy)
+          ~commission:config.commission ()
+      in
+      let sim = create_exn ~config ~deps in
+      let result =
+        match run sim with
+        | Ok r -> r
+        | Error err -> assert_failure ("simulation failed: " ^ Status.show err)
+      in
+      (* Every step: portfolio_value = initial cash (no positions ever),
+         and no split events. *)
+      let expected_step =
+        all_of
+          [
+            field
+              (fun (s : Trading_simulation_types.Simulator_types.step_result) ->
+                s.portfolio_value)
+              (float_equal 10_000.0);
+            field (fun s -> s.splits_applied) (size_is 0);
+          ]
+      in
+      assert_that result.steps
+        (elements_are
+           (List.init (List.length result.steps) ~f:(fun _ -> expected_step))))
+
+(* ------------------------------------------------------------------ *)
+(* Test 3: split day for a symbol NOT in the portfolio is a no-op      *)
+(* ------------------------------------------------------------------ *)
+
+(** Distinguishes the broker-model fix from the band-aid (the closed PR #641's
+    [_split_adjust_bar], which rescaled bars universe-wide for any symbol with a
+    future corporate action). The broker model only touches the portfolio on
+    splits for {b held} symbols.
+
+    Setup: same 4:1-split AAPL CSV as test 1, but the strategy does nothing — we
+    never enter a position. The simulator should produce 0 split events on every
+    step (the detector still has data to read, but
+    [_detect_splits_for_held_positions] iterates only over held positions and
+    the held set is always empty). Cash and position ledger are unchanged from
+    initial. *)
+let test_split_day_with_no_position_held _ =
+  with_test_data "split_day_mtm_no_position"
+    [ ("AAPL", _split_aapl_prices) ]
+    ~f:(fun data_dir ->
+      let deps =
+        create_deps ~symbols:[ "AAPL" ] ~data_dir
+          ~strategy:(module Noop_strategy)
+          ~commission:_split_config.commission ()
+      in
+      let sim = create_exn ~config:_split_config ~deps in
+      let result =
+        match run sim with
+        | Ok r -> r
+        | Error err -> assert_failure ("simulation failed: " ^ Status.show err)
+      in
+      (* Every step: no positions, portfolio_value = initial cash, no split
+         events recorded — the split is observable in the bars but the
+         broker model only acts on held symbols. *)
+      let expected_step =
+        all_of
+          [
+            field
+              (fun (s : Trading_simulation_types.Simulator_types.step_result) ->
+                s.portfolio_value)
+              (float_equal _split_config.initial_cash);
+            field (fun s -> List.length s.portfolio.positions) (equal_to 0);
+            field (fun s -> s.splits_applied) (size_is 0);
+          ]
+      in
+      assert_that result.steps
+        (elements_are
+           (List.init (List.length result.steps) ~f:(fun _ -> expected_step))))
+
+let suite =
+  "split_day_mtm"
+  >::: [
+         "portfolio_value_continuous_through_split"
+         >:: test_portfolio_value_continuous_through_split;
+         "no_split_window_unchanged" >:: test_no_split_window_unchanged;
+         "split_day_with_no_position_held"
+         >:: test_split_day_with_no_position_held;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- Wire `Split_detector` (PR-1, #658) and `Split_event` (PR-2, #662) into `Simulator.step`. At the start of each daily step, before strategy invocation and order processing, the simulator iterates over every held symbol, asks the detector whether yesterday's bar vs today's bar is a split, and applies any detected event to the broker portfolio via `Split_event.apply_to_portfolio` (lot quantity multiplied by the split factor; total cost basis preserved).
- Fixes the split-day mark-to-market bug originally surfaced by closed PR #641: on the day of a 4:1 split, the raw close drops 75% but the held quantity was unchanged, causing a phantom 75% one-day MtM crash. Post-fix, quantity ×4 and price ÷4 cancel — `portfolio_value` is continuous through the split.
- `_to_price_bar`, `_compute_portfolio_value`, `_make_get_price` are unchanged. Bars themselves are never rescaled — the fix is purely in the position-quantity ledger. Non-split-day output is therefore bit-identical to pre-broker-model main, so existing pinned goldens (`test_weinstein_backtest`, `test_panel_loader_parity`) stay stable.

## What's added

- `Price_cache.get_previous_bar` and `Market_data_adapter.get_previous_bar` — fetch the most recent bar with `date < target` for a symbol, used by split detection to handle the simulator's calendar-day stepping (weekends/holidays don't have bars).
- `step_result.splits_applied : Split_event.t list` — diagnostics. Empty on every non-split day (the common case). Used by tests to pin which symbols had a split detected and at what factor.
- `Simulator._detect_split_for_held_symbol` and `_detect_splits_for_held_positions` — the detection helpers wired into `step` before `_get_today_bars`.
- `test_split_day_mtm.ml` — 3 cases:
  - `test_portfolio_value_continuous_through_split`: 100 shares held through a 4:1 split. Pins post-fix `portfolio_value` to $100,000 on both the split day and the day after, asserts `splits_applied = [{symbol=AAPL; factor=4.0; date=2020-08-31}]`.
  - `test_no_split_window_unchanged`: 3 trading days with `adjusted_close = close_price` everywhere. Detector never fires; every step's `splits_applied` is empty.
  - `test_split_day_with_no_position_held`: same 4:1-split CSV, but the strategy never enters. Distinguishes broker-model (per-held-symbol detection) from band-aid (universe-wide rescale) — `splits_applied` is empty on every step.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest trading/simulation/test` passes
- [x] `dune build @fmt` clean
- [x] `test_weinstein_backtest` passes bit-identically
- [x] `test_panel_loader_parity` passes bit-identically (verified locally with `TRADING_DATA_DIR=/workspaces/trading-1/trading/test_data`)
- [x] `test_split_day_mtm` (3 cases) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
