### PR TITLE
feat(backtest): all-eligible trade-grading lib (issue #870 PR-1)

### DIFF
--- a/dev/plans/all-eligible-trade-grading-2026-05-06.md
+++ b/dev/plans/all-eligible-trade-grading-2026-05-06.md
@@ -1,0 +1,167 @@
+# All-eligible fixed-dollar trade-grading diagnostic (issue #870)
+
+## Context
+
+Issue #870 calls for a diagnostic tool that — for every Stage-2 entry signal
+that fires across a backtest period — allocates a fixed dollar amount per
+signal, bypasses every portfolio-level rejection, and tracks each position
+independently to its natural exit.
+
+Why now:
+- #871 15y diagnostic showed cascade is at no-look-ahead ceiling; capital
+  recycling is the leverage gap.
+- #856 grid sweep showed `max_position_pct_long` alone can't hit acceptance
+  gates. Suspected mechanisms: `Insufficient_cash` skips + stop-distance gates.
+
+The diagnostic separates **signal quality** from **portfolio mechanism**:
+
+| Tool                          | Measures                                                 |
+|-------------------------------|----------------------------------------------------------|
+| `optimal-strategy`            | Counterfactual "perfect picking" within universe scope   |
+| `all-eligible` (this PR)      | Raw signal alpha — what would each Stage-2 signal return |
+| `actual` (live backtest)      | Strategy + portfolio mechanism interaction               |
+
+Combining all three:
+- High signal alpha + many portfolio rejections → portfolio surface needs loosening
+- Low signal alpha + few rejections → screener cascade needs tightening
+- High alpha + few rejections + low actual return → optimal-strategy picking gap
+
+## Approach
+
+The `optimal-strategy` track already has the two pure functions needed:
+
+1. `Stage_transition_scanner.scan_panel` — per-Friday Stage-2 breakout
+   enumeration. Drops cascade gates (top-N, grade, macro), keeps the
+   per-candidate breakout predicate + price helpers. Macro pass is recorded
+   on each candidate, not gated.
+2. `Outcome_scorer.score` — forward-walks the panel applying the trailing
+   stop walker + Stage-3 detector. Returns the realised exit week / price /
+   R-multiple per candidate.
+
+The all-eligible diagnostic is the same pipeline minus the greedy filler.
+Instead of resolving sizing / cash / sector caps, every scored candidate
+becomes one trade record sized at `entry_dollars / entry_price` shares.
+
+**Key design decisions:**
+
+- **Reuse, don't duplicate.** The lib lives at
+  `trading/trading/backtest/all_eligible/lib/all_eligible.{ml,mli}` and depends
+  on `backtest_optimal` for `Optimal_types`, `Stage_transition_scanner`, and
+  `Outcome_scorer`. No new pure functions for entry/exit logic — same
+  byte-for-byte semantics as the optimal-strategy track.
+- **Pure function entry point.** `grade` takes the already-scored candidates
+  (the caller is responsible for scanning + scoring) and produces the trade
+  records + aggregate. This keeps the lib portable: the same surface can be
+  driven from a CLI binary (PR-2) or from in-process tests with hand-built
+  scored candidates (this PR's tests).
+- **Allocate fixed dollars per signal.** Default `entry_dollars = 10_000.0`
+  (configurable). Shares = `entry_dollars / entry_price` as float (no
+  rounding — these are diagnostic positions, not real fills).
+- **No portfolio interaction.** Every signal is taken regardless of cash,
+  exposure, sector concentration, or any other portfolio-level limit. Each
+  position evolves independently.
+- **PR-1 scope: lib + tests only.** ≤ 500 LOC. CLI exe + integration with a
+  real run's artefacts is PR-2.
+
+## Files to change
+
+New:
+
+- `trading/trading/backtest/all_eligible/lib/dune` — library declaration.
+- `trading/trading/backtest/all_eligible/lib/all_eligible.mli` — public
+  surface: `config`, `trade_record`, `aggregate`, `result`, `default_config`,
+  `grade`. Aggregate metric helpers exposed for unit testing.
+- `trading/trading/backtest/all_eligible/lib/all_eligible.ml` —
+  implementation. Pure function. Walks scored candidates, projects each into
+  a `trade_record`, computes aggregate.
+- `trading/trading/backtest/all_eligible/test/dune` — test runner.
+- `trading/trading/backtest/all_eligible/test/test_all_eligible.ml` —
+  OUnit2 + Matchers tests covering the three required cases plus edge cases.
+
+No modifications to existing modules.
+
+## Public surface (sketch)
+
+```ocaml
+type config = {
+  entry_dollars : float;
+  return_buckets : float list;
+}
+
+type trade_record = {
+  signal_date : Core.Date.t;
+  symbol : string;
+  side : Trading_base.Types.position_side;
+  entry_price : float;
+  exit_date : Core.Date.t;
+  exit_reason : Optimal_types.exit_trigger;
+  return_pct : float;
+  hold_days : int;
+  entry_dollars : float;
+  shares : float;
+  pnl_dollars : float;
+  cascade_score : int;
+  passes_macro : bool;
+}
+
+type aggregate = {
+  trade_count : int;
+  winners : int;
+  losers : int;
+  win_rate_pct : float;
+  mean_return_pct : float;
+  median_return_pct : float;
+  total_pnl_dollars : float;
+  return_buckets : (float * float * int) list;
+}
+
+type result = {
+  trades : trade_record list;
+  aggregate : aggregate;
+}
+
+val default_config : config
+val grade :
+  config:config ->
+  scored:Optimal_types.scored_candidate list ->
+  result
+```
+
+## Risks / unknowns
+
+- **Hold days vs hold weeks.** `Optimal_types.scored_candidate.hold_weeks` is
+  in weeks; the issue calls for `hold_days`. Convert via
+  `Date.diff exit_date signal_date` directly — preserves day granularity.
+- **Return buckets.** Issue says "return distribution histogram". I'll use
+  fixed default boundaries: `[-0.5; -0.2; 0.0; 0.2; 0.5; 1.0]` yielding seven
+  buckets. Configurable via `config.return_buckets`.
+- **CSV / Markdown emit.** Out of scope for PR-1 — the lib returns records,
+  PR-2 (CLI exe) handles I/O.
+
+## Acceptance criteria
+
+- `grade` returns `trade_count = scored.length` (every signal taken — no gates).
+- Per-trade `pnl_dollars = (exit_price - entry_price) * shares` for longs,
+  reflected for shorts.
+- Aggregate `total_pnl_dollars = sum(per-trade pnl_dollars)` (alpha additive).
+- `win_rate_pct = winners / trade_count`, where winner = `return_pct > 0`.
+- Tests: synthetic 3-signal scenario (all 3 taken); per-trade exit-reason +
+  return matches hand-calc; aggregate matches sum.
+- `dune build && dune runtest` green; `dune build @fmt` clean.
+- Linters (function length, magic numbers, mli coverage) all pass.
+
+## Out of scope
+
+- CLI exe wrapper (PR-2).
+- Reading a real run's `summary.sexp` / `actual.sexp` (PR-2 — uses
+  `Optimal_run_artefacts.load`).
+- Snapshot construction + per-Friday scan loop (PR-2 — reuses
+  `Optimal_strategy_runner._build_world` / `_scan_and_score`).
+- Output emission to disk (`csv`, `summary.md`) — PR-2.
+- Distributional metrics (Sharpe, Sortino, etc.) — separate M5.2c/d track.
+
+## Reference
+
+- Issue: https://github.com/dayfine/trading/issues/870
+- Optimal-strategy track: `trading/trading/backtest/optimal/lib/`
+- 15y diagnostic: `dev/notes/15y-sp500-zero-trades-diagnosis-2026-05-03.md`

--- a/trading/trading/backtest/all_eligible/lib/all_eligible.ml
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible.ml
@@ -107,9 +107,9 @@ let _median (xs : float list) : float =
         let hi = sorted.(n / 2) in
         (lo +. hi) /. 2.0
 
-(** Build the [(low, high)] bucket boundary pairs from
-    [config.return_buckets]. Prepends [neg_infinity] and appends [infinity]
-    so the first / last buckets are unbounded. *)
+(** Build the [(low, high)] bucket boundary pairs from [config.return_buckets].
+    Prepends [neg_infinity] and appends [infinity] so the first / last buckets
+    are unbounded. *)
 let _bucket_bounds (boundaries : float list) : (float * float) list =
   let starts = Float.neg_infinity :: boundaries in
   let ends = boundaries @ [ Float.infinity ] in
@@ -123,7 +123,8 @@ let _bucketize ~(boundaries : float list) (returns : float list) :
   let bounds = _bucket_bounds boundaries in
   List.map bounds ~f:(fun (low, high) ->
       let count =
-        List.count returns ~f:(fun r -> Float.( >= ) r low && Float.( < ) r high)
+        List.count returns ~f:(fun r ->
+            Float.( >= ) r low && Float.( < ) r high)
       in
       (low, high, count))
 

--- a/trading/trading/backtest/all_eligible/lib/all_eligible.ml
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible.ml
@@ -3,7 +3,7 @@
     See [all_eligible.mli] for the API contract. *)
 
 open Core
-module OT = Optimal_types
+module OT = Backtest_optimal.Optimal_types
 
 (* ------------------------------------------------------------------ *)
 (* Defaults                                                             *)

