### PR TITLE
feat(metrics): rename UnrealizedPnl→OpenPositionsValue + add corrected UnrealizedPnl

### DIFF
--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -1,6 +1,6 @@
 # Status: Backtest Infrastructure
 
-## Last updated: 2026-04-25
+## Last updated: 2026-05-01
 
 ## Status
 MERGED
@@ -128,6 +128,22 @@ None. Merged in main:
 - Non-deterministic due to Hashtbl ordering (tracked, not fully fixed)
 
 ## Completed
+
+- [x] **UnrealizedPnl rename + corrected metric** (2026-05-01,
+  `feat/metrics-unrealized-pnl-rename`, PR #741). Bug surfaced via
+  reconciler today: the existing `UnrealizedPnl` metric (=
+  `final_portfolio_value - current_cash`) is the signed mtm value of open
+  positions, not paper P&L vs cost basis. On a long-only sp500-2019-2023
+  baseline that's $1,254K (mtm) vs a true paper P&L of +$422K. PR renames
+  the existing metric to `OpenPositionsValue` (semantics preserved) and
+  adds a NEW `UnrealizedPnl` computed as `OpenPositionsValue - Σ
+  position_cost_basis` — equivalent to `Σ (current - entry) * signed_qty`
+  (long: positive on gain; short: positive on price drop). All 13 scenario
+  sexp pin keys renamed `unrealized_pnl` → `open_positions_value`
+  (range preserved). New long / short / mixed-portfolio tests in
+  `test_metrics.ml`. The reconciler-confusion source flagged in
+  `dev/notes/short-cash-accounting-design-2026-05-01.md` is now closed.
+  Verify: `dune runtest trading/simulation/test trading/backtest/scenarios/test`.
 
 - [x] **Perf-sweep harness extension** (2026-04-23,
   `feat/backtest-perf-sweep-harness`). Wraps the existing C2 perf harness

--- a/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
@@ -30,7 +30,7 @@
  (config_overrides (((universe_cap (1000)) (enable_short_side false))))
  ;; Baseline measured 2026-04-29 (long-only):
  ;;   return +148.77% / 91 trades / win_rate 39.56% / Sharpe 0.508 /
- ;;   MaxDD 62.91% / avg_hold 61.0d / unrealized_pnl $2.39M /
+ ;;   MaxDD 62.91% / avg_hold 61.0d / open_positions_value $2.39M /
  ;;   peak RSS 1,650 MB / wall 2:33.
  (expected
   ((total_return_pct   ((min 126.0)        (max 172.0)))     ;; ±15% around 148.8
@@ -39,4 +39,4 @@
    (sharpe_ratio       ((min 0.25)         (max 0.75)))      ;; small absolute, wider relative
    (max_drawdown_pct   ((min 56.5)         (max 69.5)))      ;; ±10% around 62.9
    (avg_holding_days   ((min 55.0)         (max 67.5)))      ;; ±10% around 61.0
-   (unrealized_pnl     ((min 2030000.0)    (max 2760000.0))))))   ;; ±15% around 2.39M
+   (open_positions_value ((min 2030000.0)  (max 2760000.0))))))  ;; ±15% around $2.39M (mtm value, NOT true unrealized P&L; see metric_types.mli)

--- a/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
@@ -24,7 +24,7 @@
  (config_overrides (((universe_cap (1000)) (enable_short_side false))))
  ;; Baseline measured 2026-04-29 (long-only):
  ;;   return +15.12% / 149 trades / win_rate 20.81% / Sharpe 0.238 /
- ;;   MaxDD 75.30% / avg_hold 61.1d / unrealized_pnl $1.12M /
+ ;;   MaxDD 75.30% / avg_hold 61.1d / open_positions_value $1.12M /
  ;;   peak RSS 1,693 MB / wall 2:50.
  (expected
   ((total_return_pct   ((min 12.5)         (max 17.5)))     ;; ±15% around 15.1
@@ -33,4 +33,4 @@
    (sharpe_ratio       ((min 0.10)         (max 0.40)))     ;; small absolute, wider relative
    (max_drawdown_pct   ((min 67.5)         (max 83.0)))     ;; ±10% around 75.3
    (avg_holding_days   ((min 55.0)         (max 67.5)))     ;; ±10% around 61.1
-   (unrealized_pnl     ((min 955000.0)     (max 1295000.0))))))   ;; ±15% around 1.12M
+   (open_positions_value ((min 955000.0)   (max 1295000.0))))))  ;; ±15% around $1.12M (mtm value, NOT true unrealized P&L; see metric_types.mli)

--- a/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
@@ -28,10 +28,10 @@
  (config_overrides (((universe_cap (1000)) (enable_short_side false))))
  ;; Baseline measured 2026-04-29 (long-only) — TWO independent runs landed:
  ;;   run-1: return +1582.85% / 145 trades / win_rate 40.69% / Sharpe 0.960 /
- ;;          MaxDD 94.31% / avg_hold 103.3d / unrealized_pnl $15.91M /
+ ;;          MaxDD 94.31% / avg_hold 103.3d / open_positions_value $15.91M /
  ;;          peak RSS 1,956 MB / wall 4:31.
  ;;   run-2: return +1627.09% / 135 trades / win_rate 40.00% / Sharpe 0.960 /
- ;;          MaxDD 94.84% / avg_hold 98.0d  / unrealized_pnl $16.66M.
+ ;;          MaxDD 94.84% / avg_hold 98.0d  / open_positions_value $16.66M.
  ;; The decade cell is the ONLY one of the four goldens-broad cells that is
  ;; non-deterministic across reruns (3/4 are bit-identical). Source of the
  ;; variance is unknown — likely Hashtbl iteration order divergence accumulating
@@ -46,4 +46,4 @@
    (sharpe_ratio       ((min 0.65)         (max 1.30)))     ;; small absolute, wider relative
    (max_drawdown_pct   ((min 84.0)         (max 100.0)))    ;; encompass 94.3 + 94.8 (capped at 100)
    (avg_holding_days   ((min 88.0)         (max 115.0)))    ;; encompass 98.0 + 103.3, ±10% headroom
-   (unrealized_pnl     ((min 13500000.0)   (max 19000000.0))))))   ;; encompass 15.9 + 16.7M
+   (open_positions_value ((min 13500000.0) (max 19000000.0))))))  ;; encompass 15.9 + 16.7M (mtm value, NOT true unrealized P&L; see metric_types.mli)

--- a/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
@@ -27,7 +27,7 @@
  (config_overrides (((universe_cap (1000)) (enable_short_side false))))
  ;; Baseline measured 2026-04-29 (long-only):
  ;;   return +35.34% / 167 trades / win_rate 37.13% / Sharpe 0.301 /
- ;;   MaxDD 74.86% / avg_hold 72.6d / unrealized_pnl $1.18M /
+ ;;   MaxDD 74.86% / avg_hold 72.6d / open_positions_value $1.18M /
  ;;   peak RSS 1,722 MB / wall 3:00.
  (expected
   ((total_return_pct   ((min 30.0)         (max 41.0)))     ;; ±15% around 35.3
@@ -36,4 +36,4 @@
    (sharpe_ratio       ((min 0.15)         (max 0.45)))     ;; small absolute, wider relative
    (max_drawdown_pct   ((min 67.5)         (max 82.5)))     ;; ±10% around 74.9
    (avg_holding_days   ((min 65.0)         (max 80.0)))     ;; ±10% around 72.6
-   (unrealized_pnl     ((min 999000.0)     (max 1352000.0))))))   ;; ±15% around 1.18M
+   (open_positions_value ((min 999000.0)   (max 1352000.0))))))  ;; ±15% around $1.18M (mtm value, NOT true unrealized P&L; see metric_types.mli)

