### PR TITLE
refactor(snapshot): F.3.d — Macro_inputs snapshot-views port (staged d-1)

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -6,7 +6,7 @@
 IN_PROGRESS
 
 ## Notes
-M5.3 streaming Phases A + A.1 + B + C + D + E + F.1 all merged (#779/#786/#781/#782/#790/#791/#793); Phase B writer perf fix O(N²)→O(N) merged (#792). **F.2 default-flip COMPLETE 2026-05-03** (#797/#800/#802 — snapshot mode is now the canonical runtime path). **Wiki+EODHD PR-A/B/C/D MERGED** (#803/#808/#809/#813). **F.3.a sub-sequence COMPLETE 2026-05-04**: a-1 (#825 `Bar_reader.of_in_memory_bars`), a-2 (#827 migrate 5 strategy test files / 17 callsites), a-3 (#828 `Panel_runner` CSV path through snapshot via `Csv_snapshot_builder`), a-4 (#829 delete `Bar_reader.of_panels` + `Weinstein_strategy.make ?bar_panels`). Remaining F.3 sub-PRs: **F.3.b** port `Weekly_ma_cache` off `Bar_panels.t`; **F.3.c** port `Panel_callbacks`; **F.3.d** port `Macro_inputs`; **F.3.e** delete `bar_panels.{ml,mli}` + tests. Plus: Synth-v3; Norgate ingest (vendor-blocked). F.3 is gated on three verification follow-ups (V1 sp500 5y full-universe parity, V2 ±2w fuzz on snapshot mode, V3 numeric-key fuzz at scale paired with E3 sweep). Owner authorized: feat-data per `dev/decisions.md` 2026-05-03 §"Agent scope: extend feat-backtest + create feat-data".
+M5.3 streaming Phases A + A.1 + B + C + D + E + F.1 all merged (#779/#786/#781/#782/#790/#791/#793); Phase B writer perf fix O(N²)→O(N) merged (#792). **F.2 default-flip COMPLETE 2026-05-03** (#797/#800/#802 — snapshot mode is now the canonical runtime path). **Wiki+EODHD PR-A/B/C/D MERGED** (#803/#808/#809/#813). **F.3.a sub-sequence COMPLETE 2026-05-04**: a-1 (#825 `Bar_reader.of_in_memory_bars`), a-2 (#827 migrate 5 strategy test files / 17 callsites), a-3 (#828 `Panel_runner` CSV path through snapshot via `Csv_snapshot_builder`), a-4 (#829 delete `Bar_reader.of_panels` + `Weinstein_strategy.make ?bar_panels`). **F.3.b staged b-1 MERGED** (#833 `Weekly_ma_cache.of_snapshot_views`). **F.3.c staged c-1 MERGED** (#837 `Panel_callbacks.*_of_snapshot_views`). **F.3.d staged d-1 READY_FOR_REVIEW 2026-05-04** (#842 `Macro_inputs.*_of_snapshot_views` — 3 parallel constructors + 5 parity tests). Remaining F.3 sub-PRs: **F.3.b/c/d** caller migrations from `bar_reader`-backed → `*_of_snapshot_views` paths; **F.3.e** delete `bar_panels.{ml,mli}` + tests. Plus: Synth-v3; Norgate ingest (vendor-blocked). F.3 is gated on three verification follow-ups (V1 sp500 5y full-universe parity, V2 ±2w fuzz on snapshot mode, V3 numeric-key fuzz at scale paired with E3 sweep). Owner authorized: feat-data per `dev/decisions.md` 2026-05-03 §"Agent scope: extend feat-backtest + create feat-data".
 
 Track created 2026-05-02 to absorb M5.3 (scale infra: streaming + Norgate) + M7.0 (data foundations: Norgate, multi-market, synthetic). Plans: `dev/plans/m5-experiments-roadmap-2026-05-02.md` + `dev/plans/m7-data-and-tuning-2026-05-02.md`. Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M5.3 + M7.0 (added 2026-05-02).
 
@@ -137,6 +137,13 @@ including the V1/V2/V3 verification follow-ups that gate F.2.)
 - **#790** — Phase D: simulator wire-in behind `--snapshot-mode --snapshot-dir`.
 - **#791** — Phase E: validation + tier-4 spike (parity-7sym fixture).
 - **#793** — Phase F.1: deprecation marker on `Bar_panels.t`'s docstring.
+- **#825/#827/#828/#829** — Phase F.3.a: `Bar_reader` migrated off `Bar_panels.t` (a-1 `of_in_memory_bars`, a-2 strategy test migrations, a-3 `Panel_runner` CSV → snapshot, a-4 delete `of_panels`).
+- **#833** — Phase F.3.b staged b-1: `Weekly_ma_cache.of_snapshot_views` parallel constructor.
+- **#837** — Phase F.3.c staged c-1: `Panel_callbacks.*_of_snapshot_views` parallel constructors (8 callees).
+
+### Ready for review
+
+- **#842** — Phase F.3.d staged d-1: `Macro_inputs.*_of_snapshot_views` parallel constructors (3 functions: `build_global_index_views_of_snapshot_views`, `build_global_index_bars_of_snapshot_views`, `build_sector_map_of_snapshot_views`) + 5 parity tests pinning bit-equal output. Verify: `dune exec trading/weinstein/strategy/test/test_macro_inputs.exe`.
 
 ### Pending (M5.3 Phase F.2 + F.3 + verification gates)
 

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.ml
@@ -1,4 +1,6 @@
 open Core
+module Snapshot_bar_views = Snapshot_runtime.Snapshot_bar_views
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
 
 let spdr_sector_etfs =
   [
@@ -114,6 +116,93 @@ let build_sector_map ?ma_cache ~stage_config ~lookback_bars ~sector_etfs
         _sector_context_from_views ?ma_cache ~stage_config ~lookback_bars
           ~bar_reader ~as_of ~sector_prior_stages ~index_view ~etf_symbol
           ~sector_name ()
+      with
+      | None -> ()
+      | Some (_key, ctx) ->
+          Hashtbl.set sector_ctx_by_name ~key:sector_name ~data:ctx);
+  (* Step 2: Expand to ticker-level map using ticker_sectors. *)
+  let map = Hashtbl.create (module String) in
+  Hashtbl.iteri ticker_sectors ~f:(fun ~key:ticker ~data:sector_name ->
+      match Hashtbl.find sector_ctx_by_name sector_name with
+      | Some ctx -> Hashtbl.set map ~key:ticker ~data:ctx
+      | None -> ());
+  map
+
+(* ------------------------------------------------------------------ *)
+(* Snapshot-views constructors (Phase F.3.d)                            *)
+(* ------------------------------------------------------------------ *)
+(* Parallel constructors that take a {!Snapshot_callbacks.t} and fetch
+   the underlying bar views via {!Snapshot_bar_views.weekly_view_for} /
+   [weekly_bars_for] before delegating to the panel-shaped helpers
+   above. The fetched view types are type-equal to
+   {!Bar_panels.weekly_view} (declared via [type =] in
+   [snapshot_bar_views.mli]), so the delegation requires no per-call
+   adapter. Output is bit-identical to the [bar_reader]-backed path on
+   the same underlying bar history (parity tests:
+   {!Test_macro_inputs.Test_snapshot_parity}).
+
+   Phase F.3.d plan: callers migrate from
+   [Bar_reader.weekly_view_for ... |> Macro_inputs.X ~bar_reader]
+   to [Macro_inputs.X_of_snapshot_views ~cb], which folds the view
+   fetch into the input-assembly. After every caller migrates, the
+   [bar_reader]-backed constructors above can be removed in F.3
+   deletion. *)
+
+let build_global_index_views_of_snapshot_views ~lookback_bars
+    ~global_index_symbols ~(cb : Snapshot_callbacks.t) ~as_of =
+  List.filter_map global_index_symbols ~f:(fun (symbol, label) ->
+      let view =
+        Snapshot_bar_views.weekly_view_for cb ~symbol ~n:lookback_bars ~as_of
+      in
+      if view.n = 0 then None else Some (label, view))
+
+let build_global_index_bars_of_snapshot_views ~lookback_bars
+    ~global_index_symbols ~(cb : Snapshot_callbacks.t) ~as_of =
+  List.filter_map global_index_symbols ~f:(fun (symbol, label) ->
+      let bars =
+        Snapshot_bar_views.weekly_bars_for cb ~symbol ~n:lookback_bars ~as_of
+      in
+      if List.is_empty bars then None else Some (label, bars))
+
+(** Snapshot-views variant of {!_sector_context_from_views}: fetches the sector
+    ETF's weekly view via {!Snapshot_bar_views.weekly_view_for} instead of
+    {!Bar_reader.weekly_view_for}, then takes the same path through
+    {!Panel_callbacks.sector_callbacks_of_weekly_views} +
+    {!Sector.analyze_with_callbacks}. *)
+let _sector_context_of_snapshot_views ?ma_cache ~(stage_config : Stage.config)
+    ~lookback_bars ~(cb : Snapshot_callbacks.t) ~as_of ~sector_prior_stages
+    ~(index_view : Data_panel.Bar_panels.weekly_view) ~etf_symbol ~sector_name
+    () : (string * Screener.sector_context) option =
+  let sector_view =
+    Snapshot_bar_views.weekly_view_for cb ~symbol:etf_symbol ~n:lookback_bars
+      ~as_of
+  in
+  if sector_view.n < stage_config.ma_period then None
+  else if index_view.n = 0 then None
+  else
+    let prior_stage = Hashtbl.find sector_prior_stages etf_symbol in
+    let callbacks =
+      Panel_callbacks.sector_callbacks_of_weekly_views ?ma_cache
+        ~sector_symbol:etf_symbol ~config:Sector.default_config
+        ~sector:sector_view ~benchmark:index_view ()
+    in
+    let result =
+      Sector.analyze_with_callbacks ~config:Sector.default_config ~sector_name
+        ~callbacks ~constituent_analyses:[] ~prior_stage
+    in
+    Hashtbl.set sector_prior_stages ~key:etf_symbol ~data:result.stage.stage;
+    Some (etf_symbol, Sector.sector_context_of result)
+
+let build_sector_map_of_snapshot_views ?ma_cache ~stage_config ~lookback_bars
+    ~sector_etfs ~(cb : Snapshot_callbacks.t) ~as_of ~sector_prior_stages
+    ~index_view ~ticker_sectors () =
+  (* Step 1: Analyze each sector ETF to get sector_name -> sector_context. *)
+  let sector_ctx_by_name = Hashtbl.create (module String) in
+  List.iter sector_etfs ~f:(fun (etf_symbol, sector_name) ->
+      match
+        _sector_context_of_snapshot_views ?ma_cache ~stage_config ~lookback_bars
+          ~cb ~as_of ~sector_prior_stages ~index_view ~etf_symbol ~sector_name
+          ()
       with
       | None -> ()
       | Some (_key, ctx) ->

--- a/trading/trading/weinstein/strategy/lib/macro_inputs.mli
+++ b/trading/trading/weinstein/strategy/lib/macro_inputs.mli
@@ -106,3 +106,82 @@ val build_sector_map :
 
     Stage 4 PR-D: when [ma_cache] is passed, sector ETF MA values are fetched
     from the cache rather than recomputed per Friday. *)
+
+(** {1 Snapshot-views constructors (Phase F.3.d)}
+
+    Parallel constructors that take a {!Snapshot_runtime.Snapshot_callbacks.t}
+    and fetch the underlying bar views via
+    {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for} /
+    {!Snapshot_runtime.Snapshot_bar_views.weekly_bars_for} before delegating to
+    the panel-shaped helpers above.
+
+    The fetched view types are type-equal to
+    {!Data_panel.Bar_panels.weekly_view} (declared via [type =] in
+    [snapshot_bar_views.mli]), so the delegation requires no per-call adapter
+    and the output is bit-identical to the [bar_reader]-backed path on the same
+    underlying bar history (parity tests:
+    [Test_macro_inputs.Test_snapshot_parity]).
+
+    Phase F.3.d plan: callers migrate from [Macro_inputs.X ~bar_reader] to
+    [Macro_inputs.X_of_snapshot_views ~cb], which folds the view fetch into the
+    input-assembly. After every caller migrates, the [bar_reader]-backed
+    constructors above can be removed alongside {!Data_panel.Bar_panels} in the
+    F.3 deletion PR. *)
+
+val build_global_index_views_of_snapshot_views :
+  lookback_bars:int ->
+  global_index_symbols:(string * string) list ->
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  as_of:Date.t ->
+  (string * Data_panel.Bar_panels.weekly_view) list
+(** [build_global_index_views_of_snapshot_views ~lookback_bars
+     ~global_index_symbols ~cb ~as_of] returns the [(label, weekly_view)] list
+    consumed by the macro callback bundle constructor for the global-consensus
+    indicator.
+
+    Same semantics as {!build_global_index_views} but the view fetch goes
+    through {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for} over [cb]
+    instead of {!Bar_reader.weekly_view_for}. Indices with no resident bars
+    (empty view) are silently dropped. *)
+
+val build_global_index_bars_of_snapshot_views :
+  lookback_bars:int ->
+  global_index_symbols:(string * string) list ->
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  as_of:Date.t ->
+  (string * Types.Daily_price.t list) list
+(** [build_global_index_bars_of_snapshot_views ~lookback_bars
+     ~global_index_symbols ~cb ~as_of] is the bar-list shape of
+    {!build_global_index_views_of_snapshot_views}, retained for callers that
+    build {!Macro.callbacks} via {!Macro.callbacks_from_bars}. The bar fetch
+    goes through {!Snapshot_runtime.Snapshot_bar_views.weekly_bars_for}. *)
+
+val build_sector_map_of_snapshot_views :
+  ?ma_cache:Weekly_ma_cache.t ->
+  stage_config:Stage.config ->
+  lookback_bars:int ->
+  sector_etfs:(string * string) list ->
+  cb:Snapshot_runtime.Snapshot_callbacks.t ->
+  as_of:Date.t ->
+  sector_prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  index_view:Data_panel.Bar_panels.weekly_view ->
+  ticker_sectors:(string, string) Hashtbl.t ->
+  unit ->
+  (string, Screener.sector_context) Hashtbl.t
+(** [build_sector_map_of_snapshot_views ?ma_cache ~stage_config ~lookback_bars
+     ~sector_etfs ~cb ~as_of ~sector_prior_stages ~index_view ~ticker_sectors
+     ()] is the snapshot-views variant of {!build_sector_map}: same ETF-level
+    analysis path through {!Panel_callbacks.sector_callbacks_of_weekly_views}
+    + {!Sector.analyze_with_callbacks} and the same ticker-level expansion via
+      [ticker_sectors], but the sector ETF weekly views are fetched via
+      {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for} over [cb] instead
+      of {!Bar_reader.weekly_view_for}.
+
+    [index_view] is still passed as a {!Data_panel.Bar_panels.weekly_view}
+    because the strategy keeps the benchmark view in scope across the per-tick
+    screen and reuses it across both [build_sector_map_*] paths; callers that
+    have only a [Snapshot_callbacks.t] should fetch the benchmark view via
+    {!Snapshot_runtime.Snapshot_bar_views.weekly_view_for} themselves.
+
+    [sector_prior_stages] is read and updated in place identically to
+    {!build_sector_map}. *)

--- a/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
@@ -3,6 +3,12 @@ open Core
 open Matchers
 open Weinstein_strategy
 module Bar_panels = Data_panel.Bar_panels
+module Pipeline = Snapshot_pipeline.Pipeline
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
 
 (* ------------------------------------------------------------------ *)
 (* Helpers                                                              *)
@@ -249,6 +255,319 @@ let test_build_sector_map_populates_entry_for_valid_etf _ =
     (is_some_and (fun _ -> ()))
 
 (* ------------------------------------------------------------------ *)
+(* Snapshot-views parity (Phase F.3.d)                                  *)
+(* ------------------------------------------------------------------ *)
+(* Pin that {!Macro_inputs.build_*_of_snapshot_views} produces bit-equal
+   output to the [bar_reader]-backed constructors on the same underlying
+   bar history. Since the [bar_reader]-backed path (after F.3.a-4) and
+   the new [_of_snapshot_views] path both ultimately fan out through
+   {!Snapshot_runtime.Snapshot_bar_views}, parity is the load-bearing
+   property — any drift between the two would surface as a regression
+   when callers migrate from one to the other in F.3.d's downstream PRs. *)
+
+let _build_snapshot_callbacks
+    (symbol_bars : (string * Types.Daily_price.t list) list) :
+    Snapshot_callbacks.t =
+  let dir = Stdlib.Filename.temp_dir "test_macro_inputs_" "" in
+  let entries =
+    List.map symbol_bars ~f:(fun (symbol, bars) ->
+        let rows =
+          match
+            Pipeline.build_for_symbol ~symbol ~bars
+              ~schema:Snapshot_schema.default ()
+          with
+          | Ok rs -> rs
+          | Error err ->
+              failwithf "Pipeline.build_for_symbol %s: %s" symbol
+                err.Status.message ()
+        in
+        let path = Filename.concat dir (symbol ^ ".snap") in
+        (match Snapshot_format.write ~path rows with
+        | Ok () -> ()
+        | Error err ->
+            failwithf "Snapshot_format.write %s: %s" symbol err.Status.message
+              ());
+        {
+          Snapshot_manifest.symbol;
+          path;
+          byte_size = 0;
+          payload_md5 = "ignored";
+          csv_mtime = 0.0;
+        })
+  in
+  let manifest =
+    Snapshot_manifest.create ~schema:Snapshot_schema.default ~entries
+  in
+  let manifest_path = Filename.concat dir "manifest.sexp" in
+  (match Snapshot_manifest.write ~path:manifest_path manifest with
+  | Ok () -> ()
+  | Error err -> failwithf "Snapshot_manifest.write: %s" err.Status.message ());
+  let panels =
+    match Daily_panels.create ~snapshot_dir:dir ~manifest ~max_cache_mb:16 with
+    | Ok p -> p
+    | Error err -> failwithf "Daily_panels.create: %s" err.Status.message ()
+  in
+  Snapshot_callbacks.of_daily_panels panels
+
+(* Build a per-entry matcher for a (label, weekly_view) pair from an
+   expected entry: composes label equality + per-field array equality
+   under one [all_of]. Float arrays compare with epsilon=1e-9 — both
+   paths round-trip through {!Snapshot_bar_views} for the synthetic
+   in-memory fixture, so any drift larger than IEEE round-trip noise
+   would be a regression. Used in [elements_are] to validate the full
+   [(label, weekly_view) list] under one [assert_that]. *)
+let _global_view_entry_matcher
+    ((expected_label, expected_view) : string * Bar_panels.weekly_view) =
+  let float_array_matches arr =
+    elements_are (Array.to_list arr |> List.map ~f:(float_equal ~epsilon:1e-9))
+  in
+  let date_array_matches arr =
+    elements_are (Array.to_list arr |> List.map ~f:equal_to)
+  in
+  all_of
+    [
+      field fst (equal_to expected_label);
+      field
+        (fun ((_, v) : string * Bar_panels.weekly_view) -> v.n)
+        (equal_to expected_view.n);
+      field
+        (fun ((_, v) : string * Bar_panels.weekly_view) ->
+          Array.to_list v.closes)
+        (float_array_matches expected_view.closes);
+      field
+        (fun ((_, v) : string * Bar_panels.weekly_view) ->
+          Array.to_list v.raw_closes)
+        (float_array_matches expected_view.raw_closes);
+      field
+        (fun ((_, v) : string * Bar_panels.weekly_view) ->
+          Array.to_list v.highs)
+        (float_array_matches expected_view.highs);
+      field
+        (fun ((_, v) : string * Bar_panels.weekly_view) -> Array.to_list v.lows)
+        (float_array_matches expected_view.lows);
+      field
+        (fun ((_, v) : string * Bar_panels.weekly_view) ->
+          Array.to_list v.volumes)
+        (float_array_matches expected_view.volumes);
+      field
+        (fun ((_, v) : string * Bar_panels.weekly_view) ->
+          Array.to_list v.dates)
+        (date_array_matches expected_view.dates);
+    ]
+
+(* Build a per-entry matcher for a (label, Daily_price.t list) pair from
+   an expected entry. Bar lists compare element-wise on the numeric fields
+   the bar-list path round-trips through [Snapshot_bar_views] (date,
+   adjusted_close, close, high, low, volume) — those are the load-bearing
+   fields the Macro callbacks read. *)
+let _global_bars_entry_matcher
+    ((expected_label, expected_bars) : string * Types.Daily_price.t list) =
+  let bar_matcher (b : Types.Daily_price.t) =
+    all_of
+      [
+        field (fun (x : Types.Daily_price.t) -> x.date) (equal_to b.date);
+        field
+          (fun (x : Types.Daily_price.t) -> x.adjusted_close)
+          (float_equal ~epsilon:1e-9 b.adjusted_close);
+        field
+          (fun (x : Types.Daily_price.t) -> x.close_price)
+          (float_equal ~epsilon:1e-9 b.close_price);
+        field
+          (fun (x : Types.Daily_price.t) -> x.high_price)
+          (float_equal ~epsilon:1e-9 b.high_price);
+        field
+          (fun (x : Types.Daily_price.t) -> x.low_price)
+          (float_equal ~epsilon:1e-9 b.low_price);
+        field
+          (fun (x : Types.Daily_price.t) -> Float.of_int x.volume)
+          (float_equal ~epsilon:1e-9 (Float.of_int b.volume));
+      ]
+  in
+  all_of
+    [
+      field fst (equal_to expected_label);
+      field snd (elements_are (List.map expected_bars ~f:bar_matcher));
+    ]
+
+let test_snapshot_parity_global_index_views _ =
+  let gdaxi_bars =
+    make_rising_bars
+      ~start_date:(Date.of_string "2024-01-01")
+      ~n:_sufficient_daily_bars ~start_price:15000.0
+  in
+  let n225_bars =
+    make_rising_bars
+      ~start_date:(Date.of_string "2024-01-01")
+      ~n:_sufficient_daily_bars ~start_price:30000.0
+  in
+  let as_of = (List.last_exn gdaxi_bars).date in
+  let symbols = [ ("GDAXI.INDX", gdaxi_bars); ("N225.INDX", n225_bars) ] in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols in
+  let cb = _build_snapshot_callbacks symbols in
+  let bar_reader_views =
+    Macro_inputs.build_global_index_views ~lookback_bars:52
+      ~global_index_symbols:Macro_inputs.default_global_indices ~bar_reader
+      ~as_of
+  in
+  let snapshot_views =
+    Macro_inputs.build_global_index_views_of_snapshot_views ~lookback_bars:52
+      ~global_index_symbols:Macro_inputs.default_global_indices ~cb ~as_of
+  in
+  assert_that snapshot_views
+    (elements_are (List.map bar_reader_views ~f:_global_view_entry_matcher))
+
+let test_snapshot_parity_global_index_views_drops_missing _ =
+  (* Only GDAXI present; N225 + FTSE missing → both paths drop them
+     identically and produce a single-entry list keyed by "DAX". *)
+  let bars =
+    make_rising_bars
+      ~start_date:(Date.of_string "2024-01-01")
+      ~n:30 ~start_price:15000.0
+  in
+  let as_of = (List.last_exn bars).date in
+  let symbols = [ ("GDAXI.INDX", bars) ] in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols in
+  let cb = _build_snapshot_callbacks symbols in
+  let bar_reader_views =
+    Macro_inputs.build_global_index_views ~lookback_bars:52
+      ~global_index_symbols:Macro_inputs.default_global_indices ~bar_reader
+      ~as_of
+  in
+  let snapshot_views =
+    Macro_inputs.build_global_index_views_of_snapshot_views ~lookback_bars:52
+      ~global_index_symbols:Macro_inputs.default_global_indices ~cb ~as_of
+  in
+  assert_that snapshot_views
+    (elements_are (List.map bar_reader_views ~f:_global_view_entry_matcher))
+
+let test_snapshot_parity_global_index_bars _ =
+  let bars =
+    make_rising_bars
+      ~start_date:(Date.of_string "2024-01-01")
+      ~n:_sufficient_daily_bars ~start_price:15000.0
+  in
+  let as_of = (List.last_exn bars).date in
+  let symbols = [ ("GDAXI.INDX", bars) ] in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols in
+  let cb = _build_snapshot_callbacks symbols in
+  let bar_reader_pairs =
+    Macro_inputs.build_global_index_bars ~lookback_bars:52
+      ~global_index_symbols:Macro_inputs.default_global_indices ~bar_reader
+      ~as_of
+  in
+  let snapshot_pairs =
+    Macro_inputs.build_global_index_bars_of_snapshot_views ~lookback_bars:52
+      ~global_index_symbols:Macro_inputs.default_global_indices ~cb ~as_of
+  in
+  assert_that snapshot_pairs
+    (elements_are (List.map bar_reader_pairs ~f:_global_bars_entry_matcher))
+
+let test_snapshot_parity_sector_map _ =
+  (* Both ETF + index have enough bars → both paths populate XLK with the
+     same {!Screener.sector_context} and update [sector_prior_stages]
+     identically. *)
+  let etf_bars =
+    make_rising_bars
+      ~start_date:(Date.of_string "2024-01-01")
+      ~n:_sufficient_daily_bars ~start_price:100.0
+  in
+  let index_bars =
+    make_rising_bars
+      ~start_date:(Date.of_string "2024-01-01")
+      ~n:_sufficient_daily_bars ~start_price:4500.0
+  in
+  let as_of = (List.last_exn etf_bars).date in
+  let symbols = [ ("XLK", etf_bars); ("INDEX", index_bars) ] in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols in
+  let cb = _build_snapshot_callbacks symbols in
+  let index_view =
+    Bar_reader.weekly_view_for bar_reader ~symbol:"INDEX" ~n:52 ~as_of
+  in
+  let bar_reader_prior_stages = Hashtbl.create (module String) in
+  let snapshot_prior_stages = Hashtbl.create (module String) in
+  let ticker_sectors =
+    Hashtbl.of_alist_exn (module String) [ ("XLK", "Information Technology") ]
+  in
+  let bar_reader_map =
+    Macro_inputs.build_sector_map ~stage_config:Stage.default_config
+      ~lookback_bars:52
+      ~sector_etfs:[ ("XLK", "Information Technology") ]
+      ~bar_reader ~as_of ~sector_prior_stages:bar_reader_prior_stages
+      ~index_view ~ticker_sectors ()
+  in
+  let snapshot_map =
+    Macro_inputs.build_sector_map_of_snapshot_views
+      ~stage_config:Stage.default_config ~lookback_bars:52
+      ~sector_etfs:[ ("XLK", "Information Technology") ]
+      ~cb ~as_of ~sector_prior_stages:snapshot_prior_stages ~index_view
+      ~ticker_sectors ()
+  in
+  let sorted_alist h =
+    Hashtbl.to_alist h
+    |> List.sort ~compare:(fun (a, _) (b, _) -> String.compare a b)
+  in
+  let expected_alist = sorted_alist bar_reader_map in
+  let expected_prior_alist =
+    Hashtbl.to_alist bar_reader_prior_stages
+    |> List.sort ~compare:(fun (a, _) (b, _) -> String.compare a b)
+  in
+  let snap_prior_alist =
+    Hashtbl.to_alist snapshot_prior_stages
+    |> List.sort ~compare:(fun (a, _) (b, _) -> String.compare a b)
+  in
+  let entry_matcher (k, (e : Screener.sector_context)) =
+    all_of
+      [
+        field fst (equal_to k);
+        field
+          (fun (_, (ctx : Screener.sector_context)) -> ctx.sector_name)
+          (equal_to e.sector_name);
+      ]
+  in
+  let prior_entry_matcher (k, _) = field fst (equal_to k) in
+  assert_that
+    (sorted_alist snapshot_map, snap_prior_alist)
+    (all_of
+       [
+         field fst (elements_are (List.map expected_alist ~f:entry_matcher));
+         field snd
+           (elements_are (List.map expected_prior_alist ~f:prior_entry_matcher));
+       ])
+
+let test_snapshot_parity_sector_map_drops_etfs_with_insufficient_bars _ =
+  (* 25 daily bars = ~5 weekly bars, below ma_period (30) → both paths
+     produce an empty map. *)
+  let etf_bars =
+    make_rising_bars
+      ~start_date:(Date.of_string "2024-01-01")
+      ~n:25 ~start_price:100.0
+  in
+  let index_bars =
+    make_rising_bars
+      ~start_date:(Date.of_string "2024-01-01")
+      ~n:_sufficient_daily_bars ~start_price:4500.0
+  in
+  let as_of = (List.last_exn etf_bars).date in
+  let symbols = [ ("XLK", etf_bars); ("INDEX", index_bars) ] in
+  let bar_reader = Bar_reader.of_in_memory_bars symbols in
+  let cb = _build_snapshot_callbacks symbols in
+  let index_view =
+    Bar_reader.weekly_view_for bar_reader ~symbol:"INDEX" ~n:52 ~as_of
+  in
+  let ticker_sectors =
+    Hashtbl.of_alist_exn (module String) [ ("XLK", "Information Technology") ]
+  in
+  let snapshot_map =
+    Macro_inputs.build_sector_map_of_snapshot_views
+      ~stage_config:Stage.default_config ~lookback_bars:52
+      ~sector_etfs:[ ("XLK", "Information Technology") ]
+      ~cb ~as_of
+      ~sector_prior_stages:(Hashtbl.create (module String))
+      ~index_view ~ticker_sectors ()
+  in
+  assert_that (Hashtbl.to_alist snapshot_map) is_empty
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -274,4 +593,14 @@ let () =
            >:: test_build_sector_map_drops_etfs_when_index_bars_empty;
            "build_sector_map populates entry for valid ETF"
            >:: test_build_sector_map_populates_entry_for_valid_etf;
+           "Snapshot parity: build_global_index_views"
+           >:: test_snapshot_parity_global_index_views;
+           "Snapshot parity: build_global_index_views drops missing"
+           >:: test_snapshot_parity_global_index_views_drops_missing;
+           "Snapshot parity: build_global_index_bars"
+           >:: test_snapshot_parity_global_index_bars;
+           "Snapshot parity: build_sector_map"
+           >:: test_snapshot_parity_sector_map;
+           "Snapshot parity: build_sector_map drops insufficient ETFs"
+           >:: test_snapshot_parity_sector_map_drops_etfs_with_insufficient_bars;
          ])


