### PR TITLE
feat(portfolio): G4 — force-liquidation policy (defense in depth)

### DIFF
--- a/dev/notes/short-side-gaps-2026-04-29.md
+++ b/dev/notes/short-side-gaps-2026-04-29.md
@@ -206,6 +206,24 @@ scenario count surfaces in the release-perf report's trading-metrics
 table with a non-zero red-flag glyph. Halt state in `Peak_tracker`
 suppresses new entries until macro flips off Bearish.
 
+**REWORK DONE (2026-04-29, second commit on PR #695)**: applied
+qc-behavioral findings B1–B3.
+- **B1 (load-bearing)**: halt-resume bug fixed by splitting
+  `_run_screen` into `_run_macro_only` + `_run_screen_after_macro` and
+  running the macro pass + `_maybe_reset_halt` on every Friday
+  including halted Fridays. Pre-fix the halt latched permanently
+  because `prior_macro` never refreshed after the floor fired.
+- **B2**: end-to-end `trades.csv` exit-trigger pinning via new
+  `test_result_writer.ml` (3 tests covering both labels + non-match).
+- **B3**: defensive guards pinned — zero cost-basis, zero quantity,
+  non-Holding position, missing price, double-exit avoidance (5 new
+  tests across `test_force_liquidation.ml` and
+  `test_force_liquidation_runner.ml`).
+- Test seam: new `Weinstein_strategy.Internal_for_test` exposing
+  `on_market_close` / `maybe_reset_halt` / `positions_minus_exited`
+  for direct strategy-level testing without going through `make`'s
+  closure.
+
 ### G5 — Audit harness lacks a Weinstein-strategy-backed scenario
 
 `test_split_day_audit.ml` (now 14 scenarios after PR #681) uses

--- a/dev/notes/short-side-gaps-2026-04-29.md
+++ b/dev/notes/short-side-gaps-2026-04-29.md
@@ -192,6 +192,20 @@ machinery failed to protect the trade.
 `trading/trading/backtest/lib/trade_audit.{ml,mli}`. Tests at
 `trading/trading/weinstein/portfolio_risk/test/`.
 
+**DONE — see PR `feat/force-liquidation`** (2026-04-29): defaults
+50% per-position unrealized-loss threshold + 40% portfolio-of-peak
+floor (configurable via `Portfolio_risk.config.force_liquidation`).
+New module `Portfolio_risk.Force_liquidation` (pure check + mutable
+`Peak_tracker`) plus `Weinstein_strategy.Force_liquidation_runner`
+wiring TriggerExit transitions and routing events through a new
+`Audit_recorder.record_force_liquidation` callback. Backtest-side:
+new `Force_liquidation_log.t` collector, `force_liquidations.sexp`
+artefact, and `trades.csv` exit-trigger column overrides
+(`force_liquidation_position` | `force_liquidation_portfolio`). Per-
+scenario count surfaces in the release-perf report's trading-metrics
+table with a non-zero red-flag glyph. Halt state in `Peak_tracker`
+suppresses new entries until macro flips off Bearish.
+
 ### G5 — Audit harness lacks a Weinstein-strategy-backed scenario
 
 `test_split_day_audit.ml` (now 14 scenarios after PR #681) uses

--- a/trading/trading/backtest/lib/dune
+++ b/trading/trading/backtest/lib/dune
@@ -12,6 +12,7 @@
   trading.simulation.types
   trading.strategy
   weinstein_trading.strategy
+  weinstein_trading.portfolio_risk
   weinstein.macro
   weinstein.resistance
   weinstein.rs

--- a/trading/trading/backtest/lib/force_liquidation_log.ml
+++ b/trading/trading/backtest/lib/force_liquidation_log.ml
@@ -1,0 +1,32 @@
+(** Per-run collector of force-liquidation events. See
+    [force_liquidation_log.mli]. *)
+
+open Core
+open Portfolio_risk
+
+type t = { mutable rev_events : Force_liquidation.event list }
+
+let create () = { rev_events = [] }
+let record t event = t.rev_events <- event :: t.rev_events
+
+let _compare_event (a : Force_liquidation.event) (b : Force_liquidation.event) =
+  match Date.compare a.date b.date with
+  | 0 -> String.compare a.position_id b.position_id
+  | n -> n
+
+let events t = List.rev t.rev_events |> List.sort ~compare:_compare_event
+let count t = List.length t.rev_events
+
+type artefact = { events : Force_liquidation.event list } [@@deriving sexp]
+
+let save_sexp ~path t =
+  match events t with
+  | [] -> ()
+  | evs ->
+      let blob : artefact = { events = evs } in
+      Sexp.save_hum path (sexp_of_artefact blob)
+
+let load_sexp path =
+  let sexp = Sexp.load_sexp path in
+  let blob = artefact_of_sexp sexp in
+  blob.events

--- a/trading/trading/backtest/lib/force_liquidation_log.mli
+++ b/trading/trading/backtest/lib/force_liquidation_log.mli
@@ -1,0 +1,47 @@
+(** Per-run collector of force-liquidation events.
+
+    Mirrors the shape of {!Stop_log} / {!Trade_audit}: the strategy emits
+    {!Weinstein_strategy.Audit_recorder.force_liquidation_event}s; the backtest
+    runner threads them into a collector here, then drains the collector at
+    end-of-run for persistence as [force_liquidations.sexp] and post-processing
+    of [trades.csv]'s [exit_trigger] column.
+
+    Closes G4 from [dev/notes/short-side-gaps-2026-04-29.md]. Each event is
+    evidence the strategy's primary stop machinery failed to protect the trade —
+    non-zero counts on a release run flag a regression in stops or sizing.
+
+    See {!Force_liquidation_log.t} for the collector type, [create] / [record]
+    for the API, and [save_sexp] for the on-disk shape. *)
+
+open Portfolio_risk
+
+type t
+(** Mutable collector of force-liquidation events. Not thread-safe. One per
+    backtest run. *)
+
+val create : unit -> t
+(** Empty collector. *)
+
+val record : t -> Force_liquidation.event -> unit
+(** Append one event. *)
+
+val events : t -> Force_liquidation.event list
+(** All recorded events, sorted by [(date, position_id)] ascending. *)
+
+val count : t -> int
+(** Number of recorded events. Equivalent to [List.length (events t)]. *)
+
+(** {1 Sexp persistence} *)
+
+type artefact = { events : Force_liquidation.event list } [@@deriving sexp]
+(** On-disk envelope for [force_liquidations.sexp]. Wrapping a record (rather
+    than a bare list) keeps the file forward-compatible with future fields (e.g.
+    config snapshot, peak history). *)
+
+val save_sexp : path:string -> t -> unit
+(** Save [events t] to [path] as [force_liquidations.sexp]. No-op when the
+    collector is empty — empty list scenarios produce no file. *)
+
+val load_sexp : string -> Force_liquidation.event list
+(** Inverse of {!save_sexp}. Raises if the file does not exist or fails to
+    parse. *)

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -197,7 +197,10 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     (List.length _default_specs);
   let stop_log = Stop_log.create () in
   let trade_audit = Trade_audit.create () in
-  let audit_recorder = Trade_audit_recorder.of_collector trade_audit in
+  let force_liquidation_log = Force_liquidation_log.create () in
+  let audit_recorder =
+    Trade_audit_recorder.of_collector ~trade_audit ~force_liquidation_log
+  in
   let n_all_symbols = List.length input.all_symbols in
   let sim =
     _make_simulator input ~stop_log ~audit_recorder ~start_date ~end_date
@@ -208,4 +211,4 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     Trace.record ?trace ~symbols_in:n_all_symbols Trace.Phase.Fill (fun () ->
         _run_simulator_with_gc_trace ?gc_trace sim)
   in
-  (sim_result, stop_log, trade_audit)
+  (sim_result, stop_log, trade_audit, force_liquidation_log)

--- a/trading/trading/backtest/lib/panel_runner.mli
+++ b/trading/trading/backtest/lib/panel_runner.mli
@@ -46,6 +46,7 @@ val run :
   Trading_simulation_types.Simulator_types.run_result
   * Stop_log.t
   * Trade_audit.t
+  * Force_liquidation_log.t
 (** Same shape as the Legacy path's per-strategy entry point. The Panel branch
     in [Runner] uses this; callers should not call this directly outside of
     tests.

--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -57,6 +57,26 @@ let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
   | Underperforming _ -> "underperforming"
   | Portfolio_rebalancing -> "rebalancing"
 
+(** Build a (symbol, exit_date) -> reason map from force-liquidation events.
+    [trades.csv] rows are post-processed: when a row's (symbol, exit_date)
+    matches a recorded force-liquidation, the [exit_trigger] column is
+    overridden from the generic stop-loss label to the force-liquidation label.
+    The pair (symbol, exit_date) is unique enough in practice — a single
+    position cannot be force-closed twice and the same symbol can only re-enter
+    on a different date. *)
+let _build_force_liq_index
+    (events : Portfolio_risk.Force_liquidation.event list) =
+  List.fold events
+    ~init:(Map.empty (module String))
+    ~f:(fun acc (e : Portfolio_risk.Force_liquidation.event) ->
+      let key = e.symbol ^ "|" ^ Date.to_string e.date in
+      Map.set acc ~key ~data:e.reason)
+
+let _force_liq_label (reason : Portfolio_risk.Force_liquidation.reason) =
+  match reason with
+  | Per_position -> "force_liquidation_position"
+  | Portfolio_floor -> "force_liquidation_portfolio"
+
 let _pop_stop_info stop_index ~symbol =
   match Map.find !stop_index symbol with
   | Some (info :: rest) ->
@@ -81,9 +101,15 @@ let _side_label = function
   | Trading_base.Types.Buy -> "LONG"
   | Trading_base.Types.Sell -> "SHORT"
 
-let _write_trade_row oc stop_index (t : Metrics.trade_metrics) =
+let _write_trade_row oc stop_index force_liq_index (t : Metrics.trade_metrics) =
   let info = _pop_stop_info stop_index ~symbol:t.symbol in
-  let entry_stop, exit_stop, exit_trigger = _stop_fields info in
+  let entry_stop, exit_stop, base_exit_trigger = _stop_fields info in
+  let force_liq_key = t.symbol ^ "|" ^ Date.to_string t.exit_date in
+  let exit_trigger =
+    match Map.find force_liq_index force_liq_key with
+    | Some reason -> _force_liq_label reason
+    | None -> base_exit_trigger
+  in
   fprintf oc "%s,%s,%s,%s,%d,%.2f,%.2f,%.0f,%.2f,%.2f,%s,%s,%s\n" t.symbol
     (_side_label t.side)
     (Date.to_string t.entry_date)
@@ -92,7 +118,8 @@ let _write_trade_row oc stop_index (t : Metrics.trade_metrics) =
     t.pnl_percent entry_stop exit_stop exit_trigger
 
 let _write_trades ~output_dir ~(round_trips : Metrics.trade_metrics list)
-    ~(stop_infos : Stop_log.stop_info list) =
+    ~(stop_infos : Stop_log.stop_info list)
+    ~(force_liquidations : Portfolio_risk.Force_liquidation.event list) =
   let path = output_dir ^ "/trades.csv" in
   let oc = Out_channel.create path in
   let header =
@@ -101,7 +128,8 @@ let _write_trades ~output_dir ~(round_trips : Metrics.trade_metrics list)
   in
   fprintf oc "%s\n" header;
   let stop_index = ref (_build_stop_index stop_infos) in
-  List.iter round_trips ~f:(_write_trade_row oc stop_index);
+  let force_liq_index = _build_force_liq_index force_liquidations in
+  List.iter round_trips ~f:(_write_trade_row oc stop_index force_liq_index);
   Out_channel.close oc
 
 let _write_equity_curve ~output_dir
@@ -134,14 +162,30 @@ let _write_trade_audit ~output_dir ~(audit : Trade_audit.audit_record list)
         (output_dir ^ "/trade_audit.sexp")
         (Trade_audit.sexp_of_audit_blob blob)
 
+(** Persist [result.force_liquidations] as [force_liquidations.sexp] when
+    non-empty. Empty list (the common case — the policy did not fire) produces
+    no file rather than an empty-record sexp; downstream consumers tolerate the
+    file's absence. *)
+let _write_force_liquidations ~output_dir
+    ~(force_liquidations : Portfolio_risk.Force_liquidation.event list) =
+  match force_liquidations with
+  | [] -> ()
+  | evs ->
+      let blob : Force_liquidation_log.artefact = { events = evs } in
+      Sexp.save_hum
+        (output_dir ^ "/force_liquidations.sexp")
+        (Force_liquidation_log.sexp_of_artefact blob)
+
 let write ~output_dir (result : Runner.result) =
   _write_params ~output_dir result;
   Sexp.save_hum
     (output_dir ^ "/summary.sexp")
     (Summary.sexp_of_t result.summary);
   _write_trades ~output_dir ~round_trips:result.round_trips
-    ~stop_infos:result.stop_infos;
+    ~stop_infos:result.stop_infos ~force_liquidations:result.force_liquidations;
   _write_equity_curve ~output_dir ~steps:result.steps;
   _write_trade_audit ~output_dir ~audit:result.audit
     ~cascade_summaries:result.cascade_summaries;
+  _write_force_liquidations ~output_dir
+    ~force_liquidations:result.force_liquidations;
   Macro_trend_writer.write ~output_dir result.cascade_summaries

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -26,6 +26,7 @@ type result = {
   stop_infos : Stop_log.stop_info list;
   audit : Trade_audit.audit_record list;
   cascade_summaries : Trade_audit.cascade_summary list;
+  force_liquidations : Portfolio_risk.Force_liquidation.event list;
 }
 
 (* Trading-day filter *)
@@ -260,7 +261,7 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     (Date.to_string start_date)
     (Date.to_string end_date)
     (Date.to_string warmup_start);
-  let sim_result, stop_log, trade_audit =
+  let sim_result, stop_log, trade_audit, force_liquidation_log =
     _run_panel_backtest ~deps ~start_date ~end_date ?trace ?gc_trace ()
   in
   Gc_trace.record ?trace:gc_trace ~phase:"fill_done" ();
@@ -281,12 +282,13 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
      consumers use the series. *)
   let steps = List.filter steps_in_range ~f:is_trading_day in
   let final_value = (List.last_exn steps).portfolio_value in
-  let round_trips, stop_infos, audit, cascade_summaries =
+  let round_trips, stop_infos, audit, cascade_summaries, force_liquidations =
     Trace.record ?trace Trace.Phase.Teardown (fun () ->
         ( Metrics.extract_round_trips steps_in_range,
           Stop_log.get_stop_infos stop_log,
           Trade_audit.get_audit_records trade_audit,
-          Trade_audit.get_cascade_summaries trade_audit ))
+          Trade_audit.get_cascade_summaries trade_audit,
+          Force_liquidation_log.events force_liquidation_log ))
   in
   Gc_trace.record ?trace:gc_trace ~phase:"teardown_done" ();
   let summary =
@@ -301,4 +303,5 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     stop_infos;
     audit;
     cascade_summaries;
+    force_liquidations;
   }

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -34,6 +34,13 @@ type result = {
           field records the per-cascade-phase activity for every Friday,
           including those where the cascade filtered everything. Persisted
           alongside [audit] in [trade_audit.sexp] when either is non-empty. *)
+  force_liquidations : Portfolio_risk.Force_liquidation.event list;
+      (** Per-position force-liquidation events recorded by the strategy (G4 —
+          see [dev/notes/short-side-gaps-2026-04-29.md]). Empty when no forced
+          close fired during the run. When non-empty, [Result_writer.write]
+          persists it as [force_liquidations.sexp]. Each event is evidence the
+          primary stop machinery failed to protect a trade — non-zero counts on
+          a release run flag a regression. *)
 }
 
 val is_trading_day :

