### PR TITLE
fix(optimal-strategy): scope counterfactual to actual run's universe (P0)

### DIFF
--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -287,6 +287,19 @@ let _write_splits ~output_dir ~steps =
             (_format_split_factor e.factor)));
   Out_channel.close oc
 
+(** Write [universe.txt]: one symbol per line, no header. Captures the post-cap
+    universe the simulator actually traded over (excluding the primary index and
+    sector ETFs) so downstream counterfactual tooling — [optimal_strategy] in
+    particular — can scope its analysis to the same set rather than reading the
+    full [data/sectors.csv]. The file is always written, even when
+    [result.universe] is empty (header-less / row-less file in that degenerate
+    case). *)
+let _write_universe ~output_dir ~(universe : string list) =
+  let path = output_dir ^ "/universe.txt" in
+  let oc = Out_channel.create path in
+  List.iter universe ~f:(fun sym -> fprintf oc "%s\n" sym);
+  Out_channel.close oc
+
 let write ~output_dir (result : Runner.result) =
   _write_params ~output_dir result;
   Sexp.save_hum
@@ -303,4 +316,5 @@ let write ~output_dir (result : Runner.result) =
   _write_final_prices ~output_dir ~steps:result.steps
     ~final_prices:result.final_prices;
   _write_splits ~output_dir ~steps:result.steps;
+  _write_universe ~output_dir ~universe:result.universe;
   Macro_trend_writer.write ~output_dir result.cascade_summaries

