### PR TITLE
feat(data): Daily_price.active_through field — survivorship-aware backtest foundation

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -3,7 +3,7 @@
 ## Last updated: 2026-05-13
 
 ## Status
-IN_PROGRESS
+READY_FOR_REVIEW
 
 ## Notes
 M5.3 streaming Phases A + A.1 + B + C + D + E + F.1 all merged (#779/#786/#781/#782/#790/#791/#793); Phase B writer perf fix O(N²)→O(N) merged (#792). **F.2 default-flip COMPLETE 2026-05-03** (#797/#800/#802 — snapshot mode is now the canonical runtime path). **Wiki+EODHD PR-A/B/C/D MERGED** (#803/#808/#809/#813). **F.3.a sub-sequence COMPLETE 2026-05-04** (#825/#827/#828/#829). **F.3.b–F.3.e ALL MERGED 2026-05-04..06** (#833 b-1, #837 c-1, #842 d-1, #861/#864 #848 forward fix, #866 b-2/c-2/d-2 caller migration, #868/#869 e-1/e-2 type relocation + `Bar_reader.of_panels` deletion, #875/#876/#877 e-3 stack — `Bar_panels.{ml,mli}` DELETED; sp500-2019-2023 baseline bit-equal 58.34%/81 across the stack). **M5.3 streaming Phase F COMPLETE.**
@@ -179,9 +179,44 @@ fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
 
   Combined with simulator-side #1024 (Closed-positions prune), 15y wall dropped 5h → 13.6 min (~22×). See `dev/status/backtest-perf.md` for the simulator-side share.
 
+### In Progress / READY_FOR_REVIEW
+
+- **[x] Phase 3 — `Daily_price.active_through` field**
+  (`dev/notes/historical-universe-status-2026-05-13.md` §2 action item 1;
+  original 2026-04-30 design phase 3).
+  - Adds `active_through : Date.t option` to `Types.Daily_price.t`
+    (`trading/analysis/data/types/lib/daily_price.{ml,mli}`) — typed
+    delisted-date marker; default `None` = "still trading / unknown".
+  - CSV round-trip (`trading/analysis/data/storage/csv/lib/{parser,csv_storage}.ml`):
+    reader accepts both 7-column (legacy → `None`) and 8-column input;
+    writer always emits the new column, empty cell when `None`.
+  - EODHD `/api/eod` parser leaves `active_through = None` (the bar
+    response carries no delisting marker — separate enrichment pass
+    would attach it).
+  - `Snapshot_bar_views` daily-price assembly preserves the field
+    (snapshot has no delisting source today → `None`).
+  - Mechanical update of 127 `Types.Daily_price.t` record literals
+    across 74 files (test helpers + builders) to thread
+    `active_through = None`.
+  - Tests: 4 new unit tests in `analysis/data/types/test/test_daily_price.ml`
+    (helper defaults to `None`, threads explicit dates, equality
+    respects the field); 5 new round-trip tests in
+    `analysis/data/storage/csv/test/` (both schemas + populated /
+    unpopulated active_through). `dune runtest analysis/data/`,
+    `dune runtest trading/backtest/`, `dune runtest analysis/weinstein/`,
+    `dune runtest trading/weinstein/` all green — no golden drift.
+  - A1 (qc-structural): touches a base type, will FLAG. Mitigation:
+    change is strategy-agnostic broker-data-side; default `None` keeps
+    every existing CSV / fixture loading unchanged → goldens bit-equal.
+  - Natural follow-on: **Phase 5 — screener point-in-time filter**
+    (`membership_at` callback in `Screener.screen` keyed on
+    `active_through`). Highest-leverage gain once this lands.
+
 ### Pending
 
 - **Norgate ingest** (vendor-blocked; user must sign up).
+- **Phase 5 — screener point-in-time filter** (next natural step;
+  ~250–400 LOC per design note §4).
 
 ### Detail (kept for reference; all entries below are MERGED on main)
 

--- a/trading/analysis/data/sources/eodhd/lib/http_client.ml
+++ b/trading/analysis/data/sources/eodhd/lib/http_client.ml
@@ -141,6 +141,11 @@ let _parse_price_fields fields =
   let%bind adjusted_close =
     _find_field fields "adjusted_close" >>= _float_of_yojson
   in
+  (* EODHD's [/api/eod] response carries no delisting marker on individual
+     bars. The delisted-date is sourced separately (via the fundamentals
+     endpoint or the delisted-symbol exchange listing) and would need a
+     separate enrichment pass to attach. Leaving [active_through = None]
+     here keeps the bar-parser contract narrow: bars in, bars out. *)
   Ok
     {
       Types.Daily_price.date;
@@ -150,6 +155,7 @@ let _parse_price_fields fields =
       close_price;
       volume;
       adjusted_close;
+      active_through = None;
     }
 
 let _parse_json_price = function

--- a/trading/analysis/data/sources/eodhd/test/test_http_client.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_http_client.ml
@@ -14,6 +14,7 @@ let expected_prices =
       close_price = 614.68;
       volume = 29640000;
       adjusted_close = 12.2936;
+      active_through = None;
     };
     {
       Types.Daily_price.date = Date.of_string "2015-11-13";
@@ -23,6 +24,7 @@ let expected_prices =
       close_price = 592.89;
       volume = 60785000;
       adjusted_close = 11.8578;
+      active_through = None;
     };
     {
       Types.Daily_price.date = Date.of_string "2015-11-16";
@@ -32,6 +34,7 @@ let expected_prices =
       close_price = 588.74;
       volume = 41905000;
       adjusted_close = 11.7748;
+      active_through = None;
     };
   ]
 
@@ -314,6 +317,7 @@ let test_get_bulk_last_day _ =
               close_price = 12.3;
               volume = 0;
               adjusted_close = 12.3;
+              active_through = None;
             } );
           ( "AABB",
             {
@@ -324,6 +328,7 @@ let test_get_bulk_last_day _ =
               close_price = 0.0304;
               volume = 5158473;
               adjusted_close = 0.0304;
+              active_through = None;
             } );
           ( "AABCX",
             {
@@ -334,6 +339,7 @@ let test_get_bulk_last_day _ =
               close_price = 15.51;
               volume = 0;
               adjusted_close = 15.51;
+              active_through = None;
             } );
         ]
       in

--- a/trading/analysis/data/storage/csv/lib/csv_storage.ml
+++ b/trading/analysis/data/storage/csv/lib/csv_storage.ml
@@ -18,6 +18,10 @@ let _validate_prices prices =
   | [] -> Ok ()
   | first :: rest -> _check_sorted_and_unique first.Types.Daily_price.date rest
 
+let _active_through_to_string = function
+  | None -> ""
+  | Some d -> Date.to_string d
+
 let _write_price oc price =
   let open Types.Daily_price in
   let date = Date.to_string price.date in
@@ -27,6 +31,7 @@ let _write_price oc price =
   let close_price = Float.to_string price.close_price in
   let adjusted_close = Float.to_string price.adjusted_close in
   let volume = Int.to_string price.volume in
+  let active_through = _active_through_to_string price.active_through in
   Out_channel.output_string oc
     (String.concat ~sep:","
        [
@@ -37,6 +42,7 @@ let _write_price oc price =
          close_price;
          adjusted_close;
          volume;
+         active_through;
        ]);
   Out_channel.newline oc
 
@@ -65,7 +71,7 @@ let _write_prices_to_file path prices =
   Exn.protect
     ~f:(fun () ->
       Out_channel.output_string oc
-        "date,open,high,low,close,adjusted_close,volume\n";
+        "date,open,high,low,close,adjusted_close,volume,active_through\n";
       List.iter ~f:(_write_price oc) prices;
       Ok ())
     ~finally:(fun () -> Out_channel.close oc)

--- a/trading/analysis/data/storage/csv/lib/parser.ml
+++ b/trading/analysis/data/storage/csv/lib/parser.ml
@@ -5,8 +5,12 @@ let parse_date (str : string) : Date.t =
   with _ ->
     raise (Invalid_argument "Invalid date format, expected YYYY-MM-DD")
 
-let _build_price date_str open_str high_str low_str close_str adj_close_str
-    volume_str : Types.Daily_price.t =
+let _parse_optional_date_field (str : string) : Date.t option =
+  let trimmed = String.strip str in
+  if String.is_empty trimmed then None else Some (parse_date trimmed)
+
+let _build_price ?(active_through = None) date_str open_str high_str low_str
+    close_str adj_close_str volume_str : Types.Daily_price.t =
   {
     date = parse_date date_str;
     open_price = float_of_string open_str;
@@ -15,14 +19,15 @@ let _build_price date_str open_str high_str low_str close_str adj_close_str
     close_price = float_of_string close_str;
     adjusted_close = float_of_string adj_close_str;
     volume = int_of_string volume_str;
+    active_through;
   }
 
