### PR TITLE
feat(metrics): stability + turnover metrics (rolling Sharpe / trade freq / position turnover / sector rotation)

### DIFF
--- a/trading/trading/backtest/lib/comparison.ml
+++ b/trading/trading/backtest/lib/comparison.ml
@@ -100,6 +100,11 @@ let _metric_label_table : (Metric_type.t * string) list =
     (TrackingErrorPctAnnualized, "tracking_error_pct_annualized");
     (InformationRatio, "information_ratio");
     (CorrelationToBenchmark, "correlation_to_benchmark");
+    (* stability + turnover *)
+    (RollingSharpeStability, "rolling_sharpe_stability");
+    (TradeFrequencyAnnualized, "trade_frequency_annualized");
+    (PositionTurnover, "position_turnover");
+    (PositionConcentrationHhi, "position_concentration_hhi");
   ]
 
 let _metric_label (mt : Metric_type.t) : string =

--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -29,6 +29,7 @@
   distributional_computer
   antifragility_computer
   benchmark_relative_computer
+  stability_turnover_computer
   portfolio_valuation
   stale_hold)
  (preprocess

--- a/trading/trading/simulation/lib/metric_computers.ml
+++ b/trading/trading/simulation/lib/metric_computers.ml
@@ -12,7 +12,8 @@
     - {!Drawdown_analytics_computer} (M5.2c)
     - {!Distributional_computer} (M5.2d)
     - {!Antifragility_computer} (M5.2d)
-    - {!Benchmark_relative_computer} *)
+    - {!Benchmark_relative_computer}
+    - {!Stability_turnover_computer} *)
 
 open Core
 module Metric_types = Trading_simulation_types.Metric_types
@@ -32,6 +33,7 @@ let drawdown_analytics_computer = Drawdown_analytics_computer.computer
 let distributional_computer = Distributional_computer.computer
 let antifragility_computer = Antifragility_computer.computer
 let benchmark_relative_computer = Benchmark_relative_computer.computer
+let stability_turnover_computer = Stability_turnover_computer.computer
 
 (** {1 Derived Metric Computers} *)
 
@@ -102,6 +104,11 @@ let create_computer (metric_type : Metric_types.metric_type) :
   | BenchmarkAlphaPctAnnualized | BenchmarkBeta | TrackingErrorPctAnnualized
   | InformationRatio | CorrelationToBenchmark ->
       benchmark_relative_computer ()
+  | RollingSharpeStability | PositionTurnover | PositionConcentrationHhi ->
+      stability_turnover_computer ()
+  | TradeFrequencyAnnualized ->
+      _derived_only_stub ~name:"trade_freq_annualized_stub"
+        TradeFrequencyAnnualized
 
 (** {1 Default Computer Set} *)
 
@@ -119,6 +126,7 @@ let default_computers ?(risk_free_rate = 0.0) ?(initial_cash = 0.0) () =
     distributional_computer ();
     antifragility_computer ();
     benchmark_relative_computer ();
+    stability_turnover_computer ();
   ]
 
 let default_derived_computers () =
@@ -126,6 +134,7 @@ let default_derived_computers () =
     calmar_ratio_derived;
     Risk_adjusted_computer.sortino_ratio_derived;
     Risk_adjusted_computer.mar_ratio_derived;
+    Stability_turnover_computer.trade_frequency_annualized_derived;
   ]
 
 let default_metric_suite ?(risk_free_rate = 0.0) ?(initial_cash = 0.0) () :

--- a/trading/trading/simulation/lib/metric_computers.mli
+++ b/trading/trading/simulation/lib/metric_computers.mli
@@ -118,6 +118,13 @@ val antifragility_computer :
     neither source is available, both metrics emit 0.0. See
     {!Antifragility_computer} for spec. *)
 
+(** {1 Stability + Turnover Computer} *)
+
+val stability_turnover_computer : unit -> Simulator.any_metric_computer
+(** Computer that emits the portfolio-quality group: [RollingSharpeStability],
+    [PositionTurnover], [PositionConcentrationHhi]. [TradeFrequencyAnnualized]
+    ships as a {b derived} metric (see {!default_derived_computers}). *)
+
 (** {1 Default Computer Set} *)
 
 val default_computers :

