### PR TITLE
feat(snapshot): F.2 PR 2 — wire snapshot mode through strategy bar reads

### DIFF
--- a/trading/analysis/weinstein/snapshot_runtime/lib/dune
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/dune
@@ -5,6 +5,7 @@
   core
   indicators.time_period
   status
+  trading.data_panel
   trading.data_panel.snapshot
   types
   weinstein.snapshot_pipeline)

--- a/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml
@@ -3,25 +3,14 @@
 
 open Core
 module BA1 = Bigarray.Array1
+module Bar_panels = Data_panel.Bar_panels
 module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
 
-type weekly_view = {
-  closes : float array;
-  raw_closes : float array;
-  highs : float array;
-  lows : float array;
-  volumes : float array;
-  dates : Core.Date.t array;
-  n : int;
-}
-
-type daily_view = {
-  highs : float array;
-  lows : float array;
-  closes : float array;
-  dates : Core.Date.t array;
-  n_days : int;
-}
+(* Phase F.2 PR 2: views are type-equal to [Bar_panels]'s — see the .mli. The
+   record definitions live in [Bar_panels] today; PR 3 (Phase F.3) hoists them
+   here when [Bar_panels] is deleted. *)
+type weekly_view = Bar_panels.weekly_view
+type daily_view = Bar_panels.daily_view
 
 let _empty_weekly_view : weekly_view =
   {
@@ -137,27 +126,61 @@ let _truncate_weekly_view (v : weekly_view) ~n : weekly_view =
       n;
     }
 
+(* Read OHLCV histories over [(from, as_of)] for [symbol] and assemble into
+   a [Daily_price.t list] in chronological order. Returns [] under the same
+   "missing → empty" contract as the rest of the module. Shared by
+   {!weekly_view_for}, {!daily_bars_for} and {!weekly_bars_for}. *)
+let _daily_bars_in_range cb ~symbol ~from ~as_of =
+  let read field =
+    _read_history_or_empty cb ~symbol ~from ~until:as_of ~field
+  in
+  let close = read Snapshot_schema.Close in
+  if List.is_empty close then []
+  else
+    let adj = read Snapshot_schema.Adjusted_close in
+    let high = read Snapshot_schema.High in
+    let low = read Snapshot_schema.Low in
+    let volume = read Snapshot_schema.Volume in
+    _assemble_daily_bars ~adj ~close ~high ~low ~volume
+
 let weekly_view_for (cb : Snapshot_callbacks.t) ~symbol ~n ~as_of =
   if n <= 0 then _empty_weekly_view
   else
     let from = Date.add_days as_of (-_weekly_calendar_span ~n) in
-    let read field =
-      _read_history_or_empty cb ~symbol ~from ~until:as_of ~field
-    in
-    let close = read Snapshot_schema.Close in
-    if List.is_empty close then _empty_weekly_view
+    let bars = _daily_bars_in_range cb ~symbol ~from ~as_of in
+    if List.is_empty bars then _empty_weekly_view
     else
-      let adj = read Snapshot_schema.Adjusted_close in
-      let high = read Snapshot_schema.High in
-      let low = read Snapshot_schema.Low in
-      let volume = read Snapshot_schema.Volume in
-      let bars = _assemble_daily_bars ~adj ~close ~high ~low ~volume in
-      if List.is_empty bars then _empty_weekly_view
-      else
-        let weekly =
-          Time_period.Conversion.daily_to_weekly ~include_partial_week:true bars
-        in
-        _truncate_weekly_view (_weekly_view_of_bars weekly) ~n
+      let weekly =
+        Time_period.Conversion.daily_to_weekly ~include_partial_week:true bars
+      in
+      _truncate_weekly_view (_weekly_view_of_bars weekly) ~n
+
+(* History window for [daily_bars_for] / [weekly_bars_for]. The strategy
+   readers return everything from time-zero up to [as_of]; the snapshot
+   path is keyed by date so we walk back a fixed-width window large enough
+   to cover any practical backtest horizon (10 years / 3653 days). The
+   [_assemble_daily_bars] tail filter NaN-skips pre-IPO / suspended cells,
+   so the window doesn't need to align with [symbol]'s actual history. *)
+let _bar_list_history_days = 3653
+
+let daily_bars_for (cb : Snapshot_callbacks.t) ~symbol ~as_of :
+    Types.Daily_price.t list =
+  let from = Date.add_days as_of (-_bar_list_history_days) in
+  _daily_bars_in_range cb ~symbol ~from ~as_of
+
+let weekly_bars_for (cb : Snapshot_callbacks.t) ~symbol ~n ~as_of :
+    Types.Daily_price.t list =
+  if n <= 0 then []
+  else
+    let from = Date.add_days as_of (-_bar_list_history_days) in
+    let bars = _daily_bars_in_range cb ~symbol ~from ~as_of in
+    if List.is_empty bars then []
+    else
+      let weekly =
+        Time_period.Conversion.daily_to_weekly ~include_partial_week:true bars
+      in
+      let len = List.length weekly in
+      if len <= n then weekly else List.drop weekly (len - n)
 
 (* Take the trailing [k] elements of a list. [k <= 0] yields []. *)
 let _take_trailing l k =

--- a/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.mli
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.mli
@@ -56,40 +56,39 @@
     owns its own buffer. Memory cost: at most [len * 8] bytes per call, freed by
     the GC. *)
 
-type weekly_view = {
-  closes : float array;
-      (** Adjusted close per weekly bar (chronological, oldest at index 0). *)
-  raw_closes : float array;
-      (** Raw (un-adjusted) close per weekly bar — the [Snapshot_schema.Close]
-          field's value at the last trading day of each weekly bucket. Used
-          together with [closes] to compute per-bar split-adjustment factors
-          ([closes.(i) /. raw_closes.(i)]). *)
-  highs : float array;  (** Max raw high within each weekly bucket. *)
-  lows : float array;  (** Min raw low within each weekly bucket. *)
-  volumes : float array;
-      (** Sum of raw daily volumes within each weekly bucket. Stored as float to
-          align with the snapshot column layout. *)
-  dates : Core.Date.t array;
-      (** Date of the last trading day in each weekly bucket (typically Friday
-          for complete weeks, last traded day for partial / holiday weeks). *)
-  n : int;  (** Length of every array. *)
-}
-(** Float-array view of weekly-aggregated bars for one symbol — same shape as
-    {!Data_panel.Bar_panels.weekly_view}. *)
+type weekly_view = Data_panel.Bar_panels.weekly_view
+(** Type-equal to {!Data_panel.Bar_panels.weekly_view} so the strategy's
+    panel-callback constructors
+    ({!Panel_callbacks.stage_callbacks_of_weekly_view} et al.) can consume views
+    produced by either backing without a per-call adapter or variant dispatch.
 
-type daily_view = {
-  highs : float array;
-      (** Daily raw high prices, oldest at index 0, newest at index
-          [n_days - 1]. *)
-  lows : float array;  (** Daily raw low prices, same indexing as [highs]. *)
-  closes : float array;
-      (** Daily raw closes (the [Snapshot_schema.Close] field), same indexing.
-      *)
-  dates : Core.Date.t array;  (** Daily dates, same indexing. *)
-  n_days : int;  (** Length of every array. *)
-}
-(** Float-array view of daily bars for one symbol within a lookback window —
-    same shape as {!Data_panel.Bar_panels.daily_view}. *)
+    Phase F.2 PR 2 uses this equality to wire snapshot reads through the
+    strategy in place of [Bar_panels.t]. PR 3 (Phase F.3) deletes
+    {!Data_panel.Bar_panels} and hoists the record definition into a neutral
+    location; the [type =] is the temporary bridge between PR 1 (this module
+    standalone) and PR 3 (sole owner of the record).
+
+    Field semantics — populated by {!weekly_view_for}:
+    - [closes] = adjusted close of the last trading day in each weekly bucket
+    - [raw_closes] = the [Snapshot_schema.Close] field's value at the last
+      trading day of each weekly bucket (the un-adjusted close)
+    - [highs] = max raw high within each weekly bucket
+    - [lows] = min raw low within each weekly bucket
+    - [volumes] = sum of raw daily volumes within each weekly bucket
+    - [dates] = date of the last trading day in each weekly bucket (typically
+      Friday for complete weeks, last traded day for partial / holiday weeks)
+    - [n] = length of every array. *)
+
+type daily_view = Data_panel.Bar_panels.daily_view
+(** Type-equal to {!Data_panel.Bar_panels.daily_view} for the same reason as
+    {!weekly_view}. Field semantics — populated by {!daily_view_for}:
+    - [highs] = daily raw high prices, oldest at index 0
+    - [lows] = daily raw low prices, same indexing
+    - [closes] = daily raw closes (the [Snapshot_schema.Close] field), same
+      indexing — matches {!Bar_panels.daily_view_for}, which also uses the raw
+      close panel rather than the adjusted close panel
+    - [dates] = daily dates, same indexing
+    - [n_days] = length of every array. *)
 
 val weekly_view_for :
   Snapshot_callbacks.t ->
