### PR TITLE
feat(force-liquidation): G15 step 1 — asymmetric per-position thresholds (long 25%, short 15%)

### DIFF
--- a/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.ml
+++ b/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.ml
@@ -3,14 +3,22 @@
 open Core
 
 type config = {
-  max_unrealized_loss_fraction : float;
+  max_long_unrealized_loss_fraction : float;
+  max_short_unrealized_loss_fraction : float;
   min_portfolio_value_fraction_of_peak : float;
 }
 [@@deriving show, eq, sexp]
 
 let default_config =
   {
-    max_unrealized_loss_fraction = 0.5;
+    (* Longs cap at -25% of cost basis (book: hard 25% rule on individual
+       positions, see [docs/design/weinstein-book-reference.md] §Stop-Loss
+       Rules). *)
+    max_long_unrealized_loss_fraction = 0.25;
+    (* Shorts must cap tighter — short P&L is unbounded above (price has no
+       ceiling) while a long can lose at most 100% of cost basis. Per
+       Weinstein's short-sale guidance, exit on the first sign of strength. *)
+    max_short_unrealized_loss_fraction = 0.15;
     min_portfolio_value_fraction_of_peak = 0.4;
   }
 
@@ -194,9 +202,11 @@ let _event_of_input ~date ~reason (p : position_input) : event =
     reason;
   }
 
-(* Per-position trigger: a position fires when its unrealized loss exceeds
-   [config.max_unrealized_loss_fraction] of cost basis. Cost basis must be
-   strictly positive — degenerate inputs (zero-cost basis) are not flagged. *)
+(* Per-position trigger: a position fires when its unrealized loss exceeds the
+   side-specific threshold ([max_long_unrealized_loss_fraction] for longs,
+   [max_short_unrealized_loss_fraction] for shorts) of cost basis. Cost basis
+   must be strictly positive — degenerate inputs (zero-cost basis) are not
+   flagged. *)
 let _check_per_position ~config ~date (p : position_input) : event option =
   let cost_basis = p.entry_price *. p.quantity in
   if Float.( <= ) cost_basis 0.0 then None
@@ -206,7 +216,12 @@ let _check_per_position ~config ~date (p : position_input) : event option =
         ~current_price:p.current_price ~quantity:p.quantity
     in
     let loss_fraction = -.pnl /. cost_basis in
-    if Float.( > ) loss_fraction config.max_unrealized_loss_fraction then
+    let threshold =
+      match p.side with
+      | Trading_base.Types.Long -> config.max_long_unrealized_loss_fraction
+      | Trading_base.Types.Short -> config.max_short_unrealized_loss_fraction
+    in
+    if Float.( > ) loss_fraction threshold then
       Some (_event_of_input ~date ~reason:Per_position p)
     else None
 

--- a/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.mli
+++ b/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.mli
@@ -7,9 +7,13 @@
 
     {1 Two trigger conditions}
 
-    - {b Per-position}: a single position's unrealized loss exceeds
-      [max_unrealized_loss_fraction] of its cost basis. Force-close that
-      position only.
+    - {b Per-position}: a single position's unrealized loss exceeds the
+      side-specific threshold ([max_long_unrealized_loss_fraction] for longs,
+      [max_short_unrealized_loss_fraction] for shorts) of its cost basis.
+      Force-close that position only. Asymmetric per Weinstein's stop-loss
+      rules: a long's downside is capped at 100% (price floor at 0); a short's
+      downside is unbounded (price has no ceiling), so shorts are held to a
+      tighter loss budget.
     - {b Portfolio-floor}: total portfolio value drops below
       [min_portfolio_value_fraction_of_peak] of the highest portfolio value
       observed since the strategy started. Force-close ALL positions and halt
