### PR TITLE
feat(data): ops-data snapshot-refresh dispatch (automation PR 3/4)

### DIFF
--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -95,6 +95,75 @@ Builds `data/universe.sexp` from the local inventory. Sector/industry fields wil
 
 Read `data/inventory.sexp` and report: which symbols are present, their date ranges, and any gaps for a requested symbol/date range.
 
+### Snapshot corpus refresh
+
+Use this when the broad-universe daily-snapshot warehouse (consumed by
+backtests via `--snapshot-mode --snapshot-dir`) needs to catch up to
+fresher CSV bars. Trigger on direct user dispatch — there is no auto-cron
+yet (deferred to PR 4 of
+`dev/plans/data-pipeline-automation-2026-05-03.md`).
+
+**Inputs (dispatch-time flags):**
+
+- `--universe <path>` — pinned universe sexp. Default for the broad
+  10y warehouse: a sectors-derived universe sexp (build via
+  `bootstrap_universe.exe` against `data/sectors.csv` if you don't
+  already have one pinned).
+- `--output-dir <path>` — snapshot warehouse output. Default for the
+  broad 2014–2023 corpus: `dev/data/snapshots/broad-2014-2023/`.
+- `--max-wall <duration>` — wall-clock budget for one dispatch.
+  Default: `30m`. Accepts `30m` / `1h` / `90m` / `7200s`.
+- `--csv-data-dir <path>` — source CSV root. Default: `data`.
+- `--progress-every <N>` — `progress.sexp` cadence. Default: `50`.
+
+**Steps:**
+
+1. **Freshness probe** — read existing manifest staleness:
+   ```bash
+   dev/scripts/check_snapshot_freshness.sh \
+     --output-dir <output-dir> \
+     --csv-data-dir <csv-data-dir>
+   ```
+   Emits `snapshot-freshness: <stale>/<total> stale = <pct>%`. If the
+   probe exits 0 and stale% is below the agreed threshold (default 5%),
+   record the result in `dev/notes/snapshot-corpus-status.md` and exit
+   clean — no rebuild needed.
+2. **Incremental rebuild** — invoke the wrapper bounded by `--max-wall`:
+   ```bash
+   dev/scripts/build_broad_snapshot_incremental.sh \
+     --universe <path> \
+     --output-dir <output-dir> \
+     --csv-data-dir <csv-data-dir> \
+     --progress-every <N> \
+     --max-wall <duration>
+   ```
+   The wrapper acquires `<output-dir>/.build.lock` to prevent concurrent
+   runs (exits 75 / `EX_TEMPFAIL` if held). Per-symbol manifest update
+   (PR 1) makes the run resumable across invocations: a 2-hour rebuild
+   can be split across multiple dispatches.
+3. **Re-probe + record** — re-run the freshness probe to capture the
+   post-rebuild state and append a "Last refresh" block to
+   `dev/notes/snapshot-corpus-status.md` (started, wall, symbols built,
+   failures, exit code, current freshness%).
+
+**Acceptance:**
+
+- The corpus is fresh per the staleness threshold (`stale% ≤ 5`), OR
+- `dev/notes/snapshot-corpus-status.md` records partial-progress
+  (cycles done, exit code 124 if `--max-wall` truncated, ETA for
+  resume on next dispatch).
+
+**Resume contract.** The wrapper always passes `--incremental` to
+`build_snapshots.exe`; per PR 1, manifest entries are upserted atomically
+per symbol, so a `timeout 124` exit at symbol N/Total leaves
+N entries on disk and the next dispatch picks up at symbol N+1. A full
+broad×10y rebuild from cold cache takes ~2h wall under the post-#792
+writer; with `--max-wall 30m`, that's ~4 dispatches.
+
+**Runbook.** See `dev/notes/snapshot-corpus-runbook-2026-05-03.md` for
+the canonical user-facing runbook (when to dispatch, sample dispatch
+prompts, how to read the status file).
+
 ## API key
 
 `EODHD_API_KEY` must be set in the host environment before any fetch. `dev/lib/run-in-env.sh` forwards it into the container automatically; the OCaml script receives it via the `--api-key` flag and never reads env vars directly.
