### PR TITLE
feat(weinstein): continuation buys (Interpretation B, default-off) — implements #1074 §B

### DIFF
--- a/trading/analysis/weinstein/continuation/lib/continuation.ml
+++ b/trading/analysis/weinstein/continuation/lib/continuation.ml
@@ -46,6 +46,19 @@ let _compute_ma_slope ~(get_ma : week_offset:int -> float option) : float =
   | Some now, Some back when Float.( > ) back 0.0 -> (now -. back) /. back
   | _ -> 0.0
 
+(** [true] iff the close/MA ratio at [off] falls inside [band]. Returns [false]
+    when either reading is missing or the MA is non-positive — those offsets are
+    skipped, not treated as matches. Pulled out of the [_find_pullback_offset]
+    loop body to keep the loop's depth flat. *)
+let _offset_in_band ~callbacks ~band off : bool =
+  match
+    (callbacks.get_close ~week_offset:off, callbacks.get_ma ~week_offset:off)
+  with
+  | Some close, Some ma when Float.( > ) ma 0.0 ->
+      let ratio = close /. ma in
+      Float.( >= ) ratio band.low && Float.( <= ) ratio band.high
+  | _ -> false
+
 (** Scan offsets [1 .. lookback_weeks] for the most recent bar whose
     [close / ma_30w] sits inside [band]. Skip offset 0 deliberately — the
     current bar should be ABOVE the consolidation high (i.e. on a new breakout),
@@ -54,16 +67,8 @@ let _compute_ma_slope ~(get_ma : week_offset:int -> float option) : float =
 let _find_pullback_offset ~callbacks ~band ~lookback_weeks : int option =
   let rec loop off =
     if off > lookback_weeks then None
-    else
-      match
-        (callbacks.get_close ~week_offset:off, callbacks.get_ma ~week_offset:off)
-      with
-      | Some close, Some ma when Float.( > ) ma 0.0 ->
-          let ratio = close /. ma in
-          if Float.( >= ) ratio band.low && Float.( <= ) ratio band.high then
-            Some off
-          else loop (off + 1)
-      | _ -> loop (off + 1)
+    else if _offset_in_band ~callbacks ~band off then Some off
+    else loop (off + 1)
   in
   loop 1
 
@@ -100,6 +105,15 @@ let _scan_window ~callbacks ~n : (float * float * float) option =
     | Some h, Some l, Some c -> loop 2 h l c
     | _ -> None
 
+(** [Some hi] when the [weeks]-bar window's [(hi - lo) / avg_close <= range_pct]
+    and [avg_close > 0]; [None] otherwise. Split out from [_consolidation_high]
+    so the gate evaluation is a flat else-if chain (no nested-else). *)
+let _check_tight_window ~weeks ~range_pct ~hi ~lo ~sum : float option =
+  let avg = sum /. Float.of_int weeks in
+  if Float.( <= ) avg 0.0 then None
+  else if Float.( <= ) ((hi -. lo) /. avg) range_pct then Some hi
+  else None
+
 (** Check the consolidation-tightness gate over the last [weeks] bars. Returns
     [Some hi] when [(hi - lo) / avg_close <= range_pct], i.e. the window is
     tight enough to count as consolidation. [hi] is the window's highest [high],
@@ -108,12 +122,7 @@ let _scan_window ~callbacks ~n : (float * float * float) option =
 let _consolidation_high ~callbacks ~weeks ~range_pct : float option =
   match _scan_window ~callbacks ~n:weeks with
   | None -> None
-  | Some (hi, lo, sum) ->
-      let avg = sum /. Float.of_int weeks in
-      if Float.( <= ) avg 0.0 then None
-      else
-        let range_fraction = (hi -. lo) /. avg in
-        if Float.( <= ) range_fraction range_pct then Some hi else None
+  | Some (hi, lo, sum) -> _check_tight_window ~weeks ~range_pct ~hi ~lo ~sum
 
 (** Check the breakout-arm gate: the current close (offset 0) exceeds the
     consolidation high. Mirrors the book's "breaks out anew above the top of its

--- a/trading/analysis/weinstein/continuation/lib/continuation.ml
+++ b/trading/analysis/weinstein/continuation/lib/continuation.ml
@@ -1,0 +1,151 @@
+open Core
+
+type pullback_band = { low : float; high : float } [@@deriving sexp]
+
+type config = {
+  ma_slope_min : float;
+  pullback_band : pullback_band;
+  pullback_lookback_weeks : int;
+  consolidation_range_pct : float;
+  consolidation_weeks : int;
+}
+[@@deriving sexp]
+
+let default_config =
+  {
+    ma_slope_min = 0.01;
+    pullback_band = { low = 0.95; high = 1.05 };
+    pullback_lookback_weeks = 8;
+    consolidation_range_pct = 0.10;
+    consolidation_weeks = 4;
+  }
+
+type result = {
+  is_continuation : bool;
+  pullback_low : float option;
+  consolidation_high : float option;
+  ma_slope_observed : float;
+}
+[@@deriving sexp]
+
+type callbacks = {
+  get_ma : week_offset:int -> float option;
+  get_close : week_offset:int -> float option;
+  get_high : week_offset:int -> float option;
+  get_low : week_offset:int -> float option;
+}
+
+(** Compute the MA slope as a fraction over [_slope_lookback_weeks] weeks:
+    [(ma_now - ma_back) / ma_back]. Returns [0.0] when either reading is
+    unavailable or [ma_back] is non-positive (treats as "no slope evidence",
+    which fails the [ma_slope_min] gate). *)
+let _slope_lookback_weeks = 4
+
+let _compute_ma_slope ~(get_ma : week_offset:int -> float option) : float =
+  match (get_ma ~week_offset:0, get_ma ~week_offset:_slope_lookback_weeks) with
+  | Some now, Some back when Float.( > ) back 0.0 -> (now -. back) /. back
+  | _ -> 0.0
+
+(** Scan offsets [1 .. lookback_weeks] for the most recent bar whose
+    [close / ma_30w] sits inside [band]. Skip offset 0 deliberately — the
+    current bar should be ABOVE the consolidation high (i.e. on a new breakout),
+    not in the pullback band. Returns the offset of the matching bar, or [None].
+*)
+let _find_pullback_offset ~callbacks ~band ~lookback_weeks : int option =
+  let rec loop off =
+    if off > lookback_weeks then None
+    else
+      match
+        (callbacks.get_close ~week_offset:off, callbacks.get_ma ~week_offset:off)
+      with
+      | Some close, Some ma when Float.( > ) ma 0.0 ->
+          let ratio = close /. ma in
+          if Float.( >= ) ratio band.low && Float.( <= ) ratio band.high then
+            Some off
+          else loop (off + 1)
+      | _ -> loop (off + 1)
+  in
+  loop 1
+
+(** Fold high/low/close over offsets [1 .. n]. The current bar (offset 0) is
+    DELIBERATELY excluded — the consolidation window measures the base the stock
+    just broke out of; including offset 0 would mean the breakout bar's high
+    becomes the level the breakout must exceed, which is self-defeating.
+
+    Returns [Some (high, low, sum_close)] iff every offset returned a defined
+    bar; [None] on the first hole (mirrors the contiguous-tail semantics used by
+    {!Stock_analysis._count_defined}). *)
+let _scan_window ~callbacks ~n : (float * float * float) option =
+  let rec loop off hi lo sum =
+    if off > n then Some (hi, lo, sum)
+    else
+      match
+        ( callbacks.get_high ~week_offset:off,
+          callbacks.get_low ~week_offset:off,
+          callbacks.get_close ~week_offset:off )
+      with
+      | Some h, Some l, Some c ->
+          let hi' = Float.max hi h in
+          let lo' = Float.min lo l in
+          loop (off + 1) hi' lo' (sum +. c)
+      | _ -> None
+  in
+  if n < 1 then None
+  else
+    match
+      ( callbacks.get_high ~week_offset:1,
+        callbacks.get_low ~week_offset:1,
+        callbacks.get_close ~week_offset:1 )
+    with
+    | Some h, Some l, Some c -> loop 2 h l c
+    | _ -> None
+
+(** Check the consolidation-tightness gate over the last [weeks] bars. Returns
+    [Some hi] when [(hi - lo) / avg_close <= range_pct], i.e. the window is
+    tight enough to count as consolidation. [hi] is the window's highest [high],
+    used downstream as the breakout level. [None] when the window is incomplete
+    or fails the range gate. *)
+let _consolidation_high ~callbacks ~weeks ~range_pct : float option =
+  match _scan_window ~callbacks ~n:weeks with
+  | None -> None
+  | Some (hi, lo, sum) ->
+      let avg = sum /. Float.of_int weeks in
+      if Float.( <= ) avg 0.0 then None
+      else
+        let range_fraction = (hi -. lo) /. avg in
+        if Float.( <= ) range_fraction range_pct then Some hi else None
+
+(** Check the breakout-arm gate: the current close (offset 0) exceeds the
+    consolidation high. Mirrors the book's "breaks out anew above the top of its
+    resistance zone". Returns [false] when the current close is missing. *)
+let _current_close_above ~(get_close : week_offset:int -> float option) ~level :
+    bool =
+  match get_close ~week_offset:0 with
+  | Some c -> Float.( > ) c level
+  | None -> false
+
+let analyze_with_callbacks ~(config : config) ~(callbacks : callbacks) : result
+    =
+  let ma_slope_observed = _compute_ma_slope ~get_ma:callbacks.get_ma in
+  let slope_ok = Float.( >= ) ma_slope_observed config.ma_slope_min in
+  let pullback_off_opt =
+    _find_pullback_offset ~callbacks ~band:config.pullback_band
+      ~lookback_weeks:config.pullback_lookback_weeks
+  in
+  let pullback_low =
+    Option.bind pullback_off_opt ~f:(fun off ->
+        callbacks.get_low ~week_offset:off)
+  in
+  let consolidation_high =
+    _consolidation_high ~callbacks ~weeks:config.consolidation_weeks
+      ~range_pct:config.consolidation_range_pct
+  in
+  let breakout_ok =
+    match consolidation_high with
+    | Some level -> _current_close_above ~get_close:callbacks.get_close ~level
+    | None -> false
+  in
+  let is_continuation =
+    slope_ok && Option.is_some pullback_off_opt && breakout_ok
+  in
+  { is_continuation; pullback_low; consolidation_high; ma_slope_observed }

--- a/trading/analysis/weinstein/continuation/lib/continuation.mli
+++ b/trading/analysis/weinstein/continuation/lib/continuation.mli
@@ -1,0 +1,98 @@
+(** Continuation-buy detector for Weinstein's Ch. 3 "continuation buy" pattern.
+
+    A continuation buy is a late-Stage-2 re-entry pattern: a stock already in a
+    clear Stage 2 advance pulls back to its 30-week MA, consolidates near the MA
+    for a few weeks, and then breaks out anew above the top of the
+    consolidation. The book treats this as a second-chance buy when the initial
+    breakout was missed, BUT only when the MA is clearly trending higher (a
+    flattening MA disqualifies — see [ma_slope_min]).
+
+    Authority: [docs/design/weinstein-book-reference.md] §4.6 "Continuation Buys
+    (Ch. 3)" and the design plan [dev/plans/continuation-buys-2026-05-13.md].
+
+    This module implements Interpretation B from the plan: detection of the
+    pattern so it can be admitted as a NEW position-entering candidate (for
+    symbols not already held). Interpretation A (pyramid adds to existing
+    holdings) is deferred behind a core-module decision.
+
+    All functions are pure. *)
+
+type pullback_band = { low : float; high : float } [@@deriving sexp]
+(** Acceptable range of [close / ma_30w] at the pullback bar. Default:
+    [{ low = 0.95; high = 1.05 }]. A bar's close/MA ratio inside this band
+    counts as "pulled back close to the MA" for §3.(b). *)
+
+type config = {
+  ma_slope_min : float;
+      (** Minimum MA slope (as a fraction over [Stage.config.slope_lookback]
+          weeks) for §3.(a). The book wants the MA "clearly trending higher" — a
+          stricter threshold than the Stage classifier's [slope_threshold]
+          (which only distinguishes Flat from Rising). Default: 0.01 (1% over
+          the slope-lookback window). *)
+  pullback_band : pullback_band;
+      (** Acceptable [close / ma_30w] range at the pullback bar. Default:
+          [{ low = 0.95; high = 1.05 }]. *)
+  pullback_lookback_weeks : int;
+      (** How many weeks back to scan for a pullback bar. Default: 8. *)
+  consolidation_range_pct : float;
+      (** Maximum [(window_high - window_low) / avg_close] over the
+          consolidation window for §3.(c). Default: 0.10 (10%). *)
+  consolidation_weeks : int;
+      (** Number of bars (ending at the as-of bar) used to compute the
+          consolidation range. Default: 4. *)
+}
+[@@deriving sexp]
+(** Detector configuration. All thresholds are configurable to enable parameter
+    tuning via backtesting. *)
+
+val default_config : config
+(** [default_config] provides sensible defaults per the design plan §8. *)
+
+type result = {
+  is_continuation : bool;
+      (** [true] iff all five preconditions (a)-(e) fired. (e) — volume
+          confirmation — is left to the {!Stock_analysis} caller, which has
+          access to the existing [Volume.result]. This module checks (a)-(d): MA
+          slope, pullback proximity, consolidation tightness, and recent new
+          high above the consolidation top. *)
+  pullback_low : float option;
+      (** Low of the bar identified as the pullback bar (the bar in the lookback
+          window whose [close / ma_30w] sits inside [pullback_band]). Used by
+          the caller as the structural stop floor for the continuation entry.
+          [None] when no pullback bar was identified. *)
+  consolidation_high : float option;
+      (** Highest [high] across the [consolidation_weeks] bars BEFORE the
+          current bar (offsets 1 .. consolidation_weeks). The current bar
+          (offset 0) is intentionally excluded — it represents the breakout,
+          which must exceed the base it just left. [None] when the window is
+          incomplete or when the range gate failed. *)
+  ma_slope_observed : float;
+      (** The MA slope read from the stage callbacks. Surfaced so the caller
+          (and tests) can sanity-check the slope-floor gate. *)
+}
+[@@deriving sexp]
+(** Detector output. *)
+
+type callbacks = {
+  get_ma : week_offset:int -> float option;
+      (** 30-week MA at [week_offset] weeks back (offset 0 = current). *)
+  get_close : week_offset:int -> float option;
+      (** Bar close at [week_offset] weeks back. *)
+  get_high : week_offset:int -> float option;
+      (** Bar high at [week_offset] weeks back. *)
+  get_low : week_offset:int -> float option;
+      (** Bar low at [week_offset] weeks back. *)
+}
+(** Bundle of indicator callbacks consumed by {!analyze_with_callbacks}. Shaped
+    to be trivially constructed from {!Stock_analysis.callbacks} (the [stage]
+    sub-bundle plus [get_high] / a [get_low] adapter). *)
+
+val analyze_with_callbacks : config:config -> callbacks:callbacks -> result
+(** [analyze_with_callbacks ~config ~callbacks] runs the four-precondition
+    detection ((a) MA slope ≥ [ma_slope_min], (b) pullback to MA inside
+    [pullback_band] within [pullback_lookback_weeks], (c) consolidation range ≤
+    [consolidation_range_pct] over [consolidation_weeks], (d) current close
+    above the consolidation high). Returns a {!result} whose [is_continuation]
+    field is [true] iff all four fired.
+
+    Pure function: same callback outputs always produce the same result. *)

--- a/trading/analysis/weinstein/continuation/lib/dune
+++ b/trading/analysis/weinstein/continuation/lib/dune
@@ -1,0 +1,7 @@
+(library
+ (name continuation)
+ (public_name weinstein.continuation)
+ (wrapped false)
+ (libraries core)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/analysis/weinstein/continuation/test/dune
+++ b/trading/analysis/weinstein/continuation/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_continuation)
+ (libraries continuation core ounit2 matchers))

--- a/trading/analysis/weinstein/continuation/test/test_continuation.ml
+++ b/trading/analysis/weinstein/continuation/test/test_continuation.ml
@@ -1,0 +1,241 @@
+open OUnit2
+open Core
+open Matchers
+open Continuation
+
+(* ------------------------------------------------------------------ *)
+(* Synthetic-callback builder                                          *)
+(*                                                                      *)
+(* The detector reads [get_ma], [get_close], [get_high], [get_low] at  *)
+(* weekly offsets. Tests build an explicit array per metric so each    *)
+(* precondition can be flipped independently. Offset 0 = most recent   *)
+(* bar; offsets grow back in time. Missing offsets return [None].      *)
+(* ------------------------------------------------------------------ *)
+
+let _make_get arr ~week_offset =
+  let n = Array.length arr in
+  if week_offset < 0 || week_offset >= n then None else Some arr.(week_offset)
+
+let make_callbacks ~ma ~close ~high ~low : callbacks =
+  {
+    get_ma = _make_get (Array.of_list ma);
+    get_close = _make_get (Array.of_list close);
+    get_high = _make_get (Array.of_list high);
+    get_low = _make_get (Array.of_list low);
+  }
+
+let cfg = default_config
+
+(* ------------------------------------------------------------------ *)
+(* Precondition (a): MA slope ≥ ma_slope_min                            *)
+(* ------------------------------------------------------------------ *)
+
+(** MA values trace a clearly-rising series: offset 0 = 100.0, offset 4 = 95.0 →
+    slope ≈ 5.3%. Default [ma_slope_min] is 1%. Precondition (a) fires. MA stays
+    around 95-100 across the relevant window so the pullback-band bar sits at
+    offset 5 (close 95 / ma 95 = 1.0) — outside the [consolidation_weeks = 4]
+    window (offsets 1..4). *)
+let _rising_ma = [ 100.0; 99.0; 98.0; 97.0; 96.0; 95.0; 95.0; 95.0; 95.0; 95.0 ]
+
+(** MA values flat: slope = 0%. Fails precondition (a) regardless of the other
+    gates. *)
+let _flat_ma =
+  [ 100.0; 100.0; 100.0; 100.0; 100.0; 100.0; 100.0; 100.0; 100.0; 100.0 ]
+
+(** Close series: bar 0 = 130 (new breakout above 125 consolidation high); bars
+    1-4 inside consolidation [120, 125] (ratio ≈ 1.20+, outside pullback band);
+    bar 5 in pullback band (close 95 / ma 95 = 1.0); bars 6-9 earlier. *)
+let _close_with_pullback =
+  [ 130.0; 124.0; 123.0; 121.0; 120.0; 95.0; 92.0; 89.0; 86.0; 83.0 ]
+
+let _high_with_consolidation =
+  [ 131.0; 125.0; 124.0; 122.0; 121.0; 96.0; 93.0; 90.0; 87.0; 84.0 ]
+
+let _low_with_pullback =
+  [ 129.0; 121.0; 120.0; 118.0; 117.0; 90.0; 88.0; 85.0; 82.0; 79.0 ]
+
+(** Happy-path cfg: default [consolidation_weeks = 4] (scans offsets 1..4).
+    Highs in window: 125, 124, 122, 121 → max = 125. Lows: 121, 120, 118, 117 →
+    min = 117. Closes: 124, 123, 121, 120 → sum = 488, avg = 122. Range = (125 -
+    117) / 122 ≈ 0.066 < default 10% — consolidation gate OK. Pullback scan
+    (offsets 1..8 by default): offset 5 has close 95 / ma 95 = 1.0 ∈
+    [0.95, 1.05]. Earlier offsets (1..4) have ratios 1.20+, outside.
+    pullback_low = low at offset 5 = 90.0. Breakout check: close[0] = 130 >
+    consolidation_high = 125 → passes. *)
+let _happy_cfg = cfg
+
+let test_happy_path_all_preconditions_satisfied _ =
+  let callbacks =
+    make_callbacks ~ma:_rising_ma ~close:_close_with_pullback
+      ~high:_high_with_consolidation ~low:_low_with_pullback
+  in
+  let result = analyze_with_callbacks ~config:_happy_cfg ~callbacks in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : result) -> r.is_continuation) (equal_to true);
+         field
+           (fun (r : result) -> r.pullback_low)
+           (is_some_and (float_equal 90.0));
+         field
+           (fun (r : result) -> r.consolidation_high)
+           (is_some_and (float_equal 125.0));
+       ])
+
+(** MA flat → precondition (a) fails; [is_continuation = false] even though
+    (b)-(d) would otherwise fire. *)
+let test_flat_ma_blocks_continuation _ =
+  let callbacks =
+    make_callbacks ~ma:_flat_ma ~close:_close_with_pullback
+      ~high:_high_with_consolidation ~low:_low_with_pullback
+  in
+  let result = analyze_with_callbacks ~config:_happy_cfg ~callbacks in
+  assert_that result.is_continuation (equal_to false)
+
+(* ------------------------------------------------------------------ *)
+(* Precondition (b): pullback to MA inside [pullback_band]              *)
+(* ------------------------------------------------------------------ *)
+
+(** Closes that never touch the MA — all far above (ratio > 1.05). No pullback
+    bar found. Precondition (b) fails. Closes 130..123 against MA 100..95 →
+    ratios 1.30..1.29, all outside [0.95, 1.05]. *)
+let test_no_pullback_blocks_continuation _ =
+  let close =
+    [ 130.0; 125.0; 128.0; 127.0; 126.0; 125.0; 124.0; 123.0; 122.0; 121.0 ]
+  in
+  let high =
+    [ 132.0; 126.0; 129.0; 128.0; 127.0; 126.0; 125.0; 124.0; 123.0; 122.0 ]
+  in
+  let low =
+    [ 128.0; 123.0; 126.0; 125.0; 124.0; 123.0; 122.0; 121.0; 120.0; 119.0 ]
+  in
+  let callbacks = make_callbacks ~ma:_rising_ma ~close ~high ~low in
+  let result = analyze_with_callbacks ~config:_happy_cfg ~callbacks in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : result) -> r.is_continuation) (equal_to false);
+         field (fun (r : result) -> r.pullback_low) is_none;
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Precondition (c): consolidation range tight enough                    *)
+(* ------------------------------------------------------------------ *)
+
+(** Same setup as the happy path but the consolidation window is wide (range >
+    10%). Precondition (c) fails → no consolidation_high. The single spiked high
+    (250) at offset 2 blows up the range. *)
+let test_wide_consolidation_blocks_continuation _ =
+  let high =
+    [ 131.0; 125.0; 250.0; 122.0; 121.0; 96.0; 93.0; 90.0; 87.0; 84.0 ]
+  in
+  let callbacks =
+    make_callbacks ~ma:_rising_ma ~close:_close_with_pullback ~high
+      ~low:_low_with_pullback
+  in
+  let result = analyze_with_callbacks ~config:_happy_cfg ~callbacks in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : result) -> r.is_continuation) (equal_to false);
+         field (fun (r : result) -> r.consolidation_high) is_none;
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Precondition (d): current close > consolidation_high                  *)
+(* ------------------------------------------------------------------ *)
+
+(** Consolidation high is 125 but the current close is only 123 — no new
+    breakout. Precondition (d) fails. consolidation_high is still surfaced (the
+    consolidation gate fired); only is_continuation is false. *)
+let test_no_new_breakout_blocks_continuation _ =
+  let close =
+    [ 123.0; 124.0; 123.0; 121.0; 120.0; 95.0; 92.0; 89.0; 86.0; 83.0 ]
+  in
+  let callbacks =
+    make_callbacks ~ma:_rising_ma ~close ~high:_high_with_consolidation
+      ~low:_low_with_pullback
+  in
+  let result = analyze_with_callbacks ~config:_happy_cfg ~callbacks in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : result) -> r.is_continuation) (equal_to false);
+         field
+           (fun (r : result) -> r.consolidation_high)
+           (is_some_and (float_equal 125.0));
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Lookback truncation                                                  *)
+(* ------------------------------------------------------------------ *)
+
+(** When [pullback_lookback_weeks] is 3, the scan covers offsets 1-3 only. The
+    pullback bar at offset 5 (close 95 / ma 95 = 1.0) sits past the window.
+    Closes 124, 123, 121 against MA 99, 98, 97 → ratios 1.25+, outside band.
+    Precondition (b) fails. *)
+let test_pullback_outside_lookback_window _ =
+  let tighter_cfg = { _happy_cfg with pullback_lookback_weeks = 3 } in
+  let callbacks =
+    make_callbacks ~ma:_rising_ma ~close:_close_with_pullback
+      ~high:_high_with_consolidation ~low:_low_with_pullback
+  in
+  let result = analyze_with_callbacks ~config:tighter_cfg ~callbacks in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : result) -> r.is_continuation) (equal_to false);
+         field (fun (r : result) -> r.pullback_low) is_none;
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Empty callback bundle                                                *)
+(* ------------------------------------------------------------------ *)
+
+(** Every callback returns [None]. Detector returns [is_continuation = false]
+    without crashing. *)
+let test_empty_callbacks_no_continuation _ =
+  let callbacks = make_callbacks ~ma:[] ~close:[] ~high:[] ~low:[] in
+  let result = analyze_with_callbacks ~config:cfg ~callbacks in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : result) -> r.is_continuation) (equal_to false);
+         field (fun (r : result) -> r.pullback_low) is_none;
+         field (fun (r : result) -> r.consolidation_high) is_none;
+         field (fun (r : result) -> r.ma_slope_observed) (float_equal 0.0);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Purity                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let test_pure_same_inputs _ =
+  let callbacks =
+    make_callbacks ~ma:_rising_ma ~close:_close_with_pullback
+      ~high:_high_with_consolidation ~low:_low_with_pullback
+  in
+  let r1 = analyze_with_callbacks ~config:_happy_cfg ~callbacks in
+  let r2 = analyze_with_callbacks ~config:_happy_cfg ~callbacks in
+  assert_that r1.is_continuation (equal_to r2.is_continuation)
+
+let suite =
+  "continuation_tests"
+  >::: [
+         "happy path: all preconditions satisfied"
+         >:: test_happy_path_all_preconditions_satisfied;
+         "flat MA blocks continuation" >:: test_flat_ma_blocks_continuation;
+         "no pullback to MA blocks continuation"
+         >:: test_no_pullback_blocks_continuation;
+         "wide consolidation blocks continuation"
+         >:: test_wide_consolidation_blocks_continuation;
+         "no new breakout above consolidation blocks continuation"
+         >:: test_no_new_breakout_blocks_continuation;
+         "pullback outside lookback window"
+         >:: test_pullback_outside_lookback_window;
+         "empty callbacks no continuation"
+         >:: test_empty_callbacks_no_continuation;
+         "pure: same inputs produce same result" >:: test_pure_same_inputs;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/weinstein/stock_analysis/lib/dune
+++ b/trading/analysis/weinstein/stock_analysis/lib/dune
@@ -2,6 +2,15 @@
  (name stock_analysis)
  (public_name weinstein.stock_analysis)
  (wrapped false)
- (libraries core types weinstein_types stage rs volume resistance support)
+ (libraries
+  core
+  types
+  weinstein_types
+  stage
+  rs
+  volume
+  resistance
+  support
+  continuation)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq)))

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
@@ -24,6 +24,9 @@ type config = {
   base_end_offset_weeks : int;
       (** How many recent bars to exclude from the base search (avoids counting
           the current advance as part of the base). Default: 8. *)
+  continuation : Continuation.config option;
+      (** When [Some cfg], the continuation-buy detector runs; when [None]
+          (default), it is skipped. See .mli for full semantics. *)
 }
 
 let default_config =