-let _build_price_result date_str open_str high_str low_str close_str
-    adj_close_str volume_str line =
+let _build_price_result ?(active_through = None) date_str open_str high_str
+    low_str close_str adj_close_str volume_str line =
   try
     Ok
-      (_build_price date_str open_str high_str low_str close_str adj_close_str
-         volume_str)
+      (_build_price ~active_through date_str open_str high_str low_str close_str
+         adj_close_str volume_str)
   with
   | Invalid_argument msg -> Error msg
   | Failure _ -> Error ("Invalid number in line: " ^ line)
@@ -33,9 +38,25 @@ let parse_line (line : string) : (Types.Daily_price.t, string) Result.t =
   | [
    date_str; open_str; high_str; low_str; close_str; adj_close_str; volume_str;
   ] ->
+      (* Legacy 7-column rows: active_through defaults to None. *)
       _build_price_result date_str open_str high_str low_str close_str
         adj_close_str volume_str line
-  | _ -> Error ("Expected 7 columns, line: " ^ line)
+  | [
+   date_str;
+   open_str;
+   high_str;
+   low_str;
+   close_str;
+   adj_close_str;
+   volume_str;
+   active_through_str;
+  ] -> (
+      try
+        let active_through = _parse_optional_date_field active_through_str in
+        _build_price_result ~active_through date_str open_str high_str low_str
+          close_str adj_close_str volume_str line
+      with Invalid_argument msg -> Error msg)
+  | _ -> Error ("Expected 7 or 8 columns, line: " ^ line)
 
 let parse_lines (lines : string list) :
     Types.Daily_price.t list Status.status_or =

--- a/trading/analysis/data/storage/csv/test/test_csv_parser.ml
+++ b/trading/analysis/data/storage/csv/test/test_csv_parser.ml
@@ -21,6 +21,7 @@ let test_parse_line_valid _ =
       close_price = 103.0;
       adjusted_close = 103.0;
       volume = 1000;
+      active_through = None;
     }
 
 let test_parse_line_invalid_date _ =
@@ -48,7 +49,7 @@ let test_parse_line_invalid_volume _ =
 let test_parse_line_invalid_format _ =
   let result = parse_line "not,enough,columns" |> Result.error in
   assert_equal result
-    (Option.some "Expected 7 columns, line: not,enough,columns")
+    (Option.some "Expected 7 or 8 columns, line: not,enough,columns")
 
 let test_parse_lines_with_empty_list _ =
   let result = Parser.parse_lines [] in
@@ -57,14 +58,14 @@ let test_parse_lines_with_empty_list _ =
 let test_parse_lines_with_empty_lines _ =
   let result = Parser.parse_lines [ ""; "" ] in
   assert_equal result
-    (Error (Status.invalid_argument_error "Expected 7 columns, line: "))
+    (Error (Status.invalid_argument_error "Expected 7 or 8 columns, line: "))
 
 let test_parse_lines_with_invalid_line _ =
   let result = Parser.parse_lines [ ""; "not,enough,columns" ] in
   assert_equal result
     (Error
        (Status.invalid_argument_error
-          "Expected 7 columns, line: not,enough,columns"))
+          "Expected 7 or 8 columns, line: not,enough,columns"))
 
 let test_read_test_data_file _ =
   let prices =
@@ -82,6 +83,7 @@ let test_read_test_data_file _ =
       close_price = 139.62;
       adjusted_close = 138.9618;
       volume = 19019700;
+      active_through = None;
     };
   let last_price = List.last_exn prices in
   assert_equal ~printer:Types.Daily_price.show last_price
@@ -93,7 +95,56 @@ let test_read_test_data_file _ =
       close_price = 165.98;
       adjusted_close = 165.98;
       volume = 23682500;
+      active_through = None;
     }
+
+(* 8-column input with empty active_through cell — backward-compat sister
+   case to the 7-column [test_parse_line_valid]: produces [None] without
+   raising. *)
+let test_parse_line_8col_empty_active_through _ =
+  let result =
+    parse_line "2024-03-19,100.0,105.0,98.0,103.0,103.0,1000,"
+    |> Result.ok |> Option.value_exn |> List.hd_exn
+  in
+  assert_equal ~printer:Types.Daily_price.show result
+    {
+      Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:19;
+      open_price = 100.0;
+      high_price = 105.0;
+      low_price = 98.0;
+      close_price = 103.0;
+      adjusted_close = 103.0;
+      volume = 1000;
+      active_through = None;
+    }
+
+(* 8-column input with a populated active_through cell: the typed delisted
+   marker round-trips back into the record. *)
+let test_parse_line_8col_with_active_through _ =
+  let result =
+    parse_line "2024-03-19,100.0,105.0,98.0,103.0,103.0,1000,2024-05-15"
+    |> Result.ok |> Option.value_exn |> List.hd_exn
+  in
+  assert_equal ~printer:Types.Daily_price.show result
+    {
+      Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:19;
+      open_price = 100.0;
+      high_price = 105.0;
+      low_price = 98.0;
+      close_price = 103.0;
+      adjusted_close = 103.0;
+      volume = 1000;
+      active_through = Some (Date.create_exn ~y:2024 ~m:Month.May ~d:15);
+    }
+
+(* Malformed active_through cell: parser must surface a clear error rather
+   than silently producing [None]. *)
+let test_parse_line_8col_invalid_active_through _ =
+  let result =
+    parse_line "2024-03-19,100.0,105.0,98.0,103.0,103.0,1000,not-a-date"
+    |> Result.error
+  in
+  assert_equal result (Option.some "Invalid date format, expected YYYY-MM-DD")
 
 let suite =
   "CSV Parser tests"
@@ -109,6 +160,12 @@ let suite =
          "test_parse_lines_with_invalid_line"
          >:: test_parse_lines_with_invalid_line;
          "test_read_test_data_file" >:: test_read_test_data_file;
+         "test_parse_line_8col_empty_active_through"
+         >:: test_parse_line_8col_empty_active_through;
+         "test_parse_line_8col_with_active_through"
+         >:: test_parse_line_8col_with_active_through;
+         "test_parse_line_8col_invalid_active_through"
+         >:: test_parse_line_8col_invalid_active_through;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/analysis/data/storage/csv/test/test_csv_storage.ml
+++ b/trading/analysis/data/storage/csv/test/test_csv_storage.ml
@@ -37,6 +37,7 @@ let prices =
       close_price = 103.0;
       adjusted_close = 103.0;
       volume = 1000;
+      active_through = None;
     };
     {
       Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:20;
@@ -46,6 +47,7 @@ let prices =
       close_price = 107.0;
       adjusted_close = 107.0;
       volume = 1200;
+      active_through = None;
     };
     {
       Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:21;
@@ -55,6 +57,7 @@ let prices =
       close_price = 111.0;
       adjusted_close = 111.0;
       volume = 1400;
+      active_through = None;
     };
     {
       Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:22;
@@ -64,6 +67,7 @@ let prices =
       close_price = 114.0;
       adjusted_close = 114.0;
       volume = 1600;
+      active_through = None;
     };
   ]
 
@@ -159,6 +163,7 @@ let test_reject_overlapping_contradictory_data _ =
         close_price = 112.0;
         adjusted_close = 112.0;
         volume = 1500;
+        active_through = None;
       };
       {
         Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:21;
@@ -168,6 +173,7 @@ let test_reject_overlapping_contradictory_data _ =
         close_price = 116.0;
         adjusted_close = 116.0;
         volume = 1800;
+        active_through = None;
       };
     ]
   in
@@ -196,6 +202,7 @@ let test_allow_overlapping_with_override _ =
         close_price = 112.0;
         adjusted_close = 112.0;
         volume = 1500;
+        active_through = None;
       };
       {
         Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:21;
@@ -205,6 +212,7 @@ let test_allow_overlapping_with_override _ =
         close_price = 116.0;
         adjusted_close = 116.0;
         volume = 1800;
+        active_through = None;
       };
     ]
   in
@@ -272,7 +280,7 @@ let test_stream_bad_line_propagates_error _ =
   | Error status ->
       assert_equal ~printer:Status.show status
         (Status.invalid_argument_error
-           "Expected 7 columns, line: not,enough,columns")
+           "Expected 7 or 8 columns, line: not,enough,columns")
 
 let test_stream_header_only_returns_empty _ =
   let storage = create ~data_dir:test_dir "STREAM3" |> ok_or_failwith_status in
@@ -285,13 +293,107 @@ let test_stream_header_only_returns_empty _ =
   in
   let oc = Stdlib.open_out path in
   Out_channel.output_string oc
