### PR TITLE
perf(backtest): hoist trade_context audit_idx out of trades.csv iter loop

### DIFF
--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -123,7 +123,7 @@ let _trades_csv_header =
   in
   String.concat ~sep:"," (base @ Trade_context.csv_header_fields)
 
-let _write_trade_row oc stop_index force_liq_index ~audit ~stop_infos
+let _write_trade_row oc stop_index force_liq_index ~ctx_pre
     (t : Metrics.trade_metrics) =
   let info = _pop_stop_info stop_index ~symbol:t.symbol in
   let entry_stop, exit_stop, base_exit_trigger = _stop_fields info in
@@ -133,7 +133,7 @@ let _write_trade_row oc stop_index force_liq_index ~audit ~stop_infos
     | Some reason -> _force_liq_label reason
     | None -> base_exit_trigger
   in
-  let ctx = Trade_context.of_audit_and_stop_log ~audit ~stop_infos ~trade:t in
+  let ctx = Trade_context.of_precomputed ctx_pre ~trade:t in
   let base_cells =
     [
       t.symbol;
@@ -163,8 +163,13 @@ let _write_trades ~output_dir ~(round_trips : Metrics.trade_metrics list)
   fprintf oc "%s\n" _trades_csv_header;
   let stop_index = ref (_build_stop_index stop_infos) in
   let force_liq_index = _build_force_liq_index force_liquidations in
+  (* Build the audit + stop-log indexes once, not per row. Without this hoist,
+     [Trade_context.of_audit_and_stop_log] rebuilt the audit_idx Map every
+     call — turning [trades.csv] writing into O(N²) on Cell E 15 y
+     (~3 700 round-trips × ~3 700 audit records). *)
+  let ctx_pre = Trade_context.precompute ~audit ~stop_infos in
   List.iter round_trips
-    ~f:(_write_trade_row oc stop_index force_liq_index ~audit ~stop_infos);
+    ~f:(_write_trade_row oc stop_index force_liq_index ~ctx_pre);
   Out_channel.close oc
 
 let _write_equity_curve ~output_dir

--- a/trading/trading/backtest/lib/trade_context.ml
+++ b/trading/trading/backtest/lib/trade_context.ml
@@ -53,24 +53,58 @@ let csv_row_fields (t : t) =
     _fmt_int_opt t.screener_score_at_entry;
   ]
 
-let _audit_index (audit : Trade_audit.audit_record list) =
+type precomputed = {
+  audit_by_key :
+    (string, Trade_audit.audit_record, String.comparator_witness) Map.t;
+  stop_by_position_id :
+    (string, Stop_log.stop_info, String.comparator_witness) Map.t;
+  stop_first_by_symbol :
+    (string, Stop_log.stop_info, String.comparator_witness) Map.t;
+}
+
+let _audit_key ~symbol ~entry_date = symbol ^ "|" ^ Date.to_string entry_date
+
+let _build_audit_by_key (audit : Trade_audit.audit_record list) =
   List.fold audit
     ~init:(Map.empty (module String))
     ~f:(fun acc (record : Trade_audit.audit_record) ->
       let key =
-        record.entry.symbol ^ "|" ^ Date.to_string record.entry.entry_date
+        _audit_key ~symbol:record.entry.symbol
+          ~entry_date:record.entry.entry_date
       in
       Map.set acc ~key ~data:record)
 
-let _stop_info_for ~position_id ~symbol (stop_infos : Stop_log.stop_info list) :
+let _build_stop_by_position_id (stop_infos : Stop_log.stop_info list) =
+  List.fold stop_infos
+    ~init:(Map.empty (module String))
+    ~f:(fun acc (info : Stop_log.stop_info) ->
+      Map.set acc ~key:info.position_id ~data:info)
+
+(** Map symbol -> first {!Stop_log.stop_info} encountered for that symbol. The
+    fallback path in [_stop_info_for] picks the first matching info via
+    [List.find]; preserving the head-first semantics here means we only insert
+    when the key is absent. *)
+let _build_stop_first_by_symbol (stop_infos : Stop_log.stop_info list) =
+  List.fold stop_infos
+    ~init:(Map.empty (module String))
+    ~f:(fun acc (info : Stop_log.stop_info) ->
+      Map.update acc info.symbol ~f:(function
+        | Some existing -> existing
+        | None -> info))
+
+let precompute ~(audit : Trade_audit.audit_record list)
+    ~(stop_infos : Stop_log.stop_info list) : precomputed =
+  {
+    audit_by_key = _build_audit_by_key audit;
+    stop_by_position_id = _build_stop_by_position_id stop_infos;
+    stop_first_by_symbol = _build_stop_first_by_symbol stop_infos;
+  }
+
+let _stop_info_for ~position_id ~symbol (pre : precomputed) :
     Stop_log.stop_info option =
   match position_id with
