### PR TITLE
cleanup(nesting): extract helpers to reduce nesting in _load_cascade_rejections

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,6 +15,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
+- [~] nesting: trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml — _load_cascade_rejections avg 4.15 max 9; extract helpers (source: dispatch 2026-05-08)
 - [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)
 - [x] nesting: trading/analysis/scripts/build_snapshots/build_snapshots.ml — extracted 5 helpers (_entry_is_current, _write_and_checksum, _file_metadata, _build_or_log, _load_benchmark_bars, _make_progress, _last_symbol, _fold_symbol); all 78 fns pass nesting linter (branch cleanup/nesting-build-snapshots-2, 2026-05-08)
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,7 +15,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
-- [~] nesting: trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml — _load_cascade_rejections avg 4.15 max 9; extract helpers (source: dispatch 2026-05-08)
+- [x] nesting: trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml — extracted _rejection_pair_of_alternative + _pairs_of_audit_record; nesting linter clean. PR #949 (2026-05-08)
 - [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)
 - [x] nesting: trading/analysis/scripts/build_snapshots/build_snapshots.ml — extracted 5 helpers (_entry_is_current, _write_and_checksum, _file_metadata, _build_or_log, _load_benchmark_bars, _make_progress, _last_symbol, _fold_symbol); all 78 fns pass nesting linter (branch cleanup/nesting-build-snapshots-2, 2026-05-08)
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)

--- a/trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml
@@ -130,6 +130,23 @@ let _load_trades ~output_dir : Trading_simulation.Metrics.trade_metrics list =
     | [] -> []
     | _header :: rows -> List.filter_map rows ~f:_parse_trade_row
 
+(** Convert one [alternative_candidate] to a [(symbol, reason)] pair.
+    Renders the [skip_reason] variant via its sexp atom name. *)
+let _rejection_pair_of_alternative
+    (alt : Backtest.Trade_audit.alternative_candidate) : string * string =
+  let reason =
+    Sexp.to_string
+      (Backtest.Trade_audit.sexp_of_skip_reason alt.reason_skipped)
+  in
+  (alt.symbol, reason)
+
+(** Flatten one [audit_record]'s [alternatives_considered] list into rejection
+    pairs. *)
+let _pairs_of_audit_record (rec_ : Backtest.Trade_audit.audit_record) :
+    (string * string) list =
+  List.map rec_.entry.alternatives_considered
+    ~f:_rejection_pair_of_alternative
+
 (** Harvest one [(symbol, reason)] pair per alternative-skip across the audit.
     Renders the [skip_reason] variant via its sexp atom name. Renderer attaches
     these inline against missed-trade rows; missing audit ⇒ empty list ⇒ rows
@@ -142,15 +159,7 @@ let _load_cascade_rejections ~output_dir : (string * string) list =
       let blob =
         Backtest.Trade_audit.audit_blob_of_sexp (Sexp.load_sexp path)
       in
-      List.concat_map blob.audit_records
-        ~f:(fun (rec_ : Backtest.Trade_audit.audit_record) ->
-          List.map rec_.entry.alternatives_considered
-            ~f:(fun (alt : Backtest.Trade_audit.alternative_candidate) ->
-              let reason =
-                Sexp.to_string
-                  (Backtest.Trade_audit.sexp_of_skip_reason alt.reason_skipped)
-              in
-              (alt.symbol, reason)))
+      List.concat_map blob.audit_records ~f:_pairs_of_audit_record
     with exn ->
       eprintf "optimal_strategy: failed to read trade_audit.sexp (%s)\n%!"
         (Exn.to_string exn);


### PR DESCRIPTION
## Summary

- Extracts two private helpers from `_load_cascade_rejections` in `optimal_run_artefacts.ml` to flatten deep nesting
- `_rejection_pair_of_alternative`: converts one `alternative_candidate` to a `(symbol, reason)` pair
- `_pairs_of_audit_record`: maps one `audit_record`'s `alternatives_considered` to rejection pairs
- `_load_cascade_rejections` itself now delegates via a flat `List.concat_map ... ~f:_pairs_of_audit_record` call

## Finding quoted

From dispatch 2026-05-08:
```
  4.15   9    0    avg+max    trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml:137  _load_cascade_rejections
```
(limits: avg 3.0 / max 5)

## Test plan

- [x] `dune build` passes (behavior-preserving refactor, no logic change)
- [x] `dune runtest` passes — no test newly fails or passes
- [x] Nesting linter shows no violations for `optimal_run_artefacts.ml` after fix
- [x] Diff is 19 LOC (+) / 9 LOC (−) — well within 200 LOC cap
- [x] No new public symbols added (all helpers are private `_` prefixed)
- [x] `dev/status/cleanup.md` updated with `[~]` marker for this item

🤖 Generated with [Claude Code](https://claude.com/claude-code)