### PR TITLE
feat(metrics): trade aggregates + return basics catalog (M5.2b)

### DIFF
--- a/trading/trading/backtest/lib/comparison.ml
+++ b/trading/trading/backtest/lib/comparison.ml
@@ -35,6 +35,37 @@ let _metric_label : Metric_type.t -> string = function
   | OpenPositionsValue -> "open_positions_value"
   | UnrealizedPnl -> "unrealized_pnl"
   | TradeFrequency -> "trade_frequency"
+  (* M5.2b: returns block *)
+  | TotalReturnPct -> "total_return_pct"
+  | VolatilityPctAnnualized -> "volatility_pct_annualized"
+  | DownsideDeviationPctAnnualized -> "downside_deviation_pct_annualized"
+  | BestDayPct -> "best_day_pct"
+  | WorstDayPct -> "worst_day_pct"
+  | BestWeekPct -> "best_week_pct"
+  | WorstWeekPct -> "worst_week_pct"
+  | BestMonthPct -> "best_month_pct"
+  | WorstMonthPct -> "worst_month_pct"
+  | BestQuarterPct -> "best_quarter_pct"
+  | WorstQuarterPct -> "worst_quarter_pct"
+  | BestYearPct -> "best_year_pct"
+  | WorstYearPct -> "worst_year_pct"
+  (* M5.2b: trade aggregates *)
+  | NumTrades -> "num_trades"
+  | LossRate -> "loss_rate"
+  | AvgWinDollar -> "avg_win_dollar"
+  | AvgWinPct -> "avg_win_pct"
+  | AvgLossDollar -> "avg_loss_dollar"
+  | AvgLossPct -> "avg_loss_pct"
+  | LargestWinDollar -> "largest_win_dollar"
+  | LargestLossDollar -> "largest_loss_dollar"
+  | AvgTradeSizeDollar -> "avg_trade_size_dollar"
+  | AvgTradeSizePct -> "avg_trade_size_pct"
+  | AvgHoldingDaysWinners -> "avg_holding_days_winners"
+  | AvgHoldingDaysLosers -> "avg_holding_days_losers"
+  | Expectancy -> "expectancy"
+  | WinLossRatio -> "win_loss_ratio"
+  | MaxConsecutiveWins -> "max_consecutive_wins"
+  | MaxConsecutiveLosses -> "max_consecutive_losses"
 
 let _all_metric_types : Metric_type.t list =
   [
@@ -52,6 +83,37 @@ let _all_metric_types : Metric_type.t list =
     OpenPositionsValue;
     UnrealizedPnl;
     TradeFrequency;
+    (* M5.2b: returns block *)
+    TotalReturnPct;
+    VolatilityPctAnnualized;
+    DownsideDeviationPctAnnualized;
+    BestDayPct;
+    WorstDayPct;
+    BestWeekPct;
+    WorstWeekPct;
+    BestMonthPct;
+    WorstMonthPct;
+    BestQuarterPct;
+    WorstQuarterPct;
+    BestYearPct;
+    WorstYearPct;
+    (* M5.2b: trade aggregates *)
+    NumTrades;
+    LossRate;
+    AvgWinDollar;
+    AvgWinPct;
+    AvgLossDollar;
+    AvgLossPct;
+    LargestWinDollar;
+    LargestLossDollar;
+    AvgTradeSizeDollar;
+    AvgTradeSizePct;
+    AvgHoldingDaysWinners;
+    AvgHoldingDaysLosers;
+    Expectancy;
+    WinLossRatio;
+    MaxConsecutiveWins;
+    MaxConsecutiveLosses;
   ]
 
 let _diff_for_metric ~baseline_set ~variant_set (mt : Metric_type.t) =

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -104,7 +104,7 @@ let _make_simulator (input : input) ~stop_log ~audit_recorder ~start_date
   let sim_deps =
     Simulator.create_deps ~symbols:input.all_symbols
       ~data_dir:input.data_dir_fpath ~strategy ~commission
-      ~metric_suite:(Metric_computers.default_metric_suite ())
+      ~metric_suite:(Metric_computers.default_metric_suite ~initial_cash ())
       ()
   in
   let sim_config =

--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -20,6 +20,8 @@
   sharpe_computer
   drawdown_computer
   cagr_computer
-  portfolio_state_computer)
+  portfolio_state_computer
+  trade_aggregates_computer
+  return_basics_computer)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/simulation/lib/metric_computers.ml
+++ b/trading/trading/simulation/lib/metric_computers.ml
@@ -5,7 +5,9 @@
     - {!Sharpe_computer}
     - {!Drawdown_computer}
     - {!Cagr_computer}
-    - {!Portfolio_state_computer} *)
+    - {!Portfolio_state_computer}
+    - {!Trade_aggregates_computer} (M5.2b)
+    - {!Return_basics_computer} (M5.2b) *)
 
 open Core
 module Metric_types = Trading_simulation_types.Metric_types
@@ -18,6 +20,8 @@ let sharpe_ratio_computer = Sharpe_computer.computer
 let max_drawdown_computer = Drawdown_computer.computer
 let cagr_computer = Cagr_computer.computer
 let portfolio_state_computer = Portfolio_state_computer.computer
+let trade_aggregates_computer = Trade_aggregates_computer.computer
+let return_basics_computer = Return_basics_computer.computer
 
 (** {1 Derived Metric Computers} *)
 
@@ -57,23 +61,35 @@ let create_computer (metric_type : Metric_types.metric_type) :
   | CalmarRatio -> _calmar_stub ()
   | OpenPositionCount | OpenPositionsValue | UnrealizedPnl | TradeFrequency ->
       portfolio_state_computer ()
+  | NumTrades | LossRate | AvgWinDollar | AvgWinPct | AvgLossDollar | AvgLossPct
+  | LargestWinDollar | LargestLossDollar | AvgTradeSizeDollar | AvgTradeSizePct
+  | AvgHoldingDaysWinners | AvgHoldingDaysLosers | Expectancy | WinLossRatio
+  | MaxConsecutiveWins | MaxConsecutiveLosses ->
+      trade_aggregates_computer ()
+  | TotalReturnPct | VolatilityPctAnnualized | DownsideDeviationPctAnnualized
+  | BestDayPct | WorstDayPct | BestWeekPct | WorstWeekPct | BestMonthPct
+  | WorstMonthPct | BestQuarterPct | WorstQuarterPct | BestYearPct
+  | WorstYearPct ->
+      return_basics_computer ()
 
 (** {1 Default Computer Set} *)
 
-let default_computers ?(risk_free_rate = 0.0) () =
+let default_computers ?(risk_free_rate = 0.0) ?(initial_cash = 0.0) () =
   [
     summary_computer ();
     sharpe_ratio_computer ~risk_free_rate ();
     max_drawdown_computer ();
     cagr_computer ();
     portfolio_state_computer ();
+    trade_aggregates_computer ~initial_cash ();
+    return_basics_computer ();
   ]
 
 let default_derived_computers () = [ calmar_ratio_derived ]
 
-let default_metric_suite ?(risk_free_rate = 0.0) () :
+let default_metric_suite ?(risk_free_rate = 0.0) ?(initial_cash = 0.0) () :
     Simulator_types.metric_suite =
   {
-    computers = default_computers ~risk_free_rate ();
+    computers = default_computers ~risk_free_rate ~initial_cash ();
     derived = default_derived_computers ();
   }

--- a/trading/trading/simulation/lib/metric_computers.mli
+++ b/trading/trading/simulation/lib/metric_computers.mli
@@ -62,15 +62,46 @@ val portfolio_state_computer : unit -> Simulator.any_metric_computer
       minus sum of position cost bases; signed-qty form covers longs + shorts)
     - TradeFrequency: Average trades per month *)
 
+(** {1 Trade Aggregates Computer (M5.2b)} *)
+
+val trade_aggregates_computer :
+  ?initial_cash:float -> unit -> Simulator.any_metric_computer
+(** Computer that emits the M5.2b trade-aggregate group: NumTrades, LossRate,
+    AvgWin/Loss (dollars + percent), Largest Win/Loss, AvgTradeSize (dollars +
+    percent), Avg holding days (winners / losers), Expectancy, WinLossRatio,
+    MaxConsecutiveWins / MaxConsecutiveLosses.
+
+    @param initial_cash
+      Used as the denominator for [AvgTradeSizePct]. Pass the simulator's
+      configured [initial_cash]; otherwise [AvgTradeSizePct] reports 0.0. *)
+
+(** {1 Return Basics Computer (M5.2b)} *)
+
+val return_basics_computer : unit -> Simulator.any_metric_computer
+(** Computer that emits the M5.2b returns-block group: TotalReturnPct,
+    VolatilityPctAnnualized, DownsideDeviationPctAnnualized, and best/worst
+    returns over day / week / month / quarter / year buckets.
+
+    Volatility uses the simulation's per-step (daily-cadence) returns annualized
+    via × sqrt(252); calendar bucketing pairs adjacent buckets' last
+    portfolio_value to compute compounded period returns. *)
+
 (** {1 Default Computer Set} *)
 
 val default_computers :
-  ?risk_free_rate:float -> unit -> Simulator.any_metric_computer list
+  ?risk_free_rate:float ->
+  ?initial_cash:float ->
+  unit ->
+  Simulator.any_metric_computer list
 (** Returns all default step-based metric computers: summary (including profit
-    factor), Sharpe ratio, max drawdown, CAGR, and portfolio state.
+    factor), Sharpe ratio, max drawdown, CAGR, portfolio state, trade
+    aggregates, and the M5.2b returns-block group.
 
     @param risk_free_rate