-  | Some pid ->
-      List.find stop_infos ~f:(fun (info : Stop_log.stop_info) ->
-          String.equal info.position_id pid)
-  | None ->
-      List.find stop_infos ~f:(fun (info : Stop_log.stop_info) ->
-          String.equal info.symbol symbol)
+  | Some pid -> Map.find pre.stop_by_position_id pid
+  | None -> Map.find pre.stop_first_by_symbol symbol
 
 let _stop_initial_distance_pct (entry : Trade_audit.entry_decision) =
   if Float.( <= ) entry.suggested_entry 0.0 then None
@@ -85,16 +119,15 @@ let _days_to_first_stop_trigger ~(entry_date : Date.t) ~(exit_date : Date.t)
   | Some (Stop_loss _) -> Some (Date.diff exit_date entry_date)
   | _ -> None
 
-let of_audit_and_stop_log ~audit ~stop_infos
+let of_precomputed (pre : precomputed)
     ~(trade : Trading_simulation.Metrics.trade_metrics) : t =
-  let audit_idx = _audit_index audit in
-  let key = trade.symbol ^ "|" ^ Date.to_string trade.entry_date in
-  let audit_record = Map.find audit_idx key in
+  let key = _audit_key ~symbol:trade.symbol ~entry_date:trade.entry_date in
+  let audit_record = Map.find pre.audit_by_key key in
   let entry =
     Option.map audit_record ~f:(fun (r : Trade_audit.audit_record) -> r.entry)
   in
   let position_id = Option.map entry ~f:(fun e -> e.position_id) in
-  let stop_info = _stop_info_for ~position_id ~symbol:trade.symbol stop_infos in
+  let stop_info = _stop_info_for ~position_id ~symbol:trade.symbol pre in
   let entry_stage = Option.map entry ~f:(fun e -> stage_label e.stage) in
   let entry_volume_ratio = Option.bind entry ~f:(fun e -> e.volume_ratio) in
   let stop_initial_distance_pct =
@@ -127,3 +160,12 @@ let of_audit_and_stop_log ~audit ~stop_infos
     days_to_first_stop_trigger;
     screener_score_at_entry;
   }
+
+(** Convenience wrapper: builds [precomputed] inline. Per-trade callers in a
+    loop should use [precompute] + [of_precomputed] directly to avoid rebuilding
+    the indexes every call (the original O(N²) regression on Cell E 15 y came
+    from this site rebuilding [audit_idx] per trade row). *)
+let of_audit_and_stop_log ~audit ~stop_infos
+    ~(trade : Trading_simulation.Metrics.trade_metrics) : t =
+  let pre = precompute ~audit ~stop_infos in
+  of_precomputed pre ~trade

--- a/trading/trading/backtest/lib/trade_context.mli
+++ b/trading/trading/backtest/lib/trade_context.mli
@@ -65,19 +65,37 @@ val csv_row_fields : t -> string list
     verbatim. [None] renders as the empty cell — consumers must tolerate empty
     cells (the canonical M5.2e missing-data sentinel). *)
 
+type precomputed
+(** Index bundle amortising the audit + stop-log scans across many trades.
+
+    {!of_audit_and_stop_log} rebuilt the audit index per trade — at Cell E 15 y
+    scale (~3 700 round-trips × ~3 700 audit records) the per-row build pushed
+    [trades.csv] writing into O(N²). Loop callers must hoist {!precompute}
+    outside the iter and feed each iteration via {!of_precomputed}. *)
+
+val precompute :
+  audit:Trade_audit.audit_record list ->
+  stop_infos:Stop_log.stop_info list ->
+  precomputed
+(** Build the index bundle once. O(N) over the audit + stop-log lists. The
+    by-symbol stop-log fallback preserves the head-first semantics of the legacy
+    [List.find]: when multiple [stop_info]s share a symbol, the first one in the
+    input list wins. *)
+
+val of_precomputed :
+  precomputed -> trade:Trading_simulation.Metrics.trade_metrics -> t
+(** Compute the context row for a single trade against pre-built indexes.
+    Field-population semantics match {!of_audit_and_stop_log}. O(log N) per call
+    (Map lookups). *)
+
 val of_audit_and_stop_log :
   audit:Trade_audit.audit_record list ->
   stop_infos:Stop_log.stop_info list ->
   trade:Trading_simulation.Metrics.trade_metrics ->
   t
