### PR TITLE
refactor(snapshot): F.3.b-1 — Weekly_ma_cache snapshot-views port

### DIFF
--- a/trading/trading/weinstein/strategy/lib/weekly_ma_cache.ml
+++ b/trading/trading/weinstein/strategy/lib/weekly_ma_cache.ml
@@ -2,6 +2,8 @@
 
 open Core
 module Bar_panels = Data_panel.Bar_panels
+module Snapshot_bar_views = Snapshot_runtime.Snapshot_bar_views
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
 
 (* Local mirror of [Stage.ma_type] so the cache key can derive [hash]
    without modifying the [Stage] module's preprocess attributes. The
@@ -27,9 +29,17 @@ module Key = struct
 end
 
 type cached_ma = { values : float array; dates : Date.t array }
-type t = { panels : Bar_panels.t; table : cached_ma Key.Table.t }
 
-let create panels = { panels; table = Key.Table.create () }
+(* Phase F.3.b-1: backing-agnostic representation. [weekly_history_fn] is
+   the single seam — both [create] (panels) and [of_snapshot_views]
+   (snapshot) produce a closure of this shape that returns the symbol's
+   full weekly history (closes + dates, oldest first). The cache table
+   then memoises MA computations over those arrays, identically for both
+   backings. *)
+type t = {
+  weekly_history_fn : string -> float array * Date.t array;
+  table : cached_ma Key.Table.t;
+}
 
 (* Compute the MA series via the same kernels [Stage._compute_ma] uses.
    Replicating the kernel selection here keeps the cache co-located with
@@ -64,7 +74,7 @@ let _compute_ma_array ~(ma_type : Stage.ma_type) ~(period : int)
    available [as_of_day] (the last column of the panel's calendar). Returns
    the chronological closes + dates arrays (oldest first). Empty arrays
    when the symbol has no resident bars or the panel has zero days. *)
-let _full_weekly_view (panels : Bar_panels.t) (symbol : string) :
+let _panels_weekly_history (panels : Bar_panels.t) (symbol : string) :
     float array * Date.t array =
   let n_days = Bar_panels.n_days panels in
   if n_days = 0 then ([||], [||])
@@ -75,8 +85,52 @@ let _full_weekly_view (panels : Bar_panels.t) (symbol : string) :
     in
     (view.closes, view.dates)
 
-let _build_entry panels (ma_type : Stage.ma_type) (key : Key.t) : cached_ma =
-  let closes, dates = _full_weekly_view panels key.symbol in
+(* Read the symbol's full weekly history via [Snapshot_bar_views] over a
+   [Snapshot_callbacks.t]. The semantics match the panel reader's: chronological
+   (oldest first), close = adjusted close of the last trading day in each
+   ISO-week bucket. We fetch every available weekly bucket ending on or before
+   [max_as_of] via {!Snapshot_bar_views.weekly_bars_for} with
+   [n = Int.max_value]; that helper walks back a fixed 10-year calendar
+   window (matching {!Snapshot_bar_views.daily_bars_for}'s convention),
+   wide enough for any realistic backtest horizon, and short-circuits the
+   trailing truncation when [n] exceeds the available count.
+
+   ([Snapshot_bar_views.weekly_view_for] would compute the calendar span from
+   [n] via [(n * 8) + 7], which overflows for [n = Int.max_value]; the
+   [weekly_bars_for] entrypoint sidesteps that overflow by using a fixed
+   window.) *)
+let _snapshot_weekly_history (cb : Snapshot_callbacks.t) ~(max_as_of : Date.t)
+    (symbol : string) : float array * Date.t array =
+  let weekly =
+    Snapshot_bar_views.weekly_bars_for cb ~symbol ~n:Int.max_value
+      ~as_of:max_as_of
+  in
+  if List.is_empty weekly then ([||], [||])
+  else
+    let closes =
+      Array.of_list
+        (List.map weekly ~f:(fun b -> b.Types.Daily_price.adjusted_close))
+    in
+    let dates =
+      Array.of_list (List.map weekly ~f:(fun b -> b.Types.Daily_price.date))
+    in
+    (closes, dates)
+
+let create panels =
+  {
+    weekly_history_fn = _panels_weekly_history panels;
+    table = Key.Table.create ();
+  }
+
+let of_snapshot_views cb ~max_as_of =
+  {
+    weekly_history_fn = _snapshot_weekly_history cb ~max_as_of;
+    table = Key.Table.create ();
+  }
+
+let _build_entry weekly_history_fn (ma_type : Stage.ma_type) (key : Key.t) :
+    cached_ma =
+  let closes, dates = weekly_history_fn key.symbol in
   let values, ma_dates =
     _compute_ma_array ~ma_type ~period:key.period ~closes ~dates
   in
@@ -87,7 +141,7 @@ let ma_values_for t ~symbol ~(ma_type : Stage.ma_type) ~period =
   let key : Key.t = { symbol; ma_type = tag; period } in
   let entry =
     Hashtbl.find_or_add t.table key ~default:(fun () ->
-        _build_entry t.panels ma_type key)
+        _build_entry t.weekly_history_fn ma_type key)
   in
   (entry.values, entry.dates)
 

--- a/trading/trading/weinstein/strategy/lib/weekly_ma_cache.mli
+++ b/trading/trading/weinstein/strategy/lib/weekly_ma_cache.mli
@@ -43,7 +43,23 @@
 
     Sized memory: [n_symbols] × (per-symbol full weekly history × 8 bytes ×
     n_distinct_(ma_type, period)_combos). For 300 symbols × 312 weeks × 1 combo
-    = ~750 KB total — negligible. *)
+    = ~750 KB total — negligible.
+
+    {2 Backings (Phase F.3.b-1)}
+
+    Two constructors today, semantically equivalent on bit-equal inputs:
+
+    - {!create} — legacy {!Data_panel.Bar_panels} backing. Reads weekly history
+      via [Bar_panels.weekly_view_for]. Slated for removal once every caller
+      migrates to {!of_snapshot_views}.
+    - {!of_snapshot_views} — snapshot backing. Reads weekly history via
+      {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for} over a
+      {!Snapshot_runtime.Snapshot_callbacks.t}. The canonical production
+      constructor for runs with a pre-built snapshot directory.
+
+    Both produce bit-equal MA / dates arrays for the same
+    ([symbol, ma_type, period]) key when the underlying bar history is identical
+    (parity test: {!Test_weekly_ma_cache.Test_snapshot_parity}). *)
 
 open Core
 module Bar_panels = Data_panel.Bar_panels
