### PR TITLE
feat(snapshot): F.2 PR 1 — Snapshot_bar_views shim over Snapshot_callbacks

### DIFF
--- a/trading/analysis/weinstein/snapshot_runtime/lib/dune
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/dune
@@ -3,8 +3,10 @@
  (public_name weinstein.snapshot_runtime)
  (libraries
   core
+  indicators.time_period
   status
   trading.data_panel.snapshot
+  types
   weinstein.snapshot_pipeline)
  (preprocess
   (pps ppx_compare ppx_deriving.eq ppx_deriving.show ppx_let ppx_sexp_conv)))

--- a/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml
@@ -1,0 +1,240 @@
+(** Bar-shaped views over [Snapshot_callbacks.t] — see [snapshot_bar_views.mli].
+*)
+
+open Core
+module BA1 = Bigarray.Array1
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+
+type weekly_view = {
+  closes : float array;
+  raw_closes : float array;
+  highs : float array;
+  lows : float array;
+  volumes : float array;
+  dates : Core.Date.t array;
+  n : int;
+}
+
+type daily_view = {
+  highs : float array;
+  lows : float array;
+  closes : float array;
+  dates : Core.Date.t array;
+  n_days : int;
+}
+
+let _empty_weekly_view : weekly_view =
+  {
+    closes = [||];
+    raw_closes = [||];
+    highs = [||];
+    lows = [||];
+    volumes = [||];
+    dates = [||];
+    n = 0;
+  }
+
+let _empty_daily_view : daily_view =
+  { highs = [||]; lows = [||]; closes = [||]; dates = [||]; n_days = 0 }
+
+(* Calendar slack for date-keyed windows. The snapshot fan-out is per-field
+   over an inclusive [from, until] window; [from] is computed by walking back
+   from [as_of]. We need enough slack to cover weekends + holidays + partial
+   weeks. Empirically:
+   - daily lookback: 1.5x trading-day slack covers ~250-day weekend/holiday
+     ratios; we round up.
+   - weekly: 8x weeks-to-days conversion (7 weekdays + 1 holiday slack) covers
+     ISO-week buckets + a partial leading week. *)
+let _daily_calendar_span ~lookback = (lookback * 3 / 2) + 7
+let _weekly_calendar_span ~n = (n * 8) + 7
+
+(* Fetch one field's history; return [] (not an error) on any failure. The
+   shim's surface contract is "missing data → empty view" (matches Bar_panels
+   semantics); this helper enforces that at the per-field level. *)
+let _read_history_or_empty (cb : Snapshot_callbacks.t) ~symbol ~from ~until
+    ~field =
+  match cb.read_field_history ~symbol ~from ~until ~field with
+  | Ok rows -> rows
+  | Error _ -> []
+
+(* Align five field-histories ([Adjusted_close, Close, High, Low, Volume])
+   by date into a single chronologically-ordered [Daily_price.t list]. Each
+   input list is already chronologically sorted (Daily_panels.read_history
+   sort contract). A bar is included iff [Close] is non-NaN AND every other
+   field has a row for the same date.
+
+   Implementation: build hashtables per non-Close field keyed by date, then
+   walk the [Close] list once and look up the others. O(n_close + n_other);
+   no nested-loop blow-up. *)
+let _table_of (rows : (Date.t * float) list) =
+  let tbl = Hashtbl.create (module Date) in
+  List.iter rows ~f:(fun (d, v) ->
+      Hashtbl.set tbl ~key:d ~data:v |> (ignore : unit -> unit));
+  tbl
+
+let _round_volume v =
+  if Float.is_nan v then 0 else Int.of_float (Float.round_nearest v)
+
+let _assemble_daily_bars ~adj ~close ~high ~low ~volume :
+    Types.Daily_price.t list =
+  let adj_t = _table_of adj in
+  let high_t = _table_of high in
+  let low_t = _table_of low in
+  let vol_t = _table_of volume in
+  let bar_for (date, close_v) =
+    if Float.is_nan close_v then None
+    else
+      match
+        ( Hashtbl.find adj_t date,
+          Hashtbl.find high_t date,
+          Hashtbl.find low_t date,
+          Hashtbl.find vol_t date )
+      with
+      | Some adj_v, Some high_v, Some low_v, Some vol_v ->
+          Some
+            {
+              Types.Daily_price.date;
+              open_price = Float.nan;
+              high_price = high_v;
+              low_price = low_v;
+              close_price = close_v;
+              volume = _round_volume vol_v;
+              adjusted_close = adj_v;
+            }
+      | _ -> None
+  in
+  List.filter_map close ~f:bar_for
+
+(* Convert a weekly [Daily_price.t] list (output of daily_to_weekly) into the
+   [weekly_view] float-array shape. *)
+let _weekly_view_of_bars (weekly : Types.Daily_price.t list) : weekly_view =
+  let n = List.length weekly in
+  if n = 0 then _empty_weekly_view
+  else
+    let arr_of f = Array.of_list (List.map weekly ~f) in
+    {
+      closes = arr_of (fun b -> b.adjusted_close);
+      raw_closes = arr_of (fun b -> b.close_price);
+      highs = arr_of (fun b -> b.high_price);
+      lows = arr_of (fun b -> b.low_price);
+      volumes = arr_of (fun b -> Float.of_int b.volume);
+      dates = arr_of (fun b -> b.date);
+      n;
+    }
+
+let _truncate_weekly_view (v : weekly_view) ~n : weekly_view =
+  if v.n <= n then v
+  else
+    let drop = v.n - n in
+    let take a = Array.sub a ~pos:drop ~len:n in
+    {
+      closes = take v.closes;
+      raw_closes = take v.raw_closes;
+      highs = take v.highs;
+      lows = take v.lows;
+      volumes = take v.volumes;
+      dates = take v.dates;
+      n;
+    }
+
+let weekly_view_for (cb : Snapshot_callbacks.t) ~symbol ~n ~as_of =
+  if n <= 0 then _empty_weekly_view
+  else
+    let from = Date.add_days as_of (-_weekly_calendar_span ~n) in
+    let read field =
+      _read_history_or_empty cb ~symbol ~from ~until:as_of ~field
+    in
+    let close = read Snapshot_schema.Close in
+    if List.is_empty close then _empty_weekly_view
+    else
+      let adj = read Snapshot_schema.Adjusted_close in
+      let high = read Snapshot_schema.High in
+      let low = read Snapshot_schema.Low in
+      let volume = read Snapshot_schema.Volume in
+      let bars = _assemble_daily_bars ~adj ~close ~high ~low ~volume in
+      if List.is_empty bars then _empty_weekly_view
+      else
+        let weekly =
+          Time_period.Conversion.daily_to_weekly ~include_partial_week:true bars
+        in
+        _truncate_weekly_view (_weekly_view_of_bars weekly) ~n
+
+(* Take the trailing [k] elements of a list. [k <= 0] yields []. *)
+let _take_trailing l k =
+  if k <= 0 then []
+  else
+    let n = List.length l in
+    if n <= k then l else List.drop l (n - k)
+
+let _daily_view_of_close_high_low ~close ~high ~low : daily_view =
+  let high_t = _table_of high in
+  let low_t = _table_of low in
+  (* Walk the close list once; emit a row iff close is non-NaN and the
+     high/low tables both contain the same date. *)
+  let rows =
+    List.filter_map close ~f:(fun (date, close_v) ->
+        if Float.is_nan close_v then None
+        else
+          match (Hashtbl.find high_t date, Hashtbl.find low_t date) with
+          | Some high_v, Some low_v -> Some (date, high_v, low_v, close_v)
+          | _ -> None)
+  in
+  let n = List.length rows in
+  if n = 0 then _empty_daily_view
+  else
+    let arr_of f = Array.of_list (List.map rows ~f) in
+    {
+      highs = arr_of (fun (_, h, _, _) -> h);
+      lows = arr_of (fun (_, _, l, _) -> l);
+      closes = arr_of (fun (_, _, _, c) -> c);
+      dates = arr_of (fun (d, _, _, _) -> d);
+      n_days = n;
+    }
+
+(* Bar_panels.daily_view_for walks the last [lookback] calendar columns
+   ending at [as_of_day], NaN-skips, returns the rest. The panel's calendar
+   is trading days, so "last [lookback] columns" = "last [lookback] trading
+   days". The snapshot has one row per trading day; we trim the [Close]
+   history to its trailing [lookback] rows BEFORE the NaN-skip so the count
+   matches the panel's "lookback - n_nan_skipped" semantics. *)
+let daily_view_for (cb : Snapshot_callbacks.t) ~symbol ~as_of ~lookback =
+  if lookback <= 0 then _empty_daily_view
+  else
+    let from = Date.add_days as_of (-_daily_calendar_span ~lookback) in
+    let read field =
+      _read_history_or_empty cb ~symbol ~from ~until:as_of ~field
+    in
+    let close_all = read Snapshot_schema.Close in
+    if List.is_empty close_all then _empty_daily_view
+    else
+      let close = _take_trailing close_all lookback in
+      let high = read Snapshot_schema.High in
+      let low = read Snapshot_schema.Low in
+      _daily_view_of_close_high_low ~close ~high ~low
+
+(* low_window: produce a Bigarray.Array1.t holding the last [len] daily Low
+   values ending at as_of. Bar_panels.low_window returns None when fewer than
+   [len] cells are available; we mirror that contract here.
+
+   Bar_panels' low_window does NOT NaN-skip — it returns a raw panel slice
+   that includes any NaN cells. We follow that contract here: if the snapshot
+   reports rows but some Low values are NaN, those NaNs are included. The
+   caller (the support-floor primitive) is the one that decides what to do
+   with NaN. *)
+let low_window (cb : Snapshot_callbacks.t) ~symbol ~as_of ~len =
+  if len <= 0 then None
+  else
+    let from = Date.add_days as_of (-_daily_calendar_span ~lookback:len) in
+    match
+      cb.read_field_history ~symbol ~from ~until:as_of
+        ~field:Snapshot_schema.Low
+    with
+    | Error _ -> None
+    | Ok rows ->
+        let n = List.length rows in
+        if n < len then None
+        else
+          let trailing = List.drop rows (n - len) in
+          let buf = BA1.create Bigarray.Float64 Bigarray.C_layout len in
+          List.iteri trailing ~f:(fun i (_, v) -> BA1.set buf i v);
+          Some buf

--- a/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.mli
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.mli
@@ -1,0 +1,158 @@
+(** Bar-shaped views over {!Snapshot_callbacks.t}.
+
+    Phase F.2 PR 1 of the daily-snapshot streaming pipeline (see
+    [dev/plans/daily-snapshot-streaming-2026-04-27.md] §Phasing Phase F).
+    Reproduces the {!Data_panel.Bar_panels} view shapes ([weekly_view] /
+    [daily_view] / [low_window]) on top of {!Snapshot_callbacks.t}, which is
+    backed by an LRU-bounded {!Daily_panels.t} cache rather than a whole-
+    universe × all-days bigarray panel.
+
+    {2 Why a separate module}
+
+    {!Bar_panels.t} allocates an [N x T] bigarray per OHLCV field at runner
+    startup. At N = 5000 symbols × T ~= 2520 trading days × 6 fields × 8 bytes
+    that is ~27 GB of resident memory and OOMs an 8 GB host. The snapshot path
+    holds at most [max_cache_mb] of decoded snapshot rows at once; bar reads fan
+    out through {!Snapshot_callbacks.read_field_history}.
+
+    PR 1 (this module) builds the shim + tests. PR 2 wires it through
+    [Panel_runner] / [Weinstein_strategy] in place of [Bar_panels.t].
+
+    {2 Semantics — match {!Bar_panels} bit-for-bit}
+
+    The weekly view uses ISO-week buckets via
+    {!Time_period.Conversion.daily_to_weekly} with [include_partial_week:true],
+    matching {!Bar_panels.weekly_view_for}'s aggregation rules:
+
+    - [closes] = adjusted close of the last trading day in the week
+    - [raw_closes] = raw close of the last trading day in the week
+    - [highs] = max raw high within the week
+    - [lows] = min raw low within the week
+    - [volumes] = sum of raw volumes within the week
+    - [dates] = date of the last trading day in the week
+
+    The daily view drops bars where the raw [Close] field is NaN (matching
+    {!Bar_panels.daily_view_for}'s NaN-skip), and exposes raw OHLC plus dates.
+
+    Unknown symbols, empty date ranges, or otherwise-unreadable snapshot rows
+    yield the empty view. This matches {!Bar_panels}'s "missing data → empty
+    list" surface — the strategy already handles empty bar histories. The shim
+    does not surface schema-skew or filesystem errors to the caller; those
+    failures degrade to "no bars" here. (PR 2 wiring sites can re-add explicit
+    error handling if needed; today's [Bar_panels] callers don't have it
+    either.)
+
+    {2 Calling convention vs {!Bar_panels}}
+
+    {!Bar_panels} takes [as_of_day:int] (a calendar column index). The snapshot
+    path is keyed by date, so this module takes [as_of:Core.Date.t]. The
+    strategy already has the date in scope (read from the primary index bar each
+    tick), so the swap at the call site is straightforward.
+
+    {!low_window} returns a freshly-allocated {!Bigarray.Array1.t} (a copy of
+    the relevant Low-field history). {!Bar_panels.low_window} returned a
+    zero-copy [Bigarray.Array2.sub_left] slice over its panel; the snapshot
+    backing has no equivalent contiguous panel to slice, so the snapshot version
+    owns its own buffer. Memory cost: at most [len * 8] bytes per call, freed by
+    the GC. *)
+
+type weekly_view = {
+  closes : float array;
+      (** Adjusted close per weekly bar (chronological, oldest at index 0). *)
+  raw_closes : float array;
+      (** Raw (un-adjusted) close per weekly bar — the [Snapshot_schema.Close]
+          field's value at the last trading day of each weekly bucket. Used
+          together with [closes] to compute per-bar split-adjustment factors
+          ([closes.(i) /. raw_closes.(i)]). *)
+  highs : float array;  (** Max raw high within each weekly bucket. *)
+  lows : float array;  (** Min raw low within each weekly bucket. *)
+  volumes : float array;
+      (** Sum of raw daily volumes within each weekly bucket. Stored as float to
+          align with the snapshot column layout. *)
+  dates : Core.Date.t array;
+      (** Date of the last trading day in each weekly bucket (typically Friday
+          for complete weeks, last traded day for partial / holiday weeks). *)
+  n : int;  (** Length of every array. *)
+}
+(** Float-array view of weekly-aggregated bars for one symbol — same shape as
+    {!Data_panel.Bar_panels.weekly_view}. *)
+
+type daily_view = {
+  highs : float array;
+      (** Daily raw high prices, oldest at index 0, newest at index
+          [n_days - 1]. *)
+  lows : float array;  (** Daily raw low prices, same indexing as [highs]. *)
+  closes : float array;
+      (** Daily raw closes (the [Snapshot_schema.Close] field), same indexing.
+      *)
+  dates : Core.Date.t array;  (** Daily dates, same indexing. *)
+  n_days : int;  (** Length of every array. *)
+}
+(** Float-array view of daily bars for one symbol within a lookback window —
+    same shape as {!Data_panel.Bar_panels.daily_view}. *)
+
+val weekly_view_for :
+  Snapshot_callbacks.t ->
+  symbol:string ->
+  n:int ->
+  as_of:Core.Date.t ->
+  weekly_view
+(** [weekly_view_for cb ~symbol ~n ~as_of] returns the most recent [n] weekly
+    buckets ending on or before [as_of] for [symbol], using
+    {!Snapshot_callbacks} as the data source.
+
+    Walks back enough calendar days to cover [n] weeks plus weekend / holiday
+    slack, fetches the [Adjusted_close], [Close], [High], [Low], and [Volume]
+    histories from [cb], assembles per-day [Daily_price.t] tuples (NaN-skipped
+    on the [Close] field), aggregates to weekly via
+    {!Time_period.Conversion.daily_to_weekly} with [include_partial_week:true],
+    and truncates the result to the most recent [n] buckets.
+
+    Returns the empty view ([n = 0], all arrays empty) when:
+    - [n <= 0]
+    - [symbol] is not in the snapshot manifest
+    - no resident snapshot rows fall in the calendar window
+    - any required field read fails (schema skew, filesystem error). *)
+
+val daily_view_for :
+  Snapshot_callbacks.t ->
+  symbol:string ->
+  as_of:Core.Date.t ->
+  lookback:int ->
+  daily_view
+(** [daily_view_for cb ~symbol ~as_of ~lookback] returns up to [lookback] daily
+    bars ending on or before [as_of] for [symbol].
+
+    Reads the [High], [Low], [Close] field histories from [cb] over a calendar
+    window slightly longer than [lookback] (to account for weekends / holidays
+    in the date-keyed range), aligns them by date, drops bars where [Close] is
+    NaN, and truncates to the trailing [lookback] entries.
+
+    Returns the empty view ([n_days = 0], all arrays empty) when:
+    - [lookback <= 0]
+    - [symbol] is not in the snapshot manifest
+    - no resident snapshot rows fall in the calendar window
+    - any required field read fails. *)
+
+val low_window :
+  Snapshot_callbacks.t ->
+  symbol:string ->
+  as_of:Core.Date.t ->
+  len:int ->
+  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t option
+(** [low_window cb ~symbol ~as_of ~len] returns a freshly-allocated
+    [Bigarray.Array1.t] holding [len] daily [Low] values ending on [as_of]
+    (inclusive).
+
+    Unlike {!Data_panel.Bar_panels.low_window}, the result is a copy, not a
+    zero-copy panel slice — the snapshot path has no contiguous source array to
+    slice. The buffer is owned by the caller; mutations are local.
+
+    Returns [None] when:
+    - [len <= 0]
+    - [symbol] is not in the snapshot manifest
+    - the snapshot has fewer than [len] resident bars ending at [as_of]
+    - the [Low] field read fails.
+
+    [Some buf] guarantees [Bigarray.Array1.dim buf = len], with the most recent
+    low at index [len - 1] (chronological order). *)

--- a/trading/analysis/weinstein/snapshot_runtime/test/dune
+++ b/trading/analysis/weinstein/snapshot_runtime/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_daily_panels test_snapshot_callbacks)
+ (names test_daily_panels test_snapshot_bar_views test_snapshot_callbacks)
  (libraries
   core
   core_unix
@@ -8,7 +8,9 @@
   matchers
   ounit2
   status
+  trading.data_panel
   trading.data_panel.snapshot
+  types
   weinstein.snapshot_pipeline
   weinstein.snapshot_runtime)
  (preprocess

--- a/trading/analysis/weinstein/snapshot_runtime/test/test_snapshot_bar_views.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/test/test_snapshot_bar_views.ml
@@ -1,0 +1,413 @@
+(** Tests for [Snapshot_bar_views] — the bar-shaped shim over
+    [Snapshot_callbacks].
+
+    Strategy: build a small synthetic OHLCV fixture twice — once into an
+    [Ohlcv_panels.t]/[Bar_panels.t] (the panel-backed reference), once into a
+    [Daily_panels.t]/[Snapshot_callbacks.t] (the snapshot-backed shim) — then
+    compare the views produced by [Bar_panels.weekly_view_for] /
+    [daily_view_for] / [low_window] against [Snapshot_bar_views.weekly_view_for]
+    / [daily_view_for] / [low_window] cell-by-cell.
+
+    The synthetic fixture has full OHLCV history (no NaN, no holiday gaps) so
+    the panel's row-count and the snapshot's row-count agree, and the parity is
+    bit-exact. Edge cases (unknown symbol, empty range, NaN closes) are
+    exercised separately. *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_panels = Data_panel.Bar_panels
+module Ohlcv_panels = Data_panel.Ohlcv_panels
+module Symbol_index = Data_panel.Symbol_index
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_bar_views = Snapshot_runtime.Snapshot_bar_views
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+module Snapshot = Data_panel_snapshot.Snapshot
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+
+(* --- Calendar / fixture builders ----------------------------------- *)
+
+let _ymd y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+(* Iterate weekday dates only (Mon-Fri). Approximates a trading calendar:
+   skips Saturday and Sunday. *)
+let _is_weekday d =
+  match Date.day_of_week d with
+  | Day_of_week.Sat | Day_of_week.Sun -> false
+  | _ -> true
+
+let _weekdays_starting ~start ~n_trading_days =
+  let rec loop acc d remaining =
+    if remaining = 0 then List.rev acc
+    else if _is_weekday d then
+      loop (d :: acc) (Date.add_days d 1) (remaining - 1)
+    else loop acc (Date.add_days d 1) remaining
+  in
+  loop [] start n_trading_days
+
+(* Deterministic synthetic bar — encoded so each field has a unique value
+   per (symbol_id, day_offset), so any field-aliasing bug would surface as
+   a value mismatch rather than the test passing by accident. *)
+let _make_bar ~date ~symbol_seed ~day_offset : Types.Daily_price.t =
+  let s = Float.of_int symbol_seed in
+  let i = Float.of_int day_offset in
+  {
+    date;
+    open_price = 100.0 +. s +. (i *. 0.10);
+    high_price = 110.0 +. s +. (i *. 0.20);
+    low_price = 90.0 +. s -. (i *. 0.05);
+    close_price = 105.0 +. s +. (i *. 0.15);
+    volume = 1000 + ((symbol_seed + 1) * (day_offset + 1));
+    adjusted_close = 102.0 +. s +. (i *. 0.13);
+  }
+
+(* --- Schema for the snapshot path. The shim only reads OHLCV fields, but
+   tests pass the canonical 13-field schema; the indicator scalars are set
+   to NaN so they're loud if they ever leak into a bar field. *)
+let _full_schema = Snapshot_schema.default
+
+let _values_for_bar (bar : Types.Daily_price.t) : float array =
+  Array.map (Array.of_list _full_schema.fields) ~f:(fun field ->
+      match field with
+      | Snapshot_schema.Open -> bar.open_price
+      | Snapshot_schema.High -> bar.high_price
+      | Snapshot_schema.Low -> bar.low_price
+      | Snapshot_schema.Close -> bar.close_price
+      | Snapshot_schema.Volume -> Float.of_int bar.volume
+      | Snapshot_schema.Adjusted_close -> bar.adjusted_close
+      | _ -> Float.nan)
+
+let _make_snapshot_row ~symbol ~bar : Snapshot.t =
+  match
+    Snapshot.create ~schema:_full_schema ~symbol
+      ~date:bar.Types.Daily_price.date ~values:(_values_for_bar bar)
+  with
+  | Ok r -> r
+  | Error err -> assert_failure ("Snapshot.create: " ^ Status.show err)
+
+(* --- Build a Bar_panels.t over the synthetic universe -------------- *)
+let _build_bar_panels ~symbols ~calendar ~bars_for_symbol : Bar_panels.t =
+  let symbol_index =
+    match Symbol_index.create ~universe:symbols with
+    | Ok idx -> idx
+    | Error err -> assert_failure ("Symbol_index.create: " ^ Status.show err)
+  in
+  let n_days = Array.length calendar in
+  let ohlcv = Ohlcv_panels.create symbol_index ~n_days in
+  List.iteri symbols ~f:(fun row symbol ->
+      Array.iteri calendar ~f:(fun day date ->
+          match bars_for_symbol ~symbol ~date with
+          | None -> ()
+          | Some bar -> Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day bar));
+  match Bar_panels.create ~ohlcv ~calendar with
+  | Ok t -> t
+  | Error err -> assert_failure ("Bar_panels.create: " ^ Status.show err)
+
+(* --- Build a Snapshot_callbacks.t over the same fixture ------------ *)
+let _make_tmp_dir () = Filename_unix.temp_dir ~in_dir:"/tmp" "snapshot_bv_" ""
+
+let _build_snapshot_callbacks ~symbols ~calendar ~bars_for_symbol :
+    Snapshot_callbacks.t =
+  let dir = _make_tmp_dir () in
+  let entries =
+    List.map symbols ~f:(fun symbol ->
+        let rows =
+          Array.to_list calendar
+          |> List.filter_map ~f:(fun date ->
+              match bars_for_symbol ~symbol ~date with
+              | None -> None
+              | Some bar -> Some (_make_snapshot_row ~symbol ~bar))
+        in
+        let path = Filename.concat dir (symbol ^ ".snap") in
+        (match Snapshot_format.write ~path rows with
+        | Ok () -> ()
+        | Error err ->
+            assert_failure ("Snapshot_format.write: " ^ Status.show err));
+        ({
+           symbol;
+           path;
+           byte_size = 0;
+           payload_md5 = "ignored";
+           csv_mtime = 0.0;
+         }
+          : Snapshot_manifest.file_metadata))
+  in
+  let manifest = Snapshot_manifest.create ~schema:_full_schema ~entries in
+  match Daily_panels.create ~snapshot_dir:dir ~manifest ~max_cache_mb:4 with
+  | Ok panels -> Snapshot_callbacks.of_daily_panels panels
+  | Error err -> assert_failure ("Daily_panels.create: " ^ Status.show err)
+
+(* --- Standard 3-symbol fixture ------------------------------------- *)
+
+let _start = _ymd 2024 1 2 (* Tuesday *)
+
+(* 60 trading days (weekday-only) — enough to exercise multiple ISO weeks. *)
+let _calendar_60 =
+  Array.of_list (_weekdays_starting ~start:_start ~n_trading_days:60)
+
+let _symbols_3 = [ "AAA"; "BBB"; "CCC" ]
+
+let _bars_for_symbol ~symbol ~date =
+  let symbol_seed =
+    match symbol with "AAA" -> 0 | "BBB" -> 10 | "CCC" -> 20 | _ -> -1000
+  in
+  if symbol_seed < 0 then None
+  else
+    match Array.findi _calendar_60 ~f:(fun _ d -> Date.equal d date) with
+    | Some (i, _) -> Some (_make_bar ~date ~symbol_seed ~day_offset:i)
+    | None -> None
+
+let _setup_3sym () =
+  ( _build_bar_panels ~symbols:_symbols_3 ~calendar:_calendar_60
+      ~bars_for_symbol:_bars_for_symbol,
+    _build_snapshot_callbacks ~symbols:_symbols_3 ~calendar:_calendar_60
+      ~bars_for_symbol:_bars_for_symbol )
+
+(* --- Helper assertions --------------------------------------------- *)
+
+let _float_arrays_bit_equal (a : float array) (b : float array) ~msg =
+  if Array.length a <> Array.length b then
+    assert_failure
+      (sprintf "%s: length mismatch panel=%d snapshot=%d" msg (Array.length a)
+         (Array.length b));
+  Array.iteri a ~f:(fun i pv ->
+      let sv = b.(i) in
+      let same = Float.equal pv sv || (Float.is_nan pv && Float.is_nan sv) in
+      if not same then
+        assert_failure
+          (sprintf "%s: index %d differs panel=%.18g snapshot=%.18g" msg i pv sv))
+
+let _date_arrays_equal (a : Date.t array) (b : Date.t array) ~msg =
+  if Array.length a <> Array.length b then
+    assert_failure
+      (sprintf "%s: length mismatch panel=%d snapshot=%d" msg (Array.length a)
+         (Array.length b));
+  Array.iteri a ~f:(fun i pd ->
+      let sd = b.(i) in
+      if not (Date.equal pd sd) then
+        assert_failure
+          (sprintf "%s: index %d differs panel=%s snapshot=%s" msg i
+             (Date.to_string pd) (Date.to_string sd)))
+
+let _assert_weekly_views_equal (panel : Bar_panels.weekly_view)
+    (snapshot : Snapshot_bar_views.weekly_view) =
+  assert_that snapshot.n (equal_to panel.n);
+  _float_arrays_bit_equal panel.closes snapshot.closes ~msg:"weekly closes";
+  _float_arrays_bit_equal panel.raw_closes snapshot.raw_closes
+    ~msg:"weekly raw_closes";
+  _float_arrays_bit_equal panel.highs snapshot.highs ~msg:"weekly highs";
+  _float_arrays_bit_equal panel.lows snapshot.lows ~msg:"weekly lows";
+  _float_arrays_bit_equal panel.volumes snapshot.volumes ~msg:"weekly volumes";
+  _date_arrays_equal panel.dates snapshot.dates ~msg:"weekly dates"
+
+let _assert_daily_views_equal (panel : Bar_panels.daily_view)
+    (snapshot : Snapshot_bar_views.daily_view) =
+  assert_that snapshot.n_days (equal_to panel.n_days);
+  _float_arrays_bit_equal panel.highs snapshot.highs ~msg:"daily highs";
+  _float_arrays_bit_equal panel.lows snapshot.lows ~msg:"daily lows";
+  _float_arrays_bit_equal panel.closes snapshot.closes ~msg:"daily closes";
+  _date_arrays_equal panel.dates snapshot.dates ~msg:"daily dates"
+
+(* --- weekly_view_for parity ---------------------------------------- *)
+
+let _column_of_date_exn bp date =
+  match Bar_panels.column_of_date bp date with
+  | Some i -> i
+  | None ->
+      assert_failure
+        (sprintf "calendar lookup failed for %s" (Date.to_string date))
+
+let test_weekly_view_parity_full _ =
+  let bp, cb = _setup_3sym () in
+  let as_of = _calendar_60.(Array.length _calendar_60 - 1) in
+  let as_of_day = _column_of_date_exn bp as_of in
+  List.iter _symbols_3 ~f:(fun symbol ->
+      let panel_view = Bar_panels.weekly_view_for bp ~symbol ~n:8 ~as_of_day in
+      let snapshot_view =
+        Snapshot_bar_views.weekly_view_for cb ~symbol ~n:8 ~as_of
+      in
+      _assert_weekly_views_equal panel_view snapshot_view)
+
+let test_weekly_view_parity_mid_window _ =
+  let bp, cb = _setup_3sym () in
+  let as_of = _calendar_60.(40) in
+  let as_of_day = _column_of_date_exn bp as_of in
+  let panel_view =
+    Bar_panels.weekly_view_for bp ~symbol:"BBB" ~n:5 ~as_of_day
+  in
+  let snapshot_view =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:"BBB" ~n:5 ~as_of
+  in
+  _assert_weekly_views_equal panel_view snapshot_view
+
+(* --- daily_view_for parity ----------------------------------------- *)
+
+let test_daily_view_parity_full _ =
+  let bp, cb = _setup_3sym () in
+  let as_of = _calendar_60.(Array.length _calendar_60 - 1) in
+  let as_of_day = _column_of_date_exn bp as_of in
+  List.iter _symbols_3 ~f:(fun symbol ->
+      let panel_view =
+        Bar_panels.daily_view_for bp ~symbol ~as_of_day ~lookback:30
+      in
+      let snapshot_view =
+        Snapshot_bar_views.daily_view_for cb ~symbol ~as_of ~lookback:30
+      in
+      _assert_daily_views_equal panel_view snapshot_view)
+
+let test_daily_view_parity_short_lookback _ =
+  let bp, cb = _setup_3sym () in
+  let as_of = _calendar_60.(20) in
+  let as_of_day = _column_of_date_exn bp as_of in
+  let panel_view =
+    Bar_panels.daily_view_for bp ~symbol:"AAA" ~as_of_day ~lookback:7
+  in
+  let snapshot_view =
+    Snapshot_bar_views.daily_view_for cb ~symbol:"AAA" ~as_of ~lookback:7
+  in
+  _assert_daily_views_equal panel_view snapshot_view
+
+(* --- low_window parity --------------------------------------------- *)
+
+let _bigarray_to_list (arr : (float, _, _) Bigarray.Array1.t) =
+  List.init (Bigarray.Array1.dim arr) ~f:(fun i -> Bigarray.Array1.get arr i)
+
+let test_low_window_parity _ =
+  let bp, cb = _setup_3sym () in
+  let as_of = _calendar_60.(50) in
+  let as_of_day = _column_of_date_exn bp as_of in
+  let panel = Bar_panels.low_window bp ~symbol:"CCC" ~as_of_day ~len:30 in
+  let snapshot =
+    Snapshot_bar_views.low_window cb ~symbol:"CCC" ~as_of ~len:30
+  in
+  match (panel, snapshot) with
+  | Some p, Some s ->
+      let pa = Array.of_list (_bigarray_to_list p) in
+      let sa = Array.of_list (_bigarray_to_list s) in
+      _float_arrays_bit_equal pa sa ~msg:"low_window"
+  | None, None -> ()
+  | _ -> assert_failure "low_window parity: one side returned None"
+
+(* --- Edge cases ----------------------------------------------------- *)
+
+let test_unknown_symbol_yields_empty_views _ =
+  let _, cb = _setup_3sym () in
+  let as_of = _calendar_60.(Array.length _calendar_60 - 1) in
+  let weekly =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:"ZZZ" ~n:5 ~as_of
+  in
+  assert_that weekly.n (equal_to 0);
+  let daily =
+    Snapshot_bar_views.daily_view_for cb ~symbol:"ZZZ" ~as_of ~lookback:10
+  in
+  assert_that daily.n_days (equal_to 0);
+  let low = Snapshot_bar_views.low_window cb ~symbol:"ZZZ" ~as_of ~len:5 in
+  assert_that low is_none
+
+let test_pre_history_as_of_yields_empty_views _ =
+  let _, cb = _setup_3sym () in
+  let pre = Date.add_days _calendar_60.(0) (-30) in
+  let weekly =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:"AAA" ~n:5 ~as_of:pre
+  in
+  assert_that weekly.n (equal_to 0);
+  let daily =
+    Snapshot_bar_views.daily_view_for cb ~symbol:"AAA" ~as_of:pre ~lookback:5
+  in
+  assert_that daily.n_days (equal_to 0);
+  let low = Snapshot_bar_views.low_window cb ~symbol:"AAA" ~as_of:pre ~len:5 in
+  assert_that low is_none
+
+let test_zero_n_or_lookback_yields_empty_views _ =
+  let _, cb = _setup_3sym () in
+  let as_of = _calendar_60.(Array.length _calendar_60 - 1) in
+  let weekly =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:"AAA" ~n:0 ~as_of
+  in
+  assert_that weekly.n (equal_to 0);
+  let daily =
+    Snapshot_bar_views.daily_view_for cb ~symbol:"AAA" ~as_of ~lookback:0
+  in
+  assert_that daily.n_days (equal_to 0);
+  let low = Snapshot_bar_views.low_window cb ~symbol:"AAA" ~as_of ~len:0 in
+  assert_that low is_none
+
+(* NaN handling: build a fixture where one mid-history close is NaN. The
+   daily_view must drop that bar (matching Bar_panels semantics). The
+   snapshot path's NaN-skip is gated on the [Close] field; we set Close to
+   NaN at one date and leave the other fields populated.
+
+   We compare against Bar_panels for the same fixture: writing a NaN-close
+   bar via [write_row] propagates to [close_p], which is what daily_view's
+   skip filter checks. *)
+
+let _bars_with_nan_close ~nan_date ~symbol ~date =
+  let symbol_seed = match symbol with "DDD" -> 30 | _ -> -1000 in
+  if symbol_seed < 0 then None
+  else
+    match Array.findi _calendar_60 ~f:(fun _ d -> Date.equal d date) with
+    | Some (i, _) ->
+        let bar = _make_bar ~date ~symbol_seed ~day_offset:i in
+        if Date.equal date nan_date then
+          Some { bar with close_price = Float.nan; adjusted_close = Float.nan }
+        else Some bar
+    | None -> None
+
+let test_nan_close_skipped_in_daily_view _ =
+  let nan_date = _calendar_60.(15) in
+  let bars = _bars_with_nan_close ~nan_date in
+  let symbols = [ "DDD" ] in
+  let bp =
+    _build_bar_panels ~symbols ~calendar:_calendar_60 ~bars_for_symbol:bars
+  in
+  let cb =
+    _build_snapshot_callbacks ~symbols ~calendar:_calendar_60
+      ~bars_for_symbol:bars
+  in
+  let as_of = _calendar_60.(30) in
+  let as_of_day = _column_of_date_exn bp as_of in
+  let panel_view =
+    Bar_panels.daily_view_for bp ~symbol:"DDD" ~as_of_day ~lookback:30
+  in
+  let snapshot_view =
+    Snapshot_bar_views.daily_view_for cb ~symbol:"DDD" ~as_of ~lookback:30
+  in
+  (* Both should skip the NaN-close bar. The panel's lookback walks back 30
+     calendar columns; with one NaN-close skipped, both should report 30
+     trading days minus 1 = at most 30 entries actually present (since the
+     calendar has 31 columns ending at as_of, and one is NaN). The exact
+     count may differ from the panel impl by edge effects of the
+     [_daily_calendar_span] approximation; the load-bearing assertion is
+     that the snapshot view excludes the NaN date. *)
+  assert_that snapshot_view.n_days (equal_to panel_view.n_days);
+  let snapshot_dates_set = Date.Set.of_array snapshot_view.dates in
+  assert_that (Set.mem snapshot_dates_set nan_date) (equal_to false);
+  _assert_daily_views_equal panel_view snapshot_view
+
+(* --- Suite ---------------------------------------------------------- *)
+
+let suite =
+  "Snapshot_bar_views tests"
+  >::: [
+         "weekly_view_for parity (full window, all symbols)"
+         >:: test_weekly_view_parity_full;
+         "weekly_view_for parity (mid-window single symbol)"
+         >:: test_weekly_view_parity_mid_window;
+         "daily_view_for parity (full window, all symbols)"
+         >:: test_daily_view_parity_full;
+         "daily_view_for parity (short lookback)"
+         >:: test_daily_view_parity_short_lookback;
+         "low_window parity" >:: test_low_window_parity;
+         "unknown symbol yields empty views"
+         >:: test_unknown_symbol_yields_empty_views;
+         "as_of before any data yields empty views"
+         >:: test_pre_history_as_of_yields_empty_views;
+         "n=0 / lookback=0 yields empty views"
+         >:: test_zero_n_or_lookback_yields_empty_views;
+         "NaN close skipped in daily_view"
+         >:: test_nan_close_skipped_in_daily_view;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR 1 of M5.3 Phase F.2 (per `dev/plans/snapshot-engine-phase-f-2026-05-03.md`, PR #796).

Reproduces `Bar_panels.weekly_view` / `daily_view` shapes from `Snapshot_callbacks.read_field_history` (Phase C shim over `Daily_panels.t`). No wiring change — module is built + tested but not yet consumed by `Panel_runner` or strategy. PR 2 does the wiring.

## Why

`Bar_panels.t` allocates whole-universe × all-days OHLCV bigarrays at runner startup. At N=5000×10y this is ~27 GB RSS, OOMs an 8 GB host. Snapshot path (`Daily_panels.t` LRU-bounded) is the unblock for tier-4 release-gate at N≥5000. Phase A.1 (#786) added OHLCV fields to the snapshot schema, so snapshot reads can already provide every field strategy bar-views need.

## Files

- `trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.{ml,mli}` (new)
- `trading/analysis/weinstein/snapshot_runtime/test/test_snapshot_bar_views.ml` (new)
- `trading/analysis/weinstein/snapshot_runtime/lib/dune` + `test/dune` updates

## Test plan

- [x] `dune build` clean
- [x] `dune runtest analysis/weinstein/snapshot_runtime/` — 9 tests pass
- [x] `dune build @analysis/weinstein/snapshot_runtime/fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)