-(** Compute the context row for a single trade by joining [audit] and
-    [stop_infos] on [(symbol, entry_date)] / [position_id].
-
-    The trade is matched to its audit record by [(symbol, entry_date)] — the
-    same key {!Trade_audit_report} uses. Once an audit record is found, its
-    [position_id] keys the {!Stop_log.stop_info} lookup; if no audit record
-    matches, the stop-log lookup falls back to a by-symbol scan picking the
-    first matching info.
+(** Convenience wrapper: builds {!precomputed} inline and projects one trade.
+    Useful for tests or one-shot callers; in a per-trade loop prefer
+    {!precompute} + {!of_precomputed} to amortise the index build.
 
     Each of the 6 fields populates independently:
     - Missing audit record → [entry_stage], [entry_volume_ratio],


### PR DESCRIPTION
## Summary

\`Result_writer._write_trades\` iterates over every closed round-trip and, on each iteration, called \`Trade_context.of_audit_and_stop_log\` which **rebuilt the audit \`Map\` from scratch** plus did an O(N) \`List.find\` over the stop-log list. End-of-run trades.csv writing was therefore O(N²) on trade count.

This PR introduces a \`Trade_context.precomputed\` index bundle, builds it once outside the iter, and feeds each row via the new \`of_precomputed\`. Sister fix to #1014 (per-cycle simulation hotspot).

## Why

On the partial Cell E 15 y run (~1 994 trades by mid-2018, ~3 700 projected total) the trades.csv writer alone would do ~14 M Map.set ops + ~14 M List.find scans just to emit the per-trade context columns. After this hoist: ~3 700 Map.set + 3 700 O(log N) Map.find lookups — i.e. linear instead of quadratic.

This is end-of-run cost (not per-cycle), so it doesn't explain the cycle-decay observed during simulation (#1007) — that's #1014's surface. But it compounds at scale: at Cell E 15 y, end-of-run analytics + writers can themselves take many minutes once trade count is large.

## What changes

- \`trade_context.mli\`:
  - New opaque \`type precomputed\`.
  - New \`val precompute : audit:... -> stop_infos:... -> precomputed\`.
  - New \`val of_precomputed : precomputed -> trade:... -> t\`.
  - Existing \`of_audit_and_stop_log\` retained as a one-shot convenience (calls \`precompute\` then \`of_precomputed\`); docstring directs loop callers to the new entry points.
- \`trade_context.ml\`:
  - \`precomputed\` bundles three indexes: \`audit_by_key\` (symbol|entry_date → audit_record), \`stop_by_position_id\` (position_id → stop_info), \`stop_first_by_symbol\` (symbol → first stop_info — preserves head-first semantics of the legacy \`List.find\` fallback).
  - \`_stop_info_for\` now hits the precomputed indexes — O(log N) lookup instead of O(N) scan.
- \`result_writer.ml\`:
  - \`_write_trades\` calls \`Trade_context.precompute\` once before \`List.iter round_trips\`.
  - \`_write_trade_row\` takes \`~ctx_pre\` and calls \`Trade_context.of_precomputed\` per row.

## Behavioral preservation

- The by-symbol stop-log fallback uses \`Map.update ~f:(function Some existing -> existing | None -> info)\` so the first \`stop_info\` for a symbol wins — matching the legacy \`List.find\` behavior, which returned the first list-order match.
- Field-population semantics are unchanged: missing audit record → audit-derived fields all \`None\`; missing stop-log → trigger fields \`None\`.
- Existing \`of_audit_and_stop_log\` delegates to the new path, so test callers (which use it directly) exercise the same code with one-shot index construction.

## Test plan

- [x] \`dune build\` clean.
- [x] \`dune runtest --force\` clean (full suite, exit 0; 232 \`OK\` blocks, 0 FAILs).
- [x] Existing \`test_trade_context.ml\` exercises the new path end-to-end via \`of_audit_and_stop_log\`.

## Pairs with

- #1014 — \`fix(portfolio): prepend trades to trade_history (O(N²) → O(N))\`. Together they kill the two big O(N²) hotspots on Cell E 15 y backtests called out in \`dev/notes/cell-e-15y-engineering-blocker-2026-05-09.md\`.