### PR TITLE
fix(stops_runner): G1 short-stop pathology — diagnosis + minimal fix [DRAFT]

### DIFF
--- a/dev/notes/short-side-gaps-2026-04-29.md
+++ b/dev/notes/short-side-gaps-2026-04-29.md
@@ -35,6 +35,77 @@ regression test in `trading/trading/weinstein/portfolio_risk/test/`
 that pins both directions: short with price below stop → no trigger;
 short with price above stop → trigger.
 
+**Diagnosed (PR `fix/g1-short-stop-diagnosis`, DRAFT)**: the original
+hypothesis ("`Stops_runner.update` evaluating with long-side sense")
+was wrong — PR #689 audit harness Tests A + B already pin the
+unit-level `Weinstein_stops.check_stop_hit` predicate as
+direction-correct. Two distinct bugs in `Stops_runner` produce the
+audit anomaly:
+
+1. **Stage hardcode** in `Stops_runner._handle_stop`. When invoking
+   `Weinstein_stops.update`, the runner unconditionally passes
+   `~stage:(Stage2 { weeks_advancing = 1; late = false })` — regardless
+   of position side. For shorts in warmup (the `weekly.n < ma_period`
+   branch where `ma_direction = Flat`),
+   `Weinstein_stops._should_tighten_short` matches `Stage1 | Stage2 ->
+   tighten` and fires `Entered_tightening` on the first Initial-state
+   tick. The candidate computed from the bar high (e.g. $98 + 1 % buf
+   ≈ $99 for an entry-bar high of $98) is "better" than the entry
+   stop $103.58 in short-direction logic, so the stop drops to ~$99
+   on bar 1 — already BELOW entry. Any subsequent small counter-bounce
+   above the eroded stop fires a spurious exit at a profitable price
+   (the ALB pathology shape).
+
+2. **`actual_price = bar.low_price` hardcode** in
+   `Stops_runner._make_exit_transition`. For longs, `bar.low_price` is
+   the worst-case fill on a stop trigger (the bar's low crosses DOWN
+   through the stop). For SHORTS, the trigger fires on `bar.high >=
+   stop_level` and the worst-case cover fill is at `bar.high_price`,
+   not `bar.low_price`. With the legacy hardcode, the audit log
+   records ALB exit `actual_price = $77.49` when the actual trigger
+   occurred at the bar's high (≥ $103.58). This makes the audit entry
+   read as "stop fired against profitable territory" even when the
+   trigger itself was correct.
+
+**Fix**: `Stops_runner._compute_ma` now also returns the classified
+stage (or a position-favourable warmup default: `Stage2 + Rising` for
+longs, `Stage4 + Declining` for shorts — both no-tighten by
+`_should_tighten_*`'s logic). `_make_exit_transition` selects
+`actual_price` by side: `bar.low_price` for longs, `bar.high_price`
+for shorts.
+
+**Reproducer tests**: two new tests in
+`trading/trading/weinstein/strategy/test/test_stops_runner.ml` —
+`test_g1_short_no_exit_on_counter_bounce` (pins #1: short with
+$103.58 stop emits zero exits across pullback + small counter-bounce
+below entry) and `test_g1_short_exit_records_high_not_low` (pins #2:
+on a violent down-day where bar high crosses the short stop, the
+recorded `actual_price` and `exit_price` must be ≥ stop_level, not
+bar.low). Both fail on current main, pass post-fix.
+
+**Side-effect on long-side test**:
+`test_weinstein_strategy.test_bar_accumulation_multiple_days` was
+pinning the same warmup-tightening pathology for longs (Day 2
+expected 1 transition driven by spurious tightening). Updated to
+expect 0 transitions across all 3 days — the position-favourable
+warmup default applies symmetrically to both sides.
+
+**Out-of-scope follow-up**: there is a deeper Trailing-state
+phantom-cycle bug in `Weinstein_stops._completed_cycle_stop`. For
+monotonically declining shorts (no actual counter-rally), the seeded
+`last_correction_extreme = bar.high` from `_to_trailing` paired with
+an advancing `last_trend_extreme` later phantom-fires the cycle
+without a real counter-move. This pulls the short stop further DOWN
+through entry over multiple bars. Fixing it cleanly requires a
+state-machine change (track temporal ordering of correction-vs-trend
+extremes — naive seeding-reset breaks the long-side `regression_test`
+at `stage2_trailing_stop_raised_phase_a` which deliberately seeds
+the entry-bar low as the cycle-1 correction anchor). The minimal G1
+fix above closes the runner-side hardcodes and lets the trailing
+logic operate on correct stage inputs. Re-evaluate after the
+sp500-baseline rerun whether the runner-side fix alone is sufficient
+or whether the trailing-state phantom needs follow-up work.
+
 ### G2 — `Metrics.extract_round_trips` is blind to shorts
 
 Currently pairs Buy → Sell only. Sell → Buy short round-trips are

--- a/trading/trading/weinstein/strategy/lib/stops_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.ml
@@ -1,10 +1,37 @@
 open Core
 open Trading_strategy
 
-(** Compute MA direction and value for a symbol via panel-shaped callbacks.
-    Reads and updates [prior_stages] so Stage1->Stage2 transition detection
-    works across calls. Returns [(Flat, fallback_price)] when there aren't
-    enough weekly bars yet for the MA.
+(** Position-favourable stage + MA direction default for warmup periods (when
+    fewer than [stage_config.ma_period] weekly bars are available). The return
+    must drive {!Weinstein_stops.update} into a no-tighten branch:
+
+    - {!Weinstein_stops._should_tighten_long} tightens on Stage 3 / Stage 4 and
+      on Stage 2 + Flat-or-Declining MA (when [tighten_on_flat_ma] is true). The
+      only no-tighten branch for a long is Stage 2 + Rising MA.
+    - {!Weinstein_stops._should_tighten_short} tightens on Stage 1 / Stage 2 and
+      on Stage 4 + Rising-or-Flat MA. The only no-tighten branch for a short is
+      Stage 4 + Declining MA.
+
+    Returning a position-favourable warmup default avoids the G1 short-stop
+    pathology (see [dev/notes/short-side-gaps-2026-04-29.md]): hardcoding
+    [Stage2 + Flat] for shorts triggered tightening on every warmup tick,
+    dragging short stops below entry within one or two bars. *)
+let _default_stage_and_ma_for_side = function
+  | Trading_base.Types.Long ->
+      ( Weinstein_types.Stage2 { weeks_advancing = 1; late = false },
+        Weinstein_types.Rising )
+  | Trading_base.Types.Short ->
+      (Weinstein_types.Stage4 { weeks_declining = 1 }, Weinstein_types.Declining)
+
+(** Compute MA direction, value, and stage for a symbol via panel-shaped
+    callbacks. Reads and updates [prior_stages] so Stage1->Stage2 transition
+    detection works across calls. Returns [(Flat, fallback_price, default)]
+    where [default] is [_default_stage_and_ma_for_side ~side] when there aren't
+    enough weekly bars yet for the MA — see G1 fix in
+    [dev/notes/short-side-gaps-2026-04-29.md]: hardcoding [Stage2] for shorts
+    triggered spurious tightening on every warmup tick, dragging short stops
+    below entry. The position-favourable default keeps the state machine in its
+    initial pose during warmup.
 
     Stage 4 PR-A: this no longer materialises a {!Daily_price.t list}. The
     weekly view is read directly from panels and threaded into a
@@ -13,13 +40,15 @@ open Trading_strategy
     Stage 4 PR-D: an optional [ma_cache] threads through to the panel callbacks.
     Mid-week stop adjustments miss the cache (Friday-aligned only) and fall back
     to inline; Friday-aligned calls hit the cache. *)
-let _compute_ma ?ma_cache ~(stage_config : Stage.config) ~lookback_bars
-    ~bar_reader ~as_of ~prior_stages ~symbol ~fallback_price () =
+let _compute_ma_and_stage ?ma_cache ~(stage_config : Stage.config)
+    ~lookback_bars ~bar_reader ~as_of ~prior_stages ~symbol ~side
+    ~fallback_price () =
   let weekly =
     Bar_reader.weekly_view_for bar_reader ~symbol ~n:lookback_bars ~as_of
   in
   if weekly.n < stage_config.ma_period then
-    (Weinstein_types.Flat, fallback_price)
+    let stage, ma_direction = _default_stage_and_ma_for_side side in
+    (ma_direction, fallback_price, stage)
   else
     let prior_stage = Hashtbl.find prior_stages symbol in
     let callbacks =
@@ -31,10 +60,29 @@ let _compute_ma ?ma_cache ~(stage_config : Stage.config) ~lookback_bars
         ~get_ma:callbacks.get_ma ~get_close:callbacks.get_close ~prior_stage
     in
     Hashtbl.set prior_stages ~key:symbol ~data:result.stage;
-    (result.ma_direction, result.ma_value)
+    (result.ma_direction, result.ma_value, result.stage)
+
+(** Worst-case fill price when a stop trigger fires.
+
+    For a long, the stop fires when the bar's low crosses DOWN through the stop
+    level — the worst-case fill is at the bar's low (maximum slippage in the
+    loss direction). For a short, the stop fires when the bar's high crosses UP
+    through the stop level — the worst-case fill is at the bar's high (maximum
+    slippage on the cover).
+
+    Pre-G1-fix this function unconditionally returned [bar.low_price], which for
+    shorts produced audit-log entries like ALB 2019-01-29 (stop $103.58,
+    actual_price $77.49 when bar low was $76) that read as if the stop fired
+    against profitable territory — the recorded actual price was the bar low,
+    not the trigger price near the high. See G1 in
+    [dev/notes/short-side-gaps-2026-04-29.md]. *)
+let _trigger_fill_price ~(side : Trading_base.Types.position_side) ~bar =
+  match side with
+  | Long -> bar.Types.Daily_price.low_price
+  | Short -> bar.Types.Daily_price.high_price
 
 let _make_exit_transition ~(pos : Position.t) ~current_date ~state ~bar =