--- a/trading/test_data/backtest_scenarios/goldens-broad/sp500-30y-capacity-1996.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/sp500-30y-capacity-1996.sexp
@@ -52,4 +52,4 @@
    (sharpe_ratio       ((min -10.0)        (max 10.0)))
    (max_drawdown_pct   ((min 0.0)          (max 100.0)))
    (avg_holding_days   ((min 0.0)          (max 10000.0)))
-   (unrealized_pnl     ((min -1000000000.0) (max 100000000000.0))))))
+   (open_positions_value ((min -1000000000.0) (max 100000000000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-small/bull-crash-2015-2020.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-small/bull-crash-2015-2020.sexp
@@ -9,7 +9,7 @@
 ;;   final_portfolio_value ~4.39M        total_return_pct ~339
 ;;   total_trades 15 (= n_round_trips)   win_rate ~37
 ;;   sharpe_ratio ~1.04                  max_drawdown_pct ~37
-;;   avg_holding_days ~101               unrealized_pnl ~4.37M
+;;   avg_holding_days ~101               open_positions_value ~4.37M
 ;;
 ;; Pre-#409 the count was 6 round-trips because once a symbol's position
 ;; closed it was blacklisted from re-entry (bug). Post-#409, symbols cycle
@@ -22,8 +22,10 @@
 ;; Ranges are wider than observed values to absorb Hashtbl iteration ordering
 ;; noise (see PR #298).
 ;;
-;; [unrealized_pnl] range is wide: goal is to catch regression to exactly 0
-;; (PR #393's fix).
+;; [open_positions_value] range is wide: goal is to catch regression to
+;; exactly 0 (PR #393's fix). (Pre-rename this pin was named
+;; [unrealized_pnl] but matched mtm-value semantics; see metric_types.mli
+;; for the corrected meaning.)
 ((name "bull-crash-2015-2020")
  (description "Strong bull market through the 2020 crash")
  (period ((start_date 2015-01-02) (end_date 2020-12-31)))
@@ -36,4 +38,4 @@
    (sharpe_ratio       ((min 0.60)  (max 1.40)))
    (max_drawdown_pct   ((min 30.0)  (max 45.0)))
    (avg_holding_days   ((min 80.0)  (max 140.0)))
-   (unrealized_pnl     ((min 1000.0) (max 6000000.0))))))
+   (open_positions_value ((min 1000.0) (max 6000000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-small/covid-recovery-2020-2024.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-small/covid-recovery-2020-2024.sexp
@@ -9,7 +9,7 @@
 ;;   final_portfolio_value ~1.08M        total_return_pct ~8
 ;;   total_trades 21 (= n_round_trips)   win_rate ~31
 ;;   sharpe_ratio ~0.17                  max_drawdown_pct ~36
-;;   avg_holding_days ~70                unrealized_pnl ~0.86M
+;;   avg_holding_days ~70                open_positions_value ~0.86M
 ;;
 ;; Pre-#409 the count was 8 round-trips; post-#409, symbols cycle
 ;; multiple times through the 2020 crash + 2022 correction. Return is
@@ -20,8 +20,10 @@
 ;;
 ;; Previous baseline (1,654 stocks, 2026-04-13) preserved in git history.
 ;;
-;; [unrealized_pnl] range is wide: goal is to catch regression to exactly 0
-;; (PR #393's fix).
+;; [open_positions_value] range is wide: goal is to catch regression to
+;; exactly 0 (PR #393's fix). (Pre-rename this pin was named
+;; [unrealized_pnl] but matched mtm-value semantics; see metric_types.mli
+;; for the corrected meaning.)
 ((name "covid-recovery-2020-2024")
  (description "COVID crash and recovery through 2024")
  (period ((start_date 2020-01-02) (end_date 2024-12-31)))
@@ -34,4 +36,4 @@
    (sharpe_ratio       ((min -0.3)  (max 0.80)))
    (max_drawdown_pct   ((min 25.0)  (max 45.0)))
    (avg_holding_days   ((min 55.0)  (max 120.0)))
-   (unrealized_pnl     ((min 1000.0) (max 2500000.0))))))
+   (open_positions_value ((min 1000.0) (max 2500000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-small/six-year-2018-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-small/six-year-2018-2023.sexp
@@ -9,7 +9,7 @@
 ;;   final_portfolio_value ~1.84M        total_return_pct ~84
 ;;   total_trades 19 (= n_round_trips)   win_rate ~33
 ;;   sharpe_ratio ~0.66                  max_drawdown_pct ~24
-;;   avg_holding_days ~74                unrealized_pnl ~1.81M
+;;   avg_holding_days ~74                open_positions_value ~1.81M
 ;;
 ;; Pre-#409 the count was 7 round-trips with total_return ~145 (most of
 ;; the gain parked in stuck-open positions from 2018). Post-#409 the
@@ -22,8 +22,10 @@
 ;;
 ;; Previous baseline (1,654 stocks, 2026-04-13) preserved in git history.
 ;;
-;; [unrealized_pnl] range is wide: goal is to catch regression to exactly 0
-;; (PR #393's fix) while tolerating drift as the small universe is re-curated.
+;; [open_positions_value] range is wide: goal is to catch regression to
+;; exactly 0 (PR #393's fix) while tolerating drift as the small universe is
+;; re-curated. (Pre-rename this pin was named [unrealized_pnl] but matched the
+;; mtm-value semantics now exposed under [Metric_types.OpenPositionsValue].)
 ((name "six-year-2018-2023")
  (description "6-year run covering COVID crash and recovery")
  (period ((start_date 2018-01-02) (end_date 2023-12-29)))
@@ -36,4 +38,4 @@
    (sharpe_ratio       ((min 0.30)  (max 1.30)))
    (max_drawdown_pct   ((min 18.0)  (max 35.0)))
    (avg_holding_days   ((min 55.0)  (max 100.0)))
-   (unrealized_pnl     ((min 1000.0) (max 4000000.0))))))
+   (open_positions_value ((min 1000.0) (max 4000000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
@@ -28,7 +28,13 @@
 ;; Current measured baseline 2026-05-01 (post-G12+G13, pre-G14/G15):
 ;;   total_return_pct  65.03   total_trades 136   win_rate 37.50
 ;;   sharpe_ratio       0.62   max_drawdown 31.78  avg_holding_days 69.51
-;;   unrealized_pnl 1,481,963  force_liquidations 6 (all Per_position, G14)
+;;   open_positions_value 1,481,963  force_liquidations 6 (all Per_position, G14)
+;;
+;; (Pre-rename the [unrealized_pnl] field above carried mtm-value semantics —
+;; the same quantity now exposed as [Metric_types.OpenPositionsValue]. The
+;; corrected [UnrealizedPnl] metric (open positions value minus cost basis)
+;; was first emitted in PR feat/metrics-unrealized-pnl-rename; on the
+;; long-only baseline measured 2026-04-30 it was +$421,922.)
 ;;
 ;; The 31.8% MaxDD vs the pin's 3..9% target reflects the strategy's
 ;; drawdown profile WITHOUT the (spurious) Portfolio_floor brake. Whether
@@ -47,4 +53,4 @@
    (sharpe_ratio       ((min -0.5)        (max  0.5)))
    (max_drawdown_pct   ((min 3.0)         (max  9.0)))
    (avg_holding_days   ((min 37.0)        (max  50.0)))
-   (unrealized_pnl     ((min 330000.0)    (max  450000.0))))))
+   (open_positions_value ((min 330000.0)  (max  450000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp
@@ -23,7 +23,14 @@
 ;; Measured baseline (2026-04-30, post-#710 G9 fix):
 ;;   total_return_pct  -0.01  total_trades 32   win_rate 37.50
 ;;   sharpe_ratio       0.01  max_drawdown 5.81  avg_holding_days 43.03
-;;   unrealized_pnl     391,949   force_liquidations 0
+;;   open_positions_value 391,949   force_liquidations 0
+;;
+;; (Pre-rename: this metric was named [unrealized_pnl] but its semantics
+;; matched the renamed [Metric_types.OpenPositionsValue] — signed mtm value
+;; of open positions, NOT true paper P&L. The rename in PR
+;; feat/metrics-unrealized-pnl-rename clarifies the distinction; the
+;; corrected [UnrealizedPnl] metric (= OpenPositionsValue minus position
+;; cost basis) is now also emitted but not yet pinned here.)
 ;;
 ;; The S&P 500 is a moving target; the universe sexp is a fixed snapshot
 ;; so reruns are reproducible. Refresh the universe via the build script
@@ -41,4 +48,4 @@
    (sharpe_ratio       ((min -0.5)        (max  0.5)))
    (max_drawdown_pct   ((min 3.0)         (max  9.0)))
    (avg_holding_days   ((min 37.0)        (max  50.0)))
-   (unrealized_pnl     ((min 330000.0)    (max  450000.0))))))
+   (open_positions_value ((min 330000.0)  (max  450000.0))))))

--- a/trading/test_data/backtest_scenarios/smoke/bull-2019h2.sexp
+++ b/trading/test_data/backtest_scenarios/smoke/bull-2019h2.sexp
@@ -4,10 +4,12 @@
 ;; Smoke scenario: bullish second half of 2019. Runs quickly (~5-10 min).
 ;; Ranges are broad sanity checks, not regression gates.
 ;;
-;; [unrealized_pnl] range is intentionally wide: it catches regression to
-;; exactly 0 (the bug PR #393 fixed) as well as unreasonable values, while
+;; [open_positions_value] range is intentionally wide: it catches regression
+;; to exactly 0 (the bug PR #393 fixed) as well as unreasonable values, while
 ;; tolerating the universe-size flux documented under follow-up #3 in
-;; dev/status/backtest-infra.md.
+;; dev/status/backtest-infra.md. (Pre-rename this pin was named
+;; [unrealized_pnl] but its semantics matched the renamed
+;; [Metric_types.OpenPositionsValue] — signed mtm, not true paper P&L.)
 ((name "bull-2019h2")
  (description "Bull market sanity check (H2 2019)")
  (period ((start_date 2019-06-01) (end_date 2019-12-31)))
@@ -20,4 +22,4 @@
    (sharpe_ratio       ((min -2.0)  (max 5.0)))
    (max_drawdown_pct   ((min 0.0)   (max 30.0)))
    (avg_holding_days   ((min 0.0)   (max 100.0)))
-   (unrealized_pnl     ((min 1000.0) (max 2000000.0))))))
+   (open_positions_value ((min 1000.0) (max 2000000.0))))))

--- a/trading/test_data/backtest_scenarios/smoke/crash-2020h1.sexp
+++ b/trading/test_data/backtest_scenarios/smoke/crash-2020h1.sexp
@@ -4,10 +4,11 @@
 ;; Smoke scenario: first half of 2020 (COVID crash). Runs quickly (~5-10 min).
 ;; Ranges are broad sanity checks, not regression gates.
 ;;
-;; [unrealized_pnl] is NOT pinned here because a crash regime can plausibly
-;; leave the portfolio fully liquidated (all stops hit) OR holding a few
-;; late-stage positions — the end-of-window state is too regime-dependent
-;; to pick a single range. Revisit once follow-up #3 (universe rerun) lands.
+;; [open_positions_value] / [unrealized_pnl] are NOT pinned here because a
+;; crash regime can plausibly leave the portfolio fully liquidated (all stops
+;; hit) OR holding a few late-stage positions — the end-of-window state is
+;; too regime-dependent to pick a single range. Revisit once follow-up #3
+;; (universe rerun) lands.
 ((name "crash-2020h1")
  (description "Crash regime sanity check (H1 2020)")
  (period ((start_date 2020-01-02) (end_date 2020-06-30)))

--- a/trading/test_data/backtest_scenarios/smoke/recovery-2023.sexp
+++ b/trading/test_data/backtest_scenarios/smoke/recovery-2023.sexp
@@ -4,10 +4,12 @@
 ;; Smoke scenario: calendar year 2023 recovery. Runs quickly (~5-10 min).
 ;; Ranges are broad sanity checks, not regression gates.
 ;;
-;; [unrealized_pnl] range is intentionally wide: it catches regression to
-;; exactly 0 (the bug PR #393 fixed) as well as unreasonable values, while
+;; [open_positions_value] range is intentionally wide: it catches regression
+;; to exactly 0 (the bug PR #393 fixed) as well as unreasonable values, while
 ;; tolerating the universe-size flux documented under follow-up #3 in
-;; dev/status/backtest-infra.md.
+;; dev/status/backtest-infra.md. (Pre-rename this pin was named
+;; [unrealized_pnl] but its semantics matched the renamed
+;; [Metric_types.OpenPositionsValue] — signed mtm, not true paper P&L.)
 ((name "recovery-2023")
  (description "Recovery regime sanity check (2023)")
  (period ((start_date 2023-01-02) (end_date 2023-12-31)))
@@ -20,4 +22,4 @@
    (sharpe_ratio       ((min -2.0)  (max 5.0)))
    (max_drawdown_pct   ((min 0.0)   (max 40.0)))
    (avg_holding_days   ((min 0.0)   (max 100.0)))
-   (unrealized_pnl     ((min 1000.0) (max 2000000.0))))))
+   (open_positions_value ((min 1000.0) (max 2000000.0))))))

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -37,12 +37,12 @@ type result = {
     [portfolio_value = cash] even when positions are open.
 
     Important: this heuristic exists only for mark-to-market aware consumers
-    such as [UnrealizedPnl]. It must NOT be applied to round-trip extraction —
-    round-trips are derived from position-state transitions (fills), which are
-    recorded independently of whether the portfolio's mark-to-market view is
-    populated that day. Applying this filter before
-    [Metrics.extract_round_trips] silently drops every trade whose entry *and*
-    exit landed on steps where [portfolio_value ~ cash], which happens for
+    such as [OpenPositionsValue] / [UnrealizedPnl]. It must NOT be applied to
+    round-trip extraction — round-trips are derived from position-state
+    transitions (fills), which are recorded independently of whether the
+    portfolio's mark-to-market view is populated that day. Applying this filter
+    before [Metrics.extract_round_trips] silently drops every trade whose entry
+    *and* exit landed on steps where [portfolio_value ~ cash], which happens for
     instance when the only non-[Holding] positions are [Entering]/[Closed] (they
     contribute 0.0 to [Portfolio_view.portfolio_value]). *)
 let is_trading_day (step : Trading_simulation_types.Simulator_types.step_result)
