### PR TITLE
feat(perf): add tier4-broad-1y mechanic-validation SCALE cell

### DIFF
--- a/trading/test_data/backtest_scenarios/goldens-broad/tier4-broad-1y.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/tier4-broad-1y.sexp
@@ -1,0 +1,65 @@
+;; perf-tier: 4-scale
+;; perf-tier-rationale: Tier-4 release-gate SCALE mechanic-validation cell at
+;; full broad universe (~10,472 symbols from data/sectors.csv) × 1y. Probes
+;; the snapshot-mode runtime path (default since #802 / Phase F.2) end-to-end
+;; on the full Friday-cycle universe over a short calendar wall, before
+;; committing to the multi-hour `tier4-broad-10y` run.
+;;
+;; Why a 1y mechanic-validation cell ahead of the 10y SCALE cell:
+;; per `dev/notes/tier4-release-gate-checklist-2026-04-28.md`, the 10y SCALE
+;; cell has never been run locally and brings together several first-time-at-
+;; -scale infrastructure pieces (snapshot-corpus auto-build, full-broad
+;; universe load, cache-bounded RSS budget ~50-200 MB). Running 10k×1y first
+;; surfaces any infrastructure problem in minutes rather than hours: if 1y
+;; holds at the cache-bounded RSS budget, high confidence the 10y will too.
+;; The runtime path is otherwise identical (same universe, same snapshot
+;; mode, same screener/portfolio gates) — only the calendar wall differs.
+;;
+;; Universe: `universes/broad.sexp` is the `Full_sector_map` sentinel that
+;; resolves at runtime to whatever symbols are in `data/sectors.csv` (today
+;; 10,472 entries; verify with `dev/scripts/check_broad_universe_coverage.sh`).
+;; No `universe_cap` — let the runtime use the full sentinel.
+;;
+;; Run via `dev/scripts/run_tier4_release_gate.sh` (auto-discovers all
+;; `;; perf-tier: 4-scale` cells under `goldens-broad/`). Both this 1y cell
+;; and the existing `tier4-broad-10y.sexp` will be discovered; run the 1y
+;; cell on its own first via the runner's stage-dir mechanism, or rely on
+;; the runner's per-cell timeout to gate them in sequence.
+;;
+;; Window rationale: 2022-01-03 to 2022-12-30 — a clean trading-calendar
+;; year. 2022 sits well inside the local data coverage window (post-2010
+;; deep-history gaps avoided) and overlaps multiple existing N=1000
+;; baselines, so the cell can be sanity-checked against those if needed.
+;;
+;; STATUS: SCAFFOLDING ONLY — `expected` ranges are intentionally permissive
+;; (BASELINE_PENDING_AFTER_FIRST_RUN). The first manual local run on the
+;; user's 8 GB box (under snapshot mode + auto-built snapshot corpus)
+;; produces the canonical baseline; tighten ranges via follow-up PR after
+;; that run lands. Until then this cell SHALL NOT be added to any recurring
+;; workflow.
+;;
+;; PINNED_AFTER_FIRST_RUN — leave `expected` ranges wide; first local run
+;; populates them.
+((name "tier4-broad-1y")
+ (description "Tier-4 release-gate SCALE — full broad universe × 1y mechanic validation (snapshot-mode only)")
+ (period ((start_date 2022-01-03) (end_date 2022-12-30)))
+ (universe_path "universes/broad.sexp")
+ (universe_size 10472)
+ ;; enable_short_side disabled mirroring the N=1000 tier-4 cells and the
+ ;; tier4-broad-10y cell (dev/notes/short-side-gaps-2026-04-29.md G1-G4
+ ;; unresolved). Revert when short-side gaps close + the override is
+ ;; dropped from the long-only family.
+ (config_overrides (((enable_short_side false))))
+ ;; PINNED_AFTER_FIRST_RUN — wide ranges. First local run on the user's 8 GB
+ ;; box under snapshot mode produces the canonical baseline; tighten ranges
+ ;; via follow-up PR once captured. The wide bounds below confirm "the run
+ ;; completed without OOM/crash and produced non-degenerate metrics" — same
+ ;; pattern as `tier4-broad-10y.sexp` and `sp500-30y-capacity-1996.sexp`.
+ (expected
+  ((total_return_pct   ((min -1000.0)        (max 1000000.0)))
+   (total_trades       ((min 0)              (max 100000)))
+   (win_rate           ((min 0.0)            (max 100.0)))
+   (sharpe_ratio       ((min -10.0)          (max 10.0)))
+   (max_drawdown_pct   ((min 0.0)            (max 100.0)))
+   (avg_holding_days   ((min 0.0)            (max 10000.0)))
+   (open_positions_value ((min -1000000000.0) (max 100000000000.0))))))


### PR DESCRIPTION
## Summary

Adds a tier-4 SCALE mechanic-validation cell at full broad universe (~10,472 symbols) × 1y, scaffolded ahead of the multi-hour `tier4-broad-10y` run.

## Why

Per `dev/notes/tier4-release-gate-checklist-2026-04-28.md`, the existing `tier4-broad-10y` SCALE cell has never been run locally and brings together several first-time-at-scale infrastructure pieces (snapshot-corpus auto-build, full-broad universe load, cache-bounded RSS budget ~50–200 MB).

Running 10k × 1y first surfaces any infrastructure problem in minutes rather than hours. The runtime path is otherwise identical to the 10y cell (same universe, same snapshot mode, same screener / portfolio gates) — only the calendar wall differs. If 1y holds at the cache-bounded RSS budget, high confidence the 10y will too.

## Shape

- `;; perf-tier: 4-scale` (auto-discovered by `dev/scripts/run_tier4_release_gate.sh` lines 134–140; **no script change required**).
- Window: `2022-01-03` → `2022-12-30` — clean trading-calendar year, well inside local data coverage (post-2010 deep-history gaps avoided).
- Universe: `universes/broad.sexp` (`Full_sector_map` sentinel resolving to ~10,472 symbols from `data/sectors.csv`).
- `enable_short_side` disabled mirroring the existing tier-4 cells (short-side gaps G1–G4 unresolved per `dev/notes/short-side-gaps-2026-04-29.md`).
- `expected` ranges intentionally permissive (BASELINE_PENDING_AFTER_FIRST_RUN), same SCAFFOLDING-ONLY pattern as the 10y cell. First local run produces the canonical baseline; tighten via follow-up PR.

## Verification

`dune build trading/backtest/scenarios/scenario_runner.exe` — green (exit 0).

`dev/scripts/run_tier4_release_gate.sh --dry-run` discovers **both** SCALE cells:

```
Tier-4 release-gate SCALE run.
  Scenario root  : .../trading/test_data/backtest_scenarios
  Output dir     : .../dev/perf/tier4-scale-2026-05-06T174341Z
  Per-cell timeout : 43200s
  Dry run        : 1

[dry]  tier4-broad-10y
       cmd: dune exec --no-build trading/backtest/scenarios/scenario_runner.exe -- --dir <stage>/_stage_tier4-broad-10y --parallel 1 --fixtures-root <root> --snapshot-mode
       timeout: 43200s  OCAMLRUNPARAM=o=60,s=512k
[dry]  tier4-broad-1y
       cmd: dune exec --no-build trading/backtest/scenarios/scenario_runner.exe -- --dir <stage>/_stage_tier4-broad-1y --parallel 1 --fixtures-root <root> --snapshot-mode
       timeout: 43200s  OCAMLRUNPARAM=o=60,s=512k
Tier-4 release-gate SCALE summary (2026-05-06T174341Z)
  passed: 2
  failed: 0
  dry-run: 1

STATUS  SCENARIO                          WALL      PEAK_RSS
----------------------------------------------------------------------
DRY     tier4-broad-10y                   -         -
DRY     tier4-broad-1y                    -         -
```

## Test plan

- [x] `dune build trading/backtest/scenarios/scenario_runner.exe` passes
- [x] `dev/scripts/run_tier4_release_gate.sh --dry-run` discovers both `tier4-broad-1y` and `tier4-broad-10y`
- [ ] **Not in this PR** — actual run is multi-hour user-supervised local execution, gated on coverage ≥90% (currently ~5% per `dev/notes/data-gaps.md` §broad-universe-coverage)

## Scope

Pure test_data addition:
- `trading/test_data/backtest_scenarios/goldens-broad/tier4-broad-1y.sexp` (new)

No production code, no script changes, no .mli/.ml touches.

