### PR TITLE
feat(strategy): laggard rotation — lighten up before stop-out (issue #887)

### DIFF
--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -193,6 +193,38 @@ Wire short-side entries into `Weinstein_strategy` so the simulation emits short 
      is currently unwired — placeholder for future RS-conditioned
      tuning.
 
+9. **#887 — Laggard rotation detector for capital recycling on the
+   long side** (filed 2026-05-06, PR #909, `feat-weinstein` scope).
+   Implements Weinstein Ch.4 §portfolio sizing rotation rule (book-ref
+   §5.6): "if it's lagging badly and acting poorly, lighten up on that
+   position even if the sell-stop isn't hit. Move the proceeds into a
+   new Stage 2 stock with greater promise." Distinct from #872 — fires
+   mid-Stage-2 on weak RS-vs-benchmark behaviour alone, before the
+   30-week MA flattens. Complementary mechanism per the framing-note
+   table (Stage-2-weak-RS region in the position-state matrix).
+   - **Pure detector**: `analysis/weinstein/laggard_rotation/` —
+     observes position 13-week return vs benchmark 13-week return,
+     emits `Laggard_exit` after K=4 consecutive Friday negative-RS
+     reads (configurable). 19 unit tests pinning hysteresis edges
+     (K=1/4/6/0/negative defensive), tied-RS reset, whipsaw reset,
+     bear-market both-negative comparison, per-symbol wrapper isolation.
+   - **Strategy wiring**: new `Laggard_rotation_runner` between
+     `Stage3_force_exit_runner.update` and the entry walk. Friday
+     cadence; long-only; skips positions already exiting via stops or
+     Stage-3 on the same tick (skip-list = `stop_exited_ids ∪
+     stage3_exited_ids`). 11 unit tests pinning the wiring contract.
+   - **Generic `StrategySignal` exit_reason**: emitted with
+     `label = "laggard_rotation"; detail = Some "rs_13w_neg_weeks=N"`
+     — no new variant added (per framing-note Q4 + PR #907 plumbing).
+   - **Opt-in via** `enable_laggard_rotation : bool` config field
+     (default `false`). 5y baseline `sp500-2019-2023` runs path-
+     equivalent at default OFF (runner is a no-op without code-path
+     entry); pinned baseline 58.34% / 81 trades preserved.
+   - Reserved knob `laggard_reentry_cooldown_weeks` defaults to 0 and
+     is currently unwired — placeholder for future tuning.
+   - Re-pinning under `enable=true` is a separate post-merge step per
+     `dev/notes/capital-recycling-framing-2026-05-06.md` §3.
+
 ## References
 
 - `docs/design/weinstein-book-reference.md` Ch. 11 — bear-market shorting rules (never short Stage 2; only Stage 4 with negative RS + bearish macro).

--- a/trading/analysis/weinstein/laggard_rotation/lib/dune
+++ b/trading/analysis/weinstein/laggard_rotation/lib/dune
@@ -1,0 +1,6 @@
+(library
+ (name laggard_rotation)
+ (public_name weinstein.laggard_rotation)
+ (libraries core)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/analysis/weinstein/laggard_rotation/lib/laggard_rotation.ml
+++ b/trading/analysis/weinstein/laggard_rotation/lib/laggard_rotation.ml
@@ -1,0 +1,47 @@
+open Core
+
+type config = { hysteresis_weeks : int; rs_window_weeks : int }
+[@@deriving sexp]
+
+let _default_hysteresis_weeks = 4
+let _default_rs_window_weeks = 13
+
+let default_config =
+  {
+    hysteresis_weeks = _default_hysteresis_weeks;
+    rs_window_weeks = _default_rs_window_weeks;
+  }
+
+type decision = Hold | Laggard_exit of { rs_13w_neg_weeks : int }
+[@@deriving show, eq]
+
+(** Effective hysteresis floor: a non-positive [config.hysteresis_weeks] would
+    otherwise short-circuit the detector. Treat any [<= 0] as [1] — a single
+    negative-RS observation fires immediately. The default is positive (4). *)
+let _effective_threshold ~config =
+  if config.hysteresis_weeks <= 0 then 1 else config.hysteresis_weeks
+
+let observe ~config ~prior_consecutive_neg_rs ~position_13w_return
+    ~benchmark_13w_return =
+  if Float.( < ) position_13w_return benchmark_13w_return then
+    let new_count = prior_consecutive_neg_rs + 1 in
+    let threshold = _effective_threshold ~config in
+    let decision =
+      if new_count >= threshold then
+        Laggard_exit { rs_13w_neg_weeks = new_count }
+      else Hold
+    in
+    (new_count, decision)
+  else (0, Hold)
+
+let observe_position ~config ~state ~symbol ~position_13w_return
+    ~benchmark_13w_return =
+  let prior_consecutive_neg_rs =
+    Hashtbl.find state symbol |> Option.value ~default:0
+  in
+  let new_count, decision =
+    observe ~config ~prior_consecutive_neg_rs ~position_13w_return
+      ~benchmark_13w_return
+  in
+  Hashtbl.set state ~key:symbol ~data:new_count;
+  decision

--- a/trading/analysis/weinstein/laggard_rotation/lib/laggard_rotation.mli
+++ b/trading/analysis/weinstein/laggard_rotation/lib/laggard_rotation.mli
@@ -1,0 +1,130 @@
+(** Laggard-rotation detector — capital recycling on the long side (#887).
+
+    Per Weinstein Ch. 4 §portfolio sizing (~lines 4929–4933), surfaced as §5.6
+    in [docs/design/weinstein-book-reference.md]:
+
+    > "If it's lagging badly and acting poorly, lighten up on that position >
+    even if the sell-stop isn't hit. Move the proceeds into a new Stage 2 >
+    stock with greater promise."
+
+    Distinct from the Stage-3 force exit (#872): laggard rotation fires
+    {b mid-Stage-2}, before the 30-week MA flattens, on weak relative-strength
+    behaviour alone. The empirical motivation is identical (long-runners that
+    never stop out lock cash that the cascade keeps rejecting candidates against
+    because of [Insufficient_cash] — see
+    [dev/notes/capital-recycling-framing-2026-05-06.md] §"Two proposed
+    mechanisms"), but the trigger is RS-vs-market, not stage transition.
+
+    {1 Detection signature}
+
+    A position is a {b laggard} when its rolling 13-week return minus the
+    benchmark's rolling 13-week return (i.e. relative strength over the
+    intermediate-term window) has been
+    {b negative for at least [config.hysteresis_weeks] consecutive Friday
+       observations}. Any positive or zero RS reading resets the
+    consecutive-negative count to zero.
+
+    The 13-week window matches the Weinstein-canonical "intermediate-term"
+    horizon used elsewhere in the strategy and is the smallest window that
+    smooths through one earnings-season noise pulse.
+
+    {1 What the module does NOT do}
+
+    - Does NOT compute the 13-week returns itself — call [Bar_reader] (or any
+      bar source) to read the position's and benchmark's weekly close sequences
+      and pass the computed returns in.
+    - Does NOT generate the [Position.transition] — the strategy wiring layer
+      builds the [Position.TriggerExit] with the
+      [Position.exit_reason.StrategySignal] variant
+      ([label = "laggard_rotation"]) once this detector decides [Laggard_exit].
+    - Does NOT touch trailing-stop state. A position rotated under this
+      mechanism leaves its stop state stale; the wiring layer is responsible for
+      any cleanup (typically by removing the stop-state entry on exit).
+    - Does NOT apply to short positions. Short-side relative-strength semantics
+      are inverted (short profits when RS is negative — exactly the laggard
+      signal here would mean the short is winning), so the runner filters to
+      long positions only and the detector itself takes no side argument. *)
+
+type config = {
+  hysteresis_weeks : int;
+      (** Number of consecutive negative-RS Friday observations required before
+          the detector emits [Laggard_exit]. Default 4 (issue #887:
+          "configurable; e.g., 4-6 weeks").
+
+          - K = 1 fires on first negative-RS observation — most aggressive,
+            prone to whipsaw on a single noisy week.
+          - K = 4 (default) requires roughly one trading month of negative
+            relative strength. Book-aligned with §5.6 "lagging badly" — a single
+            down week is not "lagging badly".
+          - K ≥ 6 is more conservative; trades alpha for stability. *)
+  rs_window_weeks : int;
+      (** Rolling window (in weeks) over which the position's return is compared
+          to the benchmark's return. Default 13 — Weinstein-canonical
+          intermediate-term horizon. *)
+}
+[@@deriving sexp]
+
+val default_config : config
+(** Defaults: [{ hysteresis_weeks = 4; rs_window_weeks = 13 }]. *)
+
+(** Decision emitted by {!observe}. *)
+type decision =
+  | Hold
+      (** Either current RS is non-negative, or the consecutive-negative-RS
+          count has not yet reached [config.hysteresis_weeks]. The caller takes
+          no exit action. *)
+  | Laggard_exit of { rs_13w_neg_weeks : int }
+      (** RS has been negative for [rs_13w_neg_weeks] consecutive Friday
+          observations and [rs_13w_neg_weeks >= config.hysteresis_weeks]. The
+          strategy wiring layer should emit a [Position.TriggerExit] with
+          [exit_reason = StrategySignal { label = "laggard_rotation"; detail }]
+          where [detail] encodes [rs_13w_neg_weeks]. *)
+[@@deriving show, eq]
+
+val observe :
+  config:config ->
+  prior_consecutive_neg_rs:int ->
+  position_13w_return:float ->
+  benchmark_13w_return:float ->
+  int * decision
+(** [observe ~config ~prior_consecutive_neg_rs ~position_13w_return
+     ~benchmark_13w_return] is the pure state-transition core of the detector.
+
+    Returns a pair [(new_consecutive_neg_rs, decision)]:
+    - When [position_13w_return < benchmark_13w_return] (strict — RS is
+      negative): increments the consecutive count and emits [Laggard_exit] iff
+      the new count [>= config.hysteresis_weeks].
+    - When [position_13w_return >= benchmark_13w_return] (RS is zero or
+      positive): resets the consecutive count to [0] and emits [Hold].
+
+    Pure function — same inputs always produce the same outputs.
+
+    The detector treats RS as a strict comparison: a tied RS (both returns
+    equal) resets the counter rather than continuing the streak. This avoids
+    streak persistence on a perfectly-correlated tracker that happens to match
+    the benchmark exactly — a tracking position is not "lagging badly".
+
+    Edge case: when [config.hysteresis_weeks <= 0], the function treats
+    [hysteresis_weeks = 1] (a single negative-RS observation fires immediately).
+    Defensive — a non-positive hysteresis would otherwise disable the detector
+    entirely. The default config has K = 4; callers are expected to pass a
+    positive value. *)
+
+(** {1 Symbol-keyed convenience wrapper} *)
+
+val observe_position :
+  config:config ->
+  state:(string, int) Core.Hashtbl.t ->
+  symbol:string ->
+  position_13w_return:float ->
+  benchmark_13w_return:float ->
+  decision
+(** [observe_position ~config ~state ~symbol ~position_13w_return
+     ~benchmark_13w_return] looks up the prior consecutive-negative-RS count for
+    [symbol] in [state] (defaulting to [0] when missing), calls {!observe}, then
+    writes the new count back into [state]. Mutates [state] in place. Returns
+    the [decision].
+
+    Parallel to the [stage3_streaks] table threaded through
+    [Stage3_force_exit_runner] — kept as a separate hashtable so the detector's
+    state is independent of the Stage-3 detector's streak threading. *)

--- a/trading/analysis/weinstein/laggard_rotation/test/dune
+++ b/trading/analysis/weinstein/laggard_rotation/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_laggard_rotation)
+ (libraries weinstein.laggard_rotation core ounit2 matchers))

--- a/trading/analysis/weinstein/laggard_rotation/test/test_laggard_rotation.ml
+++ b/trading/analysis/weinstein/laggard_rotation/test/test_laggard_rotation.ml
@@ -1,0 +1,275 @@
+open OUnit2
+open Core
+open Matchers
+open Laggard_rotation
+
+(* --- helpers --- *)
+
+let cfg_k4 = { hysteresis_weeks = 4; rs_window_weeks = 13 }
+let cfg_k1 = { hysteresis_weeks = 1; rs_window_weeks = 13 }
+let cfg_k6 = { hysteresis_weeks = 6; rs_window_weeks = 13 }
+
+(* --- pure observe --- *)
+
+let test_observe_positive_rs_returns_hold _ =
+  (* Position outperforms benchmark — RS positive — Hold, count resets. *)
+  assert_that
+    (observe ~config:cfg_k4 ~prior_consecutive_neg_rs:0
+       ~position_13w_return:0.10 ~benchmark_13w_return:0.05)
+    (equal_to ((0, Hold) : int * decision))
+
+let test_observe_positive_rs_resets_streak _ =
+  (* Even after a streak of negatives, a single positive RS read resets the
+     consecutive-negative count to zero and emits Hold. *)
+  assert_that
+    (observe ~config:cfg_k4 ~prior_consecutive_neg_rs:5
+       ~position_13w_return:0.20 ~benchmark_13w_return:0.10)
+    (equal_to ((0, Hold) : int * decision))
+
+let test_observe_tied_rs_resets_streak _ =
+  (* Position return matches benchmark exactly — RS is zero, not negative.
+     The detector treats this as "not lagging" and resets the streak. *)
+  assert_that
+    (observe ~config:cfg_k4 ~prior_consecutive_neg_rs:3
+       ~position_13w_return:0.05 ~benchmark_13w_return:0.05)
+    (equal_to ((0, Hold) : int * decision))
+
+let test_observe_negative_rs_first_week_below_threshold _ =
+  (* prior_count=0 → new_count=1 < threshold=4 → Hold. *)
+  assert_that
+    (observe ~config:cfg_k4 ~prior_consecutive_neg_rs:0
+       ~position_13w_return:(-0.05) ~benchmark_13w_return:0.10)
+    (equal_to ((1, Hold) : int * decision))
+
+let test_observe_negative_rs_at_threshold_fires _ =
+  (* prior_count=3 → new_count=4 ≥ threshold=4 → Laggard_exit. *)
+  assert_that
+    (observe ~config:cfg_k4 ~prior_consecutive_neg_rs:3
+       ~position_13w_return:(-0.05) ~benchmark_13w_return:0.05)
+    (equal_to ((4, Laggard_exit { rs_13w_neg_weeks = 4 }) : int * decision))
+
+let test_observe_negative_rs_above_threshold_keeps_firing _ =
+  (* prior_count=10 → new_count=11 ≥ threshold=4 → Laggard_exit (still firing
+     while RS persists negative). The wiring layer is responsible for not
+     re-issuing exits on already-exiting positions; the detector itself just
+     reports the signal. *)
+  assert_that
+    (observe ~config:cfg_k4 ~prior_consecutive_neg_rs:10
+       ~position_13w_return:(-0.10) ~benchmark_13w_return:0.05)
+    (equal_to ((11, Laggard_exit { rs_13w_neg_weeks = 11 }) : int * decision))
+
+let test_observe_k1_fires_first_week _ =
+  (* K=1: any single negative-RS observation fires immediately. *)
+  assert_that
+    (observe ~config:cfg_k1 ~prior_consecutive_neg_rs:0
+       ~position_13w_return:0.02 ~benchmark_13w_return:0.03)
+    (equal_to ((1, Laggard_exit { rs_13w_neg_weeks = 1 }) : int * decision))
+
+let test_observe_k6_requires_six_weeks _ =
+  (* prior=0 stepped through six negative-RS observations: only the sixth fires
+     under K=6. Build the sequence and assert the run of decisions. *)
+  let step prior =
+    observe ~config:cfg_k6 ~prior_consecutive_neg_rs:prior
+      ~position_13w_return:(-0.01) ~benchmark_13w_return:0.05
+  in
+  let r1 = step 0 in
+  let r2 = step (fst r1) in
+  let r3 = step (fst r2) in
+  let r4 = step (fst r3) in
+  let r5 = step (fst r4) in
+  let r6 = step (fst r5) in
+  assert_that [ r1; r2; r3; r4; r5; r6 ]
+    (elements_are
+       [
+         equal_to ((1, Hold) : int * decision);
+         equal_to ((2, Hold) : int * decision);
+         equal_to ((3, Hold) : int * decision);
+         equal_to ((4, Hold) : int * decision);
+         equal_to ((5, Hold) : int * decision);
+         equal_to ((6, Laggard_exit { rs_13w_neg_weeks = 6 }) : int * decision);
+       ])
+
+let test_observe_k0_treated_as_k1 _ =
+  (* Defensive: hysteresis_weeks <= 0 is treated as 1, so a single
+     negative-RS read fires immediately. *)
+  let config = { hysteresis_weeks = 0; rs_window_weeks = 13 } in
+  assert_that
+    (observe ~config ~prior_consecutive_neg_rs:0 ~position_13w_return:(-0.01)
+       ~benchmark_13w_return:0.01)
+    (equal_to ((1, Laggard_exit { rs_13w_neg_weeks = 1 }) : int * decision))
+
+let test_observe_negative_k_treated_as_k1 _ =
+  let config = { hysteresis_weeks = -3; rs_window_weeks = 13 } in
+  assert_that
+    (observe ~config ~prior_consecutive_neg_rs:0 ~position_13w_return:(-0.05)
+       ~benchmark_13w_return:0.05)
+    (equal_to ((1, Laggard_exit { rs_13w_neg_weeks = 1 }) : int * decision))
+
+let test_observe_neg_then_positive_then_neg_resets _ =
+  (* Whipsaw: 3 neg → 1 pos → 1 neg. Under K=4, the post-reset neg starts a
+     fresh count of 1 (Hold) — not a continuation of the prior 3-streak. *)
+  let neg prior =
+    observe ~config:cfg_k4 ~prior_consecutive_neg_rs:prior
+      ~position_13w_return:(-0.05) ~benchmark_13w_return:0.05
+  in
+  let pos prior =
+    observe ~config:cfg_k4 ~prior_consecutive_neg_rs:prior
+      ~position_13w_return:0.10 ~benchmark_13w_return:0.05
+  in
+  let r1 = neg 0 in
+  let r2 = neg (fst r1) in
+  let r3 = neg (fst r2) in
+  let r4 = pos (fst r3) in
+  let r5 = neg (fst r4) in
+  assert_that [ r1; r2; r3; r4; r5 ]
+    (elements_are
+       [
+         equal_to ((1, Hold) : int * decision);
+         equal_to ((2, Hold) : int * decision);
+         equal_to ((3, Hold) : int * decision);
+         equal_to ((0, Hold) : int * decision);
+         equal_to ((1, Hold) : int * decision);
+       ])
+
+let test_observe_both_returns_negative_position_worse _ =
+  (* Bear-market case: both position and benchmark are negative, but the
+     position is more negative — RS is still negative, count advances. *)
+  assert_that
+    (observe ~config:cfg_k4 ~prior_consecutive_neg_rs:3
+       ~position_13w_return:(-0.20) ~benchmark_13w_return:(-0.10))
+    (equal_to ((4, Laggard_exit { rs_13w_neg_weeks = 4 }) : int * decision))
+
+let test_observe_both_returns_negative_position_better _ =
+  (* Bear-market case: both negative, but the position falls less than the
+     benchmark — RS is positive, count resets, no exit. *)
+  assert_that
+    (observe ~config:cfg_k4 ~prior_consecutive_neg_rs:3
+       ~position_13w_return:(-0.10) ~benchmark_13w_return:(-0.20))
+    (equal_to ((0, Hold) : int * decision))
+
+(* --- symbol-keyed wrapper --- *)
+
+let test_observe_position_seeds_zero_for_unknown_symbol _ =
+  let state = Hashtbl.create (module String) in
+  let decision =
+    observe_position ~config:cfg_k4 ~state ~symbol:"AAPL"
+      ~position_13w_return:(-0.05) ~benchmark_13w_return:0.05
+  in
+  assert_that decision (equal_to (Hold : decision));
+  assert_that (Hashtbl.find state "AAPL") (is_some_and (equal_to 1))
+
+let test_observe_position_four_consecutive_negative_rs_fires _ =
+  let state = Hashtbl.create (module String) in
+  let neg () =
+    observe_position ~config:cfg_k4 ~state ~symbol:"AAPL"
+      ~position_13w_return:(-0.05) ~benchmark_13w_return:0.05
+  in
+  let _ = neg () in
+  let _ = neg () in
+  let _ = neg () in
+  let decision = neg () in
+  assert_that decision
+    (equal_to (Laggard_exit { rs_13w_neg_weeks = 4 } : decision))
+
+let test_observe_position_per_symbol_isolation _ =
+  (* AAPL hits negative-RS four times (fires); MSFT hits negative once then
+     positive once (no fire). State keys are independent. *)
+  let state = Hashtbl.create (module String) in
+  let aapl_neg () =
+    observe_position ~config:cfg_k4 ~state ~symbol:"AAPL"
+      ~position_13w_return:(-0.05) ~benchmark_13w_return:0.05
+  in
+  let msft_neg () =
+    observe_position ~config:cfg_k4 ~state ~symbol:"MSFT"
+      ~position_13w_return:(-0.02) ~benchmark_13w_return:0.05
+  in
+  let msft_pos () =
+    observe_position ~config:cfg_k4 ~state ~symbol:"MSFT"
+      ~position_13w_return:0.10 ~benchmark_13w_return:0.05
+  in
+  let _ = aapl_neg () in
+  let _ = aapl_neg () in
+  let _ = msft_neg () in
+  let _ = aapl_neg () in
+  let _ = msft_pos () in
+  let aapl_final = aapl_neg () in
+  let msft_final = msft_neg () in
+  assert_that [ aapl_final; msft_final ]
+    (elements_are
+       [
+         equal_to (Laggard_exit { rs_13w_neg_weeks = 4 } : decision);
+         equal_to (Hold : decision);
+       ])
+
+let test_observe_position_resets_on_positive_rs _ =
+  (* AAPL: neg → neg (count=2) → pos (resets to 0) → neg (count=1, Hold). *)
+  let state = Hashtbl.create (module String) in
+  let neg () =
+    observe_position ~config:cfg_k4 ~state ~symbol:"AAPL"
+      ~position_13w_return:(-0.05) ~benchmark_13w_return:0.05
+  in
+  let pos () =
+    observe_position ~config:cfg_k4 ~state ~symbol:"AAPL"
+      ~position_13w_return:0.10 ~benchmark_13w_return:0.05
+  in
+  let _ = neg () in
+  let _ = neg () in
+  let _ = pos () in
+  let after_reset = neg () in
+  assert_that after_reset (equal_to (Hold : decision));
+  assert_that (Hashtbl.find state "AAPL") (is_some_and (equal_to 1))
+
+(* --- default config --- *)
+
+let test_default_config_hysteresis_is_four _ =
+  assert_that default_config.hysteresis_weeks (equal_to 4)
+
+let test_default_config_window_is_thirteen _ =
+  assert_that default_config.rs_window_weeks (equal_to 13)
+
+(* --- runner --- *)
+
+let suite =
+  "laggard_rotation"
+  >::: [
+         "observe: positive RS returns Hold"
+         >:: test_observe_positive_rs_returns_hold;
+         "observe: positive RS resets streak"
+         >:: test_observe_positive_rs_resets_streak;
+         "observe: tied RS resets streak (strict comparison)"
+         >:: test_observe_tied_rs_resets_streak;
+         "observe: first negative-RS week below threshold returns Hold"
+         >:: test_observe_negative_rs_first_week_below_threshold;
+         "observe: negative RS at threshold fires Laggard_exit"
+         >:: test_observe_negative_rs_at_threshold_fires;
+         "observe: negative RS above threshold keeps firing"
+         >:: test_observe_negative_rs_above_threshold_keeps_firing;
+         "observe: K=1 fires on first negative-RS week"
+         >:: test_observe_k1_fires_first_week;
+         "observe: K=6 requires six consecutive weeks"
+         >:: test_observe_k6_requires_six_weeks;
+         "observe: K=0 treated as K=1 (defensive)"
+         >:: test_observe_k0_treated_as_k1;
+         "observe: negative K treated as K=1 (defensive)"
+         >:: test_observe_negative_k_treated_as_k1;
+         "observe: neg → pos → neg resets streak"
+         >:: test_observe_neg_then_positive_then_neg_resets;
+         "observe: both returns negative, position worse, fires"
+         >:: test_observe_both_returns_negative_position_worse;
+         "observe: both returns negative, position better, no fire"
+         >:: test_observe_both_returns_negative_position_better;
+         "observe_position: unknown symbol seeds count to zero"
+         >:: test_observe_position_seeds_zero_for_unknown_symbol;
+         "observe_position: four consecutive negative-RS reads fire"
+         >:: test_observe_position_four_consecutive_negative_rs_fires;
+         "observe_position: symbols are tracked independently"
+         >:: test_observe_position_per_symbol_isolation;
+         "observe_position: a positive-RS read resets the streak"
+         >:: test_observe_position_resets_on_positive_rs;
+         "default_config: hysteresis is 4"
+         >:: test_default_config_hysteresis_is_four;
+         "default_config: window is 13"
+         >:: test_default_config_window_is_thirteen;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -16,6 +16,7 @@
   weinstein_trading.portfolio_risk
   weinstein.stage
   weinstein.stage3_force_exit
+  weinstein.laggard_rotation
   weinstein.macro
   weinstein.rs
   weinstein.sector

--- a/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.ml
@@ -1,0 +1,110 @@
+open Core
+open Trading_strategy
+
+(** Compute the simple return over the rolling window from a list of weekly
+    bars. Expects [List.length bars >= n + 1]; takes the close at index 0
+    (oldest) and the close at index n (latest). Returns [None] if the list is
+    shorter than [n + 1] or the oldest close is non-positive (avoids
+    divide-by-zero on degenerate snapshots). *)
+let _window_return ~(n : int) (bars : Types.Daily_price.t list) : float option =
+  if List.length bars < n + 1 then None
+  else
+    let arr = Array.of_list bars in
+    let oldest = arr.(0).close_price in
+    let latest = arr.(Array.length arr - 1).close_price in
+    if Float.( <= ) oldest 0.0 then None else Some ((latest /. oldest) -. 1.0)
+
+(** Build the [TriggerExit] transition for a laggard-rotation exit. Same fill
+    convention as {!Stage3_force_exit_runner._make_exit_transition}: the exit
+    fires at the close of the current bar (discretionary exit at the close).
+
+    The emitted [exit_reason] uses the generic
+    {!Position.exit_reason.StrategySignal} variant with
+    [label = "laggard_rotation"] — this label surfaces in the [exit_trigger]
+    column of [trades.csv]. *)
+let _make_exit_transition ~(pos : Position.t) ~current_date ~bar
+    ~rs_13w_neg_weeks =
+  let exit_price = bar.Types.Daily_price.close_price in
+  let exit_reason =
+    Position.StrategySignal
+      {
+        label = "laggard_rotation";
+        detail = Some (Printf.sprintf "rs_13w_neg_weeks=%d" rs_13w_neg_weeks);
+      }
+  in
+  {
+    Position.position_id = pos.id;
+    date = current_date;
+    kind = Position.TriggerExit { exit_reason; exit_price };
+  }
+
+(** Convert a [Laggard_exit] decision into a transition, respecting the
+    skip-list collision filter and [get_price] availability. Returns [None] when
+    the position is on the skip list or the bar is missing. *)
+let _emit_exit_transition ~pos ~current_date ~get_price ~skip_position_ids
+    ~rs_13w_neg_weeks =
+  if Set.mem skip_position_ids pos.Position.id then None
+  else
+    Option.map (get_price pos.symbol) ~f:(fun bar ->
+        _make_exit_transition ~pos ~current_date ~bar ~rs_13w_neg_weeks)
+
+(** Run the detector on a long Holding position whose history covered the RS
+    window. Returns [Some transition] only on [Laggard_exit] that survives the
+    skip-list and [get_price] gates. *)
+let _observe_and_emit ~config ~laggard_streaks ~benchmark_13w_return
+    ~skip_position_ids ~get_price ~current_date ~position_13w_return
+    (pos : Position.t) =
+  let decision =
+    Laggard_rotation.observe_position ~config ~state:laggard_streaks
+      ~symbol:pos.symbol ~position_13w_return ~benchmark_13w_return
+  in
+  match decision with
+  | Laggard_rotation.Hold -> None
+  | Laggard_rotation.Laggard_exit { rs_13w_neg_weeks } ->
+      _emit_exit_transition ~pos ~current_date ~get_price ~skip_position_ids
+        ~rs_13w_neg_weeks
+
+(** Process one position. Returns [Some transition] when the detector fires AND
+    the position is not already exiting via an earlier exit channel (stops,
+    force-liq, Stage-3) on this tick. Mutates [laggard_streaks] only when both
+    the position and benchmark have enough history for a comparable RS read. *)
+let _process_position ~config ~laggard_streaks ~benchmark_13w_return
+    ~skip_position_ids ~bar_reader ~get_price ~current_date (pos : Position.t) =
+  match (pos.side, Position.get_state pos) with
+  | Trading_base.Types.Long, Position.Holding _ -> (
+      let n = config.Laggard_rotation.rs_window_weeks in
+      let pos_bars =
+        Bar_reader.weekly_bars_for bar_reader ~symbol:pos.symbol ~n:(n + 1)
+          ~as_of:current_date
+      in
+      match _window_return ~n pos_bars with
+      | None -> None
+      | Some position_13w_return ->
+          _observe_and_emit ~config ~laggard_streaks ~benchmark_13w_return
+            ~skip_position_ids ~get_price ~current_date ~position_13w_return pos
+      )
+  | _ -> None
+
+let update ~config ~benchmark_symbol ~is_screening_day ~positions ~bar_reader
+    ~get_price ~laggard_streaks ~skip_position_ids ~current_date =
+  if not is_screening_day then []
+  else if Map.is_empty positions then []
+  else
+    let n = config.Laggard_rotation.rs_window_weeks in
+    let benchmark_bars =
+      Bar_reader.weekly_bars_for bar_reader ~symbol:benchmark_symbol ~n:(n + 1)
+        ~as_of:current_date
+    in
+    match _window_return ~n benchmark_bars with
+    | None ->
+        (* Missing benchmark history is a data gap, not a stage-recovery
+           signal — leave the streak table untouched and emit nothing. *)
+        []
+    | Some benchmark_13w_return ->
+        Map.fold positions ~init:[] ~f:(fun ~key:_ ~data:pos acc ->
+            match
+              _process_position ~config ~laggard_streaks ~benchmark_13w_return
+                ~skip_position_ids ~bar_reader ~get_price ~current_date pos
+            with
+            | Some t -> t :: acc
+            | None -> acc)

--- a/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.mli
@@ -1,0 +1,100 @@
+(** Laggard-rotation runner — wires {!Laggard_rotation} into the Weinstein
+    strategy.
+
+    Capital-recycling exit per Weinstein Ch. 4 §portfolio sizing (~lines
+    4929–4933), surfaced as [docs/design/weinstein-book-reference.md] §5.6 (PR
+    #891). Issue #887, framing note
+    [dev/notes/capital-recycling-framing-2026-05-06.md].
+
+    {1 Cadence}
+
+    Fires only on Friday (weekly cadence). The detector computes
+    relative-strength-vs-benchmark over a rolling 13-week window using the
+    {!Bar_reader} primitives — meaningful only at the week-bucket boundary. On
+    non-Friday calls the runner is a no-op.
+
+    {1 Side & ordering}
+
+    Long positions only. Short positions never trigger this exit; their
+    relative-strength semantics are inverted (a short profits when the
+    underlying lags the market — exactly the laggard signal here would mean the
+    short is winning), so the runner skips shorts. The book authority (§5.6)
+    only mentions long-side rotation.
+
+    Invoked AFTER {!Stops_runner.update}, AFTER
+    {!Force_liquidation_runner.update}, AND AFTER
+    {!Stage3_force_exit_runner.update} (so the three earlier exit channels have
+    priority — a position already exiting via any of them is not re-exited under
+    laggard rotation) and BEFORE the entry walk on the same tick (so freed cash
+    is visible to the entry walk).
+
+    {1 RS computation}
+
+    For each held long position on each Friday close: 1. Read the most recent
+    [config.rs_window_weeks + 1] weekly bars (default 14) for the position
+    symbol via {!Bar_reader.weekly_bars_for}. 2. Read the same for the benchmark
+    symbol (typically [config.indices.primary]). 3. Compute
+    [position_13w_return = close[latest] / close[oldest] - 1.0] and likewise for
+    the benchmark. 4. Pass both into {!Laggard_rotation.observe_position}, which
+    advances the consecutive- negative-RS streak counter and decides whether to
+    fire.
+
+    A position whose history is shorter than [rs_window_weeks + 1] weekly bars
+    is skipped (no observation, no streak advancement) — the streak table only
+    records meaningful comparisons. Likewise when the benchmark's weekly history
+    is too short. *)
+
+open Core
+open Trading_strategy
+
+val update :
+  config:Laggard_rotation.config ->
+  benchmark_symbol:string ->
+  is_screening_day:bool ->
+  positions:Position.t Map.M(String).t ->
+  bar_reader:Bar_reader.t ->
+  get_price:Strategy_interface.get_price_fn ->
+  laggard_streaks:int Hashtbl.M(String).t ->
+  skip_position_ids:String.Set.t ->
+  current_date:Core.Date.t ->
+  Position.transition list
+(** [update] iterates over every held long {!Position.t} and runs the
+    laggard-rotation detector, returning a list of [TriggerExit] transitions for
+    positions whose detector decision is [Laggard_exit].
+
+    {2 Behaviour}
+
+    - Returns [[]] when [is_screening_day = false]. The detector runs at weekly
+      cadence only.
+    - Returns [[]] when [positions] is empty.
+    - Returns [[]] when the benchmark's weekly history is shorter than
+      [config.rs_window_weeks + 1] bars — without a comparable RS signal, no
+      position can be classified as a laggard. Streak counts are NOT reset in
+      that case (the missing benchmark is a data gap, not a stage-recovery
+      signal).
+    - For each held long position with a {!Position.Holding} state: 1. Reads
+      [config.rs_window_weeks + 1] weekly bars via [bar_reader]. If the
+      position's history is shorter than that, the position is skipped (no
+      observation, no streak advance — the symbol's history hasn't covered the
+      window yet, parallel to {!Stops_runner}'s warmup-skip). 2. Computes the
+      13-week returns for the position and the benchmark. 3. Calls
+      {!Laggard_rotation.observe_position} — the detector mutates
+      [laggard_streaks] in place to maintain the consecutive-negative-RS count.
+      4. On [Laggard_exit { rs_13w_neg_weeks }]:
+    - Skips the position if its [position_id] is in [skip_position_ids] —
+      another exit channel (stops, force-liq, Stage-3) already exited it this
+      tick.
+    - Otherwise emits a [TriggerExit] transition with
+      [exit_reason = StrategySignal { label = "laggard_rotation"; detail = Some
+       "rs_13w_neg_weeks=N" }] and [exit_price = bar.close_price] from
+      [get_price]. When [get_price] returns [None] the position is silently
+      skipped (no transition emitted).
+    - Short positions and non-Holding states are skipped without emitting, and
+      their entry in [laggard_streaks] is left untouched.
+
+    {2 Mutates}
+
+    - [laggard_streaks] — the per-symbol consecutive-negative-RS count is
+      updated in place via {!Laggard_rotation.observe_position}. Each call
+      advances the count by one on a negative-RS read or resets it to zero on
+      any non-negative read. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -9,10 +9,15 @@ module Stops_runner = Stops_runner
 module Stops_split_runner = Stops_split_runner
 module Force_liquidation_runner = Force_liquidation_runner
 module Stage3_force_exit_runner = Stage3_force_exit_runner
+module Laggard_rotation_runner = Laggard_rotation_runner
 
 module Stage3_force_exit = Stage3_force_exit
 (** Pure Stage-3 force-exit detector (issue #872). See [stage3_force_exit.mli]
     for the contract. *)
+
+module Laggard_rotation = Laggard_rotation
+(** Pure laggard-rotation detector (issue #887). See [laggard_rotation.mli] for
+    the contract. *)
 
 module Ad_bars = Ad_bars
 (** NYSE advance/decline breadth data loader. Exposed as a top-level submodule
@@ -87,6 +92,22 @@ type config = {
           (§5.2 "STATE: EXITED — IF whipsaw … acceptable to re-buy"). The knob
           exists on [config] so future tuning can flip it via sexp override
           without a code change. *)
+  laggard_rotation_config : Laggard_rotation.config;
+      [@sexp.default Laggard_rotation.default_config]
+      (** Laggard-rotation detector parameters (issue #887). Default
+          [{ hysteresis_weeks = 4; rs_window_weeks = 13 }] — fires on the fourth
+          consecutive Friday observation of negative
+          relative-strength-vs-benchmark over a rolling 13-week window. *)
+  enable_laggard_rotation : bool; [@sexp.default false]
+      (** Master switch for the laggard-rotation runner (issue #887). Default
+          [false] preserves all existing baselines: the runner is a no-op and
+          the strategy emits no [StrategySignal "laggard_rotation"] transitions.
+      *)
+  laggard_reentry_cooldown_weeks : int; [@sexp.default 0]
+      (** Reserved for future tuning — currently unwired (default [0] = no
+          cooldown applied beyond the existing stop-out cooldown surface #718).
+          The knob exists on [config] so future tuning can flip it via sexp
+          override without a code change. *)
 }
 [@@deriving sexp]
 
@@ -112,6 +133,9 @@ let default_config ~universe ~index_symbol =
     stage3_force_exit_config = Stage3_force_exit.default_config;
     enable_stage3_force_exit = false;
     stage3_reentry_cooldown_weeks = 0;
+    laggard_rotation_config = Laggard_rotation.default_config;
+    enable_laggard_rotation = false;
+    laggard_reentry_cooldown_weeks = 0;
   }
 
 let name = "Weinstein"
@@ -505,8 +529,9 @@ let _record_stop_outs ~last_stop_out_dates
 
 let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
     ~prior_macro ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
-    ~sector_prior_stages ~ticker_sectors ~stage3_streaks ~audit_recorder
-    ~get_price ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
+    ~sector_prior_stages ~ticker_sectors ~stage3_streaks ~laggard_streaks
+    ~audit_recorder ~get_price ~get_indicator:_ ~(portfolio : Portfolio_view.t)
+    =
   let positions = portfolio.positions in
   (* G13: non-trading-day short-circuit. The simulator iterates calendar
      days (Mon-Fri including holidays), so [_on_market_close] is invoked on
@@ -642,6 +667,45 @@ let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
             ~f:(fun (t : Position.transition) ->
               not (Set.mem stage3_exited_ids t.position_id))
       in
+      (* Laggard-rotation pass (issue #887). Reads per-position 13-week
+     returns vs the primary index over the rolling
+     [config.laggard_rotation_config.rs_window_weeks] window and emits
+     [TriggerExit] transitions for held longs whose consecutive-negative-
+     RS streak has reached [config.laggard_rotation_config.hysteresis_weeks].
+     The runner skips positions already exiting via stops or Stage-3
+     force-exit on this tick (see the [skip_position_ids] union below) so a
+     collision the same week resolves to a single exit. The runner is
+     conditionally enabled via [config.enable_laggard_rotation] (default
+     [false]) so existing baselines are bit-equivalent until callers opt
+     in. *)
+      let laggard_rotation_transitions =
+        if config.enable_laggard_rotation then
+          let is_screening_day = _is_screening_day_view index_view in
+          let skip_position_ids = Set.union stop_exited_ids stage3_exited_ids in
+          Laggard_rotation_runner.update ~config:config.laggard_rotation_config
+            ~benchmark_symbol:config.indices.primary ~is_screening_day
+            ~positions ~bar_reader ~get_price ~laggard_streaks
+            ~skip_position_ids ~current_date
+        else []
+      in
+      (* Strip force-liq transitions for positions the laggard runner just
+     exited — same double-exit hazard the [stop_exited_ids] /
+     [stage3_exited_ids] filters handle above. *)
+      let laggard_exited_ids =
+        List.filter_map laggard_rotation_transitions
+          ~f:(fun (t : Position.transition) ->
+            match t.kind with
+            | Position.TriggerExit _ -> Some t.position_id
+            | _ -> None)
+        |> String.Set.of_list
+      in
+      let force_exit_transitions =
+        if Set.is_empty laggard_exited_ids then force_exit_transitions
+        else
+          List.filter force_exit_transitions
+            ~f:(fun (t : Position.transition) ->
+              not (Set.mem laggard_exited_ids t.position_id))
+      in
       (* On every Friday — including Fridays where the force-liquidation halt is
      active — run the cheap macro-only path and consult [_maybe_reset_halt]
      BEFORE deciding whether to invoke the universe screen. This preserves the
@@ -683,7 +747,8 @@ let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
         {
           Strategy_interface.transitions =
             exit_transitions @ stage3_force_exit_transitions
-            @ force_exit_transitions @ adjust_transitions @ entry_transitions;
+            @ laggard_rotation_transitions @ force_exit_transitions
+            @ adjust_transitions @ entry_transitions;
         }
 
 let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
@@ -727,6 +792,13 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
   let stage3_streaks : int Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
+  (* Per-symbol consecutive-negative-RS-Friday counter consumed by
+     {!Laggard_rotation_runner} (issue #887). Empty at construction →
+     every position starts with a streak of zero, matching the no-laggard
+     baseline. *)
+  let laggard_streaks : int Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
   (* Macro.analyze requires weekly-cadence ad_bars; normalize once at load
      time, not on every [on_market_close] call. *)
   let weekly_ad_bars = Ad_bars_aggregation.daily_to_weekly ad_bars in
@@ -737,7 +809,7 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
       _on_market_close ~config ~ad_bars:weekly_ad_bars ~stop_states
         ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
         ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
-        ~stage3_streaks ~audit_recorder
+        ~stage3_streaks ~laggard_streaks ~audit_recorder
   end in
   (module M : Strategy_interface.STRATEGY)
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -68,6 +68,18 @@ module Stage3_force_exit = Stage3_force_exit
     {!Weinstein_strategy.config} can reference {!Stage3_force_exit.config} and
     {!Stage3_force_exit.default_config} without a separate library import. *)
 
+module Laggard_rotation_runner = Laggard_rotation_runner
+(** Laggard-rotation runner — capital recycling on the long side (issue #887).
+    Invoked AFTER {!Stops_runner.update}, {!Force_liquidation_runner.update} and
+    {!Stage3_force_exit_runner.update} on Friday ticks when
+    [config.enable_laggard_rotation = true]. See {!Laggard_rotation_runner}. *)
+
+module Laggard_rotation = Laggard_rotation
+(** Pure laggard-rotation detector (issue #887). Re-exposed from
+    [analysis/weinstein/laggard_rotation] so callers building a
+    {!Weinstein_strategy.config} can reference {!Laggard_rotation.config} and
+    {!Laggard_rotation.default_config} without a separate library import. *)
+
 module Macro_inputs = Macro_inputs
 (** Sector map + global index assembly from accumulated bar history. Exposes the
     canonical {!Macro_inputs.spdr_sector_etfs} and
@@ -226,6 +238,31 @@ type config = {
           (§5.2 "STATE: EXITED — IF whipsaw … acceptable to re-buy"). The knob
           exists on [config] so future tuning can flip it via sexp override
           without a code change. *)
+  laggard_rotation_config : Laggard_rotation.config;
+      [@sexp.default Laggard_rotation.default_config]
+      (** Laggard-rotation detector parameters (issue #887). Default
+          [{ hysteresis_weeks = 4; rs_window_weeks = 13 }] — fires on the fourth
+          consecutive Friday observation of negative
+          relative-strength-vs-benchmark over a rolling 13-week window. *)
+  enable_laggard_rotation : bool; [@sexp.default false]
+      (** Master switch for the laggard-rotation runner (issue #887). Default
+          [false] preserves all existing baselines: the runner is a no-op and
+          the strategy emits no [StrategySignal "laggard_rotation"] transitions.
+          Flipping to [true] activates {!Laggard_rotation_runner.update} on
+          every Friday tick.
+
+          The opt-in default is intentional: enabling the mechanism produces new
+          exits and shifts every existing fixture's pinned numbers (trade count,
+          return, MaxDD). Re-pinning every goldens-sp500-historical scenario is
+          a separate post-merge step per the framing note's "Recommended
+          sequencing" in [dev/notes/capital-recycling-framing-2026-05-06.md]. *)
+  laggard_reentry_cooldown_weeks : int; [@sexp.default 0]
+      (** Reserved for future tuning — currently unwired (default [0] = no
+          cooldown applied beyond the existing stop-out cooldown surface #718).
+          [0] is the book-aligned default per §5.6: laggard rotation is
+          discretionary, the symbol may be re-bought once it shows fresh Stage-2
+          strength. The knob exists on [config] so future tuning can flip it via
+          sexp override without a code change. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for
@@ -412,6 +449,7 @@ module Internal_for_test : sig
     sector_prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
     ticker_sectors:(string, string) Hashtbl.t ->
     stage3_streaks:int Hashtbl.M(String).t ->
+    laggard_streaks:int Hashtbl.M(String).t ->
     audit_recorder:Audit_recorder.t ->
     get_price:Trading_strategy.Strategy_interface.get_price_fn ->
     get_indicator:Trading_strategy.Strategy_interface.get_indicator_fn ->
@@ -420,8 +458,8 @@ module Internal_for_test : sig
   (** Drives [_on_market_close] with all closure-scoped state passed in
       explicitly. Mutates [stop_states] / [last_stop_out_dates] / [prior_macro]
       / [prior_macro_result] / [peak_tracker] / [prior_stages] /
-      [sector_prior_stages] / [stage3_streaks] in place, mirroring the closure
-      semantics in {!make}. *)
+      [sector_prior_stages] / [stage3_streaks] / [laggard_streaks] in place,
+      mirroring the closure semantics in {!make}. *)
 
   val maybe_reset_halt :
     peak_tracker:Portfolio_risk.Force_liquidation.Peak_tracker.t ->

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -11,6 +11,7 @@
   test_panel_callbacks
   test_short_side_bear_window
   test_stage3_force_exit_runner
+  test_laggard_rotation_runner
   test_stops_runner
   test_stops_split_runner
   test_weekly_ma_cache

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
@@ -67,6 +67,7 @@ type _strategy_state = {
   sector_prior_stages : stage Hashtbl.M(String).t;
   ticker_sectors : (string, string) Hashtbl.t;
   stage3_streaks : int Hashtbl.M(String).t;
+  laggard_streaks : int Hashtbl.M(String).t;
   bar_reader : Bar_reader.t;
 }
 (** Build a fresh closure-state bundle that mirrors what {!make} constructs
@@ -84,6 +85,7 @@ let _fresh_state ~bar_reader =
     sector_prior_stages = Hashtbl.create (module String);
     ticker_sectors = Hashtbl.create (module String);
     stage3_streaks = Hashtbl.create (module String);
+    laggard_streaks = Hashtbl.create (module String);
     bar_reader;
   }
 
@@ -105,7 +107,7 @@ let _drive_tick state ~config ~current_date ~portfolio =
     ~prior_stages:state.prior_stages
     ~sector_prior_stages:state.sector_prior_stages
     ~ticker_sectors:state.ticker_sectors ~stage3_streaks:state.stage3_streaks
-    ~audit_recorder:Audit_recorder.noop
+    ~laggard_streaks:state.laggard_streaks ~audit_recorder:Audit_recorder.noop
     ~get_price:(_get_price_of_state state ~current_date)
     ~get_indicator:(fun _ _ _ _ -> None)
     ~portfolio

--- a/trading/trading/weinstein/strategy/test/test_laggard_rotation_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_laggard_rotation_runner.ml
@@ -1,0 +1,464 @@
+open OUnit2
+open Core
+open Matchers
+open Weinstein_strategy
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let make_bar date ~close ?low ?high () =
+  let low = Option.value low ~default:(close *. 0.99) in
+  let high = Option.value high ~default:(close *. 1.01) in
+  {
+    Types.Daily_price.date = Date.of_string date;
+    open_price = close;
+    high_price = high;
+    low_price = low;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+  }
+
+let cfg_k4 = { Laggard_rotation.hysteresis_weeks = 4; rs_window_weeks = 13 }
+let cfg_k1 = { Laggard_rotation.hysteresis_weeks = 1; rs_window_weeks = 13 }
+let _friday = Date.of_string "2024-04-05" (* Friday *)
+let _monday = Date.of_string "2024-04-08" (* Monday *)
+
+(** Build a Position.t in the Holding state for [ticker] at [price]. Mirrors the
+    helper in [test_stage3_force_exit_runner.ml]. *)
+let make_holding_pos ?(side = Trading_base.Types.Long) ticker price date =
+  let pos_id = ticker in
+  let make_trans kind =
+    { Trading_strategy.Position.position_id = pos_id; date; kind }
+  in
+  let unwrap = function
+    | Ok p -> p
+    | Error _ -> OUnit2.assert_failure "position setup failed"
+  in
+  let open Trading_strategy.Position in
+  let p =
+    create_entering
+      (make_trans
+         (CreateEntering
+            {
+              symbol = ticker;
+              side;
+              target_quantity = 10.0;
+              entry_price = price;
+              reasoning = ManualDecision { description = "test" };
+            }))
+    |> unwrap
+  in
+  let p =
+    apply_transition p
+      (make_trans (EntryFill { filled_quantity = 10.0; fill_price = price }))
+    |> unwrap
+  in
+  apply_transition p
+    (make_trans
+       (EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = None;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+(** Build a sequence of N weekly Friday daily bars ending at [_friday], with the
+    close prices tracing [from_close → to_close] linearly across the range. Used
+    to seed [Bar_reader.of_in_memory_bars] so [weekly_bars_for ~n:14] returns 14
+    weekly closes that produce a known 13-week return. *)
+let _make_weekly_bars_to_friday ~from_close ~to_close ~n =
+  let step = (to_close -. from_close) /. Float.of_int (n - 1) in
+  List.init n ~f:(fun i ->
+      (* Each Friday is 7 days before the previous; bar [n-1] = _friday. *)
+      let days_back = (n - 1 - i) * 7 in
+      let d = Date.add_days _friday (-days_back) in
+      let close = from_close +. (Float.of_int i *. step) in
+      {
+        Types.Daily_price.date = d;
+        open_price = close;
+        high_price = close *. 1.005;
+        low_price = close *. 0.995;
+        close_price = close;
+        adjusted_close = close;
+        volume = 1_000_000;
+      })
+
+(** Build a [Bar_reader.t] backed by in-memory bars for the given (symbol, bars)
+    pairs. *)
+let _make_reader symbol_bars = Bar_reader.of_in_memory_bars symbol_bars
+
+let get_price_of bars symbol = List.Assoc.find bars symbol ~equal:String.equal
+
+(* ------------------------------------------------------------------ *)
+(* Off-cadence: non-Friday is a no-op                                   *)
+(* ------------------------------------------------------------------ *)
+
+let test_non_friday_no_op _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  Hashtbl.set laggard_streaks ~key:"AAPL" ~data:3;
+  let reader = Bar_reader.empty () in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:false ~positions ~bar_reader:reader
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-04-08" ~close:95.0 ()) ])
+      ~laggard_streaks ~skip_position_ids:String.Set.empty ~current_date:_monday
+  in
+  assert_that exits is_empty;
+  (* Non-Friday call must not advance the streak counter. *)
+  assert_that (Hashtbl.find laggard_streaks "AAPL") (is_some_and (equal_to 3))
+
+(* ------------------------------------------------------------------ *)
+(* Empty positions: no exits                                            *)
+(* ------------------------------------------------------------------ *)
+
+let test_empty_positions_returns_empty _ =
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions:String.Map.empty
+      ~bar_reader:(Bar_reader.empty ()) ~get_price:(get_price_of [])
+      ~laggard_streaks:(Hashtbl.create (module String))
+      ~skip_position_ids:String.Set.empty ~current_date:_friday
+  in
+  assert_that exits is_empty
+
+(* ------------------------------------------------------------------ *)
+(* Insufficient benchmark history → empty exits + streak untouched      *)
+(* ------------------------------------------------------------------ *)
+
+let test_short_benchmark_history_no_exit_streak_untouched _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  Hashtbl.set laggard_streaks ~key:"AAPL" ~data:2;
+  (* Benchmark only has 5 weekly bars — far less than required 14. *)
+  let bench_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:110.0 ~n:5
+  in
+  let reader = _make_reader [ ("GSPCX", bench_bars) ] in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions ~bar_reader:reader
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-04-05" ~close:95.0 ()) ])
+      ~laggard_streaks ~skip_position_ids:String.Set.empty ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  (* Benchmark gap leaves the streak untouched — no fresh observation. *)
+  assert_that (Hashtbl.find laggard_streaks "AAPL") (is_some_and (equal_to 2))
+
+(* ------------------------------------------------------------------ *)
+(* Insufficient position history → no exit, streak untouched            *)
+(* ------------------------------------------------------------------ *)
+
+let test_short_position_history_skips_position _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  Hashtbl.set laggard_streaks ~key:"AAPL" ~data:2;
+  (* Benchmark has full history; AAPL has only 5 weeks. *)
+  let bench_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:110.0 ~n:14
+  in
+  let aapl_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:90.0 ~n:5
+  in
+  let reader = _make_reader [ ("GSPCX", bench_bars); ("AAPL", aapl_bars) ] in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions ~bar_reader:reader
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-04-05" ~close:90.0 ()) ])
+      ~laggard_streaks ~skip_position_ids:String.Set.empty ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  assert_that (Hashtbl.find laggard_streaks "AAPL") (is_some_and (equal_to 2))
+
+(* ------------------------------------------------------------------ *)
+(* Long position: negative RS below hysteresis → no exit                *)
+(* ------------------------------------------------------------------ *)
+
+let test_neg_rs_below_hysteresis_no_exit _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  (* AAPL falls 10% over 13 weeks; benchmark rises 10%. RS sharply negative. *)
+  let bench_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:110.0 ~n:14
+  in
+  let aapl_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:90.0 ~n:14
+  in
+  let reader = _make_reader [ ("GSPCX", bench_bars); ("AAPL", aapl_bars) ] in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions ~bar_reader:reader
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-04-05" ~close:90.0 ()) ])
+      ~laggard_streaks ~skip_position_ids:String.Set.empty ~current_date:_friday
+  in
+  (* First negative-RS read brings streak to 1 < hysteresis_weeks = 4. *)
+  assert_that exits is_empty;
+  assert_that (Hashtbl.find laggard_streaks "AAPL") (is_some_and (equal_to 1))
+
+(* ------------------------------------------------------------------ *)
+(* Long position: negative RS at hysteresis → exit emitted              *)
+(* ------------------------------------------------------------------ *)
+
+let test_neg_rs_at_hysteresis_emits_exit _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  Hashtbl.set laggard_streaks ~key:"AAPL" ~data:3;
+  (* Pre-seeded streak = 3 → fourth observation fires under K=4. *)
+  let bench_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:110.0 ~n:14
+  in
+  let aapl_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:90.0 ~n:14
+  in
+  let reader = _make_reader [ ("GSPCX", bench_bars); ("AAPL", aapl_bars) ] in
+  let bar = make_bar "2024-04-05" ~close:90.0 () in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions ~bar_reader:reader
+      ~get_price:(get_price_of [ ("AAPL", bar) ])
+      ~laggard_streaks ~skip_position_ids:String.Set.empty ~current_date:_friday
+  in
+  assert_that exits
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Trading_strategy.Position.transition) -> t.position_id)
+               (equal_to "AAPL");
+             field
+               (fun (t : Trading_strategy.Position.transition) -> t.date)
+               (equal_to _friday);
+             field
+               (fun (t : Trading_strategy.Position.transition) -> t.kind)
+               (matching
+                  ~msg:
+                    "Expected TriggerExit with StrategySignal laggard_rotation"
+                  (function
+                    | Trading_strategy.Position.TriggerExit
+                        {
+                          exit_reason =
+                            Trading_strategy.Position.StrategySignal
+                              { label; detail };
+                          exit_price;
+                        } ->
+                        Some (label, detail, exit_price)
+                    | _ -> None)
+                  (all_of
+                     [
+                       field (fun (l, _, _) -> l) (equal_to "laggard_rotation");
+                       field
+                         (fun (_, d, _) -> d)
+                         (is_some_and (equal_to "rs_13w_neg_weeks=4"));
+                       field (fun (_, _, p) -> p) (float_equal 90.0);
+                     ]));
+           ];
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Long position: positive RS resets the streak                         *)
+(* ------------------------------------------------------------------ *)
+
+let test_positive_rs_resets_streak _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  Hashtbl.set laggard_streaks ~key:"AAPL" ~data:7;
+  (* AAPL rises 20%; benchmark rises 5%. RS strongly positive. *)
+  let bench_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:105.0 ~n:14
+  in
+  let aapl_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:120.0 ~n:14
+  in
+  let reader = _make_reader [ ("GSPCX", bench_bars); ("AAPL", aapl_bars) ] in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions ~bar_reader:reader
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-04-05" ~close:120.0 ()) ])
+      ~laggard_streaks ~skip_position_ids:String.Set.empty ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  assert_that (Hashtbl.find laggard_streaks "AAPL") (is_some_and (equal_to 0))
+
+(* ------------------------------------------------------------------ *)
+(* Short position: never triggers laggard rotation                      *)
+(* ------------------------------------------------------------------ *)
+
+let test_short_position_never_emits_exit _ =
+  let pos =
+    make_holding_pos ~side:Trading_base.Types.Short "AAPL" 100.0 _friday
+  in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  (* Pre-seed streak above threshold to make sure even a streak that would
+     fire on a long is suppressed for a short. *)
+  Hashtbl.set laggard_streaks ~key:"AAPL" ~data:10;
+  let bench_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:110.0 ~n:14
+  in
+  let aapl_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:90.0 ~n:14
+  in
+  let reader = _make_reader [ ("GSPCX", bench_bars); ("AAPL", aapl_bars) ] in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions ~bar_reader:reader
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-04-05" ~close:90.0 ()) ])
+      ~laggard_streaks ~skip_position_ids:String.Set.empty ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  (* Streak counter stays at the pre-seeded 10 — the runner does not
+     advance state for shorts. *)
+  assert_that (Hashtbl.find laggard_streaks "AAPL") (is_some_and (equal_to 10))
+
+(* ------------------------------------------------------------------ *)
+(* Skip-list collision: position already exited via stop is skipped     *)
+(* ------------------------------------------------------------------ *)
+
+let test_skips_position_already_exited _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  Hashtbl.set laggard_streaks ~key:"AAPL" ~data:3;
+  let bench_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:110.0 ~n:14
+  in
+  let aapl_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:90.0 ~n:14
+  in
+  let reader = _make_reader [ ("GSPCX", bench_bars); ("AAPL", aapl_bars) ] in
+  let skip_position_ids = String.Set.singleton pos.id in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions ~bar_reader:reader
+      ~get_price:
+        (get_price_of [ ("AAPL", make_bar "2024-04-05" ~close:90.0 ()) ])
+      ~laggard_streaks ~skip_position_ids ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  (* Streak counter still advances even though the exit was suppressed —
+     accurate accounting against the RS stream is kept. *)
+  assert_that (Hashtbl.find laggard_streaks "AAPL") (is_some_and (equal_to 4))
+
+(* ------------------------------------------------------------------ *)
+(* Missing bar from get_price: no exit, but streak still advances       *)
+(* ------------------------------------------------------------------ *)
+
+let test_missing_get_price_skips_position _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  Hashtbl.set laggard_streaks ~key:"AAPL" ~data:3;
+  let bench_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:110.0 ~n:14
+  in
+  let aapl_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:90.0 ~n:14
+  in
+  let reader = _make_reader [ ("GSPCX", bench_bars); ("AAPL", aapl_bars) ] in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k4 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions ~bar_reader:reader
+      ~get_price:(fun _ -> None)
+      ~laggard_streaks ~skip_position_ids:String.Set.empty ~current_date:_friday
+  in
+  assert_that exits is_empty;
+  (* Streak counter still advanced via observe_position. *)
+  assert_that (Hashtbl.find laggard_streaks "AAPL") (is_some_and (equal_to 4))
+
+(* ------------------------------------------------------------------ *)
+(* K=1 fast path: single negative-RS observation fires                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_k1_fires_first_week _ =
+  let pos = make_holding_pos "AAPL" 100.0 _friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let laggard_streaks = Hashtbl.create (module String) in
+  let bench_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:110.0 ~n:14
+  in
+  let aapl_bars =
+    _make_weekly_bars_to_friday ~from_close:100.0 ~to_close:105.0 ~n:14
+  in
+  let reader = _make_reader [ ("GSPCX", bench_bars); ("AAPL", aapl_bars) ] in
+  let bar = make_bar "2024-04-05" ~close:105.0 () in
+  let exits =
+    Laggard_rotation_runner.update ~config:cfg_k1 ~benchmark_symbol:"GSPCX"
+      ~is_screening_day:true ~positions ~bar_reader:reader
+      ~get_price:(get_price_of [ ("AAPL", bar) ])
+      ~laggard_streaks ~skip_position_ids:String.Set.empty ~current_date:_friday
+  in
+  assert_that exits
+    (elements_are
+       [
+         field
+           (fun (t : Trading_strategy.Position.transition) -> t.kind)
+           (matching ~msg:"Expected TriggerExit with rs_13w_neg_weeks=1"
+              (function
+                | Trading_strategy.Position.TriggerExit
+                    {
+                      exit_reason =
+                        Trading_strategy.Position.StrategySignal
+                          { label; detail };
+                      _;
+                    } ->
+                    Some (label, detail)
+                | _ -> None)
+              (all_of
+                 [
+                   field (fun (l, _) -> l) (equal_to "laggard_rotation");
+                   field
+                     (fun (_, d) -> d)
+                     (is_some_and (equal_to "rs_13w_neg_weeks=1"));
+                 ]));
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* runner                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "laggard_rotation_runner"
+  >::: [
+         "non-Friday is a no-op (does not advance streak)"
+         >:: test_non_friday_no_op;
+         "empty positions returns empty list"
+         >:: test_empty_positions_returns_empty;
+         "insufficient benchmark history: no exit, streak untouched"
+         >:: test_short_benchmark_history_no_exit_streak_untouched;
+         "insufficient position history: position skipped, streak untouched"
+         >:: test_short_position_history_skips_position;
+         "negative RS below hysteresis: no exit, streak advances to 1"
+         >:: test_neg_rs_below_hysteresis_no_exit;
+         "negative RS at hysteresis: emits TriggerExit with \
+          StrategySignal(laggard_rotation)"
+         >:: test_neg_rs_at_hysteresis_emits_exit;
+         "positive RS resets the streak to 0" >:: test_positive_rs_resets_streak;
+         "short position never emits exit, streak untouched"
+         >:: test_short_position_never_emits_exit;
+         "skip-list collision: position already exited is skipped (streak \
+          still advances)" >:: test_skips_position_already_exited;
+         "missing bar from get_price: no exit, streak still advances"
+         >:: test_missing_get_price_skips_position;
+         "K=1 fires on first negative-RS week" >:: test_k1_fires_first_week;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Implements Weinstein Ch.4 §portfolio sizing rotation rule (book-ref §5.6): "if it's lagging badly and acting poorly, lighten up on that position even if the sell-stop isn't hit. Move the proceeds into a new Stage 2 stock with greater promise."

Distinct from #872 Stage-3 force exit: laggard rotation fires mid-Stage-2 on weak RS-vs-benchmark behaviour alone, before the 30-week MA flattens. Both are unimplemented capital-recycling mechanisms identified in #871 (15y diagnostic). This PR addresses the second mechanism (issue #887); the first (#872) is the related Stage-3 force exit.

## Design decisions (from `dev/notes/capital-recycling-framing-2026-05-06.md` Q2-Q6)

- **Q2 (RS measure / window):** Position's rolling 13-week return minus benchmark's rolling 13-week return. A laggard is a position whose RS_13w has been negative for ≥ K consecutive Friday observations (K = `laggard_hysteresis_weeks`, default 4). Strict comparison — a tie or positive RS resets the streak.
- **Q3 (priority):** Runs AFTER stops, force-liq, and Stage-3 force-exit; BEFORE the entry walk so freed cash is visible.
- **Q4 (exit_reason):** Generic `Position.StrategySignal { label = "laggard_rotation"; detail = Some "rs_13w_neg_weeks=N" }` — no new variant added.
- **Q5 (re-entry):** No cooldown beyond #718 stop-out cooldown. Added `laggard_reentry_cooldown_weeks : int` config knob defaulting to 0 for future tuning.
- **Q6 (acceptance):** Opt-in default (`enable_laggard_rotation = false`); 5y baseline (58.34% / 81 trades) preserved bit-equivalent at default.

## What's added

### New detector module
- `analysis/weinstein/laggard_rotation/lib/laggard_rotation.{ml,mli}` — pure `observe` / `observe_position` primitives.
- `analysis/weinstein/laggard_rotation/test/test_laggard_rotation.ml` — **19 unit tests** covering positive/tied/negative RS, hysteresis edges (K=1/4/6/0/negative), whipsaw reset, per-symbol wrapper isolation, bear-market both-negative comparison.

### New runner module
- `trading/weinstein/strategy/lib/laggard_rotation_runner.{ml,mli}` — Friday-only, long-only. Mirrors `Stage3_force_exit_runner` shape. Reads weekly bars via `Bar_reader.weekly_bars_for ~n:14`, computes window returns, delegates to detector.
- `trading/weinstein/strategy/test/test_laggard_rotation_runner.ml` — **11 integration tests**: non-Friday no-op, empty positions, insufficient benchmark/position history skip, hysteresis threshold, positive-RS reset, short positions never fire, skip-list collisions, missing get_price, K=1 fast path.

### Wiring in `weinstein_strategy.ml`
- Three new config fields: `laggard_rotation_config`, `enable_laggard_rotation` (default false), `laggard_reentry_cooldown_weeks` (reserved).
- `laggard_streaks : int Hashtbl.M(String).t` threaded through `make` closure + `Internal_for_test.on_market_close`.
- Runner invoked at lines 681-705 in `_on_market_close`, AFTER Stage-3 force-exit (the position-channel sequence is stops → force-liq → Stage-3 → laggard → entry walk). `skip_position_ids` is the union `stop_exited_ids ∪ stage3_exited_ids`. Force-liq transitions filter out positions the laggard runner just exited (same double-exit hazard pattern Stage-3 handles).

## 5y baseline result (default OFF)

`enable_laggard_rotation = false` is the default. The runner is a no-op (early-returns `[]` without touching state). The existing `goldens-sp500/sp500-2019-2023.sexp` scenario does NOT override this field, so the run path is bit-equivalent to pre-PR.

The pinned baseline in the scenario sexp is **+58.34% return / 81 trades / 19.75% win rate / Sharpe 0.54 / MaxDD 33.60** — preserved.

## 5y baseline result (default ON, `hysteresis_weeks = 4`)

Empirical impact of flipping `enable_laggard_rotation = true` is a separate post-merge step (backtest re-pin per the framing note's "Recommended sequencing"). The PR itself does NOT flip the default — that's deliberate per Q6 acceptance gate.

## Test plan
- [x] `dune build` clean
- [x] `dune runtest analysis/weinstein/laggard_rotation` — 19/19 tests pass
- [x] `dune runtest trading/weinstein/strategy` — all tests pass (incl. 11 new runner tests)
- [x] `dune runtest trading/backtest` — all tests pass; 5y scenario tolerance bands hold (default-OFF bit-equivalent)
- [x] `dune build @fmt` clean for new files

## LOC summary
~620 LOC source (detector 47 + runner 110 + mli docs 230 + strategy edits ~110 + dune wiring 7) + ~740 LOC tests = ~1256 total.

## Refs

- Issue #887 — laggard rotation proposal
- Issue #872 — Stage-3 force exit (complementary mechanism)
- Issue #871 — 15y diagnostic (capital-recycling motivation)
- Book authority: `docs/design/weinstein-book-reference.md` §5.6 (PR #891)
- Framing note: `dev/notes/capital-recycling-framing-2026-05-06.md`
- Opportunity-cost note: `dev/notes/all-eligible-opportunity-cost-2026-05-07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)