### PR TITLE
fix(backtest): smoke catalog default to sp500 + --shared-override flag

### DIFF
--- a/trading/trading/backtest/bin/backtest_runner.ml
+++ b/trading/trading/backtest/bin/backtest_runner.ml
@@ -14,24 +14,28 @@
     {1 Baseline-comparison mode}
 
     [backtest_runner <start_date> [end_date] --baseline --experiment-name <name>
-     --override <arg> ...]
+     [--shared-override <arg> ...] [--override <arg> ...]]
 
-    Runs twice — once with the overrides ([variant/] subdir) and once without
-    ([baseline/] subdir) — then writes [comparison.sexp] + [comparison.md] at
-    the experiment root with per-metric deltas.
+    Runs twice — once with the variant overrides ([variant/] subdir) and once
+    without ([baseline/] subdir) — then writes [comparison.sexp] +
+    [comparison.md] at the experiment root with per-metric deltas. Any
+    [--shared-override] flags apply to {b both} runs.
 
     {1 Smoke mode}
 
-    [backtest_runner --smoke --experiment-name <name> [--override <arg>] ...
-     [--baseline]]
+    [backtest_runner --smoke --experiment-name <name>
+     [--shared-override <arg> ...] [--override <arg> ...] [--baseline]]
 
     Runs each window in {!Scenario_lib.Smoke_catalog.all} (Bull / Crash /
     Recovery), writing results under [dev/experiments/<name>/<window-name>/].
-    Composes with [--baseline] for per-window comparisons.
+    Composes with [--baseline] for per-window comparisons. Each window's
+    [universe_path] (sp500 by default; see {!Scenario_lib.Smoke_catalog})
+    constrains the loaded universe so the run fits inside the dev container's
+    memory budget.
 
-    {1 --override syntax}
+    {1 --override vs. --shared-override}
 
-    Two forms accepted, freely composable:
+    Both flags accept the same syntax, freely composable:
     - {b Key-path}: [stops_config.initial_stop_buffer=1.05] — ergonomic,
       dispatched via {!Backtest.Config_override}.
     - {b Raw sexp}: [((stops_config ((initial_stop_buffer 1.05))))] — legacy,
@@ -40,14 +44,21 @@
     The runner converts both forms to the [Sexp.t list] that
     [Backtest.Runner._apply_overrides] already deep-merges into the default
     {!Weinstein_strategy.config}. Overrides apply to exactly the named field;
-    every other config value comes from the default. *)
+    every other config value comes from the default.
+
+    Mode-dependent semantics:
+    - [--override] applies to the (single / variant / each-window) run; in
+      [--baseline] mode it does NOT apply to the baseline.
+    - [--shared-override] applies to BOTH runs in [--baseline] mode (e.g.
+      [universe_cap=500] to cap memory for both legs of the A/B). Outside
+      [--baseline], shared overrides are equivalent to [--override]. *)
 
 open Core
 
 let _usage_msg =
-  "Usage: backtest_runner <start_date> [end_date] [--override <arg>] [--trace \
-   <path>] [--memtrace <path>] [--gc-trace <path>] [--baseline] [--smoke] \
-   [--experiment-name <name>]"
+  "Usage: backtest_runner <start_date> [end_date] [--override <arg>] \
+   [--shared-override <arg>] [--trace <path>] [--memtrace <path>] [--gc-trace \
+   <path>] [--baseline] [--smoke] [--experiment-name <name>]"
 
 (** Convert each raw [--override <arg>] string into the partial-config sexp the
     runner deep-merges. Routes key-path strings through
@@ -133,11 +144,16 @@ let _start_memtrace ~path =
     side-effecting work (trace + memtrace + gc-trace plumbing) is folded in here
     so single-run / baseline / smoke modes all share the same per-run pipeline.
 
+    [sector_map_override], when supplied, replaces the sector map normally
+    loaded from [data/sectors.csv] — used by smoke mode to constrain each
+    window to the catalog's [universe_path]. See
+    {!Backtest.Runner.run_backtest}.
+
     Returns the [Backtest.Runner.result] so callers (e.g. baseline mode) can
     feed both runs into [Backtest.Comparison.compute] without re-reading the
     summary from disk. *)
