### PR TITLE
feat(screener): per-symbol post-stop-out cooldown gate

### DIFF
--- a/dev/status/screener.md
+++ b/dev/status/screener.md
@@ -1,9 +1,9 @@
 # Status: screener
 
-## Last updated: 2026-04-14
+## Last updated: 2026-04-30
 
 ## Status
-MERGED
+MERGED (with one optional knob in flight: cascade post-stop-out cooldown — PR #718)
 
 ## QC Review
 APPROVED — See dev/reviews/screener.md (2026-03-30). All prior blockers resolved.
@@ -42,9 +42,22 @@ YES
 Total: 87 new tests across 9 modules, all passing.
 
 ## In Progress
-- None — all code done, PRs open for review
+- PR #718 — cascade post-stop-out cooldown gate. Adds
+  `Screener.config.cascade_post_stop_cooldown_weeks` (default 0; preserves
+  bit-equality) and `Screener.screen_with_cooldown`. Wired through
+  `Weinstein_strategy._on_market_close` so a per-symbol last-stop-out date
+  map populates from `TriggerExit { exit_reason = StopLoss _ }` and feeds
+  the screener every Friday. Surfaces from
+  `dev/notes/sp500-trade-quality-findings-2026-04-30.md` §"Cascade re-firing
+  within days of stop-out". Sweep / scenario rerun is a separate follow-up.
 
 ## Followup / Known Improvements
+
+### Cascade post-stop-out — re-base detection
+PR #718 lands a time-based cooldown only. The findings note flags that
+"may need to be combined with re-base detection for full book conformance"
+— require the symbol to dip below the prior breakout level and re-emerge
+before the screener re-fires. Out of scope for #718.
 
 ### Stage classifier: segmentation-based MA direction
 `stage/lib/stage.ml` currently classifies MA direction via a two-point slope

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -75,6 +75,7 @@ type config = {
   min_grade : grade;
   max_buy_candidates : int;
   max_short_candidates : int;
+  cascade_post_stop_cooldown_weeks : int; [@sexp.default 0]
 }
 [@@deriving sexp]
 
@@ -86,6 +87,7 @@ let default_config =
     min_grade = C;
     max_buy_candidates = 20;
     max_short_candidates = 10;
+    cascade_post_stop_cooldown_weeks = 0;
   }
 
 type scored_candidate = {
@@ -582,7 +584,32 @@ let _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade ~total_stocks
   _build_cascade_diagnostics ~total_stocks ~candidates_after_held ~macro_trend
     ~long_phases ~short_phases ~buy_candidates ~short_candidates
 
-let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
+(** Build the per-symbol cooldown set: tickers whose last stop-out is within
+    [cooldown_weeks] of [as_of] are blocked from the cascade. Returns an empty
+    set when the gate is disabled ([cooldown_weeks <= 0] or empty
+    [last_stop_out_dates]) — preserves bit-equality with the pre-gate behaviour.
+*)
+let _cooldown_block_set ~cooldown_weeks ~as_of ~last_stop_out_dates =
+  if cooldown_weeks <= 0 then String.Set.empty
+  else
+    let cooldown_days = cooldown_weeks * 7 in
+    List.filter_map last_stop_out_dates ~f:(fun (ticker, stop_date) ->
+        let elapsed = Date.diff as_of stop_date in
+        if elapsed < cooldown_days then Some ticker else None)
+    |> String.Set.of_list
+
+(** Single-pass filter that drops [held] and [cooldown] symbols and resolves
+    each survivor's sector context. Was a chained [filter |> map] allocating two
+    lists; the [filter_map] keeps just one. Runs every Friday over the full
+    screened universe (potentially thousands of symbols). *)
+let _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map =
+  List.filter_map stocks ~f:(fun (a : Stock_analysis.t) ->
+      if Set.mem held_set a.ticker then None
+      else if Set.mem cooldown_set a.ticker then None
+      else Some (a, _resolve_sector ~sector_map a.ticker))
+
+let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
+    : result =
   let held_set = String.Set.of_list held_tickers in
   let {
     weights;
@@ -591,6 +618,7 @@ let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
     min_grade;
     max_buy_candidates;
     max_short_candidates;
+    cascade_post_stop_cooldown_weeks = _;
   } =
     config
   in
@@ -598,14 +626,8 @@ let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
     match macro_trend with Bullish | Neutral -> true | Bearish -> false
   in
   let total_stocks = List.length stocks in
-  (* Was: chained filter |> map allocated two lists (one for the held-set
-     filter, one for the (analysis, sector) pairs). Now: single-pass
-     filter_map keeps only one output list. Runs every Friday over the full
-     screened universe (potentially thousands of symbols). *)
   let candidates =
-    List.filter_map stocks ~f:(fun (a : Stock_analysis.t) ->
-        if Set.mem held_set a.ticker then None
-        else Some (a, _resolve_sector ~sector_map a.ticker))
+    _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map
   in
   let candidates_after_held = List.length candidates in
   let buy_candidates =
@@ -634,3 +656,15 @@ let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
     macro_trend;
     cascade_diagnostics;
   }
