### PR TITLE
feat(metrics): distributional + antifragility catalog (M5.2d)

### DIFF
--- a/trading/trading/backtest/lib/comparison.ml
+++ b/trading/trading/backtest/lib/comparison.ml
@@ -79,6 +79,16 @@ let _metric_label : Metric_type.t -> string = function
   | UlcerIndex -> "ulcer_index"
   | PainIndex -> "pain_index"
   | UnderwaterCurveArea -> "underwater_curve_area"
+  (* M5.2d: distributional *)
+  | Skewness -> "skewness"
+  | Kurtosis -> "kurtosis"
+  | CVaR95 -> "cvar_95"
+  | CVaR99 -> "cvar_99"
+  | TailRatio -> "tail_ratio"
+  | GainToPain -> "gain_to_pain"
+  (* M5.2d: antifragility *)
+  | ConcavityCoef -> "concavity_coef"
+  | BucketAsymmetry -> "bucket_asymmetry"
 
 let _all_metric_types : Metric_type.t list =
   [
@@ -140,6 +150,16 @@ let _all_metric_types : Metric_type.t list =
     UlcerIndex;
     PainIndex;
     UnderwaterCurveArea;
+    (* M5.2d: distributional *)
+    Skewness;
+    Kurtosis;
+    CVaR95;
+    CVaR99;
+    TailRatio;
+    GainToPain;
+    (* M5.2d: antifragility *)
+    ConcavityCoef;
+    BucketAsymmetry;
   ]
 
 let _diff_for_metric ~baseline_set ~variant_set (mt : Metric_type.t) =