--- a/trading/trading/backtest/all_eligible/lib/all_eligible.ml
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible.ml
@@ -1,0 +1,167 @@
+(** Fixed-dollar all-eligible trade-grading diagnostic.
+
+    See [all_eligible.mli] for the API contract. *)
+
+open Core
+module OT = Optimal_types
+
+(* ------------------------------------------------------------------ *)
+(* Defaults                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let _default_entry_dollars = 10_000.0
+let _default_return_buckets : float list = [ -0.5; -0.2; 0.0; 0.2; 0.5; 1.0 ]
+
+(* ------------------------------------------------------------------ *)
+(* Types                                                                *)
+(* ------------------------------------------------------------------ *)
+
+type config = { entry_dollars : float; return_buckets : float list }
+[@@deriving sexp]
+
+let default_config : config =
+  {
+    entry_dollars = _default_entry_dollars;
+    return_buckets = _default_return_buckets;
+  }
+
+type trade_record = {
+  signal_date : Date.t;
+  symbol : string;
+  side : Trading_base.Types.position_side;
+  entry_price : float;
+  exit_date : Date.t;
+  exit_reason : OT.exit_trigger;
+  return_pct : float;
+  hold_days : int;
+  entry_dollars : float;
+  shares : float;
+  pnl_dollars : float;
+  cascade_score : int;
+  passes_macro : bool;
+}
+[@@deriving sexp]
+
+type aggregate = {
+  trade_count : int;
+  winners : int;
+  losers : int;
+  win_rate_pct : float;
+  mean_return_pct : float;
+  median_return_pct : float;
+  total_pnl_dollars : float;
+  return_buckets : (float * float * int) list;
+}
+[@@deriving sexp]
+
+type result = { trades : trade_record list; aggregate : aggregate }
+[@@deriving sexp]
+
+(* ------------------------------------------------------------------ *)
+(* Per-trade projection                                                 *)
+(* ------------------------------------------------------------------ *)
+
+let build_trade_record ~(config : config) (sc : OT.scored_candidate) :
+    trade_record =
+  let entry = sc.entry in
+  let shares = config.entry_dollars /. entry.entry_price in
+  let pnl_per_share =
+    match entry.side with
+    | Trading_base.Types.Long -> sc.exit_price -. entry.entry_price
+    | Short -> entry.entry_price -. sc.exit_price
+  in
+  let pnl_dollars = pnl_per_share *. shares in
+  let hold_days = Date.diff sc.exit_week entry.entry_week in
+  {
+    signal_date = entry.entry_week;
+    symbol = entry.symbol;
+    side = entry.side;
+    entry_price = entry.entry_price;
+    exit_date = sc.exit_week;
+    exit_reason = sc.exit_trigger;
+    return_pct = sc.raw_return_pct;
+    hold_days;
+    entry_dollars = config.entry_dollars;
+    shares;
+    pnl_dollars;
+    cascade_score = entry.cascade_score;
+    passes_macro = entry.passes_macro;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* Aggregate helpers                                                    *)
+(* ------------------------------------------------------------------ *)
+
+(** Median of a non-empty float list, with the standard "average of the two
+    middles for even N" rule. Returns [0.0] for the empty list — caller is
+    responsible for the empty-trades short-circuit. *)
+let _median (xs : float list) : float =
+  match xs with
+  | [] -> 0.0
+  | _ ->
+      let sorted = List.sort xs ~compare:Float.compare |> Array.of_list in
+      let n = Array.length sorted in
+      if n mod 2 = 1 then sorted.(n / 2)
+      else
+        let lo = sorted.((n / 2) - 1) in
+        let hi = sorted.(n / 2) in
+        (lo +. hi) /. 2.0
+
+(** Build the [(low, high)] bucket boundary pairs from
+    [config.return_buckets]. Prepends [neg_infinity] and appends [infinity]
+    so the first / last buckets are unbounded. *)
+let _bucket_bounds (boundaries : float list) : (float * float) list =
+  let starts = Float.neg_infinity :: boundaries in
+  let ends = boundaries @ [ Float.infinity ] in
+  List.zip_exn starts ends
+
+(** Count returns falling into each bucket. Bucket interval is half-open
+    [\[low, high)]. The last bucket's [high] is [+infinity], so any positive
+    return falls cleanly into [\[bn, +inf)]. *)
+let _bucketize ~(boundaries : float list) (returns : float list) :
+    (float * float * int) list =
+  let bounds = _bucket_bounds boundaries in
+  List.map bounds ~f:(fun (low, high) ->
+      let count =
+        List.count returns ~f:(fun r -> Float.( >= ) r low && Float.( < ) r high)
+      in
+      (low, high, count))
+
+let compute_aggregate ~(config : config) (trades : trade_record list) :
+    aggregate =
+  let trade_count = List.length trades in
+  let returns = List.map trades ~f:(fun t -> t.return_pct) in
+  let winners = List.count returns ~f:(fun r -> Float.( > ) r 0.0) in
+  let losers = List.count returns ~f:(fun r -> Float.( < ) r 0.0) in
+  let total_pnl_dollars =
+    List.fold trades ~init:0.0 ~f:(fun acc t -> acc +. t.pnl_dollars)
+  in
+  let win_rate_pct =
+    if trade_count = 0 then 0.0
+    else Float.of_int winners /. Float.of_int trade_count
+  in
+  let mean_return_pct =
+    if trade_count = 0 then 0.0
+    else List.fold returns ~init:0.0 ~f:( +. ) /. Float.of_int trade_count
+  in
+  let median_return_pct = _median returns in
+  let return_buckets = _bucketize ~boundaries:config.return_buckets returns in
+  {
+    trade_count;
+    winners;
+    losers;
+    win_rate_pct;
+    mean_return_pct;
+    median_return_pct;
+    total_pnl_dollars;
+    return_buckets;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* Public entry point                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let grade ~(config : config) ~(scored : OT.scored_candidate list) : result =
+  let trades = List.map scored ~f:(build_trade_record ~config) in
+  let aggregate = compute_aggregate ~config trades in
+  { trades; aggregate }

--- a/trading/trading/backtest/all_eligible/lib/all_eligible.mli
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible.mli
@@ -1,0 +1,192 @@
+(** Fixed-dollar all-eligible trade-grading diagnostic.
+
+    For every Stage-2 entry signal that fires across a backtest period,
+    allocates a fixed dollar amount (default $10K) per signal, bypasses every
+    portfolio-level rejection (no cash floor, no exposure cap, no sector
+    concentration), tracks each position independently to its natural exit,
+    and emits per-trade alpha plus aggregate stats.
+
+    {1 What this measures}
+
+    Raw signal alpha — what each Stage-2 breakout signal would have returned if
+    we'd taken every one. Separates {b signal quality} from {b portfolio
+    mechanism}:
+
+    - High signal alpha + many portfolio rejections in the actual run →
+      portfolio surface needs loosening.
+    - Low signal alpha + few rejections → screener cascade needs tightening.
+    - High alpha + few rejections + low actual return → optimal-strategy
+      picking gap (orderings differ from realised outcome).
+
+    {1 Pipeline}
+
+    The diagnostic operates on the same {b scored candidates} the
+    {!Backtest_optimal} track produces:
+
+    1. Scan: {!Stage_transition_scanner.scan_panel} enumerates one candidate
+       per (symbol, week) where the system's structural breakout predicate
+       fires — drops cascade gates (top-N, grade, macro), keeps the
+       per-candidate breakout predicate + price helpers. Macro pass is
+       recorded on each candidate, not gated.
+    2. Score: {!Outcome_scorer.score} forward-walks the panel applying the
+       trailing-stop walker + Stage-3 detector and emits the realised exit
+       week / price / R-multiple per candidate.
+    3. {b Grade} (this module): every scored candidate becomes one
+       {!trade_record} sized at [config.entry_dollars / entry_price] shares
+       — no portfolio-level interaction, no cash gate, no sector cap. Aggregate
+       stats roll up across all trades.
+
+    {1 Reuse, not duplication}
+
+    The entry/exit semantics are the same byte-for-byte as the
+    optimal-strategy track (calls the same pure functions). The only
+    difference is portfolio interaction: optimal-strategy's
+    {!Optimal_portfolio_filler} resolves cash + sector + sizing; the
+    all-eligible grader skips that entirely.
+
+    {1 Purity}
+
+    Pure function. No I/O, no mutable state. The caller (PR-2 binary) owns
+    artefact loading + scan + score; this module only owns the
+    grade-and-aggregate phase.
+
+    Authority: GitHub issue #870. *)
+
+open Core
+
+type config = {
+  entry_dollars : float;
+      (** Fixed dollar amount allocated per signal. Default: $10,000. Each
+          trade's [shares] is [entry_dollars /. entry_price] — no rounding,
+          since these are diagnostic positions, not real fills. *)
+  return_buckets : float list;
+      (** Bucket boundaries (as decimal fractions, e.g.
+          [\[-0.5; -0.2; 0.0; 0.2; 0.5; 1.0\]]) for the per-trade return
+          distribution histogram. The buckets are half-open intervals:
+          [(-inf, b0)], [\[b0, b1)], ..., [\[bn, +inf)]. Default:
+          [\[-0.5; -0.2; 0.0; 0.2; 0.5; 1.0\]] — yields seven buckets:
+          [<-50%], [-50..-20%], [-20..0%], [0..20%], [20..50%], [50..100%],
+          [>100%]. *)
+}
+[@@deriving sexp]
+(** Diagnostic configuration. Both knobs configurable per
+    {!default_config} — no magic numbers in the implementation. *)
+
+val default_config : config
+(** [default_config] = [{ entry_dollars = 10_000.0; return_buckets = \[-0.5;
+    -0.2; 0.0; 0.2; 0.5; 1.0\] }]. *)
+
+type trade_record = {
+  signal_date : Date.t;
+      (** Friday on which the breakout predicate fired — the same as
+          [scored_candidate.entry.entry_week]. *)
+  symbol : string;
+  side : Trading_base.Types.position_side;
+      (** [Long] for Stage 1→2 breakouts, [Short] for Stage 3→4 breakdowns.
+          (PR-1 only sees [Long] candidates because
+          {!Stage_transition_scanner} only emits longs today; the field is
+          carried for forward-compatibility with the short-side scanner.) *)
+  entry_price : float;
+      (** Counterfactual entry price — the breakout-week close. Same source as
+          [scored_candidate.entry.entry_price]. *)
+  exit_date : Date.t;
+      (** Friday on which the position closed under the natural exit rule
+          (stop hit, Stage-3 transition confirmed, or end of run). *)
+  exit_reason : Optimal_types.exit_trigger;
+      (** Which natural exit fired. Same {!Optimal_types.exit_trigger}
+          variants as the optimal-strategy track. *)
+  return_pct : float;
+      (** Per-trade return as a decimal fraction. For longs:
+          [(exit_price -. entry_price) /. entry_price]. For shorts: the
+          mirrored expression. Sign carries the direction. *)
+  hold_days : int;
+      (** Calendar-day difference [exit_date - signal_date]. Day-granularity
+          (not week-rounded) to give the histogram more resolution than
+          [scored_candidate.hold_weeks]. *)
+  entry_dollars : float;
+      (** Dollar amount allocated to this signal — equals
+          [config.entry_dollars]. Carried on the record so downstream readers
+          can verify sizing was uniform. *)
+  shares : float;
+      (** [entry_dollars /. entry_price]. Float (no rounding) — these are
+          diagnostic positions, not real fills. *)
+  pnl_dollars : float;
+      (** [(exit_price -. entry_price) *. shares] for longs; mirrored for
+          shorts. Equivalently [entry_dollars *. return_pct]. *)
+  cascade_score : int;
+      (** Cascade score the live screener would have assigned at
+          [signal_date]. Recorded for downstream alpha-by-score-bucket
+          analysis. *)
+  passes_macro : bool;
+      (** Whether the macro gate at [signal_date] would have admitted this
+          candidate. Records both passes and fails so consumers can split the
+          aggregate by macro regime without re-running the scan. *)
+}
+[@@deriving sexp]
+(** One row per Stage-2 entry signal. Fixed-dollar sized, naturally exited.
+
+    Schema mirrors the per-trade CSV the issue calls for:
+    [\[date, symbol, entry_close, exit_date, exit_reason, return_pct,
+    hold_days, signal_score\]] — plus [side], [entry_dollars], [shares],
+    [pnl_dollars], [passes_macro] for downstream cross-tabulation. *)
+
+type aggregate = {
+  trade_count : int;
+      (** Total number of trades — equal to the input scored-candidate count
+          (every signal is taken). *)
+  winners : int;
+      (** Count of trades with [return_pct > 0.0]. *)
+  losers : int;
+      (** Count of trades with [return_pct < 0.0]. Trades with exactly zero
+          return are counted in neither — they are flat. *)
+  win_rate_pct : float;
+      (** [winners /. trade_count] as a decimal fraction. [0.0] when
+          [trade_count = 0]. *)
+  mean_return_pct : float;
+      (** Arithmetic mean of [trade.return_pct] across all trades. [0.0] when
+          [trade_count = 0]. *)
+  median_return_pct : float;
+      (** Median of [trade.return_pct] across all trades. For an even count,
+          the average of the two middle values. [0.0] when [trade_count = 0].
+      *)
+  total_pnl_dollars : float;
+      (** Sum of [trade.pnl_dollars] across all trades. Equal to
+          [config.entry_dollars *. sum(return_pct)] — the alpha is additive
+          when sizing is uniform. *)
+  return_buckets : (float * float * int) list;
+      (** Per-bucket counts: [(low, high, count)] tuples in the bucket order
+          implied by [config.return_buckets]. The first bucket has
+          [low = neg_infinity], the last bucket has [high = infinity]. *)
+}
+[@@deriving sexp]
+(** Aggregate stats over [result.trades]. [trade_count = winners + losers +
+    flat-trades]; flat trades are those with exactly [return_pct = 0.0]. *)
+
+type result = { trades : trade_record list; aggregate : aggregate }
+[@@deriving sexp]
+(** Diagnostic output. [trades] is in the same order as the input scored
+    candidates — no re-sorting. *)
+
+val grade :
+  config:config -> scored:Optimal_types.scored_candidate list -> result
+(** [grade ~config ~scored] projects each scored candidate into a
+    {!trade_record} using [config.entry_dollars] for sizing, computes the
+    {!aggregate}, and returns both as a {!result}.
+
+    Trade order matches [scored] order — no resorting. Empty input yields a
+    result with [trade_count = 0] and zeroed metrics (no exception).
+
+    Pure function. *)
+
+val build_trade_record :
+  config:config -> Optimal_types.scored_candidate -> trade_record
+(** [build_trade_record ~config sc] is the per-candidate projection helper.
+    Exposed for unit-testing the per-trade arithmetic in isolation; the
+    aggregator at {!grade} uses it internally. *)
+
+val compute_aggregate : config:config -> trade_record list -> aggregate
+(** [compute_aggregate ~config trades] computes the {!aggregate} stats over
+    [trades]. Exposed for unit-testing the aggregation in isolation; {!grade}
+    uses it internally.
+
+    Uses [config.return_buckets] for the histogram boundaries. *)

--- a/trading/trading/backtest/all_eligible/lib/all_eligible.mli
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible.mli
@@ -3,46 +3,44 @@
     For every Stage-2 entry signal that fires across a backtest period,
     allocates a fixed dollar amount (default $10K) per signal, bypasses every
     portfolio-level rejection (no cash floor, no exposure cap, no sector
-    concentration), tracks each position independently to its natural exit,
-    and emits per-trade alpha plus aggregate stats.
+    concentration), tracks each position independently to its natural exit, and
+    emits per-trade alpha plus aggregate stats.
 
     {1 What this measures}
 
     Raw signal alpha — what each Stage-2 breakout signal would have returned if
-    we'd taken every one. Separates {b signal quality} from {b portfolio
-    mechanism}:
+    we'd taken every one. Separates {b signal quality} from
+    {b portfolio mechanism}:
 
     - High signal alpha + many portfolio rejections in the actual run →
       portfolio surface needs loosening.
     - Low signal alpha + few rejections → screener cascade needs tightening.
