### PR TITLE
cleanup(nesting): extract stop-check helpers in round_trip_verifier

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -18,17 +18,17 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 - [x] nesting: trading/trading/backtest/optimal/lib/outcome_scorer.ml — extracted _step_stage3, _make_initial_state, _resolve_exit; both violations cleared. PR #950 (2026-05-08)
 - [x] nesting: trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml — extracted _rejection_pair_of_alternative + _pairs_of_audit_record; nesting linter clean. PR #949 (2026-05-08)
 - [x] fn_length: trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml — extracted 7 helpers (calendar, analysis, sector, forward, scan) to Optimal_strategy_runner_helpers; 413→282 LOC (branch cleanup/optimal-runner-split-2, 2026-05-08)
-- [~] nesting: trading/trading/data_panel/snapshot/lib/snapshot_format.ml — read_with_expected_schema avg 4.24/max 8, _validate_schemas 3.58/7, write 3.38/6, _check_payload_integrity max 5 (source: dispatch 2026-05-08)
 - [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)
 - [~] fn_length: trading/trading/simulation/lib/simulator.ml — step fn 63 lines (limit 50); extract helpers (source: dispatch 2026-05-08)
-- [~] magic_numbers: trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml — 3.0 and 1.5 thresholds in _implications_narrative; extract as named constants (source: dispatch 2026-05-08)
+- [x] magic_numbers: trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml — extracted _strong_outperform_threshold=3.0 and _moderate_outperform_threshold=1.5; linter clean (branch cleanup/optimal-report-sections-magic, 2026-05-08)
 - [x] nesting: trading/analysis/scripts/build_snapshots/build_snapshots.ml — extracted 5 helpers (_entry_is_current, _write_and_checksum, _file_metadata, _build_or_log, _load_benchmark_bars, _make_progress, _last_symbol, _fold_symbol); all 78 fns pass nesting linter (branch cleanup/nesting-build-snapshots-2, 2026-05-08)
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed
-- [x] fn_length+file_length: weinstein_strategy.ml (304→298) + weinstein_strategy_screening.ml (353→275) — extracted macro/screen helpers to weinstein_strategy_macro.ml; _on_market_close 78→41 lines. (branch cleanup/weinstein-strategy-trim, 2026-05-08)
+- [x] nesting: trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml — extracted _stop_check/_carryover_stop/_stop_adjusted_ok/_stop_unchanged_ok helpers; all 3 violations cleared. PR #964 (2026-05-08)
+- [x] nesting: trading/analysis/weinstein/screener/lib/screener.ml — extracted _filter_and_cap helper; _evaluate_longs/_evaluate_shorts nesting violations cleared. (branch cleanup/nesting-screener-eval-2, 2026-05-08)
 - [x] file_length: trading/trading/engine/lib/price_path.ml (511→498) + trading/trading/weinstein/strategy/lib/entry_audit_capture.ml (305→297) — condensed private-fn docstrings; both files now within limits. PR #958 (2026-05-08)
 
 - [x] nesting: trading/trading/weinstein/strategy/lib/exit_audit_capture.ml — extracted _pct_distance_from_callbacks, _make_exit_event, _handle_trigger_exit helpers; nesting linter now passes. (branch cleanup/nesting-exit-audit-capture, 2026-05-07)

--- a/trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml
+++ b/trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml
@@ -80,31 +80,46 @@ let _check_adjusted_close_continuity ~symbol ~split_date ~factor ~tolerance
       in
       _continuity_check_result ~symbol ~factor ~tolerance pre_bars mismatches
 
+(* Shared helper: compare [post_stop] against [expected]; return the named
+   pass/fail check.  Callers pre-compute both detail strings so all formatting
+   stays outside the conditional branch. *)
+let _stop_check ~name ~tolerance post_stop expected ~pass_detail ~fail_detail =
+  if _approximately_equal ~tolerance post_stop expected then
+    _pass ~name pass_detail
+  else _fail ~name fail_detail
+
+(* Inner body of the Some/Some arm of _check_position_carryover. *)
+let _carryover_stop ~symbol ~factor ~(pre_lot : held_lot)
+    (pre : Weekly_snapshot.held_position) (post : Weekly_snapshot.held_position)
+    =
+  let expected = pre.stop /. factor in
+  let pass_detail =
+    Printf.sprintf "%s: stop %.4f -> %.4f (factor=%.4f); pre quantity=%.4f"
+      symbol pre.stop post.stop factor pre_lot.quantity
+  in
+  let fail_detail =
+    Printf.sprintf "%s: stop_post=%.6f, expected stop_pre/factor=%.6f" symbol
+      post.stop expected
+  in
+  _stop_check ~name:"position_carryover" ~tolerance:_arithmetic_tolerance
+    post.stop expected ~pass_detail ~fail_detail
+
 let _check_position_carryover ~symbol ~factor ~(pre_lot : held_lot)
     (pick_pre : Weekly_snapshot.t) (pick_post : Weekly_snapshot.t) =
