### PR TITLE
fix(summary): align summary win/loss count with trades.csv (reconciler-surfaced drift)

### DIFF
--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -238,6 +238,25 @@ let _run_panel_backtest ~deps ~start_date ~end_date ?trace ?gc_trace () =
     ~start_date ~end_date ~warmup_days ~initial_cash ~commission ?trace
     ?gc_trace ()
 
+(** Recompute the round-trip-derived metrics ([TotalPnl], [AvgHoldingDays],
+    [WinCount], [LossCount], [WinRate], [ProfitFactor]) from the runner's
+    range-filtered [round_trips] and overlay them onto the simulator's metric
+    set. This aligns the summary's win/loss counts with [trades.csv].
+
+    The simulator's [Summary_computer] folds over every step in [step_history],
+    including the warmup window (the simulator is configured with
+    [start_date = warmup_start]). The runner instead derives [round_trips] from
+    [steps_in_range] (steps with [date >= start_date]). When complete
+    round-trips fall in the warmup window, the simulator's metric set counts
+    them while [trades.csv] does not — observed empirically on
+    [panel-golden-2019-full] (summary wincount=3 vs trades.csv 2 wins). The
+    overlay restores the invariant that summary counts equal what's visible in
+    [trades.csv] / [n_round_trips]. *)
+let _align_summary_metrics_to_round_trips ~sim_result ~round_trips =
+  let overlay = Metrics.compute_round_trip_metric_set round_trips in
+  Trading_simulation_types.Metric_types.merge
+    sim_result.Trading_simulation_types.Simulator_types.metrics overlay
+
 let _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
     ~sim_result : Summary.t =
   {
@@ -248,7 +267,7 @@ let _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
     initial_cash;
     final_portfolio_value = final_value;
     n_round_trips = List.length round_trips;
-    metrics = sim_result.Trading_simulation_types.Simulator_types.metrics;
+    metrics = _align_summary_metrics_to_round_trips ~sim_result ~round_trips;
   }
 
 let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override

--- a/trading/trading/backtest/test/test_runner_filter.ml
+++ b/trading/trading/backtest/test/test_runner_filter.ml
@@ -172,6 +172,99 @@ let test_round_trip_extraction_survives_non_trading_day_filter _ =
     (List.length round_trips - List.length buggy_round_trips)
     (gt (module Int_ord) 0)
 
