### PR TITLE
feat(stage): segmentation-driven stage classifier (M5.4 E2)

### DIFF
--- a/trading/analysis/weinstein/stage/lib/dune
+++ b/trading/analysis/weinstein/stage/lib/dune
@@ -7,6 +7,7 @@
   weinstein.types
   indicators.sma
   indicators.ema
-  indicators.types)
+  indicators.types
+  trend)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/analysis/weinstein/stage/lib/stage.ml
+++ b/trading/analysis/weinstein/stage/lib/stage.ml
@@ -13,6 +13,7 @@ open Weinstein_types
 (* ------------------------------------------------------------------ *)
 
 type ma_type = Sma | Wma | Ema [@@deriving show, eq, sexp]
+type stage_method = MaSlope | Segmentation [@@deriving show, eq, sexp]
 
 type config = {
   ma_period : int;
@@ -21,6 +22,7 @@ type config = {
   slope_lookback : int;
   confirm_weeks : int;
   late_stage2_decel : float;
+  stage_method : stage_method;
 }
 [@@deriving sexp]
 
@@ -32,6 +34,7 @@ let default_config =
     slope_lookback = 4;
     confirm_weeks = 6;
     late_stage2_decel = 0.5;
+    stage_method = MaSlope;
   }
 
 (* ------------------------------------------------------------------ *)
@@ -239,6 +242,75 @@ let _compute_ma_slope_callback ~get_ma ~slope_threshold ~slope_lookback
   _classify_direction ~threshold:slope_threshold ~current:current_ma
     ~lookback:lookback_ma
 
+(** Maximum number of weeks of MA history the segmentation path will scan
+    backward through callbacks. Bounded to keep the per-call cost predictable on
+    long-history panels; ~4 years of weekly bars is more than enough for
+    {!Trend.Segmentation.segment_by_trends} to identify a stable recent segment
+    given its [preferred_segment_length = 10] default. *)
+let _segmentation_max_history_weeks = 200
+
+(** Walk backwards from [week_offset:0] collecting consecutive defined MA
+    values. Returns the series in chronological order (oldest first, newest
+    last), suitable for piecewise linear segmentation. Stops at the first [None]
+    or at [max_offset] to bound work. *)
+let _collect_ma_series_callback ~get_ma ~max_offset : float array =
+  let rec walk off acc =
+    if off > max_offset then acc
+    else
+      match get_ma ~week_offset:off with
+      | Some v -> walk (off + 1) (v :: acc)
+      | None -> acc
+  in
+  (* Walk newest → oldest accumulating; the cons order produces oldest-first. *)
+  walk 0 [] |> Array.of_list
+
+(** Map a {!Trend.Trend_type.t} value into the Stage [ma_direction] domain. *)
+let _direction_of_trend (t : Trend.Trend_type.t) : ma_direction =
+  match t with
+  | Increasing -> Rising
+  | Decreasing -> Declining
+  | Flat | Unknown -> Flat
+
+(** Segmentation-driven MA direction. Runs
+    {!Trend.Segmentation.segment_by_trends} over the MA series and uses the most
+    recent segment's trend + slope.
+
+    [slope_pct] is reported as the most recent segment's [slope] divided by
+    [|current_ma|] (not by [|MA_lookback_ago|] as in the slope path), so the
+    units stay "fractional change per bar near current price level". When the MA
+    series is too short for any segment or [current_ma] is zero, falls back to
+    [(Flat, 0.0)].
+
+    Note: segmentation collects the full MA series back to the oldest defined
+    offset (capped by [max_offset]); a longer history gives the algorithm more
+    context to identify a stable recent trend, at O(n) cost per call. *)
+let _compute_ma_slope_segmentation ~get_ma ~current_ma ~max_offset :
+    ma_direction * float =
+  let ma_series = _collect_ma_series_callback ~get_ma ~max_offset in
+  let segments = Trend.Segmentation.segment_by_trends ma_series in
+  match List.last segments with
+  | None -> (Flat, 0.0)
+  | Some seg ->
+      let direction = _direction_of_trend seg.Trend.Segmentation.trend in
+      let slope_pct =
+        if Float.(current_ma = 0.0) then 0.0
+        else seg.Trend.Segmentation.slope /. Float.abs current_ma
+      in
+      (direction, slope_pct)
+
+(** Dispatch to the slope or segmentation MA-direction computation based on
+    [stage_method]. Both paths consume the same callbacks; only the way we
+    classify Rising/Flat/Declining differs. *)
+let _compute_ma_direction_dispatch ~stage_method ~get_ma ~slope_threshold
+    ~slope_lookback ~current_ma : ma_direction * float =
+  match stage_method with
+  | MaSlope ->
+      _compute_ma_slope_callback ~get_ma ~slope_threshold ~slope_lookback
+        ~current_ma
+  | Segmentation ->
+      _compute_ma_slope_segmentation ~get_ma ~current_ma
+        ~max_offset:_segmentation_max_history_weeks
+
 (** Count, over [week_offset] in [0; min(confirm_weeks, ma_depth) - 1], how many
     weeks have [close > ma]. Returns [(above, examined)] so the caller can
     derive [below_ma_count = examined - above]. Stops early on the first missing
@@ -326,7 +398,8 @@ let _build_result ~current_ma ~ma_dir ~ma_slope_pct ~prior_stage ~above_ma_count
 let _classify_signals ~config ~get_ma ~get_close ~prior_stage ~current_ma :
     result =
   let ma_dir, ma_slope_pct =
-    _compute_ma_slope_callback ~get_ma ~slope_threshold:config.slope_threshold
+    _compute_ma_direction_dispatch ~stage_method:config.stage_method ~get_ma
+      ~slope_threshold:config.slope_threshold
       ~slope_lookback:config.slope_lookback ~current_ma
   in
   let stop_at = max config.confirm_weeks (2 * config.slope_lookback) in

--- a/trading/analysis/weinstein/stage/lib/stage.mli
+++ b/trading/analysis/weinstein/stage/lib/stage.mli
@@ -9,6 +9,19 @@ open Types
 *)
 type ma_type = Sma | Wma | Ema [@@deriving show, eq, sexp]
 
