### PR TITLE
feat(metrics): plumb benchmark returns through simulator for antifragility

### DIFF
--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -140,6 +140,7 @@ let _make_step ~date ~portfolio ?(splits_applied = []) () :
     trades = [];
     orders_submitted = [];
     splits_applied;
+    benchmark_return = None;
   }
 
 (** Read a header-and-rows CSV back as [(header_columns, row_columns_list)].

--- a/trading/trading/backtest/test/test_runner_filter.ml
+++ b/trading/trading/backtest/test/test_runner_filter.ml
@@ -46,6 +46,7 @@ let _make_step_with_trades ~date ~portfolio ~trades =
     trades;
     orders_submitted = [];
     splits_applied = [];
+    benchmark_return = None;
   }
 
 (* -------------------------------------------------------------------- *)

--- a/trading/trading/simulation/lib/antifragility_computer.ml
+++ b/trading/trading/simulation/lib/antifragility_computer.ml
@@ -16,8 +16,19 @@ let _det_tolerance = 1e-12
 
 type state = {
   portfolio_values : float list;  (** Reversed: head is most recent. *)
-  benchmark_returns : float list option;
-      (** Chronological. None = no plumbing. *)
+  step_benchmark_returns : float list;
+      (** Reversed: head is most recent. Accumulated from each trading step's
+          [step.benchmark_return] (filtering out [None]s) so the metric can
+          read the benchmark series straight from the simulator without an
+          out-of-band override. Aligned to [portfolio_values] only when every
+          trading step carries a benchmark; otherwise the alignment helper
+          truncates to the shorter length. *)
+  benchmark_returns_override : float list option;
+      (** Optional explicit benchmark series supplied at construction. When
+          [Some], it takes precedence over [step_benchmark_returns]; when
+          [None] the step-sourced series is used. The override path supports
+          synthetic tests that pin specific benchmark values without going
+          through the simulator. *)
 }
 
 let _step_returns_pct values =
@@ -159,7 +170,7 @@ let _empty_metric_set () =
 
 let _build_metrics ~strat_returns ~benchmark_returns =
   match benchmark_returns with
-  | None -> _empty_metric_set ()
+  | None | Some [] -> _empty_metric_set ()
   | Some bench ->
       let pairs = _align_pairs strat_returns bench in
       Metric_types.of_alist_exn
@@ -168,24 +179,46 @@ let _build_metrics ~strat_returns ~benchmark_returns =
           (BucketAsymmetry, _bucket_asymmetry pairs);
         ]
 
+(** Pick the benchmark series to use: explicit override wins; otherwise the
+    step-accumulated series (reversed back to chronological). [None] when
+    no override was supplied AND no step carried a [benchmark_return]. *)
+let _resolve_benchmark_series state =
+  match state.benchmark_returns_override with
+  | Some _ as override -> override
+  | None -> (
+      match state.step_benchmark_returns with
+      | [] -> None
+      | xs -> Some (List.rev xs))
+
 let _update ~state ~step =
   if not (Metric_computer_utils.is_trading_day_step step) then state
   else
-    {
-      state with
-      portfolio_values =
-        step.Simulator_types.portfolio_value :: state.portfolio_values;
-    }
+    let portfolio_values =
+      step.Simulator_types.portfolio_value :: state.portfolio_values
+    in
+    let step_benchmark_returns =
+      match step.Simulator_types.benchmark_return with
+      | None -> state.step_benchmark_returns
+      | Some r -> r :: state.step_benchmark_returns
+    in
+    { state with portfolio_values; step_benchmark_returns }
 
 let _finalize ~state ~config:_ =
   let strat_returns = _step_returns_pct (List.rev state.portfolio_values) in
-  _build_metrics ~strat_returns ~benchmark_returns:state.benchmark_returns
+  _build_metrics ~strat_returns
+    ~benchmark_returns:(_resolve_benchmark_series state)
 
 let computer ?benchmark_returns () : Simulator_types.any_metric_computer =
   Simulator_types.wrap_computer
     {
       name = "antifragility";
-      init = (fun ~config:_ -> { portfolio_values = []; benchmark_returns });
+      init =
+        (fun ~config:_ ->
+          {
+            portfolio_values = [];
+            step_benchmark_returns = [];
+            benchmark_returns_override = benchmark_returns;
+          });
       update = _update;
       finalize = _finalize;
     }