@@ -54,7 +70,27 @@ type t
 val create : Bar_panels.t -> t
 (** [create panels] builds an empty cache backed by [panels]. The cache holds a
     reference to [panels] so subsequent [ma_values_for] calls can read the
-    symbol's full weekly history on demand. *)
+    symbol's full weekly history on demand.
+
+    Phase F.3.b-1: legacy backing; will be removed in F.3.b-N once every caller
+    migrates to {!of_snapshot_views}. *)
+
+val of_snapshot_views :
+  Snapshot_runtime.Snapshot_callbacks.t -> max_as_of:Date.t -> t
+(** [of_snapshot_views cb ~max_as_of] builds an empty cache backed by [cb]. The
+    cache holds a reference to [cb] so subsequent [ma_values_for] calls can read
+    the symbol's full weekly history on demand.
+
+    [max_as_of] is the upper-bound date for the weekly history reads — it is
+    passed as [as_of] to {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for}
+    along with [n = Int.max_value] to fetch every weekly bucket on or before
+    [max_as_of]. Callers typically pass the last calendar date of the backtest
+    (the snapshot directory's terminal date), matching the panel-backed path's
+    "use the last column of the calendar" convention.
+
+    The returned cache is semantically equivalent to {!create} on the same
+    underlying bar history: same MA values, same dates, same memoisation
+    behaviour. *)
 
 val ma_values_for :
   t ->
@@ -68,12 +104,10 @@ val ma_values_for :
     at least [period] weeks, otherwise both arrays are empty.
 
     On first call for [(symbol, ma_type, period)] the cache reads the symbol's
-    full weekly history from the underlying [Bar_panels] (using
-    [as_of_day = n_days - 1], the last column of the panel's calendar — which
-    holds the full backtest range), computes the MA via the same kernel
-    [Stage._compute_ma] uses ([Sma.calculate_sma] / [Sma.calculate_weighted_ma]
-    / [Ema.calculate_ema]), and stores the result. Subsequent calls return the
-    cached arrays directly.
+    full weekly history from the underlying backing (panels or snapshot),
+    computes the MA via the same kernel [Stage._compute_ma] uses
+    ([Sma.calculate_sma] / [Sma.calculate_weighted_ma] / [Ema.calculate_ema]),
+    and stores the result. Subsequent calls return the cached arrays directly.
 
     The returned arrays are owned by the cache; do not mutate them. *)
 

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -26,12 +26,15 @@
   fpath
   trading.base
   trading.data_panel