@@ -155,6 +224,12 @@ When asked to fetch new symbols and update the inventory:
 3. Run `build_inventory.exe` to regenerate `data/inventory.sexp`
 4. If universe needs updating: run `bootstrap_universe.exe`
 5. Report what was fetched, any errors, and updated coverage
+6. **Snapshot freshness check (broad-universe corpus only).** When the
+   refresh touched ≥N symbols of the broad-universe set, run
+   `dev/scripts/check_snapshot_freshness.sh --output-dir <broad-corpus-dir>`
+   to surface staleness. If stale% exceeds the threshold, run the
+   "Snapshot corpus refresh" workflow above (or note it in
+   `dev/notes/snapshot-corpus-status.md` for the next dispatch).
 
 ## Output format
 

--- a/dev/notes/snapshot-corpus-runbook-2026-05-03.md
+++ b/dev/notes/snapshot-corpus-runbook-2026-05-03.md
@@ -1,0 +1,129 @@
+# Snapshot corpus refresh runbook (2026-05-03)
+
+User-facing runbook for keeping the broad-universe daily-snapshot corpus
+fresh. Backtests at tier-3 / tier-4 read from this corpus via
+`--snapshot-mode --snapshot-dir <output-dir>`; if the corpus lags the
+underlying CSV bars, scenario results are silently stale.
+
+This runbook is the canonical companion to the ops-data §"Snapshot corpus
+refresh" subsection in `.claude/agents/ops-data.md`. The plan that scopes
+the automation work is `dev/plans/data-pipeline-automation-2026-05-03.md`
+(this is PR 3/4 of that track; PR 4 will add cron / launchd recipes).
+
+## When to dispatch
+
+Trigger an `ops-data` dispatch with a snapshot-refresh prompt when **any**
+of the following apply:
+
+- Broad-universe backtests (tier-3 / tier-4 scale) are about to be run
+  and the freshness probe reports `stale% > 5`. Default threshold; tune
+  per scenario.
+- A first-time corpus build is needed (the output dir does not yet
+  exist, or `manifest.sexp` is missing). The wrapper handles a cold
+  cache the same as a stale one — it just takes longer.
+- A bulk CSV refresh has just completed (e.g. ops-data fetched a
+  thousand symbols' bars). The corpus is now stale by construction.
+- `dev/notes/snapshot-corpus-status.md` shows `Status: PARTIAL` with a
+  recent partial run — pick up where the previous dispatch left off.
+
+Skip if `Status: FRESH` and the last refresh was within the last 24
+hours and no CSV refresh has happened since.
+
+## Dispatch prompt template
+
+Paste this (with the placeholders filled in) when asking the orchestrator
+to run `ops-data`:
+
+```
+Refresh the broad-universe snapshot corpus.
+
+- Universe: <path-to-pinned-universe-sexp>
+  (default: bootstrap from data/sectors.csv if no pinned sexp exists)
+- Output dir: dev/data/snapshots/broad-2014-2023/
+- CSV data dir: data
+- Max wall: 30m
+- Progress every: 50
+
+Steps:
+1. Run dev/scripts/check_snapshot_freshness.sh --output-dir <output-dir>.
+   If stale% < 5, record FRESH in dev/notes/snapshot-corpus-status.md
+   and exit clean.
+2. Otherwise run dev/scripts/build_broad_snapshot_incremental.sh
+   with the inputs above.
+3. Re-run the freshness probe and append a "Last refresh" block to
+   dev/notes/snapshot-corpus-status.md.
+
+Report the final freshness%, exit code, wall time, and whether the
+corpus is FRESH or PARTIAL after this dispatch.
+```
+
+The dispatch is single-pass: the agent does not loop on the wrapper
+within one session. A `--max-wall 30m` ceiling means a cold-cache build
+of the full broad×10y corpus (~10,472 symbols, ~2h) takes ~4 dispatches
+to complete, each picking up where the previous left off via the
+per-symbol manifest writer (PR 1, #819).
+
+## Expected outcomes
+
+| Outcome | Status file value | Next action |
+|---|---|---|
+| Probe reports `stale% < 5`, no rebuild needed | `FRESH` | None — corpus is good for backtests |
+| Wrapper exits 0, post-probe `stale% < 5` | `FRESH` | None — corpus rebuilt to current |
+| Wrapper exits 124 (max-wall hit), post-probe `stale% > 5` | `PARTIAL` | Re-dispatch later; resume continues at next symbol |
+| Wrapper exits 75 (`EX_TEMPFAIL`, lock held) | unchanged | Wait for the other run to finish; do not run concurrently |
+| Wrapper exits 1 (build/setup error) | `STALE` | Inspect `dev/logs/snapshot-build-<date>.log`; fix root cause; re-dispatch |
+
+The wrapper writes `dev/logs/snapshot-build-YYYY-MM-DD.log` on every run;
+that file is the source of truth for failure diagnosis.
+
+## Reading `dev/notes/snapshot-corpus-status.md`
+
+The status file is the lightweight ledger updated by every refresh
+dispatch. Layout:
+
+- **Header block** — `Last updated`, `Status`, `Universe`, `Output dir`,
+  `Cycles done`, `ETA`. The `Status` value is one of `NOT_STARTED`,
+  `PARTIAL`, `FRESH`, `STALE`. Use this for at-a-glance assessment.
+- **Last refresh** — most recent dispatch outcome: `Started`, `Wall`,
+  `Symbols built`, `Failures`, `Exit code`, `Post-probe freshness%`.
+- (Optional) **History** — older dispatches, oldest at bottom. Trim if
+  the file gets long; the on-disk manifest is the durable source of
+  truth.
+
+Bash one-liners that consume this file are not needed; it's primarily
+for human inspection. Programmatic consumers should read the manifest
+directly via `Snapshot_manifest.read` or the on-disk
+`<output-dir>/progress.sexp`.
+
+## Failure-mode quick reference
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Probe exits 2 with "manifest not found" | First-time build, or output dir is wrong | Confirm `--output-dir`; if first-time, run the wrapper with no probe gate |
+| Probe exits 1 with `stale% > threshold` | Bulk CSV refresh occurred since last build | Run the wrapper |
+| Wrapper exits 75 immediately | A previous run is still alive holding `.build.lock` | `ps aux \| grep build_snapshots`; wait or kill the orphan |
+| Wrapper exits 1 with "build target not found" | `_build` is stale | `cd trading && eval $(opam env) && dune build analysis/scripts/build_snapshots/` |
+| Wrapper exits 124, post-probe still high | Wall budget too small for current backlog | Either raise `--max-wall` for the next dispatch or run more dispatches |
+
+## When to fall back to a full rebuild
+
+Rare. The incremental path handles every common case (CSV refresh,
+schema drift, partial completion). Force a full rebuild only when:
+
+- The schema hash changed (`Snapshot_format` evolved). The runtime
+  layer refuses to mmap files with the wrong hash, so the manifest is
+  effectively invalidated. Delete the output dir and rebuild from
+  scratch via the same wrapper.
+- The on-disk manifest is corrupt (parse error in
+  `Snapshot_manifest.read`). Same fix: delete + rebuild.
+
+A full broad×10y rebuild is ~2h wall under the post-#792 writer
+(O(N²)→O(N) speedup). Plan for ~4 × 30min dispatches if you can't
+spare an uninterrupted window.
+
+## Future automation (deferred — PR 4 of the track)
+
+PR 4 of `dev/plans/data-pipeline-automation-2026-05-03.md` will add
+example crontab entries + launchd plists so the wrapper runs nightly
+without explicit dispatch. Until that lands, every refresh is
+operator-triggered via this runbook.

--- a/dev/notes/snapshot-corpus-status.md
+++ b/dev/notes/snapshot-corpus-status.md
@@ -1,0 +1,45 @@
+# Snapshot Corpus Status
+
+Last updated: 2026-05-03 (initial — no refresh has run yet)
+Status: NOT_STARTED
+Universe: data/sectors.csv (10,472 symbols)
+Output dir: dev/data/snapshots/broad-2014-2023/
+Cycles done: 0/10472
+ETA: ~2h cold-cache wall (post-#792 writer); ~4 dispatches at --max-wall 30m
+
+## How this file is updated
+
+This ledger is rewritten by every `ops-data` snapshot-refresh dispatch.
+The runbook is at `dev/notes/snapshot-corpus-runbook-2026-05-03.md`.
+
+`Status` field values (one of):
+
+- `NOT_STARTED` — output dir does not exist yet; no manifest on disk.
+- `PARTIAL` — manifest has some entries but the freshness probe still
+  reports `stale% > 5`. The next dispatch resumes at the next pending
+  symbol (per-symbol manifest writer, PR 1 / #819).
+- `FRESH` — last freshness probe reported `stale% ≤ 5`. Corpus is
+  ready for backtest reads.
+- `STALE` — the manifest is intact but a CSV refresh has invalidated
+  enough symbols to push the probe above threshold. Run the wrapper.
+
+## Last refresh
+
+(none — file initialized 2026-05-03 alongside automation PR 3/4)
+
+<!--
+Future entries land here as a level-3 list. Example shape (filled by
+ops-data dispatches):
+
+- Started: 2026-05-04T14:00:00Z
+- Wall: 28m12s
+- Symbols built: 1,243 (cycles 0 → 1243)
+- Failures: 2 (csv parse error: <list>)
+- Exit code: 124 (max-wall reached)
+- Post-probe freshness: 76% stale (was 100%)
+- Notes: cold cache; 3 more dispatches at --max-wall 30m to reach FRESH
+-->
+
+## History
+
+(empty)

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -1,6 +1,6 @@
 # Status: data-foundations
 
-## Last updated: 2026-05-03
+## Last updated: 2026-05-04
 
 ## Status
 IN_PROGRESS — M5.3 streaming Phases A + A.1 + B + C + D + E + F.1 all merged (#779/#786/#781/#782/#790/#791/#793); Phase B writer perf fix O(N²)→O(N) merged (#792). **F.2 default-flip COMPLETE 2026-05-03**: F.2 PR 1 (#797 Snapshot_bar_views shim), F.2 PR 2 (#800 strategy bar reads), F.2 PR 3 (#802 default-flip + `--csv-mode` opt-out) — snapshot mode is now the canonical runtime path. **Wiki+EODHD PR-A MERGED via #803** (Changes_parser + Reason_classifier; maintainer-driven on `feat/wiki-sp500-changes-parser`; orchestrator-dispatched feat-data agent on `feat/data-wiki-eodhd-pr-a` produced equivalent work but elected not to open a competing PR after detecting the duplication). Remaining: **Phase F.3 `Bar_panels.t` retirement** (gated on snapshot-mode-default soak); Wiki+EODHD PR-B/PR-C; Synth-v3; Norgate ingest. F.3 is gated on three verification follow-ups (V1 sp500 5y full-universe parity, V2 ±2w fuzz on snapshot mode, V3 numeric-key fuzz at scale paired with E3 sweep). Owner authorized: feat-data per `dev/decisions.md` 2026-05-03 §"Agent scope: extend feat-backtest + create feat-data".
@@ -91,13 +91,24 @@ including the V1/V2/V3 verification follow-ups that gate F.2.)
   plus `dev/scripts/build_broad_snapshot_incremental.sh` and
   `dev/scripts/check_snapshot_freshness.sh`). Plan:
   `dev/plans/data-pipeline-automation-2026-05-03.md` §"PR 1".
-- **PR 2/4** (this session): backtest progress checkpointing — extends
+- **#820** — Automation PR 2/4: backtest progress checkpointing — extends
   `backtest_runner.exe` with `--progress-every N` so a tail-able
   `progress.sexp` is rewritten under the experiment output dir every N Friday
   cycles plus an unconditional final write. New `Backtest.Backtest_progress`
   module owns the accumulator + atomic-rename writer. Single-run mode only;
   baseline / smoke / fuzz modes ignore the flag. Resumability deferred per
   plan §"Open question 4". Plan §"PR 2 — backtest checkpointing".
+- **PR 3/4** (this session): ops-data dispatch entry-point + runbook —
+  extends `.claude/agents/ops-data.md` with §"Snapshot corpus refresh"
+  documenting inputs (`--universe`, `--output-dir`, `--max-wall`),
+  three-step workflow (probe → wrapper → re-probe), and the resume
+  contract under `--max-wall`-bounded dispatches. Adds
+  `dev/notes/snapshot-corpus-runbook-2026-05-03.md` (canonical user-facing
+  runbook with dispatch prompt template + outcome / failure-mode tables)
+  and `dev/notes/snapshot-corpus-status.md` (lightweight per-dispatch
+  ledger with `NOT_STARTED` / `PARTIAL` / `FRESH` / `STALE` states). No
+  auto-cron yet — deferred to PR 4. Plan §"PR 3 — ops-data dispatch +
+  runbook".
 
 ### Merged (M5.3 streaming)
 


### PR DESCRIPTION
## Summary

PR 3/4 of `dev/plans/data-pipeline-automation-2026-05-03.md` — adds the
explicit `ops-data` dispatch shape for keeping the broad-universe
daily-snapshot corpus fresh, plus a user-facing runbook and status
ledger.

- Extends `.claude/agents/ops-data.md` with §"Snapshot corpus refresh":
  inputs (`--universe`, `--output-dir`, `--max-wall`,
  `--csv-data-dir`, `--progress-every`), three-step workflow
  (probe -> wrapper -> re-probe), acceptance criteria, and the
  resume contract under `--max-wall`-bounded dispatches. Also adds
  step 6 to the standard fetch+refresh workflow.
- New `dev/notes/snapshot-corpus-runbook-2026-05-03.md`: canonical
  user-facing runbook with a dispatch prompt template, expected
  outcomes, status-file legend, failure-mode quick reference, and
  guidance on when to fall back to a full rebuild.
- New `dev/notes/snapshot-corpus-status.md`: lightweight per-dispatch
  ledger with `NOT_STARTED` / `PARTIAL` / `FRESH` / `STALE` states.
  Initialized to `NOT_STARTED` (no refresh has run yet).
- Updates `dev/status/data-foundations.md` with the PR 3 entry and a
  `#820` PR number for the now-merged PR 2.

## Trade-offs

- **No auto-cron yet.** The dispatch is single-pass and manually
  triggered. PR 4 of the same plan will add example crontab entries +
  launchd plists. The wrapper's `flock` already prevents concurrent
  runs, so adding cron later is purely a config step.
- **Doc-only.** No script changes; the wrappers from PR 1 (#819) are
  already complete. Avoiding script extensions keeps the surface area
  small and the diff fully reversible if the dispatch shape evolves.
- **Status file is a markdown ledger, not a sexp.** Programmatic
  consumers should read `<output-dir>/manifest.sexp` directly via
  `Snapshot_manifest.read`; the status file is for human inspection
  and orchestrator dispatch decisions.

## Files

- `.claude/agents/ops-data.md` (extended, +75 LOC)
- `dev/notes/snapshot-corpus-runbook-2026-05-03.md` (new, +129 LOC)
- `dev/notes/snapshot-corpus-status.md` (new, +45 LOC)
- `dev/status/data-foundations.md` (extended, +13/-2 LOC)

Total: 262 insertions, 2 deletions across 4 files. No code, no Python.

## Test plan

- [ ] Read the dispatch shape end-to-end: `.claude/agents/ops-data.md`
      §"Snapshot corpus refresh" -> `dev/notes/snapshot-corpus-runbook-2026-05-03.md`
      -> `dev/notes/snapshot-corpus-status.md`. Confirm the inputs match
      the wrapper's flags (`build_broad_snapshot_incremental.sh`).
- [ ] Confirm the resume contract is consistent with PR 1's
      `Snapshot_manifest.update_for_symbol` per-symbol writer.
- [ ] (Optional, end-to-end) Dispatch `ops-data` with the runbook's
      prompt template against a small fixture universe and verify the
      status file is written and the freshness probe reports the
      expected `stale%`.