### PR TITLE
fix(portfolio_risk): G7 — short position sizing respects max_short_exposure_pct

### DIFF
--- a/dev/notes/short-side-gaps-2026-04-29.md
+++ b/dev/notes/short-side-gaps-2026-04-29.md
@@ -290,3 +290,33 @@ full details. Summary:
 - Pre-fix test: a $1M portfolio + $100/share short with default
   `max_short_exposure_pct` should size `target_quantity * entry_price
   ≤ max_short_exposure_pct * portfolio_value`. Currently fails.
+
+**DONE — see PR `feat/g7-short-position-sizing`** (2026-04-30):
+leaking surface was `Portfolio_risk.compute_position_size`. The risk-
+budget formula `shares = floor(dollar_risk / |entry - stop|)` is
+unbounded when `|entry - stop|` is small relative to `dollar_risk`.
+The `max_long_exposure_pct` / `max_short_exposure_pct` config knobs
+(default 0.90 / 0.30) existed but were only consumed by
+`Portfolio_risk.check_limits`, which is **never called from the live
+entry pipeline** (zero non-test callers).
+
+Fix: added `~side` parameter to `compute_position_size`; final share
+count is now `min(risk_based_shares, exposure_capped_shares)` where
+`exposure_capped_shares = floor(portfolio_value * max_exposure_pct /
+entry_price)`. Pre-fix the ABBV-shape test ($1M portfolio, $101.59
+entry, $102.41 stop, side=Short) sized 12,195 shares ($1.238M); post-
+fix sizes 2,953 shares ($300K = 30% cap × $1M). Symmetric long-side
+cap also pinned (max 90%). Five new tests in
+`test_portfolio_risk.ml`; existing 4 long-side tests updated for the
+new required `~side` arg. Also absorbed the Long/Short entry-stop
+swap that used to live in
+`Entry_audit_capture._normalised_entry_stop_for_sizing` into
+`compute_position_size` itself (now uses `Float.abs (entry - stop)` +
+side-direction validation).
+
+Re-enabling shorts on sp500-2019-2023 (the validation rerun) is **not
+done in this PR** — left as the next step. The override stays in
+place. G7 closing means `compute_position_size` no longer produces
+oversized entries; whether that's *sufficient* to drop the force-
+liquidation count to single digits (and produce a defensible short-
+side baseline) is what the rerun will measure.

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
@@ -125,10 +125,35 @@ let snapshot_of_portfolio ~portfolio ~prices ?(sectors = []) () =
 
 (* ---- Position sizing ---- *)
 
-let compute_position_size ~config ~portfolio_value ~entry_price ~stop_price
-    ?(big_winner = false) () =
-  let risk_per_share = entry_price -. stop_price in
-  if Float.( <= ) risk_per_share 0.0 then
+(* G7 fix: cap shares so that position_value never exceeds the side's
+   max-exposure budget. Without this, a tight stop (small risk_per_share)
+   relative to dollar_risk produces an unbounded share count, allowing single
+   positions whose notional dwarfs portfolio_value (observed: ABBV short at 124%
+   of $1M starting portfolio, sp500-2019-2023 rerun 2026-04-30). *)
+let _max_shares_by_exposure ~config ~side ~portfolio_value ~entry_price =
+  let max_pct =
+    match side with
+    | `Long -> config.max_long_exposure_pct
+    | `Short -> config.max_short_exposure_pct
+  in
+  let max_position_value = portfolio_value *. max_pct in
+  if Float.( <= ) entry_price 0.0 then Int.max_value
+  else Int.of_float (Float.round_down (max_position_value /. entry_price))
+
+let compute_position_size ~config ~portfolio_value ~side ~entry_price
+    ~stop_price ?(big_winner = false) () =
+  (* Risk-per-share is the absolute distance between entry and stop. The
+     direction is determined by [side]: for [Long] the stop must be below
+     entry; for [Short] the stop must be above entry. If the stop is on the
+     wrong side or equal to entry, [|entry - stop| = 0] (or the stop fails
+     the directional check) and we return 0 shares. *)
+  let stop_on_correct_side =
+    match side with
+    | `Long -> Float.( < ) stop_price entry_price
+    | `Short -> Float.( > ) stop_price entry_price
+  in
+  let risk_per_share = Float.abs (entry_price -. stop_price) in
+  if (not stop_on_correct_side) || Float.( <= ) risk_per_share 0.0 then
     { shares = 0; position_value = 0.0; position_pct = 0.0; risk_amount = 0.0 }
   else
     let base_risk_pct = config.risk_per_trade_pct in
