### PR TITLE
test(macro_inputs): regression test for ad_bars_at_or_before future-leak filter

### DIFF
--- a/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
@@ -87,6 +87,112 @@ let test_default_global_indices_is_canonical_triple _ =
        [ ("GDAXI.INDX", "DAX"); ("N225.INDX", "Nikkei"); ("ISF.LSE", "FTSE") ])
 
 (* ------------------------------------------------------------------ *)
+(* ad_bars_at_or_before                                                 *)
+(* ------------------------------------------------------------------ *)
+(* Regression coverage for the future-leak guard introduced in #612.
+   The guard trims the composer-loaded synthetic A-D series
+   ([Ad_bars.load], whose Synthetic tail typically extends to the most
+   recent [compute_synthetic_adl.exe] run) to dates [<= as_of] before
+   the macro callbacks read [get_cumulative_ad ~week_offset:0]. Without
+   the trim, the cumulative-as-of-last-bar would be ~years past the
+   simulator's current tick — breaking the [Bearish] composite during
+   real bear-market replays.
+
+   The deleted [test_macro_panel_callbacks_real_data.ml] (per #876) was
+   the sole direct integration test pinning this contract; this block
+   restores it as focused unit tests against {!Macro_inputs.ad_bars_at_or_before}
+   directly. The function is still called from production at
+   [weinstein_strategy.ml] inside [_run_macro_screen]. *)
+
+let _make_ad_bar ~date ~advancing ~declining : Macro.ad_bar =
+  { date; advancing; declining }
+
+(* Build a span of weekly A-D bars with monotone-increasing dates,
+   straddling the [as_of] boundary so the filter has both retained and
+   stripped bars to discriminate. The advancing/declining counts are
+   arbitrary fixed values — only the date field drives the filter. *)
+let _ad_bars_straddling_as_of ~as_of =
+  let weeks_before = [ -21; -14; -7; 0 ] in
+  let weeks_after = [ 7; 14; 21 ] in
+  List.map (weeks_before @ weeks_after) ~f:(fun offset ->
+      _make_ad_bar
+        ~date:(Date.add_days as_of offset)
+        ~advancing:1500 ~declining:1500)
+
+let test_ad_bars_at_or_before_strips_future_bars _ =
+  let as_of = Date.of_string "2022-10-14" in
+  let ad_bars = _ad_bars_straddling_as_of ~as_of in
+  let result = Macro_inputs.ad_bars_at_or_before ~ad_bars ~as_of in
+  (* Every retained bar's date must be [<= as_of]; the post-as_of
+     trio (offsets +7, +14, +21) must be stripped. The retained
+     prefix is deterministic because the input is sorted ascending. *)
+  assert_that result
+    (elements_are
+       [
+         field
+           (fun (b : Macro.ad_bar) -> b.date)
+           (equal_to (Date.add_days as_of (-21)));
+         field
+           (fun (b : Macro.ad_bar) -> b.date)
+           (equal_to (Date.add_days as_of (-14)));
+         field
+           (fun (b : Macro.ad_bar) -> b.date)
+           (equal_to (Date.add_days as_of (-7)));
+         field (fun (b : Macro.ad_bar) -> b.date) (equal_to as_of);
+       ])
+
+let test_ad_bars_at_or_before_keeps_boundary_bar _ =
+  (* Inclusivity: a bar exactly on [as_of] is retained ([<=], not [<]). *)
+  let as_of = Date.of_string "2022-10-14" in
+  let ad_bars =
+    [
+      _make_ad_bar ~date:(Date.add_days as_of (-7)) ~advancing:1500
+        ~declining:1500;
+      _make_ad_bar ~date:as_of ~advancing:1500 ~declining:1500;
+      _make_ad_bar ~date:(Date.add_days as_of 1) ~advancing:1500 ~declining:1500;
+    ]
+  in
+  let result = Macro_inputs.ad_bars_at_or_before ~ad_bars ~as_of in
+  assert_that result
+    (elements_are
+       [
+         field
+           (fun (b : Macro.ad_bar) -> b.date)
+           (equal_to (Date.add_days as_of (-7)));
+         field (fun (b : Macro.ad_bar) -> b.date) (equal_to as_of);
+       ])
+
+let test_ad_bars_at_or_before_passthrough_when_all_in_range _ =
+  (* Production-tail fast path: the input list is returned unchanged
+     when its last bar already lies on or before [as_of]. *)
+  let as_of = Date.of_string "2022-10-14" in
+  let ad_bars =
+    [
+      _make_ad_bar
+        ~date:(Date.add_days as_of (-14))
+        ~advancing:1500 ~declining:1500;
+      _make_ad_bar ~date:(Date.add_days as_of (-7)) ~advancing:1500
+        ~declining:1500;
+    ]
+  in
+  let result = Macro_inputs.ad_bars_at_or_before ~ad_bars ~as_of in
+  assert_that result
+    (elements_are
+       [
+         field
+           (fun (b : Macro.ad_bar) -> b.date)
+           (equal_to (Date.add_days as_of (-14)));
+         field
+           (fun (b : Macro.ad_bar) -> b.date)
+           (equal_to (Date.add_days as_of (-7)));
+       ])
+
+let test_ad_bars_at_or_before_empty_input _ =
+  let as_of = Date.of_string "2022-10-14" in
+  let result = Macro_inputs.ad_bars_at_or_before ~ad_bars:[] ~as_of in
+  assert_that result is_empty
+
+(* ------------------------------------------------------------------ *)
 (* build_global_index_bars                                              *)
 (* ------------------------------------------------------------------ *)
 
@@ -582,6 +688,14 @@ let () =
            >:: test_spdr_sector_etfs_names_are_valid_gics;
            "default_global_indices is the canonical triple"
            >:: test_default_global_indices_is_canonical_triple;
+           "ad_bars_at_or_before strips bars dated after as_of"
+           >:: test_ad_bars_at_or_before_strips_future_bars;
+           "ad_bars_at_or_before keeps boundary bar (date = as_of)"
+           >:: test_ad_bars_at_or_before_keeps_boundary_bar;
+           "ad_bars_at_or_before passes through when all bars in range"
+           >:: test_ad_bars_at_or_before_passthrough_when_all_in_range;
+           "ad_bars_at_or_before returns empty for empty input"
+           >:: test_ad_bars_at_or_before_empty_input;
            "build_global_index_bars returns empty for empty bar history"
            >:: test_build_global_index_bars_empty;
            "build_global_index_bars drops symbols without bars"


### PR DESCRIPTION
## Summary

Closes #878.

Adds 4 focused unit tests pinning `Macro_inputs.ad_bars_at_or_before` (the future-leak guard introduced in #612). The deleted `test_macro_panel_callbacks_real_data.ml` (per #876) was the only direct integration test for this contract — qc-behavioral on PR #876 flagged the gap (CP4 FLAG, `dev/reviews/pr-876.md`).

## What it does

Four tests exercise the filter directly against `Macro.ad_bar list`:

1. **`strips_future_bars`** — synthetic 7-bar series straddling `as_of` (offsets -21, -14, -7, 0, +7, +14, +21 days). Asserts the +7 / +14 / +21 trio is stripped and only the past/boundary bars remain. **This is the load-bearing regression — if the date guard is removed, this test fails with `List length (7) does not match matchers length (4)`.**
2. **`keeps_boundary_bar`** — a bar dated exactly on `as_of` is retained (the predicate is `<=`, not `<`).
3. **`passthrough_when_all_in_range`** — production-tail fast path: when the input list's last bar is already on or before `as_of`, the input is returned as-is (covers `_passthrough_if_in_range`).
4. **`empty_input`** — empty list returns empty.

## Verifies-the-regression confirmation

I temporarily replaced the implementation with `fun ~ad_bars ~as_of:_ -> ad_bars` (the broken/no-op variant). Ran the suite:

```
==============================================================================
Error: macro_inputs:4:ad_bars_at_or_before keeps boundary bar (date = as_of).
List length (3) does not match matchers length (2)
==============================================================================
Error: macro_inputs:3:ad_bars_at_or_before strips bars dated after as_of.
List length (7) does not match matchers length (4)
------------------------------------------------------------------------------
Ran: 18 tests in: 0.17 seconds.
FAILED: Cases: 18 Tried: 18 Errors: 0 Failures: 2 Skip:  0 Todo: 0 Timeouts: 0.
```

Both behavioral tests fail as expected; passthrough and empty correctly continue to pass (a no-op filter trivially satisfies those edge cases). Filter restored before commit.

## Refs

- #612 — root cause of the filter (synthetic A-D series tail extends past simulator tick → cumulative-AD vs index-close date misalignment → bear-market composite misclassified as Neutral/Bullish).
- #876 — F.3.e-3b PR that deleted the prior integration test as part of the panel-backed cleanup.
- `dev/reviews/pr-876.md` qc-behavioral CP4 FLAG.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest trading/weinstein/strategy/` all green (18/18 in `test_macro_inputs.exe`)
- [x] Test verified to catch the regression by temporarily breaking the filter