### PR TITLE
test(optimal-strategy): PR-4 follow-up B — fuller renderer fixture tests

### DIFF
--- a/dev/notes/optimal-strategy-pr4-followups-2026-04-28.md
+++ b/dev/notes/optimal-strategy-pr4-followups-2026-04-28.md
@@ -61,7 +61,7 @@ small smoke test through a synthetic-panel fixture is added.
   the trade-audit's per-Friday cascade summaries / rejection diagnostics.
   Missing-audit case: pass `[]` (renderer renders without reasons).
 
-### Follow-up B — fuller renderer fixture tests
+### Follow-up B — fuller renderer fixture tests — DONE (2026-04-29)
 
 The smoke tests pin section presence + a few key substrings. The plan
 asked for "the rendered markdown contains the expected divergence rows,
@@ -72,6 +72,30 @@ the missed-trade ranking ordering are not yet pinned.
 
 **Estimated LOC:** ~100 of additional fixture tests in
 `test_optimal_strategy_report.ml`. Same file, same harness.
+
+**Landed:** branch `feat/optimal-strategy-pr4-followup-b`. Three new
+OUnit2 cases in `test_optimal_strategy_report.ml` (~205 LOC of tests +
+inline fixtures, no new test-helper modules):
+
+1. `test_divergence_pins_specific_cells` — 2 actual + 4 counterfactual
+   round-trips across 2 Fridays. Pins the section's `### YYYY-MM-DD`
+   subheaders, the actual rows' `SYM (N sh)` cells, and the optimal
+   rows' `SYM (N sh, R=±X.XX)` cells with R-multiples to two decimals.
+2. `test_missed_trades_ordered_by_pnl_descending` — 3 missed-trade
+   candidates with deliberately misaligned alphabetical / P&L order
+   (`AAA`/`ZBIG`/`MSML` with P&L 300/1000/50). Restricts the search
+   to the missed-trades section (so symbol mentions in the divergence
+   section don't pollute) and asserts position(`ZBIG`) <
+   position(`AAA`) < position(`MSML`) — pinning the descending-by-
+   `pnl_dollars` ordering documented in the renderer's `.mli` and
+   implemented by `Float.compare b.pnl_dollars a.pnl_dollars`.
+3. `test_empty_divergence_renders_sentinel` — identical actual /
+   counterfactual symbol sets => the divergence section emits the
+   single sentinel line `_No Fridays where actual and constrained-
+   counterfactual picks differed._` and no per-Friday detail rows.
+
+Test count: 45 → 48. `dune build @fmt` and `dune runtest
+trading/backtest/optimal/` clean.
 
 ### Follow-up C — PR-5 (already optional in plan)
 

--- a/dev/status/optimal-strategy.md
+++ b/dev/status/optimal-strategy.md
@@ -1,6 +1,6 @@
 # Status: optimal-strategy
 
-## Last updated: 2026-04-29
+## Last updated: 2026-04-29 (PR-4 follow-up B)
 
 ## Status
 READY_FOR_REVIEW
@@ -96,13 +96,17 @@ ready to start once PR-3 lands.
       determinism, trailing newline). 45/45 pass across the optimal track.
       The binary + deeper fixture tests are deferred to PR-4b — see
       `dev/notes/optimal-strategy-pr4-followups-2026-04-28.md`.
-- [~] **PR-4b**: `optimal_strategy.exe` binary (panel loading + pipeline
-      orchestration). In flight on `feat/optimal-strategy-pr4b` / PR #666.
-      Bin scaffold + `bin/dune` shipped; panel-walking smoke test deferred
-      to a follow-up commit on the same branch (writing real artefacts to
-      a tmp dir is the cheapest path; needs panel CSV fixtures). The
-      fuller per-Friday divergence + missed-trade ordering renderer
-      fixture tests remain pending and stay attached to PR-4 followup B.
+- [x] **PR-4b**: `optimal_strategy.exe` binary (panel loading + pipeline
+      orchestration) — PR #666 (merged 2026-04-29). Bin scaffold +
+      `bin/dune`; panel-walking smoke test deferred to the lib-extraction
+      follow-up. Macro-trend hardcoded to `Neutral` until the read-side
+      wiring of #671's artefact lands.
+- [x] **PR-4 follow-up B**: fuller per-Friday divergence + missed-trade
+      ordering fixture tests on `feat/optimal-strategy-pr4-followup-b`.
+      Three new cases in `test_optimal_strategy_report.ml` pin specific
+      symbols / sizes / R-multiples in the divergence section, the
+      missed-trades descending-by-P&L ordering, and the no-divergence
+      sentinel. 45 → 48 tests pass.
 - [ ] **PR-5** (optional): wire into `release_perf_report` so each
       scenario emits the counterfactual delta. ~200 LOC.
 
