### PR TITLE
refactor(snapshot): F.3.c — Panel_callbacks snapshot-views port

### DIFF
--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
@@ -17,6 +17,8 @@
 
 open Core
 module Bar_panels = Data_panel.Bar_panels
+module Snapshot_bar_views = Snapshot_runtime.Snapshot_bar_views
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
 
 (* ------------------------------------------------------------------ *)
 (* Helpers shared by all constructors                                   *)
@@ -345,3 +347,93 @@ let support_floor_callbacks_of_daily_view (view : Bar_panels.daily_view) :
         else Some view.dates.(n - 1 - day_offset));
     n_days = n;
   }
+
+(* ------------------------------------------------------------------ *)
+(* Snapshot-views constructors (Phase F.3.c)                            *)
+(* ------------------------------------------------------------------ *)
+(* Parallel constructors that take a {!Snapshot_callbacks.t} and fetch
+   the underlying bar view via {!Snapshot_bar_views.weekly_view_for} /
+   [daily_view_for] before delegating to the corresponding
+   [*_of_*_view] constructor above. The fetched [Snapshot_bar_views]
+   view types are type-equal to {!Bar_panels.weekly_view} /
+   [daily_view] (declared via [type =] in [snapshot_bar_views.mli]),
+   so the delegation requires no per-call adapter. Output is
+   bit-identical to the panel-backed path on the same underlying bar
+   history (parity test:
+   {!Test_panel_callbacks.Test_snapshot_parity}).
+
+   Phase F.3 plan: callers migrate from
+   [Bar_reader.weekly_view_for ... |> Panel_callbacks.X_of_weekly_view]
+   to [Panel_callbacks.X_of_snapshot_views ~cb ~symbol ~n ~as_of],
+   which folds the view fetch into the callback construction. After
+   every caller migrates, the [*_of_*_view] constructors above can be
+   removed in F.3 deletion. *)
+
+let stage_callbacks_of_snapshot_views ?ma_cache ~(config : Stage.config)
+    ~(cb : Snapshot_callbacks.t) ~symbol ~n ~as_of () : Stage.callbacks =
+  let weekly = Snapshot_bar_views.weekly_view_for cb ~symbol ~n ~as_of in
+  stage_callbacks_of_weekly_view ?ma_cache ~symbol ~config ~weekly ()
+
+let rs_callbacks_of_snapshot_views ~(cb : Snapshot_callbacks.t) ~stock_symbol
+    ~benchmark_symbol ~n ~as_of : Rs.callbacks =
+  let stock =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:stock_symbol ~n ~as_of
+  in
+  let benchmark =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:benchmark_symbol ~n ~as_of
+  in
+  rs_callbacks_of_weekly_views ~stock ~benchmark
+
+let volume_callbacks_of_snapshot_views ~(cb : Snapshot_callbacks.t) ~symbol ~n
+    ~as_of : Volume.callbacks =
+  let weekly = Snapshot_bar_views.weekly_view_for cb ~symbol ~n ~as_of in
+  volume_callbacks_of_weekly_view ~weekly
+
+let resistance_callbacks_of_snapshot_views ~(cb : Snapshot_callbacks.t) ~symbol
+    ~n ~as_of : Resistance.callbacks =
+  let weekly = Snapshot_bar_views.weekly_view_for cb ~symbol ~n ~as_of in
+  resistance_callbacks_of_weekly_view ~weekly
+
+let stock_analysis_callbacks_of_snapshot_views ?ma_cache
+    ~(config : Stock_analysis.config) ~(cb : Snapshot_callbacks.t) ~stock_symbol
+    ~benchmark_symbol ~n ~as_of () : Stock_analysis.callbacks =
+  let stock =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:stock_symbol ~n ~as_of
+  in
+  let benchmark =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:benchmark_symbol ~n ~as_of
+  in
+  stock_analysis_callbacks_of_weekly_views ?ma_cache ~stock_symbol ~config
+    ~stock ~benchmark ()
+
+let sector_callbacks_of_snapshot_views ?ma_cache ~(config : Sector.config)
+    ~(cb : Snapshot_callbacks.t) ~sector_symbol ~benchmark_symbol ~n ~as_of () :
+    Sector.callbacks =
+  let sector =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:sector_symbol ~n ~as_of
+  in
+  let benchmark =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:benchmark_symbol ~n ~as_of
+  in
+  sector_callbacks_of_weekly_views ?ma_cache ~sector_symbol ~config ~sector
+    ~benchmark ()
+
+let macro_callbacks_of_snapshot_views ?ma_cache ~(config : Macro.config)
+    ~(cb : Snapshot_callbacks.t) ~index_symbol
+    ~(globals : (string * string) list) ~(ad_bars : Macro.ad_bar list) ~n ~as_of
+    () : Macro.callbacks =
+  let index =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:index_symbol ~n ~as_of
+  in
+  let global_views =
+    List.filter_map globals ~f:(fun (label, symbol) ->
+        let view = Snapshot_bar_views.weekly_view_for cb ~symbol ~n ~as_of in
+        if view.n = 0 then None else Some (label, view))
+  in
+  macro_callbacks_of_weekly_views ?ma_cache ~index_symbol ~config ~index
+    ~globals:global_views ~ad_bars ()
+
+let support_floor_callbacks_of_snapshot_views ~(cb : Snapshot_callbacks.t)
+    ~symbol ~as_of ~lookback : Weinstein_stops.callbacks =
+  let view = Snapshot_bar_views.daily_view_for cb ~symbol ~as_of ~lookback in
+  support_floor_callbacks_of_daily_view view

