### PR TITLE
cleanup(nesting): extract helpers in pipeline batch — 5 violations cleared

### DIFF
--- a/dev/status/cleanup.md
+++ b/dev/status/cleanup.md
@@ -15,6 +15,7 @@ Cleanup track has no public interface — it absorbs small mechanical fix-ups su
 
 ## Backlog
 
+- [x] nesting: pipeline.ml+daily_panels.ml+optimal_strategy_runner_helpers.ml+optimal_portfolio_filler.ml — extracted _build_rows, update_bench, _insert_rows, _neutral_ctx, _compare_by_r_multiple, _compare_by_score; all 5 dispatch violations cleared (branch cleanup/nesting-pipeline-batch-2, 2026-05-08)
 - [~] nesting: trading/trading/backtest/lib/runner.ml + optimal_strategy_runner_helpers.ml + optimal_summary.ml + reconciler_writer.ml — extract private helpers to reduce nesting in 5 flagged fns (source: dispatch 2026-05-08)
 - [~] nesting: trading/trading/weinstein/snapshot/lib/pick_diff.ml + trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_manifest.ml — extract private helpers to reduce avg/max nesting (source: dispatch 2026-05-08)
 - [~] nesting: trading/analysis/data/sources/wiki_sp500/lib/ticker_aliases.ml — file avg 2.63 (limit 2.5); deep record literals in all list (source: dispatch 2026-05-07)

--- a/trading/analysis/weinstein/snapshot_pipeline/lib/pipeline.ml
+++ b/trading/analysis/weinstein/snapshot_pipeline/lib/pipeline.ml
@@ -170,17 +170,20 @@ let _compute_weekly_arrays ~bars_arr ~weekly_prefix ~benchmark_bars =
         |> Array.of_list)
   in
   let bench_idx = ref (-1) in
+  (* Update [rs] and [macro] at index [i] from [arr]. Advances [bench_idx]
+     monotonically so the bench window stays bounded across the day loop. *)
+  let update_bench i arr =
+    let cutoff = bars_arr.(i).Types.Daily_price.date in
+    bench_idx := _advance_bench_idx arr ~from_idx:(Int.max 0 !bench_idx) ~cutoff;
+    let usable_idx = _usable_bench_idx arr ~bench_idx:!bench_idx ~cutoff in
+    rs.(i) <-
+      _rs_value ~weekly_prefix ~day_idx:i ~bench_weekly_arr:arr
+        ~bench_idx:usable_idx;
+    macro.(i) <- _macro_value ~bench_weekly_arr:arr ~bench_idx:usable_idx
+  in
   for i = 0 to n - 1 do
     stage.(i) <- _stage_value ~weekly_prefix ~day_idx:i;
-    Option.iter bench_weekly_arr ~f:(fun arr ->
-        let cutoff = bars_arr.(i).Types.Daily_price.date in
-        bench_idx :=
-          _advance_bench_idx arr ~from_idx:(Int.max 0 !bench_idx) ~cutoff;
-        let usable_idx = _usable_bench_idx arr ~bench_idx:!bench_idx ~cutoff in
-        rs.(i) <-
-          _rs_value ~weekly_prefix ~day_idx:i ~bench_weekly_arr:arr
-            ~bench_idx:usable_idx;
-        macro.(i) <- _macro_value ~bench_weekly_arr:arr ~bench_idx:usable_idx)
+    Option.iter bench_weekly_arr ~f:(update_bench i)
   done;
   (stage, rs, macro)
 
@@ -204,18 +207,23 @@ let _compute_precomputed ~bars_arr ~benchmark_bars =
   in
   { ema; sma; atr; rsi; stage; rs; macro }
 
+(* Build snapshot rows for a non-empty [bars_arr]. Extracted from
+   [build_for_symbol] to eliminate the nested-else. *)
+let _build_rows ~symbol ~bars_arr ~schema ~benchmark_bars =
+  let n = Array.length bars_arr in
+  if n = 0 then Ok []
+  else
+    let precomputed = _compute_precomputed ~bars_arr ~benchmark_bars in
+    let rows =
+      List.init n ~f:(fun i ->
+          _row_for_day ~symbol ~schema ~precomputed ~bars_arr ~i)
+    in
+    Result.all rows
+
 let build_for_symbol ~symbol ~bars ~schema ?benchmark_bars () =
   if String.is_empty symbol then
     Status.error_invalid_argument
       "Snapshot_pipeline.build_for_symbol: empty symbol"
   else
     let bars_arr = Array.of_list bars in
