### PR TITLE
refactor(snapshot): F.3.a-2 — migrate strategy tests off Bar_reader.of_panels

### DIFF
--- a/trading/trading/weinstein/strategy/test/test_entry_audit_capture.ml
+++ b/trading/trading/weinstein/strategy/test/test_entry_audit_capture.ml
@@ -10,9 +10,6 @@ open OUnit2
 open Core
 open Matchers
 open Weinstein_strategy
-module Bar_panels = Data_panel.Bar_panels
-module Symbol_index = Data_panel.Symbol_index
-module Ohlcv_panels = Data_panel.Ohlcv_panels
 module Position = Trading_strategy.Position
 
 (* ------------------------------------------------------------------ *)
@@ -26,34 +23,18 @@ let _ticker = "ZZZZ"
     list with this bar; [_effective_entry_price] reads its [close_price] as the
     realised entry. *)
 let _bar_reader_with_current_close ~current_date ~current_close : Bar_reader.t =
-  let symbol_index =
-    match Symbol_index.create ~universe:[ _ticker ] with
-    | Ok t -> t
-    | Error err ->
-        OUnit2.assert_failure ("Symbol_index.create: " ^ err.Status.message)
+  let bar : Types.Daily_price.t =
+    {
+      date = current_date;
+      open_price = current_close;
+      high_price = current_close *. 1.01;
+      low_price = current_close *. 0.99;
+      close_price = current_close;
+      adjusted_close = current_close;
+      volume = 1_000_000;
+    }
   in
-  let calendar = [| current_date |] in
-  let ohlcv = Ohlcv_panels.create symbol_index ~n_days:1 in
-  (match Symbol_index.to_row symbol_index _ticker with
-  | None -> OUnit2.assert_failure "to_row failed"
-  | Some row ->
-      Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day:0
-        {
-          Types.Daily_price.date = current_date;
-          open_price = current_close;
-          high_price = current_close *. 1.01;
-          low_price = current_close *. 0.99;
-          close_price = current_close;
-          adjusted_close = current_close;
-          volume = 1_000_000;
-        });
-  let panels =
-    match Bar_panels.create ~ohlcv ~calendar with
-    | Ok p -> p
-    | Error err ->
-        OUnit2.assert_failure ("Bar_panels.create: " ^ err.Status.message)
-  in
-  Bar_reader.of_panels panels
+  Bar_reader.of_in_memory_bars [ (_ticker, [ bar ]) ]
 
 (** Construct a minimal [Stage.result] for the analysis bundle. The fields are
     required by [scored_candidate] but [make_entry_transition] doesn't read them

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
@@ -22,9 +22,6 @@ open OUnit2
 open Matchers
 open Weinstein_strategy
 open Weinstein_types
-module Bar_panels = Data_panel.Bar_panels
-module Symbol_index = Data_panel.Symbol_index
-module Ohlcv_panels = Data_panel.Ohlcv_panels
 module FL = Portfolio_risk.Force_liquidation
 
 (* ------------------------------------------------------------------ *)
@@ -51,43 +48,6 @@ let _make_daily_bars ~start_date ~n ~start_price ~step =
       let date = Date.add_days start_date i in
       let price = start_price +. (Float.of_int i *. step) in
       _make_daily_bar ~date ~price)
-
-(** Build a [Bar_panels.t] from [(symbol, daily_bars)] pairs. Mirrors the
-    construction used by [test_panel_callbacks.ml]. *)
-let _panels_of_symbols
-    (symbols_with_bars : (string * Types.Daily_price.t list) list) =
-  let universe = List.map symbols_with_bars ~f:fst in
-  let symbol_index =
-    match Symbol_index.create ~universe with
-    | Ok t -> t
-    | Error err -> assert_failure ("Symbol_index.create: " ^ err.Status.message)
-  in
-  let calendar =
-    symbols_with_bars
-    |> List.concat_map ~f:(fun (_, bars) ->
-        List.map bars ~f:(fun b -> b.Types.Daily_price.date))
-    |> List.dedup_and_sort ~compare:Date.compare
-    |> Array.of_list
-  in
-  let ohlcv =
-    Ohlcv_panels.create symbol_index ~n_days:(Array.length calendar)
-  in
-  let date_to_col = Hashtbl.create (module Date) in
-  Array.iteri calendar ~f:(fun i d ->
-      Hashtbl.add date_to_col ~key:d ~data:i
-      |> (ignore : [ `Ok | `Duplicate ] -> unit));
-  List.iter symbols_with_bars ~f:(fun (symbol, bars) ->
-      match Symbol_index.to_row symbol_index symbol with
-      | None -> ()
-      | Some row ->
-          List.iter bars ~f:(fun bar ->
-              match Hashtbl.find date_to_col bar.Types.Daily_price.date with
-              | None -> ()
-              | Some day ->
-                  Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day bar));
-  match Bar_panels.create ~ohlcv ~calendar with
-  | Ok p -> p
-  | Error err -> assert_failure ("Bar_panels.create: " ^ err.Status.message)
 
 (** Find a Friday close to [start_date] (i.e. the next Friday on or after). *)
 let _next_friday d =
