### PR TITLE
feat(screener): add volume_ratio_exclude_range knob

### DIFF
--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -30,6 +30,8 @@ let default_candidate_params =
     breakout_fallback_pct = 0.05;
   }
 
+type volume_ratio_band = { low : float; high : float } [@@deriving sexp]
+
 type config = {
   weights : scoring_weights;
   grade_thresholds : grade_thresholds;
@@ -37,6 +39,7 @@ type config = {
   min_grade : grade;
   min_score_override : int option; [@sexp.default None]
   max_score_override : int option; [@sexp.default None]
+  volume_ratio_exclude_range : volume_ratio_band option; [@sexp.default None]
   max_buy_candidates : int;
   max_short_candidates : int;
   cascade_post_stop_cooldown_weeks : int; [@sexp.default 0]
@@ -51,6 +54,7 @@ let default_config =
     min_grade = C;
     min_score_override = None;
     max_score_override = None;
+    volume_ratio_exclude_range = None;
     max_buy_candidates = 20;
     max_short_candidates = 10;
     cascade_post_stop_cooldown_weeks = 0;
@@ -70,7 +74,7 @@ type scored_candidate = {
   rationale : string list;
 }
 
-type cascade_diagnostics = {
+type cascade_diagnostics = Screener_cascade_diagnostics.t = {
   total_stocks : int;
   candidates_after_held : int;
   macro_trend : market_trend;
@@ -165,12 +169,23 @@ let _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
     Some
       (_build_candidate ~params ~sector ~a ~score ~reasons ~thresholds ~is_short)
 
+(** Volume-band exclusion: rejects iff the candidate's volume_ratio is in the
+    half-open interval from [low] (inclusive) to [high] (exclusive). Candidates
+    without a [volume] result pass through. *)
+let _passes_volume_band ~excl (a : Stock_analysis.t) =
+  match (excl, a.volume) with
+  | None, _ | _, None -> true
+  | Some { low; high }, Some v ->
+      let r = v.Volume.volume_ratio in
+      not Float.(low <= r && r < high)
+
 (** Evaluate one (analysis, sector) pair as a long candidate. Returns [None] if
-    excluded by the sector gate, breakout test, or score floor. *)
+    excluded by the sector gate, breakout test, volume band, or score floor. *)
 let _long_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
-    ~max_score_override (a, sector) =
+    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
   if equal_sector_rating sector.rating Weak then None
   else if not (Stock_analysis.is_breakout_candidate a) then None
+  else if not (_passes_volume_band ~excl:volume_ratio_exclude_range a) then None
   else
     _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
       ~max_score_override ~is_short:false ~scorer:score_long ~sector a
@@ -190,10 +205,11 @@ let _rs_blocks_short = function
 (** Evaluate one (analysis, sector) pair as a short candidate. Bearish/Neutral
     only: score must pass {!_passes_score_floor}. *)
 let _short_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
-    ~max_score_override (a, sector) =
+    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
   if equal_sector_rating sector.rating Strong then None
   else if not (Stock_analysis.is_breakdown_candidate a) then None
   else if _rs_blocks_short a.Stock_analysis.rs then None
+  else if not (_passes_volume_band ~excl:volume_ratio_exclude_range a) then None
   else
     _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
       ~max_score_override ~is_short:true ~scorer:score_short ~sector a
@@ -244,8 +260,14 @@ let _top_n n lst =
     bools are [false]) so [(true, true, true)] means the pair passed all three
     gates. *)
 let _long_admission ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override (a, sector) =
-  let passes_breakout = Stock_analysis.is_breakout_candidate a in
+    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
+  (* Volume-band exclusion is folded into breakout phase: keeps the
+     cascade-diagnostics record stable (no new counter) while gating downstream
+     counts. *)
+  let passes_breakout =
+    Stock_analysis.is_breakout_candidate a
+    && _passes_volume_band ~excl:volume_ratio_exclude_range a
+  in
   let passes_sector =
     passes_breakout && not (equal_sector_rating sector.rating Weak)
   in
@@ -264,20 +286,23 @@ let _bump n b = if b then n + 1 else n
 (** Long-side phase counts for the cascade-diagnostics record. Folds the
     per-pair predicate triple into running counts. *)
 let _count_long_phases ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~candidates =
+    ~max_score_override ~volume_ratio_exclude_range ~candidates =
   List.fold candidates ~init:(0, 0, 0)
     ~f:(fun (breakout, sector_ok, grade_ok) pair ->
       let pb, ps, pg =
         _long_admission ~weights ~thresholds ~min_grade ~min_score_override
-          ~max_score_override pair
+          ~max_score_override ~volume_ratio_exclude_range pair
       in
       (_bump breakout pb, _bump sector_ok ps, _bump grade_ok pg))
 
 (** Short-side admission predicates. Mirrors [_long_admission] with the RS hard
     gate inserted between sector and grade — see [_short_candidate]. *)
 let _short_admission ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override (a, sector) =
-  let passes_breakdown = Stock_analysis.is_breakdown_candidate a in
+    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
+  let passes_breakdown =
+    Stock_analysis.is_breakdown_candidate a
+    && _passes_volume_band ~excl:volume_ratio_exclude_range a
+  in
   let passes_sector =
     passes_breakdown && not (equal_sector_rating sector.rating Strong)
   in
@@ -293,12 +318,12 @@ let _short_admission ~weights ~thresholds ~min_grade ~min_score_override
 
 (** Short-side phase counts mirroring [_count_long_phases]. *)
 let _count_short_phases ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~candidates =
+    ~max_score_override ~volume_ratio_exclude_range ~candidates =
   List.fold candidates ~init:(0, 0, 0, 0)
     ~f:(fun (breakdown, sector_ok, rs_ok, grade_ok) pair ->
       let pb, ps, pr, pg =
         _short_admission ~weights ~thresholds ~min_grade ~min_score_override
-          ~max_score_override pair
+          ~max_score_override ~volume_ratio_exclude_range pair
       in
       (_bump breakdown pb, _bump sector_ok ps, _bump rs_ok pr, _bump grade_ok pg))
 
@@ -309,27 +334,27 @@ let _filter_and_cap ~candidate_fn ~max_n candidates =
 
 (** Filter, score, grade, sort, and cap long candidates. *)
 let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~min_score_override
-    ~max_score_override ~max_buy_candidates ~candidates ~macro_trend :
-    scored_candidate list =
+    ~max_score_override ~volume_ratio_exclude_range ~max_buy_candidates
+    ~candidates ~macro_trend : scored_candidate list =
   match macro_trend with
   | Bearish -> []
   | Bullish | Neutral ->
       let candidate_fn =
         _long_candidate ~weights ~thresholds ~params ~min_grade
-          ~min_score_override ~max_score_override
+          ~min_score_override ~max_score_override ~volume_ratio_exclude_range
       in
       _filter_and_cap ~candidate_fn ~max_n:max_buy_candidates candidates
 
 (** Filter, score, grade, sort, and cap short candidates. *)
 let _evaluate_shorts ~weights ~thresholds ~params ~min_grade ~min_score_override
-    ~max_score_override ~max_short_candidates ~candidates ~macro_trend :
-    scored_candidate list =
+    ~max_score_override ~volume_ratio_exclude_range ~max_short_candidates
+    ~candidates ~macro_trend : scored_candidate list =
   match macro_trend with
   | Bullish -> []
   | Bearish | Neutral ->
       let candidate_fn =
         _short_candidate ~weights ~thresholds ~params ~min_grade
-          ~min_score_override ~max_score_override
+          ~min_score_override ~max_score_override ~volume_ratio_exclude_range
       in
       _filter_and_cap ~candidate_fn ~max_n:max_short_candidates candidates
 
@@ -357,59 +382,26 @@ let _resolve_sector ~sector_map ticker =
         stage = Stage1 { weeks_in_base = 0 };
       }
 