+(* -------------------------------------------------------------------- *)
+(* Phase 3: summary metrics overlay matches range-filtered round_trips    *)
+(* -------------------------------------------------------------------- *)
+
+(** Reconciler-surfaced regression: on [panel-golden-2019-full], summary's
+    WinCount disagreed with the count of [pnl_dollars > 0] rows in [trades.csv].
+    Root cause: the simulator runs from [warmup_start] to [end_date] and its
+    [Summary_computer] folds over the warmup steps too, while the runner's
+    [round_trips] are derived from [steps_in_range] (steps with
+    [date >= start_date]). When complete round-trips fall in the warmup window,
+    the simulator's metric set counts them but [trades.csv] does not.
+
+    [Backtest.Runner._make_summary] now overlays
+    [Metrics.compute_round_trip_metric_set runner_round_trips] onto
+    [sim_result.metrics] so the [Summary.t]'s WinCount/LossCount/etc. match
+    [trades.csv]. The overlay's semantics: keys present in the overlay win, keys
+    only in the simulator metric set are preserved (Sharpe, MaxDrawdown, CAGR,
+    etc., which are still computed from the full step series).
+
+    This test pins the alignment by composing the two public surfaces the runner
+    uses ([compute_round_trip_metric_set] + [Metric_types.merge]) — full
+    integration through [run_backtest] would require a real panel + scenario,
+    which is the smoke-fixture's domain. The synthetic case here mirrors the
+    panel-golden-2019-full bug exactly: simulator says 3 wins / 6 losses (warmup
+    contributed an extra 1 win + 1 loss); runner's range-filtered round_trips
+    show 2 wins / 5 losses. Post-overlay the summary must show 2 wins / 5
+    losses, never 3 / 6. *)
+let test_summary_metrics_overlay_aligns_with_range_round_trips _ =
+  let open Trading_simulation_types.Metric_types in
+  (* Simulator-reported metric_set: 3 wins + 6 losses (includes 1 win +
+     1 loss from the warmup window). *)
+  let sim_metrics =
+    of_alist_exn
+      [
+        (TotalPnl, -8000.0);
+        (WinCount, 3.0);
+        (LossCount, 6.0);
+        (WinRate, 33.33);
+        (AvgHoldingDays, 18.0);
+        (ProfitFactor, 0.4);
+        (* Non-round-trip metrics that the simulator computes from the
+           full step series — these must survive the overlay unchanged. *)
+        (SharpeRatio, 0.6);
+        (MaxDrawdown, 2.0);
+        (CAGR, 1.83);
+      ]
+  in
+  (* Runner's range-filtered round_trips: 2 wins, 5 losses. *)
+  let make_round_trip ~symbol ~pnl =
+    {
+      Trading_simulation.Metrics.symbol;
+      side = Trading_base.Types.Buy;
+      entry_date = date_of_string "2019-05-04";
+      exit_date = date_of_string "2019-05-07";
+      days_held = 3;
+      entry_price = 100.0;
+      exit_price = 100.0;
+      quantity = 100.0;
+      pnl_dollars = pnl;
+      pnl_percent = pnl /. 100.0;
+    }
+  in
+  let runner_round_trips =
+    [
+      make_round_trip ~symbol:"W1" ~pnl:1500.0;
+      make_round_trip ~symbol:"W2" ~pnl:1000.0;
+      make_round_trip ~symbol:"L1" ~pnl:(-2000.0);
+      make_round_trip ~symbol:"L2" ~pnl:(-1500.0);
+      make_round_trip ~symbol:"L3" ~pnl:(-1000.0);
+      make_round_trip ~symbol:"L4" ~pnl:(-500.0);
+      make_round_trip ~symbol:"L5" ~pnl:(-250.0);
+    ]
+  in
+  let overlay =
+    Trading_simulation.Metrics.compute_round_trip_metric_set runner_round_trips
+  in
+  let aligned = merge sim_metrics overlay in
+  assert_that aligned
+    (map_includes
+       [
+         (* The reconciler's arithmetic count must equal the summary's
+            count post-overlay. Both reflect runner_round_trips, not the
+            simulator's full-step view. *)
+         (WinCount, float_equal 2.0);
+         (LossCount, float_equal 5.0);
+         (WinRate, float_equal ~epsilon:1e-2 (2.0 /. 7.0 *. 100.0));
+         (TotalPnl, float_equal (-2750.0));
+         (* Non-overlay metrics (Sharpe, MaxDrawdown, CAGR) survive. *)
+         (SharpeRatio, float_equal 0.6);
+         (MaxDrawdown, float_equal 2.0);
+         (CAGR, float_equal 1.83);
+       ])
+
 let suite =
   "Runner_filter"
   >::: [
@@ -181,6 +274,8 @@ let suite =
          >:: test_is_trading_day_flat_value_with_positions;
          "round-trip extraction must not be gated on is_trading_day"
          >:: test_round_trip_extraction_survives_non_trading_day_filter;
+         "summary metrics overlay aligns with range-filtered round_trips"
+         >:: test_summary_metrics_overlay_aligns_with_range_round_trips;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/simulation/lib/metrics.ml
+++ b/trading/trading/simulation/lib/metrics.ml
@@ -171,3 +171,32 @@ let summary_stats_to_metrics (stats : summary_stats) : Metric_types.metric_set =
       (LossCount, Float.of_int stats.loss_count);
       (WinRate, stats.win_rate);
     ]
+
+let compute_profit_factor (round_trips : trade_metrics list) =
+  let gross_profit =
+    List.fold round_trips ~init:0.0 ~f:(fun acc (m : trade_metrics) ->
+        if Float.(m.pnl_dollars > 0.0) then acc +. m.pnl_dollars else acc)
+  in
+  let gross_loss =
+    List.fold round_trips ~init:0.0 ~f:(fun acc (m : trade_metrics) ->
+        if Float.(m.pnl_dollars < 0.0) then acc +. Float.abs m.pnl_dollars
+        else acc)
+  in
+  if Float.(gross_loss = 0.0) then
+    if Float.(gross_profit > 0.0) then Float.infinity else 0.0
+  else gross_profit /. gross_loss
+
+let compute_round_trip_metric_set (round_trips : trade_metrics list) :
+    Metric_types.metric_set =
+  let pf = compute_profit_factor round_trips in
+  let pf_metric = Metric_types.singleton ProfitFactor pf in
+  match compute_summary round_trips with
+  | None ->
+      (* Empty round-trip list: legacy [Summary_computer] still emitted
+         [ProfitFactor = 0.0] (see [compute_profit_factor] convention).
+         Pin the same shape so existing callers and the no-trades test
+         observe identical behaviour. *)
+      pf_metric
+  | Some stats ->
+      let base = summary_stats_to_metrics stats in
+      Metric_types.merge base pf_metric

--- a/trading/trading/simulation/lib/metrics.mli
+++ b/trading/trading/simulation/lib/metrics.mli
@@ -99,3 +99,26 @@ val show_summary : summary_stats -> string
 val summary_stats_to_metrics :
   summary_stats -> Trading_simulation_types.Metric_types.metric_set
 (** Convert summary_stats to metric_set *)
+
+val compute_profit_factor : trade_metrics list -> float
+(** Compute profit factor: gross profit divided by gross loss across the given
+    round-trips. Returns [Float.infinity] when there are profitable trades but
+    no losses, and [0.0] when there are no trades or no profits. *)
+
+val compute_round_trip_metric_set :
+  trade_metrics list -> Trading_simulation_types.Metric_types.metric_set
+(** Build the round-trip-derived metric set ([TotalPnl], [AvgHoldingDays],
+    [WinCount], [LossCount], [WinRate], [ProfitFactor]) directly from a list of
+    round-trips.
+
+    Empty [round_trips] yields just [{ ProfitFactor = 0.0 }] — matching the
+    legacy [Summary_computer] convention. The win/loss/PnL keys are omitted so
+    an empty-range overlay leaves the simulator's pre-existing reading intact
+    via [Metric_types.merge].
+
+    This is the canonical computation of round-trip-derived metrics — callers
+    that have already extracted [round_trips] should use this rather than
+    re-running the simulator's [Summary_computer] over a step list, which
+    re-derives [round_trips] internally and may pair across step ranges that
+    differ from the caller's window. See [Backtest.Runner._make_summary] for the
+    warmup-vs-range-window alignment use case. *)

--- a/trading/trading/simulation/lib/summary_computer.ml
+++ b/trading/trading/simulation/lib/summary_computer.ml
@@ -7,31 +7,10 @@ module Simulator_types = Trading_simulation_types.Simulator_types
 
 type state = { steps : Simulator_types.step_result list }
 
-let _compute_profit_factor (round_trips : Metrics.trade_metrics list) =
-  let gross_profit =
-    List.fold round_trips ~init:0.0 ~f:(fun acc (m : Metrics.trade_metrics) ->
-        if Float.(m.pnl_dollars > 0.0) then acc +. m.pnl_dollars else acc)
-  in
-  let gross_loss =
-    List.fold round_trips ~init:0.0 ~f:(fun acc (m : Metrics.trade_metrics) ->
-        if Float.(m.pnl_dollars < 0.0) then acc +. Float.abs m.pnl_dollars
-        else acc)
-  in
-  if Float.(gross_loss = 0.0) then
-    if Float.(gross_profit > 0.0) then Float.infinity else 0.0
-  else gross_profit /. gross_loss
-
 let _finalize ~state ~config:_ =
   let steps = List.rev state.steps in
   let round_trips = Metrics.extract_round_trips steps in
-  let base_metrics =
-    match Metrics.compute_summary round_trips with
-    | None -> Metric_types.empty
-    | Some stats -> Metrics.summary_stats_to_metrics stats
-  in
-  let profit_factor = _compute_profit_factor round_trips in
-  Metric_types.merge base_metrics
-    (Metric_types.singleton ProfitFactor profit_factor)
+  Metrics.compute_round_trip_metric_set round_trips
 
 let computer () : Simulator_types.any_metric_computer =
   Simulator_types.wrap_computer

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -668,6 +668,105 @@ let test_profit_factor_no_trades _ =
   let metrics = run_computers ~computers:[ computer ] ~config ~steps in
   assert_that metrics (contains_entry ProfitFactor (float_equal 0.0))
 
+(* ==================== compute_round_trip_metric_set Tests ==================== *)
+
+(** Build a synthetic [trade_metrics] record. Defaults the boilerplate fields so
+    test cases stay focused on [side] and [pnl_dollars]. *)
+let _make_round_trip ?(symbol = "SYM") ?(side = Trading_base.Types.Buy)
+    ?(entry_date = date_of_string "2024-01-02")
+    ?(exit_date = date_of_string "2024-01-12") ?(days_held = 10)
+    ?(entry_price = 100.0) ?(exit_price = 110.0) ?(quantity = 10.0) ~pnl_dollars
+    () =
+  let pnl_percent = pnl_dollars /. (entry_price *. quantity) *. 100.0 in
+  {
+    symbol;
+    side;
+    entry_date;
+    exit_date;
+    days_held;
+    entry_price;
+    exit_price;
+    quantity;
+    pnl_dollars;
+    pnl_percent;
+  }
+
+(** The flagship invariant: WinCount + LossCount equal the round-trip count, and
+    both reflect [pnl_dollars]'s sign. Synthetic 5 round-trips with 3 long wins,
+    1 long loss, 1 short win → [n_wins = 4], [n_losses = 1]. Pre-fix to
+    [Backtest.Runner._make_summary], the simulator's Summary_computer counted
+    warmup-window pairs that the runner's range-filtered [round_trips] did not,
+    so summary's WinCount disagreed with [List.count round_trips ~f:(pnl > 0)].
+    This test pins [compute_round_trip_metric_set] — the fix's load-bearing
+    helper — to the round-trip-derived count, which is what trades.csv reports.
+*)
+let test_compute_round_trip_metric_set_mixed_long_short _ =
+  let round_trips =
+    [
+      _make_round_trip ~symbol:"LONG_W1" ~side:Buy ~pnl_dollars:100.0 ();
+      _make_round_trip ~symbol:"LONG_W2" ~side:Buy ~pnl_dollars:200.0 ();
+      _make_round_trip ~symbol:"LONG_W3" ~side:Buy ~pnl_dollars:300.0 ();
+      _make_round_trip ~symbol:"LONG_L1" ~side:Buy ~pnl_dollars:(-150.0) ();
+      _make_round_trip ~symbol:"SHORT_W1" ~side:Sell ~pnl_dollars:50.0 ();
+    ]
+  in
+  let metrics = compute_round_trip_metric_set round_trips in
+  (* WinCount + LossCount must equal the round-trip count (no overcounting,
+     no off-by-one), and the win count must equal the arithmetic count of
+     pnl_dollars > 0 — the same predicate the reconciler applies to
+     trades.csv. *)
+  let arithmetic_wins =
+    List.count round_trips ~f:(fun (m : trade_metrics) ->
+        Float.(m.pnl_dollars > 0.0))
+  in
+  assert_that arithmetic_wins (equal_to 4);
+  assert_that metrics
+    (map_includes
+       [
+         (WinCount, float_equal 4.0);
+         (LossCount, float_equal 1.0);
+         (WinRate, float_equal 80.0);
+         (TotalPnl, float_equal 500.0);
+         (* gross_profit = 100+200+300+50 = 650; gross_loss = 150;
+            profit_factor = 650 / 150 ≈ 4.333... *)
+         (ProfitFactor, float_equal ~epsilon:1e-6 (650.0 /. 150.0));
+       ])
+
+(** Empty round-trip list emits only [ProfitFactor = 0.0], matching the legacy
+    [Summary_computer] convention (so existing callers / goldens that pin "no
+    trades" → [ProfitFactor = 0] stay green). The win/loss counts are omitted
+    from the overlay; the runner's [Metric_types.merge sim_metrics overlay]
+    therefore falls back to the simulator's WinCount/LossCount when the runner's
+    range-filtered [round_trips] is empty — which means the simulator's reading
+    also produced no round-trips on the steps it saw, so this is a graceful
+    no-op. *)
+let test_compute_round_trip_metric_set_empty _ =
+  let metrics = compute_round_trip_metric_set [] in
+  assert_that metrics (contains_entry ProfitFactor (float_equal 0.0));
+  assert_that (Map.mem metrics WinCount) (equal_to false);
+  assert_that (Map.mem metrics LossCount) (equal_to false);
+  assert_that (Map.mem metrics TotalPnl) (equal_to false)
+
+(** All winners → [LossCount = 0], [ProfitFactor = +inf] (matches the existing
+    profit-factor convention from Summary_computer). *)
+let test_compute_round_trip_metric_set_all_winners _ =
+  let round_trips =
+    [
+      _make_round_trip ~symbol:"W1" ~pnl_dollars:50.0 ();
+      _make_round_trip ~symbol:"W2" ~pnl_dollars:75.0 ();
+    ]
+  in
+  let metrics = compute_round_trip_metric_set round_trips in
+  assert_that metrics
+    (map_includes
+       [
+         (WinCount, float_equal 2.0);
+         (LossCount, float_equal 0.0);
+         (WinRate, float_equal 100.0);
+         (TotalPnl, float_equal 125.0);
+         (ProfitFactor, float_equal Float.infinity);
+       ])
+
 (* ==================== CAGR Tests ==================== *)
 
 let test_cagr_zero_with_no_data _ =
@@ -974,6 +1073,13 @@ let suite =
          (* Profit factor tests *)
          "profit factor all winners" >:: test_profit_factor_all_winners;
          "profit factor no trades" >:: test_profit_factor_no_trades;
+         (* compute_round_trip_metric_set tests *)
+         "compute_round_trip_metric_set mixed long+short"
+         >:: test_compute_round_trip_metric_set_mixed_long_short;
+         "compute_round_trip_metric_set empty"
+         >:: test_compute_round_trip_metric_set_empty;
+         "compute_round_trip_metric_set all winners"
+         >:: test_compute_round_trip_metric_set_all_winners;
          (* CAGR tests *)
          "cagr zero with no data" >:: test_cagr_zero_with_no_data;
          "cagr with growth" >:: test_cagr_with_growth;


### PR DESCRIPTION
## Summary

Reconciler-surfaced bug: on `panel-golden-2019-full`, `summary.sexp`'s `wincount = 3` while `trades.csv` only contains 2 rows with `pnl_dollars > 0`. Summary's `losscount = 6` similarly disagrees with the 5 negative rows in `trades.csv`. The reconciler treats `trades.csv` as authoritative (per `~/Projects/trading-reconciler/README.md`), so summary's win/loss counts must match its arithmetic tally.

## Root cause

The simulator runs from `start_date - warmup_days` to `end_date` and its `Summary_computer` folds over **every** step in `step_history` (warmup + range), while the runner's `round_trips` list — and the rows written to `trades.csv` — comes from `steps_in_range` (steps with `date >= start_date`). On `panel-golden-2019-full` the warmup window contained 1 win + 1 loss (AAPL `2019-04-26 → 2019-04-29` and JPM `2019-04-26 → 2019-04-29` round-trips, both before the `2019-05-01` start_date); the simulator's metric set counted them but `trades.csv` did not. Identified hypothesis: **H2** (summary used a different aggregation source than the runner's range-filtered round-trip list).

## Fix

- **`Trading_simulation.Metrics`**: Add `compute_round_trip_metric_set : trade_metrics list -> metric_set` — the canonical computation of round-trip-derived metrics ([TotalPnl], [AvgHoldingDays], [WinCount], [LossCount], [WinRate], [ProfitFactor]) from a `round_trip` list. Also expose `compute_profit_factor`.
- **`Backtest.Runner._make_summary`** now overlays this metric set onto `sim_result.metrics` via `Metric_types.merge`. Round-trip-derived metrics now reflect the runner's range-filtered `round_trips`; non-round-trip metrics ([Sharpe], [MaxDrawdown], [CAGR], [OpenPositionCount], [UnrealizedPnl], [TradeFrequency]) fall through unchanged.
- **`Summary_computer.ml`** deduplicated to use `compute_round_trip_metric_set` directly.

## Reproducer

| Field | Pre-fix | Post-fix | trades.csv (authoritative) |
|---|---:|---:|---:|
| `n_round_trips` | 7 | 7 | 7 rows |
| `wincount` | **3** | **2** | 2 wins (`pnl > 0`) |
| `losscount` | **6** | **5** | 5 losses |
| `winrate` | 33.33% | 28.57% | 28.57% |
| `totalpnl` | -10034.63 | -11694.47 | sum of pnl_dollars: -11694.47 |
| `avgholdingdays` | 18 | 22.29 | mean of `days_held`: 22.29 |
| `profitfactor` | 0.35 | 0.19 | gross profit / gross loss: 0.19 |

(Pre-fix totals 9 — the warmup pair contributed +1 win and +1 loss, with net `total_pnl` impact +1660 and avg hold 3 days.)

## Test coverage

- **`test_metrics`**: 3 new tests pinning `compute_round_trip_metric_set` shape:
  - mixed long+short (3 long wins + 1 long loss + 1 short win → `n_wins = 4`)
  - all winners (`LossCount = 0`, `ProfitFactor = +inf`)
  - empty round-trip list (only `ProfitFactor = 0.0`, matching the legacy `Summary_computer` empty-list convention).
- **`test_runner_filter`**: 1 new test pinning the overlay's alignment semantics on a synthetic warmup-contaminated metric_set + range-filtered round_trips, mirroring the panel-golden-2019-full bug exactly.

## Test plan

- [x] `dune build` passes.
- [x] `dune runtest` passes (full suite).
- [x] `dune build @fmt` clean.
- [x] Manual rerun of `panel-golden-2019-full` confirms summary counts now match `trades.csv` (see Reproducer table).
- [x] `panel_round_trips_golden` test gates still pass — the goldens pin `round_trips`, not summary metrics, so they're unaffected.

## No fixture updates required

- The `panel_round_trips_golden` goldens pin `round_trips` (not summary metrics) and remain bit-equal.
- The `summary_computer` "no trades → ProfitFactor = 0.0" test contract is preserved by `compute_round_trip_metric_set`'s empty-list shape.

## Authority

- Reconciler is the external `trading-reconciler` (separate repo) — its arithmetic walk over `trades.csv` is treated as authoritative per `~/Projects/trading-reconciler/README.md`.
- `docs/design/eng-design-4-simulation-tuning.md` — simulation/metrics spec.