### PR TITLE
feat(goldens-sp500): tighten long-only pins to match with-shorts target

### DIFF
--- a/dev/notes/g14-deep-dive-2026-05-01.md
+++ b/dev/notes/g14-deep-dive-2026-05-01.md
@@ -1,0 +1,174 @@
+# G14 — Screener / Position.t price-space mismatch
+
+Updated deep-dive on G14, originally filed in
+`dev/notes/force-liq-cascade-findings-2026-05-01.md` as "split-adjustment
+on Position.t Holding state." The earlier framing was right about the
+symptom (5 force-liqs with stale entry_prices) but wrong about the fix
+shape. This note documents the failed first-pass fix attempt
+(2026-05-01 ~07:00 UTC) and what was learned.
+
+## Updated root cause
+
+Two related bugs, intertwined:
+
+**Bug A: The screener's high/low scans read raw `high_price` /
+`low_price`.** When the lookback window spans a split (past or future),
+raw extremes leak into post-split breakout/breakdown levels.
+
+- `_make_get_high_from_bars` (stock_analysis.ml:181)
+- `_make_lookup` for `get_high`/`get_low` (resistance.ml:73)
+- `_fill_weekly_buckets` (bar_panels.ml:256) — the panel-mode path that
+  the actual sp500 backtest uses.
+
+**Bug B: `Position.t Holding.entry_price` is set to
+`cand.suggested_entry` (the screener's recommended entry level), NOT to
+the actual fill price** (entry_audit_capture.ml:80).
+
+The two bugs interact:
+
+- Pre-G14: A and B both live in **raw price space** (the screener uses
+  raw highs; the strategy enters at raw market prices). They roughly
+  agree, modulo the entry buffer + price moves between order-place and
+  fill. Force-liqs misfire on symbols whose lookback spans a SPLIT
+  BOUNDARY where raw highs are wildly larger than current raw close
+  (e.g., GOOG entered Apr 2023 at raw $107, but breakout level pulled
+  from pre-July-2022-split raw $2651). PANW + GOOG hit this. ALGN +
+  DASH + TECH hit it via stale within-window highs but not split
+  boundaries.
+
+- Post-G14 first-pass attempt (adjust the screener's high/low scans):
+  Bug A is fixed but Bug B becomes worse for symbols with FUTURE
+  splits (e.g., CTAS — has 4:1 split scheduled for 2024). For CTAS in
+  Jan 2019, raw close = $176, adjusted_close = $41 (back-projected).
+  The screener picks max-adjusted-high ≈ $41, suggested_entry ≈ $52.
+  Position.t records entry_price = $52, but the broker fills at raw
+  market $176. Per_position trigger sees `(entry $52, current $176)
+  for a Long` (or equivalent for a short) → 250%+ "loss" → fires.
+
+The first-pass attempt empirically:
+- sp500 FL count: 5 → 10 (+100%).
+- sp500 return: +100.3% (over the test universe; before the second
+  fix landed and triggered the issue).
+- New events on CTAS, LRCX, etc. — symbols with future splits.
+
+The fix attempt was reverted. Branch state at this point: main has
+G12 + G13 + #727 docs + #728 long-only sexp; **no G14 fix on main**.
+
+## Why both bugs need to be fixed together
+
+Fix A alone (split-adjust in screener) breaks symbols with future
+splits — the first-pass attempt confirmed this empirically.
+
+Fix B alone (use fill_price in Position.t) without Fix A leaves the
+GOOG-style cross-split-boundary bug — the screener still computes
+`suggested_entry` from raw pre-split highs, but since the fill happens
+at current raw price, Position.t.entry_price would now correctly equal
+~$107 (not $2651). However, the suggested_stop derived from
+suggested_entry is also in pre-split-raw space; risk-percent
+calculations break. And the trade-decision plumbing (audit records,
+sizing) all use suggested_entry.
+
+The clean fix is **both** A and B simultaneously, with a consistent
+choice of price space.
+
+## Recommended fix
+
+**Option (1): Pin everything to raw close-price space.**
+
+- Position.t.entry_price = actual fill price (raw, post-buffer-and-
+  market-move).
+- Screener's max-high lookback STAYS RAW. To handle split boundaries,
+  cap the lookback window to bars whose factor matches the latest bar
+  (i.e., "no split has happened between bar X and now"). This
+  effectively truncates the window at the most recent split.
+
+Pros: simplest. Doesn't require changing get_close / get_ma /
+Stage / RS callers (they already mostly use adjusted_close — but the
+Stop_log / FL machinery uses raw close which it gets from get_price
+on bars). Position state stays in raw space.
+
+Cons: The screener's resistance levels lose history before the most
+recent split. For CTAS, the screener can't see pre-2024 highs (because
+those become inflated raw values). For most symbols this is fine —
+splits are rare.
+
+**Option (2): Pin everything to adjusted-close space.**
+
+- Position.t.entry_price = fill_price * (adjusted_close /
+  close_price) at fill time.
+- Screener's max-high lookback uses adjusted highs (the first-pass
+  attempt fix).
+- get_price returns split-adjusted bars (adjusted_close used as
+  current_price).
+- All accumulators that compare across time windows use adjusted
+  values.
+
+Pros: Handles arbitrary numbers of splits cleanly. The continuous
+"adjusted-price universe" abstraction.
+
+Cons: Touches more code. The Daily_price.t consumers that today read
+`close_price` need to be audited and either flipped to
+`adjusted_close` or made aware of the choice. Historical `Position.t`
+state from before a split would need migration if persisted (currently
+not — all in-memory).
+
+I lean **Option 1**: less invasive, doesn't require auditing every
+get_price / close_price reader. The "lose pre-split history" cost is
+minor — a position's breakout level rarely needs to look back across
+a 4:1 split anyway.
+
+## Affected code paths (any fix)
+
+If we go Option 1:
+- `entry_audit_capture.ml:80` — change `entry_price = suggested_entry`
+  to `entry_price = current_close` (the actual current price at order
+  placement).
+- `position.ml:_entry_fill` and `_entry_complete` — already accept
+  fill_price separately; the `entry_price` field carried through could
+  be replaced by the EntryFill's `fill_price`, OR removed entirely
+  from Holding state and computed from the portfolio-side lot's
+  `cost_basis / quantity`. The latter is more architecturally clean
+  but bigger surgery.
+- `simulator.ml:_apply_split_to_position` — already split-adjusts
+  Holding.entry_price; can stay as-is.
+- Screener: window the lookback at the most recent split boundary.
+  Need a way to detect "is there a split between this bar and the
+  newest bar?" — `Types.Split_detector` already does pairwise; could
+  scan once over the window to find the most recent split day and
+  truncate the lookback there.
+
+If we go Option 2:
+- All of the above PLUS
+- Audit every `bar.close_price` reader to ensure it's in the right
+  price space relative to `Position.t` entry_price.
+- Likely add `adjusted_high`, `adjusted_low`, `adjusted_volume`
+  fields to `Daily_price.t` (or compute on the fly per the abandoned
+  G14 attempt).
+
+## Status
+
+- Abandoned: `feat/g14-screener-adjusted-prices` (the first-pass
+  attempt). Diff was small (~30 lines) but architecturally wrong.
+- Test failures expected if we go Option 1: a few `test_screener_e2e`
+  pinned ranges may shift if the lookback is truncated at a split
+  boundary. Re-pin from observed values.
+
+## Recommendation for next session
+
+Implement **Option 1** as a single PR:
+
+1. Replace `entry_price = suggested_entry` with the actual current
+   close price at order-placement time (or restructure to use
+   fill_price post-fill).
+2. Add a "lookback truncation at most recent split" guard in
+   `_scan_max_high_callback` and `_scan_min_low_callback`.
+3. Update the 4 affected `test_screener_e2e` pinned ranges where
+   needed.
+4. Verify on sp500: expect force-liq count to drop near 0, MaxDD to
+   stabilize at the strategy's actual short-side risk profile (still
+   exposes G15 — strategy needs a real risk control, but at least
+   force-liqs no longer fire spuriously).
+
+Do NOT implement Option 2 unless there's a stronger architectural
+reason. Option 1 is the minimum-blast-radius fix for the G14 force-
+liq cascade.

