### PR TITLE
refactor(snapshot): F.3.a-1 — Bar_reader.of_in_memory_bars + panel-independent empty

### DIFF
--- a/trading/trading/weinstein/strategy/lib/bar_reader.ml
+++ b/trading/trading/weinstein/strategy/lib/bar_reader.ml
@@ -2,9 +2,13 @@
 
 open Core
 module Bar_panels = Data_panel.Bar_panels
-module Symbol_index = Data_panel.Symbol_index
-module Ohlcv_panels = Data_panel.Ohlcv_panels
 module Snapshot_bar_views = Snapshot_runtime.Snapshot_bar_views
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Pipeline = Snapshot_pipeline.Pipeline
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
 
 (* Closure-based representation: each constructor captures its backing's read
    primitives and packages them as same-shape closures. The strategy's hot
@@ -73,28 +77,20 @@ let of_panels ?ma_cache panels =
     ma_cache;
   }
 
-(* {1 Empty backing — used by tests where no read is expected} *)
+(* {1 Empty backing — used by tests where no read is expected}
 
-(* Build an empty [Bar_panels.t] backed by a zero-symbol universe + zero-day
-   calendar. Used by [empty ()] for tests where no panel-backed read is
-   expected — exercising it through the panel-backed closure keeps the
-   "empty universe" fallback consistent with the panel path's semantics
-   (and means tests still see [Bar_panels]-shaped returns). *)
-let _empty_panels () =
-  let symbol_index =
-    match Symbol_index.create ~universe:[] with
-    | Ok t -> t
-    | Error err ->
-        failwithf "Bar_reader.empty: Symbol_index.create []: %s"
-          err.Status.message ()
-  in
-  let ohlcv = Ohlcv_panels.create symbol_index ~n_days:0 in
-  match Bar_panels.create ~ohlcv ~calendar:[||] with
-  | Ok p -> p
-  | Error err ->
-      failwithf "Bar_reader.empty: Bar_panels.create: %s" err.Status.message ()
-
-let empty () = of_panels (_empty_panels ())
+   Phase F.3.a-1 made [empty ()] panel-free: the closures simply return the
+   empty list / empty view directly, without allocating a [Bar_panels.t] or
+   opening a snapshot directory. This is the smallest constructor and
+   matches the "no read expected" contract precisely. *)
+let empty () =
+  {
+    daily_bars_for = (fun ~symbol:_ ~as_of:_ -> []);
+    weekly_bars_for = (fun ~symbol:_ ~n:_ ~as_of:_ -> []);
+    weekly_view_for = (fun ~symbol:_ ~n:_ ~as_of:_ -> _empty_weekly_view);
+    daily_view_for = (fun ~symbol:_ ~as_of:_ ~lookback:_ -> _empty_daily_view);
+    ma_cache = None;
+  }
 
 (* {1 Snapshot-backed constructor (Phase F.2 PR 2)}
 
@@ -129,6 +125,77 @@ let of_snapshot_views (cb : Snapshot_runtime.Snapshot_callbacks.t) =
     daily_view_for = _snapshot_daily_view_for cb;
     ma_cache = None;
   }