--- a/trading/trading/simulation/lib/antifragility_computer.mli
+++ b/trading/trading/simulation/lib/antifragility_computer.mli
@@ -1,10 +1,11 @@
 (** Antifragility / barbell metrics (M5.2d).
 
     These metrics describe the strategy's response curve as a function of a
-    {b benchmark} (default convention: SPY total return). The strategy's
-    per-step return is regressed quadratically against the benchmark's per-step
-    return; the curvature term [γ] (coefficient of [r_bench²]) is the
-    {b concavity coefficient} after Taleb:
+    {b benchmark} (typically SPY or GSPC.INDX total return; the simulator
+    accepts any symbol via [Simulator.dependencies.benchmark_symbol]). The
+    strategy's per-step return is regressed quadratically against the
+    benchmark's per-step return; the curvature term [γ] (coefficient of
+    [r_bench²]) is the {b concavity coefficient} after Taleb:
 
     - [γ > 0] → convex / antifragile (strategy gains more than linearly in
       benchmark extremes);
@@ -18,18 +19,23 @@
     Values > 1 indicate a barbell shape (strategy concentrates returns in the
     benchmark's extremes). Values ≤ 1 indicate a middle-heavy shape.
 
-    {b Benchmark plumbing.} The simulator's [step_result] does not currently
-    track benchmark returns. To avoid an invasive surface change in this PR, the
-    benchmark series is supplied directly at computer construction:
+    {b Benchmark plumbing.} The benchmark series can be sourced two ways:
 
-    {[
-      let computer = Antifragility_computer.computer ~benchmark_returns:[ ... ] ()
-    ]}
+    1. {b From the simulator} — when [Simulator.dependencies.benchmark_symbol]
+       is [Some sym], every [step_result] carries a [benchmark_return : float
+       option] computed from [sym]'s adjusted-close % change. The computer
+       accumulates those values and uses them automatically; nothing extra
+       is needed at the call site. This is the production path.
+    2. {b Override at construction} — pass [?benchmark_returns] to bypass the
+       step-sourced series and pin a synthetic series. Used by tests that
+       want to fix benchmark values independent of any market data adapter:
+       {[
+         let computer = Antifragility_computer.computer ~benchmark_returns:[ ... ] ()
+       ]}
 
-    When [benchmark_returns] is [None] (the default for stand-alone backtest
-    runs), both [ConcavityCoef] and [BucketAsymmetry] are emitted as [0.0]. A
-    follow-up PR will plumb a benchmark feed through the simulator, at which
-    point this computer will read the series from [config] instead.
+    When neither path supplies a benchmark — no override, and every step has
+    [benchmark_return = None] — both [ConcavityCoef] and [BucketAsymmetry] emit
+    [0.0]. This preserves the prior stand-alone-backtest behaviour.
 
     {b OLS formula.} Given paired samples [(x_i, y_i)] with [x = r_bench],
     [y = r_strat], the model is [y = α + β·x + γ·x²]. Define [u = x²]. Then
@@ -50,10 +56,13 @@ val computer :
     [BucketAsymmetry].
 
     @param benchmark_returns
-      Optional per-step benchmark percent-return series. When supplied, the list
-      must be in chronological order; the computer aligns it to the strategy's
-      per-step returns by truncating the longer side. When [None], both metrics
-      are emitted as [0.0].
+      Optional explicit per-step benchmark percent-return series. When
+      supplied, the list must be in chronological order; the computer aligns
+      it to the strategy's per-step returns by truncating the longer side.
+      When omitted, the computer falls back to the per-step values stored in
+      [step_result.benchmark_return] (populated by the simulator when
+      [dependencies.benchmark_symbol] is set). When neither source provides a
+      series, both metrics are emitted as [0.0].
 
     Edge cases:
     - Fewer than 5 paired samples → both metrics 0.0 (insufficient data for a

--- a/trading/trading/simulation/lib/metric_computers.mli
+++ b/trading/trading/simulation/lib/metric_computers.mli
@@ -111,10 +111,12 @@ val distributional_computer : unit -> Simulator.any_metric_computer
 
 val antifragility_computer :
   ?benchmark_returns:float list -> unit -> Simulator.any_metric_computer
-(** Computer that emits ConcavityCoef and BucketAsymmetry. Both metrics require
-    a benchmark return series; when [benchmark_returns] is omitted they emit 0.0
-    (the documented default for stand-alone backtest runs). See
-    {!Antifragility_computer} for spec and benchmark-plumbing rationale. *)
+(** Computer that emits ConcavityCoef and BucketAsymmetry. The benchmark series
+    is sourced from [step_result.benchmark_return] when the simulator is
+    configured with [dependencies.benchmark_symbol]; the optional
+    [?benchmark_returns] override pins a synthetic series for tests. When
+    neither source is available, both metrics emit 0.0. See
+    {!Antifragility_computer} for spec. *)
 
 (** {1 Default Computer Set} *)
 
@@ -127,8 +129,9 @@ val default_computers :
     factor), Sharpe ratio, max drawdown, CAGR, portfolio state, trade
     aggregates, the M5.2b returns-block group, the M5.2c Omega ratio computer,
     the M5.2c drawdown analytics group, the M5.2d distributional group, and the
-    M5.2d antifragility computer (no benchmark wired by default — its two
-    metrics emit 0.0 in this configuration).
+    M5.2d antifragility computer (which reads benchmark returns from
+    [step_result.benchmark_return]; emits 0.0 when no benchmark symbol was
+    wired into the simulator's dependencies).
 
     @param risk_free_rate
       Annual risk-free rate for Sharpe calculation (default: 0.0)
@@ -178,5 +181,7 @@ val create_computer :
     Distributional metrics (Skewness, Kurtosis, CVaR95, CVaR99, TailRatio,
     GainToPain) are produced together by [distributional_computer].
     Antifragility metrics (ConcavityCoef, BucketAsymmetry) are produced by
-    [antifragility_computer] with no benchmark wired by default — both emit
-    [0.0] under that configuration. *)
+    [antifragility_computer], which reads the benchmark series from
+    [step_result.benchmark_return] populated by the simulator when
+    [dependencies.benchmark_symbol] is set. With no benchmark wired, both
+    metrics emit [0.0]. *)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -34,10 +34,16 @@ type dependencies = {
   order_manager : Trading_orders.Manager.order_manager;
   market_data_adapter : Trading_simulation_data.Market_data_adapter.t;
   metric_suite : metric_suite;
+  benchmark_symbol : string option;
+      (** Optional symbol whose adjusted-close % change provides the per-step
+          benchmark return populated on [step_result.benchmark_return]. The
+          benchmark does not need to be in [symbols] — bars are fetched
+          independently via [market_data_adapter]. When [None] the field is
+          left as [None] on every step (default; preserves prior behaviour). *)
 }
 
 let create_deps ~symbols ~data_dir ~strategy ~commission
