### PR TITLE
cleanup: extract Friday/analysis helpers from optimal_strategy_runner

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -16,12 +16,12 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 ## Backlog
 
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
-
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed
 
 - [x] fn_length + file_length: trading/trading/backtest/lib/runner.ml — extracted `Runner_metrics` module + `_filter_steps`/`_extract_filtered_logs` helpers; runner.ml 528→468 lines, `run_backtest` 83→49 lines. Branch cleanup/runner-fn-length (2026-05-07)
+- [x] fn_length: trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml — extracted 8 helpers to Optimal_friday_helpers; 413→270 lines (branch cleanup/optimal-strategy-runner, 2026-05-07)
 - [x] nesting: trading/analysis/data/storage/csv/lib/csv_storage.ml — extracted `_parse_and_accumulate` and `_read_next_line` helpers; nesting linter now passes (835 fns, all OK). (source: 2026-04-26-fast.md, PR #578 merged 2026-04-26T16:04Z)
 - [x] fn_length / file_length: weinstein_strategy.ml — added @large-module annotation; file length linter now passes. (source: 2026-04-19-fast.md, PR #453, 2026-04-19)
 - [x] file_length: trading/analysis/weinstein/screener/lib/screener.ml — extracted sector_rating/scoring_weights/grade_thresholds types + signal helpers + price helpers to Screener_scoring; 708→485 lines (under 500 hard limit). (source: dispatch 2026-05-07, branch cleanup/screener-large)


### PR DESCRIPTION
## Summary

- `optimal_strategy_runner.ml` was 413 lines (limit 300, no `@large-module` annotation).
- Extracted 8 private helpers into a new library-internal `Optimal_friday_helpers` module:
  - **Friday calendar**: `friday_on_or_before`, `fridays_in_range`
  - **Per-Friday analysis**: `analyze_symbol_on_friday`, `build_sector_context_map`
  - **Forward-table construction**: `outlook_at`, `build_forward_table`
  - **Scan/score pipeline**: `scan_all_fridays`, `score_all_candidates`
- Runner drops from **413 → 270 lines**. New helpers file is 158 lines.
- Public interface unchanged: `forward_table` type, `forward_outlooks_for`, `load_macro_trend`, `run` remain in `optimal_strategy_runner.mli` with identical signatures.

## Finding source

Dispatch 2026-05-07: file-length linter violation — 413 lines, limit 300, no `@large-module` declaration.

## Test plan

- [x] `dune runtest` passes (full suite, EXIT:0)
- [x] `dune build @fmt` passes for touched files (no format diffs on `optimal_friday_helpers.ml` or `optimal_strategy_runner.ml`)
- [x] `optimal_strategy_runner.ml` now 270 lines (< 300)
- [x] No new public symbols in any `.mli`
- [x] No behavior change — pure extraction; `_build_world` and `_scan_and_score` call `H.*` delegates with identical semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)