### PR TITLE
cleanup(nesting): extract helpers from _check_adjusted_close_continuity

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,7 +15,8 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
-- [~] nesting: trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml — _check_adjusted_close_continuity avg 4.46 max 9 (source: dispatch 2026-05-07)
+- [x] nesting: trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml — extracted _bar_mismatch + _continuity_check_result; fn avg 4.46→resolved, file avg 2.60→below 2.5 (PR #936, 2026-05-07)
+- [ ] nesting: trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml — _check_position_carryover avg 3.62 max 6, _check_stop_adjusted avg 3.50 max 6, _check_stop_unchanged avg 3.59 max 6 (source: dispatch 2026-05-07, pre-existing, separate PR)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,7 +15,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
-- [x] nesting: trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml — extracted _find_force_exit + _emit_if_eligible; _process_position nesting flattened (PR #935, 2026-05-07)
+- [~] nesting: trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml — _check_adjusted_close_continuity avg 4.46 max 9 (source: dispatch 2026-05-07)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 

--- a/trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml
+++ b/trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml
@@ -46,6 +46,27 @@ let _candidate_symbols (snapshot : Weekly_snapshot.t) =
 
 (* --------- Split checks --------- *)
 
+(* Check whether a single bar's adjusted_close * factor recovers close_price. *)
+let _bar_mismatch ~symbol ~factor ~tolerance (b : Types.Daily_price.t) =
+  let recovered = b.adjusted_close *. factor in
+  if _approximately_equal ~tolerance recovered b.close_price then None
+  else
+    Some
+      (Printf.sprintf "%s on %s: adjusted_close*factor=%.6f, close_price=%.6f"
+         symbol (Date.to_string b.date) recovered b.close_price)
+
+(* Build the pass/fail check from the collected mismatch strings. *)
+let _continuity_check_result ~symbol ~factor ~tolerance pre_bars mismatches =
+  if List.is_empty mismatches then
+    _pass ~name:"adjusted_close_continuity"
+      (Printf.sprintf
+         "%s: all %d pre-split bars reconcile (factor=%.4f, tol=%.1e)" symbol
+         (List.length pre_bars) factor tolerance)
+  else
+    _fail ~name:"adjusted_close_continuity"
+      (Printf.sprintf "%s: %d bar(s) failed; first: %s" symbol
+         (List.length mismatches) (List.hd_exn mismatches))
+
 let _check_adjusted_close_continuity ~symbol ~split_date ~factor ~tolerance
     (bars : Types.Daily_price.t list) =
   let pre_bars = List.filter bars ~f:(fun b -> Date.( < ) b.date split_date) in
@@ -55,24 +76,9 @@ let _check_adjusted_close_continuity ~symbol ~split_date ~factor ~tolerance
         (Printf.sprintf "%s: no pre-split bars present in fixture" symbol)
   | _ ->
       let mismatches =
-        List.filter_map pre_bars ~f:(fun b ->
-            let recovered = b.adjusted_close *. factor in
-            if _approximately_equal ~tolerance recovered b.close_price then None
-            else
-              Some
-                (Printf.sprintf
-                   "%s on %s: adjusted_close*factor=%.6f, close_price=%.6f"
-                   symbol (Date.to_string b.date) recovered b.close_price))
+        List.filter_map pre_bars ~f:(_bar_mismatch ~symbol ~factor ~tolerance)
       in
-      if List.is_empty mismatches then
-        _pass ~name:"adjusted_close_continuity"
-          (Printf.sprintf
-             "%s: all %d pre-split bars reconcile (factor=%.4f, tol=%.1e)"
-             symbol (List.length pre_bars) factor tolerance)
-      else
-        _fail ~name:"adjusted_close_continuity"
-          (Printf.sprintf "%s: %d bar(s) failed; first: %s" symbol
-             (List.length mismatches) (List.hd_exn mismatches))
+      _continuity_check_result ~symbol ~factor ~tolerance pre_bars mismatches
 
 let _check_position_carryover ~symbol ~factor ~(pre_lot : held_lot)
     (pick_pre : Weekly_snapshot.t) (pick_post : Weekly_snapshot.t) =


### PR DESCRIPTION
## Finding

From dispatch 2026-05-07: nesting linter violation in
`trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml`:

```
_check_adjusted_close_continuity  line 49: avg 4.46, max 9  (limits: avg 3.0, max 5)
File average: 2.60 (limit 2.5)
```

The deep nesting (max depth 9) came from a `Printf.sprintf` inside `Some(...)` inside an `if/else` inside a `List.filter_map` callback inside a `match` arm — all within a single function.

## Fix

Extracted two private helpers before `_check_adjusted_close_continuity`:

- `_bar_mismatch ~symbol ~factor ~tolerance b` — checks one bar's `adjusted_close * factor` against `close_price`; returns `None` or `Some` mismatch string
- `_continuity_check_result ~symbol ~factor ~tolerance pre_bars mismatches` — builds the named `pass`/`fail` check from the collected mismatch strings

The original function body is now 3 lines (filter_map call + tail call).

## Behavior

Pure refactor — bit-identical behavior. All 46 snapshot tests pass.

## Linter delta

Before:
- `_check_adjusted_close_continuity`: avg 4.46, max 9 — FAIL
- file avg: 2.60 — FAIL

After:
- `_check_adjusted_close_continuity`: resolved (function split into helpers)
- file avg: below 2.5 — PASS

Remaining pre-existing violations in the file (`_check_position_carryover`, `_check_stop_adjusted`, `_check_stop_unchanged` — all avg 3.5–3.6, max 6) are out of scope for this single-concern PR and logged as backlog items.

## Test plan

- [x] `dune build trading/weinstein/snapshot/` passes
- [x] `dune runtest trading/weinstein/snapshot/` — 46 tests pass
- [x] Nesting linter: `_check_adjusted_close_continuity` violation gone; file avg below 2.5
- [x] Diff is 24+/17- = 41 LOC total, well within 200 LOC limit
- [x] No new public symbols
- [x] Single concern (one finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)