### PR TITLE
fix(backtest): write degenerate actual.sexp on crash + dedup adjust+exit collisions

### DIFF
--- a/dev/notes/15y-crash-investigation-2026-05-07.md
+++ b/dev/notes/15y-crash-investigation-2026-05-07.md
@@ -1,0 +1,155 @@
+# 15y SP500 + enable_stage3_force_exit crash investigation (2026-05-07)
+
+PR #906 surfaced a crash mode in the 15y SP500 backtest (`goldens-sp500-historical/sp500-2010-2026.sexp`) when `enable_stage3_force_exit = true` is overridden in. Equity collapses to $51K-$540K from $1M starting cash within the first 1-2 of 16 years. The runner reports `FAIL (scenario crashed or did not write actual.sexp)` with exit code 1 and no recoverable metrics.
+
+This note documents the root cause and the fix.
+
+## Reproduction
+
+```bash
+docker exec trading-1-dev bash -c '
+  cd /workspaces/trading-1/trading && eval $(opam env) &&
+  /workspaces/trading-1/trading/_build/default/trading/backtest/scenarios/scenario_runner.exe \
+    --dir /tmp/15y-crash-repro --parallel 1 \
+    --fixtures-root /workspaces/trading-1/trading/test_data/backtest_scenarios \
+    > /tmp/out.log 2> /tmp/err.log
+'
+```
+
+Where `/tmp/15y-crash-repro/sp500-15y-stage3-on-h1.sexp` is the experiment scenario from PR #906 (`enable_stage3_force_exit = true`, `hysteresis_weeks = 1`).
+
+The run progresses normally for ~60 weekly cycles (~1.4 years) and then aborts. `progress.sexp` at the time of abort:
+
+```
+((started_at 1778113204) (updated_at 1778113419) (cycles_done 60)
+ (cycles_total 882) (last_completed_date 2010-07-23) (trades_so_far 113)
+ (current_equity 1033820.4805999999))
+```
+
+## Root cause (analytical)
+
+The Weinstein strategy's `_on_market_close` collects exit transitions from four channels and one adjust channel:
+
+1. `Stops_runner.update` — emits either a `TriggerExit` (`Stop_hit` event, position closes via stop) **or** an `UpdateRiskParams` (`Stop_raised` event, trailing stop tightens). Mutually exclusive per position per tick.
+2. `Force_liquidation_runner.update` — emits `TriggerExit` for portfolio-floor / unrealized-loss breaches.
+3. `Stage3_force_exit_runner.update` (gated on `enable_stage3_force_exit`) — emits `TriggerExit` when a held long stays in Stage 3 for `hysteresis_weeks` consecutive Fridays.
+4. `Laggard_rotation_runner.update` (gated on `enable_laggard_rotation`) — emits `TriggerExit` for negative RS-vs-benchmark over a rolling window.
+
+The strategy already dedups **exit channels against each other** (e.g. Stage-3 doesn't emit if stops already exited the same position this tick; force-liq doesn't emit if Stage-3 / laggard exited it). The dedup uses `position_id` set membership.
+
+The strategy concatenates transitions in this order:
+
+```
+exit_transitions @ stage3_force_exit_transitions
+@ laggard_rotation_transitions @ force_exit_transitions
+@ adjust_transitions @ entry_transitions
+```
+
+`exit_transitions` here is the output of `Stops_runner.update`, which contains *only* `Stop_hit`-derived `TriggerExit` transitions. `adjust_transitions` is a *separate* output containing `Stop_raised`-derived `UpdateRiskParams` transitions.
+
+**The bug**: `adjust_transitions` is **not deduped against the other exit channels**. So when:
+
+- Stops_runner emits `UpdateRiskParams` for position P (a `Stop_raised` event — trail tightening), AND
+- Stage-3 / laggard / force-liq emits `TriggerExit` for position P on the same tick,
+
+the simulator's `_apply_transitions` processes the exit first (P: Holding → Exiting) and then the adjust, which fails because `Position.apply_transition` rejects `(Exiting, UpdateRiskParams)` with `Invalid transition UpdateRiskParams for current state` (per `trading/trading/strategy/lib/position.ml:328-339`).
+
+The simulator's `step` returns `Result.Error`. `Backtest.Panel_runner._step_failed` (panel_runner.ml:97-99) unconditionally calls `failwith` on the Error, raising an unhandled OCaml exception that aborts the scenario_runner child process. The child's catch-all `try/with` exits with code 1 but does **not** write an `actual.sexp`, so the parent reports the silent "scenario crashed or did not write actual.sexp" row.
+
+This collision is rare under default settings (only `Stop_raised` + force-liq simultaneously, which is uncommon), but `enable_stage3_force_exit = true` adds a third TriggerExit channel that fires on the same Friday cadence as `Stop_raised`. With 60+ held positions and a bear / topping market regime (Stage 3 transitions cluster), the probability of collision compounds; the 15y window's 882 weekly cycles guarantee it within ~60 cycles.
+
+## Fix
+
+Two complementary changes, both within `feat-backtest` scope (no core-module modifications per `.claude/rules/qc-structural-authority.md` A1):
+
+### Fix A — strategy-side dedup (preventive)
+
+`trading/trading/weinstein/strategy/lib/weinstein_strategy.ml` now filters `adjust_transitions` against the union of all exit channel `position_id` sets (stops + stage3 + laggard + force_liq) before concatenating. This eliminates the (Exiting, UpdateRiskParams) collision at the source.
+
+This change is in `weinstein_strategy.ml`, not in the core `Trading_strategy` library at `trading/trading/strategy/lib/position.ml` — the position state machine is unchanged and the validation contract is preserved. The fix lives in the strategy's transition-assembly logic, which is the appropriate locus per `docs/design/eng-design-3-portfolio-stops.md` ("strategy decides what transitions to emit; Position validates they are well-formed").
+
+### Fix B — defensive crash handling (graceful degradation)
+
+`trading/trading/backtest/scenarios/scenario_runner.ml` now writes a sentinel `actual.sexp` (with `crashed = true` + the `Exn.to_string` message) when the child process catches an unhandled exception from `Backtest.Runner.run_backtest`. The parent's `_format_row` surfaces the crash inline:
+
+```
+sp500-15y-stage3-on-h1     -100.0%       0   0.0%  100.0%   FAIL (scenario crashed: <exn>)
+```
+
+This honors the PR-goal stated in the dispatch prompt:
+
+> Backtests should always produce an `actual.sexp` even if the run is degenerate.
+
+The sentinel uses out-of-range values (-100% return, 100% drawdown) so range checks fail explicitly rather than passing on NaN. The new `crashed` field is `[@sexp.default false]` so pre-fix `actual.sexp` files still parse.
+
+Note that Fix A eliminates the *specific* invariant trip that triggered this PR. Fix B is the defense-in-depth: any future invariant (e.g. cash-floor breach, position state drift, etc.) will now produce a meaningful FAIL row instead of a silent miss.
+
+## What was *not* changed
+
+Deliberately untouched:
+
+- `trading/trading/strategy/lib/position.ml` — the position state machine. The `(Exiting, UpdateRiskParams)` rejection is correct: it's not valid to tighten the stop on a position that's already exiting.
+- `trading/trading/simulation/lib/simulator.ml` — the simulator's `step` properly returns `Error`. The buck stops at the panel runner.
+- `trading/trading/backtest/lib/panel_runner.ml`'s `_step_failed` — converting the simulator's `Error` to a `failwith` is a fail-loud choice that surfaces invariant trips clearly. The right place to soften the failure mode is the scenario_runner (Fix B), which is the orchestration layer that owns the "what should the table look like on crash?" question.
+
+## Open questions / follow-ups
+
+1. **Are there other adjust-vs-exit collision modes?** This investigation focused on the `UpdateRiskParams` adjust path because that's what stops emits. If future runners emit other non-exit transitions (e.g. position resizing), the same dedup pattern must apply.
+
+2. **Should `Force_liquidation_runner` also dedup against its own prior-tick state?** If a position transitions Holding → Exiting on tick T (via force-liq) but the broker hasn't filled by tick T+1, force-liq's input on T+1 still sees the Exiting position. The runner's `_position_input_of_holding` already guards on `Holding` state so this is fine — non-Holding positions are skipped. Same is true for Stage-3 and laggard.
+
+3. **The 5y K=1 cell was the only one that worked in PR #906.** The luck of not hitting the collision in 5y vs. hitting it in 15y is purely stochastic (more weeks → more chances for the rare combination). After Fix A, the collision is impossible regardless of window length, and 15y K=1/2/3/4 should now produce real metrics. PR #906's experiment can be re-run cleanly.
+
+4. **The PR #906 strategy-3-force-exit decision still stands.** Even with Fix A, the underlying strategy result remains: K=1 on 5y is the only profitable cell; K=2/3/4 underperform. This PR doesn't change the strategy's economics, only its crash-resistance.
+
+## Verification
+
+After the fix:
+
+```bash
+docker exec trading-1-dev bash -c '
+  cd /workspaces/trading-1/trading && eval $(opam env) &&
+  dune build && dune runtest trading/weinstein/strategy/
+'
+```
+
+passes. End-to-end 15y reproduction shows Fix A is working as designed: the
+scenario progresses past cycle 100 (where the pre-fix crash occurred at cycle 60
+in PR #906's runs), confirming the (Exiting, UpdateRiskParams) collision is
+no longer hit. Equity oscillates in the $90K–$660K range across cycles 100–160 as
+the strategy bleeds capital from high-turnover whipsaws (the same pathological
+behavior PR #906 documented at $51K–$540K terminal). The 15y window may complete
+with degenerate metrics or hit a different invariant later — either way, Fix B
+(scenario_runner sentinel `actual.sexp`) ensures a row is reported with a
+meaningful FAIL message rather than the silent "did not write actual.sexp" path.
+
+Sample progress.sexp during the post-fix run (cycle 160 of 882):
+
+```
+((started_at 1778114782) (updated_at 1778114926) (cycles_done 160)
+ (cycles_total 882) (last_completed_date 2012-06-22) (trades_so_far 389)
+ (current_equity 114288.68539999983))
+```
+
+The capital collapse is real (the strategy with Stage-3 force-exit ON is
+genuinely a bad-policy combination on 15y SP500), but it is now a *measurable*
+collapse rather than a silent process abort.
+
+## Out of scope for this PR
+
+- **Strategy economics.** This PR does not modify what the Stage-3 / laggard /
+  stops policies do — only how their transitions are assembled into the final
+  per-tick transition list. The PR #906 finding (K=1 on 5y is the only
+  profitable cell; K=2/3/4 underperform) still stands and is the appropriate
+  follow-up for `feat-weinstein` (composite Stage-3 quality filter, per the
+  PR #906 recommendation §1).
+- **Position state machine.** `(Exiting, UpdateRiskParams)` continues to be
+  rejected by `Position.apply_transition` — that is correct behavior. The
+  fix lives in the strategy (which decides what to emit), not in the position
+  module (which validates well-formed transitions).
+- **Simulator / panel_runner failure-handling.** `Backtest.Panel_runner._step_failed`
+  still calls `failwith` on simulator-step Error. The defensive layer this PR
+  adds is at the scenario_runner level (the orchestration boundary), where it
+  can write the sentinel `actual.sexp` and surface the crash inline. Pushing the
+  failure handling deeper into the simulator would require modifying core
+  modules (per `.claude/rules/qc-structural-authority.md` A1).

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -67,6 +67,17 @@ type actual = {
   force_liquidations_count : int; [@sexp.default 0]
       (* G4 (force-liquidation policy). Defaults to 0 on read so pre-G4
          actual.sexp files that don't carry the field still parse. *)
+  crashed : bool; [@sexp.default false]
+      (* True when the backtest's [Backtest.Runner.run_backtest] raised an
+         exception (e.g. an unhandled simulator-state invariant trip). The
+         child writes a sentinel [actual.sexp] in that case so the parent
+         row reports a meaningful FAIL with metrics filled with sentinel
+         values rather than the silent "did not write actual.sexp" path.
+         Defaults to [false] on read so pre-flag actual.sexp files that
+         don't carry the field still parse. *)
+  crash_message : string; [@sexp.default ""]
+      (* Human-readable [Exn.to_string] of the exception that crashed the
+         child, for diagnosis. Empty string when [crashed = false]. *)
 }
 [@@deriving sexp]
 
@@ -85,6 +96,28 @@ let _actual_of_result (r : Backtest.Runner.result) =
     open_positions_value = get OpenPositionsValue;
     unrealized_pnl = get UnrealizedPnl;
     force_liquidations_count = List.length r.force_liquidations;
+    crashed = false;
+    crash_message = "";
+  }
+
+(** Build a sentinel [actual] for a crashed run. Uses out-of-range numeric
+    values (-100% return, 0 trades, very large drawdown) so the parent's range
+    checks fail explicitly rather than passing on NaN. The [crashed] flag
+    distinguishes a genuine "strategy lost almost everything" run from a true
+    unhandled-exception abort. *)
+let _crashed_actual ~msg =
+  {
+    total_return_pct = -100.0;
+    total_trades = 0.0;
+    win_rate = 0.0;
+    sharpe_ratio = 0.0;
+    max_drawdown_pct = 100.0;
+    avg_holding_days = 0.0;
+    open_positions_value = 0.0;
+    unrealized_pnl = 0.0;
+    force_liquidations_count = 0;
+    crashed = true;
+    crash_message = msg;
   }
 
 (* Range checking *)
@@ -136,11 +169,13 @@ let _print_header () =
 let _format_row (s : Scenario.t) (a : actual) checks =
   let all_ok = List.for_all checks ~f:(fun c -> c.ok) in
   let result_str =
-    if all_ok then "PASS" else sprintf "FAIL (%s)" (_failure_message checks)
+    if a.crashed then sprintf "FAIL (scenario crashed: %s)" a.crash_message
+    else if all_ok then "PASS"
+    else sprintf "FAIL (%s)" (_failure_message checks)
   in
   printf "%-28s %7.1f%% %7.0f %7.1f%% %7.1f%%   %s\n" s.name a.total_return_pct
     a.total_trades a.win_rate a.max_drawdown_pct result_str;
-  all_ok
+  all_ok && not a.crashed
 
 (* Directories *)
 
@@ -206,6 +241,19 @@ let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
 (* Fork-based worker pool. Scenarios run in parallel child processes up to
    [parallel] at a time. *)
 
+(** Write a sentinel [actual.sexp] for a crashed child so the parent's row
+    reports a meaningful FAIL (with [-100%] return / [100%] drawdown sentinels
+    and the exception message) rather than the silent "did not write
+    actual.sexp" path that loses the failure mode in CI logs. The [scenario_dir]
+    is created defensively in case the crash predates the
+    [_run_scenario_in_child] mkdir call. *)
+let _write_crashed_actual ~output_root (s : Scenario.t) ~msg =
+  let scenario_dir = _scenario_dir ~output_root s in
+  Core_unix.mkdir_p scenario_dir;
+  Sexp.save_hum
+    (_actual_path ~output_root s)
+    (sexp_of_actual (_crashed_actual ~msg))
+
 let _fork_scenario ~output_root ~fixtures_root ~progress_every (s : Scenario.t)
     =
   match Core_unix.fork () with
@@ -214,7 +262,17 @@ let _fork_scenario ~output_root ~fixtures_root ~progress_every (s : Scenario.t)
         _run_scenario_in_child ~output_root ~fixtures_root ~progress_every s;
         Stdlib.exit 0
       with e ->
-        eprintf "Scenario %s crashed: %s\n%!" s.name (Exn.to_string e);
+        let msg = Exn.to_string e in
+        eprintf "Scenario %s crashed: %s\n%!" s.name msg;
+        (* Write a sentinel actual.sexp so the parent row reports a
+           meaningful FAIL with crash metadata instead of the silent
+           "did not write actual.sexp" path. Wrap in its own try/with
+           because a writer failure on a crash path must still exit
+           cleanly. *)
+        (try _write_crashed_actual ~output_root s ~msg
+         with e2 ->
+           eprintf "Scenario %s: failed to write crashed actual.sexp: %s\n%!"
+             s.name (Exn.to_string e2));
         Stdlib.exit 1)
   | `In_the_parent pid -> pid
 
@@ -257,19 +315,21 @@ let _print_crashed_row (s : Scenario.t) =
   printf "%-28s %8s %7s %8s %8s   %s\n" s.name "-" "-" "-" "-"
     "FAIL (scenario crashed or did not write actual.sexp)"
 
-let _process_result ~output_root (s, status) =
-  match status with
-  | Crashed ->
+let _process_result ~output_root (s, _status) =
+  (* On both [Succeeded] and [Crashed] statuses, attempt to load the child's
+     [actual.sexp] first. The child now writes a sentinel actual.sexp (with
+     [crashed = true]) on the unhandled-exception path before exiting non-zero,
+     so a [Crashed] status with a parseable actual.sexp is the new graceful-
+     degradation path. The fallback [_print_crashed_row] is kept for genuinely
+     silent failures (e.g. SIGKILL, child exit before [_run_scenario_in_child]'s
+     mkdir, or filesystem errors during the sentinel write). *)
+  match _load_actual ~output_root s with
+  | Some a ->
+      let checks = _run_checks a s.expected in
+      _format_row s a checks
+  | None ->
       _print_crashed_row s;
       false
-  | Succeeded -> (
-      match _load_actual ~output_root s with
-      | None ->
-          _print_crashed_row s;
-          false
-      | Some a ->
-          let checks = _run_checks a s.expected in
-          _format_row s a checks)
 
 (* CLI *)
 

--- a/trading/trading/backtest/scenarios/test/dune
+++ b/trading/trading/backtest/scenarios/test/dune
@@ -4,12 +4,14 @@
   test_universe_file
   test_fixtures_root
   test_scenario_runner_isolation
+  test_scenario_runner_actual_sexp
   test_scenario_progress)
  (modules
   test_scenario
   test_universe_file
   test_fixtures_root
   test_scenario_runner_isolation
+  test_scenario_runner_actual_sexp
   test_scenario_progress)
  (libraries
   ounit2

--- a/trading/trading/backtest/scenarios/test/test_scenario_runner_actual_sexp.ml
+++ b/trading/trading/backtest/scenarios/test/test_scenario_runner_actual_sexp.ml
@@ -1,0 +1,179 @@
+(** Wire-format regression for the [actual.sexp] file
+    {!Scenario_runner._write_crashed_actual} writes when a scenario crashes in a
+    child process (PR #911 follow-up).
+
+    Background: PR #911 added a sentinel-write path so a child that crashes with
+    an unhandled exception still emits [actual.sexp] — with sentinel metric
+    values (-100% return, 100% drawdown, 0 trades) and two new fields
+    ([crashed : bool] and [crash_message : string]) — instead of the silent "did
+    not write actual.sexp" failure mode that lost the crash signature in CI
+    logs.
+
+    The two contracts pinned by this test:
+
+    - Round-trip: a crashed [actual] with sentinel field values round-trips
+      through [sexp_of_t] / [t_of_sexp] without losing data.
+    - Backwards compatibility: a pre-flag [actual.sexp] that lacks the new
+      [crashed] and [crash_message] fields still parses, with the defaults
+      [crashed = false] and [crash_message = ""] applied per the
+      [[@sexp.default ...]] annotations.
+
+    Why a local mirror type rather than [Scenario_runner]'s production type:
+    [scenario_runner.ml] is an executable, not a library — its [actual] type is
+    not exposed on any module path that test code can import. Pinning the wire
+    format from a parallel type definition is the lightest viable test surface
+    that respects the "test files only — do NOT modify production code"
+    constraint of the rework. The mirror type's field shape, defaults, and
+    derivation MUST be kept bit-equivalent to the production type at
+    [scenario_runner.ml] lines 53–82; if they ever drift, both sides need to
+    land together (production change first, then this test updated to match in
+    the same PR). A future refactor that hoists [actual] into [scenario_lib]
+    should replace this mirror with a direct [Scenario_runner_actual.t]
+    reference. *)
+
+open OUnit2
+open Core
+open Matchers
+
+type actual = {
+  total_return_pct : float;
+  total_trades : float;
+  win_rate : float;
+  sharpe_ratio : float;
+  max_drawdown_pct : float;
+  avg_holding_days : float;
+  open_positions_value : float; [@sexp.default Float.nan]
+  unrealized_pnl : float;
+  force_liquidations_count : int; [@sexp.default 0]
+  crashed : bool; [@sexp.default false]
+  crash_message : string; [@sexp.default ""]
+}
+[@@deriving sexp]
+(** Local mirror of [Scenario_runner.actual] (scenario_runner.ml lines 53–82).
+    MUST match the production shape exactly — same field names, same types, same
+    [[@sexp.default ...]] annotations, same record field order. *)
+
+(** Mirror of [Scenario_runner._crashed_actual] (scenario_runner.ml lines
+    108–121). Builds the sentinel record the production code writes when a child
+    crashes. *)
+let _crashed_actual ~msg =
+  {
+    total_return_pct = -100.0;
+    total_trades = 0.0;
+    win_rate = 0.0;
+    sharpe_ratio = 0.0;
+    max_drawdown_pct = 100.0;
+    avg_holding_days = 0.0;
+    open_positions_value = 0.0;
+    unrealized_pnl = 0.0;
+    force_liquidations_count = 0;
+    crashed = true;
+    crash_message = msg;
+  }
+
+(** Round-trip: a crashed sentinel record sexps and parses back to a
+    bit-equivalent record.
+
+    Fields under load-bearing scrutiny:
+    - [crashed = true] — the boolean that distinguishes a crashed run from a
+      normal-but-degenerate run with -100% return.
+    - [crash_message] — the [Exn.to_string] payload that flows from the child's
+      [eprintf] line into the parent's row renderer.
+    - [total_return_pct = -100.0] / [max_drawdown_pct = 100.0] — out- of-range
+      sentinels picked so the parent's [Scenario.in_range] checks fail
+      explicitly rather than silently passing on NaN.
+    - [total_trades = 0.0] — sentinel that pins this is not a normal run with a
+      small trade count. *)
+let test_crashed_actual_round_trips _ =
+  let sentinel = _crashed_actual ~msg:"unhandled exception (test)" in
+  let parsed = actual_of_sexp (sexp_of_actual sentinel) in
+  assert_that parsed
+    (all_of
+       [
+         field (fun a -> a.crashed) (equal_to true);
+         field
+           (fun a -> a.crash_message)
+           (equal_to "unhandled exception (test)");
+         field (fun a -> a.total_return_pct) (float_equal (-100.0));
+         field (fun a -> a.max_drawdown_pct) (float_equal 100.0);
+         field (fun a -> a.total_trades) (float_equal 0.0);
+         field (fun a -> a.force_liquidations_count) (equal_to 0);
+       ])
+
+(** Backwards-compat: a pre-flag [actual.sexp] (one written before PR #911 added
+    [crashed] and [crash_message]) must still parse cleanly, with the defaults
+    [crashed = false] and [crash_message = ""] applied. This is what the
+    [[@sexp.default ...]] annotations are for — without them, any historical
+    [actual.sexp] sitting under [dev/backtest/] or in CI artefact archives would
+    fail to parse on re-read.
+
+    The sexp string below is exactly the shape a successful (non-crash)
+    pre-PR-#911 child wrote: the seven core metric fields, plus
+    [open_positions_value] / [unrealized_pnl] / [force_liquidations_count]
+    (which were already present pre-#911), and crucially WITHOUT the new
+    [crashed] / [crash_message] fields. *)
+let test_pre_flag_sexp_parses_with_defaults _ =
+  let pre_flag_sexp_str =
+    {|((total_return_pct 12.5)
+      (total_trades 42.0)
+      (win_rate 55.5)
+      (sharpe_ratio 1.2)
+      (max_drawdown_pct 15.0)
+      (avg_holding_days 22.5)
+      (open_positions_value 5000.0)
+      (unrealized_pnl 1234.56)
+      (force_liquidations_count 3))|}
+  in
+  let parsed = actual_of_sexp (Sexp.of_string pre_flag_sexp_str) in
+  assert_that parsed
+    (all_of
+       [
+         (* The new fields take their declared defaults. *)
+         field (fun a -> a.crashed) (equal_to false);
+         field (fun a -> a.crash_message) (equal_to "");
+         (* The pre-existing fields parse through to the values declared
+            in the pre-flag sexp, confirming the shape isn't reordered
+            or otherwise mangled. *)
+         field (fun a -> a.total_return_pct) (float_equal 12.5);
+         field (fun a -> a.total_trades) (float_equal 42.0);
+         field (fun a -> a.force_liquidations_count) (equal_to 3);
+       ])
+
+(** Backwards-compat (deeper): a pre-G4 [actual.sexp] (one written before
+    [force_liquidations_count] was added) must also parse — exercising the chain
+    of [[@sexp.default ...]] defaults the type carries. Pinning this protects
+    every historical sexp shape simultaneously, not just the most recent one
+    before #911. *)
+let test_pre_g4_sexp_parses_with_chained_defaults _ =
+  let pre_g4_sexp_str =
+    {|((total_return_pct 7.0)
+      (total_trades 10.0)
+      (win_rate 60.0)
+      (sharpe_ratio 0.8)
+      (max_drawdown_pct 12.0)
+      (avg_holding_days 18.0)
+      (open_positions_value 1000.0)
+      (unrealized_pnl 500.0))|}
+  in
+  let parsed = actual_of_sexp (Sexp.of_string pre_g4_sexp_str) in
+  assert_that parsed
+    (all_of
+       [
+         field (fun a -> a.force_liquidations_count) (equal_to 0);
+         field (fun a -> a.crashed) (equal_to false);
+         field (fun a -> a.crash_message) (equal_to "");
+         field (fun a -> a.total_return_pct) (float_equal 7.0);
+       ])
+
+let suite =
+  "Scenario_runner_actual_sexp"
+  >::: [
+         "crashed actual round-trips with sentinel values"
+         >:: test_crashed_actual_round_trips;
+         "pre-flag sexp parses with crashed/crash_message defaults"
+         >:: test_pre_flag_sexp_parses_with_defaults;
+         "pre-G4 sexp parses with chained sexp.default values"
+         >:: test_pre_g4_sexp_parses_with_chained_defaults;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -743,6 +743,44 @@ let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
               ~macro_result
         | _ -> []
       in
+      (* Strip [UpdateRiskParams] adjusts whose [position_id] is also exiting
+         this tick via any exit channel (stops [Stop_hit], Stage-3 force-exit,
+         laggard rotation, or force-liquidation). Without this filter, the
+         simulator applies transitions in declaration order — exits first,
+         adjusts last — and the trailing adjust hits an [Exiting]-state
+         position, which [Trading_strategy.Position.apply_transition] rejects
+         with [Invalid transition UpdateRiskParams for current state]. The
+         resulting [Error] propagates out of [Simulator.step], converts into
+         a [failwith] at [Backtest.Panel_runner._step_failed], and aborts the
+         scenario_runner child without an [actual.sexp]. The collision is
+         possible whenever stops emit [Stop_raised] (an adjust) for a position
+         that one of the other exit channels also fires for on the same bar
+         — which the 15y SP500 + [enable_stage3_force_exit = true] regime
+         hits within ~60 weekly cycles (PR #906 follow-up). *)
+      let force_liq_exited_ids =
+        List.filter_map force_exit_transitions
+          ~f:(fun (t : Position.transition) ->
+            match t.kind with
+            | Position.TriggerExit _ -> Some t.position_id
+            | _ -> None)
+        |> String.Set.of_list
+      in
+      let all_exited_ids =
+        Set.union_list
+          (module String)
+          [
+            stop_exited_ids;
+            stage3_exited_ids;
+            laggard_exited_ids;
+            force_liq_exited_ids;
+          ]
+      in
+      let adjust_transitions =
+        if Set.is_empty all_exited_ids then adjust_transitions
+        else
+          List.filter adjust_transitions ~f:(fun (t : Position.transition) ->
+              not (Set.mem all_exited_ids t.position_id))
+      in
       Ok
         {
           Strategy_interface.transitions =

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
@@ -278,6 +278,185 @@ let test_no_primary_index_bar_short_circuits _ =
     (equal_to FL.Active)
 
 (* ------------------------------------------------------------------ *)
+(* Adjust-vs-exit dedup invariant (PR #911 follow-up)                  *)
+(* ------------------------------------------------------------------ *)
+
+(** Build a [Holding] long position via the canonical entry chain so the result
+    is bit-equal to what the simulator would have produced. Reused by the dedup
+    test below. *)
+let _make_holding_long ~symbol ~position_id ~entry_date ~quantity ~entry_price =
+  let unwrap = function
+    | Ok p -> p
+    | Error err -> assert_failure ("position setup failed: " ^ Status.show err)
+  in
+  let trans kind =
+    { Trading_strategy.Position.position_id; date = entry_date; kind }
+  in
+  let p =
+    Trading_strategy.Position.create_entering
+      (trans
+         (Trading_strategy.Position.CreateEntering
+            {
+              symbol;
+              side = Trading_base.Types.Long;
+              target_quantity = quantity;
+              entry_price;
+              reasoning =
+                Trading_strategy.Position.TechnicalSignal
+                  { indicator = "test"; description = "dedup test entry" };
+            }))
+    |> unwrap
+  in
+  let p =
+    Trading_strategy.Position.apply_transition p
+      (trans
+         (Trading_strategy.Position.EntryFill
+            { filled_quantity = quantity; fill_price = entry_price }))
+    |> unwrap
+  in
+  Trading_strategy.Position.apply_transition p
+    (trans
+       (Trading_strategy.Position.EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = Some 50.0;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+(** Regression for the (Exiting, UpdateRiskParams) collision pinned by the dedup
+    pass at [weinstein_strategy.ml] lines 746–783.
+
+    The strategy's transition assembly previously concatenated
+    [adjust_transitions] (UpdateRiskParams from {!Stops_runner}) AFTER the exit
+    channels. When the same [position_id] appeared in both — a [Stop_raised]
+    event from {!Weinstein_stops} producing an adjust, AND a
+    {!Force_liquidation_runner} fire producing a [TriggerExit] on the same bar —
+    the simulator applied transitions in declaration order: exits first, then
+    adjusts. The trailing UpdateRiskParams hit a position whose state had just
+    been advanced to [Exiting], which
+    {!Trading_strategy.Position.apply_transition} rejects as
+    [Invalid transition UpdateRiskParams for current state]. The resulting
+    [Error] propagated out of [Simulator.step], surfaced as a [failwith] at
+    [Backtest.Panel_runner._step_failed], and aborted the scenario_runner child
+    without an [actual.sexp].
+
+    The dedup invariant pinned here: a [position_id] present in any exit-channel
+    id-set (stops [Stop_hit], Stage-3 force-exit, laggard rotation, or
+    force-liquidation) must NOT appear in the post-filter [adjust_transitions]
+    returned by {!Internal_for_test.on_market_close}.
+
+    Test construction:
+    - Long AAPL position, entry $100 × 100, [stop_state = Tightened] seeded with
+      [stop_level = 50.0, last_correction_extreme = 90.0].
+    - Tick bar at close = $70: bar.low = 70 < last_correction_extreme = 90, so
+      [Weinstein_stops._ratchet_tightened] computes a tighter candidate stop and
+      emits [Stop_raised] → [Stops_runner] turns this into an [UpdateRiskParams]
+      adjust transition for position_id "AAPL-1".
+    - The same tick: entry $100 → current $70 = 30% loss (above the 25%
+      [max_long_unrealized_loss_fraction] default), so
+      {!Force_liquidation_runner.update} emits a per-position [TriggerExit] for
+      "AAPL-1".
+    - bar.low = 70 > stop_level = 50, so [check_stop_hit] returns false — stops
+      do NOT also emit a trigger; the only exit channel firing is
+      force-liquidation.
+    - The output transition list must contain the force-liq [TriggerExit] for
+      "AAPL-1" and zero [UpdateRiskParams] entries for "AAPL-1".
+
+    Pre-dedup the test would observe both transitions; post-dedup only the
+    [TriggerExit] survives. *)
+let test_adjust_dedup_against_force_liq_exit _ =
+  let symbol = "AAPL" in
+  let position_id = "AAPL-1" in
+  let entry_date = Date.of_string "2024-01-02" in
+  let current_date = Date.of_string "2024-04-29" in
+  let pos =
+    _make_holding_long ~symbol ~position_id ~entry_date ~quantity:100.0
+      ~entry_price:100.0
+  in
+  let positions = String.Map.singleton symbol pos in
+  (* Single-bar reader: AAPL drops to $70 (30% loss → fires per-position
+     force-liq); the primary index sits at $100 so the Friday macro pass
+     and the [_compute_ma_and_stage] warmup default both stay quiet. *)
+  let aapl_bar =
+    {
+      (_make_daily_bar ~date:current_date ~price:70.0) with
+      Types.Daily_price.low_price = 70.0;
+      close_price = 70.0;
+    }
+  in
+  let index_bar = _make_daily_bar ~date:current_date ~price:100.0 in
+  let bar_reader =
+    Bar_reader.of_in_memory_bars
+      [ (symbol, [ aapl_bar ]); (_index_symbol, [ index_bar ]) ]
+  in
+  let state = _fresh_state ~bar_reader in
+  (* Seed the Tightened stop_state. Bar low = 70 stays above stop_level = 50
+     (no trigger), but 70 < last_correction_extreme = 90, so the ratchet
+     fires Stop_raised with a candidate stop above the current 50.0. *)
+  state.stop_states :=
+    Map.set !(state.stop_states) ~key:symbol
+      ~data:
+        (Weinstein_stops.Tightened
+           {
+             stop_level = 50.0;
+             last_correction_extreme = 90.0;
+             reason = "test setup — primed for ratchet";
+           });
+  let config =
+    Weinstein_strategy.default_config ~universe:[] ~index_symbol:_index_symbol
+  in
+  let portfolio : Trading_strategy.Portfolio_view.t =
+    { cash = 100_000.0; positions }
+  in
+  let result = _drive_tick state ~config ~current_date ~portfolio in
+  (* Assertion: the position's TriggerExit (from force-liq) is in the
+     transition list, and no UpdateRiskParams transition for the same
+     position_id appears. Pre-dedup, both would be present and the
+     simulator would error on the second.
+
+     Counts are extracted via [field] composition (one [assert_that] per
+     value) per .claude/rules/test-patterns.md — the [all_of] tree pins
+     both [TriggerExit = 1] and [UpdateRiskParams = 0] for the
+     position_id under test. *)
+  let count_for transitions ~is_kind =
+    List.count transitions ~f:(fun (t : Trading_strategy.Position.transition) ->
+        String.equal t.position_id position_id && is_kind t.kind)
+  in
+  let is_trigger_exit = function
+    | Trading_strategy.Position.TriggerExit _ -> true
+    | _ -> false
+  in
+  let is_update_risk_params = function
+    | Trading_strategy.Position.UpdateRiskParams _ -> true
+    | _ -> false
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (o : Trading_strategy.Strategy_interface.output) ->
+            o.transitions)
+          (all_of
+             [
+               (* Exactly one TriggerExit for the position — the force-liq
+                  one. Pre-fix this would also be 1 (force-liq still fires);
+                  this assertion just pins that the exit is preserved. *)
+               field
+                 (fun ts -> count_for ts ~is_kind:is_trigger_exit)
+                 (equal_to 1);
+               (* Zero UpdateRiskParams for the position. Pre-dedup this
+                  would be 1 (the Stop_raised adjust). The dedup filter
+                  strips it because the position is in [force_liq_exited_ids].
+                  This is the load-bearing assertion. *)
+               field
+                 (fun ts -> count_for ts ~is_kind:is_update_risk_params)
+                 (equal_to 0);
+             ])))
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -296,6 +475,8 @@ let suite =
          >:: test_halt_persists_when_macro_stays_bearish;
          "G13 — no primary index bar short-circuits without observing peak"
          >:: test_no_primary_index_bar_short_circuits;
+         "PR #911 dedup — adjust transitions stripped when force-liq exits"
+         >:: test_adjust_dedup_against_force_liq_exit;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Two complementary fixes that resolve PR #906's silent 15y crash:

- **Strategy-side preventive dedup** (`weinstein_strategy.ml`): adjust_transitions are now filtered against the union of stop / stage3 / laggard / force-liq exit ids before being concatenated into the strategy's transition output. This eliminates the (Exiting, UpdateRiskParams) collision that aborted the simulator within ~60 of 882 weekly cycles on the 15y SP500 + `enable_stage3_force_exit = true` regime.
- **Defensive crash handling** (`scenarios/scenario_runner.ml`): the child now writes a sentinel `actual.sexp` (with `crashed = true` + `Exn.to_string`) on the unhandled-exception path so the parent's row reports a meaningful FAIL with crash metadata rather than the silent "did not write actual.sexp" path. Honors PR #906's stated harness goal: backtests should always produce an `actual.sexp` even on degenerate runs.

## Root cause

`weinstein_strategy.ml` concatenates exits and adjusts in this order:

```
exit_transitions @ stage3_exits @ laggard_exits @ force_liq_exits @ adjusts @ entries
```

When `Stops_runner` emits `UpdateRiskParams` (a `Stop_raised` event — trail tightening) for position P **and** any exit channel emits `TriggerExit` for the same P on the same Friday tick:

1. The simulator applies the exit first → P transitions Holding → Exiting
2. The simulator then applies the adjust → `Position.apply_transition` rejects `(Exiting, UpdateRiskParams)` with `Invalid transition`
3. `Simulator.step` returns `Result.Error`
4. `Backtest.Panel_runner._step_failed` calls `failwith` → unhandled OCaml exception
5. `scenario_runner` child catches it, prints "crashed" to stderr, exits 1
6. Parent reports the silent "did not write actual.sexp" row

The existing dedup logic dedups overlapping TriggerExits across runners but never dedups `adjust_transitions` against any exit channel. The collision is rare under default settings (only `Stop_raised` + force-liq simultaneously) but `enable_stage3_force_exit = true` adds a third TriggerExit channel that fires on the same Friday cadence; 882 cycles + 60+ held positions guarantee the collision within ~60 weeks.

This explains why PR #906's 5y K=1 cell happened to work (stochastic non-collision) while every 15y cell crashed.

## What changed

### `trading/trading/weinstein/strategy/lib/weinstein_strategy.ml` (+38 LOC)

Added a final dedup pass before the transitions are concatenated: filter `adjust_transitions` against the union of stop/stage3/laggard/force-liq exit ids.

`weinstein_strategy.ml` is in `trading/trading/weinstein/strategy/lib/` — **not** the core `trading/trading/strategy/` (Trading_strategy.Position lives there). No core-module modification per A1.

### `trading/trading/backtest/scenarios/scenario_runner.ml` (+88 / -14 LOC)

- `actual` record gains `crashed : bool [@sexp.default false]` + `crash_message : string [@sexp.default ""]`. Both default-on-read so pre-fix `actual.sexp` still parses.
- New `_crashed_actual ~msg` constructor with sentinel values (-100% return, 100% drawdown, 0 trades) so range checks fail explicitly rather than passing on NaN.
- `_fork_scenario`'s catch-all `try/with` now writes a sentinel `actual.sexp` before exiting non-zero, wrapped in its own try/with so a writer failure on the crash path still exits cleanly.
- `_format_row` surfaces `crashed = true` inline: `FAIL (scenario crashed: <exn>)`.
- `_process_result` now attempts to load `actual.sexp` on both `Succeeded` and `Crashed` statuses, falling back to `_print_crashed_row` only for genuinely silent failures (SIGKILL, mkdir failure, FS errors during the sentinel write).

### `dev/notes/15y-crash-investigation-2026-05-07.md` (new)

Diagnostic write-up: reproduction, root-cause analysis, fix scope, what was deliberately *not* changed (Position state machine, Simulator/Panel_runner failure-handling), and follow-ups.

## Verification

- `dune build` clean.
- `dune runtest trading/backtest/ trading/weinstein/strategy/` passes (existing repo-level linters that flag pre-existing files unaffected by this diff).
- 15y SP500 + `enable_stage3_force_exit = true` scenario now progresses past cycle 100 (vs. pre-fix crash at cycle 60). Equity oscillates in the $90K–$660K range — the strategy bleeds capital at high turnover (PR #906's economic finding), but the collapse is now a *measurable* degenerate result, not a silent abort.

## What this PR does NOT change

- **Strategy economics.** The Stage-3 / laggard / stops policies are unchanged. PR #906's finding (K=1 on 5y is the only profitable cell; K=2/3/4 underperform) still stands. Composite Stage-3 quality filter is appropriate `feat-weinstein` follow-up.
- **Position state machine.** `(Exiting, UpdateRiskParams)` continues to be rejected — that is correct behavior. The fix is in the strategy (which decides what to emit), not in Position (which validates well-formed transitions).
- **Simulator / panel_runner failure-handling.** `Backtest.Panel_runner._step_failed` still calls `failwith`. Pushing the failure handling deeper into the simulator would require modifying core modules (per A1 in qc-structural-authority); the orchestration boundary is the right place to soften the failure mode.

Refs: PR #906 (issue #872 Stage-3 force-exit impact); PR #909 (issue #887 laggard rotation, also affected by the same collision pattern).

## Test plan

- [x] `dune build` clean
- [x] `dune build @fmt` clean for files in this PR (pre-existing CI/container ocamlformat skew on unrelated `.mli` files is documented in memory; not in this diff)
- [x] `dune runtest trading/backtest/ trading/weinstein/strategy/` all pass
- [x] 15y reproduction past prior crash point: cycle 100+ achieved (vs. 60 pre-fix)
- [ ] 15y reproduction completes (in progress; ~30-60 min wall time; equity will likely terminate degenerate but will produce a parseable actual.sexp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)