### PR TITLE
fix(review): post-merge cleanup of PR #670 — assert_that composition + status format

### DIFF
--- a/dev/status/optimal-strategy.md
+++ b/dev/status/optimal-strategy.md
@@ -1,6 +1,6 @@
 # Status: optimal-strategy
 
-## Last updated: 2026-04-29 (PR-4 follow-up B)
+## Last updated: 2026-04-29
 
 ## Status
 READY_FOR_REVIEW

--- a/trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml
@@ -448,8 +448,19 @@ let test_missed_trades_ordered_by_pnl_descending _ =
   let pos_big = _index_of missed_section "ZBIG" in
   let pos_mid = _index_of missed_section "AAA" in
   let pos_sml = _index_of missed_section "MSML" in
-  assert_that pos_big (lt (module Int_ord) pos_mid);
-  assert_that pos_mid (lt (module Int_ord) pos_sml)
+  (* Pin one logical invariant — the missed-trades section lists symbols in
+     descending P&L order — as a single assert_that on the canonical value
+     (the realised order in the document). Per .claude/rules/test-patterns.md
+     §"One assert_that per Value", multiple ordering relations should compose
+     into a single matcher tree. *)
+  let order_in_document =
+    List.sort
+      [ ("ZBIG", pos_big); ("AAA", pos_mid); ("MSML", pos_sml) ]
+      ~compare:(fun (_, a) (_, b) -> Int.compare a b)
+    |> List.map ~f:fst
+  in
+  assert_that order_in_document
+    (elements_are [ equal_to "ZBIG"; equal_to "AAA"; equal_to "MSML" ])
 
 (* ------------------------------------------------------------------ *)
 (* Empty divergence — sentinel renders when symbol sets match           *)


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #670 addressing two valid `qc-structural` findings the orchestrator surfaced after merge.

PR #670 (PR-4 follow-up B — fuller renderer fixture tests) was merged at 2026-04-29T13:03:59Z while the orchestrator-spawned `qc-structural` review was in flight. Both findings were valid and would have required a rework loop pre-merge; applying the small mechanical fixes as a post-merge follow-up is the simpler path.

## Findings addressed

| # | Finding | File | Fix |
|---|---------|------|-----|
| P6 | Two consecutive `assert_that` calls on related ordering invariants violate `.claude/rules/test-patterns.md` §'One assert_that per Value' | `trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml:451-452` | Compose into one `assert_that` on the realised symbol order (sorted by document position) via `elements_are [equal_to "ZBIG"; equal_to "AAA"; equal_to "MSML"]` |
| A3 | `## Last updated: 2026-04-29 (PR-4 follow-up B)` parenthetical violates `status_file_integrity.sh` schema (bare YYYY-MM-DD required) | `dev/status/optimal-strategy.md:3` | Strip parenthetical → `## Last updated: 2026-04-29` |

## Test plan

- [x] `dune build` — exit 0
- [x] `dune runtest trading/backtest/optimal/` — 48 tests pass (8 in `test_optimal_strategy_report.exe` including the rewritten ordering test)
- [x] `dune build @runtest --force` (full repo) — exit 0
- [x] `dune build @fmt` — exit 0
- [x] `status_file_integrity.sh` — 'OK: all dev/status/*.md files have required fields.'

🤖 Generated with [Claude Code](https://claude.com/claude-code) (lead-orchestrator 2026-04-29 run-2)