### PR TITLE
ops: fix ocamlformat frankenpackage + bump 5y golden timeout to 60min

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -134,8 +134,21 @@ RUN opam install --yes memtrace
 # CI fmt gate runs `dune fmt --check`, which fails if the formatter version
 # drifts. Pin here so the image cannot silently upgrade and break CI.
 # This is the ONLY tool the ci stage installs beyond runtime libraries.
+#
+# 2026-05-11: explicit `opam update` + `opam pin remove ocamlformat || true`
+# before install so opam picks the official 0.29.0 release tarball from the
+# opam-repository instead of falling back to "0.28.1 pinned to git tag 0.29.0"
+# when 0.29.0 isn't yet registered in the local opam-repo cache. That
+# frankenpackage build had subtly different output for docstring {[ ]} indent
+# vs CI's clean 0.29.0, causing the 2026-05-08 → 2026-05-11 fmt drift incident
+# (PRs #1039 + #1040 batch-fixed 22+ .mli files). See
+# `dev/notes/retrospective-ci-greenness-2026-05-11.md` for the full root cause.
 # -----------------------------------------------------------------------------
-RUN opam install --yes ocamlformat.0.29.0
+RUN opam update && \
+    (opam pin remove ocamlformat 2>/dev/null || true) && \
+    opam install --yes ocamlformat.0.29.0 && \
+    opam show ocamlformat | grep "all-installed-versions" | grep -q "0.29.0" \
+      || (echo "FAIL: ocamlformat post-install is not pure 0.29.0" && exit 1)
 
 # Drop any _build artifacts from opam install hooks so the ci stage stays lean.
 RUN rm -rf /workspaces/trading-1/trading/_build

--- a/.github/workflows/golden-runs-sp500-5y.yml
+++ b/.github/workflows/golden-runs-sp500-5y.yml
@@ -20,10 +20,11 @@
 # data preparation step.
 #
 # Expected runtimes (GHA ubuntu-latest):
-#   sp500-2019-2023:           ~5 min,  ~770 MB peak
-#   sp500-2019-2023-long-only: ~5 min   (currently FAIL — Q2 sub-bug)
-#   sp500-2019-2023-bah-spy:   ~1 min   (currently FAIL — Q2 main bug)
-# Budget: 30 min total covers all three with healthy headroom.
+#   sp500-2019-2023:           ~5 min pre-Cell-E (~15 min post-Cell-E #1036)
+#   sp500-2019-2023-long-only: ~5 min pre-Cell-E (~12 min post-Cell-E)
+#   sp500-2019-2023-bah-spy:   ~1 min   (BAH, not affected by Cell E)
+# Cell E adds ~3.3x trade count (81 → 264 trades on 2019-2023) which roughly
+# triples wall time. Budget bumped from 30 → 60 min on 2026-05-11.
 #
 # Scenarios discovered: any *.sexp with ";; perf-tier: 3" under
 # trading/test_data/backtest_scenarios/goldens-sp500/
@@ -38,7 +39,7 @@ on:
 jobs:
   golden-sp500-5y:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
Two related ops cleanups surfaced from the 2026-05-11 fmt-drift incident. See \`dev/notes/retrospective-ci-greenness-2026-05-11.md\` for the full root-cause writeup.

## 1. \`.devcontainer/Dockerfile\` — fix ocamlformat frankenpackage

**Root cause:** The local \`trading-1-dev\` container has \`ocamlformat 0.28.1\` opam-package **pinned to git tag 0.29.0**, instead of the clean \`ocamlformat 0.29.0\` opam package. Both report '0.29.0' via \`--version\`, but they're built from different sources (git tag HEAD vs official release tarball) and produce subtly different output on docstring \`{[ ]}\` indent.

Confirmed by side-by-side inspection:

| Container | opam show ocamlformat |
|---|---|
| local \`trading-1-dev\` | \`all-installed-versions: 0.28.1 [5.3]\` pinned to \`git+https://github.com/ocaml-ppx/ocamlformat.git#0.29.0\` |
| CI \`ghcr.io/dayfine/trading-ci:latest\` | \`all-installed-versions: 0.29.0 [5.3]\` from \`https://github.com/ocaml-ppx/ocamlformat/releases/download/0.29.0/ocamlformat-0.29.0.tbz\` |

This caused **22+ .mli files** to drift over 2026-05-08 → 2026-05-11 (fixed in PRs #1039 + #1040). Similar drift was previously fixed in PR #981 (~26 files). Without this root-cause fix, the drift will recur whenever a contaminated local container writes .mli files.

**Fix:** \`opam update && (opam pin remove ocamlformat || true) && opam install --yes ocamlformat.0.29.0\` — explicitly unpin + reinstall so opam picks the official 0.29.0 release tarball. Plus a post-install verifier that fails the build if the installed version isn't pure 0.29.0.

## 2. \`.github/workflows/golden-runs-sp500-5y.yml\` — 30 → 60 min timeout

Cell E rollout (#1036, #1041) increased trade count ~3.3× on the 5y goldens (81 → 264 trades on sp500-2019-2023). Wall time scales proportionally; the 30-min budget routinely hits.

This is a non-blocking postsubmit (\`continue-on-error: true\`), but the timeouts make main visually red on every visit. Bumping to 60min with headroom.

## Test plan
- [ ] Trading-1-dev container rebuild verifies \`opam show ocamlformat\` reports \`0.29.0\` (not 0.28.1)
- [ ] \`dune build @fmt\` in the new container produces same output as CI's fmt check on a known-formatted file (e.g., \`screener.mli\`)
- [ ] 5y golden postsubmit completes within new 60min budget

## Closes / related
- Retrospective: \`dev/notes/retrospective-ci-greenness-2026-05-11.md\`
- Reconciler issues filed today: dayfine/trading-reconciler#13 + #14
- Previous fmt-drift attempt: PR #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)