-    ?(metric_suite = { computers = []; derived = [] }) () =
+    ?(metric_suite = { computers = []; derived = [] }) ?benchmark_symbol () =
   let engine_config = { Trading_engine.Types.commission } in
   let engine = Trading_engine.Engine.create engine_config in
   let order_manager = Trading_orders.Manager.create () in
@@ -52,6 +58,7 @@ let create_deps ~symbols ~data_dir ~strategy ~commission
     order_manager;
     market_data_adapter;
     metric_suite;
+    benchmark_symbol;
   }
 
 (** {1 Simulator State} *)
@@ -109,6 +116,29 @@ let _to_price_bar (symbol : string) (daily_price : Types.Daily_price.t) :
     low_price = daily_price.low_price;
     close_price = daily_price.close_price;
   }
+
+(** Per-step benchmark return for the configured benchmark symbol, if any. We
+    use [adjusted_close] (split- and dividend-adjusted) to keep returns
+    comparable across the simulation window; this matches the convention used
+    by [Antifragility_computer]'s synthetic tests, which feed in raw percent
+    returns. Returns [None] when no benchmark is configured, or when either
+    today's bar or the prior trading day's bar is missing for the benchmark. *)
+let _compute_benchmark_return t : float option =
+  let%bind.Option symbol = t.deps.benchmark_symbol in
+  let adapter = t.deps.market_data_adapter in
+  let date = t.current_date in
+  let%bind.Option curr =
+    Trading_simulation_data.Market_data_adapter.get_price adapter ~symbol ~date
+  in
+  let%bind.Option prev =
+    Trading_simulation_data.Market_data_adapter.get_previous_bar adapter ~symbol
+      ~date
+  in
+  let prev_close = prev.Types.Daily_price.adjusted_close in
+  if Float.(prev_close <= 0.0) then None
+  else
+    let curr_close = curr.Types.Daily_price.adjusted_close in
+    Some ((curr_close -. prev_close) /. prev_close *. 100.0)
 
 (** Get all price bars for today using market data adapter *)
 let _get_today_bars t =
