### PR TITLE
feat(experiments): M5.4 E4 scoring-weight sweep harness

### DIFF
--- a/dev/experiments/m5-4-e4-scoring-weight-sweep/README.md
+++ b/dev/experiments/m5-4-e4-scoring-weight-sweep/README.md
@@ -1,0 +1,166 @@
+# M5.4 E4 — Scoring-weight sweep
+
+8-cell sweep of `Weinstein_strategy.config.screening_config.weights`
+(the `Screener.scoring_weights` record) on the canonical
+`goldens-sp500/sp500-2019-2023` window.
+
+Plan: `dev/plans/m5-experiments-roadmap-2026-05-02.md` §M5.4 E4.
+Hypothesis: see `hypothesis.md`.
+
+## Status
+
+Harness only — sweep has not been run yet. The 8 scenario sexps live at
+`trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/`.
+
+## Run metadata
+
+- **Date harness landed**: 2026-05-03
+- **Override**: `screening_config.weights.*` (one or two fields per cell)
+- **Window**: `2019-01-02` .. `2023-12-29` (full Weinstein cycle: 2019
+  late-cycle advance → 2020 COVID crash → 2020-21 recovery → 2022 bear
+  → 2023 rotation recovery)
+- **Universe**: `universes/sp500.sexp` (491-symbol S&P 500 snapshot,
+  same as canonical golden)
+- **Initial cash**: $1,000,000 (inherited via Weinstein_strategy default)
+- **Cell name format**: `m5-4-e4-<axis>` (e.g. `m5-4-e4-stage-heavy`)
+- **Control within sweep**: `baseline` (zero overrides; functionally
+  equivalent to the canonical sp500-2019-2023 golden)
+
+## Cells
+
+| Cell | Override | Tests |
+|---|---|---|
+| `baseline` | (none) | Control / sanity check vs canonical golden |
+| `equal-weights` | 4 primary axes all = 20 | Whether weight hierarchy matters at all |
+| `stage-heavy` | `w_stage2_breakout=60` (2x) | Stage-transition signal dominance |
+| `volume-heavy` | `w_strong_volume=40, w_adequate_volume=20` (2x) | Volume confirmation weight |
+| `rs-heavy` | `w_positive_rs=40, w_bullish_rs_crossover=20` (2x) | Relative-strength leadership weight |
+| `resistance-heavy` | `w_clean_resistance=30` (2x) | Clean-overhead breakout weight |
+| `sector-heavy` | `w_sector_strong=20` (2x) | Sector context bonus |
+| `late-stage-strict` | `w_late_stage2_penalty=-30` (2x harsher) | Late-stage penalty severity |
+
+All other weights remain at default
+(`Screener.default_scoring_weights`). The "2x default" choice is uniform
+across positive-weight cells so the magnitude axis stays comparable.
+
+## How to run
+
+From repo root, with the docker dev container running:
+
+```bash
+docker exec <container> bash -c \
+  'cd /workspaces/trading-1/trading && eval $(opam env) && \
+   dune exec backtest/scenarios/scenario_runner.exe -- \
+     --dir trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep \
+     --parallel 5'
+```
+
+Wall-clock estimate: ~5 cells in parallel × ~2h tier-3 budget per cell
+= ~3-4h depending on host cores. Local-only — do not run in GHA.
+
+The runner emits per-cell output under `dev/backtest/scenarios-<timestamp>/`:
+
+```
+dev/backtest/scenarios-YYYY-MM-DD-HHMMSS/
+├── m5-4-e4-baseline/
+│   ├── trades.csv
+│   ├── equity_curve.csv
+│   ├── summary.sexp
+│   ├── stop_log.csv
+│   └── ...
+├── m5-4-e4-stage-heavy/
+└── ...
+```
+
+## What to look at when results come back
+
+Pull the same metrics across all 8 cells from each `summary.sexp` and
+build a comparison table. Headline columns:
+
+- **Total Return %**, **Sharpe Ratio**, **Calmar Ratio** — risk-adjusted
+  performance ranking
+- **Win Rate %**, **Avg Holding Days**, **Total Trades** — behavioural
+  shape (selectivity vs activity)
+- **Max Drawdown %** — risk side
+- **Profit Factor**, **Expectancy** (from M5.2b once landed) — quality
+  of trade selection
+- **% trades originating from each axis-dominant grade band** — reveals
+  WHICH candidates actually changed ranking, distinguishing
+  "score moved but symbols stayed" from "different symbols entered
+  top-20"
+
+Then write `report.md` with:
+
+1. Comparison table (all 8 cells × ~10 metrics)
+2. Cell ranking on Sharpe + Calmar + Total Return
+3. Verdict: which axis dominates (if any), by how much, with what
+   error bars (compare against the canonical sp500-2019-2023 fuzz IQR
+   from PR #788: +37.92%–+60.86%, Sharpe 0.41–0.56, MaxDD 31.28–35.99)
+4. Followup: feed the dominant axis (if found) into M5.5 T-A grid
+   search as the prior; if no axis dominates, the tuner runs the full
+   4-D grid with the noise floor from this sweep informing early-stop
+
+If signal-to-noise is too low (any cell within fuzz IQR of the
+control), the verdict is **inconclusive** — escalate to a fuzz×grid
+joint sweep once that's wired.
+
+## Why these cells
+
+See `hypothesis.md` §"Sweep grid" for the per-cell rationale. Summary:
+
+- **`baseline`**: zero overrides → reproduces canonical golden;
+  control cell within the sweep.
+- **`equal-weights`**: meta-cell that tests whether the four-axis
+  hierarchy produces a different selection at all. If equal ≈ baseline
+  → tuning weights is the wrong knob; redirect to grade thresholds /
+  candidate caps / pricing.
+- **`stage-heavy` / `volume-heavy` / `rs-heavy` / `resistance-heavy`**:
+  the four primary positive-signal axes from the cascade scoring
+  function. Doubling each in turn isolates per-axis signal.
+- **`sector-heavy`**: fifth axis (sector bonus); included for
+  completeness even though the upstream sector pre-filter already does
+  most of the sector work.
+- **`late-stage-strict`**: the only negative weight in the default;
+  doubling its severity tests the symmetric question (does penalising
+  bad setups matter as much as rewarding good ones?). Likely the
+  cleanest predicted effect.
+
+## Config-surface gaps (none blocking)
+
+The eight `scoring_weights` fields on `Screener.config.weights` are all
+independently tunable via `(config_overrides (((screening_config ((weights
+((<field> <value>))))))))`. The runner's deep-merge primitives
+(`Backtest.Runner._merge_sexp`) handle partial-record overlays — only
+the changed weight fields need to appear in the override sexp; the
+others inherit from `Screener.default_scoring_weights`.
+
+No structural gap was discovered while writing this harness; the cascade
+is fully tunable on these axes. The 81-cell grid envisioned by the plan
+(§M5.4 E4) is mechanically buildable today; the only reason to do this
+8-cell prequel first is to constrain the search before paying for it.
+
+## Relationship to prior experiments
+
+- **E3 stop-buffer sweep** (`dev/experiments/m5-4-e3-stop-buffer-sweep/`,
+  PR #815): orthogonal axis (stop-distance, not score). E3 + E4
+  together cover the two cheapest single-knob tunings before the M5.5
+  tuner lands.
+- **stop-buffer 2026-04-14**
+  (`dev/experiments/stop-buffer/`): pre-canonical-baseline; superseded
+  by E3.
+- No prior scoring-weight experiments exist in the repo. This is the
+  first.
+
+## Followups (out of scope for this PR)
+
+- Run the sweep (local, by user or follow-up agent)
+- Write `report.md` with comparison table + verdict
+- If a single axis dominates: redirect M5.5 T-A grid search to 1-D on
+  that axis (cheap)
+- If multiple axes have signal: run M5.5 T-A as full 4-D grid (3×3×3×3
+  = 81 cells) with this sweep's noise floor as the early-stop
+  threshold
+- If no axis dominates: redirect tuning effort to grade thresholds,
+  `candidate_params`, or structural cascade changes
+- Cross-window robustness: re-run the dominant-axis cell on a 2008 GFC
+  window once Norgate ingestion lands (M5.3)

--- a/dev/experiments/m5-4-e4-scoring-weight-sweep/hypothesis.md
+++ b/dev/experiments/m5-4-e4-scoring-weight-sweep/hypothesis.md
@@ -1,0 +1,146 @@
+# M5.4 E4 — Scoring-weight sweep: hypothesis
+
+## Date
+2026-05-03
+
+## Hypothesis
+
+> The screener's current scoring weights (`Screener.default_scoring_weights`)
+> were hand-set in 2026-Q1 against a single qualitative ordering — stage
+> > rs ≈ volume > resistance > sector. A one-axis-at-a-time perturbation
+> sweep on the canonical sp500-2019-2023 multi-regime golden will reveal
+> which axis materially moves risk-adjusted return (Sharpe, Calmar) and
+> which is noise relative to the win-rate / total-return surface.
+
+Per `dev/plans/m5-experiments-roadmap-2026-05-02.md` §M5.4 E4.
+
+## Why this experiment exists
+
+The plan calls for a 3×3×3×3 grid (~81 cells) over the four primary
+weights — too expensive to run as a flat sweep without a tuner. This is
+the **manual prequel**: 8 single-axis perturbations that establish which
+weight has signal before T-A grid search (M5.5) wires up. If the sweep
+shows one axis dominates Sharpe, the tuner's grid can collapse to 1-D
+on that axis. If three axes look interchangeable, the tuner needs the
+full grid and an interpretable objective to decide which.
+
+The weights being swept (per `Screener.default_scoring_weights`):
+
+| Field | Default | Signal it captures |
+|---|---|---|
+| `w_stage2_breakout` | 30 | Clean Stage1→Stage2 transition (highest single weight) |
+| `w_strong_volume` | 20 | Volume confirmation at breakout |
+| `w_adequate_volume` | 10 | Half-credit volume confirmation |
+| `w_positive_rs` | 20 | Steady positive RS trend |
+| `w_bullish_rs_crossover` | 10 | RS crossing from negative to positive |
+| `w_clean_resistance` | 15 | Virgin territory / clean overhead |
+| `w_sector_strong` | 10 | Sector rated Strong |
+| `w_late_stage2_penalty` | -15 | Late-Stage2 (the only negative weight) |
+
+## Sweep grid
+
+8 cells, each perturbing one axis from default while leaving the others
+unchanged:
+
+| Cell | Description | Override (vs default) |
+|------|-------------|------------------------|
+| `baseline` | control | (none) |
+| `equal-weights` | 4 primary axes equalised | `w_stage2_breakout=20 w_strong_volume=20 w_positive_rs=20 w_clean_resistance=20` |
+| `stage-heavy` | stage transition 2x | `w_stage2_breakout=60` |
+| `volume-heavy` | both volume tiers 2x | `w_strong_volume=40 w_adequate_volume=20` |
+| `rs-heavy` | both RS levers 2x | `w_positive_rs=40 w_bullish_rs_crossover=20` |
+| `resistance-heavy` | clean overhead 2x | `w_clean_resistance=30` |
+| `sector-heavy` | sector strong 2x | `w_sector_strong=20` |
+| `late-stage-strict` | late-stage penalty 2x harsher | `w_late_stage2_penalty=-30` |
+
+All on `goldens-sp500/sp500-2019-2023` (491-symbol S&P snapshot,
+2019-01-02 .. 2023-12-29; same window as canonical golden + E3).
+
+The "2x default" choice is uniform across cells so the magnitude axis
+stays comparable. `equal-weights` is the only multi-axis cell; it tests
+whether the relative weighting matters at all (if equal-weights ≈
+baseline, the weighting hierarchy is informational not behavioural).
+
+## Falsification criteria
+
+The hypothesis is **not supported** if:
+
+1. **All 7 perturbations land within fuzz IQR of baseline.** The
+   sp500-2019-2023 fuzz baseline (PR #788) spans +37.92%–+60.86% on
+   total return; if every weight cell falls in that band, the cascade's
+   weighting is dominated by upstream filtering (stage classifier, RS
+   gate, sector pre-filter) and the score-rank is just choosing among
+   already-acceptable candidates.
+2. **`equal-weights` matches `baseline` within ±5% return.** Strong
+   evidence the four-axis hierarchy doesn't affect candidate selection
+   — likely because the cap (`max_buy_candidates=20`) dominates and the
+   relative order within top-20 doesn't change which positions actually
+   get traded.
+3. **No single axis consistently dominates the others.** If
+   `stage-heavy`, `volume-heavy`, `rs-heavy`, and `resistance-heavy`
+   produce statistically indistinguishable Sharpe/Calmar, then T-A
+   tuner work is unwarranted and effort should redirect to grade
+   thresholds, the entry/stop pricing block (`candidate_params`), or
+   structural changes upstream.
+
+Conversely, the hypothesis is **supported** if:
+
+- Two or more cells differ from baseline by ≥10% on Sharpe AND the
+  ordering is consistent with a clear directional bet (e.g., RS-heavy
+  improves Sharpe, sector-heavy does not).
+- `late-stage-strict` materially reduces total trades while preserving
+  return — direct evidence the default penalty under-cuts marginal
+  setups.
+
+## Expected qualitative shape
+
+Naive priors (to be falsified or confirmed):
+
+- **`stage-heavy`**: Tightens the score top-end without changing which
+  symbols enter the top-20. Expectation: marginally fewer trades,
+  marginally higher win rate, ambiguous total return.
+- **`volume-heavy`**: Promotes high-volume names that were borderline
+  on stage. Expectation: noticeable shift in which symbols trade, with
+  unclear directional return effect — depends on whether high-volume
+  breakouts on this universe are good signal or noise.
+- **`rs-heavy`**: Same shape as volume-heavy but on a Weinstein-purer
+  signal. Best bet for a positive Sharpe move per Ch. 4.
+- **`resistance-heavy`**: Smaller cardinality of "virgin territory"
+  candidates than other axes; doubling its weight may not even reorder
+  the top-20. Expectation: smallest behavioural change.
+- **`sector-heavy`**: Sector context already filters via the
+  Strong/Weak gate; the bonus is additive on top. Doubling it likely
+  has small effect on return but visible shift in sector composition.
+- **`equal-weights`**: Almost certainly indistinguishable from baseline
+  unless the score's tail (rank 15–20) matters more than rank 1–10.
+- **`late-stage-strict`**: The clearest predicted effect — reduce trade
+  count by ~5–15% while improving win rate, since the doubled penalty
+  cuts trades that scored just-barely-above-min-grade.
+
+## What this experiment does NOT prove
+
+1. **One window is one regime ensemble's worth of data.** sp500-2019-2023
+   covers five regimes but is one universe; the same sweep on a 2008
+   GFC window may invert the verdict.
+2. **One-axis-at-a-time misses interactions.** A tuner-driven grid is
+   needed to detect whether `rs-heavy + volume-heavy` jointly outperform
+   either alone.
+3. **The score weights don't dominate the cascade.** If macro gate +
+   sector pre-filter + min-grade cut + max_buy_candidates cap
+   collectively select 95% of positions before scoring matters, the
+   sweep may just measure noise on the residual 5%. This itself would
+   be a useful finding — it would redirect tuner work upstream.
+4. **Survivorship bias.** Universe is today's S&P 500. Norgate fix
+   forthcoming (M5.3).
+
+## Relationship to M5.5 (tuning)
+
+If this sweep identifies one or two dominant axes, T-A grid search
+(M5.5) collapses from 4-D to 1-D or 2-D — order-of-magnitude wall
+saving. If the sweep shows no single axis matters, T-A still runs the
+full 4-D grid but with an empirical noise floor from this sweep to
+stop early when no cell beats baseline by the noise threshold.
+
+This sweep is the **prior** that informs how T-A is parameterised. It
+is not itself a tuning step — it doesn't search; it samples 8 specific
+points to see whether the search is worth running.

--- a/dev/status/experiments.md
+++ b/dev/status/experiments.md
@@ -3,7 +3,7 @@
 ## Last updated: 2026-05-03
 
 ## Status
-IN_PROGRESS — M5.2e per-trade context logging shipped (PR #769, READY_FOR_REVIEW); M5.4 E3 sweep harness landed (this PR); M5.2a–d still PLANNED, sweep runs blocked on M5.1.
+IN_PROGRESS — M5.2e per-trade context logging shipped (PR #769, READY_FOR_REVIEW); M5.4 E3 sweep harness landed (PR #815); M5.4 E4 scoring-weight sweep harness landed (this PR); M5.2a–d still PLANNED, sweep runs blocked on M5.1.
 
 Track created 2026-05-02 to absorb M5.2 (experiment infra) + M5.4 (mechanical experiments). Plan: `dev/plans/m5-experiments-roadmap-2026-05-02.md`. Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M5.2 + M5.4 (added 2026-05-02).
 
@@ -28,14 +28,15 @@ NO — track is brand-new.
 - **E1 — Short on/off A/B** (uses 2a `--baseline`)
 - **E2 — Segmentation-driven Stage classifier** (`stage_method = MaSlope | Segmentation` enum; lib already exists at `analysis/technical/trend/segmentation.{ml,mli}`)
 - [x] **E3 — Stop-buffer sweep harness** (8 cells: 1.00 / 1.02 / 1.05 / 1.08 / 1.10 / 1.12 / 1.15 / 1.20 on `goldens-sp500/sp500-2019-2023`). Scenarios at `trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/`; hypothesis + README at `dev/experiments/m5-4-e3-stop-buffer-sweep/`. Run via `dune exec backtest/scenarios/scenario_runner.exe -- --dir trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep --parallel 5` (local-only; ~5×2h tier-3 budget). Sweep run + report.md is the follow-up.
-- **E4 — Scoring-weight sweep** (4-dim grid; manual prequel to M5.5 tuning)
+- [x] **E4 — Scoring-weight sweep harness** (8 cells on `goldens-sp500/sp500-2019-2023` — `baseline`, `equal-weights`, `stage-heavy`, `volume-heavy`, `rs-heavy`, `resistance-heavy`, `sector-heavy`, `late-stage-strict`). One-axis-at-a-time perturbations of `Screener.scoring_weights` (manual prequel to M5.5 T-A grid). Scenarios at `trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/`; hypothesis + README at `dev/experiments/m5-4-e4-scoring-weight-sweep/`. Run via `dune exec backtest/scenarios/scenario_runner.exe -- --dir trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep --parallel 5` (local-only; ~5×2h tier-3 budget). Sweep run + report.md is the follow-up.
 
 ## In Progress
 - M5.2e per-trade context logging — PR #769 awaiting review.
 
 ## Completed
 - M5.2e per-trade context logging (PR #769, 2026-05-02) — 6 new columns on trades.csv; `Trade_context` module + `Stop_log.classify_stop_trigger_kind` + `Trade_audit.entry_decision.volume_ratio`. Trade audit + stop_log pure-projection join. Verify via `dune runtest trading/backtest/test --force` (passes 14/14 in test_trade_context.ml + 18/18 in test_stop_log.ml + 26/26 in test_result_writer.ml).
-- M5.4 E3 stop-buffer sweep harness (this PR, 2026-05-03) — 8-cell grid on `goldens-sp500/sp500-2019-2023` window (`{1.00, 1.02, 1.05, 1.08, 1.10, 1.12, 1.15, 1.20}`). Scenarios at `trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.XX.sexp`; hypothesis + README at `dev/experiments/m5-4-e3-stop-buffer-sweep/`. Verify parse via `dune build && dune runtest trading/backtest/scenarios/test/`. Sweep itself is local-only follow-up (~5×2h budget).
+- M5.4 E3 stop-buffer sweep harness (PR #815, 2026-05-03) — 8-cell grid on `goldens-sp500/sp500-2019-2023` window (`{1.00, 1.02, 1.05, 1.08, 1.10, 1.12, 1.15, 1.20}`). Scenarios at `trading/test_data/backtest_scenarios/experiments/m5-4-e3-stop-buffer-sweep/buffer-1.XX.sexp`; hypothesis + README at `dev/experiments/m5-4-e3-stop-buffer-sweep/`. Verify parse via `dune build && dune runtest trading/backtest/scenarios/test/`. Sweep itself is local-only follow-up (~5×2h budget).
+- M5.4 E4 scoring-weight sweep harness (this PR, 2026-05-03) — 8-cell single-axis perturbation grid on `goldens-sp500/sp500-2019-2023` window (`baseline`, `equal-weights`, `stage-heavy`, `volume-heavy`, `rs-heavy`, `resistance-heavy`, `sector-heavy`, `late-stage-strict`). Each cell doubles a single weight from `Screener.default_scoring_weights`. Scenarios at `trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/<axis>.sexp`; hypothesis + README at `dev/experiments/m5-4-e4-scoring-weight-sweep/`. Verify parse via `dune build && dune runtest trading/backtest/scenarios/test/`. Sweep itself is local-only follow-up (~5×2h budget).
 
 ## Next Steps
 

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/baseline.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/baseline.sexp
@@ -1,0 +1,29 @@
+;; M5.4 E4 scoring-weight sweep — baseline (default weights).
+;;
+;; Sweep cell: zero overrides — uses Screener.default_scoring_weights
+;; (w_stage2_breakout=30, w_strong_volume=20, w_adequate_volume=10,
+;; w_positive_rs=20, w_bullish_rs_crossover=10, w_clean_resistance=15,
+;; w_sector_strong=10, w_late_stage2_penalty=-15). Control cell within
+;; the sweep — should reproduce the canonical sp500-2019-2023 golden
+;; (60.86% / 86 trades / 0.55 Sharpe / 34.15% MaxDD as of 2026-05-02).
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E4.
+;; Universe + period mirror the canonical sp500-2019-2023 golden so the
+;; sweep is comparable to the pinned baseline.
+;;
+;; Expected ranges are deliberately wide — sweep cells exist to discover
+;; behaviour, not to pin it. Re-tighten only if a follow-up experiment
+;; promotes a specific cell to the canonical baseline.
+((name "m5-4-e4-baseline")
+ (description "M5.4 E4 sweep: default scoring weights (control)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides ())
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/equal-weights.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/equal-weights.sexp
@@ -1,0 +1,33 @@
+;; M5.4 E4 scoring-weight sweep — equal weights across the four major axes.
+;;
+;; Sweep cell: w_stage2_breakout = w_strong_volume = w_positive_rs =
+;; w_clean_resistance = 20 (the median of the four). Tests whether the
+;; default's weighting hierarchy (stage > rs ≈ volume > resistance) is a
+;; signal or noise: if equal weights produce comparable returns, the
+;; relative weighting is not the dominant decision lever and tuning effort
+;; should focus elsewhere (grade thresholds, candidate caps, etc.).
+;;
+;; Other weights (w_adequate_volume, w_bullish_rs_crossover, w_sector_strong,
+;; w_late_stage2_penalty) left at default — only the four primary signal
+;; weights are equalised.
+;;
+;; Plan: dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E4.
+((name "m5-4-e4-equal-weights")
+ (description "M5.4 E4 sweep: equal weights for stage / volume / RS / resistance (all 20)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides
+  (((screening_config
+     ((weights
+       ((w_stage2_breakout 20)
+        (w_strong_volume 20)
+        (w_positive_rs 20)
+        (w_clean_resistance 20))))))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/late-stage-strict.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/late-stage-strict.sexp
@@ -1,0 +1,30 @@
+;; M5.4 E4 scoring-weight sweep — late-Stage2 penalty 2x harsher.
+;;
+;; Sweep cell: w_late_stage2_penalty = -30 (default -15, so 2x more
+;; negative). Tests whether the cascade should penalise late-Stage2
+;; entries more — Weinstein Ch. 7 warns that late-Stage2 pyramiding /
+;; chasing yields the worst risk/reward in the long-side space; the
+;; current default may be too gentle, allowing the cascade to grade C+
+;; setups that should fall below the cut.
+;;
+;; This is the only "negative-direction" cell in the grid — every other
+;; cell amplifies a positive signal weight. Doubling the penalty tests
+;; the symmetric question: does down-weighting bad setups matter as much
+;; as up-weighting good ones?
+;;
+;; Other weights left at default. Plan:
+;; dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E4.
+((name "m5-4-e4-late-stage-strict")
+ (description "M5.4 E4 sweep: w_late_stage2_penalty = -30 (2x harsher)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides
+  (((screening_config ((weights ((w_late_stage2_penalty -30))))))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/resistance-heavy.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/resistance-heavy.sexp
@@ -1,0 +1,25 @@
+;; M5.4 E4 scoring-weight sweep — resistance-heavy (clean overhead 2x).
+;;
+;; Sweep cell: w_clean_resistance = 30 (default 15, so 2x). Tests whether
+;; the cascade should weight clean overhead structure more — virgin
+;; territory and clean-resistance breakouts are Weinstein's highest-quality
+;; setups (Ch. 3) and the smallest weight in the default. If this sweep
+;; cell improves Sharpe, the default underweights breakout cleanliness
+;; relative to its predictive power.
+;;
+;; Other weights left at default. Plan:
+;; dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E4.
+((name "m5-4-e4-resistance-heavy")
+ (description "M5.4 E4 sweep: w_clean_resistance = 30 (2x default)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides
+  (((screening_config ((weights ((w_clean_resistance 30))))))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/rs-heavy.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/rs-heavy.sexp
@@ -1,0 +1,32 @@
+;; M5.4 E4 scoring-weight sweep — RS-heavy (relative strength 2x).
+;;
+;; Sweep cell: w_positive_rs = 40 (default 20, so 2x) and
+;; w_bullish_rs_crossover = 20 (default 10, so 2x). Tests whether the
+;; cascade should weight relative-strength leadership more — Weinstein
+;; Ch. 4 stresses RS as the primary leading indicator, and prior work
+;; (`dev/notes/sp500-trade-quality-findings-2026-04-30.md`) flagged that
+;; the RS hard gate is doing meaningful filtering on the short side; the
+;; long-side RS weight may be similarly under-leveraged.
+;;
+;; Both RS levers (steady positive trend + bullish crossover) scale
+;; together to preserve their relative ordering.
+;;
+;; Other weights left at default. Plan:
+;; dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E4.
+((name "m5-4-e4-rs-heavy")
+ (description "M5.4 E4 sweep: w_positive_rs = 40, w_bullish_rs_crossover = 20 (both 2x default)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides
+  (((screening_config
+     ((weights
+       ((w_positive_rs 40)
+        (w_bullish_rs_crossover 20))))))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/sector-heavy.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/sector-heavy.sexp
@@ -1,0 +1,28 @@
+;; M5.4 E4 scoring-weight sweep — sector-heavy (Strong-sector bonus 2x).
+;;
+;; Sweep cell: w_sector_strong = 20 (default 10, so 2x). Tests whether
+;; the cascade should weight sector leadership more — Weinstein Ch. 5
+;; argues sector RS is roughly half the picking decision (the other half
+;; being individual stock RS). If this sweep cell improves Sharpe, the
+;; default treats sector context as noise relative to its actual signal.
+;;
+;; Note: this is a bonus weight, not a hard gate — the existing sector
+;; pre-filter (Strong/Neutral/Weak sector → exclude buys from Weak sectors)
+;; is unchanged and runs upstream of the score.
+;;
+;; Other weights left at default. Plan:
+;; dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E4.
+((name "m5-4-e4-sector-heavy")
+ (description "M5.4 E4 sweep: w_sector_strong = 20 (2x default)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides
+  (((screening_config ((weights ((w_sector_strong 20))))))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/stage-heavy.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/stage-heavy.sexp
@@ -1,0 +1,28 @@
+;; M5.4 E4 scoring-weight sweep — stage-heavy (Stage1→Stage2 breakout 2x).
+;;
+;; Sweep cell: w_stage2_breakout = 60 (default 30, so 2x). Tests whether
+;; biasing the cascade toward clean stage transitions improves selection
+;; quality — Weinstein's most fundamental signal is stage classification,
+;; so amplifying its weight should improve picks if the stage classifier
+;; is reliable on this universe + window.
+;;
+;; Note: w_stage2_breakout doubles also doubles the Early-Stage2 sub-bonus
+;; (= w_stage2_breakout / 2), so this single override scales both clean
+;; and early stage transitions proportionally.
+;;
+;; Other weights left at default. Plan:
+;; dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E4.
+((name "m5-4-e4-stage-heavy")
+ (description "M5.4 E4 sweep: w_stage2_breakout = 60 (2x default)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides
+  (((screening_config ((weights ((w_stage2_breakout 60))))))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/volume-heavy.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/volume-heavy.sexp
@@ -1,0 +1,30 @@
+;; M5.4 E4 scoring-weight sweep — volume-heavy (volume confirmation 2x).
+;;
+;; Sweep cell: w_strong_volume = 40 (default 20, so 2x) and
+;; w_adequate_volume = 20 (default 10, so 2x). Tests whether the cascade
+;; should weight volume confirmation more — Weinstein Ch. 2 explicitly
+;; calls out volume as essential at the breakout, so under-weighting it
+;; is a known failure mode.
+;;
+;; Both volume tiers scale together to preserve the relative ordering
+;; between Strong and Adequate volume signals.
+;;
+;; Other weights left at default. Plan:
+;; dev/plans/m5-experiments-roadmap-2026-05-02.md §M5.4 E4.
+((name "m5-4-e4-volume-heavy")
+ (description "M5.4 E4 sweep: w_strong_volume = 40, w_adequate_volume = 20 (both 2x default)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 491)
+ (config_overrides
+  (((screening_config
+     ((weights
+       ((w_strong_volume 40)
+        (w_adequate_volume 20))))))))
+ (expected
+  ((total_return_pct   ((min -50.0)       (max 150.0)))
+   (total_trades       ((min 30)          (max 250)))
+   (win_rate           ((min  0.0)        (max 100.0)))
+   (sharpe_ratio       ((min -2.0)        (max   3.0)))
+   (max_drawdown_pct   ((min  0.0)        (max  60.0)))
+   (avg_holding_days   ((min  0.0)        (max 365.0))))))


### PR DESCRIPTION
## Summary

8-cell single-axis perturbation grid of `Screener.scoring_weights` on
the canonical `goldens-sp500/sp500-2019-2023` multi-regime window.
Manual prequel to M5.5 T-A grid search per
`dev/plans/m5-experiments-roadmap-2026-05-02.md` §M5.4 E4.

Sister to PR #815 (E3 stop-buffer sweep) — same Path A shape, harness
only, no run.

## Cells (one-axis-at-a-time, 2x default)

| Cell | Override (`screening_config.weights.*`) | Tests |
|---|---|---|
| `baseline` | (none) | Control / sanity check vs canonical golden |
| `equal-weights` | 4 primary axes all = 20 | Whether weight hierarchy matters at all |
| `stage-heavy` | `w_stage2_breakout=60` | Stage-transition signal dominance |
| `volume-heavy` | `w_strong_volume=40, w_adequate_volume=20` | Volume confirmation weight |
| `rs-heavy` | `w_positive_rs=40, w_bullish_rs_crossover=20` | RS leadership weight |
| `resistance-heavy` | `w_clean_resistance=30` | Clean-overhead breakout weight |
| `sector-heavy` | `w_sector_strong=20` | Sector context bonus |
| `late-stage-strict` | `w_late_stage2_penalty=-30` | Late-stage penalty severity |

All on the 491-symbol S&P 500 snapshot, `2019-01-02 .. 2023-12-29`
window — same universe + period as the canonical sp500-2019-2023
golden so cells are head-to-head comparable.

## Why a manual prequel before T-A

The plan calls for a 3×3×3×3 = 81-cell grid (M5.5 T-A). Too expensive
to run flat without first establishing which axes have signal. This
8-cell sweep:
- If one axis dominates → T-A collapses to 1-D on that axis (~order
  of magnitude wall saving)
- If multiple axes have signal → T-A runs the full 4-D grid with this
  sweep's noise floor as the early-stop threshold
- If no axis dominates → tuning effort redirects to grade thresholds /
  `candidate_params` / structural cascade changes

See `dev/experiments/m5-4-e4-scoring-weight-sweep/hypothesis.md` for
the full falsification matrix and per-cell priors.

## Config-surface gap (none blocking)

All eight `scoring_weights` fields are independently tunable via
`(config_overrides (((screening_config ((weights ((<field> <val>)))))))`.
The runner's deep-merge primitives (`Backtest.Runner._merge_sexp`)
handle partial-record overlays — only the changed weight fields appear
in the override sexp; the others inherit from
`Screener.default_scoring_weights`. No structural gap; the cascade is
fully tunable on these axes.

## Test plan

- [x] All 8 sexps parse as well-formed s-expressions (verified via
  parsexp: 8/8 PASS, 1 top-level sexp each)
- [x] Override paths mirror the established shape used by
  `goldens-hybrid-tier-experiment/sp500-no-candidates.sexp` (which
  already overrides `screening_config.max_buy_candidates`)
- [x] `dev/status/experiments.md` ticked + Completed entry added
- [ ] Sweep run + `report.md` (out-of-scope follow-up; local-only,
  ~5x2h tier-3 budget per cell, ~3-4h total wall on M2)
- [ ] Verify parse via `dune runtest trading/backtest/scenarios/test/`
  once docker dev container available (local OPAM switch missing
  `core` / `core_unix`; structurally verified via parsexp instead)

## Files

- `trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep/{baseline,equal-weights,stage-heavy,volume-heavy,rs-heavy,resistance-heavy,sector-heavy,late-stage-strict}.sexp` — 8 scenario fixtures
- `dev/experiments/m5-4-e4-scoring-weight-sweep/{hypothesis.md,README.md}` — hypothesis + run instructions
- `dev/status/experiments.md` — E4 ticked, Completed entry added

## How to run (follow-up)

```bash
docker exec <container> bash -c \
  'cd /workspaces/trading-1/trading && eval $(opam env) && \
   dune exec backtest/scenarios/scenario_runner.exe -- \
     --dir trading/test_data/backtest_scenarios/experiments/m5-4-e4-scoring-weight-sweep \
     --parallel 5'
```

Local-only — do not run in GHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)