### PR TITLE
feat(data): snapshot build checkpointing + incremental wrapper (automation PR 1/4)

### DIFF
--- a/dev/plans/data-pipeline-automation-2026-05-03.md
+++ b/dev/plans/data-pipeline-automation-2026-05-03.md
@@ -1,0 +1,278 @@
+# Data Pipeline Automation — Checkpointing + Incremental Refresh + Audit (2026-05-03)
+
+Date: 2026-05-03. New track. Local-only automation for the long-running data
+pipeline (snapshot corpus build, backtest runs). Owns the `data-pipeline-automation`
+track under `data-foundations`.
+
+Authority: this plan; companion to `dev/plans/wiki-eodhd-historical-universe-2026-05-03.md`
+(historical universe), `dev/plans/m7-data-and-tuning-2026-05-02.md` §M7.0 Track 1
+(Norgate), and `.claude/agents/ops-data.md` (operational dispatch).
+
+## Status / Why
+
+**NOT STARTED.**
+
+Two pieces of user feedback (verbatim, this session):
+
+1. *"For these long running process, including both simulation and snapshot
+   generation, it could be helpful if they dump checkpoints from time to time,
+   so it's easier to gauge process, and potentially recover from failure."*
+2. *"GHA doesn't work as we don't check in data directory, but the automation
+   should be more comprehensive (and the audit / improvements should be
+   ongoing)."*
+
+These map to three concrete gaps in today's pipeline:
+
+| Gap | Today | After |
+|---|---|---|
+| Snapshot build progress | No log lines until end (~2hr wall, broad×10y, 10,472 symbols) | `progress.sexp` updated every N symbols; tail-able from any shell |
+| Snapshot build resume | `--incremental` reads the manifest written **only at the end**; crash mid-run loses everything | Manifest updated atomically per symbol → `--incremental` resumes from any interrupt |
+| Local refresh automation | One-shot manual fetch dispatched via `ops-data`; no incremental wrapper | `dev/scripts/build_broad_snapshot_incremental.sh` + freshness audit script |
+
+Why local-only: `data/` is gitignored; GHA runners never have the bar-data
+tree. The release-gate workflow already documents the local constraint
+(`dev/notes/tier4-release-gate-checklist-2026-04-28.md`). Cron / launchd is
+the user's responsibility — this plan ships the building blocks, not the
+schedule entries.
+
+Cross-track impact:
+- M5.x backtest scenarios pick up faster iteration on broad×10y once
+  snapshot rebuild is interruptible.
+- M7.0 Track 1 (Norgate) ingestion will reuse the same checkpoint pattern
+  when it lands; the manifest-per-symbol contract is vendor-agnostic.
+- ops-data dispatch (`.claude/agents/ops-data.md`) gains a `--snapshot-refresh`
+  recipe in PR 3.
+
+## Scope
+
+**In:**
+
+- `progress.sexp` emission from `build_snapshots.exe` — atomic append every
+  N symbols (default 50), recording total / done / last-symbol / timestamps.
+- Per-symbol manifest update — `Snapshot_manifest.update_for_symbol`
+  rewrites `manifest.sexp` after each `.snap` file lands. Resume becomes
+  free.
+- `dev/scripts/build_broad_snapshot_incremental.sh` — wrapper invoking
+  `build_snapshots.exe --incremental` with `--max-wall <duration>` so a
+  single cron tick doesn't run forever. Default 60min wall; the wrapper
+  respects checkpoint state across invocations.
+- `dev/scripts/check_snapshot_freshness.sh` — reports per-symbol staleness
+  (CSV mtime > snapshot mtime → stale). Usable as a pre-flight gate before
+  release-gate scenarios.
+- ops-data dispatch entry-point: a paragraph in `.claude/agents/ops-data.md`
+  documenting `--snapshot-refresh` use cases.
+- A note doc covering local cron / launchd patterns (PR 4) so the user can
+  wire the wrapper into their schedule.
+
+**Out:**
+
+- `cron` / launchd plist files themselves — user-side concern; per-host.
+- GHA workflow integration — `data/` is gitignored; this is local-only by
+  design.
+- Backtest *progress streaming* (Friday-by-Friday TUI). Plan covers basic
+  `progress.sexp` only; richer dashboards deferred.
+- Norgate-specific resume logic. Manifest update is vendor-agnostic; the
+  Norgate ingest CLI (M7.0 Track 1) reuses the contract when it ships.
+- Schema versioning for `progress.sexp`. The format is stable per the .mli
+  contract; if it needs to evolve, a `version` field can be added.
+
+## Architecture
+
+### Data flow today (broken on interrupt)
+
+```
+build_snapshots.exe
+  ├─ load universe sexp
+  ├─ for each symbol s:
+  │    ├─ read CSV, run pipeline
+  │    └─ write <out>/s.snap                 ← per-symbol durable
+  └─ write <out>/manifest.sexp               ← END of run only ✗
+```
+
+If the process is killed at symbol 8000/10472, all 8000 `.snap` files exist
+but the manifest is empty → `--incremental` on restart finds no entries →
+re-builds everything from scratch.
+
+### Data flow after PR 1
+
+```
+build_snapshots.exe
+  ├─ load universe sexp
+  ├─ load existing manifest (if --incremental)
+  ├─ for each symbol s:
+  │    ├─ read CSV, run pipeline
+  │    ├─ write <out>/s.snap
+  │    └─ Snapshot_manifest.update_for_symbol      ← atomic, per-symbol
+  │       (read manifest.sexp, replace s entry, atomic-rename write)
+  ├─ every N symbols (default 50):
+  │    └─ write <out>/progress.sexp                ← atomic
+  └─ done.
+```
+
+After interrupt at symbol 8000/10472: restart with `--incremental` → manifest
+shows 8000 entries → only 2472 symbols rebuilt.
+
+### Sub-modules
+
+| File | Role |
+|---|---|
+| `build_snapshots.ml` | Add atomic-per-symbol manifest update; emit `progress.sexp` every N symbols |
+| `snapshot_manifest.ml/.mli` | Add `update_for_symbol` function (atomic single-symbol upsert) |
+| `dev/scripts/build_broad_snapshot_incremental.sh` | Wrapper: `--max-wall`, `--batch-size`, `--universe`, `--output-dir`, `--dry-run` |
+| `dev/scripts/check_snapshot_freshness.sh` | Per-symbol staleness probe; stale = CSV mtime > snapshot mtime; emits a list usable by ops-data |
+
+### Files to touch
+
+PR 1 (this plan):
+
+- `trading/analysis/scripts/build_snapshots/build_snapshots.ml` (extend)
+- `trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_manifest.ml/.mli` (extend)
+- `trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_manifest.ml` (extend)
+- `dev/scripts/build_broad_snapshot_incremental.sh` (NEW)
+- `dev/scripts/check_snapshot_freshness.sh` (NEW)
+
+PR 2: backtest checkpointing
+- `trading/analysis/scripts/backtest_runner/backtest_runner.ml` (extend)
+  — add `progress.sexp` emission + `--resume-from` flag
+- New `Backtest_progress` module under
+  `trading/analysis/scripts/backtest_runner/lib/` if reusable
+
+PR 3: ops-data dispatch entry
+- `.claude/agents/ops-data.md` (extend §"Data scripts" with snapshot-refresh)
+- `dev/notes/data-pipeline-runbook-2026-05-03.md` (NEW) — runbook covering
+  freshness probe, incremental rebuild, full rebuild
+
+PR 4: local-cron / launchd recipes
+- `dev/notes/local-automation-2026-05-03.md` (NEW) — crontab + launchd
+  patterns; user wires their host
+
+## Sub-PRs
+
+Four sub-PRs, ~700 LOC total. Each independently mergeable.
+
+### PR 1 — snapshot build checkpointing + incremental wrapper (~300 LOC, this PR)
+
+See §Acceptance below.
+
+### PR 2 — backtest checkpointing (~250 LOC)
+
+`backtest_runner.exe` extension:
+
+- Emit `progress.sexp` every Friday cycle to the run output directory
+  (records: `{cycles_done; total_cycles; last_friday; portfolio_value;
+  open_positions; started_at; updated_at}`).
+- New `--resume-from <path>` flag — load `progress.sexp` and skip cycles
+  prior to `last_friday`. Idempotent on restart.
+- Test coverage: 3+ unit tests for the `Backtest_progress` module + smoke
+  resume test in the runner.
+
+Acceptance: kill `backtest_runner.exe` mid-run, restart with
+`--resume-from <out>/progress.sexp`; the second run completes only the
+remaining Fridays and the final ledger matches a non-interrupted reference
+run within tolerance.
+
+### PR 3 — ops-data dispatch + runbook (~100 LOC + doc)
+
+Extend `.claude/agents/ops-data.md` with:
+
+- §"Snapshot refresh" subsection (mirrors §"Fetch symbols" / §"Rebuild inventory"
+  shapes): "When CSV mtimes have advanced for ≥N symbols, run
+  `dev/scripts/build_broad_snapshot_incremental.sh --max-wall 60m`.
+  Confirm via `dev/scripts/check_snapshot_freshness.sh`."
+- Standard workflow extension: snapshot freshness as a step 6 in the
+  fetch+refresh sequence.
+
+`dev/notes/data-pipeline-runbook-2026-05-03.md` (NEW): the canonical runbook.
+Covers what to do when the freshness probe reports >5% stale, how to
+recover from a partial run, when to fall back to a full rebuild.
+
+### PR 4 — local-cron / launchd recipes (~50 LOC + doc)
+
+`dev/notes/local-automation-2026-05-03.md`: example crontab entry +
+launchd plist (macOS) for invoking the incremental wrapper nightly. Warns
+against running concurrent invocations (file-lock pattern in PR 1's wrapper
+prevents two concurrent runs).
+
+## Open questions
+
+1. **Checkpoint format — sexp vs json.** Choosing sexp for consistency with
+   `manifest.sexp` and the existing `Status.status_or` ergonomics. The
+   downside is that ad-hoc shell tooling needs `sexp print` (available in
+   the dev container) rather than `jq`. Net: sexp wins because the only
+   consumers are OCaml + a handful of shell scripts, and we already write
+   sexp manifests.
+2. **Mid-symbol-build atomicity.** `Snapshot_format.write` is a single
+   `Out_channel.write_all` so each `.snap` file is written atomically by
+   POSIX semantics on local FS. The risk is `.snap` being written but
+   `manifest.sexp` not yet updated → orphan `.snap` file with no manifest
+   entry. Resolution in PR 1: write `.snap` first, then update manifest;
+   on interrupt, an orphan `.snap` is harmless (re-built next run) and
+   `--incremental` correctly skips only symbols whose manifest entry
+   matches the current CSV mtime. Manifest writes go via temp file +
+   atomic rename to prevent torn writes.
+3. **`progress.sexp` write frequency.** Default N=50 (~2.4% of broad×10y);
+   trade-off is verbosity vs. write overhead. Each `progress.sexp` write
+   is small (~200 bytes); 200 writes over a 2hr run is negligible. Make
+   it configurable via `--progress-every <N>` flag.
+4. **Backtest-side checkpointing scope.** Sized for PR 2: cycle-level
+   only (one entry per Friday). Not bar-level — that would be too
+   verbose. Discussion ongoing whether to also dump the full portfolio
+   state on interrupt for cross-run replay; deferred until M5.x asks for
+   it.
+5. **Concurrent rebuild detection.** Two concurrent
+   `build_broad_snapshot_incremental.sh` invocations would race on
+   manifest writes. PR 1's wrapper takes a flock on
+   `<output-dir>/.build.lock`; second invocation exits with code 75
+   (POSIX `EX_TEMPFAIL`). Documented in the wrapper's `--help`.
+
+## Acceptance — PR 1 (this PR)
+
+Measurable, end-to-end:
+
+1. **Atomic per-symbol manifest update**: `build_snapshots.exe` calls
+   `Snapshot_manifest.update_for_symbol` after each `.snap` write. The
+   manifest at `<out>/manifest.sexp` is well-formed at every observable
+   moment (atomic rename via temp file).
+2. **Resume on interrupt**: a unit test simulates an interrupt mid-run by
+   manually invoking `update_for_symbol` for K of N entries, then a
+   second `build_snapshots.exe --incremental` run only rebuilds the
+   missing N-K. Verified by counting pipeline calls (mocked) or by
+   reading the manifest entry count after each invocation.
+3. **`progress.sexp` emission**: `build_snapshots.exe --progress-every
+   25` writes a `progress.sexp` after every 25th symbol with
+   well-formed `{symbols_done; symbols_total; last_completed;
+   started_at; updated_at}`. Tail-able mid-run.
+4. **`build_broad_snapshot_incremental.sh --dry-run` works**: prints the
+   exact `build_snapshots.exe` invocation it would run, without doing
+   it. Includes `--max-wall`, `--universe`, `--output-dir`, `--batch-size`
+   resolution.
+5. **`check_snapshot_freshness.sh` reports correctly**: given a fixture
+   manifest with K stale entries (CSV mtime > snapshot manifest's
+   `csv_mtime`), reports `K stale / N total`. Exit 0 always; the gate
+   is in the wrapper, not the probe.
+6. **All tests green**: `dune build && dune runtest` passes; new tests
+   under `test_snapshot_manifest.ml` cover the `update_for_symbol`
+   function (3+ cases: insert new, replace existing, atomic-rename
+   semantics).
+
+## Cross-links
+
+- **Wiki+EODHD historical universe** — `dev/plans/wiki-eodhd-historical-universe-2026-05-03.md`.
+  PR-A through PR-D landed today; broad universe coverage is 100%; the
+  ~2hr snapshot rebuild is the next bottleneck.
+- **Tier-4 release gate checklist** — `dev/notes/tier4-release-gate-checklist-2026-04-28.md`
+  notes the local-only constraint and explicitly mentions snapshot
+  rebuild as a manual step. After PR 1, the snapshot step becomes
+  cron-runnable.
+- **ops-data agent** — `.claude/agents/ops-data.md` will gain a
+  snapshot-refresh recipe in PR 3.
+- **qc-structural A2 boundary** — all feature code lives under
+  `analysis/scripts/` and `analysis/weinstein/snapshot_pipeline/`. Wrapper
+  + probe scripts are under `dev/scripts/`. No `trading/trading/` writes.
+  A2 PASS by construction.
+- **qc-behavioral** — pure infra/data-ops PR. CP1–CP4 only; the
+  Weinstein-domain S*/L*/C*/T* checklist is NA per
+  `.claude/rules/qc-behavioral-authority.md` ("pure infra / harness /
+  refactor PR; domain checklist not applicable").
+- **No Python** — wrapper + probe scripts are POSIX sh; OCaml-only for
+  manifest extension. Per `.claude/rules/no-python.md`.

--- a/dev/scripts/build_broad_snapshot_incremental.sh
+++ b/dev/scripts/build_broad_snapshot_incremental.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# build_broad_snapshot_incremental.sh — incremental snapshot rebuild wrapper.
+#
+# Wraps build_snapshots.exe with:
+#   - --incremental (always)
+#   - per-host wall-clock budget (--max-wall <duration>) so a cron tick
+#     terminates after a bounded window even if the universe is huge
+#   - flock on <output-dir>/.build.lock to prevent two concurrent runs
+#     racing on the manifest
+#   - --dry-run to preview the invocation
+#
+# After PR 1 of dev/plans/data-pipeline-automation-2026-05-03.md,
+# build_snapshots.exe writes the manifest atomically per symbol AND
+# emits progress.sexp every N symbols. So this wrapper safely supports
+# checkpoint-resume across invocations: a 2-hour rebuild can be split
+# into N ~30min cron windows, each picking up where the previous left
+# off.
+#
+# Usage:
+#   build_broad_snapshot_incremental.sh \
+#     --universe <path>         (required) Pinned universe sexp
+#     --output-dir <path>       (required) Snapshot warehouse output
+#     --csv-data-dir <path>     (default: data)
+#     --benchmark-symbol <sym>  (optional) e.g. SPY
+#     --progress-every <N>      (default: 50) progress.sexp cadence
+#     --max-wall <duration>     (default: 60m) wall-clock budget;
+#                                accepts e.g. 30m, 1h, 90m, 7200s
+#     --dry-run                 Print the underlying invocation, do not run
+#     --build-target <path>     (default: built target under _build)
+#
+# Exit codes:
+#   0    completed within budget
+#   1    setup error / build_snapshots.exe error
+#   75   another instance holds the lock (POSIX EX_TEMPFAIL)
+#   124  killed by --max-wall timeout (per coreutils `timeout` convention)
+#
+# Logs to: dev/logs/snapshot-build-YYYY-MM-DD.log (appended).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Repo root from script path
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+UNIVERSE=""
+OUTPUT_DIR=""
+CSV_DATA_DIR="${REPO_ROOT}/data"
+BENCHMARK_SYMBOL=""
+PROGRESS_EVERY=50
+MAX_WALL="60m"
+DRY_RUN=0
+BUILD_TARGET="${REPO_ROOT}/trading/_build/default/analysis/scripts/build_snapshots/build_snapshots.exe"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --universe)         UNIVERSE="$2";         shift 2 ;;
+    --output-dir)       OUTPUT_DIR="$2";       shift 2 ;;
+    --csv-data-dir)     CSV_DATA_DIR="$2";     shift 2 ;;
+    --benchmark-symbol) BENCHMARK_SYMBOL="$2"; shift 2 ;;
+    --progress-every)   PROGRESS_EVERY="$2";   shift 2 ;;
+    --max-wall)         MAX_WALL="$2";         shift 2 ;;
+    --build-target)     BUILD_TARGET="$2";     shift 2 ;;
+    --dry-run)          DRY_RUN=1;             shift ;;
+    --help|-h)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      echo "Usage: $0 --universe <path> --output-dir <path> [--csv-data-dir <path>] [--benchmark-symbol <sym>] [--progress-every <N>] [--max-wall <dur>] [--dry-run]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+if [[ -z "${UNIVERSE}" ]]; then
+  echo "ERROR: --universe is required" >&2
+  exit 1
+fi
+if [[ -z "${OUTPUT_DIR}" ]]; then
+  echo "ERROR: --output-dir is required" >&2
+  exit 1
+fi
+if [[ ! -f "${UNIVERSE}" ]]; then
+  echo "ERROR: universe sexp not found: ${UNIVERSE}" >&2
+  exit 1
+fi
+if [[ ! -d "${CSV_DATA_DIR}" ]]; then
+  echo "ERROR: csv data dir not found: ${CSV_DATA_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+LOG_DATE="$(date +%Y-%m-%d)"
+LOG_DIR="${REPO_ROOT}/dev/logs"
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/snapshot-build-${LOG_DATE}.log"
+
+log() {
+  local msg="$(date '+%Y-%m-%d %H:%M:%S') [snapshot-build] $*"
+  echo "${msg}"
+  echo "${msg}" >> "${LOG_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# Build invocation
+# ---------------------------------------------------------------------------
+INVOKE_ARGS=(
+  --universe-path "${UNIVERSE}"
+  --csv-data-dir  "${CSV_DATA_DIR}"
+  --output-dir    "${OUTPUT_DIR}"
+  --incremental
+  --progress-every "${PROGRESS_EVERY}"
+)
+if [[ -n "${BENCHMARK_SYMBOL}" ]]; then
+  INVOKE_ARGS+=( --benchmark-symbol "${BENCHMARK_SYMBOL}" )
+fi
+
+CMD_PREVIEW="timeout ${MAX_WALL} ${BUILD_TARGET} ${INVOKE_ARGS[*]}"
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  echo "[dry-run] would invoke: ${CMD_PREVIEW}"
+  exit 0
+fi
+
+if [[ ! -x "${BUILD_TARGET}" ]]; then
+  echo "ERROR: build target not found or not executable: ${BUILD_TARGET}" >&2
+  echo "       Run: dune build analysis/scripts/build_snapshots/" >&2
+  exit 1
+fi
+
+log "starting incremental snapshot rebuild"
+log "  universe=${UNIVERSE}"
+log "  output_dir=${OUTPUT_DIR}"
+log "  csv_data_dir=${CSV_DATA_DIR}"
+log "  benchmark_symbol=${BENCHMARK_SYMBOL:-(none)}"
+log "  progress_every=${PROGRESS_EVERY}"
+log "  max_wall=${MAX_WALL}"
+
+# ---------------------------------------------------------------------------
+# flock-protected invocation
+# ---------------------------------------------------------------------------
+LOCK_FILE="${OUTPUT_DIR}/.build.lock"
+
+# We use a subshell + flock fd 9. -n: nonblocking; exits 1 if held → re-map
+# to POSIX EX_TEMPFAIL (75). flock is BSD-flavored on macOS via util-linux's
+# port (`flock`); fall back to a presence-test on hosts without flock.
+if command -v flock >/dev/null 2>&1; then
+  (
+    if ! flock -n 9; then
+      log "another instance holds the lock at ${LOCK_FILE}; exiting EX_TEMPFAIL"
+      exit 75
+    fi
+    set +e
+    timeout "${MAX_WALL}" "${BUILD_TARGET}" "${INVOKE_ARGS[@]}"
+    rc=$?
+    set -e
+    log "build_snapshots.exe exited with rc=${rc}"
+    exit "${rc}"
+  ) 9>"${LOCK_FILE}"
+else
+  log "WARN: flock not available; skipping concurrent-run guard"
+  set +e
+  timeout "${MAX_WALL}" "${BUILD_TARGET}" "${INVOKE_ARGS[@]}"
+  rc=$?
+  set -e
+  log "build_snapshots.exe exited with rc=${rc}"
+  exit "${rc}"
+fi

--- a/dev/scripts/check_snapshot_freshness.sh
+++ b/dev/scripts/check_snapshot_freshness.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# check_snapshot_freshness.sh — report per-symbol staleness of a snapshot
+# warehouse vs the source CSVs.
+#
+# A snapshot entry is "stale" when its source CSV's mtime is newer than the
+# manifest entry's recorded csv_mtime — meaning the CSV has been refreshed
+# (e.g. nightly fetch) since the snapshot was last built.
+#
+# Usage:
+#   check_snapshot_freshness.sh \
+#     --manifest <path>      (default: <output-dir>/manifest.sexp)
+#     --output-dir <path>    (alternative to --manifest; resolves to
+#                             <output-dir>/manifest.sexp)
+#     --csv-data-dir <path>  (default: data)
+#     --threshold-pct N      Exit non-zero if stale > N% (default: 0 = always 0)
+#     --list-stale           Print every stale symbol; default summary only
+#     --quiet                Summary line only
+#
+# Output (stdout):
+#   snapshot-freshness: <stale>/<total> stale = <pct>% (manifest=<path>)
+#
+# Exit codes:
+#   0    stale ≤ threshold-pct (or threshold not enforced)
+#   1    stale > threshold-pct
+#   2    setup error (manifest missing, parse error, etc)
+#
+# Use cases:
+#   - Pre-flight gate before tier-4 release-gate runs (require <5% stale)
+#   - Surface symbols needing rebuild for ops-data dispatch
+#   - Cron sentinel to trigger build_broad_snapshot_incremental.sh
+#
+# Implementation note: this script does NOT parse the manifest sexp directly
+# (avoiding a host dependency on sexp tooling). It reads the symbol list +
+# csv_mtime values via a small sed/awk extraction over the manifest's
+# canonical sexp shape — see Snapshot_manifest.write for the format.
+
+set -euo pipefail
+
+manifest=""
+output_dir=""
+csv_data_dir="data"
+threshold_pct=0
+list_stale=false
+quiet=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest)        manifest="$2";        shift 2 ;;
+    --output-dir)      output_dir="$2";      shift 2 ;;
+    --csv-data-dir)    csv_data_dir="$2";    shift 2 ;;
+    --threshold-pct)   threshold_pct="$2";   shift 2 ;;
+    --list-stale)      list_stale=true;      shift ;;
+    --quiet)           quiet=true;           shift ;;
+    --help|-h)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "[check-snapshot-freshness] unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$manifest" ]; then
+  if [ -z "$output_dir" ]; then
+    echo "[check-snapshot-freshness] one of --manifest or --output-dir required" >&2
+    exit 2
+  fi
+  manifest="$output_dir/manifest.sexp"
+fi
+
+if [ ! -f "$manifest" ]; then
+  echo "[check-snapshot-freshness] manifest not found: $manifest" >&2
+  exit 2
+fi
+if [ ! -d "$csv_data_dir" ]; then
+  echo "[check-snapshot-freshness] csv data dir not found: $csv_data_dir" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Extract (symbol, csv_mtime) pairs from the manifest.
+#
+# Manifest sexp shape (per Snapshot_manifest.write, Sexp.to_string_hum):
+#   ((schema_hash ...)
+#    (schema (...))
+#    (entries
+#     (((symbol AAPL) (path /.../AAPL.snap) (byte_size 1024)
+#       (payload_md5 ...) (csv_mtime 1234567890.5))
+#      ((symbol MSFT) ...))))
+#
+# We grep for `(symbol X)` and the matching `(csv_mtime Y)` pair via awk.
+# The pairing assumption: each entry record contains exactly one symbol and
+# exactly one csv_mtime, in order. This holds for the canonical writer; if
+# the manifest is hand-edited with reordered fields, awk pairs by appearance
+# order — the script docs note this.
+# ---------------------------------------------------------------------------
+
+pairs=$(awk '
+  /\(symbol [A-Za-z0-9_.\-]+\)/ {
+    if (match($0, /\(symbol [^)]+\)/)) {
+      sym = substr($0, RSTART + 8, RLENGTH - 9)
+      have_sym = 1
+    }
+  }
+  /\(csv_mtime [0-9.+\-eE]+\)/ {
+    if (have_sym && match($0, /\(csv_mtime [^)]+\)/)) {
+      mt = substr($0, RSTART + 11, RLENGTH - 12)
+      printf "%s\t%s\n", sym, mt
+      have_sym = 0
+    }
+  }
+' "$manifest")
+
+total=$(printf '%s\n' "$pairs" | grep -c '	' || true)
+if [ "$total" -eq 0 ]; then
+  echo "[check-snapshot-freshness] no entries parsed from manifest: $manifest" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# For each (sym, recorded_mtime), compare against current CSV mtime under
+# csv_data_dir/<l1>/<last>/<sym>/data.csv (matching csv_storage.symbol_data_dir).
+# ---------------------------------------------------------------------------
+stale=0
+stale_list=""
+
+while IFS=$'\t' read -r sym recorded_mtime; do
+  [ -z "$sym" ] && continue
+
+  l1=$(printf '%s' "$sym" | cut -c1)
+  sym_len=${#sym}
+  l2=$(printf '%s' "$sym" | cut -c"${sym_len}")
+  csv_path="$csv_data_dir/$l1/$l2/$sym/data.csv"
+
+  # If CSV is gone, treat as not-stale (cannot verify; rebuild won't help).
+  [ -f "$csv_path" ] || continue
+
+  # mtime as integer seconds (drop sub-second; recorded float may have ".0")
+  if stat --version >/dev/null 2>&1; then
+    # GNU stat (Linux)
+    actual_mtime=$(stat -c %Y "$csv_path")
+  else
+    # BSD stat (macOS)
+    actual_mtime=$(stat -f %m "$csv_path")
+  fi
+
+  is_stale=$(awk -v a="$actual_mtime" -v r="$recorded_mtime" 'BEGIN { print (a + 0 > r + 0) ? "yes" : "no" }')
+  if [ "$is_stale" = "yes" ]; then
+    stale=$((stale + 1))
+    if [ "$list_stale" = "true" ]; then
+      stale_list="${stale_list}${sym}\n"
+    fi
+  fi
+done <<EOF
+$pairs
+EOF
+
+pct=$(awk -v s="$stale" -v t="$total" 'BEGIN { printf "%.2f", (s * 100.0) / t }')
+
+if [ "$quiet" != "true" ]; then
+  echo "[check-snapshot-freshness] manifest=$manifest csv_data_dir=$csv_data_dir"
+fi
+
+if [ "$list_stale" = "true" ] && [ -n "$stale_list" ]; then
+  echo "[check-snapshot-freshness] stale symbols ($stale):"
+  printf '%b' "$stale_list" | sort | head -50
+  if [ "$stale" -gt 50 ]; then
+    echo "  ... (+$((stale - 50)) more)"
+  fi
+fi
+
+echo "snapshot-freshness: $stale/$total stale = ${pct}% (manifest=$manifest)"
+
+# Threshold gate
+if [ "$threshold_pct" -gt 0 ]; then
+  meets=$(awk -v p="$pct" -v t="$threshold_pct" 'BEGIN { print (p+0 <= t+0) ? "yes" : "no" }')
+  if [ "$meets" != "yes" ]; then
+    echo "[check-snapshot-freshness] FAIL: stale ${pct}% > threshold ${threshold_pct}%" >&2
+    exit 1
+  fi
+fi
+
+exit 0

--- a/trading/analysis/scripts/build_snapshots/build_snapshots.ml
+++ b/trading/analysis/scripts/build_snapshots/build_snapshots.ml
@@ -13,7 +13,21 @@
     {!Snapshot_schema.Macro_composite} are populated. Without it those columns
     are NaN per {!Snapshot_pipeline.Pipeline.build_for_symbol}'s contract.
 
-    See [dev/plans/daily-snapshot-streaming-2026-04-27.md] §Phasing Phase B. *)
+    Checkpointing (added per dev/plans/data-pipeline-automation-2026-05-03.md):
+
+    - Per-symbol atomic manifest update via
+      {!Snapshot_pipeline.Snapshot_manifest.update_for_symbol}: after each
+      [.snap] file lands, the directory manifest is rewritten via tempfile +
+      atomic rename. Crash mid-run leaves a well-formed manifest with N entries
+      where N is the number of symbols completed; [--incremental] on restart
+      resumes correctly.
+    - Periodic [progress.sexp] emission: every [--progress-every N] symbols
+      (default 50), an atomic [progress.sexp] is written to the output dir so a
+      tail-able tool can gauge progress mid-run.
+
+    See [dev/plans/daily-snapshot-streaming-2026-04-27.md] §Phasing Phase B and
+    [dev/plans/data-pipeline-automation-2026-05-03.md] for the checkpointing
+    contract. *)
 
 open Core
 module Pipeline = Snapshot_pipeline.Pipeline
