### PR TITLE
cleanup(nesting): flatten nesting in snapshot_format.ml

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -18,6 +18,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 - [x] nesting: trading/trading/backtest/optimal/lib/outcome_scorer.ml — extracted _step_stage3, _make_initial_state, _resolve_exit; both violations cleared. PR #950 (2026-05-08)
 - [x] nesting: trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml — extracted _rejection_pair_of_alternative + _pairs_of_audit_record; nesting linter clean. PR #949 (2026-05-08)
 - [x] fn_length: trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml — extracted 7 helpers (calendar, analysis, sector, forward, scan) to Optimal_strategy_runner_helpers; 413→282 LOC (branch cleanup/optimal-runner-split-2, 2026-05-08)
+- [x] nesting: trading/trading/data_panel/snapshot/lib/snapshot_format.ml — extracted _check_all_hashes_equal, _build_manifest, _flush_to_channel, _try_write_file, _check_payload_length, _check_payload_md5, _check_row_count, _check_schema_hash; all violations cleared (branch cleanup/nesting-snapshot-format, 2026-05-08)
 - [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)
 - [~] fn_length: trading/trading/simulation/lib/simulator.ml — step fn 63 lines (limit 50); extract helpers (source: dispatch 2026-05-08)
 - [x] magic_numbers: trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml — extracted _strong_outperform_threshold=3.0 and _moderate_outperform_threshold=1.5; linter clean (branch cleanup/optimal-report-sections-magic, 2026-05-08)

--- a/trading/trading/data_panel/snapshot/lib/snapshot_format.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_format.ml
@@ -37,19 +37,22 @@ let _read_int64_le ic =
   done;
   !v
 
+(* Returns [Error Invalid_argument] if any snapshot in [rest] has a different
+   schema hash than [h], or [Ok ()] if all match. *)
+let _check_all_hashes_equal h (rest : Snapshot.t list) =
+  match
+    List.find rest ~f:(fun s -> not (String.equal s.schema.schema_hash h))
+  with
+  | None -> Ok ()
+  | Some bad ->
+      Status.error_invalid_argument
+        (Printf.sprintf "Snapshot_format.write: mixed schema hashes (%s vs %s)"
+           h bad.schema.schema_hash)
+
 let _validate_schemas (snapshots : Snapshot.t list) =
   match snapshots with
   | [] -> Ok ()
-  | first :: rest -> (
-      let h = first.schema.schema_hash in
-      List.find rest ~f:(fun s -> not (String.equal s.schema.schema_hash h))
-      |> function
-      | None -> Ok ()
-      | Some bad ->
-          Status.error_invalid_argument
-            (Printf.sprintf
-               "Snapshot_format.write: mixed schema hashes (%s vs %s)" h
-               bad.schema.schema_hash))
+  | first :: rest -> _check_all_hashes_equal first.schema.schema_hash rest
 
 let _build_payload (snapshots : Snapshot.t list) =
   let rows : Row.t list =
@@ -63,28 +66,38 @@ let _schema_for_write snapshots =
   | first :: _ -> (first : Snapshot.t).schema
   | [] -> Snapshot_schema.default
 
+let _build_manifest ~snapshots ~payload =
+  let schema = _schema_for_write snapshots in
+  let payload_len = String.length payload in
+  let payload_md5 = Stdlib.Digest.to_hex (Stdlib.Digest.string payload) in
+  ({ Manifest.schema; n_rows = List.length snapshots; payload_len; payload_md5 }
+    : Manifest.t)
+
+(* Flushes manifest header + payload bytes to an already-open [oc]. *)
+let _flush_to_channel oc manifest payload =
+  let manifest_bytes =
+    manifest |> Manifest.sexp_of_t |> Sexp.to_string |> Bytes.of_string
+  in
+  _write_int64_le oc (Int64.of_int (Bytes.length manifest_bytes));
+  Out_channel.output_bytes oc manifest_bytes;
+  Out_channel.output_string oc payload
+
+(* Opens [path] for writing and maps I/O exceptions to [Error Internal]. *)
+let _try_write_file ~path manifest payload =
+  try
+    Out_channel.with_file path ~f:(fun oc ->
+        _flush_to_channel oc manifest payload);
+    Ok ()
+  with Sys_error msg | Failure msg ->
+    Status.error_internal (Printf.sprintf "Snapshot_format.write: %s" msg)
+
 let write ~path snapshots =
   match _validate_schemas snapshots with
   | Error _ as e -> e