--- a/trading/trading/backtest/lib/trade_audit_recorder.ml
+++ b/trading/trading/backtest/lib/trade_audit_recorder.ml
@@ -119,16 +119,19 @@ let _cascade_summary_of_event (e : AR.cascade_event) :
     entered = e.entered;
   }
 
-let of_collector (collector : Trade_audit.t) : AR.t =
+let of_collector ~(trade_audit : Trade_audit.t)
+    ~(force_liquidation_log : Force_liquidation_log.t) : AR.t =
   {
     record_entry =
       (fun event ->
-        Trade_audit.record_entry collector (_entry_decision_of_event event));
+        Trade_audit.record_entry trade_audit (_entry_decision_of_event event));
     record_exit =
       (fun event ->
-        Trade_audit.record_exit collector (_exit_decision_of_event event));
+        Trade_audit.record_exit trade_audit (_exit_decision_of_event event));
     record_cascade_summary =
       (fun event ->
-        Trade_audit.record_cascade_summary collector
+        Trade_audit.record_cascade_summary trade_audit
           (_cascade_summary_of_event event));
+    record_force_liquidation =
+      Force_liquidation_log.record force_liquidation_log;
   }

--- a/trading/trading/backtest/lib/trade_audit_recorder.mli
+++ b/trading/trading/backtest/lib/trade_audit_recorder.mli
@@ -7,8 +7,15 @@
     it builds {!Trade_audit.entry_decision} / [exit_decision] records from the
     events and accumulates them into the collector. *)
 
-val of_collector : Trade_audit.t -> Weinstein_strategy.Audit_recorder.t
-(** [of_collector collector] returns a recorder bundle whose [record_entry] and
-    [record_exit] callbacks construct the corresponding {!Trade_audit} records
-    from the strategy's events and route them into [collector] via
-    {!Trade_audit.record_entry} / [record_exit]. *)
+val of_collector :
+  trade_audit:Trade_audit.t ->
+  force_liquidation_log:Force_liquidation_log.t ->
+  Weinstein_strategy.Audit_recorder.t
+(** [of_collector ~trade_audit ~force_liquidation_log] returns a recorder bundle
+    whose:
+    - [record_entry] / [record_exit] / [record_cascade_summary] callbacks
+      construct the corresponding {!Trade_audit} records from the strategy's
+      events and route them into [trade_audit].
+    - [record_force_liquidation] callback appends the event to
+      [force_liquidation_log] verbatim — the event already carries every
+      audit-relevant field. *)

--- a/trading/trading/backtest/release_report/release_report.ml
+++ b/trading/trading/backtest/release_report/release_report.ml
@@ -8,6 +8,7 @@ type actual = {
   max_drawdown_pct : float;
   avg_holding_days : float;
   unrealized_pnl : float option; [@sexp.option]
+  force_liquidations_count : int; [@sexp.default 0]
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]
 
@@ -260,6 +261,9 @@ let _row_trading_metrics (cur, prior) =
       (_fmt_delta_pct
          (_delta_pct ~current:(get cur.actual) ~prior:(get prior.actual)))
   in
+  let force_liq_flag a =
+    if a.force_liquidations_count > 0 then " :rotating_light:" else ""
+  in
   [
     sprintf "### %s" cur.name;
     "";
@@ -276,6 +280,17 @@ let _row_trading_metrics (cur, prior) =
     row "Max DD %" _fmt_float_2 (fun a -> a.max_drawdown_pct);
     row "Trades" _fmt_float_1 (fun a -> a.total_trades);
     row "Avg hold (d)" _fmt_float_2 (fun a -> a.avg_holding_days);
+    (* G4 force-liquidation count. Non-zero on either side flags a primary
+       stop-machinery regression (red light glyph). *)
+    sprintf "| Force-liq count | %d%s | %d%s | %s |"
+      cur.actual.force_liquidations_count
+      (force_liq_flag cur.actual)
+      prior.actual.force_liquidations_count
+      (force_liq_flag prior.actual)
+      (_fmt_delta_pct
+         (_delta_pct
+            ~current:(Float.of_int cur.actual.force_liquidations_count)
+            ~prior:(Float.of_int prior.actual.force_liquidations_count)));
     "";
   ]
 

--- a/trading/trading/backtest/release_report/release_report.mli
+++ b/trading/trading/backtest/release_report/release_report.mli
@@ -40,12 +40,14 @@ type actual = {
   max_drawdown_pct : float;
   avg_holding_days : float;
   unrealized_pnl : float option;
+  force_liquidations_count : int;
 }
 [@@deriving sexp]
 (** Trading metrics extracted from a scenario's [actual.sexp]. Mirrors the
     fields written by [scenario_runner.ml]'s [_actual_of_result], with
     [unrealized_pnl] optional for backward-compat with pre-#393 actuals that
-    omit the field. *)
+    omit the field, and [force_liquidations_count] defaulting to [0] for
+    backward-compat with pre-G4 actuals that omit the field. *)
 
 type summary_meta = {
   start_date : Date.t;

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -50,6 +50,9 @@ type actual = {
   max_drawdown_pct : float;
   avg_holding_days : float;
   unrealized_pnl : float;
+  force_liquidations_count : int; [@sexp.default 0]
+      (* G4 (force-liquidation policy). Defaults to 0 on read so pre-G4
+         actual.sexp files that don't carry the field still parse. *)
 }
 [@@deriving sexp]
 
@@ -66,6 +69,7 @@ let _actual_of_result (r : Backtest.Runner.result) =
     max_drawdown_pct = get MaxDrawdown;
     avg_holding_days = get AvgHoldingDays;
     unrealized_pnl = get UnrealizedPnl;
+    force_liquidations_count = List.length r.force_liquidations;
   }
 
 (* Range checking *)

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -7,6 +7,7 @@
   test_trade_audit_capture
   test_trade_audit_report
   test_trade_audit_ratings
+  test_result_writer
   test_runner_hypothesis_overrides
   test_panel_loader_parity
   test_backtest_runner_args
@@ -37,6 +38,7 @@
   trading.simulation.types
   trading.strategy
   weinstein_trading.strategy
+  weinstein_trading.portfolio_risk
   weinstein.screener
   status
   matchers)

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -9,8 +9,8 @@ open Matchers
 
 let _make_actual ?(total_return_pct = 12.0) ?(total_trades = 39.0)
     ?(win_rate = 50.0) ?(sharpe_ratio = 0.58) ?(max_drawdown_pct = 13.77)
-    ?(avg_holding_days = 6.07) ?(unrealized_pnl = None) () :
-    Release_report.actual =
+    ?(avg_holding_days = 6.07) ?(unrealized_pnl = None)
+    ?(force_liquidations_count = 0) () : Release_report.actual =
   {
     total_return_pct;
     total_trades;
@@ -19,6 +19,7 @@ let _make_actual ?(total_return_pct = 12.0) ?(total_trades = 39.0)
     max_drawdown_pct;
     avg_holding_days;
     unrealized_pnl;
+    force_liquidations_count;
   }
 
 let _make_summary ?(start_date = Date.of_string "2023-01-02")
@@ -139,6 +140,7 @@ let test_render_trading_section_pinned _ =
         "| Max DD % | 14.00 | 15.00 | -6.7% |";
         "| Trades | 40.0 | 35.0 | +14.3% |";
         "| Avg hold (d) | 6.50 | 7.00 | -7.1% |";
+        "| Force-liq count | 0 | 0 | n/a |";
         "";
         "## Peak RSS (kB)";
         "";
@@ -251,6 +253,36 @@ let test_render_custom_threshold_suppresses_flag _ =
     (equal_to false);
   assert_that
     (String.is_substring md ~substring:"Regression flag: \xce\x94% > 50%")
+    (equal_to true)
+
+(* --- Render: force-liquidation count flagged when non-zero --- *)
+
+let test_render_flags_force_liquidations _ =
+  (* Non-zero force-liq counts on either side surface the rotating-light
+     glyph — this is the G4 risk-machinery red flag. *)
+  let cur =
+    _make_run ~name:"sp500-2019"
+      ~actual:(_make_actual ~force_liquidations_count:5 ())
+      ()
+  in
+  let prior =
+    _make_run ~name:"sp500-2019"
+      ~actual:(_make_actual ~force_liquidations_count:0 ())
+      ()
+  in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that
+    (String.is_substring md
+       ~substring:"| Force-liq count | 5 :rotating_light: | 0 |")
     (equal_to true)
 
 (* --- Render: empty pairing --- *)
@@ -964,6 +996,8 @@ let suite =
   >::: [
          "default_thresholds match plan" >:: test_default_thresholds_match_plan;
          "render trading section pinned" >:: test_render_trading_section_pinned;
+         "render flags force liquidations"
+         >:: test_render_flags_force_liquidations;
          "render flags rss regression" >:: test_render_flags_rss_regression;
          "render no flag within threshold"
          >:: test_render_no_flag_within_threshold;

--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -1,0 +1,225 @@
+(** End-to-end pinning of {!Backtest.Result_writer.write}'s [trades.csv]
+    [exit_trigger] override (PR #695, qc-behavioral B2).
+
+    The backtest layer produces [trades.csv] rows whose [exit_trigger] column is
+    the standard {!Backtest.Stop_log.exit_trigger} label by default
+    (["stop_loss"], ["take_profit"], etc.) but overridden to
+    ["force_liquidation_position"] / ["force_liquidation_portfolio"] when the
+    same [(symbol, exit_date)] tuple appears in [result.force_liquidations]. The
+    literal label strings live only in [result_writer.ml] and were previously
+    not asserted by any test — these tests pin them end-to-end so a refactor
+    that drifts the strings or breaks the substitution rule fails
+    deterministically. *)
+
+open Core
+open OUnit2
+open Matchers
+module FL = Portfolio_risk.Force_liquidation
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let _date = Date.of_string
+
+let _make_trade ?(symbol = "AAPL") ?(side = Trading_base.Types.Buy)
+    ?(entry_date = _date "2024-01-02") ?(exit_date = _date "2024-04-29")
+    ?(entry_price = 100.0) ?(exit_price = 40.0) ?(quantity = 100.0) () :
+    Trading_simulation.Metrics.trade_metrics =
+  let days_held = Date.diff exit_date entry_date in
+  {
+    symbol;
+    side;
+    entry_date;
+    exit_date;
+    days_held;
+    entry_price;
+    exit_price;
+    quantity;
+    pnl_dollars = (exit_price -. entry_price) *. quantity;
+    pnl_percent = (exit_price -. entry_price) /. entry_price *. 100.0;
+  }
+
+(** Build a force-liquidation event matching a trade by [(symbol, exit_date)].
+    The runner-side path always feeds [event.date = exit_date] for the close leg
+    of the round-trip, so the [(symbol, date)] join key in
+    [_build_force_liq_index] hits this row. *)
+let _make_event ~symbol ~exit_date ~reason : FL.event =
+  {
+    symbol;
+    position_id = symbol ^ "-1";
+    date = exit_date;
+    side = Trading_base.Types.Long;
+    entry_price = 100.0;
+    current_price = 40.0;
+    quantity = 100.0;
+    cost_basis = 10_000.0;
+    unrealized_pnl = -6_000.0;
+    unrealized_pnl_pct = -0.6;
+    reason;
+  }
+
+let _empty_summary ~start_date ~end_date : Backtest.Summary.t =
+  {
+    start_date;
+    end_date;
+    universe_size = 1;
+    n_steps = 1;
+    initial_cash = 100_000.0;
+    final_portfolio_value = 100_000.0;
+    n_round_trips = 1;
+    metrics = Trading_simulation_types.Metric_types.empty;
+  }
+
+let _make_result ~round_trips ~force_liquidations : Backtest.Runner.result =
+  let start_date = _date "2024-01-02" in
+  let end_date = _date "2024-04-29" in
+  {
+    summary = _empty_summary ~start_date ~end_date;
+    round_trips;
+    steps = [];
+    overrides = [];
+    stop_infos = [];
+    audit = [];
+    cascade_summaries = [];
+    force_liquidations;
+  }
+
+(** Read [trades.csv] back into [(header, rows)] where [rows] are split on the
+    first comma so callers can index into specific columns by header position
+    without re-parsing CSV. *)
+let _read_trades_csv ~output_dir =
+  let path = output_dir ^ "/trades.csv" in
+  match In_channel.read_lines path with
+  | header :: rows ->
+      let header_cols = String.split header ~on:',' in
+      let rows_cols = List.map rows ~f:(fun r -> String.split r ~on:',') in
+      (header_cols, rows_cols)
+  | [] -> assert_failure ("trades.csv missing or empty: " ^ path)
+
+(** Index of the [exit_trigger] column. Hard-pinning the column position here
+    would mask drift; we look it up from the header instead. *)
+let _exit_trigger_idx header =
+  match
+    List.findi header ~f:(fun _ name -> String.equal name "exit_trigger")
+  with
+  | Some (i, _) -> i
+  | None -> assert_failure "exit_trigger column not present in trades.csv"
+
+(* ------------------------------------------------------------------ *)
+(* B2.1 — Per_position event labels exit_trigger                       *)
+(* ------------------------------------------------------------------ *)
+
+let test_per_position_force_liq_overrides_exit_trigger _ =
+  let dir = Core_unix.mkdtemp "/tmp/result_writer_per_pos_" in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" dir) in
+      ())
+    (fun () ->
+      let exit_date = _date "2024-04-29" in
+      let trade = _make_trade ~symbol:"AAPL" ~exit_date () in
+      let event =
+        _make_event ~symbol:"AAPL" ~exit_date ~reason:FL.Per_position
+      in
+      let result =
+        _make_result ~round_trips:[ trade ] ~force_liquidations:[ event ]
+      in
+      Backtest.Result_writer.write ~output_dir:dir result;
+      let header, rows = _read_trades_csv ~output_dir:dir in
+      let idx = _exit_trigger_idx header in
+      assert_that rows
+        (elements_are
+           [
+             field
+               (fun cols -> List.nth_exn cols idx)
+               (equal_to "force_liquidation_position");
+           ]))
+
+(* ------------------------------------------------------------------ *)
+(* B2.2 — Portfolio_floor event labels exit_trigger                    *)
+(* ------------------------------------------------------------------ *)
+
+let test_portfolio_floor_force_liq_overrides_exit_trigger _ =
+  let dir = Core_unix.mkdtemp "/tmp/result_writer_floor_" in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" dir) in
+      ())
+    (fun () ->
+      let exit_date = _date "2024-04-29" in
+      let trade = _make_trade ~symbol:"TSLA" ~exit_date () in
+      let event =
+        _make_event ~symbol:"TSLA" ~exit_date ~reason:FL.Portfolio_floor
+      in
+      let result =
+        _make_result ~round_trips:[ trade ] ~force_liquidations:[ event ]
+      in
+      Backtest.Result_writer.write ~output_dir:dir result;
+      let header, rows = _read_trades_csv ~output_dir:dir in
+      let idx = _exit_trigger_idx header in
+      assert_that rows
+        (elements_are
+           [
+             field
+               (fun cols -> List.nth_exn cols idx)
+               (equal_to "force_liquidation_portfolio");
+           ]))
+
+(* ------------------------------------------------------------------ *)
+(* B2.3 — Non-matching event does NOT override exit_trigger            *)
+(* ------------------------------------------------------------------ *)
+
+(** The override is keyed on [(symbol, exit_date)]. A force-liquidation event
+    with a non-matching symbol or date must NOT override the row — pin the join
+    precision so a refactor that broadens the key doesn't silently relabel
+    unrelated trades. *)
+let test_non_matching_event_does_not_override _ =
+  let dir = Core_unix.mkdtemp "/tmp/result_writer_no_match_" in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" dir) in
+      ())
+    (fun () ->
+      let trade =
+        _make_trade ~symbol:"AAPL" ~exit_date:(_date "2024-04-29") ()
+      in
+      (* Same symbol, different exit_date — no join hit. *)
+      let event =
+        _make_event ~symbol:"AAPL" ~exit_date:(_date "2024-05-15")
+          ~reason:FL.Per_position
+      in
+      let result =
+        _make_result ~round_trips:[ trade ] ~force_liquidations:[ event ]
+      in
+      Backtest.Result_writer.write ~output_dir:dir result;
+      let header, rows = _read_trades_csv ~output_dir:dir in
+      let idx = _exit_trigger_idx header in
+      (* No matching event + no stop_info → blank exit_trigger. The point
+         is just that it is NOT one of the force-liquidation labels. *)
+      assert_that rows
+        (elements_are
+           [
+             field
+               (fun cols ->
+                 String.is_prefix (List.nth_exn cols idx)
+                   ~prefix:"force_liquidation")
+               (equal_to false);
+           ]))
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "result_writer"
+  >::: [
+         "per_position force-liq overrides exit_trigger"
+         >:: test_per_position_force_liq_overrides_exit_trigger;
+         "portfolio_floor force-liq overrides exit_trigger"
+         >:: test_portfolio_floor_force_liq_overrides_exit_trigger;
+         "non-matching event does not override exit_trigger"
+         >:: test_non_matching_event_does_not_override;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_trade_audit_report.ml
+++ b/trading/trading/backtest/test/test_trade_audit_report.ml
@@ -659,6 +659,7 @@ let _make_runner_result ~start_date ~end_date ~round_trips :
     stop_infos = [];
     audit = [];
     cascade_summaries = [];
+    force_liquidations = [];
   }
 
 let test_writer_reader_post_g2_round_trip _ =