@@ -21,6 +35,23 @@ module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
 module Snapshot_verifier = Snapshot_pipeline.Snapshot_verifier
 module Snapshot_format = Data_panel_snapshot.Snapshot_format
 module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+
+(** Default progress.sexp emission cadence: write a progress checkpoint after
+    every 50 symbols. Configurable via [--progress-every N]. *)
+let _default_progress_every = 50
+
+type progress = {
+  symbols_total : int;
+  symbols_done : int;
+  last_completed : string;
+  started_at : float;
+  updated_at : float;
+}
+[@@deriving sexp]
+(** On-disk progress checkpoint shape. Atomically rewritten every
+    [progress_every] symbols. Tail-able via standard shell tooling (sexp print).
+    The fields use the canonical sexp serialization (Float.t ↔ "1234567890.5");
+    start/update times are unix seconds since epoch. *)
 
 let _csv_mtime ~data_dir ~symbol =
   let dir = Csv.Csv_storage.symbol_data_dir ~data_dir symbol in
@@ -79,8 +110,17 @@ let _maybe_reuse ~existing ~symbol =
   | None -> None
   | Some m -> Snapshot_manifest.find m ~symbol
 
+let _checkpoint_manifest ~manifest_path ~schema entry =
+  match
+    Snapshot_manifest.update_for_symbol ~path:manifest_path ~schema entry
+  with
+  | Ok () -> ()
+  | Error err ->
+      Printf.eprintf "manifest checkpoint failed for %s: %s\n%!"
+        entry.Snapshot_manifest.symbol (Status.show err)
+
 let _process_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
