### PR TITLE
feat(scenario_runner): emit + pin wall_seconds as a perf-regression gate

### DIFF
--- a/trading/trading/backtest/scenarios/scenario.ml
+++ b/trading/trading/backtest/scenarios/scenario.ml
@@ -47,6 +47,7 @@ type expected = {
   sortino_ratio_annualized : range option; [@sexp.option]
   calmar_ratio : range option; [@sexp.option]
   ulcer_index : range option; [@sexp.option]
+  wall_seconds : range option; [@sexp.option]
 }
 [@@deriving sexp]
 

--- a/trading/trading/backtest/scenarios/scenario.mli
+++ b/trading/trading/backtest/scenarios/scenario.mli
@@ -49,6 +49,13 @@ type expected = {
           Portfolio_floor-cascade death loop pattern where many small drawdown
           spikes add up to a high ulcer index even though MaxDrawdown stays the
           same. [None] skips. *)
+  wall_seconds : range option; [@sexp.option]
+      (** Wall-clock duration of [Backtest.Runner.run_backtest] in seconds —
+          read from [wall_seconds.txt] under each scenario's output dir
+          (canonical perf-report convention; see
+          {!Backtest.Release_report.load_scenario_run}). Pinned range catches CI
+          runtime regressions and overflows of the 8 GB / 2h GHA budget. [None]
+          skips. *)
 }
 [@@deriving sexp]
 

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -151,7 +151,16 @@ let _check_one name value (range : Scenario.range) =
   let ok = Scenario.in_range range value in
   { name; value; range; ok }
 
-let _run_checks (a : actual) (e : Scenario.expected) =
+(** Read the canonical [wall_seconds.txt] perf-report file from [scenario_dir].
+    Returns [NaN] when missing — same skip-the-check semantic as NaN handling in
+    {!Scenario.in_range}. *)
+let _read_wall_seconds ~scenario_dir =
+  let path = Filename.concat scenario_dir "wall_seconds.txt" in
+  try Float.of_string (String.strip (In_channel.read_all path))
+  with _ -> Float.nan
+
+let _run_checks ?(wall_seconds = Float.nan) (a : actual) (e : Scenario.expected)
+    =
   let base =
     [
       _check_one "total_return_pct" a.total_return_pct e.total_return_pct;
@@ -175,6 +184,7 @@ let _run_checks (a : actual) (e : Scenario.expected) =
        e.sortino_ratio_annualized
   |> append_opt "calmar_ratio" a.calmar_ratio e.calmar_ratio
   |> append_opt "ulcer_index" a.ulcer_index e.ulcer_index
+  |> append_opt "wall_seconds" wall_seconds e.wall_seconds
 
 let _failure_message checks =
   List.filter checks ~f:(fun c -> not c.ok)
@@ -254,14 +264,25 @@ let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
   let progress_emitter =
     Scenario_progress.make_emitter ~scenario_dir ~every_n_fridays:progress_every
   in
+  let t_start = Time_ns_unix.now () in
   let result =
     Backtest.Runner.run_backtest ~start_date:s.period.start_date
       ~end_date:s.period.end_date ~overrides:s.config_overrides
       ?sector_map_override ~strategy_choice:s.strategy ~progress_emitter ()
   in
+  let wall_seconds =
+    Time_ns.Span.to_sec (Time_ns.diff (Time_ns_unix.now ()) t_start)
+  in
   Backtest.Result_writer.write ~output_dir:scenario_dir result;
   let a = _actual_of_result result in
   Sexp.save_hum (_actual_path ~output_root s) (sexp_of_actual a);
+  (* Emit wall_seconds.txt — the canonical perf-report convention
+     (release_report._read_optional_float). Goldens may pin
+     [expected.wall_seconds] to catch runtime regressions; scenarios that
+     don't pin are unaffected. *)
+  Out_channel.write_all
+    (Filename.concat scenario_dir "wall_seconds.txt")
+    ~data:(sprintf "%.3f\n" wall_seconds);
   (* Post-step: emit the all-eligible diagnostic alongside actual.sexp /
      summary.sexp so every scenario surfaces raw-signal alpha without manual
      [all_eligible_runner.exe] invocation. Failures inside the runner are
@@ -362,7 +383,9 @@ let _process_result ~output_root (s, _status) =
      mkdir, or filesystem errors during the sentinel write). *)
   match _load_actual ~output_root s with
   | Some a ->
-      let checks = _run_checks a s.expected in
+      let scenario_dir = _scenario_dir ~output_root s in
+      let wall_seconds = _read_wall_seconds ~scenario_dir in
+      let checks = _run_checks ~wall_seconds a s.expected in
       _format_row s a checks
   | None ->
       _print_crashed_row s;

--- a/trading/trading/backtest/scenarios/test/test_scenario.ml
+++ b/trading/trading/backtest/scenarios/test/test_scenario.ml
@@ -48,6 +48,32 @@ let test_unrealized_pnl_field_present _ =
             field (fun (r : Scenario.range) -> r.max_f) (float_equal 50000.0);
           ]))
 