@@ -437,7 +437,8 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
       ~f:(fun (s : Trading_simulation_types.Simulator_types.step_result) ->
         Date.( >= ) s.date start_date)
   in
-  (* Steps on real trading days only — used for [UnrealizedPnl] consumers and
+  (* Steps on real trading days only — used for [OpenPositionsValue] /
+     [UnrealizedPnl] consumers and
      anything else that needs a meaningful mark-to-market portfolio value.
      Simulator reports [portfolio_value = cash] on weekends/holidays even
      when positions are open, so filter them out before mark-to-market

--- a/trading/trading/backtest/release_report/release_report.ml
+++ b/trading/trading/backtest/release_report/release_report.ml
@@ -7,7 +7,13 @@ type actual = {
   sharpe_ratio : float;
   max_drawdown_pct : float;
   avg_holding_days : float;
+  open_positions_value : float option; [@sexp.option]
+      (** Post-rename signed mark-to-market value of open positions. Optional
+          for backward compat with actual.sexp files written before the rename
+          (those carry the same value under [unrealized_pnl] instead). *)
   unrealized_pnl : float option; [@sexp.option]
+      (** Post-rename: true unrealized P&L (OpenPositionsValue - cost basis).
+          Pre-rename actual.sexp files carry the legacy mtm-value here. *)
   force_liquidations_count : int; [@sexp.default 0]
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]

--- a/trading/trading/backtest/release_report/release_report.mli
+++ b/trading/trading/backtest/release_report/release_report.mli
@@ -39,15 +39,17 @@ type actual = {
   sharpe_ratio : float;
   max_drawdown_pct : float;
   avg_holding_days : float;
+  open_positions_value : float option;
   unrealized_pnl : float option;
   force_liquidations_count : int;
 }
 [@@deriving sexp]
 (** Trading metrics extracted from a scenario's [actual.sexp]. Mirrors the
     fields written by [scenario_runner.ml]'s [_actual_of_result], with
-    [unrealized_pnl] optional for backward-compat with pre-#393 actuals that
-    omit the field, and [force_liquidations_count] defaulting to [0] for
-    backward-compat with pre-G4 actuals that omit the field. *)
+    [open_positions_value] / [unrealized_pnl] optional for backward-compat with
+    pre-rename / pre-#393 actuals that omit one or both, and
+    [force_liquidations_count] defaulting to [0] for backward-compat with pre-G4
+    actuals that omit the field. *)
 
 type summary_meta = {
   start_date : Date.t;

--- a/trading/trading/backtest/scenarios/scenario.ml
+++ b/trading/trading/backtest/scenarios/scenario.ml
@@ -42,6 +42,7 @@ type expected = {
   sharpe_ratio : range;
   max_drawdown_pct : range;
   avg_holding_days : range;
+  open_positions_value : range option; [@sexp.option]
   unrealized_pnl : range option; [@sexp.option]
 }
 [@@deriving sexp]

--- a/trading/trading/backtest/scenarios/scenario.mli
+++ b/trading/trading/backtest/scenarios/scenario.mli
@@ -17,12 +17,23 @@ type expected = {
   sharpe_ratio : range;
   max_drawdown_pct : range;
   avg_holding_days : range;
-  unrealized_pnl : range option; [@sexp.option]
-      (** Dollar range for end-of-simulation unrealized P&L. [None] skips the
+  open_positions_value : range option; [@sexp.option]
+      (** Dollar range for the end-of-simulation
+          [Metric_types.OpenPositionsValue] metric — the signed mark-to-market
+          value of open positions (= [portfolio_value - cash]). [None] skips the
           check — use for scenarios where no positions remain open at the end or
           where the value is otherwise not meaningful to pin. Scenarios with
           open positions should pin a non-zero range to guard against regression
-          to the UnrealizedPnl=0 bug (see PR #393). *)
+          to the [OpenPositionsValue=0] bug (see PR #393). NOTE: pre-rename
+          scenario files used [unrealized_pnl] for this same value; the rename
+          to [open_positions_value] reflects the corrected metric semantics
+          (mark-to-market value vs true unrealized P&L). *)
+  unrealized_pnl : range option; [@sexp.option]
+      (** Dollar range for the end-of-simulation [Metric_types.UnrealizedPnl]
+          metric — true paper P&L on open positions, computed as
+          [OpenPositionsValue - Σ position_cost_basis]. [None] skips the check.
+          Optional even when [open_positions_value] is pinned — populate when an
+          empirical baseline justifies a tight range. *)
 }
 [@@deriving sexp]
 

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -49,7 +49,13 @@ type actual = {
   sharpe_ratio : float;
   max_drawdown_pct : float;
   avg_holding_days : float;
+  open_positions_value : float; [@sexp.default Float.nan]
+      (* Signed mark-to-market value of open positions at run end. Defaults to
+         NaN on read so pre-rename actual.sexp files (which used the
+         [unrealized_pnl] field for this same quantity) still parse. *)
   unrealized_pnl : float;
+      (* Post-rename: true unrealized P&L (OpenPositionsValue - cost basis).
+         Pre-rename actual.sexp files carry the legacy mtm-value here. *)
   force_liquidations_count : int; [@sexp.default 0]
       (* G4 (force-liquidation policy). Defaults to 0 on read so pre-G4
          actual.sexp files that don't carry the field still parse. *)
@@ -68,6 +74,7 @@ let _actual_of_result (r : Backtest.Runner.result) =
     sharpe_ratio = get SharpeRatio;
     max_drawdown_pct = get MaxDrawdown;
     avg_holding_days = get AvgHoldingDays;
+    open_positions_value = get OpenPositionsValue;
     unrealized_pnl = get UnrealizedPnl;
     force_liquidations_count = List.length r.force_liquidations;
   }
@@ -91,9 +98,17 @@ let _run_checks (a : actual) (e : Scenario.expected) =
       _check_one "avg_holding_days" a.avg_holding_days e.avg_holding_days;
     ]
   in
+  let with_opv =
+    match e.open_positions_value with
+    | None -> base
+    | Some range ->
+        base
+        @ [ _check_one "open_positions_value" a.open_positions_value range ]
+  in
   match e.unrealized_pnl with
-  | None -> base
-  | Some range -> base @ [ _check_one "unrealized_pnl" a.unrealized_pnl range ]
+  | None -> with_opv
+  | Some range ->
+      with_opv @ [ _check_one "unrealized_pnl" a.unrealized_pnl range ]
 
 let _failure_message checks =
   List.filter checks ~f:(fun c -> not c.ok)

--- a/trading/trading/backtest/scenarios/test/test_scenario.ml
+++ b/trading/trading/backtest/scenarios/test/test_scenario.ml
@@ -67,8 +67,8 @@ let test_unrealized_pnl_roundtrip _ =
           ]))
 
 (* Sanity check: every real scenario file under [trading/test_data/backtest_scenarios]
-   must parse. The new [unrealized_pnl] field is optional, so scenarios both with
-   and without it must be accepted. *)
+   must parse. Both [open_positions_value] and [unrealized_pnl] are optional,
+   so scenarios with neither, either, or both must be accepted. *)
 let _scenarios_root () =
   (* Under [dune runtest], cwd is
      [_build/default/trading/backtest/scenarios/test]; the test data lives at
@@ -117,16 +117,20 @@ let test_all_scenario_files_parse _ =
         (sprintf "expected >=6 scenario files, found %d in %s"
            (List.length files) root)
         (List.length files >= 6);
-      (* At least one scenario should have a pinned [unrealized_pnl] range
-         excluding zero — this is the regression guard for PR #393. *)
+      (* At least one scenario should have a pinned [open_positions_value]
+         range excluding zero — this is the regression guard for PR #393.
+         (Pre-rename this guard checked [unrealized_pnl]; after the rename
+         the same regression class lives under [open_positions_value] since
+         that's the metric whose semantic regression to 0 PR #393 fixed.) *)
       let with_nonzero_pin =
         List.filter_map files ~f:(fun path ->
             let s = Scenario.load path in
-            match s.expected.unrealized_pnl with
+            match s.expected.open_positions_value with
             | Some r when Float.(r.min_f > 0.0) -> Some s.name
             | _ -> None)
       in
-      assert_bool "expected >=1 scenario pinning unrealized_pnl with min > 0"
+      assert_bool
+        "expected >=1 scenario pinning open_positions_value with min > 0"
         (not (List.is_empty with_nonzero_pin))
 
 (* Regression guard: a range like [min=1000, max=50000] catches a regression

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -9,8 +9,9 @@ open Matchers
 
 let _make_actual ?(total_return_pct = 12.0) ?(total_trades = 39.0)
     ?(win_rate = 50.0) ?(sharpe_ratio = 0.58) ?(max_drawdown_pct = 13.77)
-    ?(avg_holding_days = 6.07) ?(unrealized_pnl = None)
-    ?(force_liquidations_count = 0) () : Release_report.actual =
+    ?(avg_holding_days = 6.07) ?(open_positions_value = None)
+    ?(unrealized_pnl = None) ?(force_liquidations_count = 0) () :
+    Release_report.actual =
   {
     total_return_pct;
     total_trades;
@@ -18,6 +19,7 @@ let _make_actual ?(total_return_pct = 12.0) ?(total_trades = 39.0)
     sharpe_ratio;
     max_drawdown_pct;
     avg_holding_days;
+    open_positions_value;
     unrealized_pnl;
     force_liquidations_count;
   }

--- a/trading/trading/backtest/test/test_runner_filter.ml
+++ b/trading/trading/backtest/test/test_runner_filter.ml
@@ -1,14 +1,14 @@
 (** Regression tests for the [Runner] step-filtering boundary.
 
     The [is_trading_day] heuristic was introduced by PR #393 so that
-    mark-to-market aware metrics like [UnrealizedPnl] ignore weekend/holiday
-    steps where the simulator falls back to [portfolio_value = cash]. The
-    heuristic was subsequently mis-applied to round-trip extraction, silently
-    dropping ~95% of trades from [trades.csv] on large multi-year runs when
-    entry+exit happened to land on steps that look "non-trading" to the
-    heuristic (e.g. because the only non-[Holding] positions are
-    [Entering]/[Closed], which contribute 0.0 to the mark-to-market portfolio
-    value).
+    mark-to-market aware metrics like [OpenPositionsValue] / [UnrealizedPnl]
+    ignore weekend/holiday steps where the simulator falls back to
+    [portfolio_value = cash]. The heuristic was subsequently mis-applied to
+    round-trip extraction, silently dropping ~95% of trades from [trades.csv] on
+    large multi-year runs when entry+exit happened to land on steps that look
+    "non-trading" to the heuristic (e.g. because the only non-[Holding]
+    positions are [Entering]/[Closed], which contribute 0.0 to the
+    mark-to-market portfolio value).
 
     These tests pin the invariant that round-trip extraction must see steps
     flagged as non-trading by [is_trading_day]. *)

--- a/trading/trading/simulation/lib/metric_computers.ml
+++ b/trading/trading/simulation/lib/metric_computers.ml
@@ -55,7 +55,7 @@ let create_computer (metric_type : Metric_types.metric_type) :
   | MaxDrawdown -> max_drawdown_computer ()
   | CAGR -> cagr_computer ()
   | CalmarRatio -> _calmar_stub ()
-  | OpenPositionCount | UnrealizedPnl | TradeFrequency ->
+  | OpenPositionCount | OpenPositionsValue | UnrealizedPnl | TradeFrequency ->
       portfolio_state_computer ()
 
 (** {1 Default Computer Set} *)

--- a/trading/trading/simulation/lib/metric_computers.mli
+++ b/trading/trading/simulation/lib/metric_computers.mli
@@ -56,7 +56,10 @@ val portfolio_state_computer : unit -> Simulator.any_metric_computer
 
     Metrics produced:
     - OpenPositionCount: Number of open positions at end
-    - UnrealizedPnl: Unrealized P&L (final value - current cash)
+    - OpenPositionsValue: Signed mark-to-market value of open positions (=
+      portfolio_value - current_cash on the last marked-to-market step)
+    - UnrealizedPnl: True paper P&L on open positions (= OpenPositionsValue
+      minus sum of position cost bases; signed-qty form covers longs + shorts)
     - TradeFrequency: Average trades per month *)
 
 (** {1 Default Computer Set} *)

--- a/trading/trading/simulation/lib/portfolio_state_computer.ml
+++ b/trading/trading/simulation/lib/portfolio_state_computer.ml
@@ -1,5 +1,5 @@
 (** Portfolio state metric computer — captures end-of-simulation state:
-    OpenPositionCount, UnrealizedPnl, TradeFrequency. *)
+    OpenPositionCount, OpenPositionsValue, UnrealizedPnl, TradeFrequency. *)
 
 open Core
 module Metric_types = Trading_simulation_types.Metric_types
@@ -15,8 +15,8 @@ type state = {
           position market values). On non-trading days (weekends, holidays) or
           when price bars for open-position symbols are missing, the simulator
           falls back to [portfolio_value = current_cash] — such steps are
-          excluded here so [UnrealizedPnl] reflects actual end-of-sim unrealized
-          P&L. See [_is_marked_to_market]. *)
+          excluded here so [OpenPositionsValue] / [UnrealizedPnl] reflect actual
+          end-of-sim state. See [_is_marked_to_market]. *)
   total_trades : int;
 }
 
@@ -40,20 +40,34 @@ let _trade_frequency ~total_trades ~start_date ~end_date =
   let months = days /. 30.44 in
   if Float.(months <= 0.0) then 0.0 else Float.of_int total_trades /. months
 
+(** Sum of [position_cost_basis] across the portfolio's currently-held
+    positions. For longs this is positive (qty>0 times avg_cost>0); for shorts
+    it is negative (qty<0 times avg_cost>0). Subtracting this signed sum from
+    [OpenPositionsValue] yields the signed-qty unrealized P&L formula in the
+    [UnrealizedPnl] metric description. *)
+let _open_positions_cost_basis (portfolio : Trading_portfolio.Portfolio.t) =
+  List.fold portfolio.positions ~init:0.0 ~f:(fun acc pos ->
+      acc +. Trading_portfolio.Calculations.position_cost_basis pos)
+
 (** Build metric set. [position_step] is the step that determines
     [OpenPositionCount] (always the absolute last step). [marked_step] is the
-    step that determines [UnrealizedPnl] (the last mark-to-market step, which
-    may or may not equal [position_step]). *)
+    step that determines [OpenPositionsValue] / [UnrealizedPnl] (the last
+    mark-to-market step, which may or may not equal [position_step]). *)
 let _metrics_from_step ~(position_step : Simulator_types.step_result)
     ~(marked_step : Simulator_types.step_result) ~total_trades ~start_date
     ~end_date =
