### PR TITLE
feat(stops_runner): add stop_update_cadence config flag (G11)

### DIFF
--- a/trading/trading/weinstein/strategy/lib/stops_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.ml
@@ -1,6 +1,16 @@
 open Core
 open Trading_strategy
 
+type stop_update_cadence = Daily | Weekly [@@deriving show, eq, sexp]
+
+(** Friday is the cadence anchor: the strategy's screening pass uses the same
+    marker (see {!Weinstein_strategy._is_screening_day_view}). Keeping the
+    runner's weekly-cadence check on Friday matches that authority — book
+    §Stop-Loss Rules describes weekly re-evaluation, and Friday is the
+    week-bucket boundary used everywhere else in the strategy. *)
+let _is_weekly_close ~as_of =
+  Date.day_of_week as_of |> Day_of_week.equal Day_of_week.Fri
+
 (** Position-favourable stage + MA direction default for warmup periods (when
     fewer than [stage_config.ma_period] weekly bars are available). The return
     must drive {!Weinstein_stops.update} into a no-tighten branch:
@@ -112,22 +122,23 @@ let _make_adjust_transition ~(pos : Position.t) ~current_date
     kind = Position.UpdateRiskParams { new_risk_params };
   }
 
-(** Process stop logic for one held position. Returns (exit_transition option,
-    adjust_transition option). *)
-let _handle_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars
-    ~(pos : Position.t) ~(risk_params : Position.risk_params) ~state ~bar
-    ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages () =
-  let current_date = bar.Types.Daily_price.date in
-  let ma_direction, ma_value, stage =
-    _compute_ma_and_stage ?ma_cache ~stage_config ~lookback_bars ~bar_reader
-      ~as_of ~prior_stages ~symbol:ticker ~side:pos.Position.side
-      ~fallback_price:bar.Types.Daily_price.close_price ()
-  in
-  let new_state, event =
-    Weinstein_stops.update ~config:stops_config ~side:pos.Position.side ~state
-      ~current_bar:bar ~ma_value ~ma_direction ~stage
-  in
-  stop_states := Map.set !stop_states ~key:ticker ~data:new_state;
+(** Trigger-only branch for [Weekly] cadence on a non-Friday bar. The state
+    machine is not advanced (no trail tightening, no correction-cycle
+    bookkeeping progresses). The trigger check still fires continuously — book
+    §Stop-Loss Rules: the GTC stop sits in the market every day; only its
+    placement re-evaluation is weekly. If the bar's high/low crosses the
+    existing stop level, an exit transition is emitted at the same actual_price
+    the daily path would have used (bar low for longs, bar high for shorts). *)
+let _handle_stop_trigger_only ~(pos : Position.t) ~state ~bar ~current_date =
+  if Weinstein_stops.check_stop_hit ~state ~side:pos.Position.side ~bar then
+    (Some (_make_exit_transition ~pos ~current_date ~state ~bar), None)
+  else (None, None)
+
+(** Translate a {!Weinstein_stops.stop_event} into the (exit, adjust) transition
+    pair the runner emits to the strategy. Pure mapping — extracted from
+    [_handle_stop] to keep that function within the nesting linter's limits. *)
+let _transitions_of_stop_event ~(pos : Position.t)
+    ~(risk_params : Position.risk_params) ~state ~bar ~current_date ~event =
   match event with
   | Weinstein_stops.Stop_hit _ ->
       (Some (_make_exit_transition ~pos ~current_date ~state ~bar), None)
@@ -138,28 +149,72 @@ let _handle_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars
       )
   | _ -> (None, None)
 
