### PR TITLE
chore(fmt): batch promote docstring {[ ]} indent drift — round 2

### DIFF
--- a/trading/analysis/weinstein/stage/lib/stage.mli
+++ b/trading/analysis/weinstein/stage/lib/stage.mli
@@ -175,8 +175,8 @@ val classify_with_callbacks :
     bottleneck, add:
 
     {[
-      val classify_step :
-        config:config -> prev_result:result -> new_bar:Daily_price.t -> result
+    val classify_step :
+      config:config -> prev_result:result -> new_bar:Daily_price.t -> result
     ]}
 
     [classify_step] would maintain an incremental MA state (e.g. a sliding
@@ -202,11 +202,11 @@ val classify_with_callbacks :
     [analysis/technical/indicators/] with a [slope] function:
 
     {[
-      val slope :
-        lookback:int ->
-        threshold:float ->
-        (Date.t * float) list ->
-        ma_direction * float
+    val slope :
+      lookback:int ->
+      threshold:float ->
+      (Date.t * float) list ->
+      ma_direction * float
     ]}
 
     This would eliminate the per-module slope implementations and give a single

--- a/trading/base/matchers/lib/matchers.mli
+++ b/trading/base/matchers/lib/matchers.mli
@@ -33,7 +33,7 @@ val __ : 'a matcher
 
     Example:
     {[
-      assert_that p (match_point ~x:(float_equal 1.0) ~y:__ ())
+    assert_that p (match_point ~x:(float_equal 1.0) ~y:__ ())
     ]} *)
 
 val assert_that : 'a -> 'a matcher -> unit
@@ -42,10 +42,10 @@ val assert_that : 'a -> 'a matcher -> unit
 
     Example:
     {[
-      assert_that actual_price (float_equal 150.25)
+    assert_that actual_price (float_equal 150.25)
     ]}
     {[
-      assert_that result (is_ok_and_holds (equal_to expected_value))
+    assert_that result (is_ok_and_holds (equal_to expected_value))
     ]} *)
 
 (** {1 Basic Matchers} *)
@@ -56,10 +56,10 @@ val equal_to : ?cmp:('a -> 'a -> bool) -> ?msg:string -> 'a -> 'a -> unit
 
     Example:
     {[
-      assert_that result (is_ok_and_holds (equal_to expected))
+    assert_that result (is_ok_and_holds (equal_to expected))
     ]}
     {[
-      field (fun r -> r.order_id) (equal_to "order123")
+    field (fun r -> r.order_id) (equal_to "order123")
     ]} *)
 
 val field : ('a -> 'b) -> ('b -> unit) -> 'a -> unit
@@ -69,17 +69,17 @@ val field : ('a -> 'b) -> ('b -> unit) -> 'a -> unit
 
     Example:
     {[
-      assert_that order (field (fun o -> o.status) (equal_to Filled))
+    assert_that order (field (fun o -> o.status) (equal_to Filled))
     ]}
     {[
-      elements_are reports
-        [
-          all_of
-            [
-              field (fun r -> r.order_id) (equal_to order.id);
-              field (fun r -> r.status) (equal_to Filled);
-            ];
-        ]
+    elements_are reports
+      [
+        all_of
+          [
+            field (fun r -> r.order_id) (equal_to order.id);
+            field (fun r -> r.status) (equal_to Filled);
+          ];
+      ]
     ]} *)
 
 val not_ : ?msg:string -> 'a matcher -> 'a matcher
@@ -88,11 +88,11 @@ val not_ : ?msg:string -> 'a matcher -> 'a matcher
 
     Example:
     {[
-      assert_that actual (not_ (equal_to unexpected))
+    assert_that actual (not_ (equal_to unexpected))
     ]}
     {[
-      assert_that stage
-        (not_ (equal_to (Stage2 { weeks_advancing = 3; late = false })))
+    assert_that stage
+      (not_ (equal_to (Stage2 { weeks_advancing = 3; late = false })))
     ]} *)
 
 val all_of : ('a -> unit) list -> 'a -> unit
@@ -101,22 +101,22 @@ val all_of : ('a -> unit) list -> 'a -> unit
 
     Example:
     {[
-      assert_that order
-        (all_of
-           [
-             (fun o -> assert_equal "order1" o.order_id);
-             (fun o -> assert_equal Filled o.status);
-           ])
+    assert_that order
+      (all_of
+         [
+           (fun o -> assert_equal "order1" o.order_id);
+           (fun o -> assert_equal Filled o.status);
+         ])
     ]}
     {[
-      elements_are reports
-        [
-          all_of
-            [
-              field (fun r -> r.order_id) (equal_to order.id);
-              field (fun r -> r.status) (equal_to Filled);
-            ];
-        ]
+    elements_are reports
+      [
+        all_of
+          [
+            field (fun r -> r.order_id) (equal_to order.id);
+            field (fun r -> r.status) (equal_to Filled);
+          ];
+      ]
     ]} *)
 
 (** {1 Result Matchers}
@@ -129,7 +129,7 @@ val is_ok : 'a Status.status_or matcher
 
     Example:
     {[
-      assert_that (validate_input valid_data) is_ok
+    assert_that (validate_input valid_data) is_ok
     ]} *)
 
 val is_ok_and_holds : 'a matcher -> 'a Status.status_or matcher
@@ -138,10 +138,10 @@ val is_ok_and_holds : 'a matcher -> 'a Status.status_or matcher
 
     Example:
     {[
-      assert_that result (is_ok_and_holds (equal_to expected_value))
+    assert_that result (is_ok_and_holds (equal_to expected_value))
     ]}
     {[
-      assert_that result (is_ok_and_holds (float_equal 150.25))
+    assert_that result (is_ok_and_holds (float_equal 150.25))
     ]} *)
 
 val is_error : 'a Status.status_or matcher
