### PR TITLE
feat(snapshot): weekly snapshot writer/reader (M6.1)

### DIFF
--- a/trading/trading/weinstein/snapshot/lib/dune
+++ b/trading/trading/weinstein/snapshot/lib/dune
@@ -1,0 +1,12 @@
+(library
+ (name weinstein_snapshot)
+ (public_name weinstein_trading.snapshot)
+ (libraries
+  core
+  core_unix
+  core_unix.sys_unix
+  core_unix.filename_unix
+  sexplib
+  status)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/weinstein/snapshot/lib/snapshot_reader.ml
+++ b/trading/trading/weinstein/snapshot/lib/snapshot_reader.ml
@@ -1,0 +1,45 @@
+open Core
+
+let _check_schema_version (t : Weekly_snapshot.t) =
+  let expected = Weekly_snapshot.current_schema_version in
+  if t.schema_version = expected then Ok t
+  else
+    Error
+      (Status.invalid_argument_error
+         (Printf.sprintf "Snapshot schema_version mismatch: expected %d, got %d"
+            expected t.schema_version))
+
+let parse (s : string) : Weekly_snapshot.t Status.status_or =
+  match
+    try Ok (Sexp.of_string (String.strip s))
+    with exn ->
+      Error
+        (Status.invalid_argument_error
+           (Printf.sprintf "Invalid sexp: %s" (Exn.to_string exn)))
+  with
+  | Error _ as e -> e
+  | Ok sexp -> (
+      match
+        try Ok (Weekly_snapshot.t_of_sexp sexp)
+        with exn ->
+          Error
+            (Status.invalid_argument_error
+               (Printf.sprintf "Snapshot schema mismatch: %s"
+                  (Exn.to_string exn)))
+      with
+      | Error _ as e -> e
+      | Ok t -> _check_schema_version t)
+
+let read_from_file path =
+  if not (Sys_unix.file_exists_exn path) then
+    Error
+      (Status.not_found_error
+         (Printf.sprintf "Snapshot file not found: %s" path))
+  else
+    try
+      let contents = In_channel.read_all path in
+      parse contents
+    with exn ->
+      Error
+        (Status.internal_error
+           (Printf.sprintf "Failed to read %s: %s" path (Exn.to_string exn)))

--- a/trading/trading/weinstein/snapshot/lib/snapshot_reader.mli
+++ b/trading/trading/weinstein/snapshot/lib/snapshot_reader.mli
@@ -1,0 +1,34 @@
+(** Sexp parser for {!Weekly_snapshot.t}.
+
+    Inverse of {!Snapshot_writer.serialize}. The round-trip property
+    [parse (serialize t) = Ok t] is pinned by [test_round_trip.ml].
+
+    {1 Schema-version handling}
+
+    The parser checks [schema_version] against
+    {!Weekly_snapshot.current_schema_version} and returns
+    [Error Invalid_argument] if they do not match. This is intentional: silently
+    accepting an older or newer schema risks misinterpreting fields that have
+    been added, removed, or repurposed. Future migrations should land as an
+    explicit [migrate_v<N>_to_v<M>] utility, not as silent acceptance. *)
+
+val parse : string -> Weekly_snapshot.t Status.status_or
+(** [parse s] parses a snapshot from its sexp string form.
+
+    Returns:
+    - [Ok t] on success.
+    - [Error Invalid_argument] if [s] is not valid sexp or does not match the
+      snapshot schema (missing required fields, wrong types).
+    - [Error Invalid_argument] (with a "schema_version mismatch" message) if [s]
+      parses but its [schema_version] does not match
+      {!Weekly_snapshot.current_schema_version}. The error message names both
+      the expected and actual versions so callers can decide whether to migrate.
+*)
+
+val read_from_file : string -> Weekly_snapshot.t Status.status_or
+(** [read_from_file path] reads and parses a snapshot from disk.
+
+    Returns:
+    - [Ok t] on success.
+    - [Error NotFound] if [path] does not exist.
+    - Errors from {!parse} otherwise. *)

--- a/trading/trading/weinstein/snapshot/lib/snapshot_writer.ml
+++ b/trading/trading/weinstein/snapshot/lib/snapshot_writer.ml
@@ -1,0 +1,42 @@
+open Core
+
+let serialize (t : Weekly_snapshot.t) : string =
+  let sexp = Weekly_snapshot.sexp_of_t t in
+  Sexp.to_string_hum sexp ^ "\n"
+
+let path_for ~root ~system_version date =
+  let date_str = Date.to_string date in
+  Filename.concat (Filename.concat root system_version) (date_str ^ ".sexp")
+
+let _mkdir_p_for_file path =
+  let dir = Filename.dirname path in
+  try
+    Core_unix.mkdir_p dir;
+    Ok ()
+  with exn ->
+    Error
+      (Status.internal_error
+         (Printf.sprintf "Failed to create directory %s: %s" dir
+            (Exn.to_string exn)))
+
+let _write_file path contents =
+  try
+    Out_channel.write_all path ~data:contents;
+    Ok path
+  with exn ->
+    Error
+      (Status.internal_error
+         (Printf.sprintf "Failed to write %s: %s" path (Exn.to_string exn)))
+
+let write_to_file ~root ~system_version (t : Weekly_snapshot.t) =
+  if not (String.equal t.system_version system_version) then
+    Error
+      (Status.invalid_argument_error
+         (Printf.sprintf
+            "Snapshot system_version (%s) does not match write directory (%s)"
+            t.system_version system_version))
+  else
+    let path = path_for ~root ~system_version t.date in
+    let contents = serialize t in
+    Result.bind (_mkdir_p_for_file path) ~f:(fun () ->
+        _write_file path contents)

--- a/trading/trading/weinstein/snapshot/lib/snapshot_writer.mli
+++ b/trading/trading/weinstein/snapshot/lib/snapshot_writer.mli
@@ -1,0 +1,50 @@
+(** Sexp serializer for {!Weekly_snapshot.t}.
+
+    Produces a canonical, sortable on-disk representation. The output is plain
+    sexp (no compression, no binary framing) — same shape used throughout the
+    codebase — so existing sexp-aware tooling (jq-style readers, [sexp pretty])
+    works without adaptation.
+
+    {1 Output shape}
+
+    See {!Weekly_snapshot} for the field-by-field schema.
+
+    {1 File naming}
+
+    The {!path_for} helper returns the canonical on-disk path for a snapshot.
+    File names use the [YYYY-MM-DD.sexp] form so lexicographic listing equals
+    chronological order.
+
+    {1 Round-trip}
+
+    [Snapshot_reader.parse (serialize t) = Ok t] for every well-formed [t]. The
+    round-trip property is pinned by [test_round_trip.ml]. *)
+
+open Core
+
+val serialize : Weekly_snapshot.t -> string
+(** [serialize t] returns the sexp form of [t] as a string, with a trailing
+    newline. The output is canonical: deterministic field order, no comments. *)
+
+val path_for : root:string -> system_version:string -> Date.t -> string
+(** [path_for ~root ~system_version date] returns the canonical on-disk path for
+    a snapshot of the given system version and date.
+
+    Layout: [<root>/<system_version>/<YYYY-MM-DD>.sexp].
+
+    Pure function — does not touch the filesystem. *)
+
+val write_to_file :
+  root:string ->
+  system_version:string ->
+  Weekly_snapshot.t ->
+  string Status.status_or
+(** [write_to_file ~root ~system_version t] serializes [t] and writes it to
+    [path_for ~root ~system_version t.date], creating parent directories as
+    needed. Returns the path written on success.
+
+    Errors are reported as [Status.t]:
+
+    - [Invalid_argument] if [t.system_version <> system_version] (guard against
+      mis-routed writes).
+    - [Internal] if filesystem I/O fails. *)

--- a/trading/trading/weinstein/snapshot/lib/weekly_snapshot.ml
+++ b/trading/trading/weinstein/snapshot/lib/weekly_snapshot.ml
@@ -1,0 +1,40 @@
+open Core
+
+let current_schema_version = 1
+
+type macro_context = { regime : string; score : float }
+[@@deriving sexp, eq, show]
+
+type candidate = {
+  symbol : string;
+  score : float;
+  grade : string;
+  entry : float;
+  stop : float;
+  sector : string;
+  rationale : string;
+  rs_vs_spy : float option;
+  resistance_grade : string option;
+}
+[@@deriving sexp, eq, show]
+
+type held_position = {
+  symbol : string;
+  entered : Date.t;
+  stop : float;
+  status : string;
+}
+[@@deriving sexp, eq, show]
+
+type t = {
+  schema_version : int;
+  system_version : string;
+  date : Date.t;
+  macro : macro_context;
+  sectors_strong : string list;
+  sectors_weak : string list;
+  long_candidates : candidate list;
+  short_candidates : candidate list;
+  held_positions : held_position list;
+}
+[@@deriving sexp, eq, show]

--- a/trading/trading/weinstein/snapshot/lib/weekly_snapshot.mli
+++ b/trading/trading/weinstein/snapshot/lib/weekly_snapshot.mli
@@ -1,0 +1,125 @@
+(** Weekly snapshot — durable, sexp-serializable view of one Friday-close
+    screener run.
+
+    A snapshot is a {b frozen} view of what the system saw and decided on a
+    single trading week. It captures:
+
+    - the macro regime gate that drove cascade decisions,
+    - the set of strong / weak sectors,
+    - the ranked long and short candidates (with score, grade, suggested entry,
+      suggested stop, sector, rationale),
+    - the held positions that survived this Friday's update.
+
+    These artifacts are written under
+    [dev/weekly-picks/<system-version>/<date>.sexp] and consumed by the
+    forward-trace (M6.2), cross-version diff (M6.3), and weekly report (M6.5)
+    tools.
+
+    {1 Design}
+
+    Snapshot record types are {b independent} of in-memory analysis types
+    ([Screener.scored_candidate], [Macro.result], [Position.t]). This decouples
+    the on-disk schema from upstream type evolution: a future refactor of
+    [scored_candidate] cannot silently change the snapshot format.
+
+    Serialization is via OCaml [sexp] — same shape as the rest of the codebase.
+    Empty data sections (no candidates, no held positions, no strong sectors)
+    serialize as [()] and round-trip cleanly.
+
+    {1 Schema versioning}
+
+    Every snapshot carries a [schema_version] field. The reader rejects any file
+    whose schema version it does not recognize, with a clear error message. The
+    {b current} schema version is {!current_schema_version}.
+
+    Bump {!current_schema_version} whenever the on-disk shape changes
+    incompatibly. Forward-compatible additions (new optional fields) do {b not}
+    require a bump if [sexp] derives a default for missing fields. *)
+
+open Core
+
+val current_schema_version : int
+(** The schema version this module emits and accepts. Bump when the on-disk
+    shape changes incompatibly. *)
+
+type macro_context = {
+  regime : string;
+      (** Macro regime as a string (e.g. ["Bullish"], ["Bearish"], ["Neutral"]).
+          Stored as string rather than [Weinstein_types.market_trend] to keep
+          the snapshot schema decoupled from upstream variant evolution. *)
+  score : float;
+      (** Macro confidence / score in [-1.0, 1.0] or [0.0, 1.0] depending on the
+          producing analyzer. Recorded verbatim. *)
+}
+[@@deriving sexp, eq, show]
+(** Macro regime context — the gate that drove this Friday's cascade. *)
+
+type candidate = {
+  symbol : string;  (** Ticker symbol (e.g. ["AAPL"]). *)
+  score : float;
+      (** Numeric score from the screener. Higher is better. Stored as [float]
+          (the screener uses [int] internally; we widen here so future scoring
+          changes don't force a schema bump). *)
+  grade : string;
+      (** Grade label as displayed (e.g. ["A+"], ["A"], ["B"]). Stored as string
+          — see [macro_context.regime] for the rationale. *)
+  entry : float;  (** Suggested buy-stop / sell-stop entry price. *)
+  stop : float;
+      (** Suggested initial stop price. For longs, below the prior base low; for
+          shorts, above the prior rally high. *)
+  sector : string;
+      (** Sector label (e.g. ["XLK"], ["Information Technology"]). Free-form
+          string — caller chooses the labeling convention. *)
+  rationale : string;
+      (** Human-readable single-line rationale (e.g.
+          ["Stage2 breakout above 30wk MA, 2.1x volume confirmation"]).
+          Multi-signal rationales should be joined with a separator before being
+          stored. *)
+  rs_vs_spy : float option;
+      (** Relative strength vs SPY at pick time, if computed. [None] if not
+          available. *)
+  resistance_grade : string option;
+      (** Resistance quality grade (e.g. ["A"], ["Virgin_territory"]). [None] if
+          not computed. *)
+}
+[@@deriving sexp, eq, show]
+(** A single ranked candidate. Same shape for long and short candidates — the
+    list it lives in determines side. *)
+
+type held_position = {
+  symbol : string;  (** Ticker of the held position. *)
+  entered : Date.t;  (** Date the position was opened. *)
+  stop : float;  (** Current stop price (post any trailing adjustment). *)
+  status : string;
+      (** Status label (e.g. ["Holding"], ["Exiting"]). Stored as string — see
+          [macro_context.regime] for the rationale. *)
+}
+[@@deriving sexp, eq, show]
+(** A held position carried into this Friday. Captures only what's needed for
+    the report; full position state lives in [Position.t]. *)
+
+type t = {
+  schema_version : int;
+      (** Schema version this snapshot was written with. The reader checks this
+          against {!current_schema_version}. *)
+  system_version : string;
+      (** System version tag — typically a git commit SHA (e.g. ["c93bf39d"]).
+          Used by the cross-version diff (M6.3) to label the producing system.
+      *)
+  date : Date.t;
+      (** The Friday-close date this snapshot represents. The on-disk file name
+          should match: [<date>.sexp] in [YYYY-MM-DD] form. *)
+  macro : macro_context;  (** Macro regime context. *)
+  sectors_strong : string list;
+      (** Sectors classified as strong by the sector analyzer. May be empty. *)
+  sectors_weak : string list;
+      (** Sectors classified as weak by the sector analyzer. May be empty. *)
+  long_candidates : candidate list;
+      (** Ranked long candidates, score-descending. May be empty. *)
+  short_candidates : candidate list;
+      (** Ranked short candidates, score-descending. May be empty. *)
+  held_positions : held_position list;
+      (** Positions held into this Friday. May be empty. *)
+}
+[@@deriving sexp, eq, show]
+(** A complete weekly snapshot. *)

--- a/trading/trading/weinstein/snapshot/test/dune
+++ b/trading/trading/weinstein/snapshot/test/dune
@@ -1,0 +1,12 @@
+(tests
+ (names test_round_trip)
+ (libraries
+  weinstein_trading.snapshot
+  status
+  core
+  core_unix
+  core_unix.filename_unix
+  ounit2
+  matchers)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/weinstein/snapshot/test/test_round_trip.ml
+++ b/trading/trading/weinstein/snapshot/test/test_round_trip.ml
@@ -1,0 +1,197 @@
+(** Round-trip + schema-version tests for {!Weekly_snapshot} via
+    {!Snapshot_writer} / {!Snapshot_reader}. *)
+
+open Core
+open OUnit2
+open Matchers
+open Weinstein_snapshot
+
+(* ------- Fixtures ------- *)
+
+let _date d = Date.of_string d
+
+(** A representative non-empty snapshot exercising every field. Pinned values so
+    the round-trip test is deterministic. *)
+let _full_snapshot : Weekly_snapshot.t =
+  {
+    schema_version = Weekly_snapshot.current_schema_version;
+    system_version = "c93bf39d";
+    date = _date "2020-08-28";
+    macro = { regime = "Bullish"; score = 0.72 };
+    sectors_strong = [ "XLK"; "XLY"; "XLC" ];
+    sectors_weak = [ "XLE"; "XLU" ];
+    long_candidates =
+      [
+        {
+          symbol = "AAPL";
+          score = 0.91;
+          grade = "A+";
+          entry = 502.13;
+          stop = 466.20;
+          sector = "XLK";
+          rationale = "Stage2 breakout above 30wk MA, 2.1x volume confirmation";
+          rs_vs_spy = Some 1.34;
+          resistance_grade = Some "A";
+        };
+        {
+          symbol = "MSFT";
+          score = 0.87;
+          grade = "A";
+          entry = 215.50;
+          stop = 200.10;
+          sector = "XLK";
+          rationale = "Continuation breakout";
+          rs_vs_spy = Some 1.18;
+          resistance_grade = None;
+        };
+      ];
+    short_candidates = [];
+    held_positions =
+      [
+        {
+          symbol = "GOOG";
+          entered = _date "2020-06-19";
+          stop = 1365.00;
+          status = "Holding";
+        };
+      ];
+  }
+
+(** A fully-empty snapshot — verifies empty data sections render correctly (no
+    candidates, no held positions, no strong/weak sectors). *)
+let _empty_snapshot : Weekly_snapshot.t =
+  {
+    schema_version = Weekly_snapshot.current_schema_version;
+    system_version = "deadbeef";
+    date = _date "2021-01-08";
+    macro = { regime = "Neutral"; score = 0.0 };
+    sectors_strong = [];
+    sectors_weak = [];
+    long_candidates = [];
+    short_candidates = [];
+    held_positions = [];
+  }
+
+(* ------- Round-trip ------- *)
+
+let test_round_trip_full _ =
+  let serialized = Snapshot_writer.serialize _full_snapshot in
+  assert_that
+    (Snapshot_reader.parse serialized)
+    (is_ok_and_holds (equal_to _full_snapshot))
+
+let test_round_trip_empty _ =
+  let serialized = Snapshot_writer.serialize _empty_snapshot in
+  assert_that
+    (Snapshot_reader.parse serialized)
+    (is_ok_and_holds (equal_to _empty_snapshot))
+
+let test_serialize_is_byte_stable _ =
+  (* Serializing the same value twice must produce identical bytes. Pins the
+     "canonical output" property — required for stable diffs across runs. *)
+  let first = Snapshot_writer.serialize _full_snapshot in
+  let second = Snapshot_writer.serialize _full_snapshot in
+  assert_that first (equal_to second)
+
+let test_re_serialize_identity _ =
+  (* parse |> serialize is byte-identity: a snapshot read from disk and
+     written back yields the same bytes. *)
+  let bytes = Snapshot_writer.serialize _full_snapshot in
+  assert_that
+    (Snapshot_reader.parse bytes)
+    (is_ok_and_holds
+       (field
+          (fun t -> Snapshot_writer.serialize t)
+          (equal_to bytes)))
+
+(* ------- Schema-version handling ------- *)
+
+let test_unknown_schema_version_rejected _ =
+  let bumped =
+    {
+      _full_snapshot with
+      schema_version = Weekly_snapshot.current_schema_version + 1;
+    }
+  in
+  let serialized = Snapshot_writer.serialize bumped in
+  assert_that
+    (Snapshot_reader.parse serialized)
+    (is_error_with Status.Invalid_argument)
+
+let test_invalid_sexp_rejected _ =
+  assert_that
+    (Snapshot_reader.parse "this is not sexp at all (")
+    (is_error_with Status.Invalid_argument)
+
+(* ------- File naming + on-disk round-trip ------- *)
+
+let test_path_for_layout _ =
+  let path =
+    Snapshot_writer.path_for ~root:"/tmp/picks" ~system_version:"c93bf39d"
+      (_date "2020-08-28")
+  in
+  assert_that path (equal_to "/tmp/picks/c93bf39d/2020-08-28.sexp")
+
+let test_path_lex_order_matches_chronological _ =
+  (* Pinned: lexicographic order of the basenames matches chronological order
+     for the YYYY-MM-DD format. Three pinned dates that would sort differently
+     under any other format. *)
+  let dates = [ _date "2020-12-31"; _date "2020-08-28"; _date "2021-01-08" ] in
+  let basenames =
+    List.map dates ~f:(fun d ->
+        Snapshot_writer.path_for ~root:"r" ~system_version:"v" d
+        |> Filename.basename)
+  in
+  let sorted = List.sort basenames ~compare:String.compare in
+  assert_that sorted
+    (equal_to [ "2020-08-28.sexp"; "2020-12-31.sexp"; "2021-01-08.sexp" ])
+
+let _with_temp_dir f =
+  let dir = Filename_unix.temp_dir "weekly_snapshot_test" "" in
+  Exn.protect
+    ~f:(fun () -> f dir)
+    ~finally:(fun () ->
+      try Core_unix.rmdir (Filename.concat dir "c93bf39d") with _ -> ())
+
+let test_write_and_read_round_trip _ =
+  _with_temp_dir (fun root ->
+      let read_back =
+        Result.bind
+          (Snapshot_writer.write_to_file ~root
+             ~system_version:_full_snapshot.system_version _full_snapshot)
+          ~f:Snapshot_reader.read_from_file
+      in
+      assert_that read_back (is_ok_and_holds (equal_to _full_snapshot)))
+
+let test_write_rejects_mismatched_version _ =
+  _with_temp_dir (fun root ->
+      assert_that
+        (Snapshot_writer.write_to_file ~root ~system_version:"different_version"
+           _full_snapshot)
+        (is_error_with Status.Invalid_argument))
+
+let test_read_missing_file _ =
+  assert_that
+    (Snapshot_reader.read_from_file "/tmp/nonexistent_snapshot_xyz.sexp")
+    (is_error_with Status.NotFound)
+
+let suite =
+  "weekly_snapshot_round_trip"
+  >::: [
+         "round_trip_full" >:: test_round_trip_full;
+         "round_trip_empty" >:: test_round_trip_empty;
+         "serialize_is_byte_stable" >:: test_serialize_is_byte_stable;
+         "re_serialize_identity" >:: test_re_serialize_identity;
+         "unknown_schema_version_rejected"
+         >:: test_unknown_schema_version_rejected;
+         "invalid_sexp_rejected" >:: test_invalid_sexp_rejected;
+         "path_for_layout" >:: test_path_for_layout;
+         "path_lex_order_matches_chronological"
+         >:: test_path_lex_order_matches_chronological;
+         "write_and_read_round_trip" >:: test_write_and_read_round_trip;
+         "write_rejects_mismatched_version"
+         >:: test_write_rejects_mismatched_version;
+         "read_missing_file" >:: test_read_missing_file;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- Introduces M6.1 weekly snapshot data layer: pure-function module under `trading/trading/weinstein/snapshot/lib/` exposing types, sexp writer, and sexp reader for Friday-close pick artifacts.
- Snapshot record types are independent of in-memory analysis types (`scored_candidate`, `macro_state`, `Position.t`) so the on-disk schema is decoupled from upstream type evolution.
- Schema-versioned: every snapshot carries `(schema_version 1)` and the reader rejects any unknown version with a clear `Invalid_argument` error naming both expected and actual.
- Filesystem layout `<root>/<system-version>/<YYYY-MM-DD>.sexp` — basenames sort lexicographically in chronological order.

This PR is scoped to the data layer + serialization only. Wiring into `Simulator.step` is a follow-up (M6.1 part 2). Independent of M5.2a (override flags), Synth-v1, and segmentation Stage — totally new module path with no file overlap.

Refs: `dev/plans/m6-weekly-snapshot-verification-2026-05-02.md` §M6.1.

## Test plan

`dune build && dune runtest trading/weinstein/snapshot` — 11 cases:

- [x] full snapshot round-trip (parse \|> serialize \|> parse = original)
- [x] empty snapshot round-trip (no candidates, no held positions, no strong/weak sectors)
- [x] serialize is byte-stable across repeated calls
- [x] re-serialize identity (parse \|> serialize yields byte-identical bytes)
- [x] unknown schema version rejected with `Invalid_argument`
- [x] invalid sexp rejected with `Invalid_argument`
- [x] `path_for` returns `<root>/<system_version>/<YYYY-MM-DD>.sexp`
- [x] lex-sort of pinned dates equals chronological sort
- [x] disk round-trip via `write_to_file` / `read_from_file`
- [x] `write_to_file` rejects mismatched `system_version` argument
- [x] `read_from_file` returns `NotFound` for missing path

## Files added

- `trading/trading/weinstein/snapshot/lib/weekly_snapshot.{ml,mli}` — types
- `trading/trading/weinstein/snapshot/lib/snapshot_writer.{ml,mli}` — sexp serializer + path helpers
- `trading/trading/weinstein/snapshot/lib/snapshot_reader.{ml,mli}` — sexp parser with schema check
- `trading/trading/weinstein/snapshot/lib/dune`
- `trading/trading/weinstein/snapshot/test/test_round_trip.ml`
- `trading/trading/weinstein/snapshot/test/dune`

🤖 Generated with [Claude Code](https://claude.com/claude-code)