+  let open_positions_value =
+    marked_step.portfolio_value
+    -. marked_step.portfolio.Trading_portfolio.Portfolio.current_cash
+  in
+  let cost_basis = _open_positions_cost_basis marked_step.portfolio in
+  let unrealized_pnl = open_positions_value -. cost_basis in
   Metric_types.of_alist_exn
     [
       ( OpenPositionCount,
         Float.of_int (List.length position_step.portfolio.positions) );
-      ( UnrealizedPnl,
-        marked_step.portfolio_value
-        -. marked_step.portfolio.Trading_portfolio.Portfolio.current_cash );
+      (OpenPositionsValue, open_positions_value);
+      (UnrealizedPnl, unrealized_pnl);
       (TradeFrequency, _trade_frequency ~total_trades ~start_date ~end_date);
     ]
 
@@ -71,8 +85,9 @@ let _finalize ~state ~(config : Simulator_types.config) =
   | Some position_step ->
       (* If no step in the sim was marked-to-market (degenerate: e.g. all
          steps were non-trading days with open positions), fall back to the
-         last step. UnrealizedPnl will then be 0 as before — not great, but
-         consistent with pre-fix behaviour for that edge case. *)
+         last step. OpenPositionsValue / UnrealizedPnl will then be 0 as
+         before — not great, but consistent with pre-fix behaviour for that
+         edge case. *)
       let marked_step =
         Option.value state.last_marked_step ~default:position_step
       in