@@ -137,9 +162,13 @@ let compute_position_size ~config ~portfolio_value ~entry_price ~stop_price
       else base_risk_pct
     in
     let dollar_risk = portfolio_value *. effective_risk_pct in
-    let shares =
+    let risk_based_shares =
       Int.of_float (Float.round_down (dollar_risk /. risk_per_share))
     in
+    let exposure_capped_shares =
+      _max_shares_by_exposure ~config ~side ~portfolio_value ~entry_price
+    in
+    let shares = Int.min risk_based_shares exposure_capped_shares in
     let position_value = Float.of_int shares *. entry_price in
     let position_pct =
       if Float.( <= ) portfolio_value 0.0 then 0.0

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
@@ -145,26 +145,48 @@ val default_config : config
 val compute_position_size :
   config:config ->
   portfolio_value:float ->
+  side:[ `Long | `Short ] ->
   entry_price:float ->
   stop_price:float ->
   ?big_winner:bool ->
   unit ->
   sizing_result
-(** Compute position size using fixed-risk sizing.
+(** Compute position size using fixed-risk sizing, capped by exposure limits.
 
-    Formula: shares = floor((portfolio_value * risk_pct) / (entry - stop))
+    Two formulas applied in series:
+    + Risk-based: shares_risk = floor((portfolio_value * risk_pct) / |entry -
+      stop|)
+    + Exposure-capped: shares_max = floor(portfolio_value * max_exposure_pct /
+      entry_price), where max_exposure_pct is [max_long_exposure_pct] for [Long]
+      and [max_short_exposure_pct] for [Short].
 
-    The stop must be strictly below the entry price (long) or above (short). If
-    stop >= entry (which would be invalid), returns 0 shares.
+    Final share count is the minimum of the two. The exposure cap prevents tight
+    stops (small [|entry - stop|]) from producing positions whose notional
+    exceeds the configured per-side budget — a sizing pathology observed in the
+    sp500-2019-2023 rerun where shorts opened at 124% of portfolio value (ABBV
+    2019-02-01).
+
+    Pass [entry_price] and [stop_price] in their natural sense — entry is the
+    real entry price and stop is the real stop level. The function checks the
+    direction against [side]:
+    - [Long]: requires [stop_price < entry_price]
+    - [Short]: requires [stop_price > entry_price]
+
+    If the stop is on the wrong side or equal to entry, returns 0 shares.
 
     @param config Risk configuration
-    @param portfolio_value Total portfolio value for risk calculation
+    @param portfolio_value Total portfolio value for risk + exposure calculation
+    @param side
+      [`Long] uses [max_long_exposure_pct]; [`Short] uses
+      [max_short_exposure_pct]
     @param entry_price Price at which to enter the position
     @param stop_price Stop-loss price for the position
     @param big_winner
-      If [true], scales position size by [config.big_winner_multiplier]. Use for
-      high-conviction setups — Stage 2 breakouts with strong volume and relative
-      strength — where you want to commit more capital. (default: false) *)
+      If [true], scales the risk-based share count by
+      [config.big_winner_multiplier]. The exposure cap still applies to the
+      final result. Use for high-conviction setups — Stage 2 breakouts with
+      strong volume and relative strength — where you want to commit more
+      capital. (default: false) *)
 
 (** {1 Limit Checks} *)
 

--- a/trading/trading/weinstein/portfolio_risk/test/test_portfolio_risk.ml
+++ b/trading/trading/weinstein/portfolio_risk/test/test_portfolio_risk.ml
@@ -138,7 +138,7 @@ let test_snapshot_of_portfolio _ =
 let test_position_size_basic _ =
   let result =
     compute_position_size ~config:default_config ~portfolio_value:100000.0
