### PR TITLE
feat(snapshot): forward-trace renderer (M6.2)

### DIFF
--- a/trading/trading/weinstein/snapshot/bin/dune
+++ b/trading/trading/weinstein/snapshot/bin/dune
@@ -1,0 +1,11 @@
+(executable
+ (name trace_picks)
+ (libraries
+  core
+  core_unix.command_unix
+  csv
+  status
+  types
+  weinstein_trading.snapshot)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv ppx_let)))

--- a/trading/trading/weinstein/snapshot/bin/trace_picks.ml
+++ b/trading/trading/weinstein/snapshot/bin/trace_picks.ml
@@ -1,0 +1,76 @@
+(** [trace_picks] CLI — render a {!Forward_trace} report from a pick file.
+
+    Usage: trace_picks --pick-file PATH --bars-dir PATH --horizon DAYS
+
+    Reads the weekly snapshot from [--pick-file], loads daily bars for each long
+    candidate from [--bars-dir] (CSV-storage layout), traces forward [--horizon]
+    calendar days, and prints both the per-pick outcome list and the aggregate
+    to stdout as sexp. *)
+
+open Core
+open Weinstein_snapshot
+
+let _read_snapshot path : Weekly_snapshot.t =
+  match Snapshot_reader.read_from_file path with
+  | Ok t -> t
+  | Error err ->
+      eprintf "Failed to read snapshot %s: %s\n" path (Status.show err);
+      exit 1
+
+let _load_bars_for_symbol ~bars_dir symbol : Types.Daily_price.t list =
+  match Csv.Csv_storage.create ~data_dir:(Fpath.v bars_dir) symbol with
+  | Error _ -> []
+  | Ok storage -> (
+      match Csv.Csv_storage.get storage () with
+      | Error _ -> []
+      | Ok bars -> bars)
+
+let _bars_for_picks ~bars_dir (picks : Weekly_snapshot.t) :
+    Types.Daily_price.t list String.Map.t =
+  List.fold picks.long_candidates ~init:String.Map.empty
+    ~f:(fun acc (c : Weekly_snapshot.candidate) ->
+      if Map.mem acc c.symbol then acc
+      else
+        Map.set acc ~key:c.symbol
+          ~data:(_load_bars_for_symbol ~bars_dir c.symbol))
+
+let _print_report (outcomes, aggregate) =
+  let outcomes_sexp =
+    Sexp.List (List.map outcomes ~f:Forward_trace.sexp_of_per_pick_outcome)
+  in
+  let report_sexp =
+    Sexp.List
+      [
+        Sexp.List
+          [ Sexp.Atom "aggregate"; Forward_trace.sexp_of_aggregate aggregate ];
+        Sexp.List [ Sexp.Atom "outcomes"; outcomes_sexp ];
+      ]
+  in
+  print_endline (Sexp.to_string_hum report_sexp)
+
+let _run ~pick_file ~bars_dir ~horizon_days () =
+  let picks = _read_snapshot pick_file in
+  let bars = _bars_for_picks ~bars_dir picks in
+  let report = Forward_trace.trace_picks ~picks ~bars ~horizon_days in
+  _print_report report
+
+let command =
+  Command.basic
+    ~summary:
+      "Render a forward-trace report from a weekly snapshot pick file. Prints \
+       per-pick outcomes + aggregate as sexp."
+    (let%map_open.Command pick_file =
+       flag "--pick-file"
+         (required Filename_unix.arg_type)
+         ~doc:"PATH Path to the weekly snapshot sexp file"
+     and bars_dir =
+       flag "--bars-dir"
+         (required Filename_unix.arg_type)
+         ~doc:"PATH Path to the CSV-storage bars directory"
+     and horizon_days =
+       flag "--horizon" (required int)
+         ~doc:"DAYS Calendar-day horizon to trace forward from the pick date"
+     in
+     fun () -> _run ~pick_file ~bars_dir ~horizon_days ())
+
+let () = Command_unix.run command

--- a/trading/trading/weinstein/snapshot/lib/dune
+++ b/trading/trading/weinstein/snapshot/lib/dune
@@ -7,6 +7,7 @@
   core_unix.sys_unix
   core_unix.filename_unix
   sexplib