--- a/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
@@ -9,24 +9,31 @@
 ;;   * If long-only PASSes pins but the with-shorts variant FAILs → issue is
 ;;     in short-side machinery (e.g., G15 short-side risk control).
 ;;   * If both FAIL similarly → issue is in shared strategy components
-;;     (e.g., G14 screener resistance calc using stale highs).
+;;     (e.g., G14 screener resistance calc / Position.t entry_price).
 ;;
-;; Baseline measured 2026-05-01 (post-G12+G13 cascade fixes; G14/G15 still
-;; open):
+;; Pinned ranges intentionally TIGHT — they target the "fully fixed" state,
+;; not current behavior. Both variants currently FAIL these pins. The
+;; long-only FAIL surfaces G14 explicitly (~6 spurious Per_position
+;; force-liqs from the screener / Position.t price-space mismatch — see
+;; dev/notes/g14-deep-dive-2026-05-01.md).
+;;
+;; Pinned values mirror [sp500-2019-2023.sexp] expected ranges: same 5-year
+;; period, same universe, and the long-only side is a strict subset of the
+;; with-shorts strategy. The "ideal" long-only profile should be ≈ the
+;; with-shorts baseline modulo the short-side contribution, which has
+;; historically been small (PR #711 measured 4 short trades / 32 total).
+;; If long-only diverges meaningfully from this target post-fix, re-pin
+;; once empirical data justifies it.
+;;
+;; Current measured baseline 2026-05-01 (post-G12+G13, pre-G14/G15):
 ;;   total_return_pct  65.03   total_trades 136   win_rate 37.50
 ;;   sharpe_ratio       0.62   max_drawdown 31.78  avg_holding_days 69.51
 ;;   unrealized_pnl 1,481,963  force_liquidations 6 (all Per_position, G14)
 ;;
-;; Pinned ranges below are ±~20% around this baseline. The 6 residual
-;; force-liqs all trace to the G14 screener pre-split-contaminated
-;; suggested_entry — see dev/notes/force-liq-cascade-findings-2026-05-01.md
-;; G14 section. Re-pin tighter once G14 closes.
-;;
-;; Note: this scenario also surfaces the strategy's drawdown profile
-;; without the (spurious) Portfolio_floor brake. The 31.8% MaxDD here is
-;; what the strategy actually produces on its own — far above the original
-;; 5.81% pinned baseline, which was an artefact of the buggy floor halting
-;; the strategy mid-drawdown.
+;; The 31.8% MaxDD vs the pin's 3..9% target reflects the strategy's
+;; drawdown profile WITHOUT the (spurious) Portfolio_floor brake. Whether
+;; that gap is closed by fixing G14 alone, or whether it requires a real
+;; risk control (G15-style for longs), is part of what these pins surface.
 ((name "sp500-2019-2023-long-only")
  (description "S&P 500 over 2019-2023 — long-only counterpart to sp500-2019-2023")
  (period ((start_date 2019-01-02) (end_date 2023-12-29)))
@@ -34,10 +41,10 @@
  (universe_size 491)
  (config_overrides (((enable_short_side false))))
  (expected
-  ((total_return_pct   ((min 40.0)        (max 90.0)))
-   (total_trades       ((min 100)         (max 170)))
-   (win_rate           ((min 30.0)        (max 45.0)))
-   (sharpe_ratio       ((min 0.30)        (max 0.95)))
-   (max_drawdown_pct   ((min 22.0)        (max 42.0)))
-   (avg_holding_days   ((min 55.0)        (max 85.0)))
-   (unrealized_pnl     ((min 1200000.0)   (max 1800000.0))))))
+  ((total_return_pct   ((min -15.0)       (max  15.0)))
+   (total_trades       ((min 27)          (max  37)))
+   (win_rate           ((min 31.0)        (max  44.0)))
+   (sharpe_ratio       ((min -0.5)        (max  0.5)))
+   (max_drawdown_pct   ((min 3.0)         (max  9.0)))
+   (avg_holding_days   ((min 37.0)        (max  50.0)))
+   (unrealized_pnl     ((min 330000.0)    (max  450000.0))))))