--- a/trading/trading/simulation/lib/antifragility_computer.ml
+++ b/trading/trading/simulation/lib/antifragility_computer.ml
@@ -1,0 +1,191 @@
+(** Antifragility metrics (M5.2d). See .mli for spec. *)
+
+open Core
+module Metric_types = Trading_simulation_types.Metric_types
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+(** Minimum number of paired (strategy, benchmark) returns required before we
+    bother fitting the quadratic; below this both metrics emit 0.0. Five is the
+    smallest count that makes one-per-quintile bucketing well-defined. *)
+let _min_paired_samples = 5
+
+(** Determinant tolerance below which the [3 × 3] OLS matrix is treated as
+    singular (γ falls back to 0.0). Conservative — at single-digit percent
+    inputs the determinant is far from zero on non-degenerate samples. *)
+let _det_tolerance = 1e-12
+
+type state = {
+  portfolio_values : float list;  (** Reversed: head is most recent. *)
+  benchmark_returns : float list option;
+      (** Chronological. None = no plumbing. *)
+}
+
+let _step_returns_pct values =
+  let rec loop prev rest acc =
+    match rest with
+    | [] -> List.rev acc
+    | curr :: rest' ->
+        let r =
+          if Float.(prev <= 0.0) then 0.0 else (curr -. prev) /. prev *. 100.0
+        in
+        loop curr rest' (r :: acc)
+  in
+  match values with [] | [ _ ] -> [] | first :: rest -> loop first rest []
+
+(** Truncate the longer of (strat, bench) to the shorter length and zip. The
+    chronological ordering of both lists is the alignment contract; we don't
+    attempt date-based alignment because the benchmark series is supplied as a
+    bare list (per the .mli's deferred-plumbing rationale). *)
+let _align_pairs strat bench =
+  let n = Int.min (List.length strat) (List.length bench) in
+  List.zip_exn (List.take strat n) (List.take bench n)
+
+(* ---- Quadratic OLS via 3x3 matrix inversion ---- *)
+
+type _ols_sums = {
+  n : float;
+  sx : float;
+  sx2 : float;
+  sx3 : float;
+  sx4 : float;
+  sy : float;
+  sxy : float;
+  sx2y : float;
+}
+(** Sums needed for the normal equations of [y = α + β·x + γ·x²]. Predictors are
+    [(1, x, x²)], so [XᵀX] is a [3 × 3] symmetric matrix of moments [Σ x^{i+j}]
+    and [Xᵀy] is a [3] vector of moments [Σ x^i · y]. *)
+
+let _accumulate_sums pairs =
+  List.fold pairs
+    ~init:
+      {
+        n = 0.0;
+        sx = 0.0;
+        sx2 = 0.0;
+        sx3 = 0.0;
+        sx4 = 0.0;
+        sy = 0.0;
+        sxy = 0.0;
+        sx2y = 0.0;
+      } ~f:(fun acc (y, x) ->
+      let x2 = x *. x in
+      let x3 = x2 *. x in
+      let x4 = x2 *. x2 in
+      {
+        n = acc.n +. 1.0;
+        sx = acc.sx +. x;
+        sx2 = acc.sx2 +. x2;
+        sx3 = acc.sx3 +. x3;
+        sx4 = acc.sx4 +. x4;
+        sy = acc.sy +. y;
+        sxy = acc.sxy +. (x *. y);
+        sx2y = acc.sx2y +. (x2 *. y);
+      })
+
+(** Determinant of the 3x3 [XᵀX] matrix:
+
+    {v
+        | n    sx   sx2 |
+        | sx   sx2  sx3 |
+        | sx2  sx3  sx4 |
+    v} *)
+let _det33 s =
+  (s.n *. ((s.sx2 *. s.sx4) -. (s.sx3 *. s.sx3)))
+  -. (s.sx *. ((s.sx *. s.sx4) -. (s.sx3 *. s.sx2)))
+  +. (s.sx2 *. ((s.sx *. s.sx3) -. (s.sx2 *. s.sx2)))
+
+(** γ via Cramer's rule: replace the third column of [XᵀX] with [Xᵀy]:
+
+    {v
+        | n    sx   sy   |
+        | sx   sx2  sxy  |
+        | sx2  sx3  sx2y |
+    v}
+
+    γ = det(replaced) / det(XᵀX). *)
+let _gamma_numerator s =
+  (s.n *. ((s.sx2 *. s.sx2y) -. (s.sxy *. s.sx3)))
+  -. (s.sx *. ((s.sx *. s.sx2y) -. (s.sxy *. s.sx2)))
+  +. (s.sy *. ((s.sx *. s.sx3) -. (s.sx2 *. s.sx2)))
+
+let _concavity_coef pairs =
+  if List.length pairs < _min_paired_samples then 0.0
+  else
+    let s = _accumulate_sums pairs in
+    let det = _det33 s in
+    if Float.(Float.abs det < _det_tolerance) then 0.0
+    else _gamma_numerator s /. det
+
+(* ---- Bucket asymmetry via benchmark quintiles ---- *)
+
+(** Sort pairs by benchmark value, then split into [n_buckets] equal-size chunks
+    (the last bucket absorbs the remainder when not divisible). Returns one
+    float list per bucket of strategy returns. *)
+let _bucket_strat_by_bench ~n_buckets pairs =
+  let sorted =
+    List.sort pairs ~compare:(fun (_y1, x1) (_y2, x2) -> Float.compare x1 x2)
+  in
+  let n = List.length sorted in
+  let chunk_size = n / n_buckets in
+  List.init n_buckets ~f:(fun i ->
+      let start_idx = i * chunk_size in
+      let end_idx = if i = n_buckets - 1 then n else (i + 1) * chunk_size in
+      List.filter_mapi sorted ~f:(fun idx (y, _x) ->
+          if idx >= start_idx && idx < end_idx then Some y else None))
+
+let _mean = function
+  | [] -> 0.0
+  | xs ->
+      let sum = List.fold xs ~init:0.0 ~f:( +. ) in
+      sum /. Float.of_int (List.length xs)
+
+let _bucket_asymmetry pairs =
+  if List.length pairs < _min_paired_samples then 0.0
+  else
+    let buckets = _bucket_strat_by_bench ~n_buckets:5 pairs in
+    let means = List.map buckets ~f:_mean in
+    match means with
+    | [ q1; q2; q3; q4; q5 ] ->
+        let extremes = q1 +. q5 in
+        let middle = q2 +. q3 +. q4 in
+        if Float.(Float.abs middle = 0.0) then 0.0 else extremes /. middle
+    | _ -> 0.0
+
+(* ---- Output assembly ---- *)
+
+let _empty_metric_set () =
+  Metric_types.of_alist_exn [ (ConcavityCoef, 0.0); (BucketAsymmetry, 0.0) ]
+
+let _build_metrics ~strat_returns ~benchmark_returns =
+  match benchmark_returns with
+  | None -> _empty_metric_set ()
+  | Some bench ->
+      let pairs = _align_pairs strat_returns bench in
+      Metric_types.of_alist_exn
+        [
+          (ConcavityCoef, _concavity_coef pairs);
+          (BucketAsymmetry, _bucket_asymmetry pairs);
+        ]
+
+let _update ~state ~step =
+  if not (Metric_computer_utils.is_trading_day_step step) then state
+  else
+    {
+      state with
+      portfolio_values =
+        step.Simulator_types.portfolio_value :: state.portfolio_values;
+    }
+
+let _finalize ~state ~config:_ =
+  let strat_returns = _step_returns_pct (List.rev state.portfolio_values) in
+  _build_metrics ~strat_returns ~benchmark_returns:state.benchmark_returns
+
+let computer ?benchmark_returns () : Simulator_types.any_metric_computer =
+  Simulator_types.wrap_computer
+    {
+      name = "antifragility";
+      init = (fun ~config:_ -> { portfolio_values = []; benchmark_returns });
+      update = _update;
+      finalize = _finalize;
+    }

--- a/trading/trading/simulation/lib/antifragility_computer.mli
+++ b/trading/trading/simulation/lib/antifragility_computer.mli
@@ -1,0 +1,64 @@
+(** Antifragility / barbell metrics (M5.2d).
+
+    These metrics describe the strategy's response curve as a function of a
+    {b benchmark} (default convention: SPY total return). The strategy's
+    per-step return is regressed quadratically against the benchmark's per-step
+    return; the curvature term [γ] (coefficient of [r_bench²]) is the
+    {b concavity coefficient} after Taleb:
+
+    - [γ > 0] → convex / antifragile (strategy gains more than linearly in
+      benchmark extremes);
+    - [γ < 0] → concave / fragile (strategy gives back gains in benchmark
+      extremes);
+    - [γ ≈ 0] → linear-tracking response.
+
+    [BucketAsymmetry] is a non-parametric companion: bin benchmark per-step
+    returns into quintiles (Q1..Q5), compute the strategy's mean return per
+    bucket, then report [(Q1_mean + Q5_mean) / (Q2_mean + Q3_mean + Q4_mean)].
+    Values > 1 indicate a barbell shape (strategy concentrates returns in the
+    benchmark's extremes). Values ≤ 1 indicate a middle-heavy shape.
+
+    {b Benchmark plumbing.} The simulator's [step_result] does not currently
+    track benchmark returns. To avoid an invasive surface change in this PR, the
+    benchmark series is supplied directly at computer construction:
+
+    {[
+      let computer = Antifragility_computer.computer ~benchmark_returns:[ ... ] ()
+    ]}
+
+    When [benchmark_returns] is [None] (the default for stand-alone backtest
+    runs), both [ConcavityCoef] and [BucketAsymmetry] are emitted as [0.0]. A
+    follow-up PR will plumb a benchmark feed through the simulator, at which
+    point this computer will read the series from [config] instead.
+
+    {b OLS formula.} Given paired samples [(x_i, y_i)] with [x = r_bench],
+    [y = r_strat], the model is [y = α + β·x + γ·x²]. Define [u = x²]. Then
+    [α, β, γ] solve the normal equations of multivariate OLS with predictors
+    [(1, x, u)]. We compute the closed-form solution via the [3 × 3] matrix
+    inversion of [Xᵀ X], using [Σ x^k] sums for [k ∈ {0..4}] and [Σ x^j y] for
+    [j ∈ {0..2}]. Numerically stable for the small return magnitudes
+    (single-digit percent) we feed in; we return [0.0] if the matrix determinant
+    is ≤ a small threshold (degenerate sample).
+
+    Pure: same step list + same benchmark series → same output. *)
+
+val computer :
+  ?benchmark_returns:float list ->
+  unit ->
+  Trading_simulation_types.Simulator_types.any_metric_computer
+(** Build the step-based computer that emits [ConcavityCoef] and
+    [BucketAsymmetry].
+
+    @param benchmark_returns
+      Optional per-step benchmark percent-return series. When supplied, the list
+      must be in chronological order; the computer aligns it to the strategy's
+      per-step returns by truncating the longer side. When [None], both metrics
+      are emitted as [0.0].
+
+    Edge cases:
+    - Fewer than 5 paired samples → both metrics 0.0 (insufficient data for a
+      stable quadratic fit and for quintile bucketing).
+    - Degenerate quadratic system (zero variance in benchmark, or small
+      determinant of [Xᵀ X]) → [ConcavityCoef] = 0.0.
+    - Empty bucket sums in the denominator of [BucketAsymmetry] → fall back to
+      0.0 to avoid division by a zero magnitude. *)

--- a/trading/trading/simulation/lib/distributional_computer.ml
+++ b/trading/trading/simulation/lib/distributional_computer.ml
@@ -1,0 +1,168 @@
+(** Distributional return-shape metrics (M5.2d). See .mli for spec. *)
+
+open Core
+module Metric_types = Trading_simulation_types.Metric_types
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+(** Tail cuts for CVaR / TailRatio. Both are conventional: 5% Expected Shortfall
+    is the dominant academic measure; 1% is the regulatory tail. *)
+let _cvar_95_p = 0.05
+
+let _cvar_99_p = 0.01
+let _tail_ratio_p = 0.05
+
+type state = {
+  portfolio_values : float list;  (** Reversed: head is most recent. *)
+}
+
+(** Step-over-step percent returns from a chronological value series. *)
+let _step_returns_pct values =
+  let rec loop prev rest acc =
+    match rest with
+    | [] -> List.rev acc
+    | curr :: rest' ->
+        let r =
+          if Float.(prev <= 0.0) then 0.0 else (curr -. prev) /. prev *. 100.0
+        in
+        loop curr rest' (r :: acc)
+  in
+  match values with [] | [ _ ] -> [] | first :: rest -> loop first rest []
+
+let _mean = function
+  | [] -> 0.0
+  | xs ->
+      let sum = List.fold xs ~init:0.0 ~f:( +. ) in
+      sum /. Float.of_int (List.length xs)
+
+(** Population variance (divides by N, not N-1). Higher moments use the
+    population convention to keep the formulas numerically self-consistent with
+    the standardized [(r - μ) / σ] terms. *)
+let _variance returns =
+  match returns with
+  | [] | [ _ ] -> 0.0
+  | _ ->
+      let m = _mean returns in
+      let sum_sq =
+        List.fold returns ~init:0.0 ~f:(fun acc r ->
+            let d = r -. m in
+            acc +. (d *. d))
+      in
+      sum_sq /. Float.of_int (List.length returns)
+
+(** Third / fourth central moments (population). *)
+let _moments_3_4 returns =
+  match returns with
+  | [] | [ _ ] -> (0.0, 0.0)
+  | _ ->
+      let m = _mean returns in
+      let n_f = Float.of_int (List.length returns) in
+      let m3, m4 =
+        List.fold returns ~init:(0.0, 0.0) ~f:(fun (acc3, acc4) r ->
+            let d = r -. m in
+            let d2 = d *. d in
+            (acc3 +. (d2 *. d), acc4 +. (d2 *. d2)))
+      in
+      (m3 /. n_f, m4 /. n_f)
+
+let _skewness returns =
+  let var = _variance returns in
+  if Float.(var <= 0.0) then 0.0
+  else
+    let m3, _m4 = _moments_3_4 returns in
+    let sigma = Float.sqrt var in
+    m3 /. (sigma *. sigma *. sigma)
+
+let _kurtosis_excess returns =
+  let var = _variance returns in
+  if Float.(var <= 0.0) then 0.0
+  else
+    let _m3, m4 = _moments_3_4 returns in
+    (m4 /. (var *. var)) -. 3.0
+
+(** [_bottom_n_mean ~p sorted_asc] returns the mean of the lowest [floor(n × p)]
+    returns; 0.0 if that count is zero. The input must be sorted ascending. *)
+let _bottom_n_mean ~p sorted_asc =
+  let n = List.length sorted_asc in
+  let k = Float.iround_down_exn (Float.of_int n *. p) in
+  if k <= 0 then 0.0
+  else
+    let bottom = List.take sorted_asc k in
+    _mean bottom
+
+(** [_top_n_mean ~p sorted_asc] returns the mean of the highest [floor(n × p)]
+    returns; 0.0 if that count is zero. *)
+let _top_n_mean ~p sorted_asc =
+  let n = List.length sorted_asc in
+  let k = Float.iround_down_exn (Float.of_int n *. p) in
+  if k <= 0 then 0.0
+  else
+    let top = List.drop sorted_asc (n - k) in
+    _mean top
+
+let _cvar ~p returns =
+  let sorted = List.sort returns ~compare:Float.compare in
+  _bottom_n_mean ~p sorted
+
+let _tail_ratio returns =
+  let sorted = List.sort returns ~compare:Float.compare in
+  let top = _top_n_mean ~p:_tail_ratio_p sorted in
+  let bottom = _bottom_n_mean ~p:_tail_ratio_p sorted in
+  let abs_bottom = Float.abs bottom in
+  if Float.(abs_bottom = 0.0) then
+    if Float.(top > 0.0) then Float.infinity else 0.0
+  else top /. abs_bottom
+
+let _gain_to_pain returns =
+  let gains, losses =
+    List.fold returns ~init:(0.0, 0.0) ~f:(fun (g, l) r ->
+        if Float.(r > 0.0) then (g +. r, l)
+        else if Float.(r < 0.0) then (g, l +. r)
+        else (g, l))
+  in
+  let abs_losses = Float.abs losses in
+  if Float.(abs_losses = 0.0) then
+    if Float.(gains > 0.0) then Float.infinity else 0.0
+  else gains /. abs_losses
+
+let _empty_metric_set () =
+  Metric_types.of_alist_exn
+    [
+      (Skewness, 0.0);
+      (Kurtosis, 0.0);
+      (CVaR95, 0.0);
+      (CVaR99, 0.0);
+      (TailRatio, 0.0);
+      (GainToPain, 0.0);
+    ]
+
+let _build_metrics returns =
+  Metric_types.of_alist_exn
+    [
+      (Skewness, _skewness returns);
+      (Kurtosis, _kurtosis_excess returns);
+      (CVaR95, _cvar ~p:_cvar_95_p returns);
+      (CVaR99, _cvar ~p:_cvar_99_p returns);
+      (TailRatio, _tail_ratio returns);
+      (GainToPain, _gain_to_pain returns);
+    ]
+
+let _update ~state ~step =
+  if not (Metric_computer_utils.is_trading_day_step step) then state
+  else
+    {
+      portfolio_values =
+        step.Simulator_types.portfolio_value :: state.portfolio_values;
+    }
+
+let _finalize ~state ~config:_ =
+  let returns = _step_returns_pct (List.rev state.portfolio_values) in
+  match returns with [] -> _empty_metric_set () | _ -> _build_metrics returns
+
+let computer () : Simulator_types.any_metric_computer =
+  Simulator_types.wrap_computer
+    {
+      name = "distributional";
+      init = (fun ~config:_ -> { portfolio_values = [] });
+      update = _update;
+      finalize = _finalize;
+    }

--- a/trading/trading/simulation/lib/distributional_computer.mli
+++ b/trading/trading/simulation/lib/distributional_computer.mli
@@ -1,0 +1,35 @@
+(** Distributional return-shape metrics (M5.2d).
+
+    Sweeps the daily portfolio-value series once and emits the per-step return
+    distribution's higher moments and tail statistics:
+
+    - [Skewness] — third standardized moment.
+    - [Kurtosis] — fourth standardized moment minus 3 (excess kurtosis).
+    - [CVaR95], [CVaR99] — Expected Shortfall (mean of the worst 5% / 1% of step
+      returns), in percent.
+    - [TailRatio] — [mean(top 5%) / |mean(bottom 5%)|].
+    - [GainToPain] — [Σ gains / |Σ losses|].
+
+    All metrics are computed on per-step (one-trading-day) percent returns.
+    Annualization is not meaningful for these metrics: skewness and kurtosis are
+    unitless, and the tail / pain statistics describe the empirical distribution
+    at the same cadence as the input.
+
+    Pure: same step list → same output. *)
+
+val computer :
+  unit -> Trading_simulation_types.Simulator_types.any_metric_computer
+(** Build the step-based computer that emits the M5.2d distributional metrics.
+
+    Edge cases:
+    - Empty input or fewer than 2 trading-day steps → all metrics 0.0.
+    - Zero variance (all returns equal) → skewness and kurtosis are 0.0 (defined
+      this way to avoid division-by-zero noise; a flat curve has no asymmetry or
+      tail-heaviness).
+    - All-positive returns → [GainToPain] is [Float.infinity]; [TailRatio] is
+      [Float.infinity] when the bottom-5% mean is zero and the top-5% mean is
+      positive.
+    - All-zero returns → [GainToPain] and [TailRatio] are 0.0.
+    - The 5% / 1% cuts use [Float.iround_down]: the bottom-N is the lowest
+      [floor(n × p)] returns. With fewer than [⌈1/p⌉] returns the cut is empty
+      and the corresponding metrics fall back to 0.0. *)

--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -24,6 +24,8 @@
   trade_aggregates_computer
   return_basics_computer
   risk_adjusted_computer
-  drawdown_analytics_computer)
+  drawdown_analytics_computer
+  distributional_computer
+  antifragility_computer)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/simulation/lib/metric_computers.ml
+++ b/trading/trading/simulation/lib/metric_computers.ml
@@ -9,7 +9,9 @@
     - {!Trade_aggregates_computer} (M5.2b)
     - {!Return_basics_computer} (M5.2b)
     - {!Risk_adjusted_computer} (M5.2c)
-    - {!Drawdown_analytics_computer} (M5.2c) *)
+    - {!Drawdown_analytics_computer} (M5.2c)
+    - {!Distributional_computer} (M5.2d)
+    - {!Antifragility_computer} (M5.2d) *)
 
 open Core
 module Metric_types = Trading_simulation_types.Metric_types