+
+let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
+  _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers
+    ~cooldown_set:String.Set.empty
+
+let screen_with_cooldown ~config ~macro_trend ~sector_map ~stocks ~held_tickers
+    ~as_of ~last_stop_out_dates : result =
+  let cooldown_set =
+    _cooldown_block_set ~cooldown_weeks:config.cascade_post_stop_cooldown_weeks
+      ~as_of ~last_stop_out_dates
+  in
+  _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -89,6 +89,19 @@ type config = {
       (** Maximum number of buy candidates returned. Default: 20. *)
   max_short_candidates : int;
       (** Maximum number of short candidates returned. Default: 10. *)
+  cascade_post_stop_cooldown_weeks : int; [@sexp.default 0]
+      (** Per-symbol post-stop-out cooldown, in weeks. After a position stops
+          out, the symbol is excluded from the cascade for this many weeks.
+          Default: [0] (disabled — preserves prior behaviour bit-equally). When
+          [> 0], callers must pass [~as_of] and [~last_stop_out_dates] to
+          {!screen}; otherwise the gate is a no-op (no map → no exclusion).
+
+          Authority: weinstein-book-reference.md §Buy-Side Rules implies a
+          stopped-out trade signals the breakout was false. The book does not
+          prescribe a specific cooldown, so this lever is configurable. Surfaced
+          in response to the same-week re-fire pattern documented in
+          dev/notes/sp500-trade-quality-findings-2026-04-30.md §"Cascade
+          re-firing within days of stop-out". *)
 }
 [@@deriving sexp]
 (** Main screener configuration. *)
@@ -202,5 +215,33 @@ val screen :
     @param sector_map Map from ticker to sector context.
     @param stocks Per-stock analysis results.
     @param held_tickers Tickers already in portfolio — excluded from output.
+
+    Pure function. Equivalent to {!screen_with_cooldown} with [as_of = None] and
+    [last_stop_out_dates = []] — i.e. the post-stop-out cooldown gate is a no-op
+    regardless of [config.cascade_post_stop_cooldown_weeks]. *)
+
+val screen_with_cooldown :
+  config:config ->
+  macro_trend:Weinstein_types.market_trend ->
+  sector_map:(string, sector_context) Core.Hashtbl.t ->
+  stocks:Stock_analysis.t list ->
+  held_tickers:string list ->
+  as_of:Core.Date.t ->
+  last_stop_out_dates:(string * Core.Date.t) list ->
+  result
+(** [screen_with_cooldown] is {!screen} with the per-symbol post-stop-out
+    cooldown gate active.
+
+    @param as_of Cascade evaluation date.
+    @param last_stop_out_dates
+      Per-symbol last stop-out date. Each entry [(ticker, date)] excludes
+      [ticker] from the cascade if
+      [(as_of - date) < config.cascade_post_stop_cooldown_weeks * 7] days. When
+      [config.cascade_post_stop_cooldown_weeks = 0] the gate is a no-op, so this
+      function is bit-equal to {!screen} on the same inputs.
+
+    Authority: weinstein-book-reference.md §Buy-Side Rules — a stopped-out trade
+    signals the breakout was false; book does not prescribe a specific cooldown
+    so it is configurable.
 
     Pure function. *)

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -731,6 +731,66 @@ let test_diagnostics_long_top_n_matches_buy_candidates _ =
   assert_that result.cascade_diagnostics.long_top_n_admitted
     (equal_to (List.length result.buy_candidates))
 
