### PR TITLE
fix(linter): extract magic-number constants + skip string-literal numerics

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -22,6 +22,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 - [x] nesting: trading/analysis/scripts/build_snapshots/build_snapshots.ml — extracted 5 helpers (_entry_is_current, _write_and_checksum, _file_metadata, _build_or_log, _load_benchmark_bars, _make_progress, _last_symbol, _fold_symbol); all 78 fns pass nesting linter (branch cleanup/nesting-build-snapshots-2, 2026-05-08)
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
+- [~] magic_numbers: multiple files — extract real magic-number constants + fix linter for string-context false positives (source: dispatch 2026-05-08)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -22,7 +22,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 - [x] nesting: trading/analysis/scripts/build_snapshots/build_snapshots.ml — extracted 5 helpers (_entry_is_current, _write_and_checksum, _file_metadata, _build_or_log, _load_benchmark_bars, _make_progress, _last_symbol, _fold_symbol); all 78 fns pass nesting linter (branch cleanup/nesting-build-snapshots-2, 2026-05-08)
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
-- [~] magic_numbers: multiple files — extract real magic-number constants + fix linter for string-context false positives (source: dispatch 2026-05-08)
+- [x] magic_numbers: multiple files — extract real magic-number constants + fix linter for string-context false positives. PR #955 (2026-05-08)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed

--- a/trading/devtools/checks/linter_magic_numbers.sh
+++ b/trading/devtools/checks/linter_magic_numbers.sh
@@ -79,6 +79,21 @@ for f in $(find "$TRADING_DIR" -path "*/lib/*.ml" \
       *'(*'* | *'*)'* | *'e.g.'*) continue ;;
     esac
 
+    # Skip OCaml multi-line string continuation lines (end with backslash).
+    # These lines are always inside a string literal started on a prior line.
+    case "$line" in
+      *'\') continue ;;
+    esac
+
+    # Skip lines whose numeric sits inside an open string from a prior line.
+    # An odd count of double-quotes means this line is a continuation of a
+    # string opened on an earlier line — all content is string literal, so
+    # any numeric is not a magic number in code.
+    quote_count=$(printf '%s' "$line" | tr -cd '"' | wc -c | tr -d ' ')
+    if [ $(( quote_count % 2 )) -ne 0 ]; then
+      continue
+    fi
+
     # Skip record field assignments and named constant definitions (= <num>)
     # e.g. "field = 42", "let max_size = 100", "let pi = 3.14"
     case "$line" in
@@ -113,7 +128,16 @@ for f in $(find "$TRADING_DIR" -path "*/lib/*.ml" \
       case "$num" in
         0 | 1 | 0.0 | 1.0) continue ;;
         2.0 | 0.5 | 100.0) continue ;;
-        *) VIOLATIONS="${VIOLATIONS}${f}: ${num} in: ${line}\n" ;;
+        *)
+          # Skip numerics that appear only inside double-quoted strings on
+          # this line. Strip all "..." segments; if the number no longer
+          # appears in the remainder, it was inside a string literal and is
+          # not a magic number in code.
+          stripped=$(printf '%s' "$line" | sed 's/"[^"]*"//g')
+          case "$stripped" in
+            *"$num"*) VIOLATIONS="${VIOLATIONS}${f}: ${num} in: ${line}\n" ;;
+          esac
+          ;;
       esac
     done
   done < "$f"

--- a/trading/trading/backtest/lib/runner_metrics.ml
+++ b/trading/trading/backtest/lib/runner_metrics.ml
@@ -9,6 +9,11 @@ open Trading_simulation
 let initial_cash = 1_000_000.0
 let commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 }
 