-    symbol =
+    ~manifest_path ~checkpoint symbol =
   match _csv_mtime ~data_dir ~symbol with
   | None ->
       Printf.eprintf "skip %s: no CSV\n%!" symbol;
@@ -98,7 +138,10 @@ let _process_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
               _build_one_symbol ~symbol ~bars ~schema ~benchmark_bars
                 ~output_dir ~csv_mtime
             with
-            | Ok entry -> Some entry
+            | Ok entry ->
+                if checkpoint then
+                  _checkpoint_manifest ~manifest_path ~schema entry;
+                Some entry
             | Error err ->
                 Printf.eprintf "skip %s: build: %s\n%!" symbol (Status.show err);
                 None))
@@ -147,31 +190,85 @@ let _verify_or_warn ~manifest_path =
 let _ensure_dir path =
   if not (Stdlib.Sys.file_exists path) then Stdlib.Sys.mkdir path 0o755
 
-let main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol ~incremental
-    () =
-  _ensure_dir output_dir;
-  let schema = Snapshot_schema.default in
-  let symbols = _load_universe ~universe_path in
-  let data_dir = Fpath.v csv_data_dir in
-  let benchmark_bars = _benchmark_bars_opt ~data_dir ~benchmark_symbol in
-  let existing = if incremental then _existing_manifest ~output_dir else None in
-  let t0 = Time_ns.now () in
-  let entries =
-    List.filter_map symbols
-      ~f:
-        (_process_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing)
-  in
-  let elapsed = Time_ns.diff (Time_ns.now ()) t0 in
+(** Atomically write [progress.sexp] under [output_dir]. Tempfile + rename so a
+    tailing reader never observes a torn write. *)
+let _write_progress ~output_dir ~progress =
+  let path = Filename.concat output_dir "progress.sexp" in
+  let tmp = path ^ ".tmp" in
+  try
+    let data = Sexp.to_string_hum (sexp_of_progress progress) in
+    Out_channel.write_all tmp ~data;
+    Stdlib.Sys.rename tmp path
+  with Sys_error msg | Failure msg -> (
+    Printf.eprintf "progress write failed: %s\n%!" msg;
+    try Stdlib.Sys.remove tmp with _ -> ())
+
+let _maybe_emit_progress ~output_dir ~progress_every ~symbols_total
+    ~symbols_done ~last_completed ~started_at =
+  if symbols_done > 0 && symbols_done mod progress_every = 0 then
+    _write_progress ~output_dir
+      ~progress:
+        {
+          symbols_total;
+          symbols_done;
+          last_completed;
+          started_at;
+          updated_at = Core_unix.time ();
+        }
+
+let _emit_final_progress ~output_dir ~symbols_total ~entries ~started_at =
+  _write_progress ~output_dir
+    ~progress:
+      {
+        symbols_total;
+        symbols_done = List.length entries;
+        last_completed =
+          (match List.last entries with
+          | Some e -> e.Snapshot_manifest.symbol
+          | None -> "");
+        started_at;
+        updated_at = Core_unix.time ();
+      }
+
+let _write_final_manifest ~manifest_path ~schema ~entries ~elapsed =
   let manifest = Snapshot_manifest.create ~schema ~entries in