-      Annual risk-free rate for Sharpe calculation (default: 0.0) *)
+      Annual risk-free rate for Sharpe calculation (default: 0.0)
+    @param initial_cash
+      Initial portfolio cash, fed into the trade-aggregates computer for
+      [AvgTradeSizePct] (default: 0.0). *)
 
 (** {1 Derived Metric Computers} *)
 
@@ -82,9 +113,12 @@ val default_derived_computers : unit -> Simulator.derived_metric_computer list
 (** Returns all default derived metric computers (currently: CalmarRatio). *)
 
 val default_metric_suite :
-  ?risk_free_rate:float -> unit -> Simulator.metric_suite
+  ?risk_free_rate:float -> ?initial_cash:float -> unit -> Simulator.metric_suite
 (** Returns a complete metric suite with all step-based and derived computers.
-*)
+
+    @param initial_cash
+      Initial portfolio cash, used by the trade-aggregates computer for
+      [AvgTradeSizePct] (default: 0.0). *)
 
 (** {1 Factory} *)
 
@@ -94,5 +128,9 @@ val create_computer :
 (** Create a metric computer from a metric type.
 
     Note: Summary metrics (TotalPnl, AvgHoldingDays, WinCount, LossCount,
-    WinRate, ProfitFactor) are produced together by summary_computer.
-    CalmarRatio is a derived metric computed post-hoc by the simulator. *)
+    WinRate, ProfitFactor) are produced together by summary_computer. The
+    trade-aggregate group (NumTrades, LossRate, AvgWin/Loss, etc.) is produced
+    together by trade_aggregates_computer; the returns-block group
+    (TotalReturnPct, VolatilityPctAnnualized, BestDayPct, etc.) by
+    return_basics_computer. CalmarRatio is a derived metric computed post-hoc by
+    the simulator. *)

--- a/trading/trading/simulation/lib/return_basics_computer.ml
+++ b/trading/trading/simulation/lib/return_basics_computer.ml
@@ -1,0 +1,234 @@
+(** Returns-block metric computer (M5.2b). See .mli for spec. *)
+
+open Core
+module Metric_types = Trading_simulation_types.Metric_types
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+(** Number of trading days per year used for volatility annualization. The
+    Sharpe computer uses the same convention via
+    [Metric_computer_utils.trading_days_per_year]; kept consistent here. *)
+let _trading_days_per_year = Metric_computer_utils.trading_days_per_year
+
+type sample = { date : Date.t; value : float }
+
+type state = {
+  samples : sample list;  (** Reversed: head is most recent. *)
+  initial_value : float option;
+}
+
+(* ---- Daily returns helpers ---- *)
+
+let _step_values samples = List.map samples ~f:(fun s -> s.value)
+
+let _step_returns_pct_from_values values =
+  let rec loop prev rest acc =
+    match rest with
+    | [] -> List.rev acc
+    | curr :: rest' ->
+        let r =
+          if Float.(prev <= 0.0) then 0.0 else (curr -. prev) /. prev *. 100.0
+        in
+        loop curr rest' (r :: acc)
+  in
+  match values with [] | [ _ ] -> [] | first :: rest -> loop first rest []
+
+(* ---- Volatility helpers ---- *)
+
+let _mean = function
+  | [] -> 0.0
+  | xs ->
+      let sum = List.fold xs ~init:0.0 ~f:( +. ) in
+      sum /. Float.of_int (List.length xs)
+
+let _stdev xs =
+  match xs with
+  | [] | [ _ ] -> 0.0
+  | _ ->
+      let mu = _mean xs in
+      let n = List.length xs in
+      let sum_sq =
+        List.fold xs ~init:0.0 ~f:(fun acc x ->
+            let d = x -. mu in
+            acc +. (d *. d))
+      in
+      Float.sqrt (sum_sq /. Float.of_int n)
+
+let _annualize_pct stdev_pct = stdev_pct *. Float.sqrt _trading_days_per_year
+
+let _downside_returns step_returns =
+  List.map step_returns ~f:(fun r -> if Float.(r < 0.0) then r else 0.0)
+
+(* ---- Calendar bucketing ----
+
+   The grouping scheme: bucket steps by a derived [bucket_key]; within each
+   bucket take the last sample (chronological max). Pair adjacent buckets
+   (prev_end, this_end) and compute compounded return. The first bucket
+   uses [initial_value] as its predecessor-end. *)
+
+let _week_key (d : Date.t) =
+  (* ISO week: rough approximation via (year, day_of_year / 7). Off by edge
+     cases at year boundaries — acceptable since callers compare by best/worst
+     bucketed return, not by bucket label. *)
+  let doy =
+    Date.diff d (Date.create_exn ~y:(Date.year d) ~m:Month.Jan ~d:1) + 1
+  in
+  (Date.year d, doy / 7)
+
+let _month_key (d : Date.t) = (Date.year d, Month.to_int (Date.month d))
+
+let _quarter_key (d : Date.t) =
+  (Date.year d, ((Month.to_int (Date.month d) - 1) / 3) + 1)
+
+let _year_key (d : Date.t) = Date.year d
+
+(** Bucket [samples] (chronological) by [key_of], emitting one entry per bucket
+    in order. The entry's value is the last sample within the bucket. Bucket
+    order is preserved by left-to-right scanning. *)
+let _bucket_last_values (samples : sample list) ~key_of =
+  let rec loop acc current rest =
+    match rest with
+    | [] -> (
+        match current with
+        | None -> List.rev acc
+        | Some (_, v) -> List.rev (v :: acc))
+    | s :: rest' -> (
+        let k = key_of s.date in
+        match current with
+        | None -> loop acc (Some (k, s.value)) rest'
+        | Some (cur_k, _) when Poly.equal cur_k k ->
+            loop acc (Some (cur_k, s.value)) rest'
+        | Some (_, prev_v) -> loop (prev_v :: acc) (Some (k, s.value)) rest')
+  in
+  loop [] None samples
+
+let _bucket_returns_pct values ~initial =
+  let rec loop prev rest acc =
+    match rest with
+    | [] -> List.rev acc
+    | curr :: rest' ->
+        let r =
+          if Float.(prev <= 0.0) then 0.0 else (curr -. prev) /. prev *. 100.0
+        in
+        loop curr rest' (r :: acc)
+  in
+  match values with [] -> [] | _ :: _ -> loop initial values []
+
+let _best_worst returns =
+  match returns with
+  | [] -> (0.0, 0.0)
+  | _ ->
+      let best = List.fold returns ~init:Float.neg_infinity ~f:Float.max in
+      let worst = List.fold returns ~init:Float.infinity ~f:Float.min in
+      (best, worst)
+
+(* ---- update / finalize ---- *)
+
+let _update ~state ~step =
+  if not (Metric_computer_utils.is_trading_day_step step) then state
+  else
+    let value = step.Simulator_types.portfolio_value in
+    let initial_value =
+      match state.initial_value with None -> Some value | some -> some
+    in
+    { samples = { date = step.date; value } :: state.samples; initial_value }
+
+let _bucket_extremes_for ~initial_value samples ~key_of =
+  let bucket_values = _bucket_last_values samples ~key_of in
+  _best_worst (_bucket_returns_pct bucket_values ~initial:initial_value)
+
+let _bucket_extremes ~initial_value chrono =
+  let best_week, worst_week =
+    _bucket_extremes_for ~initial_value chrono ~key_of:_week_key
+  in
+  let best_month, worst_month =
+    _bucket_extremes_for ~initial_value chrono ~key_of:_month_key
+  in
+  let best_quarter, worst_quarter =
+    _bucket_extremes_for ~initial_value chrono ~key_of:_quarter_key
+  in
+  let best_year, worst_year =
+    _bucket_extremes_for ~initial_value chrono ~key_of:_year_key
+  in
+  ( best_week,
+    worst_week,
+    best_month,
+    worst_month,
+    best_quarter,
+    worst_quarter,
+    best_year,
+    worst_year )
+
+let _total_return_pct ~initial_value ~last_value =
+  if Float.(initial_value <= 0.0) then 0.0
+  else (last_value -. initial_value) /. initial_value *. 100.0
+
+let _metrics ~initial_value samples =
+  let chrono = List.rev samples in
+  let values = _step_values chrono in
+  let step_returns = _step_returns_pct_from_values values in
+  let last_value =
+    match List.last chrono with None -> initial_value | Some s -> s.value
+  in
+  let vol_annualized = _annualize_pct (_stdev step_returns) in
+  let downside_annualized =
+    _annualize_pct (_stdev (_downside_returns step_returns))
+  in
+  let best_day, worst_day = _best_worst step_returns in
+  let ( best_week,
+        worst_week,
+        best_month,
+        worst_month,
+        best_quarter,
+        worst_quarter,
+        best_year,
+        worst_year ) =
+    _bucket_extremes ~initial_value chrono
+  in
+  Metric_types.of_alist_exn
+    [
+      (TotalReturnPct, _total_return_pct ~initial_value ~last_value);
+      (VolatilityPctAnnualized, vol_annualized);
+      (DownsideDeviationPctAnnualized, downside_annualized);
+      (BestDayPct, best_day);
+      (WorstDayPct, worst_day);
+      (BestWeekPct, best_week);
+      (WorstWeekPct, worst_week);
+      (BestMonthPct, best_month);
+      (WorstMonthPct, worst_month);
+      (BestQuarterPct, best_quarter);
+      (WorstQuarterPct, worst_quarter);
+      (BestYearPct, best_year);
+      (WorstYearPct, worst_year);
+    ]
+
+let _empty_metric_set () =
+  Metric_types.of_alist_exn
+    [
+      (TotalReturnPct, 0.0);
+      (VolatilityPctAnnualized, 0.0);
+      (DownsideDeviationPctAnnualized, 0.0);
+      (BestDayPct, 0.0);
+      (WorstDayPct, 0.0);
+      (BestWeekPct, 0.0);
+      (WorstWeekPct, 0.0);
+      (BestMonthPct, 0.0);
+      (WorstMonthPct, 0.0);
+      (BestQuarterPct, 0.0);
+      (WorstQuarterPct, 0.0);
+      (BestYearPct, 0.0);
+      (WorstYearPct, 0.0);
+    ]
+
+let _finalize ~state ~config:_ =
+  match state.initial_value with
+  | None -> _empty_metric_set ()
+  | Some initial_value -> _metrics ~initial_value state.samples
+
+let computer () : Simulator_types.any_metric_computer =
+  Simulator_types.wrap_computer
+    {
+      name = "return_basics";
+      init = (fun ~config:_ -> { samples = []; initial_value = None });
+      update = _update;
+      finalize = _finalize;
+    }