### PR DESCRIPTION
## Summary

Tightens `sp500-2019-2023-long-only.sexp` pinned ranges from the permissive ±20% tracker to the same target ranges as `sp500-2019-2023.sexp` (the "fully fixed" baseline). Both scenarios now FAIL on the same dimensions until G14 is properly resolved.

## Why

Previous pins were intentionally loose (40..90% return, 100..170 trades, 22..42% MaxDD) as a tracking marker. That hid G14's footprint behind a passing verdict. Tightening surfaces the bug as a measurable FAIL on multiple dimensions:

| Metric | Current measured | New pin | FAIL by |
|---|---:|---:|---:|
| max_drawdown_pct | 31.78 | 3..9 | +22.78 |
| total_trades | 136 | 27..37 | +99 |
| total_return_pct | +65.0 | -15..15 | +50 |
| sharpe_ratio | 0.62 | -0.5..0.5 | +0.12 |

The FAIL deltas measure the strategy's actual divergence from the "0 force-liq" target. As G14 fixes land, the diff between long-only and with-shorts FAIL signatures isolates G15: long-only goes green first; with-shorts stays red until short-side risk control (G15) is added.

## Test plan

- [x] No code changes — pin-data only
- [x] `dune build && dune fmt` clean (no diff in OCaml sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)