-  let manifest_path = Filename.concat output_dir "manifest.sexp" in
-  (match Snapshot_manifest.write ~path:manifest_path manifest with
+  match Snapshot_manifest.write ~path:manifest_path manifest with
   | Ok () ->
       Printf.printf "wrote %d entries to %s in %.2fs\n%!" (List.length entries)
         manifest_path
         (Time_ns.Span.to_sec elapsed)
   | Error err ->
       Printf.eprintf "manifest write failed: %s\n%!" (Status.show err);
-      exit 1);
+      exit 1
+
+let main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol ~incremental
+    ~progress_every () =
+  _ensure_dir output_dir;
+  let schema = Snapshot_schema.default in
+  let symbols = _load_universe ~universe_path in
+  let symbols_total = List.length symbols in
+  let data_dir = Fpath.v csv_data_dir in
+  let benchmark_bars = _benchmark_bars_opt ~data_dir ~benchmark_symbol in
+  let existing = if incremental then _existing_manifest ~output_dir else None in
+  let manifest_path = Filename.concat output_dir "manifest.sexp" in
+  let started_at = Core_unix.time () in
+  let t0 = Time_ns.now () in
+  let entries =
+    List.foldi symbols ~init:[] ~f:(fun i acc symbol ->
+        match
+          _process_symbol ~data_dir ~schema ~benchmark_bars ~output_dir
+            ~existing ~manifest_path ~checkpoint:true symbol
+        with
+        | None -> acc
+        | Some entry ->
+            let symbols_done = i + 1 in
+            _maybe_emit_progress ~output_dir ~progress_every ~symbols_total
+              ~symbols_done ~last_completed:symbol ~started_at;
+            acc @ [ entry ])
+  in
+  let elapsed = Time_ns.diff (Time_ns.now ()) t0 in
+  _write_final_manifest ~manifest_path ~schema ~entries ~elapsed;
+  _emit_final_progress ~output_dir ~symbols_total ~entries ~started_at;
   _verify_or_warn ~manifest_path
 
 let command =