-(** Build the cascade-diagnostics record from the per-side phase counts and the
-    final top-N counts. Pure projection. *)
-let _build_cascade_diagnostics ~total_stocks ~candidates_after_held ~macro_trend
-    ~long_phases ~short_phases ~buy_candidates ~short_candidates =
-  let long_breakout, long_sector, long_grade = long_phases in
-  let short_breakdown, short_sector, short_rs, short_grade = short_phases in
-  let long_macro_admitted =
-    match macro_trend with
-    | Bearish -> 0
-    | Bullish | Neutral -> candidates_after_held
-  in
-  let short_macro_admitted =
-    match macro_trend with
-    | Bullish -> 0
-    | Bearish | Neutral -> candidates_after_held
-  in
-  (* When the macro gate closes the side, downstream phase counts collapse to
-     0 — the screener never evaluates them. The fold above runs over all
-     candidates regardless of macro, so we reset here to keep the post-macro
-     phases consistent with what the screener actually emitted. *)
-  let zero_if (gate : int) (n : int) = if gate = 0 then 0 else n in
-  {
-    total_stocks;
-    candidates_after_held;
-    macro_trend;
-    long_macro_admitted;
-    long_breakout_admitted = zero_if long_macro_admitted long_breakout;
-    long_sector_admitted = zero_if long_macro_admitted long_sector;
-    long_grade_admitted = zero_if long_macro_admitted long_grade;
-    long_top_n_admitted = List.length buy_candidates;
-    short_macro_admitted;
-    short_breakdown_admitted = zero_if short_macro_admitted short_breakdown;
-    short_sector_admitted = zero_if short_macro_admitted short_sector;
-    short_rs_hard_gate_admitted = zero_if short_macro_admitted short_rs;
-    short_grade_admitted = zero_if short_macro_admitted short_grade;
-    short_top_n_admitted = List.length short_candidates;
-  }
-
 (** Compute the cascade-diagnostics record for one screen call. Decoupled from
     [screen] so the latter stays within the 50-line linter cap. *)
 let _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade
