### PR TITLE
feat(synth-v2): 3-regime HMM + per-regime GARCH price generator (M7.0 Track 3)

### DIFF
--- a/trading/analysis/data/synthetic/bin/dune
+++ b/trading/analysis/data/synthetic/bin/dune
@@ -1,6 +1,6 @@
-(executable
- (name generate_synth)
- (modules generate_synth)
+(executables
+ (names generate_synth generate_synth_v2)
+ (modules generate_synth generate_synth_v2)
  (libraries core core_unix.command_unix status synthetic types)
  (preprocess
   (pps ppx_jane)))

--- a/trading/analysis/data/synthetic/bin/generate_synth_v2.ml
+++ b/trading/analysis/data/synthetic/bin/generate_synth_v2.ml
@@ -1,0 +1,76 @@
+(** generate_synth_v2 — emit a synthetic daily-price series via the regime-
+    switching HMM + GARCH model (Synth-v2).
+
+    Unlike Synth-v1 ([generate_synth]) this binary does NOT take a real source
+    series; the HMM and per-regime GARCH params are hand-set defaults documented
+    in [Synth_v2]. A follow-up PR will add fit-from-history.
+
+    Output: CSV on stdout (or to [-output PATH]).
+
+    Example:
+    {v
+      generate_synth_v2.exe -target-days 20000 -seed 42 \
+        -start-date 1990-01-02 -start-price 100
+    v} *)
+
+open Core
+
+let _emit_csv_header oc =
+  Out_channel.output_string oc
+    "date,open,high,low,close,adjusted_close,volume\n"
+
+let _emit_csv_row oc (b : Types.Daily_price.t) =
+  Out_channel.fprintf oc "%s,%.4f,%.4f,%.4f,%.4f,%.4f,%d\n"
+    (Date.to_string b.date) b.open_price b.high_price b.low_price b.close_price
+    b.adjusted_close b.volume
+
+let _write_bars ~output bars =
+  let with_oc oc =
+    _emit_csv_header oc;
+    List.iter bars ~f:(_emit_csv_row oc)
+  in
+  match output with
+  | None -> with_oc Out_channel.stdout
+  | Some path -> Out_channel.with_file path ~f:with_oc
+
+let main ~target_days ~seed ~start_date ~start_price ~output () =
+  let cfg =
+    Synthetic.Synth_v2.default_config
+      ~start_date:(Date.of_string start_date)
+      ~start_price ~target_length_days:target_days ~seed
+  in
+  match Synthetic.Synth_v2.generate cfg with
+  | Error e ->
+      Printf.eprintf "Error generating synth: %s\n%!" (Status.show e);
+      exit 1
+  | Ok bars ->
+      _write_bars ~output bars;
+      Printf.eprintf "Wrote %d synthetic bars\n%!" (List.length bars)
+
+let command =
+  Command.basic
+    ~summary:
+      "Generate a synthetic daily-price series via 3-regime HMM + GARCH \
+       (Synth-v2)"
+    (let%map_open.Command target_days =
+       flag "target-days" (required int)
+         ~doc:"N Number of synthetic bars to emit"
+     and seed =
+       flag "seed"
+         (optional_with_default 42 int)
+         ~doc:"N PRNG seed (default: 42)"
+     and start_date =
+       flag "start-date"
+         (optional_with_default "1990-01-02" string)
+         ~doc:"YYYY-MM-DD First synthetic bar date (default: 1990-01-02)"
+     and start_price =
+       flag "start-price"
+         (optional_with_default 100.0 float)
+         ~doc:"P First synthetic bar's close (default: 100.0)"
+     and output =
+       flag "output" (optional string)
+         ~doc:"PATH Write CSV to this file (default: stdout)"
+     in
+     fun () -> main ~target_days ~seed ~start_date ~start_price ~output ())
+
+let () = Command_unix.run command

--- a/trading/analysis/data/synthetic/lib/dune
+++ b/trading/analysis/data/synthetic/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name synthetic)
  (public_name synthetic)