@@ -189,8 +149,7 @@ let _rising_index_reader ~end_date =
   let bars =
     _make_daily_bars ~start_date ~n:n_days ~start_price:100.0 ~step:1.0
   in
-  let panels = _panels_of_symbols [ (_index_symbol, bars) ] in
-  Bar_reader.of_panels panels
+  Bar_reader.of_in_memory_bars [ (_index_symbol, bars) ]
 
 (** B1 regression: the halt-reset fires on Friday even when the peak tracker
     enters the tick already in [Halted]. Pre-fix [_on_market_close] returned
@@ -241,8 +200,7 @@ let test_halt_persists_when_macro_stays_bearish _ =
   let bars =
     _make_daily_bars ~start_date ~n:n_days ~start_price:200.0 ~step:(-0.5)
   in
-  let panels = _panels_of_symbols [ (_index_symbol, bars) ] in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = Bar_reader.of_in_memory_bars [ (_index_symbol, bars) ] in
   let state = _fresh_state ~bar_reader in
   FL.Peak_tracker.mark_halted state.peak_tracker;
   let config =

--- a/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
@@ -3,8 +3,6 @@ open Core
 open Matchers
 open Weinstein_strategy
 module Bar_panels = Data_panel.Bar_panels
-module Symbol_index = Data_panel.Symbol_index
-module Ohlcv_panels = Data_panel.Ohlcv_panels
 
 (* ------------------------------------------------------------------ *)
 (* Helpers                                                              *)
@@ -35,50 +33,15 @@ let make_rising_bars ~start_date ~n ~start_price =
         volume = 1_000_000;
       })
 
-(** Build a [Bar_reader.t] backed by [Bar_panels] over a synthetic universe.
+(** Build a snapshot-backed [Bar_reader.t] over a synthetic universe.
     [symbols_with_bars] is [(symbol, bars)] pairs; each bar's date must be a
-    weekday since the calendar is built from those dates. Symbols absent from
-    the list (e.g., ones referenced by a sector_etfs config but with no
-    synthetic series) read as empty — the same contract the deleted
-    [Bar_history.create ()] satisfied. *)
+    weekday. Symbols absent from the list (e.g., ones referenced by a
+    sector_etfs config but with no synthetic series) read as empty — the same
+    contract the deleted [Bar_history.create ()] satisfied. *)
 let make_bar_reader ~symbols_with_bars =
-  let universe = List.map symbols_with_bars ~f:fst in
-  match universe with
+  match symbols_with_bars with
   | [] -> Bar_reader.empty ()
-  | _ ->
-      let symbol_index =
-        match Symbol_index.create ~universe with
-        | Ok t -> t
-        | Error err -> failwith ("Symbol_index.create: " ^ err.Status.message)
-      in
-      let calendar =
-        symbols_with_bars
-        |> List.concat_map ~f:(fun (_, bars) ->
-            List.map bars ~f:(fun b -> b.Types.Daily_price.date))
-        |> List.dedup_and_sort ~compare:Date.compare
-        |> Array.of_list
-      in
-      let n_days = Array.length calendar in
-      let ohlcv = Ohlcv_panels.create symbol_index ~n_days in
-      let calendar_idx = Hashtbl.create (module Date) in
-      Array.iteri calendar ~f:(fun i d ->
-          Hashtbl.add calendar_idx ~key:d ~data:i
-          |> (ignore : [ `Ok | `Duplicate ] -> unit));
-      List.iter symbols_with_bars ~f:(fun (symbol, bars) ->
-          match Symbol_index.to_row symbol_index symbol with
-          | None -> ()
-          | Some row ->
-              List.iter bars ~f:(fun (bar : Types.Daily_price.t) ->
-                  match Hashtbl.find calendar_idx bar.date with
-                  | None -> ()
-                  | Some day ->
-                      Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day bar));
-      let panels =
-        match Bar_panels.create ~ohlcv ~calendar with
-        | Ok p -> p
-        | Error err -> failwith ("Bar_panels.create: " ^ err.Status.message)
-      in
-      Bar_reader.of_panels panels
+  | _ -> Bar_reader.of_in_memory_bars symbols_with_bars
 
 (* ------------------------------------------------------------------ *)
 (* Canonical constants                                                  *)