@@ -195,9 +292,16 @@ let command =
        flag "incremental" no_arg
          ~doc:
            "Skip symbols whose CSV mtime <= the existing manifest's csv_mtime"
+     and progress_every =
+       flag "progress-every"
+         (optional_with_default _default_progress_every int)
+         ~doc:
+           (Printf.sprintf
+              "N Emit progress.sexp every N symbols processed (default %d)"
+              _default_progress_every)
      in
      fun () ->
        main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol
-         ~incremental ())
+         ~incremental ~progress_every ())
 
 let () = Command_unix.run command

--- a/trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_manifest.ml
+++ b/trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_manifest.ml
@@ -46,3 +46,48 @@ let read ~path =
 
 let find t ~symbol =
   List.find t.entries ~f:(fun e -> String.equal e.symbol symbol)
+
+let upsert_entry t entry =
+  let replaced = ref false in
+  let entries =
+    List.map t.entries ~f:(fun e ->
+        if String.equal e.symbol entry.symbol then (
+          replaced := true;
+          entry)
+        else e)
+  in
+  let entries = if !replaced then entries else entries @ [ entry ] in
+  { t with entries }
+
+let _atomic_write ~path manifest =
+  let tmp_path = path ^ ".tmp" in
+  try
+    let sexp = sexp_of_t manifest in
+    Out_channel.write_all tmp_path ~data:(Sexp.to_string_hum sexp);
+    Stdlib.Sys.rename tmp_path path;
+    Ok ()
+  with Sys_error msg | Failure msg ->
+    (* Best-effort cleanup of the temp file; ignore any error. *)
+    (try Stdlib.Sys.remove tmp_path with _ -> ());
+    Status.error_internal
+      (Printf.sprintf "Snapshot_manifest._atomic_write: %s" msg)
+
+let update_for_symbol ~path ~schema entry =
+  let existing =
+    if Stdlib.Sys.file_exists path then
+      match read ~path with Ok m -> Some m | Error _ -> None
+    else None
+  in
+  match existing with
+  | None ->
+      let manifest = create ~schema ~entries:[ entry ] in
+      _atomic_write ~path manifest
+  | Some m ->
+      if not (String.equal m.schema_hash schema.Snapshot_schema.schema_hash)
+      then
+        Status.error_internal
+          (Printf.sprintf
+             "Snapshot_manifest.update_for_symbol: schema_hash mismatch \
+              (existing=%s new=%s)"
+             m.schema_hash schema.Snapshot_schema.schema_hash)
+      else _atomic_write ~path (upsert_entry m entry)