@@ -35,6 +38,7 @@ let default_config =
     breakout_event_lookback = 8;
     base_lookback_weeks = 52;
     base_end_offset_weeks = 8;
+    continuation = None;
   }
 
 type t = {
@@ -47,6 +51,7 @@ type t = {
   breakout_price : float option;
   breakdown_price : float option;
   prior_stage : stage option;
+  continuation : Continuation.result option;
   as_of_date : Date.t;
 }
 
@@ -299,6 +304,29 @@ let _support_result ~(config : config)
       Support.analyze_with_callbacks ~config:config.resistance
         ~callbacks:resistance_callbacks ~breakdown_price:bp ~as_of_date)
 
+(** Build a {!Continuation.callbacks} bundle from this module's callbacks (Stage
+    \+ Resistance sub-bundles + our own [get_high]). [get_low] adapts the
+    Resistance callback's [~bar_offset] naming to Continuation's [~week_offset]
+    — both indices mean "offset back from the newest bar" in weekly cadence. *)
+let _continuation_callbacks_of (callbacks : callbacks) : Continuation.callbacks
+    =
+  {
+    get_ma = callbacks.stage.get_ma;
+    get_close = callbacks.stage.get_close;
+    get_high = callbacks.get_high;
+    get_low =
+      (fun ~week_offset -> callbacks.resistance.get_low ~bar_offset:week_offset);
+  }
+
+(** Run the continuation detector when [config.continuation = Some cfg]; return
+    [None] otherwise (feature off). *)
+let _continuation_result ~(config : config) ~(callbacks : callbacks) :
+    Continuation.result option =
+  Option.map config.continuation ~f:(fun cont_cfg ->
+      let cont_callbacks = _continuation_callbacks_of callbacks in
+      Continuation.analyze_with_callbacks ~config:cont_cfg
+        ~callbacks:cont_callbacks)
+
 (* ------------------------------------------------------------------ *)
 (* Main analyzer — callback shape                                       *)
 (* ------------------------------------------------------------------ *)
