### PR TITLE
fix(weinstein_stops): trailing-state phantom-cycle on monotonically declining shorts

### DIFF
--- a/dev/notes/short-side-gaps-2026-04-29.md
+++ b/dev/notes/short-side-gaps-2026-04-29.md
@@ -106,6 +106,30 @@ logic operate on correct stage inputs. Re-evaluate after the
 sp500-baseline rerun whether the runner-side fix alone is sufficient
 or whether the trailing-state phantom needs follow-up work.
 
+**DONE — see PR `fix/trailing-phantom-cycle`** (2026-04-30): added a
+`correction_observed_since_reset : bool` field to the `Trailing` state
+constructor. The cycle gate in `_completed_cycle_stop` now requires
+`correction_count = 0 || correction_observed_since_reset`: the first
+cycle is allowed to fire on the entry-bar-extreme seed (preserves the
+long-side `stage2_trailing_stop_raised_phase_a` contract), and
+subsequent cycles after a `_raised_trailing` reset require a real
+counter-move bar — `bar.low ≤ last_correction_extreme` for longs or
+`bar.high ≥ last_correction_extreme` for shorts — to refresh the
+anchor before the cycle math can re-fire. Pre-fix on a 10-bar
+monotonic short decline the stop drops from $103.125 (entry stop) to
+$90.125 (below entry close $99) via two phantom cycles; post-fix the
+stop drops to $101.125 on the seed-anchored cycle 1 and holds there
+across the remaining decline (count remains 1, second phantom is
+rejected). New regression scenarios in
+`trading/trading/weinstein/stops/test/regression_test.ml`:
+`short_monotonic_decline_no_phantom_cycle` and the symmetric
+`long_monotonic_advance_no_phantom_cycle`. Long-side
+`stage2_trailing_stop_raised_phase_a` and `_phase_b` continue to pass
+unchanged. `stage3_tightening` updated to set
+`correction_observed_since_reset = true` (it constructs an initial
+state that explicitly models a real prior pullback). Round-number
+nudge and `_advance_tracking` math are unchanged.
+
 ### G2 — `Metrics.extract_round_trips` is blind to shorts
 
 Currently pairs Buy → Sell only. Sell → Buy short round-trips are

--- a/trading/trading/weinstein/stops/lib/stop_split_adjust.ml
+++ b/trading/trading/weinstein/stops/lib/stop_split_adjust.ml
@@ -23,6 +23,7 @@ let scale ~factor state =
         last_trend_extreme;
         ma_at_last_adjustment;
         correction_count;
+        correction_observed_since_reset;
       } ->
       Trailing
         {
@@ -31,6 +32,7 @@ let scale ~factor state =
           last_trend_extreme = last_trend_extreme /. factor;
           ma_at_last_adjustment = ma_at_last_adjustment /. factor;
           correction_count;
+          correction_observed_since_reset;
         }
   | Tightened { stop_level; last_correction_extreme; reason } ->
       Tightened

--- a/trading/trading/weinstein/stops/lib/stop_types.ml
+++ b/trading/trading/weinstein/stops/lib/stop_types.ml
@@ -12,6 +12,7 @@ type stop_state =
       last_trend_extreme : float;
       ma_at_last_adjustment : float;
       correction_count : int;
+      correction_observed_since_reset : bool;
     }
   | Tightened of {
       stop_level : float;

--- a/trading/trading/weinstein/stops/lib/stop_types.mli
+++ b/trading/trading/weinstein/stops/lib/stop_types.mli
@@ -19,6 +19,21 @@ type stop_state =
       ma_at_last_adjustment : float;
           (** 30-week MA value when stop was last adjusted *)
       correction_count : int;  (** Number of correction cycles completed *)
+      correction_observed_since_reset : bool;
+          (** Whether a real counter-move bar has touched/breached the running
+              [last_correction_extreme] since the last cycle reset (or, for
+              [correction_count = 0], since the [Initial → Trailing]
+              transition).
+
+              Used to gate phantom cycles after a cycle reset: when the
+              correction extreme is reset to [bar.close_price] on cycle
+              completion, monotonic price action in the trend's favour can
+              accumulate a stale [last_correction_extreme] that the cycle math
+              would otherwise pair with a fresh trend extreme to phantom-fire a
+              new cycle. The first cycle (count = 0) is allowed to fire on the
+              entry-bar-extreme seed regardless of this flag — that pre-entry
+              extreme represents the breakout/breakdown reference point, which
+              is a legitimate Weinstein anchor (book §Stop-Loss Rules). *)
     }
   | Tightened of {
       stop_level : float;

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.ml
@@ -209,7 +209,14 @@ let _to_tightened ~config ~side ~stop_level ~correction_extreme ~reason =
       },
     Entered_tightening { reason } )
 
