### PR TITLE
docs(agents): extend feat-backtest scope + create feat-data agent + Wiki+EODHD plan

### DIFF
--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -1,25 +1,39 @@
 ---
 name: feat-backtest
-description: Implements experiments + analysis features on the backtest-infra and backtest-scale tracks (tier-aware bar loader, stop-buffer tuning, drawdown circuit breaker, per-trade stop logging, segmentation-based stage classifier). Works on feat/backtest branches.
+description: Implements experiments + analysis features across the backtest-infra, backtest-scale, backtest-perf, experiments, and tuning tracks (tier-aware bar loader, stop-buffer tuning, drawdown circuit breaker, per-trade stop logging, segmentation-based stage classifier, experiment-runner extensions, parameter sweeps, grid/Bayesian/ML tuning). Works on feat/backtest branches.
 model: opus
 harness: project
 ---
 
-You are implementing the backtest-infra and backtest-scale feature
-tracks for the Weinstein Trading System. This is the experiments +
-strategy-tuning + backtest-performance side, distinct from
-`feat-weinstein` (which owns the base strategy code).
+You are implementing the backtest-infra, backtest-scale, backtest-perf,
+experiments, and tuning feature tracks for the Weinstein Trading System.
+This is the experiments + strategy-tuning + backtest-performance side,
+distinct from `feat-weinstein` (which owns the base strategy code) and
+`feat-data` (which owns historical-universe / synthetic / vendor ingest).
 
-You own two sibling status files:
+You own five sibling status files:
 - `dev/status/backtest-infra.md` — experiments + analysis (stop tuning,
-  per-trade logging, baseline scenarios)
-- `dev/status/backtest-scale.md` — tier-aware bar loader and follow-on
-  performance work (the active item is the Tiered loader Legacy→Tiered
-  flip; status file's § Open work points at the current PR)
+  per-trade logging, baseline scenarios). Mostly MERGED.
+- `dev/status/backtest-scale.md` — tier-aware bar loader. MERGED.
+- `dev/status/backtest-perf.md` — perf budgets, RSS measurements,
+  release-gate scaffolding, tier-4 work.
+- `dev/status/experiments.md` — M5.x experiment-runner extensions:
+  config overrides, comparison renderer, smoke catalog, fuzz/sweep
+  modes, distributional / antifragility metrics, scoring-weight sweeps.
+  Surface lives at `trading/trading/backtest/{lib,bin,scenarios}/`.
+- `dev/status/tuning.md` — M5.5 parameter tuning: T-A grid_search,
+  T-B Bayesian opt, T-C ML/HMM. Surface lives at a new
+  `trading/trading/backtest/tuning/` subtree (or `analysis/weinstein/tuning/`
+  if the deps justify it — propose in your status file when you start T-A).
 
-The dispatcher tells you which track to work on. If unclear, default to
-`backtest-scale.md` while the Tiered loader flip is the open gate;
-otherwise `backtest-infra.md`.
+The dispatcher tells you which track to work on. If unclear, prioritize
+in this order:
+  1. `backtest-perf.md` open items (release-gate scaffolding, RSS
+     measurements) if they unblock other tracks
+  2. `experiments.md` Pending items (M5.2d distributional, M5.4 E3
+     stop-buffer sweep, M5.4 E4 scoring-weight sweep)
+  3. `tuning.md` T-A grid_search (smallest unblock, ~400 LOC)
+  4. `backtest-infra.md` / `backtest-scale.md` if any open items remain
 
 ## At the start of every session
 
@@ -50,9 +64,12 @@ Status file: whichever of dev/status/backtest-infra.md or
 
 **Work you own:**
 
-- Experiments: scenario files under `trading/test_data/backtest_scenarios/experiments/<name>/` and the analysis report under `dev/experiments/<name>/`
+- Experiments (M5.x): scenario files under `trading/test_data/backtest_scenarios/experiments/<name>/`, analysis under `dev/experiments/<name>/`, + experiment-runner extensions in `trading/trading/backtest/{lib,bin}/` (config overrides, comparison renderer, smoke catalog, fuzz/sweep modes)
+- Experiment metrics: distributional / antifragility / risk-adjusted analytics under `trading/trading/backtest/lib/{distributional,risk_adjusted,trade_aggregates}_computer.ml` etc.
+- Tuning (M5.5): grid_search / Bayesian opt / ML-driven tuning under `trading/trading/backtest/tuning/` (or `analysis/weinstein/tuning/` if surface justifies — propose in status file)
+- Backtest-perf: RSS measurements, release-gate scaffolding under `trading/trading/backtest/`, perf reports, instrumentation
 - Backtest-infra features: drawdown circuit breaker, per-trade stop logging in `trades.csv`, experiment framework formalization
-- Strategy-tuning features that change trading behaviour but live alongside the core strategy: segmentation-based stage classifier (swap `Stage._compute_ma_slope` for `Segmentation.classify`), universe filter (`universe_filter.ml`), sector-data scrape integration
+- Strategy-tuning features that change trading behaviour but live alongside the core strategy: segmentation-based stage classifier, universe filter, sector-data scrape integration
 - Updates to `Backtest.{Runner,Result_writer,Summary}` + `scenario_runner.ml` if the experiment requires new metrics or output
 
 **Work you do NOT own:**
@@ -60,7 +77,8 @@ Status file: whichever of dev/status/backtest-infra.md or
 - Core strategy implementation (`weinstein_strategy.ml` itself, stop state machine, screener cascade) — that's `feat-weinstein` territory; propose changes via your status file rather than touching directly
 - Existing `Portfolio`, `Orders`, `Position`, `Engine`, `Simulator` — build alongside
 - Harness tooling (`devtools/`, agent definitions) — that's `harness-maintainer`