+(** Pre-existing scenario sexps that don't pin [wall_seconds] continue to parse
+    with [None] (skip-the-check semantic). *)
+let test_wall_seconds_field_absent _ =
+  let s =
+    Scenario.t_of_sexp (Sexp.of_string (_make_sexp ~extra_expected_fields:""))
+  in
+  assert_that s.expected.wall_seconds is_none
+
+(** A scenario that pins [wall_seconds] parses the range correctly and
+    round-trips through sexp_of_t. *)
+let test_wall_seconds_field_present _ =
+  let original =
+    Scenario.t_of_sexp
+      (Sexp.of_string
+         (_make_sexp
+            ~extra_expected_fields:"(wall_seconds ((min 30.0) (max 90.0)))"))
+  in
+  let roundtripped = Scenario.t_of_sexp (Scenario.sexp_of_t original) in
+  assert_that roundtripped.expected.wall_seconds
+    (is_some_and
+       (all_of
+          [
+            field (fun (r : Scenario.range) -> r.min_f) (float_equal 30.0);
+            field (fun (r : Scenario.range) -> r.max_f) (float_equal 90.0);
+          ]))
+
 let test_unrealized_pnl_roundtrip _ =
   let original =
     Scenario.t_of_sexp
@@ -229,6 +255,9 @@ let suite =
          "unrealized_pnl present => Some range"
          >:: test_unrealized_pnl_field_present;
          "unrealized_pnl sexp round-trips" >:: test_unrealized_pnl_roundtrip;
+         "wall_seconds absent => None" >:: test_wall_seconds_field_absent;
+         "wall_seconds present => Some range round-trips"
+         >:: test_wall_seconds_field_present;
          "non-zero range rejects zero" >:: test_non_zero_range_rejects_zero;
          "near-zero range accepts zero" >:: test_near_zero_range_accepts_zero;
          "NaN actual passes any range (#882)"


### PR DESCRIPTION
## Summary

Goldens currently pin only behavioral metrics. Runtime regressions are invisible until they overflow GHA's 8 GB / 2 h budget. This PR adds optional `wall_seconds` pinning to the goldens harness.

## Changes

- `Scenario.expected.wall_seconds : range option` — new opt-in field. Pre-existing goldens that omit it remain unchanged.
- `Scenario_runner._run_scenario_in_child` measures wall-clock duration of `Backtest.Runner.run_backtest` and writes `<scenario_dir>/wall_seconds.txt` (canonical perf-report convention already consumed by `Backtest.Release_report.load_scenario_run`).
- `_run_checks` reads the .txt file at check time; checks fire only when `expected.wall_seconds = Some range`. NaN-on-missing returns the same skip-the-check semantic as the existing `in_range` guard.

## Tests

- 2 new `test_scenario.ml` cases — `wall_seconds` absent ⇒ `None`; `wall_seconds` present ⇒ `Some range` round-trips through sexp.

## Follow-ups

No goldens pin `wall_seconds` yet. Per-scenario pin lines arrive in follow-ups once each golden runs with the new binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)