### PR TITLE
chore(fmt): batch promote docstring {[ ]} indent drift

### DIFF
--- a/trading/analysis/weinstein/data_source/lib/inventory.mli
+++ b/trading/analysis/weinstein/data_source/lib/inventory.mli
@@ -7,14 +7,14 @@
 
     Typical workflow:
     {[
-      (* 1. Fetch prices for symbols of interest *)
-      fetch_symbols.exe --symbols AAPL,MSFT,...
+    (* 1. Fetch prices for symbols of interest *)
+    fetch_symbols.exe --symbols AAPL,MSFT,...
 
-      (* 2. Rebuild the inventory from cached metadata *)
-      build_inventory.exe
+    (* 2. Rebuild the inventory from cached metadata *)
+    build_inventory.exe
 
-      (* 3. Bootstrap a universe.sexp from the inventory *)
-      bootstrap_universe.exe
+    (* 3. Bootstrap a universe.sexp from the inventory *)
+    bootstrap_universe.exe
     ]}
 
     The inventory file ([inventory.sexp]) is the input to {!bootstrap_universe}

--- a/trading/trading/backtest/all_eligible/bin/all_eligible_runner.ml
+++ b/trading/trading/backtest/all_eligible/bin/all_eligible_runner.ml
@@ -7,12 +7,12 @@
     {1 Usage}
 
     {[
-      all_eligible_runner.exe \
-        --scenario trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp \
-        [--out-dir <path>] \
-        [--entry-dollars 5000.0] \
-        [--return-buckets -0.5,0.0,0.5] \
-        [--config-overrides '((some_key value))']
+    all_eligible_runner.exe \
+      --scenario trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp \
+      [--out-dir <path>] \
+      [--entry-dollars 5000.0] \
+      [--return-buckets -0.5,0.0,0.5] \
+      [--config-overrides '((some_key value))']
     ]} *)
 
 open Core

--- a/trading/trading/backtest/lib/comparison.mli
+++ b/trading/trading/backtest/lib/comparison.mli
@@ -61,10 +61,10 @@ val to_sexp : t -> Sexp.t
 (** Render [t] as a machine-readable sexp suitable for diffing or downstream
     tooling. Shape:
     {[
-      ((baseline_summary <summary-sexp>)
-       (variant_summary  <summary-sexp>)
-       (metric_diffs     ((<name> ((baseline <f>) (variant <f>) (delta <f>))) ...))
-       (scalar_diffs     ((<name> <delta>) ...)))
+    ((baseline_summary <summary-sexp>)
+     (variant_summary  <summary-sexp>)
+     (metric_diffs     ((<name> ((baseline <f>) (variant <f>) (delta <f>))) ...))
+     (scalar_diffs     ((<name> <delta>) ...)))
     ]}
     [None] floats are written as the atom [-]. *)
 

--- a/trading/trading/backtest/lib/fuzz_distribution.mli
+++ b/trading/trading/backtest/lib/fuzz_distribution.mli
@@ -61,12 +61,12 @@ val compute : fuzz_spec_raw:string -> (string * Summary.t) list -> t
 val to_sexp : t -> Sexp.t
 (** Render [t] as a machine-readable sexp. Shape:
     {[
-      ((fuzz_spec_raw <string>)
-       (variant_labels (<l1> <l2> ...))
-       (metric_stats   ((<name>
-                         ((median <f>) (p25 <f>) (p75 <f>) (std <f>)
-                          (min <f>) (max <f>)
-                          (values (<v1> <v2> ...)))) ...)))
+    ((fuzz_spec_raw <string>)
+     (variant_labels (<l1> <l2> ...))
+     (metric_stats   ((<name>
+                       ((median <f>) (p25 <f>) (p75 <f>) (std <f>)
+                        (min <f>) (max <f>)
+                        (values (<v1> <v2> ...)))) ...)))
     ]} *)
 
 val to_markdown : t -> string

--- a/trading/trading/backtest/optimal/bin/optimal_strategy.ml
+++ b/trading/trading/backtest/optimal/bin/optimal_strategy.ml
@@ -8,7 +8,7 @@
     {1 Usage}
 
     {[
-      optimal_strategy.exe --output-dir dev/backtest/scenarios-XYZ/sp500-2019-2023/
+    optimal_strategy.exe --output-dir dev/backtest/scenarios-XYZ/sp500-2019-2023/
     ]} *)
 
 open Core

--- a/trading/trading/engine/lib/engine.mli
+++ b/trading/trading/engine/lib/engine.mli
@@ -13,8 +13,8 @@ val create : engine_config -> t
 
     Example:
     {[
-      let config = { commission = { per_share = 0.01; minimum = 1.0 } } in
-      let engine = Engine.create config
+    let config = { commission = { per_share = 0.01; minimum = 1.0 } } in
+    let engine = Engine.create config
     ]} *)
 
 val update_market :