-    "date,open,high,low,close,adjusted_close,volume\n";
+    "date,open,high,low,close,adjusted_close,volume,active_through\n";
   Out_channel.close oc;
   let result = get storage () |> ok_or_failwith_status in
   assert_equal
     ~printer:(fun ps ->
       String.concat ~sep:"\n" (List.map ps ~f:Types.Daily_price.show))
     [] result
+
+(* Phase 3: round-trip [active_through] through CSV. Mixing [Some _] and
+   [None] in the same write batch verifies that the writer emits the new
+   column independently per row and that the reader maps the empty cell
+   back to [None] while keeping a populated cell as [Some d]. *)
+let test_save_and_get_with_active_through _ =
+  let storage = create ~data_dir:test_dir "DELIST" |> ok_or_failwith_status in
+  let delisted_date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:21 in
+  let prices_with_metadata =
+    [
+      {
+        Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:19;
+        open_price = 100.0;
+        high_price = 105.0;
+        low_price = 98.0;
+        close_price = 103.0;
+        adjusted_close = 103.0;
+        volume = 1000;
+        active_through = None;
+      };
+      {
+        Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:20;
+        open_price = 103.0;
+        high_price = 108.0;
+        low_price = 102.0;
+        close_price = 107.0;
+        adjusted_close = 107.0;
+        volume = 1200;
+        active_through = Some delisted_date;
+      };
+      {
+        Types.Daily_price.date = delisted_date;
+        open_price = 107.0;
+        high_price = 112.0;
+        low_price = 106.0;
+        close_price = 111.0;
+        adjusted_close = 111.0;
+        volume = 1400;
+        active_through = Some delisted_date;
+      };
+    ]
+  in
+  ok_or_failwith_status (save storage prices_with_metadata);
+  let retrieved = get storage () |> ok_or_failwith_status in
+  assert_equal
+    ~printer:(fun ps ->
+      String.concat ~sep:"\n" (List.map ps ~f:Types.Daily_price.show))
+    prices_with_metadata retrieved
+
+(* Phase 3 backward-compatibility: a 7-column legacy CSV (no
+   [active_through] column) must load with [active_through = None] for
+   every row. Goldens written before this PR have the legacy schema and
+   must keep loading. *)
+let test_read_legacy_7col_csv _ =
+  let symbol = "LEGACY" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  let path =
+    Fpath.(test_dir / "L" / "Y" / "LEGACY" / "data.csv") |> Fpath.to_string
+  in
+  let oc = Stdlib.open_out path in
+  Out_channel.output_string oc
+    "date,open,high,low,close,adjusted_close,volume\n\
+     2024-03-19,100.0,105.0,98.0,103.0,103.0,1000\n\
+     2024-03-20,103.0,108.0,102.0,107.0,107.0,1200\n";
+  Out_channel.close oc;
+  let retrieved = get storage () |> ok_or_failwith_status in
+  let expected =
+    [
+      {
+        Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:19;
+        open_price = 100.0;
+        high_price = 105.0;
+        low_price = 98.0;
+        close_price = 103.0;
+        adjusted_close = 103.0;
+        volume = 1000;
+        active_through = None;
+      };
+      {
+        Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:20;
+        open_price = 103.0;
+        high_price = 108.0;
+        low_price = 102.0;
+        close_price = 107.0;
+        adjusted_close = 107.0;
+        volume = 1200;
+        active_through = None;
+      };
+    ]
+  in
+  assert_equal
+    ~printer:(fun ps ->
+      String.concat ~sep:"\n" (List.map ps ~f:Types.Daily_price.show))
+    expected retrieved
 
 let suite =
   "CSV Storage tests"
@@ -320,6 +422,9 @@ let suite =
          >:: test_stream_bad_line_propagates_error;
          "test_stream_header_only_returns_empty"
          >:: test_stream_header_only_returns_empty;
+         "test_save_and_get_with_active_through"
+         >:: test_save_and_get_with_active_through;
+         "test_read_legacy_7col_csv" >:: test_read_legacy_7col_csv;
        ]
 
 let () =

--- a/trading/analysis/data/storage/metadata/test/metadata_test.ml
+++ b/trading/analysis/data/storage/metadata/test/metadata_test.ml
@@ -18,6 +18,7 @@ let create_test_price_data ~start_date ~end_date ~prices ~volumes =
         close_price = price;
         volume;
         adjusted_close = price;
+        active_through = None;
       })
 
 let test_normal_prices _ =

--- a/trading/analysis/data/synthetic/lib/block_bootstrap.ml
+++ b/trading/analysis/data/synthetic/lib/block_bootstrap.ml
@@ -50,6 +50,7 @@ let _apply_shape ~(shape : _bar_shape) ~close ~date : Types.Daily_price.t =
     close_price = close;
     adjusted_close = close *. shape.adj_close_ratio;
     volume = shape.volume;
+    active_through = None;
   }
 
 (* ---------------------------------------------------------------------- *)

--- a/trading/analysis/data/synthetic/lib/source_loader.ml
+++ b/trading/analysis/data/synthetic/lib/source_loader.ml
@@ -47,6 +47,7 @@ let _build_bar ~date ~close : Types.Daily_price.t =
     close_price = close;
     adjusted_close = close;
     volume = _constant_volume;
+    active_through = None;
   }
 
 let synthetic_spy_like ~start_date ~n_days ~seed =

--- a/trading/analysis/data/synthetic/lib/synth_v2.ml
+++ b/trading/analysis/data/synthetic/lib/synth_v2.ml
@@ -127,6 +127,7 @@ let _build_bar ~date ~close : Types.Daily_price.t =
     close_price = close;
     adjusted_close = close;
     volume = _synthetic_volume;
+    active_through = None;
   }
 
 (* ---------------------------------------------------------------------- *)

--- a/trading/analysis/data/synthetic/lib/synth_v3.ml
+++ b/trading/analysis/data/synthetic/lib/synth_v3.ml
@@ -126,6 +126,7 @@ let _build_bar ~date ~close : Types.Daily_price.t =
     close_price = close;
     adjusted_close = close;
     volume = _synthetic_volume;
+    active_through = None;
   }
 
 (* Compose a per-symbol bar series from log-returns and a date sequence. *)

--- a/trading/analysis/data/types/lib/daily_price.ml
+++ b/trading/analysis/data/types/lib/daily_price.ml
@@ -6,5 +6,26 @@ type t = {
   close_price : float;
   volume : int;
   adjusted_close : float;
+  active_through : Core.Date.t option;
+      (** Last date on which the issue actively traded, when known. [None] means
+          "still trading / unknown delisting status" — the default for bars
+          sourced from feeds that do not carry a delisting marker. [Some d]
+          indicates the symbol was delisted on or before [d]; callers (e.g. the
+          screener point-in-time filter) may treat look-ups strictly after [d]
+          as "bar missing because the issue is no longer listed" rather than as
+          a data gap. *)
 }
 [@@deriving show, eq]
+
+let make ~date ~open_price ~high_price ~low_price ~close_price ~volume
+    ~adjusted_close ?active_through () =
+  {
+    date;
+    open_price;
+    high_price;
+    low_price;
+    close_price;
+    volume;
+    adjusted_close;
+    active_through;
+  }

--- a/trading/analysis/data/types/lib/daily_price.mli
+++ b/trading/analysis/data/types/lib/daily_price.mli
@@ -6,5 +6,29 @@ type t = {
   close_price : float;
   volume : int;
   adjusted_close : float;
+  active_through : Core.Date.t option;
+      (** Last date on which the issue actively traded, when known. [None] is
+          the default — "still trading / unknown delisting status". [Some d]
+          means the symbol was delisted on or before [d]; consumers (screener
+          point-in-time filter, bar loaders) may distinguish "bar missing after
+          delisting" from "bar missing for plumbing reasons" using this field.
+          CSV / EODHD JSON deserialization preserves [None] for legacy inputs
+          that do not carry the column. *)
 }
 [@@deriving show, eq]
+
+val make :
+  date:Core.Date.t ->
+  open_price:float ->
+  high_price:float ->
+  low_price:float ->
+  close_price:float ->
+  volume:int ->
+  adjusted_close:float ->
+  ?active_through:Core.Date.t ->
+  unit ->
+  t
+(** Build a [t] from OHLCV fields with optional [active_through]. Defaults
+    [active_through] to [None] — appropriate for any data source that does not
+    carry a delisting marker. Provided so callers do not have to spell out
+    [active_through = None] in every record literal. *)

