### PR TITLE
feat(data): backtest progress checkpointing (automation PR 2/4)

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -83,6 +83,22 @@ Status carries forward from `hybrid-tier` track — that track stays IN_PROGRESS
 `dev/plans/snapshot-engine-phase-f-2026-05-03.md` for the F.2 + F.3 plan,
 including the V1/V2/V3 verification follow-ups that gate F.2.)
 
+### Merged (data-pipeline-automation track)
+
+- **#819** — Automation PR 1/4: snapshot build checkpointing
+  (`Snapshot_manifest.update_for_symbol` per-symbol atomic upsert + periodic
+  `progress.sexp` emission from `build_snapshots.exe` via `--progress-every N`,
+  plus `dev/scripts/build_broad_snapshot_incremental.sh` and
+  `dev/scripts/check_snapshot_freshness.sh`). Plan:
+  `dev/plans/data-pipeline-automation-2026-05-03.md` §"PR 1".
+- **PR 2/4** (this session): backtest progress checkpointing — extends
+  `backtest_runner.exe` with `--progress-every N` so a tail-able
+  `progress.sexp` is rewritten under the experiment output dir every N Friday
+  cycles plus an unconditional final write. New `Backtest.Backtest_progress`
+  module owns the accumulator + atomic-rename writer. Single-run mode only;
+  baseline / smoke / fuzz modes ignore the flag. Resumability deferred per
+  plan §"Open question 4". Plan §"PR 2 — backtest checkpointing".
+
 ### Merged (M5.3 streaming)
 
 - **#779** — Phase A: snapshot schema + file format.

--- a/trading/trading/backtest/bin/backtest_runner.ml
+++ b/trading/trading/backtest/bin/backtest_runner.ml
@@ -171,6 +171,22 @@ let _start_memtrace ~path =
   in
   eprintf "Memtrace started, writing to: %s\n%!" path
 
+(** Build a [Backtest_progress.emitter] that writes [progress.sexp] under
+    [output_dir] every [n] Friday cycles, plus an unconditional final write.
+    [None] when [progress_every] is [None]. *)
+let _make_progress_emitter ~progress_every ~output_dir =
+  Option.map progress_every ~f:(fun n ->
+      let path = Filename.concat output_dir "progress.sexp" in
+      eprintf
+        "[progress] writing progress.sexp every %d Friday cycle(s) to %s\n%!" n
+        path;
+      {
+        Backtest.Backtest_progress.every_n_fridays = n;
+        on_progress =
+          (fun progress ->
+            Backtest.Backtest_progress.write_atomic ~path progress);
+      })
+
 (** Run a single backtest and write its full result set to [output_dir]. The
     side-effecting work (trace + memtrace + gc-trace plumbing) is folded in here
     so single-run / baseline / smoke modes all share the same per-run pipeline.
@@ -184,16 +200,18 @@ let _start_memtrace ~path =
     summary from disk. *)
 let _run_and_write ~start_date ~end_date ~overrides ~output_dir
     ?sector_map_override ?trace_path ?memtrace_path ?gc_trace_path
-    ?bar_data_source () =
+    ?bar_data_source ?progress_every () =
   Option.iter memtrace_path ~f:(fun path -> _start_memtrace ~path);
   let trace = Option.map trace_path ~f:(fun _ -> Backtest.Trace.create ()) in
   let gc_trace =
     Option.map gc_trace_path ~f:(fun _ -> Backtest.Gc_trace.create ())
   in
+  let progress_emitter = _make_progress_emitter ~progress_every ~output_dir in
   Backtest.Gc_trace.record ?trace:gc_trace ~phase:"start" ();
   let result =
     Backtest.Runner.run_backtest ~start_date ~end_date ~overrides
-      ?sector_map_override ?trace ?gc_trace ?bar_data_source ()
+      ?sector_map_override ?trace ?gc_trace ?bar_data_source ?progress_emitter
+      ()
   in
   eprintf "Writing output to %s/\n%!" output_dir;
   Backtest.Result_writer.write ~output_dir result;
@@ -211,11 +229,11 @@ let _run_and_write ~start_date ~end_date ~overrides ~output_dir
     [--override] by the caller. *)
 let _single_run ~start_date ~end_date ~overrides ~output_dir
     ?sector_map_override ?trace_path ?memtrace_path ?gc_trace_path
-    ?bar_data_source () =
+    ?bar_data_source ?progress_every () =
   let result =
     _run_and_write ~start_date ~end_date ~overrides ~output_dir
       ?sector_map_override ?trace_path ?memtrace_path ?gc_trace_path
-      ?bar_data_source ()
+      ?bar_data_source ?progress_every ()
   in
   Out_channel.output_string stdout
     (Sexp.to_string_hum (Backtest.Summary.sexp_of_t result.summary));
@@ -495,4 +513,4 @@ let () =
         ~overrides:(shared_overrides @ overrides)
         ~output_dir:output_root ?trace_path:parsed.trace_path
         ?memtrace_path:parsed.memtrace_path ?gc_trace_path:parsed.gc_trace_path
-        ?bar_data_source ()
+        ?bar_data_source ?progress_every:parsed.progress_every ()