--- a/trading/trading/simulation/lib/portfolio_state_computer.mli
+++ b/trading/trading/simulation/lib/portfolio_state_computer.mli
@@ -1,5 +1,5 @@
-(** Portfolio state metric computer — OpenPositionCount, UnrealizedPnl,
-    TradeFrequency. *)
+(** Portfolio state metric computer — OpenPositionCount, OpenPositionsValue,
+    UnrealizedPnl, TradeFrequency. *)
 
 val computer :
   unit -> Trading_simulation_types.Simulator_types.any_metric_computer

--- a/trading/trading/simulation/lib/types/metric_types.ml
+++ b/trading/trading/simulation/lib/types/metric_types.ml
@@ -18,6 +18,7 @@ module Metric_type = struct
       | CAGR
       | CalmarRatio
       | OpenPositionCount
+      | OpenPositionsValue
       | UnrealizedPnl
       | TradeFrequency
     [@@deriving show, eq, compare, sexp]
@@ -39,6 +40,7 @@ type metric_type = Metric_type.t =
   | CAGR
   | CalmarRatio
   | OpenPositionCount
+  | OpenPositionsValue
   | UnrealizedPnl
   | TradeFrequency
 [@@deriving show, eq, compare, sexp]
@@ -166,16 +168,36 @@ let get_metric_info = function
         description = "Number of open positions at end of simulation";
         unit = Count;
       }
