### PR TITLE
cleanup(runner): extract metric-overlay module + shorten run_backtest

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -17,10 +17,9 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
-- [~] fn_length + file_length: trading/trading/backtest/lib/runner.ml — `run_backtest` 83 lines, file 528 lines; extract metric-overlay helpers + sub-functions (source: dispatch 2026-05-07)
-
 ## Completed
 
+- [x] fn_length + file_length: trading/trading/backtest/lib/runner.ml — extracted `Runner_metrics` module + `_filter_steps`/`_extract_filtered_logs` helpers; runner.ml 528→468 lines, `run_backtest` 83→49 lines. Branch cleanup/runner-fn-length (2026-05-07)
 - [x] nesting: trading/analysis/data/storage/csv/lib/csv_storage.ml — extracted `_parse_and_accumulate` and `_read_next_line` helpers; nesting linter now passes (835 fns, all OK). (source: 2026-04-26-fast.md, PR #578 merged 2026-04-26T16:04Z)
 - [x] fn_length / file_length: weinstein_strategy.ml — added @large-module annotation; file length linter now passes. (source: 2026-04-19-fast.md, PR #453, 2026-04-19)
 

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -17,6 +17,8 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
+- [~] fn_length + file_length: trading/trading/backtest/lib/runner.ml — `run_backtest` 83 lines, file 528 lines; extract metric-overlay helpers + sub-functions (source: dispatch 2026-05-07)
+
 ## Completed
 
 - [x] nesting: trading/analysis/data/storage/csv/lib/csv_storage.ml — extracted `_parse_and_accumulate` and `_read_next_line` helpers; nesting linter now passes (835 fns, all OK). (source: 2026-04-26-fast.md, PR #578 merged 2026-04-26T16:04Z)

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -265,87 +265,6 @@ let _run_panel_backtest ~deps ~start_date ~end_date ~warmup_days
     ~start_date ~end_date ~warmup_days ~initial_cash ~commission
     ?strategy_choice ?trace ?gc_trace ?bar_data_source ?progress_emitter ()
 
-(** Re-run the step-based metric computers ([SharpeRatio], [MaxDrawdown],
-    [CAGR]) on the in-window step list with a config whose [start_date] is the
-    actual run start (not the warmup_start the simulator was created with). The
-    simulator computed these metrics across [warmup_start..end_date], which
-    folds the warmup window's drawdown, return volatility, and total return into
-    the published values; this overlay restores the metrics' values to "what
-    happened during the measurement window only". *)
-let _recompute_in_window_step_metrics ~steps_in_range ~start_date ~end_date =
-  let config : Trading_simulation_types.Simulator_types.config =
-    {
-      start_date;
-      end_date;
-      initial_cash;
-      commission;
-      strategy_cadence = Types.Cadence.Daily;
-    }
-  in
-  let computers =
-    [
-      Metric_computers.sharpe_ratio_computer ();
-      Metric_computers.max_drawdown_computer ();
-      Metric_computers.cagr_computer ();
-    ]
-  in
-  List.fold computers ~init:Trading_simulation_types.Metric_types.empty
-    ~f:(fun acc c ->
-      Trading_simulation_types.Metric_types.merge acc
-        (c.run ~config ~steps:steps_in_range))
-
-(** Recompute [CalmarRatio = CAGR / MaxDrawdown] from already-overlaid
-    [base_metrics]. The simulator emits [CalmarRatio] from the
-    [calmar_ratio_derived] computer using its own warmup-inclusive CAGR /
-    MaxDrawdown; once the overlay has replaced those with in-window values, the
-    published [CalmarRatio] must follow or the ratio is inconsistent with its
-    components. *)
-let _recompute_calmar_ratio ~base_metrics =
-  let dummy_config : Trading_simulation_types.Simulator_types.config =
-    {
-      start_date = Date.create_exn ~y:2000 ~m:Month.Jan ~d:1;
-      end_date = Date.create_exn ~y:2000 ~m:Month.Jan ~d:1;
-      initial_cash;
-      commission;
-      strategy_cadence = Types.Cadence.Daily;
-    }
-  in
-  Metric_computers.calmar_ratio_derived.compute ~config:dummy_config
-    ~base_metrics
-
-(** Three-stage overlay applied to the simulator's metric set:
-
-    1. Replace round-trip-derived metrics ([TotalPnl], [AvgHoldingDays],
-    [WinCount], [LossCount], [WinRate], [ProfitFactor]) with values computed
-    from the runner's range-filtered [round_trips] — observed empirically on
-    [panel-golden-2019-full] (sim says 3 wins; runner round_trips says 2 wins;
-    trades.csv shows 2; the overlay aligns the summary to trades.csv).
-
-    2. Replace step-based metrics ([SharpeRatio], [MaxDrawdown], [CAGR]) with
-    values recomputed on [steps_in_range] (the in-window step list only) —
-    without this, warmup-window drawdown / return / volatility inflate the
-    published values vs. what actually happened in the run.
-
-    3. Recompute [CalmarRatio] from the overlaid CAGR / MaxDrawdown so the
-    derived metric stays consistent with its components.
-
-    The simulator runs from [warmup_start] (not [start_date]) so all three of
-    its metric flavors (round-trip, step-based, and derived) include the warmup
-    window. The overlay restores the invariant that the published metrics
-    describe the measurement window only. *)
-let _align_summary_metrics ~sim_result ~round_trips ~steps_in_range ~start_date
-    ~end_date =
-  let merge = Trading_simulation_types.Metric_types.merge in
-  let after_round_trips =
-    merge sim_result.Trading_simulation_types.Simulator_types.metrics
-      (Metrics.compute_round_trip_metric_set round_trips)
-  in
-  let after_step =
-    merge after_round_trips
-      (_recompute_in_window_step_metrics ~steps_in_range ~start_date ~end_date)
-  in
-  merge after_step (_recompute_calmar_ratio ~base_metrics:after_step)
-
 (** Drop simulator-side [stop_info]s whose [entry_date] is before [start_date] —
     i.e. positions opened during the warmup window. The simulator runs from
     [warmup_start] so [Stop_log] observes [EntryComplete] transitions for
@@ -419,8 +338,8 @@ let _make_summary ~start_date ~end_date ~deps ~steps_in_range ~steps
     n_round_trips = List.length round_trips;
     stale_held_symbols;
     metrics =
-      _align_summary_metrics ~sim_result ~round_trips ~steps_in_range
-        ~start_date ~end_date;
+      Runner_metrics.align_summary_metrics ~sim_result ~round_trips
+        ~steps_in_range ~start_date ~end_date;
   }
 
 (** Filter [final_close_prices] to symbols that are still held in the last
@@ -440,6 +359,63 @@ let _final_prices_for_held_symbols ~steps ~final_close_prices =
         |> String.Set.of_list
       in
       List.filter final_close_prices ~f:(fun (sym, _) -> Set.mem held sym)
+
+(** Split [sim_result.steps] into two views over [start_date..end_date]:
+    [steps_in_range] includes every calendar day (needed for round-trip
+    extraction) and [steps] keeps only real trading days (needed for
+    mark-to-market consumers such as the equity curve). *)
+let _filter_steps ~sim_result ~start_date =
+  (* Steps in the requested date range, all days included. Round-trip
+     extraction derives trades from position-state transitions recorded on
+     these steps, so it must see *every* step where a trade fill happened —
+     including days the [is_trading_day] mark-to-market heuristic would
+     otherwise discard. *)
+  let steps_in_range =
+    List.filter sim_result.Trading_simulation_types.Simulator_types.steps
+      ~f:(fun (s : Trading_simulation_types.Simulator_types.step_result) ->
+        Date.( >= ) s.date start_date)
+  in
+  (* Steps on real trading days only — used for [OpenPositionsValue] /
+     [UnrealizedPnl] consumers and anything else that needs a meaningful
+     mark-to-market portfolio value. Simulator reports [portfolio_value = cash]
+     on weekends/holidays even when positions are open, so filter them out
+     before mark-to-market consumers use the series. *)
+  let steps = List.filter steps_in_range ~f:is_trading_day in
+  (steps_in_range, steps)
+
+(** Extract and in-window-filter all post-simulation artefacts: round trips,
+    stop infos, audit records, cascade summaries, force liquidations, and
+    stale holds. Wrapped in a [Trace.Teardown] span. *)
+let _extract_filtered_logs ?trace ?gc_trace ~stop_log ~trade_audit
+    ~force_liquidation_log ~stale_hold_log ~steps_in_range ~start_date () =
+  let round_trips, stop_infos, audit, cascade_summaries, force_liquidations =
+    Trace.record ?trace Trace.Phase.Teardown (fun () ->
+        ( Metrics.extract_round_trips steps_in_range,
+          filter_stop_infos_in_window
+            (Stop_log.get_stop_infos stop_log)
+            ~start_date,
+          filter_audit_records_in_window
+            (Trade_audit.get_audit_records trade_audit)
+            ~start_date,
+          filter_cascade_summaries_in_window
+            (Trade_audit.get_cascade_summaries trade_audit)
+            ~start_date,
+          filter_force_liquidations_in_window
+            (Force_liquidation_log.events force_liquidation_log)
+            ~start_date ))
+  in
+  Gc_trace.record ?trace:gc_trace ~phase:"teardown_done" ();
+  let stale_holds =
+    Trading_simulation.Stale_hold.Log.events stale_hold_log
+    |> List.filter ~f:(fun (e : Trading_simulation.Stale_hold.event) ->
+        Date.( >= ) e.date start_date)
+  in
+  ( round_trips,
+    stop_infos,
+    audit,
+    cascade_summaries,
+    force_liquidations,
+    stale_holds )
 
 let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     ?(strategy_choice = Strategy_choice.default) ?trace ?gc_trace
@@ -463,45 +439,12 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
       ~strategy_choice ?trace ?gc_trace ?bar_data_source ?progress_emitter ()
   in
   Gc_trace.record ?trace:gc_trace ~phase:"fill_done" ();
-  (* Steps in the requested date range, all days included. Round-trip
-     extraction derives trades from position-state transitions recorded on
-     these steps, so it must see *every* step where a trade fill happened —
-     including days the [is_trading_day] mark-to-market heuristic would
-     otherwise discard. *)
-  let steps_in_range =
-    List.filter sim_result.steps
-      ~f:(fun (s : Trading_simulation_types.Simulator_types.step_result) ->
-        Date.( >= ) s.date start_date)
-  in
-  (* Steps on real trading days only — used for [OpenPositionsValue] /
-     [UnrealizedPnl] consumers and
-     anything else that needs a meaningful mark-to-market portfolio value.
-     Simulator reports [portfolio_value = cash] on weekends/holidays even
-     when positions are open, so filter them out before mark-to-market
-     consumers use the series. *)
-  let steps = List.filter steps_in_range ~f:is_trading_day in
+  let steps_in_range, steps = _filter_steps ~sim_result ~start_date in
   let final_value = (List.last_exn steps).portfolio_value in
-  let round_trips, stop_infos, audit, cascade_summaries, force_liquidations =
-    Trace.record ?trace Trace.Phase.Teardown (fun () ->
-        ( Metrics.extract_round_trips steps_in_range,
-          filter_stop_infos_in_window
-            (Stop_log.get_stop_infos stop_log)
-            ~start_date,
-          filter_audit_records_in_window
-            (Trade_audit.get_audit_records trade_audit)
-            ~start_date,
-          filter_cascade_summaries_in_window
-            (Trade_audit.get_cascade_summaries trade_audit)
-            ~start_date,
-          filter_force_liquidations_in_window
-            (Force_liquidation_log.events force_liquidation_log)
-            ~start_date ))
-  in
-  Gc_trace.record ?trace:gc_trace ~phase:"teardown_done" ();
-  let stale_holds =
-    Trading_simulation.Stale_hold.Log.events stale_hold_log
-    |> List.filter ~f:(fun (e : Trading_simulation.Stale_hold.event) ->
-        Date.( >= ) e.date start_date)
+  let round_trips, stop_infos, audit, cascade_summaries, force_liquidations,
+      stale_holds =
+    _extract_filtered_logs ?trace ?gc_trace ~stop_log ~trade_audit
+      ~force_liquidation_log ~stale_hold_log ~steps_in_range ~start_date ()
   in
   let summary =
     _make_summary ~start_date ~end_date ~deps ~steps_in_range ~steps

--- a/trading/trading/backtest/lib/runner_metrics.ml
+++ b/trading/trading/backtest/lib/runner_metrics.ml
@@ -1,0 +1,82 @@
+open Core
+open Trading_simulation
+
+(** The simulator runs from [warmup_start] (not [start_date]) so all three of
+    its metric flavors (round-trip, step-based, and derived) include the warmup
+    window. The three functions below restore the invariant that the published
+    metrics describe the measurement window only. *)
+
+let initial_cash = 1_000_000.0
+let commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 }
+
+(** Re-run the step-based metric computers ([SharpeRatio], [MaxDrawdown],
+    [CAGR]) on the in-window step list with a config whose [start_date] is the
+    actual run start (not the warmup_start the simulator was created with). The
+    simulator computed these metrics across [warmup_start..end_date], which
+    folds the warmup window's drawdown, return volatility, and total return into
+    the published values; this overlay restores the metrics' values to "what
+    happened during the measurement window only". *)
+let recompute_in_window_step_metrics ~steps_in_range ~start_date ~end_date =
+  let config : Trading_simulation_types.Simulator_types.config =
+    {
+      start_date;
+      end_date;
+      initial_cash;
+      commission;
+      strategy_cadence = Types.Cadence.Daily;
+    }
+  in
+  let computers =
+    [
+      Metric_computers.sharpe_ratio_computer ();
+      Metric_computers.max_drawdown_computer ();
+      Metric_computers.cagr_computer ();
+    ]
+  in
+  List.fold computers ~init:Trading_simulation_types.Metric_types.empty
+    ~f:(fun acc c ->
+      Trading_simulation_types.Metric_types.merge acc
+        (c.run ~config ~steps:steps_in_range))
+
+(** Recompute [CalmarRatio = CAGR / MaxDrawdown] from already-overlaid
+    [base_metrics]. The simulator emits [CalmarRatio] from the
+    [calmar_ratio_derived] computer using its own warmup-inclusive CAGR /
+    MaxDrawdown; once the overlay has replaced those with in-window values, the
+    published [CalmarRatio] must follow or the ratio is inconsistent with its
+    components. *)
+let recompute_calmar_ratio ~base_metrics =
+  let dummy_config : Trading_simulation_types.Simulator_types.config =
+    {
+      start_date = Date.create_exn ~y:2000 ~m:Month.Jan ~d:1;
+      end_date = Date.create_exn ~y:2000 ~m:Month.Jan ~d:1;
+      initial_cash;
+      commission;
+      strategy_cadence = Types.Cadence.Daily;
+    }
+  in
+  Metric_computers.calmar_ratio_derived.compute ~config:dummy_config
+    ~base_metrics
+
+(** Three-stage overlay applied to the simulator's metric set:
+
+    1. Replace round-trip-derived metrics ([TotalPnl], [AvgHoldingDays],
+    [WinCount], [LossCount], [WinRate], [ProfitFactor]) with values computed
+    from the runner's range-filtered [round_trips].
+
+    2. Replace step-based metrics ([SharpeRatio], [MaxDrawdown], [CAGR]) with
+    values recomputed on [steps_in_range] (the in-window step list only).
+
+    3. Recompute [CalmarRatio] from the overlaid CAGR / MaxDrawdown so the
+    derived metric stays consistent with its components. *)
+let align_summary_metrics ~sim_result ~round_trips ~steps_in_range ~start_date
+    ~end_date =
+  let merge = Trading_simulation_types.Metric_types.merge in
+  let after_round_trips =
+    merge sim_result.Trading_simulation_types.Simulator_types.metrics
+      (Metrics.compute_round_trip_metric_set round_trips)
+  in
+  let after_step =
+    merge after_round_trips
+      (recompute_in_window_step_metrics ~steps_in_range ~start_date ~end_date)
+  in
+  merge after_step (recompute_calmar_ratio ~base_metrics:after_step)

--- a/trading/trading/backtest/lib/runner_metrics.mli
+++ b/trading/trading/backtest/lib/runner_metrics.mli
@@ -1,0 +1,30 @@
+open Core
+
+val recompute_in_window_step_metrics :
+  steps_in_range:Trading_simulation_types.Simulator_types.step_result list ->
+  start_date:Date.t ->
+  end_date:Date.t ->
+  Trading_simulation_types.Metric_types.metric_set
+(** Re-run [SharpeRatio], [MaxDrawdown], and [CAGR] computers on the
+    in-window step list only. The simulator runs from [warmup_start] so its
+    published step-based metrics include the warmup window; this call restores
+    them to the measurement window. *)
+
+val recompute_calmar_ratio :
+  base_metrics:Trading_simulation_types.Metric_types.metric_set ->
+  Trading_simulation_types.Metric_types.metric_set
+(** Recompute [CalmarRatio = CAGR / MaxDrawdown] from [base_metrics] so the
+    derived metric stays consistent with the already-overlaid CAGR and
+    MaxDrawdown components. *)
+
+val align_summary_metrics :
+  sim_result:Trading_simulation_types.Simulator_types.run_result ->
+  round_trips:Trading_simulation.Metrics.trade_metrics list ->
+  steps_in_range:Trading_simulation_types.Simulator_types.step_result list ->
+  start_date:Date.t ->
+  end_date:Date.t ->
+  Trading_simulation_types.Metric_types.metric_set
+(** Three-stage overlay: replace round-trip metrics from [round_trips], replace
+    step-based metrics from [steps_in_range], then recompute [CalmarRatio].
+    Restores the invariant that published metrics describe the measurement window
+    [start_date..end_date] only, not the warmup window the simulator ran from. *)


### PR DESCRIPTION
## Summary

`runner.ml` was over BOTH file-length and function-length limits. This PR fixes both via real extraction (no `@large-module` bumps, per `feedback_no_deferred_codehealth.md`).

## Findings closed

| Linter | Before | After | Limit |
|--------|--------|-------|-------|
| File length | 528 lines | 468 lines | 500 (declared-large hard) |
| Function length (`run_backtest`) | 83 lines | 49 lines | 50 |

## What was extracted

New module `trading/backtest/lib/runner_metrics.{ml,mli}` containing the three metric-overlay helpers:
- `_recompute_in_window_step_metrics` — re-runs SharpeRatio / MaxDrawdown / CAGR computers on the in-range step list (without the warmup window).
- `_recompute_calmar_ratio` — recomputes CalmarRatio = CAGR / MaxDrawdown from the overlaid base metrics.
- `_align_summary_metrics` — three-stage overlay (round-trip-derived metrics, step-based metrics, derived calmar).

`run_backtest`'s body shrunk from 83→49 by extracting two sub-functions for the teardown filter assembly + result construction. No behavior change; helpers lifted verbatim.

## Test plan

- [x] `dune build` exits 0
- [x] `dune runtest` — all green (the metric-overlay extraction is pure plumbing; no test needed to change).
- [x] file-length linter clears for `runner.ml` (468 < 500).
- [x] function-length linter clears for `run_backtest` (49 ≤ 50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)