### PR TITLE
perf(optimal-strategy): memoize per-symbol forward outlooks (PR-1 of 5)

### DIFF
--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
@@ -405,4 +405,3 @@ let run ~output_dir =
   let world = _build_world ~output_dir ~actual_run in
   let scored = _scan_and_score ~world in
   _emit_report ~output_dir ~actual_run ~scored
-

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
@@ -147,31 +147,61 @@ let _build_sector_context_map (sectors : (string, string) Hashtbl.t) :
 (* Forward-walk outlooks for the scorer                                *)
 (* ---------------------------------------------------------------- *)
 
-(** Build a forward [Outcome_scorer.weekly_outlook list] for [symbol] starting
-    on the Friday {b after} [entry_friday]. Reads weekly bars + classifies Stage
-    at each Friday via [Stage.classify]. Empty list means the run ends at or
-    before [entry_friday]. *)
-let _forward_outlooks ~bar_panels ~all_fridays ~stage_config ~bar_lookback
-    ~symbol ~entry_friday : Scorer.weekly_outlook list =
-  let after =
-    List.drop_while all_fridays ~f:(fun d -> Date.( <= ) d entry_friday)
-  in
-  List.filter_map after ~f:(fun friday ->
-      match Bar_panels.column_of_date bar_panels friday with
+type forward_table = (string, Scorer.weekly_outlook list) Hashtbl.t
+(** Per-symbol chronologically-ordered [weekly_outlook list] across the run's
+    full Friday calendar. Built once per run (PR-1: optimal-strategy
+    improvements 2026-05-01) so per-candidate scoring becomes a list slice
+    rather than a fresh 130-week stage re-classification.
+
+    Key: symbol. Value: outlooks sorted ascending by [date], with one entry per
+    Friday for which the symbol has enough bars to classify a stage. Fridays
+    with insufficient history are simply absent from the list. *)
+
+(** Compute one [Scorer.weekly_outlook] for [symbol] at [friday], or [None] when
+    the symbol has no weekly bars at that Friday. Same shape as
+    [_analyze_symbol_on_friday] but emits the outlook record the scorer
+    consumes. *)
+let _outlook_at ~bar_panels ~stage_config ~bar_lookback ~symbol ~friday :
+    Scorer.weekly_outlook option =
+  match Bar_panels.column_of_date bar_panels friday with
+  | None -> None
+  | Some as_of_day -> (
+      let weekly =
+        Bar_panels.weekly_bars_for bar_panels ~symbol ~n:bar_lookback ~as_of_day
+      in
+      match List.last weekly with
       | None -> None
-      | Some as_of_day -> (
-          let weekly =
-            Bar_panels.weekly_bars_for bar_panels ~symbol ~n:bar_lookback
-              ~as_of_day
+      | Some bar ->
+          let stage_result =
+            Stage.classify ~config:stage_config ~bars:weekly ~prior_stage:None
           in
-          match List.last weekly with
-          | None -> None
-          | Some bar ->
-              let stage_result =
-                Stage.classify ~config:stage_config ~bars:weekly
-                  ~prior_stage:None
-              in
-              Some { Scorer.date = friday; bar; stage_result }))
+          Some { Scorer.date = friday; bar; stage_result })
+
+(** Build the per-symbol forward-outlook table (PR-1). Iterates [fridays] once
+    per symbol and memoizes the full chronological outlook list. Sized to
+    [List.length universe] for predictable hashtable growth. *)
+let _build_forward_table ~bar_panels ~fridays ~stage_config ~bar_lookback
+    ~universe : forward_table =
+  let table = Hashtbl.create ~size:(List.length universe) (module String) in
+  List.iter universe ~f:(fun symbol ->
+      let outlooks =
+        List.filter_map fridays ~f:(fun friday ->
+            _outlook_at ~bar_panels ~stage_config ~bar_lookback ~symbol ~friday)
+      in
+      Hashtbl.set table ~key:symbol ~data:outlooks);
+  table
+
+(** Slice the memoized per-symbol outlook list to keep only Fridays strictly
+    after [entry_friday]. Replaces the per-candidate Stage-classification loop
+    in the original [_forward_outlooks]. Returns [[]] for symbols absent from
+    the table (degenerate case — caller drops the candidate). *)
+let forward_outlooks_for ~forward_table ~symbol ~entry_friday :
+    Scorer.weekly_outlook list =
+  match Hashtbl.find forward_table symbol with
+  | None -> []
+  | Some outlooks ->
+      List.drop_while outlooks ~f:(fun (o : Scorer.weekly_outlook) ->
+          Date.( <= ) o.date entry_friday)
 
 (* ---------------------------------------------------------------- *)
 (* Macro-trend persistence (read side)                                *)
