### PR TITLE
feat(snapshot): F.2 PR 3 — default-flip snapshot mode + --csv-mode opt-out

### DIFF
--- a/trading/trading/backtest/runner_args/backtest_runner_args.ml
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.ml
@@ -29,12 +29,15 @@ type acc = {
   fuzz_spec : string option;
   fuzz_window : string option;
   snapshot_mode : bool;
+  csv_mode : bool;
   snapshot_dir : string option;
 }
 (** Accumulator for [_extract_flags]. Carries every flag the parser recognises
-    plus the running list of positional args. The [snapshot_mode] /
-    [snapshot_dir] split exists so we can validate at parse time that the two
-    flags appear together (see [_validate_snapshot_flags]). *)
+    plus the running list of positional args. Snapshot mode is the default since
+    F.2 PR 3; [csv_mode] tracks explicit [--csv-mode] opt-outs. The legacy
+    [--snapshot-mode] flag is still accepted (no-op) — see
+    [_validate_snapshot_flags] for the full mutual-exclusion + required-dir
+    rules. *)
 
 let _empty_acc =
   {
@@ -50,6 +53,7 @@ let _empty_acc =
     fuzz_spec = None;
     fuzz_window = None;
     snapshot_mode = false;
+    csv_mode = false;
     snapshot_dir = None;
   }
 
@@ -94,6 +98,7 @@ let rec _extract_flags args (acc : acc) =
   | [ "--fuzz-window" ] -> _err "--fuzz-window requires a name argument"
   | "--snapshot-mode" :: rest ->
       _extract_flags rest { acc with snapshot_mode = true }
+  | "--csv-mode" :: rest -> _extract_flags rest { acc with csv_mode = true }
   | "--snapshot-dir" :: value :: rest ->
       _extract_flags rest { acc with snapshot_dir = Some value }
   | [ "--snapshot-dir" ] -> _err "--snapshot-dir requires a path argument"
@@ -152,14 +157,35 @@ let _validate_fuzz_window_requires_fuzz ~fuzz_window ~fuzz_spec =
   | Some _, None -> _err "--fuzz-window requires --fuzz"
   | _ -> Ok ()
 
-(** [--snapshot-mode] and [--snapshot-dir <path>] must appear together. Either
-    alone is a likely user error: [--snapshot-mode] without a path has no way to
-    find snapshots; [--snapshot-dir] without [--snapshot-mode] silently drops
-    the flag in favour of CSV mode. *)
-let _validate_snapshot_flags ~snapshot_mode ~snapshot_dir =
-  match (snapshot_mode, snapshot_dir) with
-  | true, None -> _err "--snapshot-mode requires --snapshot-dir <path>"
-  | false, Some _ -> _err "--snapshot-dir requires --snapshot-mode"
+(** Snapshot mode is the default since F.2 PR 3. The flag matrix:
+
+    - Default (no mode flag): snapshot mode is on; [--snapshot-dir <path>] is
+      required so the runner has a manifest to read.
+    - [--snapshot-mode]: legacy explicit opt-in, still accepted as a no-op so
+      existing callers keep working. Same rules as the default.
+    - [--csv-mode]: explicit opt-out onto the legacy CSV path; [--snapshot-dir]
+      is meaningless here.
+
+    Three error conditions:
+
+    - [--snapshot-mode] AND [--csv-mode] are mutually exclusive (the user has
+      contradicted themselves).
+    - [--csv-mode] AND [--snapshot-dir <path>] together — the path would be
+      silently dropped, surface that as a parse-time error.
+    - Snapshot mode (default or explicit) without [--snapshot-dir] — the runner
+      has no way to find the manifest. *)
+let _validate_snapshot_flags ~snapshot_mode ~csv_mode ~snapshot_dir =
+  match (snapshot_mode, csv_mode, snapshot_dir) with
+  | true, true, _ ->
+      _err "--snapshot-mode and --csv-mode are mutually exclusive"
+  | false, true, Some _ ->
+      _err
+        "--snapshot-dir is meaningless with --csv-mode (CSV path has no \
+         manifest)"
+  | _, false, None ->
+      _err
+        "snapshot mode is the default; pass --snapshot-dir <path> or use \
+         --csv-mode to opt out onto the legacy CSV path"
   | _ -> Ok ()
 
 let _build_result (acc : acc) (start_date, end_date) =