-(* Transitions from Initial to Trailing, seeding tracking fields from current bar. *)
+(* Transitions from Initial to Trailing, seeding tracking fields from current bar.
+
+   The seeded [last_correction_extreme] (entry-bar low for longs, entry-bar high
+   for shorts) represents the breakout/breakdown reference. It is treated as a
+   legitimate first-cycle anchor — see the [correction_count = 0] gate in
+   [_completed_cycle_stop]. The [correction_observed_since_reset] flag starts
+   [false]: it only becomes load-bearing after the first cycle, when the reset
+   value (close_price) needs a real touch to be re-validated. *)
 let _to_trailing ~side ~ma_value ~stop_level ~bar =
   Trailing
     {
@@ -218,6 +225,7 @@ let _to_trailing ~side ~ma_value ~stop_level ~bar =
       last_trend_extreme = bar.Types.Daily_price.close_price;
       ma_at_last_adjustment = ma_value;
       correction_count = 0;
+      correction_observed_since_reset = false;
     }
 
 (* ---- Shared stop-hit and tighten dispatch ---- *)
@@ -261,6 +269,19 @@ let _update_initial ~config ~side ~state ~current_bar ~ma_value ~ma_direction
 
 (* ---- Correction cycle helpers ---- *)
 
+(* Did the current bar's against-trend extreme reach (or breach) the running
+   correction extreme? This is the "real counter-move" predicate that gates
+   post-reset phantom cycles. For longs: bar.low must dip to or below the
+   running pullback low. For shorts: bar.high must rally to or above the
+   running counter-rally high. A bar that strictly stays beyond the extreme in
+   the trend's favour did not observe any counter-move and does not refresh the
+   correction anchor. *)
+let _is_correction_touch ~side ~last_correction_extreme ~bar =
+  let extreme = _bar_extreme ~side ~bar in
+  match side with
+  | Long -> Float.( <= ) extreme last_correction_extreme
+  | Short -> Float.( >= ) extreme last_correction_extreme
+
 (* Advance correction_extreme/trend_extreme tracking for one bar.
    Returns (new_trend_extreme, new_correction_extreme). *)
 let _advance_tracking ~side ~last_correction_extreme ~last_trend_extreme ~bar =
@@ -292,16 +313,31 @@ let _advance_tracking ~side ~last_correction_extreme ~last_trend_extreme ~bar =
    held above it." When the correction dips below the MA (common in a
    healthy Stage 2), the correction low is the binding constraint.  When
    the correction holds above the MA (shallow pullback), the MA is lower
-   and becomes the reference. Either way, the stop stays below BOTH. *)
+   and becomes the reference. Either way, the stop stays below BOTH.
+
+   Phantom-cycle guard: the cycle math operates on the running correction
+   extreme without any awareness of WHEN that extreme was last observed.
+   On a fresh [Trailing] state ([correction_count = 0]) the seed represents
+   a legitimate breakout/breakdown reference (book §Stop-Loss Rules) and
+   the cycle is allowed to fire on it. After [_raised_trailing] resets both
+   extremes to [close_price], a continuing trend in a direction that drives
+   trend_extreme past the reset close (rising for long → no problem, falling
+   for short → cycle math tries to phantom-fire) needs an actual counter-move
+   bar — [correction_observed_since_reset = true] — to refresh the anchor.
+   Without it, the stale reset value is rejected as a cycle anchor. *)
 let _completed_cycle_stop ~config ~side ~stop_level ~trend_extreme
-    ~correction_extreme ~ma_value ~bar =
+    ~correction_extreme ~correction_count ~correction_observed_since_reset
+    ~ma_value ~bar =
   let had_correction =
     _is_correction ~config ~side ~trend_extreme ~correction_extreme
   in
   let recovered =
     _is_recovery ~side ~close:bar.Types.Daily_price.close_price ~trend_extreme
   in
