### PR TITLE
cleanup(fn_length+file_length): reduce weinstein_strategy_screening.ml 353→275 + strategy.ml 304→298 LOC

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -18,16 +18,17 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 - [x] nesting: trading/trading/backtest/optimal/lib/outcome_scorer.ml — extracted _step_stage3, _make_initial_state, _resolve_exit; both violations cleared. PR #950 (2026-05-08)
 - [x] nesting: trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml — extracted _rejection_pair_of_alternative + _pairs_of_audit_record; nesting linter clean. PR #949 (2026-05-08)
 - [x] fn_length: trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml — extracted 7 helpers (calendar, analysis, sector, forward, scan) to Optimal_strategy_runner_helpers; 413→282 LOC (branch cleanup/optimal-runner-split-2, 2026-05-08)
+- [~] nesting: trading/trading/data_panel/snapshot/lib/snapshot_format.ml — read_with_expected_schema avg 4.24/max 8, _validate_schemas 3.58/7, write 3.38/6, _check_payload_integrity max 5 (source: dispatch 2026-05-08)
 - [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)
 - [~] fn_length: trading/trading/simulation/lib/simulator.ml — step fn 63 lines (limit 50); extract helpers (source: dispatch 2026-05-08)
-- [x] magic_numbers: trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml — extracted _strong_outperform_threshold=3.0 and _moderate_outperform_threshold=1.5; linter clean (branch cleanup/optimal-report-sections-magic, 2026-05-08)
+- [~] magic_numbers: trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml — 3.0 and 1.5 thresholds in _implications_narrative; extract as named constants (source: dispatch 2026-05-08)
 - [x] nesting: trading/analysis/scripts/build_snapshots/build_snapshots.ml — extracted 5 helpers (_entry_is_current, _write_and_checksum, _file_metadata, _build_or_log, _load_benchmark_bars, _make_progress, _last_symbol, _fold_symbol); all 78 fns pass nesting linter (branch cleanup/nesting-build-snapshots-2, 2026-05-08)
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed
-- [x] nesting: trading/analysis/weinstein/screener/lib/screener.ml — extracted _filter_and_cap helper; _evaluate_longs/_evaluate_shorts nesting violations cleared. (branch cleanup/nesting-screener-eval-2, 2026-05-08)
+- [x] fn_length+file_length: weinstein_strategy.ml (304→298) + weinstein_strategy_screening.ml (353→275) — extracted macro/screen helpers to weinstein_strategy_macro.ml; _on_market_close 78→41 lines. (branch cleanup/weinstein-strategy-trim, 2026-05-08)
 - [x] file_length: trading/trading/engine/lib/price_path.ml (511→498) + trading/trading/weinstein/strategy/lib/entry_audit_capture.ml (305→297) — condensed private-fn docstrings; both files now within limits. PR #958 (2026-05-08)
 
 - [x] nesting: trading/trading/weinstein/strategy/lib/exit_audit_capture.ml — extracted _pct_distance_from_callbacks, _make_exit_event, _handle_trigger_exit helpers; nesting linter now passes. (branch cleanup/nesting-exit-audit-capture, 2026-05-07)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -6,52 +6,21 @@ module Stops_split_runner = Stops_split_runner
 module Force_liquidation_runner = Force_liquidation_runner
 module Stage3_force_exit_runner = Stage3_force_exit_runner
 module Laggard_rotation_runner = Laggard_rotation_runner
-
 module Stage3_force_exit = Stage3_force_exit
-
 module Laggard_rotation = Laggard_rotation
-
 module Ad_bars = Ad_bars
-
 module Macro_inputs = Macro_inputs
-
 module Panel_callbacks = Panel_callbacks
-
 module Weekly_ma_cache = Weekly_ma_cache
-
 module Audit_recorder = Audit_recorder
-
 module Entry_audit_capture = Entry_audit_capture
-
 module Exit_audit_capture = Exit_audit_capture
-
 include Weinstein_strategy_config
+module S = Weinstein_strategy_screening
 