@@ -26,6 +28,8 @@ let trade_aggregates_computer = Trade_aggregates_computer.computer
 let return_basics_computer = Return_basics_computer.computer
 let omega_ratio_computer = Risk_adjusted_computer.computer
 let drawdown_analytics_computer = Drawdown_analytics_computer.computer
+let distributional_computer = Distributional_computer.computer
+let antifragility_computer = Antifragility_computer.computer
 
 (** {1 Derived Metric Computers} *)
 
@@ -90,6 +94,9 @@ let create_computer (metric_type : Metric_types.metric_type) :
   | AvgDrawdownDurationDays | TimeInDrawdownPct | UlcerIndex | PainIndex
   | UnderwaterCurveArea ->
       drawdown_analytics_computer ()
+  | Skewness | Kurtosis | CVaR95 | CVaR99 | TailRatio | GainToPain ->
+      distributional_computer ()
+  | ConcavityCoef | BucketAsymmetry -> antifragility_computer ()
 
 (** {1 Default Computer Set} *)
 
@@ -104,6 +111,8 @@ let default_computers ?(risk_free_rate = 0.0) ?(initial_cash = 0.0) () =
     return_basics_computer ();
     omega_ratio_computer ();
     drawdown_analytics_computer ();
+    distributional_computer ();
+    antifragility_computer ();
   ]
 
 let default_derived_computers () =