-  if had_correction && recovered then
+  let anchor_is_fresh =
+    correction_count = 0 || correction_observed_since_reset
+  in
+  if had_correction && recovered && anchor_is_fresh then
     (* Use whichever reference is more conservative: correction low or MA *)
     let effective_ref =
       match side with
@@ -317,7 +353,9 @@ let _completed_cycle_stop ~config ~side ~stop_level ~trend_extreme
 
 (* Build a Trailing state after a completed correction cycle.
    Both extremes reset to close_price so the next cycle starts fresh — no phantom
-   cycles from a prior correction low being reused against a continuing advance. *)
+   cycles from a prior correction low being reused against a continuing advance.
+   [correction_observed_since_reset] resets to [false]: the next cycle requires a
+   real counter-move bar before its anchor can be paired with an advanced trend. *)
 let _raised_trailing ~side:_ ~new_stop ~ma_value ~correction_count ~bar =
   Trailing
     {
@@ -326,13 +364,19 @@ let _raised_trailing ~side:_ ~new_stop ~ma_value ~correction_count ~bar =
       last_trend_extreme = bar.Types.Daily_price.close_price;
       ma_at_last_adjustment = ma_value;
       correction_count = correction_count + 1;
+      correction_observed_since_reset = false;
     }
 
 (* Advances tracking and adjusts stop if a correction cycle completed. *)
-let _raise_after_cycle ~config ~side ~ma_value ~correction_count ~stop_level
-    ~last_correction_extreme ~last_trend_extreme ~ma_at_last_adjustment ~bar =
+let _raise_after_cycle ~config ~side ~ma_value ~correction_count
+    ~correction_observed_since_reset ~stop_level ~last_correction_extreme
+    ~last_trend_extreme ~ma_at_last_adjustment ~bar =
   let new_trend_extreme, new_correction_extreme =
     _advance_tracking ~side ~last_correction_extreme ~last_trend_extreme ~bar
+  in
+  let new_observed =
+    correction_observed_since_reset
+    || _is_correction_touch ~side ~last_correction_extreme ~bar
   in
   let no_change =
     Trailing
@@ -342,12 +386,14 @@ let _raise_after_cycle ~config ~side ~ma_value ~correction_count ~stop_level
         last_trend_extreme = new_trend_extreme;
         ma_at_last_adjustment;
         correction_count;
+        correction_observed_since_reset = new_observed;
       }
   in
   match
     _completed_cycle_stop ~config ~side ~stop_level
       ~trend_extreme:last_trend_extreme
-      ~correction_extreme:new_correction_extreme ~ma_value ~bar
+      ~correction_extreme:new_correction_extreme ~correction_count
+      ~correction_observed_since_reset:new_observed ~ma_value ~bar
   with
   | None -> (no_change, No_change)
   | Some new_stop ->
@@ -365,15 +411,16 @@ let _raise_after_cycle ~config ~side ~ma_value ~correction_count ~stop_level
 (* Apply stop/tighten/cycle logic to a fully unpacked Trailing state. *)
 let _apply_trailing ~config ~side ~state ~bar ~ma_value ~stop_level
     ~last_correction_extreme ~last_trend_extreme ~ma_at_last_adjustment
-    ~correction_count ~ma_direction ~stage =
+    ~correction_count ~correction_observed_since_reset ~ma_direction ~stage =
   match
     _check_stop_or_tighten ~config ~side ~state ~bar
       ~correction_extreme:last_correction_extreme ~ma_direction ~stage
   with
   | Some result -> result
   | None ->
-      _raise_after_cycle ~config ~side ~ma_value ~correction_count ~stop_level
-        ~last_correction_extreme ~last_trend_extreme ~ma_at_last_adjustment ~bar
+      _raise_after_cycle ~config ~side ~ma_value ~correction_count
+        ~correction_observed_since_reset ~stop_level ~last_correction_extreme
+        ~last_trend_extreme ~ma_at_last_adjustment ~bar
 
 let _update_trailing ~config ~side ~state ~current_bar ~ma_value ~ma_direction
     ~stage =
@@ -386,10 +433,11 @@ let _update_trailing ~config ~side ~state ~current_bar ~ma_value ~ma_direction
         last_trend_extreme;
         ma_at_last_adjustment;
         correction_count;
+        correction_observed_since_reset;
       } ->
       _apply_trailing ~config ~side ~state ~bar ~ma_value ~stop_level
         ~last_correction_extreme ~last_trend_extreme ~ma_at_last_adjustment