@@ -406,6 +436,7 @@ let step t =
         trades;
         orders_submitted = _submit_orders t orders;
         splits_applied = split_events;
+        benchmark_return = _compute_benchmark_return t;
       }
     in
     let t' =

--- a/trading/trading/simulation/lib/simulator.mli
+++ b/trading/trading/simulation/lib/simulator.mli
@@ -23,6 +23,12 @@ type dependencies = {
   order_manager : Trading_orders.Manager.order_manager;
   market_data_adapter : Trading_simulation_data.Market_data_adapter.t;
   metric_suite : metric_suite;
+  benchmark_symbol : string option;
+      (** Optional benchmark symbol whose adjusted-close % change is captured
+          per step on [step_result.benchmark_return]. The benchmark may be
+          outside [symbols] — bars are fetched independently. The
+          antifragility computer reads these per-step values to compute
+          ConcavityCoef and BucketAsymmetry. *)
 }
 
 val create_deps :
@@ -31,10 +37,16 @@ val create_deps :
   strategy:(module Trading_strategy.Strategy_interface.STRATEGY) ->
   commission:Trading_engine.Types.commission_config ->
   ?metric_suite:metric_suite ->
+  ?benchmark_symbol:string ->
   unit ->
   dependencies
 (** Create standard dependencies with default engine, order manager, and
-    adapter. Strategy cadence is set via [config.strategy_cadence]. *)
+    adapter. Strategy cadence is set via [config.strategy_cadence].
+
+    @param benchmark_symbol
+      Optional symbol used to populate [step_result.benchmark_return] (e.g.
+      ["SPY"]). When omitted, the field is [None] on every step and the
+      antifragility metrics emit 0.0. *)
 
 (** {1 Creation} *)
 

--- a/trading/trading/simulation/lib/types/simulator_types.ml
+++ b/trading/trading/simulation/lib/types/simulator_types.ml
@@ -22,6 +22,7 @@ type step_result = {
   trades : Trading_base.Types.trade list;
   orders_submitted : Trading_orders.Types.order list;
   splits_applied : Trading_portfolio.Split_event.t list;
+  benchmark_return : float option;
 }
 [@@deriving show, eq]
 

--- a/trading/trading/simulation/lib/types/simulator_types.mli
+++ b/trading/trading/simulation/lib/types/simulator_types.mli
@@ -35,6 +35,16 @@ type step_result = {
       (** Split events detected and applied to held positions at the start of
           this step, in detection order. Empty on non-split days (the common
           case). Used for diagnostics and parity checks. *)
+  benchmark_return : float option;
+      (** Benchmark per-step percent return for this date, if a benchmark symbol
+          was configured on [dependencies] and a prior bar exists for it.
+          Computed as [(today.adjusted_close - prev.adjusted_close) /
+          prev.adjusted_close * 100.0] from the market data adapter. [None] when
+          no benchmark is configured, when the benchmark has no bar for [date]
+          (weekend/holiday/missing data), or when there is no prior bar (the
+          first appearance of the benchmark in the simulation window). The
+          antifragility computer reads this field per step to assemble its
+          benchmark series. *)
 }
 [@@deriving show, eq]
 (** Result of a single simulation step *)

--- a/trading/trading/simulation/test/test_antifragility_computer.ml
+++ b/trading/trading/simulation/test/test_antifragility_computer.ml
@@ -16,7 +16,8 @@ module Simulator_types = Trading_simulation_types.Simulator_types
 
 let _date s = Date.of_string s
 
-let _make_step ~date ~portfolio_value : Simulator_types.step_result =
+let _make_step ?benchmark_return ~date ~portfolio_value () :
+    Simulator_types.step_result =
   let portfolio =
     Trading_portfolio.Portfolio.create ~initial_cash:10_000.0 ()
   in
@@ -27,6 +28,7 @@ let _make_step ~date ~portfolio_value : Simulator_types.step_result =
     trades = [];
     orders_submitted = [];
     splits_applied = [];
+    benchmark_return;
   }
 
 let _config =