-  | Ok () -> (
-      let schema = _schema_for_write snapshots in
+  | Ok () ->
       let payload = _build_payload snapshots in
-      let payload_len = String.length payload in
-      let payload_md5 = Stdlib.Digest.to_hex (Stdlib.Digest.string payload) in
-      let manifest : Manifest.t =
-        { schema; n_rows = List.length snapshots; payload_len; payload_md5 }
-      in
-      let manifest_bytes =
-        manifest |> Manifest.sexp_of_t |> Sexp.to_string |> Bytes.of_string
-      in
-      try
-        Out_channel.with_file path ~f:(fun oc ->
-            _write_int64_le oc (Int64.of_int (Bytes.length manifest_bytes));
-            Out_channel.output_bytes oc manifest_bytes;
-            Out_channel.output_string oc payload);
-        Ok ()
-      with Sys_error msg | Failure msg ->
-        Status.error_internal (Printf.sprintf "Snapshot_format.write: %s" msg))
+      let manifest = _build_manifest ~snapshots ~payload in
+      _try_write_file ~path manifest payload
 
 let _decode_manifest_and_payload ~path =
   In_channel.with_file path ~f:(fun ic ->
@@ -98,25 +111,42 @@ let _decode_manifest_and_payload ~path =
       let payload = In_channel.input_all ic in
       (manifest, payload))
 
-let _check_payload_integrity ~(manifest : Manifest.t) ~payload =
+(* Checks byte length of [payload] against [manifest.payload_len]. *)
+let _check_payload_length ~(manifest : Manifest.t) ~payload =
   if String.length payload <> manifest.payload_len then
     Status.error_internal
       (Printf.sprintf
          "Snapshot_format.read: payload length mismatch (file=%d manifest=%d)"
          (String.length payload) manifest.payload_len)
-  else
-    let actual = Stdlib.Digest.to_hex (Stdlib.Digest.string payload) in
-    if not (String.equal actual manifest.payload_md5) then
-      Status.error_internal
-        (Printf.sprintf
-           "Snapshot_format.read: md5 mismatch (file=%s manifest=%s)" actual
-           manifest.payload_md5)
-    else Ok ()
+  else Ok ()
+
+(* Checks MD5 digest of [payload] against [manifest.payload_md5]. *)
+let _check_payload_md5 ~(manifest : Manifest.t) ~payload =
+  let actual = Stdlib.Digest.to_hex (Stdlib.Digest.string payload) in
+  if not (String.equal actual manifest.payload_md5) then
+    Status.error_internal
+      (Printf.sprintf "Snapshot_format.read: md5 mismatch (file=%s manifest=%s)"
+         actual manifest.payload_md5)
+  else Ok ()
+
+let _check_payload_integrity ~(manifest : Manifest.t) ~payload =
+  let open Result.Let_syntax in
+  let%bind () = _check_payload_length ~manifest ~payload in
+  _check_payload_md5 ~manifest ~payload
 
 let _rows_to_snapshots ~(schema : Snapshot_schema.t) (rows : Row.t list) =
   List.map rows ~f:(fun (r : Row.t) ->
       Snapshot.create ~schema ~symbol:r.symbol ~date:r.date ~values:r.values)
   |> Result.all
+
+(* Returns [Error Internal] if [rows] count differs from [manifest.n_rows]. *)
+let _check_row_count ~(manifest : Manifest.t) rows =
+  if List.length rows <> manifest.n_rows then
+    Status.error_internal
+      (Printf.sprintf
+         "Snapshot_format.read: row count mismatch (payload=%d manifest=%d)"
+         (List.length rows) manifest.n_rows)
+  else Ok ()
 
 let read ~path =
   let open Result.Let_syntax in
