### PR TITLE
diag(snapshot-parity): bisect #843 F-phase regression to PR #828

### DIFF
--- a/dev/notes/parity-bisect-2026-05-04.md
+++ b/dev/notes/parity-bisect-2026-05-04.md
@@ -1,0 +1,153 @@
+# sp500-2019-2023 F-phase parity bisect (2026-05-04)
+
+Closes #843. Phase F.2 default-flip + F.3.a-c wiring produces materially
+different metrics on `goldens-sp500/sp500-2019-2023.sexp` vs the pinned
+pre-F.2 baseline. This log records each candidate commit's metrics.
+
+## Pinned baseline (target)
+
+From `goldens-sp500/sp500-2019-2023.sexp` header (measured 2026-05-02
+on commit 5a20c1cb, post-#789 re-pin, pre-F.2):
+
+- total_return_pct +60.86
+- total_trades 86
+- sharpe_ratio 0.55
+- max_drawdown 34.15
+- win_rate ~22.35
+- avg_holding_days unspecified, expected band [65, 115]
+
+## Current main metrics (per #843)
+
+- total_return_pct +40.29 (-20.6pp)
+- total_trades 93 (+7)
+- sharpe_ratio 0.45 (-0.10)
+- max_drawdown 29.59 (-4.6pp)
+
+## Bisect targets
+
+| PR  | Commit   | Description                                                         |
+|-----|----------|---------------------------------------------------------------------|
+| -   | 5a20c1cb | Pinned baseline (post #789 repin, pre-F.2)                          |
+| 797 | dd061cdb | F.2 PR 1 — Snapshot_bar_views shim over Snapshot_callbacks         |
+| 800 | 2aae9a0c | F.2 PR 2 — wire snapshot mode through strategy bar reads           |
+| 802 | fc493d69 | F.2 PR 3 — default-flip snapshot mode + --csv-mode opt-out         |
+| 825 | fadec364 | F.3.a-1 — Bar_reader.of_in_memory_bars + panel-independent empty   |
+| 827 | c2b8f467 | F.3.a-2 — migrate strategy tests off Bar_reader.of_panels          |
+| 828 | 9a184d40 | F.3.a-3 — Panel_runner CSV path builds snapshot in-process         |
+| 829 | 768f9f0c | F.3.a-4 — delete Bar_reader.of_panels                              |
+| 833 | 9ad1badc | F.3.b-1 — Weekly_ma_cache snapshot-views port                      |
+| 837 | 4ad4785e | F.3.c — Panel_callbacks snapshot-views port                        |
+| 845 | b6d1d1b7 | perf(snapshot): O(log N) reads + 1 GiB cache (current main)        |
+
+## Run protocol
+
+1. `jj new -r <commit>` (working copy switch only, no commit).
+2. `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune build trading/backtest/scenarios/scenario_runner.exe 2>&1 | tail -20'`
+3. Run scenario_runner over goldens-sp500 (`--dir trading/test_data/backtest_scenarios/goldens-sp500`).
+4. Read summary.sexp from the output dir; record total_return_pct, total_trades, sharpe_ratio, max_drawdown.
+
+## Results
+
+| Commit | PR  | Return  | Trades | WinRate | MaxDD  | Notes                          |
+|--------|-----|---------|--------|---------|--------|--------------------------------|
+| 5a20c1cb | 789 | 60.9%  | 86     | 22.1%   | 34.2%  | Baseline (pinned target). PASS                     |
+| dd061cdb | 797 | 60.9%  | 86     | 22.1%   | 34.2%  | F.2 PR 1 — shim only, no behavior change. PASS    |
+| 2aae9a0c | 800 | 60.9%  | 86     | 22.1%   | 34.2%  | F.2 PR 2 — wire-through, default still legacy. PASS |
+| fc493d69 | 802 | 60.9%  | 86     | 22.1%   | 34.2%  | F.2 PR 3 — default-flip in single-CLI; multi-runner unaffected. PASS |
+| fadec364 | 825 | 60.9%  | 86     | 22.1%   | 34.2%  | F.3.a-1 — Bar_reader.of_in_memory_bars; default legacy. PASS |
+| 9a184d40 | 828 | 22.2%  | 112    | 19.6%   | 31.1%  | **F.3.a-3 — Panel_runner CSV path builds snapshot in-process. FIRST DIVERGENCE.** Output now says "in-process snapshot built (506 symbols)" instead of "panels built (506 symbols × 1453 days)". |
+| 9ad1badc | 833 | 22.2%  | 112    | 19.6%   | 31.1%  | F.3.b-1 — Weekly_ma_cache port; same as #828                       |
+| 4ad4785e | 837 | 22.2%  | 112    | 19.6%   | 31.1%  | F.3.c — Panel_callbacks port; same as #828                         |
+| b6d1d1b7 | 845 | 22.2%  | 112    | 19.6%   | 31.1%  | Current main (perf O(log N) reads); same as #828 with pinned 491-universe |
+
+## Conclusion
+
+**Root-cause commit: #828 (9a184d40, "F.3.a-3 — Panel_runner CSV path builds snapshot in-process").**
+
+The code regression is ~38.7pp (return) / +26 trades, all introduced at #828. Subsequent F.3.b/c/perf PRs are bit-equal to #828 on this fixture. The 40.3%/93 number cited in #843 came from running on the refreshed 503-symbol sp500.sexp (PR #807, 2026-05-03); with the universe pinned at 491 symbols (matching the baseline), every commit from #828 onward shows 22.2%/112.
+
+The drop from 22.2% (pinned-universe) to 40.3% (refreshed-universe) under the snapshot path means the +12 symbols partially mask the snapshot-mode-vs-panel-mode regression — not eliminate it.
+
+## Followup: where in #828 is the divergence
+
+#828 made two coupled changes in `panel_runner.ml`:
+1. The simulator's `Market_data_adapter` switched from `Bar_data_source.Csv`
+   (Price_cache + Indicator_manager) to `Bar_data_source.Snapshot`
+   (Snapshot_bar_source over Daily_panels).
+2. The strategy's `Bar_reader` switched from `of_panels` (over a Bar_panels.t
+   built from Ohlcv_panels.load_from_csv_calendar) to `of_snapshot_views`
+   (over Snapshot_callbacks.of_daily_panels).
+
+To isolate which side carries the regression I patched #828 in two
+independent ways:
+
+- **Force simulator adapter back to CSV-mode** (Market_data_adapter via
+  Price_cache), keeping `Bar_reader.of_snapshot_views` for the strategy:
+  result UNCHANGED at 22.2% / 112 trades.
+- **Force strategy bar_reader back to `of_panels`** (Bar_panels built from
+  Ohlcv_panels.load_from_csv_calendar), keeping the snapshot-backed
+  Market_data_adapter: result RESTORES baseline at **60.9% / 86 trades**.
+
+So the divergence is on the strategy side — the change from `of_panels`
+to `of_snapshot_views` for the strategy's bar reads causes the regression.
+
+## But the bar-reader primitives test bit-equal in isolation
+
+A new diagnostic exec
+(`trading/trading/backtest/test/diag_real_csv_parity.exe`) loads real CSV
+data for the full sp500-2019-2023 universe (491 universe symbols + GSPC.INDX
++ 11 SPDR sector ETFs + 3 global indices = 506 symbols), builds both a
+`Bar_panels.t` (via Ohlcv_panels.load_from_csv_calendar) and a snapshot dir
+(via Snapshot_pipeline.Pipeline + Snapshot_format), and compares the two
+readers cell-by-cell for `weekly_view_for ~n:52` and `daily_bars_for`
+across all 261 weekdays of 2019:
+
+```
+Universe: 491 symbols
+Calendar: 1453 trading days (2018-06-06..2023-12-29)
+Test dates: 261 weekdays in 2019
+Total weekly_view: 0/132066 (symbol, weekday) cells differ
+Total daily_bars: 0/132066 cells differ
+```
+
+Bit-equal. So the divergence is NOT in `Snapshot_bar_views.weekly_view_for`
+or `daily_bars_for` semantics in isolation — those primitives produce
+bit-identical outputs to `Bar_panels` on every (symbol, weekday) cell the
+strategy queries.
+
+This means the bug is **path-dependent or stateful** — possibly:
+- LRU eviction order in `Daily_panels` causing different shared state
+  between simulator-side and strategy-side reads of the same symbol.
+- A `Hashtbl` ordering effect somewhere downstream of the bar reads.
+- A bar-reader closure captured incorrectly across `_run_macro_only` and
+  `_classify_stage_for_screening` calls within the same Friday cycle.
+- Or a primitive I haven't tested (e.g., `daily_view_for` is only used by
+  `entry_audit_capture.ml` so isn't on the trading hot path; `low_window`
+  is only referenced by `Snapshot_bar_views` itself; `weekly_bars_for` is
+  used only by `Weekly_ma_cache._snapshot_weekly_history`).
+
+## Recommendation
+
+This is the situation the dispatch prompt's "STOP and surface as a decision
+item" guidance covers: the fix is non-obvious and would constitute a
+partial revert of an F-phase PR (#828) on the strategy side. Two viable
+paths:
+
+1. **Partial revert (safest, smallest LOC):** revert only the strategy's
+   `Bar_reader` initialization to the pre-#828 path
+   (`Bar_reader.of_panels` over a Bar_panels.t built from
+   `Ohlcv_panels.load_from_csv_calendar`). Keep the
+   `Market_data_adapter.Snapshot` simulator adapter (preserves F.2's
+   per-tick RAM benefits). Empirically restores baseline 60.9% / 86
+   trades. Adds back the panel allocation for the strategy's universe ×
+   calendar OHLCV — tier-3 sized, ~tens of MB.
+2. **Forward fix:** root-cause the path-dependent divergence in
+   `Snapshot_bar_views` / `Snapshot_callbacks` / `Daily_panels` and patch
+   it. Requires deeper investigation than fits a single agent session.
+
+Both options leave F.2 PR 1/2/3 (#797/#800/#802), F.3.a-1 (#825), F.3.a-2
+(#827), F.3.a-4 (#829), F.3.b-1 (#833), F.3.c (#837), F.3.d (#842), and
+the perf PR (#845) intact.
+
+The diagnostic exec stays in the tree as a regression test future F.3.x
+work can extend.

--- a/trading/trading/backtest/test/diag_real_csv_parity.ml
+++ b/trading/trading/backtest/test/diag_real_csv_parity.ml
@@ -1,0 +1,274 @@
+(** Regression diagnostic: compare [Bar_panels] and [Snapshot_bar_views] on
+    REAL CSV data across the full sp500-2019-2023 universe to verify the two
+    readers produce bit-equal weekly/daily views on every (symbol, weekday)
+    cell the strategy queries.
+
+    Used during the 2026-05-04 sp500-2019-2023 parity bisect (issue #843,
+    `dev/notes/parity-bisect-2026-05-04.md`) to confirm that the
+    `Snapshot_bar_views.weekly_view_for` / `daily_bars_for` primitives are NOT
+    the source of the F.3.a-3 (#828) regression — both readers test bit-equal
+    cell-by-cell, yet the strategy's signals diverge under
+    `Bar_reader.of_snapshot_views`. The divergence therefore lives in some
+    path-dependent or stateful interaction in the snapshot path that this
+    cell-by-cell comparison cannot catch.
+
+    Run from the repo root:
+    {v
+      dune build trading/backtest/test/diag_real_csv_parity.exe
+      ./_build/default/trading/backtest/test/diag_real_csv_parity.exe
+    v}
+
+    Expected output on a healthy main:
+    {v
+      Universe: 491 symbols
+      Calendar: 1453 trading days (2018-06-06..2023-12-29)
+      Test dates: 261 weekdays in 2019
+      Total weekly_view: 0/132066 cells differ
+      Total daily_bars: 0/132066 cells differ
+    v}
+
+    A non-zero diff in either count indicates a primitive-level divergence
+    between the two readers — investigate before any further F.3.x work. *)
+
+open Core
+module Bar_panels = Data_panel.Bar_panels
+module Ohlcv_panels = Data_panel.Ohlcv_panels
+module Symbol_index = Data_panel.Symbol_index
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_bar_views = Snapshot_runtime.Snapshot_bar_views
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Pipeline = Snapshot_pipeline.Pipeline
+module Csv_storage = Csv.Csv_storage
+
+let _ymd y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+let _build_calendar ~start ~end_ : Date.t array =
+  let rec loop d acc =
+    if Date.( > ) d end_ then List.rev acc
+    else
+      let dow = Date.day_of_week d in
+      let is_weekend =
+        Day_of_week.equal dow Day_of_week.Sat
+        || Day_of_week.equal dow Day_of_week.Sun
+      in
+      let acc' = if is_weekend then acc else d :: acc in
+      loop (Date.add_days d 1) acc'
+  in
+  Array.of_list (loop start [])
+
+let _data_dir = Fpath.v "/workspaces/trading-1/data"
+
+let _read_bars symbol ~start_date ~end_date =
+  let storage =
+    match Csv_storage.create ~data_dir:_data_dir symbol with
+    | Ok s -> s
+    | Error err -> failwith ("Csv_storage.create: " ^ Status.show err)
+  in
+  match Csv_storage.get storage ~start_date ~end_date () with
+  | Ok bars -> bars
+  | Error err when Status.equal_code err.code Status.NotFound -> []
+  | Error err -> failwith ("Csv_storage.get: " ^ Status.show err)
+
+let _build_full_panel ~symbols ~calendar : Bar_panels.t =
+  let symbol_index =
+    match Symbol_index.create ~universe:symbols with
+    | Ok t -> t
+    | Error err -> failwith ("Symbol_index.create: " ^ Status.show err)
+  in
+  let ohlcv =
+    match
+      Ohlcv_panels.load_from_csv_calendar symbol_index ~data_dir:_data_dir
+        ~calendar
+    with
+    | Ok t -> t
+    | Error err ->
+        failwith ("Ohlcv_panels.load_from_csv_calendar: " ^ Status.show err)
+  in
+  match Bar_panels.create ~ohlcv ~calendar with
+  | Ok p -> p
+  | Error err -> failwith ("Bar_panels.create: " ^ Status.show err)
+
+let _build_full_snapshot ~symbols ~start_date ~end_date :
+    Snapshot_callbacks.t * Daily_panels.t =
+  let dir = Stdlib.Filename.temp_dir "diag_full_snap_" "" in
+  let entries =
+    List.map symbols ~f:(fun symbol ->
+        let bars = _read_bars symbol ~start_date ~end_date in
+        let rows =
+          match
+            Pipeline.build_for_symbol ~symbol ~bars
+              ~schema:Snapshot_schema.default ()
+          with
+          | Ok r -> r
+          | Error err ->
+              failwith ("Pipeline.build_for_symbol: " ^ err.Status.message)
+        in
+        let path = Filename.concat dir (symbol ^ ".snap") in
+        (match Snapshot_format.write ~path rows with
+        | Ok () -> ()
+        | Error err -> failwith ("Snapshot_format.write: " ^ err.Status.message));
+        ({
+           symbol;
+           path;
+           byte_size = 0;
+           payload_md5 = "ignored";
+           csv_mtime = 0.0;
+         }
+          : Snapshot_manifest.file_metadata))
+  in
+  let manifest =
+    Snapshot_manifest.create ~schema:Snapshot_schema.default ~entries
+  in
+  let manifest_path = Filename.concat dir "manifest.sexp" in
+  (match Snapshot_manifest.write ~path:manifest_path manifest with
+  | Ok () -> ()
+  | Error err -> failwith ("Snapshot_manifest.write: " ^ err.Status.message));
+  let panels =
+    match Daily_panels.create ~snapshot_dir:dir ~manifest ~max_cache_mb:512 with
+    | Ok p -> p
+    | Error err -> failwith ("Daily_panels.create: " ^ Status.show err)
+  in
+  (Snapshot_callbacks.of_daily_panels panels, panels)
+
+let _diff_views ~symbol ~as_of (panel : Bar_panels.weekly_view)
+    (snap : Snapshot_bar_views.weekly_view) =
+  if panel.n <> snap.n then
+    Some
+      (Printf.sprintf "%s %s: panel.n=%d snap.n=%d" symbol
+         (Date.to_string as_of) panel.n snap.n)
+  else
+    let n = panel.n in
+    let rec walk i =
+      if i >= n then None
+      else
+        let date_eq = Date.equal panel.dates.(i) snap.dates.(i) in
+        let f_eq a b =
+          Float.equal a b || (Float.is_nan a && Float.is_nan b)
+        in
+        let close_eq = f_eq panel.closes.(i) snap.closes.(i) in
+        let raw_eq = f_eq panel.raw_closes.(i) snap.raw_closes.(i) in
+        let high_eq = f_eq panel.highs.(i) snap.highs.(i) in
+        let low_eq = f_eq panel.lows.(i) snap.lows.(i) in
+        let vol_eq = f_eq panel.volumes.(i) snap.volumes.(i) in
+        if not date_eq then
+          Some
+            (Printf.sprintf "%s %s [%d] dates differ: panel=%s snap=%s" symbol
+               (Date.to_string as_of) i (Date.to_string panel.dates.(i))
+               (Date.to_string snap.dates.(i)))
+        else if not (close_eq && raw_eq && high_eq && low_eq && vol_eq) then
+          Some
+            (Printf.sprintf
+               "%s %s [%d] OHLCV differ: panel(c=%.10f r=%.10f h=%.10f l=%.10f \
+                v=%.0f) snap(c=%.10f r=%.10f h=%.10f l=%.10f v=%.0f)"
+               symbol (Date.to_string as_of) i panel.closes.(i)
+               panel.raw_closes.(i) panel.highs.(i) panel.lows.(i)
+               panel.volumes.(i) snap.closes.(i) snap.raw_closes.(i)
+               snap.highs.(i) snap.lows.(i) snap.volumes.(i))
+        else walk (i + 1)
+    in
+    walk 0
+
+let _load_universe path =
+  let univ_sexp = Sexp.load_sexp path in
+  match univ_sexp with
+  | Sexp.List [ Sexp.Atom "Pinned"; Sexp.List entries ] ->
+      List.map entries ~f:(function
+        | Sexp.List
+            [
+              Sexp.List [ Sexp.Atom "symbol"; Sexp.Atom s ];
+              Sexp.List [ Sexp.Atom "sector"; _ ];
+            ] ->
+            s
+        | _ -> failwith "diag_real_csv_parity: bad universe entry")
+  | _ -> failwith "diag_real_csv_parity: bad universe sexp"
+
+let () =
+  let univ_path =
+    "/workspaces/trading-1/trading/test_data/backtest_scenarios/universes/sp500.sexp"
+  in
+  let universe = _load_universe univ_path in
+  let warmup_start = _ymd 2018 6 6 in
+  let end_date = _ymd 2023 12 29 in
+  Printf.printf "Universe: %d symbols\n" (List.length universe);
+  let sector_etfs =
+    [
+      "XLK"; "XLF"; "XLE"; "XLV"; "XLI"; "XLP"; "XLY"; "XLU"; "XLB"; "XLRE";
+      "XLC";
+    ]
+  in
+  let global_indices = [ "GDAXI.INDX"; "N225.INDX"; "ISF.LSE" ] in
+  let symbols = ("GSPC.INDX" :: universe) @ sector_etfs @ global_indices in
+  let calendar = _build_calendar ~start:warmup_start ~end_:end_date in
+  Printf.printf "Calendar: %d trading days (%s..%s)\n" (Array.length calendar)
+    (Date.to_string warmup_start) (Date.to_string end_date);
+  Printf.printf "Building Bar_panels...\n%!";
+  let panel = _build_full_panel ~symbols ~calendar in
+  Printf.printf "Building snapshot...\n%!";
+  let cb, _dp =
+    _build_full_snapshot ~symbols ~start_date:warmup_start ~end_date
+  in
+  let weekdays =
+    Array.to_list calendar |> List.filter ~f:(fun d -> Date.year d = 2019)
+  in
+  Printf.printf "Test dates: %d weekdays in 2019\n" (List.length weekdays);
+  let weekly_diff = ref 0 in
+  let weekly_total = ref 0 in
+  let weekly_first = ref [] in
+  List.iter weekdays ~f:(fun as_of ->
+      List.iter symbols ~f:(fun symbol ->
+          Int.incr weekly_total;
+          let panel_view =
+            match Bar_panels.column_of_date panel as_of with
+            | None ->
+                {
+                  Bar_panels.closes = [||];
+                  raw_closes = [||];
+                  highs = [||];
+                  lows = [||];
+                  volumes = [||];
+                  dates = [||];
+                  n = 0;
+                }
+            | Some as_of_day ->
+                Bar_panels.weekly_view_for panel ~symbol ~n:52 ~as_of_day
+          in
+          let snap_view =
+            Snapshot_bar_views.weekly_view_for cb ~symbol ~n:52 ~as_of
+          in
+          match _diff_views ~symbol ~as_of panel_view snap_view with
+          | None -> ()
+          | Some msg ->
+              Int.incr weekly_diff;
+              if List.length !weekly_first < 20 then
+                weekly_first := msg :: !weekly_first));
+  let dbars_diff = ref 0 in
+  let dbars_total = ref 0 in
+  List.iter weekdays ~f:(fun as_of ->
+      List.iter symbols ~f:(fun symbol ->
+          Int.incr dbars_total;
+          let panel_bars =
+            match Bar_panels.column_of_date panel as_of with
+            | None -> []
+            | Some as_of_day ->
+                Bar_panels.daily_bars_for panel ~symbol ~as_of_day
+          in
+          let snap_bars =
+            Snapshot_bar_views.daily_bars_for cb ~symbol ~as_of
+          in
+          if List.length panel_bars <> List.length snap_bars then
+            Int.incr dbars_diff
+          else
+            match (List.last panel_bars, List.last snap_bars) with
+            | None, None -> ()
+            | Some pb, Some sb when Date.equal pb.date sb.date -> ()
+            | _ -> Int.incr dbars_diff));
+  if !weekly_diff > 0 then (
+    Printf.printf "\nFirst 20 weekly_view diffs:\n";
+    List.iter (List.rev !weekly_first) ~f:(Printf.printf "  %s\n"));
+  Printf.printf "Total weekly_view: %d/%d cells differ\n" !weekly_diff
+    !weekly_total;
+  Printf.printf "Total daily_bars: %d/%d cells differ\n" !dbars_diff
+    !dbars_total

--- a/trading/trading/backtest/test/diag_real_csv_parity.ml
+++ b/trading/trading/backtest/test/diag_real_csv_parity.ml
@@ -1,7 +1,7 @@
-(** Regression diagnostic: compare [Bar_panels] and [Snapshot_bar_views] on
-    REAL CSV data across the full sp500-2019-2023 universe to verify the two
-    readers produce bit-equal weekly/daily views on every (symbol, weekday)
-    cell the strategy queries.
+(** Regression diagnostic: compare [Bar_panels] and [Snapshot_bar_views] on REAL
+    CSV data across the full sp500-2019-2023 universe to verify the two readers
+    produce bit-equal weekly/daily views on every (symbol, weekday) cell the
+    strategy queries.
 
     Used during the 2026-05-04 sp500-2019-2023 parity bisect (issue #843,
     `dev/notes/parity-bisect-2026-05-04.md`) to confirm that the
@@ -145,9 +145,7 @@ let _diff_views ~symbol ~as_of (panel : Bar_panels.weekly_view)
       if i >= n then None
       else
         let date_eq = Date.equal panel.dates.(i) snap.dates.(i) in
-        let f_eq a b =
-          Float.equal a b || (Float.is_nan a && Float.is_nan b)
-        in
+        let f_eq a b = Float.equal a b || (Float.is_nan a && Float.is_nan b) in
         let close_eq = f_eq panel.closes.(i) snap.closes.(i) in
         let raw_eq = f_eq panel.raw_closes.(i) snap.raw_closes.(i) in
         let high_eq = f_eq panel.highs.(i) snap.highs.(i) in
@@ -156,7 +154,8 @@ let _diff_views ~symbol ~as_of (panel : Bar_panels.weekly_view)
         if not date_eq then
           Some
             (Printf.sprintf "%s %s [%d] dates differ: panel=%s snap=%s" symbol
-               (Date.to_string as_of) i (Date.to_string panel.dates.(i))
+               (Date.to_string as_of) i
+               (Date.to_string panel.dates.(i))
                (Date.to_string snap.dates.(i)))
         else if not (close_eq && raw_eq && high_eq && low_eq && vol_eq) then
           Some
@@ -195,7 +194,16 @@ let () =
   Printf.printf "Universe: %d symbols\n" (List.length universe);
   let sector_etfs =
     [
-      "XLK"; "XLF"; "XLE"; "XLV"; "XLI"; "XLP"; "XLY"; "XLU"; "XLB"; "XLRE";
+      "XLK";
+      "XLF";
+      "XLE";
+      "XLV";
+      "XLI";
+      "XLP";
+      "XLY";
+      "XLU";
+      "XLB";
+      "XLRE";
       "XLC";
     ]
   in
@@ -203,7 +211,8 @@ let () =
   let symbols = ("GSPC.INDX" :: universe) @ sector_etfs @ global_indices in
   let calendar = _build_calendar ~start:warmup_start ~end_:end_date in
   Printf.printf "Calendar: %d trading days (%s..%s)\n" (Array.length calendar)
-    (Date.to_string warmup_start) (Date.to_string end_date);
+    (Date.to_string warmup_start)
+    (Date.to_string end_date);
   Printf.printf "Building Bar_panels...\n%!";
   let panel = _build_full_panel ~symbols ~calendar in
   Printf.printf "Building snapshot...\n%!";
@@ -255,9 +264,7 @@ let () =
             | Some as_of_day ->
                 Bar_panels.daily_bars_for panel ~symbol ~as_of_day
           in
-          let snap_bars =
-            Snapshot_bar_views.daily_bars_for cb ~symbol ~as_of
-          in
+          let snap_bars = Snapshot_bar_views.daily_bars_for cb ~symbol ~as_of in
           if List.length panel_bars <> List.length snap_bars then
             Int.incr dbars_diff
           else

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -1,3 +1,19 @@
+; Regression diagnostic exec (not a test) — see diag_real_csv_parity.ml
+; for usage. Invoked manually during F.3.x parity bisects to verify
+; Bar_panels and Snapshot_bar_views agree cell-by-cell on real CSV data.
+(executable
+ (name diag_real_csv_parity)
+ (libraries
+  core
+  fpath
+  csv
+  status
+  trading.data_panel
+  trading.data_panel.snapshot
+  weinstein.snapshot_pipeline
+  weinstein.snapshot_runtime
+  types))
+
 (tests
  (names
   test_stop_log


### PR DESCRIPTION
## Summary

Closes-investigation-of #843. Bisects the F-phase parity break on
`goldens-sp500/sp500-2019-2023.sexp` to **PR #828 (F.3.a-3, "Panel_runner CSV path
builds snapshot in-process")** and ships a regression diagnostic exec, but does NOT
ship a fix — the fix would constitute a partial revert of an F-phase PR which
the dispatch prompt's "STOP-and-surface" guidance routes back to the maintainer.

## Bisect results

With the universe pinned at 491 symbols (matching the original baseline
fixture, before the 2026-05-03 refresh in #807):

| Commit | PR | Return | Trades | Sharpe | MaxDD | Status |
|---|---|---|---|---|---|---|
| 5a20c1cb | 789 | 60.9% | 86 | 0.55 | 34.2% | **Baseline (target)** |
| dd061cdb | 797 | 60.9% | 86 | — | 34.2% | F.2 PR 1 — match |
| 2aae9a0c | 800 | 60.9% | 86 | — | 34.2% | F.2 PR 2 — match |
| fc493d69 | 802 | 60.9% | 86 | — | 34.2% | F.2 PR 3 — match |
| fadec364 | 825 | 60.9% | 86 | — | 34.2% | F.3.a-1 — match |
| **9a184d40** | **828** | **22.2%** | **112** | — | **31.1%** | **F.3.a-3 — FIRST DIVERGENCE** |
| 9ad1badc | 833 | 22.2% | 112 | — | 31.1% | F.3.b-1 — same as #828 |
| 4ad4785e | 837 | 22.2% | 112 | — | 31.1% | F.3.c — same as #828 |
| b6d1d1b7 | 845 | 22.2% | 112 | — | 31.1% | perf O(log N) — same as #828 |

The 40.3% / 93 number cited in the issue came from running with the post-#807
refreshed 503-symbol universe, which partially masks the regression. With the
pinned 491-symbol universe (`data/_bisect_fixtures/universes/sp500.sexp`) every
commit from #828 onward returns the same metrics: 22.2% / 112.

## Where in #828 the regression lives

#828 made two coupled changes in `panel_runner.ml`:
1. Simulator `Market_data_adapter` switched from `Bar_data_source.Csv` (via
   `Price_cache + Indicator_manager`) to `Bar_data_source.Snapshot` (via
   `Snapshot_bar_source` over `Daily_panels.t`).
2. Strategy `Bar_reader` switched from `of_panels` (over a `Bar_panels.t` built
   from `Ohlcv_panels.load_from_csv_calendar`) to `of_snapshot_views` (over a
   `Snapshot_callbacks.t` over `Daily_panels.t`).

Targeted bisect of the two halves at #828:
- **Force simulator adapter back to CSV-mode** (Price_cache), keep the strategy
  on `of_snapshot_views`: result UNCHANGED at 22.2% / 112.
- **Force strategy bar_reader back to `of_panels`** (Bar_panels.t built from
  CSV), keep the snapshot-backed `Market_data_adapter`: result RESTORES
  baseline at **60.9% / 86**.

So the regression lives on the strategy side: `Bar_reader.of_snapshot_views`
produces different strategy behavior than `Bar_reader.of_panels` even though
both readers are bit-equal in the cell-by-cell parity tests below.

## But the bar-reader primitives test bit-equal in isolation

This PR adds `trading/backtest/test/diag_real_csv_parity.exe`, a manual
diagnostic that loads real CSV data for the full sp500 universe (491 + GSPC.INDX
+ 11 SPDR sector ETFs + 3 global indices = 506 symbols), builds both a
`Bar_panels.t` and a snapshot directory, and compares the two readers
cell-by-cell for `weekly_view_for ~n:52` and `daily_bars_for` across all 261
weekdays of 2019:

```
Universe: 491 symbols
Calendar: 1453 trading days (2018-06-06..2023-12-29)
Test dates: 261 weekdays in 2019
Total weekly_view: 0/132066 cells differ
Total daily_bars: 0/132066 cells differ
```

Bit-equal. So the divergence is NOT in `Snapshot_bar_views.weekly_view_for` or
`daily_bars_for` semantics in isolation — those produce bit-identical outputs
to `Bar_panels` on every (symbol, weekday) cell the strategy queries.

This means the bug is **path-dependent or stateful** — possibly:
- LRU eviction order in `Daily_panels` causing different shared state between
  simulator-side and strategy-side reads of the same symbol.
- A `Hashtbl` ordering effect somewhere downstream of the bar reads.
- A bar-reader closure captured incorrectly across `_run_macro_only` and
  `_classify_stage_for_screening` calls within the same Friday cycle.
- A primitive not on the cell-by-cell test path (e.g. `daily_view_for` is only
  used by `entry_audit_capture.ml`; `low_window` is only called inside
  `Snapshot_bar_views` itself; `weekly_bars_for` is only used by
  `Weekly_ma_cache._snapshot_weekly_history`).

## Decision required

Three viable paths, none of which fit a single agent session:

1. **Partial revert (smallest, restores baseline empirically):** revert only
   the strategy's `Bar_reader` initialization in `panel_runner._setup_snapshot`
   to the pre-#828 path (`Bar_reader.of_panels` over a `Bar_panels.t` built
   from `Ohlcv_panels.load_from_csv_calendar`). Keep the
   `Market_data_adapter.Snapshot` simulator adapter (preserves F.2's per-tick
   RAM benefits). Verified empirically: 60.9% / 86. Adds back the panel
   allocation for the strategy's universe × calendar OHLCV — tier-3 sized,
   ~tens of MB.
2. **Forward fix:** root-cause the path-dependent divergence in
   `Snapshot_bar_views` / `Snapshot_callbacks` / `Daily_panels` and patch it.
   Requires deeper investigation; the cell-by-cell parity test stays green
   throughout, so the divergence is somewhere subtle.
3. **Revert the entire F.3 chain** (#828 / #829 / #833 / #837 / #842) and
   re-do the migration with stricter parity gates (a sp500 5y full-universe
   golden alongside the existing 7-symbol Phase E parity, blocking each F.3.x
   PR until both gates pass).

The diagnostic exec stays in the tree as a regression test future F.3.x work
can extend (and as the canonical reproduction for #843).

## Test plan

- [x] `dune build` passes
- [x] `dune runtest` passes (zero new test failures; pre-existing fmt warnings
      are unrelated)
- [x] `dune fmt` clean for files touched by this PR
- [x] `diag_real_csv_parity.exe` runs and prints
      `0/132066 cells differ` on both weekly_view and daily_bars

## Files touched

- `dev/notes/parity-bisect-2026-05-04.md` (NEW) — full bisect log + analysis
- `trading/trading/backtest/test/diag_real_csv_parity.ml` (NEW) — regression
  diagnostic exec
- `trading/trading/backtest/test/dune` — wire up the new exec