### PR TITLE
feat(metrics): pair Sell→Buy short round-trips in extract_round_trips (G2)

### DIFF
--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -74,10 +74,18 @@ let _stop_fields (info : Stop_log.stop_info option) =
         _fmt_float_opt i.exit_stop,
         Option.value_map i.exit_trigger ~default:"" ~f:_exit_trigger_label )
 
+(** Direction label for a round-trip's entry leg, surfaced as the [side] column
+    in [trades.csv]. [LONG] = Buy→Sell round-trip; [SHORT] = Sell→Buy round-trip
+    (closing buy covers the short). *)
+let _side_label = function
+  | Trading_base.Types.Buy -> "LONG"
+  | Trading_base.Types.Sell -> "SHORT"
+
 let _write_trade_row oc stop_index (t : Metrics.trade_metrics) =
   let info = _pop_stop_info stop_index ~symbol:t.symbol in
   let entry_stop, exit_stop, exit_trigger = _stop_fields info in
-  fprintf oc "%s,%s,%s,%d,%.2f,%.2f,%.0f,%.2f,%.2f,%s,%s,%s\n" t.symbol
+  fprintf oc "%s,%s,%s,%s,%d,%.2f,%.2f,%.0f,%.2f,%.2f,%s,%s,%s\n" t.symbol
+    (_side_label t.side)
     (Date.to_string t.entry_date)
     (Date.to_string t.exit_date)
     t.days_held t.entry_price t.exit_price t.quantity t.pnl_dollars
@@ -88,7 +96,7 @@ let _write_trades ~output_dir ~(round_trips : Metrics.trade_metrics list)
   let path = output_dir ^ "/trades.csv" in
   let oc = Out_channel.create path in
   let header =
-    "symbol,entry_date,exit_date,days_held,entry_price,exit_price,"
+    "symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,"
     ^ "quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger"
   in
   fprintf oc "%s\n" header;

--- a/trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml
@@ -45,33 +45,81 @@ let _load_summary_sexp ~output_dir : _summary_sexp_shape =
     failwithf "Missing summary.sexp at %s" path ();
   _summary_sexp_shape_of_sexp (Sexp.load_sexp path)
 
-(** Parse one trades.csv line. Format set by [Backtest.Result_writer]:
-    [symbol,entry_date,exit_date,days_held,entry_price,exit_price,quantity,
-     pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger]. Columns after
-    [pnl_percent] are read but discarded — the renderer only consumes the first
-    9. *)
-let _parse_trade_row line : Trading_simulation.Metrics.trade_metrics option =
-  match String.split line ~on:',' with
-  | symbol :: entry_date :: exit_date :: days_held :: entry_price :: exit_price
-    :: quantity :: pnl_dollars :: pnl_percent :: _stop_fields -> (
-      try
-        Some
-          {
-            symbol;
-            entry_date = Date.of_string entry_date;
-            exit_date = Date.of_string exit_date;
-            days_held = Int.of_string days_held;
-            entry_price = Float.of_string entry_price;
-            exit_price = Float.of_string exit_price;
-            quantity = Float.of_string quantity;
-            pnl_dollars = Float.of_string pnl_dollars;
-            pnl_percent = Float.of_string pnl_percent;
-          }
-      with exn ->
-        eprintf "optimal_strategy: skipping malformed trade row (%s)\n%!"
-          (Exn.to_string exn);
-        None)
+(** Parse the [side] column. [Backtest.Result_writer] emits [LONG] for a
+    Buy→Sell round-trip and [SHORT] for a Sell→Buy round-trip. The
+    [trade_metrics.side] field stores the entry-leg side, so [LONG]→[Buy] and
+    [SHORT]→[Sell]. Any unknown label falls back to [Buy] to keep parsing
+    permissive against pre-G2 trades.csv files that omit the column. *)
+let _parse_side = function
+  | "LONG" -> Trading_base.Types.Buy
+  | "SHORT" -> Trading_base.Types.Sell
+  | _ -> Trading_base.Types.Buy
+
+(** Build a [trade_metrics] from already-parsed string cells. Common builder
+    shared by the post-G2 [(symbol, side, …)] layout and the legacy
+    [(symbol, …)] layout, so adding new columns in one place doesn't require
+    chasing two parser branches. *)
+let _trade_metrics_of_strings ~symbol ~side ~entry_date ~exit_date ~days_held
+    ~entry_price ~exit_price ~quantity ~pnl_dollars ~pnl_percent :
+    Trading_simulation.Metrics.trade_metrics =
+  {
+    symbol;
+    side = _parse_side side;
+    entry_date = Date.of_string entry_date;
+    exit_date = Date.of_string exit_date;
+    days_held = Int.of_string days_held;
+    entry_price = Float.of_string entry_price;
+    exit_price = Float.of_string exit_price;
+    quantity = Float.of_string quantity;
+    pnl_dollars = Float.of_string pnl_dollars;
+    pnl_percent = Float.of_string pnl_percent;
+  }
+
+(** Match a post-G2 row layout ([symbol,side,…] with [side] = [LONG]/[SHORT]).
+    Returns [None] when [cells] doesn't have the post-G2 column count or the
+    second cell isn't a valid side tag. *)
+let _match_post_g2_row cells : Trading_simulation.Metrics.trade_metrics option =
+  match cells with
+  | symbol
+    :: ("LONG" as side)
+    :: entry_date :: exit_date :: days_held :: entry_price :: exit_price
+    :: quantity :: pnl_dollars :: pnl_percent :: _stop_fields
+  | symbol
+    :: ("SHORT" as side)
+    :: entry_date :: exit_date :: days_held :: entry_price :: exit_price
+    :: quantity :: pnl_dollars :: pnl_percent :: _stop_fields ->
+      Some
+        (_trade_metrics_of_strings ~symbol ~side ~entry_date ~exit_date
+           ~days_held ~entry_price ~exit_price ~quantity ~pnl_dollars
+           ~pnl_percent)
   | _ -> None
+
+(** Match a legacy (pre-G2) row layout: [symbol,entry_date,…]. Defaults [side]
+    to [Buy] preserving the historical long-only semantics. *)
+let _match_legacy_row cells : Trading_simulation.Metrics.trade_metrics option =
+  match cells with
+  | symbol :: entry_date :: exit_date :: days_held :: entry_price :: exit_price
+    :: quantity :: pnl_dollars :: pnl_percent :: _stop_fields ->
+      Some
+        (_trade_metrics_of_strings ~symbol ~side:"LONG" ~entry_date ~exit_date
+           ~days_held ~entry_price ~exit_price ~quantity ~pnl_dollars
+           ~pnl_percent)
+  | _ -> None
+
+(** Parse one trades.csv line. Tolerates the post-G2 [(symbol,side,…)] layout
+    and the legacy [(symbol,…)] layout — see {!_match_post_g2_row} and
+    {!_match_legacy_row}. Conversion exceptions surface as a warning + [None].
+*)
+let _parse_trade_row line : Trading_simulation.Metrics.trade_metrics option =
+  let cells = String.split line ~on:',' in
+  try
+    match _match_post_g2_row cells with
+    | Some _ as t -> t
+    | None -> _match_legacy_row cells
+  with exn ->
+    eprintf "optimal_strategy: skipping malformed trade row (%s)\n%!"
+      (Exn.to_string exn);
+    None
 
 let _load_trades ~output_dir : Trading_simulation.Metrics.trade_metrics list =
   let path = Filename.concat output_dir "trades.csv" in

--- a/trading/trading/backtest/optimal/test/dune
+++ b/trading/trading/backtest/optimal/test/dune
@@ -3,6 +3,7 @@
   test_stage_transition_scanner
   test_outcome_scorer
   test_optimal_portfolio_filler
+  test_optimal_run_artefacts
   test_optimal_summary
   test_optimal_strategy_report
   test_optimal_strategy_runner)

