### PR TITLE
cleanup(nesting): extract helpers in misc batch — 9 violations cleared

### DIFF
--- a/trading/trading/backtest/all_eligible/lib/all_eligible.ml
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible.ml
@@ -121,6 +121,10 @@ let _bucket_bounds (boundaries : float list) : (float * float) list =
   let ends = boundaries @ [ Float.infinity ] in
   List.zip_exn starts ends
 
+(** Count values in [xs] falling in the half-open interval [\[low, high)]. *)
+let _count_in_range ~low ~high xs =
+  List.count xs ~f:(fun r -> Float.( >= ) r low && Float.( < ) r high)
+
 (** Count returns falling into each bucket. Bucket interval is half-open
     [\[low, high)]. The last bucket's [high] is [+infinity], so any positive
     return falls cleanly into [\[bn, +inf)]. *)
@@ -128,11 +132,7 @@ let _bucketize ~(boundaries : float list) (returns : float list) :
     (float * float * int) list =
   let bounds = _bucket_bounds boundaries in
   List.map bounds ~f:(fun (low, high) ->
-      let count =
-        List.count returns ~f:(fun r ->
-            Float.( >= ) r low && Float.( < ) r high)
-      in
-      (low, high, count))
+      (low, high, _count_in_range ~low ~high returns))
 
 let compute_aggregate ~(config : config) (trades : trade_record list) :
     aggregate =
@@ -168,6 +168,23 @@ let compute_aggregate ~(config : config) (trades : trade_record list) :
 (* First-admission dedup                                                *)
 (* ------------------------------------------------------------------ *)
 
