### PR TITLE
harness: agent prompts use jj workspace add for true isolation

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -14,6 +14,38 @@ sections. Do not omit required sections — the health-scanner checks for their 
 
 ## Required sections (every feat-agent must have all of these)
 
+### 0. Pre-Work Setup (required boilerplate — runs before any file reads)
+
+Every feat-agent (and harness-maintainer / ops-data) must include this block
+verbatim near the top. It creates an isolated jj workspace so concurrent agents
+don't race the shared `op_heads` / default `WorkspaceName`.
+See `.claude/rules/worktree-isolation.md` §"jj workspace isolation" for the
+root-cause explanation.
+
+```markdown
+## Pre-Work Setup
+
+**Skip this section if `$TRADING_IN_CONTAINER` is set** (GHA runs use plain git,
+no jj — this step is jj-local only).
+
+Before reading any file or writing any code, create an isolated jj workspace:
+
+```bash
+AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
+AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
+cd "$AGENT_WS"
+# Verify: @ should be an empty commit on top of main@origin
+jj log -n 1 -r @
+```
+
+After the session, clean up from the repo root:
+```bash
+jj workspace forget "$AGENT_ID"
+rm -rf "$AGENT_WS"
+```
+```
+
 ### 1. Frontmatter
 
 ```yaml

--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -35,6 +35,30 @@ in this order:
   3. `tuning.md` T-A grid_search (smallest unblock, ~400 LOC)
   4. `backtest-infra.md` / `backtest-scale.md` if any open items remain
 
+## Pre-Work Setup
+
+**Skip this section if `$TRADING_IN_CONTAINER` is set** (GHA runs use plain git,
+no jj — this step is jj-local only).
+
+Before reading any file or writing any code, create an isolated jj workspace:
+
+```bash
+AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
+AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
+cd "$AGENT_WS"
+# Verify: @ should be an empty commit on top of main@origin
+jj log -n 1 -r @
+```
+
+After the session, clean up from the repo root:
+```bash
+jj workspace forget "$AGENT_ID"
+rm -rf "$AGENT_WS"
+```
+
+See `.claude/rules/worktree-isolation.md` §"jj workspace isolation" for why this is needed.
+
 ## At the start of every session
 
 1. Read `dev/agent-feature-workflow.md` — shared workflow, commit discipline

--- a/.claude/agents/feat-data.md
+++ b/.claude/agents/feat-data.md
@@ -36,6 +36,30 @@ Distinct from:
   client wrapper) the feature work belongs here; if a one-off fetch
   needs running, that's `ops-data`.
 
+## Pre-Work Setup
+
+**Skip this section if `$TRADING_IN_CONTAINER` is set** (GHA runs use plain git,
+no jj — this step is jj-local only).
+
+Before reading any file or writing any code, create an isolated jj workspace:
+
+```bash
+AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
+AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
+cd "$AGENT_WS"
+# Verify: @ should be an empty commit on top of main@origin
+jj log -n 1 -r @
+```
+
+After the session, clean up from the repo root:
+```bash
+jj workspace forget "$AGENT_ID"
+rm -rf "$AGENT_WS"
+```
+
+See `.claude/rules/worktree-isolation.md` §"jj workspace isolation" for why this is needed.
+
 ## At the start of every session
 
 1. Read `dev/agent-feature-workflow.md` — shared workflow, commit discipline

--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -17,6 +17,30 @@ Older scope retained as historical note:
 
 **support-floor-based stops** (MERGED via PRs #382 + #390 in 2026-04-17). Current items are G14 + G15 above.
 
+## Pre-Work Setup
+
+**Skip this section if `$TRADING_IN_CONTAINER` is set** (GHA runs use plain git,
+no jj — this step is jj-local only).
+
+Before reading any file or writing any code, create an isolated jj workspace:
+
+```bash
+AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
+AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
+cd "$AGENT_WS"
+# Verify: @ should be an empty commit on top of main@origin
+jj log -n 1 -r @
+```
+
+After the session, clean up from the repo root:
+```bash
+jj workspace forget "$AGENT_ID"
+rm -rf "$AGENT_WS"
+```
+
+See `.claude/rules/worktree-isolation.md` §"jj workspace isolation" for why this is needed.
+
 ## At the start of every session
 
 1. Read `dev/agent-feature-workflow.md` — shared workflow, commit discipline, session procedures

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -7,6 +7,30 @@ harness: reusable
 
 You are the harness maintainer for the Weinstein Trading System. Your job is to implement tooling, linting, process improvements, and agent definition updates — not feature code.
 
+## Pre-Work Setup
+
+**Skip this section if `$TRADING_IN_CONTAINER` is set** (GHA runs use plain git,
+no jj — this step is jj-local only).
+
+Before reading any file or writing any code, create an isolated jj workspace:
+
+```bash
+AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
+AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
+cd "$AGENT_WS"
+# Verify: @ should be an empty commit on top of main@origin
+jj log -n 1 -r @
+```
+
+After the session, clean up from the repo root:
+```bash
+jj workspace forget "$AGENT_ID"
+rm -rf "$AGENT_WS"
+```
+
+See `.claude/rules/worktree-isolation.md` §"jj workspace isolation" for why this is needed.
+
 ## At the start of every session
 
 1. Read `dev/status/harness.md` — your backlog; identify the highest-priority open item

--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -9,6 +9,30 @@ You are the data operations agent for the Weinstein Trading System. You fetch ma
 
 You own the full data infrastructure stack: if a required data source lacks a parser or fetch script, write it. Data infrastructure code (parsers, fetch scripts, inventory tools) is within your scope. Feature code (screener, stops, simulation, strategy) is not.
 
+## Pre-Work Setup
+
+**Skip this section if `$TRADING_IN_CONTAINER` is set** (GHA runs use plain git,
+no jj — this step is jj-local only).
+
+Before reading any file or writing any code, create an isolated jj workspace:
+
+```bash
+AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
+AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
+cd "$AGENT_WS"
+# Verify: @ should be an empty commit on top of main@origin
+jj log -n 1 -r @
+```
+
+After the session, clean up from the repo root:
+```bash
+jj workspace forget "$AGENT_ID"
+rm -rf "$AGENT_WS"
+```
+
+See `.claude/rules/worktree-isolation.md` §"jj workspace isolation" for why this is needed.
+
 ## At the start of every session
 
 1. Read your invocation to understand what's needed (symbols to fetch, coverage check, inventory refresh, etc.)

--- a/.claude/rules/worktree-isolation.md
+++ b/.claude/rules/worktree-isolation.md
@@ -84,6 +84,57 @@ force-push — do not hand off a contaminated PR for review.
 - Git-mode dispatch inside `$TRADING_IN_CONTAINER` (GHA) — CI runners start
   from a fresh checkout, so contamination doesn't occur there.
 
+## jj workspace isolation
+
+The pre-commit / pre-push scrubbing above treats symptoms. The root cause is
+that Claude Code's `isolation: "worktree"` creates **git worktrees** (via
+`git worktree add`) — not jj workspaces. All git-worktree dirs share the same
+`.jj/repo/` backend (one `op_heads`, one shared view) and all default to
+`WorkspaceName = "default"`, so concurrent agents race the same `@` slot.
+Per the jj docs ([Git compatibility](https://docs.jj-vcs.dev/latest/git-compatibility/)),
+running jj inside a `git worktree add` directory with shared `.jj/` is
+**explicitly unsupported**.
+
+**Fix: every jj-writing agent should call `jj workspace add` as its first
+step, before reading any status file or making any edit.** This gives each
+agent a distinct `WorkspaceName` and an independent `@` slot, and op-merging
+between workspaces is well-defined per the
+[jj concurrency docs](https://docs.jj-vcs.dev/latest/technical/concurrency/).
+
+Standard boilerplate for every feat-* / harness-maintainer / ops-data agent:
+
+```bash
+# === Pre-work: create isolated jj workspace ===
+# Claude Code's isolation:"worktree" creates a git-worktree, NOT a jj-workspace.
+# Without this step, concurrent agents race the shared op_heads / default WorkspaceName.
+# See .claude/rules/worktree-isolation.md §"jj workspace isolation".
+
+AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
+AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
+cd "$AGENT_WS"
+
+# Verify isolation: the new workspace's @ should be off main@origin
+jj log -n 1 -r @
+```
+
+**After work is complete, clean up:**
+
+```bash
+# From the repo root (not inside AGENT_WS):
+jj workspace forget "$AGENT_ID"
+rm -rf "$AGENT_WS"
+```
+
+**Notes:**
+- `$AGENT_WS` is under `/tmp/` — outside the repo — so it cannot contaminate
+  the parent worktree's git index.
+- The `-r main@origin` flag ensures the new `@` starts from main, not from
+  whatever `@` the parent had at dispatch time.
+- This fix applies to local jj runs only. GHA runs use `$TRADING_IN_CONTAINER`
+  mode (plain git, no jj) and are unaffected.
+- Reference: `memory/project_jj_worktree_root_cause.md` (root cause writeup).
+
 ## Cleanup
 
 Stale `agent-*` worktrees accumulate in `.claude/worktrees/` after each session

--- a/dev/status/harness.md
+++ b/dev/status/harness.md
@@ -1,6 +1,6 @@
 # Status: harness
 
-## Last updated: 2026-05-03
+## Last updated: 2026-05-04
 
 ## Status
 IN_PROGRESS
@@ -169,6 +169,8 @@ Items surfaced in daily summaries but not yet scheduled as T1–T4 items.
   Source: `dev/daily/2026-04-14.md` end-of-day audit.
 - ~~**POSIX shell portability linter**~~ — DONE (harness/posix-sh-linter): `trading/devtools/checks/posix_sh_check.sh` runs `dash -n` over all #!/bin/sh scripts in `trading/devtools/checks/`, `trading/devtools/checks/deep_scan/`, and `dev/lib/`. Scripts with `#!/usr/bin/env bash` shebang are exempt. Smoke test: `trading/devtools/checks/posix_sh_check_test.sh`. Wired into `dune runtest`. Verify: `dune runtest devtools/checks/` — prints `OK: posix-sh linter -- N scripts clean.` Pre-existing violations found: `dev/lib/cleanup-stale-worktrees.sh` and `dev/run.sh` use `#!/usr/bin/env bash` and are exempt (intentionally bash). Source: run-4 daily summary follow-up.
 - ~~**`cc_linter.exe` overwrites its first `.ml` argument with the JSON report**~~ — DONE (PR-#570): JSON output now requires explicit `--out <path>` flag; extra positional args after the trading-root are silently ignored and never written to. Smoke test `trading/devtools/cc_linter/test/test_no_overwrite.ml` invokes the linter with two `.ml` paths and asserts byte-equality before/after. Verify: `dune runtest devtools/cc_linter/`.
+
+- ~~**`isolation: "worktree"` creates git-worktrees, not jj-workspaces — concurrent agents race shared `op_heads` + default WorkspaceName**~~ — **DONE (PR #839, Option A).** Root cause: Claude Code's `isolation: "worktree"` uses `git worktree add`, not `jj workspace add`. All git-worktree dirs share the same `.jj/repo/` backend; they collide on `WorkspaceName = "default"` and the same `@` slot, causing file leaks and silent edit-reverts (jj issue #8929). Fix implemented: `## Pre-Work Setup` boilerplate (20 lines) added to `feat-agent-template.md`, `feat-weinstein.md`, `feat-data.md`, `feat-backtest.md`, `harness-maintainer.md`, and `ops-data.md`. Each agent now runs `jj workspace add /tmp/agent-ws-${AGENT_ID} --name ${AGENT_ID} -r main@origin && cd "$AGENT_WS"` as its first step, giving each agent a distinct `WorkspaceName` and independent `@` slot. `worktree-isolation.md` extended with §"jj workspace isolation" documenting the root cause and fix. Option B (upstream Claude Code change) remains out of scope. Option C (≤1 concurrent jj-writer) remains the conservative fallback for un-upgraded sessions. Root cause reference: `memory/project_jj_worktree_root_cause.md`. Verify: `grep -l "Pre-Work Setup" .claude/agents/*.md` should list 6 files; `grep "jj workspace isolation" .claude/rules/worktree-isolation.md` should match.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `## Pre-Work Setup` boilerplate to all 6 jj-writing agent definitions (`feat-agent-template.md`, `feat-weinstein.md`, `feat-data.md`, `feat-backtest.md`, `harness-maintainer.md`, `ops-data.md`).
- Extends `.claude/rules/worktree-isolation.md` with a new `## jj workspace isolation` section documenting the root cause and the `jj workspace add` fix.
- Updates `dev/status/harness.md` to mark Option A as DONE with this PR's number.

## Why

Claude Code's `isolation: "worktree"` creates `git worktree add` directories — not `jj workspace add` workspaces. All git-worktree dirs share the same `.jj/repo/` backend (one `op_heads`, one view) and all default to `WorkspaceName = "default"`, so concurrent agents race the same `@` slot. This causes file leaks and silent edit-reverts (jj issue #8929). Running jj inside a `git worktree add` dir with shared `.jj/` is explicitly unsupported per the jj docs.

**Fix:** each jj-writing agent now runs `jj workspace add /tmp/agent-ws-${AGENT_ID} --name ${AGENT_ID} -r main@origin` as its first step, giving each agent a distinct `WorkspaceName` and an independent `@` slot. Op-merging between workspaces is well-defined per the jj concurrency docs.

## Test plan

- Verified `jj workspace add /tmp/agent-ws-test-... --name test-... -r main@origin` creates an independent `@` slot in this session (new workspace showed in `jj workspace list`; cleanup via `jj workspace forget` + `rm -rf` confirmed clean).
- `grep -l "Pre-Work Setup" .claude/agents/*.md` returns 6 files (all jj-writing agents).
- qc-structural / qc-behavioral do NOT have Pre-Work Setup (they're read-only, no jj writes).
- `sh trading/devtools/checks/agent_compliance_check.sh` → `OK: all feat-*.md agent definitions contain required sections (checked 3).`
- No code changes; all pre-existing linter failures are on main@origin before this PR.

## Files changed

- `.claude/agents/feat-agent-template.md` — new §0 Pre-Work Setup (canonical template)
- `.claude/agents/feat-weinstein.md` — Pre-Work Setup block
- `.claude/agents/feat-data.md` — Pre-Work Setup block
- `.claude/agents/feat-backtest.md` — Pre-Work Setup block
- `.claude/agents/harness-maintainer.md` — Pre-Work Setup block
- `.claude/agents/ops-data.md` — Pre-Work Setup block
- `.claude/rules/worktree-isolation.md` — new §"jj workspace isolation"
- `dev/status/harness.md` — Option A marked DONE (PR #839)

🤖 Generated with [Claude Code](https://claude.com/claude-code)