### PR TITLE
cleanup(nesting): extract helpers from _process_position in stage3_force_exit_runner

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,7 +15,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
-- [~] nesting: trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml — _process_position avg 5.00 max 11 (limits avg 3.0 max 5); extract nested match chains into helpers (source: dispatch 2026-05-07)
+- [x] nesting: trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml — extracted _find_force_exit + _emit_if_eligible; _process_position nesting flattened (PR #935, 2026-05-07)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,6 +15,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
+- [~] nesting: trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml — _process_position avg 5.00 max 11 (limits avg 3.0 max 5); extract nested match chains into helpers (source: dispatch 2026-05-07)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 

--- a/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml
@@ -27,6 +27,32 @@ let _make_exit_transition ~(pos : Position.t) ~current_date ~bar
     kind = Position.TriggerExit { exit_reason; exit_price };
   }
 
+(** Look up the current stage for [symbol] and run the detector. Returns
+    [Some weeks_in_stage3] when the detector decides [Force_exit], [None]
+    otherwise (including when the symbol has no stage reading yet). Mutates
+    [stage3_streaks] in place via {!Stage3_force_exit.observe_position}. *)
+let _find_force_exit ~config ~stage3_streaks ~prior_stages symbol =
+  match Hashtbl.find prior_stages symbol with
+  | None -> None
+  | Some current_stage -> (
+      match
+        Stage3_force_exit.observe_position ~config ~state:stage3_streaks
+          ~symbol ~current_stage
+      with
+      | Stage3_force_exit.Hold -> None
+      | Stage3_force_exit.Force_exit { weeks_in_stage3 } ->
+          Some weeks_in_stage3)
+
+(** Emit a [TriggerExit] for [pos] if it is not already being exited by the
+    stops runner this tick and [get_price] has a bar for the symbol. Returns
+    [None] when either guard fires. *)
+let _emit_if_eligible ~stop_exit_position_ids ~get_price ~pos ~current_date
+    ~weeks_in_stage3 =
+  if Set.mem stop_exit_position_ids pos.Position.id then None
+  else
+    Option.map (get_price pos.symbol) ~f:(fun bar ->
+        _make_exit_transition ~pos ~current_date ~bar ~weeks_in_stage3)
+
 (** Process one position. Returns [Some transition] when the detector fires AND
     the position is not already exiting via a stop hit this tick. The detector's
     streak counter is always mutated (in [stage3_streaks]) — even on a skipped
@@ -35,21 +61,12 @@ let _process_position ~config ~stage3_streaks ~prior_stages
     ~stop_exit_position_ids ~get_price ~current_date (pos : Position.t) =
   match (pos.side, Position.get_state pos) with
   | Trading_base.Types.Long, Position.Holding _ -> (
-      match Hashtbl.find prior_stages pos.symbol with
+      match _find_force_exit ~config ~stage3_streaks ~prior_stages pos.symbol
+      with
       | None -> None
-      | Some current_stage -> (
-          let decision =
-            Stage3_force_exit.observe_position ~config ~state:stage3_streaks
-              ~symbol:pos.symbol ~current_stage
-          in
-          match decision with
-          | Stage3_force_exit.Hold -> None
-          | Stage3_force_exit.Force_exit { weeks_in_stage3 } ->
-              if Set.mem stop_exit_position_ids pos.id then None
-              else
-                Option.map (get_price pos.symbol) ~f:(fun bar ->
-                    _make_exit_transition ~pos ~current_date ~bar
-                      ~weeks_in_stage3)))
+      | Some weeks_in_stage3 ->
+          _emit_if_eligible ~stop_exit_position_ids ~get_price ~pos
+            ~current_date ~weeks_in_stage3)
   | _ -> None
 
 let update ~config ~is_screening_day ~positions ~get_price ~prior_stages


### PR DESCRIPTION
## Finding

Nesting linter violation in `trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml`:
- `_process_position` line 34: avg 5.00, max 11 (limits: avg 3.0, max 5)
- File average: 3.03 (limit 2.5)

Source: dispatch 2026-05-07.

## What changed

`_process_position` had three nested match expressions — on position state, on `Hashtbl.find prior_stages`, and on `Stage3_force_exit.observe_position`'s decision — plus an `Option.map` inside the innermost arm.

Extracted two private helpers:

- `_find_force_exit ~config ~stage3_streaks ~prior_stages symbol`: handles the `Hashtbl.find` lookup and the `observe_position` call. Returns `Some weeks_in_stage3` on `Force_exit`, `None` otherwise. Mutates `stage3_streaks` in place (same as before).
- `_emit_if_eligible ~stop_exit_position_ids ~get_price ~pos ~current_date ~weeks_in_stage3`: handles the stop-exit guard and the `Option.map` to build the `TriggerExit` transition.

`_process_position` is now a flat two-arm match with one delegate call per arm. Pure refactor; no behavior change.

## Test plan

- [x] `dune build trading/weinstein/` passes
- [x] `dune runtest trading/weinstein/` passes (22 tests across 6 suites — all OK)
- [x] `dune build @fmt` — no format issues in touched file
- [x] Diff is 32+14 = 46 LOC (well within ≤200 limit)
- [x] Single concern: one nesting finding, one file
- [x] No new public symbols (`.mli` unchanged)
- [x] No behavior change (pure structural extraction)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)