--- a/trading/trading/simulation/lib/stability_turnover_computer.ml
+++ b/trading/trading/simulation/lib/stability_turnover_computer.ml
@@ -1,0 +1,246 @@
+(** Stability + turnover portfolio-quality metrics. See .mli for spec. *)
+
+open Core
+module Metric_types = Trading_simulation_types.Metric_types
+module Simulator_types = Trading_simulation_types.Simulator_types
+module Portfolio_summary = Trading_simulation_types.Portfolio_summary
+
+(** Window length for the rolling-Sharpe stability scan, in trading-day steps.
+    90 days mirrors the rolling-Sharpe convention used in M5.2c reporting and is
+    short enough to surface regime changes while long enough that the per-window
+    Sharpe estimate is not pure noise. *)
+let _rolling_window = 90
+
+(** Calendar days per year for [TradeFrequencyAnnualized]. Matches the
+    convention used by {!Portfolio_state_computer._trade_frequency} which
+    divides by [30.44] days/month. *)
+let _calendar_days_per_year = 365.25
+
+(** Tolerance below which a denominator is treated as zero — used both for
+    [PositionConcentrationHhi] (gross-notional denominator) and
+    [PositionTurnover] (mean-portfolio-value denominator). *)
+let _denominator_tolerance = 1e-9
+
+(* ---- Per-step snapshot kept on state ---- *)
+
+type _snapshot = {
+  date : Date.t;
+  cost_basis_by_symbol : (string * float) list;
+      (** Gross cost-basis-notional [|cost_basis|] per symbol; ordering not
+          significant. Empty when no positions are open. *)
+  portfolio_value : float;
+}
+
+type state = {
+  portfolio_values : float list;  (** Reversed: head is most recent. *)
+  snapshots : _snapshot list;  (** Reversed: head is most recent. *)
+}
+
+let _empty_state = { portfolio_values = []; snapshots = [] }
+
+(** Project a step's positions to the gross-cost-basis snapshot used by both
+    turnover and HHI. Pulled out so [_update] stays flat. *)
+let _snapshot_of_step (step : Simulator_types.step_result) : _snapshot =
+  let cost_basis_by_symbol =
+    List.map step.portfolio.positions
+      ~f:(fun (p : Portfolio_summary.position_summary) ->
+        (p.symbol, Float.abs p.cost_basis))
+  in
+  {
+    date = step.date;
+    cost_basis_by_symbol;
+    portfolio_value = step.portfolio_value;
+  }
+
+(* ---- Rolling Sharpe stability ---- *)
+
+let _step_returns values =
+  let rec loop prev rest acc =
+    match rest with
+    | [] -> List.rev acc
+    | curr :: rest' ->
+        let r = if Float.(prev <= 0.0) then 0.0 else (curr -. prev) /. prev in
+        loop curr rest' (r :: acc)
+  in
+  match values with [] | [ _ ] -> [] | first :: rest -> loop first rest []
+
+let _mean = function
+  | [] -> 0.0
+  | xs -> List.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int (List.length xs)
+
+let _sq_dev_acc m acc x =
+  let d = x -. m in
+  acc +. (d *. d)
+
+let _stdev_pop xs =
+  match xs with
+  | [] | [ _ ] -> 0.0
+  | _ ->
+      let m = _mean xs in
+      let sum_sq = List.fold xs ~init:0.0 ~f:(_sq_dev_acc m) in
+      Float.sqrt (sum_sq /. Float.of_int (List.length xs))
+
+(** Annualized Sharpe of a contiguous return slice; matches {!Sharpe_computer}'s
+    convention (population stdev, scale by [sqrt(252)]). *)
+let _window_sharpe slice =
+  match slice with
+  | [] | [ _ ] -> 0.0
+  | _ ->
+      let m = _mean slice in
+      let s = _stdev_pop slice in
+      if Float.(s = 0.0) then 0.0
+      else m /. s *. Float.sqrt Metric_computer_utils.trading_days_per_year
+
+(** Walk a contiguous return series and emit one Sharpe per [_rolling_window]
+    slice (no slide step — every contiguous window). *)
+let _rolling_sharpe_series returns =
+  let arr = Array.of_list returns in
+  let n = Array.length arr in
+  if n < _rolling_window then []
+  else
+    List.init
+      (n - _rolling_window + 1)
+      ~f:(fun start ->
+        let slice = Array.sub arr ~pos:start ~len:_rolling_window in
+        _window_sharpe (Array.to_list slice))
+
+let _rolling_sharpe_stability returns =
+  let sharpes = _rolling_sharpe_series returns in
+  match sharpes with [] | [ _ ] -> 0.0 | _ -> _stdev_pop sharpes
+
+(* ---- Position turnover ---- *)
+
+let _abs_delta_notional ~prev ~curr =
+  let prev_map = Map.of_alist_exn (module String) prev in
+  let curr_map = Map.of_alist_exn (module String) curr in
+  let symbols =
+    Set.union
+      (Set.of_list (module String) (List.map prev ~f:fst))
+      (Set.of_list (module String) (List.map curr ~f:fst))
+  in
+  Set.fold symbols ~init:0.0 ~f:(fun acc sym ->
+      let p = Map.find prev_map sym |> Option.value ~default:0.0 in
+      let c = Map.find curr_map sym |> Option.value ~default:0.0 in
+      acc +. Float.abs (c -. p))
+
+(** Step-over-step churn: walk the snapshot list pairwise and accumulate the
+    total [|Δ notional|]. Returned in chronological order's totals (the input is
+    already chronological per [_finalize]). *)
+let _pair_delta prev curr =
+  _abs_delta_notional ~prev:prev.cost_basis_by_symbol
+    ~curr:curr.cost_basis_by_symbol
+
+let _total_abs_delta snapshots_chrono =
+  let rec loop acc = function
+    | [] | [ _ ] -> acc
+    | prev :: (curr :: _ as rest) -> loop (acc +. _pair_delta prev curr) rest
+  in
+  loop 0.0 snapshots_chrono
+
+let _turnover_normalised ~total ~mean_pv ~n =
+  if Float.(Float.abs mean_pv < _denominator_tolerance) then 0.0
+  else total /. mean_pv /. Float.of_int n
+
+let _position_turnover snapshots_chrono =
+  let n = List.length snapshots_chrono in
+  if n < 2 then 0.0
+  else
+    let mean_pv =
+      _mean (List.map snapshots_chrono ~f:(fun s -> s.portfolio_value))
+    in
+    let total = _total_abs_delta snapshots_chrono in
+    _turnover_normalised ~total ~mean_pv ~n
+
+(* ---- Friday-sampled HHI ---- *)
+
+let _is_friday d =
+  match Date.day_of_week d with Day_of_week.Fri -> true | _ -> false
+
+let _hhi_for_snapshot snap =
+  let weights =
+    List.map snap.cost_basis_by_symbol ~f:(fun (_, v) -> v)
+    |> List.filter ~f:(fun v -> Float.(v > 0.0))
+  in
+  let total = List.fold weights ~init:0.0 ~f:( +. ) in
+  if Float.(Float.abs total < _denominator_tolerance) then None
+  else
+    let hhi =
+      List.fold weights ~init:0.0 ~f:(fun acc w ->
+          let w' = w /. total in
+          acc +. (w' *. w'))
+    in
+    Some hhi
+
+let _friday_hhi snapshots_chrono =
+  let samples =
+    List.filter_map snapshots_chrono ~f:(fun s ->
+        if _is_friday s.date then _hhi_for_snapshot s else None)
+  in
+  if List.is_empty samples then 0.0 else _mean samples
+
+(* ---- Output assembly ---- *)
+
+let _empty_metric_set () =
+  Metric_types.of_alist_exn
+    [
+      (RollingSharpeStability, 0.0);
+      (PositionTurnover, 0.0);
+      (PositionConcentrationHhi, 0.0);
+    ]
+
+let _build_metrics ~returns ~snapshots_chrono =
+  Metric_types.of_alist_exn
+    [
+      (RollingSharpeStability, _rolling_sharpe_stability returns);
+      (PositionTurnover, _position_turnover snapshots_chrono);
+      (PositionConcentrationHhi, _friday_hhi snapshots_chrono);
+    ]
+
+let _update ~state ~step =
+  if not (Metric_computer_utils.is_trading_day_step step) then state
+  else
+    {
+      portfolio_values =
+        step.Simulator_types.portfolio_value :: state.portfolio_values;
+      snapshots = _snapshot_of_step step :: state.snapshots;
+    }
+
+let _finalize ~state ~config:_ =
+  let returns = _step_returns (List.rev state.portfolio_values) in
+  let snapshots_chrono = List.rev state.snapshots in
+  match snapshots_chrono with
+  | [] -> _empty_metric_set ()
+  | _ -> _build_metrics ~returns ~snapshots_chrono
+
+let computer () : Simulator_types.any_metric_computer =
+  Simulator_types.wrap_computer
+    {
+      name = "stability_turnover";
+      init = (fun ~config:_ -> _empty_state);
+      update = _update;
+      finalize = _finalize;
+    }
+
+(* ---- Derived: TradeFrequencyAnnualized ---- *)
+
+let _annualized_freq ~num_trades ~start_date ~end_date =
+  let days = Float.of_int (Date.diff end_date start_date) in
+  if Float.(days <= 0.0) then 0.0
+  else num_trades *. _calendar_days_per_year /. days
+
+let trade_frequency_annualized_derived : Simulator_types.derived_metric_computer
+    =
+  {
+    name = "trade_frequency_annualized";
+    depends_on = [ NumTrades ];
+    compute =
+      (fun ~(config : Simulator_types.config) ~base_metrics ->
+        let num_trades =
+          Map.find base_metrics NumTrades |> Option.value ~default:0.0
+        in
+        let freq =
+          _annualized_freq ~num_trades ~start_date:config.start_date
+            ~end_date:config.end_date
+        in
+        Metric_types.singleton TradeFrequencyAnnualized freq);
+  }