--- a/trading/trading/simulation/lib/metric_computers.mli
+++ b/trading/trading/simulation/lib/metric_computers.mli
@@ -100,6 +100,22 @@ val drawdown_analytics_computer : unit -> Simulator.any_metric_computer
     MedianDrawdownPct, MaxDrawdownDurationDays, AvgDrawdownDurationDays,
     TimeInDrawdownPct, UlcerIndex, PainIndex, UnderwaterCurveArea. *)
 
+(** {1 Distributional Computer (M5.2d)} *)
+
+val distributional_computer : unit -> Simulator.any_metric_computer
+(** Computer that emits the M5.2d distributional-block group: Skewness, Kurtosis
+    (excess), CVaR95, CVaR99, TailRatio, GainToPain. See
+    {!Distributional_computer} for spec and edge-case behaviour. *)
+
+(** {1 Antifragility Computer (M5.2d)} *)
+
+val antifragility_computer :
+  ?benchmark_returns:float list -> unit -> Simulator.any_metric_computer
+(** Computer that emits ConcavityCoef and BucketAsymmetry. Both metrics require
+    a benchmark return series; when [benchmark_returns] is omitted they emit 0.0
+    (the documented default for stand-alone backtest runs). See
+    {!Antifragility_computer} for spec and benchmark-plumbing rationale. *)
+
 (** {1 Default Computer Set} *)
 
 val default_computers :
@@ -110,7 +126,9 @@ val default_computers :
 (** Returns all default step-based metric computers: summary (including profit
     factor), Sharpe ratio, max drawdown, CAGR, portfolio state, trade
     aggregates, the M5.2b returns-block group, the M5.2c Omega ratio computer,
-    and the M5.2c drawdown analytics group.
+    the M5.2c drawdown analytics group, the M5.2d distributional group, and the
+    M5.2d antifragility computer (no benchmark wired by default — its two
+    metrics emit 0.0 in this configuration).
 
     @param risk_free_rate
       Annual risk-free rate for Sharpe calculation (default: 0.0)
@@ -155,4 +173,10 @@ val create_computer :
 
     CalmarRatio, SortinoRatioAnnualized, and MarRatio are derived metrics — the
     factory returns a step-based stub that emits [0.0]; the real values come
-    from the corresponding entries in {!default_derived_computers}. *)
+    from the corresponding entries in {!default_derived_computers}.
+
+    Distributional metrics (Skewness, Kurtosis, CVaR95, CVaR99, TailRatio,
+    GainToPain) are produced together by [distributional_computer].
+    Antifragility metrics (ConcavityCoef, BucketAsymmetry) are produced by
+    [antifragility_computer] with no benchmark wired by default — both emit
+    [0.0] under that configuration. *)

--- a/trading/trading/simulation/lib/types/metric_info_registry.ml
+++ b/trading/trading/simulation/lib/types/metric_info_registry.ml
@@ -411,6 +411,75 @@ let get_metric_info = function
            number of trading days). Reported in percent·days.";
         unit = Ratio;
       }
