### PR TITLE
fix(backtest): --fuzz-window flag for sp500-default fuzz universe

### DIFF
--- a/trading/trading/backtest/bin/backtest_runner.ml
+++ b/trading/trading/backtest/bin/backtest_runner.ml
@@ -36,8 +36,8 @@
     {1 Fuzz mode}
 
     [backtest_runner [<start_date> [end_date]] --fuzz
-     <param>=<center>±<delta>:<n> --experiment-name <name> [--override <arg>]
-     ...]
+     <param>=<center>±<delta>:<n> [--fuzz-window <bull|crash|recovery>]
+     --experiment-name <name> [--override <arg>] ...]
 
     Parses the spec via {!Backtest.Fuzz_spec.parse}, runs N variants, and writes
     [fuzz_distribution.{sexp,md}] alongside per-variant subdirs at
@@ -52,6 +52,14 @@
     [--override] / [--shared-override] (those apply to every variant). For
     date-key specs the positional [start_date] is overridden by the variant; for
     numeric-key specs the positional [start_date] is required.
+
+    The optional [--fuzz-window <name>] flag points at a window in
+    {!Scenario_lib.Smoke_catalog} (currently [bull], [crash], [recovery]) and
+    constrains every variant to that window's [universe_path] (sp500 by
+    default). Without it, fuzz mode loads the full ~10K-symbol [sectors.csv] and
+    OOMs the 8 GB dev container — this is the same fix smoke mode received; the
+    runner now warns when [--fuzz-window] is omitted. Note: only the universe is
+    constrained; the window's start/end dates are NOT substituted into variants.
 
     {1 --override vs. --shared-override}
 
@@ -78,7 +86,8 @@ open Core
 let _usage_msg =
   "Usage: backtest_runner <start_date> [end_date] [--override <arg>] \
    [--shared-override <arg>] [--trace <path>] [--memtrace <path>] [--gc-trace \
-   <path>] [--baseline] [--smoke] [--fuzz <spec>] [--experiment-name <name>]"
+   <path>] [--baseline] [--smoke] [--fuzz <spec>] [--fuzz-window \
+   <bull|crash|recovery>] [--experiment-name <name>]"
 
 (** Convert each raw [--override <arg>] string into the partial-config sexp the
     runner deep-merges. Routes key-path strings through
@@ -254,6 +263,28 @@ let _smoke_window_sector_map ~fixtures_root
   Scenario_lib.Universe_file.to_sector_map_override
     (Scenario_lib.Universe_file.load resolved)
 
+(** Resolve a [--fuzz-window <name>] flag value into a [sector_map_override] by
+    looking up the named window in {!Scenario_lib.Smoke_catalog.all}. Exits 1
+    with a friendly error if the name doesn't match any catalog entry — that way
+    a typo surfaces immediately, not after the universe is already loaded. *)
+let _resolve_fuzz_window_override name =
+  match
+    List.find Scenario_lib.Smoke_catalog.all
+      ~f:(fun (w : Scenario_lib.Smoke_catalog.window) ->
+        String.equal w.name name)
+  with
+  | Some window ->
+      let fixtures_root = Scenario_lib.Fixtures_root.resolve () in
+      _smoke_window_sector_map ~fixtures_root window
+  | None ->
+      let known =
+        List.map Scenario_lib.Smoke_catalog.all
+          ~f:(fun (w : Scenario_lib.Smoke_catalog.window) -> w.name)
+        |> String.concat ~sep:", "
+      in
+      eprintf "Error: unknown --fuzz-window %S (known: %s)\n" name known;
+      Stdlib.exit 1
+
 (** Convert one fuzz variant into the (start_date, overrides) pair the
     per-variant run consumes. Date variants substitute the start_date; numeric
     variants are encoded as a partial-config sexp via {!Config_override} and
@@ -276,8 +307,12 @@ let _resolve_fuzz_variant ~base_start_date ~base_overrides
     already includes any [--shared-override] entries appended at the call site)
     is passed unchanged to every variant — fuzz-mode treats override and
     shared_override identically since there's no baseline to differentiate them.
-*)
-let _fuzz_run ~start_date ~end_date ~overrides ~output_root ~fuzz_spec_raw () =
+
+    [sector_map_override], when supplied (via [--fuzz-window <name>]), replaces
+    the default sector map for {b every} variant — same trick smoke mode uses to
+    keep the run inside the dev-container memory budget. *)
+let _fuzz_run ~start_date ~end_date ~overrides ~output_root ~fuzz_spec_raw
+    ?sector_map_override () =
   let fuzz_spec =
     match Backtest.Fuzz_spec.parse fuzz_spec_raw with
     | Ok spec -> spec
