### PR TITLE
fix(force_liquidation_runner): G12 — pass consistent (positions, cash) snapshot

### DIFF
--- a/trading/trading/weinstein/strategy/lib/force_liquidation_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/force_liquidation_runner.mli
@@ -34,6 +34,25 @@ val update :
   Position.transition list
 (** Run the force-liquidation policy and return TriggerExit transitions.
 
+    [positions] is used both for the per-position
+    [Force_liquidation.position_input]s and for the
+    [Portfolio_view.portfolio_value] computation that drives the [peak_tracker].
+    Callers that have already filtered out stop-exited-this-tick positions for
+    double-exit avoidance MUST still pass the unfiltered set here — see
+    {!Weinstein_strategy._on_market_close} for the safe pattern.
+
+    G12 (2026-04-30): the strategy previously called this with a filtered
+    position map ([live_positions]) but the unfiltered [cash] from the portfolio
+    view. That mixed pre-tick cash with post-stop-filter positions, causing
+    [Portfolio_view.portfolio_value] to phantom-spike whenever a short stop
+    fired (the short's negative contribution disappeared from the sum, but its
+    buy-back debit had not yet been applied to cash). Each spike permanently
+    inflated [peak_tracker.peak], and on subsequent days the post-buyback cash
+    fell below the inflated [0.4 * peak] floor — triggering mass
+    [Portfolio_floor] events on still-profitable shorts. Per-position
+    double-exit avoidance now happens at the strategy layer (filter the returned
+    transitions), not by passing a filtered position map here.
+
     Side effects:
     - [peak_tracker] observe + halt-state update via
       {!Portfolio_risk.Force_liquidation.check}.

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -479,17 +479,36 @@ let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
          ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
          ~bar_reader ~prior_stages ~positions);
   (* Force-liquidation pass: defense in depth beyond stops (G4). Runs AFTER
-     [Stops_runner.update] so positions that were already stop-exited this
-     tick are filtered out — we never double-exit. Updates the peak tracker
-     and may flip the halt state to [Halted] for the portfolio-floor case. *)
-  let live_positions =
-    _positions_minus_exited ~positions ~stop_exit_transitions:exit_transitions
+     [Stops_runner.update] but operates on the FULL pre-tick portfolio (cash
+     + all positions) so [Portfolio_view.portfolio_value] is consistent with
+     [portfolio.cash] (which has not yet been updated for this tick's
+     stop-exits). Mixing pre-tick cash with a stop-filtered position map
+     phantom-spikes [portfolio_value] when shorts stop out — a short's
+     negative contribution disappears but its buy-back debit has not yet
+     posted — permanently inflating [peak_tracker.peak] and triggering
+     spurious [Portfolio_floor] breaches on subsequent days (G12,
+     2026-04-30). Double-exit avoidance is done by filtering the returned
+     transitions instead of by hiding positions from the runner. Updates
+     the peak tracker and may flip the halt state to [Halted] for the
+     portfolio-floor case. *)
+  let raw_force_exit_transitions =
+    Force_liquidation_runner.update
+      ~config:config.portfolio_config.force_liquidation ~positions ~get_price
+      ~cash:portfolio.cash ~current_date ~peak_tracker ~audit_recorder
+  in
+  let stop_exited_ids =
+    List.filter_map exit_transitions ~f:(fun (t : Position.transition) ->
+        match t.kind with
+        | Position.TriggerExit _ -> Some t.position_id
+        | _ -> None)
+    |> String.Set.of_list
   in
   let force_exit_transitions =