--- a/trading/trading/weinstein/portfolio_risk/lib/dune
+++ b/trading/trading/weinstein/portfolio_risk/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name portfolio_risk)
  (public_name weinstein_trading.portfolio_risk)
- (libraries core weinstein.types trading.portfolio status)
+ (libraries core weinstein.types trading.base trading.portfolio status)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.ml
+++ b/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.ml
@@ -1,0 +1,228 @@
+(** Force-liquidation policy. See [force_liquidation.mli] for the contract. *)
+
+open Core
+
+type config = {
+  max_unrealized_loss_fraction : float;
+  min_portfolio_value_fraction_of_peak : float;
+}
+[@@deriving show, eq, sexp]
+
+let default_config =
+  {
+    max_unrealized_loss_fraction = 0.5;
+    min_portfolio_value_fraction_of_peak = 0.4;
+  }
+
+type reason = Per_position | Portfolio_floor [@@deriving show, eq, sexp]
+
+(* The position_side type from [Trading_base] doesn't derive [sexp] in this
+   project; re-expose it locally as a sexpable variant for the [event] /
+   [position_input] types. *)
+type _side = Long | Short [@@deriving show, eq, sexp]
+
+let _of_side : Trading_base.Types.position_side -> _side = function
+  | Trading_base.Types.Long -> Long
+  | Trading_base.Types.Short -> Short
+
+let _to_side : _side -> Trading_base.Types.position_side = function
+  | Long -> Trading_base.Types.Long
+  | Short -> Trading_base.Types.Short
+
+type _event_serial = {
+  symbol : string;
+  position_id : string;
+  date : Date.t;
+  side : _side;
+  entry_price : float;
+  current_price : float;
+  quantity : float;
+  cost_basis : float;
+  unrealized_pnl : float;
+  unrealized_pnl_pct : float;
+  reason : reason;
+}
+[@@deriving show, eq, sexp]
+
+type event = {
+  symbol : string;
+  position_id : string;
+  date : Date.t;
+  side : Trading_base.Types.position_side;
+  entry_price : float;
+  current_price : float;
+  quantity : float;
+  cost_basis : float;
+  unrealized_pnl : float;
+  unrealized_pnl_pct : float;
+  reason : reason;
+}
+
+let _to_serial (e : event) : _event_serial =
+  {
+    symbol = e.symbol;
+    position_id = e.position_id;
+    date = e.date;
+    side = _of_side e.side;
+    entry_price = e.entry_price;
+    current_price = e.current_price;
+    quantity = e.quantity;
+    cost_basis = e.cost_basis;
+    unrealized_pnl = e.unrealized_pnl;
+    unrealized_pnl_pct = e.unrealized_pnl_pct;
+    reason = e.reason;
+  }
+
+let _of_serial (s : _event_serial) : event =
+  {
+    symbol = s.symbol;
+    position_id = s.position_id;
+    date = s.date;
+    side = _to_side s.side;
+    entry_price = s.entry_price;
+    current_price = s.current_price;
+    quantity = s.quantity;
+    cost_basis = s.cost_basis;
+    unrealized_pnl = s.unrealized_pnl;
+    unrealized_pnl_pct = s.unrealized_pnl_pct;
+    reason = s.reason;
+  }
+
+let sexp_of_event e = sexp_of__event_serial (_to_serial e)
+let event_of_sexp s = _of_serial (_event_serial_of_sexp s)
+let pp_event fmt e = pp__event_serial fmt (_to_serial e)
+let show_event e = show__event_serial (_to_serial e)
+let equal_event a b = equal__event_serial (_to_serial a) (_to_serial b)
+
+(* ---- Per-position math ---- *)
+
+let unrealized_pnl ~(side : Trading_base.Types.position_side) ~entry_price
+    ~current_price ~quantity =
+  match side with
+  | Trading_base.Types.Long -> (current_price -. entry_price) *. quantity
+  | Trading_base.Types.Short -> (entry_price -. current_price) *. quantity
+
+(* ---- Peak tracker ---- *)
+
+type halt_state = Active | Halted [@@deriving show, eq, sexp]
+
+module Peak_tracker = struct
+  type t = { mutable peak : float; mutable halt : halt_state }
+
+  let create () = { peak = 0.0; halt = Active }
+  let peak t = t.peak
+  let halt_state t = t.halt
+
+  let observe t ~portfolio_value =
+    if Float.( > ) portfolio_value t.peak then t.peak <- portfolio_value
+
+  let mark_halted t = t.halt <- Halted
+  let reset t = t.halt <- Active
+end
+
+(* ---- Position_input ---- *)
+
+type _position_input_serial = {
+  symbol : string;
+  position_id : string;
+  side : _side;
+  entry_price : float;
+  current_price : float;
+  quantity : float;
+}
+[@@deriving show, eq, sexp]
+
+type position_input = {
+  symbol : string;
+  position_id : string;
+  side : Trading_base.Types.position_side;
+  entry_price : float;
+  current_price : float;
+  quantity : float;
+}
+
+let _pi_to_serial (p : position_input) : _position_input_serial =
+  {
+    symbol = p.symbol;
+    position_id = p.position_id;
+    side = _of_side p.side;
+    entry_price = p.entry_price;
+    current_price = p.current_price;
+    quantity = p.quantity;
+  }
+
+let _pi_of_serial (s : _position_input_serial) : position_input =
+  {
+    symbol = s.symbol;
+    position_id = s.position_id;
+    side = _to_side s.side;
+    entry_price = s.entry_price;
+    current_price = s.current_price;
+    quantity = s.quantity;
+  }
+
+let sexp_of_position_input p = sexp_of__position_input_serial (_pi_to_serial p)
+let position_input_of_sexp s = _pi_of_serial (_position_input_serial_of_sexp s)
+let pp_position_input fmt p = pp__position_input_serial fmt (_pi_to_serial p)
+let show_position_input p = show__position_input_serial (_pi_to_serial p)
+
+let equal_position_input a b =
+  equal__position_input_serial (_pi_to_serial a) (_pi_to_serial b)
+
+(* ---- Check ---- *)
+
+let _event_of_input ~date ~reason (p : position_input) : event =
+  let pnl =
+    unrealized_pnl ~side:p.side ~entry_price:p.entry_price
+      ~current_price:p.current_price ~quantity:p.quantity
+  in
+  let cost_basis = p.entry_price *. p.quantity in
+  let pnl_pct =
+    if Float.( <= ) cost_basis 0.0 then 0.0 else pnl /. cost_basis
+  in
+  {
+    symbol = p.symbol;
+    position_id = p.position_id;
+    date;
+    side = p.side;
+    entry_price = p.entry_price;
+    current_price = p.current_price;
+    quantity = p.quantity;
+    cost_basis;
+    unrealized_pnl = pnl;
+    unrealized_pnl_pct = pnl_pct;
+    reason;
+  }
+
+(* Per-position trigger: a position fires when its unrealized loss exceeds
+   [config.max_unrealized_loss_fraction] of cost basis. Cost basis must be
+   strictly positive — degenerate inputs (zero-cost basis) are not flagged. *)
+let _check_per_position ~config ~date (p : position_input) : event option =
+  let cost_basis = p.entry_price *. p.quantity in
+  if Float.( <= ) cost_basis 0.0 then None
+  else
+    let pnl =
+      unrealized_pnl ~side:p.side ~entry_price:p.entry_price
+        ~current_price:p.current_price ~quantity:p.quantity
+    in
+    let loss_fraction = -.pnl /. cost_basis in
+    if Float.( > ) loss_fraction config.max_unrealized_loss_fraction then
+      Some (_event_of_input ~date ~reason:Per_position p)
+    else None
+
+(* Portfolio-floor trigger fires when [portfolio_value < peak * fraction] AND
+   the peak has actually been observed (peak > 0). The peak-zero case happens
+   on the first observation; we never fire on bar 1. *)
+let _portfolio_floor_breached ~config ~peak ~portfolio_value =
+  Float.( > ) peak 0.0
+  && Float.( < ) portfolio_value
+       (peak *. config.min_portfolio_value_fraction_of_peak)
+
+let check ~config ~date ~positions ~portfolio_value
+    ~(peak_tracker : Peak_tracker.t) =
+  Peak_tracker.observe peak_tracker ~portfolio_value;
+  let peak = Peak_tracker.peak peak_tracker in
+  if _portfolio_floor_breached ~config ~peak ~portfolio_value then (
+    Peak_tracker.mark_halted peak_tracker;
+    List.map positions ~f:(_event_of_input ~date ~reason:Portfolio_floor))
+  else List.filter_map positions ~f:(_check_per_position ~config ~date)