-    - High alpha + few rejections + low actual return → optimal-strategy
-      picking gap (orderings differ from realised outcome).
+    - High alpha + few rejections + low actual return → optimal-strategy picking
+      gap (orderings differ from realised outcome).
 
     {1 Pipeline}
 
     The diagnostic operates on the same {b scored candidates} the
     {!Backtest_optimal} track produces:
 
-    1. Scan: {!Stage_transition_scanner.scan_panel} enumerates one candidate
-       per (symbol, week) where the system's structural breakout predicate
-       fires — drops cascade gates (top-N, grade, macro), keeps the
-       per-candidate breakout predicate + price helpers. Macro pass is
-       recorded on each candidate, not gated.
-    2. Score: {!Outcome_scorer.score} forward-walks the panel applying the
-       trailing-stop walker + Stage-3 detector and emits the realised exit
-       week / price / R-multiple per candidate.
-    3. {b Grade} (this module): every scored candidate becomes one
-       {!trade_record} sized at [config.entry_dollars / entry_price] shares
-       — no portfolio-level interaction, no cash gate, no sector cap. Aggregate
-       stats roll up across all trades.
+    1. Scan: {!Stage_transition_scanner.scan_panel} enumerates one candidate per
+    (symbol, week) where the system's structural breakout predicate fires —
+    drops cascade gates (top-N, grade, macro), keeps the per-candidate breakout
+    predicate + price helpers. Macro pass is recorded on each candidate, not
+    gated. 2. Score: {!Outcome_scorer.score} forward-walks the panel applying
+    the trailing-stop walker + Stage-3 detector and emits the realised exit week
+    / price / R-multiple per candidate. 3. {b Grade} (this module): every scored
+    candidate becomes one {!trade_record} sized at
+    [config.entry_dollars / entry_price] shares — no portfolio-level
+    interaction, no cash gate, no sector cap. Aggregate stats roll up across all
+    trades.
 
     {1 Reuse, not duplication}
 
-    The entry/exit semantics are the same byte-for-byte as the
-    optimal-strategy track (calls the same pure functions). The only
-    difference is portfolio interaction: optimal-strategy's
-    {!Optimal_portfolio_filler} resolves cash + sector + sizing; the
-    all-eligible grader skips that entirely.
+    The entry/exit semantics are the same byte-for-byte as the optimal-strategy
+    track (calls the same pure functions). The only difference is portfolio
+    interaction: optimal-strategy's {!Optimal_portfolio_filler} resolves cash +
+    sector + sizing; the all-eligible grader skips that entirely.
 
     {1 Purity}
 
@@ -61,20 +59,20 @@ type config = {
           since these are diagnostic positions, not real fills. *)
   return_buckets : float list;
       (** Bucket boundaries (as decimal fractions, e.g.
-          [\[-0.5; -0.2; 0.0; 0.2; 0.5; 1.0\]]) for the per-trade return
+          [[-0.5; -0.2; 0.0; 0.2; 0.5; 1.0]]) for the per-trade return
           distribution histogram. The buckets are half-open intervals:
           [(-inf, b0)], [\[b0, b1)], ..., [\[bn, +inf)]. Default:
-          [\[-0.5; -0.2; 0.0; 0.2; 0.5; 1.0\]] — yields seven buckets:
-          [<-50%], [-50..-20%], [-20..0%], [0..20%], [20..50%], [50..100%],
-          [>100%]. *)
+          [[-0.5; -0.2; 0.0; 0.2; 0.5; 1.0]] — yields seven buckets: [<-50%],
+          [-50..-20%], [-20..0%], [0..20%], [20..50%], [50..100%], [>100%]. *)
 }
 [@@deriving sexp]
-(** Diagnostic configuration. Both knobs configurable per
-    {!default_config} — no magic numbers in the implementation. *)
+(** Diagnostic configuration. Both knobs configurable per {!default_config} — no
+    magic numbers in the implementation. *)
 
 val default_config : config
-(** [default_config] = [{ entry_dollars = 10_000.0; return_buckets = \[-0.5;
-    -0.2; 0.0; 0.2; 0.5; 1.0\] }]. *)
+(** [default_config] =
+    [{ entry_dollars = 10_000.0; return_buckets = [-0.5; -0.2; 0.0; 0.2; 0.5;
+     1.0] }]. *)
 
 type trade_record = {
   signal_date : Date.t;
@@ -83,23 +81,23 @@ type trade_record = {
   symbol : string;
   side : Trading_base.Types.position_side;
       (** [Long] for Stage 1→2 breakouts, [Short] for Stage 3→4 breakdowns.
-          (PR-1 only sees [Long] candidates because
-          {!Stage_transition_scanner} only emits longs today; the field is
-          carried for forward-compatibility with the short-side scanner.) *)
+          (PR-1 only sees [Long] candidates because {!Stage_transition_scanner}
+          only emits longs today; the field is carried for forward-compatibility
+          with the short-side scanner.) *)
   entry_price : float;
       (** Counterfactual entry price — the breakout-week close. Same source as
           [scored_candidate.entry.entry_price]. *)
   exit_date : Date.t;
-      (** Friday on which the position closed under the natural exit rule
-          (stop hit, Stage-3 transition confirmed, or end of run). *)
+      (** Friday on which the position closed under the natural exit rule (stop
+          hit, Stage-3 transition confirmed, or end of run). *)
   exit_reason : Backtest_optimal.Optimal_types.exit_trigger;
       (** Which natural exit fired. Same
           {!Backtest_optimal.Optimal_types.exit_trigger} variants as the
           optimal-strategy track. *)
   return_pct : float;
       (** Per-trade return as a decimal fraction. For longs:
-          [(exit_price -. entry_price) /. entry_price]. For shorts: the
-          mirrored expression. Sign carries the direction. *)
+          [(exit_price -. entry_price) /. entry_price]. For shorts: the mirrored
+          expression. Sign carries the direction. *)
   hold_days : int;
       (** Calendar-day difference [exit_date - signal_date]. Day-granularity
           (not week-rounded) to give the histogram more resolution than
@@ -115,9 +113,8 @@ type trade_record = {
       (** [(exit_price -. entry_price) *. shares] for longs; mirrored for
           shorts. Equivalently [entry_dollars *. return_pct]. *)
   cascade_score : int;
-      (** Cascade score the live screener would have assigned at
-          [signal_date]. Recorded for downstream alpha-by-score-bucket
-          analysis. *)
+      (** Cascade score the live screener would have assigned at [signal_date].
+          Recorded for downstream alpha-by-score-bucket analysis. *)
   passes_macro : bool;
       (** Whether the macro gate at [signal_date] would have admitted this
           candidate. Records both passes and fails so consumers can split the
@@ -127,16 +124,15 @@ type trade_record = {
 (** One row per Stage-2 entry signal. Fixed-dollar sized, naturally exited.
 
     Schema mirrors the per-trade CSV the issue calls for:
-    [\[date, symbol, entry_close, exit_date, exit_reason, return_pct,
-    hold_days, signal_score\]] — plus [side], [entry_dollars], [shares],
-    [pnl_dollars], [passes_macro] for downstream cross-tabulation. *)
+    [[date, symbol, entry_close, exit_date, exit_reason, return_pct, hold_days,
+     signal_score]] — plus [side], [entry_dollars], [shares], [pnl_dollars],
+    [passes_macro] for downstream cross-tabulation. *)
 
 type aggregate = {
   trade_count : int;
       (** Total number of trades — equal to the input scored-candidate count
           (every signal is taken). *)
-  winners : int;
-      (** Count of trades with [return_pct > 0.0]. *)
+  winners : int;  (** Count of trades with [return_pct > 0.0]. *)
   losers : int;
       (** Count of trades with [return_pct < 0.0]. Trades with exactly zero
           return are counted in neither — they are flat. *)
@@ -147,21 +143,21 @@ type aggregate = {
       (** Arithmetic mean of [trade.return_pct] across all trades. [0.0] when
           [trade_count = 0]. *)
   median_return_pct : float;
-      (** Median of [trade.return_pct] across all trades. For an even count,
-          the average of the two middle values. [0.0] when [trade_count = 0].
-      *)
+      (** Median of [trade.return_pct] across all trades. For an even count, the
+          average of the two middle values. [0.0] when [trade_count = 0]. *)
   total_pnl_dollars : float;
       (** Sum of [trade.pnl_dollars] across all trades. Equal to
-          [config.entry_dollars *. sum(return_pct)] — the alpha is additive
-          when sizing is uniform. *)
+          [config.entry_dollars *. sum(return_pct)] — the alpha is additive when
+          sizing is uniform. *)
   return_buckets : (float * float * int) list;
       (** Per-bucket counts: [(low, high, count)] tuples in the bucket order
           implied by [config.return_buckets]. The first bucket has
           [low = neg_infinity], the last bucket has [high = infinity]. *)
 }
 [@@deriving sexp]
-(** Aggregate stats over [result.trades]. [trade_count = winners + losers +
-    flat-trades]; flat trades are those with exactly [return_pct = 0.0]. *)
+(** Aggregate stats over [result.trades].
+    [trade_count = winners + losers + flat-trades]; flat trades are those with
+    exactly [return_pct = 0.0]. *)
 
 type result = { trades : trade_record list; aggregate : aggregate }
 [@@deriving sexp]

--- a/trading/trading/backtest/all_eligible/lib/all_eligible.mli
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible.mli
@@ -92,9 +92,10 @@ type trade_record = {
   exit_date : Date.t;
       (** Friday on which the position closed under the natural exit rule
           (stop hit, Stage-3 transition confirmed, or end of run). *)
-  exit_reason : Optimal_types.exit_trigger;
-      (** Which natural exit fired. Same {!Optimal_types.exit_trigger}
-          variants as the optimal-strategy track. *)
+  exit_reason : Backtest_optimal.Optimal_types.exit_trigger;
+      (** Which natural exit fired. Same
+          {!Backtest_optimal.Optimal_types.exit_trigger} variants as the
+          optimal-strategy track. *)
   return_pct : float;
       (** Per-trade return as a decimal fraction. For longs:
           [(exit_price -. entry_price) /. entry_price]. For shorts: the
@@ -168,7 +169,9 @@ type result = { trades : trade_record list; aggregate : aggregate }
     candidates — no re-sorting. *)
 
 val grade :
-  config:config -> scored:Optimal_types.scored_candidate list -> result
+  config:config ->
+  scored:Backtest_optimal.Optimal_types.scored_candidate list ->
+  result
 (** [grade ~config ~scored] projects each scored candidate into a
     {!trade_record} using [config.entry_dollars] for sizing, computes the
     {!aggregate}, and returns both as a {!result}.
@@ -179,7 +182,9 @@ val grade :
     Pure function. *)
 
 val build_trade_record :
-  config:config -> Optimal_types.scored_candidate -> trade_record
+  config:config ->
+  Backtest_optimal.Optimal_types.scored_candidate ->
+  trade_record
 (** [build_trade_record ~config sc] is the per-candidate projection helper.
     Exposed for unit-testing the per-trade arithmetic in isolation; the
     aggregator at {!grade} uses it internally. *)

--- a/trading/trading/backtest/all_eligible/lib/dune
+++ b/trading/trading/backtest/all_eligible/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name backtest_all_eligible)
+ (libraries core trading.base backtest_optimal)
+ (preprocess
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/all_eligible/test/dune
+++ b/trading/trading/backtest/all_eligible/test/dune
@@ -1,0 +1,11 @@
+(tests
+ (names test_all_eligible)
+ (libraries
+  ounit2
+  core
+  matchers
+  trading.base
+  backtest_optimal
+  backtest_all_eligible)
+ (preprocess
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.eq ppx_test_matcher)))

--- a/trading/trading/backtest/all_eligible/test/test_all_eligible.ml
+++ b/trading/trading/backtest/all_eligible/test/test_all_eligible.ml
@@ -49,10 +49,10 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     passes_macro;
   }
 
-(** Build a synthetic [scored_candidate] from explicit per-trade outcome
-    fields. Mirrors [Outcome_scorer._build_scored] arithmetic for [Long]
-    side: callers provide [entry_price], [suggested_stop], [exit_price],
-    [exit_week] and the helper computes the dependent fields. *)
+(** Build a synthetic [scored_candidate] from explicit per-trade outcome fields.
+    Mirrors [Outcome_scorer._build_scored] arithmetic for [Long] side: callers
+    provide [entry_price], [suggested_stop], [exit_price], [exit_week] and the
+    helper computes the dependent fields. *)
 let make_scored ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     ?(side = Trading_base.Types.Long) ?(entry_price = 100.0)
     ?(suggested_stop = 92.0) ?(cascade_score = 50) ?(passes_macro = true)
@@ -190,9 +190,8 @@ let test_three_signals_all_taken_no_cash_gate _ =
         ~entry_price:50.0 ~suggested_stop:46.0 ~exit_week:(_date "2024-02-02")
         ~exit_price:45.0 ~exit_trigger:OT.Stop_hit ();
       make_scored ~symbol:"CCC" ~entry_week:(_date "2024-01-26")
-        ~entry_price:200.0 ~suggested_stop:184.0
-        ~exit_week:(_date "2024-03-01") ~exit_price:230.0
-        ~exit_trigger:OT.Stage3_transition ();
+        ~entry_price:200.0 ~suggested_stop:184.0 ~exit_week:(_date "2024-03-01")
+        ~exit_price:230.0 ~exit_trigger:OT.Stage3_transition ();
     ]
   in
   let result = AE.grade ~config:AE.default_config ~scored in
@@ -202,7 +201,9 @@ let test_three_signals_all_taken_no_cash_gate _ =
          all_of
            [
              field (fun (t : AE.trade_record) -> t.symbol) (equal_to "AAA");
-             field (fun (t : AE.trade_record) -> t.return_pct) (float_equal 0.20);
+             field
+               (fun (t : AE.trade_record) -> t.return_pct)
+               (float_equal 0.20);
              field
                (fun (t : AE.trade_record) -> t.exit_reason)
                (equal_to OT.End_of_run);
@@ -226,7 +227,9 @@ let test_three_signals_all_taken_no_cash_gate _ =
          all_of
            [
              field (fun (t : AE.trade_record) -> t.symbol) (equal_to "CCC");
-             field (fun (t : AE.trade_record) -> t.return_pct) (float_equal 0.15);
+             field
+               (fun (t : AE.trade_record) -> t.return_pct)
+               (float_equal 0.15);
              field
                (fun (t : AE.trade_record) -> t.exit_reason)
                (equal_to OT.Stage3_transition);
@@ -348,9 +351,7 @@ let test_flat_trade_neither_winner_nor_loser _ =
          field (fun (a : AE.aggregate) -> a.winners) (equal_to 0);
          field (fun (a : AE.aggregate) -> a.losers) (equal_to 0);
          field (fun (a : AE.aggregate) -> a.win_rate_pct) (float_equal 0.0);
-         field
-           (fun (a : AE.aggregate) -> a.total_pnl_dollars)
-           (float_equal 0.0);
+         field (fun (a : AE.aggregate) -> a.total_pnl_dollars) (float_equal 0.0);
        ])
 
 let test_return_buckets_default _ =
@@ -444,9 +445,7 @@ let test_passes_macro_carried_through _ =
          all_of
            [
              field (fun (t : AE.trade_record) -> t.symbol) (equal_to "BULL");
-             field
-               (fun (t : AE.trade_record) -> t.passes_macro)
-               (equal_to true);
+             field (fun (t : AE.trade_record) -> t.passes_macro) (equal_to true);
            ];
          all_of
            [

--- a/trading/trading/backtest/all_eligible/test/test_all_eligible.ml
+++ b/trading/trading/backtest/all_eligible/test/test_all_eligible.ml
@@ -1,0 +1,435 @@
+(** Unit tests for [Backtest_all_eligible.All_eligible].
+
+    Covers, per the issue #870 acceptance criteria + plan §Acceptance criteria:
+    - Three Stage-2 signals fire in a synthetic minimal scenario; verify all
+      three are taken (no cash gate).
+    - Per-trade exit reasons + return values match independent hand-calc.
+    - Aggregate alpha matches sum of per-trade alphas.
+
+    Plus edge cases:
+    - Empty input yields zeroed aggregate (no exception).
+    - Per-trade arithmetic pin (entry/shares/pnl wiring).
+    - Median for both odd and even trade counts.
+    - Bucket histogram exactness.
+    - Win/loss/flat split exactness.
+
+    All tests follow the [.claude/rules/test-patterns.md] discipline: one
+    [assert_that] per value, no nested asserts inside callbacks, [field] /
+    [all_of] / [elements_are] for composition. *)
+
+open OUnit2
+open Core
+open Matchers
+module AE = Backtest_all_eligible.All_eligible
+module OT = Backtest_optimal.Optimal_types
+
+(* ------------------------------------------------------------------ *)
+(* Builders                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let _date d = Date.of_string d
+
+(** Build a synthetic [candidate_entry]. Optional parameters let each test
+    override only the fields it cares about. *)
+let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
+    ?(side = Trading_base.Types.Long) ?(entry_price = 100.0)
+    ?(suggested_stop = 92.0) ?(risk_pct = 0.08)
+    ?(sector = "Information Technology") ?(cascade_grade = Weinstein_types.B)
+    ?(cascade_score = 50) ?(passes_macro = true) () : OT.candidate_entry =
+  {
+    symbol;
+    entry_week;
+    side;
+    entry_price;
+    suggested_stop;
+    risk_pct;
+    sector;
+    cascade_grade;
+    cascade_score;
+    passes_macro;
+  }
+
+(** Build a synthetic [scored_candidate] from explicit per-trade outcome
+    fields. Mirrors [Outcome_scorer._build_scored] arithmetic for [Long]
+    side: callers provide [entry_price], [suggested_stop], [exit_price],
+    [exit_week] and the helper computes the dependent fields. *)
+let make_scored ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
+    ?(side = Trading_base.Types.Long) ?(entry_price = 100.0)
+    ?(suggested_stop = 92.0) ?(cascade_score = 50) ?(passes_macro = true)
+    ~exit_week ~exit_price ~(exit_trigger : OT.exit_trigger) () :
+    OT.scored_candidate =
+  let candidate =
+    make_candidate ~symbol ~entry_week ~side ~entry_price ~suggested_stop
+      ~cascade_score ~passes_macro ()
+  in
+  let raw_return_pct =
+    match side with
+    | Trading_base.Types.Long -> (exit_price -. entry_price) /. entry_price
+    | Short -> (entry_price -. exit_price) /. entry_price
+  in
+  let hold_weeks = Date.diff exit_week entry_week / 7 in
+  let initial_risk_per_share = Float.abs (entry_price -. suggested_stop) in
+  let r_multiple =
+    if Float.( <= ) initial_risk_per_share 0.0 then 0.0
+    else
+      let signed_pnl =
+        match side with
+        | Long -> exit_price -. entry_price
+        | Short -> entry_price -. exit_price
+      in
+      signed_pnl /. initial_risk_per_share
+  in
+  {
+    entry = candidate;
+    exit_week;
+    exit_price;
+    exit_trigger;
+    raw_return_pct;
+    hold_weeks;
+    initial_risk_per_share;
+    r_multiple;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* Per-trade arithmetic                                                 *)
+(* ------------------------------------------------------------------ *)
+
+let test_build_trade_record_long _ =
+  (* Pin the per-trade arithmetic for a long that gains 30%:
+     entry=100, exit=130, $10K size → 100 shares → $3000 pnl. *)
+  let scored =
+    make_scored ~symbol:"AAPL" ~entry_week:(_date "2024-01-19")
+      ~entry_price:100.0 ~suggested_stop:92.0 ~exit_week:(_date "2024-02-09")
+      ~exit_price:130.0 ~exit_trigger:OT.End_of_run ()
+  in
+  let trade = AE.build_trade_record ~config:AE.default_config scored in
+  assert_that trade
+    (all_of
+       [
+         field (fun (t : AE.trade_record) -> t.symbol) (equal_to "AAPL");
+         field (fun t -> t.signal_date) (equal_to (_date "2024-01-19"));
+         field (fun t -> t.exit_date) (equal_to (_date "2024-02-09"));
+         field (fun t -> t.entry_price) (float_equal 100.0);
+         field (fun t -> t.return_pct) (float_equal 0.30);
+         field (fun t -> t.hold_days) (equal_to 21);
+         field (fun t -> t.entry_dollars) (float_equal 10_000.0);
+         field (fun t -> t.shares) (float_equal 100.0);
+         field (fun t -> t.pnl_dollars) (float_equal 3000.0);
+         field (fun t -> t.exit_reason) (equal_to OT.End_of_run);
+         field (fun t -> t.cascade_score) (equal_to 50);
+       ])
+
+let test_build_trade_record_short _ =
+  (* Short side: entry=100, exit=80, profit. With $10K size → 100 shares,
+     pnl_dollars = (100-80) * 100 = +2000. return_pct = (100-80)/100 = +0.20. *)
+  let scored =
+    make_scored ~symbol:"BBB" ~side:Trading_base.Types.Short ~entry_price:100.0
+      ~suggested_stop:108.0 ~exit_week:(_date "2024-02-02") ~exit_price:80.0
+      ~exit_trigger:OT.Stop_hit ()
+  in
+  let trade = AE.build_trade_record ~config:AE.default_config scored in
+  assert_that trade
+    (all_of
+       [
+         field (fun (t : AE.trade_record) -> t.side)
+           (equal_to Trading_base.Types.Short);
+         field (fun t -> t.return_pct) (float_equal 0.20);
+         field (fun t -> t.pnl_dollars) (float_equal 2000.0);
+         field (fun t -> t.exit_reason) (equal_to OT.Stop_hit);
+       ])
+
+let test_custom_entry_dollars _ =
+  (* With entry_dollars=50_000 and entry_price=200, shares = 250.
+     Exit at 220 → pnl = 20 * 250 = 5000, return = 0.10. *)
+  let scored =
+    make_scored ~entry_price:200.0 ~suggested_stop:184.0
+      ~exit_week:(_date "2024-01-26") ~exit_price:220.0
+      ~exit_trigger:OT.End_of_run ()
+  in
+  let cfg = { AE.default_config with entry_dollars = 50_000.0 } in
+  let trade = AE.build_trade_record ~config:cfg scored in
+  assert_that trade
+    (all_of
+       [
+         field (fun (t : AE.trade_record) -> t.shares) (float_equal 250.0);
+         field (fun t -> t.pnl_dollars) (float_equal 5000.0);
+         field (fun t -> t.return_pct) (float_equal 0.10);
+         field (fun t -> t.entry_dollars) (float_equal 50_000.0);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* All-three-signals scenario (the headline acceptance test)            *)
+(* ------------------------------------------------------------------ *)
+
+let test_three_signals_all_taken_no_cash_gate _ =
+  (* Three Stage-2 entries with distinct outcomes — all three appear in the
+     output regardless of cash availability.
+
+     Total $30K of "exposure" with no portfolio cash gate; in a real run,
+     the second signal would have been rejected for Insufficient_cash with
+     $20K starting cash. Here the diagnostic takes all three. *)
+  let scored =
+    [
+      make_scored ~symbol:"AAA" ~entry_week:(_date "2024-01-19")
+        ~entry_price:100.0 ~suggested_stop:92.0 ~exit_week:(_date "2024-02-09")
+        ~exit_price:120.0 ~exit_trigger:OT.End_of_run ();
+      make_scored ~symbol:"BBB" ~entry_week:(_date "2024-01-19")
+        ~entry_price:50.0 ~suggested_stop:46.0 ~exit_week:(_date "2024-02-02")
+        ~exit_price:45.0 ~exit_trigger:OT.Stop_hit ();
+      make_scored ~symbol:"CCC" ~entry_week:(_date "2024-01-26")
+        ~entry_price:200.0 ~suggested_stop:184.0
+        ~exit_week:(_date "2024-03-01") ~exit_price:230.0
+        ~exit_trigger:OT.Stage3_transition ();
+    ]
+  in
+  let result = AE.grade ~config:AE.default_config ~scored in
+  assert_that result.trades
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (t : AE.trade_record) -> t.symbol) (equal_to "AAA");
+             field (fun t -> t.return_pct) (float_equal 0.20);
+             field (fun t -> t.exit_reason) (equal_to OT.End_of_run);
+             field (fun t -> t.pnl_dollars) (float_equal 2000.0);
+           ];
+         all_of
+           [
+             field (fun (t : AE.trade_record) -> t.symbol) (equal_to "BBB");
+             field (fun t -> t.return_pct) (float_equal (-0.10));
+             field (fun t -> t.exit_reason) (equal_to OT.Stop_hit);
+             field (fun t -> t.pnl_dollars) (float_equal (-1000.0));
+           ];
+         all_of
+           [
+             field (fun (t : AE.trade_record) -> t.symbol) (equal_to "CCC");
+             field (fun t -> t.return_pct) (float_equal 0.15);
+             field (fun t -> t.exit_reason) (equal_to OT.Stage3_transition);
+             field (fun t -> t.pnl_dollars) (float_equal 1500.0);
+           ];
+       ])
+
+let test_three_signals_aggregate_matches_sum _ =
+  (* Same three signals as above; assert aggregate metrics match independent
+     hand-calc — alpha additivity is the key invariant. *)
+  let scored =
+    [
+      make_scored ~symbol:"AAA" ~entry_price:100.0 ~suggested_stop:92.0
+        ~exit_week:(_date "2024-02-09") ~exit_price:120.0
+        ~exit_trigger:OT.End_of_run ();
+      make_scored ~symbol:"BBB" ~entry_price:50.0 ~suggested_stop:46.0
+        ~exit_week:(_date "2024-02-02") ~exit_price:45.0
+        ~exit_trigger:OT.Stop_hit ();
+      make_scored ~symbol:"CCC" ~entry_price:200.0 ~suggested_stop:184.0
+        ~exit_week:(_date "2024-03-01") ~exit_price:230.0
+        ~exit_trigger:OT.Stage3_transition ();
+    ]
+  in
+  let result = AE.grade ~config:AE.default_config ~scored in
+  (* Returns: 0.20, -0.10, 0.15. Sorted: -0.10, 0.15, 0.20. Median = 0.15.
+     Mean = (0.20 - 0.10 + 0.15) / 3 = 0.0833... .
+     Total pnl = 2000 - 1000 + 1500 = 2500. *)
+  assert_that result.aggregate
+    (all_of
+       [
+         field (fun (a : AE.aggregate) -> a.trade_count) (equal_to 3);
+         field (fun a -> a.winners) (equal_to 2);
+         field (fun a -> a.losers) (equal_to 1);
+         field (fun a -> a.win_rate_pct)
+           (float_equal ~epsilon:1e-9 (2.0 /. 3.0));
+         field (fun a -> a.mean_return_pct)
+           (float_equal ~epsilon:1e-9 (0.25 /. 3.0));
+         field (fun a -> a.median_return_pct) (float_equal 0.15);
+         field (fun a -> a.total_pnl_dollars) (float_equal 2500.0);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Edge cases                                                           *)
+(* ------------------------------------------------------------------ *)
+
+let test_empty_scored_input _ =
+  let result = AE.grade ~config:AE.default_config ~scored:[] in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : AE.result) -> r.trades) is_empty;
+         field
+           (fun r -> r.aggregate)
+           (all_of
+              [
+                field (fun (a : AE.aggregate) -> a.trade_count) (equal_to 0);
+                field (fun a -> a.winners) (equal_to 0);
+                field (fun a -> a.losers) (equal_to 0);
+                field (fun a -> a.win_rate_pct) (float_equal 0.0);
+                field (fun a -> a.mean_return_pct) (float_equal 0.0);
+                field (fun a -> a.median_return_pct) (float_equal 0.0);
+                field (fun a -> a.total_pnl_dollars) (float_equal 0.0);
+              ]);
+       ])
+
+let test_median_even_count _ =
+  (* Four trades with returns 0.10, 0.20, 0.30, 0.40 → median = (0.20 + 0.30) / 2 = 0.25. *)
+  let returns = [ 0.10; 0.20; 0.30; 0.40 ] in
+  let trades =
+    List.map returns ~f:(fun r ->
+        let exit_price = 100.0 *. (1.0 +. r) in
+        let scored =
+          make_scored ~entry_price:100.0 ~suggested_stop:90.0
+            ~exit_week:(_date "2024-02-09") ~exit_price
+            ~exit_trigger:OT.End_of_run ()
+        in
+        AE.build_trade_record ~config:AE.default_config scored)
+  in
+  let agg = AE.compute_aggregate ~config:AE.default_config trades in
+  assert_that agg
+    (all_of
+       [
+         field (fun (a : AE.aggregate) -> a.trade_count) (equal_to 4);
+         field (fun a -> a.median_return_pct) (float_equal 0.25);
+       ])
+
+let test_flat_trade_neither_winner_nor_loser _ =
+  (* Trade with return_pct = 0.0 is neither a winner nor a loser. *)
+  let scored =
+    [
+      make_scored ~symbol:"FLAT" ~entry_price:100.0 ~suggested_stop:92.0
+        ~exit_week:(_date "2024-01-26") ~exit_price:100.0
+        ~exit_trigger:OT.End_of_run ();
+    ]
+  in
+  let result = AE.grade ~config:AE.default_config ~scored in
+  assert_that result.aggregate
+    (all_of
+       [
+         field (fun (a : AE.aggregate) -> a.trade_count) (equal_to 1);
+         field (fun a -> a.winners) (equal_to 0);
+         field (fun a -> a.losers) (equal_to 0);
+         field (fun a -> a.win_rate_pct) (float_equal 0.0);
+         field (fun a -> a.total_pnl_dollars) (float_equal 0.0);
+       ])
+
+let test_return_buckets_default _ =
+  (* Returns: -0.60, -0.30, -0.05, +0.10, +0.35, +0.75, +1.50.
+     Default boundaries: [-0.5; -0.2; 0.0; 0.2; 0.5; 1.0].
+     Buckets:
+       (-inf, -0.5)  → -0.60                                   1
+       [-0.5, -0.2)  → -0.30                                   1
+       [-0.2,  0.0)  → -0.05                                   1
+       [ 0.0,  0.2)  → +0.10                                   1
+       [ 0.2,  0.5)  → +0.35                                   1
+       [ 0.5,  1.0)  → +0.75                                   1
+       [ 1.0,  inf)  → +1.50                                   1 *)
+  let returns = [ -0.60; -0.30; -0.05; 0.10; 0.35; 0.75; 1.50 ] in
+  let trades =
+    List.map returns ~f:(fun r ->
+        let exit_price = 100.0 *. (1.0 +. r) in
+        let scored =
+          make_scored ~entry_price:100.0 ~suggested_stop:90.0
+            ~exit_week:(_date "2024-02-09") ~exit_price
+            ~exit_trigger:OT.End_of_run ()
+        in
+        AE.build_trade_record ~config:AE.default_config scored)
+  in
+  let agg = AE.compute_aggregate ~config:AE.default_config trades in
+  assert_that agg.return_buckets
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (_, _, c) -> c) (equal_to 1);
+             field (fun (low, _, _) -> low) (float_equal Float.neg_infinity);
+             field (fun (_, high, _) -> high) (float_equal (-0.5));
+           ];
+         all_of
+           [
+             field (fun (_, _, c) -> c) (equal_to 1);
+             field (fun (low, _, _) -> low) (float_equal (-0.5));
+             field (fun (_, high, _) -> high) (float_equal (-0.2));
+           ];
+         all_of
+           [
+             field (fun (_, _, c) -> c) (equal_to 1);
+             field (fun (low, _, _) -> low) (float_equal (-0.2));
+             field (fun (_, high, _) -> high) (float_equal 0.0);
+           ];
+         all_of
+           [
+             field (fun (_, _, c) -> c) (equal_to 1);
+             field (fun (low, _, _) -> low) (float_equal 0.0);
+             field (fun (_, high, _) -> high) (float_equal 0.2);
+           ];
+         all_of
+           [
+             field (fun (_, _, c) -> c) (equal_to 1);
+             field (fun (low, _, _) -> low) (float_equal 0.2);
+             field (fun (_, high, _) -> high) (float_equal 0.5);
+           ];
+         all_of
+           [
+             field (fun (_, _, c) -> c) (equal_to 1);
+             field (fun (low, _, _) -> low) (float_equal 0.5);
+             field (fun (_, high, _) -> high) (float_equal 1.0);
+           ];
+         all_of
+           [
+             field (fun (_, _, c) -> c) (equal_to 1);
+             field (fun (low, _, _) -> low) (float_equal 1.0);
+             field (fun (_, high, _) -> high) (float_equal Float.infinity);
+           ];
+       ])
+
+let test_passes_macro_carried_through _ =
+  (* The macro pass flag on the candidate is preserved on the trade record
+     so consumers can split aggregates by macro regime without re-running
+     the scan. *)
+  let scored =
+    [
+      make_scored ~symbol:"BULL" ~entry_price:100.0 ~suggested_stop:92.0
+        ~passes_macro:true ~exit_week:(_date "2024-02-09") ~exit_price:110.0
+        ~exit_trigger:OT.End_of_run ();
+      make_scored ~symbol:"BEAR" ~entry_price:100.0 ~suggested_stop:92.0
+        ~passes_macro:false ~exit_week:(_date "2024-02-09") ~exit_price:90.0
+        ~exit_trigger:OT.Stop_hit ();
+    ]
+  in
+  let result = AE.grade ~config:AE.default_config ~scored in
+  assert_that result.trades
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (t : AE.trade_record) -> t.symbol) (equal_to "BULL");
+             field (fun t -> t.passes_macro) (equal_to true);
+           ];
+         all_of
+           [
+             field (fun (t : AE.trade_record) -> t.symbol) (equal_to "BEAR");
+             field (fun t -> t.passes_macro) (equal_to false);
+           ];
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Test suite                                                          *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "All_eligible"
+  >::: [
+         "build_trade_record long arithmetic" >:: test_build_trade_record_long;
+         "build_trade_record short arithmetic" >:: test_build_trade_record_short;
+         "custom entry_dollars sizes shares + pnl" >:: test_custom_entry_dollars;
+         "three signals — all taken regardless of cash"
+         >:: test_three_signals_all_taken_no_cash_gate;
+         "three signals — aggregate matches sum"
+         >:: test_three_signals_aggregate_matches_sum;
+         "empty scored input → zeroed aggregate" >:: test_empty_scored_input;
+         "median for even trade count averages middles"
+         >:: test_median_even_count;
+         "flat trade is neither winner nor loser"
+         >:: test_flat_trade_neither_winner_nor_loser;
+         "return buckets count exactly" >:: test_return_buckets_default;
+         "passes_macro carried through to trade record"
+         >:: test_passes_macro_carried_through;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/all_eligible/test/test_all_eligible.ml
+++ b/trading/trading/backtest/all_eligible/test/test_all_eligible.ml
@@ -107,16 +107,24 @@ let test_build_trade_record_long _ =
     (all_of
        [
          field (fun (t : AE.trade_record) -> t.symbol) (equal_to "AAPL");
-         field (fun t -> t.signal_date) (equal_to (_date "2024-01-19"));
-         field (fun t -> t.exit_date) (equal_to (_date "2024-02-09"));
-         field (fun t -> t.entry_price) (float_equal 100.0);
-         field (fun t -> t.return_pct) (float_equal 0.30);
-         field (fun t -> t.hold_days) (equal_to 21);
-         field (fun t -> t.entry_dollars) (float_equal 10_000.0);
-         field (fun t -> t.shares) (float_equal 100.0);
-         field (fun t -> t.pnl_dollars) (float_equal 3000.0);
-         field (fun t -> t.exit_reason) (equal_to OT.End_of_run);
-         field (fun t -> t.cascade_score) (equal_to 50);
+         field
+           (fun (t : AE.trade_record) -> t.signal_date)
+           (equal_to (_date "2024-01-19"));
+         field
+           (fun (t : AE.trade_record) -> t.exit_date)
+           (equal_to (_date "2024-02-09"));
+         field (fun (t : AE.trade_record) -> t.entry_price) (float_equal 100.0);
+         field (fun (t : AE.trade_record) -> t.return_pct) (float_equal 0.30);
+         field (fun (t : AE.trade_record) -> t.hold_days) (equal_to 21);
+         field
+           (fun (t : AE.trade_record) -> t.entry_dollars)
+           (float_equal 10_000.0);
+         field (fun (t : AE.trade_record) -> t.shares) (float_equal 100.0);
+         field (fun (t : AE.trade_record) -> t.pnl_dollars) (float_equal 3000.0);
+         field
+           (fun (t : AE.trade_record) -> t.exit_reason)
+           (equal_to OT.End_of_run);
+         field (fun (t : AE.trade_record) -> t.cascade_score) (equal_to 50);
        ])
 
 let test_build_trade_record_short _ =
@@ -131,11 +139,14 @@ let test_build_trade_record_short _ =
   assert_that trade
     (all_of
        [
-         field (fun (t : AE.trade_record) -> t.side)
+         field
+           (fun (t : AE.trade_record) -> t.side)
            (equal_to Trading_base.Types.Short);
-         field (fun t -> t.return_pct) (float_equal 0.20);
-         field (fun t -> t.pnl_dollars) (float_equal 2000.0);
-         field (fun t -> t.exit_reason) (equal_to OT.Stop_hit);
+         field (fun (t : AE.trade_record) -> t.return_pct) (float_equal 0.20);
+         field (fun (t : AE.trade_record) -> t.pnl_dollars) (float_equal 2000.0);
+         field
+           (fun (t : AE.trade_record) -> t.exit_reason)
+           (equal_to OT.Stop_hit);
        ])
 
 let test_custom_entry_dollars _ =
@@ -152,9 +163,11 @@ let test_custom_entry_dollars _ =
     (all_of
        [
          field (fun (t : AE.trade_record) -> t.shares) (float_equal 250.0);
-         field (fun t -> t.pnl_dollars) (float_equal 5000.0);
-         field (fun t -> t.return_pct) (float_equal 0.10);
-         field (fun t -> t.entry_dollars) (float_equal 50_000.0);
+         field (fun (t : AE.trade_record) -> t.pnl_dollars) (float_equal 5000.0);
+         field (fun (t : AE.trade_record) -> t.return_pct) (float_equal 0.10);
+         field
+           (fun (t : AE.trade_record) -> t.entry_dollars)
+           (float_equal 50_000.0);
        ])
 
 (* ------------------------------------------------------------------ *)
@@ -189,23 +202,37 @@ let test_three_signals_all_taken_no_cash_gate _ =
          all_of
            [
              field (fun (t : AE.trade_record) -> t.symbol) (equal_to "AAA");
-             field (fun t -> t.return_pct) (float_equal 0.20);
-             field (fun t -> t.exit_reason) (equal_to OT.End_of_run);
-             field (fun t -> t.pnl_dollars) (float_equal 2000.0);
+             field (fun (t : AE.trade_record) -> t.return_pct) (float_equal 0.20);
+             field
+               (fun (t : AE.trade_record) -> t.exit_reason)
+               (equal_to OT.End_of_run);
+             field
+               (fun (t : AE.trade_record) -> t.pnl_dollars)
+               (float_equal 2000.0);
            ];
          all_of
            [
              field (fun (t : AE.trade_record) -> t.symbol) (equal_to "BBB");
-             field (fun t -> t.return_pct) (float_equal (-0.10));
-             field (fun t -> t.exit_reason) (equal_to OT.Stop_hit);
-             field (fun t -> t.pnl_dollars) (float_equal (-1000.0));
+             field
+               (fun (t : AE.trade_record) -> t.return_pct)
+               (float_equal (-0.10));
+             field
+               (fun (t : AE.trade_record) -> t.exit_reason)
+               (equal_to OT.Stop_hit);
+             field
+               (fun (t : AE.trade_record) -> t.pnl_dollars)
+               (float_equal (-1000.0));
            ];
          all_of
            [
              field (fun (t : AE.trade_record) -> t.symbol) (equal_to "CCC");
-             field (fun t -> t.return_pct) (float_equal 0.15);
-             field (fun t -> t.exit_reason) (equal_to OT.Stage3_transition);
-             field (fun t -> t.pnl_dollars) (float_equal 1500.0);
+             field (fun (t : AE.trade_record) -> t.return_pct) (float_equal 0.15);
+             field
+               (fun (t : AE.trade_record) -> t.exit_reason)
+               (equal_to OT.Stage3_transition);
+             field
+               (fun (t : AE.trade_record) -> t.pnl_dollars)
+               (float_equal 1500.0);
            ];
        ])
 