--- a/trading/analysis/data/types/test/dune
+++ b/trading/analysis/data/types/test/dune
@@ -1,4 +1,3 @@
-(test
- (name test_split_detector)
- (modules test_split_detector)
+(tests
+ (names test_split_detector test_daily_price)
  (libraries core ounit2 matchers types))

--- a/trading/analysis/data/types/test/test_daily_price.ml
+++ b/trading/analysis/data/types/test/test_daily_price.ml
@@ -1,0 +1,68 @@
+open OUnit2
+open Core
+open Matchers
+open Types
+
+let _sample_date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:19
+
+(* The [make] helper defaults [active_through] to [None] — appropriate for
+   any data source that does not carry a delisting marker. *)
+let test_make_defaults_active_through_to_none _ =
+  let bar =
+    Daily_price.make ~date:_sample_date ~open_price:100.0 ~high_price:105.0
+      ~low_price:98.0 ~close_price:103.0 ~adjusted_close:103.0 ~volume:1000 ()
+  in
+  assert_that bar.active_through is_none
+
+(* The helper threads through an explicit [active_through] when supplied. *)
+let test_make_threads_active_through _ =
+  let delisted_on = Date.create_exn ~y:2024 ~m:Month.May ~d:15 in
+  let bar =
+    Daily_price.make ~date:_sample_date ~open_price:100.0 ~high_price:105.0
+      ~low_price:98.0 ~close_price:103.0 ~adjusted_close:103.0 ~volume:1000
+      ~active_through:delisted_on ()
+  in
+  assert_that bar.active_through (is_some_and (equal_to delisted_on))
+
+(* Equality respects [active_through]: bars that differ only in their
+   delisting marker are not considered equal. This guards against an
+   eager refactor that drops the field from the derived equality. *)
+let test_equality_respects_active_through _ =
+  let base =
+    Daily_price.make ~date:_sample_date ~open_price:100.0 ~high_price:105.0
+      ~low_price:98.0 ~close_price:103.0 ~adjusted_close:103.0 ~volume:1000 ()
+  in
+  let with_marker =
+    Daily_price.make ~date:_sample_date ~open_price:100.0 ~high_price:105.0
+      ~low_price:98.0 ~close_price:103.0 ~adjusted_close:103.0 ~volume:1000
+      ~active_through:_sample_date ()
+  in
+  assert_that (Daily_price.equal base with_marker) (equal_to false)
+
+(* Two bars sharing identical OHLCV + [active_through] are equal. *)
+let test_equality_holds_for_identical_records _ =
+  let bar1 =
+    Daily_price.make ~date:_sample_date ~open_price:100.0 ~high_price:105.0
+      ~low_price:98.0 ~close_price:103.0 ~adjusted_close:103.0 ~volume:1000
+      ~active_through:_sample_date ()
+  in
+  let bar2 =
+    Daily_price.make ~date:_sample_date ~open_price:100.0 ~high_price:105.0
+      ~low_price:98.0 ~close_price:103.0 ~adjusted_close:103.0 ~volume:1000
+      ~active_through:_sample_date ()
+  in
+  assert_that (Daily_price.equal bar1 bar2) (equal_to true)
+
+let suite =
+  "Daily_price tests"
+  >::: [
+         "test_make_defaults_active_through_to_none"
+         >:: test_make_defaults_active_through_to_none;
+         "test_make_threads_active_through" >:: test_make_threads_active_through;
+         "test_equality_respects_active_through"
+         >:: test_equality_respects_active_through;
+         "test_equality_holds_for_identical_records"
+         >:: test_equality_holds_for_identical_records;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/data/types/test/test_split_detector.ml
+++ b/trading/analysis/data/types/test/test_split_detector.ml
@@ -20,6 +20,7 @@ let make_bar ~date ~close_price ~adjusted_close : Daily_price.t =
     close_price;
     adjusted_close;
     volume = 100_000;
+    active_through = None;
   }
 
 let detect prev curr = Split_detector.detect_split ~prev ~curr ()

--- a/trading/analysis/technical/indicators/atr/test/test_atr.ml
+++ b/trading/analysis/technical/indicators/atr/test/test_atr.ml
@@ -12,6 +12,7 @@ let _mk_ohlc_bar ~date ~o ~h ~l ~c : Daily_price.t =
     close_price = c;
     volume = 0;
     adjusted_close = c;
+    active_through = None;
   }
 
 let _flat_bars ~n ~start_date ~base =

--- a/trading/analysis/technical/indicators/relative_strength/test/test_relative_strength.ml
+++ b/trading/analysis/technical/indicators/relative_strength/test/test_relative_strength.ml
@@ -20,6 +20,7 @@ let make_bar date adjusted_close =
     close_price = adjusted_close;
     volume = 1000;
     adjusted_close;
+    active_through = None;
   }
 
 (** Build aligned weekly bars starting 2020-01-06 at the given prices. *)

--- a/trading/analysis/technical/indicators/time_period/lib/conversion.ml
+++ b/trading/analysis/technical/indicators/time_period/lib/conversion.ml
@@ -43,6 +43,7 @@ let _aggregate_week (week_rev : t list) : t =
     close_price = last.close_price;
     volume = List.sum (module Int) week_rev ~f:(fun d -> d.volume);
     adjusted_close = last.adjusted_close;
+    active_through = None;
   }
 
 (* Drop a trailing partial week if its last observed day is not a Friday. The

--- a/trading/analysis/technical/indicators/time_period/test/test_conversion.ml
+++ b/trading/analysis/technical/indicators/time_period/test/test_conversion.ml
@@ -14,6 +14,7 @@ let make_test_data ~date ~price =
     close_price = price;
     volume = default_volume;
     adjusted_close = price;
+    active_through = None;
   }
 
 (* Daily to weekly conversion tests *)
@@ -47,6 +48,7 @@ let test_single_week _ =
         close_price = 4.0;
         volume = default_volume * 4;
         adjusted_close = 4.0;
+        active_through = None;
       };
     ]
 
@@ -91,6 +93,7 @@ let test_multiple_weeks _ =
         close_price = 3.0;
         volume = default_volume * 4;
         adjusted_close = 3.0;
+        active_through = None;
       };
       {
         date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:20;
@@ -100,6 +103,7 @@ let test_multiple_weeks _ =
         close_price = 7.0;
         volume = default_volume * 3;
         adjusted_close = 7.0;
+        active_through = None;
       };
     ]
 
@@ -158,6 +162,7 @@ let test_weekdays_only _ =
         close_price = 4.0;
         volume = default_volume * 4;
         adjusted_close = 4.0;
+        active_through = None;
       };
     ]
 
@@ -204,6 +209,7 @@ let test_weekend_data_with_weekdays_only_raises_invalid_argument _ =
         close_price = 5.0;
         volume = default_volume * 2;
         adjusted_close = 5.0;
+        active_through = None;
       };
     ];
   (* Should fail when weekdays_only is true *)
@@ -260,6 +266,7 @@ let test_partial_week_included_by_default _ =
         close_price = 3.0;
         volume = default_volume * 3;
         adjusted_close = 3.0;
+        active_through = None;
       };
     ]
 
@@ -323,6 +330,7 @@ let test_complete_and_partial_weeks _ =
         close_price = 5.0;
         volume = default_volume * 2;
         adjusted_close = 5.0;
+        active_through = None;
       };
       {
         date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:20;
@@ -332,6 +340,7 @@ let test_complete_and_partial_weeks _ =
         close_price = 8.0;
         volume = default_volume * 2;
         adjusted_close = 8.0;
+        active_through = None;
       };
     ];
   (* Exclude partial: only complete week *)
@@ -348,6 +357,7 @@ let test_complete_and_partial_weeks _ =
         close_price = 5.0;
         volume = default_volume * 2;
         adjusted_close = 5.0;
+        active_through = None;
       };
     ]
 
@@ -385,6 +395,7 @@ let test_all_complete_weeks_unaffected _ =
         close_price = 5.0;
         volume = default_volume * 2;
         adjusted_close = 5.0;
+        active_through = None;
       };
       {
         date = Date.create_exn ~y:2024 ~m:Month.Mar ~d:22;
@@ -394,6 +405,7 @@ let test_all_complete_weeks_unaffected _ =
         close_price = 10.0;
         volume = default_volume * 2;
         adjusted_close = 10.0;
+        active_through = None;
       };
     ]
   in

--- a/trading/analysis/weinstein/data_source/test/test_historical_source.ml
+++ b/trading/analysis/weinstein/data_source/test/test_historical_source.ml
@@ -22,6 +22,7 @@ let make_bar date close =
     close_price = close;
     adjusted_close = close;
     volume = 1000;
+    active_through = None;
   }
 
 let make_query ?start_date ?end_date symbol : Data_source.bar_query =

--- a/trading/analysis/weinstein/data_source/test/test_live_source.ml
+++ b/trading/analysis/weinstein/data_source/test/test_live_source.ml
@@ -22,6 +22,7 @@ let make_bar date close =
     close_price = close;
     adjusted_close = close;
     volume = 1000;
