### PR TITLE
chore(status): refresh stale track files (hybrid-tier MERGED, M5.1 blockers cleared, tuning IN_PROGRESS)

### DIFF
--- a/dev/status/experiments.md
+++ b/dev/status/experiments.md
@@ -1,12 +1,12 @@
 # Status: experiments
 
-## Last updated: 2026-05-03
+## Last updated: 2026-05-04
 
 ## Status
 IN_PROGRESS
 
 ## Notes
-M5.2e per-trade context logging shipped (PR #769); M5.4 E3 sweep harness landed (PR #815); M5.4 E4 scoring-weight sweep harness landed (PR #816); M5.2a–d still PLANNED, sweep runs blocked on M5.1.
+M5.2e per-trade context logging shipped (PR #769); M5.4 E3 sweep harness landed (PR #815); M5.4 E4 scoring-weight sweep harness landed (PR #816). **M5.2a–d still PLANNED — these are the next priority dispatches** (config-override + comparison + smoke flags → trade aggregates → risk-adjusted → distributional / antifragility).
 
 Track created 2026-05-02 to absorb M5.2 (experiment infra) + M5.4 (mechanical experiments). Plan: `dev/plans/m5-experiments-roadmap-2026-05-02.md`. Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M5.2 + M5.4 (added 2026-05-02).
 
@@ -14,7 +14,7 @@ Track created 2026-05-02 to absorb M5.2 (experiment infra) + M5.4 (mechanical ex
 NO
 
 ## Blocked on
-- M5.1 foundation hardening (CI red on `main`: `split_day_stop_exit:1:post_split_exit_no_orphan_equity`; G14 split-adjust + G15 short-side risk surfaces). No experiment runs are interpretable until the foundation stops leaking.
+- None. Prior M5.1 blocker (`split_day_stop_exit:1:post_split_exit_no_orphan_equity`) was RESOLVED by PR #752 weeks ago; G14 split-adjust + G15 short-side risk surfaces also landed (see `dev/status/short-side-strategy.md`). Sweep runs are now interpretable — M5.4 E3/E4 sweep runs themselves remain local-only follow-ups (~5×2h tier-3 budget each).
 
 ## Scope
 

--- a/dev/status/hybrid-tier.md
+++ b/dev/status/hybrid-tier.md
@@ -1,28 +1,32 @@
 # Status: hybrid-tier
 
-## Last updated: 2026-04-28
+## Last updated: 2026-05-04
 
 ## Status
-IN_PROGRESS
+MERGED — both options shipped; no active work in this track
 
 Phase 1 (measurement infra) merged (#609). Phase 2 was replanned via
 PR #611 into two separate plans after Phase 1 results showed the
-original 3-tier design wouldn't move RSS. Option 1 (engine-layer
-pooling) is DONE as of 2026-04-28; Option 2 (daily-snapshot streaming)
-remains P1 future work, so the track stays IN_PROGRESS rather than
-MERGED.
+original 3-tier design wouldn't move RSS. Both options have shipped:
 
 - **Option 1: Engine-layer pooling** — DONE 2026-04-28. Five PRs
   (#618 instrumentation, #626 Scratch type, #628 thread per-tick,
   #632 buffer pool, #633 matrix re-run). β: 4.30 → 3.94 MB/symbol
   (−8%, short of the 1-1.5 plan target). Wall: −36% at 292×6y.
-  Cumulative promoted_words 85.8M < 100M ceiling. Working set
-  unchanged — peak RSS dominated by major-heap steady-state, not
-  allocation churn. N=1000×10y now fits 8 GB. Plan complete.
-- **Option 2: Daily-snapshot streaming** — P1 future work.
-  `dev/plans/daily-snapshot-streaming-2026-04-27.md`, ~3,000 LOC
-  across 5-8 PRs. Required for tier-4 release-gate at N≥5,000.
-  Not yet started.
+  N=1000×10y now fits 8 GB.
+- **Option 2: Daily-snapshot streaming** — DELIVERED via the
+  `data-foundations` track's **M5.3 streaming** sequence (Phases
+  A–F.2 merged 2026-05-02..03 across PRs
+  #779/#781/#782/#786/#790/#791/#792/#793/#797/#800/#802; F.3
+  retirement of `Bar_panels.t` in flight as of 2026-05-04 with F.3.a
+  COMPLETE via #825/#827/#828/#829). Snapshot mode is now the
+  canonical runtime path; tier-4 release-gate at N≥5,000 is
+  structurally unblocked. Continuing snapshot work tracked under
+  `dev/status/data-foundations.md`.
+
+Track flips to MERGED. Future deliverables route to
+`data-foundations` (snapshot infra), `backtest-perf` (release-gate
+verification), or open as their own tracks.
 
 Phase 1 results (retained for reference):
 `dev/notes/hybrid-tier-phase1-results-2026-04-27.md`. Engine-pool

--- a/dev/status/orchestrator-automation.md
+++ b/dev/status/orchestrator-automation.md
@@ -1,16 +1,27 @@
 # Status: Orchestrator Automation
 
-## Last updated: 2026-04-18
+## Last updated: 2026-05-04
 
 ## Status
-IN_PROGRESS
-
-Phase 1 live; Phase 2 (background execution) pending.
+IN_PROGRESS — Phase 1 stable (~18 days uptime); Phase 2 deferred (no active dispatch)
 
 Phase 1 (scheduled daily orchestrator on GHA) has been producing daily
 summary PRs since 2026-04-16. See `.github/workflows/orchestrator.yml`
-and daily summary PRs #422/#423/#427 etc. All five §Open blockers below
-are resolved — section retained as the implementation record.
+and daily summary PRs #422/#423/#427 ... most recently #830 (2026-05-04).
+Cron currently runs 2 overnight slots (00:17 PT + 05:17 PT) per
+`project_orchestrator_off.md` user memory. Substantive work continues
+in local sessions; orchestrator handles QC pipelines + audits + cost
+capture for in-flight PRs and writes `dev/daily/<date>.md`.
+
+All five original §Open blockers (auth, GH App, OAuth token, prompt
+hygiene, run.sh harvest) are resolved — section retained as the
+implementation record.
+
+Phase 2 (background execution: dispatch agents to run while user is
+offline, harvest results next day) remains PLANNED. No active
+dispatch — the empirical tests in §"Phase 2 — pending" have not been
+prioritized. Track stays IN_PROGRESS pending those experiments; not
+blocking anything else.
 
 ## Blocked on
 - None. Phase 2 items are scoped-work, not blockers.

--- a/dev/status/simulation.md
+++ b/dev/status/simulation.md
@@ -1,6 +1,6 @@
 # Status: simulation
 
-## Last updated: 2026-05-02
+## Last updated: 2026-05-04
 
 ## Status
 IN_PROGRESS
@@ -8,28 +8,15 @@ IN_PROGRESS
 Split-day broker-model redesign + regression follow-ups fully wrapped
 (PRs #658 / #662 / #664 / #667 broker-model; #678 strategy-side-position-map
 fix; #680 stop-state rescaling; #682 short-side flag for sp500 mitigation;
-all merged 2026-04-28..29). Slice 1+3 verdicts remain APPROVED. Track stays
-IN_PROGRESS for the M5 walk-forward + tuner catch-all items and the local
-sp500-2019-2023 baseline rerun (deferred — needs full 491-symbol universe
-data not present in GHA).
+all merged 2026-04-28..29). Slice 1+3 verdicts remain APPROVED. Track
+stays IN_PROGRESS for the M5 walk-forward + tuner catch-all items and the
+local sp500-2019-2023 baseline rerun (deferred — needs full 491-symbol
+universe data not present in GHA).
 
-**[P0 — RED CI 2026-05-02]** Failing test on `main`:
-`split_day_stop_exit:1:post_split_exit_no_orphan_equity` — exit cash =
-$99,600 vs $100,000 expected (Δ = $400 = 100 × $4). Run
-[25238889053](https://github.com/dayfine/trading/actions/runs/25238889053).
-Test landed via #678 with PR-body caveat "Do NOT merge until local
-`dune runtest` passes — Docker was unresponsive". Test was likely never
-verified against the fix. Sister tests `post_split_exit_clears_position`
-and `split_day_position_reflects_post_split` PASS, so split-event
-mechanics work; only the case where `trigger_exit_on_or_after` is the
-post-split day (not the split day itself) shows the $400 drift.
-Hypothesis: entry market order filling at day-2 close ($504) instead of
-day-2 open ($500) for that specific scenario. Engine `_would_fill_market`
-returns `path[0] = bar.open_price` invariantly so the hypothesis
-contradicts the static read — needs docker reproduction. Lives on the
-G14 split-adjustment surface already escalated as a scope-extension
-decision per the 2026-04-16 precedent. Action: bring docker up, repro,
-fix; this is the very next dispatchable item once the M5 plan docs land.
+**[Prior P0 RED CI — RESOLVED]** The 2026-05-02 P0
+(`split_day_stop_exit:1:post_split_exit_no_orphan_equity`, $400 drift)
+was resolved by PR #752 mid-April; CI green on `main` since. Section
+removed from active blockers; retained as historical entry below.
 
 ## QC
 overall_qc: APPROVED (Slice 1 + Slice 3)

--- a/dev/status/tuning.md
+++ b/dev/status/tuning.md
@@ -1,11 +1,16 @@
 # Status: tuning
 
-## Last updated: 2026-05-03
+## Last updated: 2026-05-04
 
 ## Status
-READY_FOR_REVIEW
+IN_PROGRESS — T-A + T-B libs MERGED; CLI binaries + walk-forward integration deferred
 
-T-A grid_search lib + tests landed via PR #805 (merged 2026-05-03). T-B Bayesian-opt lib + tests landed in `feat/tuner-bayesian-opt`. Track created 2026-05-02 to absorb M5.5 (parameter tuning) + M7.1 (ML training). Plans: `dev/plans/m5-experiments-roadmap-2026-05-02.md` (T-A grid + T-B Bayesian) + `dev/plans/m7-data-and-tuning-2026-05-02.md` (T-C supervised) + `dev/plans/grid-search-2026-05-03.md` (T-A clarifying) + `dev/plans/bayesian-opt-2026-05-03.md` (T-B clarifying with D1–D8 design decisions). Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M5.5 + M7.1 (added 2026-05-02). Owner authorized: feat-backtest per `dev/decisions.md` 2026-05-03 §"Agent scope: extend feat-backtest + create feat-data".
+T-A grid_search lib + tests landed via PR #805 (merged 2026-05-03). T-B Bayesian-opt lib + tests landed via PR #817 (merged 2026-05-04). Both `.mli` surfaces are stable. Track created 2026-05-02 to absorb M5.5 (parameter tuning) + M7.1 (ML training). Plans: `dev/plans/m5-experiments-roadmap-2026-05-02.md` (T-A grid + T-B Bayesian) + `dev/plans/m7-data-and-tuning-2026-05-02.md` (T-C supervised) + `dev/plans/grid-search-2026-05-03.md` (T-A clarifying) + `dev/plans/bayesian-opt-2026-05-03.md` (T-B clarifying with D1–D8 design decisions). Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M5.5 + M7.1 (added 2026-05-02).
+
+Remaining work:
+- **T-A CLI binary** — `tuner_runner.exe` wiring `Grid_search.run` to the real backtest runner. Larger PR; deferred.
+- **T-B CLI binary** — `bayesian_runner.exe` analogous to T-A. Deferred.
+- **T-C** (supervised ML walk-forward) — blocked on Norgate ingest (vendor signup) + experiments M5.2 metrics catalog + experiments M5.2e per-trade context (already shipped #769). Owner authorized: feat-backtest per `dev/decisions.md` 2026-05-03 §"Agent scope: extend feat-backtest + create feat-data".
 
 ## Interface stable
 YES

--- a/dev/status/weekly-snapshot.md
+++ b/dev/status/weekly-snapshot.md
@@ -1,11 +1,13 @@
 # Status: weekly-snapshot
 
-## Last updated: 2026-05-02
+## Last updated: 2026-05-04
 
 ## Status
-PLANNED
+PLANNED — owner moved to feat-weinstein per #778 scope expansion
 
 Track created 2026-05-02 to absorb M6.1–M6.5 (verification harness via incremental processing). Plan: `dev/plans/m6-weekly-snapshot-verification-2026-05-02.md`. Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M6.1–M6.5 (added 2026-05-02).
+
+Per the 2026-05-04 daily summary (#830): M6.1–M6.5 absorbed into feat-weinstein scope; M6.6 live cycle DEFERRED.
 
 ## Interface stable
 NO — track is brand-new.
@@ -13,7 +15,7 @@ NO — track is brand-new.
 The reframe: **weekly picks are first-class durable artifacts before they're inputs to live trading.** This subsystem is a verification harness first; the M6.6 live cycle is wiring on top.
 
 ## Blocked on
-- M5.1 foundation hardening (CI red on `main`: `split_day_stop_exit:1:post_split_exit_no_orphan_equity`). The post-split-exit failure is the very kind of bug M6.4 (split/div verification) would catch deterministically.
+- None. Prior M5.1 blocker (`split_day_stop_exit:1:post_split_exit_no_orphan_equity`) was RESOLVED by PR #752. Track is owner-pending: feat-weinstein not currently dispatched on M6.x items.
 
 ## Scope
 


### PR DESCRIPTION
## Summary
Bring 6 stale status files current so future sessions don't get confused about track standings.

- **hybrid-tier.md** → flipped to **MERGED**. Both Phase-1 options shipped: Option 1 engine-pool DONE 2026-04-28; Option 2 daily-snapshot streaming DELIVERED via data-foundations M5.3 sequence (Phases A–F.2 merged 2026-05-02..03; F.3 in flight). Future hybrid-tier work routes to data-foundations / backtest-perf / new tracks.
- **orchestrator-automation.md** → refresh dates + describe Phase-1 stable (~18 days uptime since 2026-04-16; 2 overnight cron slots; #830 most recent summary). Phase-2 deferred but not blocking.
- **experiments.md** → drop M5.1 blocker (resolved by #752 weeks ago). Identify M5.2a–d as next priority dispatches.
- **simulation.md** → drop the **[P0 RED CI 2026-05-02]** block (also resolved by #752; CI green on main since).
- **weekly-snapshot.md** → drop M5.1 blocker; note feat-weinstein owner per #778 scope expansion; M6.6 live cycle DEFERRED.
- **tuning.md** → flip from misleading **READY_FOR_REVIEW** to **IN_PROGRESS** — T-A (#805) + T-B (#817) libs MERGED but CLI binaries + walk-forward integration deferred; T-C blocked on Norgate.

No source-code changes; documentation only.

## Test plan
- [x] `grep -c '<<<<<<<\|>>>>>>>' dev/status/*.md` → 0 markers anywhere
- [x] `jj diff --stat` shows 6 files in `dev/status/`, no other paths