### PR TITLE
feat(release-report): surface all-eligible diagnostic in comparison markdown

### DIFF
--- a/dev/status/all-eligible.md
+++ b/dev/status/all-eligible.md
@@ -1,12 +1,13 @@
 # Status: all-eligible
 
-## Last updated: 2026-05-10
+## Last updated: 2026-05-11
 
 ## Status
 READY_FOR_REVIEW
 
-(PR-1 merged #899; PR-2 CLI merged #901; **PR-3 release-report wiring on
-`feat/all-eligible-release-report` — ready for review**)
+(PR-1 merged #899; PR-2 CLI merged #901; PR-3 scenario_runner wiring merged
+#1017; **PR-4 release-report rendering on
+`feat/all-eligible-release-report-wiring` — ready for review**)
 
 ## Interface stable
 NO
@@ -36,9 +37,14 @@ natural exit. Produces per-trade alpha + aggregate stats so we can separate
   emission. `all_eligible_runner.exe --scenario <path> --out-dir <path>` →
   `trades.csv` + `summary.md` + `config.sexp`. 9 integration / unit tests.
   Bin lives at `trading/trading/backtest/all_eligible/bin/`.
-- **PR-3** (deferred) — wire `all_eligible_runner` into the release-report
-  pipeline so every nightly run emits the diagnostic alongside
-  `optimal_strategy.md`.
+- **PR-3** (merged #1017) — wire `all_eligible_runner` into the
+  `scenario_runner` post-step so every per-scenario child emits the
+  diagnostic alongside `actual.sexp` / `summary.sexp`.
+- **PR-4** (this PR — `feat/all-eligible-release-report-wiring`) — surface
+  the diagnostic in the release comparison report. Adds a structured
+  `summary.sexp` emission to the runner + a new `all_eligible_summary`
+  field on `Release_report.scenario_run` + an "All-eligible diagnostic"
+  section in the rendered markdown.
 
 ## Open work
 
@@ -55,6 +61,8 @@ natural exit. Produces per-trade alpha + aggregate stats so we can separate
   sweep cascade thresholds without editing scenario files. Currently the
   flag is a passthrough — accepted for forward-compat but not yet
   threaded.
+- [x] Extend `release_report.load_scenario_run` to surface the
+  `all_eligible/grade-C/` artefact in markdown. **PR-4 (this PR).**
 
 ## Completed
 
@@ -69,8 +77,7 @@ natural exit. Produces per-trade alpha + aggregate stats so we can separate
   $10K-per-signal sizing (negative all-eligible alpha across the
   universe — informs the "screener cascade is keeping the average
   signal out" hypothesis).
-- 2026-05-10 — **PR-3 release-report wiring** READY_FOR_REVIEW on
-  `feat/all-eligible-release-report` (`6eb8d6d`).
+- 2026-05-10 — **PR-3 release-report wiring** merged via #1017.
   `Backtest_all_eligible.Scenario_post_step.emit` facade + `scenario_runner`
   wiring so every per-scenario child writes
   `<scenario_dir>/all_eligible/grade-C/{trades.csv,summary.md,config.sexp}`
@@ -79,9 +86,26 @@ natural exit. Produces per-trade alpha + aggregate stats so we can separate
   tests cover enabled/disabled/failure-isolation under
   `trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml`.
   Diagnostic failures inside the runner are logged + swallowed so a crash
-  never aborts the parent backtest. Verify:
+  never aborts the parent backtest.
+- 2026-05-11 — **PR-4 release-report rendering** READY_FOR_REVIEW on
+  `feat/all-eligible-release-report-wiring`. Three additive changes:
+  (1) `Grade_sweep._emit_cell` now writes a fourth artefact
+  `summary.sexp` alongside `trades.csv` / `summary.md` / `config.sexp` —
+  the structured `All_eligible.aggregate` is round-trippable across batches.
+  (2) `Release_report.scenario_run` gains an optional `all_eligible`
+  field populated by a new `_try_load_all_eligible_summary` helper that
+  reads `<scenario>/all_eligible/grade-C/summary.sexp` and decodes via
+  `@@sexp.allow_extra_fields` (intentionally drops the producer-side
+  `return_buckets` histogram).
+  (3) `Release_report.render` surfaces an "All-eligible diagnostic"
+  section between trade-quality and optimal-strategy, with per-scenario
+  metrics (trade count, winners/losers, win rate, mean+median return,
+  total P&L) and a `trades.csv` drill-down link. Six new tests cover
+  summary.sexp round-trip + loader presence/absence/malformed +
+  renderer omission/presence/one-sided. Verify:
   ```bash
   dune runtest trading/trading/backtest/all_eligible
+  dune runtest trading/trading/backtest/test
   ```
 
 ## Verify

--- a/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
+++ b/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
@@ -247,15 +247,9 @@ let test_summary_sexp_round_trips _ =
   assert_that parsed
     (all_of
        [
-         field
-           (fun (a : All_eligible.aggregate) -> a.trade_count)
-           (equal_to 0);
-         field
-           (fun (a : All_eligible.aggregate) -> a.winners)
-           (equal_to 0);
-         field
-           (fun (a : All_eligible.aggregate) -> a.losers)
-           (equal_to 0);
+         field (fun (a : All_eligible.aggregate) -> a.trade_count) (equal_to 0);
+         field (fun (a : All_eligible.aggregate) -> a.winners) (equal_to 0);
+         field (fun (a : All_eligible.aggregate) -> a.losers) (equal_to 0);
          field
            (fun (a : All_eligible.aggregate) -> a.total_pnl_dollars)
            (float_equal 0.0);

--- a/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
+++ b/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
@@ -161,24 +161,27 @@ let _cell_dir ~out_dir grade_dirname = Filename.concat out_dir grade_dirname
 
 let _default_cell_dir ~out_dir = _cell_dir ~out_dir "grade-C"
 
-let test_run_emits_three_artefacts _ =
+let test_run_emits_four_artefacts _ =
   let data_dir, out_dir = _mk_tmpdirs "all_elig_smoke" in
   let scenario_path = _stage_fixture ~data_dir in
   let args = _make_args ~scenario_path ~out_dir in
   _with_data_dir ~data_dir (fun () -> Runner.run_with_args args);
   let cell = _default_cell_dir ~out_dir in
   let trades = Filename.concat cell "trades.csv" in
-  let summary = Filename.concat cell "summary.md" in
+  let summary_md = Filename.concat cell "summary.md" in
+  let summary_sexp = Filename.concat cell "summary.sexp" in
   let config = Filename.concat cell "config.sexp" in
   assert_that
     ( Sys_unix.file_exists_exn trades,
-      Sys_unix.file_exists_exn summary,
+      Sys_unix.file_exists_exn summary_md,
+      Sys_unix.file_exists_exn summary_sexp,
       Sys_unix.file_exists_exn config )
     (all_of
        [
-         field (fun (t, _, _) -> t) (equal_to true);
-         field (fun (_, s, _) -> s) (equal_to true);
-         field (fun (_, _, c) -> c) (equal_to true);
+         field (fun (t, _, _, _) -> t) (equal_to true);
+         field (fun (_, s, _, _) -> s) (equal_to true);
+         field (fun (_, _, ss, _) -> ss) (equal_to true);
+         field (fun (_, _, _, c) -> c) (equal_to true);
        ])
 
 let test_summary_md_contains_aggregate_fields _ =
@@ -228,6 +231,34 @@ let test_trades_csv_has_header_only_when_no_trades _ =
              _has
                "signal_date,symbol,side,entry_price,exit_date,exit_reason,return_pct,hold_days,entry_dollars,shares,pnl_dollars,cascade_score,passes_macro";
            ];
+       ])
+
+let test_summary_sexp_round_trips _ =
+  (* Pin: summary.sexp is sexp-readable as [All_eligible.aggregate_of_sexp].
+     The flat-price fixture yields trade_count = 0, so the round-trip exercises
+     the empty-aggregate branch — what release_report.load_scenario_run will
+     decode in practice on zero-trade scenarios. *)
+  let data_dir, out_dir = _mk_tmpdirs "all_elig_summary_sexp" in
+  let scenario_path = _stage_fixture ~data_dir in
+  let args = _make_args ~scenario_path ~out_dir in
+  _with_data_dir ~data_dir (fun () -> Runner.run_with_args args);
+  let path = Filename.concat (_default_cell_dir ~out_dir) "summary.sexp" in
+  let parsed = All_eligible.aggregate_of_sexp (Sexp.load_sexp path) in
+  assert_that parsed
+    (all_of
+       [
+         field
+           (fun (a : All_eligible.aggregate) -> a.trade_count)
+           (equal_to 0);
+         field
+           (fun (a : All_eligible.aggregate) -> a.winners)
+           (equal_to 0);
+         field
+           (fun (a : All_eligible.aggregate) -> a.losers)
+           (equal_to 0);
+         field
+           (fun (a : All_eligible.aggregate) -> a.total_pnl_dollars)
+           (float_equal 0.0);
        ])
 
 let test_config_sexp_round_trips _ =
@@ -488,6 +519,7 @@ let test_grade_sweep_emits_per_grade_subdirs _ =
         let dir = Filename.concat out_dir cell in
         Sys_unix.file_exists_exn (Filename.concat dir "trades.csv")
         && Sys_unix.file_exists_exn (Filename.concat dir "summary.md")
+        && Sys_unix.file_exists_exn (Filename.concat dir "summary.sexp")
         && Sys_unix.file_exists_exn (Filename.concat dir "config.sexp"))
   in
   let top_summary_body =