+  let no_pre =
+    _fail ~name:"position_carryover"
+      (Printf.sprintf "%s: not present in pre-split snapshot.held_positions"
+         symbol)
+  in
+  let no_post =
+    _fail ~name:"position_carryover"
+      (Printf.sprintf "%s: dropped from post-split snapshot.held_positions"
+         symbol)
+  in
   match (_find_held pick_pre symbol, _find_held pick_post symbol) with
-  | None, _ ->
-      _fail ~name:"position_carryover"
-        (Printf.sprintf "%s: not present in pre-split snapshot.held_positions"
-           symbol)
-  | _, None ->
-      _fail ~name:"position_carryover"
-        (Printf.sprintf "%s: dropped from post-split snapshot.held_positions"
-           symbol)
-  | Some pre, Some post ->
-      let expected_stop = pre.stop /. factor in
-      if
-        _approximately_equal ~tolerance:_arithmetic_tolerance post.stop
-          expected_stop
-      then
-        _pass ~name:"position_carryover"
-          (Printf.sprintf
-             "%s: stop %.4f -> %.4f (factor=%.4f); pre quantity=%.4f" symbol
-             pre.stop post.stop factor pre_lot.quantity)
-      else
-        _fail ~name:"position_carryover"
-          (Printf.sprintf "%s: stop_post=%.6f, expected stop_pre/factor=%.6f"
-             symbol post.stop expected_stop)
+  | None, _ -> no_pre
+  | _, None -> no_post
+  | Some pre, Some post -> _carryover_stop ~symbol ~factor ~pre_lot pre post
 
 let _check_cost_basis_preserved ~symbol ~factor ~(pre_lot : held_lot) =
   let qty_post = pre_lot.quantity *. factor in
@@ -138,25 +153,30 @@ let _check_no_phantom_picks ~symbol (pick_pre : Weekly_snapshot.t)
       (Printf.sprintf "%s: new symbols in post-split candidates: %s" symbol
          (Set.to_list phantom |> String.concat ~sep:","))
 
+(* Inner body of the Some/Some arm of _check_stop_adjusted. *)
+let _stop_adjusted_ok ~symbol ~factor (pre : Weekly_snapshot.held_position)
+    (post : Weekly_snapshot.held_position) =
+  let expected = pre.stop /. factor in
+  let pass_detail =
+    Printf.sprintf "%s: stop %.4f -> %.4f (factor=%.4f)" symbol pre.stop
+      post.stop factor
+  in
+  let fail_detail =
+    Printf.sprintf "%s: stop_post=%.6f, expected pre/factor=%.6f" symbol
+      post.stop expected
+  in
+  _stop_check ~name:"stop_adjusted" ~tolerance:_default_adjusted_close_tolerance
+    post.stop expected ~pass_detail ~fail_detail
+
 let _check_stop_adjusted ~symbol ~factor (pick_pre : Weekly_snapshot.t)
     (pick_post : Weekly_snapshot.t) =
+  let missing =
+    _fail ~name:"stop_adjusted"
+      (Printf.sprintf "%s: position missing from snapshots" symbol)
+  in
   match (_find_held pick_pre symbol, _find_held pick_post symbol) with
-  | Some pre, Some post ->
-      let expected = pre.stop /. factor in
-      if
-        _approximately_equal ~tolerance:_default_adjusted_close_tolerance
-          post.stop expected
-      then
-        _pass ~name:"stop_adjusted"
-          (Printf.sprintf "%s: stop %.4f -> %.4f (factor=%.4f)" symbol pre.stop
-             post.stop factor)
-      else
-        _fail ~name:"stop_adjusted"
-          (Printf.sprintf "%s: stop_post=%.6f, expected pre/factor=%.6f" symbol
-             post.stop expected)
-  | _ ->
-      _fail ~name:"stop_adjusted"
-        (Printf.sprintf "%s: position missing from snapshots" symbol)
+  | Some pre, Some post -> _stop_adjusted_ok ~symbol ~factor pre post
+  | _ -> missing
 
 let verify_split_round_trip ~symbol ~split_date ~factor ~bars
     ~(pre_split_lot : held_lot) ~(pick_pre_split : Weekly_snapshot.t)
