### PR TITLE
fix(simulation): restore order_generator.ml — revert leak from #733

### DIFF
--- a/trading/trading/simulation/lib/order_generator.ml
+++ b/trading/trading/simulation/lib/order_generator.ml
@@ -17,17 +17,7 @@ let _exit_order_side (side : Trading_strategy.Position.position_side) =
   | Long -> Trading_base.Types.Sell
   | Short -> Trading_base.Types.Buy
 
-(* G6 fix: order IDs are minted from scenario-time inputs (current_date + a
-   per-call sequence index) so that two structurally identical simulations
-   produce bit-identical IDs regardless of wall-clock or process forking.
-   The IDs are hashtable keys in [Trading_orders.Manager.orders]; unstable
-   IDs caused different bucket placement -> different [list_orders]
-   iteration order in [Engine.process_orders] -> different fill order ->
-   metric drift on long-horizon backtests. *)
-let _make_id ~current_date ~seq =
-  Printf.sprintf "%s-%03d" (Date.to_string current_date) seq
-
-let _create_order ~id ~symbol ~side ~quantity =
+let _create_order ~symbol ~side ~quantity =
   let params : Trading_orders.Create_order.order_params =
     {
       symbol;
@@ -37,48 +27,40 @@ let _create_order ~id ~symbol ~side ~quantity =
       time_in_force = Trading_orders.Types.Day;
     }
   in
-  Result.map
-    (Trading_orders.Create_order.create_order ~id params)
-    ~f:Option.some
+  Result.map (Trading_orders.Create_order.create_order params) ~f:Option.some
 
-let _exit_order_for_position ~id position =
+let _exit_order_for_position position =
   let open Trading_strategy.Position in
   match get_state position with
   | Exiting { quantity; _ } ->
-      _create_order ~id ~symbol:position.symbol
+      _create_order ~symbol:position.symbol
         ~side:(_exit_order_side position.side)
         ~quantity
   | _ -> Ok None
 
-let _transition_to_order ~id ~positions
+let _transition_to_order ~positions
     (transition : Trading_strategy.Position.transition) =
   let open Trading_strategy.Position in
   match transition.kind with
   | CreateEntering { symbol; side; target_quantity; _ } ->
-      _create_order ~id ~symbol ~side:(_entry_order_side side)
+      _create_order ~symbol ~side:(_entry_order_side side)
         ~quantity:target_quantity
   | TriggerExit _ ->
       (* After _apply_transitions, the position is in Exiting state, not Holding.
          We look up the Exiting position to get the quantity and side. *)
       Map.find positions transition.position_id
-      |> Option.value_map ~default:(Ok None) ~f:(_exit_order_for_position ~id)
+      |> Option.value_map ~default:(Ok None) ~f:_exit_order_for_position
   | EntryFill _ | EntryComplete _ | CancelEntry _ | UpdateRiskParams _
   | ExitFill _ | ExitComplete ->
       Ok None
 
-let transitions_to_orders ~current_date ~positions transitions =
+let transitions_to_orders ~positions transitions =
   let open Result.Let_syntax in
-  let%bind _, orders =
-    List.fold_result transitions ~init:(0, [])
-      ~f:(fun (seq, acc) transition ->
-        let id = _make_id ~current_date ~seq in
-        let%bind maybe_order = _transition_to_order ~id ~positions transition in
+  let%bind orders =
+    List.fold_result transitions ~init:[] ~f:(fun acc transition ->
+        let%bind maybe_order = _transition_to_order ~positions transition in
         match maybe_order with
-        | Some order -> Ok (seq + 1, order :: acc)
-        | None ->
-            (* We still advance [seq] for ignored transitions so that any
-               future re-ordering of transition kinds does not silently shift
-               IDs. Sequential gaps in IDs are harmless. *)
-            Ok (seq + 1, acc))
+        | Some order -> Ok (order :: acc)
+        | None -> Ok acc)
   in
   Ok (List.rev orders)


### PR DESCRIPTION
## Summary

**Main is broken.** PR #733 (orchestrator auto-merge fix) merged with CI red because the build failed. Root cause: a worktree-isolation contamination — the in-flight G6 fix agent's `order_generator.ml` change leaked into the parent worktree after my pre-push scrub but before push, AND the change is incomplete on its own (it calls `Create_order.create_order ~id`, but `~id` parameter doesn't exist on main yet).

This PR reverts `trading/trading/simulation/lib/order_generator.ml` to its pre-#733 state (matching what's on main as of `618798e2`). Build is green locally with this revert applied.

The orchestrator-workflow part of #733 (which was the actual intended change) stays on main — only the contaminating file is rolled back.

## Verification

- `dune build` clean post-revert
- File matches `git show 618798e2:trading/trading/simulation/lib/order_generator.ml` byte-for-byte

## Follow-up

The G6 fix agent will need to re-push its work as a complete PR (all files together: `create_order.{ml,mli}`, `order_generator.{ml,mli}`, `test_order_generator.ml`). The agent's still running; will land that as a separate PR once it finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)