### PR TITLE
feat(eodhd): multi-market resolver (LSE/TSE/ASX/HKEX/TSX) — M7.0 Track 2

### DIFF
--- a/trading/analysis/data/sources/eodhd/lib/exchange_resolver.ml
+++ b/trading/analysis/data/sources/eodhd/lib/exchange_resolver.ml
@@ -1,0 +1,87 @@
+open Core
+
+type exchange = US | LSE | TSE | ASX | HKEX | TSX [@@deriving show, eq]
+type parsed_symbol = { ticker : string; exchange : exchange } [@@deriving show, eq]
+
+let all = [ US; LSE; TSE; ASX; HKEX; TSX ]
+
+(* Canonical EODHD code as used in URL paths and as the symbol suffix.
+   Sources: EODHD docs https://eodhd.com/financial-apis/list-supported-exchanges/.
+   These are intentionally fixed strings; they are routing keys, not
+   tunable parameters, so the magic-number linter exemption (string
+   identifiers) applies. *)
+let to_eodhd_code = function
+  | US -> "US"
+  | LSE -> "LSE"
+  | TSE -> "TSE"
+  | ASX -> "AU"
+  | HKEX -> "HK"
+  | TSX -> "TO"
+
+(* ISO 4217 currency codes. Same rationale as above — fixed routing
+   strings, not tunable. *)
+let currency = function
+  | US -> "USD"
+  | LSE -> "GBP"
+  | TSE -> "JPY"
+  | ASX -> "AUD"
+  | HKEX -> "HKD"
+  | TSX -> "CAD"
+
+let calendar = function
+  | US -> "NYSE"
+  | LSE -> "LSE"
+  | TSE -> "TSE"
+  | ASX -> "ASX"
+  | HKEX -> "HKEX"
+  | TSX -> "TSX"
+
+(* Map a user-supplied suffix (case-insensitive, no leading dot) to an
+   exchange. We accept both EODHD's canonical code and the looser aliases
+   that the M7.0 plan document calls out (.L for London, .T for Tokyo,
+   .AX for Sydney, .TSX for Toronto). *)
+let _exchange_of_suffix s =
+  match String.uppercase s with
+  | "US" -> Some US
+  | "LSE" | "L" -> Some LSE
+  | "TSE" | "T" -> Some TSE
+  | "AU" | "AX" -> Some ASX
+  | "HK" -> Some HKEX
+  | "TO" | "TSX" -> Some TSX
+  | _ -> None
+
+let _split_on_last_dot s =
+  match String.rsplit2 s ~on:'.' with
+  | Some (ticker, suffix) -> (ticker, Some suffix)
+  | None -> (s, None)
+
+let _resolve_explicit_suffix ~raw suffix =
+  Result.of_option (_exchange_of_suffix suffix)
+    ~error:
+      (Status.invalid_argument_error
+         (Printf.sprintf "Unknown exchange suffix %S in symbol %S" suffix raw))
+
+let _resolve_suffix ~raw = function
+  | None -> Ok US
+  | Some suffix -> _resolve_explicit_suffix ~raw suffix
+
+let _validate_non_empty raw =
+  if String.is_empty raw then Status.error_invalid_argument "Empty symbol"
+  else Ok ()
+
+let _validate_ticker ~raw ticker =
+  if String.is_empty ticker then
+    Status.error_invalid_argument
+      (Printf.sprintf "Empty ticker in symbol: %S" raw)
+  else Ok ticker
+
+let parse raw =
+  let open Result.Let_syntax in
+  let%bind () = _validate_non_empty raw in
+  let ticker_raw, suffix_opt = _split_on_last_dot raw in
+  let%bind ticker = _validate_ticker ~raw ticker_raw in
+  let%bind exchange = _resolve_suffix ~raw suffix_opt in
+  Ok { ticker; exchange }
+
+let to_eodhd_symbol { ticker; exchange } =
+  ticker ^ "." ^ to_eodhd_code exchange

--- a/trading/analysis/data/sources/eodhd/lib/exchange_resolver.ml
+++ b/trading/analysis/data/sources/eodhd/lib/exchange_resolver.ml
@@ -1,7 +1,9 @@
 open Core
 
 type exchange = US | LSE | TSE | ASX | HKEX | TSX [@@deriving show, eq]
-type parsed_symbol = { ticker : string; exchange : exchange } [@@deriving show, eq]
+
+type parsed_symbol = { ticker : string; exchange : exchange }
+[@@deriving show, eq]
 
 let all = [ US; LSE; TSE; ASX; HKEX; TSX ]
 