+(** Daily-cadence branch (and Weekly-on-Friday): advance the state machine via
+    {!Weinstein_stops.update}, persist the new state, and emit the resulting
+    (exit, adjust) transition pair. Mutates [stop_states]. *)
+let _handle_stop_full ?ma_cache ~stops_config ~stage_config ~lookback_bars
+    ~(pos : Position.t) ~(risk_params : Position.risk_params) ~state ~bar
+    ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages ~current_date () =
+  let ma_direction, ma_value, stage =
+    _compute_ma_and_stage ?ma_cache ~stage_config ~lookback_bars ~bar_reader
+      ~as_of ~prior_stages ~symbol:ticker ~side:pos.Position.side
+      ~fallback_price:bar.Types.Daily_price.close_price ()
+  in
+  let new_state, event =
+    Weinstein_stops.update ~config:stops_config ~side:pos.Position.side ~state
+      ~current_bar:bar ~ma_value ~ma_direction ~stage
+  in
+  stop_states := Map.set !stop_states ~key:ticker ~data:new_state;
+  _transitions_of_stop_event ~pos ~risk_params ~state ~bar ~current_date ~event
+
+(** Process stop logic for one held position. Returns (exit_transition option,
+    adjust_transition option).
+
+    Under [Weekly] cadence with [as_of] not on a Friday, only the trigger check
+    runs (see [_handle_stop_trigger_only]); the state machine is not advanced
+    and [stop_states] is unchanged. Under [Daily] (or [Weekly] on Friday), the
+    state machine runs as before via [_handle_stop_full]. *)
+let _handle_stop ?ma_cache ?(stop_update_cadence = Daily) ~stops_config
+    ~stage_config ~lookback_bars ~(pos : Position.t)
+    ~(risk_params : Position.risk_params) ~state ~bar ~stop_states ~ticker
+    ~bar_reader ~as_of ~prior_stages () =
+  let current_date = bar.Types.Daily_price.date in
+  let advance_state_machine =
+    match stop_update_cadence with
+    | Daily -> true
+    | Weekly -> _is_weekly_close ~as_of
+  in
+  if not advance_state_machine then
+    _handle_stop_trigger_only ~pos ~state ~bar ~current_date
+  else
+    _handle_stop_full ?ma_cache ~stops_config ~stage_config ~lookback_bars ~pos
+      ~risk_params ~state ~bar ~stop_states ~ticker ~bar_reader ~as_of
+      ~prior_stages ~current_date ()
+
 (** Process stop for one position; returns updated (exits, adjusts) accumulator.
 *)
-let _process_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars
-    ~stop_states ~get_price ~bar_reader ~as_of ~prior_stages (pos : Position.t)
-    (exits, adjusts) =
+let _process_stop ?ma_cache ?stop_update_cadence ~stops_config ~stage_config
+    ~lookback_bars ~stop_states ~get_price ~bar_reader ~as_of ~prior_stages
+    (pos : Position.t) (exits, adjusts) =
   let ticker = pos.symbol in
   match
     (Position.get_state pos, Map.find !stop_states ticker, get_price ticker)
   with
   | Position.Holding h, Some state, Some bar -> (
       match
-        _handle_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars ~pos
-          ~risk_params:h.risk_params ~state ~bar ~stop_states ~ticker
-          ~bar_reader ~as_of ~prior_stages ()
+        _handle_stop ?ma_cache ?stop_update_cadence ~stops_config ~stage_config
+          ~lookback_bars ~pos ~risk_params:h.risk_params ~state ~bar
+          ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages ()
       with
       | Some exit_tr, _ -> (exit_tr :: exits, adjusts)
       | _, Some adj_tr -> (exits, adj_tr :: adjusts)
       | None, None -> (exits, adjusts))
   | _ -> (exits, adjusts)
 
-let update ?ma_cache ~stops_config ~stage_config ~lookback_bars ~positions
-    ~get_price ~stop_states ~bar_reader ~as_of ~prior_stages () =
+let update ?ma_cache ?stop_update_cadence ~stops_config ~stage_config
+    ~lookback_bars ~positions ~get_price ~stop_states ~bar_reader ~as_of
+    ~prior_stages () =
   Map.fold positions ~init:([], []) ~f:(fun ~key:_ ~data:pos acc ->
-      _process_stop ?ma_cache ~stops_config ~stage_config ~lookback_bars
-        ~stop_states ~get_price ~bar_reader ~as_of ~prior_stages pos acc)
+      _process_stop ?ma_cache ?stop_update_cadence ~stops_config ~stage_config
+        ~lookback_bars ~stop_states ~get_price ~bar_reader ~as_of ~prior_stages
+        pos acc)

--- a/trading/trading/weinstein/strategy/lib/stops_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.mli
@@ -8,8 +8,25 @@
 open Core
 open Trading_strategy
 