+(** Sentinel year used when constructing a dummy [config] for metric re-runs
+    where the date range is irrelevant (e.g. [recompute_calmar_ratio]).
+    Year 2000 is safely before any real run date. *)
+let _empty_date_sentinel_year = 2000
+
 (** Re-run the step-based metric computers ([SharpeRatio], [MaxDrawdown],
     [CAGR]) on the in-window step list with a config whose [start_date] is the
     actual run start (not the warmup_start the simulator was created with). The
@@ -47,8 +52,8 @@ let recompute_in_window_step_metrics ~steps_in_range ~start_date ~end_date =
 let recompute_calmar_ratio ~base_metrics =
   let dummy_config : Trading_simulation_types.Simulator_types.config =
     {
-      start_date = Date.create_exn ~y:2000 ~m:Month.Jan ~d:1;
-      end_date = Date.create_exn ~y:2000 ~m:Month.Jan ~d:1;
+      start_date = Date.create_exn ~y:_empty_date_sentinel_year ~m:Month.Jan ~d:1;
+      end_date = Date.create_exn ~y:_empty_date_sentinel_year ~m:Month.Jan ~d:1;
       initial_cash;
       commission;
       strategy_cadence = Types.Cadence.Daily;

--- a/trading/trading/backtest/tuner/lib/bayesian_opt.ml
+++ b/trading/trading/backtest/tuner/lib/bayesian_opt.ml
@@ -2,6 +2,14 @@ open Core
 module Mat = Owl.Mat
 module Linalg = Owl.Linalg.D
 
+(** Deterministic seed for the default RNG so results are reproducible when no
+    external seed is supplied. Any fixed value works; 42 is conventional. *)
+let _default_rng_seed = 42
+
+(** Minimum sigma below which expected-improvement is treated as zero, avoiding
+    division by a near-zero standard deviation. *)
+let _sigma_epsilon = 1e-12
+
 (** {1 Types} *)
 
 type observation = { parameters : (string * float) list; metric : float }
@@ -17,7 +25,7 @@ type config = {
 
 let create_config ~bounds ?(acquisition = `Expected_improvement)
     ?(initial_random = 5) ?(total_budget = 50)
-    ?(rng = Stdlib.Random.State.make [| 42 |]) () =
+    ?(rng = Stdlib.Random.State.make [| _default_rng_seed |]) () =
   { bounds; acquisition; initial_random; total_budget; rng }
 
 type t = { config : config; observations : observation list (* newest first *) }
@@ -177,7 +185,7 @@ let _standard_normal_cdf z = 0.5 *. (1.0 +. Owl.Maths.erf (z /. Float.sqrt 2.0))
 let expected_improvement ~posterior ~f_best x =
   let mu = posterior.mean x in
   let sigma = Float.sqrt (posterior.variance x) in
-  if Float.( <= ) sigma 1e-12 then 0.0
+  if Float.( <= ) sigma _sigma_epsilon then 0.0
   else
     let improvement = mu -. f_best in
     let z = improvement /. sigma in

--- a/trading/trading/simulation/lib/distributional_computer.ml
+++ b/trading/trading/simulation/lib/distributional_computer.ml
@@ -11,6 +11,10 @@ let _cvar_95_p = 0.05
 let _cvar_99_p = 0.01
 let _tail_ratio_p = 0.05
 
+(** Pearson excess kurtosis subtracts 3 from the fourth standardised moment so
+    that a normal distribution has kurtosis = 0. *)
+let _pearson_kurtosis_correction = 3.0
+
 type state = {
   portfolio_values : float list;  (** Reversed: head is most recent. *)
 }
@@ -77,7 +81,7 @@ let _kurtosis_excess returns =
   if Float.(var <= 0.0) then 0.0
   else
     let _m3, m4 = _moments_3_4 returns in
-    (m4 /. (var *. var)) -. 3.0
+    (m4 /. (var *. var)) -. _pearson_kurtosis_correction
 
 (** [_bottom_n_mean ~p sorted_asc] returns the mean of the lowest [floor(n × p)]
     returns; 0.0 if that count is zero. The input must be sorted ascending. *)


### PR DESCRIPTION
## Summary

Addresses the remaining `magic_numbers` linter violations after PR #952 (multi-line comment tracking):

**Real magic numbers → named constants:**
- `distributional_computer.ml`: `3.0` → `_pearson_kurtosis_correction` (Pearson excess kurtosis formula)
- `bayesian_opt.ml`: `42` → `_default_rng_seed` (reproducible RNG seed), `1e-12` → `_sigma_epsilon` (numerical guard)
- `runner_metrics.ml`: `2000` → `_empty_date_sentinel_year` (dummy config sentinel for calmar ratio recompute)

**Linter extended to skip string-literal numerics** (false positives in `linter_magic_numbers.sh`):
1. Lines ending with `\` (OCaml multi-line string continuation) → skip
2. Lines with an odd number of `"` (open string from a prior line) → skip
3. Lines with balanced `"..."`: strip quoted segments, re-test remainder

This eliminates false positives in: `CVaR (95%)`, `CVaR (99%)`, `sqrt(252)`, `36-month rolling`, `Loss percentage; equals 100 - WinRate`, `Long candidates (top 10)`, `((entry_dollars 5000.0))`.

**Finding source:** dispatch 2026-05-08, from `dev/health/` scan surfacing remaining violations after PR #952.

## Test plan

- [x] `bash devtools/checks/linter_magic_numbers.sh` → `OK: no magic numbers found in lib/ files.`
- [x] `dune build` passes
- [x] `dune build @fmt` passes
- [x] `dune runtest trading/trading/simulation/ trading/trading/backtest/` passes
- [x] Diff is ≤200 LOC (48 lines changed)
- [x] No behavior change — all constants retain the same values
- [x] No new public symbols in any `.mli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)