### PR TITLE
feat(snapshot): F.3.e-2 — delete Bar_reader.of_panels + panel helpers

### DIFF
--- a/trading/trading/weinstein/strategy/lib/bar_reader.ml
+++ b/trading/trading/weinstein/strategy/lib/bar_reader.ml
@@ -1,7 +1,6 @@
 (** Bar source abstraction — see [bar_reader.mli]. *)
 
 open Core
-module Bar_panels = Data_panel.Bar_panels
 module Snapshot_bar_views = Snapshot_runtime.Snapshot_bar_views
 module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
 module Daily_panels = Snapshot_runtime.Daily_panels
@@ -15,26 +14,29 @@ module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
    path invokes one of these closures per call site per tick — no backing
    dispatch, no variant match.
 
-   [ma_cache] is set by [of_panels] callers that build a cache up-front; the
-   other constructors leave it [None]. The strategy's cache-aware MA paths
-   key off [Some].
+   [ma_cache] is left [None] by every constructor since F.3.e-2 deleted
+   [of_panels]; the field is retained on the public surface for source
+   compatibility ([Bar_reader.ma_cache] callers in [Weinstein_strategy] /
+   [Exit_audit_capture] still compile and read [None]).
 
    [snapshot_callbacks] is the underlying field-accessor shim for
    {!of_snapshot_views} / {!of_in_memory_bars}. The strategy's macro / sector
    entry points consume this directly via the [*_of_snapshot_views] APIs
    on {!Macro_inputs} (Phase F.3.b-2 / c-2 / d-2 caller migration). For
-   panel-backed and empty readers, this is a sentinel cb whose every read
-   returns [Error NotFound]; the macro / sector path then sees empty views,
-   matching the prior bar-list / panel-view behaviour for readers that were
-   never meant to back a real screening run. *)
+   the empty reader, this is a sentinel cb whose every read returns
+   [Error NotFound]; the macro / sector path then sees empty views,
+   matching the prior bar-list / panel-view behaviour for the empty reader. *)
 type t = {
   daily_bars_for : symbol:string -> as_of:Date.t -> Types.Daily_price.t list;
   weekly_bars_for :
     symbol:string -> n:int -> as_of:Date.t -> Types.Daily_price.t list;
   weekly_view_for :
-    symbol:string -> n:int -> as_of:Date.t -> Bar_panels.weekly_view;
+    symbol:string -> n:int -> as_of:Date.t -> Snapshot_bar_views.weekly_view;
   daily_view_for :
-    symbol:string -> as_of:Date.t -> lookback:int -> Bar_panels.daily_view;
+    symbol:string ->
+    as_of:Date.t ->
+    lookback:int ->
+    Snapshot_bar_views.daily_view;
   ma_cache : Weekly_ma_cache.t option;
   snapshot_callbacks : Snapshot_callbacks.t;
 }
@@ -43,12 +45,10 @@ let ma_cache t = t.ma_cache
 let snapshot_callbacks t = t.snapshot_callbacks
 
 (* Sentinel cb for readers that have no underlying snapshot directory
-   ({!of_panels} and {!empty}). Every [read_field] / [read_field_history] call
-   returns [Error NotFound], which {!Snapshot_bar_views.weekly_view_for} /
+   ({!empty}). Every [read_field] / [read_field_history] call returns
+   [Error NotFound], which {!Snapshot_bar_views.weekly_view_for} /
    {!Snapshot_bar_views.weekly_bars_for} fold to the empty view / empty list.
-   This matches the contract for these constructors today: panel-backed
-   readers are unused in production after Phase F.3.a-3 redo, and the empty
-   reader is documented to return empty results from every read. *)
+   This matches {!empty}'s "every read returns empty" contract. *)
 let _empty_snapshot_callbacks : Snapshot_callbacks.t =
   let not_found =
     Error
@@ -64,9 +64,9 @@ let _empty_snapshot_callbacks : Snapshot_callbacks.t =
 
 (* Empty views — used as the sentinel return when [as_of] falls outside the
    snapshot's calendar or the snapshot has no rows. Match the empty literals
-   {!Bar_panels} / {!Snapshot_bar_views} use internally so consumers can rely
-   on [n = 0] / [n_days = 0] as the "missing" signal. *)
-let _empty_weekly_view : Bar_panels.weekly_view =
+   {!Snapshot_bar_views} uses internally so consumers can rely on [n = 0] /
+   [n_days = 0] as the "missing" signal. *)
+let _empty_weekly_view : Snapshot_bar_views.weekly_view =
   {
     closes = [||];
     raw_closes = [||];
@@ -77,57 +77,14 @@ let _empty_weekly_view : Bar_panels.weekly_view =
     n = 0;
   }
 