--- a/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.mli
+++ b/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.mli
@@ -1,0 +1,157 @@
+(** Force-liquidation policy — defense in depth beyond stops.
+
+    Closes G4 from [dev/notes/short-side-gaps-2026-04-29.md]. When the primary
+    stop machinery fails to protect a trade and unrealized loss compounds
+    unchecked, this policy fires a forced close. The event is logged + emitted
+    as a signal — every fired event is evidence that stops did not do their job.
+
+    {1 Two trigger conditions}
+
+    - {b Per-position}: a single position's unrealized loss exceeds
+      [max_unrealized_loss_fraction] of its cost basis. Force-close that
+      position only.
+    - {b Portfolio-floor}: total portfolio value drops below
+      [min_portfolio_value_fraction_of_peak] of the highest portfolio value
+      observed since the strategy started. Force-close ALL positions and halt
+      new entries until macro flips.
+
+    {1 Design}
+
+    The [check] function is pure — given a snapshot of positions, prices, and
+    the current peak, it returns the full list of force-liquidation events to
+    emit on this tick. Peak tracking and halt state live separately in
+    [Peak_tracker] (mutable) so callers can wire the lifetime to their own
+    strategy-state closure.
+
+    Both checks fire after [Stops_runner.update] in
+    [Weinstein_strategy._on_market_close], so a position that already exited via
+    a regular stop on the same tick is not double-counted (it is no longer in
+    [Holding] state).
+
+    Strict broker-margin semantics (collateral pre-locked at short entry,
+    refunded on cover) are deliberately deferred — see
+    [dev/notes/short-side-gaps-2026-04-29.md] §G4. *)
+
+open Core
+
+(** {1 Configuration} *)
+
+type config = {
+  max_unrealized_loss_fraction : float;
+      (** Per-position trigger: force-close a position when its unrealized loss
+          exceeds this fraction of cost basis. Default [0.5] (50% of cost basis
+          lost). Set to [Float.infinity] to disable the per-position trigger. *)
+  min_portfolio_value_fraction_of_peak : float;
+      (** Portfolio-floor trigger: force-close all positions and halt new
+          entries when [portfolio_value < peak * fraction]. Default [0.4] (40%
+          of peak — i.e. 60% drawdown from peak). Set to [0.0] to disable the
+          portfolio trigger. *)
+}
+[@@deriving show, eq, sexp]
+(** All thresholds — nothing hardcoded. *)
+
+val default_config : config
+(** [{ max_unrealized_loss_fraction = 0.5; min_portfolio_value_fraction_of_peak
+     = 0.4 }]. *)
+
+(** {1 Event} *)
+
+(** Why a force-liquidation event fired. *)
+type reason =
+  | Per_position
+      (** Per-position threshold exceeded — only this position is closed. *)
+  | Portfolio_floor
+      (** Portfolio-floor threshold exceeded — all open positions are closed and
+          new entries are halted until macro flips. *)
+[@@deriving show, eq, sexp]
+
+type event = {
+  symbol : string;
+  position_id : string;
+  date : Date.t;
+  side : Trading_base.Types.position_side;
+  entry_price : float;
+  current_price : float;
+  quantity : float;  (** Position size (always positive). *)
+  cost_basis : float;  (** [entry_price * quantity]. *)
+  unrealized_pnl : float;
+      (** Signed dollar P&L. Long: [(current - entry) * quantity]. Short:
+          [(entry - current) * quantity]. *)
+  unrealized_pnl_pct : float;
+      (** [unrealized_pnl / cost_basis]. Negative for losses. *)
+  reason : reason;
+}
+[@@deriving show, eq, sexp]
+(** Single force-liquidation event. One per position closed. *)
+
+(** {1 Per-position math} *)
+
+val unrealized_pnl :
+  side:Trading_base.Types.position_side ->
+  entry_price:float ->
+  current_price:float ->
+  quantity:float ->
+  float
+(** Signed dollar P&L for a position. Long: [(current - entry) * quantity].
+    Short: [(entry - current) * quantity]. Quantity is always positive. *)
+
+(** {1 Peak tracking + halt state} *)
+
+(** Halt state. Once [Halted], force-liquidation suppresses new entries until
+    [reset] is called (typically when macro flips off Bearish). *)
+type halt_state = Active | Halted [@@deriving show, eq, sexp]
+
+(** Mutable peak-portfolio-value tracker. Maintains [peak] monotonically:
+    [observe] only raises it. The [halt_state] flips to [Halted] when a
+    portfolio-floor event fires; callers must call [reset] to resume entries. *)
+module Peak_tracker : sig
+  type t
+
+  val create : unit -> t
+  (** Empty tracker — peak starts at [0.0], halt_state at [Active]. *)
+
+  val peak : t -> float
+  val halt_state : t -> halt_state
+
+  val observe : t -> portfolio_value:float -> unit
+  (** Raise the tracked peak to [max peak portfolio_value]. *)
+
+  val mark_halted : t -> unit
+  (** Flip [halt_state] to [Halted]. Idempotent. *)
+
+  val reset : t -> unit
+  (** Flip [halt_state] back to [Active]. Idempotent. Peak is preserved. *)
+end
+
+(** {1 Check} *)
+
+type position_input = {
+  symbol : string;
+  position_id : string;
+  side : Trading_base.Types.position_side;
+  entry_price : float;
+  current_price : float;
+  quantity : float;
+}
+[@@deriving show, eq, sexp]
+(** Per-position input for [check]. Quantity is always positive; [side]
+    distinguishes long vs short. *)
+
+val check :
+  config:config ->
+  date:Date.t ->
+  positions:position_input list ->
+  portfolio_value:float ->
+  peak_tracker:Peak_tracker.t ->
+  event list
+(** Run both triggers and return the full list of force-liquidation events to
+    emit this tick.
+
+    Side effects: [peak_tracker] is updated to the new peak; [halt_state] is
+    flipped to [Halted] when a portfolio-floor trigger fires.
+
+    {b Order of precedence}: the portfolio-floor check runs first. When it
+    fires, every position in [positions] yields a [Portfolio_floor] event and no
+    per-position events are emitted on this tick (avoid double-counting).
+    Otherwise, each position is checked independently against the per-position
+    threshold. *)

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
@@ -1,4 +1,5 @@
 open Core
+module Force_liquidation = Force_liquidation
 
 type portfolio_snapshot = {
   total_value : float;
@@ -40,6 +41,8 @@ type config = {
   max_sector_concentration : int;
   max_unknown_sector_positions : int;
   big_winner_multiplier : float;
+  force_liquidation : Force_liquidation.config;
+      [@sexp.default Force_liquidation.default_config]
 }
 [@@deriving show, eq, sexp]
 
@@ -53,6 +56,7 @@ let default_config =
     max_sector_concentration = 5;
     max_unknown_sector_positions = 2;
     big_winner_multiplier = 1.5;
+    force_liquidation = Force_liquidation.default_config;
   }
 
 (* ---- Snapshot helpers ---- *)

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
@@ -20,6 +20,9 @@
     Does NOT modify the existing Portfolio module. Works alongside it by taking
     a snapshot of the portfolio state. *)
 
+module Force_liquidation = Force_liquidation
+(** Force-liquidation policy. See {!Force_liquidation}. *)
+
 (** {1 Portfolio Snapshot} *)
 
 type portfolio_snapshot = {
@@ -119,6 +122,10 @@ type config = {
           missing sector metadata from dominating the portfolio. *)
   big_winner_multiplier : float;
       (** Size multiplier for high-conviction trades (default: 1.5x) *)
+  force_liquidation : Force_liquidation.config;
+      [@sexp.default Force_liquidation.default_config]
+      (** Force-liquidation thresholds — see {!Force_liquidation}. Default: 50%
+          per-position loss, 40% portfolio-of-peak floor. *)
 }
 [@@deriving show, eq, sexp]
 (** All risk management parameters — nothing hardcoded. *)
@@ -132,7 +139,8 @@ val default_config : config
     - min_cash_pct = 0.10 (10%)
     - max_sector_concentration = 5
     - max_unknown_sector_positions = 2
-    - big_winner_multiplier = 1.5 *)
+    - big_winner_multiplier = 1.5
+    - force_liquidation = {!Force_liquidation.default_config} *)
 
 val compute_position_size :
   config:config ->

