### PR TITLE
cleanup(nesting): extract _make_position_input from force_liquidation_runner

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,7 +15,8 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
-- [x] nesting: analysis/scripts/build_snapshots/build_snapshots.ml — extracted _try_build_and_checkpoint; _process_symbol no longer flagged (PR #937, 2026-05-07)
+- [~] nesting: trading/trading/weinstein/strategy/lib/force_liquidation_runner.ml — `_position_input_of_holding` avg 4.56 max 7, nested match-in-match (source: 2026-05-02-fast-run2.md)
+- [~] nesting: analysis/scripts/build_snapshots/build_snapshots.ml — _process_symbol avg 5.00 max 9, file avg 2.58 (source: dispatch 2026-05-07)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
@@ -24,7 +25,7 @@ Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here 
 - [x] fn_length + file_length: trading/trading/backtest/lib/runner.ml — extracted `Runner_metrics` module + `_filter_steps`/`_extract_filtered_logs` helpers; runner.ml 528→468 lines, `run_backtest` 83→49 lines. Branch cleanup/runner-fn-length (2026-05-07)
 - [x] fn_length: trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml — extracted 8 helpers to Optimal_friday_helpers; 413→270 lines (branch cleanup/optimal-strategy-runner, 2026-05-07)
 - [x] file_length: trading/trading/backtest/optimal/lib/optimal_strategy_report.ml — extracted divergence + missed-trades sections to Optimal_strategy_report_sections; 488→281 lines (source: dispatch 2026-05-07, PR #928)
-- [x] file_length: trading/trading/backtest/lib/panel_runner.ml — extracted step-loop helpers to Panel_step_loop module; 309→237 lines (source: dispatch 2026-05-07, branch cleanup/file-length-panel-runner)
+- [x] file_length: trading/trading/backtest/lib/panel_runner.ml — extracted step-loop helpers to Panel_step_loop module; 309→182 lines (source: dispatch 2026-05-07, branch cleanup/file-length-panel-runner)
 - [x] file_length: trading/trading/backtest/lib/result_writer.ml — extracted trades-CSV cluster to Trades_writer module; 372→245 lines (source: dispatch 2026-05-07, PR #929)
 - [x] fn_length + file_length: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted entry construction + debug trace helpers to entry_audit_helpers.ml; 383→272 lines; make_entry_transition 54→31 lines (PR #930, 2026-05-07)
 - [x] nesting: trading/analysis/data/storage/csv/lib/csv_storage.ml — extracted `_parse_and_accumulate` and `_read_next_line` helpers; nesting linter now passes (835 fns, all OK). (source: 2026-04-26-fast.md, PR #578 merged 2026-04-26T16:04Z)

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,7 +15,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
-- [~] nesting: trading/trading/weinstein/strategy/lib/force_liquidation_runner.ml — `_position_input_of_holding` avg 4.56 max 7, nested match-in-match (source: 2026-05-02-fast-run2.md)
+- [x] nesting: trading/trading/weinstein/strategy/lib/force_liquidation_runner.ml — extracted _make_position_input; Option.map replaces nested match; nesting linter clean (branch cleanup/nesting-force-liq-runner, 2026-05-07)
 - [~] nesting: analysis/scripts/build_snapshots/build_snapshots.ml — _process_symbol avg 5.00 max 9, file avg 2.58 (source: dispatch 2026-05-07)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.

--- a/trading/trading/weinstein/strategy/lib/force_liquidation_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/force_liquidation_runner.ml
@@ -5,25 +5,28 @@ open Core
 open Trading_strategy
 module FL = Portfolio_risk.Force_liquidation
 
+(** Construct a [Force_liquidation.position_input] from holding fields and a
+    price bar. Called once per [Holding] position that has a price this tick. *)
+let _make_position_input ~(pos : Position.t) ~entry_price ~quantity
+    (bar : Types.Daily_price.t) : FL.position_input =
+  {
+    symbol = pos.symbol;
+    position_id = pos.id;
+    side = pos.side;
+    entry_price;
+    current_price = bar.close_price;
+    quantity;
+  }
+
 (** Build a [Force_liquidation.position_input] for one Holding position when a
     current price is available. Returns [None] for non-Holding positions and for
     symbols without a price feed this tick. *)
 let _position_input_of_holding ~get_price (pos : Position.t) :
     FL.position_input option =
   match pos.state with
-  | Position.Holding { quantity; entry_price; _ } -> (
-      match get_price pos.symbol with
-      | Some (bar : Types.Daily_price.t) ->
-          Some
-            {
-              symbol = pos.symbol;
-              position_id = pos.id;
-              side = pos.side;
-              entry_price;
-              current_price = bar.close_price;
-              quantity;
-            }
-      | None -> None)
+  | Position.Holding { quantity; entry_price; _ } ->
+      Option.map (get_price pos.symbol)
+        ~f:(_make_position_input ~pos ~entry_price ~quantity)
   | _ -> None
 
 (** Compute portfolio mark-to-market value via the canonical


### PR DESCRIPTION
## Summary
- `_position_input_of_holding` had nesting avg 4.56 / max 7 (limits 3.0/5) due to `match get_price ...` inside `match pos.state ...`
- Extracted private helper `_make_position_input` and replaced nested match with `Option.map`

## Test plan
- `dune runtest trading/weinstein/` — all 33 suites pass
- Nesting linter: `force_liquidation_runner.ml` no longer flagged
- Diff: 19+/14- = 33 LOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)