### PR TITLE
fix(trade_audit): drop warmup-window audit_records + cascade_summaries

### DIFF
--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -295,6 +295,25 @@ let filter_force_liquidations_in_window events ~start_date =
   List.filter events ~f:(fun (e : Portfolio_risk.Force_liquidation.event) ->
       Date.( >= ) e.date start_date)
 
+(** Drop trade-audit records whose entry-decision date is before [start_date] —
+    i.e. positions whose entry decision was made during the warmup window. The
+    strategy's audit recorder is wired from [warmup_start], so without this
+    filter [trade_audit.sexp] picks up entry/exit decision pairs whose
+    round-trips were never reported to [trades.csv]. *)
+let filter_audit_records_in_window records ~start_date =
+  List.filter records ~f:(fun (r : Trade_audit.audit_record) ->
+      Date.( >= ) r.entry.entry_date start_date)
+
+(** Drop cascade-summary rows whose Friday [date] is before [start_date] — i.e.
+    cascade evaluations that ran during the warmup window. The strategy's audit
+    recorder calls [record_cascade_summary] every Friday from [warmup_start], so
+    without this filter [trade_audit.sexp] reports activity counts that include
+    warmup-window screen calls (no candidates of which were ever entered into
+    [trades.csv]). *)
+let filter_cascade_summaries_in_window summaries ~start_date =
+  List.filter summaries ~f:(fun (s : Trade_audit.cascade_summary) ->
+      Date.( >= ) s.date start_date)
+
 let _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
     ~sim_result : Summary.t =
   {
@@ -367,8 +386,12 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
           filter_stop_infos_in_window
             (Stop_log.get_stop_infos stop_log)
             ~start_date,
-          Trade_audit.get_audit_records trade_audit,
-          Trade_audit.get_cascade_summaries trade_audit,
+          filter_audit_records_in_window
+            (Trade_audit.get_audit_records trade_audit)
+            ~start_date,
+          filter_cascade_summaries_in_window
+            (Trade_audit.get_cascade_summaries trade_audit)
+            ~start_date,
           filter_force_liquidations_in_window
             (Force_liquidation_log.events force_liquidation_log)
             ~start_date ))

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -74,6 +74,25 @@ val filter_force_liquidations_in_window :
     [start_date]; without this filter, warmup-window force-liqs leak into
     [force_liquidations.sexp] and inflate the visible event count. *)
 
