### PR TITLE
feat(screener): point-in-time universe-membership gate (P5)

### DIFF
--- a/dev/experiments/p5-pi-filter-validation-2026-05-14/hypothesis.md
+++ b/dev/experiments/p5-pi-filter-validation-2026-05-14/hypothesis.md
@@ -1,0 +1,128 @@
+# P5 screener point-in-time filter — wiring validation (2026-05-14)
+
+## Setup
+
+Wired `Screener.screen_with_cooldown ?membership_at` callback + strategy-side
+plumbing (`enable_pi_filter` config flag → `Bar_reader.daily_bars_for` →
+`Daily_price.active_through` lookup). Two cells over the 16y
+`sp500-2010-2026` long-only and long-short scenarios (Cell E baseline):
+
+1. `pi-off` — `enable_pi_filter = false` (current default). Callback factory
+   returns `None`; screener admits every symbol that survives the existing
+   gates. Bit-equal to the pre-feature behaviour.
+2. `pi-on` — `enable_pi_filter = true`. Strategy hands the screener a
+   callback that consults each symbol's most-recent
+   `Daily_price.active_through` cell via `Bar_reader`.
+
+## Authority
+
+- `dev/notes/historical-universe-membership-2026-04-30.md` §P5 "screener
+  point-in-time filter".
+- `dev/notes/historical-universe-status-2026-05-13.md` §1 phase 3 action
+  item #2 — "P5 next (M) — highest-leverage gain; survivorship-aware 16y
+  backtests on the existing universe".
+- `dev/notes/next-session-priorities-2026-05-14.md` §P1 — dispatch.
+
+## Hypothesis (intent)
+
+The M5.5 verdicts — especially axis-2's catastrophic 16y STOP (MaxDD
+19.9%→60.1%, 0→26 force-liquidations on `min_correction_pct=0.10`) — were
+measured on **survivorship-biased data**: the current 16y universe sexp
+treats every delisted symbol as if it were active forever. Re-running with
+a survivorship-aware PI filter could either:
+
+- **Confirm the STOP**: bias-aware MaxDD widens further or stays bad →
+  axis-2 verdict holds; the catastrophic mode is real.
+- **Invalidate the STOP**: bias-aware MaxDD narrows substantially or the
+  force-liquidation count collapses → the failure mode was a survivorship
+  artifact; the M5.5 axis-2 verdict must be revised.
+
+## Implementation status (load-bearing caveat)
+
+**The PI gate is wired but cannot yet produce a behavioural delta on the
+current snapshot corpus.** Three layers must align for the gate to fire:
+
+1. **Source layer — DONE for SP500 (Wiki+EODHD).** CSV files under
+   `goldens-sp500/universes/sp500-historical/` carry the `active_through`
+   column (PR-A/B/C/D, MERGED).
+2. **Type layer — DONE.** `Daily_price.active_through : Date.t option` field
+   present (#1076).
+3. **Snapshot-pipeline layer — NOT STARTED.** The snapshot
+   write/reconstitute path
+   (`Snapshot_runtime.Snapshot_bar_views_helpers._make_daily_price`) hard-
+   codes `active_through = None` on every reconstituted row. So even when
+   the CSV input carries a delisting marker, by the time the strategy reads
+   bars through `Bar_reader.daily_bars_for`, the marker is `None` and the
+   PI predicate returns `true` (admit) on every symbol.
+
+Step 3 is the foundational P3 follow-up — propagating `active_through`
+through the snapshot pipeline — and is intentionally **out of scope for this
+PR** per the task framing. See `dev/notes/historical-universe-status-
+2026-05-13.md` §1 row "P3 — `Daily_price.active_through` field" (NOT
+STARTED).
+
+## What this PR validates today
+
+| Cell | Expected vs baseline | What it pins |
+|---|---|---|
+| `pi-off` (default) | Bit-equal to pre-feature | Default-off contract: no goldens shift, no behavioural drift on any 5y / 10y / 16y scenario without a config opt-in. |
+| `pi-on` (today) | Bit-equal to `pi-off` | The PI gate's hot path is exercised, but every callback returns `true` because the snapshot strips `active_through`. Validates that **wiring the seam does not regress the cascade**. |
+| `pi-on` (post-P3) | Behavioural delta on 16y | Once the snapshot pipeline propagates `active_through`, this cell becomes the survivorship-aware 16y baseline. |
+
+## Falsifiability (today)
+
+- **`pi-off` ≠ baseline goldens** → wiring change regressed the default path.
+  Sanity-fail; blocks merge.
+- **`pi-on` ≠ `pi-off`** in any 5y / 16y scenario where every symbol's
+  active_through is `None` (which is every scenario today) → callback
+  factory is misfiring or the screener's PI gate has a bug. Sanity-fail;
+  blocks merge.
+
+## Falsifiability (post-P3, follow-up)
+
+- **`pi-on` 16y MaxDD ≈ `pi-off` 16y MaxDD on long-only** → survivorship
+  bias is not the cause of axis-2's catastrophic failure; the M5.5 verdict
+  stands as-is.
+- **`pi-on` 16y MaxDD ≪ `pi-off` 16y MaxDD on long-only** → survivorship
+  bias inflated the failure mode; the M5.5 axis-2 verdict must be revised,
+  and a re-run of the axis-2 sweep on PI-aware data is warranted.
+
+## Headline metrics (intended after P3 lands)
+
+Table to be filled in once `Daily_price.active_through` propagates through
+the snapshot pipeline. The runner cells should pin: total return, CAGR,
+Sharpe, MaxDD, force-liquidation count, total trades, win rate, average
+hold days. The "Δ vs pi-off" column is the survivorship-bias attribution.
+
+| Scenario | Cell | Return | CAGR | Sharpe | MaxDD | Force-liq | Trades | WR |
+|---|---|---|---|---|---|---|---|---|
+| sp500-2010-2026 long-only | pi-off | — | — | — | — | — | — | — |
+| sp500-2010-2026 long-only | pi-on | — | — | — | — | — | — | — |
+| sp500-2010-2026 long-short | pi-off | — | — | — | — | — | — | — |
+| sp500-2010-2026 long-short | pi-on | — | — | — | — | — | — | — |
+
+## Decision criteria (post-P3)
+
+- **M5.5 axis-2 verdict revision** iff: pi-on 16y long-only MaxDD < pi-off
+  MaxDD by ≥ 10pp AND force-liq count drops by ≥ 50% AND axis-2 `0.10` cell
+  re-runs above pi-off baseline. Triggers `memory/project_m5-5-tuning-
+  exhausted.md` update.
+- **Keep M5.5 verdicts** iff: pi-on 16y MaxDD within ±3pp of pi-off AND
+  force-liq count within ±20%. Survivorship is not the load-bearing factor.
+
+## Test-of-record
+
+- `trading/analysis/weinstein/screener/test/test_screener.ml`:
+  - `test_pi_filter_default_admits_all` — `pi-off` bit-equality.
+  - `test_pi_filter_admits_both` — explicit always-member callback.
+  - `test_pi_filter_excludes_delisted` — rejection branch (in-memory).
+  - `test_pi_filter_consults_as_of` — date-dependent semantics.
+  - `test_pi_filter_composes_with_cooldown` — gate composition.
+- `trading/trading/weinstein/strategy/test/test_pi_filter_wiring.ml`:
+  - Strategy-side wiring (`enable_pi_filter` flag → callback factory →
+    `Daily_price.active_through` lookup via `Bar_reader`).
+
+The screener-layer test pins the rejection semantics directly (feeds an
+in-memory predicate to the cascade); the strategy-layer test pins what's
+reachable through today's pipeline (the `None` and no-bars branches +
+flag-driven `Some`/`None` callback factory).

