### PR TITLE
feat(backtest): plumb --progress-every through scenario_runner with monthly default

### DIFF
--- a/trading/trading/backtest/scenarios/dune
+++ b/trading/trading/backtest/scenarios/dune
@@ -1,7 +1,12 @@
 (library
  (name scenario_lib)
- (modules scenario universe_file fixtures_root smoke_catalog)
- (libraries core fpath weinstein.data_source)
+ (modules
+  scenario
+  universe_file
+  fixtures_root
+  smoke_catalog
+  scenario_progress)
+ (libraries core fpath weinstein.data_source backtest)
  (preprocess
   (pps ppx_sexp_conv)))
 

--- a/trading/trading/backtest/scenarios/scenario_progress.ml
+++ b/trading/trading/backtest/scenarios/scenario_progress.ml
@@ -1,0 +1,12 @@
+open Core
+module Backtest_progress = Backtest.Backtest_progress
+
+let default_every_n_fridays = 4
+
+let make_emitter ~scenario_dir ~every_n_fridays =
+  let path = Filename.concat scenario_dir "progress.sexp" in
+  {
+    Backtest_progress.every_n_fridays;
+    on_progress =
+      (fun progress -> Backtest_progress.write_atomic ~path progress);
+  }

--- a/trading/trading/backtest/scenarios/scenario_progress.mli
+++ b/trading/trading/backtest/scenarios/scenario_progress.mli
@@ -1,0 +1,34 @@
+(** Per-scenario progress emitter for [scenario_runner.exe].
+
+    Mirrors the [backtest_runner.exe] emitter wired in PR #820 (see
+    [trading/trading/backtest/bin/backtest_runner.ml] §[_make_progress_emitter])
+    but shaped for the scenario-runner output convention: one [progress.sexp]
+    per scenario subdirectory under [dev/backtest/scenarios-<ts>/<name>/], next
+    to the existing [summary.sexp] / [trades.csv] artefacts.
+
+    Threaded through {!Backtest.Runner.run_backtest} as
+    [?progress_emitter:Backtest_progress.emitter]. Default behaviour when
+    [scenario_runner.exe] is invoked without [--progress-every] is to emit every
+    [4] Friday cycles (≈ monthly cadence) so multi-hour multi-scenario runs
+    (e.g. 15y SP500, broad-10k 10y) gain recoverability without operator opt-in.
+*)
+
+val default_every_n_fridays : int
+(** Default emission cadence: 4 Friday cycles ≈ monthly. The fast write path
+    (atomic-rename single sexp) makes this cheap in I/O terms even for a 15y
+    simulation (~195 checkpoints). Compare with PR #820's [backtest_runner.exe]
+    where [--progress-every] is opt-in (default [None]); for [scenario_runner]
+    we default to ON because the exe is the long-running multi-scenario entry
+    point and running blind for hours has no upside. *)
+
+val make_emitter :
+  scenario_dir:string ->
+  every_n_fridays:int ->
+  Backtest.Backtest_progress.emitter
+(** [make_emitter ~scenario_dir ~every_n_fridays] returns an emitter whose
+    [on_progress] callback writes [progress.sexp] under [scenario_dir] via
+    {!Backtest.Backtest_progress.write_atomic}. The path convention matches the
+    other per-scenario artefacts ([summary.sexp], [trades.csv], [actual.sexp]).
+
+    [every_n_fridays] must be [>= 1]; values [< 1] are rejected by the CLI
+    parser before this function is called. *)

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -3,7 +3,7 @@
 
     Usage: scenario_runner
     [--goldens-small | --goldens-broad | --goldens | --smoke | --dir <path>]
-    [--parallel N] [--fixtures-root <path>]
+    [--parallel N] [--fixtures-root <path>] [--progress-every N]
 
     [--goldens-small] — small-universe goldens (~300 symbols; local-friendly).
     [--goldens-broad] — broad-universe goldens (full sector-map; nightly/GHA).
@@ -14,6 +14,13 @@
     perf-tier smoke scripts pass this explicitly because they stage the scenario
     sexp into a per-cell scratch dir, which loses the original fixtures-root
     context.
