### PR TITLE
fix(panel_runner): re-route strategy bar reader to snapshot views (closes #848)

### DIFF
--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -2,10 +2,8 @@
 
 open Core
 open Trading_simulation
-module Symbol_index = Data_panel.Symbol_index
-module Ohlcv_panels = Data_panel.Ohlcv_panels
-module Bar_panels = Data_panel.Bar_panels
 module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
 module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
 
 type input = {
@@ -157,11 +155,11 @@ let _final_close_prices ~daily_panels ~symbols ~end_date =
       List.filter_map symbols
         ~f:(_read_close ~daily_panels ~close_col ~date:end_date)
 
-(* Resolve the [(snapshot_dir, manifest)] pair the simulator will read through
-   for per-tick price reads + final-close lookups. CSV mode delegates to
-   [Csv_snapshot_builder.build]; Snapshot mode reuses the caller-provided
-   directory. The strategy's bar reads do NOT flow through this snapshot —
-   see [_build_panel_bar_reader] for the panel-backed strategy reader. *)
+(* Resolve the [(snapshot_dir, manifest)] pair the runner reads through for
+   the strategy's bar reads (via [_build_snapshot_bar_reader]), the
+   simulator's per-tick price reads, and final-close lookups. CSV mode
+   delegates to [Csv_snapshot_builder.build]; Snapshot mode reuses the
+   caller-provided directory. *)
 let _resolve_snapshot_source (input : input) ~warmup_start ~end_date
     ~bar_data_source =
   match bar_data_source with
@@ -180,8 +178,9 @@ let _resolve_snapshot_source (input : input) ~warmup_start ~end_date
 (* Generate the trading-day calendar: every weekday (Mon-Fri) in the inclusive
    range [start..end_]. Holidays are not removed — the simulator already
    tolerates "no bar on this day" via the [is_trading_day] filter, and the
-   panel cells stay NaN on holidays. Used for the strategy's [Bar_panels.t]
-   build. *)
+   strategy's snapshot-backed [daily_view_for] walks calendar columns
+   identically to the prior panel path's [Bar_panels.daily_view_for] (PR1 of
+   the #848 forward fix; see [Bar_reader.of_snapshot_views]). *)
 let _build_calendar ~start ~end_ : Date.t array =
   let rec loop d acc =
     if Date.( > ) d end_ then List.rev acc
@@ -196,49 +195,35 @@ let _build_calendar ~start ~end_ : Date.t array =
   in
   Array.of_list (loop start [])
 
-(* Build OHLCV panels from CSV using the calendar-aware loader. The universe is
-   exactly [input.all_symbols] so the panel covers every symbol the simulator
-   will fetch bars for (universe + index + sector ETFs + global indices). This
-   is the strategy's bar source; the simulator's per-tick reads still flow
-   through the snapshot adapter. See module-doc for the partial-revert
-   rationale. *)
-let _build_ohlcv ~(input : input) ~calendar =
-  let symbol_index =
-    match Symbol_index.create ~universe:input.all_symbols with
-    | Ok t -> t
-    | Error err ->
-        failwithf "Panel_runner: Symbol_index.create failed: %s"
-          err.Status.message ()
-  in
-  match
-    Ohlcv_panels.load_from_csv_calendar symbol_index
-      ~data_dir:input.data_dir_fpath ~calendar
-  with
-  | Ok t -> t
-  | Error err ->
-      failwithf "Panel_runner: Ohlcv_panels.load_from_csv_calendar failed: %s"
-        (Status.show err) ()
+(* Build a snapshot-backed [Bar_reader.t] for the strategy: derive the
+   field-accessor [Snapshot_callbacks.t] from the same [Daily_panels.t] the
+   simulator + final-close lookup already use, then wrap in a
+   [Bar_reader.of_snapshot_views] passing the runner's [calendar]. The
+   calendar threads through to [Snapshot_bar_views.daily_view_for] /
+   [low_window], which walk calendar columns NaN-passthrough identically to
+   the old [Bar_panels.daily_view_for] window definition — closing the
+   path-dependent regression that motivated this rewiring.
 
-(* Build a panel-backed [Bar_reader.t] for the strategy: load OHLCV from CSV
-   on [calendar], wrap in a [Bar_panels.t], wrap in a [Bar_reader]. This is
-   the partial-revert path; the strategy's reads route through the panel
-   backing rather than [Snapshot_callbacks] until the forward fix lands. *)
-let _build_panel_bar_reader (input : input) ~warmup_start ~end_date =
-  let calendar = _build_calendar ~start:warmup_start ~end_:end_date in
-  let ohlcv = _build_ohlcv ~input ~calendar in
-  let bar_panels =
-    match Bar_panels.create ~ohlcv ~calendar with
-    | Ok p -> p
-    | Error err ->
-        failwithf "Panel_runner: Bar_panels.create failed: %s" (Status.show err)
-          ()
-  in
-  eprintf "Panel_runner: panels built (%d symbols × %d days) for strategy\n%!"
-    (Ohlcv_panels.n ohlcv) (Array.length calendar);
-  Weinstein_strategy.Bar_reader.of_panels bar_panels
+   This replaces the partial-revert [_build_panel_bar_reader] that loaded a
+   parallel [Bar_panels.t] from CSV on the same calendar. The snapshot path
+   reuses the LRU-bounded [Daily_panels.t] for both strategy bar reads and
+   simulator price reads, so we no longer hold two full per-symbol bar
+   stores resident at the same time.
 
-(* Hybrid setup: panel-backed strategy bar reader, snapshot-backed simulator
-   adapter, snapshot-backed final-close lookup. See module-doc. *)
+   Refs: closes the regression on Bar_reader.of_snapshot_views (the
+   [~calendar] plumbing on the snapshot views that this constructor now
+   consumes was introduced in a separate prior PR). *)
+let _build_snapshot_bar_reader ~daily_panels ~calendar =
+  let callbacks = Snapshot_callbacks.of_daily_panels daily_panels in
+  eprintf
+    "Panel_runner: snapshot bar reader wired (calendar %d days) for strategy\n\
+     %!"
+    (Array.length calendar);
+  Weinstein_strategy.Bar_reader.of_snapshot_views ~calendar callbacks
+
+(* Hybrid setup: snapshot-backed strategy bar reader, snapshot-backed
+   simulator adapter, snapshot-backed final-close lookup — all reading
+   through one [Daily_panels.t]. See module-doc. *)
 let _setup_hybrid (input : input) ~snapshot_dir ~manifest ~warmup_start
     ~end_date ~audit_recorder =
   let daily_panels =
@@ -251,7 +236,8 @@ let _setup_hybrid (input : input) ~snapshot_dir ~manifest ~warmup_start
         failwithf "Panel_runner: Daily_panels.create failed: %s"
           (Status.show err) ()
   in
-  let bar_reader = _build_panel_bar_reader input ~warmup_start ~end_date in
+  let calendar = _build_calendar ~start:warmup_start ~end_:end_date in
+  let bar_reader = _build_snapshot_bar_reader ~daily_panels ~calendar in
   let strategy = _build_strategy input ~bar_reader ~audit_recorder in
   let adapter =
     _build_market_data_adapter ~data_dir:input.data_dir_fpath

--- a/trading/trading/backtest/lib/panel_runner.mli
+++ b/trading/trading/backtest/lib/panel_runner.mli
@@ -1,13 +1,21 @@
 (** Panel-loader execution path — runner-side seam for the simulator + Weinstein
     strategy.
 
-    The runner uses a hybrid setup (partial revert of #828, closes #843):
+    Post-#848 forward fix (PR2 of two; PR1 #861 added the [~calendar] plumbing
+    on [Snapshot_bar_views] / [Bar_reader.of_snapshot_views]). All three reader
+    surfaces fan out from one snapshot directory:
 
-    - The strategy's [Bar_reader] is panel-backed: an [Ohlcv_panels.t] is loaded
-      from CSV via [Ohlcv_panels.load_from_csv_calendar] at runner start,
-      wrapped in a [Bar_panels.t], and exposed via [Bar_reader.of_panels]. The
-      F.3.a-3 attempt to migrate the strategy's reads to [Snapshot_callbacks]
-      produced a path-dependent regression on sp500-2019-2023 (#843).
+    - The strategy's [Bar_reader] is snapshot-backed:
+      [Bar_reader.of_snapshot_views ~calendar] is built over a
+      [Snapshot_callbacks.of_daily_panels] shim around the same [Daily_panels.t]
+      the simulator and final-close lookup use. The [~calendar] argument is the
+      trading-day calendar (Mon–Fri, holidays included) the runner builds for
+      the warmup..end_date span; threading it through makes
+      [Snapshot_bar_views.daily_view_for] walk calendar columns NaN-passthrough
+      identically to the prior [Bar_panels.daily_view_for] window definition.
+      This is the closing half of #848 — see
+      `dev/notes/path-dependent-regression-848-investigation-2026-05-05.md` for
+      the cell-by-cell parity surface.
     - The simulator's per-tick price reads flow through a snapshot-backed
       [Market_data_adapter]. CSV mode builds the snapshot directory in-process
       from CSV bars at runner start (via [Csv_snapshot_builder]); Snapshot mode
@@ -15,9 +23,9 @@
     - Final close-price lookups read from the [Snapshot_runtime.Daily_panels]
       via [Daily_panels.read_today].
 
-    The [Panel_strategy_wrapper] (panel-backed [get_indicator_fn] injector) is
-    gone — the Weinstein strategy ignores [get_indicator], so the wrapper was
-    pure overhead. The [Indicator_panels.t] allocation is also gone. *)
+    The runner no longer holds a parallel [Bar_panels.t] resident — the
+    partial-revert [_build_panel_bar_reader] is gone, along with the CSV
+    [Ohlcv_panels.load_from_csv_calendar] load. *)
 
 open Core
 
@@ -83,9 +91,9 @@ val run :
     state. When [None], the runner takes no extra work — same zero-overhead
     contract as the other optional plumbing.
 
-    [bar_data_source], when passed, selects how the simulator's snapshot
-    directory is sourced. (The strategy's panel-backed bar reader is unaffected
-    — it always loads from CSV at runner start.)
+    [bar_data_source], when passed, selects how the snapshot directory is
+    sourced. The strategy's bar reader, the simulator adapter, and the
+    final-close lookup all read through this same snapshot.
 
     - Default ({!Bar_data_source.Csv}) builds a snapshot directory in-process
       from the universe's CSV bars at runner start, then routes the simulator
@@ -94,7 +102,9 @@ val run :
     - {!Bar_data_source.Snapshot} reuses a caller-provided pre-built snapshot
       directory + manifest (typically written by [build_snapshots.exe]).
 
-    Both branches use the same hybrid wiring (panel-backed strategy reader +
-    snapshot-backed simulator adapter); the only difference is whether the
-    snapshot directory was materialised in-process or supplied externally. See
-    `dev/notes/parity-bisect-...md` for the partial-revert bisect. *)
+    Both branches use the same wiring (snapshot-backed strategy reader +
+    snapshot-backed simulator adapter, fanning out from one [Daily_panels.t]);
+    the only difference is whether the snapshot directory was materialised
+    in-process or supplied externally. See
+    `dev/notes/path-dependent-regression-848-investigation-2026-05-05.md` for
+    the path-dependence surface this rewiring closes. *)