+
+(* {1 In-memory-bars constructor (Phase F.3.a-1)}
+
+   Materialise a snapshot directory under a tmp dir, then route reads through
+   [of_snapshot_views]. The Bar_panels alternative ([of_panels] composed with
+   a synthetic [Bar_panels.t] built from in-memory bars) is the path this
+   constructor replaces; keeping it here lets every Bar_panels-backed test
+   migrate to a panel-free reader without changing call sites. *)
+
+(* Cache cap for the in-memory case: small directories (handful of symbols
+   × thousands of days) easily fit in a few MB, but giving the LRU some
+   headroom avoids thrashing on tests that read across many symbols. *)
+let _in_memory_cache_mb = 16
+
+let _build_for_symbol_or_fail ~symbol ~bars =
+  match
+    Pipeline.build_for_symbol ~symbol ~bars ~schema:Snapshot_schema.default ()
+  with
+  | Ok rows -> rows
+  | Error err ->
+      failwithf "Bar_reader.of_in_memory_bars: Pipeline.build_for_symbol %s: %s"
+        symbol err.Status.message ()
+
+let _write_symbol_snap ~dir ~symbol rows =
+  let path = Filename.concat dir (symbol ^ ".snap") in
+  match Snapshot_format.write ~path rows with
+  | Ok () -> path
+  | Error err ->
+      failwithf "Bar_reader.of_in_memory_bars: Snapshot_format.write %s: %s"
+        symbol err.Status.message ()
+
+(* The directory manifest needs per-symbol metadata; for the in-memory case
+   the byte_size / payload_md5 / csv_mtime fields are observational only —
+   the runtime [Daily_panels] reader does not validate them at create time.
+   Filling sentinel values keeps the constructor stdlib-only (no
+   [Core_unix.stat]). *)
+let _file_metadata_of ~symbol ~path : Snapshot_manifest.file_metadata =
+  { symbol; path; byte_size = 0; payload_md5 = "ignored"; csv_mtime = 0.0 }
+
+let _open_daily_panels ~dir ~manifest =
+  match
+    Daily_panels.create ~snapshot_dir:dir ~manifest
+      ~max_cache_mb:_in_memory_cache_mb
+  with
+  | Ok p -> p
+  | Error err ->
+      failwithf "Bar_reader.of_in_memory_bars: Daily_panels.create: %s"
+        err.Status.message ()
+
+let _write_manifest_or_fail ~dir manifest =
+  let path = Filename.concat dir "manifest.sexp" in
+  match Snapshot_manifest.write ~path manifest with
+  | Ok () -> ()
+  | Error err ->
+      failwithf "Bar_reader.of_in_memory_bars: Snapshot_manifest.write: %s"
+        err.Status.message ()
+
+let of_in_memory_bars (symbol_bars : (string * Types.Daily_price.t list) list) =
+  let dir = Stdlib.Filename.temp_dir "bar_reader_in_memory_" "" in
+  let entries =
+    List.map symbol_bars ~f:(fun (symbol, bars) ->
+        let rows = _build_for_symbol_or_fail ~symbol ~bars in
+        let path = _write_symbol_snap ~dir ~symbol rows in
+        _file_metadata_of ~symbol ~path)
+  in
+  let manifest =
+    Snapshot_manifest.create ~schema:Snapshot_schema.default ~entries
+  in
+  _write_manifest_or_fail ~dir manifest;
+  let panels = _open_daily_panels ~dir ~manifest in
+  of_snapshot_views (Snapshot_callbacks.of_daily_panels panels)
 
 (* {1 Public read API — direct closure invocations} *)
 

--- a/trading/trading/weinstein/strategy/lib/bar_reader.mli
+++ b/trading/trading/weinstein/strategy/lib/bar_reader.mli
@@ -60,6 +60,40 @@ val of_snapshot_views : Snapshot_runtime.Snapshot_callbacks.t -> t
     MA recomputation per call is bounded. The cache hook can be revisited if the
     snapshot hot path shows up in future profiles. *)
 
+val of_in_memory_bars : (string * Types.Daily_price.t list) list -> t
+(** [of_in_memory_bars symbol_bars] produces a snapshot-backed reader from a
+    list of in-memory [(symbol, bars)] pairs.
+
+    Phase F.3.a-1 step in retiring {!Data_panel.Bar_panels}. Tests and tools
+    that hold bar histories in memory (rather than reading them from a CSV
+    corpus) currently materialise a {!Bar_panels.t} via
+    {!Data_panel.Bar_panels.create} + {!of_panels}; this constructor lets the
+    same callers route through the snapshot path without any panel allocation.
+
+    Internally: 1. A fresh tmp directory is allocated via
+    [Stdlib.Filename.temp_dir]. 2. For each [(symbol, bars)] pair,
+    {!Snapshot_pipeline.Pipeline.build_for_symbol} computes per-day
+    {!Snapshot.t} rows under {!Snapshot_schema.default} and
+    {!Snapshot_format.write} serialises them to [<tmp>/<symbol>.snap]. No
+    benchmark is supplied, so [RS_line] / [Macro_composite] columns are
+    [Float.nan]; the bar-shaped views ({!Snapshot_bar_views}) only read the
+    OHLCV columns, so the strategy's bar reads are unaffected. 3. A directory
+    manifest is written to [<tmp>/manifest.sexp]. 4. A
+    {!Snapshot_runtime.Daily_panels.t} is opened over the tmp dir with a small
+    in-memory cache cap, and a {!Snapshot_runtime.Snapshot_callbacks.t} is built
+    over it. 5. The result is the same closure-shaped reader returned by
+    {!of_snapshot_views}.
+
+    The tmp directory is left in place after the function returns — the
+    [Daily_panels.t] reads from it lazily on each cache miss. Callers that care
+    about cleanup (long-running tests, perf rigs) should plumb a teardown hook;
+    for short-lived test usage the OS reaps it on reboot.
+
+    Returns a reader that fails-soft on bad inputs the same way
+    {!of_snapshot_views} does — unknown symbol returns the empty list / empty
+    view. Raises [Failure] only on filesystem / pipeline errors that indicate a
+    programming mistake (e.g., schema validation failed during write). *)
+
 val ma_cache : t -> Weekly_ma_cache.t option
 (** [ma_cache t] returns the cache the reader was constructed with, or [None]
     when no cache was provided. The strategy's panel-callback constructors check
@@ -67,10 +101,13 @@ val ma_cache : t -> Weekly_ma_cache.t option
     MA computation on [None]. *)
 
 val empty : unit -> t