+(** Cadence at which the trailing-stop state machine advances.
+
+    - [Daily] — call {!Weinstein_stops.update} on every tick. The state machine
+      tightens / raises the stop based on every daily bar. This is the
+      historical default and preserves all baselines.
+    - [Weekly] — only advance the state machine on the week's final trading day
+      (Friday). Mid-week (Mon-Thu) ticks still run the trigger check
+      ({!Weinstein_stops.check_stop_hit}) and emit a [TriggerExit] when the
+      bar's high/low crosses the stop, but do NOT raise/tighten the stop.
+
+    The book authority (Weinstein Ch. 6, "Stop-Loss Rules") describes weekly
+    re-evaluation: the trail moves only when a weekly bar confirms a new pivot
+    above the prior pivot. Trigger is continuous (intraday); update is weekly.
+    [Weekly] mirrors that contract; [Daily] does not. *)
+type stop_update_cadence = Daily | Weekly [@@deriving show, eq, sexp]
+
 val update :
   ?ma_cache:Weekly_ma_cache.t ->
+  ?stop_update_cadence:stop_update_cadence ->
   stops_config:Weinstein_stops.config ->
   stage_config:Stage.config ->
   lookback_bars:int ->
@@ -37,4 +54,10 @@ val update :
     Stage 4 PR-D: when [ma_cache] is passed, MA values are read from the
     per-symbol cache on Friday-aligned ticks (cache hit). Mid-week ticks miss
     the cache and fall back to inline MA computation — preserving bit-equality
-    with the bar-list path on every call. *)
+    with the bar-list path on every call.
+
+    [stop_update_cadence] (default [Daily]) controls when the trail advances —
+    see {!stop_update_cadence}. Under [Weekly], non-Friday [as_of] dates skip
+    the state-machine update and only emit [TriggerExit] when the bar crosses
+    the existing stop level. The default of [Daily] preserves bit-equality with
+    every existing caller and baseline. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -56,6 +56,13 @@ type config = {
   universe_cap : int option;
   full_compute_tail_days : int option;
   enable_short_side : bool; [@sexp.default true]
+  stop_update_cadence : Stops_runner.stop_update_cadence;
+      [@sexp.default Stops_runner.Daily]
+      (** Cadence for trailing-stop trail advancement (G11). [Daily] (the
+          default) preserves all existing baselines: the trail can tighten on
+          every daily bar. [Weekly] only advances the state machine on Friday
+          ticks, matching Weinstein Ch. 6 §Stop-Loss Rules ("trail moves only on
+          weekly close"). Trigger logic stays continuous in both modes. *)
 }
 [@@deriving sexp]
 
@@ -77,6 +84,7 @@ let default_config ~universe ~index_symbol =
     universe_cap = None;
     full_compute_tail_days = None;
     enable_short_side = true;
+    stop_update_cadence = Stops_runner.Daily;
   }
 
 let name = "Weinstein"
@@ -430,6 +438,7 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
   let exit_transitions, adjust_transitions =
     Stops_runner.update
       ?ma_cache:(Bar_reader.ma_cache bar_reader)
+      ~stop_update_cadence:config.stop_update_cadence
       ~stops_config:config.stops_config ~stage_config:config.stage_config
       ~lookback_bars:config.lookback_bars ~positions ~get_price ~stop_states
       ~bar_reader ~as_of:current_date ~prior_stages ()

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -171,6 +171,22 @@ type config = {
           Sell→Buy round-trips so shorts are invisible in [trades.csv], and the
           cash floor only triggers on Buy so unbounded short losses cannot
           force-liquidate. *)
+  stop_update_cadence : Stops_runner.stop_update_cadence;
+      [@sexp.default Stops_runner.Daily]
+      (** Cadence at which the trailing-stop state machine advances (G11).
+
+          - [Daily] (default) — preserves all existing baselines: the trail can
+            tighten on every daily bar.
+          - [Weekly] — only advances the state machine on Friday ticks. Mirrors
+            Weinstein Ch. 6 §Stop-Loss Rules: "the trail moves only when a
+            weekly bar confirms a new pivot above the prior pivot." Trigger
+            logic stays continuous — a stop can still fire on any daily bar.
+
+          Lever introduced to test whether the daily-cadence default explains
+          the very-short-hold cluster observed in
+          [dev/notes/sp500-trade-quality-findings-2026-04-30.md] §G11. The
+          comparison run is a follow-up; this field exists so the experiment
+          becomes a config flip rather than a code change. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/test/test_stops_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_runner.ml
@@ -359,6 +359,187 @@ let test_g1_short_exit_records_high_not_low _ =
        ])
 
 (* ------------------------------------------------------------------ *)
