### PR TITLE
cleanup(nesting): extract helpers from stop_split_adjust.scale

### DIFF
--- a/trading/trading/weinstein/stops/lib/stop_split_adjust.ml
+++ b/trading/trading/weinstein/stops/lib/stop_split_adjust.ml
@@ -7,15 +7,33 @@ let _validate_factor factor =
       (Printf.sprintf "Stop_split_adjust.scale: factor must be > 0.0, got %f"
          factor)
 
+let _scale_trailing ~sp ~stop_level ~last_correction_extreme ~last_trend_extreme
+    ~ma_at_last_adjustment ~correction_count ~correction_observed_since_reset =
+  Trailing
+    {
+      stop_level = sp stop_level;
+      last_correction_extreme = sp last_correction_extreme;
+      last_trend_extreme = sp last_trend_extreme;
+      ma_at_last_adjustment = sp ma_at_last_adjustment;
+      correction_count;
+      correction_observed_since_reset;
+    }
+
+let _scale_tightened ~sp ~stop_level ~last_correction_extreme ~reason =
+  Tightened
+    {
+      stop_level = sp stop_level;
+      last_correction_extreme = sp last_correction_extreme;
+      reason;
+    }
+
 let scale ~factor state =
   _validate_factor factor;
+  let sp x = x /. factor in
   match state with
   | Initial { stop_level; reference_level } ->
       Initial
-        {
-          stop_level = stop_level /. factor;
-          reference_level = reference_level /. factor;
-        }
+        { stop_level = sp stop_level; reference_level = sp reference_level }
   | Trailing
       {
         stop_level;
@@ -25,19 +43,8 @@ let scale ~factor state =
         correction_count;
         correction_observed_since_reset;
       } ->
-      Trailing
-        {
-          stop_level = stop_level /. factor;
-          last_correction_extreme = last_correction_extreme /. factor;
-          last_trend_extreme = last_trend_extreme /. factor;
-          ma_at_last_adjustment = ma_at_last_adjustment /. factor;
-          correction_count;
-          correction_observed_since_reset;
-        }
+      _scale_trailing ~sp ~stop_level ~last_correction_extreme
+        ~last_trend_extreme ~ma_at_last_adjustment ~correction_count
+        ~correction_observed_since_reset
   | Tightened { stop_level; last_correction_extreme; reason } ->
-      Tightened
-        {
-          stop_level = stop_level /. factor;
-          last_correction_extreme = last_correction_extreme /. factor;
-          reason;
-        }
+      _scale_tightened ~sp ~stop_level ~last_correction_extreme ~reason


### PR DESCRIPTION
## Finding

From dispatch 2026-05-07:

> **File:** `trading/trading/weinstein/stops/lib/stop_split_adjust.ml`
> **Violations (per nesting linter):**
> - `scale` line 10: avg 3.73, max 5 (limits 3.0/5)
> - File average: 3.24 (limit 2.5) — file-avg violation

## Fix

The `scale` function's deep nesting came from inline record constructors for
`Trailing` (6 fields) and `Tightened` (3 fields) sitting inside match arms,
driving indentation up to depth 5. OCaml inline record fields cannot be
destructured outside their match arm, so helpers receive each field as a
labeled parameter instead.

Extracted two private helpers:
- `_scale_trailing` — accepts all 6 Trailing fields + `sp` scaling function
- `_scale_tightened` — accepts 3 Tightened fields + `sp` scaling function

Added a local `sp x = x /. factor` alias so each match arm body collapses to
a single expression.

## Linter delta (nesting)

| Metric | Before | After |
|--------|--------|-------|
| `scale` fn avg nesting | 3.73 | clean |
| File avg nesting | 3.24 | clean |
| Linter fn violations (codebase) | 122 | 121 |
| Linter file-avg violations | 11 | 10 |

## Verification

- `dune build` passes
- `dune runtest trading/weinstein/stops/test/` — all 7 tests pass unchanged (bit-equal behavior)
- `ocamlformat --check` passes on the touched file
- Diff: 1 file, +26/-19 lines (well within 200 LOC cap)
- No new public symbols in `.mli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)