@@ -37,10 +41,16 @@ open Core
 (** {1 Configuration} *)
 
 type config = {
-  max_unrealized_loss_fraction : float;
-      (** Per-position trigger: force-close a position when its unrealized loss
-          exceeds this fraction of cost basis. Default [0.5] (50% of cost basis
-          lost). Set to [Float.infinity] to disable the per-position trigger. *)
+  max_long_unrealized_loss_fraction : float;
+      (** Per-position trigger for {b longs}: force-close a long position when
+          its unrealized loss exceeds this fraction of cost basis. Default
+          [0.25] (25% of cost basis lost). Set to [Float.infinity] to disable.
+      *)
+  max_short_unrealized_loss_fraction : float;
+      (** Per-position trigger for {b shorts}: force-close a short position when
+          its unrealized loss exceeds this fraction of cost basis. Default
+          [0.15] (15% of cost basis lost) — tighter than longs because short
+          downside is unbounded. Set to [Float.infinity] to disable. *)
   min_portfolio_value_fraction_of_peak : float;
       (** Portfolio-floor trigger: force-close all positions and halt new
           entries when [portfolio_value < peak * fraction]. Default [0.4] (40%
@@ -51,8 +61,9 @@ type config = {
 (** All thresholds — nothing hardcoded. *)
 
 val default_config : config
-(** [{ max_unrealized_loss_fraction = 0.5; min_portfolio_value_fraction_of_peak
-     = 0.4 }]. *)
+(** [{ max_long_unrealized_loss_fraction = 0.25;
+     max_short_unrealized_loss_fraction = 0.15;
+     min_portfolio_value_fraction_of_peak = 0.4 }]. *)
 
 (** {1 Event} *)
 

--- a/trading/trading/weinstein/portfolio_risk/test/test_force_liquidation.ml
+++ b/trading/trading/weinstein/portfolio_risk/test/test_force_liquidation.ml
@@ -85,9 +85,10 @@ let test_peak_tracker_halt_state _ =
 (* ---- Per-position trigger ---- *)
 
 let test_per_position_long_no_fire_under_threshold _ =
-  (* default 50% threshold; long at $100 → $60 = 40% loss; should NOT fire *)
+  (* default long threshold 25%; long at $100 → $80 = 20% loss; should NOT
+     fire *)
   let pt = FL.Peak_tracker.create () in
-  let positions = [ make_long ~entry_price:100.0 ~current_price:60.0 () ] in
+  let positions = [ make_long ~entry_price:100.0 ~current_price:80.0 () ] in
   let events =
     FL.check ~config:FL.default_config ~date ~positions
       ~portfolio_value:1_000_000.0 ~peak_tracker:pt
@@ -95,7 +96,7 @@ let test_per_position_long_no_fire_under_threshold _ =
   assert_that events (size_is 0)
 
 let test_per_position_long_fires_on_exceed _ =
-  (* long at $100 → $40 = 60% loss; default threshold 50%; SHOULD fire *)
+  (* long at $100 → $40 = 60% loss; default long threshold 25%; SHOULD fire *)
   let pt = FL.Peak_tracker.create () in
   let positions = [ make_long ~entry_price:100.0 ~current_price:40.0 () ] in
   let events =
@@ -116,7 +117,8 @@ let test_per_position_long_fires_on_exceed _ =
        ])
 
 let test_per_position_short_fires_on_exceed _ =
-  (* short at $200 → $320 = 60% loss; default threshold 50%; SHOULD fire *)
+  (* short at $200 → $320 = 60% loss; default short threshold 15%; SHOULD
+     fire *)
   let pt = FL.Peak_tracker.create () in
   let positions = [ make_short ~entry_price:200.0 ~current_price:320.0 () ] in
   let events =
@@ -146,10 +148,89 @@ let test_per_position_does_not_fire_on_winner _ =
   in
   assert_that events (size_is 0)
 
+(* ---- Asymmetric per-position thresholds (G15 step 1) ---- *)
+
+(** Long at $100 → $70 = 30% loss; default long threshold is 25% — fires. Pins
+    the long-side cap at the new 0.25 threshold. *)
+let test_per_position_long_threshold _ =
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long ~entry_price:100.0 ~current_price:70.0 () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (e : FL.event) -> e.side)
+               (equal_to Trading_base.Types.Long);
+             field (fun (e : FL.event) -> e.reason) (equal_to FL.Per_position);
+             field
+               (fun (e : FL.event) -> e.unrealized_pnl_pct)
+               (float_equal (-0.3));
+           ];
+       ])
+
+(** Short at $200 → $236 = 18% loss; default short threshold is 15% — fires.
+    Pins the short-side cap at the tighter 0.15 threshold (asymmetric per
+    Weinstein's short-sale guidance — short downside is unbounded, so the loss
+    budget is held tighter than for longs). *)
+let test_per_position_short_threshold _ =
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_short ~entry_price:200.0 ~current_price:236.0 () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (e : FL.event) -> e.side)
+               (equal_to Trading_base.Types.Short);
+             field (fun (e : FL.event) -> e.reason) (equal_to FL.Per_position);
+             field
+               (fun (e : FL.event) -> e.unrealized_pnl_pct)
+               (float_equal (-0.18));
+           ];
+       ])
+
+(** Long at $100 → $80 = 20% loss; below the 25% long threshold — must NOT fire.
+    Pins the asymmetry: a 20% long loss survives, but a 20% short loss would
+    exceed the 15% short threshold. *)
+let test_per_position_long_no_fire_at_20pct _ =
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_long ~entry_price:100.0 ~current_price:80.0 () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events is_empty
+
+(** Short at $200 → $224 = 12% loss; below the 15% short threshold — must NOT
+    fire. Pins the asymmetric counterpart: a 12% loss survives on a short, but
+    the same 12% loss on a short above the long threshold would not survive on a
+    long if scaled (e.g. 25%+ on a long). *)
+let test_per_position_short_no_fire_at_12pct _ =
+  let pt = FL.Peak_tracker.create () in
+  let positions = [ make_short ~entry_price:200.0 ~current_price:224.0 () ] in
+  let events =
+    FL.check ~config:FL.default_config ~date ~positions
+      ~portfolio_value:1_000_000.0 ~peak_tracker:pt
+  in
+  assert_that events is_empty
+
 let test_per_position_custom_threshold _ =
   (* tighter threshold of 20% — long at 100 → 75 = 25% loss; SHOULD fire *)
   let pt = FL.Peak_tracker.create () in
