### PR TITLE
feat(release-report): surface alpha/beta/IR/TE/corr sub-table per scenario

### DIFF
--- a/trading/trading/backtest/release_report/release_report.ml
+++ b/trading/trading/backtest/release_report/release_report.ml
@@ -59,6 +59,15 @@ type all_eligible_summary = {
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]
 
+type benchmark_relative_summary = {
+  alpha_pct_annualized : float;
+  beta : float;
+  information_ratio : float;
+  tracking_error_pct_annualized : float;
+  correlation : float;
+}
+[@@deriving sexp]
+
 type scenario_run = {
   name : string;
   actual : actual;
@@ -68,6 +77,7 @@ type scenario_run = {
   trade_quality : Trade_audit_report.t option;
   optimal_strategy : optimal_summary_pair option;
   all_eligible : all_eligible_summary option;
+  benchmark_relative : benchmark_relative_summary option;
 }
 [@@deriving sexp]
 
@@ -202,6 +212,70 @@ let _try_load_all_eligible_summary ~dir ~scenario_name :
         }
     with _ -> None
 
+(* On-disk metric labels for the five PR #1021 benchmark-relative metrics.
+   [Metric_type.show] derives [Metric_types.Metric_type.t.<Variant>], which
+   [metric_set_to_sexp_pairs] then [String.lowercase]s — yielding e.g.
+   [metric_types.metric_type.t.benchmarkbeta]. We match by suffix (last
+   dot-separated segment) so the loader survives if the producer's module path
+   ever changes. *)
+let _benchmark_relative_labels =
+  [
+    "benchmarkalphapctannualized";
+    "benchmarkbeta";
+    "informationratio";
+    "trackingerrorpctannualized";
+    "correlationtobenchmark";
+  ]
+
+let _metric_key_suffix label =
+  match String.rsplit2 label ~on:'.' with
+  | Some (_, suffix) -> suffix
+  | None -> label
+
+(* Extract the metric key/value alist from a [summary.sexp] sexp. The on-disk
+   shape is [((... fields ...) (metrics ((<label> <value>) ...)))]; we walk the
+   top-level list looking for [(metrics ...)]. Any malformed entry yields an
+   empty alist — the report renders the benchmark-relative section as [None]
+   in that case, which is the same graceful-skip path as a legacy summary. *)
+let _metrics_alist_of_summary_sexp sexp =
+  match sexp with
+  | Sexp.List fields ->
+      let rec find = function
+        | [] -> []
+        | Sexp.List [ Sexp.Atom "metrics"; Sexp.List pairs ] :: _ ->
+            List.filter_map pairs ~f:(function
+              | Sexp.List [ Sexp.Atom k; Sexp.Atom v ] -> (
+                  try Some (_metric_key_suffix k, Float.of_string v)
+                  with _ -> None)
+              | _ -> None)
+        | _ :: rest -> find rest
+      in
+      find fields
+  | _ -> []
+
+let _try_load_benchmark_relative ~summary_sexp :
+    benchmark_relative_summary option =
+  (* Build the suffix-keyed map once, then require all five labels. Missing
+     any single label yields [None] — the report renders the section only
+     when at least one side of a pair has [Some _], so this is the legacy-
+     summary graceful-skip path. *)
+  let alist = _metrics_alist_of_summary_sexp summary_sexp in
+  let has_all =
+    List.for_all _benchmark_relative_labels ~f:(fun lbl ->
+        List.Assoc.mem alist lbl ~equal:String.equal)
+  in
+  if not has_all then None
+  else
+    let get lbl = List.Assoc.find_exn alist lbl ~equal:String.equal in
+    Some
+      {
+        alpha_pct_annualized = get "benchmarkalphapctannualized";
+        beta = get "benchmarkbeta";
+        information_ratio = get "informationratio";
+        tracking_error_pct_annualized = get "trackingerrorpctannualized";
+        correlation = get "correlationtobenchmark";
+      }
+
 let load_scenario_run ~dir =
   let name = Filename.basename dir in
   let actual_path = Filename.concat dir "actual.sexp" in