-        ~correction_count ~ma_direction ~stage
+        ~correction_count ~correction_observed_since_reset ~ma_direction ~stage
   | _ -> (state, No_change)
 
 (* ---- Tightened ratchet ---- *)

--- a/trading/trading/weinstein/stops/test/regression_test.ml
+++ b/trading/trading/weinstein/stops/test/regression_test.ml
@@ -121,7 +121,10 @@ let stage2_trailing_stop_raised_phase_a _ =
 let stage2_trailing_stop_raised_phase_b _ =
   (* Start from the state left by phase A *)
   (* Initial state reflects what the fix produces after phase A: both extremes
-     reset to close_price=122 of the cycle-completion bar, not the bar's low. *)
+     reset to close_price=122 of the cycle-completion bar, not the bar's low.
+     [correction_observed_since_reset = false] mirrors what [_raised_trailing]
+     produces — the phase-B bars must touch the corr=122 anchor before cycle 3
+     can fire (bar 4 with low=122 provides that touch). *)
   let initial_state =
     Trailing
       {
@@ -130,6 +133,7 @@ let stage2_trailing_stop_raised_phase_b _ =
         last_trend_extreme = 122.0;
         ma_at_last_adjustment = 109.0;
         correction_count = 2;
+        correction_observed_since_reset = false;
       }
   in
   let steps =
@@ -169,6 +173,12 @@ let stage2_trailing_stop_raised_phase_b _ =
    - Bar 3 (c=129, Flat MA, Stage3): tightening fires, stop→126.72 *)
 
 let stage3_tightening _ =
+  (* [correction_observed_since_reset = true]: this initial state encodes a
+     pulled-back-and-recovering scenario where corr=115 represents a real
+     prior pullback low touched during the current trend leg. Without this
+     flag set, the phantom-cycle guard would (correctly) refuse to fire
+     cycle 3 from a stale anchor; here we are explicitly modeling a real
+     anchor. *)
   let initial_state =
     Trailing
       {
@@ -177,6 +187,7 @@ let stage3_tightening _ =
         last_trend_extreme = 130.0;
         ma_at_last_adjustment = 118.0;
         correction_count = 2;
+        correction_observed_since_reset = true;
       }
   in
   let steps =
@@ -231,6 +242,10 @@ let stop_hit_long _ =
    - cycle 2 at c=78: (90-80)/80=12.5%, close=78 ≤ trend=80 → fires *)
 
 let short_stage4_stop_lowered _ =
+  (* count = 0 lets the first cycle fire on the seeded counter-rally anchor
+     regardless of [correction_observed_since_reset]; the post-cycle-1 anchor
+     reset to close_price (88) is then refreshed by bar 4 (high=88, exact
+     touch) before cycle 2 fires. *)
   let initial_state =
     Trailing
       {
@@ -239,6 +254,7 @@ let short_stage4_stop_lowered _ =
         last_trend_extreme = 108.0;
         ma_at_last_adjustment = 110.0;
         correction_count = 0;
+        correction_observed_since_reset = false;
       }
   in
   let steps =
@@ -410,6 +426,134 @@ let full_lifecycle_short _ =
        (pair (float_equal 37.35) (float_equal 35.35)))
 
 (* ------------------------------------------------------------------ *)
