### PR TITLE
feat(data_panel): snapshot schema + file format (M5.3 Phase A)

### DIFF
--- a/trading/trading/data_panel/snapshot/lib/dune
+++ b/trading/trading/data_panel/snapshot/lib/dune
@@ -1,0 +1,6 @@
+(library
+ (name data_panel_snapshot)
+ (public_name trading.data_panel.snapshot)
+ (libraries core status)
+ (preprocess
+  (pps ppx_compare ppx_deriving.eq ppx_deriving.show ppx_let ppx_sexp_conv)))

--- a/trading/trading/data_panel/snapshot/lib/snapshot.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot.ml
@@ -1,0 +1,26 @@
+open Core
+
+type t = {
+  schema : Snapshot_schema.t;
+  symbol : string;
+  date : Date.t;
+  values : float array;
+}
+[@@deriving sexp]
+
+let create ~schema ~symbol ~date ~values =
+  let expected = Snapshot_schema.n_fields schema in
+  let actual = Array.length values in
+  if String.is_empty symbol then
+    Status.error_invalid_argument "Snapshot.create: empty symbol"
+  else if expected <> actual then
+    Status.error_invalid_argument
+      (Printf.sprintf
+         "Snapshot.create: values length %d does not match schema width %d"
+         actual expected)
+  else Ok { schema; symbol; date; values }
+
+let index_of t f = Snapshot_schema.index_of t.schema f
+
+let get t f =
+  match index_of t f with None -> None | Some i -> Some t.values.(i)