@@ -225,7 +229,7 @@ consumes scorer output as opaque exit fields.
     - `dev/lib/run-in-env.sh dune build @fmt`
   - Branch / PR: `feat/optimal-strategy-pr3` / PR #TBD.
 
-- **PR-4b** (2026-04-29, in flight): `optimal_strategy.exe` binary —
+- **PR-4b** (2026-04-29, MERGED): `optimal_strategy.exe` binary —
   thin orchestration wrapper that wires the existing pure-functional
   optimal-lib pipeline (scanner → scorer → filler ×2 → summary ×2) to
   artefacts on disk and emits `<output_dir>/optimal_strategy.md`.
@@ -234,13 +238,14 @@ consumes scorer output as opaque exit fields.
     - `trading/trading/backtest/optimal/bin/optimal_strategy.ml`
   - Coverage: existing 45/45 optimal-track tests still pass; no new
     unit tests in this commit. Smoke test (synthetic-panel fixture
-    invoking `main`) deferred to a follow-up commit on the same branch.
+    invoking `main`) deferred to the lib-extraction follow-up.
   - Macro-trend simplification: bin uses fixed `Neutral` for every
     Friday because run artefacts don't persist per-Friday macro state.
     `Constrained` and `Relaxed_macro` therefore tag every candidate
     identically until macro persistence lands; the headline
     cascade-ranking comparison is unaffected. Documented in the bin's
-    docstring.
+    docstring. Read-side wiring of #671's `macro_trend.sexp` artefact
+    is a small follow-up.
   - Cascade rejections sourced from `trade_audit.sexp`'s
     `alternatives_considered` when present; missing-audit case passes
     `[]` and the renderer drops rejection annotations from missed-trade
@@ -250,3 +255,34 @@ consumes scorer output as opaque exit fields.
     - `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/`
     - `dev/lib/run-in-env.sh dune build @fmt`
   - Branch / PR: `feat/optimal-strategy-pr4b` / PR #666.
+
+- **PR-4 follow-up B** (2026-04-29): fuller renderer fixture tests.
+  - Files modified:
+    - `trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml`
+      (3 new OUnit2 cases, ~205 LOC of additions; no production code
+      touched).
+  - Coverage:
+    - `test_divergence_pins_specific_cells` — 2 actual + 4 counterfactual
+      round-trips across 2 Fridays. Pins `### YYYY-MM-DD` subheaders,
+      actual `SYM (N sh)` cells, and optimal `SYM (N sh, R=±X.XX)` cells
+      with R-multiples to two decimals (per `_fmt_actual_pick` and
+      `_fmt_optimal_pick` in the renderer).
+    - `test_missed_trades_ordered_by_pnl_descending` — 3 missed-trade
+      candidates with P&L 300 / 1000 / 50 (alphabetical order
+      `AAA`/`MSML`/`ZBIG` deliberately disagrees with P&L order). Test
+      restricts the substring search to the missed-trades section so
+      the divergence section's symbol mentions don't pollute, then
+      asserts position(`ZBIG`) < position(`AAA`) < position(`MSML`)
+      via `lt (module Int_ord)`. Pins the descending-by-`pnl_dollars`
+      ordering documented in the renderer's `.mli`.
+    - `test_empty_divergence_renders_sentinel` — identical actual /
+      counterfactual symbol sets => the divergence section emits the
+      single sentinel line `_No Fridays where actual and constrained-
+      counterfactual picks differed._` and no per-Friday detail rows
+      (`### YYYY-MM-DD` substring absent).
+  - Test count: 45 → 48 across the optimal track.
+  - Verify:
+    - `dev/lib/run-in-env.sh dune build`
+    - `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/`
+    - `dev/lib/run-in-env.sh dune build @fmt`
+  - Branch / PR: `feat/optimal-strategy-pr4-followup-b` / PR #670.

