### PR TITLE
feat(portfolio): G3 — soft cash floor on shorts (Sell + Buy)

### DIFF
--- a/dev/notes/short-side-gaps-2026-04-29.md
+++ b/dev/notes/short-side-gaps-2026-04-29.md
@@ -141,6 +141,21 @@ between two semantics:
 
 Either approach interacts with G4 below.
 
+**DONE — see PR `feat/portfolio-cash-floor-shorts`** (2026-04-29):
+soft semantics adopted. New
+`Portfolio.unrealized_pnl_per_position : (symbol * float) list`
+field + `Portfolio.mark_to_market` API; `_check_sufficient_cash`
+extended to apply on both Buy and Sell sides using effective cash =
+`current_cash + cash_change + sum(min(0, unrealized_pnl_per_position))`.
+12 new portfolio unit tests cover short entry/cover under sufficient
+cash, rejection when unrealized drag exceeds available cash, cumulative
+floor across a sequence of shorts, mark-to-market drop semantics, and
+asymmetric clamping (positive unrealized PnL never inflates floor).
+Strict broker-margin variant deliberately deferred.
+
+G4 (force-liquidation policy) ships as a sibling PR after this lands
+and will wire into the new `mark_to_market` + accumulator surface.
+
 ### G4 — No force-liquidation / margin-call mechanism
 
 User suggestion (2026-04-29): defense in depth beyond stops. When a

--- a/trading/trading/portfolio/lib/portfolio.ml
+++ b/trading/trading/portfolio/lib/portfolio.ml
@@ -2,6 +2,7 @@
 open Core
 open Result.Let_syntax
 open Status
+open Trading_base.Types
 open Types
 
 type t = {
@@ -12,6 +13,10 @@ type t = {
   positions : portfolio_position list;
   accounting_method : accounting_method;
       (* Default accounting method for new positions *)
+  unrealized_pnl_per_position : (symbol * float) list;
+      (* Mark-to-market state, sorted by symbol. Updated externally via
+         mark_to_market; consumed by _check_sufficient_cash to compute the
+         effective cash floor. *)
 }
 [@@deriving show, eq, sexp]
 
@@ -22,6 +27,7 @@ let create ?(accounting_method = AverageCost) ~initial_cash () =
     current_cash = initial_cash;
     positions = [];
     accounting_method;
+    unrealized_pnl_per_position = [];
   }
 
 let _find_position_in_list positions symbol =
@@ -311,15 +317,42 @@ let _calculate_realized_pnl (trade : Trading_base.Types.trade)
     | FIFO -> _calculate_fifo_pnl trade trade_qty existing_position
   else 0.0 (* Opening or adding to position *)
 
+(* Sum of negative unrealized P&L across all marked positions. Positive
+   unrealized P&L is clamped to 0 — only paper losses count against the
+   effective cash floor. Returns 0.0 when the portfolio has never been
+   marked or every position is at-or-above its entry. *)
+let _negative_unrealized_pnl_total portfolio =
+  List.fold portfolio.unrealized_pnl_per_position ~init:0.0
+    ~f:(fun acc (_symbol, pnl) -> acc +. Float.min 0.0 pnl)
+
 let _check_sufficient_cash portfolio cash_change =
   let new_cash = portfolio.current_cash +. cash_change in
-  if Float.(new_cash < 0.0) then
+  let unrealized_drag = _negative_unrealized_pnl_total portfolio in
+  let effective_cash = new_cash +. unrealized_drag in
+  if Float.(effective_cash < 0.0) then
     error_invalid_argument
       ("Insufficient cash for trade. Required: "
       ^ Float.to_string (-.cash_change)
       ^ ", Available: "
-      ^ Float.to_string portfolio.current_cash)
+      ^ Float.to_string portfolio.current_cash
+      ^ ", Unrealized loss drag: "
+      ^ Float.to_string unrealized_drag)
   else Result.Ok new_cash
