### PR TITLE
feat(stop_log): tag end-of-period exits with End_of_period trigger

### DIFF
--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -56,6 +56,7 @@ let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
   | Time_expired _ -> "time_expired"
   | Underperforming _ -> "underperforming"
   | Portfolio_rebalancing -> "rebalancing"
+  | End_of_period -> "end_of_period"
 
 (** Build a (symbol, exit_date) -> reason map from force-liquidation events.
     [trades.csv] rows are post-processed: when a row's (symbol, exit_date)

--- a/trading/trading/backtest/lib/stop_log.ml
+++ b/trading/trading/backtest/lib/stop_log.ml
@@ -10,6 +10,7 @@ type exit_trigger =
   | Time_expired of { days_held : int; max_days : int }
   | Underperforming of { days_held : int; current_return : float }
   | Portfolio_rebalancing
+  | End_of_period
 [@@deriving show, eq, sexp]
 
 type stop_info = {
@@ -71,7 +72,17 @@ let _process_transition t (trans : Position.transition) =
   | TriggerExit { exit_reason; _ } ->
       let record = _ensure_record t ~position_id:trans.position_id ~symbol:"" in
       record.pos_exit_trigger <- Some (exit_trigger_of_reason exit_reason)
-  | EntryFill _ | CancelEntry _ | ExitFill _ | ExitComplete -> ()
+  | ExitComplete ->
+      (* Simulator's end-of-period auto-close path emits [ExitFill] +
+         [ExitComplete] without a preceding [TriggerExit]. Tag the position
+         with [End_of_period] only when no strategy-emitted trigger has
+         already been recorded — an [ExitComplete] that follows a
+         [TriggerExit] (the normal stop-out / take-profit path) leaves the
+         strategy's trigger intact. *)
+      let record = _ensure_record t ~position_id:trans.position_id ~symbol:"" in
+      if Option.is_none record.pos_exit_trigger then
+        record.pos_exit_trigger <- Some End_of_period
+  | EntryFill _ | CancelEntry _ | ExitFill _ -> ()
 
 let record_transitions t transitions =
   List.iter transitions ~f:(_process_transition t)

--- a/trading/trading/backtest/lib/stop_log.mli
+++ b/trading/trading/backtest/lib/stop_log.mli
@@ -27,6 +27,13 @@ type exit_trigger =
   | Underperforming of { days_held : int; current_return : float }
       (** Position underperformed *)
   | Portfolio_rebalancing  (** Closed for rebalancing *)
+  | End_of_period
+      (** Position was force-closed at the end of the backtest period without a
+          preceding strategy-emitted [TriggerExit]. The simulator's end-of-run
+          auto-close path emits [ExitFill] + [ExitComplete] but no
+          [TriggerExit], so the collector tags the resulting [stop_info] with
+          this fallback to avoid an empty [exit_trigger] column in [trades.csv].
+      *)
 [@@deriving show, eq, sexp]
 
 val exit_trigger_of_reason : Position.exit_reason -> exit_trigger
@@ -66,7 +73,12 @@ val record_transitions : t -> Position.transition list -> unit
     - [CreateEntering] records symbol and position_id
     - [EntryComplete] records initial stop-loss price from risk_params
     - [UpdateRiskParams] updates current stop-loss price
-    - [TriggerExit] records exit trigger and final stop level *)
+    - [TriggerExit] records exit trigger and final stop level
+    - [ExitComplete] without a preceding [TriggerExit] tags
+      [exit_trigger = End_of_period] (simulator end-of-run auto-close). An
+      [ExitComplete] that follows a [TriggerExit] keeps the strategy's original
+      trigger — the fallback is only applied when [exit_trigger] is still
+      [None]. *)
 
 val get_stop_infos : t -> stop_info list
 (** Return stop info for all positions that have been observed, sorted by

--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -77,8 +77,8 @@ let _empty_summary ~start_date ~end_date : Backtest.Summary.t =
     metrics = Trading_simulation_types.Metric_types.empty;
   }
 
-let _make_result ?(steps = []) ?(final_prices = []) ~round_trips
-    ~force_liquidations () : Backtest.Runner.result =
+let _make_result ?(steps = []) ?(final_prices = []) ?(stop_infos = [])
+    ~round_trips ~force_liquidations () : Backtest.Runner.result =
   let start_date = _date "2024-01-02" in
   let end_date = _date "2024-04-29" in
   {
@@ -86,7 +86,7 @@ let _make_result ?(steps = []) ?(final_prices = []) ~round_trips
     round_trips;
     steps;
     overrides = [];
-    stop_infos = [];
+    stop_infos;
     audit = [];
     cascade_summaries = [];
     force_liquidations;
@@ -271,6 +271,50 @@ let test_non_matching_event_does_not_override _ =
                  String.is_prefix (List.nth_exn cols idx)
                    ~prefix:"force_liquidation")
                (equal_to false);
+           ]))
+
+(* ------------------------------------------------------------------ *)
+(* B2.4 — End_of_period stop_info renders "end_of_period" in trades.csv *)
+(* ------------------------------------------------------------------ *)
+
+(** When the simulator's end-of-run auto-close fires (no preceding
+    [TriggerExit]), [Stop_log] tags the position with [End_of_period] and
+    [Result_writer] must render that as ["end_of_period"] in the [exit_trigger]
+    column. Pin this to avoid the empty-string regression seen in the
+    sp500-2019-2023 run (JPM 2019-05-04, HD 2021-03-27 — see
+    dev/notes/sp500-trade-quality-findings-2026-04-30.md). *)
+let test_end_of_period_renders_label _ =
+  let dir = Core_unix.mkdtemp "/tmp/result_writer_eop_" in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Core_unix.system (Printf.sprintf "rm -rf %s" dir) in
+      ())
+    (fun () ->
+      let trade =
+        _make_trade ~symbol:"JPM" ~exit_date:(_date "2024-04-29") ()
+      in
+      let stop_info : Backtest.Stop_log.stop_info =
+        {
+          position_id = "JPM-wein-1";
+          symbol = "JPM";
+          entry_stop = Some 95.0;
+          exit_stop = Some 95.0;
+          exit_trigger = Some Backtest.Stop_log.End_of_period;
+        }
+      in
+      let result =
+        _make_result ~round_trips:[ trade ] ~force_liquidations:[]
+          ~stop_infos:[ stop_info ] ()
+      in
+      Backtest.Result_writer.write ~output_dir:dir result;
+      let header, rows = _read_trades_csv ~output_dir:dir in
+      let idx = _exit_trigger_idx header in
+      assert_that rows
+        (elements_are
+           [
+             field
+               (fun cols -> List.nth_exn cols idx)
+               (equal_to "end_of_period");
            ]))
 
 (* ------------------------------------------------------------------ *)
