### PR TITLE
cleanup(fn-length): extract helpers from simulator.ml step fn (63→9 lines)

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -18,6 +18,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 - [x] nesting: trading/trading/backtest/optimal/lib/outcome_scorer.ml — extracted _step_stage3, _make_initial_state, _resolve_exit; both violations cleared. PR #950 (2026-05-08)
 - [x] nesting: trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml — extracted _rejection_pair_of_alternative + _pairs_of_audit_record; nesting linter clean. PR #949 (2026-05-08)
 - [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)
+- [x] fn_length: trading/trading/simulation/lib/simulator.ml — extracted _prepare_market_state + _process_step_day; step 63→9 lines (branch cleanup/simulator-step-fnlen-3, 2026-05-08)
 - [x] file_length: trading/trading/backtest/lib/result_writer.ml — extracted reconciler CSV writers to reconciler_writer.ml; 372→262 lines (source: dispatch 2026-05-08, branch cleanup/result-writer-split)
 - [x] nesting: trading/analysis/scripts/build_snapshots/build_snapshots.ml — extracted 5 helpers (_entry_is_current, _write_and_checksum, _file_metadata, _build_or_log, _load_benchmark_bars, _make_progress, _last_symbol, _fold_symbol); all 78 fns pass nesting linter (branch cleanup/nesting-build-snapshots-2, 2026-05-08)
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -351,69 +351,81 @@ let _apply_trades_best_effort portfolio trades =
 
 (* Split-handling helpers extracted to {!Split_handler}. *)
 