@@ -195,7 +221,8 @@ let parse args =
                 ~f:(fun () ->
                   Result.bind
                     (_validate_snapshot_flags ~snapshot_mode:acc.snapshot_mode
-                       ~snapshot_dir:acc.snapshot_dir) ~f:(fun () ->
+                       ~csv_mode:acc.csv_mode ~snapshot_dir:acc.snapshot_dir)
+                    ~f:(fun () ->
                       Result.bind
                         (_split_positional ~smoke:acc.smoke
                            ~fuzz_spec:acc.fuzz_spec acc.positional)

--- a/trading/trading/backtest/runner_args/backtest_runner_args.mli
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.mli
@@ -86,18 +86,22 @@ type t = {
 
           Validated at parse time: [--fuzz-window] requires [--fuzz]. *)
   snapshot_dir : string option;
-      (** [Some path] when [--snapshot-mode --snapshot-dir <path>] was passed
-          (both flags are required together): the simulator's per-tick OHLCV
+      (** [Some path] when snapshot mode is selected (the runner's default since
+          F.2 PR 3 — see [dev/plans/snapshot-engine-phase-f-2026-05-03.md]) and
+          [--snapshot-dir <path>] was passed: the simulator's per-tick OHLCV
           reads come from the snapshot directory at [path] instead of the CSV
           [data_dir]. The runner reads [<path>/manifest.sexp] and constructs a
           [Backtest.Bar_data_source.Snapshot {snapshot_dir; manifest}] which is
           forwarded into [Backtest.Runner.run_backtest ~bar_data_source:_].
-          Default [None] (CSV mode — pre-Phase-D behaviour). Phase D wiring; see
-          [dev/plans/snapshot-engine-phase-d-2026-05-02.md].
+
+          [None] when [--csv-mode] was passed (the explicit opt-out): the runner
+          stays on the legacy CSV [data_dir] code path. CSV mode is retained as
+          a fallback in F.2 and will be retired in F.3.
 
           The snapshot directory must be pre-built via the Phase B writer
           ([analysis/scripts/build_snapshots/build_snapshots.exe]); the backtest
           runner will fail loudly if the manifest is missing or schema-skewed.
+          (Auto-build of the snapshot directory is deferred to a follow-up PR.)
       *)
 }
 (** Result of parsing the [backtest_runner.exe] command line. *)
@@ -109,8 +113,15 @@ val parse : string list -> t Status.status_or
     Returns [Error status] (with [Status.code = Invalid_argument]) on any
     parsing problem (missing flag value, missing required positional, too many
     positionals, [--baseline]/[--smoke]/[--fuzz] without [--experiment-name],
-    [--fuzz] combined with [--baseline] or [--smoke], or [--fuzz-window] without
-    [--fuzz]).
+    [--fuzz] combined with [--baseline] or [--smoke], [--fuzz-window] without
+    [--fuzz], [--snapshot-mode] combined with [--csv-mode], [--csv-mode]
+    combined with [--snapshot-dir], or snapshot mode (the default, or explicit
+    [--snapshot-mode]) without [--snapshot-dir]).
+
+    Snapshot mode is the default since F.2 PR 3. Pass [--csv-mode] to opt out
+    onto the legacy CSV path. The legacy [--snapshot-mode] flag is still
+    accepted (no-op when paired with [--snapshot-dir]) so existing callers keep
+    working.
 
     Override strings are NOT validated here — the executable runs them through
     [Backtest.Config_override.parse] / [Sexp.of_string] downstream and surfaces

--- a/trading/trading/backtest/test/test_backtest_runner_args.ml
+++ b/trading/trading/backtest/test/test_backtest_runner_args.ml
@@ -7,14 +7,27 @@
 
     After Stage 3 PR 3.4 of the columnar data-shape redesign deleted the
     [Loader_strategy] enum + the [--loader-strategy] CLI flag, only the flags
-    surviving on the panel-only path are pinned here. *)
+    surviving on the panel-only path are pinned here.
+
+    Since F.2 PR 3 (snapshot mode is the default; see
+    [dev/plans/snapshot-engine-phase-f-2026-05-03.md]), every successful parse
+    must specify a mode: either [--snapshot-dir <path>] (snapshot, the default)
+    or [--csv-mode] (the explicit opt-out). Tests that pin orthogonal flags
+    (overrides, fuzz, baseline, smoke, trace, memtrace, gc-trace, etc.) prepend
+    [--csv-mode] via the [_parse_csv] helper so the flag-parsing assertions
+    aren't entangled with snapshot validation. *)
 
 open OUnit2
 open Core
 open Matchers
 