@@ -151,7 +151,7 @@ val is_error : 'a Status.status_or matcher
 
     Example:
     {[
-      assert_that (validate_input invalid_data) is_error
+    assert_that (validate_input invalid_data) is_error
     ]} *)
 
 val is_error_with : ?msg:string -> Status.code -> 'a Status.status_or matcher
@@ -161,14 +161,13 @@ val is_error_with : ?msg:string -> Status.code -> 'a Status.status_or matcher
 
     Example:
     {[
-      assert_that (get_order manager "nonexistent") (is_error_with NotFound)
+    assert_that (get_order manager "nonexistent") (is_error_with NotFound)
     ]}
     {[
-      assert_that (create_order invalid_params) (is_error_with Invalid_argument)
+    assert_that (create_order invalid_params) (is_error_with Invalid_argument)
     ]}
     {[
-      assert_that result
-        (is_error_with Invalid_argument ~msg:"must be positive")
+    assert_that result (is_error_with Invalid_argument ~msg:"must be positive")
     ]} *)
 
 (** {1 Option Matchers}
@@ -181,12 +180,12 @@ val is_some_and : 'a matcher -> 'a option matcher
 
     Example:
     {[
-      assert_that
-        (get_position portfolio "AAPL")
-        (is_some_and (field position_quantity (float_equal 100.0)))
+    assert_that
+      (get_position portfolio "AAPL")
+      (is_some_and (field position_quantity (float_equal 100.0)))
     ]}
     {[
-      assert_that (Map.find cache key) (is_some_and (equal_to expected))
+    assert_that (Map.find cache key) (is_some_and (equal_to expected))
     ]} *)
 
 val is_none : 'a option matcher
@@ -194,10 +193,10 @@ val is_none : 'a option matcher
 
     Example:
     {[
-      assert_that (get_position portfolio "AAPL") is_none
+    assert_that (get_position portfolio "AAPL") is_none
     ]}
     {[
-      assert_that (Map.find cache "nonexistent") is_none
+    assert_that (Map.find cache "nonexistent") is_none
     ]} *)
 
 val matching : ?msg:string -> ('a -> 'b option) -> 'b matcher -> 'a matcher
