### PR TITLE
cleanup(nesting): extract helpers from order_generator + simulator

### DIFF
--- a/trading/trading/simulation/lib/order_generator.ml
+++ b/trading/trading/simulation/lib/order_generator.ml
@@ -66,18 +66,22 @@ let _transition_to_order ~id ~positions
   | ExitFill _ | ExitComplete ->
       Ok None
 
+(** Advance the (seq, accumulator) pair with [maybe_order].
+
+    [seq] is always incremented even when no order is produced — this keeps
+    IDs stable regardless of how transition kinds are reordered in the
+    caller. Sequential gaps in IDs are harmless. *)
+let _accumulate_order (seq, acc) maybe_order =
+  match maybe_order with
+  | Some order -> Ok (seq + 1, order :: acc)
+  | None -> Ok (seq + 1, acc)
+
 let transitions_to_orders ~current_date ~positions transitions =
   let open Result.Let_syntax in
   let%bind _, orders =
     List.fold_result transitions ~init:(0, []) ~f:(fun (seq, acc) transition ->
         let id = _make_id ~current_date ~seq in
         let%bind maybe_order = _transition_to_order ~id ~positions transition in
-        match maybe_order with
-        | Some order -> Ok (seq + 1, order :: acc)
-        | None ->
-            (* We still advance [seq] for ignored transitions so that any
-               future re-ordering of transition kinds does not silently shift
-               IDs. Sequential gaps in IDs are harmless. *)
-            Ok (seq + 1, acc))
+        _accumulate_order (seq, acc) maybe_order)
   in
   Ok (List.rev orders)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -160,6 +160,19 @@ let _get_today_bars t =
   in
   List.filter_map t.deps.symbols ~f:get_bar
 
+(** Fetch the most recent prior close for [pos] when its symbol is absent from
+    [today_set]. Returns [None] when [pos.symbol] is in [today_set] (no
+    fallback needed) or when no prior bar exists for the symbol. *)
+let _fallback_price_for_position ~adapter ~date ~today_set
+    (pos : Trading_portfolio.Types.portfolio_position) =
+  if Set.mem today_set pos.symbol then None
+  else
+    let%map.Option prev =
+      Trading_simulation_data.Market_data_adapter.get_previous_bar adapter
+        ~symbol:pos.symbol ~date
+    in
+    (pos.symbol, prev.Types.Daily_price.close_price)
+
 (** Build a [(symbol, close_price)] alist covering every position in
     [portfolio]. Today's bar (from [today_bars]) is preferred; for any held
     symbol with no bar today, fall back to the most recent prior bar via
@@ -180,14 +193,7 @@ let _prices_for_held_positions ~adapter ~date ~portfolio ~today_bars =
   let today_set = today_prices |> List.map ~f:fst |> String.Set.of_list in
   let fallback_prices =
     List.filter_map portfolio.Trading_portfolio.Portfolio.positions
-      ~f:(fun (pos : Trading_portfolio.Types.portfolio_position) ->
-        if Set.mem today_set pos.symbol then None
-        else
-          let%map.Option prev =
-            Trading_simulation_data.Market_data_adapter.get_previous_bar adapter
-              ~symbol:pos.symbol ~date
-          in
-          (pos.symbol, prev.Types.Daily_price.close_price))
+      ~f:(_fallback_price_for_position ~adapter ~date ~today_set)
   in
   today_prices @ fallback_prices
 


### PR DESCRIPTION
## Finding

From dispatch (source: nesting linter deep scan):

- `trading/trading/simulation/lib/order_generator.ml:69` `transitions_to_orders` — avg 3.54, max 7 (limit avg 2.5, max 5)
- `trading/trading/simulation/lib/simulator.ml:175` `_prices_for_held_positions` — avg 3.12, max 7 (limit avg 2.5, max 5)

## What changed

**`order_generator.ml`**: Extracted `_accumulate_order` helper that handles the `(seq, acc)` accumulator update. Previously, a `match maybe_order with` was nested directly inside the `let%bind` inside `List.fold_result`'s lambda, creating 5+ levels. The helper is called with the result of `_transition_to_order`, flattening the lambda to a single `let%bind` + call.

**`simulator.ml`**: Extracted `_fallback_price_for_position` helper that fetches the prior close for a single position. Previously, an `if Set.mem today_set pos.symbol then None else let%map.Option ...` was nested inside the `List.filter_map` lambda. The helper takes `~today_set` as a parameter and is referenced directly in `filter_map ~f:(...)`.

## Verification

```
_build/default/devtools/nesting_linter/nesting_linter.exe <repo-root> devtools/checks/linter_exceptions.conf 2>&1 | grep -E "order_generator|simulator.ml"
```
Must print no lines from these files. Confirmed: no output (grep exits 1 = no matches).

## Test plan

- [x] `dune build` passes (exit 0)
- [x] `dune runtest` passes (exit 0)
- [x] `dune build @fmt` formatting verified via `ocamlformat --impl` on both files (no diff)
- [x] Nesting linter: no violations in `order_generator.ml` or `simulator.ml`
- [x] Diff is 2 files, 25 insertions / 15 deletions (well within 200 LOC limit)
- [x] No behavior change — pure extraction of anonymous lambdas into named helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)