### PR TITLE
harness(run-in-env): emit stderr WARN on docker-inspect fallback + sync header docstring

### DIFF
--- a/dev/lib/run-in-env.sh
+++ b/dev/lib/run-in-env.sh
@@ -18,9 +18,12 @@
 #          The script lives at <repo-root>/dev/lib/; climb two levels to reach
 #          the repo root, then descend into trading/ (the dune workspace root).
 #
-# Both paths verify that dune-workspace exists at the resolved root and fail
-# loudly if it doesn't — this catches path mismatches rather than silently
-# running dune in the wrong directory.
+# The in-container path verifies dune-workspace exists at the resolved root and
+# fails loudly if it doesn't — catches path mismatches rather than silently
+# running dune in the wrong directory. The local docker-exec path delegates
+# path resolution to a docker-inspect query against the container's mount table
+# (see "Worktree path resolution" below), with a fallback that emits a stderr
+# warning if the inspect returns empty.
 #
 # Docker liveness probe (local path only):
 #   Before running the user command, the script verifies the container is
@@ -123,6 +126,7 @@ else
   else
     # docker inspect failed or returned no mount — fall back to the original
     # hardcoded path (parent repo, no worktree).
+    echo "WARN: docker inspect on '${CONTAINER_NAME}' returned no mount source; falling back to parent-repo path /workspaces/trading-1/trading. If running from an isolated worktree, this is wrong — check 'docker inspect ${CONTAINER_NAME} --format ...'." >&2
     DOCKER_TRADING_ROOT="/workspaces/trading-1/trading"
   fi
 


### PR DESCRIPTION
## What

Two small fixes to `dev/lib/run-in-env.sh`:

1. **Stderr WARN on fallback** (lines 127-130): when `docker inspect` returns no mount source, the else-branch now emits a `WARN:` message to stderr naming the container and the hardcoded fallback path, and explaining the implication for isolated worktrees.

2. **Header docstring sync** (lines 21-26): the old comment claimed both paths verify dune-workspace existence; only the in-container path does. Reworded to accurately describe each path's behaviour — in-container does the dune-workspace check + loud fail; local docker-exec delegates to docker-inspect with an inspect-based fallback that now warns.

## Source

`dev/notes/session-followups-2026-04-29-evening.md` §4.

## Verify

```bash
# POSIX lint passes (already confirmed):
docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && bash devtools/checks/posix_sh_check.sh'
# → OK: posix-sh linter -- 47 scripts clean.

# Normal invocation still works:
dev/lib/run-in-env.sh true
```

To see the WARN: temporarily unset `TRADING_CONTAINER_NAME` to point at a non-existent container name with no mount, or patch the inspect format string; the message should appear on stderr.