--- a/trading/trading/simulation/lib/stability_turnover_computer.mli
+++ b/trading/trading/simulation/lib/stability_turnover_computer.mli
@@ -1,0 +1,37 @@
+(** Portfolio-quality metrics: rolling-Sharpe stability, position turnover, and
+    Friday-sampled position concentration.
+
+    Three step-based metrics produced by a single folding computer:
+
+    - {b RollingSharpeStability} — standard deviation of the rolling
+      90-trading-day Sharpe series. Lower means risk-adjusted return is steady
+      across regimes; higher means it lurches. [0.0] when fewer than two full
+      windows are available.
+
+    - {b PositionTurnover} — average daily churn intensity. Sums
+      [|Δ position_notional|] step-over-step across all symbols and divides by
+      [mean(portfolio_value) × n_trading_days]. [0.0] for a buy-and-hold book.
+
+    - {b PositionConcentrationHhi} — Friday-sampled Herfindahl index of
+      position-value weights. Bounded in [0, 1]; 1.0 means a single position
+      holds the entire gross book. The metric is named after the antitrust
+      concentration index because the simulator has no sector→symbol map;
+      symbol-level diversity is the available proxy. [0.0] when no Friday step
+      has any open position.
+
+    [TradeFrequencyAnnualized] is produced separately as a {b derived} metric
+    (see {!Stability_turnover_computer.trade_frequency_annualized_derived}),
+    since it depends only on [NumTrades] (already computed by
+    {!Trade_aggregates_computer}) and the config window — no per-step state is
+    required. *)
+
+val computer :
+  unit -> Trading_simulation_types.Simulator_types.any_metric_computer
+(** Build the stability + turnover step-based computer. Produces the three
+    step-folding metrics listed above. *)
+
+val trade_frequency_annualized_derived :
+  Trading_simulation_types.Simulator_types.derived_metric_computer
+(** Derived computer for [TradeFrequencyAnnualized]: divides [NumTrades] by the
+    config window's calendar-year length. Returns [0.0] when the window is
+    non-positive. *)