+(* G11: stop_update_cadence flag                                        *)
+(*                                                                      *)
+(* Authority: docs/design/weinstein-book-reference.md §Stop-Loss Rules *)
+(* — the trail moves only when a weekly bar confirms a new pivot.       *)
+(* Trigger remains continuous regardless of cadence.                    *)
+(*                                                                      *)
+(* Findings: dev/notes/sp500-trade-quality-findings-2026-04-30.md §G11  *)
+(* — under the daily-cadence default, the trail tightens above entry    *)
+(* within 3 bars; any pullback fires the stop. The Weekly cadence is    *)
+(* the lever that scopes the experiment to a config flip.               *)
+(* ------------------------------------------------------------------ *)
+
+(** Drive a long [Holding] through five trending daily bars (Mon-Fri of one
+    week) under a chosen cadence. The bars are designed so that the [Daily]
+    state machine advances out of [Initial] into [Trailing] on the first bar,
+    while [Weekly] only advances on the Friday bar — leaving the state in
+    [Initial] for Mon-Thu. No bar's low crosses the stop, so neither cadence
+    fires an exit. Returns [(final_state, exits)]. *)
+let _run_long_week_trending ~stop_update_cadence =
+  let ticker = "AAPL" in
+  let entry_date = Date.of_string "2024-01-05" in
+  let entry_price = 100.0 in
+  let pos = make_holding_pos ticker entry_price entry_date in
+  let positions = String.Map.singleton ticker pos in
+  let stop_states =
+    ref
+      (String.Map.singleton ticker
+         (Weinstein_stops.Initial { stop_level = 95.0; reference_level = 100.0 }))
+  in
+  let prior_stages = Hashtbl.create (module String) in
+  (* Mon 2024-01-08 .. Fri 2024-01-12: a calm uptrend.  No bar low touches
+     the $95 stop, so trigger never fires.  Bars give the state machine
+     room to advance under Daily but no real cycle to complete. *)
+  let bars =
+    [
+      make_bar "2024-01-08" ~close:101.0 ~low:100.5 ~high:101.5 ();
+      make_bar "2024-01-09" ~close:102.0 ~low:101.5 ~high:102.5 ();
+      make_bar "2024-01-10" ~close:103.0 ~low:102.5 ~high:103.5 ();
+      make_bar "2024-01-11" ~close:104.0 ~low:103.5 ~high:104.5 ();
+      make_bar "2024-01-12" ~close:105.0 ~low:104.5 ~high:105.5 ();
+    ]
+  in
+  let exits =
+    List.concat_map bars ~f:(fun bar ->
+        let exits, _adjusts =
+          Stops_runner.update ~stop_update_cadence ~stops_config:default_cfg
+            ~stage_config:default_stage_cfg ~lookback_bars:52 ~positions
+            ~get_price:(get_price_of [ (ticker, bar) ])
+            ~stop_states ~bar_reader:(Bar_reader.empty ())
+            ~as_of:bar.Types.Daily_price.date ~prior_stages ()
+        in
+        exits)
+  in
+  (Map.find !stop_states ticker, exits)
+
+(** Daily cadence: trail advances on every bar — [_update_initial] transitions
+    [Initial -> Trailing] on the first non-stop-hit bar, so by the end of the
+    week the state is [Trailing _]. This pins the existing default behaviour. *)
+let test_daily_cadence_advances_state_on_each_bar _ =
+  let final_state, exits =
+    _run_long_week_trending ~stop_update_cadence:Stops_runner.Daily
+  in
+  assert_that exits is_empty;
+  assert_that final_state
+    (is_some_and
+       (matching ~msg:"Expected Trailing under Daily cadence"
+          (function Weinstein_stops.Trailing _ -> Some () | _ -> None)
+          (equal_to ())))
+
+(** Weekly cadence: state machine only advances on Friday. With Mon-Thu bars
+    bypassing [Weinstein_stops.update], the state stays [Initial] until the
+    Friday tick advances it to [Trailing]. Mid-week ticks ran the trigger check
+    (no hit) but did not mutate [stop_states]. *)
+let test_weekly_cadence_advances_state_only_on_friday _ =
+  let final_state, exits =
+    _run_long_week_trending ~stop_update_cadence:Stops_runner.Weekly
+  in
+  assert_that exits is_empty;
+  (* On Friday (2024-01-12) the state machine ran once and advanced
+     [Initial -> Trailing] on a no-hit bar.  Mon-Thu were trigger-only
+     no-ops; [stop_states] was untouched on those days. *)
+  assert_that final_state
+    (is_some_and
+       (matching ~msg:"Expected Trailing under Weekly cadence after Friday tick"
+          (function Weinstein_stops.Trailing _ -> Some () | _ -> None)
+          (equal_to ())))
+
+(** Weekly cadence on Mon-Thu only: when no Friday tick is included, the state
+    machine never advances — [stop_states] remains exactly the [Initial] state
+    seeded at entry. Pins the "Mon-Thu skip" behaviour directly without relying
+    on the Friday case to disambiguate. *)
+let test_weekly_cadence_no_state_advance_when_only_midweek _ =
+  let ticker = "AAPL" in
+  let entry_date = Date.of_string "2024-01-05" in
+  let entry_price = 100.0 in
+  let pos = make_holding_pos ticker entry_price entry_date in
+  let positions = String.Map.singleton ticker pos in
+  let initial_state =
+    Weinstein_stops.Initial { stop_level = 95.0; reference_level = 100.0 }
+  in
+  let stop_states = ref (String.Map.singleton ticker initial_state) in
+  let prior_stages = Hashtbl.create (module String) in
+  (* Only Mon-Thu bars. Under Weekly, none of these advance the state. *)
+  let bars =
+    [
+      make_bar "2024-01-08" ~close:101.0 ();
+      make_bar "2024-01-09" ~close:102.0 ();
+      make_bar "2024-01-10" ~close:103.0 ();
+      make_bar "2024-01-11" ~close:104.0 ();
+    ]
+  in
+  let exits =
+    List.concat_map bars ~f:(fun bar ->
+        let exits, _adjusts =
+          Stops_runner.update ~stop_update_cadence:Stops_runner.Weekly
+            ~stops_config:default_cfg ~stage_config:default_stage_cfg
+            ~lookback_bars:52 ~positions
+            ~get_price:(get_price_of [ (ticker, bar) ])
+            ~stop_states ~bar_reader:(Bar_reader.empty ())
+            ~as_of:bar.Types.Daily_price.date ~prior_stages ()
+        in
+        exits)
+  in
+  assert_that exits is_empty;
+  (* State is unchanged from the seeded [Initial] — no Friday tick fired,
+     so [Weinstein_stops.update] was never called and stop_states never
+     mutated. *)
+  assert_that
+    (Map.find !stop_states ticker)
+    (is_some_and (equal_to initial_state))
+
+(** Weekly cadence still fires the trigger continuously: a Wednesday bar whose
+    low crosses the stop emits a [TriggerExit] even though the state machine is
+    not advanced. Pins the "trigger ≠ update" contract from the book. *)
+let test_weekly_cadence_trigger_fires_on_midweek_bar _ =
+  let ticker = "AAPL" in
+  let entry_date = Date.of_string "2024-01-05" in
+  let entry_price = 100.0 in
+  let pos = make_holding_pos ticker entry_price entry_date in
+  let positions = String.Map.singleton ticker pos in
+  let stop_states =
+    ref
+      (String.Map.singleton ticker
+         (Weinstein_stops.Initial { stop_level = 90.0; reference_level = 95.0 }))
+  in
+  (* Wednesday 2024-01-10. Bar low $85 crosses the $90 stop. *)
+  let bar = make_bar "2024-01-10" ~close:88.0 ~low:85.0 ~high:92.0 () in
+  let exits, adjusts =
+    Stops_runner.update ~stop_update_cadence:Stops_runner.Weekly
+      ~stops_config:default_cfg ~stage_config:default_stage_cfg
+      ~lookback_bars:52 ~positions
+      ~get_price:(get_price_of [ (ticker, bar) ])
+      ~stop_states ~bar_reader:(Bar_reader.empty ())
+      ~as_of:(Date.of_string "2024-01-10")
+      ~prior_stages:(Hashtbl.create (module String))
+      ()
+  in
+  assert_that adjusts is_empty;
+  assert_that exits
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (tr : Trading_strategy.Position.transition) ->
+                 tr.position_id)
+               (equal_to ticker);
+             field
+               (fun (tr : Trading_strategy.Position.transition) -> tr.kind)
+               (matching ~msg:"Expected TriggerExit"
+                  (function
+                    | Trading_strategy.Position.TriggerExit _ -> Some ()
+                    | _ -> None)
+                  (equal_to ()));
+             field
+               (fun (tr : Trading_strategy.Position.transition) -> tr.date)
+               (equal_to (Date.of_string "2024-01-10"));
+           ];
+       ])
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -380,4 +561,12 @@ let () =
            >:: test_g1_short_no_exit_on_counter_bounce;
            "G1: short exit records high (not low) on violent down-day"
            >:: test_g1_short_exit_records_high_not_low;