@@ -56,7 +58,8 @@ let _split_on_last_dot s =
   | None -> (s, None)
 
 let _resolve_explicit_suffix ~raw suffix =
-  Result.of_option (_exchange_of_suffix suffix)
+  Result.of_option
+    (_exchange_of_suffix suffix)
     ~error:
       (Status.invalid_argument_error
          (Printf.sprintf "Unknown exchange suffix %S in symbol %S" suffix raw))
@@ -83,5 +86,4 @@ let parse raw =
   let%bind exchange = _resolve_suffix ~raw suffix_opt in
   Ok { ticker; exchange }
 
-let to_eodhd_symbol { ticker; exchange } =
-  ticker ^ "." ^ to_eodhd_code exchange
+let to_eodhd_symbol { ticker; exchange } = ticker ^ "." ^ to_eodhd_code exchange

--- a/trading/analysis/data/sources/eodhd/lib/exchange_resolver.mli
+++ b/trading/analysis/data/sources/eodhd/lib/exchange_resolver.mli
@@ -1,17 +1,17 @@
 (** Exchange resolution for EODHD multi-market support.
 
-    Symbols on EODHD are addressed as [TICKER.EXCHANGE] (for example,
-    [AAPL.US], [BARC.LSE], [7203.TSE]). This module factors that suffix
-    handling out of {!Http_client} so that callers can:
+    Symbols on EODHD are addressed as [TICKER.EXCHANGE] (for example, [AAPL.US],
+    [BARC.LSE], [7203.TSE]). This module factors that suffix handling out of
+    {!Http_client} so that callers can:
 
     - Parse a user-supplied symbol like ["BARC.LSE"] into a structured
       {!parsed_symbol} value.
-    - Look up the ISO 4217 currency for a given exchange (used to tag
-      universe entries; the [Daily_price.t] bar type itself is intentionally
+    - Look up the ISO 4217 currency for a given exchange (used to tag universe
+      entries; the [Daily_price.t] bar type itself is intentionally
       currency-free — see PR description).
     - Look up the calendar identifier for the exchange. Per-market holiday
-      enumeration is intentionally deferred — calendar gaps surface
-      naturally in fetched bars.
+      enumeration is intentionally deferred — calendar gaps surface naturally in
+      fetched bars.
     - Render the canonical EODHD symbol string for a request URL. *)
 
 type exchange =
@@ -25,9 +25,9 @@ type exchange =
 
 type parsed_symbol = { ticker : string; exchange : exchange }
 [@@deriving show, eq]
-(** A symbol parsed into its ticker and exchange. For inputs without an
-    explicit suffix (for example, ["AAPL"]), the resolver defaults to
-    {!US}, preserving the prior single-market behaviour. *)
+(** A symbol parsed into its ticker and exchange. For inputs without an explicit
+    suffix (for example, ["AAPL"]), the resolver defaults to {!US}, preserving
+    the prior single-market behaviour. *)
 
 val parse : string -> parsed_symbol Status.status_or
 (** [parse s] splits [s] at the final ['.'] and resolves the suffix to an
@@ -40,31 +40,31 @@ val parse : string -> parsed_symbol Status.status_or
     - [.HK] → [HKEX]
     - [.TO], [.TSX] → [TSX]
 
-    Suffix matching is case-insensitive. Returns [Error] for an unknown
-    suffix or an empty ticker (for example, [""], [".US"]). *)
+    Suffix matching is case-insensitive. Returns [Error] for an unknown suffix
+    or an empty ticker (for example, [""], [".US"]). *)
 
 val to_eodhd_symbol : parsed_symbol -> string
-(** Render a {!parsed_symbol} as the canonical EODHD-addressable string
-    (for example, [{ ticker = "BARC"; exchange = LSE }] → ["BARC.LSE"]).
-    The canonical suffix is the {!to_eodhd_code} value. *)
+(** Render a {!parsed_symbol} as the canonical EODHD-addressable string (for
+    example, [{ ticker = "BARC"; exchange = LSE }] → ["BARC.LSE"]). The
+    canonical suffix is the {!to_eodhd_code} value. *)
 
 val to_eodhd_code : exchange -> string
-(** The canonical EODHD exchange code as it appears in URLs:
-    [US], [LSE], [TSE], [AU], [HK], [TO]. Used for both the per-symbol
-    suffix and the [/api/exchange-symbol-list/{code}] endpoint. *)
+(** The canonical EODHD exchange code as it appears in URLs: [US], [LSE], [TSE],
+    [AU], [HK], [TO]. Used for both the per-symbol suffix and the
+    [/api/exchange-symbol-list/{code}] endpoint. *)
 
 val currency : exchange -> string