-    ~min_score_override ~max_score_override ~total_stocks ~candidates_after_held
-    ~macro_trend ~candidates ~buy_candidates ~short_candidates =
+    ~min_score_override ~max_score_override ~volume_ratio_exclude_range
+    ~total_stocks ~candidates_after_held ~macro_trend ~candidates
+    ~buy_candidates ~short_candidates =
   let long_phases =
     _count_long_phases ~weights ~thresholds:grade_thresholds ~min_grade
-      ~min_score_override ~max_score_override ~candidates
+      ~min_score_override ~max_score_override ~volume_ratio_exclude_range
+      ~candidates
   in
   let short_phases =
     _count_short_phases ~weights ~thresholds:grade_thresholds ~min_grade
-      ~min_score_override ~max_score_override ~candidates
+      ~min_score_override ~max_score_override ~volume_ratio_exclude_range
+      ~candidates
   in
-  _build_cascade_diagnostics ~total_stocks ~candidates_after_held ~macro_trend
-    ~long_phases ~short_phases ~buy_candidates ~short_candidates
+  Screener_cascade_diagnostics.build ~total_stocks ~candidates_after_held
+    ~macro_trend ~long_phases ~short_phases
+    ~long_top_n:(List.length buy_candidates)
+    ~short_top_n:(List.length short_candidates)
 
 (** Build the per-symbol cooldown set: tickers whose last stop-out is within
     [cooldown_weeks] of [as_of] are blocked from the cascade. Returns an empty
@@ -445,6 +437,7 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
     min_grade;
     min_score_override;
     max_score_override;
+    volume_ratio_exclude_range;
     max_buy_candidates;
     max_short_candidates;
     cascade_post_stop_cooldown_weeks = _;
@@ -462,12 +455,14 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
   let buy_candidates =
     _evaluate_longs ~weights ~thresholds:grade_thresholds
       ~params:candidate_params ~min_grade ~min_score_override
-      ~max_score_override ~max_buy_candidates ~candidates ~macro_trend
+      ~max_score_override ~volume_ratio_exclude_range ~max_buy_candidates
+      ~candidates ~macro_trend
   in
   let short_candidates =
     _evaluate_shorts ~weights ~thresholds:grade_thresholds
       ~params:candidate_params ~min_grade ~min_score_override
-      ~max_score_override ~max_short_candidates ~candidates ~macro_trend
+      ~max_score_override ~volume_ratio_exclude_range ~max_short_candidates
+      ~candidates ~macro_trend
   in
   {
     buy_candidates;
@@ -478,9 +473,9 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
     macro_trend;
     cascade_diagnostics =
       _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade
-        ~min_score_override ~max_score_override ~total_stocks
-        ~candidates_after_held ~macro_trend ~candidates ~buy_candidates
-        ~short_candidates;
+        ~min_score_override ~max_score_override ~volume_ratio_exclude_range
+        ~total_stocks ~candidates_after_held ~macro_trend ~candidates
+        ~buy_candidates ~short_candidates;
   }
 
 let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -39,6 +39,13 @@ type candidate_params = {
 val default_candidate_params : candidate_params
 (** [default_candidate_params] provides the reference parameters. *)
 
+type volume_ratio_band = { low : float; high : float } [@@deriving sexp]
+(** Half-open volume-ratio exclusion band used by
+    {!config.volume_ratio_exclude_range}. The named-field record (rather than a
+    plain [float * float] tuple) keeps the on-disk sexp shape outside the
+    runner's deep-merge "looks like a record" heuristic, so a partial-config
+    overlay that sets just this field deep-merges correctly. *)
+
 type config = {
   weights : scoring_weights;
   grade_thresholds : grade_thresholds;
@@ -83,6 +90,31 @@ type config = {
 
           The cap is applied at the same gate as {!min_score_override} so the
           cascade-diagnostics phase counters stay consistent. *)
+  volume_ratio_exclude_range : volume_ratio_band option; [@sexp.default None]
+      (** Optional half-open exclusion band on the candidate's
+          [volume.volume_ratio] (event-volume / avg-volume). When
+          [Some {low; high}], a candidate is rejected if its volume ratio falls
+          in the half-open interval from [low] (inclusive) to [high]
+          (exclusive). Composes with the score gates: a candidate survives only
+          if both the score is in band and the volume ratio is not in the
+          excluded band.
+
+          Default: [None] — no exclusion.
+
+          Motivation: per-quintile entry-feature analysis on rolling 5y Cell E
+          trades (dev/notes/entry-signal-quintiles-2026-05-11.md) showed the
+          volume_ratio bucket between 2.5 and 3.0 is the only negative-$/trade
+          bucket and second-worst on win rate. Extreme volume (3.0 and above)
+          recovers on $/trade despite lower WR (fat-tail bull setups), so the
+          right cap is "exclude 2.5 to 3.0", not "exclude everything above 2.5".
+          This knob exposes the band as a single tunable so sweepers can move
+          the boundaries without code edits.
+
+          Candidates with no [volume] result (e.g. insufficient bars to compute
+          the ratio) are admitted unconditionally — the gate is only a filter
+          when the ratio is computable. The cascade-diagnostics phase counters
+          treat exclusion as part of the breakout phase (no new counter is
+          added; the candidate is simply absent from the downstream phases). *)
   max_buy_candidates : int;
       (** Maximum number of buy candidates returned. Default: 20. *)
   max_short_candidates : int;

--- a/trading/analysis/weinstein/screener/lib/screener_cascade_diagnostics.ml
+++ b/trading/analysis/weinstein/screener/lib/screener_cascade_diagnostics.ml
@@ -1,0 +1,52 @@
+open Core
+open Weinstein_types
+
+type t = {
+  total_stocks : int;
+  candidates_after_held : int;
+  macro_trend : market_trend;
+  long_macro_admitted : int;
+  long_breakout_admitted : int;
+  long_sector_admitted : int;
+  long_grade_admitted : int;
+  long_top_n_admitted : int;
+  short_macro_admitted : int;
+  short_breakdown_admitted : int;
+  short_sector_admitted : int;
+  short_rs_hard_gate_admitted : int;
+  short_grade_admitted : int;
+  short_top_n_admitted : int;
+}
+[@@deriving sexp]
+
+let build ~total_stocks ~candidates_after_held ~macro_trend ~long_phases
+    ~short_phases ~long_top_n ~short_top_n =
+  let long_breakout, long_sector, long_grade = long_phases in
+  let short_breakdown, short_sector, short_rs, short_grade = short_phases in
+  let long_macro_admitted =
+    match macro_trend with
+    | Bearish -> 0
+    | Bullish | Neutral -> candidates_after_held
+  in
+  let short_macro_admitted =
+    match macro_trend with
+    | Bullish -> 0
+    | Bearish | Neutral -> candidates_after_held
+  in
+  let zero_if (gate : int) (n : int) = if gate = 0 then 0 else n in
+  {
+    total_stocks;
+    candidates_after_held;
+    macro_trend;
+    long_macro_admitted;
+    long_breakout_admitted = zero_if long_macro_admitted long_breakout;
+    long_sector_admitted = zero_if long_macro_admitted long_sector;
+    long_grade_admitted = zero_if long_macro_admitted long_grade;
+    long_top_n_admitted = long_top_n;
+    short_macro_admitted;
+    short_breakdown_admitted = zero_if short_macro_admitted short_breakdown;
+    short_sector_admitted = zero_if short_macro_admitted short_sector;
+    short_rs_hard_gate_admitted = zero_if short_macro_admitted short_rs;
+    short_grade_admitted = zero_if short_macro_admitted short_grade;
+    short_top_n_admitted = short_top_n;
+  }

--- a/trading/analysis/weinstein/screener/lib/screener_cascade_diagnostics.mli
+++ b/trading/analysis/weinstein/screener/lib/screener_cascade_diagnostics.mli
@@ -1,0 +1,41 @@
+(** Per-cascade-phase admission counts for one screener call. The cumulative
+    fold {!build} turns per-side phase tuples + top-N counts into the public
+    record. Extracted from {!Screener} to keep that file under the
+    declared-large file-length cap. {!Screener.cascade_diagnostics} is a type
+    alias so existing consumers continue to spell the type as
+    [Screener.cascade_diagnostics]. *)
+
+open Weinstein_types
+
+type t = {
+  total_stocks : int;
+  candidates_after_held : int;
+  macro_trend : market_trend;
+  long_macro_admitted : int;
+  long_breakout_admitted : int;
+  long_sector_admitted : int;
+  long_grade_admitted : int;
+  long_top_n_admitted : int;
+  short_macro_admitted : int;
+  short_breakdown_admitted : int;
+  short_sector_admitted : int;
+  short_rs_hard_gate_admitted : int;
+  short_grade_admitted : int;
+  short_top_n_admitted : int;
+}
+[@@deriving sexp]
+
+val build :
+  total_stocks:int ->
+  candidates_after_held:int ->
+  macro_trend:market_trend ->
+  long_phases:int * int * int ->
+  short_phases:int * int * int * int ->
+  long_top_n:int ->
+  short_top_n:int ->
+  t
+(** [build] composes the diagnostics record. Phase tuples are
+    [(breakout, sector, grade)] for longs and [(breakdown, sector, rs, grade)]
+    for shorts. When the macro gate closes a side (Bearish for longs, Bullish
+    for shorts), downstream phase counts are forced to zero — the screener never
+    evaluates the side, so the recorded counts must reflect that. *)

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -511,6 +511,126 @@ let test_min_and_max_score_override_compose _ =
        [ field (fun (c : scored_candidate) -> c.ticker) (equal_to "LOW") ])
 
 (* ------------------------------------------------------------------ *)
+(* volume_ratio_exclude_range: per-Friday volume-band exclusion         *)
+(* ------------------------------------------------------------------ *)
+
+(** Helper: read each candidate's volume_ratio so tests can choose exclusion
+    bands relative to live values without hard-pinning them. *)
+let _volume_ratios stocks =
+  String.Map.of_alist_reduce
+    (List.filter_map stocks ~f:(fun (a : Stock_analysis.t) ->
+         Option.map a.volume ~f:(fun v -> (a.ticker, v.Volume.volume_ratio))))
+    ~f:(fun a _ -> a)
+
+(** Default ([None]) is bit-equal to legacy behaviour: both LOW (ratio 1.5) and
+    HIGH (ratio 3.0) survive. *)
+let test_volume_ratio_exclude_range_default_admits_all _ =
+  let stocks = _two_breakouts () in
+  let result =
+    screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
+      ~stocks ~held_tickers:[]
+  in
+  assert_that (List.length result.buy_candidates) (equal_to 2)
+
+(** A band that brackets LOW's volume_ratio drops LOW; HIGH (outside band)
+    survives. Pins the [low <= r < high] half-open semantics. *)
+let test_volume_ratio_exclude_range_drops_in_band _ =
+  let stocks = _two_breakouts () in
+  let ratios = _volume_ratios stocks in
+  let low_ratio = Map.find_exn ratios "LOW" in
+  let cfg_excl =
+    {
+      cfg with
+      volume_ratio_exclude_range =
+        Some { low = low_ratio -. 0.1; high = low_ratio +. 0.1 };
+    }
+  in
+  let result =
+    screen ~config:cfg_excl ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[]
+  in
+  assert_that result.buy_candidates
+    (elements_are
+       [ field (fun (c : scored_candidate) -> c.ticker) (equal_to "HIGH") ])
+
+(** Upper boundary is exclusive: a band ending exactly at HIGH's volume_ratio
+    does NOT drop HIGH. Pins the half-open shape: low inclusive, high exclusive.
+*)
+let test_volume_ratio_exclude_range_upper_bound_exclusive _ =
+  let stocks = _two_breakouts () in
+  let ratios = _volume_ratios stocks in
+  let high_ratio = Map.find_exn ratios "HIGH" in
+  let low_ratio = Map.find_exn ratios "LOW" in
+  let cfg_excl =
+    {
+      cfg with
+      volume_ratio_exclude_range =
+        Some { low = low_ratio +. 0.01; high = high_ratio };
+    }
+  in
+  let result =
+    screen ~config:cfg_excl ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[]
+  in
+  let surviving_tickers =
+    List.map result.buy_candidates ~f:(fun (c : scored_candidate) -> c.ticker)
+    |> List.sort ~compare:String.compare
+  in
+  assert_that surviving_tickers
+    (elements_are [ equal_to "HIGH"; equal_to "LOW" ])
+
+(** Composes with [min_score_override]: a candidate must pass BOTH the volume
+    band and the score gate. With a min_score_override set at HIGH's score (so
+    only HIGH would survive on score alone) AND a volume band that brackets
+    HIGH's ratio (so HIGH would be dropped on volume alone), the result is
+    empty. *)
+let test_volume_ratio_exclude_range_composes_with_score _ =
+  let stocks = _two_breakouts () in
+  let scores = _scores_by_ticker stocks in
+  let ratios = _volume_ratios stocks in
+  let high_score = Map.find_exn scores "HIGH" in
+  let high_ratio = Map.find_exn ratios "HIGH" in
+  let cfg_compose =
+    {
+      cfg with
+      min_score_override = Some high_score;
+      volume_ratio_exclude_range =
+        Some { low = high_ratio -. 0.1; high = high_ratio +. 0.1 };
+    }
+  in
+  let result =
+    screen ~config:cfg_compose ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[]
+  in
+  assert_that result.buy_candidates is_empty
+
+(** Diagnostics fold: a candidate excluded by the volume band is counted as NOT
+    passing the breakout phase, even though [is_breakout_candidate] returns
+    true. Pins the docstring claim "the cascade-diagnostics phase counters treat
+    exclusion as part of the breakout phase". *)
+let test_volume_ratio_exclude_range_counts_as_breakout_drop _ =
+  let stocks = _two_breakouts () in
+  let ratios = _volume_ratios stocks in
+  let low_ratio = Map.find_exn ratios "LOW" in
+  let cfg_excl =
+    {
+      cfg with
+      volume_ratio_exclude_range =
+        Some { low = low_ratio -. 0.1; high = low_ratio +. 0.1 };
+    }
+  in
+  let baseline =
+    screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
+      ~stocks ~held_tickers:[]
+  in
+  let with_excl =
+    screen ~config:cfg_excl ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[]
+  in
+  assert_that baseline.cascade_diagnostics.long_breakout_admitted (equal_to 2);
+  assert_that with_excl.cascade_diagnostics.long_breakout_admitted (equal_to 1)
+
+(* ------------------------------------------------------------------ *)
 (* Short candidates in Neutral market                                  *)
 (* ------------------------------------------------------------------ *)
 
@@ -1084,6 +1204,16 @@ let suite =
          >:: test_max_score_override_default_admits_all;
          "test_max_score_override_above_high_admits_all"
          >:: test_max_score_override_above_high_admits_all;
+         "test_volume_ratio_exclude_range_default_admits_all"
+         >:: test_volume_ratio_exclude_range_default_admits_all;
+         "test_volume_ratio_exclude_range_drops_in_band"
+         >:: test_volume_ratio_exclude_range_drops_in_band;
+         "test_volume_ratio_exclude_range_upper_bound_exclusive"
+         >:: test_volume_ratio_exclude_range_upper_bound_exclusive;
+         "test_volume_ratio_exclude_range_composes_with_score"
+         >:: test_volume_ratio_exclude_range_composes_with_score;
+         "test_volume_ratio_exclude_range_counts_as_breakout_drop"
+         >:: test_volume_ratio_exclude_range_counts_as_breakout_drop;
          "test_min_and_max_score_override_compose"
          >:: test_min_and_max_score_override_compose;
          "test_neutral_macro_produces_shorts"

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -44,6 +44,7 @@ let _permissive_screener_config (config : config) : Screener.config =
     min_grade = F;
     min_score_override = None;
     max_score_override = None;
+    volume_ratio_exclude_range = None;
     max_buy_candidates = Int.max_value;
     max_short_candidates = Int.max_value;
     cascade_post_stop_cooldown_weeks = 0;

--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -243,6 +243,34 @@ let test_default_screening_min_score_override_is_none _ =
   let cfg = _default_config () in
   assert_that cfg.screening_config.min_score_override is_none
 
+(** Deep-merge path for [screening_config.volume_ratio_exclude_range]. Pairs
+    with the [Screener.config.volume_ratio_exclude_range] knob added on this
+    branch; sweepers can move the boundaries by overriding the partial-config
+    overlay. *)
+let test_override_screening_volume_ratio_exclude_range _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string
+         "((screening_config ((volume_ratio_exclude_range (((low 2.5) (high \
+          3.0)))))))")
+  in
+  assert_that merged.screening_config.volume_ratio_exclude_range
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (b : Screener.volume_ratio_band) -> b.low)
+              (float_equal 2.5);
+            field
+              (fun (b : Screener.volume_ratio_band) -> b.high)
+              (float_equal 3.0);
+          ]))
+
+(** Default is preserved when no override is applied. *)
+let test_default_screening_volume_ratio_exclude_range_is_none _ =
+  let cfg = _default_config () in
+  assert_that cfg.screening_config.volume_ratio_exclude_range is_none
+
 let suite =
   "Runner_hypothesis_overrides"
   >::: [
@@ -272,6 +300,10 @@ let suite =
           sexp" >:: test_override_screening_min_score_override;
          "default: screening_config.min_score_override = None"
          >:: test_default_screening_min_score_override_is_none;
+         "override: screening_config.volume_ratio_exclude_range round-trips \
+          through sexp" >:: test_override_screening_volume_ratio_exclude_range;
+         "default: screening_config.volume_ratio_exclude_range = None"
+         >:: test_default_screening_volume_ratio_exclude_range_is_none;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- Adds `Screener.config.volume_ratio_exclude_range : volume_ratio_band option` — when `Some {low; high}`, rejects candidates whose `volume.volume_ratio` lands in `[low, high)`.
- Action #2 from `dev/notes/entry-signal-quintiles-2026-05-11.md` (Q4 vol_ratio 2.5-3.0 is the only negative-\$/trade bucket; right cap is "exclude 2.5-3.0", not "exclude ≥2.5").
- Mirrors the `#1034 max_score_override` pattern.

## Design note

The knob uses a named-field `volume_ratio_band` record (not `(float * float)`) deliberately. A plain tuple-option sexp `Some (2.5, 3.0) → ((2.5 3.0))` accidentally matches the runner deep-merge's `_is_record` heuristic and the overlay value gets dropped. The record-of-2 form ends up as `(((low 2.5) (high 3.0)))` outside that heuristic, so `--override '((screening_config ((volume_ratio_exclude_range (((low 2.5) (high 3.0)))))))'` deep-merges correctly. Pinned by the new round-trip test.

## Mechanism

Exclusion folds into the breakout-phase counter on `cascade_diagnostics` — no new counter added. A candidate dropped on volume reads as not passing breakout. Pinned by `test_volume_ratio_exclude_range_counts_as_breakout_drop`.

## File-length carve-out

Extracted `Screener_cascade_diagnostics` (type alias + builder) to a sibling module. `screener.ml` was 496 → would be 535; the extract drops it to 490. `Screener.cascade_diagnostics` stays an exported type alias so all existing consumers keep using `Screener.cascade_diagnostics` verbatim.

## Test plan

- [x] 5 new screener tests (default no-op, drops-in-band, upper-bound exclusive, composes-with-score, counts-as-breakout-drop)
- [x] 2 new runner-override tests (sexp round-trip + default-None)
- [x] dune runtest green; dune build @fmt clean
- [x] Bit-equal default contract preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)