### PR TITLE
feat(goldens): pin new metrics + re-calibrate 16y sp500-2010-2026 (long-only + long-short)

### DIFF
--- a/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026-longshort.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026-longshort.sexp
@@ -75,4 +75,7 @@
    (sharpe_ratio       ((min   0.56)        (max   0.76)))
    (max_drawdown_pct   ((min  18.1)         (max  24.6)))
    (avg_holding_days   ((min  37.7)         (max  51.1)))
-   (open_positions_value ((min 2017000.0)   (max 2730000.0))))))
+   (open_positions_value ((min 2017000.0)   (max 2730000.0)))
+   (sortino_ratio_annualized ((min  0.86)   (max   1.16)))
+   (calmar_ratio       ((min   0.32)        (max   0.44)))
+   (ulcer_index        ((min   8.38)        (max  11.33))))))

--- a/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp
@@ -50,12 +50,24 @@
  ;; goldens. Prior 0.05/0.50 baseline (110.84% / 302 trades / 23.3% DD) and
  ;; the partial 0.14/0.70-without-rotation baseline (594.35% / 40 trades /
  ;; 28.4% DD) both preserved in git history.
- ;; Measured 2026-05-11 (full Cell E, 16.3y window):
- ;;   total_return_pct  344.9   total_trades 1099   win_rate 42.8
- ;;   sharpe_ratio       0.78   max_drawdown 18.4   avg_holding_days   34
- ;;   open_positions_value 3,085,413
+ ;; Measured 2026-05-13 (full Cell E, 16.3y window, post-#1052 force-liq fix
+ ;; + #1053/#1054 schema):
+ ;;   total_return_pct  341.69  total_trades  806  win_rate 39.08
+ ;;   sharpe_ratio       0.78   max_drawdown 18.36 avg_holding_days  44.68
+ ;;   open_positions_value 3,085,413  unrealized_pnl 566,200
+ ;;   sortino_ratio_annualized 1.25   calmar_ratio 0.52   ulcer_index 7.48
+ ;;   force_liquidations_count 10
+ ;;
+ ;; Pre-P1-fix (2026-05-11) vs post-P1-fix delta:
+ ;;   return    344.9  → 341.69  (-0.9%, marginal)
+ ;;   trades   1099    → 806     (-27%, P1 prevents spurious cascade churn)
+ ;;   avg_hold  34     → 44.68   (+31%, positions live longer without
+ ;;                                weekly forced exits)
+ ;;   force-liqs  0    → 10      (1 legitimate cascade × ~10 positions —
+ ;;                                same root mechanism as long-short, see
+ ;;                                dev/notes/longshort-cascades-investigation-2026-05-13.md)
  ;; Cell E rotation cuts MaxDD by 10pp vs the no-rotation 0.14/0.70 variant
- ;; (28 → 18.4) while running 27x more trades (40 → 1099). Tolerances ±15%.
+ ;; (28 → 18.4) while running 22x more trades (40 → 806). Tolerances ±15%.
  (config_overrides
   (((enable_short_side false))
    ((portfolio_config ((max_position_pct_long 0.14))))
@@ -66,10 +78,13 @@
    ((enable_laggard_rotation true))
    ((laggard_rotation_config ((hysteresis_weeks 2))))))
  (expected
-  ((total_return_pct   ((min 293.0)         (max 397.0)))
-   (total_trades       ((min 935)           (max 1265)))
-   (win_rate           ((min  36.4)         (max  49.2)))
+  ((total_return_pct   ((min 290.0)         (max 393.0)))
+   (total_trades       ((min 685)           (max  927)))
+   (win_rate           ((min  33.2)         (max  44.9)))
    (sharpe_ratio       ((min   0.66)        (max   0.90)))
    (max_drawdown_pct   ((min  15.6)         (max  21.2)))
-   (avg_holding_days   ((min  29.0)         (max  39.0)))
-   (open_positions_value ((min 2620000.0)   (max 3550000.0))))))
+   (avg_holding_days   ((min  37.9)         (max  51.3)))
+   (open_positions_value ((min 2620000.0)   (max 3550000.0)))
+   (sortino_ratio_annualized ((min  1.06)   (max   1.43)))
+   (calmar_ratio       ((min   0.44)        (max   0.59)))
+   (ulcer_index        ((min   6.35)        (max   8.60))))))


### PR DESCRIPTION
## Summary

Adds M5.2c metric pins (Sortino/Calmar/UlcerIndex) for both 16y goldens **and** re-calibrates 7 pre-existing pins on the long-only variant to absorb the P1 fix's behavioral shift.

The P1 force-liquidation fix (#1052) reduced spurious Portfolio_floor cascades on both 16y variants, changing trade behavior.

## sp500-2010-2026 (long-only, Cell E)

Measured 2026-05-13:

| Metric | Pre-P1 (2026-05-11) | Post-P1 (2026-05-13) | Δ |
|---|---:|---:|---:|
| total_trades | 1099 | 806 | **-27%** |
| avg_holding_days | 34 | 44.68 | **+31%** |
| force_liquidations | 0 | 10 | (1 cascade × ~10 positions) |
| total_return_pct | 344.9 | 341.69 | -0.9% |
| sharpe_ratio | 0.78 | 0.78 | flat |
| max_drawdown_pct | 18.4 | 18.36 | flat |

**7 metric pins re-calibrated** (strict ±15% around new measured): total_return_pct, total_trades, win_rate, avg_holding_days.
**3 new pins** added: sortino 1.25 → [1.06, 1.43]; calmar 0.52 → [0.44, 0.59]; ulcer 7.48 → [6.35, 8.60].

## sp500-2010-2026-longshort (Cell E + shorts)

Measured 2026-05-13: all 7 prior pins (set in #1052) still hold within ±15%. Adds 3 new pins:

| Metric | Measured | Pin |
|---|---:|---:|
| sortino_ratio_annualized | 1.01 | [0.86, 1.16] |
| calmar_ratio | 0.38 | [0.32, 0.44] |
| ulcer_index | 9.86 | [8.38, 11.33] |

## Cross-cell sanity

The long-only's higher Sortino (1.25 vs 1.01) and tighter Ulcer (7.48 vs 9.86) confirm what the cascade investigation note found (#1056 / `dev/notes/longshort-cascades-investigation-2026-05-13.md`): the short-side introduces extra drawdown volatility on this window without the hypothesised downside-shape benefit. Re-evaluate once the upstream NAV stale-price fix lands and the long-short's 14 force-liqs drop to the expected ≤2.

## Test plan

- [x] `Scenario.load` parses both updated sexps
- [x] All measured 2026-05-13 actual.sexp values fall within new ±15% ranges
- [x] No config overrides changed; only `expected` block edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)