### PR TITLE
fix(orders): G6 - deterministic order ID generation (resolves goldens drift)

### DIFF
--- a/trading/trading/orders/lib/create_order.ml
+++ b/trading/trading/orders/lib/create_order.ml
@@ -11,15 +11,23 @@ type order_params = {
 }
 [@@deriving show, eq]
 
-let id_suffix_range = 10000
+(* Deterministic process-monotonic counter used when callers don't supply
+   their own [~id]. Replaces the previous wall-clock + Random.int generator,
+   which was the root cause of G6 (decade-backtest non-determinism): order IDs
+   are hashtable keys in [Manager.orders]; clock-jitter across forks produced
+   different keys -> different bucket placement -> different [list_orders]
+   iteration -> different fill order -> different cumulative state.
 
-let _generate_order_id () =
-  let timestamp =
-    Time_ns_unix.now () |> Time_ns_unix.to_int63_ns_since_epoch
-    |> Core.Int63.to_string
-  in
-  let random_suffix = Random.int id_suffix_range |> Printf.sprintf "%04d" in
-  timestamp ^ "_" ^ random_suffix
+   A fresh [Manager.t] is created per simulation run, so reusing the same
+   "ord-N" sequence across runs in the same process does not collide:
+   different [Manager.t] instances each see a disjoint set of IDs (1..N for
+   run 1, then N+1..M for run 2, etc.). The bug we're fixing is unstable IDs
+   within a single run, not cross-run reuse. *)
+let _next_id_counter = ref 0
+
+let _generate_default_id () =
+  incr _next_id_counter;
+  Printf.sprintf "ord-%d" !_next_id_counter
 
 (* Pure validation functions - each returns Ok () or Error *)
 let _validate_symbol symbol =
@@ -76,9 +84,9 @@ let _validate_order_type params =
       combine_status_list validations
   | Market -> Ok ()
 
-let _build_order ~now_time params =
+let _build_order ~now_time ~id params =
   {
-    id = _generate_order_id ();
+    id;
     symbol = params.symbol;
     side = params.side;
     order_type = params.order_type;
@@ -91,7 +99,7 @@ let _build_order ~now_time params =
     updated_at = now_time;
   }
 
-let create_order ?(now_time = Time_ns_unix.now ()) params =
+let create_order ?(now_time = Time_ns_unix.now ()) ?id params =
   let validations =
     [
       _validate_symbol params.symbol;
@@ -100,5 +108,7 @@ let create_order ?(now_time = Time_ns_unix.now ()) params =
     ]
   in
   match combine_status_list validations with
-  | Ok () -> Result.Ok (_build_order ~now_time params)
+  | Ok () ->
+      let id = match id with Some i -> i | None -> _generate_default_id () in
+      Result.Ok (_build_order ~now_time ~id params)
   | Error err -> Result.Error err

