### PR TITLE
fix(fmt): batch docstring {[ ]} indent skew — 26 files

### DIFF
--- a/trading/analysis/data/sources/wiki_sp500/lib/membership_replay.ml
+++ b/trading/analysis/data/sources/wiki_sp500/lib/membership_replay.ml
@@ -46,7 +46,8 @@ let _missing_headers_error headers =
   Status.error_invalid_argument
     (Printf.sprintf
        "current-constituents CSV missing required header(s); need \
-        Symbol/Security/Sector, got: %s" got)
+        Symbol/Security/Sector, got: %s"
+       got)
 
 let _resolve_column_indices headers =
   let symbol_idx = _find_column_index headers _symbol_header in
@@ -78,8 +79,7 @@ let _parse_data_rows ~header data_rows =
     _resolve_column_indices headers
   in
   List.mapi data_rows ~f:(fun i row ->
-      _parse_data_row ~symbol_idx ~security_idx ~sector_idx ~row_num:(i + 2)
-        row)
+      _parse_data_row ~symbol_idx ~security_idx ~sector_idx ~row_num:(i + 2) row)
   |> Result.all
 
 let parse_current_csv csv_text =
@@ -198,8 +198,8 @@ let _added_timeline_event ~current_sectors ~date (a : Changes_parser.ticker_id)
 let _removed_timeline_event ~date (r : Changes_parser.ticker_id) =
   { date; action = `Removed; symbol = r.symbol; sector = _unknown_sector }
 
-let _change_event_to_timeline ~current_sectors
-    (e : Changes_parser.change_event) =
+let _change_event_to_timeline ~current_sectors (e : Changes_parser.change_event)
+    =
   let date = e.effective_date in
   let added_evt =
     Option.map e.added ~f:(_added_timeline_event ~current_sectors ~date)

--- a/trading/analysis/scripts/build_snapshots/build_snapshots.ml
+++ b/trading/analysis/scripts/build_snapshots/build_snapshots.ml
@@ -83,7 +83,9 @@ let _should_skip ~existing ~symbol ~csv_mtime ~schema =
   | None -> false
   | Some (m : Snapshot_manifest.t) ->
       String.equal m.schema_hash schema.Snapshot_schema.schema_hash
-      && Option.value_map (Snapshot_manifest.find m ~symbol) ~default:false
+      && Option.value_map
+           (Snapshot_manifest.find m ~symbol)
+           ~default:false
            ~f:(_entry_is_current ~csv_mtime)
 
 let _file_metadata ~symbol ~path ~csv_mtime =
@@ -283,9 +285,10 @@ let main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol ~incremental
   let started_at = Core_unix.time () in
   let t0 = Time_ns.now () in
   let entries =
-    List.foldi symbols ~init:[] ~f:
-      (_fold_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
-         ~manifest_path ~progress_every ~symbols_total ~started_at)
+    List.foldi symbols ~init:[]
+      ~f:
+        (_fold_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
+           ~manifest_path ~progress_every ~symbols_total ~started_at)
   in
   let elapsed = Time_ns.diff (Time_ns.now ()) t0 in
   _write_final_manifest ~manifest_path ~schema ~entries ~elapsed;

--- a/trading/analysis/weinstein/stage/lib/stage.mli
+++ b/trading/analysis/weinstein/stage/lib/stage.mli
@@ -175,8 +175,8 @@ val classify_with_callbacks :
     bottleneck, add:
 
     {[
-      val classify_step :
-        config:config -> prev_result:result -> new_bar:Daily_price.t -> result
+    val classify_step :
+      config:config -> prev_result:result -> new_bar:Daily_price.t -> result
     ]}
 
     [classify_step] would maintain an incremental MA state (e.g. a sliding
@@ -202,11 +202,11 @@ val classify_with_callbacks :
     [analysis/technical/indicators/] with a [slope] function:
 
     {[
-      val slope :
-        lookback:int ->
-        threshold:float ->
-        (Date.t * float) list ->
-        ma_direction * float
+    val slope :
+      lookback:int ->
+      threshold:float ->
+      (Date.t * float) list ->
+      ma_direction * float
     ]}
 
     This would eliminate the per-module slope implementations and give a single

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
@@ -254,8 +254,7 @@ let _make_get_split_factor_from_bars (bars : Daily_price.t array) :
   let n = Array.length bars in
   fun ~week_offset ->
     let idx = n - 1 - week_offset in
-    if idx < 0 || idx >= n then None
-    else _split_factor_of_bar bars.(idx)
+    if idx < 0 || idx >= n then None else _split_factor_of_bar bars.(idx)
 
 let callbacks_from_bars ~(config : config) ~(bars : Daily_price.t list)
     ~(benchmark_bars : Daily_price.t list) : callbacks =

--- a/trading/base/matchers/lib/matchers.mli
+++ b/trading/base/matchers/lib/matchers.mli
@@ -33,7 +33,7 @@ val __ : 'a matcher
 
     Example:
     {[
-      assert_that p (match_point ~x:(float_equal 1.0) ~y:__ ())
+    assert_that p (match_point ~x:(float_equal 1.0) ~y:__ ())
     ]} *)
 
 val assert_that : 'a -> 'a matcher -> unit
@@ -42,10 +42,10 @@ val assert_that : 'a -> 'a matcher -> unit
 
     Example:
     {[
-      assert_that actual_price (float_equal 150.25)
+    assert_that actual_price (float_equal 150.25)
     ]}
     {[
-      assert_that result (is_ok_and_holds (equal_to expected_value))
+    assert_that result (is_ok_and_holds (equal_to expected_value))
     ]} *)
 
 (** {1 Basic Matchers} *)
@@ -56,10 +56,10 @@ val equal_to : ?cmp:('a -> 'a -> bool) -> ?msg:string -> 'a -> 'a -> unit
 
     Example:
     {[
-      assert_that result (is_ok_and_holds (equal_to expected))
+    assert_that result (is_ok_and_holds (equal_to expected))
     ]}
     {[
-      field (fun r -> r.order_id) (equal_to "order123")
+    field (fun r -> r.order_id) (equal_to "order123")
     ]} *)
 
 val field : ('a -> 'b) -> ('b -> unit) -> 'a -> unit
@@ -69,17 +69,17 @@ val field : ('a -> 'b) -> ('b -> unit) -> 'a -> unit
 
     Example:
     {[
-      assert_that order (field (fun o -> o.status) (equal_to Filled))
+    assert_that order (field (fun o -> o.status) (equal_to Filled))
     ]}
     {[
-      elements_are reports
-        [
-          all_of
-            [
-              field (fun r -> r.order_id) (equal_to order.id);
-              field (fun r -> r.status) (equal_to Filled);
-            ];
-        ]
+    elements_are reports
+      [
+        all_of
+          [
+            field (fun r -> r.order_id) (equal_to order.id);
+            field (fun r -> r.status) (equal_to Filled);
+          ];
+      ]
     ]} *)
 
 val not_ : ?msg:string -> 'a matcher -> 'a matcher
@@ -88,11 +88,11 @@ val not_ : ?msg:string -> 'a matcher -> 'a matcher
 
     Example:
     {[
-      assert_that actual (not_ (equal_to unexpected))
+    assert_that actual (not_ (equal_to unexpected))
     ]}
     {[
-      assert_that stage
-        (not_ (equal_to (Stage2 { weeks_advancing = 3; late = false })))
+    assert_that stage
+      (not_ (equal_to (Stage2 { weeks_advancing = 3; late = false })))
     ]} *)
 
 val all_of : ('a -> unit) list -> 'a -> unit
@@ -101,22 +101,22 @@ val all_of : ('a -> unit) list -> 'a -> unit
 
     Example:
     {[
-      assert_that order
-        (all_of
-           [
-             (fun o -> assert_equal "order1" o.order_id);
-             (fun o -> assert_equal Filled o.status);
-           ])
+    assert_that order
+      (all_of
+         [
+           (fun o -> assert_equal "order1" o.order_id);
+           (fun o -> assert_equal Filled o.status);
+         ])
     ]}
     {[
-      elements_are reports
-        [
-          all_of
-            [
-              field (fun r -> r.order_id) (equal_to order.id);
-              field (fun r -> r.status) (equal_to Filled);
-            ];
-        ]
+    elements_are reports
+      [
+        all_of
+          [
+            field (fun r -> r.order_id) (equal_to order.id);
+            field (fun r -> r.status) (equal_to Filled);
+          ];
+      ]
     ]} *)
 
 (** {1 Result Matchers}
@@ -129,7 +129,7 @@ val is_ok : 'a Status.status_or matcher
 
     Example:
     {[
-      assert_that (validate_input valid_data) is_ok
+    assert_that (validate_input valid_data) is_ok
     ]} *)
 
 val is_ok_and_holds : 'a matcher -> 'a Status.status_or matcher
@@ -138,10 +138,10 @@ val is_ok_and_holds : 'a matcher -> 'a Status.status_or matcher
 
     Example:
     {[
-      assert_that result (is_ok_and_holds (equal_to expected_value))
+    assert_that result (is_ok_and_holds (equal_to expected_value))
     ]}
     {[
-      assert_that result (is_ok_and_holds (float_equal 150.25))
+    assert_that result (is_ok_and_holds (float_equal 150.25))
     ]} *)
 
 val is_error : 'a Status.status_or matcher
@@ -151,7 +151,7 @@ val is_error : 'a Status.status_or matcher
 
     Example:
     {[
-      assert_that (validate_input invalid_data) is_error
+    assert_that (validate_input invalid_data) is_error
     ]} *)
 
 val is_error_with : ?msg:string -> Status.code -> 'a Status.status_or matcher
@@ -161,14 +161,13 @@ val is_error_with : ?msg:string -> Status.code -> 'a Status.status_or matcher
 
     Example:
     {[
-      assert_that (get_order manager "nonexistent") (is_error_with NotFound)
+    assert_that (get_order manager "nonexistent") (is_error_with NotFound)
     ]}
     {[
-      assert_that (create_order invalid_params) (is_error_with Invalid_argument)
+    assert_that (create_order invalid_params) (is_error_with Invalid_argument)
     ]}
     {[
-      assert_that result
-        (is_error_with Invalid_argument ~msg:"must be positive")
+    assert_that result (is_error_with Invalid_argument ~msg:"must be positive")
     ]} *)
 
 (** {1 Option Matchers}
@@ -181,12 +180,12 @@ val is_some_and : 'a matcher -> 'a option matcher
 
     Example:
     {[
-      assert_that
-        (get_position portfolio "AAPL")
-        (is_some_and (field position_quantity (float_equal 100.0)))
+    assert_that
+      (get_position portfolio "AAPL")
+      (is_some_and (field position_quantity (float_equal 100.0)))
     ]}
     {[
-      assert_that (Map.find cache key) (is_some_and (equal_to expected))
+    assert_that (Map.find cache key) (is_some_and (equal_to expected))
     ]} *)
 
 val is_none : 'a option matcher
@@ -194,10 +193,10 @@ val is_none : 'a option matcher
 
     Example:
     {[
-      assert_that (get_position portfolio "AAPL") is_none
+    assert_that (get_position portfolio "AAPL") is_none
     ]}
     {[
-      assert_that (Map.find cache "nonexistent") is_none
+    assert_that (Map.find cache "nonexistent") is_none
     ]} *)
 
 val matching : ?msg:string -> ('a -> 'b option) -> 'b matcher -> 'a matcher
@@ -207,16 +206,16 @@ val matching : ?msg:string -> ('a -> 'b option) -> 'b matcher -> 'a matcher
 
     Example:
     {[
-      assert_that result.stage
-        (matching ~msg:"Expected Stage2"
-           (function Stage2 x -> Some x | _ -> None)
-           (field (fun s -> s.weeks_advancing) (gt (module Int_ord) 0)))
+    assert_that result.stage
+      (matching ~msg:"Expected Stage2"
+         (function Stage2 x -> Some x | _ -> None)
+         (field (fun s -> s.weeks_advancing) (gt (module Int_ord) 0)))
     ]}
     {[
-      assert_that pos_state
-        (matching
-           (function Entering e -> Some e | _ -> None)
-           (field (fun e -> e.filled_quantity) (float_equal 50.0)))
+    assert_that pos_state
+      (matching
+         (function Entering e -> Some e | _ -> None)
+         (field (fun e -> e.filled_quantity) (float_equal 50.0)))
     ]} *)
 
 val pair : 'a matcher -> 'b matcher -> ('a * 'b) matcher
@@ -225,7 +224,7 @@ val pair : 'a matcher -> 'b matcher -> ('a * 'b) matcher
 
     Example:
     {[
-      assert_that result.transition (is_some_and (pair is_stage1 is_stage2))
+    assert_that result.transition (is_some_and (pair is_stage1 is_stage2))
     ]} *)
 
 (** {1 Numeric Matchers} *)
@@ -236,10 +235,10 @@ val float_equal : ?epsilon:float -> float -> float matcher
 
     Example:
     {[
-      assert_that actual_price (float_equal 150.25)
+    assert_that actual_price (float_equal 150.25)
     ]}
     {[
-      assert_that computed_value (float_equal ~epsilon:0.01 expected)
+    assert_that computed_value (float_equal ~epsilon:0.01 expected)
     ]} *)
 
 val gt : (module Ord with type t = 'a) -> 'a -> 'a matcher
@@ -249,10 +248,10 @@ val gt : (module Ord with type t = 'a) -> 'a -> 'a matcher
 
     Example:
     {[
-      assert_that result.count (gt (module Int_ord) 0)
+    assert_that result.count (gt (module Int_ord) 0)
     ]}
     {[
-      assert_that stats.r_squared (gt (module Float_ord) 0.99)
+    assert_that stats.r_squared (gt (module Float_ord) 0.99)
     ]} *)
 
 val ge : (module Ord with type t = 'a) -> 'a -> 'a matcher
@@ -260,7 +259,7 @@ val ge : (module Ord with type t = 'a) -> 'a -> 'a matcher
 
     Example:
     {[
-      assert_that trade.price (ge (module Float_ord) min_price)
+    assert_that trade.price (ge (module Float_ord) min_price)
     ]} *)
 
 val lt : (module Ord with type t = 'a) -> 'a -> 'a matcher
@@ -268,7 +267,7 @@ val lt : (module Ord with type t = 'a) -> 'a -> 'a matcher
 
     Example:
     {[
-      assert_that sharpe_with_rf (lt (module Float_ord) sharpe_no_rf)
+    assert_that sharpe_with_rf (lt (module Float_ord) sharpe_no_rf)
     ]} *)
 
 val le : (module Ord with type t = 'a) -> 'a -> 'a matcher
@@ -276,7 +275,7 @@ val le : (module Ord with type t = 'a) -> 'a -> 'a matcher
 
     Example:
     {[
-      assert_that trade.price (le (module Float_ord) max_price)
+    assert_that trade.price (le (module Float_ord) max_price)
     ]} *)
 
 val is_between :
@@ -286,8 +285,8 @@ val is_between :
 
     Example:
     {[
-      assert_that result.confidence
-        (is_between (module Float_ord) ~low:0.0 ~high:1.0)
+    assert_that result.confidence
+      (is_between (module Float_ord) ~low:0.0 ~high:1.0)
     ]} *)
 
 (** {1 List Matchers} *)
@@ -298,11 +297,11 @@ val each : 'a matcher -> 'a list matcher
 
     Example:
     {[
-      assert_that orders (each (field (fun o -> o.status) (equal_to Filled)))
+    assert_that orders (each (field (fun o -> o.status) (equal_to Filled)))
     ]}
     {[
-      assert_that reports
-        (each (all_of [ field (fun r -> r.status) (equal_to Filled) ]))
+    assert_that reports
+      (each (all_of [ field (fun r -> r.status) (equal_to Filled) ]))
     ]} *)
 
 val one : 'a matcher -> 'a list matcher
@@ -311,10 +310,10 @@ val one : 'a matcher -> 'a list matcher
 
     Example:
     {[
-      assert_that pending_orders (one (field (fun o -> o.id) (equal_to id)))
+    assert_that pending_orders (one (field (fun o -> o.id) (equal_to id)))
     ]}
     {[
-      assert_that results (one (equal_to expected))
+    assert_that results (one (equal_to expected))
     ]} *)
 
 val elements_are : 'a matcher list -> 'a list matcher
@@ -325,29 +324,29 @@ val elements_are : 'a matcher list -> 'a list matcher
 
     Example:
     {[
-      assert_that reports
-        (elements_are
-           [
-             (fun r -> assert_equal "order1" r.order_id);
-             (fun r -> assert_equal "order2" r.order_id);
-             (fun r -> assert_equal "order3" r.order_id);
-           ])
+    assert_that reports
+      (elements_are
+         [
+           (fun r -> assert_equal "order1" r.order_id);
+           (fun r -> assert_equal "order2" r.order_id);
+           (fun r -> assert_equal "order3" r.order_id);
+         ])
     ]}
     {[
-      assert_that orders
-        (elements_are
-           [
-             all_of
-               [
-                 field (fun o -> o.id) (equal_to "order1");
-                 field (fun o -> o.status) (equal_to Pending);
-               ];
-             all_of
-               [
-                 field (fun o -> o.id) (equal_to "order2");
-                 field (fun o -> o.status) (equal_to Filled);
-               ];
-           ])
+    assert_that orders
+      (elements_are
+         [
+           all_of
+             [
+               field (fun o -> o.id) (equal_to "order1");
+               field (fun o -> o.status) (equal_to Pending);
+             ];
+           all_of
+             [
+               field (fun o -> o.id) (equal_to "order2");
+               field (fun o -> o.status) (equal_to Filled);
+             ];
+         ])
     ]} *)
 
 val unordered_elements_are : 'a matcher list -> 'a list matcher
@@ -361,21 +360,21 @@ val unordered_elements_are : 'a matcher list -> 'a list matcher
 
     Example:
     {[
-      assert_that reports
-        (unordered_elements_are
-           [
-             field (fun r -> r.order_id) (equal_to "order1");
-             field (fun r -> r.order_id) (equal_to "order2");
-             field (fun r -> r.order_id) (equal_to "order3");
-           ])
+    assert_that reports
+      (unordered_elements_are
+         [
+           field (fun r -> r.order_id) (equal_to "order1");
+           field (fun r -> r.order_id) (equal_to "order2");
+           field (fun r -> r.order_id) (equal_to "order3");
+         ])
     ]}
     {[
-      assert_that positions
-        (unordered_elements_are
-           [
-             field (fun p -> p.symbol) (equal_to "AAPL");
-             field (fun p -> p.symbol) (equal_to "MSFT");
-           ])
+    assert_that positions
+      (unordered_elements_are
+         [
+           field (fun p -> p.symbol) (equal_to "AAPL");
+           field (fun p -> p.symbol) (equal_to "MSFT");
+         ])
     ]} *)
 
 val size_is : int -> 'a list matcher
@@ -383,7 +382,7 @@ val size_is : int -> 'a list matcher
 
     Example:
     {[
-      assert_that pending_orders (size_is 3)
+    assert_that pending_orders (size_is 3)
     ]} *)
 
 val is_empty : 'a list matcher
@@ -391,7 +390,7 @@ val is_empty : 'a list matcher
 
     Example:
     {[
-      assert_that pending_orders is_empty
+    assert_that pending_orders is_empty
     ]} *)
 
 (** {1 Map Matchers} *)
@@ -402,7 +401,7 @@ val contains_entry : 'k -> 'v matcher -> ('k, 'v, 'cmp) Core.Map.t matcher
 
     Example:
     {[
-      assert_that metrics (contains_entry TotalPnl (float_equal 1234.0))
+    assert_that metrics (contains_entry TotalPnl (float_equal 1234.0))
     ]} *)
 
 val map_includes : ('k * 'v matcher) list -> ('k, 'v, 'cmp) Core.Map.t matcher
@@ -411,7 +410,7 @@ val map_includes : ('k * 'v matcher) list -> ('k, 'v, 'cmp) Core.Map.t matcher
 
     Example:
     {[
-      assert_that metrics
-        (map_includes
-           [ (TotalPnl, float_equal 1234.0); (WinRate, float_equal 60.0) ])
+    assert_that metrics
+      (map_includes
+         [ (TotalPnl, float_equal 1234.0); (WinRate, float_equal 60.0) ])
     ]} *)

--- a/trading/devtools/ppx_test_matcher/lib/ppx_test_matcher.ml
+++ b/trading/devtools/ppx_test_matcher/lib/ppx_test_matcher.ml
@@ -5,15 +5,15 @@ open Ppxlib
 
     Given a record type:
     {[
-      type t = { x : float; y : int } [@@deriving test_matcher]
+    type t = { x : float; y : int } [@@deriving test_matcher]
     ]}
 
     It generates a function [match_t] with one required labeled parameter per
     field:
     {[
-      let match_t ~x ~y (r : t) =
-        x r.x;
-        y r.y
+    let match_t ~x ~y (r : t) =
+      x r.x;
+      y r.y
     ]}
 
     Every field must be explicitly matched or ignored with [__] (the wildcard

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -147,10 +147,10 @@ val run_backtest :
     order. Each must be a record sexp with fields matching
     [Weinstein_strategy.config]. Example:
     {[
-      [
-        Sexp.of_string "((initial_stop_buffer 1.08))";
-        Sexp.of_string "((stage_config ((ma_period 40))))";
-      ]
+    [
+      Sexp.of_string "((initial_stop_buffer 1.08))";
+      Sexp.of_string "((stage_config ((ma_period 40))))";
+    ]
     ]}
 
     [sector_map_override], when passed, replaces the sector-map normally loaded

--- a/trading/trading/backtest/lib/runner_metrics.ml
+++ b/trading/trading/backtest/lib/runner_metrics.ml
@@ -10,8 +10,8 @@ let initial_cash = 1_000_000.0
 let commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 }
 
 (** Sentinel year used when constructing a dummy [config] for metric re-runs
-    where the date range is irrelevant (e.g. [recompute_calmar_ratio]).
-    Year 2000 is safely before any real run date. *)
+    where the date range is irrelevant (e.g. [recompute_calmar_ratio]). Year
+    2000 is safely before any real run date. *)
 let _empty_date_sentinel_year = 2000
 
 (** Re-run the step-based metric computers ([SharpeRatio], [MaxDrawdown],
@@ -52,7 +52,8 @@ let recompute_in_window_step_metrics ~steps_in_range ~start_date ~end_date =
 let recompute_calmar_ratio ~base_metrics =
   let dummy_config : Trading_simulation_types.Simulator_types.config =
     {
-      start_date = Date.create_exn ~y:_empty_date_sentinel_year ~m:Month.Jan ~d:1;
+      start_date =
+        Date.create_exn ~y:_empty_date_sentinel_year ~m:Month.Jan ~d:1;
       end_date = Date.create_exn ~y:_empty_date_sentinel_year ~m:Month.Jan ~d:1;
       initial_cash;
       commission;

--- a/trading/trading/backtest/lib/runner_metrics.mli
+++ b/trading/trading/backtest/lib/runner_metrics.mli
@@ -5,10 +5,10 @@ val recompute_in_window_step_metrics :
   start_date:Date.t ->
   end_date:Date.t ->
   Trading_simulation_types.Metric_types.metric_set
-(** Re-run [SharpeRatio], [MaxDrawdown], and [CAGR] computers on the
-    in-window step list only. The simulator runs from [warmup_start] so its
-    published step-based metrics include the warmup window; this call restores
-    them to the measurement window. *)
+(** Re-run [SharpeRatio], [MaxDrawdown], and [CAGR] computers on the in-window
+    step list only. The simulator runs from [warmup_start] so its published
+    step-based metrics include the warmup window; this call restores them to the
+    measurement window. *)
 
 val recompute_calmar_ratio :
   base_metrics:Trading_simulation_types.Metric_types.metric_set ->
@@ -26,5 +26,6 @@ val align_summary_metrics :
   Trading_simulation_types.Metric_types.metric_set
 (** Three-stage overlay: replace round-trip metrics from [round_trips], replace
     step-based metrics from [steps_in_range], then recompute [CalmarRatio].
-    Restores the invariant that published metrics describe the measurement window
-    [start_date..end_date] only, not the warmup window the simulator ran from. *)
+    Restores the invariant that published metrics describe the measurement
+    window [start_date..end_date] only, not the warmup window the simulator ran
+    from. *)

--- a/trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml
@@ -130,13 +130,12 @@ let _load_trades ~output_dir : Trading_simulation.Metrics.trade_metrics list =
     | [] -> []
     | _header :: rows -> List.filter_map rows ~f:_parse_trade_row
 
-(** Convert one [alternative_candidate] to a [(symbol, reason)] pair.
-    Renders the [skip_reason] variant via its sexp atom name. *)
+(** Convert one [alternative_candidate] to a [(symbol, reason)] pair. Renders
+    the [skip_reason] variant via its sexp atom name. *)
 let _rejection_pair_of_alternative
     (alt : Backtest.Trade_audit.alternative_candidate) : string * string =
   let reason =
-    Sexp.to_string
-      (Backtest.Trade_audit.sexp_of_skip_reason alt.reason_skipped)
+    Sexp.to_string (Backtest.Trade_audit.sexp_of_skip_reason alt.reason_skipped)
   in
   (alt.symbol, reason)
 
@@ -144,8 +143,7 @@ let _rejection_pair_of_alternative
     pairs. *)
 let _pairs_of_audit_record (rec_ : Backtest.Trade_audit.audit_record) :
     (string * string) list =
-  List.map rec_.entry.alternatives_considered
-    ~f:_rejection_pair_of_alternative
+  List.map rec_.entry.alternatives_considered ~f:_rejection_pair_of_alternative
 
 (** Harvest one [(symbol, reason)] pair per alternative-skip across the audit.
     Renders the [skip_reason] variant via its sexp atom name. Renderer attaches

--- a/trading/trading/backtest/optimal/lib/optimal_summary.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_summary.ml
@@ -18,11 +18,10 @@ let _step_dd (state : _dd_state) (equity : float) : _dd_state =
   in
   { peak; max_drawdown = Float.max state.max_drawdown drawdown }
 
-(** Group round-trips into per-Friday buckets, sorted chronologically.
-    The equity curve advances once per Friday, not once per round-trip. *)
-let _group_by_exit_friday
-    (round_trips : Optimal_types.optimal_round_trip list) :
-    Optimal_types.optimal_round_trip list list =
+(** Group round-trips into per-Friday buckets, sorted chronologically. The
+    equity curve advances once per Friday, not once per round-trip. *)
+let _group_by_exit_friday (round_trips : Optimal_types.optimal_round_trip list)
+    : Optimal_types.optimal_round_trip list list =
   let compare_exit (a : Optimal_types.optimal_round_trip)
       (b : Optimal_types.optimal_round_trip) =
     Date.compare a.exit_week b.exit_week
@@ -38,9 +37,7 @@ let _group_by_exit_friday
 (** Advance one Friday group through the equity/drawdown state machine. *)
 let _accumulate_equity (equity, dd_state)
     (group : Optimal_types.optimal_round_trip list) =
-  let group_pnl =
-    List.sum (module Float) group ~f:(fun rt -> rt.pnl_dollars)
-  in
+  let group_pnl = List.sum (module Float) group ~f:(fun rt -> rt.pnl_dollars) in
   let new_equity = equity +. group_pnl in
   (new_equity, _step_dd dd_state new_equity)
 

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_spec.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_spec.mli
@@ -63,14 +63,14 @@ type t = {
 [@@deriving sexp]
 (** A Bayesian-optimisation spec on disk. Example sexp:
     {[
-      (bounds
-         (("screening.weights.rs" (0.1 0.5))
-            ("screening.weights.volume" (0.1 0.5))))
-        (acquisition Expected_improvement)
-        (initial_random 5) (total_budget 30) (seed 17)
-        (n_acquisition_candidates ())
-        (objective Sharpe)
-        (scenarios "trading/test_data/backtest_scenarios/smoke/bull-2019.sexp")
+    (bounds
+       (("screening.weights.rs" (0.1 0.5))
+          ("screening.weights.volume" (0.1 0.5))))
+      (acquisition Expected_improvement)
+      (initial_random 5) (total_budget 30) (seed 17)
+      (n_acquisition_candidates ())
+      (objective Sharpe)
+      (scenarios "trading/test_data/backtest_scenarios/smoke/bull-2019.sexp")
     ]} *)
 
 val load : string -> t

--- a/trading/trading/backtest/tuner/lib/grid_search.mli
+++ b/trading/trading/backtest/tuner/lib/grid_search.mli
@@ -36,12 +36,12 @@ type param_spec = (string * param_values) list
 
     Example:
     {[
-      [
-        ("screening.weights.rs", [ 0.2; 0.3; 0.4 ]);
-        ("screening.weights.volume", [ 0.2; 0.3; 0.4 ]);
-        ("screening.weights.breakout", [ 0.2; 0.3; 0.4 ]);
-        ("screening.weights.sector", [ 0.2; 0.3; 0.4 ]);
-      ]
+    [
+      ("screening.weights.rs", [ 0.2; 0.3; 0.4 ]);
+      ("screening.weights.volume", [ 0.2; 0.3; 0.4 ]);
+      ("screening.weights.breakout", [ 0.2; 0.3; 0.4 ]);
+      ("screening.weights.sector", [ 0.2; 0.3; 0.4 ]);
+    ]
     ]}
 
     yields a 3 × 3 × 3 × 3 = 81-cell grid.
@@ -54,10 +54,10 @@ type param_spec = (string * param_values) list
     replaces the grade-based filter with a strict numeric [score >= n] gate.
     Sweep example:
     {[
-      [
-        ( "screening_config.min_score_override",
-          [ 38.0; 39.0; 40.0; 41.0; 42.0; 43.0 ] );
-      ]
+    [
+      ( "screening_config.min_score_override",
+        [ 38.0; 39.0; 40.0; 41.0; 42.0; 43.0 ] );
+    ]
     ]}
     Note: although the field is [int option] in the OCaml record, the grid spec
     carries floats. The override sexp emitted by

--- a/trading/trading/data_panel/atr_kernel.mli
+++ b/trading/trading/data_panel/atr_kernel.mli
@@ -13,7 +13,7 @@
     recurrence then gives, for [t > period]:
 
     {[
-      ATR [ t ] = ((ATR [ t - 1 ] * (period - 1)) + TR [ t ]) / period
+    ATR [ t ] = ((ATR [ t - 1 ] * (period - 1)) + TR [ t ]) / period
     ]}
 
     The kernel reads its prior state from the output panel at column [t - 1],

--- a/trading/trading/data_panel/ema_kernel.mli
+++ b/trading/trading/data_panel/ema_kernel.mli
@@ -4,7 +4,7 @@
     input values as the warmup seed at column [period-1], then the recurrence
 
     {[
-      EMA [ t ] = (alpha * input [ t ]) + ((1 - alpha) * EMA [ t - 1 ])
+    EMA [ t ] = (alpha * input [ t ]) + ((1 - alpha) * EMA [ t - 1 ])
     ]}
 
     where [alpha = 2 / (period + 1)]. Output cells at columns [0..period-2] are

--- a/trading/trading/data_panel/rsi_kernel.mli
+++ b/trading/trading/data_panel/rsi_kernel.mli
@@ -12,12 +12,11 @@
     [1..period]. The Wilder recurrence then gives, for [t > period]:
 
     {[
-      avg_gain [ t ]
-      = ((avg_gain [ t - 1 ] * (period - 1)) + gain [ t ])
-        / period avg_loss [ t ]
-      = ((avg_loss [ t - 1 ] * (period - 1)) + loss [ t ]) / period rs
-      = avg_gain [ t ] / avg_loss [ t ] rsi
-      = 100 - (100 / (1 + rs))
+    avg_gain [ t ]
+    = ((avg_gain [ t - 1 ] * (period - 1)) + gain [ t ]) / period avg_loss [ t ]
+    = ((avg_loss [ t - 1 ] * (period - 1)) + loss [ t ]) / period rs
+    = avg_gain [ t ] / avg_loss [ t ] rsi
+    = 100 - (100 / (1 + rs))
     ]}
 
     Edge cases:

--- a/trading/trading/engine/lib/engine.mli
+++ b/trading/trading/engine/lib/engine.mli
@@ -30,31 +30,31 @@ val update_market :
       Optional configuration for path generation. Defaults to
       Price_path.default_config. Use a fixed seed for deterministic testing:
       {[
-        let path_config = { Price_path.default_config with seed = Some 42 } in
-        Engine.update_market ~path_config engine bars
+      let path_config = { Price_path.default_config with seed = Some 42 } in
+      Engine.update_market ~path_config engine bars
       ]}
 
     Example:
     {[
-      let bars =
-        [
-          {
-            symbol = "AAPL";
-            open_price = 150.0;
-            high_price = 152.0;
-            low_price = 149.5;
-            close_price = 151.0;
-          };
-          {
-            symbol = "GOOGL";
-            open_price = 2800.0;
-            high_price = 2850.0;
-            low_price = 2790.0;
-            close_price = 2820.0;
-          };
-        ]
-      in
-      Engine.update_market engine bars
+    let bars =
+      [
+        {
+          symbol = "AAPL";
+          open_price = 150.0;
+          high_price = 152.0;
+          low_price = 149.5;
+          close_price = 151.0;
+        };
+        {
+          symbol = "GOOGL";
+          open_price = 2800.0;
+          high_price = 2850.0;
+          low_price = 2790.0;
+          close_price = 2820.0;
+        };
+      ]
+    in
+    Engine.update_market engine bars
     ]} *)
 
 val process_orders : t -> order_manager -> execution_report list status_or

--- a/trading/trading/simulation/lib/data/time_series.mli
+++ b/trading/trading/simulation/lib/data/time_series.mli
@@ -31,15 +31,15 @@ val convert_cadence :
 
     Examples:
     {[
-      (* Complete weeks only *)
-      let weekly =
-        convert_cadence daily_prices ~cadence:Types.Cadence.Weekly
-          ~as_of_date:None
+    (* Complete weeks only *)
+    let weekly =
+      convert_cadence daily_prices ~cadence:Types.Cadence.Weekly
+        ~as_of_date:None
 
-      (* Include provisional for Wednesday *)
-      let provisional =
-        convert_cadence daily_prices ~cadence:Types.Cadence.Weekly
-          ~as_of_date:(Some wed_date)
+    (* Include provisional for Wednesday *)
+    let provisional =
+      convert_cadence daily_prices ~cadence:Types.Cadence.Weekly
+        ~as_of_date:(Some wed_date)
     ]} *)
 
 val is_period_end : cadence:Types.Cadence.t -> Date.t -> bool

--- a/trading/trading/simulation/lib/order_generator.ml
+++ b/trading/trading/simulation/lib/order_generator.ml
@@ -68,9 +68,9 @@ let _transition_to_order ~id ~positions
 
 (** Advance the (seq, accumulator) pair with [maybe_order].
 
-    [seq] is always incremented even when no order is produced — this keeps
-    IDs stable regardless of how transition kinds are reordered in the
-    caller. Sequential gaps in IDs are harmless. *)
+    [seq] is always incremented even when no order is produced — this keeps IDs
+    stable regardless of how transition kinds are reordered in the caller.
+    Sequential gaps in IDs are harmless. *)
 let _accumulate_order (seq, acc) maybe_order =
   match maybe_order with
   | Some order -> Ok (seq + 1, order :: acc)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -161,8 +161,8 @@ let _get_today_bars t =
   List.filter_map t.deps.symbols ~f:get_bar
 
 (** Fetch the most recent prior close for [pos] when its symbol is absent from
-    [today_set]. Returns [None] when [pos.symbol] is in [today_set] (no
-    fallback needed) or when no prior bar exists for the symbol. *)
+    [today_set]. Returns [None] when [pos.symbol] is in [today_set] (no fallback
+    needed) or when no prior bar exists for the symbol. *)
 let _fallback_price_for_position ~adapter ~date ~today_set
     (pos : Trading_portfolio.Types.portfolio_position) =
   if Set.mem today_set pos.symbol then None

--- a/trading/trading/simulation/lib/split_handler.mli
+++ b/trading/trading/simulation/lib/split_handler.mli
@@ -6,11 +6,11 @@
     Two-side scaling is required because the simulator threads two parallel
     representations of the same position state: the broker portfolio
     ({!Trading_portfolio.Portfolio.t}) and the strategy-facing
-    {!Trading_strategy.Position.t} map. Both must be scaled in lockstep on
-    every detected split or the views diverge.
+    {!Trading_strategy.Position.t} map. Both must be scaled in lockstep on every
+    detected split or the views diverge.
 
-    No behavior change relative to the pre-extraction simulator — the
-    helpers were lifted verbatim. *)
+    No behavior change relative to the pre-extraction simulator — the helpers
+    were lifted verbatim. *)
 
 open Core
 
@@ -19,27 +19,27 @@ val detect_for_symbol :
   date:Date.t ->
   symbol:string ->
   Trading_portfolio.Split_event.t option
-(** Detect a split for [symbol] between the prior trading day's bar and
-    today's bar. Returns [Some event] when both bars exist and
-    {!Types.Split_detector.detect_split} fires; otherwise [None]. Pure
-    with respect to the adapter's cache. *)
+(** Detect a split for [symbol] between the prior trading day's bar and today's
+    bar. Returns [Some event] when both bars exist and
+    {!Types.Split_detector.detect_split} fires; otherwise [None]. Pure with
+    respect to the adapter's cache. *)
 
 val detect_for_held_positions :
   adapter:Trading_simulation_data.Market_data_adapter.t ->
   date:Date.t ->
   portfolio:Trading_portfolio.Portfolio.t ->
   Trading_portfolio.Split_event.t list
-(** For every symbol currently held in [portfolio], call
-    {!detect_for_symbol}. Symbols with no current bar (weekends/holidays) or
-    no prior bar (first appearance) yield no event. Order follows
-    [portfolio.positions] (sorted by symbol). *)
+(** For every symbol currently held in [portfolio], call {!detect_for_symbol}.
+    Symbols with no current bar (weekends/holidays) or no prior bar (first
+    appearance) yield no event. Order follows [portfolio.positions] (sorted by
+    symbol). *)
 
 val apply_events :
   Trading_portfolio.Portfolio.t ->
   Trading_portfolio.Split_event.t list ->
   Trading_portfolio.Portfolio.t
-(** Apply each detected split event to [portfolio] in order. Pure: returns
-    the updated portfolio with all events folded in. *)
+(** Apply each detected split event to [portfolio] in order. Pure: returns the
+    updated portfolio with all events folded in. *)
 
 val apply_to_position :
   float -> Trading_strategy.Position.t -> Trading_strategy.Position.t
@@ -48,14 +48,14 @@ val apply_to_position :
     multiplies by [factor] and [Holding.entry_price] divides by [factor],
     preserving total cost basis. [Exiting] mirrors the same scaling on its
     share-count fields ([quantity], [target_quantity], [filled_quantity]) and
-    per-share-price fields ([entry_price], [exit_price]). [Entering]
-    (in-flight entry order) and [Closed] (historical) pass through unchanged:
-    an entry order spanning a split is exotic and out of scope for the
-    broker-model fix; closed positions have no live state to scale.
+    per-share-price fields ([entry_price], [exit_price]). [Entering] (in-flight
+    entry order) and [Closed] (historical) pass through unchanged: an entry
+    order spanning a split is exotic and out of scope for the broker-model fix;
+    closed positions have no live state to scale.
 
-    Pure: returns a new [Position.t] with [state] replaced. The position's
-    [id], [symbol], [side], [entry_reasoning], [exit_reason], [last_updated],
-    and [portfolio_lot_ids] are unchanged. *)
+    Pure: returns a new [Position.t] with [state] replaced. The position's [id],
+    [symbol], [side], [entry_reasoning], [exit_reason], [last_updated], and
+    [portfolio_lot_ids] are unchanged. *)
 
 val apply_to_positions :
   Trading_strategy.Position.t String.Map.t ->

--- a/trading/trading/simulation/test/test_helpers.ml
+++ b/trading/trading/simulation/test/test_helpers.ml
@@ -33,11 +33,11 @@ let teardown_test_data test_data_dir =
 
     Usage:
     {[
-      with_test_data "my_test"
-        [ ("AAPL", prices) ]
-        ~f:(fun data_dir ->
-          (* test code here *)
-          ())
+    with_test_data "my_test"
+      [ ("AAPL", prices) ]
+      ~f:(fun data_dir ->
+        (* test code here *)
+        ())
     ]} *)
 let with_test_data test_name prices_by_symbol ~f =
   let data_dir = setup_test_data test_name prices_by_symbol in

--- a/trading/trading/simulation/test/test_helpers.mli
+++ b/trading/trading/simulation/test/test_helpers.mli
@@ -52,9 +52,9 @@ val default_enter_exit_config : enter_exit_config
 
     Usage:
     {[
-      module My_strategy = Make_enter_then_exit_strategy (struct
-        let config = { default_enter_exit_config with symbol = "MSFT" }
-      end)
+    module My_strategy = Make_enter_then_exit_strategy (struct
+      let config = { default_enter_exit_config with symbol = "MSFT" }
+    end)
     ]} *)
 module Make_enter_then_exit_strategy (_ : sig
   val config : enter_exit_config

--- a/trading/trading/strategy/lib/position.mli
+++ b/trading/trading/strategy/lib/position.mli
@@ -58,61 +58,59 @@
     {1 Usage Example}
 
     {[
-      (* Create position in Entering state from transition *)
-      let transition =
-        {
-          position_id = "AAPL-1";
-          date = Date.today ();
-          kind =
-            CreateEntering
-              {
-                symbol = "AAPL";
-                target_quantity = 100.0;
-                entry_price = 150.0;
-                reasoning =
-                  TechnicalSignal { indicator = "EMA"; description = "..." };
-              };
-        }
-      in
-      let pos = Position.create_entering transition |> Status.ok_exn in
+    (* Create position in Entering state from transition *)
+    let transition =
+      {
+        position_id = "AAPL-1";
+        date = Date.today ();
+        kind =
+          CreateEntering
+            {
+              symbol = "AAPL";
+              target_quantity = 100.0;
+              entry_price = 150.0;
+              reasoning =
+                TechnicalSignal { indicator = "EMA"; description = "..." };
+            };
+      }
+    in
+    let pos = Position.create_entering transition |> Status.ok_exn in
 
-      (* Apply fill transition *)
-      let fill_transition =
-        {
-          position_id = "AAPL-1";
-          date = Date.today ();
-          kind = EntryFill { filled_quantity = 100.0; fill_price = 150.25 };
-        }
-      in
-      let pos =
-        Position.apply_transition pos fill_transition |> Status.ok_exn
-      in
+    (* Apply fill transition *)
+    let fill_transition =
+      {
+        position_id = "AAPL-1";
+        date = Date.today ();
+        kind = EntryFill { filled_quantity = 100.0; fill_price = 150.25 };
+      }
+    in
+    let pos = Position.apply_transition pos fill_transition |> Status.ok_exn in
 
-      (* Complete entry, move to Holding *)
-      let complete_transition =
-        {
-          position_id = "AAPL-1";
-          date = Date.today ();
-          kind =
-            EntryComplete
-              {
-                risk_params =
-                  {
-                    stop_loss_price = Some 142.50;
-                    take_profit_price = Some 165.00;
-                    max_hold_days = None;
-                  };
-              };
-        }
-      in
-      let pos =
-        Position.apply_transition pos complete_transition |> Status.ok_exn
-      in
+    (* Complete entry, move to Holding *)
+    let complete_transition =
+      {
+        position_id = "AAPL-1";
+        date = Date.today ();
+        kind =
+          EntryComplete
+            {
+              risk_params =
+                {
+                  stop_loss_price = Some 142.50;
+                  take_profit_price = Some 165.00;
+                  max_hold_days = None;
+                };
+            };
+      }
+    in
+    let pos =
+      Position.apply_transition pos complete_transition |> Status.ok_exn
+    in
 
-      (* Position now in Holding state *)
-      match Position.get_state pos with
-      | Holding h -> Printf.printf "Holding %f shares\\n" h.quantity
-      | _ -> ()
+    (* Position now in Holding state *)
+    match Position.get_state pos with
+    | Holding h -> Printf.printf "Holding %f shares\\n" h.quantity
+    | _ -> ()
     ]} *)
 
 open Core

--- a/trading/trading/strategy/lib/strategy.mli
+++ b/trading/trading/strategy/lib/strategy.mli
@@ -84,10 +84,10 @@ val use_strategy :
     The accessor functions should already have market_data partially applied.
     Example:
     {[
-      let get_price_fn = get_price market_data in
-      let get_indicator_fn = get_indicator market_data in
-      use_strategy ~get_price:get_price_fn ~get_indicator:get_indicator_fn
-        ~positions strategy
+    let get_price_fn = get_price market_data in
+    let get_indicator_fn = get_indicator market_data in
+    use_strategy ~get_price:get_price_fn ~get_indicator:get_indicator_fn
+      ~positions strategy
     ]} *)
 
 val get_name : t -> string

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -1,15 +1,12 @@
-(** Indices consumed by the macro analyser. *)
 type index_config = {
-  primary : string;
-      (** The US benchmark symbol (e.g. ["GSPCX"]). *)
+  primary : string;  (** The US benchmark symbol (e.g. ["GSPCX"]). *)
   global : (string * string) list;
       (** [(symbol, label)] pairs for non-US indices used by the macro
           global-consensus indicator. Default: empty. *)
 }
 [@@deriving sexp]
+(** Indices consumed by the macro analyser. *)
 
-(** Complete Weinstein strategy configuration. All parameters configurable for
-    backtesting. *)
 type config = {
   universe : string list;
   indices : index_config;
@@ -39,6 +36,8 @@ type config = {
   laggard_reentry_cooldown_weeks : int; [@sexp.default 0]
 }
 [@@deriving sexp]
+(** Complete Weinstein strategy configuration. All parameters configurable for
+    backtesting. *)
 
 val default_config : universe:string list -> index_symbol:string -> config
 (** Build a default config with Weinstein book values. *)


### PR DESCRIPTION
## Summary

CI's ocamlformat removes 2 leading spaces from content inside `{[ ... ]}` docstring code blocks, while the Docker container's ocamlformat adds them back. This caused `dune build @fmt` to fail on commit `9fbe98d9` (current `origin/main` tip).

- Applies CI-preferred format to all 26 affected files
- Pure formatting change: no logic, no behavior, no new symbols
- Pattern: `{[` block content lines: 6-space → 4-space indent (or 8→6 for nested)
- Several `.ml` files also had docstring text rewrapping (different column-wrap width between versions)

**Finding source:** CI run failure on `origin/main` tip `9fbe98d9` — `dune build @fmt` step.

## Files changed (26)

- `trading/base/matchers/lib/matchers.mli` — 25+ `{[` block fixes
- `trading/trading/strategy/lib/position.mli` — large `{[` block (~50 lines)
- `trading/trading/engine/lib/engine.mli` — 2 `{[` blocks
- `trading/trading/simulation/lib/split_handler.mli` — text rewrap
- `trading/trading/simulation/lib/data/time_series.mli` — `{[` block
- `trading/trading/simulation/test/test_helpers.mli` + `.ml` — `{[` block
- `trading/trading/strategy/lib/strategy.mli` — `{[` block
- `trading/trading/backtest/lib/runner.mli` — `{[` block
- `trading/trading/backtest/lib/runner_metrics.mli` + `.ml` — text rewrap
- `trading/trading/backtest/tuner/lib/grid_search.mli` — 2 `{[` blocks
- `trading/trading/backtest/tuner/bin/bayesian_runner_spec.mli` — `{[` block
- `trading/trading/backtest/optimal/lib/optimal_run_artefacts.ml` + `optimal_summary.ml` — text rewrap + formatting
- `trading/trading/data_panel/atr_kernel.mli`, `ema_kernel.mli`, `rsi_kernel.mli` — `{[` blocks
- `trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli` — doc comment positioning
- `trading/devtools/ppx_test_matcher/lib/ppx_test_matcher.ml` — 2 `{[` blocks
- `trading/analysis/weinstein/stage/lib/stage.mli` — 2 `{[` blocks
- `trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml` — formatting
- `trading/analysis/data/sources/wiki_sp500/lib/membership_replay.ml` — formatting
- `trading/analysis/scripts/build_snapshots/build_snapshots.ml` — formatting
- `trading/trading/simulation/lib/order_generator.ml` + `simulator.ml` — text rewrap

## Test plan

- [ ] CI `dune build @fmt` passes on this branch
- [ ] CI `dune build` passes (no logic changes)
- [ ] CI `dune runtest` passes (no behavior changes)
- [ ] `gh pr view <N> --json files` shows exactly 26 files, all expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)