--- a/trading/trading/backtest/lib/backtest_progress.ml
+++ b/trading/trading/backtest/lib/backtest_progress.ml
@@ -1,0 +1,88 @@
+open Core
+
+type t = {
+  started_at : float;
+  updated_at : float;
+  cycles_done : int;
+  cycles_total : int;
+  last_completed_date : Date.t;
+  trades_so_far : int;
+  current_equity : float;
+}
+[@@deriving sexp]
+
+let write_atomic ~path progress =
+  let tmp = path ^ ".tmp" in
+  try
+    let data = Sexp.to_string_hum (sexp_of_t progress) in
+    Out_channel.write_all tmp ~data;
+    Stdlib.Sys.rename tmp path
+  with Sys_error msg | Failure msg -> (
+    eprintf "backtest_progress: write failed at %s: %s\n%!" path msg;
+    try Stdlib.Sys.remove tmp with _ -> ())
+
+let count_fridays_in_range ~start_date ~end_date =
+  let rec loop d acc =
+    if Date.( > ) d end_date then acc
+    else
+      let acc' =
+        if Day_of_week.equal (Date.day_of_week d) Day_of_week.Fri then acc + 1
+        else acc
+      in
+      loop (Date.add_days d 1) acc'
+  in
+  loop start_date 0
+
+type emitter = { every_n_fridays : int; on_progress : t -> unit }
+
+type accumulator = {
+  cycles_total : int;
+  emitter : emitter option;
+  started_at : float;
+  mutable cycles_done : int;
+  mutable trades_so_far : int;
+  mutable last_step : (Date.t * float) option;
+}
+
+let create_accumulator ~cycles_total ?emitter () =
+  {
+    cycles_total;
+    emitter;
+    started_at = Core_unix.time ();
+    cycles_done = 0;
+    trades_so_far = 0;
+    last_step = None;
+  }
+
+let _is_friday date = Day_of_week.equal (Date.day_of_week date) Day_of_week.Fri
+
+let _build acc ~date ~portfolio_value =
+  {
+    started_at = acc.started_at;
+    updated_at = Core_unix.time ();
+    cycles_done = acc.cycles_done;
+    cycles_total = acc.cycles_total;
+    last_completed_date = date;
+    trades_so_far = acc.trades_so_far;
+    current_equity = portfolio_value;
+  }
+
+let _should_emit acc ~date e =
+  _is_friday date && acc.cycles_done > 0
+  && acc.cycles_done mod e.every_n_fridays = 0
+
+let record_step acc ~date ~trades_added ~portfolio_value =
+  acc.trades_so_far <- acc.trades_so_far + trades_added;
+  if _is_friday date then acc.cycles_done <- acc.cycles_done + 1;
+  acc.last_step <- Some (date, portfolio_value);
+  match acc.emitter with
+  | None -> ()
+  | Some e ->
+      if _should_emit acc ~date e then
+        e.on_progress (_build acc ~date ~portfolio_value)
+
+let emit_final acc =
+  match (acc.emitter, acc.last_step) with
+  | Some e, Some (date, portfolio_value) ->
+      e.on_progress (_build acc ~date ~portfolio_value)
+  | _ -> ()