--- a/trading/trading/weinstein/portfolio_risk/test/dune
+++ b/trading/trading/weinstein/portfolio_risk/test/dune
@@ -13,6 +13,13 @@
   (pps ppx_deriving.show ppx_deriving.eq ppx_test_matcher)))
 
 (test
+ (name test_force_liquidation)
+ (modules test_force_liquidation)
+ (libraries portfolio_risk ounit2 core matchers trading.base)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq)))
+
+(test
  (name test_portfolio_risk_e2e)
  (modules test_portfolio_risk_e2e)
  (libraries

--- a/trading/trading/weinstein/portfolio_risk/test/test_force_liquidation.ml
+++ b/trading/trading/weinstein/portfolio_risk/test/test_force_liquidation.ml
@@ -1,0 +1,309 @@
+open OUnit2
+open Core
+open Portfolio_risk
+open Matchers
+module FL = Force_liquidation
+
+(* ---- Helpers ---- *)
+
+let make_long ?(symbol = "AAPL") ?(position_id = "AAPL-1")
+    ?(entry_price = 100.0) ?(current_price = 100.0) ?(quantity = 10.0) () :
+    FL.position_input =
+  {
+    symbol;
+    position_id;
+    side = Trading_base.Types.Long;
+    entry_price;
+    current_price;
+    quantity;
+  }
+
+let make_short ?(symbol = "TSLA") ?(position_id = "TSLA-1")
+    ?(entry_price = 200.0) ?(current_price = 200.0) ?(quantity = 5.0) () :
+    FL.position_input =
+  {
+    symbol;
+    position_id;
+    side = Trading_base.Types.Short;
+    entry_price;
+    current_price;
+    quantity;
+  }
+
+let date = Date.of_string "2026-04-29"
+
+(* ---- unrealized_pnl ---- *)
+
+let test_pnl_long_winner _ =
+  let pnl =
+    FL.unrealized_pnl ~side:Trading_base.Types.Long ~entry_price:100.0
+      ~current_price:120.0 ~quantity:10.0
+  in
+  assert_that pnl (float_equal 200.0)
+
+let test_pnl_long_loser _ =
+  let pnl =
+    FL.unrealized_pnl ~side:Trading_base.Types.Long ~entry_price:100.0
+      ~current_price:60.0 ~quantity:10.0
+  in
+  assert_that pnl (float_equal (-400.0))
+
+let test_pnl_short_winner _ =
+  (* short profits when price goes DOWN. Entry 200, now 180 → profit 20*5 = 100 *)
+  let pnl =
+    FL.unrealized_pnl ~side:Trading_base.Types.Short ~entry_price:200.0
+      ~current_price:180.0 ~quantity:5.0
+  in
+  assert_that pnl (float_equal 100.0)
+
+let test_pnl_short_loser _ =
+  (* short loses when price goes UP. Entry 200, now 240 → loss 40*5 = 200 *)
+  let pnl =
+    FL.unrealized_pnl ~side:Trading_base.Types.Short ~entry_price:200.0
+      ~current_price:240.0 ~quantity:5.0
+  in
+  assert_that pnl (float_equal (-200.0))
+
+(* ---- Peak_tracker ---- *)
+
+let test_peak_tracker_observe_monotone _ =
+  let pt = FL.Peak_tracker.create () in
+  FL.Peak_tracker.observe pt ~portfolio_value:100.0;
+  FL.Peak_tracker.observe pt ~portfolio_value:120.0;
+  FL.Peak_tracker.observe pt ~portfolio_value:90.0;
+  (* peak should stay at 120 even after observing a lower value *)
+  assert_that (FL.Peak_tracker.peak pt) (float_equal 120.0)
+
+let test_peak_tracker_halt_state _ =
+  let pt = FL.Peak_tracker.create () in
+  assert_that (FL.Peak_tracker.halt_state pt) (equal_to FL.Active);
+  FL.Peak_tracker.mark_halted pt;
+  assert_that (FL.Peak_tracker.halt_state pt) (equal_to FL.Halted);
+  FL.Peak_tracker.reset pt;
+  assert_that (FL.Peak_tracker.halt_state pt) (equal_to FL.Active)
+
+(* ---- Per-position trigger ---- *)
+
+let test_per_position_long_no_fire_under_threshold _ =
+  (* default 50% threshold; long at $100 → $60 = 40% loss; should NOT fire *)
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long ~entry_price:100.0 ~current_price:60.0 () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events (size_is 0)
+
+let test_per_position_long_fires_on_exceed _ =
+  (* long at $100 → $40 = 60% loss; default threshold 50%; SHOULD fire *)
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long ~entry_price:100.0 ~current_price:40.0 () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (e : FL.event) -> e.symbol) (equal_to "AAPL");
+             field (fun (e : FL.event) -> e.reason) (equal_to FL.Per_position);
+             field
+               (fun (e : FL.event) -> e.unrealized_pnl_pct)
+               (float_equal (-0.6));
+           ];
+       ])
+
+let test_per_position_short_fires_on_exceed _ =
+  (* short at $200 → $320 = 60% loss; default threshold 50%; SHOULD fire *)
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_short ~entry_price:200.0 ~current_price:320.0 () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (e : FL.event) -> e.symbol) (equal_to "TSLA");
+             field (fun (e : FL.event) -> e.reason) (equal_to FL.Per_position);
+             field
+               (fun (e : FL.event) -> e.side)
+               (equal_to Trading_base.Types.Short);
+           ];
+       ])
+
+let test_per_position_does_not_fire_on_winner _ =
+  (* long at $100 → $200 = +100% gain; never fires *)
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long ~entry_price:100.0 ~current_price:200.0 () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events (size_is 0)
+
+let test_per_position_custom_threshold _ =
+  (* tighter threshold of 20% — long at 100 → 75 = 25% loss; SHOULD fire *)
+  let pt = FL.Peak_tracker.create () in
+  let config = { FL.default_config with max_unrealized_loss_fraction = 0.2 } in
+  let positions = [ make_long ~entry_price:100.0 ~current_price:75.0 () ] in
+  let events =
+    FL.check ~config ~date ~positions ~portfolio_value:1_000_000.0
+      ~peak_tracker:pt
+  in
+  assert_that events (size_is 1)
+
+(* ---- Portfolio-floor trigger ---- *)
+
+let test_portfolio_floor_first_observation_no_fire _ =
+  (* On the first observe, peak starts at 0 and is set to portfolio_value;
+     no fire on bar 1 even at very low values — there is no prior peak. *)
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions ~portfolio_value:100.0
+      ~peak_tracker:pt
+  in
+  assert_that events (size_is 0)
+
+let test_portfolio_floor_fires_after_drawdown _ =
+  (* observe peak at 1M, drop to 350K = 65% drawdown; default 60% threshold
+     (40% of peak floor); fires. *)
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long (); make_short () ] in
+  let _events1 =
+    FL.check ~config:FL.default_config ~date ~positions:[]
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  let events2 =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:350_000.0 ~peak_tracker:pt
+  in
+  (* Both positions should be force-closed under Portfolio_floor reason *)
+  assert_that events2
+    (all_of
+       [
+         size_is 2;
+         elements_are
+           [
+             field
+               (fun (e : FL.event) -> e.reason)
+               (equal_to FL.Portfolio_floor);
+             field
+               (fun (e : FL.event) -> e.reason)
+               (equal_to FL.Portfolio_floor);
+           ];
+       ])
+
+let test_portfolio_floor_marks_halted _ =
+  let pt = FL.Peak_tracker.create () in
+  let _ =
+    FL.check ~config:FL.default_config ~date ~positions:[]
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  let _ =
+    FL.check ~config:FL.default_config ~date ~positions:[]
+      ~portfolio_value:350_000.0 ~peak_tracker:pt
+  in
+  assert_that (FL.Peak_tracker.halt_state pt) (equal_to FL.Halted)
+
+let test_portfolio_floor_no_fire_under_threshold _ =
+  (* peak at 1M, drop to 500K = 50% drawdown; default fraction 0.4 means
+     fire below 400K. 500K is above the floor — no fire. *)
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long () ] in
+  let _ =
+    FL.check ~config:FL.default_config ~date ~positions:[]
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:500_000.0 ~peak_tracker:pt
+  in
+  assert_that events (size_is 0)
+
+(* ---- Precedence: portfolio-floor wins over per-position ---- *)
+
+let test_portfolio_floor_precedence _ =
+  (* Single position with 60% loss; portfolio_value down to 30% of peak.
+     Both triggers would fire; portfolio-floor takes precedence and emits
+     the Portfolio_floor reason for every position. *)
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long ~entry_price:100.0 ~current_price:40.0 () ] in
+  let _ =
+    FL.check ~config:FL.default_config ~date ~positions:[]
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:300_000.0 ~peak_tracker:pt
+  in
+  assert_that events
+    (elements_are
+       [ field (fun (e : FL.event) -> e.reason) (equal_to FL.Portfolio_floor) ])
+
+(* ---- Default config ---- *)
+
+let test_default_config_values _ =
+  assert_that FL.default_config
+    (all_of
+       [
+         field (fun c -> c.FL.max_unrealized_loss_fraction) (float_equal 0.5);
+         field
+           (fun c -> c.FL.min_portfolio_value_fraction_of_peak)
+           (float_equal 0.4);
+       ])
+
+(* ---- Sexp round-trip ---- *)
+
+let test_event_sexp_round_trip _ =
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long ~entry_price:100.0 ~current_price:40.0 () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  match events with
+  | [ event ] ->
+      let sexp = FL.sexp_of_event event in
+      let round_tripped = FL.event_of_sexp sexp in
+      assert_that round_tripped (equal_to event)
+  | _ -> assert_failure "expected exactly one event"
+
+(* ---- Suite ---- *)
+
+let suite =
+  "force_liquidation"
+  >::: [
+         "pnl_long_winner" >:: test_pnl_long_winner;
+         "pnl_long_loser" >:: test_pnl_long_loser;
+         "pnl_short_winner" >:: test_pnl_short_winner;
+         "pnl_short_loser" >:: test_pnl_short_loser;
+         "peak_tracker_observe_monotone" >:: test_peak_tracker_observe_monotone;
+         "peak_tracker_halt_state" >:: test_peak_tracker_halt_state;
+         "per_position_long_no_fire_under_threshold"
+         >:: test_per_position_long_no_fire_under_threshold;
+         "per_position_long_fires_on_exceed"
+         >:: test_per_position_long_fires_on_exceed;
+         "per_position_short_fires_on_exceed"
+         >:: test_per_position_short_fires_on_exceed;
+         "per_position_does_not_fire_on_winner"
+         >:: test_per_position_does_not_fire_on_winner;
+         "per_position_custom_threshold" >:: test_per_position_custom_threshold;
+         "portfolio_floor_first_observation_no_fire"
+         >:: test_portfolio_floor_first_observation_no_fire;
+         "portfolio_floor_fires_after_drawdown"
+         >:: test_portfolio_floor_fires_after_drawdown;
+         "portfolio_floor_marks_halted" >:: test_portfolio_floor_marks_halted;
+         "portfolio_floor_no_fire_under_threshold"
+         >:: test_portfolio_floor_no_fire_under_threshold;
+         "portfolio_floor_precedence" >:: test_portfolio_floor_precedence;
+         "default_config_values" >:: test_default_config_values;
+         "event_sexp_round_trip" >:: test_event_sexp_round_trip;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/weinstein/portfolio_risk/test/test_force_liquidation.ml
+++ b/trading/trading/weinstein/portfolio_risk/test/test_force_liquidation.ml
@@ -246,6 +246,37 @@ let test_portfolio_floor_precedence _ =
     (elements_are
        [ field (fun (e : FL.event) -> e.reason) (equal_to FL.Portfolio_floor) ])
 
+(* ---- Defensive guards (PR #695, qc-behavioral B3) ---- *)
+
+(** Guard: [_check_per_position] short-circuits when cost basis is non-positive
+    (zero or negative). Pin the no-fire behaviour so a refactor that drops the
+    [cost_basis <= 0] guard fails deterministically. Per-position threshold
+    semantics are undefined when there's no cost basis to size the loss against
+    (would otherwise divide by zero / produce NaN). *)
+let test_zero_cost_basis_does_not_fire _ =
+  let pt = FL.Peak_tracker.create () in
+  let positions =
+    [ make_long ~entry_price:0.0 ~current_price:50.0 ~quantity:100.0 () ]
+  in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events is_empty
+
+let test_zero_quantity_does_not_fire _ =
+  (* Symmetric: cost_basis = entry_price * quantity; quantity = 0 yields 0
+     cost_basis. Pin no-fire here too. *)
+  let pt = FL.Peak_tracker.create () in
+  let positions =
+    [ make_long ~entry_price:100.0 ~current_price:40.0 ~quantity:0.0 () ]
+  in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events is_empty
+
 (* ---- Default config ---- *)
 
 let test_default_config_values _ =
@@ -302,6 +333,8 @@ let suite =
          "portfolio_floor_no_fire_under_threshold"
          >:: test_portfolio_floor_no_fire_under_threshold;
          "portfolio_floor_precedence" >:: test_portfolio_floor_precedence;
+         "zero cost basis does not fire" >:: test_zero_cost_basis_does_not_fire;
+         "zero quantity does not fire" >:: test_zero_quantity_does_not_fire;
          "default_config_values" >:: test_default_config_values;
          "event_sexp_round_trip" >:: test_event_sexp_round_trip;
        ]

--- a/trading/trading/weinstein/strategy/lib/audit_recorder.ml
+++ b/trading/trading/weinstein/strategy/lib/audit_recorder.ml
@@ -43,10 +43,13 @@ type cascade_event = {
   entered : int;
 }
 
+type force_liquidation_event = Portfolio_risk.Force_liquidation.event
+
 type t = {
   record_entry : entry_event -> unit;
   record_exit : exit_event -> unit;
   record_cascade_summary : cascade_event -> unit;
+  record_force_liquidation : force_liquidation_event -> unit;
 }
 
 let noop : t =
@@ -54,4 +57,5 @@ let noop : t =
     record_entry = (fun _ -> ());
     record_exit = (fun _ -> ());
     record_cascade_summary = (fun _ -> ());
+    record_force_liquidation = (fun _ -> ());
   }

--- a/trading/trading/weinstein/strategy/lib/audit_recorder.mli
+++ b/trading/trading/weinstein/strategy/lib/audit_recorder.mli
@@ -112,10 +112,19 @@ type cascade_event = {
     whole cascade — including phases that filter out every candidate before any
     rival comparison happens. *)
 
+type force_liquidation_event = Portfolio_risk.Force_liquidation.event
+(** Event captured every time {!Force_liquidation.check} fires for a position.
+    Mirrors [Force_liquidation.event] one-for-one; re-exposed here as part of
+    the recorder bundle so the strategy library does not depend on [Backtest.*].
+    The backtest-side recorder maps these into a [Force_liquidation_log] for
+    [force_liquidations.sexp] persistence and [trades.csv] exit-trigger
+    labelling. *)
+
 type t = {
   record_entry : entry_event -> unit;
   record_exit : exit_event -> unit;
   record_cascade_summary : cascade_event -> unit;
+  record_force_liquidation : force_liquidation_event -> unit;
 }
 (** Recorder bundle. All callbacks are invoked unconditionally by the strategy
     at entry / exit / per-Friday sites; the implementation decides whether to

--- a/trading/trading/weinstein/strategy/lib/force_liquidation_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/force_liquidation_runner.ml
@@ -1,0 +1,76 @@
+(** Force-liquidation policy applied to held positions. See
+    [force_liquidation_runner.mli]. *)
+
+open Core
+open Trading_strategy
+module FL = Portfolio_risk.Force_liquidation
+
+(** Build a [Force_liquidation.position_input] for one Holding position when a
+    current price is available. Returns [None] for non-Holding positions and for
+    symbols without a price feed this tick. *)
+let _position_input_of_holding ~get_price (pos : Position.t) :
+    FL.position_input option =
+  match pos.state with
+  | Position.Holding { quantity; entry_price; _ } -> (
+      match get_price pos.symbol with
+      | Some (bar : Types.Daily_price.t) ->
+          Some
+            {
+              symbol = pos.symbol;
+              position_id = pos.id;
+              side = pos.side;
+              entry_price;
+              current_price = bar.close_price;
+              quantity;
+            }
+      | None -> None)
+  | _ -> None
+
+(** Compute portfolio mark-to-market value the same way [Portfolio_view] does:
+    cash + sum of (quantity * close_price) over Holding positions whose symbol
+    has a price this tick. Mirrors {!Portfolio_view.portfolio_value} but takes
+    the cash separately so the strategy can pass its own cash field directly. *)
+let _portfolio_value ~cash ~positions ~get_price =
+  Map.fold positions ~init:cash ~f:(fun ~key:_ ~data:pos acc ->
+      match pos.Position.state with
+      | Position.Holding { quantity; _ } -> (
+          match get_price pos.symbol with
+          | Some (bar : Types.Daily_price.t) ->
+              acc +. (quantity *. bar.close_price)
+          | None -> acc)
+      | _ -> acc)
+
+(** Convert a force-liquidation event into a TriggerExit transition. The
+    exit_reason is [Position.StopLoss] — the existing variant the position state
+    machine + simulator already handle. The force-liquidation distinction is
+    recorded separately via the audit recorder. *)
+let _transition_of_event (e : FL.event) : Position.transition =
+  let exit_reason =
+    Position.StopLoss
+      {
+        stop_price = e.entry_price;
+        actual_price = e.current_price;
+        loss_percent = -.e.unrealized_pnl_pct *. 100.0;
+      }
+  in
+  {
+    Position.position_id = e.position_id;
+    date = e.date;
+    kind = Position.TriggerExit { exit_reason; exit_price = e.current_price };
+  }
+
+let update ~config ~positions ~get_price ~cash ~current_date ~peak_tracker
+    ~audit_recorder =
+  let inputs =
+    Map.fold positions ~init:[] ~f:(fun ~key:_ ~data:pos acc ->
+        match _position_input_of_holding ~get_price pos with
+        | Some pi -> pi :: acc
+        | None -> acc)
+  in
+  let portfolio_value = _portfolio_value ~cash ~positions ~get_price in
+  let events =
+    FL.check ~config ~date:current_date ~positions:inputs ~portfolio_value
+      ~peak_tracker
+  in
+  List.iter events ~f:audit_recorder.Audit_recorder.record_force_liquidation;
+  List.map events ~f:_transition_of_event

--- a/trading/trading/weinstein/strategy/lib/force_liquidation_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/force_liquidation_runner.mli
@@ -1,0 +1,42 @@
+(** Force-liquidation policy applied to held positions.
+
+    Runs at end of {!Weinstein_strategy._on_market_close}, AFTER
+    {!Stops_runner.update}. Responsibilities:
+
+    1. Build {!Portfolio_risk.Force_liquidation.position_input}s from the
+    portfolio's [Holding] positions + current bar prices. 2. Compute current
+    [portfolio_value] and call {!Portfolio_risk.Force_liquidation.check} — which
+    updates the peak-tracker and returns the events to fire. 3. For each event,
+    emit a [TriggerExit] transition (kind:
+    {!Trading_strategy.Position.StopLoss}) and a parallel
+    [record_force_liquidation] audit event.
+
+    The strategy state machine sees a regular [TriggerExit]; the audit channel
+    is what distinguishes a forced close from a regular stop-out. The [Halted]
+    state in the [peak_tracker] is consulted by the strategy to suppress new
+    entries until macro flips off Bearish.
+
+    Pure function over its inputs — no global state. Reads [peak_tracker]
+    (mutates it via [Force_liquidation.check]) and [audit_recorder] (invokes the
+    [record_force_liquidation] callback). *)
+
+open Core
+open Trading_strategy
+
+val update :
+  config:Portfolio_risk.Force_liquidation.config ->
+  positions:Position.t Map.M(String).t ->
+  get_price:Strategy_interface.get_price_fn ->
+  cash:float ->
+  current_date:Date.t ->
+  peak_tracker:Portfolio_risk.Force_liquidation.Peak_tracker.t ->
+  audit_recorder:Audit_recorder.t ->
+  Position.transition list
+(** Run the force-liquidation policy and return TriggerExit transitions.
+
+    Side effects:
+    - [peak_tracker] observe + halt-state update via
+      {!Portfolio_risk.Force_liquidation.check}.
+    - [audit_recorder.record_force_liquidation] called once per event.
+
+    Empty list when no events fire — the common case. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -330,15 +330,14 @@ let _is_screening_day_view (view : Data_panel.Bar_panels.weekly_view) =
     Date.day_of_week view.dates.(view.n - 1)
     |> Day_of_week.equal Day_of_week.Fri
 
-(** Run the Friday macro + screener path and return entry transitions. Under all
-    macro regimes (Bullish, Neutral, Bearish) the screener is invoked;
-    macro-specific gating — longs blocked under Bearish, shorts blocked under
-    Bullish — happens inside the screener. Under Bearish this yields short-side
-    entries (per the bear-market shorting chapter), where previously the branch
-    returned [] unconditionally. *)
-let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~prior_macro_result
-    ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price
-    ~portfolio ~current_date ~index_view ~audit_recorder =
+(** Compute the macro result for [current_date] and update the strategy's macro
+    refs. Cheap relative to [_run_screen_after_macro] — touches only the index,
+    globals, AD bars, and the macro analyser. Runs unconditionally on every
+    Friday (including when the halt is active) so [_maybe_reset_halt] can
+    consult the freshest macro trend even when the universe screen is gated off.
+*)
+let _run_macro_only ~config ~ad_bars ~prior_macro ~prior_macro_result
+    ~bar_reader ~prior_stages ~current_date ~index_view =
   let index_prior_stage = Hashtbl.find prior_stages config.indices.primary in
   let global_index_views =
     Macro_inputs.build_global_index_views ~lookback_bars:config.lookback_bars
@@ -360,6 +359,17 @@ let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~prior_macro_result
   in
   prior_macro := macro_result.trend;
   prior_macro_result := Some macro_result;
+  macro_result
+
+(** Run the Friday universe screener path given an already-computed
+    [macro_result]. Under all macro regimes (Bullish, Neutral, Bearish) the
+    screener is invoked; macro-specific gating — longs blocked under Bearish,
+    shorts blocked under Bullish — happens inside the screener. Under Bearish
+    this yields short-side entries (per the bear-market shorting chapter). *)
+let _run_screen_after_macro ~config ~stop_states ~bar_reader ~prior_stages
+    ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio ~current_date
+    ~index_view ~audit_recorder ~macro_result =
+  let ma_cache = Bar_reader.ma_cache bar_reader in
   let sector_map =
     Macro_inputs.build_sector_map ?ma_cache ~stage_config:config.stage_config
       ~lookback_bars:config.lookback_bars ~sector_etfs:config.sector_etfs
@@ -449,6 +459,24 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
     Bar_reader.weekly_view_for bar_reader ~symbol:config.indices.primary
       ~n:config.lookback_bars ~as_of:current_date
   in
+  (* On every Friday — including Fridays where the force-liquidation halt is
+     active — run the cheap macro-only path and consult [_maybe_reset_halt]
+     BEFORE deciding whether to invoke the universe screen. This preserves the
+     contract claim that the halt clears when macro flips off Bearish: if we
+     short-circuited on [halted = true] before updating [prior_macro], the
+     halt would latch permanently because no path would ever observe the new
+     macro trend. The macro-only path is a strict subset of the full screen
+     and adds no work over the buggy short-circuit when no halt is active. *)
+  let is_screening_day = _is_screening_day_view index_view in
+  let macro_result_opt =
+    if is_screening_day then
+      Some
+        (_run_macro_only ~config ~ad_bars ~prior_macro ~prior_macro_result
+           ~bar_reader ~prior_stages ~current_date ~index_view)
+    else None
+  in
+  if is_screening_day then
+    _maybe_reset_halt ~peak_tracker ~macro_trend:!prior_macro;
   (* New entries are blocked entirely while the halt is active — that is the
      portfolio-floor trigger's purpose. The halt clears when macro flips off
      Bearish (the typical condition under which the floor fires). *)
@@ -460,17 +488,13 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
     | Active -> false
   in
   let entry_transitions =
-    if halted || not (_is_screening_day_view index_view) then []
-    else
-      _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~prior_macro_result
-        ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
-        ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
+    match (halted, is_screening_day, macro_result_opt) with
+    | false, true, Some macro_result ->
+        _run_screen_after_macro ~config ~stop_states ~bar_reader ~prior_stages
+          ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio
+          ~current_date ~index_view ~audit_recorder ~macro_result
+    | _ -> []
   in
-  (* If this Friday's screen ran, [_run_screen] updated [prior_macro]; reset
-     the halt when the new macro trend is non-Bearish so subsequent screens
-     can resume entering positions. *)
-  if (not halted) && _is_screening_day_view index_view then
-    _maybe_reset_halt ~peak_tracker ~macro_trend:!prior_macro;
   Ok
     {
       Strategy_interface.transitions =
@@ -529,3 +553,13 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
         ~sector_prior_stages ~ticker_sectors ~audit_recorder
   end in
   (module M : Strategy_interface.STRATEGY)
+
+(** Test-only entry point. Exposes [_on_market_close] with all closure-scoped
+    refs / hashtables passed in explicitly so tests can pin the macro / halt /
+    screening-day gating without the indirection of going through {!make}. Not
+    intended for production use — public callers must use {!make} instead. *)
+module Internal_for_test = struct
+  let on_market_close = _on_market_close
+  let maybe_reset_halt = _maybe_reset_halt
+  let positions_minus_exited = _positions_minus_exited
+end

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -7,6 +7,7 @@ open Trading_strategy
 module Bar_reader = Bar_reader
 module Stops_runner = Stops_runner
 module Stops_split_runner = Stops_split_runner
+module Force_liquidation_runner = Force_liquidation_runner
 
 module Ad_bars = Ad_bars
 (** NYSE advance/decline breadth data loader. Exposed as a top-level submodule
@@ -369,10 +370,41 @@ let _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~prior_macro_result
     ~portfolio ~get_price ~bar_reader ~prior_stages ~current_date
     ~audit_recorder
 
+(** Filter the position map down to symbols not yet exited on this tick. The
+    force-liquidation pass runs after [Stops_runner.update] but before the
+    [TriggerExit] transitions are applied to position state, so a position that
+    already received a stop-out exit transition this tick must NOT be
+    double-exited via force-liquidation. *)
+let _positions_minus_exited ~(positions : Position.t Map.M(String).t)
+    ~(stop_exit_transitions : Position.transition list) :
+    Position.t Map.M(String).t =
+  let exited_ids =
+    List.filter_map stop_exit_transitions ~f:(fun (t : Position.transition) ->
+        match t.kind with
+        | Position.TriggerExit _ -> Some t.position_id
+        | _ -> None)
+    |> String.Set.of_list
+  in
+  if Set.is_empty exited_ids then positions
+  else
+    Map.filter positions ~f:(fun (p : Position.t) ->
+        not (Set.mem exited_ids p.id))
+
+(** When the macro flips off Bearish, reset the force-liquidation halt so the
+    strategy can resume opening new positions. Bearish-window peak drawdowns are
+    exactly when the halt fires; once macro recovers we trust the standard
+    cascade gating again. *)
+let _maybe_reset_halt ~peak_tracker
+    ~(macro_trend : Weinstein_types.market_trend) =
+  match macro_trend with
+  | Weinstein_types.Bearish -> ()
+  | Weinstein_types.Bullish | Weinstein_types.Neutral ->
+      Portfolio_risk.Force_liquidation.Peak_tracker.reset peak_tracker
+
 let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
-    ~prior_macro_result ~bar_reader ~prior_stages ~sector_prior_stages
-    ~ticker_sectors ~audit_recorder ~get_price ~get_indicator:_
-    ~(portfolio : Portfolio_view.t) =
+    ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
+    ~sector_prior_stages ~ticker_sectors ~audit_recorder ~get_price
+    ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
   let positions = portfolio.positions in
   let current_date =
     match get_price config.indices.primary with
@@ -397,6 +429,19 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
       (Exit_audit_capture.emit_exit_audit ~audit_recorder ~prior_macro_result
          ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
          ~bar_reader ~prior_stages ~positions);
+  (* Force-liquidation pass: defense in depth beyond stops (G4). Runs AFTER
+     [Stops_runner.update] so positions that were already stop-exited this
+     tick are filtered out — we never double-exit. Updates the peak tracker
+     and may flip the halt state to [Halted] for the portfolio-floor case. *)
+  let live_positions =
+    _positions_minus_exited ~positions ~stop_exit_transitions:exit_transitions
+  in
+  let force_exit_transitions =
+    Force_liquidation_runner.update
+      ~config:config.portfolio_config.force_liquidation
+      ~positions:live_positions ~get_price ~cash:portfolio.cash ~current_date
+      ~peak_tracker ~audit_recorder
+  in
   (* Stage 4 PR-A: read the primary index as a weekly view directly. The
      Friday detection uses the view's latest date; the screener path consumes
      the same view to avoid building two parallel inputs. *)
@@ -404,17 +449,33 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
     Bar_reader.weekly_view_for bar_reader ~symbol:config.indices.primary
       ~n:config.lookback_bars ~as_of:current_date
   in
+  (* New entries are blocked entirely while the halt is active — that is the
+     portfolio-floor trigger's purpose. The halt clears when macro flips off
+     Bearish (the typical condition under which the floor fires). *)
+  let halted =
+    match
+      Portfolio_risk.Force_liquidation.Peak_tracker.halt_state peak_tracker
+    with
+    | Halted -> true
+    | Active -> false
+  in
   let entry_transitions =
-    if not (_is_screening_day_view index_view) then []
+    if halted || not (_is_screening_day_view index_view) then []
     else
       _run_screen ~config ~ad_bars ~stop_states ~prior_macro ~prior_macro_result
         ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
         ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
   in
+  (* If this Friday's screen ran, [_run_screen] updated [prior_macro]; reset
+     the halt when the new macro trend is non-Bearish so subsequent screens
+     can resume entering positions. *)
+  if (not halted) && _is_screening_day_view index_view then
+    _maybe_reset_halt ~peak_tracker ~macro_trend:!prior_macro;
   Ok
     {
       Strategy_interface.transitions =
-        exit_transitions @ adjust_transitions @ entry_transitions;
+        exit_transitions @ force_exit_transitions @ adjust_transitions
+        @ entry_transitions;
     }
 
 let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
@@ -424,6 +485,11 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
   let prior_macro : Weinstein_types.market_trend ref =
     ref Weinstein_types.Neutral
   in
+  (* Force-liquidation peak tracker (G4). Lives in the strategy closure: each
+     [make] call yields an independent tracker so concurrent backtest /
+     paper / live instances don't pollute each other. The tracker is
+     observed every [_on_market_close] tick. *)
+  let peak_tracker = Portfolio_risk.Force_liquidation.Peak_tracker.create () in
   (* Cached full macro result for exit-time audit capture. Updated alongside
      [prior_macro] inside [_run_screen]. Held as an option until the first
      Friday so an exit firing before the first screen call gets a stable
@@ -459,7 +525,7 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
 
     let on_market_close =
       _on_market_close ~config ~ad_bars:weekly_ad_bars ~stop_states ~prior_macro
-        ~prior_macro_result ~bar_reader ~prior_stages ~sector_prior_stages
-        ~ticker_sectors ~audit_recorder
+        ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
+        ~sector_prior_stages ~ticker_sectors ~audit_recorder
   end in
   (module M : Strategy_interface.STRATEGY)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -331,3 +331,50 @@ val make :
       {!Audit_recorder.noop} — no observation is emitted and the strategy runs
       unchanged. Backtest callers wire a recorder backed by a
       [Backtest.Trade_audit.t] collector. *)
+
+(** {1 Internal — testing only}
+
+    Direct seams into the strategy's [_on_market_close] used by behavioural
+    regression tests. These bypass {!make}'s closure so a test can drive a
+    [Peak_tracker] in a known [Halted] state and assert that the next Friday
+    tick resets the halt to [Active] when macro flips off Bearish (PR #695,
+    review item B1). Not for production use. *)
+module Internal_for_test : sig
+  val on_market_close :
+    config:config ->
+    ad_bars:Macro.ad_bar list ->
+    stop_states:Weinstein_stops.stop_state String.Map.t ref ->
+    prior_macro:Weinstein_types.market_trend ref ->
+    prior_macro_result:Macro.result option ref ->
+    peak_tracker:Portfolio_risk.Force_liquidation.Peak_tracker.t ->
+    bar_reader:Bar_reader.t ->
+    prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+    sector_prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+    ticker_sectors:(string, string) Hashtbl.t ->
+    audit_recorder:Audit_recorder.t ->
+    get_price:Trading_strategy.Strategy_interface.get_price_fn ->
+    get_indicator:Trading_strategy.Strategy_interface.get_indicator_fn ->
+    portfolio:Trading_strategy.Portfolio_view.t ->
+    Trading_strategy.Strategy_interface.output Status.status_or
+  (** Drives [_on_market_close] with all closure-scoped state passed in
+      explicitly. Mutates [stop_states] / [prior_macro] / [prior_macro_result] /
+      [peak_tracker] / [prior_stages] / [sector_prior_stages] in place,
+      mirroring the closure semantics in {!make}. *)
+
+  val maybe_reset_halt :
+    peak_tracker:Portfolio_risk.Force_liquidation.Peak_tracker.t ->
+    macro_trend:Weinstein_types.market_trend ->
+    unit
+  (** Resets [peak_tracker]'s halt state to [Active] when [macro_trend] is not
+      [Bearish]; no-op otherwise. The strategy invokes this on every Friday
+      after refreshing macro so the halt clears as soon as macro recovers. *)
+
+  val positions_minus_exited :
+    positions:Trading_strategy.Position.t String.Map.t ->
+    stop_exit_transitions:Trading_strategy.Position.transition list ->
+    Trading_strategy.Position.t String.Map.t
+  (** Filters [positions] down to those whose [position_id] is NOT among the
+      [TriggerExit] transitions in [stop_exit_transitions]. Used to ensure
+      force-liquidation does not double-exit a position [Stops_runner] already
+      closed on this tick. *)
+end

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -49,6 +49,12 @@ module Stops_split_runner = Stops_split_runner
     stay in lockstep with the broker-side share-count rescale on a
     corporate-action split. See {!Stops_split_runner}. *)
 
+module Force_liquidation_runner = Force_liquidation_runner
+(** Force-liquidation policy runner. Invoked at the bottom of [on_market_close]
+    after {!Stops_runner.update} — defense in depth beyond stops. Closes G4 from
+    [dev/notes/short-side-gaps-2026-04-29.md]. See {!Force_liquidation_runner}.
+*)
+
 module Macro_inputs = Macro_inputs
 (** Sector map + global index assembly from accumulated bar history. Exposes the
     canonical {!Macro_inputs.spdr_sector_etfs} and

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -3,6 +3,7 @@
   test_ad_bars_unicorn
   test_ad_bars_compose
   test_ad_bars_weekly_e2e
+  test_force_liquidation_runner
   test_macro_inputs
   test_macro_panel_callbacks_real_data
   test_panel_callbacks

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -4,6 +4,7 @@
   test_ad_bars_compose
   test_ad_bars_weekly_e2e
   test_force_liquidation_runner
+  test_force_liquidation_strategy
   test_macro_inputs
   test_macro_panel_callbacks_real_data
   test_panel_callbacks

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
@@ -1,0 +1,265 @@
+(** End-to-end exercise of {!Force_liquidation_runner} with a synthetic
+    [Position.t] [Holding] + bar input.
+
+    Closes the runner-side contract for G4: given a held position whose
+    unrealized P&L exceeds the configured threshold, the runner emits a
+    [TriggerExit] transition and routes a [force_liquidation_event] through the
+    audit recorder. *)
+
+open OUnit2
+open Core
+open Matchers
+open Weinstein_strategy
+module Position = Trading_strategy.Position
+module FL = Portfolio_risk.Force_liquidation
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let _date s = Date.of_string s
+
+let _make_bar ~date ~close =
+  Types.Daily_price.
+    {
+      date;
+      open_price = close;
+      high_price = close *. 1.01;
+      low_price = close *. 0.99;
+      close_price = close;
+      adjusted_close = close;
+      volume = 1_000_000;
+    }
+
+(** Build a [Holding] position with [side]/[entry_price]/[quantity] using the
+    canonical entry chain so the result is bit-equal to what the simulator would
+    have produced. *)
+let _make_holding ~symbol ~side ~entry_date ~quantity ~entry_price =
+  let pos_id = symbol ^ "-1" in
+  let unwrap = function
+    | Ok p -> p
+    | Error err -> assert_failure ("position setup failed: " ^ Status.show err)
+  in
+  let trans kind = { Position.position_id = pos_id; date = entry_date; kind } in
+  let p =
+    Position.create_entering
+      (trans
+         (Position.CreateEntering
+            {
+              symbol;
+              side;
+              target_quantity = quantity;
+              entry_price;
+              reasoning =
+                Position.TechnicalSignal
+                  { indicator = "audit"; description = "test-entry" };
+            }))
+    |> unwrap
+  in
+  let p =
+    Position.apply_transition p
+      (trans
+         (Position.EntryFill
+            { filled_quantity = quantity; fill_price = entry_price }))
+    |> unwrap
+  in
+  Position.apply_transition p
+    (trans
+       (Position.EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = None;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+(** Recorder bundle that captures every emitted force-liquidation event into a
+    mutable ref. Other callbacks are no-ops. *)
+let _capturing_recorder () =
+  let captured = ref [] in
+  let recorder : Audit_recorder.t =
+    {
+      record_entry = (fun _ -> ());
+      record_exit = (fun _ -> ());
+      record_cascade_summary = (fun _ -> ());
+      record_force_liquidation = (fun e -> captured := e :: !captured);
+    }
+  in
+  (recorder, captured)
+
+(* ------------------------------------------------------------------ *)
+(* Per-position trigger                                                 *)
+(* ------------------------------------------------------------------ *)
+
+let test_per_position_trigger_emits_exit _ =
+  (* Long entered $100, current $40 — 60% loss; default threshold 50% fires. *)
+  let pos =
+    _make_holding ~symbol:"AAPL" ~side:Trading_base.Types.Long
+      ~entry_date:(_date "2024-01-02") ~quantity:100.0 ~entry_price:100.0
+  in
+  let bar = _make_bar ~date:(_date "2024-04-29") ~close:40.0 in
+  let positions = String.Map.singleton "AAPL" pos in
+  let get_price s = if String.equal s "AAPL" then Some bar else None in
+  let peak_tracker = FL.Peak_tracker.create () in
+  let recorder, captured = _capturing_recorder () in
+  let transitions =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price ~cash:1_000_000.0 ~current_date:(_date "2024-04-29")
+      ~peak_tracker ~audit_recorder:recorder
+  in
+  assert_that transitions
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Position.transition) -> t.position_id)
+               (equal_to "AAPL-1");
+             field
+               (fun (t : Position.transition) -> t.kind)
+               (matching ~msg:"Expected TriggerExit"
+                  (function
+                    | Position.TriggerExit { exit_price; _ } -> Some exit_price
+                    | _ -> None)
+                  (float_equal 40.0));
+           ];
+       ]);
+  assert_that !captured (size_is 1)
+
+let test_per_position_trigger_no_fire_under_threshold _ =
+  (* Long $100 → $60 = 40% loss; threshold 50%; no fire. *)
+  let pos =
+    _make_holding ~symbol:"AAPL" ~side:Trading_base.Types.Long
+      ~entry_date:(_date "2024-01-02") ~quantity:100.0 ~entry_price:100.0
+  in
+  let bar = _make_bar ~date:(_date "2024-04-29") ~close:60.0 in
+  let positions = String.Map.singleton "AAPL" pos in
+  let get_price s = if String.equal s "AAPL" then Some bar else None in
+  let peak_tracker = FL.Peak_tracker.create () in
+  let recorder, captured = _capturing_recorder () in
+  let transitions =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price ~cash:1_000_000.0 ~current_date:(_date "2024-04-29")
+      ~peak_tracker ~audit_recorder:recorder
+  in
+  assert_that transitions is_empty;
+  assert_that !captured is_empty
+
+(* ------------------------------------------------------------------ *)
+(* Portfolio-floor trigger                                              *)
+(* ------------------------------------------------------------------ *)
+
+let test_portfolio_floor_trigger_closes_all _ =
+  (* Two positions; portfolio_value drops below 40% of peak; both close. *)
+  let pos_a =
+    _make_holding ~symbol:"AAPL" ~side:Trading_base.Types.Long
+      ~entry_date:(_date "2024-01-02") ~quantity:100.0 ~entry_price:100.0
+  in
+  let pos_b =
+    _make_holding ~symbol:"TSLA" ~side:Trading_base.Types.Long
+      ~entry_date:(_date "2024-01-02") ~quantity:50.0 ~entry_price:200.0
+  in
+  let positions =
+    String.Map.of_alist_exn [ ("AAPL", pos_a); ("TSLA", pos_b) ]
+  in
+  let peak_tracker = FL.Peak_tracker.create () in
+  let recorder, captured = _capturing_recorder () in
+  (* First tick: establish peak at 1M with both positions at par. *)
+  let bar_par_a = _make_bar ~date:(_date "2024-01-02") ~close:100.0 in
+  let bar_par_b = _make_bar ~date:(_date "2024-01-02") ~close:200.0 in
+  let get_price_par s =
+    if String.equal s "AAPL" then Some bar_par_a
+    else if String.equal s "TSLA" then Some bar_par_b
+    else None
+  in
+  (* cash: 1M - 10K (AAPL) - 10K (TSLA) = 980K; positions worth 20K → total 1M. *)
+  let _ =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price:get_price_par ~cash:980_000.0
+      ~current_date:(_date "2024-01-02") ~peak_tracker ~audit_recorder:recorder
+  in
+  (* Second tick: catastrophic drop. AAPL 100→20, TSLA 200→40.
+     Position values: 100*20 + 50*40 = 4000; cash unchanged at 980_000.
+     Wait — that's still 984K which is above 40% of 1M peak. Need a bigger
+     drop in CASH for the floor to fire. Let's drop cash too (e.g. simulate
+     accumulated losses on shorts that already covered): cash 200_000,
+     positions 4000 → total 204_000, well below 400_000 (40% of peak 1M). *)
+  let bar_crash_a = _make_bar ~date:(_date "2024-04-29") ~close:20.0 in
+  let bar_crash_b = _make_bar ~date:(_date "2024-04-29") ~close:40.0 in
+  let get_price_crash s =
+    if String.equal s "AAPL" then Some bar_crash_a
+    else if String.equal s "TSLA" then Some bar_crash_b
+    else None
+  in
+  let transitions =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price:get_price_crash ~cash:200_000.0
+      ~current_date:(_date "2024-04-29") ~peak_tracker ~audit_recorder:recorder
+  in
+  (* Both positions close under Portfolio_floor reason. *)
+  assert_that transitions (size_is 2);
+  assert_that !captured (size_is 2);
+  (* Halt state must flip. *)
+  assert_that (FL.Peak_tracker.halt_state peak_tracker) (equal_to FL.Halted)
+
+let test_no_positions_no_events _ =
+  let peak_tracker = FL.Peak_tracker.create () in
+  let recorder, captured = _capturing_recorder () in
+  let transitions =
+    Force_liquidation_runner.update ~config:FL.default_config
+      ~positions:String.Map.empty
+      ~get_price:(fun _ -> None)
+      ~cash:1_000_000.0 ~current_date:(_date "2024-04-29") ~peak_tracker
+      ~audit_recorder:recorder
+  in
+  assert_that transitions is_empty;
+  assert_that !captured is_empty
+
+let test_short_position_loss_fires _ =
+  (* Short at $200, current $320 = 60% loss (entry 200 + price up 120 / cost
+     basis 200 = 0.6); default 50% fires. *)
+  let pos =
+    _make_holding ~symbol:"TSLA" ~side:Trading_base.Types.Short
+      ~entry_date:(_date "2024-01-02") ~quantity:50.0 ~entry_price:200.0
+  in
+  let bar = _make_bar ~date:(_date "2024-04-29") ~close:320.0 in
+  let positions = String.Map.singleton "TSLA" pos in
+  let get_price s = if String.equal s "TSLA" then Some bar else None in
+  let peak_tracker = FL.Peak_tracker.create () in
+  let recorder, captured = _capturing_recorder () in
+  let transitions =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price ~cash:1_000_000.0 ~current_date:(_date "2024-04-29")
+      ~peak_tracker ~audit_recorder:recorder
+  in
+  assert_that transitions (size_is 1);
+  assert_that !captured
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (e : FL.event) -> e.symbol) (equal_to "TSLA");
+             field
+               (fun (e : FL.event) -> e.side)
+               (equal_to Trading_base.Types.Short);
+             field (fun (e : FL.event) -> e.reason) (equal_to FL.Per_position);
+           ];
+       ])
+
+let suite =
+  "force_liquidation_runner"
+  >::: [
+         "per_position_trigger_emits_exit"
+         >:: test_per_position_trigger_emits_exit;
+         "per_position_trigger_no_fire_under_threshold"
+         >:: test_per_position_trigger_no_fire_under_threshold;
+         "portfolio_floor_trigger_closes_all"
+         >:: test_portfolio_floor_trigger_closes_all;
+         "no_positions_no_events" >:: test_no_positions_no_events;
+         "short_position_loss_fires" >:: test_short_position_loss_fires;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
@@ -76,6 +76,30 @@ let _make_holding ~symbol ~side ~entry_date ~quantity ~entry_price =
           }))
   |> unwrap
 