+(* ------------------------------------------------------------------ *)
+(* Cascade post-stop-out cooldown gate                                 *)
+(* ------------------------------------------------------------------ *)
+
+(** Stage1→Stage2 breakout fixture used across the cooldown tests so each test
+    pins one independent variable (cooldown_weeks, recency, per-symbol scope).
+*)
+let _breakout_stocks tickers =
+  let bars = rising_bars_with_spike ~n:35 50.0 100.0 ~spike_idx:31 in
+  let prior = Some (Stage1 { weeks_in_base = 10 }) in
+  List.map tickers ~f:(fun t -> make_analysis t prior bars)
+
+(** Cooldown disabled (default 0 weeks): even a stop-out from yesterday must not
+    exclude the symbol — pins bit-equality with [screen]. *)
+let test_cooldown_disabled_no_exclusion _ =
+  let stocks = _breakout_stocks [ "AAPL" ] in
+  let result =
+    screen_with_cooldown ~config:cfg ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
+      ~last_stop_out_dates:[ ("AAPL", Date.add_days as_of (-1)) ]
+  in
+  assert_that result.buy_candidates
+    (elements_are [ field (fun c -> c.ticker) (equal_to "AAPL") ])
+
+(** Cooldown 4 weeks, stop-out 14 days ago (< 28d): symbol excluded. *)
+let test_cooldown_recent_stop_excludes _ =
+  let stocks = _breakout_stocks [ "AAPL" ] in
+  let cooldown_cfg = { cfg with cascade_post_stop_cooldown_weeks = 4 } in
+  let result =
+    screen_with_cooldown ~config:cooldown_cfg ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
+      ~last_stop_out_dates:[ ("AAPL", Date.add_days as_of (-14)) ]
+  in
+  assert_that result.buy_candidates is_empty
+
+(** Cooldown 4 weeks, stop-out 35 days ago (>= 28d): symbol eligible again. *)
+let test_cooldown_elapsed_stop_eligible _ =
+  let stocks = _breakout_stocks [ "AAPL" ] in
+  let cooldown_cfg = { cfg with cascade_post_stop_cooldown_weeks = 4 } in
+  let result =
+    screen_with_cooldown ~config:cooldown_cfg ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
+      ~last_stop_out_dates:[ ("AAPL", Date.add_days as_of (-35)) ]
+  in
+  assert_that result.buy_candidates
+    (elements_are [ field (fun c -> c.ticker) (equal_to "AAPL") ])
+
+(** Cooldown applies per-symbol: a recent stop-out on AAPL must not block HD. *)
+let test_cooldown_per_symbol_scope _ =
+  let stocks = _breakout_stocks [ "AAPL"; "HD" ] in
+  let cooldown_cfg = { cfg with cascade_post_stop_cooldown_weeks = 4 } in
+  let result =
+    screen_with_cooldown ~config:cooldown_cfg ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
+      ~last_stop_out_dates:[ ("AAPL", Date.add_days as_of (-7)) ]
+  in
+  assert_that result.buy_candidates
+    (all_of
+       [ size_is 1; elements_are [ field (fun c -> c.ticker) (equal_to "HD") ] ])
+
 let suite =
   "screener_tests"
   >::: [
@@ -774,6 +834,13 @@ let suite =
          >:: test_diagnostics_bullish_macro_blocks_shorts;
          "test_diagnostics_long_top_n_matches_buy_candidates"
          >:: test_diagnostics_long_top_n_matches_buy_candidates;
+         "test_cooldown_disabled_no_exclusion"
+         >:: test_cooldown_disabled_no_exclusion;
+         "test_cooldown_recent_stop_excludes"
+         >:: test_cooldown_recent_stop_excludes;
+         "test_cooldown_elapsed_stop_eligible"
+         >:: test_cooldown_elapsed_stop_eligible;
+         "test_cooldown_per_symbol_scope" >:: test_cooldown_per_symbol_scope;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -44,6 +44,7 @@ let _permissive_screener_config (config : config) : Screener.config =
     min_grade = F;
     max_buy_candidates = Int.max_value;
     max_short_candidates = Int.max_value;
+    cascade_post_stop_cooldown_weeks = 0;
   }
 
 (** Whether [trend] would have admitted longs at the macro gate. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -271,8 +271,9 @@ let survivors_for_screening ?sector_map ~config ~bar_reader ~prior_stages
     the screener; concatenating [buy_candidates] + [short_candidates] yields the
     right shape per regime. *)
 let _screen_universe ~config ~index_view ~(macro_result : Macro.result)