--- a/trading/trading/weinstein/strategy/test/test_stops_split_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_split_runner.ml
@@ -21,9 +21,6 @@
 open OUnit2
 open Core
 open Matchers
-module Bar_panels = Data_panel.Bar_panels
-module Symbol_index = Data_panel.Symbol_index
-module Ohlcv_panels = Data_panel.Ohlcv_panels
 module Bar_reader = Weinstein_strategy.Bar_reader
 module Stops_split_runner = Weinstein_strategy.Stops_split_runner
 module Position = Trading_strategy.Position
@@ -44,27 +41,9 @@ let _make_bar ~date ~open_ ~high ~low ~close ~adjusted_close ~volume =
       volume;
     }
 
-(** Pack a single-symbol bar series into a {!Bar_panels.t}. *)
-let _panels_of_one_symbol ~symbol bars =
-  let symbol_index =
-    match Symbol_index.create ~universe:[ symbol ] with
-    | Ok t -> t
-    | Error err -> failwith ("Symbol_index.create: " ^ err.Status.message)
-  in
-  let calendar =
-    List.map bars ~f:(fun b -> b.Types.Daily_price.date) |> Array.of_list
-  in
-  let ohlcv =
-    Ohlcv_panels.create symbol_index ~n_days:(Array.length calendar)
-  in
-  (match Symbol_index.to_row symbol_index symbol with
-  | None -> failwith "row not found"
-  | Some row ->
-      List.iteri bars ~f:(fun day bar ->
-          Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day bar));
-  match Bar_panels.create ~ohlcv ~calendar with
-  | Ok p -> p
-  | Error err -> failwith ("Bar_panels.create: " ^ err.Status.message)
+(** Build a snapshot-backed [Bar_reader.t] from a single-symbol bar series. *)
+let _bar_reader_of_one_symbol ~symbol bars =
+  Bar_reader.of_in_memory_bars [ (symbol, bars) ]
 
 (** Build a Holding-state position for [symbol] — minimal scaffold to feed
     [Stops_split_runner.adjust]. We only need [symbol]; the state machine
@@ -155,8 +134,7 @@ let _flat_bars =
 (* Pin: on a non-split day the stop_state is unchanged. *)
 let test_no_split_leaves_stop_state_untouched _ =
   let symbol = "AAPL" in
-  let panels = _panels_of_one_symbol ~symbol _flat_bars in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = _bar_reader_of_one_symbol ~symbol _flat_bars in
   let pos =
     _make_holding_pos ~symbol ~entry_price:100.0
       ~entry_date:(Date.of_string "2024-08-26")
@@ -177,8 +155,7 @@ let test_no_split_leaves_stop_state_untouched _ =
    $112. *)
 let test_forward_4_to_1_scales_initial_stop _ =
   let symbol = "AAPL" in
-  let panels = _panels_of_one_symbol ~symbol (_split_bars ~symbol) in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = _bar_reader_of_one_symbol ~symbol (_split_bars ~symbol) in
   let pos =
     _make_holding_pos ~symbol ~entry_price:500.0
       ~entry_date:(Date.of_string "2024-08-26")
@@ -201,8 +178,7 @@ let test_forward_4_to_1_scales_initial_stop _ =
    preserved. *)
 let test_forward_4_to_1_scales_trailing_stop _ =
   let symbol = "AAPL" in
-  let panels = _panels_of_one_symbol ~symbol (_split_bars ~symbol) in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = _bar_reader_of_one_symbol ~symbol (_split_bars ~symbol) in
   let pos =
     _make_holding_pos ~symbol ~entry_price:500.0
       ~entry_date:(Date.of_string "2024-08-26")
