### PR TITLE
refactor(position): generic StrategySignal exit_reason variant (PR #902 A1 follow-up)

### DIFF
--- a/trading/analysis/weinstein/stage3_force_exit/lib/stage3_force_exit.mli
+++ b/trading/analysis/weinstein/stage3_force_exit/lib/stage3_force_exit.mli
@@ -30,8 +30,8 @@
       variants) and pass the result in.
     - Does NOT generate the [Position.transition] — the strategy wiring layer
       builds the {!Position.TriggerExit} with the
-      {!Position.exit_reason.Stage3ForceExit} variant once this detector decides
-      [Force_exit].
+      {!Position.exit_reason.StrategySignal} variant
+      ([label = "stage3_force_exit"]) once this detector decides [Force_exit].
     - Does NOT touch trailing-stop state. A position force-exited under this
       mechanism leaves its stop state stale; the wiring layer is responsible for
       the cleanup (typically by removing the stop-state entry on exit).
@@ -68,7 +68,8 @@ type decision =
       (** Stage 3 has been observed for [weeks_in_stage3] consecutive Friday
           classifications and [weeks_in_stage3 >= config.hysteresis_weeks]. The
           strategy wiring layer should emit a [Position.TriggerExit] with
-          [exit_reason = Stage3ForceExit { weeks_in_stage3 }]. *)
+          [exit_reason = StrategySignal { label = "stage3_force_exit"; detail }]
+          where [detail] encodes [weeks_in_stage3]. *)
 [@@deriving show, eq]
 
 val observe :

--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -56,7 +56,7 @@ let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
   | Time_expired _ -> "time_expired"
   | Underperforming _ -> "underperforming"
   | Portfolio_rebalancing -> "rebalancing"