-  let actual_price = bar.Types.Daily_price.low_price in
+  let actual_price = _trigger_fill_price ~side:pos.Position.side ~bar in
   let exit_reason =
     Position.StopLoss
       {
@@ -70,15 +118,14 @@ let _handle_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars
     ~(pos : Position.t) ~(risk_params : Position.risk_params) ~state ~bar
     ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages () =
   let current_date = bar.Types.Daily_price.date in
-  let ma_direction, ma_value =
-    _compute_ma ?ma_cache ~stage_config ~lookback_bars ~bar_reader ~as_of
-      ~prior_stages ~symbol:ticker
+  let ma_direction, ma_value, stage =
+    _compute_ma_and_stage ?ma_cache ~stage_config ~lookback_bars ~bar_reader
+      ~as_of ~prior_stages ~symbol:ticker ~side:pos.Position.side
       ~fallback_price:bar.Types.Daily_price.close_price ()
   in
   let new_state, event =
     Weinstein_stops.update ~config:stops_config ~side:pos.Position.side ~state
-      ~current_bar:bar ~ma_value ~ma_direction
-      ~stage:(Weinstein_types.Stage2 { weeks_advancing = 1; late = false })
+      ~current_bar:bar ~ma_value ~ma_direction ~stage
   in
   stop_states := Map.set !stop_states ~key:ticker ~data:new_state;
   match event with

--- a/trading/trading/weinstein/strategy/test/test_stops_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_runner.ml
@@ -22,8 +22,10 @@ let make_bar date ~close ?low ?high () =
 
 let get_price_of bars symbol = List.Assoc.find bars symbol ~equal:String.equal
 
-(** Build a Position.t in the [Holding] state for [ticker] at [price]. *)
-let make_holding_pos ticker price date =
+(** Build a Position.t in the [Holding] state for [ticker] at [price]. Defaults
+    to [Long]; pass [~side:Short] for short positions (used by the G1
+    short-stop-direction reproducer tests below). *)
+let make_holding_pos ?(side = Trading_base.Types.Long) ticker price date =
   let pos_id = ticker in
   let make_trans kind =
     { Trading_strategy.Position.position_id = pos_id; date; kind }
@@ -39,7 +41,7 @@ let make_holding_pos ticker price date =
          (CreateEntering
             {
               symbol = ticker;
-              side = Trading_base.Types.Long;
+              side;
               target_quantity = 10.0;
               entry_price = price;
               reasoning = ManualDecision { description = "test" };
@@ -203,6 +205,160 @@ let test_update_mutates_stop_states_ref _ =
   assert_that (Map.find !stop_states ticker) (is_some_and (fun _ -> ()))
 
 (* ------------------------------------------------------------------ *)
+(* G1 reproducer — ALB short-stop anomaly                              *)
+(*                                                                      *)
+(* Audit evidence (dev/notes/short-side-gaps-2026-04-29.md): ALB short  *)
+(* with stop $103.58 exits at $77.49 on 2019-01-29 when ALB was at      *)
+(* ~$76 — profitable territory for a short, NOT a stop trigger.         *)
+(*                                                                      *)
+(* Reproduction strategy: drive Stops_runner.update over a multi-bar    *)
+(* sequence where ALB declines from $100 to ~$76 over 4 weekly bars.    *)
+(* Bar high stays well below the stop level ($103.58) on every bar.    *)
+(* Contract: zero TriggerExit transitions across all bars; the runner   *)
+(* must keep the stop ABOVE entry throughout (a short stop never moves  *)
+(* DOWN through entry — that would be moving the stop AGAINST the       *)
+(* position, which docs/design/eng-design-3-portfolio-stops.md          *)
+(* explicitly forbids).                                                 *)
+(* ------------------------------------------------------------------ *)
+
+(** Drive [Stops_runner.update] for a short [Holding] across a sequence of bars,
+    threading [stop_states] across calls. Returns the cumulative
+    [(exits, adjusts)] across all bars. The position, prior_stages, and
+    stop_states ref are constructed once and mutated by the runner. *)
+let _run_short_sequence ~ticker ~entry_price ~entry_date ~stop_level ~bars =
+  let pos =
+    make_holding_pos ~side:Trading_base.Types.Short ticker entry_price
+      entry_date
+  in
+  let positions = String.Map.singleton ticker pos in
+  let stop_states =
+    ref
+      (String.Map.singleton ticker
+         (Weinstein_stops.Initial { stop_level; reference_level = stop_level }))
+  in
+  let prior_stages = Hashtbl.create (module String) in
+  List.fold bars ~init:([], []) ~f:(fun (exits_acc, adjusts_acc) bar ->
+      let exits, adjusts =
+        Stops_runner.update ~stops_config:default_cfg
+          ~stage_config:default_stage_cfg ~lookback_bars:52 ~positions
+          ~get_price:(get_price_of [ (ticker, bar) ])
+          ~stop_states ~bar_reader:(Bar_reader.empty ())
+          ~as_of:bar.Types.Daily_price.date ~prior_stages ()
+      in
+      (exits_acc @ exits, adjusts_acc @ adjusts))
+  |> fun (exits, adjusts) -> (exits, adjusts, !stop_states)
+
+(** Reproducer 1: ALB short, stop $103.58 above entry $100. Two bars: an initial
+    pullback bar (close $95, high $98), then a small counter- bounce bar (high
+    $99.5) — comfortably below the $103.58 entry-stop.
+
+    On current main (pre-G1 fix), [Stops_runner._handle_stop] hardcodes
+    [stage = Stage2] regardless of position side when calling
+    [Weinstein_stops.update]. [_should_tighten_short] matches
+    [Stage1 | Stage2 -> tighten], so on bar 1 the runner immediately tightens
+    the short's stop from $103.58 down to ~$99.13 (the bar high $98 plus the
+    trailing buffer). Bar 2 (high $99.5) then prints above the eroded stop,
+    firing a spurious [Stop_hit]. This is exactly the ALB pathology shape: a
+    short in profitable territory exits on a small counter-bounce because the
+    stop drifted through entry into loss territory.
+
+    Post-fix: the runner passes the position-favourable warmup default
+    ([Stage4 + Declining MA] for shorts), no spurious tightening fires on bar 1,
+    the stop stays at $103.58, and bar 2's $99.5 high doesn't cross it. Zero
+    exits emitted.
+
+    Contract: zero [TriggerExit] transitions across the sequence. *)
+let test_g1_short_no_exit_on_counter_bounce _ =
+  let ticker = "ALB" in
+  let entry_date = Date.of_string "2019-01-15" in
+  let entry_price = 100.0 in
+  let stop_level = 103.58 in
+  (* Two bars: initial pullback then a small counter-bounce.  Both bar
+     highs stay below the $103.58 entry-stop, but the bounce high
+     ($99.5) is above the stop level the Stage2-hardcode bug drifts to
+     (~$99.13) on bar 1. *)
+  let bars =
+    [
+      make_bar "2019-01-22" ~close:95.0 ~low:94.0 ~high:98.0 ();
+      make_bar "2019-01-29" ~close:80.0 ~low:79.0 ~high:99.5 ();
+    ]
+  in
+  let exits, _adjusts, _final_stop_states =
+    _run_short_sequence ~ticker ~entry_price ~entry_date ~stop_level ~bars
+  in
+  (* Contract: no exit transitions emitted on either bar.  Neither bar
+     prints above the $103.58 entry-stop; a short held profitably must
+     not exit when the stop machinery is functioning correctly. *)
+  assert_that exits is_empty
+
+(** Reproducer 2: the canonical ALB audit anomaly.
+
+    On a single violent down-day where the bar high crosses the short stop
+    (intraday spike before close), [check_stop_hit] correctly fires — but
+    [_make_exit_transition] then records [actual_price = bar.low_price]
+    regardless of position side. For a SHORT covered when price rallies UP
+    through the stop, the worst-case fill is at [bar.high_price] (or the stop
+    level), not [bar.low_price]. Recording bar.low produces audit log entries
+    like ALB on 2019-01-29 — stop $103.58, actual_price $77.49, when ALB closed
+    at $76 — that look as if the stop fired against profitable territory.
+
+    This pins the audit-record contract: when a short stop fires on a bar whose
+    high crosses the stop, the recorded [actual_price] (and [exit_price]) must
+    reflect the trigger side (high or stop level), not the bar's low. *)
+let test_g1_short_exit_records_high_not_low _ =
+  let ticker = "ALB" in
+  let entry_date = Date.of_string "2019-01-15" in
+  let entry_price = 100.0 in
+  let stop_level = 103.58 in
+  let pos =
+    make_holding_pos ~side:Trading_base.Types.Short ticker entry_price
+      entry_date
+  in
+  let positions = String.Map.singleton ticker pos in
+  let stop_states =
+    ref
+      (String.Map.singleton ticker
+         (Weinstein_stops.Initial { stop_level; reference_level = stop_level }))
+  in
+  (* Violent down-day: open above stop, intraday spike crosses stop,
+     close near the day's low. Mirrors the ALB 2019-01-29 audit shape:
+     intraday high $104 (above stop $103.58) → trigger fires; close /
+     low at $76–$77 (the misleading "actual_price" in the audit log). *)
+  let bar = make_bar "2019-01-29" ~close:76.0 ~low:75.5 ~high:104.0 () in
+  let exits, _adjusts =
+    Stops_runner.update ~stops_config:default_cfg
+      ~stage_config:default_stage_cfg ~lookback_bars:52 ~positions
+      ~get_price:(get_price_of [ (ticker, bar) ])
+      ~stop_states ~bar_reader:(Bar_reader.empty ())
+      ~as_of:(Date.of_string "2019-01-29")
+      ~prior_stages:(Hashtbl.create (module String))
+      ()
+  in
+  (* The trigger fired (correct: high $104 >= stop $103.58). Now pin
+     the audit record: actual_price must be the trigger side — the
+     short cover hits at bar.high or the stop level, not bar.low. *)
+  assert_that exits
+    (elements_are
+       [
+         field
+           (fun (tr : Trading_strategy.Position.transition) -> tr.kind)
+           (matching ~msg:"Expected TriggerExit with StopLoss"
+              (function
+                | Trading_strategy.Position.TriggerExit
+                    { exit_reason = StopLoss s; exit_price } ->
+                    Some (s.actual_price, exit_price)
+                | _ -> None)
+              (all_of
+                 [
+                   (* actual_price must be at or above the stop level —
+                      a short cover triggers at the trigger price (high
+                      or stop), never at the bar's low. *)
+                   field (fun (a, _) -> a) (ge (module Float_ord) stop_level);
+                   field (fun (_, e) -> e) (ge (module Float_ord) stop_level);
+                 ]));
+       ])
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -220,4 +376,8 @@ let () =
            >:: test_update_stop_hit_emits_trigger_exit;
            "update mutates stop_states ref for held positions"
            >:: test_update_mutates_stop_states_ref;
+           "G1: short stop emits no exit on counter-bounce below entry stop"
+           >:: test_g1_short_no_exit_on_counter_bounce;
+           "G1: short exit records high (not low) on violent down-day"
+           >:: test_g1_short_exit_records_high_not_low;
          ])

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -277,7 +277,17 @@ let test_bar_accumulation_multiple_days _ =
   let portfolio : Trading_strategy.Portfolio_view.t =
     { cash = 100000.0; positions }
   in
-  (* Three consecutive days with rising price — stop adjusts each day *)
+  (* Three consecutive days with rising price — too few bars for the
+     30-week MA to come online, so the stop machinery stays in its
+     position-favourable warmup pose throughout. Pre-G1 fix
+     ([Stops_runner._handle_stop] hardcoded [stage = Stage2] + [Flat MA]
+     for the warmup fallback), Day 2 spuriously emitted a [Stop_raised]
+     transition driven by [_should_tighten_long]'s "30-week MA flattening"
+     branch — the same pathology that pulled short stops AGAINST short
+     positions on the short-side audit (G1, see
+     [dev/notes/short-side-gaps-2026-04-29.md]). Post-fix, the runner
+     passes [Stage2 + Rising MA] during long warmup, no spurious tightening
+     fires, and all three days emit zero transitions. *)
   let days_and_prices =
     [ ("2024-01-08", 175.0); ("2024-01-09", 180.0); ("2024-01-10", 185.0) ]
   in
@@ -292,10 +302,7 @@ let test_bar_accumulation_multiple_days _ =
         in
         _transition_count result)
   in
-  (* Day 1: Initial stop, no raise yet (0 transitions).
-     Day 2: bar history now has 2 days; stop adjusts (1 transition).
-     Day 3: stop already adjusted, no further raise at this level (0). *)
-  assert_that counts (elements_are [ equal_to 0; equal_to 1; equal_to 0 ])
+  assert_that counts (elements_are [ equal_to 0; equal_to 0; equal_to 0 ])
 
 (* ------------------------------------------------------------------ *)
 (* simulation date: transition uses bar date, not Date.today            *)


### PR DESCRIPTION
## Summary

Diagnoses and fixes the **G1** short-stop audit anomaly from
`dev/notes/short-side-gaps-2026-04-29.md`: ALB short with stop $103.58
exiting at $77.49 on 2019-01-29 when ALB closed at $76. **Two distinct
bugs** in `Stops_runner` produce the anomaly — neither matches the
original "comparison evaluating with long-side sense" hypothesis.

**Status: DRAFT** — fix is unit-test verified but not yet sp500-baseline-verified. The
gaps doc convention (PR #682 / #687) is to ship G1 / G2 fixes draft until
the sp500 backtest rerun confirms metrics improve.

## Hypotheses tested

The dispatch listed 3 hypotheses. Trace results:

- **H1 — `_make_exit_transition` hardcodes `bar.low_price` for shorts** → **CONFIRMED**. Pinned by `test_g1_short_exit_records_high_not_low`.
- **H2 — Trailing-state extreme inversion for shorts** → **WRONG SHAPE, but partially correct**. The `_advance_tracking` `min`/`max` choice is correct, but there's a *deeper* phantom-cycle bug in `_completed_cycle_stop` triggered by the `_to_trailing` seeding (out-of-scope follow-up; documented in gaps doc).
- **H3 — Screener-driven exit pathway** → **NA**. Stops_runner emits the anomalous transition directly.
- **H4 — `_handle_stop` hardcodes `~stage:Stage2`** → **CONFIRMED** (new hypothesis). Pinned by `test_g1_short_no_exit_on_counter_bounce`.

## What it does

### Bug 1: stage hardcode

`Stops_runner._handle_stop` unconditionally passes `~stage:(Stage2 { weeks_advancing = 1; late = false })` to `Weinstein_stops.update`, regardless of position side. For shorts in warmup (`weekly.n < ma_period`, `ma_direction = Flat` fallback), `Weinstein_stops._should_tighten_short` matches `Stage1 | Stage2 -> tighten` and fires `Entered_tightening` on the very first Initial-state tick. The candidate computed from the bar's high (`bar.high * (1 + buf)` ≈ $99 for entry-bar high $98) is "better" than the entry stop $103.58 in short-direction logic, so the stop drops to ~$99 on bar 1 — already BELOW entry $100. Subsequent small counter-bounces above the eroded stop fire spurious exits.

**Fix**: `_compute_ma` (renamed to `_compute_ma_and_stage`) now also returns the classified stage. In warmup, returns a position-favourable default (`Stage2 + Rising` for longs, `Stage4 + Declining` for shorts) — both no-tighten branches by `_should_tighten_*`'s logic.

### Bug 2: `actual_price = bar.low_price` hardcode for shorts

`Stops_runner._make_exit_transition` reads `bar.low_price` for `actual_price` and `exit_price` regardless of side. For longs, `bar.low` is the worst-case fill on a stop trigger (the bar's low crosses DOWN through the stop). For shorts, the trigger fires on `bar.high >= stop_level` and the worst-case cover fill is at `bar.high` (or the stop level). Recording `bar.low` produces audit entries like ALB 2019-01-29 (stop $103.58, actual_price $77.49) that read as "stop fired against profitable territory" even when the trigger itself was correct.

**Fix**: new `_trigger_fill_price` helper selects by side.

## Trace excerpt (pre-fix)

Reproducer driving 4 weekly bars ALB short, stop $103.58:

```
[trace] ALB side=Short bar=(low=94 high=98 close=95)   state.in=Initial(103.58)   state.out=Tightened(99.125, ext=98)  event=Entered_tightening
[trace] ALB side=Short bar=(low=87 high=91 close=88)   state.in=Tightened(99.125) state.out=Tightened(98.625, ext=91)  event=Stop_raised
[trace] ALB side=Short bar=(low=81 high=84 close=82)   state.in=Tightened(98.625) state.out=Tightened(98.625)          event=No_change
[trace] ALB side=Short bar=(low=75.5 high=77.5 close=76) ...
```

Stop dropped from $103.58 → $99.125 on bar 1 — already in profit-territory for the short. `Expected value >= 100. but got 98.625`.

## Reproducer tests

Both fail on current main, pass post-fix:

- **`test_g1_short_no_exit_on_counter_bounce`** — short with $103.58 stop, pullback bar (high $98) then counter-bounce (high $99.5, below $100 entry). Asserts zero exit transitions across the sequence. Pins bug 1.
- **`test_g1_short_exit_records_high_not_low`** — violent down-day with bar.high=$104 (crosses stop). Asserts the recorded `actual_price` and `exit_price` ≥ stop_level (not bar.low). Pins bug 2.

## Side-effect

`test_weinstein_strategy.test_bar_accumulation_multiple_days` previously pinned the same warmup-tightening pathology for longs (Day 2 expected 1 transition driven by spurious tightening). Updated to expect 0 transitions across all 3 days — the position-favourable warmup default applies symmetrically to both sides.

## Out-of-scope follow-up

There is a deeper Trailing-state phantom-cycle bug in `Weinstein_stops._completed_cycle_stop`: the seeded `last_correction_extreme = bar.high` from `_to_trailing` paired with an advancing `last_trend_extreme` over subsequent bars phantom-fires the cycle even without an actual counter-rally, dragging the short stop further DOWN through entry. The naive fix (reset correction_extreme on trend advance) breaks `regression_test.stage2_trailing_stop_raised_phase_a` — that test deliberately seeds the entry-bar low as the cycle-1 correction anchor for longs. A proper fix needs temporal-ordering tracking (correction must be set AFTER trend extreme). **Re-evaluate after sp500 baseline rerun whether the runner-side fix alone is sufficient.** Documented in the gaps doc.

## PR #689 audit harness compatibility

PR #689's Tests A and B (audit harness) are preserved by this fix:

- **Test A** (short stop above entry, bar high below stop, no exit): unaffected — `Weinstein_stops.check_stop_hit` unchanged.
- **Test B** (short stop above entry, bar high above stop, exit fires with stop_price = $103.58): unaffected — Test B asserts only `stop_price` (read from `state.in`, unchanged), not `actual_price` (which my fix changes).

## Test plan

- [ ] `dune build trading/weinstein` (clean)
- [ ] `dune runtest trading/weinstein` — all weinstein-tree tests pass (22 strategy tests + 7 stops_runner tests + 29+25+10 stops tests)
- [ ] Reproducer tests fail on current main (verified by stashing the fix and re-running)
- [ ] Reproducer tests pass with fix
- [ ] PR #689 audit harness Tests A + B preserved (analytical — fix doesn't touch `check_stop_hit`)
- [ ] sp500-2019-2023 baseline rerun (maintainer's job post-merge): confirm short-side metrics improve and no regression in long-side returns

## Files touched

- `trading/trading/weinstein/strategy/lib/stops_runner.ml` — minimal fix
- `trading/trading/weinstein/strategy/test/test_stops_runner.ml` — 2 reproducer tests + side-aware `make_holding_pos` helper
- `trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml` — `test_bar_accumulation_multiple_days` updated to expect 0 transitions in warmup
- `dev/notes/short-side-gaps-2026-04-29.md` — G1 sub-section with diagnosis + fix reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)