+(** Parse with [--csv-mode] prepended. Use in tests that pin flag-parsing
+    behaviour orthogonal to snapshot mode — the explicit opt-out keeps the parse
+    Ok without forcing every test to fabricate a [--snapshot-dir] path. *)
+let _parse_csv args = Backtest_runner_args.parse ("--csv-mode" :: args)
+
 let test_minimal_start_date_only _ =
-  let result = Backtest_runner_args.parse [ "2018-01-02" ] in
+  let result = _parse_csv [ "2018-01-02" ] in
   assert_that result
     (is_ok_and_holds
        (all_of
@@ -60,7 +73,7 @@ let test_override_key_path_form _ =
   (* The new key.path=value form is stored verbatim — interpretation is the
      executable's job. *)
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [ "2018-01-02"; "--override"; "stops_config.initial_stop_buffer=1.05" ]
   in
   assert_that result
@@ -72,8 +85,7 @@ let test_override_key_path_form _ =
 let test_override_legacy_sexp_form _ =
   (* Backward compatibility: pre-existing scripts pass full sexp blobs. *)
   let result =
-    Backtest_runner_args.parse
-      [ "2018-01-02"; "--override"; "((initial_stop_buffer 1.08))" ]
+    _parse_csv [ "2018-01-02"; "--override"; "((initial_stop_buffer 1.08))" ]
   in
   assert_that result
     (is_ok_and_holds
@@ -83,7 +95,7 @@ let test_override_legacy_sexp_form _ =
 
 let test_override_can_repeat _ =
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "2018-01-02";
         "--override";
@@ -104,7 +116,7 @@ let test_override_can_repeat _ =
 
 let test_baseline_flag _ =
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [ "2018-01-02"; "--baseline"; "--experiment-name"; "stop_buffer_test" ]
   in
   assert_that result
@@ -125,8 +137,7 @@ let test_baseline_without_experiment_name_is_error _ =
 
 let test_smoke_flag _ =
   let result =
-    Backtest_runner_args.parse
-      [ "--smoke"; "--experiment-name"; "stop_buffer_smoke" ]
+    _parse_csv [ "--smoke"; "--experiment-name"; "stop_buffer_smoke" ]
   in
   assert_that result
     (is_ok_and_holds
@@ -148,10 +159,7 @@ let test_smoke_without_experiment_name_is_error _ =
 let test_experiment_name_alone_is_allowed _ =
   (* --experiment-name without --baseline / --smoke just renames the output
      dir; both can be combined freely. *)
-  let result =
-    Backtest_runner_args.parse
-      [ "2018-01-02"; "--experiment-name"; "manual_run" ]
-  in
+  let result = _parse_csv [ "2018-01-02"; "--experiment-name"; "manual_run" ] in
   assert_that result
     (is_ok_and_holds
        (field
@@ -170,7 +178,7 @@ let test_experiment_name_missing_value_is_error _ =
     main is responsible for the per-mode merge. Repeatable. *)
 let test_shared_override_can_repeat _ =
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "2018-01-02";
         "--shared-override";
@@ -202,7 +210,7 @@ let test_shared_override_missing_value _ =
     decides how to dispatch them per mode (single, baseline, smoke). *)
 let test_shared_override_composes_with_override _ =
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "2018-01-02";
         "--shared-override";
@@ -225,7 +233,7 @@ let test_shared_override_composes_with_override _ =
 
 let test_fuzz_flag _ =
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "2019-05-01";
         "--fuzz";
@@ -264,7 +272,7 @@ let test_fuzz_without_value_is_error _ =
 
 let test_fuzz_no_positional_uses_sentinel _ =
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "--fuzz";
         "start_date=2019-05-01\xC2\xB15w:3";
@@ -303,7 +311,7 @@ let test_fuzz_window_with_fuzz _ =
   (* --fuzz-window composes with --fuzz to constrain the per-variant universe
      to a smoke-catalog window's universe_path (sp500 by default). *)
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "2020-04-30";
         "--fuzz";
@@ -343,7 +351,7 @@ let test_fuzz_window_missing_value _ =
 let test_fuzz_with_overrides_composes _ =
   (* --fuzz composes with --override (overrides apply to every variant). *)
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "2019-05-01";
         "--fuzz";
@@ -369,7 +377,7 @@ let test_fuzz_with_overrides_composes _ =
 
 let test_baseline_and_smoke_compose _ =
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "--smoke";
         "--baseline";
@@ -393,7 +401,7 @@ let test_baseline_and_smoke_compose _ =
           ]))
 
 let test_start_and_end_date _ =
-  let result = Backtest_runner_args.parse [ "2018-01-02"; "2019-12-31" ] in
+  let result = _parse_csv [ "2018-01-02"; "2019-12-31" ] in
   assert_that result
     (is_ok_and_holds
        (all_of
@@ -407,9 +415,7 @@ let test_start_and_end_date _ =
           ]))
 
 let test_trace_flag _ =
-  let result =
-    Backtest_runner_args.parse [ "2018-01-02"; "--trace"; "/tmp/run.sexp" ]
-  in
+  let result = _parse_csv [ "2018-01-02"; "--trace"; "/tmp/run.sexp" ] in
   assert_that result
     (is_ok_and_holds
        (field
@@ -417,7 +423,7 @@ let test_trace_flag _ =
           (equal_to (Some "/tmp/run.sexp"))))
 
 let test_trace_default_is_none _ =
-  let result = Backtest_runner_args.parse [ "2018-01-02" ] in
+  let result = _parse_csv [ "2018-01-02" ] in
   assert_that result
     (is_ok_and_holds
        (field
@@ -428,7 +434,7 @@ let test_trace_with_other_flags _ =
   (* Verify that --trace composes with --override and end_date in a single
      command. Order should not matter. *)
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "2018-01-02";
         "2019-12-31";
@@ -460,8 +466,7 @@ let test_trace_missing_value _ =
 
 let test_memtrace_flag _ =
   let result =
-    Backtest_runner_args.parse
-      [ "2018-01-02"; "--memtrace"; "/tmp/run.memtrace.ctf" ]
+    _parse_csv [ "2018-01-02"; "--memtrace"; "/tmp/run.memtrace.ctf" ]
   in
   assert_that result
     (is_ok_and_holds
@@ -470,7 +475,7 @@ let test_memtrace_flag _ =
           (equal_to (Some "/tmp/run.memtrace.ctf"))))
 
 let test_memtrace_default_is_none _ =
-  let result = Backtest_runner_args.parse [ "2018-01-02" ] in
+  let result = _parse_csv [ "2018-01-02" ] in
   assert_that result
     (is_ok_and_holds
        (field
@@ -483,7 +488,7 @@ let test_memtrace_with_other_flags _ =
      (--trace) and per-callsite allocation traces (--memtrace) in one run for
      cross-correlation. *)
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "2018-01-02";
         "2019-12-31";
@@ -519,9 +524,7 @@ let test_memtrace_missing_value _ =
   assert_that result is_error
 
 let test_gc_trace_flag _ =
-  let result =
-    Backtest_runner_args.parse [ "2018-01-02"; "--gc-trace"; "/tmp/gc.csv" ]
-  in
+  let result = _parse_csv [ "2018-01-02"; "--gc-trace"; "/tmp/gc.csv" ] in
   assert_that result
     (is_ok_and_holds
        (field
@@ -529,7 +532,7 @@ let test_gc_trace_flag _ =
           (equal_to (Some "/tmp/gc.csv"))))
 
 let test_gc_trace_default_is_none _ =
-  let result = Backtest_runner_args.parse [ "2018-01-02" ] in
+  let result = _parse_csv [ "2018-01-02" ] in
   assert_that result
     (is_ok_and_holds
        (field
@@ -542,7 +545,7 @@ let test_gc_trace_with_other_flags _ =
      traces (--trace), per-callsite allocation traces (--memtrace), and GC
      phase-boundary snapshots (--gc-trace) in one run for cross-correlation. *)
   let result =
-    Backtest_runner_args.parse
+    _parse_csv
       [
         "2018-01-02";
         "2019-12-31";
@@ -627,7 +630,64 @@ let test_trace_write_and_parse _ =
            (equal_to Backtest.Trace.Phase.Teardown);
        ])
 
-let test_snapshot_mode_with_dir _ =
+(** Since F.2 PR 3, snapshot mode is the runner's default — passing
+    [--snapshot-dir <path>] alone (no mode flag) is the canonical invocation and
+    parses to a [Snapshot] selector. *)
+let test_default_is_snapshot_mode_with_dir _ =
+  let result =
+    Backtest_runner_args.parse
+      [ "2018-01-02"; "--snapshot-dir"; "/tmp/snapshots/v1" ]
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (a : Backtest_runner_args.t) -> a.snapshot_dir)
+          (equal_to (Some "/tmp/snapshots/v1"))))
+
+(** Default mode (snapshot) requires [--snapshot-dir] — the runner has no way to
+    find a manifest otherwise. Surface the missing flag at parse time rather
+    than letting the runner fail later. *)
+let test_default_requires_snapshot_dir _ =
+  let result = Backtest_runner_args.parse [ "2018-01-02" ] in
+  assert_that result is_error
+
+(** [--csv-mode] is the explicit opt-out onto the legacy CSV [data_dir] code
+    path. CSV mode parses to [snapshot_dir = None] regardless of whether the
+    user passed [--snapshot-dir] (combining the two is rejected — see below). *)
+let test_csv_mode_opt_out _ =
+  let result = Backtest_runner_args.parse [ "2018-01-02"; "--csv-mode" ] in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (a : Backtest_runner_args.t) -> a.snapshot_dir)
+          (equal_to None)))
+
+(** [--csv-mode] + [--snapshot-dir <path>] is rejected — the path would be
+    silently dropped, which is a likely user error worth surfacing at parse
+    time. *)
+let test_csv_mode_with_snapshot_dir_errors _ =
+  let result =
+    Backtest_runner_args.parse
+      [ "2018-01-02"; "--csv-mode"; "--snapshot-dir"; "/tmp/snapshots/v1" ]
+  in
+  assert_that result is_error
+
+(** [--snapshot-mode] (legacy, no-op since F.2 PR 3) and [--csv-mode] are
+    mutually exclusive: passing both means the user has contradicted themselves.
+*)
+let test_snapshot_mode_and_csv_mode_mutually_exclusive _ =
+  let result =
+    Backtest_runner_args.parse [ "2018-01-02"; "--snapshot-mode"; "--csv-mode" ]
+  in
+  assert_that result is_error
+
+(** Backward compatibility: existing callers with
+    [--snapshot-mode --snapshot-dir <path>] continue to parse to a [Snapshot]
+    selector exactly as before. The legacy [--snapshot-mode] flag is now a
+    documented no-op (snapshot mode is the default), but the runner does not
+    reject the flag — that would break in-tree scenario / fuzz scripts and CI
+    invocations landed before F.2 PR 3. *)
+let test_legacy_snapshot_mode_flag_still_accepted _ =
   let result =
     Backtest_runner_args.parse
       [ "2018-01-02"; "--snapshot-mode"; "--snapshot-dir"; "/tmp/snapshots/v1" ]