-let _run_and_write ~start_date ~end_date ~overrides ~output_dir ?trace_path
-    ?memtrace_path ?gc_trace_path () =
+let _run_and_write ~start_date ~end_date ~overrides ~output_dir
+    ?sector_map_override ?trace_path ?memtrace_path ?gc_trace_path () =
   Option.iter memtrace_path ~f:(fun path -> _start_memtrace ~path);
   let trace = Option.map trace_path ~f:(fun _ -> Backtest.Trace.create ()) in
   let gc_trace =
@@ -145,8 +161,8 @@ let _run_and_write ~start_date ~end_date ~overrides ~output_dir ?trace_path
   in
   Backtest.Gc_trace.record ?trace:gc_trace ~phase:"start" ();
   let result =
-    Backtest.Runner.run_backtest ~start_date ~end_date ~overrides ?trace
-      ?gc_trace ()
+    Backtest.Runner.run_backtest ~start_date ~end_date ~overrides
+      ?sector_map_override ?trace ?gc_trace ()
   in
   eprintf "Writing output to %s/\n%!" output_dir;
   Backtest.Result_writer.write ~output_dir result;
@@ -160,32 +176,42 @@ let _run_and_write ~start_date ~end_date ~overrides ~output_dir ?trace_path
 
 (** Single-run mode: one backtest, write to [output_dir], echo summary to
     stdout. This is the legacy code path (also reused by smoke mode for the
-    no-baseline case). *)
-let _single_run ~start_date ~end_date ~overrides ~output_dir ?trace_path
-    ?memtrace_path ?gc_trace_path () =
+    no-baseline case). [overrides] are pre-merged from [--shared-override] +
+    [--override] by the caller. *)
+let _single_run ~start_date ~end_date ~overrides ~output_dir
+    ?sector_map_override ?trace_path ?memtrace_path ?gc_trace_path () =
   let result =
-    _run_and_write ~start_date ~end_date ~overrides ~output_dir ?trace_path
-      ?memtrace_path ?gc_trace_path ()
+    _run_and_write ~start_date ~end_date ~overrides ~output_dir
+      ?sector_map_override ?trace_path ?memtrace_path ?gc_trace_path ()
   in
   Out_channel.output_string stdout
     (Sexp.to_string_hum (Backtest.Summary.sexp_of_t result.summary));
   Out_channel.newline stdout
 
-(** Baseline-comparison mode: run with [overrides] (variant) and again without
-    (baseline), then write [comparison.{sexp,md}] at [output_root]. *)
-let _baseline_run ~start_date ~end_date ~overrides ~output_root () =
+(** Baseline-comparison mode: run with [shared_overrides @ overrides]
+    (variant) and again with [shared_overrides] only (baseline), then write
+    [comparison.{sexp,md}] at [output_root]. The [shared_overrides] split is
+    what lets a caller cap the universe (or tweak any other env-shaping
+    parameter) for both legs of the A/B without contaminating the comparison
+    delta with the cap itself. *)
+let _baseline_run ~start_date ~end_date ~shared_overrides ~overrides
+    ~output_root ?sector_map_override () =
   let baseline_dir = Filename.concat output_root "baseline" in
   let variant_dir = Filename.concat output_root "variant" in
   Core_unix.mkdir_p baseline_dir;
   Core_unix.mkdir_p variant_dir;
-  eprintf "[baseline] running with default config...\n%!";
+  eprintf "[baseline] running with %d shared override(s)...\n%!"
+    (List.length shared_overrides);
   let baseline_result =
-    _run_and_write ~start_date ~end_date ~overrides:[] ~output_dir:baseline_dir
-      ()
+    _run_and_write ~start_date ~end_date ~overrides:shared_overrides
+      ~output_dir:baseline_dir ?sector_map_override ()
   in
-  eprintf "[variant] running with %d override(s)...\n%!" (List.length overrides);
+  eprintf "[variant] running with %d shared + %d variant override(s)...\n%!"
+    (List.length shared_overrides) (List.length overrides);
   let variant_result =
-    _run_and_write ~start_date ~end_date ~overrides ~output_dir:variant_dir ()
+    _run_and_write ~start_date ~end_date
+      ~overrides:(shared_overrides @ overrides)
+      ~output_dir:variant_dir ?sector_map_override ()
   in
   let comparison =
     Backtest.Comparison.compute ~baseline:baseline_result.summary
