### PR TITLE
feat(strategy): Stage-3 force-exit detector for capital recycling (#872)

### DIFF
--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -162,6 +162,37 @@ Wire short-side entries into `Weinstein_strategy` so the simulation emits short 
    likely needed. See `dev/notes/force-liq-cascade-findings-2026-05-01.md`
    §G15. Owner: `feat-weinstein` — same scope-extension prereq as G14.
 
+8. **#872 — Stage-3 force-exit detector for capital recycling on the
+   long side** (filed 2026-05-06, PR #902, `feat-weinstein` scope).
+   Implements an opt-in mechanism that liberates portfolio cash from
+   mature long-runners whose 30-week MA has flattened. Empirical
+   motivation: the 15y SP500 baseline locks ~$1M in 18 long-runners
+   opened in Q1 2010 for the entire 16-year window; cascade idles
+   90.7% of Fridays with `Insufficient_cash` (per
+   `dev/notes/856-optimal-strategy-diagnostic-15y-2026-05-06.md`).
+   - **Pure detector**: `analysis/weinstein/stage3_force_exit/` —
+     reuses `Stage.classify` authority; emits `Force_exit` after K=2
+     consecutive Friday Stage-3 reads on a held long position
+     (configurable). 16 unit tests pinning hysteresis and reset
+     semantics.
+   - **Strategy wiring**: new
+     `Stage3_force_exit_runner` between `Stops_runner.update` and
+     `Force_liquidation_runner.update`. Friday cadence; long-only;
+     skips positions already exiting via stops on the same tick.
+     9 unit tests pinning the wiring contract.
+   - **New `exit_reason` variant**: `Position.Stage3ForceExit
+     { weeks_in_stage3 : int }` — separate per-trade attribution in
+     `trades.csv` as `stage3_force_exit`.
+   - **Opt-in via** `enable_stage3_force_exit : bool` config field
+     (default `false`). 5y baseline `sp500-2019-2023` PASSes scenario_runner
+     unchanged with default off (53.4% / 73 trades, inside pinned
+     [45.0-72.0%, 70-95 trades] band).
+   - Re-pinning under `enable=true` is a separate post-merge step per
+     `dev/notes/capital-recycling-framing-2026-05-06.md` §3.
+   - Reserved knob `stage3_reentry_cooldown_weeks` defaults to 0 and
+     is currently unwired — placeholder for future RS-conditioned
+     tuning.
+
 ## References
 
 - `docs/design/weinstein-book-reference.md` Ch. 11 — bear-market shorting rules (never short Stage 2; only Stage 4 with negative RS + bearish macro).

--- a/trading/analysis/weinstein/stage3_force_exit/lib/dune
+++ b/trading/analysis/weinstein/stage3_force_exit/lib/dune
@@ -1,0 +1,6 @@
+(library
+ (name stage3_force_exit)
+ (public_name weinstein.stage3_force_exit)
+ (libraries core weinstein.types)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/analysis/weinstein/stage3_force_exit/lib/stage3_force_exit.ml
+++ b/trading/analysis/weinstein/stage3_force_exit/lib/stage3_force_exit.ml
@@ -1,0 +1,38 @@
+open Core
+
+type config = { hysteresis_weeks : int } [@@deriving sexp]
+
+let _default_hysteresis_weeks = 2
+let default_config = { hysteresis_weeks = _default_hysteresis_weeks }
+
+type decision = Hold | Force_exit of { weeks_in_stage3 : int }
+[@@deriving show, eq]
+
+(** Effective hysteresis floor: a non-positive [config.hysteresis_weeks] would
+    otherwise short-circuit the detector. Treat any [<= 0] as [1] — a single
+    Stage-3 read fires immediately. The default is positive (2). *)
+let _effective_threshold ~config =
+  if config.hysteresis_weeks <= 0 then 1 else config.hysteresis_weeks
+
+let observe ~config ~prior_consecutive_stage3 ~current_stage =
+  match (current_stage : Weinstein_types.stage) with
+  | Stage3 _ ->
+      let new_count = prior_consecutive_stage3 + 1 in
+      let threshold = _effective_threshold ~config in
+      let decision =
+        if new_count >= threshold then
+          Force_exit { weeks_in_stage3 = new_count }
+        else Hold
+      in
+      (new_count, decision)
+  | Stage1 _ | Stage2 _ | Stage4 _ -> (0, Hold)
+
+let observe_position ~config ~state ~symbol ~current_stage =
+  let prior_consecutive_stage3 =
+    Hashtbl.find state symbol |> Option.value ~default:0
+  in
+  let new_count, decision =
+    observe ~config ~prior_consecutive_stage3 ~current_stage
+  in
+  Hashtbl.set state ~key:symbol ~data:new_count;
+  decision

--- a/trading/analysis/weinstein/stage3_force_exit/lib/stage3_force_exit.mli
+++ b/trading/analysis/weinstein/stage3_force_exit/lib/stage3_force_exit.mli
@@ -1,0 +1,119 @@
+(** Stage-3 force-exit detector — capital recycling on the long side (#872).
+
+    Per Weinstein Ch. 6 §5.2 (STAGE3_TIGHTENING) and Ch. 2 (Stage 3 detail):
+    when a held long position transitions from Stage 2 to Stage 3
+    ("topping/distribution" — 30-week MA flattening, price oscillating around
+    the MA), the book authority calls for either tightening the trailing stop or
+    exiting outright. This detector implements the exit-outright variant — the
+    trader-side discipline ("Traders: exit with profits") — to free portfolio
+    cash for fresh Stage-2 candidates. See
+    [dev/notes/856-optimal-strategy-diagnostic-15y-2026-05-06.md] for the
+    empirical motivation: the live strategy generated zero Stage-3 exits over a
+    16-year window, locking ~$1M in 18 long-runners that the cascade kept
+    rejecting candidates against because of [Insufficient_cash].
+
+    {1 Detection signature}
+
+    The detector reuses the existing {!Stage.classify} authority: a position is
+    "in Stage 3" when its weekly classification yields [Stage3 _]. The
+    classifier already encodes the book's MA-flat + price-oscillation rules, so
+    this module does not re-implement them. The detector adds {b hysteresis} on
+    top: a force-exit fires only when [Stage3 _] is observed for
+    [config.hysteresis_weeks] consecutive Friday classifications. This avoids
+    whipsaw on a single transient flattening that resolves back into Stage 2.
+
+    Any non-[Stage3] classification resets the consecutive count to zero.
+
+    {1 What the module does NOT do}
+
+    - Does NOT classify stages itself — call {!Stage.classify} (or its callback
+      variants) and pass the result in.
+    - Does NOT generate the [Position.transition] — the strategy wiring layer
+      builds the {!Position.TriggerExit} with the
+      {!Position.exit_reason.Stage3ForceExit} variant once this detector decides
+      [Force_exit].
+    - Does NOT touch trailing-stop state. A position force-exited under this
+      mechanism leaves its stop state stale; the wiring layer is responsible for
+      the cleanup (typically by removing the stop-state entry on exit).
+    - Does NOT apply to short positions. The book authority for shorts (§6.3)
+      uses different stage transitions; short-side force-exit would require a
+      separate analysis. Today the detector returns [Hold] for any non-long
+      classification result; callers wire only the long branch. *)
+
+type config = {
+  hysteresis_weeks : int;
+      (** Number of consecutive Stage-3 classifications required before the
+          detector emits [Force_exit]. Default 2.
+
+          - K = 1 fires on first Stage-3 observation — most aggressive, prone to
+            whipsaw on transient flattening.
+          - K = 2 (default) requires two consecutive Friday Stage-3 reads —
+            book-aligned with §5.2 STAGE3_TIGHTENING which fires "when MA
+            flattens out" rather than on a single noisy week.
+          - K ≥ 3 is more conservative; trades alpha for stability. *)
+}
+[@@deriving sexp]
+(** Configuration for the detector. *)
+
+val default_config : config
+(** Defaults: [{ hysteresis_weeks = 2 }]. *)
+
+(** Decision emitted by {!observe}. *)
+type decision =
+  | Hold
+      (** Either the current stage is not Stage 3, or the consecutive Stage-3
+          count has not yet reached [config.hysteresis_weeks]. The caller takes
+          no exit action. *)
+  | Force_exit of { weeks_in_stage3 : int }
+      (** Stage 3 has been observed for [weeks_in_stage3] consecutive Friday
+          classifications and [weeks_in_stage3 >= config.hysteresis_weeks]. The
+          strategy wiring layer should emit a [Position.TriggerExit] with
+          [exit_reason = Stage3ForceExit { weeks_in_stage3 }]. *)
+[@@deriving show, eq]
+
+val observe :
+  config:config ->
+  prior_consecutive_stage3:int ->
+  current_stage:Weinstein_types.stage ->
+  int * decision
+(** [observe ~config ~prior_consecutive_stage3 ~current_stage] is the pure
+    state-transition core of the detector.
+
+    Returns a pair [(new_consecutive_stage3, decision)]:
+    - When [current_stage] is [Stage3 _]: increments the consecutive count and
+      emits [Force_exit] iff the new count [>= config.hysteresis_weeks].
+    - When [current_stage] is anything other than [Stage3 _]: resets the
+      consecutive count to [0] and emits [Hold].
+
+    The detector does not consider the [weeks_topping] payload of [Stage3]
+    directly — [weeks_topping] is the Stage classifier's own count (which can
+    include weeks before the position was opened) and uses a different state
+    machine (sticky across MA-direction noise). The detector's own
+    consecutive-Friday count is a distinct, bounded measure of how long the
+    detector has seen Stage 3 reads on this position.
+
+    Pure function — same inputs always produce the same outputs.
+
+    Edge case: when [config.hysteresis_weeks <= 0], the function treats
+    [hysteresis_weeks = 1] (a single Stage-3 read fires immediately). This is
+    defensive — a non-positive hysteresis would otherwise disable the detector
+    entirely. The default config has K = 2; callers are expected to pass a
+    positive value. *)
+
+(** {1 Symbol-keyed convenience wrapper} *)
+
+val observe_position :
+  config:config ->
+  state:(string, int) Core.Hashtbl.t ->
+  symbol:string ->
+  current_stage:Weinstein_types.stage ->
+  decision
+(** [observe_position ~config ~state ~symbol ~current_stage] looks up the prior
+    consecutive-Stage-3 count for [symbol] in [state] (defaulting to [0] when
+    missing), calls {!observe}, then writes the new count back into [state].
+    Mutates [state] in place. Returns the [decision].
+
+    Parallel to the [prior_stages] table in
+    {!Weinstein_strategy._on_market_close} — kept as a separate hashtable so the
+    detector's state is independent of the stage classifier's prior-stage
+    threading. *)

--- a/trading/analysis/weinstein/stage3_force_exit/test/dune
+++ b/trading/analysis/weinstein/stage3_force_exit/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_stage3_force_exit)
+ (libraries weinstein.stage3_force_exit weinstein.types core ounit2 matchers))

--- a/trading/analysis/weinstein/stage3_force_exit/test/test_stage3_force_exit.ml
+++ b/trading/analysis/weinstein/stage3_force_exit/test/test_stage3_force_exit.ml
@@ -1,0 +1,225 @@
+open OUnit2
+open Core
+open Matchers
+open Stage3_force_exit
+
+(* --- helpers --- *)
+
+let stage1 = Weinstein_types.Stage1 { weeks_in_base = 5 }
+let stage2 = Weinstein_types.Stage2 { weeks_advancing = 3; late = false }
+let stage3 = Weinstein_types.Stage3 { weeks_topping = 1 }
+let stage4 = Weinstein_types.Stage4 { weeks_declining = 2 }
+let cfg_k2 = { hysteresis_weeks = 2 }
+let cfg_k1 = { hysteresis_weeks = 1 }
+let cfg_k3 = { hysteresis_weeks = 3 }
+
+(* --- pure observe --- *)
+
+let test_observe_stage2_returns_hold _ =
+  assert_that
+    (observe ~config:cfg_k2 ~prior_consecutive_stage3:0 ~current_stage:stage2)
+    (equal_to ((0, Hold) : int * decision))
+
+let test_observe_stage1_returns_hold_resets_count _ =
+  (* Even after a streak, a non-Stage-3 read resets the consecutive count to
+     zero and emits Hold. *)
+  assert_that
+    (observe ~config:cfg_k2 ~prior_consecutive_stage3:5 ~current_stage:stage1)
+    (equal_to ((0, Hold) : int * decision))
+
+let test_observe_stage4_returns_hold_resets_count _ =
+  assert_that
+    (observe ~config:cfg_k2 ~prior_consecutive_stage3:7 ~current_stage:stage4)
+    (equal_to ((0, Hold) : int * decision))
+
+let test_observe_stage3_first_week_below_threshold _ =
+  (* prior_count=0 → new_count=1 < threshold=2 → Hold. *)
+  assert_that
+    (observe ~config:cfg_k2 ~prior_consecutive_stage3:0 ~current_stage:stage3)
+    (equal_to ((1, Hold) : int * decision))
+
+let test_observe_stage3_at_threshold_fires _ =
+  (* prior_count=1 → new_count=2 ≥ threshold=2 → Force_exit. *)
+  assert_that
+    (observe ~config:cfg_k2 ~prior_consecutive_stage3:1 ~current_stage:stage3)
+    (equal_to ((2, Force_exit { weeks_in_stage3 = 2 }) : int * decision))
+
+let test_observe_stage3_above_threshold_keeps_firing _ =
+  (* prior_count=4 → new_count=5 ≥ threshold=2 → Force_exit (still firing
+     while Stage 3 persists). The wiring layer is responsible for not
+     re-issuing exits on already-exiting positions; the detector itself just
+     reports the signal. *)
+  assert_that
+    (observe ~config:cfg_k2 ~prior_consecutive_stage3:4 ~current_stage:stage3)
+    (equal_to ((5, Force_exit { weeks_in_stage3 = 5 }) : int * decision))
+
+let test_observe_k1_fires_first_week _ =
+  assert_that
+    (observe ~config:cfg_k1 ~prior_consecutive_stage3:0 ~current_stage:stage3)
+    (equal_to ((1, Force_exit { weeks_in_stage3 = 1 }) : int * decision))
+
+let test_observe_k3_requires_three_weeks _ =
+  (* prior=0, new=1, 2, 3 — only the third fires. Build the sequence. *)
+  let r1 =
+    observe ~config:cfg_k3 ~prior_consecutive_stage3:0 ~current_stage:stage3
+  in
+  let r2 =
+    observe ~config:cfg_k3 ~prior_consecutive_stage3:(fst r1)
+      ~current_stage:stage3
+  in
+  let r3 =
+    observe ~config:cfg_k3 ~prior_consecutive_stage3:(fst r2)
+      ~current_stage:stage3
+  in
+  assert_that [ r1; r2; r3 ]
+    (elements_are
+       [
+         equal_to ((1, Hold) : int * decision);
+         equal_to ((2, Hold) : int * decision);
+         equal_to ((3, Force_exit { weeks_in_stage3 = 3 }) : int * decision);
+       ])
+
+let test_observe_k0_treated_as_k1 _ =
+  (* Defensive: hysteresis_weeks <= 0 is treated as 1, so a single Stage-3
+     read fires immediately. *)
+  let config = { hysteresis_weeks = 0 } in
+  assert_that
+    (observe ~config ~prior_consecutive_stage3:0 ~current_stage:stage3)
+    (equal_to ((1, Force_exit { weeks_in_stage3 = 1 }) : int * decision))
+
+let test_observe_negative_k_treated_as_k1 _ =
+  let config = { hysteresis_weeks = -5 } in
+  assert_that
+    (observe ~config ~prior_consecutive_stage3:0 ~current_stage:stage3)
+    (equal_to ((1, Force_exit { weeks_in_stage3 = 1 }) : int * decision))
+
+let test_observe_stage3_then_stage2_resets _ =
+  (* A whipsaw scenario: 1 week Stage 3, then 1 week Stage 2.
+     The next Stage-3 read should be treated as a fresh first week (count=1),
+     not as a continuation of the prior streak. *)
+  let r1 =
+    observe ~config:cfg_k2 ~prior_consecutive_stage3:0 ~current_stage:stage3
+  in
+  let r2 =
+    observe ~config:cfg_k2 ~prior_consecutive_stage3:(fst r1)
+      ~current_stage:stage2
+  in
+  let r3 =
+    observe ~config:cfg_k2 ~prior_consecutive_stage3:(fst r2)
+      ~current_stage:stage3
+  in
+  assert_that [ r1; r2; r3 ]
+    (elements_are
+       [
+         equal_to ((1, Hold) : int * decision);
+         equal_to ((0, Hold) : int * decision);
+         equal_to ((1, Hold) : int * decision);
+       ])
+
+(* --- symbol-keyed wrapper --- *)
+
+let test_observe_position_seeds_zero_for_unknown_symbol _ =
+  let state = Hashtbl.create (module String) in
+  let decision =
+    observe_position ~config:cfg_k2 ~state ~symbol:"AAPL" ~current_stage:stage3
+  in
+  assert_that decision (equal_to (Hold : decision));
+  assert_that (Hashtbl.find state "AAPL") (is_some_and (equal_to 1))
+
+let test_observe_position_two_consecutive_stage3_fires _ =
+  let state = Hashtbl.create (module String) in
+  let _ =
+    observe_position ~config:cfg_k2 ~state ~symbol:"AAPL" ~current_stage:stage3
+  in
+  let decision =
+    observe_position ~config:cfg_k2 ~state ~symbol:"AAPL" ~current_stage:stage3
+  in
+  assert_that decision
+    (equal_to (Force_exit { weeks_in_stage3 = 2 } : decision))
+
+let test_observe_position_per_symbol_isolation _ =
+  (* Two symbols are tracked independently. AAPL hits Stage 3 twice (fires);
+     MSFT hits Stage 3 once (no fire). *)
+  let state = Hashtbl.create (module String) in
+  let _ =
+    observe_position ~config:cfg_k2 ~state ~symbol:"AAPL" ~current_stage:stage3
+  in
+  let _ =
+    observe_position ~config:cfg_k2 ~state ~symbol:"MSFT" ~current_stage:stage2
+  in
+  let aapl =
+    observe_position ~config:cfg_k2 ~state ~symbol:"AAPL" ~current_stage:stage3
+  in
+  let msft =
+    observe_position ~config:cfg_k2 ~state ~symbol:"MSFT" ~current_stage:stage3
+  in
+  assert_that [ aapl; msft ]
+    (elements_are
+       [
+         equal_to (Force_exit { weeks_in_stage3 = 2 } : decision);
+         equal_to (Hold : decision);
+       ])
+
+let test_observe_position_resets_on_stage2_read _ =
+  (* AAPL: Stage3 → Stage3 (fires) → Stage2 (resets). Next Stage3 read is
+     a fresh first week (Hold under K=2). *)
+  let state = Hashtbl.create (module String) in
+  let _ =
+    observe_position ~config:cfg_k2 ~state ~symbol:"AAPL" ~current_stage:stage3
+  in
+  let _ =
+    observe_position ~config:cfg_k2 ~state ~symbol:"AAPL" ~current_stage:stage3
+  in
+  let _ =
+    observe_position ~config:cfg_k2 ~state ~symbol:"AAPL" ~current_stage:stage2
+  in
+  let after_reset =
+    observe_position ~config:cfg_k2 ~state ~symbol:"AAPL" ~current_stage:stage3
+  in
+  assert_that after_reset (equal_to (Hold : decision));
+  assert_that (Hashtbl.find state "AAPL") (is_some_and (equal_to 1))
+
+(* --- default config --- *)
+
+let test_default_config_hysteresis_is_two _ =
+  assert_that default_config.hysteresis_weeks (equal_to 2)
+
+(* --- runner --- *)
+
+let suite =
+  "stage3_force_exit"
+  >::: [
+         "observe: Stage 2 returns Hold" >:: test_observe_stage2_returns_hold;
+         "observe: Stage 1 returns Hold and resets count"
+         >:: test_observe_stage1_returns_hold_resets_count;
+         "observe: Stage 4 returns Hold and resets count"
+         >:: test_observe_stage4_returns_hold_resets_count;
+         "observe: first Stage 3 week below threshold returns Hold"
+         >:: test_observe_stage3_first_week_below_threshold;
+         "observe: Stage 3 at threshold fires Force_exit"
+         >:: test_observe_stage3_at_threshold_fires;
+         "observe: Stage 3 above threshold keeps firing"
+         >:: test_observe_stage3_above_threshold_keeps_firing;
+         "observe: K=1 fires on first Stage 3 week"
+         >:: test_observe_k1_fires_first_week;
+         "observe: K=3 requires three consecutive weeks"
+         >:: test_observe_k3_requires_three_weeks;
+         "observe: K=0 treated as K=1 (defensive)"
+         >:: test_observe_k0_treated_as_k1;
+         "observe: negative K treated as K=1 (defensive)"
+         >:: test_observe_negative_k_treated_as_k1;
+         "observe: Stage 3 then Stage 2 then Stage 3 resets streak"
+         >:: test_observe_stage3_then_stage2_resets;
+         "observe_position: unknown symbol seeds count to zero"
+         >:: test_observe_position_seeds_zero_for_unknown_symbol;
+         "observe_position: two consecutive Stage 3 reads fire"
+         >:: test_observe_position_two_consecutive_stage3_fires;
+         "observe_position: symbols are tracked independently"
+         >:: test_observe_position_per_symbol_isolation;
+         "observe_position: a Stage 2 read resets the streak"
+         >:: test_observe_position_resets_on_stage2_read;
+         "default_config: hysteresis is 2"
+         >:: test_default_config_hysteresis_is_two;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -56,6 +56,7 @@ let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
   | Time_expired _ -> "time_expired"
   | Underperforming _ -> "underperforming"
   | Portfolio_rebalancing -> "rebalancing"
+  | Stage3_force_exit _ -> "stage3_force_exit"
   | End_of_period -> "end_of_period"
 
 (** Build a (symbol, exit_date) -> reason map from force-liquidation events.

--- a/trading/trading/backtest/lib/stop_log.ml
+++ b/trading/trading/backtest/lib/stop_log.ml
@@ -10,6 +10,7 @@ type exit_trigger =
   | Time_expired of { days_held : int; max_days : int }
   | Underperforming of { days_held : int; current_return : float }
   | Portfolio_rebalancing
+  | Stage3_force_exit of { weeks_in_stage3 : int }
   | End_of_period
 [@@deriving show, eq, sexp]
 
@@ -52,6 +53,7 @@ let exit_trigger_of_reason (reason : Position.exit_reason) : exit_trigger =
   | Underperforming { days_held; current_return } ->
       Underperforming { days_held; current_return }
   | PortfolioRebalancing -> Portfolio_rebalancing
+  | Stage3ForceExit { weeks_in_stage3 } -> Stage3_force_exit { weeks_in_stage3 }
 
 type stop_trigger_kind = Gap_down | Intraday | End_of_period | Non_stop_exit
 [@@deriving show, eq, sexp]
@@ -73,7 +75,7 @@ let classify_stop_trigger_kind ?(gap_threshold_pct = gap_down_threshold_pct)
       else Intraday
   | End_of_period -> End_of_period
   | Take_profit _ | Signal_reversal _ | Time_expired _ | Underperforming _
-  | Portfolio_rebalancing ->
+  | Portfolio_rebalancing | Stage3_force_exit _ ->
       Non_stop_exit
 
 let _fresh_record ~symbol =

--- a/trading/trading/backtest/lib/stop_log.mli
+++ b/trading/trading/backtest/lib/stop_log.mli
@@ -27,6 +27,11 @@ type exit_trigger =
   | Underperforming of { days_held : int; current_return : float }
       (** Position underperformed *)
   | Portfolio_rebalancing  (** Closed for rebalancing *)
+  | Stage3_force_exit of { weeks_in_stage3 : int }
+      (** Strategy-driven force exit fired after the position was classified as
+          Stage 3 for [weeks_in_stage3] consecutive Friday classifications (≥
+          the configured hysteresis window). Capital-recycling exit per
+          Weinstein Ch. 6 §5.2 (issue #872). *)
   | End_of_period
       (** Position was force-closed at the end of the backtest period without a
           preceding strategy-emitted [TriggerExit]. The simulator's end-of-run

--- a/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
+++ b/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
@@ -85,6 +85,7 @@ let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
   | Time_expired _ -> "time_expired"
   | Underperforming _ -> "underperforming"
   | Portfolio_rebalancing -> "rebalancing"
+  | Stage3_force_exit _ -> "stage3_force_exit"
   | End_of_period -> "end_of_period"
 
 let _row_of_trade audit_idx (trade : Trading_simulation.Metrics.trade_metrics) :

--- a/trading/trading/strategy/lib/position.ml
+++ b/trading/trading/strategy/lib/position.ml
@@ -34,6 +34,7 @@ type exit_reason =
   | TimeExpired of { days_held : int; max_days : int }
   | Underperforming of { days_held : int; current_return : float }
   | PortfolioRebalancing
+  | Stage3ForceExit of { weeks_in_stage3 : int }
 [@@deriving show, eq]
 
 type position_state =

--- a/trading/trading/strategy/lib/position.mli
+++ b/trading/trading/strategy/lib/position.mli
@@ -158,6 +158,15 @@ type exit_reason =
   | TimeExpired of { days_held : int; max_days : int }
   | Underperforming of { days_held : int; current_return : float }
   | PortfolioRebalancing
+  | Stage3ForceExit of { weeks_in_stage3 : int }
+      (** Strategy-driven exit fired after a held position has been classified
+          as Stage 3 ("topping / distribution" — 30-week MA flattening) for at
+          least the configured hysteresis window. Capital-recycling mechanism
+          per Weinstein Ch. 6 §5.2 (STAGE3_TIGHTENING) extended to a full
+          exit rather than a stop tighten — frees cash for fresh Stage-2
+          candidates (issue #872). [weeks_in_stage3] is the consecutive
+          count of Stage-3 classifications observed at the moment the exit
+          fires. *)
 [@@deriving show, eq]
 
 (** Position state variants - only state-specific data *)

--- a/trading/trading/strategy/lib/position.mli
+++ b/trading/trading/strategy/lib/position.mli
@@ -162,11 +162,10 @@ type exit_reason =
       (** Strategy-driven exit fired after a held position has been classified
           as Stage 3 ("topping / distribution" — 30-week MA flattening) for at
           least the configured hysteresis window. Capital-recycling mechanism
-          per Weinstein Ch. 6 §5.2 (STAGE3_TIGHTENING) extended to a full
-          exit rather than a stop tighten — frees cash for fresh Stage-2
-          candidates (issue #872). [weeks_in_stage3] is the consecutive
-          count of Stage-3 classifications observed at the moment the exit
-          fires. *)
+          per Weinstein Ch. 6 §5.2 (STAGE3_TIGHTENING) extended to a full exit
+          rather than a stop tighten — frees cash for fresh Stage-2 candidates
+          (issue #872). [weeks_in_stage3] is the consecutive count of Stage-3
+          classifications observed at the moment the exit fires. *)
 [@@deriving show, eq]
 
 (** Position state variants - only state-specific data *)

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -15,6 +15,7 @@
   weinstein_trading.stops
   weinstein_trading.portfolio_risk
   weinstein.stage
+  weinstein.stage3_force_exit
   weinstein.macro
   weinstein.rs
   weinstein.sector

--- a/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml
@@ -1,0 +1,54 @@
+open Core
+open Trading_strategy
+
+(** Build the [TriggerExit] transition for a Stage-3 force exit. The exit fires
+    at the close of the current bar — same convention as a stop hit that fills
+    at the bar's worst-case price (book §5.2 reads: "stop is hit → sell, no
+    questions asked"). For a discretionary force exit at the close,
+    [bar.close_price] is the most defensible fill marker. *)
+let _make_exit_transition ~(pos : Position.t) ~current_date ~bar
+    ~weeks_in_stage3 =
+  let exit_price = bar.Types.Daily_price.close_price in
+  let exit_reason = Position.Stage3ForceExit { weeks_in_stage3 } in
+  {
+    Position.position_id = pos.id;
+    date = current_date;
+    kind = Position.TriggerExit { exit_reason; exit_price };
+  }
+
+(** Process one position. Returns [Some transition] when the detector fires AND
+    the position is not already exiting via a stop hit this tick. The detector's
+    streak counter is always mutated (in [stage3_streaks]) — even on a skipped
+    emit — so the count remains accurate against the underlying stage stream. *)
+let _process_position ~config ~stage3_streaks ~prior_stages
+    ~stop_exit_position_ids ~get_price ~current_date (pos : Position.t) =
+  match (pos.side, Position.get_state pos) with
+  | Trading_base.Types.Long, Position.Holding _ -> (
+      match Hashtbl.find prior_stages pos.symbol with
+      | None -> None
+      | Some current_stage -> (
+          let decision =
+            Stage3_force_exit.observe_position ~config ~state:stage3_streaks
+              ~symbol:pos.symbol ~current_stage
+          in
+          match decision with
+          | Stage3_force_exit.Hold -> None
+          | Stage3_force_exit.Force_exit { weeks_in_stage3 } ->
+              if Set.mem stop_exit_position_ids pos.id then None
+              else
+                Option.map (get_price pos.symbol) ~f:(fun bar ->
+                    _make_exit_transition ~pos ~current_date ~bar
+                      ~weeks_in_stage3)))
+  | _ -> None
+
+let update ~config ~is_screening_day ~positions ~get_price ~prior_stages
+    ~stage3_streaks ~stop_exit_position_ids ~current_date =
+  if not is_screening_day then []
+  else
+    Map.fold positions ~init:[] ~f:(fun ~key:_ ~data:pos acc ->
+        match
+          _process_position ~config ~stage3_streaks ~prior_stages
+            ~stop_exit_position_ids ~get_price ~current_date pos
+        with
+        | Some t -> t :: acc
+        | None -> acc)

--- a/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.mli
@@ -1,0 +1,69 @@
+(** Stage-3 force-exit runner — wires {!Stage3_force_exit} into the Weinstein
+    strategy.
+
+    Capital-recycling exit per Weinstein Ch. 6 §5.2 (STAGE3_TIGHTENING) extended
+    to a full exit. Issue #872, framing note
+    [dev/notes/capital-recycling-framing-2026-05-06.md].
+
+    {1 Cadence}
+
+    Fires only on Friday (weekly cadence). The detector reads per-position stage
+    classifications written into [prior_stages] by {!Stops_runner.update} on the
+    same tick. On non-Friday calls the runner is a no-op — avoids intra-week
+    noise from daily-cadence classifications.
+
+    {1 Side & ordering}
+
+    Long positions only. Short positions never trigger this exit; their stage
+    semantics for "topping" differ (see book §6.3) and short-side capital
+    recycling has separate gaps.
+
+    Invoked AFTER {!Stops_runner.update} (so stop-outs have priority — a
+    position already exiting via a stop hit is not re-exited under Stage 3) and
+    BEFORE the entry walk + {!Force_liquidation_runner.update} on the same tick
+    (so freed cash is visible to the entry walk). *)
+
+open Core
+open Trading_strategy
+
+val update :
+  config:Stage3_force_exit.config ->
+  is_screening_day:bool ->
+  positions:Position.t Map.M(String).t ->
+  get_price:Strategy_interface.get_price_fn ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  stage3_streaks:int Hashtbl.M(String).t ->
+  stop_exit_position_ids:String.Set.t ->
+  current_date:Core.Date.t ->
+  Position.transition list
+(** [update] iterates over every held long {!Position.t} and runs the Stage-3
+    force-exit detector, returning a list of [TriggerExit] transitions for
+    positions whose detector decision is [Force_exit].
+
+    {2 Behaviour}
+
+    - Returns [[]] when [is_screening_day = false]. The detector runs at weekly
+      cadence only.
+    - Returns [[]] when [positions] is empty.
+    - For each held long position with a {!Position.Holding} state: 1. Reads the
+      current stage from [prior_stages]; falls back to no-op when the symbol is
+      missing (typical on a position's first tick or when MA warmup hasn't
+      completed). 2. Calls {!Stage3_force_exit.observe_position} — the detector
+      mutates [stage3_streaks] in place to maintain the consecutive-Stage-3
+      count. 3. On [Force_exit { weeks_in_stage3 }]:
+    - Skips the position if its [position_id] is in [stop_exit_position_ids] —
+      the stops runner already exited it this tick.
+    - Otherwise emits a [TriggerExit] transition with
+      [exit_reason = Stage3ForceExit { weeks_in_stage3 }] and
+      [exit_price = bar.close_price] from [get_price]. When [get_price] returns
+      [None] the position is silently skipped.
+    - Short positions and non-Holding states are skipped without emitting, and
+      their entry in [stage3_streaks] is left untouched. This keeps the streak
+      counter accurate if the position later transitions back into Holding.
+
+    {2 Mutates}
+
+    - [stage3_streaks] — the per-symbol consecutive-Stage-3 count is updated in
+      place via {!Stage3_force_exit.observe_position}. Each call advances the
+      count by one on a Stage-3 read or resets it to zero on any non-Stage-3
+      read. *)

--- a/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.mli
@@ -18,10 +18,10 @@
     semantics for "topping" differ (see book §6.3) and short-side capital
     recycling has separate gaps.
 
-    Invoked AFTER {!Stops_runner.update} (so stop-outs have priority — a
-    position already exiting via a stop hit is not re-exited under Stage 3) and
-    BEFORE the entry walk + {!Force_liquidation_runner.update} on the same tick
-    (so freed cash is visible to the entry walk). *)
+    Invoked AFTER {!Stops_runner.update} and {!Force_liquidation_runner.update}
+    (so both stop-outs and force-liquidations have priority — a position already
+    exiting via either path is not re-exited under Stage 3) and BEFORE the entry
+    walk on the same tick (so freed cash is visible to the entry walk). *)
 
 open Core
 open Trading_strategy

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -8,6 +8,11 @@ module Bar_reader = Bar_reader
 module Stops_runner = Stops_runner
 module Stops_split_runner = Stops_split_runner
 module Force_liquidation_runner = Force_liquidation_runner
+module Stage3_force_exit_runner = Stage3_force_exit_runner
+
+module Stage3_force_exit = Stage3_force_exit
+(** Pure Stage-3 force-exit detector (issue #872). See [stage3_force_exit.mli]
+    for the contract. *)
 
 module Ad_bars = Ad_bars
 (** NYSE advance/decline breadth data loader. Exposed as a top-level submodule
@@ -63,6 +68,24 @@ type config = {
           every daily bar. [Weekly] only advances the state machine on Friday
           ticks, matching Weinstein Ch. 6 §Stop-Loss Rules ("trail moves only on
           weekly close"). Trigger logic stays continuous in both modes. *)
+  stage3_force_exit_config : Stage3_force_exit.config;
+      [@sexp.default Stage3_force_exit.default_config]
+      (** Stage-3 force-exit detector parameters (issue #872). Default
+          [{ hysteresis_weeks = 2 }] — fires on the second consecutive Friday
+          Stage-3 classification of a held long position. *)
+  enable_stage3_force_exit : bool; [@sexp.default false]
+      (** Master switch for the Stage-3 force-exit runner. Default [false]
+          preserves all existing baselines: the runner is a no-op and the
+          strategy emits no [Stage3ForceExit] transitions. Flipping to [true]
+          activates {!Stage3_force_exit_runner.update} on every Friday tick. *)
+  stage3_reentry_cooldown_weeks : int; [@sexp.default 0]
+      (** Reserved for future tuning — currently unwired (default [0] = no
+          cooldown applied). Once wired, would suppress cascade re-admission of
+          a symbol force-exited under Stage 3 for [N] weeks beyond the existing
+          stop-out cooldown surface (#718). [0] is the book-aligned default
+          (§5.2 "STATE: EXITED — IF whipsaw … acceptable to re-buy"). The knob
+          exists on [config] so future tuning can flip it via sexp override
+          without a code change. *)
 }
 [@@deriving sexp]
 
@@ -85,6 +108,9 @@ let default_config ~universe ~index_symbol =
     full_compute_tail_days = None;
     enable_short_side = true;
     stop_update_cadence = Stops_runner.Daily;
+    stage3_force_exit_config = Stage3_force_exit.default_config;
+    enable_stage3_force_exit = false;
+    stage3_reentry_cooldown_weeks = 0;
   }
 
 let name = "Weinstein"
@@ -478,8 +504,8 @@ let _record_stop_outs ~last_stop_out_dates
 
 let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
     ~prior_macro ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
-    ~sector_prior_stages ~ticker_sectors ~audit_recorder ~get_price
-    ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
+    ~sector_prior_stages ~ticker_sectors ~stage3_streaks ~audit_recorder
+    ~get_price ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
   let positions = portfolio.positions in
   (* G13: non-trading-day short-circuit. The simulator iterates calendar
      days (Mon-Fri including holidays), so [_on_market_close] is invoked on
@@ -578,6 +604,43 @@ let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
         Bar_reader.weekly_view_for bar_reader ~symbol:config.indices.primary
           ~n:config.lookback_bars ~as_of:current_date
       in
+      (* Stage-3 force-exit pass (issue #872). Reads per-position stages from
+     [prior_stages] (just refreshed by [Stops_runner.update]) and emits
+     [TriggerExit] transitions for held longs whose Stage-3 streak has
+     reached [config.stage3_force_exit_config.hysteresis_weeks]. The runner
+     filters out positions already exiting via stops on this tick (see
+     [stop_exited_ids]) so a stop-out and a Stage-3 fire on the same
+     position the same week resolve to a single exit. The runner is
+     conditionally enabled via [config.enable_stage3_force_exit] (default
+     [false]) so existing baselines are bit-equivalent until callers opt
+     in. *)
+      let stage3_force_exit_transitions =
+        if config.enable_stage3_force_exit then
+          let is_screening_day = _is_screening_day_view index_view in
+          Stage3_force_exit_runner.update
+            ~config:config.stage3_force_exit_config ~is_screening_day ~positions
+            ~get_price ~prior_stages ~stage3_streaks
+            ~stop_exit_position_ids:stop_exited_ids ~current_date
+        else []
+      in
+      (* Strip force-liq transitions for positions the Stage-3 runner just
+     exited — same double-exit hazard the [stop_exited_ids] filter handles
+     for stops above. Re-using a fresh union of exited ids covers both. *)
+      let stage3_exited_ids =
+        List.filter_map stage3_force_exit_transitions
+          ~f:(fun (t : Position.transition) ->
+            match t.kind with
+            | Position.TriggerExit _ -> Some t.position_id
+            | _ -> None)
+        |> String.Set.of_list
+      in
+      let force_exit_transitions =
+        if Set.is_empty stage3_exited_ids then force_exit_transitions
+        else
+          List.filter force_exit_transitions
+            ~f:(fun (t : Position.transition) ->
+              not (Set.mem stage3_exited_ids t.position_id))
+      in
       (* On every Friday — including Fridays where the force-liquidation halt is
      active — run the cheap macro-only path and consult [_maybe_reset_halt]
      BEFORE deciding whether to invoke the universe screen. This preserves the
@@ -618,8 +681,8 @@ let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
       Ok
         {
           Strategy_interface.transitions =
-            exit_transitions @ force_exit_transitions @ adjust_transitions
-            @ entry_transitions;
+            exit_transitions @ stage3_force_exit_transitions
+            @ force_exit_transitions @ adjust_transitions @ entry_transitions;
         }
 
 let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
@@ -656,6 +719,13 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
   let sector_prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
+  (* Per-symbol consecutive-Stage-3-Friday counter consumed by
+     {!Stage3_force_exit_runner} (issue #872). Empty at construction →
+     every position starts with a streak of zero, matching the no-stage-3
+     baseline. *)
+  let stage3_streaks : int Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
   (* Macro.analyze requires weekly-cadence ad_bars; normalize once at load
      time, not on every [on_market_close] call. *)
   let weekly_ad_bars = Ad_bars_aggregation.daily_to_weekly ad_bars in
@@ -666,7 +736,7 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
       _on_market_close ~config ~ad_bars:weekly_ad_bars ~stop_states
         ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
         ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
-        ~audit_recorder
+        ~stage3_streaks ~audit_recorder
   end in
   (module M : Strategy_interface.STRATEGY)
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -55,6 +55,19 @@ module Force_liquidation_runner = Force_liquidation_runner
     [dev/notes/short-side-gaps-2026-04-29.md]. See {!Force_liquidation_runner}.
 *)
 
+module Stage3_force_exit_runner = Stage3_force_exit_runner
+(** Stage-3 force-exit runner — capital recycling on the long side (issue #872).
+    Invoked AFTER {!Stops_runner.update} and BEFORE
+    {!Force_liquidation_runner.update} on Friday ticks when
+    [config.enable_stage3_force_exit = true]. See {!Stage3_force_exit_runner}.
+*)
+
+module Stage3_force_exit = Stage3_force_exit
+(** Pure Stage-3 force-exit detector (issue #872). Re-exposed from
+    [analysis/weinstein/stage3_force_exit] so callers building a
+    {!Weinstein_strategy.config} can reference {!Stage3_force_exit.config} and
+    {!Stage3_force_exit.default_config} without a separate library import. *)
+
 module Macro_inputs = Macro_inputs
 (** Sector map + global index assembly from accumulated bar history. Exposes the
     canonical {!Macro_inputs.spdr_sector_etfs} and
@@ -187,6 +200,32 @@ type config = {
           [dev/notes/sp500-trade-quality-findings-2026-04-30.md] §G11. The
           comparison run is a follow-up; this field exists so the experiment
           becomes a config flip rather than a code change. *)
+  stage3_force_exit_config : Stage3_force_exit.config;
+      [@sexp.default Stage3_force_exit.default_config]
+      (** Stage-3 force-exit detector parameters (issue #872). Default
+          [{ hysteresis_weeks = 2 }] — fires on the second consecutive Friday
+          Stage-3 classification of a held long position. *)
+  enable_stage3_force_exit : bool; [@sexp.default false]
+      (** Master switch for the Stage-3 force-exit runner (issue #872). Default
+          [false] preserves all existing baselines: the runner is a no-op and
+          the strategy emits no [Stage3ForceExit] transitions. Flipping to
+          [true] activates {!Stage3_force_exit_runner.update} on every Friday
+          tick.
+
+          The opt-in default is intentional: enabling the mechanism produces new
+          exits and shifts every existing fixture's pinned numbers (trade count,
+          return, MaxDD). Re-pinning every goldens-sp500-historical scenario is
+          a separate post-merge step per the framing note's "Recommended
+          sequencing" (§3) in
+          [dev/notes/capital-recycling-framing-2026-05-06.md]. *)
+  stage3_reentry_cooldown_weeks : int; [@sexp.default 0]
+      (** Reserved for future tuning — currently unwired (default [0] = no
+          cooldown applied). Once wired, would suppress cascade re-admission of
+          a symbol force-exited under Stage 3 for [N] weeks beyond the existing
+          stop-out cooldown surface (#718). [0] is the book-aligned default
+          (§5.2 "STATE: EXITED — IF whipsaw … acceptable to re-buy"). The knob
+          exists on [config] so future tuning can flip it via sexp override
+          without a code change. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for
@@ -372,6 +411,7 @@ module Internal_for_test : sig
     prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
     sector_prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
     ticker_sectors:(string, string) Hashtbl.t ->
+    stage3_streaks:int Hashtbl.M(String).t ->
     audit_recorder:Audit_recorder.t ->
     get_price:Trading_strategy.Strategy_interface.get_price_fn ->
     get_indicator:Trading_strategy.Strategy_interface.get_indicator_fn ->
@@ -380,8 +420,8 @@ module Internal_for_test : sig
   (** Drives [_on_market_close] with all closure-scoped state passed in
       explicitly. Mutates [stop_states] / [last_stop_out_dates] / [prior_macro]
       / [prior_macro_result] / [peak_tracker] / [prior_stages] /
-      [sector_prior_stages] in place, mirroring the closure semantics in
-      {!make}. *)
+      [sector_prior_stages] / [stage3_streaks] in place, mirroring the closure
+      semantics in {!make}. *)
 
   val maybe_reset_halt :
     peak_tracker:Portfolio_risk.Force_liquidation.Peak_tracker.t ->

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -10,6 +10,7 @@
   test_macro_inputs
   test_panel_callbacks
   test_short_side_bear_window
+  test_stage3_force_exit_runner
   test_stops_runner
   test_stops_split_runner
   test_weekly_ma_cache

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
@@ -66,6 +66,7 @@ type _strategy_state = {
   prior_stages : stage Hashtbl.M(String).t;
   sector_prior_stages : stage Hashtbl.M(String).t;
   ticker_sectors : (string, string) Hashtbl.t;
+  stage3_streaks : int Hashtbl.M(String).t;
   bar_reader : Bar_reader.t;
 }
 (** Build a fresh closure-state bundle that mirrors what {!make} constructs
@@ -82,6 +83,7 @@ let _fresh_state ~bar_reader =
     prior_stages = Hashtbl.create (module String);
     sector_prior_stages = Hashtbl.create (module String);
     ticker_sectors = Hashtbl.create (module String);
+    stage3_streaks = Hashtbl.create (module String);
     bar_reader;
   }
 
@@ -102,7 +104,8 @@ let _drive_tick state ~config ~current_date ~portfolio =
     ~peak_tracker:state.peak_tracker ~bar_reader:state.bar_reader
     ~prior_stages:state.prior_stages
     ~sector_prior_stages:state.sector_prior_stages
-    ~ticker_sectors:state.ticker_sectors ~audit_recorder:Audit_recorder.noop
+    ~ticker_sectors:state.ticker_sectors ~stage3_streaks:state.stage3_streaks
+    ~audit_recorder:Audit_recorder.noop
     ~get_price:(_get_price_of_state state ~current_date)
     ~get_indicator:(fun _ _ _ _ -> None)
     ~portfolio

--- a/trading/trading/weinstein/strategy/test/test_stage3_force_exit_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stage3_force_exit_runner.ml
@@ -1,0 +1,331 @@
+open OUnit2
+open Core
+open Matchers
+open Weinstein_strategy
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let make_bar date ~close ?low ?high () =
+  let low = Option.value low ~default:(close *. 0.99) in
+  let high = Option.value high ~default:(close *. 1.01) in
+  {
+    Types.Daily_price.date = Date.of_string date;
+    open_price = close;
+    high_price = high;
+    low_price = low;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+let stage3 = Weinstein_types.Stage3 { weeks_topping = 1 }
+let stage2 = Weinstein_types.Stage2 { weeks_advancing = 5; late = false }
+let cfg_k2 = { Stage3_force_exit.hysteresis_weeks = 2 }
+
+(** Build a Position.t in the Holding state for [ticker] at [price]. Mirrors the
+    helper in [test_stops_runner.ml] but exposes only the fields the Stage-3
+    runner reads. *)
+let make_holding_pos ?(side = Trading_base.Types.Long) ticker price date =
+  let pos_id = ticker in
+  let make_trans kind =
+    { Trading_strategy.Position.position_id = pos_id; date; kind }
+  in
+  let unwrap = function
+    | Ok p -> p
+    | Error _ -> OUnit2.assert_failure "position setup failed"
+  in
+  let open Trading_strategy.Position in
+  let p =
+    create_entering
+      (make_trans
+         (CreateEntering
+            {
+              symbol = ticker;
+              side;
+              target_quantity = 10.0;
+              entry_price = price;
+              reasoning = ManualDecision { description = "test" };
+            }))
+    |> unwrap
+  in
+  let p =
+    apply_transition p
+      (make_trans (EntryFill { filled_quantity = 10.0; fill_price = price }))
+    |> unwrap
+  in
+  apply_transition p
+    (make_trans
+       (EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = None;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+let get_price_of bars symbol = List.Assoc.find bars symbol ~equal:String.equal
+let _friday = Date.of_string "2024-01-05" (* Friday *)
+let _monday = Date.of_string "2024-01-08" (* Monday *)
+
+(* ------------------------------------------------------------------ *)
+(* Off-cadence: non-Friday is a no-op                                   *)
+(* ------------------------------------------------------------------ *)
+
+let test_non_friday_no_op _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"AAPL" ~data:stage3;
+  let stage3_streaks = Hashtbl.create (module String) in
+  Hashtbl.set stage3_streaks ~key:"AAPL" ~data:1;
+  let exits =
+    Stage3_force_exit_runner.update ~config:cfg_k2 ~is_screening_day:false
+      ~positions
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-01-08" ~close:95.0 ()) ])
+      ~prior_stages ~stage3_streaks ~stop_exit_position_ids:String.Set.empty
+      ~current_date:_monday
+  in
+  assert_that exits is_empty;
+  (* Non-Friday call must not advance the streak counter. *)
+  assert_that (Hashtbl.find stage3_streaks "AAPL") (is_some_and (equal_to 1))
+
+(* ------------------------------------------------------------------ *)
+(* Empty positions: no exits                                            *)
+(* ------------------------------------------------------------------ *)
+
+let test_empty_positions_returns_empty _ =
+  let exits =
+    Stage3_force_exit_runner.update ~config:cfg_k2 ~is_screening_day:true
+      ~positions:String.Map.empty ~get_price:(get_price_of [])
+      ~prior_stages:(Hashtbl.create (module String))
+      ~stage3_streaks:(Hashtbl.create (module String))
+      ~stop_exit_position_ids:String.Set.empty ~current_date:_friday
+  in
+  assert_that exits is_empty
+
+(* ------------------------------------------------------------------ *)
+(* Long position: Stage 3 below hysteresis → no exit                    *)
+(* ------------------------------------------------------------------ *)
+
+let test_stage3_below_hysteresis_no_exit _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"AAPL" ~data:stage3;
+  let stage3_streaks = Hashtbl.create (module String) in
+  let exits =
+    Stage3_force_exit_runner.update ~config:cfg_k2 ~is_screening_day:true
+      ~positions
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-01-05" ~close:95.0 ()) ])
+      ~prior_stages ~stage3_streaks ~stop_exit_position_ids:String.Set.empty
+      ~current_date:_friday
+  in
+  (* First Stage-3 read brings streak to 1 < hysteresis_weeks = 2. *)
+  assert_that exits is_empty;
+  assert_that (Hashtbl.find stage3_streaks "AAPL") (is_some_and (equal_to 1))
+
+(* ------------------------------------------------------------------ *)
+(* Long position: Stage 3 at hysteresis → exit emitted                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_stage3_at_hysteresis_emits_exit _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"AAPL" ~data:stage3;
+  let stage3_streaks = Hashtbl.create (module String) in
+  Hashtbl.set stage3_streaks ~key:"AAPL" ~data:1;
+  (* prior streak = 1 — second Stage-3 read fires *)
+  let bar = make_bar "2024-01-05" ~close:97.5 () in
+  let exits =
+    Stage3_force_exit_runner.update ~config:cfg_k2 ~is_screening_day:true
+      ~positions
+      ~get_price:(get_price_of [ ("AAPL", bar) ])
+      ~prior_stages ~stage3_streaks ~stop_exit_position_ids:String.Set.empty
+      ~current_date:_friday
+  in
+  assert_that exits
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Trading_strategy.Position.transition) -> t.position_id)
+               (equal_to "AAPL");
+             field
+               (fun (t : Trading_strategy.Position.transition) -> t.date)
+               (equal_to _friday);
+             field
+               (fun (t : Trading_strategy.Position.transition) -> t.kind)
+               (matching ~msg:"Expected TriggerExit with Stage3ForceExit"
+                  (function
+                    | Trading_strategy.Position.TriggerExit
+                        {
+                          exit_reason =
+                            Trading_strategy.Position.Stage3ForceExit
+                              { weeks_in_stage3 };
+                          exit_price;
+                        } ->
+                        Some (weeks_in_stage3, exit_price)
+                    | _ -> None)
+                  (all_of
+                     [
+                       field (fun (w, _) -> w) (equal_to 2);
+                       field (fun (_, p) -> p) (float_equal 97.5);
+                     ]));
+           ];
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Short position: never triggers Stage 3 force exit                    *)
+(* ------------------------------------------------------------------ *)
+
+let test_short_position_never_emits_exit _ =
+  let pos =
+    make_holding_pos ~side:Trading_base.Types.Short "AAPL" 100.0 _friday
+  in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"AAPL" ~data:stage3;
+  let stage3_streaks = Hashtbl.create (module String) in
+  (* Pre-seed the streak above the threshold to make sure even a streak that
+     would fire on a long is suppressed for a short. *)
+  Hashtbl.set stage3_streaks ~key:"AAPL" ~data:5;
+  let exits =
+    Stage3_force_exit_runner.update ~config:cfg_k2 ~is_screening_day:true
+      ~positions
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-01-05" ~close:95.0 ()) ])
+      ~prior_stages ~stage3_streaks ~stop_exit_position_ids:String.Set.empty
+      ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  (* Streak counter stays at the pre-seeded 5 — the runner does not advance
+     state for shorts. *)
+  assert_that (Hashtbl.find stage3_streaks "AAPL") (is_some_and (equal_to 5))
+
+(* ------------------------------------------------------------------ *)
+(* Stop-out collision: position already exited via stops is skipped     *)
+(* ------------------------------------------------------------------ *)
+
+let test_skips_position_already_stop_exited _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"AAPL" ~data:stage3;
+  let stage3_streaks = Hashtbl.create (module String) in
+  Hashtbl.set stage3_streaks ~key:"AAPL" ~data:1;
+  let stop_exit_position_ids = String.Set.singleton pos.id in
+  let exits =
+    Stage3_force_exit_runner.update ~config:cfg_k2 ~is_screening_day:true
+      ~positions
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-01-05" ~close:95.0 ()) ])
+      ~prior_stages ~stage3_streaks ~stop_exit_position_ids
+      ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  (* Streak counter still advances even though the exit was suppressed —
+     accurate accounting against the stage stream is kept. *)
+  assert_that (Hashtbl.find stage3_streaks "AAPL") (is_some_and (equal_to 2))
+
+(* ------------------------------------------------------------------ *)
+(* Symbol missing from prior_stages: no exit                            *)
+(* ------------------------------------------------------------------ *)
+
+let test_unknown_symbol_in_prior_stages_no_exit _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  let stage3_streaks = Hashtbl.create (module String) in
+  let exits =
+    Stage3_force_exit_runner.update ~config:cfg_k2 ~is_screening_day:true
+      ~positions
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-01-05" ~close:95.0 ()) ])
+      ~prior_stages ~stage3_streaks ~stop_exit_position_ids:String.Set.empty
+      ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  (* Streak counter is not touched — there's no signal to record. *)
+  assert_that (Hashtbl.find stage3_streaks "AAPL") is_none
+
+(* ------------------------------------------------------------------ *)
+(* Stage 2 read resets the streak                                       *)
+(* ------------------------------------------------------------------ *)
+
+let test_stage2_read_resets_streak _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"AAPL" ~data:stage2;
+  let stage3_streaks = Hashtbl.create (module String) in
+  Hashtbl.set stage3_streaks ~key:"AAPL" ~data:7;
+  (* prior streak = 7 *)
+  let exits =
+    Stage3_force_exit_runner.update ~config:cfg_k2 ~is_screening_day:true
+      ~positions
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-01-05" ~close:95.0 ()) ])
+      ~prior_stages ~stage3_streaks ~stop_exit_position_ids:String.Set.empty
+      ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  assert_that (Hashtbl.find stage3_streaks "AAPL") (is_some_and (equal_to 0))
+
+(* ------------------------------------------------------------------ *)
+(* No bar from get_price: position skipped (no exit)                   *)
+(* ------------------------------------------------------------------ *)
+
+let test_missing_bar_skips_position _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"AAPL" ~data:stage3;
+  let stage3_streaks = Hashtbl.create (module String) in
+  Hashtbl.set stage3_streaks ~key:"AAPL" ~data:1;
+  let exits =
+    Stage3_force_exit_runner.update ~config:cfg_k2 ~is_screening_day:true
+      ~positions
+      ~get_price:(fun _ -> None)
+      ~prior_stages ~stage3_streaks ~stop_exit_position_ids:String.Set.empty
+      ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  (* Streak counter still advanced via observe_position. *)
+  assert_that (Hashtbl.find stage3_streaks "AAPL") (is_some_and (equal_to 2))
+
+(* ------------------------------------------------------------------ *)
+(* runner                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "stage3_force_exit_runner"
+  >::: [
+         "non-Friday is a no-op (does not advance streak)"
+         >:: test_non_friday_no_op;
+         "empty positions returns empty list"
+         >:: test_empty_positions_returns_empty;
+         "Stage 3 below hysteresis: no exit, streak advances to 1"
+         >:: test_stage3_below_hysteresis_no_exit;
+         "Stage 3 at hysteresis: emits TriggerExit with Stage3ForceExit"
+         >:: test_stage3_at_hysteresis_emits_exit;
+         "short position never emits exit, streak counter not touched"
+         >:: test_short_position_never_emits_exit;
+         "stops-already-exited position is skipped (streak still advances)"
+         >:: test_skips_position_already_stop_exited;
+         "symbol missing from prior_stages: no exit, streak unchanged"
+         >:: test_unknown_symbol_in_prior_stages_no_exit;
+         "Stage 2 read resets streak to 0" >:: test_stage2_read_resets_streak;
+         "missing bar from get_price: no exit, streak still advances"
+         >:: test_missing_bar_skips_position;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Implements the Stage-3-detection force exit (issue #872) to liberate
portfolio cash from mature long-runners whose 30-week MA has flattened.
Per Weinstein Ch. 6 §5.2 (STAGE3_TIGHTENING) extended to a full exit
rather than a stop tighten — frees cash for fresh Stage-2 candidates.

The mechanism is **opt-in**: \`enable_stage3_force_exit\` defaults to
\`false\` so existing baselines are bit-equivalent. Re-pinning under
\`true\` is a separate post-merge step per the framing note's
\"Recommended sequencing\" §3 (\`dev/notes/capital-recycling-framing-2026-05-06.md\`).

## What lands

### Pure detector — \`analysis/weinstein/stage3_force_exit/\`

\`\`\`ocaml
type config = { hysteresis_weeks : int }
type decision = Hold | Force_exit of { weeks_in_stage3 : int }

val observe :
  config:config ->
  prior_consecutive_stage3:int ->
  current_stage:Weinstein_types.stage ->
  int * decision

val observe_position :
  config:config ->
  state:(string, int) Core.Hashtbl.t ->
  symbol:string ->
  current_stage:Weinstein_types.stage ->
  decision
\`\`\`

The detector reuses the existing \`Stage.classify\` authority — no
re-implementation of the MA-flat / price-oscillation rules. Hysteresis
(K=2 default) requires two consecutive Friday Stage-3 reads before
firing — book-aligned with §5.2 STAGE3_TIGHTENING and avoids whipsaw.

### Strategy wiring — \`trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.{ml,mli}\`

Friday-only runner, long-positions only. Invoked AFTER \`Stops_runner.update\`
(stop-outs win) and BEFORE \`Force_liquidation_runner.update\` (freed cash
visible next tick). Skips positions already exiting via stops this tick.

### New \`exit_reason\` variant — \`Position.Stage3ForceExit { weeks_in_stage3 : int }\`

Added at the canonical place (\`trading/trading/strategy/lib/position.{ml,mli}\`).
Match-site updates (one variant per file):

- \`trading/trading/backtest/lib/stop_log.ml\` — \`exit_trigger_of_reason\` + \`classify_stop_trigger_kind\`
- \`trading/trading/backtest/lib/result_writer.ml\` — \`_exit_trigger_label → \"stage3_force_exit\"\`
- \`trading/trading/backtest/trade_audit_report/trade_audit_report.ml\` — same label

Audit trail: a Stage-3 force exit shows up in \`trades.csv\` as
\`exit_trigger = \"stage3_force_exit\"\`, distinct from stop-loss /
take-profit / portfolio-rebalancing.

### Strategy config — three new fields

- \`stage3_force_exit_config : Stage3_force_exit.config\` (default \`{ hysteresis_weeks = 2 }\`)
- \`enable_stage3_force_exit : bool\` (default \`false\`)
- \`stage3_reentry_cooldown_weeks : int\` (default \`0\` — reserved knob, currently unwired)

## How this PR answers the framing-note design questions

| Q | Answer |
|---|---|
| Q1 (Stage-3 detection signature) | Reuse existing \`Stage.classify\` + hysteresis on top. K=2 default. |
| Q3 (priority vs stops) | Stops fire first; Stage 3 runs after \`stops_runner\` and skips \`stop_exit_position_ids\`. Documented in \`.mli\`. |
| Q4 (interaction with exit reasons) | New \`Stage3ForceExit\` variant — does NOT collapse into existing reasons. Per-trade attribution stays explicit. |
| Q5 (re-entry) | No cooldown wired in this PR. \`stage3_reentry_cooldown_weeks = 0\` reserved for future tuning. Existing #718 cooldown does NOT trigger on Stage 3 (only on \`StopLoss\`). |
| Q6 (acceptance gate) | Not gated by this PR — runner is opt-in. Re-pinning under \`enable=true\` is the post-merge step per the framing note. |

## 5y baseline (acceptance pinning)

Ran \`scenario_runner --dir test_data/backtest_scenarios/goldens-sp500/\` with my changes
(default \`enable_stage3_force_exit = false\`):

\`\`\`
sp500-2019-2023        53.4%      73    21.9%    32.5%   PASS
\`\`\`

Pinned acceptance band: \`total_return_pct ∈ [45.0, 72.0]\`, \`total_trades ∈ [70, 95]\`.
Result is **inside** the pinned band — no regression. (The pinned
\"current\" central value is 58.34% / 81 trades; my snapshot at 53.4% / 73
sits in the lower portion of the band but well within tolerance and
PASSes the runner's gate.)

The opt-in default ensures any user-visible behavior change requires
explicit \`enable_stage3_force_exit = true\` in the scenario sexp.

## Tests

- \`test_stage3_force_exit.ml\` — 16 unit tests (pure detector + symbol-keyed wrapper)
- \`test_stage3_force_exit_runner.ml\` — 9 unit tests (Friday cadence, long-only, stops collision, missing bar, stage-2 reset)
- \`test_force_liquidation_strategy.ml\` — updated to thread the new \`stage3_streaks\` parameter through \`Internal_for_test.on_market_close\`

\`\`\`
analysis/weinstein/stage3_force_exit/test       16/16 OK
trading/weinstein/strategy/test/                49/49 OK (includes 9 new + 40 prior)
\`\`\`

\`dune build && dune runtest\` green.

## LOC

~432 source / ~556 tests / ~988 total insertions. Within scope target.

## Files

\`\`\`
analysis/weinstein/stage3_force_exit/lib/{dune,stage3_force_exit.ml,stage3_force_exit.mli}
analysis/weinstein/stage3_force_exit/test/{dune,test_stage3_force_exit.ml}
trading/strategy/lib/position.{ml,mli}
trading/backtest/lib/{stop_log.{ml,mli},result_writer.ml}
trading/backtest/trade_audit_report/trade_audit_report.ml
trading/weinstein/strategy/lib/{dune,stage3_force_exit_runner.{ml,mli},weinstein_strategy.{ml,mli}}
trading/weinstein/strategy/test/{dune,test_force_liquidation_strategy.ml,test_stage3_force_exit_runner.ml}
\`\`\`

## Test plan

- [x] Pure detector unit tests pass (16/16)
- [x] Strategy runner unit tests pass (9/9)
- [x] \`dune build && dune runtest\` green across the workspace
- [x] 5y baseline scenario PASSes with \`enable_stage3_force_exit = false\` (default opt-in preserves baseline)
- [ ] Post-merge: re-baseline goldens-sp500-historical scenarios with \`enable_stage3_force_exit = true\` (separate PR per framing-note §3)

## Refs

- Issue #872
- \`dev/notes/capital-recycling-framing-2026-05-06.md\` — framing + design questions
- \`dev/notes/856-optimal-strategy-diagnostic-15y-2026-05-06.md\` — empirical motivation
- \`docs/design/weinstein-book-reference.md\` §1, §5.2 — book authority