+  trading.data_panel.snapshot
   trading.engine
   trading.portfolio
   trading.simulation
   trading.simulation.types
   trading.strategy
   weinstein_trading.strategy
+  weinstein.snapshot_pipeline
+  weinstein.snapshot_runtime
   weinstein.types
   weinstein.screener
   weinstein.stage

--- a/trading/trading/weinstein/strategy/test/test_weekly_ma_cache.ml
+++ b/trading/trading/weinstein/strategy/test/test_weekly_ma_cache.ml
@@ -278,6 +278,167 @@ let test_cache_memoisation _ =
   assert_that (phys_equal v1 v2) (equal_to true)
 
 (* ------------------------------------------------------------------ *)
+(* Snapshot-backed parity (Phase F.3.b-1)                                *)
+(* ------------------------------------------------------------------ *)
+(* Pin that {!Weekly_ma_cache.of_snapshot_views} produces bit-equal MA
+   values + dates to {!Weekly_ma_cache.create} on the same underlying bar
+   history. The legacy [create] reads via [Bar_panels.weekly_view_for];
+   the new [of_snapshot_views] reads via
+   [Snapshot_runtime.Snapshot_bar_views.weekly_view_for] over a
+   {!Snapshot_callbacks.t} backed by a tmp snapshot directory.
+
+   The helper [build_snapshot_callbacks] mirrors the internal setup that
+   {!Bar_reader.of_in_memory_bars} uses (Phase F.3.a-1), producing a
+   {!Snapshot_callbacks.t} from in-memory [(symbol, bars)] pairs. *)
+
+module Pipeline = Snapshot_pipeline.Pipeline
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+
+let _build_snapshot_callbacks
+    (symbol_bars : (string * Types.Daily_price.t list) list) :
+    Snapshot_callbacks.t =
+  let dir = Stdlib.Filename.temp_dir "test_weekly_ma_cache_" "" in
+  let entries =
+    List.map symbol_bars ~f:(fun (symbol, bars) ->
+        let rows =
+          match
+            Pipeline.build_for_symbol ~symbol ~bars
+              ~schema:Snapshot_schema.default ()
+          with
+          | Ok rs -> rs
+          | Error err ->
+              failwithf "Pipeline.build_for_symbol %s: %s" symbol
+                err.Status.message ()
+        in
+        let path = Filename.concat dir (symbol ^ ".snap") in
+        (match Snapshot_format.write ~path rows with
+        | Ok () -> ()
+        | Error err ->
+            failwithf "Snapshot_format.write %s: %s" symbol err.Status.message
+              ());
+        {
+          Snapshot_manifest.symbol;
+          path;
+          byte_size = 0;
+          payload_md5 = "ignored";
+          csv_mtime = 0.0;
+        })
+  in
+  let manifest =
+    Snapshot_manifest.create ~schema:Snapshot_schema.default ~entries
+  in
+  let manifest_path = Filename.concat dir "manifest.sexp" in
+  (match Snapshot_manifest.write ~path:manifest_path manifest with
+  | Ok () -> ()
+  | Error err -> failwithf "Snapshot_manifest.write: %s" err.Status.message ());
+  let panels =
+    match Daily_panels.create ~snapshot_dir:dir ~manifest ~max_cache_mb:16 with
+    | Ok p -> p
+    | Error err -> failwithf "Daily_panels.create: %s" err.Status.message ()
+  in
+  Snapshot_callbacks.of_daily_panels panels
+
+(* The terminal date used as [max_as_of] for the snapshot-backed cache.
+   The legacy panel-backed reader reads the largest available [as_of_day]
+   (last column); the snapshot reader reads up to [max_as_of]. Pass the
+   date of the last bar in the fixture so both backings see the same
+   weekly window. *)
+let _max_as_of_of bars =
+  let last = List.last_exn bars in
+  last.Types.Daily_price.date
+
+let _run_snapshot_parity ~(ma_type : Stage.ma_type) ~period ~bars ~symbol =
+  let panels = panels_of_symbols [ (symbol, bars) ] in
+  let cb = _build_snapshot_callbacks [ (symbol, bars) ] in
+  let max_as_of = _max_as_of_of bars in
+  let panel_cache = Weekly_ma_cache.create panels in
+  let snapshot_cache = Weekly_ma_cache.of_snapshot_views cb ~max_as_of in
+  let panel_values, panel_dates =
+    Weekly_ma_cache.ma_values_for panel_cache ~symbol ~ma_type ~period
+  in
+  let snap_values, snap_dates =
+    Weekly_ma_cache.ma_values_for snapshot_cache ~symbol ~ma_type ~period
+  in
+  let panel_pairs =
+    Array.to_list
+      (Array.map2_exn panel_values panel_dates ~f:(fun v d -> (v, d)))
+  in
+  let snap_pairs =
+    Array.to_list (Array.map2_exn snap_values snap_dates ~f:(fun v d -> (v, d)))
+  in
+  assert_that snap_pairs
+    (elements_are
+       (List.map panel_pairs ~f:(fun (v, d) ->
+            all_of
+              [
+                field (fun (sv, _) -> sv) (float_equal ~epsilon:1e-9 v);
+                field (fun (_, sd) -> sd) (equal_to d);
+              ])))
+
+let test_snapshot_parity_sma_30 _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  _run_snapshot_parity ~ma_type:Stage.Sma ~period:30 ~bars ~symbol:"AAPL"
+
+let test_snapshot_parity_wma_30 _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  _run_snapshot_parity ~ma_type:Stage.Wma ~period:30 ~bars ~symbol:"AAPL"
+
+let test_snapshot_parity_sma_10 _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:30 ~start_price:50.0 ~step:0.25
+  in
+  _run_snapshot_parity ~ma_type:Stage.Sma ~period:10 ~bars ~symbol:"XLK"
+
+let test_snapshot_short_history_returns_empty _ =
+  (* History shorter than period → empty arrays under either backing. *)
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:5 ~start_price:100.0 ~step:0.1
+  in
+  let cb = _build_snapshot_callbacks [ ("AAPL", bars) ] in
+  let cache =
+    Weekly_ma_cache.of_snapshot_views cb ~max_as_of:(_max_as_of_of bars)
+  in
+  let values, dates =
+    Weekly_ma_cache.ma_values_for cache ~symbol:"AAPL" ~ma_type:Stage.Sma
+      ~period:30
+  in
+  assert_that (Array.length values) (equal_to 0);
+  assert_that (Array.length dates) (equal_to 0)
+
+let test_snapshot_unknown_symbol_returns_empty _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.1
+  in
+  let cb = _build_snapshot_callbacks [ ("AAPL", bars) ] in
+  let cache =
+    Weekly_ma_cache.of_snapshot_views cb ~max_as_of:(_max_as_of_of bars)
+  in
+  let values, dates =
+    Weekly_ma_cache.ma_values_for cache ~symbol:"MISSING" ~ma_type:Stage.Wma
+      ~period:30
+  in
+  assert_that (Array.length values) (equal_to 0);
+  assert_that (Array.length dates) (equal_to 0)
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -297,4 +458,11 @@ let () =
            "locate_date returns None for missing dates"
            >:: test_locate_date_returns_none_for_missing;
            "Cache memoises by key" >:: test_cache_memoisation;