@@ -233,14 +260,20 @@ let test_three_signals_aggregate_matches_sum _ =
     (all_of
        [
          field (fun (a : AE.aggregate) -> a.trade_count) (equal_to 3);
-         field (fun a -> a.winners) (equal_to 2);
-         field (fun a -> a.losers) (equal_to 1);
-         field (fun a -> a.win_rate_pct)
+         field (fun (a : AE.aggregate) -> a.winners) (equal_to 2);
+         field (fun (a : AE.aggregate) -> a.losers) (equal_to 1);
+         field
+           (fun (a : AE.aggregate) -> a.win_rate_pct)
            (float_equal ~epsilon:1e-9 (2.0 /. 3.0));
-         field (fun a -> a.mean_return_pct)
+         field
+           (fun (a : AE.aggregate) -> a.mean_return_pct)
            (float_equal ~epsilon:1e-9 (0.25 /. 3.0));
-         field (fun a -> a.median_return_pct) (float_equal 0.15);
-         field (fun a -> a.total_pnl_dollars) (float_equal 2500.0);
+         field
+           (fun (a : AE.aggregate) -> a.median_return_pct)
+           (float_equal 0.15);
+         field
+           (fun (a : AE.aggregate) -> a.total_pnl_dollars)
+           (float_equal 2500.0);
        ])
 
 (* ------------------------------------------------------------------ *)