--- a/trading/trading/backtest/optimal/test/test_optimal_run_artefacts.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_run_artefacts.ml
@@ -1,0 +1,217 @@
+(** Round-trip tests for [Backtest_optimal.Optimal_run_artefacts.load].
+
+    Pins the on-disk [trades.csv] contract that the loader consumes: the post-G2
+    13-column layout (with a [side] column) emitted by [Backtest.Result_writer]
+    AND the legacy 12-column layout still produced by pre-G2 runs. Both LONG
+    (Buy→Sell) and SHORT (Sell→Buy) round-trip rows must parse with the correct
+    entry-leg [side] tag.
+
+    The {!_canonical_post_g2_header} literal mirrors the writer-side header in
+    [Backtest.Result_writer._write_trades] verbatim. Schema drift on either side
+    will fail one of the parser tests loudly. *)
+
+open OUnit2
+open Core
+open Matchers
+module RA = Backtest_optimal.Optimal_run_artefacts
+
+(* --- Canonical CSV header literals ------------------------------------- *)
+
+(** Mirrors [Backtest.Result_writer._write_trades]'s post-G2 header verbatim. A
+    drift here means the writer's column list changed and the post-G2 parser
+    fixtures below are stale — pin both sides against the same string. *)
+let _canonical_post_g2_header =
+  "symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger"
+
+(** Mirrors the pre-G2 header (no [side] column). Kept around so the loader's
+    legacy fallback branch stays exercised. *)
+let _canonical_legacy_header =
+  "symbol,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger"
+
+(* --- Fixture staging --------------------------------------------------- *)
+
+let _date d = Date.of_string d
+let _write_text path text = Out_channel.write_all path ~data:text
+
+let _write_summary_sexp ~output_dir =
+  let path = Filename.concat output_dir "summary.sexp" in
+  _write_text path
+    "((start_date 2024-01-05) (end_date 2024-04-30) (universe_size 1) (n_steps \
+     5) (initial_cash 10000.00) (final_portfolio_value 10500.00) \
+     (n_round_trips 2) (metrics ()))"
+
+let _write_actual_sexp ~output_dir =
+  let path = Filename.concat output_dir "actual.sexp" in
+  _write_text path
+    "((total_return_pct 5.00) (total_trades 2.00) (win_rate 100.00) \
+     (sharpe_ratio 0.50) (max_drawdown_pct 1.00) (avg_holding_days 30.00) \
+     (unrealized_pnl 0.00))"
+
+let _write_trades_csv ~output_dir ~contents =
+  _write_text (Filename.concat output_dir "trades.csv") contents
+
+let _stage_run_dir ~prefix ~trades_csv =
+  let output_dir = Core_unix.mkdtemp ("/tmp/" ^ prefix ^ "_") in
+  _write_summary_sexp ~output_dir;
+  _write_actual_sexp ~output_dir;
+  _write_trades_csv ~output_dir ~contents:trades_csv;
+  output_dir
+
+(* --- Post-G2 round-trip tests ------------------------------------------ *)
+
+(* A LONG round-trip emitted by Result_writer in the post-G2 layout: AAPL
+   bought at 150, sold at 165, +15.00 pnl_$, +10.00%, with stop annotations. *)
+let _long_row =
+  "AAPL,LONG,2024-01-15,2024-02-20,36,150.00,165.00,10,150.00,10.00,140.00,160.00,signal_reversal"
+
+(* A SHORT round-trip: TSLA sold short at 200, covered at 180, +20 pnl_$,
+   +10.00%. The entry leg's side tag is SHORT — i.e. [Trading_base.Types.Sell]. *)
+let _short_row =
+  "TSLA,SHORT,2024-03-04,2024-04-08,35,200.00,180.00,5,100.00,10.00,210.00,185.00,stop_loss"
+
+let test_load_post_g2_long_only_round_trip _ =
+  let csv = _canonical_post_g2_header ^ "\n" ^ _long_row ^ "\n" in
+  let output_dir =
+    _stage_run_dir ~prefix:"opt_artefacts_long" ~trades_csv:csv
+  in
+  let inputs = RA.load ~output_dir in
+  assert_that inputs.trades
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.symbol)
+               (equal_to "AAPL");
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.side)
+               (equal_to Trading_base.Types.Buy);
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) ->
+                 t.quantity)
+               (float_equal 10.0);
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) ->
+                 t.pnl_dollars)
+               (float_equal 150.00);
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) ->
+                 t.pnl_percent)
+               (float_equal 10.00);
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) ->
+                 t.entry_date)
+               (equal_to (_date "2024-01-15"));
+           ];
+       ])
+
+let test_load_post_g2_short_only_round_trip _ =
+  let csv = _canonical_post_g2_header ^ "\n" ^ _short_row ^ "\n" in
+  let output_dir =
+    _stage_run_dir ~prefix:"opt_artefacts_short" ~trades_csv:csv
+  in
+  let inputs = RA.load ~output_dir in
+  (* SHORT row must round-trip with side = Sell — this is the new G2 contract. *)
+  assert_that inputs.trades
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.symbol)
+               (equal_to "TSLA");
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.side)
+               (equal_to Trading_base.Types.Sell);
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) ->
+                 t.entry_price)
+               (float_equal 200.00);
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) ->
+                 t.exit_price)
+               (float_equal 180.00);
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) ->
+                 t.pnl_dollars)
+               (float_equal 100.00);
+           ];
+       ])
+
+let test_load_post_g2_mixed_long_and_short _ =
+  let csv =
+    _canonical_post_g2_header ^ "\n" ^ _long_row ^ "\n" ^ _short_row ^ "\n"
+  in
+  let output_dir =
+    _stage_run_dir ~prefix:"opt_artefacts_mixed" ~trades_csv:csv
+  in
+  let inputs = RA.load ~output_dir in
+  assert_that inputs.trades
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.symbol)
+               (equal_to "AAPL");
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.side)
+               (equal_to Trading_base.Types.Buy);
+           ];
+         all_of
+           [
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.symbol)
+               (equal_to "TSLA");
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.side)
+               (equal_to Trading_base.Types.Sell);
+           ];
+       ])
+
+(* --- Legacy (pre-G2) regression --------------------------------------- *)
+
+let test_load_legacy_12_col_defaults_to_buy _ =
+  (* Pre-G2 trades.csv files have no [side] column. The loader must keep parsing
+     them, defaulting [side] to [Buy] preserving the historical long-only
+     semantics. *)
+  let legacy_row =
+    "AAPL,2024-01-15,2024-02-20,36,150.00,165.00,10,150.00,10.00,140.00,160.00,signal_reversal"
+  in
+  let csv = _canonical_legacy_header ^ "\n" ^ legacy_row ^ "\n" in
+  let output_dir =
+    _stage_run_dir ~prefix:"opt_artefacts_legacy" ~trades_csv:csv
+  in
+  let inputs = RA.load ~output_dir in
+  assert_that inputs.trades
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.symbol)
+               (equal_to "AAPL");
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) -> t.side)
+               (equal_to Trading_base.Types.Buy);
+             field
+               (fun (t : Trading_simulation.Metrics.trade_metrics) ->
+                 t.pnl_dollars)
+               (float_equal 150.00);
+           ];
+       ])
+
+let suite =
+  "Optimal_run_artefacts"
+  >::: [
+         "load post-G2 LONG round-trip"
+         >:: test_load_post_g2_long_only_round_trip;
+         "load post-G2 SHORT round-trip"
+         >:: test_load_post_g2_short_only_round_trip;
+         "load post-G2 mixed LONG and SHORT"
+         >:: test_load_post_g2_mixed_long_and_short;
+         "load legacy 12-col defaults to Buy"
+         >:: test_load_legacy_12_col_defaults_to_buy;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml
@@ -43,9 +43,11 @@ let _make_actual ?(scenario_name = "test-2024") ?(round_trips = []) () :
   }
 
 let _make_actual_trade ~symbol ~entry_date ~exit_date ~pnl_dollars ~pnl_percent
