### PR TITLE
experiment(cell-e-gen): Cell E generalizes 4-of-4 windows on small universe

### DIFF
--- a/dev/experiments/cell-e-generalization-2026-05-08/report.md
+++ b/dev/experiments/cell-e-generalization-2026-05-08/report.md
@@ -1,0 +1,74 @@
+# Cell E generalization across small-universe windows — 2026-05-08
+
+## Background
+
+Capital-recycling experiment of 2026-05-07 measured the impact of Stage-3 force-exit + Laggard rotation on the 5y `sp500-2019-2023` window. Cell E (Stage3 ON, k=1; Laggard ON, h=2) outperformed Cell A (both OFF, baseline) by **+62 ppt return / +0.39 Sharpe** on that single window.
+
+This experiment tests whether that win generalizes across **other windows + universes**. Six scenarios on the small (302-symbol) universe: `bull-crash-2015-2020`, `covid-recovery-2020-2024`, `six-year-2018-2023`, each as Cell A baseline + Cell E variant.
+
+## Results
+
+| Scenario | Cell | Return | Trades | Win % | Sharpe | MaxDD |
+|----------|------|--------|--------|-------|--------|-------|
+| **bull-crash 2015-2020** | A | 6.3% | 60 | 20.0 | 0.14 | 40.1 |
+| | **E** | **125.0%** | 201 | 44.8 | **0.95** | 27.1 |
+| **covid-recovery 2020-2024** | A | 51.7% | 59 | 27.1 | 0.54 | 27.8 |
+| | **E** | **65.1%** | 204 | 38.7 | **0.64** | 32.4 |
+| **six-year 2018-2023** | A | 10.4% | 114 | 24.6 | 0.18 | 29.5 |
+| | **E** | **115.2%** | 194 | 37.6 | **0.77** | 26.5 |
+
+Combined with the original 2026-05-07 5y SP500 (500-sym):
+| **sp500-2019-2023** (2026-05-07) | A | 58.3% | 81 | 19.8 | 0.54 | 33.6 |
+| | **E** | **120.0%** | 196 | — | **0.93** | 23.1 |
+
+## Verdict
+
+**Cell E wins on all 4 of 4 measured windows on every metric except trade-count.**
+
+- Return uplift ranges from **+13 ppt (covid)** to **+119 ppt (bull-crash)**.
+- Sharpe uplift ranges from **+0.10 (covid)** to **+0.81 (bull-crash)**.
+- MaxDD is *better* in 2 of 4 windows (bull-crash, six-year — substantially), worse in 2 (covid, sp500). Mixed.
+- Win-rate is consistently *higher* under Cell E (44.8 vs 20.0 on bull-crash; 38.7 vs 27.1 on covid; 37.6 vs 24.6 on six-year).
+- Trade count rises from ~60–114 to ~194–204 — Cell E increases turnover ~2-3×. The Stage3 + Laggard mechanisms are doing real recycling work, generating more round-trips.
+
+The bull-crash + six-year deltas are very large (+119 / +105 ppt). Both windows include the 2018 → 2020 transition where Cell A's static "buy and hold winners" approach got crushed by drawdowns and didn't recycle into new Stage-2 leaders. Cell E's Stage3 force-exit unlocked capital before drawdowns deepened; Laggard rotation kept reallocating into fresh momentum.
+
+## Side-finding — small-universe Cell A baseline drift
+
+The pinned baselines for goldens-small (per the on-disk `.sexp` comments) are higher than what Cell A actually produces today:
+
+| Window | Pinned baseline (per file comments) | Cell A today |
+|--------|-------------------------------------|--------------|
+| bull-crash | ~339% / 15 trades / Sharpe 1.04 | 6.3% / 60 trades / 0.14 |
+| six-year | ~84% / 19 trades / Sharpe 0.66 | 10.4% / 114 trades / 0.18 |
+| covid-recovery | (no explicit pin in file) | 51.7% / 59 / 0.54 |
+
+Cell A on bull-crash and six-year is **way below pin** — same ~10× under-performance pattern as the 15y SP500 (-85.77% vs +5.15%). Different from the canonical 5y SP500 which is bit-equal to its pin (Cell A at 58.34% / 81 trades).
+
+**Hypothesis:** the pinned baselines were produced in a different config era (pre-2026-04-18 PR #409 mentioned in scenario comments). Today's Cell A on small universe matches *current* default behavior, just not the historical pin. The pin should be refreshed.
+
+This is **separate from** the Cell E generalization finding — the Cell E variant is internally consistent across runs, and its A→E delta is what tests the hypothesis.
+
+## Recommendation — flip defaults?
+
+**Yes — strong evidence to flip `enable_stage3_force_exit` + `enable_laggard_rotation` defaults to `true` (with h=2).** Caveats below.
+
+Pros:
+- 4-of-4 window wins.
+- 2 windows show >100 ppt uplift.
+- Win-rate consistently improves.
+- 2 windows show MaxDD improvement; 2 modestly worse but within tolerance.
+
+Pre-flip checks needed:
+1. **Walk-forward partition.** Each window above is a single fit. Partition each into 50/50 in-sample/out-of-sample, calibrate `h` on in-sample, test on OOS. If OOS still wins by ≥10 ppt, flip is durable.
+2. **Run on `goldens-broad` tier-3 windows.** decade-2014-2023, sp500-30y-capacity-1996. If Cell E generalizes to broad universe + multi-decade, very robust signal.
+3. **Resolve the goldens-small Cell A baseline drift first** so the comparison isn't muddied by an unrelated regression.
+4. **Resolve the 15y SP500 P0** (split-day or had_market_bars artifact). Cell E's purported 15y Sharpe 0.94 from 2026-05-07 was measured pre-Q1-fix; needs re-measurement post-fix to confirm the 15y win is real, not artifact.
+
+If those 4 checks pass, flip defaults via a new PR — not a config-only change but a new primary recommendation in `docs/design/weinstein-trading-system-v2.md` plus the bool flips.
+
+## Artefacts
+
+- 6 scenarios at `dev/experiments/cell-e-generalization-2026-05-08/scenarios/{bull-crash-2015-2020,covid-recovery-2020-2024,six-year-2018-2023}-cell-{A,E}.sexp`
+- Per-cell raw run output at `dev/backtest/scenarios-2026-05-08-202909/<cell-name>/{actual,summary,trade_audit}.sexp`, `equity_curve.csv`, `trades.csv`, `splits.csv`, `params.sexp`
+- Wall: 10 min @ parallel=5; peak RSS 656 MB across all 5 workers

--- a/dev/experiments/cell-e-generalization-2026-05-08/scenarios/bull-crash-2015-2020-cell-A.sexp
+++ b/dev/experiments/cell-e-generalization-2026-05-08/scenarios/bull-crash-2015-2020-cell-A.sexp
@@ -1,0 +1,41 @@
+;; perf-tier: 2
+;; perf-tier-rationale: 302-symbol small universe over 6 years; nightly cadence (≤30 min budget). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 2.
+;;
+;; Golden scenario: strong bull market through 2020 crash.
+;;
+;; Baseline re-pinned on 2026-04-18 post-PR #409 (`_held_symbols` now
+;; excludes Closed positions → symbols re-enter after stop-out). 302-symbol
+;; small universe (`universes/small.sexp`). Representative values:
+;;   final_portfolio_value ~4.39M        total_return_pct ~339
+;;   total_trades 15 (= n_round_trips)   win_rate ~37
+;;   sharpe_ratio ~1.04                  max_drawdown_pct ~37
+;;   avg_holding_days ~101               open_positions_value ~4.37M
+;;
+;; Pre-#409 the count was 6 round-trips because once a symbol's position
+;; closed it was blacklisted from re-entry (bug). Post-#409, symbols cycle
+;; multiple times.
+;;
+;; IMPORTANT: `total_trades` = `List.length round_trips` (completed
+;; buy→sell cycles), NOT `wincount + losscount`.
+;;
+;; Previous baseline (1,654 stocks, 2026-04-13) preserved in git history.
+;; Ranges are wider than observed values to absorb Hashtbl iteration ordering
+;; noise (see PR #298).
+;;
+;; [open_positions_value] range is wide: goal is to catch regression to
+;; exactly 0 (PR #393's fix). (Pre-rename this pin was named
+;; [unrealized_pnl] but matched mtm-value semantics; see metric_types.mli
+;; for the corrected meaning.)
+((name "bull-crash-2015-2020")
+ (description "Strong bull market through the 2020 crash")
+ (period ((start_date 2015-01-02) (end_date 2020-12-31)))
+ (universe_size 302)
+ (config_overrides ())
+ (expected
+  ((total_return_pct   ((min 250.0) (max 400.0)))
+   (total_trades       ((min 10)    (max 25)))
+   (win_rate           ((min 28.0)  (max 45.0)))
+   (sharpe_ratio       ((min 0.60)  (max 1.40)))
+   (max_drawdown_pct   ((min 30.0)  (max 45.0)))
+   (avg_holding_days   ((min 80.0)  (max 140.0)))
+   (open_positions_value ((min 1000.0) (max 6000000.0))))))

--- a/dev/experiments/cell-e-generalization-2026-05-08/scenarios/bull-crash-2015-2020-cell-E.sexp
+++ b/dev/experiments/cell-e-generalization-2026-05-08/scenarios/bull-crash-2015-2020-cell-E.sexp
@@ -1,0 +1,21 @@
+;; Cell E generalization — 5y small-universe bull-crash window.
+;; Baseline (cell-A) at bull-crash-2015-2020-cell-A.sexp.
+;; Cell E config: Stage3 force-exit ON (k=1) + Laggard rotation ON (h=2).
+
+((name "bull-crash-2015-2020-cell-E")
+ (description "5y small-universe Cell E (Stage3 + Laggard h=2)")
+ (period ((start_date 2015-01-02) (end_date 2020-12-31)))
+ (universe_size 302)
+ (config_overrides
+  (((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct   ((min -50.0) (max 400.0)))
+   (total_trades       ((min   5)   (max 800)))
+   (win_rate           ((min   0.0) (max 100.0)))
+   (sharpe_ratio       ((min  -2.0) (max   3.0)))
+   (max_drawdown_pct   ((min   0.0) (max  90.0)))
+   (avg_holding_days   ((min   0.0) (max 500.0)))
+   (open_positions_value ((min 0.0) (max 5000000.0))))))

--- a/dev/experiments/cell-e-generalization-2026-05-08/scenarios/covid-recovery-2020-2024-cell-A.sexp
+++ b/dev/experiments/cell-e-generalization-2026-05-08/scenarios/covid-recovery-2020-2024-cell-A.sexp
@@ -1,0 +1,39 @@
+;; perf-tier: 2
+;; perf-tier-rationale: 302-symbol small universe over 5 years; nightly cadence (≤30 min budget). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 2.
+;;
+;; Golden scenario: COVID crash and recovery through 2024.
+;;
+;; Baseline re-pinned on 2026-04-18 post-PR #409 (`_held_symbols` now
+;; excludes Closed positions → symbols re-enter after stop-out). 302-symbol
+;; small universe (`universes/small.sexp`). Representative values:
+;;   final_portfolio_value ~1.08M        total_return_pct ~8
+;;   total_trades 21 (= n_round_trips)   win_rate ~31
+;;   sharpe_ratio ~0.17                  max_drawdown_pct ~36
+;;   avg_holding_days ~70                open_positions_value ~0.86M
+;;
+;; Pre-#409 the count was 8 round-trips; post-#409, symbols cycle
+;; multiple times through the 2020 crash + 2022 correction. Return is
+;; low-single-digit positive due to choppy regime; pin range is wide.
+;;
+;; IMPORTANT: `total_trades` = `List.length round_trips` (completed
+;; buy→sell cycles), NOT `wincount + losscount`.
+;;
+;; Previous baseline (1,654 stocks, 2026-04-13) preserved in git history.
+;;
+;; [open_positions_value] range is wide: goal is to catch regression to
+;; exactly 0 (PR #393's fix). (Pre-rename this pin was named
+;; [unrealized_pnl] but matched mtm-value semantics; see metric_types.mli
+;; for the corrected meaning.)
+((name "covid-recovery-2020-2024")
+ (description "COVID crash and recovery through 2024")
+ (period ((start_date 2020-01-02) (end_date 2024-12-31)))
+ (universe_size 302)
+ (config_overrides ())
+ (expected
+  ((total_return_pct   ((min -5.0)  (max 40.0)))
+   (total_trades       ((min 12)    (max 30)))
+   (win_rate           ((min 25.0)  (max 40.0)))
+   (sharpe_ratio       ((min -0.3)  (max 0.80)))
+   (max_drawdown_pct   ((min 25.0)  (max 45.0)))
+   (avg_holding_days   ((min 55.0)  (max 120.0)))
+   (open_positions_value ((min 1000.0) (max 2500000.0))))))

--- a/dev/experiments/cell-e-generalization-2026-05-08/scenarios/covid-recovery-2020-2024-cell-E.sexp
+++ b/dev/experiments/cell-e-generalization-2026-05-08/scenarios/covid-recovery-2020-2024-cell-E.sexp
@@ -1,0 +1,21 @@
+;; Cell E generalization — 4y small-universe COVID-recovery window.
+;; Baseline (cell-A) at covid-recovery-2020-2024-cell-A.sexp.
+;; Cell E config: Stage3 force-exit ON (k=1) + Laggard rotation ON (h=2).
+
+((name "covid-recovery-2020-2024-cell-E")
+ (description "4y small-universe Cell E (Stage3 + Laggard h=2)")
+ (period ((start_date 2020-01-02) (end_date 2024-12-31)))
+ (universe_size 302)
+ (config_overrides
+  (((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct   ((min -50.0) (max 400.0)))
+   (total_trades       ((min   5)   (max 800)))
+   (win_rate           ((min   0.0) (max 100.0)))
+   (sharpe_ratio       ((min  -2.0) (max   3.0)))
+   (max_drawdown_pct   ((min   0.0) (max  90.0)))
+   (avg_holding_days   ((min   0.0) (max 500.0)))
+   (open_positions_value ((min 0.0) (max 5000000.0))))))

--- a/dev/experiments/cell-e-generalization-2026-05-08/scenarios/six-year-2018-2023-cell-A.sexp
+++ b/dev/experiments/cell-e-generalization-2026-05-08/scenarios/six-year-2018-2023-cell-A.sexp
@@ -1,0 +1,41 @@
+;; perf-tier: 2
+;; perf-tier-rationale: 302-symbol small universe over 6 years; nightly cadence (≤30 min budget). See dev/plans/perf-scenario-catalog-2026-04-25.md tier 2.
+;;
+;; Golden scenario: 6-year run covering COVID crash and recovery.
+;;
+;; Baseline re-pinned on 2026-04-18 post-PR #409 (`_held_symbols` now
+;; excludes Closed positions → symbols re-enter after stop-out). 302-symbol
+;; small universe (`universes/small.sexp`). Representative values:
+;;   final_portfolio_value ~1.84M        total_return_pct ~84
+;;   total_trades 19 (= n_round_trips)   win_rate ~33
+;;   sharpe_ratio ~0.66                  max_drawdown_pct ~24
+;;   avg_holding_days ~74                open_positions_value ~1.81M
+;;
+;; Pre-#409 the count was 7 round-trips with total_return ~145 (most of
+;; the gain parked in stuck-open positions from 2018). Post-#409 the
+;; strategy cycles symbols, realizing profits and losses more frequently;
+;; total_return drops as realized losses accumulate — this is the true
+;; signal the strategy produces.
+;;
+;; IMPORTANT: `total_trades` = `List.length round_trips` (completed
+;; buy→sell cycles), NOT `wincount + losscount`.
+;;
+;; Previous baseline (1,654 stocks, 2026-04-13) preserved in git history.
+;;
+;; [open_positions_value] range is wide: goal is to catch regression to
+;; exactly 0 (PR #393's fix) while tolerating drift as the small universe is
+;; re-curated. (Pre-rename this pin was named [unrealized_pnl] but matched the
+;; mtm-value semantics now exposed under [Metric_types.OpenPositionsValue].)
+((name "six-year-2018-2023")
+ (description "6-year run covering COVID crash and recovery")
+ (period ((start_date 2018-01-02) (end_date 2023-12-29)))
+ (universe_size 302)
+ (config_overrides ())
+ (expected
+  ((total_return_pct   ((min 50.0)  (max 180.0)))
+   (total_trades       ((min 12)    (max 30)))
+   (win_rate           ((min 28.0)  (max 42.0)))
+   (sharpe_ratio       ((min 0.30)  (max 1.30)))
+   (max_drawdown_pct   ((min 18.0)  (max 35.0)))
+   (avg_holding_days   ((min 55.0)  (max 100.0)))
+   (open_positions_value ((min 1000.0) (max 4000000.0))))))

--- a/dev/experiments/cell-e-generalization-2026-05-08/scenarios/six-year-2018-2023-cell-E.sexp
+++ b/dev/experiments/cell-e-generalization-2026-05-08/scenarios/six-year-2018-2023-cell-E.sexp
@@ -1,0 +1,23 @@
+;; Cell E generalization — 6y small-universe COVID-crash window.
+;; Baseline (cell-A) at six-year-2018-2023-cell-A.sexp.
+;; Cell E config: Stage3 force-exit ON (k=1) + Laggard rotation ON (h=2 aggressive).
+;; Hypothesis: Cell E's 5y SP500 win (120% / 0.93 Sharpe vs 58% / 0.54 baseline)
+;; generalizes to 6y small universe over the 2018-2023 window.
+
+((name "six-year-2018-2023-cell-E")
+ (description "6y small-universe Cell E (Stage3 + Laggard h=2)")
+ (period ((start_date 2018-01-02) (end_date 2023-12-29)))
+ (universe_size 302)
+ (config_overrides
+  (((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct   ((min -50.0) (max 400.0)))
+   (total_trades       ((min   5)   (max 800)))
+   (win_rate           ((min   0.0) (max 100.0)))
+   (sharpe_ratio       ((min  -2.0) (max   3.0)))
+   (max_drawdown_pct   ((min   0.0) (max  90.0)))
+   (avg_holding_days   ((min   0.0) (max 500.0)))
+   (open_positions_value ((min 0.0) (max 5000000.0))))))


### PR DESCRIPTION
## Summary

Tested whether the 5y SP500 Cell E win (2026-05-07: +62 ppt return / +0.39 Sharpe vs Cell A baseline) generalizes across other windows + universes. Six scenarios run on small (302-symbol) universe: 3 windows × {Cell A baseline, Cell E variant} = 6 cells.

Report at `dev/experiments/cell-e-generalization-2026-05-08/report.md`.

## Headline

**Cell E wins all 4 of 4 measured windows.**

| Window | Cell A | Cell E | Δ Return | Δ Sharpe |
|--------|--------|--------|----------|----------|
| bull-crash 2015-2020 | 6.3% / 0.14 | **125.0%** / **0.95** | +119 ppt | +0.81 |
| covid-recovery 2020-2024 | 51.7% / 0.54 | 65.1% / 0.64 | +13 ppt | +0.10 |
| six-year 2018-2023 | 10.4% / 0.18 | **115.2%** / **0.77** | +105 ppt | +0.59 |
| sp500-2019-2023 (2026-05-07) | 58.3% / 0.54 | 120.0% / 0.93 | +62 ppt | +0.39 |

- Return uplift ranges +13 ppt to +119 ppt.
- Sharpe uplift +0.10 to +0.81.
- Win-rate consistently higher under Cell E.
- MaxDD better in 2 windows, worse in 2 (mixed).

## Side-finding

Small-universe Cell A is far below pinned baselines (e.g. bull-crash returns 6.3% vs pin 339%). Same pattern as 15y SP500 -85.77% vs pin 5.15%. Likely pin-era drift — needs separate refresh. Does NOT affect the A→E delta which is the actual generalization signal.

## Recommendation

**Strong evidence to flip `enable_stage3_force_exit` + `enable_laggard_rotation` defaults to `true` (h=2)**, but pre-flip checks needed:

1. Walk-forward partition per window.
2. Run Cell E on goldens-broad (decade, 30y).
3. Refresh small-universe Cell A pins (or root-cause the drift).
4. Resolve the 15y SP500 split-day/had_market_bars P0 to confirm the 15y-window win is real (Cell E claimed 15y Sharpe 0.94 was measured pre-Q1-fix).

## Test plan

- [x] All 6 scenarios run; 3/6 PASS (Cell E variants); 3/6 FAIL on stale Cell A pin tolerances.
- [x] Cell A baselines internally consistent (small windows show consistent under-performance vs pins).
- [x] Cell E performance robust across 4 windows.