@@ -56,7 +58,8 @@ let _curve_from_returns ?(seed_value = 10_000.0) returns_pct =
     |> List.rev
   in
   List.mapi values ~f:(fun i v ->
-      _make_step ~date:(Date.add_days (_date "2024-01-02") i) ~portfolio_value:v)
+      _make_step ~date:(Date.add_days (_date "2024-01-02") i) ~portfolio_value:v
+        ())
 
 (* ==================== No-benchmark default ==================== *)
 
@@ -135,6 +138,63 @@ let test_bucket_asymmetry_barbell _ =
     (Map.find metrics BucketAsymmetry)
     (is_some_and (float_equal ~epsilon:1e-3 (20.0 /. 6.0)))
 
+(* ==================== Step-sourced benchmark series ==================== *)
+
+(** Build a benchmark-bearing equity curve. Each step carries
+    [benchmark_return = Some r]; portfolio_value follows [strat] returns. The N
+    benchmark values populate one fewer step than the curve (the seed step has
+    no benchmark — there is no prior bar). *)
+let _curve_with_step_benchmark ~strat ~bench =
+  let values =
+    List.fold strat ~init:[ 10_000.0 ] ~f:(fun acc r ->
+        let prev = List.hd_exn acc in
+        let next = prev *. (1.0 +. (r /. 100.0)) in
+        next :: acc)
+    |> List.rev
+  in
+  List.mapi values ~f:(fun i v ->
+      let benchmark_return =
+        if i = 0 then None else List.nth bench (i - 1)
+      in
+      _make_step ?benchmark_return
+        ~date:(Date.add_days (_date "2024-01-02") i)
+        ~portfolio_value:v ())
+
+(** Convex strategy via step-sourced benchmark returns. Same shape as
+    {!test_convex_strategy_gamma_positive} but the benchmark series flows
+    through [step_result.benchmark_return] instead of an override — pinning
+    the production wiring path. *)
+let test_step_sourced_benchmark_recovers_convex _ =
+  let bench = [ -3.0; -2.0; -1.0; 0.0; 1.0; 2.0; 3.0 ] in
+  let strat = List.map bench ~f:(fun r -> r *. r) in
+  let steps = _curve_with_step_benchmark ~strat ~bench in
+  let metrics = _run steps in
+  let gamma = Map.find_exn metrics ConcavityCoef in
+  assert_that gamma
+    (all_of [ gt (module Float_ord) 0.0; float_equal ~epsilon:1e-3 1.0 ])
+
+(** When both an override and step-sourced benchmark returns are present, the
+    override wins. Steps carry [Some 0.0] (linear-flat) but the override
+    supplies the convex series — γ should reflect the override (≈ 1.0), not
+    the step-sourced flat-line (which would yield γ = 0). *)
+let test_override_wins_over_step_benchmark _ =
+  let bench = [ -3.0; -2.0; -1.0; 0.0; 1.0; 2.0; 3.0 ] in
+  let strat = List.map bench ~f:(fun r -> r *. r) in
+  let bench_zeros = List.map bench ~f:(fun _ -> 0.0) in
+  let steps = _curve_with_step_benchmark ~strat ~bench:bench_zeros in
+  let metrics = _run ~benchmark_returns:bench steps in
+  let gamma = Map.find_exn metrics ConcavityCoef in
+  assert_that gamma (float_equal ~epsilon:1e-3 1.0)
+
+(** Steps that all carry [benchmark_return = None] (e.g. simulator with no
+    benchmark configured) and no override → both metrics emit 0.0. *)
+let test_step_benchmark_all_none_yields_zero _ =
+  let steps = _curve_from_returns [ 1.0; -2.0; 3.0; -1.0; 2.0; -1.0 ] in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [ (ConcavityCoef, float_equal 0.0); (BucketAsymmetry, float_equal 0.0) ])
+
 let suite =
   "Antifragility_computer"
   >::: [
@@ -147,6 +207,12 @@ let suite =
          "linear strategy → γ ≈ 0" >:: test_linear_strategy_gamma_zero;
          "bucket asymmetry barbell (Q1+Q5 dominate) → 3.333"
          >:: test_bucket_asymmetry_barbell;
+         "step-sourced benchmark recovers convex γ"
+         >:: test_step_sourced_benchmark_recovers_convex;
+         "override wins over step-sourced benchmark"
+         >:: test_override_wins_over_step_benchmark;
+         "all step benchmarks None → both metrics 0.0"
+         >:: test_step_benchmark_all_none_yields_zero;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/simulation/test/test_distributional_computer.ml
+++ b/trading/trading/simulation/test/test_distributional_computer.ml
@@ -23,6 +23,7 @@ let _make_step ~date ~portfolio_value : Simulator_types.step_result =
     trades = [];
     orders_submitted = [];
     splits_applied = [];
+    benchmark_return = None;
   }
 
 let _config =