@@ -235,14 +265,15 @@ let _scan_all_fridays ~bar_panels ~fridays ~universe ~sector_map ~stock_config
       Scanner.scan_week ~config:scanner_config week)
 
 (** Score each candidate by forward-walking the panel. Drops candidates with no
-    forward bars (degenerate end-of-run). *)
-let _score_all_candidates ~bar_panels ~all_fridays ~scorer_config ~stage_config
-    ~bar_lookback (candidates : OT.candidate_entry list) :
-    OT.scored_candidate list =
+    forward bars (degenerate end-of-run). Uses the precomputed [forward_table]
+    so each candidate's forward outlooks are an O(N_fridays) slice of the
+    per-symbol memoized list rather than a fresh Stage-classification sweep. *)
+let _score_all_candidates ~forward_table ~scorer_config
+    (candidates : OT.candidate_entry list) : OT.scored_candidate list =
   List.filter_map candidates ~f:(fun (c : OT.candidate_entry) ->
       let forward =
-        _forward_outlooks ~bar_panels ~all_fridays ~stage_config ~bar_lookback
-          ~symbol:c.symbol ~entry_friday:c.entry_week
+        forward_outlooks_for ~forward_table ~symbol:c.symbol
+          ~entry_friday:c.entry_week
       in
       Scorer.score ~config:scorer_config ~candidate:c ~forward)
 
@@ -332,11 +363,13 @@ let _scan_and_score ~(world : _world) : OT.scored_candidate list =
   in
   eprintf "optimal_strategy: %d candidates emitted; scoring...\n%!"
     (List.length candidates);
-  let scored =
-    _score_all_candidates ~bar_panels:world.bar_panels
-      ~all_fridays:world.fridays ~scorer_config ~stage_config
-      ~bar_lookback:_bar_lookback_weeks candidates
+  let forward_table =
+    _build_forward_table ~bar_panels:world.bar_panels ~fridays:world.fridays
+      ~stage_config ~bar_lookback:_bar_lookback_weeks ~universe:world.universe
   in
+  eprintf "optimal_strategy: forward outlooks memoized (%d symbols)\n%!"
+    (Hashtbl.length forward_table);
+  let scored = _score_all_candidates ~forward_table ~scorer_config candidates in
   eprintf "optimal_strategy: %d scored candidates; filling variants...\n%!"
     (List.length scored);
   scored
@@ -372,3 +405,4 @@ let run ~output_dir =
   let world = _build_world ~output_dir ~actual_run in
   let scored = _scan_and_score ~world in
   _emit_report ~output_dir ~actual_run ~scored
+

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.mli
@@ -62,6 +62,28 @@
 
 open Core
 
+type forward_table = (string, Outcome_scorer.weekly_outlook list) Hashtbl.t
+(** Per-symbol chronologically-ordered [Outcome_scorer.weekly_outlook list]
+    across the run's full Friday calendar. Built once per run by the scoring
+    phase so per-candidate scoring is a list slice rather than a fresh
+    Stage-classification sweep (PR-1: optimal-strategy improvements 2026-05-01).
+
+    Key: symbol. Value: outlooks sorted ascending by [date], with one entry per
+    Friday for which the symbol has enough bars to classify a stage. Fridays
+    with insufficient history are absent from the list. Exposed at module
+    boundary for direct unit testing; the runner itself consumes the table
+    inside {!run}. *)
+
+val forward_outlooks_for :
+  forward_table:forward_table ->
+  symbol:string ->
+  entry_friday:Date.t ->
+  Outcome_scorer.weekly_outlook list
+(** [forward_outlooks_for ~forward_table ~symbol ~entry_friday] returns the
+    per-symbol forward outlooks strictly after [entry_friday]. Returns the empty
+    list when [symbol] is absent from the table. Exposed for unit testing the
+    memoized-slice contract. *)
+
 val load_macro_trend :
   output_dir:string -> (Date.t, Weinstein_types.market_trend) Hashtbl.t
 (** [load_macro_trend ~output_dir] reads [<output_dir>/macro_trend.sexp] and

--- a/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
@@ -317,6 +317,110 @@ let test_run_handles_missing_trade_audit _ =
            (equal_to false);
        ])
 
