### PR TITLE
feat(portfolio_risk): add max_position_pct=0.20 per-position cap

### DIFF
--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
@@ -32,6 +32,11 @@ type limit_violation =
   | Risk_too_high of float
 [@@deriving show]
 
+(* Named default for [max_position_pct] so the [@sexp.default] attribute
+   below references a binding rather than a bare numeric literal — the
+   magic-number linter accepts named constants but flags inline floats. *)
+let default_max_position_pct = 0.20
+
 type config = {
   risk_per_trade_pct : float;
   max_positions : int;
@@ -39,6 +44,7 @@ type config = {
   max_short_exposure_pct : float;
   max_short_notional_fraction : float;
   min_cash_pct : float;
+  max_position_pct : float; [@sexp.default default_max_position_pct]
   max_sector_concentration : int;
   max_unknown_sector_positions : int;
   big_winner_multiplier : float;
@@ -55,6 +61,7 @@ let default_config =
     max_short_exposure_pct = 0.30;
     max_short_notional_fraction = 0.30;
     min_cash_pct = 0.10;
+    max_position_pct = default_max_position_pct;
     max_sector_concentration = 5;
     max_unknown_sector_positions = 2;
     big_winner_multiplier = 1.5;
@@ -132,15 +139,20 @@ let snapshot_of_portfolio ~portfolio ~prices ?(sectors = []) () =
    relative to dollar_risk produces an unbounded share count, allowing single
    positions whose notional dwarfs portfolio_value (observed: ABBV short at 124%
    of $1M starting portfolio, sp500-2019-2023 rerun 2026-04-30). *)
-let _max_shares_by_exposure ~config ~side ~portfolio_value ~entry_price =
-  let max_pct =
+(* Extended to also cap per-position notional at [portfolio_value *.
+   config.max_position_pct]. Per-position concentration sat well above the
+   side-exposure cap; the [min()] of both caps tightens this. *)
+let _max_shares_by_caps ~config ~side ~portfolio_value ~entry_price =
+  let exposure_pct =
     match side with
     | `Long -> config.max_long_exposure_pct
     | `Short -> config.max_short_exposure_pct
   in
-  let max_position_value = portfolio_value *. max_pct in
+  let exposure_cap = portfolio_value *. exposure_pct in
+  let position_cap = portfolio_value *. config.max_position_pct in
+  let dollar_cap = Float.min exposure_cap position_cap in
   if Float.( <= ) entry_price 0.0 then Int.max_value
-  else Int.of_float (Float.round_down (max_position_value /. entry_price))
+  else Int.of_float (Float.round_down (dollar_cap /. entry_price))
 
 let compute_position_size ~config ~portfolio_value ~side ~entry_price
     ~stop_price ?(big_winner = false) () =
@@ -168,7 +180,7 @@ let compute_position_size ~config ~portfolio_value ~side ~entry_price
       Int.of_float (Float.round_down (dollar_risk /. risk_per_share))
     in
     let exposure_capped_shares =
-      _max_shares_by_exposure ~config ~side ~portfolio_value ~entry_price
+      _max_shares_by_caps ~config ~side ~portfolio_value ~entry_price
     in
     let shares = Int.min risk_based_shares exposure_capped_shares in
     let position_value = Float.of_int shares *. entry_price in

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
@@ -102,6 +102,12 @@ type sizing_result = {
 
 (** {1 Configuration} *)
 
+val default_max_position_pct : float
+(** Default per-position concentration cap (0.20 = 20% of portfolio_value).
+    Exposed as a binding so the [@sexp.default] attribute on
+    [config.max_position_pct] can reference it by name — the magic-number linter
+    accepts named constants in attributes but flags inline floats. *)
+
 type config = {
   risk_per_trade_pct : float;
       (** Fraction of portfolio to risk per trade (default: 0.01 = 1%) *)
@@ -127,7 +133,22 @@ type config = {
           inflation of [portfolio_value] doesn't size around the cap. Default:
           0.30 (30% of portfolio_value). *)
   min_cash_pct : float;
-      (** Minimum cash fraction to maintain (default: 0.10 = 10%) *)
+      (** Minimum cash fraction to maintain (default: 0.10 = 10%).
+
+          {b Deprecated as of 2026-05-01:} never wired into the entry walk's
+          [check_cash_and_deduct]. Cash discipline is now handled by
+          [max_position_pct × max_positions] + macro gating + force-liquidation
+          thresholds. Field retained for sexp compat. *)
+  max_position_pct : float; [@sexp.default default_max_position_pct]
+      (** Per-position concentration cap. Caps EACH new position at
+          [portfolio_value * max_position_pct] dollars of notional. Combined
+          with the side-level [max_long_exposure_pct] / [max_short_exposure_pct]
+          caps via [min()] in {!compute_position_size}: the final share count is
+          the minimum of (risk-based, side-exposure cap, per-position cap).
+
+          Rationale: 45-48% per-position concentration was observed in
+          sp500-2019-2023 with no per-position cap; the 90% side cap fired only
+          at the aggregate level. Default 0.20 (20% of portfolio_value). *)
   max_sector_concentration : int;
       (** Maximum positions in any single named sector (default: 5) *)
   max_unknown_sector_positions : int;
@@ -151,7 +172,8 @@ val default_config : config
     - max_long_exposure_pct = 0.90 (90%)
     - max_short_exposure_pct = 0.30 (30%)
     - max_short_notional_fraction = 0.30 (30%)
-    - min_cash_pct = 0.10 (10%)
+    - min_cash_pct = 0.10 (10%, deprecated — see field doc)
+    - max_position_pct = 0.20 (20% per position)
     - max_sector_concentration = 5
     - max_unknown_sector_positions = 2
     - big_winner_multiplier = 1.5
@@ -171,15 +193,18 @@ val compute_position_size :
     Two formulas applied in series:
     + Risk-based: shares_risk = floor((portfolio_value * risk_pct) / |entry -
       stop|)
-    + Exposure-capped: shares_max = floor(portfolio_value * max_exposure_pct /
-      entry_price), where max_exposure_pct is [max_long_exposure_pct] for [Long]
-      and [max_short_exposure_pct] for [Short].
+    + Cap-bounded: shares_max = floor(min(side_exposure_cap, position_cap) /
+      entry_price), where side_exposure_cap = portfolio_value *
+      [max_long_exposure_pct] for [Long] (or [max_short_exposure_pct] for
+      [Short]) and position_cap = portfolio_value * [max_position_pct].
 
     Final share count is the minimum of the two. The exposure cap prevents tight
     stops (small [|entry - stop|]) from producing positions whose notional
     exceeds the configured per-side budget — a sizing pathology observed in the
     sp500-2019-2023 rerun where shorts opened at 124% of portfolio value (ABBV
-    2019-02-01).
+    2019-02-01). The per-position cap further bounds individual concentration —
+    45-48% per-position concentration was observed in sp500-2019-2023 with no
+    per-position cap (2026-05-01).
 
     Pass [entry_price] and [stop_price] in their natural sense — entry is the
     real entry price and stop is the real stop level. The function checks the

--- a/trading/trading/weinstein/portfolio_risk/test/test_portfolio_risk.ml
+++ b/trading/trading/weinstein/portfolio_risk/test/test_portfolio_risk.ml
@@ -176,45 +176,49 @@ let test_position_size_big_winner _ =
        ~risk_amount:__)
 
 (* G7 regression — short with very tight stop must not size to >100% of
-   portfolio. Pre-fix: risk-budget formula alone produces 12,191 shares for a
+   portfolio. Pre-G7: risk-budget formula alone produces 12,191 shares for a
    $1M portfolio at risk_pct=0.01 with 0.82 risk_per_share → $1.238M position
-   (124% of portfolio). Post-fix: capped by max_short_exposure_pct = 0.30. *)
+   (124% of portfolio). Post-G7: capped by max_short_exposure_pct = 0.30.
+
+   max_position_pct=0.20 cap landed 2026-05-01 — re-pinned: per-position cap
+   (20% × $1M = $200K) is now tighter than the side-exposure cap (30% × $1M
+   = $300K), so floor($200K / $101.59) = 1,968 shares is the binding limit. *)
 let test_position_size_short_capped_by_max_short_exposure _ =
   let result =
     compute_position_size ~config:default_config ~portfolio_value:1_000_000.0
       ~side:`Short ~entry_price:101.59 ~stop_price:102.41 ()
   in
-  (* The risk-only formula would produce ~12,195 shares ($1.238M position).
-     With max_short_exposure_pct = 0.30, max position_value = $300K →
-     max shares = floor($300K / $101.59) = 2,953. *)
+  (* Per-position cap binds: floor($200K / $101.59) = 1,968 shares. *)
   assert_that result
     (all_of
        [
-         field (fun (s : sizing) -> s.shares) (equal_to 2953);
+         field (fun (s : sizing) -> s.shares) (equal_to 1968);
          field
            (fun (s : sizing) -> s.position_value)
-           (le (module Float_ord) 300_000.0);
-         field (fun (s : sizing) -> s.position_pct) (le (module Float_ord) 0.30);
+           (le (module Float_ord) 200_000.0);
+         field (fun (s : sizing) -> s.position_pct) (le (module Float_ord) 0.20);
        ])
 
 (* Symmetric long-side check: a long with a very tight stop must not exceed
-   max_long_exposure_pct (default 0.90). *)
+   the binding cap.
+
+   max_position_pct=0.20 cap landed 2026-05-01 — re-pinned: per-position cap
+   (20% × $1M = $200K) is tighter than max_long_exposure_pct = 0.90, so
+   $200K / $100 = 2,000 shares is the binding limit. *)
 let test_position_size_long_capped_by_max_long_exposure _ =
   let result =
     compute_position_size ~config:default_config ~portfolio_value:1_000_000.0
       ~side:`Long ~entry_price:100.0 ~stop_price:99.0 ()
   in