@@ -133,6 +132,48 @@ val daily_view_for :
     - [symbol] is not in the snapshot manifest
     - no resident snapshot rows fall in the calendar window
     - any required field read fails. *)
+
+val daily_bars_for :
+  Snapshot_callbacks.t ->
+  symbol:string ->
+  as_of:Core.Date.t ->
+  Types.Daily_price.t list
+(** [daily_bars_for cb ~symbol ~as_of] returns daily bars for [symbol] up to and
+    including [as_of], in chronological order (oldest first). Used by
+    {!Bar_reader.of_snapshot_views} to satisfy the [Bar_reader.daily_bars_for]
+    surface (consumed by [Stops_split_runner._last_two_bars] for split detection
+    and [Entry_audit_capture._effective_entry_price]).
+
+    Reads the [Adjusted_close], [Close], [High], [Low], and [Volume] field
+    histories from [cb] over a fixed-width calendar window (10 years ≈ 3653
+    days, conservatively wide so historical strategies see the symbol's full
+    backtest history), aligns them by date, drops bars where [Close] is NaN, and
+    returns the assembled list.
+
+    {b open_price NaN.} The [Snapshot_schema.Open] field is not currently
+    surfaced — every returned bar has [open_price = Float.nan]. None of the
+    in-tree consumers of {!Bar_reader.daily_bars_for} read [open_price], so this
+    is sound today; if a future caller needs it, fold [Open] into
+    [_assemble_daily_bars]'s input set.
+
+    Returns the empty list when:
+    - [symbol] is not in the snapshot manifest
+    - no resident snapshot rows fall in the calendar window
+    - any required field read fails. *)
+
+val weekly_bars_for :
+  Snapshot_callbacks.t ->
+  symbol:string ->
+  n:int ->
+  as_of:Core.Date.t ->
+  Types.Daily_price.t list
+(** [weekly_bars_for cb ~symbol ~n ~as_of] returns the most recent [n]
+    weekly-aggregated bars for [symbol] as of [as_of], in chronological order.
+    Same aggregation rules as {!weekly_view_for} (ISO-week buckets,
+    [include_partial_week:true]).
+
+    Returns the empty list when [n <= 0] or under the same conditions as
+    {!daily_bars_for}. *)
 
 val low_window :
   Snapshot_callbacks.t ->

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -7,6 +7,8 @@ module Ohlcv_panels = Data_panel.Ohlcv_panels
 module Bar_panels = Data_panel.Bar_panels
 module Indicator_panels = Data_panel.Indicator_panels
 module Indicator_spec = Data_panel.Indicator_spec
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
 
 type input = {
   data_dir_fpath : Fpath.t;
@@ -71,7 +73,7 @@ let _build_indicators ~ohlcv ~n_days =
 
 let _build_strategy (input : input) ~bar_panels ~ohlcv ~indicators ~calendar
     ~audit_recorder =
-  (* The inner Weinstein strategy reads OHLCV bars from
+  (* CSV path: the inner Weinstein strategy reads OHLCV bars from
      {!Data_panel.Bar_panels} (populated up-front from CSV at runner start).
      Stage 3 PR-C deleted the Tiered tier system + parallel [Bar_history]
      cache; the strategy is wrapped only by [Panel_strategy_wrapper], which
@@ -92,6 +94,18 @@ let _build_strategy (input : input) ~bar_panels ~ohlcv ~indicators ~calendar
   in
   Panel_strategy_wrapper.wrap ~config:panel_config inner_strategy
 
+(* Snapshot path: the inner Weinstein strategy reads bars via a
+   pre-built [Bar_reader.t] backed by [Snapshot_runtime.Snapshot_callbacks].
+   No [Panel_strategy_wrapper] — the wrapper exists to inject a panel-backed
+   [get_indicator_fn], but the Weinstein strategy ignores [get_indicator]
+   (see [_on_market_close]'s [~get_indicator:_] argument), so wrapping is
+   pure overhead in this branch. The strategy is handed straight through
+   to the simulator. *)
+let _build_strategy_snapshot (input : input) ~bar_reader ~audit_recorder =
+  Weinstein_strategy.make ~ad_bars:input.ad_bars
+    ~ticker_sectors:input.ticker_sectors ~bar_reader ~audit_recorder
+    input.config
+
 (* LRU cap for the snapshot cache. Generous for the typical small-universe
    parity test (a few symbols × a few hundred days = handful of MB) and roomy
    for a five-year sp500 golden (universe size in the hundreds × ~1.3K days
@@ -111,14 +125,9 @@ let _build_market_data_adapter ~data_dir ?bar_data_source () =
       failwithf "Panel_runner: Bar_data_source.build_adapter failed: %s"
         (Status.show err) ()
 
-let _make_simulator (input : input) ~stop_log ~audit_recorder ~start_date
-    ~end_date ~warmup_days ~initial_cash ~commission ~ohlcv ~indicators
-    ~calendar ~bar_panels ~market_data_adapter =
+let _make_simulator (input : input) ~stop_log ~start_date ~end_date ~warmup_days
+    ~initial_cash ~commission ~strategy ~market_data_adapter =
   let warmup_start = Date.add_days start_date (-warmup_days) in
-  let strategy =
-    _build_strategy input ~bar_panels ~ohlcv ~indicators ~calendar
-      ~audit_recorder
-  in
   let strategy = Strategy_wrapper.wrap ~stop_log strategy in
   let sim_deps =
     Simulator.create_deps ~symbols:input.all_symbols
@@ -204,7 +213,7 @@ let _run_simulator_with_gc_trace ?gc_trace ~stop_log sim =
     weekend, holiday, suspended, or pre-IPO) are dropped. Empty result when
     [n_days = 0]. The runner filters this alist to held symbols when populating
     [Runner.result.final_prices]. *)
-let _final_close_prices ~ohlcv =
+let _final_close_prices_csv ~ohlcv =
   let n_days = Ohlcv_panels.n_days ohlcv in
   if n_days <= 0 then []
   else
@@ -216,14 +225,31 @@ let _final_close_prices ~ohlcv =
         let v = close_panel.{row, last_col} in
         if Float.is_nan v then None else Some (symbol, v))
 
-let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
-    ~commission ?trace ?gc_trace ?bar_data_source () =
-  let warmup_start = Date.add_days start_date (-warmup_days) in
-  let calendar = _build_calendar ~start:warmup_start ~end_:end_date in
-  let n_days = Array.length calendar in
-  eprintf "Panel_runner: calendar has %d trading days (%s..%s)\n%!" n_days
-    (Date.to_string warmup_start)
-    (Date.to_string end_date);
+(** Snapshot-mode counterpart of [_final_close_prices_csv]. Walks the universe
+    and reads the [Close] field from each symbol's snapshot row at [end_date]
+    via [Daily_panels.read_today]. Symbols not present, errored reads, or NaN
+    closes are dropped — same "missing → omit" contract as the CSV path. *)
+let _final_close_prices_snapshot ~daily_panels ~symbols ~end_date =
+  let schema = Daily_panels.schema daily_panels in
+  match
+    Data_panel_snapshot.Snapshot_schema.index_of schema
+      Data_panel_snapshot.Snapshot_schema.Close
+  with
+  | None -> []
+  | Some close_col ->
+      List.filter_map symbols ~f:(fun symbol ->
+          match Daily_panels.read_today daily_panels ~symbol ~date:end_date with
+          | Error _ -> None
+          | Ok snap ->
+              let v = snap.values.(close_col) in
+              if Float.is_nan v then None else Some (symbol, v))
+
+(* CSV path: build OHLCV + indicator panels + Bar_panels, build the
+   panel-wrapped strategy, build a CSV-backed market data adapter. Returns
+   the configured strategy and adapter plus a closure to read final-day
+   close prices when the run completes. *)
+let _setup_csv (input : input) ~calendar ~n_days ~audit_recorder
+    ~bar_data_source =
   let ohlcv = _build_ohlcv ~input ~calendar in
   let indicators = _build_indicators ~ohlcv ~n_days in
   let bar_panels =
@@ -237,6 +263,70 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     "Panel_runner: panels built (%d symbols × %d days, %d indicator specs)\n%!"
     (Ohlcv_panels.n ohlcv) n_days
     (List.length _default_specs);
+  let strategy =
+    _build_strategy input ~bar_panels ~ohlcv ~indicators ~calendar
+      ~audit_recorder
+  in
+  let adapter =
+    _build_market_data_adapter ~data_dir:input.data_dir_fpath ?bar_data_source
+      ()
+  in
+  let final_close_prices () = _final_close_prices_csv ~ohlcv in
+  (strategy, adapter, final_close_prices)
+
+(* Snapshot path: skip the OHLCV / Bar_panels / Indicator_panels build
+   entirely (the RAM-spike unblock — see eng-design Phase F.2). Build a
+   [Daily_panels.t] over the snapshot directory, derive a
+   [Snapshot_callbacks.t], then a [Bar_reader.t] over the callbacks; build
+   the strategy with that reader and the snapshot-backed adapter. *)
+let _setup_snapshot (input : input) ~snapshot_dir ~manifest ~end_date
+    ~audit_recorder =
+  let daily_panels =
+    match
+      Daily_panels.create ~snapshot_dir ~manifest
+        ~max_cache_mb:_snapshot_cache_mb
+    with
+    | Ok p -> p
+    | Error err ->
+        failwithf "Panel_runner: Daily_panels.create failed: %s"
+          (Status.show err) ()
+  in
+  let callbacks = Snapshot_callbacks.of_daily_panels daily_panels in
+  let bar_reader = Weinstein_strategy.Bar_reader.of_snapshot_views callbacks in
+  let strategy = _build_strategy_snapshot input ~bar_reader ~audit_recorder in
+  let adapter =
+    _build_market_data_adapter ~data_dir:input.data_dir_fpath
+      ~bar_data_source:(Bar_data_source.Snapshot { snapshot_dir; manifest })
+      ()
+  in
+  let final_close_prices () =
+    _final_close_prices_snapshot ~daily_panels ~symbols:input.all_symbols
+      ~end_date
+  in
+  (strategy, adapter, final_close_prices)
+
+(* Dispatch the per-mode setup. CSV is the default; Snapshot is the F.2
+   short-circuit that bypasses [Bar_panels.t]. The selector is the same
+   [Bar_data_source.t] the simulator already uses for per-tick price
+   reads — so passing [Snapshot _] flips both the strategy's bar reads
+   and the simulator's per-tick reads onto the snapshot backing in one
+   gesture. *)
+let _setup_for_mode (input : input) ~calendar ~n_days ~end_date ~audit_recorder
+    ~bar_data_source =
+  match bar_data_source with
+  | None | Some Bar_data_source.Csv ->
+      _setup_csv input ~calendar ~n_days ~audit_recorder ~bar_data_source
+  | Some (Bar_data_source.Snapshot { snapshot_dir; manifest }) ->
+      _setup_snapshot input ~snapshot_dir ~manifest ~end_date ~audit_recorder
+
+let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
+    ~commission ?trace ?gc_trace ?bar_data_source () =
+  let warmup_start = Date.add_days start_date (-warmup_days) in
+  let calendar = _build_calendar ~start:warmup_start ~end_:end_date in
+  let n_days = Array.length calendar in
+  eprintf "Panel_runner: calendar has %d trading days (%s..%s)\n%!" n_days
+    (Date.to_string warmup_start)
+    (Date.to_string end_date);
   let stop_log = Stop_log.create () in
   let trade_audit = Trade_audit.create () in
   let force_liquidation_log = Force_liquidation_log.create () in
@@ -244,18 +334,17 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     Trade_audit_recorder.of_collector ~trade_audit ~force_liquidation_log
   in
   let n_all_symbols = List.length input.all_symbols in
-  let market_data_adapter =
-    _build_market_data_adapter ~data_dir:input.data_dir_fpath ?bar_data_source
-      ()
+  let strategy, market_data_adapter, final_close_prices_thunk =
+    _setup_for_mode input ~calendar ~n_days ~end_date ~audit_recorder
+      ~bar_data_source
   in
   let sim =
-    _make_simulator input ~stop_log ~audit_recorder ~start_date ~end_date
-      ~warmup_days ~initial_cash ~commission ~ohlcv ~indicators ~calendar
-      ~bar_panels ~market_data_adapter
+    _make_simulator input ~stop_log ~start_date ~end_date ~warmup_days
+      ~initial_cash ~commission ~strategy ~market_data_adapter
   in
   let sim_result =
     Trace.record ?trace ~symbols_in:n_all_symbols Trace.Phase.Fill (fun () ->
         _run_simulator_with_gc_trace ?gc_trace ~stop_log sim)
   in
-  let final_close_prices = _final_close_prices ~ohlcv in
+  let final_close_prices = final_close_prices_thunk () in
   (sim_result, stop_log, trade_audit, force_liquidation_log, final_close_prices)

--- a/trading/trading/backtest/lib/panel_runner.mli
+++ b/trading/trading/backtest/lib/panel_runner.mli
@@ -74,13 +74,24 @@ val run :
     the buffer-reuse refactors land. When [gc_trace] is omitted, the runner
     takes no per-step snapshots and the cost is one [None] match per step.
 
-    [bar_data_source], when passed, selects the OHLCV backend the simulator's
-    per-tick price reads use. Default ({!Bar_data_source.Csv}) is the
-    pre-Phase-D behaviour: build a CSV-backed [Market_data_adapter] from
-    [input.data_dir_fpath]. {!Bar_data_source.Snapshot} switches to a
-    callback-mode adapter backed by [Daily_panels.t] over the snapshot directory
-    in the selector. The strategy's bar reads (via [Bar_panels.t]) are unchanged
-    in either mode — only the simulator's per-tick reads (engine
-    [update_market], split detection, MtM portfolio_value, benchmark return)
-    shift to the snapshot source. Phase D scope; see
-    [dev/plans/snapshot-engine-phase-d-2026-05-02.md]. *)
+    [bar_data_source], when passed, selects the OHLCV backend used by both the
+    simulator's per-tick price reads AND the strategy's bar reads.
+
+    - Default ({!Bar_data_source.Csv}) is the pre-Phase-D behaviour: build OHLCV
+      / Indicator / Bar panels up front from CSV; the strategy reads via
+      [Bar_panels.t] through [Bar_reader.of_panels]; the simulator's
+      [Market_data_adapter] reads from CSV.
+
+    - {!Bar_data_source.Snapshot} switches both surfaces to the snapshot
+      backing. Phase F.2 PR 2 (snapshot-engine plan) made this branch skip the
+      [Bar_panels.t] / [Ohlcv_panels.t] / [Indicator_panels.t] allocation
+      entirely — these were the dominant resident-set cost at tier-4 universe
+      sizes (~27 GB at N=5000 × 10y). The strategy reads via
+      [Bar_reader.of_snapshot_views] over [Snapshot_runtime.Daily_panels]
+      (LRU-bounded, [_snapshot_cache_mb] cap); the simulator's adapter is the
+      same callback-mode adapter Phase D introduced. The snapshot path keeps no
+      calendar-wide bigarray panel resident.
+
+    Phase D wired the simulator surface; Phase F.2 PR 2 wires the strategy
+    surface. See [dev/plans/snapshot-engine-phase-d-2026-05-02.md] and the Phase
+    F notes in [dev/plans/daily-snapshot-streaming-2026-04-27.md]. *)

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -12,6 +12,7 @@
   test_runner_hypothesis_overrides
   test_panel_loader_parity
   test_snapshot_mode_parity