-let _empty_daily_view : Bar_panels.daily_view =
+let _empty_daily_view : Snapshot_bar_views.daily_view =
   { highs = [||]; lows = [||]; closes = [||]; dates = [||]; n_days = 0 }
-
-(* {1 Panel-backed constructor (Bar_panels.t over a CSV-loaded calendar)}
-
-   Restored by the partial revert of the Phase F.3.a-3 strategy-side flip.
-   The runner's strategy bar reads stay on this constructor until the
-   path-dependent divergence in {!of_snapshot_views} is forward-fixed; see
-   [bar_reader.mli] module-doc for context. *)
-
-let _panel_daily_bars_for panels ~symbol ~as_of =
-  match Bar_panels.column_of_date panels as_of with
-  | None -> []
-  | Some as_of_day -> Bar_panels.daily_bars_for panels ~symbol ~as_of_day
-
-let _panel_weekly_bars_for panels ~symbol ~n ~as_of =
-  match Bar_panels.column_of_date panels as_of with
-  | None -> []
-  | Some as_of_day -> Bar_panels.weekly_bars_for panels ~symbol ~n ~as_of_day
-
-let _panel_weekly_view_for panels ~symbol ~n ~as_of =
-  match Bar_panels.column_of_date panels as_of with
-  | None -> _empty_weekly_view
-  | Some as_of_day -> Bar_panels.weekly_view_for panels ~symbol ~n ~as_of_day
-
-let _panel_daily_view_for panels ~symbol ~as_of ~lookback =
-  match Bar_panels.column_of_date panels as_of with
-  | None -> _empty_daily_view
-  | Some as_of_day ->
-      Bar_panels.daily_view_for panels ~symbol ~as_of_day ~lookback
-
-let of_panels ?ma_cache panels =
-  {
-    daily_bars_for = _panel_daily_bars_for panels;
-    weekly_bars_for = _panel_weekly_bars_for panels;
-    weekly_view_for = _panel_weekly_view_for panels;
-    daily_view_for = _panel_daily_view_for panels;
-    ma_cache;
-    (* Panel-backed readers have no underlying snapshot directory; the
-       sentinel cb yields empty views from {!Snapshot_bar_views}. Production
-       does not use this constructor (Phase F.3.a-3 redo flipped the runner
-       to {!of_snapshot_views}); F.3.e deletes [of_panels] entirely. *)
-    snapshot_callbacks = _empty_snapshot_callbacks;
-  }
 
 (* {1 Empty backing — used by tests where no read is expected}
 
    The closures simply return the empty list / empty view directly, without
-   allocating a [Bar_panels.t] or opening a snapshot directory. This is the
-   smallest constructor and matches the "no read expected" contract
-   precisely. *)
+   opening a snapshot directory. This is the smallest constructor and matches
+   the "no read expected" contract precisely. *)
 let empty () =
   {
     daily_bars_for = (fun ~symbol:_ ~as_of:_ -> []);
@@ -211,10 +168,10 @@ let of_snapshot_views ?calendar (cb : Snapshot_runtime.Snapshot_callbacks.t) =
 (* {1 In-memory-bars constructor (Phase F.3.a-1)}
 
    Materialise a snapshot directory under a tmp dir, then route reads through
-   [of_snapshot_views]. The Bar_panels alternative ([of_panels] composed with
-   a synthetic [Bar_panels.t] built from in-memory bars) is the path this
-   constructor replaces; keeping it here lets every Bar_panels-backed test
-   migrate to a panel-free reader without changing call sites. *)
+   [of_snapshot_views]. The legacy [Bar_panels.t]-backed alternative
+   ([of_panels] composed with a synthetic panel built from in-memory bars)
+   was deleted in F.3.e-2; every test that previously used that path now
+   uses this constructor. *)
 
 (* Cache cap for the in-memory case: small directories (handful of symbols
    × thousands of days) easily fit in a few MB, but giving the LRU some

--- a/trading/trading/weinstein/strategy/lib/bar_reader.mli
+++ b/trading/trading/weinstein/strategy/lib/bar_reader.mli
@@ -3,16 +3,10 @@
     Backend-agnostic facade over the OHLCV bar reads the strategy needs (daily
     bar lists, weekly aggregates, daily / weekly views).
 
-    - {!of_panels} — backed by a {!Data_panel.Bar_panels.t} loaded from CSV at
-      runner start. Restored by the partial revert of #828's strategy-side flip
-      (closes #843; see `dev/notes/parity-bisect-...md` for the bisect record).
-      The runner's strategy uses this reader; flipping back to
-      {!of_snapshot_views} requires resolving the path-dependent divergence
-      first.
     - {!of_snapshot_views} — backed by {!Snapshot_runtime.Snapshot_callbacks},
       the LRU-bounded daily-snapshot reader that streams rows from per-symbol
-      [.snap] files on demand. Used directly by parity / migration tests; the
-      runner does not use this for the strategy until the forward fix lands.
+      [.snap] files on demand. The production runner uses this for the strategy
+      after the #848 forward fix landed (#864 + #866).
     - {!of_in_memory_bars} — convenience constructor that materialises a tmp
       snapshot directory from in-memory [(symbol, bars)] pairs. Used by tests
       and tools that hold bar histories in memory.
@@ -22,28 +16,15 @@
     Internally [Bar_reader.t] is a record of closures; the constructors capture
     their backing's read primitives and produce identical-shape closures, so the
     strategy's downstream callees see one bar-reading API regardless of backing.
-*)
+
+    {b Phase F.3.e-2}: the legacy {!Data_panel.Bar_panels}-backed [of_panels]
+    constructor + [_panel_*] helpers were deleted in this PR; production code
+    has been on {!of_snapshot_views} since #864/#866. *)
 
 open Core
 
 type t
 (** Opaque bar source. *)
-
-val of_panels : ?ma_cache:Weekly_ma_cache.t -> Data_panel.Bar_panels.t -> t
-(** [of_panels ?ma_cache panels] produces a reader backed by a
-    {!Data_panel.Bar_panels.t}.
-
-    All four readers ([daily_bars_for], [weekly_bars_for], [weekly_view_for],
-    [daily_view_for]) wrap the corresponding [Bar_panels] primitive plus a
-    [column_of_date] guard. Returns the empty list / empty view when [as_of] is
-    not in the panel's calendar.
-
-    [ma_cache], when supplied, is exposed via {!ma_cache} so the strategy's
-    cache-aware MA paths can read it without re-walking the panel.
-
-    Restored by the partial revert of #828's strategy-side flip (see module
-    docstring). This is the runner's strategy bar-reader path until the forward
-    fix lands. *)
 
 val of_snapshot_views :
   ?calendar:Date.t array -> Snapshot_runtime.Snapshot_callbacks.t -> t
