### PR TITLE
feat(result_writer): emit open_positions.csv + splits.csv + final_prices.csv for reconciler

### DIFF
--- a/dev/notes/reconciler-producer-csvs-2026-04-30.md
+++ b/dev/notes/reconciler-producer-csvs-2026-04-30.md
@@ -1,0 +1,83 @@
+# Reconciler-producer CSVs (2026-04-30)
+
+Wires three new per-scenario artefacts that the external
+`trading-reconciler` tool consumes to verify cash-floor / held-through-split
+/ unrealized-P&L accounting independently of the backtest's own metrics
+pipeline. Schemas are pinned by `~/Projects/trading-reconciler/PHASE_1_SPEC.md`
+§3 + §4 + §3.3.
+
+## What landed
+
+`Result_writer.write` now emits, alongside the existing `trades.csv` /
+`equity_curve.csv` / `summary.sexp` / `trade_audit.sexp` /
+`force_liquidations.sexp` artefacts:
+
+- `open_positions.csv` — one row per Holding position at run end.
+  Columns: `symbol,side,entry_date,entry_price,quantity`. `side` is
+  `LONG` / `SHORT` (case-sensitive, derived from net quantity sign).
+  `entry_price` is the per-share average cost; `quantity` is the absolute
+  share count.
+
+- `final_prices.csv` — one row per symbol present in `open_positions.csv`.
+  Columns: `symbol,price`. Price is the close on the run's final
+  calendar day, snapshotted from the panel runner's `Bar_panels.t` at
+  `n_days - 1`. Symbols held at run end without a final-day bar (delisted
+  / suspended / pre-IPO on that day) are silently dropped — the reconciler
+  surfaces the gap via its left-anti join.
+
+- `splits.csv` — one row per split event during the run window.
+  Columns: `symbol,date,factor`. Sourced from `step_result.splits_applied`
+  across all steps (the simulator only logs splits for symbols actively
+  held that day, so no further filtering is needed).
+
+All three CSVs are header-only when there is nothing to record. The
+reconciler accepts the empty-with-header form (treats it as "zero
+records to verify").
+
+## How the price snapshot threads through
+
+`Panel_runner.run` was extended to return a fifth tuple element
+`final_close_prices : (string * float) list`. After the simulation loop
+completes, it iterates the universe via `Symbol_index.symbols` and reads
+cell `(row, n_days - 1)` of `Ohlcv_panels.close`. NaN cells are dropped.
+
+`Runner.run_backtest` filters that alist to symbols still held in the
+last step's portfolio and stores the result in `Runner.result.final_prices`.
+Filtering happens at the runner level, not the writer level, so callers
+that don't need the CSV (e.g. ad-hoc scripts using `Runner.run_backtest`
+without `Result_writer.write`) still pay only the universe-scan cost
+once.
+
+## Test coverage
+
+`trading/trading/backtest/test/test_result_writer.ml` was extended with
+six tests pinning the artefact schemas end-to-end:
+
+- `open_positions.csv` header + rows for one LONG + one SHORT
+- `open_positions.csv` empty case writes header-only
+- `final_prices.csv` header + rows; entries for non-held symbols dropped
+- `final_prices.csv` empty case writes header-only
+- `splits.csv` header + rows for forward (4.0) + reverse (0.125) splits
+- `splits.csv` empty case writes header-only
+
+Reconciler validates files on header match and exits 2 on any drift, so
+tests assert both the literal header text and the row format strictly.
+
+## Files touched
+
+- `trading/trading/backtest/lib/runner.{ml,mli}` — `final_prices` field
+  on `Runner.result`; `_final_prices_for_held_symbols` helper.
+- `trading/trading/backtest/lib/panel_runner.{ml,mli}` — fifth tuple
+  element from `run`; `_final_close_prices` helper.
+- `trading/trading/backtest/lib/result_writer.{ml,mli}` — three new
+  writers (`_write_open_positions`, `_write_final_prices`,
+  `_write_splits`) wired into `Result_writer.write`.
+- `trading/trading/backtest/test/test_result_writer.ml` — six new tests.
+- `trading/trading/backtest/test/test_trade_audit_report.ml` — one-line
+  fix to add `final_prices = []` to a record literal.
+
+## Out of scope
+
+None of the existing artefacts changed. `trades.csv` schema is
+unchanged. Splits sourced from `step_result.splits_applied` so no new
+plumbing through `Runner.result.steps` was needed.

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -174,6 +174,24 @@ let _run_simulator_with_gc_trace ?gc_trace sim =
   in
   loop sim ~pending_date:start_date
 
