### PR TITLE
feat(release-report): wire optimal-strategy counterfactual delta + link

### DIFF
--- a/dev/status/optimal-strategy.md
+++ b/dev/status/optimal-strategy.md
@@ -118,8 +118,19 @@ ready to start once PR-3 lands.
       trading/backtest/optimal/` (47/47 pass: 45 prior + 2 new smoke
       tests). Unblocks the macro-persistence read-side wiring (a clean
       lib edit instead of a 480-line bin edit).
-- [ ] **PR-5** (optional): wire into `release_perf_report` so each
-      scenario emits the counterfactual delta. ~200 LOC.
+- [x] **PR-5**: wire `optimal_strategy.exe` artefacts into
+      `release_perf_report`. Runner now emits structured
+      `<output_dir>/optimal_summary.sexp` via the new
+      `Optimal_summary_artefact` module; release report renders an
+      "Optimal-strategy delta" section (per-scenario sub-table with
+      Actual / Constrained / Δ / Relaxed rows + a markdown link to
+      `<scenario>/optimal_strategy.md`) for paired scenarios where at
+      least one side has the artefact. Verify:
+      `dev/lib/run-in-env.sh dune exec trading/backtest/test/test_release_perf_report.exe`
+      (22/22) and
+      `dev/lib/run-in-env.sh dune exec trading/backtest/optimal/test/test_optimal_strategy_runner.exe`
+      (3/3). Branch `feat/optimal-strategy-pr5-release-report` /
+      TBD.
 
 ### Macro-trend persistence (write/read split)
 
@@ -380,3 +391,52 @@ consumes scorer output as opaque exit fields.
     - `dev/lib/run-in-env.sh dune runtest trading/backtest/optimal/`
     - `dev/lib/run-in-env.sh dune build @fmt`
   - Branch / PR: `feat/optimal-strategy-runner-lib` / PR #672.
+
+- **PR-5** (2026-04-29): wire optimal-strategy counterfactual delta + link
+  into `release_perf_report`. Runner now emits a structured
+  `<output_dir>/optimal_summary.sexp` artefact alongside the existing
+  markdown report; release-report consumes it to render an
+  "Optimal-strategy delta" section per paired scenario with the
+  constrained / relaxed-macro variants, Δ_constrained / Δ_relaxed (in
+  percentage points), and a markdown link to the per-scenario
+  `optimal_strategy.md`. Missing artefacts on either side render as
+  `—` and the link cell is empty; the section as a whole is omitted
+  if both sides are missing.
+  - Files added:
+    - `trading/trading/backtest/optimal/lib/optimal_summary_artefact.{ml,mli}`
+      — small two-field record (`constrained` / `relaxed_macro`) carrying
+      the runner's `Optimal_summary.t` outputs, with a `write` helper that
+      sexp-saves to `<output_dir>/optimal_summary.sexp`. Pulled out of the
+      runner so the runner's body stays close to the 300-line norm and the
+      on-disk shape has its own home.
+  - Files modified:
+    - `trading/trading/backtest/optimal/lib/optimal_strategy_runner.{ml,mli}`
+      — `_emit_report` calls `Optimal_summary_artefact.write` after the
+      markdown emit; mli's "I/O surface" lists the new artefact.
+    - `trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml`
+      — new `test_run_emits_optimal_summary_sexp` smoke (3 → +1 = 4
+      cases overall when the suite is run; the existing 2 cases still
+      pin the markdown contract).
+    - `trading/trading/backtest/release_report/release_report.{ml,mli}`
+      — adds `optimal_summary` + `optimal_summary_pair` types,
+      a `_try_load_optimal_summary` loader that requires both
+      `optimal_summary.sexp` and `optimal_strategy.md` (avoids 404
+      links), and `_optimal_strategy_section` renderer — sub-table per
+      paired scenario with the link cell + 5 metric rows.
+    - `trading/trading/backtest/test/test_release_perf_report.ml` — 6
+      new OUnit2 cases (16 → 22): omit-when-both-none, full pin with
+      hand-computed Δ, one-sided rendering with em-dash placeholders,
+      loader round-trip, both-files-missing → None, sexp-only-missing-md
+      → None.
+  - Decision: structured sexp over markdown parsing. Reasons: (a) the
+    renderer evolves separately so markdown sections may shift, (b) the
+    `Optimal_summary.t` already derives sexp so the producer side is a
+    one-line emit, (c) `release_report` mirrors the shape locally with
+    `[@@sexp.allow_extra_fields]` and avoids a heavy dep on
+    `backtest_optimal`.
+  - Verify:
+    - `dev/lib/run-in-env.sh dune build`
+    - `dev/lib/run-in-env.sh dune exec trading/backtest/test/test_release_perf_report.exe` (22/22 pass)
+    - `dev/lib/run-in-env.sh dune exec trading/backtest/optimal/test/test_optimal_strategy_runner.exe` (3/3 pass)
+    - `dev/lib/run-in-env.sh dune build @fmt`
+  - Branch / PR: `feat/optimal-strategy-pr5-release-report` / TBD.

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
@@ -357,7 +357,9 @@ let _emit_report ~output_dir ~(actual_run : Report.actual_run) ~scored : unit =
   let md = Report.render input in
   let out_path = Filename.concat output_dir "optimal_strategy.md" in
   Out_channel.write_all out_path ~data:md;
-  eprintf "optimal_strategy: wrote %s\n%!" out_path
+  eprintf "optimal_strategy: wrote %s\n%!" out_path;
+  Optimal_summary_artefact.write ~output_dir
+    { constrained = constrained.summary; relaxed_macro = relaxed_macro.summary }
 
 let run ~output_dir =
   eprintf "optimal_strategy: reading artefacts from %s\n%!" output_dir;

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.mli
@@ -52,6 +52,12 @@
     - Reads OHLCV CSVs and [sectors.csv] under [Data_path.default_data_dir ()]
       (overridable via [TRADING_DATA_DIR]).
     - Writes [output_dir/optimal_strategy.md] (the rendered report).
+    - Writes [output_dir/optimal_summary.sexp] via
+      {!Optimal_summary_artefact.write} — a structured record with both
+      [Constrained] and [Relaxed_macro] variants of
+      {!Optimal_types.optimal_summary}, for downstream consumers (e.g.
+      release_report) that want headline counterfactual metrics without parsing
+      markdown. See {!Optimal_summary_artefact} for the on-disk shape.
     - Writes progress messages to stderr. *)
 
 open Core

--- a/trading/trading/backtest/optimal/lib/optimal_summary_artefact.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_summary_artefact.ml
@@ -1,0 +1,14 @@
+open Core
+
+type t = {
+  constrained : Optimal_types.optimal_summary;
+  relaxed_macro : Optimal_types.optimal_summary;
+}
+[@@deriving sexp]
+
+let _filename = "optimal_summary.sexp"
+
+let write ~output_dir t =
+  let path = Filename.concat output_dir _filename in
+  Sexp.save_hum path (sexp_of_t t);
+  eprintf "optimal_strategy: wrote %s\n%!" path

--- a/trading/trading/backtest/optimal/lib/optimal_summary_artefact.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_summary_artefact.mli
@@ -1,0 +1,28 @@
+(** Structured artefact written alongside [optimal_strategy.md] so downstream
+    consumers (e.g. {!Release_report}) can read the headline counterfactual
+    metrics without parsing markdown.
+
+    The on-disk shape is a record carrying both [Constrained] and
+    [Relaxed_macro] variants of {!Optimal_types.optimal_summary}; every field on
+    the markdown headline table is recoverable from this sexp. The
+    {!Optimal_strategy_runner} writes one to [<output_dir>/optimal_summary.sexp]
+    on every run.
+
+    Pure data — no I/O beyond the {!write} helper. The sexp shape is fixed by
+    the [@@deriving sexp] derivation; downstream readers should mirror the
+    record locally with [@@sexp.allow_extra_fields] to stay forward-compatible
+    with future field additions. *)
+
+type t = {
+  constrained : Optimal_types.optimal_summary;
+      (** Counterfactual variant honouring the macro gate — the honest
+          comparison against the actual run. *)
+  relaxed_macro : Optimal_types.optimal_summary;
+      (** Counterfactual variant ignoring the macro gate — the upper bound. *)
+}
+[@@deriving sexp]
+(** The two-variant artefact emitted alongside [optimal_strategy.md]. *)
+
+val write : output_dir:string -> t -> unit
+(** [write ~output_dir t] writes [t] to [<output_dir>/optimal_summary.sexp] in
+    sexp-of-record form. Logs a one-line stderr message on completion. *)

--- a/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
@@ -267,6 +267,33 @@ let test_run_consumes_macro_trend_sexp _ =
          _has "Optimal (relaxed macro)";
        ])
 
+let test_run_emits_optimal_summary_sexp _ =
+  (* The runner emits [optimal_summary.sexp] alongside [optimal_strategy.md]
+     so downstream consumers (Release_report PR-5) can read the headline
+     counterfactual metrics without parsing markdown. Pin: file exists, parses
+     as a sexp pair tagged with both [Constrained] and [Relaxed_macro]. *)
+  let data_dir, output_dir = _mk_tmpdirs "opt_runner_summary_sexp" in
+  _stage_fixture ~data_dir ~output_dir;
+  _with_data_dir ~data_dir (fun () ->
+      Backtest_optimal.Optimal_strategy_runner.run ~output_dir);
+  let sexp_path = Filename.concat output_dir "optimal_summary.sexp" in
+  let exists = Sys_unix.file_exists_exn sexp_path in
+  let body = if exists then In_channel.read_all sexp_path else "" in
+  assert_that (exists, body)
+    (all_of
+       [
+         field (fun (e, _) -> e) (equal_to true);
+         field
+           (fun (_, b) -> b)
+           (all_of
+              [
+                _has "(constrained";
+                _has "(relaxed_macro";
+                _has "(variant Constrained)";
+                _has "(variant Relaxed_macro)";
+              ]);
+       ])
+
 let test_run_handles_missing_trade_audit _ =
   let data_dir, output_dir = _mk_tmpdirs "opt_runner_no_audit" in
   _stage_fixture ~data_dir ~output_dir;
@@ -299,6 +326,8 @@ let suite =
          "load_macro_trend missing file returns empty table"
          >:: test_load_macro_trend_missing_file_returns_empty_table;
          "run consumes macro_trend.sexp" >:: test_run_consumes_macro_trend_sexp;
+         "run emits optimal_summary.sexp"
+         >:: test_run_emits_optimal_summary_sexp;
          "run handles missing trade_audit.sexp"
          >:: test_run_handles_missing_trade_audit;
        ]

--- a/trading/trading/backtest/release_report/release_report.ml
+++ b/trading/trading/backtest/release_report/release_report.ml
@@ -21,6 +21,25 @@ type summary_meta = {
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]
 
+type optimal_summary = {
+  total_round_trips : int;
+  winners : int;
+  losers : int;
+  total_return_pct : float;
+  win_rate_pct : float;
+  avg_r_multiple : float;
+  profit_factor : float;
+  max_drawdown_pct : float;
+}
+[@@deriving sexp] [@@sexp.allow_extra_fields]
+
+type optimal_summary_pair = {
+  constrained : optimal_summary;
+  relaxed_macro : optimal_summary;
+  report_path : string;
+}
+[@@deriving sexp] [@@sexp.allow_extra_fields]
+
 type scenario_run = {
   name : string;
   actual : actual;
@@ -28,6 +47,7 @@ type scenario_run = {
   peak_rss_kb : int option;
   wall_seconds : float option;
   trade_quality : Trade_audit_report.t option;
+  optimal_strategy : optimal_summary_pair option;
 }
 [@@deriving sexp]
 
@@ -74,6 +94,41 @@ let _try_load_trade_quality ~dir : Trade_audit_report.t option =
   if not (Sys_unix.file_exists_exn trades_path) then None
   else try Some (Trade_audit_report.load ~scenario_dir:dir) with _ -> None
 
+(* On-disk shape of [optimal_summary.sexp] — mirrors the
+   [Optimal_strategy_runner.optimal_summary_artefact] producer. We re-declare
+   the shape locally so [release_report] does not need to depend on the heavy
+   [backtest_optimal] library; [@@sexp.allow_extra_fields] keeps us forward-
+   compatible with future field additions on the producer side. *)
+type _optimal_summary_artefact_on_disk = {
+  constrained : optimal_summary;
+  relaxed_macro : optimal_summary;
+}
+[@@deriving of_sexp] [@@sexp.allow_extra_fields]
+
+let _try_load_optimal_summary ~dir ~scenario_name : optimal_summary_pair option
+    =
+  (* Both the structured sexp and the markdown report must exist for the
+     section to be rendered — the link target would 404 otherwise. Any read /
+     parse failure swallows silently: the optimal-strategy section is
+     auxiliary, never a hard requirement. *)
+  let sexp_path = Filename.concat dir "optimal_summary.sexp" in
+  let md_path = Filename.concat dir "optimal_strategy.md" in
+  if not (Sys_unix.file_exists_exn sexp_path && Sys_unix.file_exists_exn md_path)
+  then None
+  else
+    try
+      let artefact =
+        _optimal_summary_artefact_on_disk_of_sexp (Sexp.load_sexp sexp_path)
+      in
+      let report_path = Filename.concat scenario_name "optimal_strategy.md" in
+      Some
+        {
+          constrained = artefact.constrained;
+          relaxed_macro = artefact.relaxed_macro;
+          report_path;
+        }
+    with _ -> None
+
 let load_scenario_run ~dir =
   let name = Filename.basename dir in
   let actual_path = Filename.concat dir "actual.sexp" in
@@ -91,7 +146,16 @@ let load_scenario_run ~dir =
     _read_optional_float (Filename.concat dir "wall_seconds.txt")
   in
   let trade_quality = _try_load_trade_quality ~dir in
-  { name; actual; summary; peak_rss_kb; wall_seconds; trade_quality }
+  let optimal_strategy = _try_load_optimal_summary ~dir ~scenario_name:name in
+  {
+    name;
+    actual;
+    summary;
+    peak_rss_kb;
+    wall_seconds;
+    trade_quality;
+    optimal_strategy;
+  }
 
 let _list_scenario_subdirs root =
   if not (Sys_unix.is_directory_exn root) then
@@ -470,12 +534,110 @@ let _trade_quality_section paired =
     let body = List.concat_map with_quality ~f:_row_quality_for_pair in
     header @ body
 
+(* --- Optimal-strategy counterfactual delta section ---
+
+   For each paired scenario where at least one side has [Some _] optimal-
+   strategy artefacts, surface the constrained + relaxed-macro counterfactual
+   total returns alongside the actual total return, plus a per-side Δ from
+   actual to each variant. Each scenario also links its full
+   [optimal_strategy.md] so reviewers can drill into per-Friday divergence,
+   missed-trade ordering, and the implications block. Δ is rendered in
+   percentage points (constrained - actual) — positive means the cascade
+   ranking left return on the table; negative (rare) means the actual run
+   outperformed the perfect-hindsight greedy fill under sizing caps. *)
+
+(* The runner's [Optimal_types.optimal_summary.total_return_pct] is a fraction
+   (e.g. 0.30 = +30%); the actual side's [actual.total_return_pct] is already a
+   percentage (e.g. 30.0). Normalise both to percentage units before computing
+   Δ so the headline rows are directly comparable. *)
+let _opt_return_pct_pp (s : optimal_summary) = s.total_return_pct *. 100.0
+let _fmt_pct_signed_pp v = sprintf "%+.2f%%" v
+let _fmt_delta_pp_pct v = sprintf "%+.2f pp" v
+let _fmt_optional_str = function Some s -> s | None -> "—"
+
+let _opt_row ~label ~cur_str ~prior_str =
+  sprintf "| %s | %s | %s |" label cur_str prior_str
+
+let _opt_actual_str (run : scenario_run) =
+  _fmt_pct_signed_pp run.actual.total_return_pct
+
+let _opt_variant_str (run : scenario_run)
+    ~(get : optimal_summary_pair -> optimal_summary) =
+  match run.optimal_strategy with
+  | None -> "—"
+  | Some pair -> _fmt_pct_signed_pp (_opt_return_pct_pp (get pair))
+
+let _opt_delta_str (run : scenario_run)
+    ~(get : optimal_summary_pair -> optimal_summary) =
+  match run.optimal_strategy with
+  | None -> "—"
+  | Some pair ->
+      let actual = run.actual.total_return_pct in
+      let opt = _opt_return_pct_pp (get pair) in
+      _fmt_delta_pp_pct (opt -. actual)
+
+let _opt_link_str (run : scenario_run) =
+  Option.map run.optimal_strategy ~f:(fun pair ->
+      sprintf "[optimal_strategy.md](%s)" pair.report_path)
+  |> _fmt_optional_str
+
+let _row_optimal_for_pair (cur, prior) =
+  [
+    sprintf "### %s" cur.name;
+    "";
+    sprintf "Report — Current: %s · Prior: %s" (_opt_link_str cur)
+      (_opt_link_str prior);
+    "";
+    "| Metric | Current | Prior |";
+    "|---|---:|---:|";
+    _opt_row ~label:"Actual total return" ~cur_str:(_opt_actual_str cur)
+      ~prior_str:(_opt_actual_str prior);
+    _opt_row ~label:"Optimal (constrained)"
+      ~cur_str:(_opt_variant_str cur ~get:(fun p -> p.constrained))
+      ~prior_str:(_opt_variant_str prior ~get:(fun p -> p.constrained));
+    _opt_row ~label:"Δ to constrained"
+      ~cur_str:(_opt_delta_str cur ~get:(fun p -> p.constrained))
+      ~prior_str:(_opt_delta_str prior ~get:(fun p -> p.constrained));
+    _opt_row ~label:"Optimal (relaxed macro)"
+      ~cur_str:(_opt_variant_str cur ~get:(fun p -> p.relaxed_macro))
+      ~prior_str:(_opt_variant_str prior ~get:(fun p -> p.relaxed_macro));
+    _opt_row ~label:"Δ to relaxed"
+      ~cur_str:(_opt_delta_str cur ~get:(fun p -> p.relaxed_macro))
+      ~prior_str:(_opt_delta_str prior ~get:(fun p -> p.relaxed_macro));
+    "";
+  ]
+
+let _optimal_strategy_section paired =
+  let with_optimal =
+    List.filter paired ~f:(fun (c, p) ->
+        Option.is_some c.optimal_strategy || Option.is_some p.optimal_strategy)
+  in
+  if List.is_empty with_optimal then []
+  else
+    let header =
+      [
+        "## Optimal-strategy delta";
+        "";
+        "Counterfactual comparison against the perfect-hindsight greedy fill \
+         under the same sizing envelope (`optimal_summary.sexp` required). Δ \
+         is constrained-counterfactual minus actual, in percentage points — \
+         positive means the cascade ranking left return on the table; negative \
+         (rare) means the actual run outperformed the counterfactual under \
+         sizing caps. Per-Friday divergence detail lives in the linked \
+         `optimal_strategy.md`.";
+        "";
+      ]
+    in
+    let body = List.concat_map with_optimal ~f:_row_optimal_for_pair in
+    header @ body
+
 let render ?(thresholds = default_thresholds) (t : t) =
   let lines =
     _section_header ~title:"Release perf report" ~current:t.current_label
       ~prior:t.prior_label
     @ _trading_section t.paired
     @ _trade_quality_section t.paired
+    @ _optimal_strategy_section t.paired
     @ _rss_section ~thresholds t.paired
     @ _wall_section ~thresholds t.paired
     @ _one_sided_section ~title:"Current-only scenarios" t.current_only

--- a/trading/trading/backtest/release_report/release_report.mli
+++ b/trading/trading/backtest/release_report/release_report.mli
@@ -60,6 +60,45 @@ type summary_meta = {
     the run-identifying fields that are useful in a comparison header; detailed
     per-metric data is already in [actual]. *)
 
+type optimal_summary = {
+  total_round_trips : int;
+  winners : int;
+  losers : int;
+  total_return_pct : float;
+      (** Cumulative counterfactual return, expressed as a fraction (e.g. [0.42]
+          = +42%). Mirrors the [Optimal_types.optimal_summary.total_return_pct]
+          contract — multiply by 100 to compare to {!actual.total_return_pct}
+          which is already in percentage units. *)
+  win_rate_pct : float;
+      (** Counterfactual win rate as a fraction in [0.0, 1.0]. *)
+  avg_r_multiple : float;
+  profit_factor : float;
+  max_drawdown_pct : float;
+      (** Counterfactual peak-to-trough drawdown as a fraction in [0.0, 1.0]. *)
+}
+[@@deriving sexp]
+(** One variant's headline counterfactual metrics. Mirrors the on-disk shape
+    that {!Backtest_optimal.Optimal_strategy_runner} writes to
+    [optimal_summary.sexp] for the [Constrained] and [Relaxed_macro] variants;
+    fields are decoded with [@@sexp.allow_extra_fields] so the reader survives
+    forward additions to the producing record (e.g. a future [variant] tag). *)
+
+type optimal_summary_pair = {
+  constrained : optimal_summary;
+      (** Counterfactual variant honouring the macro gate — the honest
+          comparison against the actual run. *)
+  relaxed_macro : optimal_summary;
+      (** Counterfactual variant ignoring the macro gate — the upper bound. *)
+  report_path : string;
+      (** Relative path (from the scenario directory's parent batch root) to
+          [optimal_strategy.md] — used to render a markdown link in the report's
+          per-scenario row. Always [<scenario_name>/optimal_strategy.md]. *)
+}
+[@@deriving sexp]
+(** The [optimal_summary.sexp] artefact + the relative link the report renders
+    alongside it. Built by {!load_scenario_run} when both files are present in
+    the scenario dir. *)
+
 type scenario_run = {
   name : string;
   actual : actual;
@@ -72,14 +111,22 @@ type scenario_run = {
           trail, or when [trades.csv] is missing. The report renders an
           additional "Trade quality" section for paired scenarios where at least
           one side has [Some _]. *)
+  optimal_strategy : optimal_summary_pair option;
+      (** Loaded from [optimal_summary.sexp] + [optimal_strategy.md] in the
+          scenario dir when present. [None] for scenarios that did not run the
+          [optimal_strategy.exe] binary against their output dir. The report
+          renders an additional "Optimal-strategy delta" section for paired
+          scenarios where at least one side has [Some _]. *)
 }
 [@@deriving sexp]
 (** One scenario's per-run readings — the [actual] block plus optional
-    infra-perf measurements and an optional trade-audit summary. Both
-    [peak_rss_kb] and [wall_seconds] are [None] when the corresponding sibling
-    files are absent in the batch dir; the report still renders trading metrics
-    in that case. [trade_quality] is [None] when no audit artefacts were found
-    or when the audit was empty (no trades). *)
+    infra-perf measurements, an optional trade-audit summary, and an optional
+    optimal-strategy counterfactual summary. Both [peak_rss_kb] and
+    [wall_seconds] are [None] when the corresponding sibling files are absent in
+    the batch dir; the report still renders trading metrics in that case.
+    [trade_quality] is [None] when no audit artefacts were found or when the
+    audit was empty (no trades). [optimal_strategy] is [None] when no
+    [optimal_summary.sexp] was emitted. *)
 
 type t = {
   current_label : string;

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -886,6 +886,77 @@ let test_load_scenario_run_no_optimal_when_md_missing _ =
   let run = Release_report.load_scenario_run ~dir:scenario_dir in
   assert_that run.optimal_strategy is_none
 
+let test_load_scenario_run_no_optimal_when_sexp_missing_but_md_present _ =
+  (* Mirror image of the prior test: pins the asymmetric branch of the
+     both-must-exist guard. If the markdown report is staged but the
+     structured sexp is absent, the loader still returns [None] because
+     there is nothing to deserialise. *)
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_optstrat_" in
+  _make_scenario_dir ~root:dir "md-only" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "md-only" in
+  _write_text
+    (Filename.concat scenario_dir "optimal_strategy.md")
+    "# Optimal-strategy counterfactual\n";
+  (* No optimal_summary.sexp staged. *)
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.optimal_strategy is_none
+
+let test_load_scenario_run_no_optimal_when_sexp_malformed _ =
+  (* Pins the [try ... with _ -> None] swallow on parse failure. Both files
+     are present, so the existence guard is satisfied, but the sexp is not
+     valid syntax — the loader must return [None] rather than raise. *)
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_optstrat_" in
+  _make_scenario_dir ~root:dir "malformed-sexp" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "malformed-sexp" in
+  _write_text
+    (Filename.concat scenario_dir "optimal_summary.sexp")
+    "this is not valid sexp\n";
+  _write_text
+    (Filename.concat scenario_dir "optimal_strategy.md")
+    "# Optimal-strategy counterfactual\n";
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.optimal_strategy is_none
+
+let test_load_scenario_run_loads_optimal_strategy_with_extra_fields _ =
+  (* Pins the outer [_optimal_summary_artefact_on_disk] record's
+     [@@sexp.allow_extra_fields] — the existing happy-path test only
+     exercises [@@sexp.allow_extra_fields] on the inner [optimal_summary]
+     record (via the [variant] field tolerance). Here we add a wholly new
+     outer field [(future_extension foo)] that the type does not know
+     about; the loader must accept it and still surface the known
+     [total_return_pct] values. *)
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_optstrat_" in
+  _make_scenario_dir ~root:dir "with-extra" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "with-extra" in
+  _write_text
+    (Filename.concat scenario_dir "optimal_summary.sexp")
+    "((constrained ((total_round_trips 50) (winners 25) (losers 25)\n\
+    \                (total_return_pct 0.30) (win_rate_pct 0.50)\n\
+    \                (avg_r_multiple 0.40) (profit_factor 1.20)\n\
+    \                (max_drawdown_pct 0.10) (variant Constrained)))\n\
+    \ (relaxed_macro ((total_round_trips 60) (winners 32) (losers 28)\n\
+    \                  (total_return_pct 0.35) (win_rate_pct 0.53)\n\
+    \                  (avg_r_multiple 0.45) (profit_factor 1.25)\n\
+    \                  (max_drawdown_pct 0.12) (variant Relaxed_macro)))\n\
+    \ (future_extension foo))\n";
+  _write_text
+    (Filename.concat scenario_dir "optimal_strategy.md")
+    "# Optimal-strategy counterfactual\n";
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.optimal_strategy
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (p : Release_report.optimal_summary_pair) ->
+                p.constrained.total_return_pct)
+              (float_equal 0.30);
+            field
+              (fun (p : Release_report.optimal_summary_pair) ->
+                p.relaxed_macro.total_return_pct)
+              (float_equal 0.35);
+          ]))
+
 let suite =
   "release_perf_report"
   >::: [
@@ -927,6 +998,13 @@ let suite =
          >:: test_load_scenario_run_no_optimal_when_files_missing;
          "load_scenario_run no optimal_strategy when md missing"
          >:: test_load_scenario_run_no_optimal_when_md_missing;
+         "load_scenario_run no optimal_strategy when sexp missing but md \
+          present"
+         >:: test_load_scenario_run_no_optimal_when_sexp_missing_but_md_present;
+         "load_scenario_run no optimal_strategy when sexp malformed"
+         >:: test_load_scenario_run_no_optimal_when_sexp_malformed;
+         "load_scenario_run loads optimal_strategy with extra outer fields"
+         >:: test_load_scenario_run_loads_optimal_strategy_with_extra_fields;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -35,11 +35,42 @@ let _make_summary ?(start_date = Date.of_string "2023-01-02")
   }
 
 let _make_run ?(name = "scenario") ?actual ?summary ?(peak_rss_kb = None)
-    ?(wall_seconds = None) ?(trade_quality = None) () :
-    Release_report.scenario_run =
+    ?(wall_seconds = None) ?(trade_quality = None) ?(optimal_strategy = None) ()
+    : Release_report.scenario_run =
   let actual = Option.value actual ~default:(_make_actual ()) in
   let summary = Option.value summary ~default:(_make_summary ()) in
-  { name; actual; summary; peak_rss_kb; wall_seconds; trade_quality }
+  {
+    name;
+    actual;
+    summary;
+    peak_rss_kb;
+    wall_seconds;
+    trade_quality;
+    optimal_strategy;
+  }
+
+let _make_optimal_summary ?(total_round_trips = 50) ?(winners = 25)
+    ?(losers = 25) ?(total_return_pct = 0.30) ?(win_rate_pct = 0.50)
+    ?(avg_r_multiple = 0.40) ?(profit_factor = 1.20) ?(max_drawdown_pct = 0.10)
+    () : Release_report.optimal_summary =
+  {
+    total_round_trips;
+    winners;
+    losers;
+    total_return_pct;
+    win_rate_pct;
+    avg_r_multiple;
+    profit_factor;
+    max_drawdown_pct;
+  }
+
+let _make_optimal_pair ?(constrained = _make_optimal_summary ())
+    ?(relaxed_macro =
+      _make_optimal_summary ~total_return_pct:0.35 ~total_round_trips:60
+        ~winners:32 ~losers:28 ())
+    ?(report_path = "scenario/optimal_strategy.md") () :
+    Release_report.optimal_summary_pair =
+  { constrained; relaxed_macro; report_path }
 
 (* --- default_thresholds --- *)
 
@@ -619,6 +650,242 @@ let test_load_scenario_run_no_trade_quality_when_trades_csv_missing _ =
   let run = Release_report.load_scenario_run ~dir:scenario_dir in
   assert_that run.trade_quality is_none
 
+(* --- Optimal-strategy delta section ---
+
+   For paired scenarios where at least one side has [Some _] optimal-strategy
+   artefacts, the renderer surfaces a counterfactual comparison plus a link to
+   the per-scenario [optimal_strategy.md]. These tests pin the section's
+   omission, presence, and Δ computation. *)
+
+let test_render_omits_optimal_strategy_when_both_none _ =
+  let cur = _make_run ~name:"recovery-2023" () in
+  let prior = _make_run ~name:"recovery-2023" () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s ->
+             String.is_substring s ~substring:"## Optimal-strategy delta")
+           (equal_to false);
+         field
+           (fun s -> String.is_substring s ~substring:"Optimal (constrained)")
+           (equal_to false);
+       ])
+
+let test_render_includes_optimal_strategy_when_present _ =
+  (* Hand-computed Δ:
+       Actual cur = 18.5%, constrained = 30.0%, relaxed = 35.0%
+         => Δ_constrained = 30.0 - 18.5 = +11.50 pp
+         => Δ_relaxed     = 35.0 - 18.5 = +16.50 pp
+       Actual prior = 12.0%, constrained = 25.0%, relaxed = 28.0%
+         => Δ_constrained = 25.0 - 12.0 = +13.00 pp
+         => Δ_relaxed     = 28.0 - 12.0 = +16.00 pp *)
+  let cur =
+    _make_run ~name:"recovery-2023"
+      ~actual:(_make_actual ~total_return_pct:18.5 ())
+      ~optimal_strategy:
+        (Some
+           (_make_optimal_pair
+              ~constrained:(_make_optimal_summary ~total_return_pct:0.30 ())
+              ~relaxed_macro:(_make_optimal_summary ~total_return_pct:0.35 ())
+              ~report_path:"recovery-2023/optimal_strategy.md" ()))
+      ()
+  in
+  let prior =
+    _make_run ~name:"recovery-2023"
+      ~actual:(_make_actual ~total_return_pct:12.0 ())
+      ~optimal_strategy:
+        (Some
+           (_make_optimal_pair
+              ~constrained:(_make_optimal_summary ~total_return_pct:0.25 ())
+              ~relaxed_macro:(_make_optimal_summary ~total_return_pct:0.28 ())
+              ~report_path:"recovery-2023/optimal_strategy.md" ()))
+      ()
+  in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s ->
+             String.is_substring s ~substring:"## Optimal-strategy delta")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"### recovery-2023")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:
+                 "Report — Current: \
+                  [optimal_strategy.md](recovery-2023/optimal_strategy.md) · \
+                  Prior: \
+                  [optimal_strategy.md](recovery-2023/optimal_strategy.md)")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Actual total return | +18.50% | +12.00% |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Optimal (constrained) | +30.00% | +25.00% |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Δ to constrained | +11.50 pp | +13.00 pp |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Optimal (relaxed macro) | +35.00% | +28.00% |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Δ to relaxed | +16.50 pp | +16.00 pp |")
+           (equal_to true);
+       ])
+
+let test_render_optimal_strategy_handles_one_sided _ =
+  (* Only current side has artefacts — prior renders "—" in the variant /
+     delta cells and the prior link cell. *)
+  let cur =
+    _make_run ~name:"recovery-2023"
+      ~actual:(_make_actual ~total_return_pct:18.5 ())
+      ~optimal_strategy:
+        (Some
+           (_make_optimal_pair
+              ~constrained:(_make_optimal_summary ~total_return_pct:0.30 ())
+              ~relaxed_macro:(_make_optimal_summary ~total_return_pct:0.35 ())
+              ~report_path:"recovery-2023/optimal_strategy.md" ()))
+      ()
+  in
+  let prior =
+    _make_run ~name:"recovery-2023"
+      ~actual:(_make_actual ~total_return_pct:12.0 ())
+      ()
+  in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         (* Section still renders because at least one side has artefacts. *)
+         field
+           (fun s ->
+             String.is_substring s ~substring:"## Optimal-strategy delta")
+           (equal_to true);
+         (* Prior link cell shows the em-dash placeholder. *)
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:
+                 "Report — Current: \
+                  [optimal_strategy.md](recovery-2023/optimal_strategy.md) · \
+                  Prior: —")
+           (equal_to true);
+         (* Prior variant + Δ cells are em-dashes. *)
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Optimal (constrained) | +30.00% | — |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Δ to constrained | +11.50 pp | — |")
+           (equal_to true);
+       ])
+
+(* --- Loader: optimal-strategy round-trip via on-disk fixtures --- *)
+
+let _write_optimal_summary_sexp path =
+  _write_text path
+    "((constrained ((total_round_trips 50) (winners 25) (losers 25)\n\
+    \                (total_return_pct 0.30) (win_rate_pct 0.50)\n\
+    \                (avg_r_multiple 0.40) (profit_factor 1.20)\n\
+    \                (max_drawdown_pct 0.10) (variant Constrained)))\n\
+    \ (relaxed_macro ((total_round_trips 60) (winners 32) (losers 28)\n\
+    \                  (total_return_pct 0.35) (win_rate_pct 0.53)\n\
+    \                  (avg_r_multiple 0.45) (profit_factor 1.25)\n\
+    \                  (max_drawdown_pct 0.12) (variant Relaxed_macro))))\n"
+
+let test_load_scenario_run_loads_optimal_strategy_when_present _ =
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_optstrat_" in
+  _make_scenario_dir ~root:dir "with-optimal" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "with-optimal" in
+  _write_optimal_summary_sexp
+    (Filename.concat scenario_dir "optimal_summary.sexp");
+  _write_text
+    (Filename.concat scenario_dir "optimal_strategy.md")
+    "# Optimal-strategy counterfactual\n";
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.optimal_strategy
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (p : Release_report.optimal_summary_pair) ->
+                p.constrained.total_return_pct)
+              (float_equal 0.30);
+            field
+              (fun (p : Release_report.optimal_summary_pair) ->
+                p.relaxed_macro.total_return_pct)
+              (float_equal 0.35);
+            field
+              (fun (p : Release_report.optimal_summary_pair) -> p.report_path)
+              (equal_to "with-optimal/optimal_strategy.md");
+          ]))
+
+let test_load_scenario_run_no_optimal_when_files_missing _ =
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_optstrat_" in
+  _make_scenario_dir ~root:dir "no-optimal" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "no-optimal" in
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.optimal_strategy is_none
+
+let test_load_scenario_run_no_optimal_when_md_missing _ =
+  (* Both the structured sexp and the markdown report must exist; if one is
+     missing, the loader returns [None] (the link target would 404). *)
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_optstrat_" in
+  _make_scenario_dir ~root:dir "sexp-only" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "sexp-only" in
+  _write_optimal_summary_sexp
+    (Filename.concat scenario_dir "optimal_summary.sexp");
+  (* No optimal_strategy.md staged. *)
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.optimal_strategy is_none
+
 let suite =
   "release_perf_report"
   >::: [
@@ -648,6 +915,18 @@ let suite =
          >:: test_load_scenario_run_loads_trade_quality_when_present;
          "load_scenario_run no trade_quality when trades.csv missing"
          >:: test_load_scenario_run_no_trade_quality_when_trades_csv_missing;
+         "render omits optimal-strategy when both none"
+         >:: test_render_omits_optimal_strategy_when_both_none;
+         "render includes optimal-strategy when present"
+         >:: test_render_includes_optimal_strategy_when_present;
+         "render optimal-strategy handles one-sided"
+         >:: test_render_optimal_strategy_handles_one_sided;
+         "load_scenario_run loads optimal_strategy when present"
+         >:: test_load_scenario_run_loads_optimal_strategy_when_present;
+         "load_scenario_run no optimal_strategy when files missing"
+         >:: test_load_scenario_run_no_optimal_when_files_missing;
+         "load_scenario_run no optimal_strategy when md missing"
+         >:: test_load_scenario_run_no_optimal_when_md_missing;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR-5 of the optimal-strategy track: wires `optimal_strategy.exe`'s
counterfactual output into `release_perf_report` so each scenario surfaces
its delta to the perfect-hindsight greedy fill alongside a markdown link to
the per-scenario `optimal_strategy.md`.

- **Producer side** (`optimal_strategy_runner`): now emits a structured
  `<output_dir>/optimal_summary.sexp` artefact alongside the existing
  markdown report, via the new `Optimal_summary_artefact` lib module
  (a 14-line two-field record carrying both `Constrained` and
  `Relaxed_macro` variants of `Optimal_summary.t`).
- **Consumer side** (`release_report`): `load_scenario_run` now
  optionally loads `optimal_summary.sexp` + verifies
  `optimal_strategy.md` exists alongside it (avoids 404 links). New
  "Optimal-strategy delta" section renders a per-scenario sub-table
  with the actual return, both counterfactual variants, both Δs (in
  percentage points), and the markdown link. Missing artefacts on
  either side render as `—`; the section is omitted entirely when both
  sides are missing.

The release report keeps its existing trading-metrics / trade-quality /
RSS / wall-time sections; the new section sits between trade-quality and
RSS.

## Decision: structured sexp over markdown parsing

The task brief offered a choice between parsing the existing
`optimal_strategy.md` (brittle — sections may shift as the renderer
evolves) or adding a structured emit. I went with the structured emit
because:

1. `Optimal_types.optimal_summary` already derives `[@@deriving sexp]`,
   so the producer side is a one-line write.
2. The renderer's section ordering / wording is not stable; markdown
   parsing would couple the consumer to display details.
3. `release_report` mirrors the on-disk record locally with
   `[@@sexp.allow_extra_fields]`, so it doesn't have to depend on the
   heavy `backtest_optimal` library. Future field additions on the
   producer side (e.g. a new `variant_label` tag) won't break the
   consumer.

The new `Optimal_summary_artefact` module is the explicit on-disk
contract surface — both the producer (`Optimal_strategy_runner._emit_report`)
and the consumer ([`release_report._optimal_summary_artefact_on_disk`])
reference it for the shape.

## Example: scenario row before vs after

**Before** (release report's per-scenario row):

```
### sp500-2019-2023