@@ -211,7 +285,8 @@ let load_scenario_run ~dir =
   if not (Sys_unix.file_exists_exn summary_path) then
     failwithf "Missing summary.sexp in %s" dir ();
   let actual = actual_of_sexp (Sexp.load_sexp actual_path) in
-  let summary = summary_meta_of_sexp (Sexp.load_sexp summary_path) in
+  let summary_sexp = Sexp.load_sexp summary_path in
+  let summary = summary_meta_of_sexp summary_sexp in
   let peak_rss_kb =
     _read_optional_int (Filename.concat dir "peak_rss_kb.txt")
   in
@@ -221,6 +296,7 @@ let load_scenario_run ~dir =
   let trade_quality = _try_load_trade_quality ~dir in
   let optimal_strategy = _try_load_optimal_summary ~dir ~scenario_name:name in
   let all_eligible = _try_load_all_eligible_summary ~dir ~scenario_name:name in
+  let benchmark_relative = _try_load_benchmark_relative ~summary_sexp in
   {
     name;
     actual;
@@ -230,6 +306,7 @@ let load_scenario_run ~dir =
     trade_quality;
     optimal_strategy;
     all_eligible;
+    benchmark_relative;
   }
 
 let _list_scenario_subdirs root =
@@ -828,11 +905,95 @@ let _all_eligible_section paired =
     let body = List.concat_map with_alleli ~f:_row_all_eligible_for_pair in
     header @ body
 
