### PR TITLE
fix(portfolio_view): G8 — shorts subtract from portfolio_value (sign convention)

### DIFF
--- a/dev/notes/short-side-gaps-2026-04-29.md
+++ b/dev/notes/short-side-gaps-2026-04-29.md
@@ -320,3 +320,41 @@ place. G7 closing means `compute_position_size` no longer produces
 oversized entries; whether that's *sufficient* to drop the force-
 liquidation count to single digits (and produce a defensible short-
 side baseline) is what the rerun will measure.
+
+## G8 — `Portfolio_view.portfolio_value` ignores `pos.side`
+
+Surfaced 2026-04-30 by qc-behavioral on PR #702 (G7 fix).
+
+- Symptom: `Portfolio_view.portfolio_value` summed `quantity *.
+  close_price` for every `Holding` regardless of `pos.side`. Since
+  `Position.t.state.Holding.quantity` is unsigned and the long/short
+  direction lives in `pos.side`, short positions inflated
+  `portfolio_value` instead of subtracting from it.
+- Impact: any consumer reading
+  `Trading_strategy.Portfolio_view.portfolio_value` saw paper-rich
+  portfolios on bear-side trades. Sizing / risk / metrics that key off
+  this number all read inflated. Direct caller in the live entry path:
+  `Weinstein_strategy._build_entry_inputs` (uses portfolio_value to
+  compute target dollar exposure) — short candidates were sized as if
+  the short already counted as an asset twice over.
+- Leaking surface: `trading/trading/strategy/lib/portfolio_view.ml`,
+  `_holding_market_value` (single function — the strategy-side mark-to-
+  market path).
+- Not affected: `trading/trading/portfolio/lib/calculations.ml`. That
+  module's `market_value` / `unrealized_pnl` use the signed-quantity
+  convention from `lots.quantity` (negative for shorts), so it already
+  signs correctly. The bug was strictly the strategy-side
+  `Portfolio_view`, which carries the `Position.t` shape (unsigned
+  `quantity` + separate `side`).
+
+**DONE — see PR `fix/g8-portfolio-view-shorts`** (2026-04-30):
+`_holding_market_value` now matches on `pos.side` and contributes
+`+quantity * close_price` for `Long` and `-quantity * close_price` for
+`Short`. The fix is strategy-agnostic — works for any STRATEGY that
+returns long+short positions, no Weinstein-specific logic. Three new
+tests in `test_portfolio_view.ml` (short at profit, short at loss,
+mixed long+short) plus the existing two long-side tests, all explicit
+numeric assertions. No existing tests required updates: pre-fix the
+weinstein-strategy / simulation suites passed because their fixtures
+either used long-only positions or did not pin `portfolio_value` at a
+specific number.

--- a/trading/trading/strategy/lib/portfolio_view.ml
+++ b/trading/trading/strategy/lib/portfolio_view.ml
@@ -2,11 +2,24 @@ open Core
 
 type t = { cash : float; positions : Position.t String.Map.t }
 
+(* Mark-to-market contribution of a single position to portfolio value.
+
+   [Position.t.state.Holding.quantity] is unsigned (always positive); the
+   long/short direction lives in [pos.side]. Long holdings contribute their
+   market value as an asset; short holdings contribute the negative of their
+   current market value, since the position is a liability — shares owed back
+   at the current price. Cash already reflects the proceeds credited at short
+   entry, so subtracting the current liability is what makes
+   [portfolio_value] track P&L correctly on shorts. *)
 let _holding_market_value (pos : Position.t) ~get_price =
   match pos.state with
   | Holding { quantity; _ } -> (
       match get_price pos.symbol with
-      | Some (bar : Types.Daily_price.t) -> quantity *. bar.close_price
+      | Some (bar : Types.Daily_price.t) ->
+          let signed_qty =
+            match pos.side with Long -> quantity | Short -> -.quantity
+          in
+          signed_qty *. bar.close_price
       | None -> 0.0)
   | _ -> 0.0
 