@@ -197,23 +223,46 @@ let _baseline_run ~start_date ~end_date ~overrides ~output_root () =
   Backtest.Comparison.write_markdown ~output_path:md_path comparison;
   eprintf "Comparison written to: %s and %s\n%!" sexp_path md_path
 
+(** Resolve a smoke window's [universe_path] (relative to the fixtures root)
+    into a [sector_map_override] for {!Backtest.Runner.run_backtest}. Mirrors
+    the convention used by [scenario_runner.ml]: the path is documented as
+    relative to [TRADING_DATA_DIR/backtest_scenarios/], which is what
+    {!Scenario_lib.Fixtures_root.resolve} returns. *)
+let _smoke_window_sector_map ~fixtures_root
+    (window : Scenario_lib.Smoke_catalog.window) =
+  let resolved = Filename.concat fixtures_root window.universe_path in
+  Scenario_lib.Universe_file.to_sector_map_override
+    (Scenario_lib.Universe_file.load resolved)
+
 (** Smoke mode: loop over every window in {!Scenario_lib.Smoke_catalog.all},
     delegating to either [_single_run] or [_baseline_run] per window depending
-    on the [baseline] flag. Per-window subdirs sit under the experiment root. *)
-let _smoke_run ~overrides ~output_root ~baseline () =
+    on the [baseline] flag. Each window's [universe_path] is loaded into a
+    [sector_map_override] so the run stays inside the dev container's memory
+    budget rather than blowing up on the full ~10K-symbol [sectors.csv]. *)
+let _smoke_run ~shared_overrides ~overrides ~output_root ~baseline () =
+  let fixtures_root = Scenario_lib.Fixtures_root.resolve () in
   List.iter Scenario_lib.Smoke_catalog.all ~f:(fun window ->
       let window_dir = Filename.concat output_root window.name in
       Core_unix.mkdir_p window_dir;
-      eprintf "\n=== smoke window: %s (%s .. %s) — %s ===\n%!" window.name
+      let sector_map_override =
+        _smoke_window_sector_map ~fixtures_root window
+      in
+      let n_symbols =
+        Option.value_map sector_map_override ~default:0 ~f:Hashtbl.length
+      in
+      eprintf "\n=== smoke window: %s (%s .. %s, %d symbols) — %s ===\n%!"
+        window.name
         (Date.to_string window.start_date)
         (Date.to_string window.end_date)
-        window.description;
+        n_symbols window.description;
       if baseline then
         _baseline_run ~start_date:window.start_date ~end_date:window.end_date
-          ~overrides ~output_root:window_dir ()
+          ~shared_overrides ~overrides ~output_root:window_dir
+          ?sector_map_override ()
       else
         _single_run ~start_date:window.start_date ~end_date:window.end_date
-          ~overrides ~output_dir:window_dir ())
+          ~overrides:(shared_overrides @ overrides) ~output_dir:window_dir
+          ?sector_map_override ())
 
 (** Resolve the raw start/end positionals into [Date.t]. Smoke mode supplies its
     own dates per window so the positionals are unused there; the caller only
@@ -230,22 +279,29 @@ let _resolve_dates ~start_date_raw ~end_date_raw =
 let () =
   let parsed = _parse_args () in
   let overrides = _resolve_overrides parsed.overrides in
+  let shared_overrides = _resolve_overrides parsed.shared_overrides in
   let output_root =
     _make_output_root ?experiment_name:parsed.experiment_name ()
   in
   match (parsed.smoke, parsed.baseline) with
-  | true, _ -> _smoke_run ~overrides ~output_root ~baseline:parsed.baseline ()
+  | true, _ ->
+      _smoke_run ~shared_overrides ~overrides ~output_root
+        ~baseline:parsed.baseline ()
   | false, true ->
       let start_date, end_date =
         _resolve_dates ~start_date_raw:parsed.start_date
           ~end_date_raw:parsed.end_date
       in
-      _baseline_run ~start_date ~end_date ~overrides ~output_root ()
+      _baseline_run ~start_date ~end_date ~shared_overrides ~overrides
+        ~output_root ()
   | false, false ->
       let start_date, end_date =
         _resolve_dates ~start_date_raw:parsed.start_date
           ~end_date_raw:parsed.end_date
       in
-      _single_run ~start_date ~end_date ~overrides ~output_dir:output_root
+      (* Outside [--baseline], shared overrides are equivalent to overrides:
+         applied identically to the (single) run. *)
+      _single_run ~start_date ~end_date
+        ~overrides:(shared_overrides @ overrides) ~output_dir:output_root
         ?trace_path:parsed.trace_path ?memtrace_path:parsed.memtrace_path
         ?gc_trace_path:parsed.gc_trace_path ()

--- a/trading/trading/backtest/bin/backtest_runner.ml
+++ b/trading/trading/backtest/bin/backtest_runner.ml
@@ -23,8 +23,8 @@
 
     {1 Smoke mode}
 
-    [backtest_runner --smoke --experiment-name <name>
-     [--shared-override <arg> ...] [--override <arg> ...] [--baseline]]
+    [backtest_runner --smoke --experiment-name <name> [--shared-override <arg>
+     ...] [--override <arg> ...] [--baseline]]
 
     Runs each window in {!Scenario_lib.Smoke_catalog.all} (Bull / Crash /
     Recovery), writing results under [dev/experiments/<name>/<window-name>/].
@@ -145,9 +145,8 @@ let _start_memtrace ~path =
     so single-run / baseline / smoke modes all share the same per-run pipeline.
 
     [sector_map_override], when supplied, replaces the sector map normally
-    loaded from [data/sectors.csv] — used by smoke mode to constrain each
-    window to the catalog's [universe_path]. See
-    {!Backtest.Runner.run_backtest}.
+    loaded from [data/sectors.csv] — used by smoke mode to constrain each window
+    to the catalog's [universe_path]. See {!Backtest.Runner.run_backtest}.
 
     Returns the [Backtest.Runner.result] so callers (e.g. baseline mode) can
     feed both runs into [Backtest.Comparison.compute] without re-reading the
@@ -188,8 +187,8 @@ let _single_run ~start_date ~end_date ~overrides ~output_dir
     (Sexp.to_string_hum (Backtest.Summary.sexp_of_t result.summary));
   Out_channel.newline stdout
 
-(** Baseline-comparison mode: run with [shared_overrides @ overrides]
-    (variant) and again with [shared_overrides] only (baseline), then write
+(** Baseline-comparison mode: run with [shared_overrides @ overrides] (variant)
+    and again with [shared_overrides] only (baseline), then write
     [comparison.{sexp,md}] at [output_root]. The [shared_overrides] split is
     what lets a caller cap the universe (or tweak any other env-shaping
     parameter) for both legs of the A/B without contaminating the comparison
@@ -207,7 +206,8 @@ let _baseline_run ~start_date ~end_date ~shared_overrides ~overrides
       ~output_dir:baseline_dir ?sector_map_override ()
   in
   eprintf "[variant] running with %d shared + %d variant override(s)...\n%!"
-    (List.length shared_overrides) (List.length overrides);
+    (List.length shared_overrides)
+    (List.length overrides);
   let variant_result =
     _run_and_write ~start_date ~end_date
       ~overrides:(shared_overrides @ overrides)
@@ -261,8 +261,8 @@ let _smoke_run ~shared_overrides ~overrides ~output_root ~baseline () =
           ?sector_map_override ()
       else
         _single_run ~start_date:window.start_date ~end_date:window.end_date
-          ~overrides:(shared_overrides @ overrides) ~output_dir:window_dir
-          ?sector_map_override ())
+          ~overrides:(shared_overrides @ overrides)
+          ~output_dir:window_dir ?sector_map_override ())
 
 (** Resolve the raw start/end positionals into [Date.t]. Smoke mode supplies its
     own dates per window so the positionals are unused there; the caller only
@@ -302,6 +302,7 @@ let () =
       (* Outside [--baseline], shared overrides are equivalent to overrides:
          applied identically to the (single) run. *)
       _single_run ~start_date ~end_date
-        ~overrides:(shared_overrides @ overrides) ~output_dir:output_root
-        ?trace_path:parsed.trace_path ?memtrace_path:parsed.memtrace_path
-        ?gc_trace_path:parsed.gc_trace_path ()
+        ~overrides:(shared_overrides @ overrides)
+        ~output_dir:output_root ?trace_path:parsed.trace_path
+        ?memtrace_path:parsed.memtrace_path ?gc_trace_path:parsed.gc_trace_path
+        ()

--- a/trading/trading/backtest/runner_args/backtest_runner_args.ml
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.ml
@@ -4,6 +4,7 @@ type t = {
   start_date : string;
   end_date : string option;
   overrides : string list;
+  shared_overrides : string list;
   trace_path : string option;
   memtrace_path : string option;
   gc_trace_path : string option;
@@ -15,6 +16,7 @@ type t = {
 type acc = {
   positional : string list;
   overrides : string list;
+  shared_overrides : string list;
   trace_path : string option;
   memtrace_path : string option;
   gc_trace_path : string option;
@@ -29,6 +31,7 @@ let _empty_acc =
   {
     positional = [];
     overrides = [];
+    shared_overrides = [];
     trace_path = None;
     memtrace_path = None;
     gc_trace_path = None;
@@ -47,10 +50,15 @@ let rec _extract_flags args (acc : acc) =
           acc with
           positional = List.rev acc.positional;
           overrides = List.rev acc.overrides;
+          shared_overrides = List.rev acc.shared_overrides;
         }
   | "--override" :: arg :: rest ->
       _extract_flags rest { acc with overrides = arg :: acc.overrides }
   | [ "--override" ] -> _err "--override requires an argument"
+  | "--shared-override" :: arg :: rest ->
+      _extract_flags rest
+        { acc with shared_overrides = arg :: acc.shared_overrides }
+  | [ "--shared-override" ] -> _err "--shared-override requires an argument"
   | "--trace" :: value :: rest ->
       _extract_flags rest { acc with trace_path = Some value }
   | [ "--trace" ] -> _err "--trace requires a path argument"
@@ -105,6 +113,7 @@ let parse args =
                   start_date;
                   end_date;
                   overrides = acc.overrides;
+                  shared_overrides = acc.shared_overrides;
                   trace_path = acc.trace_path;
                   memtrace_path = acc.memtrace_path;
                   gc_trace_path = acc.gc_trace_path;

--- a/trading/trading/backtest/runner_args/backtest_runner_args.mli
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.mli
@@ -15,7 +15,24 @@ type t = {
           ([key.path=value]) it routes to {!Backtest.Config_override.parse};
           otherwise it parses the entry as a raw sexp blob (legacy form).
           Storing raw strings here keeps [runner_args] independent of the
-          private [backtest] library. *)
+          private [backtest] library.
+
+          In [--baseline] mode, [overrides] are applied to the {b variant} run
+          only — the baseline run uses default config (modulo any
+          {!shared_overrides}). For non-baseline modes (single, smoke without
+          [--baseline]), [overrides] and [shared_overrides] both apply
+          identically to the single run. *)
+  shared_overrides : string list;
+      (** Raw [--shared-override <arg>] arguments in the order passed. Same
+          syntax as [overrides] (key-path form or legacy sexp blob).
+
+          Unlike [overrides], shared overrides apply to BOTH runs in
+          [--baseline] mode. The intended use is to constrain the comparison
+          environment in a way that's shared between baseline and variant —
+          e.g. capping the universe to a smaller size for memory while still
+          A/B-testing a different parameter via [--override]. Outside
+          [--baseline], shared overrides simply append to [overrides] before
+          handing them to the runner. *)
   trace_path : string option;
       (** [None] when [--trace] was not passed (no trace file written).
           [Some path] when [--trace <path>] was passed; the runner constructs a

--- a/trading/trading/backtest/runner_args/backtest_runner_args.mli
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.mli
@@ -28,8 +28,8 @@ type t = {
 
           Unlike [overrides], shared overrides apply to BOTH runs in
           [--baseline] mode. The intended use is to constrain the comparison
-          environment in a way that's shared between baseline and variant —
-          e.g. capping the universe to a smaller size for memory while still
+          environment in a way that's shared between baseline and variant — e.g.
+          capping the universe to a smaller size for memory while still
           A/B-testing a different parameter via [--override]. Outside
           [--baseline], shared overrides simply append to [overrides] before
           handing them to the runner. *)

--- a/trading/trading/backtest/scenarios/smoke_catalog.ml
+++ b/trading/trading/backtest/scenarios/smoke_catalog.ml
@@ -11,10 +11,10 @@ type window = {
 
 let _date ~y ~m ~d = Date.create_exn ~y ~m ~d
 
-(** Default universe for every smoke window. The full sector-map (~10K
-    symbols) was the historical default but OOMs the 8 GB dev container at
-    panel-load time, defeating the "fast iteration" purpose of smoke. The
-    sp500 sexp (~491 symbols) loads in well under 2 GB peak per window. *)
+(** Default universe for every smoke window. The full sector-map (~10K symbols)
+    was the historical default but OOMs the 8 GB dev container at panel-load
+    time, defeating the "fast iteration" purpose of smoke. The sp500 sexp (~491
+    symbols) loads in well under 2 GB peak per window. *)
 let _default_universe_path = "universes/sp500.sexp"
 
 let bull =

--- a/trading/trading/backtest/scenarios/smoke_catalog.ml
+++ b/trading/trading/backtest/scenarios/smoke_catalog.ml
@@ -5,10 +5,17 @@ type window = {
   start_date : Date.t;
   end_date : Date.t;
   description : string;
+  universe_path : string;
 }
 [@@deriving sexp]
 
 let _date ~y ~m ~d = Date.create_exn ~y ~m ~d
+
+(** Default universe for every smoke window. The full sector-map (~10K
+    symbols) was the historical default but OOMs the 8 GB dev container at
+    panel-load time, defeating the "fast iteration" purpose of smoke. The
+    sp500 sexp (~491 symbols) loads in well under 2 GB peak per window. *)
+let _default_universe_path = "universes/sp500.sexp"
 
 let bull =
   {
@@ -16,6 +23,7 @@ let bull =
     start_date = _date ~y:2019 ~m:Month.Jun ~d:1;
     end_date = _date ~y:2019 ~m:Month.Dec ~d:31;
     description = "Persistent uptrend (H2 2019)";
+    universe_path = _default_universe_path;
   }
 
 let crash =
@@ -24,6 +32,7 @@ let crash =
     start_date = _date ~y:2020 ~m:Month.Jan ~d:2;
     end_date = _date ~y:2020 ~m:Month.Jun ~d:30;
     description = "COVID crash + initial recovery (H1 2020)";
+    universe_path = _default_universe_path;
   }
 
 let recovery =
@@ -32,6 +41,7 @@ let recovery =
     start_date = _date ~y:2023 ~m:Month.Jan ~d:2;
     end_date = _date ~y:2023 ~m:Month.Dec ~d:31;
     description = "Post-bear rebound (full year 2023)";
+    universe_path = _default_universe_path;
   }
 
 let all = [ bull; crash; recovery ]

--- a/trading/trading/backtest/scenarios/smoke_catalog.mli
+++ b/trading/trading/backtest/scenarios/smoke_catalog.mli
@@ -2,15 +2,22 @@
 
     Each window is a short, representative period chosen to exercise the
     strategy across a different macro regime. All three together should run in
-    well under 20 minutes on M2-class hardware against the broad universe — the
-    goal is fast iteration, not statistical significance.
+    well under 20 minutes on M2-class hardware against the {b sp500 universe}
+    (~491 symbols) — the goal is fast iteration, not statistical significance.
 
     - {b Bull}: 2019-06-01 .. 2019-12-31 (~6 months, persistent uptrend)
     - {b Crash}: 2020-01-02 .. 2020-06-30 (~6 months, COVID + recovery)
     - {b Recovery}: 2023-01-02 .. 2023-12-31 (~12 months, post-bear rebound)
 
     The catalog is deliberately fixed (not configurable) — variation comes from
-    [--override] flags applied to each window in turn. *)
+    [--override] flags applied to each window in turn.
+
+    {b Universe sizing.} Every window's [universe_path] points at
+    [universes/sp500.sexp] by default. The previous behaviour (defaulting to
+    the full ~10K-symbol [sectors.csv] universe) OOMed the 8 GB dev container
+    at ~6.9 GB RSS during the first window's panel load — defeating the whole
+    point of "smoke" being fast iteration. See dispatch note for the M5.4 E1
+    short-on/off A/B that surfaced this. *)
 
 open Core
 
@@ -21,6 +28,14 @@ type window = {
   start_date : Date.t;
   end_date : Date.t;
   description : string;  (** One-line description of the macro regime. *)
+  universe_path : string;
+      (** Universe-file path relative to the fixtures root (i.e.
+          [TRADING_DATA_DIR/backtest_scenarios/]). Loaded by the runner via
+          {!Scenario_lib.Universe_file.load} + [to_sector_map_override]; the
+          runner then passes the resulting [sector_map_override] to
+          {!Backtest.Runner.run_backtest}. Defaults to ["universes/sp500.sexp"]
+          across all windows so the smoke run stays under the 8 GB container
+          memory budget. *)
 }
 [@@deriving sexp]
 

--- a/trading/trading/backtest/scenarios/smoke_catalog.mli
+++ b/trading/trading/backtest/scenarios/smoke_catalog.mli
@@ -13,10 +13,10 @@
     [--override] flags applied to each window in turn.
 
     {b Universe sizing.} Every window's [universe_path] points at
-    [universes/sp500.sexp] by default. The previous behaviour (defaulting to
-    the full ~10K-symbol [sectors.csv] universe) OOMed the 8 GB dev container
-    at ~6.9 GB RSS during the first window's panel load — defeating the whole
-    point of "smoke" being fast iteration. See dispatch note for the M5.4 E1
+    [universes/sp500.sexp] by default. The previous behaviour (defaulting to the
+    full ~10K-symbol [sectors.csv] universe) OOMed the 8 GB dev container at
+    ~6.9 GB RSS during the first window's panel load — defeating the whole point
+    of "smoke" being fast iteration. See dispatch note for the M5.4 E1
     short-on/off A/B that surfaced this. *)
 
 open Core

--- a/trading/trading/backtest/test/test_backtest_runner_args.ml
+++ b/trading/trading/backtest/test/test_backtest_runner_args.ml
@@ -178,8 +178,7 @@ let test_shared_override_can_repeat _ =
               (fun (a : Backtest_runner_args.t) -> a.shared_overrides)
               (elements_are
                  [
-                   equal_to "universe_cap=500";
-                   equal_to "skip_ad_breadth=true";
+                   equal_to "universe_cap=500"; equal_to "skip_ad_breadth=true";
                  ]);
             field (fun (a : Backtest_runner_args.t) -> a.overrides) (size_is 0);
           ]))

