### PR TITLE
cleanup(nesting): extract helpers in optimal_strategy_report_sections — 3 violations

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -17,7 +17,10 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 - [~] nesting: trading/trading/backtest/lib/runner.ml + optimal_strategy_runner_helpers.ml + optimal_summary.ml + reconciler_writer.ml — extract private helpers to reduce nesting in 5 flagged fns (source: dispatch 2026-05-08)
 - [~] nesting: trading/trading/weinstein/snapshot/lib/pick_diff.ml + trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_manifest.ml — extract private helpers to reduce avg/max nesting (source: dispatch 2026-05-08)
+- [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)
+- [~] fn_length: trading/trading/simulation/lib/simulator.ml — step fn 63 lines (limit 50); extract helpers (source: dispatch 2026-05-08)
 
+- [x] nesting: trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml — extracted _cmp_actual_by_date, _actual_date_break, _label_actual_group, _cmp_optimal_by_date, _optimal_date_break, _label_optimal_group, _ratio_narrative; all 3 violations cleared (branch cleanup/nesting-report-sections, 2026-05-08)
 - [x] nesting: trading/trading/backtest/optimal/lib/outcome_scorer.ml — extracted _step_stage3, _make_initial_state, _resolve_exit; both violations cleared. PR #950 (2026-05-08)
 - [x] nesting: trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml — extracted _rejection_pair_of_alternative + _pairs_of_audit_record; nesting linter clean. PR #949 (2026-05-08)
 - [x] fn_length: trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml — extracted 7 helpers (calendar, analysis, sector, forward, scan) to Optimal_strategy_runner_helpers; 413→282 LOC (branch cleanup/optimal-runner-split-2, 2026-05-08)

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml
@@ -12,45 +12,58 @@ open Core
 (* Section: per-Friday divergence table                              *)
 (* ---------------------------------------------------------------- *)
 
+(** Compare two actual trade_metrics by entry_date. *)
+let _cmp_actual_by_date (x : Trading_simulation.Metrics.trade_metrics)
+    (y : Trading_simulation.Metrics.trade_metrics) =
+  Date.compare x.entry_date y.entry_date
+
+(** True iff two actual trade_metrics have different entry_dates (group break).
+*)
+let _actual_date_break (a : Trading_simulation.Metrics.trade_metrics)
+    (b : Trading_simulation.Metrics.trade_metrics) =
+  not (Date.equal a.entry_date b.entry_date)
+
+(** Label a group of actual round-trips with their common entry_date. *)
+let _label_actual_group (group : Trading_simulation.Metrics.trade_metrics list)
+    =
+  match group with
+  | [] -> failwith "_actual_picks_by_friday: empty group (impossible)"
+  | (hd : Trading_simulation.Metrics.trade_metrics) :: _ ->
+      (hd.entry_date, group)
+
 (** Group actual round-trips by their entry date (the equivalent of "Friday").
 *)
 let _actual_picks_by_friday
     (rts : Trading_simulation.Metrics.trade_metrics list) :
     (Date.t * Trading_simulation.Metrics.trade_metrics list) list =
   rts
-  |> List.sort
-       ~compare:(fun
-           (x : Trading_simulation.Metrics.trade_metrics)
-           (y : Trading_simulation.Metrics.trade_metrics)
-         -> Date.compare x.entry_date y.entry_date)
-  |> List.group
-       ~break:(fun
-           (a : Trading_simulation.Metrics.trade_metrics)
-           (b : Trading_simulation.Metrics.trade_metrics)
-         -> not (Date.equal a.entry_date b.entry_date))
-  |> List.map ~f:(fun group ->
-      match group with
-      | [] -> failwith "_actual_picks_by_friday: empty group (impossible)"
-      | (hd : Trading_simulation.Metrics.trade_metrics) :: _ ->
-          (hd.entry_date, group))
+  |> List.sort ~compare:_cmp_actual_by_date
+  |> List.group ~break:_actual_date_break
+  |> List.map ~f:_label_actual_group
+
+(** Compare two optimal round-trips by entry_week. *)
+let _cmp_optimal_by_date (x : Optimal_types.optimal_round_trip)
+    (y : Optimal_types.optimal_round_trip) =
+  Date.compare x.entry_week y.entry_week
+
+(** True iff two optimal round-trips have different entry_weeks (group break).
+*)
+let _optimal_date_break (a : Optimal_types.optimal_round_trip)
+    (b : Optimal_types.optimal_round_trip) =
+  not (Date.equal a.entry_week b.entry_week)
+
+(** Label a group of optimal round-trips with their common entry_week. *)
+let _label_optimal_group (group : Optimal_types.optimal_round_trip list) =
+  match group with
+  | [] -> failwith "_optimal_picks_by_friday: empty group (impossible)"
+  | (hd : Optimal_types.optimal_round_trip) :: _ -> (hd.entry_week, group)
 
 let _optimal_picks_by_friday (rts : Optimal_types.optimal_round_trip list) :
     (Date.t * Optimal_types.optimal_round_trip list) list =
   rts