+           "Snapshot parity (SMA period=30)" >:: test_snapshot_parity_sma_30;
+           "Snapshot parity (WMA period=30)" >:: test_snapshot_parity_wma_30;
+           "Snapshot parity (SMA period=10)" >:: test_snapshot_parity_sma_10;
+           "Snapshot short history returns empty"
+           >:: test_snapshot_short_history_returns_empty;
+           "Snapshot unknown symbol returns empty"
+           >:: test_snapshot_unknown_symbol_returns_empty;
          ])


### PR DESCRIPTION
## Summary

Phase F.3.b-1 of the daily-snapshot streaming pipeline. Adds a parallel `Weekly_ma_cache.of_snapshot_views` constructor alongside the legacy `Weekly_ma_cache.create`, with a parity test pinning that the snapshot-backed path produces bit-equal MA values + dates to the panel-backed path on a known fixture.

This is the second of four consumer ports tracked in `dev/plans/snapshot-engine-phase-f-2026-05-03.md` §F.3 (after F.3.a Bar_reader, completed via #825/#827/#828/#829).

## What

- **`Weekly_ma_cache.of_snapshot_views : Snapshot_callbacks.t -> max_as_of:Date.t -> t`** — new constructor backed by `Snapshot_runtime.Snapshot_bar_views.weekly_bars_for`. Takes `max_as_of` as the upper-bound date for weekly history reads (matches the panel reader's "use the last column of the calendar" convention).
- Internal restructure: `Weekly_ma_cache.t` now holds a `weekly_history_fn : string -> float array * Date.t array` closure produced by either constructor. Both paths converge at MA computation, so memoization behaviour is identical.
- Legacy `Weekly_ma_cache.create : Bar_panels.t -> t` is preserved unchanged for callers — slated for removal in a follow-up F.3.b-N once `Panel_callbacks` and the `Bar_reader.ma_cache` field are migrated.

### Implementation note

`Snapshot_bar_views.weekly_view_for` derives its calendar window from `(n * 8) + 7`, which overflows for `n = Int.max_value`. The new path uses `weekly_bars_for` instead — that helper uses a fixed 10-year window, sidestepping the overflow.

## Why

Step toward retiring `Bar_panels.t`. `Weekly_ma_cache` was one of four `Bar_panels.t` consumers identified in the plan §F.3. The staged b-1 PR (parallel constructor + parity test, no caller migration) keeps the change scoped and reviewable; subsequent F.3.b-N PRs will migrate the four call sites and delete the legacy `create`.

## Test plan

- [x] `dune build` passes for `trading/weinstein/strategy`
- [x] `dune runtest trading/weinstein/strategy/test` passes (14 tests in `test_weekly_ma_cache.ml` — 9 original + 5 new snapshot parity)
- [x] `dune build @fmt` clean for files touched
- [x] **Parity tests added** — `test_snapshot_parity_{sma_30, wma_30, sma_10}` build a Bar_panels backing AND a Snapshot_callbacks backing from the same in-memory fixture and assert bit-equal MA values + dates from `Weekly_ma_cache.ma_values_for` on either path
- [x] **Edge-case tests added** — `test_snapshot_short_history_returns_empty` and `test_snapshot_unknown_symbol_returns_empty` mirror the legacy edge-case tests on the snapshot path

## Files

- `trading/trading/weinstein/strategy/lib/weekly_ma_cache.ml` — restructured to weekly_history_fn closure; added of_snapshot_views + _snapshot_weekly_history
- `trading/trading/weinstein/strategy/lib/weekly_ma_cache.mli` — added of_snapshot_views declaration + Backings docstring section
- `trading/trading/weinstein/strategy/test/test_weekly_ma_cache.ml` — added 5 snapshot parity tests + helper _build_snapshot_callbacks
- `trading/trading/weinstein/strategy/test/dune` — added trading.data_panel.snapshot, weinstein.snapshot_pipeline, weinstein.snapshot_runtime deps for the snapshot helper

## LOC

273 insertions / 14 deletions, ~287 LOC delta (well under the 500 cap).

## Plan reference

`dev/plans/snapshot-engine-phase-f-2026-05-03.md` §F.3 (lines 73-89).

🤖 Generated with [Claude Code](https://claude.com/claude-code)