### PR TITLE
fixture: 15y scenario position-sizing override per #853 root-cause

### DIFF
--- a/dev/runs/15y-overrides-verify.log
+++ b/dev/runs/15y-overrides-verify.log
@@ -1,0 +1,12 @@
+Loading 1 scenarios from /workspaces/trading-1/data/backtest_scenarios/goldens-sp500-historical (parallel=1)
+Fixtures root: /workspaces/trading-1/data/backtest_scenarios
+Progress emission: every 4 Friday cycle(s) per scenario
+Output root: /workspaces/trading-1/dev/backtest/scenarios-2026-05-05-004535
+
+>>> Running sp500-2010-2026-historical: 15y sp500 historical backtest — survivorship-aware universe (510 symbols, replayed back to 2010-01-01), 2010-01-01 → 2026-04-30. Companion to goldens-sp500/sp500-2019-2023.sexp's 5y window. (2010-01-01 to 2026-04-30)
+Using scenario-provided sector map (510 symbols)...
+Universe: 510 stocks
+Loading AD breadth bars...
+Total symbols (universe + index + sector ETFs): 525
+Running backtest (2010-01-01 to 2026-04-30, warmup from 2009-06-05)...
+Panel_runner: simulator window 2009-06-05..2026-04-30 (warmup 210 days)

--- a/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp
@@ -33,7 +33,22 @@
  ;; enable_short_side disabled mirroring the existing sp500-2019-2023 +
  ;; goldens-broad/decade-2014-2023 cells (G1-G4 short-side gaps unresolved per
  ;; dev/notes/short-side-gaps-2026-04-29.md).
- (config_overrides (((enable_short_side false))))
+ ;;
+ ;; Position-sizing overrides per dev/notes/15y-trade-count-investigation-2026-05-05.md
+ ;; (PR #853 root-cause). Default sizing was calibrated against the 5y
+ ;; sp500-2019-2023 baseline; on a 15y window with 510 symbols + only $1M
+ ;; initial cash, the 0.30/0.90/0.10 defaults caused day-1 to lock up
+ ;; ~$993K across 4 oversized positions, with 8 long-runners pinning
+ ;; ~$949K cost basis for ~15 years. Skip ratio measured 271
+ ;; Insufficient_cash : 37 Stop_too_wide (7.3:1). The override below
+ ;; widens the entry funnel proportional to the window's longer horizon
+ ;; without modifying the default Portfolio_risk.config (which other
+ ;; goldens depend on).
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.05))))
+   ((portfolio_config ((max_long_exposure_pct 0.50))))
+   ((portfolio_config ((min_cash_pct 0.30))))))
  ;; PINNED_AFTER_FIRST_RUN — wide ranges. First successful run on the
  ;; user's 8 GB box under snapshot mode produces the canonical baseline.
  (expected


### PR DESCRIPTION
## Summary

Apply the recommended fix from PR #853 (15y trade-count investigation): scenario-level `config_overrides` on `goldens-sp500-historical/sp500-2010-2026.sexp` ONLY. Default `Portfolio_risk.config` unchanged (other goldens depend on it).

```
max_position_pct_long  0.30 → 0.05
max_long_exposure_pct  0.90 → 0.50
min_cash_pct           0.10 → 0.30
```

## Why

Per #853 investigation, the 16-trade-over-16-years count is dominated by Day-1 cash exhaustion (4 positions consumed $993K of $1M, 3 hitting `max_position_pct_long` cap; 8 long-runners pinned $949K cost basis for 15 years; skip ratio 271 Insufficient_cash : 37 Stop_too_wide).

## Expected impact

Per #853 estimate: **200-400 trades over 16 years** (vs current 16). Verification run kicked off; results in PR comment when finished (~7-12 min).

## Stacked on #853

This PR depends on #853's investigation note context being on main. Base = #853's branch; will rebase onto main after #853 merges.

## Test plan

- [x] `jj diff --stat` shows only `sp500-2010-2026.sexp` (16 ins / 1 del)
- [x] No source-code changes
- [ ] 15y backtest verifies trade count rises to expected 200-400 range