### PR TITLE
feat(goldens): pin Sortino / Calmar / UlcerIndex on 5y sp500-2019-2023

### DIFF
--- a/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
@@ -49,10 +49,11 @@
  ;; (max_position_pct_long=0.14, max_long_exposure_pct=0.70, min_cash_pct=0.30,
  ;; stage3 force-exit h=1, laggard rotation h=2). Replaces prior 0.30/0.90/0.10
  ;; default-sized baseline (79.74% / 74 trades / 30.8% DD).
- ;; Measured 2026-05-11 (Cell E):
- ;;   total_return_pct   66.5   total_trades 248   win_rate 39.1
- ;;   sharpe_ratio       0.68   max_drawdown 24.1  avg_holding_days  42
+ ;; Measured 2026-05-12 (Cell E, post-#1052 force-liq fix + #1053 metric schema):
+ ;;   total_return_pct   66.54  total_trades 248   win_rate 39.11
+ ;;   sharpe_ratio       0.68   max_drawdown 24.09 avg_holding_days  41.95
  ;;   open_positions_value 1,401,130
+ ;;   sortino_ratio_annualized 0.95   calmar_ratio 0.45   ulcer_index 8.61
  ;; MaxDD cut 6.7pp (31 → 24), trade count 3.4x. Tolerances ±15%.
  (config_overrides
   (((enable_short_side false))
@@ -70,4 +71,7 @@
    (sharpe_ratio       ((min   0.58)       (max   0.78)))
    (max_drawdown_pct   ((min  20.5)        (max  27.7)))
    (avg_holding_days   ((min  36.0)        (max  48.0)))
-   (open_positions_value ((min 1190000.0)  (max 1611000.0))))))
+   (open_positions_value ((min 1190000.0)  (max 1611000.0)))
+   (sortino_ratio_annualized ((min 0.81)   (max 1.09)))
+   (calmar_ratio       ((min   0.38)       (max   0.51)))
+   (ulcer_index        ((min   7.32)       (max   9.90))))))

--- a/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp
@@ -51,10 +51,11 @@
  ;; (max_position_pct_long=0.14, max_long_exposure_pct=0.70, min_cash_pct=0.30,
  ;; stage3 force-exit h=1, laggard rotation h=2). Replaces prior 0.30/0.90/0.10
  ;; default-sized baseline (58.34% / 81 trades / 33.6% DD).
- ;; Measured 2026-05-11 (Cell E):
- ;;   total_return_pct   50.7   total_trades 264   win_rate 37.5
- ;;   sharpe_ratio       0.56   max_drawdown 21.6  avg_holding_days  41
+ ;; Measured 2026-05-12 (Cell E, post-#1052 force-liq fix + #1053 metric schema):
+ ;;   total_return_pct   50.66  total_trades 264   win_rate 37.5
+ ;;   sharpe_ratio       0.56   max_drawdown 21.56 avg_holding_days  40.78
  ;;   open_positions_value 1,221,041
+ ;;   sortino_ratio_annualized 0.75   calmar_ratio 0.40   ulcer_index 8.41
  ;; MaxDD cut 12pp (34 → 22), trade count 3.3x. Tolerances ±15%.
  (config_overrides
   (((portfolio_config ((max_position_pct_long 0.14))))
@@ -71,4 +72,7 @@
    (sharpe_ratio       ((min   0.48)       (max   0.65)))
    (max_drawdown_pct   ((min  18.4)        (max  24.9)))
    (avg_holding_days   ((min  35.0)        (max  47.0)))
-   (open_positions_value ((min 1040000.0)  (max 1405000.0))))))
+   (open_positions_value ((min 1040000.0)  (max 1405000.0)))
+   (sortino_ratio_annualized ((min 0.64)   (max 0.86)))
+   (calmar_ratio       ((min   0.34)       (max   0.46)))
+   (ulcer_index        ((min   7.15)       (max   9.68))))))


### PR DESCRIPTION
## Summary

First user of the #1053 goldens-harness M5.2c metric-pin extension. Adds pin ranges (±15% around the post-#1052 measured values) for Sortino, Calmar, and Ulcer on both 5y sp500-2019-2023 variants.

| Scenario | Sortino | Calmar | Ulcer |
|---|---:|---:|---:|
| sp500-2019-2023 (long-short Cell E) | 0.75 → [0.64, 0.86] | 0.40 → [0.34, 0.46] | 8.41 → [7.15, 9.68] |
| sp500-2019-2023-long-only (Cell E) | 0.95 → [0.81, 1.09] | 0.45 → [0.38, 0.51] | 8.61 → [7.32, 9.90] |

## Why this matters

- **Sortino** catches strategies where Sharpe stays stable but the downside shape changes (e.g. regressions that add skewed tail losses without moving overall vol).
- **Calmar** composes total return + MaxDD into one orthogonal check.
- **Ulcer** penalises both depth AND duration of drawdowns — catches the cascade-loop pattern fixed in #1052.

## What didn't change

Pure metric-pin extension. No config overrides, no other expected-range edits. Pre-existing 7 metric pins unchanged.

## Test plan

- [x] `Scenario.load` parses the updated sexps without error
- [x] Measured values from `dev/backtest/scenarios-2026-05-12-212307/.../actual.sexp` fall within the new ±15% ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)