### PR TITLE
fix(orchestrator-workflow): stash budget JSON across git reset/clean

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -377,9 +377,19 @@ jobs:
           # working copy.  git checkout refuses to overwrite those files.
           # Everything intentional is already on the remote branch, so a
           # hard reset + clean is safe here.
+          #
+          # Stash OUT_FILE outside the workspace before reset/clean — the
+          # cost-capture step wrote it as an untracked file, and `git clean`
+          # would delete it before we can stage it. Restore after checkout.
+          # (Earlier shape of this step lost the budget JSON to clean: see
+          # run 25166328542 / 2026-04-30 for the failure.)
+          BUDGET_STASH="${RUNNER_TEMP:-/tmp}/${BUDGET_BASENAME}.json"
+          cp "$OUT_FILE" "$BUDGET_STASH"
           git reset --hard HEAD && git clean -fd
           git fetch origin "${DAILY_BRANCH}"
           git checkout "${DAILY_BRANCH}"
+          mkdir -p "$(dirname "$OUT_FILE")"
+          cp "$BUDGET_STASH" "$OUT_FILE"
           git add "$OUT_FILE"
           if git diff --cached --quiet; then
             echo "Budget JSON already on branch (re-run?); skipping add."


### PR DESCRIPTION
## Summary

Run [25166328542](https://github.com/dayfine/trading/actions/runs/25166328542) (2026-04-30 run-2) failed at the **Bundle budget into daily summary and auto-merge** step:

```
fatal: pathspec 'dev/budget/2026-04-30-25166328542.json' did not match any files
```

## Root cause

\`Capture run cost from execution file\` writes the budget JSON as an **untracked** file in \`dev/budget/\`. The bundle step then runs:

```bash
git reset --hard HEAD && git clean -fd     # ← removes the untracked budget JSON
git fetch origin "${DAILY_BRANCH}"
git checkout "${DAILY_BRANCH}"
git add "$OUT_FILE"                         # ← FAIL: file no longer exists
```

The \`git clean -fd\` deletes the untracked budget JSON before the subsequent \`git add\`. PR #706 stayed open without budget JSON; auto-merge skipped.

## Fix

Copy \`OUT_FILE\` to \`\$RUNNER_TEMP\` before reset/clean, then copy back after checkout but before \`git add\`. \`mkdir -p\` ensures the target directory exists on the daily branch (it may not, if no prior dev/budget/ commits landed).

## Test plan

- [x] Diff stays in scope (\`.github/workflows/orchestrator.yml\` only).
- [x] Next scheduled orchestrator run will exercise this path live (no GHA test harness for workflow yaml short of dispatching).
- [ ] Human follow-up: PRs #704 + #706 stay open without budget JSON; consider merging manually or dropping (observational PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)