@@ -246,8 +222,7 @@ let test_forward_4_to_1_scales_trailing_stop _ =
 let test_split_day_no_spurious_stop_hit _ =
   let symbol = "AAPL" in
   let bars = _split_bars ~symbol in
-  let panels = _panels_of_one_symbol ~symbol bars in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = _bar_reader_of_one_symbol ~symbol bars in
   let pos =
     _make_holding_pos ~symbol ~entry_price:500.0
       ~entry_date:(Date.of_string "2024-08-26")
@@ -295,8 +270,7 @@ let test_real_adverse_move_after_split_still_triggers _ =
         ~volume:4_000_000;
     ]
   in
-  let panels = _panels_of_one_symbol ~symbol bars in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = _bar_reader_of_one_symbol ~symbol bars in
   let pos =
     _make_holding_pos ~symbol ~entry_price:500.0
       ~entry_date:(Date.of_string "2024-08-26")
@@ -323,8 +297,7 @@ let test_real_adverse_move_after_split_still_triggers _ =
    no-op and [stop_states] stays empty. *)
 let test_position_without_stop_state_is_noop _ =
   let symbol = "AAPL" in
-  let panels = _panels_of_one_symbol ~symbol (_split_bars ~symbol) in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = _bar_reader_of_one_symbol ~symbol (_split_bars ~symbol) in
   let pos =
     _make_holding_pos ~symbol ~entry_price:500.0
       ~entry_date:(Date.of_string "2024-08-26")

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -679,44 +679,17 @@ let _make_friday_bars ~start_friday ~n ~start_price ~step =
         volume = 1_000_000;
       })
 
-(** Pack [(symbol, bars)] pairs into a {!Bar_panels.t}. The calendar is the
-    union of all dates (sorted, deduped). Mirrors the helper in
-    {!test_panel_callbacks.ml}. *)
-let _panels_of_symbols
+(** Last date across every bar in [symbols_with_bars]. Mirrors the calendar's
+    [last_date] without materialising a {!Bar_panels.t}. *)
+let _last_date_of_symbols
     (symbols_with_bars : (string * Types.Daily_price.t list) list) =
