### PR TITLE
feat(weinstein/snapshot): cross-version pick diff (M6.3)

### DIFF
--- a/trading/trading/weinstein/snapshot/bin/diff_picks.ml
+++ b/trading/trading/weinstein/snapshot/bin/diff_picks.ml
@@ -1,0 +1,33 @@
+(** [diff_picks] CLI — render a {!Pick_diff} between two weekly snapshots.
+
+    Usage: [diff_picks <v1.sexp> <v2.sexp>]
+
+    Reads two weekly snapshots from disk and prints the cross-version pick diff
+    to stdout as a sexp. Exits non-zero on read errors or when the snapshots are
+    from different dates. *)
+
+open Core
+open Weinstein_snapshot
+
+let _read_snapshot path : Weekly_snapshot.t =
+  match Snapshot_reader.read_from_file path with
+  | Ok t -> t
+  | Error err ->
+      eprintf "Failed to read snapshot %s: %s\n" path (Status.show err);
+      exit 1
+
+let _run v1_path v2_path =
+  let v1 = _read_snapshot v1_path in
+  let v2 = _read_snapshot v2_path in
+  match Pick_diff.diff ~v1 ~v2 with
+  | Error err ->
+      eprintf "Diff failed: %s\n" (Status.show err);
+      exit 1
+  | Ok diff -> print_endline (Sexp.to_string_hum (Pick_diff.sexp_of_t diff))
+
+let () =
+  match Sys.get_argv () |> Array.to_list with
+  | _ :: v1_path :: v2_path :: _ -> _run v1_path v2_path
+  | _ ->
+      eprintf "Usage: diff_picks <v1.sexp> <v2.sexp>\n";
+      exit 2

