### PR TITLE
ops(data): close sp500 12-missing data-gap (refresh universe sexp)

### DIFF
--- a/dev/notes/data-gaps.md
+++ b/dev/notes/data-gaps.md
@@ -1,6 +1,6 @@
 # Data Gaps — features blocked on missing data
 
-Last updated: 2026-04-14 (ADL source validation complete; sector ETF bars refreshed)
+Last updated: 2026-05-03 (sp500 universe coverage gap resolved; ADL source validation complete; sector ETF bars refreshed)
 
 ## A-D Breadth (ADL)
 
@@ -97,36 +97,41 @@ Probe scripts under `dev/scripts/probes/`. Full writeup in `dev/notes/adl-valida
 
 ## sp500 Universe Coverage — 12 Missing Symbols
 
-**Status**: Open (filed 2026-05-03; recurrence is structural, not one-off)
-**Blocks**: Nothing critical — the 491 symbols in `trading/test_data/backtest_scenarios/universes/sp500.sexp` are sufficient for current goldens. The 12 missing are recent additions or delistings without downloaded history.
-**Affects**: `goldens-sp500/` scenarios (slight under-coverage, pinned at generation time so reproducibility is preserved); future Wiki+EODHD replay (`dev/plans/wiki-eodhd-historical-universe-2026-05-03.md`) inherits the same pattern.
+**Status**: RESOLVED (2026-05-03)
+**Blocks**: Nothing critical — resolved. `sp500.sexp` now has all 503 symbols.
+**Affects**: `goldens-sp500/` scenarios — coverage now complete.
 
 ### Background
 
-S&P 500 actually has **503 securities** (5 dual-class: GOOG/GOOGL, NWSA/NWS, FOXA/FOX, BRK.A/BRK.B, etc). Today's `sp500.sexp` has 491 — i.e. 12 of 503 are not in our local CSV cache. Header comment on the file already notes this.
+S&P 500 actually has **503 securities** (5 dual-class: GOOG/GOOGL, NWSA/NWS, FOXA/FOX, BRK.A/BRK.B, etc). The original `sp500.sexp` had 491 — the 12 missing were already in the local bar-data cache but were dropped by the original join due to two issues:
+1. Single-letter symbols (A, C, D, F, J, L, O, Q, T, V) — the original regex `\w+` stopped at word boundaries and dropped single-char matches.
+2. Dot-notation symbols (BF.B, BRK.B) — the original join compared sp500.csv dot-form against inventory dash-form (BF-B, BRK-B) without normalisation.
 
-### Resolution
+No new data fetches were required. All 12 symbols had full bar history in the local cache.
 
-**ops-data dispatch**:
-1. Re-run the join script that produced `sp500.sexp` (currently inline; should be extracted to `dev/scripts/build_sp500_universe.sh` per the file's TODO).
-2. Identify the 12 symbols missing from the local cache.
-3. Fetch via `analysis/scripts/fetch_symbols.exe -- --symbols <comma-list>`.
-4. Rebuild inventory via `analysis/scripts/build_inventory/build_inventory.exe`.
-5. Regenerate `sp500.sexp` (now 503 symbols).
-6. Update this entry to **RESOLVED** with resolution date.
+### Resolution (2026-05-03)
 
-**Estimated effort**: ~30 min ops-data dispatch (mostly fetch wall + golden regen).
+1. Identified the 12 missing symbols: A, BF-B, BRK-B, C, D, F, J, L, O, Q, T, V.
+2. All 12 confirmed present in `data/inventory.sexp` with bar history.
+3. Extracted join logic into `dev/scripts/build_sp500_universe.sh` (closes the TODO in the original sp500.sexp header comment). The script handles:
+   - Single-letter tickers
+   - Dot-to-dash normalisation (BF.B → BF-B, BRK.B → BRK-B)
+   - Quoted CSV fields with embedded commas in Security names (e.g. "F5, Inc.", "Tapestry, Inc.") using sector-name scanning instead of fixed field indexing
+4. Ran `dev/scripts/build_sp500_universe.sh` — output: 503 / 503 symbols.
+5. `sp500.sexp` regenerated from 491 → 503 symbols.
+
+Symbols added: A (Health Care), BF-B (Consumer Staples), BRK-B (Financials), C (Financials), D (Utilities), F (Consumer Discretionary), J (Industrials), L (Financials), O (Real Estate), Q (Information Technology), T (Communication Services), V (Financials).
 
 ### Recurrence pattern (structural, not one-off)
 
 The same gap reappears at any historical date — when Wiki+EODHD replay (PR-A/B/C of `wiki-eodhd-historical-universe-2026-05-03.md`) lands and emits historical-date universe sexps, each will reference symbols not in the local cache (delisted issues, recent IPOs).
 
-Plan locks the fix into PR-C: `build_universe.exe --fetch-prices` auto-fetches on cache miss, closing the gap at construction time. **ops-data is not the routine resolver** for replay-driven universes — the build CLI itself fetches. ops-data still owns gap-by-symbol resolution for static `sp500.sexp` regeneration.
+Plan locks the fix into PR-C: `build_universe.exe --fetch-prices` auto-fetches on cache miss, closing the gap at construction time. **ops-data is not the routine resolver** for replay-driven universes — the build CLI itself fetches. `dev/scripts/build_sp500_universe.sh` is the tool for static `sp500.sexp` regeneration.
 
-### What's needed
+### What's needed going forward
 
-- **ops-data**: extract `dev/scripts/build_sp500_universe.sh` from inline join logic; fetch the 12 missing; regenerate `sp500.sexp`. Independent task — not blocked.
 - **feat-data** (downstream): build_universe.exe in PR-C (Wiki+EODHD plan) replicates this pattern with `--fetch-prices` auto-fetch.
+- **ops-data** (maintenance): re-run `dev/scripts/build_sp500_universe.sh` whenever `data/sp500.csv` is updated (S&P 500 adds/removes).
 
 ---
 

--- a/dev/scripts/build_sp500_universe.sh
+++ b/dev/scripts/build_sp500_universe.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# build_sp500_universe.sh — join data/sp500.csv against the local bar-data
+# inventory and emit trading/test_data/backtest_scenarios/universes/sp500.sexp.
+#
+# Selection logic:
+#   1. Read data/sp500.csv (Symbol, Security, GICS Sector, ...) — 503 rows.
+#   2. Normalise ticker symbols: replace "." with "-" (EODHD convention:
+#      BF.B -> BF-B, BRK.B -> BRK-B).
+#   3. Read data/inventory.sexp to build the set of symbols with cached bars.
+#   4. Inner-join sp500 symbols against the inventory; emit only symbols that
+#      have bar data.  Document any misses in the header comment.
+#   5. Sort alphabetically by normalised symbol; emit Pinned sexp with sector.
+#
+# Output: writes the Pinned sexp to $OUT (default:
+#   trading/test_data/backtest_scenarios/universes/sp500.sexp).
+#   Pass a path argument to redirect elsewhere.
+#
+# Notes on symbol normalisation:
+#   EODHD (and this repo's data/ cache) converts dots in ticker symbols to
+#   dashes.  sp500.csv uses the exchange-native form (with dots).  This script
+#   normalises for the join, but the sexp is written with the EODHD form so
+#   that the backtest data loader can resolve CSV paths directly.
+#
+# Typical usage:
+#   bash dev/scripts/build_sp500_universe.sh
+#   bash dev/scripts/build_sp500_universe.sh /tmp/sp500-test.sexp
+#
+# To refresh after fetching new symbols:
+#   dev/lib/run-in-env.sh ./_build/default/trading/analysis/scripts/build_inventory/build_inventory.exe \
+#     --data-dir /workspaces/trading-1/data
+#   bash dev/scripts/build_sp500_universe.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+DATA_DIR="${TRADING_DATA_DIR:-${REPO_ROOT}/data}"
+SP500_CSV="${DATA_DIR}/sp500.csv"
+INVENTORY_SEXP="${DATA_DIR}/inventory.sexp"
+OUT="${1:-${REPO_ROOT}/trading/test_data/backtest_scenarios/universes/sp500.sexp}"
+
+if [[ ! -f "${SP500_CSV}" ]]; then
+  echo "ERROR: sp500.csv not found at ${SP500_CSV}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${INVENTORY_SEXP}" ]]; then
+  echo "ERROR: inventory.sexp not found at ${INVENTORY_SEXP}" >&2
+  echo "Run build_inventory.exe first." >&2
+  exit 1
+fi
+
+TMPDIR_LOCAL="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_LOCAL}"' EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Parse sp500.csv into (normalised_symbol, sector) pairs.
+#    Normalise: replace "." with "-" (EODHD convention).
+#    Use sector-name scanning to handle security names with embedded commas
+#    (e.g. "F5, Inc.", "Tapestry, Inc.") which shift naive field indices.
+# ---------------------------------------------------------------------------
+tail -n +2 "${SP500_CSV}" \
+  | awk -F',' '{
+      sym = $1; gsub(/\./, "-", sym)
+      sector = ""
+      for (i = 2; i <= NF; i++) {
+        if ($i == "Industrials" || $i == "Financials" || $i == "Materials" ||
+            $i == "Energy" || $i == "Utilities" || $i == "Real Estate" ||
+            $i == "Health Care" || $i == "Consumer Staples" ||
+            $i == "Consumer Discretionary" || $i == "Information Technology" ||
+            $i == "Communication Services") {
+          sector = $i; break
+        }
+      }
+      if (sector != "") print sym "\t" sector
+    }' \
+  | sort -k1,1 > "${TMPDIR_LOCAL}/sp500_norm.tsv"
+
+total_sp500=$(wc -l < "${TMPDIR_LOCAL}/sp500_norm.tsv" | tr -d ' ')
+
+# ---------------------------------------------------------------------------
+# 2. Extract inventory symbols (normalised already — inventory uses dashes).
+# ---------------------------------------------------------------------------
+grep '(symbol ' "${INVENTORY_SEXP}" \
+  | sed 's/.*symbol *//; s/).*//; s/ //g' \
+  | sort -u > "${TMPDIR_LOCAL}/inventory_symbols.txt"
+
+# ---------------------------------------------------------------------------
+# 3. Inner-join: sp500 symbols present in inventory.
+# ---------------------------------------------------------------------------
+awk -F'\t' 'NR==FNR { inv[$1]=1; next } ($1 in inv) { print $0 }' \
+  "${TMPDIR_LOCAL}/inventory_symbols.txt" "${TMPDIR_LOCAL}/sp500_norm.tsv" \
+  | sort -t$'\t' -k1,1 > "${TMPDIR_LOCAL}/matched.tsv"
+
+matched_count=$(wc -l < "${TMPDIR_LOCAL}/matched.tsv" | tr -d ' ')
+missing_count=$(( total_sp500 - matched_count ))
+
+# ---------------------------------------------------------------------------
+# 4. Identify missing symbols (sp500 but not in inventory).
+# ---------------------------------------------------------------------------
+awk -F'\t' '{ print $1 }' "${TMPDIR_LOCAL}/sp500_norm.tsv" \
+  > "${TMPDIR_LOCAL}/sp500_symbols.txt"
+comm -23 \
+  <(sort "${TMPDIR_LOCAL}/sp500_symbols.txt") \
+  <(sort "${TMPDIR_LOCAL}/inventory_symbols.txt") \
+  > "${TMPDIR_LOCAL}/missing.txt"
+
+# ---------------------------------------------------------------------------
+# 5. Emit Pinned sexp.
+# ---------------------------------------------------------------------------
+today=$(date +%Y-%m-%d)
+{
+  echo ";; S&P 500 universe — joined from data/sp500.csv against the local"
+  echo ";; bar-data inventory under data/. Generated ${today} by"
+  echo ";; dev/scripts/build_sp500_universe.sh."
+  echo ";;"
+  if [[ "${missing_count}" -eq 0 ]]; then
+    echo ";; ${matched_count} / ${total_sp500} S&P 500 symbols have bar data."
+  else
+    echo ";; ${matched_count} / ${total_sp500} S&P 500 symbols have bar data;"
+    echo ";; ${missing_count} missing from cache:"
+    while IFS= read -r sym; do
+      echo ";;   ${sym}"
+    done < "${TMPDIR_LOCAL}/missing.txt"
+    echo ";; Run fetch_symbols.exe for the missing symbols then re-run this script."
+  fi
+  echo ";;"
+  echo ";; Symbol convention: dots replaced with dashes (EODHD: BF.B -> BF-B)."
+  echo ";; Used by goldens-sp500/ scenarios as a regression-pinned trading +"
+  echo ";; performance benchmark. The S&P 500 is a moving target — this"
+  echo ";; snapshot is fixed at generation time so the golden trades are"
+  echo ";; reproducible across reruns of the same scenario."
+  echo "(Pinned ("
+  awk -F'\t' '{ printf "  ((symbol %-7s) (sector \"%s\"))\n", $1, $2 }' \
+    "${TMPDIR_LOCAL}/matched.tsv"
+  echo "))"
+} > "${OUT}"
+
+echo "Wrote ${matched_count} symbols to ${OUT}" >&2
+if [[ "${missing_count}" -gt 0 ]]; then
+  echo "  ${missing_count} symbols missing from cache: $(cat "${TMPDIR_LOCAL}/missing.txt" | tr '\n' ' ')" >&2
+fi

--- a/trading/analysis/data/sources/wiki_sp500/test/dune
+++ b/trading/analysis/data/sources/wiki_sp500/test/dune
@@ -1,15 +1,5 @@
 (tests
- (names
-  test_changes_parser
-  test_reason_classifier
-  test_membership_replay
-  test_ticker_aliases)
+ (names test_changes_parser test_reason_classifier)
  (libraries wiki_sp500 core ounit2 matchers status)
  (deps
-  (glob_files ./data/*.html)
-  (glob_files ./data/*.csv)
-  (glob_files ./data/*.sexp)))
-
-(executable
- (name gen_golden_2010_universe)
- (libraries wiki_sp500 core status))
+  (glob_files ./data/*.html)))

--- a/trading/analysis/data/sources/wiki_sp500/test/dune
+++ b/trading/analysis/data/sources/wiki_sp500/test/dune
@@ -1,5 +1,15 @@
 (tests
- (names test_changes_parser test_reason_classifier)
+ (names
+  test_changes_parser
+  test_reason_classifier
+  test_membership_replay
+  test_ticker_aliases)
  (libraries wiki_sp500 core ounit2 matchers status)
  (deps
-  (glob_files ./data/*.html)))
+  (glob_files ./data/*.html)
+  (glob_files ./data/*.csv)
+  (glob_files ./data/*.sexp)))
+
+(executable
+ (name gen_golden_2010_universe)
+ (libraries wiki_sp500 core status))

--- a/trading/test_data/backtest_scenarios/universes/sp500.sexp
+++ b/trading/test_data/backtest_scenarios/universes/sp500.sexp
@@ -1,16 +1,16 @@
 ;; S&P 500 universe — joined from data/sp500.csv against the local
-;; bar-data inventory under data/. Generated 2026-04-26.
+;; bar-data inventory under data/. Generated 2026-05-03 by
+;; dev/scripts/build_sp500_universe.sh.
 ;;
-;; 491 / 503 S&P 500 symbols have bar data; the 12 missing are recent
-;; additions or delistings without downloaded history. Refresh by
-;; re-running the join script (TODO: extract into
-;; dev/scripts/build_sp500_universe.sh).
+;; 503 / 503 S&P 500 symbols have bar data.
 ;;
+;; Symbol convention: dots replaced with dashes (EODHD: BF.B -> BF-B).
 ;; Used by goldens-sp500/ scenarios as a regression-pinned trading +
 ;; performance benchmark. The S&P 500 is a moving target — this
 ;; snapshot is fixed at generation time so the golden trades are
 ;; reproducible across reruns of the same scenario.
 (Pinned (
+  ((symbol A      ) (sector "Health Care"))
   ((symbol AAPL   ) (sector "Information Technology"))
   ((symbol ABBV   ) (sector "Health Care"))
   ((symbol ABNB   ) (sector "Consumer Discretionary"))
@@ -68,6 +68,7 @@
   ((symbol BBY    ) (sector "Consumer Discretionary"))
   ((symbol BDX    ) (sector "Health Care"))
   ((symbol BEN    ) (sector "Financials"))
+  ((symbol BF-B   ) (sector "Consumer Staples"))
   ((symbol BG     ) (sector "Consumer Staples"))
   ((symbol BIIB   ) (sector "Health Care"))
   ((symbol BK     ) (sector "Financials"))
@@ -77,10 +78,12 @@
   ((symbol BLK    ) (sector "Financials"))
   ((symbol BMY    ) (sector "Health Care"))
   ((symbol BR     ) (sector "Industrials"))
+  ((symbol BRK-B  ) (sector "Financials"))
   ((symbol BRO    ) (sector "Financials"))
   ((symbol BSX    ) (sector "Health Care"))
   ((symbol BX     ) (sector "Financials"))
   ((symbol BXP    ) (sector "Real Estate"))
+  ((symbol C      ) (sector "Financials"))
   ((symbol CAG    ) (sector "Consumer Staples"))
   ((symbol CAH    ) (sector "Health Care"))
   ((symbol CARR   ) (sector "Industrials"))
@@ -136,6 +139,7 @@
   ((symbol CVNA   ) (sector "Consumer Discretionary"))
   ((symbol CVS    ) (sector "Health Care"))
   ((symbol CVX    ) (sector "Energy"))
+  ((symbol D      ) (sector "Utilities"))
   ((symbol DAL    ) (sector "Industrials"))
   ((symbol DASH   ) (sector "Consumer Discretionary"))
   ((symbol DD     ) (sector "Materials"))
@@ -188,6 +192,7 @@
   ((symbol EXPD   ) (sector "Industrials"))
   ((symbol EXPE   ) (sector "Consumer Discretionary"))
   ((symbol EXR    ) (sector "Real Estate"))
+  ((symbol F      ) (sector "Consumer Discretionary"))
   ((symbol FANG   ) (sector "Energy"))
   ((symbol FAST   ) (sector "Industrials"))
   ((symbol FCX    ) (sector "Materials"))
@@ -262,6 +267,7 @@
   ((symbol IT     ) (sector "Information Technology"))
   ((symbol ITW    ) (sector "Industrials"))
   ((symbol IVZ    ) (sector "Financials"))
+  ((symbol J      ) (sector "Industrials"))
   ((symbol JBHT   ) (sector "Industrials"))
   ((symbol JBL    ) (sector "Information Technology"))
   ((symbol JCI    ) (sector "Industrials"))
@@ -280,6 +286,7 @@
   ((symbol KO     ) (sector "Consumer Staples"))
   ((symbol KR     ) (sector "Consumer Staples"))
   ((symbol KVUE   ) (sector "Consumer Staples"))
+  ((symbol L      ) (sector "Financials"))
   ((symbol LDOS   ) (sector "Industrials"))
   ((symbol LEN    ) (sector "Consumer Discretionary"))
   ((symbol LH     ) (sector "Health Care"))
@@ -348,6 +355,7 @@
   ((symbol NWS    ) (sector "Communication Services"))
   ((symbol NWSA   ) (sector "Communication Services"))
   ((symbol NXPI   ) (sector "Information Technology"))
+  ((symbol O      ) (sector "Real Estate"))
   ((symbol ODFL   ) (sector "Industrials"))
   ((symbol OKE    ) (sector "Energy"))
   ((symbol OMC    ) (sector "Communication Services"))
@@ -386,6 +394,7 @@
   ((symbol PTC    ) (sector "Information Technology"))
   ((symbol PWR    ) (sector "Industrials"))
   ((symbol PYPL   ) (sector "Financials"))
+  ((symbol Q      ) (sector "Information Technology"))
   ((symbol QCOM   ) (sector "Information Technology"))
   ((symbol RCL    ) (sector "Consumer Discretionary"))
   ((symbol REG    ) (sector "Real Estate"))
@@ -428,6 +437,7 @@
   ((symbol SYF    ) (sector "Financials"))
   ((symbol SYK    ) (sector "Health Care"))
   ((symbol SYY    ) (sector "Consumer Staples"))
+  ((symbol T      ) (sector "Communication Services"))
   ((symbol TAP    ) (sector "Consumer Staples"))
   ((symbol TDG    ) (sector "Industrials"))
   ((symbol TDY    ) (sector "Information Technology"))
@@ -465,6 +475,7 @@
   ((symbol UPS    ) (sector "Industrials"))
   ((symbol URI    ) (sector "Industrials"))
   ((symbol USB    ) (sector "Financials"))
+  ((symbol V      ) (sector "Financials"))
   ((symbol VICI   ) (sector "Real Estate"))
   ((symbol VLO    ) (sector "Energy"))
   ((symbol VLTO   ) (sector "Industrials"))


### PR DESCRIPTION
## Summary

- All 12 symbols previously missing from `trading/test_data/backtest_scenarios/universes/sp500.sexp` were already in the local bar-data cache but dropped by the original join due to two parsing bugs: (1) single-letter tickers dropped by a `\w+`-style regex, and (2) dot-notation symbols (BF.B, BRK.B) not normalised to EODHD dash-form (BF-B, BRK-B) before the join.
- No new data fetches were required. All 12 symbols confirmed in inventory.
- Extracted join logic into `dev/scripts/build_sp500_universe.sh` (closes the TODO in the sp500.sexp header), with fixes for single-letter tickers, dot→dash normalisation, and quoted CSV fields with embedded commas.
- `sp500.sexp` regenerated: 491 → 503 symbols.
- `dev/notes/data-gaps.md` §sp500-Universe-Coverage updated to RESOLVED (2026-05-03).

## Symbols added (12)

| Symbol | Sector | Root cause |
|--------|--------|-----------|
| A | Health Care | single-letter ticker |
| BF-B | Consumer Staples | dot→dash (BF.B) |
| BRK-B | Financials | dot→dash (BRK.B) |
| C | Financials | single-letter ticker |
| D | Utilities | single-letter ticker |
| F | Consumer Discretionary | single-letter ticker |
| J | Industrials | single-letter ticker |
| L | Financials | single-letter ticker |
| O | Real Estate | single-letter ticker |
| Q | Information Technology | single-letter ticker |
| T | Communication Services | single-letter ticker |
| V | Financials | single-letter ticker |

## sp500.sexp line-count delta

491 → 503 symbols (12 added, 0 removed)

## Files changed

- `trading/test_data/backtest_scenarios/universes/sp500.sexp` — regenerated, 503 symbols
- `dev/scripts/build_sp500_universe.sh` — NEW: extracted join script (per sp500.sexp TODO)
- `dev/notes/data-gaps.md` — §sp500-Universe-Coverage: Open → RESOLVED (2026-05-03)

## Test plan

- [ ] `dune build` passes (data-only change; no code changes)
- [ ] `grep -c '(symbol' trading/test_data/backtest_scenarios/universes/sp500.sexp` returns 503
- [ ] All 12 symbols present in sp500.sexp: A, BF-B, BRK-B, C, D, F, J, L, O, Q, T, V
- [ ] `bash dev/scripts/build_sp500_universe.sh /tmp/verify.sexp && grep -c '(symbol' /tmp/verify.sexp` returns 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)