@@ -65,9 +46,10 @@ val of_snapshot_views :
 
     Returns the empty view / empty list when the symbol is unknown, [as_of] is
     before any resident snapshot row, or any underlying field-read failure
-    fires. The view types ({!Data_panel.Bar_panels.weekly_view} / [daily_view])
-    are shared with the panel module's view definitions for historical reasons;
-    {!Panel_callbacks} consumes them directly. *)
+    fires. The view types ({!Snapshot_runtime.Snapshot_bar_views.weekly_view} /
+    [daily_view]) are shared with the panel module's view definitions
+    (re-exported from {!Data_panel.Bar_panels} until F.3.e-3 deletes that
+    module); {!Panel_callbacks} consumes them directly. *)
 
 val of_in_memory_bars : (string * Types.Daily_price.t list) list -> t
 (** [of_in_memory_bars symbol_bars] produces a snapshot-backed reader from a
@@ -75,8 +57,8 @@ val of_in_memory_bars : (string * Types.Daily_price.t list) list -> t
 
     Convenience constructor for tests and tools that hold bar histories in
     memory (rather than reading them from a CSV corpus). Materialises a tmp
-    snapshot directory and routes reads through {!of_snapshot_views} — no
-    {!Data_panel.Bar_panels.t} allocation.
+    snapshot directory and routes reads through {!of_snapshot_views} — no panel
+    allocation.
 
     Internally: 1. A fresh tmp directory is allocated via
     [Stdlib.Filename.temp_dir]. 2. For each [(symbol, bars)] pair,
@@ -104,9 +86,12 @@ val of_in_memory_bars : (string * Types.Daily_price.t list) list -> t
 
 val ma_cache : t -> Weekly_ma_cache.t option
 (** [ma_cache t] returns the cache the reader was constructed with, or [None]
-    when no cache was provided. Currently only {!of_panels} accepts a cache;
-    {!of_snapshot_views} / {!of_in_memory_bars} / {!empty} always set this to
-    [None]. *)
+    when no cache was provided. After F.3.e-2 every constructor sets this to
+    [None]; the strategy's cache-aware MA paths now route through
+    {!Panel_callbacks.X_of_snapshot_views}'s built-in caching. Kept on the
+    public surface so existing strategy callsites
+    ([Bar_reader.ma_cache bar_reader]) continue to compile and degrade to the
+    inline-MA path uniformly. *)
 
 val snapshot_callbacks : t -> Snapshot_runtime.Snapshot_callbacks.t
 (** [snapshot_callbacks t] returns the underlying field-accessor shim for
@@ -115,14 +100,13 @@ val snapshot_callbacks : t -> Snapshot_runtime.Snapshot_callbacks.t
     / d-2 caller migration) via the [*_of_snapshot_views] APIs on
     {!Macro_inputs}.
 