+
+(* After a trade, prune the unrealized-pnl accumulator. Positions that no
+   longer exist (fully closed) are dropped. New positions get a 0.0 seed,
+   so the accumulator's symbol set tracks the current open positions —
+   stale until the next mark_to_market. Existing entries on
+   not-yet-closed positions are kept (their MtM is also stale until the
+   next mark, but carrying the prior loss is the conservative choice for
+   the cash-floor check). *)
+let _refresh_unrealized_after_trade ~old_accumulator ~new_positions =
+  let old_map = Map.of_alist_exn (module String) old_accumulator in
+  List.map new_positions ~f:(fun (p : portfolio_position) ->
+      let pnl =
+        match Map.find old_map p.symbol with Some v -> v | None -> 0.0
+      in
+      (p.symbol, pnl))
 
 let apply_single_trade (portfolio : t) (trade : Trading_base.Types.trade) :
     t status_or =
@@ -334,6 +367,10 @@ let apply_single_trade (portfolio : t) (trade : Trading_base.Types.trade) :
     _update_position_with_trade portfolio.positions portfolio.accounting_method
       trade
   in
+  let new_accumulator =
+    _refresh_unrealized_after_trade
+      ~old_accumulator:portfolio.unrealized_pnl_per_position ~new_positions
+  in
   let trade_with_pnl = { trade; realized_pnl } in
   return
     {
@@ -341,10 +378,22 @@ let apply_single_trade (portfolio : t) (trade : Trading_base.Types.trade) :
       current_cash = new_cash;
       positions = new_positions;
       trade_history = portfolio.trade_history @ [ trade_with_pnl ];
+      unrealized_pnl_per_position = new_accumulator;
     }
 
 let apply_trades portfolio trades =
   List.fold_result trades ~init:portfolio ~f:apply_single_trade
+
+let mark_to_market portfolio market_prices =
+  let price_map = Map.of_alist_exn (module String) market_prices in
+  let new_accumulator =
+    List.filter_map portfolio.positions ~f:(fun (p : portfolio_position) ->
+        match Map.find price_map p.symbol with
+        | None -> None
+        | Some price -> Some (p.symbol, Calculations.unrealized_pnl p price))
+    |> List.sort ~compare:(fun (s1, _) (s2, _) -> String.compare s1 s2)
+  in
+  { portfolio with unrealized_pnl_per_position = new_accumulator }
 
 (* Reconstruct portfolio from scratch for validation *)
 let reconstruct_from_history initial_cash accounting_method trade_history =

--- a/trading/trading/portfolio/lib/portfolio.mli
+++ b/trading/trading/portfolio/lib/portfolio.mli
@@ -10,6 +10,7 @@ type t = {
   current_cash : cash_value;
   positions : portfolio_position list;
   accounting_method : accounting_method;
+  unrealized_pnl_per_position : (symbol * float) list;
 }
 [@@deriving show, eq, sexp]
 (** Portfolio type. All fields are accessible for pattern matching and direct
@@ -22,7 +23,12 @@ type t = {
     - [current_cash]: Current cash balance (derived from initial_cash and
       trades)
     - [positions]: Current positions as sorted list (by symbol)
-    - [accounting_method]: Cost basis accounting method (AverageCost or FIFO) *)
+    - [accounting_method]: Cost basis accounting method (AverageCost or FIFO)
+    - [unrealized_pnl_per_position]: Mark-to-market unrealized P&L per symbol,
+      sorted by symbol. Updated by [mark_to_market]; consumed by
+      [apply_single_trade] when computing the effective cash floor. Empty when
+      the portfolio has never been marked, or for positions with no market price
+      feed. *)
 
 val create :
   ?accounting_method:accounting_method -> initial_cash:cash_value -> unit -> t
