### PR TITLE
cleanup(nesting): extract helpers in strategy batch — 6 violations cleared

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -27,6 +27,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 - [x] nesting: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — extracted 9 helpers (_make_daily_price, _match_ohlcv, _fetch_and_build_weekly_view, _fetch_weekly_bars, _to_weekly_bars, _daily_view_from_idx, _find_and_build_daily_view, _low_buf_from_idx, _check_and_fetch_low); all 5 violations cleared. PR #966 (2026-05-08)
+- [x] nesting: strategy batch (laggard_rotation_runner.ml, stage3_force_exit_runner.ml, portfolio_view.ml, weinstein_strategy.ml) — extracted _simple_return, _laggard_exit_for_holding, _fold_position, _collect_laggard_exits, _force_exit_for_holding, _signed_quantity, _process_market_day; 6 violations cleared. PR #969 (2026-05-08)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed

--- a/trading/trading/strategy/lib/portfolio_view.ml
+++ b/trading/trading/strategy/lib/portfolio_view.ml
@@ -11,16 +11,17 @@ type t = { cash : float; positions : Position.t String.Map.t }
    at the current price. Cash already reflects the proceeds credited at short
    entry, so subtracting the current liability is what makes
    [portfolio_value] track P&L correctly on shorts. *)
+let _signed_quantity ~side quantity =
+  match (side : Position.position_side) with
+  | Long -> quantity
+  | Short -> -.quantity
+
 let _holding_market_value (pos : Position.t) ~get_price =
   match pos.state with
-  | Holding { quantity; _ } -> (
-      match get_price pos.symbol with
-      | Some (bar : Types.Daily_price.t) ->
-          let signed_qty =
-            match pos.side with Long -> quantity | Short -> -.quantity
-          in
-          signed_qty *. bar.close_price
-      | None -> 0.0)
+  | Holding { quantity; _ } ->
+      Option.value_map (get_price pos.symbol) ~default:0.0
+        ~f:(fun (bar : Types.Daily_price.t) ->
+          _signed_quantity ~side:pos.side quantity *. bar.close_price)
   | _ -> 0.0
 
 let portfolio_value { cash; positions } ~get_price =

--- a/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.ml
@@ -1,6 +1,11 @@
 open Core
 open Trading_strategy
 