Period: 2019-01-04 → 2023-12-29 · Universe: 503 · Steps: 1257

| Metric | Current | Prior | Δ% |
|---|---:|---:|---:|
| Return % | 18.50 | 12.00 | +54.2% |
| Sharpe | 0.26 | 0.20 | +30.0% |
…
```

**After**: the trading-metrics row is unchanged, plus a new section:

```
## Optimal-strategy delta

Counterfactual comparison against the perfect-hindsight greedy fill
under the same sizing envelope (`optimal_summary.sexp` required). Δ is
constrained-counterfactual minus actual, in percentage points — positive
means the cascade ranking left return on the table; negative (rare)
means the actual run outperformed the counterfactual under sizing caps.
Per-Friday divergence detail lives in the linked `optimal_strategy.md`.

### sp500-2019-2023

Report — Current: [optimal_strategy.md](sp500-2019-2023/optimal_strategy.md) · Prior: [optimal_strategy.md](sp500-2019-2023/optimal_strategy.md)

| Metric | Current | Prior |
|---|---:|---:|
| Actual total return | +18.50% | +12.00% |
| Optimal (constrained) | +30.00% | +25.00% |
| Δ to constrained | +11.50 pp | +13.00 pp |
| Optimal (relaxed macro) | +35.00% | +28.00% |
| Δ to relaxed | +16.50 pp | +16.00 pp |
```

## Files

New module:
- `trading/trading/backtest/optimal/lib/optimal_summary_artefact.{ml,mli}` — structured artefact + writer.

Modified:
- `trading/trading/backtest/optimal/lib/optimal_strategy_runner.{ml,mli}` — `_emit_report` writes the artefact after the markdown emit; mli's I/O surface lists the new file.
- `trading/trading/backtest/release_report/release_report.{ml,mli}` — adds `optimal_summary` / `optimal_summary_pair` types, `_try_load_optimal_summary` loader, `_optimal_strategy_section` renderer.
- Tests + status entry.

## Test plan

- [x] `dev/lib/run-in-env.sh dune build` — clean.
- [x] `dev/lib/run-in-env.sh dune build @fmt` — no diff.
- [x] `dev/lib/run-in-env.sh dune exec trading/backtest/test/test_release_perf_report.exe` — 22/22 pass (was 16; +6 new cases for the section's omission, full-pin, one-sided, and on-disk loader paths).
- [x] `dev/lib/run-in-env.sh dune exec trading/backtest/optimal/test/test_optimal_strategy_runner.exe` — 3/3 pass (was 2; +1 new case asserting `optimal_summary.sexp` is emitted with both `Constrained` / `Relaxed_macro` variants tagged).

## Out of scope

- Bin invocation orchestration. The release report assumes the bin has
  already been run for each scenario; running it is left to the
  scenario_runner / orchestrator.
- Cross-scenario aggregation (e.g. a portfolio-wide Δ table). The
  per-scenario sub-table format mirrors the existing trade-quality
  section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
