### PR TITLE
feat(scenario_runner): support pinning Sortino / Calmar / UlcerIndex in goldens

### DIFF
--- a/trading/trading/backtest/scenarios/scenario.ml
+++ b/trading/trading/backtest/scenarios/scenario.ml
@@ -44,6 +44,9 @@ type expected = {
   avg_holding_days : range;
   open_positions_value : range option; [@sexp.option]
   unrealized_pnl : range option; [@sexp.option]
+  sortino_ratio_annualized : range option; [@sexp.option]
+  calmar_ratio : range option; [@sexp.option]
+  ulcer_index : range option; [@sexp.option]
 }
 [@@deriving sexp]
 

--- a/trading/trading/backtest/scenarios/scenario.mli
+++ b/trading/trading/backtest/scenarios/scenario.mli
@@ -34,6 +34,21 @@ type expected = {
           [OpenPositionsValue - Σ position_cost_basis]. [None] skips the check.
           Optional even when [open_positions_value] is pinned — populate when an
           empirical baseline justifies a tight range. *)
+  sortino_ratio_annualized : range option; [@sexp.option]
+      (** Annualized Sortino ratio — penalises downside volatility only. Pinned
+          range catches strategies where Sharpe stays stable but the downside
+          shape changes (e.g. a regression that adds skewed tail losses). [None]
+          skips the check. *)
+  calmar_ratio : range option; [@sexp.option]
+      (** CAGR / |MaxDrawdown|. Single number capturing return-per-unit-of-pain.
+          Composes MaxDrawdown and total return into one orthogonal check.
+          [None] skips. *)
+  ulcer_index : range option; [@sexp.option]
+      (** Sqrt of mean squared per-day drawdown percent — penalises BOTH depth
+          and duration of drawdowns. Catches the long-short
+          Portfolio_floor-cascade death loop pattern where many small drawdown
+          spikes add up to a high ulcer index even though MaxDrawdown stays the
+          same. [None] skips. *)
 }
 [@@deriving sexp]
 

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -74,6 +74,13 @@ type actual = {
   unrealized_pnl : float;
       (* Post-rename: true unrealized P&L (OpenPositionsValue - cost basis).
          Pre-rename actual.sexp files carry the legacy mtm-value here. *)
+  sortino_ratio_annualized : float; [@sexp.default Float.nan]
+      (* M5.2c Sortino — defaults to NaN on read so pre-pin actual.sexp files
+         still parse. *)
+  calmar_ratio : float; [@sexp.default Float.nan]
+      (* M5.2c Calmar (CAGR / |MaxDD|) — defaults to NaN as above. *)
+  ulcer_index : float; [@sexp.default Float.nan]
+      (* M5.2c Ulcer Index — defaults to NaN as above. *)
   force_liquidations_count : int; [@sexp.default 0]
       (* G4 (force-liquidation policy). Defaults to 0 on read so pre-G4
          actual.sexp files that don't carry the field still parse. *)
@@ -105,6 +112,9 @@ let _actual_of_result (r : Backtest.Runner.result) =
     avg_holding_days = get AvgHoldingDays;
     open_positions_value = get OpenPositionsValue;
     unrealized_pnl = get UnrealizedPnl;
+    sortino_ratio_annualized = get SortinoRatioAnnualized;
+    calmar_ratio = get CalmarRatio;
+    ulcer_index = get UlcerIndex;
     force_liquidations_count = List.length r.force_liquidations;
     crashed = false;
     crash_message = "";
@@ -125,6 +135,9 @@ let _crashed_actual ~msg =
     avg_holding_days = 0.0;
     open_positions_value = 0.0;
     unrealized_pnl = 0.0;
+    sortino_ratio_annualized = Float.nan;
+    calmar_ratio = Float.nan;
+    ulcer_index = Float.nan;
     force_liquidations_count = 0;
     crashed = true;
     crash_message = msg;
@@ -149,17 +162,19 @@ let _run_checks (a : actual) (e : Scenario.expected) =
       _check_one "avg_holding_days" a.avg_holding_days e.avg_holding_days;
     ]
   in
-  let with_opv =
-    match e.open_positions_value with
-    | None -> base
-    | Some range ->
-        base
-        @ [ _check_one "open_positions_value" a.open_positions_value range ]
+  let append_opt name value range_opt acc =
+    match range_opt with
+    | None -> acc
+    | Some range -> acc @ [ _check_one name value range ]
   in
-  match e.unrealized_pnl with
-  | None -> with_opv
-  | Some range ->
-      with_opv @ [ _check_one "unrealized_pnl" a.unrealized_pnl range ]
+  base
+  |> append_opt "open_positions_value" a.open_positions_value
+       e.open_positions_value
+  |> append_opt "unrealized_pnl" a.unrealized_pnl e.unrealized_pnl
+  |> append_opt "sortino_ratio_annualized" a.sortino_ratio_annualized
+       e.sortino_ratio_annualized
+  |> append_opt "calmar_ratio" a.calmar_ratio e.calmar_ratio
+  |> append_opt "ulcer_index" a.ulcer_index e.ulcer_index
 
 let _failure_message checks =
   List.filter checks ~f:(fun c -> not c.ok)

--- a/trading/trading/backtest/scenarios/test/test_scenario_runner_actual_sexp.ml
+++ b/trading/trading/backtest/scenarios/test/test_scenario_runner_actual_sexp.ml
@@ -44,6 +44,9 @@ type actual = {
   avg_holding_days : float;
   open_positions_value : float; [@sexp.default Float.nan]
   unrealized_pnl : float;
+  sortino_ratio_annualized : float; [@sexp.default Float.nan]
+  calmar_ratio : float; [@sexp.default Float.nan]
+  ulcer_index : float; [@sexp.default Float.nan]
   force_liquidations_count : int; [@sexp.default 0]
   crashed : bool; [@sexp.default false]
   crash_message : string; [@sexp.default ""]
@@ -66,6 +69,9 @@ let _crashed_actual ~msg =
     avg_holding_days = 0.0;
     open_positions_value = 0.0;
     unrealized_pnl = 0.0;
+    sortino_ratio_annualized = Float.nan;
+    calmar_ratio = Float.nan;
+    ulcer_index = Float.nan;
     force_liquidations_count = 0;
     crashed = true;
     crash_message = msg;


### PR DESCRIPTION
## Summary

Extends the goldens-harness `expected` schema with three optional metric ranges so goldens can pin Sortino, Calmar, and UlcerIndex alongside the existing 7 mandatory metrics. Pure plumbing — no behavior change. Pre-existing goldens are unchanged.

| Metric | Why pin it |
|---|---|
| `sortino_ratio_annualized` | Penalises downside vol only — orthogonal to Sharpe. Catches strategies that keep Sharpe stable while skewing downside shape. |
| `calmar_ratio` | CAGR / \|MaxDD\|. Single-number summary; composes two existing pinned metrics. |
| `ulcer_index` | Penalises both depth AND duration of drawdowns. Catches the Portfolio_floor cascade pattern fixed in #1052 (many small drawdown spikes that don't move MaxDD but raise the ulcer integral). |

## Implementation

- `scenario.ml`/`scenario.mli`: 3 new `range option` fields on `type expected`, all `[@sexp.option]`. Backward-compat: existing scenarios that omit the fields parse exactly as before.
- `scenario_runner.ml`:
  - 3 new float fields on `type actual` with `[@sexp.default Float.nan]` so old `actual.sexp` reads still parse.
  - Populated via `Map.find s.metrics` (same pattern as existing metrics — returns NaN when missing).
  - `_run_checks` refactored to use a small `append_opt` helper that walks the option-fold; eliminates the deepening match nest as more optional checks are added.

## Why these three and not the full M5.2c/d catalog

Skipping for now (deferred to follow-ups):

- `InformationRatio` — currently 0.0 everywhere (no benchmark feed wired; #1021 still on a feature branch).
- `CVaR95` / `CVaR99` — high-variance metric across different bear windows; tight pins would false-positive.
- `ProfitFactor`, `MarRatio`, `OmegaRatio` — informational; MarRatio = Calmar over single-window, ProfitFactor more useful as a per-trade aggregate.

This PR is the schema. Per-scenario pin lines arrive in follow-up PRs as each golden is re-run and the observed values land.

## Test plan

- [x] `dune build` clean (full project)
- [x] `dune runtest` clean (exit 0)
- [x] Existing scenarios parse without changes (pre-existing test_scenario.ml passes)
- [x] `Scenario.expected` backward-compat — sexp without the new fields still parses (the 3 `[@sexp.option]` declarations handle this; the existing 2 optional fields already exercise the same pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)