### PR TITLE
fix(status): strict enum values for status linter

### DIFF
--- a/dev/status/all-eligible.md
+++ b/dev/status/all-eligible.md
@@ -3,7 +3,12 @@
 ## Last updated: 2026-05-06
 
 ## Status
-IN_PROGRESS (PR-2 ready for review; PR-1 merged via #899)
+IN_PROGRESS
+
+(PR-2 ready for review; PR-1 merged via #899)
+
+## Interface stable
+NO
 
 ## Goal
 

--- a/dev/status/hybrid-tier.md
+++ b/dev/status/hybrid-tier.md
@@ -3,7 +3,9 @@
 ## Last updated: 2026-05-04
 
 ## Status
-MERGED — both options shipped; no active work in this track
+MERGED
+
+(Both options shipped; no active work in this track.)
 
 Phase 1 (measurement infra) merged (#609). Phase 2 was replanned via
 PR #611 into two separate plans after Phase 1 results showed the

--- a/dev/status/orchestrator-automation.md
+++ b/dev/status/orchestrator-automation.md
@@ -3,7 +3,9 @@
 ## Last updated: 2026-05-04
 
 ## Status
-IN_PROGRESS — Phase 1 stable (~18 days uptime); Phase 2 deferred (no active dispatch)
+IN_PROGRESS
+
+(Phase 1 stable, ~18 days uptime; Phase 2 deferred, no active dispatch.)
 
 Phase 1 (scheduled daily orchestrator on GHA) has been producing daily
 summary PRs since 2026-04-16. See `.github/workflows/orchestrator.yml`

--- a/dev/status/tuning.md
+++ b/dev/status/tuning.md
@@ -3,7 +3,9 @@
 ## Last updated: 2026-05-07
 
 ## Status
-READY_FOR_REVIEW — T-A lib + CLI MERGED; T-B lib MERGED; T-B CLI READY_FOR_REVIEW; walk-forward integration deferred
+READY_FOR_REVIEW
+
+(T-A lib + CLI MERGED; T-B lib MERGED; T-B CLI READY_FOR_REVIEW; walk-forward integration deferred)
 
 T-A grid_search lib + tests landed via PR #805 (merged 2026-05-03). T-A CLI binary landed via PR #893 (merged 2026-05-06). T-B Bayesian-opt lib + tests landed via PR #817 (merged 2026-05-04). T-B CLI binary `bayesian_runner.exe` ready for review on branch `feat/backtest-tuning-bayesian-opt-cli` (this PR). All `.mli` surfaces are stable. Track created 2026-05-02 to absorb M5.5 (parameter tuning) + M7.1 (ML training). Plans: `dev/plans/m5-experiments-roadmap-2026-05-02.md` (T-A grid + T-B Bayesian) + `dev/plans/m7-data-and-tuning-2026-05-02.md` (T-C supervised) + `dev/plans/grid-search-2026-05-03.md` (T-A clarifying) + `dev/plans/bayesian-opt-2026-05-03.md` (T-B clarifying with D1–D8 design decisions). Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M5.5 + M7.1 (added 2026-05-02).
 

--- a/dev/status/weekly-snapshot.md
+++ b/dev/status/weekly-snapshot.md
@@ -3,14 +3,16 @@
 ## Last updated: 2026-05-04
 
 ## Status
-PLANNED — owner moved to feat-weinstein per #778 scope expansion
+PENDING
+
+(Owner moved to feat-weinstein per #778 scope expansion.)
 
 Track created 2026-05-02 to absorb M6.1–M6.5 (verification harness via incremental processing). Plan: `dev/plans/m6-weekly-snapshot-verification-2026-05-02.md`. Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M6.1–M6.5 (added 2026-05-02).
 
 Per the 2026-05-04 daily summary (#830): M6.1–M6.5 absorbed into feat-weinstein scope; M6.6 live cycle DEFERRED.
 
 ## Interface stable
-NO — track is brand-new.
+N/A
 
 The reframe: **weekly picks are first-class durable artifacts before they're inputs to live trading.** This subsystem is a verification harness first; the M6.6 live cycle is wiring on top.
 


### PR DESCRIPTION
## Summary

Status integrity linter (`trading/devtools/checks/status_file_integrity.sh`) requires the `## Status` value to be a strict enum: one of `IN_PROGRESS|READY_FOR_REVIEW|APPROVED|MERGED|BLOCKED|PENDING`. The orchestrator + manual edits accumulated values like `MERGED — both options shipped...` which violate the enum check.

5 status files fixed:
- `tuning.md`: `READY_FOR_REVIEW — T-A lib + ...` → `READY_FOR_REVIEW` + prose moved to a follow-on paragraph.
- `all-eligible.md`: `IN_PROGRESS (PR-2 ready ...)` → `IN_PROGRESS` + prose moved + new `## Interface stable: NO` section (was missing).
- `hybrid-tier.md`: `MERGED — both options shipped...` → `MERGED` + prose moved.
- `orchestrator-automation.md`: `IN_PROGRESS — Phase 1 stable...` → `IN_PROGRESS` + prose moved.
- `weekly-snapshot.md`: `PLANNED — owner moved to feat-weinstein per #778` → `PENDING` (PLANNED isn't in the enum; PENDING semantically matches "designed/specced but not yet dispatched"). Plus `## Interface stable` updated to `N/A` (matches the PENDING + N/A rule the linter enforces).

Context information that was previously in the status value itself is now in a parenthetical paragraph immediately below — preserves the diagnostic content while satisfying the linter.

## Why now

After #919 merged, the dune-runtest cache invalidated and surfaced a number of pre-existing linter violations. Status integrity was one of 6 linter failures revealed. This PR closes the simplest of the six.

Per `feedback_status_refresh_must_verify.md` user memory: claims in status prose were preserved verbatim during the move, no propagation of stale truths.

## Test plan

- [x] `bash trading/devtools/checks/status_file_integrity.sh` exits 0 — `OK: all dev/status/*.md files have required fields.`
- [x] All 5 modified files build/lint clean.
- [x] Other linter failures (file length, function length, magic numbers, nesting) NOT addressed in this PR — separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)