+  | Skewness ->
+      {
+        display_name = "Skewness";
+        description =
+          "Third standardized moment of the per-step return distribution. \
+           Positive = heavier right tail (gains); negative = heavier left tail \
+           (losses).";
+        unit = Ratio;
+      }
+  | Kurtosis ->
+      {
+        display_name = "Kurtosis (Excess)";
+        description =
+          "Fourth standardized moment of the per-step return distribution \
+           minus 3. 0 = Gaussian; positive = fat-tailed; negative = \
+           thin-tailed.";
+        unit = Ratio;
+      }
+  | CVaR95 ->
+      {
+        display_name = "CVaR (95%)";
+        description =
+          "Conditional Value-at-Risk at 95% (Expected Shortfall): mean of the \
+           worst 5% of step returns.";
+        unit = Percent;
+      }
+  | CVaR99 ->
+      {
+        display_name = "CVaR (99%)";
+        description =
+          "Conditional Value-at-Risk at 99%: mean of the worst 1% of step \
+           returns.";
+        unit = Percent;
+      }
+  | TailRatio ->
+      {
+        display_name = "Tail Ratio";
+        description =
+          "mean(top 5% returns) / |mean(bottom 5% returns)|. > 1 means upside \
+           tail dominates downside tail.";
+        unit = Ratio;
+      }
+  | GainToPain ->
+      {
+        display_name = "Gain-to-Pain";
+        description =
+          "Sum of positive step returns divided by absolute sum of negative \
+           step returns. > 1 means cumulative gains exceed cumulative losses.";
+        unit = Ratio;
+      }
+  | ConcavityCoef ->
+      {
+        display_name = "Concavity Coefficient (γ)";
+        description =
+          "Antifragility coefficient from r_strat = α + β·r_bench + \
+           γ·r_bench². γ > 0 = convex/antifragile; γ < 0 = concave/fragile. \
+           Reported as 0 when no benchmark series is supplied.";
+        unit = Ratio;
+      }
+  | BucketAsymmetry ->
+      {
+        display_name = "Bucket Asymmetry";
+        description =
+          "(Q1 + Q5) / (Q2 + Q3 + Q4) of strategy step returns bucketed by \
+           benchmark quintile. > 1 means barbell (strategy concentrates \
+           returns in extremes). Reported as 0 when no benchmark series is \
+           supplied.";
+        unit = Ratio;
+      }
 
 let format_metric metric_type value =
   let info = get_metric_info metric_type in

--- a/trading/trading/simulation/lib/types/metric_types.ml
+++ b/trading/trading/simulation/lib/types/metric_types.ml
@@ -61,6 +61,14 @@ module Metric_type = struct
       | UlcerIndex
       | PainIndex
       | UnderwaterCurveArea
+      | Skewness
+      | Kurtosis
+      | CVaR95
+      | CVaR99
+      | TailRatio
+      | GainToPain
+      | ConcavityCoef
+      | BucketAsymmetry
     [@@deriving show, eq, compare, sexp]
   end
 
@@ -123,6 +131,14 @@ type metric_type = Metric_type.t =
   | UlcerIndex
   | PainIndex
   | UnderwaterCurveArea
+  | Skewness
+  | Kurtosis
+  | CVaR95
+  | CVaR99
+  | TailRatio
+  | GainToPain
+  | ConcavityCoef
+  | BucketAsymmetry
 [@@deriving show, eq, compare, sexp]
 
 include (Metric_type : Comparator.S with type t := metric_type)

--- a/trading/trading/simulation/lib/types/metric_types.mli
+++ b/trading/trading/simulation/lib/types/metric_types.mli
@@ -143,6 +143,46 @@ module Metric_type : sig
         (** Sum of per-day drawdown percent across the run (= [PainIndex]
             multiplied by the number of trading days). Reported in percent·days;
             useful as a raw integral when the period length is held constant. *)
+    (* ---- M5.2d distributional ---- *)
+    | Skewness
+        (** Third standardized moment of the per-step return distribution
+            ([E[(r - μ)^3] / σ^3]). [0.0] for a symmetric distribution; positive
+            means the right tail (gains) is heavier; negative means the left
+            tail (losses) is heavier. *)
+    | Kurtosis
+        (** Excess kurtosis of the per-step return distribution: the fourth
+            standardized moment ([E[(r - μ)^4] / σ^4]) minus 3. [0.0] for a
+            normal distribution; positive (leptokurtic) means fatter tails;
+            negative (platykurtic) means thinner tails. *)
+    | CVaR95
+        (** Conditional Value-at-Risk at 95% (also known as Expected Shortfall):
+            the mean of the worst 5% of step returns, in percent. Negative for a
+            losing tail. *)
+    | CVaR99
+        (** Conditional Value-at-Risk at 99%: the mean of the worst 1% of step
+            returns, in percent. Negative for a losing tail. *)
+    | TailRatio
+        (** [mean(top 5% returns) / |mean(bottom 5% returns)|]. > 1 means upside
+            tail dominates downside tail. Returns [Float.infinity] when the
+            bottom-5% mean is zero (no losses) and the top-5% mean is positive;
+            [0.0] when there are no returns to bucket. *)
+    | GainToPain
+        (** [Σ positive_step_returns / |Σ negative_step_returns|]. Returns
+            [Float.infinity] when there are gains but no losses; [0.0] when
+            there are no gains. *)
+    (* ---- M5.2d antifragility ---- *)
+    | ConcavityCoef
+        (** Antifragility coefficient (γ) from the quadratic regression
+            [r_strat = α + β·r_bench + γ·r_bench²]. [γ > 0] is convex /
+            antifragile; [γ < 0] is concave / fragile. Reported as [0.0] when no
+            benchmark series is supplied to the antifragility computer (the
+            default for stand-alone backtest runs without a benchmark feed). *)
+    | BucketAsymmetry
+        (** [(Q1_mean + Q5_mean) / (Q2_mean + Q3_mean + Q4_mean)] of strategy
+            step returns bucketed by benchmark step-return quintile. > 1 means
+            the strategy concentrates returns in the extremes (barbell); ≤ 1
+            means returns are concentrated in the middle. Reported as [0.0] when
+            no benchmark series is supplied. *)
   [@@deriving show, eq, compare, sexp]
 
   include Comparator.S with type t := t
@@ -204,6 +244,14 @@ type metric_type = Metric_type.t =
   | UlcerIndex
   | PainIndex
   | UnderwaterCurveArea
+  | Skewness
+  | Kurtosis
+  | CVaR95
+  | CVaR99
+  | TailRatio
+  | GainToPain
+  | ConcavityCoef
+  | BucketAsymmetry
 [@@deriving show, eq, compare, sexp]
 
 (** {1 Metric Set} *)

--- a/trading/trading/simulation/test/dune
+++ b/trading/trading/simulation/test/dune
@@ -251,3 +251,31 @@
   trading.portfolio
   types
   matchers))
+
+(test
+ (name test_distributional_computer)
+ (modules test_distributional_computer)
+ (libraries
+  ounit2
+  core
+  trading.simulation
+  trading.simulation.types
+  trading.base
+  trading.engine
+  trading.portfolio
+  types
+  matchers))
+
+(test
+ (name test_antifragility_computer)
+ (modules test_antifragility_computer)
+ (libraries
+  ounit2
+  core
+  trading.simulation
+  trading.simulation.types
+  trading.base
+  trading.engine
+  trading.portfolio
+  types
+  matchers))