@@ -254,16 +287,24 @@ let test_empty_scored_input _ =
        [
          field (fun (r : AE.result) -> r.trades) is_empty;
          field
-           (fun r -> r.aggregate)
+           (fun (r : AE.result) -> r.aggregate)
            (all_of
               [
                 field (fun (a : AE.aggregate) -> a.trade_count) (equal_to 0);
-                field (fun a -> a.winners) (equal_to 0);
-                field (fun a -> a.losers) (equal_to 0);
-                field (fun a -> a.win_rate_pct) (float_equal 0.0);
-                field (fun a -> a.mean_return_pct) (float_equal 0.0);
-                field (fun a -> a.median_return_pct) (float_equal 0.0);
-                field (fun a -> a.total_pnl_dollars) (float_equal 0.0);
+                field (fun (a : AE.aggregate) -> a.winners) (equal_to 0);
+                field (fun (a : AE.aggregate) -> a.losers) (equal_to 0);
+                field
+                  (fun (a : AE.aggregate) -> a.win_rate_pct)
+                  (float_equal 0.0);
+                field
+                  (fun (a : AE.aggregate) -> a.mean_return_pct)
+                  (float_equal 0.0);
+                field
+                  (fun (a : AE.aggregate) -> a.median_return_pct)
+                  (float_equal 0.0);
+                field
+                  (fun (a : AE.aggregate) -> a.total_pnl_dollars)
+                  (float_equal 0.0);
               ]);
        ])
 