+    active_through = None;
   }
 
 let make_query ?start_date ?end_date symbol : Data_source.bar_query =
@@ -148,6 +149,7 @@ let test_live_stale_cache_refetches _ =
           close_price = 100.0;
           adjusted_close = 100.0;
           volume = 1000;
+          active_through = None;
         }
       in
       let fake_json =
@@ -190,6 +192,7 @@ let test_live_cache_write _ =
           close_price = 51.0;
           adjusted_close = 51.0;
           volume = 2000;
+          active_through = None;
         }
       in
       let fake_json =

--- a/trading/analysis/weinstein/data_source/testing/lib/synthetic_source.ml
+++ b/trading/analysis/weinstein/data_source/testing/lib/synthetic_source.ml
@@ -57,6 +57,7 @@ let _make_bar date close volume =
     close_price = close;
     adjusted_close = close;
     volume;
+    active_through = None;
   }
 
 (* @nesting-ok: structural weekend skip — match arms are flat transformations *)

--- a/trading/analysis/weinstein/macro/test/test_macro.ml
+++ b/trading/analysis/weinstein/macro/test/test_macro.ml
@@ -20,6 +20,7 @@ let make_bar date adjusted_close =
     close_price = adjusted_close;
     adjusted_close;
     volume = 100_000;
+    active_through = None;
   }
 
 let weekly_bars prices =

--- a/trading/analysis/weinstein/resistance/test/test_resistance.ml
+++ b/trading/analysis/weinstein/resistance/test/test_resistance.ml
@@ -23,6 +23,7 @@ let make_bar ?(low = 90.0) ?(high = 110.0) close =
     close_price = close;
     adjusted_close = close;
     volume = 1000;
+    active_through = None;
   }
 
 (* ------------------------------------------------------------------ *)

--- a/trading/analysis/weinstein/rs/test/test_rs.ml
+++ b/trading/analysis/weinstein/rs/test/test_rs.ml
@@ -21,6 +21,7 @@ let make_bar date adjusted_close =
     close_price = adjusted_close;
     volume = 1000;
     adjusted_close;
+    active_through = None;
   }
 
 (** Build aligned weekly bars starting 2020-01-06 at the given prices. *)

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -21,6 +21,7 @@ let make_bar ?(volume = 1000) date adjusted_close =
     close_price = adjusted_close;
     adjusted_close;
     volume;
+    active_through = None;
   }
 
 let weekly_bars_with_volumes prices_and_volumes =

--- a/trading/analysis/weinstein/sector/test/test_sector.ml
+++ b/trading/analysis/weinstein/sector/test/test_sector.ml
@@ -22,6 +22,7 @@ let make_bar date adjusted_close =
     close_price = adjusted_close;
     adjusted_close;
     volume = 10_000;
+    active_through = None;
   }
 
 let weekly_bars prices =

--- a/trading/analysis/weinstein/snapshot_pipeline/lib/weekly_prefix.ml
+++ b/trading/analysis/weinstein/snapshot_pipeline/lib/weekly_prefix.ml
@@ -42,6 +42,7 @@ let _aggregate_week (week_rev : Types.Daily_price.t list) : Types.Daily_price.t
     close_price = last.close_price;
     volume = List.sum (module Int) week_rev ~f:(fun d -> d.volume);
     adjusted_close = last.adjusted_close;
+    active_through = None;
   }
 
 let _empty =

--- a/trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_pipeline.ml
+++ b/trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_pipeline.ml
@@ -17,6 +17,7 @@ let _make_bar ~date ~close =
     close_price = close;
     volume = 1_000_000;
     adjusted_close = close;
+    active_through = None;
   }
 
 let _date_seq ~start ~n = List.init n ~f:(fun i -> Date.add_days start i)
@@ -239,6 +240,7 @@ let _make_distinct_bar ~date ~i =
     close_price = 105.0 +. f;
     volume = 1_000 + i;
     adjusted_close = 104.0 +. f;
+    active_through = None;
   }
 
 let _distinct_bars ~n =

--- a/trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_verifier.ml
+++ b/trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_verifier.ml
@@ -20,6 +20,7 @@ let _make_bar ~date ~close =
     close_price = close;
     volume = 1_000_000;
     adjusted_close = close;
+    active_through = None;
   }
 
 let _ramp_bars ~n =

--- a/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views_helpers.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views_helpers.ml
@@ -24,6 +24,7 @@ let _make_daily_price ~open_t ~date ~close_v ~adj_v ~high_v ~low_v ~vol_v =
     close_price = close_v;
     volume = _round_volume vol_v;
     adjusted_close = adj_v;
+    active_through = None;
   }
 
 let _match_ohlcv ~open_t ~adj_t ~high_t ~low_t ~vol_t ~date ~close_v =

--- a/trading/analysis/weinstein/snapshot_runtime/test/test_snapshot_bar_views.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/test/test_snapshot_bar_views.ml
@@ -56,6 +56,7 @@ let _make_bar ~date ~symbol_seed ~day_offset : Types.Daily_price.t =
     close_price = 105.0 +. s +. (i *. 0.15);
     volume = 1000 + ((symbol_seed + 1) * (day_offset + 1));
     adjusted_close = 102.0 +. s +. (i *. 0.13);
+    active_through = None;
   }
 
 (* --- Schema for the snapshot path. The shim only reads OHLCV fields, but

--- a/trading/analysis/weinstein/stage/test/test_stage.ml
+++ b/trading/analysis/weinstein/stage/test/test_stage.ml
@@ -21,6 +21,7 @@ let make_bar ?(date = "2024-01-01") adjusted_close =
     close_price = adjusted_close;
     volume = 1000;
     adjusted_close;
+    active_through = None;
   }
 
 (** Make [n] bars with the given price, assigning consecutive Monday dates. *)

--- a/trading/analysis/weinstein/stock_analysis/test/test_stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/test/test_stock_analysis.ml
@@ -23,6 +23,7 @@ let make_bar i price volume =
     close_price = price;
     adjusted_close = price;
     volume;
+    active_through = None;
   }
 
 (** Rising bars from [start] to [stop_], all at uniform volume 1000. *)
@@ -352,6 +353,7 @@ let _split_synth ~n_total ~n_pre ~pre_high ~pre_close ~pre_adj ~post_high
         close_price = close;
         adjusted_close = adj;
         volume = 1000;
+        active_through = None;
       })
 
 (** With a 4:1 split between weeks 15 and 16 (pre: factor 0.25, post: factor

--- a/trading/analysis/weinstein/support/test/test_support.ml
+++ b/trading/analysis/weinstein/support/test/test_support.ml
@@ -23,6 +23,7 @@ let make_bar ?(low = 90.0) ?(high = 110.0) close =
     close_price = close;
     adjusted_close = close;
     volume = 1000;
+    active_through = None;
   }
 
 (* ------------------------------------------------------------------ *)

--- a/trading/analysis/weinstein/volume/test/test_volume.ml
+++ b/trading/analysis/weinstein/volume/test/test_volume.ml
@@ -20,6 +20,7 @@ let make_bar ?(price = 100.0) volume =
     close_price = price;
     adjusted_close = price;
     volume;
+    active_through = None;
   }
 
 (** [n] baseline bars followed by one event bar. *)

--- a/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
+++ b/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
@@ -36,6 +36,7 @@ let _make_bar ~date ~close () : Types.Daily_price.t =
     close_price = close;
     volume = 1_000;
     adjusted_close = close;
+    active_through = None;
   }
 
 (** Generate weekday daily bars between [start] and [end_] (inclusive) at a flat

--- a/trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml
+++ b/trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml
@@ -36,6 +36,7 @@ let _make_bar ~date ~close () : Types.Daily_price.t =
     close_price = close;
     volume = 1_000;
     adjusted_close = close;
+    active_through = None;
   }
 
 let _flat_bars ~start ~end_ ~close : Types.Daily_price.t list =

--- a/trading/trading/backtest/lib/snapshot_bar_source.ml
+++ b/trading/trading/backtest/lib/snapshot_bar_source.ml
@@ -44,6 +44,7 @@ let _snapshot_to_daily_price (s : Snapshot.t) : Types.Daily_price.t option =
       close_price;
       volume = Float.to_int volume_f;
       adjusted_close;