-  let config = { FL.default_config with max_unrealized_loss_fraction = 0.2 } in
+  let config =
+    { FL.default_config with max_long_unrealized_loss_fraction = 0.2 }
+  in
   let positions = [ make_long ~entry_price:100.0 ~current_price:75.0 () ] in
   let events =
     FL.check ~config ~date ~positions ~portfolio_value:1_000_000.0
@@ -283,7 +364,12 @@ let test_default_config_values _ =
   assert_that FL.default_config
     (all_of
        [
-         field (fun c -> c.FL.max_unrealized_loss_fraction) (float_equal 0.5);
+         field
+           (fun c -> c.FL.max_long_unrealized_loss_fraction)
+           (float_equal 0.25);
+         field
+           (fun c -> c.FL.max_short_unrealized_loss_fraction)
+           (float_equal 0.15);
          field
            (fun c -> c.FL.min_portfolio_value_fraction_of_peak)
            (float_equal 0.4);
@@ -324,6 +410,14 @@ let suite =
          >:: test_per_position_short_fires_on_exceed;
          "per_position_does_not_fire_on_winner"
          >:: test_per_position_does_not_fire_on_winner;
+         "per_position_long_threshold (G15)"
+         >:: test_per_position_long_threshold;
+         "per_position_short_threshold (G15)"
+         >:: test_per_position_short_threshold;
+         "per_position_long_no_fire_at_20pct (G15)"
+         >:: test_per_position_long_no_fire_at_20pct;
+         "per_position_short_no_fire_at_12pct (G15)"
+         >:: test_per_position_short_no_fire_at_12pct;
          "per_position_custom_threshold" >:: test_per_position_custom_threshold;
          "portfolio_floor_first_observation_no_fire"
          >:: test_portfolio_floor_first_observation_no_fire;

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
@@ -119,7 +119,8 @@ let _capturing_recorder () =
 (* ------------------------------------------------------------------ *)
 
 let test_per_position_trigger_emits_exit _ =
-  (* Long entered $100, current $40 — 60% loss; default threshold 50% fires. *)
+  (* Long entered $100, current $40 — 60% loss; default long threshold 25%
+     fires. *)
   let pos =
     _make_holding ~symbol:"AAPL" ~side:Trading_base.Types.Long
       ~entry_date:(_date "2024-01-02") ~quantity:100.0 ~entry_price:100.0
@@ -154,12 +155,12 @@ let test_per_position_trigger_emits_exit _ =
   assert_that !captured (size_is 1)
 
 let test_per_position_trigger_no_fire_under_threshold _ =
-  (* Long $100 → $60 = 40% loss; threshold 50%; no fire. *)
+  (* Long $100 → $80 = 20% loss; long threshold 25%; no fire. *)
   let pos =
     _make_holding ~symbol:"AAPL" ~side:Trading_base.Types.Long
       ~entry_date:(_date "2024-01-02") ~quantity:100.0 ~entry_price:100.0
   in
-  let bar = _make_bar ~date:(_date "2024-04-29") ~close:60.0 in
+  let bar = _make_bar ~date:(_date "2024-04-29") ~close:80.0 in
   let positions = String.Map.singleton "AAPL" pos in
   let get_price s = if String.equal s "AAPL" then Some bar else None in
   let peak_tracker = FL.Peak_tracker.create () in
@@ -244,7 +245,7 @@ let test_no_positions_no_events _ =
 
 let test_short_position_loss_fires _ =
   (* Short at $200, current $320 = 60% loss (entry 200 + price up 120 / cost
-     basis 200 = 0.6); default 50% fires. *)
+     basis 200 = 0.6); default short threshold 15% fires. *)
   let pos =
     _make_holding ~symbol:"TSLA" ~side:Trading_base.Types.Short
       ~entry_date:(_date "2024-01-02") ~quantity:50.0 ~entry_price:200.0


### PR DESCRIPTION
## Summary