### PR DESCRIPTION
## Summary

Adds parallel `*_of_snapshot_views` constructors to `Macro_inputs` that take a `Snapshot_callbacks.t` and fetch weekly views via `Snapshot_bar_views`, alongside the existing `bar_reader`-backed constructors. Fourth and final consumer port for `Bar_panels.t` retirement (Phase F.3 §plan).

This mirrors the staged b-1/c-1 pattern from:
- F.3.b (PR #833 — `Weekly_ma_cache.of_snapshot_views`)
- F.3.c (PR #837 — `Panel_callbacks.*_of_snapshot_views`)

## What changed

New surface (3 parallel constructors, ~89 LOC implementation + 79 LOC `.mli`):

- `Macro_inputs.build_global_index_views_of_snapshot_views` — takes `cb:Snapshot_callbacks.t`, fetches weekly views via `Snapshot_bar_views.weekly_view_for`. Empty-view filter matches the legacy path.
- `Macro_inputs.build_global_index_bars_of_snapshot_views` — bar-list shape, fetches via `Snapshot_bar_views.weekly_bars_for`.
- `Macro_inputs.build_sector_map_of_snapshot_views` — sector ETF analysis path with the same `Panel_callbacks.sector_callbacks_of_weekly_views` + `Sector.analyze_with_callbacks` delegation; only the view fetch differs.

Each is a thin wrapper that fetches via `Snapshot_bar_views` and delegates to the shared panel-shaped helpers — no logic duplication, no behavioural change.

## Why staged

The legacy `bar_reader`-backed constructors stay as-is. Subsequent PRs:
1. Migrate callers (`Weinstein_strategy._run_screen` line 371, `Runner` line 183) from `Macro_inputs.X ~bar_reader` to `Macro_inputs.X_of_snapshot_views ~cb`.
2. The F.3 deletion PR removes the `bar_reader`-backed constructors alongside `Data_panel.Bar_panels`.

## Test plan

- [x] `dune build` — green
- [x] `dune exec trading/weinstein/strategy/test/test_macro_inputs.exe` — 14/14 tests pass (9 original + 5 new parity tests)
- [x] `dune build @fmt` — clean for files touched (pre-existing fmt drift in unrelated files left untouched per worktree-isolation rule)

The 5 new parity tests pin bit-equal output between both paths on a shared in-memory fixture:
- `Snapshot parity: build_global_index_views` — multi-symbol weekly views
- `Snapshot parity: build_global_index_views drops missing` — empty-view filter
- `Snapshot parity: build_global_index_bars` — bar-list shape
- `Snapshot parity: build_sector_map` — full sector analysis with `sector_prior_stages` updates
- `Snapshot parity: build_sector_map drops insufficient ETFs` — too-few-bars short-circuit

Float comparisons use `epsilon=1e-9` (IEEE round-trip noise tolerance); date / int / sector_name use exact equality.

## PR sizing

497 LOC (89 + 79 + 329 — test file is the bulk; `.ml` + `.mli` is 168 LOC). Within the ≤500 cap.

## Plan reference

`dev/plans/snapshot-engine-phase-f-2026-05-03.md` §F.3 (lines 73-89). Fourth and final F.3 staged consumer port.