-  | Stage3_force_exit _ -> "stage3_force_exit"
+  | Strategy_signal { label; _ } -> label
   | End_of_period -> "end_of_period"
 
 (** Build a (symbol, exit_date) -> reason map from force-liquidation events.

--- a/trading/trading/backtest/lib/stop_log.ml
+++ b/trading/trading/backtest/lib/stop_log.ml
@@ -10,7 +10,7 @@ type exit_trigger =
   | Time_expired of { days_held : int; max_days : int }
   | Underperforming of { days_held : int; current_return : float }
   | Portfolio_rebalancing
-  | Stage3_force_exit of { weeks_in_stage3 : int }
+  | Strategy_signal of { label : string; detail : string option }
   | End_of_period
 [@@deriving show, eq, sexp]
 
@@ -53,7 +53,7 @@ let exit_trigger_of_reason (reason : Position.exit_reason) : exit_trigger =
   | Underperforming { days_held; current_return } ->
       Underperforming { days_held; current_return }
   | PortfolioRebalancing -> Portfolio_rebalancing
-  | Stage3ForceExit { weeks_in_stage3 } -> Stage3_force_exit { weeks_in_stage3 }
+  | StrategySignal { label; detail } -> Strategy_signal { label; detail }
 
 type stop_trigger_kind = Gap_down | Intraday | End_of_period | Non_stop_exit
 [@@deriving show, eq, sexp]
@@ -75,7 +75,7 @@ let classify_stop_trigger_kind ?(gap_threshold_pct = gap_down_threshold_pct)
       else Intraday
   | End_of_period -> End_of_period
   | Take_profit _ | Signal_reversal _ | Time_expired _ | Underperforming _
-  | Portfolio_rebalancing | Stage3_force_exit _ ->
+  | Portfolio_rebalancing | Strategy_signal _ ->
       Non_stop_exit
 
 let _fresh_record ~symbol =

--- a/trading/trading/backtest/lib/stop_log.mli
+++ b/trading/trading/backtest/lib/stop_log.mli
@@ -27,11 +27,13 @@ type exit_trigger =
   | Underperforming of { days_held : int; current_return : float }
       (** Position underperformed *)
   | Portfolio_rebalancing  (** Closed for rebalancing *)
-  | Stage3_force_exit of { weeks_in_stage3 : int }
-      (** Strategy-driven force exit fired after the position was classified as
-          Stage 3 for [weeks_in_stage3] consecutive Friday classifications (≥
-          the configured hysteresis window). Capital-recycling exit per
-          Weinstein Ch. 6 §5.2 (issue #872). *)
+  | Strategy_signal of { label : string; detail : string option }
+      (** Strategy-emitted exit reason — mirrors
+          {!Position.exit_reason.StrategySignal}. [label] is the stable string
+          identifier surfaced as the [exit_trigger] column value in [trades.csv]
+          (e.g. ["stage3_force_exit"]). [detail] carries an optional
+          strategy-side payload that downstream tuner / audit tools can inspect
+          (e.g. ["weeks_in_stage3=3"]) — the trades.csv writer ignores it. *)
   | End_of_period
       (** Position was force-closed at the end of the backtest period without a
           preceding strategy-emitted [TriggerExit]. The simulator's end-of-run
@@ -92,7 +94,8 @@ val classify_stop_trigger_kind :
 
     The {!End_of_period} variant maps to {!stop_trigger_kind.End_of_period}. All
     other variants ({!Take_profit}, {!Signal_reversal}, {!Time_expired},
-    {!Underperforming}, {!Portfolio_rebalancing}) classify as {!Non_stop_exit}.
+    {!Underperforming}, {!Portfolio_rebalancing}, {!Strategy_signal}) classify
+    as {!Non_stop_exit}.
 
     [gap_threshold_pct] defaults to {!gap_down_threshold_pct}. Pure function —
     same inputs always produce the same output. *)

--- a/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
+++ b/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
@@ -85,7 +85,7 @@ let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
   | Time_expired _ -> "time_expired"
   | Underperforming _ -> "underperforming"
   | Portfolio_rebalancing -> "rebalancing"
-  | Stage3_force_exit _ -> "stage3_force_exit"
+  | Strategy_signal { label; _ } -> label
   | End_of_period -> "end_of_period"
 
 let _row_of_trade audit_idx (trade : Trading_simulation.Metrics.trade_metrics) :

--- a/trading/trading/strategy/lib/position.ml
+++ b/trading/trading/strategy/lib/position.ml
@@ -34,7 +34,7 @@ type exit_reason =
   | TimeExpired of { days_held : int; max_days : int }
   | Underperforming of { days_held : int; current_return : float }
   | PortfolioRebalancing
-  | Stage3ForceExit of { weeks_in_stage3 : int }
+  | StrategySignal of { label : string; detail : string option }
 [@@deriving show, eq]
 
 type position_state =

--- a/trading/trading/strategy/lib/position.mli
+++ b/trading/trading/strategy/lib/position.mli
@@ -158,14 +158,20 @@ type exit_reason =
   | TimeExpired of { days_held : int; max_days : int }
   | Underperforming of { days_held : int; current_return : float }
   | PortfolioRebalancing
-  | Stage3ForceExit of { weeks_in_stage3 : int }
-      (** Strategy-driven exit fired after a held position has been classified
-          as Stage 3 ("topping / distribution" — 30-week MA flattening) for at
-          least the configured hysteresis window. Capital-recycling mechanism
-          per Weinstein Ch. 6 §5.2 (STAGE3_TIGHTENING) extended to a full exit
-          rather than a stop tighten — frees cash for fresh Stage-2 candidates
-          (issue #872). [weeks_in_stage3] is the consecutive count of Stage-3
-          classifications observed at the moment the exit fires. *)
+  | StrategySignal of { label : string; detail : string option }
+      (** Strategy-emitted exit reason for cases that don't map onto one of the
+          generic variants above. The shared core stays strategy-agnostic: any
+          strategy can emit a {!StrategySignal} without adding a new variant
+          here.
+
+          - [label]: short identifier suitable for the [exit_trigger] column of
+            backtest output (e.g. ["stage3_force_exit"], ["regime_change"]).
+            Stable per strategy-side trigger so downstream tooling can group
+            exits by reason.
+          - [detail]: optional free-form payload — typically a small
+            [key=value] string the strategy uses to encode salient context
+            (e.g. ["weeks_in_stage3=3"]). Consumers that only label the exit
+            (trades.csv writer, audit report) ignore [detail]. *)
 [@@deriving show, eq]
 
 (** Position state variants - only state-specific data *)

--- a/trading/trading/strategy/lib/position.mli
+++ b/trading/trading/strategy/lib/position.mli
@@ -168,9 +168,9 @@ type exit_reason =
             backtest output (e.g. ["stage3_force_exit"], ["regime_change"]).
             Stable per strategy-side trigger so downstream tooling can group
             exits by reason.
-          - [detail]: optional free-form payload — typically a small
-            [key=value] string the strategy uses to encode salient context
-            (e.g. ["weeks_in_stage3=3"]). Consumers that only label the exit
+          - [detail]: optional free-form payload — typically a small [key=value]
+            string the strategy uses to encode salient context (e.g.
+            ["weeks_in_stage3=3"]). Consumers that only label the exit
             (trades.csv writer, audit report) ignore [detail]. *)
 [@@deriving show, eq]
 

--- a/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml
@@ -5,11 +5,22 @@ open Trading_strategy
     at the close of the current bar — same convention as a stop hit that fills
     at the bar's worst-case price (book §5.2 reads: "stop is hit → sell, no
     questions asked"). For a discretionary force exit at the close,
-    [bar.close_price] is the most defensible fill marker. *)
+    [bar.close_price] is the most defensible fill marker.
+
+    The emitted [exit_reason] uses the generic
+    {!Position.exit_reason.StrategySignal} variant with
+    [label = "stage3_force_exit"] — this label is the value surfaced in the
+    [exit_trigger] column of [trades.csv]. *)
 let _make_exit_transition ~(pos : Position.t) ~current_date ~bar
     ~weeks_in_stage3 =
   let exit_price = bar.Types.Daily_price.close_price in
