### PR TITLE
cleanup(nesting): extract helpers from membership_replay.ml

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -1,6 +1,6 @@
 # Status: cleanup
 
-## Last updated: 2026-05-08
+## Last updated: 2026-05-07
 
 ## Status
 IN_PROGRESS
@@ -15,15 +15,12 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
-- [~] nesting: trading/trading/simulation/lib/split_handler.ml — apply_to_position avg 4.31 max 6; apply_to_positions avg 3.43 max 6; file avg 3.12 (source: dispatch 2026-05-08)
-- [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)
-- [~] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — emit_entries avg 5.41 max 9; classify_candidate avg 5.30 max 11; file avg 2.76 (source: dispatch 2026-05-07)
+- [~] nesting: analysis/data/sources/wiki_sp500/lib/membership_replay.ml — _events_in_window avg 5.83 max 9; _undo_event avg 4.11 max 6; parse_current_csv max 6; _resolve_column_indices max 6; _compare_events nested-else 1 (source: dispatch 2026-05-07)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed
 
-- [x] nesting: trading/trading/weinstein/snapshot/lib/snapshot_reader.ml — extracted _parse_sexp + _deserialize_snapshot helpers; hoisted msg in _check_schema_version; parse/file avg violations gone (branch cleanup/nesting-snapshot-reader, 2026-05-08)
 - [x] nesting: trading/trading/weinstein/strategy/lib/exit_audit_capture.ml — extracted _pct_distance_from_callbacks, _make_exit_event, _handle_trigger_exit helpers; nesting linter now passes. (branch cleanup/nesting-exit-audit-capture, 2026-05-07)
 - [x] fn_length + file_length: trading/trading/backtest/lib/runner.ml — extracted `Runner_metrics` module + `_filter_steps`/`_extract_filtered_logs` helpers; runner.ml 528→468 lines, `run_backtest` 83→49 lines. Branch cleanup/runner-fn-length (2026-05-07)
 - [x] fn_length: trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml — extracted 8 helpers to Optimal_friday_helpers; 413→270 lines (branch cleanup/optimal-strategy-runner, 2026-05-07)

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,7 +15,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
-- [~] nesting: analysis/data/sources/wiki_sp500/lib/membership_replay.ml — _events_in_window avg 5.83 max 9; _undo_event avg 4.11 max 6; parse_current_csv max 6; _resolve_column_indices max 6; _compare_events nested-else 1 (source: dispatch 2026-05-07)
+- [x] nesting: analysis/data/sources/wiki_sp500/lib/membership_replay.ml — extracted 6 helpers; all 5 violations eliminated; 51 tests pass. (branch cleanup/nesting-membership-replay, 2026-05-08)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 

--- a/trading/analysis/data/sources/wiki_sp500/lib/membership_replay.ml
+++ b/trading/analysis/data/sources/wiki_sp500/lib/membership_replay.ml
@@ -36,22 +36,25 @@ let _find_column_index headers name =
       String.equal (String.lowercase (String.strip h)) name)
   |> Option.map ~f:fst
 
+let _resolve_sector_index headers =
+  match _find_column_index headers _sector_header_primary with
+  | Some i -> Some i
+  | None -> _find_column_index headers _sector_header_alt
+
+let _missing_headers_error headers =
+  let got = String.concat ~sep:"," headers in
+  Status.error_invalid_argument
+    (Printf.sprintf
+       "current-constituents CSV missing required header(s); need \
+        Symbol/Security/Sector, got: %s" got)
+
 let _resolve_column_indices headers =
   let symbol_idx = _find_column_index headers _symbol_header in
   let security_idx = _find_column_index headers _security_header in
-  let sector_idx =
-    match _find_column_index headers _sector_header_primary with
-    | Some i -> Some i
-    | None -> _find_column_index headers _sector_header_alt
-  in
+  let sector_idx = _resolve_sector_index headers in
   match (symbol_idx, security_idx, sector_idx) with
   | Some s, Some sec, Some sector -> Ok (s, sec, sector)
