### PR TITLE
feat(backtest): #856 grid sweep on max_position_pct_long (15y SP500)

### DIFF
--- a/dev/notes/856-grid-sweep-2026-05-05.md
+++ b/dev/notes/856-grid-sweep-2026-05-05.md
@@ -13,7 +13,7 @@ ceiling on this strategy/universe combination:
 - **Total trades ∈ [200, 400]**: NO cell — max is 102 trades at the
   current `0.05` baseline; the `[200, 400]` band is unreachable on $1M
   initial cash with default-shaped per-trade dollar-risk sizing.
-- **Sharpe ≥ 0.6**: 4 of 6 settings hit it (`0.10`, `0.13`, `0.16`, `0.20`),
+- **Sharpe ≥ 0.6**: 4 of 5 swept cells hit it (`0.10`, `0.13`, `0.16`, `0.20`),
   but all of those have ≤38 trades.
 
 **Recommendation:** *do not* flip the fixture override based on this
@@ -82,7 +82,7 @@ Acceptance gates per #856 (all three must hit):
 | 0.20                  |          9.36  |  0.55  |           29 |     27.59  |  0.63  |          14.99 |          164.03  |
 | 0.30 (default, pre-#855) |       16.30  |  0.93  |           16 |     18.75  |  0.91  |          17.20 |          186.60  |
 
-CAGR computed over the 16.25-year 2010-01-01 → 2026-04-30 window.
+CAGR computed over the 16.33-year 2010-01-01 → 2026-04-30 window.
 
 ## Acceptance check
 
@@ -192,10 +192,11 @@ with the data above as the binding context.
 - **Win rate at `0.16` is 37.5%** — the highest in the sweep, vs.
   19-27% at other settings. Likely a small-sample artefact (24
   trades), but worth noting if the cell is selected for follow-up.
-- **`0.07` has the lowest MaxDD (13.5%)** — counterintuitive given the
-  larger-position settings (`0.13`, `0.16`) also have low MaxDD (13.0,
-  14.5%). Smaller positions absorb larger moves with smaller dollar
-  drawdowns.
+- **`0.13` has the lowest MaxDD (12.98%)** — counterintuitive given that
+  larger-position settings concentrate exposure; `0.07` (13.52%) and the
+  larger `0.16` (14.50%) both come in higher. The `0.13` cell's combination
+  of moderate concurrent-position count with fewer marginal entries appears
+  to absorb drawdowns better than either extreme.
 - The earlier crash at cell-007 cycle 480 corresponds to a 2018Q4 /
   COVID-era simulation date — high-volatility periods with many
   concurrent positions in flight.

--- a/dev/notes/856-grid-sweep-2026-05-05.md
+++ b/dev/notes/856-grid-sweep-2026-05-05.md
@@ -1,0 +1,250 @@
+# Issue #856 grid sweep — 15y SP500 `max_position_pct_long` (2026-05-05)
+
+Grid-sweep five values of `max_position_pct_long` on the 15y SP500
+`goldens-sp500-historical/sp500-2010-2026` scenario to find a setting
+that satisfies #856's acceptance gates.
+
+## TL;DR
+
+**No cell passes all three acceptance gates.** The sweep reveals a hard
+ceiling on this strategy/universe combination:
+
+- **Total return ≥ 50%**: NO cell — max is 16.41% (cell-013, ≈0.94% CAGR).
+- **Total trades ∈ [200, 400]**: NO cell — max is 102 trades at the
+  current `0.05` baseline; the `[200, 400]` band is unreachable on $1M
+  initial cash with default-shaped per-trade dollar-risk sizing.
+- **Sharpe ≥ 0.6**: 4 of 6 settings hit it (`0.10`, `0.13`, `0.16`, `0.20`),
+  but all of those have ≤38 trades.
+
+**Recommendation:** *do not* flip the fixture override based on this
+sweep alone. Two of the three #856 gates (return + trade count) require
+deeper changes than position-sizing tuning — flagged as follow-ups
+below. As a transitional fixture choice, `max_position_pct_long: 0.13`
+is the **best Sharpe + return + drawdown combination** of the swept set
+(16.4% return, 0.98 Sharpe, 13.0% MaxDD), but it doesn't hit the
+acceptance bar. Treat the bar as aspirational pending strategy work.
+
+## Context
+
+PR #855 added a 3-line `config_overrides` block to the 15y fixture
+(`max_position_pct_long: 0.05`, `max_long_exposure_pct: 0.50`,
+`min_cash_pct: 0.30`) to fix the 16-trades-over-16-years issue from #853.
+Trade count went 16 → 102, but CAGR collapsed to 0.31% (vs 0.95% pre-fix).
+
+qc-behavioral on #855 found that two of the three overrides are **inert**:
+
+- **`max_long_exposure_pct`** — dominated by `Float.min(per_position,
+  exposure)` whenever `per_position` is the tighter cap (i.e. always at
+  sub-10% per-position settings).
+- **`min_cash_pct`** — `Portfolio_risk._check_cash` exists, but
+  `Portfolio_risk.check_limits` has no production caller in the strategy
+  hot path (only in test code). Setting it has zero effect on entries.
+
+Verified: `grep -rn "Portfolio_risk.check_limits\|check_limits"
+trading/trading/weinstein/strategy/` returns no hits.
+
+Only **`max_position_pct_long`** is the binding knob. This sweep tests
+{0.07, 0.10, 0.13, 0.16, 0.20} with everything else held at the #855
+fixture state.
+
+Acceptance gates per #856 (all three must hit):
+
+- total_return_pct ≥ 50%
+- total_trades ∈ [200, 400]
+- sharpe_ratio ≥ 0.6
+
+## Method
+
+- Scenario fixtures: `trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-{007,010,013,016,020}.sexp`.
+  Each clones the 15y window + 510-sym universe; only
+  `max_position_pct_long` varies. `enable_short_side false` is preserved.
+  `max_long_exposure_pct` and `min_cash_pct` are dropped from the sweep
+  per the qc-behavioral #855 F1 finding above.
+- Runner: `scenario_runner.exe --dir <sweeps-dir> --parallel 2 --progress-every 24`.
+- Cells 010, 013, 016, 020 ran successfully. Cell-007 OOM-killed at
+  cycle 480/882 in the parallel run (memory pressure: 5 concurrent
+  large runs initially saturated container's 7.8 GB; even with
+  parallel=2 the dual-cell + concurrent agent's `goldens-sp500` run
+  drove the 0.07 cell — the heaviest position-count case — out of
+  memory). Re-run alone (`--parallel 1`) succeeded.
+- Total wall: ~85 min including the failed parallel-5 attempt + parallel-2
+  pass + cell-007 sequential re-run.
+
+## Results
+
+| max_position_pct_long | total_return % | CAGR % | total_trades | win_rate % | sharpe | max_drawdown % | avg_holding_days |
+|-----------------------|---------------:|-------:|-------------:|-----------:|-------:|---------------:|-----------------:|
+| 0.05 (#855 baseline)  |          5.15  |  0.31  |          102 |     21.57  |  0.40  |          16.12 |          130.58  |
+| 0.07                  |          6.22  |  0.37  |           86 |     26.74  |  0.47  |          13.52 |          141.97  |
+| 0.10                  |          9.16  |  0.54  |           37 |     18.92  |  0.61  |          15.50 |          213.73  |
+| **0.13**              |     **16.41**  |**0.94**|           38 |     21.05  |**0.98**|      **12.98** |          138.50  |
+| 0.16                  |         12.08  |  0.70  |           24 |     37.50  |  0.71  |          14.50 |          136.29  |
+| 0.20                  |          9.36  |  0.55  |           29 |     27.59  |  0.63  |          14.99 |          164.03  |
+| 0.30 (default, pre-#855) |       16.30  |  0.93  |           16 |     18.75  |  0.91  |          17.20 |          186.60  |
+
+CAGR computed over the 16.25-year 2010-01-01 → 2026-04-30 window.
+
+## Acceptance check
+
+| Cell | total_return ≥ 50% | total_trades ∈ [200, 400] | sharpe ≥ 0.6 | All 3? |
+|------|:------------------:|:-------------------------:|:------------:|:------:|
+| 0.07 | NO (6.22%)         | NO (86)                   | NO (0.47)    | NO     |
+| 0.10 | NO (9.16%)         | NO (37)                   | YES (0.61)   | NO     |
+| 0.13 | NO (16.41%)        | NO (38)                   | YES (0.98)   | NO     |
+| 0.16 | NO (12.08%)        | NO (24)                   | YES (0.71)   | NO     |
+| 0.20 | NO (9.36%)         | NO (29)                   | YES (0.63)   | NO     |
+
+**No cell passes all three gates.**
+
+## Observations
+
+1. **Trade count and per-position size move opposite ways, as expected**, but
+   the trade-count axis is asymmetric. Going 0.05 → 0.30 collapses trade
+   count from 102 → 16 (6.4× drop), but the [200, 400] band is unreachable
+   from any `max_position_pct_long` setting alone. Hitting 200+ trades
+   requires loosening **other** caps too (entry stop-distance gate, cash
+   floor) or starting cash > $1M, or both.
+
+2. **Return as a function of position size is non-monotonic** — peaks
+   at `0.13` (16.41%), drops on either side. Mechanism (probable):
+   - `0.05`-`0.10`: too many small positions → too much capital sitting
+     in mediocre stage-2 setups dragging the overall return.
+   - `0.13`: sweet spot — 8-10 simultaneous positions × ~$130K each.
+     Decent diversification without per-trade gain dilution.
+   - `0.16`-`0.30`: positions get bigger but fewer trades fire (the
+     `Insufficient_cash` skip rate climbs again, mirroring the
+     pre-#855 behaviour from `dev/notes/15y-trade-count-investigation`).
+
+3. **Sharpe ≥ 0.6 is satisfied by cells 0.10, 0.13, 0.16, 0.20.**
+   `0.13` is the clean winner on Sharpe (0.98) and also has the lowest
+   MaxDD (12.98%). All four "passing-Sharpe" cells exceed the
+   default's 0.91 in some respect; `0.13` is roughly equivalent to the
+   default on return but with **less drawdown, more trades, more
+   recent** equity curve.
+
+4. **The pre-fix `0.30` default's 0.91 Sharpe vs. current `0.05`'s 0.40
+   was the primary qc-behavioral observation in #855.** The sweep
+   confirms: the default's apparent strength was a small-sample
+   artifact (only 16 trades capturing a few big winners), while the
+   `0.13` cell achieves comparable return with 2.4× more trades — a
+   more statistically robust pin point.
+
+5. **Cell-007 OOM during parallel-5 was a memory artefact, not a
+   strategy artefact.** The 0.07 setting puts the most simultaneous
+   positions on the books (~14-20 vs ~3-8 at 0.16+); each open position
+   carries weekly-MA cache + stop_state + screener context, so peak
+   RSS scales with portfolio breadth. Mitigation: `--parallel 2` is
+   the new ceiling for 15y goldens; `--parallel 1` is required for
+   `max_position_pct_long ≤ 0.07`.
+
+## Recommendation
+
+Do **not** change the fixture's `max_position_pct_long` from 0.05 to
+anything else **as a result of this sweep alone**, because:
+
+- No cell satisfies #856's acceptance bar; flipping the override
+  doesn't actually close the issue.
+- The `0.05` override exists to enforce the *trade-count fix* from
+  #855. Trade count drops sharply for any value > 0.05 (102 → 86 → 37).
+  Switching the override to `0.13` would be giving up trade count in
+  exchange for higher return — but the higher return still doesn't
+  meet the acceptance bar (16.41% vs ≥50% target).
+
+If the acceptance bar is itself unrealistic — i.e., the strategy on
+this universe genuinely cannot achieve 50% return with 200+ trades on
+$1M starting cash — that's a strategy-level finding, not a tuning
+finding. Recommend:
+
+1. **Open a follow-up issue: "15y CAGR target unreachable via
+   position-sizing alone"** referencing this sweep + `dev/notes/15y-trade-count-investigation-2026-05-05.md`.
+   The follow-up should test: (a) higher initial cash ($5M–$10M)
+   removes the trade-count ceiling; (b) loosening `max_stop_distance_pct`
+   admits more entries (currently 37 cycles cite Stop_too_wide); (c)
+   removing the `Insufficient_cash` skip mechanism at sizing time
+   (so the strategy enters at smaller-than-target size rather than
+   skipping); (d) the screener-cascade ranking quality (winners' P&L
+   distribution among the entered trades).
+2. **Pin a Sharpe-target-only fixture variant** — copy the 15y
+   fixture as `goldens-sp500-historical/sp500-2010-2026-pos013.sexp`
+   with `max_position_pct_long: 0.13`. This documents the "best
+   Sharpe + return achievable via sizing alone" baseline for future
+   comparisons, without competing with the canonical fixture's
+   trade-count guarantee.
+3. **Loosen the canonical fixture's `expected.sharpe_ratio` band to
+   include 0.30..0.65** (currently 0.25..0.65 — already wide enough
+   per #855), but **leave `max_position_pct_long: 0.05`** so the
+   trade-count regression check still fires.
+
+If the acceptance bar **must** be hit on the canonical fixture, the
+required changes are deeper than position-sizing — they involve the
+strategy's stop-distance and cash-skip gates. Those are
+`feat-weinstein` territory; this issue should hand off to that track
+with the data above as the binding context.
+
+## Surprises
+
+- **Cell-013's (`max_position_pct_long=0.13`) Sharpe of 0.98 was
+  unexpectedly high** — better than the pre-fix `0.30` default's 0.91.
+  The default at 0.30 had `Insufficient_cash` skipping out the bottom
+  16 trades; at 0.13 the strategy enters 38 trades but the additional
+  22 trades happened to include winners that improved both the return
+  and the variance of the daily-return series, lifting Sharpe.
+- **Win rate at `0.16` is 37.5%** — the highest in the sweep, vs.
+  19-27% at other settings. Likely a small-sample artefact (24
+  trades), but worth noting if the cell is selected for follow-up.
+- **`0.07` has the lowest MaxDD (13.5%)** — counterintuitive given the
+  larger-position settings (`0.13`, `0.16`) also have low MaxDD (13.0,
+  14.5%). Smaller positions absorb larger moves with smaller dollar
+  drawdowns.
+- The earlier crash at cell-007 cycle 480 corresponds to a 2018Q4 /
+  COVID-era simulation date — high-volatility periods with many
+  concurrent positions in flight.
+
+## Output artefacts
+
+- Sweep run dir: `dev/backtest/scenarios-2026-05-05-195959/sweep-856-cell-{010,013,016,020}/`
+  (each contains `actual.sexp`, `summary.sexp`, `trades.csv`, `params.sexp`).
+- Cell-007 re-run: `dev/backtest/scenarios-2026-05-05-210054/sweep-856-cell-007/`.
+- Scenario fixtures: `trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/`.
+- Sweep stdout log: `/tmp/856-sweep-logs/sweep-run-p2.log` (host) and
+  per-cell `progress.sexp` files.
+
+## Next actions
+
+In priority order:
+
+1. **Decision: how to close #856.** Three reasonable paths:
+   - **Close as "infeasible without strategy work"** — link this doc;
+     defer the 50%/200-400/0.6 bar to follow-up issue (option in
+     §Recommendation #1).
+   - **Loosen acceptance bar** to "Sharpe ≥ 0.6 AND total_return ≥ 10%
+     AND trades ≥ 30" — under that bar, the `0.13` cell passes; flip
+     the fixture to `0.13`.
+   - **Keep open** with an explicit "blocked on stop-distance/cash-skip
+     tuning" tag.
+
+2. **Do NOT bundle a fixture-flip with this sweep PR.** If the maintainer
+   chooses path 2 above, the fixture flip is a separate decision —
+   land it in a follow-up PR after #856 is re-scoped.
+
+3. **Tighten the M5.5 T-A grid_search CLI binary as the next experiment.**
+   This sweep was hand-wired (5 sexp fixtures + scenario_runner). The
+   shipped grid_search lib (PR #805) was designed for this surface;
+   the deferred CLI binary would have made this sweep two lines instead
+   of two hours. See `dev/status/tuning.md` §Next Steps #1.
+
+4. **Open a follow-up issue tracking the 15y CAGR ceiling**, referencing
+   this sweep + `dev/notes/15y-trade-count-investigation-2026-05-05.md`
+   §"Quantitative breakdown".
+
+## Cross-refs
+
+- Issue: https://github.com/dayfine/trading/issues/856
+- Predecessor: PR #855 (override that triggered the return collapse)
+- Predecessor: `dev/notes/15y-trade-count-investigation-2026-05-05.md`
+  (root-cause of the 16-trade pre-fix state)
+- Sibling baseline: `dev/notes/next-session-priorities-2026-05-05.md` §
+  "15y SP500"
+- Tuning lib used: `trading/trading/backtest/tuner/lib/grid_search.{ml,mli}`
+  (PR #805) — the sweep was hand-wired but the lib's evaluator-callback
+  shape would directly support this if the CLI binary were wired.

--- a/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-007.sexp
+++ b/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-007.sexp
@@ -1,0 +1,31 @@
+;; #856 grid sweep cell — max_position_pct_long = 0.07
+;;
+;; Sweep over {0.07, 0.10, 0.13, 0.16, 0.20} per dev/notes/next-session-priorities-2026-05-05.md.
+;; Background: #855 baseline at 0.05 → 5.15% return / 102 trades / 0.40 Sharpe.
+;; Acceptance gates: total_return_pct ≥ 50% AND total_trades ∈ [200, 400] AND
+;; sharpe_ratio ≥ 0.6 (per #856).
+;;
+;; All other config matches goldens-sp500-historical/sp500-2010-2026.sexp;
+;; only `max_position_pct_long` varies per cell. Note: per qc-behavioral on
+;; #855 F1, `max_long_exposure_pct` and `min_cash_pct` are inert under default
+;; sizing (per_position dominates, and min_cash_pct has no production caller),
+;; so we drop them from the sweep but DO keep `enable_short_side false`.
+;;
+;; Wide expected ranges intentional — we want raw metrics in actual.sexp, not
+;; pass/fail. Per-cell wall ~7-12 min (per #845 Daily_panels O(log N) reads).
+((name "sweep-856-cell-007")
+ (description
+   "#856 grid cell: max_position_pct_long=0.07; 15y sp500 historical (510-sym); base=sp500-2010-2026 fixture")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.07))))))
+ (expected
+  ((total_return_pct   ((min -100.0)        (max 1000.0)))
+   (total_trades       ((min    0)          (max 5000)))
+   (win_rate           ((min    0.0)        (max  100.0)))
+   (sharpe_ratio       ((min   -5.0)        (max    5.0)))
+   (max_drawdown_pct   ((min    0.0)        (max  100.0)))
+   (avg_holding_days   ((min    0.0)        (max 5000.0))))))

--- a/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-010.sexp
+++ b/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-010.sexp
@@ -1,0 +1,18 @@
+;; #856 grid sweep cell — max_position_pct_long = 0.10
+;; See cell-007.sexp for sweep context.
+((name "sweep-856-cell-010")
+ (description
+   "#856 grid cell: max_position_pct_long=0.10; 15y sp500 historical (510-sym); base=sp500-2010-2026 fixture")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.10))))))
+ (expected
+  ((total_return_pct   ((min -100.0)        (max 1000.0)))
+   (total_trades       ((min    0)          (max 5000)))
+   (win_rate           ((min    0.0)        (max  100.0)))
+   (sharpe_ratio       ((min   -5.0)        (max    5.0)))
+   (max_drawdown_pct   ((min    0.0)        (max  100.0)))
+   (avg_holding_days   ((min    0.0)        (max 5000.0))))))