--- a/trading/trading/data_panel/snapshot/lib/snapshot.mli
+++ b/trading/trading/data_panel/snapshot/lib/snapshot.mli
@@ -1,0 +1,48 @@
+(** In-memory per-(symbol, day) snapshot row.
+
+    A {!t} is one row in the daily-snapshot warehouse: the precomputed indicator
+    values for one symbol on one trading day, under a single
+    {!Snapshot_schema.t}. Phase A is the type definition + sexp round-trip;
+    Phase B (offline pipeline) is responsible for actually populating these from
+    the per-symbol CSV history; Phase C (runtime) consumes them via mmap'd file
+    format. See [dev/plans/daily-snapshot-streaming-2026-04-27.md].
+
+    The [values] array is column-aligned to [schema.fields]: index [i] in
+    [values] corresponds to field [List.nth_exn schema.fields i]. Reads should
+    go through {!get} or {!index_of}, never raw indexing. *)
+
+type t = {
+  schema : Snapshot_schema.t;
+      (** The schema this snapshot row was produced under. The
+          [schema.schema_hash] is what the file-format layer uses to detect
+          version skew between a serialized snapshot and the runtime's expected
+          schema. *)
+  symbol : string;  (** Universe symbol, e.g. ["AAPL"]. *)
+  date : Core.Date.t;  (** The trading day this row describes. *)
+  values : float array;
+      (** Float64 indicator values, one per field in [schema.fields]. Length
+          must equal [Snapshot_schema.n_fields schema]; constructors enforce
+          this. [Float.nan] is the canonical "value unknown / not yet
+          computable" marker (e.g. ATR-14 on day < 14 of a symbol's history). *)
+}
+[@@deriving sexp]
+
+val create :
+  schema:Snapshot_schema.t ->
+  symbol:string ->
+  date:Core.Date.t ->
+  values:float array ->
+  t Status.status_or
+(** [create ~schema ~symbol ~date ~values] constructs a snapshot row, validating
+    that [Array.length values = Snapshot_schema.n_fields schema]. Returns
+    [Error Invalid_argument] on width mismatch, empty symbol, or width-mismatch.
+*)
+
+val get : t -> Snapshot_schema.field -> float option
+(** [get t f] returns the cell for field [f] in this snapshot, or [None] if [f]
+    is not in [t.schema.fields]. Returns [Some Float.nan] when the value is
+    present but not computable for this (symbol, day). *)
+
+val index_of : t -> Snapshot_schema.field -> int option
+(** [index_of t f] is [Snapshot_schema.index_of t.schema f] — exposed for hot
+    paths that want to lift the lookup outside an inner loop. *)

--- a/trading/trading/data_panel/snapshot/lib/snapshot_format.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_format.ml
@@ -1,0 +1,158 @@
+open Core
+
+module Manifest = struct
+  type t = {
+    schema : Snapshot_schema.t;
+    n_rows : int;
+    payload_len : int;
+    payload_md5 : string;
+  }
+  [@@deriving sexp]
+end
+
+(* Compact serializable shape for one row — values inlined as a float list so
+   the payload sexp stays self-contained (no schema references). The row's
+   schema is reattached at read time from the manifest. *)
+module Row = struct
+  type t = { symbol : string; date : Date.t; values : float array }
+  [@@deriving sexp]
+end
+
+let _write_int64_le oc (v : int64) =
+  let b = Bytes.create 8 in
+  for i = 0 to 7 do
+    let shifted = Int64.shift_right_logical v (i * 8) in
+    let byte = Int64.to_int_exn (Int64.bit_and shifted 0xFFL) in
+    Bytes.set b i (Char.of_int_exn byte)
+  done;
+  Out_channel.output_bytes oc b
+
+let _read_int64_le ic =
+  let b = Bytes.create 8 in
+  In_channel.really_input_exn ic ~buf:b ~pos:0 ~len:8;
+  let v = ref 0L in
+  for i = 7 downto 0 do
+    let byte = Int64.of_int (Char.to_int (Bytes.get b i)) in
+    v := Int64.bit_or (Int64.shift_left !v 8) byte
+  done;
+  !v
+
+let _validate_schemas (snapshots : Snapshot.t list) =
+  match snapshots with
+  | [] -> Ok ()
+  | first :: rest -> (
+      let h = first.schema.schema_hash in
+      List.find rest ~f:(fun s -> not (String.equal s.schema.schema_hash h))
+      |> function
+      | None -> Ok ()
+      | Some bad ->
+          Status.error_invalid_argument
+            (Printf.sprintf
+               "Snapshot_format.write: mixed schema hashes (%s vs %s)" h
+               bad.schema.schema_hash))
+
+let _build_payload (snapshots : Snapshot.t list) =
+  let rows : Row.t list =
+    List.map snapshots ~f:(fun (s : Snapshot.t) ->
+        { Row.symbol = s.symbol; date = s.date; values = s.values })
+  in
+  Sexp.to_string ([%sexp_of: Row.t list] rows)
+
+let _schema_for_write snapshots =
+  match snapshots with
+  | first :: _ -> (first : Snapshot.t).schema
+  | [] -> Snapshot_schema.default
+
+let write ~path snapshots =
+  match _validate_schemas snapshots with
+  | Error _ as e -> e
+  | Ok () -> (
+      let schema = _schema_for_write snapshots in
+      let payload = _build_payload snapshots in
+      let payload_len = String.length payload in
+      let payload_md5 = Stdlib.Digest.to_hex (Stdlib.Digest.string payload) in
+      let manifest : Manifest.t =
+        { schema; n_rows = List.length snapshots; payload_len; payload_md5 }
+      in
+      let manifest_bytes =
+        manifest |> Manifest.sexp_of_t |> Sexp.to_string |> Bytes.of_string
+      in
+      try
+        Out_channel.with_file path ~f:(fun oc ->
+            _write_int64_le oc (Int64.of_int (Bytes.length manifest_bytes));
+            Out_channel.output_bytes oc manifest_bytes;
+            Out_channel.output_string oc payload);
+        Ok ()
+      with Sys_error msg | Failure msg ->
+        Status.error_internal (Printf.sprintf "Snapshot_format.write: %s" msg))
+
+let _decode_manifest_and_payload ~path =
+  In_channel.with_file path ~f:(fun ic ->
+      let manifest_len = _read_int64_le ic |> Int64.to_int_exn in
+      let manifest_bytes = Bytes.create manifest_len in
+      In_channel.really_input_exn ic ~buf:manifest_bytes ~pos:0
+        ~len:manifest_len;
+      let manifest =
+        Sexp.of_string (Bytes.to_string manifest_bytes) |> Manifest.t_of_sexp
+      in
+      let payload = In_channel.input_all ic in
+      (manifest, payload))
+
+let _check_payload_integrity ~(manifest : Manifest.t) ~payload =
+  if String.length payload <> manifest.payload_len then
+    Status.error_internal
+      (Printf.sprintf
+         "Snapshot_format.read: payload length mismatch (file=%d manifest=%d)"
+         (String.length payload) manifest.payload_len)
+  else
+    let actual = Stdlib.Digest.to_hex (Stdlib.Digest.string payload) in
+    if not (String.equal actual manifest.payload_md5) then
+      Status.error_internal
+        (Printf.sprintf
+           "Snapshot_format.read: md5 mismatch (file=%s manifest=%s)" actual
+           manifest.payload_md5)
+    else Ok ()
+
+let _rows_to_snapshots ~(schema : Snapshot_schema.t) (rows : Row.t list) =
+  List.map rows ~f:(fun (r : Row.t) ->
+      Snapshot.create ~schema ~symbol:r.symbol ~date:r.date ~values:r.values)
+  |> Result.all
+
+let read ~path =
+  let open Result.Let_syntax in
+  try
+    let manifest, payload = _decode_manifest_and_payload ~path in
+    let%bind () = _check_payload_integrity ~manifest ~payload in
+    let rows = Sexp.of_string payload |> [%of_sexp: Row.t list] in
+    if List.length rows <> manifest.n_rows then
+      Status.error_internal
+        (Printf.sprintf
+           "Snapshot_format.read: row count mismatch (payload=%d manifest=%d)"
+           (List.length rows) manifest.n_rows)
+    else _rows_to_snapshots ~schema:manifest.schema rows
+  with
+  | Sys_error msg | Failure msg ->
+      Status.error_internal (Printf.sprintf "Snapshot_format.read: %s" msg)
+  | Sexp.Of_sexp_error (exn, _) ->
+      Status.error_internal
+        (Printf.sprintf "Snapshot_format.read: sexp decode: %s"
+           (Exn.to_string exn))
+
+let read_with_expected_schema ~path ~(expected : Snapshot_schema.t) =
+  let open Result.Let_syntax in
+  let%bind snapshots = read ~path in
+  match snapshots with
+  | [] -> Ok snapshots
+  | first :: _ ->
+      if String.equal first.schema.schema_hash expected.schema_hash then
+        Ok snapshots
+      else
+        Error
+          {
+            Status.code = Failed_precondition;
+            message =
+              Printf.sprintf
+                "Snapshot_format.read_with_expected_schema: schema hash skew \
+                 (file=%s expected=%s)"
+                first.schema.schema_hash expected.schema_hash;
+          }

--- a/trading/trading/data_panel/snapshot/lib/snapshot_format.mli
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_format.mli
@@ -1,0 +1,55 @@
+(** On-disk serialization for a list of {!Snapshot.t}.
+
+    Phase A file format ({!dev/plans/daily-snapshot-streaming-2026-04-27.md}
+    §Decisions point 2: "Snapshot file = single contiguous binary with sexp
+    manifest"):
+
+    {v
+      bytes 0..7        manifest_len : int64 little-endian
+      bytes 8..(8+M-1)  manifest_sexp : ASCII sexp (M = manifest_len)
+      bytes 8+M..       payload : sexp-encoded list of (symbol, date, values)
+    v}
+
+    The manifest records:
+    - [schema] (full {!Snapshot_schema.t} including hash)
+    - [n_rows] (count of {!Snapshot.t} rows)
+    - [payload_len] (byte length of the payload)
+    - [payload_md5] (hex digest of the payload bytes)
+
+    Integrity checks at {!read} time:
+    - manifest sexp parses cleanly → else [Error Internal "manifest decode"]
+    - payload byte length matches manifest → else
+      [Error Internal "payload length mismatch"]
+    - payload MD5 matches manifest → else [Error Internal "md5 mismatch"]
+    - every row's [schema.schema_hash] equals the manifest's
+      [schema.schema_hash] → else [Error Internal "schema hash mismatch"]
+
+    Phase A uses a sexp-encoded payload (not raw Float64 bytes) for portability
+    and ease of debugging. The plan's risk note R3 calls out the Phase C upgrade
+    to a Bigarray.map_file payload — file format will bump schema hash and the
+    migration will be a full corpus rebuild. *)
+
+val write : path:string -> Snapshot.t list -> unit Status.status_or
+(** [write ~path snapshots] serializes [snapshots] to [path], overwriting any
+    existing file.
+
+    Returns [Error Invalid_argument] if [snapshots] mixes multiple schema hashes
+    (every row must share one schema for the file). The empty list is permitted
+    and writes a header-only file using {!Snapshot_schema.default}.
+
+    Returns [Error Internal] if the underlying file write raises. *)
+
+val read : path:string -> Snapshot.t list Status.status_or
+(** [read ~path] deserializes a snapshot file written by {!write}.
+
+    Returns the list of rows in write order. Returns [Error Internal] on any
+    integrity-check failure (loud, not silent — see the integrity checks listed
+    in the module docstring). *)
+
+val read_with_expected_schema :
+  path:string -> expected:Snapshot_schema.t -> Snapshot.t list Status.status_or
+(** [read_with_expected_schema ~path ~expected] is {!read} composed with a
+    schema-hash check: returns
+    [Error Failed_precondition "schema hash skew: file=<X> expected=<Y>"] if the
+    file's manifest schema hash differs from [expected.schema_hash]. Used by the
+    Phase C runtime to refuse files produced under a different indicator set. *)

--- a/trading/trading/data_panel/snapshot/lib/snapshot_schema.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_schema.ml
@@ -1,0 +1,40 @@
+open Core
+
+type field =
+  | EMA_50
+  | SMA_50
+  | ATR_14
+  | RSI_14
+  | Stage
+  | RS_line
+  | Macro_composite
+[@@deriving sexp, compare, equal, show]
+
+let all_fields =
+  [ EMA_50; SMA_50; ATR_14; RSI_14; Stage; RS_line; Macro_composite ]
+
+let field_name = function
+  | EMA_50 -> "EMA_50"
+  | SMA_50 -> "SMA_50"
+  | ATR_14 -> "ATR_14"
+  | RSI_14 -> "RSI_14"
+  | Stage -> "Stage"
+  | RS_line -> "RS_line"
+  | Macro_composite -> "Macro_composite"
+
+(* Canonical sexp form drives the hash. We use [Sexp.to_string] (not
+   [to_string_hum]) because the compact form omits whitespace entirely, so
+   trivial formatter changes can never perturb the hash. *)
+let compute_hash fields =
+  let sexp = [%sexp_of: field list] fields in
+  Sexp.to_string sexp |> Stdlib.Digest.string |> Stdlib.Digest.to_hex
+
+type t = { fields : field list; schema_hash : string } [@@deriving sexp]
+
+let create ~fields = { fields; schema_hash = compute_hash fields }
+let default = create ~fields:all_fields
+let n_fields t = List.length t.fields
+
+let index_of t f =
+  List.findi t.fields ~f:(fun _ g -> equal_field f g)
+  |> Option.map ~f:(fun (i, _) -> i)

--- a/trading/trading/data_panel/snapshot/lib/snapshot_schema.mli
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_schema.mli
@@ -1,0 +1,97 @@
+(** Snapshot field schema — what every per-(symbol, day) snapshot row contains.
+
+    Phase A of the daily-snapshot streaming pipeline (see
+    [dev/plans/daily-snapshot-streaming-2026-04-27.md] §Phasing Phase A).
+    Defines the enumerable indicator fields that the offline pipeline (Phase B)
+    will pre-compute and the runtime layer (Phase C) will mmap-stream.
+
+    The schema is **order-significant**: the field list determines the binary
+    column layout of [Snapshot.t.values] and the on-disk byte layout of
+    [Snapshot_format] payloads. Two schemas with the same fields in different
+    orders are different schemas (different [schema_hash]).
+
+    A new field, removal, reordering, or rename produces a new [schema_hash];
+    the runtime mmap-loader rejects file-vs-runtime hash mismatches loudly (no
+    silent corruption — see [Snapshot_format.read]). Migration cost is a full
+    corpus rebuild via [bin/build_snapshots.exe] (Phase B). *)
+
+(** Phase A field set, locked-in per the plan §"Indicator set lock-in".
+
+    Every value is a Float64 scalar (parity-gate decision, plan §Decisions).
+    Variant-shaped indicators (e.g. multi-period RS) must be enumerated as
+    distinct fields — there is no per-row bag.
+
+    Field semantics — the offline pipeline is the single source of truth for how
+    each is computed; the runtime simply reads the precomputed scalar:
+
+    - {!EMA_50}: 50-period exponential moving average of the adjusted close
+    - {!SMA_50}: 50-period simple moving average of the adjusted close
+    - {!ATR_14}: 14-period average true range
+    - {!RSI_14}: 14-period relative strength index
+    - {!Stage}: Weinstein stage classification encoded as
+      [1.0 | 2.0 | 3.0 | 4.0]; [Float.nan] means "not yet classifiable"
+    - {!RS_line}: relative-strength line (price vs market benchmark)
+    - {!Macro_composite}: macro-environment composite score *)
+type field =
+  | EMA_50
+  | SMA_50
+  | ATR_14
+  | RSI_14
+  | Stage
+  | RS_line
+  | Macro_composite
+[@@deriving sexp, compare, equal, show]
+
+val all_fields : field list
+(** [all_fields] enumerates every variant of {!field} in declaration order. Used
+    by tests and by [Snapshot_schema.default] to construct the canonical Phase-A
+    schema. *)
+
+val field_name : field -> string
+(** [field_name f] returns the canonical short string name (e.g. ["EMA_50"]).
+    Used for human-readable manifests and error messages — not for hashing. *)
+
+type t = {
+  fields : field list;
+      (** Ordered field list. Index in this list = column index in
+          [Snapshot.t.values]. Order is significant — different orderings
+          produce different [schema_hash]. *)
+  schema_hash : string;
+      (** Lazily-cached deterministic fingerprint of [fields]. See
+          {!compute_hash} for the exact algorithm. *)
+}
+[@@deriving sexp]
+(** A schema is the ordered list of fields plus a memoized hash. Construct via
+    {!create} (computes the hash) — never via record literal in production code.
+*)
+
+val create : fields:field list -> t
+(** [create ~fields] builds a schema with [schema_hash] computed by
+    {!compute_hash}. The empty field list is permitted (its hash is
+    well-defined) but produces a schema that no real snapshot can match. *)
+
+val default : t
+(** [default] is the Phase-A locked-in schema: every variant of {!field} in
+    declaration order ({!all_fields}). The single source of truth for Phase-A
+    snapshots produced by the offline pipeline. *)
+
+val compute_hash : field list -> string
+(** [compute_hash fields] returns a deterministic hex fingerprint of the ordered
+    field list.
+
+    The fingerprint is the MD5 of the canonical sexp serialization
+    [fields |> [%sexp_of: field list] |> Sexp.to_string]. MD5 is used because no
+    SHA-256 library is installed in the build; this is a content-address
+    fingerprint for schema-version tracking, not a security primitive.
+
+    Determinism guarantees:
+    - same field list (same order) → same hash on every run, every machine
+    - any reordering, addition, removal, or rename → different hash *)
+
+val n_fields : t -> int
+(** [n_fields t] returns the number of fields in [t.fields]. The expected
+    column-width of every {!Snapshot.t.values} produced under [t]. *)
+
+val index_of : t -> field -> int option
+(** [index_of t f] returns the zero-based column index of [f] in [t.fields], or
+    [None] if [f] is not in the schema. *)

--- a/trading/trading/data_panel/snapshot/test/dune
+++ b/trading/trading/data_panel/snapshot/test/dune
@@ -1,0 +1,10 @@
+(tests
+ (names test_snapshot_schema test_snapshot test_snapshot_format)
+ (libraries
+  core
+  core_unix
+  core_unix.filename_unix
+  matchers
+  ounit2
+  status
+  trading.data_panel.snapshot))

--- a/trading/trading/data_panel/snapshot/test/test_snapshot.ml
+++ b/trading/trading/data_panel/snapshot/test/test_snapshot.ml
@@ -1,0 +1,112 @@
+open OUnit2
+open Core
+open Matchers
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Snapshot = Data_panel_snapshot.Snapshot
+
+let _values_full () =
+  Array.init (Snapshot_schema.n_fields Snapshot_schema.default) ~f:(fun i ->
+      Float.of_int i +. 0.5)
+
+let _make_full ?(symbol = "AAPL") ?(date = Date.of_string "2024-01-02") () =
+  Snapshot.create ~schema:Snapshot_schema.default ~symbol ~date
+    ~values:(_values_full ())
+
+let test_create_ok _ =
+  assert_that (_make_full ())
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun s -> s.Snapshot.symbol) (equal_to "AAPL");
+            field
+              (fun s -> Date.to_string s.Snapshot.date)
+              (equal_to "2024-01-02");
+            field (fun s -> Array.length s.Snapshot.values) (equal_to 7);
+          ]))
+
+let test_create_rejects_width_mismatch _ =
+  let result =
+    Snapshot.create ~schema:Snapshot_schema.default ~symbol:"AAPL"
+      ~date:(Date.of_string "2024-01-02")
+      ~values:[| 1.0; 2.0 |]
+  in
+  assert_that result (is_error_with Status.Invalid_argument)
+
+let test_create_rejects_empty_symbol _ =
+  let result =
+    Snapshot.create ~schema:Snapshot_schema.default ~symbol:""
+      ~date:(Date.of_string "2024-01-02")
+      ~values:(_values_full ())
+  in
+  assert_that result (is_error_with Status.Invalid_argument)
+
+let test_get_returns_cell _ =
+  assert_that (_make_full ())
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun s -> Snapshot.get s Snapshot_schema.EMA_50)
+              (equal_to (Some 0.5));
+            field
+              (fun s -> Snapshot.get s Snapshot_schema.Stage)
+              (equal_to (Some 4.5));
+          ]))
+
+let test_get_returns_none_for_absent_field _ =
+  let custom_schema =
+    Snapshot_schema.create ~fields:[ Snapshot_schema.EMA_50 ]
+  in
+  let result =
+    Snapshot.create ~schema:custom_schema ~symbol:"X"
+      ~date:(Date.of_string "2024-01-02")
+      ~values:[| 1.0 |]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field (fun s -> Snapshot.get s Snapshot_schema.RSI_14) is_none))
+
+let test_index_of_proxies_schema _ =
+  assert_that (_make_full ())
+    (is_ok_and_holds
+       (field
+          (fun s -> Snapshot.index_of s Snapshot_schema.RSI_14)
+          (is_some_and (equal_to 3))))
+
+let test_sexp_round_trip_preserves_fields _ =
+  let restored =
+    Result.map (_make_full ()) ~f:(fun original ->
+        let sexp = Snapshot.sexp_of_t original in
+        Snapshot.t_of_sexp sexp)
+  in
+  assert_that restored
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun s -> s.Snapshot.symbol) (equal_to "AAPL");
+            field
+              (fun s -> Date.to_string s.Snapshot.date)
+              (equal_to "2024-01-02");
+            field
+              (fun s -> s.Snapshot.schema.schema_hash)
+              (equal_to Snapshot_schema.default.schema_hash);
+            field
+              (fun s -> Array.to_list s.Snapshot.values)
+              (equal_to (Array.to_list (_values_full ())));
+          ]))
+
+let suite =
+  "Snapshot tests"
+  >::: [
+         "create ok" >:: test_create_ok;
+         "create rejects width mismatch" >:: test_create_rejects_width_mismatch;
+         "create rejects empty symbol" >:: test_create_rejects_empty_symbol;
+         "get returns cell" >:: test_get_returns_cell;
+         "get returns none for absent field"
+         >:: test_get_returns_none_for_absent_field;
+         "index_of proxies schema" >:: test_index_of_proxies_schema;
+         "sexp round trip preserves fields"
+         >:: test_sexp_round_trip_preserves_fields;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/data_panel/snapshot/test/test_snapshot_format.ml
+++ b/trading/trading/data_panel/snapshot/test/test_snapshot_format.ml
@@ -1,0 +1,160 @@
+open OUnit2
+open Core
+open Matchers
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Snapshot = Data_panel_snapshot.Snapshot
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+
+let _tmp_path () =
+  Filename_unix.temp_file ~in_dir:"/tmp" "snapshot_format_test_" ".snap"
+
+let _values_for n = Array.init n ~f:(fun i -> Float.of_int i +. 0.25)
+
+let _make_row ~symbol ~date =
+  let n = Snapshot_schema.n_fields Snapshot_schema.default in
+  match
+    Snapshot.create ~schema:Snapshot_schema.default ~symbol ~date
+      ~values:(_values_for n)
+  with
+  | Ok s -> s
+  | Error err -> failwith (Status.show err)
+
+let _sample_rows () =
+  [
+    _make_row ~symbol:"AAPL" ~date:(Date.of_string "2024-01-02");
+    _make_row ~symbol:"MSFT" ~date:(Date.of_string "2024-01-02");
+    _make_row ~symbol:"GOOG" ~date:(Date.of_string "2024-01-03");
+  ]
+
+let _write_then_read path rows =
+  Result.bind (Snapshot_format.write ~path rows) ~f:(fun () ->
+      Snapshot_format.read ~path)
+
+let test_round_trip_three_rows _ =
+  let path = _tmp_path () in
+  let rows = _sample_rows () in
+  assert_that
+    (_write_then_read path rows)
+    (is_ok_and_holds
+       (elements_are
+          [
+            all_of
+              [
+                field (fun s -> s.Snapshot.symbol) (equal_to "AAPL");
+                field
+                  (fun s -> Array.to_list s.Snapshot.values)
+                  (equal_to (Array.to_list (_values_for 7)));
+              ];
+            field (fun s -> s.Snapshot.symbol) (equal_to "MSFT");
+            field (fun s -> s.Snapshot.symbol) (equal_to "GOOG");
+          ]))
+
+let test_round_trip_preserves_schema_hash _ =
+  let path = _tmp_path () in
+  let rows = _sample_rows () in
+  let expected_hash = Snapshot_schema.default.schema_hash in
+  assert_that
+    (_write_then_read path rows)
+    (is_ok_and_holds
+       (each
+          (field
+             (fun s -> s.Snapshot.schema.schema_hash)
+             (equal_to expected_hash))))
+
+let test_empty_list_round_trip _ =
+  let path = _tmp_path () in
+  assert_that (_write_then_read path []) (is_ok_and_holds is_empty)
+
+let test_write_rejects_mixed_schemas _ =
+  let path = _tmp_path () in
+  let other_schema =
+    Snapshot_schema.create ~fields:[ Snapshot_schema.EMA_50 ]
+  in
+  let other_row =
+    match
+      Snapshot.create ~schema:other_schema ~symbol:"X"
+        ~date:(Date.of_string "2024-01-02")
+        ~values:[| 1.0 |]
+    with
+    | Ok s -> s
+    | Error err -> failwith (Status.show err)
+  in
+  let rows =
+    [ _make_row ~symbol:"AAPL" ~date:(Date.of_string "2024-01-02"); other_row ]
+  in
+  assert_that
+    (Snapshot_format.write ~path rows)
+    (is_error_with Status.Invalid_argument)
+
+(* Integrity check: corrupt one byte of the payload (the file's last byte) and
+   read must fail with an md5 mismatch. *)
+let _flip_last_byte path =
+  let bytes = In_channel.read_all path |> Bytes.of_string in
+  let n = Bytes.length bytes in
+  let last = Char.to_int (Bytes.get bytes (n - 1)) in
+  Bytes.set bytes (n - 1) (Char.of_int_exn (last lxor 0xFF));
+  Out_channel.write_all path ~data:(Bytes.to_string bytes)
+
+let _write_corrupt_then_read path rows =
+  Result.bind (Snapshot_format.write ~path rows) ~f:(fun () ->
+      _flip_last_byte path;
+      Snapshot_format.read ~path)
+
+let test_corrupted_payload_detected _ =
+  let path = _tmp_path () in
+  assert_that
+    (_write_corrupt_then_read path (_sample_rows ()))
+    (is_error_with Status.Internal)
+
+let _write_then_read_with_schema path rows ~expected =
+  Result.bind (Snapshot_format.write ~path rows) ~f:(fun () ->
+      Snapshot_format.read_with_expected_schema ~path ~expected)
+
+let test_schema_hash_skew_detected _ =
+  let path = _tmp_path () in
+  let other_schema =
+    Snapshot_schema.create ~fields:[ Snapshot_schema.EMA_50 ]
+  in
+  assert_that
+    (_write_then_read_with_schema path (_sample_rows ()) ~expected:other_schema)
+    (is_error_with Status.Failed_precondition)
+
+let test_schema_hash_match_succeeds _ =
+  let path = _tmp_path () in
+  assert_that
+    (_write_then_read_with_schema path (_sample_rows ())
+       ~expected:Snapshot_schema.default)
+    (is_ok_and_holds (size_is 3))
+
+(* Two writes of the same input must produce byte-identical files. The hashing
+   primitive depends on this for cross-machine reproducibility. *)
+let _write_pair_and_read_bytes ~path_a ~path_b rows =
+  Result.bind (Snapshot_format.write ~path:path_a rows) ~f:(fun () ->
+      Result.map (Snapshot_format.write ~path:path_b rows) ~f:(fun () ->
+          (In_channel.read_all path_a, In_channel.read_all path_b)))
+
+let test_write_byte_identical _ =
+  let path_a = _tmp_path () in
+  let path_b = _tmp_path () in
+  assert_that
+    (_write_pair_and_read_bytes ~path_a ~path_b (_sample_rows ()))
+    (is_ok_and_holds
+       (matching ~msg:"two writes byte-equal"
+          (fun (a, b) -> if String.equal a b then Some () else None)
+          (equal_to ())))
+
+let suite =
+  "Snapshot_format tests"
+  >::: [
+         "round trip three rows" >:: test_round_trip_three_rows;
+         "round trip preserves schema hash"
+         >:: test_round_trip_preserves_schema_hash;
+         "empty list round trip" >:: test_empty_list_round_trip;
+         "write rejects mixed schemas" >:: test_write_rejects_mixed_schemas;
+         "corrupted payload detected" >:: test_corrupted_payload_detected;
+         "schema hash skew detected" >:: test_schema_hash_skew_detected;
+         "schema hash match succeeds" >:: test_schema_hash_match_succeeds;
+         "write byte identical" >:: test_write_byte_identical;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/data_panel/snapshot/test/test_snapshot_schema.ml
+++ b/trading/trading/data_panel/snapshot/test/test_snapshot_schema.ml
@@ -1,0 +1,88 @@
+open OUnit2
+open Core
+open Matchers
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+
+let test_compute_hash_deterministic _ =
+  let h1 = Snapshot_schema.compute_hash Snapshot_schema.all_fields in
+  let h2 = Snapshot_schema.compute_hash Snapshot_schema.all_fields in
+  assert_that (h1, h2)
+    (all_of
+       [
+         field (fun (a, _) -> String.length a) (gt (module Int_ord) 0);
+         field (fun (a, b) -> String.equal a b) (equal_to true);
+       ])
+
+let test_compute_hash_order_sensitive _ =
+  let open Snapshot_schema in
+  let h_canonical = compute_hash [ EMA_50; SMA_50; ATR_14 ] in
+  let h_swapped = compute_hash [ SMA_50; EMA_50; ATR_14 ] in
+  assert_that (String.equal h_canonical h_swapped) (equal_to false)
+
+let test_compute_hash_field_set_sensitive _ =
+  let open Snapshot_schema in
+  let h_short = compute_hash [ EMA_50; SMA_50 ] in
+  let h_long = compute_hash [ EMA_50; SMA_50; ATR_14 ] in
+  assert_that (String.equal h_short h_long) (equal_to false)
+
+let test_default_schema_locks_in_phase_a_fields _ =
+  let open Snapshot_schema in
+  assert_that default.fields
+    (elements_are
+       [
+         equal_to EMA_50;
+         equal_to SMA_50;
+         equal_to ATR_14;
+         equal_to RSI_14;
+         equal_to Stage;
+         equal_to RS_line;
+         equal_to Macro_composite;
+       ])
+
+let test_default_schema_n_fields _ =
+  assert_that (Snapshot_schema.n_fields Snapshot_schema.default) (equal_to 7)
+
+let test_index_of_present_and_absent _ =
+  let open Snapshot_schema in
+  let s = create ~fields:[ EMA_50; ATR_14; Stage ] in
+  assert_that
+    (index_of s EMA_50, index_of s ATR_14, index_of s Stage, index_of s RSI_14)
+    (equal_to (Some 0, Some 1, Some 2, None))
+
+let test_create_caches_hash _ =
+  let s = Snapshot_schema.create ~fields:Snapshot_schema.all_fields in
+  let recomputed = Snapshot_schema.compute_hash s.fields in
+  assert_that (String.equal s.schema_hash recomputed) (equal_to true)
+
+let test_field_name_round_trip _ =
+  let names =
+    List.map Snapshot_schema.all_fields ~f:Snapshot_schema.field_name
+  in
+  assert_that names
+    (elements_are
+       [
+         equal_to "EMA_50";
+         equal_to "SMA_50";
+         equal_to "ATR_14";
+         equal_to "RSI_14";
+         equal_to "Stage";
+         equal_to "RS_line";
+         equal_to "Macro_composite";
+       ])
+
+let suite =
+  "Snapshot_schema tests"
+  >::: [
+         "compute_hash deterministic" >:: test_compute_hash_deterministic;
+         "compute_hash order sensitive" >:: test_compute_hash_order_sensitive;
+         "compute_hash field set sensitive"
+         >:: test_compute_hash_field_set_sensitive;
+         "default schema locks in Phase A fields"
+         >:: test_default_schema_locks_in_phase_a_fields;
+         "default schema n_fields = 7" >:: test_default_schema_n_fields;
+         "index_of present and absent" >:: test_index_of_present_and_absent;
+         "create caches hash" >:: test_create_caches_hash;
+         "field_name round trip" >:: test_field_name_round_trip;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

First PR of the daily-snapshot streaming pipeline (see [`dev/plans/daily-snapshot-streaming-2026-04-27.md`](../blob/main/dev/plans/daily-snapshot-streaming-2026-04-27.md) §Phasing **Phase A**) that ultimately unblocks tier-4 release-gate at N>=5,000 universe + 10y horizons by replacing the full-history-resident panel design with mmap-streamed per-day snapshots.

This PR is the foundation: the in-memory snapshot type, the field schema enum + deterministic hash, and a sexp-payload file format with end-to-end integrity checks. The offline pipeline writer (Phase B), runtime mmap layer (Phase C), engine integration (Phase D), validation (Phase E), and panel retirement (Phase F) all build on this. **Phase B (offline pipeline) is the next PR; this PR is foundation only.**

## Scope (Phase A only)

Per the plan's Phase A definition: "Define `Snapshot_schema.t`, `Snapshot.t`, file format spec; round-trip test; schema-hashing logic."

### New module: `trading.data_panel.snapshot`

- `Snapshot_schema` — field enum + deterministic hash
- `Snapshot` — in-memory per-(symbol, day) row
- `Snapshot_format` — file format with manifest + integrity checks

### Phase A field set (locked-in per the plan §"Indicator set lock-in")

| # | Field | Computed by (Phase B) |
|---|---|---|
| 0 | `EMA_50` | 50-period EMA of adjusted close |
| 1 | `SMA_50` | 50-period SMA of adjusted close |
| 2 | `ATR_14` | 14-period ATR |
| 3 | `RSI_14` | 14-period RSI |
| 4 | `Stage` | Weinstein stage classification (1.0\|2.0\|3.0\|4.0; NaN = unclassifiable) |
| 5 | `RS_line` | relative-strength line vs market benchmark |
| 6 | `Macro_composite` | macro-environment composite score |

Schema is **order-significant**: any reordering produces a new `schema_hash` → full corpus rebuild.

### File format

```
bytes 0..7        manifest_len : int64 little-endian
bytes 8..(8+M-1)  manifest_sexp : ASCII sexp (M = manifest_len)
bytes 8+M..       payload : sexp-encoded list of (symbol, date, values)
```

Manifest carries `schema` (with hash), `n_rows`, `payload_len`, `payload_md5`. Phase A uses sexp-encoded payload for portability; Phase C upgrades to a `Bigarray.map_file` raw-Float64 payload (will bump schema hash).

### Integrity checks at `read` time

- payload length must match manifest → else `Error Internal "payload length mismatch"`
- payload MD5 must match manifest → else `Error Internal "md5 mismatch"`
- (via `read_with_expected_schema`) file's schema_hash must match runtime expectation → else `Error Failed_precondition "schema hash skew"`

`write` rejects mixed-schema input lists with `Error Invalid_argument`.

### Hash primitive

Uses OCaml stdlib `Digest` (MD5 hex) for both schema fingerprinting and payload integrity. The plan name "sha256" suggested SHA-256, but no SHA-256 library is installed in the build; MD5 is deterministic and adequate for content-addressable schema-version tracking and payload integrity in this closed pipeline (not a security primitive). The `.mli` docstrings call this out explicitly.

## NOT in scope (deferred to Phase B+)

- `bin/build_snapshots.exe` writer (Phase B, ~700 LOC)
- mmap + LRU runtime layer (Phase C, ~800 LOC)
- Strategy/screener integration (Phase D, ~400 LOC)
- Per-day file storage / on-disk directory layout — Phase A defines **format**, not **layout**

## PR sizing

- 11 new files, 800 LOC total (224 impl + 200 mli + 360 tests + 16 dune)
- All new modules under one library (`trading.data_panel.snapshot`)
- No modifications to existing modules

`data/snapshots/` (the future on-disk store, written in Phase B) is already covered by the existing `/data/*` gitignore rule.

## Test plan

- [x] `dune build && dune runtest data_panel/snapshot` — 23 tests across 3 files, all green
- [x] `dune build` — full project clean
- [x] `dune build @fmt` — clean (no fmt diff in our files)
- [x] **Round-trip stable** — `write` then `read` reproduces input list
- [x] **Schema hash deterministic** — same field list → same hex hash; reordering or set change → different hash
- [x] **Corrupted payload detected** — flipping the last byte → `Error Internal` MD5 mismatch
- [x] **Schema mismatch detected** — `read_with_expected_schema` with the wrong schema → loud `Error Failed_precondition`
- [x] **Empty list round-trips** — header-only file is valid
- [x] **Byte-identical writes** — two `write` calls of the same input produce byte-equal files (cross-machine reproducibility primitive)

## Connection to data inventory plan (PR #776)

Phase A schema-hashing pairs naturally with the manifest writer in [`dev/plans/data-inventory-and-reproducibility-2026-05-02.md`](../blob/main/dev/plans/data-inventory-and-reproducibility-2026-05-02.md) Phase 1. Same hashing primitives can be reused. **Optional future cross-reference** (no-op here): the inventory manifest could pick up a `schema_hash` field once Phase B starts emitting snapshots. Not implemented in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)