@@ -285,7 +326,9 @@ let test_median_even_count _ =
     (all_of
        [
          field (fun (a : AE.aggregate) -> a.trade_count) (equal_to 4);
-         field (fun a -> a.median_return_pct) (float_equal 0.25);
+         field
+           (fun (a : AE.aggregate) -> a.median_return_pct)
+           (float_equal 0.25);
        ])
 
 let test_flat_trade_neither_winner_nor_loser _ =
@@ -302,10 +345,12 @@ let test_flat_trade_neither_winner_nor_loser _ =
     (all_of
        [
          field (fun (a : AE.aggregate) -> a.trade_count) (equal_to 1);
-         field (fun a -> a.winners) (equal_to 0);
-         field (fun a -> a.losers) (equal_to 0);
-         field (fun a -> a.win_rate_pct) (float_equal 0.0);
-         field (fun a -> a.total_pnl_dollars) (float_equal 0.0);
+         field (fun (a : AE.aggregate) -> a.winners) (equal_to 0);
+         field (fun (a : AE.aggregate) -> a.losers) (equal_to 0);
+         field (fun (a : AE.aggregate) -> a.win_rate_pct) (float_equal 0.0);
+         field
+           (fun (a : AE.aggregate) -> a.total_pnl_dollars)
+           (float_equal 0.0);
        ])
 
 let test_return_buckets_default _ =