--- a/dev/experiments/p5-pi-filter-validation-2026-05-14/scenarios/pi-off.sexp
+++ b/dev/experiments/p5-pi-filter-validation-2026-05-14/scenarios/pi-off.sexp
@@ -1,0 +1,31 @@
+;; PI filter OFF: bit-equal twin of goldens-sp500-historical/sp500-2010-2026.sexp
+;; (long-only Cell E baseline). Control arm for the P5 wiring validation.
+;; See ../hypothesis.md for the load-bearing caveat about today's snapshot
+;; pipeline stripping active_through.
+((name "pi-filter-off-2010-2026")
+ (description
+   "P5 control — Cell E 16y long-only, enable_pi_filter=false (default)")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct   ((min 290.0)         (max 393.0)))
+   (total_trades       ((min 640)           (max  800)))
+   (win_rate           ((min  33.2)         (max  44.9)))
+   (sharpe_ratio       ((min   0.66)        (max   0.90)))
+   (max_drawdown_pct   ((min  15.6)         (max  21.2)))
+   (avg_holding_days   ((min  37.9)         (max  51.3)))
+   (open_positions_value ((min 3400000.0)   (max 4400000.0)))
+   (sortino_ratio_annualized ((min  1.06)   (max   1.43)))
+   (calmar_ratio       ((min   0.44)        (max   0.59)))
+   (ulcer_index        ((min   6.35)        (max   8.60)))
+   (wall_seconds       ((min 600.0)         (max 2400.0))))))

--- a/dev/experiments/p5-pi-filter-validation-2026-05-14/scenarios/pi-on.sexp
+++ b/dev/experiments/p5-pi-filter-validation-2026-05-14/scenarios/pi-on.sexp
@@ -1,0 +1,44 @@
+;; PI filter ON: 16y long-only Cell E with enable_pi_filter=true.
+;;
+;; **EXPECTED BEHAVIOUR TODAY**: bit-equal to pi-off because the snapshot
+;; pipeline currently strips Daily_price.active_through during the
+;; write/reconstitute cycle. Every callback invocation returns true
+;; (admit), so the cascade behaves identically to the default path.
+;; This cell validates that wiring the seam does not regress the hot path.
+;;
+;; **EXPECTED BEHAVIOUR POST-P3**: once the snapshot pipeline propagates
+;; active_through (see dev/notes/historical-universe-status-2026-05-13.md
+;; §1 row P3, NOT STARTED), this cell becomes the survivorship-aware 16y
+;; baseline. Headline metrics (MaxDD, force-liq count, total return) may
+;; shift materially; the M5.5 axis-2 STOP verdict will be re-evaluated.
+;;
+;; Expected ranges below mirror pi-off because the gate is a no-op today.
+;; Re-pin in a follow-up PR after P3 propagation lands.
+((name "pi-filter-on-2010-2026")
+ (description
+   "P5 treatment — Cell E 16y long-only, enable_pi_filter=true (no-op until P3)")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((enable_pi_filter true))))
+ (expected
+  ((total_return_pct   ((min 290.0)         (max 393.0)))
+   (total_trades       ((min 640)           (max  800)))
+   (win_rate           ((min  33.2)         (max  44.9)))
+   (sharpe_ratio       ((min   0.66)        (max   0.90)))
+   (max_drawdown_pct   ((min  15.6)         (max  21.2)))
+   (avg_holding_days   ((min  37.9)         (max  51.3)))
+   (open_positions_value ((min 3400000.0)   (max 4400000.0)))
+   (sortino_ratio_annualized ((min  1.06)   (max   1.43)))
+   (calmar_ratio       ((min   0.44)        (max   0.59)))
+   (ulcer_index        ((min   6.35)        (max   8.60)))
+   (wall_seconds       ((min 600.0)         (max 2400.0))))))

--- a/dev/status/screener.md
+++ b/dev/status/screener.md
@@ -3,7 +3,7 @@
 ## Last updated: 2026-05-14
 
 ## Status
-MERGED — with one PR in flight
+IN_PROGRESS
 
 Cascade post-stop-out cooldown gate landed via PR #718 (merged 2026-04-30 evening). 2026-05-14: `feat/screener-pi-filter` adds an opt-in point-in-time universe-membership gate (`Screener.screen_with_cooldown ?membership_at`) plus strategy-side wiring (`enable_pi_filter` config flag → `Bar_reader.daily_bars_for` → `Daily_price.active_through`). Default-off preserves all baselines; behavioural effect is gated on the P3 follow-up (snapshot pipeline propagation of `active_through`). See `dev/experiments/p5-pi-filter-validation-2026-05-14/` and `dev/notes/historical-universe-status-2026-05-13.md`.
 

--- a/dev/status/screener.md
+++ b/dev/status/screener.md
@@ -1,11 +1,11 @@
 # Status: screener
 
-## Last updated: 2026-05-01
+## Last updated: 2026-05-14
 
 ## Status
-MERGED
+MERGED — with one PR in flight
 
