### PR TITLE
feat(sp500-baseline): re-enable shorts on sp500-2019-2023 (G1-G5 + G7-G9 closed)

### DIFF
--- a/dev/notes/short-side-gaps-2026-04-29.md
+++ b/dev/notes/short-side-gaps-2026-04-29.md
@@ -313,6 +313,15 @@ back to `enable_short_side = true`), the BASELINE_PENDING expected
 ranges re-pinned to whatever the with-shorts run produces, and G5
 added as the standing regression gate.
 
+**DONE 2026-04-30 (evening)**: third retry succeeded after PR #710 (G9)
+landed. sp500-2019-2023 now runs with shorts enabled and produces
+clean, deterministic metrics: 32 trades / -0.01% return / 0 force-
+liquidations / 43-day avg holding / 5.8% MaxDD. Override removed,
+ranges re-pinned ±10-15% around measured baseline. See
+`dev/notes/sp500-shortside-reenabled-2026-04-30.md` for full report
+including side breakdown, comparison vs long-only / AM / PM runs, and
+G1-G9 fix validation.
+
 ## G7 — Position sizing for shorts
 
 See `dev/notes/sp500-shortside-rerun-blocked-g7-2026-04-30.md` for

--- a/dev/notes/sp500-shortside-reenabled-2026-04-30.md
+++ b/dev/notes/sp500-shortside-reenabled-2026-04-30.md
@@ -1,0 +1,150 @@
+# sp500-2019-2023 — shorts re-enabled (post-G9), 2026-04-30 evening
+
+Third retry of the sp500-2019-2023 baseline rerun with `enable_short_side = true`,
+following the merge of PR #710 (G9 — `Force_liquidation_runner._portfolio_value`
+shorts-sign fix). All preconditions G1-G5 + G7 + G8 + G9 are now closed on
+`main@origin = d7e8b89b`.
+
+## Pre-flight
+
+Worktree confirmed at `main@origin` (`d7e8b89b` — PR #710 G9 fix). The G7, G8,
+G9 fixes are all present in the worktree:
+
+- G7 (PR #702): `Portfolio_risk.compute_position_size` accepts `~side`,
+  caps shares at `max_short_exposure_pct` (30%) for shorts and
+  `max_long_exposure_pct` (90%) for longs.
+- G8 (PR #705): `Portfolio_view._holding_market_value` signs by `pos.side`
+  (longs add `+quantity * close_price`, shorts add `-quantity * close_price`).
+- G9 (PR #710): `Force_liquidation_runner._portfolio_value` delegates to
+  `Portfolio_view.portfolio_value` so the same sign convention is used in
+  both call sites.
+
+## Scenario edit
+
+`trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp`:
+
+- Removed `(config_overrides (((enable_short_side false))))`; replaced with
+  `(config_overrides ())` (the field is required by the sexp schema, but the
+  empty list yields the default `enable_short_side = true`).
+- Removed the BASELINE_PENDING comment block + the disable rationale comment.
+- Re-tightened `expected` ranges to ±10-15% around the measured metrics.
+
+## Rerun
+
+```
+docker exec -e TRADING_DATA_DIR=/workspaces/trading-1/trading/test_data trading-1-dev \
+  bash -c 'cd /workspaces/trading-1/.claude/worktrees/agent-a66ac26b351f1f111/trading \
+  && eval $(opam env) \
+  && dune exec trading/backtest/scenarios/scenario_runner.exe -- \
+       --dir /tmp/sp500-shorts-v3 \
+       --fixtures-root /workspaces/trading-1/.claude/worktrees/agent-a66ac26b351f1f111/trading/test_data/backtest_scenarios'
+```
+
+Output: `/workspaces/trading-1/trading/dev/backtest/scenarios-2026-04-30-135424/sp500-2019-2023/`
+(also re-confirmed in `scenarios-2026-04-30-135705/`).
+
+## Metrics
+
+| Metric              | Value      |
+|---------------------|------------|
+| total_return_pct    |  -0.01     |
+| total_trades        |    32      |
+| win_rate            |  37.50     |
+| sharpe_ratio        |   0.01     |
+| max_drawdown_pct    |   5.81     |
+| avg_holding_days    |  43.03     |
+| unrealized_pnl      |  391,949   |
+| force_liquidations  |     0      |
+| final_portfolio_value | 999,937  |
+
+Side breakdown:
+
+| Side  | Trades | Wins | Win rate | Realized PnL  |
+|-------|--------|------|----------|---------------|
+| LONG  |  28    |  12  |  42.9%   |   -15,350     |
+| SHORT |   4    |   0  |   0.0%   |   -49,247     |
+| Total |  32    |  12  |  37.5%   |   -64,597     |
+
+Position sizing on shorts: all initial position values fell between $117k and
+$125k against $1M portfolio (~11.7-12.5%) — well under the 30% short-exposure
+cap that G7 introduced.
+
+Equity curve range: min $941,915 (max drawdown) to max $1,000,000 (start).
+**Portfolio value never went negative on any day** — the canonical pathology
+of the pre-G9 runs is gone.
+
+## Comparison vs prior runs
+
+| Run                         | Trades  | Force-liq | Avg hold (d) | Return  | Notes                                |
+|-----------------------------|---------|-----------|--------------|---------|--------------------------------------|
+| Long-only baseline (canonical 2026-04-28) | 134     |     0     |    n/a       | +70.8%  | `enable_short_side = false`           |
+| AM run (post-G7 only)       |  ~hundreds | 910       | 3.46         | -100+%  | sized OK; but force-liq spam from G8 |
+| PM run (post-G7+G8)         |  ~hundreds | 928       | 3.46         | -100+%  | G8 only patched 1 of 2 sites; G9 left |
+| Evening run (post-G7+G8+G9) |  32     |     0     |    43.03     | -0.01%  | clean — all gates pass                |
+
+The evening run produces fewer trades than long-only baseline because shorts
+compete with longs for capital, and the strategy is more conservative when
+both sides are available (some entries during 2019's Bearish-macro window
+get short-side classification rather than long-side). All 4 short trades
+were entered in 2019 (Bearish macro) and exited at stop_loss as the 2020-2023
+bull market unfolded — that's expected behaviour for this period.
+
+## G1-G9 fix validation
+
+- **G1 (short-stop direction)**: shorts exited at stop_loss with the correct
+  sign convention; no spurious early exits at profitable prices.
+- **G2 (short metrics visibility)**: `wincount=12 losscount=20` aggregates
+  both sides correctly.
+- **G3 (cash floor on shorts)**: cash floor not breached at entry; sizing
+  now caps below the floor.
+- **G4 (force liquidation)**: force_liquidations=0 (no events written).
+  Eliminated by the combination of G7 (correct sizing) + G9 (correct
+  portfolio_value tracking).
+- **G5 (audit harness)**: regression tests in `simulation/test/` continue
+  to pass (verified via `dune runtest`).
+- **G7 (position sizing)**: all initial_position_value entries ≤ 12.5% of
+  portfolio. Cap of 30% never approached.
+- **G8 + G9 (portfolio_value sign)**: equity-curve never goes negative;
+  drawdown of 5.81% is a real drawdown, not a phantom-cycle artefact.
+
+## Decision tree (all pass)
+
+- [x] Total return > -10% (measured: -0.01%)
+- [x] Force-liquidation count ≤ 50 (measured: 0)
+- [x] portfolio_value never goes negative (min $941,915)
+- [x] Avg holding days > 20 (measured: 43.03)
+- [x] Position sizing ≤ 30% at entry (measured: max 12.5%)
+
+## Tightened ranges
+
+```
+(expected
+ ((total_return_pct   ((min -15.0)       (max  15.0)))
+  (total_trades       ((min 27)          (max  37)))
+  (win_rate           ((min 31.0)        (max  44.0)))
+  (sharpe_ratio       ((min -0.5)        (max  0.5)))
+  (max_drawdown_pct   ((min 3.0)         (max  9.0)))
+  (avg_holding_days   ((min 37.0)        (max  50.0)))
+  (unrealized_pnl     ((min 330000.0)    (max  450000.0)))))
+```
+
+The scenario PASSES against these ranges (verified via second run with the
+edited file).
+
+## Follow-ups
+
+- The 32-trade count is much lower than the 134-trade long-only baseline.
+  Most of that delta is shorts taking up a small fraction of capital
+  during the Bearish-macro window; the larger driver is that with shorts
+  enabled the strategy's cascade may down-rank some Stage-2 long entries
+  that compete with Stage-4 short candidates. Worth investigating
+  whether the long-side entry rate has actually changed (28 longs vs.
+  the long-only baseline's 134 is a 79% drop).
+- All 4 shorts lost (-$49k). Short-side strategy hit-rate during a
+  prolonged bull is structurally low. The gap closures were about
+  *correctness*, not profitability — the strategy now behaves
+  deterministically with shorts on; whether shorts are *worth keeping
+  on* in a sustained bull regime is a separate (downstream) question
+  for the strategy-tuning track.
+- G5 audit harness should now have `enable_short_side = true` as the
+  default for the regression baseline.

--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -1,6 +1,6 @@
 # Status: short-side-strategy
 
-## Last updated: 2026-04-28
+## Last updated: 2026-04-30 (evening)
 
 ## Status
 MERGED
@@ -12,6 +12,17 @@ originally landed via #420 on 2026-04-19. Track wraps; future
 short-side work is performance-driven (e.g., revisiting the cascade
 parameters once the trade-audit track ships) rather than feature
 build-out.
+
+**2026-04-30 (evening) update**: shorts now live in the sp500
+regression scenario. After G1-G5 + G7-G9 closed (PRs #689-#710),
+`goldens-sp500/sp500-2019-2023.sexp` has the `enable_short_side =
+false` override removed and ranges re-pinned to the with-shorts
+baseline (32 trades / -0.01% / 0 force-liquidations / 43d avg holding
+/ 5.8% MaxDD). See `dev/notes/sp500-shortside-reenabled-2026-04-30.md`.
+The 5-year sp500 scenario is now the standing regression gate for
+short-side correctness; the 4 short trades the strategy emits during
+the 2019 Bearish-macro window all exit via stop_loss with the correct
+sign convention.
 
 **Historical: live-cascade bug (resolved by #623)**: real-data SP500
 verification (PR #612) revealed 0 short trades + 37 long entries in

--- a/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp
@@ -14,10 +14,16 @@
 ;; strategy, segmentation-based stage classifier, stop-buffer tuning, etc.
 ;; Once metrics here are pinned, follow-on PRs measure against this baseline.
 ;;
-;; Initial expected ranges tightened to ±10–15% around the baseline measured
-;; on 2026-04-26 (see dev/notes/sp500-golden-baseline-2026-04-26.md for the
-;; baseline run and reasoning). Re-pin with each deliberate strategy
+;; Expected ranges pinned ±10-15% around the post-G9 with-shorts baseline
+;; measured 2026-04-30 (see dev/notes/sp500-shortside-reenabled-2026-04-30.md
+;; for the rerun results and dev/notes/short-side-gaps-2026-04-29.md for the
+;; G1-G9 gap closure history). Re-pin with each deliberate strategy
 ;; behaviour change; don't bump these to absorb regressions.
+;;
+;; Measured baseline (2026-04-30, post-#710 G9 fix):
+;;   total_return_pct  -0.01  total_trades 32   win_rate 37.50
+;;   sharpe_ratio       0.01  max_drawdown 5.81  avg_holding_days 43.03
+;;   unrealized_pnl     391,949   force_liquidations 0
 ;;
 ;; The S&P 500 is a moving target; the universe sexp is a fixed snapshot
 ;; so reruns are reproducible. Refresh the universe via the build script
@@ -27,21 +33,12 @@
  (period ((start_date 2019-01-02) (end_date 2023-12-29)))
  (universe_path "universes/sp500.sexp")
  (universe_size 491)
- ;; enable_short_side disabled 2026-04-29: short-side gaps surfaced on the
- ;; sp500 baseline rerun (post-#680). 128 short entries during 2019's Bearish
- ;; macro rode the 2020-2023 bull market with stops not firing correctly; the
- ;; portfolio went negative on multiple days. Until short-side stops + the
- ;; visibility/force-liquidation gaps are closed, this scenario runs long-only.
- ;; Tracked in dev/notes/short-side-gaps-2026-04-29.md.
- (config_overrides (((enable_short_side false))))
- ;; BASELINE_PENDING — wide ranges while we capture the long-only baseline
- ;; (post-#680, enable_short_side=false). Re-pin once the maintainer-local
- ;; rerun lands and the short-side gaps note has the corrected metrics.
+ (config_overrides ())
  (expected
-  ((total_return_pct   ((min -100.0)      (max 500.0)))
-   (total_trades       ((min 0)           (max 1000)))
-   (win_rate           ((min 0.0)         (max 100.0)))
-   (sharpe_ratio       ((min -10.0)       (max 10.0)))
-   (max_drawdown_pct   ((min 0.0)         (max 100.0)))
-   (avg_holding_days   ((min 0.0)         (max 1000.0)))
-   (unrealized_pnl     ((min -10000000.0) (max 10000000.0))))))
+  ((total_return_pct   ((min -15.0)       (max  15.0)))
+   (total_trades       ((min 27)          (max  37)))
+   (win_rate           ((min 31.0)        (max  44.0)))
+   (sharpe_ratio       ((min -0.5)        (max  0.5)))
+   (max_drawdown_pct   ((min 3.0)         (max  9.0)))
+   (avg_holding_days   ((min 37.0)        (max  50.0)))
+   (unrealized_pnl     ((min 330000.0)    (max  450000.0))))))


### PR DESCRIPTION
## Summary

Removes the `enable_short_side = false` override from the
`sp500-2019-2023` golden scenario and re-pins expected ranges to the
with-shorts baseline measured 2026-04-30 evening on `main@origin =
d7e8b89b` (post-PR #710 G9 fix). All preconditions G1-G5 + G7-G9 are
now closed; this is the third retry of the rerun (prior runs surfaced
G7 + G9 respectively).

## Why now

Preconditions met:

- G1-G5: PRs #689-#695 (short-stop direction, metrics visibility,
  cash floor on shorts, force-liquidation policy, audit harness)
- G7 (PR #702): `Portfolio_risk.compute_position_size` accepts
  `~side`, caps shares at `max_short_exposure_pct = 30%` for shorts
- G8 (PR #705): `Portfolio_view._holding_market_value` signs by
  `pos.side` (longs `+`, shorts `-`)
- G9 (PR #710): `Force_liquidation_runner._portfolio_value` delegates
  to `Portfolio_view.portfolio_value` so the sign convention has a
  single source of truth

Two prior 2026-04-30 retries surfaced gaps:
- AM run (post-G5): 910 force-liquidations → G7 surfaced
- PM run (post-G7+G8): 928 force-liquidations → G9 surfaced

Third retry (this PR) confirms G7+G8+G9 in combination produce clean
metrics: 0 force-liquidations, deterministic sign convention, no
phantom-cycle artefacts.

## Measured baseline (post-G9, 2026-04-30 evening)

| Metric              | Value      |
|---------------------|------------|
| total_return_pct    |  -0.01     |
| total_trades        |    32      |
| win_rate            |  37.50%    |
| sharpe_ratio        |   0.01     |
| max_drawdown_pct    |   5.81     |
| avg_holding_days    |  43.03     |
| unrealized_pnl      |  391,949   |
| force_liquidations  |     0      |

Side breakdown: 28 long (12 wins, -$15,350 realized), 4 short (0 wins,
-$49,247 realized). All shorts entered during 2019's Bearish-macro
window and exited via `stop_loss` as the 2020-2023 bull market
unfolded — expected behaviour for shorts caught in a sustained bull
regime.

## Decision tree (all pass)

- [x] Total return > -10% (measured: -0.01%)
- [x] Force-liquidation count <= 50 (measured: 0)
- [x] portfolio_value never negative (min equity $941,915)
- [x] Avg holding days > 20 (measured: 43.03)
- [x] Position sizing <= 30% at entry (measured: max 12.5%)

## Changes

- `trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp`:
  - Remove `(config_overrides (((enable_short_side false))))`. The
    `config_overrides` field is required by the sexp schema, so it's
    replaced with `(config_overrides ())` (empty list) — defaulting
    `enable_short_side` back to `true`.
  - Drop the BASELINE_PENDING comment block and the disable rationale.
  - Add a measured-baseline summary comment block.
  - Re-tighten `expected` ranges to ±10-15% around measured metrics
    (window for 0%-ish return uses an absolute -15.0 to 15.0 band).
- `dev/notes/sp500-shortside-reenabled-2026-04-30.md` (new): full
  report — metrics table, side breakdown, comparison vs long-only /
  AM / PM runs, G1-G9 fix validation.
- `dev/notes/short-side-gaps-2026-04-29.md`: mark "Re-enabling shorts"
  as DONE 2026-04-30 (evening) with link to the rerun report.
- `dev/status/short-side-strategy.md`: note that shorts are now live
  in the sp500 regression scenario.

## Test plan

- [x] `dune build` (worktree, post-edit) — OK (zero warnings)
- [x] `dune build @fmt` — OK
- [x] Scenario passes against tightened ranges:
      ```
      Scenario                       Return  Trades  WinRate    MaxDD   Result
      ----------------------------------------------------------------------------
      sp500-2019-2023                 -0.0%      32    37.5%     5.8%   PASS
      ```
- [x] Pre-push verification: branch ancestry single commit on top of
      `origin/main = d7e8b89b`; no sibling-agent commits in lineage.

## Follow-ups (not in this PR)

- Long-side entry rate dropped from 134 (long-only) to 28 (with shorts
  on). Worth investigating whether the cascade interaction is
  appropriately calibrated. Tracked as a follow-up in the rerun report.
- Short-side hit rate 0/4 in this period is a profitability question,
  not a correctness one — separate strategy-tuning work.
- G5 audit harness to default `enable_short_side = true` for the
  regression baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)