### PR TITLE
harness: fix git checkout failure in bundle-budget GHA step

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -371,6 +371,13 @@ jobs:
           # ---------------------------------------------------------------
           # Add the budget JSON onto the daily summary branch.
           # ---------------------------------------------------------------
+          # The lead-orchestrator step (jj) leaves the working tree dirty:
+          # modified dev/reviews/*.md and untracked dev/audit/* / dev/health/*
+          # files that it committed via jj but did not clean up from the git
+          # working copy.  git checkout refuses to overwrite those files.
+          # Everything intentional is already on the remote branch, so a
+          # hard reset + clean is safe here.
+          git reset --hard HEAD && git clean -fd
           git fetch origin "${DAILY_BRANCH}"
           git checkout "${DAILY_BRANCH}"
           git add "$OUT_FILE"

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -1,6 +1,6 @@
 # Status: harness
 
-## Last updated: 2026-04-25
+## Last updated: 2026-04-29
 
 ## Status
 IN_PROGRESS
@@ -327,6 +327,10 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
 ### Deep scan heuristic gap sub-item 1: Drift coverage extension (backtest)
 
 - [x] `trading/trading/backtest/` subsystem added to `trading/devtools/checks/deep_scan/check_02_design_doc_drift.sh` — checks top-level subdirectories of `trading/trading/backtest/` against `dev/plans/backtest-scale-optimization-2026-04-17.md` using the same heuristic as the existing Weinstein subsystem checks (grep for dir name in plan doc; missing = WARNING). Plan document is the active backtest design spec. Current live finding: `trading/trading/backtest/bin/` is not mentioned in the plan (expected — runner binary added post-plan). Smoke test: `trading/devtools/checks/deep_scan_drift_coverage_check.sh` — verifies BACKTEST_PLAN, BACKTEST_DIR, and the plan filename markers are present in `check_02`, and that the most-recent deep scan report references drift. Wired into `dune runtest` via `trading/devtools/checks/dune`. Verify: `sh trading/devtools/checks/deep_scan_drift_coverage_check.sh` — prints OK; `sh trading/devtools/checks/deep_scan.sh` — report shows `Design doc drift items: 1` and warns about `backtest/bin/`.
+
+### orchestrator-daily bundle-budget checkout fix
+
+- [x] GHA "Bundle budget into daily summary and auto-merge" step now resets the working tree before `git checkout "${DAILY_BRANCH}"`. Root cause: lead-orchestrator (jj) leaves modified `dev/reviews/*.md` and untracked `dev/audit/*` / `dev/health/*` files in the git working copy after pushing to the daily branch; `git checkout` refuses to overwrite them. Fix: `git reset --hard HEAD && git clean -fd` added immediately before `git fetch origin "${DAILY_BRANCH}"` with an explanatory comment. Failed run: https://github.com/dayfine/trading/actions/runs/25109871573. File: `.github/workflows/orchestrator.yml` (lines 374–382). Verify: next scheduled run (00:17 or 05:17 PT) completes the step without checkout error.
 
 ### POSIX shell portability linter
 


### PR DESCRIPTION
## Summary

- GHA run [25109871573](https://github.com/dayfine/trading/actions/runs/25109871573) failed at \"Bundle budget into daily summary and auto-merge\" because `git checkout "${DAILY_BRANCH}"` refused to overwrite files left dirty by the lead-orchestrator jj step.
- Adds `git reset --hard HEAD && git clean -fd` immediately before `git fetch origin "${DAILY_BRANCH}"` in the bundle step, with an explanatory comment.
- The reset is safe: the lead-orchestrator has already pushed all intentional changes (dev/reviews/*.md, dev/audit/*, dev/health/*) to the remote daily branch via jj before this step runs.

## Root cause

The lead-orchestrator step runs jj inside the devcontainer. jj commits and pushes `dev/reviews/optimal-strategy.md` and untracked `dev/audit/2026-04-29-*.json` / `dev/health/2026-04-29-*.md` to the daily branch. However, jj operates on its own object store and does not clean the git working copy. When the bundle step then runs `git checkout "${DAILY_BRANCH}"`, git sees:

- `dev/reviews/optimal-strategy.md` — modified in working tree
- `dev/audit/2026-04-29-optimal-strategy-followup-b.json` — untracked
- `dev/health/2026-04-29-fast-run2.md` — untracked

and aborts rather than overwrite them.

## Files changed

- `.github/workflows/orchestrator.yml` — 7 lines added (+7/-0)

## Test plan

- The fix is exercised by the next scheduled orchestrator run (00:17 or 05:17 PT per project_orchestrator_off).
- No way to dry-run in CI without faking a dirty working tree; the fix is observed-correct by inspection: `git reset --hard HEAD && git clean -fd` unconditionally clears modified-tracked and untracked files before checkout, and the comment explains why this is safe at that point in the workflow.
- Verify the next run completes the \"Bundle budget\" step without the checkout error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)