+  test_snapshot_mode_strategy_parity
   test_backtest_runner_args
   test_config_override
   test_comparison
@@ -38,8 +39,10 @@
   scenario_lib
   weinstein.data_source
   weinstein.snapshot_pipeline
+  weinstein.snapshot_runtime
   weinstein.types
   trading.base
+  trading.data_panel
   trading.data_panel.snapshot
   trading.engine
   trading.portfolio

--- a/trading/trading/backtest/test/test_snapshot_mode_strategy_parity.ml
+++ b/trading/trading/backtest/test/test_snapshot_mode_strategy_parity.ml
@@ -1,0 +1,333 @@
+(** Phase F.2 PR 2 parity gate — snapshot-mode vs CSV-mode [Bar_reader] return
+    identical [weekly_view] / [daily_view] reads on the same input bars.
+
+    Sibling of [test_snapshot_mode_parity.ml]: that test pinned the simulator's
+    per-tick price-read seam at [Market_data_adapter]; this test pins the
+    strategy's per-tick bar-read seam at [Bar_reader]. The two cover the two
+    distinct surfaces snapshot mode now subsumes.
+
+    {1 What we assert}
+
+    Build the same in-memory bar stream into BOTH a CSV directory (for
+    [Ohlcv_panels.load_from_csv_calendar] -> [Bar_panels.create]) and a snapshot
+    directory (for [Daily_panels.create]). Wrap each in a [Bar_reader.t] via the
+    appropriate constructor. Walk every (symbol, date) pair in the fixture and
+    assert the two readers' views are array-equal.
+
+    If this holds, the strategy's bar-shaped reads
+    ([Stage.classify_with_callbacks], [Stock_analysis.analyze], etc.) observe
+    the same input series in either mode by construction — every downstream
+    consumer is a pure function of these reads. *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_panels = Data_panel.Bar_panels
+module Bar_reader = Weinstein_strategy.Bar_reader
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Pipeline = Snapshot_pipeline.Pipeline
+module Symbol_index = Data_panel.Symbol_index
+module Ohlcv_panels = Data_panel.Ohlcv_panels
+
+(* -------------------------------------------------------------------- *)
+(* Fixture helpers — adapted from [test_snapshot_mode_parity.ml].        *)
+(* -------------------------------------------------------------------- *)
+
+let _ymd y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+(* Synthetic bars: deterministic per-(symbol, day_index) so any drift
+   shows up as a per-cell mismatch. Volumes < 2^53 round-trip exactly. *)
+let _make_bar ~symbol ~day_index ~start =
+  let date = Date.add_days start day_index in
+  let base = 100.0 +. (Float.of_int (String.hash symbol mod 50) *. 0.1) in
+  let drift = Float.of_int day_index *. 0.05 in
+  let close = base +. drift in
+  {
+    Types.Daily_price.date;
+    open_price = close -. 0.10;
+    high_price = close +. 0.20;
+    low_price = close -. 0.30;
+    close_price = close;
+    volume = 1_000_000 + (day_index * 1000);
+    adjusted_close = close;
+  }
+
+(* Filter a bar list to weekdays only — the calendar [Bar_panels.create]
+   consumes is weekday-only ([Panel_runner._build_calendar]); to compare
+   apples-to-apples the snapshot path must store the same weekday subset.
+   The Phase B pipeline accepts an arbitrary date list, so passing the
+   pre-filtered list keeps both paths in lockstep. *)
+let _bars_for ~symbol ~start ~n =
+  List.init n ~f:(fun i -> _make_bar ~symbol ~day_index:i ~start)
+  |> List.filter ~f:(fun (b : Types.Daily_price.t) ->
+      let dow = Date.day_of_week b.date in
+      not
+        (Day_of_week.equal dow Day_of_week.Sat
+        || Day_of_week.equal dow Day_of_week.Sun))
+
+let _make_tmp_dir prefix = Filename_unix.temp_dir ~in_dir:"/tmp" prefix ""
+
+(* CSV writer: identical schema to [test_snapshot_mode_parity._write_csv_dir];
+   the [Ohlcv_panels.load_from_csv_calendar] path resolves
+   [data_dir/<F>/<L>/<SYM>/data.csv] for each symbol. *)
+let _write_csv_dir ~data_dir bars_by_symbol =
+  List.iter bars_by_symbol ~f:(fun (symbol, bars) ->
+      let f = String.sub symbol ~pos:0 ~len:1 in
+      let l = String.sub symbol ~pos:(String.length symbol - 1) ~len:1 in
+      let dir = Filename.of_parts [ data_dir; f; l; symbol ] in
+      Core_unix.mkdir_p dir;
+      let path = Filename.concat dir "data.csv" in
+      Out_channel.with_file path ~f:(fun oc ->
+          Out_channel.output_string oc
+            "date,open,high,low,close,adjusted_close,volume\n";
+          List.iter bars ~f:(fun (b : Types.Daily_price.t) ->
+              Out_channel.output_string oc
+                (sprintf "%s,%.17g,%.17g,%.17g,%.17g,%.17g,%d\n"
+                   (Date.to_string b.date) b.open_price b.high_price b.low_price
+                   b.close_price b.adjusted_close b.volume))))
+
+let _write_snapshot_dir ~snapshot_dir bars_by_symbol =
+  let schema = Snapshot_schema.default in
+  let entries =
+    List.map bars_by_symbol ~f:(fun (symbol, bars) ->
+        let rows =
+          match Pipeline.build_for_symbol ~symbol ~bars ~schema () with
+          | Ok r -> r
+          | Error err ->
+              assert_failure ("Pipeline.build_for_symbol: " ^ Status.show err)
+        in
+        let path = Filename.concat snapshot_dir (symbol ^ ".snap") in
+        (match Snapshot_format.write ~path rows with
+        | Ok () -> ()
+        | Error err ->
+            assert_failure ("Snapshot_format.write: " ^ Status.show err));
+        let stat = Core_unix.stat path in
+        ({
+           symbol;
+           path;
+           byte_size = Int64.to_int_exn stat.st_size;
+           payload_md5 = "ignored";
+           csv_mtime = stat.st_mtime;
+         }
+          : Snapshot_manifest.file_metadata))
+  in
+  Snapshot_manifest.create ~schema ~entries
+
+(* Generate the calendar [Bar_panels.create] expects: every weekday from
+   [start..start + n - 1] (inclusive). Same shape as
+   [Panel_runner._build_calendar]. *)
+let _calendar_of ~start ~n =
+  let rec loop i acc =
+    if i >= n then List.rev acc
+    else
+      let d = Date.add_days start i in
+      let dow = Date.day_of_week d in
+      let is_weekend =
+        Day_of_week.equal dow Day_of_week.Sat
+        || Day_of_week.equal dow Day_of_week.Sun
+      in
+      let acc' = if is_weekend then acc else d :: acc in
+      loop (i + 1) acc'
+  in
+  Array.of_list (loop 0 [])
+
+(* Build a [Bar_panels.t] from CSV files using the canonical pipeline. *)
+let _build_bar_panels ~data_dir ~symbols ~calendar =
+  let symbol_index =
+    match Symbol_index.create ~universe:symbols with
+    | Ok t -> t
+    | Error err -> assert_failure ("Symbol_index.create: " ^ Status.show err)
+  in
+  let ohlcv =
+    match
+      Ohlcv_panels.load_from_csv_calendar symbol_index
+        ~data_dir:(Fpath.v data_dir) ~calendar
+    with
+    | Ok t -> t
+    | Error err ->
+        assert_failure
+          ("Ohlcv_panels.load_from_csv_calendar: " ^ Status.show err)
+  in
+  match Bar_panels.create ~ohlcv ~calendar with
+  | Ok p -> p
+  | Error err -> assert_failure ("Bar_panels.create: " ^ Status.show err)
+
+let _build_snapshot_callbacks ~snapshot_dir ~manifest =
+  match Daily_panels.create ~snapshot_dir ~manifest ~max_cache_mb:64 with
+  | Ok p -> Snapshot_callbacks.of_daily_panels p
+  | Error err -> assert_failure ("Daily_panels.create: " ^ Status.show err)
+
+(* -------------------------------------------------------------------- *)
+(* Tests                                                                 *)
+(* -------------------------------------------------------------------- *)
+
+let _default_symbols = [ "AAPL"; "MSFT"; "JPM" ]
+let _default_start = _ymd 2024 1 2
+let _default_n = 60
+
+(* Bundle returned to tests so each test isn't repeating the dual-fixture
+   setup. *)
+type fixtures = {
+  csv_reader : Bar_reader.t;
+  snap_reader : Bar_reader.t;
+  bars_by_symbol : (string * Types.Daily_price.t list) list;
+}
+
+let _setup_dual_readers () =
+  let data_dir = _make_tmp_dir "snapshot_strategy_parity_csv_" in
+  let snapshot_dir = _make_tmp_dir "snapshot_strategy_parity_snap_" in
+  let bars_by_symbol =
+    List.map _default_symbols ~f:(fun s ->
+        (s, _bars_for ~symbol:s ~start:_default_start ~n:_default_n))
+  in
+  _write_csv_dir ~data_dir bars_by_symbol;
+  let manifest = _write_snapshot_dir ~snapshot_dir bars_by_symbol in
+  let calendar = _calendar_of ~start:_default_start ~n:_default_n in
+  let bar_panels =
+    _build_bar_panels ~data_dir ~symbols:_default_symbols ~calendar
+  in
+  let csv_reader = Bar_reader.of_panels bar_panels in
+  let cb = _build_snapshot_callbacks ~snapshot_dir ~manifest in
+  let snap_reader = Bar_reader.of_snapshot_views cb in
+  { csv_reader; snap_reader; bars_by_symbol }
+
+(* Per-cell parity helpers. The [weekly_view] / [daily_view] records are
+   pure-data float arrays + dates + an [n] counter; we compare component-
+   wise. Float equality is structural ([Bar_panels] writes the exact float
+   we put into the CSV at %.17g, [Snapshot_format] carries the float
+   verbatim) so [equal_to] suffices. *)
+let _assert_weekly_views_equal ~snap ~csv =
+  assert_that snap (equal_to (csv : Bar_panels.weekly_view))
+
+let _assert_daily_views_equal ~snap ~csv =
+  assert_that snap (equal_to (csv : Bar_panels.daily_view))
+
+(* {1 Weekly view parity}
+
+   Walk every (symbol, date) and assert weekly_view_for matches between the
+   two readers. [n=8] covers the screener's typical lookback window (the
+   strategy reads 8 weekly bars for stage / volume / resistance). *)
+let test_weekly_view_bit_equal _ =
+  let { csv_reader; snap_reader; bars_by_symbol } = _setup_dual_readers () in
+  let n = 8 in
+  List.iter bars_by_symbol ~f:(fun (symbol, bars) ->
+      List.iter bars ~f:(fun (bar : Types.Daily_price.t) ->
+          let csv_view =
+            Bar_reader.weekly_view_for csv_reader ~symbol ~n ~as_of:bar.date
+          in
+          let snap_view =
+            Bar_reader.weekly_view_for snap_reader ~symbol ~n ~as_of:bar.date
+          in
+          _assert_weekly_views_equal ~snap:snap_view ~csv:csv_view))
+
+(* {1 Daily view parity}
+
+   Same shape, [lookback=20] covering the support-floor primitive's typical
+   window (Weinstein 90-day support floor scaled down to fit the fixture). *)
+let test_daily_view_bit_equal _ =
+  let { csv_reader; snap_reader; bars_by_symbol } = _setup_dual_readers () in
+  let lookback = 20 in
+  List.iter bars_by_symbol ~f:(fun (symbol, bars) ->
+      List.iter bars ~f:(fun (bar : Types.Daily_price.t) ->
+          let csv_view =
+            Bar_reader.daily_view_for csv_reader ~symbol ~as_of:bar.date
+              ~lookback
+          in
+          let snap_view =
+            Bar_reader.daily_view_for snap_reader ~symbol ~as_of:bar.date
+              ~lookback
+          in
+          _assert_daily_views_equal ~snap:snap_view ~csv:csv_view))
+
+(* {1 Daily bar list parity (excluding [open_price])}
+
+   The snapshot path's [daily_bars_for] does not surface [Snapshot_schema.Open]
+   today (see [Snapshot_bar_views.daily_bars_for]'s [open_price = NaN]
+   contract). The in-tree consumers of [Bar_reader.daily_bars_for] read
+   close / high / low / volume / adjusted_close — never open — so the parity
+   we care about is "every consumer-relevant field matches". Compare the two
+   paths' bar lists element-wise, asserting equality on every field except
+   [open_price]. *)
+let _assert_bars_equal_except_open ~snap ~csv =
+  assert_that snap
+    (elements_are
+       (List.map csv ~f:(fun (cb : Types.Daily_price.t) ->
+            all_of
+              [
+                field
+                  (fun (b : Types.Daily_price.t) -> b.date)
+                  (equal_to cb.date);
+                field
+                  (fun (b : Types.Daily_price.t) -> b.high_price)
+                  (float_equal cb.high_price);
+                field
+                  (fun (b : Types.Daily_price.t) -> b.low_price)
+                  (float_equal cb.low_price);
+                field
+                  (fun (b : Types.Daily_price.t) -> b.close_price)
+                  (float_equal cb.close_price);
+                field
+                  (fun (b : Types.Daily_price.t) -> b.adjusted_close)
+                  (float_equal cb.adjusted_close);
+                field
+                  (fun (b : Types.Daily_price.t) -> b.volume)
+                  (equal_to cb.volume);
+              ])))
+
+let test_daily_bars_for_consumer_fields_equal _ =
+  let { csv_reader; snap_reader; bars_by_symbol } = _setup_dual_readers () in
+  List.iter bars_by_symbol ~f:(fun (symbol, bars) ->
+      List.iter bars ~f:(fun (bar : Types.Daily_price.t) ->
+          let csv_bars =
+            Bar_reader.daily_bars_for csv_reader ~symbol ~as_of:bar.date
+          in
+          let snap_bars =
+            Bar_reader.daily_bars_for snap_reader ~symbol ~as_of:bar.date
+          in
+          _assert_bars_equal_except_open ~snap:snap_bars ~csv:csv_bars))
+
+(* {1 Edge case parity}
+
+   Both readers must return the empty view under the same conditions:
+   (1) date with no bar (probe before fixture start), and
+   (2) unknown symbol. *)
+let test_missing_returns_empty_in_both _ =
+  let { csv_reader; snap_reader; _ } = _setup_dual_readers () in
+  let probes =
+    [
+      ("AAPL", Date.add_days _default_start (-10));
+      ("UNKNOWN", Date.add_days _default_start 5);
+    ]
+  in
+  List.iter probes ~f:(fun (symbol, date) ->
+      let csv_w =
+        Bar_reader.weekly_view_for csv_reader ~symbol ~n:8 ~as_of:date
+      in
+      let snap_w =
+        Bar_reader.weekly_view_for snap_reader ~symbol ~n:8 ~as_of:date
+      in
+      _assert_weekly_views_equal ~snap:snap_w ~csv:csv_w;
+      let csv_d =
+        Bar_reader.daily_view_for csv_reader ~symbol ~as_of:date ~lookback:20
+      in
+      let snap_d =
+        Bar_reader.daily_view_for snap_reader ~symbol ~as_of:date ~lookback:20
+      in
+      _assert_daily_views_equal ~snap:snap_d ~csv:csv_d)
+
+let suite =
+  "Snapshot_mode_strategy_parity"
+  >::: [
+         "test_weekly_view_bit_equal" >:: test_weekly_view_bit_equal;
+         "test_daily_view_bit_equal" >:: test_daily_view_bit_equal;
+         "test_daily_bars_for_consumer_fields_equal"
+         >:: test_daily_bars_for_consumer_fields_equal;
+         "test_missing_returns_empty_in_both"
+         >:: test_missing_returns_empty_in_both;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/bar_reader.ml
+++ b/trading/trading/weinstein/strategy/lib/bar_reader.ml
@@ -4,50 +4,29 @@ open Core
 module Bar_panels = Data_panel.Bar_panels
 module Symbol_index = Data_panel.Symbol_index
 module Ohlcv_panels = Data_panel.Ohlcv_panels
+module Snapshot_bar_views = Snapshot_runtime.Snapshot_bar_views
 
-type t = { panels : Bar_panels.t; ma_cache : Weekly_ma_cache.t option }
+(* Closure-based representation: each constructor captures its backing's read
+   primitives and packages them as same-shape closures. The strategy's hot
+   path invokes one of these closures per call site per tick — no backing
+   dispatch, no variant match. *)
+type t = {
+  daily_bars_for : symbol:string -> as_of:Date.t -> Types.Daily_price.t list;
+  weekly_bars_for :
+    symbol:string -> n:int -> as_of:Date.t -> Types.Daily_price.t list;
+  weekly_view_for :
+    symbol:string -> n:int -> as_of:Date.t -> Bar_panels.weekly_view;
+  daily_view_for :
+    symbol:string -> as_of:Date.t -> lookback:int -> Bar_panels.daily_view;
+  ma_cache : Weekly_ma_cache.t option;
+}
 
-let of_panels ?ma_cache panels = { panels; ma_cache }
 let ma_cache t = t.ma_cache
 
-(** Build an empty [Bar_panels.t] backed by a zero-symbol universe + zero-day
-    calendar. Used by [empty ()] for tests where no panel-backed read is
-    expected. *)
-let _empty_panels () =
-  let symbol_index =
-    match Symbol_index.create ~universe:[] with
-    | Ok t -> t
-    | Error err ->
-        failwithf "Bar_reader.empty: Symbol_index.create []: %s"
-          err.Status.message ()
-  in
-  let ohlcv = Ohlcv_panels.create symbol_index ~n_days:0 in
-  match Bar_panels.create ~ohlcv ~calendar:[||] with
-  | Ok p -> p
-  | Error err ->
-      failwithf "Bar_reader.empty: Bar_panels.create: %s" err.Status.message ()
-
-let empty () = { panels = _empty_panels (); ma_cache = None }
-
-(* When [as_of] is not in the calendar (e.g., the backtest hasn't started yet,
-   or the strategy was somehow handed a date outside the bounds), return the
-   empty list. The strategy's downstream code already tolerates an empty
-   result: [Stage.classify_with_callbacks] returns the Stage1 default,
-   [Sector.analyze] returns the empty result, etc. *)
-let daily_bars_for t ~symbol ~as_of =
-  match Bar_panels.column_of_date t.panels as_of with
-  | None -> []
-  | Some as_of_day -> Bar_panels.daily_bars_for t.panels ~symbol ~as_of_day
-
-let weekly_bars_for t ~symbol ~n ~as_of =
-  match Bar_panels.column_of_date t.panels as_of with
-  | None -> []
-  | Some as_of_day -> Bar_panels.weekly_bars_for t.panels ~symbol ~n ~as_of_day
-
-(* Float-array views: same calendar-fallback semantics as the bar-list reads.
-   Returning the empty view (n=0 / n_days=0) when [as_of] is not in the
-   calendar matches the empty-list contract callers already tolerate. *)
-
+(* Empty views — used as the sentinel return when [as_of] falls outside the
+   panel's calendar or the snapshot has no rows. Match the empty literals
+   [Bar_panels] / [Snapshot_bar_views] use internally so consumers can rely
+   on [n = 0] / [n_days = 0] as the "missing" signal. *)
 let _empty_weekly_view : Bar_panels.weekly_view =
   {
     closes = [||];
@@ -62,13 +41,98 @@ let _empty_weekly_view : Bar_panels.weekly_view =
 let _empty_daily_view : Bar_panels.daily_view =
   { highs = [||]; lows = [||]; closes = [||]; dates = [||]; n_days = 0 }
 
-let weekly_view_for t ~symbol ~n ~as_of =
-  match Bar_panels.column_of_date t.panels as_of with
-  | None -> _empty_weekly_view
-  | Some as_of_day -> Bar_panels.weekly_view_for t.panels ~symbol ~n ~as_of_day
+(* {1 Panel-backed constructor} *)
 
-let daily_view_for t ~symbol ~as_of ~lookback =
-  match Bar_panels.column_of_date t.panels as_of with
+let _panel_daily_bars_for panels ~symbol ~as_of =
+  match Bar_panels.column_of_date panels as_of with
+  | None -> []
+  | Some as_of_day -> Bar_panels.daily_bars_for panels ~symbol ~as_of_day
+
+let _panel_weekly_bars_for panels ~symbol ~n ~as_of =
+  match Bar_panels.column_of_date panels as_of with
+  | None -> []
+  | Some as_of_day -> Bar_panels.weekly_bars_for panels ~symbol ~n ~as_of_day
+
+let _panel_weekly_view_for panels ~symbol ~n ~as_of =
+  match Bar_panels.column_of_date panels as_of with
+  | None -> _empty_weekly_view
+  | Some as_of_day -> Bar_panels.weekly_view_for panels ~symbol ~n ~as_of_day
+
+let _panel_daily_view_for panels ~symbol ~as_of ~lookback =
+  match Bar_panels.column_of_date panels as_of with
   | None -> _empty_daily_view
   | Some as_of_day ->
-      Bar_panels.daily_view_for t.panels ~symbol ~as_of_day ~lookback
+      Bar_panels.daily_view_for panels ~symbol ~as_of_day ~lookback
+
+let of_panels ?ma_cache panels =
+  {
+    daily_bars_for = _panel_daily_bars_for panels;
+    weekly_bars_for = _panel_weekly_bars_for panels;
+    weekly_view_for = _panel_weekly_view_for panels;
+    daily_view_for = _panel_daily_view_for panels;
+    ma_cache;
+  }
+
+(* {1 Empty backing — used by tests where no read is expected} *)
+
+(* Build an empty [Bar_panels.t] backed by a zero-symbol universe + zero-day
+   calendar. Used by [empty ()] for tests where no panel-backed read is
+   expected — exercising it through the panel-backed closure keeps the
+   "empty universe" fallback consistent with the panel path's semantics
+   (and means tests still see [Bar_panels]-shaped returns). *)
+let _empty_panels () =
+  let symbol_index =
+    match Symbol_index.create ~universe:[] with
+    | Ok t -> t
+    | Error err ->
+        failwithf "Bar_reader.empty: Symbol_index.create []: %s"
+          err.Status.message ()
+  in
+  let ohlcv = Ohlcv_panels.create symbol_index ~n_days:0 in
+  match Bar_panels.create ~ohlcv ~calendar:[||] with
+  | Ok p -> p
+  | Error err ->
+      failwithf "Bar_reader.empty: Bar_panels.create: %s" err.Status.message ()
+
+let empty () = of_panels (_empty_panels ())
+
+(* {1 Snapshot-backed constructor (Phase F.2 PR 2)}
+
+   Reads fan out through [Snapshot_bar_views] over a [Snapshot_callbacks.t].
+   The shim's "missing data → empty view" contract matches [Bar_panels]', so
+   the strategy's downstream callees see the same fallback semantics.
+
+   All four readers ([daily_bars_for], [weekly_bars_for], [weekly_view_for],
+   [daily_view_for]) are backed by [Snapshot_bar_views] helpers. The
+   bar-list readers are needed in production by [Stops_split_runner]
+   (split-event detection across the last two daily bars) and
+   [Entry_audit_capture] (effective entry close-price); the view readers
+   are needed by every panel-callback constructor. *)
+
+let _snapshot_weekly_view_for cb ~symbol ~n ~as_of =
+  Snapshot_bar_views.weekly_view_for cb ~symbol ~n ~as_of
+
+let _snapshot_daily_view_for cb ~symbol ~as_of ~lookback =
+  Snapshot_bar_views.daily_view_for cb ~symbol ~as_of ~lookback
+
+let _snapshot_daily_bars_for cb ~symbol ~as_of =
+  Snapshot_bar_views.daily_bars_for cb ~symbol ~as_of
+
+let _snapshot_weekly_bars_for cb ~symbol ~n ~as_of =
+  Snapshot_bar_views.weekly_bars_for cb ~symbol ~n ~as_of
+
+let of_snapshot_views (cb : Snapshot_runtime.Snapshot_callbacks.t) =
+  {
+    daily_bars_for = _snapshot_daily_bars_for cb;
+    weekly_bars_for = _snapshot_weekly_bars_for cb;
+    weekly_view_for = _snapshot_weekly_view_for cb;
+    daily_view_for = _snapshot_daily_view_for cb;
+    ma_cache = None;
+  }
+
+(* {1 Public read API — direct closure invocations} *)
+
+let daily_bars_for t = t.daily_bars_for
+let weekly_bars_for t = t.weekly_bars_for
+let weekly_view_for t = t.weekly_view_for
+let daily_view_for t = t.daily_view_for

--- a/trading/trading/weinstein/strategy/lib/bar_reader.mli
+++ b/trading/trading/weinstein/strategy/lib/bar_reader.mli
@@ -1,16 +1,27 @@
 (** Bar source abstraction for the Weinstein strategy.
 
-    Thin wrapper over {!Data_panel.Bar_panels} — the panel-backed reader that
-    reconstructs OHLCV bars on the fly from the underlying [Ohlcv_panels]
-    columns. The strategy reads daily / weekly bars through this interface,
-    keyed on the strategy's notion of "current date" (the date of the primary
-    index bar).
+    Backend-agnostic facade over the OHLCV bar reads the strategy needs (daily
+    bar lists, weekly aggregates, daily / weekly views). Two backings are
+    available:
+
+    - {!of_panels} — backed by {!Data_panel.Bar_panels}, the in-memory panel
+      reader populated up-front from CSV at runner start. The default for
+      pre-Phase-F.2 runs.
+    - {!of_snapshot_views} — backed by {!Snapshot_runtime.Snapshot_callbacks},
+      the LRU-bounded daily-snapshot reader that streams rows from per-symbol
+      [.snap] files on demand. Used by snapshot-mode runs (Phase F.2 PR 2),
+      which skip the {!Bar_panels.t} build entirely.
+
+    Internally [Bar_reader.t] is a record of closures; the constructors capture
+    their backing's read primitives and produce identical-shape closures, so the
+    strategy's downstream callees see one bar-reading API regardless of backing.
 
     Stage 3 PR 3.2 collapsed the dual-backend ([Bar_history] | [Bar_panels])
-    abstraction into a single panel-backed reader. The [Bar_reader.t] type
-    survives as a slim seam so callers and the strategy share one bar-reading
-    API; future backend swaps (e.g. live-mode streaming reads) can be added by
-    extending this module rather than every reader site. *)
+    abstraction into a single panel-backed reader. Phase F.2 PR 2 generalised
+    [t] to closure-based and re-introduced a second backing — but this time the
+    backings are purely an internal swap (no variant in [t], no per-call
+    dispatch) so callers can stay backend-agnostic and the hot-path remains a
+    direct closure invocation. *)
 
 open Core
 