@@ -69,10 +69,10 @@ val process_orders : t -> order_manager -> execution_report list status_or
 
     Example:
     {[
-      let reports = Engine.process_orders engine order_mgr in
-      match reports with
-      | Ok reports ->
-          let trades = List.concat_map reports ~f:(fun r -> r.trades) in
-          Portfolio.apply_trades portfolio trades
-      | Error err -> (* handle error *)
+    let reports = Engine.process_orders engine order_mgr in
+    match reports with
+    | Ok reports ->
+        let trades = List.concat_map reports ~f:(fun r -> r.trades) in
+        Portfolio.apply_trades portfolio trades
+    | Error err -> (* handle error *)
     ]} *)

--- a/trading/trading/simulation/lib/antifragility_computer.mli
+++ b/trading/trading/simulation/lib/antifragility_computer.mli
@@ -30,7 +30,7 @@
     step-sourced series and pin a synthetic series. Used by tests that want to
     fix benchmark values independent of any market data adapter:
     {[
-      let computer = Antifragility_computer.computer ~benchmark_returns:[ ... ] ()
+    let computer = Antifragility_computer.computer ~benchmark_returns:[ ... ] ()
     ]}
 
     When neither path supplies a benchmark — no override, and every step has

--- a/trading/trading/strategy/lib/strategy.mli
+++ b/trading/trading/strategy/lib/strategy.mli
@@ -6,24 +6,24 @@
     {1 Usage Example}
 
     {[
-      (* Create strategies using factory *)
-      let strategies = [
-        Strategy.create_strategy (Strategy.EmaConfig {
-          symbols = ["AAPL"]; ema_period = 20; ...
-        });
-        Strategy.create_strategy (Strategy.BuyAndHoldConfig {
-          symbols = ["MSFT"]; position_size = 100.0; ...
-        });
-      ] in
+    (* Create strategies using factory *)
+    let strategies = [
+      Strategy.create_strategy (Strategy.EmaConfig {
+        symbols = ["AAPL"]; ema_period = 20; ...
+      });
+      Strategy.create_strategy (Strategy.BuyAndHoldConfig {
+        symbols = ["MSFT"]; position_size = 100.0; ...
+      });
+    ] in
 
-      (* Execute uniformly - no pattern matching needed *)
-      (* Partially apply market_data to accessor functions *)
-      let get_price_fn = get_price market_data in
-      let get_indicator_fn = get_indicator market_data in
-      let results = List.map strategies ~f:(fun strategy ->
-        Strategy.use_strategy ~get_price:get_price_fn ~get_indicator:get_indicator_fn
-          ~portfolio strategy
-      ) in
+    (* Execute uniformly - no pattern matching needed *)
+    (* Partially apply market_data to accessor functions *)
+    let get_price_fn = get_price market_data in
+    let get_indicator_fn = get_indicator market_data in
+    let results = List.map strategies ~f:(fun strategy ->
+      Strategy.use_strategy ~get_price:get_price_fn ~get_indicator:get_indicator_fn
+        ~portfolio strategy
+    ) in
     ]} *)
 
 include module type of Strategy_interface
@@ -57,16 +57,16 @@ val create_strategy : config -> t
 
     Example:
     {[
-      let ema_cfg : Ema_strategy.config =
-        {
-          symbols = [ "AAPL" ];
-          ema_period = 20;
-          stop_loss_percent = 0.05;
-          take_profit_percent = 0.10;
-          position_size = 100.0;
-        }
-      in
-      let strategy = create_strategy (EmaConfig ema_cfg)
+    let ema_cfg : Ema_strategy.config =
+      {
+        symbols = [ "AAPL" ];
+        ema_period = 20;
+        stop_loss_percent = 0.05;
+        take_profit_percent = 0.10;
+        position_size = 100.0;
+      }
+    in
+    let strategy = create_strategy (EmaConfig ema_cfg)
     ]} *)
 
 val use_strategy :


### PR DESCRIPTION
Fixes chronic ocamlformat 0.29.0 skew where CI expects 4-space indent inside `{[ ]}` blocks but commits drift to 6-space. Re-applies PR #981 cleanup batch. Blocking PRs #1034 + #1028 from merging.

## Files fixed (8)
- trading/analysis/weinstein/data_source/lib/inventory.mli
- trading/trading/simulation/lib/antifragility_computer.mli
- trading/trading/backtest/optimal/bin/optimal_strategy.ml
- trading/trading/backtest/lib/comparison.mli
- trading/trading/backtest/lib/fuzz_distribution.mli
- trading/trading/backtest/all_eligible/bin/all_eligible_runner.ml
- trading/trading/engine/lib/engine.mli
- trading/trading/strategy/lib/strategy.mli

Each block had first-content-line indent +2 over the opener `{[` indent; this PR dedents the whole block by 2 to match the canonical pattern used in already-fixed files (e.g. grid_search.mli, runner.mli).

No semantic changes — pure whitespace inside docstring code examples.