+(* Phantom-cycle guard — monotonically declining short, no counter-rally *)
+(* ------------------------------------------------------------------ *)
+(* Reproducer for the trailing-state phantom-cycle bug: a short with
+   monotonically declining bars (no actual counter-rally above the seeded
+   entry-bar high) must NOT phantom-fire repeated cycles that pull the
+   stop DOWN through entry. Pre-fix, the seeded [last_correction_extreme]
+   = bar.high paired with a continuously falling [last_trend_extreme]
+   triggered cycle 1 off the seed (stop dropped), then [_raised_trailing]
+   reset both extremes to bar.close — and the stale post-reset value
+   would phantom-fire cycle 2+ on subsequent declining bars, pulling the
+   stop below entry. The first cycle's drop (from seed) is bounded by
+   the seed value itself and stays above entry; the load-bearing claim
+   is that NO subsequent cycle fires without a real counter-move. *)
+
+let _short_monotonic_decline_bars =
+  (* Entry stop $103, entry close $99, entry high $100. Subsequent bars
+     decline by $2 close-to-close with NO bar high reaching $89 (the
+     post-cycle-1 reset close). *)
+  [
+    (97.0, 96.0, 98.0);
+    (95.0, 94.0, 96.0);
+    (93.0, 92.0, 94.0);
+    (91.0, 90.0, 92.0);
+    (89.0, 88.0, 90.0);
+    (* potential cycle 1 around here *)
+    (87.0, 86.0, 88.0);
+    (85.0, 84.0, 86.0);
+    (83.0, 82.0, 84.0);
+    (81.0, 80.0, 82.0);
+    (79.0, 78.0, 80.0);
+    (* if cycle 2 would phantom-fire it would be here *)
+  ]
+
+let short_monotonic_decline_no_phantom_cycle _ =
+  (* Entry: bar high=100, low=98, close=99. Initial stop $103 (≈ 99 *
+     1.04, nudged). After Initial→Trailing, corr=100 (high), trend=99
+     (close). Subsequent monotonic decline with NO counter-rally above
+     100 — every bar's high is strictly less than the previous bar's
+     close (no real counter-move). MA is held below the seed at 85 so
+     [effective_ref] in cycle stop calc would be the corr anchor — pre-
+     fix, this is exactly what drives the stop down. *)
+  let entry_bar = make_bar ~low_price:98.0 ~high_price:100.0 99.0 in
+  let initial_state =
+    compute_initial_stop ~config:cfg ~side:Short ~reference_level:99.0
+  in
+  let entry_stop = get_stop_level initial_state in
+  let trailing_state, _ =
+    update ~config:cfg ~side:Short ~state:initial_state ~current_bar:entry_bar
+      ~ma_value:99.0 ~ma_direction:Declining ~stage:stage4
+  in
+  let final_state =
+    List.fold _short_monotonic_decline_bars ~init:trailing_state
+      ~f:(fun state (close, low, high) ->
+        let bar = make_bar ~low_price:low ~high_price:high close in
+        let new_state, _ =
+          update ~config:cfg ~side:Short ~state ~current_bar:bar ~ma_value:85.0
+            ~ma_direction:Declining ~stage:stage4
+        in
+        new_state)
+  in
+  (* Contract: the stop never moves through entry on a no-counter-rally
+     short. The first cycle (count = 0 gate) is allowed to fire on the
+     seeded high — that drop is bounded above the entry close. The
+     phantom-cycle guard rejects every subsequent cycle, so the stop
+     stays above entry across the entire monotonic decline. *)
+  let final_stop = get_stop_level final_state in
+  assert_that final_stop
+    (gt (module Float_ord) entry_bar.Types.Daily_price.close_price);
+  (* Sanity: the stop did not move backward (above entry stop). It
+     either held or improved (lower for short). *)
+  assert_that final_stop (le (module Float_ord) entry_stop);
+  (* And the correction_count is at most 1 (only the seed-anchored cycle
+     ever fires; no phantoms after the reset). *)
+  assert_that final_state
+    (matching ~msg:"Trailing with correction_count <= 1"
+       (function
+         | Trailing { correction_count; _ } -> Some correction_count | _ -> None)
+       (le (module Int_ord) 1))
+
+(* Mirror long-side check: monotonic advance with no real pullback should
+   produce at most 1 cycle (the seed-anchored one) and the stop stays
+   below entry close throughout. *)
+
+let _long_monotonic_advance_bars =
+  [
+    (102.0, 101.0, 103.0);
+    (104.0, 103.0, 105.0);
+    (106.0, 105.0, 107.0);
+    (108.0, 107.0, 109.0);
+    (110.0, 109.0, 111.0);
+    (112.0, 111.0, 113.0);
+    (114.0, 113.0, 115.0);
+    (116.0, 115.0, 117.0);
+    (118.0, 117.0, 119.0);
+    (120.0, 119.0, 121.0);
+  ]
+
+let long_monotonic_advance_no_phantom_cycle _ =
+  let entry_bar = make_bar ~low_price:99.0 ~high_price:101.0 100.0 in
+  let initial_state =
+    compute_initial_stop ~config:cfg ~side:Long ~reference_level:100.0
+  in
+  let entry_stop = get_stop_level initial_state in
+  let trailing_state, _ =
+    update ~config:cfg ~side:Long ~state:initial_state ~current_bar:entry_bar
+      ~ma_value:100.0 ~ma_direction:Rising ~stage:stage2
+  in
+  let final_state =
+    List.fold _long_monotonic_advance_bars ~init:trailing_state
+      ~f:(fun state (close, low, high) ->
+        let bar = make_bar ~low_price:low ~high_price:high close in
+        let new_state, _ =
+          update ~config:cfg ~side:Long ~state ~current_bar:bar ~ma_value:115.0
+            ~ma_direction:Rising ~stage:stage2
+        in
+        new_state)
+  in
+  let final_stop = get_stop_level final_state in
+  assert_that final_stop
+    (lt (module Float_ord) entry_bar.Types.Daily_price.close_price);
+  assert_that final_stop (ge (module Float_ord) entry_stop);
+  assert_that final_state
+    (matching ~msg:"Trailing with correction_count <= 1"
+       (function
+         | Trailing { correction_count; _ } -> Some correction_count | _ -> None)
+       (le (module Int_ord) 1))
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -429,4 +573,8 @@ let () =
            >:: full_lifecycle_long;
            "full lifecycle short (initial→trailing→tightened→stop_hit)"
            >:: full_lifecycle_short;