+           "G11: Daily cadence advances state machine on every bar"
+           >:: test_daily_cadence_advances_state_on_each_bar;
+           "G11: Weekly cadence advances state machine only on Friday"
+           >:: test_weekly_cadence_advances_state_only_on_friday;
+           "G11: Weekly cadence skips state advance on Mon-Thu"
+           >:: test_weekly_cadence_no_state_advance_when_only_midweek;
+           "G11: Weekly cadence still fires trigger on mid-week bar"
+           >:: test_weekly_cadence_trigger_fires_on_midweek_bar;
          ])


### PR DESCRIPTION
## Summary

- Adds a runner-level `stop_update_cadence` lever (`Daily | Weekly`) to gate trailing-stop trail advancement.
- Default is `Daily` — preserves all existing baselines bit-for-bit; no behavioural change in this PR.
- `Weekly` mirrors Weinstein Ch. 6 §Stop-Loss Rules: the trail moves only on a Friday tick. The trigger check (`Weinstein_stops.check_stop_hit`) stays continuous in both modes, so a stop can still fire on any daily bar.

## Why

Top finding from `dev/notes/sp500-trade-quality-findings-2026-04-30.md` §G11: 17 of 30 round-trips on the sp500-2019-2023 backtest held exactly 3 days; stop-outs at +0.13% / +0.70% / +1.28%. The trail tightens above entry within 3 daily bars and any pullback fires the stop. The book describes weekly re-evaluation; the runner currently runs the state machine on every daily tick. This PR lands the lever; the A/B run (Weekly vs Daily metrics) is a separate follow-up.

