### PR TITLE
refactor(simulator): extract Split_handler module (file-length unblock)

### DIFF
--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -12,6 +12,7 @@
   core)
  (modules
   simulator
+  split_handler
   order_generator
   metrics
   metric_computers

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -349,103 +349,7 @@ let _apply_trades_best_effort portfolio trades =
       | Ok p -> (p, accepted @ [ trade ])
       | Error _ -> (portfolio, accepted))
 
-(* Detect a split for [symbol] between the prior trading day's bar and
-   today's bar. Returns [Some event] when both bars exist and the detector
-   fires, otherwise [None]. Pure with respect to the adapter's cache. *)
-let _detect_split_for_held_symbol ~adapter ~date ~symbol =
-  let curr =
-    Trading_simulation_data.Market_data_adapter.get_price adapter ~symbol ~date
-  in
-  let prev =
-    Trading_simulation_data.Market_data_adapter.get_previous_bar adapter ~symbol
-      ~date
-  in
-  let%bind.Option curr = curr in
-  let%bind.Option prev = prev in
-  let%map.Option factor = Types.Split_detector.detect_split ~prev ~curr () in
-  { Trading_portfolio.Split_event.symbol; date; factor }
-
-(* For every symbol currently held in [portfolio], compare the prior
-   trading day's bar against the current day's bar and return the list of
-   detected split events. Symbols with no current bar (weekends/holidays)
-   or no prior bar (first appearance) yield no event. Order follows
-   [portfolio.positions] (sorted by symbol). *)
-let _detect_splits_for_held_positions t =
-  let adapter = t.deps.market_data_adapter in
-  let date = t.current_date in
-  List.filter_map t.portfolio.Trading_portfolio.Portfolio.positions
-    ~f:(fun (pos : Trading_portfolio.Types.portfolio_position) ->
-      _detect_split_for_held_symbol ~adapter ~date ~symbol:pos.symbol)
-
-(* Apply each detected split event to [portfolio] in order. Pure: returns
-   the updated portfolio with all events folded in. *)
-let _apply_split_events portfolio events =
-  List.fold events ~init:portfolio ~f:(fun acc event ->
-      Trading_portfolio.Split_event.apply_to_portfolio event acc)
-
-(* Apply a split factor to a strategy-side [Position.t]'s share-count and
-   per-share-price fields. Long-only path: [Holding.quantity] multiplies by
-   [factor] and [Holding.entry_price] divides by [factor], preserving total
-   cost basis. [Exiting] mirrors the same scaling on its share-count fields
-   ([quantity], [target_quantity], [filled_quantity]) and per-share-price
-   fields ([entry_price], [exit_price]). [Entering] (in-flight entry order)
-   and [Closed] (historical) pass through unchanged: an entry order spanning
-   a split is exotic and out of scope for the broker-model fix; closed
-   positions have no live state to scale.
-
-   Pure: returns a new [Position.t] with [state] replaced. The position's
-   [id], [symbol], [side], [entry_reasoning], [exit_reason], [last_updated],
-   and [portfolio_lot_ids] are unchanged. *)
-let _apply_split_to_position (factor : float)
-    (pos : Trading_strategy.Position.t) : Trading_strategy.Position.t =
-  let open Trading_strategy.Position in
-  let new_state =
-    match pos.state with
-    | Holding { quantity; entry_price; entry_date; risk_params } ->
-        Holding
-          {
-            quantity = quantity *. factor;
-            entry_price = entry_price /. factor;
-            entry_date;
-            risk_params;
-          }
-    | Exiting
-        {
-          quantity;
-          entry_price;
-          entry_date;
-          target_quantity;
-          exit_price;
-          filled_quantity;
-          started_date;
-        } ->
-        Exiting
-          {
-            quantity = quantity *. factor;
-            entry_price = entry_price /. factor;
-            entry_date;
-            target_quantity = target_quantity *. factor;
-            exit_price = exit_price /. factor;
-            filled_quantity = filled_quantity *. factor;
-            started_date;
-          }
-    | (Entering _ | Closed _) as s -> s
-  in
-  { pos with state = new_state }
-
-(* Apply detected split events to the strategy-side [Position.t] map. Each
-   event matches positions by symbol; multiple positions on the same symbol
-   (lots reopened after a prior close) all get scaled. Order matches
-   [_apply_split_events]: events are folded in detection order. Pure. *)
-let _apply_splits_to_positions
-    (positions : Trading_strategy.Position.t String.Map.t)
-    (events : Trading_portfolio.Split_event.t list) :
-    Trading_strategy.Position.t String.Map.t =
-  List.fold events ~init:positions ~f:(fun acc event ->
-      Map.map acc ~f:(fun pos ->
-          if String.equal pos.Trading_strategy.Position.symbol event.symbol then
-            _apply_split_to_position event.factor pos
-          else pos))
+(* Split-handling helpers extracted to {!Split_handler}. *)
 
 let step t =
   if _is_complete t then Ok (Completed (_build_run_result t))
@@ -453,9 +357,13 @@ let step t =
     let open Result.Let_syntax in
     (* Detect splits first; then scale BOTH the broker portfolio and the
        strategy-side [Position.t] map in lockstep — see the helper docs. *)
-    let split_events = _detect_splits_for_held_positions t in
-    let portfolio = _apply_split_events t.portfolio split_events in
-    let positions = _apply_splits_to_positions t.positions split_events in
+    let split_events =
+      Split_handler.detect_for_held_positions
+        ~adapter:t.deps.market_data_adapter ~date:t.current_date
+        ~portfolio:t.portfolio
+    in
+    let portfolio = Split_handler.apply_events t.portfolio split_events in
+    let positions = Split_handler.apply_to_positions t.positions split_events in
     let today_bars = _get_today_bars t in
     (* Record stale-held positions (symbols without bars for K+ days) into
        the per-run log. Detector only — no force-close; see [Stale_hold].

--- a/trading/trading/simulation/lib/split_handler.ml
+++ b/trading/trading/simulation/lib/split_handler.ml
@@ -1,0 +1,69 @@
+open Core
+
+let detect_for_symbol ~adapter ~date ~symbol =
+  let curr =
+    Trading_simulation_data.Market_data_adapter.get_price adapter ~symbol ~date
+  in
+  let prev =
+    Trading_simulation_data.Market_data_adapter.get_previous_bar adapter ~symbol
+      ~date
+  in
+  let%bind.Option curr = curr in
+  let%bind.Option prev = prev in
+  let%map.Option factor = Types.Split_detector.detect_split ~prev ~curr () in
+  { Trading_portfolio.Split_event.symbol; date; factor }
+
+let detect_for_held_positions ~adapter ~date ~portfolio =
+  List.filter_map portfolio.Trading_portfolio.Portfolio.positions
+    ~f:(fun (pos : Trading_portfolio.Types.portfolio_position) ->
+      detect_for_symbol ~adapter ~date ~symbol:pos.symbol)
+
+let apply_events portfolio events =
+  List.fold events ~init:portfolio ~f:(fun acc event ->
+      Trading_portfolio.Split_event.apply_to_portfolio event acc)
+
+let apply_to_position (factor : float) (pos : Trading_strategy.Position.t) :
+    Trading_strategy.Position.t =
+  let open Trading_strategy.Position in
+  let new_state =
+    match pos.state with
+    | Holding { quantity; entry_price; entry_date; risk_params } ->
+        Holding
+          {
+            quantity = quantity *. factor;
+            entry_price = entry_price /. factor;
+            entry_date;
+            risk_params;
+          }
+    | Exiting
+        {
+          quantity;
+          entry_price;
+          entry_date;
+          target_quantity;
+          exit_price;
+          filled_quantity;
+          started_date;
+        } ->
+        Exiting
+          {
+            quantity = quantity *. factor;
+            entry_price = entry_price /. factor;
+            entry_date;
+            target_quantity = target_quantity *. factor;
+            exit_price = exit_price /. factor;
+            filled_quantity = filled_quantity *. factor;
+            started_date;
+          }
+    | (Entering _ | Closed _) as s -> s
+  in
+  { pos with state = new_state }
+
+let apply_to_positions (positions : Trading_strategy.Position.t String.Map.t)
+    (events : Trading_portfolio.Split_event.t list) :
+    Trading_strategy.Position.t String.Map.t =
+  List.fold events ~init:positions ~f:(fun acc event ->
+      Map.map acc ~f:(fun pos ->
+          if String.equal pos.Trading_strategy.Position.symbol event.symbol then
+            apply_to_position event.factor pos
+          else pos))

--- a/trading/trading/simulation/lib/split_handler.mli
+++ b/trading/trading/simulation/lib/split_handler.mli
@@ -1,0 +1,67 @@
+(** Split detection and application — broker portfolio + strategy-side
+    {!Trading_strategy.Position.t} map updates. Pure helpers extracted from
+    {!Simulator} so the simulator stays under the file-length limit and the
+    split-handling logic is independently unit-testable.
+
+    Two-side scaling is required because the simulator threads two parallel
+    representations of the same position state: the broker portfolio
+    ({!Trading_portfolio.Portfolio.t}) and the strategy-facing
+    {!Trading_strategy.Position.t} map. Both must be scaled in lockstep on
+    every detected split or the views diverge.
+
+    No behavior change relative to the pre-extraction simulator — the
+    helpers were lifted verbatim. *)
+
+open Core
+
+val detect_for_symbol :
+  adapter:Trading_simulation_data.Market_data_adapter.t ->
+  date:Date.t ->
+  symbol:string ->
+  Trading_portfolio.Split_event.t option
+(** Detect a split for [symbol] between the prior trading day's bar and
+    today's bar. Returns [Some event] when both bars exist and
+    {!Types.Split_detector.detect_split} fires; otherwise [None]. Pure
+    with respect to the adapter's cache. *)
+
+val detect_for_held_positions :
+  adapter:Trading_simulation_data.Market_data_adapter.t ->
+  date:Date.t ->
+  portfolio:Trading_portfolio.Portfolio.t ->
+  Trading_portfolio.Split_event.t list
+(** For every symbol currently held in [portfolio], call
+    {!detect_for_symbol}. Symbols with no current bar (weekends/holidays) or
+    no prior bar (first appearance) yield no event. Order follows
+    [portfolio.positions] (sorted by symbol). *)
+
+val apply_events :
+  Trading_portfolio.Portfolio.t ->
+  Trading_portfolio.Split_event.t list ->
+  Trading_portfolio.Portfolio.t
+(** Apply each detected split event to [portfolio] in order. Pure: returns
+    the updated portfolio with all events folded in. *)
+
+val apply_to_position :
+  float -> Trading_strategy.Position.t -> Trading_strategy.Position.t
+(** Apply a split [factor] to a strategy-side {!Trading_strategy.Position.t}'s
+    share-count and per-share-price fields. Long-only path: [Holding.quantity]
+    multiplies by [factor] and [Holding.entry_price] divides by [factor],
+    preserving total cost basis. [Exiting] mirrors the same scaling on its
+    share-count fields ([quantity], [target_quantity], [filled_quantity]) and
+    per-share-price fields ([entry_price], [exit_price]). [Entering]
+    (in-flight entry order) and [Closed] (historical) pass through unchanged:
+    an entry order spanning a split is exotic and out of scope for the
+    broker-model fix; closed positions have no live state to scale.
+
+    Pure: returns a new [Position.t] with [state] replaced. The position's
+    [id], [symbol], [side], [entry_reasoning], [exit_reason], [last_updated],
+    and [portfolio_lot_ids] are unchanged. *)
+
+val apply_to_positions :
+  Trading_strategy.Position.t String.Map.t ->
+  Trading_portfolio.Split_event.t list ->
+  Trading_strategy.Position.t String.Map.t
+(** Apply detected split events to the strategy-side {!Position.t} map. Each
+    event matches positions by symbol; multiple positions on the same symbol
+    (lots reopened after a prior close) all get scaled. Order matches
+    {!apply_events}: events are folded in detection order. Pure. *)


### PR DESCRIPTION
## Summary

`simulator.ml` grew to 519 lines after PR #916 (P1 stale-hold detector), exceeding the 500-line `@large-module` hard limit. The `dune runtest` cache had been hiding the violation; **PR #919 merging invalidated the cache and revealed main's CI is now broken**.

This PR extracts the five split-handling helpers (~90 lines) verbatim from `simulator.ml` to `trading/simulation/lib/split_handler.{ml,mli}`:

- `detect_for_symbol` (was `_detect_split_for_held_symbol`)
- `detect_for_held_positions` (was `_detect_splits_for_held_positions`, now pure — takes `~portfolio` explicitly)
- `apply_events` (was `_apply_split_events`)
- `apply_to_position` (was `_apply_split_to_position`)
- `apply_to_positions` (was `_apply_splits_to_positions`)

`simulator.ml` now 427 lines, under the 500 limit. No behavior change.

## Caveat — partial fix

This PR does NOT fully restore green CI. Other linter violations on main:

| Linter | Files / functions |
|--------|-------------------|
| File length | `screener.ml` 708, `weinstein_strategy.ml` 862, `runner.ml` 528, `entry_audit_capture.ml` 383, `optimal_strategy_runner.ml` 413, `optimal_strategy_report.ml` 488, `result_writer.ml` 372, `panel_runner.ml` 310, `snapshot_bar_views.ml` 312 |
| Function length | `run_backtest` 83, `simulator.step` 63, `_on_market_close` 261, `make` 61, `make_entry_transition` 54 |
| Magic numbers | 3+ literals in `snapshot_bar_views.ml` |
| Nesting | 99 functions exceed avg+max nesting |
| Status integrity | 6 status files use orchestrator-style "ENUM — prose" values; linter requires strict enum |

A follow-up linter-recalibration PR (or PRs) is needed to either (a) refactor the offenders, (b) loosen the limits to current state, or (c) add per-file exceptions. Each is a strategic call on how strictly to enforce.

## Test plan

- [x] `dune build` exits 0.
- [x] `dune build trading/simulation/` exits 0.
- [x] `simulator.ml` line count: 427 (was 519).
- [x] No behavior change — helpers lifted verbatim; call site in `Simulator.step` unchanged semantically.
- ⚠️ `dune runtest` still fails on the OTHER pre-existing linter violations (see caveat above). This PR's contribution is one violation removed, not all.

## Diff

3 files: `simulator.ml` (-90 LOC), `simulator.ml`'s helpers extracted to new `split_handler.ml` (+71 LOC) + `split_handler.mli` (+58 LOC), dune updated. Net +50 LOC across the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)