### PR TITLE
fix(simulation): unique test_data dir per split_day_stop_exit sub-test

### DIFF
--- a/trading/trading/simulation/test/test_split_day_stop_exit.ml
+++ b/trading/trading/simulation/test/test_split_day_stop_exit.ml
@@ -210,15 +210,18 @@ let _last_step steps =
   | None -> assert_failure "no steps in result"
 
 (** Run the simulation and return the result. Builds test data via
-    [with_test_data]. *)
-let _run_split_exit_simulation ~trigger_exit_on =
+    [with_test_data]. [test_name] is used as the unique CSV-storage subdirectory
+    so OUnit's parallel sub-test execution does not race on
+    [test_data/<name>/...] setup/teardown. Each sub-test in [suite] passes its
+    own name. *)
+let _run_split_exit_simulation ~test_name ~trigger_exit_on =
   let module Strat = Make_buy_then_exit (struct
     let symbol = "TEST"
     let target_quantity = 100.0
     let trigger_exit_on_or_after = trigger_exit_on
   end) in
   let result_ref = ref None in
-  with_test_data "split_day_stop_exit"
+  with_test_data test_name
     [ ("TEST", _split_bars) ]
     ~f:(fun data_dir ->
       let deps =
@@ -256,7 +259,8 @@ let _run_split_exit_simulation ~trigger_exit_on =
     Pin: broker.positions is empty at the last step. *)
 let test_post_split_exit_clears_position _ =
   let result =
-    _run_split_exit_simulation ~trigger_exit_on:(_date "2024-01-09")
+    _run_split_exit_simulation ~test_name:"split_day_stop_exit_clears_position"
+      ~trigger_exit_on:(_date "2024-01-09")
   in
   let last = _last_step result.steps in
   assert_that last.portfolio.positions (size_is 0)
@@ -277,7 +281,8 @@ let test_post_split_exit_clears_position _ =
     portfolio_value to ~$100K to fail in that regime. *)
 let test_post_split_exit_no_orphan_equity _ =
   let result =
-    _run_split_exit_simulation ~trigger_exit_on:(_date "2024-01-09")
+    _run_split_exit_simulation ~test_name:"split_day_stop_exit_no_orphan_equity"
+      ~trigger_exit_on:(_date "2024-01-09")
   in
   let last = _last_step result.steps in
   assert_that last
@@ -318,7 +323,9 @@ let test_post_split_exit_no_orphan_equity _ =
     the post-fill broker holds 0 shares. *)
 let test_split_day_position_reflects_post_split _ =
   let result =
-    _run_split_exit_simulation ~trigger_exit_on:(_date "2024-01-08")
+    _run_split_exit_simulation
+      ~test_name:"split_day_stop_exit_reflects_post_split"
+      ~trigger_exit_on:(_date "2024-01-08")
   in
   let last = _last_step result.steps in
   let last_cash_or_value =


### PR DESCRIPTION
## Summary

Fixes flaky `split_day_stop_exit` test suite. CI failure on main: [run 25238889053](https://github.com/dayfine/trading/actions/runs/25238889053). Root cause: all 3 sub-tests in `test_split_day_stop_exit.ml` shared a single CSV-storage subdirectory `test_data/split_day_stop_exit/` via `with_test_data "split_day_stop_exit"`, racing on directory create/delete when OUnit runs them in parallel (default 2 shards).

Sister files `test_split_day_mtm.ml` and `test_split_day_audit.ml` correctly use unique `test_name` per sub-test (`split_day_mtm_continuous`, `audit_01_no_position`, etc.). This PR brings `test_split_day_stop_exit.ml` into line.

## Two failure modes (both fixed by the same change)

1. **Local — dir-create race**: `Failure("create directory test_data/split_day_stop_exit/T/T/TEST: test_data/split_day_stop_exit/T/: No such file or directory")`. Reproduces ~4% of runs (4/100 in my repro).

2. **CI — partial CSV cash drift**: shard A's `setup_test_data` deletes shard B's data dir mid-execution; shard B reads partial CSV; simulator processes wrong bars; entry order fills at unexpected price; final cash $99,600 instead of $100,000 ($400 = 100 × $4 artifact). Hit once in CI run 25238889053.

## Change

Added `~test_name:string` parameter to `_run_split_exit_simulation`. Each of the 3 tests now passes a unique name:
- `split_day_stop_exit_clears_position`
- `split_day_stop_exit_no_orphan_equity`
- `split_day_stop_exit_reflects_post_split`

Pure mechanical change, no source-code modification, no behavioral change in the underlying split-day fix from #678.

## Test plan
- [x] 200/200 PASS in flakiness sweep (`for i in $(seq 1 200); do ./_build/default/.../test_split_day_stop_exit.exe; done`)
- [x] Full `dune build && dune runtest` clean (lint warnings unchanged from main)
- [x] `dune build @fmt --auto-promote` clean
- [x] No source files touched; only `trading/simulation/test/test_split_day_stop_exit.ml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)