@@ -28,6 +39,26 @@ val of_panels : ?ma_cache:Weekly_ma_cache.t -> Data_panel.Bar_panels.t -> t
     strategy's hot-path callees can fetch per-symbol MA values from the cache
     without threading a separate parameter through every helper. Populated
     lazily by {!Weekly_ma_cache.ma_values_for} on first access. *)
+
+val of_snapshot_views : Snapshot_runtime.Snapshot_callbacks.t -> t
+(** [of_snapshot_views cb] produces a reader backed by
+    {!Snapshot_runtime.Snapshot_bar_views} over [cb]. Reads fan out through
+    {!Snapshot_runtime.Snapshot_callbacks.read_field_history} (LRU-bounded via
+    {!Snapshot_runtime.Daily_panels}); per-call cost is O(window-size) plus an
+    at-most-one-symbol disk read on cache miss.
+
+    Returns the empty view / empty list under the same conditions as
+    {!of_panels}: unknown symbol, [as_of] before any resident snapshot row, or
+    any underlying field-read failure. The view types
+    ({!Data_panel.Bar_panels.weekly_view} / [daily_view]) are the same as those
+    returned by {!of_panels}, so {!Panel_callbacks} consumes either backing's
+    views without modification.
+
+    No [?ma_cache] parameter — the snapshot path does not currently use a
+    pre-computed weekly MA cache because {!Snapshot_runtime.Daily_panels} is
+    symbol-keyed (loading a symbol's full history on first access is cheap), so
+    MA recomputation per call is bounded. The cache hook can be revisited if the
+    snapshot hot path shows up in future profiles. *)
 
 val ma_cache : t -> Weekly_ma_cache.t option
 (** [ma_cache t] returns the cache the reader was constructed with, or [None]

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -8,6 +8,7 @@
   trading.base
   trading.data_panel
   trading.strategy
+  weinstein.snapshot_runtime
   weinstein.types
   weinstein_trading.stops
   weinstein_trading.portfolio_risk

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -609,7 +609,7 @@ let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
         }
 
 let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
-    ?(ticker_sectors = Hashtbl.create (module String)) ?bar_panels
+    ?(ticker_sectors = Hashtbl.create (module String)) ?bar_panels ?bar_reader
     ?(audit_recorder = Audit_recorder.noop) config =
   let stop_states = ref initial_stop_states in
   (* Per-symbol last stop-out date — feeds [Screener.screen_with_cooldown]
@@ -635,20 +635,28 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
      Friday so an exit firing before the first screen call gets a stable
      [Neutral / 0.0] snapshot. *)
   let prior_macro_result : Macro.result option ref = ref None in
-  (* Stage 4 PR-D: when bar_panels are present, also create a [Weekly_ma_cache]
+  (* Stage 4 PR-D: when bar_panels are present, create a [Weekly_ma_cache]
      scoped to this strategy and bundle it into the [Bar_reader]. The cache
      is read by [Panel_callbacks.stage_callbacks_of_weekly_view] (and
      transitively by Stock_analysis / Sector / Macro / Stops_runner) so
      per-symbol weekly MA values are computed once, not per Friday tick.
 
      The cache is opt-in (only when bar_panels are passed) so test
-     fixtures using [Bar_reader.empty ()] aren't affected. *)
+     fixtures using [Bar_reader.empty ()] aren't affected.
+
+     Phase F.2 PR 2: [bar_reader] is an alternate path used by snapshot-mode
+     runs that bypasses the [Bar_panels.t] allocation entirely. When
+     [bar_reader] is provided it takes precedence; otherwise fall back to
+     the [bar_panels]-or-empty branches above. *)
   let bar_reader =
-    match bar_panels with
-    | Some p ->
-        let ma_cache = Weekly_ma_cache.create p in
-        Bar_reader.of_panels ~ma_cache p
-    | None -> Bar_reader.empty ()
+    match bar_reader with
+    | Some r -> r
+    | None -> (
+        match bar_panels with
+        | Some p ->
+            let ma_cache = Weekly_ma_cache.create p in
+            Bar_reader.of_panels ~ma_cache p
+        | None -> Bar_reader.empty ())
   in
   let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -608,65 +608,57 @@ let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
             @ entry_transitions;
         }
 
+(* Resolve the strategy's [Bar_reader] from the optional [bar_panels] /
+   [bar_reader] inputs.
+
+   Phase F.2 PR 2: [bar_reader] takes precedence (snapshot-mode runs bypass
+   [Bar_panels.t] allocation entirely). Otherwise fall back to the
+   [bar_panels]-or-empty branches.
+
+   Stage 4 PR-D: when [bar_panels] is the chosen path, create a
+   [Weekly_ma_cache] scoped to this strategy and bundle it into the
+   [Bar_reader] so per-symbol weekly MA values are computed once, not per
+   Friday tick. Cache is opt-in: test fixtures using [Bar_reader.empty ()]
+   are unaffected. *)
+let _resolve_bar_reader ~bar_panels ~bar_reader =
+  match bar_reader with
+  | Some r -> r
+  | None -> (
+      match bar_panels with
+      | Some p ->
+          let ma_cache = Weekly_ma_cache.create p in
+          Bar_reader.of_panels ~ma_cache p
+      | None -> Bar_reader.empty ())
+
 let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
     ?(ticker_sectors = Hashtbl.create (module String)) ?bar_panels ?bar_reader
     ?(audit_recorder = Audit_recorder.noop) config =
   let stop_states = ref initial_stop_states in
-  (* Per-symbol last stop-out date — feeds [Screener.screen_with_cooldown]
-     for the cascade post-stop-out cooldown gate
-     ([cascade_post_stop_cooldown_weeks]). Mutated in place by
-     [_record_stop_outs] after each [Stops_runner.update] tick. Empty when
-     the strategy is constructed: an empty map is bit-equivalent to no
-     cooldown effect, so backtests / live runs that don't set the cooldown
-     knob continue to behave identically. *)
+  (* [last_stop_out_dates] feeds [Screener.screen_with_cooldown] for the
+     cascade post-stop-out cooldown gate. Mutated in place by
+     [_record_stop_outs] after each [Stops_runner.update] tick. Empty at
+     construction is bit-equivalent to no cooldown effect. *)
   let last_stop_out_dates : Date.t Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
   let prior_macro : Weinstein_types.market_trend ref =
     ref Weinstein_types.Neutral
   in
-  (* Force-liquidation peak tracker (G4). Lives in the strategy closure: each
-     [make] call yields an independent tracker so concurrent backtest /
-     paper / live instances don't pollute each other. The tracker is
-     observed every [_on_market_close] tick. *)
+  (* G4 force-liquidation peak tracker — per-strategy-instance state. *)
   let peak_tracker = Portfolio_risk.Force_liquidation.Peak_tracker.create () in
-  (* Cached full macro result for exit-time audit capture. Updated alongside
-     [prior_macro] inside [_run_screen]. Held as an option until the first
-     Friday so an exit firing before the first screen call gets a stable
+  (* Cached macro result for exit-time audit capture. Held as option until
+     first Friday so an exit firing before the first screen gets a stable
      [Neutral / 0.0] snapshot. *)
   let prior_macro_result : Macro.result option ref = ref None in
-  (* Stage 4 PR-D: when bar_panels are present, create a [Weekly_ma_cache]
-     scoped to this strategy and bundle it into the [Bar_reader]. The cache
-     is read by [Panel_callbacks.stage_callbacks_of_weekly_view] (and
-     transitively by Stock_analysis / Sector / Macro / Stops_runner) so
-     per-symbol weekly MA values are computed once, not per Friday tick.
-
-     The cache is opt-in (only when bar_panels are passed) so test
-     fixtures using [Bar_reader.empty ()] aren't affected.
-
-     Phase F.2 PR 2: [bar_reader] is an alternate path used by snapshot-mode
-     runs that bypasses the [Bar_panels.t] allocation entirely. When
-     [bar_reader] is provided it takes precedence; otherwise fall back to
-     the [bar_panels]-or-empty branches above. *)
-  let bar_reader =
-    match bar_reader with
-    | Some r -> r
-    | None -> (
-        match bar_panels with
-        | Some p ->
-            let ma_cache = Weekly_ma_cache.create p in
-            Bar_reader.of_panels ~ma_cache p
-        | None -> Bar_reader.empty ())
-  in
+  let bar_reader = _resolve_bar_reader ~bar_panels ~bar_reader in
   let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
   let sector_prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
-  (* Macro.analyze requires weekly-cadence ad_bars (see Macro.ad_bar's
-     cadence contract). Loaders like Ad_bars.Unicorn return daily bars, so
-     normalize once at load time — not on every on_market_close call. *)
+  (* Macro.analyze requires weekly-cadence ad_bars; normalize once at load
+     time, not on every [on_market_close] call. *)
   let weekly_ad_bars = Ad_bars_aggregation.daily_to_weekly ad_bars in
   let module M = struct
     let name = name

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -312,6 +312,7 @@ val make :
   ?ad_bars:Macro.ad_bar list ->
   ?ticker_sectors:(string, string) Hashtbl.t ->
   ?bar_panels:Data_panel.Bar_panels.t ->
+  ?bar_reader:Bar_reader.t ->
   ?audit_recorder:Audit_recorder.t ->
   config ->
   (module Trading_strategy.Strategy_interface.STRATEGY)
@@ -340,7 +341,14 @@ val make :
       When omitted, an empty reader is used — every read returns the empty list,
       which is sufficient for tests that exercise control paths where no
       panel-backed bar is ever consumed (empty universe, no held positions,
-      etc.). Production callers must always supply this.
+      etc.). Production callers must always supply this OR [bar_reader].
+    @param bar_reader
+      Optional pre-built {!Bar_reader.t}. When provided, takes precedence over
+      [bar_panels] — used by snapshot-mode runs (Phase F.2 PR 2) which build a
+      reader via {!Bar_reader.of_snapshot_views} instead of allocating a
+      {!Data_panel.Bar_panels.t}. The two parameters are mutually exclusive;
+      passing both is an unsupported combination (the strategy uses [bar_reader]
+      and ignores [bar_panels]).
     @param audit_recorder
       Optional callback bundle invoked at entry / exit decision sites
       ({!Audit_recorder.entry_event} / [exit_event]). When omitted defaults to


### PR DESCRIPTION
## Summary

Phase F.2 PR 2 of M5.3 (snapshot streaming pipeline). Wires snapshot mode through the Weinstein strategy's bar reads. When the runner is invoked with `Bar_data_source.Snapshot { ... }`, the strategy now reads OHLCV bars via `Bar_reader.of_snapshot_views` over `Snapshot_runtime.Snapshot_callbacks`, and the `Bar_panels.t` / `Ohlcv_panels.t` / `Indicator_panels.t` build is skipped entirely.

Default behaviour is unchanged: when `bar_data_source` is omitted (or set to `Csv`), the runner builds the panels and the strategy reads via `Bar_reader.of_panels` exactly as before.

## Why

`Bar_panels.t` allocates whole-universe × all-days bigarrays at runner startup. At N=5000 × ~10y the resident set is ~27 GB, which OOMs an 8 GB host. The snapshot path holds at most `max_cache_mb` of decoded snapshot rows at once — bounded RSS regardless of universe size. This PR is the unblock for the tier-4 release-gate at N>=5000.

Plan: see `dev/plans/snapshot-engine-phase-f-2026-05-03.md` (referenced from PR #796); this is PR 2 of 3 within Phase F.2.

## Decisions

**D1 — type unification (Decision 1a in dispatch).**
`Snapshot_bar_views.weekly_view` and `Snapshot_bar_views.daily_view` are now `type =` aliases for `Data_panel.Bar_panels.weekly_view` / `daily_view`. The strategy's `Panel_callbacks` constructors take `Bar_panels.weekly_view` directly; the type equality lets snapshot-backed views flow through unchanged. Adds a transitional `trading.data_panel` dep on `snapshot_runtime`. PR 3 (Phase F.3) deletes `Bar_panels` and hoists the record into a neutral location, removing the dep.

**D2 — closure-based `Bar_reader.t` (Decision 2b in dispatch).**
`Bar_reader.t` is now a record of closures rather than a struct of panels. `of_panels` and the new `of_snapshot_views` produce identical-shape closures; the public API is unchanged (`empty`, `daily_bars_for`, `weekly_bars_for`, `weekly_view_for`, `daily_view_for`, `ma_cache`). No variant dispatch on the hot path.

**Out-of-scope correction.** While wiring `daily_bars_for` for the snapshot path I noticed `Stops_split_runner` and `Entry_audit_capture` consume that surface in production. Returning `[]` would silently break split detection / entry audit. Added `Snapshot_bar_views.daily_bars_for` and `weekly_bars_for` (small additions; reuse the existing `_assemble_daily_bars` machinery). The `open_price` field is not surfaced today (NaN on the snapshot path); none of the in-tree consumers read `open_price`, so this is sound — documented in the `.mli`.

## Files

| File | Change |
|------|--------|
| `trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.{ml,mli}` | Type-equality with `Bar_panels`; add `daily_bars_for` / `weekly_bars_for`; share `_daily_bars_in_range` helper. |
| `trading/analysis/weinstein/snapshot_runtime/lib/dune` | Add `trading.data_panel` dep (transitional, PR 3 removes). |
| `trading/trading/weinstein/strategy/lib/bar_reader.{ml,mli}` | Closure-based `t`; new `of_snapshot_views` constructor. |
| `trading/trading/weinstein/strategy/lib/dune` | Add `weinstein.snapshot_runtime` dep. |
| `trading/trading/weinstein/strategy/lib/weinstein_strategy.{ml,mli}` | New optional `?bar_reader` parameter on `make`; takes precedence over `?bar_panels` when present. |
| `trading/trading/backtest/lib/panel_runner.{ml,mli}` | Branch on `Bar_data_source` selector; new `_setup_csv` / `_setup_snapshot` helpers; `_final_close_prices` split into per-mode variants. CSV path untouched. |
| `trading/trading/backtest/test/dune` | Add new test + deps. |
| `trading/trading/backtest/test/test_snapshot_mode_strategy_parity.ml` | NEW. Bit-equality parity test on `weekly_view` / `daily_view` and field-equality on `daily_bars_for` (excluding `open_price`). |

LOC: 12 files, +779 / -166 (net +613).

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` clean for `analysis/weinstein/snapshot_runtime/`, `trading/weinstein/strategy/`, `trading/backtest/test/`
- [x] New `test_snapshot_mode_strategy_parity` — 4 cases pass (weekly view bit-equal, daily view bit-equal, daily bar list consumer-fields equal, missing returns empty in both)
- [x] No new formatter drift on the touched files (`dune build @fmt` shows no diff for any file in this PR's diff)
- [x] A2 dependency boundary: `analysis/weinstein/snapshot_runtime` -> `trading/trading/weinstein/strategy/` is consistent with established practice (the strategy already imports six other `weinstein.*` libs)
- [ ] Tier-4 RSS validation: deferred to a follow-up scenario run against the canonical sp500 fixture under `--snapshot-mode`. The unit-level parity is pinned here; tier-4 wall-clock + RSS observation belongs in a separate experiment PR per the Phase F.2 plan.

## Default behaviour unchanged

The CSV path through `Panel_runner.run` is byte-identical to pre-PR — no edits to `_build_ohlcv`, `_build_indicators`, `Bar_panels.create`, `_build_strategy`, `_make_simulator`'s CSV inputs, or `_final_close_prices_csv`. The only code paths that change for default callers are the wrapper level (`run` now dispatches on `bar_data_source`); same allocation, same call sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)