@@ -196,24 +216,29 @@ let _check_quantity_unchanged_label ~symbol ~quantity =
   _pass ~name:"quantity_unchanged"
     (Printf.sprintf "%s: quantity=%.4f (no DRIP / scrip)" symbol quantity)
 
+(* Inner body of the Some/Some arm of _check_stop_unchanged. *)
+let _stop_unchanged_ok ~symbol (pre : Weekly_snapshot.held_position)
+    (post : Weekly_snapshot.held_position) =
+  let pass_detail =
+    Printf.sprintf "%s: stop %.4f preserved across dividend" symbol pre.stop
+  in
+  let fail_detail =
+    Printf.sprintf
+      "%s: stop_pre=%.6f, stop_post=%.6f (dividends should not adjust)" symbol
+      pre.stop post.stop
+  in
+  _stop_check ~name:"stop_unchanged" ~tolerance:_arithmetic_tolerance post.stop
+    pre.stop ~pass_detail ~fail_detail
+
 let _check_stop_unchanged ~symbol (pick_pre : Weekly_snapshot.t)
     (pick_post : Weekly_snapshot.t) =
+  let missing =
+    _fail ~name:"stop_unchanged"
+      (Printf.sprintf "%s: position missing from snapshots" symbol)
+  in
   match (_find_held pick_pre symbol, _find_held pick_post symbol) with
-  | Some pre, Some post ->
-      if
-        _approximately_equal ~tolerance:_arithmetic_tolerance post.stop pre.stop
-      then
-        _pass ~name:"stop_unchanged"
-          (Printf.sprintf "%s: stop %.4f preserved across dividend" symbol
-             pre.stop)
-      else
-        _fail ~name:"stop_unchanged"
-          (Printf.sprintf
-             "%s: stop_pre=%.6f, stop_post=%.6f (dividends should not adjust)"
-             symbol pre.stop post.stop)
-  | _ ->
-      _fail ~name:"stop_unchanged"
-        (Printf.sprintf "%s: position missing from snapshots" symbol)
+  | Some pre, Some post -> _stop_unchanged_ok ~symbol pre post
+  | _ -> missing
 
 let verify_dividend_round_trip ~symbol ~ex_date:_ ~amount_per_share
     ~(pre_lot : held_lot) ~(pick_pre : Weekly_snapshot.t)


### PR DESCRIPTION
## Finding

From nesting linter scan (dispatch 2026-05-08):

```
3.62   6    0    avg+max    trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml:83  _check_position_carryover
3.59   6    0    avg+max    trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml:199  _check_stop_unchanged
3.50   6    0    avg+max    trading/trading/weinstein/snapshot/lib/round_trip_verifier.ml:141  _check_stop_adjusted
```

## Fix

All three functions shared the pattern: `match (_find_held pre, _find_held post)` with a long `| Some pre, Some post ->` arm containing an inner `if _approximately_equal ... then _pass ... else _fail ...`.

Extracted:
- `_stop_check` — shared helper for the tolerance comparison (pass/fail with pre-computed detail strings)
- `_carryover_stop` — inner body of `_check_position_carryover`'s `Some/Some` arm  
- `_stop_adjusted_ok` — inner body of `_check_stop_adjusted`'s `Some/Some` arm
- `_stop_unchanged_ok` — inner body of `_check_stop_unchanged`'s `Some/Some` arm

All three check functions now have 2-3 arm matches with single-expression arms. All detail strings are bit-identical to the originals.

## Verification

```
dune build && dune runtest  # all tests pass
nesting_linter | grep round_trip_verifier  # no output = no violations
```

Before: 3 violations (avg+max). After: 0 violations.

## Test plan

- [ ] `dune build` passes
- [ ] `dune runtest` passes (no newly failing tests)
- [ ] `dune build @fmt` passes for round_trip_verifier.ml
- [ ] Nesting linter reports zero violations for round_trip_verifier.ml
- [ ] Diff ≤200 LOC, single file, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)