### PR TITLE
fixture: dedup share-class pairs in sp500 universe (drop GOOG/FOX/NWS)

### DIFF
--- a/trading/test_data/backtest_scenarios/universes/sp500.sexp
+++ b/trading/test_data/backtest_scenarios/universes/sp500.sexp
@@ -2,7 +2,12 @@
 ;; bar-data inventory under data/. Generated 2026-05-03 by
 ;; dev/scripts/build_sp500_universe.sh.
 ;;
-;; 503 / 503 S&P 500 symbols have bar data.
+;; 500 symbols (was 503; dropped GOOG/FOX/NWS share-class duplicates of
+;; GOOGL/FOXA/NWSA on 2026-05-04 to prevent the strategy from
+;; double-loading the same underlying issuer — Class-A voting symbol
+;; kept by convention).
+;;
+;; Original: 503 / 503 S&P 500 symbols have bar data (pre-dedup).
 ;;
 ;; Symbol convention: dots replaced with dashes (EODHD: BF.B -> BF-B).
 ;; Used by goldens-sp500/ scenarios as a regression-pinned trading +
@@ -205,7 +210,6 @@
   ((symbol FISV   ) (sector "Financials"))
   ((symbol FITB   ) (sector "Financials"))
   ((symbol FIX    ) (sector "Industrials"))
-  ((symbol FOX    ) (sector "Communication Services"))
   ((symbol FOXA   ) (sector "Communication Services"))
   ((symbol FRT    ) (sector "Real Estate"))
   ((symbol FSLR   ) (sector "Information Technology"))
@@ -223,7 +227,6 @@
   ((symbol GLW    ) (sector "Information Technology"))
   ((symbol GM     ) (sector "Consumer Discretionary"))
   ((symbol GNRC   ) (sector "Industrials"))
-  ((symbol GOOG   ) (sector "Communication Services"))
   ((symbol GOOGL  ) (sector "Communication Services"))
   ((symbol GPC    ) (sector "Consumer Discretionary"))
   ((symbol GPN    ) (sector "Financials"))
@@ -352,7 +355,6 @@
   ((symbol NUE    ) (sector "Materials"))
   ((symbol NVDA   ) (sector "Information Technology"))
   ((symbol NVR    ) (sector "Consumer Discretionary"))
-  ((symbol NWS    ) (sector "Communication Services"))
   ((symbol NWSA   ) (sector "Communication Services"))
   ((symbol NXPI   ) (sector "Information Technology"))
   ((symbol O      ) (sector "Real Estate"))


### PR DESCRIPTION
## Summary

Drop share-class duplicates from `universes/sp500.sexp` so the strategy doesn't double-load the same underlying issuer. Three pairs found:

- **GOOG / GOOGL** (Alphabet Class C / Class A) — drop GOOG, keep GOOGL
- **FOX / FOXA** (Fox Corp Class B / Class A) — drop FOX, keep FOXA
- **NWS / NWSA** (News Corp Class B / Class A) — drop NWS, keep NWSA

Convention: keep the Class-A (voting) symbol per pair.

Universe shrinks **503 → 500 symbols**.

## Why this matters

The Weinstein strategy treats symbols as independent. Without dedup, GOOG and GOOGL can both enter Stage 2, both pass the screener, both open positions — inflating exposure to one issuer 2x while appearing diversified. Same for FOX/FOXA and NWS/NWSA. Removed at the universe level so this can't happen by accident.

Historical universe (`universes/sp500-historical/sp500-2010-01-01.sexp`, 510-sym 2010 snapshot) is unaffected — those companies issued dual classes after 2010 (e.g., GOOGL launched 2014). Future build_universe.exe runs that replay forward across share-class issuance need a similar dedup pass; filed as a follow-up if not already.

## Verification

- [x] `jj diff --stat` shows only `universes/sp500.sexp` (10 ins / 4 del)
- [x] Symbol count: `grep -c '(symbol ' universes/sp500.sexp` → 500
- [ ] sp500-2019-2023 backtest re-run on 500-sym universe — kicked off in parallel; metric drift expected to be within existing pinned ranges (30-70 return, 70-110 trades), but if it falls outside, follow-up PR will widen tolerances or re-pin

## Follow-up if needed

If the 500-sym backtest produces metrics outside the goldens-sp500 fixture's `(expected ...)` ranges, a separate small PR will re-pin (similar to PR #850's long-only re-pin pattern).