### PR TITLE
feat(optimal-strategy): add Score_picked filler variant (PR-4 of 5)

### DIFF
--- a/trading/trading/backtest/optimal/lib/optimal_portfolio_filler.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_portfolio_filler.ml
@@ -47,7 +47,7 @@ let _candidate_admissible ~(variant : Optimal_types.variant_label)
     (sc : Optimal_types.scored_candidate) : bool =
   match variant with
   | Relaxed_macro -> true
-  | Constrained -> sc.entry.passes_macro
+  | Constrained | Score_picked -> sc.entry.passes_macro
 
 (** All distinct entry-Fridays in [scored], in ascending order. Drives the walk.
 *)
@@ -58,19 +58,41 @@ let _distinct_entry_fridays (scored : Optimal_types.scored_candidate list) :
       sc.entry.entry_week)
   |> List.dedup_and_sort ~compare:Date.compare
 
-(** Candidates entering on [friday], sorted by R-multiple descending. *)
-let _entries_on (scored : Optimal_types.scored_candidate list) (friday : Date.t)
-    : Optimal_types.scored_candidate list =
+(** Comparator for sorting same-Friday candidates under [variant].
+
+    - [Constrained] / [Relaxed_macro] sort by realised [r_multiple] descending.
+      The R-multiple is computed forward from the candidate, so this picks
+      winners by hindsight — useful as a ceiling, contaminating as a target.
+    - [Score_picked] sorts by pre-trade [cascade_score] descending — the same
+      signal the actual strategy uses at decision time. Ties broken by [symbol]
+      ascending so the order is deterministic across runs. *)
+let _entry_comparator ~(variant : Optimal_types.variant_label) :
+    Optimal_types.scored_candidate -> Optimal_types.scored_candidate -> int =
+  match variant with
+  | Constrained | Relaxed_macro ->
+      fun (a : Optimal_types.scored_candidate)
+        (b : Optimal_types.scored_candidate)
+      -> Float.compare b.r_multiple a.r_multiple
+  | Score_picked ->
+      fun (a : Optimal_types.scored_candidate)
+        (b : Optimal_types.scored_candidate)
+      ->
+        let by_score =
+          Int.compare b.entry.cascade_score a.entry.cascade_score
+        in
+        if by_score <> 0 then by_score
+        else String.compare a.entry.symbol b.entry.symbol
+
+(** Candidates entering on [friday], sorted by the variant-specific key:
+    [r_multiple] DESC for [Constrained] / [Relaxed_macro], [cascade_score] DESC
+    (with [symbol] ASC tie-break) for [Score_picked]. *)
+let _entries_on ~(variant : Optimal_types.variant_label)
+    (scored : Optimal_types.scored_candidate list) (friday : Date.t) :
+    Optimal_types.scored_candidate list =
   scored
   |> List.filter ~f:(fun (sc : Optimal_types.scored_candidate) ->
       Date.equal sc.entry.entry_week friday)
-  |> List.sort
-       ~compare:(fun
-           (a : Optimal_types.scored_candidate)
-           (b : Optimal_types.scored_candidate)
-         ->
-         (* Descending: larger R first. *)
-         Float.compare b.r_multiple a.r_multiple)
+  |> List.sort ~compare:(_entry_comparator ~variant)
 
 (** Number of currently open positions in [sector] in [book]. *)
 let _sector_count (book : _book) (sector : string) : int =
@@ -206,7 +228,7 @@ let fill ~(config : config) (input : fill_input) :
     let fridays = _distinct_entry_fridays admissible in
     List.iter fridays ~f:(fun friday ->
         _close_due book friday;
-        let entries = _entries_on admissible friday in
+        let entries = _entries_on ~variant:input.variant admissible friday in
         _process_entries ~config book entries);
     _close_remaining book;
     _final_order book.closed

--- a/trading/trading/backtest/optimal/lib/optimal_portfolio_filler.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_portfolio_filler.mli
@@ -6,9 +6,11 @@
       equals this Friday closes — its proceeds accrue to cash before new entries
       are sized.
     - {b Then entries.} Candidates with [entry.entry_week = this Friday] are
-      ranked by R-multiple descending. Each is admitted only if it passes the
-      skip-already-held / concurrent-position-cap / sector-cap / cash checks.
-      Sizing is dollar-based:
+      ranked by the variant-specific key (R-multiple descending for
+      [Constrained] / [Relaxed_macro]; pre-trade [cascade_score] descending with
+      [symbol] tie-break for [Score_picked]). Each is admitted only if it passes
+      the skip-already-held / concurrent-position-cap / sector-cap / cash
+      checks. Sizing is dollar-based:
       [shares = risk_per_trade_dollars / initial_risk_per_share]. Cash is
       deducted at entry and accrued at exit.
 
@@ -32,10 +34,13 @@
     {1 Variant tagging}
 
     Every emitted round-trip carries the candidate's [passes_macro] flag
-    forward. The caller picks one variant per fill — PR-4's renderer emits two
-    summaries by invoking the filler twice (once with [variant = Constrained]
-    filtering candidates whose [passes_macro = true]; once with
-    [variant = Relaxed_macro] admitting all candidates).
+    forward. The caller picks one variant per fill — the renderer emits three
+    summaries by invoking the filler three times:
+    - [Constrained]: macro gate kept, sort by realised [r_multiple] DESC (full
+      outcome foresight; ceiling).
+    - [Score_picked]: macro gate kept, sort by pre-trade [cascade_score] DESC
+      (no outcome foresight; the same signal the live strategy uses).
+    - [Relaxed_macro]: macro gate dropped, sort by realised [r_multiple] DESC.
 
     {1 Purity}
 
