### PR TITLE
fix(summary_metrics): overlay Sharpe/MaxDD/CAGR from in-window steps

### DIFF
--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -239,24 +239,86 @@ let _run_panel_backtest ~deps ~start_date ~end_date ?trace ?gc_trace () =
     ~start_date ~end_date ~warmup_days ~initial_cash ~commission ?trace
     ?gc_trace ()
 
-(** Recompute the round-trip-derived metrics ([TotalPnl], [AvgHoldingDays],
-    [WinCount], [LossCount], [WinRate], [ProfitFactor]) from the runner's
-    range-filtered [round_trips] and overlay them onto the simulator's metric
-    set. This aligns the summary's win/loss counts with [trades.csv].
+(** Re-run the step-based metric computers ([SharpeRatio], [MaxDrawdown],
+    [CAGR]) on the in-window step list with a config whose [start_date] is the
+    actual run start (not the warmup_start the simulator was created with). The
+    simulator computed these metrics across [warmup_start..end_date], which
+    folds the warmup window's drawdown, return volatility, and total return into
+    the published values; this overlay restores the metrics' values to "what
+    happened during the measurement window only". *)
+let _recompute_in_window_step_metrics ~steps_in_range ~start_date ~end_date =
+  let config : Trading_simulation_types.Simulator_types.config =
+    {
+      start_date;
+      end_date;
+      initial_cash;
+      commission;
+      strategy_cadence = Types.Cadence.Daily;
+    }
+  in
+  let computers =
+    [
+      Metric_computers.sharpe_ratio_computer ();
+      Metric_computers.max_drawdown_computer ();
+      Metric_computers.cagr_computer ();
+    ]
+  in
+  List.fold computers ~init:Trading_simulation_types.Metric_types.empty
+    ~f:(fun acc c ->
+      Trading_simulation_types.Metric_types.merge acc
+        (c.run ~config ~steps:steps_in_range))
 
-    The simulator's [Summary_computer] folds over every step in [step_history],
-    including the warmup window (the simulator is configured with
-    [start_date = warmup_start]). The runner instead derives [round_trips] from
-    [steps_in_range] (steps with [date >= start_date]). When complete
-    round-trips fall in the warmup window, the simulator's metric set counts
-    them while [trades.csv] does not — observed empirically on
-    [panel-golden-2019-full] (summary wincount=3 vs trades.csv 2 wins). The
-    overlay restores the invariant that summary counts equal what's visible in
-    [trades.csv] / [n_round_trips]. *)
-let _align_summary_metrics_to_round_trips ~sim_result ~round_trips =
-  let overlay = Metrics.compute_round_trip_metric_set round_trips in
-  Trading_simulation_types.Metric_types.merge
-    sim_result.Trading_simulation_types.Simulator_types.metrics overlay
+(** Recompute [CalmarRatio = CAGR / MaxDrawdown] from already-overlaid
+    [base_metrics]. The simulator emits [CalmarRatio] from the
+    [calmar_ratio_derived] computer using its own warmup-inclusive CAGR /
+    MaxDrawdown; once the overlay has replaced those with in-window values, the
+    published [CalmarRatio] must follow or the ratio is inconsistent with its
+    components. *)
+let _recompute_calmar_ratio ~base_metrics =
+  let dummy_config : Trading_simulation_types.Simulator_types.config =
+    {
+      start_date = Date.create_exn ~y:2000 ~m:Month.Jan ~d:1;
+      end_date = Date.create_exn ~y:2000 ~m:Month.Jan ~d:1;
+      initial_cash;
+      commission;
+      strategy_cadence = Types.Cadence.Daily;
+    }
+  in
+  Metric_computers.calmar_ratio_derived.compute ~config:dummy_config
+    ~base_metrics
+
+(** Three-stage overlay applied to the simulator's metric set:
+
+    1. Replace round-trip-derived metrics ([TotalPnl], [AvgHoldingDays],
+    [WinCount], [LossCount], [WinRate], [ProfitFactor]) with values computed
+    from the runner's range-filtered [round_trips] — observed empirically on
+    [panel-golden-2019-full] (sim says 3 wins; runner round_trips says 2 wins;
+    trades.csv shows 2; the overlay aligns the summary to trades.csv).
+
+    2. Replace step-based metrics ([SharpeRatio], [MaxDrawdown], [CAGR]) with
+    values recomputed on [steps_in_range] (the in-window step list only) —
+    without this, warmup-window drawdown / return / volatility inflate the
+    published values vs. what actually happened in the run.
+
+    3. Recompute [CalmarRatio] from the overlaid CAGR / MaxDrawdown so the
+    derived metric stays consistent with its components.
+
+    The simulator runs from [warmup_start] (not [start_date]) so all three of
+    its metric flavors (round-trip, step-based, and derived) include the warmup
+    window. The overlay restores the invariant that the published metrics
+    describe the measurement window only. *)
+let _align_summary_metrics ~sim_result ~round_trips ~steps_in_range ~start_date
+    ~end_date =
+  let merge = Trading_simulation_types.Metric_types.merge in
+  let after_round_trips =
+    merge sim_result.Trading_simulation_types.Simulator_types.metrics
+      (Metrics.compute_round_trip_metric_set round_trips)
+  in
+  let after_step =
+    merge after_round_trips
+      (_recompute_in_window_step_metrics ~steps_in_range ~start_date ~end_date)
+  in
+  merge after_step (_recompute_calmar_ratio ~base_metrics:after_step)
 
 (** Drop simulator-side [stop_info]s whose [entry_date] is before [start_date] —
     i.e. positions opened during the warmup window. The simulator runs from
@@ -314,8 +376,8 @@ let filter_cascade_summaries_in_window summaries ~start_date =
   List.filter summaries ~f:(fun (s : Trade_audit.cascade_summary) ->
       Date.( >= ) s.date start_date)
 
-let _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
-    ~sim_result : Summary.t =
+let _make_summary ~start_date ~end_date ~deps ~steps_in_range ~steps
+    ~final_value ~round_trips ~sim_result : Summary.t =
   {
     start_date;
     end_date;
@@ -324,7 +386,9 @@ let _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
     initial_cash;
     final_portfolio_value = final_value;
     n_round_trips = List.length round_trips;
-    metrics = _align_summary_metrics_to_round_trips ~sim_result ~round_trips;
+    metrics =
+      _align_summary_metrics ~sim_result ~round_trips ~steps_in_range
+        ~start_date ~end_date;
   }
 
 (** Filter [final_close_prices] to symbols that are still held in the last
@@ -398,8 +462,8 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
   in
   Gc_trace.record ?trace:gc_trace ~phase:"teardown_done" ();
   let summary =
-    _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
-      ~sim_result
+    _make_summary ~start_date ~end_date ~deps ~steps_in_range ~steps
+      ~final_value ~round_trips ~sim_result
   in
   let final_prices =
     _final_prices_for_held_symbols ~steps ~final_close_prices


### PR DESCRIPTION
## Summary

Part 4 of 4 of the **warmup-emit-during-warmup** leak fix series. The simulator runs from `warmup_start = start_date - 210d` so the step-based metric computers (`SharpeRatio`, `MaxDrawdown`, `CAGR`) fold warmup-window portfolio values into the published results. PR #713 already addressed the round-trip-derived metrics by overlaying values from the runner's range-filtered round_trips, but the step-based metrics remained warmup-inclusive — contradicting the summary's measurement-window semantics.

## What it does

Extends the existing overlay (`_align_summary_metrics`) to also recompute Sharpe / MaxDD / CAGR on `steps_in_range` with a config whose `start_date` is the actual run start, then recomputes `CalmarRatio` from the new (CAGR, MaxDD) pair so the derived metric stays consistent.

## Empirical effect

Smoke goldens — Sharpe + CalmarRatio drift down because warmup-window volatility was artificially low (no positions held during early warmup days inflated the published Sharpe). CAGR drifts down because the simulator annualized over `[warmup_start..end_date]` (1.25y for 8-month scenarios) rather than `[start_date..end_date]` (0.5y).

| Scenario | Sharpe before | Sharpe after | CAGR before | CAGR after |
|---|---:|---:|---:|---:|
| bull-2019h2 | 1.62 | 1.16 | 26.77 | 13.76 |
| panel-golden-2019-full | 0.92 | 0.60 | 3.45 | 1.83 |
| recovery-2023 | 0.84 | 0.62 | 10.71 | 6.66 |
| tiered-loader-parity | 2.75 | 1.74 | 17.26 | 8.31 |
| crash-2020h1 | -1.25 | -0.76 | -45.03 | -24.13 |

MaxDrawdown is mostly unchanged (drawdown happened during the measurement window in these scenarios).

## Caveat — pinned baselines may need re-pinning

Pinned scenarios (`goldens-small`, `goldens-broad`, `goldens-sp500`) have `expected` ranges for `sharpe_ratio` / `max_drawdown_pct`. After this fix, in-window values may fall outside the existing ranges for some scenarios. Verified for smoke goldens (4/5 still PASS — the one FAIL is the pre-existing `crash-2020h1 trades>50` issue, not new). Larger goldens (six-year-2018-2023, sp500-2019-2023) require a follow-up re-pin pass once the underlying baseline divergence (#719) is resolved.

## Test plan

- [x] `dune build && dune fmt` clean
- [x] All pre-existing backtest tests still pass
- [x] Smoke goldens — same trade counts as before, summary metrics shift to in-window values as expected

Stacked on #722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)