+  | OpenPositionsValue ->
+      {
+        display_name = "Open Positions Value";
+        description =
+          "Signed mark-to-market value of all open positions at end of \
+           simulation. Equals last-marked-to-market portfolio_value minus \
+           current_cash on that step (= sum of [position_quantity(p) * \
+           current_close(p)] across each held position, with long \
+           contributions positive and short contributions negative). Computed \
+           from the most recent step whose portfolio_value actually reflects \
+           position mark-to-market — non-trading days (weekends, holidays, \
+           missing bars) are skipped because the simulator falls back to \
+           portfolio_value = cash on those days. NOT to be confused with \
+           unrealized P&L (see [UnrealizedPnl]) — this metric does not \
+           subtract cost basis.";
+        unit = Dollars;
+      }
   | UnrealizedPnl ->
       {
         display_name = "Unrealized P&L";
         description =
-          "Total unrealized profit/loss at end of simulation: \
-           last-marked-to-market portfolio_value minus current_cash on that \
-           step. Computed from the most recent step whose portfolio_value \
-           actually reflects position mark-to-market — non-trading days \
-           (weekends, holidays, missing bars) are skipped because the \
-           simulator falls back to portfolio_value = cash on those days.";
+          "Total unrealized profit/loss on open positions at end of \
+           simulation: sum of [(current_close(p) - entry_price(p)) * \
+           signed_qty(p)] across each held position, where signed_qty is \
+           positive for longs and negative for shorts. Equivalently: \
+           [OpenPositionsValue] minus the sum of position cost bases. Positive \
+           means paper gains on the open book; negative means paper losses. \
+           Computed from the most recent step whose portfolio_value actually \
+           reflects position mark-to-market — non-trading days are skipped per \
+           the same logic as [OpenPositionsValue].";
         unit = Dollars;
       }
   | TradeFrequency ->

--- a/trading/trading/simulation/lib/types/metric_types.mli
+++ b/trading/trading/simulation/lib/types/metric_types.mli
@@ -22,7 +22,20 @@ module Metric_type : sig
     | CAGR  (** Compound annual growth rate *)
     | CalmarRatio  (** CAGR / max drawdown *)
     | OpenPositionCount  (** Open positions at end of simulation *)
-    | UnrealizedPnl  (** Unrealized P&L at end of simulation *)
+    | OpenPositionsValue
+        (** Signed mark-to-market value of all open positions at end of
+            simulation: [Σ position_quantity(p) * current_close(p)] across each
+            held position. Positive sum dominated by long mark-to-market;
+            negative when shorts dominate. Equal to
+            [portfolio_value - current_cash] on a marked-to-market step. NOT
+            unrealized P&L — that requires subtracting cost basis (see
+            [UnrealizedPnl]). *)
+    | UnrealizedPnl
+        (** True unrealized profit/loss on open positions at end of simulation:
+            [Σ (current_close(p) - entry_price(p)) * signed_qty(p)] across each
+            held position. Equal to [OpenPositionsValue - Σ position_cost_basis]
+            (longs and shorts both fold in via signed quantity). Positive means
+            paper gains on the open book; negative means paper losses. *)
     | TradeFrequency  (** Trades per month *)
   [@@deriving show, eq, compare, sexp]
 
@@ -42,6 +55,7 @@ type metric_type = Metric_type.t =
   | CAGR
   | CalmarRatio
   | OpenPositionCount
+  | OpenPositionsValue
   | UnrealizedPnl
   | TradeFrequency
 [@@deriving show, eq, compare, sexp]

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -900,13 +900,17 @@ let test_portfolio_state_with_trades _ =
   in
   let computer = portfolio_state_computer () in
   let metrics = run_computers ~computers:[ computer ] ~config ~steps in
-  (* 3 total trades across 2 steps *)
+  (* 3 total trades across 2 steps. The portfolio passed into each step is
+     the empty-positions fixture (no held positions), so OpenPositionsValue
+     collapses to [portfolio_value - cash = 50.0] and UnrealizedPnl collapses
+     to the same value (cost basis sum is 0 when no positions are held). *)
   assert_that
     (Map.find metrics TradeFrequency)
     (is_some_and (gt (module Float_ord) 0.0));
   assert_that
     (Map.find metrics OpenPositionCount)
     (is_some_and (float_equal 0.0));
