### PR TITLE
fix(backtest): trade_context audit join date-window fallback

### DIFF
--- a/trading/trading/backtest/lib/trade_context.ml
+++ b/trading/trading/backtest/lib/trade_context.ml
@@ -56,6 +56,21 @@ let csv_row_fields (t : t) =
 type precomputed = {
   audit_by_key :
     (string, Trade_audit.audit_record, String.comparator_witness) Map.t;
+      (** Exact (symbol, entry_date) → audit_record. *)
+  audit_by_symbol :
+    ( string,
+      Trade_audit.audit_record list,
+      String.comparator_witness )
+    Map.t;
+      (** symbol → audit_records sorted by [entry.entry_date] descending. Used
+          as fallback when the exact-date key misses: the audit records the
+          {b decision} date (typically a Friday), while [trade.entry_date]
+          reflects the simulator step on which the order's fill was recorded
+          — which can be a calendar day or two later because the simulator
+          increments [current_date] by 1 calendar day per step and fills GTC
+          orders on the next step that has price-path state. We pick the most
+          recent audit record whose [entry.entry_date] is ≤ [trade.entry_date]
+          and within a small window (1 week). *)
   stop_by_position_id :
     (string, Stop_log.stop_info, String.comparator_witness) Map.t;
   stop_first_by_symbol :
@@ -73,6 +88,21 @@ let _build_audit_by_key (audit : Trade_audit.audit_record list) =
           ~entry_date:record.entry.entry_date
       in
       Map.set acc ~key ~data:record)
+
+(** Group audit records by symbol, sorted by [entry.entry_date] descending
+    (newest first). Used by [_lookup_audit_for_trade] for the date-window
+    fallback. *)
+let _build_audit_by_symbol (audit : Trade_audit.audit_record list) =
+  List.fold audit
+    ~init:(Map.empty (module String))
+    ~f:(fun acc (record : Trade_audit.audit_record) ->
+      Map.update acc record.entry.symbol ~f:(function
+        | None -> [ record ]
+        | Some xs -> record :: xs))
+  |> Map.map ~f:(fun records ->
+         List.sort records
+           ~compare:(fun (a : Trade_audit.audit_record) b ->
+             Date.compare b.entry.entry_date a.entry.entry_date))
 
 let _build_stop_by_position_id (stop_infos : Stop_log.stop_info list) =
   List.fold stop_infos
@@ -96,9 +126,32 @@ let precompute ~(audit : Trade_audit.audit_record list)
     ~(stop_infos : Stop_log.stop_info list) : precomputed =
   {
     audit_by_key = _build_audit_by_key audit;
+    audit_by_symbol = _build_audit_by_symbol audit;
     stop_by_position_id = _build_stop_by_position_id stop_infos;
     stop_first_by_symbol = _build_stop_first_by_symbol stop_infos;
   }
+
+(* Tolerance for the date-window fallback. Cell E h=2 typically yields
+   trade.entry_date one calendar day after audit.entry_date (Friday decision
+   → Saturday-step fill record); a week handles long-weekend / holiday
+   stretches conservatively without admitting cross-trade ambiguity. *)
+let _audit_lookup_window_days = 7
+
+(** Find the audit record for [trade]. Tries exact (symbol, entry_date) first;
+    on miss, falls back to the most recent audit record for [symbol] whose
+    [entry.entry_date] is ≤ [trade.entry_date] and within
+    [_audit_lookup_window_days]. Returns [None] when no candidate matches. *)
+let _lookup_audit_for_trade (pre : precomputed) ~symbol ~entry_date :
+    Trade_audit.audit_record option =
+  let key = _audit_key ~symbol ~entry_date in
+  match Map.find pre.audit_by_key key with
+  | Some _ as r -> r
+  | None ->
+      Option.bind (Map.find pre.audit_by_symbol symbol) ~f:(fun records ->
+          List.find records ~f:(fun (r : Trade_audit.audit_record) ->
+              Date.( <= ) r.entry.entry_date entry_date
+              && Date.diff entry_date r.entry.entry_date
+                 <= _audit_lookup_window_days))
 
 let _stop_info_for ~position_id ~symbol (pre : precomputed) :
     Stop_log.stop_info option =
@@ -121,8 +174,10 @@ let _days_to_first_stop_trigger ~(entry_date : Date.t) ~(exit_date : Date.t)
 
 let of_precomputed (pre : precomputed)
     ~(trade : Trading_simulation.Metrics.trade_metrics) : t =
-  let key = _audit_key ~symbol:trade.symbol ~entry_date:trade.entry_date in
-  let audit_record = Map.find pre.audit_by_key key in
+  let audit_record =
+    _lookup_audit_for_trade pre ~symbol:trade.symbol
+      ~entry_date:trade.entry_date
+  in
   let entry =
     Option.map audit_record ~f:(fun (r : Trade_audit.audit_record) -> r.entry)
   in