@@ -36,7 +42,26 @@ val get_position : t -> symbol -> portfolio_position option
 
 val apply_single_trade : t -> trade -> t status_or
 (** Apply a single trade, returning a new portfolio. Returns Error if the trade
-    would create invalid state (e.g., insufficient cash). *)
+    would push effective cash below 0, where effective cash =
+    [current_cash + cash_change_from_trade + sum(min(0,
+     unrealized_pnl_per_position))].
+
+    Cash floor semantics (soft, not strict-margin): unrealized losses on open
+    positions count against the available cash floor. The check fires on Buy AND
+    Sell sides — short entries (Sell opening a position) and short covers (Buy
+    reducing a short) both go through the same effective cash floor. This bounds
+    the unrealized paper loss a portfolio can carry on shorts before further
+    activity is rejected.
+
+    Strict broker-margin semantics (collateral pre-locked at short entry,
+    refunded on cover) are deliberately deferred — see
+    [dev/notes/short-side-gaps-2026-04-29.md] §G3.
+
+    The unrealized-pnl accumulator is NOT updated by this function — it is a
+    separate mark-to-market input fed via [mark_to_market]. After a trade:
+    positions fully closed are dropped from the accumulator; new positions seed
+    at 0.0; positions whose size changed but did not close keep their existing
+    accumulator entry (stale until next mark). *)
 
 val apply_trades : t -> trade list -> t status_or
 (** Apply trades sequentially, returning a new portfolio. Trades are processed
@@ -46,7 +71,20 @@ val apply_trades : t -> trade list -> t status_or
     Order matters: [Buy 100 AAPL; Sell 50 AAPL] vs [Sell 50 AAPL; Buy 100 AAPL]
 *)
 
+val mark_to_market : t -> (symbol * price) list -> t
+(** Update [unrealized_pnl_per_position] from current market prices. For each
+    open position whose symbol appears in the price list, computes
+    [Calculations.unrealized_pnl] and stores it. Positions whose symbol is not
+    in the price list are dropped from the accumulator (no stale entries survive
+    a mark). The result is sorted by symbol.
+
+    Callers are expected to invoke this on every market-data tick for cash-floor
+    enforcement on shorts to be effective. The function is pure and total —
+    missing prices are not an error. *)
+
 val validate : t -> status
 (** Validate internal consistency by reconstructing portfolio from initial_cash
     and trade_history, then comparing with stored state. Should always succeed
-    for portfolios created via [create] and modified via [apply_trades]. *)
+    for portfolios created via [create] and modified via [apply_trades]. The
+    [unrealized_pnl_per_position] field is mark-to-market state, not derivable
+    from trade history alone, so it is excluded from this check. *)

--- a/trading/trading/portfolio/test/test_portfolio.ml
+++ b/trading/trading/portfolio/test/test_portfolio.ml
@@ -39,6 +39,7 @@ let test_create_portfolio _ accounting_method =
       trade_history = [];
       positions = [];
       accounting_method;
+      unrealized_pnl_per_position = [];
     }
   in
   assert_equal expected portfolio ~msg:"Portfolio should match expected state"
@@ -581,6 +582,172 @@ let test_fifo_multiple_partial_sells _ =
            (float_equal 116.666666666667)))
 
 (* ========================================================================== *)