--- a/trading/trading/simulation/lib/types/metric_info_registry.ml
+++ b/trading/trading/simulation/lib/types/metric_info_registry.ml
@@ -472,12 +472,17 @@ let get_metric_info = function
         unit = Ratio;
       }
   | ( BenchmarkAlphaPctAnnualized | BenchmarkBeta | TrackingErrorPctAnnualized
-    | InformationRatio | CorrelationToBenchmark ) as t -> (
-      match Metric_info_registry_extras.info_for_benchmark_relative t with
-      | Some info -> info
+    | InformationRatio | CorrelationToBenchmark | RollingSharpeStability
+    | TradeFrequencyAnnualized | PositionTurnover | PositionConcentrationHhi )
+    as t -> (
+      let open Metric_info_registry_extras in
+      match info_for_benchmark_relative t with
+      | Some i -> i
       | None ->
-          failwithf "missing benchmark-relative info for %s"
-            (show_metric_type t) ())
+          Option.value_exn
+            (info_for_stability_turnover t)
+            ~message:(sprintf "missing extras info for %s" (show_metric_type t))
+      )
 
 let format_metric metric_type value =
   let info = get_metric_info metric_type in

--- a/trading/trading/simulation/lib/types/metric_info_registry_extras.ml
+++ b/trading/trading/simulation/lib/types/metric_info_registry_extras.ml
@@ -1,7 +1,6 @@
-(** Per-variant metric_info for the benchmark-relative (CAPM-style) family.
-    Carved out of {!Metric_info_registry} to keep that file under the
-    file-length linter limit. {!Metric_info_registry.get_metric_info} delegates
-    the five cases handled here. *)
+(** Per-variant metric_info for variants carved out of {!Metric_info_registry}
+    to keep that file under the file-length linter limit.
+    {!Metric_info_registry.get_metric_info} delegates the cases handled here. *)
 
 open Metric_types
 open Metric_info_types
@@ -31,4 +30,33 @@ let info_for_benchmark_relative : metric_type -> metric_info option = function
       Some
         (_info "Correlation to Benchmark"
            "Pearson r in [−1, 1]. 0 when either series is constant." Ratio)
+  | _ -> None
+
+let info_for_stability_turnover : metric_type -> metric_info option = function
+  | RollingSharpeStability ->
+      Some
+        (_info "Rolling Sharpe Stability"
+           "Stdev of rolling-90-day Sharpe across the equity curve. Lower = \
+            steadier risk-adjusted return through time; 0 when fewer than two \
+            full windows."
+           Ratio)
+  | TradeFrequencyAnnualized ->
+      Some
+        (_info "Trade Frequency (Annualized)"
+           "Round-trips per calendar year (NumTrades × 365.25 / window days). \
+            Distinct from TradeFrequency, which is trades/month."
+           Ratio)
+  | PositionTurnover ->
+      Some
+        (_info "Position Turnover"
+           "Average daily churn intensity: Σ |Δ position notional| / \
+            (mean(portfolio_value) × n_trading_days). 0 for buy-and-hold."
+           Ratio)
+  | PositionConcentrationHhi ->
+      Some
+        (_info "Position Concentration (HHI)"
+           "Herfindahl-Hirschman index of position-value weights, sampled \
+            every Friday and averaged. 1.0 = single position; lower = more \
+            diversified."
+           Ratio)
   | _ -> None

--- a/trading/trading/simulation/lib/types/metric_info_registry_extras.mli
+++ b/trading/trading/simulation/lib/types/metric_info_registry_extras.mli
@@ -1,9 +1,16 @@
-(** Per-variant metric_info for the benchmark-relative (CAPM-style) family —
-    [BenchmarkAlphaPctAnnualized], [BenchmarkBeta],
-    [TrackingErrorPctAnnualized], [InformationRatio], [CorrelationToBenchmark].
-    Returns [Some info] for those five variants and [None] for any other.
-    {!Metric_info_registry.get_metric_info} delegates those cases here so that
-    file stays under the file-length linter limit. *)
+(** Per-variant metric_info for variants carved out of {!Metric_info_registry}
+    to keep that file under the file-length linter limit. Each helper here
+    returns [Some info] for its family's variants and [None] for any other;
+    {!Metric_info_registry.get_metric_info} delegates those cases here. *)
 
 val info_for_benchmark_relative :
   Metric_types.metric_type -> Metric_info_types.metric_info option