-    ~sector_map ~stop_states ~(portfolio : Portfolio_view.t) ~get_price
-    ~bar_reader ~prior_stages ~current_date ~audit_recorder =
+    ~sector_map ~stop_states ~last_stop_out_dates
+    ~(portfolio : Portfolio_view.t) ~get_price ~bar_reader ~prior_stages
+    ~current_date ~audit_recorder =
   let classified =
     _classify_all ~config ~bar_reader ~prior_stages ~current_date
   in
@@ -288,9 +289,10 @@ let _screen_universe ~config ~index_view ~(macro_result : Macro.result)
   in
   _commit_prior_stages ~prior_stages classified;
   let screen_result =
-    Screener.screen ~config:config.screening_config
+    Screener.screen_with_cooldown ~config:config.screening_config
       ~macro_trend:macro_result.trend ~sector_map ~stocks
-      ~held_tickers:(held_symbols portfolio)
+      ~held_tickers:(held_symbols portfolio) ~as_of:current_date
+      ~last_stop_out_dates:(Hashtbl.to_alist last_stop_out_dates)
   in
   let combined_candidates =
     if config.enable_short_side then
@@ -366,9 +368,9 @@ let _run_macro_only ~config ~ad_bars ~prior_macro ~prior_macro_result
     screener is invoked; macro-specific gating — longs blocked under Bearish,
     shorts blocked under Bullish — happens inside the screener. Under Bearish
     this yields short-side entries (per the bear-market shorting chapter). *)
-let _run_screen_after_macro ~config ~stop_states ~bar_reader ~prior_stages
-    ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio ~current_date
-    ~index_view ~audit_recorder ~macro_result =
+let _run_screen_after_macro ~config ~stop_states ~last_stop_out_dates
+    ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price
+    ~portfolio ~current_date ~index_view ~audit_recorder ~macro_result =
   let ma_cache = Bar_reader.ma_cache bar_reader in
   let sector_map =
     Macro_inputs.build_sector_map ?ma_cache ~stage_config:config.stage_config
@@ -377,8 +379,8 @@ let _run_screen_after_macro ~config ~stop_states ~bar_reader ~prior_stages
       ~ticker_sectors ()
   in
   _screen_universe ~config ~index_view ~macro_result ~sector_map ~stop_states