- (modules block_bootstrap source_loader)
+ (modules block_bootstrap source_loader regime_hmm garch synth_v2)
  (libraries core core_unix.sys_unix csv status types)
  (preprocess
-  (pps ppx_deriving.show ppx_deriving.eq)))
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/analysis/data/synthetic/lib/garch.ml
+++ b/trading/analysis/data/synthetic/lib/garch.ml
@@ -1,0 +1,107 @@
+open Core
+
+type params = { omega : float; alpha : float; beta : float }
+[@@deriving sexp, eq, show]
+
+(* Hard cap on σ² to keep generated returns finite when callers pass
+   parameters very close to the stationarity boundary. The cap corresponds
+   to a daily stdev of ~1.0, well above any realistic regime; it only trips
+   when [α + β] is numerically near 1. *)
+let _max_variance = 1.0
+
+let long_run_variance p =
+  let denom = 1.0 -. p.alpha -. p.beta in
+  if Float.(denom <= 0.0) then None else Some (p.omega /. denom)
+
+(* ---------------------------------------------------------------------- *)
+(* Validation                                                             *)
+(* ---------------------------------------------------------------------- *)
+
+let _check_finite name x =
+  if Float.is_finite x then Ok ()
+  else
+    Status.error_invalid_argument
+      (Printf.sprintf "garch: %s must be finite (got %f)" name x)
+
+let _check_omega_positive omega =
+  if Float.(omega > 0.0) then Ok ()
+  else
+    Status.error_invalid_argument
+      (Printf.sprintf "garch: omega must be > 0 (got %.6e)" omega)
+
+let _check_non_negative name x =
+  if Float.(x >= 0.0) then Ok ()
+  else
+    Status.error_invalid_argument
+      (Printf.sprintf "garch: %s must be >= 0 (got %.6e)" name x)
+
+let _check_stationary alpha beta =
+  if Float.(alpha +. beta < 1.0) then Ok ()
+  else
+    Status.error_invalid_argument
+      (Printf.sprintf
+         "garch: alpha + beta must be < 1 for stationarity (got %.6f)"
+         (alpha +. beta))
+
+let validate p =
+  Status.combine_status_list
+    [
+      _check_finite "omega" p.omega;
+      _check_finite "alpha" p.alpha;
+      _check_finite "beta" p.beta;
+      _check_omega_positive p.omega;
+      _check_non_negative "alpha" p.alpha;
+      _check_non_negative "beta" p.beta;
+      _check_stationary p.alpha p.beta;
+    ]
+
+(* ---------------------------------------------------------------------- *)
+(* Sampling                                                               *)
+(* ---------------------------------------------------------------------- *)
+
+(* Box-Muller — two U(0,1) samples to one N(0,1) sample. We discard the
+   second normal for simplicity; this is fine for fixture data. *)
+let _normal_sample rng =
+  let u1 = Stdlib.Random.State.float rng 1.0 in
+  let u2 = Stdlib.Random.State.float rng 1.0 in
+  let u1' = Float.max u1 Float.min_positive_normal_value in
+  Float.sqrt (-2.0 *. Float.log u1') *. Float.cos (2.0 *. Float.pi *. u2)
+
+let _clamp_variance v = Float.min _max_variance (Float.max 0.0 v)
+
+let _next_variance ~params ~prev_eps ~prev_var =
+  let raw =
+    params.omega
+    +. (params.alpha *. (prev_eps ** 2.0))
+    +. (params.beta *. prev_var)
+  in
+  _clamp_variance raw
+
+let _check_initial_variance v =
+  if Float.is_finite v && Float.(v >= 0.0) then Ok ()
+  else
+    Status.error_invalid_argument
+      (Printf.sprintf "garch: initial_variance must be finite and >= 0 (got %f)"
+         v)
+
+let sample_returns params ~n_steps ~seed ~initial_variance =
+  if n_steps <= 0 then []
+  else
+    let validation =
+      Status.combine_status_list
+        [ validate params; _check_initial_variance initial_variance ]
+    in
+    match validation with
+    | Error e -> invalid_arg ("garch: " ^ Status.show e)
+    | Ok () ->
+        let rng = Stdlib.Random.State.make [| seed |] in
+        let out = Array.create ~len:n_steps 0.0 in
+        let var = ref (_clamp_variance initial_variance) in
+        for k = 0 to n_steps - 1 do
+          let z = _normal_sample rng in
+          let sigma = Float.sqrt !var in
+          let eps = sigma *. z in
+          out.(k) <- eps;
+          var := _next_variance ~params ~prev_eps:eps ~prev_var:!var
+        done;
+        Array.to_list out

--- a/trading/analysis/data/synthetic/lib/garch.mli
+++ b/trading/analysis/data/synthetic/lib/garch.mli
@@ -1,0 +1,49 @@
+(** GARCH(1,1) variance simulation.
+
+    Bollerslev (1986). The GARCH(1,1) variance recursion is:
+    {v
+      σ²_t = ω + α · ε²_{t-1} + β · σ²_{t-1}
+      ε_t  = σ_t · z_t,    z_t ~ N(0, 1)
+    v}
+    where [ω > 0], [α >= 0], [β >= 0]. A finite long-run variance requires
+    [α + β < 1]; otherwise variance is non-stationary and grows without bound.
+    The long-run (unconditional) variance is [ω / (1 - α - β)].
+
+    This module exposes a single sampler [sample_returns] that emits a list of
+    GARCH-driven log-returns of arbitrary length, deterministic in the seed. The
+    variance recursion is updated using the realised shock at each step; the
+    returned series is the [ε_t] sequence (not [σ²_t]).
+
+    Numerical safety: the recursion is clamped to a non-negative variance and a
+    hard upper bound to keep generated returns finite even when callers pass
+    near-explosive parameters [α + β ≈ 1]. The clamps trip only when caller
+    parameters violate [α + β < 1]; well-behaved parameters never reach them. *)
+
+type params = {
+  omega : float;  (** Baseline variance term, must be > 0. *)
+  alpha : float;  (** Shock weight ([ε²_{t-1}] coefficient), must be >= 0. *)
+  beta : float;
+      (** Persistence weight ([σ²_{t-1}] coefficient), must be >= 0. *)
+}
+[@@deriving sexp, eq, show]
+
+val long_run_variance : params -> float option
+(** [long_run_variance p] returns [Some (omega / (1 - alpha - beta))] when
+    [alpha + beta < 1] (stationary regime) and [None] otherwise. Useful as the
+    natural [initial_variance] when a caller has no prior estimate. *)
+
+val validate : params -> (unit, Status.t) Result.t
+(** Returns [Error Status.Invalid_argument] for non-finite, negative, or
+    non-stationary parameters. Stationarity check is [alpha + beta < 1]. *)
+
+val sample_returns :
+  params -> n_steps:int -> seed:int -> initial_variance:float -> float list
+(** [sample_returns params ~n_steps ~seed ~initial_variance] generates [n_steps]
+    GARCH-driven returns. The variance at step 0 is [initial_variance]; the
+    shock at step 0 is drawn against that variance. For [k >= 1] the variance at
+    step [k] uses the recursion above with the realised [ε²_{k-1}] and
+    [σ²_{k-1}].
+
+    Returns the empty list when [n_steps <= 0]. Raises [Invalid_argument] if
+    [params] fails [validate] or if [initial_variance < 0]; callers should
+    validate up front. *)

--- a/trading/analysis/data/synthetic/lib/regime_hmm.ml
+++ b/trading/analysis/data/synthetic/lib/regime_hmm.ml
@@ -1,0 +1,125 @@
+open Core
+
+type regime = Bull | Bear | Crisis [@@deriving sexp, eq, show]
+type transition_matrix = (regime * (regime * float) list) list
+type t = { initial_regime : regime; transitions : transition_matrix }
+
+(* Tolerance for "row sums to 1". Each transition row is a tiny float
+   association list; floating-point sums of three exact decimals like
+   0.97 + 0.025 + 0.005 land within ~1e-15. We use a generous epsilon
+   so hand-set matrices entered as decimal literals always pass. *)
+let _prob_epsilon = 1e-9
+
+(* Hand-set defaults — see regime_hmm.mli for rationale. *)
+let default_transitions : transition_matrix =
+  [
+    (Bull, [ (Bull, 0.97); (Bear, 0.025); (Crisis, 0.005) ]);
+    (Bear, [ (Bull, 0.05); (Bear, 0.93); (Crisis, 0.02) ]);
+    (Crisis, [ (Bull, 0.10); (Bear, 0.25); (Crisis, 0.65) ]);
+  ]
+
+let default = { initial_regime = Bull; transitions = default_transitions }
+
+(* ---------------------------------------------------------------------- *)
+(* Validation                                                             *)
+(* ---------------------------------------------------------------------- *)
+
+let _all_regimes = [ Bull; Bear; Crisis ]
+
+let _check_row_present transitions r =
+  if List.Assoc.mem transitions ~equal:equal_regime r then Ok ()
+  else
+    Status.error_invalid_argument
+      (Printf.sprintf "transition matrix missing row for regime %s"
+         (show_regime r))
+
+let _check_row_entries row =
+  let missing =
+    List.filter _all_regimes ~f:(fun r ->
+        not (List.Assoc.mem row ~equal:equal_regime r))
+  in
+  match missing with
+  | [] -> Ok ()
+  | r :: _ ->
+      Status.error_invalid_argument
+        (Printf.sprintf "transition row missing entry for %s" (show_regime r))
+
+let _check_row_probs row =
+  let bad =
+    List.find row ~f:(fun (_, p) -> Float.(p < 0.0) || Float.(p > 1.0))
+  in
+  match bad with
+  | Some (r, p) ->
+      Status.error_invalid_argument
+        (Printf.sprintf "transition probability out of [0,1] for %s: %.6f"
+           (show_regime r) p)
+  | None -> Ok ()
+
+let _check_row_sum row =
+  let s = List.sum (module Float) row ~f:snd in
+  if Float.(abs (s -. 1.0) <= _prob_epsilon) then Ok ()
+  else
+    Status.error_invalid_argument
+      (Printf.sprintf "transition row sums to %.9f (expected 1.0)" s)
+
+let _validate_row transitions r =
+  match List.Assoc.find transitions ~equal:equal_regime r with
+  | None ->
+      Status.error_invalid_argument
+        (Printf.sprintf "no row for %s" (show_regime r))
+  | Some row ->
+      Status.combine_status_list
+        [ _check_row_entries row; _check_row_probs row; _check_row_sum row ]
+
+let validate t =
+  let row_presence =
+    List.map _all_regimes ~f:(_check_row_present t.transitions)
+  in
+  let row_validations =
+    List.map _all_regimes ~f:(_validate_row t.transitions)
+  in
+  Status.combine_status_list (row_presence @ row_validations)
+
+(* ---------------------------------------------------------------------- *)
+(* Sampling                                                               *)
+(* ---------------------------------------------------------------------- *)
+
+(* Inverse-CDF sampling on a discrete distribution. Walk the row in fixed
+   order; cumulate probabilities; return the first regime whose cumulative
+   exceeds the uniform draw. We canonicalise the iteration order via
+   [_all_regimes] so the result is independent of how the caller spelled
+   the row association list. *)
+let _sample_next_regime ~rng ~row =
+  let u = Stdlib.Random.State.float rng 1.0 in
+  let rec walk acc = function
+    | [] -> List.last_exn _all_regimes
+    | r :: rest ->
+        let p =
+          List.Assoc.find row ~equal:equal_regime r |> Option.value ~default:0.0
+        in
+        let acc' = acc +. p in
+        if Float.(u <= acc') then r else walk acc' rest
+  in
+  walk 0.0 _all_regimes
+
+let _row_for ~transitions r =
+  match List.Assoc.find transitions ~equal:equal_regime r with
+  | Some row -> row
+  | None ->
+      invalid_arg
+        (Printf.sprintf "regime_hmm: missing transition row for %s"
+           (show_regime r))
+
+let sample_path t ~n_steps ~seed =
+  if n_steps <= 0 then []
+  else
+    match validate t with
+    | Error e -> invalid_arg ("regime_hmm: invalid t — " ^ Status.show e)
+    | Ok () ->
+        let rng = Stdlib.Random.State.make [| seed |] in
+        let arr = Array.create ~len:n_steps t.initial_regime in
+        for k = 1 to n_steps - 1 do
+          let row = _row_for ~transitions:t.transitions arr.(k - 1) in
+          arr.(k) <- _sample_next_regime ~rng ~row
+        done;
+        Array.to_list arr

--- a/trading/analysis/data/synthetic/lib/regime_hmm.mli
+++ b/trading/analysis/data/synthetic/lib/regime_hmm.mli
@@ -1,0 +1,60 @@
+(** Three-regime hidden Markov model — Bull / Bear / Crisis.
+
+    Synth-v2's regime layer. The HMM models market regime persistence — the
+    statistical property that block bootstrap (Synth-v1) demonstrably misses
+    because block boundaries break regime continuity. Here, regime evolution is
+    driven by an explicit Markov chain over [Bull], [Bear], [Crisis]; the
+    per-step output (volatility, drift) lives in sibling modules ([Garch],
+    [Synth_v2]).
+
+    A regime path is sampled by repeatedly drawing the next regime from the
+    current regime's row of the transition matrix. Determinism: same
+    [initial_regime] + same transition matrix + same seed produces an identical
+    path.
+
+    Calibration TODO: the hand-set defaults below were chosen so that mean
+    durations roughly match historical SPY bull/bear/crisis cycles (~33 / 15 / 3
+    months respectively). A follow-up PR will fit the matrix from real history
+    (Baum-Welch / EM). *)
+
+type regime = Bull | Bear | Crisis [@@deriving sexp, eq, show]
+
+type transition_matrix = (regime * (regime * float) list) list
+(** Row-stochastic 3x3 matrix expressed as an association list.
+    [List.assoc r matrix] yields [(r', p)] pairs; the inner list's [p] values
+    must sum to 1.0 (within [_prob_epsilon]) and be non-negative. *)
+
+type t = {
+  initial_regime : regime;
+      (** Starting regime for sampled paths; treated as the regime at step 0. *)
+  transitions : transition_matrix;
+      (** Row-stochastic matrix governing per-step regime transitions. *)
+}
+
+val default_transitions : transition_matrix
+(** Hand-set defaults documented in the module-level comment. Chosen so:
+    - Mean Bull duration ≈ 1 / (1 - 0.97) ≈ 33 steps (interpreted as months when
+      paired with monthly drivers; the HMM itself is unitless).
+    - Mean Bear duration ≈ 1 / (1 - 0.93) ≈ 15 steps.
+    - Mean Crisis duration ≈ 1 / (1 - 0.65) ≈ ~3 steps; Crisis is rarely entered
+      (Bull→Crisis 0.005, Bear→Crisis 0.02).
+
+    Calibration TODO: re-derive from a Baum-Welch fit on 30y SPY history. *)
+
+val default : t
+(** Bull initial regime + [default_transitions]. Convenience constructor for
+    callers that want the canonical hand-set HMM. *)
+
+val validate : t -> (unit, Status.t) Result.t
+(** Returns [Error Status.Invalid_argument] if any of:
+    - a transition row is missing (must have entries for all three regimes);
+    - a probability is negative or > 1.0;
+    - a row's probabilities don't sum to 1.0 (within numerical tolerance). *)
+
+val sample_path : t -> n_steps:int -> seed:int -> regime list
+(** [sample_path t ~n_steps ~seed] returns a regime sequence of length
+    [n_steps]. The first element is [t.initial_regime]; element [k+1] is drawn
+    from the row of [t.transitions] keyed by element [k].
+
+    Returns the empty list when [n_steps <= 0]. Raises [Invalid_argument] if [t]
+    fails [validate]; callers should validate up front. *)

--- a/trading/analysis/data/synthetic/lib/synth_v2.ml
+++ b/trading/analysis/data/synthetic/lib/synth_v2.ml
@@ -1,0 +1,231 @@
+open Core
+
+type config = {
+  hmm : Regime_hmm.t;
+  garch_per_regime : (Regime_hmm.regime * Garch.params) list;
+  drift_per_regime : (Regime_hmm.regime * float) list;
+  start_price : float;
+  target_length_days : int;
+  start_date : Date.t;
+  seed : int;
+}
+
+(* Hand-set per-regime defaults — see synth_v2.mli for rationale. *)
+let default_garch_per_regime : (Regime_hmm.regime * Garch.params) list =
+  [
+    (Regime_hmm.Bull, { omega = 1e-6; alpha = 0.05; beta = 0.93 });
+    (Regime_hmm.Bear, { omega = 1e-5; alpha = 0.10; beta = 0.85 });
+    (Regime_hmm.Crisis, { omega = 5e-5; alpha = 0.20; beta = 0.75 });
+  ]
+
+let default_drift_per_regime : (Regime_hmm.regime * float) list =
+  [
+    (Regime_hmm.Bull, 0.0005);
+    (Regime_hmm.Bear, -0.0003);
+    (Regime_hmm.Crisis, -0.002);
+  ]
+
+let default_config ~start_date ~start_price ~target_length_days ~seed =
+  {
+    hmm = Regime_hmm.default;
+    garch_per_regime = default_garch_per_regime;
+    drift_per_regime = default_drift_per_regime;
+    start_price;
+    target_length_days;
+    start_date;
+    seed;
+  }
+
+(* ---------------------------------------------------------------------- *)
+(* Validation                                                             *)
+(* ---------------------------------------------------------------------- *)
+
+let _all_regimes = [ Regime_hmm.Bull; Regime_hmm.Bear; Regime_hmm.Crisis ]
+
+let _check_target_days n =
+  if n <= 0 then
+    Status.error_invalid_argument
+      (Printf.sprintf "target_length_days must be > 0 (got %d)" n)
+  else Ok ()
+
+let _check_start_price p =
+  if Float.(p <= 0.0) then
+    Status.error_invalid_argument
+      (Printf.sprintf "start_price must be > 0 (got %.4f)" p)
+  else Ok ()
+
+let _check_garch_assignment garch_per_regime r =
+  match List.Assoc.find garch_per_regime ~equal:Regime_hmm.equal_regime r with
+  | None ->
+      Status.error_invalid_argument
+        (Printf.sprintf "garch_per_regime missing entry for %s"
+           (Regime_hmm.show_regime r))
+  | Some p -> Garch.validate p
+
+let _check_drift_assignment drift_per_regime r =
+  if List.Assoc.mem drift_per_regime ~equal:Regime_hmm.equal_regime r then Ok ()
+  else
+    Status.error_invalid_argument
+      (Printf.sprintf "drift_per_regime missing entry for %s"
+         (Regime_hmm.show_regime r))
+
+let _validate config =
+  let garch_checks =
+    List.map _all_regimes ~f:(_check_garch_assignment config.garch_per_regime)
+  in
+  let drift_checks =
+    List.map _all_regimes ~f:(_check_drift_assignment config.drift_per_regime)
+  in
+  Status.combine_status_list
+    ([
+       _check_target_days config.target_length_days;
+       _check_start_price config.start_price;
+       Regime_hmm.validate config.hmm;
+     ]
+    @ garch_checks @ drift_checks)
+
+(* ---------------------------------------------------------------------- *)
+(* Calendar (mirrors Block_bootstrap)                                     *)
+(* ---------------------------------------------------------------------- *)
+
+let _next_business_day d =
+  let next = Date.add_days d 1 in
+  match Date.day_of_week next with
+  | Sat -> Date.add_days next 2
+  | Sun -> Date.add_days next 1
+  | _ -> next
+
+let _normalise_start_date d =
+  match Date.day_of_week d with
+  | Sat -> Date.add_days d 2
+  | Sun -> Date.add_days d 1
+  | _ -> d
+
+let _business_days ~start_date ~n =
+  let normalised_start = _normalise_start_date start_date in
+  let rec loop acc d remaining =
+    if remaining = 0 then List.rev acc
+    else loop (d :: acc) (_next_business_day d) (remaining - 1)
+  in
+  loop [] normalised_start n
+
+(* ---------------------------------------------------------------------- *)
+(* Bar shape                                                              *)
+(* ---------------------------------------------------------------------- *)
+
+(* Synthesise a well-formed bar from a close price + date. We don't model
+   intra-day structure here; a small fixed band around the close suffices for
+   downstream consumers that need OHLC. *)
+let _synthetic_volume = 10_000_000
+
+let _build_bar ~date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close *. 0.999;
+    high_price = close *. 1.005;
+    low_price = close *. 0.995;
+    close_price = close;
+    adjusted_close = close;
+    volume = _synthetic_volume;
+  }
+
+(* ---------------------------------------------------------------------- *)
+(* Generation                                                             *)
+(* ---------------------------------------------------------------------- *)
+
+let _drift_for ~drift_per_regime r =
+  List.Assoc.find drift_per_regime ~equal:Regime_hmm.equal_regime r
+  |> Option.value ~default:0.0
+
+let _params_for ~garch_per_regime r =
+  match List.Assoc.find garch_per_regime ~equal:Regime_hmm.equal_regime r with
+  | Some p -> p
+  | None ->
+      invalid_arg
+        (Printf.sprintf "synth_v2: missing GARCH params for regime %s"
+           (Regime_hmm.show_regime r))
+
+(* Box-Muller, same as Garch._normal_sample. Inlined here so the GARCH state
+   is owned by this module — we run a single recursion that switches
+   parameters when the regime switches, rather than calling Garch.sample_returns
+   per-regime (which would reset variance at each regime boundary). *)
+let _normal_sample rng =
+  let u1 = Stdlib.Random.State.float rng 1.0 in
+  let u2 = Stdlib.Random.State.float rng 1.0 in
+  let u1' = Float.max u1 Float.min_positive_normal_value in
+  Float.sqrt (-2.0 *. Float.log u1') *. Float.cos (2.0 *. Float.pi *. u2)
+
+(* Same hard cap as Garch._max_variance, kept locally to avoid leaking it
+   into the public Garch interface. *)
+let _max_variance = 1.0
+let _clamp_variance v = Float.min _max_variance (Float.max 0.0 v)
+
+let _initial_variance ~garch_per_regime ~initial_regime =
+  let p = _params_for ~garch_per_regime initial_regime in
+  match Garch.long_run_variance p with
+  | Some v -> v
+  | None ->
+      (* Stationarity is enforced by Garch.validate; this branch is a safety
+         net for non-stationary parameters that somehow slipped through. *)
+      p.omega
+
+(* Compose log-returns using a regime-switching GARCH variance recursion.
+   The variance carries forward across steps; only the (ω, α, β) parameters
+   switch on regime change. Returns drift + ε at each step. *)
+let _compose_log_returns ~regimes ~garch_per_regime ~drift_per_regime ~rng =
+  let n = List.length regimes in
+  let regimes_arr = Array.of_list regimes in
+  let out = Array.create ~len:n 0.0 in
+  let initial_regime = regimes_arr.(0) in
+  let var =
+    ref (_initial_variance ~garch_per_regime ~initial_regime |> _clamp_variance)
+  in
+  for k = 0 to n - 1 do
+    let r = regimes_arr.(k) in
+    let p = _params_for ~garch_per_regime r in
+    let z = _normal_sample rng in
+    let sigma = Float.sqrt !var in
+    let eps = sigma *. z in
+    let drift = _drift_for ~drift_per_regime r in
+    out.(k) <- drift +. eps;
+    let next_var = p.omega +. (p.alpha *. (eps ** 2.0)) +. (p.beta *. !var) in
+    var := _clamp_variance next_var
+  done;
+  Array.to_list out
+
+let _build_bars ~dates ~start_price ~log_returns =
+  let dates_arr = Array.of_list dates in
+  let returns_arr = Array.of_list log_returns in
+  let n = Array.length dates_arr in
+  let bars =
+    Array.create ~len:n (_build_bar ~date:dates_arr.(0) ~close:start_price)
+  in
+  bars.(0) <- _build_bar ~date:dates_arr.(0) ~close:start_price;
+  let prev_close = ref start_price in
+  for k = 1 to n - 1 do
+    (* Apply the (k-1)-th sampled return between bar k-1 and bar k. We have
+       n returns from the regime sampler but only need n-1 transitions; the
+       0-th return is implicit in the [start_price]. *)
+    let close = !prev_close *. Float.exp returns_arr.(k - 1) in
+    bars.(k) <- _build_bar ~date:dates_arr.(k) ~close;
+    prev_close := close
+  done;
+  Array.to_list bars
+
+let _generate_validated config =
+  let n = config.target_length_days in
+  let regimes =
+    Regime_hmm.sample_path config.hmm ~n_steps:n ~seed:config.seed
+  in
+  (* GARCH stream uses seed + 1 so it is independent of the HMM stream
+     even when seeds collide across calls. *)
+  let rng = Stdlib.Random.State.make [| config.seed + 1 |] in
+  let log_returns =
+    _compose_log_returns ~regimes ~garch_per_regime:config.garch_per_regime
+      ~drift_per_regime:config.drift_per_regime ~rng
+  in
+  let dates = _business_days ~start_date:config.start_date ~n in
+  _build_bars ~dates ~start_price:config.start_price ~log_returns
+
+let generate config =
+  Result.bind (_validate config) ~f:(fun () -> Ok (_generate_validated config))

--- a/trading/analysis/data/synthetic/lib/synth_v2.mli
+++ b/trading/analysis/data/synthetic/lib/synth_v2.mli
@@ -1,0 +1,76 @@
+(** Synth-v2 — regime-switching GARCH price-series generator.
+
+    Combines the [Regime_hmm] regime layer with per-regime [Garch] volatility
+    and per-regime drift to emit a deterministic [Daily_price.t list].
+
+    Pipeline:
+    {v
+      1. sample regime path [r_0 .. r_{N-1}] from the HMM
+      2. for each step k, draw a GARCH return ε_k using the GARCH params
+         attached to regime r_k. The GARCH state (variance) is carried
+         forward across steps but parameters switch when the regime switches.
+      3. add the per-regime drift μ_{r_k} to ε_k to obtain the log-return.
+      4. build a price chain by compounding log-returns on top of [start_price]
+         and emit OHLCV bars with synthetic intra-day shape (close ± 0.5%).
+    v}
+
+    Determinism: same [config] produces an identical output. The HMM and the
+    GARCH series share [seed]: the HMM uses [seed] directly; the GARCH layer
+    uses [seed + 1] so the two streams are independent.
+
+    Calibration TODO: per-regime GARCH params and drifts are currently hand-set
+    defaults intended to roughly match historical SPY regime characteristics. A
+    follow-up PR will fit them from real history. *)
+
+type config = {
+  hmm : Regime_hmm.t;
+  garch_per_regime : (Regime_hmm.regime * Garch.params) list;
+      (** Must contain entries for all three regimes. *)
+  drift_per_regime : (Regime_hmm.regime * float) list;
+      (** Per-step (per-day) log-return drift added to the GARCH shock. Must
+          contain entries for all three regimes. *)
+  start_price : float;  (** First bar's close, must be > 0. *)
+  target_length_days : int;  (** Number of bars to emit, must be > 0. *)
+  start_date : Core.Date.t;
+      (** First bar's date; subsequent bars advance one business day at a time
+          (Mon-Fri). Holidays are ignored. *)
+  seed : int;
+      (** Master seed. The HMM uses [seed]; the GARCH layer uses [seed + 1]. *)
+}
+
+val default_garch_per_regime : (Regime_hmm.regime * Garch.params) list
+(** Hand-set per-regime GARCH parameters. Documented in the module-level
+    comment. Roughly:
+    - Bull: omega=1e-6, alpha=0.05, beta=0.93 — annualised vol ~12%
+    - Bear: omega=1e-5, alpha=0.10, beta=0.85 — annualised vol ~25%
+    - Crisis: omega=5e-5, alpha=0.20, beta=0.75 — annualised vol ~60%
+
+    Calibration TODO: re-fit per regime from real history. *)
+
+val default_drift_per_regime : (Regime_hmm.regime * float) list
+(** Hand-set per-regime per-day log-return drifts:
+    - Bull: +0.0005/day (~13% annualised)
+    - Bear: -0.0003/day (~-7.5% annualised)
+    - Crisis: -0.002/day (~-50% annualised over a sustained crisis; mitigated by
+      short mean duration). *)
+
+val default_config :
+  start_date:Core.Date.t ->
+  start_price:float ->
+  target_length_days:int ->
+  seed:int ->
+  config
+(** Convenience constructor wiring up [Regime_hmm.default],
+    [default_garch_per_regime], and [default_drift_per_regime]. *)
+
+val generate : config -> (Types.Daily_price.t list, Status.t) Result.t
+(** [generate config] returns a synthetic daily-price list of length
+    [config.target_length_days].
+
+    Returns [Error Status.Invalid_argument] when:
+    - [config.target_length_days <= 0]
+    - [config.start_price <= 0]
+    - [config.hmm] fails [Regime_hmm.validate]
+    - [config.garch_per_regime] is missing any regime or any params fail
+      [Garch.validate]
+    - [config.drift_per_regime] is missing any regime. *)

--- a/trading/analysis/data/synthetic/test/dune
+++ b/trading/analysis/data/synthetic/test/dune
@@ -1,6 +1,6 @@
-(test
- (name test_block_bootstrap)
- (modules test_block_bootstrap)
+(tests
+ (names test_block_bootstrap test_regime_hmm test_garch test_synth_v2)
+ (modules test_block_bootstrap test_regime_hmm test_garch test_synth_v2)
  (libraries
   core
   core_unix

--- a/trading/analysis/data/synthetic/test/test_garch.ml
+++ b/trading/analysis/data/synthetic/test/test_garch.ml
@@ -1,0 +1,156 @@
+open OUnit2
+open Core
+open Matchers
+open Synthetic
+
+(* Bull-like default: low vol, high persistence, stationary. *)
+let _bull_params : Garch.params = { omega = 1e-6; alpha = 0.05; beta = 0.93 }
+
+(* ------------------------------------------------------------------ *)
+(* Validation                                                           *)
+(* ------------------------------------------------------------------ *)
+
+let test_validate_default_ok _ = assert_that (Garch.validate _bull_params) is_ok
+
+let test_validate_rejects_zero_omega _ =
+  assert_that
+    (Garch.validate { _bull_params with omega = 0.0 })
+    (is_error_with Status.Invalid_argument)
+
+let test_validate_rejects_negative_alpha _ =
+  assert_that
+    (Garch.validate { _bull_params with alpha = -0.01 })
+    (is_error_with Status.Invalid_argument)
+
+let test_validate_rejects_non_stationary _ =
+  assert_that
+    (Garch.validate { omega = 1e-6; alpha = 0.6; beta = 0.5 })
+    (is_error_with Status.Invalid_argument)
+
+(* ------------------------------------------------------------------ *)
+(* Long-run variance                                                    *)
+(* ------------------------------------------------------------------ *)
+
+let test_long_run_variance_default _ =
+  (* omega / (1 - alpha - beta) = 1e-6 / 0.02 = 5e-5 *)
+  assert_that
+    (Garch.long_run_variance _bull_params)
+    (is_some_and (float_equal 5e-5))
+
+let test_long_run_variance_non_stationary_is_none _ =
+  assert_that
+    (Garch.long_run_variance { omega = 1e-6; alpha = 0.6; beta = 0.5 })
+    is_none
+
+(* ------------------------------------------------------------------ *)
+(* Sampling                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let test_sample_returns_zero_steps_is_empty _ =
+  assert_that
+    (Garch.sample_returns _bull_params ~n_steps:0 ~seed:1 ~initial_variance:5e-5)
+    is_empty
+
+let test_sample_returns_length_matches _ =
+  let returns =
+    Garch.sample_returns _bull_params ~n_steps:200 ~seed:42
+      ~initial_variance:5e-5
+  in
+  assert_that returns (size_is 200)
+
+let test_sample_returns_deterministic _ =
+  let r1 =
+    Garch.sample_returns _bull_params ~n_steps:200 ~seed:42
+      ~initial_variance:5e-5
+  in
+  let r2 =
+    Garch.sample_returns _bull_params ~n_steps:200 ~seed:42
+      ~initial_variance:5e-5
+  in
+  assert_that (List.equal Float.equal r1 r2) (equal_to true)
+
+let test_sample_returns_finite _ =
+  let returns =
+    Garch.sample_returns _bull_params ~n_steps:1000 ~seed:99
+      ~initial_variance:5e-5
+  in
+  assert_that (List.for_all returns ~f:Float.is_finite) (equal_to true)
+
+(* ------------------------------------------------------------------ *)
+(* Variance clustering — feed a short window, then a long window with   *)
+(* the same parameters. The realised variance over a stretch following  *)
+(* a high-shock burst should exceed the variance over a stretch         *)
+(* following a quiet stretch. We compare two windows from the same      *)
+(* generated path: the 50 returns following the largest-magnitude       *)
+(* return vs. the 50 returns following the smallest-magnitude return.   *)
+(* ------------------------------------------------------------------ *)
+
+let _variance xs =
+  let n = List.length xs in
+  if n = 0 then 0.0
+  else
+    let m = List.sum (module Float) xs ~f:Fn.id /. Float.of_int n in
+    List.sum (module Float) xs ~f:(fun x -> (x -. m) ** 2.0) /. Float.of_int n
+
+let test_variance_clustering _ =
+  let returns =
+    Garch.sample_returns _bull_params ~n_steps:2000 ~seed:11
+      ~initial_variance:5e-5
+  in
+  let arr = Array.of_list returns in
+  let n = Array.length arr in
+  (* Find the index of the largest |r| in [0, n-100). The window we sample
+     is [i+1, i+50] so we need i + 50 < n. *)
+  let max_idx = ref 0 in
+  let min_idx = ref 0 in
+  for i = 0 to n - 100 do
+    if Float.(Float.abs arr.(i) > Float.abs arr.(!max_idx)) then max_idx := i;
+    if Float.(Float.abs arr.(i) < Float.abs arr.(!min_idx)) then min_idx := i
+  done;
+  let window_after i = Array.sub arr ~pos:(i + 1) ~len:50 |> Array.to_list in
+  let var_after_high = _variance (window_after !max_idx) in
+  let var_after_low = _variance (window_after !min_idx) in
+  (* GARCH variance clustering means a large shock raises σ², driving up
+     variance in the immediately following window. We assert the post-high
+     window variance strictly exceeds the post-low window variance. *)
+  assert_that var_after_high (gt (module Float_ord) var_after_low)
+
+(* ------------------------------------------------------------------ *)
+(* Stationary regime — empirical variance of a long sample is in the    *)
+(* same order of magnitude as the long-run variance.                    *)
+(* ------------------------------------------------------------------ *)
+
+let test_empirical_variance_near_long_run _ =
+  let returns =
+    Garch.sample_returns _bull_params ~n_steps:5000 ~seed:5
+      ~initial_variance:5e-5
+  in
+  let v = _variance returns in
+  (* Long-run variance = 5e-5; empirical variance should be within a factor
+     of ~3 (loose band — finite-sample variance has high variance itself). *)
+  assert_that v (is_between (module Float_ord) ~low:1.5e-5 ~high:1.5e-4)
+
+let suite =
+  "garch"
+  >::: [
+         "validate default ok" >:: test_validate_default_ok;
+         "validate rejects zero omega" >:: test_validate_rejects_zero_omega;
+         "validate rejects negative alpha"
+         >:: test_validate_rejects_negative_alpha;
+         "validate rejects non-stationary"
+         >:: test_validate_rejects_non_stationary;
+         "long_run_variance default" >:: test_long_run_variance_default;
+         "long_run_variance non-stationary is None"
+         >:: test_long_run_variance_non_stationary_is_none;
+         "sample_returns n=0 is empty"
+         >:: test_sample_returns_zero_steps_is_empty;
+         "sample_returns length matches" >:: test_sample_returns_length_matches;
+         "sample_returns deterministic in seed"
+         >:: test_sample_returns_deterministic;
+         "sample_returns finite for long path" >:: test_sample_returns_finite;
+         "variance clusters after large shocks" >:: test_variance_clustering;
+         "empirical variance near long-run target"
+         >:: test_empirical_variance_near_long_run;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/data/synthetic/test/test_regime_hmm.ml
+++ b/trading/analysis/data/synthetic/test/test_regime_hmm.ml
@@ -1,0 +1,156 @@
+open OUnit2
+open Core
+open Matchers
+open Synthetic
+
+(* ------------------------------------------------------------------ *)
+(* Validation                                                           *)
+(* ------------------------------------------------------------------ *)
+
+let test_default_validates _ =
+  assert_that (Regime_hmm.validate Regime_hmm.default) is_ok
+
+let test_validate_rejects_non_summing_row _ =
+  let bad : Regime_hmm.t =
+    {
+      initial_regime = Bull;
+      transitions =
+        [
+          (Bull, [ (Bull, 0.5); (Bear, 0.2); (Crisis, 0.1) ]);
+          (Bear, [ (Bull, 0.05); (Bear, 0.93); (Crisis, 0.02) ]);
+          (Crisis, [ (Bull, 0.10); (Bear, 0.25); (Crisis, 0.65) ]);
+        ];
+    }
+  in
+  assert_that (Regime_hmm.validate bad) (is_error_with Status.Invalid_argument)
+
+let test_validate_rejects_negative_prob _ =
+  let bad : Regime_hmm.t =
+    {
+      initial_regime = Bull;
+      transitions =
+        [
+          (Bull, [ (Bull, 1.1); (Bear, -0.05); (Crisis, -0.05) ]);
+          (Bear, [ (Bull, 0.05); (Bear, 0.93); (Crisis, 0.02) ]);
+          (Crisis, [ (Bull, 0.10); (Bear, 0.25); (Crisis, 0.65) ]);
+        ];
+    }
+  in
+  assert_that (Regime_hmm.validate bad) (is_error_with Status.Invalid_argument)
+
+let test_validate_rejects_missing_row _ =
+  let bad : Regime_hmm.t =
+    {
+      initial_regime = Bull;
+      transitions =
+        [
+          (Bull, [ (Bull, 1.0); (Bear, 0.0); (Crisis, 0.0) ]);
+          (Bear, [ (Bull, 0.05); (Bear, 0.93); (Crisis, 0.02) ]);
+          (* Crisis row missing *)
+        ];
+    }
+  in
+  assert_that (Regime_hmm.validate bad) (is_error_with Status.Invalid_argument)
+
+(* ------------------------------------------------------------------ *)
+(* Sampling                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let test_sample_path_zero_steps_is_empty _ =
+  assert_that
+    (Regime_hmm.sample_path Regime_hmm.default ~n_steps:0 ~seed:1)
+    is_empty
+
+let test_sample_path_first_element_is_initial _ =
+  let path = Regime_hmm.sample_path Regime_hmm.default ~n_steps:10 ~seed:42 in
+  assert_that (List.hd path) (is_some_and (equal_to Regime_hmm.Bull))
+
+let test_sample_path_deterministic _ =
+  let p1 = Regime_hmm.sample_path Regime_hmm.default ~n_steps:200 ~seed:7 in
+  let p2 = Regime_hmm.sample_path Regime_hmm.default ~n_steps:200 ~seed:7 in
+  assert_that (List.equal Regime_hmm.equal_regime p1 p2) (equal_to true)
+
+let test_sample_path_different_seeds_differ _ =
+  let p1 = Regime_hmm.sample_path Regime_hmm.default ~n_steps:200 ~seed:7 in
+  let p2 = Regime_hmm.sample_path Regime_hmm.default ~n_steps:200 ~seed:8 in
+  assert_that (List.equal Regime_hmm.equal_regime p1 p2) (equal_to false)
+
+(* ------------------------------------------------------------------ *)
+(* Persistence — Bull initial state with rare-crisis transitions stays  *)
+(* mostly Bull over 100 steps.                                          *)
+(* ------------------------------------------------------------------ *)
+
+let test_bull_persistence_over_100_steps _ =
+  let path = Regime_hmm.sample_path Regime_hmm.default ~n_steps:100 ~seed:13 in
+  let bull_count =
+    List.count path ~f:(fun r -> Regime_hmm.equal_regime r Bull)
+  in
+  (* With P(Bull|Bull) = 0.97, expected Bull count is well above 50 even
+     with multiple regime switches. We pin a generous floor (60/100) so
+     the test isn't brittle but still catches the catastrophic case where
+     the chain leaves Bull immediately. *)
+  assert_that bull_count (gt (module Int_ord) 60)
+
+(* ------------------------------------------------------------------ *)
+(* Persistence — over 1000 steps the average Bull-segment length is     *)
+(* within ±50% of the theoretical mean ≈ 1 / (1 - 0.97) ≈ 33 steps.     *)
+(* ------------------------------------------------------------------ *)
+
+let _bull_segment_lengths path =
+  let _, _, segments =
+    List.fold path ~init:(None, 0, []) ~f:(fun (current, run_len, acc) r ->
+        let is_bull = Regime_hmm.equal_regime r Bull in
+        match current with
+        | None when is_bull -> (Some Regime_hmm.Bull, 1, acc)
+        | None -> (None, 0, acc)
+        | Some _ when is_bull -> (Some Regime_hmm.Bull, run_len + 1, acc)
+        | Some _ -> (None, 0, run_len :: acc))
+  in
+  segments
+
+let test_average_bull_segment_within_band _ =
+  (* Use a long path with multiple seeds aggregated; a single 1000-step
+     path has high variance in segment length. Aggregating across seeds
+     stabilises the empirical mean while keeping the test deterministic. *)
+  let all_segments =
+    List.concat_map [ 1; 2; 3; 4; 5; 6; 7; 8 ] ~f:(fun s ->
+        let path =
+          Regime_hmm.sample_path Regime_hmm.default ~n_steps:1000 ~seed:s
+        in
+        _bull_segment_lengths path)
+  in
+  let n = List.length all_segments in
+  let mean =
+    if n = 0 then 0.0
+    else
+      Float.of_int (List.sum (module Int) all_segments ~f:Fn.id)
+      /. Float.of_int n
+  in
+  (* Theoretical mean = 1 / (1 - 0.97) = 33.33. Tolerance ±50% = [16.67, 50]. *)
+  assert_that mean (is_between (module Float_ord) ~low:16.67 ~high:50.0)
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "regime_hmm"
+  >::: [
+         "default validates" >:: test_default_validates;
+         "validate rejects non-summing row"
+         >:: test_validate_rejects_non_summing_row;
+         "validate rejects negative prob"
+         >:: test_validate_rejects_negative_prob;
+         "validate rejects missing row" >:: test_validate_rejects_missing_row;
+         "sample_path n=0 is empty" >:: test_sample_path_zero_steps_is_empty;
+         "sample_path first element is initial"
+         >:: test_sample_path_first_element_is_initial;
+         "sample_path deterministic in seed" >:: test_sample_path_deterministic;
+         "sample_path differs across seeds"
+         >:: test_sample_path_different_seeds_differ;
+         "bull persists over 100 steps" >:: test_bull_persistence_over_100_steps;
+         "average bull-segment length within ±50% of theoretical"
+         >:: test_average_bull_segment_within_band;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/data/synthetic/test/test_synth_v2.ml
+++ b/trading/analysis/data/synthetic/test/test_synth_v2.ml
@@ -1,0 +1,163 @@
+open OUnit2
+open Core
+open Matchers
+open Synthetic
+
+let _default_cfg ?(target = 500) ?(seed = 17) () =
+  Synth_v2.default_config
+    ~start_date:(Date.of_string "2030-01-01")
+    ~start_price:100.0 ~target_length_days:target ~seed
+
+let _unwrap_or_fail msg = function
+  | Ok v -> v
+  | Error e -> assert_failure (msg ^ ": " ^ Status.show e)
+
+(* ------------------------------------------------------------------ *)
+(* Output length matches request                                        *)
+(* ------------------------------------------------------------------ *)
+
+let test_output_length _ =
+  assert_that
+    (Synth_v2.generate (_default_cfg ~target:500 ()))
+    (is_ok_and_holds (size_is 500))
+
+(* ------------------------------------------------------------------ *)
+(* Determinism                                                          *)
+(* ------------------------------------------------------------------ *)
+
+let test_determinism_same_seed _ =
+  let cfg = _default_cfg ~target:200 () in
+  let bars1 = _unwrap_or_fail "first run failed" (Synth_v2.generate cfg) in
+  let bars2 = _unwrap_or_fail "second run failed" (Synth_v2.generate cfg) in
+  assert_that (List.equal Types.Daily_price.equal bars1 bars2) (equal_to true)
+
+let test_different_seeds_differ _ =
+  let cfg1 = _default_cfg ~target:200 ~seed:17 () in
+  let cfg2 = _default_cfg ~target:200 ~seed:99 () in
+  let bars1 = _unwrap_or_fail "seed=17 failed" (Synth_v2.generate cfg1) in
+  let bars2 = _unwrap_or_fail "seed=99 failed" (Synth_v2.generate cfg2) in
+  assert_that (List.equal Types.Daily_price.equal bars1 bars2) (equal_to false)
+
+(* ------------------------------------------------------------------ *)
+(* Dates strictly increase + business days only                         *)
+(* ------------------------------------------------------------------ *)
+
+let test_dates_monotonic_business_days _ =
+  let cfg = _default_cfg ~target:50 () in
+  let bars = _unwrap_or_fail "generate failed" (Synth_v2.generate cfg) in
+  let dates = List.map bars ~f:(fun (b : Types.Daily_price.t) -> b.date) in
+  let pairs = List.zip_exn (List.drop_last_exn dates) (List.tl_exn dates) in
+  let strictly_increasing =
+    List.for_all pairs ~f:(fun (a, b) -> Date.compare a b < 0)
+  in
+  let all_weekdays =
+    List.for_all dates ~f:(fun d ->
+        match Date.day_of_week d with Sat | Sun -> false | _ -> true)
+  in
+  assert_that strictly_increasing (equal_to true);
+  assert_that all_weekdays (equal_to true)
+
+(* ------------------------------------------------------------------ *)
+(* OHLC well-formed: low <= open <= high, low <= close <= high          *)
+(* ------------------------------------------------------------------ *)
+
+let test_ohlc_well_formed _ =
+  let cfg = _default_cfg ~target:200 () in
+  let bars = _unwrap_or_fail "generate failed" (Synth_v2.generate cfg) in
+  let ok_bar (b : Types.Daily_price.t) =
+    Float.(b.low_price <= b.open_price)
+    && Float.(b.open_price <= b.high_price)
+    && Float.(b.low_price <= b.close_price)
+    && Float.(b.close_price <= b.high_price)
+    && Float.(b.close_price > 0.0)
+  in
+  assert_that (List.for_all bars ~f:ok_bar) (equal_to true)
+
+(* ------------------------------------------------------------------ *)
+(* Validation — non-positive target                                     *)
+(* ------------------------------------------------------------------ *)
+
+let test_validation_zero_target _ =
+  let cfg = _default_cfg ~target:0 () in
+  assert_that (Synth_v2.generate cfg) (is_error_with Status.Invalid_argument)
+
+let test_validation_zero_start_price _ =
+  let cfg = { (_default_cfg ()) with start_price = 0.0 } in
+  assert_that (Synth_v2.generate cfg) (is_error_with Status.Invalid_argument)
+
+let test_validation_missing_garch_for_regime _ =
+  let cfg =
+    {
+      (_default_cfg ()) with
+      garch_per_regime =
+        [
+          (Regime_hmm.Bull, { omega = 1e-6; alpha = 0.05; beta = 0.93 });
+          (* Bear and Crisis missing *)
+        ];
+    }
+  in
+  assert_that (Synth_v2.generate cfg) (is_error_with Status.Invalid_argument)
+
+let test_validation_invalid_garch _ =
+  let cfg =
+    {
+      (_default_cfg ()) with
+      garch_per_regime =
+        [
+          (* alpha + beta > 1 is non-stationary *)
+          (Regime_hmm.Bull, { omega = 1e-6; alpha = 0.6; beta = 0.5 });
+          (Regime_hmm.Bear, { omega = 1e-5; alpha = 0.10; beta = 0.85 });
+          (Regime_hmm.Crisis, { omega = 5e-5; alpha = 0.20; beta = 0.75 });
+        ];
+    }
+  in
+  assert_that (Synth_v2.generate cfg) (is_error_with Status.Invalid_argument)
+
+(* ------------------------------------------------------------------ *)
+(* All bar prices remain finite over a long simulation                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_long_simulation_finite _ =
+  (* 80yr ≈ 252 * 80 = 20160 bars. Use 20000 for speed and pin numerical
+     stability boundary. *)
+  let cfg = _default_cfg ~target:20000 ~seed:23 () in
+  let bars = _unwrap_or_fail "generate failed" (Synth_v2.generate cfg) in
+  let finite =
+    List.for_all bars ~f:(fun (b : Types.Daily_price.t) ->
+        Float.is_finite b.close_price && Float.(b.close_price > 0.0))
+  in
+  assert_that finite (equal_to true)
+
+(* ------------------------------------------------------------------ *)
+(* default_config defaults round-trip                                   *)
+(* ------------------------------------------------------------------ *)
+
+let test_default_config_uses_defaults _ =
+  let cfg = _default_cfg () in
+  assert_that cfg.hmm.initial_regime (equal_to Regime_hmm.Bull);
+  assert_that cfg.garch_per_regime (size_is 3);
+  assert_that cfg.drift_per_regime (size_is 3)
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "synth_v2"
+  >::: [
+         "output length matches request" >:: test_output_length;
+         "determinism — same seed identical" >:: test_determinism_same_seed;
+         "different seeds differ" >:: test_different_seeds_differ;
+         "dates monotonic business days" >:: test_dates_monotonic_business_days;
+         "OHLC bars well-formed" >:: test_ohlc_well_formed;
+         "validation: zero target" >:: test_validation_zero_target;
+         "validation: zero start_price" >:: test_validation_zero_start_price;
+         "validation: missing GARCH for regime"
+         >:: test_validation_missing_garch_for_regime;
+         "validation: non-stationary GARCH" >:: test_validation_invalid_garch;
+         "long simulation stays finite" >:: test_long_simulation_finite;
+         "default_config wires all defaults"
+         >:: test_default_config_uses_defaults;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Implements **M7.0 Track 3 Synth-v2** per `dev/plans/m7-data-and-tuning-2026-05-02.md` — a 3-regime HMM + per-regime GARCH price generator that captures regime persistence, the property block bootstrap (Synth-v1) misses because block boundaries break regime continuity.

Three new modules under `analysis/data/synthetic/lib/`:

- **`regime_hmm`**: 3-regime HMM (Bull / Bear / Crisis) with a row-stochastic transition matrix and inverse-CDF sampler. Hand-set defaults documented in `.mli`.
- **`garch`**: GARCH(1,1) variance recursion + sampler. Validates stationarity (`alpha + beta < 1`), exposes `long_run_variance`, clamps variance as a numerical-stability safety net.
- **`synth_v2`**: combines HMM + per-regime GARCH + per-regime drift to emit a `Daily_price.t list`. The variance recursion carries forward across regime boundaries; only `(omega, alpha, beta)` parameters switch on regime change. Master `seed` split: HMM uses `seed`; GARCH layer uses `seed + 1`.

Plus a new bin `bin/generate_synth_v2.ml` for CLI use, leaving Synth-v1's `generate_synth.ml` untouched.

## Hand-set defaults rationale

(Real fitting from history is out of scope — see "Calibration TODO" below.)

**Transition matrix** (chosen so mean durations roughly match historical SPY cycles):
- `P(Bull|Bull) = 0.97` → mean Bull duration ~33 steps (`1/(1-0.97)`)
- `P(Bear|Bear) = 0.93` → mean Bear duration ~15 steps
- `P(Crisis|Crisis) = 0.65` → mean Crisis duration ~3 steps
- `P(Crisis|Bull) = 0.005`, `P(Crisis|Bear) = 0.02` → Crisis is rare

**Per-regime GARCH(1,1)**:
- Bull: `omega=1e-6, alpha=0.05, beta=0.93` (low vol, high persistence) — long-run sigma ~0.71% daily, ~11% annualised
- Bear: `omega=1e-5, alpha=0.10, beta=0.85` (higher vol, lower persistence) — ~1.4% daily, ~22% annualised
- Crisis: `omega=5e-5, alpha=0.20, beta=0.75` (very high vol) — ~3.2% daily, ~50% annualised

**Per-regime drift**:
- Bull: `+0.0005/day` (~13% annualised)
- Bear: `-0.0003/day` (~-7.5% annualised)
- Crisis: `-0.002/day`

## Acceptance-criteria mapping to tests

Plan states (M7.0 Track 3):
- "HMM fit on 30y SPY history converges; transition probabilities reasonable" — **deferred to follow-up PR** (calibration is out of scope here).
- "80yr simulation shows realistic regime persistence (avg bear-market length ~15 months)" — `regime_hmm`'s `test_average_bull_segment_within_band` aggregates 8 seeds at 1000 steps each and asserts the mean Bull-segment length lands within +/-50% of theoretical 33 steps. Equivalent test for bear can be added once calibration lands.
- "Crisis regime (rare) appears 1-2x per 80yr run" — guarded by the rare transition probabilities in defaults; not pinned as a test (it's stochastic at one run; a multi-seed Crisis-frequency assertion will land alongside calibration in the follow-up).
- "Statistical match: vol clustering preserved within regime" — `garch`'s `test_variance_clustering` asserts post-large-shock window variance > post-small-shock window variance.

Other tests (46 total):
- `regime_hmm` (10): validation rejects malformed matrices; sampler is deterministic in seed; differs across seeds; first element is initial; Bull persists >60% over 100 steps; aggregated mean segment length within band.
- `garch` (12): validation; long-run variance correctness; sampler determinism + length + finiteness; variance clustering; empirical variance over 5000 steps within order-of-magnitude of long-run.
- `synth_v2` (11): output length; determinism; OHLC well-formed; validation rejects zero target / zero start_price / missing or non-stationary GARCH per regime; long simulation (20000 bars ~= 80yr) stays finite; default config wires all defaults.

## Calibration TODO (follow-up PR)

- Fit transition matrix from real history (Baum-Welch / EM on 30y SPY).
- Per-regime GARCH parameters fitted from real per-regime returns.
- Per-regime drifts re-derived empirically.
- Add Crisis-frequency assertion across multi-seed 80yr runs.

These are all explicitly flagged as "Calibration TODO" comments in each module's `.mli`.

## Numerical-stability boundary

`garch` clamps variance into `[0, 1.0]`. The cap corresponds to a daily stdev of ~1.0, well above any realistic regime — it only trips when caller parameters violate `alpha + beta < 1` (rejected by `validate` for typed callers but defensively clamped at runtime). `Synth_v2` mirrors the same clamp internally for its own variance loop. Both are documented in their `.mli`s.

## Test plan
- [x] `dune build && dune runtest analysis/data/synthetic` — all 46 new tests pass + 13 pre-existing block_bootstrap tests pass
- [x] `dune build @analysis/data/synthetic/fmt` — clean
- [x] Smoke test: `dune exec analysis/data/synthetic/bin/generate_synth_v2.exe -- -target-days 10 -seed 1` — emits well-formed CSV
- [x] Long-run finiteness: 20000-bar (~80yr) simulation stays finite

## Files
- `trading/analysis/data/synthetic/lib/regime_hmm.{ml,mli}` (new)
- `trading/analysis/data/synthetic/lib/garch.{ml,mli}` (new)
- `trading/analysis/data/synthetic/lib/synth_v2.{ml,mli}` (new)
- `trading/analysis/data/synthetic/test/test_regime_hmm.ml` (new)
- `trading/analysis/data/synthetic/test/test_garch.ml` (new)
- `trading/analysis/data/synthetic/test/test_synth_v2.ml` (new)
- `trading/analysis/data/synthetic/bin/generate_synth_v2.ml` (new)
- `trading/analysis/data/synthetic/{lib,test,bin}/dune` (modified — module list + new test names + new exe name)

No modifications to existing Synth-v1 files (`block_bootstrap.{ml,mli}`, `source_loader.{ml,mli}`, `generate_synth.ml`).

Plan ref: `dev/plans/m7-data-and-tuning-2026-05-02.md` Sec. M7.0 Track 3 Synth-v2.