### PR TITLE
fix(force_liquidation_runner): G9 — shorts subtract from portfolio_value (mirror G8)

### DIFF
--- a/dev/notes/short-side-gaps-2026-04-29.md
+++ b/dev/notes/short-side-gaps-2026-04-29.md
@@ -397,6 +397,15 @@ specific number.
 
 ## G9 — `Force_liquidation_runner._portfolio_value` has the same shorts-sign bug
 
+**DONE — see PR `fix/g9-force-liquidation-shorts`** (2026-04-30 PM):
+Refactored `_portfolio_value` to delegate to
+`Portfolio_view.portfolio_value` (the canonical, post-G8 signed
+implementation), eliminating the duplicate calculation. Two regression
+tests pin (a) the peak observed after `update` is the true (signed) value,
+not the inflated (unsigned) value; (b) profitable shorts do not trigger
+`Portfolio_floor`. Pre-fix both new tests fail with the inflation factor
+matching `2 * Σ short_notional`; post-fix they pass. Sibling-of G8 fix.
+
 Surfaced 2026-04-30 PM on the post-G8 sp500 rerun. See
 `dev/notes/sp500-shortside-rerun-blocked-g9-2026-04-30-pm.md` for full
 details.

--- a/trading/trading/weinstein/strategy/lib/force_liquidation_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/force_liquidation_runner.ml
@@ -26,19 +26,19 @@ let _position_input_of_holding ~get_price (pos : Position.t) :
       | None -> None)
   | _ -> None
 
-(** Compute portfolio mark-to-market value the same way [Portfolio_view] does:
-    cash + sum of (quantity * close_price) over Holding positions whose symbol
-    has a price this tick. Mirrors {!Portfolio_view.portfolio_value} but takes
-    the cash separately so the strategy can pass its own cash field directly. *)
+(** Compute portfolio mark-to-market value via the canonical
+    [Portfolio_view.portfolio_value]. Long holdings contribute
+    [+quantity * close_price]; shorts contribute [-quantity * close_price] (cash
+    already reflects short-entry proceeds, so subtracting the buy-back liability
+    is what makes mark-to-market track P&L correctly).
+
+    G9 fix: previously this fold added [+quantity * close_price] for every
+    Holding regardless of side, mirroring the pre-G8 bug in
+    {!Portfolio_view._holding_market_value}. Delegating to
+    [Portfolio_view.portfolio_value] eliminates the duplicate calculation so the
+    sign convention has a single source of truth. *)
 let _portfolio_value ~cash ~positions ~get_price =
