### PR TITLE
fix(simulation): cache + avg-cost fallback in _resolve_price

### DIFF
--- a/dev/reviews/pr-1019-simulator-nav-fallback-behavioral-v2.md
+++ b/dev/reviews/pr-1019-simulator-nav-fallback-behavioral-v2.md
@@ -1,0 +1,164 @@
+Reviewed SHA: 70ab3af9f62092c9de74f41ce02e1294fbd00a4f
+
+# Behavioral QC (re-review v2) — pr-1019-simulator-nav-fallback
+Date: 2026-05-10
+Reviewer: qc-behavioral
+
+PR: https://github.com/dayfine/trading/pull/1019
+Title: fix(simulation): cache + avg-cost fallback in _resolve_price
+Branch: fix/simulator-nav-fallback
+Commits reviewed: 75cdda6b (original NAV fix) + 70ab3af9 ("Apply review: fix linter regressions in simulator.ml")
+Files changed (vs merge-base 9b3d17f6):
+  - trading/trading/simulation/lib/dune (+1)
+  - trading/trading/simulation/lib/portfolio_state_computer.ml (+11/-8 docstring update)
+  - trading/trading/simulation/lib/portfolio_valuation.ml (NEW, 87 lines)
+  - trading/trading/simulation/lib/portfolio_valuation.mli (NEW, 45 lines)
+  - trading/trading/simulation/lib/simulator.ml (+47/-71 → 436 lines, was 516)
+
+Classification: **Infrastructure / library** (pure simulator-correctness change). Per
+`.claude/rules/qc-behavioral-authority.md`, the S*/L*/C*/T* domain block does not
+apply — only CP1–CP4 contract pinning.
+
+Prior review: `pr-1019-simulator-nav-fallback-behavioral.md` (NEEDS_REWORK at
+75cdda6b due to three dune-wired linter regressions surfaced by CI: function
+length on `_process_step_day` 51>50, file length on simulator.ml 516>500,
+nesting on `_resolve_price` avg=3.17/max=7). The follow-up commit 70ab3af9
+addresses these by extracting valuation logic into a dedicated
+`Portfolio_valuation` module and extracting `_build_step_result` from
+`_process_step_day`.
+
+## Contract Pinning Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| CP1 | Each non-trivial claim in new .mli docstrings has an identified test that pins it | PARTIAL | A new `.mli` was added (`portfolio_valuation.mli`). Its primary contract is the four-tier resolution chain: (1) today's bars, (2) `Market_data_adapter.get_previous_bar`, (3) `last_known_prices` cache, (4) avg-cost. The chain claims `compute` "always returns a finite value" and "the legacy cash-only fallback should not fire". Tier (1) and tier (2) are pinned by `test_forward_fill_uses_last_known_close_when_held_symbol_has_no_bar` (test_simulator.ml:817–866) — same test that pinned the pre-extraction implementation; logic moved verbatim into `Portfolio_valuation.compute`, so the existing pin still covers tier (2). Tiers (3) cache and (4) avg-cost remain unpinned by dedicated unit tests. The cache update via `_update_cache_with_today_bars` (newly factored as a separate helper) is also unpinned. The .mli's "increments [valuation_failure_count] exactly once per (symbol, step) pair that fell through to the avg-cost last-resort" claim is unpinned. Recorded as a non-blocking FLAG below — same judgment call as v1, per the user's brief. |
+| CP2 | Each claim in PR body "Test plan" / "Test coverage" sections has a corresponding green test in CI | PASS | PR body's Test plan: "[x] `dune build` clean (no errors)" — verified locally inside docker. "[x] `dune runtest trading/simulation/` — all green" — verified locally inside docker (no diff output, all simulation tests pass including the dune-wired `fn_length_linter`, `linter_magic_numbers.sh`, `linter_mli_coverage.sh`, and `nesting_linter`). "[x] dune runtest trading/orders/ trading/engine/ trading/portfolio/ trading/strategy/ trading/backtest/ — all green" — covered by CI. CI status at 70ab3af9: `build-and-test` COMPLETED SUCCESS (workflow run 25628987441), `perf-tier1-smoke` COMPLETED SUCCESS. The remaining unchecked item ("Re-run Cell E 15y backtest — expect equity_curve.csv to match reconstructed_equity_curve.csv") is explicitly marked "tracked separately" by the author. Three previously-failing linter rows (function length / file length / nesting) are now PASS — directly verifiable: simulator.ml=436 lines (was 516), `_process_step_day`=37 lines (was 51), `_resolve_price` extracted into `portfolio_valuation.ml` and now uses `Option.first_some` to flatten the previously-nested fallback chain. |
+| CP3 | Pass-through / identity / invariant tests pin identity, not just size | NA | This PR introduces a value-resolution chain, not pass-through semantics. |
+| CP4 | Each guard called out explicitly in code docstrings has a test that exercises the guarded-against scenario | PARTIAL | Same posture as v1 with one improvement: the docstring claim "the legacy `Error _ -> portfolio.current_cash` survives only as defense-in-depth" remains by-construction unreachable (acceptable). The named-and-described scenarios for the cache tier ("held symbols whose bar dataset has gaps the adapter cannot reach — M&A delisting, dataset edges, survivor-bias purges") and the avg-cost tier ("zero-unrealized assumption — last resort when no market price has ever been seen") are still not pinned by dedicated unit tests. The new `valuation_failure_count` invariant ("incremented exactly once per (symbol, step) pair that fell through to avg-cost") is also not pinned. Treated as FLAG, not FAIL — per the user's brief: empirical Cell E 15y reconstruction is doing the end-to-end validation, deferred to a follow-up unit-test PR. harness_gap: LINTER_CANDIDATE. |
+
+## Behavioral Checklist
+
+Pure infra / simulator-correctness PR; domain checklist (S*/L*/C*/T*) not applicable.
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| A1 | Core module modification is strategy-agnostic | NA | No core-module modification: only `trading/trading/simulation/lib/` files touched (+ a one-line dune entry). The Portfolio/Orders/Position/Strategy/Engine modules are untouched. |
+| S1–S6 | Stage definitions / buy criteria | NA | Pure infra / simulator-correctness PR; domain checklist not applicable. |
+| L1–L4 | Stop-loss rules | NA | Pure infra / simulator-correctness PR; domain checklist not applicable. |
+| C1–C3 | Screener cascade | NA | Pure infra / simulator-correctness PR; domain checklist not applicable. |
+| T1–T4 | Domain test coverage | NA | Pure infra / simulator-correctness PR; domain checklist not applicable. |
+
+## Verification notes (what I checked and how)
+
+1. Re-fetched `origin/fix/simulator-nav-fallback` and pinned the review at tip
+   SHA `70ab3af9f62092c9de74f41ce02e1294fbd00a4f`.
+2. Read both new files (`portfolio_valuation.ml`, `portfolio_valuation.mli`)
+   end-to-end. The four-tier chain in the .mli docstring matches the
+   implementation:
+   - `_update_cache_with_today_bars` (tier 1 prefilling)
+   - `_from_adapter` (tier 2)
+   - `_from_cache` (tier 3)
+   - `_from_avg_cost` (tier 4 — increments `valuation_failure_count`,
+     uses `Trading_portfolio.Calculations.avg_cost_of_position`)
+   `_resolve_price` composes tiers 2+3 via `Option.first_some` and falls
+   through to tier 4 only when both return `None`. The
+   `Trading_portfolio.Calculations.avg_cost_of_position` symbol exists
+   (`trading/trading/portfolio/lib/calculations.ml:10`).
+3. Read `simulator.ml` diff (+47/-71): the entire `_compute_portfolio_value`
+   /`_prices_for_held_positions`/`_fallback_price_for_position` block is
+   removed; the call site in `_process_step_day` now invokes
+   `Portfolio_valuation.compute` with the new `~last_known_prices` and
+   `~valuation_failure_count` parameters threaded from the simulator state.
+   `_build_step_result` is extracted from `_process_step_day` (mirrors the
+   PR body's claim "extracts `_build_step_result` from `_process_step_day`").
+4. Verified field lifetimes on `t`: `last_known_prices : float String.Table.t`
+   (mutable hashtable) and `valuation_failure_count : int ref` are both shared
+   by reference across `{ t with ... }` per-step copies — confirmed by reading
+   `_advance_step` and the `create` initializer (allocated once at
+   `String.Table.create ()` / `ref 0`, never copied). The .mli claim
+   "Reference-shared across all per-step copies" is correct.
+5. Read the existing pin
+   `test_forward_fill_uses_last_known_close_when_held_symbol_has_no_bar`
+   (`test_simulator.ml:817–866`). Test setup: AAPL has bars on Jan 2 + Jan 3
+   only; on Jan 4 the broker still holds 10 shares with no bar today;
+   `portfolio_value` must equal `cash_after_buy + 10*157.0`. This still
+   exercises tier (2) of the new chain (adapter `get_previous_bar` returns
+   `Some`). Plus an additional bug-path floor pin (`gt cash_after_buy + 100`)
+   that would also catch a regression of the cache tier in the same fixture.
+6. Read `portfolio_state_computer.ml` diff: only docstring updates on the
+   `last_marked_step` field and the `_is_marked_to_market` heuristic, both
+   correctly reflecting the new fallback chain. No behavior change.
+7. Local rebuild inside docker:
+   ```
+   docker exec trading-1-dev bash -c \
+     'cd /workspaces/trading-1/trading && eval $(opam env) && dune build'
+   # → BUILD OK (only the no-dune-project-in-cwd warning)
+   docker exec trading-1-dev bash -c \
+     'cd /workspaces/trading-1/trading && eval $(opam env) && \
+      dune runtest trading/simulation/'
+   # → exit 0, no test failures, no linter regressions
+   ```
+   The previously-failing linter rows from v1 (function length, file length,
+   nesting) are all green.
+8. CI status at tip 70ab3af9 (`gh pr view 1019 --json statusCheckRollup`):
+   - `build-and-test` (workflow run 25628987441): COMPLETED, SUCCESS
+   - `perf-tier1-smoke` (workflow run 25628987439): COMPLETED, SUCCESS
+9. `dune build @fmt` reports residual diffs only in files NOT touched by this
+   PR (e.g. `analysis/weinstein/stage/lib/stage.mli`,
+   `trading/data_panel/atr_kernel.mli`, etc.) — pre-existing
+   container-vs-CI ocamlformat skew on docstring `{[ ]}` indent (per memory
+   `project_ocamlformat_version_skew.md`). Not a regression introduced by
+   this PR.
+
+## Quality Score
+
+4 — Logic of the fallback chain is sound and well-documented; the four-tier
+resolver is the right shape; the rework cleanly extracts the valuation logic
+into a dedicated module with its own .mli, which improves modularity beyond
+what would have been achieved by inline annotations. Score is held at 4 (not
+5) because the cache + avg-cost tiers — the very tiers added by this PR —
+are still not pinned by dedicated unit tests; the existing forward-fill test
+covers tier (2) but not tiers (3) or (4). The user's brief explicitly accepts
+this gap as a non-blocking FLAG, with the empirical 15y Cell E reconstruction
+serving as end-to-end validation.
+
+## Verdict
+
+APPROVED
+
+(Mechanical: CP2 = PASS, CP1/CP4 = PARTIAL but recorded as FLAG per the
+reviewer brief, not FAIL. CP3 = NA. All applicable items are PASS or NA-with-FLAG.
+The three blocking linter regressions from v1 are resolved.)
+
+## Non-blocking FLAGs (do not block merge)
+
+### FLAG: cache + avg-cost tiers lack dedicated test pins
+- Finding: The cache fallback (tier 3) and avg-cost fallback (tier 4) of
+  `Portfolio_valuation._resolve_price` are not exercised by any unit test.
+  Only tier 2 (`get_previous_bar` returning `Some`) is pinned, by
+  `test_forward_fill_uses_last_known_close_when_held_symbol_has_no_bar`.
+  The `valuation_failure_count`-incremented-exactly-once invariant from the
+  .mli docstring is also unpinned.
+- Location: `trading/trading/simulation/lib/portfolio_valuation.ml:19–21`
+  (`_from_cache`), `:24–28` (`_from_avg_cost`).
+- Authority: `portfolio_valuation.mli` lines 9–13 (the four-tier chain
+  contract) and lines 38–40 (the failure-count invariant).
+- Recommended follow-up (non-blocking):
+  1. Cache-tier test — fixture where a symbol has bars on day 1, no bars
+     for day 2 onward, and `get_previous_bar` returns `None` after day N.
+     Assert `portfolio_value` uses the cached close from day 1 on day N+1
+     and `valuation_failure_count` stays at 0.
+  2. Avg-cost-tier test — same setup but with the cache empty for the
+     symbol. Assert `valuation_failure_count` increments by exactly 1 and
+     `portfolio_value` equals `cash + qty × avg_cost`.
+- harness_gap: LINTER_CANDIDATE — both tiers can be deterministically pinned
+  with a synthetic fixture (no real-data dependency). Empirical Cell E 15y
+  reconstruction at `dev/experiments/cell-e-15y-2026-05-09/` is the
+  end-to-end validation in the meantime.
+
+### Note: Cell E 15y reconstruction parity tracked separately
+- The PR body's expected `equity_curve.csv` parity with
+  `reconstructed_equity_curve.csv` from `dev/experiments/cell-e-15y-2026-05-09/`
+  is explicitly tracked as a separate validation step. Not a behavioral
+  blocker for this PR — but if that re-run shows a divergence, the
+  follow-up unit tests above become higher-priority.

--- a/dev/reviews/pr-1021-benchmark-relative-metrics-behavioral.md
+++ b/dev/reviews/pr-1021-benchmark-relative-metrics-behavioral.md
@@ -1,0 +1,56 @@
+Reviewed SHA: d97948d599c6467af05c24a3a28a2bdaaea55f9e
+
+# Behavioral QC — pr-1021-benchmark-relative-metrics
+Date: 2026-05-10
+Reviewer: qc-behavioral
+
+## Contract Pinning Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| CP1 | Each non-trivial claim in new .mli docstrings has an identified test that pins it | PASS | Claim-to-test trace: (i) "five metrics emitted as 0.0 when no benchmark series is supplied or fewer than minimum paired samples" → `test_no_benchmark_yields_zero` (asserts all 5 metrics = 0.0 via `map_includes`) + `test_too_few_samples` (4 paired samples, < `_min_paired_samples=5`, α/β/corr=0). (ii) `BenchmarkBeta` "slope β" → `test_identical_series` (β=1±1e-6), `test_perfect_linear_2x` (β=2±1e-3), `test_zero_variance_benchmark` (β=0±1e-9 via variance gate), `test_step_sourced_benchmark` (β=1.5±1e-3 with strat=1.5·bench). (iii) `BenchmarkAlphaPctAnnualized` "α annualized × 252" → identical-series and 2× linear both pin α=0 (no constant offset); 0.0-fallback paths pinned. (iv) `CorrelationToBenchmark` "Pearson, in [-1,1]" → identical (corr=1), 2× (corr=1), zero-variance (corr=0). (v) `TrackingErrorPctAnnualized` "annualized stdev of (r_strat − r_bench) × √252" → identical-series TE=0 pinned. (vi) `InformationRatio` "α / TE" → 0.0-fallback case pinned in `test_no_benchmark_yields_zero`. The override-vs-step-sourced .mli claim ("override takes precedence over per-step `step.benchmark_return`") → `test_override_wins_over_step_benchmark` (zeros wired into step.benchmark_return, real series passed as override, β=2 confirms override wins). All non-trivial claims have at least one pinning test. |
+| CP2 | Each claim in PR body "Test plan"/"Test coverage" sections has a corresponding test | PASS | PR body's "Test plan" lists three focused-unit-test cases as a follow-up commit: "perfect-correlation, zero-correlation, no-benchmark". All three are present in the committed test file: perfect-correlation → `test_identical_series` + `test_perfect_linear_2x`; zero-correlation → `test_zero_variance_benchmark`; no-benchmark → `test_no_benchmark_yields_zero`. The PR body also notes: "All five metrics emit `0.0` when no benchmark series is supplied or fewer than five paired samples are available — matches the existing antifragility convention." Both halves pinned (`test_no_benchmark_yields_zero` and `test_too_few_samples`). The `test_metrics.ml` 11→12 default_computers count claim is satisfied by the assertion bump on line 590 (`assert_that computers (size_is 12)`). The "Computer mirrors `Antifragility_computer.computer` API (`?benchmark_returns` override)" claim is pinned by `test_override_wins_over_step_benchmark` and `test_step_sourced_benchmark` exercising both API paths. |
+| CP3 | Pass-through / identity / invariant tests pin identity (elements_are or equal_to on entire value), not just size_is | NA | This PR introduces a metric computer that emits five derived numerical values; there are no pass-through, identity, or invariant semantics. All assertions on metric values use `float_equal` with explicit numerical targets (1.0, 2.0, 0.0, 1.5) or the multi-key `map_includes` matcher with `float_equal`. |
+| CP4 | Each guard called out explicitly in code docstrings has a test that exercises the guarded-against scenario | PASS | Guards documented in `benchmark_relative_computer.ml` and pinning tests: (1) `_min_paired_samples = 5` ("Minimum paired samples before fitting … keeps variance estimates non-degenerate") → `test_too_few_samples` provides 4 paired samples and asserts α/β/corr=0. (2) `_variance_tolerance = 1e-12` ("Variance below which the benchmark series is treated as constant; β / α / correlation fall back to [0.0]") → `test_zero_variance_benchmark` provides constant zero benchmark and asserts β=0, corr=0. (3) "All five metrics emitted as [0.0] when no benchmark series is supplied" (.mli) → `test_no_benchmark_yields_zero`. (4) Override-vs-step-sourced precedence (.mli) → `test_override_wins_over_step_benchmark` and `test_step_sourced_benchmark` cover both branches of `_resolve_benchmark_series`. The IR-when-TE-near-zero internal guard (line 136) isn't separately advertised in a docstring as a guard claim — it falls out of the algebraic α/TE formula — and is exercised indirectly by `test_no_benchmark_yields_zero` (IR=0) and by the identical-series scenario where TE=0 forces IR=0. |
+
+## Behavioral Checklist
+
+Pure infra PR (new metric computer, CAPM-style benchmark-relative metrics, no Weinstein-domain logic); domain checklist not applicable.
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| A1 | Core module modification is strategy-agnostic | NA | qc-structural did not flag A1; no core-module modifications. |
+| S1 | Stage 1 definition matches book | NA | Pure infra PR (new metric computer); domain checklist not applicable. |
+| S2 | Stage 2 definition matches book | NA | Pure infra PR; domain checklist not applicable. |
+| S3 | Stage 3 definition matches book | NA | Pure infra PR; domain checklist not applicable. |
+| S4 | Stage 4 definition matches book | NA | Pure infra PR; domain checklist not applicable. |
+| S5 | Buy criteria (Stage 2 entry on breakout) | NA | Pure infra PR; domain checklist not applicable. |
+| S6 | No buy signals in Stage 1/3/4 | NA | Pure infra PR; domain checklist not applicable. |
+| L1 | Initial stop placed below the base | NA | Pure infra PR; domain checklist not applicable. |
+| L2 | Trailing stop never lowered | NA | Pure infra PR; domain checklist not applicable. |
+| L3 | Stop triggers on weekly close | NA | Pure infra PR; domain checklist not applicable. |
+| L4 | Stop state machine transitions | NA | Pure infra PR; domain checklist not applicable. |
+| C1 | Screener cascade order | NA | Pure infra PR; domain checklist not applicable. |
+| C2 | Bearish macro blocks all buys | NA | Pure infra PR; domain checklist not applicable. |
+| C3 | Sector RS vs. market | NA | Pure infra PR; domain checklist not applicable. |
+| T1 | Tests cover all 4 stage transitions | NA | Pure infra PR; domain checklist not applicable. |
+| T2 | Bearish macro → zero buy candidates test | NA | Pure infra PR; domain checklist not applicable. |
+| T3 | Stop trailing tests | NA | Pure infra PR; domain checklist not applicable. |
+| T4 | Tests assert domain outcomes | NA | Pure infra PR; domain checklist not applicable. |
+
+## Verification details
+
+- Built test executable in a separate worktree at SHA d97948d5: `_build/default/trading/simulation/test/test_benchmark_relative_computer.exe` runs 7/7 tests OK in 0.12s.
+- Full simulation test suite (`dune runtest simulation/test/`) is green — no regressions.
+- OLS algebra spot-check on the perfect-linear 2× case: with `bench = [0.5, -0.3, 0.7, -0.2, 0.4, -0.5, 0.1]` and `strat = 2 · bench`, single-pass `_accumulate_moments` gives `Cov(y,x) = 2·Var(x)` and `Var(x) > _variance_tolerance`, so `β = 2·Var(x)/Var(x) = 2`, `α = mean_y − β·mean_x = 2·mean_x − 2·mean_x = 0`, `corr = 2·Var(x)/sqrt(Var(x)·4·Var(x)) = 1`. All match the test's assertions (β=2±1e-3, α=0±1e-3, corr=1±1e-3).
+- Identity-case algebra: with strat = bench, the active-return series (y − x) is identically zero, so `_active_return_stdev = 0`, `_alpha_beta` returns (0, 1), and `_correlation` returns 1. Matches the test's pinned values.
+- `_resolve_benchmark_series` precedence: when `benchmark_returns_override = Some xs`, it short-circuits regardless of `step_benchmark_returns`. Confirmed by `test_override_wins_over_step_benchmark` where step-sourced bench is zeros but override is the real series and β=2 is recovered.
+- `_step_returns_pct` with `_curve_from_returns` gives a near-perfect round-trip (input return → recovered percent return) up to floating-point. The test's epsilons (1e-3 to 1e-9) are appropriate.
+
+## Quality Score
+
+5 — Exemplary infra PR: every .mli claim has a pinning test, edge cases (zero-variance, too-few-samples, no-benchmark) are explicitly covered, both API paths (override vs. step-sourced) are exercised, and the OLS implementation uses a clean single-pass moment accumulator with documented variance gating. Tests follow `assert_that` + matcher composition idioms (`map_includes`, `float_equal` with explicit epsilons). Could serve as a reference for future metric-computer PRs.
+
+## Verdict
+
+APPROVED

--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -28,6 +28,7 @@
   drawdown_analytics_computer
   distributional_computer
   antifragility_computer
+  portfolio_valuation
   stale_hold)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/simulation/lib/portfolio_state_computer.ml
