### PR TITLE
feat(screener): expose min_score_override; quick-look threshold sweep (#888)

### DIFF
--- a/dev/notes/888-score-threshold-quick-look-2026-05-06.md
+++ b/dev/notes/888-score-threshold-quick-look-2026-05-06.md
@@ -1,0 +1,134 @@
+# #888 score-threshold quick-look — 2026-05-06
+
+## Context
+
+Issue #888 asks to (1) expose the cascade score threshold as a config
+parameter and (2) measure the impact of bumping it by 1-2 points on the
+sp500-2019-2023 5y baseline.
+
+This note covers part (2). Part (1) is implemented as a new
+`min_score_override : int option` field in `Screener.config` (PR
+feat/screener/888-threshold-param). Default `None` preserves the existing
+grade-based filter bit-equally; when set to `Some n`, replaces the filter with
+a strict numeric `score >= n` gate.
+
+The flagship 15y run is intentionally NOT in scope here per the dispatch — the
+goal is to validate the parameter wiring against the well-pinned 5y baseline
+before designing the full sweep. Per #871, the cascade is at the no-look-ahead
+ceiling; the dispatch (and #871's verdict) recommend deferring the actual
+threshold sweep until capital-recycling work (#872 / #887) lands, so a tighter
+threshold can compound with freed-up cash rather than just reducing entries.
+
+## Setup
+
+- Universe: `universes/sp500.sexp` (500 symbols, post-#851 share-class dedup).
+- Period: 2019-01-02 → 2023-12-29 (5y, COVID + 2022 bear cycle).
+- Strategy: Weinstein, default config.
+- Baseline pin (sp500-2019-2023.sexp): **+58.34% / 81 trades / Sharpe 0.54 / MaxDD 33.60%**.
+- Three cells:
+  - **A (default)** — `min_score_override = None`. Bit-equal to the
+    pinned baseline.
+  - **B (+1)** — `min_score_override = Some 41`. Cuts grade-C (40-pt) admissions.
+  - **C (+2)** — `min_score_override = Some 42`. Cuts grade-C through 41.
+
+The default `grade_thresholds.c = 40` so `min_score_override = Some 40` would
+be a no-op relative to grade-based filtering. `Some 41` is the smallest delta
+that actually changes admissions.
+
+## Results
+
+Wall time: 6m53s for the 3-cell sweep at `--parallel 3`.
+
+| Cell | Threshold | Total return | Trades | Win rate | Sharpe | MaxDD | AvgHold (d) |
+|---|---|---:|---:|---:|---:|---:|---:|
+| A (default) | grade ≥ C (≥40 pts) | **+58.34%** | **81** | 19.75% | 0.537 | 33.60% | 84.1 |
+| B (+1)      | score ≥ 41          | +54.57%     | 93     | 19.35% | 0.545 | 28.69% | 104.5 |
+| C (+2)      | score ≥ 42          | +54.57%     | 93     | 19.35% | 0.545 | 28.69% | 104.5 |
+
+**Cell A is bit-equal to the pinned baseline (58.34% / 81 / Sharpe 0.54 / MaxDD
+33.60% / AvgHold 84).** Confirms the default `min_score_override = None` is a
+no-op relative to the existing grade-based filter — required by acceptance.
+
+**Cells B and C are byte-identical**: the actual.sexp values match across
+total_return_pct (54.57149502), total_trades (93), win_rate (19.355), sharpe
+(0.54497), MaxDD (28.694), AvgHold (104.484), open_positions_value
+(1,515,890.08). At default scoring weights (10/15/20/30 per signal) no candidate
+scores exactly 41, so the 42-floor admits the same set as the 41-floor.
+
+## Observations
+
+1. **Counter-intuitive: tighter threshold INCREASED trade count** (81 → 93,
+   +14.8%). Mechanism (hypothesis, not yet verified):
+   - Lower-grade candidates that the score-41 floor excludes were typically
+     the marginal entries that locked cash in losers. Removing them frees
+     cash for OTHER candidates that show up later in the period.
+   - Avg holding days expanded from 84 → 104.5 (+24%), consistent with
+     fewer-but-stickier picks displacing more-but-shorter-cycle picks.
+2. **Return DROPPED** (58.34% → 54.57%, −3.8 pp). MaxDD also dropped
+   (33.60% → 28.69%, −4.9 pp) and Sharpe is unchanged. Risk-adjusted return
+   is essentially flat at the threshold + 1 setting; absolute return is
+   slightly worse. **Tighter threshold in isolation does not improve
+   selectivity outcomes** on this 5y window.
+3. **Step size of 1-vs-2 is invisible** at default weights. Real grid sweeps
+   should test threshold values that fall on actual cumulative-score
+   boundaries. From `Screener.default_scoring_weights`, achievable cumulative
+   scores are sums of subsets of {10, 15, 20, 30, ±10}, so meaningful
+   boundaries are at {25, 30, 35, 40, 45, 50, 55, 60, 70, 75, 85, ...}.
+   Sweep cells should bracket these (e.g. {40, 45, 50, 55}) rather than
+   single integers.
+4. Consistent with #871 §"Do NOT prioritize: cascade score re-weighting" —
+   tightening the score floor doesn't beat the no-look-ahead ceiling because
+   the bottleneck is capital recycling (cash locked in long-runners), not
+   candidate quality.
+
+## Recommendation for next session
+
+Per #871 §Recommendation and the cells-B/C result above, do NOT prioritize
+a full multi-period sweep of this knob in isolation. Direct evidence from the
+3 cells: tightening from 40 → 41/42 reduces return by 3.8pp AND trades go up
+by 12 — the marginal candidates dropped weren't the losing ones, and the cash
+those losers tied up isn't getting recycled productively. The leverage of
+tightening the threshold should compound with capital recycling (#872 /
+Stage-3 force exits / lower `max_position_pct_long`).
+
+The right design for the next session is:
+
+1. Land #872 / #887 (capital-recycling).
+2. Then run a sweep with cells that fall on score-boundary discontinuities,
+   not 1-pt increments: `min_score_override ∈ {40, 45, 50, 55, 60}` on
+   sp500-2019-2023 + sp500-2010-2026 (2 periods × 5 cells = 10 cells,
+   ~10h on tier-3 budget).
+3. Pin the optimum if return improves AND trade-count stays sane. Otherwise
+   leave the default as the canonical setting.
+
+Until then, this PR provides:
+
+- The config parameter (bit-equal default).
+- The grid-search dimension example in `Tuner.Grid_search.param_spec`.
+- Override-path test pinning the deep-merge at
+  `screening_config.min_score_override = Some 41`.
+- This quick-look as the placeholder for the eventual sweep.
+
+## Verify locally
+
+The 3 scenario sexps live at `trading/test_data/888-quicklook/cell-*.sexp`.
+Re-run via:
+
+```bash
+dev/lib/run-in-env.sh dune exec trading/backtest/scenarios/scenario_runner.exe -- \
+  --dir test_data/888-quicklook \
+  --parallel 3 \
+  --fixtures-root test_data/backtest_scenarios
+```
+
+Output goes to `dev/backtest/scenarios-<timestamp>/888-cell-*/actual.sexp`.
+
+Note: the scenario runner resolves `_repo_root` via `Data_path.default_data_dir`
+which climbs to the repo root, so when run from a worktree the output lands in
+the **parent repo**'s `dev/backtest/`, not the worktree's. Look there if the
+worktree's `dev/backtest/` shows no recent run.
+
+The unit test `test_override_screening_min_score_override` in
+`trading/trading/backtest/test/test_runner_hypothesis_overrides.ml` pins the
+deep-merge path so a CI failure there is the canonical signal that the override
+wiring has regressed.

--- a/dev/status/tuning.md
+++ b/dev/status/tuning.md
@@ -1,6 +1,6 @@
 # Status: tuning
 
-## Last updated: 2026-05-04
+## Last updated: 2026-05-06
 
 ## Status
 IN_PROGRESS — T-A + T-B libs MERGED; CLI binaries + walk-forward integration deferred
@@ -54,6 +54,8 @@ Per `.claude/rules/no-python.md`. OCaml-native or FFI to C libs only.
 - None. T-A and T-B both shipped.
 
 ## Completed
+
+- [x] **#888 cascade score-floor knob exposed for grid sweep** (~250 LOC; branch `feat/screener/888-threshold-param`). Added `min_score_override : int option` to `Screener.config` (default `None` preserves grade-based filter bit-equally; `Some n` replaces with strict `score >= n` numeric gate). Threaded via `_passes_score_floor` helper through `_score_and_build`, `_long_admission`/`_short_admission`, and the diagnostics-counting path (single source of truth). Registered in `Tuner.Grid_search.param_spec` docstring as a sweepable dimension at `screening_config.min_score_override`. Override deep-merge pinned by `test_override_screening_min_score_override` in `test_runner_hypothesis_overrides.ml`. 5 new unit tests in `test_screener.ml` pin the gate's `>=` semantics + bit-equal-default contract. 3-cell quick-look on sp500-2019-2023 (cells: default / 41 / 42) documented in `dev/notes/888-score-threshold-quick-look-2026-05-06.md` — finding consistent with #871's "cascade is at no-look-ahead ceiling" verdict; full sweep deferred until #872 / #887 capital-recycling lands. Verify: `dev/lib/run-in-env.sh dune runtest analysis/weinstein/screener/test/` + `dev/lib/run-in-env.sh dune exec trading/backtest/test/test_runner_hypothesis_overrides.exe`.
 
 - [x] **T-B Bayesian-opt lib + tests** (~922 LOC including tests, ~439 lib; branch `feat/tuner-bayesian-opt`). Surface: `trading/trading/backtest/tuner/lib/bayesian_opt.{ml,mli}`. Pure functional GP-based optimiser using `owl` (`Owl.Linalg.D.chol` + `triangular_solve` for the Cholesky-factor linear system, `Owl.Mat` for matrix ops). Two-phase suggestion (initial random samples → GP-driven argmax of acquisition function over uniformly-sampled candidates). RBF kernel with default length scales `0.25` in normalised `[0,1]` parameter space; signal variance `1.0`; noise jitter `1e-6`. Two acquisition functions: `Expected_improvement` (default) and `Upper_confidence_bound β`. Determinism: same `Random.State.t` seed → byte-identical suggestion sequences. Convergence pinned by 1D parabola (`f(x) = -(x-3)²`) within 30 evals + 2D Branin within 50 evals. 27 tests including bounds enforcement, RBF/EI/UCB unit tests, GP-fit interpolation verification at observed points. Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest trading/backtest/tuner/'` (27/27 pass). Design decisions in `dev/plans/bayesian-opt-2026-05-03.md` §D1–D8. Follow-up: CLI binary (deferred from T-B to keep PR ≤500 LOC; mirrors T-A's split). Hyperparameter learning (Type-II MLE on length scales) deferred — fixed-hyperparameter GP is sufficient for the dimensions and budgets the M5.5 spec calls out.
 

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -73,6 +73,7 @@ type config = {
   grade_thresholds : grade_thresholds;
   candidate_params : candidate_params;
   min_grade : grade;
+  min_score_override : int option; [@sexp.default None]
   max_buy_candidates : int;
   max_short_candidates : int;
   cascade_post_stop_cooldown_weeks : int; [@sexp.default 0]
@@ -85,6 +86,7 @@ let default_config =
     grade_thresholds = default_grade_thresholds;
     candidate_params = default_candidate_params;
     min_grade = C;
+    min_score_override = None;
     max_buy_candidates = 20;
     max_short_candidates = 10;
     cascade_post_stop_cooldown_weeks = 0;
@@ -357,25 +359,39 @@ let _build_candidate ~params ~sector ~(a : Stock_analysis.t) ~score ~reasons
 (* Per-candidate filters                                               *)
 (* ------------------------------------------------------------------ *)
 
+(** Score gate: [true] iff [score] passes the configured floor. When
+    [min_score_override] is [Some n], the floor is the strict numeric gate
+    [score >= n] and {!min_grade} is ignored. When [None] (default), the
+    grade-based floor is used: the grade derived from [score] under [thresholds]
+    must be at-or-better than [min_grade].
+
+    Single source of truth for the cascade score-floor decision so the
+    score-and-build path and the diagnostics-counting predicates can't drift. *)
+let _passes_score_floor ~thresholds ~min_grade ~min_score_override score =
+  match min_score_override with
+  | Some n -> score >= n
+  | None -> compare_grade (_grade_of_score ~thresholds score) min_grade <= 0
+
 (** Score, grade, and build a candidate after passing preliminary gates. Returns
-    [None] if the grade does not meet [min_grade]. *)
-let _score_and_build ~weights ~thresholds ~params ~min_grade ~is_short ~scorer
-    ~sector a =
+    [None] if [score] does not pass {!_passes_score_floor}. *)
+let _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
+    ~is_short ~scorer ~sector a =
   let score, reasons = scorer ~weights ~sector a in
-  let grade = _grade_of_score ~thresholds score in
-  if compare_grade grade min_grade > 0 then None
+  if not (_passes_score_floor ~thresholds ~min_grade ~min_score_override score)
+  then None
   else
     Some
       (_build_candidate ~params ~sector ~a ~score ~reasons ~thresholds ~is_short)
 
 (** Evaluate one (analysis, sector) pair as a long candidate. Returns [None] if
-    excluded by the sector gate, breakout test, or grade floor. *)
-let _long_candidate ~weights ~thresholds ~params ~min_grade (a, sector) =
+    excluded by the sector gate, breakout test, or score floor. *)
+let _long_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
+    (a, sector) =
   if equal_sector_rating sector.rating Weak then None
   else if not (Stock_analysis.is_breakout_candidate a) then None
   else
-    _score_and_build ~weights ~thresholds ~params ~min_grade ~is_short:false
-      ~scorer:_score_long ~sector a
+    _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
+      ~is_short:false ~scorer:_score_long ~sector a
 
 (** Hard gate per Weinstein Ch. 11: never short a stock with strong relative
     strength, even if it breaks down. Rejects candidates whose RS trend is
@@ -390,14 +406,15 @@ let _rs_blocks_short = function
   | _ -> false
 
 (** Evaluate one (analysis, sector) pair as a short candidate. Bearish/Neutral
-    only: grade must meet [min_grade]. *)
-let _short_candidate ~weights ~thresholds ~params ~min_grade (a, sector) =
+    only: score must pass {!_passes_score_floor}. *)
+let _short_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
+    (a, sector) =
   if equal_sector_rating sector.rating Strong then None
   else if not (Stock_analysis.is_breakdown_candidate a) then None
   else if _rs_blocks_short a.Stock_analysis.rs then None
   else
-    _score_and_build ~weights ~thresholds ~params ~min_grade ~is_short:true
-      ~scorer:_score_short ~sector a
+    _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
+      ~is_short:true ~scorer:_score_short ~sector a
 
 (** Check watchlist eligibility after the breakout gate. Returns [None] if the
     ticker is already in [buy_candidates] or the grade is above C/D. *)
@@ -444,7 +461,8 @@ let _top_n n lst =
     actually got evaluated. Phases short-circuit (a [false] earlier means later
     bools are [false]) so [(true, true, true)] means the pair passed all three
     gates. *)
-let _long_admission ~weights ~thresholds ~min_grade (a, sector) =
+let _long_admission ~weights ~thresholds ~min_grade ~min_score_override
+    (a, sector) =
   let passes_breakout = Stock_analysis.is_breakout_candidate a in
   let passes_sector =
     passes_breakout && not (equal_sector_rating sector.rating Weak)
@@ -453,7 +471,7 @@ let _long_admission ~weights ~thresholds ~min_grade (a, sector) =
     if not passes_sector then false
     else
       let score, _ = _score_long ~weights ~sector a in
-      compare_grade (_grade_of_score ~thresholds score) min_grade <= 0
+      _passes_score_floor ~thresholds ~min_grade ~min_score_override score
   in
   (passes_breakout, passes_sector, passes_grade)
 
@@ -462,15 +480,19 @@ let _bump n b = if b then n + 1 else n
 
 (** Long-side phase counts for the cascade-diagnostics record. Folds the
     per-pair predicate triple into running counts. *)
-let _count_long_phases ~weights ~thresholds ~min_grade ~candidates =
+let _count_long_phases ~weights ~thresholds ~min_grade ~min_score_override
+    ~candidates =
   List.fold candidates ~init:(0, 0, 0)
     ~f:(fun (breakout, sector_ok, grade_ok) pair ->
-      let pb, ps, pg = _long_admission ~weights ~thresholds ~min_grade pair in
+      let pb, ps, pg =
+        _long_admission ~weights ~thresholds ~min_grade ~min_score_override pair
+      in
       (_bump breakout pb, _bump sector_ok ps, _bump grade_ok pg))
 
 (** Short-side admission predicates. Mirrors [_long_admission] with the RS hard
     gate inserted between sector and grade — see [_short_candidate]. *)
-let _short_admission ~weights ~thresholds ~min_grade (a, sector) =
+let _short_admission ~weights ~thresholds ~min_grade ~min_score_override
+    (a, sector) =
   let passes_breakdown = Stock_analysis.is_breakdown_candidate a in
   let passes_sector =
     passes_breakdown && not (equal_sector_rating sector.rating Strong)
@@ -480,39 +502,45 @@ let _short_admission ~weights ~thresholds ~min_grade (a, sector) =
     if not passes_rs then false
     else
       let score, _ = _score_short ~weights ~sector a in
-      compare_grade (_grade_of_score ~thresholds score) min_grade <= 0
+      _passes_score_floor ~thresholds ~min_grade ~min_score_override score
   in
   (passes_breakdown, passes_sector, passes_rs, passes_grade)
 
 (** Short-side phase counts mirroring [_count_long_phases]. *)
-let _count_short_phases ~weights ~thresholds ~min_grade ~candidates =
+let _count_short_phases ~weights ~thresholds ~min_grade ~min_score_override
+    ~candidates =
   List.fold candidates ~init:(0, 0, 0, 0)
     ~f:(fun (breakdown, sector_ok, rs_ok, grade_ok) pair ->
       let pb, ps, pr, pg =
-        _short_admission ~weights ~thresholds ~min_grade pair
+        _short_admission ~weights ~thresholds ~min_grade ~min_score_override
+          pair
       in
       (_bump breakdown pb, _bump sector_ok ps, _bump rs_ok pr, _bump grade_ok pg))
 
 (** Filter, score, grade, sort, and cap long candidates. *)
-let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~max_buy_candidates
-    ~candidates ~macro_trend : scored_candidate list =
+let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~min_score_override
+    ~max_buy_candidates ~candidates ~macro_trend : scored_candidate list =
   match macro_trend with
   | Bearish -> []
   | Bullish | Neutral ->
       candidates
       |> List.filter_map
-           ~f:(_long_candidate ~weights ~thresholds ~params ~min_grade)
+           ~f:
+             (_long_candidate ~weights ~thresholds ~params ~min_grade
+                ~min_score_override)
       |> _top_n max_buy_candidates
 
 (** Filter, score, grade, sort, and cap short candidates. *)
-let _evaluate_shorts ~weights ~thresholds ~params ~min_grade
+let _evaluate_shorts ~weights ~thresholds ~params ~min_grade ~min_score_override
     ~max_short_candidates ~candidates ~macro_trend : scored_candidate list =
   match macro_trend with
   | Bullish -> []
   | Bearish | Neutral ->
       candidates
       |> List.filter_map
-           ~f:(_short_candidate ~weights ~thresholds ~params ~min_grade)
+           ~f:
+             (_short_candidate ~weights ~thresholds ~params ~min_grade
+                ~min_score_override)
       |> _top_n max_short_candidates
 
 (** Build watchlist: breakout candidates with grade C/D not in the buy list.
@@ -579,16 +607,16 @@ let _build_cascade_diagnostics ~total_stocks ~candidates_after_held ~macro_trend
 
 (** Compute the cascade-diagnostics record for one screen call. Decoupled from
     [screen] so the latter stays within the 50-line linter cap. *)
-let _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade ~total_stocks
-    ~candidates_after_held ~macro_trend ~candidates ~buy_candidates
-    ~short_candidates =
+let _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade
+    ~min_score_override ~total_stocks ~candidates_after_held ~macro_trend
+    ~candidates ~buy_candidates ~short_candidates =
   let long_phases =
     _count_long_phases ~weights ~thresholds:grade_thresholds ~min_grade
-      ~candidates
+      ~min_score_override ~candidates
   in
   let short_phases =
     _count_short_phases ~weights ~thresholds:grade_thresholds ~min_grade
-      ~candidates
+      ~min_score_override ~candidates
   in
   _build_cascade_diagnostics ~total_stocks ~candidates_after_held ~macro_trend
     ~long_phases ~short_phases ~buy_candidates ~short_candidates
@@ -625,6 +653,7 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
     grade_thresholds;
     candidate_params;
     min_grade;
+    min_score_override;
     max_buy_candidates;
     max_short_candidates;
     cascade_post_stop_cooldown_weeks = _;
@@ -641,22 +670,22 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
   let candidates_after_held = List.length candidates in
   let buy_candidates =
     _evaluate_longs ~weights ~thresholds:grade_thresholds
-      ~params:candidate_params ~min_grade ~max_buy_candidates ~candidates
-      ~macro_trend
+      ~params:candidate_params ~min_grade ~min_score_override
+      ~max_buy_candidates ~candidates ~macro_trend
   in
   let short_candidates =
     _evaluate_shorts ~weights ~thresholds:grade_thresholds
-      ~params:candidate_params ~min_grade ~max_short_candidates ~candidates
-      ~macro_trend
+      ~params:candidate_params ~min_grade ~min_score_override
+      ~max_short_candidates ~candidates ~macro_trend
   in
   let watchlist =
     _build_watchlist ~weights ~thresholds:grade_thresholds ~candidates
       ~buy_candidates ~buys_active
   in
   let cascade_diagnostics =
-    _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade ~total_stocks
-      ~candidates_after_held ~macro_trend ~candidates ~buy_candidates
-      ~short_candidates
+    _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade
+      ~min_score_override ~total_stocks ~candidates_after_held ~macro_trend
+      ~candidates ~buy_candidates ~short_candidates
   in
   {
     buy_candidates;

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -84,7 +84,24 @@ type config = {
       (** Per-candidate price parameters. Default: [default_candidate_params].
       *)
   min_grade : Weinstein_types.grade;
-      (** Minimum grade to include in output. Default: C. *)
+      (** Minimum grade to include in output. Default: C. Used unless
+          [min_score_override] is [Some _] — in that case the numeric override
+          takes precedence and the grade ladder is bypassed. *)
+  min_score_override : int option; [@sexp.default None]
+      (** Optional numeric score floor that, when [Some n], replaces the
+          {!min_grade} filter with a strict [score >= n] gate on the cascade
+          output. The numeric form is the natural tuning knob — sweepers can
+          vary a single integer (e.g. 38..50) without having to also adjust the
+          grade ladder ordering implied by {!grade_thresholds}.
+
+          Default: [None] — preserves the {!min_grade} grade-based filter
+          bit-equally. The grade label on each surviving candidate is still
+          computed from {!grade_thresholds} regardless.
+
+          Authority: GitHub issue #888 — "expose threshold as a config
+          parameter; add to the M5.5 grid_search sweep parameter list". The
+          design intent is to make the cascade score gate a single tunable
+          dimension. *)
   max_buy_candidates : int;
       (** Maximum number of buy candidates returned. Default: 20. *)
   max_short_candidates : int;

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -293,6 +293,119 @@ let test_watchlist_captures_low_grade _ =
     (List.exists result.watchlist ~f:(fun (t, _) -> String.(t = "LOW")))
 
 (* ------------------------------------------------------------------ *)
+(* min_score_override: numeric threshold gate                           *)
+(* ------------------------------------------------------------------ *)
+
+(** Build two breakout candidates with distinct scores by varying volume
+    confirmation: [LOW] uses Adequate-volume bars (spike_volume 1500 → ratio
+    1.5, [w_adequate_volume = 10]); [HIGH] uses Strong-volume bars (spike_volume
+    3000 → ratio 3.0, [w_strong_volume = 20]). Both share the Stage1→Stage2 stem
+    so the score delta isolates the volume signal. The exact integer scores
+    depend on additional analyzer signals (RS, resistance) — tests below probe
+    the [min_score_override] gate by comparing scores from the screener output
+    rather than pinning specific integers. *)
+let _two_breakouts () =
+  let bars_low =
+    rising_bars_with_custom_spike ~n:35 50.0 100.0 ~spike_idx:31
+      ~spike_volume:1500
+  in
+  let bars_high = rising_bars_with_spike ~n:35 50.0 100.0 ~spike_idx:31 in
+  let prior = Some (Stage1 { weeks_in_base = 10 }) in
+  [ make_analysis "LOW" prior bars_low; make_analysis "HIGH" prior bars_high ]
+
+(** Probe scores by running the screener with [min_grade = F] and no override —
+    every breakout that passes the per-stock filters lands in the output, and we
+    can read [score] for each ticker. *)
+let _scores_by_ticker stocks =
+  let probe_cfg = { cfg with min_grade = F; min_score_override = None } in
+  let result =
+    screen ~config:probe_cfg ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[]
+  in
+  String.Map.of_alist_reduce
+    (List.map result.buy_candidates ~f:(fun (c : scored_candidate) ->
+         (c.ticker, c.score)))
+    ~f:(fun a _ -> a)
+
+(** [min_score_override = Some n] strictly above LOW's score and at-or-below
+    HIGH's score admits only HIGH — pure numeric gate, not grade-dependent. *)
+let test_min_score_override_filters_below_threshold _ =
+  let stocks = _two_breakouts () in
+  let scores = _scores_by_ticker stocks in
+  let low_score = Map.find_exn scores "LOW" in
+  let high_score = Map.find_exn scores "HIGH" in
+  assert_that high_score (gt (module Int_ord) low_score);
+  let threshold = low_score + 1 in
+  let cfg_override = { cfg with min_score_override = Some threshold } in
+  let result =
+    screen ~config:cfg_override ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[]
+  in
+  assert_that result.buy_candidates
+    (elements_are
+       [ field (fun (c : scored_candidate) -> c.ticker) (equal_to "HIGH") ])
+
+(** [min_score_override = Some n] equal to HIGH's exact score still admits HIGH
+    — the gate is [>=], not [>]. *)
+let test_min_score_override_inclusive_at_boundary _ =
+  let stocks = _two_breakouts () in
+  let scores = _scores_by_ticker stocks in
+  let high_score = Map.find_exn scores "HIGH" in
+  let cfg_override = { cfg with min_score_override = Some high_score } in
+  let result =
+    screen ~config:cfg_override ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[]
+  in
+  assert_that result.buy_candidates
+    (elements_are
+       [ field (fun (c : scored_candidate) -> c.ticker) (equal_to "HIGH") ])
+
+(** [min_score_override] strictly above HIGH's score excludes both — pins the
+    [>=] semantics from above (no candidate strictly less than the threshold
+    passes). *)
+let test_min_score_override_strict_above_score _ =
+  let stocks = _two_breakouts () in
+  let scores = _scores_by_ticker stocks in
+  let high_score = Map.find_exn scores "HIGH" in
+  let cfg_override = { cfg with min_score_override = Some (high_score + 1) } in
+  let result =
+    screen ~config:cfg_override ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[]
+  in
+  assert_that result.buy_candidates is_empty
+
+(** [min_score_override = None] (default) is bit-equal to the legacy
+    {!min_grade}-based filter — for each [min_grade] level, the override-off run
+    admits exactly the same candidates as the override-off run did before this
+    field existed. Probed by running both LOW (grade C) and HIGH (grade B+)
+    under [min_grade = C] — both are admitted. *)
+let test_min_score_override_default_preserves_min_grade _ =
+  let stocks = _two_breakouts () in
+  let result =
+    screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
+      ~stocks ~held_tickers:[]
+  in
+  assert_that (List.length result.buy_candidates) (equal_to 2)
+
+(** When [min_score_override] is set, {!min_grade} is ignored — a configuration
+    that would block both candidates under [min_grade = A_plus] still admits the
+    HIGH candidate when the numeric override is at-or-below HIGH's score. *)
+let test_min_score_override_supersedes_min_grade _ =
+  let stocks = _two_breakouts () in
+  let scores = _scores_by_ticker stocks in
+  let low_score = Map.find_exn scores "LOW" in
+  let cfg_override =
+    { cfg with min_grade = A_plus; min_score_override = Some (low_score + 1) }
+  in
+  let result =
+    screen ~config:cfg_override ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[]
+  in
+  assert_that result.buy_candidates
+    (elements_are
+       [ field (fun (c : scored_candidate) -> c.ticker) (equal_to "HIGH") ])
+
+(* ------------------------------------------------------------------ *)
 (* Short candidates in Neutral market                                  *)
 (* ------------------------------------------------------------------ *)
 
@@ -810,6 +923,16 @@ let suite =
          "test_max_buy_candidates_cap" >:: test_max_buy_candidates_cap;
          "test_watchlist_captures_low_grade"
          >:: test_watchlist_captures_low_grade;
+         "test_min_score_override_filters_below_threshold"
+         >:: test_min_score_override_filters_below_threshold;
+         "test_min_score_override_inclusive_at_boundary"
+         >:: test_min_score_override_inclusive_at_boundary;
+         "test_min_score_override_strict_above_score"
+         >:: test_min_score_override_strict_above_score;
+         "test_min_score_override_default_preserves_min_grade"
+         >:: test_min_score_override_default_preserves_min_grade;
+         "test_min_score_override_supersedes_min_grade"
+         >:: test_min_score_override_supersedes_min_grade;
          "test_neutral_macro_produces_shorts"
          >:: test_neutral_macro_produces_shorts;
          "test_short_candidate_stop_above_entry"

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -190,12 +190,22 @@ let test_candidate_has_suggested_entry _ =
     screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
       ~stocks ~held_tickers:[]
   in
-  match result.buy_candidates with
-  | [] -> assert_failure "Expected at least one buy candidate"
-  | c :: _ ->
-      assert_that c.suggested_entry (gt (module Float_ord) 0.0);
-      assert_that c.suggested_stop (lt (module Float_ord) c.suggested_entry);
-      assert_that c.risk_pct (gt (module Float_ord) 0.0)
+  assert_that result.buy_candidates
+    (all_of
+       [
+         size_is 1;
+         elements_are
+           [
+             all_of
+               [
+                 field (fun c -> c.suggested_entry) (gt (module Float_ord) 0.0);
+                 field
+                   (fun c -> c.suggested_entry -. c.suggested_stop)
+                   (gt (module Float_ord) 0.0);
+                 field (fun c -> c.risk_pct) (gt (module Float_ord) 0.0);
+               ];
+           ];
+       ])
 
 (* ------------------------------------------------------------------ *)
 (* Purity                                                               *)
@@ -241,12 +251,22 @@ let test_scores_drive_sort_order _ =
   let result =
     screen ~config:cfg ~macro_trend:Bullish ~sector_map ~stocks ~held_tickers:[]
   in
-  match result.buy_candidates with
-  | c1 :: c2 :: _ ->
-      assert_that c1.ticker (equal_to "A");
-      assert_that c2.ticker (equal_to "B");
-      assert_that c1.score (gt (module Int_ord) c2.score)
-  | _ -> assert_failure "Expected at least two buy candidates"
+  assert_that result.buy_candidates
+    (all_of
+       [
+         size_is 2;
+         elements_are
+           [
+             field (fun c -> c.ticker) (equal_to "A");
+             field (fun c -> c.ticker) (equal_to "B");
+           ];
+         field
+           (fun cs ->
+             let c1 = List.nth_exn cs 0 in
+             let c2 = List.nth_exn cs 1 in
+             c1.score - c2.score)
+           (gt (module Int_ord) 0);
+       ])
 
 (* ------------------------------------------------------------------ *)
 (* Max cap: only top-N returned                                        *)
@@ -438,11 +458,21 @@ let test_short_candidate_stop_above_entry _ =
   let result =
     screen ~config:cfg ~macro_trend:Bearish ~sector_map ~stocks ~held_tickers:[]
   in
-  match result.short_candidates with
-  | [] -> assert_failure "Expected a short candidate"
-  | c :: _ ->
-      assert_that c.suggested_stop (gt (module Float_ord) c.suggested_entry);
-      assert_that c.risk_pct (gt (module Float_ord) 0.0)
+  assert_that result.short_candidates
+    (all_of
+       [
+         size_is 1;
+         elements_are
+           [
+             all_of
+               [
+                 field
+                   (fun c -> c.suggested_stop -. c.suggested_entry)
+                   (gt (module Float_ord) 0.0);
+                 field (fun c -> c.risk_pct) (gt (module Float_ord) 0.0);
+               ];
+           ];
+       ])
 
 (* ------------------------------------------------------------------ *)
 (* Candidate grade field matches score                                 *)
@@ -452,22 +482,31 @@ let test_candidate_grade_matches_score _ =
   let bars = rising_bars_with_spike ~n:35 50.0 100.0 ~spike_idx:31 in
   let prior = Some (Stage1 { weeks_in_base = 10 }) in
   let stocks = [ make_analysis "G" prior bars ] in
+  let grade_for_score score : grade =
+    if score >= 85 then A_plus
+    else if score >= 70 then A
+    else if score >= 55 then B
+    else if score >= 40 then C
+    else if score >= 25 then D
+    else F
+  in
   let result =
     screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
       ~stocks ~held_tickers:[]
   in
-  match result.buy_candidates with
-  | [] -> assert_failure "Expected a buy candidate"
-  | c :: _ ->
-      let expected_grade =
-        if c.score >= 85 then A_plus
-        else if c.score >= 70 then A
-        else if c.score >= 55 then B
-        else if c.score >= 40 then C
-        else if c.score >= 25 then D
-        else F
-      in
-      assert_that c.grade (equal_to (expected_grade : grade))
+  assert_that result.buy_candidates
+    (all_of
+       [
+         size_is 1;
+         elements_are
+           [
+             matching ~msg:"grade matches score-derived grade"
+               (fun c ->
+                 if Poly.equal c.grade (grade_for_score c.score) then Some ()
+                 else None)
+               (equal_to ());
+           ];
+       ])
 
 (* ------------------------------------------------------------------ *)
 (* Candidate side: buy_candidates are Long, short_candidates are Short *)
@@ -481,9 +520,13 @@ let test_buy_candidates_are_long _ =
     screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
       ~stocks ~held_tickers:[]
   in
-  match result.buy_candidates with
-  | [] -> assert_failure "Expected a buy candidate"
-  | c :: _ -> assert_that c.side (equal_to Trading_base.Types.Long)
+  assert_that result.buy_candidates
+    (all_of
+       [
+         size_is 1;
+         elements_are
+           [ field (fun c -> c.side) (equal_to Trading_base.Types.Long) ];
+       ])
 
 let test_short_candidates_are_short _ =
   let bars = declining_bars_with_spike ~n:60 100.0 30.0 ~spike_idx:55 in
@@ -495,9 +538,13 @@ let test_short_candidates_are_short _ =
   let result =
     screen ~config:cfg ~macro_trend:Bearish ~sector_map ~stocks ~held_tickers:[]
   in
-  match result.short_candidates with
-  | [] -> assert_failure "Expected a short candidate"
-  | c :: _ -> assert_that c.side (equal_to Trading_base.Types.Short)
+  assert_that result.short_candidates
+    (all_of
+       [
+         size_is 1;
+         elements_are
+           [ field (fun c -> c.side) (equal_to Trading_base.Types.Short) ];
+       ])
 
 (* ------------------------------------------------------------------ *)
 (* Short-side volume confirmation (mirror of long-side)                *)
@@ -537,26 +584,31 @@ let test_short_side_volume_confirmation_strong _ =
     screen ~config:cfg ~macro_trend:Bearish ~sector_map:(empty_sector_map ())
       ~stocks:[ with_neg_rs ] ~held_tickers:[]
   in
-  match result.short_candidates with
-  | [] -> assert_failure "Expected a short candidate"
-  | c :: _ ->
-      assert_that c
-        (all_of
+  assert_that result.short_candidates
+    (all_of
+       [
+         size_is 1;
+         elements_are
            [
-             field (fun c -> c.ticker) (equal_to "VOL_STRONG");
-             field (fun c -> c.score) (equal_to 85);
-             field (fun c -> c.grade) (equal_to (A_plus : grade));
-             field
-               (fun c -> c.rationale)
-               (matching ~msg:"rationale contains breakdown-volume label"
-                  (fun rs ->
-                    if
-                      List.exists rs ~f:(fun r ->
-                          String.is_substring r ~substring:"breakdown volume")
-                    then Some ()
-                    else None)
-                  (equal_to ()));
-           ])
+             all_of
+               [
+                 field (fun c -> c.ticker) (equal_to "VOL_STRONG");
+                 field (fun c -> c.score) (equal_to 85);
+                 field (fun c -> c.grade) (equal_to (A_plus : grade));
+                 field
+                   (fun c -> c.rationale)
+                   (matching ~msg:"rationale contains breakdown-volume label"
+                      (fun rs ->
+                        if
+                          List.exists rs ~f:(fun r ->
+                              String.is_substring r
+                                ~substring:"breakdown volume")
+                        then Some ()
+                        else None)
+                      (equal_to ()));
+               ];
+           ];
+       ])
 
 (** Adequate breakdown volume (1.5x average) adds [w_adequate_volume = 10]
     points, lifting a Stage-4 candidate that would otherwise score 30 + 0 + 0
@@ -587,15 +639,21 @@ let test_short_side_volume_adequate_label _ =
     screen ~config:cfg ~macro_trend:Bearish ~sector_map:(empty_sector_map ())
       ~stocks:[ with_neg_rs ] ~held_tickers:[]
   in
-  match result.short_candidates with
-  | [] -> assert_failure "Expected a short candidate"
-  | c :: _ ->
-      assert_that c.rationale
-        (matching ~msg:"contains 'Adequate breakdown volume'"
-           (fun rs ->
-             List.find rs ~f:(fun r ->
-                 String.equal r "Adequate breakdown volume"))
-           (equal_to "Adequate breakdown volume"))
+  assert_that result.short_candidates
+    (all_of
+       [
+         size_is 1;
+         elements_are
+           [
+             field
+               (fun c -> c.rationale)
+               (matching ~msg:"contains 'Adequate breakdown volume'"
+                  (fun rs ->
+                    List.find rs ~f:(fun r ->
+                        String.equal r "Adequate breakdown volume"))
+                  (equal_to "Adequate breakdown volume"));
+           ];
+       ])
 
 (** Inject a [Support.result] directly onto an otherwise-identical candidate and
     assert the screener's [_support_signal] picks it up as a clean-space- below

--- a/trading/test_data/888-quicklook/cell-A-default.sexp
+++ b/trading/test_data/888-quicklook/cell-A-default.sexp
@@ -1,0 +1,17 @@
+;; #888 quick-look — Cell A: default (min_score_override = None)
+;; Expected to reproduce sp500-2019-2023 baseline: 58.34% / 81 trades.
+;; Universe / period identical to goldens-sp500/sp500-2019-2023.sexp.
+((name "888-cell-A-default")
+ (description "#888 quick-look Cell A: default min_score_override (None) — baseline reproduction")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 500)
+ (config_overrides ())
+ (expected
+  ((total_return_pct   ((min  -100.0)     (max 1000.0)))
+   (total_trades       ((min 0)           (max 10000)))
+   (win_rate           ((min 0.0)         (max 100.0)))
+   (sharpe_ratio       ((min -10.0)       (max  10.0)))
+   (max_drawdown_pct   ((min 0.0)         (max 100.0)))
+   (avg_holding_days   ((min 0.0)         (max 1000.0)))
+   (open_positions_value ((min -10000000.0) (max 10000000.0))))))

--- a/trading/test_data/888-quicklook/cell-B-thresh-41.sexp
+++ b/trading/test_data/888-quicklook/cell-B-thresh-41.sexp
@@ -1,0 +1,17 @@
+;; #888 quick-look — Cell B: min_score_override = Some 41 (default + 1)
+;; Tightens the cascade score floor by 1 point. Expected: fewer trades.
+((name "888-cell-B-thresh-41")
+ (description "#888 quick-look Cell B: min_score_override = Some 41")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 500)
+ (config_overrides
+  (((screening_config ((min_score_override (41)))))))
+ (expected
+  ((total_return_pct   ((min  -100.0)     (max 1000.0)))
+   (total_trades       ((min 0)           (max 10000)))
+   (win_rate           ((min 0.0)         (max 100.0)))
+   (sharpe_ratio       ((min -10.0)       (max  10.0)))
+   (max_drawdown_pct   ((min 0.0)         (max 100.0)))
+   (avg_holding_days   ((min 0.0)         (max 1000.0)))
+   (open_positions_value ((min -10000000.0) (max 10000000.0))))))

--- a/trading/test_data/888-quicklook/cell-C-thresh-42.sexp
+++ b/trading/test_data/888-quicklook/cell-C-thresh-42.sexp
@@ -1,0 +1,17 @@
+;; #888 quick-look — Cell C: min_score_override = Some 42 (default + 2)
+;; Tightens the cascade score floor by 2 points. Expected: fewer trades still.
+((name "888-cell-C-thresh-42")
+ (description "#888 quick-look Cell C: min_score_override = Some 42")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 500)
+ (config_overrides
+  (((screening_config ((min_score_override (42)))))))
+ (expected
+  ((total_return_pct   ((min  -100.0)     (max 1000.0)))
+   (total_trades       ((min 0)           (max 10000)))
+   (win_rate           ((min 0.0)         (max 100.0)))
+   (sharpe_ratio       ((min -10.0)       (max  10.0)))
+   (max_drawdown_pct   ((min 0.0)         (max 100.0)))
+   (avg_holding_days   ((min 0.0)         (max 1000.0)))
+   (open_positions_value ((min -10000000.0) (max 10000000.0))))))

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -42,6 +42,7 @@ let _permissive_screener_config (config : config) : Screener.config =
     grade_thresholds = config.grade_thresholds;
     candidate_params = config.candidate_params;
     min_grade = F;
+    min_score_override = None;
     max_buy_candidates = Int.max_value;
     max_short_candidates = Int.max_value;
     cascade_post_stop_cooldown_weeks = 0;

--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -224,6 +224,25 @@ let test_skip_sector_etf_load_runs_to_completion _ =
   in
   assert_that (List.length result.steps) (gt (module Int_ord) 0)
 
+(** Pin the deep-merge path for [screening_config.min_score_override] — [(41)]
+    as the value sexp parses back to [Some 41] once the partial-config overlay
+    is merged into the default config. Issue #888 wires this knob into the M5.5
+    grid_search sweep via [Tuner.Grid_search.param_spec], so the runner must
+    accept it. *)
+let test_override_screening_min_score_override _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string "((screening_config ((min_score_override (41)))))")
+  in
+  assert_that merged.screening_config.min_score_override
+    (is_some_and (equal_to 41))
+
+(** [None] (the default) is preserved when no override is applied. Pins the
+    bit-equality contract documented in [Screener.config.min_score_override]. *)
+let test_default_screening_min_score_override_is_none _ =
+  let cfg = _default_config () in
+  assert_that cfg.screening_config.min_score_override is_none
+
 let suite =
   "Runner_hypothesis_overrides"
   >::: [
@@ -249,6 +268,10 @@ let suite =
          >:: test_skip_ad_breadth_runs_to_completion;
          "skip_sector_etf_load = true runs to completion (degraded mode)"
          >:: test_skip_sector_etf_load_runs_to_completion;
+         "override: screening_config.min_score_override round-trips through \
+          sexp" >:: test_override_screening_min_score_override;
+         "default: screening_config.min_score_override = None"
+         >:: test_default_screening_min_score_override_is_none;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/tuner/lib/grid_search.mli
+++ b/trading/trading/backtest/tuner/lib/grid_search.mli
@@ -44,7 +44,25 @@ type param_spec = (string * param_values) list
     ]
     ]}
 
-    yields a 3 × 3 × 3 × 3 = 81-cell grid. *)
+    yields a 3 × 3 × 3 × 3 = 81-cell grid.
+
+    {2 Cascade score-floor sweep (issue #888)}
+
+    The cascade score gate is exposed as [screening_config.min_score_override]
+    (see [Screener.config.min_score_override] in
+    [analysis/weinstein/screener/lib/screener.mli]). When set to [Some n], it
+    replaces the grade-based filter with a strict numeric [score >= n] gate.
+    Sweep example:
+    {[
+    [
+      ( "screening_config.min_score_override",
+        [ 38.0; 39.0; 40.0; 41.0; 42.0; 43.0 ] );
+    ]
+    ]}
+    Note: although the field is [int option] in the OCaml record, the grid spec
+    carries floats. The override sexp emitted by
+    {!Backtest.Config_override.parse_to_sexp} for [40.0] is the atom [40.],
+    which sexp-parses back to [Some 40] when deep-merged into the config. *)
 
 type cell = (string * float) list
 (** A single point in parameter space — one value per key, in the same order as


### PR DESCRIPTION
## What

Closes #888 (small + immediate-prep variant).

Adds a numeric cascade-score-floor knob to `Screener.config` and pins the
override-deep-merge path so the M5.5 grid_search sweep can include it.

### Design

`Screener.config` gains a new field:

```ocaml
min_score_override : int option;  [@sexp.default None]
```

When `Some n`, the cascade replaces the existing grade-based filter
(`min_grade` + `grade_thresholds`) with a strict numeric gate `score >= n`.
When `None` (default), the legacy grade-based filter is used unchanged —
**bit-equal to pre-PR behaviour**, verified against the pinned 5y SP500
baseline (see Cell A below).

Threading: a single `_passes_score_floor` helper is the source of truth,
called from `_score_and_build` and the `_long_admission` /
`_short_admission` predicates so the cascade-diagnostics counts can't drift
from the actual filter.

### Why an int-option override field rather than re-using grade_thresholds.c?

The threshold *was* already exposed via `grade_thresholds.c` (default 40),
but tuning it requires preserving the grade ladder ordering across all 5
grade cutoffs. `min_score_override` is the natural single-knob surface for
the issue's stated use case ("bump the cascade score threshold by 1-2
points"), and cleanly fits the M5.5 grid_search `(string * float list)`
spec.

## 3-cell quick-look (sp500-2019-2023)

Wall time: 6m53s for 3 cells at `--parallel 3`. Full numbers in
`dev/notes/888-score-threshold-quick-look-2026-05-06.md`.

| Cell | Threshold | Return | Trades | Sharpe | MaxDD |
|---|---|---:|---:|---:|---:|
| A (default) | grade ≥ C (≥40) | **+58.34%** | **81** | 0.537 | 33.60% |
| B (+1)      | score ≥ 41       | +54.57%      | 93     | 0.545 | 28.69% |
| C (+2)      | score ≥ 42       | +54.57%      | 93     | 0.545 | 28.69% |

**Cell A is bit-equal to the pinned baseline** — confirms default `None` is
a no-op (required by acceptance).

**Cells B = C byte-identical** — at default scoring weights (subsets of
{10,15,20,30,±10}), no candidate scores exactly 41, so the 42-floor admits the
same set as 41.

**Counter-intuitive: tighter threshold INCREASED trade count** (81 → 93,
+14.8%); return DROPPED 3.8pp; MaxDD dropped 4.9pp; Sharpe ~unchanged.
Consistent with #871's "cascade is at no-look-ahead ceiling" verdict — the
bottleneck is capital recycling, not candidate quality.

## Recommendation

Per #871 §"Do NOT prioritize cascade score re-weighting" and the cells-B/C
result above, **defer the actual sweep** until #872 / #887 capital-recycling
work lands. When sweeping post-#872, use cells that bracket score
discontinuities (e.g. {40, 45, 50, 55, 60}) rather than 1-pt increments.

## Files

- `trading/analysis/weinstein/screener/lib/screener.{ml,mli}` — new field
  + `_passes_score_floor` helper threaded through admission predicates
- `trading/analysis/weinstein/screener/test/test_screener.ml` — 5 new tests:
  filters-below / inclusive-at-boundary / strict-above / default-preserves /
  supersedes-min-grade
- `trading/trading/backtest/optimal/lib/stage_transition_scanner.ml` — set
  `min_score_override = None` in the permissive scanner config
- `trading/trading/backtest/test/test_runner_hypothesis_overrides.ml` —
  pins the deep-merge path: `((screening_config ((min_score_override (41)))))`
  → `Some 41`; default-None pin
- `trading/trading/backtest/tuner/lib/grid_search.mli` — registers
  `screening_config.min_score_override` as a sweepable dimension example
- `trading/test_data/888-quicklook/cell-{A,B,C}-*.sexp` — the 3-cell sweep
  scenarios
- `dev/notes/888-score-threshold-quick-look-2026-05-06.md` — the quick-look
  report
- `dev/status/tuning.md` — Completed entry

## Test plan

- [x] `dune build` passes (zero warnings; only pre-existing "no dune-project"
      cosmetic noise).
- [x] `dune runtest analysis/weinstein/screener/test/` — 36 / 36 (5 new).
- [x] `dune exec trading/backtest/test/test_runner_hypothesis_overrides.exe`
      — 13 / 13 (2 new).
- [x] 3-cell sweep ran in 6m53s; Cell A reproduces the pinned baseline
      bit-equally (58.343651690 / 81 trades / Sharpe 0.5369 / MaxDD 33.5996).
- [x] `dune build @fmt` — only pre-existing `{[ ]}` block indentation skew
      in `grid_search.mli` (per memory `project_ocamlformat_version_skew.md`,
      CI uses an older ocamlformat that accepts the 4-space form; my new
      block matches the pre-existing convention in the same file).

## Acceptance (issue #888)

- [x] Threshold parameter exposed in `Screener.config`
- [x] Default unchanged (preserves baseline — bit-equal Cell A)
- [x] Grid sweep dimension added to T-A grid_search (docstring + example)
- [x] Documented finding: threshold-vs-trade-count quick-look for the canonical
      5y scenario
- [x] **Out of scope (per dispatch):** no production fixture flip; no 15y run;
      full sweep deferred until #872 / #887 lands