@@ -489,6 +533,8 @@ let suite =
          >:: test_portfolio_floor_force_liq_overrides_exit_trigger;
          "non-matching event does not override exit_trigger"
          >:: test_non_matching_event_does_not_override;
+         "end_of_period stop_info renders end_of_period label"
+         >:: test_end_of_period_renders_label;
          "open_positions.csv header and rows"
          >:: test_open_positions_csv_header_and_rows;
          "open_positions.csv empty writes header only"

--- a/trading/trading/backtest/test/test_stop_log.ml
+++ b/trading/trading/backtest/test/test_stop_log.ml
@@ -311,6 +311,146 @@ let test_wrapper_handles_error _ =
   assert_that result is_error;
   assert_that (Backtest.Stop_log.get_stop_infos log) (size_is 0)
 
+(** ExitComplete without a preceding TriggerExit (the simulator's end-of-run
+    auto-close path) tags the position with [End_of_period]. This is the
+    fallback that prevents [trades.csv] from emitting an empty [exit_trigger]
+    column for positions liquidated at scenario end without a strategy-emitted
+    trigger (sp500-2019-2023 reproducer: JPM 2019-05-04, HD 2021-03-27 — see
+    dev/notes/sp500-trade-quality-findings-2026-04-30.md). *)
+let test_exit_complete_without_trigger_tags_end_of_period _ =
+  let log = Backtest.Stop_log.create () in
+  Backtest.Stop_log.record_transitions log
+    [
+      {
+        Position.position_id = "AAPL-wein-1";
+        date;
+        kind =
+          CreateEntering
+            {
+              symbol = "AAPL";
+              side = Long;
+              target_quantity = 100.0;
+              entry_price = 150.0;
+              reasoning = ManualDecision { description = "test" };
+            };
+      };
+      {
+        Position.position_id = "AAPL-wein-1";
+        date;
+        kind =
+          EntryComplete
+            {
+              risk_params =
+                {
+                  stop_loss_price = Some 142.50;
+                  take_profit_price = None;
+                  max_hold_days = None;
+                };
+            };
+      };
+    ];
+  (* End-of-period auto-close: ExitFill + ExitComplete with no preceding
+     TriggerExit. *)
+  Backtest.Stop_log.record_transitions log
+    [
+      {
+        Position.position_id = "AAPL-wein-1";
+        date = Date.of_string "2024-12-31";
+        kind = ExitFill { filled_quantity = 100.0; fill_price = 200.0 };
+      };
+      {
+        Position.position_id = "AAPL-wein-1";
+        date = Date.of_string "2024-12-31";
+        kind = ExitComplete;
+      };
+    ];
+  let infos = Backtest.Stop_log.get_stop_infos log in
+  assert_that infos
+    (elements_are
+       [
+         field
+           (fun (i : Backtest.Stop_log.stop_info) -> i.exit_trigger)
+           (is_some_and
+              (equal_to
+                 (Backtest.Stop_log.End_of_period
+                   : Backtest.Stop_log.exit_trigger)));
+       ])
+
+(** ExitComplete arriving AFTER an explicit TriggerExit must NOT overwrite the
+    strategy's trigger. Pins that the End_of_period fallback only fires when
+    [exit_trigger] is still None — a stop-loss that fires the normal TriggerExit
+    -> ExitFill -> ExitComplete sequence keeps its Stop_loss label. *)
+let test_exit_complete_does_not_overwrite_trigger_exit _ =
+  let log = Backtest.Stop_log.create () in
+  Backtest.Stop_log.record_transitions log
+    [
+      {
+        Position.position_id = "AAPL-wein-1";
+        date;
+        kind =
+          CreateEntering
+            {
+              symbol = "AAPL";
+              side = Long;
+              target_quantity = 100.0;
+              entry_price = 150.0;
+              reasoning = ManualDecision { description = "test" };
+            };
+      };
+      {
+        Position.position_id = "AAPL-wein-1";
+        date;
+        kind =
+          EntryComplete
+            {
+              risk_params =
+                {
+                  stop_loss_price = Some 142.50;
+                  take_profit_price = None;
+                  max_hold_days = None;
+                };
+            };
+      };
+      {
+        Position.position_id = "AAPL-wein-1";
+        date = Date.of_string "2024-02-01";
+        kind =
+          TriggerExit
+            {
+              exit_reason =
+                StopLoss
+                  {
+                    stop_price = 142.50;
+                    actual_price = 141.80;
+                    loss_percent = 5.47;
+                  };
+              exit_price = 141.80;
+            };
+      };
+      {
+        Position.position_id = "AAPL-wein-1";
+        date = Date.of_string "2024-02-01";
+        kind = ExitFill { filled_quantity = 100.0; fill_price = 141.80 };
+      };
+      {
+        Position.position_id = "AAPL-wein-1";
+        date = Date.of_string "2024-02-01";
+        kind = ExitComplete;
+      };
+    ];
+  let infos = Backtest.Stop_log.get_stop_infos log in
+  assert_that infos
+    (elements_are
+       [
+         field
+           (fun (i : Backtest.Stop_log.stop_info) -> i.exit_trigger)
+           (is_some_and
+              (equal_to
+                 (Backtest.Stop_log.Stop_loss
+                    { stop_price = 142.50; actual_price = 141.80 }
+                   : Backtest.Stop_log.exit_trigger)));
+       ])
+
 let suite =
   "Stop_log"
   >::: [
@@ -320,6 +460,10 @@ let suite =
          "update_risk_params updates stop"
          >:: test_update_risk_params_updates_stop;
          "trigger_exit records trigger" >:: test_trigger_exit_records_trigger;
+         "exit_complete without trigger tags End_of_period"
+         >:: test_exit_complete_without_trigger_tags_end_of_period;
+         "exit_complete does not overwrite TriggerExit"
+         >:: test_exit_complete_does_not_overwrite_trigger_exit;
          "wrapper passes through" >:: test_wrapper_passes_through;
          "wrapper handles error" >:: test_wrapper_handles_error;
        ]

