### PR TITLE
feat(runner): validate sweep overlay paths resolve to real record fields

### DIFF
--- a/trading/trading/backtest/lib/overlay_validator.ml
+++ b/trading/trading/backtest/lib/overlay_validator.ml
@@ -1,0 +1,103 @@
+open Core
+
+let _is_record fields =
+  List.for_all fields ~f:(function
+    | Sexp.List [ Sexp.Atom _; _ ] -> true
+    | _ -> false)
+
+let _record_field_pairs fields =
+  List.filter_map fields ~f:(function
+    | Sexp.List [ Sexp.Atom k; v ] -> Some (k, v)
+    | _ -> None)
+
+(** Deep-merge [overlay] into [base], collecting any overlay key that does not
+    resolve to a real field in [base]. The walk only treats both nodes as
+    "records" when each is a list of [(atom, value)] pairs ([_is_record]); any
+    other shape is overlay-wins (legacy behaviour preserved at leaves).
+
+    [path] is the dot-path from the root used only to build human-readable error
+    messages when an unknown key is found. The caller seeds it with [[]] and
+    each recursive step prepends the parent field name.
+
+    Returns [(merged_sexp, unknown_paths)] where [unknown_paths] is the list of
+    dot-paths the overlay attempted to set that have no match in [base]. The
+    PR-#1051 bug was exactly this: overlays keyed on
+    [screening_config.weights.rs] (no such field — the real names are
+    [w_positive_rs] etc.) were silently dropped, so an 81-cell sweep produced
+    bit-identical metrics. [apply_overrides] raises on a non-empty
+    [unknown_paths] list to surface this loudly. *)
+let rec _merge_sexp ~path base overlay =
+  match (base, overlay) with
+  | Sexp.List base_fields, Sexp.List overlay_fields
+    when _is_record base_fields && _is_record overlay_fields ->
+      _merge_records ~path base_fields overlay_fields
+  | _, _ -> (overlay, [])
+
+and _merge_records ~path base_fields overlay_fields =
+  let base_keys =
+    _record_field_pairs base_fields |> List.map ~f:fst |> String.Set.of_list
+  in
+  let overlay_pairs = _record_field_pairs overlay_fields in
+  let unknown_at_this_level =
+    List.filter_map overlay_pairs ~f:(fun (k, _) ->
+        if Set.mem base_keys k then None
+        else Some (String.concat ~sep:"." (List.rev (k :: path))))
+  in
+  let overlay_map = String.Map.of_alist_exn overlay_pairs in
+  let nested_unknowns, merged_pairs =
+    List.fold_map base_fields ~init:[] ~f:(_merge_one_field ~path ~overlay_map)
+  in
+  (Sexp.List merged_pairs, unknown_at_this_level @ nested_unknowns)
+
+and _merge_field_with_overlay ~path ~k ~base_v ~overlay_v ~acc =
+  let merged_v, sub_unknowns = _merge_sexp ~path:(k :: path) base_v overlay_v in
+  (sub_unknowns @ acc, Sexp.List [ Sexp.Atom k; merged_v ])
+
+and _merge_one_field ~path ~overlay_map acc field =
+  match field with
+  | Sexp.List [ Sexp.Atom k; base_v ] -> (
+      match Map.find overlay_map k with
+      | Some overlay_v ->
+          _merge_field_with_overlay ~path ~k ~base_v ~overlay_v ~acc
+      | None -> (acc, field))
+  | other -> (acc, other)
+
+(** Format an unknown-key error message for human-readable output. The
+    [overlay_idx] is the position in the [overrides] list (0-based) so operators
+    can tell which [--override] flag is the culprit. *)
+let _format_unknown_keys_error ~overlay_idx ~unknowns ~overlay_sexp =
+  let bullets =
+    List.map unknowns ~f:(fun p -> Printf.sprintf "  - %s" p)
+    |> String.concat ~sep:"\n"
+  in
+  Printf.sprintf
+    "Runner overlay #%d contains key(s) that do not resolve to any field on \
+     the base [Weinstein_strategy.config] record:\n\
+     %s\n\
+     Offending overlay sexp:\n\
+     %s\n\
+     This is fatal — the previous behaviour silently dropped the unknown keys, \
+     so e.g. a sweep over a misspelled path produced bit-identical metrics \
+     across every cell. Fix the key path (consult \
+     [Weinstein_strategy.sexp_of_config] / [Screener.config] for valid field \
+     names) and re-run."
+    overlay_idx bullets
+    (Sexp.to_string_hum overlay_sexp)
+
+let _raise_if_unknowns ~overlay_idx ~overlay_sexp = function
+  | [] -> ()
+  | unknowns ->
+      failwith (_format_unknown_keys_error ~overlay_idx ~unknowns ~overlay_sexp)
+
+let _merge_one_overlay i acc_sexp overlay =
+  let merged_sexp, unknowns = _merge_sexp ~path:[] acc_sexp overlay in
+  _raise_if_unknowns ~overlay_idx:i ~overlay_sexp:overlay unknowns;
+  merged_sexp
+
+let apply_overrides (config : Weinstein_strategy.config) overrides =
+  match overrides with
+  | [] -> config
+  | _ ->
+      let base = Weinstein_strategy.sexp_of_config config in
+      let merged = List.foldi overrides ~init:base ~f:_merge_one_overlay in
+      Weinstein_strategy.config_of_sexp merged