+(** Compare two position sides: [Long < Short] — purely a tiebreaker so that
+    same-day same-symbol long and short entries produce a deterministic order.
+*)
+let _compare_sides (a : Trading_base.Types.position_side)
+    (b : Trading_base.Types.position_side) : int =
+  match (a, b) with
+  | Long, Long | Short, Short -> 0
+  | Long, Short -> -1
+  | Short, Long -> 1
+
+(** Secondary comparison for candidates with equal entry dates: first by symbol
+    then by side. *)
+let _compare_by_symbol_then_side (a : OT.scored_candidate)
+    (b : OT.scored_candidate) : int =
+  let by_symbol = String.compare a.entry.symbol b.entry.symbol in
+  if by_symbol <> 0 then by_symbol else _compare_sides a.entry.side b.entry.side
+
 (** Total order on scored candidates: [(entry_week, symbol, side)] ascending,
     side ordered Long < Short. The walk relies on chronological order; the
     secondary keys are deterministic tiebreakers for same-day cascade emissions
@@ -175,16 +192,7 @@ let compute_aggregate ~(config : config) (trades : trade_record list) :
 let _compare_scored_for_dedup (a : OT.scored_candidate)
     (b : OT.scored_candidate) : int =
   let by_date = Date.compare a.entry.entry_week b.entry.entry_week in
-  if by_date <> 0 then by_date
-  else
-    let by_symbol = String.compare a.entry.symbol b.entry.symbol in
-    if by_symbol <> 0 then by_symbol
-    else
-      (* Long < Short — purely a tiebreaker. *)
-      match (a.entry.side, b.entry.side) with
-      | Long, Long | Short, Short -> 0
-      | Long, Short -> -1
-      | Short, Long -> 1
+  if by_date <> 0 then by_date else _compare_by_symbol_then_side a b
 
 (** Render a [(symbol, side)] pair as a string key for the watermark table. The
     pipe character is reserved (never appears in tickers) so the encoding is

--- a/trading/trading/backtest/tuner/lib/bayesian_opt.ml
+++ b/trading/trading/backtest/tuner/lib/bayesian_opt.ml
@@ -32,14 +32,17 @@ type t = { config : config; observations : observation list (* newest first *) }
 
 (** {1 Validation} *)
 
+(** Raise [Invalid_argument] if bound [k] has [lo > hi]. *)
+let _validate_bound (k, (lo, hi)) =
+  if Float.( > ) lo hi then
+    invalid_arg
+      (sprintf "Bayesian_opt.create: bound for %s has min > max (%g > %g)" k lo
+         hi)
+
 let _validate_config config =
   if List.is_empty config.bounds then
     invalid_arg "Bayesian_opt.create: bounds must be non-empty";
-  List.iter config.bounds ~f:(fun (k, (lo, hi)) ->
-      if Float.( > ) lo hi then
-        invalid_arg
-          (sprintf "Bayesian_opt.create: bound for %s has min > max (%g > %g)" k
-             lo hi));
+  List.iter config.bounds ~f:_validate_bound;
   if config.initial_random < 0 then
     invalid_arg "Bayesian_opt.create: initial_random must be >= 0";
   if config.total_budget < 0 then
@@ -54,20 +57,16 @@ let create config =
 let observe t obs = { t with observations = obs :: t.observations }
 let all_observations t = List.rev t.observations
 
+(** Return whichever of [acc] and [obs] has the higher metric, or [Some obs]
+    when [acc] is [None]. Ties go to [acc] (first-observation-wins). *)
+let _pick_better acc obs =
+  match acc with
+  | None -> Some obs
+  | Some b -> if Float.( > ) obs.metric b.metric then Some obs else acc
+
 (** Iterate over observations in eval order (oldest first); the first
     observation reaching the max metric wins ties. *)
-let best t =
-  let rec loop best = function
-    | [] -> best
-    | obs :: rest ->
-        let new_best =
-          match best with
-          | None -> Some obs
-          | Some b -> if Float.( > ) obs.metric b.metric then Some obs else best
-        in
-        loop new_best rest
-  in
-  loop None (all_observations t)
+let best t = List.fold (all_observations t) ~init:None ~f:_pick_better
 
 (** {1 Input scaling: raw <-> [0, 1]} *)
 

--- a/trading/trading/simulation/lib/antifragility_computer.ml
+++ b/trading/trading/simulation/lib/antifragility_computer.ml
@@ -124,13 +124,14 @@ let _gamma_numerator s =
   -. (s.sx *. ((s.sx *. s.sx2y) -. (s.sxy *. s.sx2)))
   +. (s.sy *. ((s.sx *. s.sx3) -. (s.sx2 *. s.sx2)))
 
+let _gamma_coef_or_zero s =
+  let det = _det33 s in
+  if Float.(Float.abs det < _det_tolerance) then 0.0
+  else _gamma_numerator s /. det
+
 let _concavity_coef pairs =
   if List.length pairs < _min_paired_samples then 0.0
-  else
-    let s = _accumulate_sums pairs in
-    let det = _det33 s in
-    if Float.(Float.abs det < _det_tolerance) then 0.0
-    else _gamma_numerator s /. det
+  else _gamma_coef_or_zero (_accumulate_sums pairs)
 
 (* ---- Bucket asymmetry via benchmark quintiles ---- *)
 

--- a/trading/trading/simulation/lib/portfolio_state_computer.ml
+++ b/trading/trading/simulation/lib/portfolio_state_computer.ml
@@ -79,21 +79,23 @@ let _update ~state ~step =
     total_trades = state.total_trades + List.length step.trades;
   }
 
+(** Compute metrics from [state] when a last step exists. If no marked-to-market
+    step was recorded (degenerate: all steps were non-trading days with open
+    positions), falls back to [position_step] so [OpenPositionsValue] /
+    [UnrealizedPnl] both read as 0. *)
+let _metrics_for_last_steps ~state ~(config : Simulator_types.config)
+    position_step =
+  let marked_step =
+    Option.value state.last_marked_step ~default:position_step
+  in
+  _metrics_from_step ~position_step ~marked_step
+    ~total_trades:state.total_trades ~start_date:config.start_date
+    ~end_date:config.end_date
+
 let _finalize ~state ~(config : Simulator_types.config) =
   match state.last_step with
   | None -> Metric_types.empty
-  | Some position_step ->
-      (* If no step in the sim was marked-to-market (degenerate: e.g. all
-         steps were non-trading days with open positions), fall back to the
-         last step. OpenPositionsValue / UnrealizedPnl will then be 0 as
-         before — not great, but consistent with pre-fix behaviour for that
-         edge case. *)
-      let marked_step =
-        Option.value state.last_marked_step ~default:position_step
-      in
-      _metrics_from_step ~position_step ~marked_step
-        ~total_trades:state.total_trades ~start_date:config.start_date
-        ~end_date:config.end_date
+  | Some position_step -> _metrics_for_last_steps ~state ~config position_step
 
 let computer () : Simulator_types.any_metric_computer =
   Simulator_types.wrap_computer

--- a/trading/trading/simulation/lib/stale_hold.ml
+++ b/trading/trading/simulation/lib/stale_hold.ml
@@ -32,6 +32,30 @@ let _today_symbol_set today_bars =
   List.map today_bars ~f:(fun bar -> bar.Trading_engine.Types.symbol)
   |> String.Set.of_list
 
+(** Build a stale event for [pos] given its most recent prior bar [prev].
+    Returns [None] when the gap is below [stale_after_days]. *)
+let _build_stale_event ~date ~stale_after_days
+    (pos : Trading_portfolio.Types.portfolio_position)
+    (prev : Types.Daily_price.t) : event option =
+  let last_bar_date = prev.Types.Daily_price.date in
+  let gap = Date.diff date last_bar_date in
+  if gap < stale_after_days then None
+  else
+    let quantity =
+      Trading_portfolio.Calculations.position_quantity pos |> Float.abs
+    in
+    let avg_cost = Trading_portfolio.Calculations.avg_cost_of_position pos in
+    Some
+      {
+        symbol = pos.symbol;
+        date;
+        last_bar_date;
+        last_close = prev.Types.Daily_price.close_price;
+        days_since_last_bar = gap;
+        quantity;
+        cost_basis = avg_cost *. quantity;
+      }
+
 (** Build one stale event for a single held position, or [None] when the
     position has a bar today, no prior bar, or the prior bar is recent enough.
     Pure with respect to the adapter's cache. *)
@@ -43,24 +67,7 @@ let _event_for_position ~adapter ~date ~today_set ~stale_after_days
       Trading_simulation_data.Market_data_adapter.get_previous_bar adapter
         ~symbol:pos.symbol ~date
     in
-    let last_bar_date = prev.Types.Daily_price.date in
-    let gap = Date.diff date last_bar_date in
-    if gap < stale_after_days then None
-    else
-      let quantity =
-        Trading_portfolio.Calculations.position_quantity pos |> Float.abs
-      in
-      let avg_cost = Trading_portfolio.Calculations.avg_cost_of_position pos in
-      Some
-        {
-          symbol = pos.symbol;
-          date;
-          last_bar_date;
-          last_close = prev.Types.Daily_price.close_price;
-          days_since_last_bar = gap;
-          quantity;
-          cost_basis = avg_cost *. quantity;
-        }
+    _build_stale_event ~date ~stale_after_days pos prev
 
 let detect_stale ~adapter ~date ~portfolio ~today_bars ~config =
   if not config.enabled then []

--- a/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.ml
+++ b/trading/trading/weinstein/portfolio_risk/lib/force_liquidation.ml
@@ -202,6 +202,27 @@ let _event_of_input ~date ~reason (p : position_input) : event =
     reason;
   }
 
+(** Loss fraction threshold for the given position side. *)
+let _loss_threshold ~config (side : Trading_base.Types.position_side) =
+  match side with
+  | Trading_base.Types.Long -> config.max_long_unrealized_loss_fraction
+  | Trading_base.Types.Short -> config.max_short_unrealized_loss_fraction
+
+(** Check whether position [p] has breached its loss threshold; return
+    [Some event] if so, [None] otherwise. Assumes strictly positive
+    [cost_basis]. *)
+let _loss_event_if_breached ~config ~date ~cost_basis (p : position_input) :
+    event option =
+  let pnl =
+    unrealized_pnl ~side:p.side ~entry_price:p.entry_price
+      ~current_price:p.current_price ~quantity:p.quantity
+  in
+  let loss_fraction = -.pnl /. cost_basis in
+  let threshold = _loss_threshold ~config p.side in
+  if Float.( > ) loss_fraction threshold then
+    Some (_event_of_input ~date ~reason:Per_position p)
+  else None
+
 (* Per-position trigger: a position fires when its unrealized loss exceeds the
    side-specific threshold ([max_long_unrealized_loss_fraction] for longs,
    [max_short_unrealized_loss_fraction] for shorts) of cost basis. Cost basis
@@ -210,20 +231,7 @@ let _event_of_input ~date ~reason (p : position_input) : event =
 let _check_per_position ~config ~date (p : position_input) : event option =
   let cost_basis = p.entry_price *. p.quantity in
   if Float.( <= ) cost_basis 0.0 then None
-  else
-    let pnl =
-      unrealized_pnl ~side:p.side ~entry_price:p.entry_price
-        ~current_price:p.current_price ~quantity:p.quantity
-    in
-    let loss_fraction = -.pnl /. cost_basis in
-    let threshold =
-      match p.side with
-      | Trading_base.Types.Long -> config.max_long_unrealized_loss_fraction
-      | Trading_base.Types.Short -> config.max_short_unrealized_loss_fraction
-    in
-    if Float.( > ) loss_fraction threshold then
-      Some (_event_of_input ~date ~reason:Per_position p)
-    else None
+  else _loss_event_if_breached ~config ~date ~cost_basis p
 
 (* Portfolio-floor trigger fires when [portfolio_value < peak * fraction] AND
    the peak has actually been observed (peak > 0). The peak-zero case happens

--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
@@ -207,6 +207,20 @@ let resistance_callbacks_of_weekly_view
 (* Stock_analysis — bundle of high/volume + nested Stage/Rs/Volume/Resistance *)
 (* ------------------------------------------------------------------ *)
 
+(** Compute the split-adjustment factor at array position [idx] within aligned
+    [closes] / [raw_closes] arrays. Returns [None] when the raw close is
+    non-positive. Caller is responsible for bounds checking. *)
+let _factor_at_idx ~closes ~raw_closes idx : float option =
+  let raw = raw_closes.(idx) in
+  if Float.( <= ) raw 0.0 then None else Some (closes.(idx) /. raw)
+
+(** Look up the split factor at [week_offset] within aligned arrays, after the
+    caller has already confirmed [n = m]. Returns [None] when [week_offset] is
+    out of range or the raw close is non-positive. *)
+let _factor_at_offset ~closes ~raw_closes ~n ~week_offset : float option =
+  let idx = n - 1 - week_offset in
+  if idx < 0 || idx >= n then None else _factor_at_idx ~closes ~raw_closes idx
+
 (** Per-bar split-adjustment factor lookup over a weekly view's [closes]
     (adjusted) and [raw_closes] (unadjusted). Returns [None] when [raw_closes]
     is empty (e.g., the empty weekly_view) or when the raw close at this offset
@@ -221,11 +235,8 @@ let _split_factor_of_weekly_view (weekly : Snapshot_bar_views.weekly_view) :
   fun ~week_offset ->
     if n <> m then None
     else
-      let idx = n - 1 - week_offset in
-      if idx < 0 || idx >= n then None
-      else
-        let raw = weekly.raw_closes.(idx) in
-        if Float.( <= ) raw 0.0 then None else Some (weekly.closes.(idx) /. raw)
+      _factor_at_offset ~closes:weekly.closes ~raw_closes:weekly.raw_closes ~n
+        ~week_offset
 
 let stock_analysis_callbacks_of_weekly_views ?ma_cache ?stock_symbol
     ~(config : Stock_analysis.config) ~(stock : Snapshot_bar_views.weekly_view)


### PR DESCRIPTION
## Finding (from dispatch 2026-05-08)

Nine nesting violations across 7 files:
- \`stale_hold.ml:38 _event_for_position\`: avg 3.28 > 3.0
- \`bayesian_opt.ml:59 best\`: avg 3.09 > 3.0
- \`bayesian_opt.ml:35 _validate_config\`: max 6 > 5
- \`portfolio_state_computer.ml:82 _finalize\`: avg 3.08 > 3.0
- \`all_eligible.ml:127 _bucketize\`: max 6 > 5
- \`all_eligible.ml:175 _compare_scored_for_dedup\`: else 2 > 0
- \`panel_callbacks.ml:217 _split_factor_of_weekly_view\`: else 2 > 0
- \`force_liquidation.ml:210 _check_per_position\`: else 1 > 0
- \`antifragility_computer.ml:127 _concavity_coef\`: else 1 > 0

## What changed

Extracted private helpers to split nested else chains and reduce per-function avg/max nesting:

| File | Helper(s) extracted | Violation cleared |
|---|---|---|
| `stale_hold.ml` | `_build_stale_event` | avg 3.28 |
| `bayesian_opt.ml` | `_validate_bound`, `_pick_better` | max 6, avg 3.09 |
| `portfolio_state_computer.ml` | `_metrics_for_last_steps` | avg 3.08 |
| `all_eligible.ml` | `_count_in_range`, `_compare_sides`, `_compare_by_symbol_then_side` | max 6, else 2 |
| `panel_callbacks.ml` | `_factor_at_idx`, `_factor_at_offset` | else 2 |
| `force_liquidation.ml` | `_loss_threshold`, `_loss_event_if_breached` | else 1 |
| `antifragility_computer.ml` | `_gamma_coef_or_zero` | else 1 |

## Test plan

- [x] `dune build` passes
- [x] `dune runtest` passes (no new failures; pre-existing 19 nesting violations in other files unchanged)
- [x] Nesting linter shows 0 violations in all 7 target files
- [x] `dune build @fmt` passes for all modified files
- [x] No behavior change — pure extraction, identical logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)