### PR TITLE
harness: add missing test deps for *_test.sh self-tests (red main fix)

### DIFF
--- a/trading/devtools/checks/dune
+++ b/trading/devtools/checks/dune
@@ -134,7 +134,7 @@
 
 (rule
  (alias runtest)
- (deps _check_lib.sh)
+ (deps _check_lib.sh agent_compliance_check.sh)
  (action
   (run sh %{dep:agent_compliance_test.sh})))
 
@@ -288,7 +288,7 @@
 
 (rule
  (alias runtest)
- (deps _check_lib.sh)
+ (deps _check_lib.sh rule_promotion_check.sh)
  (action
   (run sh %{dep:rule_promotion_self_test.sh})))
 
@@ -326,7 +326,7 @@
 
 (rule
  (alias runtest)
- (deps _check_lib.sh)
+ (deps _check_lib.sh posix_sh_check.sh)
  (action
   (run sh %{dep:posix_sh_check_test.sh})))
 


### PR DESCRIPTION
## Summary

Main CI went RED at SHA `6d625857` (Fix A merge, PR #992) with:
- `FAIL: assertion 1 — agent_compliance_check.sh failed on the as-checked-in tree`
- `FAIL: posix_sh_check_test: linter not found at ./posix_sh_check.sh`
- `cp: cannot stat './rule_promotion_check.sh': No such file or directory`

## Root cause

Three `*_test.sh` self-tests in `trading/devtools/checks/dune` invoke their corresponding `*_check.sh` linter, but the dune rule's `(deps ...)` block only lists `_check_lib.sh`. PR #943 (\"fix dune dep tracking for linter cache invalidation\") made dune sandboxes strict — when the cache invalidated post-Fix-A, the missing deps surfaced.

The test wrappers call:
- `agent_compliance_test.sh` → calls `agent_compliance_check.sh`
- `rule_promotion_self_test.sh` → calls `rule_promotion_check.sh`
- `posix_sh_check_test.sh` → calls `posix_sh_check.sh`

None of these `*_check.sh` files were in the sandbox, so they exited \"file not found\" and the self-tests reported FAIL.

## Fix

Add the missing `*_check.sh` to each test rule's `(deps ...)`:

\`\`\`dune
(rule
 (alias runtest)
 (deps _check_lib.sh agent_compliance_check.sh)  ; was: (deps _check_lib.sh)
 (action
  (run sh %{dep:agent_compliance_test.sh})))
\`\`\`

Same pattern for `rule_promotion_self_test` and `posix_sh_check_test`. Net diff: 3 lines.

## Test plan

- [x] Local `dune runtest devtools/checks --force` clean — all 3 self-tests pass with explicit OK lines:
  - \`OK: agent_compliance_test — all 2 assertions passed.\`
  - \`OK: rule_promotion_self_test — all assertions passed.\`
  - \`OK: posix_sh_check_test -- all 3 assertions passed.\`
- [ ] CI: this PR's build-and-test green.