-    For panel-backed and empty readers ({!of_panels} / {!empty}), returns a
-    sentinel cb whose every [read_field] / [read_field_history] returns
-    [Error NotFound]. {!Snapshot_runtime.Snapshot_bar_views} folds these
-    NotFound results to the empty view / empty list, so callers see the "no
-    bars" surface that matches these readers' contract. Production runs use only
-    snapshot-backed readers, so the sentinel is exercised only in tests that
-    never reach a macro / sector read (typically the no-primary-bar
-    short-circuit in [_on_market_close]). *)
+    For empty readers ({!empty}), returns a sentinel cb whose every [read_field]
+    / [read_field_history] returns [Error NotFound].
+    {!Snapshot_runtime.Snapshot_bar_views} folds these NotFound results to the
+    empty view / empty list, so callers see the "no bars" surface that matches
+    {!empty}'s contract. Production runs use only snapshot-backed readers, so
+    the sentinel is exercised only in tests that never reach a macro / sector
+    read (typically the no-primary-bar short-circuit in [_on_market_close]). *)
 
 val empty : unit -> t
 (** [empty ()] produces a reader whose every read returns the empty list / empty
@@ -135,44 +119,39 @@ val empty : unit -> t
 val daily_bars_for :
   t -> symbol:string -> as_of:Date.t -> Types.Daily_price.t list
 (** [daily_bars_for t ~symbol ~as_of] returns daily bars for [symbol] up to and
-    including [as_of], in chronological order (oldest first).
-
-    Bars are reconstructed from the panel columns [0..as_of_day]. Returns the
-    empty list when the symbol has no resident bars or [as_of] is out of the
-    panel calendar. *)
+    including [as_of], in chronological order (oldest first). Returns the empty
+    list when the symbol has no resident bars or [as_of] is before any resident
+    snapshot row. *)
 
 val weekly_bars_for :
   t -> symbol:string -> n:int -> as_of:Date.t -> Types.Daily_price.t list
 (** [weekly_bars_for t ~symbol ~n ~as_of] returns the most recent [n]
-    weekly-aggregated bars for [symbol] as of [as_of]. Same semantics as
-    {!Data_panel.Bar_panels.weekly_bars_for}.
-
-    Returns the empty list when the symbol has no resident bars or [as_of] is
-    out of the panel calendar. *)
+    weekly-aggregated bars for [symbol] as of [as_of]. Same aggregation
+    semantics as {!Snapshot_runtime.Snapshot_bar_views.weekly_bars_for}. *)
 
 (** {1 Float-array views (Stage 4 PR-A)}
 
-    Pass-throughs to the underlying {!Data_panel.Bar_panels} float-array
-    primitives. Use these in production hot paths to avoid materialising a
-    {!Types.Daily_price.t list} per call site per tick. *)
+    Pass-throughs to the underlying {!Snapshot_runtime.Snapshot_bar_views}
+    float-array primitives. Use these in production hot paths to avoid
+    materialising a {!Types.Daily_price.t list} per call site per tick. *)
 
 val weekly_view_for :
   t ->
   symbol:string ->
   n:int ->
   as_of:Date.t ->