-(** ISO 4217 currency code for the exchange's primary listing currency
-    (USD, GBP, JPY, AUD, HKD, CAD). Tagging is at the
-    universe / instrument-info layer; we deliberately do not add a
-    currency field to {!Types.Daily_price.t} in this PR. *)
+(** ISO 4217 currency code for the exchange's primary listing currency (USD,
+    GBP, JPY, AUD, HKD, CAD). Tagging is at the universe / instrument-info
+    layer; we deliberately do not add a currency field to {!Types.Daily_price.t}
+    in this PR. *)
 
 val calendar : exchange -> string
-(** Short calendar identifier for the exchange (for example, ["NYSE"],
-    ["LSE"], ["TSE"], ["ASX"], ["HKEX"], ["TSX"]). Returned as a string;
-    full holiday enumeration is intentionally out of scope — fetched bars
-    encode trading days for the markets we currently care about. *)
+(** Short calendar identifier for the exchange (for example, ["NYSE"], ["LSE"],
+    ["TSE"], ["ASX"], ["HKEX"], ["TSX"]). Returned as a string; full holiday
+    enumeration is intentionally out of scope — fetched bars encode trading days
+    for the markets we currently care about. *)
 
 val all : exchange list
-(** All exchanges this resolver knows about, in declaration order. Useful
-    for tests and for building per-market reports. *)
+(** All exchanges this resolver knows about, in declaration order. Useful for
+    tests and for building per-market reports. *)

--- a/trading/analysis/data/sources/eodhd/lib/exchange_resolver.mli
+++ b/trading/analysis/data/sources/eodhd/lib/exchange_resolver.mli
@@ -1,0 +1,70 @@
+(** Exchange resolution for EODHD multi-market support.
+
+    Symbols on EODHD are addressed as [TICKER.EXCHANGE] (for example,
+    [AAPL.US], [BARC.LSE], [7203.TSE]). This module factors that suffix
+    handling out of {!Http_client} so that callers can:
+
+    - Parse a user-supplied symbol like ["BARC.LSE"] into a structured
+      {!parsed_symbol} value.
+    - Look up the ISO 4217 currency for a given exchange (used to tag
+      universe entries; the [Daily_price.t] bar type itself is intentionally
+      currency-free — see PR description).
+    - Look up the calendar identifier for the exchange. Per-market holiday
+      enumeration is intentionally deferred — calendar gaps surface
+      naturally in fetched bars.
+    - Render the canonical EODHD symbol string for a request URL. *)
+
+type exchange =
+  | US  (** NYSE / NASDAQ — currency USD *)
+  | LSE  (** London Stock Exchange — currency GBP *)
+  | TSE  (** Tokyo Stock Exchange — currency JPY *)
+  | ASX  (** Australian Securities Exchange — currency AUD *)
+  | HKEX  (** Hong Kong Exchanges and Clearing — currency HKD *)
+  | TSX  (** Toronto Stock Exchange — currency CAD *)
+[@@deriving show, eq]
+
+type parsed_symbol = { ticker : string; exchange : exchange }
+[@@deriving show, eq]
+(** A symbol parsed into its ticker and exchange. For inputs without an
+    explicit suffix (for example, ["AAPL"]), the resolver defaults to
+    {!US}, preserving the prior single-market behaviour. *)
+
+val parse : string -> parsed_symbol Status.status_or
+(** [parse s] splits [s] at the final ['.'] and resolves the suffix to an
+    {!exchange}. Recognised suffixes:
+
+    - [.US] → [US] (also: bare ticker with no suffix)
+    - [.LSE], [.L] → [LSE]
+    - [.TSE], [.T] → [TSE]
+    - [.AU], [.AX] → [ASX]
+    - [.HK] → [HKEX]
+    - [.TO], [.TSX] → [TSX]
+
+    Suffix matching is case-insensitive. Returns [Error] for an unknown
+    suffix or an empty ticker (for example, [""], [".US"]). *)
+
+val to_eodhd_symbol : parsed_symbol -> string
+(** Render a {!parsed_symbol} as the canonical EODHD-addressable string
+    (for example, [{ ticker = "BARC"; exchange = LSE }] → ["BARC.LSE"]).
+    The canonical suffix is the {!to_eodhd_code} value. *)
+
+val to_eodhd_code : exchange -> string
+(** The canonical EODHD exchange code as it appears in URLs:
+    [US], [LSE], [TSE], [AU], [HK], [TO]. Used for both the per-symbol
+    suffix and the [/api/exchange-symbol-list/{code}] endpoint. *)
+
+val currency : exchange -> string
+(** ISO 4217 currency code for the exchange's primary listing currency
+    (USD, GBP, JPY, AUD, HKD, CAD). Tagging is at the
+    universe / instrument-info layer; we deliberately do not add a
+    currency field to {!Types.Daily_price.t} in this PR. *)
+
+val calendar : exchange -> string
+(** Short calendar identifier for the exchange (for example, ["NYSE"],
+    ["LSE"], ["TSE"], ["ASX"], ["HKEX"], ["TSX"]). Returned as a string;
+    full holiday enumeration is intentionally out of scope — fetched bars
+    encode trading days for the markets we currently care about. *)
+
+val all : exchange list
+(** All exchanges this resolver knows about, in declaration order. Useful
+    for tests and for building per-market reports. *)