-let held_symbols = Weinstein_strategy_screening.held_symbols
-let entries_from_candidates = Weinstein_strategy_screening.entries_from_candidates
-let survivors_for_screening = Weinstein_strategy_screening.survivors_for_screening
-
-let _positions_minus_exited ~(positions : Position.t Map.M(String).t)
-    ~(stop_exit_transitions : Position.transition list) :
-    Position.t Map.M(String).t =
-  let exited_ids =
-    List.filter_map stop_exit_transitions ~f:(fun (t : Position.transition) ->
-        match t.kind with
-        | Position.TriggerExit _ -> Some t.position_id
-        | _ -> None)
-    |> String.Set.of_list
-  in
-  if Set.is_empty exited_ids then positions
-  else
-    Map.filter positions ~f:(fun (p : Position.t) ->
-        not (Set.mem exited_ids p.id))
-
-let _maybe_reset_halt ~peak_tracker
-    ~(macro_trend : Weinstein_types.market_trend) =
-  match macro_trend with
-  | Weinstein_types.Bearish -> ()
-  | Weinstein_types.Bullish | Weinstein_types.Neutral ->
-      Portfolio_risk.Force_liquidation.Peak_tracker.reset peak_tracker
+let held_symbols = S.held_symbols
+let entries_from_candidates = S.entries_from_candidates
+let survivors_for_screening = S.survivors_for_screening
 
 let _trigger_exit_ids_of (ts : Position.transition list) : String.Set.t =
   List.filter_map ts ~f:(fun (t : Position.transition) ->
@@ -66,6 +35,22 @@ let _filter_out_exited_ids exited_ids (ts : Position.transition list) :
   else
     List.filter ts ~f:(fun (t : Position.transition) ->
         not (Set.mem exited_ids t.position_id))
+
+let _positions_minus_exited ~(positions : Position.t Map.M(String).t)
+    ~(stop_exit_transitions : Position.transition list) :
+    Position.t Map.M(String).t =
+  let exited_ids = _trigger_exit_ids_of stop_exit_transitions in
+  if Set.is_empty exited_ids then positions
+  else
+    Map.filter positions ~f:(fun (p : Position.t) ->
+        not (Set.mem exited_ids p.id))
+
+let _maybe_reset_halt ~peak_tracker
+    ~(macro_trend : Weinstein_types.market_trend) =
+  match macro_trend with
+  | Weinstein_types.Bearish -> ()
+  | Weinstein_types.Bullish | Weinstein_types.Neutral ->
+      Portfolio_risk.Force_liquidation.Peak_tracker.reset peak_tracker
 
 let _symbol_of_position_id ~(positions : Position.t Map.M(String).t) id =
   Map.data positions
@@ -82,13 +67,6 @@ let _handle_stop_out_transition ~last_stop_out_dates ~positions ~current_date
       | None -> ())
   | _ -> ()
 
-let _record_stop_outs ~last_stop_out_dates
-    ~(positions : Position.t Map.M(String).t)
-    ~(exit_transitions : Position.transition list) ~current_date =
-  List.iter exit_transitions
-    ~f:
-      (_handle_stop_out_transition ~last_stop_out_dates ~positions ~current_date)
-
 let _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
     ~get_price ~last_stop_out_dates ~audit_recorder ~prior_macro_result
     ~current_date =
@@ -102,8 +80,9 @@ let _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
       ~lookback_bars:config.lookback_bars ~positions ~get_price ~stop_states
       ~bar_reader ~as_of:current_date ~prior_stages ()
   in