-    Force_liquidation_runner.update
-      ~config:config.portfolio_config.force_liquidation
-      ~positions:live_positions ~get_price ~cash:portfolio.cash ~current_date
-      ~peak_tracker ~audit_recorder
+    if Set.is_empty stop_exited_ids then raw_force_exit_transitions
+    else
+      List.filter raw_force_exit_transitions
+        ~f:(fun (t : Position.transition) ->
+          not (Set.mem stop_exited_ids t.position_id))
   in
   (* Stage 4 PR-A: read the primary index as a weekly view directly. The
      Friday detection uses the view's latest date; the screener path consumes

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
@@ -506,6 +506,84 @@ let test_double_exit_avoidance_filters_already_exited _ =
     (Map.keys filtered |> List.sort ~compare:String.compare)
     (elements_are [ equal_to "TSLA" ])
 
+(* ------------------------------------------------------------------ *)
+(* G12 — phantom peak spike from inconsistent (positions, cash) snapshot *)
+(* ------------------------------------------------------------------ *)
+
+(** Regression: phantom peak spike from inconsistent (positions, cash) passed to
+    [FL.check].
+
+    Invariant: peak_tracker.peak after [update] = Portfolio_view.portfolio_value
+    ~cash ~positions
+
+    Buggy path: positions = full \ \{S1\}, cash = pre_tick_cash (S1 already
+    removed to avoid double-exit but its buy-back debit has not yet posted to
+    cash) → peak inflated by [current_price_S1 * quantity_S1] (the absolute
+    value of S1's signed mtm contribution; for a short the contribution is
+    [-current_price * quantity], so removing S1 from the sum while keeping the
+    same cash adds a positive term back).
+
+    Fixed path: positions = full, cash = pre_tick_cash → peak = true pre-tick
+    portfolio_value.
+
+    Contract enforced at the call site (Weinstein_strategy._on_market_close):
+    (positions, cash) must be a consistent snapshot — either both pre-stop or
+    both post-stop, never the hybrid. The runner here just takes the arguments
+    it's given; this test pins the math at the runner boundary so a desync
+    (caller passing inconsistent snapshots) shows up as a measurable peak
+    divergence on the very same tick, without needing to run forward to the
+    floor breach. The breach is downstream — the load-bearing witness is the
+    peak value after a single [update] call. *)
+let test_inconsistent_positions_cash_phantom_spikes_peak _ =
+  let make_short ~symbol ~entry_price ~qty =
+    _make_holding ~symbol ~side:Trading_base.Types.Short
+      ~entry_date:(_date "2024-01-02") ~quantity:qty ~entry_price
+  in
+  let s1 = make_short ~symbol:"S1" ~entry_price:100.0 ~qty:1000.0 in
+  let s2 = make_short ~symbol:"S2" ~entry_price:200.0 ~qty:500.0 in
+  (* Both shorts profitable: current < entry. *)
+  let bar_s1 = _make_bar ~date:(_date "2024-01-15") ~close:80.0 in
+  let bar_s2 = _make_bar ~date:(_date "2024-01-15") ~close:180.0 in
+  let get_price s =
+    if String.equal s "S1" then Some bar_s1
+    else if String.equal s "S2" then Some bar_s2
+    else None
+  in
+  (* Pre-tick cash = $1.2M (post-entry: $1M starting + $100K S1 proceeds +
+     $100K S2 proceeds).
+     True portfolio_value:
+       1_200_000 + (-80 * 1000) + (-180 * 500)
+       = 1_200_000 - 80_000 - 90_000 = 1_030_000.
+     S1's mtm magnitude (which the buggy desync adds back to the sum):
+       current_price_S1 * quantity_S1 = 80 * 1000 = 80_000. *)
+  let pre_tick_cash = 1_200_000.0 in
+  let true_pv = 1_030_000.0 in
+  let s1_mtm_magnitude = 80_000.0 in
+  let recorder, _ = _capturing_recorder () in
+  let positions_full = String.Map.of_alist_exn [ ("S1", s1); ("S2", s2) ] in
+  let positions_buggy = String.Map.singleton "S2" s2 in
+  let date = _date "2024-01-15" in
+  (* Fixed path: consistent snapshot (full positions, pre-tick cash). *)
+  let peak_fixed = FL.Peak_tracker.create () in
+  let _ =
+    Force_liquidation_runner.update ~config:FL.default_config
+      ~positions:positions_full ~get_price ~cash:pre_tick_cash
+      ~current_date:date ~peak_tracker:peak_fixed ~audit_recorder:recorder
+  in
+  assert_that (FL.Peak_tracker.peak peak_fixed) (float_equal true_pv);
+  (* Buggy path: positions filtered as if S1 already removed, cash NOT yet
+     debited for the buy-back — the exact desync the WIP G12 fix prevents at
+     the call site. *)
+  let peak_buggy = FL.Peak_tracker.create () in
+  let _ =
+    Force_liquidation_runner.update ~config:FL.default_config
+      ~positions:positions_buggy ~get_price ~cash:pre_tick_cash
+      ~current_date:date ~peak_tracker:peak_buggy ~audit_recorder:recorder
+  in
+  assert_that
+    (FL.Peak_tracker.peak peak_buggy)
+    (float_equal (true_pv +. s1_mtm_magnitude))
+
 let suite =
   "force_liquidation_runner"
   >::: [
@@ -526,6 +604,8 @@ let suite =
          >:: test_short_holding_does_not_inflate_peak;
          "G9 — two profitable shorts do not trigger portfolio_floor"
          >:: test_two_profitable_shorts_no_portfolio_floor;
+         "G12 — inconsistent (positions, cash) phantom-spikes peak"
+         >:: test_inconsistent_positions_cash_phantom_spikes_peak;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

**G12** — phantom peak spike from inconsistent `(positions, cash)` snapshot passed to `Force_liquidation_runner.update`. Originally surfaced via the post-#719 sp500-2019-2023 baseline divergence (820 Day-1 `Portfolio_floor` force-liqs on profitable shorts).

## Mechanism

The strategy's `_on_market_close` previously called `Force_liquidation_runner.update` with a filtered position map (`live_positions` = positions minus the ones already stop-exited this tick) but the unfiltered `portfolio.cash`. That mixes **pre-tick cash with a post-stop-filter position map** — when a short S1 stopped out:

- Pre-tick: `pv = cash + sum_full(-current * qty)` for shorts.
- Buggy mid-tick: `pv_buggy = cash + sum_full\{S1}(-current * qty) = pv_pre + (current_price_S1 * quantity_S1)` — inflated by S1's signed-mtm magnitude because removing the position from the sum adds back the negative term.

`Peak_tracker.observe pv_buggy` permanently inflates `peak`. On subsequent ticks `pv` returns to the true level but `peak` stays elevated → `pv < peak * 0.4` breaches → all remaining shorts force-liq'd at `Portfolio_floor`.

## Fix

Pass the **full pre-tick positions + pre-tick cash** so `Portfolio_view.portfolio_value` is internally consistent. Double-exit avoidance moved to post-filtering the returned transitions (drop those whose `position_id` appears in the stop-exit set) instead of hiding positions from the runner.

Contract enforced at the call site: `(positions, cash)` must be a consistent snapshot — either both pre-stop or both post-stop, never the hybrid.

## Regression test

New unit test `test_inconsistent_positions_cash_phantom_spikes_peak` in `test_force_liquidation_runner.ml` pins the math at the runner boundary. Two `update` calls with the same `pre_tick_cash` and a fresh `peak_tracker` each time:

| Combo | positions | cash | Expected peak |
|---|---|---|---|
| Fixed | full | pre-tick | true pre-tick pv |
| Buggy | full \\ {S1} | pre-tick | true pv + `current_price_S1 * quantity_S1` |

Both branches are pinned with concrete float values so a desync (caller passing inconsistent snapshot OR runner doing its own arithmetic) is mechanically observable. No simulator loop needed — the peak value after a single `update` is the complete witness of the invariant.

## Empirical effect on `goldens-sp500/sp500-2019-2023`

| Metric | Pre-fix | Post-fix | Pin |
|---|---:|---:|---:|
| Total force-liqs | 820 | 449 | 0 |
| Day-1 Portfolio_floor events | 820 | 18 | — |
| Total trades | 1410 | 527 | 27..37 |
| Avg holding days | 3.69 | 11.41 | 37..50 |
| Total return % | 39.3 | 46.6 | -15..15 |

**Partial resolution.** The fix mathematically correct per the unit test, but sp500 still shows residual cascades — 18 force-liqs on Day 1 + ~8/Monday after. The peak somehow gets set high enough to trigger the floor at $955K pv on a peak that the equity curve can't explain (max post-tick pv pre-Day-14 = $1M, floor at $400K). There's a separate phantom-spike pathway not yet found. Investigation deferred to a follow-up.

## Test plan

- [x] `dune build && dune fmt` clean
- [x] All existing tests pass (85 across `portfolio_risk` + `strategy/force_liquidation_runner` + `strategy/weinstein_strategy`)
- [x] New regression test `test_inconsistent_positions_cash_phantom_spikes_peak` passes
- [x] sp500-2019-2023 rerun: 820 → 449 force-liqs (partial resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)