### PR TITLE
fix(portfolio): prepend trades to trade_history (O(N²) → O(N))

### DIFF
--- a/trading/trading/portfolio/lib/portfolio.ml
+++ b/trading/trading/portfolio/lib/portfolio.ml
@@ -377,7 +377,14 @@ let apply_single_trade (portfolio : t) (trade : Trading_base.Types.trade) :
       portfolio with
       current_cash = new_cash;
       positions = new_positions;
-      trade_history = portfolio.trade_history @ [ trade_with_pnl ];
+      (* Newest-first: prepend (O(1), shares tail across snapshots) instead of
+         append-via-[@] (O(N) per call, fresh prefix per snapshot). The latter
+         was the dominant cost on Cell E 15 y runs — both algorithmically
+         (N(N+1)/2 cons cells for N trades) and via [step_history] retention
+         (every [step_result.portfolio] held a fresh trade_history spine, so
+         [step_history] memory scaled O(N²) instead of O(N)).
+         See [dev/notes/cell-e-15y-engineering-blocker-2026-05-09.md]. *)
+      trade_history = trade_with_pnl :: portfolio.trade_history;
       unrealized_pnl_per_position = new_accumulator;
     }
 
@@ -395,9 +402,11 @@ let mark_to_market portfolio market_prices =
   in
   { portfolio with unrealized_pnl_per_position = new_accumulator }
 
-(* Reconstruct portfolio from scratch for validation *)
+(* Reconstruct portfolio from scratch for validation. [trade_history] is stored
+   newest-first (see [trade_history = trade_with_pnl :: ...] above), so we
+   reverse it once here to replay trades in chronological order. *)
 let reconstruct_from_history initial_cash accounting_method trade_history =
-  let trades = List.map trade_history ~f:(fun { trade; _ } -> trade) in
+  let trades = List.rev_map trade_history ~f:(fun { trade; _ } -> trade) in
   let empty_portfolio = create ~accounting_method ~initial_cash () in
   apply_trades empty_portfolio trades
 

--- a/trading/trading/portfolio/lib/portfolio.mli
+++ b/trading/trading/portfolio/lib/portfolio.mli
@@ -19,7 +19,12 @@ type t = {
 
     Fields:
     - [initial_cash]: Starting cash balance
-    - [trade_history]: Complete history of trades with realized P&L
+    - [trade_history]: Complete history of trades with realized P&L, stored
+      **newest-first** (most recent trade at the head). Readers that need
+      chronological order must [List.rev] before consuming. The newest-first
+      convention enables O(1) append in [apply_single_trade] and lets successive
+      [step_result.portfolio] snapshots share spines, which is load-bearing for
+      backtest memory at scale (15 y / 3 700 trades).
     - [current_cash]: Current cash balance (derived from initial_cash and
       trades)
     - [positions]: Current positions as sorted list (by symbol)

--- a/trading/trading/portfolio/test/test_portfolio.ml
+++ b/trading/trading/portfolio/test/test_portfolio.ml
@@ -215,8 +215,10 @@ let test_short_cover _ accounting_method =
   assert_that portfolio.current_cash (float_equal 17992.0);
 
   (* Verify realized P&L: covering 50 shares
-     P&L = 50 * ($149.95 - $140) - $3 = 50 * $9.95 - $3 = $497.50 - $3 = $494.50 *)
-  let history = portfolio.trade_history in
+     P&L = 50 * ($149.95 - $140) - $3 = 50 * $9.95 - $3 = $497.50 - $3 = $494.50
+
+     trade_history is newest-first; reverse for chronological indexing. *)
+  let history = List.rev portfolio.trade_history in
   let cover_pnl = (List.nth_exn history 1).realized_pnl in
   assert_that cover_pnl (float_equal 494.5);
 
@@ -294,7 +296,8 @@ let test_realized_pnl_calculation _ accounting_method =
         OUnit2.assert_failure ("Realized P&L test failed: " ^ Status.show err)
   in
 
-  let trade_history = updated_portfolio.trade_history in
+  (* trade_history is stored newest-first; reverse for chronological indexing. *)
+  let trade_history = List.rev updated_portfolio.trade_history in
   assert_equal 3 (List.length trade_history) ~msg:"Should have 3 trades";
 
   let trade1 = List.nth_exn trade_history 0 in


### PR DESCRIPTION
## Summary

\`Portfolio.apply_single_trade\` was building \`trade_history\` with \`portfolio.trade_history @ [ trade_with_pnl ]\` — the classic OCaml O(N²) anti-pattern. Switches to \`trade_with_pnl :: portfolio.trade_history\` (O(1) prepend) and documents \`trade_history\` as newest-first.

## Why

This single line is the dominant runtime + memory cost on Cell E 15 y backtests (#1007).

**Algorithmic.** \`@ [x]\` allocates a fresh prefix every call; trade k allocates k cons-cells. For 3 700 trades that's 3700·3701/2 ≈ 6.8 M cons-cell allocations just to build \`trade_history\` — and the cumulative work scales as N(N+1)/2.

**Memory (worse than algorithmic).** \`step_result.portfolio\` retains the whole \`Portfolio.t\` snapshot — see \`dev/notes/15y-memory-cliff-2026-05-08.md\` Cliff #3. Because \`@\` doesn't share spines (the right operand differs each call), every step's snapshot held a unique trade_history list. With 4 350 step_results × growing trade_history this contributes ~3.5 GB of retained memory on 15 y runs (the bulk of the 11.4 GB RSS at 15 y vs 766 MB at 5 y). With \`::\` the spine tail is shared across all snapshots, so total cons-cell live set is O(N) instead of O(N²).

**GC-bound cycle decay.** As live heap approaches 11 GB, major-GC time scales with live heap size and dominates per-cycle wall time — driving the 30 cycles/min → 1 cycle / 30 min slowdown observed during the partial Cell E 15 y run (#1007).

## What changes

- \`portfolio.ml:380\` — \`@ [trade_with_pnl]\` → \`trade_with_pnl :: ...\`. Comment cites the rationale.
- \`portfolio.ml:399\` \`reconstruct_from_history\` — uses \`List.rev_map\` so trades are replayed in chronological order (apply_trades is order-dependent).
- \`portfolio.mli\` — documents \`trade_history\` as **newest-first**, with the rationale that the convention enables O(1) append and step-snapshot spine sharing.
- \`test_portfolio.ml\` — two readers that index with \`List.nth_exn\` now \`List.rev\` the field first.

Other readers checked and unchanged:
- \`Calculations.realized_pnl_from_trades\` — \`List.fold\` sum, order-independent.
- \`Metrics.extract_round_trips\` — pulls from \`step_result.trades\` (per-step), not from cumulative \`trade_history\`. Bit-equal output preserved.
- \`Calculations\` + \`Split_event\` tests use \`List.length\` (order-independent).

## Test plan

- [x] \`dune build\` clean.
- [x] \`dune runtest\` clean (full suite, exit 0).
- [x] \`dune build @fmt\` clean.
- [x] Sexp round-trip preserved (no custom converters touched).

## Follow-up

PR-2 (next) hoists \`Trade_context.of_audit_and_stop_log\`'s per-row \`audit_idx\` rebuild outside the iter loop in \`result_writer._write_trades\` — the second O(N²) on the same scale, but at end-of-run rather than per-cycle.