+      active_through = None;
     }
 
 (* Today's bar: a single read_today call, then OHLCV reconstruction. *)

--- a/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
@@ -64,6 +64,7 @@ let _make_bar ~date_str ~close () : Types.Daily_price.t =
     close_price = close;
     volume = 1_000;
     adjusted_close = close;
+    active_through = None;
   }
 
 (** Generate weekday daily bars between [start] and [end_] (inclusive) at a flat
@@ -333,6 +334,7 @@ let _outlook_bar ~date ~close : Types.Daily_price.t =
     close_price = close;
     volume = 1_000_000;
     adjusted_close = close;
+    active_through = None;
   }
 
 (** Synthetic Stage-2 result; the slice tests don't drive the stage classifier,

--- a/trading/trading/backtest/optimal/test/test_outcome_scorer.ml
+++ b/trading/trading/backtest/optimal/test/test_outcome_scorer.ml
@@ -59,6 +59,7 @@ let make_bar ~date ?(open_price = 100.0) ?(high_price = 105.0)
     close_price;
     volume;
     adjusted_close;
+    active_through = None;
   }
 
 (** Build a [Stage.result]. Defaults to a healthy Stage 2; tests flip [stage] to

--- a/trading/trading/backtest/test/test_snapshot_mode_parity.ml
+++ b/trading/trading/backtest/test/test_snapshot_mode_parity.ml
@@ -45,6 +45,7 @@ let _make_bar ~symbol ~day_index ~start =
     close_price = close;
     volume = 1_000_000 + (day_index * 1000);
     adjusted_close = close;
+    active_through = None;
   }
 
 let _bars_for ~symbol ~start ~n =

--- a/trading/trading/data_panel/test/calendar_aware_load_test.ml
+++ b/trading/trading/data_panel/test/calendar_aware_load_test.ml
@@ -26,6 +26,7 @@ let _make_price ~date_str ~close () : Types.Daily_price.t =
     close_price = close;
     volume = 1_000;
     adjusted_close = close;
+    active_through = None;
   }
 
 let _write_csv ~data_dir ~symbol prices =

--- a/trading/trading/data_panel/test/ohlcv_panels_test.ml
+++ b/trading/trading/data_panel/test/ohlcv_panels_test.ml
@@ -21,6 +21,7 @@ let _make_price ~date_str ~open_ ~high ~low ~close ~volume () :
     close_price = close;
     volume;
     adjusted_close = close;
+    active_through = None;
   }
 
 let test_create_initializes_to_nan _ =

--- a/trading/trading/simulation/test/test_audit_weinstein_bear.ml
+++ b/trading/trading/simulation/test/test_audit_weinstein_bear.ml
@@ -107,6 +107,7 @@ let _make_bar ~date ~open_ ~high ~low ~close ~adjusted_close ~volume =
       close_price = close;
       adjusted_close;
       volume;
+      active_through = None;
     }
 
 (** Build a [Position.t] in [Holding] state for a short with the given

--- a/trading/trading/simulation/test/test_indicator_computer.ml
+++ b/trading/trading/simulation/test/test_indicator_computer.ml
@@ -13,6 +13,7 @@ let make_price ~y ~m ~d ~close () =
     close_price = close;
     volume = 1000000;
     adjusted_close = close;
+    active_through = None;
   }
 
 (** Test helper: extract result or fail *)
@@ -228,6 +229,7 @@ let test_uses_close_prices _ =
         close_price = 100.0;
         volume = 1000000;
         adjusted_close = 100.0;
+        active_through = None;
       };
       {
         Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Jan ~d:2;
@@ -237,6 +239,7 @@ let test_uses_close_prices _ =
         close_price = 105.0;
         volume = 1000000;
         adjusted_close = 105.0;
+        active_through = None;
       };
       {
         Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Jan ~d:3;
@@ -246,6 +249,7 @@ let test_uses_close_prices _ =
         close_price = 110.0;
         volume = 1000000;
         adjusted_close = 110.0;
+        active_through = None;
       };
     ]
   in

--- a/trading/trading/simulation/test/test_indicator_manager.ml
+++ b/trading/trading/simulation/test/test_indicator_manager.ml
@@ -17,6 +17,7 @@ let generate_prices ~start_date ~num_days ~base_price =
         close_price = close;
         volume = 1000000;
         adjusted_close = close;
+        active_through = None;
       })
 
 (** Standard test prices for indicator tests *)

--- a/trading/trading/simulation/test/test_market_data_adapter.ml
+++ b/trading/trading/simulation/test/test_market_data_adapter.ml
@@ -20,6 +20,7 @@ let generate_prices ~start_date ~num_days ~base_price =
         close_price = close;
         volume = 1000000;
         adjusted_close = close;
+        active_through = None;
       })
 
 let setup_test_data test_name =
@@ -188,6 +189,7 @@ let test_zero_close_bar_is_filtered _ =
       close_price = 0.0;
       volume = 0;
       adjusted_close = 0.0;
+      active_through = None;
     }
   in
   let valid_bar : Types.Daily_price.t =
@@ -199,6 +201,7 @@ let test_zero_close_bar_is_filtered _ =
       close_price = 10.07;
       volume = 0;
       adjusted_close = 10.07;
+      active_through = None;
     }
   in
   let zero_date = Date.create_exn ~y:2023 ~m:Month.Jan ~d:11 in

--- a/trading/trading/simulation/test/test_price_cache.ml
+++ b/trading/trading/simulation/test/test_price_cache.ml
@@ -29,6 +29,7 @@ let setup_test_data test_name =
         close_price = 101.0;
         volume = 1000000;
         adjusted_close = 101.0;
+        active_through = None;
       };
       {
         Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Jan ~d:2;
@@ -38,6 +39,7 @@ let setup_test_data test_name =
         close_price = 102.0;
         volume = 1100000;
         adjusted_close = 102.0;
+        active_through = None;
       };
       {
         Types.Daily_price.date = Date.create_exn ~y:2024 ~m:Month.Jan ~d:3;
@@ -47,6 +49,7 @@ let setup_test_data test_name =
         close_price = 103.0;
         volume = 1200000;
         adjusted_close = 103.0;
+        active_through = None;
       };
     ]
   in
@@ -66,6 +69,7 @@ let setup_test_data test_name =
         close_price = 151.0;
         volume = 2000000;
         adjusted_close = 151.0;
+        active_through = None;
       };
     ]
   in

--- a/trading/trading/simulation/test/test_simulator.ml
+++ b/trading/trading/simulation/test/test_simulator.ml
@@ -16,6 +16,7 @@ let make_daily_price ~date ~open_price ~high ~low ~close ~volume =
       close_price = close;
       volume;
       adjusted_close = close;
+      active_through = None;
     }
 
 let sample_config =

--- a/trading/trading/simulation/test/test_split_day_audit.ml
+++ b/trading/trading/simulation/test/test_split_day_audit.ml
@@ -182,6 +182,7 @@ let _make_bar ~date ~open_ ~high ~low ~close ~adjusted_close ~volume =
       close_price = close;
       adjusted_close;
       volume;
+      active_through = None;
     }
 
 (* ------------------------------------------------------------------ *)

--- a/trading/trading/simulation/test/test_split_day_mtm.ml
+++ b/trading/trading/simulation/test/test_split_day_mtm.ml
@@ -46,6 +46,7 @@ let _make_bar ~date ~open_ ~high ~low ~close ~adjusted_close ~volume =
       close_price = close;
       adjusted_close;
       volume;
+      active_through = None;
     }
 
 (** Synthetic AAPL-like CSV spanning a 4:1 split.

--- a/trading/trading/simulation/test/test_split_day_stop_exit.ml
+++ b/trading/trading/simulation/test/test_split_day_stop_exit.ml
@@ -75,6 +75,7 @@ let _make_bar ~date ~open_ ~high ~low ~close ~adjusted_close ~volume =
       close_price = close;
       adjusted_close;
       volume;
+      active_through = None;
     }
 
 (** Synthetic 4:1 split bars for [TEST] — same shape as the AAPL fixture in

--- a/trading/trading/simulation/test/test_stale_hold.ml
+++ b/trading/trading/simulation/test/test_stale_hold.ml
@@ -34,6 +34,7 @@ let _adapter_of_table ~(table : (string * Date.t * float) list) =
       close_price = price;
       adjusted_close = price;
       volume = 1_000;
+      active_through = None;
     }
   in
   let get_price ~symbol ~date =

--- a/trading/trading/simulation/test/test_time_series.ml
+++ b/trading/trading/simulation/test/test_time_series.ml
@@ -15,6 +15,7 @@ let make_test_price ~date ~price =
       close_price = price;
       volume = default_volume;
       adjusted_close = price;
+      active_through = None;
     }
 
 (* Cadence type tests *)
@@ -88,6 +89,7 @@ let test_convert_cadence_daily _ =
               close_price = 1.0;
               volume = default_volume;
               adjusted_close = 1.0;
+              active_through = None;
             }
              : Types.Daily_price.t);
          equal_to
@@ -99,6 +101,7 @@ let test_convert_cadence_daily _ =
               close_price = 2.0;
               volume = default_volume;
               adjusted_close = 2.0;