+  assert_that metrics (contains_entry OpenPositionsValue (float_equal 50.0));
   assert_that metrics (contains_entry UnrealizedPnl (float_equal 50.0))
 
 (** Build a portfolio with one open long position by applying a buy trade. *)
@@ -930,12 +934,12 @@ let _portfolio_with_open_position ~symbol ~quantity ~price =
       OUnit2.assert_failure
         ("failed to build test portfolio: " ^ Status.show err)
 
-(** Reproduces the UnrealizedPnl=0 bug. The simulator produces a step every
+(** Reproduces the OpenPositionsValue=0 bug (originally tracked as
+    UnrealizedPnl=0 before the rename). The simulator produces a step every
     calendar day. On the final day (often a weekend), price bars are missing, so
     [_compute_portfolio_value] falls back to [portfolio_value = cash] even
-    though positions are open — leaving a spurious [UnrealizedPnl = 0] in the
-    summary. The computer must skip those steps and use the last real
-    mark-to-market step. *)
+    though positions are open — leaving a spurious zero in the summary. The
+    computer must skip those steps and use the last real mark-to-market step. *)
 let test_portfolio_state_skips_non_trading_final_step _ =
   let config = make_config () in
   let portfolio =
@@ -967,14 +971,19 @@ let test_portfolio_state_skips_non_trading_final_step _ =
   in
   let computer = portfolio_state_computer () in
   let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  (* 1 long position, qty=10, entry $100, current $105:
+     - OpenPositionsValue = mtm_value - cash = 1050.0 (10 * $105)
+     - cost_basis sum = 10 * $100 = 1000.0
+     - UnrealizedPnl = OpenPositionsValue - cost_basis = 50.0 (10 * $5 gain) *)
   assert_that metrics
     (map_includes
        [
          (* OpenPositionCount still comes from the absolute final step
             (positions don't depend on price bars). *)
          (OpenPositionCount, float_equal 1.0);
-         (* UnrealizedPnl derived from the last marked-to-market step. *)
-         (UnrealizedPnl, float_equal (mtm_value -. cash));
+         (* OpenPositionsValue derived from the last marked-to-market step. *)
+         (OpenPositionsValue, float_equal (mtm_value -. cash));
+         (UnrealizedPnl, float_equal 50.0);
        ])
 
 (** Guard: when every step is marked-to-market, the final step wins unchanged.
@@ -1007,10 +1016,181 @@ let test_portfolio_state_uses_last_step_when_all_trading_days _ =
   in
   let computer = portfolio_state_computer () in
   let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  (* 1 long position, qty=10, entry $100. Final step pins
+     OpenPositionsValue = 800.0 (= portfolio_value - cash). cost_basis = 10 *
+     $100 = 1000.0, so UnrealizedPnl = 800 - 1000 = -200.0 — the
+     hand-constructed final mtm represents an $80/share mark, i.e. a $20/share
+     paper loss. *)
   assert_that metrics
     (map_includes
        [
-         (OpenPositionCount, float_equal 1.0); (UnrealizedPnl, float_equal 800.0);
+         (OpenPositionCount, float_equal 1.0);
+         (OpenPositionsValue, float_equal 800.0);
+         (UnrealizedPnl, float_equal (-200.0));
+       ])
+
+(** Round-trip the new [OpenPositionsValue] / [UnrealizedPnl] split through the
+    full long-only formula on a single Holding position: enter at $100, current
+    bar $130, qty 100. *)
+let test_portfolio_state_long_unrealized_pnl _ =
+  let config = make_config () in
+  let portfolio =
+    _portfolio_with_open_position ~symbol:"BULL" ~quantity:100.0 ~price:100.0
+  in
+  let cash = portfolio.current_cash in
+  let current_price = 130.0 in
+  let portfolio_value = cash +. (100.0 *. current_price) in
+  let steps =
+    [
+      {
+        date = date_of_string "2024-01-05";
+        portfolio;
+        portfolio_value;
+        trades = [];
+        orders_submitted = [];
+        splits_applied = [];
+      };
+    ]
+  in
+  let computer = portfolio_state_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  (* 100 shares of BULL @ entry $100, current $130:
+     - OpenPositionsValue = 100 * $130 = $13,000
+     - UnrealizedPnl = (130 - 100) * 100 = +$3,000 *)
+  assert_that metrics
+    (map_includes
+       [
+         (OpenPositionCount, float_equal 1.0);
+         (OpenPositionsValue, float_equal 13_000.0);
+         (UnrealizedPnl, float_equal 3_000.0);
+       ])
+
+(** Build a portfolio with one open short position by applying a sell trade.
+    Mirror of [_portfolio_with_open_position] for the short side. *)
+let _portfolio_with_open_short ~symbol ~quantity ~price =
+  let base = Trading_portfolio.Portfolio.create ~initial_cash:10000.0 () in
+  let sell =
+    {
+      Trading_base.Types.id = "s1";
+      order_id = "o1";
+      symbol;
+      side = Sell;
+      quantity;
+      price;
+      commission = 0.0;
+      timestamp = Time_ns_unix.now ();
+    }
+  in
+  match Trading_portfolio.Portfolio.apply_single_trade base sell with
+  | Ok p -> p
+  | Error err ->
+      OUnit2.assert_failure
+        ("failed to build short test portfolio: " ^ Status.show err)
+
+(** Short-side counterpart: enter short at $100, current bar $80, qty 100.
+    OpenPositionsValue is signed-negative; UnrealizedPnl is positive (shorts
+    profit on price drops). *)
+let test_portfolio_state_short_unrealized_pnl _ =
+  let config = make_config () in
+  let portfolio =
+    _portfolio_with_open_short ~symbol:"BEAR" ~quantity:100.0 ~price:100.0
+  in
+  let cash = portfolio.current_cash in
+  let current_price = 80.0 in
+  (* signed_qty = -100 ; market_value contribution = -100 * 80 = -$8,000. *)
+  let portfolio_value = cash +. (-100.0 *. current_price) in
+  let steps =
+    [
+      {
+        date = date_of_string "2024-01-05";
+        portfolio;
+        portfolio_value;
+        trades = [];
+        orders_submitted = [];
+        splits_applied = [];
+      };
+    ]
+  in
+  let computer = portfolio_state_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  (* 100 shares short BEAR @ entry $100, current $80:
+     - OpenPositionsValue = -100 * $80 = -$8,000 (signed: shorts contribute
+       negative mtm)
+     - UnrealizedPnl = (80 - 100) * (-100) = +$2,000 (short gains $20/share) *)
+  assert_that metrics
+    (map_includes
+       [
+         (OpenPositionCount, float_equal 1.0);
+         (OpenPositionsValue, float_equal (-8_000.0));
+         (UnrealizedPnl, float_equal 2_000.0);
+       ])
+
+(** Mixed-portfolio guard: one long + one short, hand-pinned via arithmetic.
+    Confirms the signed-qty formula composes additively across positions. *)
+let test_portfolio_state_mixed_unrealized_pnl _ =
+  let config = make_config () in
+  let base = Trading_portfolio.Portfolio.create ~initial_cash:100_000.0 () in
+  let buy =
+    {
+      Trading_base.Types.id = "b1";
+      order_id = "ob";
+      symbol = "BULL";
+      side = Buy;
+      quantity = 100.0;
+      price = 100.0;
+      commission = 0.0;
+      timestamp = Time_ns_unix.now ();
+    }
+  in
+  let sell =
+    {
+      Trading_base.Types.id = "s1";
+      order_id = "os";
+      symbol = "BEAR";
+      side = Sell;
+      quantity = 50.0;
+      price = 200.0;
+      commission = 0.0;
+      timestamp = Time_ns_unix.now ();
+    }
+  in
+  let portfolio =
+    match Trading_portfolio.Portfolio.apply_trades base [ buy; sell ] with
+    | Ok p -> p
+    | Error err ->
+        OUnit2.assert_failure
+          ("failed to build mixed test portfolio: " ^ Status.show err)
+  in
+  let cash = portfolio.current_cash in
+  (* BULL current $130 (long winner): mtm contribution = 100 * 130 = +$13,000;
+     UnrealizedPnl_BULL = (130-100) * 100 = +$3,000.
+     BEAR current $250 (short loser, price went UP): mtm contribution =
+     -50 * 250 = -$12,500; UnrealizedPnl_BEAR = (250-200) * -50 = -$2,500. *)
+  let bull_mtm = 100.0 *. 130.0 in
+  let bear_mtm = -50.0 *. 250.0 in
+  let portfolio_value = cash +. bull_mtm +. bear_mtm in
+  let steps =
+    [
+      {
+        date = date_of_string "2024-01-05";
+        portfolio;
+        portfolio_value;
+        trades = [];
+        orders_submitted = [];
+        splits_applied = [];
+      };
+    ]
+  in
+  let computer = portfolio_state_computer () in
+  let metrics = run_computers ~computers:[ computer ] ~config ~steps in
+  assert_that metrics
+    (map_includes
+       [
+         (OpenPositionCount, float_equal 2.0);
+         (* +$13,000 + (-$12,500) = +$500 *)
+         (OpenPositionsValue, float_equal 500.0);
+         (* +$3,000 + (-$2,500) = +$500 *)
+         (UnrealizedPnl, float_equal 500.0);
        ])
 
 (* ==================== Test Suite ==================== *)
@@ -1093,6 +1273,12 @@ let suite =
          >:: test_portfolio_state_skips_non_trading_final_step;
          "portfolio state uses last step when all trading days"
          >:: test_portfolio_state_uses_last_step_when_all_trading_days;
+         "portfolio state long unrealized pnl"
+         >:: test_portfolio_state_long_unrealized_pnl;
+         "portfolio state short unrealized pnl"
+         >:: test_portfolio_state_short_unrealized_pnl;
+         "portfolio state mixed unrealized pnl"
+         >:: test_portfolio_state_mixed_unrealized_pnl;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

The existing \`UnrealizedPnl\` metric was computed as \`final_portfolio_value - current_cash\` and named "UnrealizedPnl" — but that quantity is the **mark-to-market value of open positions** (signed across longs and shorts), NOT unrealized P&L (gain/loss vs cost basis). The naming caused confusion mid-session when \`unrealized_pnl=1,307,974\` on a $1.32M portfolio looked like $1.3M of paper profit; the actual paper P&L on open positions was ~$422K, with the rest being the cash that bought the positions sitting as mtm value.

This PR:
- Renames the existing metric to \`OpenPositionsValue\` (semantics preserved: signed mtm sum across open positions).
- Adds a NEW \`UnrealizedPnl\` metric with corrected semantics: \`Σ (current - entry) * signed_qty\` across each held position. Equivalently \`OpenPositionsValue - Σ position_cost_basis\` — both formulations agree, the second is what the implementation uses.
- Renames the \`unrealized_pnl\` pin key to \`open_positions_value\` in all 13 scenario sexp files (the existing pins matched mtm-value semantics, so ranges stay the same).
- Adds long / short / mixed-portfolio tests pinning the new arithmetic:
  - long: entry \$100 / current \$130 / qty 100 → \`OpenPositionsValue=\$13,000\`, \`UnrealizedPnl=+\$3,000\`
  - short: entry \$100 / current \$80 / qty 100 → \`OpenPositionsValue=-\$8,000\`, \`UnrealizedPnl=+\$2,000\` (shorts profit on price drops)
  - mixed long+short: pinned arithmetically.

## Empirical re-run

Long-only \`sp500-2019-2023\` (today's reconciliation):
\`\`\`
realized:                  -\$161,606
open_positions_value:      \$1,254,325   (mtm value of open positions)
unrealized_pnl (NEW):      +\$421,922    (= mtm - cost basis = real paper P&L)
\`\`\`

Note for the with-shorts \`sp500-2019-2023\` baseline (\`open_positions_value=\$1,307,974\` per the bug report), the new \`unrealized_pnl\` value depends on the cost-basis snapshot of open positions, which can be reconstructed via \`open_positions.csv + entry_price\` — left as a follow-up to add a tight \`unrealized_pnl\` pin once it's measured. The \`open_positions_value\` pin already guards regression to 0 (the original PR #393 invariant) under its new key.

## Files touched

- \`trading/simulation/lib/types/metric_types.{ml,mli}\` — new variant + descriptions
- \`trading/simulation/lib/portfolio_state_computer.{ml,mli}\` — emits both metrics
- \`trading/simulation/lib/metric_computers.{ml,mli}\` — factory + docstring
- \`trading/backtest/scenarios/scenario.{ml,mli}\` — \`open_positions_value\` and \`unrealized_pnl\` both optional pin fields
- \`trading/backtest/scenarios/scenario_runner.ml\` — emit both fields in \`actual.sexp\`, gate both checks
- \`trading/backtest/release_report/release_report.{ml,mli}\` — new optional \`open_positions_value\` field
- \`trading/backtest/lib/runner.ml\` + \`trading/backtest/test/test_runner_filter.ml\` — comment updates referencing the new metric names
- \`trading/test_data/backtest_scenarios/**/*.sexp\` — 13 scenario files: rename \`unrealized_pnl\` pin → \`open_positions_value\`, preserving range
- \`trading/simulation/test/test_metrics.ml\` — update existing portfolio-state tests + add long / short / mixed tests
- \`trading/backtest/scenarios/test/test_scenario.ml\` — regression guard now checks \`open_positions_value\`
- \`trading/backtest/test/test_release_perf_report.ml\` — thread new field through synthetic builder

## Test plan

- [x] \`dune build\` clean
- [x] \`dune fmt\` (no diff)
- [x] \`dune runtest trading/simulation/test\` — passes (46 tests, including 3 new portfolio-state tests)
- [x] \`dune runtest trading/backtest/scenarios/test\` — passes
- [x] \`dune runtest trading/backtest/test\` — passes
- [ ] Run sp500 long-only + with-shorts to verify the renamed pins still PASS (deferred — pre-existing pin ranges and value semantics are preserved by the rename)

## Constraints respected

- Per \`.claude/rules/qc-structural-authority.md\`: this is metric/reporting infrastructure — does NOT touch core modules (Portfolio/Orders/Position/Strategy/Engine).
- Per \`.claude/rules/worktree-isolation.md\`: branch built fresh off \`origin/main\`; \`git status\` shows only intended files in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)