### PR TITLE
experiments(tuning): M5.5 axis-3 min_score_override 5-cell sweep on sp500-2019-2023

### DIFF
--- a/dev/experiments/m5-5-axis-3-min-score-override-2026-05-14/hypothesis.md
+++ b/dev/experiments/m5-5-axis-3-min-score-override-2026-05-14/hypothesis.md
@@ -1,0 +1,63 @@
+# M5.5 axis-3 min_score_override sweep — hypothesis
+
+Date: 2026-05-14
+Scenario: `sp500-2019-2023.sexp` (Cell E config, shorts ON)
+Design doc: `dev/notes/p3-tuning-sweep-design-2026-05-13.md` (PR #1064)
+
+## Why axis-3 (after axis-1/axis-2/cross all rejected)
+
+- Axis-1 (PR #1079 → #1081): partial CONDITIONAL GO; broad-1000 inconclusive.
+- Axis-2 (PR #1083 → #1086): STOP on all three long horizons (catastrophic on 16y).
+- Cross-sweep (PR #1084): combined is destructive.
+
+All three rejected axes target **stop distance**. Axis-3 targets a different
+mechanism — the **cascade entry gate** (`screening_config.min_score_override`).
+It tightens the admission filter (fewer marginal candidates) rather than
+widening per-trade stops.
+
+## Cells (5)
+
+Vary only `screening_config.min_score_override`. The default screener uses
+`min_grade = C` which corresponds to score ≥ 40. An override replaces the
+grade ladder with a numeric floor.
+
+| Cell      | min_score_override | Grade-equivalent          |
+|-----------|--------------------|---------------------------|
+| baseline  | None (default)     | C (score >= 40)           |
+| cell-45   | 45                 | between C and B           |
+| cell-50   | 50                 | between C and B (midpoint)|
+| cell-55   | 55                 | at grade B threshold      |
+| cell-60   | 60                 | between B and A           |
+
+Grade ladder (per screener.ml): A+ ≥85, A ≥70, B ≥55, C ≥40.
+
+## Hypothesis
+
+Tighter score floor → fewer admitted candidates → entry-walk competition
+is stiffer because supply is reduced. Expected directional effects:
+
+- Trade count drops monotonically (mechanical: fewer admissions).
+- Win-rate may rise as lower-quality cells are excluded.
+- Return is ambiguous — fewer trades, each higher-quality.
+- MaxDD: unclear — could improve (better selectivity) or worsen (less
+  diversification across leaders).
+
+## Falsifiable Δ-thresholds (vs baseline)
+
+Pre-registered, identical to axis-1/axis-2 evaluation:
+
+- **ΔCalmar ≥ +0.05** → winner candidate.
+- **ΔCalmar in [−0.05, +0.05]** → neutral, no recommendation.
+- **ΔCalmar < −0.05** → reject.
+
+If a winner is identified on 5y, recommend validation on 10y (`decade-2014-2023`)
+and 16y (`sp500-2010-2026`) per the lessons from PR #1081 / #1086 (5y wins
+that fail to generalize).
+
+## Risk
+
+- Tightening admission may starve the portfolio of candidates during
+  bear phases (2020 H1, 2022) when fewer names score well — potential
+  drawdown worsening due to under-diversification or cash idling.
+- The grade ladder may already approximate a sensible default; large
+  jumps (cell-55/60) could over-tighten and degrade returns sharply.

--- a/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/baseline.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/baseline.sexp
@@ -1,0 +1,34 @@
+;; M5.5 axis-3 min_score_override sweep — baseline cell.
+;;
+;; Twin of goldens-sp500/sp500-2019-2023.sexp (Cell E config, shorts ON);
+;; no min_score_override overlay applied (default min_grade = C, score >= 40).
+;; Control for the axis-3 sweep.
+;;
+;; Pinned baseline from goldens-sp500/sp500-2019-2023.sexp (2026-05-12):
+;;   total_return_pct 50.66  total_trades 264  win_rate 37.5
+;;   sharpe_ratio 0.56  max_drawdown_pct 21.56  calmar_ratio 0.40
+;;   sortino_ratio_annualized 0.75  ulcer_index 8.41  avg_holding_days 40.78
+((name "m5-5-axis-3-baseline")
+ (description "Axis-3 baseline (Cell E, shorts on, no min_score_override overlay)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 500)
+ (config_overrides
+  (((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct        ((min -50.0)       (max 500.0)))
+   (total_trades            ((min   1)         (max 1000)))
+   (win_rate                ((min   0.0)       (max 100.0)))
+   (sharpe_ratio            ((min  -2.0)       (max   3.0)))
+   (max_drawdown_pct        ((min   0.0)       (max  80.0)))
+   (avg_holding_days        ((min   0.0)       (max 300.0)))
+   (sortino_ratio_annualized ((min -2.0)       (max   5.0)))
+   (calmar_ratio            ((min  -2.0)       (max   3.0)))
+   (ulcer_index             ((min   0.0)       (max  50.0)))
+   (wall_seconds            ((min   0.0)       (max 3600.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/cell-45.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/cell-45.sexp
@@ -1,0 +1,29 @@
+;; M5.5 axis-3 min_score_override sweep — cell-45 (mildly tighter).
+;;
+;; Overrides min_grade-derived floor (C, score >= 40) with explicit score >= 45.
+;; Lives strictly between grade C (>= 40) and grade B (>= 55).
+((name "m5-5-axis-3-cell-45")
+ (description "Axis-3 cell: min_score_override = 45 (mildly tighter than C)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 500)
+ (config_overrides
+  (((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((screening_config ((min_score_override (45)))))))
+ (expected
+  ((total_return_pct        ((min -50.0)       (max 500.0)))
+   (total_trades            ((min   1)         (max 1000)))
+   (win_rate                ((min   0.0)       (max 100.0)))
+   (sharpe_ratio            ((min  -2.0)       (max   3.0)))
+   (max_drawdown_pct        ((min   0.0)       (max  80.0)))
+   (avg_holding_days        ((min   0.0)       (max 300.0)))
+   (sortino_ratio_annualized ((min -2.0)       (max   5.0)))
+   (calmar_ratio            ((min  -2.0)       (max   3.0)))
+   (ulcer_index             ((min   0.0)       (max  50.0)))
+   (wall_seconds            ((min   0.0)       (max 3600.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/cell-50.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/cell-50.sexp
@@ -1,0 +1,29 @@
+;; M5.5 axis-3 min_score_override sweep — cell-50 (moderate).
+;;
+;; Overrides min_grade-derived floor (C, score >= 40) with explicit score >= 50.
+;; Midpoint between grade C (>= 40) and grade B (>= 55).
+((name "m5-5-axis-3-cell-50")
+ (description "Axis-3 cell: min_score_override = 50 (moderate tightening)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 500)
+ (config_overrides
+  (((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((screening_config ((min_score_override (50)))))))
+ (expected
+  ((total_return_pct        ((min -50.0)       (max 500.0)))
+   (total_trades            ((min   1)         (max 1000)))
+   (win_rate                ((min   0.0)       (max 100.0)))
+   (sharpe_ratio            ((min  -2.0)       (max   3.0)))
+   (max_drawdown_pct        ((min   0.0)       (max  80.0)))
+   (avg_holding_days        ((min   0.0)       (max 300.0)))
+   (sortino_ratio_annualized ((min -2.0)       (max   5.0)))
+   (calmar_ratio            ((min  -2.0)       (max   3.0)))
+   (ulcer_index             ((min   0.0)       (max  50.0)))
+   (wall_seconds            ((min   0.0)       (max 3600.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/cell-55.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/cell-55.sexp
@@ -1,0 +1,29 @@
+;; M5.5 axis-3 min_score_override sweep — cell-55 (tight, near grade B).
+;;
+;; Overrides min_grade-derived floor (C, score >= 40) with explicit score >= 55.
+;; Coincides with grade B threshold.
+((name "m5-5-axis-3-cell-55")
+ (description "Axis-3 cell: min_score_override = 55 (tight, at grade B threshold)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 500)
+ (config_overrides
+  (((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((screening_config ((min_score_override (55)))))))
+ (expected
+  ((total_return_pct        ((min -50.0)       (max 500.0)))
+   (total_trades            ((min   1)         (max 1000)))
+   (win_rate                ((min   0.0)       (max 100.0)))
+   (sharpe_ratio            ((min  -2.0)       (max   3.0)))
+   (max_drawdown_pct        ((min   0.0)       (max  80.0)))
+   (avg_holding_days        ((min   0.0)       (max 300.0)))
+   (sortino_ratio_annualized ((min -2.0)       (max   5.0)))
+   (calmar_ratio            ((min  -2.0)       (max   3.0)))
+   (ulcer_index             ((min   0.0)       (max  50.0)))
+   (wall_seconds            ((min   0.0)       (max 3600.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/cell-60.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/cell-60.sexp
@@ -1,0 +1,29 @@
+;; M5.5 axis-3 min_score_override sweep — cell-60 (very tight, above grade B).
+;;
+;; Overrides min_grade-derived floor (C, score >= 40) with explicit score >= 60.
+;; Sits between grade B (>= 55) and grade A (>= 70).
+((name "m5-5-axis-3-cell-60")
+ (description "Axis-3 cell: min_score_override = 60 (very tight, above grade B)")
+ (period ((start_date 2019-01-02) (end_date 2023-12-29)))
+ (universe_path "universes/sp500.sexp")
+ (universe_size 500)
+ (config_overrides
+  (((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((screening_config ((min_score_override (60)))))))
+ (expected
+  ((total_return_pct        ((min -50.0)       (max 500.0)))
+   (total_trades            ((min   1)         (max 1000)))
+   (win_rate                ((min   0.0)       (max 100.0)))
+   (sharpe_ratio            ((min  -2.0)       (max   3.0)))
+   (max_drawdown_pct        ((min   0.0)       (max  80.0)))
+   (avg_holding_days        ((min   0.0)       (max 300.0)))
+   (sortino_ratio_annualized ((min -2.0)       (max   5.0)))
+   (calmar_ratio            ((min  -2.0)       (max   3.0)))
+   (ulcer_index             ((min   0.0)       (max  50.0)))
+   (wall_seconds            ((min   0.0)       (max 3600.0))))))


### PR DESCRIPTION
## Summary

Axis-3 of the M5.5 tuning plan (`dev/notes/p3-tuning-sweep-design-2026-05-13.md`, #1064): sweep `screening_config.min_score_override` over 5y `sp500-2019-2023` (Cell E, shorts ON, 500-symbol S&P 500). 5 cells: baseline (None, default `min_grade = C` → score ≥ 40), 45, 50, 55, 60.

## Why axis-3

Axis-3 targets the **cascade entry gate**, not stop distance. All three prior axes targeting stop distance have been rejected:
- Axis-1 (#1079 → #1081): partial CONDITIONAL GO; broad-1000 inconclusive
- Axis-2 (#1083 → #1086): STOP on all 3 long horizons (catastrophic on 16y)
- Cross-sweep (#1084): combined destructive

Axis-3 is a different mechanism — admission filter, not per-trade risk. May behave differently.

## Result

Pre-registered ΔCalmar ≥ +0.05 winner threshold. None met.

| Cell      | Return%  | Trades | WR%   | Sharpe | MaxDD% | Calmar | ΔCalmar | Verdict |
|-----------|----------|--------|-------|--------|--------|--------|---------|---------|
| baseline  | 50.66    | 264    | 37.50 | 0.564  | 21.56  | 0.397  | —       | —       |
| cell-45   | 51.27    | 263    | 37.64 | 0.569  | 21.56  | 0.401  | +0.004  | neutral |
| cell-50   | 51.27    | 263    | 37.64 | 0.569  | 21.56  | 0.401  | +0.004  | neutral |
| cell-55   | 57.23    | 269    | 36.80 | 0.630  | 21.61  | 0.439  | +0.042  | neutral |
| cell-60   | 57.23    | 269    | 36.80 | 0.630  | 21.61  | 0.439  | +0.042  | neutral |

**No 5y winner.** cell-55/60 land just short of the threshold (+0.042 < +0.05).

## Observations

- **Plateau structure.** Cells 45/50 are identical; cells 55/60 are identical. The admitted-score distribution clusters around discrete buckets, so integer-spaced overrides hit the same effective floor.
- **Counter-directional trade count.** Hypothesis predicted tighter floor → fewer trades. cells 55/60 actually produced MORE trades (+5). Mechanism: tighter admission excludes marginal candidates, freeing position slots for higher-conviction names with faster Stage 2 → Stage 3 turnover.
- **MaxDD effectively flat** (21.56 → 21.61). Cascade tightening did not improve drawdown — dominant DD events on this horizon (COVID 2020 H1, 2022) bypass cascade-level selectivity.
- **Sortino lift is real but sub-threshold.** cell-55/60 +0.121 Sortino (+16% relative) suggests downside-vol reduction exists; Calmar's denominator (MaxDD) being flat damps the relative improvement.

## Verdict

Reject axis-3 as a standalone tuning candidate on 5y. **Do not validate on 10y/16y** — burning compute without a 5y winner has no falsifiable target.

## Lessons for future axes

- The screening cascade has structural plateaus. Future sweeps over `min_score_override` should be informed by an empirical per-Friday score histogram, not uniform integer spacing.
- Cascade tightening can INCREASE trade count via slot-competition reshuffling, contradicting "tighter filter → fewer trades" intuition.
- Three of four pre-registered axes (1, 2, cross) rejected; axis-3 neutral. Single-lever tuning under Cell E does not yield material risk-adjusted improvement on this horizon — bottleneck likely lies elsewhere (cost model, sector exposure, sizing dynamics).

## Test plan

- [x] All 5 scenarios PASS scenario_runner expected ranges (5/5 passed)
- [x] Output dir: `dev/backtest/scenarios-2026-05-14-030943/`
- [x] Wall ~200s parallel-3
- [x] Sweep-path linter accepts `screening_config.min_score_override` (dune runtest devtools clean)
- [x] `--no-emit-all-eligible` used per disk-conservation guidance

## Files

- `trading/test_data/backtest_scenarios/experiments/m5-5-axis-3-min-score-override-2026-05-14/{baseline,cell-45,cell-50,cell-55,cell-60}.sexp`
- `dev/experiments/m5-5-axis-3-min-score-override-2026-05-14/hypothesis.md`