### PR TITLE
fix(portfolio_view): avg-cost fallback when get_price=None

### DIFF
--- a/trading/trading/strategy/lib/portfolio_view.ml
+++ b/trading/trading/strategy/lib/portfolio_view.ml
@@ -16,12 +16,23 @@ let _signed_quantity ~side quantity =
   | Long -> quantity
   | Short -> -.quantity
 
+(* When [get_price] returns None for a held symbol (e.g. M&A delist, dataset
+   gap, weekend/holiday before the adapter forward-fill kicks in), fall back to
+   [entry_price] — zero unrealized P&L. Returning 0.0 here used to silently
+   collapse market value to bare cash, which corrupted [portfolio_value] and
+   anything derived from it (sizing, [Peak_tracker], NAV series). The
+   simulator's own NAV path has an analogous cache+avg-cost chain (see
+   simulator.ml [_resolve_price]); this fallback is the defense-in-depth at the
+   strategy-facing seam. *)
 let _holding_market_value (pos : Position.t) ~get_price =
   match pos.state with
-  | Holding { quantity; _ } ->
-      Option.value_map (get_price pos.symbol) ~default:0.0
-        ~f:(fun (bar : Types.Daily_price.t) ->
-          _signed_quantity ~side:pos.side quantity *. bar.close_price)
+  | Holding { quantity; entry_price; _ } ->
+      let price =
+        match get_price pos.symbol with
+        | Some (bar : Types.Daily_price.t) -> bar.close_price
+        | None -> entry_price
+      in
+      _signed_quantity ~side:pos.side quantity *. price
   | _ -> 0.0
 
 let portfolio_value { cash; positions } ~get_price =

--- a/trading/trading/strategy/lib/portfolio_view.mli
+++ b/trading/trading/strategy/lib/portfolio_view.mli
@@ -16,5 +16,7 @@ val portfolio_value :
     positions. Long holdings contribute [+quantity * close_price]; shorts
     contribute [-quantity * close_price] (the buy-back liability — cash already
     reflects proceeds credited at short entry, so subtracting the current
-    liability tracks short P&L correctly). Positions not in [Holding] state or
-    without a current price are excluded. *)
+    liability tracks short P&L correctly). When [get_price] returns [None] for a
+    held symbol, the position is marked at its [entry_price] (zero unrealized
+    P&L) — defense in depth against silent NAV collapse on dataset gaps.
+    Positions not in [Holding] state are excluded. *)

--- a/trading/trading/strategy/test/test_portfolio_view.ml
+++ b/trading/trading/strategy/test/test_portfolio_view.ml
@@ -63,7 +63,10 @@ let test_portfolio_value_with_long_position _ =
     (Portfolio_view.portfolio_value pv ~get_price)
     (float_equal 66000.0)
 
-let test_portfolio_value_no_price_excludes _ =
+(* When get_price returns None for a held symbol, fall back to entry_price
+   (zero unrealized P&L). Previously returned 0.0 → cash-only collapse, which
+   silently corrupted portfolio_value and the Peak_tracker. *)
+let test_portfolio_value_no_price_uses_avg_cost _ =
   let aapl =
     _make_holding ~id:"AAPL-1" ~symbol:"AAPL" ~side:Long ~quantity:100.0
       ~entry_price:150.0
@@ -72,9 +75,25 @@ let test_portfolio_value_no_price_excludes _ =
     { cash = 50000.0; positions = String.Map.singleton "AAPL-1" aapl }
   in
   let get_price _ = None in
+  (* 50000 cash + 100 shares * 150 (avg cost) = 65000 *)
   assert_that
     (Portfolio_view.portfolio_value pv ~get_price)
