### PR TITLE
cleanup(nesting): hoist ticker alias entries to reduce file avg depth

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -1,6 +1,6 @@
 # Status: cleanup
 
-## Last updated: 2026-05-07
+## Last updated: 2026-05-08
 
 ## Status
 IN_PROGRESS
@@ -15,6 +15,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
+- [x] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — hoisted 11 alias entries to top-level lets; file avg 2.63→1.61 (branch cleanup/nesting-ticker-aliases, 2026-05-08)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 

--- a/trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml
+++ b/trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml
@@ -8,109 +8,128 @@ type alias = {
 }
 [@@deriving show, eq]
 
+let _meta =
+  {
+    current_symbol = "META";
+    historical_symbol = "FB";
+    effective_date = Date.create_exn ~y:2022 ~m:Month.Jun ~d:9;
+    rationale =
+      "Meta Platforms rebrand from Facebook 2022-06-09 (NASDAQ:FB → \
+       NASDAQ:META; Meta 8-K filed 2021-10-28).";
+  }
+
+let _elv =
+  {
+    current_symbol = "ELV";
+    historical_symbol = "ANTM";
+    effective_date = Date.create_exn ~y:2022 ~m:Month.Jun ~d:28;
+    rationale =
+      "Elevance Health rebrand from Anthem 2022-06-28 (NYSE:ANTM → NYSE:ELV; \
+       Elevance 8-K filed 2022-04-28).";
+  }
+
+let _vtrs =
+  {
+    current_symbol = "VTRS";
+    historical_symbol = "MYL";
+    effective_date = Date.create_exn ~y:2020 ~m:Month.Nov ~d:16;
+    rationale =
+      "Viatris merger of Mylan + Pfizer Upjohn 2020-11-16 (NASDAQ:MYL → \
+       NASDAQ:VTRS; Viatris S-4 effective 2020-06-16).";
+  }
+
+let _otis =
+  {
+    current_symbol = "OTIS";
+    historical_symbol = "UTX";
+    effective_date = Date.create_exn ~y:2020 ~m:Month.Apr ~d:3;
+    rationale =
+      "Otis Worldwide spinoff from United Technologies 2020-04-03; UTX \
+       simultaneously renamed RTX after Raytheon merger.";
+  }
+
+let _carr =
+  {
+    current_symbol = "CARR";
+    historical_symbol = "UTX";
+    effective_date = Date.create_exn ~y:2020 ~m:Month.Apr ~d:3;
+    rationale =
+      "Carrier Global spinoff from United Technologies 2020-04-03 (sister \
+       spinoff to OTIS).";
+  }
+
+let _rtx =
+  {
+    current_symbol = "RTX";
+    historical_symbol = "UTX";
+    effective_date = Date.create_exn ~y:2020 ~m:Month.Apr ~d:3;
+    rationale =
+      "Raytheon Technologies rename of United Technologies post-Raytheon \
+       merger 2020-04-03 (NYSE:UTX → NYSE:RTX).";
+  }
+
+let _dow =
+  {
+    current_symbol = "DOW";
+    historical_symbol = "DWDP";
+    effective_date = Date.create_exn ~y:2019 ~m:Month.Apr ~d:1;
+    rationale =
+      "Dow Inc. spinoff from DowDuPont 2019-04-01 (DWDP split into DD, DOW, \
+       CTVA).";
+  }
+
+let _lin =
+  {
+    current_symbol = "LIN";
+    historical_symbol = "PX";
+    effective_date = Date.create_exn ~y:2018 ~m:Month.Oct ~d:31;
+    rationale =
+      "Linde plc merger of Praxair (PX) + Linde AG 2018-10-31 (NYSE:PX → \
+       NYSE:LIN).";
+  }
+
+let _dxc =
+  {
+    current_symbol = "DXC";
+    historical_symbol = "CSC";
+    effective_date = Date.create_exn ~y:2017 ~m:Month.Apr ~d:3;
+    rationale =
+      "DXC Technology merger of CSC + HPE Enterprise Services 2017-04-03 \
+       (NYSE:CSC → NYSE:DXC).";
+  }
+
+let _bkng =
+  {
+    current_symbol = "BKNG";
+    historical_symbol = "PCLN";
+    effective_date = Date.create_exn ~y:2018 ~m:Month.Feb ~d:27;
+    rationale =
+      "Booking Holdings rename of Priceline Group 2018-02-27 (NASDAQ:PCLN → \
+       NASDAQ:BKNG).";
+  }
+
+let _googl =
+  {
+    current_symbol = "GOOGL";
+    historical_symbol = "GOOG";
+    effective_date = Date.create_exn ~y:2014 ~m:Month.Apr ~d:3;
+    rationale =
+      "Alphabet (Google) class A/C dual-class restructure 2014-04-03; original \
+       GOOG became GOOGL (class A, voting), new GOOG (class C, non-voting) \
+       issued. Pre-2014 historical bars trade as the single-class GOOG.";
+  }
+
 (* Curated list of corporate ticker renames affecting S&P 500 constituents.
    Order is newest-first for ease of human review; [canonicalize] is
    order-independent. Each entry must cite a verifiable source in
    [rationale]. *)
 let all =