+              active_through = None;
             }
              : Types.Daily_price.t);
          equal_to
@@ -110,6 +113,7 @@ let test_convert_cadence_daily _ =
               close_price = 3.0;
               volume = default_volume;
               adjusted_close = 3.0;
+              active_through = None;
             }
              : Types.Daily_price.t);
        ])
@@ -147,6 +151,7 @@ let test_convert_cadence_weekly_complete _ =
               close_price = 5.0;
               volume = default_volume * 3;
               adjusted_close = 5.0;
+              active_through = None;
             }
              : Types.Daily_price.t);
        ])
@@ -202,6 +207,7 @@ let test_convert_cadence_weekly_incomplete_provisional _ =
               close_price = 3.0;
               volume = default_volume * 2;
               adjusted_close = 3.0;
+              active_through = None;
             }
              : Types.Daily_price.t);
        ])
@@ -245,6 +251,7 @@ let test_convert_cadence_weekly_mixed _ =
               close_price = 5.0;
               volume = default_volume * 2;
               adjusted_close = 5.0;
+              active_through = None;
             }
              : Types.Daily_price.t);
        ]);
@@ -265,6 +272,7 @@ let test_convert_cadence_weekly_mixed _ =
               close_price = 5.0;
               volume = default_volume * 2;
               adjusted_close = 5.0;
+              active_through = None;
             }
              : Types.Daily_price.t);
          equal_to
@@ -276,6 +284,7 @@ let test_convert_cadence_weekly_mixed _ =
               close_price = 8.0;
               volume = default_volume * 2;
               adjusted_close = 8.0;
+              active_through = None;
             }
              : Types.Daily_price.t);
        ])

--- a/trading/trading/strategy/test/price_generators.ml
+++ b/trading/trading/strategy/test/price_generators.ml
@@ -36,6 +36,7 @@ let make_price_sequence ~symbol:_ ~start_date ~days ~base_price ~trend
             close_price;
             volume = 1000000;
             adjusted_close = close_price;
+            active_through = None;
           }
       in
       generate (daily_price :: acc) (Date.add_days date 1) (remaining_days - 1)

--- a/trading/trading/strategy/test/test_portfolio_view.ml
+++ b/trading/trading/strategy/test/test_portfolio_view.ml
@@ -36,6 +36,7 @@ let _make_price close_price =
     close_price;
     adjusted_close = close_price;
     volume = 1000;
+    active_through = None;
   }
 
 let test_portfolio_value_cash_only _ =

--- a/trading/trading/strategy/test/test_strategy_lifecycle.ml
+++ b/trading/trading/strategy/test/test_strategy_lifecycle.ml
@@ -233,6 +233,7 @@ let test_complete_lifecycle _ =
       close_price = 50.0;
       volume = 1000;
       adjusted_close = 50.0;
+      active_through = None;
     }
   in
 
@@ -287,6 +288,7 @@ let test_complete_lifecycle _ =
       close_price = 60.0;
       volume = 1000;
       adjusted_close = 60.0;
+      active_through = None;
     }
   in
 

--- a/trading/trading/weinstein/snapshot/bin/verify_corporate_actions.ml
+++ b/trading/trading/weinstein/snapshot/bin/verify_corporate_actions.ml
@@ -29,6 +29,7 @@ let _parse_bar_line line =
            close_price = Float.of_string c;
            adjusted_close = Float.of_string ac;
            volume = Int.of_string v;
+           active_through = None;
          }
           : Types.Daily_price.t)
   | _ -> Error (Printf.sprintf "Malformed bar line: %s" line)

--- a/trading/trading/weinstein/snapshot/test/test_forward_trace.ml
+++ b/trading/trading/weinstein/snapshot/test/test_forward_trace.ml
@@ -22,6 +22,7 @@ let _bar ?(volume = 1_000_000) ~date ~o ~h ~l ~c () : Daily_price.t =
     close_price = c;
     volume;
     adjusted_close = c;
+    active_through = None;
   }
 
 let _candidate ?(score = 0.9) ?(grade = "A+") ?(sector = "XLK")
@@ -168,6 +169,7 @@ let _split_day_bars : Daily_price.t list =
       close_price = 500.0;
       volume = 1_000_000;
       adjusted_close = 125.0;
+      active_through = None;
     };
     {
       date = _date "2020-09-01";
@@ -177,6 +179,7 @@ let _split_day_bars : Daily_price.t list =
       close_price = 502.0;
       volume = 1_000_000;
       adjusted_close = 125.5;
+      active_through = None;
     };
     (* Split day: raw price collapses 4×, adjusted is unchanged scale *)
     {
@@ -187,6 +190,7 @@ let _split_day_bars : Daily_price.t list =
       close_price = 130.0;
       volume = 4_000_000;
       adjusted_close = 130.0;
+      active_through = None;
     };
     {
       date = _date "2020-09-03";
@@ -196,6 +200,7 @@ let _split_day_bars : Daily_price.t list =
       close_price = 132.0;
       volume = 4_000_000;
       adjusted_close = 132.0;
+      active_through = None;
     };
   ]
 

--- a/trading/trading/weinstein/snapshot/test/test_split_replay.ml
+++ b/trading/trading/weinstein/snapshot/test/test_split_replay.ml
@@ -36,6 +36,7 @@ let _parse_bar_line line =
          close_price = Float.of_string c;
          adjusted_close = Float.of_string ac;
          volume = Int.of_string v;
+         active_through = None;
        }
         : Types.Daily_price.t)
   | _ -> assert_failure (Printf.sprintf "Malformed bar line: %s" line)

--- a/trading/trading/weinstein/stops/test/regression_test.ml
+++ b/trading/trading/weinstein/stops/test/regression_test.ml
@@ -30,6 +30,7 @@ let make_bar ?(high_price = 105.0) ?(low_price = 95.0) close_price =
     close_price;
     adjusted_close = close_price;
     volume = 1000000;
+    active_through = None;
   }
 
 (** Apply a sequence of (close, low, high, ma, ma_dir, stage) tuples and return

--- a/trading/trading/weinstein/stops/test/test_support_floor.ml
+++ b/trading/trading/weinstein/stops/test/test_support_floor.ml
@@ -29,6 +29,7 @@ let make_bar ~date ~high ~low ~close =
     close_price = close;
     adjusted_close = close;
     volume = 1_000_000;
+    active_through = None;
   }
 
 (* ==================================================================== *)

--- a/trading/trading/weinstein/stops/test/test_weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/test/test_weinstein_stops.ml
@@ -18,6 +18,7 @@ let make_bar ?(open_price = 100.0) ?(high_price = 105.0) ?(low_price = 95.0)
       close_price;
       volume;
       adjusted_close;
+      active_through = None;
     }
 
 let cfg = default_config

--- a/trading/trading/weinstein/stops/test/test_weinstein_stops_callbacks_parity.ml
+++ b/trading/trading/weinstein/stops/test/test_weinstein_stops_callbacks_parity.ml
@@ -28,6 +28,7 @@ let make_bar ~date ~high ~low ~close =
     close_price = close;
     adjusted_close = close;
     volume = 1_000_000;
+    active_through = None;
   }
 
 (* Call the bar-list path and the callback path on identical inputs and assert

--- a/trading/trading/weinstein/strategy/test/test_bar_reader.ml
+++ b/trading/trading/weinstein/strategy/test/test_bar_reader.ml
@@ -55,6 +55,7 @@ let _make_bar ~date ~price : Types.Daily_price.t =
     close_price = price;
     adjusted_close = price;
     volume = 1_000_000;
+    active_through = None;
   }
 
 let _make_bars ~start ~n ~start_price ~step =

--- a/trading/trading/weinstein/strategy/test/test_entry_audit_capture.ml
+++ b/trading/trading/weinstein/strategy/test/test_entry_audit_capture.ml
@@ -32,6 +32,7 @@ let _bar_reader_with_current_close ~current_date ~current_close : Bar_reader.t =
       close_price = current_close;
       adjusted_close = current_close;
       volume = 1_000_000;
+      active_through = None;
     }
   in
   Bar_reader.of_in_memory_bars [ (_ticker, [ bar ]) ]

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_runner.ml
@@ -29,6 +29,7 @@ let _make_bar ~date ~close =
       close_price = close;
       adjusted_close = close;
       volume = 1_000_000;