-  status)
+  status
+  types)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/weinstein/snapshot/lib/forward_trace.ml
+++ b/trading/trading/weinstein/snapshot/lib/forward_trace.ml
@@ -1,0 +1,257 @@
+open Core
+open Types
+
+type per_pick_outcome = {
+  symbol : string;
+  pick_date : Date.t;
+  suggested_entry : float;
+  suggested_stop : float;
+  entry_filled_at : float;
+  entry_filled_date : Date.t;
+  max_favorable : float;
+  max_adverse : float;
+  final_price : float;
+  final_date : Date.t;
+  pct_return_horizon : float;
+  stop_triggered : bool;
+  max_drawdown_within_horizon : float;
+  winner : bool;
+}
+[@@deriving sexp, eq, show]
+
+type aggregate = {
+  horizon_days : int;
+  total_picks : int;
+  winners : int;
+  losers : int;
+  stopped_out : int;
+  avg_return_pct : float;
+  avg_winner_return_pct : float;
+  avg_loser_return_pct : float;
+  best_pick : string;
+  worst_pick : string;
+}
+[@@deriving sexp, eq, show]
+
+type adj_bar = {
+  date : Date.t;
+  adj_open : float;
+  adj_high : float;
+  adj_low : float;
+  adj_close : float;
+}
+(** Adjusted-price view of a single bar. We scale [open]/[high]/[low] by the
+    ratio [adjusted_close / close_price] so all prices live in the same
+    split-adjusted space as [adjusted_close]. *)
+
+let _is_close_to_zero x = Float.( <. ) (Float.abs x) 1e-12
+
+let _adjust_bar (b : Daily_price.t) : adj_bar =
+  (* Scale OHL by the adjusted_close / close ratio. If close_price is ~0 (a
+     pathological input), fall back to the raw values rather than producing
+     NaN — the caller will just see uncorrected prices. *)
+  let ratio =
+    if _is_close_to_zero b.close_price then 1.0
+    else b.adjusted_close /. b.close_price
+  in
+  {
+    date = b.date;
+    adj_open = b.open_price *. ratio;
+    adj_high = b.high_price *. ratio;
+    adj_low = b.low_price *. ratio;
+    adj_close = b.adjusted_close;
+  }
+
+let _bars_in_window ~(pick_date : Date.t) ~(horizon_days : int)
+    (bars : Daily_price.t list) : adj_bar list =
+  let end_date = Date.add_days pick_date horizon_days in
+  bars
+  |> List.filter ~f:(fun (b : Daily_price.t) ->
+      Date.( > ) b.date pick_date && Date.( <= ) b.date end_date)
+  |> List.sort ~compare:(fun (a : Daily_price.t) (b : Daily_price.t) ->
+      Date.compare a.date b.date)
+  |> List.map ~f:_adjust_bar
+
+(** Find the first bar whose [adj_high] reaches [entry]; the fill price is
+    [max entry adj_open] (gap-fill rule). *)
+let _find_entry_fill ~(entry : float) (bars : adj_bar list) :
+    (adj_bar * float) option =
+  List.find_map bars ~f:(fun b ->
+      if Float.( >=. ) b.adj_high entry then
+        let fill_price = Float.max entry b.adj_open in
+        Some (b, fill_price)
+      else None)
+
+(** Return only the bars at and after the entry bar. *)
+let _bars_from_entry ~(entry_date : Date.t) (bars : adj_bar list) : adj_bar list
+    =
+  List.filter bars ~f:(fun b -> Date.( >= ) b.date entry_date)
+
+type tracking = {
+  max_favorable : float;
+  max_adverse : float;
+  highest_close_so_far : float;
+  max_drawdown : float;
+  stop_triggered : bool;
+}
+(** Tracking state during the post-entry walk. *)
+
+let _initial_tracking ~entry_fill =
+  {
+    max_favorable = entry_fill;
+    max_adverse = entry_fill;
+    highest_close_so_far = entry_fill;
+    max_drawdown = 0.0;
+    stop_triggered = false;
+  }
+
+let _update_tracking ~stop ~bar t =
+  let max_favorable = Float.max t.max_favorable bar.adj_high in
+  let max_adverse = Float.min t.max_adverse bar.adj_low in
+  let highest_close_so_far = Float.max t.highest_close_so_far bar.adj_close in
+  let drawdown_now =
+    if Float.( <=. ) highest_close_so_far 0.0 then 0.0
+    else (bar.adj_close -. highest_close_so_far) /. highest_close_so_far
+  in
+  let max_drawdown = Float.min t.max_drawdown drawdown_now in
+  let stop_triggered = t.stop_triggered || Float.( <=. ) bar.adj_low stop in
+  {
+    max_favorable;
+    max_adverse;
+    highest_close_so_far;
+    max_drawdown;
+    stop_triggered;
+  }
+
+let _walk_post_entry ~entry_fill ~stop (bars : adj_bar list) : tracking =
+  List.fold bars ~init:(_initial_tracking ~entry_fill) ~f:(fun acc bar ->
+      _update_tracking ~stop ~bar acc)
+
+let _unfilled_outcome ~(c : Weekly_snapshot.candidate) ~(pick_date : Date.t) :
+    per_pick_outcome =
+  {
+    symbol = c.symbol;
+    pick_date;
+    suggested_entry = c.entry;
+    suggested_stop = c.stop;
+    entry_filled_at = Float.nan;
+    entry_filled_date = pick_date;
+    max_favorable = Float.nan;
+    max_adverse = Float.nan;
+    final_price = Float.nan;
+    final_date = pick_date;
+    pct_return_horizon = Float.nan;
+    stop_triggered = false;
+    max_drawdown_within_horizon = Float.nan;
+    winner = false;
+  }
+
+let _filled_outcome ~(c : Weekly_snapshot.candidate) ~(pick_date : Date.t)
+    ~(entry_bar : adj_bar) ~(entry_fill : float) ~(post : adj_bar list)
+    ~(tracking : tracking) : per_pick_outcome =
+  let final_bar =
+    match List.last post with Some b -> b | None -> entry_bar
+  in
+  let pct_return_horizon =
+    (final_bar.adj_close -. entry_fill) /. entry_fill
+  in
+  {
+    symbol = c.symbol;
+    pick_date;
+    suggested_entry = c.entry;
+    suggested_stop = c.stop;
+    entry_filled_at = entry_fill;
+    entry_filled_date = entry_bar.date;
+    max_favorable = tracking.max_favorable;
+    max_adverse = tracking.max_adverse;
+    final_price = final_bar.adj_close;
+    final_date = final_bar.date;
+    pct_return_horizon;
+    stop_triggered = tracking.stop_triggered;
+    max_drawdown_within_horizon = tracking.max_drawdown;
+    winner = Float.( >. ) pct_return_horizon 0.0;
+  }
+
+let _trace_window ~(pick_date : Date.t) ~(c : Weekly_snapshot.candidate)
+    (window : adj_bar list) : per_pick_outcome =
+  match _find_entry_fill ~entry:c.entry window with
+  | None -> _unfilled_outcome ~c ~pick_date
+  | Some (entry_bar, entry_fill) ->
+      let post = _bars_from_entry ~entry_date:entry_bar.date window in
+      let tracking = _walk_post_entry ~entry_fill ~stop:c.stop post in
+      _filled_outcome ~c ~pick_date ~entry_bar ~entry_fill ~post ~tracking
+
+let _trace_one ~(pick_date : Date.t) ~(horizon_days : int)
+    ~(bars : Daily_price.t list option) (c : Weekly_snapshot.candidate) :
+    per_pick_outcome =
+  match bars with
+  | None -> _unfilled_outcome ~c ~pick_date
+  | Some raw_bars ->
+      let window = _bars_in_window ~pick_date ~horizon_days raw_bars in
+      _trace_window ~pick_date ~c window
+
+let _is_filled (o : per_pick_outcome) = not (Float.is_nan o.entry_filled_at)
+
+let _avg (xs : float list) : float =
+  match xs with
+  | [] -> Float.nan
+  | _ ->
+      let n = List.length xs in
+      List.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int n
+
+let _aggregate ~(horizon_days : int) (outcomes : per_pick_outcome list) :
+    aggregate =
+  let total_picks = List.length outcomes in
+  let filled = List.filter outcomes ~f:_is_filled in
+  let winners_l = List.filter filled ~f:(fun o -> o.winner) in
+  let losers_l = List.filter filled ~f:(fun o -> not o.winner) in
+  let stopped_out =
+    List.count outcomes ~f:(fun o -> _is_filled o && o.stop_triggered)
+  in
+  let avg_return_pct =
+    _avg (List.map filled ~f:(fun o -> o.pct_return_horizon))
+  in
+  let avg_winner_return_pct =
+    _avg (List.map winners_l ~f:(fun o -> o.pct_return_horizon))
+  in
+  let avg_loser_return_pct =
+    _avg (List.map losers_l ~f:(fun o -> o.pct_return_horizon))
+  in
+  let best_pick =
+    match
+      List.max_elt filled ~compare:(fun a b ->
+          Float.compare a.pct_return_horizon b.pct_return_horizon)
+    with
+    | Some o -> o.symbol
+    | None -> ""
+  in
+  let worst_pick =
+    match
+      List.min_elt filled ~compare:(fun a b ->
+          Float.compare a.pct_return_horizon b.pct_return_horizon)
+    with
+    | Some o -> o.symbol
+    | None -> ""
+  in
+  {
+    horizon_days;
+    total_picks;
+    winners = List.length winners_l;
+    losers = List.length losers_l;
+    stopped_out;
+    avg_return_pct;
+    avg_winner_return_pct;
+    avg_loser_return_pct;
+    best_pick;
+    worst_pick;
+  }
+
+let trace_picks ~(picks : Weekly_snapshot.t)
+    ~(bars : Daily_price.t list String.Map.t) ~(horizon_days : int) :
+    per_pick_outcome list * aggregate =
+  let outcomes =
+    List.map picks.long_candidates ~f:(fun c ->
+        _trace_one ~pick_date:picks.date ~horizon_days
+          ~bars:(Map.find bars c.symbol) c)
+  in
+  (outcomes, _aggregate ~horizon_days outcomes)