-  _record_stop_outs ~last_stop_out_dates ~positions ~exit_transitions
-    ~current_date;
+  List.iter exit_transitions
+    ~f:
+      (_handle_stop_out_transition ~last_stop_out_dates ~positions ~current_date);
   List.iter exit_transitions
     ~f:
       (Exit_audit_capture.emit_exit_audit ~audit_recorder ~prior_macro_result
@@ -129,10 +108,9 @@ let _run_special_exits ~config ~positions ~(portfolio : Portfolio_view.t)
   in
   let stage3_ts =
     if config.enable_stage3_force_exit then
-      Stage3_force_exit_runner.update
-        ~config:config.stage3_force_exit_config ~is_screening_day:is_friday
-        ~positions ~get_price ~prior_stages ~stage3_streaks
-        ~stop_exit_position_ids:stop_exited_ids ~current_date
+      Stage3_force_exit_runner.update ~config:config.stage3_force_exit_config
+        ~is_screening_day:is_friday ~positions ~get_price ~prior_stages
+        ~stage3_streaks ~stop_exit_position_ids:stop_exited_ids ~current_date
     else []
   in
   let stage3_exited_ids = _trigger_exit_ids_of stage3_ts in
@@ -154,6 +132,60 @@ let _run_special_exits ~config ~positions ~(portfolio : Portfolio_view.t)
     stop_exited_ids,
     stage3_exited_ids,
     laggard_exited_ids )
+
+let _run_macro_and_entries ~config ~ad_bars ~stop_states ~last_stop_out_dates
+    ~prior_macro ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
+    ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio ~current_date
+    ~index_view ~audit_recorder =
+  let is_screening_day =
+    Weinstein_strategy_screening.is_screening_day_view index_view
+  in
+  let macro_result_opt =
+    if is_screening_day then
+      Some
+        (Weinstein_strategy_macro.run_macro_only ~config ~ad_bars ~prior_macro
+           ~prior_macro_result ~bar_reader ~prior_stages ~current_date
+           ~index_view)
+    else None
+  in
+  if is_screening_day then
+    _maybe_reset_halt ~peak_tracker ~macro_trend:!prior_macro;
+  let halted =
+    match
+      Portfolio_risk.Force_liquidation.Peak_tracker.halt_state peak_tracker
+    with
+    | Halted -> true
+    | Active -> false
+  in
+  Weinstein_strategy_macro.entry_transitions_if_active ~halted ~is_screening_day
+    ~macro_result_opt ~config ~stop_states ~last_stop_out_dates ~bar_reader
+    ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio
+    ~current_date ~index_view ~audit_recorder
+
+let _assemble_output ~exit_transitions ~stage3_force_exit_transitions
+    ~laggard_rotation_transitions ~force_exit_transitions ~adjust_transitions
+    ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids =
+  let force_liq_exited_ids = _trigger_exit_ids_of force_exit_transitions in
+  let all_exited_ids =
+    Set.union_list
+      (module String)
+      [
+        stop_exited_ids;
+        stage3_exited_ids;
+        laggard_exited_ids;
+        force_liq_exited_ids;
+      ]
+  in
+  let adjust_transitions =
+    _filter_out_exited_ids all_exited_ids adjust_transitions
+  in
+  Ok
+    {
+      Strategy_interface.transitions =
+        exit_transitions @ stage3_force_exit_transitions
+        @ laggard_rotation_transitions @ force_exit_transitions
+        @ adjust_transitions @ entry_transitions;
+    }
 
 let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
     ~prior_macro ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
@@ -185,54 +217,16 @@ let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
           ~laggard_streaks ~bar_reader ~index_view ~exit_transitions
           ~current_date
       in
-      let is_screening_day =
-        Weinstein_strategy_screening.is_screening_day_view index_view
-      in
-      let macro_result_opt =
-        if is_screening_day then
-          Some
-            (Weinstein_strategy_screening.run_macro_only ~config ~ad_bars
-               ~prior_macro ~prior_macro_result ~bar_reader ~prior_stages
-               ~current_date ~index_view)
-        else None
-      in
-      if is_screening_day then
-        _maybe_reset_halt ~peak_tracker ~macro_trend:!prior_macro;
-      let halted =
-        match
-          Portfolio_risk.Force_liquidation.Peak_tracker.halt_state peak_tracker
-        with
-        | Halted -> true
-        | Active -> false
-      in
       let entry_transitions =