@@ -300,7 +335,7 @@ let _fuzz_run ~start_date ~end_date ~overrides ~output_root ~fuzz_spec_raw () =
         eprintf "[fuzz %d/%d] %s = %s\n%!" v.index n v.key_path v.label;
         let result =
           _run_and_write ~start_date:v_start ~end_date ~overrides:v_overrides
-            ~output_dir:variant_dir ()
+            ~output_dir:variant_dir ?sector_map_override ()
         in
         (v.label, result.summary))
   in
@@ -387,12 +422,24 @@ let () =
         _resolve_dates_for_fuzz ~start_date_raw:parsed.start_date
           ~end_date_raw:parsed.end_date
       in
+      let sector_map_override =
+        match parsed.fuzz_window with
+        | Some name -> _resolve_fuzz_window_override name
+        | None ->
+            eprintf
+              "[fuzz] WARNING: --fuzz-window not set; loading the full \
+               sector-map. This OOMs the 8 GB dev container at panel-load. \
+               Pass --fuzz-window <bull|crash|recovery> to constrain to the \
+               sp500 universe (~491 symbols).\n\
+               %!";
+            None
+      in
       (* Fuzz mode treats override and shared_override identically — there's
          no baseline to differentiate them, so flatten both into the per-variant
          override list. *)
       _fuzz_run ~start_date ~end_date
         ~overrides:(shared_overrides @ overrides)
-        ~output_root ~fuzz_spec_raw ()
+        ~output_root ~fuzz_spec_raw ?sector_map_override ()
   | None, true, _ ->
       _smoke_run ~shared_overrides ~overrides ~output_root
         ~baseline:parsed.baseline ()

--- a/trading/trading/backtest/runner_args/backtest_runner_args.ml
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.ml
@@ -12,6 +12,7 @@ type t = {
   smoke : bool;
   experiment_name : string option;
   fuzz_spec : string option;
+  fuzz_window : string option;
 }
 
 type acc = {
@@ -25,6 +26,7 @@ type acc = {
   smoke : bool;
   experiment_name : string option;
   fuzz_spec : string option;
+  fuzz_window : string option;
 }
 (** Accumulator for [_extract_flags]. Carries every flag the parser recognises
     plus the running list of positional args. *)
@@ -41,6 +43,7 @@ let _empty_acc =
     smoke = false;
     experiment_name = None;
     fuzz_spec = None;
+    fuzz_window = None;
   }
 
 let _err msg = Error (Status.invalid_argument_error msg)
@@ -79,6 +82,9 @@ let rec _extract_flags args (acc : acc) =
   | "--fuzz" :: value :: rest ->
       _extract_flags rest { acc with fuzz_spec = Some value }
   | [ "--fuzz" ] -> _err "--fuzz requires a spec argument"
+  | "--fuzz-window" :: value :: rest ->
+      _extract_flags rest { acc with fuzz_window = Some value }
+  | [ "--fuzz-window" ] -> _err "--fuzz-window requires a name argument"
   | arg :: rest ->
       _extract_flags rest { acc with positional = arg :: acc.positional }
 
@@ -125,6 +131,15 @@ let _validate_fuzz_exclusivity ~baseline ~smoke ~fuzz_spec =
   | Some _ when smoke -> _err "--fuzz is mutually exclusive with --smoke"
   | Some _ -> Ok ()
 
+(** [--fuzz-window] only makes sense in fuzz mode — outside fuzz, the runner has
+    no per-variant pipeline to apply the universe override to. We surface a
+    parse-time error rather than silently ignoring the flag, since the silent
+    behaviour would mislead callers expecting a constrained universe. *)
+let _validate_fuzz_window_requires_fuzz ~fuzz_window ~fuzz_spec =
+  match (fuzz_window, fuzz_spec) with
+  | Some _, None -> _err "--fuzz-window requires --fuzz"
+  | _ -> Ok ()
+
 let _build_result (acc : acc) (start_date, end_date) =
   Ok
     {
@@ -139,6 +154,7 @@ let _build_result (acc : acc) (start_date, end_date) =
       smoke = acc.smoke;
       experiment_name = acc.experiment_name;
       fuzz_spec = acc.fuzz_spec;
+      fuzz_window = acc.fuzz_window;
     }
 
 let parse args =
