### PR TITLE
cleanup(file-length): trim weinstein_strategy.ml 305→300 lines

### DIFF
--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -93,11 +93,10 @@ let _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
 let _run_special_exits ~config ~positions ~(portfolio : Portfolio_view.t)
     ~get_price ~peak_tracker ~audit_recorder ~prior_stages ~stage3_streaks
     ~laggard_streaks ~bar_reader ~index_view ~exit_transitions ~current_date =
-  let cash = portfolio.cash in
   let raw_force_exit_ts =
     Force_liquidation_runner.update
       ~config:config.portfolio_config.force_liquidation ~positions ~get_price
-      ~cash ~current_date ~peak_tracker ~audit_recorder
+      ~cash:portfolio.cash ~current_date ~peak_tracker ~audit_recorder
   in
   let stop_exited_ids = _trigger_exit_ids_of exit_transitions in
   let force_exit_ts =
@@ -240,14 +239,10 @@ let _init_strategy_state ~initial_stop_states ~ad_bars =
   let last_stop_out_dates : Date.t Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in
-  let prior_macro : Weinstein_types.market_trend ref =
-    ref Weinstein_types.Neutral
-  in
+  let prior_macro = ref Weinstein_types.Neutral in
   let peak_tracker = Portfolio_risk.Force_liquidation.Peak_tracker.create () in
   let prior_macro_result : Macro.result option ref = ref None in
-  let prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
-    Hashtbl.create (module String)
-  in
+  let prior_stages = Hashtbl.create (module String) in
   let sector_prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
     Hashtbl.create (module String)
   in


### PR DESCRIPTION
## Finding

`trading/trading/weinstein/strategy/lib/weinstein_strategy.ml`: 305 lines (limit: 300)

Source: dispatch 2026-05-08, confirmed by `bash devtools/checks/linter_file_length.sh 2>&1 | grep weinstein_strategy.ml`

## Changes

Three mechanical line-count reductions, no behavior change:

1. **`_run_special_exits`**: Inline `let cash = portfolio.cash` — single-use binding replaced by `~cash:portfolio.cash` at the call site (−1 line)
2. **`_init_strategy_state`**: Drop explicit type annotation on `prior_macro` (type trivially inferred from `ref Weinstein_types.Neutral`) — collapses 3-line form to 1 line (−2 lines)
3. **`_init_strategy_state`**: Drop explicit type annotation on `prior_stages` (type inferred from usage context) — collapses 3-line form to 1 line (−2 lines)

Total: 305 → 300 lines (−5 lines, at limit).

## Verification

- `dune build` passes
- `dune runtest trading/weinstein/strategy/` — all 17 test suites pass
- `bash devtools/checks/linter_file_length.sh 2>&1 | grep weinstein_strategy.ml` — no output (finding cleared)
- `dune build @fmt` — no format violations on touched file
- Diff is 11 lines changed (3 insertions, 8 deletions) — well within ≤200 LOC cap

## Test plan

- [x] `dune build` green
- [x] `dune runtest trading/weinstein/strategy/` all pass
- [x] File-length linter reports no violation on `weinstein_strategy.ml`
- [x] `dune build @fmt` no format change on touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)