+++ b/trading/trading/simulation/lib/portfolio_state_computer.ml
@@ -17,11 +17,12 @@ type state = {
       *)
   last_marked_step : Simulator_types.step_result option;
       (** Last step whose [portfolio_value] is a real mark-to-market (cash +
-          position market values). On non-trading days (weekends, holidays) or
-          when price bars for open-position symbols are missing, the simulator
-          falls back to [portfolio_value = current_cash] — such steps are
-          excluded here so [OpenPositionsValue] / [UnrealizedPnl] reflect actual
-          end-of-sim state. See [_is_marked_to_market]. *)
+          position market values). Held positions are valued via cache +
+          avg-cost fallback chain in [Simulator._resolve_price] so the cash-only
+          collapse no longer fires; this filter remains as a safety net for any
+          residual cash-only step (e.g. zero-position runs) so
+          [OpenPositionsValue] / [UnrealizedPnl] reflect actual end-of-sim
+          state. See [_is_marked_to_market]. *)
   total_trades : int;
 }
 
@@ -30,9 +31,11 @@ type state = {
     Heuristic (mirrors [Backtest.Runner._is_trading_day] at
     [trading/trading/backtest/lib/runner.ml]): when there are no open positions,
     [portfolio_value = cash] is trivially correct. When there are open
-    positions, [portfolio_value] should differ measurably from cash — otherwise
-    the simulator's [_compute_portfolio_value] fell back to cash because no
-    price bars were available for that date. *)
+    positions, [portfolio_value] should differ measurably from cash — the
+    simulator's cache + avg-cost fallback in [_resolve_price] now guarantees
+    every held position is priced, so a step where they coincide indicates an
+    edge case (e.g., avg cost equals zero, or no positions remain after
+    end-of-day) that the metric computers should still skip. *)
 let _is_marked_to_market (step : Simulator_types.step_result) =
   let cash = step.portfolio.current_cash in
   let has_positions = Portfolio_summary.positions_count step.portfolio > 0 in