--- a/trading/trading/weinstein/snapshot/bin/dune
+++ b/trading/trading/weinstein/snapshot/bin/dune
@@ -1,5 +1,5 @@
 (executables
- (names trace_picks verify_corporate_actions)
+ (names trace_picks verify_corporate_actions diff_picks)
  (libraries
   core
   core_unix.command_unix

--- a/trading/trading/weinstein/snapshot/lib/pick_diff.ml
+++ b/trading/trading/weinstein/snapshot/lib/pick_diff.ml
@@ -1,0 +1,94 @@
+open Core
+
+type score_change = {
+  symbol : string;
+  v1_score : float;
+  v2_score : float;
+  delta : float;
+}
+[@@deriving sexp, eq, show]
+
+type rank_change = {
+  symbol : string;
+  v1_rank : int;
+  v2_rank : int;
+  delta : int;
+}
+[@@deriving sexp, eq, show]
+
+type macro_change = { v1_regime : string; v2_regime : string }
+[@@deriving sexp, eq, show]
+
+type t = {
+  date : Date.t;
+  v1_version : string;
+  v2_version : string;
+  added_in_v2 : string list;
+  removed_in_v2 : string list;
+  score_changes : score_change list;
+  rank_changes : rank_change list;
+  macro_change : macro_change option;
+}
+[@@deriving sexp, eq, show]
+
+(** Build a map from symbol → (1-based rank, candidate). The rank is the
+    position in the input list, which the screener emits score-descending. *)
+let _index_candidates (candidates : Weekly_snapshot.candidate list) :
+    (int * Weekly_snapshot.candidate) String.Map.t =
+  List.foldi candidates ~init:String.Map.empty ~f:(fun i acc c ->
+      Map.set acc ~key:c.symbol ~data:(i + 1, c))
+
+let _symbols (candidates : Weekly_snapshot.candidate list) : String.Set.t =
+  List.map candidates ~f:(fun (c : Weekly_snapshot.candidate) -> c.symbol)
+  |> String.Set.of_list
+
+let _macro_change_of ~(v1 : Weekly_snapshot.macro_context)
+    ~(v2 : Weekly_snapshot.macro_context) : macro_change option =
+  if String.equal v1.regime v2.regime then None
+  else Some { v1_regime = v1.regime; v2_regime = v2.regime }
+
+(** Score deltas for overlapping symbols, only nonzero. Sorted by symbol. *)
+let _score_changes_of ~v1_index ~v2_index ~overlap : score_change list =
+  Set.to_list overlap
+  |> List.filter_map ~f:(fun symbol ->
+      let _, (c1 : Weekly_snapshot.candidate) = Map.find_exn v1_index symbol in
+      let _, (c2 : Weekly_snapshot.candidate) = Map.find_exn v2_index symbol in
+      let delta = c2.score -. c1.score in
+      if Float.equal delta 0.0 then None
+      else Some { symbol; v1_score = c1.score; v2_score = c2.score; delta })
+
+(** Rank deltas for overlapping symbols, only nonzero. Sorted by symbol. *)
+let _rank_changes_of ~v1_index ~v2_index ~overlap : rank_change list =
+  Set.to_list overlap
+  |> List.filter_map ~f:(fun symbol ->
+      let r1, _ = Map.find_exn v1_index symbol in
+      let r2, _ = Map.find_exn v2_index symbol in
+      let delta = r2 - r1 in
+      if delta = 0 then None
+      else Some { symbol; v1_rank = r1; v2_rank = r2; delta })
+
+let diff ~(v1 : Weekly_snapshot.t) ~(v2 : Weekly_snapshot.t) :
+    t Status.status_or =
+  if not (Date.equal v1.date v2.date) then
+    Error
+      (Status.invalid_argument_error
+         (Printf.sprintf
+            "Cannot diff snapshots from different dates: v1=%s v2=%s"
+            (Date.to_string v1.date) (Date.to_string v2.date)))
+  else
+    let v1_index = _index_candidates v1.long_candidates in
+    let v2_index = _index_candidates v2.long_candidates in
+    let v1_set = _symbols v1.long_candidates in
+    let v2_set = _symbols v2.long_candidates in
+    let overlap = Set.inter v1_set v2_set in
+    Ok
+      {
+        date = v1.date;
+        v1_version = v1.system_version;
+        v2_version = v2.system_version;
+        added_in_v2 = Set.to_list (Set.diff v2_set v1_set);
+        removed_in_v2 = Set.to_list (Set.diff v1_set v2_set);
+        score_changes = _score_changes_of ~v1_index ~v2_index ~overlap;
+        rank_changes = _rank_changes_of ~v1_index ~v2_index ~overlap;
+        macro_change = _macro_change_of ~v1:v1.macro ~v2:v2.macro;
+      }

--- a/trading/trading/weinstein/snapshot/lib/pick_diff.mli
+++ b/trading/trading/weinstein/snapshot/lib/pick_diff.mli
@@ -1,0 +1,101 @@
+(** Cross-version pick diff — pure function comparing two {!Weekly_snapshot.t}
+    values produced by different system versions on the {b same} date.
+
+    Catches silent screener drift across system revisions: when [v1] and [v2]
+    differ in their long-candidate set, scores, ranks, or macro regime, the diff
+    surfaces exactly what changed.
+
+    {1 Model}
+
+    The diff considers [long_candidates] only — that is the canonical pick list.
+    Held positions, sectors, and short candidates are out of scope for M6.3.
+
+    For overlapping symbols (in both [v1] and [v2]):
+
+    - {b score_changes} reports [v2_score - v1_score] when nonzero.
+    - {b rank_changes} reports [v2_rank - v1_rank] when nonzero. Rank is 1-based
+      positional index in [long_candidates] (which is already score-descending
+      per the screener contract).
+
+    For non-overlapping symbols:
+
+    - {b added_in_v2} lists symbols present in [v2] but not [v1].
+    - {b removed_in_v2} lists symbols present in [v1] but not [v2].
+
+    For the macro regime:
+
+    - {b macro_change} is [Some {v1_regime; v2_regime}] iff the regime label
+      differs; [None] if it matches. Macro score deltas are not reported by this
+      module — the regime label is the gate-relevant signal.
+
+    {1 Determinism}
+
+    Pure function. Same inputs → same outputs. No I/O, no clock, no global
+    state. Suitable for fixture-pinned tests.
+
+    {1 Date safety}
+
+    [diff] requires [v1.date = v2.date]. Comparing snapshots from different
+    dates is not meaningful (the universe and macro context differ for reasons
+    unrelated to the system version under test) and is rejected with
+    [Status.Invalid_argument]. *)
+
+open Core
+
+type score_change = {
+  symbol : string;  (** Ticker present in both [v1] and [v2]. *)
+  v1_score : float;  (** Score in [v1]. *)
+  v2_score : float;  (** Score in [v2]. *)
+  delta : float;  (** [v2_score -. v1_score]. *)
+}
+[@@deriving sexp, eq, show]
+(** Score change for a symbol present in both snapshots. *)
+
+type rank_change = {
+  symbol : string;  (** Ticker present in both [v1] and [v2]. *)
+  v1_rank : int;  (** 1-based rank in [v1.long_candidates]. *)
+  v2_rank : int;  (** 1-based rank in [v2.long_candidates]. *)
+  delta : int;
+      (** [v2_rank - v1_rank]. Negative means the symbol moved up (better rank)
+          in [v2]; positive means it moved down. *)
+}
+[@@deriving sexp, eq, show]
+(** Rank change for a symbol present in both snapshots. *)
+
+type macro_change = {
+  v1_regime : string;  (** Macro regime label in [v1]. *)
+  v2_regime : string;  (** Macro regime label in [v2]. *)
+}
+[@@deriving sexp, eq, show]
+(** Macro regime change. Only reported when [v1.regime <> v2.regime]. *)
+
+type t = {
+  date : Date.t;  (** Common snapshot date (equal across [v1] and [v2]). *)
+  v1_version : string;  (** [v1.system_version]. *)
+  v2_version : string;  (** [v2.system_version]. *)
+  added_in_v2 : string list;
+      (** Symbols in [v2.long_candidates] but not [v1.long_candidates], sorted
+          ascending. *)
+  removed_in_v2 : string list;
+      (** Symbols in [v1.long_candidates] but not [v2.long_candidates], sorted
+          ascending. *)
+  score_changes : score_change list;
+      (** Score deltas for overlapping symbols, only entries with nonzero delta.
+          Sorted by symbol ascending. *)
+  rank_changes : rank_change list;
+      (** Rank deltas for overlapping symbols, only entries with nonzero delta.
+          Sorted by symbol ascending. *)
+  macro_change : macro_change option;
+      (** [Some _] iff [v1.macro.regime <> v2.macro.regime], else [None]. *)
+}
+[@@deriving sexp, eq, show]
+(** Cross-version pick diff. An empty diff (identical inputs) has empty lists
+    and [macro_change = None]. *)
+
+val diff : v1:Weekly_snapshot.t -> v2:Weekly_snapshot.t -> t Status.status_or
+(** [diff ~v1 ~v2] computes the cross-version pick diff between [v1] and [v2].
+
+    Returns:
+    - [Ok t] on success.
+    - [Error Invalid_argument] if [v1.date <> v2.date]. The error message names
+      both dates. *)

--- a/trading/trading/weinstein/snapshot/test/dune
+++ b/trading/trading/weinstein/snapshot/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_round_trip test_forward_trace test_split_replay)
+ (names test_round_trip test_forward_trace test_split_replay test_pick_diff)
  (libraries
   weinstein_trading.snapshot
   status

--- a/trading/trading/weinstein/snapshot/test/test_pick_diff.ml
+++ b/trading/trading/weinstein/snapshot/test/test_pick_diff.ml
@@ -1,0 +1,282 @@
+(** Hand-pinned tests for {!Pick_diff} — cross-version pick diff. *)
+
+open Core
+open OUnit2
+open Matchers
+open Weinstein_snapshot
+
+(* ------- Fixtures ------- *)
+
+let _date d = Date.of_string d
+let _common_date = _date "2020-08-28"
+
+let _candidate ?(score = 0.5) ?(grade = "B") ?(entry = 100.0) ?(stop = 90.0)
+    ?(sector = "XLK") ?(rationale = "test") ?(rs_vs_spy = None)
+    ?(resistance_grade = None) symbol : Weekly_snapshot.candidate =
+  {
+    symbol;
+    score;
+    grade;
+    entry;
+    stop;
+    sector;
+    rationale;
+    rs_vs_spy;
+    resistance_grade;
+  }
+
+let _snapshot ?(system_version = "v1") ?(date = _common_date)
+    ?(macro =
+      ({ regime = "Bullish"; score = 0.7 } : Weekly_snapshot.macro_context))
+    ?(long_candidates = []) () : Weekly_snapshot.t =
+  {
+    schema_version = Weekly_snapshot.current_schema_version;
+    system_version;
+    date;
+    macro;
+    sectors_strong = [];
+    sectors_weak = [];
+    long_candidates;
+    short_candidates = [];
+    held_positions = [];
+  }
+
+(* ------- Tests ------- *)
+
+let test_identical_snapshots_yield_empty_diff _ =
+  let snap =
+    _snapshot
+      ~long_candidates:
+        [ _candidate ~score:0.91 "AAPL"; _candidate ~score:0.87 "MSFT" ]
+      ()
+  in
+  assert_that
+    (Pick_diff.diff ~v1:snap ~v2:snap)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (d : Pick_diff.t) -> d.added_in_v2) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.removed_in_v2) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.score_changes) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.rank_changes) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.macro_change) is_none;
+            field (fun (d : Pick_diff.t) -> d.date) (equal_to _common_date);
+          ]))
+
+let test_added_in_v2 _ =
+  let v1 =
+    _snapshot ~system_version:"v1"
+      ~long_candidates:[ _candidate ~score:0.91 "AAPL" ]
+      ()
+  in
+  let v2 =
+    _snapshot ~system_version:"v2"
+      ~long_candidates:
+        [ _candidate ~score:0.91 "AAPL"; _candidate ~score:0.80 "NVDA" ]
+      ()
+  in
+  assert_that (Pick_diff.diff ~v1 ~v2)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (d : Pick_diff.t) -> d.v1_version) (equal_to "v1");
+            field (fun (d : Pick_diff.t) -> d.v2_version) (equal_to "v2");
+            field (fun (d : Pick_diff.t) -> d.added_in_v2) (equal_to [ "NVDA" ]);
+            field (fun (d : Pick_diff.t) -> d.removed_in_v2) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.score_changes) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.rank_changes) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.macro_change) is_none;
+          ]))
+
+let test_removed_in_v2 _ =
+  let v1 =
+    _snapshot
+      ~long_candidates:
+        [ _candidate ~score:0.91 "AAPL"; _candidate ~score:0.65 "XOM" ]
+      ()
+  in
+  let v2 = _snapshot ~long_candidates:[ _candidate ~score:0.91 "AAPL" ] () in
+  assert_that (Pick_diff.diff ~v1 ~v2)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (d : Pick_diff.t) -> d.added_in_v2) (equal_to []);
+            field
+              (fun (d : Pick_diff.t) -> d.removed_in_v2)
+              (equal_to [ "XOM" ]);
+            field (fun (d : Pick_diff.t) -> d.score_changes) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.rank_changes) (equal_to []);
+          ]))
+
+let test_score_change_on_shared_symbol _ =
+  let v1 = _snapshot ~long_candidates:[ _candidate ~score:0.91 "AAPL" ] () in
+  let v2 = _snapshot ~long_candidates:[ _candidate ~score:0.88 "AAPL" ] () in
+  assert_that (Pick_diff.diff ~v1 ~v2)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (d : Pick_diff.t) -> d.added_in_v2) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.removed_in_v2) (equal_to []);
+            field
+              (fun (d : Pick_diff.t) -> d.score_changes)
+              (elements_are
+                 [
+                   all_of
+                     [
+                       field
+                         (fun (c : Pick_diff.score_change) -> c.symbol)
+                         (equal_to "AAPL");
+                       field
+                         (fun (c : Pick_diff.score_change) -> c.v1_score)
+                         (float_equal 0.91);
+                       field
+                         (fun (c : Pick_diff.score_change) -> c.v2_score)
+                         (float_equal 0.88);
+                       field
+                         (fun (c : Pick_diff.score_change) -> c.delta)
+                         (float_equal (-0.03));
+                     ];
+                 ]);
+            field (fun (d : Pick_diff.t) -> d.rank_changes) (equal_to []);
+          ]))
+
+let test_rank_only_swap _ =
+  (* Same symbols, scores differ enough to flip rank, but we want to assert
+     the rank deltas explicitly. *)
+  let v1 =
+    _snapshot
+      ~long_candidates:
+        [ _candidate ~score:0.91 "AAPL"; _candidate ~score:0.87 "MSFT" ]
+      ()
+  in
+  let v2 =
+    _snapshot
+      ~long_candidates:
+        [ _candidate ~score:0.95 "MSFT"; _candidate ~score:0.91 "AAPL" ]
+      ()
+  in
+  assert_that (Pick_diff.diff ~v1 ~v2)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (d : Pick_diff.t) -> d.added_in_v2) (equal_to []);
+            field (fun (d : Pick_diff.t) -> d.removed_in_v2) (equal_to []);
+            field
+              (fun (d : Pick_diff.t) -> d.rank_changes)
+              (elements_are
+                 [
+                   equal_to
+                     ({ symbol = "AAPL"; v1_rank = 1; v2_rank = 2; delta = 1 }
+                       : Pick_diff.rank_change);
+                   equal_to
+                     ({ symbol = "MSFT"; v1_rank = 2; v2_rank = 1; delta = -1 }
+                       : Pick_diff.rank_change);
+                 ]);
+          ]))
+
+let test_macro_regime_change _ =
+  let v1 = _snapshot ~macro:{ regime = "Bullish"; score = 0.7 } () in
+  let v2 = _snapshot ~macro:{ regime = "Bearish"; score = -0.4 } () in
+  assert_that (Pick_diff.diff ~v1 ~v2)
+    (is_ok_and_holds
+       (field
+          (fun (d : Pick_diff.t) -> d.macro_change)
+          (is_some_and
+             (equal_to
+                ({ v1_regime = "Bullish"; v2_regime = "Bearish" }
+                  : Pick_diff.macro_change)))))
+
+let test_different_dates_rejected _ =
+  let v1 = _snapshot ~date:(_date "2020-08-28") () in
+  let v2 = _snapshot ~date:(_date "2020-09-04") () in
+  assert_that (Pick_diff.diff ~v1 ~v2) (is_error_with Status.Invalid_argument)
+
+let test_combined_changes _ =
+  (* Add, remove, score change, rank change, macro change all at once. *)
+  let v1 =
+    _snapshot ~system_version:"v1"
+      ~macro:{ regime = "Bullish"; score = 0.6 }
+      ~long_candidates:
+        [
+          _candidate ~score:0.91 "AAPL";
+          _candidate ~score:0.87 "MSFT";
+          _candidate ~score:0.65 "XOM";
+        ]
+      ()
+  in
+  let v2 =
+    _snapshot ~system_version:"v2"
+      ~macro:{ regime = "Neutral"; score = 0.05 }
+      ~long_candidates:
+        [
+          _candidate ~score:0.92 "MSFT";
+          _candidate ~score:0.88 "AAPL";
+          _candidate ~score:0.70 "NVDA";
+        ]
+      ()
+  in
+  assert_that (Pick_diff.diff ~v1 ~v2)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (d : Pick_diff.t) -> d.added_in_v2) (equal_to [ "NVDA" ]);
+            field
+              (fun (d : Pick_diff.t) -> d.removed_in_v2)
+              (equal_to [ "XOM" ]);
+            field
+              (fun (d : Pick_diff.t) -> d.score_changes)
+              (elements_are
+                 [
+                   all_of
+                     [
+                       field
+                         (fun (c : Pick_diff.score_change) -> c.symbol)
+                         (equal_to "AAPL");
+                       field
+                         (fun (c : Pick_diff.score_change) -> c.delta)
+                         (float_equal (-0.03));
+                     ];
+                   all_of
+                     [
+                       field
+                         (fun (c : Pick_diff.score_change) -> c.symbol)
+                         (equal_to "MSFT");
+                       field
+                         (fun (c : Pick_diff.score_change) -> c.delta)
+                         (float_equal 0.05);
+                     ];
+                 ]);
+            field
+              (fun (d : Pick_diff.t) -> d.rank_changes)
+              (elements_are
+                 [
+                   equal_to
+                     ({ symbol = "AAPL"; v1_rank = 1; v2_rank = 2; delta = 1 }
+                       : Pick_diff.rank_change);
+                   equal_to
+                     ({ symbol = "MSFT"; v1_rank = 2; v2_rank = 1; delta = -1 }
+                       : Pick_diff.rank_change);
+                 ]);
+            field
+              (fun (d : Pick_diff.t) -> d.macro_change)
+              (is_some_and
+                 (equal_to
+                    ({ v1_regime = "Bullish"; v2_regime = "Neutral" }
+                      : Pick_diff.macro_change)));
+          ]))
+
+let suite =
+  "pick_diff"
+  >::: [
+         "identical_snapshots_yield_empty_diff"
+         >:: test_identical_snapshots_yield_empty_diff;
+         "added_in_v2" >:: test_added_in_v2;
+         "removed_in_v2" >:: test_removed_in_v2;
+         "score_change_on_shared_symbol" >:: test_score_change_on_shared_symbol;
+         "rank_only_swap" >:: test_rank_only_swap;
+         "macro_regime_change" >:: test_macro_regime_change;
+         "different_dates_rejected" >:: test_different_dates_rejected;
+         "combined_changes" >:: test_combined_changes;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Implements **M6.3** of the M6 weekly-snapshot verification plan
(`dev/plans/m6-weekly-snapshot-verification-2026-05-02.md` §M6.3).

Adds `Pick_diff` — pure function comparing two `Weekly_snapshot.t`
values produced by different system versions on the **same date**.
Surfaces silent screener drift across system revisions via four channels:

- `added_in_v2` / `removed_in_v2`: long-candidate set deltas
- `score_changes`: per-symbol score delta (only nonzero entries) for overlapping symbols
- `rank_changes`: per-symbol 1-based rank delta (only nonzero entries) for overlapping symbols
- `macro_change`: regime label change (`None` when unchanged)

Different-date inputs are rejected with `Status.Invalid_argument` since
the universe and macro context differ for reasons unrelated to the
system version under test (decision documented in `pick_diff.mli`).

CLI: `diff_picks <v1.sexp> <v2.sexp>` reads two snapshots and emits
the diff to stdout as a sexp.

## Files

All new, no modifications to existing modules:

- `trading/trading/weinstein/snapshot/lib/pick_diff.{ml,mli}` — pure diff function
- `trading/trading/weinstein/snapshot/bin/diff_picks.ml` — CLI wrapper
- `trading/trading/weinstein/snapshot/test/test_pick_diff.ml` — 8 hand-pinned tests
- `bin/dune` and `test/dune` — extended to include the new targets (one-line each)

`weekly_snapshot.{ml,mli}` is **not** modified — the diff reads existing
fields only.

## Test plan

- [x] `dune build` clean
- [x] `dune build @fmt --auto-promote` clean
- [x] `dune runtest trading/weinstein/snapshot` — 32 tests pass (8 new pick_diff tests)
- [x] `dune runtest` (full suite) green
- [x] 8 hand-pinned scenarios cover: identical inputs (empty diff),
      add-only, remove-only, score change on shared symbol, rank-only swap,
      macro regime change, different-date rejection, combined-changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>