### PR TITLE
feat(backtest): persist per-Friday macro_trend artefact

### DIFF
--- a/dev/status/optimal-strategy.md
+++ b/dev/status/optimal-strategy.md
@@ -101,6 +101,24 @@ ready to start once PR-3 lands.
 - [ ] **PR-5** (optional): wire into `release_perf_report` so each
       scenario emits the counterfactual delta. ~200 LOC.
 
+### Macro-trend persistence (write/read split)
+
+- [x] **Write side**: per-Friday `macro_trend.sexp` artefact emitted by
+      `Backtest.Result_writer` on every backtest run. Sourced from
+      `Trade_audit.cascade_summary.{date,macro_trend}` (already populated
+      by the strategy's `Macro.analyze_with_callbacks` call inside
+      `_run_screen` — no plumbing changes needed). Module:
+      `trading/trading/backtest/lib/macro_trend_writer.{ml,mli}`. Verify:
+      `dev/lib/run-in-env.sh dune exec trading/backtest/test/test_macro_trend_writer.exe`.
+      Branch / PR: `feat/scenario-runner-macro-persistence` / TBD.
+- [ ] **Read side** (post-merge follow-up): `optimal_strategy.exe` (PR-4b
+      / #666) currently hardcodes `Weinstein_types.Neutral` for every
+      Friday because run artefacts didn't persist macro state — making
+      the `Constrained` and `Relaxed_macro` counterfactual variants
+      produce identical output. After this PR + PR-4b both merge, swap
+      the hardcode for `Macro_trend_writer.t_of_sexp (Sexp.load_sexp …)`.
+      ~30 LOC change in the bin.
+
 ## Ownership
 
 `feat-backtest` agent — sibling of backtest-infra, backtest-perf,

--- a/trading/trading/backtest/lib/macro_trend_writer.ml
+++ b/trading/trading/backtest/lib/macro_trend_writer.ml
@@ -1,0 +1,15 @@
+open Core
+
+type per_friday = { date : Date.t; trend : Weinstein_types.market_trend }
+[@@deriving sexp]
+
+type t = per_friday list [@@deriving sexp]
+
+let of_cascade_summaries (summaries : Trade_audit.cascade_summary list) : t =
+  List.map summaries ~f:(fun (s : Trade_audit.cascade_summary) ->
+      { date = s.date; trend = s.macro_trend })
+  |> List.sort ~compare:(fun a b -> Date.compare a.date b.date)
+
+let write ~output_dir (summaries : Trade_audit.cascade_summary list) =
+  let entries = of_cascade_summaries summaries in
+  Sexp.save_hum (output_dir ^ "/macro_trend.sexp") (sexp_of_t entries)

--- a/trading/trading/backtest/lib/macro_trend_writer.mli
+++ b/trading/trading/backtest/lib/macro_trend_writer.mli
@@ -1,0 +1,35 @@
+(** Per-Friday macro-trend persistence.
+
+    Emits [macro_trend.sexp] alongside the other run artefacts so external
+    counterfactual tooling (notably {!Backtest_optimal}'s
+    [optimal_strategy.exe]) can replay each Friday's [macro_trend] without
+    re-running the strategy's macro pipeline.
+
+    The per-Friday values are sourced from {!Trade_audit.cascade_summary}'s
+    [date] + [macro_trend] fields — already populated by the strategy's
+    [Macro.analyze_with_callbacks] call inside [_run_screen]. This module only
+    projects + writes; no recompute. *)
+
+open Core
+
+type per_friday = { date : Date.t; trend : Weinstein_types.market_trend }
+[@@deriving sexp]
+(** One Friday's macro reading. [date] is the Friday on which [_run_screen]
+    fired; [trend] is the [Macro.result.trend] returned by
+    [Macro.analyze_with_callbacks] that Friday. *)
+
+type t = per_friday list [@@deriving sexp]
+(** The per-Friday ledger written to disk. Sorted ascending by [date]; one entry
+    per Friday on which the screener actually ran. Empty when no Friday fell
+    inside the run window. *)
+
+val of_cascade_summaries : Trade_audit.cascade_summary list -> t
+(** Project a list of cascade summaries down to per-Friday macro readings. Sorts
+    ascending by [date]. Pure projection — no compute. *)
+
+val write : output_dir:string -> Trade_audit.cascade_summary list -> unit
+(** Write [<output_dir>/macro_trend.sexp]. The directory must already exist.
+
+    Always writes the file (including when the input list is empty, which yields
+    [()] sexp) — the artefact's presence is the contract for downstream
+    consumers, distinct from [trade_audit.sexp]'s "absent on empty" rule. *)

--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -135,4 +135,5 @@ let write ~output_dir (result : Runner.result) =
     ~stop_infos:result.stop_infos;
   _write_equity_curve ~output_dir ~steps:result.steps;
   _write_trade_audit ~output_dir ~audit:result.audit
-    ~cascade_summaries:result.cascade_summaries
+    ~cascade_summaries:result.cascade_summaries;
+  Macro_trend_writer.write ~output_dir result.cascade_summaries

--- a/trading/trading/backtest/lib/result_writer.mli
+++ b/trading/trading/backtest/lib/result_writer.mli
@@ -3,10 +3,14 @@
     customize what gets written. *)
 
 val write : output_dir:string -> Runner.result -> unit
-(** Write [params.sexp], [summary.sexp], [trades.csv], and [equity_curve.csv]
-    into [output_dir]. The directory must already exist.
+(** Write [params.sexp], [summary.sexp], [trades.csv], [equity_curve.csv], and
+    [macro_trend.sexp] into [output_dir]. The directory must already exist.
 
     Additionally writes [trade_audit.sexp] iff [result.audit] is non-empty.
     Empty audit lists (the pre-PR-2 default, capture sites not yet wired)
     produce no file rather than a sexp containing [()] — consumers must tolerate
-    the file's absence. *)
+    the file's absence.
+
+    [macro_trend.sexp] is always written (one entry per Friday the screener
+    fired, possibly empty list) — counterfactual tooling consumes it to replay
+    per-Friday macro state. See {!Macro_trend_writer}. *)

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -13,7 +13,8 @@
   test_gc_trace
   test_panel_runner_gc_trace
   test_release_perf_report
-  test_determinism)
+  test_determinism
+  test_macro_trend_writer)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/test/test_macro_trend_writer.ml
+++ b/trading/trading/backtest/test/test_macro_trend_writer.ml
@@ -1,0 +1,181 @@
+(** Unit tests for {!Backtest.Macro_trend_writer}. Pin the projection from
+    [cascade_summary] (date + macro_trend only), the ascending-by-date sort,
+    sexp round-trip stability, and the on-disk artefact format including the
+    empty-list case. *)
+
+open OUnit2
+open Core
+open Matchers
+module MTW = Backtest.Macro_trend_writer
+module TA = Backtest.Trade_audit
+
+let _date s = Date.of_string s
+
+(* Cascade-summary builder copied from test_trade_audit.ml — defaults model a
+   typical Bullish-macro Friday. Only [date] + [macro_trend] feed
+   [Macro_trend_writer]; the other fields are filler so the projection is
+   exercised against a realistic input. *)
+let _make_cascade ?(date = _date "2024-01-19")
+    ?(macro_trend = Weinstein_types.Bullish) () : TA.cascade_summary =
+  {
+    date;
+    total_stocks = 20;
+    candidates_after_held = 18;
+    macro_trend;
+    long_macro_admitted = 18;
+    long_breakout_admitted = 5;
+    long_sector_admitted = 5;
+    long_grade_admitted = 3;
+    long_top_n_admitted = 3;
+    short_macro_admitted = 18;
+    short_breakdown_admitted = 0;
+    short_sector_admitted = 0;
+    short_rs_hard_gate_admitted = 0;
+    short_grade_admitted = 0;
+    short_top_n_admitted = 0;
+    entered = 1;
+  }
+
+(* of_cascade_summaries projection ---------------------------------------- *)
+
+let test_empty_input_yields_empty_list _ =
+  assert_that (MTW.of_cascade_summaries []) (size_is 0)
+
+let test_three_fridays_in_date_order _ =
+  let summaries =
+    [
+      _make_cascade ~date:(_date "2024-01-19")
+        ~macro_trend:Weinstein_types.Bullish ();
+      _make_cascade ~date:(_date "2024-01-26")
+        ~macro_trend:Weinstein_types.Neutral ();
+      _make_cascade ~date:(_date "2024-02-02")
+        ~macro_trend:Weinstein_types.Bearish ();
+    ]
+  in
+  assert_that
+    (MTW.of_cascade_summaries summaries)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (e : MTW.per_friday) -> Date.to_string e.date)
+               (equal_to "2024-01-19");
+             field
+               (fun (e : MTW.per_friday) -> e.trend)
+               (equal_to Weinstein_types.Bullish);
+           ];
+         all_of
+           [
+             field
+               (fun (e : MTW.per_friday) -> Date.to_string e.date)
+               (equal_to "2024-01-26");
+             field
+               (fun (e : MTW.per_friday) -> e.trend)
+               (equal_to Weinstein_types.Neutral);
+           ];
+         all_of
+           [
+             field
+               (fun (e : MTW.per_friday) -> Date.to_string e.date)
+               (equal_to "2024-02-02");
+             field
+               (fun (e : MTW.per_friday) -> e.trend)
+               (equal_to Weinstein_types.Bearish);
+           ];
+       ])
+
+let test_unsorted_input_is_sorted_ascending_by_date _ =
+  (* Cascades arrive in arbitrary order — the projection must still emit
+     ascending dates. *)
+  let summaries =
+    [
+      _make_cascade ~date:(_date "2024-03-15")
+        ~macro_trend:Weinstein_types.Bullish ();
+      _make_cascade ~date:(_date "2024-01-19")
+        ~macro_trend:Weinstein_types.Bearish ();
+      _make_cascade ~date:(_date "2024-02-09")
+        ~macro_trend:Weinstein_types.Neutral ();
+    ]
+  in
+  assert_that
+    (MTW.of_cascade_summaries summaries
+    |> List.map ~f:(fun (e : MTW.per_friday) -> Date.to_string e.date))
+    (elements_are
+       [ equal_to "2024-01-19"; equal_to "2024-02-09"; equal_to "2024-03-15" ])
+
+(* Sexp round-trip --------------------------------------------------------- *)
+
+let test_sexp_round_trip _ =
+  let original : MTW.t =
+    [
+      { date = _date "2024-01-19"; trend = Weinstein_types.Bullish };
+      { date = _date "2024-01-26"; trend = Weinstein_types.Bearish };
+    ]
+  in
+  let parsed = MTW.t_of_sexp (MTW.sexp_of_t original) in
+  assert_that parsed (elements_are (List.map original ~f:equal_to))
+
+(* On-disk artefact -------------------------------------------------------- *)
+
+let test_write_creates_file_and_round_trips _ =
+  let dir = Core_unix.mkdtemp "/tmp/macro_trend_writer_test_" in
+  let summaries =
+    [
+      _make_cascade ~date:(_date "2024-02-02")
+        ~macro_trend:Weinstein_types.Bearish ();
+      _make_cascade ~date:(_date "2024-01-19")
+        ~macro_trend:Weinstein_types.Bullish ();
+    ]
+  in
+  MTW.write ~output_dir:dir summaries;
+  let path = dir ^ "/macro_trend.sexp" in
+  let parsed = MTW.t_of_sexp (Sexp.load_sexp path) in
+  assert_that parsed
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (e : MTW.per_friday) -> Date.to_string e.date)
+               (equal_to "2024-01-19");
+             field
+               (fun (e : MTW.per_friday) -> e.trend)
+               (equal_to Weinstein_types.Bullish);
+           ];
+         all_of
+           [
+             field
+               (fun (e : MTW.per_friday) -> Date.to_string e.date)
+               (equal_to "2024-02-02");
+             field
+               (fun (e : MTW.per_friday) -> e.trend)
+               (equal_to Weinstein_types.Bearish);
+           ];
+       ])
+
+let test_write_empty_list_creates_file _ =
+  (* Empty input still writes the artefact — the file's presence is the
+     contract for downstream consumers, distinct from [trade_audit.sexp]'s
+     "absent on empty" rule. *)
+  let dir = Core_unix.mkdtemp "/tmp/macro_trend_writer_test_empty_" in
+  MTW.write ~output_dir:dir [];
+  let path = dir ^ "/macro_trend.sexp" in
+  assert_that (Stdlib.Sys.file_exists path) (equal_to true);
+  let parsed = MTW.t_of_sexp (Sexp.load_sexp path) in
+  assert_that parsed (size_is 0)
+
+let suite =
+  "macro_trend_writer"
+  >::: [
+         "empty_input_yields_empty_list" >:: test_empty_input_yields_empty_list;
+         "three_fridays_in_date_order" >:: test_three_fridays_in_date_order;
+         "unsorted_input_is_sorted_ascending_by_date"
+         >:: test_unsorted_input_is_sorted_ascending_by_date;
+         "sexp_round_trip" >:: test_sexp_round_trip;
+         "write_creates_file_and_round_trips"
+         >:: test_write_creates_file_and_round_trips;
+         "write_empty_list_creates_file" >:: test_write_empty_list_creates_file;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- Emit `<output_dir>/macro_trend.sexp` from `Backtest.Result_writer.write` on every backtest run — one entry per Friday the screener fired, sorted ascending by date.
- Sourced from `Trade_audit.cascade_summary.{date, macro_trend}` (already populated by `Macro.analyze_with_callbacks` inside `Weinstein_strategy._run_screen`). Pure projection — no plumbing changes to the strategy, screener, or runner.
- Always written (including empty list when no Friday falls inside the run window) so downstream consumers don't have to handle absence as a special case — distinct from `trade_audit.sexp`'s "absent on empty" rule.

## Why

The optimal-strategy bin (`optimal_strategy.exe`, PR #666) currently hardcodes `Weinstein_types.Neutral` for every Friday because run artefacts didn't persist macro state. As a result, the `Constrained` and `Relaxed_macro` counterfactual variants produce identical output. This PR ships the **write side**; the read side (swap the hardcode for `Macro_trend_writer.t_of_sexp (Sexp.load_sexp ...)`) is a follow-up that lands after both this PR and #666 merge — see `dev/status/optimal-strategy.md` § Macro-trend persistence.

## Approach (1 of 2 in spec — chosen for simplicity)

Picked **approach 1** (hook into the live computation, indirectly): the strategy already fills `cascade_summary` per Friday via the `Audit_recorder` pipeline, and the Friday's macro trend is one of those fields. No need to rerun `Macro.score_market` post-hoc; the value's already in `result.cascade_summaries`. New module is a thin projection + writer over data the runner already collects.

This also avoids the bit-equality risk approach 2 carries (recomputing macro from the same panel inputs but at a different code site).

## Files changed

New:
- `trading/trading/backtest/lib/macro_trend_writer.{ml,mli}` — projection + writer (~50 LOC).
- `trading/trading/backtest/test/test_macro_trend_writer.ml` — 6 OUnit2 cases.

Modified:
- `trading/trading/backtest/lib/result_writer.{ml,mli}` — append `Macro_trend_writer.write` to the per-run write sequence and update the doc-comment.
- `trading/trading/backtest/test/dune` — register the new test binary.
- `dev/status/optimal-strategy.md` — add § Macro-trend persistence with this PR ticked off and the read-side wiring as the open follow-up.

Total diff: 7 files, +260 / -5.

## Test plan

- [x] `dune build` clean.
- [x] `dune exec trading/backtest/test/test_macro_trend_writer.exe` — 6/6 pass.
- [x] `dune build @fmt` clean (formatter applied during dev cycle).
- [x] `dune runtest trading/backtest/test/` — pre-existing `tiered-loader-parity` data-fixture failures observed; they fail identically on `origin/main` and are unrelated to this change.

Test coverage breakdown:
- Empty input → empty list (size_is 0).
- 3-Friday Bullish/Neutral/Bearish input → 3-entry output in declared order.
- Unsorted input (Mar 15 / Jan 19 / Feb 9) → ascending dates.
- Sexp round-trip stability.
- `write` creates the file on disk + round-trips the entries.
- Empty input still creates the file (artefact-presence contract).

## Out of scope (follow-ups, captured in optimal-strategy.md)

- Updating `optimal_strategy.exe` to read the new artefact instead of the `Neutral`-hardcode (post-merge of this PR + #666).
- Plumbing macro into `summary.sexp`/`actual.sexp` (a separate file is cheaper + isolates the change).
- Recomputing macro for already-merged scenarios (forward-looking only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)