@@ -151,6 +167,10 @@ let parse args =
             (_validate_fuzz_exclusivity ~baseline:acc.baseline ~smoke:acc.smoke
                ~fuzz_spec:acc.fuzz_spec) ~f:(fun () ->
               Result.bind
-                (_split_positional ~smoke:acc.smoke ~fuzz_spec:acc.fuzz_spec
-                   acc.positional)
-                ~f:(_build_result acc))))
+                (_validate_fuzz_window_requires_fuzz
+                   ~fuzz_window:acc.fuzz_window ~fuzz_spec:acc.fuzz_spec)
+                ~f:(fun () ->
+                  Result.bind
+                    (_split_positional ~smoke:acc.smoke ~fuzz_spec:acc.fuzz_spec
+                       acc.positional)
+                    ~f:(_build_result acc)))))

--- a/trading/trading/backtest/runner_args/backtest_runner_args.mli
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.mli
@@ -72,6 +72,19 @@ type t = {
           markdown alongside the per-variant subdirs. The string is stored
           verbatim — interpretation is the executable's job. Mutually exclusive
           with [--baseline] and [--smoke] (validated at parse time). *)
+  fuzz_window : string option;
+      (** [Some name] when [--fuzz-window <bull|crash|recovery>] was passed.
+          Only meaningful in fuzz mode: the runner resolves the named window in
+          {!Scenario_lib.Smoke_catalog} and uses its [universe_path] to build a
+          [sector_map_override] for every variant — the same trick smoke mode
+          uses to keep the run inside the 8 GB dev-container memory budget
+          (avoids loading the full ~10K-symbol [sectors.csv]).
+
+          The window's start/end dates are {b not} substituted into fuzz
+          variants — only the universe is constrained. Fuzz date variants and
+          the positional [start_date] still drive the per-variant time range.
+
+          Validated at parse time: [--fuzz-window] requires [--fuzz]. *)
 }
 (** Result of parsing the [backtest_runner.exe] command line. *)
 
@@ -81,8 +94,9 @@ val parse : string list -> t Status.status_or
 
     Returns [Error status] (with [Status.code = Invalid_argument]) on any
     parsing problem (missing flag value, missing required positional, too many
-    positionals, [--baseline]/[--smoke]/[--fuzz] without [--experiment-name], or
-    [--fuzz] combined with [--baseline] or [--smoke]).
+    positionals, [--baseline]/[--smoke]/[--fuzz] without [--experiment-name],
+    [--fuzz] combined with [--baseline] or [--smoke], or [--fuzz-window] without
+    [--fuzz]).
 
     Override strings are NOT validated here — the executable runs them through
     [Backtest.Config_override.parse] / [Sexp.of_string] downstream and surfaces

--- a/trading/trading/backtest/test/test_backtest_runner_args.ml
+++ b/trading/trading/backtest/test/test_backtest_runner_args.ml
@@ -48,6 +48,9 @@ let test_minimal_start_date_only _ =
             field
               (fun (a : Backtest_runner_args.t) -> a.fuzz_spec)
               (equal_to None);
+            field
+              (fun (a : Backtest_runner_args.t) -> a.fuzz_window)
+              (equal_to None);
           ]))
 
 let test_override_key_path_form _ =
@@ -291,6 +294,47 @@ let test_fuzz_with_smoke_is_error _ =
     Backtest_runner_args.parse
       [ "--fuzz"; "x=1.0\xC2\xB10.1:3"; "--smoke"; "--experiment-name"; "x" ]
   in
