### PR TITLE
cleanup(nesting): extract helpers in all_eligible_runner to clear nesting violations

### DIFF
--- a/trading/trading/backtest/all_eligible/lib/all_eligible_runner.ml
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible_runner.ml
@@ -222,37 +222,43 @@ let _analyze_symbol_on_friday ~snapshot_callbacks ~friday ~stock_config
         (Stock_analysis.analyze ~config:stock_config ~ticker:symbol ~bars:weekly
            ~benchmark_bars:benchmark ~prior_stage:None ~as_of_date:friday)
 
+let _make_sector_context (sector_name : string) : Screener.sector_context =
+  {
+    sector_name;
+    rating = Screener.Neutral;
+    stage = Stage2 { weeks_advancing = 4; late = false };
+  }
+
 let _build_sector_context_map (sectors : (string, string) Hashtbl.t) :
     (string, Screener.sector_context) Hashtbl.t =
   let out = Hashtbl.create (module String) in
   Hashtbl.iteri sectors ~f:(fun ~key ~data ->
-      let ctx : Screener.sector_context =
-        {
-          sector_name = data;
-          rating = Screener.Neutral;
-          stage = Stage2 { weeks_advancing = 4; late = false };
-        }
-      in
-      Hashtbl.set out ~key ~data:ctx);
+      Hashtbl.set out ~key ~data:(_make_sector_context data));
   out
+
+let _scan_one_friday ~snapshot_callbacks ~universe ~sector_map ~stock_config
+    ~scanner_config ~bar_lookback (friday : Date.t) : OT.candidate_entry list =
+  let analyses =
+    List.filter_map universe ~f:(fun sym ->
+        _analyze_symbol_on_friday ~snapshot_callbacks ~friday ~stock_config
+          ~bar_lookback sym)
+  in
+  let week : Scanner.week_input =
+    {
+      date = friday;
+      macro_trend = Weinstein_types.Neutral;
+      analyses;
+      sector_map;
+    }
+  in
+  Scanner.scan_week ~config:scanner_config week
 
 let _scan_all_fridays ~snapshot_callbacks ~fridays ~universe ~sector_map
     ~stock_config ~scanner_config ~bar_lookback : OT.candidate_entry list =
-  List.concat_map fridays ~f:(fun friday ->
-      let analyses =
-        List.filter_map universe ~f:(fun sym ->
-            _analyze_symbol_on_friday ~snapshot_callbacks ~friday ~stock_config
-              ~bar_lookback sym)
-      in
-      let week : Scanner.week_input =
-        {
-          date = friday;
-          macro_trend = Weinstein_types.Neutral;
-          analyses;
-          sector_map;
-        }
-      in
-      Scanner.scan_week ~config:scanner_config week)
+  List.concat_map fridays
+    ~f:
+      (_scan_one_friday ~snapshot_callbacks ~universe ~sector_map ~stock_config
+         ~scanner_config ~bar_lookback)
 
 (* ---------------------------------------------------------------- *)
 (* Forward-walk outlooks for the scorer                                *)
@@ -272,14 +278,19 @@ let _outlook_at ~snapshot_callbacks ~stage_config ~bar_lookback ~symbol ~friday
       in
       Some { Scorer.date = friday; bar; stage_result }
 
+let _outlooks_for_symbol ~snapshot_callbacks ~fridays ~stage_config
+    ~bar_lookback (symbol : string) : Scorer.weekly_outlook list =
+  List.filter_map fridays ~f:(fun friday ->
+      _outlook_at ~snapshot_callbacks ~stage_config ~bar_lookback ~symbol
+        ~friday)
+
 let _build_forward_table ~snapshot_callbacks ~fridays ~stage_config
     ~bar_lookback ~universe : (string, Scorer.weekly_outlook list) Hashtbl.t =
   let table = Hashtbl.create ~size:(List.length universe) (module String) in
   List.iter universe ~f:(fun symbol ->
       let outlooks =
-        List.filter_map fridays ~f:(fun friday ->
-            _outlook_at ~snapshot_callbacks ~stage_config ~bar_lookback ~symbol
-              ~friday)
+        _outlooks_for_symbol ~snapshot_callbacks ~fridays ~stage_config
+          ~bar_lookback symbol
       in
       Hashtbl.set table ~key:symbol ~data:outlooks);
   table


### PR DESCRIPTION
## Finding

From dispatch 2026-05-08 — three nesting linter violations in
`trading/trading/backtest/all_eligible/lib/all_eligible_runner.ml`:

```
3.94   7    0    avg+max    ...all_eligible_runner.ml:239  _scan_all_fridays
3.10   7    0    avg+max    ...all_eligible_runner.ml:275  _build_forward_table
3.08   5    0    avg        ...all_eligible_runner.ml:225  _build_sector_context_map
```

## Changes

Extracted three private helpers to flatten nesting:

- `_scan_one_friday` — extracted from the `List.concat_map` body in `_scan_all_fridays`; reduces the lambda's nested `List.filter_map` + record construction to top-level scope
- `_outlooks_for_symbol` — extracted from the `List.iter` body in `_build_forward_table`; wraps the `List.filter_map` over fridays for a single symbol
- `_make_sector_context` — extracted the `Screener.sector_context` record literal from the `Hashtbl.iteri` callback in `_build_sector_context_map`

One file changed; no interface (`mli`) changes. Behavior is identical.

## Verification

```
nesting_linter | grep all_eligible_runner
# → no output (all three violations cleared)
```

`dune build && dune runtest` pass.

## Test plan

- [x] Nesting linter shows no `all_eligible_runner` violations after change
- [x] `dune build` passes (exit 0)
- [x] `dune runtest` passes (exit 0)
- [x] Single file changed, 63 LOC diff (well within 250 LOC cap)
- [x] No `.mli` changes, no new public symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)