### PR TITLE
cleanup(file_length): split OHLCV helpers from snapshot_bar_views 338->295 LOC

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -30,7 +30,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 - [x] nesting: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — extracted 9 helpers (_make_daily_price, _match_ohlcv, _fetch_and_build_weekly_view, _fetch_weekly_bars, _to_weekly_bars, _daily_view_from_idx, _find_and_build_daily_view, _low_buf_from_idx, _check_and_fetch_low); all 5 violations cleared. PR #966 (2026-05-08)
-- [~] file_length: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — 338 LOC (limit 300); move private helpers into snapshot_bar_views_helpers.ml sibling (source: dispatch 2026-05-08)
+- [x] file_length: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — 338->295 LOC; extracted 5 OHLCV helpers to snapshot_bar_views_helpers. PR #972 (2026-05-08)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed

--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,22 +15,22 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
+- [~] nesting: trading/trading/backtest/lib/runner.ml + optimal_strategy_runner_helpers.ml + optimal_summary.ml + reconciler_writer.ml — extract private helpers to reduce nesting in 5 flagged fns (source: dispatch 2026-05-08)
+- [~] nesting: trading/trading/weinstein/snapshot/lib/pick_diff.ml + trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_manifest.ml — extract private helpers to reduce avg/max nesting (source: dispatch 2026-05-08)
+
 - [x] nesting: trading/trading/backtest/optimal/lib/outcome_scorer.ml — extracted _step_stage3, _make_initial_state, _resolve_exit; both violations cleared. PR #950 (2026-05-08)
 - [x] nesting: trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml — extracted _rejection_pair_of_alternative + _pairs_of_audit_record; nesting linter clean. PR #949 (2026-05-08)
 - [x] fn_length: trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml — extracted 7 helpers (calendar, analysis, sector, forward, scan) to Optimal_strategy_runner_helpers; 413→282 LOC (branch cleanup/optimal-runner-split-2, 2026-05-08)
 - [x] nesting: trading/trading/data_panel/snapshot/lib/snapshot_format.ml — extracted _check_all_hashes_equal, _build_manifest, _flush_to_channel, _try_write_file, _check_payload_length, _check_payload_md5, _check_row_count, _check_schema_hash; all violations cleared (branch cleanup/nesting-snapshot-format, 2026-05-08)
-- [x] nesting: trading/trading/backtest/lib/runner.ml + optimal_strategy_runner_helpers.ml + optimal_summary.ml + reconciler_writer.ml — extracted 7 helpers; all 5 violations cleared. PR #971 (2026-05-08)
 - [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)
 - [~] fn_length: trading/trading/simulation/lib/simulator.ml — step fn 63 lines (limit 50); extract helpers (source: dispatch 2026-05-08)
 - [x] nesting: trading/trading/simulation/lib/{antifragility,return_basics,distributional}_computer.ml — extracted _add_ols_pair, _zero_sums, _add_sq_dev, _add_moments, _bucket_loop helpers; all 5 dispatch violations cleared. PR #967 (2026-05-08)
-- [x] nesting: trading/trading/simulation/lib/order_generator.ml + simulator.ml — extracted _accumulate_order + _fallback_price_for_position; transitions_to_orders + _prices_for_held_positions violations cleared. PR #968 (2026-05-08)
-- [x] nesting: trading/trading/weinstein/snapshot/lib/pick_diff.ml + trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_manifest.ml — extracted _compute_diff, _date_mismatch_error, _decode_sexp, _load_if_exists, _validate_and_write; all 3 violations cleared (branch cleanup/nesting-pick-manifest, 2026-05-08)
 - [x] magic_numbers: trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml — extracted _strong_outperform_threshold=3.0 and _moderate_outperform_threshold=1.5; linter clean (branch cleanup/optimal-report-sections-magic, 2026-05-08)
 - [x] nesting: trading/analysis/scripts/build_snapshots/build_snapshots.ml — extracted 5 helpers (_entry_is_current, _write_and_checksum, _file_metadata, _build_or_log, _load_benchmark_bars, _make_progress, _last_symbol, _fold_symbol); all 78 fns pass nesting linter (branch cleanup/nesting-build-snapshots-2, 2026-05-08)
 - [x] nesting: trading/trading/weinstein/strategy/lib/entry_audit_capture.ml — extracted 5 helpers; classify_candidate/emit_entries/alternatives_of_decisions all pass; file avg now under 2.5 (branch cleanup/nesting-entry-audit-capture, 2026-05-08)
 - [x] fn_length + magic_numbers: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — condensed comments −15 lines (297); restructured to avoid bare literals on mid-comment lines. PR #924 (2026-05-07)
 - [x] nesting: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — extracted 9 helpers (_make_daily_price, _match_ohlcv, _fetch_and_build_weekly_view, _fetch_weekly_bars, _to_weekly_bars, _daily_view_from_idx, _find_and_build_daily_view, _low_buf_from_idx, _check_and_fetch_low); all 5 violations cleared. PR #966 (2026-05-08)