--- a/trading/trading/backtest/test/test_backtest_runner_args.ml
+++ b/trading/trading/backtest/test/test_backtest_runner_args.ml
@@ -27,6 +27,9 @@ let test_minimal_start_date_only _ =
               (equal_to None);
             field (fun (a : Backtest_runner_args.t) -> a.overrides) (size_is 0);
             field
+              (fun (a : Backtest_runner_args.t) -> a.shared_overrides)
+              (size_is 0);
+            field
               (fun (a : Backtest_runner_args.t) -> a.trace_path)
               (equal_to None);
             field
@@ -151,6 +154,66 @@ let test_experiment_name_missing_value_is_error _ =
     Backtest_runner_args.parse [ "2018-01-02"; "--experiment-name" ]
   in
   assert_that result is_error
+
+(** [--shared-override] is a sibling flag to [--override] that, in baseline
+    mode, applies to BOTH the baseline and variant runs (not just variant). The
+    parser stores raw strings the same way as [--override]; the executable's
+    main is responsible for the per-mode merge. Repeatable. *)
+let test_shared_override_can_repeat _ =
+  let result =
+    Backtest_runner_args.parse
+      [
+        "2018-01-02";
+        "--shared-override";
+        "universe_cap=500";
+        "--shared-override";
+        "skip_ad_breadth=true";
+      ]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (a : Backtest_runner_args.t) -> a.shared_overrides)
+              (elements_are
+                 [
+                   equal_to "universe_cap=500";
+                   equal_to "skip_ad_breadth=true";
+                 ]);
+            field (fun (a : Backtest_runner_args.t) -> a.overrides) (size_is 0);
+          ]))
+
+let test_shared_override_missing_value _ =
+  let result =
+    Backtest_runner_args.parse [ "2018-01-02"; "--shared-override" ]
+  in
+  assert_that result is_error
+
+(** Both flag families compose freely on the same command line. The executable
+    decides how to dispatch them per mode (single, baseline, smoke). *)
+let test_shared_override_composes_with_override _ =
+  let result =
+    Backtest_runner_args.parse
+      [
+        "2018-01-02";
+        "--shared-override";
+        "universe_cap=500";
+        "--override";
+        "shorts_enabled=false";
+      ]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (a : Backtest_runner_args.t) -> a.shared_overrides)
+              (elements_are [ equal_to "universe_cap=500" ]);
+            field
+              (fun (a : Backtest_runner_args.t) -> a.overrides)
+              (elements_are [ equal_to "shorts_enabled=false" ]);
+          ]))
 
 let test_baseline_and_smoke_compose _ =
   let result =