-(** [empty ()] produces a reader with an empty universe / zero-day calendar. All
-    reads return the empty list. Useful for tests that exercise control paths
-    where the strategy never reaches a panel-backed read (e.g., empty universe,
-    no held positions). *)
+(** [empty ()] produces a reader whose every read returns the empty list / empty
+    view. Useful for tests that exercise control paths where the strategy never
+    reaches a bar read (e.g., empty universe, no held positions).
+
+    Allocates no {!Bar_panels.t} and opens no snapshot directory — the closures
+    are direct empty-returning lambdas. Phase F.3.a-1 made this panel-free as a
+    step toward retiring {!Bar_panels}. *)
 
 val daily_bars_for :
   t -> symbol:string -> as_of:Date.t -> Types.Daily_price.t list

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -7,7 +7,9 @@
   status
   trading.base
   trading.data_panel
+  trading.data_panel.snapshot
   trading.strategy
+  weinstein.snapshot_pipeline
   weinstein.snapshot_runtime
   weinstein.types
   weinstein_trading.stops

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -3,6 +3,7 @@
   test_ad_bars_unicorn
   test_ad_bars_compose
   test_ad_bars_weekly_e2e
+  test_bar_reader
   test_entry_audit_capture
   test_force_liquidation_runner
   test_force_liquidation_strategy