+(** Build an [Entering] position — entry order placed but not yet filled.
+    [_position_input_of_holding] returns [None] for non-Holding positions, so no
+    event fires for these. *)
+let _make_entering ~symbol ~side ~entry_date ~quantity ~entry_price =
+  let pos_id = symbol ^ "-1" in
+  let unwrap = function
+    | Ok p -> p
+    | Error err -> assert_failure ("position setup failed: " ^ Status.show err)
+  in
+  let trans kind = { Position.position_id = pos_id; date = entry_date; kind } in
+  Position.create_entering
+    (trans
+       (Position.CreateEntering
+          {
+            symbol;
+            side;
+            target_quantity = quantity;
+            entry_price;
+            reasoning =
+              Position.TechnicalSignal
+                { indicator = "audit"; description = "test-entry" };
+          }))
+  |> unwrap
+
 (** Recorder bundle that captures every emitted force-liquidation event into a
     mutable ref. Other callbacks are no-ops. *)
 let _capturing_recorder () =
@@ -249,6 +273,108 @@ let test_short_position_loss_fires _ =
            ];
        ])
 
+(* ------------------------------------------------------------------ *)
+(* Defensive guards (PR #695, qc-behavioral B3)                         *)
+(* ------------------------------------------------------------------ *)
+
+(** Guard: [_position_input_of_holding] returns [None] for non-Holding
+    positions. An [Entering] position (entry order placed, no fills yet) has no
+    entry_price / quantity that match the [Holding] state's contract; the runner
+    must skip it without firing an event. *)
+let test_non_holding_position_does_not_fire _ =
+  let pos =
+    _make_entering ~symbol:"AAPL" ~side:Trading_base.Types.Long
+      ~entry_date:(_date "2024-01-02") ~quantity:100.0 ~entry_price:100.0
+  in
+  let bar = _make_bar ~date:(_date "2024-04-29") ~close:30.0 in
+  let positions = String.Map.singleton "AAPL" pos in
+  let get_price s = if String.equal s "AAPL" then Some bar else None in
+  let peak_tracker = FL.Peak_tracker.create () in
+  let recorder, captured = _capturing_recorder () in
+  let transitions =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price ~cash:1_000_000.0 ~current_date:(_date "2024-04-29")
+      ~peak_tracker ~audit_recorder:recorder
+  in
+  assert_that transitions is_empty;
+  assert_that !captured is_empty
+
+(** Guard: [_position_input_of_holding] returns [None] when [get_price] returns
+    [None] for the position's symbol — the runner can't evaluate the threshold
+    without a current price. The position is silently skipped this tick rather
+    than fired with stale data. *)
+let test_missing_price_does_not_fire _ =
+  let pos =
+    _make_holding ~symbol:"AAPL" ~side:Trading_base.Types.Long
+      ~entry_date:(_date "2024-01-02") ~quantity:100.0 ~entry_price:100.0
+  in
+  let positions = String.Map.singleton "AAPL" pos in
+  let peak_tracker = FL.Peak_tracker.create () in
+  let recorder, captured = _capturing_recorder () in
+  let transitions =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price:(fun _ -> None)
+      ~cash:1_000_000.0 ~current_date:(_date "2024-04-29") ~peak_tracker
+      ~audit_recorder:recorder
+  in
+  assert_that transitions is_empty;
+  assert_that !captured is_empty
+
+(* ------------------------------------------------------------------ *)
+(* Double-exit avoidance — strategy-level filter                        *)
+(* ------------------------------------------------------------------ *)
+
+(** [Weinstein_strategy.Internal_for_test.positions_minus_exited] removes any
+    position whose [position_id] appears in a [TriggerExit] transition. The
+    force-liquidation runner sees the filtered map, so a position already
+    stop-exited this tick does NOT receive a duplicate force-liquidation
+    [TriggerExit].
+
+    Pinning this at the [_positions_minus_exited] seam (rather than the runner)
+    matches where the contract lives — the runner has no notion of pending
+    stop-exits; the strategy filter is the single source of truth. *)
+let test_double_exit_avoidance_filters_already_exited _ =
+  let pos_a =
+    _make_holding ~symbol:"AAPL" ~side:Trading_base.Types.Long
+      ~entry_date:(_date "2024-01-02") ~quantity:100.0 ~entry_price:100.0
+  in
+  let pos_b =
+    _make_holding ~symbol:"TSLA" ~side:Trading_base.Types.Long
+      ~entry_date:(_date "2024-01-02") ~quantity:50.0 ~entry_price:200.0
+  in
+  let positions =
+    String.Map.of_alist_exn [ ("AAPL", pos_a); ("TSLA", pos_b) ]
+  in
+  (* AAPL just received a stop-exit transition this tick — must be filtered
+     out before force-liquidation considers it. *)
+  let stop_exit_transitions =
+    [
+      {
+        Position.position_id = "AAPL-1";
+        date = _date "2024-04-29";
+        kind =
+          Position.TriggerExit
+            {
+              exit_reason =
+                Position.StopLoss
+                  {
+                    stop_price = 90.0;
+                    actual_price = 89.0;
+                    loss_percent = 11.0;
+                  };
+              exit_price = 89.0;
+            };
+      };
+    ]
+  in
+  let filtered =
+    Weinstein_strategy.Internal_for_test.positions_minus_exited ~positions
+      ~stop_exit_transitions
+  in
+  assert_that
+    (Map.keys filtered |> List.sort ~compare:String.compare)
+    (elements_are [ equal_to "TSLA" ])
+
 let suite =
   "force_liquidation_runner"
   >::: [
@@ -260,6 +386,11 @@ let suite =
          >:: test_portfolio_floor_trigger_closes_all;
          "no_positions_no_events" >:: test_no_positions_no_events;
          "short_position_loss_fires" >:: test_short_position_loss_fires;
+         "non-Holding position does not fire"
+         >:: test_non_holding_position_does_not_fire;
+         "missing price does not fire" >:: test_missing_price_does_not_fire;
+         "double-exit avoidance filters already-exited"
+         >:: test_double_exit_avoidance_filters_already_exited;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
@@ -1,0 +1,277 @@
+(** Strategy-level regression tests for the force-liquidation halt-and-resume
+    contract (PR #695, qc-behavioral B1).
+
+    The bug pinned here: [Weinstein_strategy._on_market_close] previously
+    short-circuited on [halted = true] before invoking the macro analyser, so
+    [prior_macro] was never refreshed once the portfolio-floor halt fired.
+    [_maybe_reset_halt] was gated on [not halted] downstream of the
+    short-circuit, so the halt latched permanently — contradicting the .mli
+    claim that the halt clears when macro flips off [Bearish].
+
+    The fix splits [_run_screen] into a cheap [_run_macro_only] pass and an
+    expensive [_run_screen_after_macro] pass; the macro pass and
+    [_maybe_reset_halt] now run on every Friday including halted Fridays, so the
+    halt-reset fires the moment macro recovers.
+
+    These tests drive [Internal_for_test.on_market_close] directly so the
+    halt-and-resume sequencing is observable without going through {!make}'s
+    closure. *)
+
+open Core
+open OUnit2
+open Matchers
+open Weinstein_strategy
+open Weinstein_types
+module Bar_panels = Data_panel.Bar_panels
+module Symbol_index = Data_panel.Symbol_index
+module Ohlcv_panels = Data_panel.Ohlcv_panels
+module FL = Portfolio_risk.Force_liquidation
+
+(* ------------------------------------------------------------------ *)
+(* Helpers — minimal panel-backed bar reader on a single index symbol  *)
+(* ------------------------------------------------------------------ *)
+
+let _make_daily_bar ~date ~price =
+  {
+    Types.Daily_price.date;
+    open_price = price;
+    high_price = price *. 1.01;
+    low_price = price *. 0.99;
+    close_price = price;
+    adjusted_close = price;
+    volume = 1_000_000;
+  }
+
+(** Build [n] consecutive daily bars (one per calendar day) starting at
+    [start_date], with prices walking by [step] per day. The strategy reads
+    weekly views on top of the daily panel; producing one daily bar per day
+    gives the weekly aggregator a clean sequence to bucket. *)
+let _make_daily_bars ~start_date ~n ~start_price ~step =
+  List.init n ~f:(fun i ->
+      let date = Date.add_days start_date i in
+      let price = start_price +. (Float.of_int i *. step) in
+      _make_daily_bar ~date ~price)
+
+(** Build a [Bar_panels.t] from [(symbol, daily_bars)] pairs. Mirrors the
+    construction used by [test_panel_callbacks.ml]. *)
+let _panels_of_symbols
+    (symbols_with_bars : (string * Types.Daily_price.t list) list) =
+  let universe = List.map symbols_with_bars ~f:fst in
+  let symbol_index =
+    match Symbol_index.create ~universe with
+    | Ok t -> t
+    | Error err -> assert_failure ("Symbol_index.create: " ^ err.Status.message)
+  in
+  let calendar =
+    symbols_with_bars
+    |> List.concat_map ~f:(fun (_, bars) ->
+        List.map bars ~f:(fun b -> b.Types.Daily_price.date))
+    |> List.dedup_and_sort ~compare:Date.compare
+    |> Array.of_list
+  in
+  let ohlcv =
+    Ohlcv_panels.create symbol_index ~n_days:(Array.length calendar)
+  in
+  let date_to_col = Hashtbl.create (module Date) in
+  Array.iteri calendar ~f:(fun i d ->
+      Hashtbl.add date_to_col ~key:d ~data:i
+      |> (ignore : [ `Ok | `Duplicate ] -> unit));
+  List.iter symbols_with_bars ~f:(fun (symbol, bars) ->
+      match Symbol_index.to_row symbol_index symbol with
+      | None -> ()
+      | Some row ->
+          List.iter bars ~f:(fun bar ->
+              match Hashtbl.find date_to_col bar.Types.Daily_price.date with
+              | None -> ()
+              | Some day ->
+                  Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day bar));
+  match Bar_panels.create ~ohlcv ~calendar with
+  | Ok p -> p
+  | Error err -> assert_failure ("Bar_panels.create: " ^ err.Status.message)
+
+(** Find a Friday close to [start_date] (i.e. the next Friday on or after). *)
+let _next_friday d =
+  let rec go d =
+    if Day_of_week.equal (Date.day_of_week d) Day_of_week.Fri then d
+    else go (Date.add_days d 1)
+  in
+  go d
+
+type _strategy_state = {
+  stop_states : Weinstein_stops.stop_state String.Map.t ref;
+  prior_macro : market_trend ref;
+  prior_macro_result : Macro.result option ref;
+  peak_tracker : FL.Peak_tracker.t;
+  prior_stages : stage Hashtbl.M(String).t;
+  sector_prior_stages : stage Hashtbl.M(String).t;
+  ticker_sectors : (string, string) Hashtbl.t;
+  bar_reader : Bar_reader.t;
+}
+(** Build a fresh closure-state bundle that mirrors what {!make} constructs
+    internally. Returns [(state, get_price)] where [state] holds the mutable
+    refs used by {!Internal_for_test.on_market_close}. *)
+
+let _fresh_state ~bar_reader =
+  {
+    stop_states = ref String.Map.empty;
+    prior_macro = ref Neutral;
+    prior_macro_result = ref None;
+    peak_tracker = FL.Peak_tracker.create ();
+    prior_stages = Hashtbl.create (module String);
+    sector_prior_stages = Hashtbl.create (module String);
+    ticker_sectors = Hashtbl.create (module String);
+    bar_reader;
+  }
+
+(** Wrap [Bar_reader.daily_bars_for state.bar_reader] into the
+    [Strategy_interface.get_price_fn] shape expected by [_on_market_close]. *)
+let _get_price_of_state state ~current_date symbol =
+  match
+    Bar_reader.daily_bars_for state.bar_reader ~symbol ~as_of:current_date
+  with
+  | [] -> None
+  | bars -> List.last bars
+
+let _drive_tick state ~config ~current_date ~portfolio =
+  Internal_for_test.on_market_close ~config ~ad_bars:[]
+    ~stop_states:state.stop_states ~prior_macro:state.prior_macro
+    ~prior_macro_result:state.prior_macro_result
+    ~peak_tracker:state.peak_tracker ~bar_reader:state.bar_reader
+    ~prior_stages:state.prior_stages
+    ~sector_prior_stages:state.sector_prior_stages
+    ~ticker_sectors:state.ticker_sectors ~audit_recorder:Audit_recorder.noop
+    ~get_price:(_get_price_of_state state ~current_date)
+    ~get_indicator:(fun _ _ _ _ -> None)
+    ~portfolio
+
+(* ------------------------------------------------------------------ *)
+(* Direct-unit pinning of _maybe_reset_halt                            *)
+(* ------------------------------------------------------------------ *)
+
+(** Pins the macro-flip semantics of {!Internal_for_test.maybe_reset_halt}. The
+    halt clears when macro is [Bullish] or [Neutral]; stays armed under
+    [Bearish]. *)
+let test_maybe_reset_halt_clears_on_non_bearish _ =
+  let pt = FL.Peak_tracker.create () in
+  FL.Peak_tracker.mark_halted pt;
+  Internal_for_test.maybe_reset_halt ~peak_tracker:pt ~macro_trend:Bullish;
+  assert_that (FL.Peak_tracker.halt_state pt) (equal_to FL.Active)
+
+let test_maybe_reset_halt_clears_on_neutral _ =
+  let pt = FL.Peak_tracker.create () in
+  FL.Peak_tracker.mark_halted pt;
+  Internal_for_test.maybe_reset_halt ~peak_tracker:pt ~macro_trend:Neutral;
+  assert_that (FL.Peak_tracker.halt_state pt) (equal_to FL.Active)
+
+let test_maybe_reset_halt_persists_under_bearish _ =
+  let pt = FL.Peak_tracker.create () in
+  FL.Peak_tracker.mark_halted pt;
+  Internal_for_test.maybe_reset_halt ~peak_tracker:pt ~macro_trend:Bearish;
+  assert_that (FL.Peak_tracker.halt_state pt) (equal_to FL.Halted)
+
+(* ------------------------------------------------------------------ *)
+(* End-to-end halt-resume regression                                    *)
+(* ------------------------------------------------------------------ *)
+
+let _index_symbol = "GSPCX"
+
+(** Build a panel-backed bar reader with a steadily-rising index series of
+    [n_days] bars ending on or before [end_date]. The trend is strongly upward
+    (1% daily gain); over 30+ weeks of weekly aggregation this drives the macro
+    analyser away from [Bearish] under empty AD bars + empty globals. *)
+let _rising_index_reader ~end_date =
+  let n_days = 260 in
+  (* ~52 weeks of trading days *)
+  let start_date = Date.add_days end_date (-(n_days - 1)) in
+  let bars =
+    _make_daily_bars ~start_date ~n:n_days ~start_price:100.0 ~step:1.0
+  in
+  let panels = _panels_of_symbols [ (_index_symbol, bars) ] in
+  Bar_reader.of_panels panels
+
+(** B1 regression: the halt-reset fires on Friday even when the peak tracker
+    enters the tick already in [Halted]. Pre-fix [_on_market_close] returned
+    [entry_transitions = []] AND skipped [_maybe_reset_halt] entirely (gated on
+    [not halted]); the halt latched permanently. Post-fix the macro pass runs
+    unconditionally on Friday and [_maybe_reset_halt] consults the fresh trend,
+    flipping the halt back to [Active] when macro is no longer [Bearish]. *)
+let test_halt_resets_after_macro_flip _ =
+  let current_date = _next_friday (Date.of_string "2024-04-26") in
+  let bar_reader = _rising_index_reader ~end_date:current_date in
+  let state = _fresh_state ~bar_reader in
+  (* Prime the pump: halt is active before the tick. *)
+  FL.Peak_tracker.mark_halted state.peak_tracker;
+  assert_that
+    (FL.Peak_tracker.halt_state state.peak_tracker)
+    (equal_to FL.Halted);
+  let config =
+    Weinstein_strategy.default_config ~universe:[] ~index_symbol:_index_symbol
+  in
+  let portfolio : Trading_strategy.Portfolio_view.t =
+    { cash = 100_000.0; positions = String.Map.empty }
+  in
+  let result = _drive_tick state ~config ~current_date ~portfolio in
+  (* Tick must succeed cleanly even with the halt active. *)
+  assert_that result is_ok;
+  (* The rising-index series produces a non-Bearish macro trend; the halt
+     therefore clears. Pre-fix, macro was never refreshed and the halt
+     remained Halted. *)
+  assert_that
+    (FL.Peak_tracker.halt_state state.peak_tracker)
+    (equal_to FL.Active);
+  (* prior_macro must reflect the just-computed trend (not the initial
+     Neutral default). The rising series hits Bullish under the panel-
+     callbacks macro pipeline. *)
+  assert_that !(state.prior_macro)
+    (matching ~msg:"Expected non-Bearish macro after rising index"
+       (function Bearish -> None | t -> Some t)
+       (equal_to Bullish))
+
+(** Symmetric: the halt persists when macro stays [Bearish]. Pinned via a
+    declining index series — the macro analyser returns [Bearish] under a
+    monotonically falling 30-week MA. The halt does NOT clear, even though the
+    macro pass ran. *)
+let test_halt_persists_when_macro_stays_bearish _ =
+  let current_date = _next_friday (Date.of_string "2024-04-26") in
+  let n_days = 260 in
+  let start_date = Date.add_days current_date (-(n_days - 1)) in
+  let bars =
+    _make_daily_bars ~start_date ~n:n_days ~start_price:200.0 ~step:(-0.5)
+  in
+  let panels = _panels_of_symbols [ (_index_symbol, bars) ] in
+  let bar_reader = Bar_reader.of_panels panels in
+  let state = _fresh_state ~bar_reader in
+  FL.Peak_tracker.mark_halted state.peak_tracker;
+  let config =
+    Weinstein_strategy.default_config ~universe:[] ~index_symbol:_index_symbol
+  in
+  let portfolio : Trading_strategy.Portfolio_view.t =
+    { cash = 100_000.0; positions = String.Map.empty }
+  in
+  let result = _drive_tick state ~config ~current_date ~portfolio in
+  assert_that result is_ok;
+  assert_that
+    (FL.Peak_tracker.halt_state state.peak_tracker)
+    (equal_to FL.Halted);
+  assert_that !(state.prior_macro) (equal_to Bearish)
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "force_liquidation_strategy"
+  >::: [
+         "maybe_reset_halt clears on Bullish"
+         >:: test_maybe_reset_halt_clears_on_non_bearish;
+         "maybe_reset_halt clears on Neutral"
+         >:: test_maybe_reset_halt_clears_on_neutral;
+         "maybe_reset_halt persists under Bearish"
+         >:: test_maybe_reset_halt_persists_under_bearish;
+         "halt resets after macro flip on Friday tick"
+         >:: test_halt_resets_after_macro_flip;
+         "halt persists when macro stays Bearish"
+         >:: test_halt_persists_when_macro_stays_bearish;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Closes **G4** from `dev/notes/short-side-gaps-2026-04-29.md`: defense in depth beyond stops. When primary stop machinery fails to protect a trade and unrealized loss compounds unchecked, this policy force-closes the position and emits an audit signal — every fired event flags a regression.

## What it does

Two configurable triggers, applied at the end of `Weinstein_strategy._on_market_close` after `Stops_runner.update`:

- **Per-position**: a position's unrealized loss exceeds `max_unrealized_loss_fraction` of cost basis. Force-close that single position.
  - Default: **0.5** (50% of cost basis lost)
- **Portfolio-floor**: total `portfolio_value < peak * min_portfolio_value_fraction_of_peak`. Force-close ALL positions and halt new entries until macro flips off Bearish.
  - Default: **0.4** (40% of peak — i.e. 60% drawdown from peak)

Both thresholds live on `Portfolio_risk.config.force_liquidation` (sexp-defaulted for backward-compat with existing override sexps).

The new `Peak_tracker` (mutable, scoped to the strategy closure) maintains the running peak monotonically and the halt-state flag. The strategy resets the halt when its macro snapshot flips off Bearish.

## Audit-record schema additions

`Force_liquidation.event` carries:
- `symbol`, `position_id`, `date`, `side`
- `entry_price`, `current_price`, `quantity`
- `cost_basis`, `unrealized_pnl`, `unrealized_pnl_pct`
- `reason : Per_position | Portfolio_floor`

Strategy library exposes the event via `Audit_recorder.record_force_liquidation`. Backtest layer collects events into a new `Force_liquidation_log.t`, persists as `force_liquidations.sexp` (when non-empty), and post-processes `trades.csv` so the `exit_trigger` column reads `force_liquidation_position` or `force_liquidation_portfolio` instead of the generic `stop_loss` label for force-liquidated rows.

## Visibility

- `trades.csv` `exit_trigger` column overridden by symbol+exit_date join.
- New `force_liquidations.sexp` artefact alongside `trade_audit.sexp`.
- New `force_liquidations_count` field on `actual.sexp` (sexp-defaulted to 0 for backward compat).
- Release-perf report renders a **Force-liq count** row in the trading-metrics table with a `:rotating_light:` glyph when either side is non-zero — non-zero counts are the G4 risk-machinery red flag.

## Test plan

- [x] `Portfolio_risk.Force_liquidation` unit tests (18) — per-position thresholds, portfolio-floor with peak tracking, precedence, sexp round-trip, default config values
- [x] `Weinstein_strategy.Force_liquidation_runner` end-to-end tests (5) — TriggerExit emission for long/short losses; portfolio-floor closes all positions and flips halt state; no events on empty positions; recorder callback fires
- [x] `Release_report` render pinning + new flag-on-nonzero-count test (26 total)
- [x] All existing portfolio_risk / strategy / backtest tests still pass
- [x] `dune build` clean
- [x] `dune build @fmt` (via direct ocamlformat — `dune @fmt` is git-aware and does not run inside the worktree harness)

## Default thresholds (chosen)

- `max_unrealized_loss_fraction = 0.5`
- `min_portfolio_value_fraction_of_peak = 0.4`

Both sit at the conservative end of the spec — a 50% per-position loss should already have been caught by stops; a 60% portfolio drawdown is well past the territory where Weinstein's primary risk machinery should have gotten you out.

## Audit-harness scenario count delta

`test_audit_weinstein_bear` (the existing G5 audit harness): 3 tests, unchanged. Force-liquidation gets a dedicated `test_force_liquidation_runner` suite (5 tests) directly invoking the runner with synthetic Holding positions — keeps the audit harness narrow and avoids extending the synthetic-strategy fixtures unnecessarily for this PR.

## CI status

- `dune build`: clean (exit 0).
- `dune runtest` on touched test files: all green.
- `dune runtest` repo-wide: pre-existing magic-number-linter failures on `stops_runner.ml` / `optimal_strategy_runner.ml` (date strings + PR refs in comments) — unchanged from main; not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)