@@ -207,16 +206,16 @@ val matching : ?msg:string -> ('a -> 'b option) -> 'b matcher -> 'a matcher
 
     Example:
     {[
-      assert_that result.stage
-        (matching ~msg:"Expected Stage2"
-           (function Stage2 x -> Some x | _ -> None)
-           (field (fun s -> s.weeks_advancing) (gt (module Int_ord) 0)))
+    assert_that result.stage
+      (matching ~msg:"Expected Stage2"
+         (function Stage2 x -> Some x | _ -> None)
+         (field (fun s -> s.weeks_advancing) (gt (module Int_ord) 0)))
     ]}
     {[
-      assert_that pos_state
-        (matching
-           (function Entering e -> Some e | _ -> None)
-           (field (fun e -> e.filled_quantity) (float_equal 50.0)))
+    assert_that pos_state
+      (matching
+         (function Entering e -> Some e | _ -> None)
+         (field (fun e -> e.filled_quantity) (float_equal 50.0)))
     ]} *)
 
 val pair : 'a matcher -> 'b matcher -> ('a * 'b) matcher
@@ -225,7 +224,7 @@ val pair : 'a matcher -> 'b matcher -> ('a * 'b) matcher
 
     Example:
     {[
-      assert_that result.transition (is_some_and (pair is_stage1 is_stage2))
+    assert_that result.transition (is_some_and (pair is_stage1 is_stage2))
     ]} *)
 
 (** {1 Numeric Matchers} *)