+(** Method for determining MA direction (Rising/Flat/Declining).
+
+    [MaSlope] — current behavior (default): compare [MA_now] to
+    [MA_lookback_ago] and classify by slope_pct vs threshold.
+
+    [Segmentation] — feature-flagged alternative (M5.4 E2): runs piecewise
+    linear regression over the MA series via
+    {!Trend.Segmentation.segment_by_trends} and uses the most recent segment's
+    trend. Reduces false direction flips from short-term noise. The
+    [Trend.Trend_type.t] result maps as: [Increasing → Rising],
+    [Decreasing → Declining], [Flat | Unknown → Flat]. *)
+type stage_method = MaSlope | Segmentation [@@deriving show, eq, sexp]
+
 (** Stage classifier for the Weinstein methodology.
 
     Classifies a stock into one of four stages based on weekly price bars and
@@ -32,6 +45,10 @@ type config = {
       (** MA slope deceleration threshold to flag late Stage 2 warning. A
           reading this much below the recent peak slope triggers [late=true].
           Default: 0.5 (50% deceleration from recent peak). *)
+  stage_method : stage_method;
+      (** Method for determining MA direction. Default: [MaSlope] (current
+          behavior). [Segmentation] enables the feature-flagged piecewise linear
+          regression path (see {!stage_method}). *)
 }
 [@@deriving sexp]
 (** Configuration for stage classification. All thresholds are configurable to
@@ -144,14 +161,11 @@ val classify_with_callbacks :
 
     {3 Segmentation-based MA direction}
 
-    MA direction is currently determined by a simple two-point slope comparison
-    ([MA_now] vs [MA_lookback_ago]). A more robust alternative would use the
-    piecewise linear segmentation in
-    [analysis/technical/trend/lib/segmentation.ml]: fit a regression to the MA
-    series over a rolling window and classify the most recent segment's slope as
-    Rising/Flat/Declining. This would reduce false direction flips from
-    short-term noise and better identify the transition out of Stage 1
-    base-building periods.
+    Wired as of M5.4 E2 behind the [stage_method = Segmentation] feature flag
+    (default remains [MaSlope] for byte-identical legacy behavior). The
+    [Segmentation] path runs piecewise linear regression over the MA series via
+    {!Trend.Segmentation.segment_by_trends} and uses the most recent segment's
+    trend. A/B sweep is tracked as a follow-up experiment.
 
     {3 Incremental [classify_step]}
 

--- a/trading/analysis/weinstein/stage/test/test_stage.ml
+++ b/trading/analysis/weinstein/stage/test/test_stage.ml
@@ -325,6 +325,107 @@ let test_parity_insufficient_data _ =
   let bars = List.init 10 ~f:(fun _ -> 50.0) |> bars_of_prices in
   assert_parity bars
 
+(* ------------------------------------------------------------------ *)
+(* Segmentation variant — feature-flagged Stage classifier (M5.4 E2)  *)
+(*                                                                      *)
+(* Goal: verify both [stage_method] variants produce a [Stage.t] for   *)
+(* each scenario and that the new [Segmentation] path identifies the   *)
+(* expected stage on clear-cut inputs (rising/declining series).       *)
+(* The default-on-MaSlope tests above guard the existing behavior.     *)
+(* ------------------------------------------------------------------ *)
+
+let cfg_segmentation = { default_config with stage_method = Segmentation }
+
+(** Default config preserves [MaSlope]: changing nothing else, the new field
+    must select the legacy path. *)
+let test_default_config_uses_ma_slope _ =
+  assert_that default_config.stage_method (equal_to MaSlope)
+
+(** Stage 2: clearly rising series with the segmentation variant should still
+    classify as Stage 2 with a Rising direction. *)
+let test_segmentation_stage2_rising _ =
+  let bars = rising_bars ~n:100 50.0 200.0 in
+  let result = classify ~config:cfg_segmentation ~bars ~prior_stage:None in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.stage) is_stage2;
+         field (fun r -> r.ma_direction) (equal_to Rising);
+       ])
+
+(** Stage 4: clearly declining series with the segmentation variant should
+    classify as Stage 4 with a Declining direction. *)
+let test_segmentation_stage4_declining _ =
+  let bars = declining_bars ~n:100 200.0 50.0 in
+  let result = classify ~config:cfg_segmentation ~bars ~prior_stage:None in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.stage) is_stage4;
+         field (fun r -> r.ma_direction) (equal_to Declining);
+       ])
+
+(** Insufficient data: the segmentation variant must take the same early-return
+    branch as the slope variant ([_stage1_default_result]). *)
+let test_segmentation_insufficient_data _ =
+  let bars = List.init 10 ~f:(fun _ -> 50.0) |> bars_of_prices in
+  let result = classify ~config:cfg_segmentation ~bars ~prior_stage:None in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.stage) is_stage1;
+         field (fun r -> r.ma_value) (float_equal 0.0);
+       ])
+
+(** Purity for the segmentation path: same inputs always produce the same
+    output. *)
+let test_segmentation_pure _ =
+  let bars = rising_bars ~n:80 50.0 150.0 in
+  let r1 = classify ~config:cfg_segmentation ~bars ~prior_stage:None in
+  let r2 = classify ~config:cfg_segmentation ~bars ~prior_stage:None in
+  assert_that r2
+    (all_of
+       [
+         field (fun r -> r.stage) (equal_to (r1.stage : stage));
+         field (fun r -> r.ma_value) (float_equal r1.ma_value);
+         field
+           (fun r -> r.ma_direction)
+           (equal_to (r1.ma_direction : ma_direction));
+         field (fun r -> r.ma_slope_pct) (float_equal r1.ma_slope_pct);
+       ])
+
+(** Both methods return a valid [Stage.t] for the same bars.
+
+    Acceptance criterion from M5.4 E2: "Both methods produce a [Stage.t] for the
+    same input." We assert both produce *some* stage; we do not require them to
+    agree on which stage. *)
+let test_both_methods_return_a_stage _ =
+  let bars = rising_bars ~n:80 50.0 150.0 in
+  let r_slope =
+    classify
+      ~config:{ default_config with stage_method = MaSlope }
+      ~bars ~prior_stage:None
+  in
+  let r_seg =
+    classify
+      ~config:{ default_config with stage_method = Segmentation }
+      ~bars ~prior_stage:None
+  in
+  (* Both stage values should belong to one of the four stage variants —
+     since [stage] is a closed variant, just asserting equality of the
+     stage_number domain is enough to confirm both produced a valid value. *)
+  let stage_number = function
+    | Stage1 _ -> 1
+    | Stage2 _ -> 2
+    | Stage3 _ -> 3
+    | Stage4 _ -> 4
+  in
+  assert_that
+    (stage_number r_slope.stage)
+    (is_between (module Int_ord) ~low:1 ~high:4);
+  assert_that (stage_number r_seg.stage)
+    (is_between (module Int_ord) ~low:1 ~high:4)
+
 let suite =
   "stage_tests"
   >::: [
@@ -352,6 +453,15 @@ let suite =
          >:: test_parity_stage3_flat_after_advance;
          "test_parity_late_stage2" >:: test_parity_late_stage2;
          "test_parity_insufficient_data" >:: test_parity_insufficient_data;
+         "test_default_config_uses_ma_slope"
+         >:: test_default_config_uses_ma_slope;
+         "test_segmentation_stage2_rising" >:: test_segmentation_stage2_rising;
+         "test_segmentation_stage4_declining"
+         >:: test_segmentation_stage4_declining;
+         "test_segmentation_insufficient_data"
+         >:: test_segmentation_insufficient_data;
+         "test_segmentation_pure" >:: test_segmentation_pure;
+         "test_both_methods_return_a_stage" >:: test_both_methods_return_a_stage;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/analysis/weinstein/stage/test/test_stage.ml
+++ b/trading/analysis/weinstein/stage/test/test_stage.ml
@@ -426,6 +426,91 @@ let test_both_methods_return_a_stage _ =
   assert_that (stage_number r_seg.stage)
     (is_between (module Int_ord) ~low:1 ~high:4)
 
+(* ------------------------------------------------------------------ *)
+(* Segmentation guards: history truncation + empty-segments fallback   *)
+(* ------------------------------------------------------------------ *)
+
+(** Build a [get_ma] callback over a synthetic MA-value array (oldest at index
+    0, newest at the end). Mirrors {!make_get_ma} but kept local for clarity in
+    these guard tests. *)
+let make_get_ma_array (ma_values : float array) ~week_offset =
+  let n = Array.length ma_values in
+  let idx = n - 1 - week_offset in
+  if idx < 0 || idx >= n then None else Some ma_values.(idx)
+
+(** Build a [get_close] callback that returns the same value as the MA at every
+    offset (sufficient for direction-only assertions; the [above_ma_count]
+    branch isn't load-bearing for what we pin here). *)
+let make_get_close_array (ma_values : float array) ~week_offset =
+  make_get_ma_array ma_values ~week_offset
+
+(** Pin: the [_segmentation_max_history_weeks = 200] truncation cap does not
+    bias the classification on long histories. We feed a deterministic linear MA
+    ramp of 250 weeks to the segmentation path, then truncate to the most recent
+    200 weeks of the same ramp and feed that. The cap silently drops the oldest
+    50 values from the 250-week input; the truncated input is naturally only 200
+    long. Both must classify identically (Stage 2 + Rising direction) — proving
+    the cap is a pure performance bound, not a behavioral knob. *)
+let test_segmentation_history_truncation_no_bias _ =
+  (* Deterministic linear ramp from 50.0 to 200.0 over 250 weeks. The shape is
+     monotonically increasing with no oscillation, so segmentation classifies
+     the most recent segment as Increasing regardless of where the cap lands. *)
+  let n_full = 250 in
+  let n_capped = 200 in
+  let ramp_full =
+    Array.init n_full ~f:(fun i ->
+        50.0 +. (Float.of_int i *. (150.0 /. Float.of_int (n_full - 1))))
+  in
+  let ramp_capped =
+    Array.sub ramp_full ~pos:(n_full - n_capped) ~len:n_capped
+  in
+  let result_full =
+    classify_with_callbacks ~config:cfg_segmentation
+      ~get_ma:(make_get_ma_array ramp_full)
+      ~get_close:(make_get_close_array ramp_full)
+      ~prior_stage:None
+  in
+  let result_capped =
+    classify_with_callbacks ~config:cfg_segmentation
+      ~get_ma:(make_get_ma_array ramp_capped)
+      ~get_close:(make_get_close_array ramp_capped)
+      ~prior_stage:None
+  in
+  (* The classification must be identical: same Stage variant + same direction.
+     ma_value should also match (newest MA point is the same in both inputs). *)
+  assert_that result_full
+    (all_of
+       [
+         field (fun r -> r.stage) (equal_to (result_capped.stage : stage));
+         field (fun r -> r.ma_direction) (equal_to Rising);
+         field (fun r -> r.ma_value) (float_equal result_capped.ma_value);
+       ])
+
+(** Pin: when the MA series has only a single defined point (passes the
+    [get_ma ~week_offset:0 = Some _] guard but [get_ma ~week_offset:1 = None]),
+    the segmentation path falls through to its conservative [(Flat, 0.0)]
+    result. The underlying {!Trend.Segmentation.segment_by_trends} returns one
+    Unknown segment for a length-1 array (n < min_segment_length), and
+    [_direction_of_trend Unknown = Flat] with slope 0.0 — exercising the
+    practical empty / unsegmentable fallback that was unreachable in the
+    pre-existing [test_segmentation_insufficient_data] (which short-circuits at
+    the higher-level [get_ma ~week_offset:0 = None] guard). *)
+let test_segmentation_single_ma_point_falls_back_to_flat _ =
+  let single_value = [| 100.0 |] in
+  let result =
+    classify_with_callbacks ~config:cfg_segmentation
+      ~get_ma:(make_get_ma_array single_value)
+      ~get_close:(make_get_close_array single_value)
+      ~prior_stage:None
+  in
+  assert_that result
+    (all_of
+       [
+         field (fun r -> r.ma_direction) (equal_to Flat);
+         field (fun r -> r.ma_slope_pct) (float_equal 0.0);
+         field (fun r -> r.ma_value) (float_equal 100.0);
+       ])
+
 let suite =
   "stage_tests"
   >::: [
@@ -462,6 +547,10 @@ let suite =
          >:: test_segmentation_insufficient_data;
          "test_segmentation_pure" >:: test_segmentation_pure;
          "test_both_methods_return_a_stage" >:: test_both_methods_return_a_stage;
+         "test_segmentation_history_truncation_no_bias"
+         >:: test_segmentation_history_truncation_no_bias;
+         "test_segmentation_single_ma_point_falls_back_to_flat"
+         >:: test_segmentation_single_ma_point_falls_back_to_flat;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- Adds a feature-flagged `stage_method = MaSlope | Segmentation` enum to `Stage.config`. Default `MaSlope` keeps existing behavior byte-identical.
- New `Segmentation` variant routes MA-direction detection through `Trend.Segmentation.segment_by_trends` (the piecewise linear regression library that has lived in `analysis/technical/trend/` since 2026-03 but was unwired). The most recent segment's trend maps `Increasing -> Rising`, `Decreasing -> Declining`, `Flat | Unknown -> Flat`.
- All other classification logic (above-MA count, late-Stage-2 deceleration, stage state machine) is shared. Only the Rising/Flat/Declining decision differs.

## Design notes

- The dispatch happens in a new helper `_compute_ma_direction_dispatch` called from `_classify_signals`. Both variants consume the existing `get_ma`/`get_close` callbacks, so the bar-list and panel-backed entry points both benefit transparently.
- The segmentation path collects up to 200 weeks of MA history through the callback (capped via `_segmentation_max_history_weeks`) so the algorithm has enough context (preferred segment length is 10 by default) without unbounded scanning.
- `slope_pct` for the segmentation path is reported as `segment.slope / |current_ma|` (fractional change per bar near current price level).

## Test plan

- [x] `dune build` (full project) — clean.
- [x] `dune runtest analysis/weinstein/stage` — 24/24 pass (18 existing parity + golden tests, 6 new for the Segmentation variant).
- [x] `dune build @fmt --auto-promote` — clean.
- New tests:
  - `test_default_config_uses_ma_slope` — verifies default flag is unchanged.
  - `test_segmentation_stage2_rising` / `test_segmentation_stage4_declining` — clear-cut rising/declining series classify correctly via the new path.
  - `test_segmentation_insufficient_data` — fewer bars than `ma_period` returns the same Stage1 default-result early-return.
  - `test_segmentation_pure` — same inputs always produce same output.
  - `test_both_methods_return_a_stage` — covers M5.4 E2 acceptance: both variants produce a valid `Stage.t` for the same input.

## Acceptance criteria (M5.4 E2)

- [x] Both methods produce a `Stage.t` for the same input.
- [x] No behavioral regression on the existing MaSlope path (all 18 pre-existing tests still pass, including the byte-identical bar-list-vs-callback parity tests).
- [ ] A/B run on 5 scenarios shows distinct trade counts — out of scope for this PR. The plan calls out the A/B sweep itself as a follow-up experiment.

Plan reference: `dev/plans/m5-experiments-roadmap-2026-05-02.md` Section M5.4 E2.