-  [
-    {
-      current_symbol = "META";
-      historical_symbol = "FB";
-      effective_date = Date.create_exn ~y:2022 ~m:Month.Jun ~d:9;
-      rationale =
-        "Meta Platforms rebrand from Facebook 2022-06-09 (NASDAQ:FB → \
-         NASDAQ:META; Meta 8-K filed 2021-10-28).";
-    };
-    {
-      current_symbol = "ELV";
-      historical_symbol = "ANTM";
-      effective_date = Date.create_exn ~y:2022 ~m:Month.Jun ~d:28;
-      rationale =
-        "Elevance Health rebrand from Anthem 2022-06-28 (NYSE:ANTM → NYSE:ELV; \
-         Elevance 8-K filed 2022-04-28).";
-    };
-    {
-      current_symbol = "VTRS";
-      historical_symbol = "MYL";
-      effective_date = Date.create_exn ~y:2020 ~m:Month.Nov ~d:16;
-      rationale =
-        "Viatris merger of Mylan + Pfizer Upjohn 2020-11-16 (NASDAQ:MYL → \
-         NASDAQ:VTRS; Viatris S-4 effective 2020-06-16).";
-    };
-    {
-      current_symbol = "OTIS";
-      historical_symbol = "UTX";
-      effective_date = Date.create_exn ~y:2020 ~m:Month.Apr ~d:3;
-      rationale =
-        "Otis Worldwide spinoff from United Technologies 2020-04-03; UTX \
-         simultaneously renamed RTX after Raytheon merger.";
-    };
-    {
-      current_symbol = "CARR";
-      historical_symbol = "UTX";
-      effective_date = Date.create_exn ~y:2020 ~m:Month.Apr ~d:3;
-      rationale =
-        "Carrier Global spinoff from United Technologies 2020-04-03 (sister \
-         spinoff to OTIS).";
-    };
-    {
-      current_symbol = "RTX";
-      historical_symbol = "UTX";
-      effective_date = Date.create_exn ~y:2020 ~m:Month.Apr ~d:3;
-      rationale =
-        "Raytheon Technologies rename of United Technologies post-Raytheon \
-         merger 2020-04-03 (NYSE:UTX → NYSE:RTX).";
-    };
-    {
-      current_symbol = "DOW";
-      historical_symbol = "DWDP";
-      effective_date = Date.create_exn ~y:2019 ~m:Month.Apr ~d:1;
-      rationale =
-        "Dow Inc. spinoff from DowDuPont 2019-04-01 (DWDP split into DD, DOW, \
-         CTVA).";
-    };
-    {
-      current_symbol = "LIN";
-      historical_symbol = "PX";
-      effective_date = Date.create_exn ~y:2018 ~m:Month.Oct ~d:31;
-      rationale =
-        "Linde plc merger of Praxair (PX) + Linde AG 2018-10-31 (NYSE:PX → \
-         NYSE:LIN).";
-    };
-    {
-      current_symbol = "DXC";
-      historical_symbol = "CSC";
-      effective_date = Date.create_exn ~y:2017 ~m:Month.Apr ~d:3;
-      rationale =
-        "DXC Technology merger of CSC + HPE Enterprise Services 2017-04-03 \
-         (NYSE:CSC → NYSE:DXC).";
-    };
-    {
-      current_symbol = "BKNG";
-      historical_symbol = "PCLN";
-      effective_date = Date.create_exn ~y:2018 ~m:Month.Feb ~d:27;
-      rationale =
-        "Booking Holdings rename of Priceline Group 2018-02-27 (NASDAQ:PCLN → \
-         NASDAQ:BKNG).";
-    };
-    {
-      current_symbol = "GOOGL";
-      historical_symbol = "GOOG";
-      effective_date = Date.create_exn ~y:2014 ~m:Month.Apr ~d:3;
-      rationale =
-        "Alphabet (Google) class A/C dual-class restructure 2014-04-03; \
-         original GOOG became GOOGL (class A, voting), new GOOG (class C, \
-         non-voting) issued. Pre-2014 historical bars trade as the \
-         single-class GOOG.";
-    };
-  ]
+  [ _meta; _elv; _vtrs; _otis; _carr; _rtx; _dow; _lin; _dxc; _bkng; _googl ]
+
+let _is_pre_rename_date ~symbol ~as_of (a : alias) =
+  String.equal a.current_symbol symbol && Date.( < ) as_of a.effective_date
 
 let canonicalize ~symbol ~as_of =
-  match
-    List.find all ~f:(fun a ->
-        String.equal a.current_symbol symbol
-        && Date.( < ) as_of a.effective_date)
-  with
+  match List.find all ~f:(_is_pre_rename_date ~symbol ~as_of) with
   | Some a -> a.historical_symbol
   | None -> symbol


### PR DESCRIPTION
## Finding

From dispatch 2026-05-07 — nesting linter file-avg violation:

> `trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml` — file avg 2.63 (limit 2.5); deep record literals in `all` list

The `all` list contained 11 alias records as inline literals, pushing field lines to depth 3 and string-continuation lines to depth 4, driving the file average over the 2.5 limit.

## Fix

Extract each alias entry to a top-level `let _xxx = { ... }` binding (depth 0-1 fields instead of depth 2-3). Reduce `all` to a simple one-line list reference. Extract `_is_pre_rename_date` predicate to simplify `canonicalize`.

**Before:** file avg 2.63/112 lines = 2.63 (FAIL)
**After:** file avg 191/119 lines = 1.61 (PASS)

## Behavior

No behavior change. `all` exposes the same `alias list` with identical content; `canonicalize` logic is bit-identical. All 6 ticker_aliases tests pass.

## Test plan

- [x] `dune runtest analysis/data/sources/wiki_sp500/` — 6 tests OK
- [x] Nesting linter on worktree — `ticker_aliases.ml` absent from file violations (was 2.63, now 1.61)
- [x] `ocamlformat --check` passes (no format diff)
- [x] Single file changed (plus status update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)