@@ -236,10 +235,10 @@ val float_equal : ?epsilon:float -> float -> float matcher
 
     Example:
     {[
-      assert_that actual_price (float_equal 150.25)
+    assert_that actual_price (float_equal 150.25)
     ]}
     {[
-      assert_that computed_value (float_equal ~epsilon:0.01 expected)
+    assert_that computed_value (float_equal ~epsilon:0.01 expected)
     ]} *)
 
 val gt : (module Ord with type t = 'a) -> 'a -> 'a matcher
@@ -249,10 +248,10 @@ val gt : (module Ord with type t = 'a) -> 'a -> 'a matcher
 
     Example:
     {[
-      assert_that result.count (gt (module Int_ord) 0)
+    assert_that result.count (gt (module Int_ord) 0)
     ]}
     {[
-      assert_that stats.r_squared (gt (module Float_ord) 0.99)
+    assert_that stats.r_squared (gt (module Float_ord) 0.99)
     ]} *)
 
 val ge : (module Ord with type t = 'a) -> 'a -> 'a matcher
@@ -260,7 +259,7 @@ val ge : (module Ord with type t = 'a) -> 'a -> 'a matcher
 
     Example:
     {[
-      assert_that trade.price (ge (module Float_ord) min_price)
+    assert_that trade.price (ge (module Float_ord) min_price)
     ]} *)
 
 val lt : (module Ord with type t = 'a) -> 'a -> 'a matcher
@@ -268,7 +267,7 @@ val lt : (module Ord with type t = 'a) -> 'a -> 'a matcher
 
     Example:
     {[
-      assert_that sharpe_with_rf (lt (module Float_ord) sharpe_no_rf)
+    assert_that sharpe_with_rf (lt (module Float_ord) sharpe_no_rf)
     ]} *)
 
 val le : (module Ord with type t = 'a) -> 'a -> 'a matcher
@@ -276,7 +275,7 @@ val le : (module Ord with type t = 'a) -> 'a -> 'a matcher
 
     Example:
     {[
-      assert_that trade.price (le (module Float_ord) max_price)
+    assert_that trade.price (le (module Float_ord) max_price)
     ]} *)
 
 val is_between :
@@ -286,8 +285,8 @@ val is_between :
 
     Example:
     {[
-      assert_that result.confidence
-        (is_between (module Float_ord) ~low:0.0 ~high:1.0)
+    assert_that result.confidence
+      (is_between (module Float_ord) ~low:0.0 ~high:1.0)
     ]} *)
 
 (** {1 List Matchers} *)
@@ -298,11 +297,11 @@ val each : 'a matcher -> 'a list matcher
 
     Example:
     {[
-      assert_that orders (each (field (fun o -> o.status) (equal_to Filled)))
+    assert_that orders (each (field (fun o -> o.status) (equal_to Filled)))
     ]}
     {[
-      assert_that reports
-        (each (all_of [ field (fun r -> r.status) (equal_to Filled) ]))
+    assert_that reports
+      (each (all_of [ field (fun r -> r.status) (equal_to Filled) ]))
     ]} *)
 
 val one : 'a matcher -> 'a list matcher
@@ -311,10 +310,10 @@ val one : 'a matcher -> 'a list matcher
 
     Example:
     {[
-      assert_that pending_orders (one (field (fun o -> o.id) (equal_to id)))
+    assert_that pending_orders (one (field (fun o -> o.id) (equal_to id)))
     ]}
     {[
-      assert_that results (one (equal_to expected))
+    assert_that results (one (equal_to expected))
     ]} *)
 
 val elements_are : 'a matcher list -> 'a list matcher
@@ -325,29 +324,29 @@ val elements_are : 'a matcher list -> 'a list matcher
 
     Example:
     {[
-      assert_that reports
-        (elements_are
-           [
-             (fun r -> assert_equal "order1" r.order_id);
-             (fun r -> assert_equal "order2" r.order_id);
-             (fun r -> assert_equal "order3" r.order_id);
-           ])
+    assert_that reports
+      (elements_are
+         [
+           (fun r -> assert_equal "order1" r.order_id);
+           (fun r -> assert_equal "order2" r.order_id);
+           (fun r -> assert_equal "order3" r.order_id);
+         ])
     ]}
     {[
-      assert_that orders
-        (elements_are
-           [
-             all_of
-               [
-                 field (fun o -> o.id) (equal_to "order1");
-                 field (fun o -> o.status) (equal_to Pending);
-               ];
-             all_of
-               [
-                 field (fun o -> o.id) (equal_to "order2");
-                 field (fun o -> o.status) (equal_to Filled);
-               ];
-           ])
+    assert_that orders
+      (elements_are
+         [
+           all_of
+             [
+               field (fun o -> o.id) (equal_to "order1");
+               field (fun o -> o.status) (equal_to Pending);
+             ];
+           all_of
+             [
+               field (fun o -> o.id) (equal_to "order2");
+               field (fun o -> o.status) (equal_to Filled);
+             ];
+         ])
     ]} *)
 
 val unordered_elements_are : 'a matcher list -> 'a list matcher
@@ -361,21 +360,21 @@ val unordered_elements_are : 'a matcher list -> 'a list matcher
 
     Example:
     {[
-      assert_that reports
-        (unordered_elements_are
-           [
-             field (fun r -> r.order_id) (equal_to "order1");
-             field (fun r -> r.order_id) (equal_to "order2");
-             field (fun r -> r.order_id) (equal_to "order3");
-           ])
+    assert_that reports
+      (unordered_elements_are
+         [
+           field (fun r -> r.order_id) (equal_to "order1");
+           field (fun r -> r.order_id) (equal_to "order2");
+           field (fun r -> r.order_id) (equal_to "order3");
+         ])
     ]}
     {[
-      assert_that positions
-        (unordered_elements_are
-           [
-             field (fun p -> p.symbol) (equal_to "AAPL");
-             field (fun p -> p.symbol) (equal_to "MSFT");
-           ])
+    assert_that positions
+      (unordered_elements_are
+         [
+           field (fun p -> p.symbol) (equal_to "AAPL");
+           field (fun p -> p.symbol) (equal_to "MSFT");
+         ])
     ]} *)
 
 val size_is : int -> 'a list matcher
@@ -383,7 +382,7 @@ val size_is : int -> 'a list matcher
 
     Example:
     {[
-      assert_that pending_orders (size_is 3)
+    assert_that pending_orders (size_is 3)
     ]} *)
 
 val is_empty : 'a list matcher