-Cascade post-stop-out cooldown gate landed via PR #718 (merged 2026-04-30 evening). Track wraps for now; cascade re-base detection (book-conformance follow-up to #718) is queued under §Followup but not in flight.
+Cascade post-stop-out cooldown gate landed via PR #718 (merged 2026-04-30 evening). 2026-05-14: `feat/screener-pi-filter` adds an opt-in point-in-time universe-membership gate (`Screener.screen_with_cooldown ?membership_at`) plus strategy-side wiring (`enable_pi_filter` config flag → `Bar_reader.daily_bars_for` → `Daily_price.active_through`). Default-off preserves all baselines; behavioural effect is gated on the P3 follow-up (snapshot pipeline propagation of `active_through`). See `dev/experiments/p5-pi-filter-validation-2026-05-14/` and `dev/notes/historical-universe-status-2026-05-13.md`.
 
 ## QC Review
 APPROVED — See dev/reviews/screener.md (2026-03-30). All prior blockers resolved.

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -419,16 +419,9 @@ let _cooldown_block_set ~cooldown_weeks ~as_of ~last_stop_out_dates =
         if elapsed < cooldown_days then Some ticker else None)
     |> String.Set.of_list
 
-(** Single-pass filter that drops [held], [cooldown], and non-member symbols and
-    resolves each survivor's sector context. Was a chained [filter |> map]
-    allocating two lists; the [filter_map] keeps just one. Runs every Friday
-    over the full screened universe (potentially thousands of symbols).
-
-    [is_member] is the point-in-time membership predicate. A symbol is admitted
-    only when [is_member a.ticker] is [true]; the default predicate (used by
-    [screen]) returns [true] unconditionally so existing callers preserve
-    bit-equality. See [screen_with_cooldown] for the wiring that closes over
-    [as_of]. *)
+(** Single-pass filter dropping [held], [cooldown], and non-member symbols.
+    [is_member] defaults to always-true via [screen]; [screen_with_cooldown]
+    wires it from [?membership_at] closed over [as_of]. *)
 let _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map ~is_member =
   List.filter_map stocks ~f:(fun (a : Stock_analysis.t) ->
       if Set.mem held_set a.ticker then None
@@ -487,15 +480,9 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
         ~buy_candidates ~short_candidates;
   }
 
-(** Default membership predicate — admits every symbol. Used as the seed for
-    [screen] / [screen_with_cooldown] when the caller does not supply
-    [?membership_at]; preserves bit-equality with the pre-PI-filter behaviour.
-*)
-let _always_member (_ : string) = true
-
 let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
   _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers
-    ~cooldown_set:String.Set.empty ~is_member:_always_member
+    ~cooldown_set:String.Set.empty ~is_member:(fun _ -> true)
 
 let screen_with_cooldown ?membership_at ~config ~macro_trend ~sector_map ~stocks
     ~held_tickers ~as_of ~last_stop_out_dates () : result =
@@ -503,10 +490,8 @@ let screen_with_cooldown ?membership_at ~config ~macro_trend ~sector_map ~stocks
     _cooldown_block_set ~cooldown_weeks:config.cascade_post_stop_cooldown_weeks
       ~as_of ~last_stop_out_dates
   in
-  let is_member =
-    match membership_at with
-    | None -> _always_member
-    | Some m -> fun ticker -> m ticker as_of
+  let is_member ticker =
+    match membership_at with None -> true | Some m -> m ticker as_of
   in
   _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
     ~is_member

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -419,18 +419,25 @@ let _cooldown_block_set ~cooldown_weeks ~as_of ~last_stop_out_dates =
         if elapsed < cooldown_days then Some ticker else None)
     |> String.Set.of_list
 
-(** Single-pass filter that drops [held] and [cooldown] symbols and resolves
-    each survivor's sector context. Was a chained [filter |> map] allocating two
-    lists; the [filter_map] keeps just one. Runs every Friday over the full
-    screened universe (potentially thousands of symbols). *)
-let _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map =
+(** Single-pass filter that drops [held], [cooldown], and non-member symbols and
+    resolves each survivor's sector context. Was a chained [filter |> map]
+    allocating two lists; the [filter_map] keeps just one. Runs every Friday
+    over the full screened universe (potentially thousands of symbols).
+
+    [is_member] is the point-in-time membership predicate. A symbol is admitted
+    only when [is_member a.ticker] is [true]; the default predicate (used by
+    [screen]) returns [true] unconditionally so existing callers preserve
+    bit-equality. See [screen_with_cooldown] for the wiring that closes over
+    [as_of]. *)
+let _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map ~is_member =
   List.filter_map stocks ~f:(fun (a : Stock_analysis.t) ->
       if Set.mem held_set a.ticker then None
       else if Set.mem cooldown_set a.ticker then None
+      else if not (is_member a.ticker) then None
       else Some (a, _resolve_sector ~sector_map a.ticker))
 
 let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
-    : result =
+    ~is_member : result =
   let held_set = String.Set.of_list held_tickers in
   let {
     weights;
@@ -451,7 +458,7 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
   in
   let total_stocks = List.length stocks in
   let candidates =
-    _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map
+    _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map ~is_member
   in
   let candidates_after_held = List.length candidates in
   let buy_candidates =
@@ -480,14 +487,26 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
         ~buy_candidates ~short_candidates;
   }
 
+(** Default membership predicate — admits every symbol. Used as the seed for
+    [screen] / [screen_with_cooldown] when the caller does not supply
+    [?membership_at]; preserves bit-equality with the pre-PI-filter behaviour.
+*)
+let _always_member (_ : string) = true
+
 let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
   _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers
-    ~cooldown_set:String.Set.empty
+    ~cooldown_set:String.Set.empty ~is_member:_always_member
 
-let screen_with_cooldown ~config ~macro_trend ~sector_map ~stocks ~held_tickers
-    ~as_of ~last_stop_out_dates : result =
+let screen_with_cooldown ?membership_at ~config ~macro_trend ~sector_map ~stocks
+    ~held_tickers ~as_of ~last_stop_out_dates () : result =
   let cooldown_set =
     _cooldown_block_set ~cooldown_weeks:config.cascade_post_stop_cooldown_weeks
       ~as_of ~last_stop_out_dates
   in
+  let is_member =
+    match membership_at with
+    | None -> _always_member
+    | Some m -> fun ticker -> m ticker as_of
+  in
   _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
+    ~is_member

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -273,11 +273,13 @@ val screen :
     @param stocks Per-stock analysis results.
     @param held_tickers Tickers already in portfolio — excluded from output.
 
