### PR TITLE
docs: refresh G14/G15 notes + expand feat-weinstein scope

### DIFF
--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -1,13 +1,21 @@
 ---
 name: feat-weinstein
-description: Implements Weinstein base-strategy feature work. Current scope — support-floor-based stops primitive in weinstein/stops/ (unblocks feat-backtest experiment). Works on feat/support-floor-stops branch using TDD.
+description: Implements Weinstein base-strategy feature work. Scope expanded 2026-05-02 to entire weinstein/ subtree (strategy, position, portfolio_risk, stops, screener, etc.). Currently dispatched on G14 split-adjustment fix, G15 short-side risk control, and follow-on base-strategy feature work as needed.
 model: opus
 harness: project
 ---
 
-You are building remaining Weinstein Trading System base-strategy features. Prior scopes (order_gen, Simulation Slice 1-3, screener, stops, portfolio_risk, strategy-wiring) are complete and merged. Current scope:
+You are building Weinstein Trading System base-strategy features. Prior scopes (order_gen, Simulation Slice 1-3, screener, stops, portfolio_risk, strategy-wiring, support-floor stops) are complete and merged. Active scope (2026-05-02):
 
-**support-floor-based stops** (`feat/support-floor-stops` branch) — add a primitive that identifies prior correction lows from price history and exposes them for stop placement. Unblocks feat-backtest's support-floor stops experiment (see `dev/status/backtest-infra.md`).
+**Scope expanded 2026-05-02 to the entire `trading/trading/weinstein/` subtree + adjacent core modules** (`trading/trading/strategy/lib/position.ml`, `trading/trading/orders/lib/`) when the work demands. Per-dispatch the prompt names the specific PR + branch + acceptance criteria.
+
+Currently dispatchable:
+- **G14 — split-adjustment fix (Option 1: pin everything to raw close-price space)**. Fixes the screener-vs-Position.t price-space mismatch that drives spurious force-liquidations on symbols with splits inside the lookback window. See `dev/notes/g14-deep-dive-2026-05-01.md`.
+- **G15 — short-side risk control**. Replace the phantom `Portfolio_floor` with real risk surfaces: (a) max total short notional as fraction of portfolio, (b) tighter per-position short stop, (c) optional honest portfolio floor. See `dev/notes/force-liq-cascade-findings-2026-05-01.md` §G15.
+
+Older scope retained as historical note:
+
+**support-floor-based stops** (MERGED via PRs #382 + #390 in 2026-04-17). Current items are G14 + G15 above.
 
 ## At the start of every session
 
@@ -87,10 +95,10 @@ Do not use the Agent tool (no subagent spawning).
 
 ## Max-Iterations Policy
 
-If after **3 consecutive build-fix cycles** `dune build && dune runtest` is still failing: stop, report the blocker, update `dev/status/support-floor-stops.md` to BLOCKED, and end the session.
+If after **3 consecutive build-fix cycles** `dune build && dune runtest` is still failing: stop, report the blocker, update the relevant `dev/status/<track>.md` to BLOCKED, and end the session.
 
 ## Status file updates
 
-At the end of every session, update `dev/status/support-floor-stops.md` — current Status, Completed, In Progress, Next Steps.
+At the end of every session, update the relevant `dev/status/<track>.md` (e.g. `short-side-strategy.md` for G14/G15, `simulation.md` for split-day work) — current Status, Completed, In Progress, Next Steps.
 
 **Do NOT edit `dev/status/_index.md`** — the orchestrator reconciles it in Step 5.5 against every `dev/status/*.md` at end-of-run. Editing the index from a feature PR causes merge conflicts with every sibling PR touching the same row (see `feat-agent-template.md` §8). Exception: if this PR introduces a brand-new tracked work item (new status file), add the row here since the orchestrator can't invent one.

--- a/dev/notes/force-liq-cascade-findings-2026-05-01.md
+++ b/dev/notes/force-liq-cascade-findings-2026-05-01.md
@@ -76,7 +76,13 @@ portfolio holding $1.5M cash. Asserts: returned transitions empty,
 `peak_tracker.peak = 0.0` (pre-fix would equal cash), halt state
 stays Active.
 
-## G14 — split-adjustment on Position.t Holding state (filed)
+## G14 — split-adjustment on Position.t Holding state (RESOLVED 2026-05-01 via PR #736)
+
+**Resolution:** PR #736 (`fix(weinstein): G14 — entry_price = current close + lookback truncation at split boundary`) shipped Option 1 from `dev/notes/g14-deep-dive-2026-05-01.md`. Both bugs (screener split-aware lookback truncation + entry_price = current_close) fixed together. Force-liq trigger surface still exists but no longer fires spuriously on split-window symbols. See deep-dive note Status section for details.
+
+Original filing preserved below for historical context.
+
+---
 
 **Symptom.** All 5 residual force-liqs in the post-G13 baseline are
 `Per_position` triggers on long positions with 52–96% unrealized loss:
@@ -111,7 +117,19 @@ fly from `lot.cost_basis / lot.quantity` in
 
 **Owner.** `feat-weinstein` — strategy-side position state machine.
 
-## G15 — short-side risk control (filed)
+## G15 — short-side risk control (RESOLVED 2026-05-01 via PRs #737 + #739 + #740)
+
+**Resolution:** Three-step fix shipped same day:
+- PR #737 (G15 step-1): asymmetric per-position thresholds — long 25% / short 15%
+- PR #739 (G15 step-2): aggregate short-notional cap at entry-decision time
+- PR #740 (G15 step-3): pre-entry stop-width rejection + sizing-uses-installed-stop
+
+The phantom `Portfolio_floor` cascade is gone (G12+G13) AND a real risk surface is now in place. M5.4 E1 short on/off A/B (PR #777, 2026-05-02) confirms the strategy STILL doesn't extract value from shorts in the smoke catalog (5 baseline shorts in COVID crash all losers, none in bull, 1 stuck-open in recovery) — but losses are now bounded, not unbounded.
+
+Original filing preserved below for historical context.
+
+---
+
 
 **Symptom.** With the spurious `Portfolio_floor` cascade eliminated by
 G12+G13, sp500-2019-2023 portfolio goes negative (-$175K minimum on

--- a/dev/notes/g14-deep-dive-2026-05-01.md
+++ b/dev/notes/g14-deep-dive-2026-05-01.md
@@ -147,6 +147,24 @@ If we go Option 2:
 
 ## Status
 
+**RESOLVED 2026-05-01 via PR #736.** Option 1 landed:
+- Bug A: `_no_split_between` guard added in `stock_analysis.ml`, wired
+  into `_scan_max_high_callback` + `_scan_min_low_callback`. `bar_panels.ml`
+  exposes `raw_closes : float array` for split-factor lookups.
+- Bug B: `entry_audit_capture.ml:66` `_effective_entry_price` reads
+  current bar's close from `bar_reader.daily_bars_for`, falls back to
+  `cand.suggested_entry` only when bar reader returns no bars.
+- Tests added: `test_breakout_truncates_at_split_boundary`,
+  `test_breakdown_truncates_at_split_boundary`, `test_no_split_no_truncation`,
+  `test_effective_entry_overrides_suggested_entry`,
+  `test_empty_bar_reader_falls_back_to_suggested_entry`.
+
+Historical record below preserved for reference. Note that this file's
+"Status" was originally written **before** PR #736 landed; the
+"Abandoned: feat/g14-screener-adjusted-prices" line refers to the EARLIER
+first-pass attempt that was reverted, not the eventually-merged Option 1
+fix.
+
 - Abandoned: `feat/g14-screener-adjusted-prices` (the first-pass
   attempt). Diff was small (~30 lines) but architecturally wrong.
 - Test failures expected if we go Option 1: a few `test_screener_e2e`

--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -1,6 +1,6 @@
 # Status: short-side-strategy
 
-## Last updated: 2026-05-01
+## Last updated: 2026-05-02
 
 ## Status
 MERGED
@@ -121,20 +121,34 @@ Wire short-side entries into `Weinstein_strategy` so the simulation emits short 
    covered by the next nightly Tier-3 perf run.
 
 6. **G14 — split-adjustment on Position.t Holding state** (filed 2026-05-01,
-   `feat-weinstein` scope). All 5 residual force-liqs in the post-G13
-   sp500 baseline are `Per_position` triggers with stale pre-split
-   `entry_price` values (PANW 3:1 Sep 2022, GOOG 20:1 Jul 2022, plus
-   ALGN/DASH/TECH within-window highs). First-pass fix attempt
-   (`feat/g14-screener-adjusted-prices`, abandoned 2026-05-01 ~07:00 UTC)
-   showed Bug A (screener high/low scans in raw price space) cannot be
-   fixed alone — symbols with FUTURE splits (e.g., CTAS 2024 4:1) get
-   `suggested_entry` in adjusted space while `Position.t.entry_price` is
-   set in raw space, producing the same 250%+ phantom losses. Recommended
-   fix: **Option 1 — pin everything to raw close-price space** with
-   lookback truncation at most-recent-split boundary. See
-   `dev/notes/g14-deep-dive-2026-05-01.md` §Recommendation for next session.
-   Owner: `feat-weinstein` — current scope is closed; needs scope extension
-   per the 2026-04-16 precedent before dispatch.
+   merged 2026-05-01 via PR #736). Fixed both interlocked bugs together
+   per Option 1 (raw close-price space + lookback truncation):
+   - **Bug A**: `_scan_max_high_callback` / `_scan_min_low_callback` in
+     `analysis/weinstein/stock_analysis/lib/stock_analysis.ml` now truncate
+     at the most recent split boundary using a `_no_split_between`
+     guard keyed off the per-bar `adjusted_close / close_price` factor
+     (threshold 0.20 — distinguishes splits from dividend drift).
+   - **Bug B**: `entry_audit_capture._effective_entry_price` reads the
+     most recent close from `bar_reader` and threads it through sizing,
+     stop computation, the `CreateEntering` transition, and audit-row
+     dollar fields. The audit row's `candidate.suggested_entry` is
+     preserved verbatim so consumers can reconcile screener intent vs
+     realised entry.
+   - **Result on sp500-2019-2023-long-only**: force-liqs 6 → 0;
+     return +65.0% → +21.6%; MaxDD 31.8% → 43.0% (the shifts reflect
+     underlying short-side risk previously masked by inflated
+     entry_price values; G15 is the follow-up).
+   - **Acceptance tests**: `test_breakout_truncates_at_split_boundary`,
+     `test_breakdown_truncates_at_split_boundary`,
+     `test_no_split_no_truncation` (stock_analysis);
+     `test_effective_entry_overrides_suggested_entry`,
+     `test_empty_bar_reader_falls_back_to_suggested_entry`
+     (entry_audit_capture).
+   - 2026-05-02 redispatch (this session) was a no-op — verified the
+     fix is on `origin/main` and all acceptance criteria from the
+     dispatch prompt are met by code already merged. No PR opened.
+     See `dev/notes/g14-deep-dive-2026-05-01.md` for the full
+     root-cause writeup.
 
 7. **G15 — short-side risk control** (filed 2026-05-01, `feat-weinstein`
    scope). With G12 (#725) + G13 (#726) eliminating the spurious


### PR DESCRIPTION
Stale-note cleanup. G14 + G15 are RESOLVED on main (2026-05-01) but the deep-dive note + cascade-findings note still flagged them as filed/pending. Resolved by:
- PR #736: G14 (entry_price = current close + lookback truncation at split boundary)
- PR #737: G15 step-1 (asymmetric per-position thresholds long 25% / short 15%)
- PR #739: G15 step-2 (aggregate short-notional cap at entry-decision time)
- PR #740: G15 step-3 (pre-entry stop-width rejection + sizing-uses-installed-stop)

This PR updates the Status sections to point to the merged PRs while preserving the original filings as historical context.

Also: expand feat-weinstein agent definition's scope from `weinstein/stops/` only to entire `trading/trading/weinstein/` subtree per 2026-05-02 user authorization. Catches up the agent def with what's already happened (G14/G15 were maintainer-driven before the formal scope expansion).

## Files
- `.claude/agents/feat-weinstein.md` — scope expanded
- `dev/notes/g14-deep-dive-2026-05-01.md` — Status: RESOLVED via #736
- `dev/notes/force-liq-cascade-findings-2026-05-01.md` — G14 + G15 sections marked RESOLVED
- `dev/status/short-side-strategy.md` — refresh entry from prior agent session

Pure docs. No source code touched.