@@ -391,7 +390,7 @@ val is_empty : 'a list matcher
 
     Example:
     {[
-      assert_that pending_orders is_empty
+    assert_that pending_orders is_empty
     ]} *)
 
 (** {1 Map Matchers} *)
@@ -402,7 +401,7 @@ val contains_entry : 'k -> 'v matcher -> ('k, 'v, 'cmp) Core.Map.t matcher
 
     Example:
     {[
-      assert_that metrics (contains_entry TotalPnl (float_equal 1234.0))
+    assert_that metrics (contains_entry TotalPnl (float_equal 1234.0))
     ]} *)
 
 val map_includes : ('k * 'v matcher) list -> ('k, 'v, 'cmp) Core.Map.t matcher
@@ -411,7 +410,7 @@ val map_includes : ('k * 'v matcher) list -> ('k, 'v, 'cmp) Core.Map.t matcher
 
     Example:
     {[
-      assert_that metrics
-        (map_includes
-           [ (TotalPnl, float_equal 1234.0); (WinRate, float_equal 60.0) ])
+    assert_that metrics
+      (map_includes
+         [ (TotalPnl, float_equal 1234.0); (WinRate, float_equal 60.0) ])
     ]} *)

--- a/trading/devtools/ppx_test_matcher/lib/ppx_test_matcher.ml
+++ b/trading/devtools/ppx_test_matcher/lib/ppx_test_matcher.ml
@@ -5,15 +5,15 @@ open Ppxlib
 
     Given a record type:
     {[
-      type t = { x : float; y : int } [@@deriving test_matcher]
+    type t = { x : float; y : int } [@@deriving test_matcher]
     ]}
 
     It generates a function [match_t] with one required labeled parameter per
     field:
     {[
-      let match_t ~x ~y (r : t) =
-        x r.x;
-        y r.y
+    let match_t ~x ~y (r : t) =
+      x r.x;
+      y r.y
     ]}
 
     Every field must be explicitly matched or ignored with [__] (the wildcard

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -160,10 +160,10 @@ val run_backtest :
     order. Each must be a record sexp with fields matching
     [Weinstein_strategy.config]. Example:
     {[
-      [
-        Sexp.of_string "((initial_stop_buffer 1.08))";
-        Sexp.of_string "((stage_config ((ma_period 40))))";
-      ]
+    [
+      Sexp.of_string "((initial_stop_buffer 1.08))";
+      Sexp.of_string "((stage_config ((ma_period 40))))";
+    ]
     ]}
 
     [sector_map_override], when passed, replaces the sector-map normally loaded

--- a/trading/trading/backtest/tuner/lib/grid_search.mli
+++ b/trading/trading/backtest/tuner/lib/grid_search.mli
@@ -36,12 +36,12 @@ type param_spec = (string * param_values) list
 
     Example:
     {[
-      [
-        ("screening.weights.rs", [ 0.2; 0.3; 0.4 ]);
-        ("screening.weights.volume", [ 0.2; 0.3; 0.4 ]);
-        ("screening.weights.breakout", [ 0.2; 0.3; 0.4 ]);
-        ("screening.weights.sector", [ 0.2; 0.3; 0.4 ]);
-      ]
+    [
+      ("screening.weights.rs", [ 0.2; 0.3; 0.4 ]);
+      ("screening.weights.volume", [ 0.2; 0.3; 0.4 ]);
+      ("screening.weights.breakout", [ 0.2; 0.3; 0.4 ]);
+      ("screening.weights.sector", [ 0.2; 0.3; 0.4 ]);
+    ]
     ]}
 
     yields a 3 × 3 × 3 × 3 = 81-cell grid.
@@ -54,10 +54,10 @@ type param_spec = (string * param_values) list
     replaces the grade-based filter with a strict numeric [score >= n] gate.
     Sweep example:
     {[
-      [
-        ( "screening_config.min_score_override",
-          [ 38.0; 39.0; 40.0; 41.0; 42.0; 43.0 ] );
-      ]
+    [
+      ( "screening_config.min_score_override",
+        [ 38.0; 39.0; 40.0; 41.0; 42.0; 43.0 ] );
+    ]
     ]}
     Note: although the field is [int option] in the OCaml record, the grid spec
     carries floats. The override sexp emitted by

--- a/trading/trading/data_panel/atr_kernel.mli
+++ b/trading/trading/data_panel/atr_kernel.mli
@@ -13,7 +13,7 @@
     recurrence then gives, for [t > period]:
 
     {[
-      ATR [ t ] = ((ATR [ t - 1 ] * (period - 1)) + TR [ t ]) / period
+    ATR [ t ] = ((ATR [ t - 1 ] * (period - 1)) + TR [ t ]) / period
     ]}
 
     The kernel reads its prior state from the output panel at column [t - 1],

--- a/trading/trading/data_panel/ema_kernel.mli
+++ b/trading/trading/data_panel/ema_kernel.mli
@@ -4,7 +4,7 @@
     input values as the warmup seed at column [period-1], then the recurrence
 
     {[
-      EMA [ t ] = (alpha * input [ t ]) + ((1 - alpha) * EMA [ t - 1 ])
+    EMA [ t ] = (alpha * input [ t ]) + ((1 - alpha) * EMA [ t - 1 ])
     ]}
 
     where [alpha = 2 / (period + 1)]. Output cells at columns [0..period-2] are

--- a/trading/trading/data_panel/rsi_kernel.mli
+++ b/trading/trading/data_panel/rsi_kernel.mli
@@ -12,12 +12,11 @@
     [1..period]. The Wilder recurrence then gives, for [t > period]:
 
     {[
-      avg_gain [ t ]
-      = ((avg_gain [ t - 1 ] * (period - 1)) + gain [ t ])
-        / period avg_loss [ t ]
-      = ((avg_loss [ t - 1 ] * (period - 1)) + loss [ t ]) / period rs
-      = avg_gain [ t ] / avg_loss [ t ] rsi
-      = 100 - (100 / (1 + rs))
+    avg_gain [ t ]
+    = ((avg_gain [ t - 1 ] * (period - 1)) + gain [ t ]) / period avg_loss [ t ]
+    = ((avg_loss [ t - 1 ] * (period - 1)) + loss [ t ]) / period rs
+    = avg_gain [ t ] / avg_loss [ t ] rsi
+    = 100 - (100 / (1 + rs))
     ]}
 
     Edge cases:

--- a/trading/trading/engine/lib/engine.mli
+++ b/trading/trading/engine/lib/engine.mli
@@ -30,31 +30,31 @@ val update_market :
       Optional configuration for path generation. Defaults to
       Price_path.default_config. Use a fixed seed for deterministic testing:
       {[
-        let path_config = { Price_path.default_config with seed = Some 42 } in
-        Engine.update_market ~path_config engine bars
+      let path_config = { Price_path.default_config with seed = Some 42 } in
+      Engine.update_market ~path_config engine bars
       ]}
 
     Example:
     {[
-      let bars =
-        [
-          {
-            symbol = "AAPL";
-            open_price = 150.0;
-            high_price = 152.0;
-            low_price = 149.5;
-            close_price = 151.0;
-          };
-          {
-            symbol = "GOOGL";
-            open_price = 2800.0;
-            high_price = 2850.0;
-            low_price = 2790.0;
-            close_price = 2820.0;
-          };
-        ]
-      in
-      Engine.update_market engine bars
+    let bars =
+      [
+        {
+          symbol = "AAPL";
+          open_price = 150.0;
+          high_price = 152.0;
+          low_price = 149.5;
+          close_price = 151.0;
+        };
+        {
+          symbol = "GOOGL";
+          open_price = 2800.0;
+          high_price = 2850.0;
+          low_price = 2790.0;
+          close_price = 2820.0;
+        };
+      ]
+    in
+    Engine.update_market engine bars
     ]} *)
 
 val process_orders : t -> order_manager -> execution_report list status_or

--- a/trading/trading/simulation/lib/data/time_series.mli
+++ b/trading/trading/simulation/lib/data/time_series.mli
@@ -31,15 +31,15 @@ val convert_cadence :
 
     Examples:
     {[
-      (* Complete weeks only *)
-      let weekly =
-        convert_cadence daily_prices ~cadence:Types.Cadence.Weekly
-          ~as_of_date:None
+    (* Complete weeks only *)
+    let weekly =
+      convert_cadence daily_prices ~cadence:Types.Cadence.Weekly
+        ~as_of_date:None
 
-      (* Include provisional for Wednesday *)
-      let provisional =
-        convert_cadence daily_prices ~cadence:Types.Cadence.Weekly
-          ~as_of_date:(Some wed_date)
+    (* Include provisional for Wednesday *)
+    let provisional =
+      convert_cadence daily_prices ~cadence:Types.Cadence.Weekly
+        ~as_of_date:(Some wed_date)
     ]} *)
 
 val is_period_end : cadence:Types.Cadence.t -> Date.t -> bool