--- a/trading/trading/simulation/test/test_antifragility_computer.ml
+++ b/trading/trading/simulation/test/test_antifragility_computer.ml
@@ -1,0 +1,152 @@
+(** Pinned tests for {!Antifragility_computer} (M5.2d).
+
+    Two acceptance gates from the M5.2d plan:
+
+    - convex synthetic strategy ([r_strat = r_bench²]) → γ > 0
+    - concave synthetic strategy ([r_strat = -r_bench²]) → γ < 0
+
+    Plus stand-alone defaults (no benchmark → 0.0), and a hand-pinned
+    bucket-asymmetry case. *)
+
+open OUnit2
+open Core
+open Trading_simulation_types.Metric_types
+open Matchers
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+let _date s = Date.of_string s
+
+let _make_step ~date ~portfolio_value : Simulator_types.step_result =
+  let portfolio =
+    Trading_portfolio.Portfolio.create ~initial_cash:10_000.0 ()
+  in
+  {
+    date;
+    portfolio;
+    portfolio_value;
+    trades = [];
+    orders_submitted = [];
+    splits_applied = [];
+  }
+
+let _config =
+  {
+    Simulator_types.start_date = _date "2024-01-01";
+    end_date = _date "2024-12-31";
+    initial_cash = 10_000.0;
+    commission = { Trading_engine.Types.per_share = 0.0; minimum = 0.0 };
+    strategy_cadence = Types.Cadence.Daily;
+  }
+
+let _run ?benchmark_returns steps =
+  let computer =
+    Trading_simulation.Antifragility_computer.computer ?benchmark_returns ()
+  in
+  computer.run ~config:_config ~steps
+
+(** Convert a list of consecutive percent returns into an [N+1]-sample equity
+    curve seeded at [10000]. The N returns recovered by the computer match the
+    input list. *)
+let _curve_from_returns ?(seed_value = 10_000.0) returns_pct =
+  let values =
+    List.fold returns_pct ~init:[ seed_value ] ~f:(fun acc r ->
+        let prev = List.hd_exn acc in
+        let next = prev *. (1.0 +. (r /. 100.0)) in
+        next :: acc)
+    |> List.rev
+  in
+  List.mapi values ~f:(fun i v ->
+      _make_step ~date:(Date.add_days (_date "2024-01-02") i) ~portfolio_value:v)
+
+(* ==================== No-benchmark default ==================== *)
+
+let test_no_benchmark_yields_zero _ =
+  let steps = _curve_from_returns [ 1.0; -2.0; 3.0; -1.0; 2.0; -1.0 ] in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [ (ConcavityCoef, float_equal 0.0); (BucketAsymmetry, float_equal 0.0) ])
+
+(* ==================== Insufficient samples ==================== *)
+
+(** Only 4 paired returns → below [_min_paired_samples = 5] → both metrics fall
+    back to 0.0. *)
+let test_too_few_samples _ =
+  let steps = _curve_from_returns [ 1.0; -1.0; 2.0; -2.0 ] in
+  let metrics = _run ~benchmark_returns:[ 1.0; -1.0; 2.0; -2.0 ] steps in
+  assert_that metrics
+    (map_includes
+       [ (ConcavityCoef, float_equal 0.0); (BucketAsymmetry, float_equal 0.0) ])
+
+(* ==================== Convex strategy → γ > 0 ==================== *)
+
+(** Convex strategy: [r_strat = r_bench²]. The OLS quadratic fit recovers
+    [α = 0, β = 0, γ = 1]. We verify γ > 0 (the acceptance gate from the M5.2d
+    plan); we also pin γ ≈ 1.0 within a generous tolerance because the
+    constructed inputs satisfy the model exactly. *)
+let test_convex_strategy_gamma_positive _ =
+  let bench = [ -3.0; -2.0; -1.0; 0.0; 1.0; 2.0; 3.0 ] in
+  let strat = List.map bench ~f:(fun r -> r *. r) in
+  let steps = _curve_from_returns strat in
+  let metrics = _run ~benchmark_returns:bench steps in
+  let gamma = Map.find_exn metrics ConcavityCoef in
+  assert_that gamma (gt (module Float_ord) 0.0);
+  assert_that gamma (float_equal ~epsilon:1e-3 1.0)
+
+(* ==================== Concave strategy → γ < 0 ==================== *)
+
+(** Concave strategy: [r_strat = -r_bench²]. The OLS fit recovers [γ = -1]. *)
+let test_concave_strategy_gamma_negative _ =
+  let bench = [ -3.0; -2.0; -1.0; 0.0; 1.0; 2.0; 3.0 ] in
+  let strat = List.map bench ~f:(fun r -> -.(r *. r)) in
+  let steps = _curve_from_returns strat in
+  let metrics = _run ~benchmark_returns:bench steps in
+  let gamma = Map.find_exn metrics ConcavityCoef in
+  assert_that gamma (lt (module Float_ord) 0.0);
+  assert_that gamma (float_equal ~epsilon:1e-3 (-1.0))
+
+(* ==================== Linear strategy → γ ≈ 0 ==================== *)
+
+(** Linear strategy: [r_strat = 2 × r_bench]. Quadratic fit recovers [γ ≈ 0]. *)
+let test_linear_strategy_gamma_zero _ =
+  let bench = [ -3.0; -2.0; -1.0; 0.0; 1.0; 2.0; 3.0 ] in
+  let strat = List.map bench ~f:(fun r -> 2.0 *. r) in
+  let steps = _curve_from_returns strat in
+  let metrics = _run ~benchmark_returns:bench steps in
+  let gamma = Map.find_exn metrics ConcavityCoef in
+  assert_that gamma (float_equal ~epsilon:1e-3 0.0)
+
+(* ==================== Bucket asymmetry ==================== *)
+
+(** Build 10 paired samples (2 per quintile when sorted by benchmark).
+    Benchmarks (sorted): [-5, -4, -3, -2, -1, 1, 2, 3, 4, 5]
+    Buckets (Q1..Q5):   {-5,-4} {-3,-2} {-1,1} {2,3} {4,5}
+    Strategy values constructed so that bucket means are
+      Q1=10, Q2=2, Q3=2, Q4=2, Q5=10
+    BucketAsymmetry = (10 + 10) / (2 + 2 + 2) = 20 / 6 ≈ 3.3333. *)
+let test_bucket_asymmetry_barbell _ =
+  let bench = [ -5.0; -4.0; -3.0; -2.0; -1.0; 1.0; 2.0; 3.0; 4.0; 5.0 ] in
+  (* Strategy returns in the same chronological position as the benchmarks
+     (after sort: Q1 mean 10, Q2 2, Q3 2, Q4 2, Q5 10). *)
+  let strat = [ 10.0; 10.0; 2.0; 2.0; 2.0; 2.0; 2.0; 2.0; 10.0; 10.0 ] in
+  let steps = _curve_from_returns strat in
+  let metrics = _run ~benchmark_returns:bench steps in
+  assert_that
+    (Map.find metrics BucketAsymmetry)
+    (is_some_and (float_equal ~epsilon:1e-3 (20.0 /. 6.0)))
+
+let suite =
+  "Antifragility_computer"
+  >::: [
+         "no benchmark → both metrics 0.0" >:: test_no_benchmark_yields_zero;
+         "too few paired samples → both metrics 0.0" >:: test_too_few_samples;
+         "convex strategy (r_strat = r_bench²) → γ > 0"
+         >:: test_convex_strategy_gamma_positive;
+         "concave strategy (r_strat = -r_bench²) → γ < 0"
+         >:: test_concave_strategy_gamma_negative;
+         "linear strategy → γ ≈ 0" >:: test_linear_strategy_gamma_zero;
+         "bucket asymmetry barbell (Q1+Q5 dominate) → 3.333"
+         >:: test_bucket_asymmetry_barbell;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/simulation/test/test_distributional_computer.ml
+++ b/trading/trading/simulation/test/test_distributional_computer.ml
@@ -1,0 +1,220 @@
+(** Pinned tests for {!Distributional_computer} (M5.2d).
+
+    Each test pins the entire output set against hand-computed values. Test
+    inputs are short, hand-pickable curves so all moments / tails fit on paper.
+*)
+
+open OUnit2
+open Core
+open Trading_simulation_types.Metric_types
+open Matchers
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+let _date s = Date.of_string s
+
+let _make_step ~date ~portfolio_value : Simulator_types.step_result =
+  let portfolio =
+    Trading_portfolio.Portfolio.create ~initial_cash:10_000.0 ()
+  in
+  {
+    date;
+    portfolio;
+    portfolio_value;
+    trades = [];
+    orders_submitted = [];
+    splits_applied = [];
+  }
+
+let _config =
+  {
+    Simulator_types.start_date = _date "2024-01-01";
+    end_date = _date "2024-12-31";
+    initial_cash = 10_000.0;
+    commission = { Trading_engine.Types.per_share = 0.0; minimum = 0.0 };
+    strategy_cadence = Types.Cadence.Daily;
+  }
+
+let _run steps =
+  let computer = Trading_simulation.Distributional_computer.computer () in
+  computer.run ~config:_config ~steps
+
+(** Build a synthetic equity curve from a list of consecutive percent returns:
+    [seed_value × Π (1 + r_i / 100)]. The first sample is [seed_value], then one
+    sample per return — the [N+1]-sample curve produces exactly the [N] input
+    returns when fed to the computer. Dates are auto-incremented from
+    [2024-01-02] in trading-day order. *)
+let _curve_from_returns ?(seed_value = 10_000.0) returns_pct =
+  let values =
+    List.fold returns_pct ~init:[ seed_value ] ~f:(fun acc r ->
+        let prev = List.hd_exn acc in
+        let next = prev *. (1.0 +. (r /. 100.0)) in
+        next :: acc)
+    |> List.rev
+  in
+  List.mapi values ~f:(fun i v ->
+      _make_step ~date:(Date.add_days (_date "2024-01-02") i) ~portfolio_value:v)
+
+(* ==================== Empty / degenerate inputs ==================== *)
+
+let test_empty_steps_yields_zero_metrics _ =
+  let metrics = _run [] in
+  assert_that metrics
+    (map_includes
+       [
+         (Skewness, float_equal 0.0);
+         (Kurtosis, float_equal 0.0);
+         (CVaR95, float_equal 0.0);
+         (CVaR99, float_equal 0.0);
+         (TailRatio, float_equal 0.0);
+         (GainToPain, float_equal 0.0);
+       ])
+
+(** Single-step input: no returns can be derived. All metrics fall back to zero.
+*)
+let test_single_step_yields_zero _ =
+  let steps =
+    [ _make_step ~date:(_date "2024-01-02") ~portfolio_value:10_000.0 ]
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (Skewness, float_equal 0.0);
+         (Kurtosis, float_equal 0.0);
+         (TailRatio, float_equal 0.0);
+         (GainToPain, float_equal 0.0);
+       ])
+
+(** Constant equity curve → all returns 0; variance is 0; skew/kurt fall back to
+    0; gain-to-pain falls back to 0 (no gains, no losses). *)
+let test_flat_curve _ =
+  let steps = _curve_from_returns [ 0.0; 0.0; 0.0; 0.0 ] in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (Skewness, float_equal 0.0);
+         (Kurtosis, float_equal 0.0);
+         (GainToPain, float_equal 0.0);
+       ])
+
+(* ==================== Symmetric distribution ==================== *)
+
+(** Returns [-1, +1, -1, +1]. Mean 0; variance 1; m3 = 0; m4 = 1. Skewness = 0 /
+    1 = 0. Kurtosis (excess) = (1 / 1) - 3 = -2. The two tail-cut metrics use
+    [floor(4 × 0.05) = 0] elements → both fall back to 0.0. GainToPain = 2 / 2 =
+    1.0. *)
+let test_symmetric_distribution _ =
+  let steps = _curve_from_returns [ -1.0; 1.0; -1.0; 1.0 ] in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (Skewness, float_equal ~epsilon:1e-6 0.0);
+         (Kurtosis, float_equal ~epsilon:1e-6 (-2.0));
+         (GainToPain, float_equal ~epsilon:1e-6 1.0);
+         (CVaR95, float_equal 0.0);
+         (CVaR99, float_equal 0.0);
+         (TailRatio, float_equal 0.0);
+       ])
+
+(* ==================== Right-skewed distribution ==================== *)
+
+(** Returns [-1, -1, -1, 3]. Mean = 0; variance = ((1 + 1 + 1 + 9) / 4) = 3.
+    m3 = (-1 -1 -1 + 27) / 4 = 24 / 4 = 6. Skewness = 6 / pow(3, 1.5) ≈ 1.1547.
+    m4 = (1 + 1 + 1 + 81) / 4 = 21. Kurtosis (excess) = 21 / 9 - 3 ≈ -0.6667.
+    GainToPain = 3 / 3 = 1.0. *)
+let test_right_skewed _ =
+  let steps = _curve_from_returns [ -1.0; -1.0; -1.0; 3.0 ] in
+  let metrics = _run steps in
+  let var = 3.0 in
+  let sigma = Float.sqrt var in
+  let expected_skew = 6.0 /. (sigma *. sigma *. sigma) in
+  let expected_kurt = (21.0 /. (var *. var)) -. 3.0 in
+  assert_that metrics
+    (map_includes
+       [
+         (Skewness, float_equal ~epsilon:1e-4 expected_skew);
+         (Kurtosis, float_equal ~epsilon:1e-4 expected_kurt);
+         (GainToPain, float_equal ~epsilon:1e-6 1.0);
+       ])
+
+(* ==================== Tail-cut metrics ==================== *)
+
+(** 100 returns: 95 zeros and 5 large drops of -10%. With 100 samples,
+    [floor(100 × 0.05) = 5] → CVaR95 averages the worst 5 (= -10%).
+    [floor(100 × 0.01) = 1] → CVaR99 averages the worst 1 (= -10%). Top-5% mean
+    = 0 (best 5 are zeros) → TailRatio = 0/10 = 0.0. GainToPain = 0/(5×10) = 0.
+*)
+let test_cvar_with_known_tail _ =
+  let returns =
+    List.init 95 ~f:(fun _ -> 0.0) @ List.init 5 ~f:(fun _ -> -10.0)
+  in
+  let steps = _curve_from_returns returns in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (CVaR95, float_equal ~epsilon:1e-6 (-10.0));
+         (CVaR99, float_equal ~epsilon:1e-6 (-10.0));
+         (TailRatio, float_equal 0.0);
+         (GainToPain, float_equal 0.0);
+       ])
+
+(** Tail ratio with known top + bottom: 5 returns of +10%, 90 of 0, 5 of -5%.
+    Top-5% = 10; Bottom-5% = -5; ratio = 10 / 5 = 2.0. *)
+let test_tail_ratio_asymmetric _ =
+  let returns =
+    List.init 5 ~f:(fun _ -> 10.0)
+    @ List.init 90 ~f:(fun _ -> 0.0)
+    @ List.init 5 ~f:(fun _ -> -5.0)
+  in
+  let steps = _curve_from_returns returns in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (TailRatio, float_equal ~epsilon:1e-6 2.0);
+         (CVaR95, float_equal ~epsilon:1e-6 (-5.0));
+       ])
+
+(* ==================== Gain-to-pain edge cases ==================== *)
+
+(** All-positive returns → GainToPain is infinity. *)
+let test_gain_to_pain_all_positive_is_infinity _ =
+  let steps = _curve_from_returns [ 1.0; 2.0; 3.0 ] in
+  let metrics = _run steps in
+  assert_that
+    (Map.find metrics GainToPain)
+    (is_some_and (equal_to Float.infinity))
+
+(** Asymmetric gains/losses: gains sum to 6, losses sum to 2 → GainToPain = 3.0.
+*)
+let test_gain_to_pain_asymmetric _ =
+  let steps = _curve_from_returns [ 1.0; 2.0; 3.0; -2.0 ] in
+  let metrics = _run steps in
+  let gtp = 6.0 /. 2.0 in
+  assert_that
+    (Map.find metrics GainToPain)
+    (is_some_and (float_equal ~epsilon:1e-6 gtp))
+
+let suite =
+  "Distributional_computer"
+  >::: [
+         "empty steps yields zero metrics"
+         >:: test_empty_steps_yields_zero_metrics;
+         "single step yields zero" >:: test_single_step_yields_zero;
+         "flat curve → all zero" >:: test_flat_curve;
+         "symmetric ±1 returns: skew=0, excess kurt=-2, gtp=1.0"
+         >:: test_symmetric_distribution;
+         "right-skewed [-1,-1,-1,3]: pinned skew + kurt" >:: test_right_skewed;
+         "CVaR with known tail (95 zeros + 5 drops of -10)"
+         >:: test_cvar_with_known_tail;
+         "tail ratio asymmetric (top=+10 / bottom=-5 → 2.0)"
+         >:: test_tail_ratio_asymmetric;
+         "gain-to-pain all-positive → infinity"
+         >:: test_gain_to_pain_all_positive_is_infinity;
+         "gain-to-pain asymmetric (6/2 = 3.0)" >:: test_gain_to_pain_asymmetric;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -584,8 +584,9 @@ let test_default_computers _ =
   let computers = default_computers () in
   (* Default set: summary, sharpe, max_drawdown, cagr, portfolio_state,
      trade_aggregates (M5.2b), return_basics (M5.2b), omega_ratio (M5.2c),
-     drawdown_analytics (M5.2c). *)
-  assert_that computers (size_is 9)
+     drawdown_analytics (M5.2c), distributional (M5.2d), antifragility
+     (M5.2d). *)
+  assert_that computers (size_is 11)
 
 (* ==================== Factory Tests ==================== *)
 


