### PR TITLE
feat(perf): tier-4 release-gate scaffolding for N=5k/10k × 5-10y

### DIFF
--- a/dev/notes/tier4-release-gate-checklist-2026-04-28.md
+++ b/dev/notes/tier4-release-gate-checklist-2026-04-28.md
@@ -123,6 +123,48 @@ on a runner-accessible volume, or (b) plumb a streaming data source
 does not need a full local mirror. At that point, reconstruct the
 workflow shape from `dev/scripts/perf_tier4_release_gate.sh`.
 
+## SCALE cells (N=5000 / N=10000) — scaffolded 2026-05-03
+
+The N=1000 cells covered above use the CSV-mode loader and run via
+`dev/scripts/perf_tier4_release_gate.sh`. The N=5000 / N=10000 SCALE
+cells are tagged `;; perf-tier: 4-scale` (distinct sub-tier) and run
+via a separate runner: `dev/scripts/run_tier4_release_gate.sh`.
+
+Cells:
+- `goldens-broad/tier4-N5000-5y.sexp`  (5y × N=5000, 2019-2023)
+- `goldens-broad/tier4-N5000-10y.sexp` (10y × N=5000, 2014-2023)
+- `goldens-broad/tier4-N10000-5y.sexp` (5y × N=10000, 2019-2023)
+
+Snapshot mode is mandatory: CSV-mode formula upper bounds are
+24-47 GB peak RSS for these cells, far beyond any single runner.
+Snapshot mode (Phase E §F3) caps RSS at the configured `max_cache_mb`
+(~50-200 MB) — this is what makes them feasible on the 8 GB local box.
+
+Pre-flight (in addition to the N=1000 pre-flight above):
+- The 5000-symbol (or 10000-symbol) snapshot corpus must be pre-built
+  under `data/snapshots/<schema-hash>/`. F.2's `auto_build` mode
+  materializes this on first invocation but the initial build can take
+  hours at scale; expect to schedule the corpus build separately from
+  the gate run. The ops-data agent's 15y sp500 historical fetch
+  (in flight 2026-05-03) is the prerequisite.
+- `expected` ranges in the three SCALE sexps are intentionally
+  permissive (BASELINE_PENDING_AFTER_FIRST_RUN). First run produces
+  the canonical baseline; tighten ranges via follow-up PR.
+
+Invocation (dry-run first to confirm discovery):
+
+```sh
+docker exec -it trading-1-dev bash -c \
+  'cd /workspaces/trading-1 && dev/scripts/run_tier4_release_gate.sh --dry-run'
+
+# When ready:
+docker exec -it trading-1-dev bash -c \
+  'cd /workspaces/trading-1 && dev/scripts/run_tier4_release_gate.sh'
+```
+
+Output dir: `dev/perf/tier4-scale-<UTC-timestamp>/` (separate from the
+N=1000 release-gate's `dev/perf/tier4-release-gate-<UTC-timestamp>/`).
+
 ## References
 
 - `dev/notes/session-followups-2026-04-28.md` §2 — full problem
@@ -130,7 +172,12 @@ workflow shape from `dev/scripts/perf_tier4_release_gate.sh`.
 - `dev/plans/perf-scenario-catalog-2026-04-25.md` §"Release-gate
   strategy" — strategy this implements operationally.
 - `dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md` —
-  source for the "8 GB at N=1000 fits" finding.
-- `dev/scripts/perf_tier4_release_gate.sh` — the runner script.
+  source for the "8 GB at N=1000 fits" finding (and 24-47 GB
+  CSV-mode upper bounds for the SCALE cells).
+- `dev/plans/snapshot-engine-phase-f-2026-05-03.md` — F.2 default-flip
+  and the cache-bounded snapshot-mode RSS context for SCALE cells.
+- `dev/scripts/perf_tier4_release_gate.sh` — the N=1000 runner script.
+- `dev/scripts/run_tier4_release_gate.sh` — the N=5000 / N=10000
+  SCALE runner script.
 - `trading/trading/backtest/bin/release_perf_report.ml` — comparison
   exe (built via `dune build trading/backtest/bin/release_perf_report.exe`).

--- a/dev/scripts/run_tier4_release_gate.sh
+++ b/dev/scripts/run_tier4_release_gate.sh
@@ -1,0 +1,244 @@
+#!/bin/sh
+# Tier-4 release-gate SCALE runner for N=5000 / N=10000 cells.
+#
+# Distinct from `dev/scripts/perf_tier4_release_gate.sh`, which runs the
+# established N=1000 release-gate cells (`bull-crash-2015-2020`,
+# `covid-recovery-2020-2024`, `decade-2014-2023`, `six-year-2018-2023`)
+# tagged `;; perf-tier: 4`. This script discovers and runs the SCALE
+# variants tagged `;; perf-tier: 4-scale`:
+#   - tier4-N5000-5y   (5y × N=5000)
+#   - tier4-N5000-10y  (10y × N=5000)
+#   - tier4-N10000-5y  (5y × N=10000)
+#
+# Why a separate sub-tier:
+#   1. The N=1000 cells fit 8 GB under CSV mode and have pinned baselines.
+#      They run today via `perf_tier4_release_gate.sh` at every release cut.
+#   2. The N=5000 / N=10000 cells require snapshot-mode runtime (default
+#      since #802 / Phase F.2) + a pre-built snapshot corpus that is still
+#      being assembled (ops-data agent in flight on the 15y sp500 fetch).
+#      Tagging them with a distinct sub-tier keeps them OFF the standard
+#      tier-4 runner until both prereqs land.
+#
+# Snapshot-mode is mandatory: CSV-mode upper bound (RSS ≈ 67 + 3.94·N +
+# 0.19·N·(T-1)) projects 24-47 GB peak for these cells, well beyond any
+# single runner. Snapshot mode (Phase E §F3 cache-bounded RSS ~50-200 MB)
+# is what makes them feasible on the user's 8 GB local box. The runner
+# below sets `--snapshot-mode` explicitly to be future-proof against the
+# F.2 default ever flipping back.
+#
+# This script is SCAFFOLDING — the actual gate run is local-only on the
+# user's box once the 5000-symbol snapshot corpus is built. Until then
+# `--dry-run` is the expected invocation: it prints the discovered cells
+# + planned commands without executing them.
+#
+# Exit status:
+#   0 if every tier-4-scale scenario completes within budget (or --dry-run)
+#   1 if any scenario exits non-zero, errors, or times out
+#   2 if invocation is malformed or no cells are discovered
+#
+# Usage:
+#   dev/scripts/run_tier4_release_gate.sh                       -- run all
+#   dev/scripts/run_tier4_release_gate.sh --dry-run             -- print plan, no exec
+#   PERF_TIER4_SCALE_TIMEOUT=14400 dev/scripts/run_tier4_release_gate.sh
+#
+# Output artefacts under dev/perf/tier4-scale-<timestamp>/:
+#   <scenario-name>.log        scenario_runner stdout/stderr
+#   <scenario-name>.peak_rss   integer kB from /usr/bin/time -f '%M'
+#   <scenario-name>.wall_sec   seconds (real time) — best-effort
+#   <scenario-name>.error      present iff the run errored / timed out
+#   summary.txt                aggregate table written at the end
+#
+# References:
+#   dev/notes/tier4-release-gate-checklist-2026-04-28.md
+#   dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md
+#   dev/plans/snapshot-engine-phase-f-2026-05-03.md
+#   dev/plans/daily-snapshot-streaming-2026-04-27.md
+
+set -e
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run|-n) DRY_RUN=1 ;;
+    --help|-h)
+      sed -n '2,55p' "$0"
+      exit 0 ;;
+    *)
+      printf 'FAIL: unknown argument: %s\n' "$arg" >&2
+      printf 'See `%s --help`.\n' "$0" >&2
+      exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCENARIO_ROOT="${REPO_ROOT}/trading/test_data/backtest_scenarios"
+RUN_IN_ENV="${REPO_ROOT}/dev/lib/run-in-env.sh"
+
+# Default per-cell timeout: 12 h. The largest cell (N=10000 × 5y) is
+# expected to be screener-bound, not memory-bound, under snapshot mode.
+# Override via env var.
+TIMEOUT="${PERF_TIER4_SCALE_TIMEOUT:-43200}"
+
+# Snapshot-mode default-flip landed in #802 (Phase F.2). We pass the flag
+# explicitly so this script remains correct if a future change reverts the
+# default. Override via env var if you need to test a specific snapshot
+# directory; otherwise auto-build is used.
+SNAPSHOT_DIR="${PERF_TIER4_SCALE_SNAPSHOT_DIR:-}"
+
+# Aggressive major-GC + smaller minor heap. Same rationale as the N=1000
+# tier-4 runner. Override via PERF_TIER4_SCALE_OCAMLRUNPARAM=...; pass
+# empty to use the OCaml defaults.
+export OCAMLRUNPARAM="${PERF_TIER4_SCALE_OCAMLRUNPARAM:-o=60,s=512k}"
+
+if [ "$DRY_RUN" = "0" ] && [ ! -x "$RUN_IN_ENV" ]; then
+  printf 'FAIL: %s not found / not executable\n' "$RUN_IN_ENV" >&2
+  exit 1
+fi
+
+if [ ! -d "$SCENARIO_ROOT" ]; then
+  printf 'FAIL: scenario root not found: %s\n' "$SCENARIO_ROOT" >&2
+  exit 1
+fi
+
+if [ -x /usr/bin/time ]; then
+  HAVE_GNU_TIME=1
+else
+  HAVE_GNU_TIME=0
+fi
+
+TS="$(date -u +%Y-%m-%dT%H%M%SZ)"
+OUT_DIR="${REPO_ROOT}/dev/perf/tier4-scale-${TS}"
+mkdir -p "$OUT_DIR"
+
+printf 'Tier-4 release-gate SCALE run.\n'
+printf '  Scenario root  : %s\n' "$SCENARIO_ROOT"
+printf '  Output dir     : %s\n' "$OUT_DIR"
+printf '  Per-cell timeout : %ss\n' "$TIMEOUT"
+printf '  GNU /usr/bin/time : %s\n' "$HAVE_GNU_TIME"
+printf '  Snapshot dir   : %s\n' "${SNAPSHOT_DIR:-<auto-build>}"
+printf '  Dry run        : %s\n\n' "$DRY_RUN"
+
+# Discover tier-4-scale scenarios under goldens-broad/.
+TIER4_SCALE_PATHS=""
+for sexp in "${SCENARIO_ROOT}/goldens-broad"/*.sexp; do
+  [ -f "$sexp" ] || continue
+  if grep -q '^;; perf-tier: 4-scale' "$sexp"; then
+    TIER4_SCALE_PATHS="${TIER4_SCALE_PATHS}${sexp}
+"
+  fi
+done
+
+if [ -z "$TIER4_SCALE_PATHS" ]; then
+  printf 'WARNING: no scenarios found with [;; perf-tier: 4-scale] -- nothing to do.\n' >&2
+  exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TABLE_ROWS=""
+
+# Snapshot-mode flag set. Empty if SNAPSHOT_DIR is empty (then auto-build
+# takes over per F.2). Otherwise pass an explicit dir.
+SNAPSHOT_FLAGS="--snapshot-mode"
+if [ -n "$SNAPSHOT_DIR" ]; then
+  SNAPSHOT_FLAGS="--snapshot-mode --snapshot-dir $SNAPSHOT_DIR"
+fi
+
+_run_one() {
+  scenario_path="$1"
+  base_name="$(basename "$scenario_path" .sexp)"
+  log_path="${OUT_DIR}/${base_name}.log"
+  rss_path="${OUT_DIR}/${base_name}.peak_rss"
+  wall_path="${OUT_DIR}/${base_name}.wall_sec"
+  error_path="${OUT_DIR}/${base_name}.error"
+
+  stage_dir="${OUT_DIR}/_stage_${base_name}"
+  mkdir -p "$stage_dir"
+  cp "$scenario_path" "$stage_dir/"
+
+  cmd="dune exec --no-build trading/backtest/scenarios/scenario_runner.exe -- --dir $stage_dir --parallel 1 --fixtures-root $SCENARIO_ROOT $SNAPSHOT_FLAGS"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '[dry]  %s\n' "$base_name"
+    printf '       cmd: %s\n' "$cmd"
+    printf '       timeout: %ss  OCAMLRUNPARAM=%s\n' "$TIMEOUT" "$OCAMLRUNPARAM"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}DRY   ${base_name}  -          -
+"
+    rm -rf "$stage_dir"
+    return 0
+  fi
+
+  printf '[run]  %s\n' "$base_name"
+
+  start_epoch=$(date +%s)
+  rc=0
+  if [ "$HAVE_GNU_TIME" = "1" ]; then
+    /usr/bin/time -o "$rss_path" -f '%M' \
+      timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" sh -c "$cmd" \
+      >"$log_path" 2>&1 || rc=$?
+  else
+    timeout "$TIMEOUT" \
+      "$RUN_IN_ENV" sh -c "$cmd" \
+      >"$log_path" 2>&1 || rc=$?
+    printf 'UNAVAILABLE\n' >"$rss_path"
+  fi
+  end_epoch=$(date +%s)
+  wall_sec=$((end_epoch - start_epoch))
+  printf '%s\n' "$wall_sec" >"$wall_path"
+
+  rss_value="?"
+  if [ -f "$rss_path" ]; then
+    rss_value=$(tr -d '\n' <"$rss_path")
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    printf 'exit=%s — see %s\n' "$rc" "$log_path" >"$error_path"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}FAIL  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  else
+    PASS_COUNT=$((PASS_COUNT + 1))
+    TABLE_ROWS="${TABLE_ROWS}PASS  ${base_name}  ${wall_sec}s  ${rss_value}kB
+"
+  fi
+
+  rm -rf "$stage_dir"
+}
+
+if [ "$DRY_RUN" = "0" ]; then
+  "$RUN_IN_ENV" dune build trading/backtest/scenarios/scenario_runner.exe \
+    >"${OUT_DIR}/_prebuild.log" 2>&1 || true
+fi
+
+OLD_IFS="$IFS"
+IFS='
+'
+for path in $TIER4_SCALE_PATHS; do
+  IFS="$OLD_IFS"
+  _run_one "$path"
+  IFS='
+'
+done
+IFS="$OLD_IFS"
+
+SUMMARY="${OUT_DIR}/summary.txt"
+{
+  printf 'Tier-4 release-gate SCALE summary (%s)\n' "$TS"
+  printf '  passed: %d\n' "$PASS_COUNT"
+  printf '  failed: %d\n' "$FAIL_COUNT"
+  printf '  dry-run: %s\n' "$DRY_RUN"
+  printf '\n'
+  printf '%-6s  %-32s  %-8s  %s\n' "STATUS" "SCENARIO" "WALL" "PEAK_RSS"
+  printf '%s\n' "----------------------------------------------------------------------"
+  printf '%b' "$TABLE_ROWS" | awk 'NF { printf "%-6s  %-32s  %-8s  %s\n", $1, $2, $3, $4 }'
+} >"$SUMMARY"
+
+cat "$SUMMARY"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -186,6 +186,38 @@ mechanics + release-gate procedure.
 
 ## Completed
 
+- **Tier-4 release-gate SCALE scaffolding for N=5k/10k × 5-10y** (2026-05-03,
+  `feat/backtest-tier4-scaffolding`). Adds three scenarios + a dedicated
+  runner script for the snapshot-mode-only N≥5000 release-gate cells.
+  Files:
+  - `trading/test_data/backtest_scenarios/goldens-broad/tier4-N5000-5y.sexp`
+    (5y × N=5000, 2019-2023).
+  - `trading/test_data/backtest_scenarios/goldens-broad/tier4-N5000-10y.sexp`
+    (10y × N=5000, 2014-2023; mirrors `decade-2014-2023.sexp` window).
+  - `trading/test_data/backtest_scenarios/goldens-broad/tier4-N10000-5y.sexp`
+    (5y × N=10000, 2019-2023; chose 5y over 10y to keep wall budget
+    reasonable at the widest cell).
+  - `dev/scripts/run_tier4_release_gate.sh` — auto-discovers
+    `;; perf-tier: 4-scale` scenarios, runs each via `scenario_runner.exe`
+    with `timeout 43200` (12 h default), `--snapshot-mode`, and
+    `--fixtures-root`. Supports `--dry-run` (prints discovered cells +
+    planned commands without executing) and `--help`.
+  Scaffolding only — `expected` ranges are intentionally permissive
+  (`BASELINE_PENDING_AFTER_FIRST_RUN`); first local run on the user's 8 GB
+  box (under snapshot mode + auto-built corpus) populates the canonical
+  baseline. Distinct sub-tier (`4-scale` vs the existing `4`) keeps these
+  cells OFF the standard `dev/scripts/perf_tier4_release_gate.sh` until
+  the snapshot corpus + 5-10k symbol data plumbing land. CSV-mode formula
+  upper bound: N=5000×5y ≈ 24 GB, N=5000×10y ≈ 28 GB, N=10000×5y ≈ 47 GB —
+  all far beyond any single runner; reachable only under snapshot mode
+  (Phase E §F3 cache-bounded RSS ~50-200 MB). Verify:
+  `dev/scripts/run_tier4_release_gate.sh --dry-run` (3 cells discovered),
+  `dune runtest trading/backtest/scenarios/test/` (scenarios parse, 10/10),
+  `PERF_CATALOG_CHECK_STRICT=1 sh trading/devtools/checks/perf_catalog_check.sh`
+  (20/20 tagged). The actual gate run is a follow-up local-only task,
+  blocked on (a) the ops-data 15y sp500 historical fetch in flight and
+  (b) the 5-10k symbol snapshot corpus not yet built.
+
 - **G6 — decade-2014-2023 non-determinism investigation + forward-guard test**
   (2026-04-30, `feat/backtest-g6-decade-nondeterminism`). Investigation note
   `dev/notes/g6-decade-nondeterminism-investigation-2026-04-30.md` audits the

--- a/trading/test_data/backtest_scenarios/goldens-broad/tier4-N10000-5y.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/tier4-N10000-5y.sexp
@@ -1,0 +1,45 @@
+;; perf-tier: 4-scale
+;; perf-tier-rationale: Tier-4 release-gate SCALE cell at N=10000 × 5y (2019-2023). The widest universe cell in the catalog — exercises the snapshot-mode runtime at the 10x-of-production scale ceiling. CSV-mode upper bound (RSS ≈ 67 + 3.94·N + 0.19·N·(T−1)) projects ~47 GB peak — well beyond any single runner — so this cell is reachable ONLY under snapshot mode (Phase E §F3 cache-bounded RSS ~50–200 MB). Run on-demand via `dev/scripts/run_tier4_release_gate.sh` (NOT the pre-existing `perf_tier4_release_gate.sh`, which auto-discovers `;; perf-tier: 4` cells only). Local-only: needs the 10000-symbol snapshot corpus pre-built; ops-data agent in flight on the prerequisite 15y sp500 historical fetch.
+;;
+;; STATUS: SCAFFOLDING ONLY — `expected` ranges are intentionally
+;; permissive (BASELINE_PENDING_AFTER_FIRST_RUN). The first manual local run
+;; on the user's 8 GB box (under snapshot mode + auto-built snapshot corpus)
+;; produces the canonical baseline; tighten ranges via follow-up PR after
+;; that run lands. Until then this cell SHALL NOT be added to any recurring
+;; workflow.
+;;
+;; Why a separate sub-tier (`perf-tier: 4-scale`) vs the existing `perf-tier: 4`:
+;;   See `tier4-N5000-5y.sexp` for the rationale. Distinct sub-tier keeps these
+;;   off `dev/scripts/perf_tier4_release_gate.sh` until the snapshot corpus +
+;;   wide-universe data plumbing land.
+;;
+;; Window rationale: 2019-2023 (5y) at N=10000 — chose 5y over 10y because
+;; (a) the snapshot-mode RSS ceiling is independent of T (cache-bounded), but
+;; the per-day snapshot file size scales with N, so seek + LRU pressure is
+;; what 10000 universe-cap probes; (b) keeping T at 5y limits the absolute
+;; wall budget — at the largest cell the wall is dominated by per-Friday
+;; screener work, which scales with N × Fridays. 5y × 10000 ≈ 260 × 10000 =
+;; 2.6M screener-cycles, comparable to 10y × 5000.
+;;
+;; This cell is the canonical "can the streaming runtime hold the full
+;; Friday-cycle universe at production scale" certification. If this passes
+;; cleanly under snapshot mode, the streaming pivot is validated end-to-end.
+;;
+;; PINNED_AFTER_FIRST_RUN — leave `expected` ranges wide; first local run
+;; populates them.
+((name "tier4-N10000-5y")
+ (description "Tier-4 release-gate SCALE — 5y × N=10000 (snapshot-mode only)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/broad.sexp")
+ (universe_size 10000)
+ ;; enable_short_side disabled — see `tier4-N5000-5y.sexp` for rationale.
+ (config_overrides (((universe_cap (10000)) (enable_short_side false))))
+ ;; PINNED_AFTER_FIRST_RUN — wide ranges; first local run populates them.
+ (expected
+  ((total_return_pct   ((min -1000.0)        (max 1000000.0)))
+   (total_trades       ((min 0)              (max 100000)))
+   (win_rate           ((min 0.0)            (max 100.0)))
+   (sharpe_ratio       ((min -10.0)          (max 10.0)))
+   (max_drawdown_pct   ((min 0.0)            (max 100.0)))
+   (avg_holding_days   ((min 0.0)            (max 10000.0)))
+   (open_positions_value ((min -1000000000.0) (max 100000000000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/tier4-N5000-10y.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/tier4-N5000-10y.sexp
@@ -1,0 +1,46 @@
+;; perf-tier: 4-scale
+;; perf-tier-rationale: Tier-4 release-gate SCALE cell at N=5000 × 10y (2014-2023). The flagship "long-horizon × wide-universe" certification — exercises the snapshot-mode runtime over the same decade window as `decade-2014-2023.sexp` but at 5x universe size. CSV-mode upper bound (RSS ≈ 67 + 3.94·N + 0.19·N·(T−1)) projects ~28.3 GB peak — far beyond any single runner — so this cell is reachable ONLY under snapshot mode (Phase E §F3 cache-bounded RSS ~50–200 MB). Run on-demand via `dev/scripts/run_tier4_release_gate.sh` (NOT the pre-existing `perf_tier4_release_gate.sh`, which auto-discovers `;; perf-tier: 4` cells only). Local-only: needs the 5000-symbol snapshot corpus pre-built; ops-data agent in flight on the prerequisite 15y sp500 historical fetch.
+;;
+;; STATUS: SCAFFOLDING ONLY — `expected` ranges are intentionally
+;; permissive (BASELINE_PENDING_AFTER_FIRST_RUN). The first manual local run
+;; on the user's 8 GB box (under snapshot mode + auto-built snapshot corpus)
+;; produces the canonical baseline; tighten ranges via follow-up PR after
+;; that run lands. Until then this cell SHALL NOT be added to any recurring
+;; workflow.
+;;
+;; Why a separate sub-tier (`perf-tier: 4-scale`) vs the existing `perf-tier: 4`:
+;;   See `tier4-N5000-5y.sexp` for the rationale. Distinct sub-tier keeps these
+;;   off `dev/scripts/perf_tier4_release_gate.sh` until the snapshot corpus +
+;;   wide-universe data plumbing land.
+;;
+;; Window rationale: 2014-2023 mirrors `decade-2014-2023.sexp` (canonical
+;; decade cell) so the wide-universe variant can be A/B-compared against the
+;; N=1000 reference once the snapshot corpus contains both.
+;;
+;; Determinism caveat: `decade-2014-2023.sexp` (the N=1000 sibling) is the only
+;; tier-4 cell that drifts across reruns (G6 finding —
+;; `dev/notes/g6-decade-nondeterminism-investigation-2026-04-30.md`). The
+;; multiplicative factor 520 Fridays × N=5000 puts this cell deeper into the
+;; non-deterministic regime; expect drift across reruns until the
+;; create_order.ml time-prefixed-IDs root cause is fixed (out of this PR's
+;; scope; flagged for `feat-weinstein` / orders-owner follow-up).
+;;
+;; PINNED_AFTER_FIRST_RUN — leave `expected` ranges wide; first local run
+;; populates them. First runs SHOULD be done as a pair (run-1 + run-2) so
+;; the determinism drift can be measured from the start.
+((name "tier4-N5000-10y")
+ (description "Tier-4 release-gate SCALE — 10y × N=5000 (snapshot-mode only)")
+ (period ((start_date 2014-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/broad.sexp")
+ (universe_size 5000)
+ ;; enable_short_side disabled — see `tier4-N5000-5y.sexp` for rationale.
+ (config_overrides (((universe_cap (5000)) (enable_short_side false))))
+ ;; PINNED_AFTER_FIRST_RUN — wide ranges; first local run populates them.
+ (expected
+  ((total_return_pct   ((min -1000.0)        (max 1000000.0)))
+   (total_trades       ((min 0)              (max 100000)))
+   (win_rate           ((min 0.0)            (max 100.0)))
+   (sharpe_ratio       ((min -10.0)          (max 10.0)))
+   (max_drawdown_pct   ((min 0.0)            (max 100.0)))
+   (avg_holding_days   ((min 0.0)            (max 10000.0)))
+   (open_positions_value ((min -1000000000.0) (max 100000000000.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/tier4-N5000-5y.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/tier4-N5000-5y.sexp
@@ -1,0 +1,48 @@
+;; perf-tier: 4-scale
+;; perf-tier-rationale: Tier-4 release-gate SCALE cell at N=5000 × 5y (2019-2023). Probes whether the snapshot-mode runtime path (default since #802 / Phase F.2) can hold the full Friday-cycle universe at 5x the production size. CSV-mode upper bound (RSS ≈ 67 + 3.94·N + 0.19·N·(T−1)) projects ~23.6 GB peak — far beyond any single runner — so this cell is reachable ONLY under snapshot mode (Phase E §F3 cache-bounded RSS ~50–200 MB). Run on-demand via `dev/scripts/run_tier4_release_gate.sh` (NOT the pre-existing `perf_tier4_release_gate.sh`, which auto-discovers `;; perf-tier: 4` cells only). Local-only: needs the 5000-symbol snapshot corpus pre-built; ops-data agent in flight on the prerequisite 15y sp500 historical fetch.
+;;
+;; STATUS: SCAFFOLDING ONLY — `expected` ranges are intentionally
+;; permissive (BASELINE_PENDING_AFTER_FIRST_RUN). The first manual local run
+;; on the user's 8 GB box (under snapshot mode + auto-built snapshot corpus)
+;; produces the canonical baseline; tighten ranges via follow-up PR after
+;; that run lands. Until then this cell SHALL NOT be added to any recurring
+;; workflow.
+;;
+;; Why a separate sub-tier (`perf-tier: 4-scale`) vs the existing `perf-tier: 4`:
+;;   1. The existing tier-4 cells (`bull-crash-2015-2020`, `covid-recovery-2020-2024`,
+;;      `decade-2014-2023`, `six-year-2018-2023`) are pinned at N=1000 and
+;;      validated to fit 8 GB under CSV mode. They run today via
+;;      `dev/scripts/perf_tier4_release_gate.sh` at every release cut.
+;;   2. The N=5000 / N=10000 scale cells require snapshot-mode runtime + a
+;;      pre-built snapshot corpus that does not yet exist. Tagging them with
+;;      a distinct sub-tier (`4-scale`) keeps them OFF the standard tier-4
+;;      runner until both prereqs land.
+;;
+;; Window rationale: 2019-2023 mirrors the canonical sp500-2019-2023 cell so
+;; this cell can be A/B-compared against the small-universe sp500 baseline once
+;; the snapshot corpus is wide enough to contain both.
+;;
+;; PINNED_AFTER_FIRST_RUN — leave `expected` ranges wide; first local run
+;; populates them.
+((name "tier4-N5000-5y")
+ (description "Tier-4 release-gate SCALE — 5y × N=5000 (snapshot-mode only)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/broad.sexp")
+ (universe_size 5000)
+ ;; enable_short_side disabled mirroring the N=1000 tier-4 cells
+ ;; (dev/notes/short-side-gaps-2026-04-29.md G1-G4 unresolved). Revert when
+ ;; short-side gaps close + the override is dropped from the long-only family.
+ (config_overrides (((universe_cap (5000)) (enable_short_side false))))
+ ;; PINNED_AFTER_FIRST_RUN — wide ranges. First local run on the user's 8 GB
+ ;; box under snapshot mode produces the canonical baseline; tighten ranges
+ ;; via follow-up PR once captured. The wide bounds below confirm "the run
+ ;; completed without OOM/crash and produced non-degenerate metrics" — same
+ ;; pattern as `goldens-broad/sp500-30y-capacity-1996.sexp`.
+ (expected
+  ((total_return_pct   ((min -1000.0)        (max 1000000.0)))
+   (total_trades       ((min 0)              (max 100000)))
+   (win_rate           ((min 0.0)            (max 100.0)))
+   (sharpe_ratio       ((min -10.0)          (max 10.0)))
+   (max_drawdown_pct   ((min 0.0)            (max 100.0)))
+   (avg_holding_days   ((min 0.0)            (max 10000.0)))
+   (open_positions_value ((min -1000000000.0) (max 100000000000.0))))))


### PR DESCRIPTION
## Summary

Scaffolds three new tier-4 release-gate scenarios at N=5000 / N=10000 plus a dedicated runner script. The cells are tagged `;; perf-tier: 4-scale` (distinct sub-tier vs the existing N=1000 `;; perf-tier: 4` cells) so they stay OFF `dev/scripts/perf_tier4_release_gate.sh` until the prerequisites land.

This PR ships scaffolding only — the actual gate run is local-only on the user's 8 GB box and is blocked on (a) the ops-data 15y sp500 historical fetch in flight in parallel, and (b) the 5-10k symbol snapshot corpus not yet built.

## Why

Per `dev/status/backtest-perf.md` §Open work + `dev/notes/tier4-release-gate-checklist-2026-04-28.md`: tier-4 release-gate at N≥5000 has been P1-blocked since the engine-pool measurement landed (`dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md`). CSV-mode formula upper bound: N=5000×5y ≈ 24 GB, N=5000×10y ≈ 28 GB, N=10000×5y ≈ 47 GB — far beyond any single runner.

The snapshot-mode runtime (default since #802 / Phase F.2 — `dev/plans/snapshot-engine-phase-f-2026-05-03.md`) caps RSS at the configured `max_cache_mb` (~50–200 MB). The SCALE cells are reachable only under that runtime. Scaffolding them now lets the user run the gate locally as soon as the prereqs land, without waiting for another scaffolding cycle.

## What lands

**Three new scenarios** under `goldens-broad/` (each tagged `;; perf-tier: 4-scale`):
- `tier4-N5000-5y.sexp` — 5y × N=5000 (2019-2023, mirrors sp500-2019-2023 window for A/B)
- `tier4-N5000-10y.sexp` — 10y × N=5000 (2014-2023, mirrors `decade-2014-2023.sexp` window)
- `tier4-N10000-5y.sexp` — 5y × N=10000 (2019-2023; chose 5y over 10y to keep wall budget reasonable at the widest cell)

**One new runner script**:
- `dev/scripts/run_tier4_release_gate.sh` — auto-discovers `;; perf-tier: 4-scale` scenarios, runs each via `scenario_runner.exe` with `timeout 43200` (12 h default), `--snapshot-mode`, and `--fixtures-root`. Supports `--dry-run` (prints discovered cells + planned commands without executing) and `--help`.

**Documentation updates**:
- `dev/status/backtest-perf.md` — Completed entry for the scaffolding.
- `dev/notes/tier4-release-gate-checklist-2026-04-28.md` — new SCALE-cells subsection covering the snapshot-mode prereqs, dry-run invocation, and the BASELINE_PENDING posture.

All `expected` ranges in the three SCALE sexps are intentionally permissive (`BASELINE_PENDING_AFTER_FIRST_RUN` marker per the dispatch convention). First local run produces the canonical baseline; tighten ranges via follow-up PR.

## Decisions

- **Universe-cap convention**: `(config_overrides (((universe_cap (<N>)) (enable_short_side false))))` — same as the N=1000 cells. `enable_short_side false` mirrors the long-only family (G1-G4 short-side gaps still open).
- **Sub-tier marker**: `;; perf-tier: 4-scale` (new) vs `;; perf-tier: 4` (existing). Keeps the standard `perf_tier4_release_gate.sh` runner pure for the validated N=1000 cells. Linter `perf_catalog_check.sh` accepts `4-scale` because it greps for the `^;; perf-tier:` prefix.
- **Windows**: 2019-2023 (5y) and 2014-2023 (10y) — same eras as existing tier-4 cells; minimizes data-availability surprises and enables A/B against the N=1000 reference once the snapshot corpus contains both.
- **Why N=10000 × 5y, not × 10y**: snapshot-mode RSS is independent of T (cache-bounded), but per-day file size scales with N and wall scales with N × Fridays. 5y × 10000 ≈ 2.6M screener-cycles, comparable to 10y × 5000.

## Expected RSS per cell (CSV-mode upper bound only — context)

Per `dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md`: `RSS ≈ 67 + 3.94·N + 0.19·N·(T−1)` MB.

| Cell | CSV upper bound | Snapshot mode |
|---|---:|---:|
| N=5000 × 5y | ~23.6 GB | ~50–200 MB |
| N=5000 × 10y | ~28.3 GB | ~50–200 MB |
| N=10000 × 5y | ~47.0 GB | ~50–200 MB |

The CSV upper bound is the formal proof these cells are infeasible without the streaming pivot. Snapshot-mode bounds will be confirmed by the first local run (see `dev/plans/snapshot-engine-phase-f-2026-05-03.md` §"RSS-formula caveat" for the F.2 re-derivation point).

## Test plan

- [x] `dune runtest trading/backtest/scenarios/test/` — 10/10 PASS, scenario sexps parse via `Scenario.load`.
- [x] `PERF_CATALOG_CHECK_STRICT=1 sh trading/devtools/checks/perf_catalog_check.sh` — 20/20 scenarios tagged.
- [x] `sh trading/devtools/checks/posix_sh_check.sh` — 48/48 scripts clean (new runner included).
- [x] `dune build` — clean across the project.
- [x] `dev/scripts/run_tier4_release_gate.sh --dry-run` — discovers all 3 SCALE cells, prints planned commands.
- [ ] First end-to-end run (deferred to local user session — needs snapshot corpus).

## Files

```
dev/notes/tier4-release-gate-checklist-2026-04-28.md          | +51 -2  (new SCALE subsection)
dev/scripts/run_tier4_release_gate.sh                          | +244   (new runner)
dev/status/backtest-perf.md                                    | +32    (Completed entry)
trading/test_data/backtest_scenarios/goldens-broad/tier4-N10000-5y.sexp | +45 (new)
trading/test_data/backtest_scenarios/goldens-broad/tier4-N5000-10y.sexp | +46 (new)
trading/test_data/backtest_scenarios/goldens-broad/tier4-N5000-5y.sexp  | +48 (new)
```

464 LOC total, well under the 500-LOC PR sizing target.

## PR sizing

- Single concern: tier-4 release-gate SCALE scaffolding.
- One new runner script; three new fixtures; doc updates only on existing files.
- No core-module modifications (A1-clean per `qc-structural-authority.md`).
- No new `analysis/` imports into `trading/trading/` (A2-clean — fixtures only).
- No code changes to existing modules (A3-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)