-    Pure function. Equivalent to {!screen_with_cooldown} with [as_of = None] and
-    [last_stop_out_dates = []] — i.e. the post-stop-out cooldown gate is a no-op
-    regardless of [config.cascade_post_stop_cooldown_weeks]. *)
+    Pure function. Equivalent to {!screen_with_cooldown} with no [membership_at]
+    callback, [as_of] equal to today, and [last_stop_out_dates = []] — i.e. the
+    post-stop-out cooldown gate and the point-in-time membership gate are both
+    no-ops. *)
 
 val screen_with_cooldown :
+  ?membership_at:(string -> Core.Date.t -> bool) ->
   config:config ->
   macro_trend:Weinstein_types.market_trend ->
   sector_map:(string, sector_context) Core.Hashtbl.t ->
@@ -285,17 +287,36 @@ val screen_with_cooldown :
   held_tickers:string list ->
   as_of:Core.Date.t ->
   last_stop_out_dates:(string * Core.Date.t) list ->
+  unit ->
   result
 (** [screen_with_cooldown] is {!screen} with the per-symbol post-stop-out
-    cooldown gate active.
+    cooldown gate active and an optional point-in-time (PI) membership gate.
 
+    @param membership_at
+      Optional point-in-time universe-membership predicate. When supplied, the
+      cascade rejects any symbol for which [membership_at ticker as_of] returns
+      [false] before stage classification, sector resolution, or scoring runs.
+      The intent is to model "this symbol was not in the eligible universe on
+      [as_of]" — e.g. a delisted symbol whose bars are stale, a stock added to
+      the index after [as_of], or any other source of survivorship-bias drift in
+      the loaded universe.
+
+    Default behaviour ([None]): every symbol is treated as a member — bit-equal
+    to the pre-PI-filter cascade. The default preserves every existing baseline
+    so wiring this gate at a single call site is a no-op until the caller opts
+    in.
+
+    Authority: [dev/notes/historical-universe-membership-2026-04-30.md] §P5 —
+    "screener point-in-time filter";
+    [dev/notes/historical-universe-status-2026-05-13.md] §1 phase 3 action item
+    #2.
     @param as_of Cascade evaluation date.
     @param last_stop_out_dates
       Per-symbol last stop-out date. Each entry [(ticker, date)] excludes
       [ticker] from the cascade if
       [(as_of - date) < config.cascade_post_stop_cooldown_weeks * 7] days. When
       [config.cascade_post_stop_cooldown_weeks = 0] the gate is a no-op, so this
-      function is bit-equal to {!screen} on the same inputs.
+      function is bit-equal to {!screen} on the same inputs (modulo PI filter).
 
     Authority: weinstein-book-reference.md §Buy-Side Rules — a stopped-out trade
     signals the breakout was false; book does not prescribe a specific cooldown

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -1128,6 +1128,7 @@ let test_cooldown_disabled_no_exclusion _ =
     screen_with_cooldown ~config:cfg ~macro_trend:Bullish
       ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
       ~last_stop_out_dates:[ ("AAPL", Date.add_days as_of (-1)) ]
+      ()
   in
   assert_that result.buy_candidates
     (elements_are [ field (fun c -> c.ticker) (equal_to "AAPL") ])
@@ -1140,6 +1141,7 @@ let test_cooldown_recent_stop_excludes _ =
     screen_with_cooldown ~config:cooldown_cfg ~macro_trend:Bullish
       ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
       ~last_stop_out_dates:[ ("AAPL", Date.add_days as_of (-14)) ]
+      ()
   in
   assert_that result.buy_candidates is_empty
 
@@ -1151,6 +1153,7 @@ let test_cooldown_elapsed_stop_eligible _ =
     screen_with_cooldown ~config:cooldown_cfg ~macro_trend:Bullish
       ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
       ~last_stop_out_dates:[ ("AAPL", Date.add_days as_of (-35)) ]
+      ()
   in
   assert_that result.buy_candidates
     (elements_are [ field (fun c -> c.ticker) (equal_to "AAPL") ])
@@ -1163,10 +1166,82 @@ let test_cooldown_per_symbol_scope _ =
     screen_with_cooldown ~config:cooldown_cfg ~macro_trend:Bullish
       ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
       ~last_stop_out_dates:[ ("AAPL", Date.add_days as_of (-7)) ]
+      ()
   in
   assert_that result.buy_candidates
     (all_of
        [ size_is 1; elements_are [ field (fun c -> c.ticker) (equal_to "HD") ] ])
+
+(* ------------------------------------------------------------------ *)
+(* Point-in-time membership filter                                    *)
+(* ------------------------------------------------------------------ *)
+
+(** PI filter unsupplied (default): every symbol is admitted — pins bit-equality
+    with the pre-feature [screen_with_cooldown]. *)
+let test_pi_filter_default_admits_all _ =
+  let stocks = _breakout_stocks [ "AAPL"; "HD" ] in
+  let result =
+    screen_with_cooldown ~config:cfg ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
+      ~last_stop_out_dates:[] ()
+  in
+  assert_that result.buy_candidates (size_is 2)
+
+(** PI filter explicitly admits both symbols: same result as the default. *)
+let test_pi_filter_admits_both _ =
+  let stocks = _breakout_stocks [ "AAPL"; "HD" ] in
+  let always_member _ _ = true in
+  let result =
+    screen_with_cooldown ~membership_at:always_member ~config:cfg
+      ~macro_trend:Bullish ~sector_map:(empty_sector_map ()) ~stocks
+      ~held_tickers:[] ~as_of ~last_stop_out_dates:[] ()
+  in
+  assert_that result.buy_candidates (size_is 2)
+
+(** PI filter rejects AAPL (delisted) but keeps HD. Models a 16y backtest where
+    a symbol was active for years before [as_of] but is no longer in the
+    eligible universe. *)
+let test_pi_filter_excludes_delisted _ =
+  let stocks = _breakout_stocks [ "AAPL"; "HD" ] in
+  let membership_at ticker _date = not (String.equal ticker "AAPL") in
+  let result =
+    screen_with_cooldown ~membership_at ~config:cfg ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
+      ~last_stop_out_dates:[] ()
+  in
+  assert_that result.buy_candidates
+    (all_of
+       [ size_is 1; elements_are [ field (fun c -> c.ticker) (equal_to "HD") ] ])
+
+(** PI filter is consulted with [as_of]: a callback that depends on the date can
+    admit or reject the same ticker on different days. *)
+let test_pi_filter_consults_as_of _ =
+  let stocks = _breakout_stocks [ "AAPL" ] in
+  let cutoff = Date.add_days as_of (-1) in
+  (* AAPL is a member only on or before [cutoff]; here as_of > cutoff. *)
+  let membership_at _ticker date = Date.( <= ) date cutoff in
+  let result =
+    screen_with_cooldown ~membership_at ~config:cfg ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ()) ~stocks ~held_tickers:[] ~as_of
+      ~last_stop_out_dates:[] ()
+  in
+  assert_that result.buy_candidates is_empty
+
+(** PI filter composes with the cooldown gate: a symbol that would survive the
+    cooldown gate but fail the PI filter is still rejected. *)
+let test_pi_filter_composes_with_cooldown _ =
+  let stocks = _breakout_stocks [ "AAPL"; "HD" ] in
+  let cooldown_cfg = { cfg with cascade_post_stop_cooldown_weeks = 4 } in
+  (* HD blocked by PI filter; AAPL blocked by cooldown (recent stop). *)
+  let membership_at ticker _date = not (String.equal ticker "HD") in
+  let result =
+    screen_with_cooldown ~membership_at ~config:cooldown_cfg
+      ~macro_trend:Bullish ~sector_map:(empty_sector_map ()) ~stocks
+      ~held_tickers:[] ~as_of
+      ~last_stop_out_dates:[ ("AAPL", Date.add_days as_of (-7)) ]
+      ()
+  in
+  assert_that result.buy_candidates is_empty
 
 let suite =
   "screener_tests"
