### PR TITLE
fix(harness): cleanup_merged_worktrees default --stale-hours 1 (protect in-flight agents)

### DIFF
--- a/dev/scripts/cleanup_merged_worktrees.sh
+++ b/dev/scripts/cleanup_merged_worktrees.sh
@@ -7,22 +7,29 @@
 #
 # Flags:
 #   --dry-run           Print what would be removed; make no deletions.
-#   --stale-hours N     Only remove worktrees older than N hours (default: 0,
-#                       i.e. any merged-branch worktree is eligible immediately).
-#                       Use a positive value to preserve very-recent failed-push
-#                       agent work for manual inspection.
+#   --stale-hours N     Only remove worktrees older than N hours
+#                       (default: 1). The default protects in-flight agents
+#                       whose branches have not yet been pushed to origin —
+#                       [git ls-remote] returns empty for them, which would
+#                       otherwise classify them as "merged + branch deleted"
+#                       and reap them mid-run. Set to 0 to override (e.g.
+#                       in CI cleanup where no agents are running). Set
+#                       higher to retain failed-push artefacts longer for
+#                       manual inspection.
 #
 # How it works:
 #   For each .claude/worktrees/agent-*/ directory:
 #     1. Determine the branch name from jj bookmarks (preferred) or git HEAD.
 #     2. If the branch is still present on origin → keep (PR not yet merged).
-#     3. If the branch is gone from origin → remove (PR merged, branch deleted).
+#     3. If the branch is gone from origin and the worktree is older than
+#        --stale-hours → remove (either: PR merged + branch deleted, or:
+#        long-abandoned failed-push).
 #     4. If no branch can be determined → skip with a warning (can't decide).
 #
-# This is safe to run mid-session: live branches are always preserved.
-# Failed-push agents (never pushed) have no origin branch → treated as merged
-# and are removed after --stale-hours (default 0, so immediately). Pass
-# --stale-hours 1 to retain them for manual inspection.
+# This is safe to run mid-session: live branches are always preserved, and
+# the 1-hour default protects in-flight agents whose first push has not yet
+# completed. The previous default (0) reaped such agents — see PR #916
+# follow-up + dev/notes/next-session-priorities-2026-05-07.md §P6.
 #
 # Logs to: dev/logs/worktree-cleanup-YYYY-MM-DD.log (appended)
 
@@ -38,7 +45,7 @@ REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
 # Defaults
 # ---------------------------------------------------------------------------
 DRY_RUN=0
-STALE_HOURS=0
+STALE_HOURS=1
 
 # ---------------------------------------------------------------------------
 # Argument parsing


### PR DESCRIPTION
## Summary

P6 from `dev/notes/next-session-priorities-2026-05-07.md`.

The hook-driven cleanup at `dev/scripts/cleanup_merged_worktrees.sh` previously defaulted `--stale-hours 0`. For agent worktrees whose branch had not yet been pushed to origin, `git ls-remote` returns empty — the script classified them as "merged + deleted" and reaped them immediately. This caught **three** in-flight multi-hour experiment agents during the 2026-05-06 overnight session.

## Fix

Default `--stale-hours 1` (one-line change). One hour of grace is enough for an in-flight agent to complete its first push (typically within minutes of dispatch); once the branch lands on origin, `ls-remote` sees it and the keep path takes over for as long as the PR is open. After merge, the branch is deleted from origin, the worktree's directory mtime is well past the 1h gate, and the merged-PR cleanup proceeds.

## Override

- `--stale-hours 0` recovers the previous "reap immediately" behavior — appropriate in CI cleanup where no agents are running.
- Higher values retain failed-push artefacts for manual inspection.

## Test plan

- [x] `bash -n dev/scripts/cleanup_merged_worktrees.sh` — syntax clean.
- [x] `bash dev/scripts/cleanup_merged_worktrees.sh --dry-run` — runs end-to-end on the current `.claude/worktrees/`; existing worktrees skipped (no determinable branch); `git worktree prune` clean.
- Behavior change is in the default constant + docstring; no test infrastructure pinned the default's value, so the change is observed via the docstring + side-by-side dry-run logs.

## Diff

1 file, ~30 lines (mostly docstring rewording; the actual default constant change is one line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)