-  let universe = List.map symbols_with_bars ~f:fst in
-  let symbol_index =
-    match Data_panel.Symbol_index.create ~universe with
-    | Ok t -> t
-    | Error err -> failwith ("Symbol_index.create: " ^ err.Status.message)
-  in
-  let calendar =
-    symbols_with_bars
-    |> List.concat_map ~f:(fun (_, bars) ->
-        List.map bars ~f:(fun b -> b.Types.Daily_price.date))
-    |> List.dedup_and_sort ~compare:Date.compare
-    |> Array.of_list
-  in
-  let ohlcv =
-    Data_panel.Ohlcv_panels.create symbol_index ~n_days:(Array.length calendar)
-  in
-  let date_to_col = Hashtbl.create (module Date) in
-  Array.iteri calendar ~f:(fun i d ->
-      Hashtbl.add date_to_col ~key:d ~data:i
-      |> (ignore : [ `Ok | `Duplicate ] -> unit));
-  List.iter symbols_with_bars ~f:(fun (symbol, bars) ->
-      match Data_panel.Symbol_index.to_row symbol_index symbol with
-      | None -> ()
-      | Some row ->
-          List.iter bars ~f:(fun bar ->
-              match Hashtbl.find date_to_col bar.Types.Daily_price.date with
-              | None -> ()
-              | Some day ->
-                  Data_panel.Ohlcv_panels.write_row ohlcv ~symbol_index:row ~day
-                    bar));
-  match Data_panel.Bar_panels.create ~ohlcv ~calendar with
-  | Ok p -> p
-  | Error err -> failwith ("Bar_panels.create: " ^ err.Status.message)
+  symbols_with_bars
+  |> List.concat_map ~f:(fun (_, bars) ->
+      List.map bars ~f:(fun b -> b.Types.Daily_price.date))
+  |> List.max_elt ~compare:Date.compare
+  |> function
+  | Some d -> d
+  | None -> failwith "_last_date_of_symbols: empty input"
 
 (** Build a 60-week Friday-anchored series with the given start_price + step.
     Positive [step] yields a Stage2-classifying series (rising MA, price above
@@ -737,16 +710,15 @@ let test_survivors_for_screening_filters_by_stage _ =
   let declining_b =
     _trending_series ~start_friday ~start_price:180.0 ~step:(-1.0)
   in
-  let panels =
-    _panels_of_symbols
-      [
-        ("RISE_A", rising_a);
-        ("RISE_B", rising_b);
-        ("FALL_A", declining_a);
-        ("FALL_B", declining_b);
-      ]
+  let symbols_with_bars =
+    [
+      ("RISE_A", rising_a);
+      ("RISE_B", rising_b);
+      ("FALL_A", declining_a);
+      ("FALL_B", declining_b);
+    ]
   in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols_with_bars in
   let cfg =
     default_config
       ~universe:[ "RISE_A"; "RISE_B"; "FALL_A"; "FALL_B" ]
@@ -755,16 +727,9 @@ let test_survivors_for_screening_filters_by_stage _ =
   let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
-  (* Use the panel's last date as the screening day — guaranteed to land in
-     the calendar so [weekly_view_for] returns a non-empty view. *)
-  let last_date =
-    let n = Data_panel.Bar_panels.n_days panels in
-    let cal_view =
-      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"RISE_A" ~n:1
-        ~as_of_day:(n - 1)
-    in
-    cal_view.dates.(cal_view.n - 1)
-  in
+  (* Use the bars' last date as the screening day — guaranteed to land in the
+     calendar so [weekly_view_for] returns a non-empty view. *)
+  let last_date = _last_date_of_symbols symbols_with_bars in
   let survivors =
     survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
       ~current_date:last_date ()
@@ -816,11 +781,10 @@ let test_survivors_for_screening_drops_stage1_and_stage3 _ =
   let stage4_bars =
     _trending_series ~start_friday ~start_price:200.0 ~step:(-1.5)
   in
-  let panels =
-    _panels_of_symbols
-      [ ("BASE", stage1_bars); ("TOP", stage3_bars); ("DECLINE", stage4_bars) ]
+  let symbols_with_bars =
+    [ ("BASE", stage1_bars); ("TOP", stage3_bars); ("DECLINE", stage4_bars) ]
   in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols_with_bars in
   let cfg =
     default_config ~universe:[ "BASE"; "TOP"; "DECLINE" ] ~index_symbol:"GSPCX"
   in
@@ -834,14 +798,7 @@ let test_survivors_for_screening_drops_stage1_and_stage3 _ =
         ("TOP", Weinstein_types.Stage2 { weeks_advancing = 10; late = false });
       ]
   in
-  let last_date =
-    let n = Data_panel.Bar_panels.n_days panels in
-    let cal_view =
-      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"DECLINE" ~n:1
-        ~as_of_day:(n - 1)
-    in
-    cal_view.dates.(cal_view.n - 1)
-  in
+  let last_date = _last_date_of_symbols symbols_with_bars in
   let survivors =
     survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
       ~current_date:last_date ()
@@ -895,18 +852,17 @@ let test_phase2_call_count_equals_survivor_count _ =
   let stage4_bars seed =
     _trending_series ~start_friday ~start_price:(200.0 +. seed) ~step:(-1.5)
   in
-  let panels =
-    _panels_of_symbols
-      [
-        ("BASE_A", stage1_bars 0.0);
-        ("BASE_B", stage1_bars 1.0);
-        ("TOP_A", stage3_bars 0.0);
-        ("TOP_B", stage3_bars 1.0);
-        ("DECLINE_A", stage4_bars 0.0);
-        ("DECLINE_B", stage4_bars 5.0);
-      ]
+  let symbols_with_bars =
+    [
+      ("BASE_A", stage1_bars 0.0);
+      ("BASE_B", stage1_bars 1.0);
+      ("TOP_A", stage3_bars 0.0);
+      ("TOP_B", stage3_bars 1.0);
+      ("DECLINE_A", stage4_bars 0.0);
+      ("DECLINE_B", stage4_bars 5.0);
+    ]
   in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols_with_bars in
   let cfg =
     default_config
       ~universe:
@@ -923,14 +879,7 @@ let test_phase2_call_count_equals_survivor_count _ =
         ("TOP_B", Weinstein_types.Stage2 { weeks_advancing = 10; late = false });
       ]
   in