+(* --- Benchmark-relative section ---
+
+   For each paired scenario where at least one side has [Some _]
+   benchmark-relative artefacts (i.e. all five PR #1021 metrics were emitted in
+   [summary.sexp]'s metrics block), surface α, β, IR, TE, and Pearson
+   correlation side-by-side. The five metrics together pin how much of the
+   strategy's return is benchmark-explained vs. residual: a strategy with
+   β ≈ 1, corr ≈ 1, α ≈ 0 is replicating the benchmark; β < 1 with positive
+   α and low correlation indicates a genuinely independent return stream.
+
+   Δ is rendered as (current - prior) in absolute units for β, IR, and corr
+   (which are unitless ratios) and in percentage points (pp) for α and TE
+   (which are already in %/yr). Rendered only when at least one side has
+   [Some _]; missing sides print "—". *)
+
+let _br_field_str (run : scenario_run) ~(fmt : float -> string)
+    ~(get : benchmark_relative_summary -> float) =
+  match run.benchmark_relative with None -> "—" | Some b -> fmt (get b)
+
+let _br_delta_str ~(fmt : float -> string)
+    ~(get : benchmark_relative_summary -> float) cur prior =
+  match (cur.benchmark_relative, prior.benchmark_relative) with
+  | Some c, Some p -> fmt (get c -. get p)
+  | _ -> "—"
+
+let _fmt_signed_3 v = sprintf "%+.3f" v
+let _fmt_signed_pp_2 v = sprintf "%+.2f pp" v
+let _fmt_signed_pct_2 v = sprintf "%+.2f%%" v
+
+let _br_row ~label ~cur_str ~prior_str ~delta_str =
+  sprintf "| %s | %s | %s | %s |" label cur_str prior_str delta_str
+
+let _br_value_row (cur, prior) ~label ~fmt_val ~fmt_delta ~get =
+  _br_row ~label
+    ~cur_str:(_br_field_str cur ~fmt:fmt_val ~get)
+    ~prior_str:(_br_field_str prior ~fmt:fmt_val ~get)
+    ~delta_str:(_br_delta_str ~fmt:fmt_delta ~get cur prior)
+
+let _row_benchmark_relative_for_pair (cur, prior) =
+  [
+    sprintf "### %s" cur.name;
+    "";
+    "| Metric | Current | Prior | \xce\x94 |";
+    "|---|---:|---:|---:|";
+    _br_value_row (cur, prior) ~label:"Alpha (%/yr)" ~fmt_val:_fmt_signed_pct_2
+      ~fmt_delta:_fmt_signed_pp_2 ~get:(fun b -> b.alpha_pct_annualized);
+    _br_value_row (cur, prior) ~label:"Beta" ~fmt_val:_fmt_signed_3
+      ~fmt_delta:_fmt_signed_3 ~get:(fun b -> b.beta);
+    _br_value_row (cur, prior) ~label:"Information ratio" ~fmt_val:_fmt_signed_3
+      ~fmt_delta:_fmt_signed_3 ~get:(fun b -> b.information_ratio);
+    _br_value_row (cur, prior) ~label:"Tracking error (%/yr)"
+      ~fmt_val:_fmt_signed_pct_2 ~fmt_delta:_fmt_signed_pp_2 ~get:(fun b ->
+        b.tracking_error_pct_annualized);
+    _br_value_row (cur, prior) ~label:"Correlation" ~fmt_val:_fmt_signed_3
+      ~fmt_delta:_fmt_signed_3 ~get:(fun b -> b.correlation);
+    "";
+  ]
+
+let _benchmark_relative_section paired =
+  let with_br =
+    List.filter paired ~f:(fun (c, p) ->
+        Option.is_some c.benchmark_relative
+        || Option.is_some p.benchmark_relative)
+  in
+  if List.is_empty with_br then []
+  else
+    let header =
+      [
+        "## Benchmark-relative";
+        "";
+        "CAPM-style residual-return diagnostics from PR #1021: α (annualised \
+         intercept of [r_strat = α + β · r_bench]), β (slope), Information \
+         Ratio (α / TE), Tracking Error (annualised stdev of the active-return \
+         series), and Pearson correlation. Δ is current minus prior — α / TE \
+         in percentage points, β / IR / correlation in absolute units. \
+         Rendered only for scenarios whose [summary.sexp] metrics block \
+         carries all five labels.";
+        "";
+      ]
+    in
+    let body = List.concat_map with_br ~f:_row_benchmark_relative_for_pair in
+    header @ body
+
 let render ?(thresholds = default_thresholds) (t : t) =
   let lines =
     _section_header ~title:"Release perf report" ~current:t.current_label
       ~prior:t.prior_label
     @ _trading_section t.paired
+    @ _benchmark_relative_section t.paired
     @ _trade_quality_section t.paired
     @ _all_eligible_section t.paired
     @ _optimal_strategy_section t.paired

--- a/trading/trading/backtest/release_report/release_report.mli
+++ b/trading/trading/backtest/release_report/release_report.mli
@@ -133,6 +133,31 @@ type all_eligible_summary = {
     producer side (e.g. the [return_buckets] field is intentionally dropped — it
     doesn't render in the comparison report). *)
 
+type benchmark_relative_summary = {
+  alpha_pct_annualized : float;
+      (** Annualized intercept α from [r_strat = α + β · r_bench] regressed over
+          per-step returns, scaled by 252. Mirrors the
+          [BenchmarkAlphaPctAnnualized] metric written into [summary.sexp]. *)
+  beta : float;
+      (** Slope β from the same regression. Mirrors [BenchmarkBeta]. *)
+  information_ratio : float;
+      (** [α / TE] — risk-adjusted active return analogue of Sharpe. Mirrors
+          [InformationRatio]. *)
+  tracking_error_pct_annualized : float;
+      (** Annualized stdev of [r_strat - r_bench] in percent. Mirrors
+          [TrackingErrorPctAnnualized]. *)
+  correlation : float;
+      (** Pearson correlation of strategy and benchmark per-step returns,
+          bounded in [-1, 1]. Mirrors [CorrelationToBenchmark]. *)
+}
+[@@deriving sexp]
+(** The five benchmark-relative metrics emitted by PR #1021 — surfaced in the
+    release report as a per-scenario sub-table beneath the main trading metrics.
+    Loaded from the [(metrics ...)] block of [summary.sexp] by matching the
+    [Metric_type.show]-derived lowercase variant labels (e.g.
+    [metric_types.metric_type.t.benchmarkbeta]). All five must be present to
+    populate this record; missing-any-of-them yields [None] (graceful skip). *)
+
 type scenario_run = {
   name : string;
   actual : actual;
@@ -158,18 +183,27 @@ type scenario_run = {
           [--no-emit-all-eligible]). The report renders an additional
           "All-eligible diagnostic" section for paired scenarios where at least
           one side has [Some _]. *)
+  benchmark_relative : benchmark_relative_summary option;
+      (** Loaded from the [(metrics ...)] block of [summary.sexp] when all five
+          benchmark-relative metric labels are present. [None] for legacy
+          summaries written before PR #1021 (none of the five emitted), or when
+          any of the five is absent. The report renders an additional
+          "Benchmark-relative" sub-table for paired scenarios where at least one
+          side has [Some _]. *)
 }
 [@@deriving sexp]
 (** One scenario's per-run readings — the [actual] block plus optional
     infra-perf measurements, an optional trade-audit summary, an optional
-    optimal-strategy counterfactual summary, and an optional all-eligible
-    diagnostic summary. Both [peak_rss_kb] and [wall_seconds] are [None] when
-    the corresponding sibling files are absent in the batch dir; the report
-    still renders trading metrics in that case. [trade_quality] is [None] when
-    no audit artefacts were found or when the audit was empty (no trades).
-    [optimal_strategy] is [None] when no [optimal_summary.sexp] was emitted.
-    [all_eligible] is [None] when no [all_eligible/grade-C/summary.sexp] was
-    emitted. *)
+    optimal-strategy counterfactual summary, an optional all-eligible diagnostic
+    summary, and an optional benchmark-relative summary. Both [peak_rss_kb] and
+    [wall_seconds] are [None] when the corresponding sibling files are absent in
+    the batch dir; the report still renders trading metrics in that case.
+    [trade_quality] is [None] when no audit artefacts were found or when the
+    audit was empty (no trades). [optimal_strategy] is [None] when no
+    [optimal_summary.sexp] was emitted. [all_eligible] is [None] when no
+    [all_eligible/grade-C/summary.sexp] was emitted. [benchmark_relative] is
+    [None] when [summary.sexp]'s metrics block lacks any of the five
+    benchmark-relative metric labels. *)
 
 type t = {
   current_label : string;

--- a/trading/trading/backtest/test/test_release_perf_report.ml
+++ b/trading/trading/backtest/test/test_release_perf_report.ml
@@ -39,7 +39,8 @@ let _make_summary ?(start_date = Date.of_string "2023-01-02")
 
 let _make_run ?(name = "scenario") ?actual ?summary ?(peak_rss_kb = None)
     ?(wall_seconds = None) ?(trade_quality = None) ?(optimal_strategy = None)
-    ?(all_eligible = None) () : Release_report.scenario_run =
+    ?(all_eligible = None) ?(benchmark_relative = None) () :
+    Release_report.scenario_run =
   let actual = Option.value actual ~default:(_make_actual ()) in
   let summary = Option.value summary ~default:(_make_summary ()) in
   {
@@ -51,6 +52,18 @@ let _make_run ?(name = "scenario") ?actual ?summary ?(peak_rss_kb = None)
     trade_quality;
     optimal_strategy;
     all_eligible;
+    benchmark_relative;
+  }
+
+let _make_benchmark_relative ?(alpha_pct_annualized = 3.42) ?(beta = 0.87)
+    ?(information_ratio = 0.51) ?(tracking_error_pct_annualized = 6.70)
+    ?(correlation = 0.82) () : Release_report.benchmark_relative_summary =
+  {
+    alpha_pct_annualized;
+    beta;
+    information_ratio;
+    tracking_error_pct_annualized;
+    correlation;
   }
 
 let _make_optimal_summary ?(total_round_trips = 50) ?(winners = 25)
@@ -1242,6 +1255,223 @@ let test_load_scenario_run_no_all_eligible_when_sexp_malformed _ =
   let run = Release_report.load_scenario_run ~dir:scenario_dir in
   assert_that run.all_eligible is_none
 
+(* --- Benchmark-relative section ---
+
+   The "Benchmark-relative" sub-table is rendered only when at least one side
+   of a paired scenario carries a [benchmark_relative] record (i.e. all five
+   PR #1021 metrics were emitted in [summary.sexp]'s metrics block). These
+   tests pin the header text + per-metric formatting, exercise the
+   graceful-skip path (no metrics → no section), and verify the loader
+   recognises the on-disk metric labels written by [metric_set_to_sexp_pairs].
+*)
+
+let test_render_omits_benchmark_relative_when_both_none _ =
+  let cur = _make_run ~name:"no-bench" () in
+  let prior = _make_run ~name:"no-bench" () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that
+    (String.is_substring md ~substring:"## Benchmark-relative")
+    (equal_to false)
+
+let test_render_includes_benchmark_relative_when_present _ =
+  let cur =
+    _make_run ~name:"sp500-2019"
+      ~benchmark_relative:
+        (Some
+           (_make_benchmark_relative ~alpha_pct_annualized:3.42 ~beta:0.87
+              ~information_ratio:0.51 ~tracking_error_pct_annualized:6.70
+              ~correlation:0.82 ()))
+      ()
+  in
+  let prior =
+    _make_run ~name:"sp500-2019"
+      ~benchmark_relative:
+        (Some
+           (_make_benchmark_relative ~alpha_pct_annualized:2.00 ~beta:0.80
+              ~information_ratio:0.30 ~tracking_error_pct_annualized:6.00
+              ~correlation:0.75 ()))
+      ()
+  in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur, prior) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         (* Section header pinned *)
+         field
+           (fun s -> String.is_substring s ~substring:"## Benchmark-relative")
+           (equal_to true);
+         (* α row: current = +3.42% (already in %), Δ = +1.42 pp *)
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Alpha (%/yr) | +3.42% | +2.00% | +1.42 pp |")
+           (equal_to true);
+         (* β row: unitless, Δ in absolute units *)
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Beta | +0.870 | +0.800 | +0.070 |")
+           (equal_to true);
+         (* IR row *)
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Information ratio | +0.510 | +0.300 | +0.210 |")
+           (equal_to true);
+         (* TE row: pp units *)
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:
+                 "| Tracking error (%/yr) | +6.70% | +6.00% | +0.70 pp |")
+           (equal_to true);
+         (* Correlation row *)
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:"| Correlation | +0.820 | +0.750 | +0.070 |")
+           (equal_to true);
+       ])
+
+let test_render_benchmark_relative_handles_one_sided _ =
+  (* One scenario has the section, one doesn't — the with-bench side renders;
+     the without-bench side prints "—" for current and "—" for Δ. *)
+  let cur_with =
+    _make_run ~name:"with-bench"
+      ~benchmark_relative:(Some (_make_benchmark_relative ()))
+      ()
+  in
+  let prior_no = _make_run ~name:"with-bench" () in
+  let cur_no = _make_run ~name:"without-bench" () in
+  let prior_no2 = _make_run ~name:"without-bench" () in
+  let comparison : Release_report.t =
+    {
+      current_label = "cur";
+      prior_label = "prior";
+      paired = [ (cur_with, prior_no); (cur_no, prior_no2) ];
+      current_only = [];
+      prior_only = [];
+    }
+  in
+  let md = Release_report.render comparison in
+  assert_that md
+    (all_of
+       [
+         (* Section is rendered (at least one side has data) *)
+         field
+           (fun s -> String.is_substring s ~substring:"## Benchmark-relative")
+           (equal_to true);
+         (* with-bench scenario header present *)
+         field
+           (fun s -> String.is_substring s ~substring:"### with-bench")
+           (equal_to true);
+         (* without-bench scenario is skipped: per-scenario block only emits
+            when at least one of (cur, prior) has [Some _] benchmark_relative.
+            Neither side of without-bench has data, so its ### header should
+            NOT appear in the Benchmark-relative section. We approximate by
+            asserting that without-bench's prior column renders "—" — but
+            since the without-bench row is never emitted, we instead verify
+            the prior-side "—" appears for the with-bench scenario. *)
+         field
+           (fun s ->
+             String.is_substring s
+               ~substring:
+                 "| Alpha (%/yr) | +3.42% | \xe2\x80\x94 | \xe2\x80\x94 |")
+           (equal_to true);
+       ])
+
+let test_load_scenario_run_loads_benchmark_relative_when_all_five_present _ =
+  (* Pins that the loader recognises the [Metric_type.show]-derived lowercase
+     labels written by [metric_set_to_sexp_pairs] — the suffix-match approach
+     means the producer's module path can change without breaking the
+     loader. *)
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_br_" in
+  let scenario_dir = Filename.concat dir "br-present" in
+  Core_unix.mkdir_p scenario_dir;
+  _write_actual_sexp (Filename.concat scenario_dir "actual.sexp");
+  _write_text
+    (Filename.concat scenario_dir "summary.sexp")
+    "((start_date 2023-01-02) (end_date 2023-12-31) (universe_size 1654)\n\
+    \ (n_steps 251) (initial_cash 1000000.00) (final_portfolio_value 1122915.42)\n\
+    \ (n_round_trips 39)\n\
+    \ (metrics ((metric_types.metric_type.t.benchmarkalphapctannualized 3.42)\n\
+    \           (metric_types.metric_type.t.benchmarkbeta 0.87)\n\
+    \           (metric_types.metric_type.t.informationratio 0.51)\n\
+    \           (metric_types.metric_type.t.trackingerrorpctannualized 6.70)\n\
+    \           (metric_types.metric_type.t.correlationtobenchmark 0.82))))\n";
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.benchmark_relative
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (b : Release_report.benchmark_relative_summary) ->
+                b.alpha_pct_annualized)
+              (float_equal 3.42);
+            field
+              (fun (b : Release_report.benchmark_relative_summary) -> b.beta)
+              (float_equal 0.87);
+            field
+              (fun (b : Release_report.benchmark_relative_summary) ->
+                b.information_ratio)
+              (float_equal 0.51);
+            field
+              (fun (b : Release_report.benchmark_relative_summary) ->
+                b.tracking_error_pct_annualized)
+              (float_equal 6.70);
+            field
+              (fun (b : Release_report.benchmark_relative_summary) ->
+                b.correlation)
+              (float_equal 0.82);
+          ]))
+
+let test_load_scenario_run_no_benchmark_relative_when_legacy_summary _ =
+  (* Legacy summary.sexp from before PR #1021 — none of the five labels
+     present. Loader must return [None] for graceful skip. *)
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_br_legacy_" in
+  _make_scenario_dir ~root:dir "legacy" ~with_perf:false;
+  let scenario_dir = Filename.concat dir "legacy" in
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.benchmark_relative is_none
+
+let test_load_scenario_run_no_benchmark_relative_when_any_missing _ =
+  (* Partial summary — only four of the five labels present. Loader must
+     return [None] (graceful skip): the section requires all five so users
+     never see a phantom 0.0 hiding a producer regression. *)
+  let dir = Core_unix.mkdtemp "/tmp/rel_perf_br_partial_" in
+  let scenario_dir = Filename.concat dir "partial" in
+  Core_unix.mkdir_p scenario_dir;
+  _write_actual_sexp (Filename.concat scenario_dir "actual.sexp");
+  _write_text
+    (Filename.concat scenario_dir "summary.sexp")
+    "((start_date 2023-01-02) (end_date 2023-12-31) (universe_size 1654)\n\
+    \ (n_steps 251) (initial_cash 1000000.00) (final_portfolio_value 1122915.42)\n\
+    \ (n_round_trips 39)\n\
+    \ (metrics ((metric_types.metric_type.t.benchmarkalphapctannualized 3.42)\n\
+    \           (metric_types.metric_type.t.benchmarkbeta 0.87)\n\
+    \           (metric_types.metric_type.t.informationratio 0.51)\n\
+    \           (metric_types.metric_type.t.correlationtobenchmark 0.82))))\n";
+  let run = Release_report.load_scenario_run ~dir:scenario_dir in
+  assert_that run.benchmark_relative is_none
+
 let suite =
   "release_perf_report"
   >::: [
@@ -1304,6 +1534,18 @@ let suite =
          >:: test_render_includes_all_eligible_when_present;
          "render all-eligible handles one-sided"
          >:: test_render_all_eligible_handles_one_sided;
+         "render omits benchmark-relative when both none"
+         >:: test_render_omits_benchmark_relative_when_both_none;
+         "render includes benchmark-relative when present"
+         >:: test_render_includes_benchmark_relative_when_present;
+         "render benchmark-relative handles one-sided"
+         >:: test_render_benchmark_relative_handles_one_sided;
+         "load_scenario_run loads benchmark_relative when all five present"
+         >:: test_load_scenario_run_loads_benchmark_relative_when_all_five_present;
+         "load_scenario_run no benchmark_relative when legacy summary"
+         >:: test_load_scenario_run_no_benchmark_relative_when_legacy_summary;
+         "load_scenario_run no benchmark_relative when any missing"
+         >:: test_load_scenario_run_no_benchmark_relative_when_any_missing;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR #1021 (merged 2026-05-10) shipped five benchmark-relative metrics — `alpha_pct_annualized`, `beta`, `information_ratio`, `tracking_error_pct_annualized`, `correlation_to_benchmark` — through `summary.sexp`'s `(metrics ...)` block. The release perf report was rendering trading metrics, peak RSS, wall time, trade quality, all-eligible diagnostics, and optimal-strategy delta, but **not these five**. This PR adds a per-scenario sub-table to surface them.

- `benchmark_relative_summary` record + `benchmark_relative : benchmark_relative_summary option` field added to `scenario_run`.
- Loaded by walking `summary.sexp`'s `(metrics ...)` block and matching by suffix on the `Metric_type.show`-derived lowercase variant labels (e.g. `metric_types.metric_type.t.benchmarkbeta`). Suffix-match means the loader survives if the producer's module path ever shifts.
- All five labels must be present to populate the record; missing any of them yields `None` — graceful skip for legacy `summary.sexp` files written before #1021.
- New `_benchmark_relative_section` renderer mirrors `_optimal_strategy_section` (header + per-scenario block; skipped entirely when no paired scenario carries data).
- Wired into `render` right after the trading-metrics block, before trade quality.

## Sample output

For a paired scenario with current (α=3.42, β=0.87, IR=0.51, TE=6.70, corr=0.82) vs prior (α=2.00, β=0.80, IR=0.30, TE=6.00, corr=0.75):

\`\`\`markdown
## Benchmark-relative

CAPM-style residual-return diagnostics from PR #1021: α (annualised intercept of [r_strat = α + β · r_bench]), β (slope), Information Ratio (α / TE), Tracking Error (annualised stdev of the active-return series), and Pearson correlation. Δ is current minus prior — α / TE in percentage points, β / IR / correlation in absolute units. Rendered only for scenarios whose [summary.sexp] metrics block carries all five labels.

### sp500-2019

| Metric | Current | Prior | Δ |
|---|---:|---:|---:|
| Alpha (%/yr) | +3.42% | +2.00% | +1.42 pp |
| Beta | +0.870 | +0.800 | +0.070 |
| Information ratio | +0.510 | +0.300 | +0.210 |
| Tracking error (%/yr) | +6.70% | +6.00% | +0.70 pp |
| Correlation | +0.820 | +0.750 | +0.070 |
\`\`\`

## Test plan

Six new fixture tests in \`trading/trading/backtest/test/test_release_perf_report.ml\`:

- [x] \`render_omits_benchmark_relative_when_both_none\` — section absent when neither side has data (legacy summary path).
- [x] \`render_includes_benchmark_relative_when_present\` — pins all 5 rows: α (+pp Δ), β (absolute Δ), IR (absolute Δ), TE (+pp Δ), correlation (absolute Δ).
- [x] \`render_benchmark_relative_handles_one_sided\` — one side has data, other prints "—" for current and Δ; section still rendered.
- [x] \`load_scenario_run_loads_benchmark_relative_when_all_five_present\` — on-disk \`summary.sexp\` with all five metric labels parses correctly.
- [x] \`load_scenario_run_no_benchmark_relative_when_legacy_summary\` — pre-#1021 summary returns \`None\`.
- [x] \`load_scenario_run_no_benchmark_relative_when_any_missing\` — partial summary (4/5 labels) returns \`None\` rather than phantom 0.0.

Runs cleanly under \`dune build && dune runtest backtest/\` + \`dune build @fmt\` (38 tests, was 32; +6 added).

## Constraints

- ~250 LOC across .ml/.mli (impl + types) + ~200 LOC tests; under the 500-LOC PR cap.
- No new modules or dune-file edits — single library extension.
- No core-module modifications.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>