--- a/trading/trading/backtest/lib/result_writer.mli
+++ b/trading/trading/backtest/lib/result_writer.mli
@@ -4,7 +4,7 @@
 
 val write : output_dir:string -> Runner.result -> unit
 (** Write [params.sexp], [summary.sexp], [trades.csv], [equity_curve.csv],
-    [open_positions.csv], [final_prices.csv], [splits.csv], and
+    [open_positions.csv], [final_prices.csv], [splits.csv], [universe.txt], and
     [macro_trend.sexp] into [output_dir]. The directory must already exist.
 
     Additionally writes [trade_audit.sexp] iff [result.audit] is non-empty.
@@ -15,6 +15,11 @@ val write : output_dir:string -> Runner.result -> unit
     [macro_trend.sexp] is always written (one entry per Friday the screener
     fired, possibly empty list) — counterfactual tooling consumes it to replay
     per-Friday macro state. See {!Macro_trend_writer}.
+
+    [universe.txt] is always written — one symbol per line, no header, captured
+    from [result.universe]. Downstream counterfactual tooling
+    ([optimal_strategy]) loads this file to scope its analysis to the actual
+    run's universe; an empty [universe] yields an empty file.
 
     The reconciler-producer artefacts ([open_positions.csv], [splits.csv],
     [final_prices.csv]) are always written, header-only when there is nothing to

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -28,6 +28,14 @@ type result = {
   cascade_summaries : Trade_audit.cascade_summary list;
   force_liquidations : Portfolio_risk.Force_liquidation.event list;
   final_prices : (string * float) list;
+  universe : string list;
+      (** Post-cap, sorted list of symbols the simulator actually traded over
+          (excludes the primary index and sector ETFs). Persisted to
+          [universe.txt] by [Result_writer.write] so downstream counterfactual
+          tooling — [optimal_strategy] in particular — can scope its analysis to
+          the same universe rather than reloading [data/sectors.csv] (the full
+          ~10k-symbol set, which over-states what the strategy could have
+          picked). *)
 }
 
 (* Trading-day filter *)
@@ -97,6 +105,10 @@ let _apply_overrides (config : Weinstein_strategy.config) overrides =
 type _deps = {
   data_dir_fpath : Fpath.t;
   ticker_sectors : (string, string) Hashtbl.t;
+  universe : string list;
+      (** Post-cap, sorted list of universe symbols (excluding the primary index
+          and sector ETFs). Same set the runner trades over and the value
+          carried forward into [Runner.result.universe] / [universe.txt]. *)
   universe_size : int;
   ad_bars : Macro.ad_bar list;
   config : Weinstein_strategy.config;
@@ -214,6 +226,7 @@ let _load_deps ?trace ?gc_trace ~overrides ~sector_map_override () =
   {
     data_dir_fpath;
     ticker_sectors;
+    universe;
     universe_size;
     ad_bars;
     config;
@@ -479,4 +492,5 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     cascade_summaries;
     force_liquidations;
     final_prices;
+    universe = deps.universe;
   }

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -50,6 +50,14 @@ type result = {
           Consumed by [Result_writer] to emit [final_prices.csv] for the
           external [trading-reconciler] tool — see
           [~/Projects/trading-reconciler/PHASE_1_SPEC.md] §3.3. *)
+  universe : string list;
+      (** Post-cap, sorted list of symbols the simulator actually traded over
+          (excludes the primary index and sector ETFs). Persisted to
+          [universe.txt] by [Result_writer.write] so downstream counterfactual
+          tooling — [optimal_strategy] in particular — can scope its analysis to
+          the same universe rather than reloading [data/sectors.csv] (the full
+          ~10k-symbol set, which over-states what the strategy could have
+          picked). *)
 }
 
 val filter_stop_infos_in_window :

--- a/trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml
@@ -165,6 +165,12 @@ type actual_run_inputs = {
   start_date : Date.t;
   end_date : Date.t;
   universe_size : int;
+  universe : string list;
+      (** Sorted list of symbols the actual run traded over, loaded from
+          [<output_dir>/universe.txt]. When [universe.txt] is absent (legacy
+          artefacts that pre-date the universe-pinning fix), the loader falls
+          back to [Sector_map.load] over [data/sectors.csv] with a stderr
+          warning — note that fallback over-states the universe. *)
   initial_cash : float;
   final_portfolio_value : float;
   trades : Trading_simulation.Metrics.trade_metrics list;
@@ -178,16 +184,44 @@ let _scenario_name_of_dir dir =
   let basename = Filename.basename dir in
   if String.is_empty basename then dir else basename
 
+(** Load the actual run's universe from [<output_dir>/universe.txt] — one symbol
+    per line, no header (the format {!Backtest.Result_writer} writes). Empty
+    lines are skipped, and the result is sorted by [String.compare] for
+    determinism. When the file is missing (legacy artefacts that pre-date the
+    universe-pinning fix), fall back to [Sector_map.load] over
+    [data/sectors.csv] with a stderr warning so callers know the universe is
+    over-stated relative to what the actual run could have picked. *)
+let _load_universe ~output_dir : string list =
+  let path = Filename.concat output_dir "universe.txt" in
+  if Sys_unix.file_exists_exn path then
+    In_channel.read_lines path
+    |> List.filter_map ~f:(fun line ->
+        let s = String.strip line in
+        if String.is_empty s then None else Some s)
+    |> List.sort ~compare:String.compare
+  else (
+    eprintf
+      "optimal_strategy: universe.txt absent at %s; falling back to \
+       Sector_map.load (over-stated universe — counterfactual will scan \
+       symbols outside the actual run's universe)\n\
+       %!"
+      path;
+    let data_dir = Data_path.default_data_dir () in
+    let sectors_tbl = Sector_map.load ~data_dir in
+    Hashtbl.keys sectors_tbl |> List.sort ~compare:String.compare)
+
 let load ~output_dir : actual_run_inputs =
   let actual = _load_actual_sexp ~output_dir in
   let summary = _load_summary_sexp ~output_dir in
   let trades = _load_trades ~output_dir in
   let cascade_rejections = _load_cascade_rejections ~output_dir in
+  let universe = _load_universe ~output_dir in
   {
     scenario_name = _scenario_name_of_dir output_dir;
     start_date = summary.start_date;
     end_date = summary.end_date;
     universe_size = summary.universe_size;
+    universe;
     initial_cash = summary.initial_cash;
     final_portfolio_value = summary.final_portfolio_value;
     trades;

--- a/trading/trading/backtest/optimal/lib/optimal_run_artefacts.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_run_artefacts.mli
@@ -31,6 +31,14 @@ type actual_run_inputs = {
   start_date : Date.t;
   end_date : Date.t;
   universe_size : int;
+  universe : string list;
+      (** Sorted list of symbols the actual run traded over. Loaded from
+          [<output_dir>/universe.txt] (one symbol per line, no header) — the
+          file [Backtest.Result_writer] emits alongside the other artefacts.
+          When the file is absent (legacy artefacts), the loader falls back to
+          [Sector_map.load] over [data/sectors.csv] with a stderr warning;
+          callers that depend on the exact universe should treat the missing
+          file as a correctness regression rather than a soft fallback. *)
   initial_cash : float;
   final_portfolio_value : float;
   trades : Trading_simulation.Metrics.trade_metrics list;

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
@@ -293,12 +293,20 @@ type _world = {
     macro trends over the run window. Built once per invocation, consumed by
     scan + score. *)
 
-let _build_world ~output_dir ~(actual_run : Report.actual_run) : _world =
+(** Build the panels-and-context world.
+
+    The [universe] used here MUST match the actual run's universe (loaded from
+    [universe.txt] in [Optimal_run_artefacts.load]). Earlier revisions sourced
+    [universe] from [Sector_map.load] (the full ~10k-symbol [data/sectors.csv]
+    set), which let the counterfactual cherry-pick trades from symbols the
+    actual sp500-2019-2023 backtest never saw — yielding a meaningless ~1997%
+    optimal return. The sector_map is still loaded for
+    [_build_sector_context_map], but its keys are no longer the universe source.
+*)
+let _build_world ~output_dir ~(actual_run : Report.actual_run)
+    ~(universe : string list) : _world =
   let data_dir_fpath = Data_path.default_data_dir () in
   let sectors_tbl = Sector_map.load ~data_dir:data_dir_fpath in
-  let universe =
-    Hashtbl.keys sectors_tbl |> List.sort ~compare:String.compare
-  in
   let warmup_start = Date.add_days actual_run.start_date (-_warmup_days) in
   let calendar =
     _build_calendar ~start:warmup_start ~end_:actual_run.end_date
@@ -369,6 +377,6 @@ let run ~output_dir =
     (Date.to_string actual_run.start_date)
     (Date.to_string actual_run.end_date)
     actual_run.universe_size;
-  let world = _build_world ~output_dir ~actual_run in
+  let world = _build_world ~output_dir ~actual_run ~universe:inputs.universe in
   let scored = _scan_and_score ~world in
   _emit_report ~output_dir ~actual_run ~scored

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.mli
@@ -10,10 +10,12 @@
     The orchestrator is divided into three phases, each surfaced as a named
     helper for testability + readability:
 
-    - {b Build world.} Loads the universe ([sectors.csv]), constructs the
-      trading-day calendar with a 210-day warm-up window before [start_date],
-      builds [Bar_panels.t] over the universe + benchmark index, and computes
-      the Friday calendar over the run window.
+    - {b Build world.} Loads the universe from [<output_dir>/universe.txt]
+      ([Backtest.Result_writer]'s artefact, scoped to the actual run's universe
+      — falls back to [Sector_map.load] over [data/sectors.csv] when the file is
+      absent), constructs the trading-day calendar with a 210-day warm-up window
+      before [start_date], builds [Bar_panels.t] over the universe + benchmark
+      index, and computes the Friday calendar over the run window.
     - {b Scan and score.} Walks every Friday in the run window, runs
       [Stock_analysis.analyze] per universe symbol, feeds the analyses into
       {!Stage_transition_scanner.scan_week} to emit [candidate_entry] records,

--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -78,7 +78,8 @@ let _empty_summary ~start_date ~end_date : Backtest.Summary.t =
   }
 
 let _make_result ?(steps = []) ?(final_prices = []) ?(stop_infos = [])
-    ~round_trips ~force_liquidations () : Backtest.Runner.result =
+    ?(universe = []) ~round_trips ~force_liquidations () :
+    Backtest.Runner.result =
   let start_date = _date "2024-01-02" in
   let end_date = _date "2024-04-29" in
   {
@@ -91,6 +92,7 @@ let _make_result ?(steps = []) ?(final_prices = []) ?(stop_infos = [])
     cascade_summaries = [];
     force_liquidations;
     final_prices;
+    universe;
   }
 
 (** Build a [Trading_portfolio.Types.portfolio_position] with a single lot. The

--- a/trading/trading/backtest/test/test_trade_audit_report.ml
+++ b/trading/trading/backtest/test/test_trade_audit_report.ml
@@ -661,6 +661,7 @@ let _make_runner_result ~start_date ~end_date ~round_trips :
     cascade_summaries = [];
     force_liquidations = [];
     final_prices = [];
+    universe = [];
   }
 
 let test_writer_reader_post_g2_round_trip _ =


### PR DESCRIPTION
## Critical correctness fix

\`optimal_strategy_runner._build_world\` was using \`Sector_map.load\` to derive the universe — that's the FULL data dir's \`sectors.csv\` = 10,473 symbols, NOT the actual scenario's universe (e.g. 491 sp500 symbols).

Symptoms on sp500-2019-2023 pre-fix:
- Optimal returns: +1997% (constrained), +2185% (relaxed)
- Win rate: 100%, MaxDD: 0.00%, R-multiple: 222
- "Optimal" picks: small caps not in sp500 (CLDX, AXSM, IVDA, ENLV)
- Runtime: 90+ min (21x universe = 21x slower)

The numbers are meaningless because the optimal can pick stocks the actual strategy was never able to consider.

## Fix

Capture the universe in the backtest artefacts:
- \`Backtest.Result_writer.write\` emits \`<output_dir>/universe.txt\` (one symbol per line)
- \`Optimal_run_artefacts.load\` reads it; falls back to \`Sector_map.load\` with stderr warning if absent (backwards compat)
- \`Optimal_strategy_runner._build_world\` uses the loaded universe instead of the global sectors map

## Test plan

- [x] dune build clean
- [x] dune runtest trading/backtest/test trading/backtest/optimal/test pass
- [x] dune fmt clean
- [ ] CI verifies on Linux
- [ ] Re-run optimal_strategy on sp500-2019-2023 with fix; expect:
  - "building panels (492 symbols × ...)" not 10473
  - candidates ~10-20k not 264k
  - Realistic optimal returns (100-300% range, not 1997%)

## P0 origin

Surfaced 2026-05-01 during \`optimal_strategy.exe\` run on sp500-2019-2023 (PR #747's plan documented perf concerns; this is the correctness gap that wasn't in the plan but supersedes it). Adding to plan in a follow-up doc commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)