### PR TITLE
feat(experiments): M5.4 E3 stop-buffer sweep harness

### DIFF
--- a/dev/experiments/m5-4-e3-stop-buffer-sweep/README.md
+++ b/dev/experiments/m5-4-e3-stop-buffer-sweep/README.md
@@ -1,0 +1,123 @@
+# M5.4 E3 — Stop-buffer sweep
+
+8-cell sweep of `Weinstein_strategy.config.initial_stop_buffer` on the
+canonical `goldens-sp500/sp500-2019-2023` window.
+
+Plan: `dev/plans/m5-experiments-roadmap-2026-05-02.md` §M5.4 E3.
+Hypothesis: see `hypothesis.md`.
+
+## Status
+
+Harness only — sweep has not been run yet. The 8 scenario sexps live at
+`trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/`.
+
+## Run metadata
+
+- **Date harness landed**: 2026-05-03
+- **Override**: `initial_stop_buffer` (top-level on `Weinstein_strategy.config`)
+- **Grid**: `{1.00, 1.02, 1.05, 1.08, 1.10, 1.12, 1.15, 1.20}` (8 cells)
+- **Window**: `2019-01-02` .. `2023-12-29` (full Weinstein cycle: 2019
+  late-cycle advance → 2020 COVID crash → 2020-21 recovery → 2022 bear
+  → 2023 rotation recovery)
+- **Universe**: `universes/sp500.sexp` (491-symbol S&P 500 snapshot,
+  same as canonical golden)
+- **Initial cash**: $1,000,000 (inherited via Weinstein_strategy default)
+- **Cell name format**: `m5-4-e3-buffer-1.XX`
+- **Control within sweep**: `1.02` (matches current default); see also
+  the canonical sp500-2019-2023 golden which is functionally identical.
+
+## How to run
+
+From repo root, with the docker dev container running:
+
+```bash
+docker exec <container> bash -c \
+  'cd /workspaces/trading-1/trading && eval $(opam env) && \
+   dune exec backtest/scenarios/scenario_runner.exe -- \
+     --dir trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep \
+     --parallel 5'
+```
+
+Wall-clock estimate: ~5 cells in parallel × ~2h tier-3 budget per cell
+= ~3-4h depending on host cores. Local-only — do not run in GHA.
+
+The runner emits per-cell output under `dev/backtest/scenarios-<timestamp>/`:
+
+```
+dev/backtest/scenarios-YYYY-MM-DD-HHMMSS/
+├── m5-4-e3-buffer-1.00/
+│   ├── trades.csv
+│   ├── equity_curve.csv
+│   ├── summary.sexp
+│   ├── stop_log.csv
+│   └── ...
+├── m5-4-e3-buffer-1.02/
+└── ...
+```
+
+## What to look at when results come back
+
+Pull the same metrics across all 8 cells from each `summary.sexp` and
+build a comparison table similar to `dev/experiments/stop-buffer/report.md`'s
+shape. Headline columns:
+
+- **Total Return %**, **Sharpe Ratio**, **Calmar Ratio** — risk-adjusted
+  performance ranking
+- **Win Rate %**, **Avg Holding Days**, **Total Trades** — behavioral
+  shape (whipsaw vs. ride-through)
+- **Max Drawdown %** — risk side of the trade-off
+- **Profit Factor**, **Expectancy** (from M5.2b once landed) — quality
+  of trade selection
+- **% trades exited within 1 day** — direct whipsaw measure (from
+  trades.csv via M5.2e per-trade columns)
+
+Then write `report.md` with:
+
+1. Comparison table (all 8 cells × ~10 metrics)
+2. Cell ranking on Sharpe + Calmar + Total Return
+3. Verdict: which cell wins, by how much, with what error bars (compare
+   against the canonical sp500-2019-2023 fuzz IQR from PR #788:
+   +37.92%–+60.86%, Sharpe 0.41–0.56, MaxDD 31.28–35.99)
+4. Followup: whether to promote the winner (re-pin baseline) or escalate
+   to a multi-window robustness check before promoting
+
+If signal-to-noise is too low (any cell within fuzz IQR of the control),
+the verdict is **inconclusive** — escalate to a fuzz×grid joint sweep
+once `--fuzz` × grid is wired.
+
+## Why these grid points
+
+See `hypothesis.md` §"Sweep grid" for the per-cell rationale. Summary:
+
+- **1.00 / 1.20**: tail controls outside the book's 5–15% band
+- **1.02**: current default — control cell within the sweep
+- **1.05 / 1.08 / 1.10 / 1.12 / 1.15**: even spacing across the book's
+  recommended band, with 1.05 / 1.08 / 1.12 / 1.15 mirroring the prior
+  recovery-2023 sweep (2026-04-14) for cross-comparability
+
+## Relationship to prior experiments
+
+The 2026-04-14 study (`dev/experiments/stop-buffer/`) explored 5 cells
+on a single recovery-2023 window. Its conclusion was **default stays at
+1.02** because the single-regime sweep's verdict reversed on the
+6-year golden. This M5.4 E3 sweep:
+
+- Uses the multi-regime sp500-2019-2023 golden from the start (no
+  single-window pitfall)
+- Adds 3 new cells (1.00, 1.10, 1.20) for a wider grid
+- Runs against the new canonical baseline (post-#744/#745/#746/#771)
+
+If results re-confirm 1.02 as the optimum, the prior verdict stands. If
+they promote a different cell, that's a baseline change requiring a
+re-pin of the sp500-2019-2023 golden's expected ranges.
+
+## Followups (out of scope for this PR)
+
+- Run the sweep (local, by user)
+- Write `report.md` with comparison table + verdict
+- If a cell wins decisively: re-pin baseline, propagate to short-side
+  golden + small-universe scenarios
+- If signal is unclear: escalate to a `--fuzz` × grid joint sweep once
+  the runner supports it (M5.4 follow-up)
+- Cross-window robustness: re-run the winner on a 2008 GFC window once
+  Norgate ingestion lands (M5.3)

--- a/dev/experiments/m5-4-e3-stop-buffer-sweep/hypothesis.md
+++ b/dev/experiments/m5-4-e3-stop-buffer-sweep/hypothesis.md
@@ -1,0 +1,108 @@
+# M5.4 E3 — Stop-buffer sweep: hypothesis
+
+## Date
+2026-05-03
+
+## Hypothesis
+
+> Widening `initial_stop_buffer` from the current default of 1.02 (2%) to
+> values in the 1.05–1.15 range improves risk-adjusted return (Sharpe,
+> Calmar) on the sp500-2019-2023 full-cycle golden by reducing whipsaw
+> exits.
+
+Per `dev/plans/m5-experiments-roadmap-2026-05-02.md` §M5.4 E3.
+
+The book (Weinstein Ch. 6) prescribes initial stops 5–15% below entry,
+sited at the prior correction low. The current default of 1.02 (2%) is
+materially tighter than the book's lower bound and produces frequent
+sub-1-day stop-outs in baseline runs (74% whipsaw rate observed in the
+prior recovery-2023 stop-buffer experiment, dev/experiments/stop-buffer/).
+
+## Why re-run despite the prior `dev/experiments/stop-buffer/` study
+
+The 2026-04-14 stop-buffer experiment ran a 5-cell sweep on a single
+recovery-2023 window (2023-01-02 .. 2023-12-31). Its conclusion was
+**hypothesis rejected on the 6-year golden** — single-regime tuning
+favoured 1.15, but the multi-regime golden reversed that ordering and
+the default stayed at 1.02.
+
+Three things have changed since:
+
+1. **Canonical baseline moved.** The sp500-2019-2023 golden was re-pinned
+   on 2026-05-02 to 60.86% return / 86 trades / 0.55 Sharpe (vs the
+   2026-04-30 baseline of -0.01% / 32 trades) after #744 (sizing fix),
+   #745 (cash-deployment fix), #746 (long/short cap split), and #771
+   (stop tuning). The behaviour space the prior study explored is no
+   longer current.
+2. **Wider grid.** This sweep adds 1.00 (no buffer; tightest possible),
+   1.10 (canonical 10% rule of thumb), and 1.20 (out-of-band right-tail
+   control) to the prior 1.02 / 1.05 / 1.08 / 1.12 / 1.15 set. 8 cells
+   total, all run on the same multi-regime window.
+3. **Single multi-regime window from the start.** sp500-2019-2023 covers
+   late-cycle advance (2019), COVID crash (2020 H1), V-recovery (2020
+   H2 – 2021), bear (2022), and rotation recovery (2023) — five regimes
+   in one run. Avoids the prior study's single-regime-then-validate
+   pitfall by collapsing the initial sweep onto the multi-regime view.
+
+## Sweep grid
+
+| Cell | `initial_stop_buffer` | Buffer meaning | Note |
+|------|----------------------|----------------|------|
+| 1.00 | 1.00 | exactly at suggested | left-tail control (no buffer at all) |
+| 1.02 | 1.02 | 2% beyond suggested | current default; control / baseline within sweep |
+| 1.05 | 1.05 | 5% beyond suggested | book lower bound |
+| 1.08 | 1.08 | 8% beyond suggested | book lower-mid |
+| 1.10 | 1.10 | 10% beyond suggested | "10% trailing stop" rule of thumb |
+| 1.12 | 1.12 | 12% beyond suggested | book upper-mid; prior study's win-rate winner on recovery-2023 |
+| 1.15 | 1.15 | 15% beyond suggested | book upper bound |
+| 1.20 | 1.20 | 20% beyond suggested | out-of-band right-tail control |
+
+8 cells, all on `goldens-sp500/sp500-2019-2023` (same universe, period,
+and config; only `initial_stop_buffer` varies).
+
+## Falsification criteria
+
+The hypothesis is **not supported** if:
+
+1. Sharpe and Calmar are flat (within ±10% of the 1.02 control) across
+   the entire 1.05–1.15 band, indicating the prior study's signal was a
+   single-regime artefact that doesn't replicate on the new baseline.
+2. Total return degrades monotonically with wider buffers (1.00 best,
+   1.20 worst), indicating the strategy genuinely cannot hold positions
+   profitably beyond the tight default.
+3. Variance between runs (start-date sensitivity, fuzz IQR) exceeds the
+   signal between cells. The 2026-05-02 fuzz on the canonical baseline
+   spans +37.92%–+60.86% — if a sweep cell falls inside that band, it
+   isn't statistically distinguishable from the control.
+
+## Expected qualitative shape
+
+Naive prior:
+
+- **Win rate:** monotonic up with buffer (less whipsaw); plateau or
+  reverse past 1.15 as positions held too long give back gains.
+- **Total trades:** monotonic down with buffer (fewer positions
+  re-cycled).
+- **Avg holding days:** monotonic up with buffer.
+- **Max drawdown:** *not* monotonic. Tight buffers (1.00 / 1.02) stop
+  out fast → small drawdowns from individual losses but high frequency.
+  Wide buffers (1.15 / 1.20) absorb larger excursions per trade →
+  fewer-but-larger drawdowns. Optimal is some interior point.
+- **Sharpe / Calmar:** maximum at an interior cell (best guess: 1.05
+  to 1.10), not at either extreme.
+
+If the actual shape diverges meaningfully from the above (e.g. monotone
+in either direction across the full grid), that itself is a useful
+finding — the sub-1-day whipsaw mode may not be the dominant loss
+driver on the multi-regime sp500 golden.
+
+## What this experiment does NOT prove
+
+1. **One window, even a 5-year one, is not a regime ensemble.** A 1.10
+   winner here may not be the cross-regime winner. Norgate ingestion
+   (M5.3) + the smoke catalog will let a follow-up triangulate this.
+2. **`initial_stop_buffer` is one knob.** The trailing-stop-percent
+   parameters in `stops_config` are unchanged — a wider initial buffer
+   may interact non-trivially with those.
+3. **Survivorship bias.** Universe is today's S&P 500. Norgate fix
+   forthcoming (M5.3).

--- a/dev/status/experiments.md
+++ b/dev/status/experiments.md
@@ -1,9 +1,9 @@
 # Status: experiments
 
-## Last updated: 2026-05-02
+## Last updated: 2026-05-03
 
 ## Status
-IN_PROGRESS — M5.2e per-trade context logging shipped (PR #769, READY_FOR_REVIEW); M5.2a–d still PLANNED, M5.4 blocked on M5.1.
+IN_PROGRESS — M5.2e per-trade context logging shipped (PR #769, READY_FOR_REVIEW); M5.4 E3 sweep harness landed (this PR); M5.2a–d still PLANNED, sweep runs blocked on M5.1.
 
 Track created 2026-05-02 to absorb M5.2 (experiment infra) + M5.4 (mechanical experiments). Plan: `dev/plans/m5-experiments-roadmap-2026-05-02.md`. Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M5.2 + M5.4 (added 2026-05-02).
 
@@ -27,7 +27,7 @@ NO — track is brand-new.
 
 - **E1 — Short on/off A/B** (uses 2a `--baseline`)
 - **E2 — Segmentation-driven Stage classifier** (`stage_method = MaSlope | Segmentation` enum; lib already exists at `analysis/technical/trend/segmentation.{ml,mli}`)
-- **E3 — Stop-buffer sweep** (1.05 / 1.08 / 1.12 on smoke scenarios)
+- [x] **E3 — Stop-buffer sweep harness** (8 cells: 1.00 / 1.02 / 1.05 / 1.08 / 1.10 / 1.12 / 1.15 / 1.20 on `goldens-sp500/sp500-2019-2023`). Scenarios at `trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/`; hypothesis + README at `dev/experiments/m5-4-e3-stop-buffer-sweep/`. Run via `dune exec backtest/scenarios/scenario_runner.exe -- --dir trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep --parallel 5` (local-only; ~5×2h tier-3 budget). Sweep run + report.md is the follow-up.
 - **E4 — Scoring-weight sweep** (4-dim grid; manual prequel to M5.5 tuning)
 
 ## In Progress
@@ -35,6 +35,7 @@ NO — track is brand-new.
 
 ## Completed
 - M5.2e per-trade context logging (PR #769, 2026-05-02) — 6 new columns on trades.csv; `Trade_context` module + `Stop_log.classify_stop_trigger_kind` + `Trade_audit.entry_decision.volume_ratio`. Trade audit + stop_log pure-projection join. Verify via `dune runtest trading/backtest/test --force` (passes 14/14 in test_trade_context.ml + 18/18 in test_stop_log.ml + 26/26 in test_result_writer.ml).
+- M5.4 E3 stop-buffer sweep harness (this PR, 2026-05-03) — 8-cell grid on `goldens-sp500/sp500-2019-2023` window (`{1.00, 1.02, 1.05, 1.08, 1.10, 1.12, 1.15, 1.20}`). Scenarios at `trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.XX.sexp`; hypothesis + README at `dev/experiments/m5-4-e3-stop-buffer-sweep/`. Verify parse via `dune build && dune runtest trading/backtest/scenarios/test/`. Sweep itself is local-only follow-up (~5×2h budget).
 
 ## Next Steps
 

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.00.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.00.sexp
@@ -1,0 +1,26 @@
+;; M5.4 E3 stop-buffer sweep — 1.00 (no buffer; stop at suggested level).
+;;
+;; Sweep cell: stop_buffer = 1.00 → stop placed exactly at the screener's
+;; suggested level (no buffer). Tightest possible stop in the grid.
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E3.
+;; Universe + period mirror the canonical sp500-2019-2023 golden so the
+;; sweep is comparable to the pinned baseline (60.86% / 86 trades / 0.55
+;; Sharpe / 34.15% MaxDD as of 2026-05-02).
+;;
+;; Expected ranges are deliberately wide — sweep cells exist to discover
+;; behaviour, not to pin it. Re-tighten only if a follow-up experiment
+;; promotes a specific cell to the canonical baseline.
+((name "m5-4-e3-buffer-1.00")
+ (description "M5.4 E3 sweep: initial_stop_buffer = 1.00 (no buffer)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides (((initial_stop_buffer 1.00))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.02.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.02.sexp
@@ -1,0 +1,27 @@
+;; M5.4 E3 stop-buffer sweep — 1.02 (current default; control cell).
+;;
+;; Sweep cell: stop_buffer = 1.02 → 2% beyond the suggested level. This
+;; matches the current Weinstein_strategy.config default and serves as the
+;; control / baseline within this sweep.
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E3.
+;; Universe + period mirror the canonical sp500-2019-2023 golden so the
+;; sweep is comparable to the pinned baseline (60.86% / 86 trades / 0.55
+;; Sharpe / 34.15% MaxDD as of 2026-05-02).
+;;
+;; Expected ranges are deliberately wide — sweep cells exist to discover
+;; behaviour, not to pin it. Re-tighten only if a follow-up experiment
+;; promotes a specific cell to the canonical baseline.
+((name "m5-4-e3-buffer-1.02")
+ (description "M5.4 E3 sweep: initial_stop_buffer = 1.02 (current default; control)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides (((initial_stop_buffer 1.02))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.05.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.05.sexp
@@ -1,0 +1,28 @@
+;; M5.4 E3 stop-buffer sweep — 1.05 (5% beyond suggested stop).
+;;
+;; Sweep cell: stop_buffer = 1.05 → 5% beyond the suggested level. Within
+;; the 5–8% band the prior recovery-2023 stop-buffer experiment (2026-04-14,
+;; dev/experiments/stop-buffer/) found most favourable on a single regime
+;; before the 6-year golden reversed the verdict.
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E3.
+;; Universe + period mirror the canonical sp500-2019-2023 golden so the
+;; sweep is comparable to the pinned baseline (60.86% / 86 trades / 0.55
+;; Sharpe / 34.15% MaxDD as of 2026-05-02).
+;;
+;; Expected ranges are deliberately wide — sweep cells exist to discover
+;; behaviour, not to pin it. Re-tighten only if a follow-up experiment
+;; promotes a specific cell to the canonical baseline.
+((name "m5-4-e3-buffer-1.05")
+ (description "M5.4 E3 sweep: initial_stop_buffer = 1.05 (5% beyond suggested stop)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides (((initial_stop_buffer 1.05))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.08.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.08.sexp
@@ -1,0 +1,28 @@
+;; M5.4 E3 stop-buffer sweep — 1.08 (8% beyond suggested stop).
+;;
+;; Sweep cell: stop_buffer = 1.08 → 8% beyond the suggested level. Per
+;; Weinstein Ch. 6, initial stops should sit below the prior correction
+;; low (typically 5-15% below entry), so 1.08 is squarely in the book's
+;; recommended band.
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E3.
+;; Universe + period mirror the canonical sp500-2019-2023 golden so the
+;; sweep is comparable to the pinned baseline (60.86% / 86 trades / 0.55
+;; Sharpe / 34.15% MaxDD as of 2026-05-02).
+;;
+;; Expected ranges are deliberately wide — sweep cells exist to discover
+;; behaviour, not to pin it. Re-tighten only if a follow-up experiment
+;; promotes a specific cell to the canonical baseline.
+((name "m5-4-e3-buffer-1.08")
+ (description "M5.4 E3 sweep: initial_stop_buffer = 1.08 (8% beyond suggested stop)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides (((initial_stop_buffer 1.08))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.10.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.10.sexp
@@ -1,0 +1,27 @@
+;; M5.4 E3 stop-buffer sweep — 1.10 (10% beyond suggested stop).
+;;
+;; Sweep cell: stop_buffer = 1.10 → 10% beyond the suggested level. Mid-
+;; point of the book's 5–15% band; the canonical "10% trailing stop" rule
+;; of thumb expressed as an initial buffer.
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E3.
+;; Universe + period mirror the canonical sp500-2019-2023 golden so the
+;; sweep is comparable to the pinned baseline (60.86% / 86 trades / 0.55
+;; Sharpe / 34.15% MaxDD as of 2026-05-02).
+;;
+;; Expected ranges are deliberately wide — sweep cells exist to discover
+;; behaviour, not to pin it. Re-tighten only if a follow-up experiment
+;; promotes a specific cell to the canonical baseline.
+((name "m5-4-e3-buffer-1.10")
+ (description "M5.4 E3 sweep: initial_stop_buffer = 1.10 (10% beyond suggested stop)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides (((initial_stop_buffer 1.10))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.12.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.12.sexp
@@ -1,0 +1,29 @@
+;; M5.4 E3 stop-buffer sweep — 1.12 (12% beyond suggested stop).
+;;
+;; Sweep cell: stop_buffer = 1.12 → 12% beyond the suggested level. Upper
+;; portion of the book's 5–15% band. The prior recovery-2023 experiment
+;; (2026-04-14) showed 1.12 had the highest win rate (54.8%) on a single
+;; regime, but the 6-year golden reversed that ordering — see
+;; dev/experiments/stop-buffer/report.md.
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E3.
+;; Universe + period mirror the canonical sp500-2019-2023 golden so the
+;; sweep is comparable to the pinned baseline (60.86% / 86 trades / 0.55
+;; Sharpe / 34.15% MaxDD as of 2026-05-02).
+;;
+;; Expected ranges are deliberately wide — sweep cells exist to discover
+;; behaviour, not to pin it. Re-tighten only if a follow-up experiment
+;; promotes a specific cell to the canonical baseline.
+((name "m5-4-e3-buffer-1.12")
+ (description "M5.4 E3 sweep: initial_stop_buffer = 1.12 (12% beyond suggested stop)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides (((initial_stop_buffer 1.12))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.15.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.15.sexp
@@ -1,0 +1,26 @@
+;; M5.4 E3 stop-buffer sweep — 1.15 (15% beyond suggested stop).
+;;
+;; Sweep cell: stop_buffer = 1.15 → 15% beyond the suggested level. The
+;; book's stated upper bound for the initial-stop-below-prior-low rule.
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E3.
+;; Universe + period mirror the canonical sp500-2019-2023 golden so the
+;; sweep is comparable to the pinned baseline (60.86% / 86 trades / 0.55
+;; Sharpe / 34.15% MaxDD as of 2026-05-02).
+;;
+;; Expected ranges are deliberately wide — sweep cells exist to discover
+;; behaviour, not to pin it. Re-tighten only if a follow-up experiment
+;; promotes a specific cell to the canonical baseline.
+((name "m5-4-e3-buffer-1.15")
+ (description "M5.4 E3 sweep: initial_stop_buffer = 1.15 (15% beyond suggested stop; book max)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides (((initial_stop_buffer 1.15))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.20.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.20.sexp
@@ -1,0 +1,29 @@
+;; M5.4 E3 stop-buffer sweep — 1.20 (20% beyond suggested stop; out-of-band).
+;;
+;; Sweep cell: stop_buffer = 1.20 → 20% beyond the suggested level. Past
+;; the book's 5–15% upper bound; included as the right-tail control to
+;; characterise behaviour past the recommended range. Expect monotone
+;; drop-off in win rate vs the 1.10–1.15 cells if the book's guidance
+;; holds.
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E3.
+;; Universe + period mirror the canonical sp500-2019-2023 golden so the
+;; sweep is comparable to the pinned baseline (60.86% / 86 trades / 0.55
+;; Sharpe / 34.15% MaxDD as of 2026-05-02).
+;;
+;; Expected ranges are deliberately wide — sweep cells exist to discover
+;; behaviour, not to pin it. Re-tighten only if a follow-up experiment
+;; promotes a specific cell to the canonical baseline.
+((name "m5-4-e3-buffer-1.20")
+ (description "M5.4 E3 sweep: initial_stop_buffer = 1.20 (20% beyond suggested stop; out-of-band)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides (((initial_stop_buffer 1.20))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))


### PR DESCRIPTION
## Summary

- 8-cell sweep of `Weinstein_strategy.config.initial_stop_buffer` on the canonical `goldens-sp500/sp500-2019-2023` window: `{1.00, 1.02, 1.05, 1.08, 1.10, 1.12, 1.15, 1.20}`. Per `dev/plans/m5-experiments-roadmap-2026-05-02.md` §M5.4 E3.
- Path A (per-variant scenario sexps), the simpler of the two paths in the dispatch — each cell is a copy of the canonical golden differing only in `name`, `description`, and the `(config_overrides (((initial_stop_buffer 1.XX))))` override. The existing `scenario_runner.exe --dir <dir> --parallel N` runs them all.
- Harness only — sweep run + comparison `report.md` are the local-only follow-up.

## What changes

- `trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.{00,02,05,08,10,12,15,20}.sexp` — 8 sweep cells (universe + period + ranges identical; only the override differs)
- `dev/experiments/m5-4-e3-stop-buffer-sweep/{hypothesis.md, README.md}` — falsifiable hypothesis + run instructions
- `dev/status/experiments.md` — tick the M5.4 E3 box, add a Completed entry

No source-code changes; no behavioural drift; no test changes. A2/A3 clean.

## Why these grid points

The prior 2026-04-14 stop-buffer experiment (`dev/experiments/stop-buffer/`) explored 5 cells on a single recovery-2023 window and concluded the default should stay at 1.02 because the single-regime winner (1.15) reversed on the 6-year golden. This sweep:

- Uses the multi-regime sp500-2019-2023 golden from the start
- Adds 1.00 (left-tail control), 1.10 (canonical 10% rule of thumb), and 1.20 (out-of-band right-tail control) to the prior 1.02 / 1.05 / 1.08 / 1.12 / 1.15 set
- Runs against the new canonical baseline (post-#744/#745/#746/#771)

See `dev/experiments/m5-4-e3-stop-buffer-sweep/hypothesis.md` for the full hypothesis + falsification criteria.

## Test plan

- [x] All 8 sexps parse via `Scenario.load` — verified locally with an ad-hoc `test_e3_parse.exe` (passed; not committed to keep the PR scope to fixtures + docs only)
- [x] `dune build` clean
- [x] No source modifications — only fixtures + docs
- [ ] Sweep run + comparison `report.md` (local-only, by user — out of scope for this PR)

## How to run (local)

```bash
docker exec <container> bash -c \
  'cd /workspaces/trading-1/trading && eval $(opam env) && \
   dune exec backtest/scenarios/scenario_runner.exe -- \
     --dir trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep \
     --parallel 5'
```

Wall-clock: ~5 cells in parallel × ~2h tier-3 budget = ~3-4h. **Local-only — do not run in GHA.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)