### PR TITLE
docs: 16y long-short cascade investigation — death loop suppressed not eliminated

### DIFF
--- a/dev/experiments/golden-rerun-2026-05-12/scenarios-10y/decade-2014-2023.sexp
+++ b/dev/experiments/golden-rerun-2026-05-12/scenarios-10y/decade-2014-2023.sexp
@@ -1,0 +1,55 @@
+;; perf-tier: 4
+;; perf-tier-rationale: Tier-4 release-gate cell — full decade (2014-2023, ~10y) at N=1000. The flagship "can we run a decade-long backtest at scale?" cell. Per dev/notes/panels-rss-matrix-post-engine-pool-2026-04-28.md (RSS ≈ 67 + 3.94·N + 0.19·N·(T−1)), projects to ~5.7 GB peak at N=1000×10y — fits the 8 GB ceiling. Run on-demand via `dev/scripts/perf_tier4_release_gate.sh` (see `dev/notes/tier4-release-gate-checklist-2026-04-28.md`) when cutting a release. N>=5000 release-gate stays P1 awaiting daily-snapshot streaming (dev/plans/daily-snapshot-streaming-2026-04-27.md).
+;;
+;; STATUS: long-only baseline pinned 2026-04-29. Expected ranges are tightened
+;; to ±~15% around the canonical long-only baseline measured on 2026-04-29
+;; (post-#682 — `enable_short_side = false`). See
+;; dev/notes/goldens-broad-long-only-baselines-2026-04-29.md for the run output
+;; and reasoning. Re-pin once short-side gaps G1-G4
+;; (dev/notes/short-side-gaps-2026-04-29.md) close and the override is reverted.
+;;
+;; Golden (broad-1000): full 10-year run spanning the post-2014 bull, 2018
+;; correction, 2020 COVID crash, 2021 reflation rally, and 2022 bear. Run
+;; against the full sector-map with universe_cap=1000. This is the single most
+;; demanding cell in the catalog and the canonical "release-shippable"
+;; certification: a regression here means the system can't reliably run the
+;; longest-window scenario we care about.
+;;
+;; See bull-crash-2015-2020.sexp for the rationale on universe_cap=1000.
+((name "decade-2014-2023")
+ (description "10-year decade run spanning multiple regimes (broad-1000 universe)")
+ (period ((start_date 2014-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/broad.sexp")
+ (universe_size 1000)
+ ;; enable_short_side disabled 2026-04-29: short-side gaps (G1-G4 in
+ ;; dev/notes/short-side-gaps-2026-04-29.md) produce broken metrics on any
+ ;; scenario crossing a Bearish-macro window. Until the gaps close, this
+ ;; cell runs long-only — see dev/notes/goldens-broad-long-only-baselines-2026-04-29.md.
+ ;; Cell E rollout 2026-05-11: applies the new standard strategy config
+ ;; (max_position_pct_long=0.14, max_long_exposure_pct=0.70, min_cash_pct=0.30,
+ ;; stage3 force-exit h=1, laggard rotation h=2). Replaces prior 0.30/0.90/0.10
+ ;; default-sized baseline (1582-1627% / 135-145 trades / 94% DD on N=1000).
+ ;; Measured 2026-05-11 (Cell E, N=1000 broad):
+ ;;   total_return_pct  545.4   total_trades 553   win_rate 36.7
+ ;;   sharpe_ratio       0.73   max_drawdown 46.3  avg_holding_days  41
+ ;;   open_positions_value 5,410,009
+ ;; Return cut (concentrated bull run loses to rotation) but MaxDD cut 48pp
+ ;; (94 → 46) — much safer. Tolerances ±15%.
+ (config_overrides
+  (((universe_cap (1000)))
+   ((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct   ((min 463.0)        (max 627.0)))
+   (total_trades       ((min 470)          (max 636)))
+   (win_rate           ((min  31.2)        (max  42.2)))
+   (sharpe_ratio       ((min   0.62)       (max   0.84)))
+   (max_drawdown_pct   ((min  39.4)        (max  53.3)))
+   (avg_holding_days   ((min  35.0)        (max  47.0)))
+   (open_positions_value ((min 4600000.0)  (max 6220000.0))))))

--- a/dev/notes/longshort-cascades-investigation-2026-05-13.md
+++ b/dev/notes/longshort-cascades-investigation-2026-05-13.md
@@ -1,0 +1,124 @@
+# 16y Long-Short Portfolio_floor Cascade Investigation (post-PR #1052)
+
+Scenario: `dev/backtest/scenarios-2026-05-12-194906/sp500-2010-2026-longshort-historical/`.
+Cascade dates: **2025-04-17, 2025-05-05, 2025-05-19** (13 Portfolio_floor events; +1
+unrelated DISCA Per_position on 2014-08-07).
+
+## 1. Macro transitions in 2025
+
+`macro_trend.sexp` is sparse — it only records Fridays where the screener actually
+ran, which (per `weinstein_strategy_macro.entry_transitions_if_active`) requires
+`halted=false` at the entry step. Recorded entries near the cascades:
+
+| Friday | Trend |
+|---|---|
+| 2025-02-28 | Bullish |
+| 2025-03-07 | Neutral |
+| 2025-04-04 | Neutral |
+| 2025-04-11 | **Bearish** |
+| 2025-05-02 | Neutral |
+| 2025-05-16 | Neutral |
+
+Missing Fridays (04-18, 04-25, 05-09, 05-23, 05-30) = days where halt was Halted at
+screening time, so no `record_cascade_summary` was called.
+
+Implied Bearish → non-Bearish transitions (each releases the halt once via
+`_maybe_reset_halt`):
+
+1. **2025-05-02** Bearish (from 04-11) → Neutral. Re-arms halt for cascade #2 (Monday 05-05).
+2. **2025-05-16** Bearish → Neutral. The 05-09 trend is NOT in the log, but for halt
+   to have been reset by 05-16 (so screening could run and log the entry) macro must
+   have re-flipped Bearish on 05-09 and back to Neutral on 05-16. Re-arms halt for
+   cascade #3 (Monday 05-19).
+
+So the gate mechanically permits 3 cascades: the initial fire (04-17, during the
+Bearish week itself) + 2 re-fires after Bearish→Neutral transitions. **The
+transition-only reset gate is doing exactly what PR #1052 specified.**
+
+## 2. Equity-curve sanity check — Portfolio_floor breach is impossible at real values
+
+`force_liquidation.ml:239` fires when `portfolio_value < peak * 0.4`. Default
+floor fraction = 0.4 (`force_liquidation.ml:22`).
+
+- All-time peak (`equity_curve.csv`): **$4,555,330 on 2021-06-01**. 0.4 × peak = $1,822,132.
+- Recent peak before cascades (~2025-03-03): $3,707,112. 0.4 × peak = $1,482,845.
+- Portfolio_value at cascade dates: **$3,614,536 (04-17), $3,618,726 (05-05),
+  $3,629,101 (05-19)** — i.e. ~78-79% of all-time peak, ~97-98% of recent peak.
+- `actual.sexp` reports `max_drawdown_pct = 21.35` over the entire 16y run.
+
+**No date in the equity curve falls below 45% of running peak.** Yet
+Portfolio_floor fired three times. Conclusion: `portfolio_value` passed into
+`FL.check` differs from the equity_curve.csv value at the cascade tick.
+
+Suspect mechanism: `Portfolio_view._holding_market_value`
+(`portfolio_view.ml:19-25`) returns **0.0** when `get_price` returns None for a
+holding. Across the bar boundary, holdings that lack a price-bar collapse the
+mark-to-market sum to ~cash-only, which can fall below the floor when most NAV
+is deployed in positions. This is the same class of bug as G9/G12 (memo in the
+.mli on `force_liquidation_runner.mli:42-54`), reappearing in a new shape.
+
+Adjacent equity-curve flatlines (04-18 → 05-02 frozen at $3,613,923.53; 05-06 →
+05-16 frozen at $3,614,960.78) match the simulator NAV fallback bug pattern
+(`memory/project_simulator_nav_fallback_bug.md`).
+
+## 3. Position-ID continuity across cascades
+
+All 13 Portfolio_floor positions are **distinct**, fresh entries (IDs 8188 →
+8234, monotonic):
+
+- 04-17 cascade: ED-8188, TAP-8201, VZ-8205 (entered 2025-03-08 / 03-15).
+- 05-05 cascade: GT-8225, HRB-8224, SII-8226, TRV-8227 (all entered 2025-05-03,
+  2 trading days before cascade).
+- 05-19 cascade: CTAS-8230, EMC-8231, FAST-8232, GE-8233, GT-8234, NRG-8229
+  (all entered 2025-05-17 — Saturday-dated, executed Monday 05-19).
+
+Each cascade flushes the book, the screener immediately re-enters on the next
+Friday (post-reset), and the new cohort gets force-liquidated near-instantly.
+Same-symbol overlap (GT, TRV, SII reappearing) but distinct position_ids → not
+a re-fire on surviving positions; the death-loop suppression is working.
+
+## 4. Verdict
+
+The PR #1052 halt-gate **is mechanically correct**: only one Portfolio_floor
+re-fire happens per Bearish → (Bullish|Neutral) macro transition, and we see
+exactly that ratio (1 initial + 2 re-fires = 3 cascades; 2 implied transitions
+on 2025-05-02 and 2025-05-16 plus the initial 04-11 Bearish week).
+
+**However the underlying Portfolio_floor signal is firing on a falsehood.** Real
+equity ~78% of peak should never trip a 40% floor. Two contributing bugs (both
+known, neither fully fixed):
+
+1. **`Portfolio_view._holding_market_value` returns 0 on missing price** —
+   suspected primary mechanism: newly-entered positions (entries dated 05-03 /
+   05-17) likely lack a price-bar on the cascade tick, deflating
+   `portfolio_value` to ~cash, which is below `0.4 * peak` when most NAV is
+   deployed.
+2. **Simulator NAV fallback** (`memory/project_simulator_nav_fallback_bug.md`,
+   `simulator.ml:213-214`) — equity curve flatlines between cascades, consistent
+   with stale `current_cash` substitution.
+
+The death loop (307 → 13 events) is *suppressed* but the falsity that drives
+the loop is *not removed.* Three cascades in 8 weeks on a portfolio at -22%
+drawdown is still wrong. Recommended follow-ups:
+
+- F1. Make `_holding_market_value` either propagate a stale `Some bar` from the
+  last-known price (forward-fill at the Portfolio_view layer) or surface an
+  explicit "stale" flag so `FL.check` can skip the floor evaluation when
+  mark-to-market is not trustable.
+- F2. Land the simulator NAV-fallback fix (open PR #1019 per memory) so
+  equity_curve.csv stops flatlining and ground-truth divergence is visible.
+- F3. Optional belt-and-braces: gate Portfolio_floor on a *rolling* portfolio
+  high-watermark (e.g. trailing 12 months) rather than all-time peak, so that
+  one 2021 high doesn't dominate the floor through 2025.
+
+## File references
+
+- `dev/backtest/scenarios-2026-05-12-194906/sp500-2010-2026-longshort-historical/force_liquidations.sexp:6-57`
+- `dev/backtest/scenarios-2026-05-12-194906/sp500-2010-2026-longshort-historical/macro_trend.sexp:380-388`
+- `dev/backtest/scenarios-2026-05-12-194906/sp500-2010-2026-longshort-historical/equity_curve.csv:3948-4012`
+- `dev/backtest/scenarios-2026-05-12-194906/sp500-2010-2026-longshort-historical/actual.sexp:6` (force_liquidations_count 14, max_drawdown_pct 21.35)
+- `trading/trading/weinstein/portfolio_risk/lib/force_liquidation.ml:236-262` (halt gate)
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy.ml:53-58` (`_maybe_reset_halt`)
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.ml:70-81` (`entry_transitions_if_active` — halt gates screener which gates macro_trend logging)
+- `trading/trading/strategy/lib/portfolio_view.ml:19-25` (suspected primary bug: 0.0 default on missing price)
+- `trading/trading/backtest/lib/macro_trend_writer.ml:8-15` (macro_trend.sexp built from cascade_summary list — explains the missing Fridays)


### PR DESCRIPTION
## Summary

Documents the 2026-05-13 trade-by-trade audit of the 13 remaining Portfolio_floor force-liquidations on the 16y long-short golden after PR #1052's death-loop fix.

## Headline

The halt-gate is mechanically correct (1 cascade per Bearish→non-Bearish macro transition), but the **underlying breach signal is firing on a falsehood**.

All 3 cascade dates (2025-04-17, 05-05, 05-19) had `portfolio_value` at ~79% of peak — well above the 40% floor — and `actual.sexp` reports `max_drawdown_pct = 21.35%`. Math says the floor should not have triggered.

**Smoking gun**: `equity_curve.csv` flatlines from 2025-04-18 → 05-02 and 2025-05-06 → 05-16, consistent with `Portfolio_view._holding_market_value` returning `0.0` on `get_price = None` for newly-entered positions. Combined with the known simulator NAV-fallback bug (memory note `project_simulator_nav_fallback_bug.md`), this artificially deflates the mark-to-market and trips the floor.

## Recommended follow-ups (NOT in scope for this docs PR)

1. Forward-fill stale prices in `Portfolio_view`, or surface a "stale" flag so `FL.check` skips the floor when MTM is untrustable.
2. Land the simulator NAV fix (PR #1019).
3. Optionally switch the floor to a rolling high-water mark.

The 16y long-short golden's `force_liquidations_count` band should be re-evaluated once the upstream NAV fix lands; with the floor firing legitimately, the count likely drops from 14 to ≤2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)