-    () : Trading_simulation.Metrics.trade_metrics =
+    ?(side = Trading_base.Types.Buy) () :
+    Trading_simulation.Metrics.trade_metrics =
   {
     symbol;
+    side;
     entry_date;
     exit_date;
     days_held = Date.diff exit_date entry_date;

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -458,11 +458,13 @@ let _make_audit_record ~symbol ~entry_date
   in
   { entry; exit_ = Some exit_ }
 
-let _make_trade ~symbol ~entry_date ?(days_held = 100) ?(entry_price = 100.0)
-    ?(exit_price = 110.0) ?(quantity = 100.0) ?(pnl_dollars = 1_000.0)
-    ?(pnl_percent = 10.0) () : Trading_simulation.Metrics.trade_metrics =
+let _make_trade ~symbol ~entry_date ?(side = Trading_base.Types.Buy)
+    ?(days_held = 100) ?(entry_price = 100.0) ?(exit_price = 110.0)
+    ?(quantity = 100.0) ?(pnl_dollars = 1_000.0) ?(pnl_percent = 10.0) () :
+    Trading_simulation.Metrics.trade_metrics =
   {
     symbol;
+    side;
     entry_date;
     exit_date = Date.add_days entry_date days_held;
     days_held;

--- a/trading/trading/backtest/test/test_trade_audit_ratings.ml
+++ b/trading/trading/backtest/test/test_trade_audit_ratings.ml
@@ -88,12 +88,14 @@ let make_exit ?(symbol = "AAPL") ?(exit_date = _date "2024-04-20")
 let make_record ?(exit_ = Some (make_exit ())) entry : TA.audit_record =
   { entry; exit_ }
 
-let make_trade ?(symbol = "AAPL") ?(entry_date = _date "2024-01-15")
-    ?(exit_date = _date "2024-04-20") ?(days_held = 96) ?(entry_price = 100.0)
-    ?(exit_price = 95.0) ?(quantity = 100.0) ?(pnl_dollars = -500.0)
-    ?(pnl_percent = -5.0) () : Trading_simulation.Metrics.trade_metrics =
+let make_trade ?(symbol = "AAPL") ?(side = Trading_base.Types.Buy)
+    ?(entry_date = _date "2024-01-15") ?(exit_date = _date "2024-04-20")
+    ?(days_held = 96) ?(entry_price = 100.0) ?(exit_price = 95.0)
+    ?(quantity = 100.0) ?(pnl_dollars = -500.0) ?(pnl_percent = -5.0) () :
+    Trading_simulation.Metrics.trade_metrics =
   {
     symbol;
+    side;
     entry_date;
     exit_date;
     days_held;

--- a/trading/trading/backtest/test/test_trade_audit_report.ml
+++ b/trading/trading/backtest/test/test_trade_audit_report.ml
@@ -19,12 +19,14 @@ module TA = Backtest.Trade_audit
 
 let _date d = Date.of_string d
 
-let make_trade ?(symbol = "AAPL") ?(entry_date = _date "2024-01-15")
-    ?(exit_date = _date "2024-04-20") ?(days_held = 96) ?(entry_price = 150.50)
-    ?(exit_price = 138.46) ?(quantity = 500.0) ?(pnl_dollars = -6_020.0)
-    ?(pnl_percent = -8.0) () : Trading_simulation.Metrics.trade_metrics =
+let make_trade ?(symbol = "AAPL") ?(side = Trading_base.Types.Buy)
+    ?(entry_date = _date "2024-01-15") ?(exit_date = _date "2024-04-20")
+    ?(days_held = 96) ?(entry_price = 150.50) ?(exit_price = 138.46)
+    ?(quantity = 500.0) ?(pnl_dollars = -6_020.0) ?(pnl_percent = -8.0) () :
+    Trading_simulation.Metrics.trade_metrics =
   {
     symbol;
+    side;
     entry_date;
     exit_date;
     days_held;

--- a/trading/trading/backtest/test/test_trade_audit_report.ml
+++ b/trading/trading/backtest/test/test_trade_audit_report.ml
@@ -494,6 +494,248 @@ let test_load_missing_trades_csv_raises _ =
   in
   assert_that result (equal_to (Error "raised" : (unit, string) Result.t))
 
+(* --- Loader: post-G2 13-column trades.csv -----------------------------
+
+   The G2 contract adds a [side] column to trades.csv, with values [LONG]
+   (Buy→Sell round-trip) and [SHORT] (Sell→Buy round-trip). The {!_canonical_post_g2_header}
+   literal mirrors [Backtest.Result_writer._write_trades]'s header verbatim so
+   schema drift on either side fails the parser tests below loudly. The legacy
+   12-column tests above continue to exercise the fallback parser branch. *)
+
+(** Mirror of [Backtest.Result_writer._write_trades]'s post-G2 header. *)
+let _canonical_post_g2_header =
+  "symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger"
+
+(* AAPL LONG round-trip: bought at 280, sold at 404, +12 400 / +44.20%. *)
+let _post_g2_long_row =
+  "AAPL,LONG,2020-04-25,2020-08-01,98,280.00,404.00,100,12400.00,44.20,260.00,400.00,signal_reversal"
+
+(* TSLA SHORT round-trip: shorted at 200, covered at 180, +1 000 / +10.00%. *)
+let _post_g2_short_row =
+  "TSLA,SHORT,2024-03-04,2024-04-08,35,200.00,180.00,50,1000.00,10.00,210.00,185.00,stop_loss"
+
+let _stage_post_g2_scenario ~prefix ~rows =
+  let dir = Core_unix.mkdtemp ("/tmp/trade_audit_report_" ^ prefix ^ "_") in
+  let scenario_dir = Filename.concat dir "scenario" in
+  Core_unix.mkdir_p scenario_dir;
+  let csv =
+    String.concat ~sep:"\n" (_canonical_post_g2_header :: rows) ^ "\n"
+  in
+  _write_text (Filename.concat scenario_dir "trades.csv") csv;
+  _write_summary_sexp (Filename.concat scenario_dir "summary.sexp");
+  scenario_dir
+
+let test_load_post_g2_long_round_trip _ =
+  let scenario_dir =
+    _stage_post_g2_scenario ~prefix:"post_g2_long" ~rows:[ _post_g2_long_row ]
+  in
+  let report = TAR.load ~scenario_dir in
+  (* TAR.load builds [per_trade_row]s whose [side] is sourced from the
+     trade-audit's [entry.side] when matched, OR defaulted to [Long] when no
+     audit is present. With no audit staged, the row's [side] field cannot
+     pin the LONG-vs-SHORT contract — the parser-level pin runs through the
+     trade_metrics list returned by [_read_trades_csv], which the report
+     surfaces only via header counts. We pin: 1 winner (LONG row had +pnl)
+     and the parsed pnl + price fields exposed in [per_trade_row]. *)
+  assert_that report
+    (all_of
+       [
+         field (fun (t : TAR.t) -> t.header.total_round_trips) (equal_to 1);
+         field (fun (t : TAR.t) -> t.header.winners) (equal_to 1);
+         field
+           (fun (t : TAR.t) -> t.rows)
+           (elements_are
+              [
+                all_of
+                  [
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.symbol)
+                      (equal_to "AAPL");
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.entry_price)
+                      (float_equal 280.00);
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.exit_price)
+                      (float_equal 404.00);
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.pnl_dollars)
+                      (float_equal 12_400.00);
+                  ];
+              ]);
+       ])
+
+let test_load_post_g2_short_round_trip _ =
+  let scenario_dir =
+    _stage_post_g2_scenario ~prefix:"post_g2_short" ~rows:[ _post_g2_short_row ]
+  in
+  let report = TAR.load ~scenario_dir in
+  (* SHORT row produces a positive pnl (covered below entry). The [side] field
+     in the parsed [trade_metrics] is [Sell] — see the parallel pin in
+     [test_optimal_run_artefacts.ml]. Here we pin the row-level fields surfaced
+     by the report. *)
+  assert_that report
+    (all_of
+       [
+         field (fun (t : TAR.t) -> t.header.total_round_trips) (equal_to 1);
+         field (fun (t : TAR.t) -> t.header.winners) (equal_to 1);
+         field
+           (fun (t : TAR.t) -> t.rows)
+           (elements_are
+              [
+                all_of
+                  [
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.symbol)
+                      (equal_to "TSLA");
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.entry_price)
+                      (float_equal 200.00);
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.exit_price)
+                      (float_equal 180.00);
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.pnl_dollars)
+                      (float_equal 1_000.00);
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.pnl_percent)
+                      (float_equal 10.00);
+                  ];
+              ]);
+       ])
+
+let test_load_post_g2_mixed_long_and_short _ =
+  let scenario_dir =
+    _stage_post_g2_scenario ~prefix:"post_g2_mixed"
+      ~rows:[ _post_g2_long_row; _post_g2_short_row ]
+  in
+  let report = TAR.load ~scenario_dir in
+  (* Both rows must parse and surface in entry-date order. *)
+  assert_that report
+    (all_of
+       [
+         field (fun (t : TAR.t) -> t.header.total_round_trips) (equal_to 2);
+         field (fun (t : TAR.t) -> t.header.winners) (equal_to 2);
+         field
+           (fun (t : TAR.t) -> t.rows)
+           (elements_are
+              [
+                field
+                  (fun (r : TAR.per_trade_row) -> r.symbol)
+                  (equal_to "AAPL");
+                field
+                  (fun (r : TAR.per_trade_row) -> r.symbol)
+                  (equal_to "TSLA");
+              ]);
+       ])
+
+(* --- Writer -> reader round-trip --------------------------------------
+
+   The strongest CP2 closure: stage a [Runner.result] with one LONG and one
+   SHORT round-trip, write it via the canonical [Result_writer.write], and
+   read the resulting [trades.csv] back via [TAR.load]. Pins both sides of
+   the on-disk contract at once — schema drift on either fails this test. *)
+
+let _make_runner_result ~start_date ~end_date ~round_trips :
+    Backtest.Runner.result =
+  {
+    summary =
+      {
+        start_date;
+        end_date;
+        universe_size = 2;
+        n_steps = 1;
+        initial_cash = 10_000.0;
+        final_portfolio_value =
+          10_000.0
+          +. List.fold round_trips ~init:0.0
+               ~f:(fun acc (t : Trading_simulation.Metrics.trade_metrics) ->
+                 acc +. t.pnl_dollars);
+        n_round_trips = List.length round_trips;
+        metrics = Trading_simulation_types.Metric_types.empty;
+      };
+    round_trips;
+    steps = [];
+    overrides = [];
+    stop_infos = [];
+    audit = [];
+    cascade_summaries = [];
+  }
+
+let test_writer_reader_post_g2_round_trip _ =
+  let dir = Core_unix.mkdtemp "/tmp/trade_audit_report_writer_" in
+  let long_trip : Trading_simulation.Metrics.trade_metrics =
+    {
+      symbol = "AAPL";
+      side = Trading_base.Types.Buy;
+      entry_date = _date "2024-01-15";
+      exit_date = _date "2024-02-20";
+      days_held = 36;
+      entry_price = 150.00;
+      exit_price = 165.00;
+      quantity = 10.0;
+      pnl_dollars = 150.00;
+      pnl_percent = 10.00;
+    }
+  in
+  let short_trip : Trading_simulation.Metrics.trade_metrics =
+    {
+      symbol = "TSLA";
+      side = Trading_base.Types.Sell;
+      entry_date = _date "2024-03-04";
+      exit_date = _date "2024-04-08";
+      days_held = 35;
+      entry_price = 200.00;
+      exit_price = 180.00;
+      quantity = 5.0;
+      pnl_dollars = 100.00;
+      pnl_percent = 10.00;
+    }
+  in
+  let result =
+    _make_runner_result ~start_date:(_date "2024-01-01")
+      ~end_date:(_date "2024-04-30") ~round_trips:[ long_trip; short_trip ]
+  in
+  Backtest.Result_writer.write ~output_dir:dir result;
+  (* Pin: writer emitted the canonical post-G2 header verbatim. Schema drift on
+     the writer side fails this string match. *)
+  let trades_csv_path = Filename.concat dir "trades.csv" in
+  let lines = In_channel.read_lines trades_csv_path in
+  let header_line = List.hd_exn lines in
+  assert_that header_line (equal_to _canonical_post_g2_header);
+  (* Reader parses both rows back. The report aggregates over [trade_metrics]
+     where [side] survives intact; we pin via the header counts (both winners)
+     and the ordered symbol list. *)
+  let report = TAR.load ~scenario_dir:dir in
+  assert_that report
+    (all_of
+       [
+         field (fun (t : TAR.t) -> t.header.total_round_trips) (equal_to 2);
+         field (fun (t : TAR.t) -> t.header.winners) (equal_to 2);
+         field
+           (fun (t : TAR.t) -> t.rows)
+           (elements_are
+              [
+                all_of
+                  [
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.symbol)
+                      (equal_to "AAPL");
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.pnl_dollars)
+                      (float_equal 150.00);
+                  ];
+                all_of
+                  [
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.symbol)
+                      (equal_to "TSLA");
+                    field
+                      (fun (r : TAR.per_trade_row) -> r.pnl_dollars)
+                      (float_equal 100.00);
+                  ];
+              ]);
+       ])
+
 let suite =
   "Trade_audit_report"
   >::: [
@@ -517,6 +759,12 @@ let suite =
          "load without audit file" >:: test_load_without_audit_file;
          "load missing trades.csv raises"
          >:: test_load_missing_trades_csv_raises;
+         "load post-G2 LONG round-trip" >:: test_load_post_g2_long_round_trip;
+         "load post-G2 SHORT round-trip" >:: test_load_post_g2_short_round_trip;
+         "load post-G2 mixed LONG and SHORT"
+         >:: test_load_post_g2_mixed_long_and_short;
+         "writer -> reader post-G2 round-trip"
+         >:: test_writer_reader_post_g2_round_trip;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
+++ b/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
@@ -338,46 +338,122 @@ let to_markdown (t : t) : string =
 
 (* Loader ----------------------------------------------------------------- *)
 
+(** Map the CSV [side] column ([LONG] / [SHORT]) emitted by
+    [Backtest.Result_writer] back to the [Trading_base.Types.side] of the
+    round-trip's entry leg. Unknown labels fall back to [Buy] so pre-G2
+    trades.csv files (with no [side] column) keep parsing. *)
+let _parse_side = function
+  | "LONG" -> Trading_base.Types.Buy
+  | "SHORT" -> Trading_base.Types.Sell
+  | _ -> Trading_base.Types.Buy
+
+(** Build a [trade_metrics] from already-parsed string cells. Shared by the
+    post-G2 (with [side]) and legacy (no [side]) parser branches in
+    {!_read_trades_csv} so the field list lives in one place. *)
+let _trade_metrics_of_strings ~symbol ~side ~entry_date ~exit_date ~days_held
+    ~entry_price ~exit_price ~quantity ~pnl_dollars ~pnl_percent :
+    Trading_simulation.Metrics.trade_metrics =
+  {
+    symbol;
+    side = _parse_side side;
+    entry_date = Date.of_string entry_date;
+    exit_date = Date.of_string exit_date;
+    days_held = Int.of_string days_held;
+    entry_price = Float.of_string entry_price;
+    exit_price = Float.of_string exit_price;
+    quantity = Float.of_string quantity;
+    pnl_dollars = Float.of_string pnl_dollars;
+    pnl_percent = Float.of_string pnl_percent;
+  }
+
+(** Match a post-G2 row layout (13 columns; [side] = [LONG]/[SHORT]). *)
+let _match_post_g2_csv_row cells :
+    Trading_simulation.Metrics.trade_metrics option =
+  match cells with
+  | [
+      symbol;
+      ("LONG" as side);
+      entry_date;
+      exit_date;
+      days_held;
+      entry_price;
+      exit_price;
+      quantity;
+      pnl_dollars;
+      pnl_percent;
+      _entry_stop;
+      _exit_stop;
+      _exit_trigger;
+    ]
+  | [
+      symbol;
+      ("SHORT" as side);
+      entry_date;
+      exit_date;
+      days_held;
+      entry_price;
+      exit_price;
+      quantity;
+      pnl_dollars;
+      pnl_percent;
+      _entry_stop;
+      _exit_stop;
+      _exit_trigger;
+    ] ->
+      Some
+        (_trade_metrics_of_strings ~symbol ~side ~entry_date ~exit_date
+           ~days_held ~entry_price ~exit_price ~quantity ~pnl_dollars
+           ~pnl_percent)
+  | _ -> None
+
+(** Match a legacy (pre-G2) 12-column row layout. Defaults [side] to [Buy]. *)
+let _match_legacy_csv_row cells :
+    Trading_simulation.Metrics.trade_metrics option =
+  match cells with
+  | [
+   symbol;
+   entry_date;
+   exit_date;
+   days_held;
+   entry_price;
+   exit_price;
+   quantity;
+   pnl_dollars;
+   pnl_percent;
+   _entry_stop;
+   _exit_stop;
+   _exit_trigger;
+  ] ->
+      Some
+        (_trade_metrics_of_strings ~symbol ~side:"LONG" ~entry_date ~exit_date
+           ~days_held ~entry_price ~exit_price ~quantity ~pnl_dollars
+           ~pnl_percent)
+  | _ -> None
+
+(** Read trades.csv. Tolerates both the post-G2 (13-column, with [side]) and
+    legacy (12-column, no [side]) layouts. The disambiguator is whether the
+    second cell is a [LONG]/[SHORT] tag (post-G2) or a date (legacy). Legacy
+    rows default to [side = Buy] preserving the historical long-only semantics.
+*)
+let _parse_trades_csv_line path line :
+    Trading_simulation.Metrics.trade_metrics option =
+  if String.is_empty (String.strip line) then None
+  else
+    let cells = String.split line ~on:',' in
+    match _match_post_g2_csv_row cells with
+    | Some _ as t -> t
+    | None -> (
+        match _match_legacy_csv_row cells with
+        | Some _ as t -> t
+        | None -> failwithf "Unexpected trades.csv row in %s: %s" path line ())
+
 let _read_trades_csv path : Trading_simulation.Metrics.trade_metrics list =
   let ic = In_channel.create path in
   let lines = In_channel.input_lines ic in
   In_channel.close ic;
   match lines with
   | [] -> failwithf "trades.csv at %s is empty" path ()
-  | _header :: rest ->
-      List.filter_map rest ~f:(fun line ->
-          if String.is_empty (String.strip line) then None
-          else
-            let cells = String.split line ~on:',' in
-            match cells with
-            | [
-             symbol;
-             entry_date;
-             exit_date;
-             days_held;
-             entry_price;
-             exit_price;
-             quantity;
-             pnl_dollars;
-             pnl_percent;
-             _entry_stop;
-             _exit_stop;
-             _exit_trigger;
-            ] ->
-                Some
-                  ({
-                     symbol;
-                     entry_date = Date.of_string entry_date;
-                     exit_date = Date.of_string exit_date;
-                     days_held = Int.of_string days_held;
-                     entry_price = Float.of_string entry_price;
-                     exit_price = Float.of_string exit_price;
-                     quantity = Float.of_string quantity;
-                     pnl_dollars = Float.of_string pnl_dollars;
-                     pnl_percent = Float.of_string pnl_percent;
-                   }
-                    : Trading_simulation.Metrics.trade_metrics)
-            | _ -> failwithf "Unexpected trades.csv row in %s: %s" path line ())
+  | _header :: rest -> List.filter_map rest ~f:(_parse_trades_csv_line path)
 
 type _summary_meta = {
   start_date : Date.t;

--- a/trading/trading/simulation/lib/metrics.ml
+++ b/trading/trading/simulation/lib/metrics.ml
@@ -8,6 +8,7 @@ module Simulator_types = Trading_simulation_types.Simulator_types
 
 type trade_metrics = {
   symbol : string;
+  side : Trading_base.Types.side;
   entry_date : Date.t;
   exit_date : Date.t;
   days_held : int;
@@ -30,10 +31,15 @@ type summary_stats = {
 
 (** {1 Trade Metrics Functions} *)
 
+let _side_label = function
+  | Trading_base.Types.Buy -> "LONG"
+  | Trading_base.Types.Sell -> "SHORT"
+
 let show_trade_metrics m =
   Printf.sprintf
-    "%s: %s -> %s (%d days), entry=%.2f exit=%.2f qty=%.0f, P&L=$%.2f (%.2f%%)"
-    m.symbol
+    "%s [%s]: %s -> %s (%d days), entry=%.2f exit=%.2f qty=%.0f, P&L=$%.2f \
+     (%.2f%%)"
+    m.symbol (_side_label m.side)
     (Date.to_string m.entry_date)
     (Date.to_string m.exit_date)
     m.days_held m.entry_price m.exit_price m.quantity m.pnl_dollars
@@ -45,13 +51,36 @@ let show_summary s =
     s.total_pnl s.avg_holding_days s.win_rate s.win_count
     (s.win_count + s.loss_count)
 
+(** Compute (pnl_dollars, pnl_percent) for a closed round-trip, dispatching on
+    the entry side. Long: profit when exit > entry. Short: profit when exit
+    (cover) < entry. Both pnl_percent figures are expressed as a percentage of
+    the entry price; the sign convention is that a positive reading always means
+    profit, regardless of direction. *)
+let _compute_pnl ~entry_side ~entry_price ~exit_price ~quantity =
+  let dollars =
+    match entry_side with
+    | Trading_base.Types.Buy -> (exit_price -. entry_price) *. quantity
+    | Trading_base.Types.Sell -> (entry_price -. exit_price) *. quantity
+  in
+  let percent =
+    match entry_side with
+    | Trading_base.Types.Buy ->
+        (exit_price -. entry_price) /. entry_price *. 100.0
+    | Trading_base.Types.Sell ->
+        (entry_price -. exit_price) /. entry_price *. 100.0
+  in
+  (dollars, percent)
+
 let _make_trade_metric symbol entry_date entry exit_date exit =
   let open Trading_base.Types in
   let days_held = Date.diff exit_date entry_date in
-  let pnl_dollars = (exit.price -. entry.price) *. entry.quantity in
-  let pnl_percent = (exit.price -. entry.price) /. entry.price *. 100.0 in
+  let pnl_dollars, pnl_percent =
+    _compute_pnl ~entry_side:entry.side ~entry_price:entry.price
+      ~exit_price:exit.price ~quantity:entry.quantity
+  in
   {
     symbol;
+    side = entry.side;
     entry_date;
     exit_date;
     days_held;
@@ -62,17 +91,26 @@ let _make_trade_metric symbol entry_date entry exit_date exit =
     pnl_percent;
   }
 
-let _is_buy_sell_pair entry exit =
+(** Recognise a paired round-trip by side direction. A long round-trip is
+    Buy→Sell; a short round-trip is Sell→Buy (the entry is the short open, the
+    exit is the buy-to-cover). The pairing is direction-only — quantities are
+    not required to match because the simulator can in principle scale out;
+    callers wanting a quantity-equality invariant assert that separately. *)
+let _is_paired_round_trip entry exit =
   let open Trading_base.Types in
-  equal_side entry.side Buy && equal_side exit.side Sell
+  match (entry.side, exit.side) with
+  | Buy, Sell | Sell, Buy -> true
+  | Buy, Buy | Sell, Sell -> false
 
-(** Pair buy trades with sells to form round-trips for a single symbol. *)
+(** Pair entry trades with subsequent close trades to form round-trips for a
+    single symbol. Handles both Buy→Sell (long) and Sell→Buy (short) — see
+    {!_is_paired_round_trip}. *)
 let _pair_trades_for_symbol symbol
     (trades : (Date.t * Trading_base.Types.trade) list) : trade_metrics list =
   let rec pair_trades trades_list metrics =
     match trades_list with
     | (entry_date, entry) :: (exit_date, exit) :: rest
-      when _is_buy_sell_pair entry exit ->
+      when _is_paired_round_trip entry exit ->
         let m = _make_trade_metric symbol entry_date entry exit_date exit in
         pair_trades rest (m :: metrics)
     | _ :: rest -> pair_trades rest metrics

--- a/trading/trading/simulation/lib/metrics.mli
+++ b/trading/trading/simulation/lib/metrics.mli
@@ -12,21 +12,33 @@ open Core
 
 type trade_metrics = {
   symbol : string;  (** The traded symbol *)
-  entry_date : Date.t;  (** Date of entry (buy) *)
-  exit_date : Date.t;  (** Date of exit (sell) *)
+  side : Trading_base.Types.side;
+      (** Direction of the round-trip's {b entry} leg. [Buy] means a long
+          round-trip (Buy→Sell); [Sell] means a short round-trip (Sell→Buy where
+          the closing buy covers the short). Callers that distinguish long vs
+          short P&L (release-report, [trades.csv], regression metrics) must
+          dispatch on this field. *)
+  entry_date : Date.t;  (** Date of entry — the open leg *)
+  exit_date : Date.t;  (** Date of exit — the close leg *)
   days_held : int;  (** Number of days position was held *)
-  entry_price : float;  (** Price at entry *)
-  exit_price : float;  (** Price at exit *)
+  entry_price : float;  (** Price at entry — i.e. the open-leg fill price *)
+  exit_price : float;  (** Price at exit — i.e. the close-leg fill price *)
   quantity : float;  (** Number of shares traded *)
-  pnl_dollars : float;  (** Profit/loss in dollars *)
-  pnl_percent : float;  (** Profit/loss as percentage of entry price *)
+  pnl_dollars : float;
+      (** Profit/loss in dollars. Long: [(exit − entry) × qty]. Short:
+          [(entry − exit) × qty] (positive when cover price < entry). *)
+  pnl_percent : float;
+      (** Profit/loss as percentage of entry price. Mirrored direction so a
+          positive reading always means profit, regardless of long or short. *)
 }
 [@@deriving show, eq]
 (** Metrics for a completed round-trip trade.
 
-    A round-trip trade consists of an entry (buy) followed by an exit (sell) for
-    the same symbol. This record captures the key performance metrics for
-    analyzing trade profitability. *)
+    A round-trip trade consists of an entry followed by a close trade for the
+    same symbol. Two directions are supported: long (Buy→Sell) and short
+    (Sell→Buy, where the closing buy covers the short). [side] tags the
+    direction of the entry leg so downstream consumers can dispatch P&L
+    semantics. *)
 
 type summary_stats = {
   total_pnl : float;  (** Sum of P&L across all trades *)
@@ -48,9 +60,17 @@ val extract_round_trips :
   trade_metrics list
 (** Extract round-trip trades from simulation step results.
 
-    A round-trip is identified by pairing buy trades with subsequent sell trades
-    for the same symbol. Trades are matched in chronological order, with each
-    buy paired with the next sell.
+    A round-trip is identified by pairing an entry trade with the next close
+    trade for the same symbol. Two directions are paired:
+
+    - {b Long} round-trip: Buy → Sell, with [side = Buy] in the result.
+    - {b Short} round-trip: Sell → Buy (the buy covers the short), with
+      [side = Sell] in the result.
+
+    Trades are matched in chronological order, with each entry paired with the
+    next opposite-side trade for the same symbol. A trailing entry trade with no
+    matching close (e.g., an open position at the end of the simulation window)
+    is dropped.
 
     @param steps List of step results from simulator run
     @return List of trade metrics for completed round-trips *)

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -94,6 +94,223 @@ let test_summary_stats_to_metrics _ =
          (AvgHoldingDays, float_equal 5.5);
        ])
 
+(* ==================== extract_round_trips Tests ==================== *)
+
+(** Build a trade record. Defaults the boilerplate fields so test cases stay
+    focused on the side / price / quantity that matters. *)
+let _make_trade ~id ~symbol ~side ~quantity ~price =
+  {
+    Trading_base.Types.id;
+    order_id = id ^ "-order";
+    symbol;
+    side;
+    quantity;
+    price;
+    commission = 0.0;
+    timestamp = Time_ns_unix.now ();
+  }
+
+(** Wrap a list of trades in a single [step_result] on [date]. The portfolio +
+    portfolio_value fields are placeholders — [extract_round_trips] only
+    consumes [step.trades] and [step.date]. *)
+let _step_with_trades ~date ~trades =
+  let portfolio = Trading_portfolio.Portfolio.create ~initial_cash:10000.0 () in
+  {
+    date;
+    portfolio;
+    portfolio_value = 10000.0;
+    trades;
+    orders_submitted = [];
+    splits_applied = [];
+  }
+
+(** Long round-trip: Buy@100 → Sell@110, quantity 10, profit $100. Pins the
+    pre-existing contract — this test must keep passing after the short-side
+    extension. *)
+let test_extract_round_trips_long_pair _ =
+  let buy =
+    _make_trade ~id:"b1" ~symbol:"AAPL" ~side:Buy ~quantity:10.0 ~price:100.0
+  in
+  let sell =
+    _make_trade ~id:"s1" ~symbol:"AAPL" ~side:Sell ~quantity:10.0 ~price:110.0
+  in
+  let steps =
+    [
+      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ buy ];
+      _step_with_trades ~date:(date_of_string "2024-01-12") ~trades:[ sell ];
+    ]
+  in
+  let trips = extract_round_trips steps in
+  assert_that trips
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (t : trade_metrics) -> t.symbol) (equal_to "AAPL");
+             field
+               (fun (t : trade_metrics) -> t.side)
+               (equal_to Trading_base.Types.Buy);
+             field
+               (fun (t : trade_metrics) -> t.entry_price)
+               (float_equal 100.0);
+             field (fun (t : trade_metrics) -> t.exit_price) (float_equal 110.0);
+             field (fun (t : trade_metrics) -> t.quantity) (float_equal 10.0);
+             field
+               (fun (t : trade_metrics) -> t.pnl_dollars)
+               (float_equal 100.0);
+             field (fun (t : trade_metrics) -> t.pnl_percent) (float_equal 10.0);
+             field (fun (t : trade_metrics) -> t.days_held) (equal_to 10);
+           ];
+       ])
+
+(** Short round-trip: Sell@110 → Buy@100 covers a short. Cover below entry means
+    the short was profitable: pnl_dollars = (entry − cover) × qty = (110 − 100)
+    × 10 = $100. Pins gap G2 from [dev/notes/short-side-gaps-2026-04-29.md]. *)
+let test_extract_round_trips_short_pair_profit _ =
+  let sell =
+    _make_trade ~id:"s1" ~symbol:"BEAR" ~side:Sell ~quantity:10.0 ~price:110.0
+  in
+  let buy =
+    _make_trade ~id:"b1" ~symbol:"BEAR" ~side:Buy ~quantity:10.0 ~price:100.0
+  in
+  let steps =
+    [
+      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ sell ];
+      _step_with_trades ~date:(date_of_string "2024-01-09") ~trades:[ buy ];
+    ]
+  in
+  let trips = extract_round_trips steps in
+  assert_that trips
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (t : trade_metrics) -> t.symbol) (equal_to "BEAR");
+             field
+               (fun (t : trade_metrics) -> t.side)
+               (equal_to Trading_base.Types.Sell);
+             (* Entry = sell-side fill price, exit = buy-to-cover fill price. *)
+             field
+               (fun (t : trade_metrics) -> t.entry_price)
+               (float_equal 110.0);
+             field (fun (t : trade_metrics) -> t.exit_price) (float_equal 100.0);
+             field (fun (t : trade_metrics) -> t.quantity) (float_equal 10.0);
+             (* (entry − cover) × qty = (110 − 100) × 10 = +100 *)
+             field
+               (fun (t : trade_metrics) -> t.pnl_dollars)
+               (float_equal 100.0);
+             (* pnl percent: (entry − cover) / entry × 100 = 10/110 × 100 *)
+             field
+               (fun (t : trade_metrics) -> t.pnl_percent)
+               (float_equal ~epsilon:1e-6 (10.0 /. 110.0 *. 100.0));
+             field (fun (t : trade_metrics) -> t.days_held) (equal_to 7);
+           ];
+       ])
+
+(** Short round-trip with a cover ABOVE entry: short took a loss. P&L for a
+    short is (entry − cover) × qty, so cover above entry yields negative. *)
+let test_extract_round_trips_short_pair_loss _ =
+  let sell =
+    _make_trade ~id:"s1" ~symbol:"BEAR" ~side:Sell ~quantity:10.0 ~price:100.0
+  in
+  let buy =
+    _make_trade ~id:"b1" ~symbol:"BEAR" ~side:Buy ~quantity:10.0 ~price:120.0
+  in
+  let steps =
+    [
+      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ sell ];
+      _step_with_trades ~date:(date_of_string "2024-01-09") ~trades:[ buy ];
+    ]
+  in
+  let trips = extract_round_trips steps in
+  assert_that trips
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : trade_metrics) -> t.side)
+               (equal_to Trading_base.Types.Sell);
+             (* (100 − 120) × 10 = −200 *)
+             field
+               (fun (t : trade_metrics) -> t.pnl_dollars)
+               (float_equal (-200.0));
+             field
+               (fun (t : trade_metrics) -> t.pnl_percent)
+               (float_equal ~epsilon:1e-6 (-20.0));
+           ];
+       ])
+
+(** Long and short legs in the same run, on different symbols, must both be
+    paired up — independent per-symbol pairing means the order they arrive at
+    [extract_round_trips] does not matter. *)
+let test_extract_round_trips_long_and_short_mixed _ =
+  let long_buy =
+    _make_trade ~id:"l1" ~symbol:"AAPL" ~side:Buy ~quantity:5.0 ~price:200.0
+  in
+  let long_sell =
+    _make_trade ~id:"l2" ~symbol:"AAPL" ~side:Sell ~quantity:5.0 ~price:220.0
+  in
+  let short_sell =
+    _make_trade ~id:"s1" ~symbol:"BEAR" ~side:Sell ~quantity:10.0 ~price:50.0
+  in
+  let short_buy =
+    _make_trade ~id:"s2" ~symbol:"BEAR" ~side:Buy ~quantity:10.0 ~price:40.0
+  in
+  let steps =
+    [
+      _step_with_trades
+        ~date:(date_of_string "2024-01-02")
+        ~trades:[ long_buy; short_sell ];
+      _step_with_trades
+        ~date:(date_of_string "2024-01-12")
+        ~trades:[ long_sell; short_buy ];
+    ]
+  in
+  let trips = extract_round_trips steps in
+  let by_symbol =
+    List.fold trips
+      ~init:(Map.empty (module String))
+      ~f:(fun acc (m : trade_metrics) -> Map.set acc ~key:m.symbol ~data:m)
+  in
+  assert_that by_symbol
+    (map_includes
+       [
+         ( "AAPL",
+           all_of
+             [
+               field
+                 (fun (t : trade_metrics) -> t.side)
+                 (equal_to Trading_base.Types.Buy);
+               field
+                 (fun (t : trade_metrics) -> t.pnl_dollars)
+                 (float_equal 100.0);
+             ] );
+         ( "BEAR",
+           all_of
+             [
+               field
+                 (fun (t : trade_metrics) -> t.side)
+                 (equal_to Trading_base.Types.Sell);
+               field
+                 (fun (t : trade_metrics) -> t.pnl_dollars)
+                 (float_equal 100.0);
+             ] );
+       ])
+
+(** A dangling Sell with no Buy follow-up (e.g., open short position at the end
+    of the simulation window) must NOT be reported as a round-trip. The pairing
+    only fires when a complete close trade arrives. *)
+let test_extract_round_trips_unclosed_short_dropped _ =
+  let sell =
+    _make_trade ~id:"s1" ~symbol:"BEAR" ~side:Sell ~quantity:10.0 ~price:100.0
+  in
+  let steps =
+    [ _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ sell ] ]
+  in
+  let trips = extract_round_trips steps in
+  assert_that trips (size_is 0)
+
 (* ==================== Metric Computer Tests ==================== *)
 
 (* Helper to create a mock step_result *)
