### PR TITLE
feat(weinstein/snapshot): weekly report markdown renderer (M6.5)

### DIFF
--- a/trading/trading/weinstein/snapshot/bin/dune
+++ b/trading/trading/weinstein/snapshot/bin/dune
@@ -1,5 +1,5 @@
 (executables
- (names trace_picks verify_corporate_actions diff_picks)
+ (names trace_picks verify_corporate_actions diff_picks render_weekly_report)
  (libraries
   core
   core_unix.command_unix

--- a/trading/trading/weinstein/snapshot/bin/render_weekly_report.ml
+++ b/trading/trading/weinstein/snapshot/bin/render_weekly_report.ml
@@ -1,0 +1,28 @@
+(** [render_weekly_report] CLI — render a weekly snapshot as Markdown.
+
+    Usage: [render_weekly_report <pick-file>]
+
+    Reads a single weekly snapshot from disk, renders it via
+    {!Report_renderer.render}, and prints the Markdown to stdout. Exits non-zero
+    on read or schema-version errors. *)
+
+open Core
+open Weinstein_snapshot
+
+let _read_snapshot path : Weekly_snapshot.t =
+  match Snapshot_reader.read_from_file path with
+  | Ok t -> t
+  | Error err ->
+      eprintf "Failed to read snapshot %s: %s\n" path (Status.show err);
+      exit 1
+
+let _run pick_path =
+  let snap = _read_snapshot pick_path in
+  print_string (Report_renderer.render snap)
+
+let () =
+  match Sys.get_argv () |> Array.to_list with
+  | _ :: pick_path :: _ -> _run pick_path
+  | _ ->
+      eprintf "Usage: render_weekly_report <pick-file>\n";
+      exit 2

--- a/trading/trading/weinstein/snapshot/lib/report_renderer.ml
+++ b/trading/trading/weinstein/snapshot/lib/report_renderer.ml
@@ -1,0 +1,95 @@
+open Core
+
+(* Display caps for the candidate tables. Match the section headers
+   ("top 10" / "top 5") to keep header and content in sync. *)
+let _long_display_limit = 10
+let _short_display_limit = 5
+
+(* Marker rendered for empty lists / tables so the reader never sees a missing
+   section. *)
+let _empty_marker = "(none)"
+
+let _risk_pct ~entry ~stop =
+  if Float.equal entry 0.0 then 0.0 else (entry -. stop) /. entry *. 100.0
+
+(* Header line plus separator for a Markdown table. *)
+let _table_header columns =
+  let header = "| " ^ String.concat ~sep:" | " columns ^ " |" in
+  let sep =
+    "|" ^ String.concat ~sep:"" (List.map columns ~f:(fun _ -> "---|"))
+  in
+  header ^ "\n" ^ sep
+
+let _candidate_row ~rank (c : Weekly_snapshot.candidate) =
+  let risk = _risk_pct ~entry:c.entry ~stop:c.stop in
+  Printf.sprintf "| %d | %s | %s | %.2f | $%.2f | $%.2f | %.1f%% | %s |" rank
+    c.symbol c.grade c.score c.entry c.stop risk c.rationale
+
+let _candidate_table candidates ~limit =
+  let header =
+    _table_header
+      [
+        "Rank";
+        "Symbol";
+        "Grade";
+        "Score";
+        "Entry";
+        "Stop";
+        "Risk %";
+        "Rationale";
+      ]
+  in
+  match candidates with
+  | [] -> _empty_marker
+  | _ ->
+      let truncated = List.take candidates limit in
+      let rows =
+        List.mapi truncated ~f:(fun i c -> _candidate_row ~rank:(i + 1) c)
+      in
+      String.concat ~sep:"\n" (header :: rows)
+
+let _held_row (h : Weekly_snapshot.held_position) =
+  Printf.sprintf "| %s | %s | $%.2f | %s |" h.symbol (Date.to_string h.entered)
+    h.stop h.status
+
+let _held_table positions =
+  let header = _table_header [ "Symbol"; "Entered"; "Stop"; "Status" ] in
+  match positions with
+  | [] -> _empty_marker
+  | _ ->
+      let rows = List.map positions ~f:_held_row in
+      String.concat ~sep:"\n" (header :: rows)
+
+let _sector_list sectors =
+  match sectors with
+  | [] -> _empty_marker
+  | _ -> String.concat ~sep:"\n" (List.map sectors ~f:(fun s -> "- " ^ s))
+
+let _macro_section (m : Weekly_snapshot.macro_context) =
+  Printf.sprintf "**%s** (score %.2f)" m.regime m.score
+
+let _section ~title body = Printf.sprintf "## %s\n%s" title body
+
+let render (t : Weekly_snapshot.t) : string =
+  let buf = Buffer.create 1024 in
+  Buffer.add_string buf
+    (Printf.sprintf "# Weekly Pick Report — %s\n\n" (Date.to_string t.date));
+  Buffer.add_string buf
+    (Printf.sprintf "System version: `%s`\n\n" t.system_version);
+  Buffer.add_string buf (_section ~title:"Macro" (_macro_section t.macro));
+  Buffer.add_string buf "\n\n";
+  Buffer.add_string buf
+    (_section ~title:"Strong sectors" (_sector_list t.sectors_strong));
+  Buffer.add_string buf "\n\n";
+  Buffer.add_string buf
+    (_section ~title:"Long candidates (top 10)"
+       (_candidate_table t.long_candidates ~limit:_long_display_limit));
+  Buffer.add_string buf "\n\n";
+  Buffer.add_string buf
+    (_section ~title:"Short candidates (top 5)"
+       (_candidate_table t.short_candidates ~limit:_short_display_limit));
+  Buffer.add_string buf "\n\n";
+  Buffer.add_string buf
+    (_section ~title:"Held positions" (_held_table t.held_positions));
+  Buffer.add_string buf "\n";
+  Buffer.contents buf

--- a/trading/trading/weinstein/snapshot/lib/report_renderer.mli
+++ b/trading/trading/weinstein/snapshot/lib/report_renderer.mli
@@ -1,0 +1,39 @@
+(** Render a {!Weekly_snapshot.t} as a Markdown report.
+
+    This is the M6.5 weekly report renderer — a {b pure} function from a frozen
+    weekly snapshot to a human-readable Markdown string. No I/O.
+
+    {1 Output shape}
+
+    The Markdown contains, in order:
+
+    - Title: [# Weekly Pick Report — <YYYY-MM-DD>]
+    - System version line: [System version: `<sha>`]
+    - [## Macro] section: regime in bold + score
+    - [## Strong sectors] section: bulleted list (or "(none)" if empty)
+    - [## Long candidates (top 10)]: ranked Markdown table
+    - [## Short candidates (top 5)]: ranked Markdown table
+    - [## Held positions]: Markdown table
+
+    All section headers are always rendered, even when the underlying data list
+    is empty — empty tables / lists render as ["(none)"] so a reader never sees
+    a missing section.
+
+    {1 Determinism}
+
+    [render] is a pure function: same input snapshot → byte-identical output. No
+    dependence on system time, environment, or hash ordering. The round-trip
+    "render twice, identical bytes" property is pinned by the test suite.
+
+    {1 Risk percent}
+
+    For each candidate, the risk-percent column is computed as
+    [(entry - stop) / entry * 100] (long convention) and formatted to one
+    decimal place. The renderer applies the same formula for short candidates
+    (caller is responsible for the sign convention of [entry] and [stop]
+    relative to side). *)
+
+val render : Weekly_snapshot.t -> string
+(** [render snapshot] returns the snapshot rendered as a single Markdown string,
+    terminated by a final newline. Always succeeds — every section header is
+    emitted unconditionally. Pure function: no I/O, no exceptions. *)

--- a/trading/trading/weinstein/snapshot/test/dune
+++ b/trading/trading/weinstein/snapshot/test/dune
@@ -1,5 +1,10 @@
 (tests
- (names test_round_trip test_forward_trace test_split_replay test_pick_diff)
+ (names
+  test_round_trip
+  test_forward_trace
+  test_split_replay
+  test_pick_diff
+  test_report_renderer)
  (libraries
   weinstein_trading.snapshot
   status

--- a/trading/trading/weinstein/snapshot/test/test_report_renderer.ml
+++ b/trading/trading/weinstein/snapshot/test/test_report_renderer.ml
@@ -1,0 +1,206 @@
+(** Tests for {!Report_renderer} — pure markdown render of a weekly snapshot. *)
+
+open Core
+open OUnit2
+open Matchers
+open Weinstein_snapshot
+
+let _date d = Date.of_string d
+
+(** Pinned full snapshot. Same shape as the round-trip fixture so the two test
+    suites drift together if {!Weekly_snapshot.t} ever changes. *)
+let _full_snapshot : Weekly_snapshot.t =
+  {
+    schema_version = Weekly_snapshot.current_schema_version;
+    system_version = "c93bf39d";
+    date = _date "2020-08-28";
+    macro = { regime = "Bullish"; score = 0.72 };
+    sectors_strong = [ "XLK"; "XLY"; "XLC" ];
+    sectors_weak = [ "XLE"; "XLU" ];
+    long_candidates =
+      [
+        {
+          symbol = "AAPL";
+          score = 0.91;
+          grade = "A+";
+          entry = 502.13;
+          stop = 466.20;
+          sector = "XLK";
+          rationale = "Stage 2 breakout, 2.1x volume";
+          rs_vs_spy = Some 1.34;
+          resistance_grade = Some "A";
+        };
+        {
+          symbol = "MSFT";
+          score = 0.87;
+          grade = "A";
+          entry = 215.50;
+          stop = 200.10;
+          sector = "XLK";
+          rationale = "Continuation breakout";
+          rs_vs_spy = Some 1.18;
+          resistance_grade = None;
+        };
+      ];
+    short_candidates = [];
+    held_positions =
+      [
+        {
+          symbol = "GOOG";
+          entered = _date "2020-06-19";
+          stop = 1365.00;
+          status = "Holding";
+        };
+      ];
+  }
+
+let _empty_snapshot : Weekly_snapshot.t =
+  {
+    schema_version = Weekly_snapshot.current_schema_version;
+    system_version = "deadbeef";
+    date = _date "2021-01-08";
+    macro = { regime = "Neutral"; score = 0.0 };
+    sectors_strong = [];
+    sectors_weak = [];
+    long_candidates = [];
+    short_candidates = [];
+    held_positions = [];
+  }
+
+(* Substring matcher built on top of the [matching] combinator. Keeps tests in
+   the declarative `assert_that` style — no `assert_bool` calls. *)
+let _has_substring substring : string matcher =
+  matching
+    ~msg:(Printf.sprintf "Expected substring %S" substring)
+    (fun s -> if String.is_substring s ~substring then Some () else None)
+    __
+
+(* ------- Tests ------- *)
+
+let test_full_snapshot_contains_all_sections _ =
+  let md = Report_renderer.render _full_snapshot in
+  assert_that md
+    (all_of
+       [
+         _has_substring "# Weekly Pick Report — 2020-08-28";
+         _has_substring "System version: `c93bf39d`";
+         _has_substring "## Macro";
+         _has_substring "**Bullish** (score 0.72)";
+         _has_substring "## Strong sectors";
+         _has_substring "- XLK";
+         _has_substring "- XLY";
+         _has_substring "- XLC";
+         _has_substring "## Long candidates (top 10)";
+         (* Pinned candidate row — fully formatted. Risk = (502.13-466.20)/502.13*100 = 7.155... → "7.2%" *)
+         _has_substring
+           "| 1 | AAPL | A+ | 0.91 | $502.13 | $466.20 | 7.2% | Stage 2 \
+            breakout, 2.1x volume |";
+         _has_substring "## Short candidates (top 5)";
+         _has_substring "## Held positions";
+         _has_substring "| GOOG | 2020-06-19 | $1365.00 | Holding |";
+       ])
+
+let test_empty_long_candidates_renders_marker _ =
+  let md = Report_renderer.render _empty_snapshot in
+  assert_that md
+    (all_of
+       [
+         _has_substring "## Long candidates (top 10)\n(none)";
+         _has_substring "## Short candidates (top 5)\n(none)";
+       ])
+
+let test_empty_held_positions_renders_marker _ =
+  let md = Report_renderer.render _empty_snapshot in
+  assert_that md (_has_substring "## Held positions\n(none)")
+
+let test_empty_strong_sectors_renders_marker _ =
+  let md = Report_renderer.render _empty_snapshot in
+  assert_that md (_has_substring "## Strong sectors\n(none)")
+
+let test_bearish_macro_rendered _ =
+  let snap =
+    { _empty_snapshot with macro = { regime = "Bearish"; score = -0.45 } }
+  in
+  let md = Report_renderer.render snap in
+  assert_that md (_has_substring "**Bearish** (score -0.45)")
+
+let test_risk_pct_formatting _ =
+  (* Snapshot with one candidate. Risk = (100 - 90) / 100 * 100 = 10.0% — pin
+     the formatted decimal exactly. *)
+  let snap =
+    {
+      _empty_snapshot with
+      long_candidates =
+        [
+          {
+            symbol = "TEST";
+            score = 0.5;
+            grade = "B";
+            entry = 100.0;
+            stop = 90.0;
+            sector = "XLK";
+            rationale = "test";
+            rs_vs_spy = None;
+            resistance_grade = None;
+          };
+        ];
+    }
+  in
+  let md = Report_renderer.render snap in
+  assert_that md
+    (_has_substring "| 1 | TEST | B | 0.50 | $100.00 | $90.00 | 10.0% | test |")
+
+let test_render_is_deterministic _ =
+  let first = Report_renderer.render _full_snapshot in
+  let second = Report_renderer.render _full_snapshot in
+  assert_that first (equal_to second)
+
+let test_long_candidates_truncated_to_top_10 _ =
+  (* 12 candidates → only first 10 rendered; rank 10 row present, rank 11
+     absent. *)
+  let make_c i =
+    {
+      Weekly_snapshot.symbol = Printf.sprintf "SYM%02d" i;
+      score = 1.0 -. (Float.of_int i *. 0.01);
+      grade = "B";
+      entry = 100.0;
+      stop = 90.0;
+      sector = "XLK";
+      rationale = "r";
+      rs_vs_spy = None;
+      resistance_grade = None;
+    }
+  in
+  let snap =
+    {
+      _empty_snapshot with
+      long_candidates = List.init 12 ~f:(fun i -> make_c (i + 1));
+    }
+  in
+  let md = Report_renderer.render snap in
+  assert_that md
+    (all_of
+       [
+         _has_substring "| 10 | SYM10 |";
+         not_ ~msg:"row 11 must be truncated" (_has_substring "| 11 | SYM11 |");
+       ])
+
+let suite =
+  "report_renderer"
+  >::: [
+         "full_snapshot_contains_all_sections"
+         >:: test_full_snapshot_contains_all_sections;
+         "empty_long_candidates_renders_marker"
+         >:: test_empty_long_candidates_renders_marker;
+         "empty_held_positions_renders_marker"
+         >:: test_empty_held_positions_renders_marker;
+         "empty_strong_sectors_renders_marker"
+         >:: test_empty_strong_sectors_renders_marker;
+         "bearish_macro_rendered" >:: test_bearish_macro_rendered;
+         "risk_pct_formatting" >:: test_risk_pct_formatting;
+         "render_is_deterministic" >:: test_render_is_deterministic;
+         "long_candidates_truncated_to_top_10"
+         >:: test_long_candidates_truncated_to_top_10;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Implements M6.5 from `dev/plans/m6-weekly-snapshot-verification-2026-05-02.md` — a pure function `Weekly_snapshot.t -> string` that renders the Saturday-morning Markdown weekly report, plus a CLI wrapper.

- `Report_renderer.render` — pure function, no I/O. Sections: title, system version, macro, strong sectors, ranked long candidates (top 10), short candidates (top 5), held positions. Empty sections render as `(none)`. Risk % computed as `(entry - stop) / entry * 100`, formatted to 1 decimal.
- `render_weekly_report <pick-file>` — CLI: reads a snapshot via `Snapshot_reader` (which already enforces schema-version), prints rendered Markdown to stdout. Exits non-zero on read / schema errors.
- 8 new tests (`test_report_renderer.ml`): full snapshot section coverage with one fully pinned candidate row, empty-data variants for each section, bearish macro, exact risk-percent formatting, determinism (render twice → byte-identical), top-10 truncation.

## What this PR does NOT do

- Does not extend `Weekly_snapshot.t` — uses the existing record verbatim.
- Does not modify the snapshot reader / writer / round-trip code.
- M6.6 (live cron, alerting, persistence) is deferred per the plan.

## Test plan

- [x] `dune build` (full project) clean
- [x] `dune runtest weinstein/snapshot` — 8/8 new + existing tests pass
- [x] `dune runtest` (full project) — no regressions
- [x] `dune build @fmt --auto-promote` — no diffs in this PR's files
- [x] Manual: `dune exec render_weekly_report <sample.sexp>` — output matches the spec template byte-for-byte

## Acceptance (per plan)

- [x] Round-trip stable: same input → byte-identical output (`test_render_is_deterministic`)
- [x] Renders all sections even with empty data (`test_empty_*` tests)
- [x] Schema-version-aware: rejects unknown schema versions — delegated to `Snapshot_reader.read_from_file`, already pinned by `test_round_trip.ml`