--- a/trading/trading/simulation/test/test_helpers.ml
+++ b/trading/trading/simulation/test/test_helpers.ml
@@ -33,11 +33,11 @@ let teardown_test_data test_data_dir =
 
     Usage:
     {[
-      with_test_data "my_test"
-        [ ("AAPL", prices) ]
-        ~f:(fun data_dir ->
-          (* test code here *)
-          ())
+    with_test_data "my_test"
+      [ ("AAPL", prices) ]
+      ~f:(fun data_dir ->
+        (* test code here *)
+        ())
     ]} *)
 let with_test_data test_name prices_by_symbol ~f =
   let data_dir = setup_test_data test_name prices_by_symbol in

--- a/trading/trading/simulation/test/test_helpers.mli
+++ b/trading/trading/simulation/test/test_helpers.mli
@@ -52,9 +52,9 @@ val default_enter_exit_config : enter_exit_config
 
     Usage:
     {[
-      module My_strategy = Make_enter_then_exit_strategy (struct
-        let config = { default_enter_exit_config with symbol = "MSFT" }
-      end)
+    module My_strategy = Make_enter_then_exit_strategy (struct
+      let config = { default_enter_exit_config with symbol = "MSFT" }
+    end)
     ]} *)
 module Make_enter_then_exit_strategy (_ : sig
   val config : enter_exit_config

--- a/trading/trading/strategy/lib/position.mli
+++ b/trading/trading/strategy/lib/position.mli
@@ -58,61 +58,59 @@
     {1 Usage Example}
 
     {[
-      (* Create position in Entering state from transition *)
-      let transition =
-        {
-          position_id = "AAPL-1";
-          date = Date.today ();
-          kind =
-            CreateEntering
-              {
-                symbol = "AAPL";
-                target_quantity = 100.0;
-                entry_price = 150.0;
-                reasoning =
-                  TechnicalSignal { indicator = "EMA"; description = "..." };
-              };
-        }
-      in
-      let pos = Position.create_entering transition |> Status.ok_exn in
+    (* Create position in Entering state from transition *)
+    let transition =
+      {
+        position_id = "AAPL-1";
+        date = Date.today ();
+        kind =
+          CreateEntering
+            {
+              symbol = "AAPL";
+              target_quantity = 100.0;
+              entry_price = 150.0;
+              reasoning =
+                TechnicalSignal { indicator = "EMA"; description = "..." };
+            };
+      }
+    in
+    let pos = Position.create_entering transition |> Status.ok_exn in
 
-      (* Apply fill transition *)
-      let fill_transition =
-        {
-          position_id = "AAPL-1";
-          date = Date.today ();
-          kind = EntryFill { filled_quantity = 100.0; fill_price = 150.25 };
-        }
-      in
-      let pos =
-        Position.apply_transition pos fill_transition |> Status.ok_exn
-      in
+    (* Apply fill transition *)
+    let fill_transition =
+      {
+        position_id = "AAPL-1";
+        date = Date.today ();
+        kind = EntryFill { filled_quantity = 100.0; fill_price = 150.25 };
+      }
+    in
+    let pos = Position.apply_transition pos fill_transition |> Status.ok_exn in
 
-      (* Complete entry, move to Holding *)
-      let complete_transition =
-        {
-          position_id = "AAPL-1";
-          date = Date.today ();
-          kind =
-            EntryComplete
-              {
-                risk_params =
-                  {
-                    stop_loss_price = Some 142.50;
-                    take_profit_price = Some 165.00;
-                    max_hold_days = None;
-                  };
-              };
-        }
-      in
-      let pos =
-        Position.apply_transition pos complete_transition |> Status.ok_exn
-      in
+    (* Complete entry, move to Holding *)
+    let complete_transition =
+      {
+        position_id = "AAPL-1";
+        date = Date.today ();
+        kind =
+          EntryComplete
+            {
+              risk_params =
+                {
+                  stop_loss_price = Some 142.50;
+                  take_profit_price = Some 165.00;
+                  max_hold_days = None;
+                };
+            };
+      }
+    in
+    let pos =
+      Position.apply_transition pos complete_transition |> Status.ok_exn
+    in
 
-      (* Position now in Holding state *)
-      match Position.get_state pos with
-      | Holding h -> Printf.printf "Holding %f shares\\n" h.quantity
-      | _ -> ()
+    (* Position now in Holding state *)
+    match Position.get_state pos with
+    | Holding h -> Printf.printf "Holding %f shares\\n" h.quantity
+    | _ -> ()
     ]} *)
 
 open Core