--- a/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-013.sexp
+++ b/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-013.sexp
@@ -1,0 +1,18 @@
+;; #856 grid sweep cell — max_position_pct_long = 0.13
+;; See cell-007.sexp for sweep context.
+((name "sweep-856-cell-013")
+ (description
+   "#856 grid cell: max_position_pct_long=0.13; 15y sp500 historical (510-sym); base=sp500-2010-2026 fixture")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.13))))))
+ (expected
+  ((total_return_pct   ((min -100.0)        (max 1000.0)))
+   (total_trades       ((min    0)          (max 5000)))
+   (win_rate           ((min    0.0)        (max  100.0)))
+   (sharpe_ratio       ((min   -5.0)        (max    5.0)))
+   (max_drawdown_pct   ((min    0.0)        (max  100.0)))
+   (avg_holding_days   ((min    0.0)        (max 5000.0))))))

--- a/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-016.sexp
+++ b/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-016.sexp
@@ -1,0 +1,18 @@
+;; #856 grid sweep cell — max_position_pct_long = 0.16
+;; See cell-007.sexp for sweep context.
+((name "sweep-856-cell-016")
+ (description
+   "#856 grid cell: max_position_pct_long=0.16; 15y sp500 historical (510-sym); base=sp500-2010-2026 fixture")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.16))))))
+ (expected
+  ((total_return_pct   ((min -100.0)        (max 1000.0)))
+   (total_trades       ((min    0)          (max 5000)))
+   (win_rate           ((min    0.0)        (max  100.0)))
+   (sharpe_ratio       ((min   -5.0)        (max    5.0)))
+   (max_drawdown_pct   ((min    0.0)        (max  100.0)))
+   (avg_holding_days   ((min    0.0)        (max 5000.0))))))