+(** Snapshot of close prices on the final calendar column. Iterates the universe
+    via [Symbol_index.symbols] and reads cell [(row, n_days - 1)] of
+    [Ohlcv_panels.close]. Symbols whose final cell is NaN (no bar that day —
+    weekend, holiday, suspended, or pre-IPO) are dropped. Empty result when
+    [n_days = 0]. The runner filters this alist to held symbols when populating
+    [Runner.result.final_prices]. *)
+let _final_close_prices ~ohlcv =
+  let n_days = Ohlcv_panels.n_days ohlcv in
+  if n_days <= 0 then []
+  else
+    let last_col = n_days - 1 in
+    let close_panel = Ohlcv_panels.close ohlcv in
+    let symbol_index = Ohlcv_panels.symbol_index ohlcv in
+    let symbols = Symbol_index.symbols symbol_index in
+    List.filter_mapi symbols ~f:(fun row symbol ->
+        let v = close_panel.{row, last_col} in
+        if Float.is_nan v then None else Some (symbol, v))
+
 let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     ~commission ?trace ?gc_trace () =
   let warmup_start = Date.add_days start_date (-warmup_days) in
@@ -211,4 +229,5 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     Trace.record ?trace ~symbols_in:n_all_symbols Trace.Phase.Fill (fun () ->
         _run_simulator_with_gc_trace ?gc_trace sim)
   in
-  (sim_result, stop_log, trade_audit, force_liquidation_log)
+  let final_close_prices = _final_close_prices ~ohlcv in
+  (sim_result, stop_log, trade_audit, force_liquidation_log, final_close_prices)

--- a/trading/trading/backtest/lib/panel_runner.mli
+++ b/trading/trading/backtest/lib/panel_runner.mli
@@ -47,14 +47,21 @@ val run :
   * Stop_log.t
   * Trade_audit.t
   * Force_liquidation_log.t
+  * (string * float) list
 (** Same shape as the Legacy path's per-strategy entry point. The Panel branch
     in [Runner] uses this; callers should not call this directly outside of
     tests.
 
-    Returns a triple of [(run_result, stop_log, trade_audit)]: the simulator
-    output, the per-position stop log accumulated by the strategy wrapper, and
-    the per-trade decision-trail audit collected at the strategy's entry / exit
-    decision sites (PR-2 of the trade-audit plan).
+    Returns a 5-tuple
+    [(run_result, stop_log, trade_audit, force_liquidation_log,
+     final_close_prices)]: the simulator output, the per-position stop log
+    accumulated by the strategy wrapper, the per-trade decision-trail audit
+    collected at the strategy's entry / exit decision sites (PR-2 of the
+    trade-audit plan), the force-liquidation event log, and an alist of
+    [(symbol, close_price)] read from the [Bar_panels.t] last calendar column
+    for every symbol in the universe with a non-NaN close at run end. The
+    consumer ([Runner]) filters [final_close_prices] to symbols still held at
+    end of run when populating [Runner.result.final_prices].
 
     [gc_trace], when passed, snapshots [Gc.stat] before and after every
     simulator step (one step = one calendar day = one [Engine.update_market]

--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -260,12 +260,12 @@ let _write_final_prices ~output_dir ~steps
       | None -> ());
   Out_channel.close oc
 
-(** Format a split factor for [splits.csv]. PHASE_1_SPEC §4 examples show
-    plain decimal output: [4.0] for forward 4:1, [0.125] for reverse 1:8.
-    Strategy: integer factors render as [N.0] (via [%.1f]); fractional factors
-    use [%.6g], which produces canonical [0.125] / [1.5] without trailing
-    zeros. [%g] alone prints integer factors as ["4"] without a decimal point,
-    which trips reconciler parsers expecting a float. *)
+(** Format a split factor for [splits.csv]. PHASE_1_SPEC §4 examples show plain
+    decimal output: [4.0] for forward 4:1, [0.125] for reverse 1:8. Strategy:
+    integer factors render as [N.0] (via [%.1f]); fractional factors use [%.6g],
+    which produces canonical [0.125] / [1.5] without trailing zeros. [%g] alone
+    prints integer factors as ["4"] without a decimal point, which trips
+    reconciler parsers expecting a float. *)
 let _format_split_factor (f : float) =
   if Float.( = ) f (Float.round_down f) then sprintf "%.1f" f
   else sprintf "%.6g" f

--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -176,6 +176,116 @@ let _write_force_liquidations ~output_dir
         (output_dir ^ "/force_liquidations.sexp")
         (Force_liquidation_log.sexp_of_artefact blob)
 