@@ -353,6 +381,7 @@ let analyze_with_callbacks ~(config : config) ~ticker ~(callbacks : callbacks)
     _support_result ~config ~resistance_callbacks:callbacks.resistance
       ~as_of_date ~breakdown_price
   in
+  let continuation = _continuation_result ~config ~callbacks in
   {
     ticker;
     stage = stage_result;
@@ -363,6 +392,7 @@ let analyze_with_callbacks ~(config : config) ~ticker ~(callbacks : callbacks)
     breakout_price;
     breakdown_price;
     prior_stage;
+    continuation;
     as_of_date;
   }
 
@@ -379,14 +409,27 @@ let analyze ~(config : config) ~ticker ~bars ~benchmark_bars ~prior_stage
 (* Candidate predicates                                                 *)
 (* ------------------------------------------------------------------ *)
 
+(** Initial-breakout arm (pre-existing): Stage1→Stage2 transition, or fresh
+    Stage2 with [weeks_advancing ≤ 4]. Mature Stage2 symbols (the cascade's
+    blind spot per dev/notes/capital-recycling-framing-2026-05-06.md) are
+    rejected by this arm but admitted by the continuation arm when enabled. *)
+let _initial_breakout_arm (a : t) : bool =
+  match (a.stage.stage, a.prior_stage) with
+  | Stage2 _, Some (Stage1 _) -> true
+  | Stage2 { weeks_advancing; late = false }, _ -> weeks_advancing <= 4
+  | _ -> false
+
+(** Continuation-buy arm (Interpretation B of issue #889). Active only when
+    [a.continuation = Some r] (the detector ran AND found a hit). Restricted to
+    symbols currently in Stage 2 — the book's continuation pattern only fires
+    inside an existing Stage 2 advance. *)
+let _continuation_arm (a : t) : bool =
+  match (a.continuation, a.stage.stage) with
+  | Some { is_continuation = true; _ }, Stage2 _ -> true
+  | _ -> false
+
 let is_breakout_candidate (a : t) : bool =
-  (* Stage 2 transition from Stage 1, with rising MA *)
-  let stage_ok =
-    match (a.stage.stage, a.prior_stage) with
-    | Stage2 _, Some (Stage1 _) -> true
-    | Stage2 { weeks_advancing; late = false }, _ -> weeks_advancing <= 4
-    | _ -> false
-  in
+  let stage_ok = _initial_breakout_arm a || _continuation_arm a in
   (* Volume confirmation: at least Adequate *)
   let volume_ok =
     match a.volume with

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.mli
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.mli
@@ -21,6 +21,15 @@ type config = {
           (~1 year). *)
   base_end_offset_weeks : int;
       (** How many recent bars to exclude from the base search. Default: 8. *)
+  continuation : Continuation.config option;
+      (** When [Some cfg], the continuation-buy detector (Weinstein Ch. 3
+          "continuation buy") runs and populates {!t.continuation}, which then
+          feeds the OR-arm in {!is_breakout_candidate}. When [None] (default),
+          the detector is skipped and {!t.continuation} is [None] — preserves
+          bit-equality with pre-feature behaviour. Gated at this level so
+          callers (strategy / screener) can enable continuation buys via
+          [Weinstein_strategy_config.enable_continuation_buys] without touching
+          tests that rely on bit-equal screener output. *)
 }
 (** Configuration bundling all sub-module configs. *)
 