--- a/trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_manifest.mli
+++ b/trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_manifest.mli
@@ -76,3 +76,31 @@ val find : t -> symbol:string -> file_metadata option
 (** [find t ~symbol] returns the entry for [symbol], or [None] if absent. O(N)
     in the entry count — Phase B universes (≤ 10K) scan in microseconds; if
     Phase C demands faster lookup it can build a hashtable on top. *)
+
+val upsert_entry : t -> file_metadata -> t
+(** [upsert_entry t entry] returns a manifest with [entry] added (if no entry
+    matches its [symbol]) or replaced (if an entry for that symbol already
+    exists). Pure: does not touch disk. The relative order of other entries is
+    preserved; an inserted entry is appended at the end. *)
+
+val update_for_symbol :
+  path:string ->
+  schema:Data_panel_snapshot.Snapshot_schema.t ->
+  file_metadata ->
+  unit Status.status_or
+(** [update_for_symbol ~path ~schema entry] atomically updates the manifest at
+    [path] with [entry]. If no manifest exists at [path], a new one is created
+    with [schema] and [entry] as the only record. If a manifest exists, its
+    schema_hash is checked against [schema.schema_hash] — on mismatch returns
+    [Error Internal] (to refuse appending under a different indicator set). On
+    match, the manifest's entries are upserted via {!upsert_entry} and written
+    back.
+
+    Atomic-rename semantics: the new manifest is written to [path ^ ".tmp"]
+    first, then [Stdlib.Sys.rename] swaps it in. POSIX guarantees readers
+    observe either the old or new file, never a torn write. This is the
+    primitive the snapshot writer uses to checkpoint after every per-symbol
+    [.snap] file lands, so [--incremental] can resume from any interrupt
+    mid-run.
+
+    Returns [Error Internal] on filesystem error or schema mismatch. *)