+(* ------------------------------------------------------------------ *)
+(* Reconciler-producer artefacts                                        *)
+(*                                                                      *)
+(* The external [trading-reconciler] tool consumes three additional     *)
+(* per-scenario CSVs to verify cash-floor / held-through-split /        *)
+(* unrealized-P&L accounting. Schemas are pinned by                     *)
+(* [~/Projects/trading-reconciler/PHASE_1_SPEC.md] §3 + §4 + §3.3 — the *)
+(* reconciler exits 2 on any header drift so the writers below          *)
+(* deliberately use literal header strings to land in the diff if       *)
+(* drifted.                                                             *)
+(* ------------------------------------------------------------------ *)
+
+(** [LONG] for net-positive quantity, [SHORT] for net-negative. Used in
+    [open_positions.csv] — case-sensitive per spec. *)
+let _open_position_side_label (qty : float) =
+  if Float.( > ) qty 0.0 then "LONG" else "SHORT"
+
+(** Earliest acquisition date across the position's lots — the position's "entry
+    date" in the PHASE_1_SPEC sense. The {!Trading_portfolio.Types.position_lot}
+    invariant ([lots] sorted ascending by [acquisition_date]) means this is
+    [(List.hd_exn lots).acquisition_date], but we [List.min_elt] defensively in
+    case future refactors break the sort. *)
+let _entry_date_of (pos : Trading_portfolio.Types.portfolio_position) =
+  match
+    List.min_elt pos.lots ~compare:(fun a b ->
+        Date.compare a.acquisition_date b.acquisition_date)
+  with
+  | Some lot -> lot.acquisition_date
+  | None -> failwithf "position %s has no lots" pos.symbol ()
+
+(** One row per [Holding] position at run end. PHASE_1_SPEC §3:
+    [symbol,side,entry_date,entry_price,quantity]. [entry_price] is the average
+    cost per share (positive for both longs and shorts); [quantity] is the
+    absolute share count. *)
+let _write_open_positions ~output_dir ~steps =
+  let open Trading_simulation_types.Simulator_types in
+  let path = output_dir ^ "/open_positions.csv" in
+  let oc = Out_channel.create path in
+  fprintf oc "symbol,side,entry_date,entry_price,quantity\n";
+  (match List.last steps with
+  | None -> ()
+  | Some last_step ->
+      List.iter last_step.portfolio.Trading_portfolio.Portfolio.positions
+        ~f:(fun (pos : Trading_portfolio.Types.portfolio_position) ->
+          let qty = Trading_portfolio.Calculations.position_quantity pos in
+          let avg_cost =
+            Trading_portfolio.Calculations.avg_cost_of_position pos
+          in
+          let side = _open_position_side_label qty in
+          let entry_date = _entry_date_of pos in
+          fprintf oc "%s,%s,%s,%.2f,%.0f\n" pos.symbol side
+            (Date.to_string entry_date)
+            avg_cost (Float.abs qty)));
+  Out_channel.close oc
+
+(** One row per symbol present in [open_positions.csv]. PHASE_1_SPEC §3.3:
+    [symbol,price]. Symbols held at run end without an entry in [final_prices]
+    (e.g. delisted on the final calendar day) are silently dropped — the
+    reconciler's join is left-anti and surfaces these as "missing final price"
+    diagnostics. *)
+let _write_final_prices ~output_dir ~steps
+    ~(final_prices : (string * float) list) =
+  let open Trading_simulation_types.Simulator_types in
+  let path = output_dir ^ "/final_prices.csv" in
+  let oc = Out_channel.create path in
+  fprintf oc "symbol,price\n";
+  let held_symbols =
+    match List.last steps with
+    | None -> String.Set.empty
+    | Some last_step ->
+        last_step.portfolio.Trading_portfolio.Portfolio.positions
+        |> List.map ~f:(fun (p : Trading_portfolio.Types.portfolio_position) ->
+            p.symbol)
+        |> String.Set.of_list
+  in
+  let price_map =
+    Map.of_alist_reduce (module String) final_prices ~f:(fun a _ -> a)
+  in
+  Set.iter held_symbols ~f:(fun sym ->
+      match Map.find price_map sym with
+      | Some price -> fprintf oc "%s,%.2f\n" sym price
+      | None -> ());
+  Out_channel.close oc
+
+(** Format a split factor for [splits.csv]. PHASE_1_SPEC §4 examples show
+    plain decimal output: [4.0] for forward 4:1, [0.125] for reverse 1:8.
+    Strategy: integer factors render as [N.0] (via [%.1f]); fractional factors
+    use [%.6g], which produces canonical [0.125] / [1.5] without trailing
+    zeros. [%g] alone prints integer factors as ["4"] without a decimal point,
+    which trips reconciler parsers expecting a float. *)
+let _format_split_factor (f : float) =
+  if Float.( = ) f (Float.round_down f) then sprintf "%.1f" f
+  else sprintf "%.6g" f
+
+(** All split events that fired during the run. Pulled from
+    [step_result.splits_applied] across every step the simulator produced (the
+    simulator only logs splits for symbols actively held that day, so no further
+    filtering is needed). PHASE_1_SPEC §4: [symbol,date,factor]. *)
+let _write_splits ~output_dir ~steps =
+  let open Trading_simulation_types.Simulator_types in
+  let path = output_dir ^ "/splits.csv" in
+  let oc = Out_channel.create path in
+  fprintf oc "symbol,date,factor\n";
+  List.iter steps ~f:(fun (s : step_result) ->
+      List.iter s.splits_applied
+        ~f:(fun (e : Trading_portfolio.Split_event.t) ->
+          fprintf oc "%s,%s,%s\n" e.symbol (Date.to_string e.date)
+            (_format_split_factor e.factor)));
+  Out_channel.close oc
+
 let write ~output_dir (result : Runner.result) =
   _write_params ~output_dir result;
   Sexp.save_hum