-  Data_panel.Bar_panels.weekly_view
-(** [weekly_view_for t ~symbol ~n ~as_of] returns the panel weekly view of the
-    most recent [n] weeks ending at [as_of]. Maps [as_of] to a panel column via
-    {!Data_panel.Bar_panels.column_of_date}; returns the empty view when [as_of]
-    is not in the calendar. *)
+  Snapshot_runtime.Snapshot_bar_views.weekly_view
+(** [weekly_view_for t ~symbol ~n ~as_of] returns the snapshot weekly view of
+    the most recent [n] weeks ending at [as_of]. Returns the empty view when
+    [as_of] is before any resident snapshot row. *)
 
 val daily_view_for :
   t ->
   symbol:string ->
   as_of:Date.t ->
   lookback:int ->
-  Data_panel.Bar_panels.daily_view
-(** [daily_view_for t ~symbol ~as_of ~lookback] returns the panel daily view of
-    the most recent [lookback] days ending at [as_of]. Same calendar- fallback
-    semantics as {!weekly_view_for}. *)
+  Snapshot_runtime.Snapshot_bar_views.daily_view
+(** [daily_view_for t ~symbol ~as_of ~lookback] returns the snapshot daily view
+    of the most recent [lookback] days ending at [as_of]. Same calendar fallback
+    semantics as {!of_snapshot_views}'s [?calendar] parameter (uses a
+    synthesized Mon–Fri calendar when none was supplied at construction). *)


### PR DESCRIPTION
## Summary
- Delete `Bar_reader.of_panels` (panel-backed constructor) + the four `_panel_*` helpers (`_panel_daily_bars_for`, `_panel_weekly_bars_for`, `_panel_weekly_view_for`, `_panel_daily_view_for`).
- Drop the `Bar_panels` module alias from `bar_reader.ml`. The reader's view types now reference `Snapshot_runtime.Snapshot_bar_views.weekly_view` / `.daily_view` directly (post F.3.e-1's type relocation).
- Update `bar_reader.mli`'s docstrings: removed `of_panels` from the constructor list, fixed remaining cross-references to point at `Snapshot_runtime.Snapshot_bar_views`.
- Keep `ma_cache` field on the public surface (now always `None` from every constructor) so existing strategy callsites (`Bar_reader.ma_cache bar_reader` in `Weinstein_strategy` / `Exit_audit_capture`) compile unchanged.
- Keep `_empty_snapshot_callbacks` sentinel (consumed by `empty ()`).

## Why
F.3.e-2 (per dispatch): the production runner has been on `Bar_reader.of_snapshot_views` since #864 + #866. The only remaining references to `of_panels` were comments / historical docstrings — no live callers — confirmed by `grep -rn "Bar_reader\.of_panels"` returning 3 hits, all comments in `weinstein_strategy.ml/.mli` / `test_weinstein_strategy_smoke.ml`. Those comments are accurate historical context (Phase F.3.a-4) and remain.

## What's not in this PR (follow-up)
- F.3.e-3: delete `Data_panel.Bar_panels.{ml,mli}` + `bar_panels_test.ml`. Port `optimal_strategy_runner` off direct `Bar_panels` usage. Drop the panel-backed test paths in `test_panel_callbacks.ml` / `test_weekly_ma_cache.ml` / `test_macro_inputs.ml` / `test_macro_panel_callbacks_real_data.ml` / `test_snapshot_bar_views.ml` (they still build a `Bar_panels.t` for parity comparisons; they need to be retired or migrated).

## Test plan
- [x] `dune build` clean.
- [x] `dune runtest` clean (full suite).
- [x] `dune build @fmt` clean for files I touched.
- [ ] sp500-2019-2023 baseline = 58.34%/81 trades — production runner is on `of_snapshot_views`, not `of_panels`; `of_panels` had zero live callers per grep, so deletion is behaviourally inert. Full re-run deferred to F.3.e-3.

## Stack
Targets `feat/snapshot/f3-e-1-move-bar-view-types` (PR #868). Merge after F.3.e-1 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)