### PR TITLE
cleanup(nesting): extract _filter_and_cap to fix screener _evaluate_longs/_evaluate_shorts

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -26,6 +26,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed
+- [x] nesting: trading/analysis/weinstein/screener/lib/screener.ml — extracted _filter_and_cap helper; _evaluate_longs/_evaluate_shorts nesting violations cleared. (branch cleanup/nesting-screener-eval-2, 2026-05-08)
 - [x] file_length: trading/trading/engine/lib/price_path.ml (511→498) + trading/trading/weinstein/strategy/lib/entry_audit_capture.ml (305→297) — condensed private-fn docstrings; both files now within limits. PR #958 (2026-05-08)
 
 - [x] nesting: trading/trading/weinstein/strategy/lib/exit_audit_capture.ml — extracted _pct_distance_from_callbacks, _make_exit_event, _handle_trigger_exit helpers; nesting linter now passes. (branch cleanup/nesting-exit-audit-capture, 2026-05-07)

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -293,18 +293,22 @@ let _count_short_phases ~weights ~thresholds ~min_grade ~min_score_override
       in
       (_bump breakdown pb, _bump sector_ok ps, _bump rs_ok pr, _bump grade_ok pg))
 
+(** Apply [candidate_fn] to each pair, drop [None]s, sort by score, and cap at
+    [max_n]. Shared by the long and short evaluation paths. *)
+let _filter_and_cap ~candidate_fn ~max_n candidates =
+  List.filter_map candidates ~f:candidate_fn |> _top_n max_n
+
 (** Filter, score, grade, sort, and cap long candidates. *)
 let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~min_score_override
     ~max_buy_candidates ~candidates ~macro_trend : scored_candidate list =
   match macro_trend with
   | Bearish -> []
   | Bullish | Neutral ->
-      candidates
-      |> List.filter_map
-           ~f:
-             (_long_candidate ~weights ~thresholds ~params ~min_grade
-                ~min_score_override)
-      |> _top_n max_buy_candidates
+      let candidate_fn =
+        _long_candidate ~weights ~thresholds ~params ~min_grade
+          ~min_score_override
+      in
+      _filter_and_cap ~candidate_fn ~max_n:max_buy_candidates candidates
 
 (** Filter, score, grade, sort, and cap short candidates. *)
 let _evaluate_shorts ~weights ~thresholds ~params ~min_grade ~min_score_override
@@ -312,12 +316,11 @@ let _evaluate_shorts ~weights ~thresholds ~params ~min_grade ~min_score_override
   match macro_trend with
   | Bullish -> []
   | Bearish | Neutral ->
-      candidates
-      |> List.filter_map
-           ~f:
-             (_short_candidate ~weights ~thresholds ~params ~min_grade
-                ~min_score_override)
-      |> _top_n max_short_candidates
+      let candidate_fn =
+        _short_candidate ~weights ~thresholds ~params ~min_grade
+          ~min_score_override
+      in
+      _filter_and_cap ~candidate_fn ~max_n:max_short_candidates candidates
 
 (** Build watchlist: breakout candidates with grade C/D not in the buy list.
     Empty when buys are inactive (Bearish market). *)


### PR DESCRIPTION
## Finding

From nesting linter dispatch 2026-05-08:

```
  3.30   8    0    avg+max    trading/analysis/weinstein/screener/lib/screener.ml:297  _evaluate_longs
  3.30   8    0    avg+max    trading/analysis/weinstein/screener/lib/screener.ml:310  _evaluate_shorts
```

Both functions had avg 3.30 / max 8 nesting depth due to inline partial application
of multi-argument `_long_candidate`/`_short_candidate` inside a `|>` pipeline:

```ocaml
candidates
|> List.filter_map
     ~f:
       (_long_candidate ~weights ~thresholds ~params ~min_grade
          ~min_score_override)
|> _top_n max_buy_candidates
```

## Fix

Extracted a shared `_filter_and_cap ~candidate_fn ~max_n candidates` helper
(4 lines) that takes the candidate function and cap, applying `List.filter_map`
+ `_top_n`. Both functions now bind the candidate function to a `let` binding
before calling `_filter_and_cap`, flattening the inline nesting.

## Verification

- `dune build` passes (worktree)
- `dune runtest analysis/weinstein/screener/` passes (51 tests)
- Nesting linter reports 0 screener.ml violations after the fix
- Diff: 1 file, +15 / -12 lines (27 LOC total, well within ≤200 LOC cap)
- No new public symbols; no behavior change

## Checklist

- [x] Diff ≤200 LOC (27 lines across 1 file, status file excluded)
- [x] Single finding addressed
- [x] `dune build && dune runtest analysis/weinstein/screener/` passes
- [x] Nesting linter: 0 screener.ml violations (was 2)
- [x] No new public symbols in any `.mli`
- [x] `dev/status/cleanup.md` updated: finding marked `[x]`