+           "short monotonic decline — no phantom cycles, stop stays above entry"
+           >:: short_monotonic_decline_no_phantom_cycle;
+           "long monotonic advance — no phantom cycles, stop stays below entry"
+           >:: long_monotonic_advance_no_phantom_cycle;
          ])

--- a/trading/trading/weinstein/stops/test/test_stop_split_adjust.ml
+++ b/trading/trading/weinstein/stops/test/test_stop_split_adjust.ml
@@ -32,8 +32,8 @@ let test_initial_reverse_1_to_5 _ =
 (* ---- Trailing state ---- *)
 
 let test_trailing_forward_4_to_1 _ =
-  (* Every absolute price field divides by 4; correction_count is a
-     {b count} and must NOT scale. *)
+  (* Every absolute price field divides by 4; non-price fields
+     ([correction_count], [correction_observed_since_reset]) must NOT scale. *)
   let state =
     Trailing
       {
@@ -42,6 +42,7 @@ let test_trailing_forward_4_to_1 _ =
         last_trend_extreme = 520.0;
         ma_at_last_adjustment = 480.0;
         correction_count = 3;
+        correction_observed_since_reset = true;
       }
   in
   assert_that
@@ -54,6 +55,7 @@ let test_trailing_forward_4_to_1 _ =
             last_trend_extreme = 130.0;
             ma_at_last_adjustment = 120.0;
             correction_count = 3;
+            correction_observed_since_reset = true;
           }))
 
 (* ---- Tightened state ---- *)
@@ -92,6 +94,7 @@ let test_factor_one_is_identity _ =
         last_trend_extreme = 130.0;
         ma_at_last_adjustment = 120.0;
         correction_count = 1;
+        correction_observed_since_reset = false;
       }
   in
   assert_that (Stop_split_adjust.scale ~factor:1.0 state) (equal_to state)

--- a/trading/trading/weinstein/stops/test/test_weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/test/test_weinstein_stops.ml
@@ -108,6 +108,7 @@ let test_get_stop_level_trailing _ =
         last_trend_extreme = 55.0;
         ma_at_last_adjustment = 50.0;
         correction_count = 1;
+        correction_observed_since_reset = false;
       }
   in
   assert_that (get_stop_level state) (float_equal 48.0)
@@ -154,6 +155,7 @@ let test_update_stop_hit_trailing _ =
         last_trend_extreme = 55.0;
         ma_at_last_adjustment = 50.0;
         correction_count = 1;
+        correction_observed_since_reset = false;
       }
   in
   let bar = make_bar ~low_price:47.0 ~close_price:47.5 () in
@@ -175,6 +177,7 @@ let test_update_stop_hit_short _ =
         last_trend_extreme = 45.0;
         ma_at_last_adjustment = 50.0;
         correction_count = 1;
+        correction_observed_since_reset = false;
       }
   in
   let bar = make_bar ~high_price:56.0 ~close_price:55.5 () in
@@ -215,6 +218,7 @@ let test_update_tighten_on_stage3 _ =
         last_trend_extreme = 55.0;
         ma_at_last_adjustment = 50.0;
         correction_count = 1;
+        correction_observed_since_reset = false;
       }
   in
   let bar = make_bar ~low_price:52.0 ~close_price:53.0 () in
@@ -243,6 +247,7 @@ let test_update_tighten_on_flat_ma _ =
         last_trend_extreme = 55.0;
         ma_at_last_adjustment = 50.0;
         correction_count = 1;