--- a/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
+++ b/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
@@ -85,6 +85,7 @@ let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
   | Time_expired _ -> "time_expired"
   | Underperforming _ -> "underperforming"
   | Portfolio_rebalancing -> "rebalancing"
+  | End_of_period -> "end_of_period"
 
 let _row_of_trade audit_idx (trade : Trading_simulation.Metrics.trade_metrics) :
     per_trade_row =


### PR DESCRIPTION
## What

Add an `End_of_period` case to `Backtest.Stop_log.exit_trigger` and tag it
inside `Stop_log._process_transition` when an `ExitComplete` arrives without
a preceding `TriggerExit`. Render it as `"end_of_period"` in the
`exit_trigger` column of `trades.csv` (and the trade-audit report).

## Why

Per `dev/notes/sp500-trade-quality-findings-2026-04-30.md` §"Empty
`exit_trigger` rows in trades.csv", the post-G7-G9 sp500-2019-2023 run
produced 2 of 30 trades (JPM 2019-05-04, HD 2021-03-27) with an empty
`exit_trigger` column.

Root cause: `Stop_log._process_transition`
(`trading/trading/backtest/lib/stop_log.ml`) only intercepts `TriggerExit`
transitions. When the simulator's end-of-run auto-close emits `ExitFill`
followed by `ExitComplete` without a preceding `TriggerExit` (see
`trading/trading/simulation/lib/simulator.ml:205`), `pos_exit_trigger` stays
`None`, and the writer renders the column as empty string.