-  Map.fold positions ~init:cash ~f:(fun ~key:_ ~data:pos acc ->
-      match pos.Position.state with
-      | Position.Holding { quantity; _ } -> (
-          match get_price pos.symbol with
-          | Some (bar : Types.Daily_price.t) ->
-              acc +. (quantity *. bar.close_price)
-          | None -> acc)
-      | _ -> acc)
+  Portfolio_view.portfolio_value { cash; positions } ~get_price
 
 (** Convert a force-liquidation event into a TriggerExit transition. The
     exit_reason is [Position.StopLoss] — the existing variant the position state

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
@@ -321,6 +321,137 @@ let test_missing_price_does_not_fire _ =
   assert_that !captured is_empty
 
 (* ------------------------------------------------------------------ *)
+(* G9 — shorts must subtract from portfolio_value (sign convention)     *)
+(* ------------------------------------------------------------------ *)
+
+(** Pin the G9 fix: a short Holding contributes [-quantity * close_price] to
+    portfolio_value, mirroring G8's fix to
+    {!Portfolio_view._holding_market_value}.
+
+    Pre-fix, [_portfolio_value] folded [+quantity * close_price] for every
+    Holding regardless of side. With shorts, this inflated portfolio_value by
+    twice the short notional (cash already includes short-entry proceeds, so
+    subtracting the buy-back liability is what makes mark-to-market track P&L
+    correctly).
+
+    The peak observed after one [update] call is the most direct surface to pin:
+    pre-fix returns the inflated peak, post-fix returns the true peak. *)
+let test_short_holding_does_not_inflate_peak _ =
+  (* 1 short, 1000 shares @ $100. Cash $1.1M (= $1M starting + $100K short
+     proceeds). True portfolio_value at entry: $1.1M - $100K = $1M.
+     Pre-fix portfolio_value: $1.1M + $100K = $1.2M (inflated by 2x notional). *)
+  let pos =
+    _make_holding ~symbol:"TSLA" ~side:Trading_base.Types.Short
+      ~entry_date:(_date "2024-01-02") ~quantity:1000.0 ~entry_price:100.0
+  in
+  let bar = _make_bar ~date:(_date "2024-01-02") ~close:100.0 in
+  let positions = String.Map.singleton "TSLA" pos in
+  let get_price s = if String.equal s "TSLA" then Some bar else None in
+  let peak_tracker = FL.Peak_tracker.create () in
+  let recorder, _captured = _capturing_recorder () in
+  let _ =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price ~cash:1_100_000.0 ~current_date:(_date "2024-01-02")
+      ~peak_tracker ~audit_recorder:recorder
+  in
+  (* Post-fix: peak = $1M (true value). Pre-fix: peak = $1.2M (inflated). *)
+  assert_that (FL.Peak_tracker.peak peak_tracker) (float_equal 1_000_000.0)
+
+(** Pin the downstream consequence of G9: a profitable short should not trigger
+    Portfolio_floor.
+
+    Construction: portfolio is dominated by a single short. At entry the peak is
+    established. On a later tick the short price drops sharply (large profit).
+    With the buggy unsigned formula, the peak was set at
+    [cash + qty * entry_price] (inflated); on the profit tick, the buggy
+    portfolio_value drops to [cash + qty * lower_price], and at sufficient
+    short-dominance + price-drop ratios the buggy floor check fires.
+
+    Sized to actually trip the buggy floor: cash = $20K, 1000-share short at
+    $100 (entry proceeds bringing cash to $120K but starting cash post-entry set
+    at $20K so short notional dominates). At entry buggy value = $20K + 1000 *
+    $100 = $120K. Tick 2 at price $20: buggy = $20K + 1000 * $20 = $40K. $40K /
+    $120K = 0.333 < 0.4 → FLOOR FIRES. Post-fix value at entry = $20K - $100K =
+    -$80K (negative — peak observation is monotonic, so peak stays whatever it
+    became; if first observed value is -$80K, peak <= 0 and floor never fires
+    per [_portfolio_floor_breached]'s [peak > 0] guard). Even with profit at
+    price $20: post-fix value = $20K - $20K = $0K. Floor check requires peak > 0
+    — never fires.
+
+    To make the post-fix scenario produce a positive peak (closer to a real
+    portfolio), use a more realistic balance: cash = $1.05M, 100-share short at
+    $500 (cash already includes proceeds; pre-entry cash was $1M). True value =
+    $1.05M - $50K = $1M. Buggy = $1.05M + $50K = $1.1M. Tick 2 at price $50 (90%
+    short profit, large but plausible): buggy = $1.05M + $5K = $1.055M. $1.055M
+    / $1.1M = 0.959 > 0.4 → still doesn't fire on a single short.
+
+    The single-short surface alone is too tame to trip the floor without extreme
+    parameters. The peak-inflation assertion above pins the formula bug directly
+    — that is the load-bearing test. We add this companion test pinning that the
+    peak-tracker math passes through correctly when we add a second short,
+    multiplying the inflation factor. *)
+let test_two_profitable_shorts_no_portfolio_floor _ =
+  let pos_a =
+    _make_holding ~symbol:"AAPL" ~side:Trading_base.Types.Short
+      ~entry_date:(_date "2024-01-02") ~quantity:1000.0 ~entry_price:100.0
+  in
+  let pos_b =
+    _make_holding ~symbol:"TSLA" ~side:Trading_base.Types.Short
+      ~entry_date:(_date "2024-01-02") ~quantity:500.0 ~entry_price:200.0
+  in
+  let positions =
+    String.Map.of_alist_exn [ ("AAPL", pos_a); ("TSLA", pos_b) ]
+  in
+  let peak_tracker = FL.Peak_tracker.create () in
+  let recorder, captured = _capturing_recorder () in
+  (* Cash: $1M starting + $100K (AAPL short) + $100K (TSLA short) = $1.2M.
+     True value: $1.2M - $100K - $100K = $1M.
+     Buggy value: $1.2M + $100K + $100K = $1.4M. *)
+  let bar_par_a = _make_bar ~date:(_date "2024-01-02") ~close:100.0 in
+  let bar_par_b = _make_bar ~date:(_date "2024-01-02") ~close:200.0 in
+  let get_price_par s =
+    if String.equal s "AAPL" then Some bar_par_a
+    else if String.equal s "TSLA" then Some bar_par_b
+    else None
+  in
+  let _ =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price:get_price_par ~cash:1_200_000.0
+      ~current_date:(_date "2024-01-02") ~peak_tracker ~audit_recorder:recorder
+  in
+  (* Post-fix peak: $1M. Pre-fix: $1.4M. *)
+  assert_that (FL.Peak_tracker.peak peak_tracker) (float_equal 1_000_000.0);
+  (* Tick 2: both shorts profit big — AAPL 100→50, TSLA 200→100 (50% profit
+     each). True value: $1.2M - $50K - $50K = $1.1M (peak rises to $1.1M).
+     Pre-fix: $1.2M + $50K + $50K = $1.3M (drops from buggy peak $1.4M to
+     $1.3M = 92.9% — still above 40% floor; per-position threshold is also
+     not exceeded since these are profits, not losses). The pre-fix bug
+     does NOT trip the floor in this scenario, but the bug is fully captured
+     by the peak assertion above. We assert no Portfolio_floor events fire
+     here to pin the higher-level invariant: profitable shorts → no
+     Portfolio_floor. *)
+  let bar_profit_a = _make_bar ~date:(_date "2024-04-29") ~close:50.0 in
+  let bar_profit_b = _make_bar ~date:(_date "2024-04-29") ~close:100.0 in
+  let get_price_profit s =
+    if String.equal s "AAPL" then Some bar_profit_a
+    else if String.equal s "TSLA" then Some bar_profit_b
+    else None
+  in
+  let _ =
+    Force_liquidation_runner.update ~config:FL.default_config ~positions
+      ~get_price:get_price_profit ~cash:1_200_000.0
+      ~current_date:(_date "2024-04-29") ~peak_tracker ~audit_recorder:recorder
+  in
+  (* No Portfolio_floor events captured — these shorts are profiting. *)
+  let portfolio_floor_events =
+    List.filter !captured ~f:(fun e ->
+        match e.FL.reason with FL.Portfolio_floor -> true | _ -> false)
+  in
+  assert_that portfolio_floor_events is_empty;
+  (* Halt state must remain Active. *)
+  assert_that (FL.Peak_tracker.halt_state peak_tracker) (equal_to FL.Active)
+
+(* ------------------------------------------------------------------ *)
 (* Double-exit avoidance — strategy-level filter                        *)
 (* ------------------------------------------------------------------ *)
 
@@ -391,6 +522,10 @@ let suite =
          "missing price does not fire" >:: test_missing_price_does_not_fire;
          "double-exit avoidance filters already-exited"
          >:: test_double_exit_avoidance_filters_already_exited;
+         "G9 — short holding does not inflate peak"
+         >:: test_short_holding_does_not_inflate_peak;
+         "G9 — two profitable shorts do not trigger portfolio_floor"
+         >:: test_two_profitable_shorts_no_portfolio_floor;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

G9 fix: `Force_liquidation_runner._portfolio_value` had the same shorts-sign bug
that G8 (#705) fixed in `Portfolio_view._holding_market_value`. G8 patched one
copy of the calculation; this is the twin.

**Before**: shorts contributed `+quantity * close_price` to portfolio_value.
With cash already inflated by short-entry proceeds, this made the tracked peak
roughly 2× the true peak. As shorts profited (price drops), the buggy unsigned
formula caused `portfolio_value` to drop below 40 % of the inflated peak, firing
spurious `Portfolio_floor` force-liquidations on profitable shorts.

**After**: `_portfolio_value` delegates to `Portfolio_view.portfolio_value`,
which already encodes the post-G8 sign convention (long: +qty*price; short:
-qty*price). One source of truth, no duplicate formula.

Surfaced on the 2026-04-30 PM sp500 short-side rerun: 928 force-liquidations,
many on profitable shorts (e.g. ABBV at +20.7 % unrealized). See
`dev/notes/sp500-shortside-rerun-blocked-g9-2026-04-30-pm.md`.

## Fix shape

**Option B (delegate)** chosen over Option A (inline sign-by-side match):
the function signature in `force_liquidation_runner.ml` already takes
`~cash`, `~positions`, `~get_price` — the exact inputs `Portfolio_view.t`
needs. One-liner delegation is mechanically clean and removes the duplicate
implementation that caused G9 to miss G8's patch.

```ocaml
let _portfolio_value ~cash ~positions ~get_price =
  Portfolio_view.portfolio_value { cash; positions } ~get_price
```

## Test plan

- [x] Two new regression tests in `test_force_liquidation_runner.ml`:
  - `G9 — short holding does not inflate peak`: 1 short of 1000 shares at \$100,
        cash \$1.1M. Asserts `Peak_tracker.peak = \$1M` (true, signed). Pre-fix
        returns \$1.2M (inflated by 2 × short notional).
  - `G9 — two profitable shorts do not trigger portfolio_floor`: two shorts at
        par on tick 1, both profitable on tick 2. Asserts no `Portfolio_floor`
        events captured + halt state stays Active. Peak assertion at tick 1
        confirms the formula change (\$1M true vs \$1.4M inflated).
- [x] Pre-fix both new tests fail with the exact predicted inflation amount.
- [x] Post-fix all 10 tests in `test_force_liquidation_runner.ml` pass.
- [x] Full `weinstein/strategy/` suite passes (no regressions).
- [x] `dune fmt` clean.

## References

- G8 fix: #705 (`fix(portfolio_view): shorts subtract from portfolio_value`)
- G9 finding: #709 (docs-only PR, on main as `c224d948`)
- Authority docs:
  - `dev/notes/sp500-shortside-rerun-blocked-g9-2026-04-30-pm.md`
  - `dev/notes/short-side-gaps-2026-04-29.md` (G9 section now marked DONE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)