--- a/trading/analysis/data/sources/eodhd/test/dune
+++ b/trading/analysis/data/sources/eodhd/test/dune
@@ -1,5 +1,10 @@
 (tests
- (names test_http_client test_splits_endpoint test_dividends_endpoint)
+ (names
+  test_http_client
+  test_splits_endpoint
+  test_dividends_endpoint
+  test_exchange_resolver
+  test_multi_market)
  (libraries eodhd core async async_unix ounit2 csv matchers status)
  (deps
   (glob_files ./data/*.json)))

--- a/trading/analysis/data/sources/eodhd/test/test_exchange_resolver.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_exchange_resolver.ml
@@ -65,14 +65,9 @@ let test_parse_lowercase_suffix _ =
     (is_ok_and_holds
        (equal_to ({ ticker = "barc"; exchange = LSE } : parsed_symbol)))
 
-let test_parse_unknown_suffix _ =
-  assert_that (parse "FOO.XYZ") is_error
-
-let test_parse_empty_string _ =
-  assert_that (parse "") is_error
-
-let test_parse_empty_ticker _ =
-  assert_that (parse ".US") is_error
+let test_parse_unknown_suffix _ = assert_that (parse "FOO.XYZ") is_error
+let test_parse_empty_string _ = assert_that (parse "") is_error
+let test_parse_empty_ticker _ = assert_that (parse ".US") is_error
 
 (* --- canonical EODHD codes --- *)
 
@@ -90,7 +85,9 @@ let test_to_eodhd_code _ =
        ])
 
 let test_to_eodhd_symbol_round_trip _ =
-  let inputs = [ "AAPL.US"; "BARC.LSE"; "7203.TSE"; "BHP.AU"; "0700.HK"; "RY.TO" ] in
+  let inputs =
+    [ "AAPL.US"; "BARC.LSE"; "7203.TSE"; "BHP.AU"; "0700.HK"; "RY.TO" ]
+  in
   let round_tripped =
     List.map inputs ~f:(fun s ->
         match parse s with
@@ -167,7 +164,8 @@ let suite =
          "parse_empty_ticker" >:: test_parse_empty_ticker;
          "to_eodhd_code" >:: test_to_eodhd_code;
          "to_eodhd_symbol_round_trip" >:: test_to_eodhd_symbol_round_trip;
-         "to_eodhd_symbol_normalizes_alias" >:: test_to_eodhd_symbol_normalizes_alias;
+         "to_eodhd_symbol_normalizes_alias"
+         >:: test_to_eodhd_symbol_normalizes_alias;
          "currency_per_exchange" >:: test_currency_per_exchange;
          "calendar_per_exchange" >:: test_calendar_per_exchange;
          "all_distinct" >:: test_all_distinct;

--- a/trading/analysis/data/sources/eodhd/test/test_exchange_resolver.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_exchange_resolver.ml
@@ -1,0 +1,176 @@
+open Core
+open OUnit2
+open Matchers
+open Eodhd.Exchange_resolver
+
+(* --- parsing --- *)
+
+let test_parse_us_default _ =
+  assert_that (parse "AAPL")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "AAPL"; exchange = US } : parsed_symbol)))
+
+let test_parse_us_explicit _ =
+  assert_that (parse "AAPL.US")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "AAPL"; exchange = US } : parsed_symbol)))
+
+let test_parse_lse_canonical _ =
+  assert_that (parse "BARC.LSE")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "BARC"; exchange = LSE } : parsed_symbol)))
+
+let test_parse_lse_alias _ =
+  assert_that (parse "BARC.L")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "BARC"; exchange = LSE } : parsed_symbol)))
+
+let test_parse_tse_canonical _ =
+  assert_that (parse "7203.TSE")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "7203"; exchange = TSE } : parsed_symbol)))
+
+let test_parse_tse_alias _ =
+  assert_that (parse "7203.T")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "7203"; exchange = TSE } : parsed_symbol)))
+
+let test_parse_asx_canonical _ =
+  assert_that (parse "BHP.AU")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "BHP"; exchange = ASX } : parsed_symbol)))
+
+let test_parse_asx_alias _ =
+  assert_that (parse "BHP.AX")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "BHP"; exchange = ASX } : parsed_symbol)))
+
+let test_parse_hkex _ =
+  assert_that (parse "0700.HK")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "0700"; exchange = HKEX } : parsed_symbol)))
+
+let test_parse_tsx_canonical _ =
+  assert_that (parse "RY.TO")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "RY"; exchange = TSX } : parsed_symbol)))
+
+let test_parse_tsx_alias _ =
+  assert_that (parse "RY.TSX")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "RY"; exchange = TSX } : parsed_symbol)))
+
+let test_parse_lowercase_suffix _ =
+  assert_that (parse "barc.lse")
+    (is_ok_and_holds
+       (equal_to ({ ticker = "barc"; exchange = LSE } : parsed_symbol)))
+
+let test_parse_unknown_suffix _ =
+  assert_that (parse "FOO.XYZ") is_error
+
+let test_parse_empty_string _ =
+  assert_that (parse "") is_error
+
+let test_parse_empty_ticker _ =
+  assert_that (parse ".US") is_error
+
+(* --- canonical EODHD codes --- *)
+
+let test_to_eodhd_code _ =
+  let codes = List.map all ~f:to_eodhd_code in
+  assert_that codes
+    (elements_are
+       [
+         equal_to "US";
+         equal_to "LSE";
+         equal_to "TSE";
+         equal_to "AU";
+         equal_to "HK";
+         equal_to "TO";
+       ])
+
+let test_to_eodhd_symbol_round_trip _ =
+  let inputs = [ "AAPL.US"; "BARC.LSE"; "7203.TSE"; "BHP.AU"; "0700.HK"; "RY.TO" ] in
+  let round_tripped =
+    List.map inputs ~f:(fun s ->
+        match parse s with
+        | Ok ps -> to_eodhd_symbol ps
+        | Error err ->
+            assert_failure
+              (Printf.sprintf "parse failed for %S: %s" s (Status.show err)))
+  in
+  assert_that round_tripped (elements_are (List.map inputs ~f:equal_to))
+
+let test_to_eodhd_symbol_normalizes_alias _ =
+  (* .L and .LSE both round-trip to the canonical .LSE form *)
+  let result =
+    match parse "BARC.L" with
+    | Ok ps -> to_eodhd_symbol ps
+    | Error err -> assert_failure (Status.show err)
+  in
+  assert_that result (equal_to "BARC.LSE")
+
+(* --- currency tagging --- *)
+
+let test_currency_per_exchange _ =
+  let pairs = List.map all ~f:(fun ex -> (ex, currency ex)) in
+  assert_that pairs
+    (elements_are
+       [
+         equal_to (US, "USD");
+         equal_to (LSE, "GBP");
+         equal_to (TSE, "JPY");
+         equal_to (ASX, "AUD");
+         equal_to (HKEX, "HKD");
+         equal_to (TSX, "CAD");
+       ])
+
+(* --- calendar identifiers --- *)
+
+let test_calendar_per_exchange _ =
+  let pairs = List.map all ~f:(fun ex -> (ex, calendar ex)) in
+  assert_that pairs
+    (elements_are
+       [
+         equal_to (US, "NYSE");
+         equal_to (LSE, "LSE");
+         equal_to (TSE, "TSE");
+         equal_to (ASX, "ASX");
+         equal_to (HKEX, "HKEX");
+         equal_to (TSX, "TSX");
+       ])
+
+(* --- coverage: every variant in [all] is distinct --- *)
+
+let test_all_distinct _ =
+  let codes = List.map all ~f:to_eodhd_code in
+  let unique = List.dedup_and_sort codes ~compare:String.compare in
+  assert_that (List.length unique) (equal_to (List.length all))
+
+let suite =
+  "exchange_resolver_test"
+  >::: [
+         "parse_us_default" >:: test_parse_us_default;
+         "parse_us_explicit" >:: test_parse_us_explicit;
+         "parse_lse_canonical" >:: test_parse_lse_canonical;
+         "parse_lse_alias" >:: test_parse_lse_alias;
+         "parse_tse_canonical" >:: test_parse_tse_canonical;
+         "parse_tse_alias" >:: test_parse_tse_alias;
+         "parse_asx_canonical" >:: test_parse_asx_canonical;
+         "parse_asx_alias" >:: test_parse_asx_alias;
+         "parse_hkex" >:: test_parse_hkex;
+         "parse_tsx_canonical" >:: test_parse_tsx_canonical;
+         "parse_tsx_alias" >:: test_parse_tsx_alias;
+         "parse_lowercase_suffix" >:: test_parse_lowercase_suffix;
+         "parse_unknown_suffix" >:: test_parse_unknown_suffix;
+         "parse_empty_string" >:: test_parse_empty_string;
+         "parse_empty_ticker" >:: test_parse_empty_ticker;
+         "to_eodhd_code" >:: test_to_eodhd_code;
+         "to_eodhd_symbol_round_trip" >:: test_to_eodhd_symbol_round_trip;
+         "to_eodhd_symbol_normalizes_alias" >:: test_to_eodhd_symbol_normalizes_alias;
+         "currency_per_exchange" >:: test_currency_per_exchange;
+         "calendar_per_exchange" >:: test_calendar_per_exchange;
+         "all_distinct" >:: test_all_distinct;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/data/sources/eodhd/test/test_multi_market.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_multi_market.ml
@@ -1,0 +1,121 @@
+(** Stubbed multi-market integration test for the M7.0 Track 2 EODHD
+    expansion (LSE, TSE, ASX, HKEX, TSX).
+
+    Each case parses a market-suffixed symbol via {!Exchange_resolver},
+    drives {!Http_client.get_historical_price} with the canonical EODHD
+    symbol, and asserts:
+
+    - the request URL embeds the canonical [TICKER.SUFFIX];
+    - the parsed price bars round-trip cleanly (3 rows, plausible OHLC);
+    - the currency tag from the resolver matches expectations.
+
+    No network is involved — the fetch function is a fixture stub that
+    reads the same shared price JSON used by [test_http_client.ml]. *)
+
+open Core
+open Async
+open OUnit2
+open Matchers
+open Eodhd
+
+let _make_stub ~expected_symbol_suffix =
+  fun uri ->
+    let uri_str = Uri.to_string uri in
+    assert_bool
+      (Printf.sprintf "URI should embed %S, got %S" expected_symbol_suffix
+         uri_str)
+      (String.is_substring uri_str ~substring:expected_symbol_suffix);
+    let body = In_channel.read_all "./data/get_historical_price.json" in
+    Deferred.return (Ok body)
+
+let _params_for symbol : Http_client.historical_price_params =
+  {
+    symbol;
+    start_date = Some (Date.create_exn ~y:2024 ~m:Month.Jan ~d:1);
+    end_date = Some (Date.create_exn ~y:2024 ~m:Month.Jan ~d:31);
+    period = Types.Cadence.Daily;
+  }
+
+let _fetch_for_market input_symbol =
+  let parsed =
+    match Exchange_resolver.parse input_symbol with
+    | Ok p -> p
+    | Error err ->
+        assert_failure
+          (Printf.sprintf "resolver failed on %S: %s" input_symbol
+             (Status.show err))
+  in
+  let canonical = Exchange_resolver.to_eodhd_symbol parsed in
+  let stub = _make_stub ~expected_symbol_suffix:canonical in
+  let result =
+    Async.Thread_safe.block_on_async_exn (fun () ->
+        Http_client.get_historical_price ~fetch:stub ~token:"test_token"
+          ~params:(_params_for canonical) ())
+  in
+  (parsed, result)
+
+(* Each fetched bar should have OHLC > 0 and high >= low. The fixture
+   data are AAPL split-adjusted prices in the hundreds, so this is a
+   loose plausibility gate; per-market specific assertions live above. *)
+let _bar_is_plausible : Types.Daily_price.t matcher =
+ fun bar ->
+  assert_that bar
+    (all_of
+       [
+         field
+           (fun (b : Types.Daily_price.t) -> b.open_price)
+           (gt (module Float_ord) 0.0);
+         field
+           (fun (b : Types.Daily_price.t) -> b.high_price)
+           (gt (module Float_ord) 0.0);
+         field
+           (fun (b : Types.Daily_price.t) -> b.low_price)
+           (gt (module Float_ord) 0.0);
+         field
+           (fun (b : Types.Daily_price.t) -> b.close_price)
+           (gt (module Float_ord) 0.0);
+         field
+           (fun (b : Types.Daily_price.t) -> b.high_price -. b.low_price)
+           (ge (module Float_ord) 0.0);
+       ])
+
+let _check_market ~input_symbol ~expected_exchange ~expected_currency =
+  let parsed, result = _fetch_for_market input_symbol in
+  assert_that parsed.exchange (equal_to expected_exchange);
+  assert_that
+    (Exchange_resolver.currency parsed.exchange)
+    (equal_to expected_currency);
+  assert_that result
+    (is_ok_and_holds (all_of [ size_is 3; each _bar_is_plausible ]))
+
+let test_lse _ =
+  _check_market ~input_symbol:"BARC.LSE" ~expected_exchange:Exchange_resolver.LSE
+    ~expected_currency:"GBP"
+
+let test_tse _ =
+  _check_market ~input_symbol:"7203.T" ~expected_exchange:Exchange_resolver.TSE
+    ~expected_currency:"JPY"
+
+let test_asx _ =
+  _check_market ~input_symbol:"BHP.AU" ~expected_exchange:Exchange_resolver.ASX
+    ~expected_currency:"AUD"
+
+let test_hkex _ =
+  _check_market ~input_symbol:"0700.HK"
+    ~expected_exchange:Exchange_resolver.HKEX ~expected_currency:"HKD"
+
+let test_tsx _ =
+  _check_market ~input_symbol:"RY.TO" ~expected_exchange:Exchange_resolver.TSX
+    ~expected_currency:"CAD"
+
+let suite =
+  "multi_market_test"
+  >::: [
+         "lse_barclays" >:: test_lse;
+         "tse_toyota" >:: test_tse;
+         "asx_bhp" >:: test_asx;
+         "hkex_tencent" >:: test_hkex;
+         "tsx_royal_bank" >:: test_tsx;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/data/sources/eodhd/test/test_multi_market.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_multi_market.ml
@@ -1,16 +1,16 @@
-(** Stubbed multi-market integration test for the M7.0 Track 2 EODHD
-    expansion (LSE, TSE, ASX, HKEX, TSX).
+(** Stubbed multi-market integration test for the M7.0 Track 2 EODHD expansion
+    (LSE, TSE, ASX, HKEX, TSX).
 
-    Each case parses a market-suffixed symbol via {!Exchange_resolver},
-    drives {!Http_client.get_historical_price} with the canonical EODHD
-    symbol, and asserts:
+    Each case parses a market-suffixed symbol via {!Exchange_resolver}, drives
+    {!Http_client.get_historical_price} with the canonical EODHD symbol, and
+    asserts:
 
     - the request URL embeds the canonical [TICKER.SUFFIX];
     - the parsed price bars round-trip cleanly (3 rows, plausible OHLC);
     - the currency tag from the resolver matches expectations.
 
-    No network is involved — the fetch function is a fixture stub that
-    reads the same shared price JSON used by [test_http_client.ml]. *)
+    No network is involved — the fetch function is a fixture stub that reads the
+    same shared price JSON used by [test_http_client.ml]. *)
 
 open Core
 open Async
@@ -19,14 +19,13 @@ open Matchers
 open Eodhd
 
 let _make_stub ~expected_symbol_suffix =
-  fun uri ->
-    let uri_str = Uri.to_string uri in
-    assert_bool
-      (Printf.sprintf "URI should embed %S, got %S" expected_symbol_suffix
-         uri_str)
-      (String.is_substring uri_str ~substring:expected_symbol_suffix);
-    let body = In_channel.read_all "./data/get_historical_price.json" in
-    Deferred.return (Ok body)
+ fun uri ->
+  let uri_str = Uri.to_string uri in
+  assert_bool
+    (Printf.sprintf "URI should embed %S, got %S" expected_symbol_suffix uri_str)
+    (String.is_substring uri_str ~substring:expected_symbol_suffix);
+  let body = In_channel.read_all "./data/get_historical_price.json" in
+  Deferred.return (Ok body)
 
 let _params_for symbol : Http_client.historical_price_params =
   {
@@ -89,8 +88,8 @@ let _check_market ~input_symbol ~expected_exchange ~expected_currency =
     (is_ok_and_holds (all_of [ size_is 3; each _bar_is_plausible ]))
 
 let test_lse _ =
-  _check_market ~input_symbol:"BARC.LSE" ~expected_exchange:Exchange_resolver.LSE
-    ~expected_currency:"GBP"
+  _check_market ~input_symbol:"BARC.LSE"
+    ~expected_exchange:Exchange_resolver.LSE ~expected_currency:"GBP"
 
 let test_tse _ =
   _check_market ~input_symbol:"7203.T" ~expected_exchange:Exchange_resolver.TSE


### PR DESCRIPTION
## Summary

Adds a new \`Exchange_resolver\` module under \`analysis/data/sources/eodhd/lib/\` that factors exchange-suffix and currency-tag handling out of the implicit US-only assumption in \`http_client.ml\`. Wires the 5 new EODHD markets called out in \`dev/plans/m7-data-and-tuning-2026-05-02.md\` §M7.0 Track 2 (LSE, TSE, ASX, HKEX, TSX).

This PR is **resolver + parsing + stub-tested round-trip only**. No changes to \`http_client\`, no live network, no production wiring. Live multi-market backtests are downstream work.

## What it does

- Parses market-suffixed symbols (\`BARC.LSE\`, \`7203.T\`, \`BHP.AU\`, \`0700.HK\`, \`RY.TO\`) into a \`{ ticker; exchange }\` record. Bare tickers default to US (preserving prior behaviour).
- Provides per-exchange lookups for canonical EODHD code (\`US\`/\`LSE\`/\`TSE\`/\`AU\`/\`HK\`/\`TO\`), ISO 4217 currency (\`USD\`/\`GBP\`/\`JPY\`/\`AUD\`/\`HKD\`/\`CAD\`), and a calendar identifier string.
- Accepts both EODHD canonical codes and the looser aliases the plan calls out (\`.L\` for London, \`.T\` for Tokyo, \`.AX\` for Sydney, \`.TSX\` for Toronto). Suffix matching is case-insensitive.
- \`to_eodhd_symbol\` round-trips a parsed value back to the canonical \`TICKER.SUFFIX\` form (\`.L\` → \`.LSE\`, etc.).

## Decisions made (per plan latitude)

1. **Currency tagging stays at the resolver / universe layer, NOT on \`Daily_price.t\`.**  Adding a currency field to the bar type would touch every downstream consumer (CSV writers, backtest plumbing, snapshot reports, simulator) and is well outside this PR's scope. Resolver provides \`currency : exchange -> string\`; callers tag at the \`instrument_info\` level.  A future PR can promote currency to the bar if cross-currency P&L aggregation actually needs it.

2. **Calendar handling returns an identifier string only — no holiday enumeration.**  The plan flags Tokyo half-days and ASX time zones as nice-to-have. Implementing a per-market holiday DB is a deep, slow-moving rabbit hole that doesn't unblock anything we currently want to backtest. For first cut, fetched bars naturally encode trading days; missing days surface as gaps in the data. \`calendar : exchange -> string\` returns a short identifier (\`NYSE\`, \`LSE\`, \`TSE\`, \`ASX\`, \`HKEX\`, \`TSX\`) for routing; concrete holiday handling deferred.

3. **No changes to \`http_client.ml\` or its endpoints.**  The plan listed \`exchange_resolver\` as a separate file. Reading the existing code, the resolver is a clean orthogonal building block — it transforms strings, has no I/O. Downstream callers (universe loaders, cache, backtest configs) will use it to construct symbols before calling the existing \`get_historical_price\` endpoint, which already accepts arbitrary symbol strings (\`AAPL\`, \`BARC.LSE\`, …) and routes them via the EODHD URL pattern.

## Test plan

- [x] \`dune build analysis/data/sources/eodhd\` — clean
- [x] \`dune runtest analysis/data/sources/eodhd\` — 54 tests pass (21 resolver + 5 multi-market + existing 28)
- [x] \`test_exchange_resolver.ml\` — 21 cases: every variant parses both canonical and alias suffixes; \`currency\` and \`calendar\` lookups pin every value via \`elements_are\`; round-trip via \`to_eodhd_symbol\` normalizes aliases to canonical; bad input (\`""\`, \`".US"\`, unknown suffix) errors. Uses Matchers + the project's \`assert_that\`/\`is_ok_and_holds\`/\`elements_are\` patterns per \`.claude/rules/test-patterns.md\`.
- [x] \`test_multi_market.ml\` — 5 cases: fixture-stubbed integration round-trip per market (\`BARC.LSE\`, \`7203.T\`, \`BHP.AU\`, \`0700.HK\`, \`RY.TO\`). Each case parses via the resolver, asserts the canonical symbol embeds in the EODHD URL, parses 3 OHLCV bars (plausibility-gated: OHLC > 0, high ≥ low), and confirms the resolver-reported currency. No network involved — fetch is a stub returning the existing shared \`get_historical_price.json\` fixture.
- [x] No new linter regressions: \`fn_length_linter\` / \`nesting_linter\` / \`magic_numbers\` / \`mli_coverage\` clean for my files (verified by grep on full \`dune runtest\` output).
- [x] \`dune fmt\` — local Docker image has ocamlformat 0.28.1 vs project's pinned 0.29.0; deferring to CI per task instructions.
- [x] Pre-push: scrub clean (\`git diff --stat origin/main..HEAD\` = 5 files only); ancestry single-commit on \`origin/main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)