--- a/trading/trading/simulation/lib/return_basics_computer.ml
+++ b/trading/trading/simulation/lib/return_basics_computer.ml
@@ -66,13 +66,13 @@ let _downside_returns step_returns =
    uses [initial_value] as its predecessor-end. *)
 
 let _week_key (d : Date.t) =
-  (* ISO week: rough approximation via (year, day_of_year / 7). Off by edge
-     cases at year boundaries — acceptable since callers compare by best/worst
-     bucketed return, not by bucket label. *)
-  let doy =
-    Date.diff d (Date.create_exn ~y:(Date.year d) ~m:Month.Jan ~d:1) + 1
-  in
-  (Date.year d, doy / 7)
+  (* ISO 8601 calendar week (Mon–Sun). Returns (week_numbering_year,
+     week_number); the week-numbering year may differ from the calendar year
+     near year boundaries (e.g. 2024-12-30 belongs to 2025-W01 by ISO). Equal
+     keys correspond to dates in the same ISO week, which is what the bucketing
+     logic requires. *)
+  let week, week_year = Date.week_number_and_year d in
+  (week_year, week)
 
 let _month_key (d : Date.t) = (Date.year d, Month.to_int (Date.month d))
 

--- a/trading/trading/simulation/lib/return_basics_computer.mli
+++ b/trading/trading/simulation/lib/return_basics_computer.mli
@@ -1,0 +1,29 @@
+(** Returns-block metric computer (M5.2b).
+
+    Produces the raw + extreme returns metrics from the portfolio-value sequence
+    emitted by the simulator: total return, annualized volatility, annualized
+    downside deviation, and best/worst calendar-bucketed returns (day, week,
+    month, quarter, year).
+
+    Pure: same step list → same output. *)
+
+val computer :
+  unit -> Trading_simulation_types.Simulator_types.any_metric_computer
+(** Build a metric computer that emits the returns-block group:
+
+    - [TotalReturnPct]
+    - [VolatilityPctAnnualized]
+    - [DownsideDeviationPctAnnualized]
+    - [BestDayPct], [WorstDayPct]
+    - [BestWeekPct], [WorstWeekPct]
+    - [BestMonthPct], [WorstMonthPct]
+    - [BestQuarterPct], [WorstQuarterPct]
+    - [BestYearPct], [WorstYearPct]
+
+    Calendar bucketing is by ISO calendar week (Mon–Sun), calendar month,
+    calendar quarter (Q1=Jan–Mar, …, Q4=Oct–Dec), and calendar year. Cumulative
+    bucket return is computed on the {b last} portfolio_value of each bucket
+    relative to the {b last} portfolio_value of the previous bucket (i.e. the
+    bucket's compounded change), which mirrors the standard "monthly returns"
+    reporting convention. The first bucket's return is relative to the initial
+    portfolio_value (= initial_cash). *)

--- a/trading/trading/simulation/lib/return_basics_computer.mli
+++ b/trading/trading/simulation/lib/return_basics_computer.mli
@@ -20,10 +20,13 @@ val computer :
     - [BestQuarterPct], [WorstQuarterPct]
     - [BestYearPct], [WorstYearPct]
 
-    Calendar bucketing is by ISO calendar week (Mon–Sun), calendar month,
-    calendar quarter (Q1=Jan–Mar, …, Q4=Oct–Dec), and calendar year. Cumulative
-    bucket return is computed on the {b last} portfolio_value of each bucket
-    relative to the {b last} portfolio_value of the previous bucket (i.e. the
-    bucket's compounded change), which mirrors the standard "monthly returns"
-    reporting convention. The first bucket's return is relative to the initial
+    Calendar bucketing is by ISO 8601 calendar week (Mon–Sun, keyed by the
+    [(week_numbering_year, week_number)] pair from [Core.Date], so a date in
+    early January or late December is grouped with its true ISO week — e.g.
+    2024-12-30 and 2025-01-02 share bucket 2025-W01), calendar month, calendar
+    quarter (Q1=Jan–Mar, …, Q4=Oct–Dec), and calendar year. Cumulative bucket
+    return is computed on the {b last} portfolio_value of each bucket relative
+    to the {b last} portfolio_value of the previous bucket (i.e. the bucket's
+    compounded change), which mirrors the standard "monthly returns" reporting
+    convention. The first bucket's return is relative to the initial
     portfolio_value (= initial_cash). *)

--- a/trading/trading/simulation/lib/trade_aggregates_computer.ml
+++ b/trading/trading/simulation/lib/trade_aggregates_computer.ml
@@ -1,0 +1,201 @@
+(** Trade-aggregate metric computer (M5.2b).
+
+    See {!Trade_aggregates_computer.mli} for the metric list. The shape mirrors
+    [Summary_computer]: accumulate [step_result]s during [update], reconstruct
+    round-trips at [finalize] via [Metrics.extract_round_trips], then derive the
+    aggregate metric set. *)
+
+open Core
+module Metric_types = Trading_simulation_types.Metric_types
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+type state = { steps : Simulator_types.step_result list; initial_cash : float }
+
+(** Mean of a non-empty float list. Returns [0.0] for the empty case rather than
+    raising — the call sites already guarded by an emptiness check, so this is
+    just a defensive default. *)
+let _mean = function
+  | [] -> 0.0
+  | xs ->
+      let sum = List.fold xs ~init:0.0 ~f:( +. ) in
+      sum /. Float.of_int (List.length xs)
+
+let _max_consecutive ~pred trades =
+  List.fold trades ~init:(0, 0) ~f:(fun (curr, best) t ->
+      if pred t then
+        let next = curr + 1 in
+        (next, Int.max next best)
+      else (0, best))
+  |> snd
+
+let _entry_notional (m : Metrics.trade_metrics) = m.entry_price *. m.quantity
+
+let _expectancy ~win_rate_pct ~avg_win ~avg_loss =
+  let win_p = win_rate_pct /. 100.0 in
+  let loss_p = 1.0 -. win_p in
+  (win_p *. avg_win) -. (loss_p *. Float.abs avg_loss)
+
+let _win_loss_ratio ~avg_win ~avg_loss =
+  if Float.(avg_loss = 0.0) then
+    if Float.(avg_win > 0.0) then Float.infinity else 0.0
+  else avg_win /. Float.abs avg_loss
+
+(** Sort round-trips chronologically by entry date so consecutive-win and
+    consecutive-loss runs reflect real time order across symbols. *)
+let _sort_by_entry trades =
+  List.sort trades ~compare:(fun (a : Metrics.trade_metrics) b ->
+      Date.compare a.entry_date b.entry_date)
+
+let _split_winners_losers trades =
+  List.partition_tf trades ~f:(fun (m : Metrics.trade_metrics) ->
+      Float.(m.pnl_dollars > 0.0))
+
+let _largest_win_dollar = function
+  | [] -> 0.0
+  | winners ->
+      List.fold winners ~init:Float.neg_infinity
+        ~f:(fun acc (m : Metrics.trade_metrics) -> Float.max acc m.pnl_dollars)
+
+let _largest_loss_dollar = function
+  | [] -> 0.0
+  | losers ->
+      List.fold losers ~init:Float.infinity
+        ~f:(fun acc (m : Metrics.trade_metrics) -> Float.min acc m.pnl_dollars)
+
+(** Collect the per-group means used by multiple downstream metrics. Returned
+    flat for clarity at the call site rather than as a record (no record escapes
+    this module). *)
+let _group_means ~winners ~losers =
+  let avg_win_dollar =
+    _mean
+      (List.map winners ~f:(fun (m : Metrics.trade_metrics) -> m.pnl_dollars))
+  in
+  let avg_win_pct =
+    _mean
+      (List.map winners ~f:(fun (m : Metrics.trade_metrics) -> m.pnl_percent))
+  in
+  let avg_loss_dollar =
+    _mean
+      (List.map losers ~f:(fun (m : Metrics.trade_metrics) -> m.pnl_dollars))
+  in
+  let avg_loss_pct =
+    _mean
+      (List.map losers ~f:(fun (m : Metrics.trade_metrics) -> m.pnl_percent))
+  in
+  let avg_holding_winners =
+    _mean
+      (List.map winners ~f:(fun (m : Metrics.trade_metrics) ->
+           Float.of_int m.days_held))
+  in
+  let avg_holding_losers =
+    _mean
+      (List.map losers ~f:(fun (m : Metrics.trade_metrics) ->
+           Float.of_int m.days_held))
+  in
+  ( avg_win_dollar,
+    avg_win_pct,
+    avg_loss_dollar,
+    avg_loss_pct,
+    avg_holding_winners,
+    avg_holding_losers )
+
+let _trade_size_metrics ~all ~initial_cash =
+  let avg_size_dollar = _mean (List.map all ~f:_entry_notional) in
+  let avg_size_pct =
+    if Float.(initial_cash <= 0.0) then 0.0
+    else avg_size_dollar /. initial_cash *. 100.0
+  in
+  (avg_size_dollar, avg_size_pct)
+
+let _consecutive_runs trades =
+  let chrono = _sort_by_entry trades in
+  let max_wins =
+    _max_consecutive
+      ~pred:(fun (m : Metrics.trade_metrics) -> Float.(m.pnl_dollars > 0.0))
+      chrono
+  in
+  let max_losses =
+    _max_consecutive
+      ~pred:(fun (m : Metrics.trade_metrics) -> Float.(m.pnl_dollars < 0.0))
+      chrono
+  in
+  (max_wins, max_losses)
+
+let _empty_metric_set () =
+  Metric_types.of_alist_exn
+    [
+      (NumTrades, 0.0);
+      (LossRate, 0.0);
+      (AvgWinDollar, 0.0);
+      (AvgWinPct, 0.0);
+      (AvgLossDollar, 0.0);
+      (AvgLossPct, 0.0);
+      (LargestWinDollar, 0.0);
+      (LargestLossDollar, 0.0);
+      (AvgTradeSizeDollar, 0.0);
+      (AvgTradeSizePct, 0.0);
+      (AvgHoldingDaysWinners, 0.0);
+      (AvgHoldingDaysLosers, 0.0);
+      (Expectancy, 0.0);
+      (WinLossRatio, 0.0);
+      (MaxConsecutiveWins, 0.0);
+      (MaxConsecutiveLosses, 0.0);
+    ]
+
+let _metrics_of_trades ~initial_cash trades =
+  let n = List.length trades in
+  let winners, losers = _split_winners_losers trades in
+  let win_count = List.length winners in
+  let loss_count = List.length losers in
+  let win_rate_pct = Float.of_int win_count /. Float.of_int n *. 100.0 in
+  let loss_rate_pct = Float.of_int loss_count /. Float.of_int n *. 100.0 in
+  let ( avg_win_dollar,
+        avg_win_pct,
+        avg_loss_dollar,
+        avg_loss_pct,
+        avg_holding_winners,
+        avg_holding_losers ) =
+    _group_means ~winners ~losers
+  in
+  let avg_size_dollar, avg_size_pct =
+    _trade_size_metrics ~all:trades ~initial_cash
+  in
+  let max_wins, max_losses = _consecutive_runs trades in
+  Metric_types.of_alist_exn
+    [
+      (NumTrades, Float.of_int n);
+      (LossRate, loss_rate_pct);
+      (AvgWinDollar, avg_win_dollar);
+      (AvgWinPct, avg_win_pct);
+      (AvgLossDollar, avg_loss_dollar);
+      (AvgLossPct, avg_loss_pct);
+      (LargestWinDollar, _largest_win_dollar winners);
+      (LargestLossDollar, _largest_loss_dollar losers);
+      (AvgTradeSizeDollar, avg_size_dollar);
+      (AvgTradeSizePct, avg_size_pct);
+      (AvgHoldingDaysWinners, avg_holding_winners);
+      (AvgHoldingDaysLosers, avg_holding_losers);
+      ( Expectancy,
+        _expectancy ~win_rate_pct ~avg_win:avg_win_dollar
+          ~avg_loss:avg_loss_dollar );
+      ( WinLossRatio,
+        _win_loss_ratio ~avg_win:avg_win_dollar ~avg_loss:avg_loss_dollar );
+      (MaxConsecutiveWins, Float.of_int max_wins);
+      (MaxConsecutiveLosses, Float.of_int max_losses);
+    ]
+
+let _finalize ~state ~config:_ =
+  let steps = List.rev state.steps in
+  let trades = Metrics.extract_round_trips steps in
+  match trades with
+  | [] -> _empty_metric_set ()
+  | _ -> _metrics_of_trades ~initial_cash:state.initial_cash trades
+
+let computer ?(initial_cash = 0.0) () : Simulator_types.any_metric_computer =
+  Simulator_types.wrap_computer
+    {
+      name = "trade_aggregates";
+      init = (fun ~config:_ -> { steps = []; initial_cash });
+      update = (fun ~state ~step -> { state with steps = step :: state.steps });
+      finalize = _finalize;
+    }

--- a/trading/trading/simulation/lib/trade_aggregates_computer.mli
+++ b/trading/trading/simulation/lib/trade_aggregates_computer.mli
@@ -1,0 +1,29 @@
+(** Trade-aggregate metric computer (M5.2b).
+
+    Produces per-trade derived metrics from the round-trips reconstructed from a
+    simulation's [step_result] list. Complements [Summary_computer], which emits
+    the basic count/PnL/win-rate group; this module covers the richer statistics
+    — average win/loss, expectancy, consecutive runs, etc.
+
+    Pure (in the same sense as the other computers): same step list → same
+    output. *)
+
+val computer :
+  ?initial_cash:float ->
+  unit ->
+  Trading_simulation_types.Simulator_types.any_metric_computer
+(** Build a metric computer that emits the trade-aggregate group:
+
+    - [NumTrades], [LossRate]
+    - [AvgWinDollar], [AvgWinPct], [AvgLossDollar], [AvgLossPct]
+    - [LargestWinDollar], [LargestLossDollar]
+    - [AvgTradeSizeDollar], [AvgTradeSizePct]
+    - [AvgHoldingDaysWinners], [AvgHoldingDaysLosers]
+    - [Expectancy], [WinLossRatio]
+    - [MaxConsecutiveWins], [MaxConsecutiveLosses]
+
+    @param initial_cash
+      Used as the denominator for [AvgTradeSizePct]. When omitted (default
+      [0.0]), [AvgTradeSizePct] is reported as [0.0] to avoid division by zero.
+      Callers wiring this computer into the default suite should pass the
+      simulator's configured [initial_cash] explicitly. *)

--- a/trading/trading/simulation/lib/types/metric_types.ml
+++ b/trading/trading/simulation/lib/types/metric_types.ml
@@ -21,6 +21,35 @@ module Metric_type = struct
       | OpenPositionsValue
       | UnrealizedPnl
       | TradeFrequency
+      | TotalReturnPct
+      | VolatilityPctAnnualized
+      | DownsideDeviationPctAnnualized
+      | BestDayPct
+      | WorstDayPct
+      | BestWeekPct
+      | WorstWeekPct
+      | BestMonthPct
+      | WorstMonthPct
+      | BestQuarterPct
+      | WorstQuarterPct
+      | BestYearPct
+      | WorstYearPct
+      | NumTrades
+      | LossRate
+      | AvgWinDollar
+      | AvgWinPct
+      | AvgLossDollar
+      | AvgLossPct
+      | LargestWinDollar
+      | LargestLossDollar
+      | AvgTradeSizeDollar
+      | AvgTradeSizePct
+      | AvgHoldingDaysWinners
+      | AvgHoldingDaysLosers
+      | Expectancy
+      | WinLossRatio
+      | MaxConsecutiveWins
+      | MaxConsecutiveLosses
     [@@deriving show, eq, compare, sexp]
   end
 
@@ -43,6 +72,35 @@ type metric_type = Metric_type.t =
   | OpenPositionsValue
   | UnrealizedPnl
   | TradeFrequency
+  | TotalReturnPct
+  | VolatilityPctAnnualized
+  | DownsideDeviationPctAnnualized
+  | BestDayPct
+  | WorstDayPct
+  | BestWeekPct
+  | WorstWeekPct
+  | BestMonthPct
+  | WorstMonthPct
+  | BestQuarterPct
+  | WorstQuarterPct
+  | BestYearPct
+  | WorstYearPct
+  | NumTrades
+  | LossRate
+  | AvgWinDollar
+  | AvgWinPct
+  | AvgLossDollar
+  | AvgLossPct
+  | LargestWinDollar
+  | LargestLossDollar
+  | AvgTradeSizeDollar
+  | AvgTradeSizePct
+  | AvgHoldingDaysWinners
+  | AvgHoldingDaysLosers
+  | Expectancy
+  | WinLossRatio
+  | MaxConsecutiveWins
+  | MaxConsecutiveLosses
 [@@deriving show, eq, compare, sexp]
 
 include (Metric_type : Comparator.S with type t := metric_type)
@@ -205,6 +263,192 @@ let get_metric_info = function
         display_name = "Trade Frequency";
         description = "Average number of trades per month";
         unit = Ratio;
+      }
+  | TotalReturnPct ->
+      {
+        display_name = "Total Return";
+        description =
+          "Total period return: (final - initial) / initial. Raw, not \
+           annualized — use CAGR for annualized.";
+        unit = Percent;
+      }
+  | VolatilityPctAnnualized ->
+      {
+        display_name = "Volatility (Annualized)";
+        description =
+          "Annualized standard deviation of step returns: per-step stdev × \
+           sqrt(252).";
+        unit = Percent;
+      }
+  | DownsideDeviationPctAnnualized ->
+      {
+        display_name = "Downside Deviation (Annualized)";
+        description =
+          "Annualized standard deviation of negative step returns only \
+           (positive returns clipped to zero, Sortino convention).";
+        unit = Percent;
+      }
+  | BestDayPct ->
+      {
+        display_name = "Best Day";
+        description = "Largest single-step return in the period.";
+        unit = Percent;
+      }
+  | WorstDayPct ->
+      {
+        display_name = "Worst Day";
+        description = "Smallest single-step return in the period.";
+        unit = Percent;
+      }
+  | BestWeekPct ->
+      {
+        display_name = "Best Week";
+        description = "Largest cumulative return over a calendar week.";
+        unit = Percent;
+      }
+  | WorstWeekPct ->
+      {
+        display_name = "Worst Week";
+        description = "Smallest cumulative return over a calendar week.";
+        unit = Percent;
+      }
+  | BestMonthPct ->
+      {
+        display_name = "Best Month";
+        description = "Largest cumulative return over a calendar month.";
+        unit = Percent;
+      }
+  | WorstMonthPct ->
+      {
+        display_name = "Worst Month";
+        description = "Smallest cumulative return over a calendar month.";
+        unit = Percent;
+      }
+  | BestQuarterPct ->
+      {
+        display_name = "Best Quarter";
+        description = "Largest cumulative return over a calendar quarter.";
+        unit = Percent;
+      }
+  | WorstQuarterPct ->
+      {
+        display_name = "Worst Quarter";
+        description = "Smallest cumulative return over a calendar quarter.";
+        unit = Percent;
+      }
+  | BestYearPct ->
+      {
+        display_name = "Best Year";
+        description = "Largest cumulative return over a calendar year.";
+        unit = Percent;
+      }
+  | WorstYearPct ->
+      {
+        display_name = "Worst Year";
+        description = "Smallest cumulative return over a calendar year.";
+        unit = Percent;
+      }
+  | NumTrades ->
+      {
+        display_name = "Number of Trades";
+        description = "Total round-trip count (= win + loss).";
+        unit = Count;
+      }
+  | LossRate ->
+      {
+        display_name = "Loss Rate";
+        description = "Loss percentage; equals 100 - WinRate.";
+        unit = Percent;
+      }
+  | AvgWinDollar ->
+      {
+        display_name = "Average Win";
+        description = "Mean P&L of winning round-trips.";
+        unit = Dollars;
+      }
+  | AvgWinPct ->
+      {
+        display_name = "Average Win %";
+        description =
+          "Mean per-trade percent return of winning round-trips, relative to \
+           entry price.";
+        unit = Percent;
+      }
+  | AvgLossDollar ->
+      {
+        display_name = "Average Loss";
+        description = "Mean P&L of losing round-trips (negative).";
+        unit = Dollars;
+      }
+  | AvgLossPct ->
+      {
+        display_name = "Average Loss %";
+        description =
+          "Mean per-trade percent return of losing round-trips (negative).";
+        unit = Percent;
+      }
+  | LargestWinDollar ->
+      {
+        display_name = "Largest Win";
+        description = "Single largest winning round-trip in dollars.";
+        unit = Dollars;
+      }
+  | LargestLossDollar ->
+      {
+        display_name = "Largest Loss";
+        description = "Single largest losing round-trip in dollars.";
+        unit = Dollars;
+      }
+  | AvgTradeSizeDollar ->
+      {
+        display_name = "Average Trade Size";
+        description = "Mean entry notional (entry_price × quantity) per trade.";
+        unit = Dollars;
+      }
+  | AvgTradeSizePct ->
+      {
+        display_name = "Average Trade Size %";
+        description = "Mean entry notional as a percent of initial cash.";
+        unit = Percent;
+      }
+  | AvgHoldingDaysWinners ->
+      {
+        display_name = "Avg Holding Days (Winners)";
+        description = "Mean days_held across winning round-trips only.";
+        unit = Days;
+      }
+  | AvgHoldingDaysLosers ->
+      {
+        display_name = "Avg Holding Days (Losers)";
+        description = "Mean days_held across losing round-trips only.";
+        unit = Days;
+      }
+  | Expectancy ->
+      {
+        display_name = "Expectancy";
+        description =
+          "Per-trade expected dollars: win_rate × avg_win - loss_rate × \
+           |avg_loss|.";
+        unit = Dollars;
+      }
+  | WinLossRatio ->
+      {
+        display_name = "Win/Loss Ratio";
+        description = "avg_win_dollar / |avg_loss_dollar|.";
+        unit = Ratio;
+      }
+  | MaxConsecutiveWins ->
+      {
+        display_name = "Max Consecutive Wins";
+        description =
+          "Longest run of consecutive winning round-trips (chronological).";
+        unit = Count;
+      }
+  | MaxConsecutiveLosses ->
+      {
+        display_name = "Max Consecutive Losses";
+        description = "Longest run of consecutive losing round-trips.";
+        unit = Count;
       }
 
 (** {1 Formatting} *)

--- a/trading/trading/simulation/lib/types/metric_types.mli
+++ b/trading/trading/simulation/lib/types/metric_types.mli
@@ -37,6 +37,68 @@ module Metric_type : sig
             (longs and shorts both fold in via signed quantity). Positive means
             paper gains on the open book; negative means paper losses. *)
     | TradeFrequency  (** Trades per month *)
+    (* ---- M5.2b returns block ---- *)
+    | TotalReturnPct
+        (** Total period return as a percent:
+            [(final - initial) / initial * 100]. Raw, not annualized — see
+            [CAGR] for the annualized counterpart. *)
+    | VolatilityPctAnnualized
+        (** Annualized standard deviation of step-over-step portfolio returns,
+            in percent. Multiplies the per-step stdev by [sqrt(252)] (assumes
+            daily steps). *)
+    | DownsideDeviationPctAnnualized
+        (** Annualized standard deviation of {b negative} step returns only
+            (returns above zero are treated as zero, in line with Sortino's
+            convention). Reported in percent. *)
+    | BestDayPct
+        (** Largest single-step (one trading day) return, in percent. *)
+    | WorstDayPct
+        (** Smallest single-step (one trading day) return, in percent. *)
+    | BestWeekPct
+        (** Largest cumulative return over a calendar week, in percent. *)
+    | WorstWeekPct
+        (** Smallest cumulative return over a calendar week, in percent. *)
+    | BestMonthPct  (** Largest cumulative return over a calendar month. *)
+    | WorstMonthPct  (** Smallest cumulative return over a calendar month. *)
+    | BestQuarterPct  (** Largest cumulative return over a calendar quarter. *)
+    | WorstQuarterPct
+        (** Smallest cumulative return over a calendar quarter. *)
+    | BestYearPct  (** Largest cumulative return over a calendar year. *)
+    | WorstYearPct  (** Smallest cumulative return over a calendar year. *)
+    (* ---- M5.2b trade aggregates ---- *)
+    | NumTrades  (** Total number of round-trip trades (= win + loss). *)
+    | LossRate  (** Loss percentage (0–100); equals [100 - WinRate]. *)
+    | AvgWinDollar  (** Mean P&L of winning round-trips, in dollars. *)
+    | AvgWinPct
+        (** Mean per-trade percent return of winning round-trips
+            (entry-price-relative), in percent. *)
+    | AvgLossDollar
+        (** Mean P&L of losing round-trips, in dollars (negative). *)
+    | AvgLossPct
+        (** Mean per-trade percent return of losing round-trips, in percent
+            (negative). *)
+    | LargestWinDollar  (** Single largest winning round-trip, in dollars. *)
+    | LargestLossDollar
+        (** Single largest losing round-trip, in dollars (most negative). *)
+    | AvgTradeSizeDollar
+        (** Mean entry notional ([entry_price × quantity]) across all
+            round-trips. *)
+    | AvgTradeSizePct  (** Mean entry notional as a percent of initial cash. *)
+    | AvgHoldingDaysWinners
+        (** Mean [days_held] across winning round-trips only. *)
+    | AvgHoldingDaysLosers
+        (** Mean [days_held] across losing round-trips only. *)
+    | Expectancy
+        (** Per-trade expected dollars:
+            [(win_rate × avg_win_dollar) - (loss_rate × |avg_loss_dollar|)]. *)
+    | WinLossRatio
+        (** [avg_win_dollar / |avg_loss_dollar|]; [Float.infinity] when there
+            are wins but no losses. *)
+    | MaxConsecutiveWins
+        (** Longest run of consecutive winning round-trips (chronologically by
+            entry date). *)
+    | MaxConsecutiveLosses
+        (** Longest run of consecutive losing round-trips. *)
   [@@deriving show, eq, compare, sexp]
 
   include Comparator.S with type t := t
@@ -58,6 +120,35 @@ type metric_type = Metric_type.t =
   | OpenPositionsValue
   | UnrealizedPnl
   | TradeFrequency
+  | TotalReturnPct
+  | VolatilityPctAnnualized
+  | DownsideDeviationPctAnnualized
+  | BestDayPct
+  | WorstDayPct
+  | BestWeekPct
+  | WorstWeekPct
+  | BestMonthPct
+  | WorstMonthPct
+  | BestQuarterPct
+  | WorstQuarterPct
+  | BestYearPct
+  | WorstYearPct
+  | NumTrades
+  | LossRate
+  | AvgWinDollar
+  | AvgWinPct
+  | AvgLossDollar
+  | AvgLossPct
+  | LargestWinDollar
+  | LargestLossDollar
+  | AvgTradeSizeDollar
+  | AvgTradeSizePct
+  | AvgHoldingDaysWinners
+  | AvgHoldingDaysLosers
+  | Expectancy
+  | WinLossRatio
+  | MaxConsecutiveWins
+  | MaxConsecutiveLosses
 [@@deriving show, eq, compare, sexp]
 
 (** {1 Metric Set} *)

--- a/trading/trading/simulation/test/dune
+++ b/trading/trading/simulation/test/dune
@@ -194,3 +194,32 @@
   types
   matchers
   simulation_test_helpers))
+
+(test
+ (name test_trade_aggregates_computer)
+ (modules test_trade_aggregates_computer)
+ (libraries
+  ounit2
+  core
+  core_unix.time_ns_unix
+  trading.simulation
+  trading.simulation.types
+  trading.base
+  trading.engine
+  trading.portfolio
+  types
+  matchers))
+
+(test
+ (name test_return_basics_computer)
+ (modules test_return_basics_computer)
+ (libraries
+  ounit2
+  core
+  trading.simulation
+  trading.simulation.types
+  trading.base
+  trading.engine
+  trading.portfolio
+  types
+  matchers))

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -581,8 +581,9 @@ let test_run_computers_combines_results _ =
 
 let test_default_computers _ =
   let computers = default_computers () in
-  (* Default set: summary, sharpe, max_drawdown, cagr, portfolio_state *)
-  assert_that computers (size_is 5)
+  (* Default set: summary, sharpe, max_drawdown, cagr, portfolio_state,
+     trade_aggregates (M5.2b), return_basics (M5.2b). *)
+  assert_that computers (size_is 7)
 
 (* ==================== Factory Tests ==================== *)
 

--- a/trading/trading/simulation/test/test_return_basics_computer.ml
+++ b/trading/trading/simulation/test/test_return_basics_computer.ml
@@ -181,6 +181,47 @@ let test_best_worst_year_and_quarter _ =
          (WorstQuarterPct, float_equal ~epsilon:1e-6 0.0);
        ])
 
+(* ----- Week bucketing across an ISO year boundary ----- *)
+
+(** ISO 8601 week-numbering pins (verified against the calendar):
+    - 2024-12-30 (Mon), 2024-12-31 (Tue), 2025-01-01 (Wed), 2025-01-02 (Thu) all
+      belong to ISO week 2025-W01.
+    - 2025-01-06 (Mon) starts ISO week 2025-W02.
+    - 2024-12-23 (Mon) is in ISO week 2024-W52.
+
+    Steps:
+    - 2024-12-23 → 10000 (week 2024-W52)
+    - 2024-12-30 → 11000 (start of week 2025-W01)
+    - 2025-01-02 → 9900 (still in week 2025-W01; bucket end-value)
+    - 2025-01-06 → 10395 (week 2025-W02)
+
+    With ISO bucketing, three week buckets emit:
+    - 2024-W52 last value 10000 → return vs initial 10000 = 0.0%
+    - 2025-W01 last value 9900 → return vs 10000 = -1.0%
+    - 2025-W02 last value 10395 → return vs 9900 = +5.0% Best week = +5.0, worst
+      week = -1.0.
+
+    The naive (year, day_of_year / 7) approximation would put 2024-12-30/31 in a
+    different bucket from 2025-01-01/02, splitting the W01 cluster and producing
+    a different best/worst pair. Asserting +5.0 / -1.0 here pins the ISO
+    behaviour. *)
+let test_week_bucket_year_boundary _ =
+  let steps =
+    [
+      _make_step ~date:(_date "2024-12-23") ~portfolio_value:10_000.0;
+      _make_step ~date:(_date "2024-12-30") ~portfolio_value:11_000.0;
+      _make_step ~date:(_date "2025-01-02") ~portfolio_value:9_900.0;
+      _make_step ~date:(_date "2025-01-06") ~portfolio_value:10_395.0;
+    ]
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (BestWeekPct, float_equal ~epsilon:1e-6 5.0);
+         (WorstWeekPct, float_equal ~epsilon:1e-6 (-1.0));
+       ])
+
 let suite =
   "Return_basics_computer"
   >::: [
@@ -192,6 +233,8 @@ let suite =
          >:: test_volatility_and_downside;
          "best/worst month" >:: test_best_worst_month;
          "best/worst year + best quarter" >:: test_best_worst_year_and_quarter;
+         "week bucket across ISO year boundary"
+         >:: test_week_bucket_year_boundary;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/simulation/test/test_return_basics_computer.ml
+++ b/trading/trading/simulation/test/test_return_basics_computer.ml
@@ -1,0 +1,197 @@
+(** Pinned tests for {!Return_basics_computer} (M5.2b).
+
+    Each test pins the entire metric set against a hand-computed value. *)
+
+open OUnit2
+open Core
+open Trading_simulation_types.Metric_types
+open Matchers
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+let _date s = Date.of_string s
+
+let _make_step ~date ~portfolio_value : Simulator_types.step_result =
+  let portfolio =
+    Trading_portfolio.Portfolio.create ~initial_cash:10_000.0 ()
+  in
+  {
+    date;
+    portfolio;
+    portfolio_value;
+    trades = [];
+    orders_submitted = [];
+    splits_applied = [];
+  }
+
+let _config =
+  {
+    Simulator_types.start_date = _date "2024-01-01";
+    end_date = _date "2024-12-31";
+    initial_cash = 10_000.0;
+    commission = { Trading_engine.Types.per_share = 0.0; minimum = 0.0 };
+    strategy_cadence = Types.Cadence.Daily;
+  }
+
+let _run steps =
+  let computer = Trading_simulation.Return_basics_computer.computer () in
+  computer.run ~config:_config ~steps
+
+(* ----- Empty input ----- *)
+
+let test_empty_steps_yields_zero_metrics _ =
+  let metrics = _run [] in
+  assert_that metrics
+    (map_includes
+       [
+         (TotalReturnPct, float_equal 0.0);
+         (VolatilityPctAnnualized, float_equal 0.0);
+         (DownsideDeviationPctAnnualized, float_equal 0.0);
+         (BestDayPct, float_equal 0.0);
+         (WorstDayPct, float_equal 0.0);
+         (BestWeekPct, float_equal 0.0);
+         (WorstWeekPct, float_equal 0.0);
+       ])
+
+(* ----- Total return ----- *)
+
+(** Three steps, portfolio walks 10000 → 11000 → 12000. Total return = (12000 -
+    10000) / 10000 × 100 = 20%. *)
+let test_total_return_pct _ =
+  let steps =
+    [
+      _make_step ~date:(_date "2024-01-02") ~portfolio_value:10_000.0;
+      _make_step ~date:(_date "2024-01-03") ~portfolio_value:11_000.0;
+      _make_step ~date:(_date "2024-01-04") ~portfolio_value:12_000.0;
+    ]
+  in
+  let metrics = _run steps in
+  assert_that (Map.find metrics TotalReturnPct) (is_some_and (float_equal 20.0))
+
+(* ----- Best/worst day ----- *)
+
+(** Day-over-day returns:
+    - 10000 → 10500 = +5.0%
+    - 10500 → 9975 = -5.0% (= -525 / 10500)
+    - 9975 → 11_172.0 = +12.0% (= +1197 / 9975)
+
+    Best day = +12, worst day = -5. *)
+let test_best_worst_day _ =
+  let steps =
+    [
+      _make_step ~date:(_date "2024-01-02") ~portfolio_value:10_000.0;
+      _make_step ~date:(_date "2024-01-03") ~portfolio_value:10_500.0;
+      _make_step ~date:(_date "2024-01-04") ~portfolio_value:9_975.0;
+      _make_step ~date:(_date "2024-01-05") ~portfolio_value:11_172.0;
+    ]
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (BestDayPct, float_equal ~epsilon:1e-6 12.0);
+         (WorstDayPct, float_equal ~epsilon:1e-6 (-5.0));
+       ])
+
+(* ----- Volatility ----- *)
+
+(** Two steps with returns [+5%, -5%]. mean = 0, stdev (popn) = sqrt((25 + 25) /
+    2) = 5. Annualized = 5 × sqrt(252) ≈ 79.3725%. Downside dev: only negative
+    returns count (positive clipped to 0): values [0, -5], mean = -2.5,
+    popn-stdev = sqrt((6.25 + 6.25) / 2) = 2.5; annualized = 2.5 × sqrt(252) ≈
+    39.6863%. *)
+let test_volatility_and_downside _ =
+  let steps =
+    [
+      _make_step ~date:(_date "2024-01-02") ~portfolio_value:10_000.0;
+      _make_step ~date:(_date "2024-01-03") ~portfolio_value:10_500.0;
+      _make_step ~date:(_date "2024-01-04") ~portfolio_value:9_975.0;
+    ]
+  in
+  let metrics = _run steps in
+  let sqrt_252 = Float.sqrt 252.0 in
+  let expected_vol = 5.0 *. sqrt_252 in
+  let expected_dd = 2.5 *. sqrt_252 in
+  assert_that metrics
+    (map_includes
+       [
+         (VolatilityPctAnnualized, float_equal ~epsilon:1e-6 expected_vol);
+         (DownsideDeviationPctAnnualized, float_equal ~epsilon:1e-6 expected_dd);
+       ])
+
+(* ----- Calendar bucket extremes ----- *)
+
+(** Two months: Jan ends at 11000 (+10% from 10000), Feb ends at 9900 (-10% from
+    11000). Best month = +10, worst month = -10. *)
+let test_best_worst_month _ =
+  let steps =
+    [
+      _make_step ~date:(_date "2024-01-02") ~portfolio_value:10_000.0;
+      _make_step ~date:(_date "2024-01-15") ~portfolio_value:10_500.0;
+      _make_step ~date:(_date "2024-01-31") ~portfolio_value:11_000.0;
+      _make_step ~date:(_date "2024-02-15") ~portfolio_value:10_400.0;
+      _make_step ~date:(_date "2024-02-29") ~portfolio_value:9_900.0;
+    ]
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (BestMonthPct, float_equal ~epsilon:1e-6 10.0);
+         (WorstMonthPct, float_equal ~epsilon:1e-6 (-10.0));
+       ])
+
+(** Two years to validate quarter + year bucketing.
+
+    Bucket end-values (last sample within each bucket, chronological):
+    - 2024 Q1: 11000 (2024-03-30)
+    - 2024 Q4: 11000 (2024-12-31)
+    - 2025 Q1: 12000 (2025-03-30)
+    - 2025 Q4: 12000 (2025-12-31)
+    - Year 2024: 11000 (last 2024 sample)
+    - Year 2025: 12000
+
+    The first bucket compounds against [initial_value] (= 10000, the first
+    sample). Subsequent buckets compound against the previous bucket's last
+    value.
+
+    Year returns: 2024 = (11000-10000)/10000 = +10%; 2025 = (12000-11000)/11000
+    ≈ +9.0909%. Best year = 10, worst year = 9.0909.
+
+    Quarter returns: 2024-Q1 = +10% (vs 10000), 2024-Q4 = 0% (11000→11000),
+    2025-Q1 ≈ +9.0909% (11000→12000), 2025-Q4 = 0% (12000→12000). Best quarter =
+    +10, worst quarter = 0. *)
+let test_best_worst_year_and_quarter _ =
+  let steps =
+    [
+      _make_step ~date:(_date "2024-01-02") ~portfolio_value:10_000.0;
+      _make_step ~date:(_date "2024-03-30") ~portfolio_value:11_000.0;
+      _make_step ~date:(_date "2024-12-31") ~portfolio_value:11_000.0;
+      _make_step ~date:(_date "2025-03-30") ~portfolio_value:12_000.0;
+      _make_step ~date:(_date "2025-12-31") ~portfolio_value:12_000.0;
+    ]
+  in
+  let metrics = _run steps in
+  let year_2025_return = (12_000.0 -. 11_000.0) /. 11_000.0 *. 100.0 in
+  assert_that metrics
+    (map_includes
+       [
+         (BestYearPct, float_equal ~epsilon:1e-6 10.0);
+         (WorstYearPct, float_equal ~epsilon:1e-6 year_2025_return);
+         (BestQuarterPct, float_equal ~epsilon:1e-6 10.0);
+         (WorstQuarterPct, float_equal ~epsilon:1e-6 0.0);
+       ])
+
+let suite =
+  "Return_basics_computer"
+  >::: [
+         "empty steps yields zero metrics"
+         >:: test_empty_steps_yields_zero_metrics;
+         "total_return_pct" >:: test_total_return_pct;
+         "best/worst day" >:: test_best_worst_day;
+         "volatility + downside dev (annualized)"
+         >:: test_volatility_and_downside;
+         "best/worst month" >:: test_best_worst_month;
+         "best/worst year + best quarter" >:: test_best_worst_year_and_quarter;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/simulation/test/test_trade_aggregates_computer.ml
+++ b/trading/trading/simulation/test/test_trade_aggregates_computer.ml
@@ -247,6 +247,40 @@ let test_consecutive_runs _ =
          (* L1 + L2 *)
        ])
 
+(* ----- AvgTradeSizePct zero-initial-cash guard ----- *)
+
+(** Exercises the documented [?initial_cash] default-0.0 guard in the .mli. Same
+    single-trade fixture, but the computer is built without [~initial_cash] so
+    the default of [0.0] applies. The guard must short- circuit the division and
+    emit [AvgTradeSizePct = 0.0] (not NaN, not +inf). [AvgTradeSizeDollar] is
+    unaffected by the guard and still equals the entry notional. *)
+let test_avg_trade_size_pct_zero_initial_cash _ =
+  let steps =
+    [
+      _step_with_trades ~date:(_date "2024-06-01")
+        ~trades:
+          [
+            _make_trade ~id:"x-b" ~symbol:"XYZ" ~side:Buy ~quantity:10.0
+              ~price:100.0;
+          ];
+      _step_with_trades ~date:(_date "2024-06-08")
+        ~trades:
+          [
+            _make_trade ~id:"x-s" ~symbol:"XYZ" ~side:Sell ~quantity:10.0
+              ~price:110.0;
+          ];
+    ]
+  in
+  let computer = Trading_simulation.Trade_aggregates_computer.computer () in
+  let metrics = computer.run ~config:_config ~steps in
+  assert_that metrics
+    (map_includes
+       [
+         (NumTrades, float_equal 1.0);
+         (AvgTradeSizeDollar, float_equal 1000.0);
+         (AvgTradeSizePct, float_equal 0.0);
+       ])
+
 let suite =
   "Trade_aggregates_computer"
   >::: [
@@ -256,6 +290,8 @@ let suite =
          "all wins → win/loss ratio = infinity"
          >:: test_all_wins_sets_win_loss_ratio_to_infinity;
          "consecutive runs over [W L L W W]" >:: test_consecutive_runs;
+         "AvgTradeSizePct = 0 when initial_cash defaults to 0"
+         >:: test_avg_trade_size_pct_zero_initial_cash;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/simulation/test/test_trade_aggregates_computer.ml
+++ b/trading/trading/simulation/test/test_trade_aggregates_computer.ml
@@ -1,0 +1,261 @@
+(** Pinned tests for {!Trade_aggregates_computer} (M5.2b).
+
+    Each test builds a small, hand-pinned fixture of round-trip trades, runs the
+    computer, and asserts every metric against a value computed by hand. *)
+
+open OUnit2
+open Core
+open Trading_simulation_types.Metric_types
+open Matchers
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+let _date s = Date.of_string s
+
+let _make_trade ~id ~symbol ~side ~quantity ~price =
+  {
+    Trading_base.Types.id;
+    order_id = id ^ "-order";
+    symbol;
+    side;
+    quantity;
+    price;
+    commission = 0.0;
+    timestamp = Time_ns_unix.now ();
+  }
+
+let _step_with_trades ~date ~trades : Simulator_types.step_result =
+  let portfolio =
+    Trading_portfolio.Portfolio.create ~initial_cash:10_000.0 ()
+  in
+  {
+    date;
+    portfolio;
+    portfolio_value = 10_000.0;
+    trades;
+    orders_submitted = [];
+    splits_applied = [];
+  }
+
+let _config =
+  {
+    Simulator_types.start_date = _date "2024-01-01";
+    end_date = _date "2024-12-31";
+    initial_cash = 10_000.0;
+    commission = { Trading_engine.Types.per_share = 0.0; minimum = 0.0 };
+    strategy_cadence = Types.Cadence.Daily;
+  }
+
+let _run ?(initial_cash = 10_000.0) steps =
+  let computer =
+    Trading_simulation.Trade_aggregates_computer.computer ~initial_cash ()
+  in
+  computer.run ~config:_config ~steps
+
+(* ----- Empty input ----- *)
+
+let test_empty_steps_yields_zero_metrics _ =
+  let metrics = _run [] in
+  assert_that metrics
+    (map_includes
+       [
+         (NumTrades, float_equal 0.0);
+         (LossRate, float_equal 0.0);
+         (AvgWinDollar, float_equal 0.0);
+         (LargestWinDollar, float_equal 0.0);
+         (LargestLossDollar, float_equal 0.0);
+         (Expectancy, float_equal 0.0);
+         (WinLossRatio, float_equal 0.0);
+         (MaxConsecutiveWins, float_equal 0.0);
+         (MaxConsecutiveLosses, float_equal 0.0);
+       ])
+
+(* ----- Mixed wins / losses ----- *)
+
+(** Three round-trips, hand-pinned numbers:
+
+    Trip 1: AAPL Buy@100 q=10 → Sell@120 q=10. PnL = +200, pct = +20%. Notional
+    = 1000. Days held = 5. Trip 2: MSFT Buy@50 q=20 → Sell@40 q=20. PnL = -200,
+    pct = -20%. Notional = 1000. Days held = 10. Trip 3: GOOG Buy@200 q=5 →
+    Sell@260 q=5. PnL = +300, pct = +30%. Notional = 1000. Days held = 7.
+
+    Wins = 2 (trips 1 + 3), losses = 1 (trip 2). win_rate = 2/3 × 100 = 66.6...
+    loss_rate = 1/3 × 100 = 33.3... avg_win_dollar = (200 + 300) / 2 = 250
+    avg_win_pct = (20 + 30) / 2 = 25 avg_loss_dollar = -200, avg_loss_pct = -20
+    largest_win = 300, largest_loss = -200 avg_size_dollar = (1000 + 1000 +
+    1000) / 3 = 1000 avg_size_pct = 1000 / 10000 × 100 = 10 avg_holding_winners
+    = (5 + 7) / 2 = 6 avg_holding_losers = 10 expectancy = 0.6667 × 250 - 0.3333
+    × 200 = 166.667 - 66.667 = 100 win_loss_ratio = 250 / 200 = 1.25
+    consecutive: ordered by entry date — assume distinct dates, so the sequence
+    is [trip1=W, trip2=L, trip3=W]. max wins = 1, max losses = 1. *)
+let test_mixed_three_trips _ =
+  let steps =
+    [
+      _step_with_trades ~date:(_date "2024-02-01")
+        ~trades:
+          [
+            _make_trade ~id:"a-b" ~symbol:"AAPL" ~side:Buy ~quantity:10.0
+              ~price:100.0;
+          ];
+      _step_with_trades ~date:(_date "2024-02-06")
+        ~trades:
+          [
+            _make_trade ~id:"a-s" ~symbol:"AAPL" ~side:Sell ~quantity:10.0
+              ~price:120.0;
+          ];
+      _step_with_trades ~date:(_date "2024-02-10")
+        ~trades:
+          [
+            _make_trade ~id:"m-b" ~symbol:"MSFT" ~side:Buy ~quantity:20.0
+              ~price:50.0;
+          ];
+      _step_with_trades ~date:(_date "2024-02-20")
+        ~trades:
+          [
+            _make_trade ~id:"m-s" ~symbol:"MSFT" ~side:Sell ~quantity:20.0
+              ~price:40.0;
+          ];
+      _step_with_trades ~date:(_date "2024-03-01")
+        ~trades:
+          [
+            _make_trade ~id:"g-b" ~symbol:"GOOG" ~side:Buy ~quantity:5.0
+              ~price:200.0;
+          ];
+      _step_with_trades ~date:(_date "2024-03-08")
+        ~trades:
+          [
+            _make_trade ~id:"g-s" ~symbol:"GOOG" ~side:Sell ~quantity:5.0
+              ~price:260.0;
+          ];
+    ]
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (NumTrades, float_equal 3.0);
+         (LossRate, float_equal ~epsilon:1e-6 (1.0 /. 3.0 *. 100.0));
+         (AvgWinDollar, float_equal 250.0);
+         (AvgWinPct, float_equal 25.0);
+         (AvgLossDollar, float_equal (-200.0));
+         (AvgLossPct, float_equal (-20.0));
+         (LargestWinDollar, float_equal 300.0);
+         (LargestLossDollar, float_equal (-200.0));
+         (AvgTradeSizeDollar, float_equal 1000.0);
+         (AvgTradeSizePct, float_equal 10.0);
+         (AvgHoldingDaysWinners, float_equal 6.0);
+         (AvgHoldingDaysLosers, float_equal 10.0);
+         (* expectancy = 2/3 × 250 − 1/3 × 200 = (500 − 200)/3 = 100. *)
+         (Expectancy, float_equal ~epsilon:1e-6 100.0);
+         (WinLossRatio, float_equal 1.25);
+         (MaxConsecutiveWins, float_equal 1.0);
+         (MaxConsecutiveLosses, float_equal 1.0);
+       ])
+
+(* ----- All wins (no losses) ----- *)
+
+(** Two winning round-trips. avg_loss_dollar = 0 → win_loss_ratio = +∞. *)
+let test_all_wins_sets_win_loss_ratio_to_infinity _ =
+  let steps =
+    [
+      _step_with_trades ~date:(_date "2024-04-01")
+        ~trades:
+          [
+            _make_trade ~id:"a-b" ~symbol:"AAA" ~side:Buy ~quantity:10.0
+              ~price:100.0;
+          ];
+      _step_with_trades ~date:(_date "2024-04-08")
+        ~trades:
+          [
+            _make_trade ~id:"a-s" ~symbol:"AAA" ~side:Sell ~quantity:10.0
+              ~price:110.0;
+          ];
+      _step_with_trades ~date:(_date "2024-04-09")
+        ~trades:
+          [
+            _make_trade ~id:"b-b" ~symbol:"BBB" ~side:Buy ~quantity:5.0
+              ~price:200.0;
+          ];
+      _step_with_trades ~date:(_date "2024-04-16")
+        ~trades:
+          [
+            _make_trade ~id:"b-s" ~symbol:"BBB" ~side:Sell ~quantity:5.0
+              ~price:230.0;
+          ];
+    ]
+  in
+  let metrics = _run steps in
+  let win_loss = Map.find_exn metrics WinLossRatio in
+  assert_that win_loss (equal_to Float.infinity);
+  assert_that metrics
+    (map_includes
+       [
+         (NumTrades, float_equal 2.0);
+         (LossRate, float_equal 0.0);
+         (MaxConsecutiveWins, float_equal 2.0);
+         (MaxConsecutiveLosses, float_equal 0.0);
+       ])
+
+(* ----- Consecutive run accounting ----- *)
+
+(** Five round-trips in a [W L L W W] order — pin both consecutive runs. The PnL
+    signs encode the pattern; pinned values are picked for clarity. *)
+let test_consecutive_runs _ =
+  let make_round_trip ~entry_date ~exit_date ~symbol ~entry_price ~exit_price =
+    [
+      _step_with_trades ~date:entry_date
+        ~trades:
+          [
+            _make_trade ~id:(symbol ^ "-b") ~symbol ~side:Buy ~quantity:10.0
+              ~price:entry_price;
+          ];
+      _step_with_trades ~date:exit_date
+        ~trades:
+          [
+            _make_trade ~id:(symbol ^ "-s") ~symbol ~side:Sell ~quantity:10.0
+              ~price:exit_price;
+          ];
+    ]
+  in
+  let steps =
+    List.concat
+      [
+        make_round_trip ~entry_date:(_date "2024-05-01")
+          ~exit_date:(_date "2024-05-05") ~symbol:"W1" ~entry_price:100.0
+          ~exit_price:110.0 (* W *);
+        make_round_trip ~entry_date:(_date "2024-05-06")
+          ~exit_date:(_date "2024-05-10") ~symbol:"L1" ~entry_price:100.0
+          ~exit_price:90.0 (* L *);
+        make_round_trip ~entry_date:(_date "2024-05-11")
+          ~exit_date:(_date "2024-05-15") ~symbol:"L2" ~entry_price:100.0
+          ~exit_price:95.0 (* L *);
+        make_round_trip ~entry_date:(_date "2024-05-16")
+          ~exit_date:(_date "2024-05-20") ~symbol:"W2" ~entry_price:100.0
+          ~exit_price:105.0 (* W *);
+        make_round_trip ~entry_date:(_date "2024-05-21")
+          ~exit_date:(_date "2024-05-25") ~symbol:"W3" ~entry_price:100.0
+          ~exit_price:120.0 (* W *);
+      ]
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (NumTrades, float_equal 5.0);
+         (MaxConsecutiveWins, float_equal 2.0);
+         (* W3 + W2 trailing run length 2 *)
+         (MaxConsecutiveLosses, float_equal 2.0);
+         (* L1 + L2 *)
+       ])
+
+let suite =
+  "Trade_aggregates_computer"
+  >::: [
+         "empty steps yields zero metrics"
+         >:: test_empty_steps_yields_zero_metrics;
+         "mixed three round-trips, all values pinned" >:: test_mixed_three_trips;
+         "all wins → win/loss ratio = infinity"
+         >:: test_all_wins_sets_win_loss_ratio_to_infinity;
+         "consecutive runs over [W L L W W]" >:: test_consecutive_runs;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Implements **M5.2b** per `dev/plans/m5-experiments-roadmap-2026-05-02.md`: extends the metrics catalog with 29 new metric variants for trade aggregates and return basics. Wired into `default_metric_suite`, so values flow through M5.2a's `Comparison.compute` + `comparison.{sexp,md}` without further changes.

**Two new computers:**

- `Trade_aggregates_computer` (`trading/trading/simulation/lib/`) — emits NumTrades, LossRate, AvgWin/Loss (dollars + percent), Largest Win/Loss, AvgTradeSize, Avg holding days (winners/losers), Expectancy, WinLossRatio, Max consecutive wins/losses. Built on top of the existing round-trip extraction from `Metrics.extract_round_trips`.

- `Return_basics_computer` (`trading/trading/simulation/lib/`) — emits TotalReturnPct, annualized volatility, annualized downside deviation, and best/worst cumulative returns over day / week / month / quarter / year calendar buckets.

**Touched files:**
- New: `simulation/lib/{trade_aggregates,return_basics}_computer.{ml,mli}` + dune
- New: `simulation/test/test_{trade_aggregates,return_basics}_computer.ml` + dune
- Extended: `simulation/lib/types/metric_types.{ml,mli}` (29 new variants + display info)
- Extended: `simulation/lib/metric_computers.{ml,mli}` (factory + default suite)
- Extended: `backtest/lib/comparison.ml` (label table + variant list)
- Extended: `backtest/lib/panel_runner.ml` (passes `~initial_cash` to `default_metric_suite`)

## Acceptance (per plan §M5.2b)

- ✅ Every metric computable from existing `step_result` + `trade_metrics`
- ✅ Test fixture with hand-pinned values per metric (`float_equal`)
- ✅ All new metrics flow through M5.2a `Comparison.compute` automatically
- ✅ `dune build && dune runtest` exits 0

## Test plan

- [x] `dune build && dune runtest backtest simulation` passes (verified locally in docker)
- [x] `dune build @fmt` clean for files in this PR (pre-existing test_round_trip.ml stylistic issue is out of scope)
- [x] New computer outputs flow through `Backtest.Comparison` end-to-end (existing test_comparison.ml continues to pass — asymmetric metric presence already handled)
- [ ] Reviewer: verify the rendering of comparison.md for a real backtest run includes all 29 new metrics (not blocking — `Comparison` is generic over the metric set)

## Follow-ups (out of scope)

- M5.2c — risk-adjusted + drawdown analytics (Sharpe, Sortino, Calmar, MAR, Omega, max_DD duration / time_in_DD / ulcer_index)
- M5.2d — distributional + antifragility (skew, kurtosis, concavity coefficient γ, CVaR_95/99, tail_ratio, gain_to_pain)