### PR TITLE
harness(ci): upload golden-runs artefacts for postmortem analysis

### DIFF
--- a/.github/workflows/golden-runs-sp500-15y.yml
+++ b/.github/workflows/golden-runs-sp500-15y.yml
@@ -77,3 +77,20 @@ jobs:
           else
             echo "SP500 15y golden run: no summary produced." >>"$GITHUB_STEP_SUMMARY"
           fi
+
+      # Upload run artefacts (equity_curve.csv, splits.csv, trades.csv, actual.sexp,
+      # progress.sexp, summary.sexp) so postmortem analysis after a FAIL doesn't
+      # require re-running the 50-minute scenario.  Retain 7 days — long enough
+      # to investigate, short enough to keep storage usage low.  See
+      # `dev/notes/15y-split-day-regression-2026-05-08.md` §"Fix-path" for how
+      # these are used.
+      - name: Upload run artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-sp500-15y-${{ github.run_id }}
+          path: |
+            dev/perf/golden-sp500-postsubmit-*/
+            dev/backtest/scenarios-*/sp500-2010-2026-historical/
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/golden-runs-sp500-5y.yml
+++ b/.github/workflows/golden-runs-sp500-5y.yml
@@ -86,3 +86,17 @@ jobs:
           else
             echo "SP500 5y golden postsubmit: no summary produced." >>"$GITHUB_STEP_SUMMARY"
           fi
+
+      # Upload run artefacts (equity_curve.csv, splits.csv, trades.csv,
+      # actual.sexp, progress.sexp, summary.sexp) so postmortem analysis after a
+      # FAIL doesn't require re-running. Retain 7 days.
+      - name: Upload run artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-sp500-5y-${{ github.run_id }}
+          path: |
+            dev/perf/golden-sp500-postsubmit-*/
+            dev/backtest/scenarios-*/sp500-2019-2023*/
+          retention-days: 7
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Add `actions/upload-artifact@v4` step to both `golden-runs-sp500-5y.yml` and `golden-runs-sp500-15y.yml` so when a scenario FAILs (or any time really), the per-cell `actual.sexp`, `equity_curve.csv`, `trades.csv`, `splits.csv`, `progress.sexp`, `summary.sexp` are downloadable from the run page.

7-day retention — long enough to investigate a FAIL, short enough to keep storage usage low.

## Motivation

Today's 15y golden runs (after Q1 memory fix) FAIL the scenario-runner assertion (`-85.77%` return vs pinned `+5.15%`). Investigation note (PR #998) hypothesises the wild-jump pattern in the equity_curve may be a non-trading-day filtering artifact, not real P&L drift. Confirming requires the actual `equity_curve.csv` + `splits.csv` from a CI run. Today's runs left no artefacts — required local 30-min reproductions just to read the curve.

## Test plan

- [x] YAML syntax — only added a step, no structural change.
- [ ] CI: next 15y cron run uploads a `golden-sp500-15y-<run_id>` artefact zip downloadable via `gh run download <run_id>`.
- [ ] CI: next 5y postsubmit on main upload uploads `golden-sp500-5y-<run_id>`.