-    let n = Array.length bars_arr in
-    if n = 0 then Ok []
-    else
-      let precomputed = _compute_precomputed ~bars_arr ~benchmark_bars in
-      let rows =
-        List.init n ~f:(fun i ->
-            _row_for_day ~symbol ~schema ~precomputed ~bars_arr ~i)
-      in
-      Result.all rows
+    _build_rows ~symbol ~bars_arr ~schema ~benchmark_bars

--- a/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.ml
@@ -112,16 +112,19 @@ let _insert_into_cache t ~symbol ~rows =
 let _sort_rows_by_date (rows : Snapshot.t array) =
   Array.sort rows ~compare:(fun a b -> Date.compare a.date b.date)
 
+(* Convert a decoded row list into a sorted array and insert into cache. *)
+let _insert_rows t ~symbol rows_list =
+  let rows = Array.of_list rows_list in
+  _sort_rows_by_date rows;
+  _insert_into_cache t ~symbol ~rows
+
 let _load_and_insert t ~symbol =
   match Snapshot_manifest.find t.manifest ~symbol with
   | None ->
       Status.error_not_found
         (Printf.sprintf "Daily_panels: symbol %s not in manifest" symbol)
   | Some metadata ->
-      Result.map (_load_symbol_file t metadata) ~f:(fun rows_list ->
-          let rows = Array.of_list rows_list in
-          _sort_rows_by_date rows;
-          _insert_into_cache t ~symbol ~rows)
+      Result.map (_load_symbol_file t metadata) ~f:(_insert_rows t ~symbol)
 
 (* Cache hit: promote to MRU and return the resident entry. *)
 let _hit_path t (elt : cache_entry Doubly_linked.Elt.t) =

--- a/trading/trading/backtest/optimal/lib/optimal_portfolio_filler.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_portfolio_filler.ml
@@ -58,6 +58,21 @@ let _distinct_entry_fridays (scored : Optimal_types.scored_candidate list) :
       sc.entry.entry_week)
   |> List.dedup_and_sort ~compare:Date.compare
 