-- [x] nesting: strategy batch (laggard_rotation_runner.ml, stage3_force_exit_runner.ml, portfolio_view.ml, weinstein_strategy.ml) — extracted _simple_return, _laggard_exit_for_holding, _fold_position, _collect_laggard_exits, _force_exit_for_holding, _signed_quantity, _process_market_day; 6 violations cleared. PR #969 (2026-05-08)
+- [~] file_length: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — 338 LOC (limit 300); move private helpers into snapshot_bar_views_helpers.ml sibling (source: dispatch 2026-05-08)
 Orchestrator populates this from `dev/health/<date>-{fast,deep}.md`. Items here are eligible for next dispatch.
 
 ## Completed

--- a/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml
@@ -5,6 +5,7 @@ open Core
 module BA1 = Bigarray.Array1
 module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
 module Panel_views = Data_panel_snapshot.Panel_views
+module H = Snapshot_bar_views_helpers
 
 (* Phase F.3.e-1 (revised): the canonical record definitions live in
    [Data_panel_snapshot.Panel_views] — a neutral hub library with no
@@ -58,61 +59,17 @@ let _read_history_or_empty (cb : Snapshot_callbacks.t) ~symbol ~from ~until
   | Ok rows -> rows
   | Error _ -> []
 
-let _table_of (rows : (Date.t * float) list) =
-  let tbl = Hashtbl.create (module Date) in
-  List.iter rows ~f:(fun (d, v) ->
-      Hashtbl.set tbl ~key:d ~data:v |> (ignore : unit -> unit));
-  tbl
-
-let _round_volume v =
-  if Float.is_nan v then 0 else Int.of_float (Float.round_nearest v)
-
-(* Build a [Daily_price.t] from fully-matched OHLCAV values and a date. *)
-let _make_daily_price ~open_t ~date ~close_v ~adj_v ~high_v ~low_v ~vol_v =
-  let open_price =
-    Hashtbl.find open_t date |> Option.value ~default:Float.nan
-  in
-  {
-    Types.Daily_price.date;
-    open_price;
-    high_price = high_v;
-    low_price = low_v;
-    close_price = close_v;
-    volume = _round_volume vol_v;
-    adjusted_close = adj_v;
-  }
-
-(* Match OHLCV side-tables for [date]; returns [None] if any required field is
-   missing. [open_t] is optional so missing open degrades to NaN. *)
-let _match_ohlcv ~open_t ~adj_t ~high_t ~low_t ~vol_t ~date ~close_v =
-  match
-    ( Hashtbl.find adj_t date,
-      Hashtbl.find high_t date,
-      Hashtbl.find low_t date,
-      Hashtbl.find vol_t date )
-  with
-  | Some adj_v, Some high_v, Some low_v, Some vol_v ->
-      Some
-        (_make_daily_price ~open_t ~date ~close_v ~adj_v ~high_v ~low_v ~vol_v)
-  | _ -> None
-
-(* Attempt to build one [Daily_price.t] from a (date, close) pair and the
-   OHLCV side-tables. Returns [None] for NaN-close or any missing field. *)
-let _bar_for ~open_t ~adj_t ~high_t ~low_t ~vol_t (date, close_v) =
-  if Float.is_nan close_v then None
-  else _match_ohlcv ~open_t ~adj_t ~high_t ~low_t ~vol_t ~date ~close_v
-
 (* Align OHLCV field-histories by date → [Daily_price.t list]. Builds one
    hashtable per non-Close field, walks [Close] once (O(n)), skips NaN-close
    bars. [Open] included since Phase A.1; missing rows degrade to NaN. *)
 let _assemble_daily_bars ~open_ ~adj ~close ~high ~low ~volume :
     Types.Daily_price.t list =
-  let open_t = _table_of open_ in
-  let adj_t = _table_of adj in
-  let high_t = _table_of high in
-  let low_t = _table_of low in
-  let vol_t = _table_of volume in
-  List.filter_map close ~f:(_bar_for ~open_t ~adj_t ~high_t ~low_t ~vol_t)
+  let open_t = H.table_of open_ in
+  let adj_t = H.table_of adj in
+  let high_t = H.table_of high in
+  let low_t = H.table_of low in
+  let vol_t = H.table_of volume in
+  List.filter_map close ~f:(H.bar_for ~open_t ~adj_t ~high_t ~low_t ~vol_t)
 
 (* Convert a weekly [Daily_price.t] list (output of daily_to_weekly) into the
    [weekly_view] float-array shape. *)
@@ -270,7 +227,7 @@ let _read_close_high_low cb ~symbol ~from_date ~until_date =
   else
     let high = read Snapshot_schema.High in
     let low = read Snapshot_schema.Low in
-    Some (_table_of close, _table_of high, _table_of low)
+    Some (H.table_of close, H.table_of high, H.table_of low)
 
 (* Build a daily view from a valid [as_of_idx]; reads and walks the window. *)
 let _daily_view_from_idx cb ~symbol ~calendar ~as_of_idx ~lookback =
@@ -317,7 +274,7 @@ let _low_buf_from_idx (cb : Snapshot_callbacks.t) ~symbol ~calendar ~from_idx
   with
   | Error _ -> None
   | Ok rows ->
-      let low_t = _table_of rows in
+      let low_t = H.table_of rows in
       let buf = BA1.create Bigarray.Float64 Bigarray.C_layout len in
       _fill_low_buf ~calendar ~from_idx ~len ~low_t buf;
       Some buf

--- a/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views_helpers.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views_helpers.ml
@@ -1,0 +1,43 @@
+(** Private OHLCV-assembly helpers for [Snapshot_bar_views]. Not part of the
+    public library surface. See [.mli] for doc. *)
+
+open Core
+
+let table_of (rows : (Date.t * float) list) =
+  let tbl = Hashtbl.create (module Date) in
+  List.iter rows ~f:(fun (d, v) ->
+      Hashtbl.set tbl ~key:d ~data:v |> (ignore : unit -> unit));
+  tbl
+
+let _round_volume v =
+  if Float.is_nan v then 0 else Int.of_float (Float.round_nearest v)
+
+let _make_daily_price ~open_t ~date ~close_v ~adj_v ~high_v ~low_v ~vol_v =
+  let open_price =
+    Hashtbl.find open_t date |> Option.value ~default:Float.nan
+  in
+  {
+    Types.Daily_price.date;
+    open_price;
+    high_price = high_v;
+    low_price = low_v;
+    close_price = close_v;
+    volume = _round_volume vol_v;
+    adjusted_close = adj_v;
+  }
+
+let _match_ohlcv ~open_t ~adj_t ~high_t ~low_t ~vol_t ~date ~close_v =
+  match
+    ( Hashtbl.find adj_t date,
+      Hashtbl.find high_t date,
+      Hashtbl.find low_t date,
+      Hashtbl.find vol_t date )
+  with
+  | Some adj_v, Some high_v, Some low_v, Some vol_v ->
+      Some
+        (_make_daily_price ~open_t ~date ~close_v ~adj_v ~high_v ~low_v ~vol_v)
+  | _ -> None
+
+let bar_for ~open_t ~adj_t ~high_t ~low_t ~vol_t (date, close_v) =
+  if Float.is_nan close_v then None
+  else _match_ohlcv ~open_t ~adj_t ~high_t ~low_t ~vol_t ~date ~close_v

--- a/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views_helpers.mli
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views_helpers.mli
@@ -1,0 +1,19 @@
+(** Private OHLCV-assembly helpers for [Snapshot_bar_views]. Not part of the
+    public library surface. *)
+
+open Core
+
+val table_of : (Date.t * float) list -> (Date.t, float) Hashtbl.t
+(** Build a date-keyed hashtable from a [(date, value)] row list. *)
+
+val bar_for :
+  open_t:(Date.t, float) Hashtbl.t ->
+  adj_t:(Date.t, float) Hashtbl.t ->
+  high_t:(Date.t, float) Hashtbl.t ->
+  low_t:(Date.t, float) Hashtbl.t ->
+  vol_t:(Date.t, float) Hashtbl.t ->
+  Date.t * float ->
+  Types.Daily_price.t option
+(** Build one [Daily_price.t] from a [(date, close)] pair and the OHLCV
+    side-tables. Returns [None] for NaN-close or any missing field. Open
+    degrades to [Float.nan] when the snapshot has no row for the date. *)


### PR DESCRIPTION
## Finding

> file_length: trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views.ml — 338 LOC (limit 300); move private helpers into snapshot_bar_views_helpers.ml sibling (source: dispatch 2026-05-08)

## What changed

Extracted 5 cohesive OHLCV-assembly helpers from `snapshot_bar_views.ml` into a new sibling module `snapshot_bar_views_helpers.ml` + `.mli`:

- `table_of` — build a `Date.t`-keyed hashtable from a row list (public)
- `_round_volume` — NaN-safe volume rounding (private)
- `_make_daily_price` — assemble one `Daily_price.t` record (private)
- `_match_ohlcv` — pattern-match on the 4 OHLCV side-tables (private)
- `bar_for` — top-level entry point called by `_assemble_daily_bars` (public)

The main file now uses `module H = Snapshot_bar_views_helpers` and calls `H.table_of` / `H.bar_for` directly. No behavior change.

**LOC delta:** 338 → 295 (limit 300). Diff: 75 ins + 52 del = 127 LOC total.

## Test plan

- [x] `dune build` passes (no errors)
- [x] `dune runtest` passes (identical output, exit 0)
- [x] `linter_file_length.sh | grep snapshot_bar_views` — empty (violation cleared)
- [x] `dune build @fmt` — no format changes on touched files
- [x] Diff is 127 LOC (under 200 hard cap)
- [x] Single finding addressed; no new public symbols in any `.mli` beyond `table_of` + `bar_for`

🤖 Generated with [Claude Code](https://claude.com/claude-code)