### PR TITLE
feat(scripts): EODHD delisted-symbol audit cross-ref (fixture-driven)

### DIFF
--- a/trading/analysis/scripts/eodhd_delisted_audit/dune
+++ b/trading/analysis/scripts/eodhd_delisted_audit/dune
@@ -1,0 +1,5 @@
+(executable
+ (name eodhd_delisted_audit)
+ (libraries core core_unix.command_unix status eodhd_delisted_audit_lib)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/scripts/eodhd_delisted_audit/eodhd_delisted_audit.ml
+++ b/trading/analysis/scripts/eodhd_delisted_audit/eodhd_delisted_audit.ml
@@ -1,0 +1,71 @@
+(** EODHD delisted-symbol audit (offline / fixture-driven).
+
+    Cross-references the Wiki S&P 500 "removed" event list against a pinned
+    snapshot of EODHD's exchange-symbol-list endpoint, classifying every removed
+    symbol as [matched-in-eodhd-delisted], [live-on-eodhd], or [not-found]. The
+    live HTTP fetch is deferred to a follow-up; this exe operates entirely on
+    local fixture files.
+
+    Typical usage:
+    {v
+      eodhd_delisted_audit.exe \
+        --removed-sexp data/sp500_removed.sexp \
+        --eodhd-fixture data/eodhd_delisted_fixture.json \
+        --out reports/eodhd_delisted_audit.md
+    v} *)
+
+open Core
+
+let _read_file path =
+  try Ok (In_channel.read_all path)
+  with Sys_error msg ->
+    Status.error_invalid_argument
+      (Printf.sprintf "failed to read %s: %s" path msg)
+
+let _write_file path content =
+  try
+    Out_channel.write_all path ~data:content;
+    Ok ()
+  with Sys_error msg ->
+    Status.error_invalid_argument
+      (Printf.sprintf "failed to write %s: %s" path msg)
+
+let _run ~removed_sexp_path ~eodhd_fixture_path ~out_path =
+  let open Result.Let_syntax in
+  let%bind removed_text = _read_file removed_sexp_path in
+  let%bind removed = Eodhd_delisted_audit_lib.parse_removed_sexp removed_text in
+  let%bind eodhd_text = _read_file eodhd_fixture_path in
+  let%bind eodhd = Eodhd_delisted_audit_lib.parse_eodhd_fixture eodhd_text in
+  let rows = Eodhd_delisted_audit_lib.cross_reference ~removed ~eodhd in
+  let markdown = Eodhd_delisted_audit_lib.render_markdown rows in
+  let%bind () = _write_file out_path markdown in
+  Ok rows
+
+let _main ~removed_sexp_path ~eodhd_fixture_path ~out_path () =
+  match _run ~removed_sexp_path ~eodhd_fixture_path ~out_path with
+  | Error e ->
+      Printf.eprintf "Error: %s\n" (Status.show e);
+      exit 1
+  | Ok rows ->
+      Printf.printf "Audited %d removed symbols, wrote %s\n%!"
+        (List.length rows) out_path
+
+let command =
+  Command.basic
+    ~summary:
+      "Cross-reference Wiki S&P 500 removed-symbol list against EODHD fixture"
+    (let%map_open.Command removed_sexp_path =
+       flag "removed-sexp" (required string)
+         ~doc:
+           "PATH Sexp list of removed events (((symbol \"X\") (effective_date \
+            \"YYYY-MM-DD\")) ...)"
+     and eodhd_fixture_path =
+       flag "eodhd-fixture" (required string)
+         ~doc:
+           "PATH JSON snapshot of EODHD exchange-symbol-list (delisted + live)"
+     and out_path =
+       flag "out" (required string) ~doc:"PATH Markdown report destination"
+     in
+     fun () -> _main ~removed_sexp_path ~eodhd_fixture_path ~out_path ())
+
+let () = Command_unix.run command

--- a/trading/analysis/scripts/eodhd_delisted_audit/lib/dune
+++ b/trading/analysis/scripts/eodhd_delisted_audit/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name eodhd_delisted_audit_lib)
+ (libraries core status yojson)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/scripts/eodhd_delisted_audit/lib/eodhd_delisted_audit_lib.ml
+++ b/trading/analysis/scripts/eodhd_delisted_audit/lib/eodhd_delisted_audit_lib.ml
@@ -1,0 +1,103 @@
+open Core
+
+type removed_symbol = { symbol : string; effective_date : string }
+[@@deriving sexp, equal]
+
+type eodhd_fixture = { delisted : string list; live : string list }
+[@@deriving sexp_of, equal]
+
+type status = Matched_in_eodhd_delisted | Live_on_eodhd | Not_found
+[@@deriving sexp_of, equal]
+
+type row = { symbol : string; effective_date : string; status : status }
+[@@deriving sexp_of, equal]
+
+let parse_removed_sexp text =
+  try
+    let sexp = Sexp.of_string text in
+    Ok (List.t_of_sexp removed_symbol_of_sexp sexp)
+  with exn ->
+    Status.error_invalid_argument
+      ("Failed to parse removed-symbols sexp: " ^ Exn.to_string exn)
+
+let _code_of_entry = function
+  | `Assoc fields -> (
+      match List.Assoc.find fields "Code" ~equal:String.equal with
+      | Some (`String s) -> Some s
+      | _ -> None)
+  | _ -> None
+
+let _codes_of_json_array = function
+  | `List entries -> List.filter_map entries ~f:_code_of_entry
+  | _ -> []
+
+let _fixture_of_object fields =
+  let lookup key =
+    List.Assoc.find fields key ~equal:String.equal
+    |> Option.value ~default:(`List [])
+  in
+  Ok
+    {
+      delisted = _codes_of_json_array (lookup "delisted");
+      live = _codes_of_json_array (lookup "live");
+    }
+
+let parse_eodhd_fixture text =
+  try
+    match Yojson.Safe.from_string text with
+    | `Assoc fields -> _fixture_of_object fields
+    | _ ->
+        Status.error_invalid_argument
+          "Expected top-level JSON object with 'delisted' and 'live' keys"
+  with Yojson.Json_error msg ->
+    Status.error_invalid_argument ("Invalid EODHD fixture JSON: " ^ msg)
+
+let _classify ~delisted_set ~live_set symbol =
+  if Hash_set.mem delisted_set symbol then Matched_in_eodhd_delisted
+  else if Hash_set.mem live_set symbol then Live_on_eodhd
+  else Not_found
+
+let cross_reference ~(removed : removed_symbol list) ~eodhd =
+  let delisted_set = Hash_set.of_list (module String) eodhd.delisted in
+  let live_set = Hash_set.of_list (module String) eodhd.live in
+  List.map removed ~f:(fun r ->
+      {
+        symbol = r.symbol;
+        effective_date = r.effective_date;
+        status = _classify ~delisted_set ~live_set r.symbol;
+      })
+  |> List.sort ~compare:(fun a b -> String.compare a.symbol b.symbol)
+
+let _status_label = function
+  | Matched_in_eodhd_delisted -> "matched-in-eodhd-delisted"
+  | Live_on_eodhd -> "live-on-eodhd"
+  | Not_found -> "not-found"
+
+let _status_order = function
+  | Matched_in_eodhd_delisted -> 0
+  | Live_on_eodhd -> 1
+  | Not_found -> 2
+
+let _count_status rows s = List.count rows ~f:(fun r -> equal_status r.status s)
+let _initial_buffer_bytes = 1024
+
+let render_markdown rows =
+  let buf = Buffer.create _initial_buffer_bytes in
+  Buffer.add_string buf "# EODHD Delisted-Symbol Audit\n\n";
+  Printf.bprintf buf "Matched: %d / Live: %d / Not-found: %d (total: %d)\n\n"
+    (_count_status rows Matched_in_eodhd_delisted)
+    (_count_status rows Live_on_eodhd)
+    (_count_status rows Not_found)
+    (List.length rows);
+  Buffer.add_string buf "| Symbol | Effective Date | Status |\n";
+  Buffer.add_string buf "|--------|----------------|--------|\n";
+  let sorted =
+    List.sort rows ~compare:(fun a b ->
+        match Int.compare (_status_order a.status) (_status_order b.status) with
+        | 0 -> String.compare a.symbol b.symbol
+        | c -> c)
+  in
+  List.iter sorted ~f:(fun r ->
+      Printf.bprintf buf "| %s | %s | %s |\n" r.symbol r.effective_date
+        (_status_label r.status));
+  Buffer.contents buf

--- a/trading/analysis/scripts/eodhd_delisted_audit/lib/eodhd_delisted_audit_lib.mli
+++ b/trading/analysis/scripts/eodhd_delisted_audit/lib/eodhd_delisted_audit_lib.mli
@@ -1,0 +1,69 @@
+(** Cross-reference logic for the EODHD delisted-symbol audit.
+
+    Companion plan: this is the offline half of P5 phase-2 — we already have a
+    list of S&P 500 symbols that were *removed* from the index (sourced from
+    {!Wiki_sp500.Changes_parser}) and we want to know, for each such symbol,
+    whether EODHD has it in its delisted-symbol feed, in its live-symbol feed,
+    or nowhere. The "live fetch" CLI flag (calling EODHD over HTTP) is left for
+    a follow-up — this module operates entirely on pinned JSON fixtures. *)
+
+(** {1 Inputs} *)
+
+type removed_symbol = { symbol : string; effective_date : string }
+[@@deriving sexp_of, equal]
+(** A single "removed" event from the Wiki S&P 500 changes table, reduced to
+    just the symbol and the effective date (as a free-form string — typically
+    [YYYY-MM-DD] — preserved verbatim for human inspection in the report). The
+    audit deliberately drops [security_name] and [reason_text] from the upstream
+    {!Wiki_sp500.Changes_parser.change_event}: those fields are not needed for
+    cross-referencing against EODHD, and dropping them keeps the fixture format
+    trivial to hand-author. *)
+
+type eodhd_fixture = { delisted : string list; live : string list }
+[@@deriving sexp_of, equal]
+(** A snapshot of EODHD's exchange-symbol-list endpoint for the US market. In
+    real use this would be populated from two calls — one with [?delisted=1] and
+    one without — but for offline cross-referencing we only need the set of
+    ticker codes on each side. *)
+
+(** {1 Cross-reference output} *)
+
+type status =
+  | Matched_in_eodhd_delisted  (** EODHD knows the symbol delisted. *)
+  | Live_on_eodhd
+      (** EODHD has the symbol in its active universe — usually means the ticker
+          was reassigned (e.g. WB: Wachovia → Weibo). *)
+  | Not_found  (** EODHD does not have the symbol on either side. *)
+[@@deriving sexp_of, equal]
+
+type row = { symbol : string; effective_date : string; status : status }
+[@@deriving sexp_of, equal]
+(** One row per audited removed-symbol. Output is sorted by [symbol] ascending
+    for deterministic reports. *)
+
+(** {1 Parsers} *)
+
+val parse_removed_sexp : string -> removed_symbol list Status.status_or
+(** Parse a sexp of the form
+    [(((symbol "ACE") (effective_date "2016-01-11")) ...)]. Returns [Error] on
+    structural malformation. *)
+
+val parse_eodhd_fixture : string -> eodhd_fixture Status.status_or
+(** Parse a JSON object of the form
+    [{"delisted":[{"Code":"LEH",...}, ...], "live":[{"Code":"AAPL",...}, ...]}].
+    Only the [Code] field of each entry is consulted; other fields are ignored
+    so the fixture can be a verbatim slice of EODHD's response. *)
+
+(** {1 Cross-referencer} *)
+
+val cross_reference :
+  removed:removed_symbol list -> eodhd:eodhd_fixture -> row list
+(** Classify each [removed] symbol against [eodhd]. Output is sorted by [symbol]
+    ascending. Pure. *)
+
+(** {1 Report writer} *)
+
+val render_markdown : row list -> string
+(** Render the cross-reference output as a markdown report. The report has a
+    summary line ("Matched: N / Live: M / Not-found: K") followed by a table of
+    [symbol | effective_date | status] sorted by status then symbol. Pure. *)

--- a/trading/analysis/scripts/eodhd_delisted_audit/test/data/eodhd_delisted_fixture.json
+++ b/trading/analysis/scripts/eodhd_delisted_audit/test/data/eodhd_delisted_fixture.json
@@ -1,0 +1,11 @@
+{
+  "delisted": [
+    {"Code": "LEH", "Name": "Lehman Brothers Holdings Inc"},
+    {"Code": "BSC", "Name": "Bear Stearns Companies Inc"}
+  ],
+  "live": [
+    {"Code": "AAPL", "Name": "Apple Inc"},
+    {"Code": "WB",   "Name": "Weibo Corp"},
+    {"Code": "MSFT", "Name": "Microsoft Corp"}
+  ]
+}

--- a/trading/analysis/scripts/eodhd_delisted_audit/test/data/sp500_removed_fixture.sexp
+++ b/trading/analysis/scripts/eodhd_delisted_audit/test/data/sp500_removed_fixture.sexp
@@ -1,0 +1,7 @@
+; Three S&P 500 removal events, each illustrating one of the audit outcomes:
+;   LEH — Lehman Brothers, present in EODHD's delisted feed (matched).
+;   WB  — Wachovia, ticker since reassigned to Weibo Corp (live-on-eodhd).
+;   ACE — ACE Limited, absent from both EODHD lists (not-found).
+(((symbol "LEH") (effective_date "2008-09-22"))
+ ((symbol "WB")  (effective_date "2008-12-22"))
+ ((symbol "ACE") (effective_date "2016-01-11")))

--- a/trading/analysis/scripts/eodhd_delisted_audit/test/dune
+++ b/trading/analysis/scripts/eodhd_delisted_audit/test/dune
@@ -1,0 +1,8 @@
+(test
+ (name test_eodhd_delisted_audit)
+ (libraries core ounit2 matchers status eodhd_delisted_audit_lib)
+ (deps
+  (glob_files ./data/*.json)
+  (glob_files ./data/*.sexp))
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/scripts/eodhd_delisted_audit/test/test_eodhd_delisted_audit.ml
+++ b/trading/analysis/scripts/eodhd_delisted_audit/test/test_eodhd_delisted_audit.ml
@@ -1,0 +1,119 @@
+open Core
+open OUnit2
+open Matchers
+open Eodhd_delisted_audit_lib
+
+let _eodhd_fixture_path = "./data/eodhd_delisted_fixture.json"
+let _removed_fixture_path = "./data/sp500_removed_fixture.sexp"
+
+let _load_eodhd () =
+  match parse_eodhd_fixture (In_channel.read_all _eodhd_fixture_path) with
+  | Ok x -> x
+  | Error err ->
+      assert_failure ("Failed to parse EODHD fixture: " ^ Status.show err)
+
+let _load_removed () =
+  match parse_removed_sexp (In_channel.read_all _removed_fixture_path) with
+  | Ok x -> x
+  | Error err ->
+      assert_failure ("Failed to parse removed-sexp fixture: " ^ Status.show err)
+
+let test_parse_eodhd_fixture _ =
+  assert_that
+    (parse_eodhd_fixture
+       {|{"delisted":[{"Code":"LEH"}],"live":[{"Code":"AAPL"}]}|})
+    (is_ok_and_holds
+       (equal_to ({ delisted = [ "LEH" ]; live = [ "AAPL" ] } : eodhd_fixture)))
+
+let test_parse_eodhd_fixture_rejects_bad_json _ =
+  assert_that (parse_eodhd_fixture "{not json") is_error
+
+let _removed_symbol ~symbol ~effective_date : removed_symbol =
+  { symbol; effective_date }
+
+let _row ~symbol ~effective_date ~status : row =
+  { symbol; effective_date; status }
+
+let test_parse_removed_sexp _ =
+  let expected = _removed_symbol ~symbol:"ACE" ~effective_date:"2016-01-11" in
+  assert_that
+    (parse_removed_sexp {|(((symbol "ACE") (effective_date "2016-01-11")))|})
+    (is_ok_and_holds (elements_are [ equal_to expected ]))
+
+(* Pin the .mli "Returns [Error] on structural malformation" guard. *)
+let test_parse_removed_sexp_rejects_malformed _ =
+  assert_that (parse_removed_sexp "(((not a valid record") is_error
+
+let test_cross_reference_three_statuses _ =
+  let removed = _load_removed () in
+  let eodhd = _load_eodhd () in
+  let expected =
+    [
+      _row ~symbol:"ACE" ~effective_date:"2016-01-11" ~status:Not_found;
+      _row ~symbol:"LEH" ~effective_date:"2008-09-22"
+        ~status:Matched_in_eodhd_delisted;
+      _row ~symbol:"WB" ~effective_date:"2008-12-22" ~status:Live_on_eodhd;
+    ]
+  in
+  assert_that
+    (cross_reference ~removed ~eodhd)
+    (elements_are (List.map expected ~f:equal_to))
+
+let _contains needle =
+  field
+    (fun md -> String.is_substring md ~substring:needle)
+    (equal_to true
+       ~msg:(Printf.sprintf "expected markdown to contain %S" needle))
+
+let test_render_markdown_contains_summary_and_rows _ =
+  let rows =
+    cross_reference ~removed:(_load_removed ()) ~eodhd:(_load_eodhd ())
+  in
+  assert_that (render_markdown rows)
+    (all_of
+       [
+         _contains "Matched: 1 / Live: 1 / Not-found: 1 (total: 3)";
+         _contains "| LEH | 2008-09-22 | matched-in-eodhd-delisted |";
+         _contains "| WB | 2008-12-22 | live-on-eodhd |";
+         _contains "| ACE | 2016-01-11 | not-found |";
+       ])
+
+(* Pin the .mli "table sorted by status then symbol" guarantee — substring
+   checks above pass with arbitrary row order, so without an index assertion
+   the sort contract is unenforced. *)
+let _index_of needle md =
+  String.substr_index md ~pattern:needle |> Option.value ~default:Int.max_value
+
+let _order_msg ~leh ~wb ~ace =
+  Printf.sprintf
+    "expected order matched < live < not-found, got LEH=%d WB=%d ACE=%d" leh wb
+    ace
+
+let test_render_markdown_sort_status_then_symbol _ =
+  let rows =
+    cross_reference ~removed:(_load_removed ()) ~eodhd:(_load_eodhd ())
+  in
+  let md = render_markdown rows in
+  let leh = _index_of "| LEH " md in
+  let wb = _index_of "| WB " md in
+  let ace = _index_of "| ACE " md in
+  let in_order = leh < wb && wb < ace in
+  assert_that in_order (equal_to true ~msg:(_order_msg ~leh ~wb ~ace))
+
+let () =
+  run_test_tt_main
+    ("eodhd_delisted_audit"
+    >::: [
+           "parse_eodhd_fixture" >:: test_parse_eodhd_fixture;
+           "parse_eodhd_fixture_rejects_bad_json"
+           >:: test_parse_eodhd_fixture_rejects_bad_json;
+           "parse_removed_sexp" >:: test_parse_removed_sexp;
+           "parse_removed_sexp_rejects_malformed"
+           >:: test_parse_removed_sexp_rejects_malformed;
+           "cross_reference_three_statuses"
+           >:: test_cross_reference_three_statuses;
+           "render_markdown_contains_summary_and_rows"
+           >:: test_render_markdown_contains_summary_and_rows;
+           "render_markdown_sort_status_then_symbol"
+           >:: test_render_markdown_sort_status_then_symbol;
+         ])


### PR DESCRIPTION
## Summary

Offline half of the EODHD delisted-symbol audit (P5 phase-2). Cross-references a Wiki S&P 500 "removed" event list against a pinned EODHD exchange-symbol-list JSON snapshot, emitting a markdown report that classifies each removed symbol as one of:

- **matched-in-eodhd-delisted** — EODHD knows the symbol delisted (e.g. LEH)
- **live-on-eodhd** — ticker reassigned to a different company (e.g. WB: Wachovia -> Weibo)
- **not-found** — EODHD has no record of the symbol on either side (e.g. ACE)

## What is in this PR

- ``trading/analysis/scripts/eodhd_delisted_audit/lib/`` — pure cross-ref logic + markdown renderer + JSON / sexp parsers
- ``trading/analysis/scripts/eodhd_delisted_audit/eodhd_delisted_audit.ml`` — thin CLI driver
- ``trading/analysis/scripts/eodhd_delisted_audit/test/`` — OUnit2 + Matchers tests against a 3-symbol fixture covering all three statuses

CLI shape:

\`\`\`
eodhd_delisted_audit.exe \\
  --removed-sexp data/sp500_removed.sexp \\
  --eodhd-fixture data/eodhd_delisted_fixture.json \\
  --out reports/eodhd_delisted_audit.md
\`\`\`

## What is deferred

- **Live HTTP fetch.** A ``--fetch-eodhd --token-file <path>`` flag that calls the EODHD ``/api/exchange-symbol-list/US?delisted=1`` endpoint directly (and writes the JSON to the fixture path) is a follow-up. The cross-ref + report-writer surface in this PR is the consumer of whatever produces the fixture, so it can be reviewed independently.
- **Wiring the Wiki ``Changes_parser`` output to the removed-sexp.** This PR takes the removed-symbol list as a hand-authorable sexp; a follow-up exe can pipe ``Wiki_sp500.Changes_parser.parse`` output into the same format so the audit consumes a freshly-parsed Wikipedia snapshot.

Closes the offline half of P5 phase-2.

## Test plan

- [ ] CI green on ``dune build`` + ``dune runtest trading/analysis/scripts/`` + ``dune build @fmt``
- [ ] Manual: ``dune exec trading/analysis/scripts/eodhd_delisted_audit/eodhd_delisted_audit.exe -- --removed-sexp <path> --eodhd-fixture <path> --out /tmp/audit.md`` produces a markdown report with the three-status summary and the per-symbol rows.

## Notes for reviewers

- **Local container is currently unable to build** (docker daemon hit an i/o error during this session due to host disk pressure, before disk had been swept). The code was authored against the existing ``fetch_finviz_sectors`` / ``build_inventory`` exe patterns and should compile cleanly; CI is the gating signal.
- ``[@@deriving sexp_of, equal]`` is used throughout (via ``ppx_jane``) instead of ``show, eq`` to match the ``analysis/scripts/`` convention (see ``universe_filter_lib``).
- ~390 LOC total including fixtures + tests; the lib itself is ~110 LOC.