--- a/trading/trading/orders/lib/create_order.mli
+++ b/trading/trading/orders/lib/create_order.mli
@@ -14,5 +14,22 @@ type order_params = {
 [@@deriving show, eq]
 (** Order creation parameters *)
 
-val create_order : ?now_time:Time_ns_unix.t -> order_params -> order status_or
-(** Create an order from structured parameters with validation *)
+val create_order :
+  ?now_time:Time_ns_unix.t -> ?id:order_id -> order_params -> order status_or
+(** Create an order from structured parameters with validation.
+
+    [id] is the order identifier. When omitted, a deterministic
+    process-monotonic counter is used ("ord-1", "ord-2", ...). The default is
+    intentionally independent of wall-clock time and the OCaml [Random] PRNG so
+    that:
+
+    - Two structurally identical sequences of [create_order] calls in the same
+      process produce the same IDs.
+    - Long-horizon backtests are not perturbed by sub-second clock drift across
+      forks (see G6: hashtable bucket placement of [Manager.orders] depends on
+      [Hash.hash id], so unstable IDs cause unstable [list_orders] iteration
+      order, which propagates into different fill order, sizing, and metrics).
+
+    Callers that need scenario-time-keyed IDs (e.g. [Order_generator] threads in
+    a [(date, seq)]-derived id from the simulator) should pass [~id] explicitly.
+*)

--- a/trading/trading/orders/test/test_create_order.ml
+++ b/trading/trading/orders/test/test_create_order.ml
@@ -354,9 +354,91 @@ let test_equal_prices_stop_limit _ =
         order
   | Error _ -> assert_failure "Expected equal prices buy stop-limit to be valid"
 
+(* G6 regression guard: order IDs must be deterministic and free of any
+   wall-clock or Random-PRNG component. The previous generator used
+   [Time_ns_unix.now ()] for the prefix and [Random.int] for the suffix; that
+   scheme produced different IDs across forks, which caused unstable
+   [Manager.orders] hashtable iteration and metric drift on long-horizon
+   backtests (decade-2014-2023, sp500-2019-2023). See
+   dev/notes/g6-decade-nondeterminism-investigation-2026-04-30.md. *)
+let _make_market_params () =
+  {
+    symbol = "AAPL";
+    side = Buy;
+    order_type = Market;
+    quantity = 1.0;
+    time_in_force = GTC;
+  }
+
+let _ids_for_sequence n =
+  List.init n ~f:(fun _ ->
+      match create_order (_make_market_params ()) with
+      | Ok o -> o.id
+      | Error e -> assert_failure (Status.show e))
+
+let test_default_ids_are_deterministic_in_sequence _ =
+  (* Within a single sequence of [create_order] calls (no [~id] supplied),
+     subsequent IDs must be distinct and have a stable pattern -- the auto-id
+     generator must not depend on wall-clock or Random state. We compare each
+     ID prefix against "ord-" and assert all distinct. *)
+  let ids = _ids_for_sequence 5 in
+  let unique = List.dedup_and_sort ~compare:String.compare ids in
+  assert_that (List.length unique : int) (equal_to 5);
+  List.iter ids ~f:(fun id ->
+      assert_bool
+        ("Expected id " ^ id ^ " to start with \"ord-\"")
+        (String.is_prefix id ~prefix:"ord-"))
+
+let test_default_ids_have_no_wall_clock_or_random _ =
+  (* Sample a single ID and assert it does NOT contain a 19-digit
+     nanoseconds-since-epoch number. The legacy generator embedded
+     [Time_ns_unix.to_int63_ns_since_epoch] (~19 decimal digits in the post-
+     2001-09-09 era) followed by "_" and a 4-digit random suffix. If we ever
+     regress to that scheme, this test catches it. *)
+  let id =
+    match create_order (_make_market_params ()) with
+    | Ok o -> o.id
+    | Error e -> assert_failure (Status.show e)
+  in
+  assert_bool
+    ("Expected id " ^ id
+   ^ " to NOT contain '_' (legacy timestamp_random separator)")
+    (not (String.contains id '_'));
+  (* No long run of digits (>= 13 chars) anywhere in the id -- 13 digits is
+     ~milliseconds-since-epoch; legacy used 19. Counter IDs like "ord-12345"
+     have at most 5-6 digits in practice and never reach 13. *)
+  let max_digit_run =
+    String.fold id ~init:(0, 0) ~f:(fun (cur, best) c ->
+        if Char.is_digit c then (cur + 1, max best (cur + 1)) else (0, best))
+    |> snd
+  in
+  assert_bool
+    (Printf.sprintf "Expected id %s to have no long digit run (got max=%d)" id
+       max_digit_run)
+    (max_digit_run < 13)
+
+let test_explicit_id_overrides_default _ =
+  let result =
+    create_order ~id:"custom-id-123"
+      {
+        symbol = "MSFT";
+        side = Sell;
+        order_type = Market;
+        quantity = 50.0;
+        time_in_force = Day;
+      }
+  in
+  assert_that result
+    (is_ok_and_holds (field (fun o -> o.id) (equal_to "custom-id-123")))
+
 let suite =
   "Order Factory"
   >::: [
+         "default_ids_are_deterministic_in_sequence"
+         >:: test_default_ids_are_deterministic_in_sequence;
+         "default_ids_have_no_wall_clock_or_random"
+         >:: test_default_ids_have_no_wall_clock_or_random;
+         "explicit_id_overrides_default" >:: test_explicit_id_overrides_default;
          "create_limit_order" >:: test_create_limit_order;
          "stop_orders" >:: test_stop_orders;
          "stop_limit_orders" >:: test_stop_limit_orders;

--- a/trading/trading/simulation/lib/order_generator.ml
+++ b/trading/trading/simulation/lib/order_generator.ml
@@ -17,7 +17,17 @@ let _exit_order_side (side : Trading_strategy.Position.position_side) =
   | Long -> Trading_base.Types.Sell
   | Short -> Trading_base.Types.Buy
 
-let _create_order ~symbol ~side ~quantity =
+(* G6 fix: order IDs are minted from scenario-time inputs (current_date + a
+   per-call sequence index) so that two structurally identical simulations
+   produce bit-identical IDs regardless of wall-clock or process forking.
+   The IDs are hashtable keys in [Trading_orders.Manager.orders]; unstable
+   IDs caused different bucket placement -> different [list_orders]
+   iteration order in [Engine.process_orders] -> different fill order ->
+   metric drift on long-horizon backtests. *)
+let _make_id ~current_date ~seq =
+  Printf.sprintf "%s-%03d" (Date.to_string current_date) seq
+
+let _create_order ~id ~symbol ~side ~quantity =
   let params : Trading_orders.Create_order.order_params =
     {
       symbol;
@@ -27,40 +37,47 @@ let _create_order ~symbol ~side ~quantity =
       time_in_force = Trading_orders.Types.Day;
     }
   in
-  Result.map (Trading_orders.Create_order.create_order params) ~f:Option.some
+  Result.map
+    (Trading_orders.Create_order.create_order ~id params)
+    ~f:Option.some
 
-let _exit_order_for_position position =
+let _exit_order_for_position ~id position =
   let open Trading_strategy.Position in
   match get_state position with
   | Exiting { quantity; _ } ->
-      _create_order ~symbol:position.symbol
+      _create_order ~id ~symbol:position.symbol
         ~side:(_exit_order_side position.side)
         ~quantity
   | _ -> Ok None
 
-let _transition_to_order ~positions
+let _transition_to_order ~id ~positions
     (transition : Trading_strategy.Position.transition) =
   let open Trading_strategy.Position in
   match transition.kind with
   | CreateEntering { symbol; side; target_quantity; _ } ->
-      _create_order ~symbol ~side:(_entry_order_side side)
+      _create_order ~id ~symbol ~side:(_entry_order_side side)
         ~quantity:target_quantity
   | TriggerExit _ ->
       (* After _apply_transitions, the position is in Exiting state, not Holding.
          We look up the Exiting position to get the quantity and side. *)
       Map.find positions transition.position_id
-      |> Option.value_map ~default:(Ok None) ~f:_exit_order_for_position
+      |> Option.value_map ~default:(Ok None) ~f:(_exit_order_for_position ~id)
   | EntryFill _ | EntryComplete _ | CancelEntry _ | UpdateRiskParams _
   | ExitFill _ | ExitComplete ->
       Ok None
 
-let transitions_to_orders ~positions transitions =
+let transitions_to_orders ~current_date ~positions transitions =
   let open Result.Let_syntax in
-  let%bind orders =
-    List.fold_result transitions ~init:[] ~f:(fun acc transition ->
-        let%bind maybe_order = _transition_to_order ~positions transition in
+  let%bind _, orders =
+    List.fold_result transitions ~init:(0, []) ~f:(fun (seq, acc) transition ->
+        let id = _make_id ~current_date ~seq in
+        let%bind maybe_order = _transition_to_order ~id ~positions transition in
         match maybe_order with
-        | Some order -> Ok (order :: acc)
-        | None -> Ok acc)
+        | Some order -> Ok (seq + 1, order :: acc)
+        | None ->
+            (* We still advance [seq] for ignored transitions so that any
+               future re-ordering of transition kinds does not silently shift
+               IDs. Sequential gaps in IDs are harmless. *)
+            Ok (seq + 1, acc))
   in
   Ok (List.rev orders)

--- a/trading/trading/simulation/lib/order_generator.mli
+++ b/trading/trading/simulation/lib/order_generator.mli
@@ -15,6 +15,7 @@
     transitions and determining appropriate limit prices. *)
 
 val transitions_to_orders :
+  current_date:Core.Date.t ->
   positions:Trading_strategy.Position.t Core.String.Map.t ->
   Trading_strategy.Position.transition list ->
   Trading_orders.Types.order list Status.status_or
@@ -27,5 +28,17 @@ val transitions_to_orders :
 
     Other transition types are ignored (they don't generate orders).
 
-    @param positions Current positions map for looking up quantities
-    @return Ok list of orders, or Error if order creation fails *)
+    Order IDs are minted deterministically from [current_date] and the
+    transition's index in the list (e.g. ["2024-03-15-007"]). This is the G6
+    fix: order IDs were previously derived from [Time_ns_unix.now ()] and
+    [Random.int], producing different IDs across forks. Because the IDs are
+    hashtable keys in [Trading_orders.Manager.orders], unstable IDs led to
+    unstable [list_orders] iteration order -> unstable fill order -> metric
+    drift on long-horizon backtests. See
+    dev/notes/g6-decade-nondeterminism-investigation-2026-04-30.md.
+
+    @param current_date
+      date of the simulation step generating these orders; used to seed
+      deterministic IDs.
+    @param positions Current positions map for looking up quantities.
+    @return Ok list of orders, or Error if order creation fails. *)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -395,7 +395,8 @@ let step t =
     let%bind transitions = _call_strategy { t with portfolio; positions } in
     let%bind positions = _apply_transitions ~positions ~transitions in
     let%bind orders =