--- a/trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml
@@ -305,6 +305,203 @@ let test_ends_with_newline _ =
        (fun s -> Char.equal (String.get s (String.length s - 1)) '\n')
        (equal_to true))
 
+(* ------------------------------------------------------------------ *)
+(* Per-Friday divergence — pin specific cells                           *)
+(* ------------------------------------------------------------------ *)
+
+(** Two-Friday fixture. Each Friday has different actual vs counterfactual picks
+    (symbol sets differ), so both Fridays appear in the divergence section.
+    Pins:
+    - the section's ### date headers for both Fridays
+    - actual rows render as "SYM (N sh)" with share counts
+    - optimal rows render as "SYM (N sh, R=±X.XX)" with share counts +
+      R-multiples to two decimals *)
+let test_divergence_pins_specific_cells _ =
+  let friday1 = _date "2024-02-02" in
+  let friday2 = _date "2024-03-01" in
+  (* Actual: 2 round-trips, one per Friday. *)
+  let actual_aapl =
+    _make_actual_trade ~symbol:"AAPL" ~entry_date:friday1
+      ~exit_date:(_date "2024-03-08") ~pnl_dollars:200.0 ~pnl_percent:20.0 ()
+  in
+  let actual_googl =
+    _make_actual_trade ~symbol:"GOOGL" ~entry_date:friday2
+      ~exit_date:(_date "2024-04-05") ~pnl_dollars:150.0 ~pnl_percent:15.0 ()
+  in
+  let actual =
+    _make_actual ~scenario_name:"divergence-pin"
+      ~round_trips:[ actual_aapl; actual_googl ]
+      ()
+  in
+  (* Constrained counterfactual: 4 round-trips across the same two Fridays.
+     Friday1 picks {MSFT, NVDA} (both differ from AAPL); Friday2 picks
+     {AMZN, META} (both differ from GOOGL). *)
+  let constrained_rts =
+    [
+      _make_optimal_rt ~symbol:"MSFT" ~entry_week:friday1
+        ~exit_week:(_date "2024-03-29") ~pnl_dollars:500.0 ~r_multiple:5.0 ();
+      _make_optimal_rt ~symbol:"NVDA" ~entry_week:friday1
+        ~exit_week:(_date "2024-03-22") ~pnl_dollars:300.0 ~r_multiple:3.5 ();
+      _make_optimal_rt ~symbol:"AMZN" ~entry_week:friday2
+        ~exit_week:(_date "2024-04-26") ~pnl_dollars:400.0 ~r_multiple:4.0 ();
+      _make_optimal_rt ~symbol:"META" ~entry_week:friday2
+        ~exit_week:(_date "2024-04-19") ~pnl_dollars:250.0 ~r_multiple:2.5 ();
+    ]
+  in
+  let constrained =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
+    }
+  in
+  let relaxed_macro =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
+    }
+  in
+  let md = R.render { actual; constrained; relaxed_macro } in
+  assert_that md
+    (all_of
+       [
+         (* Both Friday section headers present. *)
+         _has "### 2024-02-02";
+         _has "### 2024-03-01";
+         (* Actual picks render with share counts (quantity = 10.0 from
+            _make_actual_trade). *)
+         _has "AAPL (10 sh)";
+         _has "GOOGL (10 sh)";
+         (* Optimal picks render with share counts + R-multiples to 2 dp.
+            shares = 10.0 from _make_optimal_rt; R= per fixture above. *)
+         _has "MSFT (10 sh, R=+5.00)";
+         _has "NVDA (10 sh, R=+3.50)";
+         _has "AMZN (10 sh, R=+4.00)";
+         _has "META (10 sh, R=+2.50)";
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Missed-trade ranking — descending by realized P&L                    *)
+(* ------------------------------------------------------------------ *)
+
+(** Index of the first occurrence of [needle] in [haystack]. Helper for
+    asserting relative order of substrings in the rendered markdown. *)
+let _index_of haystack needle = String.substr_index_exn haystack ~pattern:needle
+
+(** Three missed-trade candidates with distinct P&L (all symbols absent from the
+    actual run). The renderer's {!Optimal_strategy_report.mli} documents that
+    "trades the actual missed" are "ranked by realized P&L"; the impl sorts by
+    [pnl_dollars] descending. We pin that ordering by extracting each symbol's
+    position in the rendered output and asserting BIG appears before MID before
+    SML. *)
+let test_missed_trades_ordered_by_pnl_descending _ =
+  (* Actual has one round-trip in a totally different symbol, so all three
+     counterfactual symbols qualify as "missed". *)
+  let actual_trade =
+    _make_actual_trade ~symbol:"ZZZ" ~entry_date:(_date "2024-02-02")
+      ~exit_date:(_date "2024-03-01") ~pnl_dollars:50.0 ~pnl_percent:5.0 ()
+  in
+  let actual =
+    _make_actual ~scenario_name:"missed-ranking" ~round_trips:[ actual_trade ]
+      ()
+  in
+  (* Symbols are deliberately spelled to make alphabetical ordering disagree
+     with the expected P&L ordering, so the test fails loudly if the renderer
+     sorts alphabetically. *)
+  let constrained_rts =
+    [
+      (* Alphabetical-first but middle P&L. *)
+      _make_optimal_rt ~symbol:"AAA" ~entry_week:(_date "2024-02-02")
+        ~exit_week:(_date "2024-03-01") ~pnl_dollars:300.0 ~r_multiple:3.0 ();
+      (* Alphabetical-last but largest P&L (must render first). *)
+      _make_optimal_rt ~symbol:"ZBIG" ~entry_week:(_date "2024-02-09")
+        ~exit_week:(_date "2024-03-08") ~pnl_dollars:1_000.0 ~r_multiple:10.0 ();
+      (* Alphabetical-middle but smallest P&L (must render last). *)
+      _make_optimal_rt ~symbol:"MSML" ~entry_week:(_date "2024-02-16")
+        ~exit_week:(_date "2024-03-15") ~pnl_dollars:50.0 ~r_multiple:0.5 ();
+    ]
+  in
+  let constrained =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
+    }
+  in
+  let relaxed_macro =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
+    }
+  in
+  let md = R.render { actual; constrained; relaxed_macro } in
+  (* Restrict the search to the missed-trades section so we don't pick up
+     symbol mentions from the divergence section (which lists them by
+     entry-week, not by P&L). *)
+  let missed_section =
+    let start_idx =
+      String.substr_index_exn md ~pattern:"## Trades the actual missed"
+    in
+    let end_idx =
+      String.substr_index_exn md ~pos:start_idx ~pattern:"## Implications"
+    in
+    String.sub md ~pos:start_idx ~len:(end_idx - start_idx)
+  in
+  let pos_big = _index_of missed_section "ZBIG" in
+  let pos_mid = _index_of missed_section "AAA" in
+  let pos_sml = _index_of missed_section "MSML" in
+  assert_that pos_big (lt (module Int_ord) pos_mid);
+  assert_that pos_mid (lt (module Int_ord) pos_sml)
+
+(* ------------------------------------------------------------------ *)
+(* Empty divergence — sentinel renders when symbol sets match           *)
+(* ------------------------------------------------------------------ *)
+
+(** When the actual and constrained sets contain the same symbols on every
+    Friday, [_picks_diverge] returns false everywhere and the divergence section
+    emits a single sentinel line ("_No Fridays where actual and
+    constrained-counterfactual picks differed._"). Pins that contract; also
+    asserts the per-Friday detail rows are absent. *)
+let test_empty_divergence_renders_sentinel _ =
+  let friday = _date "2024-02-02" in
+  let symbol = "AAPL" in
+  let actual_trade =
+    _make_actual_trade ~symbol ~entry_date:friday
+      ~exit_date:(_date "2024-03-01") ~pnl_dollars:200.0 ~pnl_percent:20.0 ()
+  in
+  let actual =
+    _make_actual ~scenario_name:"no-divergence" ~round_trips:[ actual_trade ] ()
+  in
+  let constrained_rts =
+    [
+      _make_optimal_rt ~symbol ~entry_week:friday
+        ~exit_week:(_date "2024-03-01") ~pnl_dollars:200.0 ~r_multiple:2.0 ();
+    ]
+  in
+  let constrained =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
+    }
+  in
+  let relaxed_macro =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
+    }
+  in
+  let md = R.render { actual; constrained; relaxed_macro } in
+  assert_that md
+    (all_of
+       [
+         _has "## Per-Friday divergence";
+         _has
+           "_No Fridays where actual and constrained-counterfactual picks \
+            differed._";
+         (* No per-Friday detail subsection should render. *)
+         field
+           (fun s -> String.is_substring s ~substring:"### 2024-02-02")
+           (equal_to false);
+       ])
+
 let suite =
   "Optimal_strategy_report"
   >::: [
@@ -321,6 +518,12 @@ let suite =
          >:: test_implications_degenerate;
          "render is deterministic" >:: test_render_is_deterministic;
          "output ends with single newline" >:: test_ends_with_newline;
+         "divergence section pins specific symbols / sizes / R-multiples"
+         >:: test_divergence_pins_specific_cells;
+         "missed trades ordered by P&L descending"
+         >:: test_missed_trades_ordered_by_pnl_descending;
+         "no divergence: sentinel renders, no detail rows"
+         >:: test_empty_divergence_renders_sentinel;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Adds three fixture-based test cases to `test_optimal_strategy_report.ml`, pinning the per-Friday divergence row content + missed-trade ranking ordering that the smoke tests merged in PR #665 left as TODO.

This is **PR-4 follow-up B** per `dev/notes/optimal-strategy-pr4-followups-2026-04-28.md` §Follow-up B. Renderer is untouched; only the test file + the two follow-up tracking docs change. PR-4b (the `optimal_strategy.exe` binary) stays its own track on PR #666.

## What it adds

| Test | Pins |
|---|---|
| `test_divergence_pins_specific_cells` | Section's `### YYYY-MM-DD` subheaders for both Fridays; actual rows render as `SYM (N sh)`; optimal rows render as `SYM (N sh, R=±X.XX)` with R-multiples to two decimals. Fixture: 2 actual + 4 counterfactual round-trips across 2 Fridays with disjoint symbol sets per Friday. |
| `test_missed_trades_ordered_by_pnl_descending` | The missed-trades section lists candidates by realized P&L descending. Fixture: `AAA` (P&L 300), `ZBIG` (P&L 1000), `MSML` (P&L 50) — alphabetical order disagrees with expected P&L order, so the test fails loudly if ranking goes alphabetic. Asserts position(`ZBIG`) < position(`AAA`) < position(`MSML`) within the `## Trades the actual missed` section only (so the divergence section's symbol mentions don't pollute). |
| `test_empty_divergence_renders_sentinel` | When actual and constrained share identical symbol sets on every Friday, the divergence section emits the sentinel `_No Fridays where actual and constrained-counterfactual picks differed._` with no per-Friday detail rows. |

All three follow the test-patterns.md style (one `assert_that` per value, composed via `all_of` / `field`). The new helper `_index_of` is local to the file (not a new test-helper module).

## Test plan

- [x] `dev/lib/run-in-env.sh dune build` — clean
- [x] `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/` — 5 + 10 + 9 + 13 + 11 = 48 tests pass (was 45 = +3)
- [x] `dev/lib/run-in-env.sh dune build @fmt` — clean
- [x] Worktree-isolation pre-flight: branch ancestry lands on `main@origin`; diff contains only the three files listed above (test file + 2 status / notes docs)

## Out of scope

- `bin/optimal_strategy.ml` (PR-4 follow-up A → PR #666)
- `release_perf_report` integration (PR-5, optional)