@@ -399,12 +444,16 @@ let test_passes_macro_carried_through _ =
          all_of
            [
              field (fun (t : AE.trade_record) -> t.symbol) (equal_to "BULL");
-             field (fun t -> t.passes_macro) (equal_to true);
+             field
+               (fun (t : AE.trade_record) -> t.passes_macro)
+               (equal_to true);
            ];
          all_of
            [
              field (fun (t : AE.trade_record) -> t.symbol) (equal_to "BEAR");
-             field (fun t -> t.passes_macro) (equal_to false);
+             field
+               (fun (t : AE.trade_record) -> t.passes_macro)
+               (equal_to false);
            ];
        ])
 


### PR DESCRIPTION
## Summary

PR-1 of #870: pure-function lib + 10 tests for the fixed-dollar all-eligible
trade-grading diagnostic. Module surface lives at
`trading/trading/backtest/all_eligible/lib/all_eligible.{ml,mli}`.

## Why

#871 15y diagnostic showed cascade is at no-look-ahead ceiling; capital
recycling is the leverage gap. #856 grid sweep showed
\`max_position_pct_long\` alone can't hit acceptance gates. Suspected
mechanisms: \`Insufficient_cash\` skips + stop-distance gates.

This diagnostic separates **signal quality** from **portfolio mechanism**:

| Tool                      | Measures                                                   |
|---------------------------|------------------------------------------------------------|
| \`optimal-strategy\`        | Counterfactual perfect picking within universe scope       |
| \`all-eligible\` (this PR)  | Raw signal alpha — what each Stage-2 signal would return   |
| \`actual\` (live backtest)  | Strategy + portfolio mechanism interaction                 |

## What it does

For every Stage-2 entry signal that fires across a backtest period:
1. Allocates a fixed dollar amount per signal (default \$10K, configurable).
2. Bypasses every portfolio-level rejection — no cash floor, no exposure cap,
   no sector concentration.
3. Tracks each position independently to its natural exit (stop hit,
   Stage-3 transition, or end of run).
4. Emits per-trade alpha + aggregate stats (trade count, win rate, mean /
   median return, total \$pnl, return-distribution histogram).

## Reuse, not duplication

The lib operates on \`scored_candidate list\` produced by the existing
\`Backtest_optimal\` track:
- Scan: \`Stage_transition_scanner.scan_panel\` (already lands in main)
- Score: \`Outcome_scorer.score\` (already lands in main)

This PR adds only the **grade-and-aggregate phase** that turns scored
candidates into per-trade records + an aggregate. Same byte-for-byte
entry/exit semantics as the optimal-strategy track; the only difference is
no \`Optimal_portfolio_filler\` (no cash, sector, or sizing resolution).

## Files

- \`trading/trading/backtest/all_eligible/lib/all_eligible.{ml,mli}\` — pure lib
- \`trading/trading/backtest/all_eligible/lib/dune\` — library declaration
- \`trading/trading/backtest/all_eligible/test/test_all_eligible.ml\` — 10 tests
- \`trading/trading/backtest/all_eligible/test/dune\` — test runner declaration
- \`dev/plans/all-eligible-trade-grading-2026-05-06.md\` — design plan

LOC (excluding plan + tests): 361 LOC (\`.ml\` + \`.mli\`). Well under 500.

## Test plan

10 OUnit2 + Matchers tests, all passing locally:
- \`build_trade_record long arithmetic\` — pin per-trade math (entry=\$100,
  exit=\$130, \$10K size → 100 shares → \$3000 pnl).
- \`build_trade_record short arithmetic\` — short-side reflected pnl.
- \`custom entry_dollars sizes shares + pnl\` — \$50K override.
- \`three signals — all taken regardless of cash\` — headline acceptance:
  three Stage-2 signals fire, all three appear in output (\$30K total
  exposure with no cash gate; in a real run the second would be rejected
  for \`Insufficient_cash\`).
- \`three signals — aggregate matches sum\` — alpha additivity invariant.
- \`empty scored input → zeroed aggregate\`.
- \`median for even trade count averages middles\`.
- \`flat trade is neither winner nor loser\` (\`return_pct = 0.0\` excluded).
- \`return buckets count exactly\` — pins the seven default buckets.
- \`passes_macro carried through to trade record\` — macro flag preserved
  for downstream cross-tabulation.

\`\`\`
$ dune build trading/backtest/all_eligible/
$ dune runtest trading/backtest/all_eligible/ --force
..........
Ran: 10 tests in: 0.13 seconds.
OK
\`\`\`

Tests follow \`.claude/rules/test-patterns.md\`: one \`assert_that\` per value,
\`field\` / \`all_of\` / \`elements_are\` for composition.

## What's NOT in this PR (PR-2 follow-up)

- CLI exe wrapper that drives \`grade\` from a real run's artefacts.
- Snapshot construction + per-Friday scan loop (will reuse
  \`Optimal_strategy_runner._build_world\` / \`_scan_and_score\`).
- Output emission to disk — \`csv\` (per-trade) + \`summary.md\` (aggregate)
  under \`dev/all_eligible/<scenario>/<UTC-timestamp>/\`.
- Distributional metrics (Sharpe, Sortino, etc.) — separate M5.2c/d track.

## References

- Issue: #870
- Plan: \`dev/plans/all-eligible-trade-grading-2026-05-06.md\`
- 15y empirical context: \`dev/notes/15y-sp500-zero-trades-diagnosis-2026-05-03.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)