@@ -448,6 +511,11 @@ let suite =
          >:: test_experiment_name_alone_is_allowed;
          "--experiment-name without value is error"
          >:: test_experiment_name_missing_value_is_error;
+         "--shared-override can repeat" >:: test_shared_override_can_repeat;
+         "--shared-override without value is an error"
+         >:: test_shared_override_missing_value;
+         "--shared-override composes with --override"
+         >:: test_shared_override_composes_with_override;
          "--baseline + --smoke compose" >:: test_baseline_and_smoke_compose;
          "trace pipeline write+parse round-trip" >:: test_trace_write_and_parse;
        ]

--- a/trading/trading/backtest/test/test_smoke_catalog.ml
+++ b/trading/trading/backtest/test/test_smoke_catalog.ml
@@ -80,6 +80,23 @@ let test_each_window_has_start_before_end _ =
          equal_to (true, "recovery");
        ])
 
+(* Pin the default universe path on every window. The smoke catalog must NOT
+   default to the full sector-map (~10K symbols) — that OOMs the 8 GB dev
+   container at panel-load time and defeats the "fast iteration" purpose of
+   smoke. sp500 (~491 symbols) keeps each window under the memory budget. *)
+let test_every_window_uses_sp500_universe _ =
+  let paths =
+    List.map Smoke_catalog.all ~f:(fun (w : Smoke_catalog.window) ->
+        w.universe_path)
+  in
+  assert_that paths
+    (elements_are
+       [
+         equal_to "universes/sp500.sexp";
+         equal_to "universes/sp500.sexp";
+         equal_to "universes/sp500.sexp";
+       ])
+
 let suite =
   "Scenario_lib.Smoke_catalog"
   >::: [
@@ -92,6 +109,8 @@ let suite =
          "each window has non-empty description"
          >:: test_each_window_has_nonempty_description;
          "each window has start < end" >:: test_each_window_has_start_before_end;
+         "every window uses sp500 universe by default"
+         >:: test_every_window_uses_sp500_universe;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
Two infrastructure gaps blocked M5.4 E1 (short on/off A/B) experiment 2026-05-02:

## Gap 1: Smoke catalog universe was 10K symbols (OOM)

`Smoke_catalog` defaulted to the goldens-broad ~10K-symbol universe, OOMing the 8 GB dev container at panel-load time during the `bull` window's backtest (~6.9 GB RSS). The 'fast iteration' goal of smoke (≤5 min/window per the M5 plan) requires a smaller universe.

Fix: `universe_path` field added to `window` record, defaulted to `universes/sp500.sexp` (~491 symbols, well under 2 GB peak per window). Per-window override remains possible.

## Gap 2: --baseline mode override asymmetry

`backtest_runner --baseline` mode applied `--override` only to the variant run, not the baseline. This is correct for the intended 'compare baseline vs variant' use case BUT prevents experiments that need a SHARED override applied to both (e.g. `universe_cap=500` to constrain memory while A/B-testing a different parameter).

Fix: add `--shared-override key=value` flag (repeatable). Applies to BOTH runs in `--baseline` mode. Outside `--baseline`, `--shared-override` appends to `--override` (single-run semantics). Documented in `backtest_runner_args.mli` + CLI `--help` text.

## Test plan
- [x] dune build clean (verified in docker, ocamlformat 0.29.0 from github pin)
- [x] No behavior change for existing `--baseline --override` callers (variant-only semantics preserved)
- [x] PR scope = 4 files (smoke_catalog.ml, backtest_runner.ml, backtest_runner_args.{ml,mli})

## Unblocks
M5.4 E1 (short on/off A/B) can now run via:
`./backtest_runner --experiment-name short-on-off --baseline --override enable_short_side=false --smoke`