--- a/trading/trading/simulation/test/test_drawdown_analytics_computer.ml
+++ b/trading/trading/simulation/test/test_drawdown_analytics_computer.ml
@@ -21,6 +21,7 @@ let _make_step ~date ~portfolio_value : Simulator_types.step_result =
     trades = [];
     orders_submitted = [];
     splits_applied = [];
+    benchmark_return = None;
   }
 
 let _config =

--- a/trading/trading/simulation/test/test_e2e_integration.ml
+++ b/trading/trading/simulation/test/test_e2e_integration.ml
@@ -422,6 +422,85 @@ let test_ema_strategy_e2e _ =
   in
   Printf.printf "Total individual trades: %d\n" total_trades
 
+(* ==================== Benchmark Plumbing Integration Tests ==================== *)
+
+(** Integration test for the antifragility benchmark plumbing
+    (M5.2d follow-up).
+
+    Verifies that wiring [~benchmark_symbol] through
+    [Simulator.create_deps] populates [step_result.benchmark_return] on every
+    trading day for which the benchmark has both a current and a prior bar.
+    The benchmark symbol is independent from the universe — [symbols] holds
+    only ["AAPL"] but the benchmark series is sourced from [GSPC.INDX]. *)
+let test_benchmark_symbol_populates_step_result _ =
+  let deps =
+    create_deps ~symbols:[ "AAPL" ] ~data_dir:real_data_dir
+      ~strategy:(module Noop_strategy)
+      ~commission:sample_commission ~benchmark_symbol:"GSPC.INDX" ()
+  in
+  let config =
+    {
+      start_date = date_of_string "2024-01-02";
+      end_date = date_of_string "2024-01-31";
+      initial_cash = 100000.0;
+      commission = sample_commission;
+      strategy_cadence = Types.Cadence.Daily;
+    }
+  in
+  let sim = create_exn ~config ~deps in
+  let steps, _ = run_sim_exn sim in
+  (* Every trading day past the first one should carry a benchmark return; the
+     first trading day has no prior bar inside the configured window so it can
+     be [None]. We assert at least 15 of the ~21 trading days have a value to
+     keep the test resilient to weekend/holiday spread. *)
+  let with_bench =
+    List.count steps ~f:(fun s -> Option.is_some s.benchmark_return)
+  in
+  assert_that with_bench (gt (module Int_ord) 15)
+
+(** Integration test: when [~benchmark_symbol] is wired and the antifragility
+    computer is included in the metric suite, the metrics produced by
+    [BucketAsymmetry] reflect the strategy/benchmark co-movement (non-zero,
+    finite). Uses [Buy_first_day_strategy] so portfolio_value moves with
+    AAPL — correlated with GSPC.INDX, so the OLS quadratic fit and the
+    bucket means are well-defined. *)
+let test_antifragility_metrics_non_zero_with_benchmark _ =
+  Buy_first_day_strategy.reset ();
+  let metric_suite =
+    Trading_simulation.Metric_computers.default_metric_suite ()
+  in
+  let deps =
+    create_deps ~symbols:[ "AAPL" ] ~data_dir:real_data_dir
+      ~strategy:(module Buy_first_day_strategy)
+      ~commission:sample_commission ~metric_suite
+      ~benchmark_symbol:"GSPC.INDX" ()
+  in
+  let config =
+    {
+      start_date = date_of_string "2024-01-02";
+      end_date = date_of_string "2024-03-31";
+      initial_cash = 100000.0;
+      commission = sample_commission;
+      strategy_cadence = Types.Cadence.Daily;
+    }
+  in
+  let sim = create_exn ~config ~deps in
+  let result =
+    match run sim with
+    | Ok r -> r
+    | Error err -> failwith ("Sim failed: " ^ Status.show err)
+  in
+  (* BucketAsymmetry compares Q1+Q5 vs Q2+Q3+Q4 means; with AAPL co-moving
+     with the S&P 500 the bucket means are non-trivial and the ratio is
+     bounded away from 0. The exact value depends on the period; we assert
+     a strict positive lower bound (0.01) so a future regression to the
+     [None]-short-circuit path (which would emit 0.0) is caught. *)
+  let bucket_asym =
+    Map.find_exn result.metrics
+      Trading_simulation_types.Metric_types.BucketAsymmetry
+  in
+  assert_that (Float.abs bucket_asym) (gt (module Float_ord) 0.01)
+
 (* ==================== Test Suite ==================== *)
 
 let suite =