@@ -124,12 +154,8 @@ let read ~path =
     let manifest, payload = _decode_manifest_and_payload ~path in
     let%bind () = _check_payload_integrity ~manifest ~payload in
     let rows = Sexp.of_string payload |> [%of_sexp: Row.t list] in
-    if List.length rows <> manifest.n_rows then
-      Status.error_internal
-        (Printf.sprintf
-           "Snapshot_format.read: row count mismatch (payload=%d manifest=%d)"
-           (List.length rows) manifest.n_rows)
-    else _rows_to_snapshots ~schema:manifest.schema rows
+    let%bind () = _check_row_count ~manifest rows in
+    _rows_to_snapshots ~schema:manifest.schema rows
   with
   | Sys_error msg | Failure msg ->
       Status.error_internal (Printf.sprintf "Snapshot_format.read: %s" msg)
@@ -138,21 +164,26 @@ let read ~path =
         (Printf.sprintf "Snapshot_format.read: sexp decode: %s"
            (Exn.to_string exn))
 
+(* Returns [Error Failed_precondition] when [file_hash] <> [expected_hash]. *)
+let _check_schema_hash ~file_hash ~expected_hash =
+  if String.equal file_hash expected_hash then Ok ()
+  else
+    let msg =
+      Printf.sprintf
+        "Snapshot_format.read_with_expected_schema: schema hash skew (file=%s \
+         expected=%s)"
+        file_hash expected_hash
+    in
+    Error Status.{ code = Failed_precondition; message = msg }
+
 let read_with_expected_schema ~path ~(expected : Snapshot_schema.t) =
   let open Result.Let_syntax in
   let%bind snapshots = read ~path in
   match snapshots with
   | [] -> Ok snapshots
   | first :: _ ->
-      if String.equal first.schema.schema_hash expected.schema_hash then
-        Ok snapshots
-      else
-        Error
-          {
-            Status.code = Failed_precondition;
-            message =
-              Printf.sprintf
-                "Snapshot_format.read_with_expected_schema: schema hash skew \
-                 (file=%s expected=%s)"
-                first.schema.schema_hash expected.schema_hash;
-          }
+      let%bind () =
+        _check_schema_hash ~file_hash:first.schema.schema_hash
+          ~expected_hash:expected.schema_hash
+      in
+      Ok snapshots


### PR DESCRIPTION
## Finding

From dispatch 2026-05-08 — nesting linter flagged 4 functions in
`trading/trading/data_panel/snapshot/lib/snapshot_format.ml`:

```
4.24   8    0    avg+max    snapshot_format.ml:141  read_with_expected_schema
3.58   7    0    avg+max    snapshot_format.ml:40   _validate_schemas
3.38   6    0    avg+max    snapshot_format.ml:66   write
2.92   5    1    else       snapshot_format.ml:101  _check_payload_integrity
```

## Summary

- Extracted 8 private helpers to flatten nesting depth in the 4 flagged functions:
  - `_check_all_hashes_equal`: pulls the `List.find` + match out of `_validate_schemas`
  - `_build_manifest`: hoists manifest construction out of `write`
  - `_flush_to_channel`: extracts the `Out_channel` body out of `write`
  - `_try_write_file`: extracts the `try/with` file-write block out of `write`
  - `_check_payload_length`: splits the length check out of `_check_payload_integrity`
  - `_check_payload_md5`: splits the MD5 check out of `_check_payload_integrity`
  - `_check_row_count`: extracts row count check out of `read`
  - `_check_schema_hash`: extracts schema hash comparison out of `read_with_expected_schema`
- No behavior change; all 8 existing tests pass unchanged.
- Nesting linter now shows no violations for snapshot_format.ml.

## Test plan

- [x] `dune build` passes
- [x] `dune runtest trading/data_panel/snapshot/test/` — 8 tests, all OK
- [x] `dune build @fmt` — no format diff for snapshot_format.ml
- [x] Nesting linter: `NO VIOLATIONS` for snapshot_format.ml
- [x] Diff ≤300 LOC (87 insertions, 55 deletions = 142 total)
- [x] Single concern: only snapshot_format.ml touched (plus cleanup.md status)
- [x] No new public symbols in snapshot_format.mli (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)