+
+    [--progress-every N] — emit a tail-able [progress.sexp] under each
+    scenario's output directory every [N] Friday cycles. Default is
+    {!Scenario_progress.default_every_n_fridays} (≈ monthly cadence) so
+    multi-hour multi-scenario runs (e.g. 15y SP500, broad-10k 10y) emit
+    checkpoints by default. Mirrors the [backtest_runner.exe --progress-every]
+    flag from PR #820, but threads one emitter per scenario into each child.
 
     Reads all *.sexp files from the selected directory, runs each via
     {!Backtest.Runner.run_backtest}, prints a pass/fail table, and writes
@@ -28,6 +35,7 @@ open Core
 module Scenario = Scenario_lib.Scenario
 module Universe_file = Scenario_lib.Universe_file
 module Fixtures_root = Scenario_lib.Fixtures_root
+module Scenario_progress = Scenario_lib.Scenario_progress
 
 (* Universe resolution *)
 
@@ -173,7 +181,8 @@ let _actual_path ~output_root (s : Scenario.t) =
 
 (* Run one scenario inside a child process *)
 
-let _run_scenario_in_child ~output_root ~fixtures_root (s : Scenario.t) =
+let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
+    (s : Scenario.t) =
   eprintf "\n>>> Running %s: %s (%s to %s)\n%!" s.name s.description
     (Date.to_string s.period.start_date)
     (Date.to_string s.period.end_date);
@@ -182,10 +191,13 @@ let _run_scenario_in_child ~output_root ~fixtures_root (s : Scenario.t) =
   let sector_map_override =
     _sector_map_of_universe_file ~fixtures_root s.universe_path
   in
+  let progress_emitter =
+    Scenario_progress.make_emitter ~scenario_dir ~every_n_fridays:progress_every
+  in
   let result =
     Backtest.Runner.run_backtest ~start_date:s.period.start_date
       ~end_date:s.period.end_date ~overrides:s.config_overrides
-      ?sector_map_override ()
+      ?sector_map_override ~progress_emitter ()
   in
   Backtest.Result_writer.write ~output_dir:scenario_dir result;
   let a = _actual_of_result result in
@@ -194,11 +206,12 @@ let _run_scenario_in_child ~output_root ~fixtures_root (s : Scenario.t) =
 (* Fork-based worker pool. Scenarios run in parallel child processes up to
    [parallel] at a time. *)
 