-  | _ ->
-      Status.error_invalid_argument
-        (Printf.sprintf
-           "current-constituents CSV missing required header(s); need \
-            Symbol/Security/Sector, got: %s"
-           (String.concat ~sep:"," headers))
+  | _ -> _missing_headers_error headers
 
 let _parse_data_row ~symbol_idx ~security_idx ~sector_idx ~row_num row =
   let cells = _split_csv_line row in
@@ -69,6 +72,16 @@ let _parse_data_row ~symbol_idx ~security_idx ~sector_idx ~row_num row =
         sector = cell sector_idx;
       }
 
+let _parse_data_rows ~header data_rows =
+  let headers = _split_csv_line header in
+  let%bind.Result symbol_idx, security_idx, sector_idx =
+    _resolve_column_indices headers
+  in
+  List.mapi data_rows ~f:(fun i row ->
+      _parse_data_row ~symbol_idx ~security_idx ~sector_idx ~row_num:(i + 2)
+        row)
+  |> Result.all
+
 let parse_current_csv csv_text =
   let lines =
     String.split_lines csv_text
@@ -76,15 +89,7 @@ let parse_current_csv csv_text =
   in
   match lines with
   | [] -> Status.error_invalid_argument "current-constituents CSV is empty"
-  | header :: data_rows ->
-      let headers = _split_csv_line header in
-      let%bind.Result symbol_idx, security_idx, sector_idx =
-        _resolve_column_indices headers
-      in
-      List.mapi data_rows ~f:(fun i row ->
-          _parse_data_row ~symbol_idx ~security_idx ~sector_idx ~row_num:(i + 2)
-            row)
-      |> Result.all
+  | header :: data_rows -> _parse_data_rows ~header data_rows
 
 (* --- Replay ------------------------------------------------------------- *)
 
@@ -104,16 +109,19 @@ let _from_table table =
 (* Apply the inverse of one change event: drop [added], restore [removed].
    Tolerant of [added] not being in the working set (see .mli docstring on
    why we choose silent-skip over hard error). *)
+let _restore_removed table (r : Changes_parser.ticker_id) =
+  let entry =
+    {
+      symbol = r.symbol;
+      security_name = r.security_name;
+      sector = _unknown_sector;
+    }
+  in
+  Hashtbl.set table ~key:r.symbol ~data:entry
+
 let _undo_event table (event : Changes_parser.change_event) =
   Option.iter event.added ~f:(fun a -> Hashtbl.remove table a.symbol);
-  Option.iter event.removed ~f:(fun r ->
-      Hashtbl.set table ~key:r.symbol
-        ~data:
-          {
-            symbol = r.symbol;
-            security_name = r.security_name;
-            sector = _unknown_sector;
-          })
+  Option.iter event.removed ~f:(_restore_removed table)
 
 let replay_back ~current ~changes ~as_of =
   let table = _to_table current in
@@ -163,12 +171,13 @@ let _action_rank = function `Added -> 0 | `Removed -> 1
 
 let _compare_events a b =
   let date_cmp = Date.compare a.date b.date in
-  if date_cmp <> 0 then date_cmp
-  else
-    let action_cmp =
-      Int.compare (_action_rank a.action) (_action_rank b.action)
-    in
-    if action_cmp <> 0 then action_cmp else String.compare a.symbol b.symbol
+  let action_cmp () =
+    Int.compare (_action_rank a.action) (_action_rank b.action)
+  in
+  let symbol_cmp () = String.compare a.symbol b.symbol in
+  match date_cmp with
+  | n when n <> 0 -> n
+  | _ -> ( match action_cmp () with n when n <> 0 -> n | _ -> symbol_cmp ())
 
 (* Each Wikipedia change-event yields up to two timeline events: one
    [`Added] line for the new ticker and one [`Removed] line for the
@@ -177,36 +186,33 @@ let _compare_events a b =
    forward-replay through the window, post-[from] additions don't have a
    GICS sector available. We use ["Unknown"] there, matching the
    convention in [_undo_event]. *)