-  let exit_reason = Position.Stage3ForceExit { weeks_in_stage3 } in
+  let exit_reason =
+    Position.StrategySignal
+      {
+        label = "stage3_force_exit";
+        detail = Some (Printf.sprintf "weeks_in_stage3=%d" weeks_in_stage3);
+      }
+  in
   {
     Position.position_id = pos.id;
     date = current_date;

--- a/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.mli
@@ -54,9 +54,10 @@ val update :
     - Skips the position if its [position_id] is in [stop_exit_position_ids] —
       the stops runner already exited it this tick.
     - Otherwise emits a [TriggerExit] transition with
-      [exit_reason = Stage3ForceExit { weeks_in_stage3 }] and
-      [exit_price = bar.close_price] from [get_price]. When [get_price] returns
-      [None] the position is silently skipped.
+      [exit_reason = StrategySignal { label = "stage3_force_exit"; detail = Some
+       "weeks_in_stage3=N" }] and [exit_price = bar.close_price] from
+      [get_price]. When [get_price] returns [None] the position is silently
+      skipped.
     - Short positions and non-Holding states are skipped without emitting, and
       their entry in [stage3_streaks] is left untouched. This keeps the streak
       counter accurate if the position later transitions back into Holding.

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -76,8 +76,9 @@ type config = {
   enable_stage3_force_exit : bool; [@sexp.default false]
       (** Master switch for the Stage-3 force-exit runner. Default [false]
           preserves all existing baselines: the runner is a no-op and the
-          strategy emits no [Stage3ForceExit] transitions. Flipping to [true]
-          activates {!Stage3_force_exit_runner.update} on every Friday tick. *)
+          strategy emits no [StrategySignal "stage3_force_exit"] transitions.
+          Flipping to [true] activates {!Stage3_force_exit_runner.update} on
+          every Friday tick. *)
   stage3_reentry_cooldown_weeks : int; [@sexp.default 0]
       (** Reserved for future tuning — currently unwired (default [0] = no
           cooldown applied). Once wired, would suppress cascade re-admission of

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -208,9 +208,9 @@ type config = {
   enable_stage3_force_exit : bool; [@sexp.default false]
       (** Master switch for the Stage-3 force-exit runner (issue #872). Default
           [false] preserves all existing baselines: the runner is a no-op and
-          the strategy emits no [Stage3ForceExit] transitions. Flipping to
-          [true] activates {!Stage3_force_exit_runner.update} on every Friday
-          tick.
+          the strategy emits no [StrategySignal "stage3_force_exit"]
+          transitions. Flipping to [true] activates
+          {!Stage3_force_exit_runner.update} on every Friday tick.
 
           The opt-in default is intentional: enabling the mechanism produces new
           exits and shifts every existing fixture's pinned numbers (trade count,

--- a/trading/trading/weinstein/strategy/test/test_stage3_force_exit_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stage3_force_exit_runner.ml
@@ -164,21 +164,26 @@ let test_stage3_at_hysteresis_emits_exit _ =
                (equal_to _friday);
              field
                (fun (t : Trading_strategy.Position.transition) -> t.kind)
-               (matching ~msg:"Expected TriggerExit with Stage3ForceExit"
+               (matching
+                  ~msg:
+                    "Expected TriggerExit with StrategySignal stage3_force_exit"
                   (function
                     | Trading_strategy.Position.TriggerExit
                         {
                           exit_reason =
-                            Trading_strategy.Position.Stage3ForceExit
-                              { weeks_in_stage3 };
+                            Trading_strategy.Position.StrategySignal
+                              { label; detail };
                           exit_price;
                         } ->
-                        Some (weeks_in_stage3, exit_price)
+                        Some (label, detail, exit_price)
                     | _ -> None)
                   (all_of
                      [
-                       field (fun (w, _) -> w) (equal_to 2);
-                       field (fun (_, p) -> p) (float_equal 97.5);
+                       field (fun (l, _, _) -> l) (equal_to "stage3_force_exit");
+                       field
+                         (fun (_, d, _) -> d)
+                         (is_some_and (equal_to "weeks_in_stage3=2"));
+                       field (fun (_, _, p) -> p) (float_equal 97.5);
                      ]));
            ];
        ])
@@ -315,7 +320,8 @@ let suite =
          >:: test_empty_positions_returns_empty;
          "Stage 3 below hysteresis: no exit, streak advances to 1"
          >:: test_stage3_below_hysteresis_no_exit;
-         "Stage 3 at hysteresis: emits TriggerExit with Stage3ForceExit"
+         "Stage 3 at hysteresis: emits TriggerExit with \
+          StrategySignal(stage3_force_exit)"
          >:: test_stage3_at_hysteresis_emits_exit;
          "short position never emits exit, streak counter not touched"
          >:: test_short_position_never_emits_exit;


### PR DESCRIPTION
## Summary

Addresses the qc-behavioral A1 finding from PR #902 (`dev/reviews/pr-902.md`):
the `Position.exit_reason.Stage3ForceExit { weeks_in_stage3 : int }` variant
leaked Weinstein-specific naming and semantics into the strategy-agnostic core
`Position` module.

This PR replaces it with a generic shape that any strategy can use without
modifying the shared `Position` type:

```ocaml
| StrategySignal of { label : string; detail : string option }
```

The Weinstein Stage-3 producer (`stage3_force_exit_runner.ml`) now builds:

```ocaml
StrategySignal {
  label = "stage3_force_exit";
  detail = Some (sprintf "weeks_in_stage3=%d" weeks_in_stage3);
}
```

The on-disk `exit_trigger` column in `trades.csv` continues to emit the
string `"stage3_force_exit"` — bit-identical to PR #902's output.

## Files changed

Core:
- `trading/trading/strategy/lib/position.{ml,mli}` — variant rename.

Audit / backtest reporting (downstream of `Position`):
- `trading/trading/backtest/lib/stop_log.{ml,mli}` — mirror rename
  (`Stage3_force_exit { weeks_in_stage3 }` → `Strategy_signal { label; detail }`).
- `trading/trading/backtest/lib/result_writer.ml` — `_exit_trigger_label`
  becomes a label-pass-through.
- `trading/trading/backtest/trade_audit_report/trade_audit_report.ml` — same
  pass-through.

Producer + tests:
- `trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml` — emits
  the new variant with the same `\"stage3_force_exit\"` label.
- `trading/trading/weinstein/strategy/test/test_stage3_force_exit_runner.ml` —
  Stage-3 hysteresis-emit test now asserts on `(label, detail, exit_price)`
  shape.

Doc references updated:
- `trading/analysis/weinstein/stage3_force_exit/lib/stage3_force_exit.mli`
- `trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.mli`
- `trading/trading/weinstein/strategy/lib/weinstein_strategy.{ml,mli}`

## Bit-equivalence verification (5y SP500 baseline)

Default config (Stage-3 OFF):
```
sp500-2019-2023                 58.3%      81    19.8%    33.6%   PASS
```
Matches the prior 58.34% / 81 trades baseline pinned in `sp500-2019-2023.sexp`.

Feature ON (one-off measurement):
```
sp500-2019-2023-stage3on        54.9%     128    26.6%    28.9%   PASS
```
Trade count rises (capital recycling), MaxDD drops, win-rate improves.
22 of the 128 round-trips have `exit_trigger=stage3_force_exit` in
`trades.csv` — label is bit-identical to PR #902.

## Why the audit-side `Stop_log.exit_trigger` was renamed too

The audit-side variant in `stop_log.{ml,mli}` mirrored the core variant name.
Now that the core uses `StrategySignal`, the audit-side mirror is renamed to
`Strategy_signal { label; detail }` so:

1. Adding a new strategy-side trigger no longer requires editing `stop_log`,
   `result_writer`, or `trade_audit_report`.
2. The existing `_exit_trigger_label` consumers become a one-line pass-through
   of the embedded `label` — no per-strategy match arms.

## Why core `Position` is touched (qc-structural A1 will FLAG)

This is the explicit point of the refactor: the new variant is
strategy-agnostic, so qc-behavioral A1 should PASS even though qc-structural
flags A1 (core module modification).

## Test plan

- [x] `dune build` — clean.
- [x] `dune runtest` — all existing tests pass (incl. Stage-3 unit tests
  updated for the new variant shape).
- [x] `dune build @fmt` — clean for all files in this PR. (Pre-existing local
  vs CI ocamlformat skew on unrelated `position.mli` Usage Example block,
  `grid_search_spec.mli`, `test_helpers.ml` etc. is left for CI per
  `project_ocamlformat_version_skew` memory.)
- [x] 5y SP500 default-OFF baseline matches 58.34% / 81 trades.
- [x] 5y SP500 feature-ON measurement reported (54.9% / 128 trades / 22
  stage3_force_exit rows in trades.csv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>