@@ -188,4 +298,8 @@ let write ~output_dir (result : Runner.result) =
     ~cascade_summaries:result.cascade_summaries;
   _write_force_liquidations ~output_dir
     ~force_liquidations:result.force_liquidations;
+  _write_open_positions ~output_dir ~steps:result.steps;
+  _write_final_prices ~output_dir ~steps:result.steps
+    ~final_prices:result.final_prices;
+  _write_splits ~output_dir ~steps:result.steps;
   Macro_trend_writer.write ~output_dir result.cascade_summaries

--- a/trading/trading/backtest/lib/result_writer.mli
+++ b/trading/trading/backtest/lib/result_writer.mli
@@ -3,7 +3,8 @@
     customize what gets written. *)
 
 val write : output_dir:string -> Runner.result -> unit
-(** Write [params.sexp], [summary.sexp], [trades.csv], [equity_curve.csv], and
+(** Write [params.sexp], [summary.sexp], [trades.csv], [equity_curve.csv],
+    [open_positions.csv], [final_prices.csv], [splits.csv], and
     [macro_trend.sexp] into [output_dir]. The directory must already exist.
 
     Additionally writes [trade_audit.sexp] iff [result.audit] is non-empty.
@@ -13,4 +14,10 @@ val write : output_dir:string -> Runner.result -> unit
 
     [macro_trend.sexp] is always written (one entry per Friday the screener
     fired, possibly empty list) — counterfactual tooling consumes it to replay
-    per-Friday macro state. See {!Macro_trend_writer}. *)
+    per-Friday macro state. See {!Macro_trend_writer}.
+
+    The reconciler-producer artefacts ([open_positions.csv], [splits.csv],
+    [final_prices.csv]) are always written, header-only when there is nothing to
+    record. Consumed by the external [trading-reconciler] tool to verify
+    cash-floor / held-through-split / unrealized-P&L accounting — see
+    [~/Projects/trading-reconciler/PHASE_1_SPEC.md] §3 + §4 + §3.3. *)

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -27,6 +27,7 @@ type result = {
   audit : Trade_audit.audit_record list;
   cascade_summaries : Trade_audit.cascade_summary list;
   force_liquidations : Portfolio_risk.Force_liquidation.event list;
+  final_prices : (string * float) list;
 }
 
 (* Trading-day filter *)
@@ -251,6 +252,24 @@ let _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
     metrics = sim_result.Trading_simulation_types.Simulator_types.metrics;
   }
 
+(** Filter [final_close_prices] to symbols that are still held in the last
+    step's portfolio. Empty result when [steps] is empty or no positions are
+    open. The reconciler only references [final_prices.csv] via the join key
+    against [open_positions.csv], so prices for never-held or already-closed
+    symbols are not needed and would just bloat the artefact. *)
+let _final_prices_for_held_symbols ~steps ~final_close_prices =
+  match List.last steps with
+  | None -> []
+  | Some last_step ->
+      let open Trading_simulation_types.Simulator_types in
+      let held =
+        last_step.portfolio.Trading_portfolio.Portfolio.positions
+        |> List.map ~f:(fun (p : Trading_portfolio.Types.portfolio_position) ->
+            p.symbol)
+        |> String.Set.of_list
+      in
+      List.filter final_close_prices ~f:(fun (sym, _) -> Set.mem held sym)
+
 let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     ?trace ?gc_trace () =
   let deps = _load_deps ?trace ?gc_trace ~overrides ~sector_map_override () in
@@ -261,7 +280,11 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     (Date.to_string start_date)
     (Date.to_string end_date)
     (Date.to_string warmup_start);
-  let sim_result, stop_log, trade_audit, force_liquidation_log =
+  let ( sim_result,
+        stop_log,
+        trade_audit,
+        force_liquidation_log,
+        final_close_prices ) =
     _run_panel_backtest ~deps ~start_date ~end_date ?trace ?gc_trace ()
   in
   Gc_trace.record ?trace:gc_trace ~phase:"fill_done" ();
@@ -295,6 +318,9 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
       ~sim_result
   in
+  let final_prices =
+    _final_prices_for_held_symbols ~steps ~final_close_prices
+  in
   {
     summary;
     round_trips;
@@ -304,4 +330,5 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     audit;
     cascade_summaries;
     force_liquidations;
+    final_prices;
   }

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -41,6 +41,15 @@ type result = {
           persists it as [force_liquidations.sexp]. Each event is evidence the
           primary stop machinery failed to protect a trade — non-zero counts on
           a release run flag a regression. *)