+val filter_audit_records_in_window :
+  Trade_audit.audit_record list ->
+  start_date:Date.t ->
+  Trade_audit.audit_record list
+(** Drop audit records whose entry-decision date is before [start_date]. The
+    strategy's audit recorder fires from [warmup_start], so without this filter
+    [trade_audit.sexp] picks up entries whose round-trips were never reported to
+    [trades.csv]. *)
+
+val filter_cascade_summaries_in_window :
+  Trade_audit.cascade_summary list ->
+  start_date:Date.t ->
+  Trade_audit.cascade_summary list
+(** Drop cascade-summary rows whose Friday [date] is before [start_date] —
+    cascade evaluations that ran during the warmup window. The strategy records
+    summaries every Friday from [warmup_start], so without this filter
+    [trade_audit.sexp] reports activity counts that include warmup- window
+    screen calls. *)
+
 val is_trading_day :
   Trading_simulation_types.Simulator_types.step_result -> bool
 (** True if [step] represents a real trading day — i.e. the portfolio's

--- a/trading/trading/backtest/test/test_runner_filter.ml
+++ b/trading/trading/backtest/test/test_runner_filter.ml
@@ -390,6 +390,116 @@ let test_filter_force_liquidations_keeps_boundary _ =
   in
   assert_that kept (size_is 1)
 
+(* -------------------------------------------------------------------- *)
+(* Phase 6: trade_audit + cascade_summary filters                        *)
+(* -------------------------------------------------------------------- *)
+
+(** Regression: warmup-emit leak in [trade_audit]. The audit recorder fires from
+    [warmup_start], so [audit_record]s with warmup-window [entry.entry_date] and
+    [cascade_summary]s with warmup-window [date] sit in the collector at
+    teardown.
+
+    [Runner.filter_audit_records_in_window] /
+    [Runner.filter_cascade_summaries_in_window] drop entries before [start_date]
+    from [trade_audit.sexp]. *)
+let _entry ~entry_date ~position_id ~symbol :
+    Backtest.Trade_audit.entry_decision =
+  {
+    symbol;
+    entry_date;
+    position_id;
+    macro_trend = Bullish;
+    macro_confidence = 0.5;
+    macro_indicators = [];
+    stage = Stage1 { weeks_in_base = 0 };
+    ma_direction = Flat;
+    ma_slope_pct = 0.0;
+    rs_trend = None;
+    rs_value = None;
+    volume_quality = None;
+    resistance_quality = None;
+    support_quality = None;
+    sector_name = "Tech";
+    sector_rating = Neutral;
+    cascade_score = 0;
+    cascade_grade = D;
+    cascade_score_components = [];
+    cascade_rationale = [];
+    side = Long;
+    suggested_entry = 100.0;
+    suggested_stop = 95.0;
+    installed_stop = 95.0;
+    stop_floor_kind = Buffer_fallback;
+    risk_pct = 0.05;
+    initial_position_value = 10_000.0;
+    initial_risk_dollars = 500.0;
+    alternatives_considered = [];
+  }
+
+let _audit_record ~entry_date ~position_id ~symbol :
+    Backtest.Trade_audit.audit_record =
+  { entry = _entry ~entry_date ~position_id ~symbol; exit_ = None }
+
+let test_filter_audit_records_drops_warmup _ =
+  let start_date = date_of_string "2019-01-02" in
+  let warmup =
+    _audit_record
+      ~entry_date:(date_of_string "2018-08-01")
+      ~position_id:"A-1" ~symbol:"AAPL"
+  in
+  let in_window =
+    _audit_record
+      ~entry_date:(date_of_string "2019-04-15")
+      ~position_id:"M-1" ~symbol:"MSFT"
+  in
+  let kept =
+    Backtest.Runner.filter_audit_records_in_window [ warmup; in_window ]
+      ~start_date
+  in
+  assert_that kept
+    (elements_are
+       [
+         field
+           (fun (r : Backtest.Trade_audit.audit_record) -> r.entry.symbol)
+           (equal_to "MSFT");
+       ])
+
+let _cascade_summary ~date : Backtest.Trade_audit.cascade_summary =
+  {
+    date;
+    total_stocks = 100;
+    candidates_after_held = 100;
+    macro_trend = Bullish;
+    long_macro_admitted = 0;
+    long_breakout_admitted = 0;
+    long_sector_admitted = 0;
+    long_grade_admitted = 0;
+    long_top_n_admitted = 0;
+    short_macro_admitted = 0;
+    short_breakdown_admitted = 0;
+    short_sector_admitted = 0;
+    short_rs_hard_gate_admitted = 0;
+    short_grade_admitted = 0;
+    short_top_n_admitted = 0;
+    entered = 0;
+  }
+
+let test_filter_cascade_summaries_drops_warmup _ =
+  let start_date = date_of_string "2019-01-02" in
+  let warmup = _cascade_summary ~date:(date_of_string "2018-09-07") in
+  let in_window = _cascade_summary ~date:(date_of_string "2019-03-15") in
+  let kept =
+    Backtest.Runner.filter_cascade_summaries_in_window [ warmup; in_window ]
+      ~start_date
+  in
+  assert_that kept
+    (elements_are
+       [
+         field
+           (fun (s : Backtest.Trade_audit.cascade_summary) -> s.date)
+           (equal_to (date_of_string "2019-03-15"));
+       ])
+
 let suite =
   "Runner_filter"
   >::: [
@@ -411,6 +521,10 @@ let suite =
          >:: test_filter_force_liquidations_drops_warmup;
          "filter_force_liquidations keeps events on the start_date boundary"
          >:: test_filter_force_liquidations_keeps_boundary;
+         "filter_audit_records drops warmup entries"
+         >:: test_filter_audit_records_drops_warmup;
+         "filter_cascade_summaries drops warmup entries"
+         >:: test_filter_cascade_summaries_drops_warmup;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Part 3 of 4 of the **warmup-emit-during-warmup** leak fix series. The strategy's `Audit_recorder` fires from `warmup_start`, so `audit_records` with warmup-window `entry.entry_date` and `cascade_summary`s with warmup-window `date` both leak into `trade_audit.sexp`.

## What it does

`Runner.filter_audit_records_in_window` + `Runner.filter_cascade_summaries_in_window` drop entries before `start_date` at teardown.

## Empirical effect

Smoke goldens after fix3 vs before — ~30 warmup-window cascade summary entries dropped per scenario, exactly matching the 210-day = 30-Friday warmup window:

| Scenario | Pre-fix dates | Post-fix dates |
|---|---:|---:|
| bull-2019h2 | 59 | 30 |
| crash-2020h1 | 55 | 25 |
| panel-golden-2019-full | 64 | 35 |
| recovery-2023 | 81 | 51 |
| tiered-loader-parity | 59 | 30 |

## Test plan

- [x] `dune build && dune fmt` clean
- [x] `dune exec backtest/test/test_runner_filter.exe` — 13 OK (2 new tests: drops warmup audit_records, drops warmup cascade_summaries)
- [x] Smoke goldens still PASS

Stacked on #721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)