### PR DESCRIPTION
## Summary
- PR2 of two for the #848 forward fix. PR1 (#861) added the `~calendar` plumbing on `Snapshot_bar_views.daily_view_for` / `low_window` and exposed it via `Bar_reader.of_snapshot_views ~calendar`. This PR rewires `Panel_runner._setup_hybrid` to use that constructor.
- The strategy's bar reader now fans out from the same `Daily_panels.t` instance the simulator adapter and final-close lookup already use, with the runner's trading-day calendar threaded through. `daily_view_for`'s window walking matches the prior `Bar_panels.daily_view_for` behaviour cell-by-cell.
- Drops the partial-revert `_build_panel_bar_reader` helper plus the parallel `Bar_panels.t` build (`Ohlcv_panels.load_from_csv_calendar`). The runner no longer holds two full per-symbol bar stores resident at the same time.

## Why
Investigation note `dev/notes/path-dependent-regression-848-investigation-2026-05-05.md` traced the panel-vs-snapshot divergence to a window-definition mismatch on `daily_view_for` (and the unused `low_window`). PR1 closed the underlying view divergence by making `Snapshot_bar_views.daily_view_for` accept a `~calendar` and walk it identically to the panel path. This PR exercises that fix in the runner, completing the #848 closure.

## Test plan
- [x] `dune build` clean (zero warnings).
- [x] `dune runtest trading/backtest/` clean — including the panel-mode golden parity test (`test_panel_loader_parity.ml`) which pins `round_trips` against checked-in goldens. The snapshot-backed reader produces bit-equal trades.
- [x] sp500-2019-2023 baseline run on 503-symbol post-#851 universe:

  | metric | actual | fixture-pinned (post-#857) | within fixture range |
  |---|---|---|---|
  | total_return_pct  | 58.34  | 58.34  | yes ([45.0, 72.0]) |
  | total_trades      | 81     | 81     | yes ([70, 95]) |
  | win_rate          | 19.75  | 19.75  | yes ([15.0, 28.0]) |
  | sharpe_ratio      | 0.54   | 0.54   | yes ([0.35, 0.70]) |
  | max_drawdown_pct  | 33.60  | 33.60  | yes ([28.0, 42.0]) |
  | avg_holding_days  | 84.10  | 84.10  | yes ([70.0, 110.0]) |
  | open_positions_value | 1,553,948.90 | 1,553,948.90 | yes ([1.3M, 1.8M]) |

  Bit-equal to the post-#857 tight-pinned scenario fixture baseline.

  Note: `dev/scripts/check_sp500_baseline.sh`'s hardcoded baseline (53.36% / 73 trades) appears stale relative to the post-#851 share-class-dedup universe (the script header refers to "503-symbol universe" but pinned numbers are from a pre-#851 measurement). The scenario fixture file's pinned `expected` ranges (set in #857) are the canonical post-#851 baseline, and we match those exactly.

## Files
- `trading/trading/backtest/lib/panel_runner.ml` — replace `_build_panel_bar_reader` with `_build_snapshot_bar_reader` over `Snapshot_callbacks.of_daily_panels`; thread `calendar` through `Bar_reader.of_snapshot_views`. Drop now-dead `_build_ohlcv` helper and the `Symbol_index` / `Ohlcv_panels` / `Bar_panels` module aliases.
- `trading/trading/backtest/lib/panel_runner.mli` — module docstring rewritten to describe the snapshot-backed strategy reader path.

## References
- Closes #848
- Builds on #861 (PR1, calendar plumbing)
- Investigation: `dev/notes/path-dependent-regression-848-investigation-2026-05-05.md`
- Bisect record: `dev/notes/parity-bisect-2026-05-04.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