+  final_prices : (string * float) list;
+      (** Snapshot of close prices on the run's final calendar day, keyed by
+          symbol. Populated by [Panel_runner.run] from the [Bar_panels.t] last
+          column for every symbol still held in
+          [(List.last_exn steps).portfolio.positions]; empty when the simulation
+          never reached the final calendar day or no positions were held at end.
+          Consumed by [Result_writer] to emit [final_prices.csv] for the
+          external [trading-reconciler] tool — see
+          [~/Projects/trading-reconciler/PHASE_1_SPEC.md] §3.3. *)
 }
 
 val is_trading_day :

--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -9,7 +9,13 @@
     literal label strings live only in [result_writer.ml] and were previously
     not asserted by any test — these tests pin them end-to-end so a refactor
     that drifts the strings or breaks the substitution rule fails
-    deterministically. *)
+    deterministically.
+
+    Also pins the reconciler-producer artefacts ([open_positions.csv],
+    [splits.csv], [final_prices.csv]) — see
+    [~/Projects/trading-reconciler/PHASE_1_SPEC.md]. The reconciler validates
+    these files on header match and exits 2 on drift, so tests pin both the
+    header and the row format strictly. *)
 
 open Core
 open OUnit2
@@ -71,19 +77,79 @@ let _empty_summary ~start_date ~end_date : Backtest.Summary.t =
     metrics = Trading_simulation_types.Metric_types.empty;
   }
 
-let _make_result ~round_trips ~force_liquidations : Backtest.Runner.result =
+let _make_result ?(steps = []) ?(final_prices = []) ~round_trips
+    ~force_liquidations () : Backtest.Runner.result =
   let start_date = _date "2024-01-02" in
   let end_date = _date "2024-04-29" in
   {
     summary = _empty_summary ~start_date ~end_date;
     round_trips;
-    steps = [];
+    steps;
     overrides = [];
     stop_infos = [];
     audit = [];
     cascade_summaries = [];
     force_liquidations;
+    final_prices;
   }
+
+(** Build a [Trading_portfolio.Types.portfolio_position] with a single lot. The
+    [quantity] sign carries the side: positive for longs, negative for shorts.
+    [cost_basis] is the {e total} cost (entry_price × quantity), preserving the
+    invariant {!Trading_portfolio.Calculations.avg_cost_of_position} relies on.
+*)
+let _make_position ~symbol ~quantity ~entry_price ~entry_date :
+    Trading_portfolio.Types.portfolio_position =
+  let cost_basis = entry_price *. Float.abs quantity in
+  {
+    symbol;
+    accounting_method = Trading_portfolio.Types.AverageCost;
+    lots =
+      [
+        {
+          lot_id = symbol ^ "-1";
+          quantity;
+          cost_basis;
+          acquisition_date = entry_date;
+        };
+      ];
+  }
+
+let _make_portfolio ~positions : Trading_portfolio.Portfolio.t =
+  {
+    initial_cash = 100_000.0;
+    trade_history = [];
+    current_cash = 50_000.0;
+    positions;
+    accounting_method = Trading_portfolio.Types.AverageCost;
+    unrealized_pnl_per_position = [];
+  }
+
+(** Build a [step_result] with the supplied portfolio + splits_applied. The
+    [date] is the step's date; [trades] / [orders_submitted] are empty because
+    the reconciler artefacts under test consume only [portfolio] (open
+    positions) and [splits_applied] (split events). *)
+let _make_step ~date ~portfolio ?(splits_applied = []) () :
+    Trading_simulation_types.Simulator_types.step_result =
+  {
+    date;
+    portfolio;
+    portfolio_value = portfolio.Trading_portfolio.Portfolio.current_cash;
+    trades = [];
+    orders_submitted = [];
+    splits_applied;
+  }
+
+(** Read a header-and-rows CSV back as [(header_columns, row_columns_list)].
+    Each row is split on [,]. Mirrors [_read_trades_csv] but generalized so the
+    new tests can read any of the three new CSVs through one helper. *)
+let _read_csv ~path =
+  match In_channel.read_lines path with
+  | header :: rows ->
+      let header_cols = String.split header ~on:',' in
+      let rows_cols = List.map rows ~f:(fun r -> String.split r ~on:',') in
+      (header_cols, rows_cols)
+  | [] -> assert_failure ("CSV missing or empty: " ^ path)
 
 (** Read [trades.csv] back into [(header, rows)] where [rows] are split on the
     first comma so callers can index into specific columns by header position
@@ -123,7 +189,7 @@ let test_per_position_force_liq_overrides_exit_trigger _ =
         _make_event ~symbol:"AAPL" ~exit_date ~reason:FL.Per_position
       in
       let result =
-        _make_result ~round_trips:[ trade ] ~force_liquidations:[ event ]
+        _make_result ~round_trips:[ trade ] ~force_liquidations:[ event ] ()
       in
       Backtest.Result_writer.write ~output_dir:dir result;
       let header, rows = _read_trades_csv ~output_dir:dir in
@@ -153,7 +219,7 @@ let test_portfolio_floor_force_liq_overrides_exit_trigger _ =
         _make_event ~symbol:"TSLA" ~exit_date ~reason:FL.Portfolio_floor
       in
       let result =
-        _make_result ~round_trips:[ trade ] ~force_liquidations:[ event ]
+        _make_result ~round_trips:[ trade ] ~force_liquidations:[ event ] ()
       in
       Backtest.Result_writer.write ~output_dir:dir result;
       let header, rows = _read_trades_csv ~output_dir:dir in
@@ -190,7 +256,7 @@ let test_non_matching_event_does_not_override _ =
           ~reason:FL.Per_position
       in
       let result =
-        _make_result ~round_trips:[ trade ] ~force_liquidations:[ event ]
+        _make_result ~round_trips:[ trade ] ~force_liquidations:[ event ] ()
       in
       Backtest.Result_writer.write ~output_dir:dir result;
       let header, rows = _read_trades_csv ~output_dir:dir in
@@ -208,6 +274,209 @@ let test_non_matching_event_does_not_override _ =
            ]))
 
 (* ------------------------------------------------------------------ *)