+let _added_timeline_event ~current_sectors ~date (a : Changes_parser.ticker_id)
+    =
+  let sector =
+    Option.value
+      (Hashtbl.find current_sectors a.symbol)
+      ~default:_unknown_sector
+  in
+  { date; action = `Added; symbol = a.symbol; sector }
+
+let _removed_timeline_event ~date (r : Changes_parser.ticker_id) =
+  { date; action = `Removed; symbol = r.symbol; sector = _unknown_sector }
+
+let _change_event_to_timeline ~current_sectors
+    (e : Changes_parser.change_event) =
+  let date = e.effective_date in
+  let added_evt =
+    Option.map e.added ~f:(_added_timeline_event ~current_sectors ~date)
+  in
+  let removed_evt = Option.map e.removed ~f:(_removed_timeline_event ~date) in
+  List.filter_opt [ added_evt; removed_evt ]
+
 let _events_in_window ~current_sectors ~from ~until
     (changes : Changes_parser.change_event list) =
   List.concat_map changes ~f:(fun (e : Changes_parser.change_event) ->
       if Date.( <= ) e.effective_date from || Date.( > ) e.effective_date until
       then []
-      else
-        let added_evt =
-          Option.map e.added ~f:(fun (a : Changes_parser.ticker_id) ->
-              let sector =
-                Option.value
-                  (Hashtbl.find current_sectors a.symbol)
-                  ~default:_unknown_sector
-              in
-              {
-                date = e.effective_date;
-                action = `Added;
-                symbol = a.symbol;
-                sector;
-              })
-        in
-        let removed_evt =
-          Option.map e.removed ~f:(fun (r : Changes_parser.ticker_id) ->
-              {
-                date = e.effective_date;
-                action = `Removed;
-                symbol = r.symbol;
-                sector = _unknown_sector;
-              })
-        in
-        List.filter_opt [ added_evt; removed_evt ])
+      else _change_event_to_timeline ~current_sectors e)
   |> List.sort ~compare:_compare_events
 
 let build_timeline ~current ~changes ~from ~until =


### PR DESCRIPTION
## Summary

Reduces nesting depth in `trading/analysis/data/sources/wiki_sp500/lib/membership_replay.ml` by extracting 6 private helper functions. This was flagged by the nesting linter during dispatch on 2026-05-07.

**Original finding (dispatch 2026-05-07):**
- `_events_in_window` line 180: avg 5.83, max 9 (limits 3.0/5)
- `_undo_event` line 107: avg 4.11, max 6
- `parse_current_csv` line 72: max 6
- `_resolve_column_indices` line 39: max 6
- `_compare_events` line 164: nested-else 1

**Helpers extracted:**
- `_resolve_sector_index`: sector-column fallback lookup from `_resolve_column_indices`
- `_missing_headers_error`: nested `Printf.sprintf` error construction from `_resolve_column_indices`
- `_parse_data_rows`: header-parse + row-mapping from `parse_current_csv`
- `_restore_removed`: constituent-rebuild from `_undo_event` lambda
- `_added_timeline_event`, `_removed_timeline_event`, `_change_event_to_timeline`: per-event builders from `_events_in_window`'s nested `Option.map` callbacks

**Linter delta:** 5 violations → 0 violations for this file.

## Test plan

- [x] `dune build analysis/data/sources/wiki_sp500/` passes
- [x] `dune runtest analysis/data/sources/wiki_sp500/test/ --force`: all 51 tests pass (6+15+9+5+16)
- [x] Nesting linter reports 0 violations for `membership_replay.ml` (before: 5)
- [x] Diff is 117 LOC (well under 200 LOC limit)
- [x] No new public symbols in `.mli`
- [x] Single finding addressed
- [x] `dev/status/cleanup.md` updated: `[~]` → `[x]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)