@@ -444,6 +523,11 @@ let suite =
          "ema strategy e2e" >:: test_ema_strategy_e2e;
          (* Longer simulation *)
          "longer simulation period" >:: test_longer_simulation_period;
+         (* Benchmark plumbing (M5.2d follow-up) *)
+         "benchmark symbol populates step_result"
+         >:: test_benchmark_symbol_populates_step_result;
+         "antifragility metrics emit with benchmark"
+         >:: test_antifragility_metrics_non_zero_with_benchmark;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -123,6 +123,7 @@ let _step_with_trades ~date ~trades =
     trades;
     orders_submitted = [];
     splits_applied = [];
+    benchmark_return = None;
   }
 
 (** Long round-trip: Buy@100 → Sell@110, quantity 10, profit $100. Pins the
@@ -324,6 +325,7 @@ let make_step_result ~date ~portfolio_value =
     trades = [];
     orders_submitted = [];
     splits_applied = [];
+    benchmark_return = None;
   }
 
 let make_config () =
@@ -642,6 +644,7 @@ let test_profit_factor_all_winners _ =
         trades = [ buy_trade ];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
       {
         date = date_of_string "2024-01-10";
@@ -650,6 +653,7 @@ let test_profit_factor_all_winners _ =
         trades = [ sell_trade ];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
     ]
   in
@@ -891,6 +895,7 @@ let test_portfolio_state_with_trades _ =
         trades = [ trade ];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
       {
         date = date_of_string "2024-01-05";
@@ -899,6 +904,7 @@ let test_portfolio_state_with_trades _ =
         trades = [ trade; trade ];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
     ]
   in
@@ -961,6 +967,7 @@ let test_portfolio_state_skips_non_trading_final_step _ =
         trades = [];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
       {
         (* Non-trading day — simulator fell back to cash. *)
@@ -970,6 +977,7 @@ let test_portfolio_state_skips_non_trading_final_step _ =
         trades = [];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
     ]
   in
@@ -1007,6 +1015,7 @@ let test_portfolio_state_uses_last_step_when_all_trading_days _ =
         trades = [];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
       {
         date = date_of_string "2024-01-06";
@@ -1015,6 +1024,7 @@ let test_portfolio_state_uses_last_step_when_all_trading_days _ =
         trades = [];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
     ]
   in
@@ -1053,6 +1063,7 @@ let test_portfolio_state_long_unrealized_pnl _ =
         trades = [];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
     ]
   in
@@ -1112,6 +1123,7 @@ let test_portfolio_state_short_unrealized_pnl _ =
         trades = [];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
     ]
   in
@@ -1182,6 +1194,7 @@ let test_portfolio_state_mixed_unrealized_pnl _ =
         trades = [];
         orders_submitted = [];
         splits_applied = [];
+        benchmark_return = None;
       };
     ]
   in

--- a/trading/trading/simulation/test/test_return_basics_computer.ml
+++ b/trading/trading/simulation/test/test_return_basics_computer.ml
@@ -21,6 +21,7 @@ let _make_step ~date ~portfolio_value : Simulator_types.step_result =
     trades = [];
     orders_submitted = [];
     splits_applied = [];
+    benchmark_return = None;
   }
 
 let _config =

--- a/trading/trading/simulation/test/test_risk_adjusted_computer.ml
+++ b/trading/trading/simulation/test/test_risk_adjusted_computer.ml
@@ -22,6 +22,7 @@ let _make_step ~date ~portfolio_value : Simulator_types.step_result =
     trades = [];
     orders_submitted = [];
     splits_applied = [];
+    benchmark_return = None;
   }
 
 let _config =

--- a/trading/trading/simulation/test/test_simulator.ml
+++ b/trading/trading/simulation/test/test_simulator.ml
@@ -61,6 +61,7 @@ let make_expected_step_result ~date ~portfolio ?portfolio_value ~trades
     trades;
     orders_submitted;
     splits_applied = [];
+    benchmark_return = None;
   }
 
 (* Custom matchers for step_outcome *)