-    (float_equal 50000.0)
+    (float_equal 65000.0)
+
+(* Same fallback for shorts: liability marked at entry_price. *)
+let test_portfolio_value_short_no_price_uses_avg_cost _ =
+  let xyz =
+    _make_holding ~id:"XYZ-1" ~symbol:"XYZ" ~side:Short ~quantity:100.0
+      ~entry_price:100.0
+  in
+  let pv : Portfolio_view.t =
+    { cash = 1_010_000.0; positions = String.Map.singleton "XYZ-1" xyz }
+  in
+  let get_price _ = None in
+  (* 1_010_000 cash - 100 shares * 100 (avg cost liability) = 1_000_000 *)
+  assert_that
+    (Portfolio_view.portfolio_value pv ~get_price)
+    (float_equal 1_000_000.0)
 
 (* G8 — short positions must subtract from portfolio value, not add.
 
@@ -148,8 +167,10 @@ let suite =
          "portfolio_value_cash_only" >:: test_portfolio_value_cash_only;
          "portfolio_value_with_long_position"
          >:: test_portfolio_value_with_long_position;
-         "portfolio_value_no_price_excludes"
-         >:: test_portfolio_value_no_price_excludes;
+         "portfolio_value_no_price_uses_avg_cost"
+         >:: test_portfolio_value_no_price_uses_avg_cost;
+         "portfolio_value_short_no_price_uses_avg_cost"
+         >:: test_portfolio_value_short_no_price_uses_avg_cost;
          "portfolio_value_short_position_at_profit"
          >:: test_portfolio_value_short_position_at_profit;
          "portfolio_value_short_position_at_loss"


### PR DESCRIPTION
## Summary

Previously \`Portfolio_view._holding_market_value\` returned \`0.0\` whenever \`get_price\` returned \`None\` for a held symbol, silently collapsing market value to bare cash. This corrupted \`portfolio_value\` and every caller that derived from it: position sizing in \`weinstein_strategy_screening\`, the \`Peak_tracker\`/\`Portfolio_floor\` drawdown gate, and any mid-tick valuation.

Falls back to \`Holding.entry_price\` (zero unrealized P&L) when \`get_price\` returns \`None\`. Mirrors the avg-cost tail of the simulator's \`_resolve_price\` chain (#1019): bar → previous_bar → cache → avg_cost. This is the defense-in-depth at the strategy-facing seam — analogous to the simulator fix but on the strategy/Portfolio_view side.

For shorts the fallback marks the liability at \`entry_price\` too, so signed mtm goes \`-qty * entry_price\` (zero unrealized P&L); \`portfolio_value\` stays conservative on gapped data.

## What changed

- \`trading/trading/strategy/lib/portfolio_view.ml\` — fall back to \`entry_price\` on \`get_price = None\` for long and short holdings.
- \`trading/trading/strategy/lib/portfolio_view.mli\` — document the fallback in the public docstring.
- \`trading/trading/strategy/test/test_portfolio_view.ml\` — replace the test that pinned the bug (\`test_portfolio_value_no_price_excludes\`) with \`test_portfolio_value_no_price_uses_avg_cost\` (long) + new \`test_portfolio_value_short_no_price_uses_avg_cost\` (short).

## Test plan

- [x] \`dune build\` clean.
- [x] \`dune runtest\` — full repo green; no regressions in upstream / downstream callers (strategy / simulation / backtest / weinstein).
- [x] 5y goldens (\`sp500-2019-2023\` + \`sp500-2019-2023-long-only\`) re-run locally — both PASS within existing pinned ranges:
  - \`sp500-2019-2023\`: Return 50.7% / Trades 264 / WR 37.5% / MaxDD 21.6% — inside (43.0, 58.0) / (224, 304) / (31.8, 43.2) / (18.4, 24.9).
  - \`sp500-2019-2023-long-only\`: Return 66.5% / Trades 248 / WR 39.1% / MaxDD 24.1%.
- [ ] 10y decade + 16y sp500-2010-2026 goldens — heavier runs, will re-pin in a follow-up PR if force-liq counts drop materially (per #1056 P1 sub-path 3 expectation: long-short force-liqs ≤2, long-only 0).

## Notes

The simulator's NAV path (#1019) was the bigger half of this fix; this PR is the strategy-side companion. They cover different seams: simulator's \`_resolve_price\` resolves bars for daily NAV emission, while \`Portfolio_view.portfolio_value\` is called by the strategy itself (sizing, peak tracker) and inherits whatever \`get_price\` the simulator handed in — which currently does not include the #1019 cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)