+(** Sort by realised [r_multiple] descending — hindsight ceiling for
+    [Constrained] / [Relaxed_macro] variants. *)
+let _compare_by_r_multiple (a : Optimal_types.scored_candidate)
+    (b : Optimal_types.scored_candidate) : int =
+  Float.compare b.r_multiple a.r_multiple
+
+(** Sort by pre-trade [cascade_score] descending; ties broken by [symbol]
+    ascending so the order is deterministic across runs. Used by [Score_picked].
+*)
+let _compare_by_score (a : Optimal_types.scored_candidate)
+    (b : Optimal_types.scored_candidate) : int =
+  let by_score = Int.compare b.entry.cascade_score a.entry.cascade_score in
+  if by_score <> 0 then by_score
+  else String.compare a.entry.symbol b.entry.symbol
+
 (** Comparator for sorting same-Friday candidates under [variant].
 
     - [Constrained] / [Relaxed_macro] sort by realised [r_multiple] descending.
@@ -69,19 +84,8 @@ let _distinct_entry_fridays (scored : Optimal_types.scored_candidate list) :
 let _entry_comparator ~(variant : Optimal_types.variant_label) :
     Optimal_types.scored_candidate -> Optimal_types.scored_candidate -> int =
   match variant with
-  | Constrained | Relaxed_macro ->
-      fun (a : Optimal_types.scored_candidate)
-        (b : Optimal_types.scored_candidate)
-      -> Float.compare b.r_multiple a.r_multiple
-  | Score_picked ->
-      fun (a : Optimal_types.scored_candidate)
-        (b : Optimal_types.scored_candidate)
-      ->
-        let by_score =
-          Int.compare b.entry.cascade_score a.entry.cascade_score
-        in
-        if by_score <> 0 then by_score
-        else String.compare a.entry.symbol b.entry.symbol
+  | Constrained | Relaxed_macro -> _compare_by_r_multiple
+  | Score_picked -> _compare_by_score
 
 (** Candidates entering on [friday], sorted by the variant-specific key:
     [r_multiple] DESC for [Constrained] / [Relaxed_macro], [cascade_score] DESC

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner_helpers.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner_helpers.ml
@@ -69,6 +69,16 @@ let analyze_symbol_on_friday ~snapshot_callbacks ~friday ~stock_config
         (Stock_analysis.analyze ~config:stock_config ~ticker:symbol ~bars:weekly
            ~benchmark_bars:benchmark ~prior_stage:None ~as_of_date:friday)
 
+(** Pass-through sector context used by the counterfactual. [Neutral] rating and
+    [Stage2] stage because sector caps are handled separately via the filler's
+    [max_sector_concentration]. *)
+let _neutral_ctx (sector_name : string) : Screener.sector_context =
+  {
+    sector_name;
+    rating = Screener.Neutral;
+    stage = Stage2 { weeks_advancing = 4; late = false };
+  }
+
 (** Build a [sector_map] (symbol -> [Screener.sector_context]) from a flat
     [sectors : (symbol -> sector_name)] table. The screener's sector-context
     expects a [rating] and [stage] per sector; we use [Neutral] / [Stage2] as
@@ -78,14 +88,7 @@ let build_sector_context_map (sectors : (string, string) Hashtbl.t) :
     (string, Screener.sector_context) Hashtbl.t =
   let out = Hashtbl.create (module String) in
   Hashtbl.iteri sectors ~f:(fun ~key ~data ->
-      let ctx : Screener.sector_context =
-        {
-          sector_name = data;
-          rating = Screener.Neutral;
-          stage = Stage2 { weeks_advancing = 4; late = false };
-        }
-      in
-      Hashtbl.set out ~key ~data:ctx);
+      Hashtbl.set out ~key ~data:(_neutral_ctx data));
   out
 
 (* ---------------------------------------------------------------- *)
@@ -110,10 +113,11 @@ let _outlook_at ~snapshot_callbacks ~stage_config ~bar_lookback ~symbol ~friday
 
 (** Collect the chronological outlook list for one [symbol] across all
     [fridays]. Factored out of [build_forward_table] to reduce nesting depth. *)
-let _outlooks_for_symbol ~snapshot_callbacks ~fridays ~stage_config ~bar_lookback
-    ~symbol =
+let _outlooks_for_symbol ~snapshot_callbacks ~fridays ~stage_config
+    ~bar_lookback ~symbol =
   List.filter_map fridays ~f:(fun friday ->
-      _outlook_at ~snapshot_callbacks ~stage_config ~bar_lookback ~symbol ~friday)
+      _outlook_at ~snapshot_callbacks ~stage_config ~bar_lookback ~symbol
+        ~friday)
 
 (** Build the per-symbol forward-outlook table (PR-1). Iterates [fridays] once
     per symbol and memoizes the full chronological outlook list. Sized to


### PR DESCRIPTION
## Finding (source: dispatch 2026-05-08)

Nesting linter flagged 5 functions across 4 files (fresh-workspace baseline of 24 violations before this PR):

```
2.64  6  1  max+else  trading/analysis/weinstein/snapshot_pipeline/lib/pipeline.ml:207  build_for_symbol
2.61  6  0  max       trading/analysis/weinstein/snapshot_pipeline/lib/pipeline.ml:162  _compute_weekly_arrays
3.11  5  0  avg       trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.ml:115  _load_and_insert
3.08  4  0  avg       trading/trading/backtest/optimal/lib/optimal_strategy_runner_helpers.ml:77  build_sector_context_map
3.07  5  0  avg       trading/trading/backtest/optimal/lib/optimal_portfolio_filler.ml:69  _entry_comparator
```

## Fix

Extracted private helpers to break nested-else and reduce avg/max depth:

- `pipeline.ml`: extracted `_build_rows` (eliminates nested-else in `build_for_symbol`) and `update_bench` local helper (reduces max nesting in `_compute_weekly_arrays` from 6 to under 5)
- `daily_panels.ml`: extracted `_insert_rows` from `_load_and_insert` callback
- `optimal_strategy_runner_helpers.ml`: extracted `_neutral_ctx` from `build_sector_context_map` iteri body
- `optimal_portfolio_filler.ml`: extracted `_compare_by_r_multiple` and `_compare_by_score` from `_entry_comparator` match arms

## Result

All 5 dispatch violations cleared. Nesting linter count: 24 → 14 (on fresh workspace).

`dune build && dune runtest` passes for all 4 affected modules. `dune build @fmt` passes.

## Test plan

- [x] `dune build analysis/weinstein/snapshot_pipeline/ analysis/weinstein/snapshot_runtime/ trading/backtest/optimal/` — passes
- [x] `dune runtest analysis/weinstein/snapshot_pipeline/ analysis/weinstein/snapshot_runtime/ trading/backtest/optimal/` — all tests pass
- [x] `dune build @fmt` — passes
- [x] Nesting linter shows none of the 5 original violations
- [x] Diff 66 insertions + 46 deletions = 112 LOC (under 200 limit)
- [x] No behavior change — pure extraction of identical logic into named helpers
- [x] No new public symbols in any `.mli`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)