### PR TITLE
experiments(tuning): M5.5 axis-2 min_correction_pct 4-cell sweep on sp500-2019-2023

### DIFF
--- a/dev/experiments/m5-5-min-correction-pct-2026-05-14/main-scenario-addendum.md
+++ b/dev/experiments/m5-5-min-correction-pct-2026-05-14/main-scenario-addendum.md
@@ -1,0 +1,59 @@
+# Axis-2 main-scenario re-measurement (review addendum)
+
+The PR's original 4-cell sweep ran on `sp500-2019-2023-long-only.sexp` (shorts
+off). Behavioral QC flagged that the "axis-2 lifts Calmar 2.8× more than
+axis-1" comparison was not apples-to-apples since axis-1 (PR #1079) ran on
+the main scenario (`sp500-2019-2023.sexp`, shorts on).
+
+This addendum re-runs the same 4 cells on the main scenario. The qualitative
+verdict survives — actually strengthens.
+
+## Main-scenario results
+
+| Cell | Return | Trades | WR | Sharpe | MaxDD | Calmar | AvgHold |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| 006 | 33.94% | 312 | 36.86% | 0.43 | 28.67% | 0.21 | 33.65d |
+| 008 baseline | 50.66% | 264 | 37.50% | 0.56 | 21.56% | 0.40 | 40.78d |
+| **010** | **93.76%** | **195** | **36.41%** | **0.88** | **18.36%** | **0.77** | **56.05d** |
+| 012 | 92.79% | 183 | 34.97% | 0.87 | 19.61% | 0.72 | 55.41d |
+
+## Apples-to-apples comparison (main vs main)
+
+| Axis | Δ Return | Δ Sharpe | Δ MaxDD | Δ Calmar |
+|---|---:|---:|---:|---:|
+| **axis-1 winner** (`installed_stop_min_pct = 0.08`, #1079) | +36.4 pp | +0.19 | **+3.9** | +0.13 |
+| **axis-2 winner** (`min_correction_pct = 0.10`, this PR) | **+43.1 pp** | **+0.32** | **−3.2** | **+0.37** |
+
+Axis-2 cell-010 is strictly better than axis-1 on every dimension:
+- Bigger return lift (+43 pp vs +36 pp)
+- Bigger Sharpe lift (+0.32 vs +0.19)
+- **MaxDD IMPROVES** (-3.2 pp) where axis-1 MaxDD worsened (+3.9 pp)
+- Calmar lift 2.85× larger (+0.37 vs +0.13)
+
+The "2.8× stronger" headline is preserved on main-to-main.
+
+## Long-only result (original PR body) — also valid
+
+The long-only baseline + cell-010 long-only also showed ΔCalmar +0.37
+(coincidentally identical). Both scenarios produce the same lift magnitude,
+so the conclusion is robust:
+
+**`min_correction_pct = 0.10` is the dominant axis-2 lever, and dominates
+axis-1.**
+
+## Recommendation
+
+1. Promote `min_correction_pct = 0.10` as the next Cell E tuning candidate.
+2. **Run a 1×2 cross-sweep** of axis-1 (`installed_stop_min_pct = 0.08`) ×
+   axis-2 (`min_correction_pct = 0.10`) to see if effects compound. The
+   axis-1 sweep widened the installed stop floor; axis-2 widens the
+   support-floor + buffer. They may be additive or interact destructively.
+3. Validate cell-010 on 10y + 16y goldens before locking in (per the same
+   protocol as #1081 for axis-1).
+
+## Files
+
+- Main-scenario cell sexps: `dev/backtest/axis2-main-rerun/cell-*.sexp` (not
+  committed; trivially regenerable by stripping `enable_short_side false`
+  from the original long-only cells).
+- Output dir: `dev/backtest/scenarios-2026-05-14-011236/`

--- a/trading/test_data/backtest_scenarios/experiments/m5-5-min-correction-pct-2026-05-14/cell-006.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-5-min-correction-pct-2026-05-14/cell-006.sexp
@@ -1,0 +1,37 @@
+;; M5.5 axis-2 sweep cell — stops_config.min_correction_pct = 0.06.
+;;
+;; Twin of goldens-sp500/sp500-2019-2023-long-only.sexp (Cell E config); only
+;; differs by appended overlay setting min_correction_pct. Per
+;; dev/notes/p3-tuning-sweep-design-2026-05-13.md (PR #1064), axis #2.
+;;
+;; Hypothesis: lower min_correction_pct (tighter support-floor and stop buffer)
+;; increases stop-out churn relative to the 0.08 baseline.
+;;
+;; Expected ranges intentionally wide (BASELINE_PENDING-style) — discovery cell,
+;; not a pin.
+((name "m5-5-axis-2-min-correction-pct-006")
+ (description "min_correction_pct = 0.06 sweep cell on sp500-2019-2023 long-only")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 503)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((stops_config ((min_correction_pct 0.06))))))
+ (expected
+  ((total_return_pct        ((min -50.0)       (max 500.0)))
+   (total_trades            ((min   1)         (max 1000)))
+   (win_rate                ((min   0.0)       (max 100.0)))
+   (sharpe_ratio            ((min  -2.0)       (max   3.0)))
+   (max_drawdown_pct        ((min   0.0)       (max  80.0)))
+   (avg_holding_days        ((min   0.0)       (max 300.0)))
+   (sortino_ratio_annualized ((min -2.0)       (max   5.0)))
+   (calmar_ratio            ((min  -2.0)       (max   3.0)))
+   (ulcer_index             ((min   0.0)       (max  50.0)))
+   (wall_seconds            ((min   0.0)       (max 3600.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-5-min-correction-pct-2026-05-14/cell-008-baseline.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-5-min-correction-pct-2026-05-14/cell-008-baseline.sexp
@@ -1,0 +1,34 @@
+;; M5.5 axis-2 sweep cell — stops_config.min_correction_pct = 0.08 (default).
+;;
+;; Baseline cell: equivalent to Cell E config without any override on
+;; min_correction_pct (default is 0.08). Included explicitly with the overlay
+;; written out so the runner exercises the same merge path as the other cells
+;; — guarantees apples-to-apples comparison.
+;;
+;; Per dev/notes/p3-tuning-sweep-design-2026-05-13.md (PR #1064), axis #2.
+((name "m5-5-axis-2-min-correction-pct-008-baseline")
+ (description "min_correction_pct = 0.08 (default) baseline cell on sp500-2019-2023 long-only")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 503)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((stops_config ((min_correction_pct 0.08))))))
+ (expected
+  ((total_return_pct        ((min -50.0)       (max 500.0)))
+   (total_trades            ((min   1)         (max 1000)))
+   (win_rate                ((min   0.0)       (max 100.0)))
+   (sharpe_ratio            ((min  -2.0)       (max   3.0)))
+   (max_drawdown_pct        ((min   0.0)       (max  80.0)))
+   (avg_holding_days        ((min   0.0)       (max 300.0)))
+   (sortino_ratio_annualized ((min -2.0)       (max   5.0)))
+   (calmar_ratio            ((min  -2.0)       (max   3.0)))
+   (ulcer_index             ((min   0.0)       (max  50.0)))
+   (wall_seconds            ((min   0.0)       (max 3600.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-5-min-correction-pct-2026-05-14/cell-010.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-5-min-correction-pct-2026-05-14/cell-010.sexp
@@ -1,0 +1,34 @@
+;; M5.5 axis-2 sweep cell — stops_config.min_correction_pct = 0.10.
+;;
+;; Twin of goldens-sp500/sp500-2019-2023-long-only.sexp (Cell E config); only
+;; differs by appended overlay setting min_correction_pct. Per
+;; dev/notes/p3-tuning-sweep-design-2026-05-13.md (PR #1064), axis #2.
+;;
+;; Hypothesis: higher min_correction_pct (wider support-floor + stop buffer)
+;; suppresses noise stop-outs and lengthens holds relative to the 0.08 default.
+((name "m5-5-axis-2-min-correction-pct-010")
+ (description "min_correction_pct = 0.10 sweep cell on sp500-2019-2023 long-only")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 503)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((stops_config ((min_correction_pct 0.10))))))
+ (expected
+  ((total_return_pct        ((min -50.0)       (max 500.0)))
+   (total_trades            ((min   1)         (max 1000)))
+   (win_rate                ((min   0.0)       (max 100.0)))
+   (sharpe_ratio            ((min  -2.0)       (max   3.0)))
+   (max_drawdown_pct        ((min   0.0)       (max  80.0)))
+   (avg_holding_days        ((min   0.0)       (max 300.0)))
+   (sortino_ratio_annualized ((min -2.0)       (max   5.0)))
+   (calmar_ratio            ((min  -2.0)       (max   3.0)))
+   (ulcer_index             ((min   0.0)       (max  50.0)))
+   (wall_seconds            ((min   0.0)       (max 3600.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-5-min-correction-pct-2026-05-14/cell-012.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-5-min-correction-pct-2026-05-14/cell-012.sexp
@@ -1,0 +1,35 @@
+;; M5.5 axis-2 sweep cell — stops_config.min_correction_pct = 0.12.
+;;
+;; Twin of goldens-sp500/sp500-2019-2023-long-only.sexp (Cell E config); only
+;; differs by appended overlay setting min_correction_pct. Per
+;; dev/notes/p3-tuning-sweep-design-2026-05-13.md (PR #1064), axis #2.
+;;
+;; Hypothesis: wider min_correction_pct continues to suppress churn; tests
+;; whether the lever has a knee somewhere between 0.10 and 0.12 (paralleling
+;; axis-1's installed_stop_min_pct knee at 0.08).
+((name "m5-5-axis-2-min-correction-pct-012")
+ (description "min_correction_pct = 0.12 sweep cell on sp500-2019-2023 long-only")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 503)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((stops_config ((min_correction_pct 0.12))))))
+ (expected
+  ((total_return_pct        ((min -50.0)       (max 500.0)))
+   (total_trades            ((min   1)         (max 1000)))
+   (win_rate                ((min   0.0)       (max 100.0)))
+   (sharpe_ratio            ((min  -2.0)       (max   3.0)))
+   (max_drawdown_pct        ((min   0.0)       (max  80.0)))
+   (avg_holding_days        ((min   0.0)       (max 300.0)))
+   (sortino_ratio_annualized ((min -2.0)       (max   5.0)))
+   (calmar_ratio            ((min  -2.0)       (max   3.0)))
+   (ulcer_index             ((min   0.0)       (max  50.0)))
+   (wall_seconds            ((min   0.0)       (max 3600.0))))))


### PR DESCRIPTION
## Summary

Axis #2 of M5.5 tuning sweep per `dev/notes/p3-tuning-sweep-design-2026-05-13.md` (PR #1064). Varies `stops_config.min_correction_pct` ∈ {0.06, 0.08, 0.10, 0.12} on the 5y sp500-2019-2023 long-only Cell E config. All cells under `trading/test_data/backtest_scenarios/experiments/m5-5-min-correction-pct-2026-05-14/`.

**Winner: cell-010 (`min_correction_pct = 0.10`)** — best Calmar (0.82), best Sharpe (0.93), best Sortino (1.44), lowest MaxDD (18.4%), lowest ulcer index (6.86), highest return (102%). Magnitude is ~2.8x the axis-1 winner's Calmar lift (PR #1079: +0.13).

## Results

| Cell | min_corr | Return | Trades | WR | Sharpe | MaxDD | Calmar | Sortino | Ulcer | AvgHold | Result |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 006 | 0.06 | 48.43% | 307 | 38.11% | 0.54 | 26.0% | 0.32 | 0.70 | 9.54 | 34.2d | PASS |
| 008 (baseline) | 0.08 | 66.54% | 248 | 39.11% | 0.68 | 24.1% | 0.45 | 0.95 | 8.61 | 42.0d | PASS |
| **010** | **0.10** | **101.88%** | **194** | **37.11%** | **0.93** | **18.4%** | **0.82** | **1.44** | **6.86** | **56.4d** | **PASS** |
| 012 | 0.12 | 68.69% | 191 | 36.65% | 0.72 | 21.3% | 0.52 | 1.07 | 7.96 | 53.4d | PASS |

## Δ vs default (0.08)

| Metric | baseline → 010 | comment |
|---|---|---|
| Return | 66.5 → 101.9% | **+35.3 pp** |
| Trades | 248 → 194 | **−22%** churn reduction |
| WR | 39.1 → 37.1% | -2.0 pp (slightly more break-evens, but bigger wins) |
| Sharpe | 0.68 → 0.93 | **+0.25** |
| MaxDD | 24.1 → 18.4% | **−5.7 pp** (rare: return up AND DD down) |
| **Calmar** | **0.45 → 0.82** | **+0.37** (~2.8× the axis-1 winner's +0.13) |
| Sortino | 0.95 → 1.44 | +0.49 |
| Ulcer | 8.61 → 6.86 | −20% |
| AvgHold | 42 → 56d | +34% |

## Verdict

**Winner cell-010 (0.10).** The lever has a clear interior maximum: 0.06 is strictly worse on every metric, 0.10 dominates the default, and 0.12 regresses (the marginal Calmar / Sharpe / Sortino curves all invert above 0.10). This is the same knee-curve shape as axis-1 but with a much stronger peak.

## Comparison to axis-1 winner (PR #1079)

| Knob | Default → Winner | ΔCalmar | ΔReturn | ΔMaxDD |
|---|---|---:|---:|---:|
| axis-1: `installed_stop_min_pct` 0.0 → 0.08 | 0.40 → 0.53 | +0.13 | +36.4 pp | +3.9 pp |
| axis-2: `min_correction_pct` 0.08 → 0.10 | 0.45 → 0.82 | **+0.37** | +35.3 pp | **−5.7 pp** |

Axis-2 lifts Calmar ~2.8× more than axis-1, AND lowers MaxDD instead of raising it. Two mechanistic differences:

1. **Axis-2 acts on the correction-detection threshold + trailing buffer.** Lower `min_correction_pct` mis-triggers stop-raises on noise dips, widening the natural stop band reduces those false-positives without changing the entry decision.
2. **Axis-1 acts on the entry-side installed-stop floor.** It widens stops on candidates whose support-floor stop sits tighter than the floor — admits the same candidates with looser exits. Wider stops → MaxDD rises modestly, return rises proportionally.

The two levers are partially redundant (both modify effective stop distance) but operate at different state-machine stages. A future 1×2 cross-sweep (axis-1 winner 0.08 × axis-2 winner 0.10) is the natural next step.

## Recommendation

1. **Promote `stops_config.min_correction_pct = 0.10`** as a Cell E default candidate. Validate on 10y decade-2014-2023 + 16y sp500-2010-2026 long-only before promoting to goldens.
2. **Do not go higher than 0.10 on 5y** — cell-012 regresses on Calmar, Sharpe, Sortino.
3. **Cross-axis 1×2 follow-up** — combine `installed_stop_min_pct = 0.08` (axis-1 winner) × `min_correction_pct = 0.10` (axis-2 winner) and verify gains compound rather than cannibalize.

## Test plan

- [x] All 4 cells PASS existing tolerances (4/4 in run log).
- [x] Cell-008-baseline metrics match the published goldens-sp500 long-only baseline (return 66.5% / Sharpe 0.68 / MaxDD 24.1% / Calmar 0.45 → exactly matches `sp500-2019-2023-long-only.sexp` measured baseline).
- [x] Stage_dir cleaned up; only durable cell sexps committed.

Source: `dev/notes/p3-tuning-sweep-design-2026-05-13.md` (PR #1064), axis #2.
Comparison: PR #1079 axis-1 result.