--- a/trading/trading/backtest/lib/overlay_validator.mli
+++ b/trading/trading/backtest/lib/overlay_validator.mli
@@ -1,0 +1,16 @@
+(** Validate + apply sweep-overlay sexps onto the canonical
+    [Weinstein_strategy.config] base. Closes the silent-no-op hazard from PR
+    #1051: an overlay key that does not resolve to a real field on the base
+    record now raises [Failure] with the offending overlay index, the unknown
+    dot-paths, and the verbatim overlay sexp — rather than being silently
+    dropped (which previously produced bit-identical metrics across an 81-cell
+    sweep). *)
+
+val apply_overrides :
+  Weinstein_strategy.config -> Sexplib.Sexp.t list -> Weinstein_strategy.config
+(** [apply_overrides config overrides] deep-merges each overlay in [overrides]
+    (left-to-right) into [config]. Raises [Failure] on the first overlay
+    containing any key path that does not resolve to a real field on the running
+    base record. The error message names the offending overlay index (0-based),
+    the dot-paths that did not resolve, and the overlay sexp verbatim, so
+    operators can locate the typo in their sweep spec. *)

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -76,42 +76,11 @@ let is_trading_day (step : Trading_simulation_types.Simulator_types.step_result)
     =
   step.had_market_bars
 
-(* Config overrides via sexp deep-merge *)
+(* Config overrides via sexp deep-merge — see {!Overlay_validator} for the
+   deep-merge + unknown-key validation. Extracted to a sibling module to keep
+   this file under the @large-module size limit. *)
 
-let _is_record fields =
-  List.for_all fields ~f:(function
-    | Sexp.List [ Sexp.Atom _; _ ] -> true
-    | _ -> false)
-
-let rec _merge_sexp base overlay =
-  match (base, overlay) with
-  | Sexp.List base_fields, Sexp.List overlay_fields
-    when _is_record base_fields && _is_record overlay_fields ->
-      _merge_records base_fields overlay_fields
-  | _, _ -> overlay
-
-and _merge_records base_fields overlay_fields =
-  let overlay_map =
-    List.filter_map overlay_fields ~f:(function
-      | Sexp.List [ Sexp.Atom k; v ] -> Some (k, v)
-      | _ -> None)
-    |> String.Map.of_alist_exn
-  in
-  Sexp.List
-    (List.map base_fields ~f:(function
-      | Sexp.List [ Sexp.Atom k; v ] as pair -> (
-          match Map.find overlay_map k with
-          | Some overlay_v -> Sexp.List [ Sexp.Atom k; _merge_sexp v overlay_v ]
-          | None -> pair)
-      | other -> other))
-
-let _apply_overrides (config : Weinstein_strategy.config) overrides =
-  match overrides with
-  | [] -> config
-  | _ ->
-      let base = Weinstein_strategy.sexp_of_config config in
-      let merged = List.fold overrides ~init:base ~f:_merge_sexp in
-      Weinstein_strategy.config_of_sexp merged
+let _apply_overrides = Overlay_validator.apply_overrides
 
 (* Dependency loading *)
 