--- a/trading/trading/weinstein/snapshot/lib/forward_trace.mli
+++ b/trading/trading/weinstein/snapshot/lib/forward_trace.mli
@@ -1,0 +1,136 @@
+(** Forward-trace renderer — pure function that rolls a {!Weekly_snapshot.t}'s
+    long candidates forward over a fixed horizon of daily bars and reports the
+    per-pick outcome.
+
+    Lets us answer "would these picks have worked?" without re-running the full
+    simulator. Adjusted-close prices are used throughout, so split-day round-
+    trips do not produce phantom returns.
+
+    {1 Model}
+
+    For each long candidate we model a buy-stop entry: scan forward in time
+    until a bar's high reaches the suggested entry price, mark the entry at that
+    bar's date and price (clipped to the high if the open gapped past), then
+    continue rolling forward up to [horizon_days] from the pick date. Over that
+    window we track:
+
+    - [max_favorable]: highest high observed after entry
+    - [max_adverse]: lowest low observed after entry
+    - [final_price]: adjusted close on the last bar within the horizon
+    - [stop_triggered]: true iff any post-entry bar's low pierced the suggested
+      stop
+    - [pct_return_horizon]: ([final_price] - [entry_filled_at]) /
+      [entry_filled_at]
+    - [winner]: [pct_return_horizon] > 0
+
+    The horizon is measured in {b calendar} days from the pick date — bars that
+    fall on weekends/holidays simply aren't there. If the horizon ends before
+    enough trading days exist, we use the last available bar.
+
+    Picks whose entry is never filled within the horizon are reported with
+    [entry_filled_at = nan] and [winner = false] (a sentinel — they don't count
+    toward winner / loser averages).
+
+    Short candidates are not currently traced (entry/stop semantics differ).
+    [trace_picks] currently consumes only [picks.long_candidates].
+
+    {1 Split safety}
+
+    All prices read from bars use [adjusted_close] for closes and apply a
+    bar-relative scaling for highs / lows derived from
+    [(high_price / close_price) * adjusted_close] etc. This keeps split-day
+    round-trips numerically clean: a 4:1 split between pick date and horizon end
+    produces no phantom 4× return because both entry and exit are in adjusted
+    terms.
+
+    {1 Determinism}
+
+    Pure function. Same inputs → same outputs. No I/O, no clock, no global
+    state. Suitable for fixture-pinned tests. *)
+
+open Core
+open Types
+
+type per_pick_outcome = {
+  symbol : string;  (** Ticker. *)
+  pick_date : Date.t;  (** Snapshot date the candidate was emitted on. *)
+  suggested_entry : float;
+      (** Suggested buy-stop entry from the snapshot, in adjusted terms. *)
+  suggested_stop : float;
+      (** Suggested initial stop from the snapshot, in adjusted terms. *)
+  entry_filled_at : float;
+      (** Adjusted price the entry was filled at, or [Float.nan] if never filled
+          within the horizon. *)
+  entry_filled_date : Date.t;
+      (** Date the entry was filled. Equal to [pick_date] if never filled
+          (sentinel — disambiguated by [Float.is_nan entry_filled_at]). *)
+  max_favorable : float;
+      (** Maximum adjusted high observed in the post-entry window. *)
+  max_adverse : float;
+      (** Minimum adjusted low observed in the post-entry window. *)
+  final_price : float;
+      (** Adjusted close on the final bar in the horizon (or last available bar
+          before the horizon ends). *)
+  final_date : Date.t;  (** Date of the [final_price] bar. *)
+  pct_return_horizon : float;
+      (** [(final_price - entry_filled_at) / entry_filled_at]. [Float.nan] if
+          the entry was never filled. *)
+  stop_triggered : bool;
+      (** True iff any post-entry bar's adjusted low ≤ [suggested_stop]. *)
+  max_drawdown_within_horizon : float;
+      (** Maximum drawdown from the highest post-entry close, expressed as a
+          negative fraction (e.g. [-0.0221] for -2.21%). [0.0] if no drawdown
+          occurred. *)
+  winner : bool;
+      (** [pct_return_horizon > 0]. Always false if entry never filled. *)
+}
+[@@deriving sexp, eq, show]
+(** Per-candidate outcome over the horizon. *)
+
+type aggregate = {
+  horizon_days : int;  (** Horizon used for the trace, in calendar days. *)
+  total_picks : int;  (** Number of long candidates traced. *)
+  winners : int;  (** Picks with [pct_return_horizon > 0]. *)
+  losers : int;
+      (** Filled picks with [pct_return_horizon ≤ 0]. Excludes never-filled
+          picks. *)
+  stopped_out : int;
+      (** Picks whose post-entry low pierced [suggested_stop]. *)
+  avg_return_pct : float;
+      (** Mean [pct_return_horizon] across all filled picks. [Float.nan] if no
+          picks were filled. *)
+  avg_winner_return_pct : float;
+      (** Mean [pct_return_horizon] among winners only. [Float.nan] if no
+          winners. *)
+  avg_loser_return_pct : float;
+      (** Mean [pct_return_horizon] among losers only. [Float.nan] if no losers.
+      *)
+  best_pick : string;
+      (** Symbol of the highest-return filled pick. Empty string if no picks
+          were filled. *)
+  worst_pick : string;
+      (** Symbol of the lowest-return filled pick. Empty string if no picks were
+          filled. *)
+}
+[@@deriving sexp, eq, show]
+(** Cross-pick summary for the whole snapshot. *)
+
+val trace_picks :
+  picks:Weekly_snapshot.t ->
+  bars:Daily_price.t list String.Map.t ->
+  horizon_days:int ->
+  per_pick_outcome list * aggregate
+(** [trace_picks ~picks ~bars ~horizon_days] traces each long candidate in
+    [picks] forward over [horizon_days] calendar days using the bar series for
+    that symbol from [bars].
+
+    Bars for each symbol are expected ascending by date. They are sorted
+    defensively. Bars outside the half-open window
+    [pick_date < bar_date <= pick_date + horizon_days] are ignored.
+
+    A symbol that has no entry in [bars], or whose bars are entirely outside the
+    window, produces an unfilled outcome (see [per_pick_outcome]).
+
+    [horizon_days] must be ≥ 1; if less than 1 the function still returns a
+    well-formed result — every pick is unfilled and the aggregate counts are
+    zero. This permits using the function as a no-op probe. *)

--- a/trading/trading/weinstein/snapshot/test/dune
+++ b/trading/trading/weinstein/snapshot/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_round_trip)
+ (names test_round_trip test_forward_trace)
  (libraries
   weinstein_trading.snapshot
   status
@@ -7,6 +7,7 @@
   core_unix
   core_unix.filename_unix
   ounit2
-  matchers)
+  matchers
+  types)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/weinstein/snapshot/test/test_forward_trace.ml
+++ b/trading/trading/weinstein/snapshot/test/test_forward_trace.ml
@@ -1,0 +1,395 @@
+(** Tests for {!Forward_trace}.
+
+    Pinned via fixtures so future drift in the rendering function shows up as a
+    test failure rather than as a silent regression in CI metrics. *)
+
+open Core
+open OUnit2
+open Matchers
+open Weinstein_snapshot
+open Types
+
+let _date d = Date.of_string d
+
+(** Build a [Daily_price.t] with no split adjustment (close = adjusted_close).
+    Used everywhere except the explicit split fixture. *)
+let _bar ?(volume = 1_000_000) ~date ~o ~h ~l ~c () : Daily_price.t =
+  {
+    date;
+    open_price = o;
+    high_price = h;
+    low_price = l;
+    close_price = c;
+    volume;
+    adjusted_close = c;
+  }
+
+let _candidate ?(score = 0.9) ?(grade = "A+") ?(sector = "XLK")
+    ?(rationale = "test") ?(rs_vs_spy = None) ?(resistance_grade = None) ~symbol
+    ~entry ~stop () : Weekly_snapshot.candidate =
+  {
+    symbol;
+    score;
+    grade;
+    entry;
+    stop;
+    sector;
+    rationale;
+    rs_vs_spy;
+    resistance_grade;
+  }
+
+let _snapshot ~date ~candidates : Weekly_snapshot.t =
+  {
+    schema_version = Weekly_snapshot.current_schema_version;
+    system_version = "test";
+    date;
+    macro = { regime = "Bullish"; score = 0.5 };
+    sectors_strong = [];
+    sectors_weak = [];
+    long_candidates = candidates;
+    short_candidates = [];
+    held_positions = [];
+  }
+
+(* ---------- Fixture 1: known historical pick (entry fills, +1% horizon) ---- *)
+
+(** A 5-bar series where the pick (entry $100) fills on day 1 at $100, and the
+    final bar closes at $101 — a +1% horizon return. Pinned values. *)
+let _aapl_like_bars : Daily_price.t list =
+  [
+    _bar ~date:(_date "2020-08-31") ~o:99.5 ~h:100.5 ~l:98.5 ~c:100.0 ();
+    _bar ~date:(_date "2020-09-01") ~o:100.2 ~h:101.0 ~l:99.0 ~c:100.5 ();
+    _bar ~date:(_date "2020-09-02") ~o:100.5 ~h:102.0 ~l:99.5 ~c:101.5 ();
+    _bar ~date:(_date "2020-09-03") ~o:101.0 ~h:101.5 ~l:99.0 ~c:99.5 ();
+    _bar ~date:(_date "2020-09-04") ~o:99.5 ~h:101.5 ~l:99.0 ~c:101.0 ();
+  ]
+
+let test_filled_pick_basic_outcome _ =
+  let pick =
+    _candidate ~symbol:"AAPL" ~entry:100.0 ~stop:95.0 ~rs_vs_spy:(Some 1.34) ()
+  in
+  let picks = _snapshot ~date:(_date "2020-08-28") ~candidates:[ pick ] in
+  let bars = String.Map.singleton "AAPL" _aapl_like_bars in
+  let outcomes, _agg =
+    Forward_trace.trace_picks ~picks ~bars ~horizon_days:20
+  in
+  assert_that outcomes
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.symbol)
+               (equal_to "AAPL");
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.entry_filled_at)
+               (float_equal 100.0);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.entry_filled_date)
+               (equal_to (_date "2020-08-31"));
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.final_price)
+               (float_equal 101.0);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.final_date)
+               (equal_to (_date "2020-09-04"));
+             field
+               (fun (o : Forward_trace.per_pick_outcome) ->
+                 o.pct_return_horizon)
+               (float_equal ~epsilon:1e-6 0.01);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.stop_triggered)
+               (equal_to false);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.winner)
+               (equal_to true);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.max_favorable)
+               (float_equal 102.0);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.max_adverse)
+               (float_equal 98.5);
+           ];
+       ])
+
+(* ---------- Fixture 2: stop-trigger detection ---- *)
+
+let _stop_trigger_bars : Daily_price.t list =
+  [
+    (* Entry fills at 410 on day 1 *)
+    _bar ~date:(_date "2021-01-04") ~o:405.0 ~h:415.0 ~l:402.0 ~c:412.0 ();
+    (* Day 2 plummets — low pierces $400 stop at $399 *)
+    _bar ~date:(_date "2021-01-05") ~o:411.0 ~h:412.0 ~l:399.0 ~c:401.0 ();
+    _bar ~date:(_date "2021-01-06") ~o:401.0 ~h:404.0 ~l:400.0 ~c:402.0 ();
+  ]
+
+let test_stop_trigger_detected _ =
+  let pick = _candidate ~symbol:"FOO" ~entry:410.0 ~stop:400.0 () in
+  let picks = _snapshot ~date:(_date "2021-01-01") ~candidates:[ pick ] in
+  let bars = String.Map.singleton "FOO" _stop_trigger_bars in
+  let outcomes, _agg =
+    Forward_trace.trace_picks ~picks ~bars ~horizon_days:10
+  in
+  assert_that outcomes
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.entry_filled_at)
+               (float_equal 410.0);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.stop_triggered)
+               (equal_to true);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.max_adverse)
+               (float_equal 399.0);
+           ];
+       ])
+
+(* ---------- Fixture 3: split-day round-trip (no phantom 4× return) ---- *)
+
+(** Bars spanning a 4:1 split. Pre-split: close ~$500, post-split: close ~$125
+    raw — but [adjusted_close] for the pre-split bar is rebased to ~$125 too, so
+    a forward trace using adjusted prices throughout sees ≈0% return, not 4×.
+
+    Day 0 (pick): close 500, adjusted_close 125 Day 1: high 510, low 490, close
+    502, adj_close 125.5 Day 2 (split day): raw close 130, adjusted_close 130 —
+    same scale Day 3: close 132, adj_close 132 — small gain in adjusted terms
+    only *)
+let _split_day_bars : Daily_price.t list =
+  [
+    {
+      date = _date "2020-08-31";
+      open_price = 498.0;
+      high_price = 503.0;
+      low_price = 497.0;
+      close_price = 500.0;
+      volume = 1_000_000;
+      adjusted_close = 125.0;
+    };
+    {
+      date = _date "2020-09-01";
+      open_price = 500.0;
+      high_price = 510.0;
+      low_price = 498.0;
+      close_price = 502.0;
+      volume = 1_000_000;
+      adjusted_close = 125.5;
+    };
+    (* Split day: raw price collapses 4×, adjusted is unchanged scale *)
+    {
+      date = _date "2020-09-02";
+      open_price = 126.0;
+      high_price = 132.0;
+      low_price = 125.0;
+      close_price = 130.0;
+      volume = 4_000_000;
+      adjusted_close = 130.0;
+    };
+    {
+      date = _date "2020-09-03";
+      open_price = 130.5;
+      high_price = 134.0;
+      low_price = 130.0;
+      close_price = 132.0;
+      volume = 4_000_000;
+      adjusted_close = 132.0;
+    };
+  ]
+
+let test_split_day_no_phantom_return _ =
+  (* Suggested entry 125 (in adjusted terms). Stop 115. Day 0 high adj 503 *
+     (125/500) = 125.75 ≥ 125 → fills at 125 (entry). Final adj_close 132 →
+     return = (132 - 125)/125 = 5.6%, not the phantom 4× a naive close-based
+     impl would produce. *)
+  let pick = _candidate ~symbol:"AAPL" ~entry:125.0 ~stop:115.0 () in
+  let picks = _snapshot ~date:(_date "2020-08-28") ~candidates:[ pick ] in
+  let bars = String.Map.singleton "AAPL" _split_day_bars in
+  let outcomes, _agg =
+    Forward_trace.trace_picks ~picks ~bars ~horizon_days:20
+  in
+  assert_that outcomes
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.entry_filled_at)
+               (float_equal 125.0);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.final_price)
+               (float_equal 132.0);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) ->
+                 o.pct_return_horizon)
+               (float_equal ~epsilon:1e-6 0.056);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.stop_triggered)
+               (equal_to false);
+             (* No phantom 4× return — adjusted prices keep scale uniform *)
+             field
+               (fun (o : Forward_trace.per_pick_outcome) ->
+                 o.pct_return_horizon)
+               (lt (module Float_ord) 1.0);
+           ];
+       ])
+
+(* ---------- Fixture 4: empty bars / never-filled pick ---- *)
+
+let test_empty_bars_unfilled _ =
+  let pick = _candidate ~symbol:"NOPE" ~entry:100.0 ~stop:90.0 () in
+  let picks = _snapshot ~date:(_date "2021-06-04") ~candidates:[ pick ] in
+  let outcomes, agg =
+    Forward_trace.trace_picks ~picks ~bars:String.Map.empty ~horizon_days:20
+  in
+  assert_that outcomes
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.symbol)
+               (equal_to "NOPE");
+             field
+               (fun (o : Forward_trace.per_pick_outcome) ->
+                 Float.is_nan o.entry_filled_at)
+               (equal_to true);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.winner)
+               (equal_to false);
+             field
+               (fun (o : Forward_trace.per_pick_outcome) -> o.stop_triggered)
+               (equal_to false);
+           ];
+       ]);
+  assert_that agg
+    (all_of
+       [
+         field (fun (a : Forward_trace.aggregate) -> a.total_picks) (equal_to 1);
+         field (fun (a : Forward_trace.aggregate) -> a.winners) (equal_to 0);
+         field (fun (a : Forward_trace.aggregate) -> a.losers) (equal_to 0);
+         field (fun (a : Forward_trace.aggregate) -> a.stopped_out) (equal_to 0);
+         field (fun (a : Forward_trace.aggregate) -> a.best_pick) (equal_to "");
+         field (fun (a : Forward_trace.aggregate) -> a.worst_pick) (equal_to "");
+         field
+           (fun (a : Forward_trace.aggregate) -> Float.is_nan a.avg_return_pct)
+           (equal_to true);
+       ])
+
+(* ---------- Fixture 5: never-filled pick (entry never reached) ---- *)
+
+let test_entry_never_reached _ =
+  (* Bars that stay below entry of 200 — never fill *)
+  let bars : Daily_price.t list =
+    [
+      _bar ~date:(_date "2022-01-04") ~o:150.0 ~h:155.0 ~l:148.0 ~c:152.0 ();
+      _bar ~date:(_date "2022-01-05") ~o:152.0 ~h:158.0 ~l:150.0 ~c:155.0 ();
+    ]
+  in
+  let pick = _candidate ~symbol:"BAR" ~entry:200.0 ~stop:140.0 () in
+  let picks = _snapshot ~date:(_date "2022-01-01") ~candidates:[ pick ] in
+  let bars_map = String.Map.singleton "BAR" bars in
+  let outcomes, _agg =
+    Forward_trace.trace_picks ~picks ~bars:bars_map ~horizon_days:20
+  in
+  assert_that outcomes
+    (elements_are
+       [
+         field
+           (fun (o : Forward_trace.per_pick_outcome) ->
+             Float.is_nan o.entry_filled_at)
+           (equal_to true);
+       ])
+
+(* ---------- Fixture 6: aggregate over multiple picks ---- *)
+
+let test_aggregate_winners_losers _ =
+  (* Two filled picks: one winner (+5%), one loser (-3%). Both fill on day 1. *)
+  let bars_w : Daily_price.t list =
+    [
+      _bar ~date:(_date "2020-09-01") ~o:99.5 ~h:101.0 ~l:99.0 ~c:100.0 ();
+      _bar ~date:(_date "2020-09-02") ~o:100.0 ~h:106.0 ~l:99.5 ~c:105.0 ();
+    ]
+  in
+  let bars_l : Daily_price.t list =
+    [
+      _bar ~date:(_date "2020-09-01") ~o:49.5 ~h:51.0 ~l:49.0 ~c:50.0 ();
+      _bar ~date:(_date "2020-09-02") ~o:50.0 ~h:50.5 ~l:48.0 ~c:48.5 ();
+    ]
+  in
+  let candidates =
+    [
+      _candidate ~symbol:"WIN" ~entry:100.0 ~stop:90.0 ();
+      _candidate ~symbol:"LOSE" ~entry:50.0 ~stop:45.0 ();
+    ]
+  in
+  let picks = _snapshot ~date:(_date "2020-08-31") ~candidates in
+  let bars = String.Map.of_alist_exn [ ("WIN", bars_w); ("LOSE", bars_l) ] in
+  let _outcomes, agg = Forward_trace.trace_picks ~picks ~bars ~horizon_days:5 in
+  assert_that agg
+    (all_of
+       [
+         field
+           (fun (a : Forward_trace.aggregate) -> a.horizon_days)
+           (equal_to 5);
+         field (fun (a : Forward_trace.aggregate) -> a.total_picks) (equal_to 2);
+         field (fun (a : Forward_trace.aggregate) -> a.winners) (equal_to 1);
+         field (fun (a : Forward_trace.aggregate) -> a.losers) (equal_to 1);
+         field (fun (a : Forward_trace.aggregate) -> a.stopped_out) (equal_to 0);
+         field
+           (fun (a : Forward_trace.aggregate) -> a.best_pick)
+           (equal_to "WIN");
+         field
+           (fun (a : Forward_trace.aggregate) -> a.worst_pick)
+           (equal_to "LOSE");
+         field
+           (fun (a : Forward_trace.aggregate) -> a.avg_winner_return_pct)
+           (float_equal ~epsilon:1e-6 0.05);
+         field
+           (fun (a : Forward_trace.aggregate) -> a.avg_loser_return_pct)
+           (float_equal ~epsilon:1e-6 (-0.03));
+         field
+           (fun (a : Forward_trace.aggregate) -> a.avg_return_pct)
+           (float_equal ~epsilon:1e-6 0.01);
+       ])
+
+(* ---------- Fixture 7: gap-up entry fills at the open, not at the entry ---- *)
+
+let test_gap_up_open_entry _ =
+  (* Pick entry $100. Day 1 opens at $105 (gap above), high 108. Fill must be at
+     105 (the open), not 100 — buy-stop becomes a market order on gap. *)
+  let bars : Daily_price.t list =
+    [
+      _bar ~date:(_date "2023-03-02") ~o:105.0 ~h:108.0 ~l:104.0 ~c:107.0 ();
+      _bar ~date:(_date "2023-03-03") ~o:107.0 ~h:109.0 ~l:106.0 ~c:108.0 ();
+    ]
+  in
+  let pick = _candidate ~symbol:"GAP" ~entry:100.0 ~stop:90.0 () in
+  let picks = _snapshot ~date:(_date "2023-03-01") ~candidates:[ pick ] in
+  let bars_map = String.Map.singleton "GAP" bars in
+  let outcomes, _agg =
+    Forward_trace.trace_picks ~picks ~bars:bars_map ~horizon_days:5
+  in
+  assert_that outcomes
+    (elements_are
+       [
+         field
+           (fun (o : Forward_trace.per_pick_outcome) -> o.entry_filled_at)
+           (float_equal 105.0);
+       ])
+
+let suite =
+  "forward_trace"
+  >::: [
+         "filled_pick_basic_outcome" >:: test_filled_pick_basic_outcome;
+         "stop_trigger_detected" >:: test_stop_trigger_detected;
+         "split_day_no_phantom_return" >:: test_split_day_no_phantom_return;
+         "empty_bars_unfilled" >:: test_empty_bars_unfilled;
+         "entry_never_reached" >:: test_entry_never_reached;
+         "aggregate_winners_losers" >:: test_aggregate_winners_losers;
+         "gap_up_open_entry" >:: test_gap_up_open_entry;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- Implements M6.2 of the M6 weekly-snapshot verification plan (`dev/plans/m6-weekly-snapshot-verification-2026-05-02.md`).
- Pure function `Forward_trace.trace_picks` rolls a `Weekly_snapshot.t`'s long candidates forward over a fixed horizon of daily bars and reports per-pick outcomes + aggregate.
- Per-pick reports: suggested entry / stop, fill price + date, max favorable, max adverse, final price + date, pct return, stop trigger, max drawdown within horizon, winner.
- Aggregate reports: total / winners / losers / stopped, avg / winner avg / loser avg returns, best / worst pick.
- CLI wrapper `trace_picks` (`--pick-file PATH --bars-dir PATH --horizon DAYS`) prints sexp to stdout.
- Adjusted-close-based throughout — split between pick date and horizon end produces no phantom return.

## Scope

This PR ships **lib + tests + CLI only**. No simulator wiring, no `release_perf_report` integration — those are M6.5 / follow-up scope.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest trading/trading/weinstein/snapshot` green (7 new + 11 round-trip tests)
- [x] `dune build @fmt --auto-promote` clean
- [x] Filled-pick basic outcome: entry fill price, fill date, final price, pct_return_horizon, max_favorable, max_adverse all pinned
- [x] Stop trigger: synthetic bar with low = $399 vs stop = $400 → `stop_triggered = true`
- [x] Split-day round trip: 4:1 split mid-horizon, return reported as ~5.6% (adjusted), not phantom 4×
- [x] Empty bars map → unfilled outcome, NaN return, aggregate counts zero
- [x] Entry never reached: bars stay below entry → `Float.is_nan entry_filled_at`
- [x] Aggregate winners/losers/best/worst pinned over a 2-pick fixture
- [x] Gap-up entry: open above suggested entry → fill at the open, not at the entry

## Files

- `trading/trading/weinstein/snapshot/lib/forward_trace.{ml,mli}` (new)
- `trading/trading/weinstein/snapshot/lib/dune` (add `types` lib dep)
- `trading/trading/weinstein/snapshot/bin/{dune,trace_picks.ml}` (new)
- `trading/trading/weinstein/snapshot/test/dune` (add new test target + `types` dep)
- `trading/trading/weinstein/snapshot/test/test_forward_trace.ml` (new)