-    ~portfolio ~get_price ~bar_reader ~prior_stages ~current_date
-    ~audit_recorder
+    ~last_stop_out_dates ~portfolio ~get_price ~bar_reader ~prior_stages
+    ~current_date ~audit_recorder
 
 (** Filter the position map down to symbols not yet exited on this tick. The
     force-liquidation pass runs after [Stops_runner.update] but before the
@@ -411,8 +413,31 @@ let _maybe_reset_halt ~peak_tracker
   | Weinstein_types.Bullish | Weinstein_types.Neutral ->
       Portfolio_risk.Force_liquidation.Peak_tracker.reset peak_tracker
 
-let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
-    ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
+(** Update [last_stop_out_dates] from any [TriggerExit] transitions whose
+    [exit_reason] is [StopLoss] — i.e. only stop-machinery exits, not
+    take-profit / signal-reversal / time-expired / force-liquidation /
+    rebalancing. The mutated map is consumed by [Screener.screen_with_cooldown]
+    on the same Friday tick (and on every subsequent Friday until the cooldown
+    elapses). Looks up the symbol via [position_id] -> position.symbol from the
+    snapshot taken before the stops pass. *)
+let _record_stop_outs ~last_stop_out_dates
+    ~(positions : Position.t Map.M(String).t)
+    ~(exit_transitions : Position.transition list) ~current_date =
+  List.iter exit_transitions ~f:(fun (t : Position.transition) ->
+      match t.kind with
+      | Position.TriggerExit { exit_reason = Position.StopLoss _; _ } -> (
+          match
+            Map.data positions
+            |> List.find ~f:(fun (p : Position.t) ->
+                String.equal p.id t.position_id)
+          with
+          | Some pos ->
+              Hashtbl.set last_stop_out_dates ~key:pos.symbol ~data:current_date
+          | None -> ())
+      | _ -> ())
+
+let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
+    ~prior_macro ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
     ~sector_prior_stages ~ticker_sectors ~audit_recorder ~get_price
     ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
   let positions = portfolio.positions in
@@ -434,6 +459,11 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
       ~lookback_bars:config.lookback_bars ~positions ~get_price ~stop_states
       ~bar_reader ~as_of:current_date ~prior_stages ()
   in
+  (* Track per-symbol last stop-out date for the cascade post-stop-out
+     cooldown gate. Walks [exit_transitions] before they are applied to the
+     position state — looks up symbols from the [positions] snapshot. *)
+  _record_stop_outs ~last_stop_out_dates ~positions ~exit_transitions
+    ~current_date;
   List.iter exit_transitions
     ~f:
       (Exit_audit_capture.emit_exit_audit ~audit_recorder ~prior_macro_result
@@ -490,9 +520,10 @@ let _on_market_close ~config ~ad_bars ~stop_states ~prior_macro
   let entry_transitions =
     match (halted, is_screening_day, macro_result_opt) with
     | false, true, Some macro_result ->
-        _run_screen_after_macro ~config ~stop_states ~bar_reader ~prior_stages
-          ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio
-          ~current_date ~index_view ~audit_recorder ~macro_result
+        _run_screen_after_macro ~config ~stop_states ~last_stop_out_dates
+          ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
+          ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
+          ~macro_result
     | _ -> []
   in
   Ok
@@ -506,6 +537,16 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
     ?(ticker_sectors = Hashtbl.create (module String)) ?bar_panels
     ?(audit_recorder = Audit_recorder.noop) config =
   let stop_states = ref initial_stop_states in
+  (* Per-symbol last stop-out date — feeds [Screener.screen_with_cooldown]
+     for the cascade post-stop-out cooldown gate
+     ([cascade_post_stop_cooldown_weeks]). Mutated in place by
+     [_record_stop_outs] after each [Stops_runner.update] tick. Empty when
+     the strategy is constructed: an empty map is bit-equivalent to no
+     cooldown effect, so backtests / live runs that don't set the cooldown
+     knob continue to behave identically. *)
+  let last_stop_out_dates : Date.t Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
   let prior_macro : Weinstein_types.market_trend ref =
     ref Weinstein_types.Neutral
   in
@@ -548,9 +589,10 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
     let name = name
 
     let on_market_close =
-      _on_market_close ~config ~ad_bars:weekly_ad_bars ~stop_states ~prior_macro
-        ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
-        ~sector_prior_stages ~ticker_sectors ~audit_recorder
+      _on_market_close ~config ~ad_bars:weekly_ad_bars ~stop_states
+        ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
+        ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
+        ~audit_recorder
   end in
   (module M : Strategy_interface.STRATEGY)
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -344,6 +344,7 @@ module Internal_for_test : sig
     config:config ->
     ad_bars:Macro.ad_bar list ->
     stop_states:Weinstein_stops.stop_state String.Map.t ref ->
+    last_stop_out_dates:Date.t Hashtbl.M(String).t ->
     prior_macro:Weinstein_types.market_trend ref ->
     prior_macro_result:Macro.result option ref ->
     peak_tracker:Portfolio_risk.Force_liquidation.Peak_tracker.t ->
@@ -357,9 +358,10 @@ module Internal_for_test : sig
     portfolio:Trading_strategy.Portfolio_view.t ->
     Trading_strategy.Strategy_interface.output Status.status_or
   (** Drives [_on_market_close] with all closure-scoped state passed in
-      explicitly. Mutates [stop_states] / [prior_macro] / [prior_macro_result] /
-      [peak_tracker] / [prior_stages] / [sector_prior_stages] in place,
-      mirroring the closure semantics in {!make}. *)
+      explicitly. Mutates [stop_states] / [last_stop_out_dates] / [prior_macro]
+      / [prior_macro_result] / [peak_tracker] / [prior_stages] /
+      [sector_prior_stages] in place, mirroring the closure semantics in
+      {!make}. *)
 
   val maybe_reset_halt :
     peak_tracker:Portfolio_risk.Force_liquidation.Peak_tracker.t ->

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
@@ -99,6 +99,7 @@ let _next_friday d =
 
 type _strategy_state = {
   stop_states : Weinstein_stops.stop_state String.Map.t ref;
+  last_stop_out_dates : Date.t Hashtbl.M(String).t;
   prior_macro : market_trend ref;
   prior_macro_result : Macro.result option ref;
   peak_tracker : FL.Peak_tracker.t;
@@ -114,6 +115,7 @@ type _strategy_state = {
 let _fresh_state ~bar_reader =
   {
     stop_states = ref String.Map.empty;
+    last_stop_out_dates = Hashtbl.create (module String);
     prior_macro = ref Neutral;
     prior_macro_result = ref None;
     peak_tracker = FL.Peak_tracker.create ();
@@ -134,8 +136,9 @@ let _get_price_of_state state ~current_date symbol =
 
 let _drive_tick state ~config ~current_date ~portfolio =
   Internal_for_test.on_market_close ~config ~ad_bars:[]
-    ~stop_states:state.stop_states ~prior_macro:state.prior_macro
-    ~prior_macro_result:state.prior_macro_result
+    ~stop_states:state.stop_states
+    ~last_stop_out_dates:state.last_stop_out_dates
+    ~prior_macro:state.prior_macro ~prior_macro_result:state.prior_macro_result
     ~peak_tracker:state.peak_tracker ~bar_reader:state.bar_reader
     ~prior_stages:state.prior_stages
     ~sector_prior_stages:state.sector_prior_stages


### PR DESCRIPTION
## Summary

- Add a configurable `cascade_post_stop_cooldown_weeks` lever to the
  Weinstein screener. When > 0, the screener excludes symbols whose
  last stop-out is within N weeks of the cascade evaluation date.
  Default 0 preserves bit-equality with prior behaviour.
- Wire a per-symbol last-stop-out-date map through the strategy
  closure: populated from `TriggerExit { exit_reason = StopLoss _ }`
  transitions emitted by `Stops_runner.update`, consumed by the new
  `Screener.screen_with_cooldown` on every Friday cascade.
- Surfaces from `dev/notes/sp500-trade-quality-findings-2026-04-30.md`
  §"Cascade re-firing within days of stop-out" — sp500-2019-2023 shows
  AAPL, HD, JNJ, CVX patterns of stop-out → re-entry → stop-out within
  4-7 days. Authority: `weinstein-book-reference.md` §Buy-Side Rules
  implies a stopped-out trade signals the breakout was false; book does
  not prescribe a specific cooldown so the lever is configurable.

## Files changed

- `trading/analysis/weinstein/screener/lib/screener.{ml,mli}` —
  config field, new `screen_with_cooldown` wrapper, internal
  `_cooldown_block_set` helper, factored `_prepare_candidates` so
  `_screen` stays under the 50-line linter cap.
- `trading/analysis/weinstein/screener/test/test_screener.ml` — 4 new
  tests covering default-disabled, recent-stop excludes, elapsed-stop
  eligible, per-symbol scope.
- `trading/trading/weinstein/strategy/lib/weinstein_strategy.{ml,mli}`
  — closure ref + `_record_stop_outs` helper + plumb through
  `_run_screen_after_macro` / `_screen_universe` to the screener.
  `Internal_for_test.on_market_close` gains the new arg.
- `trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml`
  — fixture passes empty hashtable for the new arg.
- `trading/trading/backtest/optimal/lib/stage_transition_scanner.ml`
  — explicit-record-init site updated for the new field.

PR sizing: +220 / -30 = 250 net (under the 400-LOC cap).

## Test plan

- [x] `dune build` clean
- [x] `dune build @fmt` clean
- [x] `dune runtest analysis/weinstein/screener/` — 31 tests pass
      (27 baseline + 4 new)
- [x] `dune runtest trading/weinstein/strategy/` — all pass
- [x] Mutation-tested by inverting the cooldown gate; the recent-stop
      and per-symbol tests fail as expected, then restore + verify.
- [x] Pre-existing failures (`Trade_audit_capture`,
      `Panel_round_trips_golden`, `Panel_runner_gc_trace`,
      `Runner_hypothesis_overrides`) reproduce on `main@origin` and are
      unrelated to this change.

## Out of scope

- Re-base detection (require price to dip below prior breakout and
  re-emerge before re-entry) — separate PR.
- Sweep / scenario rerun comparing fixed-buffer vs cooldown across
  goldens — separate experiment.
- Cross-symbol cooldowns (sector-wide etc.).
- Default value remains 0 — no behavioural change to current backtests
  unless the knob is opted in.

## Decision items for review

- The per-symbol last-stop-out-date map currently lives in the strategy
  closure (in-memory) rather than `Weinstein_trading_state`. The
  trading-state record already has `trade_log` with `Sell` / `Cover`
  entries, but those don't distinguish stop-out exits from other
  exits. Persisting the map across sessions can be a follow-up if
  cooldown gets enabled in live mode; for backtesting the closure
  scope is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)