--- a/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-020.sexp
+++ b/trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-020.sexp
@@ -1,0 +1,18 @@
+;; #856 grid sweep cell — max_position_pct_long = 0.20
+;; See cell-007.sexp for sweep context.
+((name "sweep-856-cell-020")
+ (description
+   "#856 grid cell: max_position_pct_long=0.20; 15y sp500 historical (510-sym); base=sp500-2010-2026 fixture")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.20))))))
+ (expected
+  ((total_return_pct   ((min -100.0)        (max 1000.0)))
+   (total_trades       ((min    0)          (max 5000)))
+   (win_rate           ((min    0.0)        (max  100.0)))
+   (sharpe_ratio       ((min   -5.0)        (max    5.0)))
+   (max_drawdown_pct   ((min    0.0)        (max  100.0)))
+   (avg_holding_days   ((min    0.0)        (max 5000.0))))))


### PR DESCRIPTION
## Summary

Grid sweep over `max_position_pct_long` ∈ {0.07, 0.10, 0.13, 0.16, 0.20}
on `goldens-sp500-historical/sp500-2010-2026` to test #856's acceptance
gates (≥50% return AND 200-400 trades AND ≥0.6 Sharpe).

**Result:** No cell passes all three gates. The 50% return + 200-400
trade-count bar is unreachable via position-sizing alone; both require
deeper strategy changes (the `Insufficient_cash` skip mechanism and the
`max_stop_distance_pct` gate). The Sharpe gate IS reachable: 4 of 5
swept cells satisfy it, with `0.13` the clean winner at **16.4% return,
0.98 Sharpe, 13.0% MaxDD, 38 trades**.

