### PR TITLE
fix(fmt): runner.mli docblock indent for ocamlformat 0.29 (CI fix)

### DIFF
--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -134,10 +134,10 @@ val run_backtest :
     order. Each must be a record sexp with fields matching
     [Weinstein_strategy.config]. Example:
     {[
-      [
-        Sexp.of_string "((initial_stop_buffer 1.08))";
-        Sexp.of_string "((stage_config ((ma_period 40))))";
-      ]
+    [
+      Sexp.of_string "((initial_stop_buffer 1.08))";
+      Sexp.of_string "((stage_config ((ma_period 40))))";
+    ]
     ]}
 
     [sector_map_override], when passed, replaces the sector-map normally loaded


### PR DESCRIPTION
## Summary
Apply CI-version ocamlformat 0.29 indentation on `runner.mli` lines 137-141. The docblock `{[ ... ]}` example was 6-space indented (container's 0.28.1-pinned-to-0.29.0 preference); CI's released 0.29.0 wants 4-space.

## Why
Per memory `project_ocamlformat_version_skew.md`: container ocamlformat 0.28.1 (pinned to git ref 0.29.0) and CI's released ocamlformat 0.29.0 produce OPPOSITE docblock indentation. PR #883 was merged with a build-and-test FAILURE on this exact line range — main was left in a broken-format state. This PR restores green CI.

## Test plan
- [x] `dev/lib/run-in-env.sh dune build` clean
- [ ] CI: `dune build @fmt` will pass