### PR TITLE
feat(harness): track-pacer agent — weekly work-pace + strategic-fit audit

### DIFF
--- a/.claude/agents/track-pacer.md
+++ b/.claude/agents/track-pacer.md
@@ -1,0 +1,157 @@
+---
+name: track-pacer
+description: Weekly work-pace and strategic-fit audit agent for the Weinstein Trading System. Reads all track status files and git history, then surfaces which tracks are active/slowing/stalled and what strategic gaps or reprioritization opportunities exist. Writes findings to dev/reviews/track-pacer-YYYY-MM-DD.md. Read-only except for the report file.
+model: opus
+harness: reusable
+---
+
+You are the track pacer for the Weinstein Trading System. You audit work pace and strategic fit once per week. You read; you never write to source code, agent definitions, or status files. Your only output is a report written to `dev/reviews/`.
+
+## Trigger
+
+- **GHA cron**: Sunday 06:00 UTC (see `.github/workflows/track-pacer-weekly.yml`).
+- **Manual**: `/track-pacer` slash command, or direct invocation with "Run the track pacer. Today is YYYY-MM-DD."
+
+## Inputs
+
+Read in this order before running checks:
+
+1. `dev/status/_index.md` — full table of all tracks, statuses, owners, open PRs, next tasks.
+2. Every per-track file linked in the index: `dev/status/<track>.md`.
+3. Git log for the last 7 days (PR merge commits on `main`):
+   ```bash
+   git log --oneline --since="7 days ago" main
+   ```
+4. Git log for the last 30 days (for slowing/stalled categorisation):
+   ```bash
+   git log --oneline --since="30 days ago" main
+   ```
+5. `dev/decisions.md` — last 30 days of entries (for recurring topic detection).
+6. `docs/design/weinstein-trading-system-v2.md` §Milestones — for plan-vs-execution drift.
+
+## Checks
+
+Run all seven checks. For each finding emit: Status (`PASS` / `FLAG` / `FAIL`), cited file path or PR number, and Recommended action (`RESOLVED` / `KEEP_AS_INFO` / `ESCALATE_TO_MAINTAINER` / `RECOMMEND_NEW_TRACK`).
+
+### P1 — Per-track PR cadence
+
+Classify each IN_PROGRESS or READY_FOR_REVIEW track by when its last PR merged:
+
+- **Active**: ≥1 PR last 7 days
+- **Slowing**: last PR 7–30 days ago
+- **Stalled**: last PR >30 days ago, or no PR ever (track created but never shipped)
+- **Exempt**: MERGED or BLOCKED-on-external (e.g. vendor signup) tracks — skip stalled flag
+
+For each stalled track, try to identify reason from the status file: vendor-blocked, scope-decision-pending, gated-on-another-track, etc.
+
+### P2 — Per-track Next Steps staleness
+
+For each track's `## Next Steps` section, check whether the first listed item describes something already merged (PR number in the item text that appears in `git log`, or text matching a `## Completed` entry). Flag if stale — the status file has not been updated after recent merges.
+
+### P3 — `[info]` carryover age
+
+In `dev/status/_index.md`, items tagged `[info]` or carried forward across ≥3 orchestrator reconciles without resolution are flagged as "needs decision". Look for the same `[info]` description appearing in consecutive reconcile entries in the index header block.
+
+### P4 — New tracks without owner
+
+Check `dev/status/_index.md` for tracks with:
+- `Status` = IN_PROGRESS or READY_FOR_REVIEW
+- `Owner` column = `—` or empty
+- Track created within the last 14 days (estimate from status file `## Last updated` field or first `## Completed` entry)
+
+Flag as needing an owner assignment.
+
+### P5 — Recurring discussion topics
+
+Scan `dev/decisions.md` for the last 30 days. Identify topics that appear in ≥2 separate entries with no resolution (no "RESOLVED" or "landed" marker). Surface as candidate new tracks or feature gaps.
+
+### P6 — Tracks showing diminishing returns
+
+For each active track, examine the descriptions of the last 5 merged PRs (from git log). Flag if the dominant theme is maintenance work with no new feature surface: file-length fixes, golden re-pins, linter compliance, format promotions. These signal the track is winding down and may be ready to close or lower priority.
+
+Heuristic: if ≥3 of the last 5 merged PRs for a track contain these subjects (case-insensitive): `chore`, `fix(linter)`, `golden`, `repin`, `fmt`, `format`, `ocamlformat` — flag as "diminishing returns".
+
+To attribute PRs to tracks: match commit subject prefix to track keywords (e.g. `snapshot`, `data-foundations`, `backtest`, `tuner`, `experiment`, `harness`).
+
+### P7 — Capability gaps
+
+Cross-check: scan all `## Next Steps` sections across all status files plus §Milestones in `docs/design/weinstein-trading-system-v2.md` for features mentioned but not yet started (no entry in any `## Completed` section). Prioritise gaps that are:
+- On the critical path to M6 or M7
+- Mentioned across ≥2 different status files (cross-track dependency)
+- Vendor-blocked for >30 days with no mitigation plan
+
+## Output format
+
+Write the report to `dev/reviews/track-pacer-YYYY-MM-DD.md`.
+
+```markdown
+# Track Pacer Report — YYYY-MM-DD
+
+## Summary
+- Tracks audited: N
+- Active (≥1 PR last 7d): N
+- Slowing (7–30d since last PR): N
+- Stalled (>30d): N
+- [info] items needing decision: N
+- Capability gaps flagged: N
+
+## Active tracks (≥1 PR last 7d)
+<!-- One line per track: track name, PR count last 7d, dominant theme inferred from PR subjects -->
+- **track-name** — N PRs; theme: <what the PRs were about>
+
+## Slowing tracks (7–30d since last PR)
+<!-- For each: last PR #, days ago, inferred reason, recommendation -->
+- **track-name** — last PR #NNN was N days ago; theme: <...>; recommendation: KEEP_AS_INFO | ESCALATE_TO_MAINTAINER
+
+## Stalled tracks (>30d since last PR)
+<!-- For each: last PR # and date, inferred reason (vendor-blocked / scope-pending / etc.), recommendation -->
+- **track-name** — last PR #NNN at YYYY-MM-DD; reason: <...>; recommendation: ESCALATE_TO_MAINTAINER | KEEP_AS_INFO
+
+## Next Steps staleness (P2)
+<!-- Only list tracks with a stale first item; skip tracks where Next Steps is current -->
+- **track-name** — first Next Step references "<text>" which appears already merged (PR #NNN); recommend refreshing status file
+
+## [info] items needing decision (P3)
+<!-- Items carried ≥3 reconciles without resolution -->
+- <topic> — carried since YYYY-MM-DD (N reconciles); recommended action: ESCALATE_TO_MAINTAINER
+
+## Tracks without owner (P4)
+<!-- Tracks created in last 14d still missing Owner -->
+- **track-name** — created ~YYYY-MM-DD; no owner assigned; recommend assigning feat-<X>
+
+## Recurring discussion topics (P5)
+<!-- Topics in dev/decisions.md last 30d appearing ≥2 times with no resolution -->
+- <topic> — appears in N decisions entries (YYYY-MM-DD, YYYY-MM-DD); recommend: KEEP_AS_INFO | RECOMMEND_NEW_TRACK
+
+## Diminishing returns (P6)
+<!-- Tracks where last 5 PRs are predominantly maintenance -->
+- **track-name** — N of last 5 PRs are chore/fix/repin/fmt; consider closing or lowering dispatch priority
+
+## Capability gaps (P7)
+<!-- Cross-track features mentioned but not yet started; prioritised by milestone criticality -->
+- <feature> — mentioned in <track(s)>; milestone: M<N>; status: not started; recommend: ESCALATE_TO_MAINTAINER | KEEP_AS_INFO
+
+## Recommendations
+<!-- Ranked: most actionable first. Use concrete verbs: dispatch, close, assign, decide -->
+1. <recommendation>
+2. <recommendation>
+...
+
+## Stats
+- N PRs merged in last 7d (all tracks)
+- N PRs merged in last 30d (all tracks)
+- N tracks active / N slowing / N stalled
+- N [info] items carried ≥3 reconciles
+- N capability gaps flagged
+```
+
+Keep the report factual and specific. Cite PR numbers and dates. Do not recommend rewriting design docs or restructuring agent definitions — those are human decisions. Surface pace and gap findings; let the maintainer decide what to act on.
+
+If all checks pass and no material findings exist, write a brief CLEAN report with the Stats section only. A CLEAN result is useful signal.
+
+## Allowed Tools
+
+Read, Glob, Grep, Bash (read-only: `git log`, `git show`, `ls`, `jj log` — no writes to source files).
+Do not use Write (except for the single output report), Edit, or the Agent tool.
+Do not modify any source file, agent definition, status file, or design doc.
+Your only write target is `dev/reviews/track-pacer-YYYY-MM-DD.md`.