-  |> List.sort
-       ~compare:(fun
-           (x : Optimal_types.optimal_round_trip)
-           (y : Optimal_types.optimal_round_trip)
-         -> Date.compare x.entry_week y.entry_week)
-  |> List.group
-       ~break:(fun
-           (a : Optimal_types.optimal_round_trip)
-           (b : Optimal_types.optimal_round_trip)
-         -> not (Date.equal a.entry_week b.entry_week))
-  |> List.map ~f:(fun group ->
-      match group with
-      | [] -> failwith "_optimal_picks_by_friday: empty group (impossible)"
-      | (hd : Optimal_types.optimal_round_trip) :: _ -> (hd.entry_week, group))
+  |> List.sort ~compare:_cmp_optimal_by_date
+  |> List.group ~break:_optimal_date_break
+  |> List.map ~f:_label_optimal_group
 
 let _syms_of_actual (rts : Trading_simulation.Metrics.trade_metrics list) =
   rts
@@ -229,6 +242,30 @@ let _strong_outperform_threshold = 3.0
     near-optimal (moderate outperformance band lower bound). *)
 let _moderate_outperform_threshold = 1.5
 
+(** Format a narrative for a valid (positive-actual) ratio of counterfactual to
+    actual return. *)
+let _ratio_narrative ~(r : float) : string =
+  if Float.(r > _strong_outperform_threshold) then
+    sprintf
+      "Constrained-counterfactual return is %.1f* the actual run's. The \
+       cascade is significantly mis-scoring opportunities -- material gains \
+       are reachable via re-weighting alone, without relaxing the macro gate \
+       or sector caps."
+      r
+  else if Float.(r < _moderate_outperform_threshold) then
+    sprintf
+      "Constrained-counterfactual return is %.1f* the actual run's -- the \
+       cascade is near-optimal under the current envelope. Further upside \
+       requires structural changes (envelope, gate thresholds, or additional \
+       signals)."
+      r
+  else
+    sprintf
+      "Constrained-counterfactual return is %.1f* the actual run's. Moderate \
+       cascade-ranking improvement is reachable; structural changes (envelope \
+       / gate / signals) are also needed for full upside."
+      r
+
 let _implications_narrative ~(actual_total_return_pct : float)
     ~(constrained_total_return_pct : float) : string =
   if Float.(actual_total_return_pct <= 0.0) then
@@ -237,26 +274,7 @@ let _implications_narrative ~(actual_total_return_pct : float)
      few candidates, or the macro gate may be over-restrictive."
   else
     let r = constrained_total_return_pct /. actual_total_return_pct in
-    if Float.(r > _strong_outperform_threshold) then
-      sprintf
-        "Constrained-counterfactual return is %.1f* the actual run's. The \
-         cascade is significantly mis-scoring opportunities -- material gains \
-         are reachable via re-weighting alone, without relaxing the macro gate \
-         or sector caps."
-        r
-    else if Float.(r < _moderate_outperform_threshold) then
-      sprintf
-        "Constrained-counterfactual return is %.1f* the actual run's -- the \
-         cascade is near-optimal under the current envelope. Further upside \
-         requires structural changes (envelope, gate thresholds, or additional \
-         signals)."
-        r
-    else
-      sprintf
-        "Constrained-counterfactual return is %.1f* the actual run's. Moderate \
-         cascade-ranking improvement is reachable; structural changes \
-         (envelope / gate / signals) are also needed for full upside."
-        r
+    _ratio_narrative ~r
 
 let implications_section ~(actual_initial_cash : float)
     ~(actual_final_portfolio_value : float)


### PR DESCRIPTION
## Summary

Addresses nesting-linter violations in `trading/trading/backtest/optimal/lib/optimal_strategy_report_sections.ml` (from dispatch 2026-05-08):

- `_actual_picks_by_friday` line 17: avg 3.11 (limit 2.5)
- `_optimal_picks_by_friday` line 37: avg 3.06 (limit 2.5)
- `_implications_narrative` line 232: avg 3.07 + else-1 (limit 2.5)

**Root cause:** Inline typed lambdas inside `List.sort ~compare:`, `List.group ~break:`, and `List.map ~f:(match ...)` pipelines created 5-deep nesting. The nested `if/else` in `_implications_narrative`'s `else` branch added `else 1` depth.

**Fix:** Extract 7 private named helpers:
- `_cmp_actual_by_date`, `_actual_date_break`, `_label_actual_group` → replace inline lambdas in `_actual_picks_by_friday`
- `_cmp_optimal_by_date`, `_optimal_date_break`, `_label_optimal_group` → replace inline lambdas in `_optimal_picks_by_friday`
- `_ratio_narrative` → extract nested if/else body from `_implications_narrative`'s else branch

No behavior change. Pure structural refactor; bit-equal golden output.

## Verification

Nesting linter before: 3 violations (avg 3.11, 3.06, 3.07+else-1)
Nesting linter after: 0 violations for this file

```
_build/default/devtools/nesting_linter/nesting_linter.exe /workspaces/trading-1 \
  devtools/checks/linter_exceptions.conf | grep optimal_strategy_report_sections
# (no output)
```

## Test plan
- [x] `dune build` passes (exit 0)
- [x] `dune build @fmt` passes without modifying the file (file already ocamlformat-canonical)
- [x] Nesting linter shows 0 violations for `optimal_strategy_report_sections.ml`
- [x] Diff is ≤200 LOC (70 insertions, 49 deletions in the .ml file)
- [x] Single concern: nesting in one file
- [x] No behavior change (pure extraction of inline lambdas to named fns)
- [x] No new public symbols (all helpers are `_`-prefixed private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)