-      ~entry_price:50.0 ~stop_price:45.0 ()
+      ~side:`Long ~entry_price:50.0 ~stop_price:45.0 ()
   in
   (* risk = 1000, risk_per_share = 5, shares = 200, position_value = 10000 *)
   assert_that result
@@ -149,7 +149,7 @@ let test_position_size_basic _ =
 let test_position_size_rounds_down _ =
   let result =
     compute_position_size ~config:default_config ~portfolio_value:100000.0
-      ~entry_price:47.0 ~stop_price:44.50 ()
+      ~side:`Long ~entry_price:47.0 ~stop_price:44.50 ()
   in
   (* risk = 1000, risk_per_share = 2.5, shares = floor(400) = 400 *)
   assert_that result
@@ -159,7 +159,7 @@ let test_position_size_rounds_down _ =
 let test_position_size_invalid_stop _ =
   let result =
     compute_position_size ~config:default_config ~portfolio_value:100000.0
-      ~entry_price:50.0 ~stop_price:50.0 ()
+      ~side:`Long ~entry_price:50.0 ~stop_price:50.0 ()
   in
   assert_that result
     (match_sizing ~shares:(equal_to 0) ~position_value:(float_equal 0.0)
@@ -168,12 +168,87 @@ let test_position_size_invalid_stop _ =
 let test_position_size_big_winner _ =
   let result =
     compute_position_size ~config:default_config ~portfolio_value:100000.0
-      ~entry_price:50.0 ~stop_price:45.0 ~big_winner:true ()
+      ~side:`Long ~entry_price:50.0 ~stop_price:45.0 ~big_winner:true ()
   in
   (* risk = 1500 (1% * 1.5x), risk_per_share = 5, shares = 300 *)
   assert_that result
     (match_sizing ~shares:(equal_to 300) ~position_value:__ ~position_pct:__
        ~risk_amount:__)
+
+(* G7 regression — short with very tight stop must not size to >100% of
+   portfolio. Pre-fix: risk-budget formula alone produces 12,191 shares for a
+   $1M portfolio at risk_pct=0.01 with 0.82 risk_per_share → $1.238M position
+   (124% of portfolio). Post-fix: capped by max_short_exposure_pct = 0.30. *)
+let test_position_size_short_capped_by_max_short_exposure _ =
+  let result =
+    compute_position_size ~config:default_config ~portfolio_value:1_000_000.0
+      ~side:`Short ~entry_price:101.59 ~stop_price:102.41 ()
+  in
+  (* The risk-only formula would produce ~12,195 shares ($1.238M position).
+     With max_short_exposure_pct = 0.30, max position_value = $300K →
+     max shares = floor($300K / $101.59) = 2,953. *)
+  assert_that result
+    (all_of
+       [
+         field (fun (s : sizing) -> s.shares) (equal_to 2953);
+         field
+           (fun (s : sizing) -> s.position_value)
+           (le (module Float_ord) 300_000.0);
+         field (fun (s : sizing) -> s.position_pct) (le (module Float_ord) 0.30);
+       ])
+
+(* Symmetric long-side check: a long with a very tight stop must not exceed
+   max_long_exposure_pct (default 0.90). *)
+let test_position_size_long_capped_by_max_long_exposure _ =
+  let result =
+    compute_position_size ~config:default_config ~portfolio_value:1_000_000.0
+      ~side:`Long ~entry_price:100.0 ~stop_price:99.0 ()
+  in
+  (* Risk-only formula: dollar_risk = $10K, risk_per_share = $1 → 10,000 shares
+     × $100 = $1,000,000 position (100% of portfolio). With max_long_exposure_pct
+     = 0.90, max position_value = $900K → max shares = 9,000. *)
+  assert_that result
+    (all_of
+       [
+         field (fun (s : sizing) -> s.shares) (equal_to 9000);
+         field
+           (fun (s : sizing) -> s.position_value)
+           (le (module Float_ord) 900_000.0);
+         field (fun (s : sizing) -> s.position_pct) (le (module Float_ord) 0.90);
+       ])
+
+(* Cap is configurable: tightening max_short_exposure_pct further reduces the
+   sized shares proportionally. *)
+let test_position_size_short_cap_is_configurable _ =
+  let config = { default_config with max_short_exposure_pct = 0.10 } in
+  let result =
+    compute_position_size ~config ~portfolio_value:1_000_000.0 ~side:`Short
+      ~entry_price:100.0 ~stop_price:101.0 ()
+  in
+  (* max position_value = 0.10 * $1M = $100K → max shares = 1,000. *)
+  assert_that result
+    (all_of
+       [
+         field (fun (s : sizing) -> s.shares) (equal_to 1000);
+         field (fun (s : sizing) -> s.position_pct) (le (module Float_ord) 0.10);
+       ])
+
+(* When the risk-based sizing is already below the exposure cap, the cap is
+   inert and the original sizing stands. *)
+let test_position_size_below_cap_unaffected _ =
+  let result =
+    compute_position_size ~config:default_config ~portfolio_value:100_000.0
+      ~side:`Long ~entry_price:50.0 ~stop_price:45.0 ()
+  in
+  (* shares = 200, position_value = $10K = 10% of portfolio — well below
+     max_long_exposure_pct = 0.90, so cap is inert. *)
+  assert_that result
+    (all_of
+       [
+         field (fun (s : sizing) -> s.shares) (equal_to 200);
+         field (fun (s : sizing) -> s.position_value) (float_equal 10_000.0);
+         field (fun (s : sizing) -> s.risk_amount) (float_equal 1000.0);
+       ])
 
 (* ---- Limit check tests ---- *)
 