--- a/trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_manifest.ml
+++ b/trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_manifest.ml
@@ -94,6 +94,120 @@ let test_schema_hash_mismatch_detectable _ =
   in
   assert_that mismatch_detected (is_ok_and_holds (equal_to true))
 
+(* upsert_entry: appending a symbol not in the manifest adds a new entry
+   at the end; existing entries are preserved in order. *)
+let test_upsert_entry_appends_new _ =
+  let manifest = _sample_manifest () in
+  let new_entry = _sample_entry ~symbol:"AMZN" in
+  let updated = Snapshot_manifest.upsert_entry manifest new_entry in
+  assert_that updated
+    (field
+       (fun (m : Snapshot_manifest.t) ->
+         List.map m.entries ~f:(fun e -> e.Snapshot_manifest.symbol))
+       (equal_to [ "AAPL"; "MSFT"; "GOOG"; "AMZN" ]))
+
+(* upsert_entry: replacing an existing symbol keeps the entry list length
+   constant and preserves the original order. *)
+let test_upsert_entry_replaces_existing _ =
+  let manifest = _sample_manifest () in
+  let replacement =
+    {
+      Snapshot_manifest.symbol = "MSFT";
+      path = "/snapshots/MSFT_v2.snap";
+      byte_size = 2048;
+      payload_md5 = "feedface";
+      csv_mtime = 1800000000.0;
+    }
+  in
+  let updated = Snapshot_manifest.upsert_entry manifest replacement in
+  assert_that updated
+    (all_of
+       [
+         field
+           (fun (m : Snapshot_manifest.t) ->
+             List.map m.entries ~f:(fun e -> e.Snapshot_manifest.symbol))
+           (equal_to [ "AAPL"; "MSFT"; "GOOG" ]);
+         field
+           (fun (m : Snapshot_manifest.t) ->
+             Snapshot_manifest.find m ~symbol:"MSFT")
+           (is_some_and
+              (all_of
+                 [
+                   field
+                     (fun (e : Snapshot_manifest.file_metadata) -> e.byte_size)
+                     (equal_to 2048);
+                   field
+                     (fun (e : Snapshot_manifest.file_metadata) ->
+                       e.payload_md5)
+                     (equal_to "feedface");
+                 ]));
+       ])
+
+(* update_for_symbol: when no manifest exists at the path, a new one is
+   created with [schema] and the single entry. *)
+let test_update_for_symbol_creates_new _ =
+  let path = _tmp_path () in
+  (* Remove the temp file created by Filename_unix.temp_file so we exercise
+     the "no manifest exists" branch. *)
+  Stdlib.Sys.remove path;
+  let entry = _sample_entry ~symbol:"AAPL" in
+  let result =
+    Result.bind
+      (Snapshot_manifest.update_for_symbol ~path ~schema:Snapshot_schema.default
+         entry) ~f:(fun () -> Snapshot_manifest.read ~path)
+  in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (m : Snapshot_manifest.t) -> m.schema_hash)
+              (equal_to Snapshot_schema.default.schema_hash);
+            field
+              (fun (m : Snapshot_manifest.t) ->
+                List.map m.entries ~f:(fun e -> e.Snapshot_manifest.symbol))
+              (equal_to [ "AAPL" ]);
+          ]))
+
+(* update_for_symbol: a sequence of upserts builds the manifest incrementally,
+   matching the resume-from-interrupt contract. *)
+let test_update_for_symbol_appends_incrementally _ =
+  let path = _tmp_path () in
+  Stdlib.Sys.remove path;
+  let upsert sym =
+    Snapshot_manifest.update_for_symbol ~path ~schema:Snapshot_schema.default
+      (_sample_entry ~symbol:sym)
+  in
+  let result =
+    Result.bind (upsert "AAPL") ~f:(fun () ->
+        Result.bind (upsert "MSFT") ~f:(fun () ->
+            Result.bind (upsert "GOOG") ~f:(fun () ->
+                Snapshot_manifest.read ~path)))
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (m : Snapshot_manifest.t) ->
+            List.map m.entries ~f:(fun e -> e.Snapshot_manifest.symbol))
+          (equal_to [ "AAPL"; "MSFT"; "GOOG" ])))
+
+(* update_for_symbol: schema mismatch returns Internal error. *)
+let test_update_for_symbol_rejects_schema_mismatch _ =
+  let path = _tmp_path () in
+  Stdlib.Sys.remove path;
+  let other_schema =
+    Snapshot_schema.create ~fields:[ Snapshot_schema.EMA_50 ]
+  in
+  let result =
+    Result.bind
+      (Snapshot_manifest.update_for_symbol ~path ~schema:Snapshot_schema.default
+         (_sample_entry ~symbol:"AAPL"))
+      ~f:(fun () ->
+        Snapshot_manifest.update_for_symbol ~path ~schema:other_schema
+          (_sample_entry ~symbol:"MSFT"))
+  in
+  assert_that result (is_error_with Status.Internal)
+
 let suite =
   "Snapshot_manifest tests"
   >::: [
@@ -106,6 +220,15 @@ let suite =
          "find returns none for unknown" >:: test_find_returns_none_for_unknown;
          "schema hash mismatch detectable"
          >:: test_schema_hash_mismatch_detectable;
+         "upsert_entry appends new" >:: test_upsert_entry_appends_new;
+         "upsert_entry replaces existing"
+         >:: test_upsert_entry_replaces_existing;
+         "update_for_symbol creates new manifest"
+         >:: test_update_for_symbol_creates_new;
+         "update_for_symbol appends incrementally"
+         >:: test_update_for_symbol_appends_incrementally;
+         "update_for_symbol rejects schema mismatch"
+         >:: test_update_for_symbol_rejects_schema_mismatch;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR 1 of the data-pipeline-automation track (plan: `dev/plans/data-pipeline-automation-2026-05-03.md`). Addresses two items of session feedback:

1. *"For these long running process [snapshot generation, simulation], it could be helpful if they dump checkpoints from time to time, so it's easier to gauge progress, and potentially recover from failure."*
2. *"GHA doesn't work as we don't check in data directory, but the automation should be more comprehensive."*

This PR ships the building blocks for **local-only** snapshot pipeline automation. The broad×10y snapshot rebuild (~2hr wall on 10,472 symbols) becomes:
- **Tail-able mid-run**: \`progress.sexp\` written every \`--progress-every N\` symbols (default 50).
- **Resume-on-interrupt**: \`manifest.sexp\` is rewritten atomically (tempfile + rename) after each \`.snap\` lands, so \`--incremental\` re-runs only the un-built symbols.
- **Cron-friendly**: \`dev/scripts/build_broad_snapshot_incremental.sh\` wraps the executable with \`--max-wall\`, \`flock\`-based concurrent-run protection, logging.
- **Pre-flight gateable**: \`dev/scripts/check_snapshot_freshness.sh\` reports stale symbols (CSV mtime > recorded csv_mtime).

## What changed

- **\`Snapshot_manifest.upsert_entry\` + \`update_for_symbol\`** (new public API in \`snapshot_manifest.{ml,mli}\`). Atomic single-symbol upsert via tempfile + rename. Schema-hash check refuses appending under a different indicator set.
- **\`build_snapshots.exe\`** extension: per-symbol checkpoint after each \`.snap\` write; periodic \`progress.sexp\` emission; new \`--progress-every N\` flag (default 50). Previous behavior preserved (final manifest write at end canonicalizes ordering).
- **\`dev/scripts/build_broad_snapshot_incremental.sh\`** (NEW): bash wrapper. Flags: \`--universe\`, \`--output-dir\`, \`--csv-data-dir\`, \`--benchmark-symbol\`, \`--progress-every\`, \`--max-wall\`, \`--dry-run\`. flock-protected concurrent-run guard.
- **\`dev/scripts/check_snapshot_freshness.sh\`** (NEW): bash probe. Parses manifest sexp, compares each symbol's recorded \`csv_mtime\` against the live CSV's mtime. Threshold gate: \`--threshold-pct N\` exits non-zero if stale exceeds N%.

## Test plan

- [x] \`dune build && dune runtest analysis/weinstein/snapshot_pipeline/\` passes — 12 tests in \`test_snapshot_manifest.ml\` (was 7, +5 new for upsert/update_for_symbol).
- [x] \`dune build @fmt\` clean for touched files (auto-promoted).
- [x] Smoke run: \`build_snapshots.exe\` on 3-symbol fixture produces \`manifest.sexp\` + \`progress.sexp\`. Confirmed atomic per-symbol manifest update via interrupt simulation (delete one \`.snap\`, rerun with \`--incremental\`, only the deleted symbol rebuilds).
- [x] \`build_broad_snapshot_incremental.sh --dry-run\` prints the underlying invocation correctly.
- [x] \`check_snapshot_freshness.sh\` correctly identifies stale entries on a synthetic fixture (1/2 stale = 50%) and on the real 3-symbol smoke run (0/3 stale).
- [x] Threshold gate works: \`--threshold-pct 5\` returns exit 1 on 50% stale; \`--threshold-pct 60\` returns exit 0.

## Plan doc

\`dev/plans/data-pipeline-automation-2026-05-03.md\` — full 4-PR breakdown.

## Sub-PR plan (follow-ups)

- **PR 2** (~250 LOC): \`backtest_runner.exe\` checkpointing — \`progress.sexp\` per Friday cycle + \`--resume-from\` flag.
- **PR 3** (~100 LOC + doc): \`ops-data\` agent dispatch entry-point + runbook.
- **PR 4** (~50 LOC + doc): local cron / launchd recipes for the user's host.

## A2/A3

- A2: feature code under \`analysis/scripts/build_snapshots/\` and \`analysis/weinstein/snapshot_pipeline/lib/\`. Wrapper + probe under \`dev/scripts/\`. No \`trading/trading/\` writes. PASS.
- A3: extends existing \`build_snapshots.ml\` and \`snapshot_manifest.{ml,mli}\` (in-scope changes); no unrelated drift. PASS.

## LOC

OCaml: 336 (140 build_snapshots + 45 snapshot_manifest.ml + 28 .mli + 123 tests). Plan doc + scripts excluded from cap. Within \`feat-data\`'s \~500 LOC budget.

## No Python

Confirmed. Wrapper + probe are POSIX bash with explicit \`#!/usr/bin/env bash\` shebang (excluded from \`posix_sh_check.sh\` per the linter's stated exclusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)