+(* ------------------------------------------------------------------ *)
+(* Forward-table memoization (PR-1)                                     *)
+(* ------------------------------------------------------------------ *)
+
+(** Build a synthetic [Daily_price.t] for forward-table tests. *)
+let _outlook_bar ~date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close +. 1.0;
+    low_price = close -. 1.0;
+    close_price = close;
+    volume = 1_000_000;
+    adjusted_close = close;
+  }
+
+(** Synthetic Stage-2 result; the slice tests don't drive the stage classifier,
+    they just assert which Fridays are kept. *)
+let _stage2_result : Stage.result =
+  {
+    stage = Weinstein_types.Stage2 { weeks_advancing = 4; late = false };
+    ma_value = 95.0;
+    ma_direction = Weinstein_types.Rising;
+    ma_slope_pct = 0.02;
+    transition = None;
+    above_ma_count = 5;
+  }
+
+let _outlook ~date ~close : Backtest_optimal.Outcome_scorer.weekly_outlook =
+  { date; bar = _outlook_bar ~date ~close; stage_result = _stage2_result }
+
+let test_forward_outlooks_for_drops_entries_at_or_before_entry_friday _ =
+  (* Contract: outlooks are kept iff their date is STRICTLY after entry_friday.
+     Entry-week itself is excluded; the next Friday is the first forward bar. *)
+  let fridays =
+    [
+      Date.of_string "2024-01-05";
+      Date.of_string "2024-01-12";
+      Date.of_string "2024-01-19";
+      Date.of_string "2024-01-26";
+      Date.of_string "2024-02-02";
+    ]
+  in
+  let outlooks =
+    List.mapi fridays ~f:(fun i d ->
+        _outlook ~date:d ~close:(100.0 +. Float.of_int i))
+  in
+  let table : Backtest_optimal.Optimal_strategy_runner.forward_table =
+    Hashtbl.create (module String)
+  in
+  Hashtbl.set table ~key:"AAA" ~data:outlooks;
+  let sliced =
+    Backtest_optimal.Optimal_strategy_runner.forward_outlooks_for
+      ~forward_table:table ~symbol:"AAA"
+      ~entry_friday:(Date.of_string "2024-01-12")
+  in
+  assert_that sliced
+    (elements_are
+       [
+         field
+           (fun (o : Backtest_optimal.Outcome_scorer.weekly_outlook) -> o.date)
+           (equal_to (Date.of_string "2024-01-19"));
+         field
+           (fun (o : Backtest_optimal.Outcome_scorer.weekly_outlook) -> o.date)
+           (equal_to (Date.of_string "2024-01-26"));
+         field
+           (fun (o : Backtest_optimal.Outcome_scorer.weekly_outlook) -> o.date)
+           (equal_to (Date.of_string "2024-02-02"));
+       ])
+
+let test_forward_outlooks_for_missing_symbol_returns_empty _ =
+  (* Symbols absent from the table degenerate to an empty forward — the scorer
+     drops the candidate. Pin: lookup is total. *)
+  let table : Backtest_optimal.Optimal_strategy_runner.forward_table =
+    Hashtbl.create (module String)
+  in
+  let sliced =
+    Backtest_optimal.Optimal_strategy_runner.forward_outlooks_for
+      ~forward_table:table ~symbol:"ZZZ"
+      ~entry_friday:(Date.of_string "2024-01-12")
+  in
+  assert_that sliced (size_is 0)
+
+let test_forward_outlooks_for_entry_after_last_friday_returns_empty _ =
+  (* End-of-run case: entry_friday past the last memoized Friday yields an
+     empty slice — matches the original [_forward_outlooks] behaviour where
+     [List.drop_while] consumes the whole list. *)
+  let outlooks =
+    [
+      _outlook ~date:(Date.of_string "2024-01-05") ~close:100.0;
+      _outlook ~date:(Date.of_string "2024-01-12") ~close:101.0;
+    ]
+  in
+  let table : Backtest_optimal.Optimal_strategy_runner.forward_table =
+    Hashtbl.create (module String)
+  in
+  Hashtbl.set table ~key:"AAA" ~data:outlooks;
+  let sliced =
+    Backtest_optimal.Optimal_strategy_runner.forward_outlooks_for
+      ~forward_table:table ~symbol:"AAA"
+      ~entry_friday:(Date.of_string "2024-01-26")
+  in
+  assert_that sliced (size_is 0)
+
 let suite =
   "Optimal_strategy_runner"
   >::: [
@@ -330,6 +434,12 @@ let suite =
          >:: test_run_emits_optimal_summary_sexp;
          "run handles missing trade_audit.sexp"
          >:: test_run_handles_missing_trade_audit;
+         "forward_outlooks_for drops entries at or before entry_friday"
+         >:: test_forward_outlooks_for_drops_entries_at_or_before_entry_friday;
+         "forward_outlooks_for unknown symbol returns empty"
+         >:: test_forward_outlooks_for_missing_symbol_returns_empty;
+         "forward_outlooks_for entry past last Friday returns empty"
+         >:: test_forward_outlooks_for_entry_after_last_friday_returns_empty;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR-1 of 5 from `dev/plans/optimal-strategy-improvements-2026-05-01.md`.

`Optimal_strategy_runner._forward_outlooks` rebuilt the 130-week forward
outlook (re-extracting 90 weekly bars + re-running `Stage.classify` per
Friday) once **per candidate**. With ~10k candidates × ~260 Fridays this
is the single biggest hot spot — same symbol, same future, recomputed.

This change builds a per-symbol forward-outlook table once per run, then
slices it for each candidate. Same outputs, dramatically less work.

## What changes

- **New `forward_table` type** (`(string, weekly_outlook list) Hashtbl.t`):
  per-symbol chronological outlook list across the run's full Friday
  calendar. Sized to `List.length universe`.
- **New `_build_forward_table`** iterates each symbol's full Friday
  calendar once and memoizes the chronological outlook list.
- **New `forward_outlooks_for`** (exposed for unit testing) slices the
  memoized list to keep only Fridays strictly after `entry_friday`.
- **`_score_all_candidates`** signature simplified — now consumes
  `forward_table` + `scorer_config` only; no longer threads
  `bar_panels`, `all_fridays`, `stage_config`, or `bar_lookback` per
  candidate.

## Algorithmic improvement

```
before: O(N_candidates × N_fridays × bar_extraction)
after:  O(N_symbols × N_fridays × bar_extraction + N_candidates × N_fridays)
```

For sp500-2019-2023: ~10k candidates × 260 Fridays of bar+stage work →
491 symbols × 260 Fridays of the same work + 10k × 260 list-slice
comparisons. Plan target was 3-5× Phase-2 speedup; the algorithm makes
that mechanical.

## Test plan

- [x] `dune build` clean.
- [x] `dune runtest trading/backtest/optimal/test` passes — all 9
  existing tests + 3 new unit tests for the slice contract:
  - `forward_outlooks_for drops entries at or before entry_friday`
  - `forward_outlooks_for unknown symbol returns empty`
  - `forward_outlooks_for entry past last Friday returns empty`
- [x] Memoization log fires (`forward outlooks memoized (1 symbols)`)
  in the runner smoke test stderr.

## Empirical perf measurement

Deferred. The 22-symbol panel-golden fixture completes in seconds even
pre-fix, so a host-side `time` comparison wouldn't be meaningful. The
algorithmic improvement is mechanical and pinned by the unit tests. The
expected wall-time win lands cleanly when this runs on `sp500-2019-2023`
(491 symbols × ~260 Fridays) — measurement to come from the
plan-tracking issue once PR-1 + PR-2 + PR-3 land together.

## References

- Plan: `dev/plans/optimal-strategy-improvements-2026-05-01.md` (PR-1)
- Touched: `trading/trading/backtest/optimal/lib/optimal_strategy_runner.{ml,mli}`,
  `trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml`