### PR TITLE
chore(fmt): promote ocamlformat 0.29 drift in snapshot test + lib

### DIFF
--- a/trading/trading/weinstein/snapshot/lib/forward_trace.ml
+++ b/trading/trading/weinstein/snapshot/lib/forward_trace.ml
@@ -149,12 +149,8 @@ let _unfilled_outcome ~(c : Weekly_snapshot.candidate) ~(pick_date : Date.t) :
 let _filled_outcome ~(c : Weekly_snapshot.candidate) ~(pick_date : Date.t)
     ~(entry_bar : adj_bar) ~(entry_fill : float) ~(post : adj_bar list)
     ~(tracking : tracking) : per_pick_outcome =
-  let final_bar =
-    match List.last post with Some b -> b | None -> entry_bar
-  in
-  let pct_return_horizon =
-    (final_bar.adj_close -. entry_fill) /. entry_fill
-  in
+  let final_bar = match List.last post with Some b -> b | None -> entry_bar in
+  let pct_return_horizon = (final_bar.adj_close -. entry_fill) /. entry_fill in
   {
     symbol = c.symbol;
     pick_date;

--- a/trading/trading/weinstein/snapshot/test/test_round_trip.ml
+++ b/trading/trading/weinstein/snapshot/test/test_round_trip.ml
@@ -100,9 +100,7 @@ let test_re_serialize_identity _ =
   assert_that
     (Snapshot_reader.parse bytes)
     (is_ok_and_holds
-       (field
-          (fun t -> Snapshot_writer.serialize t)
-          (equal_to bytes)))
+       (field (fun t -> Snapshot_writer.serialize t) (equal_to bytes)))
 
 (* ------- Schema-version handling ------- *)
 


### PR DESCRIPTION
Two-file fmt-promote PR.

dune build @fmt --auto-promote landed:
- trading/trading/weinstein/snapshot/test/test_round_trip.ml — field() call now fits on one line
- trading/trading/weinstein/snapshot/lib/forward_trace.ml — two let...in blocks now fit on one line each

No behavior change. dune build && dune runtest trading/weinstein/snapshot remain clean (11 round-trip + 7 forward-trace tests pass).