--- a/trading/trading/backtest/lib/trade_context.ml
+++ b/trading/trading/backtest/lib/trade_context.ml
@@ -58,15 +58,12 @@ type precomputed = {
     (string, Trade_audit.audit_record, String.comparator_witness) Map.t;
       (** Exact (symbol, entry_date) → audit_record. *)
   audit_by_symbol :
-    ( string,
-      Trade_audit.audit_record list,
-      String.comparator_witness )
-    Map.t;
+    (string, Trade_audit.audit_record list, String.comparator_witness) Map.t;
       (** symbol → audit_records sorted by [entry.entry_date] descending. Used
           as fallback when the exact-date key misses: the audit records the
           {b decision} date (typically a Friday), while [trade.entry_date]
-          reflects the simulator step on which the order's fill was recorded
-          — which can be a calendar day or two later because the simulator
+          reflects the simulator step on which the order's fill was recorded —
+          which can be a calendar day or two later because the simulator
           increments [current_date] by 1 calendar day per step and fills GTC
           orders on the next step that has price-path state. We pick the most
           recent audit record whose [entry.entry_date] is ≤ [trade.entry_date]
@@ -100,9 +97,8 @@ let _build_audit_by_symbol (audit : Trade_audit.audit_record list) =
         | None -> [ record ]
         | Some xs -> record :: xs))
   |> Map.map ~f:(fun records ->
-         List.sort records
-           ~compare:(fun (a : Trade_audit.audit_record) b ->
-             Date.compare b.entry.entry_date a.entry.entry_date))
+      List.sort records ~compare:(fun (a : Trade_audit.audit_record) b ->
+          Date.compare b.entry.entry_date a.entry.entry_date))
 
 let _build_stop_by_position_id (stop_infos : Stop_log.stop_info list) =
   List.fold stop_infos
@@ -137,6 +133,21 @@ let precompute ~(audit : Trade_audit.audit_record list)
    stretches conservatively without admitting cross-trade ambiguity. *)
 let _audit_lookup_window_days = 7
 
+(* Predicate: audit record's entry_date is within the lookup window before
+   [trade_entry_date]. Pulled out of [_lookup_audit_for_trade] to flatten its
+   nesting. *)
+let _within_audit_window ~trade_entry_date (r : Trade_audit.audit_record) =
+  Date.( <= ) r.entry.entry_date trade_entry_date
+  && Date.diff trade_entry_date r.entry.entry_date <= _audit_lookup_window_days
+
+(* Fallback path: scan the per-symbol audit list for the most recent record
+   inside the lookup window. List is pre-sorted newest-first, so [List.find]
+   returns the closest match. *)
+let _audit_window_fallback (pre : precomputed) ~symbol ~trade_entry_date =
+  Option.bind
+    (Map.find pre.audit_by_symbol symbol)
+    ~f:(List.find ~f:(_within_audit_window ~trade_entry_date))
+
 (** Find the audit record for [trade]. Tries exact (symbol, entry_date) first;
     on miss, falls back to the most recent audit record for [symbol] whose
     [entry.entry_date] is ≤ [trade.entry_date] and within
@@ -146,12 +157,7 @@ let _lookup_audit_for_trade (pre : precomputed) ~symbol ~entry_date :
   let key = _audit_key ~symbol ~entry_date in
   match Map.find pre.audit_by_key key with
   | Some _ as r -> r
-  | None ->
-      Option.bind (Map.find pre.audit_by_symbol symbol) ~f:(fun records ->
-          List.find records ~f:(fun (r : Trade_audit.audit_record) ->
-              Date.( <= ) r.entry.entry_date entry_date
-              && Date.diff entry_date r.entry.entry_date
-                 <= _audit_lookup_window_days))
+  | None -> _audit_window_fallback pre ~symbol ~trade_entry_date:entry_date
 
 let _stop_info_for ~position_id ~symbol (pre : precomputed) :
     Stop_log.stop_info option =


### PR DESCRIPTION
## Summary

Fix the trades.csv ↔ trade_audit.sexp join in `Trade_context.of_precomputed`: previous exact-date match was failing because the audit records strategy-decision date (typically Friday) while `trade.entry_date` from `Metrics.trade_metrics` reflects the simulator step on which the fill was recorded (the next calendar-day step, since the simulator increments by 1 calendar day per step). All entry-time CSV fields — `entry_stage`, `entry_volume_ratio`, `screener_score_at_entry`, `stop_initial_distance_pct` — were therefore blank in every row of trades.csv.

## What changed

- Added `audit_by_symbol` precomputed index: symbol → audit_records sorted newest-first.
- New `_lookup_audit_for_trade`: tries exact (symbol, entry_date) key first; on miss, falls back to the most recent audit_record for the symbol whose `entry.entry_date` is ≤ `trade.entry_date` and within `_audit_lookup_window_days` (7 days). The 7-day window comfortably covers long-weekend / holiday gaps without admitting cross-trade ambiguity (audit emissions are typically weekly).
- `of_precomputed` now uses `_lookup_audit_for_trade` instead of `Map.find` on the exact key.

## Why

`dev/backtest/scenarios-2026-05-10-132149/cell-e-5y-2010-2014/trades.csv` confirms the bug empirically: for symbol A, `trade_audit.sexp` has `(entry_date 2014-06-13)` (Friday) but `trades.csv` shows `entry_date 2014-06-14` (Saturday — the next step where the GTC order found a price path). 1-day mismatch → exact-key miss → all entry fields blank. The same mismatch holds for every trade.

Without this fix, the per-trade entry-feature bucket analysis (which winner/loser separation by screener_score, volume_ratio, rs_value, stage) is impossible — there's no way to correlate exit P&L with entry decision quality.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest trading/backtest/` — all green
- [ ] Re-run any Cell E scenario; verify entry_stage / entry_volume_ratio / screener_score_at_entry columns in trades.csv are populated for the vast majority of rows
- [ ] Spot-check that the (symbol, entry_date) within the 7-day window is the matching audit record, not a stale prior one

## Notes

- The deeper sim issue — simulator increments `current_date` by 1 calendar day per step rather than skipping non-trading days — is unchanged and not in scope here. The window-based fallback is the pragmatic fix for the audit-join; addressing the calendar-day stepping is a much larger refactor that would shift every step.date across the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)