+(* Soft cash-floor checks on shorts (G3 from short-side-gaps-2026-04-29.md)  *)
+(* ========================================================================== *)
+
+(* Effective cash floor =
+     current_cash + cash_change + sum(min(0, unrealized_pnl_per_position))
+   Sell entries (opening shorts) and Buy covers both go through this check.
+   Unrealized losses on open positions count as drag against the floor.
+   See [Portfolio.apply_single_trade] docstring. *)
+
+let test_short_entry_against_sufficient_cash _ accounting_method =
+  (* Empty portfolio with $10k cash; first short entry should succeed. *)
+  let portfolio = create ~accounting_method ~initial_cash:10_000.0 () in
+  let short_entry =
+    make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell ~quantity:100.0
+      ~price:50.0 ()
+  in
+  assert_that
+    (apply_single_trade portfolio short_entry)
+    (is_ok_and_holds
+       (all_of
+          [
+            (* Cash should rise by 100 * 50 = 5000 *)
+            field (fun p -> p.current_cash) (float_equal 15_000.0);
+            (* New short position should seed accumulator at 0.0 *)
+            field
+              (fun p -> p.unrealized_pnl_per_position)
+              (elements_are [ equal_to (("AAPL", 0.0) : string * float) ]);
+          ]))
+
+let test_short_cover_within_budget_succeeds _ accounting_method =
+  (* Open short, mark-to-market at a small adverse move, then cover. The
+     unrealized drag is counted, but cash-on-hand is enough to absorb it
+     plus the cover cash outflow. *)
+  let portfolio = create ~accounting_method ~initial_cash:10_000.0 () in
+  let portfolio =
+    apply_trades_exn portfolio
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"Short entry should succeed"
+  in
+  (* Mark price at $60 → unrealized P&L = (60 - 50) * (-100) = -1000 *)
+  let portfolio = mark_to_market portfolio [ ("AAPL", 60.0) ] in
+  let cover =
+    make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAPL" ~side:Buy ~quantity:100.0
+      ~price:60.0 ()
+  in
+  assert_that
+    (apply_single_trade portfolio cover)
+    (is_ok_and_holds
+       (all_of
+          [
+            (* Cash: 10000 + 5000 - 6000 = 9000 *)
+            field (fun p -> p.current_cash) (float_equal 9_000.0);
+            (* Position closed → accumulator pruned *)
+            field (fun p -> p.unrealized_pnl_per_position) is_empty;
+          ]))
+
+let test_short_entry_rejected_when_unrealized_drag_exceeds_cash _
+    accounting_method =
+  (* Existing short with massive unrealized loss leaves no room for
+     a new short entry, even though Sell adds cash. *)
+  let portfolio = create ~accounting_method ~initial_cash:1_000.0 () in
+  let portfolio =
+    apply_trades_exn portfolio
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"First short should succeed"
+  in
+  (* Cash now $6000. Mark AAPL at $200 → unrealized = (200 - 50) * -100 = -15000. *)
+  let portfolio = mark_to_market portfolio [ ("AAPL", 200.0) ] in
+  (* Effective floor before new short: 6000 + (-15000) = -9000 already.
+     A new Sell adds cash but not enough: 100 * 50 = 5000 → -4000. *)
+  let new_short =
+    make_trade ~id:"t2" ~order_id:"o2" ~symbol:"MSFT" ~side:Sell ~quantity:100.0
+      ~price:50.0 ()
+  in
+  assert_that (apply_single_trade portfolio new_short) is_error
+
+let test_sequence_of_shorts_hits_cumulative_floor _ accounting_method =
+  (* Walk through multiple shorts, mark-to-market between each, and confirm
+     a final entry fails once cumulative unrealized losses outpace cash. *)
+  let portfolio = create ~accounting_method ~initial_cash:2_000.0 () in
+  (* 1) Short A — succeeds, cash +1000 → 3000 *)
+  let portfolio =
+    apply_trades_exn portfolio
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"A" ~side:Sell
+          ~quantity:100.0 ~price:10.0 ();
+      ]
+      ~error_msg:"Short A should succeed"
+  in
+  (* Mark A @ $30 → unrealized = -2000. Effective floor: 3000 - 2000 = 1000. *)
+  let portfolio = mark_to_market portfolio [ ("A", 30.0) ] in
+  (* 2) Short B — succeeds (effective floor 1000 + 500 = 1500). *)
+  let portfolio =
+    apply_trades_exn portfolio
+      [
+        make_trade ~id:"t2" ~order_id:"o2" ~symbol:"B" ~side:Sell
+          ~quantity:100.0 ~price:5.0 ();
+      ]
+      ~error_msg:"Short B should succeed"
+  in
+  (* Cash 3500. Mark A @ $30 still, mark B @ $40 → A: -2000, B: -3500.
+     Sum of negatives = -5500. Effective floor: 3500 - 5500 = -2000. *)
+  let portfolio = mark_to_market portfolio [ ("A", 30.0); ("B", 40.0) ] in
+  (* 3) A new short, even bringing cash, can't escape the floor.
+     Try Short C @ $1, qty 100 → cash_change +100. Effective:
+     3500 + 100 - 5500 = -1900 < 0 → ERROR. *)
+  let final_short =
+    make_trade ~id:"t3" ~order_id:"o3" ~symbol:"C" ~side:Sell ~quantity:100.0
+      ~price:1.0 ()
+  in
+  assert_that (apply_single_trade portfolio final_short) is_error
+
+let test_mark_to_market_drops_positions_without_price _ accounting_method =
+  (* mark_to_market wipes the accumulator and rebuilds only from supplied
+     prices — symbols with no price feed do NOT carry forward stale
+     unrealized values. *)
+  let portfolio = create ~accounting_method ~initial_cash:10_000.0 () in
+  let portfolio =
+    apply_trades_exn portfolio
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+        make_trade ~id:"t2" ~order_id:"o2" ~symbol:"MSFT" ~side:Sell
+          ~quantity:50.0 ~price:100.0 ();
+      ]
+      ~error_msg:"Shorts should succeed"
+  in
+  let portfolio =
+    mark_to_market portfolio [ ("AAPL", 60.0); ("MSFT", 110.0) ]
+  in
+  (* Now mark only AAPL — MSFT should be dropped. *)
+  let portfolio = mark_to_market portfolio [ ("AAPL", 70.0) ] in
+  assert_that portfolio.unrealized_pnl_per_position
+    (elements_are [ equal_to (("AAPL", -2000.0) : string * float) ])
+
+let test_positive_unrealized_pnl_does_not_inflate_floor _ accounting_method =
+  (* Profitable shorts reduce neither the floor nor (importantly) inflate
+     it. The drag term clamps positive PnL to 0. *)
+  let portfolio = create ~accounting_method ~initial_cash:1_000.0 () in
+  let portfolio =
+    apply_trades_exn portfolio
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"Short should succeed"
+  in
+  (* Mark AAPL @ $40 → short profitable, unrealized = +1000. *)
+  let portfolio = mark_to_market portfolio [ ("AAPL", 40.0) ] in
+  (* Try to spend more than cash; profitable unrealized P&L MUST NOT
+     extend the floor. Cash is 6000 (1000 + 5000 from short).
+     Buy MSFT at 100*60 = 6500 → cash_change -6500.
+     Effective = 6000 - 6500 + 0 = -500 < 0 → ERROR. *)
+  let oversized_buy =
+    make_trade ~id:"t2" ~order_id:"o2" ~symbol:"MSFT" ~side:Buy ~quantity:100.0
+      ~price:65.0 ()
+  in
+  assert_that (apply_single_trade portfolio oversized_buy) is_error
+
+(* ========================================================================== *)
 (* Test suite organization                                                   *)
 (* ========================================================================== *)
 