@@ -51,6 +60,13 @@ type t = {
           [(base_end_offset_weeks .. base_lookback_weeks)]. *)
   prior_stage : Weinstein_types.stage option;
       (** Stage from the previous week, passed forward for transition tracking.
+      *)
+  continuation : Continuation.result option;
+      (** Continuation-buy detector output. [None] when
+          [config.continuation = None] (default — feature off) OR when the
+          underlying callbacks couldn't compute the result. [Some r] with
+          [r.is_continuation = true] indicates the bar matches Weinstein's Ch. 3
+          continuation pattern and feeds the OR-arm in {!is_breakout_candidate}.
       *)
   as_of_date : Core.Date.t;  (** The date this analysis was computed. *)
 }
@@ -164,6 +180,15 @@ val is_breakout_candidate : t -> bool
 (** [is_breakout_candidate analysis] returns true if the stock shows a potential
     Stage 2 breakout: transitioning from Stage 1, with rising MA and strong
     volume.
+
+    OR-arm (Interpretation B of issue #889): a stock that has [Some r] in
+    {!t.continuation} with [r.is_continuation = true] also qualifies, even when
+    the Stage1→Stage2 transition is no longer in scope ([weeks_advancing > 4]).
+    This admits the Weinstein Ch. 3 "continuation buy" pattern as a new-position
+    candidate when [config.continuation = Some _].
+
+    Volume confirmation (Strong / Adequate) and the RS-not-negative-declining
+    gate apply to both arms equally.
 
     Uses the sub-analysis results directly — no additional I/O. *)
 

--- a/trading/analysis/weinstein/stock_analysis/test/dune
+++ b/trading/analysis/weinstein/stock_analysis/test/dune
@@ -8,6 +8,7 @@
   rs
   volume
   resistance
+  continuation
   types
   core
   ounit2

--- a/trading/analysis/weinstein/stock_analysis/test/test_stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/test/test_stock_analysis.ml
@@ -410,6 +410,92 @@ let test_no_split_no_truncation _ =
      bound to confirm truncation didn't fire spuriously. *)
   assert_that result.breakout_price (is_some_and (gt (module Float_ord) 100.0))
 
+(* ------------------------------------------------------------------ *)
+(* Continuation buys — Interpretation B of issue #889                   *)
+(*                                                                      *)
+(* The continuation arm of [is_breakout_candidate] only fires when      *)
+(* [config.continuation = Some _]. The default config keeps it [None]   *)
+(* so the existing screener tests remain bit-equal.                     *)
+(* ------------------------------------------------------------------ *)
+
+(** Build a Stage-2 stock with a pullback-then-breakout shape:
+    - rising trend up to bar [n-12]
+    - pullback (close back near MA) at bar [n-6]
+    - tight consolidation bars [n-5..n-2]
+    - fresh breakout bar at [n-1] (the as-of bar)
+
+    With [n = 60] this puts the continuation pattern inside the default
+    [pullback_lookback_weeks = 8] window. *)
+let _continuation_shape_bars =
+  let bars = ref [] in
+  (* Phase 1: rising bars 0..47 (Stage 2 advance) *)
+  for i = 0 to 47 do
+    bars := make_bar i (50.0 +. (Float.of_int i *. 1.5)) 1000 :: !bars
+  done;
+  (* Phase 2: pullback at bars 48-52 *)
+  let pullback_prices = [ 110.0; 108.0; 106.0; 105.0; 105.0 ] in
+  List.iteri pullback_prices ~f:(fun k p ->
+      let i = 48 + k in
+      bars := make_bar i p 1000 :: !bars);
+  (* Phase 3: consolidation at bars 53-58 *)
+  let consol_prices = [ 110.0; 112.0; 111.0; 113.0; 114.0; 115.0 ] in
+  List.iteri consol_prices ~f:(fun k p ->
+      let i = 53 + k in
+      bars := make_bar i p 1000 :: !bars);
+  (* Phase 4: breakout at bar 59 with a strong volume spike (3x) so the
+     volume gate also fires. *)
+  bars := make_bar 59 130.0 3000 :: !bars;
+  List.rev !bars
+
+(** With [config.continuation = None] (default), a mature Stage-2 symbol fails
+    the initial-breakout arm ([weeks_advancing > 4] without
+    [prior_stage = Stage1]) and is NOT admitted. *)
+let test_continuation_default_off_keeps_existing_rejection _ =
+  let bars = _continuation_shape_bars in
+  let bench = rising_bars ~n:60 80.0 110.0 in
+  let prior = Some (Stage2 { weeks_advancing = 10; late = false }) in
+  let result =
+    analyze ~config:cfg ~ticker:"X" ~bars ~benchmark_bars:bench
+      ~prior_stage:prior ~as_of_date:as_of
+  in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : Stock_analysis.t) -> r.continuation) is_none;
+         field
+           (fun (r : Stock_analysis.t) -> is_breakout_candidate r)
+           (equal_to false);
+       ])
+
+(** With [config.continuation = Some _], the same mature Stage-2 symbol IS
+    admitted via the continuation OR-arm because the bars show the
+    pullback-then-breakout pattern. Pins the design plan's "B-1 approach" (issue
+    #889) integration site. *)
+let test_continuation_enabled_admits_mature_stage2 _ =
+  let bars = _continuation_shape_bars in
+  let bench = rising_bars ~n:60 80.0 110.0 in
+  let prior = Some (Stage2 { weeks_advancing = 10; late = false }) in
+  let cfg_on = { cfg with continuation = Some Continuation.default_config } in
+  let result =
+    analyze ~config:cfg_on ~ticker:"X" ~bars ~benchmark_bars:bench
+      ~prior_stage:prior ~as_of_date:as_of
+  in
+  (* Sanity: the detector fired (continuation field populated). The OR-arm
+     of [is_breakout_candidate] also fires. *)
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Stock_analysis.t) -> r.continuation)
+           (is_some_and
+              (field
+                 (fun (c : Continuation.result) -> c.is_continuation)
+                 (equal_to true)));
+         field
+           (fun (r : Stock_analysis.t) -> is_breakout_candidate r)
+           (equal_to true);
+       ])
+
 let suite =
   "stock_analysis_tests"
   >::: [
@@ -445,6 +531,10 @@ let suite =
          "G14: breakdown truncates at split boundary"
          >:: test_breakdown_truncates_at_split_boundary;
          "G14: no split, no truncation" >:: test_no_split_no_truncation;
+         "continuation default off keeps existing rejection"
+         >:: test_continuation_default_off_keeps_existing_rejection;
+         "continuation enabled admits mature stage2"
+         >:: test_continuation_enabled_admits_mature_stage2;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml
@@ -82,6 +82,7 @@ let make_analysis ?(ticker = "AAPL")
     breakout_price;
     breakdown_price = None;
     prior_stage;
+    continuation = None;
     as_of_date;
   }
 

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -22,6 +22,7 @@
   weinstein.sector
   weinstein.screener
   weinstein.stock_analysis
