### PR TITLE
fix(force_liquidations): drop warmup-window events from result

### DIFF
--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -281,6 +281,20 @@ let filter_stop_infos_in_window stop_infos ~start_date =
       | Some d -> Date.( >= ) d start_date
       | None -> true)
 
+(** Drop force-liquidation events whose [date] is before [start_date] — i.e.
+    events that fired during the warmup window. The simulator runs from
+    [warmup_start] so [Force_liquidation_log] observes events from days before
+    [start_date]; without this filter, warmup-window force-liqs appear in
+    [force_liquidations.sexp] and the [_build_force_liq_index] layer in
+    [Result_writer] inflates the visible force-liq count for release-gate
+    consumers. Round-trip rows in [trades.csv] would not directly attach these
+    events (the index keys on [(symbol, exit_date)] which is in the warmup
+    window for warmup events), but downstream tooling that loads
+    [force_liquidations.sexp] independently still over-counts. *)
+let filter_force_liquidations_in_window events ~start_date =
+  List.filter events ~f:(fun (e : Portfolio_risk.Force_liquidation.event) ->
+      Date.( >= ) e.date start_date)
+
 let _make_summary ~start_date ~end_date ~deps ~steps ~final_value ~round_trips
     ~sim_result : Summary.t =
   {
@@ -355,7 +369,9 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
             ~start_date,
           Trade_audit.get_audit_records trade_audit,
           Trade_audit.get_cascade_summaries trade_audit,
-          Force_liquidation_log.events force_liquidation_log ))
+          filter_force_liquidations_in_window
+            (Force_liquidation_log.events force_liquidation_log)
+            ~start_date ))
   in
   Gc_trace.record ?trace:gc_trace ~phase:"teardown_done" ();
   let summary =

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -64,6 +64,16 @@ val filter_stop_infos_in_window :
     Stop_infos with [entry_date = None] are kept (test fixtures that don't drive
     {!Stop_log.set_current_date}). *)
 
+val filter_force_liquidations_in_window :
+  Portfolio_risk.Force_liquidation.event list ->
+  start_date:Date.t ->
+  Portfolio_risk.Force_liquidation.event list
+(** Drop force-liquidation events whose [date] is before [start_date] — i.e.
+    events that fired during the warmup window. The simulator runs from
+    [warmup_start] so [Force_liquidation_log] observes events from days before
+    [start_date]; without this filter, warmup-window force-liqs leak into
+    [force_liquidations.sexp] and inflate the visible event count. *)
+
 val is_trading_day :
   Trading_simulation_types.Simulator_types.step_result -> bool
 (** True if [step] represents a real trading day — i.e. the portfolio's

--- a/trading/trading/backtest/test/test_runner_filter.ml
+++ b/trading/trading/backtest/test/test_runner_filter.ml
@@ -336,6 +336,60 @@ let test_filter_stop_infos_keeps_boundary _ =
   in
   assert_that kept (size_is 1)
 
+(* -------------------------------------------------------------------- *)
+(* Phase 5: force-liquidation event filter — drop warmup-window events  *)
+(* -------------------------------------------------------------------- *)
+
+(** Regression: warmup-emit leak in [force_liquidation_log]. The simulator runs
+    from [warmup_start] so [Audit_recorder.record_force_liquidation] observes
+    events from the warmup window. Without filtering, those events leak into
+    [force_liquidations.sexp] and inflate downstream consumers' counts.
+
+    [Runner.filter_force_liquidations_in_window] drops events with
+    [date < start_date]. *)
+let _force_liq_event ~date ~symbol : Portfolio_risk.Force_liquidation.event =
+  {
+    symbol;
+    position_id = symbol ^ "-1";
+    date;
+    side = Trading_base.Types.Long;
+    entry_price = 100.0;
+    current_price = 40.0;
+    quantity = 100.0;
+    cost_basis = 10_000.0;
+    unrealized_pnl = -6_000.0;
+    unrealized_pnl_pct = -0.6;
+    reason = Portfolio_risk.Force_liquidation.Per_position;
+  }
+
+let test_filter_force_liquidations_drops_warmup _ =
+  let start_date = date_of_string "2019-01-02" in
+  let warmup =
+    _force_liq_event ~date:(date_of_string "2018-09-15") ~symbol:"AAPL"
+  in
+  let in_window =
+    _force_liq_event ~date:(date_of_string "2019-04-12") ~symbol:"MSFT"
+  in
+  let kept =
+    Backtest.Runner.filter_force_liquidations_in_window [ warmup; in_window ]
+      ~start_date
+  in
+  assert_that kept
+    (elements_are
+       [
+         field
+           (fun (e : Portfolio_risk.Force_liquidation.event) -> e.symbol)
+           (equal_to "MSFT");
+       ])
+
+let test_filter_force_liquidations_keeps_boundary _ =
+  let start_date = date_of_string "2019-01-02" in
+  let boundary = _force_liq_event ~date:start_date ~symbol:"AAPL" in
+  let kept =
+    Backtest.Runner.filter_force_liquidations_in_window [ boundary ] ~start_date
+  in
+  assert_that kept (size_is 1)
+
 let suite =
   "Runner_filter"
   >::: [
@@ -353,6 +407,10 @@ let suite =
          >:: test_filter_stop_infos_keeps_unstamped;
          "filter_stop_infos keeps entries on the start_date boundary"
          >:: test_filter_stop_infos_keeps_boundary;
+         "filter_force_liquidations drops warmup-window events"
+         >:: test_filter_force_liquidations_drops_warmup;
+         "filter_force_liquidations keeps events on the start_date boundary"
+         >:: test_filter_force_liquidations_keeps_boundary;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Part 2 of 4 of the **warmup-emit-during-warmup** leak fix series. (Replaces closed #721 — original was based on the just-merged feat/warmup-fix-1-stop-log branch which was deleted by the squash-merge of #720.)

`Force_liquidation_log` is populated by the strategy's `Audit_recorder.record_force_liquidation` from `warmup_start` onwards. At runner teardown, `Runner.run_backtest` returned the unfiltered list, so warmup-window force-liqs leaked into `force_liquidations.sexp` and into the `exit_trigger` override path in `Result_writer` (when the warmup-window `(symbol, date)` happened to match a later round-trip's `(symbol, exit_date)`).

## What it does

`Runner.filter_force_liquidations_in_window` drops events with `date < start_date` before they reach the result.

## Test plan

- [x] `dune build && dune fmt` clean
- [x] `dune exec backtest/test/test_runner_filter.exe` — 9 OK (2 new tests: drops warmup events, keeps boundary events)
- [x] Smoke goldens still PASS — `crash-2020h1` is the only smoke scenario producing force-liqs and its 86 in-window events are preserved unchanged

Stacks under #722 (which targets this branch) and #723. Merging this first will keep the stack mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)