@@ -715,6 +932,16 @@ let suite =
          "format_metrics multiple" >:: test_format_metrics_multiple;
          (* Summary stats conversion *)
          "summary_stats_to_metrics" >:: test_summary_stats_to_metrics;
+         (* extract_round_trips tests *)
+         "extract_round_trips long pair" >:: test_extract_round_trips_long_pair;
+         "extract_round_trips short pair profit"
+         >:: test_extract_round_trips_short_pair_profit;
+         "extract_round_trips short pair loss"
+         >:: test_extract_round_trips_short_pair_loss;
+         "extract_round_trips long and short mixed"
+         >:: test_extract_round_trips_long_and_short_mixed;
+         "extract_round_trips unclosed short dropped"
+         >:: test_extract_round_trips_unclosed_short_dropped;
          (* Sharpe ratio tests *)
          "sharpe ratio zero with no data"
          >:: test_sharpe_ratio_zero_with_no_data;

--- a/trading/trading/simulation/test/test_weinstein_backtest.ml
+++ b/trading/trading/simulation/test/test_weinstein_backtest.ml
@@ -181,13 +181,18 @@ let test_six_year_full_lifecycle _ =
          equal_to "KO";
          equal_to "MSFT";
        ]);
-  assert_that (List.length round_trips) (equal_to 33);
+  (* Post-G2 ([dev/notes/short-side-gaps-2026-04-29.md]): Sell→Buy short
+     round-trips are now extracted alongside Buy→Sell longs. The 33 long
+     round-trips remain unchanged; an additional 3 short round-trips appear
+     from the 2018-2020 bear-window short cascade activity (n_buys 39 /
+     n_sells 36 — the delta of 3 was the unpaired-but-now-paired set). *)
+  assert_that (List.length round_trips) (equal_to 36);
   assert_that stats
     (is_some_and
        (all_of
           [
-            field (fun s -> s.Metrics.win_count) (equal_to 16);
-            field (fun s -> s.Metrics.loss_count) (equal_to 17);
+            field (fun s -> s.Metrics.win_count) (equal_to 17);
+            field (fun s -> s.Metrics.loss_count) (equal_to 19);
           ]));
   (* Final value pinned within ±$3K of the captured post-3.2 value
      ($506,694.70). Tight band catches drift in the screener cascade or


### PR DESCRIPTION
## Summary

Closes gap **G2** from `dev/notes/short-side-gaps-2026-04-29.md`. Extends
`Metrics.extract_round_trips` to recognise Sell→Buy pairings (short
round-trips) alongside the existing Buy→Sell long pairings, so the 128
short entries the Weinstein strategy fires during 2019's bearish-macro
window finally surface in `trades.csv` and downstream P&L metrics.

## What changed

- `trading/simulation/lib/metrics.{ml,mli}`:
  - `trade_metrics` gains a `side : Trading_base.Types.side` field
    tagging the entry-leg direction. `side = Buy` ⇒ long round-trip
    (Buy→Sell). `side = Sell` ⇒ short round-trip (Sell→Buy, where the
    closing buy covers the short).
  - `_is_buy_sell_pair` renamed to `_is_paired_round_trip`; matches both
    Buy→Sell and Sell→Buy.
  - New `_compute_pnl` helper: Long P&L = (exit − entry) × qty; Short
    P&L = (entry − cover) × qty (positive when cover < entry). Both
    `pnl_percent` figures use the same sign convention so a positive
    reading always means profit.
  - `show_trade_metrics` includes a `[LONG]`/`[SHORT]` tag.

- `trading/backtest/lib/result_writer.ml`: `trades.csv` gains a `side`
  column (second column, after `symbol`) emitting `LONG`/`SHORT` per
  round-trip.

- Both downstream parsers (`Optimal_run_artefacts._parse_trade_row`,
  `Trade_audit_report._read_trades_csv`) tolerate both the post-G2
  13-column layout and the legacy 12-column layout. Legacy rows default
  to `side = Buy`, preserving the historical long-only semantics for any
  cached fixture or run artefact written before G2.

## Tests

- `test_metrics.ml` gains 5 new round-trip cases (40 total, was 35):
  - long pair (regression — pins existing contract)
  - short pair, profit (cover below entry)
  - short pair, loss (cover above entry)
  - mixed long + short on different symbols in one run
  - unclosed short dropped (open position at end of window)
- `test_weinstein_backtest.ml`'s 6-year lifecycle pin updated:
  `round_trips` count 33 → 36 (3 newly-paired short round-trips from
  the 2018-2020 bear window — the n_buys 39 / n_sells 36 delta
  previously mentioned in the test comment), `win_count`/`loss_count`
  17/19 (was 16/17). The 1.5-year and 2-year tests are unchanged
  because their windows don't span the bear window where shorts fire.
- All 4 downstream test files that constructed `trade_metrics` records
  directly (`test_trade_audit_report`, `test_trade_audit_ratings`,
  `test_release_perf_report`, `test_optimal_strategy_report`) now pass
  `side = Buy` via an optional builder argument.

## PR #689 contract test C

This PR is the implementation that turns PR #689's test C (currently
DRAFT) from FAIL → PASS. Test C asserts that a Sell→Buy synthetic
short round-trip surfaces in `Metrics.extract_round_trips` with
`quantity > 0` and `pnl_dollars > 0` when cover < entry — the exact
contract this implementation satisfies.

## Test plan

- [x] `dune build` clean
- [x] `dune build @fmt` clean
- [x] `dune runtest trading/simulation/test/` clean (40 metrics + 16
      simulator + 14 e2e + 3 weinstein backtest)
- [x] Targeted: `_build/default/trading/simulation/test/test_metrics.exe`
      reports `Ran: 40 tests ... OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)