@@ -641,17 +701,8 @@ let test_snapshot_mode_with_dir _ =
 let test_snapshot_mode_without_dir_is_error _ =
   (* --snapshot-mode without --snapshot-dir has no way to find the manifest;
      we surface this at parse time rather than failing later inside the
-     runner. *)
+     runner. (Same rule applies under the default since F.2 PR 3.) *)
   let result = Backtest_runner_args.parse [ "2018-01-02"; "--snapshot-mode" ] in
-  assert_that result is_error
-
-let test_snapshot_dir_without_mode_is_error _ =
-  (* --snapshot-dir without --snapshot-mode would silently fall back to CSV
-     mode and ignore the path; surface that as an error so the user notices. *)
-  let result =
-    Backtest_runner_args.parse
-      [ "2018-01-02"; "--snapshot-dir"; "/tmp/snapshots/v1" ]
-  in
   assert_that result is_error
 
 let test_snapshot_dir_missing_value _ =
@@ -750,12 +801,20 @@ let suite =
          >:: test_fuzz_window_without_fuzz_is_error;
          "--fuzz-window without value is error"
          >:: test_fuzz_window_missing_value;
-         "--snapshot-mode + --snapshot-dir compose"
-         >:: test_snapshot_mode_with_dir;
+         "default mode (no flag) + --snapshot-dir parses to Snapshot"
+         >:: test_default_is_snapshot_mode_with_dir;
+         "default mode (no flag) without --snapshot-dir is error"
+         >:: test_default_requires_snapshot_dir;
+         "--csv-mode opts out onto the legacy CSV path"
+         >:: test_csv_mode_opt_out;
+         "--csv-mode + --snapshot-dir is error"
+         >:: test_csv_mode_with_snapshot_dir_errors;
+         "--snapshot-mode + --csv-mode are mutually exclusive"
+         >:: test_snapshot_mode_and_csv_mode_mutually_exclusive;
+         "legacy --snapshot-mode + --snapshot-dir still accepted (no-op)"
+         >:: test_legacy_snapshot_mode_flag_still_accepted;
          "--snapshot-mode without --snapshot-dir is error"
          >:: test_snapshot_mode_without_dir_is_error;