--- a/trading/trading/simulation/lib/portfolio_valuation.ml
+++ b/trading/trading/simulation/lib/portfolio_valuation.ml
@@ -1,0 +1,87 @@
+(** Portfolio mark-to-market valuation. See [portfolio_valuation.mli]. *)
+
+open Core
+
+(* Cache an authoritative price for [symbol] in [last_known_prices], returning
+   the price for fluent chaining. *)
+let _cache_price last_known_prices ~symbol price =
+  Hashtbl.set last_known_prices ~key:symbol ~data:price;
+  price
+
+(* Tier 2: ask the adapter for the most recent prior bar; cache the close. *)
+let _from_adapter adapter ~symbol ~date last_known_prices =
+  Trading_simulation_data.Market_data_adapter.get_previous_bar adapter ~symbol
+    ~date
+  |> Option.map ~f:(fun prev ->
+      _cache_price last_known_prices ~symbol prev.Types.Daily_price.close_price)
+
+(* Tier 3: read from this run's cache. No mutation. *)
+let _from_cache last_known_prices ~symbol =
+  Hashtbl.find last_known_prices symbol
+
+(* Tier 4: avg cost basis (zero-unrealized assumption). Records a fallback
+   event and caches the value so repeated misses don't double-count. *)
+let _from_avg_cost ~pos ~last_known_prices ~valuation_failure_count =
+  incr valuation_failure_count;
+  let avg_cost = Trading_portfolio.Calculations.avg_cost_of_position pos in
+  _cache_price last_known_prices ~symbol:pos.Trading_portfolio.Types.symbol
+    avg_cost
+
+(** Resolve a held position's price via the chain of tiers (adapter → cache →
+    avg-cost). Returns [None] only when [pos.symbol] is already in [today_set];
+    otherwise always [Some (symbol, price)]. *)
+let _resolve_price ~adapter ~date ~today_set ~last_known_prices
+    ~valuation_failure_count (pos : Trading_portfolio.Types.portfolio_position)
+    =
+  let symbol = pos.symbol in
+  if Set.mem today_set symbol then None
+  else
+    let from_adapter_or_cache =
+      Option.first_some
+        (_from_adapter adapter ~symbol ~date last_known_prices)
+        (_from_cache last_known_prices ~symbol)
+    in
+    let price =
+      match from_adapter_or_cache with
+      | Some p -> p
+      | None -> _from_avg_cost ~pos ~last_known_prices ~valuation_failure_count
+    in
+    Some (symbol, price)
+
+(* Update the cache with today's authoritative bars (tier 1). *)
+let _update_cache_with_today_bars last_known_prices today_prices =
+  List.iter today_prices ~f:(fun (sym, p) ->
+      Hashtbl.set last_known_prices ~key:sym ~data:p)
+
+(** Build a [(symbol, close_price)] alist covering every held position. *)
+let _prices_for_held_positions ~adapter ~date ~portfolio ~today_bars
+    ~last_known_prices ~valuation_failure_count =
+  let today_prices =
+    List.map today_bars ~f:(fun bar ->
+        (bar.Trading_engine.Types.symbol, bar.close_price))
+  in
+  _update_cache_with_today_bars last_known_prices today_prices;
+  let today_set = today_prices |> List.map ~f:fst |> String.Set.of_list in
+  let fallback_prices =
+    List.filter_map portfolio.Trading_portfolio.Portfolio.positions
+      ~f:
+        (_resolve_price ~adapter ~date ~today_set ~last_known_prices
+           ~valuation_failure_count)
+  in
+  today_prices @ fallback_prices
+
+let compute ~adapter ~date ~portfolio ~today_bars ~last_known_prices
+    ~valuation_failure_count =
+  let prices =
+    _prices_for_held_positions ~adapter ~date ~portfolio ~today_bars
+      ~last_known_prices ~valuation_failure_count
+  in
+  match
+    Trading_portfolio.Calculations.portfolio_value
+      portfolio.Trading_portfolio.Portfolio.positions portfolio.current_cash
+      prices
+  with
+  | Ok value -> value
+  | Error _ ->
+      incr valuation_failure_count;
+      portfolio.current_cash

--- a/trading/trading/simulation/lib/portfolio_valuation.mli
+++ b/trading/trading/simulation/lib/portfolio_valuation.mli
@@ -1,0 +1,45 @@
+(** Portfolio mark-to-market valuation with multi-tier price-resolution
+    fallback.
+
+    The simulator drives daily NAV via {!compute}, which routes each held
+    position through a four-tier resolution chain:
+
+    + [today_bars] (the current step's bar set, authoritative when present),
+    + [Market_data_adapter.get_previous_bar] (adapter forward-fill),
+    + [last_known_prices] cache (this run's last-resolved close, populated on
+      every successful resolution above),
+    + the position's avg cost basis (zero-unrealized assumption — last resort
+      when no market price has ever been seen for the symbol).
+
+    Tier (4) increments [valuation_failure_count] so the operator can audit the
+    fallback rate at end-of-run. The earlier silent collapse to
+    [portfolio.current_cash] (which corrupted [equity_curve.csv]
+    daily-derivative metrics on runs with delisting / dataset edges) survives
+    only as defense-in-depth: with the cache + avg-cost chain in place, every
+    held position is now priced, so [Calculations.portfolio_value] should always
+    return [Ok]. See {!compute} for the full contract. *)
+
+open Core
+
+val compute :
+  adapter:Trading_simulation_data.Market_data_adapter.t ->
+  date:Date.t ->
+  portfolio:Trading_portfolio.Portfolio.t ->
+  today_bars:Trading_engine.Types.price_bar list ->
+  last_known_prices:float String.Table.t ->
+  valuation_failure_count:int ref ->
+  float
+(** [compute ~adapter ~date ~portfolio ~today_bars ~last_known_prices
+     ~valuation_failure_count] returns the portfolio's total mark-to-market
+    value (cash + position market values) on [date].
+
+    Each held position is priced via the four-tier chain documented at the top
+    of this module. The cache is updated on every successful resolution so
+    subsequent steps within the same run benefit from carry-forward.
+    [valuation_failure_count] is incremented exactly once per (symbol, step)
+    pair that fell through to the avg-cost last-resort.
+
+    Always returns a finite value. The legacy cash-only fallback (when
+    [Calculations.portfolio_value] errors despite the chain providing a price
+    for every held position) is preserved as defense-in-depth and likewise
+    increments [valuation_failure_count]. *)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -174,91 +174,6 @@ let _get_today_bars t =
   in
   List.filter_map t.deps.symbols ~f:get_bar
 
-(** Resolve a held position's price for today, populating + consulting
-    [last_known_prices] as a third-tier fallback after today's bar and the
-    adapter's forward-fill via [get_previous_bar]. The avg-cost last-resort
-    fires only when none of the three sources knows a price — equivalent to
-    "value the position at cost basis," i.e., assume zero unrealized P&L for
-    that position. Increments [valuation_failure_count] in the avg-cost branch.
-
-    Returns [None] only when [pos.symbol] is already in [today_set] (the caller
-    covers it via [today_prices]); otherwise always returns
-    [Some (symbol, price)] so the downstream [Calculations.portfolio_value] is
-    guaranteed to succeed. *)
-let _resolve_price ~adapter ~date ~today_set ~last_known_prices
-    ~valuation_failure_count (pos : Trading_portfolio.Types.portfolio_position)
-    =
-  let symbol = pos.symbol in
-  if Set.mem today_set symbol then None
-  else
-    let cache p =
-      Hashtbl.set last_known_prices ~key:symbol ~data:p;
-      p
-    in
-    let price =
-      match
-        Trading_simulation_data.Market_data_adapter.get_previous_bar adapter
-          ~symbol ~date
-      with
-      | Some prev -> cache prev.Types.Daily_price.close_price
-      | None -> (
-          match Hashtbl.find last_known_prices symbol with
-          | Some cached -> cached
-          | None ->
-              incr valuation_failure_count;
-              cache (Trading_portfolio.Calculations.avg_cost_of_position pos))
-    in
-    Some (symbol, price)
-
-(** Build a [(symbol, close_price)] alist covering every position in
-    [portfolio]. Today's bar (from [today_bars]) is preferred; for any held
-    symbol with no bar today, fall back to the adapter's [get_previous_bar]
-    forward-fill, then to [last_known_prices] cache, then to the position's avg
-    cost basis (zero-unrealized assumption). The cache + avg-cost fallback were
-    added to fix the silent-cash-only valuation bug that previously corrupted
-    the [equity_curve.csv] daily-derivative metrics whenever any held symbol's
-    bar dataset had a gap. See [dev/notes/cell-e-15y-full-window-2026-05-10.md].
-*)
-let _prices_for_held_positions ~adapter ~date ~portfolio ~today_bars
-    ~last_known_prices ~valuation_failure_count =
-  let today_prices =
-    List.map today_bars ~f:(fun bar ->
-        (bar.Trading_engine.Types.symbol, bar.close_price))
-  in
-  List.iter today_prices ~f:(fun (sym, p) ->
-      Hashtbl.set last_known_prices ~key:sym ~data:p);
-  let today_set = today_prices |> List.map ~f:fst |> String.Set.of_list in
-  let fallback_prices =
-    List.filter_map portfolio.Trading_portfolio.Portfolio.positions
-      ~f:
-        (_resolve_price ~adapter ~date ~today_set ~last_known_prices
-           ~valuation_failure_count)
-  in
-  today_prices @ fallback_prices
-
-(** Compute total portfolio value (cash + position market values). With the
-    cache + avg-cost fallback in [_prices_for_held_positions], every held
-    position now has a price, so [Calculations.portfolio_value] should always
-    return [Ok]. The legacy cash-only fallback is preserved as defense-in-depth:
-    if anything regresses (e.g., a future field is added that causes the calc to
-    fail for an unrelated reason), we still log it instead of silently
-    corrupting the curve. *)
-let _compute_portfolio_value ~adapter ~date ~portfolio ~today_bars
-    ~last_known_prices ~valuation_failure_count =
-  let prices =
-    _prices_for_held_positions ~adapter ~date ~portfolio ~today_bars
-      ~last_known_prices ~valuation_failure_count
-  in
-  match
-    Trading_portfolio.Calculations.portfolio_value
-      portfolio.Trading_portfolio.Portfolio.positions portfolio.current_cash
-      prices
-  with
-  | Ok value -> value
-  | Error _ ->
-      incr valuation_failure_count;
-      portfolio.current_cash
-
 (** Extract trades from execution reports *)
 let _extract_trades reports =
   List.concat_map reports ~f:(fun report -> report.Trading_engine.Types.trades)
@@ -441,6 +356,26 @@ let _prepare_market_state t =
   Trading_engine.Engine.update_market t.deps.engine today_bars;
   (portfolio, positions, today_bars, split_events)
 
+(** Build the per-step [step_result]. Projection to the skinny
+    [Portfolio_summary] mirrors Fix B from
+    [dev/notes/15y-memory-cliff-2026-05-08.md]. *)
+let _build_step_result t ~portfolio ~portfolio_value ~trades ~orders ~today_bars
+    ~split_events =
+  let portfolio_summary =
+    Trading_simulation_types.Portfolio_summary.of_portfolio portfolio
+      ~position_value_total:(portfolio_value -. portfolio.current_cash)
+  in
+  {
+    date = t.current_date;
+    portfolio = portfolio_summary;
+    portfolio_value;
+    trades;
+    orders_submitted = _submit_orders t orders;
+    splits_applied = split_events;
+    benchmark_return = _compute_benchmark_return t;
+    had_market_bars = not (List.is_empty today_bars);
+  }
+
 (** Process one day: execute pending orders, call strategy, generate new orders,
     and assemble the [step_result]. Returns the next simulator state paired with
     this day's [step_result]. *)
@@ -461,29 +396,14 @@ let _process_step_day t ~portfolio ~positions ~today_bars ~split_events =
       ~positions transitions
   in
   let portfolio_value =
-    _compute_portfolio_value ~adapter:t.deps.market_data_adapter
+    Portfolio_valuation.compute ~adapter:t.deps.market_data_adapter
       ~date:t.current_date ~portfolio ~today_bars
       ~last_known_prices:t.last_known_prices
       ~valuation_failure_count:t.valuation_failure_count
   in
-  (* Project to skinny per-step summary — see [Portfolio_summary.t] for the
-     memory-pressure rationale (Fix B in
-     dev/notes/15y-memory-cliff-2026-05-08.md). *)
-  let portfolio_summary =
-    Trading_simulation_types.Portfolio_summary.of_portfolio portfolio
-      ~position_value_total:(portfolio_value -. portfolio.current_cash)
-  in
   let step_result =
-    {
-      date = t.current_date;
-      portfolio = portfolio_summary;
-      portfolio_value;
-      trades;
-      orders_submitted = _submit_orders t orders;
-      splits_applied = split_events;
-      benchmark_return = _compute_benchmark_return t;
-      had_market_bars = not (List.is_empty today_bars);
-    }
+    _build_step_result t ~portfolio ~portfolio_value ~trades ~orders ~today_bars
+      ~split_events
   in
   let t' =
     {

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -83,6 +83,18 @@ and t = {
   portfolio : Trading_portfolio.Portfolio.t;
   positions : Trading_strategy.Position.t String.Map.t;
   step_history : step_result list;  (** Accumulated steps in reverse order *)
+  last_known_prices : float String.Table.t;
+      (** Per-symbol last-resolved close price. Populated whenever
+          [_prices_for_held_positions] resolves a price for a held symbol
+          (today's bar OR adapter forward-fill). Consulted as the third fallback
+          if both today's bar and [get_previous_bar] fail — covers held symbols
+          whose bar dataset has gaps the adapter cannot reach (M&A delisting +
+          dataset edge, survivor-bias purges). Reference-shared across all
+          per-step copies of [t]. *)
+  valuation_failure_count : int ref;
+      (** Counter incremented each time [_resolve_price] fell through to the
+          avg-cost last-resort (the cache was also empty for a held symbol).
+          Should remain [0] in healthy runs; printed at end of [run]. *)
 }
 
 (** {1 Creation} *)
@@ -107,6 +119,8 @@ let create ~config ~deps =
         portfolio;
         positions = String.Map.empty;
         step_history = [];
+        last_known_prices = String.Table.create ();
+        valuation_failure_count = ref 0;
       }
 
 (** {1 Running} *)
@@ -160,50 +174,80 @@ let _get_today_bars t =
   in
   List.filter_map t.deps.symbols ~f:get_bar
 
-(** Fetch the most recent prior close for [pos] when its symbol is absent from
-    [today_set]. Returns [None] when [pos.symbol] is in [today_set] (no fallback
-    needed) or when no prior bar exists for the symbol. *)
-let _fallback_price_for_position ~adapter ~date ~today_set
-    (pos : Trading_portfolio.Types.portfolio_position) =
-  if Set.mem today_set pos.symbol then None
+(** Resolve a held position's price for today, populating + consulting
+    [last_known_prices] as a third-tier fallback after today's bar and the
+    adapter's forward-fill via [get_previous_bar]. The avg-cost last-resort
+    fires only when none of the three sources knows a price — equivalent to
+    "value the position at cost basis," i.e., assume zero unrealized P&L for
+    that position. Increments [valuation_failure_count] in the avg-cost branch.
+
+    Returns [None] only when [pos.symbol] is already in [today_set] (the caller
+    covers it via [today_prices]); otherwise always returns
+    [Some (symbol, price)] so the downstream [Calculations.portfolio_value] is
+    guaranteed to succeed. *)
+let _resolve_price ~adapter ~date ~today_set ~last_known_prices
+    ~valuation_failure_count (pos : Trading_portfolio.Types.portfolio_position)
+    =
+  let symbol = pos.symbol in
+  if Set.mem today_set symbol then None
   else
-    let%map.Option prev =
-      Trading_simulation_data.Market_data_adapter.get_previous_bar adapter
-        ~symbol:pos.symbol ~date
+    let cache p =
+      Hashtbl.set last_known_prices ~key:symbol ~data:p;
+      p
     in
-    (pos.symbol, prev.Types.Daily_price.close_price)
+    let price =
+      match
+        Trading_simulation_data.Market_data_adapter.get_previous_bar adapter
+          ~symbol ~date
+      with
+      | Some prev -> cache prev.Types.Daily_price.close_price
+      | None -> (
+          match Hashtbl.find last_known_prices symbol with
+          | Some cached -> cached
+          | None ->
+              incr valuation_failure_count;
+              cache (Trading_portfolio.Calculations.avg_cost_of_position pos))
+    in
+    Some (symbol, price)
 
 (** Build a [(symbol, close_price)] alist covering every position in
     [portfolio]. Today's bar (from [today_bars]) is preferred; for any held
-    symbol with no bar today, fall back to the most recent prior bar via
-    [adapter.get_previous_bar] (forward-fill of last-known close). Symbols with
-    neither today's bar nor any prior bar are dropped — the downstream
-    [Calculations.portfolio_value] errors when this happens, and the caller
-    falls back to cash-only valuation. The forward-fill matters when a held
-    symbol stops trading mid-run (corporate action, suspension): without it,
-    [Calculations.portfolio_value] errors, the caller silently substitutes
-    [current_cash], the equity curve flatlines, and the
-    [Backtest.Runner.is_trading_day] heuristic that gates equity-curve rows
-    drops every subsequent step. *)
-let _prices_for_held_positions ~adapter ~date ~portfolio ~today_bars =
+    symbol with no bar today, fall back to the adapter's [get_previous_bar]
+    forward-fill, then to [last_known_prices] cache, then to the position's avg
+    cost basis (zero-unrealized assumption). The cache + avg-cost fallback were
+    added to fix the silent-cash-only valuation bug that previously corrupted
+    the [equity_curve.csv] daily-derivative metrics whenever any held symbol's
+    bar dataset had a gap. See [dev/notes/cell-e-15y-full-window-2026-05-10.md].
+*)
+let _prices_for_held_positions ~adapter ~date ~portfolio ~today_bars
+    ~last_known_prices ~valuation_failure_count =
   let today_prices =
     List.map today_bars ~f:(fun bar ->
         (bar.Trading_engine.Types.symbol, bar.close_price))
   in
+  List.iter today_prices ~f:(fun (sym, p) ->
+      Hashtbl.set last_known_prices ~key:sym ~data:p);
   let today_set = today_prices |> List.map ~f:fst |> String.Set.of_list in
   let fallback_prices =
     List.filter_map portfolio.Trading_portfolio.Portfolio.positions
-      ~f:(_fallback_price_for_position ~adapter ~date ~today_set)
+      ~f:
+        (_resolve_price ~adapter ~date ~today_set ~last_known_prices
+           ~valuation_failure_count)
   in
   today_prices @ fallback_prices
 
-(** Compute total portfolio value (cash + position market values). Forward-
-    fills missing prices for held positions via [_prices_for_held_positions];
-    when even the forward-fill cannot resolve a price (no prior bar ever), falls
-    back to cash-only valuation rather than crashing the run. *)
-let _compute_portfolio_value ~adapter ~date ~portfolio ~today_bars =
+(** Compute total portfolio value (cash + position market values). With the
+    cache + avg-cost fallback in [_prices_for_held_positions], every held
+    position now has a price, so [Calculations.portfolio_value] should always
+    return [Ok]. The legacy cash-only fallback is preserved as defense-in-depth:
+    if anything regresses (e.g., a future field is added that causes the calc to
+    fail for an unrelated reason), we still log it instead of silently
+    corrupting the curve. *)
+let _compute_portfolio_value ~adapter ~date ~portfolio ~today_bars
+    ~last_known_prices ~valuation_failure_count =
   let prices =
     _prices_for_held_positions ~adapter ~date ~portfolio ~today_bars
+      ~last_known_prices ~valuation_failure_count
   in
   match
     Trading_portfolio.Calculations.portfolio_value
@@ -211,7 +255,9 @@ let _compute_portfolio_value ~adapter ~date ~portfolio ~today_bars =
       prices
   with
   | Ok value -> value
-  | Error _ -> portfolio.current_cash
+  | Error _ ->
+      incr valuation_failure_count;
+      portfolio.current_cash
 
 (** Extract trades from execution reports *)
 let _extract_trades reports =
@@ -351,6 +397,14 @@ let _build_run_result t =
     _compute_derived ~derived_computers:t.deps.metric_suite.derived
       ~config:t.config ~base_metrics
   in
+  if !(t.valuation_failure_count) > 0 then
+    eprintf
+      "WARN: %d held-position price resolutions fell through to avg-cost \
+       fallback (zero unrealized assumption). Run still produced a valid \
+       portfolio_value series; review valuation_failure_count for cache \
+       coverage gaps.\n\
+       %!"
+      !(t.valuation_failure_count);
   { steps; final_portfolio = t.portfolio; metrics }
 
 (* Apply trades one at a time, skipping any that fail (e.g. insufficient
@@ -409,6 +463,8 @@ let _process_step_day t ~portfolio ~positions ~today_bars ~split_events =
   let portfolio_value =
     _compute_portfolio_value ~adapter:t.deps.market_data_adapter
       ~date:t.current_date ~portfolio ~today_bars
+      ~last_known_prices:t.last_known_prices
+      ~valuation_failure_count:t.valuation_failure_count
   in
   (* Project to skinny per-step summary — see [Portfolio_summary.t] for the
      memory-pressure rationale (Fix B in


### PR DESCRIPTION
## Summary

Replace silent cash-only collapse in [`_compute_portfolio_value`](trading/trading/simulation/lib/simulator.ml) with a per-symbol last-known-price cache plus avg-cost last-resort. Restores correctness of `equity_curve.csv` and every daily-derivative metric (`max_drawdown_pct`, `sharpe_ratio`, `best/worst_*_pct`, `volatility`, `time_in_drawdown`, etc.) on runs where any held symbol's bar dataset has a gap the adapter cannot forward-fill (M&A delisting, dataset window edges, survivor-bias purges).

## What changed

- Added `last_known_prices : float String.Table.t` + `valuation_failure_count : int ref` to simulator state `t`. Reference-shared across per-step copies.
- New `_resolve_price`: today's bar → `Market_data_adapter.get_previous_bar` → cache → position avg-cost (zero unrealized assumption). Cache is populated on every successful resolution.
- `_prices_for_held_positions` now ALWAYS returns a `(symbol, price)` for every held position; `Trading_portfolio.Calculations.portfolio_value` no longer errors on the happy path. The legacy `Error _ -> portfolio.current_cash` survives only as defense-in-depth (assertion-style — should not fire).
- `eprintf` warning at end-of-run if any avg-cost fallbacks fired.
- Updated stale `_is_marked_to_market` docstring in `portfolio_state_computer.ml` to reflect the new fallback chain.

## Why

`dev/notes/cell-e-15y-full-window-2026-05-10.md` documents the bug: Cell E 15y reported `total_return_pct = -50.30 / max_drawdown_pct = 99.95` because the simulator fell back to `current_cash` whenever any held position couldn't be priced. Offline reconstruction from `trades.csv` showed the actual run was `+163.56% / 20.12% MaxDD / Sharpe 0.59`. Trade-tape integrity was intact; only the daily NAV series was corrupt. This PR makes the simulator's daily NAV match the offline reconstruction.

## Test plan

- [x] `dune build` clean (no errors)
- [x] `dune runtest trading/simulation/` — all green (existing forward-fill test `test_forward_fill_uses_last_known_close_when_held_symbol_has_no_bar` still passes; pins the success branch of the new chain)
- [x] `dune runtest trading/orders/ trading/engine/ trading/portfolio/ trading/strategy/ trading/backtest/` — all green; no regressions in upstream/downstream callers
- [ ] Re-run Cell E 15y backtest — expect `equity_curve.csv` to match `reconstructed_equity_curve.csv` from `dev/experiments/cell-e-15y-2026-05-09/` within rounding (tracked separately)

## Notes

- A separate PR will land the `Order_manager` perf hotspot fix surfaced during this investigation.
- A future improvement could persist `valuation_failure_count` events into a `valuation_failures.sexp` artifact parallel to `stale_holds.sexp`; deferred since the cache should keep it at zero in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)