## Approach

Picked the smaller-blast-radius option (collector-side detection):

- Extend `Stop_log.exit_trigger` with a new `End_of_period` variant.
- In `_process_transition`, when `ExitComplete` arrives for a position with
  `pos_exit_trigger = None`, set it to `Some End_of_period`. An
  `ExitComplete` following a `TriggerExit` (normal stop-out / take-profit
  path) keeps the strategy's original trigger.
- Extend `Result_writer._exit_trigger_label` and the matching helper in
  `trade_audit_report.ml` with the new label string `"end_of_period"`.

Alternative considered: emit a synthetic `TriggerExit { exit_reason =
EndOfPeriod }` from the simulator at end-of-backtest. Rejected: would
require a new variant in `Position.exit_reason` (a core-module change),
and the audit collector is already the source of truth for `exit_trigger`
labels — keeping the change inside `Stop_log` keeps the simulator /
strategy boundary intact.

## Test plan

- [x] `dune build` clean (no warnings)
- [x] `dune fmt` clean
- [x] `dune exec trading/backtest/test/test_stop_log.exe` — 8/8 pass
- [x] `dune exec trading/backtest/test/test_result_writer.exe` — 10/10 pass
- [x] `dune exec trading/backtest/test/test_trade_audit_report.exe` — 18/18
  pass (verified the second labelling site updates cleanly)

New tests:
1. `test_exit_complete_without_trigger_tags_end_of_period` — pins the new
   collector-side tagging.
2. `test_exit_complete_does_not_overwrite_trigger_exit` — regression: an
   explicit `TriggerExit` (StopLoss in this case) is NOT overwritten by
   the new fallback.
3. `test_end_of_period_renders_label` (in `test_result_writer.ml`) — pins
   the CSV label string `"end_of_period"` end-to-end.

Sanity check: the sp500 reproducer JPM 2019-05-04 / HD 2021-03-27 trades
will now render `"end_of_period"` in their `exit_trigger` column rather
than the empty string.

## Out of scope

- Force-liquidation labelling (already tagged via `StopLoss` reason —
  verified).
- Stage-transition exits (handled separately by `stops_runner`).
- Reconciler-side spec update (separate PR, separate repo
  `dayfine/trading-reconciler`).

## PR sizing

220 LOC, 6 files. Below the 250-LOC budget.

## Pre-existing test failures unrelated to this PR

`Trade_audit_capture`, `Panel_round_trips_golden`, and
`Runner_hypothesis_overrides` fail with
`Sys_error("...tiered-loader-parity.sexp: No such file or directory")`
in this environment — pre-existing fixture-availability issue
flagged by the dispatch prompt.