### PR DESCRIPTION
## Summary

Adds two new step-based computers landing 8 new metric types in the M5.2 framework, completing M5.2d per `dev/plans/m5-experiments-roadmap-2026-05-02.md` §M5.2d.

**Distributional (6):** `Skewness`, `Kurtosis` (excess), `CVaR95`, `CVaR99`, `TailRatio`, `GainToPain`.

**Antifragility (2):** `ConcavityCoef` (γ from quadratic OLS — Taleb's antifragility measure), `BucketAsymmetry` (barbell/middle-heavy ratio across benchmark quintiles).

## Why

Closes the M5.2 metrics catalog with the distributional + antifragility block called out in the roadmap. The concavity coefficient is the novel measure — γ > 0 indicates a strategy that gains more than linearly in benchmark extremes (antifragile per Taleb); γ < 0 indicates a fragile/concave response. This unblocks experiments that want to evaluate strategy variants on convexity in addition to mean/variance.

## Benchmark plumbing — deferred

The simulator's `step_result` has no benchmark return field; adding one would be invasive (touches `Simulator_types`, every step-result constructor, every test). For this PR the antifragility computer accepts the benchmark series via an optional `?benchmark_returns` argument at construction time. When `None` (the default in `default_computers`) both `ConcavityCoef` and `BucketAsymmetry` emit `0.0`. Tests pass synthetic benchmark series directly. The .mli documents the deferral and the next-PR migration path (read benchmark from `config`).

## Implementation notes

- **OLS for γ**: closed-form 3×3 Cramer's rule on the moment-sum matrix `XᵀX` with predictors `(1, x, x²)`. Numerically stable for single-digit-percent returns; degenerate matrices (`det < 1e-12`) fall back to `γ = 0`.
- **Pure functions**: same step list (+ same benchmark series) → same output.
- **Cadence-agnostic**: distributional metrics are unitless or per-step — annualization NOT applicable.

## Test plan

- [x] 9 hand-pinned cases for distributional: empty / single-step / flat / symmetric / right-skewed / hand-tail / asymmetric tail / all-positive infinity / asymmetric gain-to-pain
- [x] 6 cases for antifragility: no-benchmark default, too-few-samples, convex (γ > 0), concave (γ < 0), linear (γ ≈ 0), barbell `BucketAsymmetry` ≈ 3.33
- [x] Convex / concave acceptance gate from the M5.2d plan: synthetic `r_strat = ±r_bench²` recovers γ ≈ ±1.0
- [x] `dune build && dune runtest trading/simulation && dune runtest trading/backtest` — green
- [x] `dune build @fmt` — clean
- [x] `default_computers` count test bumped from 9 → 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)