@@ -1248,6 +1323,13 @@ let suite =
          "test_cooldown_elapsed_stop_eligible"
          >:: test_cooldown_elapsed_stop_eligible;
          "test_cooldown_per_symbol_scope" >:: test_cooldown_per_symbol_scope;
+         "test_pi_filter_default_admits_all"
+         >:: test_pi_filter_default_admits_all;
+         "test_pi_filter_admits_both" >:: test_pi_filter_admits_both;
+         "test_pi_filter_excludes_delisted" >:: test_pi_filter_excludes_delisted;
+         "test_pi_filter_consults_as_of" >:: test_pi_filter_consults_as_of;
+         "test_pi_filter_composes_with_cooldown"
+         >:: test_pi_filter_composes_with_cooldown;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -20,6 +20,8 @@ module Audit_recorder = Audit_recorder
 module Entry_audit_capture = Entry_audit_capture
 module Exit_audit_capture = Exit_audit_capture
 include Weinstein_strategy_config
+module Weinstein_strategy_macro = Weinstein_strategy_macro
+module Weinstein_strategy_config = Weinstein_strategy_config
 module S = Weinstein_strategy_screening
 
 let held_symbols = S.held_symbols

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -107,6 +107,18 @@ module Exit_audit_capture = Exit_audit_capture
 (** Exit-side trade-audit capture. Bridges [TriggerExit] transitions to
     {!Audit_recorder.exit_event}. See {!Exit_audit_capture}. *)
 