-  (* Risk-only formula: dollar_risk = $10K, risk_per_share = $1 → 10,000 shares
-     × $100 = $1,000,000 position (100% of portfolio). With max_long_exposure_pct
-     = 0.90, max position_value = $900K → max shares = 9,000. *)
+  (* Per-position cap binds: $200K / $100 = 2,000 shares. *)
   assert_that result
     (all_of
        [
-         field (fun (s : sizing) -> s.shares) (equal_to 9000);
+         field (fun (s : sizing) -> s.shares) (equal_to 2000);
          field
            (fun (s : sizing) -> s.position_value)
-           (le (module Float_ord) 900_000.0);
-         field (fun (s : sizing) -> s.position_pct) (le (module Float_ord) 0.90);
+           (le (module Float_ord) 200_000.0);
+         field (fun (s : sizing) -> s.position_pct) (le (module Float_ord) 0.20);
        ])
 
 (* Cap is configurable: tightening max_short_exposure_pct further reduces the
@@ -231,6 +235,29 @@ let test_position_size_short_cap_is_configurable _ =
        [
          field (fun (s : sizing) -> s.shares) (equal_to 1000);
          field (fun (s : sizing) -> s.position_pct) (le (module Float_ord) 0.10);
+       ])
+
+(* max_position_pct cap binds when the side-exposure cap is looser. With
+   risk_per_trade_pct=0.01, portfolio_value=$1M, entry=$200, stop=$199:
+     - risk-based: dollar_risk=$10K, risk_per_share=$1 → 10,000 shares
+     - side-exposure cap (long 90%): $900K / $200 = 4,500 shares
+     - per-position cap (20%): $200K / $200 = 1,000 shares (binds)
+   Final shares = min(10000, 4500, 1000) = 1,000.
+
+   max_position_pct=0.20 cap landed 2026-05-01 — pins the new behavior. *)
+let test_position_size_capped_by_max_position_pct _ =
+  let result =
+    compute_position_size ~config:default_config ~portfolio_value:1_000_000.0
+      ~side:`Long ~entry_price:200.0 ~stop_price:199.0 ()
+  in
+  assert_that result
+    (all_of
+       [
+         field (fun (s : sizing) -> s.shares) (equal_to 1000);
+         field (fun (s : sizing) -> s.position_value) (float_equal 200_000.0);
+         field
+           (fun (s : sizing) -> s.position_pct)
+           (float_equal ~epsilon:1e-6 0.20);
        ])
 
 (* When the risk-based sizing is already below the exposure cap, the cap is
@@ -423,6 +450,8 @@ let suite =
          >:: test_position_size_long_capped_by_max_long_exposure;
          "position_size_short_cap_is_configurable"
          >:: test_position_size_short_cap_is_configurable;
+         "position_size_capped_by_max_position_pct"
+         >:: test_position_size_capped_by_max_position_pct;
          "position_size_below_cap_unaffected"
          >:: test_position_size_below_cap_unaffected;
          "check_limits_ok" >:: test_check_limits_ok;

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy_smoke.ml
@@ -438,8 +438,12 @@ let test_weinstein_breakout_trade _ =
          support-floor stop sits much closer to entry than the
          screener's nominal buffer-based stop, so risk_per_share is
          smaller and shares scale up proportionally. Trade.price
-         (market fill) is unchanged. Pin the post-G15-step-3
-         deterministic values: 271 shares at $166.38. *)
+         (market fill) is unchanged.
+
+         max_position_pct=0.20 cap landed 2026-05-01 — re-pinned: with
+         portfolio_value=$100K and max_position_pct=0.20, the per-position
+         cap is $20K. At entry $166.38, max shares = floor($20K / $166.38)
+         = 120. The risk-based size (271) is now capped down to 120. *)
       let all_trades =
         List.concat_map result.steps ~f:(fun step -> step.trades)
       in
@@ -454,7 +458,7 @@ let test_weinstein_breakout_trade _ =
                    (equal_to Trading_base.Types.Buy);
                  field
                    (fun t -> t.Trading_base.Types.quantity)
-                   (float_equal ~epsilon:0.5 271.0);
+                   (float_equal ~epsilon:0.5 120.0);
                  field
                    (fun t -> t.Trading_base.Types.price)
                    (float_equal ~epsilon:0.1 166.383146);


### PR DESCRIPTION
## Summary

Adds a per-position concentration cap to Weinstein portfolio risk sizing. Each new position is now capped at `portfolio_value * max_position_pct` (default 0.20 = 20% of portfolio) in addition to the existing side-exposure caps. Final share count is `min(risk_based, side_exposure_cap, position_cap)`.

## Rationale

- 45-48% per-position concentration was observed in sp500-2019-2023 baselines with no per-position cap.
- The 90% per-side cap (`max_long_exposure_pct`) fired only at the aggregate level, leaving room for individual positions to dominate the portfolio.
- 20% per-position cap matches `1 / max_positions` × 4 (i.e., even a 5-position portfolio doesn't over-concentrate).
- Note that `min_cash_pct` (the prior nominal cash discipline) was never wired into the entry walk's `check_cash_and_deduct`. Cash discipline now flows from `max_position_pct × max_positions` + macro gating + force-liquidation thresholds. The `min_cash_pct` field is kept for sexp compat and marked deprecated in the `.mli`.

## Implementation

- `portfolio_risk.ml`: rename `_max_shares_by_exposure` → `_max_shares_by_caps`; the new function computes `min(side_exposure_cap, position_cap)` instead of the prior side-only `exposure_cap`.
- `portfolio_risk.mli`: new `default_max_position_pct` binding (= 0.20) so the `[@sexp.default ...]` attribute references a named constant (magic-number linter accepts named constants but flags inline floats); new `max_position_pct` field with `[@sexp.default default_max_position_pct]` for backward compat with existing scenario sexps; updated doc-comments for `min_cash_pct` (deprecated) and `compute_position_size`.

## Pin updates

- `test_portfolio_risk.ml`: short-cap test (2953 → 1968 shares), long-cap test (9000 → 2000 shares); new `test_position_size_capped_by_max_position_pct` pins the 20% cap behavior at portfolio=$1M, entry=$200, stop=$199 → 1000 shares.
- `test_weinstein_strategy_smoke.ml`: AAPL quantity (271 → 120 shares; portfolio=$100K × 0.20 = $20K cap / $166.38 entry = 120 shares).
- The 3 `test_weinstein_backtest.ml` tier-1 backtest tests pass unchanged because they use `risk_per_trade_pct=0.003` on a $500K portfolio, which produces small positions well below the 20% cap.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` clean for portfolio_risk (27 tests), weinstein_strategy_smoke (5 tests), weinstein_backtest (3 tests)
- [x] `dune fmt` clean
- [x] sp500-2019-2023 + sp500-2019-2023-long-only scenario goldens were already FAILing on `main` before this PR (76→97 trades / +37→+47% return, etc.); pin retuning is out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)