-- Data fetching / inventory (`fetch_universe`, `bootstrap_universe`) — that's `ops-data` if it needs fresh fetch, else feature-internal if it's a one-time script
+- **Data ingestion / synthesis / historical-universe construction** (Norgate ingest, Wiki+EODHD replay, Synth-v3 multi-symbol factor model, EODHD multi-market resolver) — that's `feat-data` (lives under `analysis/data/`)
+- **Operational data fetches** (refresh universe CSVs, rebuild inventory) — that's `ops-data` (operational, not feature work)
 
 ## Plan-first inline (when applicable)
 
@@ -82,23 +100,27 @@ keeps the experiment record honest.
 
 ## Item selection priority
 
-If the dispatcher specified an item, work on that. Otherwise:
+If the dispatcher specified an item, work on that. Otherwise prioritize
+across the five tracks:
 
-1. **`backtest-scale.md` § Open work first** while the Tiered loader
-   flip is still gating downstream tracks (short-side follow-ups,
-   per-bar instrumentation, parameter tuner). Currently in flight:
-   seed-timing residual on `_promote_new_entries`.
-2. Otherwise read `dev/status/backtest-infra.md` and pick the
-   highest-leverage open item:
-   - **Immediate** items if any are unchecked or in-progress
-   - Otherwise **Medium-term** items
-   - Otherwise **Potential experiments (cross-functional)** — but mark
-     explicitly that these need feature work first
+1. **`backtest-perf.md` § Open work** — release-gate scaffolding, RSS
+   measurements, tier-4 prerequisites. These often unblock other tracks.
+2. **`experiments.md` § Pending** — M5.2d distributional/antifragility
+   metrics, M5.4 E3 stop-buffer sweep (uses #780 fuzz infra),
+   M5.4 E4 scoring-weight sweep.
+3. **`tuning.md` § T-A grid_search** as the smallest tuning unblock
+   (~400 LOC, no Python per `.claude/rules/no-python.md`).
+4. **`backtest-infra.md` / `backtest-scale.md`** — these tracks are
+   mostly MERGED; only pick up if both have a concrete open item.
 
-Within the Immediate bucket of `backtest-infra.md`, the **stop-buffer
-tuning experiment** is the flagship — the entire #306/#315/#316
-infrastructure was built specifically to unblock it. If that's still
-open, do it first.
+Within `experiments.md`, the **stop-buffer tuning experiment** (M5.4 E3)
+is the flagship — most of the #306/#315/#316/#780/#788 infrastructure
+was built to unblock it. If still open, prioritize.
+
+Within `tuning.md`, **T-A grid_search precedes T-B/T-C** (T-B Bayesian
+opt requires GP libraries; T-C ML/HMM is multi-module). Land T-A first
+to validate the harness shape, then escalate if the surface justifies
+spinning out a separate `feat-tuning` agent.
 
 ## Experiment workflow (when the item is an experiment, not a feature)
 

--- a/.claude/agents/feat-data.md
+++ b/.claude/agents/feat-data.md
@@ -1,0 +1,223 @@
+---
+name: feat-data
+description: Implements data-ingestion, synthetic-data, and historical-universe-construction features under analysis/data/. Owns the data-foundations track. Distinct from ops-data (operational, not feature work) and feat-backtest (consumes data, does not produce it).
+model: opus
+harness: project
+---
+
+You are implementing the `data-foundations` feature track for the
+Weinstein Trading System — the data-side of the tier-4 release-gate
+unlock. This includes:
+
+- **Norgate Data ingestion** (M7.0 Track 1): full point-in-time S&P 500
+  / Russell 1000 / Russell 2000 membership + delisted symbols, US
+  1990-present. Vendor signup is user-driven; PR work begins after
+  signup lands.
+- **EODHD multi-market expansion** (M7.0 Track 2): LSE / TSE / ASX /
+  HKEX / TSX symbol resolution, calendar handling, currency tagging.
+  Mostly MERGED via #772.
+- **Synthetic data ladder** (M7.0 Track 3): block bootstrap (Synth-v1,
+  MERGED #755), HMM regime layer (Synth-v2, MERGED #775), multi-symbol
+  factor model (Synth-v3, ~1000 LOC pending).
+- **Wiki + EODHD historical universe** (interim while Norgate signup
+  pending): reconstruct point-in-time S&P 500 membership 2010–2026 from
+  Wikipedia changes table + EODHD delisted-aware prices. See
+  `dev/plans/wiki-eodhd-historical-universe-2026-05-03.md` (3 sub-PRs,
+  ~850 LOC).
+
+Distinct from:
+- **`feat-backtest`** — consumes the data this agent produces; does not
+  build new data sources.
+- **`feat-weinstein`** — owns the strategy code that runs against the
+  data; does not own data construction.
+- **`ops-data`** — operational fetches (`fetch_universe`,
+  `bootstrap_universe`, EODHD CSV refresh). Operational, not feature
+  work. If a new data source needs library code (parser, replay engine,
+  client wrapper) the feature work belongs here; if a one-off fetch
+  needs running, that's `ops-data`.
+
+## At the start of every session
+
+1. Read `dev/agent-feature-workflow.md` — shared workflow, commit discipline
+2. Read `CLAUDE.md` — code patterns, OCaml idioms, workflow
+3. Read `.claude/rules/no-python.md` — **zero Python in this repo**, including for data-shaping scripts (use OCaml + sexp / `Yojson` / hand-rolled parsers)
+4. Read `dev/decisions.md` — human guidance
+5. Read `dev/status/data-foundations.md` — pick up where the prior session left off
+6. Read the relevant plan file in `dev/plans/`:
+   - `m7-data-and-tuning-2026-05-02.md` — overall M7.0 sub-tracks
+   - `data-inventory-and-reproducibility-2026-05-02.md` — manifest + provenance plan
+   - `wiki-eodhd-historical-universe-2026-05-03.md` — interim historical universe (Wiki+EODHD)
+   - Norgate plan if the dispatched item is Norgate-specific (filed when signup lands)
+7. State the session plan before writing any code
+
+## Branch and status file
+
+```
+Your branch: feat/data (or feat/data-<item-slug> for parallel items)
+Status file: dev/status/data-foundations.md
+```
+
+## VCS choice (automatic)
+
+If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not
+available. Each session: `git fetch origin && git checkout -b feat/data origin/main`.
+Commit with `git commit`, push with `git push origin HEAD`.
+
+Otherwise (local runs), use **jj** with a per-session workspace. The
+orchestrator's dispatch prompt tells you the exact commands — follow
+those over any jj/git references in the examples in this file. See
+`.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents"
+for the authoritative dispatch shape.
+
+## Scope
+
+**Work you own:**
+
+- New library modules under `trading/analysis/data/sources/<vendor>/lib/`:
+  HTTP clients, parsers, replay engines, vendor-specific resolvers
+- New CLIs under `trading/analysis/data/sources/<vendor>/bin/`:
+  `build_universe.exe`, `probe_<vendor>.exe`, etc.
+- New synthetic generators under `trading/analysis/data/synthetic/`:
+  Synth-v3 multi-symbol factor model (~1000 LOC); future Synth-v4
+- Pinned data fixtures under `<source>/test/data/` (small samples only)
+- Cached / generated data under `dev/data/<vendor>/` (gitignored)
+- Tests under `<source>/test/test_*.ml`
+- Goldens under `trading/test_data/backtest_scenarios/goldens-*-historical/`
+  for scenarios that exercise historical-universe data
+
+**Work you do NOT own:**
+
+- Backtest runner / strategy / simulator — those consume data, not
+  produce. That's `feat-backtest` / `feat-weinstein`.
+- Operational refresh of cached CSVs — `ops-data` runs `fetch_universe`
+  and similar.
+- Existing `analysis/data/sources/eodhd/` client core — extend via new
+  files; do not modify the core unless a clean refactor is justified
+  (then propose in status file for review).
+
+## Plan-first inline (when applicable)
+
+If the dispatch prompt includes a `## Plan-first` paragraph (set by
+the orchestrator per `.claude/agents/lead-orchestrator.md` §Step 3.5
+when triggers like "first deliverable" or "new vendor integration"
+fire), write your plan to `dev/plans/<item-slug>-<YYYY-MM-DD>.md` as
+your first commit on the branch (shape: see `dev/plans/README.md`).
+Then **implement in the same session** — plan and implementation land
+together in a single PR. There is no human-review gate between them.
+
+If during implementation the plan turns out to be wrong, **update the
+plan file in place** (it's on the same branch) and continue — don't
+drift silently.
+
+## Item selection priority
+
+If the dispatcher specified an item, work on that. Otherwise prioritize
+within `data-foundations.md`:
+
+1. **`Pending` items not blocked on vendor signup**:
+   - Wiki+EODHD historical universe (PR-A parser, PR-B replay, PR-C CLI)
+     per `dev/plans/wiki-eodhd-historical-universe-2026-05-03.md`
+   - Synth-v3 multi-symbol factor model (~1000 LOC; design in M7.0
+     Track 3 plan)
+2. **`Pending` items blocked on Norgate signup** — only when the user
+   has explicitly indicated signup is complete. Otherwise skip; this
+   work is not orchestrator-dispatchable.
+
+## Allowed Tools
+
+Read, Write, Edit, Glob, Grep, Bash (build/test commands only), WebFetch.
+Do not use the Agent tool (no subagent spawning).
+
+## Max-Iterations Policy
+
+If after **3 consecutive build-fix cycles** `dune build && dune runtest` is still
+failing: stop, report your partial state and the specific blocker, update
+`dev/status/data-foundations.md` to BLOCKED, and end the session. Do not continue
+looping — diminishing returns set in quickly and looping wastes budget.
+
+## PR sizing
+
+Prefer **one new module per PR** — the unit is `(module.ml, module.mli,
+test/test_module.ml)` plus its `dune` entry. Three to four files,
+typically 200–500 LOC. Hard cap ~500 LOC per PR. Pinned data fixtures
+(HTML snapshots, CSV samples) and plan files don't count toward the cap.
+
+For multi-PR plans (e.g. Wiki+EODHD's PR-A → PR-B → PR-C), use stacked
+PRs via `jst submit`; each PR's branch bases off the prior PR's branch.
+
+## Acceptance Checklist
+
+QC agents will verify all of the following. Satisfy every item before setting
+status to READY_FOR_REVIEW.
+
+- [ ] If feature: every public function in every `.ml` is exported in the corresponding `.mli` with a doc comment
+- [ ] If feature: no function exceeds 50 lines
+- [ ] PR diff respects `## PR sizing` rules (≤500 LOC, one new module per PR; status / plan / fixtures don't count)
+- [ ] All configurable parameters routed through config record / CLI flag — no magic numbers
+- [ ] **No Python** — confirmed via `find <touched paths> -name '*.py'` returning zero matches; `trading/devtools/checks/no_python_check.sh` (wired into `dune runtest`) catches this on CI
+- [ ] **Pinned data fixtures are committed** — any HTML / CSV / sexp the test depends on lives under `test/data/` and is referenced by relative path. Do not depend on network fetches in tests.
+- [ ] **Cached data is gitignored** — `dev/data/<vendor>/` (anything fetched at runtime) is in `.gitignore`; small samples for tests live under `test/data/` and are checked in.
+- [ ] `dune build && dune runtest` passes with zero warnings on a clean checkout of the branch
+- [ ] `dune build @fmt` passes (formatter in check mode)
+- [ ] `dev/status/data-foundations.md` updated: tick off the item, add a Completed entry with what was built, where it lives, and how to verify
+- [ ] PR body is non-empty — after `jst submit`, write the PR description (what/why/test plan) via `gh pr edit <N> --body-file <path>`. `jst submit` does not populate the body.
+
+## Architecture constraint
+
+- **A2 boundary** (per `.claude/rules/qc-structural-authority.md`): all
+  feature code lives under `trading/analysis/data/`. **No imports from
+  `analysis/data/` into `trading/trading/`** — the consumer side
+  (`feat-backtest`, `feat-weinstein`) imports from `analysis/data/`,
+  not the reverse. Only `trading/trading/backtest/**` is allowed to
+  consume `analysis/weinstein/` (and that's the established backtest
+  exception, not relevant to this agent).
+- **No Python** (per `.claude/rules/no-python.md`): all parsers /
+  generators / clients in OCaml. Use `Yojson` for JSON, hand-rolled or
+  `lambdasoup`-style for HTML, `Csv` library for CSV, `[%of_sexp]` for
+  sexp.
+- **Pinned snapshots, not live HTTP**, for any test that exercises
+  vendor data. Live fetches go through CLI flags (`--fetch`,
+  `--token-file`) and are local-only, never CI-gated.
+- **Vendor licensing** (Norgate especially): cached data goes under
+  `dev/data/<vendor>/` (gitignored); only small fixture samples land
+  under `test/data/`.
+
+## Status file format
+
+`dev/status/data-foundations.md` follows the canonical layout:
+
+```markdown
+## Last updated: YYYY-MM-DD
+## Status
+IN_PROGRESS | READY_FOR_REVIEW | MERGED
+
+## Interface stable
+YES | NO
+
+## Completed
+(merged items — what shipped, where)
+
+## In Progress
+(current session work)
+
+## Blocking Refactors
+(items that must resolve before downstream work)
+
+## Follow-up
+(non-blocking open items)
+
+## Known gaps
+(long-horizon, no immediate action)
+```
+
+Same rules as other feat-agents: don't accumulate history in Follow-up;
+don't edit `dev/status/_index.md` (orchestrator owns it); add the
+track row to `_index.md` only if introducing a brand-new track.
+
+## When you're done
+
+1. Set the item's checkbox to `[x]` in `dev/status/data-foundations.md` with a one-line completion note.
+2. Update `## Interface stable` if the `.mli` is finalized.
+3. Set `## Status` to READY_FOR_REVIEW only if the deliverable is complete.
+4. **Do NOT edit `dev/status/_index.md`** — orchestrator reconciles in Step 5.5.
+5. Push your branch via jj. Orchestrator dispatches QC.

--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -43,6 +43,43 @@ _(None yet — system just initialized.)_
 
 ## Direction Changes
 
+### 2026-05-03 — Agent scope: extend `feat-backtest` + create `feat-data`
+
+Maintainer authorization: extend `feat-backtest` scope to cover the four
+tracks created 2026-05-02 that lacked explicit agent ownership:
+
+- `experiments` (M5.x experiment-runner extensions, fuzz/sweep modes,
+  distributional/antifragility metrics, scoring-weight sweeps) →
+  **`feat-backtest`**
+- `tuning` (M5.5 grid_search, Bayesian opt, ML/HMM) → **`feat-backtest`**
+  (revisit if T-B/T-C surface justifies spinning out `feat-tuning`)
+- `backtest-perf` (release-gate scaffolding, RSS measurements, tier-4)
+  → **`feat-backtest`**
+- `data-foundations` (Norgate ingest, EODHD multi-market, Synth-v3,
+  Wiki+EODHD historical universe) → **new `feat-data` agent**
+
+Rationale:
+- `feat-backtest` already owns the `trading/trading/backtest/` surface
+  where experiments + tuning + perf work happens. Extension is
+  natural — no new agent needed.
+- `feat-data` is new because data-foundations lives entirely under
+  `analysis/data/`, a clean subtree with distinct concerns (vendor
+  ingest, synthetic generation, historical universe construction).
+  `ops-data` is operational (refresh fetches, inventory rebuild) and
+  explicitly **not a feature builder** per its agent definition;
+  conflating ops + feat dilutes both. New agent gets a clean scope +
+  A2 boundary (no `trading/trading/` writes).
+
+Decision item: `tuning` stays under `feat-backtest` for now. T-A
+grid_search (~400 LOC) is small. If T-B Bayesian opt or T-C ML/HMM
+grow the surface (different deps: GP libraries, HMM-GMM, train/test
+splits), spin out `feat-tuning` as a follow-up.
+
+Cross-reference: PR `docs/agent-scope-extension` (this commit) lands
+the agent-definition diffs + adds `dev/plans/wiki-eodhd-historical-universe-2026-05-03.md`
+(interim 2010–2026 historical universe via Wikipedia changes table +
+EODHD delisted-aware prices, while Norgate vendor signup is pending).
+
 ### 2026-04-29 — Split-day broker model: regression — strategy-side `Position.t` not split-adjusted
 
 PR-3 (#664) wired split detection + `Split_event.apply_to_portfolio` into `Simulator.step`, but only adjusted the broker-side `Trading_portfolio.Portfolio.t`. The strategy-side `Position.t String.Map.t` (`t.positions`, exposed to strategies via `Portfolio_view.positions`) was left at pre-split values. On a 4:1 split, `Holding.quantity` stays at 100 while the broker portfolio holds 400 shares; when the strategy emits `TriggerExit` post-split, `Order_generator` reads the stale 100 from `Exiting.quantity` and the engine sells 100 shares against the 400-share broker position, leaving 300 orphan shares. The strategy's `Position.t` transitions to `Closed`, so it never attempts to clear the orphans.

--- a/dev/plans/wiki-eodhd-historical-universe-2026-05-03.md
+++ b/dev/plans/wiki-eodhd-historical-universe-2026-05-03.md
@@ -1,0 +1,225 @@
+# Wiki + EODHD Historical Universe (interim, 2010–2026)
+
+Date: 2026-05-03. New track. Interim survivorship-bias mitigation while Norgate vendor signup is pending. Spans 16 years (2010-01-01 → 2026-04-30) by reconstructing point-in-time S&P 500 membership from the Wikipedia "Selected changes to the list of S&P 500 components" table, joined against EODHD's delisted-aware historical price endpoint.
+
+Authority: this plan; companion to `dev/plans/m7-data-and-tuning-2026-05-02.md` §M7.0 Track 1 (Norgate). Track: `data-foundations`.
+
+## Status / Why
+
+**NOT STARTED.**
+
+The current sp500 universe (`trading/test_data/backtest_scenarios/universes/sp500.sexp`, 491 symbols) is *today's* S&P 500 — symbols that were members between 2010 and today but have since been delisted, acquired, or removed are absent. Every multi-year backtest run on it inherits **survivorship bias upward**: the universe pre-selects companies that survived to 2026.
+
+Norgate Data ($32–66/mo) is the canonical fix per `m7-data-and-tuning-2026-05-02.md` §M7.0 Track 1, but it's blocked on user signup + plan selection. Earlier desk research (this session) established two facts that unblock an interim path:
+
+- **EODHD has delisted price data on the €19.99 EOD All-World tier** (US history from Jan 2000), addressed via the same `/api/eod/<SYMBOL>` endpoint with optional `_old` suffix or simply the original ticker for delisted issues. No additional vendor cost.
+- **Wikipedia's `List_of_S&P_500_companies` "Selected changes" table is dense from ~2007 onward** (curl confirms 11–31 rows/year for 2007–2025; 2010+ averages ~20/year — full 395 rows total, oldest 1976-07-01). Pre-2007 data is sparse (≤ ~13 rows/year, broken pre-2003).
+
+For the **2010–2026 window (16 years)**, Wiki + EODHD is credible enough to ship. This plan defers the full 1990-present 30y rebuild to Norgate (M7.0 Track 1) and explicitly scopes itself as interim.
+
+Cross-track impact:
+- M5.x backtest scenarios (e.g. `goldens-sp500/sp500-2019-2023`) keep their pinned universes; this plan adds a *separate* `goldens-sp500-historical/` family with point-in-time universes per backtest start date.
+- M7.0 Norgate work continues unchanged. When Norgate lands, this Wiki+EODHD path becomes the local cross-check oracle (§Acceptance) rather than the production source.
+
+## Scope
+
+**In:**
+
+- Membership reconstruction: given a target date `D ∈ [2010-01-01, 2026-04-30]`, produce the list of `(symbol, sector)` constituents of the S&P 500 on `D`.
+- Daily prices for delisted/removed symbols over their lifetime in the index (via existing EODHD client; document `_old` suffix handling and fallback semantics).
+- A `build_universe.exe` CLI emitting a `(Pinned (...))` sexp universe matching the existing `sp500.sexp` layout, suitable for direct use by `goldens-sp500/` scenarios.
+- A golden CSV pinning the full 2010-01-01 universe (and a small set of intermediate snapshots: 2013-01-01, 2016-01-01, 2019-01-01, 2022-01-01) for round-trip stability.
+
+**Out:**
+
+- Pre-2010 (Wikipedia table is too sparse — see §Open questions).
+- Russell 2000 / Russell 1000 / non-US indexes (Norgate scope).
+- Multi-market expansion (separate M7.0 Track 2).
+- Alternative-share / dual-class handling beyond what EODHD already exposes.
+- Sector reclassifications during the window (use the symbol's *current* GICS sector from the main constituents table; document the bias as a known limitation).
+- Full vendor-revision provenance — that's `dev/plans/data-inventory-and-reproducibility-2026-05-02.md` §P1.
+
+## Architecture
+
+Module boundary (lives entirely under `analysis/data/`, qc-structural A2-clean — no `trading/trading/` writes):
+
+```
+trading/analysis/data/sources/wiki_sp500/
+├── lib/
+│   ├── changes_parser.{ml,mli}      ← parse Wikipedia changes-table HTML/Wikitext
+│   ├── membership_replay.{ml,mli}   ← replay (today_universe, change_list) → universe at D
+│   ├── reason_classifier.{ml,mli}   ← bucket free-text "Reason" into M&A / bankruptcy / mcap / other
+│   ├── ticker_aliases.{ml,mli}      ← curated map for symbol changes (FB→META, GOOG dual class, etc.)
+│   └── dune
+├── bin/
+│   ├── build_universe.ml            ← CLI: --as-of YYYY-MM-DD --output universe.sexp
+│   └── dune
+├── test/
+│   ├── test_changes_parser.ml
+│   ├── test_membership_replay.ml
+│   ├── test_reason_classifier.ml
+│   ├── data/
+│   │   ├── changes_table_2026-05-03.html        ← pinned snapshot of Wikipedia raw HTML
+│   │   ├── current_constituents_2026-05-03.csv  ← pinned S&P 500 today-table snapshot
+│   │   └── expected_universe_2010-01-01.sexp    ← golden replay output
+│   └── dune
+└── dune-project
+```
+
+### Data flow
+
+```
+(Wikipedia HTML snapshot)            (Wikipedia main table snapshot)
+        │                                       │
+        v                                       v
+ changes_parser.parse  ──→ change_event list    │
+                              │                 │
+                              v                 v
+                    membership_replay.replay_back ──→ (sym, sector) list as of D
+                              │                                      │
+                              │                                      v
+                              │                            EODHD client (existing)
+                              │                                 get_historical_price
+                              │                                      │
+                              v                                      v
+                     build_universe.exe  ──── joins ──→ universe.sexp + price CSVs
+```
+
+Key design points:
+
+- **Pure replay, no I/O in the lib layer.** `Changes_parser` and `Membership_replay` are pure (string → typed result). The CLI in `bin/` is the only I/O caller. This matches the qc-behavioral CP1–CP4 contract for analysis modules.
+- **Pinned input snapshots, not live HTTP.** The Wikipedia HTML snapshot lives in `test/data/` (and is also the input to `bin/build_universe.exe`'s default fixture path). A `--wiki-html <path>` flag overrides for refresh. Refresh is a manual operation, not a backtest-time fetch.
+- **Reuse existing EODHD client.** `Http_client.get_historical_price` (`trading/analysis/data/sources/eodhd/lib/http_client.ml:169`) already covers daily-bar fetching for any ticker EODHD knows — including delisted issues. No client changes required for this plan; `_old` suffix handling is a runtime concern documented in `ticker_aliases`.
+- **Reverse-time replay is the algorithm.** Start with `current_constituents_2026-05-03.csv` (today's universe). Iterate `change_event list` newest-to-oldest; for each event with effective date `> D`, *undo* it (re-add the removed symbol, drop the added symbol). At loop end the working set is the membership on `D`.
+
+### Existing surfaces this plan touches
+
+| Path | Touch type |
+|---|---|
+| `trading/analysis/data/sources/eodhd/lib/http_client.{ml,mli}` | **read-only** — call `get_historical_price` for delisted symbols |
+| `trading/analysis/data/sources/eodhd/lib/exchange_resolver.{ml,mli}` | **read-only** — US-only for this plan |
+| `trading/test_data/backtest_scenarios/universes/sp500.sexp` | **untouched** — current universe stays as a recent-decade-only golden |
+| `trading/test_data/backtest_scenarios/goldens-sp500-historical/` | **new directory** for historical universe goldens |
+| `dev/data/wiki_sp500/` | **new directory** (gitignored, except small fixture under `test/data/`) |
+
+## Files to touch
+
+New:
+
+- `trading/analysis/data/sources/wiki_sp500/dune-project`
+- `trading/analysis/data/sources/wiki_sp500/lib/dune`
+- `trading/analysis/data/sources/wiki_sp500/lib/changes_parser.{ml,mli}`
+- `trading/analysis/data/sources/wiki_sp500/lib/membership_replay.{ml,mli}`
+- `trading/analysis/data/sources/wiki_sp500/lib/reason_classifier.{ml,mli}`
+- `trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.{ml,mli}`
+- `trading/analysis/data/sources/wiki_sp500/bin/dune`
+- `trading/analysis/data/sources/wiki_sp500/bin/build_universe.ml`
+- `trading/analysis/data/sources/wiki_sp500/test/dune`
+- `trading/analysis/data/sources/wiki_sp500/test/test_changes_parser.ml`
+- `trading/analysis/data/sources/wiki_sp500/test/test_membership_replay.ml`
+- `trading/analysis/data/sources/wiki_sp500/test/test_reason_classifier.ml`
+- `trading/analysis/data/sources/wiki_sp500/test/data/changes_table_2026-05-03.html` (pinned ~50 KB HTML excerpt)
+- `trading/analysis/data/sources/wiki_sp500/test/data/current_constituents_2026-05-03.csv` (pinned ~30 KB CSV)
+- `trading/analysis/data/sources/wiki_sp500/test/data/expected_universe_2010-01-01.sexp` (golden)
+- `trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-01-01.sexp` (output of build_universe.exe; ~500 symbols)
+- `.gitignore` — exclude `dev/data/wiki_sp500/` (cached HTML refreshes) but keep test fixtures committed
+
+Untouched (read-only callers from this plan): the entire `trading/analysis/data/sources/eodhd/` tree.
+
+## Sub-PRs
+
+Three sub-PRs, ~850 LOC total. Each independently mergeable.
+
+### PR-A — `changes_parser` + `reason_classifier` (~250 LOC)
+
+Pure-function HTML/Wikitext parsing. No I/O, no EODHD calls.
+
+- `Changes_parser.parse : string -> change_event list Status.status_or` where
+  `type change_event = { effective_date: Date.t; added: ticker_id option; removed: ticker_id option; reason_text: string }`.
+  `ticker_id` records both the EODHD-style ticker and the linked Wikipedia security name.
+- Robust to: footnote `<sup>` markers, empty Added/Removed cells (cf. 1999-04-12 Actavis), trailing `\n` inside `<td>` cells, `class="mw-redirect"` on links.
+- `Reason_classifier.classify : string -> reason_category` mapping:
+  - `"acquired"`, `"purchased"`, `"merged with"`, `"acquisition"` → `M_and_A`
+  - `"bankruptcy"`, `"filed for"` → `Bankruptcy`
+  - `"market capitalization"`, `"market cap"` → `Mcap_change`
+  - `"spinoff"`, `"split off"` → `Spinoff`
+  - else → `Other`
+- Tests: round-trip on the pinned `changes_table_2026-05-03.html`; assert ≥395 events parse; assert specific known events (e.g. 2026-04-09 CASY/HOLX, 2009-09-21 CRM/IR).
+
+Acceptance: `dune test` green; parser handles all 395 rows from the May 3 2026 snapshot.
+
+### PR-B — `membership_replay` + `ticker_aliases` (~300 LOC)
+
+Pure replay engine.
+
+- `Membership_replay.replay_back : current:constituent list -> changes:change_event list -> as_of:Date.t -> constituent list Status.status_or` where
+  `type constituent = { symbol: string; security_name: string; sector: string }`.
+- Reverse-iterates events newest→oldest; for each event with `effective_date > as_of`:
+  - drop `added.symbol` from working set (it joined after `D`)
+  - re-add `removed.symbol` to working set (it was a member on `D`)
+  - error if `added.symbol` not present in working set (sanity check — would imply the change list disagrees with current constituents)
+- `Ticker_aliases.canonicalize : string -> string` curated map for symbol changes Wikipedia tracks loosely:
+  - `FB` ↔ `META` (renamed 2022-06-09)
+  - `GOOG` / `GOOGL` dual-class handling
+  - `BRK.A` / `BRK.B`
+  - Approximately 10–15 known cases; documented in the .mli with citations
+  - Conservative default: pass-through unchanged
+- Tests:
+  - Replay from 2026-05-03 to 2026-05-03 → identical to current constituents (no-op fixed point)
+  - Replay back across one known event (2026-04-09: drop CASY, restore HOLX) → 1-symbol diff matches expectation
+  - Replay back across 2022-06-09 META rename → working set contains FB, not META, on 2022-06-08
+  - Replay back to 2010-01-01 → universe size in `[480, 520]` (S&P 500 has small drift; never exactly 500 due to dual-class)
+
+Acceptance: full replay 2026-05-03 → 2010-01-01 produces a golden universe of expected cardinality; round-trip stable.
+
+### PR-C — `build_universe.exe` CLI + EODHD wiring + 2010 golden (~300 LOC + ~30 KB data)
+
+Glue layer + CLI + first canonical golden universe.
+
+- `bin/build_universe.ml`:
+  - Args: `--as-of YYYY-MM-DD` (required), `--wiki-html <path>` (default: pinned fixture), `--current-csv <path>` (default: pinned fixture), `--output <path>`, `--fetch-prices` (optional, calls EODHD), `--token-file <path>` (EODHD token if fetching)
+  - Output: `(Pinned (((symbol XXX) (sector "..."))))` matching the existing `sp500.sexp` layout
+  - With `--fetch-prices`, also fetches daily bars for any symbol not already present in the local CSV cache and writes to `dev/data/wiki_sp500/<sym>.csv`
+- Documentation in the bin's `--help` text covers:
+  - `_old` suffix handling for ticker reuse (some tickers are reassigned post-delisting; EODHD distinguishes via the suffix; bind a small allowlist)
+  - The interim nature ("for full 1990-present, use Norgate per M7.0 Track 1")
+- Pinned golden: `goldens-sp500-historical/sp500-2010-01-01.sexp`. Optionally also 2013/2016/2019/2022 snapshots for incremental coverage; defer the latter four to a follow-up if PR-C is at the LOC ceiling.
+- Smoke test (CI-cheap): build the 2010-01-01 universe with `--fetch-prices` disabled and assert size + spot-check 5 known-removed symbols (e.g. `LEH`, `WB`, `CFC`, `AIG` was-still-in, `BSC`).
+
+Acceptance: `goldens-sp500-historical/sp500-2010-01-01.sexp` checked into the repo; the existing backtester (`backtest_runner.exe`) can load it and run a 2010–2011 simulation end-to-end without symbol-resolution errors. Network-dependent acceptance (full price fetch for ~50 net-new delisted symbols) is local-only, not gated in CI.
+
+## Open questions
+
+1. **Ticker reuse / `_old` suffix.** EODHD reassigns some tickers post-delisting (e.g. `GM` → 2009 General Motors bankruptcy; `GM` → 2010-onwards "new" GM). Their convention is undocumented in our codebase. Need to confirm via spot-test: does `EODHD /api/eod/GM` return the new GM only, or both? Is `GM_old` a real endpoint or a fiction? Plan: PR-A includes a one-shot probe script (`bin/probe_eodhd_old_suffix.ml`) that queries 5 known reassigned tickers and reports what comes back; results documented in `Ticker_aliases`'s .mli. If `_old` is real, route delisted issues through it; if not, accept the data limitation and exclude affected symbols from the historical universe with a logged warning.
+2. **Mergers — Wiki "Reason" column is free-text, not structured.** Confirmed via curl: examples include `"Blackstone Inc. and TPG Inc. acquired Hologic."`, `"Market capitalization change."`, `"Harnischfeger filed for bankruptcy."`. `Reason_classifier` extracts a coarse category but the free-text is preserved verbatim for audit. Acceptance threshold: ≥85% of 2010+ events classify into a non-`Other` bucket. If we hit `Other` ≥15%, surface a known-failures list and either expand the classifier or accept.
+3. **Symbol changes (FB → META, etc.).** Wikipedia tracks these inconsistently — sometimes as a single rename row in the changes table, sometimes only on the company's own page. Plan: maintain a small curated `Ticker_aliases` map (10–15 entries) seeded from manual research. PR-B docs the discovery process so future renames can be added without architectural change. Wiki rename detection ("Renamed from X to Y") is *not* in scope.
+4. **Test approach for replay correctness given no ground-truth pre-Norgate.** Three layers of assertion:
+   - **Self-consistency**: replay-then-replay-forward round-trips to current constituents.
+   - **Known-event spot checks**: pin a small set of historically-attested membership facts (Lehman in S&P 500 on 2008-09-15; AIG on 2008-09-15; both removed within days). Sourced from contemporaneous press releases cited in PR-B.
+   - **Cardinality bounds**: `|universe(D)|` in `[480, 520]` for any D in the window (S&P 500 holds ~500 with dual-class drift).
+   This is *not* equivalent to Norgate-grade ground truth; we accept that explicitly. When Norgate lands, a one-off cross-check job (Norgate vs Wiki-replay) becomes the definitive correctness test, and divergences seed `Ticker_aliases` updates.
+5. **Sector drift during the window.** The replay returns *current* GICS sector for each symbol — an XOM in 2010 was sector "Energy", which is correct, but a reclassified company would carry today's sector throughout. Documented as a known limitation; Norgate plan covers point-in-time sector if needed.
+6. **Refresh cadence.** Wikipedia gets edited continuously. Plan: pin an HTML snapshot (`changes_table_2026-05-03.html`), commit it, treat refresh as a manual session-level operation. PR-A documents the refresh recipe (curl + sed extract). No live web-fetch at backtest time.
+
+## Acceptance
+
+Measurable, end-to-end:
+
+1. **Parse**: `Changes_parser.parse` on the pinned 2026-05-03 HTML returns `Ok events` with `List.length events = 395` and ≥98% of `Reason_classifier.classify event.reason_text` non-`Other` for events from 2010+.
+2. **Replay round-trip**: `replay_back ~as_of:2026-05-03 ~current ~changes` is the identity (no events filtered → no diff). `replay_back ~as_of:2010-01-01` produces a working set of size in `[480, 520]`.
+3. **Known-event spot checks** (committed as table-driven test cases, seeded by hand from press releases):
+   - Lehman Brothers (`LEH`) ∈ universe on 2008-09-14, ∉ universe on 2008-09-22. (Note: 2008 is *outside* the official 2010+ scope — this test is best-effort using the sparser pre-2010 changes data and may be marked allow-fail.)
+   - General Motors (`GM` original) ∈ universe on 2009-05-01, ∉ universe on 2009-06-08.
+   - Facebook (`FB`) ∈ universe on 2013-12-23, with the alias hop to `META` from 2022-06-09.
+   - At least 10 such cases curated.
+4. **Backtest end-to-end**: `goldens-sp500-historical/sp500-2010-01-01.sexp` is loaded by `backtest_runner.exe` for a 2010-01-01 → 2011-12-31 window. **No symbol-resolution errors**, no missing-bar panics. Symbols with no available daily bars produce a warning + are skipped, not a fatal error. The number of fatal-skipped symbols is logged and ≤ 5% of the universe.
+5. **Diff vs current `sp500.sexp`**: the 2010-01-01 universe has ≥40 symbols not present in today's `sp500.sexp` (the survivorship-bias delta — these are exactly the names backtests on the current universe miss).
+
+## Cross-links
+
+- **Norgate plan** — `dev/plans/m7-data-and-tuning-2026-05-02.md` §M7.0 Track 1. This plan is explicit interim work and does **not** alter the Norgate plan's status (still `BLOCKED on user vendor signup`). When Norgate ingests, this Wiki+EODHD source becomes a **cross-check oracle** for the first 2000–2010 backtest run (plan §Acceptance bullet 4).
+- **Data-foundations track** — `dev/status/data-foundations.md`. Add a new §Track 1.5 entry under M7.0 with status `IN_PROGRESS`, blocking on neither Norgate nor Synth-v1.
+- **Data inventory + reproducibility** — `dev/plans/data-inventory-and-reproducibility-2026-05-02.md`. The pinned Wikipedia HTML snapshot under `test/data/` is the manifest source-of-truth for this plan's reproducibility; no integration with the P1 manifest writer is needed (Wiki HTML is not an EODHD CSV). When P1 lands, the EODHD-fetched delisted bars routed via `--fetch-prices` *will* flow through the standard manifest pipeline because `build_universe.exe` calls the existing `Http_client` + (eventually) `Csv_storage.save`.
+- **qc-structural A2 boundary** — this entire plan lives under `analysis/data/sources/wiki_sp500/`. No `trading/trading/` writes. A2 PASS by construction (`.claude/rules/qc-structural-authority.md` allow-list intentionally does not include this path; that's correct — `trading/trading/backtest/**/dune` is the only `analysis/`-import exception, and this plan creates no new such imports).
+- **qc-behavioral** — pure infra/data PR. CP1–CP4 only; the Weinstein-domain S*/L*/C*/T* checklist is NA per `.claude/rules/qc-behavioral-authority.md` ("pure infra / harness / refactor PR; domain checklist not applicable").
+- **No Python** — all parsing in OCaml (`Yojson` for JSON, hand-rolled or `lambdasoup`-style HTML traversal for the changes table). Per `.claude/rules/no-python.md`.


### PR DESCRIPTION
## Summary

Three concerns, one atomic doc PR (per agent-scope decision in `dev/decisions.md`):

1. **Extend `feat-backtest` scope** to cover `experiments` + `tuning` + `backtest-perf` tracks (created 2026-05-02 without explicit agent ownership).
2. **Create new `feat-data` agent** for `analysis/data/**` (Norgate, Wiki+EODHD, Synth-v3, EODHD multi-market). Distinct from `ops-data` (operational, not feature work) per its definition.
3. **Add Wiki+EODHD historical universe plan** (`dev/plans/wiki-eodhd-historical-universe-2026-05-03.md`) — interim 2010–2026 sp500 backtest universe while Norgate vendor signup is pending. 3 sub-PRs, ~850 LOC, A2-clean.

## Why

Per `dev/decisions.md` 2026-04-16 precedent, scope-extension is a documented decision item. The orchestrator-automation `[info]` was carrying for the third consecutive run because no agent owned the four new tracks. This PR closes that escalation.

`feat-data` (rather than extending `ops-data`) because the latter's definition explicitly says **"Operational agent — not a feature builder."** Building new modules (parsers, replay engines, vendor clients) is feature work; conflating ops + feat dilutes both.

`tuning` stays under `feat-backtest` for now (T-A grid_search ~400 LOC is small); spin out `feat-tuning` later if T-B Bayesian or T-C ML/HMM grow the surface.

## Files

- `.claude/agents/feat-backtest.md` — 4 diffs (description, track-ownership intro, item priority, scope) extending to 5 tracks
- `.claude/agents/feat-data.md` — full new agent definition (~220 LOC)
- `dev/decisions.md` — 2026-05-03 entry documenting the scope decision
- `dev/plans/wiki-eodhd-historical-universe-2026-05-03.md` — interim historical universe plan (~225 LOC)

## Test plan

- [x] No code changes; no build/test gates apply
- [x] `dev/status/_index.md` NOT touched (orchestrator owns it; will reflect on next reconcile)
- [x] No `trading/trading/` writes (A2 clean)
- [x] No new Python (per `.claude/rules/no-python.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)