--- a/trading/trading/strategy/lib/strategy.mli
+++ b/trading/trading/strategy/lib/strategy.mli
@@ -84,10 +84,10 @@ val use_strategy :
     The accessor functions should already have market_data partially applied.
     Example:
     {[
-      let get_price_fn = get_price market_data in
-      let get_indicator_fn = get_indicator market_data in
-      use_strategy ~get_price:get_price_fn ~get_indicator:get_indicator_fn
-        ~positions strategy
+    let get_price_fn = get_price market_data in
+    let get_indicator_fn = get_indicator market_data in
+    use_strategy ~get_price:get_price_fn ~get_indicator:get_indicator_fn
+      ~positions strategy
     ]} *)
 
 val get_name : t -> string


### PR DESCRIPTION
Round 1 (PR #1039) fixed 8 files but missed several. CI on PR #1034 surfaces 14 additional drift files where docstring `{[ ]}` block content indents diverged from the canonical 4-space form ocamlformat 0.29.0 in CI expects.

This PR is stacked on top of #1034 and restores the 14 files to their main state so #1034 can merge. Merging this is equivalent to rebasing #1034 with the fmt fix applied.

## Files restored to canonical (main) state (14)
- `analysis/weinstein/stage/lib/stage.mli`
- `base/matchers/lib/matchers.mli`
- `devtools/ppx_test_matcher/lib/ppx_test_matcher.ml`
- `trading/backtest/lib/runner.mli`
- `trading/backtest/tuner/lib/grid_search.mli`
- `trading/data_panel/atr_kernel.mli`
- `trading/data_panel/ema_kernel.mli`
- `trading/data_panel/rsi_kernel.mli`
- `trading/engine/lib/engine.mli`
- `trading/simulation/lib/data/time_series.mli`
- `trading/simulation/test/test_helpers.ml`
- `trading/simulation/test/test_helpers.mli`
- `trading/strategy/lib/position.mli`
- `trading/strategy/lib/strategy.mli`

## Why main is clean but #1034 (and #1035, #1036) drift
Local ocamlformat 0.29.0 in the dev container indents docstring `{[ ]}` content +2 vs the opener; CI's ocamlformat 0.29.0 wants content at the same indent as the opener. Any `dune fmt` run locally re-introduces the drift (see `memory/project_ocamlformat_version_skew.md`).

## Test plan
- [ ] CI passes `dune fmt (check only)` on this branch