--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.mli
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.mli
@@ -127,3 +127,138 @@ val support_floor_callbacks_of_daily_view :
     mirroring the convention of {!Support_floor.callbacks_from_bars}.
 
     Returns [None]-yielding callbacks (with [n_days = 0]) for empty views. *)
+
+(** {1 Snapshot-views constructors (Phase F.3.c)}
+
+    Parallel constructors that take a {!Snapshot_runtime.Snapshot_callbacks.t}
+    and the symbol / window the underlying bar view should cover, fetching the
+    view via {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for} /
+    {!Snapshot_runtime.Snapshot_bar_views.daily_view_for} before delegating to
+    the panel-shaped constructors above.
+
+    The fetched view types are type-equal to
+    {!Data_panel.Bar_panels.weekly_view} / {!Data_panel.Bar_panels.daily_view}
+    (declared via [type =] in [snapshot_bar_views.mli]), so the delegation
+    requires no per-call adapter and the output is bit-identical to the
+    panel-backed path on the same underlying bar history (parity test:
+    [Test_panel_callbacks.Test_snapshot_parity]).
+
+    Phase F.3 plan: callers migrate from
+    [Bar_reader.weekly_view_for ... |> Panel_callbacks.X_of_weekly_view] to
+    [Panel_callbacks.X_of_snapshot_views ~cb ~symbol ~n ~as_of], which folds the
+    view fetch into the callback construction. After every caller migrates, the
+    [*_of_*_view] constructors above can be removed alongside
+    {!Data_panel.Bar_panels} in the F.3 deletion PR. *)
+
+val stage_callbacks_of_snapshot_views :
+  ?ma_cache:Weekly_ma_cache.t ->
+  config:Stage.config ->
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  symbol:string ->
+  n:int ->
+  as_of:Core.Date.t ->
+  unit ->
+  Stage.callbacks
+(** [stage_callbacks_of_snapshot_views ?ma_cache ~config ~cb ~symbol ~n ~as_of
+     ()] fetches a weekly view for [symbol] over the most recent [n] weekly
+    buckets ending on or before [as_of] via
+    {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for}, then delegates to
+    {!stage_callbacks_of_weekly_view}. [symbol] doubles as the cache key when
+    [ma_cache] is supplied (matching the panel-backed
+    [stage_callbacks_of_weekly_view ~symbol] convention). *)
+
+val rs_callbacks_of_snapshot_views :
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  stock_symbol:string ->
+  benchmark_symbol:string ->
+  n:int ->
+  as_of:Core.Date.t ->
+  Rs.callbacks
+(** [rs_callbacks_of_snapshot_views ~cb ~stock_symbol ~benchmark_symbol ~n
+     ~as_of] fetches weekly views for both symbols (same [n] / [as_of] window
+    via {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for}) and delegates to
+    {!rs_callbacks_of_weekly_views}. The date-aligned join inside the delegate
+    handles asymmetric calendar coverage between the two symbols. *)
+
+val volume_callbacks_of_snapshot_views :
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  symbol:string ->
+  n:int ->
+  as_of:Core.Date.t ->
+  Volume.callbacks
+(** [volume_callbacks_of_snapshot_views ~cb ~symbol ~n ~as_of] fetches the
+    weekly view for [symbol] and delegates to
+    {!volume_callbacks_of_weekly_view}. *)
+
+val resistance_callbacks_of_snapshot_views :
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  symbol:string ->
+  n:int ->
+  as_of:Core.Date.t ->
+  Resistance.callbacks
+(** [resistance_callbacks_of_snapshot_views ~cb ~symbol ~n ~as_of] fetches the
+    weekly view for [symbol] and delegates to
+    {!resistance_callbacks_of_weekly_view}. *)
+
+val stock_analysis_callbacks_of_snapshot_views :
+  ?ma_cache:Weekly_ma_cache.t ->
+  config:Stock_analysis.config ->
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  stock_symbol:string ->
+  benchmark_symbol:string ->
+  n:int ->
+  as_of:Core.Date.t ->
+  unit ->
+  Stock_analysis.callbacks
+(** [stock_analysis_callbacks_of_snapshot_views ?ma_cache ~config ~cb
+     ~stock_symbol ~benchmark_symbol ~n ~as_of ()] fetches both weekly views
+    (same [n] / [as_of] window) and delegates to
+    {!stock_analysis_callbacks_of_weekly_views}. [stock_symbol] doubles as the
+    cache key when [ma_cache] is supplied. *)
+
+val sector_callbacks_of_snapshot_views :
+  ?ma_cache:Weekly_ma_cache.t ->
+  config:Sector.config ->
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  sector_symbol:string ->
+  benchmark_symbol:string ->
+  n:int ->
+  as_of:Core.Date.t ->
+  unit ->
+  Sector.callbacks
+(** [sector_callbacks_of_snapshot_views ?ma_cache ~config ~cb ~sector_symbol
+     ~benchmark_symbol ~n ~as_of ()] fetches both weekly views (same [n] /
+    [as_of] window) and delegates to {!sector_callbacks_of_weekly_views}.
+    [sector_symbol] doubles as the cache key when [ma_cache] is supplied. *)
+
+val macro_callbacks_of_snapshot_views :
+  ?ma_cache:Weekly_ma_cache.t ->
+  config:Macro.config ->
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  index_symbol:string ->
+  globals:(string * string) list ->
+  ad_bars:Macro.ad_bar list ->
+  n:int ->
+  as_of:Core.Date.t ->
+  unit ->
+  Macro.callbacks
+(** [macro_callbacks_of_snapshot_views ?ma_cache ~config ~cb ~index_symbol
+     ~globals ~ad_bars ~n ~as_of ()] fetches the primary index weekly view plus
+    one weekly view per [(label, symbol)] entry in [globals] (same [n] / [as_of]
+    window), filters out empty global views (matching
+    {!Macro_inputs.build_global_index_views}'s [view.n = 0] short-circuit), and
+    delegates to {!macro_callbacks_of_weekly_views}. [index_symbol] doubles as
+    the cache key for the index Stage callback when [ma_cache] is supplied;
+    global Stage callbacks remain uncached (matching the panel-backed path). *)
+
+val support_floor_callbacks_of_snapshot_views :
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  symbol:string ->
+  as_of:Core.Date.t ->
+  lookback:int ->
+  Weinstein_stops.callbacks
+(** [support_floor_callbacks_of_snapshot_views ~cb ~symbol ~as_of ~lookback]
+    fetches a daily view for [symbol] over the most recent [lookback] daily bars
+    ending on or before [as_of] via
+    {!Snapshot_runtime.Snapshot_bar_views.daily_view_for}, then delegates to
+    {!support_floor_callbacks_of_daily_view}. *)

--- a/trading/trading/weinstein/strategy/test/test_panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/test/test_panel_callbacks.ml
@@ -533,6 +533,221 @@ let test_stage_callbacks_parity_with_cache _ =
            (equal_to inline_result.above_ma_count);
        ])
 