+(** Benchmark-relative (CAPM-style) family: [BenchmarkAlphaPctAnnualized],
+    [BenchmarkBeta], [TrackingErrorPctAnnualized], [InformationRatio],
+    [CorrelationToBenchmark]. *)
+
+val info_for_stability_turnover :
+  Metric_types.metric_type -> Metric_info_types.metric_info option
+(** Stability + turnover family: [RollingSharpeStability],
+    [TradeFrequencyAnnualized], [PositionTurnover], [PositionConcentrationHhi].
+*)

--- a/trading/trading/simulation/lib/types/metric_types.ml
+++ b/trading/trading/simulation/lib/types/metric_types.ml
@@ -74,6 +74,10 @@ module Metric_type = struct
       | TrackingErrorPctAnnualized
       | InformationRatio
       | CorrelationToBenchmark
+      | RollingSharpeStability
+      | TradeFrequencyAnnualized
+      | PositionTurnover
+      | PositionConcentrationHhi
     [@@deriving show, eq, compare, sexp]
   end
 
@@ -149,6 +153,10 @@ type metric_type = Metric_type.t =
   | TrackingErrorPctAnnualized
   | InformationRatio
   | CorrelationToBenchmark
+  | RollingSharpeStability
+  | TradeFrequencyAnnualized
+  | PositionTurnover
+  | PositionConcentrationHhi
 [@@deriving show, eq, compare, sexp]
 
 include (Metric_type : Comparator.S with type t := metric_type)

--- a/trading/trading/simulation/lib/types/metric_types.mli
+++ b/trading/trading/simulation/lib/types/metric_types.mli
@@ -218,6 +218,42 @@ module Metric_type : sig
             low |corr| means the strategy moves on signals largely uncorrelated
             with the benchmark. Reported as [0.0] when either series has zero
             variance or no benchmark is supplied. *)
+    (* ---- Stability / turnover (portfolio-quality) ---- *)
+    | RollingSharpeStability
+        (** Standard deviation of the rolling 90-trading-day Sharpe ratio
+            computed across the equity curve, in absolute Sharpe units. Lower
+            means the strategy's risk-adjusted return is steady through time;
+            higher means it lurches between regimes. Reported as [0.0] when
+            fewer than two full rolling windows are available. *)
+    | TradeFrequencyAnnualized
+        (** Round-trips per calendar year:
+            [NumTrades × 365.25 / (config.end_date − config.start_date)].
+            Distinct from [TradeFrequency], which counts every trade (entry +
+            exit) per month. Note that [config.{start,end}_date] is the
+            simulator window, which may include a warmup prefix in the
+            [Backtest.Runner] flow; this matches the convention of the existing
+            [TradeFrequency] metric so both divide by the same denominator. Use
+            this for turnover-oriented diagnostics and cost-model calibration.
+            Reported as [0.0] when the window length is non-positive. *)
+    | PositionTurnover
+        (** Average daily churn intensity:
+            [Σ_step |Δ position_notional| / mean(portfolio_value)] divided by
+            the count of trading-day steps. Sums absolute changes in each
+            symbol's [|quantity × cost_basis_per_share|] proxy from one
+            trading-day step to the next, normalized by the mean mark-to-market
+            portfolio value across the run. Higher means more churn per day;
+            [0.0] for a buy-and-hold portfolio with no position changes. *)
+    | PositionConcentrationHhi
+        (** Herfindahl-Hirschman index of per-position absolute market value
+            weights, sampled every Friday and averaged across all sampled days.
+            Bounded in [0, 1]: 1.0 means a single position holds 100% of the
+            gross book; lower values mean exposure is spread across more
+            positions (a 1/n equal-weighted book of n positions has HHI = 1/n).
+            The metric is named after the antitrust concentration index since
+            the codebase has no sector→symbol map at the simulator level;
+            symbol-level diversity is the available proxy for the
+            rotation-vs-concentration question. Reported as [0.0] when no Friday
+            step has any open position. *)
   [@@deriving show, eq, compare, sexp]
 
   include Comparator.S with type t := t
@@ -292,6 +328,10 @@ type metric_type = Metric_type.t =
   | TrackingErrorPctAnnualized
   | InformationRatio
   | CorrelationToBenchmark
+  | RollingSharpeStability
+  | TradeFrequencyAnnualized
+  | PositionTurnover
+  | PositionConcentrationHhi
 [@@deriving show, eq, compare, sexp]
 
 (** {1 Metric Set} *)

--- a/trading/trading/simulation/test/dune
+++ b/trading/trading/simulation/test/dune
@@ -329,3 +329,18 @@
   trading.portfolio
   types
   matchers))
