### PR TITLE
feat(all-eligible): wire runner into scenario_runner per-scenario post-step

### DIFF
--- a/dev/status/all-eligible.md
+++ b/dev/status/all-eligible.md
@@ -1,11 +1,12 @@
 # Status: all-eligible
 
-## Last updated: 2026-05-09
+## Last updated: 2026-05-10
 
 ## Status
-IN_PROGRESS
+READY_FOR_REVIEW
 
-(PR-1 merged #899; PR-2 CLI merged #901; **PR-3 release-report wiring is the next dispatchable item**)
+(PR-1 merged #899; PR-2 CLI merged #901; **PR-3 release-report wiring on
+`feat/all-eligible-release-report` — ready for review**)
 
 ## Interface stable
 NO
@@ -41,16 +42,6 @@ natural exit. Produces per-trade alpha + aggregate stats so we can separate
 
 ## Open work
 
-**Next dispatchable (P0):** PR-3 release-report wiring — owner: feat-backtest.
-
-- [ ] **PR-3 wiring** — invoke `all_eligible_runner.exe` from the
-  release-report pipeline (or scenario_runner post-step) so every backtest
-  produces the diagnostic without manual invocation. Plan: add a
-  post-backtest step in the release-report pipeline that calls the runner
-  with the same `--scenario` + an `all_eligible/` subdirectory under the
-  report out-dir; gate behind a config flag (`emit_all_eligible : bool`,
-  default `true`); pin via a smoke-scenario integration test that asserts
-  the three-file emission. ~150 LOC + 2-3 tests.
 - [ ] Hand-crafted Stage-1→2 breakout fixture for content tests of the
   smoke suite (current smoke uses flat-price bars ⇒ zero breakouts ⇒
   pins runner shape but not alpha math). Currently a deferred follow-up
@@ -78,6 +69,20 @@ natural exit. Produces per-trade alpha + aggregate stats so we can separate
   $10K-per-signal sizing (negative all-eligible alpha across the
   universe — informs the "screener cascade is keeping the average
   signal out" hypothesis).
+- 2026-05-10 — **PR-3 release-report wiring** READY_FOR_REVIEW on
+  `feat/all-eligible-release-report` (`6eb8d6d`).
+  `Backtest_all_eligible.Scenario_post_step.emit` facade + `scenario_runner`
+  wiring so every per-scenario child writes
+  `<scenario_dir>/all_eligible/grade-C/{trades.csv,summary.md,config.sexp}`
+  alongside its existing `actual.sexp` / `summary.sexp` artefacts.
+  Gated by `--no-emit-all-eligible` flag (default: emit on). Three pinning
+  tests cover enabled/disabled/failure-isolation under
+  `trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml`.
+  Diagnostic failures inside the runner are logged + swallowed so a crash
+  never aborts the parent backtest. Verify:
+  ```bash
+  dune runtest trading/trading/backtest/all_eligible
+  ```
 
 ## Verify
 

--- a/trading/trading/backtest/all_eligible/bin/test/dune
+++ b/trading/trading/backtest/all_eligible/bin/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_all_eligible_runner)
+ (names test_all_eligible_runner test_scenario_post_step)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml
+++ b/trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml
@@ -1,0 +1,190 @@
+(** Integration tests for [Backtest_all_eligible.Scenario_post_step.emit] — the
+    per-scenario hook the [scenario_runner] executable calls after writing
+    [actual.sexp] / [summary.sexp].
+
+    These tests stage the same flat-price synthetic fixture used by
+    [test_all_eligible_runner] (so they're robust to scanner / scorer drift) and
+    pin the wiring contract:
+
+    - [enabled = true] → [<scenario_dir>/all_eligible/grade-C/] gets the three
+      runner artefacts ([trades.csv], [summary.md], [config.sexp]).
+    - [enabled = false] → no [all_eligible] subdir is created at all (so the
+      [scenario_runner --no-emit-all-eligible] flag is a real no-op).
+
+    The flat-price fixture yields [trade_count = 0]; what we assert is the
+    {b emission shape}, not strategy outcomes. *)
+
+open Core
+open OUnit2
+open Matchers
+module Post_step = Backtest_all_eligible.Scenario_post_step
+
+(* ------------------------------------------------------------------ *)
+(* Fixture builders — mirror of test_all_eligible_runner.ml's helpers.  *)
+(* Kept local so the test is self-contained and the flat-price scenario *)
+(* is identical (so a regression in the post-step hook is bisectable    *)
+(* against the runner's own smoke tests).                                *)
+(* ------------------------------------------------------------------ *)
+
+let _make_bar ~date ~close () : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close;
+    low_price = close;
+    close_price = close;
+    volume = 1_000;
+    adjusted_close = close;
+  }
+
+let _flat_bars ~start ~end_ ~close : Types.Daily_price.t list =
+  let rec loop d acc =
+    if Date.( > ) d end_ then List.rev acc
+    else
+      let dow = Date.day_of_week d in
+      let is_weekend =
+        Day_of_week.equal dow Day_of_week.Sat
+        || Day_of_week.equal dow Day_of_week.Sun
+      in
+      let acc' =
+        if is_weekend then acc else _make_bar ~date:d ~close () :: acc
+      in
+      loop (Date.add_days d 1) acc'
+  in
+  loop start []
+
+let _write_symbol_csv ~data_dir ~symbol prices =
+  match Csv.Csv_storage.create ~data_dir symbol with
+  | Error err ->
+      assert_failure (Printf.sprintf "csv create: %s" err.Status.message)
+  | Ok storage -> (
+      match Csv.Csv_storage.save storage prices with
+      | Error err ->
+          assert_failure (Printf.sprintf "csv save: %s" err.Status.message)
+      | Ok () -> ())
+
+let _stage_fixture ~data_dir : string =
+  let bench_bars =
+    _flat_bars
+      ~start:(Date.of_string "2023-06-01")
+      ~end_:(Date.of_string "2024-03-01")
+      ~close:4500.0
+  in
+  let sym_bars =
+    _flat_bars
+      ~start:(Date.of_string "2023-06-01")
+      ~end_:(Date.of_string "2024-03-01")
+      ~close:100.0
+  in
+  _write_symbol_csv ~data_dir ~symbol:"GSPC.INDX" bench_bars;
+  _write_symbol_csv ~data_dir ~symbol:"AAA" sym_bars;
+  let bs_dir = Fpath.(to_string (data_dir / "backtest_scenarios")) in
+  let universes_dir = Filename.concat bs_dir "universes" in
+  Core_unix.mkdir_p universes_dir;
+  let universe_path = Filename.concat universes_dir "test.sexp" in
+  Out_channel.write_all universe_path
+    ~data:"(Pinned (((symbol AAA) (sector \"Information Technology\"))))\n";
+  let scenario_path = Filename.concat bs_dir "test_post_step.sexp" in
+  let scenario_body =
+    "((name \"test_post_step\")\n\
+    \ (description \"Post-step smoke fixture\")\n\
+    \ (period ((start_date 2024-01-05) (end_date 2024-02-23)))\n\
+    \ (universe_path \"universes/test.sexp\")\n\
+    \ (config_overrides ())\n\
+    \ (expected\n\
+    \  ((total_return_pct ((min -100.0) (max 100.0)))\n\
+    \   (total_trades ((min 0) (max 10)))\n\
+    \   (win_rate ((min 0.0) (max 100.0)))\n\
+    \   (sharpe_ratio ((min -10.0) (max 10.0)))\n\
+    \   (max_drawdown_pct ((min 0.0) (max 100.0)))\n\
+    \   (avg_holding_days ((min 0.0) (max 1000.0))))))\n"
+  in
+  Out_channel.write_all scenario_path ~data:scenario_body;
+  scenario_path
+
+let _with_data_dir ~data_dir f =
+  let prev = Sys.getenv "TRADING_DATA_DIR" in
+  Core_unix.putenv ~key:"TRADING_DATA_DIR" ~data:(Fpath.to_string data_dir);
+  Exn.protect ~f ~finally:(fun () ->
+      match prev with
+      | Some v -> Core_unix.putenv ~key:"TRADING_DATA_DIR" ~data:v
+      | None -> Core_unix.unsetenv "TRADING_DATA_DIR")
+
+let _mk_tmpdirs prefix =
+  let data_dir = Fpath.v (Core_unix.mkdtemp ("/tmp/" ^ prefix ^ "_data_")) in
+  let scenario_dir = Core_unix.mkdtemp ("/tmp/" ^ prefix ^ "_sd_") in
+  (data_dir, scenario_dir)
+
+(* ------------------------------------------------------------------ *)
+(* Tests                                                                *)
+(* ------------------------------------------------------------------ *)
+
+(** Pins the [enabled = true] wiring: the post-step writes
+    [<scenario_dir>/all_eligible/grade-C/{trades.csv,summary.md,config.sexp}].
+    These three artefacts are the contract [release_report.load_scenario_run]
+    will consume in a future follow-up. *)
+let test_emit_enabled_writes_three_artefacts _ =
+  let data_dir, scenario_dir = _mk_tmpdirs "post_step_on" in
+  let scenario_path = _stage_fixture ~data_dir in
+  _with_data_dir ~data_dir (fun () ->
+      Post_step.emit ~enabled:true ~scenario_path ~scenario_dir);
+  let cell =
+    Filename.concat (Filename.concat scenario_dir "all_eligible") "grade-C"
+  in
+  let trades = Filename.concat cell "trades.csv" in
+  let summary = Filename.concat cell "summary.md" in
+  let config = Filename.concat cell "config.sexp" in
+  assert_that
+    ( Sys_unix.file_exists_exn trades,
+      Sys_unix.file_exists_exn summary,
+      Sys_unix.file_exists_exn config )
+    (all_of
+       [
+         field (fun (t, _, _) -> t) (equal_to true);
+         field (fun (_, s, _) -> s) (equal_to true);
+         field (fun (_, _, c) -> c) (equal_to true);
+       ])
+
+(** Pins the [enabled = false] wiring: no [all_eligible] subdir is created. This
+    is the contract behind [scenario_runner.exe --no-emit-all-eligible]:
+    operators sweeping perf or running quick smoke pipelines must be able to
+    suppress the diagnostic without paying its scan + score cost or its on-disk
+    footprint. *)
+let test_emit_disabled_creates_no_subdir _ =
+  let data_dir, scenario_dir = _mk_tmpdirs "post_step_off" in
+  let scenario_path = _stage_fixture ~data_dir in
+  _with_data_dir ~data_dir (fun () ->
+      Post_step.emit ~enabled:false ~scenario_path ~scenario_dir);
+  let all_eligible_dir = Filename.concat scenario_dir "all_eligible" in
+  assert_that (Sys_unix.file_exists_exn all_eligible_dir) (equal_to false)
+
+(** Pins the failure-isolation contract: a runner failure (here triggered by
+    pointing at a nonexistent scenario sexp) is logged + swallowed, never raised
+    — so a host scenario_runner fork is never aborted by the diagnostic
+    side-effect. *)
+let test_emit_swallows_runner_failure _ =
+  let scenario_dir = Core_unix.mkdtemp "/tmp/post_step_fail_sd_" in
+  (* No fixture staged — the scenario path is bogus, [Scenario.load] will
+     raise inside the runner. The post-step's try/with must catch it. *)
+  let bogus_scenario_path = "/tmp/nonexistent-post-step-scenario.sexp" in
+  let raised =
+    try
+      Post_step.emit ~enabled:true ~scenario_path:bogus_scenario_path
+        ~scenario_dir;
+      false
+    with _ -> true
+  in
+  assert_that raised (equal_to false)
+
+let suite =
+  "Scenario_post_step"
+  >::: [
+         "emit enabled writes three artefacts under all_eligible/grade-C"
+         >:: test_emit_enabled_writes_three_artefacts;
+         "emit disabled creates no all_eligible subdir"
+         >:: test_emit_disabled_creates_no_subdir;
+         "emit swallows runner failures (does not raise)"
+         >:: test_emit_swallows_runner_failure;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/all_eligible/lib/scenario_post_step.ml
+++ b/trading/trading/backtest/all_eligible/lib/scenario_post_step.ml
@@ -1,0 +1,39 @@
+(** All-eligible scenario post-step — see [scenario_post_step.mli] for the API
+    contract. *)
+
+open Core
+
+(** Subdir leaf under [scenario_dir] where the all-eligible runner writes its
+    per-cell artefacts. The runner itself is responsible for creating
+    [grade-<G>/] cells inside this directory. *)
+let _all_eligible_subdir = "all_eligible"
+
+(** Build the [All_eligible_runner.cli_args] passed to
+    [All_eligible_runner.run_with_args]. We pin
+    [out_dir = Some <scenario_dir>/all_eligible] so the runner skips its default
+    [dev/all_eligible/<name>/<UTC>/] timestamp path. All other knobs are left at
+    library defaults so the per-scenario emission is reproducible across runs
+    (the host scenario_runner doesn't accept all-eligible-specific tuning
+    flags). *)
+let _make_runner_args ~scenario_path ~all_eligible_dir :
+    All_eligible_runner.cli_args =
+  {
+    scenario_path;
+    out_dir = Some all_eligible_dir;
+    entry_dollars = None;
+    return_buckets = None;
+    min_grade = None;
+    grade_sweep = false;
+    config_overrides = [];
+  }
+
+let emit ~enabled ~scenario_path ~scenario_dir =
+  if not enabled then ()
+  else
+    let all_eligible_dir = Filename.concat scenario_dir _all_eligible_subdir in
+    Core_unix.mkdir_p all_eligible_dir;
+    let args = _make_runner_args ~scenario_path ~all_eligible_dir in
+    try All_eligible_runner.run_with_args args
+    with e ->
+      eprintf "all_eligible post-step: scenario:%s failed: %s\n%!" scenario_path
+        (Exn.to_string e)

--- a/trading/trading/backtest/all_eligible/lib/scenario_post_step.mli
+++ b/trading/trading/backtest/all_eligible/lib/scenario_post_step.mli
@@ -1,0 +1,57 @@
+(** Per-scenario post-step that invokes {!All_eligible_runner.run_with_args} so
+    every backtest scenario emits the all-eligible diagnostic alongside its
+    [actual.sexp] / [summary.sexp] artefacts.
+
+    Called from [scenario_runner.exe] after the per-scenario
+    {!Backtest.Result_writer.write} + [actual.sexp] writes complete. The runner
+    is invoked in single-cell mode with library defaults; the artefacts land
+    under [<scenario_dir>/all_eligible/grade-C/].
+
+    Layout produced under [scenario_dir]:
+
+    {v
+    <scenario_dir>/
+      actual.sexp           — written by scenario_runner
+      summary.sexp          — written by Backtest.Result_writer
+      all_eligible/
+        grade-C/            — default min-grade cell from
+                              All_eligible.default_config
+          trades.csv
+          summary.md
+          config.sexp
+    v}
+
+    {1 Failure isolation}
+
+    {!emit} wraps the all-eligible run in [try/with]. A failure (missing CSV
+    bars, snapshot construction error, scanner crash) is logged to [stderr] and
+    swallowed — the diagnostic is purely informational and must never abort the
+    parent scenario's backtest. The host scenario_runner has already written
+    [actual.sexp] / [summary.sexp] before this hook runs, so a failure here
+    leaves those upstream artefacts intact.
+
+    {1 Disabled mode}
+
+    When [enabled = false] the function is a no-op: no directory is created, no
+    runner is invoked. This is the toggle the
+    [scenario_runner.exe --no-emit-all-eligible] flag flips. *)
+
+val emit : enabled:bool -> scenario_path:string -> scenario_dir:string -> unit
+(** [emit ~enabled ~scenario_path ~scenario_dir] writes the all-eligible
+    diagnostic under [scenario_dir/all_eligible/] when [enabled = true].
+
+    Parameters:
+    - [enabled] — gate flag. When [false], the function returns immediately
+      without invoking the runner or creating the [all_eligible] subdir.
+    - [scenario_path] — absolute path to the scenario sexp file. The runner
+      re-loads it (cheap; sexp-only).
+    - [scenario_dir] — the per-scenario output directory the host scenario
+      runner already populated with [actual.sexp] / [summary.sexp].
+
+    Side effects (when [enabled = true]):
+    - Creates [scenario_dir/all_eligible/].
+    - Invokes {!All_eligible_runner.run_with_args} in single-cell mode with
+      [out_dir = scenario_dir/all_eligible/] and the library default config. The
+      runner emits [grade-C/{trades.csv,summary.md,config.sexp}].
+    - On any [Failure] / exception from the runner, logs the message to [stderr]
+      with a [scenario:] tag and returns normally (does not raise). *)

--- a/trading/trading/backtest/scenarios/dune
+++ b/trading/trading/backtest/scenarios/dune
@@ -21,6 +21,7 @@
   trading.simulation
   trading.simulation.types
   backtest
+  backtest_all_eligible
   scenario_lib)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -4,6 +4,7 @@
     Usage: scenario_runner
     [--goldens-small | --goldens-broad | --goldens | --smoke | --dir <path>]
     [--parallel N] [--fixtures-root <path>] [--progress-every N]
+    [--no-emit-all-eligible]
 
     [--goldens-small] — small-universe goldens (~300 symbols; local-friendly).
     [--goldens-broad] — broad-universe goldens (full sector-map; nightly/GHA).
@@ -21,6 +22,15 @@
     multi-hour multi-scenario runs (e.g. 15y SP500, broad-10k 10y) emit
     checkpoints by default. Mirrors the [backtest_runner.exe --progress-every]
     flag from PR #820, but threads one emitter per scenario into each child.
+
+    [--no-emit-all-eligible] — disable the per-scenario all-eligible diagnostic
+    post-step. By default, after each child writes [actual.sexp] /
+    [summary.sexp], the runner invokes
+    {!Backtest_all_eligible.Scenario_post_step.emit} to produce
+    [<scenario_dir>/all_eligible/grade-C/{trades.csv,summary.md,config.sexp}] —
+    a per-trade alpha snapshot of every Stage-1→2 breakout that fired across the
+    run window. Use [--no-emit-all-eligible] to suppress for perf sweeps / quick
+    smoke pipelines that don't want to pay the diagnostic's scan + score cost.
 
     Reads all *.sexp files from the selected directory, runs each via
     {!Backtest.Runner.run_backtest}, prints a pass/fail table, and writes
@@ -217,7 +227,7 @@ let _actual_path ~output_root (s : Scenario.t) =
 (* Run one scenario inside a child process *)
 
 let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
-    (s : Scenario.t) =
+    ~emit_all_eligible ~scenario_path (s : Scenario.t) =
   eprintf "\n>>> Running %s: %s (%s to %s)\n%!" s.name s.description
     (Date.to_string s.period.start_date)
     (Date.to_string s.period.end_date);
@@ -236,7 +246,14 @@ let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
   in
   Backtest.Result_writer.write ~output_dir:scenario_dir result;
   let a = _actual_of_result result in
-  Sexp.save_hum (_actual_path ~output_root s) (sexp_of_actual a)
+  Sexp.save_hum (_actual_path ~output_root s) (sexp_of_actual a);
+  (* Post-step: emit the all-eligible diagnostic alongside actual.sexp /
+     summary.sexp so every scenario surfaces raw-signal alpha without manual
+     [all_eligible_runner.exe] invocation. Failures inside the runner are
+     logged + swallowed by [Scenario_post_step.emit] so a diagnostic crash
+     never aborts the parent scenario. *)
+  Backtest_all_eligible.Scenario_post_step.emit ~enabled:emit_all_eligible
+    ~scenario_path ~scenario_dir
 
 (* Fork-based worker pool. Scenarios run in parallel child processes up to
    [parallel] at a time. *)
@@ -254,12 +271,13 @@ let _write_crashed_actual ~output_root (s : Scenario.t) ~msg =
     (_actual_path ~output_root s)
     (sexp_of_actual (_crashed_actual ~msg))
 
-let _fork_scenario ~output_root ~fixtures_root ~progress_every (s : Scenario.t)
-    =
+let _fork_scenario ~output_root ~fixtures_root ~progress_every
+    ~emit_all_eligible ~scenario_path (s : Scenario.t) =
   match Core_unix.fork () with
   | `In_the_child -> (
       try
-        _run_scenario_in_child ~output_root ~fixtures_root ~progress_every s;
+        _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
+          ~emit_all_eligible ~scenario_path s;
         Stdlib.exit 0
       with e ->
         let msg = Exn.to_string e in
@@ -283,7 +301,8 @@ let _await_one running =
   match Core_unix.waitpid pid with Ok () -> Succeeded | Error _ -> Crashed
 
 let _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
-    ~progress_every (scenarios : Scenario.t list) =
+    ~progress_every ~emit_all_eligible (scenarios : (string * Scenario.t) list)
+    =
   let running = Queue.create () in
   let statuses = Hashtbl.create (module String) in
   let reap () =
@@ -292,14 +311,17 @@ let _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
     let status = _await_one running in
     Hashtbl.set statuses ~key:s.Scenario.name ~data:status
   in
-  List.iter scenarios ~f:(fun s ->
+  List.iter scenarios ~f:(fun (scenario_path, s) ->
       if Queue.length running >= parallel then reap ();
-      let pid = _fork_scenario ~output_root ~fixtures_root ~progress_every s in
+      let pid =
+        _fork_scenario ~output_root ~fixtures_root ~progress_every
+          ~emit_all_eligible ~scenario_path s
+      in
       Queue.enqueue running (s, pid));
   while not (Queue.is_empty running) do
     reap ()
   done;
-  List.map scenarios ~f:(fun s ->
+  List.map scenarios ~f:(fun (_, s) ->
       let status =
         Hashtbl.find statuses s.Scenario.name |> Option.value ~default:Crashed
       in
@@ -343,6 +365,14 @@ type _cli_args = {
          defaults to [Scenario_progress.default_every_n_fridays] (≈ monthly)
          when [--progress-every] is omitted, so the long-running multi-scenario
          exe gets recoverability by default. *)
+  emit_all_eligible : bool;
+      (* When [true] (the default), each scenario's child process invokes
+         [Backtest_all_eligible.Scenario_post_step.emit] after writing
+         actual.sexp, producing
+         [<scenario_dir>/all_eligible/grade-C/{trades.csv,summary.md,config.sexp}].
+         The [--no-emit-all-eligible] flag flips this off for perf sweeps /
+         quick smoke pipelines that don't want to pay the diagnostic's scan +
+         score cost. *)
 }
 
 let _default_parallel = 4
@@ -351,7 +381,7 @@ let _usage () =
   eprintf
     "Usage: scenario_runner [--goldens-small | --goldens-broad | --goldens | \
      --smoke | --dir <path>] [--parallel N] [--fixtures-root <path>] \
-     [--progress-every N]\n";
+     [--progress-every N] [--no-emit-all-eligible]\n";
   Stdlib.exit 1
 
 let _parse_progress_every n_str =
@@ -362,7 +392,8 @@ let _parse_progress_every n_str =
       Stdlib.exit 1
 
 let _parse_flag args =
-  let rec loop args dir parallel fixtures_root progress_every =
+  let rec loop args dir parallel fixtures_root progress_every emit_all_eligible
+      =
     match args with
     | [] ->
         let dir = Option.value dir ~default:(_goldens_small_dir ()) in
@@ -373,39 +404,51 @@ let _parse_flag args =
           progress_every =
             Option.value progress_every
               ~default:Scenario_progress.default_every_n_fridays;
+          emit_all_eligible;
         }
     | "--goldens-small" :: rest ->
         loop rest
           (Some (_goldens_small_dir ()))
-          parallel fixtures_root progress_every
+          parallel fixtures_root progress_every emit_all_eligible
     | "--goldens-broad" :: rest ->
         loop rest
           (Some (_goldens_broad_dir ()))
-          parallel fixtures_root progress_every
+          parallel fixtures_root progress_every emit_all_eligible
     | "--goldens" :: rest ->
         loop rest
           (Some (_goldens_small_dir ()))
-          parallel fixtures_root progress_every
+          parallel fixtures_root progress_every emit_all_eligible
     | "--smoke" :: rest ->
-        loop rest (Some (_smoke_dir ())) parallel fixtures_root progress_every
+        loop rest
+          (Some (_smoke_dir ()))
+          parallel fixtures_root progress_every emit_all_eligible
     | "--dir" :: path :: rest ->
         loop rest (Some path) parallel fixtures_root progress_every
+          emit_all_eligible
     | "--parallel" :: n :: rest ->
-        loop rest dir (Some (Int.of_string n)) fixtures_root progress_every
+        loop rest dir
+          (Some (Int.of_string n))
+          fixtures_root progress_every emit_all_eligible
     | "--fixtures-root" :: path :: rest ->
-        loop rest dir parallel (Some path) progress_every
+        loop rest dir parallel (Some path) progress_every emit_all_eligible
     | "--progress-every" :: n :: rest ->
-        loop rest dir parallel fixtures_root (Some (_parse_progress_every n))
+        loop rest dir parallel fixtures_root
+          (Some (_parse_progress_every n))
+          emit_all_eligible
+    | "--no-emit-all-eligible" :: rest ->
+        loop rest dir parallel fixtures_root progress_every false
     | _ -> _usage ()
   in
-  loop args None None None None
+  loop args None None None None true
 
 let _parse_args () =
   let argv = Sys.get_argv () in
   _parse_flag (List.tl_exn (Array.to_list argv))
 
 let () =
-  let { dir; parallel; fixtures_root; progress_every } = _parse_args () in
+  let { dir; parallel; fixtures_root; progress_every; emit_all_eligible } =
+    _parse_args ()
+  in
   let fixtures_root = Fixtures_root.resolve ?fixtures_root () in
   let files = _list_scenario_files dir in
   if List.is_empty files then (
@@ -417,12 +460,16 @@ let () =
   eprintf "Fixtures root: %s\n%!" fixtures_root;
   eprintf "Progress emission: every %d Friday cycle(s) per scenario\n%!"
     progress_every;
-  let scenarios = List.map files ~f:Scenario.load in
+  eprintf "All-eligible diagnostic: %s\n%!"
+    (if emit_all_eligible then "enabled" else "disabled");
+  let scenarios_with_paths =
+    List.map files ~f:(fun file -> (file, Scenario.load file))
+  in
   let output_root = _make_output_root () in
   eprintf "Output root: %s\n%!" output_root;
   let results =
     _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
-      ~progress_every scenarios
+      ~progress_every ~emit_all_eligible scenarios_with_paths
   in
   _print_header ();
   let pass_flags = List.map results ~f:(_process_result ~output_root) in


### PR DESCRIPTION
## Summary

- New `Backtest_all_eligible.Scenario_post_step.emit` thin facade over `All_eligible_runner.run_with_args`. Pinned to single-cell mode (grade-C default) with library-default config.
- `scenario_runner` invokes the post-step inside each per-scenario child after writing `actual.sexp` / `summary.sexp`, producing `<scenario_dir>/all_eligible/grade-C/{trades.csv,summary.md,config.sexp}` alongside existing artefacts.
- New `--no-emit-all-eligible` CLI flag (default: emit on) suppresses the diagnostic for perf sweeps / quick smoke pipelines.
- Failure isolation: any runner exception is logged to stderr and swallowed so the diagnostic never aborts the parent backtest.

Closes PR-3 of the all-eligible track per `dev/status/all-eligible.md`. The three remaining open items (Stage-1->2 fixture, shared orchestration helpers, `--config-overrides` thread-through) are explicitly out of scope.

## Test plan

- [x] `dune build` clean (no warnings).
- [x] `dune runtest` green — full repo, including the 3 new pinning tests.
- [x] `dune build @fmt` clean.
- [x] All linters pass (file-length, mli-coverage, magic-numbers, fn-length).
- [x] Three pinning tests under `trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml`:
  - `enabled=true` writes the three artefacts under `<scenario_dir>/all_eligible/grade-C/`
  - `enabled=false` creates no `all_eligible` subdir at all
  - runner failure is swallowed (does not raise)

## Diff size

- 357 additions across 6 files; ~190 LOC are tests, ~140 LOC source, ~12 LOC dune/docs. Within ~250 LOC + tests budget.
- One new module (`Scenario_post_step`); no changes to `weinstein_strategy.ml`, core stop-machine code, or the `All_eligible_runner` lib / CLI surface.

## Follow-ups

Not in this PR (tracked in `dev/status/all-eligible.md` Open work):
- Hand-crafted Stage-1->2 breakout fixture for content tests of the smoke suite.
- Shared snapshot-orchestration helpers extracted from `Optimal_strategy_runner` and `All_eligible_runner`.
- `--config-overrides` thread-through into the scanner config.
- Optionally extending `release_report.load_scenario_run` to surface the new artefact in the comparison markdown — kept as a deferred bullet since the artefact format is now durable.
