### PR TITLE
feat(backtest): wire --snapshot-mode through --fuzz harness

### DIFF
--- a/trading/trading/backtest/bin/backtest_runner.ml
+++ b/trading/trading/backtest/bin/backtest_runner.ml
@@ -49,9 +49,11 @@
     v}
 
     Mutually exclusive with [--baseline] and [--smoke]; composes freely with
-    [--override] / [--shared-override] (those apply to every variant). For
-    date-key specs the positional [start_date] is overridden by the variant; for
-    numeric-key specs the positional [start_date] is required.
+    [--override] / [--shared-override] (those apply to every variant) and with
+    [--snapshot-mode --snapshot-dir <path>] (every variant reads from the
+    snapshot dir instead of the CSV [data_dir]). For date-key specs the
+    positional [start_date] is overridden by the variant; for numeric-key specs
+    the positional [start_date] is required.
 
     The optional [--fuzz-window <name>] flag points at a window in
     {!Scenario_lib.Smoke_catalog} (currently [bull], [crash], [recovery]) and
@@ -313,9 +315,15 @@ let _resolve_fuzz_variant ~base_start_date ~base_overrides
 
     [sector_map_override], when supplied (via [--fuzz-window <name>]), replaces
     the default sector map for {b every} variant — same trick smoke mode uses to
-    keep the run inside the dev-container memory budget. *)
+    keep the run inside the dev-container memory budget.
+
+    [bar_data_source], when supplied (via [--snapshot-mode --snapshot-dir]),
+    replaces the default CSV-mode market-data adapter for {b every} variant. The
+    same selector is reused across cells (the manifest is read once at parse
+    time); per-variant cache state is constructed inside the per-cell
+    [Runner.run_backtest]. *)
 let _fuzz_run ~start_date ~end_date ~overrides ~output_root ~fuzz_spec_raw
-    ?sector_map_override () =
+    ?sector_map_override ?bar_data_source () =
   let fuzz_spec =
     match Backtest.Fuzz_spec.parse fuzz_spec_raw with
     | Ok spec -> spec
@@ -338,7 +346,7 @@ let _fuzz_run ~start_date ~end_date ~overrides ~output_root ~fuzz_spec_raw
         eprintf "[fuzz %d/%d] %s = %s\n%!" v.index n v.key_path v.label;
         let result =
           _run_and_write ~start_date:v_start ~end_date ~overrides:v_overrides
-            ~output_dir:variant_dir ?sector_map_override ()
+            ~output_dir:variant_dir ?sector_map_override ?bar_data_source ()
         in
         (v.label, result.summary))
   in
@@ -458,12 +466,13 @@ let () =
                %!";
             None
       in
+      let bar_data_source = _resolve_bar_data_source parsed.snapshot_dir in
       (* Fuzz mode treats override and shared_override identically — there's
          no baseline to differentiate them, so flatten both into the per-variant
          override list. *)
       _fuzz_run ~start_date ~end_date
         ~overrides:(shared_overrides @ overrides)
-        ~output_root ~fuzz_spec_raw ?sector_map_override ()
+        ~output_root ~fuzz_spec_raw ?sector_map_override ?bar_data_source ()
   | None, true, _ ->
       _smoke_run ~shared_overrides ~overrides ~output_root
         ~baseline:parsed.baseline ()

--- a/trading/trading/backtest/test/test_backtest_runner_args.ml
+++ b/trading/trading/backtest/test/test_backtest_runner_args.ml
@@ -658,6 +658,42 @@ let test_snapshot_dir_missing_value _ =
   let result = Backtest_runner_args.parse [ "2018-01-02"; "--snapshot-dir" ] in
   assert_that result is_error
 
+(** [--snapshot-mode] composes freely with [--fuzz]. The fuzz harness loops over
+    N variants and threads the snapshot [Bar_data_source] into every per-variant
+    [Runner.run_backtest] — pinning this composition here guards against a
+    future parser change accidentally introducing a [--fuzz] vs.
+    [--snapshot-mode] exclusivity rule. *)
+let test_snapshot_mode_with_fuzz _ =
+  let result =
+    Backtest_runner_args.parse
+      [
+        "2019-05-01";
+        "--fuzz";
+        "start_date=2019-05-01\xC2\xB12w:3";
+        "--fuzz-window";
+        "bull";
+        "--snapshot-mode";
+        "--snapshot-dir";
+        "/tmp/snapshots/v1";
+        "--experiment-name";
+        "fuzz_snapshot_test";
+      ]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (a : Backtest_runner_args.t) -> a.fuzz_spec)
+              (equal_to (Some "start_date=2019-05-01\xC2\xB12w:3"));
+            field
+              (fun (a : Backtest_runner_args.t) -> a.fuzz_window)
+              (equal_to (Some "bull"));
+            field
+              (fun (a : Backtest_runner_args.t) -> a.snapshot_dir)
+              (equal_to (Some "/tmp/snapshots/v1"));
+          ]))
+
 let suite =
   "Backtest_runner_args"
   >::: [
@@ -722,6 +758,7 @@ let suite =
          >:: test_snapshot_dir_without_mode_is_error;
          "--snapshot-dir without value is error"
          >:: test_snapshot_dir_missing_value;
+         "--snapshot-mode composes with --fuzz" >:: test_snapshot_mode_with_fuzz;
          "trace pipeline write+parse round-trip" >:: test_trace_write_and_parse;
        ]
 


### PR DESCRIPTION
## Summary

Wires `--snapshot-mode` + `--snapshot-dir` through the existing `--fuzz` harness so PR #788's ±2w start_date fuzz spec (canonical sp500-2019-2023) can rerun on snapshot mode without other behavior change. Pure plumbing — gates V2 verification follow-up in `dev/plans/snapshot-engine-phase-f-2026-05-03.md`.

## Why

V2 verification gate (PR #796): #788's CSV-mode-only fuzz needs to rerun on snapshot mode under default-flipped runtime. Without this wiring, the fuzz dispatch path silently dropped `--snapshot-mode` while the single-run dispatch path threaded it correctly.

## Integration point

`_fuzz_run` (`backtest_runner.ml:317`) loops over variants and calls `_run_and_write` per cell — already accepted `?bar_data_source`. Single-run dispatch (line 482) resolved `parsed.snapshot_dir` into `Bar_data_source.Snapshot {snapshot_dir; manifest}`; fuzz dispatch didn't. This PR adds the resolver call to the fuzz dispatch.

## Files

- `trading/trading/backtest/bin/backtest_runner.ml` — `_fuzz_run` accepts + threads `?bar_data_source`
- `trading/trading/backtest/test/test_backtest_runner_args.ml` — new test pinning parser composition

## Test plan

- [x] `dune build` clean
- [x] `dune runtest trading/trading/backtest/` — 45 tests pass
- [x] Test `test_snapshot_mode_with_fuzz` pins parser composition

Bit-equality is transitively covered by `test_snapshot_mode_parity` (#790/#791) since per-cell fuzz invokes the same `Runner.run_backtest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)