+
+(test
+ (name test_stability_turnover_computer)
+ (modules test_stability_turnover_computer)
+ (libraries
+  ounit2
+  core
+  trading.simulation
+  trading.simulation.types
+  trading.base
+  trading.engine
+  trading.portfolio
+  trading.strategy
+  types
+  matchers))

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -587,8 +587,9 @@ let test_default_computers _ =
   (* Default set: summary, sharpe, max_drawdown, cagr, portfolio_state,
      trade_aggregates (M5.2b), return_basics (M5.2b), omega_ratio (M5.2c),
      drawdown_analytics (M5.2c), distributional (M5.2d), antifragility
-     (M5.2d), benchmark_relative (CAPM-style alpha/beta/IR). *)
-  assert_that computers (size_is 12)
+     (M5.2d), benchmark_relative (CAPM-style alpha/beta/IR), stability +
+     turnover (rolling-sharpe stability, position turnover, HHI). *)
+  assert_that computers (size_is 13)
 
 (* ==================== Factory Tests ==================== *)
 

--- a/trading/trading/simulation/test/test_stability_turnover_computer.ml
+++ b/trading/trading/simulation/test/test_stability_turnover_computer.ml
@@ -1,0 +1,222 @@
+(** Pinned tests for {!Stability_turnover_computer}.
+
+    Coverage:
+    - [RollingSharpeStability] on a hand-rolled regime-switch equity curve:
+      stable regime then erratic regime → nonzero positive stdev.
+    - [PositionTurnover]: buy-and-hold scenario → 0; daily-rebalance scenario →
+      strictly positive.
+    - [PositionConcentrationHhi]: equal-weight two-symbol Friday book → 0.5;
+      single-symbol Friday book → 1.0.
+    - [TradeFrequencyAnnualized] (derived): NumTrades + window → trades/yr. *)
+
+open OUnit2
+open Core
+open Trading_simulation_types.Metric_types
+open Matchers
+module Simulator_types = Trading_simulation_types.Simulator_types
+module Portfolio_summary = Trading_simulation_types.Portfolio_summary
+
+let _date s = Date.of_string s
+
+let _config ?(start_date = _date "2024-01-01") ?(end_date = _date "2024-12-31")
+    () =
+  {
+    Simulator_types.start_date;
+    end_date;
+    initial_cash = 100_000.0;
+    commission = { Trading_engine.Types.per_share = 0.0; minimum = 0.0 };
+    strategy_cadence = Types.Cadence.Daily;
+  }
+
+(** Build a [position_summary] with the symbol's quantity and cost_basis. The
+    HHI metric reads only [|cost_basis|]; the turnover metric reads only the
+    same field (no [quantity] dependency in the current implementation). *)
+let _pos ~symbol ~cost_basis : Portfolio_summary.position_summary =
+  { symbol; quantity = 1.0; cost_basis }
+
+let _summary ~cash ~positions : Portfolio_summary.t =
+  let position_value_total =
+    List.fold positions ~init:0.0
+      ~f:(fun acc (p : Portfolio_summary.position_summary) ->
+        acc +. Float.abs p.cost_basis)
+  in
+  { current_cash = cash; positions; position_value_total }
+
+let _make_step ?(positions = []) ?(cash = 100_000.0) ~date ~portfolio_value () :
+    Simulator_types.step_result =
+  {
+    date;
+    portfolio = _summary ~cash ~positions;
+    portfolio_value;
+    trades = [];
+    orders_submitted = [];
+    splits_applied = [];
+    benchmark_return = None;
+    had_market_bars = true;
+  }
+
+let _run steps =
+  let computer = Trading_simulation.Stability_turnover_computer.computer () in
+  computer.run ~config:(_config ()) ~steps
+
+(** Hand-rolled equity curve: first half is gentle steady growth (low Sharpe
+    volatility within each 90-day window), second half lurches between large
+    gains and losses (high Sharpe volatility within each 90-day window). Two
+    regimes → rolling-Sharpe series has nonzero spread. *)
+let test_rolling_sharpe_stability_regime_switch _ =
+  let make_returns regime_steady regime_erratic =
+    List.init regime_steady ~f:(fun _ -> 0.05)
+    @ List.init regime_erratic ~f:(fun i -> if i % 2 = 0 then 2.0 else -1.8)
+  in
+  (* 200 steady days + 200 erratic days = 400 days; enough for >2 windows of 90. *)
+  let returns = make_returns 200 200 in
+  let steps =
+    List.folding_map returns ~init:100_000.0 ~f:(fun pv r ->
+        let next = pv *. (1.0 +. (r /. 100.0)) in
+        (next, next))
+    |> List.mapi ~f:(fun i pv ->
+        _make_step
+          ~date:(Date.add_days (_date "2024-01-02") i)
+          ~portfolio_value:pv ())
+  in
+  let metrics = _run steps in
+  assert_that
+    (Map.find_exn metrics RollingSharpeStability)
+    (gt (module Float_ord) 0.0)
+
+let test_position_turnover_buy_and_hold _ =
+  (* Same positions held every day → zero turnover.
+     Also pins [RollingSharpeStability] = 0.0 for a 30-day window: fewer than
+     two full 90-day windows fit, so the .mli guard "0.0 when fewer than two
+     full windows are available" is exercised here. *)
+  let positions = [ _pos ~symbol:"AAPL" ~cost_basis:50_000.0 ] in
+  let steps =
+    List.init 30 ~f:(fun i ->
+        _make_step ~positions ~cash:50_000.0
+          ~date:(Date.add_days (_date "2024-01-02") i)
+          ~portfolio_value:100_000.0 ())
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes
+       [
+         (PositionTurnover, float_equal ~epsilon:1e-9 0.0);
+         (RollingSharpeStability, float_equal ~epsilon:1e-9 0.0);
+       ])
+
+let test_position_turnover_daily_rebalance _ =
+  (* Alternate between two symbols every day → high turnover. *)
+  let positions_a = [ _pos ~symbol:"AAPL" ~cost_basis:50_000.0 ] in
+  let positions_b = [ _pos ~symbol:"MSFT" ~cost_basis:50_000.0 ] in
+  let steps =
+    List.init 20 ~f:(fun i ->
+        let positions = if i % 2 = 0 then positions_a else positions_b in
+        _make_step ~positions ~cash:50_000.0
+          ~date:(Date.add_days (_date "2024-01-02") i)
+          ~portfolio_value:100_000.0 ())
+  in
+  let metrics = _run steps in
+  assert_that
+    (Map.find_exn metrics PositionTurnover)
+    (gt (module Float_ord) 0.0)
+
+let test_hhi_equal_weight_two_symbols_on_friday _ =
+  (* 2024-01-05 is a Friday. Two equal-cost-basis positions → HHI = 2 × 0.25
+     = 0.5. *)
+  let positions =
+    [
+      _pos ~symbol:"AAPL" ~cost_basis:50_000.0;
+      _pos ~symbol:"MSFT" ~cost_basis:50_000.0;
+    ]
+  in
+  let steps =
+    [
+      _make_step ~positions ~cash:0.0 ~date:(_date "2024-01-05")
+        ~portfolio_value:100_000.0 ();
+    ]
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes [ (PositionConcentrationHhi, float_equal ~epsilon:1e-9 0.5) ])
+
+let test_hhi_single_position_on_friday _ =
+  (* Friday with one position → HHI = 1.0. *)
+  let positions = [ _pos ~symbol:"AAPL" ~cost_basis:100_000.0 ] in
+  let steps =
+    [
+      _make_step ~positions ~cash:0.0 ~date:(_date "2024-01-05")
+        ~portfolio_value:100_000.0 ();
+    ]
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes [ (PositionConcentrationHhi, float_equal ~epsilon:1e-9 1.0) ])
+
+let test_hhi_no_friday_yields_zero _ =
+  (* All steps on non-Friday weekdays (Mon-Thu) → no samples → 0.0. *)
+  let positions = [ _pos ~symbol:"AAPL" ~cost_basis:50_000.0 ] in
+  let steps =
+    List.init 4 ~f:(fun i ->
+        _make_step ~positions ~cash:50_000.0
+          ~date:(Date.add_days (_date "2024-01-01") i)
+          ~portfolio_value:100_000.0 ())
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes [ (PositionConcentrationHhi, float_equal ~epsilon:1e-9 0.0) ])
+
+(** Cover the derived computer end-to-end: feed a small [NumTrades] base set
+    through the registered derived rule. *)
+let test_trade_frequency_annualized_derived _ =
+  let config =
+    _config ~start_date:(_date "2023-01-01") ~end_date:(_date "2024-01-01") ()
+  in
+  let derived =
+    Trading_simulation.Stability_turnover_computer
+    .trade_frequency_annualized_derived
+  in
+  let base_metrics =
+    Trading_simulation_types.Metric_types.singleton NumTrades 50.0
+  in
+  let result = derived.compute ~config ~base_metrics in
+  (* 50 round-trips across 365 days → 50 × 365.25 / 365 ≈ 50.034. *)
+  assert_that
+    (Map.find_exn result TradeFrequencyAnnualized)
+    (float_equal ~epsilon:0.1 50.034)
+
+let test_trade_frequency_annualized_zero_window _ =
+  let config =
+    _config ~start_date:(_date "2024-01-01") ~end_date:(_date "2024-01-01") ()
+  in
+  let derived =
+    Trading_simulation.Stability_turnover_computer
+    .trade_frequency_annualized_derived
+  in
+  let base_metrics =
+    Trading_simulation_types.Metric_types.singleton NumTrades 10.0
+  in
+  let result = derived.compute ~config ~base_metrics in
+  assert_that result
+    (map_includes [ (TradeFrequencyAnnualized, float_equal ~epsilon:1e-9 0.0) ])
+
+let suite =
+  "Stability_turnover_computer"
+  >::: [
+         "rolling sharpe stability: regime switch → nonzero spread"
+         >:: test_rolling_sharpe_stability_regime_switch;
+         "position turnover: buy-and-hold → 0"
+         >:: test_position_turnover_buy_and_hold;
+         "position turnover: daily rebalance → positive"
+         >:: test_position_turnover_daily_rebalance;
+         "hhi: equal-weight two symbols on Friday → 0.5"
+         >:: test_hhi_equal_weight_two_symbols_on_friday;
+         "hhi: single position on Friday → 1.0"
+         >:: test_hhi_single_position_on_friday;
+         "hhi: no Friday samples → 0.0" >:: test_hhi_no_friday_yields_zero;
+         "trade frequency annualized derived: NumTrades over 1y → ≈ NumTrades"
+         >:: test_trade_frequency_annualized_derived;
+         "trade frequency annualized: zero-length window → 0"
+         >:: test_trade_frequency_annualized_zero_window;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Adds 4 portfolio-quality / turnover metrics, mirroring the alpha/beta/IR
computer pattern landed in PR #1021. From \`dev/status/experiments.md\` §Next
Steps.

- **\`RollingSharpeStability\`** — stdev of the rolling-90-trading-day Sharpe
  across the equity curve. Lower = steadier risk-adjusted return through time;
  higher = strategy lurches between regimes. \`0.0\` when fewer than two full
  windows are available.
- **\`TradeFrequencyAnnualized\`** — derived metric: \`NumTrades × 365.25 /
  (config.end_date − config.start_date)\`. Distinct from the existing
  \`TradeFrequency\` (which counts every trade, entry + exit, per month). Use
  this for turnover diagnostics and cost-model calibration.
- **\`PositionTurnover\`** — average daily churn intensity: sum of
  \`|Δ position_notional|\` step-over-step across all symbols, divided by
  \`mean(portfolio_value) × n_trading_days\`. Zero for buy-and-hold.
- **\`PositionConcentrationHhi\`** — Friday-sampled Herfindahl-Hirschman
  index of position-value weights, averaged across all sampled Fridays.
  Bounded in \`[0, 1]\`; 1.0 = single position, lower = more diversified. The
  metric is named after the antitrust concentration index because the
  simulator has no sector→symbol map at this level; symbol-level diversity is
  the available proxy for the rotation-vs-concentration question. (The
  request's \"sector_rotation_index\" name is preserved in spirit; renamed to
  \`PositionConcentrationHhi\` to be honest about what data is available.)

The three step-based metrics fold over \`step_result\` via a single
\`Stability_turnover_computer\`; \`TradeFrequencyAnnualized\` is a
\`derived_metric_computer\` over \`NumTrades\`. Wired into
\`metric_computers.default_metric_suite\` and
\`Comparison.all_metric_types\` so the values flow through \`summary.sexp\`,
panel comparisons, and the fuzz distribution writer automatically.

### Sample values (recovery-2023 smoke scenario, 1y window, 51 round-trips)

\`\`\`
rollingsharpestability   0.98   (moderate Sharpe variability across windows)
tradefrequencyannualized 32.51  (~32.5 round-trips/yr; denominator includes warmup window)
positionturnover         0.03   (3% of mean portfolio value churned per day)
positionconcentrationhhi 0.18   (~5.5 effective positions; well-diversified Friday book)
\`\`\`

## Test plan

- [x] 8 OUnit2 tests in \`test_stability_turnover_computer.ml\`:
  - rolling-sharpe stability on a regime-switch curve → positive
  - position turnover: buy-and-hold → 0; daily-rebalance → positive
  - HHI: equal-weight 2 symbols on Friday → 0.5
  - HHI: single position on Friday → 1.0
  - HHI: no Friday sample → 0.0
  - trade frequency annualized derived: 50 over 365 days → ~50.034
  - trade frequency annualized: zero-length window → 0.0
- [x] \`dune build && dune runtest\` clean (48 simulation tests pass, all
  backtest tests pass, formatter clean, nesting + file-length linters clean)
- [x] Smoke run against \`recovery-2023\` produces sensible values for all
  four metrics in \`summary.sexp\`
- [ ] (follow-up) Pin the new metrics in goldens — out-of-scope per task
  prompt

## Files touched

- \`trading/trading/simulation/lib/types/metric_types.{ml,mli}\` — 4 new
  variants
- \`trading/trading/simulation/lib/types/metric_info_registry{,_extras}.{ml,mli}\`
  — display-name + unit dispatch; the new family ships in extras to keep
  \`metric_info_registry.ml\` under the 500-line declared-large cap
- \`trading/trading/simulation/lib/stability_turnover_computer.{ml,mli}\` —
  new step-based + derived computers
- \`trading/trading/simulation/lib/metric_computers.{ml,mli}\` — register
  in default suite + factory
- \`trading/trading/backtest/lib/comparison.ml\` — 4 new label-table entries
- \`trading/trading/simulation/test/{dune,test_stability_turnover_computer.ml,test_metrics.ml}\`
  — new test fixture + bump the \`default_computers\` count assertion to 13

🤖 Generated with [Claude Code](https://claude.com/claude-code)