--- a/trading/trading/backtest/lib/backtest_progress.mli
+++ b/trading/trading/backtest/lib/backtest_progress.mli
@@ -1,0 +1,106 @@
+(** Periodic progress checkpoint written by the backtest runner during a long
+    simulation.
+
+    Mirrors the snapshot-build checkpointing pattern from PR 1 of the
+    data-pipeline-automation track (see
+    [dev/plans/data-pipeline-automation-2026-05-03.md] §"PR 2 — backtest
+    checkpointing"). A 15y sp500 backtest emits no progress information today;
+    after this PR a tail-able [progress.sexp] is rewritten under the run output
+    directory every N Friday cycles (default 50) so the operator can gauge "10%
+    complete vs. 90% complete" mid-run.
+
+    The sexp shape is stable and pinned by the test suite. Atomic-write via
+    tempfile + [Stdlib.Sys.rename] guarantees a tailing reader observes either
+    the prior or the new value, never a torn write. *)
+
+open Core
+
+type t = {
+  started_at : float;
+      (** Unix seconds since epoch at the moment the run began. Stable across
+          all checkpoints in a single run; useful for computing elapsed time
+          [updated_at -. started_at] from any checkpoint. *)
+  updated_at : float;
+      (** Unix seconds since epoch at the moment this checkpoint was written.
+          Advances on every checkpoint emission. *)
+  cycles_done : int;
+      (** Number of Friday cycles completed so far. Counts only Fridays
+          encountered in the simulator's calendar walk; weekdays Mon–Thu and
+          weekends do not increment this. *)
+  cycles_total : int;
+      (** Estimated total Friday cycles in the simulation window
+          [warmup_start..end_date]. Computed once at simulation start as the
+          number of Fridays in that calendar range. Stable across all
+          checkpoints in a single run. *)
+  last_completed_date : Date.t;
+      (** The most recent simulator step's [pending_date] — i.e. the calendar
+          day the last completed step ran on (typically a Friday at checkpoint
+          emission, since checkpoints fire on Friday boundaries; on the final
+          checkpoint it is whatever the simulator's last day was). *)
+  trades_so_far : int;
+      (** Cumulative count of trades observed across all simulator steps to
+          date. Each [step_result.trades] list contributes its length. *)
+  current_equity : float;
+      (** Total portfolio value at the most recent step
+          ([cash + market value of all positions]). Pulled from
+          [step_result.portfolio_value]. *)
+}
+[@@deriving sexp]
+(** On-disk progress checkpoint. *)
+
+val write_atomic : path:string -> t -> unit
+(** [write_atomic ~path progress] serializes [progress] to [path] using
+    [Sexp.to_string_hum], via tempfile [path ^ ".tmp"] and atomic rename. On a
+    filesystem error the tempfile is cleaned up best-effort and the error is
+    logged to [stderr] but not raised — progress emission must never crash a
+    long-running backtest. *)
+
+val count_fridays_in_range : start_date:Date.t -> end_date:Date.t -> int
+(** [count_fridays_in_range ~start_date ~end_date] returns the inclusive count
+    of Fridays in [start_date..end_date]. Used by the runner to compute
+    [cycles_total] once at simulation start. O(N) in days; cheap for any
+    realistic backtest window. *)
+
+type emitter = {
+  every_n_fridays : int;
+      (** Emit a checkpoint on every Nth Friday encountered. Must be [>= 1].
+          Final-step emission is unconditional regardless of this setting, so
+          the very last completed step always lands a [progress.sexp]. *)
+  on_progress : t -> unit;
+      (** Called by the runner with the current progress snapshot. The provided
+          callback in the CLI is {!write_atomic}; tests can install a recording
+          callback to pin emission cadence. *)
+}
+(** Bundle of emission cadence + sink callback, threaded through
+    {!Backtest.Runner.run_backtest} as [?progress_emitter]. The runner owns the
+    cycle-mod check; the emitter only specifies when and where. *)
+
+type accumulator
+(** Mutable accumulator threaded through the simulator step loop. Tracks
+    [cycles_done] (Fridays completed), [trades_so_far] (cumulative trade count),
+    and the most recent step's date + portfolio value. Encapsulates the
+    per-Friday emission decision so the step-loop body keeps a low nesting
+    profile. *)
+
+val create_accumulator :
+  cycles_total:int -> ?emitter:emitter -> unit -> accumulator
+(** [create_accumulator ~cycles_total ?emitter ()] starts a fresh accumulator.
+    [started_at] is captured here from [Core_unix.time ()]. When [emitter] is
+    [None] every {!record_step} / {!emit_final} call becomes a cheap no-op. *)
+
+val record_step :
+  accumulator ->
+  date:Date.t ->
+  trades_added:int ->
+  portfolio_value:float ->
+  unit
+(** [record_step acc ~date ~trades_added ~portfolio_value] is invoked from the
+    step loop after every simulator step completes. It updates the running
+    counters and, when [date] is a Friday whose cycle index is a multiple of the
+    emitter's [every_n_fridays], invokes the emitter callback. *)
+
+val emit_final : accumulator -> unit
+(** [emit_final acc] writes one final [t] reflecting the most recently recorded
+    step. No-op if no step was recorded or no emitter was attached. Called once
+    after the simulator completes so [progress.sexp] always reflects the run's
+    terminal state, regardless of cadence boundaries. *)

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -174,36 +174,60 @@ let _step_failed e =
     (sprintf "Backtest.Panel_runner: simulation failed: %s" (Status.show e))
 
 (** One iteration of the step loop: snapshot before/after, dispatch on the
-    outcome. Returns [`Done r] when the simulator completes, or [`Continue sim']
-    with the next simulator state. *)
+    outcome. Returns [`Done r] when the simulator completes, or
+    [`Continue (sim', step_result)] with the next simulator state plus the
+    per-step result (used to advance progress counters). *)
 let _step_loop_iter ?gc_trace ~date sim =
   match _step_with_gc_trace ?gc_trace ~date sim with
   | Error e -> _step_failed e
   | Ok (Simulator.Completed result) -> `Done result
-  | Ok (Simulator.Stepped (sim', _step_result)) -> `Continue sim'
+  | Ok (Simulator.Stepped (sim', step_result)) -> `Continue (sim', step_result)
+
+(** Build a progress accumulator from the optional emitter. Extracted so the
+    [run] entry-point keeps low nesting. *)
+let _build_progress_acc ~progress_emitter ~warmup_start ~end_date =
+  match progress_emitter with
+  | None -> None
+  | Some emitter ->
+      let cycles_total =
+        Backtest_progress.count_fridays_in_range ~start_date:warmup_start
+          ~end_date
+      in
+      Some (Backtest_progress.create_accumulator ~cycles_total ~emitter ())
+
+(** Forward a completed step into [progress_acc]. Pulled out of the step loop so
+    the recursive [loop] body keeps low nesting. *)
+let _record_step_into_progress ~progress_acc ~date
+    ~(step_result : Trading_simulation_types.Simulator_types.step_result) =
+  match progress_acc with
+  | None -> ()
+  | Some acc ->
+      Backtest_progress.record_step acc ~date
+        ~trades_added:(List.length step_result.trades)
+        ~portfolio_value:step_result.portfolio_value
 
 (** Step-loop replacement for [Simulator.run] that snapshots [Gc.stat] before
     and after each [Simulator.step] call. One step = one calendar day in the
     [Daily] cadence used by the panel runner = one [Engine.update_market] call
     (the dominant per-tick allocator per the post-PR-A memtrace).
 
-    When [gc_trace = None] the loop is functionally identical to [Simulator.run]
-    modulo one [Option.is_some] check per step.
-
     [pending_date] is tracked locally in lockstep with the simulator's internal
     [current_date] so the [_before] snapshot can be labeled with the step's date
-    *before* [Simulator.step] is invoked. *)
-let _run_simulator_with_gc_trace ?gc_trace ~stop_log sim =
+    *before* [Simulator.step] is invoked.
+
+    [progress_acc], when passed, has [Backtest_progress.record_step] invoked
+    after every completed step. The accumulator owns the per-Friday emission
+    decision so the step-loop body stays simple. The caller is responsible for
+    the final {!Backtest_progress.emit_final} call after the loop returns. *)
+let _run_simulator_with_gc_trace ?gc_trace ?progress_acc ~stop_log sim =
   let start_date = (Simulator.get_config sim).start_date in
   let rec loop sim ~pending_date =
-    (* Stamp [pending_date] on [stop_log] so any [EntryComplete] transition
-       observed by the strategy wrapper during this step records the correct
-       entry_date. The runner reads this back at teardown to drop stop_infos
-       for positions opened during the warmup window. *)
     Stop_log.set_current_date stop_log pending_date;
     match _step_loop_iter ?gc_trace ~date:pending_date sim with
     | `Done result -> result
-    | `Continue sim' -> loop sim' ~pending_date:(Date.add_days pending_date 1)
+    | `Continue (sim', step_result) ->
+        _record_step_into_progress ~progress_acc ~date:pending_date ~step_result;
+        loop sim' ~pending_date:(Date.add_days pending_date 1)
   in
   loop sim ~pending_date:start_date
 
@@ -320,7 +344,7 @@ let _setup_for_mode (input : input) ~calendar ~n_days ~end_date ~audit_recorder
       _setup_snapshot input ~snapshot_dir ~manifest ~end_date ~audit_recorder
 
 let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
-    ~commission ?trace ?gc_trace ?bar_data_source () =
+    ~commission ?trace ?gc_trace ?bar_data_source ?progress_emitter () =
   let warmup_start = Date.add_days start_date (-warmup_days) in
   let calendar = _build_calendar ~start:warmup_start ~end_:end_date in
   let n_days = Array.length calendar in
@@ -342,9 +366,13 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     _make_simulator input ~stop_log ~start_date ~end_date ~warmup_days
       ~initial_cash ~commission ~strategy ~market_data_adapter
   in
+  let progress_acc =
+    _build_progress_acc ~progress_emitter ~warmup_start ~end_date
+  in
   let sim_result =
     Trace.record ?trace ~symbols_in:n_all_symbols Trace.Phase.Fill (fun () ->
-        _run_simulator_with_gc_trace ?gc_trace ~stop_log sim)
+        _run_simulator_with_gc_trace ?gc_trace ?progress_acc ~stop_log sim)
   in
+  Option.iter progress_acc ~f:Backtest_progress.emit_final;
   let final_close_prices = final_close_prices_thunk () in
   (sim_result, stop_log, trade_audit, force_liquidation_log, final_close_prices)

--- a/trading/trading/backtest/lib/panel_runner.mli
+++ b/trading/trading/backtest/lib/panel_runner.mli
@@ -43,6 +43,7 @@ val run :
   ?trace:Trace.t ->
   ?gc_trace:Gc_trace.t ->
   ?bar_data_source:Bar_data_source.t ->
+  ?progress_emitter:Backtest_progress.emitter ->
   unit ->
   Trading_simulation_types.Simulator_types.run_result
   * Stop_log.t
@@ -73,6 +74,15 @@ val run :
     that [Engine.update_market] dominates the per-tick allocator profile before
     the buffer-reuse refactors land. When [gc_trace] is omitted, the runner
     takes no per-step snapshots and the cost is one [None] match per step.
+
+    [progress_emitter], when passed, threads a periodic-checkpoint hook into the
+    per-step loop. On every [emitter.every_n_fridays]-th Friday the runner
+    builds a {!Backtest_progress.t} reflecting cycles done / total / last
+    completed date / cumulative trade count / current equity, and invokes
+    [emitter.on_progress] with it. The final completed step also fires an
+    emission unconditionally so a [progress.sexp] always reflects the run's end
+    state. When [None], the runner takes no extra work — same zero-overhead
+    contract as the other optional plumbing.
 
     [bar_data_source], when passed, selects the OHLCV backend used by both the
     simulator's per-tick price reads AND the strategy's bar reads.

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -247,11 +247,11 @@ let _panel_input_of_deps (deps : _deps) : Panel_runner.input =
   }
 
 let _run_panel_backtest ~deps ~start_date ~end_date ?trace ?gc_trace
-    ?bar_data_source () =
+    ?bar_data_source ?progress_emitter () =
   Panel_runner.run
     ~input:(_panel_input_of_deps deps)
     ~start_date ~end_date ~warmup_days ~initial_cash ~commission ?trace
-    ?gc_trace ?bar_data_source ()
+    ?gc_trace ?bar_data_source ?progress_emitter ()
 
 (** Re-run the step-based metric computers ([SharpeRatio], [MaxDrawdown],
     [CAGR]) on the in-window step list with a config whose [start_date] is the
@@ -424,7 +424,7 @@ let _final_prices_for_held_symbols ~steps ~final_close_prices =
       List.filter final_close_prices ~f:(fun (sym, _) -> Set.mem held sym)
 
 let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
-    ?trace ?gc_trace ?bar_data_source () =
+    ?trace ?gc_trace ?bar_data_source ?progress_emitter () =
   let deps = _load_deps ?trace ?gc_trace ~overrides ~sector_map_override () in
   eprintf "Total symbols (universe + index + sector ETFs): %d\n%!"
     (List.length deps.all_symbols);
@@ -439,7 +439,7 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
         force_liquidation_log,
         final_close_prices ) =
     _run_panel_backtest ~deps ~start_date ~end_date ?trace ?gc_trace
-      ?bar_data_source ()
+      ?bar_data_source ?progress_emitter ()
   in
   Gc_trace.record ?trace:gc_trace ~phase:"fill_done" ();
   (* Steps in the requested date range, all days included. Round-trip

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -123,6 +123,7 @@ val run_backtest :
   ?trace:Trace.t ->
   ?gc_trace:Gc_trace.t ->
   ?bar_data_source:Bar_data_source.t ->
+  ?progress_emitter:Backtest_progress.emitter ->
   unit ->
   result
 (** Run the simulator from [start_date - warmup] to [end_date], filter to the
@@ -132,10 +133,10 @@ val run_backtest :
     order. Each must be a record sexp with fields matching
     [Weinstein_strategy.config]. Example:
     {[
-    [
-      Sexp.of_string "((initial_stop_buffer 1.08))";
-      Sexp.of_string "((stage_config ((ma_period 40))))";
-    ]
+      [
+        Sexp.of_string "((initial_stop_buffer 1.08))";
+        Sexp.of_string "((stage_config ((ma_period 40))))";
+      ]
     ]}
 
     [sector_map_override], when passed, replaces the sector-map normally loaded
@@ -186,4 +187,12 @@ val run_backtest :
     to read OHLCV from a snapshot directory written by Phase B. See
     {!Bar_data_source.t} and the Phase D plan
     ([dev/plans/snapshot-engine-phase-d-2026-05-02.md]) for the full contract.
-*)
+
+    [progress_emitter], when passed, threads a Friday-cycle checkpoint hook
+    through the simulator step loop. See {!Backtest_progress.emitter}. Used by
+    [backtest_runner.exe]'s [--progress-every] flag to emit a tail-able
+    [progress.sexp] mid-run; tests install a recording emitter to pin emission
+    cadence. Resumability is intentionally NOT in this PR — the checkpoint is
+    read-only progress information; restartability of the simulator state is a
+    follow-up (deferred per the data-pipeline-automation plan, §"Open question
+    4"). *)

--- a/trading/trading/backtest/runner_args/backtest_runner_args.ml
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.ml
@@ -14,6 +14,7 @@ type t = {
   fuzz_spec : string option;
   fuzz_window : string option;
   snapshot_dir : string option;
+  progress_every : int option;
 }
 
 type acc = {
@@ -31,6 +32,7 @@ type acc = {
   snapshot_mode : bool;
   csv_mode : bool;
   snapshot_dir : string option;
+  progress_every : int option;
 }
 (** Accumulator for [_extract_flags]. Carries every flag the parser recognises
     plus the running list of positional args. Snapshot mode is the default since
@@ -55,6 +57,7 @@ let _empty_acc =
     snapshot_mode = false;
     csv_mode = false;
     snapshot_dir = None;
+    progress_every = None;
   }
 
 let _err msg = Error (Status.invalid_argument_error msg)
@@ -102,6 +105,13 @@ let rec _extract_flags args (acc : acc) =
   | "--snapshot-dir" :: value :: rest ->
       _extract_flags rest { acc with snapshot_dir = Some value }
   | [ "--snapshot-dir" ] -> _err "--snapshot-dir requires a path argument"
+  | "--progress-every" :: value :: rest -> (
+      match Int.of_string_opt value with
+      | Some n when n >= 1 ->
+          _extract_flags rest { acc with progress_every = Some n }
+      | _ -> _err "--progress-every requires a positive integer argument")
+  | [ "--progress-every" ] ->
+      _err "--progress-every requires a positive integer argument"
   | arg :: rest ->
       _extract_flags rest { acc with positional = arg :: acc.positional }
 
@@ -204,6 +214,7 @@ let _build_result (acc : acc) (start_date, end_date) =
       fuzz_spec = acc.fuzz_spec;
       fuzz_window = acc.fuzz_window;
       snapshot_dir = acc.snapshot_dir;
+      progress_every = acc.progress_every;
     }
 
 let parse args =

--- a/trading/trading/backtest/runner_args/backtest_runner_args.mli
+++ b/trading/trading/backtest/runner_args/backtest_runner_args.mli
@@ -103,6 +103,14 @@ type t = {
           runner will fail loudly if the manifest is missing or schema-skewed.
           (Auto-build of the snapshot directory is deferred to a follow-up PR.)
       *)
+  progress_every : int option;
+      (** [Some n] when [--progress-every <n>] was passed; the runner emits a
+          [progress.sexp] checkpoint every [n] Friday cycles to the experiment
+          output directory, plus an unconditional final write at the end of the
+          run. [None] (the default) disables emission entirely — same
+          zero-overhead contract as the existing [--trace] / [--gc-trace]
+          plumbing. Validated at parse time: [n] must be [>= 1]. Single-run mode
+          only — baseline/smoke/fuzz modes ignore this flag. *)
 }
 (** Result of parsing the [backtest_runner.exe] command line. *)
 

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -21,6 +21,7 @@
   test_fuzz_distribution
   test_gc_trace
   test_panel_runner_gc_trace
+  test_backtest_progress
   test_release_perf_report
   test_determinism
   test_macro_trend_writer)

--- a/trading/trading/backtest/test/test_backtest_progress.ml
+++ b/trading/trading/backtest/test/test_backtest_progress.ml
@@ -99,6 +99,31 @@ let test_write_atomic_round_trip _ =
            (float_equal 152384.21);
        ])
 
+(* CP4 pin: [write_atomic]'s docstring guarantees "must never crash" on
+   filesystem errors. Exercise the guarded scenario by writing to a path
+   under a non-existent parent directory and asserting no exception
+   escapes. *)
+let test_write_atomic_does_not_crash_on_missing_parent _ =
+  let progress : Backtest_progress.t =
+    {
+      started_at = 1714780000.0;
+      updated_at = 1714780000.0;
+      cycles_done = 1;
+      cycles_total = 100;
+      last_completed_date = Date.create_exn ~y:2010 ~m:Month.Jan ~d:1;
+      trades_so_far = 0;
+      current_equity = 100000.0;
+    }
+  in
+  let bogus_path =
+    "/tmp/nonexistent_parent_dir_for_backtest_progress_test/progress.sexp"
+  in
+  (* The contract: write_atomic must NOT raise even when the destination
+     can't be written. Implementation should swallow Sys_error / Failure. *)
+  Backtest_progress.write_atomic ~path:bogus_path progress;
+  (* If we got here, the contract held. *)
+  assert_that () (equal_to ())
+
 let _run_with_emitter ~every_n_fridays ~recorder =
   let s = _load_scenario _scenario_rel in
   let sector_map_override = _sector_map_override s in
@@ -172,6 +197,8 @@ let suite =
          "count_fridays handles single-day ranges"
          >:: test_count_fridays_zero_range;
          "write_atomic produces parsable sexp" >:: test_write_atomic_round_trip;
+         "write_atomic does not crash on missing parent dir"
+         >:: test_write_atomic_does_not_crash_on_missing_parent;
          "emitter fires during a real run with every_n_fridays = 1"
          >:: test_emitter_fires_during_run;
          "emitter records monotonic progress"

--- a/trading/trading/backtest/test/test_backtest_progress.ml
+++ b/trading/trading/backtest/test/test_backtest_progress.ml
@@ -1,0 +1,183 @@
+(** Periodic-progress emission contract for the backtest runner — see
+    [dev/plans/data-pipeline-automation-2026-05-03.md] §"PR 2 — backtest
+    checkpointing".
+
+    Pin two behaviors:
+
+    1. {b Friday cadence}: when a [Backtest_progress.emitter] is threaded
+    through [Runner.run_backtest] with [every_n_fridays = 1], the runner fires
+    the [on_progress] callback at least once during a multi-week simulation, and
+    a final write always happens (regardless of whether the last completed step
+    landed on an N-th Friday). The [progress.sexp] fields parse round-trip via
+    [t_of_sexp].
+
+    2. {b Atomic write}: [write_atomic] writes a well-formed sexp that can be
+    parsed back into [Backtest_progress.t] with the same field values.
+
+    These tests do NOT pin an exact [cycles_done] count — that depends on the
+    scenario calendar / holidays / warmup window — but they do pin that the
+    progress sexp records monotonically advance and that the structure is stable
+    across runs. *)
+
+open OUnit2
+open Core
+open Matchers
+module Backtest_progress = Backtest.Backtest_progress
+module Scenario = Scenario_lib.Scenario
+module Universe_file = Scenario_lib.Universe_file
+
+let _fixtures_root () =
+  let data_dir = Data_path.default_data_dir () |> Fpath.to_string in
+  Filename.concat data_dir "backtest_scenarios"
+
+let _scenario_path rel = Filename.concat (_fixtures_root ()) rel
+let _load_scenario rel = Scenario.load (_scenario_path rel)
+
+let _sector_map_override (s : Scenario.t) =
+  let resolved = Filename.concat (_fixtures_root ()) s.universe_path in
+  Universe_file.to_sector_map_override (Universe_file.load resolved)
+
+(* Smallest, fastest scenario in the catalog (perf-tier-1, 7 symbols, ~6
+   months) so the test stays well inside any per-PR budget. Same scenario as
+   [test_panel_runner_gc_trace] for cross-test consistency. *)
+let _scenario_rel = "smoke/tiered-loader-parity.sexp"
+
+let test_count_fridays_in_range _ =
+  (* 2024-01-01 (Monday) .. 2024-01-31 (Wednesday) contains the Fridays
+     2024-01-05, 2024-01-12, 2024-01-19, 2024-01-26 → 4. *)
+  let start_date = Date.create_exn ~y:2024 ~m:Month.Jan ~d:1 in
+  let end_date = Date.create_exn ~y:2024 ~m:Month.Jan ~d:31 in
+  assert_that
+    (Backtest_progress.count_fridays_in_range ~start_date ~end_date)
+    (equal_to 4)
+
+let test_count_fridays_zero_range _ =
+  (* Single non-Friday day → 0; single Friday → 1. *)
+  let mon = Date.create_exn ~y:2024 ~m:Month.Jan ~d:1 in
+  let fri = Date.create_exn ~y:2024 ~m:Month.Jan ~d:5 in
+  assert_that
+    ( Backtest_progress.count_fridays_in_range ~start_date:mon ~end_date:mon,
+      Backtest_progress.count_fridays_in_range ~start_date:fri ~end_date:fri )
+    (all_of
+       [
+         field (fun (a, _) -> a) (equal_to 0);
+         field (fun (_, b) -> b) (equal_to 1);
+       ])
+
+let test_write_atomic_round_trip _ =
+  (* [write_atomic] produces a parsable sexp round-trip. Use a tmp directory so
+     the test doesn't pollute the working tree. *)
+  let tmp_dir = Filename_unix.temp_dir "backtest_progress_test_" "" in
+  let path = Filename.concat tmp_dir "progress.sexp" in
+  let progress : Backtest_progress.t =
+    {
+      started_at = 1714780000.0;
+      updated_at = 1714780123.5;
+      cycles_done = 42;
+      cycles_total = 838;
+      last_completed_date = Date.create_exn ~y:2014 ~m:Month.Dec ~d:26;
+      trades_so_far = 7;
+      current_equity = 152384.21;
+    }
+  in
+  Backtest_progress.write_atomic ~path progress;
+  let loaded = Sexp.load_sexp path |> Backtest_progress.t_of_sexp in
+  (* Cleanup. *)
+  Stdlib.Sys.remove path;
+  Stdlib.Sys.rmdir tmp_dir;
+  assert_that loaded
+    (all_of
+       [
+         field (fun p -> p.Backtest_progress.cycles_done) (equal_to 42);
+         field (fun p -> p.Backtest_progress.cycles_total) (equal_to 838);
+         field (fun p -> p.Backtest_progress.trades_so_far) (equal_to 7);
+         field
+           (fun p -> p.Backtest_progress.last_completed_date)
+           (equal_to (Date.create_exn ~y:2014 ~m:Month.Dec ~d:26));
+         field
+           (fun p -> p.Backtest_progress.current_equity)
+           (float_equal 152384.21);
+       ])
+
+let _run_with_emitter ~every_n_fridays ~recorder =
+  let s = _load_scenario _scenario_rel in
+  let sector_map_override = _sector_map_override s in
+  let progress_emitter : Backtest_progress.emitter =
+    { every_n_fridays; on_progress = (fun p -> recorder := !recorder @ [ p ]) }
+  in
+  let _result =
+    Backtest.Runner.run_backtest ~start_date:s.period.start_date
+      ~end_date:s.period.end_date ~overrides:s.config_overrides
+      ?sector_map_override ~progress_emitter ()
+  in
+  ()
+
+let test_emitter_fires_during_run _ =
+  (* With [every_n_fridays = 1], every Friday triggers an emission, and a
+     final emission always lands. The smoke scenario covers ~6 months of
+     calendar days including warmup, so we expect [>= 4] emissions
+     (very conservative). *)
+  let recorder = ref [] in
+  _run_with_emitter ~every_n_fridays:1 ~recorder;
+  let snapshots = !recorder in
+  assert_that (List.length snapshots) (gt (module Int_ord) 4)
+
+let test_emitter_records_monotonic_progress _ =
+  (* Across the recorded checkpoints, [cycles_done] is non-decreasing,
+     [updated_at] is non-decreasing, and the FINAL emission's
+     [last_completed_date] >= the first emission's [last_completed_date]. *)
+  let recorder = ref [] in
+  _run_with_emitter ~every_n_fridays:2 ~recorder;
+  let snapshots = !recorder in
+  let dates =
+    List.map snapshots ~f:(fun p -> p.Backtest_progress.last_completed_date)
+  in
+  let cycles =
+    List.map snapshots ~f:(fun p -> p.Backtest_progress.cycles_done)
+  in
+  let updated_ats =
+    List.map snapshots ~f:(fun p -> p.Backtest_progress.updated_at)
+  in
+  let is_sorted ~compare xs =
+    List.is_sorted xs ~compare:(fun a b ->
+        if compare a b < 0 then -1 else if compare a b > 0 then 1 else 0)
+  in
+  assert_that
+    ( is_sorted ~compare:Date.compare dates,
+      is_sorted ~compare:Int.compare cycles,
+      is_sorted ~compare:Float.compare updated_ats,
+      List.length snapshots > 0 )
+    (all_of
+       [
+         field (fun (a, _, _, _) -> a) (equal_to true);
+         field (fun (_, b, _, _) -> b) (equal_to true);
+         field (fun (_, _, c, _) -> c) (equal_to true);
+         field (fun (_, _, _, d) -> d) (equal_to true);
+       ])
+
+let test_emitter_final_write_always_fires _ =
+  (* With [every_n_fridays] much larger than the scenario's Friday count,
+     the per-N gate never fires — but the unconditional final-emission contract
+     still produces exactly one write. *)
+  let recorder = ref [] in
+  _run_with_emitter ~every_n_fridays:10_000 ~recorder;
+  let snapshots = !recorder in
+  assert_that snapshots (size_is 1)
+
+let suite =
+  "Backtest_progress"
+  >::: [
+         "count_fridays_in_range counts inclusive"
+         >:: test_count_fridays_in_range;
+         "count_fridays handles single-day ranges"
+         >:: test_count_fridays_zero_range;
+         "write_atomic produces parsable sexp" >:: test_write_atomic_round_trip;
+         "emitter fires during a real run with every_n_fridays = 1"
+         >:: test_emitter_fires_during_run;
+         "emitter records monotonic progress"
+         >:: test_emitter_records_monotonic_progress;
+         "final write always fires regardless of cadence"
+         >:: test_emitter_final_write_always_fires;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_backtest_runner_args.ml
+++ b/trading/trading/backtest/test/test_backtest_runner_args.ml
@@ -67,6 +67,9 @@ let test_minimal_start_date_only _ =
             field
               (fun (a : Backtest_runner_args.t) -> a.snapshot_dir)
               (equal_to None);
+            field
+              (fun (a : Backtest_runner_args.t) -> a.progress_every)
+              (equal_to None);
           ]))
 
 let test_override_key_path_form _ =
@@ -745,6 +748,26 @@ let test_snapshot_mode_with_fuzz _ =
               (equal_to (Some "/tmp/snapshots/v1"));
           ]))
 
+let test_progress_every_flag _ =
+  let result = _parse_csv [ "2018-01-02"; "--progress-every"; "25" ] in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (a : Backtest_runner_args.t) -> a.progress_every)
+          (equal_to (Some 25))))
+
+let test_progress_every_zero_is_error _ =
+  let result = _parse_csv [ "2018-01-02"; "--progress-every"; "0" ] in
+  assert_that result is_error
+
+let test_progress_every_non_numeric_is_error _ =
+  let result = _parse_csv [ "2018-01-02"; "--progress-every"; "fast" ] in
+  assert_that result is_error
+
+let test_progress_every_missing_value _ =
+  let result = _parse_csv [ "2018-01-02"; "--progress-every" ] in
+  assert_that result is_error
+
 let suite =
   "Backtest_runner_args"
   >::: [
@@ -819,6 +842,12 @@ let suite =
          >:: test_snapshot_dir_missing_value;
          "--snapshot-mode composes with --fuzz" >:: test_snapshot_mode_with_fuzz;
          "trace pipeline write+parse round-trip" >:: test_trace_write_and_parse;
+         "--progress-every captures positive int" >:: test_progress_every_flag;
+         "--progress-every 0 is rejected" >:: test_progress_every_zero_is_error;
+         "--progress-every non-numeric is rejected"
+         >:: test_progress_every_non_numeric_is_error;
+         "--progress-every without value is error"
+         >:: test_progress_every_missing_value;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Extends `backtest_runner.exe` with periodic progress checkpointing so long-running backtests (notably the 15y sp500 run that motivated this PR — ~40 min wall with zero feedback today) emit a tail-able `progress.sexp` mid-run.

PR 2/4 of the data-pipeline-automation track (`dev/plans/data-pipeline-automation-2026-05-03.md`); mirrors the snapshot-build checkpointing pattern from PR 1 (#819).

## What changed

- **New `Backtest.Backtest_progress` module** (lib): on-disk progress checkpoint type + atomic-rename writer + step-loop `accumulator` that owns the per-Friday emission decision. The accumulator is a thin mutable bundle so the simulator step loop just calls `record_step` and `emit_final`.
- **`Panel_runner.run` + `Runner.run_backtest`** gain an optional `?progress_emitter:Backtest_progress.emitter` parameter. Runner constructs the accumulator, threads it through the step loop, and calls `emit_final` after the simulator completes. Default behaviour (no emitter) is unchanged — same zero-overhead contract as the existing `?trace` / `?gc_trace` plumbing.
- **`backtest_runner.exe --progress-every <N>`**: when set, the runner builds a `Backtest_progress.emitter` whose `on_progress` callback writes `progress.sexp` to the experiment output dir via tempfile + atomic rename. Single-run mode only; baseline / smoke / fuzz modes ignore the flag (per plan §"Out").
- Cycle counting: `count_fridays_in_range` walks the warmup_start..end_date calendar once at startup to populate `cycles_total`. The accumulator increments `cycles_done` each time `pending_date` is a Friday, and emits when `cycles_done mod every_n_fridays = 0`.

## What's NOT in this PR

- **Resumability** (i.e. `--resume-from <progress.sexp>`): backtest state is large (positions, stop_states, prior_macro, peak_tracker, etc.). The plan §"Open question 4" defers full resumability; this PR ships progress emission only. The progress sexp captures `last_completed_date` which is sufficient to resume manually if needed (re-run from a later start date).
- Auto-emission for baseline / smoke / fuzz modes (multiple output dirs, multi-run flow).

## Files

- New:
  - `trading/trading/backtest/lib/backtest_progress.{ml,mli}` (~190 LOC)
  - `trading/trading/backtest/test/test_backtest_progress.ml` (~180 LOC)
- Extended: `panel_runner.{ml,mli}`, `runner.{ml,mli}`, `backtest_runner.ml`, `backtest_runner_args.{ml,mli}`, `test_backtest_runner_args.ml`.

Total: ~536 insertions / 29 deletions across 13 files (counts include `dev/status/data-foundations.md` Completed entry).

## Test plan

- [x] `dune build && dune runtest trading/backtest/` green (existing 53 args tests + 6 new progress tests + all backtest tests, EXIT=0).
- [x] `dune build @fmt` clean for files touched in this PR.
- [x] New `test_backtest_progress.ml` pins:
  - `count_fridays_in_range` correctness on a January 2024 fixture (4 Fridays).
  - `write_atomic` round-trip via `t_of_sexp`.
  - Emitter fires more than once with `every_n_fridays=1` on the smoke scenario.
  - `cycles_done`, `updated_at`, `last_completed_date` are non-decreasing across the recorded checkpoints.
  - Final unconditional emission fires exactly once with `every_n_fridays=10000` (the periodic gate never trips).
- [x] No A1 / A2 / A3 violations: no core-module modifications outside the `?progress_emitter` opt-in surface; no new `analysis/` imports into `trading/trading/`; only the backtest crate's runner/CLI/tests are touched.
- [x] No new Python.

## Decisions

- **Cadence trigger**: every Nth Friday (not every N seconds, not every N steps). The plan called for "Friday cycle" emission; calendar-day cadence isn't user-meaningful (a 15y backtest has thousands of weekend "steps" that don't represent strategy progress). Friday-aligned emission is what the operator actually wants to see ("we're at Friday 2014-12-26 of 838 total").
- **Module placement**: `Backtest_progress` lives under `trading/trading/backtest/lib/` next to other runner-adjacent modules (`Trace`, `Gc_trace`, `Stop_log`). Same shape as the surrounding instrumentation plumbing.
- **Mutable accumulator**: chose a small mutable record over a folded immutable state because (a) it composes cleanly with the existing recursive step loop without changing its signature in a disruptive way, and (b) it keeps the per-step nesting profile under the linter caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)