-  let last_date =
-    let n = Data_panel.Bar_panels.n_days panels in
-    let cal_view =
-      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"DECLINE_A" ~n:1
-        ~as_of_day:(n - 1)
-    in
-    cal_view.dates.(cal_view.n - 1)
-  in
+  let last_date = _last_date_of_symbols symbols_with_bars in
   let loaded_count = List.length cfg.universe in
   let survivors =
     survivors_for_screening ~config:cfg ~bar_reader ~prior_stages
@@ -975,11 +924,10 @@ let test_survivors_for_screening_sector_filter_drops_weak_long _ =
   let rising_weak =
     _trending_series ~start_friday ~start_price:60.0 ~step:1.0
   in
-  let panels =
-    _panels_of_symbols
-      [ ("RISE_STRONG", rising_strong); ("RISE_WEAK", rising_weak) ]
+  let symbols_with_bars =
+    [ ("RISE_STRONG", rising_strong); ("RISE_WEAK", rising_weak) ]
   in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols_with_bars in
   let cfg =
     default_config
       ~universe:[ "RISE_STRONG"; "RISE_WEAK" ]
@@ -988,14 +936,7 @@ let test_survivors_for_screening_sector_filter_drops_weak_long _ =
   let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
-  let last_date =
-    let n = Data_panel.Bar_panels.n_days panels in
-    let cal_view =
-      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"RISE_STRONG" ~n:1
-        ~as_of_day:(n - 1)
-    in
-    cal_view.dates.(cal_view.n - 1)
-  in
+  let last_date = _last_date_of_symbols symbols_with_bars in
   let sector_map =
     _sector_map_of_pairs
       [ ("RISE_STRONG", Screener.Strong); ("RISE_WEAK", Screener.Weak) ]
@@ -1019,11 +960,10 @@ let test_survivors_for_screening_sector_filter_drops_strong_short _ =
   let declining_strong =
     _trending_series ~start_friday ~start_price:180.0 ~step:(-1.0)
   in
-  let panels =
-    _panels_of_symbols
-      [ ("FALL_WEAK", declining_weak); ("FALL_STRONG", declining_strong) ]
+  let symbols_with_bars =
+    [ ("FALL_WEAK", declining_weak); ("FALL_STRONG", declining_strong) ]
   in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols_with_bars in
   let cfg =
     default_config
       ~universe:[ "FALL_WEAK"; "FALL_STRONG" ]
@@ -1032,14 +972,7 @@ let test_survivors_for_screening_sector_filter_drops_strong_short _ =
   let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
-  let last_date =
-    let n = Data_panel.Bar_panels.n_days panels in
-    let cal_view =
-      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"FALL_WEAK" ~n:1
-        ~as_of_day:(n - 1)
-    in
-    cal_view.dates.(cal_view.n - 1)
-  in
+  let last_date = _last_date_of_symbols symbols_with_bars in
   let sector_map =
     _sector_map_of_pairs
       [ ("FALL_WEAK", Screener.Weak); ("FALL_STRONG", Screener.Strong) ]
@@ -1056,20 +989,13 @@ let test_survivors_for_screening_sector_filter_unknown_ticker_passes _ =
      [Screener._resolve_sector]'s [Neutral] fallback. *)
   let start_friday = Date.of_string "2024-01-05" in
   let rising = _trending_series ~start_friday ~start_price:50.0 ~step:0.8 in
-  let panels = _panels_of_symbols [ ("UNKNOWN", rising) ] in
-  let bar_reader = Bar_reader.of_panels panels in
+  let symbols_with_bars = [ ("UNKNOWN", rising) ] in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols_with_bars in
   let cfg = default_config ~universe:[ "UNKNOWN" ] ~index_symbol:"GSPCX" in
   let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
-  let last_date =
-    let n = Data_panel.Bar_panels.n_days panels in
-    let cal_view =
-      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"UNKNOWN" ~n:1
-        ~as_of_day:(n - 1)
-    in
-    cal_view.dates.(cal_view.n - 1)
-  in
+  let last_date = _last_date_of_symbols symbols_with_bars in
   (* Empty sector_map: every ticker is "unknown" → all PASS. *)
   let sector_map = Hashtbl.create (module String) in
   let survivors =