+(* Reconciler-producer artefacts                                        *)
+(*                                                                      *)
+(* PHASE_1_SPEC.md §3 + §4 + §3.3 schemas pinned end-to-end. The        *)
+(* downstream reconciler validates files on header match and exits 2 on *)
+(* any drift, so these tests assert both the header text and the row    *)
+(* shape exactly.                                                       *)
+(* ------------------------------------------------------------------ *)
+
+(** Run [Result_writer.write] inside a temp directory, then pass the directory
+    path to [k]. The directory is removed even on test failure. *)
+let _with_writer_output ~result ~prefix k =
+  let dir = Core_unix.mkdtemp prefix in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" dir) in
+      ())
+    (fun () ->
+      Backtest.Result_writer.write ~output_dir:dir result;
+      k dir)
+
+(* ------------------------------------------------------------------ *)
+(* open_positions.csv                                                   *)
+(* ------------------------------------------------------------------ *)
+
+(** Per PHASE_1_SPEC §3, the file has columns
+    [symbol,side,entry_date,entry_price,quantity] with one row per Holding
+    position at run end, [side] is uppercase (LONG / SHORT), [entry_date] is
+    [YYYY-MM-DD], and [quantity] is the entry-leg (positive) quantity. *)
+let test_open_positions_csv_header_and_rows _ =
+  let long_pos =
+    _make_position ~symbol:"AAPL" ~quantity:100.0 ~entry_price:189.50
+      ~entry_date:(_date "2024-11-15")
+  in
+  let short_pos =
+    _make_position ~symbol:"TSLA" ~quantity:(-50.0) ~entry_price:420.00
+      ~entry_date:(_date "2025-02-04")
+  in
+  let portfolio = _make_portfolio ~positions:[ long_pos; short_pos ] in
+  let step = _make_step ~date:(_date "2024-04-29") ~portfolio () in
+  let result =
+    _make_result ~round_trips:[] ~force_liquidations:[] ~steps:[ step ] ()
+  in
+  _with_writer_output ~result ~prefix:"/tmp/result_writer_open_pos_" (fun dir ->
+      let header, rows = _read_csv ~path:(dir ^ "/open_positions.csv") in
+      assert_that header
+        (elements_are
+           [
+             equal_to "symbol";
+             equal_to "side";
+             equal_to "entry_date";
+             equal_to "entry_price";
+             equal_to "quantity";
+           ]);
+      assert_that rows
+        (elements_are
+           [
+             elements_are
+               [
+                 equal_to "AAPL";
+                 equal_to "LONG";
+                 equal_to "2024-11-15";
+                 equal_to "189.50";
+                 equal_to "100";
+               ];
+             elements_are
+               [
+                 equal_to "TSLA";
+                 equal_to "SHORT";
+                 equal_to "2025-02-04";
+                 equal_to "420.00";
+                 equal_to "50";
+               ];
+           ]))
+
+(** Empty case: no open positions → header-only file. The reconciler still
+    accepts this (an empty input means zero open positions to verify). *)
+let test_open_positions_csv_empty_writes_header_only _ =
+  let portfolio = _make_portfolio ~positions:[] in
+  let step = _make_step ~date:(_date "2024-04-29") ~portfolio () in
+  let result =
+    _make_result ~round_trips:[] ~force_liquidations:[] ~steps:[ step ] ()
+  in
+  _with_writer_output ~result ~prefix:"/tmp/result_writer_open_pos_empty_"
+    (fun dir ->
+      let header, rows = _read_csv ~path:(dir ^ "/open_positions.csv") in
+      assert_that header
+        (elements_are
+           [
+             equal_to "symbol";
+             equal_to "side";
+             equal_to "entry_date";
+             equal_to "entry_price";
+             equal_to "quantity";
+           ]);
+      assert_that rows (elements_are []))
+
+(* ------------------------------------------------------------------ *)
+(* final_prices.csv                                                     *)
+(* ------------------------------------------------------------------ *)
+
+(** Per PHASE_1_SPEC §3.3, the file has columns [symbol,price] with one row per
+    symbol present in [open_positions.csv]. The runner threads [final_prices] as
+    an alist; [Result_writer] filters to held symbols. *)
+let test_final_prices_csv_header_and_rows _ =
+  let long_pos =
+    _make_position ~symbol:"AAPL" ~quantity:100.0 ~entry_price:189.50
+      ~entry_date:(_date "2024-11-15")
+  in
+  let short_pos =
+    _make_position ~symbol:"TSLA" ~quantity:(-50.0) ~entry_price:420.00
+      ~entry_date:(_date "2025-02-04")
+  in
+  let portfolio = _make_portfolio ~positions:[ long_pos; short_pos ] in
+  let step = _make_step ~date:(_date "2024-04-29") ~portfolio () in
+  (* Include extra symbols not held — they must be dropped. *)
+  let final_prices = [ ("AAPL", 182.45); ("TSLA", 395.10); ("NVDA", 800.00) ] in
+  let result =
+    _make_result ~round_trips:[] ~force_liquidations:[] ~steps:[ step ]
+      ~final_prices ()
+  in
+  _with_writer_output ~result ~prefix:"/tmp/result_writer_final_prices_"
+    (fun dir ->
+      let header, rows = _read_csv ~path:(dir ^ "/final_prices.csv") in
+      assert_that header (elements_are [ equal_to "symbol"; equal_to "price" ]);
+      assert_that rows
+        (elements_are
+           [
+             elements_are [ equal_to "AAPL"; equal_to "182.45" ];
+             elements_are [ equal_to "TSLA"; equal_to "395.10" ];
+           ]))
+
+(** Empty case: no open positions → header-only file regardless of how many
+    [final_prices] entries the runner supplied. *)
+let test_final_prices_csv_empty_writes_header_only _ =
+  let portfolio = _make_portfolio ~positions:[] in
+  let step = _make_step ~date:(_date "2024-04-29") ~portfolio () in
+  let result =
+    _make_result ~round_trips:[] ~force_liquidations:[] ~steps:[ step ]
+      ~final_prices:[ ("AAPL", 100.0) ]
+      ()
+  in
+  _with_writer_output ~result ~prefix:"/tmp/result_writer_final_prices_empty_"
+    (fun dir ->
+      let header, rows = _read_csv ~path:(dir ^ "/final_prices.csv") in
+      assert_that header (elements_are [ equal_to "symbol"; equal_to "price" ]);
+      assert_that rows (elements_are []))
+
+(* ------------------------------------------------------------------ *)
+(* splits.csv                                                           *)
+(* ------------------------------------------------------------------ *)
+
+(** Per PHASE_1_SPEC §4, the file has columns [symbol,date,factor]. Splits are
+    pulled from [step_result.splits_applied] across all steps — deduplicated on
+    [(symbol, date)] in case the simulator emits the same event on multiple
+    holding positions of the same symbol. *)
+let test_splits_csv_header_and_rows _ =
+  let portfolio = _make_portfolio ~positions:[] in
+  let split_aapl : Trading_portfolio.Split_event.t =
+    { symbol = "AAPL"; date = _date "2020-08-31"; factor = 4.0 }
+  in
+  let split_ge : Trading_portfolio.Split_event.t =
+    { symbol = "GE"; date = _date "2021-08-02"; factor = 0.125 }
+  in
+  let step1 =
+    _make_step ~date:(_date "2020-08-31") ~portfolio
+      ~splits_applied:[ split_aapl ] ()
+  in
+  let step2 =
+    _make_step ~date:(_date "2021-08-02") ~portfolio
+      ~splits_applied:[ split_ge ] ()
+  in
+  let result =
+    _make_result ~round_trips:[] ~force_liquidations:[] ~steps:[ step1; step2 ]
+      ()
+  in
+  _with_writer_output ~result ~prefix:"/tmp/result_writer_splits_" (fun dir ->
+      let header, rows = _read_csv ~path:(dir ^ "/splits.csv") in
+      assert_that header
+        (elements_are [ equal_to "symbol"; equal_to "date"; equal_to "factor" ]);
+      assert_that rows
+        (elements_are
+           [
+             elements_are
+               [ equal_to "AAPL"; equal_to "2020-08-31"; equal_to "4.0" ];
+             elements_are
+               [ equal_to "GE"; equal_to "2021-08-02"; equal_to "0.125" ];
+           ]))
+
+(** Empty case: no splits across steps → header-only file. *)
+let test_splits_csv_empty_writes_header_only _ =
+  let portfolio = _make_portfolio ~positions:[] in
+  let step = _make_step ~date:(_date "2024-04-29") ~portfolio () in
+  let result =
+    _make_result ~round_trips:[] ~force_liquidations:[] ~steps:[ step ] ()
+  in
+  _with_writer_output ~result ~prefix:"/tmp/result_writer_splits_empty_"
+    (fun dir ->
+      let header, rows = _read_csv ~path:(dir ^ "/splits.csv") in
+      assert_that header
+        (elements_are [ equal_to "symbol"; equal_to "date"; equal_to "factor" ]);
+      assert_that rows (elements_are []))
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -220,6 +489,17 @@ let suite =
          >:: test_portfolio_floor_force_liq_overrides_exit_trigger;
          "non-matching event does not override exit_trigger"
          >:: test_non_matching_event_does_not_override;