+module Weinstein_strategy_macro = Weinstein_strategy_macro
+(** Macro computation and screen-dispatch helpers. Re-exposed for tests that
+    drive {!Weinstein_strategy_macro.Internal_for_test} (the PI membership
+    predicate and the flag-driven callback factory consumed by
+    {!Screener.screen_with_cooldown}'s [?membership_at] argument). *)
+
+module Weinstein_strategy_config = Weinstein_strategy_config
+(** Strategy configuration record + {!Weinstein_strategy_config.default_config}
+    factory. Re-exposed so tests can construct configs without depending on the
+    included-into-this-module re-export below (which is read-only at the type
+    level). *)
+
 (** {1 Configuration} *)
 
 type index_config = {
@@ -282,6 +294,29 @@ type config = {
           sweeps can tune [ma_slope_min], [pullback_band],
           [consolidation_weeks], and [consolidation_range_pct] via the standard
           config-override mechanism (issue #889 follow-up). *)
+  enable_pi_filter : bool; [@sexp.default false]
+      (** Master switch for the screener point-in-time (PI) universe-membership
+          filter. Default [false] preserves all existing baselines: the
+          [Screener.screen_with_cooldown] [?membership_at] callback is left
+          unsupplied and every loaded symbol participates in the cascade.
+
+          When [true], the strategy builds a callback from per-symbol bar reads
+          — a symbol is treated as a member on [as_of] iff its most recent
+          observed bar's [Daily_price.active_through] is either [None] (still
+          trading / unknown delisting status) or [Some d] with [as_of <= d].
+          Symbols delisted before [as_of] are excluded from stage
+          classification, sector resolution, and scoring before the cascade's
+          downstream phases run.
+
+          Authority: [dev/notes/historical-universe-membership-2026-04-30.md]
+          §P5; [dev/notes/historical-universe-status-2026-05-13.md] §1 phase 3
+          action item #2.
+
+          The opt-in default is intentional: enabling the filter changes which
+          symbols the cascade considers and shifts every existing fixture's
+          pinned numbers as the underlying [active_through] column propagates
+          through the snapshot pipeline. Re-pinning goldens is a separate
+          post-merge step. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -49,6 +49,29 @@ type config = {
       [@sexp.default Continuation.default_config]
       (** Detector parameters; only consulted when
           [enable_continuation_buys = true]. See [.mli] for tuning context. *)
+  enable_pi_filter : bool; [@sexp.default false]
+      (** Master switch for the screener point-in-time (PI) universe-membership
+          filter. Default [false] preserves all existing baselines: the
+          [Screener.screen_with_cooldown] [?membership_at] callback is left
+          unsupplied and every loaded symbol participates in the cascade.
+
+          When [true], the strategy builds a callback from per-symbol bar reads
+          — a symbol is treated as a member on [as_of] iff its most recent
+          observed bar's [Daily_price.active_through] is either [None] (still
+          trading / unknown delisting status) or [Some d] with [as_of <= d].
+          Symbols delisted before [as_of] are excluded from stage
+          classification, sector resolution, and scoring before the cascade's
+          downstream phases run.
+
+          Authority: [dev/notes/historical-universe-membership-2026-04-30.md]
+          §P5; [dev/notes/historical-universe-status-2026-05-13.md] §1 phase 3
+          action item #2.
+
+          The opt-in default is intentional: enabling the filter changes which
+          symbols the cascade considers and shifts every existing fixture's
+          pinned numbers as the underlying [active_through] column propagates
+          through the snapshot pipeline. Re-pinning goldens is a separate
+          post-merge step. *)
 }
 [@@deriving sexp]
 
@@ -79,6 +102,7 @@ let default_config ~universe ~index_symbol =
     laggard_reentry_cooldown_weeks = 0;
     enable_continuation_buys = false;
     continuation_config = Continuation.default_config;
+    enable_pi_filter = false;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -49,6 +49,10 @@ type config = {
           [ma_slope_min], [pullback_band], [consolidation_weeks], and
           [consolidation_range_pct] via the standard config-override mechanism.
       *)
+  enable_pi_filter : bool; [@sexp.default false]
+      (** Master switch for the screener point-in-time universe-membership
+          filter (universe plan phase P5). Default [false] preserves existing
+          baselines. See [.ml] for full semantics. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.ml
@@ -39,6 +39,39 @@ let run_macro_only ~config ~ad_bars ~prior_macro ~prior_macro_result ~bar_reader
   prior_macro_result := Some macro_result;
   macro_result
 
+(** Point-in-time membership predicate derived from [Bar_reader].
+
+    [pi_membership_at ~bar_reader symbol as_of] returns:
+    - [true] when the symbol has no resident bars on or before [as_of] — no
+      delisting information available, default to membership so the cascade's
+      downstream phases (which will themselves drop the symbol when its weekly
+      view is empty) make the rejection decision uniformly.
+    - [true] when the most recent bar's [active_through] is [None] — the symbol
+      is still trading or the loader did not surface a delisting marker.
+    - [Core.Date.(as_of <= d)] when the most recent bar's [active_through] is
+      [Some d] — the symbol was active through [d] and is treated as a member on
+      or before that date.
+
+    Reading the last bar only (rather than scanning the full history) is
+    sufficient: the snapshot pipeline writes [active_through] uniformly on every
+    per-symbol row, so any non-empty history will surface the marker on its last
+    row. *)
+let _pi_membership_at ~bar_reader (symbol : string) (as_of : Core.Date.t) =
+  let bars = Bar_reader.daily_bars_for bar_reader ~symbol ~as_of in
+  match List.last bars with
+  | None -> true
+  | Some bar -> (
+      match bar.Types.Daily_price.active_through with
+      | None -> true
+      | Some d -> Core.Date.( <= ) as_of d)
+
+(** Build the optional [?membership_at] callback for {!screen_universe} based on
+    [config.enable_pi_filter]. When the flag is [false] (default), returns
+    [None] — the screener's PI gate is a no-op and baselines are preserved. When
+    [true], returns [Some] of {!_pi_membership_at} closed over [bar_reader]. *)
+let _membership_at_callback_of ~config ~bar_reader =
+  if config.enable_pi_filter then Some (_pi_membership_at ~bar_reader) else None
+
 (** Run the Friday universe screener path given an already-computed
     [macro_result]. Under all macro regimes (Bullish, Neutral, Bearish) the
     screener is invoked; macro-specific gating — longs blocked under Bearish,
@@ -59,9 +92,11 @@ let run_screen_after_macro ~config ~stop_states ~last_stop_out_dates ~bar_reader
       ~sector_etfs:config.sector_etfs ~cb ~as_of:current_date
       ~sector_prior_stages ~index_view ~ticker_sectors ()
   in
-  Weinstein_strategy_screening.screen_universe ~config ~index_view ~macro_result
-    ~sector_map ~stop_states ~last_stop_out_dates ~portfolio ~get_price
-    ~bar_reader ~prior_stages ~current_date ~audit_recorder
+  let membership_at = _membership_at_callback_of ~config ~bar_reader in
+  Weinstein_strategy_screening.screen_universe ?membership_at ~config
+    ~index_view ~macro_result ~sector_map ~stop_states ~last_stop_out_dates
+    ~portfolio ~get_price ~bar_reader ~prior_stages ~current_date
+    ~audit_recorder ()
 
 (** Run the universe screen when the strategy is active (not halted, on a
     Friday, with a valid macro result). Returns the list of entry transitions,
@@ -78,3 +113,8 @@ let entry_transitions_if_active ~halted ~is_screening_day ~macro_result_opt
         ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
         ~macro_result
   | _ -> []
+
+module Internal_for_test = struct
+  let pi_membership_at = _pi_membership_at
+  let membership_at_callback_of = _membership_at_callback_of
+end

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.mli
@@ -61,3 +61,34 @@ val entry_transitions_if_active :
     [is_screening_day = true], and [macro_result_opt = Some _]. Returns [[]]
     when any guard is false. Keeps [_on_market_close] at a shallow nesting
     level. *)
+
+module Internal_for_test : sig
+  val pi_membership_at : bar_reader:Bar_reader.t -> string -> Date.t -> bool
+  (** [pi_membership_at ~bar_reader symbol as_of] is the point-in-time
+      membership predicate the strategy hands to
+      {!Screener.screen_with_cooldown} when [config.enable_pi_filter = true].
+
+      Returns [true] for: a symbol with no resident bars (no delisting marker
+      available; the cascade's downstream phases will themselves drop the symbol
+      when its weekly view is empty); a symbol whose most recent bar has
+      [active_through = None] (still trading or unknown delisting status); a
+      symbol whose most recent bar has [active_through = Some d] with
+      [as_of <= d].
+
+      Returns [false] only when the most recent bar carries
+      [active_through = Some d] with [as_of > d] — the symbol is known to have
+      been delisted before the cascade's evaluation date.
+
+      Exposed for behavioural unit-testing of the [Bar_reader] →
+      [Daily_price.active_through] wiring. *)
+
+  val membership_at_callback_of :
+    config:Weinstein_strategy_config.config ->
+    bar_reader:Bar_reader.t ->
+    (string -> Date.t -> bool) option
+  (** [membership_at_callback_of ~config ~bar_reader] returns [None] when
+      [config.enable_pi_filter = false] (default), preserving existing
+      baselines, and [Some] of {!pi_membership_at} closed over [bar_reader] when
+      [config.enable_pi_filter = true]. Exposed for unit-testing the flag-driven
+      branch. *)
+end

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -240,10 +240,10 @@ let _sector_filter_of ~sector_map (ticker, view, _prior, sr) =
     pre-filter → Phase 2 full {!Stock_analysis}). Macro-trend gating lives in
     the screener; concatenating [buy_candidates] + [short_candidates] yields the
     right shape per regime. *)
-let screen_universe ~config ~index_view ~(macro_result : Macro.result)
-    ~sector_map ~stop_states ~last_stop_out_dates
+let screen_universe ?membership_at ~config ~index_view
+    ~(macro_result : Macro.result) ~sector_map ~stop_states ~last_stop_out_dates
     ~(portfolio : Portfolio_view.t) ~get_price ~bar_reader ~prior_stages
-    ~current_date ~audit_recorder =
+    ~current_date ~audit_recorder () =
   let classified =
     _classify_all ~config ~bar_reader ~prior_stages ~current_date
   in
@@ -259,10 +259,11 @@ let screen_universe ~config ~index_view ~(macro_result : Macro.result)
   in
   _commit_prior_stages ~prior_stages classified;
   let screen_result =
-    Screener.screen_with_cooldown ~config:config.screening_config
+    Screener.screen_with_cooldown ?membership_at ~config:config.screening_config
       ~macro_trend:macro_result.trend ~sector_map ~stocks
       ~held_tickers:(held_symbols portfolio) ~as_of:current_date
       ~last_stop_out_dates:(Hashtbl.to_alist last_stop_out_dates)
+      ()
   in
   let combined_candidates =
     if config.enable_short_side then

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -295,7 +295,6 @@ let screen_universe ?membership_at ~config ~index_view
     week-bucket aggregation). *)
 let is_screening_day_view
     (view : Snapshot_runtime.Snapshot_bar_views.weekly_view) =
-  if view.n = 0 then false
-  else
-    Date.day_of_week view.dates.(view.n - 1)
-    |> Day_of_week.equal Day_of_week.Fri
+  view.n > 0
+  && Day_of_week.equal Day_of_week.Fri
+       (Date.day_of_week view.dates.(view.n - 1))

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -9,6 +9,7 @@
   test_force_liquidation_strategy
   test_macro_inputs
   test_panel_callbacks
+  test_pi_filter_wiring
   test_short_side_bear_window
   test_stage3_force_exit_runner
   test_laggard_rotation_runner

--- a/trading/trading/weinstein/strategy/test/test_pi_filter_wiring.ml
+++ b/trading/trading/weinstein/strategy/test/test_pi_filter_wiring.ml
@@ -1,0 +1,139 @@
+(** Tests for the screener point-in-time (PI) filter wiring in the Weinstein
+    strategy.
+
+    Pins the [Bar_reader.daily_bars_for] → [Daily_price.active_through] →
+    [membership_at] callback path that [Weinstein_strategy_macro] hands to
+    [Screener.screen_with_cooldown] when [config.enable_pi_filter = true].
+
+    Authority: [dev/notes/historical-universe-membership-2026-04-30.md] §P5
+    "screener point-in-time filter";
+    [dev/notes/historical-universe-status- 2026-05-13.md] §1 phase 3 action item
+    #2.
+
+    {b Caveat — snapshot pipeline currently strips [active_through]}. The
+    in-memory bar reader ({!Bar_reader.of_in_memory_bars}) round-trips bars
+    through the snapshot-pipeline write/read path. The snapshot-runtime
+    reconstitution
+    ([Snapshot_runtime.Snapshot_bar_views_helpers._make_daily_price]) hard-
+    codes [active_through = None] on every reconstituted row, so any
+    [active_through] set on the input bars is dropped before reaching
+    {!Bar_reader.daily_bars_for}'s consumers (this PR).
+
+    That is the foundational P3 follow-up — propagating [active_through] through
+    the snapshot pipeline — and is intentionally out of scope here. The tests
+    below cover what can be exercised today: (a) the [None] / no-bars branches
+    of the predicate, (b) the flag-driven callback factory. The rejection branch
+    ([active_through = Some d] with [as_of > d]) is pinned at the {!Screener}
+    layer by [test_pi_filter_excludes_delisted] in [test_screener.ml], which
+    feeds the cascade an in-memory predicate directly. *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_reader = Weinstein_strategy.Bar_reader
+module Macro = Weinstein_strategy.Weinstein_strategy_macro
+module Config = Weinstein_strategy.Weinstein_strategy_config
+
+let _ymd y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+let _is_weekday d =
+  match Date.day_of_week d with
+  | Day_of_week.Sat | Day_of_week.Sun -> false
+  | _ -> true
+
+let _weekdays_starting ~start ~n =
+  let rec loop acc d remaining =
+    if remaining = 0 then List.rev acc
+    else if _is_weekday d then
+      loop (d :: acc) (Date.add_days d 1) (remaining - 1)
+    else loop acc (Date.add_days d 1) remaining
+  in
+  loop [] start n
+
+let _make_bar ~date ~price : Types.Daily_price.t =
+  {
+    date;
+    open_price = price;
+    high_price = price *. 1.01;
+    low_price = price *. 0.99;
+    close_price = price;
+    adjusted_close = price;
+    volume = 1_000_000;
+    active_through = None;
+  }
+
+let _bars ~n ~start_date ~start_price ~step =
+  let dates = _weekdays_starting ~start:start_date ~n in
+  List.mapi dates ~f:(fun i d ->
+      _make_bar ~date:d ~price:(start_price +. (Float.of_int i *. step)))
+
+let _default_config () =
+  Config.default_config ~universe:[ "AAPL"; "MSFT" ] ~index_symbol:"SPY"
+
+(* ------------------------------------------------------------------ *)
+(* pi_membership_at: branches reachable through the current pipeline   *)
+(* ------------------------------------------------------------------ *)
+
+(** No resident bars: predicate returns [true] — default to membership so the
+    cascade's downstream phases (which themselves drop the symbol when its
+    weekly view is empty) make the rejection decision uniformly. *)
+let test_no_bars_admits _ =
+  let bar_reader = Bar_reader.empty () in
+  assert_that
+    (Macro.Internal_for_test.pi_membership_at ~bar_reader "AAPL"
+       (_ymd 2024 6 14))
+    (equal_to true)
+
+(** Most-recent bar's [active_through] reconstitutes to [None] under the current
+    snapshot pipeline (P3 propagation not yet wired): predicate returns [true].
+    Pins the bit-equality contract that PI-filter ON today does not change which
+    symbols are admitted purely on bar contents — only the
+    {!Daily_price.active_through} P3 follow-up activates the rejection branch.
+*)
+let test_active_through_currently_admits_through_snapshot _ =
+  let bars =
+    _bars ~n:10 ~start_date:(_ymd 2024 1 2) ~start_price:100.0 ~step:0.5
+  in
+  let bar_reader = Bar_reader.of_in_memory_bars [ ("AAPL", bars) ] in
+  assert_that
+    (Macro.Internal_for_test.pi_membership_at ~bar_reader "AAPL"
+       (_ymd 2024 6 14))
+    (equal_to true)
+
+(* ------------------------------------------------------------------ *)
+(* membership_at_callback_of: flag-driven wiring                       *)
+(* ------------------------------------------------------------------ *)
+
+(** Default config ([enable_pi_filter = false]): callback factory returns [None]
+    — the screener's PI gate is a no-op and all baselines are preserved. *)
+let test_callback_default_is_none _ =
+  let config = _default_config () in
+  let bar_reader = Bar_reader.empty () in
+  assert_that
+    (Macro.Internal_for_test.membership_at_callback_of ~config ~bar_reader)
+    is_none
+
+(** [enable_pi_filter = true] with no bars: callback factory returns [Some _],
+    and the wrapped callback returns [true] on every symbol (the no-bars branch
+    defaults to membership). This pins the "flag flip → seam open" half of the
+    wiring; the as_of-vs-active_through semantics are covered by the
+    screener-layer test. *)
+let test_callback_enabled_returns_some _ =
+  let config = { (_default_config ()) with enable_pi_filter = true } in
+  let bar_reader = Bar_reader.empty () in
+  assert_that
+    (Macro.Internal_for_test.membership_at_callback_of ~config ~bar_reader)
+    (is_some_and (field (fun c -> c "AAPL" (_ymd 2024 6 14)) (equal_to true)))
+
+let suite =
+  "pi_filter_wiring_tests"
+  >::: [
+         "test_no_bars_admits" >:: test_no_bars_admits;
+         "test_active_through_currently_admits_through_snapshot"
+         >:: test_active_through_currently_admits_through_snapshot;
+         "test_callback_default_is_none" >:: test_callback_default_is_none;
+         "test_callback_enabled_returns_some"
+         >:: test_callback_enabled_returns_some;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- Adds `?membership_at : (string -> Date.t -> bool)` callback to `Screener.screen_with_cooldown`. When supplied, the cascade rejects any symbol for which the callback returns `false` on the cascade's `as_of` date before stage classification / sector resolution / scoring run.
- Wires the callback from the strategy via a new `enable_pi_filter` config flag (default-off). When enabled, the strategy hands the screener a predicate that reads each symbol's most-recent `Daily_price.active_through` cell through `Bar_reader.daily_bars_for`.
- Default-off preserves every existing baseline bit-equal — the callback factory returns `None`, and the screener's `_always_member` predicate admits all symbols.

This is the structural unlock for survivorship-aware backtests per the universe plan phase P5. The seam is in place; the behavioural delta requires the orthogonal P3 follow-up (snapshot pipeline propagation of `active_through`).

## Load-bearing caveat

The PI gate is wired but cannot yet produce a behavioural delta on the current snapshot corpus. The snapshot runtime (`snapshot_bar_views_helpers._make_daily_price`) hard-codes `active_through = None` on every reconstituted row, so the CSV-source `active_through` markers are dropped before reaching the strategy. That is P3 (NOT STARTED per `dev/notes/historical-universe-status-2026-05-13.md`), explicitly out of scope here.

M5.5 axis-2 verdict status: UNCHANGED. The hypothesis that survivorship bias inflated the catastrophic 16y failure (MaxDD 19.9%->60.1%, 0->26 force-liquidations on `min_correction_pct=0.10`) remains testable but blocked on P3.

## Authority

- `dev/notes/historical-universe-membership-2026-04-30.md` P5 - "screener point-in-time filter".
- `dev/notes/historical-universe-status-2026-05-13.md` phase 3 action item #2.
- `dev/notes/next-session-priorities-2026-05-14.md` P1 - dispatch.

## Files

- `analysis/weinstein/screener/lib/screener.{ml,mli}` - new `?membership_at` param + `is_member` predicate in `_prepare_candidates` / `_screen`. Public `screen` stays unchanged.
- `trading/weinstein/strategy/lib/weinstein_strategy_config.{ml,mli}` - new `enable_pi_filter : bool [@sexp.default false]`.
- `trading/weinstein/strategy/lib/weinstein_strategy.{ml,mli}` - duplicate `config` record updated; new module aliases exposed for the new strategy-side test.
- `trading/weinstein/strategy/lib/weinstein_strategy_macro.{ml,mli}` - `_pi_membership_at` (reads `Bar_reader.daily_bars_for` -> `Daily_price.active_through`) + `_membership_at_callback_of` (flag-driven `None`/`Some`). `Internal_for_test` exposes both for unit tests.
- `trading/weinstein/strategy/lib/weinstein_strategy_screening.ml` - `screen_universe` accepts `?membership_at` and forwards.
- `dev/experiments/p5-pi-filter-validation-2026-05-14/` - hypothesis + pi-off / pi-on scenarios for the post-P3 follow-up run.
- `dev/status/screener.md` - note the in-flight PR.

## Test plan

- [x] `dune build` green
- [x] `dune runtest` green (51 tests in screener suite; 4 tests in new test_pi_filter_wiring; full repo suite green)
- [x] `dune build @fmt` clean
- [x] Default-off (`enable_pi_filter = false`) bit-equality pinned by `test_pi_filter_default_admits_all` + `test_callback_default_is_none`
- [x] Rejection branch pinned by `test_pi_filter_excludes_delisted` (in-memory predicate at the screener layer)
- [x] `as_of`-dependent semantics pinned by `test_pi_filter_consults_as_of`
- [x] Gate composition with cooldown pinned by `test_pi_filter_composes_with_cooldown`
- [x] Strategy-side wiring (`enable_pi_filter` -> callback factory -> `Daily_price.active_through` via `Bar_reader`) pinned by `test_pi_filter_wiring.ml`

## Follow-up

1. P3 - `Daily_price.active_through` snapshot propagation (owner: ops-data / data-foundations). Wire `active_through` through `snapshot_pipeline` write + `snapshot_runtime` reconstitute.
2. P5 re-run on PI-aware corpus - run `dev/experiments/p5-pi-filter-validation-2026-05-14/scenarios/{pi-off,pi-on}.sexp` after P3 lands.
3. M5.5 axis-2 re-evaluation - if `pi-on` 16y MaxDD drops materially, re-run axis-2 `min_correction_pct = 0.10` on PI-aware data and update `memory/project_m5-5-tuning-exhausted.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)