@@ -1095,18 +1021,17 @@ let test_survivors_for_screening_pr_b_counter _ =
   let declining seed =
     _trending_series ~start_friday ~start_price:(200.0 +. seed) ~step:(-1.5)
   in
-  let panels =
-    _panels_of_symbols
-      [
-        ("RISE_STRONG_A", rising 0.0);
-        ("RISE_STRONG_B", rising 1.0);
-        ("RISE_WEAK_A", rising 2.0);
-        ("RISE_WEAK_B", rising 3.0);
-        ("FALL_STRONG", declining 0.0);
-        ("FALL_WEAK", declining 1.0);
-      ]
+  let symbols_with_bars =
+    [
+      ("RISE_STRONG_A", rising 0.0);
+      ("RISE_STRONG_B", rising 1.0);
+      ("RISE_WEAK_A", rising 2.0);
+      ("RISE_WEAK_B", rising 3.0);
+      ("FALL_STRONG", declining 0.0);
+      ("FALL_WEAK", declining 1.0);
+    ]
   in
-  let bar_reader = Bar_reader.of_panels panels in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols_with_bars in
   let cfg =
     default_config
       ~universe:
@@ -1120,14 +1045,7 @@ let test_survivors_for_screening_pr_b_counter _ =
         ]
       ~index_symbol:"GSPCX"
   in
-  let last_date =
-    let n = Data_panel.Bar_panels.n_days panels in
-    let cal_view =
-      Data_panel.Bar_panels.weekly_view_for panels ~symbol:"RISE_STRONG_A" ~n:1
-        ~as_of_day:(n - 1)
-    in
-    cal_view.dates.(cal_view.n - 1)
-  in
+  let last_date = _last_date_of_symbols symbols_with_bars in
   let sector_map =
     _sector_map_of_pairs
       [


### PR DESCRIPTION
## Summary

- Mechanical migration of 5 strategy test files from `Bar_reader.of_panels` to `Bar_reader.of_in_memory_bars` (added in F.3.a-1, #825).
- Removes per-test `_panels_of_symbols` / `_panels_of_one_symbol` helpers; the snapshot-backed constructor takes `(string * Daily_price.t list) list` directly.
- For `test_weinstein_strategy.ml` (8 callsites), the per-test `last_date` calculation that read `panels.weekly_view_for` is replaced with a single `_last_date_of_symbols` helper that scans the input bars — no behavior change since the calendar is the union of all bar dates.

## Scope

Phase F.3.a-2 of the `Bar_panels.t` retirement (`dev/plans/snapshot-engine-phase-f-2026-05-03.md` §F.3). `of_panels` STAYS in `bar_reader.{ml,mli}` — its deletion is F.3.a-4.

## Files changed (5)

- `trading/trading/weinstein/strategy/test/test_macro_inputs.ml` — `make_bar_reader` helper now wraps `of_in_memory_bars`
- `trading/trading/weinstein/strategy/test/test_entry_audit_capture.ml` — `_bar_reader_with_current_close` inlined
- `trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml` — `_panels_of_symbols` deleted
- `trading/trading/weinstein/strategy/test/test_stops_split_runner.ml` — `_bar_reader_of_one_symbol` replaces `_panels_of_one_symbol`
- `trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml` — 8 callsites + `_last_date_of_symbols` helper

## LOC delta

Net **-207 lines** (87 insertions, 294 deletions) — helpers deleted across all five files.

## Callsites migrated

17 `Bar_reader.of_panels` callsites replaced. Final state: 0 remaining in `trading/trading/weinstein/strategy/test/*.ml`.

## Test plan

- [x] `dune build` — passes
- [x] `dune runtest trading/weinstein/strategy/` — all 22 strategy test executables pass
- [x] No new `Bar_reader.of_panels` usage in strategy tests: `grep 'Bar_reader.of_panels' trading/trading/weinstein/strategy/test/*.ml` returns nothing
- [x] No public API change; `of_panels` remains in `bar_reader.{ml,mli}` for runtime callers (deletion is F.3.a-4)

## CI fmt note

Local `dune build @fmt --auto-promote` flags pre-existing main-drift on 14 unrelated files (mostly `*.mli` ocamlformat 0.29 differences). These were scrubbed via `jj restore --from main@origin` per `.claude/rules/worktree-isolation.md` — they are not part of this PR. None of the 5 touched files need formatting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)