--- a/trading/trading/weinstein/strategy/test/test_bar_reader.ml
+++ b/trading/trading/weinstein/strategy/test/test_bar_reader.ml
@@ -1,0 +1,175 @@
+(** Tests for {!Weinstein_strategy.Bar_reader} — the closure-shaped bar source.
+
+    Phase F.3.a-1 added two pieces of behaviour to cover here:
+
+    - {!Bar_reader.empty} no longer allocates a {!Bar_panels.t}; every read
+      returns the empty list / empty view directly.
+    - {!Bar_reader.of_in_memory_bars} materialises a tmp snapshot dir from
+      [(symbol, bars)] pairs and produces a snapshot-backed reader.
+
+    The empty-reader test is a smoke check (the panel-free implementation has no
+    observable difference from the panel-backed one was, but we still want a
+    test that pins the empty contract for future refactors).
+
+    The of_in_memory_bars tests pin the round-trip: feed in synthetic OHLCV
+    history for a symbol, read it back via [daily_bars_for], and assert the
+    reconstructed close-prices match. We also pin the unknown-symbol fallback so
+    consumers can rely on "missing → empty list" without a NotFound. *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_reader = Weinstein_strategy.Bar_reader
+
+(* ------------------------------------------------------------------ *)
+(* Synthetic OHLCV builders                                            *)
+(* ------------------------------------------------------------------ *)
+
+let _ymd y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+(* Build [n] consecutive weekday bars starting at [start]. The date walks
+   one day at a time, skipping Sat/Sun so the calendar approximates a real
+   trading week. Prices walk [+step] per bar from [start_price]. *)
+let _is_weekday d =
+  match Date.day_of_week d with
+  | Day_of_week.Sat | Day_of_week.Sun -> false
+  | _ -> true
+
+let _weekdays_starting ~start ~n =
+  let rec loop acc d remaining =
+    if remaining = 0 then List.rev acc
+    else if _is_weekday d then
+      loop (d :: acc) (Date.add_days d 1) (remaining - 1)
+    else loop acc (Date.add_days d 1) remaining
+  in
+  loop [] start n
+
+let _make_bar ~date ~price : Types.Daily_price.t =
+  {
+    date;
+    open_price = price;
+    high_price = price *. 1.01;
+    low_price = price *. 0.99;
+    close_price = price;
+    adjusted_close = price;
+    volume = 1_000_000;
+  }
+
+let _make_bars ~start ~n ~start_price ~step =
+  let dates = _weekdays_starting ~start ~n in
+  List.mapi dates ~f:(fun i d ->
+      _make_bar ~date:d ~price:(start_price +. (Float.of_int i *. step)))
+
+(* ------------------------------------------------------------------ *)
+(* empty: closures return empty without allocating a panel              *)
+(* ------------------------------------------------------------------ *)
+
+let test_empty_daily_bars_returns_empty _ =
+  let r = Bar_reader.empty () in
+  let date = _ymd 2024 1 2 in
+  assert_that
+    (Bar_reader.daily_bars_for r ~symbol:"AAPL" ~as_of:date)
+    (size_is 0)
+
+let test_empty_weekly_view_has_zero_n _ =
+  let r = Bar_reader.empty () in
+  let date = _ymd 2024 1 2 in
+  assert_that
+    (Bar_reader.weekly_view_for r ~symbol:"AAPL" ~n:30 ~as_of:date)
+    (field (fun (v : Data_panel.Bar_panels.weekly_view) -> v.n) (equal_to 0))
+
+let test_empty_daily_view_has_zero_n_days _ =
+  let r = Bar_reader.empty () in
+  let date = _ymd 2024 1 2 in
+  assert_that
+    (Bar_reader.daily_view_for r ~symbol:"AAPL" ~as_of:date ~lookback:50)
+    (field
+       (fun (v : Data_panel.Bar_panels.daily_view) -> v.n_days)
+       (equal_to 0))
+
+(* ------------------------------------------------------------------ *)
+(* of_in_memory_bars: round-trip through tmp snapshot dir               *)
+(* ------------------------------------------------------------------ *)
+
+let test_of_in_memory_bars_round_trip _ =
+  let start =
+    _ymd 2024 1 2
+    (* Tuesday *)
+  in
+  let n = 60 in
+  let bars = _make_bars ~start ~n ~start_price:100.0 ~step:0.5 in
+  let r = Bar_reader.of_in_memory_bars [ ("AAPL", bars) ] in
+  let last_bar = List.last_exn bars in
+  let read_back =
+    Bar_reader.daily_bars_for r ~symbol:"AAPL" ~as_of:last_bar.date
+  in
+  (* The snapshot reader returns bars up to and including [as_of] in
+     chronological order. Compare close_price of the last few entries to
+     the synthetic series. *)
+  let expected_closes =
+    List.map bars ~f:(fun b -> b.Types.Daily_price.close_price)
+  in
+  let got_closes =
+    List.map read_back ~f:(fun b -> b.Types.Daily_price.close_price)
+  in
+  assert_that got_closes
+    (elements_are (List.map expected_closes ~f:(fun c -> float_equal c)))
+
+let test_of_in_memory_bars_unknown_symbol_returns_empty _ =
+  let start = _ymd 2024 1 2 in
+  let bars = _make_bars ~start ~n:10 ~start_price:100.0 ~step:0.5 in
+  let r = Bar_reader.of_in_memory_bars [ ("AAPL", bars) ] in
+  let last_bar = List.last_exn bars in
+  assert_that
+    (Bar_reader.daily_bars_for r ~symbol:"NOPE" ~as_of:last_bar.date)
+    (size_is 0)
+
+let test_of_in_memory_bars_multi_symbol _ =
+  let start = _ymd 2024 1 2 in
+  let n = 20 in
+  let aapl_bars = _make_bars ~start ~n ~start_price:100.0 ~step:0.5 in
+  let msft_bars = _make_bars ~start ~n ~start_price:200.0 ~step:1.0 in
+  let r =
+    Bar_reader.of_in_memory_bars [ ("AAPL", aapl_bars); ("MSFT", msft_bars) ]
+  in
+  let last_aapl = List.last_exn aapl_bars in
+  let last_msft = List.last_exn msft_bars in
+  (* Per-symbol reads must isolate; AAPL's close is NOT MSFT's close. *)
+  let aapl_last_close =
+    Bar_reader.daily_bars_for r ~symbol:"AAPL" ~as_of:last_aapl.date
+    |> List.last_exn
+    |> fun (b : Types.Daily_price.t) -> b.close_price
+  in
+  let msft_last_close =
+    Bar_reader.daily_bars_for r ~symbol:"MSFT" ~as_of:last_msft.date
+    |> List.last_exn
+    |> fun (b : Types.Daily_price.t) -> b.close_price
+  in
+  assert_that
+    (aapl_last_close, msft_last_close)
+    (all_of
+       [
+         field fst (float_equal last_aapl.close_price);
+         field snd (float_equal last_msft.close_price);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "bar_reader"
+  >::: [
+         "empty_daily_bars_returns_empty"
+         >:: test_empty_daily_bars_returns_empty;
+         "empty_weekly_view_has_zero_n" >:: test_empty_weekly_view_has_zero_n;
+         "empty_daily_view_has_zero_n_days"
+         >:: test_empty_daily_view_has_zero_n_days;
+         "of_in_memory_bars_round_trip" >:: test_of_in_memory_bars_round_trip;
+         "of_in_memory_bars_unknown_symbol_returns_empty"
+         >:: test_of_in_memory_bars_unknown_symbol_returns_empty;
+         "of_in_memory_bars_multi_symbol"
+         >:: test_of_in_memory_bars_multi_symbol;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Phase F.3.a-1 — first sub-PR of the `Bar_panels.t` retirement sequence.

This adds `Bar_reader.of_in_memory_bars`, a snapshot-backed constructor that
materialises a tmp snapshot directory from `(symbol, bars)` pairs and routes
reads through `Snapshot_callbacks.of_daily_panels`, and makes `Bar_reader.empty`
panel-independent (the closures return empty lists / empty views directly,
no `Bar_panels.t` allocation).

## Why

Per the F.3 plan in `dev/plans/snapshot-engine-phase-f-2026-05-03.md`, the
final goal is to delete `Bar_panels.t`. The maintainer's recommended split
(per the prior dispatch's exit report) decomposes that into four sub-PRs:

- **F.3.a-1 (this PR)** — add `of_in_memory_bars` + panel-free `empty`.
  No deletions; `of_panels` stays for now. Unblocks F.3.a-2.
- F.3.a-2 — migrate the 9 in-tree test files using `Bar_panels.create` to
  `Bar_reader.of_in_memory_bars`.
- F.3.a-3 — delete the runner CSV path that builds `Bar_panels.t`.
- F.3.a-4 — actually delete `of_panels` + `Bar_panels.t`.

The four-step split is to keep each PR small, each with passing
`dune build && dune runtest`, and to keep reverts cheap if any step
surfaces a regression.

## Files

- `trading/trading/weinstein/strategy/lib/bar_reader.{ml,mli}` — extend
- `trading/trading/weinstein/strategy/lib/dune` — explicit deps on
  `weinstein.snapshot_pipeline` + `trading.data_panel.snapshot`
- `trading/trading/weinstein/strategy/test/test_bar_reader.ml` (NEW) — 6
  tests covering empty + of_in_memory_bars round-trip / unknown-symbol /
  multi-symbol
- `trading/trading/weinstein/strategy/test/dune` — wire up the new test

## Decisions

- **Stdlib `Filename.temp_dir`, not `Core_unix.Filename_unix.temp_dir`.**
  Avoids adding `core_unix` to the strategy lib's dep closure. The lib
  was already free of `core_unix`; keeping it that way means production
  binaries don't pull in additional transitive deps just for a tmp dir.
- **`max_cache_mb = 16` for the in-memory `Daily_panels.t`.** Small but
  comfortable; the in-memory case is a handful of symbols × thousands
  of days (a few MB of data total). 16 MB lets the LRU stay warm without
  thrashing on multi-symbol tests.
- **Manifest sentinel values for `byte_size` / `payload_md5` /
  `csv_mtime`.** The runtime `Daily_panels` reader doesn't validate these
  at create time, so for the in-memory case we fill `0 / "ignored" / 0.0`.
  This keeps the constructor stdlib-only (no `Core_unix.stat`).
- **Tmp directory lifetime: leak-on-drop.** The `Daily_panels.t` reads
  lazily on cache miss, so the directory must outlive the reader. Adding
  a teardown hook would require returning a closer; for short-lived
  test usage the OS reaps the dir on reboot. If a long-running consumer
  ever needs cleanup, we'll add it then.

## Test plan

- [x] `dune build` clean (full repo, zero warnings from changed files)
- [x] `dune runtest trading/weinstein/strategy/` passes (16 test files
      including the new `test_bar_reader.ml`, 6 new tests pass)
- [x] `dune build @trading/weinstein/strategy/lib/fmt
       @trading/weinstein/strategy/test/fmt --auto-promote` clean
- [x] No new linter complaints from `bar_reader.ml` (magic numbers,
      function lengths, file lengths)
- [x] `of_panels` STAYS — deferred to F.3.a-4

## Note

The `of_panels` deletion is **NOT** in this PR. F.3.a-2 must migrate
the 9 test files first; F.3.a-3 must remove the CSV-mode runner path;
only then can F.3.a-4 delete `of_panels` and `Bar_panels.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