@@ -552,12 +584,13 @@ let test_format_summary_md_pins_table_header _ =
 let suite =
   "All_eligible_runner"
   >::: [
-         "run emits three artefacts" >:: test_run_emits_three_artefacts;
+         "run emits four artefacts" >:: test_run_emits_four_artefacts;
          "summary.md surfaces aggregate fields"
          >:: test_summary_md_contains_aggregate_fields;
          "trades.csv header-only on zero-trade run"
          >:: test_trades_csv_has_header_only_when_no_trades;
          "config.sexp round-trips" >:: test_config_sexp_round_trips;
+         "summary.sexp round-trips" >:: test_summary_sexp_round_trips;
          "parse_argv minimum required flags" >:: test_parse_argv_minimum;
          "parse_argv all flags populated" >:: test_parse_argv_all_flags;
          "parse_argv --min-grade variants" >:: test_parse_argv_min_grade;

--- a/trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml
+++ b/trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml
@@ -6,8 +6,9 @@
     [test_all_eligible_runner] (so they're robust to scanner / scorer drift) and
     pin the wiring contract:
 
-    - [enabled = true] → [<scenario_dir>/all_eligible/grade-C/] gets the three
-      runner artefacts ([trades.csv], [summary.md], [config.sexp]).
+    - [enabled = true] → [<scenario_dir>/all_eligible/grade-C/] gets the four
+      runner artefacts ([trades.csv], [summary.md], [summary.sexp],
+      [config.sexp]).
     - [enabled = false] → no [all_eligible] subdir is created at all (so the
       [scenario_runner --no-emit-all-eligible] flag is a real no-op).
 
@@ -120,10 +121,11 @@ let _mk_tmpdirs prefix =
 (* ------------------------------------------------------------------ *)
 
 (** Pins the [enabled = true] wiring: the post-step writes
-    [<scenario_dir>/all_eligible/grade-C/{trades.csv,summary.md,config.sexp}].
-    These three artefacts are the contract [release_report.load_scenario_run]
-    will consume in a future follow-up. *)
-let test_emit_enabled_writes_three_artefacts _ =
+    [<scenario_dir>/all_eligible/grade-C/{trades.csv,summary.md,summary.sexp,config.sexp}].
+    These four artefacts are the contract [release_report.load_scenario_run]
+    consumes — [summary.sexp] is the structured aggregate the comparison
+    renderer surfaces in the markdown report. *)
+let test_emit_enabled_writes_four_artefacts _ =
   let data_dir, scenario_dir = _mk_tmpdirs "post_step_on" in
   let scenario_path = _stage_fixture ~data_dir in
   _with_data_dir ~data_dir (fun () ->
@@ -132,17 +134,20 @@ let test_emit_enabled_writes_three_artefacts _ =
     Filename.concat (Filename.concat scenario_dir "all_eligible") "grade-C"
   in
   let trades = Filename.concat cell "trades.csv" in
-  let summary = Filename.concat cell "summary.md" in
+  let summary_md = Filename.concat cell "summary.md" in
+  let summary_sexp = Filename.concat cell "summary.sexp" in
   let config = Filename.concat cell "config.sexp" in
   assert_that
     ( Sys_unix.file_exists_exn trades,
-      Sys_unix.file_exists_exn summary,
+      Sys_unix.file_exists_exn summary_md,
+      Sys_unix.file_exists_exn summary_sexp,
       Sys_unix.file_exists_exn config )
     (all_of
        [
-         field (fun (t, _, _) -> t) (equal_to true);
-         field (fun (_, s, _) -> s) (equal_to true);
-         field (fun (_, _, c) -> c) (equal_to true);
+         field (fun (t, _, _, _) -> t) (equal_to true);
+         field (fun (_, s, _, _) -> s) (equal_to true);
+         field (fun (_, _, ss, _) -> ss) (equal_to true);
+         field (fun (_, _, _, c) -> c) (equal_to true);
        ])
 
 (** Pins the [enabled = false] wiring: no [all_eligible] subdir is created. This
@@ -179,8 +184,8 @@ let test_emit_swallows_runner_failure _ =
 let suite =
   "Scenario_post_step"
   >::: [
-         "emit enabled writes three artefacts under all_eligible/grade-C"
-         >:: test_emit_enabled_writes_three_artefacts;
+         "emit enabled writes four artefacts under all_eligible/grade-C"
+         >:: test_emit_enabled_writes_four_artefacts;
          "emit disabled creates no all_eligible subdir"
          >:: test_emit_disabled_creates_no_subdir;
          "emit swallows runner failures (does not raise)"

--- a/trading/trading/backtest/all_eligible/lib/grade_sweep.ml
+++ b/trading/trading/backtest/all_eligible/lib/grade_sweep.ml
@@ -87,11 +87,15 @@ type cell_inputs = {
 let _write_config_sexp ~path (config : All_eligible.config) : unit =
   Sexp.save_hum path (All_eligible.sexp_of_config config)
 
-(** Write the three per-cell artefacts to [cell_dir]. *)
+let _write_summary_sexp ~path (aggregate : All_eligible.aggregate) : unit =
+  Sexp.save_hum path (All_eligible.sexp_of_aggregate aggregate)
+
+(** Write the four per-cell artefacts to [cell_dir]. *)
 let _emit_cell ~cell_dir ~(inputs : cell_inputs) ~(config : All_eligible.config)
     ~(result : All_eligible.result) : unit =
   let trades_path = Filename.concat cell_dir "trades.csv" in
-  let summary_path = Filename.concat cell_dir "summary.md" in
+  let summary_md_path = Filename.concat cell_dir "summary.md" in
+  let summary_sexp_path = Filename.concat cell_dir "summary.sexp" in
   let config_path = Filename.concat cell_dir "config.sexp" in
   inputs.write_trades_csv ~path:trades_path result;
   let md =
@@ -100,10 +104,11 @@ let _emit_cell ~cell_dir ~(inputs : cell_inputs) ~(config : All_eligible.config)
       ~start_date:inputs.scenario.period.start_date
       ~end_date:inputs.scenario.period.end_date ~result
   in
-  Out_channel.write_all summary_path ~data:md;
+  Out_channel.write_all summary_md_path ~data:md;
+  _write_summary_sexp ~path:summary_sexp_path result.aggregate;
   _write_config_sexp ~path:config_path config;
-  eprintf "all_eligible: wrote %s, %s, %s\n%!" trades_path summary_path
-    config_path
+  eprintf "all_eligible: wrote %s, %s, %s, %s\n%!" trades_path summary_md_path
+    summary_sexp_path config_path
 
 (** Materialise the cell directory + emit one cell. Common between single and
     sweep modes. *)

--- a/trading/trading/backtest/release_report/release_report.ml
+++ b/trading/trading/backtest/release_report/release_report.ml
@@ -47,6 +47,18 @@ type optimal_summary_pair = {
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]
 
+type all_eligible_summary = {
+  trade_count : int;
+  winners : int;
+  losers : int;
+  win_rate_pct : float;
+  mean_return_pct : float;
+  median_return_pct : float;
+  total_pnl_dollars : float;
+  trades_csv_path : string;
+}
+[@@deriving sexp] [@@sexp.allow_extra_fields]
+
 type scenario_run = {
   name : string;
   actual : actual;
@@ -55,6 +67,7 @@ type scenario_run = {
   wall_seconds : float option;
   trade_quality : Trade_audit_report.t option;
   optimal_strategy : optimal_summary_pair option;
+  all_eligible : all_eligible_summary option;
 }
 [@@deriving sexp]
 
@@ -136,6 +149,59 @@ let _try_load_optimal_summary ~dir ~scenario_name : optimal_summary_pair option
         }
     with _ -> None
 
+(* On-disk shape of [all_eligible/grade-C/summary.sexp] — mirrors the
+   [Backtest_all_eligible.All_eligible.aggregate] producer. We re-declare the
+   shape locally so [release_report] does not need to depend on the heavy
+   [backtest_all_eligible] library; [@@sexp.allow_extra_fields] absorbs
+   producer-side fields the comparison report does not surface (notably
+   [return_buckets], which is a per-cell histogram and would inflate the report
+   without per-batch context). The fields kept here are exactly those the
+   rendered table reads. *)
+type _all_eligible_summary_on_disk = {
+  trade_count : int;
+  winners : int;
+  losers : int;
+  win_rate_pct : float;
+  mean_return_pct : float;
+  median_return_pct : float;
+  total_pnl_dollars : float;
+}
+[@@deriving of_sexp] [@@sexp.allow_extra_fields]
+
+let _all_eligible_cell_subdir = Filename.concat "all_eligible" "grade-C"
+
+let _try_load_all_eligible_summary ~dir ~scenario_name :
+    all_eligible_summary option =
+  (* Loads [<dir>/all_eligible/grade-C/summary.sexp] when present. The
+     companion [trades.csv] path is recorded for the rendered drill-down link;
+     the section still renders if the CSV is absent (the link will 404 but
+     the metrics are intact). Any read / parse failure swallows silently —
+     the all-eligible section is auxiliary, never a hard requirement. *)
+  let cell_dir = Filename.concat dir _all_eligible_cell_subdir in
+  let sexp_path = Filename.concat cell_dir "summary.sexp" in
+  if not (Sys_unix.file_exists_exn sexp_path) then None
+  else
+    try
+      let on_disk =
+        _all_eligible_summary_on_disk_of_sexp (Sexp.load_sexp sexp_path)
+      in
+      let trades_csv_path =
+        Filename.concat scenario_name
+          (Filename.concat _all_eligible_cell_subdir "trades.csv")
+      in
+      Some
+        {
+          trade_count = on_disk.trade_count;
+          winners = on_disk.winners;
+          losers = on_disk.losers;
+          win_rate_pct = on_disk.win_rate_pct;
+          mean_return_pct = on_disk.mean_return_pct;
+          median_return_pct = on_disk.median_return_pct;
+          total_pnl_dollars = on_disk.total_pnl_dollars;
+          trades_csv_path;
+        }
+    with _ -> None
+
 let load_scenario_run ~dir =
   let name = Filename.basename dir in
   let actual_path = Filename.concat dir "actual.sexp" in
@@ -154,6 +220,9 @@ let load_scenario_run ~dir =
   in
   let trade_quality = _try_load_trade_quality ~dir in
   let optimal_strategy = _try_load_optimal_summary ~dir ~scenario_name:name in
+  let all_eligible =
+    _try_load_all_eligible_summary ~dir ~scenario_name:name
+  in
   {
     name;
     actual;
@@ -162,6 +231,7 @@ let load_scenario_run ~dir =
     wall_seconds;
     trade_quality;
     optimal_strategy;
+    all_eligible;
   }
 
 let _list_scenario_subdirs root =

--- a/trading/trading/backtest/release_report/release_report.ml
+++ b/trading/trading/backtest/release_report/release_report.ml
@@ -722,12 +722,123 @@ let _optimal_strategy_section paired =
     let body = List.concat_map with_optimal ~f:_row_optimal_for_pair in
     header @ body
 
+(* --- All-eligible diagnostic section ---
+
+   For each paired scenario where at least one side has [Some _] all-eligible
+   artefacts, surface the headline aggregate (trade count, win rate, mean /
+   median return, total P&L) for current vs prior side. The diagnostic
+   measures opportunity cost: it sizes every cascade-admissible Stage-2
+   breakout signal at a uniform fixed-dollar entry, bypassing every
+   portfolio-level rejection (cash, exposure cap, sector concentration), and
+   reports what each signal would have returned. A negative win rate / total
+   P&L across the universe with a positive [actual] return implies the
+   cascade is correctly keeping the average signal out; the inverse implies
+   the cascade is leaving alpha on the table. Per-trade drill-down lives in
+   the linked [trades.csv]. *)
+
+let _fmt_pct_fraction_signed v = sprintf "%+.2f%%" (v *. 100.0)
+let _fmt_pnl_dollars v = sprintf "%+.0f" v
+let _fmt_int_signed v = sprintf "%d" v
+
+let _alleli_row ~label ~cur_str ~prior_str =
+  sprintf "| %s | %s | %s |" label cur_str prior_str
+
+let _alleli_field_str (run : scenario_run) ~(fmt : float -> string)
+    ~(get : all_eligible_summary -> float) =
+  match run.all_eligible with None -> "—" | Some s -> fmt (get s)
+
+let _alleli_int_field_str (run : scenario_run)
+    ~(get : all_eligible_summary -> int) =
+  match run.all_eligible with
+  | None -> "—"
+  | Some s -> _fmt_int_signed (get s)
+
+let _alleli_link_str (run : scenario_run) =
+  Option.map run.all_eligible ~f:(fun s ->
+      sprintf "[trades.csv](%s)" s.trades_csv_path)
+  |> _fmt_optional_str
+
+let _row_all_eligible_for_pair (cur, prior) =
+  [
+    sprintf "### %s" cur.name;
+    "";
+    sprintf "Drill-down — Current: %s · Prior: %s" (_alleli_link_str cur)
+      (_alleli_link_str prior);
+    "";
+    "| Metric | Current | Prior |";
+    "|---|---:|---:|";
+    _alleli_row ~label:"Trades"
+      ~cur_str:(_alleli_int_field_str cur ~get:(fun s -> s.trade_count))
+      ~prior_str:(_alleli_int_field_str prior ~get:(fun s -> s.trade_count));
+    _alleli_row ~label:"Winners"
+      ~cur_str:(_alleli_int_field_str cur ~get:(fun s -> s.winners))
+      ~prior_str:(_alleli_int_field_str prior ~get:(fun s -> s.winners));
+    _alleli_row ~label:"Losers"
+      ~cur_str:(_alleli_int_field_str cur ~get:(fun s -> s.losers))
+      ~prior_str:(_alleli_int_field_str prior ~get:(fun s -> s.losers));
+    _alleli_row ~label:"Win rate"
+      ~cur_str:
+        (_alleli_field_str cur ~fmt:_fmt_pct_fraction_signed ~get:(fun s ->
+             s.win_rate_pct))
+      ~prior_str:
+        (_alleli_field_str prior ~fmt:_fmt_pct_fraction_signed ~get:(fun s ->
+             s.win_rate_pct));
+    _alleli_row ~label:"Mean return"
+      ~cur_str:
+        (_alleli_field_str cur ~fmt:_fmt_pct_fraction_signed ~get:(fun s ->
+             s.mean_return_pct))
+      ~prior_str:
+        (_alleli_field_str prior ~fmt:_fmt_pct_fraction_signed ~get:(fun s ->
+             s.mean_return_pct));
+    _alleli_row ~label:"Median return"
+      ~cur_str:
+        (_alleli_field_str cur ~fmt:_fmt_pct_fraction_signed ~get:(fun s ->
+             s.median_return_pct))
+      ~prior_str:
+        (_alleli_field_str prior ~fmt:_fmt_pct_fraction_signed ~get:(fun s ->
+             s.median_return_pct));
+    _alleli_row ~label:"Total P&L ($)"
+      ~cur_str:
+        (_alleli_field_str cur ~fmt:_fmt_pnl_dollars ~get:(fun s ->
+             s.total_pnl_dollars))
+      ~prior_str:
+        (_alleli_field_str prior ~fmt:_fmt_pnl_dollars ~get:(fun s ->
+             s.total_pnl_dollars));
+    "";
+  ]
+
+let _all_eligible_section paired =
+  let with_alleli =
+    List.filter paired ~f:(fun (c, p) ->
+        Option.is_some c.all_eligible || Option.is_some p.all_eligible)
+  in
+  if List.is_empty with_alleli then []
+  else
+    let header =
+      [
+        "## All-eligible diagnostic";
+        "";
+        "Fixed-dollar opportunity-cost diagnostic — every cascade-admissible \
+         Stage-2 breakout signal is sized at a uniform entry and tracked to \
+         its natural exit, bypassing portfolio-level rejections \
+         (`all_eligible/grade-C/summary.sexp` required). Compare against \
+         actual trading metrics: negative aggregate P&L with a positive \
+         actual return means the cascade is correctly keeping the average \
+         signal out; the inverse means signal alpha is being left on the \
+         table. Per-trade drill-down lives in the linked `trades.csv`.";
+        "";
+      ]
+    in
+    let body = List.concat_map with_alleli ~f:_row_all_eligible_for_pair in
+    header @ body
+
 let render ?(thresholds = default_thresholds) (t : t) =
   let lines =
     _section_header ~title:"Release perf report" ~current:t.current_label
       ~prior:t.prior_label
     @ _trading_section t.paired
     @ _trade_quality_section t.paired
+    @ _all_eligible_section t.paired
     @ _optimal_strategy_section t.paired
     @ _rss_section ~thresholds t.paired
     @ _wall_section ~thresholds t.paired

--- a/trading/trading/backtest/release_report/release_report.ml
+++ b/trading/trading/backtest/release_report/release_report.ml
@@ -220,9 +220,7 @@ let load_scenario_run ~dir =
   in
   let trade_quality = _try_load_trade_quality ~dir in
   let optimal_strategy = _try_load_optimal_summary ~dir ~scenario_name:name in
-  let all_eligible =
-    _try_load_all_eligible_summary ~dir ~scenario_name:name
-  in
+  let all_eligible = _try_load_all_eligible_summary ~dir ~scenario_name:name in
   {
     name;
     actual;
@@ -749,9 +747,7 @@ let _alleli_field_str (run : scenario_run) ~(fmt : float -> string)
 
 let _alleli_int_field_str (run : scenario_run)
     ~(get : all_eligible_summary -> int) =
-  match run.all_eligible with
-  | None -> "—"
-  | Some s -> _fmt_int_signed (get s)
+  match run.all_eligible with None -> "—" | Some s -> _fmt_int_signed (get s)
 
 let _alleli_link_str (run : scenario_run) =
   Option.map run.all_eligible ~f:(fun s ->
@@ -822,10 +818,10 @@ let _all_eligible_section paired =
          Stage-2 breakout signal is sized at a uniform entry and tracked to \
          its natural exit, bypassing portfolio-level rejections \
          (`all_eligible/grade-C/summary.sexp` required). Compare against \
-         actual trading metrics: negative aggregate P&L with a positive \
-         actual return means the cascade is correctly keeping the average \
-         signal out; the inverse means signal alpha is being left on the \
-         table. Per-trade drill-down lives in the linked `trades.csv`.";
+         actual trading metrics: negative aggregate P&L with a positive actual \
+         return means the cascade is correctly keeping the average signal out; \
+         the inverse means signal alpha is being left on the table. Per-trade \
+         drill-down lives in the linked `trades.csv`.";
         "";
       ]
     in

--- a/trading/trading/backtest/release_report/release_report.mli
+++ b/trading/trading/backtest/release_report/release_report.mli
@@ -120,9 +120,9 @@ type all_eligible_summary = {
       (** Sum of per-trade [pnl_dollars] across every signal at the cell's
           fixed-dollar sizing. *)
   trades_csv_path : string;
-      (** Relative path (from the scenario directory's parent batch root) to
-          the per-trade [trades.csv] — used to render a markdown link for
-          drill-down in the report. Always
+      (** Relative path (from the scenario directory's parent batch root) to the
+          per-trade [trades.csv] — used to render a markdown link for drill-down
+          in the report. Always
           [<scenario_name>/all_eligible/grade-C/trades.csv]. *)
 }
 [@@deriving sexp]
@@ -130,8 +130,8 @@ type all_eligible_summary = {
     plus a relative path to its companion [trades.csv]. Mirrors the on-disk
     shape that {!Backtest_all_eligible.Grade_sweep} writes; decoded with
     [@@sexp.allow_extra_fields] so the reader survives forward additions on the
-    producer side (e.g. the [return_buckets] field is intentionally dropped —
-    it doesn't render in the comparison report). *)
+    producer side (e.g. the [return_buckets] field is intentionally dropped — it
+    doesn't render in the comparison report). *)
 
 type scenario_run = {
   name : string;

--- a/trading/trading/backtest/release_report/release_report.mli
+++ b/trading/trading/backtest/release_report/release_report.mli
@@ -103,6 +103,36 @@ type optimal_summary_pair = {
     alongside it. Built by {!load_scenario_run} when both files are present in
     the scenario dir. *)
 
+type all_eligible_summary = {
+  trade_count : int;
+  winners : int;
+  losers : int;
+  win_rate_pct : float;
+      (** Per-trade win rate as a decimal fraction in [0.0, 1.0]. Mirrors the
+          [All_eligible.aggregate.win_rate_pct] contract — multiply by 100 to
+          compare against {!actual.win_rate} which is already in percentage
+          units. *)
+  mean_return_pct : float;
+      (** Arithmetic mean of per-trade [return_pct] as a decimal fraction. *)
+  median_return_pct : float;
+      (** Median of per-trade [return_pct] as a decimal fraction. *)
+  total_pnl_dollars : float;
+      (** Sum of per-trade [pnl_dollars] across every signal at the cell's
+          fixed-dollar sizing. *)
+  trades_csv_path : string;
+      (** Relative path (from the scenario directory's parent batch root) to
+          the per-trade [trades.csv] — used to render a markdown link for
+          drill-down in the report. Always
+          [<scenario_name>/all_eligible/grade-C/trades.csv]. *)
+}
+[@@deriving sexp]
+(** The headline metrics from the [all_eligible/grade-C/summary.sexp] artefact
+    plus a relative path to its companion [trades.csv]. Mirrors the on-disk
+    shape that {!Backtest_all_eligible.Grade_sweep} writes; decoded with
+    [@@sexp.allow_extra_fields] so the reader survives forward additions on the
+    producer side (e.g. the [return_buckets] field is intentionally dropped —
+    it doesn't render in the comparison report). *)
+
 type scenario_run = {
   name : string;
   actual : actual;
@@ -121,16 +151,25 @@ type scenario_run = {
           [optimal_strategy.exe] binary against their output dir. The report
           renders an additional "Optimal-strategy delta" section for paired
           scenarios where at least one side has [Some _]. *)
+  all_eligible : all_eligible_summary option;
+      (** Loaded from [all_eligible/grade-C/summary.sexp] in the scenario dir
+          when present. [None] for scenarios that did not run the all-eligible
+          diagnostic (e.g. scenario_runner invoked with
+          [--no-emit-all-eligible]). The report renders an additional
+          "All-eligible diagnostic" section for paired scenarios where at least
+          one side has [Some _]. *)
 }
 [@@deriving sexp]
 (** One scenario's per-run readings — the [actual] block plus optional
-    infra-perf measurements, an optional trade-audit summary, and an optional
-    optimal-strategy counterfactual summary. Both [peak_rss_kb] and
-    [wall_seconds] are [None] when the corresponding sibling files are absent in
-    the batch dir; the report still renders trading metrics in that case.
-    [trade_quality] is [None] when no audit artefacts were found or when the
-    audit was empty (no trades). [optimal_strategy] is [None] when no
-    [optimal_summary.sexp] was emitted. *)
+    infra-perf measurements, an optional trade-audit summary, an optional
+    optimal-strategy counterfactual summary, and an optional all-eligible
+    diagnostic summary. Both [peak_rss_kb] and [wall_seconds] are [None] when
+    the corresponding sibling files are absent in the batch dir; the report
+    still renders trading metrics in that case. [trade_quality] is [None] when
+    no audit artefacts were found or when the audit was empty (no trades).
+    [optimal_strategy] is [None] when no [optimal_summary.sexp] was emitted.
+    [all_eligible] is [None] when no [all_eligible/grade-C/summary.sexp] was
+    emitted. *)
 
 type t = {
   current_label : string;

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -1035,7 +1035,8 @@ let test_render_omits_all_eligible_when_both_none _ =
     (all_of
        [
          field
-           (fun s -> String.is_substring s ~substring:"## All-eligible diagnostic")
+           (fun s ->
+             String.is_substring s ~substring:"## All-eligible diagnostic")
            (equal_to false);
          field
            (fun s -> String.is_substring s ~substring:"Drill-down — Current:")
@@ -1079,7 +1080,8 @@ let test_render_includes_all_eligible_when_present _ =
     (all_of
        [
          field
-           (fun s -> String.is_substring s ~substring:"## All-eligible diagnostic")
+           (fun s ->
+             String.is_substring s ~substring:"## All-eligible diagnostic")
            (equal_to true);
          field
            (fun s -> String.is_substring s ~substring:"### recovery-2023")
@@ -1147,7 +1149,8 @@ let test_render_all_eligible_handles_one_sided _ =
     (all_of
        [
          field
-           (fun s -> String.is_substring s ~substring:"## All-eligible diagnostic")
+           (fun s ->
+             String.is_substring s ~substring:"## All-eligible diagnostic")
            (equal_to true);
          field
            (fun s ->
@@ -1161,7 +1164,8 @@ let test_render_all_eligible_handles_one_sided _ =
            (fun s -> String.is_substring s ~substring:"| Trades | 200 | — |")
            (equal_to true);
          field
-           (fun s -> String.is_substring s ~substring:"| Win rate | +30.00% | — |")
+           (fun s ->
+             String.is_substring s ~substring:"| Win rate | +30.00% | — |")
            (equal_to true);
        ])
 
@@ -1185,8 +1189,7 @@ let _write_all_eligible_summary_sexp path =
 
 let _stage_all_eligible_cell ~scenario_dir =
   let cell =
-    Filename.concat scenario_dir
-      (Filename.concat "all_eligible" "grade-C")
+    Filename.concat scenario_dir (Filename.concat "all_eligible" "grade-C")
   in
   Core_unix.mkdir_p cell;
   _write_all_eligible_summary_sexp (Filename.concat cell "summary.sexp")
@@ -1205,8 +1208,7 @@ let test_load_scenario_run_loads_all_eligible_when_present _ =
               (fun (s : Release_report.all_eligible_summary) -> s.trade_count)
               (equal_to 100);
             field
-              (fun (s : Release_report.all_eligible_summary) ->
-                s.win_rate_pct)
+              (fun (s : Release_report.all_eligible_summary) -> s.win_rate_pct)
               (float_equal 0.30);
             field
               (fun (s : Release_report.all_eligible_summary) ->
@@ -1233,12 +1235,10 @@ let test_load_scenario_run_no_all_eligible_when_sexp_malformed _ =
   _make_scenario_dir ~root:dir "malformed-alleli" ~with_perf:false;
   let scenario_dir = Filename.concat dir "malformed-alleli" in
   let cell =
-    Filename.concat scenario_dir
-      (Filename.concat "all_eligible" "grade-C")
+    Filename.concat scenario_dir (Filename.concat "all_eligible" "grade-C")
   in
   Core_unix.mkdir_p cell;
-  _write_text (Filename.concat cell "summary.sexp")
-    "this is not valid sexp\n";
+  _write_text (Filename.concat cell "summary.sexp") "this is not valid sexp\n";
   let run = Release_report.load_scenario_run ~dir:scenario_dir in
   assert_that run.all_eligible is_none
 

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -1011,6 +1011,160 @@ let test_load_scenario_run_loads_optimal_strategy_with_extra_fields _ =
               (float_equal 0.35);
           ]))
 
+(* --- All-eligible diagnostic section ---
+
+   For paired scenarios where at least one side has [Some _] all-eligible
+   artefacts, the renderer surfaces a fixed-dollar opportunity-cost diagnostic
+   plus a link to the per-scenario [trades.csv]. These tests pin the section's
+   omission, presence, and one-sided rendering. *)
+
+let test_render_omits_all_eligible_when_both_none _ =
+  let cur = _make_run ~name:"recovery-2023" () in
+  let prior = _make_run ~name:"recovery-2023" () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"## All-eligible diagnostic")
+           (equal_to false);
+         field
+           (fun s -> String.is_substring s ~substring:"Drill-down — Current:")
+           (equal_to false);
+       ])
+
+let test_render_includes_all_eligible_when_present _ =
+  let cur =
+    _make_run ~name:"recovery-2023"
+      ~all_eligible:
+        (Some
+           (_make_all_eligible_summary ~trade_count:200 ~winners:60 ~losers:130
+              ~win_rate_pct:0.30 ~mean_return_pct:(-0.04)
+              ~median_return_pct:(-0.06) ~total_pnl_dollars:(-80_000.0)
+              ~trades_csv_path:"recovery-2023/all_eligible/grade-C/trades.csv"
+              ()))
+      ()
+  in
+  let prior =
+    _make_run ~name:"recovery-2023"
+      ~all_eligible:
+        (Some
+           (_make_all_eligible_summary ~trade_count:180 ~winners:55 ~losers:115
+              ~win_rate_pct:0.31 ~mean_return_pct:(-0.03)
+              ~median_return_pct:(-0.05) ~total_pnl_dollars:(-60_000.0)
+              ~trades_csv_path:"recovery-2023/all_eligible/grade-C/trades.csv"
+              ()))
+      ()
+  in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"## All-eligible diagnostic")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"### recovery-2023")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:
+                 "Drill-down — Current: \
+                  [trades.csv](recovery-2023/all_eligible/grade-C/trades.csv) \
+                  · Prior: \
+                  [trades.csv](recovery-2023/all_eligible/grade-C/trades.csv)")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"| Trades | 200 | 180 |")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"| Winners | 60 | 55 |")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"| Losers | 130 | 115 |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s ~substring:"| Win rate | +30.00% | +31.00% |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Mean return | -4.00% | -3.00% |")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Total P&L ($) | -80000 | -60000 |")
+           (equal_to true);
+       ])
+
+let test_render_all_eligible_handles_one_sided _ =
+  (* Only current side has artefacts — prior renders "—" in every value cell
+     and the prior link cell. *)
+  let cur =
+    _make_run ~name:"recovery-2023"
+      ~all_eligible:
+        (Some
+           (_make_all_eligible_summary ~trade_count:200 ~winners:60 ~losers:130
+              ~win_rate_pct:0.30 ~mean_return_pct:(-0.04)
+              ~median_return_pct:(-0.06) ~total_pnl_dollars:(-80_000.0)
+              ~trades_csv_path:"recovery-2023/all_eligible/grade-C/trades.csv"
+              ()))
+      ()
+  in
+  let prior = _make_run ~name:"recovery-2023" () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"## All-eligible diagnostic")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:
+                 "Drill-down — Current: \
+                  [trades.csv](recovery-2023/all_eligible/grade-C/trades.csv) \
+                  · Prior: —")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"| Trades | 200 | — |")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"| Win rate | +30.00% | — |")
+           (equal_to true);
+       ])
+
 (* --- Loader: all-eligible diagnostic round-trip via on-disk fixtures ---
 
    The all-eligible diagnostic lands at
@@ -1144,6 +1298,12 @@ let suite =
          >:: test_load_scenario_run_no_all_eligible_when_files_missing;
          "load_scenario_run no all_eligible when sexp malformed"
          >:: test_load_scenario_run_no_all_eligible_when_sexp_malformed;
+         "render omits all-eligible when both none"
+         >:: test_render_omits_all_eligible_when_both_none;
+         "render includes all-eligible when present"
+         >:: test_render_includes_all_eligible_when_present;
+         "render all-eligible handles one-sided"
+         >:: test_render_all_eligible_handles_one_sided;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -38,8 +38,8 @@ let _make_summary ?(start_date = Date.of_string "2023-01-02")
   }
 
 let _make_run ?(name = "scenario") ?actual ?summary ?(peak_rss_kb = None)
-    ?(wall_seconds = None) ?(trade_quality = None) ?(optimal_strategy = None) ()
-    : Release_report.scenario_run =
+    ?(wall_seconds = None) ?(trade_quality = None) ?(optimal_strategy = None)
+    ?(all_eligible = None) () : Release_report.scenario_run =
   let actual = Option.value actual ~default:(_make_actual ()) in
   let summary = Option.value summary ~default:(_make_summary ()) in
   {
@@ -50,6 +50,7 @@ let _make_run ?(name = "scenario") ?actual ?summary ?(peak_rss_kb = None)
     wall_seconds;
     trade_quality;
     optimal_strategy;
+    all_eligible;
   }
 
 let _make_optimal_summary ?(total_round_trips = 50) ?(winners = 25)
@@ -74,6 +75,22 @@ let _make_optimal_pair ?(constrained = _make_optimal_summary ())
     ?(report_path = "scenario/optimal_strategy.md") () :
     Release_report.optimal_summary_pair =
   { constrained; relaxed_macro; report_path }
+
+let _make_all_eligible_summary ?(trade_count = 100) ?(winners = 30)
+    ?(losers = 65) ?(win_rate_pct = 0.30) ?(mean_return_pct = -0.05)
+    ?(median_return_pct = -0.08) ?(total_pnl_dollars = -50_000.0)
+    ?(trades_csv_path = "scenario/all_eligible/grade-C/trades.csv") () :
+    Release_report.all_eligible_summary =
+  {
+    trade_count;
+    winners;
+    losers;
+    win_rate_pct;
+    mean_return_pct;
+    median_return_pct;
+    total_pnl_dollars;
+    trades_csv_path;
+  }
 
 (* --- default_thresholds --- *)
 
@@ -994,6 +1011,83 @@ let test_load_scenario_run_loads_optimal_strategy_with_extra_fields _ =
               (float_equal 0.35);
           ]))
 