+(** Compute the simple return between two price levels. Returns [None] if
+    [oldest] is non-positive (avoids divide-by-zero on degenerate snapshots). *)
+let _simple_return ~oldest ~latest : float option =
+  if Float.( <= ) oldest 0.0 then None else Some ((latest /. oldest) -. 1.0)
+
 (** Compute the simple return over the rolling window from a list of weekly
     bars. Expects [List.length bars >= n + 1]; takes the close at index 0
     (oldest) and the close at index n (latest). Returns [None] if the list is
@@ -10,9 +15,8 @@ let _window_return ~(n : int) (bars : Types.Daily_price.t list) : float option =
   if List.length bars < n + 1 then None
   else
     let arr = Array.of_list bars in
-    let oldest = arr.(0).close_price in
-    let latest = arr.(Array.length arr - 1).close_price in
-    if Float.( <= ) oldest 0.0 then None else Some ((latest /. oldest) -. 1.0)
+    _simple_return ~oldest:arr.(0).close_price
+      ~latest:arr.(Array.length arr - 1).close_price
 
 (** Build the [TriggerExit] transition for a laggard-rotation exit. Same fill
     convention as {!Stage3_force_exit_runner._make_exit_transition}: the exit
@@ -64,6 +68,22 @@ let _observe_and_emit ~config ~laggard_streaks ~benchmark_13w_return
       _emit_exit_transition ~pos ~current_date ~get_price ~skip_position_ids
         ~rs_13w_neg_weeks
 
+(** Check the RS return for a [Holding] long position over the configured window
+    and emit a laggard-rotation exit when the detector fires. Returns [None]
+    when the position has insufficient bar history. *)
+let _laggard_exit_for_holding ~config ~laggard_streaks ~benchmark_13w_return
+    ~skip_position_ids ~bar_reader ~get_price ~current_date (pos : Position.t) =
+  let n = config.Laggard_rotation.rs_window_weeks in
+  let pos_bars =
+    Bar_reader.weekly_bars_for bar_reader ~symbol:pos.symbol ~n:(n + 1)
+      ~as_of:current_date
+  in
+  match _window_return ~n pos_bars with
+  | None -> None
+  | Some position_13w_return ->
+      _observe_and_emit ~config ~laggard_streaks ~benchmark_13w_return
+        ~skip_position_ids ~get_price ~current_date ~position_13w_return pos
+
 (** Process one position. Returns [Some transition] when the detector fires AND
     the position is not already exiting via an earlier exit channel (stops,
     force-liq, Stage-3) on this tick. Mutates [laggard_streaks] only when both
@@ -71,19 +91,26 @@ let _observe_and_emit ~config ~laggard_streaks ~benchmark_13w_return
 let _process_position ~config ~laggard_streaks ~benchmark_13w_return
     ~skip_position_ids ~bar_reader ~get_price ~current_date (pos : Position.t) =
   match (pos.side, Position.get_state pos) with
-  | Trading_base.Types.Long, Position.Holding _ -> (
-      let n = config.Laggard_rotation.rs_window_weeks in
-      let pos_bars =
-        Bar_reader.weekly_bars_for bar_reader ~symbol:pos.symbol ~n:(n + 1)
-          ~as_of:current_date
-      in
-      match _window_return ~n pos_bars with
-      | None -> None
-      | Some position_13w_return ->
-          _observe_and_emit ~config ~laggard_streaks ~benchmark_13w_return
-            ~skip_position_ids ~get_price ~current_date ~position_13w_return pos
-      )
+  | Trading_base.Types.Long, Position.Holding _ ->
+      _laggard_exit_for_holding ~config ~laggard_streaks ~benchmark_13w_return
+        ~skip_position_ids ~bar_reader ~get_price ~current_date pos
   | _ -> None
+
+let _fold_position ~config ~laggard_streaks ~benchmark_13w_return
+    ~skip_position_ids ~bar_reader ~get_price ~current_date acc pos =
+  match
+    _process_position ~config ~laggard_streaks ~benchmark_13w_return
+      ~skip_position_ids ~bar_reader ~get_price ~current_date pos
+  with
+  | Some t -> t :: acc
+  | None -> acc
+
+let _collect_laggard_exits ~config ~positions ~laggard_streaks
+    ~benchmark_13w_return ~skip_position_ids ~bar_reader ~get_price
+    ~current_date =
+  Map.fold positions ~init:[] ~f:(fun ~key:_ ~data:pos acc ->
+      _fold_position ~config ~laggard_streaks ~benchmark_13w_return
+        ~skip_position_ids ~bar_reader ~get_price ~current_date acc pos)
 
 let update ~config ~benchmark_symbol ~is_screening_day ~positions ~bar_reader
     ~get_price ~laggard_streaks ~skip_position_ids ~current_date =
@@ -101,10 +128,6 @@ let update ~config ~benchmark_symbol ~is_screening_day ~positions ~bar_reader
            signal — leave the streak table untouched and emit nothing. *)
         []
     | Some benchmark_13w_return ->
-        Map.fold positions ~init:[] ~f:(fun ~key:_ ~data:pos acc ->
-            match
-              _process_position ~config ~laggard_streaks ~benchmark_13w_return
-                ~skip_position_ids ~bar_reader ~get_price ~current_date pos
-            with
-            | Some t -> t :: acc
-            | None -> acc)
+        _collect_laggard_exits ~config ~positions ~laggard_streaks
+          ~benchmark_13w_return ~skip_position_ids ~bar_reader ~get_price
+          ~current_date

--- a/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stage3_force_exit_runner.ml
@@ -36,12 +36,12 @@ let _find_force_exit ~config ~stage3_streaks ~prior_stages symbol =
   | None -> None
   | Some current_stage -> (
       match
-        Stage3_force_exit.observe_position ~config ~state:stage3_streaks
-          ~symbol ~current_stage
+        Stage3_force_exit.observe_position ~config ~state:stage3_streaks ~symbol
+          ~current_stage
       with
       | Stage3_force_exit.Hold -> None
-      | Stage3_force_exit.Force_exit { weeks_in_stage3 } ->
-          Some weeks_in_stage3)
+      | Stage3_force_exit.Force_exit { weeks_in_stage3 } -> Some weeks_in_stage3
+      )
 
 (** Emit a [TriggerExit] for [pos] if it is not already being exited by the
     stops runner this tick and [get_price] has a bar for the symbol. Returns
@@ -53,6 +53,17 @@ let _emit_if_eligible ~stop_exit_position_ids ~get_price ~pos ~current_date
     Option.map (get_price pos.symbol) ~f:(fun bar ->
         _make_exit_transition ~pos ~current_date ~bar ~weeks_in_stage3)
 
+(** Emit a force-exit for a [Holding] long position when the detector fires.
+    Checks stage via [_find_force_exit] then eligibility; returns [None] when
+    either guard is absent. *)
+let _force_exit_for_holding ~config ~stage3_streaks ~prior_stages
+    ~stop_exit_position_ids ~get_price ~current_date (pos : Position.t) =
+  match _find_force_exit ~config ~stage3_streaks ~prior_stages pos.symbol with
+  | None -> None
+  | Some weeks_in_stage3 ->
+      _emit_if_eligible ~stop_exit_position_ids ~get_price ~pos ~current_date
+        ~weeks_in_stage3
+
 (** Process one position. Returns [Some transition] when the detector fires AND
     the position is not already exiting via a stop hit this tick. The detector's
     streak counter is always mutated (in [stage3_streaks]) — even on a skipped
@@ -60,23 +71,24 @@ let _emit_if_eligible ~stop_exit_position_ids ~get_price ~pos ~current_date
 let _process_position ~config ~stage3_streaks ~prior_stages
     ~stop_exit_position_ids ~get_price ~current_date (pos : Position.t) =
   match (pos.side, Position.get_state pos) with
-  | Trading_base.Types.Long, Position.Holding _ -> (
-      match _find_force_exit ~config ~stage3_streaks ~prior_stages pos.symbol
-      with
-      | None -> None
-      | Some weeks_in_stage3 ->
-          _emit_if_eligible ~stop_exit_position_ids ~get_price ~pos
-            ~current_date ~weeks_in_stage3)
+  | Trading_base.Types.Long, Position.Holding _ ->
+      _force_exit_for_holding ~config ~stage3_streaks ~prior_stages
+        ~stop_exit_position_ids ~get_price ~current_date pos
   | _ -> None
+
+let _fold_position ~config ~stage3_streaks ~prior_stages ~stop_exit_position_ids
+    ~get_price ~current_date acc pos =
+  match
+    _process_position ~config ~stage3_streaks ~prior_stages
+      ~stop_exit_position_ids ~get_price ~current_date pos
+  with
+  | Some t -> t :: acc
+  | None -> acc
 
 let update ~config ~is_screening_day ~positions ~get_price ~prior_stages
     ~stage3_streaks ~stop_exit_position_ids ~current_date =
   if not is_screening_day then []
   else
     Map.fold positions ~init:[] ~f:(fun ~key:_ ~data:pos acc ->
-        match
-          _process_position ~config ~stage3_streaks ~prior_stages
-            ~stop_exit_position_ids ~get_price ~current_date pos
-        with
-        | Some t -> t :: acc
-        | None -> acc)
+        _fold_position ~config ~stage3_streaks ~prior_stages
+          ~stop_exit_position_ids ~get_price ~current_date acc pos)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -187,46 +187,53 @@ let _assemble_output ~exit_transitions ~stage3_force_exit_transitions
         @ adjust_transitions @ entry_transitions;
     }
 
+let _process_market_day ~config ~ad_bars ~stop_states ~last_stop_out_dates
+    ~prior_macro ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
+    ~sector_prior_stages ~ticker_sectors ~stage3_streaks ~laggard_streaks
+    ~audit_recorder ~get_price ~(portfolio : Portfolio_view.t) ~current_date =
+  let positions = portfolio.positions in
+  let exit_transitions, adjust_transitions =
+    _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
+      ~get_price ~last_stop_out_dates ~audit_recorder ~prior_macro_result
+      ~current_date
+  in
+  let index_view =
+    Bar_reader.weekly_view_for bar_reader ~symbol:config.indices.primary
+      ~n:config.lookback_bars ~as_of:current_date
+  in
+  let ( force_exit_transitions,
+        stage3_force_exit_transitions,
+        laggard_rotation_transitions,
+        stop_exited_ids,
+        stage3_exited_ids,
+        laggard_exited_ids ) =
+    _run_special_exits ~config ~positions ~portfolio ~get_price ~peak_tracker
+      ~audit_recorder ~prior_stages ~stage3_streaks ~laggard_streaks ~bar_reader
+      ~index_view ~exit_transitions ~current_date
+  in
+  let entry_transitions =
+    _run_macro_and_entries ~config ~ad_bars ~stop_states ~last_stop_out_dates
+      ~prior_macro ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
+      ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio ~current_date
+      ~index_view ~audit_recorder
+  in
+  _assemble_output ~exit_transitions ~stage3_force_exit_transitions
+    ~laggard_rotation_transitions ~force_exit_transitions ~adjust_transitions
+    ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids
+
 let _on_market_close ~config ~ad_bars ~stop_states ~last_stop_out_dates
     ~prior_macro ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
     ~sector_prior_stages ~ticker_sectors ~stage3_streaks ~laggard_streaks
     ~audit_recorder ~get_price ~get_indicator:_ ~(portfolio : Portfolio_view.t)
     =
-  let positions = portfolio.positions in
   match get_price config.indices.primary with
   | None -> Ok { Strategy_interface.transitions = [] }
   | Some primary_bar ->
       let current_date = primary_bar.Types.Daily_price.date in
-      let exit_transitions, adjust_transitions =
-        _run_stops_pass ~config ~positions ~stop_states ~bar_reader
-          ~prior_stages ~get_price ~last_stop_out_dates ~audit_recorder
-          ~prior_macro_result ~current_date
-      in
-      let index_view =
-        Bar_reader.weekly_view_for bar_reader ~symbol:config.indices.primary
-          ~n:config.lookback_bars ~as_of:current_date
-      in
-      let ( force_exit_transitions,
-            stage3_force_exit_transitions,
-            laggard_rotation_transitions,
-            stop_exited_ids,
-            stage3_exited_ids,
-            laggard_exited_ids ) =
-        _run_special_exits ~config ~positions ~portfolio ~get_price
-          ~peak_tracker ~audit_recorder ~prior_stages ~stage3_streaks
-          ~laggard_streaks ~bar_reader ~index_view ~exit_transitions
-          ~current_date
-      in
-      let entry_transitions =
-        _run_macro_and_entries ~config ~ad_bars ~stop_states
-          ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
-          ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
-          ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
-      in
-      _assemble_output ~exit_transitions ~stage3_force_exit_transitions
-        ~laggard_rotation_transitions ~force_exit_transitions
-        ~adjust_transitions ~entry_transitions ~stop_exited_ids
-        ~stage3_exited_ids ~laggard_exited_ids
+      _process_market_day ~config ~ad_bars ~stop_states ~last_stop_out_dates
+        ~prior_macro ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages
+        ~sector_prior_stages ~ticker_sectors ~stage3_streaks ~laggard_streaks
+        ~audit_recorder ~get_price ~portfolio ~current_date
 
 let _init_strategy_state ~initial_stop_states ~ad_bars =
   let stop_states = ref initial_stop_states in


### PR DESCRIPTION
## Finding

From health-scanner dispatch 2026-05-08, nesting violations in 4 strategy-layer files:

| File | Function | avg | max | violation |
|------|----------|-----|-----|-----------|
| `laggard_rotation_runner.ml:88` | `update` | 3.62 | 8 | avg+max |
| `laggard_rotation_runner.ml:71` | `_process_position` | 3.07 | 6 | avg+max |
| `laggard_rotation_runner.ml:9` | `_window_return` | — | — | nested-else |
| `stage3_force_exit_runner.ml:72` | `update` | 3.30 | 6 | avg+max |
| `stage3_force_exit_runner.ml:60` | `_process_position` | 2.80 | 6 | max |
| `portfolio_view.ml:14` | `_holding_market_value` | 3.30 | 6 | avg+max |
| `weinstein_strategy.ml:190` | `_on_market_close` | 3.72 | 6 | avg+max |

## Changes

- **`portfolio_view.ml`**: Extract `_signed_quantity`; flatten double-match in `_holding_market_value` using `Option.value_map`
- **`stage3_force_exit_runner.ml`**: Extract `_force_exit_for_holding` (removes nested match in `_process_position`) and `_fold_position` (removes inline match in `update` fold body)
- **`laggard_rotation_runner.ml`**: Extract `_simple_return` (fixes nested-else in `_window_return`), `_laggard_exit_for_holding` (removes nested match in `_process_position`), `_fold_position`, and `_collect_laggard_exits` (flatten `update`)
- **`weinstein_strategy.ml`**: Extract `_process_market_day`; `_on_market_close` becomes a 5-line dispatcher over a primary-bar match

## Verify

```
_build/default/devtools/nesting_linter/nesting_linter.exe <root> devtools/checks/linter_exceptions.conf 2>&1 \
  | grep -E "laggard_rotation_runner|stage3_force_exit_runner|portfolio_view|weinstein_strategy"
```
Must print no lines — verified clean.

## Test plan

- [x] `dune build` passes
- [x] `dune runtest trading/strategy/ trading/weinstein/` — all tests pass (0 failures)
- [x] Nesting linter: zero lines from all 4 files
- [x] No new public symbols; behavior is identical (pure structural refactor)
- [x] Diff ≤ 400 LOC (121 ins / 78 del = 199 LOC changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)