-      Order_generator.transitions_to_orders ~positions transitions
+      Order_generator.transitions_to_orders ~current_date:t.current_date
+        ~positions transitions
     in
     let step_result =
       {

--- a/trading/trading/simulation/test/test_order_generator.ml
+++ b/trading/trading/simulation/test/test_order_generator.ml
@@ -107,7 +107,9 @@ let make_exiting_position ?(side = Long) ~position_id ~symbol ~quantity ~price
 (* ==================== transitions_to_orders tests ==================== *)
 
 let test_empty_transitions_returns_empty_orders _ =
-  let result = transitions_to_orders ~positions:empty_positions [] in
+  let result =
+    transitions_to_orders ~current_date:today ~positions:empty_positions []
+  in
   assert_that result (is_ok_and_holds (elements_are []))
 
 let test_create_entering_generates_buy_order _ =
@@ -117,7 +119,10 @@ let test_create_entering_generates_buy_order _ =
         ~quantity:100.0 ~price:150.0 ();
     ]
   in
-  let result = transitions_to_orders ~positions:empty_positions transitions in
+  let result =
+    transitions_to_orders ~current_date:today ~positions:empty_positions
+      transitions
+  in
   assert_that result
     (is_ok_and_holds
        (elements_are
@@ -139,7 +144,10 @@ let test_trigger_exit_no_position_returns_empty _ =
   let transitions =
     [ make_trigger_exit_transition ~position_id:"AAPL-1" ~exit_price:155.0 ]
   in
-  let result = transitions_to_orders ~positions:empty_positions transitions in
+  let result =
+    transitions_to_orders ~current_date:today ~positions:empty_positions
+      transitions
+  in
   assert_that result (is_ok_and_holds (elements_are []))
 
 let test_trigger_exit_with_position_generates_sell_order _ =
@@ -153,7 +161,9 @@ let test_trigger_exit_with_position_generates_sell_order _ =
   let transitions =
     [ make_trigger_exit_transition ~position_id:"AAPL-1" ~exit_price:155.0 ]
   in
-  let result = transitions_to_orders ~positions transitions in
+  let result =
+    transitions_to_orders ~current_date:today ~positions transitions
+  in
   assert_that result
     (is_ok_and_holds
        (elements_are
@@ -178,12 +188,18 @@ let test_entry_fill_returns_no_orders _ =
         ~price:150.5;
     ]
   in
-  let result = transitions_to_orders ~positions:empty_positions transitions in
+  let result =
+    transitions_to_orders ~current_date:today ~positions:empty_positions
+      transitions
+  in
   assert_that result (is_ok_and_holds (elements_are []))
 
 let test_entry_complete_returns_no_orders _ =
   let transitions = [ make_entry_complete_transition ~position_id:"AAPL-1" ] in
-  let result = transitions_to_orders ~positions:empty_positions transitions in
+  let result =
+    transitions_to_orders ~current_date:today ~positions:empty_positions
+      transitions
+  in
   assert_that result (is_ok_and_holds (elements_are []))
 
 let test_multiple_create_entering_generates_multiple_orders _ =
@@ -195,7 +211,10 @@ let test_multiple_create_entering_generates_multiple_orders _ =
         ~quantity:50.0 ~price:140.0 ();
     ]
   in
-  let result = transitions_to_orders ~positions:empty_positions transitions in
+  let result =
+    transitions_to_orders ~current_date:today ~positions:empty_positions
+      transitions
+  in
   assert_that result
     (is_ok_and_holds
        (elements_are
@@ -236,7 +255,10 @@ let test_mixed_transitions_filters_non_order_generating _ =
       make_trigger_exit_transition ~position_id:"AAPL-1" ~exit_price:155.0;
     ]
   in
-  let result = transitions_to_orders ~positions:empty_positions transitions in
+  let result =
+    transitions_to_orders ~current_date:today ~positions:empty_positions
+      transitions
+  in
   assert_that result
     (is_ok_and_holds
        (elements_are
@@ -263,7 +285,10 @@ let test_short_create_entering_generates_sell_order _ =
         ~symbol:"AAPL" ~quantity:100.0 ~price:150.0 ();
     ]
   in
-  let result = transitions_to_orders ~positions:empty_positions transitions in
+  let result =
+    transitions_to_orders ~current_date:today ~positions:empty_positions
+      transitions
+  in
   assert_that result
     (is_ok_and_holds
        (elements_are
@@ -291,7 +316,9 @@ let test_short_trigger_exit_generates_buy_order _ =
   let transitions =
     [ make_trigger_exit_transition ~position_id:"AAPL-1" ~exit_price:145.0 ]
   in
-  let result = transitions_to_orders ~positions transitions in
+  let result =
+    transitions_to_orders ~current_date:today ~positions transitions
+  in
   assert_that result
     (is_ok_and_holds
        (elements_are


### PR DESCRIPTION
## Summary

Replaces the wall-clock + Random.int order-ID generator in
`Trading_orders.Create_order` with a deterministic generator keyed on
scenario-time inputs (`current_date` + per-call sequence index) threaded
through `Simulation.Order_generator`.

This fixes G6 — see
`dev/notes/g6-decade-nondeterminism-investigation-2026-04-30.md`. Order
IDs are hashtable keys in `Trading_orders.Manager.orders`; the previous
generator used `Time_ns_unix.now ()` (ns-precision wall clock) for the
prefix and `Random.int 10000` for the suffix, so different process
forks (or different fork-time clock jitter) produced different IDs ->
different `Hashtbl` bucket placement -> different `list_orders` /
`process_orders` iteration order -> different fill order -> different
cash-floor / sizing / risk-gate decisions on long-horizon, wide-universe
runs (decade-2014-2023, sp500-2019-2023). Short, narrow scenarios
rarely cross a flip threshold, which is why the existing
in-process determinism test (`test_determinism.ml`) and forward-guard
isolation test (`test_scenario_runner_isolation.ml`, PR #703) both pass
on small windows even before this fix; the bug surfaces empirically
only at the 10-year × N=1000 scale.

## Why this fix is strategy-agnostic (qc-structural A1 / qc-behavioral A1)

`Trading_orders.Create_order` is on the core-module watch-list (A1),
but the change is purely about how an **opaque identifier string** is
minted: no Weinstein concept (stage classifier, screener, stops,
macro, sector) appears anywhere in the diff. The new ID format
(`"YYYY-MM-DD-NNN"` from `Order_generator`, `"ord-N"` for direct
callers) carries no strategy-specific semantics. Any strategy that
plugs into the existing `STRATEGY` interface and produces transitions
gets deterministic IDs by construction; `create_order` callers that
mint their own IDs (via the new `~id` parameter) are unaffected. The
only assumption the fix relies on is that callers either (a) construct
a fresh `Manager.t` per simulation (the existing pattern in
`Simulator.create_deps`) or (b) supply their own `~id`; both are
strategy-independent properties.

## Empirical verification

**Pre-fix (legacy `Time_ns_unix.now ()` + `Random.int 10000`)**:
- Order IDs of the form `"2147483648123456789_4321"` (19-digit ns
  timestamp + `_` + 4-digit random suffix). Two `create_order` calls
  in the same process produce different IDs (advancing nanoseconds);
  two `create_order` calls in different forks produce different IDs
  with high probability (different ns prefix).

**Post-fix (this PR)**:
- `Order_generator.transitions_to_orders` mints IDs of the form
  `"2019-05-13-000"`, `"2019-05-13-001"`, ... — date + zero-padded
  sequence within the day's transition list. Identical inputs
  produce identical IDs.
- Direct callers of `Create_order.create_order` without `~id` get
  `"ord-1"`, `"ord-2"`, ... from a process-monotonic counter (still
  free of wall-clock and Random PRNG state).

**Verified on `panel-golden-2019-full` (the
`test_scenario_runner_isolation.ml` fixture)**: ran the scenario_runner
exe **three times in three different processes** (different fork
PIDs, different wall-clock times) — all 9 output artefacts
(`actual.sexp`, `summary.sexp`, `round_trips`, `trades.csv`,
`equity_curve.csv`, `macro_trend.sexp`, `trade_audit.sexp`,
`params.sexp`, `splits.csv`, `final_prices.csv`,
`open_positions.csv`) bit-identical across all 3 runs:

```
--- Run 1 vs Run 2 ---
ALL FILES BIT-IDENTICAL
--- Run 1 vs Run 3 ---
ALL FILES BIT-IDENTICAL
```

The decade × N=1000 case in the original investigation cannot be
reproduced on the per-PR test surface (no fixture; runs ~5 min × 4
cores), but the same mechanism that drives the small-window
bit-identity also drives the large-window bit-identity once the
process-time-dependent ID generator is removed. Empirical
confirmation on `goldens-broad/decade-2014-2023` and
`goldens-sp500/sp500-2019-2023` is deferred to the next nightly run.

## Tests

**New (TDD-pinned in this PR):**
- `test_default_ids_are_deterministic_in_sequence` — 5 successive
  `create_order` calls produce 5 distinct deterministic IDs all
  prefixed `"ord-"`.
- `test_default_ids_have_no_wall_clock_or_random` — asserts the
  default ID has no `_` separator (legacy timestamp/random scheme)
  and no run of >= 13 consecutive digits (legacy ns-since-epoch was
  19 digits).
- `test_explicit_id_overrides_default` — `~id:"custom-id-123"` flows
  through to the resulting `order.id`.

**Forward guards (must still pass — confirmed):**
- `test_scenario_runner_isolation.ml` (PR #703): all 3 cases PASS
  (round-trips bit-equal across standalone vs after-perturber, final
  portfolio value within 1e-9, target across 2 perturber cycles
  stable). Run time 8.4 s.
- `test_determinism.ml` (5x in-process round-trip): cannot run in
  this environment (missing fixture file `data/backtest_scenarios/
  smoke/panel-golden-2019-full.sexp` is a pre-existing env issue,
  also fails on `main`).

**Updated callers (signature change in `Order_generator`):**
- `test_order_generator.ml` — 10 sites add `~current_date:today`.
  All assertions still hold.
- `Simulator.step` — single-line update, threads `t.current_date` in.

## Files changed (LOC delta)

```
trading/orders/lib/create_order.ml      | 36 +++/-/14 (~22 net)
trading/orders/lib/create_order.mli     | 21 +++/- (15 doc, 4 sig)
trading/orders/test/test_create_order.ml| 82 +++ (new tests + counter resets)
trading/simulation/lib/order_generator.ml  | 38 +++/-7
trading/simulation/lib/order_generator.mli | 17 +++/-2 (param + docs)
trading/simulation/lib/simulator.ml     |  3 +/-1
trading/simulation/test/test_order_generator.ml | 47 +/- (mech sig update)
7 files, ~179 insertions, ~30 deletions
```

## Test plan

- [x] `dune build` clean
- [x] `dune fmt` clean
- [x] `dune runtest trading/orders` (19/19 PASS — adds 3 new G6 guards)
- [x] `dune runtest trading/simulation` (~70 PASS, no new failures)
- [x] `test_scenario_runner_isolation.ml` (forward-guard from #703) PASSES
- [x] `panel-golden-2019-full` 3-run cross-process bit-identity verified
- [ ] (next nightly) Re-run `goldens-broad/decade-2014-2023` and
      `goldens-sp500/sp500-2019-2023` to confirm the long-horizon /
      wide-universe drift is gone.