--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -328,6 +328,107 @@ let test_two_overlays_same_top_level_field _ =
            (float_equal 0.10);
        ])
 
+(* -------------------------------------------------------------------- *)
+(* Sweep-path validation: unknown overlay keys fail loudly               *)
+(* -------------------------------------------------------------------- *)
+
+(** Reproduction of the PR-#1051 silent-no-op hazard: a sweep cell keyed on
+    [screening_config.weights.rs] (a path that does not name any field on the
+    real [scoring_weights] record — the field is [w_positive_rs]) used to be
+    silently dropped by the deep-merge, so all 81 cells produced bit-identical
+    metrics. With the sweep-path linter added in this PR, the runner must FAIL
+    LOUDLY on the first unknown key, naming the offending dotted path. *)
+let test_unknown_top_level_overlay_key_fails _ =
+  let s = _load_scenario () in
+  let sector_map_override = _sector_map_override s in
+  let result =
+    Result.try_with (fun () ->
+        Backtest.Runner.run_backtest ~start_date:s.period.start_date
+          ~end_date:s.period.end_date
+          ~overrides:[ Sexp.of_string "((no_such_field 42))" ]
+          ?sector_map_override ())
+  in
+  assert_that result
+    (matching ~msg:"Expected Failure raising on unknown key"
+       (function Error (Failure msg) -> Some msg | _ -> None)
+       (all_of
+          [
+            field
+              (fun s -> String.is_substring s ~substring:"no_such_field")
+              (equal_to true);
+            field
+              (fun s -> String.is_substring s ~substring:"overlay #0")
+              (equal_to true);
+          ]))
+
+(** Nested unknown path — the merge walks into the (real) [screening_config]
+    sub-record, then sees the (non-existent) [weights.rs] path. The error must
+    name the full dotted path so an operator looking at the error can match it
+    back to their sweep-spec key. *)
+let test_unknown_nested_overlay_key_fails _ =
+  let s = _load_scenario () in
+  let sector_map_override = _sector_map_override s in
+  let result =
+    Result.try_with (fun () ->
+        Backtest.Runner.run_backtest ~start_date:s.period.start_date
+          ~end_date:s.period.end_date
+          ~overrides:
+            [ Sexp.of_string "((screening_config ((weights ((rs 1.5))))))" ]
+          ?sector_map_override ())
+  in
+  assert_that result
+    (matching ~msg:"Expected Failure raising on nested unknown key"
+       (function Error (Failure msg) -> Some msg | _ -> None)
+       (field
+          (fun s ->
+            String.is_substring s ~substring:"screening_config.weights.rs")
+          (equal_to true)))
+
+(** A real (deep, valid) path must still resolve and apply — the
+    [screening_config.weights.w_clean_resistance] field IS a real
+    [scoring_weights] field. This pins that the happy path is unaffected by the
+    new validation. *)
+let test_known_nested_overlay_key_succeeds _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string
+         "((screening_config ((weights ((w_clean_resistance 30))))))")
+  in
+  assert_that merged.screening_config.weights.w_clean_resistance (equal_to 30)
+
+(** The error message must include the index of the offending overlay (0-based)
+    so operators can map back to the specific [--override] flag. When the second
+    overlay is invalid and the first is valid, the index must report [#1] (not
+    [#0]). *)
+let test_unknown_key_error_reports_overlay_index _ =
+  let s = _load_scenario () in
+  let sector_map_override = _sector_map_override s in
+  let result =
+    Result.try_with (fun () ->
+        Backtest.Runner.run_backtest ~start_date:s.period.start_date
+          ~end_date:s.period.end_date
+          ~overrides:
+            [
+              (* valid — universe_cap is a real field *)
+              Sexp.of_string "((universe_cap (3)))";
+              (* invalid — typo of universe_cap *)
+              Sexp.of_string "((universe_caps (3)))";
+            ]
+          ?sector_map_override ())
+  in
+  assert_that result
+    (matching ~msg:"Expected Failure naming overlay #1"
+       (function Error (Failure msg) -> Some msg | _ -> None)
+       (all_of
+          [
+            field
+              (fun s -> String.is_substring s ~substring:"overlay #1")
+              (equal_to true);
+            field
+              (fun s -> String.is_substring s ~substring:"universe_caps")
+              (equal_to true);
+          ]))
+
 let suite =
   "Runner_hypothesis_overrides"
   >::: [
@@ -363,6 +464,14 @@ let suite =
          >:: test_default_screening_volume_ratio_exclude_range_is_none;
          "two overlays targeting same top-level field both apply"
          >:: test_two_overlays_same_top_level_field;
+         "unknown top-level overlay key fails loudly (sweep-path linter)"
+         >:: test_unknown_top_level_overlay_key_fails;
+         "unknown nested overlay key names the full dotted path"
+         >:: test_unknown_nested_overlay_key_fails;
+         "known nested overlay key still applies (linter happy path)"
+         >:: test_known_nested_overlay_key_succeeds;
+         "error message reports overlay index for multi-overlay runs"
+         >:: test_unknown_key_error_reports_overlay_index;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Closes the PR #1051 silent-no-op hazard called out in §5 #3 of
`dev/notes/screener-weights-inertness-2026-05-13.md`.

PR #1051 ran an 81-cell grid sweep over `screening_config.weights.{rs, volume, breakout, sector}` — none of which name actual `scoring_weights` record fields (the real names are `w_positive_rs` / `w_strong_volume` / `w_stage2_breakout` / `w_sector_strong`). The runner's `_merge_records` deep-merge silently dropped the unknown keys, so every cell ran with identical config and the experiment was misread as "weights are inert." The P4 investigation in `dev/notes/screener-weights-inertness-2026-05-13.md` (merged via #1061) traced this back to the merge function and called for a sweep-path linter.

## What it does

`_merge_sexp` / `_merge_records` in `trading/trading/backtest/lib/runner.ml` now thread a dotted **path** through the recursion and collect overlay keys that do not resolve to a real field in the base sexp. `_apply_overrides` raises a `Failure` with a clear multi-line error message when any overlay contains unknown keys:

- the overlay's **0-based index** in the `overrides` list (so operators can map back to the specific `--override` flag),
- the **dotted paths** of each unknown key,
- the **offending overlay sexp** verbatim.

Happy-path behaviour is bit-identical for every override that uses real field names — every existing scenario in `test_data/backtest_scenarios/` already uses the correct paths, and the full `dune runtest trading/backtest/` suite passes unchanged.

## Test plan

Four new tests in `test_runner_hypothesis_overrides.ml` pin the failure surface:

- [x] top-level unknown overlay key → `Failure` naming the key and `overlay #0`
- [x] nested unknown overlay key → `Failure` naming the full dotted path (e.g. `screening_config.weights.rs`)
- [x] known deep path (`screening_config.weights.w_clean_resistance`) still applies — linter does not break the happy path
- [x] second of two overlays unknown → error message reports `overlay #1`
- [x] all 20 tests in `test_runner_hypothesis_overrides` pass via `dune runtest trading/backtest/`
- [x] `dune build @fmt` is clean