@@ -342,6 +417,14 @@ let suite =
          "position_size_rounds_down" >:: test_position_size_rounds_down;
          "position_size_invalid_stop" >:: test_position_size_invalid_stop;
          "position_size_big_winner" >:: test_position_size_big_winner;
+         "position_size_short_capped_by_max_short_exposure"
+         >:: test_position_size_short_capped_by_max_short_exposure;
+         "position_size_long_capped_by_max_long_exposure"
+         >:: test_position_size_long_capped_by_max_long_exposure;
+         "position_size_short_cap_is_configurable"
+         >:: test_position_size_short_cap_is_configurable;
+         "position_size_below_cap_unaffected"
+         >:: test_position_size_below_cap_unaffected;
          "check_limits_ok" >:: test_check_limits_ok;
          "check_limits_max_positions" >:: test_check_limits_max_positions;
          "check_limits_long_exposure" >:: test_check_limits_long_exposure;

--- a/trading/trading/weinstein/portfolio_risk/test/test_portfolio_risk_e2e.ml
+++ b/trading/trading/weinstein/portfolio_risk/test/test_portfolio_risk_e2e.ml
@@ -349,7 +349,7 @@ let test_position_sizing_respects_risk_budget _ =
     List.map cases ~f:(fun (entry, stop) ->
         let result =
           Portfolio_risk.compute_position_size ~config ~portfolio_value
-            ~entry_price:entry ~stop_price:stop ()
+            ~side:`Long ~entry_price:entry ~stop_price:stop ()
         in
         result.risk_amount /. portfolio_value)
   in

--- a/trading/trading/weinstein/strategy/lib/entry_audit_capture.ml
+++ b/trading/trading/weinstein/strategy/lib/entry_audit_capture.ml
@@ -33,27 +33,17 @@ let gen_position_id symbol =
   Int.incr _position_counter;
   Printf.sprintf "%s-wein-%d" symbol !_position_counter
 
-(** Normalise (entry, stop) to the order [Portfolio_risk.compute_position_size]
-    expects: entry first, stop below. For longs that's the identity (stop <
-    entry); for shorts we swap (stop > entry → [max, min]). *)
-let _normalised_entry_stop_for_sizing (cand : Screener.scored_candidate) =
-  let open Trading_base.Types in
-  match cand.side with
-  | Long -> (cand.suggested_entry, cand.suggested_stop)
-  | Short ->
-      ( Float.max cand.suggested_entry cand.suggested_stop,
-        Float.min cand.suggested_entry cand.suggested_stop )
+let _sizing_side_of_cand_side (side : Trading_base.Types.position_side) =
+  match side with Long -> `Long | Short -> `Short
 
 let make_entry_transition ~portfolio_risk_config ~stops_config
     ~initial_stop_buffer ~stop_states ~bar_reader ~portfolio_value ~current_date
     (cand : Screener.scored_candidate) =
-  let entry_for_sizing, stop_for_sizing =
-    _normalised_entry_stop_for_sizing cand
-  in
   let sizing =
     Portfolio_risk.compute_position_size ~config:portfolio_risk_config
-      ~portfolio_value ~entry_price:entry_for_sizing ~stop_price:stop_for_sizing
-      ()
+      ~portfolio_value
+      ~side:(_sizing_side_of_cand_side cand.side)
+      ~entry_price:cand.suggested_entry ~stop_price:cand.suggested_stop ()
   in
   if sizing.shares = 0 then None
   else


### PR DESCRIPTION
## What it does

Closes G7 (position sizing for shorts produces oversized entries) per
`dev/notes/sp500-shortside-rerun-blocked-g7-2026-04-30.md`.

The risk-budget formula `shares = floor(dollar_risk / |entry - stop|)` was
unbounded — when `|entry - stop|` is small relative to `dollar_risk`, the
share count explodes. Caps existed in `Portfolio_risk.config`
(`max_long_exposure_pct = 0.90`, `max_short_exposure_pct = 0.30`) but
were only referenced by `check_limits`, which has **zero non-test
callers** — the live entry pipeline runs `compute_position_size` and
never `check_limits`.

## Before / after

ABBV-shape scenario: $1M portfolio, $101.59 entry, $102.41 stop (8 cents
above entry — typical Weinstein short stop), `side=Short`,
`risk_per_trade_pct = 0.01` (default).

| | shares | position_value | % of portfolio |
|---|---:|---:|---:|
| Before (main) | 12,195 | \$1,238,790 | **124% — oversized** |
| After (this PR) | 2,953 | \$300,096 | **30.0% (exactly the cap)** |

The 30% cap matches `default_config.max_short_exposure_pct`. Symmetric
long-side cap pinned in a separate test ($1M portfolio + tight stop +
side=Long → ≤90% of portfolio).

## Fix surface

- `Portfolio_risk.compute_position_size`: added required `~side`
  parameter; final share count = `min(risk_based, exposure_capped)`.
- `Portfolio_risk.compute_position_size`: absorbed the Long/Short
  entry-stop swap (formerly in
  `Entry_audit_capture._normalised_entry_stop_for_sizing`) — uses
  `Float.abs (entry - stop)` + side-direction validation. Callers now
  pass natural entry/stop.
- `Entry_audit_capture.make_entry_transition`: removed the swap helper;
  passes `cand.suggested_entry` and `cand.suggested_stop` directly.

No core-module changes (Portfolio/Orders/Position/Strategy/Engine).
Scoped entirely to `weinstein/portfolio_risk/` and one caller-side
update in `weinstein/strategy/`.

## Test coverage

5 new in `test_portfolio_risk.ml`:
- `position_size_short_capped_by_max_short_exposure` — the ABBV regression
- `position_size_long_capped_by_max_long_exposure` — symmetric long
- `position_size_short_cap_is_configurable` — tightening to 10%
- `position_size_below_cap_unaffected` — original sizing preserved when below cap

Existing 4 long-side tests updated for the new required `~side` arg.
`test_portfolio_risk_e2e.ml` also updated. All 50 tests pass:
- `weinstein/portfolio_risk/test/`: 26+20+4 = 50 OK
- No regressions in `weinstein/strategy/test/`.

## Test plan

- [x] `dune build && dune build @fmt && dune runtest weinstein/portfolio_risk/test/` passes
- [x] ABBV-shape regression test: 2,953 shares (30%-cap) instead of 12,195 (124%)
- [x] Long-side cap test: ≤90% of portfolio
- [x] Below-cap test: risk-based sizing preserved
- [ ] Re-enable shorts on sp500-2019-2023 (next step, separate session)
- [ ] Measure force-liquidation count drop on the rerun (the validation signal)

## Re-enabling shorts on sp500

Not done in this PR — left as the next step. The
`enable_short_side = false` override in
`goldens-sp500/sp500-2019-2023.sexp` stays in place. Closing G7 means
`compute_position_size` no longer produces oversized entries; whether
that drops the 910 force-liquidation count to single digits (and
produces a defensible short-side baseline) is what the rerun measures.

## Authority

- `docs/design/weinstein-book-reference.md` §Short-Selling Rules
- `dev/notes/short-side-gaps-2026-04-29.md` §G7 (this PR updates the
  section to mark DONE)
- `dev/notes/sp500-shortside-rerun-blocked-g7-2026-04-30.md` (the
  finding doc, landed via #701)

🤖 Generated with [Claude Code](https://claude.com/claude-code)