+  assert_that result is_error
+
+let test_fuzz_window_with_fuzz _ =
+  (* --fuzz-window composes with --fuzz to constrain the per-variant universe
+     to a smoke-catalog window's universe_path (sp500 by default). *)
+  let result =
+    Backtest_runner_args.parse
+      [
+        "2020-04-30";
+        "--fuzz";
+        "start_date=2020-01-02\xC2\xB12w:3";
+        "--fuzz-window";
+        "crash";
+        "--experiment-name";
+        "fuzz_window_test";
+      ]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (a : Backtest_runner_args.t) -> a.fuzz_spec)
+              (equal_to (Some "start_date=2020-01-02\xC2\xB12w:3"));
+            field
+              (fun (a : Backtest_runner_args.t) -> a.fuzz_window)
+              (equal_to (Some "crash"));
+          ]))
+
+let test_fuzz_window_without_fuzz_is_error _ =
+  (* --fuzz-window outside fuzz mode is meaningless — the override would
+     have nowhere to apply. Surface it at parse time rather than silently
+     ignoring. *)
+  let result =
+    Backtest_runner_args.parse
+      [ "2020-01-02"; "--fuzz-window"; "crash"; "--experiment-name"; "x" ]
+  in
+  assert_that result is_error
+
+let test_fuzz_window_missing_value _ =
+  let result = Backtest_runner_args.parse [ "2020-01-02"; "--fuzz-window" ] in
   assert_that result is_error
 
 let test_fuzz_with_overrides_composes _ =
@@ -631,6 +675,11 @@ let suite =
          "--fuzz with --baseline is error" >:: test_fuzz_with_baseline_is_error;
          "--fuzz with --smoke is error" >:: test_fuzz_with_smoke_is_error;
          "--fuzz composes with --override" >:: test_fuzz_with_overrides_composes;
+         "--fuzz-window composes with --fuzz" >:: test_fuzz_window_with_fuzz;
+         "--fuzz-window without --fuzz is error"
+         >:: test_fuzz_window_without_fuzz_is_error;
+         "--fuzz-window without value is error"
+         >:: test_fuzz_window_missing_value;
          "trace pipeline write+parse round-trip" >:: test_trace_write_and_parse;
        ]
 


### PR DESCRIPTION
Follow-up to #780 (fuzz-runner). Without `--fuzz-window`, fuzz mode loads the full ~10K-symbol `sectors.csv` → OOMs the 8 GB dev container before the first variant completes. Same root cause #774 fixed for `--smoke`.

## Changes

- `fuzz_window : string option` on `backtest_runner_args.t`
- `--fuzz-window <bull|crash|recovery>` CLI flag
- Validation: `--fuzz-window` requires `--fuzz` (parse-time error); when `--fuzz` is used without `--fuzz-window` the runner emits a loud `[fuzz] WARNING:` line pointing to the OOM hazard
- `_fuzz_run` threads `sector_map_override` resolved from the named `Smoke_catalog` window's `universe_path`
- Bogus window names exit with a friendly `Error: unknown --fuzz-window "X" (known: bull, crash, recovery)`
- **Window's start/end dates NOT substituted** — only the universe is constrained. Fuzz date variants + positional `start_date` still drive per-variant time range. Documented in `.mli`.

## Live verification (2026-05-02 in trading-1-dev)

```
backtest_runner 2020-04-30 --fuzz "start_date=2020-04-15±1w:3" \
  --fuzz-window crash --experiment-name fuzz-window-smoke2
```

- 3 variants ran against 491-symbol sp500 universe (was 10472 before)
- Wall time: 9m40s (no OOM, no timeout)
- `fuzz_distribution.{sexp,md}` written at `dev/experiments/fuzz-window-smoke2/`
- Each variant logs `Using scenario-provided sector map (491 symbols)... Universe: 491 stocks`
- Each variant got its own subdir under `variants/var-N/` with full result set

Negative-path checks also verified:
- `--fuzz-window bogus` → exit 1 with friendly error listing known names
- `--fuzz-window crash` (no `--fuzz`) → exit 1 with `--fuzz-window requires --fuzz`
- `--fuzz "..."` (no `--fuzz-window`) → runs but emits the loud OOM warning before loading the universe

## Test plan

- 3 new unit tests in `test_backtest_runner_args` (`--fuzz-window` with `--fuzz`, without `--fuzz` is error, missing value is error)
- Existing `test_minimal_start_date_only` updated to pin new field defaults to `None`
- 40/40 in `test_backtest_runner_args.exe` green
- `dune build` clean (zero warnings besides workspace-root warning, pre-existing)
- `dune build @fmt` clean (verified via `ocamlformat --inplace --enable-outside-detected-project --profile=default --margin=80` against my 4 files; no diff)

## PR sizing

148 LOC across 4 files, 1 module touched, scope = pure plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)