@@ -84,12 +89,14 @@ type fill_input = {
       (** All scored candidates produced by Phase B, in any order — the filler
           sorts internally. Empty list yields an empty round-trip list. *)
   variant : Optimal_types.variant_label;
-      (** Which variant to fill. [Constrained] admits only candidates whose
-          [entry.passes_macro] is [true]; [Relaxed_macro] admits all. *)
+      (** Which variant to fill. [Constrained] / [Score_picked] admit only
+          candidates whose [entry.passes_macro] is [true]; [Relaxed_macro]
+          admits all. The variant also determines the per-Friday entry sort key
+          — see {!fill}. *)
 }
-(** Inputs to a single fill pass. The [variant] choice determines which subset
-    of candidates is admissible; everything else (sort key, sizing, caps) is
-    identical across variants. *)
+(** Inputs to a single fill pass. The [variant] choice determines both which
+    subset of candidates is admissible and the per-Friday entry sort key;
+    everything else (sizing, caps) is identical across variants. *)
 
 val fill : config:config -> fill_input -> Optimal_types.optimal_round_trip list
 (** [fill ~config input] runs the greedy Friday-by-Friday fill described above
@@ -98,8 +105,8 @@ val fill : config:config -> fill_input -> Optimal_types.optimal_round_trip list
 
     Algorithm:
     {ol
-     {- Filter [input.candidates] by variant. For [Constrained], drop any
-        candidate where [entry.passes_macro = false].
+     {- Filter [input.candidates] by variant. For [Constrained] /
+        [Score_picked], drop any candidate where [entry.passes_macro = false].
      }
      {- Group remaining candidates by [entry.entry_week] (Friday). }
      {- Walk Fridays in ascending date order. For each Friday:
@@ -108,8 +115,10 @@ val fill : config:config -> fill_input -> Optimal_types.optimal_round_trip list
             this Friday. Accrue [exit_price * shares] to cash. Open positions
             are tracked by symbol; sector counts and position counts decrement.
          }
-         {- {b Entry phase.} Sort the day's admissible candidates by R-multiple
-            descending. For each candidate in order:
+         {- {b Entry phase.} Sort the day's admissible candidates by the
+            variant's key — [r_multiple] DESC for [Constrained] /
+            [Relaxed_macro], [cascade_score] DESC ([symbol] ASC tie-break) for
+            [Score_picked]. For each candidate in order:
             + {b Skip if symbol already held.} The counterfactual mirrors the
               live strategy's "one position per symbol" rule.
             + {b Skip if at concurrent-position cap.}

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_report.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_report.ml
@@ -27,6 +27,7 @@ type actual_run = {
 type input = {
   actual : actual_run;
   constrained : variant_pack;
+  score_picked : variant_pack;
   relaxed_macro : variant_pack;
 }
 
@@ -104,68 +105,113 @@ let _section_header (input : input) : string list =
 (* Section: headline comparison table                                 *)
 (* ---------------------------------------------------------------- *)
 
-let _comp_row label ~actual ~constrained_v ~relaxed ~delta =
-  sprintf "| %s | %s | %s | %s | %s |" label actual constrained_v relaxed delta
+let _comp_row label ~actual ~constrained_v ~score_picked_v ~relaxed ~delta =
+  sprintf "| %s | %s | %s | %s | %s | %s |" label actual constrained_v
+    score_picked_v relaxed delta
 
 let _delta_pp ~constrained_v ~actual = _fmt_pp (constrained_v -. actual)
+
+let _row_total_return ~actual_return ~c ~s ~r =
+  let constrained_return = _frac_to_pct c.summary.total_return_pct in
+  let score_picked_return = _frac_to_pct s.summary.total_return_pct in
+  let relaxed_return = _frac_to_pct r.summary.total_return_pct in
+  _comp_row "Total return"
+    ~actual:(_fmt_pct_signed actual_return)
+    ~constrained_v:(_fmt_pct_signed constrained_return)
+    ~score_picked_v:(_fmt_pct_signed score_picked_return)
+    ~relaxed:(_fmt_pct_signed relaxed_return)
+    ~delta:(_delta_pp ~constrained_v:constrained_return ~actual:actual_return)
+
+let _row_win_rate ~(a : actual_run) ~c ~s ~r =
+  _comp_row "Win rate"
+    ~actual:(_fmt_pct_unsigned a.win_rate_pct)
+    ~constrained_v:(_fmt_pct_unsigned (_wr_frac_to_pct c.summary.win_rate_pct))
+    ~score_picked_v:(_fmt_pct_unsigned (_wr_frac_to_pct s.summary.win_rate_pct))
+    ~relaxed:(_fmt_pct_unsigned (_wr_frac_to_pct r.summary.win_rate_pct))
+    ~delta:
+      (_delta_pp
+         ~constrained_v:(_wr_frac_to_pct c.summary.win_rate_pct)
+         ~actual:a.win_rate_pct)
+
+let _row_max_dd ~(a : actual_run) ~c ~s ~r =
+  _comp_row "MaxDD"
+    ~actual:(sprintf "-%.2f%%" a.max_drawdown_pct)
+    ~constrained_v:
+      (sprintf "-%.2f%%" (_dd_frac_to_pct c.summary.max_drawdown_pct))
+    ~score_picked_v:
+      (sprintf "-%.2f%%" (_dd_frac_to_pct s.summary.max_drawdown_pct))
+    ~relaxed:(sprintf "-%.2f%%" (_dd_frac_to_pct r.summary.max_drawdown_pct))
+    ~delta:
+      (_delta_pp
+         ~constrained_v:(-._dd_frac_to_pct c.summary.max_drawdown_pct)
+         ~actual:(-.a.max_drawdown_pct))
+
+let _row_sharpe ~(a : actual_run) =
+  _comp_row "Sharpe"
+    ~actual:(_fmt_float_2 a.sharpe_ratio)
+    ~constrained_v:"n/a" ~score_picked_v:"n/a" ~relaxed:"n/a" ~delta:"n/a"
+
+let _row_profit_factor ~(a : actual_run) ~c ~s ~r =
+  _comp_row "Profit factor"
+    ~actual:(_fmt_float_or_inf a.profit_factor)
+    ~constrained_v:(_fmt_float_or_inf c.summary.profit_factor)
+    ~score_picked_v:(_fmt_float_or_inf s.summary.profit_factor)
+    ~relaxed:(_fmt_float_or_inf r.summary.profit_factor)
+    ~delta:"—"
+
+let _row_round_trips ~(a : actual_run) ~c ~s ~r =
+  _comp_row "Round-trips"
+    ~actual:(_fmt_int (List.length a.round_trips))
+    ~constrained_v:(_fmt_int c.summary.total_round_trips)
+    ~score_picked_v:(_fmt_int s.summary.total_round_trips)
+    ~relaxed:(_fmt_int r.summary.total_round_trips)
+    ~delta:"—"
+
+let _row_avg_r ~actual_avg_r ~c ~s ~r =
+  _comp_row "Avg R-multiple"
+    ~actual:(_fmt_float_2 actual_avg_r)
+    ~constrained_v:(_fmt_float_2 c.summary.avg_r_multiple)
+    ~score_picked_v:(_fmt_float_2 s.summary.avg_r_multiple)
+    ~relaxed:(_fmt_float_2 r.summary.avg_r_multiple)
+    ~delta:"—"
+
+(** Header lines for the headline section: title, gap-decomposition narrative,
+    and table column header / divider. Pulled out so [_headline_section] stays
+    short enough to fit the function-length linter. *)
+let _headline_header_lines : string list =
+  [
+    "## Headline comparison";
+    "";
+    "Variant ordering reads left-to-right as a gap decomposition:";
+    "- **Actual → Score_picked** = cascade-ranking error (closeable: improve \
+     scoring).";
+    "- **Score_picked → Constrained** = outcome-foresight bonus (uncloseable: \
+     requires hindsight).";
+    "- **Constrained → Relaxed_macro** = macro-gate cost.";
+    "";
+    "| Metric | Actual | Optimal (constrained) | Optimal (score_picked) | \
+     Optimal (relaxed macro) | Δ to constrained |";
+    "|---|---:|---:|---:|---:|---:|";
+  ]
 
 let _headline_section (input : input) : string list =
   let a = input.actual in
   let c = input.constrained in
+  let s = input.score_picked in
   let r = input.relaxed_macro in
   let actual_return = _actual_total_return_pct a in
-  let constrained_return = _frac_to_pct c.summary.total_return_pct in
-  let relaxed_return = _frac_to_pct r.summary.total_return_pct in
   let actual_avg_r = _actual_avg_r a in
-  [
-    "## Headline comparison";
-    "";
-    "| Metric | Actual | Optimal (constrained) | Optimal (relaxed macro) | Δ \
-     to constrained |";
-    "|---|---:|---:|---:|---:|";
-    _comp_row "Total return"
-      ~actual:(_fmt_pct_signed actual_return)
-      ~constrained_v:(_fmt_pct_signed constrained_return)
-      ~relaxed:(_fmt_pct_signed relaxed_return)
-      ~delta:(_delta_pp ~constrained_v:constrained_return ~actual:actual_return);
-    _comp_row "Win rate"
-      ~actual:(_fmt_pct_unsigned a.win_rate_pct)
-      ~constrained_v:
-        (_fmt_pct_unsigned (_wr_frac_to_pct c.summary.win_rate_pct))
-      ~relaxed:(_fmt_pct_unsigned (_wr_frac_to_pct r.summary.win_rate_pct))
-      ~delta:
-        (_delta_pp
-           ~constrained_v:(_wr_frac_to_pct c.summary.win_rate_pct)
-           ~actual:a.win_rate_pct);
-    _comp_row "MaxDD"
-      ~actual:(sprintf "-%.2f%%" a.max_drawdown_pct)
-      ~constrained_v:
-        (sprintf "-%.2f%%" (_dd_frac_to_pct c.summary.max_drawdown_pct))
-      ~relaxed:(sprintf "-%.2f%%" (_dd_frac_to_pct r.summary.max_drawdown_pct))
-      ~delta:
-        (_delta_pp
-           ~constrained_v:(-._dd_frac_to_pct c.summary.max_drawdown_pct)
-           ~actual:(-.a.max_drawdown_pct));
-    _comp_row "Sharpe"
-      ~actual:(_fmt_float_2 a.sharpe_ratio)
-      ~constrained_v:"n/a" ~relaxed:"n/a" ~delta:"n/a";
-    _comp_row "Profit factor"
-      ~actual:(_fmt_float_or_inf a.profit_factor)
-      ~constrained_v:(_fmt_float_or_inf c.summary.profit_factor)
-      ~relaxed:(_fmt_float_or_inf r.summary.profit_factor)
-      ~delta:"—";
-    _comp_row "Round-trips"
-      ~actual:(_fmt_int (List.length a.round_trips))
-      ~constrained_v:(_fmt_int c.summary.total_round_trips)
-      ~relaxed:(_fmt_int r.summary.total_round_trips)
-      ~delta:"—";
-    _comp_row "Avg R-multiple"
-      ~actual:(_fmt_float_2 actual_avg_r)
-      ~constrained_v:(_fmt_float_2 c.summary.avg_r_multiple)
-      ~relaxed:(_fmt_float_2 r.summary.avg_r_multiple)
-      ~delta:"—";
-    "";
-  ]
+  _headline_header_lines
+  @ [
+      _row_total_return ~actual_return ~c ~s ~r;
+      _row_win_rate ~a ~c ~s ~r;
+      _row_max_dd ~a ~c ~s ~r;
+      _row_sharpe ~a;
+      _row_profit_factor ~a ~c ~s ~r;
+      _row_round_trips ~a ~c ~s ~r;
+      _row_avg_r ~actual_avg_r ~c ~s ~r;
+      "";
+    ]
 
 (* ---------------------------------------------------------------- *)
 (* Section: per-Friday divergence table                              *)

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_report.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_report.mli
@@ -1,7 +1,7 @@
 (** Phase D of the optimal-strategy counterfactual: pure markdown renderer.
 
-    Takes the actual run's round-trips + summary plus the two counterfactual
-    variants (Constrained, Relaxed_macro) produced by the
+    Takes the actual run's round-trips + summary plus the three counterfactual
+    variants (Constrained, Score_picked, Relaxed_macro) produced by the
     {!Optimal_portfolio_filler} and emits a markdown string suitable for writing
     to [<output_dir>/optimal_strategy.md].
 
@@ -11,9 +11,13 @@
 
     - {b Run header.} Period, universe size, scenario name, and a loud
       disclaimer that the counterfactual uses look-ahead and is unrealizable.
-    - {b Headline comparison table.} Actual vs Constrained vs Relaxed-macro,
-      with a Δ column relative to the Constrained variant. Rows: Total return,
-      Win rate, MaxDD, Sharpe, Profit factor, Round-trips, Avg R-multiple.
+    - {b Headline comparison table.} Actual vs Constrained vs Score_picked vs
+      Relaxed-macro, with a Δ column relative to the Constrained variant. The
+      column ordering reads left-to-right as a gap decomposition: [Actual] →
+      [Score_picked] is cascade-ranking error (closeable); [Score_picked] →
+      [Constrained] is outcome-foresight bonus (uncloseable); [Constrained] →
+      [Relaxed_macro] is macro-gate cost. Rows: Total return, Win rate, MaxDD,
+      Sharpe, Profit factor, Round-trips, Avg R-multiple.
     - {b Per-Friday divergence table.} For each Friday where the actual and
       Constrained-counterfactual picks differ: the actual picks (symbols +
       sizes), the counterfactual picks, and the top-3 candidates the actual
@@ -38,7 +42,8 @@ type variant_pack = {
   summary : Optimal_types.optimal_summary;
 }
 (** A single counterfactual variant's round-trips + headline summary. {!render}
-    consumes one of these per variant (Constrained, Relaxed_macro). *)
+    consumes one of these per variant (Constrained, Score_picked,
+    Relaxed_macro). *)
 
 type actual_run = {
   scenario_name : string;
@@ -78,9 +83,15 @@ type actual_run = {
 type input = {
   actual : actual_run;
   constrained : variant_pack;
-      (** Counterfactual variant honouring the macro gate. *)
+      (** Macro-gated, ordered by realised R-multiple — outcome-foresight
+          ceiling. *)
+  score_picked : variant_pack;
+      (** Macro-gated, ordered by pre-trade [cascade_score] — the same signal
+          the live strategy uses. The [Strategy actual] → [Score_picked] gap
+          isolates cascade-ranking error from outcome-foresight bonus. *)
   relaxed_macro : variant_pack;
-      (** Counterfactual variant ignoring the macro gate. *)
+      (** Macro gate dropped, ordered by realised R-multiple — unconstrained
+          upper bound. *)
 }
 (** Inputs for {!render}. *)
 

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
@@ -343,23 +343,31 @@ let _scan_and_score ~(world : _world) : OT.scored_candidate list =
 
 let _emit_report ~output_dir ~(actual_run : Report.actual_run) ~scored : unit =
   let filler_config = Filler.default_config in
+  let starting_cash = actual_run.initial_cash in
   let constrained =
-    _build_variant ~filler_config ~variant:OT.Constrained ~scored
-      ~starting_cash:actual_run.initial_cash
+    _build_variant ~filler_config ~variant:OT.Constrained ~scored ~starting_cash
+  in
+  let score_picked =
+    _build_variant ~filler_config ~variant:OT.Score_picked ~scored
+      ~starting_cash
   in
   let relaxed_macro =
     _build_variant ~filler_config ~variant:OT.Relaxed_macro ~scored
-      ~starting_cash:actual_run.initial_cash
+      ~starting_cash
   in
   let input : Report.input =
-    { actual = actual_run; constrained; relaxed_macro }
+    { actual = actual_run; constrained; score_picked; relaxed_macro }
   in
   let md = Report.render input in
   let out_path = Filename.concat output_dir "optimal_strategy.md" in
   Out_channel.write_all out_path ~data:md;
   eprintf "optimal_strategy: wrote %s\n%!" out_path;
   Optimal_summary_artefact.write ~output_dir
-    { constrained = constrained.summary; relaxed_macro = relaxed_macro.summary }
+    {
+      constrained = constrained.summary;
+      score_picked = score_picked.summary;
+      relaxed_macro = relaxed_macro.summary;
+    }
 
 let run ~output_dir =
   eprintf "optimal_strategy: reading artefacts from %s\n%!" output_dir;

--- a/trading/trading/backtest/optimal/lib/optimal_summary_artefact.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_summary_artefact.ml
@@ -2,6 +2,7 @@ open Core
 
 type t = {
   constrained : Optimal_types.optimal_summary;
+  score_picked : Optimal_types.optimal_summary;
   relaxed_macro : Optimal_types.optimal_summary;
 }
 [@@deriving sexp]

--- a/trading/trading/backtest/optimal/lib/optimal_summary_artefact.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_summary_artefact.mli
@@ -2,9 +2,9 @@
     consumers (e.g. {!Release_report}) can read the headline counterfactual
     metrics without parsing markdown.
 
-    The on-disk shape is a record carrying both [Constrained] and
-    [Relaxed_macro] variants of {!Optimal_types.optimal_summary}; every field on
-    the markdown headline table is recoverable from this sexp. The
+    The on-disk shape is a record carrying the [Constrained], [Score_picked],
+    and [Relaxed_macro] variants of {!Optimal_types.optimal_summary}; every
+    field on the markdown headline table is recoverable from this sexp. The
     {!Optimal_strategy_runner} writes one to [<output_dir>/optimal_summary.sexp]
     on every run.
 
@@ -15,13 +15,19 @@
 
 type t = {
   constrained : Optimal_types.optimal_summary;
-      (** Counterfactual variant honouring the macro gate — the honest
-          comparison against the actual run. *)
+      (** Macro-gated, ordered by realised R-multiple (descending) — the
+          outcome-foresight ceiling against the actual run. *)
+  score_picked : Optimal_types.optimal_summary;
+      (** Macro-gated, ordered by pre-trade [cascade_score] (descending) — the
+          honest cascade-ranking comparison. The [Strategy actual] →
+          [Score_picked] gap is closeable cascade-ranking error; [Score_picked]
+          → [Constrained] is the (uncloseable) outcome-foresight bonus. *)
   relaxed_macro : Optimal_types.optimal_summary;
-      (** Counterfactual variant ignoring the macro gate — the upper bound. *)
+      (** Macro gate dropped, ordered by realised R-multiple — the unconstrained
+          upper bound. *)
 }
 [@@deriving sexp]
-(** The two-variant artefact emitted alongside [optimal_strategy.md]. *)
+(** The three-variant artefact emitted alongside [optimal_strategy.md]. *)
 
 val write : output_dir:string -> t -> unit
 (** [write ~output_dir t] writes [t] to [<output_dir>/optimal_summary.sexp] in

--- a/trading/trading/backtest/optimal/lib/optimal_types.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_types.ml
@@ -13,6 +13,7 @@ type candidate_entry = {
   risk_pct : float;
   sector : string;
   cascade_grade : Weinstein_types.grade;
+  cascade_score : int;
   passes_macro : bool;
 }
 [@@deriving sexp]
@@ -61,4 +62,5 @@ type optimal_summary = {
   variant : variant_label;
 }
 
-and variant_label = Constrained | Relaxed_macro [@@deriving sexp]
+and variant_label = Constrained | Score_picked | Relaxed_macro
+[@@deriving sexp]

--- a/trading/trading/backtest/optimal/lib/optimal_types.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_types.mli
@@ -51,6 +51,13 @@ type candidate_entry = {
       (** Cascade grade the live screener would have assigned. Recorded for the
           per-Friday divergence report (PR-4) so the renderer can attribute
           missed entries to "filtered by grade threshold". *)
+  cascade_score : int;
+      (** Cascade score the live screener would have assigned at [entry_week] —
+          the integer composite score the cascade ranks candidates by before
+          applying the grade threshold. Recorded so the {!Score_picked}
+          counterfactual variant can sort by the same pre-trade signal the live
+          strategy uses, isolating cascade-ranking error from outcome-foresight
+          ordering. *)
   passes_macro : bool;
       (** Whether the macro gate at [entry_week] would have admitted this
           candidate. The scanner records both passes and fails so the renderer
@@ -167,12 +174,24 @@ type optimal_summary = {
     pipeline can split rows by variant without re-running Phase A. *)
 and variant_label =
   | Constrained
-      (** Macro gate honoured — counterfactual only enters candidates whose
-          [passes_macro] flag was [true] at the breakout week. The honest
-          comparison: "what's reachable if cascade ranking were perfect, all
-          else equal?" *)
+      (** Macro gate honoured AND candidates ordered by realised [r_multiple]
+          (descending). Picks winners with full outcome foresight — the upper
+          bound on "what's reachable if cascade ranking + sizing were perfectly
+          informed about future returns, with macro gate kept". Useful as a
+          ceiling, but {b not} a target the live strategy can hit (the live
+          filler can't peek at future R-multiples). *)
+  | Score_picked
+      (** Macro gate honoured AND candidates ordered by pre-trade
+          [cascade_score] (descending) — the same signal the actual strategy
+          uses. Closes the perfect-foresight contamination in {!Constrained} so
+          the gap "Strategy actual" → [Score_picked] reads cleanly as
+          {b cascade-ranking error} (closeable by improving the screener), and
+          the gap [Score_picked] → [Constrained] reads as
+          {b outcome-foresight bonus} (uncloseable; requires hindsight). Ties
+          broken by symbol ASC for determinism. *)
   | Relaxed_macro
-      (** Macro gate dropped — every candidate is eligible regardless of regime.
-          The upper bound: "what's reachable if we also relaxed the macro gate?"
-      *)
+      (** Macro gate dropped AND candidates ordered by realised [r_multiple]
+          (descending). The unconstrained upper bound: "what's reachable if we
+          also relaxed the macro gate?" The [Constrained] → [Relaxed_macro] gap
+          reads as macro-gate cost. *)
 [@@deriving sexp]

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -65,6 +65,7 @@ let _candidate_of_scored ~date ~passes_macro (sc : Screener.scored_candidate) :
     risk_pct = sc.risk_pct;
     sector = sc.sector.sector_name;
     cascade_grade = sc.grade;
+    cascade_score = sc.score;
     passes_macro;
   }
 

--- a/trading/trading/backtest/optimal/test/test_optimal_portfolio_filler.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_portfolio_filler.ml
@@ -30,7 +30,7 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     ?(side = Trading_base.Types.Long) ?(entry_price = 100.0)
     ?(suggested_stop = 90.0) ?(risk_pct = 0.10)
     ?(sector = "Information Technology") ?(cascade_grade = Weinstein_types.B)
-    ?(passes_macro = true) () : OT.candidate_entry =
+    ?(cascade_score = 0) ?(passes_macro = true) () : OT.candidate_entry =
   {
     symbol;
     entry_week;
@@ -40,6 +40,7 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     risk_pct;
     sector;
     cascade_grade;
+    cascade_score;
     passes_macro;
   }
 
@@ -50,8 +51,9 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
 let make_scored ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     ?(side = Trading_base.Types.Long) ?(entry_price = 100.0)
     ?(suggested_stop = 90.0) ?(sector = "Information Technology")
-    ?(passes_macro = true) ?(exit_week_offset_weeks = 4) ?(r_multiple = 2.0)
-    ?(exit_trigger = OT.End_of_run) () : OT.scored_candidate =
+    ?(cascade_score = 0) ?(passes_macro = true) ?(exit_week_offset_weeks = 4)
+    ?(r_multiple = 2.0) ?(exit_trigger = OT.End_of_run) () : OT.scored_candidate
+    =
   let initial_risk_per_share = Float.abs (entry_price -. suggested_stop) in
   let raw_return_pct = r_multiple *. (initial_risk_per_share /. entry_price) in
   let exit_price =
@@ -63,7 +65,7 @@ let make_scored ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
   let entry =
     make_candidate ~symbol ~entry_week ~side ~entry_price ~suggested_stop
       ~risk_pct:(initial_risk_per_share /. entry_price)
-      ~sector ~passes_macro ()
+      ~sector ~cascade_score ~passes_macro ()
   in
   {
     entry;
@@ -135,6 +137,102 @@ let test_simultaneous_candidates_ranked_by_r_descending _ =
            (fun (rt : OT.optimal_round_trip) -> rt.symbol)
            (equal_to "STRONG");
          field (fun (rt : OT.optimal_round_trip) -> rt.symbol) (equal_to "WEAK");
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Variant-driven sort key — Score_picked vs Constrained                *)
+(* ------------------------------------------------------------------ *)
+
+(** With [max_positions = 1] and two same-Friday candidates A and B where:
+    - A has the higher pre-trade [cascade_score] but the lower realised
+      [r_multiple];
+    - B has the higher [r_multiple] but the lower [cascade_score];
+
+    [Score_picked] must admit A first (orders by score DESC, the same signal the
+    live strategy uses) while [Constrained] must admit B first (orders by
+    R-multiple DESC, full outcome foresight). This pins that the variant flips
+    the per-Friday sort key — the central PR-4 contract. *)
+let test_score_picked_orders_by_score_constrained_by_r_multiple _ =
+  let cfg = { F.default_config with max_positions = 1 } in
+  let high_score_low_r =
+    make_scored ~symbol:"A" ~cascade_score:90 ~r_multiple:1.0 ~sector:"Sector_A"
+      ()
+  in
+  let low_score_high_r =
+    make_scored ~symbol:"B" ~cascade_score:10 ~r_multiple:5.0 ~sector:"Sector_B"
+      ()
+  in
+  let candidates = [ high_score_low_r; low_score_high_r ] in
+  let score_picked =
+    F.fill ~config:cfg { candidates; variant = OT.Score_picked }
+  in
+  let constrained =
+    F.fill ~config:cfg { candidates; variant = OT.Constrained }
+  in
+  assert_that
+    (score_picked, constrained)
+    (all_of
+       [
+         field
+           (fun (sp, _) -> sp)
+           (elements_are
+              [
+                field
+                  (fun (rt : OT.optimal_round_trip) -> rt.symbol)
+                  (equal_to "A");
+              ]);
+         field
+           (fun (_, c) -> c)
+           (elements_are
+              [
+                field
+                  (fun (rt : OT.optimal_round_trip) -> rt.symbol)
+                  (equal_to "B");
+              ]);
+       ])
+
+(** Score_picked tie-break: when two same-Friday candidates have identical
+    [cascade_score], the comparator falls back to symbol ASC to keep the order
+    deterministic across runs. With [max_positions = 1] the alphabetically
+    earlier symbol must be admitted. *)
+let test_score_picked_tie_breaks_by_symbol_asc _ =
+  let cfg = { F.default_config with max_positions = 1 } in
+  let later_alpha =
+    make_scored ~symbol:"ZED" ~cascade_score:50 ~r_multiple:5.0
+      ~sector:"Sector_A" ()
+  in
+  let earlier_alpha =
+    make_scored ~symbol:"ABC" ~cascade_score:50 ~r_multiple:1.0
+      ~sector:"Sector_B" ()
+  in
+  let result =
+    F.fill ~config:cfg
+      { candidates = [ later_alpha; earlier_alpha ]; variant = OT.Score_picked }
+  in
+  assert_that result
+    (elements_are
+       [
+         field (fun (rt : OT.optimal_round_trip) -> rt.symbol) (equal_to "ABC");
+       ])
+
+(** Score_picked honours the macro gate just like Constrained: a candidate with
+    [passes_macro = false] must be dropped. Mirrors
+    [test_constrained_variant_drops_macro_fail] for the new variant. *)
+let test_score_picked_drops_macro_fail _ =
+  let pass =
+    make_scored ~symbol:"AAPL" ~cascade_score:50 ~passes_macro:true ()
+  in
+  let fail =
+    make_scored ~symbol:"MSFT" ~cascade_score:90 ~passes_macro:false ()
+  in
+  let result =
+    F.fill ~config:F.default_config
+      { candidates = [ pass; fail ]; variant = OT.Score_picked }
+  in
+  assert_that result
+    (elements_are
+       [
+         field (fun (rt : OT.optimal_round_trip) -> rt.symbol) (equal_to "AAPL");
        ])
 
 (* ------------------------------------------------------------------ *)
@@ -329,6 +427,12 @@ let suite =
          >:: test_relaxed_macro_admits_both;
          "simultaneous candidates ranked by R-multiple desc"
          >:: test_simultaneous_candidates_ranked_by_r_descending;
+         "Score_picked orders by cascade_score; Constrained by r_multiple"
+         >:: test_score_picked_orders_by_score_constrained_by_r_multiple;
+         "Score_picked tie-breaks by symbol ASC"
+         >:: test_score_picked_tie_breaks_by_symbol_asc;
+         "Score_picked drops macro-fail candidates"
+         >:: test_score_picked_drops_macro_fail;
          "concurrent-position cap forces lower-rank skip"
          >:: test_concurrent_position_cap_forces_skip;
          "sector cap forces skip even when ranking allows"

--- a/trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_strategy_report.ml
@@ -101,13 +101,19 @@ let test_all_sections_present _ =
       summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
     }
   in
+  let score_picked =
+    {
+      R.round_trips = [];
+      summary = _make_summary ~total_return_pct:0.25 ~variant:OT.Score_picked;
+    }
+  in
   let relaxed_macro =
     {
       R.round_trips = [];
       summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
   assert_that md
     (all_of
        [
@@ -124,12 +130,18 @@ let test_all_sections_present _ =
 (* Headline table cells                                                *)
 (* ------------------------------------------------------------------ *)
 
-let test_headline_includes_three_variants _ =
+let test_headline_includes_four_variants _ =
   let actual = _make_actual () in
   let constrained =
     {
       R.round_trips = [];
       summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
+    }
+  in
+  let score_picked =
+    {
+      R.round_trips = [];
+      summary = _make_summary ~total_return_pct:0.25 ~variant:OT.Score_picked;
     }
   in
   let relaxed_macro =
@@ -138,17 +150,21 @@ let test_headline_includes_three_variants _ =
       summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
-  (* +18.00% (actual) vs +30.00% (constrained) vs +45.00% (relaxed) *)
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
+  (* +18.00% (actual) vs +30.00% (constrained) vs +25.00% (score_picked)
+     vs +45.00% (relaxed). The Score_picked column header reads
+     "Optimal (score_picked)" in the rendered table. *)
   assert_that md
     (all_of
        [
          _has "+18.00%";
          _has "+30.00%";
+         _has "+25.00%";
          _has "+45.00%";
          _has "Total return";
          _has "MaxDD";
          _has "Round-trips";
+         _has "Optimal (score_picked)";
        ])
 
 (* ------------------------------------------------------------------ *)
@@ -178,13 +194,19 @@ let test_missed_trades_with_reason _ =
       summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
     }
   in
+  let score_picked =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.25 ~variant:OT.Score_picked;
+    }
+  in
   let relaxed_macro =
     {
       R.round_trips = constrained_rts;
       summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
   assert_that md
     (all_of
        [
@@ -207,13 +229,19 @@ let test_implications_high_ratio _ =
       summary = _make_summary ~total_return_pct:0.60 ~variant:OT.Constrained;
     }
   in
+  let score_picked =
+    {
+      R.round_trips = [];
+      summary = _make_summary ~total_return_pct:0.50 ~variant:OT.Score_picked;
+    }
+  in
   let relaxed_macro =
     {
       R.round_trips = [];
       summary = _make_summary ~total_return_pct:0.80 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
   assert_that md (_has "significantly mis-scoring")
 
 let test_implications_low_ratio _ =
@@ -226,13 +254,19 @@ let test_implications_low_ratio _ =
       summary = _make_summary ~total_return_pct:0.20 ~variant:OT.Constrained;
     }
   in
+  let score_picked =
+    {
+      R.round_trips = [];
+      summary = _make_summary ~total_return_pct:0.19 ~variant:OT.Score_picked;
+    }
+  in
   let relaxed_macro =
     {
       R.round_trips = [];
       summary = _make_summary ~total_return_pct:0.25 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
   assert_that md (_has "near-optimal")
 
 let test_implications_degenerate _ =
@@ -249,13 +283,19 @@ let test_implications_degenerate _ =
       summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
     }
   in
+  let score_picked =
+    {
+      R.round_trips = [];
+      summary = _make_summary ~total_return_pct:0.25 ~variant:OT.Score_picked;
+    }
+  in
   let relaxed_macro =
     {
       R.round_trips = [];
       summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
   assert_that md (_has "non-positive")
 
 (* ------------------------------------------------------------------ *)
@@ -270,6 +310,12 @@ let test_render_is_deterministic _ =
         {
           R.round_trips = [];
           summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
+        };
+      score_picked =
+        {
+          R.round_trips = [];
+          summary =
+            _make_summary ~total_return_pct:0.25 ~variant:OT.Score_picked;
         };
       relaxed_macro =
         {
@@ -295,13 +341,19 @@ let test_ends_with_newline _ =
       summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
     }
   in
+  let score_picked =
+    {
+      R.round_trips = [];
+      summary = _make_summary ~total_return_pct:0.25 ~variant:OT.Score_picked;
+    }
+  in
   let relaxed_macro =
     {
       R.round_trips = [];
       summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
   assert_that md
     (field
        (fun s -> Char.equal (String.get s (String.length s - 1)) '\n')
@@ -356,13 +408,19 @@ let test_divergence_pins_specific_cells _ =
       summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
     }
   in
+  let score_picked =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.25 ~variant:OT.Score_picked;
+    }
+  in
   let relaxed_macro =
     {
       R.round_trips = constrained_rts;
       summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
   assert_that md
     (all_of
        [
@@ -428,13 +486,19 @@ let test_missed_trades_ordered_by_pnl_descending _ =
       summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
     }
   in
+  let score_picked =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.25 ~variant:OT.Score_picked;
+    }
+  in
   let relaxed_macro =
     {
       R.round_trips = constrained_rts;
       summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
   (* Restrict the search to the missed-trades section so we don't pick up
      symbol mentions from the divergence section (which lists them by
      entry-week, not by P&L). *)
@@ -495,13 +559,19 @@ let test_empty_divergence_renders_sentinel _ =
       summary = _make_summary ~total_return_pct:0.30 ~variant:OT.Constrained;
     }
   in
+  let score_picked =
+    {
+      R.round_trips = constrained_rts;
+      summary = _make_summary ~total_return_pct:0.25 ~variant:OT.Score_picked;
+    }
+  in
   let relaxed_macro =
     {
       R.round_trips = constrained_rts;
       summary = _make_summary ~total_return_pct:0.45 ~variant:OT.Relaxed_macro;
     }
   in
-  let md = R.render { actual; constrained; relaxed_macro } in
+  let md = R.render { actual; constrained; score_picked; relaxed_macro } in
   assert_that md
     (all_of
        [
@@ -519,8 +589,8 @@ let suite =
   "Optimal_strategy_report"
   >::: [
          "all five sections present" >:: test_all_sections_present;
-         "headline shows three variant columns"
-         >:: test_headline_includes_three_variants;
+         "headline shows four variant columns"
+         >:: test_headline_includes_four_variants;
          "missed trades flag cascade-rejection reason"
          >:: test_missed_trades_with_reason;
          "implications: high ratio fires mis-scoring branch"

--- a/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
@@ -288,8 +288,10 @@ let test_run_emits_optimal_summary_sexp _ =
            (all_of
               [
                 _has "(constrained";
+                _has "(score_picked";
                 _has "(relaxed_macro";
                 _has "(variant Constrained)";
+                _has "(variant Score_picked)";
                 _has "(variant Relaxed_macro)";
               ]);
        ])

--- a/trading/trading/backtest/optimal/test/test_outcome_scorer.ml
+++ b/trading/trading/backtest/optimal/test/test_outcome_scorer.ml
@@ -31,7 +31,7 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     ?(side = Trading_base.Types.Long) ?(entry_price = 100.0)
     ?(suggested_stop = 92.0) ?(risk_pct = 0.08)
     ?(sector = "Information Technology") ?(cascade_grade = Weinstein_types.B)
-    ?(passes_macro = true) () : OT.candidate_entry =
+    ?(cascade_score = 0) ?(passes_macro = true) () : OT.candidate_entry =
   {
     symbol;
     entry_week;
@@ -41,6 +41,7 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     risk_pct;
     sector;
     cascade_grade;
+    cascade_score;
     passes_macro;
   }
 

--- a/trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml
@@ -125,6 +125,7 @@ let test_candidate_entry_sexp_round_trip _ =
       risk_pct = 0.08;
       sector = "Information Technology";
       cascade_grade = A;
+      cascade_score = 75;
       passes_macro = true;
     }
   in
@@ -153,6 +154,7 @@ let test_scored_candidate_sexp_round_trip _ =
       risk_pct = 0.08;
       sector = "Information Technology";
       cascade_grade = B;
+      cascade_score = 60;
       passes_macro = true;
     }
   in


### PR DESCRIPTION
## Summary

Adds a third optimal-strategy variant alongside Constrained / Relaxed_macro:

- **Score_picked** — sorts entries by the screener's pre-trade \`cascade_score\` (DESC), tie-broken by ticker. Same signal the actual strategy uses, no perfect-foresight contamination.

The new gap structure is:

\`\`\`
Strategy actual → Score_picked: cascade-ranking error
                                (closeable: improve scoring weights / signals)
Score_picked → Constrained:   outcome-foresight bonus
                                (uncloseable: requires hindsight)
Constrained → Relaxed_macro:  macro-gate cost
\`\`\`

Per the plan in PR #747 (D1 in \`dev/plans/optimal-strategy-improvements-2026-05-01.md\`).

## Test plan

- [x] dune build clean
- [x] dune runtest trading/backtest/optimal/test passes
- [x] dune fmt clean
- [ ] CI verifies on Linux

## Notes

This PR was salvaged from a stalled subagent worktree (the original agent stalled mid-edit with watchdog timeout; commits were applied + verified in-session before push). The branch is named \`-v2\` because the agent's original branch existed but didn't have any commits pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)