+        correction_observed_since_reset = false;
       }
   in
   let bar = make_bar ~low_price:52.0 ~close_price:53.0 () in
@@ -269,6 +274,7 @@ let test_update_no_tighten_when_disabled _ =
         last_trend_extreme = 55.0;
         ma_at_last_adjustment = 50.0;
         correction_count = 0;
+        correction_observed_since_reset = false;
       }
   in
   let bar = make_bar ~low_price:52.0 ~close_price:53.0 () in
@@ -292,6 +298,7 @@ let test_update_tighten_short_on_stage2 _ =
         last_trend_extreme = 45.0;
         ma_at_last_adjustment = 50.0;
         correction_count = 1;
+        correction_observed_since_reset = false;
       }
   in
   let bar = make_bar ~high_price:48.0 ~close_price:47.0 () in
@@ -311,7 +318,9 @@ let test_update_tighten_short_on_stage2 _ =
 (* ---- update: stop ratchet after correction cycle ---- *)
 
 let test_update_stop_raised_after_cycle _ =
-  (* Scenario: price had a correction (pullback >= 8%), now recovered *)
+  (* Scenario: price had a correction (pullback >= 8%), now recovered.
+     [correction_observed_since_reset = true] models a real prior pullback —
+     the corr=49 anchor was touched during the current trend leg. *)
   let peak = 55.0 in
   let correction_low = 49.0 in
   (* pullback = (55 - 49)/55 = 10.9% > 8% ✓ *)
@@ -323,6 +332,7 @@ let test_update_stop_raised_after_cycle _ =
         last_trend_extreme = peak;
         ma_at_last_adjustment = 50.0;
         correction_count = 1;
+        correction_observed_since_reset = true;
       }
   in
   (* Current bar: close above the previous rally peak — cycle complete *)
@@ -359,6 +369,7 @@ let test_update_no_ratchet_insufficient_correction _ =
         last_trend_extreme = peak;
         ma_at_last_adjustment = 50.0;
         correction_count = 0;
+        correction_observed_since_reset = false;
       }
   in
   let bar = make_bar ~low_price:53.0 ~close_price:56.0 () in
@@ -403,6 +414,7 @@ let test_stop_never_lowered_for_long _ =
         last_trend_extreme = 55.0;
         ma_at_last_adjustment = 50.0;
         correction_count = 1;
+        correction_observed_since_reset = true;
       }
   in
   let bar = make_bar ~low_price:53.0 ~close_price:56.0 () in
@@ -424,6 +436,7 @@ let test_stop_never_raised_for_short _ =
         last_trend_extreme = 45.0;
         ma_at_last_adjustment = 50.0;
         correction_count = 1;
+        correction_observed_since_reset = true;
       }
   in
   (* Close above last_trend_extreme (45.0) — but this is a SHORT, so close above
@@ -455,6 +468,7 @@ let test_no_phantom_cycle_on_continuous_advance _ =
         last_trend_extreme = 100.0;
         ma_at_last_adjustment = 90.0;
         correction_count = 1;
+        correction_observed_since_reset = false;
       }
   in
   let bar = make_bar ~low_price:107.0 ~close_price:110.0 () in

--- a/trading/trading/weinstein/strategy/test/test_stops_split_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_split_runner.ml
@@ -216,6 +216,7 @@ let test_forward_4_to_1_scales_trailing_stop _ =
         last_trend_extreme = 520.0;
         ma_at_last_adjustment = 480.0;
         correction_count = 2;
+        correction_observed_since_reset = true;
       }
   in
   let stop_states = ref (String.Map.singleton symbol trailing) in
@@ -232,6 +233,7 @@ let test_forward_4_to_1_scales_trailing_stop _ =
                last_trend_extreme = 130.0;
                ma_at_last_adjustment = 120.0;
                correction_count = 2;