+(** Apply split detection, update market state, and record stale-held positions.
+    Returns the post-split portfolio, positions, today's bars, and the split
+    events (needed for [step_result.splits_applied]). *)
+let _prepare_market_state t =
+  let split_events =
+    Split_handler.detect_for_held_positions ~adapter:t.deps.market_data_adapter
+      ~date:t.current_date ~portfolio:t.portfolio
+  in
+  let portfolio = Split_handler.apply_events t.portfolio split_events in
+  let positions = Split_handler.apply_to_positions t.positions split_events in
+  let today_bars = _get_today_bars t in
+  (* Record stale-held positions (symbols without bars for K+ days) into
+     the per-run log. Detector only — no force-close; see [Stale_hold].
+     Runs only on bar-bearing days so weekend/holiday gaps don't trigger
+     false-positives every Saturday. *)
+  if not (List.is_empty today_bars) then
+    List.iter
+      (Stale_hold.detect_stale ~adapter:t.deps.market_data_adapter
+         ~date:t.current_date ~portfolio ~today_bars
+         ~config:t.deps.stale_hold_policy)
+      ~f:(Stale_hold.Log.record t.deps.stale_hold_log);
+  Trading_engine.Engine.update_market t.deps.engine today_bars;
+  (portfolio, positions, today_bars, split_events)
+
+(** Process one day: execute pending orders, call strategy, generate new orders,
+    and assemble the [step_result]. Returns the next simulator state paired with
+    this day's [step_result]. *)
+let _process_step_day t ~portfolio ~positions ~today_bars ~split_events =
+  let open Result.Let_syntax in
+  let%bind execution_reports =
+    Trading_engine.Engine.process_orders t.deps.engine t.deps.order_manager
+  in
+  let all_trades = _extract_trades execution_reports in
+  let portfolio, trades = _apply_trades_best_effort portfolio all_trades in
+  let%bind positions =
+    _update_positions_from_trades ~date:t.current_date ~positions ~trades
+  in
+  let%bind transitions = _call_strategy { t with portfolio; positions } in
+  let%bind positions = _apply_transitions ~positions ~transitions in
+  let%bind orders =
+    Order_generator.transitions_to_orders ~current_date:t.current_date
+      ~positions transitions
+  in
+  let step_result =
+    {
+      date = t.current_date;
+      portfolio;
+      portfolio_value =
+        _compute_portfolio_value ~adapter:t.deps.market_data_adapter
+          ~date:t.current_date ~portfolio ~today_bars;
+      trades;
+      orders_submitted = _submit_orders t orders;
+      splits_applied = split_events;
+      benchmark_return = _compute_benchmark_return t;
+      had_market_bars = not (List.is_empty today_bars);
+    }
+  in
+  let t' =
+    {
+      t with
+      current_date = Date.add_days t.current_date 1;
+      portfolio;
+      positions;
+      step_history = step_result :: t.step_history;
+    }
+  in
+  return (Stepped (t', step_result))
+
 let step t =
   if _is_complete t then Ok (Completed (_build_run_result t))
   else
-    let open Result.Let_syntax in
-    (* Detect splits first; then scale BOTH the broker portfolio and the
-       strategy-side [Position.t] map in lockstep — see the helper docs. *)
-    let split_events =
-      Split_handler.detect_for_held_positions
-        ~adapter:t.deps.market_data_adapter ~date:t.current_date
-        ~portfolio:t.portfolio
+    let portfolio, positions, today_bars, split_events =
+      _prepare_market_state t
     in
-    let portfolio = Split_handler.apply_events t.portfolio split_events in
-    let positions = Split_handler.apply_to_positions t.positions split_events in
-    let today_bars = _get_today_bars t in
-    (* Record stale-held positions (symbols without bars for K+ days) into
-       the per-run log. Detector only — no force-close; see [Stale_hold].
-       Runs only on bar-bearing days so weekend/holiday gaps don't trigger
-       false-positives every Saturday. *)
-    if not (List.is_empty today_bars) then
-      List.iter
-        (Stale_hold.detect_stale ~adapter:t.deps.market_data_adapter
-           ~date:t.current_date ~portfolio ~today_bars
-           ~config:t.deps.stale_hold_policy)
-        ~f:(Stale_hold.Log.record t.deps.stale_hold_log);
-    Trading_engine.Engine.update_market t.deps.engine today_bars;
-    let%bind execution_reports =
-      Trading_engine.Engine.process_orders t.deps.engine t.deps.order_manager
-    in
-    let all_trades = _extract_trades execution_reports in
-    let portfolio, trades = _apply_trades_best_effort portfolio all_trades in
-    let%bind positions =
-      _update_positions_from_trades ~date:t.current_date ~positions ~trades
-    in
-    let%bind transitions = _call_strategy { t with portfolio; positions } in
-    let%bind positions = _apply_transitions ~positions ~transitions in
-    let%bind orders =
-      Order_generator.transitions_to_orders ~current_date:t.current_date
-        ~positions transitions
-    in
-    let step_result =
-      {
-        date = t.current_date;
-        portfolio;
-        portfolio_value =
-          _compute_portfolio_value ~adapter:t.deps.market_data_adapter
-            ~date:t.current_date ~portfolio ~today_bars;
-        trades;
-        orders_submitted = _submit_orders t orders;
-        splits_applied = split_events;
-        benchmark_return = _compute_benchmark_return t;
-        had_market_bars = not (List.is_empty today_bars);
-      }
-    in
-    let t' =
-      {
-        t with
-        current_date = Date.add_days t.current_date 1;
-        portfolio;
-        positions;
-        step_history = step_result :: t.step_history;
-      }
-    in
-    return (Stepped (t', step_result))
+    _process_step_day t ~portfolio ~positions ~today_bars ~split_events
 
 let get_config t = t.config
 


### PR DESCRIPTION
## Finding

From `linter_fn_length`: `step` in `trading/trading/simulation/lib/simulator.ml` was 63 lines (limit 50).

## Fix

Extract two private helpers from the monolithic `step` function:

- `_prepare_market_state` — split detection + portfolio/position scaling + stale-hold detection + engine market update. Returns `(portfolio, positions, today_bars, split_events)`.
- `_process_step_day` — pending order execution + trade application + strategy call + order generation + `step_result` assembly. Returns `Result (Stepped (t', step_result))`.

`step` itself becomes a 9-line thin orchestrator: early-exit when complete, call `_prepare_market_state`, call `_process_step_day`.

Behavior is unchanged — the same operations execute in the same order.

## Verification

- `dune build trading/simulation/lib/` — clean
- `dune runtest trading/simulation/` — all tests pass (identical output to baseline)
- `bash devtools/checks/linter_fn_length.sh 2>&1 | grep simulator.ml` — no output (violation cleared)
- `dune build @fmt 2>&1 | grep simulator.ml` — no output (fmt clean)

## Test plan

- [x] All simulation tests pass (`dune runtest trading/simulation/`)
- [x] `linter_fn_length.sh` no longer flags `simulator.ml`
- [x] `dune build @fmt` clean for `simulator.ml`
- [x] Diff is ≤200 LOC (72 insertions / 59 deletions = 131 LOC net change)
- [x] Single concern: fn_length violation in `simulator.ml`
- [x] No new public symbols
- [x] `dev/status/cleanup.md` updated: `[x]` with one-line completion note

🤖 Generated with [Claude Code](https://claude.com/claude-code)