--- a/trading/trading/strategy/lib/portfolio_view.mli
+++ b/trading/trading/strategy/lib/portfolio_view.mli
@@ -12,5 +12,9 @@ type t = {
 
 val portfolio_value :
   t -> get_price:(string -> Types.Daily_price.t option) -> float
-(** Total portfolio value: [cash] + mark-to-market of all [Holding] positions.
-    Positions not in [Holding] state or without a current price are excluded. *)
+(** Total portfolio value: [cash] + signed mark-to-market of all [Holding]
+    positions. Long holdings contribute [+quantity * close_price]; shorts
+    contribute [-quantity * close_price] (the buy-back liability — cash already
+    reflects proceeds credited at short entry, so subtracting the current
+    liability tracks short P&L correctly). Positions not in [Holding] state or
+    without a current price are excluded. *)

--- a/trading/trading/strategy/test/test_portfolio_view.ml
+++ b/trading/trading/strategy/test/test_portfolio_view.ml
@@ -3,11 +3,11 @@ open Core
 open Matchers
 open Trading_strategy
 
-let _make_holding ~id ~symbol ~quantity ~entry_price =
+let _make_holding ~id ~symbol ~side ~quantity ~entry_price =
   {
     Position.id;
     symbol;
-    side = Long;
+    side;
     entry_reasoning = ManualDecision { description = "test" };
     exit_reason = None;
     state =
@@ -47,9 +47,10 @@ let test_portfolio_value_cash_only _ =
     (Portfolio_view.portfolio_value pv ~get_price)
     (float_equal 100000.0)
 
-let test_portfolio_value_with_positions _ =
+let test_portfolio_value_with_long_position _ =
   let aapl =
-    _make_holding ~id:"AAPL-1" ~symbol:"AAPL" ~quantity:100.0 ~entry_price:150.0
+    _make_holding ~id:"AAPL-1" ~symbol:"AAPL" ~side:Long ~quantity:100.0
+      ~entry_price:150.0
   in
   let pv : Portfolio_view.t =
     { cash = 50000.0; positions = String.Map.singleton "AAPL-1" aapl }
@@ -64,7 +65,8 @@ let test_portfolio_value_with_positions _ =
 
 let test_portfolio_value_no_price_excludes _ =
   let aapl =
-    _make_holding ~id:"AAPL-1" ~symbol:"AAPL" ~quantity:100.0 ~entry_price:150.0
+    _make_holding ~id:"AAPL-1" ~symbol:"AAPL" ~side:Long ~quantity:100.0
+      ~entry_price:150.0
   in
   let pv : Portfolio_view.t =
     { cash = 50000.0; positions = String.Map.singleton "AAPL-1" aapl }
@@ -74,14 +76,86 @@ let test_portfolio_value_no_price_excludes _ =
     (Portfolio_view.portfolio_value pv ~get_price)
     (float_equal 50000.0)
 
+(* G8 — short positions must subtract from portfolio value, not add.
+
+   Setup: $1M cash already reflects the short proceeds (entry $100 * 100 sh =
+   $10K credited, so cash = $1.01M post-entry under broker model). At current
+   price $90 (short profit), the liability to buy back is 100 * $90 = $9K.
+
+   Correct portfolio_value = cash - liability = $1,010,000 - $9,000 =
+   $1,001,000. *)
+let test_portfolio_value_short_position_at_profit _ =
+  let xyz =
+    _make_holding ~id:"XYZ-1" ~symbol:"XYZ" ~side:Short ~quantity:100.0
+      ~entry_price:100.0
+  in
+  let pv : Portfolio_view.t =
+    { cash = 1_010_000.0; positions = String.Map.singleton "XYZ-1" xyz }
+  in
+  let get_price symbol =
+    if String.equal symbol "XYZ" then Some (_make_price 90.0) else None
+  in
+  assert_that
+    (Portfolio_view.portfolio_value pv ~get_price)
+    (float_equal 1_001_000.0)
+
+(* G8 — short at a loss: cash $1.01M (post-entry), current $110 → liability
+   $11K. portfolio_value = $1,010,000 - $11,000 = $999,000. *)
+let test_portfolio_value_short_position_at_loss _ =
+  let xyz =
+    _make_holding ~id:"XYZ-1" ~symbol:"XYZ" ~side:Short ~quantity:100.0
+      ~entry_price:100.0
+  in
+  let pv : Portfolio_view.t =
+    { cash = 1_010_000.0; positions = String.Map.singleton "XYZ-1" xyz }
+  in
+  let get_price symbol =
+    if String.equal symbol "XYZ" then Some (_make_price 110.0) else None
+  in
+  assert_that
+    (Portfolio_view.portfolio_value pv ~get_price)
+    (float_equal 999_000.0)
+
+(* G8 — mixed long + short. Long AAPL 100 sh entry $150, current $160 → +$16K
+   asset. Short XYZ 100 sh entry $100, current $110 → -$11K liability. Cash
+   $50K. Total = $50K + $16K - $11K = $55K. *)
+let test_portfolio_value_mixed_long_and_short _ =
+  let aapl =
+    _make_holding ~id:"AAPL-1" ~symbol:"AAPL" ~side:Long ~quantity:100.0
+      ~entry_price:150.0
+  in
+  let xyz =
+    _make_holding ~id:"XYZ-1" ~symbol:"XYZ" ~side:Short ~quantity:100.0
+      ~entry_price:100.0
+  in
+  let positions =
+    String.Map.of_alist_exn [ ("AAPL-1", aapl); ("XYZ-1", xyz) ]
+  in
+  let pv : Portfolio_view.t = { cash = 50_000.0; positions } in
+  let get_price symbol =
+    match symbol with
+    | "AAPL" -> Some (_make_price 160.0)
+    | "XYZ" -> Some (_make_price 110.0)
+    | _ -> None
+  in
+  assert_that
+    (Portfolio_view.portfolio_value pv ~get_price)
+    (float_equal 55_000.0)
+
 let suite =
   "portfolio_view"
   >::: [
          "portfolio_value_cash_only" >:: test_portfolio_value_cash_only;
-         "portfolio_value_with_positions"
-         >:: test_portfolio_value_with_positions;
+         "portfolio_value_with_long_position"
+         >:: test_portfolio_value_with_long_position;
          "portfolio_value_no_price_excludes"
          >:: test_portfolio_value_no_price_excludes;
+         "portfolio_value_short_position_at_profit"
+         >:: test_portfolio_value_short_position_at_profit;
+         "portfolio_value_short_position_at_loss"
+         >:: test_portfolio_value_short_position_at_loss;
+         "portfolio_value_mixed_long_and_short"
+         >:: test_portfolio_value_mixed_long_and_short;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

`Portfolio_view._holding_market_value` ignored `pos.side`, so shorts inflated `portfolio_value` instead of subtracting from it. `Position.t.state.Holding.quantity` is unsigned; the long/short direction lives in `pos.side`. Long holdings contribute `+quantity * close_price` (asset); shorts contribute `-quantity * close_price` (buy-back liability — cash already reflects proceeds credited at short entry).

Surfaced 2026-04-30 by qc-behavioral on the G7 fix (PR #702). See `dev/notes/short-side-gaps-2026-04-29.md` §G8 (added in this PR).

## Before / after

`$1M cash + short of 100 sh @ $100, current $110` (cash actually $1.01M post-entry):

- **Before**: `portfolio_value = 1,010,000 + 100*110 = 1,021,000` (inflated by $22K — appears profitable when the short is at a $1K loss)
- **After**: `portfolio_value = 1,010,000 - 100*110 = 999,000` (correctly $1K below entry-day value)

## A1 FLAG

Fix is in `trading/trading/strategy/lib/portfolio_view.ml`, which is on the qc-structural A1 watch-list (core strategy module). The change is **strategy-agnostic**: it pattern-matches on `pos.side` (`Long | Short`) — no Weinstein-specific logic. It generalizes to any STRATEGY that produces long+short positions.

## Scope clarification — only `Portfolio_view` was buggy

Audited the parallel module `trading/trading/portfolio/lib/calculations.ml`. That module's `market_value` / `unrealized_pnl` use a **signed-quantity** convention from `lots.quantity` (negative for shorts), so it already signs correctly. The G3 unrealized-P&L accumulator (`Portfolio.mark_to_market` → `Calculations.unrealized_pnl`) is also correct. The bug was strictly the strategy-side `Portfolio_view`, which carries the `Position.t` shape (unsigned `quantity` + separate `side` discriminator).

## Test coverage

Three new short-side tests in `test_portfolio_view.ml`, all explicit numeric assertions per `.claude/rules/test-patterns.md`:

- `portfolio_value_short_position_at_profit`: short XYZ 100 sh @ $100, current $90 → expect $1,001,000 (verified failing pre-fix: returned $1,019,000).
- `portfolio_value_short_position_at_loss`: short XYZ 100 sh @ $100, current $110 → expect $999,000 (verified failing pre-fix: returned $1,021,000).
- `portfolio_value_mixed_long_and_short`: long AAPL @ profit + short XYZ @ loss → expect $55,000 (verified failing pre-fix: returned $77,000).

Existing two long-side tests (`cash_only`, `with_long_position`, `no_price_excludes`) updated to thread `~side:Long` through the helper but otherwise unchanged. No fixture updates required in `test_portfolio.ml` or downstream weinstein-strategy / simulation suites — those either use long-only positions or do not pin `portfolio_value` at a specific number.

## Test plan

- [x] `dune build` passes
- [x] `dune runtest trading/strategy/` passes (6/6 — 3 long, 3 new short)
- [x] `dune runtest trading/portfolio/` passes (no regressions)
- [x] `dune runtest trading/weinstein/` passes (no regressions in strategy / portfolio_risk / stops_runner consumers)
- [x] `dune runtest trading/simulation/` passes (no regressions)
- [x] `dune fmt` clean
- [x] Pre-push isolation check: branch contains only this single commit, files match plan exactly

## Related

- G7 PR #702 (`fix/g7-short-position-sizing`) — sized shorts at 30% cap; this PR ensures the portfolio_value those caps multiply against is itself accurate.
- `dev/notes/short-side-gaps-2026-04-29.md` §G8 — added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)