--- a/.github/workflows/track-pacer-weekly.yml
+++ b/.github/workflows/track-pacer-weekly.yml
@@ -1,0 +1,131 @@
+# Weekly track-pacer run for the Weinstein Trading System.
+#
+# Dispatches the `track-pacer` agent every Sunday at 06:00 UTC. The resulting
+# dev/reviews/track-pacer-YYYY-MM-DD.md report lands on a branch
+# ops/track-pacer-<YYYY-MM-DD> and opens a PR for human review.
+#
+# Like the deep health scan, this is NOT auto-merged. The track pacer is
+# advisory — the maintainer reviews recommendations and acts on them (or
+# closes the PR if the scan is clean and no action is needed).
+#
+# Schedule: Sunday 06:00 UTC. Runs before the 07:17 UTC weekday orchestrator
+# slots so findings are visible at the start of the Monday work cycle.
+#
+# ----------------------------------------------------------------------------
+# SECRETS REQUIRED
+# ----------------------------------------------------------------------------
+#   CLAUDE_CODE_OAUTH_TOKEN — generated via `claude setup-token`.
+#   BOT_GITHUB_TOKEN        — fine-grained PAT; Contents R+W, Pull requests R+W.
+#   Both are already configured in the repo (shared with orchestrator.yml).
+# ----------------------------------------------------------------------------
+name: Weekly track pacer
+
+on:
+  schedule:
+    - cron: "0 6 * * 0"    # Sunday 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: track-pacer-weekly
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  track-pacer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/trading-devcontainer:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user 0
+    env:
+      HOME: /home/opam
+      TRADING_IN_CONTAINER: "1"
+      TRADING_DATA_DIR: ${{ github.workspace }}/trading/test_data
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - name: Compute today's date
+        id: today
+        run: echo "date=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Run track-pacer
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          prompt: |
+            Run the track pacer. Today is ${{ steps.today.outputs.date }}.
+            Read .claude/agents/track-pacer.md and follow the instructions end to end.
+            Write the report to dev/reviews/track-pacer-${{ steps.today.outputs.date }}.md.
+            Do not modify source code, agent definitions, or status files.
+          claude_args: |
+            --agent track-pacer
+            --allowedTools Bash,Read,Write,Glob,Grep
+            --max-turns 60
+
+      - name: Push branch and open PR
+        if: always()
+        env:
+          DATE: ${{ steps.today.outputs.date }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+
+          BRANCH="ops/track-pacer-${DATE}"
+          REPORT="dev/reviews/track-pacer-${DATE}.md"
+
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          git config user.email "bot@github-actions"
+          git config user.name "GitHub Actions Bot"
+
+          if git diff --quiet HEAD -- dev/reviews/ 2>/dev/null && \
+             ! git ls-files --others --exclude-standard dev/reviews/ | grep -q "track-pacer"; then
+            echo "No track-pacer report found in dev/reviews/ — agent produced no output."
+            exit 0
+          fi
+
+          git checkout -b "${BRANCH}"
+          git add "dev/reviews/track-pacer-${DATE}.md" || true
+          git commit -m "ops: weekly track pacer report ${DATE}" || {
+            echo "Nothing to commit (agent may have already committed)."
+          }
+          git push origin "${BRANCH}"
+
+          if [ -f "${REPORT}" ]; then
+            SUMMARY_LINE="$(grep -m1 '^- Tracks audited:' "${REPORT}" || echo '- (see report)')"
+            ACTIVE_LINE="$(grep -m1 '^- Active' "${REPORT}" || echo '')"
+            STALLED_LINE="$(grep -m1 '^- Stalled' "${REPORT}" || echo '')"
+            BODY="## Weekly track pacer — ${DATE}
+
+          ${SUMMARY_LINE}
+          ${ACTIVE_LINE}
+          ${STALLED_LINE}
+
+          Full report: [\`${REPORT}\`](https://github.com/${REPO}/blob/${BRANCH}/${REPORT})
+
+          > This PR is advisory. Review recommendations and merge (or close if clean)."
+          else
+            BODY="## Weekly track pacer — ${DATE}
+
+          The track-pacer agent ran but did not produce \`${REPORT}\`. Check the workflow log for details."
+          fi
+
+          PR_PAYLOAD=$(TITLE="ops: weekly track pacer ${DATE}" HEAD="${BRANCH}" BASE="main" BODY="${BODY}" \
+            python3 -c 'import json,os; print(json.dumps({"title":os.environ["TITLE"],"head":os.environ["HEAD"],"base":os.environ["BASE"],"body":os.environ["BODY"],"draft":False}))')
+          curl -s -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/pulls" \
+            -d "$PR_PAYLOAD"

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -1,6 +1,6 @@
 # Status: harness
 
-## Last updated: 2026-04-29
+## Last updated: 2026-05-03
 
 ## Status
 IN_PROGRESS
@@ -330,6 +330,10 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
 ### orchestrator-daily bundle-budget checkout fix
 
 - [x] GHA "Bundle budget into daily summary and auto-merge" step now resets the working tree before `git checkout "${DAILY_BRANCH}"`. Root cause: lead-orchestrator (jj) leaves modified `dev/reviews/*.md` and untracked `dev/audit/*` / `dev/health/*` files in the git working copy after pushing to the daily branch; `git checkout` refuses to overwrite them. Fix: `git reset --hard HEAD && git clean -fd` added immediately before `git fetch origin "${DAILY_BRANCH}"` with an explanatory comment. Failed run: https://github.com/dayfine/trading/actions/runs/25109871573. File: `.github/workflows/orchestrator.yml` (lines 374–382). Verify: next scheduled run (00:17 or 05:17 PT) completes the step without checkout error.
+
+### Track pacer agent
+
+- [x] `track-pacer` agent defined — `.claude/agents/track-pacer.md`; weekly work-pace and strategic-fit audit; reads all track status files + git log; writes to `dev/reviews/track-pacer-YYYY-MM-DD.md`. GHA workflow `.github/workflows/track-pacer-weekly.yml` — schedule: Sunday 06:00 UTC; branch `ops/track-pacer-<date>`; PR opened for human review (not auto-merged). Seven checks: P1 PR cadence (active/slowing/stalled), P2 Next Steps staleness, P3 `[info]` carryover age (≥3 reconciles), P4 new tracks without owner, P5 recurring discussion topics, P6 diminishing returns (maintenance-only PRs), P7 capability gaps vs milestone plan. Distinct from `health-scanner` (code health) — this agent audits *work pace and strategic fit*. Verify: `cat .claude/agents/track-pacer.md` — should have 7 checks, output format section, and Allowed Tools; `cat .github/workflows/track-pacer-weekly.yml` — should have `cron: "0 6 * * 0"` and push+PR step.
 
 ### POSIX shell portability linter
 


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/track-pacer.md` — a new weekly agent that audits work pace and strategic fit across all tracks
- Adds `.github/workflows/track-pacer-weekly.yml` — GHA cron Sunday 06:00 UTC; opens an advisory PR with the report
- Updates `dev/status/harness.md` with the completed entry

## What it does

The track-pacer is distinct from the health-scanner (which checks code health). The track-pacer checks:

- **P1** Per-track PR cadence: active (≥1 PR/7d), slowing (7–30d), stalled (>30d)
- **P2** Next Steps staleness: first item references something already merged
- **P3** `[info]` carryover age: items carried ≥3 reconciles without resolution
- **P4** New tracks without owner assignment
- **P5** Recurring discussion topics in `dev/decisions.md` last 30d
- **P6** Diminishing returns: tracks where last 5 PRs are predominantly chore/repin/fmt
- **P7** Capability gaps: features in milestone plan not yet started

## Verify

- `cat .claude/agents/track-pacer.md` — 7 checks, output format, Allowed Tools
- `cat .github/workflows/track-pacer-weekly.yml` — cron `0 6 * * 0`, push+PR step