+               correction_observed_since_reset = true;
              })))
 
 (* Strategy-level regression. After [adjust] runs on a 4:1 split day, the


### PR DESCRIPTION
## Summary

Closes the trailing-state phantom-cycle follow-up tracked in `dev/notes/short-side-gaps-2026-04-29.md` G1 § "Out-of-scope follow-up".

For monotonically declining shorts (no actual counter-rally above the entry-bar high), `Weinstein_stops._completed_cycle_stop` phantom-fires repeated correction cycles that pull the stop DOWN through entry. The fix adds a `correction_observed_since_reset : bool` field to the `Trailing` state and gates the cycle on either `correction_count = 0` (first cycle from the entry-seeded anchor — the long-side `stage2_trailing_stop_raised_phase_a` regression contract) OR a real counter-move bar having touched/breached the post-reset correction extreme.

## Mechanism

1. `_to_trailing` seeds `last_correction_extreme = bar.high` (short) / `bar.low` (long) and `last_trend_extreme = bar.close_price`.
2. On a monotonically declining short, no subsequent bar's high reaches the seeded value, but `last_trend_extreme` keeps falling. The pullback math `(corr - trend) / trend` accumulates past 8% and "recovery" is trivially true (every close is a new low). Cycle 1 fires off the seed.
3. After `_raised_trailing` resets both extremes to `bar.close_price`, the same pattern repeats: subsequent declining bars never refresh the post-reset corr value (highs stay below `bar.close_price`), but trend keeps falling, and cycle 2+ phantom-fires off the stale reset value — driving the stop below entry.
4. The asymmetric long-side equivalent does NOT phantom-fire because the post-reset close sits BELOW the advancing trend, so the pullback math goes negative.

## Before / After (10-bar monotonic short, entry close $99, entry stop $103.125)

| Bar | Close | High | Pre-fix stop | Post-fix stop |
|-----|-------|------|--------------|---------------|
| Entry | 99   | 100  | 103.125      | 103.125       |
| 1   | 97    | 98   | 103.125      | 103.125       |
| ...   | ...   | ...  | ...          | ...           |
| 5   | 89    | 90   | **101.125** (cycle 1 phantom) | **101.125** (cycle 1 — count=0 gate) |
| ...   | ...   | ...  | ...          | 101.125       |
| 10  | 79    | 80   | **90.125** (cycle 2 phantom — BELOW entry) | **101.125** (cycle 2 rejected) |

Pre-fix stop ends at $90.125, $9 below entry close. Post-fix stays at $101.125, $2 above entry close. The contract \"stop never moves through entry on a no-counter-rally short\" holds.

## Fix

State change in `trading/trading/weinstein/stops/lib/stop_types.{ml,mli}`:

```ocaml
| Trailing of {
    ...
    correction_count : int;
    correction_observed_since_reset : bool;  (* new *)
  }
```

Cycle gate in `_completed_cycle_stop`:

```ocaml
let anchor_is_fresh =
  correction_count = 0 || correction_observed_since_reset
in
if had_correction && recovered && anchor_is_fresh then ...
```

Each `_raise_after_cycle` checks `_is_correction_touch` (`bar.low <= corr` for long, `bar.high >= corr` for short) and ORs the result into the running flag. `_raised_trailing` resets the flag to `false` on cycle completion.

## Test coverage

- New `regression_test.short_monotonic_decline_no_phantom_cycle`: pins the bug — final stop stays above entry close, correction_count <= 1.
  - Verified the test fails pre-fix by temporarily disabling the gate: `Expected value > 99. but got 90.125`.
- New `regression_test.long_monotonic_advance_no_phantom_cycle`: symmetric long-side check (passes pre-fix and post-fix).
- Existing tests preserved: `stage2_trailing_stop_raised_phase_a` (entry-bar-low seeded cycle 1), `stage2_trailing_stop_raised_phase_b` (cycle 3 fires after bar 4 touches the corr=122 anchor), `short_stage4_stop_lowered`, `full_lifecycle_long`, `full_lifecycle_short`.
- `stage3_tightening` updated to set `correction_observed_since_reset = true` (test explicitly models a real prior pullback).
- `Stop_split_adjust.scale` propagates the new field; tests updated.

## Test plan

- [x] `dune build` — clean.
- [x] `dune runtest trading/weinstein/stops` — all 80 tests pass (incl. 2 new).
- [x] `dune runtest trading/weinstein/strategy` — all tests pass.
- [x] `dune runtest trading/simulation` — all tests pass.
- [x] `dune build @fmt` — clean.
- [x] Long-side regression `stage2_trailing_stop_raised_phase_a` confirmed unchanged.

## Constraints respected

- Touches only `trading/trading/weinstein/stops/` (lib + test) and `trading/trading/weinstein/strategy/test/` (test fixture). Not a core module per A1 watch-list.
- ~273 LOC change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)