## Files touched

- `trading/trading/weinstein/strategy/lib/stops_runner.{ml,mli}` — new `stop_update_cadence` variant; optional `?stop_update_cadence` (default `Daily`) on `update`; Mon-Thu non-Friday ticks under `Weekly` route through `_handle_stop_trigger_only`, which still calls `check_stop_hit` but does NOT advance the state machine.
- `trading/trading/weinstein/strategy/lib/weinstein_strategy.{ml,mli}` — new `config.stop_update_cadence` field (`[@sexp.default Stops_runner.Daily]`) wired into the call site in `_on_market_close`.
- `trading/trading/weinstein/strategy/test/test_stops_runner.ml` — 4 new tests (Daily advances on every bar; Weekly advances only on Friday; Weekly skips state advance Mon-Thu; Weekly trigger still fires on a mid-week bar).

## Decisions

- **Friday as the weekly-close marker.** Reused the same anchor `Weinstein_strategy._is_screening_day_view` already uses (`Date.day_of_week as_of = Fri`). Did not introduce a new "weekly close" concept.
- **Lever lives on `Stops_runner`, not `Weinstein_stops.config`.** The state machine itself is unchanged; only the runner's invocation cadence is gated. Keeping it at the runner level matches the lever's actual scope.
- **Default = `Daily`** — all existing baselines unchanged. The `Weekly` flip is the experiment; it is not enabled anywhere in this PR.

## Test plan

- [x] `dune build` clean
- [x] `dune build @fmt` clean
- [x] `dune runtest trading/weinstein/strategy/test/` — all 11 tests pass (added 4: Daily/Weekly cadence + trigger-on-midweek-bar)
- [x] `dune runtest trading/simulation/test/` — clean
- [x] `dune runtest trading/weinstein/stops/test/` — clean
- [x] Nesting / function-length linters: no new offenders introduced (in fact, removed one — `_handle_stop` was refactored into smaller helpers)
- [x] Pre-existing failures (`Trade_audit_capture`, `Panel_round_trips_golden`, `Runner_hypothesis_overrides`) are missing-data errors (`tiered-loader-parity.sexp: No such file`) and reproduce on `main@origin` — unrelated to this change.

## Out of scope

- Running the sp500 Weekly vs Daily comparison — separate follow-up; this PR lands the lever only.
- Cascade-cooldown (separate G11 sibling finding).
- Any changes to the stop state machine itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)