+         "open_positions.csv header and rows"
+         >:: test_open_positions_csv_header_and_rows;
+         "open_positions.csv empty writes header only"
+         >:: test_open_positions_csv_empty_writes_header_only;
+         "final_prices.csv header and rows"
+         >:: test_final_prices_csv_header_and_rows;
+         "final_prices.csv empty writes header only"
+         >:: test_final_prices_csv_empty_writes_header_only;
+         "splits.csv header and rows" >:: test_splits_csv_header_and_rows;
+         "splits.csv empty writes header only"
+         >:: test_splits_csv_empty_writes_header_only;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_trade_audit_report.ml
+++ b/trading/trading/backtest/test/test_trade_audit_report.ml
@@ -660,6 +660,7 @@ let _make_runner_result ~start_date ~end_date ~round_trips :
     audit = [];
     cascade_summaries = [];
     force_liquidations = [];
+    final_prices = [];
   }
 
 let test_writer_reader_post_g2_round_trip _ =


### PR DESCRIPTION
## Why

The external [`trading-reconciler`](~/Projects/trading-reconciler/) tool
needs three additional per-scenario CSVs to verify cash-floor /
held-through-split / unrealized-P&L accounting independently of the
backtest's own metrics pipeline. Schemas are pinned by
\`~/Projects/trading-reconciler/PHASE_1_SPEC.md\` §3 + §4 + §3.3 — the
reconciler exits 2 on any header drift.

## What's in scope

\`Result_writer.write\` now emits, alongside the existing artefacts:

- **\`open_positions.csv\`** — \`symbol,side,entry_date,entry_price,quantity\`.
  One row per Holding position at run end. \`side\` is uppercase
  (\`LONG\` / \`SHORT\`) derived from net quantity sign. Header-only when
  no positions are open.

- **\`final_prices.csv\`** — \`symbol,price\`. One row per symbol present in
  \`open_positions.csv\`. Price snapshotted from the panel runner's
  \`Bar_panels.t\` at \`n_days - 1\`. NaN cells (delisted / pre-IPO that
  day) are dropped. Header-only when no positions are open.

- **\`splits.csv\`** — \`symbol,date,factor\`. One row per split event
  during the run window, sourced from \`step_result.splits_applied\`
  across every step (the simulator only logs splits for symbols actively
  held that day, so no further filtering is needed). Splits are wired
  through the existing \`step_result\` channel — no new plumbing
  needed. Header-only when no splits fired.

All three CSVs are header-only when there is nothing to record (the
reconciler accepts the empty-with-header form).

## How the price snapshot threads through

\`Panel_runner.run\` was extended to return a fifth tuple element
\`final_close_prices : (string * float) list\`, populated from the OHLCV
panels' last column. \`Runner.run_backtest\` filters that alist to symbols
still held at end of run and stores it in \`Runner.result.final_prices\`.

## Splits.csv status

Wired through to actual split events via \`step_result.splits_applied\`.
No deferred follow-up needed.

## Test coverage

Six new tests in \`test_result_writer.ml\` pin the artefact schemas
end-to-end:

- \`open_positions.csv\` header + rows for one LONG + one SHORT
- \`open_positions.csv\` empty case writes header-only
- \`final_prices.csv\` header + rows; non-held symbols dropped
- \`final_prices.csv\` empty case writes header-only
- \`splits.csv\` header + rows for forward (\`4.0\`) + reverse (\`0.125\`)
- \`splits.csv\` empty case writes header-only

Reconciler validates files on header match and exits 2 on any drift, so
tests assert both literal header text and row format strictly.

## Test plan

- [x] \`dune build trading/backtest/\` passes
- [x] \`dune build trading/backtest/test/test_result_writer.exe && _build/default/trading/backtest/test/test_result_writer.exe\` — 9/9 tests pass
- [x] \`dune fmt\` — formatter clean
- [ ] Reviewer confirms PHASE_1_SPEC schemas match the writers in
  \`result_writer.ml\` lines for \`_write_open_positions\`,
  \`_write_final_prices\`, \`_write_splits\`

## Notes / follow-ups

- Pre-existing test_panel_runner_gc_trace / test_trade_audit_capture /
  test_runner_hypothesis_overrides failures remain due to data-path
  issues unrelated to this PR (worktree doesn't carry
  \`/workspaces/trading-1/data/backtest_scenarios/smoke/\`). They fail
  on \`Sys_error\` for the smoke fixture before reaching any of this
  PR's code.
- See \`dev/notes/reconciler-producer-csvs-2026-04-30.md\` for full
  details.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>