Tighten the per-position force-liquidation backstop and split it into asymmetric long/short thresholds. Pre-fix, both sides shared a single 50% threshold; post-fix, longs cap at -25% and shorts cap at -15%. Asymmetric per Weinstein's stop-loss rules — a long's downside is bounded at 100% (price floor at 0) but a short's downside is unbounded (price has no ceiling), so shorts must be held to a tighter loss budget.

This is G15 step 1 from \`dev/notes/force-liq-cascade-findings-2026-05-01.md\` — a "stops protective backstop" tuning, not a Portfolio_floor circuit-breaker change. The Portfolio_floor trigger is unchanged at 0.4 of peak. The new thresholds apply only to the per-position trigger that fires when individual stops fail to protect a trade and unrealized loss compounds unchecked.

## Changes

- \`force_liquidation.ml/.mli\` — \`config\` field \`max_unrealized_loss_fraction : float\` split into \`max_long_unrealized_loss_fraction\` (default 0.25) and \`max_short_unrealized_loss_fraction\` (default 0.15). \`_check_per_position\` now dispatches on \`position_input.side\` to pick the right threshold.
- \`test_force_liquidation.ml\` — re-targeted 5 existing tests for the new defaults; added 4 new tests (\`test_per_position_long_threshold\`, \`test_per_position_short_threshold\`, \`test_per_position_long_no_fire_at_20pct\`, \`test_per_position_short_no_fire_at_12pct\`) pinning the asymmetry directly.
- \`test_force_liquidation_runner.ml\` — re-targeted the 50%-threshold test (40% loss / no-fire scenario) for the new 25% threshold using a 20%-loss / no-fire scenario.

## sp500 metric deltas (post-G14 baseline → post-G15-step-1)

| Scenario     | Metric             | Pre   | Post  |
|--------------|--------------------|------:|------:|
| with-shorts  | total_return_pct   |  -1.2 |  -1.2 |
| with-shorts  | total_trades       |   130 |   130 |
| with-shorts  | win_rate           |  20.0 |  20.0 |
| with-shorts  | max_drawdown_pct   |  34.4 |  34.4 |
| with-shorts  | force_liquidations |     0 |   {b 2} |
| long-only    | total_return_pct   |  26.0 |  26.0 |
| long-only    | total_trades       |   113 |   113 |
| long-only    | win_rate           |  31.9 |  31.9 |
| long-only    | max_drawdown_pct   |  41.2 |  41.2 |
| long-only    | force_liquidations |     0 |     0 |

Top-line metrics unchanged. The two new force-liq events are short-side, both triggered by the new 0.15 threshold:

| Symbol | Date       | Side  | Entry  | Current | PnL %    | Reason       |
|--------|------------|-------|-------:|--------:|---------:|--------------|
| AOS    | 2019-02-12 | Short |  44.12 |   50.89 |  -15.34% | Per_position |
| HOOD   | 2022-03-16 | Short |  10.96 |   12.78 |  -16.61% | Per_position |

Both legitimate stops on shorts whose price moved against the position past the new 15% threshold — exactly what the tighter threshold was designed to catch. Long-only is unchanged because the regular Stops_runner already exits losing longs before the 25% Per_position threshold trips. Top-line MaxDD on with-shorts is unchanged because these two events are small in dollar terms (combined cost basis ~\$18K against a \$1M+ portfolio) — they don't move the portfolio-level needle, but they pin the protective-backstop contract.

## Justification for the 0.25 / 0.15 thresholds

Asymmetric per Weinstein's Stop-Loss Rules (\`docs/design/weinstein-book-reference.md\`): a long position has downside bounded at -100% (price floor at 0), so a 25% backstop leaves headroom above the regular per-trade stop. A short position has unbounded downside (price has no ceiling), so the cap must be tighter — 15% gives meaningfully tighter risk control on the side where loss runaway is the risk. Both numbers are above the typical regular-stop fire range, so the backstop only kicks in when regular stops have failed to protect the trade.

## Test plan

- [x] \`dune build\` clean
- [x] \`dune runtest weinstein/portfolio_risk/test/\` — 26/26 pass (4 new + 22 retargeted/existing)
- [x] \`dune runtest weinstein/strategy/test/\` — all pass (incl. retargeted runner test)
- [x] \`dune runtest\` full suite — no regressions
- [x] \`dune build @fmt\` clean
- [x] sp500-2019-2023 (with-shorts) — 2 legit short force-liqs, otherwise unchanged
- [x] sp500-2019-2023-long-only — unchanged

## Out of scope

- Maximum total short notional as fraction of portfolio (G15 step 2+).
- Honest Portfolio_floor reintroduction based on real peak observations (separate decision item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)