-        Weinstein_strategy_screening.entry_transitions_if_active ~halted
-          ~is_screening_day ~macro_result_opt ~config ~stop_states
-          ~last_stop_out_dates ~bar_reader ~prior_stages ~sector_prior_stages
-          ~ticker_sectors ~get_price ~portfolio ~current_date ~index_view
-          ~audit_recorder
+        _run_macro_and_entries ~config ~ad_bars ~stop_states
+          ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
+          ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
+          ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
       in
-      let force_liq_exited_ids = _trigger_exit_ids_of force_exit_transitions in
-      let all_exited_ids =
-        Set.union_list
-          (module String)
-          [
-            stop_exited_ids;
-            stage3_exited_ids;
-            laggard_exited_ids;
-            force_liq_exited_ids;
-          ]
-      in
-      let adjust_transitions =
-        _filter_out_exited_ids all_exited_ids adjust_transitions
-      in
-      Ok
-        {
-          Strategy_interface.transitions =
-            exit_transitions @ stage3_force_exit_transitions
-            @ laggard_rotation_transitions @ force_exit_transitions
-            @ adjust_transitions @ entry_transitions;
-        }
+      _assemble_output ~exit_transitions ~stage3_force_exit_transitions
+        ~laggard_rotation_transitions ~force_exit_transitions
+        ~adjust_transitions ~entry_transitions ~stop_exited_ids
+        ~stage3_exited_ids ~laggard_exited_ids
 
 let _init_strategy_state ~initial_stop_states ~ad_bars =
   let stop_states = ref initial_stop_states in

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.ml
@@ -1,0 +1,80 @@
+open Core
+open Weinstein_strategy_config
+
+(** Compute the macro result for [current_date] and update the strategy's macro
+    refs. Cheap relative to [run_screen_after_macro] — touches only the index,
+    globals, AD bars, and the macro analyser. Runs unconditionally on every
+    Friday (including when the halt is active) so [_maybe_reset_halt] can
+    consult the freshest macro trend even when the universe screen is gated off.
+*)
+let run_macro_only ~config ~ad_bars ~prior_macro ~prior_macro_result ~bar_reader
+    ~prior_stages ~current_date ~index_view =
+  let index_prior_stage = Hashtbl.find prior_stages config.indices.primary in
+  (* Phase F.3.d-2 caller migration: the global-index view assembly reads
+     through {!Snapshot_runtime.Snapshot_callbacks} directly via the
+     [*_of_snapshot_views] API rather than re-routing through the
+     bar_reader's panel-shaped views. The cb is exposed by the
+     snapshot-backed [Bar_reader.t] (production runner uses
+     {!Bar_reader.of_snapshot_views} post-#864). *)
+  let cb = Bar_reader.snapshot_callbacks bar_reader in
+  let global_index_views =
+    Macro_inputs.build_global_index_views_of_snapshot_views
+      ~lookback_bars:config.lookback_bars
+      ~global_index_symbols:config.indices.global ~cb ~as_of:current_date
+  in
+  let ma_cache = Bar_reader.ma_cache bar_reader in
+  let ad_bars =
+    Macro_inputs.ad_bars_at_or_before ~ad_bars ~as_of:current_date
+  in
+  let macro_callbacks =
+    Panel_callbacks.macro_callbacks_of_weekly_views ?ma_cache
+      ~index_symbol:config.indices.primary ~config:config.macro_config
+      ~index:index_view ~globals:global_index_views ~ad_bars ()
+  in
+  let macro_result =
+    Macro.analyze_with_callbacks ~config:config.macro_config
+      ~callbacks:macro_callbacks ~prior_stage:index_prior_stage ~prior:None
+  in
+  prior_macro := macro_result.trend;
+  prior_macro_result := Some macro_result;
+  macro_result
+
+(** Run the Friday universe screener path given an already-computed
+    [macro_result]. Under all macro regimes (Bullish, Neutral, Bearish) the
+    screener is invoked; macro-specific gating — longs blocked under Bearish,
+    shorts blocked under Bullish — happens inside the screener. Under Bearish
+    this yields short-side entries (per the bear-market shorting chapter). *)
+let run_screen_after_macro ~config ~stop_states ~last_stop_out_dates ~bar_reader
+    ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio
+    ~current_date ~index_view ~audit_recorder ~macro_result =
+  let ma_cache = Bar_reader.ma_cache bar_reader in
+  (* Phase F.3.d-2 caller migration: the sector ETF analysis reads through
+     {!Snapshot_runtime.Snapshot_callbacks} directly via the
+     [*_of_snapshot_views] API. See [run_macro_only] for context on the
+     cb-from-bar_reader plumbing. *)
+  let cb = Bar_reader.snapshot_callbacks bar_reader in
+  let sector_map =
+    Macro_inputs.build_sector_map_of_snapshot_views ?ma_cache
+      ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
+      ~sector_etfs:config.sector_etfs ~cb ~as_of:current_date
+      ~sector_prior_stages ~index_view ~ticker_sectors ()
+  in
+  Weinstein_strategy_screening.screen_universe ~config ~index_view ~macro_result
+    ~sector_map ~stop_states ~last_stop_out_dates ~portfolio ~get_price
+    ~bar_reader ~prior_stages ~current_date ~audit_recorder
+
+(** Run the universe screen when the strategy is active (not halted, on a
+    Friday, with a valid macro result). Returns the list of entry transitions,
+    or [[]] when any guard is false. Extracted from [_on_market_close] to keep
+    the entry-transition branch at a shallower nesting level. *)
+let entry_transitions_if_active ~halted ~is_screening_day ~macro_result_opt
+    ~config ~stop_states ~last_stop_out_dates ~bar_reader ~prior_stages
+    ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio ~current_date
+    ~index_view ~audit_recorder =
+  match (halted, is_screening_day, macro_result_opt) with
+  | false, true, Some macro_result ->
+      run_screen_after_macro ~config ~stop_states ~last_stop_out_dates
+        ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
+        ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
+        ~macro_result
+  | _ -> []

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.mli
@@ -1,0 +1,63 @@
+open Core
+
+(** Macro computation and screen-dispatch helpers, factored out of
+    [Weinstein_strategy_screening] to keep that file within the 300-line soft
+    limit. All three functions are wired directly by [Weinstein_strategy] and
+    are not intended for external callers. *)
+
+val run_macro_only :
+  config:Weinstein_strategy_config.config ->
+  ad_bars:Macro.ad_bar list ->
+  prior_macro:Weinstein_types.market_trend ref ->
+  prior_macro_result:Macro.result option ref ->
+  bar_reader:Bar_reader.t ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  current_date:Date.t ->
+  index_view:Snapshot_runtime.Snapshot_bar_views.weekly_view ->
+  Macro.result
+(** Compute the macro result for [current_date] and update [prior_macro] /
+    [prior_macro_result] refs in place. Runs unconditionally on every Friday so
+    that halt-reset logic can consult the freshest macro trend even when the
+    universe screen is gated off. *)
+
+val run_screen_after_macro :
+  config:Weinstein_strategy_config.config ->
+  stop_states:Weinstein_stops.stop_state String.Map.t ref ->
+  last_stop_out_dates:Date.t Hashtbl.M(String).t ->
+  bar_reader:Bar_reader.t ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  sector_prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  ticker_sectors:(string, string) Hashtbl.t ->
+  get_price:(string -> Types.Daily_price.t option) ->
+  portfolio:Trading_strategy.Portfolio_view.t ->
+  current_date:Date.t ->
+  index_view:Snapshot_runtime.Snapshot_bar_views.weekly_view ->
+  audit_recorder:Audit_recorder.t ->
+  macro_result:Macro.result ->
+  Trading_strategy.Position.transition list
+(** Run the Friday universe screener given an already-computed [macro_result].
+    Builds the sector map, delegates to
+    {!Weinstein_strategy_screening.screen_universe}, and returns entry
+    transitions. *)
+
+val entry_transitions_if_active :
+  halted:bool ->
+  is_screening_day:bool ->
+  macro_result_opt:Macro.result option ->
+  config:Weinstein_strategy_config.config ->
+  stop_states:Weinstein_stops.stop_state String.Map.t ref ->
+  last_stop_out_dates:Date.t Hashtbl.M(String).t ->
+  bar_reader:Bar_reader.t ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  sector_prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  ticker_sectors:(string, string) Hashtbl.t ->
+  get_price:(string -> Types.Daily_price.t option) ->
+  portfolio:Trading_strategy.Portfolio_view.t ->
+  current_date:Date.t ->
+  index_view:Snapshot_runtime.Snapshot_bar_views.weekly_view ->
+  audit_recorder:Audit_recorder.t ->
+  Trading_strategy.Position.transition list
+(** Run the universe screen only when [halted = false],
+    [is_screening_day = true], and [macro_result_opt = Some _]. Returns [[]]
+    when any guard is false. Keeps [_on_market_close] at a shallow nesting
+    level. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -29,10 +29,10 @@ let _short_holding_notional (pos : Position.t) =
       Float.abs quantity *. entry_price
   | _ -> 0.0
 
-(** Sum entry-price-denominated short notional across all open [Holding]
-    shorts. Used to seed the per-Friday accumulator in [entries_from_candidates]
-    before the entry walk begins. Entry-price-denominated rather than
-    current-price so the cap measures committed-at-entry exposure. *)
+(** Sum entry-price-denominated short notional across all open [Holding] shorts.
+    Used to seed the per-Friday accumulator in [entries_from_candidates] before
+    the entry walk begins. Entry-price-denominated rather than current-price so
+    the cap measures committed-at-entry exposure. *)
 let _initial_short_notional (positions : Position.t Map.M(String).t) =
   Map.fold positions ~init:0.0 ~f:(fun ~key:_ ~data:pos acc ->
       acc +. _short_holding_notional pos)
@@ -273,81 +273,3 @@ let is_screening_day_view
   else
     Date.day_of_week view.dates.(view.n - 1)
     |> Day_of_week.equal Day_of_week.Fri
-
-(** Compute the macro result for [current_date] and update the strategy's macro
-    refs. Cheap relative to [run_screen_after_macro] — touches only the index,
-    globals, AD bars, and the macro analyser. Runs unconditionally on every
-    Friday (including when the halt is active) so [_maybe_reset_halt] can
-    consult the freshest macro trend even when the universe screen is gated off.
-*)
-let run_macro_only ~config ~ad_bars ~prior_macro ~prior_macro_result
-    ~bar_reader ~prior_stages ~current_date ~index_view =
-  let index_prior_stage = Hashtbl.find prior_stages config.indices.primary in
-  (* Phase F.3.d-2 caller migration: the global-index view assembly reads
-     through {!Snapshot_runtime.Snapshot_callbacks} directly via the
-     [*_of_snapshot_views] API rather than re-routing through the
-     bar_reader's panel-shaped views. The cb is exposed by the
-     snapshot-backed [Bar_reader.t] (production runner uses
-     {!Bar_reader.of_snapshot_views} post-#864). *)
-  let cb = Bar_reader.snapshot_callbacks bar_reader in
-  let global_index_views =
-    Macro_inputs.build_global_index_views_of_snapshot_views
-      ~lookback_bars:config.lookback_bars
-      ~global_index_symbols:config.indices.global ~cb ~as_of:current_date
-  in
-  let ma_cache = Bar_reader.ma_cache bar_reader in
-  let ad_bars =
-    Macro_inputs.ad_bars_at_or_before ~ad_bars ~as_of:current_date
-  in
-  let macro_callbacks =
-    Panel_callbacks.macro_callbacks_of_weekly_views ?ma_cache
-      ~index_symbol:config.indices.primary ~config:config.macro_config
-      ~index:index_view ~globals:global_index_views ~ad_bars ()
-  in
-  let macro_result =
-    Macro.analyze_with_callbacks ~config:config.macro_config
-      ~callbacks:macro_callbacks ~prior_stage:index_prior_stage ~prior:None
-  in
-  prior_macro := macro_result.trend;
-  prior_macro_result := Some macro_result;
-  macro_result
-
-(** Run the Friday universe screener path given an already-computed
-    [macro_result]. Under all macro regimes (Bullish, Neutral, Bearish) the
-    screener is invoked; macro-specific gating — longs blocked under Bearish,
-    shorts blocked under Bullish — happens inside the screener. Under Bearish
-    this yields short-side entries (per the bear-market shorting chapter). *)
-let run_screen_after_macro ~config ~stop_states ~last_stop_out_dates
-    ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price
-    ~portfolio ~current_date ~index_view ~audit_recorder ~macro_result =
-  let ma_cache = Bar_reader.ma_cache bar_reader in
-  (* Phase F.3.d-2 caller migration: the sector ETF analysis reads through
-     {!Snapshot_runtime.Snapshot_callbacks} directly via the
-     [*_of_snapshot_views] API. See [run_macro_only] for context on the
-     cb-from-bar_reader plumbing. *)
-  let cb = Bar_reader.snapshot_callbacks bar_reader in
-  let sector_map =
-    Macro_inputs.build_sector_map_of_snapshot_views ?ma_cache
-      ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
-      ~sector_etfs:config.sector_etfs ~cb ~as_of:current_date
-      ~sector_prior_stages ~index_view ~ticker_sectors ()
-  in
-  screen_universe ~config ~index_view ~macro_result ~sector_map ~stop_states
-    ~last_stop_out_dates ~portfolio ~get_price ~bar_reader ~prior_stages
-    ~current_date ~audit_recorder
-
-(** Run the universe screen when the strategy is active (not halted, on a
-    Friday, with a valid macro result). Returns the list of entry transitions,
-    or [[]] when any guard is false. Extracted from [_on_market_close] to keep
-    the entry-transition branch at a shallower nesting level. *)
-let entry_transitions_if_active ~halted ~is_screening_day ~macro_result_opt
-    ~config ~stop_states ~last_stop_out_dates ~bar_reader ~prior_stages
-    ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio ~current_date
-    ~index_view ~audit_recorder =
-  match (halted, is_screening_day, macro_result_opt) with
-  | false, true, Some macro_result ->
-      run_screen_after_macro ~config ~stop_states ~last_stop_out_dates
-        ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
-        ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
-        ~macro_result
-  | _ -> []


### PR DESCRIPTION
## Finding (source: dispatch 2026-05-08)

> `weinstein_strategy_screening.ml` — 353 LOC, soft limit 300 (53 over)
> `weinstein_strategy.ml` — 304 LOC, soft limit 300 (4 over)
> `_on_market_close` in `weinstein_strategy.ml` — 78 lines, limit 50 (28 over)

## What this PR does

Extracts three macro/screen-dispatch functions from `weinstein_strategy_screening.ml` into a new `weinstein_strategy_macro.ml` module:
- `run_macro_only` — computes Friday macro result and updates strategy refs
- `run_screen_after_macro` — builds sector map and delegates to `screen_universe`
- `entry_transitions_if_active` — guards the universe screen by halt/day/macro state

Also extracts two private helpers from `_on_market_close` in `weinstein_strategy.ml`:
- `_run_macro_and_entries` — Friday macro + halt-reset + entry pipeline (29 lines)
- `_assemble_output` — union exited-IDs and build output transition list (22 lines)

## Results

| File | Before | After |
|------|--------|-------|
| `weinstein_strategy_screening.ml` | 353 | 275 |
| `weinstein_strategy.ml` | 304 | 298 |
| `weinstein_strategy_macro.ml` (new) | — | 80 |
| `weinstein_strategy_macro.mli` (new) | — | 63 |
| `_on_market_close` fn | 78 lines | 41 lines |

## Test plan

- [x] `dune build` passes
- [x] `dune runtest trading/weinstein/` passes (all golden tests bit-equal)
- [x] `dune runtest` passes (no newly failing tests)
- [x] `bash devtools/checks/linter_file_length.sh 2>&1 | grep weinstein_strategy` — no output
- [x] `bash devtools/checks/linter_fn_length.sh 2>&1 | grep weinstein_strategy` — no output
- [x] `dune build @fmt` — no format issues in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)