### PR TITLE
docs(notes): strategic pivot 2026-05-15 — broader-first beats more-knobs

### DIFF
--- a/dev/notes/next-session-priorities-2026-05-14.md
+++ b/dev/notes/next-session-priorities-2026-05-14.md
@@ -1,5 +1,12 @@
 # Next-session priorities (2026-05-14)
 
+> **Superseded by `dev/notes/next-session-priorities-2026-05-15.md`** —
+> strategic pivot to broader-first + ML-discipline tuning. The P1-P3
+> priorities below all landed today (PRs #1089, #1090, #1091, plus
+> followups #1094 + #1095); the P4-P5 priorities are demoted to a new
+> P1 tier behind the broader-universe data-foundation work that's now
+> the P0. See the successor note for the new framing.
+
 ## Context
 
 The 2026-05-13 → 2026-05-14 marathon landed 29 PRs, including the M5.5

--- a/dev/notes/next-session-priorities-2026-05-15.md
+++ b/dev/notes/next-session-priorities-2026-05-15.md
@@ -1,0 +1,151 @@
+# Next-session priorities (2026-05-15) — strategic pivot
+
+Supersedes `dev/notes/next-session-priorities-2026-05-14.md`.
+
+## TL;DR
+
+Two cross-window inversions this week — M5.5 axis-2's 5y→16y blowup
+(PR #1086) and today's continuation-buy combined-axis sweep
+(PR #1095) — have made the diagnosis explicit:
+
+**Cell E is locally near-optimal on the levers it exposes. The limiting
+factor is what the optimizer is looking at, not what knobs we give it.**
+
+Lean broader-first:
+
+- **P0** — broader survivorship-correct universes + walk-forward CV +
+  multi-parameter ML tuning. Build the data foundation that lets the
+  validation discipline scale beyond single-axis sweeps.
+- **P1** — sector-concentration cap + short-side margin Phase 1.
+  Useful features in their own right, but no longer load-bearing for
+  the next breakthrough. Land them so the multi-parameter optimizer
+  can choose to set them, not as human-tuned cells.
+- **P2 / defer** — synthetic data, more single-axis sweeps,
+  hand-tuned "Cell F" variants.
+
+## P0 — broader-universe + ML-discipline tuning
+
+Treat as a coherent 2-4 week track, dispatched in PR-sized increments.
+
+### Phase 1 — universe extension (~5-10 PRs, 1-2 weeks)
+
+Extend `dev/notes/historical-universe-status-2026-05-13.md` work from
+the 510-symbol 2010-2026 universe to a broader / longer cohort:
+
+1. **`sp500-1996-01-01.sexp` membership data.** Mirror PR #1076's
+   per-symbol `active_through` columns back to 1996. Need historical
+   SP500 membership change-log (likely from Wikipedia changelog via
+   PR #813's `Changes_parser` infra). Authority: same hypothesis as
+   PR #1076 — survivorship bias inflates losses by ~13 pp CAGR on 16y
+   (verified by today's P3-followup data).
+2. **`broad-3000-2010-01-01.sexp` cohort.** Expand beyond SP500
+   constituents to the full Russell 3000 universe with PI-aware
+   active-through data. The current 510-sym universe artificially
+   constrains cross-sectional dispersion the Weinstein cascade
+   depends on.
+3. **Survivorship-correct re-pin of pinned baselines.** Replace the
+   current `goldens-sp500-historical/sp500-2010-2026.sexp` pinned
+   baseline with one where PI filter is ON by default. Today's
+   pinned baseline was measured on survivorship-biased data — every
+   downstream tuning conclusion stacks on it.
+
+Track owner: `feat-data` per `dev/decisions.md` 2026-05-03 §"Agent
+scope".
+
+### Phase 2 — walk-forward CV harness (~3-5 PRs, 1 week)
+
+The existing `dev/experiments/cell-e-walk-forward-2026-05-08/` has
+8 half-period folds. Scale to ~30 rolling folds with explicit
+out-of-sample windows. Output a `walk_forward_report.md` per
+configuration that surfaces:
+
+- Per-fold Sharpe / CAGR / MaxDD / Calmar.
+- Rolling-fold stability (variance across folds).
+- Cross-fold parameter sensitivity (does cell X win on every fold or
+  just the average?).
+- Explicit go/no-go gate: "wins on ≥M of N folds with no fold worse
+  than baseline by Δ" — the gate language matters because it's the
+  one thing both M5.5 axis-2 and continuation-combined would have
+  failed.
+
+Track owner: `feat-backtest`.
+
+### Phase 3 — multi-parameter Bayesian optimizer (~3-5 PRs, 1 week)
+
+Scale up `bayesian_runner.exe` (PR #914) from 4-D bounds to the full
+Cell E config knob set (~15-25 tunable parameters). Score on
+walk-forward CV from Phase 2, with explicit MaxDD penalty term in
+the loss function. Acceptance criterion: converges to a cell that
+beats Cell E on walk-forward Sharpe by ≥0.05 with MaxDD no worse.
+
+Track owner: `feat-backtest`.
+
+## P1 — feature work that the optimizer will tune over
+
+These are still wanted as features, but no longer load-bearing for
+the next breakthrough. Land them so Phase 3 can choose to set them.
+
+### Sector-concentration cap
+
+Per the prior priorities doc §P4. New config field
+`max_sector_exposure_pct : float option`, gate in `portfolio_risk`.
+M effort. Touches `Portfolio_risk` (core watchlist — qc-structural
+A1 will FLAG, qc-behavioral judges generalizability).
+
+### Short-side margin Phase 1
+
+Per `dev/plans/short-side-margin-2026-05-13.md`. Default-off
+`enable_margin_accounting` flag + Reg-T initial/maintenance margin
++ borrow fee. L effort. Touches `Portfolio` (core — same A1 flag
+pattern).
+
+The plan's hypothesis (realistic margin makes shorts strictly
+negative-EV at current Stage-4 entry edge) is testable after Phase 3
+runs — let the optimizer decide if shorts should be on at all.
+
+## P2 / defer
+
+- **Synthetic data with proper statistical attributes** — research
+  project (regime switching, fat tails, sector rotations, correlation
+  structure). Defer until P0 surfaces a specific failure mode that
+  requires synthetic to study. Current Synth-v1/v2/v3 (PRs #755 /
+  #775 / #1028) already provide block-bootstrap + HMM-GARCH +
+  multi-symbol factor model — sufficient for unit testing but not
+  for strategy validation.
+- **More single-axis sweeps under Cell E** — explicitly REJECTED.
+  See `memory/project_m5-5-tuning-exhausted.md` and
+  `memory/project_continuation_combined_rejected.md`.
+- **Hand-tuned Cell F variants** — same. Hand-tuning produces
+  cells that look good on the eyeballed window and fail validation.
+  Pass this work to Phase 3.
+
+## What the user said (2026-05-15)
+
+User framing: "we should lean broader-first; sector cap / margin /
+etc. are P1; defer synthetic". This note records the agreement.
+
+## Recommended sequencing
+
+1. **Spin up `feat-data` on Phase 1.1** (1996 membership data) — the
+   single most expensive prerequisite. Most other Phase 1 work
+   blocks on it.
+2. In parallel, **dispatch `feat-backtest` on Phase 2** (walk-forward
+   harness) — independent of Phase 1; can run on the existing
+   510-sym 2010-2026 universe to start, then re-baseline once Phase 1
+   lands.
+3. **Sector cap (P1)** is a good "small win" dispatch when you want
+   a feature PR on the side of the data-foundation work. It's
+   orthogonal to the universe extension.
+4. **Margin Phase 1 (P1)** waits until the broader universe lands —
+   margin behavior across regimes (2000-2002 + 2008 windows) is the
+   point, and those windows need real per-symbol membership data to
+   evaluate honestly.
+
+## Open follow-ups still in flight when this was written
+
+- PR #1095 (P3-followup combined sweep, REJECTED on 16y) — awaits
+  CI + qc-structural + qc-behavioral. Will merge for the record.
+- PI-filter 16y validation experiment — `feat-backtest` agent running
+  in background. Tests whether M5.5 axis-2's 16y STOP verdict was
+  a survivorship artifact. Once it lands, that data informs Phase 1.3
+  (the survivorship-correct re-pin).

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -1,11 +1,36 @@
 # Status: data-foundations
 
-## Last updated: 2026-05-13
+## Last updated: 2026-05-15
 
 ## Status
-READY_FOR_REVIEW
+IN_PROGRESS
 
 ## Notes
+
+**2026-05-15 strategic pivot — track elevated to P0.** Per
+`dev/notes/next-session-priorities-2026-05-15.md`, broader-universe +
+longer-horizon survivorship-correct data is now the load-bearing
+prerequisite for the next round of strategy work. Two cross-window
+inversions in one week (M5.5 axis-2 PR #1086 + continuation combined
+PR #1095) confirmed Cell E is locally near-optimal on the levers it
+exposes; the limiting factor is what the optimizer is looking at. New
+Phase 1 work below:
+
+1. **`sp500-1996-01-01.sexp` membership data** — mirror PR #1076's
+   per-symbol `active_through` columns back to 1996, sourced from
+   the Wikipedia changelog infra in PR #813 (`Changes_parser`).
+2. **`broad-3000-2010-01-01.sexp` cohort** — expand beyond SP500 to
+   the full Russell 3000 with PI-aware `active_through` data.
+3. **Survivorship-correct re-pin of `goldens-sp500-historical/sp500-2010-2026.sexp`** —
+   replace current pinned baseline (measured on survivorship-biased
+   data per #1076's hypothesis) with one where PI filter is ON by
+   default.
+
+Owner: feat-data. Status flipped READY_FOR_REVIEW → IN_PROGRESS on
+the strategic pivot.
+
+**Prior notes retained below.**
+
 M5.3 streaming Phases A + A.1 + B + C + D + E + F.1 all merged (#779/#786/#781/#782/#790/#791/#793); Phase B writer perf fix O(N²)→O(N) merged (#792). **F.2 default-flip COMPLETE 2026-05-03** (#797/#800/#802 — snapshot mode is now the canonical runtime path). **Wiki+EODHD PR-A/B/C/D MERGED** (#803/#808/#809/#813). **F.3.a sub-sequence COMPLETE 2026-05-04** (#825/#827/#828/#829). **F.3.b–F.3.e ALL MERGED 2026-05-04..06** (#833 b-1, #837 c-1, #842 d-1, #861/#864 #848 forward fix, #866 b-2/c-2/d-2 caller migration, #868/#869 e-1/e-2 type relocation + `Bar_reader.of_panels` deletion, #875/#876/#877 e-3 stack — `Bar_panels.{ml,mli}` DELETED; sp500-2019-2023 baseline bit-equal 58.34%/81 across the stack). **M5.3 streaming Phase F COMPLETE.**
 
 **Synth-v1 — block bootstrap — MERGED 2026-05-02 (#755).** **Synth-v2 — HMM + GARCH — MERGED 2026-05-02 (#775).** **Synth-v3 — multi-symbol factor model — MERGED 2026-05-11 (#1028)** (`factor_model.{ml,mli}` + `synth_v3.{ml,mli}` + `generate_synth_v3.exe` CLI; 44 new tests passing; cross-sectional avg pairwise correlation in [0.3, 0.7] target band; 500-sym × 80yr universe smoke-tested via the CLI). **EODHD multi-market expansion MERGED 2026-05-02 (#772)** — LSE/TSE/ASX/HKEX/TSX symbol resolution.

--- a/dev/status/tuning.md
+++ b/dev/status/tuning.md
@@ -1,9 +1,43 @@
 # Status: tuning
 
-## Last updated: 2026-05-13
+## Last updated: 2026-05-15
 
 ## Status
 IN_PROGRESS
+
+**2026-05-15 strategic pivot — track elevated to P0 alongside
+data-foundations.** Per `dev/notes/next-session-priorities-2026-05-15.md`,
+multi-parameter ML-discipline tuning over the full Cell E config
+surface (~15-25 parameters) on walk-forward CV is now the primary
+tuning vector. Two cross-window inversions in one week (PR #1086 M5.5
+axis-2 + PR #1095 continuation combined) confirmed that single-axis
+and small-grid sweeps under fixed windows are diagnostic-only at this
+point; further manual tuning is rejected.
+
+New Phase 2 work — **walk-forward CV harness scaled up**:
+- Extend `dev/experiments/cell-e-walk-forward-2026-05-08/` (8 half-period
+  folds) to ~30 rolling folds.
+- Output `walk_forward_report.md` surfacing per-fold metrics + cross-
+  fold stability + parameter sensitivity + explicit go/no-go gate
+  ("wins on ≥M of N folds with no fold worse than baseline by Δ").
+- This gate language is what M5.5 axis-2 and continuation-combined
+  would have failed.
+
+New Phase 3 work — **multi-parameter Bayesian opt scaled up**:
+- Extend `bayesian_runner.exe` (PR #914) from current 4-D bounds to
+  the full Cell E config surface.
+- Scored on Phase 2 walk-forward CV with explicit MaxDD penalty.
+- Acceptance: converges to a cell beating Cell E on walk-forward
+  Sharpe by ≥0.05 with MaxDD no worse.
+
+Phase 2 is independent of `data-foundations` Phase 1 (can run on
+existing 510-sym 2010-2026 universe) and should land in parallel.
+Phase 3 benefits from Phase 1 broader universe but is not strictly
+blocked on it.
+
+Owner: feat-backtest.
+
+**Prior status preamble retained below.**
 
 (T-A lib + CLI MERGED; T-B lib + CLI MERGED; 81-cell flagship grid RUN but key-path bug invalidated result; weights surface CONFIRMED load-bearing via correct field paths)
 


### PR DESCRIPTION
## Summary

Strategic priorities pivot. After two cross-window inversions in one week
(PR #1086 M5.5 axis-2 + PR #1095 continuation combined), Cell E is confirmed
locally near-optimal on the levers it exposes. The limiting factor is what
the optimizer is looking at, not what knobs we give it.

New framing:
- **P0** — broader survivorship-correct universes + walk-forward CV +
  multi-parameter ML-discipline tuning.
- **P1** — sector-concentration cap + short-side margin Phase 1 (still
  wanted, but no longer load-bearing; land them so the optimizer can choose
  to set them).
- **Defer** — synthetic data, more single-axis sweeps, hand-tuned Cell F
  variants.

## Files

- `dev/notes/next-session-priorities-2026-05-15.md` — new primary priorities
  doc with the broader-first framing.
- `dev/notes/next-session-priorities-2026-05-14.md` — header pointer marking
  supersession.
- `dev/status/data-foundations.md` — flipped READY_FOR_REVIEW → IN_PROGRESS;
  Phase 1 work (1996 membership, 3000-sym cohort, survivorship-correct re-pin)
  enumerated.
- `dev/status/tuning.md` — Phase 2 walk-forward CV harness + Phase 3
  multi-parameter Bayesian opt enumerated as the new primary tuning vectors.

## Why now

User-confirmed agreement (in-session 2026-05-15) that:
- ~2-4 weeks of foundation work is worth it to land before the next visible
  tuning result.
- Synthetic data with proper statistical attributes is its own research
  project; defer until P0 surfaces a specific failure mode that requires it.
- Sector cap + margin still land as features but in parallel as small PRs,
  not as the headline lever to move Cell E.

See `memory/project_strategic_pivot_broader_first.md` for the in-session
rationale + sequencing recommendation.

## Test plan

- [x] Docs-only PR; no source code touched.
- [ ] CI passes status-file integrity linter (the two status files use the
  canonical schema).
- [ ] qc-structural reviews the doc structure.
- [ ] Merge once both gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)