### PR TITLE
chore(goldens): repin sp500-2019-2023 baseline post-#744/#745/#746/#771

### DIFF
--- a/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp
@@ -14,16 +14,23 @@
 ;; strategy, segmentation-based stage classifier, stop-buffer tuning, etc.
 ;; Once metrics here are pinned, follow-on PRs measure against this baseline.
 ;;
-;; Expected ranges pinned ±10-15% around the post-G9 with-shorts baseline
-;; measured 2026-04-30 (see dev/notes/sp500-shortside-reenabled-2026-04-30.md
-;; for the rerun results and dev/notes/short-side-gaps-2026-04-29.md for the
-;; G1-G9 gap closure history). Re-pin with each deliberate strategy
-;; behaviour change; don't bump these to absorb regressions.
+;; Expected ranges are pinned around the canonical run with cushion sized to
+;; absorb the start-date IQR observed in the PR #788 fuzz (5 variants at
+;; ±2w around 2019-01-02). Re-pin with each deliberate strategy behaviour
+;; change; don't bump these to absorb regressions.
 ;;
-;; Measured baseline (2026-04-30, post-#710 G9 fix):
-;;   total_return_pct  -0.01  total_trades 32   win_rate 37.50
-;;   sharpe_ratio       0.01  max_drawdown 5.81  avg_holding_days 43.03
-;;   open_positions_value 391,949   force_liquidations 0
+;; Measured baseline (2026-05-02, post-#744+#745+#746+#771):
+;;   total_return_pct  +60.86  total_trades 86   win_rate ~22.35
+;;   sharpe_ratio       0.55   max_drawdown 34.15
+;;
+;; Verified via PR #788 fuzz: 5 variants ±2w start_date all returned
+;; +37.92% to +60.86% / Sharpe 0.41-0.56 / MaxDD 31.28-35.99 / 82-99 trades
+;; (see dev/experiments/fuzz-startdate-canonical-full/fuzz_distribution.md).
+;; The pin shift from the prior 2026-04-30 baseline (-0.01% / 32 trades /
+;; 5.81% MaxDD) reflects the structural changes in #744 (sizing fix), #745
+;; (cash-deployment fix), #746 (long/short cap split), and #771 (stop
+;; tuning). Bands are sized to absorb the fuzz IQR plus cushion so future
+;; small drift (start-date sensitivity, calendar rolls) does not flap CI.
 ;;
 ;; (Pre-rename: this metric was named [unrealized_pnl] but its semantics
 ;; matched the renamed [Metric_types.OpenPositionsValue] — signed mtm value
@@ -42,10 +49,10 @@
  (universe_size 491)
  (config_overrides ())
  (expected
-  ((total_return_pct   ((min -15.0)       (max  15.0)))
-   (total_trades       ((min 27)          (max  37)))
-   (win_rate           ((min 31.0)        (max  44.0)))
-   (sharpe_ratio       ((min -0.5)        (max  0.5)))
-   (max_drawdown_pct   ((min 3.0)         (max  9.0)))
-   (avg_holding_days   ((min 37.0)        (max  50.0)))
-   (open_positions_value ((min 330000.0)  (max  450000.0))))))
+  ((total_return_pct   ((min  30.0)       (max  70.0)))
+   (total_trades       ((min 70)          (max 110)))
+   (win_rate           ((min 15.0)        (max  35.0)))
+   (sharpe_ratio       ((min  0.30)       (max   0.70)))
+   (max_drawdown_pct   ((min 25.0)        (max  42.0)))
+   (avg_holding_days   ((min 65.0)        (max 115.0)))
+   (open_positions_value ((min 1200000.0) (max 1700000.0))))))


### PR DESCRIPTION
## Summary

Repin the `goldens-sp500/sp500-2019-2023.sexp` baseline. The pin was stale (2026-04-30) and predated four structural strategy changes that shifted the canonical metrics significantly.

### Structural changes since the prior pin

- #744 sizing fix
- #745 cash-deployment fix
- #746 long/short cap split (`max_position_pct` → asymmetric long/short caps)
- #771 stop tuning

### Old vs new measured baseline

| Metric              | Old pin (2026-04-30) | New pin (2026-05-02) |
|---------------------|----------------------|----------------------|
| total_return_pct    | -0.01%               | +60.86%              |
| total_trades        | 32                   | 86                   |
| win_rate            | 37.50%               | ~22.35%              |
| sharpe_ratio        | 0.01                 | 0.55                 |
| max_drawdown_pct    | 5.81                 | 34.15                |

### Verification — PR #788 fuzz

Distribution across 5 variants (`start_date=2019-01-02 ±2w`, full 5-year window):

| Metric              | Fuzz min  | Fuzz max  | Fuzz median | New band     |
|---------------------|-----------|-----------|-------------|--------------|
| total_return_pct    | +37.92    | +60.86    | 55.44       | 30 — 70      |
| total_trades        | 82        | 99        | 87          | 70 — 110     |
| win_rate            | 21.95     | 25.25     | 22.35       | 15 — 35      |
| sharpe_ratio        | 0.41      | 0.56      | 0.52        | 0.30 — 0.70  |
| max_drawdown_pct    | 31.28     | 35.99     | 34.15       | 25 — 42      |
| avg_holding_days    | 78.22     | 103.84    | 82.10       | 65 — 115     |
| open_positions_val  | 1,313,382 | 1,530,796 | 1,519,818   | 1.2M — 1.7M  |

The center variant (`start_date=2019-01-02`) was bit-identical to this morning's manual canonical run (60.86% / 34.15% / 86 trades / Sharpe 0.55), so this is the new canonical point.

### Band sizing rationale

Each band absorbs the full fuzz min/max plus an asymmetric cushion (~5–15 absolute points or ~10–25%) sized to keep CI from flapping under expected drift sources (start-date shifts, calendar rolls, small data-vintage changes) while still failing on real regression. The `total_return_pct` lower bound (+30) leaves ~8 points of headroom below the fuzz min (+37.92); the upper bound (+70) leaves ~9 points above the max.

### Source

`dev/experiments/fuzz-startdate-canonical-full/fuzz_distribution.md` (PR #788).

## Test plan

- [x] Sexp parses (verified via `dune runtest backtest/scenarios/test`, status=0)
- [x] `dune build` clean with the updated file in place (no compilation error)
- [x] Comment block updated to point at the fuzz output + prior-baseline delta so future re-baselines retain context
- [ ] Reviewer: confirm bands are appropriately tight given fuzz IQR

🤖 Generated with [Claude Code](https://claude.com/claude-code)