--- a/trading/trading/simulation/test/test_trade_aggregates_computer.ml
+++ b/trading/trading/simulation/test/test_trade_aggregates_computer.ml
@@ -34,6 +34,7 @@ let _step_with_trades ~date ~trades : Simulator_types.step_result =
     trades;
     orders_submitted = [];
     splits_applied = [];
+    benchmark_return = None;
   }
 
 let _config =


### PR DESCRIPTION
## Summary

M5.2d follow-up: ConcavityCoef and BucketAsymmetry previously emitted 0.0 in
production runs because no benchmark series was wired through the simulator.
This PR plumbs benchmark returns end-to-end so the antifragility computer's
existing OLS path produces non-zero output in production.

The flagship change: `Simulator.create_deps` now accepts an optional
`?benchmark_symbol:string` (e.g. `\"SPY\"` or `\"GSPC.INDX\"`). When set, the
simulator computes the per-step adjusted-close % change and stamps it on
`step_result.benchmark_return`. The antifragility computer reads those
per-step values automatically — no caller changes needed past the
`create_deps` line.

## Wiring overview

- `step_result` gains `benchmark_return : float option` (None when no
  benchmark configured)
- `Simulator.dependencies` gains `benchmark_symbol : string option`;
  `Simulator.create_deps` takes `?benchmark_symbol`
- `Simulator.step` computes today's benchmark return from
  `adjusted_close` % change via `market_data_adapter` (independent of
  `dependencies.symbols` — the benchmark may be outside the universe)
- `Antifragility_computer` accumulates `step.benchmark_return` values;
  the pre-existing `?benchmark_returns` override remains in the public
  signature for synthetic tests

## Decisions documented

- **Benchmark source**: per-step injection on `dependencies` (not
  `Simulator.config`), keeping the runtime configuration surface flexible.
  The symbol is pluggable — not hardcoded SPY — to match the configurability
  of `weinstein_strategy.config`.
- **None handling**: backward-compatible 0.0 emission when neither path
  provides a series. Picks Option A from the task brief (preserve existing
  behaviour for stand-alone backtests).
- **Step-level vs window-level**: per-step `benchmark_return : float option`
  on `step_result`, aggregated by the computer at finalize time. No attempt
  to smuggle full benchmark series through `Simulator.config` — the per-step
  field accumulates naturally and is the smaller surface change.

## Files touched

Production (5):
- `trading/trading/simulation/lib/types/simulator_types.{ml,mli}` — add
  `benchmark_return` field
- `trading/trading/simulation/lib/simulator.{ml,mli}` — add
  `benchmark_symbol` to `dependencies` + `create_deps`; populate the field
  via `_compute_benchmark_return`
- `trading/trading/simulation/lib/antifragility_computer.{ml,mli}` — add
  step-sourced benchmark series accumulation; preserve `?benchmark_returns`
  override for synthetic tests
- `trading/trading/simulation/lib/metric_computers.mli` — docstring update

Test fixtures (12 files): add `benchmark_return = None` to each
`step_result` literal. Mechanical, one-line change per call site.

New tests (2 files):
- `trading/trading/simulation/test/test_antifragility_computer.ml` — 3 new
  cases: step-sourced benchmark recovers convex γ; override wins over
  step-sourced; all-None yields 0.0
- `trading/trading/simulation/test/test_e2e_integration.ml` — 2 new cases
  using real GSPC.INDX benchmark data: benchmark populates `step_result`;
  BucketAsymmetry non-zero with `Buy_first_day_strategy` on AAPL

## Test plan

- [x] `dune runtest trading/simulation` passes (all unit + e2e tests)
- [x] `dune runtest trading/backtest` passes (test_runner_filter,
  test_result_writer use updated step_result shape)
- [x] `dune runtest trading/weinstein` passes (no API breakage on
  `create_deps` callers)
- [x] All 9 antifragility unit tests pass (6 original + 3 new)
- [x] Both new e2e integration tests pass against real test_data

## Pre-existing test framework caveats

The repo has `ocamlformat 0.29.0` pinned in `.ocamlformat` but the docker
container ships `0.28.1` — a known environment-skew issue. `dune fmt`
fails with a version-mismatch error on every file in the project, not
just my changes. This is pre-existing.

The function-length linter, magic-number linter, and status-file
integrity linter all show pre-existing FAILs unrelated to this PR's
scope (e.g. `weinstein_strategy.ml` has a 145-line function flagged from
prior PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)