-let _fork_scenario ~output_root ~fixtures_root (s : Scenario.t) =
+let _fork_scenario ~output_root ~fixtures_root ~progress_every (s : Scenario.t)
+    =
   match Core_unix.fork () with
   | `In_the_child -> (
       try
-        _run_scenario_in_child ~output_root ~fixtures_root s;
+        _run_scenario_in_child ~output_root ~fixtures_root ~progress_every s;
         Stdlib.exit 0
       with e ->
         eprintf "Scenario %s crashed: %s\n%!" s.name (Exn.to_string e);
@@ -212,7 +225,7 @@ let _await_one running =
   match Core_unix.waitpid pid with Ok () -> Succeeded | Error _ -> Crashed
 
 let _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
-    (scenarios : Scenario.t list) =
+    ~progress_every (scenarios : Scenario.t list) =
   let running = Queue.create () in
   let statuses = Hashtbl.create (module String) in
   let reap () =
@@ -223,7 +236,7 @@ let _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
   in
   List.iter scenarios ~f:(fun s ->
       if Queue.length running >= parallel then reap ();
-      let pid = _fork_scenario ~output_root ~fixtures_root s in
+      let pid = _fork_scenario ~output_root ~fixtures_root ~progress_every s in
       Queue.enqueue running (s, pid));
   while not (Queue.is_empty running) do
     reap ()
@@ -260,18 +273,36 @@ let _process_result ~output_root (s, status) =
 
 (* CLI *)
 
-type _cli_args = { dir : string; parallel : int; fixtures_root : string option }
+type _cli_args = {
+  dir : string;
+  parallel : int;
+  fixtures_root : string option;
+  progress_every : int;
+      (* Friday-cycle cadence for [progress.sexp] emission, threaded into each
+         scenario's [Backtest.Runner.run_backtest] call. Always populated:
+         defaults to [Scenario_progress.default_every_n_fridays] (≈ monthly)
+         when [--progress-every] is omitted, so the long-running multi-scenario
+         exe gets recoverability by default. *)
+}
 
 let _default_parallel = 4
 
 let _usage () =
   eprintf
     "Usage: scenario_runner [--goldens-small | --goldens-broad | --goldens | \
-     --smoke | --dir <path>] [--parallel N] [--fixtures-root <path>]\n";
+     --smoke | --dir <path>] [--parallel N] [--fixtures-root <path>] \
+     [--progress-every N]\n";
   Stdlib.exit 1
 
+let _parse_progress_every n_str =
+  match Int.of_string_opt n_str with
+  | Some n when n >= 1 -> n
+  | _ ->
+      eprintf "--progress-every requires a positive integer argument\n";
+      Stdlib.exit 1
+
 let _parse_flag args =
-  let rec loop args dir parallel fixtures_root =
+  let rec loop args dir parallel fixtures_root progress_every =
     match args with
     | [] ->
         let dir = Option.value dir ~default:(_goldens_small_dir ()) in
@@ -279,29 +310,42 @@ let _parse_flag args =
           dir;
           parallel = Option.value parallel ~default:_default_parallel;
           fixtures_root;
+          progress_every =
+            Option.value progress_every
+              ~default:Scenario_progress.default_every_n_fridays;
         }
     | "--goldens-small" :: rest ->
-        loop rest (Some (_goldens_small_dir ())) parallel fixtures_root
+        loop rest
+          (Some (_goldens_small_dir ()))
+          parallel fixtures_root progress_every
     | "--goldens-broad" :: rest ->
-        loop rest (Some (_goldens_broad_dir ())) parallel fixtures_root
+        loop rest
+          (Some (_goldens_broad_dir ()))
+          parallel fixtures_root progress_every
     | "--goldens" :: rest ->
-        loop rest (Some (_goldens_small_dir ())) parallel fixtures_root
+        loop rest
+          (Some (_goldens_small_dir ()))
+          parallel fixtures_root progress_every
     | "--smoke" :: rest ->
-        loop rest (Some (_smoke_dir ())) parallel fixtures_root
-    | "--dir" :: path :: rest -> loop rest (Some path) parallel fixtures_root
+        loop rest (Some (_smoke_dir ())) parallel fixtures_root progress_every
+    | "--dir" :: path :: rest ->
+        loop rest (Some path) parallel fixtures_root progress_every
     | "--parallel" :: n :: rest ->
-        loop rest dir (Some (Int.of_string n)) fixtures_root
-    | "--fixtures-root" :: path :: rest -> loop rest dir parallel (Some path)
+        loop rest dir (Some (Int.of_string n)) fixtures_root progress_every
+    | "--fixtures-root" :: path :: rest ->
+        loop rest dir parallel (Some path) progress_every
+    | "--progress-every" :: n :: rest ->
+        loop rest dir parallel fixtures_root (Some (_parse_progress_every n))
     | _ -> _usage ()
   in
-  loop args None None None
+  loop args None None None None
 
 let _parse_args () =
   let argv = Sys.get_argv () in
   _parse_flag (List.tl_exn (Array.to_list argv))
 
 let () =
-  let { dir; parallel; fixtures_root } = _parse_args () in
+  let { dir; parallel; fixtures_root; progress_every } = _parse_args () in
   let fixtures_root = Fixtures_root.resolve ?fixtures_root () in
   let files = _list_scenario_files dir in
   if List.is_empty files then (
@@ -311,11 +355,14 @@ let () =
   eprintf "Loading %d scenarios from %s (parallel=%d)\n%!" (List.length files)
     dir parallel;
   eprintf "Fixtures root: %s\n%!" fixtures_root;
+  eprintf "Progress emission: every %d Friday cycle(s) per scenario\n%!"
+    progress_every;
   let scenarios = List.map files ~f:Scenario.load in
   let output_root = _make_output_root () in
   eprintf "Output root: %s\n%!" output_root;
   let results =
-    _run_scenarios_parallel ~output_root ~fixtures_root ~parallel scenarios
+    _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
+      ~progress_every scenarios
   in
   _print_header ();
   let pass_flags = List.map results ~f:(_process_result ~output_root) in

--- a/trading/trading/backtest/scenarios/test/dune
+++ b/trading/trading/backtest/scenarios/test/dune
@@ -3,12 +3,14 @@
   test_scenario
   test_universe_file
   test_fixtures_root
-  test_scenario_runner_isolation)
+  test_scenario_runner_isolation
+  test_scenario_progress)
  (modules
   test_scenario
   test_universe_file
   test_fixtures_root
-  test_scenario_runner_isolation)
+  test_scenario_runner_isolation
+  test_scenario_progress)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/scenarios/test/test_scenario_progress.ml
+++ b/trading/trading/backtest/scenarios/test/test_scenario_progress.ml
@@ -1,0 +1,140 @@
+(** Pin the [Scenario_progress] emitter wiring used by [scenario_runner.exe].
+
+    Two contracts are exercised here:
+
+    1. {b Path convention}: [make_emitter ~scenario_dir ~every_n_fridays] builds
+    an emitter whose [on_progress] callback writes [progress.sexp] under
+    [scenario_dir] (NOT under a global output root). Recorded by asserting the
+    file lands at the expected path after invoking the callback.
+
+    2. {b End-to-end emission cadence via [Runner.run_backtest]}: a recording
+    emitter substitute (NOT the [write_atomic] sink) is installed via the same
+    [?progress_emitter] argument [scenario_runner.exe] uses, on a real smoke
+    scenario. With [every_n_fridays = 1] the recorder must capture more than one
+    snapshot, mirroring the test pattern from [test_backtest_progress.ml]. This
+    pins the integration: the scenario's config + the runner's
+    [progress_emitter] threading + the [Backtest_progress.accumulator] all line
+    up.
+
+    The recording-emitter substitute is the same shape as the one in
+    [test_backtest_progress.ml]: a [ref] [list] that the [on_progress] callback
+    appends to. We do NOT exercise the fork-per-cell scenario-runner path here —
+    that's tested implicitly by the scenario-runner CLI smoke runs. *)
+
+open OUnit2
+open Core
+open Matchers
+module Backtest_progress = Backtest.Backtest_progress
+module Scenario = Scenario_lib.Scenario
+module Scenario_progress = Scenario_lib.Scenario_progress
+module Universe_file = Scenario_lib.Universe_file
+
+let _fixtures_root () =
+  let data_dir = Data_path.default_data_dir () |> Fpath.to_string in
+  Filename.concat data_dir "backtest_scenarios"
+
+(* Smallest, fastest scenario in the catalog (perf-tier-1, 7 symbols, ~6
+   months) so the test stays well inside any per-PR budget. Same scenario as
+   [test_backtest_progress.ml] and [test_panel_runner_gc_trace] for cross-test
+   consistency. *)
+let _scenario_rel = "smoke/tiered-loader-parity.sexp"
+let _load_scenario rel = Scenario.load (Filename.concat (_fixtures_root ()) rel)
+
+let _sector_map_override (s : Scenario.t) =
+  let resolved = Filename.concat (_fixtures_root ()) s.universe_path in
+  Universe_file.to_sector_map_override (Universe_file.load resolved)
+
+(* Pin the documented default of 4 Friday cycles (≈ monthly) so any change to
+   the cadence default is a deliberate, code-reviewed action — not silent. *)
+let test_default_every_n_fridays_is_four _ =
+  assert_that Scenario_progress.default_every_n_fridays (equal_to 4)
+
+(* Pin the path convention: [make_emitter ~scenario_dir]'s [on_progress]
+   writes to [<scenario_dir>/progress.sexp] (NOT a global path). *)
+let test_make_emitter_writes_under_scenario_dir _ =
+  let tmp_dir = Filename_unix.temp_dir "scenario_progress_test_" "" in
+  let emitter =
+    Scenario_progress.make_emitter ~scenario_dir:tmp_dir ~every_n_fridays:4
+  in
+  let progress : Backtest_progress.t =
+    {
+      started_at = 1714780000.0;
+      updated_at = 1714780123.5;
+      cycles_done = 4;
+      cycles_total = 838;
+      last_completed_date = Date.create_exn ~y:2014 ~m:Month.Dec ~d:26;
+      trades_so_far = 7;
+      current_equity = 152384.21;
+    }
+  in
+  emitter.on_progress progress;
+  let expected_path = Filename.concat tmp_dir "progress.sexp" in
+  let exists = Stdlib.Sys.file_exists expected_path in
+  let loaded =
+    if exists then
+      Some (Sexp.load_sexp expected_path |> Backtest_progress.t_of_sexp)
+    else None
+  in
+  (* Cleanup. *)
+  if exists then Stdlib.Sys.remove expected_path;
+  Stdlib.Sys.rmdir tmp_dir;
+  assert_that
+    (exists, emitter.every_n_fridays, loaded)
+    (all_of
+       [
+         field (fun (e, _, _) -> e) (equal_to true);
+         field (fun (_, n, _) -> n) (equal_to 4);
+         field
+           (fun (_, _, l) -> l)
+           (is_some_and
+              (field (fun p -> p.Backtest_progress.cycles_done) (equal_to 4)));
+       ])
+
+(* End-to-end pin: a recording emitter threaded through [Runner.run_backtest]
+   with [every_n_fridays = 1] fires more than once on the smoke scenario, plus
+   the unconditional final write. Mirrors [test_emitter_fires_during_run] in
+   [test_backtest_progress.ml]. *)
+let test_recorded_emitter_fires_during_scenario_run _ =
+  let s = _load_scenario _scenario_rel in
+  let sector_map_override = _sector_map_override s in
+  let recorder = ref [] in
+  let progress_emitter : Backtest_progress.emitter =
+    {
+      every_n_fridays = 1;
+      on_progress = (fun p -> recorder := !recorder @ [ p ]);
+    }
+  in
+  let _result =
+    Backtest.Runner.run_backtest ~start_date:s.period.start_date
+      ~end_date:s.period.end_date ~overrides:s.config_overrides
+      ?sector_map_override ~progress_emitter ()
+  in
+  assert_that (List.length !recorder) (gt (module Int_ord) 4)
+
+let suite =
+  "Scenario_progress"
+  >::: [
+         "default_every_n_fridays is 4 (monthly)"
+         >:: test_default_every_n_fridays_is_four;
+         "make_emitter writes progress.sexp under scenario_dir"
+         >:: test_make_emitter_writes_under_scenario_dir;
+         "recorded emitter fires during scenario run via Runner.run_backtest"
+         >:: test_recorded_emitter_fires_during_scenario_run;
+       ]
+
+(* CI sets [TRADING_DATA_DIR] explicitly. Local dev container does not, so
+   [Data_path.default_data_dir ()] would fall back to [/workspaces/trading-1/data]
+   where [backtest_scenarios/] does not exist. Fall back to the canonical local
+   path before the suite runs so the test works in both environments. Same
+   logic as [test_scenario_runner_isolation.ml]. *)
+let _ensure_trading_data_dir () =
+  match Sys.getenv "TRADING_DATA_DIR" with
+  | Some _ -> ()
+  | None ->
+      let local_default = "/workspaces/trading-1/trading/test_data" in
+      if Sys_unix.is_directory_exn local_default then
+        Core_unix.putenv ~key:"TRADING_DATA_DIR" ~data:local_default
+
+let () =
+  _ensure_trading_data_dir ();
+  run_test_tt_main suite


### PR DESCRIPTION
## Summary

Plumbs `--progress-every N` through `scenario_runner.exe` so multi-scenario long backtests (15y SP500, broad-10k 10y) emit a tail-able `progress.sexp` per scenario by default. Mirrors the `backtest_runner.exe --progress-every` flag from PR #820 — but threads one emitter per scenario, into each forked child, with a sane default rather than an opt-in.

## Why

PR #820 added the underlying `Backtest_progress` module + emitter wiring on `backtest_runner.exe`, but `scenario_runner.exe` (which is what runs the long-form goldens / experiments) never picked the flag up. Today's two long-running backtests are 38+ min in with zero on-disk feedback. If the runner crashes there's nothing to inspect.

This PR closes that gap.

## What changed

- **New `Scenario_lib.Scenario_progress` module** (~46 LOC mli+ml): `make_emitter ~scenario_dir ~every_n_fridays` builds a `Backtest_progress.emitter` that writes `progress.sexp` under that scenario's output directory (same path convention as `summary.sexp` / `trades.csv` / `actual.sexp`). `default_every_n_fridays = 4` exposed as a value so callers + tests pin it.
- **`scenario_runner.exe --progress-every N`**: new optional CLI flag, validated as a positive integer. Threaded through `_run_scenarios_parallel` → `_fork_scenario` → `_run_scenario_in_child`, where each child constructs an emitter pointing at its own `<output_root>/<scenario_name>/progress.sexp` and passes `~progress_emitter:` into `Backtest.Runner.run_backtest`.
- **`scenario_lib`** now depends on `backtest` (the existing executable already does, no cycle).
- **Test pin** (`test_scenario_progress.ml`): pins (1) the `default_every_n_fridays = 4` constant; (2) the path convention — `make_emitter ~scenario_dir` writes under `<scenario_dir>/progress.sexp`; (3) end-to-end emission cadence — a recording emitter substitute threaded through `Runner.run_backtest` on the smoke scenario fires more than once with `every_n_fridays = 1`. Same recorder pattern as PR #820's `test_backtest_progress.ml`.

## Default-value choice (intentional behaviour shift)

When `--progress-every` is omitted, `scenario_runner.exe` previously emitted no progress files. After this PR it defaults to **4 Friday cycles** (≈ monthly cadence).

Rationale:
- This is the long-running entry point — the operator's expectation is "checkpoint by default", not "checkpoint by opt-in".
- For a 15y simulation that's ~195 checkpoints. The atomic-rename single-sexp write is cheap (single `tempfile + rename` per emission); I/O is a non-factor next to the simulator's per-step work.
- 4 Fridays balances recovery granularity (lose at most ~4 weeks of work on a crash) vs. avoiding emission spam in fast scenarios (a 6-month smoke scenario emits ~6 checkpoints).

This is the default, not the only option — operators can override with any positive integer.

The contrast with PR #820's `backtest_runner.exe`, which kept emission opt-in (`None` default), is deliberate: `backtest_runner.exe`'s primary use case is single-scenario fast/instrumented runs and the trace-style flags (`--trace`, `--gc-trace`) all default off. `scenario_runner.exe`'s primary use case is the multi-hour batch where progress visibility is the operator's actual ask.

## What's NOT in this PR

- Auto-resumability (`--resume-from progress.sexp`) — same scope-out as PR #820 §"Open question 4". The progress checkpoint is read-only progress info; restartability of simulator state is a follow-up.
- Backwards-compat for the `actual.sexp` field-shape changes from earlier PRs — out of scope.

## Files

- New:
  - `trading/trading/backtest/scenarios/scenario_progress.{ml,mli}`
  - `trading/trading/backtest/scenarios/test/test_scenario_progress.ml`
- Extended: `scenario_runner.ml`, `scenarios/dune` (added `scenario_progress` module + `backtest` dep on `scenario_lib`), `scenarios/test/dune` (added new test module).

Total: ~264 insertions / 24 deletions across 6 files (well within budget).

## Test plan

- [x] `dune build` green from `/workspaces/trading-1/trading/`.
- [x] `dune runtest` green (full suite, no regressions).
- [x] `dune build @fmt` produces no diffs in the touched files (other in-repo format drift was pre-existing and intentionally left alone).
- [x] New test `test_scenario_progress.ml` pins:
  - `default_every_n_fridays = 4` (regression guard against silent default flips).
  - `make_emitter`'s `on_progress` writes to `<scenario_dir>/progress.sexp` (path-convention pin).
  - Recording-emitter substitute fires more than once on the smoke scenario via `Runner.run_backtest` with `every_n_fridays = 1` (end-to-end integration pin).

## Acceptance criteria from dispatch

- [x] `scenario_runner.exe` gains `--progress-every N` flag.
- [x] Default value is 4 Friday cycles when omitted (NOT disabled).
- [x] Per-scenario `progress.sexp` lands under each scenario's output directory.
- [x] `dune build && dune runtest` green.
- [x] Test pinning that the flag is correctly threaded.
- [x] LOC delta ~240 net new (under 300; the soft 200-target is exceeded only by the test file's documentation comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