+      active_through = None;
     }
 
 (** Build a [Holding] position with [side]/[entry_price]/[quantity] using the

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
@@ -37,6 +37,7 @@ let _make_daily_bar ~date ~price =
     close_price = price;
     adjusted_close = price;
     volume = 1_000_000;
+    active_through = None;
   }
 
 (** Build [n] consecutive daily bars (one per calendar day) starting at

--- a/trading/trading/weinstein/strategy/test/test_laggard_rotation_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_laggard_rotation_runner.ml
@@ -18,6 +18,7 @@ let make_bar date ~close ?low ?high () =
     close_price = close;
     adjusted_close = close;
     volume = 1_000_000;
+    active_through = None;
   }
 
 let cfg_k4 = { Laggard_rotation.hysteresis_weeks = 4; rs_window_weeks = 13 }
@@ -87,6 +88,7 @@ let _make_weekly_bars_to_friday ~from_close ~to_close ~n =
         close_price = close;
         adjusted_close = close;
         volume = 1_000_000;
+        active_through = None;
       })
 
 (** Build a [Bar_reader.t] backed by in-memory bars for the given (symbol, bars)

--- a/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
+++ b/trading/trading/weinstein/strategy/test/test_macro_inputs.ml
@@ -37,6 +37,7 @@ let make_rising_bars ~start_date ~n ~start_price =
         close_price = price;
         adjusted_close = price;
         volume = 1_000_000;
+        active_through = None;
       })
 
 (** Build a snapshot-backed [Bar_reader.t] over a synthetic universe.

--- a/trading/trading/weinstein/strategy/test/test_panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/test/test_panel_callbacks.ml
@@ -41,6 +41,7 @@ let make_weekly_bar ~date ~price =
     close_price = price;
     adjusted_close = price;
     volume = 1_000_000;
+    active_through = None;
   }
 
 (** Build [n] consecutive Friday weekly bars starting at [start_friday]. The
@@ -385,6 +386,7 @@ let test_support_floor_callbacks_parity _ =
           close_price = price;
           adjusted_close = price;
           volume = 100_000;
+          active_through = None;
         })
   in
   let cb = build_snapshot_callbacks [ ("AAPL", bars) ] in
@@ -565,6 +567,7 @@ let test_support_floor_snapshot_views_parity _ =
           close_price = price;
           adjusted_close = price;
           volume = 100_000;
+          active_through = None;
         })
   in
   let cb = build_snapshot_callbacks [ ("AAPL", bars) ] in

--- a/trading/trading/weinstein/strategy/test/test_short_side_bear_window.ml
+++ b/trading/trading/weinstein/strategy/test/test_short_side_bear_window.ml
@@ -65,6 +65,7 @@ let _make_bar ?(volume = 1000) date adjusted_close =
     close_price = adjusted_close;
     adjusted_close;
     volume;
+    active_through = None;
   }
 
 let _weekly_bars_with_volumes prices_and_volumes =

--- a/trading/trading/weinstein/strategy/test/test_stage3_force_exit_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stage3_force_exit_runner.ml
@@ -18,6 +18,7 @@ let make_bar date ~close ?low ?high () =
     close_price = close;
     adjusted_close = close;
     volume = 1_000_000;
+    active_through = None;
   }
 
 let stage3 = Weinstein_types.Stage3 { weeks_topping = 1 }

--- a/trading/trading/weinstein/strategy/test/test_stops_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_runner.ml
@@ -18,6 +18,7 @@ let make_bar date ~close ?low ?high () =
     close_price = close;
     adjusted_close = close;
     volume = 1_000_000;
+    active_through = None;
   }
 
 let get_price_of bars symbol = List.Assoc.find bars symbol ~equal:String.equal

--- a/trading/trading/weinstein/strategy/test/test_stops_split_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_split_runner.ml
@@ -39,6 +39,7 @@ let _make_bar ~date ~open_ ~high ~low ~close ~adjusted_close ~volume =
       close_price = close;
       adjusted_close;
       volume;
+      active_through = None;
     }
 
 (** Build a snapshot-backed [Bar_reader.t] from a single-symbol bar series. *)

--- a/trading/trading/weinstein/strategy/test/test_weekly_ma_cache.ml
+++ b/trading/trading/weinstein/strategy/test/test_weekly_ma_cache.ml
@@ -44,6 +44,7 @@ let make_weekly_bar ~date ~price =
     close_price = price;
     adjusted_close = price;
     volume = 1_000_000;
+    active_through = None;
   }
 
 let make_friday_bars ~start_friday ~n ~start_price ~step =

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -16,6 +16,7 @@ let make_bar date price =
     close_price = price;
     adjusted_close = price;
     volume = 1000;
+    active_through = None;
   }
 
 let get_price_of prices symbol =
@@ -677,6 +678,7 @@ let _make_friday_bars ~start_friday ~n ~start_price ~step =
         close_price = price;
         adjusted_close = price;
         volume = 1_000_000;
+        active_through = None;
       })
 
 (** Last date across every bar in [symbols_with_bars]. Mirrors the calendar's
@@ -763,6 +765,7 @@ let test_survivors_for_screening_drops_stage1_and_stage3 _ =
           close_price = p;
           adjusted_close = p;
           volume = 1_000_000;
+          active_through = None;
         })
   in
   (* Stage1: 15 weeks declining 100 → 86, then 50 weeks flat at 85. *)
@@ -837,6 +840,7 @@ let test_phase2_call_count_equals_survivor_count _ =
           close_price = p;
           adjusted_close = p;
           volume = 1_000_000;
+          active_through = None;
         })
   in
   let stage1_bars _seed =


### PR DESCRIPTION
## Summary

Phase 3 of the historical S&P 500 membership plan: add a typed
`active_through : Date.t option` field to `Types.Daily_price.t`. This
is the typed delisted-date marker that unblocks Phase 5 (screener
point-in-time filter) and gives survivorship-aware backtests on the
existing Wiki+EODHD substrate.

References:
- `dev/notes/historical-universe-status-2026-05-13.md` (merged via
  #1062) §2 action item 1 — "Phase 3: typed [active_through] field".
- `dev/notes/historical-universe-membership-2026-04-30.md` — original
  6-phase design (P3 in the parent doc).

## What changed

- **`trading/analysis/data/types/lib/daily_price.{ml,mli}`** — new
  `active_through : Date.t option` field on `t`; default `None` means
  "still trading / unknown delisting status". `Daily_price.make`
  helper accepts the optional argument for callers that don't want to
  spell out `active_through = None` in every literal.
- **`trading/analysis/data/storage/csv/lib/parser.ml`** — accepts
  both 7-column (legacy → `None`) and 8-column (new schema) input
  lines. Error message updated to "Expected 7 or 8 columns".
- **`trading/analysis/data/storage/csv/lib/csv_storage.ml`** — writes
  the new `active_through` column (empty cell when `None`); the
  header now has the column too. Legacy 7-column CSVs still load
  correctly via the parser's two-arm match.
- **`trading/analysis/data/sources/eodhd/lib/http_client.ml`** — bar
  parser leaves `active_through = None` (EODHD's `/api/eod` carries
  no delisting marker on bars; enrichment would come from
  fundamentals / delisted-symbol endpoint as a separate pass).
- **`trading/analysis/weinstein/snapshot_runtime/lib/snapshot_bar_views_helpers.ml`**
  — the snapshot daily-price assembly carries the new field
  (currently `None` since the snapshot path has no delisting source
  today — Phase 5 will plumb it through).
- **~127 call-sites** across 74 files updated to thread
  `active_through = None` in their `Types.Daily_price.t` record
  literals (mostly test fixture builders).

## Test plan

- [x] `dune build` — clean on a clean checkout
- [x] `dune runtest analysis/data/` — green (4 new tests in
  `test_daily_price.ml` + 3 new in `test_csv_parser.ml` + 2 new in
  `test_csv_storage.ml`)
- [x] `dune runtest analysis/weinstein/` — green
- [x] `dune runtest trading/weinstein/` — green
- [x] `dune runtest trading/backtest/` — green (goldens bit-equal:
  default `None` preserves existing fixture decoding)
- [x] `dune build @fmt` — clean
- [x] Round-trip golden: 8-column CSV with `Some d` + `None` rows
  loads back to the same record; legacy 7-column CSV loads with
  `active_through = None` for every row.

## A1 flag (qc-structural)

`Daily_price` is a base type, so the structural reviewer will FLAG
A1 (base type modification).

Mitigation: change is **strategy-agnostic** (broker-data-side, not
Weinstein-specific) — every strategy that consumes `Daily_price`
benefits from a typed delisted-date marker. Default `None` keeps all
existing CSVs / fixtures / goldens deserializing unchanged → no
behavior change in the simulator, runner, or scenarios. Phase 5 will
plumb the field through the screener's point-in-time filter.

## Follow-on

Phase 5 — screener point-in-time filter — is the natural next step
once this lands. `membership_at` callback in `Screener.screen`
keyed on `active_through` would close the survivorship-bias gap on
the existing 510-symbol 2010-01-01 universe without rebuilding the
universe shape.