## Recommendation

- Do NOT flip the fixture's `max_position_pct_long` from the current
  `0.05` based on this sweep alone — `0.05` enforces the trade-count
  fix from #855, and no candidate setting closes #856's gates.
- Re-scope #856: either accept that the bar requires strategy work
  (file follow-up referencing this sweep + `dev/notes/15y-trade-count-investigation-2026-05-05.md`)
  or loosen the bar.
- Pin a `0.13`-variant fixture as a "best-Sharpe-achievable-via-sizing"
  baseline; keep the canonical fixture at `0.05`.

See `dev/notes/856-grid-sweep-2026-05-05.md` for the full table,
acceptance check, observations, and 4 follow-up actions.

## Files

- `dev/notes/856-grid-sweep-2026-05-05.md` — sweep report (single doc).
- `trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct/cell-{007,010,013,016,020}.sexp` —
  5 scenario fixtures used by the sweep (kept for reproducibility +
  re-execution; ~25 LOC each).

## Test plan

- [ ] Verify `dune build` still passes (no code changed; only sexp +
      markdown adds).
- [ ] Verify the 5 scenario sexp files parse — invoke
      `scenario_runner.exe --dir trading/test_data/backtest_scenarios/sweeps/856-max-pos-pct
      --parallel 2 --progress-every 24` and confirm parsing (full run
      takes ~25-30 min wall — local-only, tier-4 data).
- [ ] Maintainer reviews `dev/notes/856-grid-sweep-2026-05-05.md` §
      "Recommendation" + § "Next actions" and chooses #856 disposition
      (close as infeasible / loosen bar / keep open).

## Notes

- One cell (`cell-007`, `max_position_pct_long=0.07`) OOM-killed in
  `--parallel 5`; re-ran successfully at `--parallel 1`. The 0.07
  setting puts the most simultaneous positions on the books, hence
  highest peak RSS. Documented in the report § Observations.
- Per `.claude/rules/no-python.md`, the CAGR computation in the report
  was done with a one-shot Python script during analysis but the
  output table is plain markdown — no Python code is added to the
  repo.
- The shipped M5.5 T-A `Tuner.Grid_search` lib (PR #805) was
  designed for this sweep shape, but its CLI binary is deferred. This
  sweep was hand-wired (5 sexp + scenario_runner). Wiring the binary
  is tracked in `dev/status/tuning.md` §Next Steps #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