+(* --- Loader: all-eligible diagnostic round-trip via on-disk fixtures ---
+
+   The all-eligible diagnostic lands at
+   [<scenario>/all_eligible/grade-C/summary.sexp]. The on-disk shape is the
+   raw [All_eligible.aggregate] sexp, which includes a [return_buckets] field
+   the comparison report intentionally drops (the histogram is per-cell and
+   doesn't carry useful cross-batch signal). These tests pin the loader's
+   presence-and-absence branches plus the [@@sexp.allow_extra_fields] guard
+   against forward additions on the producer side. *)
+
+let _write_all_eligible_summary_sexp path =
+  _write_text path
+    "((trade_count 100) (winners 30) (losers 65)\n\
+    \ (win_rate_pct 0.30) (mean_return_pct -0.05)\n\
+    \ (median_return_pct -0.08) (total_pnl_dollars -50000.00)\n\
+    \ (return_buckets (((-inf) -0.5 5) (-0.5 -0.2 20) (-0.2 0.0 40)\n\
+    \                   (0.0 0.2 25) (0.2 0.5 8) (0.5 1.0 1) (1.0 (+inf) 1))))\n"
+
+let _stage_all_eligible_cell ~scenario_dir =
+  let cell =
+    Filename.concat scenario_dir
+      (Filename.concat "all_eligible" "grade-C")
+  in
+  Core_unix.mkdir_p cell;
+  _write_all_eligible_summary_sexp (Filename.concat cell "summary.sexp")
+
+let test_load_scenario_run_loads_all_eligible_when_present _ =
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_alleli_" in
+  _make_scenario_dir ~root:dir "with-alleli" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "with-alleli" in
+  _stage_all_eligible_cell ~scenario_dir;
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.all_eligible
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (s : Release_report.all_eligible_summary) -> s.trade_count)
+              (equal_to 100);
+            field
+              (fun (s : Release_report.all_eligible_summary) ->
+                s.win_rate_pct)
+              (float_equal 0.30);
+            field
+              (fun (s : Release_report.all_eligible_summary) ->
+                s.total_pnl_dollars)
+              (float_equal (-50_000.0));
+            field
+              (fun (s : Release_report.all_eligible_summary) ->
+                s.trades_csv_path)
+              (equal_to "with-alleli/all_eligible/grade-C/trades.csv");
+          ]))
+
+let test_load_scenario_run_no_all_eligible_when_files_missing _ =
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_alleli_" in
+  _make_scenario_dir ~root:dir "no-alleli" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "no-alleli" in
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.all_eligible is_none
+
+let test_load_scenario_run_no_all_eligible_when_sexp_malformed _ =
+  (* Pins the [try ... with _ -> None] swallow on parse failure. The cell
+     directory exists and contains a [summary.sexp], but the content is not
+     valid sexp — the loader must return [None] rather than raise. *)
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_alleli_" in
+  _make_scenario_dir ~root:dir "malformed-alleli" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "malformed-alleli" in
+  let cell =
+    Filename.concat scenario_dir
+      (Filename.concat "all_eligible" "grade-C")
+  in
+  Core_unix.mkdir_p cell;
+  _write_text (Filename.concat cell "summary.sexp")
+    "this is not valid sexp\n";
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.all_eligible is_none
+
 let suite =
   "release_perf_report"
   >::: [
@@ -1044,6 +1138,12 @@ let suite =
          >:: test_load_scenario_run_no_optimal_when_sexp_malformed;
          "load_scenario_run loads optimal_strategy with extra outer fields"
          >:: test_load_scenario_run_loads_optimal_strategy_with_extra_fields;
+         "load_scenario_run loads all_eligible when present"
+         >:: test_load_scenario_run_loads_all_eligible_when_present;
+         "load_scenario_run no all_eligible when files missing"
+         >:: test_load_scenario_run_no_all_eligible_when_files_missing;
+         "load_scenario_run no all_eligible when sexp malformed"
+         >:: test_load_scenario_run_no_all_eligible_when_sexp_malformed;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Surfaces the all-eligible diagnostic in the release-perf comparison report alongside the existing trade-quality and optimal-strategy sections. Three additive changes:

1. **`Grade_sweep._emit_cell`** now writes a fourth per-cell artefact `summary.sexp` containing the structured `All_eligible.aggregate`. Existing `trades.csv` / `summary.md` / `config.sexp` schemas unchanged.
2. **`Release_report.scenario_run`** gains an optional `all_eligible : all_eligible_summary option` field, populated by `_try_load_all_eligible_summary` reading `<scenario>/all_eligible/grade-C/summary.sexp`. Decoded with `@@sexp.allow_extra_fields` so the producer-side `return_buckets` histogram (intentionally not surfaced cross-batch) is absorbed silently.
3. **`Release_report.render`** emits a new "All-eligible diagnostic" section between trade-quality and optimal-strategy. Renders only when at least one paired side has `Some _`; one-sided pairs show `—` in the missing cells. Each block links to the per-side `trades.csv` for drill-down.

The diagnostic is strictly additive — older release-report consumers continue to work against the new artefact set, the rendered section is a no-op for scenarios that haven't run the all-eligible post-step.

## Test plan

- [x] `dune build && dune runtest` passes cleanly
- [x] `dune build @fmt` clean
- [x] `dune runtest trading/backtest/all_eligible` passes 17 tests (added: `summary.sexp round-trips`, updated 2 file-count assertions)
- [x] `dune runtest trading/backtest/test` passes 32 tests (added: loader presence/absence/malformed × 3 + renderer omission/presence/one-sided × 3)

Resolves PR-4 follow-up from `dev/status/all-eligible.md` § Open work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)