-         "--snapshot-dir without --snapshot-mode is error"
-         >:: test_snapshot_dir_without_mode_is_error;
          "--snapshot-dir without value is error"
          >:: test_snapshot_dir_missing_value;
          "--snapshot-mode composes with --fuzz" >:: test_snapshot_mode_with_fuzz;


### PR DESCRIPTION
## Summary

PR 3 of M5.3 Phase F.2: flip the runner's default to snapshot mode and add an explicit `--csv-mode` opt-out flag. Snapshot mode now activates without `--snapshot-mode`; the legacy flag is still accepted (no-op) so existing callers keep working.

## Why

Per `dev/plans/snapshot-engine-phase-f-2026-05-03.md` §F.2 (PR #796). Snapshot mode is now end-to-end wired:
- Phase D (#790): simulator per-tick reads
- F.2 PR 1 (#797): `Snapshot_bar_views` shim
- F.2 PR 2 (#800): strategy bar reads via `Bar_reader.of_snapshot_views`

Default-flipping unblocks the tier-4 release-gate at N≥5000 by skipping `Bar_panels.t` allocation. CSV mode is retained as a fallback in F.2 and will be retired in F.3.

## Decisions

**Decision 1 — flag shape.** Default = snapshot mode. Mode flags:
- No flag: snapshot mode (default since this PR); requires `--snapshot-dir <path>`.
- `--snapshot-mode`: legacy explicit opt-in, accepted as a no-op so existing callers keep working.
- `--csv-mode`: explicit opt-out onto the legacy CSV path.

Three error conditions:
- `--snapshot-mode` AND `--csv-mode` are mutually exclusive.
- `--csv-mode` + `--snapshot-dir <path>` is rejected (the path would be silently dropped).
- Snapshot mode (default or explicit) without `--snapshot-dir` errors with a clear message guiding the user to either pass the path or opt out via `--csv-mode`.

**Decision 2 — backward compatibility.** Existing scenarios / fuzz catalogs / CI scripts that pass `--snapshot-mode --snapshot-dir <path>` keep working unchanged. The wired-in `#798` fuzz invocations and the `test_snapshot_mode_with_fuzz` / `test_legacy_snapshot_mode_flag_still_accepted` tests confirm this.

## Files

- `trading/trading/backtest/runner_args/backtest_runner_args.{ml,mli}`: added `--csv-mode` flag; rewrote `_validate_snapshot_flags` for the new matrix; updated docstrings.
- `trading/trading/backtest/test/test_backtest_runner_args.ml`: added `_parse_csv` helper to keep orthogonal flag-parsing tests untangled from snapshot validation; added 5 new tests covering the default-flip + opt-out + mutual-exclusion + legacy-no-op behaviours; replaced `test_snapshot_dir_without_mode_is_error` (no longer applicable — `--snapshot-dir` alone is now the canonical default invocation) with `test_default_is_snapshot_mode_with_dir`.

## Out of scope (deferred)

**Auto-build of `--snapshot-dir`** — deferred to a follow-up PR (3b). When the user passes a snapshot path that doesn't exist yet, the runner should auto-build it via the Phase B writer rather than failing loudly. This PR keeps the F.2-level "fail loudly if manifest is missing" behaviour.

## Test plan

- [x] `dune build` clean (full project)
- [x] `dune runtest trading/trading/backtest/` passes — all 24 backtest test suites green; `test_backtest_runner_args.exe` reports 49 tests / OK (was 45 before; net +4 = +5 new tests, -1 obsolete test).
- [x] New tests cover:
  - `test_default_is_snapshot_mode_with_dir`: no mode flag + `--snapshot-dir <path>` parses to Snapshot.
  - `test_default_requires_snapshot_dir`: no mode flag + no `--snapshot-dir` errors.
  - `test_csv_mode_opt_out`: `--csv-mode` parses to `snapshot_dir = None`.
  - `test_csv_mode_with_snapshot_dir_errors`: `--csv-mode --snapshot-dir <p>` errors.
  - `test_snapshot_mode_and_csv_mode_mutually_exclusive`: both flags errors.
  - `test_legacy_snapshot_mode_flag_still_accepted`: `--snapshot-mode --snapshot-dir <p>` parses to Snapshot (back-compat pin).
- [x] `dune build @trading/trading/backtest/runner_args/fmt @trading/trading/backtest/test/fmt` clean.
- [x] Diff stays inside the runner_args lib + its test file; no boundary changes (A2/A3 clean).
- [x] LOC: 233 / 300 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