+  weinstein.continuation
   indicators.types
   indicators.sma
   indicators.ema

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -72,6 +72,11 @@ let _handle_stop_out_transition ~last_stop_out_dates ~positions ~current_date
       | None -> ())
   | _ -> ()
 
+(* Stamp the cooldown table for one position-id, no-op when the position has
+   already been pruned. Extracted from [_record_force_exit] so the nested
+   match against [_symbol_of_position_id] doesn't push depth past the linter's
+   max-5 ceiling. *)
+
 (** Record stage3 / laggard force-exit dates into [last_stop_out_dates] when the
     corresponding reentry cooldown knob is enabled. Re-uses the existing
     [Screener.screen_with_cooldown] gate (which keys on [last_stop_out_dates])
@@ -81,6 +86,12 @@ let _handle_stop_out_transition ~last_stop_out_dates ~positions ~current_date
     [cascade_post_stop_cooldown_weeks] is the responsibility of a follow-up: the
     screener applies a single window today; widening that to a per-source window
     is out of scope for the continuation-buys PR (issue #889). *)
+let _stamp_cooldown ~last_stop_out_dates ~positions ~current_date position_id =
+  match _symbol_of_position_id ~positions position_id with
+  | Some symbol ->
+      Hashtbl.set last_stop_out_dates ~key:symbol ~data:current_date
+  | None -> ()
+
 let _record_force_exit ~last_stop_out_dates ~positions ~current_date
     ~cooldown_weeks ~(label : string) (t : Position.transition) =
   if cooldown_weeks <= 0 then ()
@@ -88,11 +99,9 @@ let _record_force_exit ~last_stop_out_dates ~positions ~current_date
     match t.kind with
     | Position.TriggerExit
         { exit_reason = Position.StrategySignal { label = l; _ }; _ }
-      when String.equal l label -> (
-        match _symbol_of_position_id ~positions t.position_id with
-        | Some symbol ->
-            Hashtbl.set last_stop_out_dates ~key:symbol ~data:current_date
-        | None -> ())
+      when String.equal l label ->
+        _stamp_cooldown ~last_stop_out_dates ~positions ~current_date
+          t.position_id
     | _ -> ()
 
 let _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
@@ -117,6 +126,23 @@ let _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
          ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
          ~bar_reader ~prior_stages ~positions);
   (exit_transitions, adjust_transitions)
+
+let _run_laggard_rotation ~config ~positions ~last_stop_out_dates ~bar_reader
+    ~get_price ~laggard_streaks ~is_friday ~skip_ids ~current_date =
+  let laggard_ts =
+    if config.enable_laggard_rotation then
+      Laggard_rotation_runner.update ~config:config.laggard_rotation_config
+        ~benchmark_symbol:config.indices.primary ~is_screening_day:is_friday
+        ~positions ~bar_reader ~get_price ~laggard_streaks
+        ~skip_position_ids:skip_ids ~current_date
+    else []
+  in
+  List.iter laggard_ts
+    ~f:
+      (_record_force_exit ~last_stop_out_dates ~positions ~current_date
+         ~cooldown_weeks:config.laggard_reentry_cooldown_weeks
+         ~label:"laggard_rotation");
+  laggard_ts
 
 let _run_special_exits ~config ~positions ~last_stop_out_dates
     ~(portfolio : Portfolio_view.t) ~get_price ~peak_tracker ~audit_recorder
@@ -149,19 +175,11 @@ let _run_special_exits ~config ~positions ~last_stop_out_dates
   let stage3_exited_ids = _trigger_exit_ids_of stage3_ts in
   let force_exit_ts = _filter_out_exited_ids stage3_exited_ids force_exit_ts in
   let laggard_ts =
-    if config.enable_laggard_rotation then
-      let skip_ids = Set.union stop_exited_ids stage3_exited_ids in
-      Laggard_rotation_runner.update ~config:config.laggard_rotation_config
-        ~benchmark_symbol:config.indices.primary ~is_screening_day:is_friday
-        ~positions ~bar_reader ~get_price ~laggard_streaks
-        ~skip_position_ids:skip_ids ~current_date
-    else []
+    _run_laggard_rotation ~config ~positions ~last_stop_out_dates ~bar_reader
+      ~get_price ~laggard_streaks ~is_friday
+      ~skip_ids:(Set.union stop_exited_ids stage3_exited_ids)
+      ~current_date
   in
-  List.iter laggard_ts
-    ~f:
-      (_record_force_exit ~last_stop_out_dates ~positions ~current_date
-         ~cooldown_weeks:config.laggard_reentry_cooldown_weeks
-         ~label:"laggard_rotation");
   let laggard_exited_ids = _trigger_exit_ids_of laggard_ts in
   let force_exit_ts = _filter_out_exited_ids laggard_exited_ids force_exit_ts in
   ( force_exit_ts,

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -72,6 +72,29 @@ let _handle_stop_out_transition ~last_stop_out_dates ~positions ~current_date
       | None -> ())
   | _ -> ()
 
+(** Record stage3 / laggard force-exit dates into [last_stop_out_dates] when the
+    corresponding reentry cooldown knob is enabled. Re-uses the existing
+    [Screener.screen_with_cooldown] gate (which keys on [last_stop_out_dates])
+    instead of adding a separate map / cooldown knob. When the per-source
+    cooldown knob is [0] (default), this is a no-op — preserves the pre-feature
+    goldens bit-equal. Decoupling from the screener-level
+    [cascade_post_stop_cooldown_weeks] is the responsibility of a follow-up: the
+    screener applies a single window today; widening that to a per-source window
+    is out of scope for the continuation-buys PR (issue #889). *)
+let _record_force_exit ~last_stop_out_dates ~positions ~current_date
+    ~cooldown_weeks ~(label : string) (t : Position.transition) =
+  if cooldown_weeks <= 0 then ()
+  else
+    match t.kind with
+    | Position.TriggerExit
+        { exit_reason = Position.StrategySignal { label = l; _ }; _ }
+      when String.equal l label -> (
+        match _symbol_of_position_id ~positions t.position_id with
+        | Some symbol ->
+            Hashtbl.set last_stop_out_dates ~key:symbol ~data:current_date
+        | None -> ())
+    | _ -> ()
+
 let _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
     ~get_price ~last_stop_out_dates ~audit_recorder ~prior_macro_result
     ~current_date =
@@ -95,9 +118,10 @@ let _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
          ~bar_reader ~prior_stages ~positions);
   (exit_transitions, adjust_transitions)
 
-let _run_special_exits ~config ~positions ~(portfolio : Portfolio_view.t)
-    ~get_price ~peak_tracker ~audit_recorder ~prior_stages ~stage3_streaks
-    ~laggard_streaks ~bar_reader ~index_view ~exit_transitions ~current_date =
+let _run_special_exits ~config ~positions ~last_stop_out_dates
+    ~(portfolio : Portfolio_view.t) ~get_price ~peak_tracker ~audit_recorder
+    ~prior_stages ~stage3_streaks ~laggard_streaks ~bar_reader ~index_view
+    ~exit_transitions ~current_date =
   let raw_force_exit_ts =
     Force_liquidation_runner.update
       ~config:config.portfolio_config.force_liquidation ~positions ~get_price
@@ -117,6 +141,11 @@ let _run_special_exits ~config ~positions ~(portfolio : Portfolio_view.t)
         ~stage3_streaks ~stop_exit_position_ids:stop_exited_ids ~current_date
     else []
   in
+  List.iter stage3_ts
+    ~f:
+      (_record_force_exit ~last_stop_out_dates ~positions ~current_date
+         ~cooldown_weeks:config.stage3_reentry_cooldown_weeks
+         ~label:"stage3_force_exit");
   let stage3_exited_ids = _trigger_exit_ids_of stage3_ts in
   let force_exit_ts = _filter_out_exited_ids stage3_exited_ids force_exit_ts in
   let laggard_ts =
@@ -128,6 +157,11 @@ let _run_special_exits ~config ~positions ~(portfolio : Portfolio_view.t)
         ~skip_position_ids:skip_ids ~current_date
     else []
   in
+  List.iter laggard_ts
+    ~f:
+      (_record_force_exit ~last_stop_out_dates ~positions ~current_date
+         ~cooldown_weeks:config.laggard_reentry_cooldown_weeks
+         ~label:"laggard_rotation");
   let laggard_exited_ids = _trigger_exit_ids_of laggard_ts in
   let force_exit_ts = _filter_out_exited_ids laggard_exited_ids force_exit_ts in
   ( force_exit_ts,
@@ -213,9 +247,9 @@ let _process_market_day ~config ~ad_bars ~stop_states ~last_stop_out_dates
         stop_exited_ids,
         stage3_exited_ids,
         laggard_exited_ids ) =
-    _run_special_exits ~config ~positions ~portfolio ~get_price ~peak_tracker
-      ~audit_recorder ~prior_stages ~stage3_streaks ~laggard_streaks ~bar_reader
-      ~index_view ~exit_transitions ~current_date
+    _run_special_exits ~config ~positions ~last_stop_out_dates ~portfolio
+      ~get_price ~peak_tracker ~audit_recorder ~prior_stages ~stage3_streaks
+      ~laggard_streaks ~bar_reader ~index_view ~exit_transitions ~current_date
   in
   let entry_transitions =
     _run_macro_and_entries ~config ~ad_bars ~stop_states ~last_stop_out_dates
@@ -304,4 +338,5 @@ module Internal_for_test = struct
   let on_market_close = _on_market_close
   let maybe_reset_halt = _maybe_reset_halt
   let positions_minus_exited = _positions_minus_exited
+  let record_force_exit = _record_force_exit
 end

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -231,13 +231,12 @@ type config = {
           sequencing" (§3) in
           [dev/notes/capital-recycling-framing-2026-05-06.md]. *)
   stage3_reentry_cooldown_weeks : int; [@sexp.default 0]
-      (** Reserved for future tuning — currently unwired (default [0] = no
-          cooldown applied). Once wired, would suppress cascade re-admission of
-          a symbol force-exited under Stage 3 for [N] weeks beyond the existing
-          stop-out cooldown surface (#718). [0] is the book-aligned default
-          (§5.2 "STATE: EXITED — IF whipsaw … acceptable to re-buy"). The knob
-          exists on [config] so future tuning can flip it via sexp override
-          without a code change. *)
+      (** Suppresses cascade re-admission of a symbol force-exited under Stage 3
+          for [N] weeks beyond the existing stop-out cooldown surface (#718).
+          Default [0] = no cooldown applied (preserves baselines). The strategy
+          records Stage-3 force-exit events into [last_stop_out_dates] when this
+          knob is [> 0], so the existing cascade gate applies regardless of
+          which exit path fired. *)
   laggard_rotation_config : Laggard_rotation.config;
       [@sexp.default Laggard_rotation.default_config]
       (** Laggard-rotation detector parameters (issue #887). Default
@@ -257,12 +256,23 @@ type config = {
           a separate post-merge step per the framing note's "Recommended
           sequencing" in [dev/notes/capital-recycling-framing-2026-05-06.md]. *)
   laggard_reentry_cooldown_weeks : int; [@sexp.default 0]
-      (** Reserved for future tuning — currently unwired (default [0] = no
-          cooldown applied beyond the existing stop-out cooldown surface #718).
-          [0] is the book-aligned default per §5.6: laggard rotation is
-          discretionary, the symbol may be re-bought once it shows fresh Stage-2
-          strength. The knob exists on [config] so future tuning can flip it via
-          sexp override without a code change. *)
+      (** Suppresses cascade re-admission of a symbol exited by the laggard-
+          rotation runner for [N] weeks beyond the existing stop-out cooldown
+          surface (#718). Default [0] = no cooldown applied (preserves
+          baselines). The strategy records laggard-rotation exits into
+          [last_stop_out_dates] when this knob is [> 0], so the existing cascade
+          gate applies regardless of which exit path fired. *)
+  enable_continuation_buys : bool; [@sexp.default false]
+      (** Master switch for Weinstein Ch. 3 continuation-buy detection
+          (Interpretation B of issue #889). Default [false] preserves all
+          existing baselines: the {!Continuation} detector does not run and
+          {!Stock_analysis.is_breakout_candidate} retains its
+          initial-breakout-only behaviour. Flipping to [true] populates
+          [Stock_analysis.continuation] via the detector and admits continuation
+          candidates through the OR-arm of the cascade.
+
+          Interpretation A (pyramid adds to existing holdings) is deferred
+          behind a core-module decision and is NOT enabled by this flag. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for
@@ -460,6 +470,22 @@ module Internal_for_test : sig
       / [prior_macro_result] / [peak_tracker] / [prior_stages] /
       [sector_prior_stages] / [stage3_streaks] / [laggard_streaks] in place,
       mirroring the closure semantics in {!make}. *)
+
+  val record_force_exit :
+    last_stop_out_dates:Date.t Hashtbl.M(String).t ->
+    positions:Trading_strategy.Position.t Map.M(String).t ->
+    current_date:Date.t ->
+    cooldown_weeks:int ->
+    label:string ->
+    Trading_strategy.Position.transition ->
+    unit
+  (** Records a strategy-signal exit into [last_stop_out_dates] when
+      [cooldown_weeks > 0] AND the transition is a [TriggerExit] whose
+      [StrategySignal.label] equals [label]. Otherwise a no-op.
+
+      Used to plumb stage-3 force-exit and laggard-rotation exits through the
+      existing screener cooldown gate (issue #889 §F1). Exposed for tests; not
+      part of the public strategy API. *)
 
   val maybe_reset_halt :
     peak_tracker:Portfolio_risk.Force_liquidation.Peak_tracker.t ->

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -39,13 +39,13 @@ type config = {
           Flipping to [true] activates {!Stage3_force_exit_runner.update} on
           every Friday tick. *)
   stage3_reentry_cooldown_weeks : int; [@sexp.default 0]
-      (** Reserved for future tuning — currently unwired (default [0] = no
-          cooldown applied). Once wired, would suppress cascade re-admission of
-          a symbol force-exited under Stage 3 for [N] weeks beyond the existing
-          stop-out cooldown surface (#718). [0] is the book-aligned default
-          (§5.2 "STATE: EXITED — IF whipsaw … acceptable to re-buy"). The knob
-          exists on [config] so future tuning can flip it via sexp override
-          without a code change. *)
+      (** Suppresses cascade re-admission of a symbol force-exited under Stage 3
+          for [N] weeks beyond the existing stop-out cooldown surface (#718).
+          Default [0] = no cooldown applied (preserves baselines). The strategy
+          records Stage-3 force-exit events into [last_stop_out_dates] when this
+          knob is [> 0], so the existing cascade gate
+          ([Screener.screen_with_cooldown]) applies regardless of which exit
+          path fired. *)
   laggard_rotation_config : Laggard_rotation.config;
       [@sexp.default Laggard_rotation.default_config]
       (** Laggard-rotation detector parameters (issue #887). Default
@@ -58,10 +58,22 @@ type config = {
           the strategy emits no [StrategySignal "laggard_rotation"] transitions.
       *)
   laggard_reentry_cooldown_weeks : int; [@sexp.default 0]
-      (** Reserved for future tuning — currently unwired (default [0] = no
-          cooldown applied beyond the existing stop-out cooldown surface #718).
-          The knob exists on [config] so future tuning can flip it via sexp
-          override without a code change. *)
+      (** Suppresses cascade re-admission of a symbol exited by the laggard-
+          rotation runner for [N] weeks beyond the existing stop-out cooldown
+          surface (#718). Default [0] = no cooldown applied (preserves
+          baselines). Wired through the same [Screener.screen_with_cooldown]
+          gate as [Screener.cascade_post_stop_cooldown_weeks]: the strategy
+          records laggard-rotation exits into [last_stop_out_dates] when this
+          knob is [> 0], so the same cascade gate applies regardless of which
+          exit path fired. *)
+  enable_continuation_buys : bool; [@sexp.default false]
+      (** Master switch for Weinstein Ch. 3 continuation-buy detection
+          (Interpretation B of issue #889). Default [false] preserves all
+          existing baselines: the {!Continuation} detector does not run and
+          {!Stock_analysis.is_breakout_candidate} keeps its initial-breakout-
+          only behaviour. Flipping to [true] populates
+          [Stock_analysis.continuation] via the detector and admits continuation
+          candidates through the OR-arm of the cascade. *)
 }
 [@@deriving sexp]
 
@@ -90,6 +102,7 @@ let default_config ~universe ~index_symbol =
     laggard_rotation_config = Laggard_rotation.default_config;
     enable_laggard_rotation = false;
     laggard_reentry_cooldown_weeks = 0;
+    enable_continuation_buys = false;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -22,58 +22,29 @@ type config = {
   enable_short_side : bool; [@sexp.default true]
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
-      (** Cadence for trailing-stop trail advancement (G11). [Daily] (the
-          default) preserves all existing baselines: the trail can tighten on
-          every daily bar. [Weekly] only advances the state machine on Friday
-          ticks, matching Weinstein Ch. 6 §Stop-Loss Rules ("trail moves only on
-          weekly close"). Trigger logic stays continuous in both modes. *)
+      (** Cadence for trailing-stop trail advancement (G11). [Daily] preserves
+          baselines; [Weekly] gates trail advancement to Friday ticks. *)
   stage3_force_exit_config : Stage3_force_exit.config;
       [@sexp.default Stage3_force_exit.default_config]
-      (** Stage-3 force-exit detector parameters (issue #872). Default
-          [{ hysteresis_weeks = 2 }] — fires on the second consecutive Friday
-          Stage-3 classification of a held long position. *)
+      (** Stage-3 force-exit detector parameters (issue #872). *)
   enable_stage3_force_exit : bool; [@sexp.default false]
       (** Master switch for the Stage-3 force-exit runner. Default [false]
-          preserves all existing baselines: the runner is a no-op and the
-          strategy emits no [StrategySignal "stage3_force_exit"] transitions.
-          Flipping to [true] activates {!Stage3_force_exit_runner.update} on
-          every Friday tick. *)
+          preserves all existing baselines. *)
   stage3_reentry_cooldown_weeks : int; [@sexp.default 0]
-      (** Suppresses cascade re-admission of a symbol force-exited under Stage 3
-          for [N] weeks beyond the existing stop-out cooldown surface (#718).
-          Default [0] = no cooldown applied (preserves baselines). The strategy
-          records Stage-3 force-exit events into [last_stop_out_dates] when this
-          knob is [> 0], so the existing cascade gate
-          ([Screener.screen_with_cooldown]) applies regardless of which exit
-          path fired. *)
+      (** Cascade re-admission cooldown (#718) for Stage-3 force-exited symbols.
+          Default [0] = no extra cooldown. *)
   laggard_rotation_config : Laggard_rotation.config;
       [@sexp.default Laggard_rotation.default_config]
-      (** Laggard-rotation detector parameters (issue #887). Default
-          [{ hysteresis_weeks = 4; rs_window_weeks = 13 }] — fires on the fourth
-          consecutive Friday observation of negative
-          relative-strength-vs-benchmark over a rolling 13-week window. *)
+      (** Laggard-rotation detector parameters (issue #887). *)
   enable_laggard_rotation : bool; [@sexp.default false]
-      (** Master switch for the laggard-rotation runner (issue #887). Default
-          [false] preserves all existing baselines: the runner is a no-op and
-          the strategy emits no [StrategySignal "laggard_rotation"] transitions.
-      *)
+      (** Master switch for the laggard-rotation runner (issue #887). *)
   laggard_reentry_cooldown_weeks : int; [@sexp.default 0]
-      (** Suppresses cascade re-admission of a symbol exited by the laggard-
-          rotation runner for [N] weeks beyond the existing stop-out cooldown
-          surface (#718). Default [0] = no cooldown applied (preserves
-          baselines). Wired through the same [Screener.screen_with_cooldown]
-          gate as [Screener.cascade_post_stop_cooldown_weeks]: the strategy
-          records laggard-rotation exits into [last_stop_out_dates] when this
-          knob is [> 0], so the same cascade gate applies regardless of which
-          exit path fired. *)
+      (** Cascade re-admission cooldown (#718) for laggard-rotation exited
+          symbols. Default [0] = no extra cooldown. *)
   enable_continuation_buys : bool; [@sexp.default false]
       (** Master switch for Weinstein Ch. 3 continuation-buy detection
-          (Interpretation B of issue #889). Default [false] preserves all
-          existing baselines: the {!Continuation} detector does not run and
-          {!Stock_analysis.is_breakout_candidate} keeps its initial-breakout-
-          only behaviour. Flipping to [true] populates
-          [Stock_analysis.continuation] via the detector and admits continuation
-          candidates through the OR-arm of the cascade. *)
+          (Interpretation B of issue #889). Default [false] preserves baselines.
+      *)
 }
 [@@deriving sexp]
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -34,6 +34,10 @@ type config = {
       [@sexp.default Laggard_rotation.default_config]
   enable_laggard_rotation : bool; [@sexp.default false]
   laggard_reentry_cooldown_weeks : int; [@sexp.default 0]
+  enable_continuation_buys : bool; [@sexp.default false]
+      (** Master switch for Weinstein Ch. 3 continuation-buy detection
+          (Interpretation B of issue #889). Default [false] preserves existing
+          baselines. See [.ml] for full semantics. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -228,6 +228,14 @@ let survivors_for_screening ?sector_map ~config ~bar_reader ~prior_stages
   _commit_prior_stages ~prior_stages classified;
   final_survivors
 
+(* Per-element predicates over the four-tuple shape so [screen_universe]'s
+   cascade stays a flat pipeline (one filter per gate, no destructuring
+   lambdas pushing nesting depth). *)
+let _phase1_of (_, _, _, sr) = _survives_phase1 sr
+
+let _sector_filter_of ~sector_map (ticker, view, _prior, sr) =
+  _survives_sector_filter ~sector_map (ticker, view, sr)
+
 (** Screen the universe via the lazy cascade (Phase 1 stage filter → PR-B sector
     pre-filter → Phase 2 full {!Stock_analysis}). Macro-trend gating lives in
     the screener; concatenating [buy_candidates] + [short_candidates] yields the
@@ -240,18 +248,14 @@ let screen_universe ~config ~index_view ~(macro_result : Macro.result)
     _classify_all ~config ~bar_reader ~prior_stages ~current_date
   in
   let stock_analysis_config = _stock_analysis_config_for ~config in
-  (* Cascade: Phase 1 stage filter → PR-B sector pre-filter → Phase 2 full
-     analysis. The four-tuple shape is preserved through both filters so
-     [prior_stage] stays threaded into [_full_analysis_of_survivor]. *)
+  (* Bind Phase-2 closure outside the pipeline (depth-5 ceiling). *)
+  let analyze =
+    _full_analysis_of_survivor ~stock_analysis_config ~bar_reader ~index_view
+  in
   let stocks =
-    classified
-    |> List.filter ~f:(fun (_, _, _, sr) -> _survives_phase1 sr)
-    |> List.filter ~f:(fun (ticker, view, _prior, sr) ->
-        _survives_sector_filter ~sector_map (ticker, view, sr))
-    |> List.map
-         ~f:
-           (_full_analysis_of_survivor ~stock_analysis_config ~bar_reader
-              ~index_view)
+    classified |> List.filter ~f:_phase1_of
+    |> List.filter ~f:(_sector_filter_of ~sector_map)
+    |> List.map ~f:analyze
   in
   _commit_prior_stages ~prior_stages classified;
   let screen_result =

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -151,6 +151,21 @@ let _classify_stage_for_screening ~config ~bar_reader ~prior_stages
     in
     Some (ticker, stock_view, prior_stage, stage_result)
 
+(** Build the per-screen-pass [Stock_analysis.config]. Currently differs from
+    {!Stock_analysis.default_config} only by toggling the continuation detector
+    based on [Weinstein_strategy_config.enable_continuation_buys]. When the
+    strategy flag is [false] (default), this returns a config equal to
+    [Stock_analysis.default_config] — preserving bit-equality with prior
+    behaviour. *)
+let _stock_analysis_config_for ~(config : Weinstein_strategy_config.config) :
+    Stock_analysis.config =
+  if config.enable_continuation_buys then
+    {
+      Stock_analysis.default_config with
+      continuation = Some Continuation.default_config;
+    }
+  else Stock_analysis.default_config
+
 (** Stage 4-5 PR-A Phase 2: build the full [Stock_analysis.callbacks] bundle
     (Stage / Rs / Volume / Resistance) for a survivor and run
     [Stock_analysis.analyze_with_callbacks]. This is the load-bearing allocation
@@ -159,7 +174,7 @@ let _classify_stage_for_screening ~config ~bar_reader ~prior_stages
     Phase 1 captured before any [prior_stages] update — matches the pre-PR-A
     semantics where every per-symbol analysis on a given Friday saw the same
     "previous Friday" snapshot. *)
-let _full_analysis_of_survivor ~bar_reader ~index_view
+let _full_analysis_of_survivor ~stock_analysis_config ~bar_reader ~index_view
     ( ticker,
       (stock_view : Snapshot_runtime.Snapshot_bar_views.weekly_view),
       prior_stage,
@@ -168,11 +183,11 @@ let _full_analysis_of_survivor ~bar_reader ~index_view
   let callbacks =
     Panel_callbacks.stock_analysis_callbacks_of_weekly_views
       ?ma_cache:(Bar_reader.ma_cache bar_reader)
-      ~stock_symbol:ticker ~config:Stock_analysis.default_config
-      ~stock:stock_view ~benchmark:index_view ()
+      ~stock_symbol:ticker ~config:stock_analysis_config ~stock:stock_view
+      ~benchmark:index_view ()
   in
-  Stock_analysis.analyze_with_callbacks ~config:Stock_analysis.default_config
-    ~ticker ~callbacks ~prior_stage ~as_of_date
+  Stock_analysis.analyze_with_callbacks ~config:stock_analysis_config ~ticker
+    ~callbacks ~prior_stage ~as_of_date
 
 (** Phase 1: classify every ticker in [config.universe] via the cheap stage-only
     pass. Returns the full classification result — non-survivors retained so the
@@ -224,6 +239,7 @@ let screen_universe ~config ~index_view ~(macro_result : Macro.result)
   let classified =
     _classify_all ~config ~bar_reader ~prior_stages ~current_date
   in
+  let stock_analysis_config = _stock_analysis_config_for ~config in
   (* Cascade: Phase 1 stage filter → PR-B sector pre-filter → Phase 2 full
      analysis. The four-tuple shape is preserved through both filters so
      [prior_stage] stays threaded into [_full_analysis_of_survivor]. *)
@@ -232,7 +248,10 @@ let screen_universe ~config ~index_view ~(macro_result : Macro.result)
     |> List.filter ~f:(fun (_, _, _, sr) -> _survives_phase1 sr)
     |> List.filter ~f:(fun (ticker, view, _prior, sr) ->
         _survives_sector_filter ~sector_map (ticker, view, sr))
-    |> List.map ~f:(_full_analysis_of_survivor ~bar_reader ~index_view)
+    |> List.map
+         ~f:
+           (_full_analysis_of_survivor ~stock_analysis_config ~bar_reader
+              ~index_view)
   in
   _commit_prior_stages ~prior_stages classified;
   let screen_result =

--- a/trading/trading/weinstein/strategy/test/test_entry_audit_capture.ml
+++ b/trading/trading/weinstein/strategy/test/test_entry_audit_capture.ml
@@ -60,6 +60,7 @@ let _stock_analysis ~ticker ~as_of_date : Stock_analysis.t =
     breakout_price = None;
     breakdown_price = None;
     prior_stage = None;
+    continuation = None;
     as_of_date;
   }
 

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -559,6 +559,7 @@ let make_scored_candidate ~ticker ~side ~entry ~stop ~grade =
       resistance = None;
       support = None;
       prior_stage = Some (Stage3 { weeks_topping = 8 });
+      continuation = None;
       as_of_date = Date.of_string "2024-01-05";
     }
   in
@@ -1083,6 +1084,124 @@ let test_survivors_for_screening_pr_b_counter _ =
     (equal_to [ "FALL_WEAK"; "RISE_STRONG_A"; "RISE_STRONG_B" ])
 
 (* ------------------------------------------------------------------ *)
+(* record_force_exit — feeds stage3 / laggard exits into the existing  *)
+(* screener cooldown gate (issue #889 §F1).                            *)
+(* ------------------------------------------------------------------ *)
+
+(** Build a minimal [Position.t] in Holding state for the given [symbol]. Only
+    the [symbol], [id], and state matter for [_record_force_exit]'s
+    [_symbol_of_position_id] lookup. Mirrors the helper in
+    [test_stage3_force_exit_runner.ml]. *)
+let _make_holding_position ~symbol ~id : Trading_strategy.Position.t =
+  let date = Date.of_string "2024-01-01" in
+  let make_trans kind =
+    { Trading_strategy.Position.position_id = id; date; kind }
+  in
+  let unwrap = function
+    | Ok p -> p
+    | Error err ->
+        OUnit2.assert_failure ("position setup failed: " ^ Status.show err)
+  in
+  let open Trading_strategy.Position in
+  let p =
+    create_entering
+      (make_trans
+         (CreateEntering
+            {
+              symbol;
+              side = Trading_base.Types.Long;
+              target_quantity = 100.0;
+              entry_price = 50.0;
+              reasoning = ManualDecision { description = "test" };
+            }))
+    |> unwrap
+  in
+  let p =
+    apply_transition p
+      (make_trans (EntryFill { filled_quantity = 100.0; fill_price = 50.0 }))
+    |> unwrap
+  in
+  apply_transition p
+    (make_trans
+       (EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = Some 45.0;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+(** Build a [StrategySignal] exit transition for the given symbol's position_id.
+*)
+let _make_strategy_signal_exit ~position_id ~current_date ~label :
+    Trading_strategy.Position.transition =
+  {
+    position_id;
+    date = current_date;
+    kind =
+      TriggerExit
+        {
+          exit_reason = StrategySignal { label; detail = Some "test exit" };
+          exit_price = 60.0;
+        };
+  }
+
+(** When [cooldown_weeks = 0] the recorder is a no-op even on a matching label —
+    preserves the bit-equal default-off behaviour. *)
+let test_record_force_exit_zero_cooldown_is_noop _ =
+  let last_stop_out_dates = Hashtbl.create (module String) in
+  let pos = _make_holding_position ~symbol:"AAPL" ~id:"pos_a" in
+  let positions = Map.singleton (module String) "pos_a" pos in
+  let current_date = Date.of_string "2024-02-15" in
+  let trans =
+    _make_strategy_signal_exit ~position_id:"pos_a" ~current_date
+      ~label:"stage3_force_exit"
+  in
+  Internal_for_test.record_force_exit ~last_stop_out_dates ~positions
+    ~current_date ~cooldown_weeks:0 ~label:"stage3_force_exit" trans;
+  assert_that (Hashtbl.length last_stop_out_dates) (equal_to 0)
+
+(** When [cooldown_weeks > 0] and the transition's StrategySignal label matches,
+    the recorder writes [(symbol, current_date)] into the map. The
+    screener-level cooldown gate then blocks the symbol from re-admission via
+    the continuation arm — closing the same-Friday re-entry hazard. *)
+let test_record_force_exit_positive_cooldown_records_date _ =
+  let last_stop_out_dates = Hashtbl.create (module String) in
+  let pos = _make_holding_position ~symbol:"AAPL" ~id:"pos_a" in
+  let positions = Map.singleton (module String) "pos_a" pos in
+  let current_date = Date.of_string "2024-02-15" in
+  let trans =
+    _make_strategy_signal_exit ~position_id:"pos_a" ~current_date
+      ~label:"stage3_force_exit"
+  in
+  Internal_for_test.record_force_exit ~last_stop_out_dates ~positions
+    ~current_date ~cooldown_weeks:4 ~label:"stage3_force_exit" trans;
+  assert_that
+    (Hashtbl.find last_stop_out_dates "AAPL")
+    (is_some_and (equal_to current_date))
+
+(** When the StrategySignal label DOES NOT match (e.g. the recorder is looking
+    for laggard_rotation but the transition is stage3_force_exit), the recorder
+    is a no-op. This isolates per-source cooldown handling so a future
+    per-source cooldown design can add separate maps without
+    cross-contamination. *)
+let test_record_force_exit_label_mismatch_is_noop _ =
+  let last_stop_out_dates = Hashtbl.create (module String) in
+  let pos = _make_holding_position ~symbol:"AAPL" ~id:"pos_a" in
+  let positions = Map.singleton (module String) "pos_a" pos in
+  let current_date = Date.of_string "2024-02-15" in
+  let trans =
+    _make_strategy_signal_exit ~position_id:"pos_a" ~current_date
+      ~label:"stage3_force_exit"
+  in
+  Internal_for_test.record_force_exit ~last_stop_out_dates ~positions
+    ~current_date ~cooldown_weeks:4 ~label:"laggard_rotation" trans;
+  assert_that (Hashtbl.length last_stop_out_dates) (equal_to 0)
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -1090,6 +1209,12 @@ let () =
   run_test_tt_main
     ("weinstein_strategy"
     >::: [
+           "record_force_exit: zero cooldown is no-op"
+           >:: test_record_force_exit_zero_cooldown_is_noop;
+           "record_force_exit: positive cooldown records date"
+           >:: test_record_force_exit_positive_cooldown_records_date;
+           "record_force_exit: label mismatch is no-op"
+           >:: test_record_force_exit_label_mismatch_is_noop;
            "make produces strategy" >:: test_make_produces_strategy;
            "empty universe no transitions"
            >:: test_empty_universe_no_transitions;


### PR DESCRIPTION
## Summary

Implements Interpretation B from the [continuation-buys design plan PR #1074](https://github.com/dayfine/trading/pull/1074) (issue #889): detect Weinstein Ch. 3 "continuation buy" pattern and admit mature Stage-2 symbols as **new** position-entering candidates via an OR-arm in `Stock_analysis.is_breakout_candidate`. Today these symbols are rejected by the cascade because `weeks_advancing > 4`. Closes the capital-recycling blind spot documented in `dev/notes/capital-recycling-framing-2026-05-06.md`.

**Interpretation A (pyramid adds to existing holdings) is deferred** behind a core-module decision (`Position.t` would need an `AddToHolding` transition). This PR is B-only.

## 5 preconditions wired

| # | Precondition | Implementation |
|---|---|---|
| (a) | MA clearly trending higher (slope ≥ `ma_slope_min`, default 1%) | `Continuation._compute_ma_slope` reads `stage.callbacks.get_ma` |
| (b) | Price pulled back to MA (`close/MA ∈ pullback_band`, default [0.95, 1.05]) within `pullback_lookback_weeks` (default 8) | `Continuation._find_pullback_offset` |
| (c) | Consolidation tight (range ≤ `consolidation_range_pct`, default 10%) over `consolidation_weeks` (default 4) | `Continuation._consolidation_high` — scans offsets 1..N (current bar excluded so the breakout day's high doesn't anchor the gate) |
| (d) | Breakout above the prior resistance / consolidation high | `Continuation._current_close_above` |
| (e) | Volume confirmation (Strong / Adequate) | Inherited from existing `is_breakout_candidate` volume gate — the continuation OR-arm only swaps the **stage** half of the predicate |

## Cooldown design choice

Wired the **existing reserved** `stage3_reentry_cooldown_weeks` and `laggard_reentry_cooldown_weeks` knobs rather than adding a new `cascade_post_rotation_cooldown_weeks` (the design plan §F1 listed both options). Rationale:

1. The reserved knobs were shaped for exactly this purpose (config was added when stage3 / laggard PRs landed; doc comments said "Reserved for future tuning — currently unwired").
2. No new config knob; smaller config surface.
3. Default 0 preserves bit-equal goldens (the strategy is a no-op unless the knob is >0).
4. The strategy records stage3 / laggard StrategySignal exits into `last_stop_out_dates` when their respective knob is >0, plumbing through the existing `Screener.screen_with_cooldown` gate. The cooldown **duration** is the existing `cascade_post_stop_cooldown_weeks` window — a future refactor can separate per-source windows if motivated.

The `stage3_reentry_cooldown_weeks` / `laggard_reentry_cooldown_weeks` knobs now act as **enable flags** for whether the corresponding exit-source feeds the cascade cooldown gate.

## Feature gates

- `Stock_analysis.config.continuation : Continuation.config option` — `None` (default) skips the detector entirely.
- `Weinstein_strategy_config.enable_continuation_buys : bool` — default `false` keeps `continuation = None` for every screen pass.
- Default `false` for both → bit-equal goldens.

## Test plan

- [x] **Detector unit tests** (8 in `test_continuation.ml`): happy path, each precondition fails independently (flat MA / no pullback / wide consolidation / no breakout above consolidation), lookback window truncation, empty callbacks, purity.
- [x] **Stock_analysis integration tests** (2 in `test_stock_analysis.ml`): mature Stage-2 stock REJECTED with `continuation = None` (default-off bit-equivalence), ADMITTED with `continuation = Some default_config` (continuation OR-arm fires).
- [x] **Strategy cooldown unit tests** (3 in `test_weinstein_strategy.ml`): `_record_force_exit` zero-cooldown is a no-op, positive-cooldown writes `(symbol, current_date)` into `last_stop_out_dates`, label-mismatch is a no-op (so laggard cooldown doesn't pick up stage3 exits and vice-versa).
- [x] `dune build && dune runtest` green
- [x] `dune build @fmt` green
- [x] Existing 5y / 10y / 16y goldens still PASS (default-off preserves them — verified with full `dune runtest`)
- [x] No `Position.t` modifications

## Authority

- Plan PR #1074 / `dev/plans/continuation-buys-2026-05-13.md`
- Issue #889
- `docs/design/weinstein-book-reference.md` §4.6 "Continuation Buys (Ch. 3)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)