### PR TITLE
perf(orders): bound list_orders ~ActiveOnly walk via active_orders index

### DIFF
--- a/trading/trading/orders/lib/manager.ml
+++ b/trading/trading/orders/lib/manager.ml
@@ -9,10 +9,32 @@ type order_filter =
   | ActiveOnly
 [@@deriving show, eq]
 
-type order_manager = { orders : (order_id, order) Hashtbl.t }
+(* [orders] is the historical record (insert-only — Filled / Cancelled /
+   Rejected orders persist for audit). [active_orders] mirrors only the
+   currently-active subset (Pending + PartiallyFilled) so the per-step
+   [list_orders ~filter:ActiveOnly] walk is bounded by current pending
+   load instead of cumulative submissions. Without this index, hot-loop
+   scenarios (e.g. Cell E h=2 on 15y, 4000+ submitted orders) pay an
+   O(N) cumulative scan every simulator step — the dominant remaining
+   per-day perf cost after PRs #1014 + #1015. *)
+type order_manager = {
+  orders : (order_id, order) Hashtbl.t;
+  active_orders : (order_id, order) Hashtbl.t;
+}
 
 let _initial_size = 100
-let create () = { orders = Hashtbl.create _initial_size }
+
+let create () =
+  {
+    orders = Hashtbl.create _initial_size;
+    active_orders = Hashtbl.create _initial_size;
+  }
+
+(* Sync [active_orders] with the current status of [order]: insert/refresh
+   when active, remove when no longer active. Idempotent. *)
+let _sync_active manager order =
+  if is_active order then Hashtbl.replace manager.active_orders order.id order
+  else Hashtbl.remove manager.active_orders order.id
 
 let submit_orders manager orders =
   List.map
@@ -21,6 +43,7 @@ let submit_orders manager orders =
         error_invalid_argument ("Order with ID " ^ order.id ^ " already exists")
       else (
         Hashtbl.add manager.orders order.id order;
+        _sync_active manager order;
         Result.Ok ()))
     orders
 
@@ -30,6 +53,7 @@ let _cancel_order manager order_id order =
   else
     let cancelled_order = update_status order Cancelled in
     Hashtbl.replace manager.orders order_id cancelled_order;
+    _sync_active manager cancelled_order;
     Result.Ok ()
 
 let cancel_orders manager order_ids =
@@ -51,18 +75,23 @@ let matches_filter order = function
   | BySide side -> order.side = side
   | ActiveOnly -> is_active order
 
+(* [ActiveOnly] walks [active_orders] (bounded by current pending count);
+   every other branch walks the full audit table. *)
 let list_orders ?filter manager =
+  let collect tbl predicate =
+    Hashtbl.fold
+      (fun _ order acc -> if predicate order then order :: acc else acc)
+      tbl []
+  in
   match filter with
-  | None -> Hashtbl.fold (fun _ order acc -> order :: acc) manager.orders []
-  | Some f ->
-      Hashtbl.fold
-        (fun _ order acc ->
-          if matches_filter order f then order :: acc else acc)
-        manager.orders []
+  | None -> collect manager.orders (fun _ -> true)
+  | Some ActiveOnly -> collect manager.active_orders (fun _ -> true)
+  | Some f -> collect manager.orders (fun o -> matches_filter o f)
 
 let update_order manager order =
   match Hashtbl.find_opt manager.orders order.id with
   | None -> error_not_found ("Order with ID " ^ order.id ^ " not found")
   | Some _ ->
       Hashtbl.replace manager.orders order.id order;
+      _sync_active manager order;
       Result.Ok ()


### PR DESCRIPTION
## Summary

Add a parallel `active_orders : (order_id, order) Hashtbl.t` mirror to `Order_manager`, sync'd on submit / update / cancel via a private `_sync_active` helper. `list_orders ~filter:ActiveOnly` now walks only the currently-active subset (bounded by current pending load) instead of the full historical orders table (monotonically growing with cumulative submissions).

## Why

The simulator step calls `Engine.process_orders` every day, which calls `Order_manager.list_orders ~filter:ActiveOnly` (`engine.ml:297`). The orders table is insert-only — Filled/Cancelled/Rejected orders persist for audit but pollute the active-scan path. On long, high-turnover backtests (e.g. Cell E h=2 on 15y, 2090 round-trips ≈ 4–8K cumulative orders) this becomes the dominant remaining per-day cost after PRs #1014 + #1015 fixed the trade_history O(N²) hotspots — measured ~14× per-day slowdown 5y→15y while per-trade processing stays roughly linear.

## What changed

- `order_manager` now carries `{ orders; active_orders }`; both initialised in `create`.
- `submit_orders` / `_cancel_order` / `update_order` call `_sync_active` to keep the mirror in step (insert when `is_active` returns true, remove when not).
- `list_orders ~filter:ActiveOnly` walks `active_orders` directly (O(currently-pending)). All other filter branches keep walking the full `orders` table (audit semantics preserved).

## Test plan

- [x] `dune runtest trading/orders/ trading/engine/ trading/simulation/ trading/backtest/` — all green; bit-equal results
- [x] 5y Cell E perf re-measurement (`dev/experiments/cell-e-5y-perf-2026-05-10/`):
  - Wall **6:30 → 6:14** (4% wall, 6% user CPU)
  - Peak RSS flat (552 MB → 555 MB)
  - Trade count, return, win-rate, MaxDD bit-equal vs prior run (120.0% / 196 / 33.7% / 23.1%)
- [ ] 15y Cell E re-run will validate the bigger predicted payoff (~10× cumulative orders → much larger absolute saving on `cumulative_orders × elapsed_steps`)

## Notes

- Audit semantics unchanged: filled/cancelled/rejected orders remain in `orders` for `get_order` and `list_orders` (no filter / `BySymbol` / `ByStatus` / `BySide`). Only the `ActiveOnly` filter takes the optimised path.
- Companion to #1019 (simulator NAV fallback fix). Both surfaced during the Cell E 15y validation work documented in `dev/notes/cell-e-15y-full-window-2026-05-10.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)