### PR TITLE
ops(workflows): bump orchestrator auto-merge poll 6m → 10m

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -418,11 +418,14 @@ jobs:
           # "Pull Request is not mergeable" or 409 "Head branch is out of
           # date" — that was the silent failure mode 2026-04-26..2026-05-01
           # (see dev/notes/orchestrator-auto-merge-regression-2026-05-01.md).
-          # Timeout 6 min (72 × 5s) covers the typical CI runtime; if CI
+          # Timeout 10 min (120 × 5s) covers the typical CI runtime; if CI
           # genuinely fails the loop times out and the warning fires below.
+          # Bumped from 6 min → 10 min on 2026-05-09 after PR #1008 hit the
+          # 6-min timeout while CI completed at ~7m49s (~77s past the
+          # original budget; see workflow run 25595939612).
           # See run 24996059895 for the original "still computing" failure
           # mode this poll was originally introduced to handle.
-          for _ in $(seq 1 72); do
+          for _ in $(seq 1 120); do
             RESPONSE="$(curl -sSL \
               -H "Authorization: Bearer ${GH_TOKEN}" \
               -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary

Bumps the daily-orchestrator auto-merge poll budget from 6 min (72×5s) to 10 min (120×5s).

## Why

PR #1008 (run-1's daily summary) hit the 6-min poll timeout while CI was still running:

- 08:07:07Z — \`build-and-test\` started
- 08:13:39Z — poll timed out → PUT /merge → HTTP 405 \`"Required status check \"build-and-test\" is in progress."\`
- 08:14:56Z — CI completed SUCCESS, **~77s after the timeout**

CI runtime crept past the original 6-min budget (this run was ~7m49s). Bumping to 10 min covers typical drift with margin without affecting the genuine-CI-failure path (the warning still fires after the new 10-min budget).

## What this is NOT

This is the minimal patch to unblock auto-merge today. A cleaner follow-up is to switch from REST PUT /merge with poll loop to native auto-merge (\`gh pr merge --auto\` or GraphQL \`enablePullRequestAutoMerge\`) now that branch protection is active on \`main\` (verified 2026-05-09: \`strict + enforce_admins + 2 required checks\`). Native auto-merge queues server-side and removes the poll-window race entirely. History check confirms we've never tried that path — every prior auto-merge fix (#499, #624, #733) has been REST + poll variations.

## Test plan

- [x] \`dune build\` not affected (workflow-file-only change)
- [ ] Next overnight orchestrator run validates the change empirically