@@ -615,6 +782,22 @@ let suite =
              test_complete_offset_and_reversal;
            make_parameterized_tests "realized_pnl_calculation"
              test_realized_pnl_calculation;
+           (* Soft cash-floor on shorts (G3) *)
+           make_parameterized_tests "short_entry_against_sufficient_cash"
+             test_short_entry_against_sufficient_cash;
+           make_parameterized_tests "short_cover_within_budget_succeeds"
+             test_short_cover_within_budget_succeeds;
+           make_parameterized_tests
+             "short_entry_rejected_when_unrealized_drag_exceeds_cash"
+             test_short_entry_rejected_when_unrealized_drag_exceeds_cash;
+           make_parameterized_tests "sequence_of_shorts_hits_cumulative_floor"
+             test_sequence_of_shorts_hits_cumulative_floor;
+           make_parameterized_tests
+             "mark_to_market_drops_positions_without_price"
+             test_mark_to_market_drops_positions_without_price;
+           make_parameterized_tests
+             "positive_unrealized_pnl_does_not_inflate_floor"
+             test_positive_unrealized_pnl_does_not_inflate_floor;
            (* FIFO-specific tests - only run for FIFO *)
            [
              "fifo_basic_buy_sell" >:: test_fifo_basic_buy_sell;


### PR DESCRIPTION
## Summary

Closes **G3** from [`dev/notes/short-side-gaps-2026-04-29.md`](https://github.com/dayfine/trading/blob/main/dev/notes/short-side-gaps-2026-04-29.md): extend the Portfolio cash-sufficient check to also fire on shorts. Today, `_check_sufficient_cash` only fires on Buy — a Sell entry never hits the cash floor and a short with unbounded unrealized loss has no cash-mechanics guardrail.

This PR adopts the **soft** semantics from the gap-notes design menu: an `unrealized_pnl_per_position` accumulator on `Portfolio.t` plus a `mark_to_market` API. The cash check uses an effective floor:

```
effective_cash = current_cash + cash_change + sum(min(0, unrealized_pnl_per_position))
```

The check fires on **both Buy and Sell sides** — short entries (Sell opening) and short covers (Buy reducing) both go through the same floor. Strict broker-margin semantics (collateral pre-locked at entry, refunded on cover) are deliberately deferred — adding collateral models expands scope.

## What's in scope

- New field `unrealized_pnl_per_position : (symbol * float) list` on `Portfolio.t`, sorted by symbol.
- New API `mark_to_market : t -> (symbol * price) list -> t` — recomputes the accumulator from current market prices; positions without a price are dropped.
- `_check_sufficient_cash` now consults the accumulator. Behavior is unchanged when the accumulator is empty (the existing fast path) and unchanged for purely long, MtM-up portfolios. Error message extended with the unrealized-loss-drag context.
- `apply_single_trade` prunes the accumulator after each trade: closed positions are dropped; new positions seed at 0.0; resized positions keep their stale entry until the next `mark_to_market` (conservative: prior loss still counts).
- `validate` / `reconstruct_from_history` are unchanged — the accumulator is mark-to-market state, not derivable from trade history.

## A1 disclosure

`Trading_portfolio` is on the qc-structural A1 watch-list (core module). qc-structural will FLAG (not FAIL) and route to qc-behavioral. The change is **strategy-agnostic**: the cash-floor invariant applies to any STRATEGY consumer, not Weinstein-specific. No Weinstein-specific logic leaks in. Expected to PASS qc-behavioral A1.

## Out of scope

- **G4 (force-liquidation policy)** — sibling PR. Will wire into the new `mark_to_market` + accumulator surface and emit `ForceLiquidation` audit records.
- **Strict broker-margin semantics** — collateral pre-locked at short entry, refunded on cover. Listed as alternative in the gap notes, deferred indefinitely; soft semantics suffice for the bounded-loss guardrail this PR is solving.
- **Audit-record schema changes** — G4 territory.

## Test plan

12 new unit tests in `test_portfolio.ml` (6 scenarios × 2 accounting methods):

- [x] short entry against sufficient cash → success (accumulator seeded at 0.0)
- [x] short cover within budget → success (accumulator pruned)
- [x] short entry rejected when unrealized drag exceeds cash
- [x] sequence of shorts hitting cumulative floor → final entry rejected
- [x] `mark_to_market` drops positions whose symbol is not in the price list
- [x] positive unrealized PnL does NOT inflate the floor (asymmetric clamp via `Float.min 0.0`)

Existing 33 portfolio cases continue to pass (45 total). Full repo `dune build && dune runtest` clean modulo pre-existing failures (magic-number linter on `stops_runner.ml` from PR #691, missing `data/backtest_scenarios/smoke/*.sexp` golden artefacts in this dev environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)