+(* ------------------------------------------------------------------ *)
+(* Snapshot-views parity (Phase F.3.c)                                  *)
+(* ------------------------------------------------------------------ *)
+(* Pin that {!Panel_callbacks.X_of_snapshot_views} produces bit-equal
+   callee-analysis output to {!Panel_callbacks.X_of_*_view} on the same
+   underlying bar history. The legacy [_of_*_view] constructors take a
+   pre-built {!Bar_panels.weekly_view} / [daily_view]; the new
+   [_of_snapshot_views] constructors take a {!Snapshot_callbacks.t}
+   plus the symbol / window the view should cover and fetch via
+   {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for} /
+   [daily_view_for]. The view types are type-equal (declared via [type =]
+   in [snapshot_bar_views.mli]), so the delegation requires no per-call
+   adapter and the output is bit-identical. *)
+
+module Pipeline = Snapshot_pipeline.Pipeline
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+
+(* Mirror of {!Test_weekly_ma_cache._build_snapshot_callbacks}: build a
+   {!Snapshot_callbacks.t} from in-memory [(symbol, bars)] pairs by
+   materialising a tmp snapshot directory under
+   {!Snapshot_schema.default}. Same setup as {!Bar_reader.of_in_memory_bars}
+   but exposes the {!Snapshot_callbacks.t} directly so the parity tests
+   can also drive {!Bar_panels.weekly_view_for} from the same input. *)
+let _build_snapshot_callbacks
+    (symbol_bars : (string * Types.Daily_price.t list) list) :
+    Snapshot_callbacks.t =
+  let dir = Stdlib.Filename.temp_dir "test_panel_callbacks_" "" in
+  let entries =
+    List.map symbol_bars ~f:(fun (symbol, bars) ->
+        let rows =
+          match
+            Pipeline.build_for_symbol ~symbol ~bars
+              ~schema:Snapshot_schema.default ()
+          with
+          | Ok rs -> rs
+          | Error err ->
+              failwithf "Pipeline.build_for_symbol %s: %s" symbol
+                err.Status.message ()
+        in
+        let path = Filename.concat dir (symbol ^ ".snap") in
+        (match Snapshot_format.write ~path rows with
+        | Ok () -> ()
+        | Error err ->
+            failwithf "Snapshot_format.write %s: %s" symbol err.Status.message
+              ());
+        {
+          Snapshot_manifest.symbol;
+          path;
+          byte_size = 0;
+          payload_md5 = "ignored";
+          csv_mtime = 0.0;
+        })
+  in
+  let manifest =
+    Snapshot_manifest.create ~schema:Snapshot_schema.default ~entries
+  in
+  let manifest_path = Filename.concat dir "manifest.sexp" in
+  (match Snapshot_manifest.write ~path:manifest_path manifest with
+  | Ok () -> ()
+  | Error err -> failwithf "Snapshot_manifest.write: %s" err.Status.message ());
+  let panels =
+    match Daily_panels.create ~snapshot_dir:dir ~manifest ~max_cache_mb:16 with
+    | Ok p -> p
+    | Error err -> failwithf "Daily_panels.create: %s" err.Status.message ()
+  in
+  Snapshot_callbacks.of_daily_panels panels
+
+(* Stage parity (snapshot vs panel): same 60-bar fixture as the bar-list
+   parity test, run through {!Stage.classify_with_callbacks} via both
+   constructors. *)
+let test_stage_snapshot_parity _ =
+  let bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:100.0 ~step:0.5
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let panel_view =
+    Bar_panels.weekly_view_for panels ~symbol:"AAPL" ~n:60
+      ~as_of_day:(Bar_panels.n_days panels - 1)
+  in
+  let cb = _build_snapshot_callbacks [ ("AAPL", bars) ] in
+  let as_of = (List.last_exn bars).Types.Daily_price.date in
+  let config = Stage.default_config in
+  let panel_cbs =
+    Panel_callbacks.stage_callbacks_of_weekly_view ~config ~weekly:panel_view ()
+  in
+  let snap_cbs =
+    Panel_callbacks.stage_callbacks_of_snapshot_views ~config ~cb ~symbol:"AAPL"
+      ~n:60 ~as_of ()
+  in
+  let panel_result =
+    Stage.classify_with_callbacks ~config ~get_ma:panel_cbs.get_ma
+      ~get_close:panel_cbs.get_close ~prior_stage:None
+  in
+  let snap_result =
+    Stage.classify_with_callbacks ~config ~get_ma:snap_cbs.get_ma
+      ~get_close:snap_cbs.get_close ~prior_stage:None
+  in
+  assert_that snap_result
+    (all_of
+       [
+         field
+           (fun (r : Stage.result) -> r.ma_value)
+           (float_equal panel_result.ma_value);
+         field
+           (fun (r : Stage.result) -> r.ma_slope_pct)
+           (float_equal panel_result.ma_slope_pct);
+         field
+           (fun (r : Stage.result) -> r.above_ma_count)
+           (equal_to panel_result.above_ma_count);
+       ])
+
+(* Support_floor parity (snapshot vs panel): daily lookback over a
+   rally-then-pullback fixture; the daily_view fetch is the load-bearing
+   path for the daily_view-based snapshot constructor (the only daily
+   constructor; every other [_of_snapshot_views] uses [weekly_view_for]
+   which is exercised by {!test_stage_snapshot_parity}). *)
+let test_support_floor_snapshot_parity _ =
+  let dates =
+    List.init 30 ~f:(fun i -> Date.add_days (Date.of_string "2024-01-02") i)
+  in
+  let bars =
+    List.mapi dates ~f:(fun i date ->
+        let price =
+          if i < 20 then 100.0 +. (Float.of_int i *. 1.0)
+          else 120.0 -. (Float.of_int (i - 20) *. 0.5)
+        in
+        {
+          Types.Daily_price.date;
+          open_price = price;
+          high_price = price *. 1.01;
+          low_price = price *. 0.99;
+          close_price = price;
+          adjusted_close = price;
+          volume = 100_000;
+        })
+  in
+  let panels = panels_of_symbols [ ("AAPL", bars) ] in
+  let as_of_day = Bar_panels.n_days panels - 1 in
+  let panel_view =
+    Bar_panels.daily_view_for panels ~symbol:"AAPL" ~as_of_day ~lookback:30
+  in
+  let cb = _build_snapshot_callbacks [ ("AAPL", bars) ] in
+  let as_of = (List.last_exn bars).Types.Daily_price.date in
+  let panel_cbs =
+    Panel_callbacks.support_floor_callbacks_of_daily_view panel_view
+  in
+  let snap_cbs =
+    Panel_callbacks.support_floor_callbacks_of_snapshot_views ~cb ~symbol:"AAPL"
+      ~as_of ~lookback:30
+  in
+  let panel_result =
+    Weinstein_stops.Support_floor.find_recent_level_with_callbacks
+      ~callbacks:panel_cbs ~side:Trading_base.Types.Long ~min_pullback_pct:0.05
+  in
+  let snap_result =
+    Weinstein_stops.Support_floor.find_recent_level_with_callbacks
+      ~callbacks:snap_cbs ~side:Trading_base.Types.Long ~min_pullback_pct:0.05
+  in
+  match (panel_result, snap_result) with
+  | None, None -> ()
+  | Some r1, Some r2 -> assert_that r2 (float_equal r1)
+  | Some r, None ->
+      assert_failure
+        (Printf.sprintf "snapshot returned None; panel returned Some %f" r)
+  | None, Some r ->
+      assert_failure
+        (Printf.sprintf "panel returned None; snapshot returned Some %f" r)
+
+(* Edge case: macro globals filter — one valid + one missing symbol
+   in the [globals] list. The snapshot constructor's [filter_map] over
+   empty views must drop the missing entry and pass only the valid one
+   through to {!macro_callbacks_of_weekly_views}, matching
+   {!Macro_inputs.build_global_index_views}'s [view.n = 0] short-circuit. *)
+let test_macro_snapshot_globals_filter_missing _ =
+  let index_bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:4000.0 ~step:5.0
+  in
+  let global_bars =
+    make_friday_bars
+      ~start_friday:(Date.of_string "2024-01-05")
+      ~n:60 ~start_price:15000.0 ~step:2.0
+  in
+  let cb =
+    _build_snapshot_callbacks [ ("SPY", index_bars); ("GDAXI", global_bars) ]
+  in
+  let as_of = (List.last_exn index_bars).Types.Daily_price.date in
+  let ad_bars =
+    List.init 60 ~f:(fun i ->
+        {
+          Macro.date = Date.add_days (Date.of_string "2024-01-05") (i * 7);
+          advancing = 1500 + i;
+          declining = 1500 - i;
+        })
+  in
+  let config = Macro.default_config in
+  let snap_cbs =
+    Panel_callbacks.macro_callbacks_of_snapshot_views ~config ~cb
+      ~index_symbol:"SPY"
+      ~globals:[ ("DAX", "GDAXI"); ("MISSING", "MISSING_SYMBOL") ]
+      ~ad_bars ~n:60 ~as_of ()
+  in
+  (* Only DAX should be present in [global_index_stages]; MISSING is
+     filtered out at view-fetch time. *)
+  assert_that
+    (List.map snap_cbs.global_index_stages ~f:fst)
+    (elements_are [ equal_to "DAX" ])
+
 let suite =
   "Panel_callbacks parity"
   >::: [
@@ -547,6 +762,10 @@ let suite =
          >:: test_support_floor_callbacks_parity;
          "Volume parity" >:: test_volume_callbacks_parity;
          "Resistance parity" >:: test_resistance_callbacks_parity;
+         "Snapshot Stage parity" >:: test_stage_snapshot_parity;
+         "Snapshot Support_floor parity" >:: test_support_floor_snapshot_parity;
+         "Snapshot Macro globals filter missing"
+         >:: test_macro_snapshot_globals_filter_missing;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Phase F.3.c of the daily-snapshot streaming pipeline. Adds parallel
`Panel_callbacks.*_of_snapshot_views` constructors alongside the legacy
`*_of_*_view` constructors, with parity tests pinning that the
snapshot-backed path produces bit-equal callee-analysis output to the
panel-backed path on a known fixture.

This is the third of four consumer ports tracked in
`dev/plans/snapshot-engine-phase-f-2026-05-03.md` §F.3 (after F.3.a
Bar_reader via #825/#827/#828/#829, and F.3.b-1 Weekly_ma_cache via #833).

## What

Eight new parallel constructors in `Panel_callbacks` — one per existing
`*_of_*_view` constructor:

- `stage_callbacks_of_snapshot_views`
- `rs_callbacks_of_snapshot_views`
- `volume_callbacks_of_snapshot_views`
- `resistance_callbacks_of_snapshot_views`
- `stock_analysis_callbacks_of_snapshot_views`
- `sector_callbacks_of_snapshot_views`
- `macro_callbacks_of_snapshot_views`
- `support_floor_callbacks_of_snapshot_views`

Each new constructor takes a `Snapshot_runtime.Snapshot_callbacks.t` and
the symbol / `n` / `as_of` window the underlying bar view should cover,
fetches the view via `Snapshot_runtime.Snapshot_bar_views.weekly_view_for`
or `daily_view_for`, then delegates to the existing `*_of_*_view`
constructor. The fetched view types are type-equal to
`Bar_panels.weekly_view` / `daily_view` (declared via `type =` in
`snapshot_bar_views.mli`), so the delegation requires no per-call
adapter; output is bit-identical to the panel-backed path on the same
underlying bar history.

## Why

Phase F.3 retires `Bar_panels.t` from the strategy hot path. Today
callers fetch views via `Bar_reader.weekly_view_for` (snapshot-backed
already, post F.3.a-4) and pass them to `Panel_callbacks.X_of_*_view`
which still references `Bar_panels.weekly_view` / `daily_view` types.
The new `*_of_snapshot_views` constructors fold the view fetch into the
callback construction so callers can migrate from the two-step pattern
to a single call that takes `Snapshot_callbacks.t` directly. After every
caller migrates (subsequent F.3.c-N PRs), the legacy `*_of_*_view`
constructors can be removed alongside `Bar_panels` in the F.3 deletion
PR.

The staged pattern matches F.3.b-1: parallel constructor first, then
caller migration in follow-up PRs.

## Test plan

- [x] `dune build` green
- [x] `dune runtest trading/weinstein/strategy/test` green; new tests:
  - `Snapshot Stage parity` — load-bearing weekly path, full
    `Stage.classify_with_callbacks` round-trip
  - `Snapshot Support_floor parity` — only daily path, full
    `find_recent_level_with_callbacks` round-trip
  - `Snapshot Macro globals filter missing` — pins that the constructor
    drops `(label, missing_symbol)` entries (matching
    `Macro_inputs.build_global_index_views`'s `view.n = 0`
    short-circuit)
- [x] `dune build @fmt` clean for both touched files
- [x] LOC: 446 lines (.ml +92 / .mli +135 / test +219), under the 500
  cap. Mirrors F.3.b-1's 273-line shape with the larger constructor
  surface (8 vs 1)

The other 6 constructors (`rs`, `volume`, `resistance`, `stock_analysis`,
`sector`, `macro`) are pure 3-5 LOC delegations exercising the same
`weekly_view_for` fetch path that `stage_callbacks_of_snapshot_views`
covers; their parity follows by construction. If any future caller
migration reveals a divergence, a targeted parity test is cheap to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
