### PR TITLE
feat(optimal): PR-4b — optimal_strategy.exe binary scaffold

### DIFF
--- a/dev/status/optimal-strategy.md
+++ b/dev/status/optimal-strategy.md
@@ -1,18 +1,19 @@
 # Status: optimal-strategy
 
-## Last updated: 2026-04-28 (post run-2)
+## Last updated: 2026-04-29 (PR-4b in flight)
 
 ## Status
-IN_PROGRESS
+READY_FOR_REVIEW
 
-PR-1 (#652), PR-2 (#659), and PR-3 (#663) all merged into `main`. PR-4
-(`Optimal_strategy_report` renderer + smoke tests) is open as a partial
-landing on branch `feat/optimal-strategy-pr4`. The renderer + smoke tests
-ship in this PR; the binary (`optimal_strategy.exe`) and the deeper
-fixture tests are deferred — see
-`dev/notes/optimal-strategy-pr4-followups-2026-04-28.md` for the
-follow-up surface (PR-4b for the bin, ~150–200 LOC; optional follow-up
-B for fuller renderer fixture tests).
+PR-1 (#652), PR-2 (#659), PR-3 (#663), and PR-4 (#665) all merged into
+`main`. PR-4b (`optimal_strategy.exe` binary scaffold) is open as PR
+#666 on branch `feat/optimal-strategy-pr4b`. The bin wires the existing
+pure-functional optimal-lib pipeline (scanner → scorer → filler →
+summary → renderer) to disk artefacts and emits
+`<output_dir>/optimal_strategy.md`. The synthetic-panel smoke test and
+the deeper renderer fixture tests remain as a follow-up commit on the
+same branch / PR-4 followup B respectively — see
+`dev/notes/optimal-strategy-pr4-followups-2026-04-28.md`.
 
 ## Goal
 
@@ -95,9 +96,13 @@ ready to start once PR-3 lands.
       determinism, trailing newline). 45/45 pass across the optimal track.
       The binary + deeper fixture tests are deferred to PR-4b — see
       `dev/notes/optimal-strategy-pr4-followups-2026-04-28.md`.
-- [ ] **PR-4b**: `optimal_strategy.exe` binary (panel loading + pipeline
-      orchestration), plus fuller per-Friday divergence + missed-trade
-      ordering fixture tests. ~250 LOC. Deferred per PR-4 followups note.
+- [~] **PR-4b**: `optimal_strategy.exe` binary (panel loading + pipeline
+      orchestration). In flight on `feat/optimal-strategy-pr4b` / PR #666.
+      Bin scaffold + `bin/dune` shipped; panel-walking smoke test deferred
+      to a follow-up commit on the same branch (writing real artefacts to
+      a tmp dir is the cheapest path; needs panel CSV fixtures). The
+      fuller per-Friday divergence + missed-trade ordering renderer
+      fixture tests remain pending and stay attached to PR-4 followup B.
 - [ ] **PR-5** (optional): wire into `release_perf_report` so each
       scenario emits the counterfactual delta. ~200 LOC.
 
@@ -201,3 +206,29 @@ consumes scorer output as opaque exit fields.
     - `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/`
     - `dev/lib/run-in-env.sh dune build @fmt`
   - Branch / PR: `feat/optimal-strategy-pr3` / PR #TBD.
+
+- **PR-4b** (2026-04-29, in flight): `optimal_strategy.exe` binary —
+  thin orchestration wrapper that wires the existing pure-functional
+  optimal-lib pipeline (scanner → scorer → filler ×2 → summary ×2) to
+  artefacts on disk and emits `<output_dir>/optimal_strategy.md`.
+  - Files added:
+    - `trading/trading/backtest/optimal/bin/dune`
+    - `trading/trading/backtest/optimal/bin/optimal_strategy.ml`
+  - Coverage: existing 45/45 optimal-track tests still pass; no new
+    unit tests in this commit. Smoke test (synthetic-panel fixture
+    invoking `main`) deferred to a follow-up commit on the same branch.
+  - Macro-trend simplification: bin uses fixed `Neutral` for every
+    Friday because run artefacts don't persist per-Friday macro state.
+    `Constrained` and `Relaxed_macro` therefore tag every candidate
+    identically until macro persistence lands; the headline
+    cascade-ranking comparison is unaffected. Documented in the bin's
+    docstring.
+  - Cascade rejections sourced from `trade_audit.sexp`'s
+    `alternatives_considered` when present; missing-audit case passes
+    `[]` and the renderer drops rejection annotations from missed-trade
+    rows.
+  - Verify:
+    - `dev/lib/run-in-env.sh dune build`
+    - `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/`
+    - `dev/lib/run-in-env.sh dune build @fmt`
+  - Branch / PR: `feat/optimal-strategy-pr4b` / PR #666.

--- a/dev/status/optimal-strategy.md
+++ b/dev/status/optimal-strategy.md
@@ -1,6 +1,6 @@
 # Status: optimal-strategy
 
-## Last updated: 2026-04-29 (PR-4b in flight)
+## Last updated: 2026-04-29
 
 ## Status
 READY_FOR_REVIEW

--- a/trading/trading/backtest/optimal/bin/dune
+++ b/trading/trading/backtest/optimal/bin/dune
@@ -1,0 +1,24 @@
+(executable
+ (name optimal_strategy)
+ (modules optimal_strategy)
+ (libraries
+  core
+  core_unix
+  core_unix.sys_unix
+  fpath
+  trading.base
+  trading.data_panel
+  trading.simulation
+  types
+  weinstein.data_source
+  weinstein.macro
+  weinstein.screener
+  weinstein.stage
+  weinstein.stock_analysis
+  weinstein.types
+  weinstein_trading.stops
+  weinstein_trading.strategy
+  backtest
+  backtest_optimal)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/optimal/bin/optimal_strategy.ml
+++ b/trading/trading/backtest/optimal/bin/optimal_strategy.ml
@@ -2,26 +2,25 @@
 
     Reads the artefacts written by a prior [scenario_runner.exe] run from
     [--output-dir] and produces [<output_dir>/optimal_strategy.md] — a markdown
-    report comparing the actual run's performance against the
-    [Constrained] / [Relaxed_macro] counterfactual variants, rendered via
+    report comparing the actual run's performance against the [Constrained] /
+    [Relaxed_macro] counterfactual variants, rendered via
     {!Backtest_optimal.Optimal_strategy_report.render}.
 
     {1 Pipeline}
 
-    1. Parse [--output-dir] from the CLI.
-    2. Load [actual.sexp], [summary.sexp], [trades.csv] (and optionally
-       [trade_audit.sexp]) to build the renderer's [actual_run].
-    3. Re-build OHLCV + bar panels over the run's universe + period via the same
-       calendar-aware loader [Panel_runner] uses.
-    4. Walk Fridays in [start_date, end_date]:
-       - Per symbol: run [Stock_analysis.analyze] via {!Stage_callbacks_from_bars}
-         to produce a candidate-eligibility analysis.
-       - Build a [Stage_transition_scanner.week_input] and call [scan_week].
-    5. For each candidate, score forward-weekly outlooks via
-       {!Outcome_scorer.score} (walks future Fridays' bar + stage classification).
-    6. Run [Optimal_portfolio_filler.fill] for [Constrained] and [Relaxed_macro];
-       summarise each via [Optimal_summary.summarize].
-    7. Build the renderer input and write [<output_dir>/optimal_strategy.md].
+    1. Parse [--output-dir] from the CLI. 2. Load [actual.sexp], [summary.sexp],
+    [trades.csv] (and optionally [trade_audit.sexp]) to build the renderer's
+    [actual_run]. 3. Re-build OHLCV + bar panels over the run's universe +
+    period via the same calendar-aware loader [Panel_runner] uses. 4. Walk
+    Fridays in [start_date, end_date]:
+    - Per symbol: run [Stock_analysis.analyze] via {!Stage_callbacks_from_bars}
+      to produce a candidate-eligibility analysis.
+    - Build a [Stage_transition_scanner.week_input] and call [scan_week]. 5. For
+      each candidate, score forward-weekly outlooks via {!Outcome_scorer.score}
+      (walks future Fridays' bar + stage classification). 6. Run
+      [Optimal_portfolio_filler.fill] for [Constrained] and [Relaxed_macro];
+      summarise each via [Optimal_summary.summarize]. 7. Build the renderer
+      input and write [<output_dir>/optimal_strategy.md].
 
     {1 Macro-trend simplification}
 
@@ -60,8 +59,8 @@ module OT = Backtest_optimal.Optimal_types
 (* CLI parsing                                                       *)
 (* ---------------------------------------------------------------- *)
 
-(** Parsed CLI arguments. *)
 type cli_args = { output_dir : string }
+(** Parsed CLI arguments. *)
 
 let _usage_and_exit () =
   eprintf "Usage: optimal_strategy --output-dir <path>\n";
@@ -82,9 +81,6 @@ let _parse_args () : cli_args =
 (* Loading actual-run artefacts                                       *)
 (* ---------------------------------------------------------------- *)
 
-(** Mirrors [Backtest.Scenarios.Scenario_runner.actual] — a private record
-    written alongside other artefacts. We re-declare the shape locally and
-    parse it via the same [@@deriving sexp]. *)
 type _actual_sexp_shape = {
   total_return_pct : float;
   total_trades : float;
@@ -95,9 +91,10 @@ type _actual_sexp_shape = {
   unrealized_pnl : float;
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]
+(** Mirrors [Backtest.Scenarios.Scenario_runner.actual] — a private record
+    written alongside other artefacts. We re-declare the shape locally and parse
+    it via the same [@@deriving sexp]. *)
 
-(** Mirrors [Backtest.Summary.t]'s on-disk fields. We use [sexp.allow_extra_fields]
-    to tolerate the [metrics] field which we don't read here. *)
 type _summary_sexp_shape = {
   start_date : Date.t;
   end_date : Date.t;
@@ -106,6 +103,9 @@ type _summary_sexp_shape = {
   final_portfolio_value : float;
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]
+(** Mirrors [Backtest.Summary.t]'s on-disk fields. We use
+    [sexp.allow_extra_fields] to tolerate the [metrics] field which we don't
+    read here. *)
 
 let _load_actual_sexp ~output_dir : _actual_sexp_shape =
   let path = Filename.concat output_dir "actual.sexp" in
@@ -123,8 +123,9 @@ let _load_summary_sexp ~output_dir : _summary_sexp_shape =
 (* Loading trades.csv                                                 *)
 (* ---------------------------------------------------------------- *)
 
-(** Parse one line of trades.csv into a [Trading_simulation.Metrics.trade_metrics].
-    The on-disk format is set by [Backtest.Result_writer._write_trade_row]:
+(** Parse one line of trades.csv into a
+    [Trading_simulation.Metrics.trade_metrics]. The on-disk format is set by
+    [Backtest.Result_writer._write_trade_row]:
     [symbol,entry_date,exit_date,days_held,entry_price,exit_price,
      quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger]. *)
 let _parse_trade_row line : Trading_simulation.Metrics.trade_metrics option =
@@ -169,8 +170,11 @@ let _load_cascade_rejections ~output_dir : (string * string) list =
   if not (Sys_unix.file_exists_exn path) then []
   else
     try
-      let blob = Backtest.Trade_audit.audit_blob_of_sexp (Sexp.load_sexp path) in
-      List.concat_map blob.audit_records ~f:(fun (rec_ : Backtest.Trade_audit.audit_record) ->
+      let blob =
+        Backtest.Trade_audit.audit_blob_of_sexp (Sexp.load_sexp path)
+      in
+      List.concat_map blob.audit_records
+        ~f:(fun (rec_ : Backtest.Trade_audit.audit_record) ->
           List.map rec_.entry.alternatives_considered
             ~f:(fun (alt : Backtest.Trade_audit.alternative_candidate) ->
               let reason =
@@ -208,8 +212,7 @@ let _build_calendar ~start ~end_ : Date.t array =
 let _build_bar_panels ~data_dir_fpath ~universe ~calendar :
     Bar_panels.t * Date.t array =
   let symbols =
-    _index_symbol :: universe
-    |> List.dedup_and_sort ~compare:String.compare
+    _index_symbol :: universe |> List.dedup_and_sort ~compare:String.compare
   in
   let symbol_index =
     match Symbol_index.create ~universe:symbols with
@@ -230,8 +233,7 @@ let _build_bar_panels ~data_dir_fpath ~universe ~calendar :
   let bar_panels =
     match Bar_panels.create ~ohlcv ~calendar with
     | Ok p -> p
-    | Error err ->
-        failwithf "Bar_panels.create failed: %s" (Status.show err) ()
+    | Error err -> failwithf "Bar_panels.create failed: %s" (Status.show err) ()
   in
   (bar_panels, calendar)
 
@@ -292,8 +294,8 @@ let _analyze_symbol_on_friday ~bar_panels ~friday ~stock_config ~bar_lookback
 (** Build a [sector_map] (symbol → [Screener.sector_context]) from a flat
     [sectors : (symbol → sector_name)] table. The screener's sector-context
     expects a [rating] and [stage] per sector; we use [Neutral] / [Stage2] as
-    pass-throughs because the counterfactual treats sector caps separately
-    (via the filler's [max_sector_concentration]). *)
+    pass-throughs because the counterfactual treats sector caps separately (via
+    the filler's [max_sector_concentration]). *)
 let _build_sector_context_map (sectors : (string, string) Hashtbl.t) :
     (string, Screener.sector_context) Hashtbl.t =
   let out = Hashtbl.create (module String) in
@@ -313,9 +315,9 @@ let _build_sector_context_map (sectors : (string, string) Hashtbl.t) :
 (* ---------------------------------------------------------------- *)
 
 (** Build a forward [Outcome_scorer.weekly_outlook list] for [symbol] starting
-    on the Friday {b after} [entry_friday]. Reads weekly bars + classifies
-    Stage at each Friday via [Stage.classify]. Empty list means the run ends
-    at or before [entry_friday]. *)
+    on the Friday {b after} [entry_friday]. Reads weekly bars + classifies Stage
+    at each Friday via [Stage.classify]. Empty list means the run ends at or
+    before [entry_friday]. *)
 let _forward_outlooks ~bar_panels ~all_fridays ~stage_config ~bar_lookback
     ~symbol ~entry_friday : Scorer.weekly_outlook list =
   let after =
@@ -361,8 +363,8 @@ let _scan_all_fridays ~bar_panels ~fridays ~universe ~sector_map ~stock_config
       in
       Scanner.scan_week ~config:scanner_config week)
 
-(** Score each candidate by forward-walking the panel. Drops candidates with
-    no forward bars (degenerate end-of-run). *)
+(** Score each candidate by forward-walking the panel. Drops candidates with no
+    forward bars (degenerate end-of-run). *)
 let _score_all_candidates ~bar_panels ~all_fridays ~scorer_config ~stage_config
     ~bar_lookback (candidates : OT.candidate_entry list) :
     OT.scored_candidate list =
@@ -389,8 +391,8 @@ let _build_variant ~filler_config ~variant ~scored ~starting_cash :
 (* Top-level                                                          *)
 (* ---------------------------------------------------------------- *)
 
-(** Number of weekly bars to slice for each per-Friday analysis. Large enough
-    to satisfy the 30-week MA + breakout-base lookback in
+(** Number of weekly bars to slice for each per-Friday analysis. Large enough to
+    satisfy the 30-week MA + breakout-base lookback in
     [Stock_analysis.default_config]. *)
 let _bar_lookback_weeks = 90
 
@@ -431,13 +433,13 @@ let main ~output_dir =
     Hashtbl.keys sectors_tbl |> List.sort ~compare:String.compare
   in
   let warmup_start = Date.add_days actual_run.start_date (-_warmup_days) in
-  let calendar = _build_calendar ~start:warmup_start ~end_:actual_run.end_date in
+  let calendar =
+    _build_calendar ~start:warmup_start ~end_:actual_run.end_date
+  in
   eprintf "optimal_strategy: building panels (%d symbols × %d days)\n%!"
     (List.length universe + 1)
     (Array.length calendar);
-  let bar_panels, _ =
-    _build_bar_panels ~data_dir_fpath ~universe ~calendar
-  in
+  let bar_panels, _ = _build_bar_panels ~data_dir_fpath ~universe ~calendar in
   let sector_ctx_map = _build_sector_context_map sectors_tbl in
   let fridays =
     _fridays_in_range ~start:actual_run.start_date ~end_:actual_run.end_date
@@ -469,7 +471,9 @@ let main ~output_dir =
     _build_variant ~filler_config ~variant:OT.Relaxed_macro ~scored
       ~starting_cash:actual_run.initial_cash
   in
-  let input : Report.input = { actual = actual_run; constrained; relaxed_macro } in
+  let input : Report.input =
+    { actual = actual_run; constrained; relaxed_macro }
+  in
   let md = Report.render input in
   let out_path = Filename.concat output_dir "optimal_strategy.md" in
   Out_channel.write_all out_path ~data:md;

--- a/trading/trading/backtest/optimal/bin/optimal_strategy.ml
+++ b/trading/trading/backtest/optimal/bin/optimal_strategy.ml
@@ -1,0 +1,480 @@
+(** Optimal-strategy counterfactual binary.
+
+    Reads the artefacts written by a prior [scenario_runner.exe] run from
+    [--output-dir] and produces [<output_dir>/optimal_strategy.md] — a markdown
+    report comparing the actual run's performance against the
+    [Constrained] / [Relaxed_macro] counterfactual variants, rendered via
+    {!Backtest_optimal.Optimal_strategy_report.render}.
+
+    {1 Pipeline}
+
+    1. Parse [--output-dir] from the CLI.
+    2. Load [actual.sexp], [summary.sexp], [trades.csv] (and optionally
+       [trade_audit.sexp]) to build the renderer's [actual_run].
+    3. Re-build OHLCV + bar panels over the run's universe + period via the same
+       calendar-aware loader [Panel_runner] uses.
+    4. Walk Fridays in [start_date, end_date]:
+       - Per symbol: run [Stock_analysis.analyze] via {!Stage_callbacks_from_bars}
+         to produce a candidate-eligibility analysis.
+       - Build a [Stage_transition_scanner.week_input] and call [scan_week].
+    5. For each candidate, score forward-weekly outlooks via
+       {!Outcome_scorer.score} (walks future Fridays' bar + stage classification).
+    6. Run [Optimal_portfolio_filler.fill] for [Constrained] and [Relaxed_macro];
+       summarise each via [Optimal_summary.summarize].
+    7. Build the renderer input and write [<output_dir>/optimal_strategy.md].
+
+    {1 Macro-trend simplification}
+
+    The actual run records a per-Friday macro trend implicitly — but it is not
+    persisted to disk in the run artefacts. The counterfactual bin uses a fixed
+    [Neutral] macro trend across all weeks: this makes [passes_macro = true] for
+    every candidate (the gate's rule is [macro_trend <> Bearish]), so
+    [Constrained] and [Relaxed_macro] tag every candidate the same way. The
+    headline comparison still surfaces the cascade-ranking gap; honest
+    macro-driven divergence between the two variants is a follow-up that needs
+    the macro trend persisted alongside [actual.sexp].
+
+    {1 Outputs}
+
+    - [<output_dir>/optimal_strategy.md] — the markdown report.
+    - stderr: progress messages.
+
+    {1 Usage}
+
+    {[
+      optimal_strategy.exe --output-dir dev/backtest/scenarios-XYZ/sp500-2019-2023/
+    ]} *)
+
+open Core
+module Bar_panels = Data_panel.Bar_panels
+module Ohlcv_panels = Data_panel.Ohlcv_panels
+module Symbol_index = Data_panel.Symbol_index
+module Scanner = Backtest_optimal.Stage_transition_scanner
+module Scorer = Backtest_optimal.Outcome_scorer
+module Filler = Backtest_optimal.Optimal_portfolio_filler
+module Summary_agg = Backtest_optimal.Optimal_summary
+module Report = Backtest_optimal.Optimal_strategy_report
+module OT = Backtest_optimal.Optimal_types
+
+(* ---------------------------------------------------------------- *)
+(* CLI parsing                                                       *)
+(* ---------------------------------------------------------------- *)
+
+(** Parsed CLI arguments. *)
+type cli_args = { output_dir : string }
+
+let _usage_and_exit () =
+  eprintf "Usage: optimal_strategy --output-dir <path>\n";
+  Stdlib.exit 1
+
+let _parse_args () : cli_args =
+  let argv = Sys.get_argv () |> Array.to_list |> List.tl_exn in
+  let rec loop output_dir = function
+    | [] -> output_dir
+    | "--output-dir" :: v :: rest -> loop (Some v) rest
+    | _ :: _ -> _usage_and_exit ()
+  in
+  match loop None argv with
+  | Some d -> { output_dir = d }
+  | None -> _usage_and_exit ()
+
+(* ---------------------------------------------------------------- *)
+(* Loading actual-run artefacts                                       *)
+(* ---------------------------------------------------------------- *)
+
+(** Mirrors [Backtest.Scenarios.Scenario_runner.actual] — a private record
+    written alongside other artefacts. We re-declare the shape locally and
+    parse it via the same [@@deriving sexp]. *)
+type _actual_sexp_shape = {
+  total_return_pct : float;
+  total_trades : float;
+  win_rate : float;
+  sharpe_ratio : float;
+  max_drawdown_pct : float;
+  avg_holding_days : float;
+  unrealized_pnl : float;
+}
+[@@deriving sexp] [@@sexp.allow_extra_fields]
+
+(** Mirrors [Backtest.Summary.t]'s on-disk fields. We use [sexp.allow_extra_fields]
+    to tolerate the [metrics] field which we don't read here. *)
+type _summary_sexp_shape = {
+  start_date : Date.t;
+  end_date : Date.t;
+  universe_size : int;
+  initial_cash : float;
+  final_portfolio_value : float;
+}
+[@@deriving sexp] [@@sexp.allow_extra_fields]
+
+let _load_actual_sexp ~output_dir : _actual_sexp_shape =
+  let path = Filename.concat output_dir "actual.sexp" in
+  if not (Sys_unix.file_exists_exn path) then
+    failwithf "Missing actual.sexp at %s" path ();
+  _actual_sexp_shape_of_sexp (Sexp.load_sexp path)
+
+let _load_summary_sexp ~output_dir : _summary_sexp_shape =
+  let path = Filename.concat output_dir "summary.sexp" in
+  if not (Sys_unix.file_exists_exn path) then
+    failwithf "Missing summary.sexp at %s" path ();
+  _summary_sexp_shape_of_sexp (Sexp.load_sexp path)
+
+(* ---------------------------------------------------------------- *)
+(* Loading trades.csv                                                 *)
+(* ---------------------------------------------------------------- *)
+
+(** Parse one line of trades.csv into a [Trading_simulation.Metrics.trade_metrics].
+    The on-disk format is set by [Backtest.Result_writer._write_trade_row]:
+    [symbol,entry_date,exit_date,days_held,entry_price,exit_price,
+     quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger]. *)
+let _parse_trade_row line : Trading_simulation.Metrics.trade_metrics option =
+  match String.split line ~on:',' with
+  | symbol :: entry_date :: exit_date :: days_held :: entry_price :: exit_price
+    :: quantity :: pnl_dollars :: pnl_percent :: _stop_fields -> (
+      try
+        Some
+          {
+            symbol;
+            entry_date = Date.of_string entry_date;
+            exit_date = Date.of_string exit_date;
+            days_held = Int.of_string days_held;
+            entry_price = Float.of_string entry_price;
+            exit_price = Float.of_string exit_price;
+            quantity = Float.of_string quantity;
+            pnl_dollars = Float.of_string pnl_dollars;
+            pnl_percent = Float.of_string pnl_percent;
+          }
+      with _ -> None)
+  | _ -> None
+
+let _load_trades ~output_dir : Trading_simulation.Metrics.trade_metrics list =
+  let path = Filename.concat output_dir "trades.csv" in
+  if not (Sys_unix.file_exists_exn path) then []
+  else
+    let lines = In_channel.read_lines path in
+    match lines with
+    | [] -> []
+    | _header :: rows -> List.filter_map rows ~f:_parse_trade_row
+
+(* ---------------------------------------------------------------- *)
+(* Optional cascade-rejections from trade_audit.sexp                  *)
+(* ---------------------------------------------------------------- *)
+
+(** Harvest one [(symbol, reason)] pair per alternative-skip across the audit.
+    Renders the [skip_reason] variant via its sexp atom name. Renderer attaches
+    these inline against missed-trade rows; missing audit ⇒ empty list ⇒ rows
+    render without reason annotations. *)
+let _load_cascade_rejections ~output_dir : (string * string) list =
+  let path = Filename.concat output_dir "trade_audit.sexp" in
+  if not (Sys_unix.file_exists_exn path) then []
+  else
+    try
+      let blob = Backtest.Trade_audit.audit_blob_of_sexp (Sexp.load_sexp path) in
+      List.concat_map blob.audit_records ~f:(fun (rec_ : Backtest.Trade_audit.audit_record) ->
+          List.map rec_.entry.alternatives_considered
+            ~f:(fun (alt : Backtest.Trade_audit.alternative_candidate) ->
+              let reason =
+                Sexp.to_string
+                  (Backtest.Trade_audit.sexp_of_skip_reason alt.reason_skipped)
+              in
+              (alt.symbol, reason)))
+    with _ -> []
+
+(* ---------------------------------------------------------------- *)
+(* Panel construction (cribbed from Panel_runner)                     *)
+(* ---------------------------------------------------------------- *)
+
+let _index_symbol = "GSPC.INDX"
+let _warmup_days = 210
+
+(** Build the trading-day calendar (weekdays only, holidays kept) over
+    [warmup_start..end_]. Same shape Panel_runner uses. *)
+let _build_calendar ~start ~end_ : Date.t array =
+  let rec loop d acc =
+    if Date.( > ) d end_ then List.rev acc
+    else
+      let dow = Date.day_of_week d in
+      let is_weekend =
+        Day_of_week.equal dow Day_of_week.Sat
+        || Day_of_week.equal dow Day_of_week.Sun
+      in
+      let acc' = if is_weekend then acc else d :: acc in
+      loop (Date.add_days d 1) acc'
+  in
+  Array.of_list (loop start [])
+
+(** Build a [Bar_panels.t] over [universe ∪ {primary_index}] for the calendar.
+    Returns the bar panels + the calendar array so callers can resolve dates. *)
+let _build_bar_panels ~data_dir_fpath ~universe ~calendar :
+    Bar_panels.t * Date.t array =
+  let symbols =
+    _index_symbol :: universe
+    |> List.dedup_and_sort ~compare:String.compare
+  in
+  let symbol_index =
+    match Symbol_index.create ~universe:symbols with
+    | Ok t -> t
+    | Error err ->
+        failwithf "Symbol_index.create failed: %s" err.Status.message ()
+  in
+  let ohlcv =
+    match
+      Ohlcv_panels.load_from_csv_calendar symbol_index ~data_dir:data_dir_fpath
+        ~calendar
+    with
+    | Ok t -> t
+    | Error err ->
+        failwithf "Ohlcv_panels.load_from_csv_calendar failed: %s"
+          (Status.show err) ()
+  in
+  let bar_panels =
+    match Bar_panels.create ~ohlcv ~calendar with
+    | Ok p -> p
+    | Error err ->
+        failwithf "Bar_panels.create failed: %s" (Status.show err) ()
+  in
+  (bar_panels, calendar)
+
+(* ---------------------------------------------------------------- *)
+(* Per-Friday analysis + scanning                                     *)
+(* ---------------------------------------------------------------- *)
+
+(** Resolve the most recent Friday on or before [d]. *)
+let _friday_on_or_before (d : Date.t) : Date.t =
+  let dow = Date.day_of_week d in
+  let offset =
+    match dow with
+    | Day_of_week.Mon -> 3
+    | Day_of_week.Tue -> 4
+    | Day_of_week.Wed -> 5
+    | Day_of_week.Thu -> 6
+    | Day_of_week.Fri -> 0
+    | Day_of_week.Sat -> 1
+    | Day_of_week.Sun -> 2
+  in
+  Date.add_days d (-offset)
+
+(** All Fridays in [start, end_], inclusive on each end where a Friday lies in
+    range. Drives the per-week scan loop. *)
+let _fridays_in_range ~start ~end_ : Date.t list =
+  let first_fri =
+    let f = _friday_on_or_before start in
+    if Date.( < ) f start then Date.add_days f 7 else f
+  in
+  let rec loop d acc =
+    if Date.( > ) d end_ then List.rev acc
+    else loop (Date.add_days d 7) (d :: acc)
+  in
+  loop first_fri []
+
+(** Run [Stock_analysis.analyze] for one symbol on one Friday. Returns [None]
+    when there are not enough bars for the analysis (e.g. early in the run). *)
+let _analyze_symbol_on_friday ~bar_panels ~friday ~stock_config ~bar_lookback
+    (symbol : string) : Stock_analysis.t option =
+  match Bar_panels.column_of_date bar_panels friday with
+  | None -> None
+  | Some as_of_day -> (
+      let weekly =
+        Bar_panels.weekly_bars_for bar_panels ~symbol ~n:bar_lookback ~as_of_day
+      in
+      let benchmark =
+        Bar_panels.weekly_bars_for bar_panels ~symbol:_index_symbol
+          ~n:bar_lookback ~as_of_day
+      in
+      match (weekly, benchmark) with
+      | [], _ | _, [] -> None
+      | _ ->
+          Some
+            (Stock_analysis.analyze ~config:stock_config ~ticker:symbol
+               ~bars:weekly ~benchmark_bars:benchmark ~prior_stage:None
+               ~as_of_date:friday))
+
+(** Build a [sector_map] (symbol → [Screener.sector_context]) from a flat
+    [sectors : (symbol → sector_name)] table. The screener's sector-context
+    expects a [rating] and [stage] per sector; we use [Neutral] / [Stage2] as
+    pass-throughs because the counterfactual treats sector caps separately
+    (via the filler's [max_sector_concentration]). *)
+let _build_sector_context_map (sectors : (string, string) Hashtbl.t) :
+    (string, Screener.sector_context) Hashtbl.t =
+  let out = Hashtbl.create (module String) in
+  Hashtbl.iteri sectors ~f:(fun ~key ~data ->
+      let ctx : Screener.sector_context =
+        {
+          sector_name = data;
+          rating = Screener.Neutral;
+          stage = Stage2 { weeks_advancing = 4; late = false };
+        }
+      in
+      Hashtbl.set out ~key ~data:ctx);
+  out
+
+(* ---------------------------------------------------------------- *)
+(* Forward-walk outlooks for the scorer                                *)
+(* ---------------------------------------------------------------- *)
+
+(** Build a forward [Outcome_scorer.weekly_outlook list] for [symbol] starting
+    on the Friday {b after} [entry_friday]. Reads weekly bars + classifies
+    Stage at each Friday via [Stage.classify]. Empty list means the run ends
+    at or before [entry_friday]. *)
+let _forward_outlooks ~bar_panels ~all_fridays ~stage_config ~bar_lookback
+    ~symbol ~entry_friday : Scorer.weekly_outlook list =
+  let after =
+    List.drop_while all_fridays ~f:(fun d -> Date.( <= ) d entry_friday)
+  in
+  List.filter_map after ~f:(fun friday ->
+      match Bar_panels.column_of_date bar_panels friday with
+      | None -> None
+      | Some as_of_day -> (
+          let weekly =
+            Bar_panels.weekly_bars_for bar_panels ~symbol ~n:bar_lookback
+              ~as_of_day
+          in
+          match List.last weekly with
+          | None -> None
+          | Some bar ->
+              let stage_result =
+                Stage.classify ~config:stage_config ~bars:weekly
+                  ~prior_stage:None
+              in
+              Some { Scorer.date = friday; bar; stage_result }))
+
+(* ---------------------------------------------------------------- *)
+(* Scanning + scoring all candidates                                  *)
+(* ---------------------------------------------------------------- *)
+
+(** Run the scanner over all Fridays in the run and emit candidates. *)
+let _scan_all_fridays ~bar_panels ~fridays ~universe ~sector_map ~stock_config
+    ~scanner_config ~bar_lookback : OT.candidate_entry list =
+  List.concat_map fridays ~f:(fun friday ->
+      let analyses =
+        List.filter_map universe ~f:(fun sym ->
+            _analyze_symbol_on_friday ~bar_panels ~friday ~stock_config
+              ~bar_lookback sym)
+      in
+      let week : Scanner.week_input =
+        {
+          date = friday;
+          macro_trend = Weinstein_types.Neutral;
+          analyses;
+          sector_map;
+        }
+      in
+      Scanner.scan_week ~config:scanner_config week)
+
+(** Score each candidate by forward-walking the panel. Drops candidates with
+    no forward bars (degenerate end-of-run). *)
+let _score_all_candidates ~bar_panels ~all_fridays ~scorer_config ~stage_config
+    ~bar_lookback (candidates : OT.candidate_entry list) :
+    OT.scored_candidate list =
+  List.filter_map candidates ~f:(fun (c : OT.candidate_entry) ->
+      let forward =
+        _forward_outlooks ~bar_panels ~all_fridays ~stage_config ~bar_lookback
+          ~symbol:c.symbol ~entry_friday:c.entry_week
+      in
+      Scorer.score ~config:scorer_config ~candidate:c ~forward)
+
+(* ---------------------------------------------------------------- *)
+(* Variant build-out                                                  *)
+(* ---------------------------------------------------------------- *)
+
+let _build_variant ~filler_config ~variant ~scored ~starting_cash :
+    Report.variant_pack =
+  let round_trips =
+    Filler.fill ~config:filler_config { candidates = scored; variant }
+  in
+  let summary = Summary_agg.summarize ~starting_cash ~variant round_trips in
+  { Report.round_trips; summary }
+
+(* ---------------------------------------------------------------- *)
+(* Top-level                                                          *)
+(* ---------------------------------------------------------------- *)
+
+(** Number of weekly bars to slice for each per-Friday analysis. Large enough
+    to satisfy the 30-week MA + breakout-base lookback in
+    [Stock_analysis.default_config]. *)
+let _bar_lookback_weeks = 90
+
+let _scenario_name_of_dir dir =
+  let basename = Filename.basename dir in
+  if String.is_empty basename then dir else basename
+
+let _build_actual_run ~output_dir : Report.actual_run =
+  let actual = _load_actual_sexp ~output_dir in
+  let summary = _load_summary_sexp ~output_dir in
+  let trades = _load_trades ~output_dir in
+  let cascade_rejections = _load_cascade_rejections ~output_dir in
+  {
+    scenario_name = _scenario_name_of_dir output_dir;
+    start_date = summary.start_date;
+    end_date = summary.end_date;
+    universe_size = summary.universe_size;
+    initial_cash = summary.initial_cash;
+    final_portfolio_value = summary.final_portfolio_value;
+    round_trips = trades;
+    win_rate_pct = actual.win_rate;
+    sharpe_ratio = actual.sharpe_ratio;
+    max_drawdown_pct = actual.max_drawdown_pct;
+    profit_factor = Float.nan;
+    cascade_rejections;
+  }
+
+let main ~output_dir =
+  eprintf "optimal_strategy: reading artefacts from %s\n%!" output_dir;
+  let actual_run = _build_actual_run ~output_dir in
+  eprintf "optimal_strategy: actual run %s..%s, universe=%d\n%!"
+    (Date.to_string actual_run.start_date)
+    (Date.to_string actual_run.end_date)
+    actual_run.universe_size;
+  let data_dir_fpath = Data_path.default_data_dir () in
+  let sectors_tbl = Sector_map.load ~data_dir:data_dir_fpath in
+  let universe =
+    Hashtbl.keys sectors_tbl |> List.sort ~compare:String.compare
+  in
+  let warmup_start = Date.add_days actual_run.start_date (-_warmup_days) in
+  let calendar = _build_calendar ~start:warmup_start ~end_:actual_run.end_date in
+  eprintf "optimal_strategy: building panels (%d symbols × %d days)\n%!"
+    (List.length universe + 1)
+    (Array.length calendar);
+  let bar_panels, _ =
+    _build_bar_panels ~data_dir_fpath ~universe ~calendar
+  in
+  let sector_ctx_map = _build_sector_context_map sectors_tbl in
+  let fridays =
+    _fridays_in_range ~start:actual_run.start_date ~end_:actual_run.end_date
+  in
+  eprintf "optimal_strategy: scanning %d Fridays\n%!" (List.length fridays);
+  let stock_config = Stock_analysis.default_config in
+  let stage_config = stock_config.stage in
+  let screener_config = Screener.default_config in
+  let scanner_config = Scanner.config_of_screener_config screener_config in
+  let scorer_config = Scorer.default_config in
+  let candidates =
+    _scan_all_fridays ~bar_panels ~fridays ~universe ~sector_map:sector_ctx_map
+      ~stock_config ~scanner_config ~bar_lookback:_bar_lookback_weeks
+  in
+  eprintf "optimal_strategy: %d candidates emitted; scoring...\n%!"
+    (List.length candidates);
+  let scored =
+    _score_all_candidates ~bar_panels ~all_fridays:fridays ~scorer_config
+      ~stage_config ~bar_lookback:_bar_lookback_weeks candidates
+  in
+  eprintf "optimal_strategy: %d scored candidates; filling variants...\n%!"
+    (List.length scored);
+  let filler_config = Filler.default_config in
+  let constrained =
+    _build_variant ~filler_config ~variant:OT.Constrained ~scored
+      ~starting_cash:actual_run.initial_cash
+  in
+  let relaxed_macro =
+    _build_variant ~filler_config ~variant:OT.Relaxed_macro ~scored
+      ~starting_cash:actual_run.initial_cash
+  in
+  let input : Report.input = { actual = actual_run; constrained; relaxed_macro } in
+  let md = Report.render input in
+  let out_path = Filename.concat output_dir "optimal_strategy.md" in
+  Out_channel.write_all out_path ~data:md;
+  eprintf "optimal_strategy: wrote %s\n%!" out_path
+
+let () =
+  let { output_dir } = _parse_args () in
+  main ~output_dir

--- a/trading/trading/backtest/optimal/bin/optimal_strategy.ml
+++ b/trading/trading/backtest/optimal/bin/optimal_strategy.ml
@@ -145,7 +145,10 @@ let _parse_trade_row line : Trading_simulation.Metrics.trade_metrics option =
             pnl_dollars = Float.of_string pnl_dollars;
             pnl_percent = Float.of_string pnl_percent;
           }
-      with _ -> None)
+      with exn ->
+        eprintf "optimal_strategy: skipping malformed trade row (%s)\n%!"
+          (Exn.to_string exn);
+        None)
   | _ -> None
 
 let _load_trades ~output_dir : Trading_simulation.Metrics.trade_metrics list =
@@ -182,7 +185,10 @@ let _load_cascade_rejections ~output_dir : (string * string) list =
                   (Backtest.Trade_audit.sexp_of_skip_reason alt.reason_skipped)
               in
               (alt.symbol, reason)))
-    with _ -> []
+    with exn ->
+      eprintf "optimal_strategy: failed to read trade_audit.sexp (%s)\n%!"
+        (Exn.to_string exn);
+      []
 
 (* ---------------------------------------------------------------- *)
 (* Panel construction (cribbed from Panel_runner)                     *)
@@ -420,13 +426,16 @@ let _build_actual_run ~output_dir : Report.actual_run =
     cascade_rejections;
   }
 
-let main ~output_dir =
-  eprintf "optimal_strategy: reading artefacts from %s\n%!" output_dir;
-  let actual_run = _build_actual_run ~output_dir in
-  eprintf "optimal_strategy: actual run %s..%s, universe=%d\n%!"
-    (Date.to_string actual_run.start_date)
-    (Date.to_string actual_run.end_date)
-    actual_run.universe_size;
+type pipeline_world = {
+  bar_panels : Bar_panels.t;
+  sector_ctx_map : (string, Screener.sector_context) Hashtbl.t;
+  fridays : Date.t list;
+  universe : string list;
+}
+(** Loaded panels + per-symbol sector context + Friday calendar over the run
+    window. Built once per invocation, consumed by scan + score. *)
+
+let _build_world ~(actual_run : Report.actual_run) : pipeline_world =
   let data_dir_fpath = Data_path.default_data_dir () in
   let sectors_tbl = Sector_map.load ~data_dir:data_dir_fpath in
   let universe =
@@ -444,24 +453,33 @@ let main ~output_dir =
   let fridays =
     _fridays_in_range ~start:actual_run.start_date ~end_:actual_run.end_date
   in
-  eprintf "optimal_strategy: scanning %d Fridays\n%!" (List.length fridays);
+  { bar_panels; sector_ctx_map; fridays; universe }
+
+let _scan_and_score ~(world : pipeline_world) : OT.scored_candidate list =
+  eprintf "optimal_strategy: scanning %d Fridays\n%!"
+    (List.length world.fridays);
   let stock_config = Stock_analysis.default_config in
   let stage_config = stock_config.stage in
   let screener_config = Screener.default_config in
   let scanner_config = Scanner.config_of_screener_config screener_config in
   let scorer_config = Scorer.default_config in
   let candidates =
-    _scan_all_fridays ~bar_panels ~fridays ~universe ~sector_map:sector_ctx_map
-      ~stock_config ~scanner_config ~bar_lookback:_bar_lookback_weeks
+    _scan_all_fridays ~bar_panels:world.bar_panels ~fridays:world.fridays
+      ~universe:world.universe ~sector_map:world.sector_ctx_map ~stock_config
+      ~scanner_config ~bar_lookback:_bar_lookback_weeks
   in
   eprintf "optimal_strategy: %d candidates emitted; scoring...\n%!"
     (List.length candidates);
   let scored =
-    _score_all_candidates ~bar_panels ~all_fridays:fridays ~scorer_config
-      ~stage_config ~bar_lookback:_bar_lookback_weeks candidates
+    _score_all_candidates ~bar_panels:world.bar_panels
+      ~all_fridays:world.fridays ~scorer_config ~stage_config
+      ~bar_lookback:_bar_lookback_weeks candidates
   in
   eprintf "optimal_strategy: %d scored candidates; filling variants...\n%!"
     (List.length scored);
+  scored
+
+let _emit_report ~output_dir ~(actual_run : Report.actual_run) ~scored : unit =
   let filler_config = Filler.default_config in
   let constrained =
     _build_variant ~filler_config ~variant:OT.Constrained ~scored
@@ -478,6 +496,17 @@ let main ~output_dir =
   let out_path = Filename.concat output_dir "optimal_strategy.md" in
   Out_channel.write_all out_path ~data:md;
   eprintf "optimal_strategy: wrote %s\n%!" out_path
+
+let main ~output_dir =
+  eprintf "optimal_strategy: reading artefacts from %s\n%!" output_dir;
+  let actual_run = _build_actual_run ~output_dir in
+  eprintf "optimal_strategy: actual run %s..%s, universe=%d\n%!"
+    (Date.to_string actual_run.start_date)
+    (Date.to_string actual_run.end_date)
+    actual_run.universe_size;
+  let world = _build_world ~actual_run in
+  let scored = _scan_and_score ~world in
+  _emit_report ~output_dir ~actual_run ~scored
 
 let () =
   let { output_dir } = _parse_args () in


### PR DESCRIPTION
## Summary

PR-4b of the optimal-strategy track. Wires `Optimal_strategy_report.render` to artefacts written by `scenario_runner.exe`.

- `bin/optimal_strategy.ml` (~470 LOC, formatted): parses `--output-dir`, loads `summary.sexp` / `actual.sexp` / `trades.csv` (and optionally `trade_audit.sexp` for cascade-rejection annotations), rebuilds `Ohlcv_panels` + `Bar_panels` via the same calendar-aware loader `Panel_runner` uses, walks Fridays running `Stock_analysis.analyze` + `Stage_transition_scanner.scan_week`, scores each candidate via `Outcome_scorer`, fills both `Constrained` + `Relaxed_macro` variants via `Optimal_portfolio_filler.fill`, summarises via `Optimal_summary`, then renders to `<output_dir>/optimal_strategy.md`.
- `bin/dune`: registers the executable; depends only on existing libraries (no new lib/ surface).
- `dev/status/optimal-strategy.md`: PR-4b checkbox flipped to `[~]`, Completed entry added pointing at branch / PR #666.

## Notes (recurring on this track)

- **A2 architecture rule context (recurring carve-out):** `trading/trading/backtest/optimal/bin/dune` imports from `weinstein.*`. This is consistent with PR-1/2/3/4 (5+ existing `trading/trading/backtest/*/dune` files import `weinstein.*`); the established workaround is `qc-structural` marks A2 as FLAG, not FAIL.
- **Macro-trend simplification:** the bin uses fixed `Neutral` for every Friday because run artefacts do not persist per-Friday macro state. `Constrained` and `Relaxed_macro` will tag every candidate identically until macro persistence lands; the headline cascade-ranking comparison is unaffected. Documented in the bin docstring.
- **Cascade rejections:** harvested from `trade_audit.sexp`'s `alternatives_considered` when present; missing-audit case passes `[]` and the renderer drops rejection annotations from missed-trade rows.

## What is deferred

- **Smoke test (synthetic-panel fixture invoking the bin)** — optional but recommended per the followups note. Invoking the bin end-to-end in a unit test requires staged CSV fixtures in a tmp `data_dir`; that artefact stack is heavier than the bin scaffold and is left as a follow-up commit on this branch.
- **Per-Friday macro persistence** so `Constrained` not equal to `Relaxed_macro` — pre-requisite is the actual run side persisting `macro_trend` per Friday.

## Test plan

- [x] `dev/lib/run-in-env.sh dune build` clean (zero warnings).
- [x] `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/` clean (45/45 PASS unchanged).
- [x] `dev/lib/run-in-env.sh dune build @fmt` clean.
- [ ] Future: synthetic-panel smoke test on top of staged tmp `data_dir` fixture — follow-up commit on this branch.

## PR sizing

- 2 new files (`bin/dune`, `bin/optimal_strategy.ml`); 1 status update.
- ~504 LOC bin + dune + 2 commits. Slightly over the 250-LOC PR-4b estimate from the followups note; the overshoot lives in defensive doc comments and the panel-walking + per-symbol forward-outlook loops, both of which the spec explicitly required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)