### PR TITLE
feat(backtest): walk-forward CV harness (Phase 2, first PR)

### DIFF
--- a/dev/plans/walk-forward-cv-harness-2026-05-15.md
+++ b/dev/plans/walk-forward-cv-harness-2026-05-15.md
@@ -1,0 +1,283 @@
+# Walk-forward CV harness — implementation plan (Phase 2)
+
+Date: 2026-05-15. Authority:
+`dev/notes/next-session-priorities-2026-05-15.md` §"Phase 2 —
+walk-forward CV harness". This is the first PR of a planned ~3-5 PR
+track owned by `feat-backtest`.
+
+## Context
+
+Two cross-window inversions this week — M5.5 axis-2's 5y→16y blowup
+(PR #1086) and the continuation-buy combined-axis sweep (PR #1095) —
+have made the diagnosis explicit: **Cell E is locally near-optimal on
+the levers it exposes**. The limiting factor is the validation
+discipline, not the search surface.
+
+The existing walk-forward setup at
+`dev/experiments/cell-e-walk-forward-2026-05-08/` is **8 hand-curated
+scenarios** (4 pairs × 2 cells). That partition produced an "11/12
+wins" verdict that nonetheless failed both subsequent 16y validation
+sweeps. The hand-curated shape:
+
+- Only 4 underlying windows; one (`bull-crash-2018-2020` /
+  `six-year-2018-2020`) is bit-identical.
+- Two-half splits give 2 measurements per window — minimum useful
+  variance signal.
+- No explicit go/no-go gate; the verdict was eyeballed from the table.
+
+Phase 2 scales this to ~30 rolling folds with parameterised window
+specs, automated report generation, and a load-bearing
+machine-checkable gate.
+
+The existing infra:
+
+- `Scenario_lib.Scenario` (`trading/trading/backtest/scenarios/scenario.{ml,mli}`)
+  — sexp-loadable scenario with `period`, `universe_path`,
+  `config_overrides`, `expected`.
+- `Scenario_runner` (`.../scenario_runner.ml`) — parallel
+  per-scenario runner via fork; writes `actual.sexp` + per-scenario
+  artefacts under a timestamped output root.
+- `Tuner_bin.Bayesian_runner_evaluator` — the closest analogue: an
+  evaluator builder that takes `~fixtures_root ~scenarios
+  ~scenarios_by_path ~objective` and runs backtests with parameter
+  overrides applied per cell. Phase 3 will likely consume this lib.
+
+## Approach
+
+Add a new sub-library + binary under
+`trading/trading/backtest/walk_forward/`:
+
+- `lib/window_spec.{ml,mli}` — `WindowSpec.t` describing rolling
+  window generation: anchor dates, train/test/step lengths in days,
+  whether to emit train fold or test-only fold scenarios. Pure;
+  produces a list of `{ name; period }` pairs.
+- `lib/fold_gate.{ml,mli}` — pure go/no-go gate. Encodes the rule
+  "wins on ≥M of N folds with no fold worse than baseline by Δ". `M`,
+  `N`, and `Δ` configurable. Returns `Gate_pass | Gate_fail of
+  reason_list`.
+- `lib/walk_forward_runner.{ml,mli}` — pure: given a base scenario
+  sexp template + `WindowSpec.t` + a list of variant config-override
+  bundles (each tagged with a label like "baseline" / "cell-E"),
+  generates per-fold per-variant `Scenario.t` values ready for
+  `scenario_runner` execution. **Does not run backtests itself in this
+  PR** — delegation is via emitting scenario sexps to a scratch dir
+  and shelling out to the existing `scenario_runner.exe`, OR by
+  exposing the generated list for an in-process driver. We pick the
+  emit-and-shell-out shape because (a) it reuses the entire forked
+  scenario_runner harness, (b) it's interruptible / re-runnable, (c)
+  it gives free per-fold artefacts (trades.csv, summary.sexp, etc.)
+  for downstream diagnosis.
+- `lib/walk_forward_report.{ml,mli}` — pure: given a list of
+  `(fold_name, variant_label, actual.sexp)` triples + a baseline
+  variant label + gate parameters, emits a markdown report with the
+  four required sections (per-fold metrics, stability, sensitivity,
+  go/no-go).
+- `bin/walk_forward_runner.ml` — thin CLI: reads a top-level sexp
+  spec (`(window_spec ...) (variants ((label baseline) (overrides
+  ...))) (base_scenario ...) (gate ...)`), generates per-fold
+  scenario sexps under `--out-dir/scenarios/`, optionally invokes
+  `Scenario_runner` machinery in-process (NOT shelling out — same
+  process), reads the per-fold `actual.sexp` files, emits
+  `walk_forward_report.md`.
+
+### Public interfaces
+
+```ocaml
+(* window_spec.mli *)
+type t = {
+  start_date : Date.t;          (* first fold start *)
+  end_date : Date.t;            (* last fold end (clamp) *)
+  train_days : int;             (* in-sample width; 0 = OOS-only folds *)
+  test_days : int;              (* out-of-sample width *)
+  step_days : int;              (* how far to advance each fold *)
+} [@@deriving sexp]
+
+type fold = {
+  index : int;                  (* 0-based *)
+  name : string;                (* e.g. "fold-007" *)
+  train_period : Scenario.period option;   (* None when train_days = 0 *)
+  test_period : Scenario.period;
+} [@@deriving sexp]
+
+val generate : t -> fold list
+(** Pure: roll a window of train_days + test_days from start_date
+    forward in step_days increments, clamping to end_date.
+    Folds whose test_period would extend past end_date are dropped. *)
+```
+
+```ocaml
+(* fold_gate.mli *)
+type metric_key =
+  | Sharpe
+  | Calmar
+  | TotalReturnPct
+  | MaxDrawdownPct
+[@@deriving sexp]
+
+type t = {
+  metric : metric_key;          (* what to gate on *)
+  m : int;                      (* must win at least M folds *)
+  n : int;                      (* of the N folds measured *)
+  worst_delta : float;          (* no single fold worse than baseline by > Δ *)
+} [@@deriving sexp]
+
+type fold_result = {
+  fold_name : string;
+  variant_score : float;
+  baseline_score : float;
+}
+
+type verdict =
+  | Pass of { wins : int; n : int; }
+  | Fail of { wins : int; n : int; worst_fold : string; worst_gap : float; reason : string }
+
+val evaluate : t -> fold_result list -> verdict
+```
+
+```ocaml
+(* walk_forward_runner.mli — scenario generation *)
+type variant = {
+  label : string;
+  overrides : Sexp.t list;
+}
+
+val build_fold_scenario :
+  base : Scenario.t ->
+  fold : Window_spec.fold ->
+  variant : variant ->
+  Scenario.t
+(** Pure: produces a Scenario.t with name = "<base.name>-<variant.label>-<fold.name>",
+    period = fold.test_period, config_overrides = base.config_overrides @
+    variant.overrides. *)
+
+val build_all :
+  base : Scenario.t ->
+  spec : Window_spec.t ->
+  variants : variant list ->
+  Scenario.t list
+```
+
+```ocaml
+(* walk_forward_report.mli *)
+type fold_actual = {
+  fold_name : string;
+  variant_label : string;
+  total_return_pct : float;
+  sharpe_ratio : float;
+  max_drawdown_pct : float;
+  calmar_ratio : float;
+}
+
+val render :
+  baseline_label : string ->
+  gate : Fold_gate.t ->
+  fold_actuals : fold_actual list ->
+  string
+(** Pure: produces a markdown report with:
+    (1) Per-fold metrics table (one row per fold × variant)
+    (2) Stability table (mean ± stdev per variant)
+    (3) Sensitivity ranking (variant win-count per fold)
+    (4) Go/no-go verdict block from Fold_gate.evaluate. *)
+```
+
+### Rejected alternatives
+
+1. **Reuse `Tuner_bin.Bayesian_runner_evaluator` directly.** That
+   evaluator takes a single scenario and folds parameters over it. The
+   walk-forward harness folds **windows**, not parameters — different
+   axis. We will hand off variant evaluation to Phase 3's BO loop, but
+   the walk-forward harness must own window generation independently.
+2. **Modify `scenario.mli` to add a `windows` field.** That bloats the
+   scenario type for every consumer. Keep windows as a separate spec;
+   generate per-window scenarios from a base template.
+3. **Re-invent metric collection / forking.** We delegate execution to
+   `Backtest.Runner.run_backtest` directly inside the binary (same
+   pattern as `Bayesian_runner_evaluator.build`). Parallel forking is
+   future work — start sequential, mirror `scenario_runner.ml`'s
+   fork-pool only if needed.
+
+## Files to change
+
+| Path | Status | Est. lines |
+|---|---|---|
+| `trading/trading/backtest/walk_forward/lib/window_spec.mli` | new | ~30 |
+| `trading/trading/backtest/walk_forward/lib/window_spec.ml` | new | ~50 |
+| `trading/trading/backtest/walk_forward/lib/fold_gate.mli` | new | ~40 |
+| `trading/trading/backtest/walk_forward/lib/fold_gate.ml` | new | ~80 |
+| `trading/trading/backtest/walk_forward/lib/walk_forward_runner.mli` | new | ~40 |
+| `trading/trading/backtest/walk_forward/lib/walk_forward_runner.ml` | new | ~60 |
+| `trading/trading/backtest/walk_forward/lib/walk_forward_report.mli` | new | ~40 |
+| `trading/trading/backtest/walk_forward/lib/walk_forward_report.ml` | new | ~150 |
+| `trading/trading/backtest/walk_forward/lib/dune` | new | ~10 |
+| `trading/trading/backtest/walk_forward/test/test_window_spec.ml` | new | ~80 |
+| `trading/trading/backtest/walk_forward/test/test_fold_gate.ml` | new | ~120 |
+| `trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml` | new | ~80 |
+| `trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml` | new | ~80 |
+| `trading/trading/backtest/walk_forward/test/dune` | new | ~10 |
+| `trading/trading/backtest/walk_forward/bin/walk_forward_runner.ml` | new | ~120 |
+| `trading/trading/backtest/walk_forward/bin/dune` | new | ~10 |
+| `dev/status/walk-forward-cv.md` | new | ~50 |
+| `dev/plans/walk-forward-cv-harness-2026-05-15.md` | this file | ~250 |
+
+Total estimated source lines: ~720; total tests: ~360; total LOC
+including docs/status: ~1050.
+
+## Risks
+
+1. **Same M5.5 cross-window inversion the gate is meant to prevent.**
+   The gate language ("wins on ≥M of N with no fold worse than
+   baseline by Δ") only catches inversions if the fold count is
+   large enough to surface tail behavior. Mitigation: the gate is
+   tunable; the harness is the discipline, not the threshold. Phase 3
+   chooses thresholds.
+2. **30 folds × N variants is multi-hour even on small universe.**
+   Mitigation: this PR ships the scenario-generation + report
+   machinery + a tiny integration test (2-3 folds on parity-7sym).
+   Big-fold runs are out of scope for this PR; they're run-time
+   artefacts produced once the harness is merged.
+3. **Sexp interface ossification.** The variant-and-gate sexp shape
+   becomes the public contract for downstream tooling. Mitigation:
+   mark unstable in the `.mli`; we expect to iterate when Phase 3 BO
+   integration lands.
+4. **Date arithmetic.** Train/test boundary off-by-one bugs are
+   classic walk-forward failures. Mitigation: `WindowSpec.generate`
+   is pure with property tests over canonical date inputs.
+
+## Acceptance (this PR only)
+
+- [ ] `dune build && dune runtest` passes from a clean checkout.
+- [ ] `dune build @fmt` clean.
+- [ ] All public functions in `walk_forward/lib/*.mli` have doc
+  comments.
+- [ ] No function exceeds 50 lines (hard limit).
+- [ ] Tests use `assert_that` + matchers per
+  `.claude/rules/test-patterns.md`.
+- [ ] `WindowSpec.generate` has at least 3 distinct date-arithmetic
+  test cases (start = end, train = 0, step > test).
+- [ ] `Fold_gate.evaluate` has a test for each of: full pass, M
+  threshold miss, Δ threshold miss, baseline tie.
+- [ ] `Walk_forward_runner.build_fold_scenario` has a parity test
+  showing variant overrides are appended *after* base overrides
+  (last-writer-wins, matching `Bayesian_runner_evaluator`).
+- [ ] `Walk_forward_report.render` produces deterministic markdown for
+  fixed inputs (one pinned-string test).
+- [ ] `walk_forward_runner.exe` builds and has a `--help` flag. End-
+  to-end backtest invocation is wired but its on-corpus correctness
+  is deferred — the test plan uses tiny synthetic actuals.
+- [ ] `dev/status/walk-forward-cv.md` created with Status / Interface
+  stable / Completed / In Progress / Next Steps / Commits.
+- [ ] PR diff ≤ ~1000 LOC including tests.
+
+## Out of scope (defer)
+
+- **Running an actual ~30-fold sweep.** First PR ships the harness;
+  the first real sweep is a follow-up local run.
+- **Phase 3 Bayesian integration.** Out of scope here. The harness
+  exposes its public interface so a future PR can wire it into
+  `bayesian_runner.exe` or a successor.
+- **Parallel fold execution via fork-pool.** Start sequential; copy
+  `scenario_runner._run_scenarios_parallel` only when wall-time
+  measurements demand it.
+- **Multi-universe sweeps.** Single-universe per spec for now.
+- **Modifications to `Scenario.t`, `Backtest.Runner`, the tuner libs,
+  or any existing surface.** Pure addition.

--- a/dev/status/walk-forward-cv.md
+++ b/dev/status/walk-forward-cv.md
@@ -1,0 +1,98 @@
+# Status: walk-forward-cv
+
+## Last updated: 2026-05-15
+
+## Status
+READY_FOR_REVIEW
+
+## Notes
+
+Track created 2026-05-15 by `feat-backtest` per the strategic pivot in
+`dev/notes/next-session-priorities-2026-05-15.md` §"Phase 2 —
+walk-forward CV harness". Plan at
+`dev/plans/walk-forward-cv-harness-2026-05-15.md`.
+
+Phase 2 of the broader P0 ML-discipline-tuning track. Scales the
+existing hand-curated 8-fold walk-forward
+(`dev/experiments/cell-e-walk-forward-2026-05-08/`) to a parameterised
+rolling-window harness with a machine-checkable go/no-go gate. The gate
+language is what would have rejected M5.5 axis-2 (PR #1086) and the
+P3-followup combined-axis sweep (PR #1095) on their short-window data
+alone — Phase 3 BO will consume this harness for variant scoring
+instead of single-window mean-Sharpe.
+
+## Interface stable
+NO (M5.5 follow-on work — `WalkForwardRunner` spec sexp shape is
+explicitly marked unstable in the binary's docstring; Phase 3 BO
+integration will iterate it).
+
+## Scope
+
+### First PR (this PR, #1100) — harness modules + thin CLI
+
+- [x] `Walk_forward.Window_spec` (`trading/trading/backtest/walk_forward/lib/window_spec.{ml,mli}`) — pure date-arithmetic spec for rolling train/test windows. Generates `fold` records (optional train period + required test period). Drops folds extending past `end_date`. 11 tests.
+- [x] `Walk_forward.Fold_gate` (`trading/trading/backtest/walk_forward/lib/fold_gate.{ml,mli}`) — pure go/no-go evaluator. Rule: "variant wins ≥M of N folds AND no fold worse than baseline by >Δ". Direction inverted for `MaxDrawdownPct` (lower is better). 13 tests.
+- [x] `Walk_forward.Walk_forward_runner` (`trading/trading/backtest/walk_forward/lib/walk_forward_runner.{ml,mli}`) — pure scenario builder: composes base scenario + Window_spec folds + variant overrides into the list of `Scenario.t` the harness runs. Variant overrides appended last (last-writer-wins per `Bayesian_runner_evaluator`). 9 tests.
+- [x] `Walk_forward.Walk_forward_report` (`trading/trading/backtest/walk_forward/lib/walk_forward_report.{ml,mli}`) — pure markdown renderer. Emits 4 sections: per-fold metrics, stability (μ±σ per variant), cross-fold sensitivity (win-counts), go/no-go verdict per non-baseline variant. Deterministic. 10 tests.
+- [x] `walk_forward_runner.exe` (`trading/trading/backtest/walk_forward/bin/walk_forward_runner.ml`) — thin CLI that reads a top-level sexp spec (`base_scenario` / `window_spec` / `variants` / `baseline_label` / `gate`), invokes `Backtest.Runner.run_backtest` sequentially per (variant, fold), writes `fold_actuals.sexp` + `walk_forward_report.md` under `--out-dir`. Same per-suggestion shape as `Bayesian_runner_evaluator` so Phase 3 can swap variant overrides for BO suggestions.
+
+### Verify
+
+```
+dune build && dune runtest trading/backtest/walk_forward
+```
+
+43 tests across 4 modules (11 + 13 + 9 + 10), all pass.
+
+Quick smoke (not run in CI; local-only because backtest invocation is
+expensive):
+
+```
+dune exec trading/backtest/walk_forward/bin/walk_forward_runner.exe -- --help
+# Usage: walk_forward_runner.exe --spec <spec.sexp> --out-dir <dir> [--fixtures-root <path>]
+```
+
+## In Progress
+
+None for this PR. The harness is complete in its first-PR scope.
+
+## Completed
+
+- **PR #1100** (this PR, 2026-05-15) — walk-forward CV harness first PR. Plan + 4 lib modules + binary + tests. ~1200 LOC including tests. All four checklist items satisfied (`dune build`, `dune runtest`, `dune fmt`, nesting + magic-number linters clean).
+
+## Next Steps
+
+1. **First production sweep** — run the binary against a real spec
+   (`base = goldens-sp500/sp500-2010-2026.sexp`, 30 rolling folds with
+   train_days=730 / test_days=365 / step_days=182, variants = baseline +
+   cell-E + cell-F-candidates). Local-only follow-up; multi-hour wall
+   time. Output: `dev/experiments/walk-forward-cell-e-2026-05-XX/`.
+2. **Re-baseline the M5.4-E3 and -E4 sweeps** — re-run those reports
+   through the walk-forward gate to confirm which buffer / weight cells
+   actually pass M-of-N on rolling folds.
+3. **Phase 3 — Bayesian-optimizer integration** (~3-5 PRs, 1 week).
+   `bayesian_runner.exe` consumes the walk-forward harness as its
+   evaluator (replacing the single-window mean-Sharpe scoring); the BO
+   loop chooses variant overrides. Convergence acceptance: a cell that
+   beats Cell E on walk-forward Sharpe by ≥0.05 with MaxDD no worse.
+4. **Parallel fold execution** — sequential is fine for first sweeps;
+   wall-time will demand fork-pool akin to
+   `Scenario_runner._run_scenarios_parallel` once sweeps go to ~30
+   folds × ~10 variants.
+
+## Out of scope (this track / deferred)
+
+- Multi-universe sweeps within a single spec.
+- Live trading wiring.
+- Modifications to `Backtest.Runner`, `Scenario`, the tuner libs, or
+  any existing surface (pure addition).
+- Norgate / vendor data ingest (separate `feat-data` track).
+
+## Commits
+
+- `b193358` — plan: dev/plans/walk-forward-cv-harness-2026-05-15.md
+- `3868131` — feat(walk-forward): Window_spec module + 11 tests
+- `fbd20b9` — feat(walk-forward): Fold_gate go/no-go evaluator + 13 tests
+- `6c69757` — feat(walk-forward): Walk_forward_runner scenario builder + 9 tests
+- `a81f9aa` — feat(walk-forward): Walk_forward_report markdown renderer + 10 tests
+- (next commit on this branch will add the binary + this status file)

--- a/dev/status/walk-forward-cv.md
+++ b/dev/status/walk-forward-cv.md
@@ -22,9 +22,11 @@ alone — Phase 3 BO will consume this harness for variant scoring
 instead of single-window mean-Sharpe.
 
 ## Interface stable
-NO (M5.5 follow-on work — `WalkForwardRunner` spec sexp shape is
-explicitly marked unstable in the binary's docstring; Phase 3 BO
-integration will iterate it).
+NO
+
+M5.5 follow-on work — `WalkForwardRunner` spec sexp shape is explicitly
+marked unstable in the binary's docstring; Phase 3 BO integration will
+iterate it.
 
 ## Scope
 

--- a/trading/base/matchers/lib/matchers.ml
+++ b/trading/base/matchers/lib/matchers.ml
@@ -52,6 +52,18 @@ let not_ ?(msg = "Expected matcher to fail but it succeeded") matcher value =
   if passed then assert_failure msg
 
 (* ========================================================================== *)
+(* String Matchers                                                            *)
+(* ========================================================================== *)
+
+let contains_substring ?msg substring actual =
+  if not (String.is_substring actual ~substring) then
+    let default_msg =
+      Printf.sprintf "Expected string to contain substring %S but got: %S"
+        substring actual
+    in
+    assert_failure (Option.value msg ~default:default_msg)
+
+(* ========================================================================== *)
 (* Result Matchers                                                           *)
 (* ========================================================================== *)
 

--- a/trading/base/matchers/lib/matchers.mli
+++ b/trading/base/matchers/lib/matchers.mli
@@ -119,6 +119,30 @@ val all_of : ('a -> unit) list -> 'a -> unit
       ]
     ]} *)
 
+(** {1 String Matchers} *)
+
+val contains_substring : ?msg:string -> string -> string matcher
+(** [contains_substring ?msg substring] asserts the actual string contains
+    [substring] (via [String.is_substring]). Optionally takes a custom failure
+    message; otherwise reports the expected substring and the actual string.
+
+    Use this instead of wrapping [String.is_substring] in [equal_to true] —
+    that pattern violates the test-pattern rule against boolean equality in
+    assertions.
+
+    Example:
+    {[
+    assert_that markdown (contains_substring "## Verdict")
+    ]}
+    {[
+    assert_that markdown
+      (all_of
+         [
+           contains_substring "PASS";
+           contains_substring "cellE";
+         ])
+    ]} *)
+
 (** {1 Result Matchers}
 
     Matchers for [Result.t] and [Status.status_or] types *)

--- a/trading/base/matchers/lib/matchers.mli
+++ b/trading/base/matchers/lib/matchers.mli
@@ -126,8 +126,8 @@ val contains_substring : ?msg:string -> string -> string matcher
     [substring] (via [String.is_substring]). Optionally takes a custom failure
     message; otherwise reports the expected substring and the actual string.
 
-    Use this instead of wrapping [String.is_substring] in [equal_to true] —
-    that pattern violates the test-pattern rule against boolean equality in
+    Use this instead of wrapping [String.is_substring] in [equal_to true] — that
+    pattern violates the test-pattern rule against boolean equality in
     assertions.
 
     Example:
@@ -136,11 +136,7 @@ val contains_substring : ?msg:string -> string -> string matcher
     ]}
     {[
     assert_that markdown
-      (all_of
-         [
-           contains_substring "PASS";
-           contains_substring "cellE";
-         ])
+      (all_of [ contains_substring "PASS"; contains_substring "cellE" ])
     ]} *)
 
 (** {1 Result Matchers}

--- a/trading/base/matchers/test/test_matchers.ml
+++ b/trading/base/matchers/test/test_matchers.ml
@@ -94,6 +94,28 @@ let test_matching_custom_msg_fails _ =
            (function `A x -> Some x | _ -> None)
            (equal_to 0)))
 
+(* ------------------------------------------------------------------ *)
+(* contains_substring                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let test_contains_substring_passes _ =
+  assert_that "hello world" (contains_substring "world");
+  assert_that "## Verdict: PASS" (contains_substring "PASS")
+
+let test_contains_substring_fails_when_absent _ =
+  assert_fails (fun () ->
+      assert_that "hello world" (contains_substring "goodbye"))
+
+let test_contains_substring_empty_substring_passes _ =
+  (* Empty substring is contained in every string per String.is_substring. *)
+  assert_that "anything" (contains_substring "")
+
+let test_contains_substring_empty_haystack_fails _ =
+  assert_fails (fun () -> assert_that "" (contains_substring "nonempty"))
+
+let test_contains_substring_equal_strings_passes _ =
+  assert_that "exact" (contains_substring "exact")
+
 let suite =
   "matchers"
   >::: [
@@ -115,6 +137,15 @@ let suite =
          "matching_passes_when_some" >:: test_matching_passes_when_some;
          "matching_fails_when_none" >:: test_matching_fails_when_none;
          "matching_custom_msg_fails" >:: test_matching_custom_msg_fails;
+         "contains_substring_passes" >:: test_contains_substring_passes;
+         "contains_substring_fails_when_absent"
+         >:: test_contains_substring_fails_when_absent;
+         "contains_substring_empty_substring_passes"
+         >:: test_contains_substring_empty_substring_passes;
+         "contains_substring_empty_haystack_fails"
+         >:: test_contains_substring_empty_haystack_fails;
+         "contains_substring_equal_strings_passes"
+         >:: test_contains_substring_equal_strings_passes;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/walk_forward/bin/dune
+++ b/trading/trading/backtest/walk_forward/bin/dune
@@ -1,0 +1,13 @@
+(executable
+ (name walk_forward_runner)
+ (modules walk_forward_runner)
+ (libraries
+  core
+  core_unix
+  core_unix.filename_unix
+  backtest
+  scenario_lib
+  walk_forward
+  trading.simulation.types)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/walk_forward/bin/walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/bin/walk_forward_runner.ml
@@ -1,0 +1,172 @@
+(** Walk-forward CV runner — wires [Window_spec] + [Walk_forward_runner] +
+    [Walk_forward_report] to {!Backtest.Runner.run_backtest} via the same
+    per-scenario invocation pattern used by
+    {!Tuner_bin.Bayesian_runner_evaluator.build}.
+
+    Reads a top-level sexp spec describing:
+    - [base_scenario] — path to the base scenario sexp file
+    - [window_spec] — {!Walk_forward.Window_spec.t}
+    - [variants] — list of {!Walk_forward.Walk_forward_runner.variant}
+    - [baseline_label] — which variant is the baseline for the report
+    - [gate] — {!Walk_forward.Fold_gate.t}
+
+    Writes [walk_forward_report.md] and [fold_actuals.sexp] under [--out-dir].
+
+    Usage:
+    {v
+      walk_forward_runner.exe --spec <spec.sexp> --out-dir <dir>
+                              [--fixtures-root <path>]
+    v}
+
+    This binary is the integration seam for Phase 3: the Bayesian optimizer
+    consumes the same harness with variant-overrides chosen by the BO loop
+    instead of hard-coded in the spec. *)
+
+open Core
+module Scenario = Scenario_lib.Scenario
+module Universe_file = Scenario_lib.Universe_file
+module Fixtures_root = Scenario_lib.Fixtures_root
+module WS = Walk_forward.Window_spec
+module WFR = Walk_forward.Walk_forward_runner
+module FG = Walk_forward.Fold_gate
+module Report = Walk_forward.Walk_forward_report
+
+(* -------------- spec -------------- *)
+
+type spec = {
+  base_scenario : string;  (** Path to a base scenario sexp file. *)
+  window_spec : WS.t;
+  variants : WFR.variant list;
+  baseline_label : string;
+  gate : FG.t;
+}
+[@@deriving sexp]
+(** On-disk shape of the harness spec. *)
+
+let _load_spec path : spec = spec_of_sexp (Sexp.load_sexp path)
+
+(* -------------- argument parsing -------------- *)
+
+type cli_args = {
+  spec_path : string;
+  out_dir : string;
+  fixtures_root : string option;
+}
+
+let _usage_msg =
+  "Usage: walk_forward_runner.exe --spec <spec.sexp> --out-dir <dir> \
+   [--fixtures-root <path>]"
+
+let _parse_args argv =
+  let rec loop spec out fixtures = function
+    | [] -> (
+        match (spec, out) with
+        | Some s, Some o ->
+            { spec_path = s; out_dir = o; fixtures_root = fixtures }
+        | _ ->
+            eprintf "%s\n" _usage_msg;
+            Stdlib.exit 1)
+    | "--spec" :: p :: rest -> loop (Some p) out fixtures rest
+    | "--out-dir" :: p :: rest -> loop spec (Some p) fixtures rest
+    | "--fixtures-root" :: p :: rest -> loop spec out (Some p) rest
+    | ("--help" | "-h") :: _ ->
+        printf "%s\n" _usage_msg;
+        Stdlib.exit 0
+    | unknown :: _ ->
+        eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
+        Stdlib.exit 1
+  in
+  loop None None None argv
+
+(* -------------- per-scenario evaluation -------------- *)
+
+(** Run a single scenario via [Backtest.Runner.run_backtest], in process —
+    mirrors the per-suggestion shape used by
+    {!Tuner_bin.Bayesian_runner_evaluator}. *)
+let _run_one ~fixtures_root (s : Scenario.t) : Report.fold_actual =
+  let resolved = Filename.concat fixtures_root s.universe_path in
+  let sector_map_override =
+    Universe_file.to_sector_map_override (Universe_file.load resolved)
+  in
+  let result =
+    Backtest.Runner.run_backtest ~start_date:s.period.start_date
+      ~end_date:s.period.end_date ~overrides:s.config_overrides
+      ?sector_map_override ~strategy_choice:s.strategy
+      ?slippage_bps:s.slippage_bps ()
+  in
+  let summary = result.summary in
+  let get k = Map.find summary.metrics k |> Option.value ~default:Float.nan in
+  let total_return =
+    (summary.final_portfolio_value -. summary.initial_cash)
+    /. summary.initial_cash *. 100.0
+  in
+  let open Trading_simulation_types.Metric_types in
+  {
+    fold_name = "";
+    (* filled by caller — see _evaluate_one_pair *)
+    variant_label = "";
+    total_return_pct = total_return;
+    sharpe_ratio = get SharpeRatio;
+    max_drawdown_pct = get MaxDrawdown;
+    calmar_ratio = get CalmarRatio;
+  }
+
+(** Tag a per-(variant, fold) actual with the metadata the renderer needs. *)
+let _evaluate_one_pair ~fixtures_root ~base ~(fold : WS.fold)
+    ~(variant : WFR.variant) =
+  let scenario = WFR.build_fold_scenario ~base ~fold ~variant in
+  let actual_no_tag = _run_one ~fixtures_root scenario in
+  { actual_no_tag with fold_name = fold.name; variant_label = variant.label }
+
+(** Evaluate the full grid of (variant x fold) — sequential. Parallel execution
+    is a follow-up; mirrors [Scenario_runner._run_scenarios_parallel] when
+    wall-time demands it. *)
+let _evaluate_all ~fixtures_root ~base ~(spec : spec) =
+  let folds = WS.generate spec.window_spec in
+  List.concat_map spec.variants ~f:(fun variant ->
+      List.map folds ~f:(fun fold ->
+          eprintf "[walk_forward] running variant=%s fold=%s [%s..%s]\n%!"
+            variant.label fold.name
+            (Date.to_string fold.test_period.start_date)
+            (Date.to_string fold.test_period.end_date);
+          _evaluate_one_pair ~fixtures_root ~base ~fold ~variant))
+
+(* -------------- output writers -------------- *)
+
+let _write_report ~out_dir ~(spec : spec)
+    (fold_actuals : Report.fold_actual list) =
+  let md =
+    Report.render ~baseline_label:spec.baseline_label ~gate:spec.gate
+      ~fold_actuals
+  in
+  let path = Filename.concat out_dir "walk_forward_report.md" in
+  Out_channel.write_all path ~data:md;
+  eprintf "[walk_forward] wrote %s\n%!" path
+
+let _write_fold_actuals ~out_dir (fold_actuals : Report.fold_actual list) =
+  let sexp = Sexp.List (List.map fold_actuals ~f:Report.sexp_of_fold_actual) in
+  let path = Filename.concat out_dir "fold_actuals.sexp" in
+  Sexp.save_hum path sexp;
+  eprintf "[walk_forward] wrote %s\n%!" path
+
+(* -------------- main -------------- *)
+
+let _main () =
+  let argv = Sys.get_argv () |> Array.to_list |> List.tl_exn in
+  let args = _parse_args argv in
+  let spec = _load_spec args.spec_path in
+  Core_unix.mkdir_p args.out_dir;
+  let fixtures_root =
+    Fixtures_root.resolve ?fixtures_root:args.fixtures_root ()
+  in
+  let base = Scenario.load spec.base_scenario in
+  eprintf "[walk_forward] spec=%s base=%s baseline=%s variants=%d folds=%d\n%!"
+    args.spec_path spec.base_scenario spec.baseline_label
+    (List.length spec.variants)
+    (List.length (WS.generate spec.window_spec));
+  let fold_actuals = _evaluate_all ~fixtures_root ~base ~spec in
+  _write_fold_actuals ~out_dir:args.out_dir fold_actuals;
+  _write_report ~out_dir:args.out_dir ~spec fold_actuals;
+  eprintf "[walk_forward] done\n%!"
+
+let () = _main ()

--- a/trading/trading/backtest/walk_forward/lib/dune
+++ b/trading/trading/backtest/walk_forward/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name walk_forward)
+ (libraries core scenario_lib)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/walk_forward/lib/fold_gate.ml
+++ b/trading/trading/backtest/walk_forward/lib/fold_gate.ml
@@ -1,0 +1,100 @@
+open Core
+
+type metric_key = Sharpe | Calmar | TotalReturnPct | MaxDrawdownPct
+[@@deriving sexp]
+
+type t = { metric : metric_key; m : int; n : int; worst_delta : float }
+[@@deriving sexp]
+
+type fold_result = {
+  fold_name : string;
+  variant_score : float;
+  baseline_score : float;
+}
+[@@deriving sexp]
+
+type verdict =
+  | Pass of { wins : int; n : int }
+  | Fail of {
+      wins : int;
+      n : int;
+      worst_fold : string;
+      worst_gap : float;
+      reason : string;
+    }
+[@@deriving sexp]
+
+let higher_is_better = function
+  | Sharpe | Calmar | TotalReturnPct -> true
+  | MaxDrawdownPct -> false
+
+let _validate (gate : t) (folds : fold_result list) =
+  if gate.n < 1 then
+    failwith (sprintf "Fold_gate.evaluate: n must be >= 1, got %d" gate.n);
+  if gate.m < 0 || gate.m > gate.n then
+    failwith
+      (sprintf "Fold_gate.evaluate: m must be in [0, n=%d], got %d" gate.n
+         gate.m);
+  if Float.(gate.worst_delta < 0.0) then
+    failwith
+      (sprintf "Fold_gate.evaluate: worst_delta must be >= 0.0, got %f"
+         gate.worst_delta);
+  let actual = List.length folds in
+  if actual <> gate.n then
+    failwith
+      (sprintf
+         "Fold_gate.evaluate: fold count mismatch — gate.n=%d but got %d folds"
+         gate.n actual)
+
+(** [_signed_gap_for ~hib variant baseline] returns the shortfall amount, in the
+    convention that positive = variant trails baseline. For "higher is better"
+    metrics it is [baseline - variant]; for "lower is better" metrics (drawdown)
+    it is [variant - baseline]. *)
+let _signed_gap_for ~hib variant baseline =
+  if hib then baseline -. variant else variant -. baseline
+
+(** A fold is a "win" for variant when its signed_gap_for is strictly negative
+    (variant strictly beats baseline). Ties count as baseline wins. *)
+let _is_win ~hib (fr : fold_result) =
+  Float.(_signed_gap_for ~hib fr.variant_score fr.baseline_score < 0.0)
+
+(** Find the largest individual shortfall across folds — used both for the
+    Δ-threshold check and for the diagnostic in [Fail.worst_fold]. *)
+let _worst_shortfall ~hib (folds : fold_result list) =
+  List.fold folds ~init:("", Float.neg_infinity)
+    ~f:(fun (best_name, best_gap) fr ->
+      let g = _signed_gap_for ~hib fr.variant_score fr.baseline_score in
+      if Float.(g > best_gap) then (fr.fold_name, g) else (best_name, best_gap))
+
+let evaluate (gate : t) (folds : fold_result list) =
+  _validate gate folds;
+  let hib = higher_is_better gate.metric in
+  let wins = List.count folds ~f:(_is_win ~hib) in
+  let worst_fold, worst_gap = _worst_shortfall ~hib folds in
+  let delta_fail = Float.(worst_gap > gate.worst_delta) in
+  let m_fail = wins < gate.m in
+  match (m_fail, delta_fail) with
+  | false, false -> Pass { wins; n = gate.n }
+  | _, _ ->
+      let reason =
+        match (m_fail, delta_fail) with
+        | true, true ->
+            sprintf
+              "M-threshold miss: %d wins < %d required; worst fold %s trails \
+               by %.4f > Δ=%.4f"
+              wins gate.m worst_fold worst_gap gate.worst_delta
+        | true, false ->
+            sprintf "M-threshold miss: %d wins < %d required" wins gate.m
+        | false, true ->
+            sprintf "Δ-threshold miss: fold %s trails by %.4f > Δ=%.4f"
+              worst_fold worst_gap gate.worst_delta
+        | false, false -> assert false (* unreachable *)
+      in
+      Fail
+        {
+          wins;
+          n = gate.n;
+          worst_fold;
+          worst_gap = Float.max worst_gap 0.0;
+          reason;
+        }

--- a/trading/trading/backtest/walk_forward/lib/fold_gate.ml
+++ b/trading/trading/backtest/walk_forward/lib/fold_gate.ml
@@ -66,6 +66,19 @@ let _worst_shortfall ~hib (folds : fold_result list) =
       let g = _signed_gap_for ~hib fr.variant_score fr.baseline_score in
       if Float.(g > best_gap) then (fr.fold_name, g) else (best_name, best_gap))
 
+let _fail_reason ~wins ~(gate : t) ~worst_fold ~worst_gap ~m_fail ~delta_fail =
+  match (m_fail, delta_fail) with
+  | true, true ->
+      sprintf
+        "M-threshold miss: %d wins < %d required; worst fold %s trails by %.4f \
+         > Δ=%.4f"
+        wins gate.m worst_fold worst_gap gate.worst_delta
+  | true, false -> sprintf "M-threshold miss: %d wins < %d required" wins gate.m
+  | false, true ->
+      sprintf "Δ-threshold miss: fold %s trails by %.4f > Δ=%.4f" worst_fold
+        worst_gap gate.worst_delta
+  | false, false -> assert false (* unreachable; caller guards *)
+
 let evaluate (gate : t) (folds : fold_result list) =
   _validate gate folds;
   let hib = higher_is_better gate.metric in
@@ -73,28 +86,16 @@ let evaluate (gate : t) (folds : fold_result list) =
   let worst_fold, worst_gap = _worst_shortfall ~hib folds in
   let delta_fail = Float.(worst_gap > gate.worst_delta) in
   let m_fail = wins < gate.m in
-  match (m_fail, delta_fail) with
-  | false, false -> Pass { wins; n = gate.n }
-  | _, _ ->
-      let reason =
-        match (m_fail, delta_fail) with
-        | true, true ->
-            sprintf
-              "M-threshold miss: %d wins < %d required; worst fold %s trails \
-               by %.4f > Δ=%.4f"
-              wins gate.m worst_fold worst_gap gate.worst_delta
-        | true, false ->
-            sprintf "M-threshold miss: %d wins < %d required" wins gate.m
-        | false, true ->
-            sprintf "Δ-threshold miss: fold %s trails by %.4f > Δ=%.4f"
-              worst_fold worst_gap gate.worst_delta
-        | false, false -> assert false (* unreachable *)
-      in
-      Fail
-        {
-          wins;
-          n = gate.n;
-          worst_fold;
-          worst_gap = Float.max worst_gap 0.0;
-          reason;
-        }
+  if (not m_fail) && not delta_fail then Pass { wins; n = gate.n }
+  else
+    let reason =
+      _fail_reason ~wins ~gate ~worst_fold ~worst_gap ~m_fail ~delta_fail
+    in
+    Fail
+      {
+        wins;
+        n = gate.n;
+        worst_fold;
+        worst_gap = Float.max worst_gap 0.0;
+        reason;
+      }

--- a/trading/trading/backtest/walk_forward/lib/fold_gate.mli
+++ b/trading/trading/backtest/walk_forward/lib/fold_gate.mli
@@ -1,0 +1,85 @@
+(** Pure go/no-go gate for walk-forward fold results.
+
+    The gate encodes the rule "variant wins on at least M of N folds AND no
+    single fold is worse than baseline by more than Δ". This is the
+    machine-checkable verdict that supersedes the eyeballed
+    [dev/experiments/cell-e-walk-forward-2026-05-08/report.md] verdict — the
+    M5.5 axis-2 and continuation-combined sweeps that ultimately failed 16y
+    validation would have been rejected by an honest M-of-N gate set on
+    short-window data alone.
+
+    All thresholds are inputs. The harness chooses sensible defaults; the
+    discipline is in the gate's shape, not in the specific numbers. *)
+
+(** Which metric the gate compares variant vs baseline on. [MaxDrawdownPct]
+    inverts the comparison direction (lower is better) — see {!evaluate}. *)
+type metric_key = Sharpe | Calmar | TotalReturnPct | MaxDrawdownPct
+[@@deriving sexp]
+
+type t = {
+  metric : metric_key;
+      (** The per-fold score the gate compares variant vs baseline on. *)
+  m : int;
+      (** Minimum number of fold-wins required for [Pass]. Must satisfy
+          [0 <= m <= n]. *)
+  n : int;
+      (** Expected total fold count. The evaluator raises [Failure] when the
+          input fold list's length doesn't match [n] — a guard against
+          accidentally fudging the gate by silently dropping folds. Must be
+          [>= 1]. *)
+  worst_delta : float;
+      (** Maximum permitted shortfall on any single fold:
+          [variant_score < baseline_score - worst_delta] is a hard fail
+          regardless of total win count. For [MaxDrawdownPct] (lower is better)
+          the shortfall direction is reversed:
+          [variant_score > baseline_score + worst_delta] is the failure
+          condition. Must be [>= 0.0]. *)
+}
+[@@deriving sexp]
+
+type fold_result = {
+  fold_name : string;
+  variant_score : float;
+  baseline_score : float;
+}
+[@@deriving sexp]
+(** One per-fold measurement pair. The walk-forward report builder produces one
+    [fold_result] per (fold, metric) pair. *)
+
+type verdict =
+  | Pass of { wins : int; n : int }
+  | Fail of {
+      wins : int;
+      n : int;
+      worst_fold : string;
+      worst_gap : float;
+          (** Signed shortfall in [variant - baseline] units for "higher is
+              better" metrics, or in [baseline - variant] units for
+              [MaxDrawdownPct]. Always nonnegative when [worst_gap > 0.0]
+              triggered the failure; may be [0.0] when only the M-threshold
+              tripped. *)
+      reason : string;
+    }
+[@@deriving sexp]
+
+val evaluate : t -> fold_result list -> verdict
+(** [evaluate gate folds] returns [Pass _] iff:
+    - [List.length folds = gate.n] (raises [Failure] otherwise),
+    - the variant wins on at least [gate.m] folds (ties count as a win for the
+      baseline — variant must strictly beat),
+    - AND no single fold's variant trails the baseline by more than
+      [gate.worst_delta] (direction inverted for [MaxDrawdownPct]).
+
+    Otherwise returns [Fail _] with the diagnostic shape. The [worst_fold] /
+    [worst_gap] / [reason] fields name the largest individual shortfall (even on
+    a pure M-threshold miss) so the report renderer can surface a useful "why"
+    sentence.
+
+    For "higher is better" metrics (Sharpe, Calmar, TotalReturnPct), a "win"
+    means [variant_score > baseline_score]. For [MaxDrawdownPct], a "win" means
+    [variant_score < baseline_score] (less drawdown is better). *)
+
+val higher_is_better : metric_key -> bool
+(** Returns [true] for Sharpe / Calmar / TotalReturnPct; [false] for
+    MaxDrawdownPct. Exposed so the report renderer's per-fold table can label
+    wins consistently with the gate's interpretation. *)

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_report.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_report.ml
@@ -1,0 +1,228 @@
+open Core
+
+type fold_actual = {
+  fold_name : string;
+  variant_label : string;
+  total_return_pct : float;
+  sharpe_ratio : float;
+  max_drawdown_pct : float;
+  calmar_ratio : float;
+}
+[@@deriving sexp]
+
+(* -------------- helpers -------------- *)
+
+let _variant_labels_in_order (folds : fold_actual list) =
+  let seen = Hash_set.create (module String) in
+  List.filter_map folds ~f:(fun fa ->
+      if Hash_set.mem seen fa.variant_label then None
+      else (
+        Hash_set.add seen fa.variant_label;
+        Some fa.variant_label))
+
+let _fold_names_in_order (folds : fold_actual list) =
+  let seen = Hash_set.create (module String) in
+  List.filter_map folds ~f:(fun fa ->
+      if Hash_set.mem seen fa.fold_name then None
+      else (
+        Hash_set.add seen fa.fold_name;
+        Some fa.fold_name))
+
+let _mean xs =
+  let n = List.length xs in
+  if n = 0 then Float.nan
+  else List.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int n
+
+let _stdev xs =
+  let n = List.length xs in
+  if n < 2 then Float.nan
+  else
+    let m = _mean xs in
+    let s = List.fold xs ~init:0.0 ~f:(fun acc x -> acc +. ((x -. m) ** 2.0)) in
+    Float.sqrt (s /. Float.of_int (n - 1))
+
+let _project_metric (gate : Fold_gate.t) (fa : fold_actual) =
+  match gate.metric with
+  | Sharpe -> fa.sharpe_ratio
+  | Calmar -> fa.calmar_ratio
+  | TotalReturnPct -> fa.total_return_pct
+  | MaxDrawdownPct -> fa.max_drawdown_pct
+
+(* -------------- section renderers -------------- *)
+
+let _render_per_fold_table (folds : fold_actual list) =
+  let header =
+    "| Fold | Variant | Return % | Sharpe | MaxDD % | Calmar |\n\
+     |------|---------|---------:|-------:|--------:|-------:|"
+  in
+  let rows =
+    List.map folds ~f:(fun fa ->
+        sprintf "| %s | %s | %.2f | %.3f | %.2f | %.3f |" fa.fold_name
+          fa.variant_label fa.total_return_pct fa.sharpe_ratio
+          fa.max_drawdown_pct fa.calmar_ratio)
+  in
+  String.concat ~sep:"\n" (header :: rows)
+
+let _variant_metric_lists (folds : fold_actual list) label =
+  List.filter folds ~f:(fun fa -> String.equal fa.variant_label label)
+
+let _render_stability_table (folds : fold_actual list) =
+  let header =
+    "| Variant | Return % (μ ± σ) | Sharpe (μ ± σ) | MaxDD % (μ ± σ) | Calmar \
+     (μ ± σ) |\n\
+     |---------|-----------------:|---------------:|----------------:|--------------:|"
+  in
+  let labels = _variant_labels_in_order folds in
+  let rows =
+    List.map labels ~f:(fun label ->
+        let vs = _variant_metric_lists folds label in
+        let r = List.map vs ~f:(fun fa -> fa.total_return_pct) in
+        let s = List.map vs ~f:(fun fa -> fa.sharpe_ratio) in
+        let d = List.map vs ~f:(fun fa -> fa.max_drawdown_pct) in
+        let c = List.map vs ~f:(fun fa -> fa.calmar_ratio) in
+        sprintf "| %s | %.2f ± %.2f | %.3f ± %.3f | %.2f ± %.2f | %.3f ± %.3f |"
+          label (_mean r) (_stdev r) (_mean s) (_stdev s) (_mean d) (_stdev d)
+          (_mean c) (_stdev c))
+  in
+  String.concat ~sep:"\n" (header :: rows)
+
+let _wins_per_variant_on_metric (folds : fold_actual list)
+    ~(baseline_label : string) ~(gate : Fold_gate.t) =
+  let labels = _variant_labels_in_order folds in
+  let fold_names = _fold_names_in_order folds in
+  let hib = Fold_gate.higher_is_better gate.metric in
+  List.filter labels ~f:(fun l -> not (String.equal l baseline_label))
+  |> List.map ~f:(fun variant_label ->
+      let wins =
+        List.count fold_names ~f:(fun fold_name ->
+            let fold_of label =
+              List.find folds ~f:(fun fa ->
+                  String.equal fa.fold_name fold_name
+                  && String.equal fa.variant_label label)
+            in
+            match (fold_of baseline_label, fold_of variant_label) with
+            | Some b, Some v ->
+                let bv = _project_metric gate b in
+                let vv = _project_metric gate v in
+                if hib then Float.(vv > bv) else Float.(vv < bv)
+            | _ -> false)
+      in
+      (variant_label, wins))
+
+let _metric_str (gate : Fold_gate.t) =
+  match gate.metric with
+  | Sharpe -> "Sharpe"
+  | Calmar -> "Calmar"
+  | TotalReturnPct -> "TotalReturn%"
+  | MaxDrawdownPct -> "MaxDD%"
+
+let _render_sensitivity_table ~baseline_label ~(gate : Fold_gate.t)
+    (folds : fold_actual list) =
+  let n = List.length (_fold_names_in_order folds) in
+  let header =
+    sprintf
+      "Variant wins per fold on **%s** (vs baseline `%s`, %d folds total):\n\n\
+       | Variant | Wins | of |\n\
+       |---------|-----:|---:|"
+      (_metric_str gate) baseline_label n
+  in
+  let rows =
+    _wins_per_variant_on_metric folds ~baseline_label ~gate
+    |> List.map ~f:(fun (label, wins) ->
+        sprintf "| %s | %d | %d |" label wins n)
+  in
+  String.concat ~sep:"\n" (header :: rows)
+
+(** Build [Fold_gate.fold_result] list for a single (variant vs baseline)
+    pairing. Returns folds in baseline-side ordering — anchors on the unique
+    fold-name list. *)
+let _fold_results_for_pair (folds : fold_actual list) ~baseline_label
+    ~variant_label ~gate =
+  let fold_names = _fold_names_in_order folds in
+  List.filter_map fold_names ~f:(fun fold_name ->
+      let find label =
+        List.find folds ~f:(fun fa ->
+            String.equal fa.fold_name fold_name
+            && String.equal fa.variant_label label)
+      in
+      match (find baseline_label, find variant_label) with
+      | Some b, Some v ->
+          let bv = _project_metric gate b in
+          let vv = _project_metric gate v in
+          Some
+            ({ fold_name; variant_score = vv; baseline_score = bv }
+              : Fold_gate.fold_result)
+      | _ -> None)
+
+let _render_verdict_for_variant ~(gate : Fold_gate.t) ~variant_label
+    fold_results =
+  let n_folds = List.length fold_results in
+  if n_folds <> gate.n then
+    sprintf "- **%s**: SKIPPED — measured %d folds but gate expects %d"
+      variant_label n_folds gate.n
+  else
+    match Fold_gate.evaluate gate fold_results with
+    | Fold_gate.Pass { wins; n } ->
+        sprintf "- **%s**: PASS (%d / %d wins, Δ≤%.4f satisfied)" variant_label
+          wins n gate.worst_delta
+    | Fold_gate.Fail { wins; n; worst_fold; worst_gap; reason } ->
+        sprintf
+          "- **%s**: FAIL (%d / %d wins; worst fold `%s` gap %.4f). Reason: %s"
+          variant_label wins n worst_fold worst_gap reason
+
+let _render_verdict_block ~baseline_label ~(gate : Fold_gate.t)
+    (folds : fold_actual list) =
+  let labels = _variant_labels_in_order folds in
+  let non_baseline =
+    List.filter labels ~f:(fun l -> not (String.equal l baseline_label))
+  in
+  let header =
+    sprintf
+      "Gate: variant wins ≥%d of %d folds on **%s** vs baseline `%s`, no fold \
+       worse by Δ>%.4f.\n"
+      gate.m gate.n (_metric_str gate) baseline_label gate.worst_delta
+  in
+  let lines =
+    List.map non_baseline ~f:(fun variant_label ->
+        let frs =
+          _fold_results_for_pair folds ~baseline_label ~variant_label ~gate
+        in
+        _render_verdict_for_variant ~gate ~variant_label frs)
+  in
+  String.concat ~sep:"\n" (header :: lines)
+
+(* -------------- top-level render -------------- *)
+
+let _validate ~baseline_label folds =
+  if List.is_empty folds then
+    failwith "Walk_forward_report.render: fold_actuals must be non-empty";
+  let labels = _variant_labels_in_order folds in
+  if not (List.mem labels baseline_label ~equal:String.equal) then
+    failwith
+      (sprintf
+         "Walk_forward_report.render: baseline_label %S not present in \
+          fold_actuals (labels: %s)"
+         baseline_label
+         (String.concat ~sep:", " labels))
+
+let render ~baseline_label ~(gate : Fold_gate.t)
+    ~(fold_actuals : fold_actual list) =
+  _validate ~baseline_label fold_actuals;
+  let per_fold = _render_per_fold_table fold_actuals in
+  let stability = _render_stability_table fold_actuals in
+  let sensitivity =
+    _render_sensitivity_table ~baseline_label ~gate fold_actuals
+  in
+  let verdict = _render_verdict_block ~baseline_label ~gate fold_actuals in
+  String.concat ~sep:"\n\n"
+    [
+      "# Walk-forward CV report";
+      "## 1. Per-fold metrics";
+      per_fold;
+      "## 2. Stability (mean ± stdev across folds)";
+      stability;
+      "## 3. Cross-fold sensitivity";
+      sensitivity;
+      "## 4. Go/no-go verdict";
+      verdict;
+    ]

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_report.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_report.ml
@@ -86,26 +86,40 @@ let _render_stability_table (folds : fold_actual list) =
   in
   String.concat ~sep:"\n" (header :: rows)
 
+(** Lookup a fold actual by (fold_name, variant_label). Returns [None] when no
+    such measurement exists. *)
+let _find_fold_actual (folds : fold_actual list) ~fold_name ~variant_label =
+  List.find folds ~f:(fun fa ->
+      String.equal fa.fold_name fold_name
+      && String.equal fa.variant_label variant_label)
+
+(** True iff [variant] strictly beats [baseline] on the named fold, per the
+    gate's metric direction (higher-is-better vs drawdown). *)
+let _variant_beats_baseline ~(gate : Fold_gate.t) ~hib ~folds ~baseline_label
+    ~variant_label ~fold_name =
+  let b = _find_fold_actual folds ~fold_name ~variant_label:baseline_label in
+  let v = _find_fold_actual folds ~fold_name ~variant_label in
+  match (b, v) with
+  | Some b, Some v ->
+      let bv = _project_metric gate b in
+      let vv = _project_metric gate v in
+      if hib then Float.(vv > bv) else Float.(vv < bv)
+  | _ -> false
+
+let _wins_for_variant ~gate ~hib ~folds ~baseline_label ~variant_label =
+  let fold_names = _fold_names_in_order folds in
+  List.count fold_names ~f:(fun fold_name ->
+      _variant_beats_baseline ~gate ~hib ~folds ~baseline_label ~variant_label
+        ~fold_name)
+
 let _wins_per_variant_on_metric (folds : fold_actual list)
     ~(baseline_label : string) ~(gate : Fold_gate.t) =
   let labels = _variant_labels_in_order folds in
-  let fold_names = _fold_names_in_order folds in
   let hib = Fold_gate.higher_is_better gate.metric in
   List.filter labels ~f:(fun l -> not (String.equal l baseline_label))
   |> List.map ~f:(fun variant_label ->
       let wins =
-        List.count fold_names ~f:(fun fold_name ->
-            let fold_of label =
-              List.find folds ~f:(fun fa ->
-                  String.equal fa.fold_name fold_name
-                  && String.equal fa.variant_label label)
-            in
-            match (fold_of baseline_label, fold_of variant_label) with
-            | Some b, Some v ->
-                let bv = _project_metric gate b in
-                let vv = _project_metric gate v in
-                if hib then Float.(vv > bv) else Float.(vv < bv)
-            | _ -> false)
+        _wins_for_variant ~gate ~hib ~folds ~baseline_label ~variant_label
       in
       (variant_label, wins))
 
@@ -133,6 +147,19 @@ let _render_sensitivity_table ~baseline_label ~(gate : Fold_gate.t)
   in
   String.concat ~sep:"\n" (header :: rows)
 
+(** Build one [Fold_gate.fold_result] for the (baseline, variant) pair on the
+    named fold. Returns [None] when either side's measurement is missing. *)
+let _fold_result_for_one ~(gate : Fold_gate.t) ~folds ~baseline_label
+    ~variant_label ~fold_name : Fold_gate.fold_result option =
+  let b = _find_fold_actual folds ~fold_name ~variant_label:baseline_label in
+  let v = _find_fold_actual folds ~fold_name ~variant_label in
+  match (b, v) with
+  | Some b, Some v ->
+      let baseline_score = _project_metric gate b in
+      let variant_score = _project_metric gate v in
+      Some { fold_name; variant_score; baseline_score }
+  | _ -> None
+
 (** Build [Fold_gate.fold_result] list for a single (variant vs baseline)
     pairing. Returns folds in baseline-side ordering — anchors on the unique
     fold-name list. *)
@@ -140,19 +167,8 @@ let _fold_results_for_pair (folds : fold_actual list) ~baseline_label
     ~variant_label ~gate =
   let fold_names = _fold_names_in_order folds in
   List.filter_map fold_names ~f:(fun fold_name ->
-      let find label =
-        List.find folds ~f:(fun fa ->
-            String.equal fa.fold_name fold_name
-            && String.equal fa.variant_label label)
-      in
-      match (find baseline_label, find variant_label) with
-      | Some b, Some v ->
-          let bv = _project_metric gate b in
-          let vv = _project_metric gate v in
-          Some
-            ({ fold_name; variant_score = vv; baseline_score = bv }
-              : Fold_gate.fold_result)
-      | _ -> None)
+      _fold_result_for_one ~gate ~folds ~baseline_label ~variant_label
+        ~fold_name)
 
 let _render_verdict_for_variant ~(gate : Fold_gate.t) ~variant_label
     fold_results =

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_report.mli
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_report.mli
@@ -1,0 +1,41 @@
+(** Pure markdown renderer for walk-forward CV results.
+
+    Consumes a flat list of per-(fold, variant) measurements + a baseline label
+    \+ a {!Fold_gate.t}, and emits a four-section markdown report:
+
+    1. **Per-fold metrics table** — one row per fold × variant, columns: fold
+    name, variant label, total return %, Sharpe, MaxDD %, Calmar. 2. **Stability
+    table** — one row per variant: mean ± stdev of each metric across folds. 3.
+    **Cross-fold parameter sensitivity** — variant win-count per metric. 4.
+    **Go/no-go verdict block** — calls {!Fold_gate.evaluate} on the
+    gate-selected metric and renders Pass/Fail with the diagnostic fields. *)
+
+type fold_actual = {
+  fold_name : string;
+  variant_label : string;
+  total_return_pct : float;
+  sharpe_ratio : float;
+  max_drawdown_pct : float;
+  calmar_ratio : float;
+}
+[@@deriving sexp]
+
+val render :
+  baseline_label:string ->
+  gate:Fold_gate.t ->
+  fold_actuals:fold_actual list ->
+  string
+(** [render ~baseline_label ~gate ~fold_actuals] returns a markdown report
+    string. The renderer is deterministic — same inputs produce byte-identical
+    output (modulo timestamp, which is intentionally omitted).
+
+    Raises [Failure] if [fold_actuals] is empty or if [baseline_label] is not
+    present among the variant labels in [fold_actuals].
+
+    The per-fold table preserves the input ordering of [fold_actuals]. The
+    stability and sensitivity tables aggregate by variant label, in the order
+    the labels first appear in [fold_actuals].
+
+    The go/no-go verdict block pairs each non-baseline variant against the
+    baseline on the gate's [metric] and renders a separate Pass/Fail line per
+    variant. *)

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_runner.ml
@@ -1,0 +1,30 @@
+open Core
+module Scenario = Scenario_lib.Scenario
+
+type variant = { label : string; overrides : Sexp.t list } [@@deriving sexp]
+
+let _scenario_name ~(base : Scenario.t) ~variant ~(fold : Window_spec.fold) =
+  sprintf "%s-%s-%s" base.name variant.label fold.name
+
+let _description ~(base : Scenario.t) ~variant ~(fold : Window_spec.fold) =
+  sprintf "[walk-forward fold %s | variant %s] %s" fold.name variant.label
+    base.description
+
+let build_fold_scenario ~(base : Scenario.t) ~(fold : Window_spec.fold)
+    ~(variant : variant) : Scenario.t =
+  {
+    name = _scenario_name ~base ~variant ~fold;
+    description = _description ~base ~variant ~fold;
+    period = fold.test_period;
+    universe_path = base.universe_path;
+    config_overrides = base.config_overrides @ variant.overrides;
+    strategy = base.strategy;
+    slippage_bps = base.slippage_bps;
+    expected = base.expected;
+  }
+
+let build_all ~(base : Scenario.t) ~(spec : Window_spec.t)
+    ~(variants : variant list) =
+  let folds = Window_spec.generate spec in
+  List.concat_map variants ~f:(fun variant ->
+      List.map folds ~f:(fun fold -> build_fold_scenario ~base ~fold ~variant))

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_runner.mli
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_runner.mli
@@ -1,0 +1,58 @@
+(** Pure scenario generation for walk-forward CV.
+
+    Given a base {!Scenario_lib.Scenario.t} (the template — its period gets
+    overridden), a {!Window_spec.t} (the rolling windows), and a list of
+    {!variant}s (variant_label → extra config overrides), produces the list of
+    {!Scenario_lib.Scenario.t} the walk-forward harness instantiates.
+
+    Pure: same inputs → same output sexps. No backtest invocation here; the CLI
+    binary feeds these scenarios to [Backtest.Runner.run_backtest] in the same
+    shape {!Tuner_bin.Bayesian_runner_evaluator.build} does. *)
+
+open Core
+
+type variant = {
+  label : string;
+      (** Human-readable variant identifier. Becomes part of the generated
+          scenario name and the report's column header. Must be unique within a
+          single walk-forward run. *)
+  overrides : Sexp.t list;
+      (** Partial config sexps deep-merged into the scenario's existing
+          [config_overrides], in order. Mirrors
+          {!Scenario_lib.Scenario.config_overrides}. *)
+}
+[@@deriving sexp]
+
+val build_fold_scenario :
+  base:Scenario_lib.Scenario.t ->
+  fold:Window_spec.fold ->
+  variant:variant ->
+  Scenario_lib.Scenario.t
+(** [build_fold_scenario ~base ~fold ~variant] produces a scenario suitable for
+    {!Backtest.Runner.run_backtest}.
+
+    Mapping:
+    - [name = base.name ^ "-" ^ variant.label ^ "-" ^ fold.name]
+    - [description] preserved from [base] but prefixed with the fold label.
+    - [period = fold.test_period] — the OOS evaluation window.
+    - [universe_path] preserved.
+    - [config_overrides = base.config_overrides @ variant.overrides] — variant
+      overrides are APPENDED last so they win on conflicts (last-writer-wins per
+      {!Tuner_bin.Bayesian_runner_evaluator.build} and
+      {!Backtest.Runner.run_backtest}).
+    - [strategy] preserved.
+    - [slippage_bps] preserved.
+    - [expected] preserved — note this means range checks may fail per-fold; the
+      walk-forward report's comparison is across variants, not against pinned
+      ranges. *)
+
+val build_all :
+  base:Scenario_lib.Scenario.t ->
+  spec:Window_spec.t ->
+  variants:variant list ->
+  Scenario_lib.Scenario.t list
+(** [build_all ~base ~spec ~variants] = the flat list of all
+    [{!build_fold_scenario}] outputs across
+    [variants × WindowSpec.generate spec]. Ordering: outer = variants in input
+    order, inner = folds in generation order. Empty variant list → empty result.
+*)

--- a/trading/trading/backtest/walk_forward/lib/window_spec.ml
+++ b/trading/trading/backtest/walk_forward/lib/window_spec.ml
@@ -1,0 +1,63 @@
+open Core
+module Scenario = Scenario_lib.Scenario
+
+type t = {
+  start_date : Date.t;
+  end_date : Date.t;
+  train_days : int;
+  test_days : int;
+  step_days : int;
+}
+[@@deriving sexp]
+
+type fold = {
+  index : int;
+  name : string;
+  train_period : Scenario.period option;
+  test_period : Scenario.period;
+}
+[@@deriving sexp]
+
+let _validate spec =
+  if spec.train_days < 0 then
+    failwith
+      (sprintf "WindowSpec.generate: train_days must be >= 0, got %d"
+         spec.train_days);
+  if spec.test_days <= 0 then
+    failwith
+      (sprintf "WindowSpec.generate: test_days must be > 0, got %d"
+         spec.test_days);
+  if spec.step_days <= 0 then
+    failwith
+      (sprintf "WindowSpec.generate: step_days must be > 0, got %d"
+         spec.step_days)
+
+let _fold_name index = sprintf "fold-%03d" index
+
+let _build_fold ~index ~spec ~anchor =
+  let train_start = anchor in
+  let train_end = Date.add_days anchor (spec.train_days - 1) in
+  let test_start = Date.add_days anchor spec.train_days in
+  let test_end = Date.add_days test_start (spec.test_days - 1) in
+  let train_period =
+    if spec.train_days = 0 then None
+    else
+      Some
+        ({ start_date = train_start; end_date = train_end } : Scenario.period)
+  in
+  let test_period : Scenario.period =
+    { start_date = test_start; end_date = test_end }
+  in
+  { index; name = _fold_name index; train_period; test_period }
+
+let generate spec =
+  _validate spec;
+  let rec loop ~index ~anchor acc =
+    let candidate = _build_fold ~index ~spec ~anchor in
+    if Date.( > ) candidate.test_period.end_date spec.end_date then List.rev acc
+    else
+      let next_anchor = Date.add_days anchor spec.step_days in
+      loop ~index:(index + 1) ~anchor:next_anchor (candidate :: acc)
+  in
+  if Date.( > ) spec.start_date spec.end_date then []
+  else loop ~index:0 ~anchor:spec.start_date []

--- a/trading/trading/backtest/walk_forward/lib/window_spec.mli
+++ b/trading/trading/backtest/walk_forward/lib/window_spec.mli
@@ -1,0 +1,73 @@
+(** Rolling window specification for walk-forward cross-validation.
+
+    A [WindowSpec.t] is a pure description of how to roll a fixed-shape
+    train/test window forward across a calendar range. {!generate} expands the
+    spec into a list of {!fold}s; each fold carries a name and the train + test
+    {!Scenario_lib.Scenario.period}s the walk-forward runner will instantiate
+    base scenarios over.
+
+    Walk-forward CV (Phase 2 per
+    [dev/notes/next-session-priorities-2026-05-15.md]) scales the existing
+    hand-curated 8-fold experiment to ~30 rolling folds so per-fold variance is
+    observable and a machine-checkable go/no-go gate becomes the verdict rather
+    than an eyeballed table.
+
+    All date arithmetic is in calendar days (not trading days). Conversion to
+    trading-day windows is the backtest runner's job — the spec only constrains
+    the wall-clock period each fold runs over. *)
+
+open Core
+
+type t = {
+  start_date : Date.t;
+      (** Inclusive earliest day for the first fold's train (or test, when
+          [train_days = 0]) period. *)
+  end_date : Date.t;
+      (** Inclusive latest day any fold may extend to. Folds whose test period
+          would end after [end_date] are dropped. *)
+  train_days : int;
+      (** Length of each fold's in-sample (train) period in calendar days. Zero
+          means OOS-only folds — [train_period] in the generated fold is [None].
+          Must be [>= 0]. *)
+  test_days : int;
+      (** Length of each fold's out-of-sample (test) period in calendar days.
+          Must be [> 0]. *)
+  step_days : int;
+      (** How far each subsequent fold's anchor advances in calendar days. Must
+          be [> 0]. When [step_days < test_days] the test windows overlap
+          (classic rolling walk-forward); when [step_days = test_days] the test
+          windows tile without overlap. *)
+}
+[@@deriving sexp]
+(** Sexp shape (one record):
+    [((start_date 2010-01-01) (end_date 2024-12-31) (train_days 730) (test_days
+     365) (step_days 182))]. *)
+
+type fold = {
+  index : int;  (** Zero-based fold index in generation order. *)
+  name : string;
+      (** Human-readable fold name, shape ["fold-NNN"] where [NNN] is [index]
+          zero-padded to width 3. Used as a suffix in generated scenario names.
+      *)
+  train_period : Scenario_lib.Scenario.period option;
+      (** [Some] when [WindowSpec.train_days > 0], else [None]. The train period
+          precedes the test period back-to-back. *)
+  test_period : Scenario_lib.Scenario.period;
+}
+[@@deriving sexp]
+
+val generate : t -> fold list
+(** [generate spec] expands a spec into its sequence of folds.
+
+    Algorithm: starting from [spec.start_date], the first fold's train_period
+    runs [start_date .. start_date + train_days - 1] (inclusive) and its
+    test_period runs
+    [start_date + train_days .. start_date + train_days + test_days - 1]. Each
+    subsequent fold's anchor advances by [step_days] calendar days. A fold is
+    included iff its test_period ends on or before [spec.end_date]; the first
+    fold whose test_period would extend past [end_date] is dropped along with
+    all later folds.
+
+    Returns an empty list when [start_date > end_date] or no fold fits the
+    bounds. Raises [Failure] when [train_days < 0], [test_days <= 0], or
+    [step_days <= 0]. *)

--- a/trading/trading/backtest/walk_forward/test/dune
+++ b/trading/trading/backtest/walk_forward/test/dune
@@ -1,0 +1,9 @@
+(tests
+ (names
+  test_window_spec
+  test_fold_gate
+  test_walk_forward_runner
+  test_walk_forward_report)
+ (libraries ounit2 core matchers scenario_lib walk_forward)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/walk_forward/test/dune
+++ b/trading/trading/backtest/walk_forward/test/dune
@@ -4,6 +4,6 @@
   test_fold_gate
   test_walk_forward_runner
   test_walk_forward_report)
- (libraries ounit2 core matchers scenario_lib walk_forward)
+ (libraries ounit2 core matchers backtest scenario_lib walk_forward)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/walk_forward/test/test_fold_gate.ml
+++ b/trading/trading/backtest/walk_forward/test/test_fold_gate.ml
@@ -18,10 +18,12 @@ let _gate ?(metric = FG.Sharpe) ?(m = 3) ?(n = 5) ?(worst_delta = 0.10) () :
 (* ---------- higher_is_better ---------- *)
 
 let test_higher_is_better _ =
-  assert_that (FG.higher_is_better Sharpe) (equal_to true);
-  assert_that (FG.higher_is_better Calmar) (equal_to true);
-  assert_that (FG.higher_is_better TotalReturnPct) (equal_to true);
-  assert_that (FG.higher_is_better MaxDrawdownPct) (equal_to false)
+  assert_bool "Sharpe is higher-is-better" (FG.higher_is_better Sharpe);
+  assert_bool "Calmar is higher-is-better" (FG.higher_is_better Calmar);
+  assert_bool "TotalReturnPct is higher-is-better"
+    (FG.higher_is_better TotalReturnPct);
+  assert_bool "MaxDrawdownPct is lower-is-better"
+    (not (FG.higher_is_better MaxDrawdownPct))
 
 (* ---------- Validation ---------- *)
 
@@ -94,9 +96,7 @@ let test_m_threshold_miss _ =
   | FG.Fail { wins; n; reason; _ } ->
       assert_that wins (equal_to 2);
       assert_that n (equal_to 5);
-      assert_that
-        (String.is_substring reason ~substring:"M-threshold")
-        (equal_to true)
+      assert_that reason (contains_substring "M-threshold")
   | FG.Pass _ -> assert_failure "Expected Fail (M-threshold)"
 
 (* ---------- Δ-threshold miss ---------- *)
@@ -119,9 +119,7 @@ let test_delta_threshold_miss _ =
       assert_that wins (equal_to 4);
       assert_that worst_fold (equal_to "fold-004");
       assert_that worst_gap (float_equal 0.5);
-      assert_that
-        (String.is_substring reason ~substring:"Δ-threshold")
-        (equal_to true)
+      assert_that reason (contains_substring "Δ-threshold")
   | FG.Pass _ -> assert_failure "Expected Fail (Δ-threshold)"
 
 (* ---------- Baseline tie counts as baseline win ---------- *)

--- a/trading/trading/backtest/walk_forward/test/test_fold_gate.ml
+++ b/trading/trading/backtest/walk_forward/test/test_fold_gate.ml
@@ -1,2 +1,226 @@
-(* TODO: stub - to be filled in next commit *)
-let () = ()
+(** Unit tests for {!Walk_forward.Fold_gate}. Pure scoring checks — no backtest
+    invocation. *)
+
+open OUnit2
+open Core
+open Matchers
+module FG = Walk_forward.Fold_gate
+
+(* ---------- Helpers ---------- *)
+
+let _fr ~name ~variant ~baseline : FG.fold_result =
+  { fold_name = name; variant_score = variant; baseline_score = baseline }
+
+let _gate ?(metric = FG.Sharpe) ?(m = 3) ?(n = 5) ?(worst_delta = 0.10) () :
+    FG.t =
+  { metric; m; n; worst_delta }
+
+(* ---------- higher_is_better ---------- *)
+
+let test_higher_is_better _ =
+  assert_that (FG.higher_is_better Sharpe) (equal_to true);
+  assert_that (FG.higher_is_better Calmar) (equal_to true);
+  assert_that (FG.higher_is_better TotalReturnPct) (equal_to true);
+  assert_that (FG.higher_is_better MaxDrawdownPct) (equal_to false)
+
+(* ---------- Validation ---------- *)
+
+let test_n_zero_raises _ =
+  let gate = _gate ~n:0 ~m:0 () in
+  assert_raises (Failure "Fold_gate.evaluate: n must be >= 1, got 0") (fun () ->
+      FG.evaluate gate [])
+
+let test_m_out_of_range_raises _ =
+  let gate = _gate ~m:6 ~n:5 () in
+  assert_raises (Failure "Fold_gate.evaluate: m must be in [0, n=5], got 6")
+    (fun () ->
+      let folds =
+        List.init 5 ~f:(fun i ->
+            _fr ~name:(sprintf "fold-%03d" i) ~variant:1.0 ~baseline:0.5)
+      in
+      FG.evaluate gate folds)
+
+let test_negative_delta_raises _ =
+  let gate = _gate ~worst_delta:(-0.1) () in
+  assert_raises
+    (Failure "Fold_gate.evaluate: worst_delta must be >= 0.0, got -0.100000")
+    (fun () -> FG.evaluate gate [])
+
+let test_fold_count_mismatch_raises _ =
+  let gate = _gate ~n:5 ~m:3 () in
+  let folds =
+    List.init 3 ~f:(fun i ->
+        _fr ~name:(sprintf "fold-%03d" i) ~variant:1.0 ~baseline:0.5)
+  in
+  assert_raises
+    (Failure
+       "Fold_gate.evaluate: fold count mismatch — gate.n=5 but got 3 folds")
+    (fun () -> FG.evaluate gate folds)
+
+(* ---------- Full pass ---------- *)
+
+let test_full_pass_5_of_5 _ =
+  let gate = _gate ~metric:Sharpe ~m:3 ~n:5 ~worst_delta:0.5 () in
+  let folds =
+    List.init 5 ~f:(fun i ->
+        _fr ~name:(sprintf "fold-%03d" i) ~variant:1.0 ~baseline:0.5)
+  in
+  (* Inline-record variants can't be projected via [function FG.Pass p -> Some
+     p] without the type escaping. Destructure inline and assert on the bare
+     fields. *)
+  let verdict = FG.evaluate gate folds in
+  match verdict with
+  | FG.Pass { wins; n } ->
+      assert_that wins (equal_to 5);
+      assert_that n (equal_to 5)
+  | FG.Fail _ -> assert_failure "Expected Pass, got Fail"
+
+(* ---------- M-threshold miss ---------- *)
+
+let test_m_threshold_miss _ =
+  (* Variant wins 2 of 5; gate requires 4. *)
+  let gate = _gate ~metric:Sharpe ~m:4 ~n:5 ~worst_delta:1.0 () in
+  let folds =
+    [
+      _fr ~name:"fold-000" ~variant:1.0 ~baseline:0.5;
+      _fr ~name:"fold-001" ~variant:1.0 ~baseline:0.5;
+      _fr ~name:"fold-002" ~variant:0.3 ~baseline:0.5;
+      _fr ~name:"fold-003" ~variant:0.4 ~baseline:0.5;
+      _fr ~name:"fold-004" ~variant:0.4 ~baseline:0.5;
+    ]
+  in
+  let verdict = FG.evaluate gate folds in
+  match verdict with
+  | FG.Fail { wins; n; reason; _ } ->
+      assert_that wins (equal_to 2);
+      assert_that n (equal_to 5);
+      assert_that
+        (String.is_substring reason ~substring:"M-threshold")
+        (equal_to true)
+  | FG.Pass _ -> assert_failure "Expected Fail (M-threshold)"
+
+(* ---------- Δ-threshold miss ---------- *)
+
+let test_delta_threshold_miss _ =
+  (* Variant wins 4 of 5 (passes M) but one fold has a 0.5 shortfall > delta=0.1. *)
+  let gate = _gate ~metric:Sharpe ~m:3 ~n:5 ~worst_delta:0.1 () in
+  let folds =
+    [
+      _fr ~name:"fold-000" ~variant:1.0 ~baseline:0.5;
+      _fr ~name:"fold-001" ~variant:1.0 ~baseline:0.5;
+      _fr ~name:"fold-002" ~variant:1.0 ~baseline:0.5;
+      _fr ~name:"fold-003" ~variant:1.0 ~baseline:0.5;
+      _fr ~name:"fold-004" ~variant:0.0 ~baseline:0.5;
+    ]
+  in
+  let verdict = FG.evaluate gate folds in
+  match verdict with
+  | FG.Fail { wins; worst_fold; worst_gap; reason; _ } ->
+      assert_that wins (equal_to 4);
+      assert_that worst_fold (equal_to "fold-004");
+      assert_that worst_gap (float_equal 0.5);
+      assert_that
+        (String.is_substring reason ~substring:"Δ-threshold")
+        (equal_to true)
+  | FG.Pass _ -> assert_failure "Expected Fail (Δ-threshold)"
+
+(* ---------- Baseline tie counts as baseline win ---------- *)
+
+let test_tie_counts_as_baseline_win _ =
+  let gate = _gate ~metric:Sharpe ~m:1 ~n:3 ~worst_delta:1.0 () in
+  let folds =
+    [
+      _fr ~name:"fold-000" ~variant:0.5 ~baseline:0.5;
+      _fr ~name:"fold-001" ~variant:0.5 ~baseline:0.5;
+      _fr ~name:"fold-002" ~variant:0.5 ~baseline:0.5;
+    ]
+  in
+  let verdict = FG.evaluate gate folds in
+  match verdict with
+  | FG.Fail { wins; _ } -> assert_that wins (equal_to 0)
+  | FG.Pass _ -> assert_failure "Expected Fail on all-tie"
+
+(* ---------- MaxDrawdownPct inverts direction ---------- *)
+
+let test_drawdown_inverted_direction _ =
+  (* Lower DD is better. Variant has 10% DD vs baseline 20%; variant wins. *)
+  let gate = _gate ~metric:MaxDrawdownPct ~m:3 ~n:3 ~worst_delta:5.0 () in
+  let folds =
+    [
+      _fr ~name:"fold-000" ~variant:10.0 ~baseline:20.0;
+      _fr ~name:"fold-001" ~variant:8.0 ~baseline:15.0;
+      _fr ~name:"fold-002" ~variant:12.0 ~baseline:13.0;
+    ]
+  in
+  let verdict = FG.evaluate gate folds in
+  match verdict with
+  | FG.Pass { wins; _ } -> assert_that wins (equal_to 3)
+  | FG.Fail _ -> assert_failure "Expected Pass on inverted DD"
+
+let test_drawdown_inverted_delta_miss _ =
+  let gate = _gate ~metric:MaxDrawdownPct ~m:0 ~n:3 ~worst_delta:2.0 () in
+  let folds =
+    [
+      _fr ~name:"fold-000" ~variant:10.0 ~baseline:11.0;
+      _fr ~name:"fold-001" ~variant:8.0 ~baseline:9.0;
+      _fr ~name:"fold-002" ~variant:25.0 ~baseline:15.0;
+      (* variant_dd 25 > baseline_dd 15 + delta 2 = 17 → fail *)
+    ]
+  in
+  let verdict = FG.evaluate gate folds in
+  match verdict with
+  | FG.Fail { worst_fold; worst_gap; _ } ->
+      assert_that worst_fold (equal_to "fold-002");
+      assert_that worst_gap (float_equal 10.0)
+  | FG.Pass _ -> assert_failure "Expected Fail on inverted-DD Δ miss"
+
+(* ---------- Boundary: variant_score - baseline = worst_delta exactly (Pass) ---------- *)
+
+let test_exact_delta_boundary_passes _ =
+  (* worst_delta=0.5 and a fold trails by exactly 0.5 — must Pass per ">". *)
+  let gate = _gate ~metric:Sharpe ~m:0 ~n:2 ~worst_delta:0.5 () in
+  let folds =
+    [
+      _fr ~name:"fold-000" ~variant:1.0 ~baseline:0.5;
+      _fr ~name:"fold-001" ~variant:0.0 ~baseline:0.5;
+      (* trails by 0.5 = delta, not > *)
+    ]
+  in
+  let verdict = FG.evaluate gate folds in
+  match verdict with
+  | FG.Pass _ -> ()
+  | FG.Fail _ -> assert_failure "Expected Pass at exact-delta boundary"
+
+(* ---------- Sexp round-trip on gate ---------- *)
+
+let test_gate_sexp_round_trip _ =
+  let gate = _gate ~metric:Calmar ~m:18 ~n:25 ~worst_delta:0.20 () in
+  let parsed = FG.t_of_sexp (FG.sexp_of_t gate) in
+  assert_that parsed
+    (all_of
+       [
+         field (fun (g : FG.t) -> g.metric) (equal_to FG.Calmar);
+         field (fun (g : FG.t) -> g.m) (equal_to 18);
+         field (fun (g : FG.t) -> g.n) (equal_to 25);
+         field (fun (g : FG.t) -> g.worst_delta) (float_equal 0.20);
+       ])
+
+let suite =
+  "Fold_gate"
+  >::: [
+         "higher_is_better" >:: test_higher_is_better;
+         "n=0 raises" >:: test_n_zero_raises;
+         "m out of range raises" >:: test_m_out_of_range_raises;
+         "negative delta raises" >:: test_negative_delta_raises;
+         "fold count mismatch raises" >:: test_fold_count_mismatch_raises;
+         "full pass 5/5" >:: test_full_pass_5_of_5;
+         "M-threshold miss" >:: test_m_threshold_miss;
+         "Δ-threshold miss" >:: test_delta_threshold_miss;
+         "tie counts as baseline win" >:: test_tie_counts_as_baseline_win;
+         "drawdown inverted direction pass" >:: test_drawdown_inverted_direction;
+         "drawdown inverted Δ miss" >:: test_drawdown_inverted_delta_miss;
+         "exact-delta boundary passes" >:: test_exact_delta_boundary_passes;
+         "gate sexp round-trip" >:: test_gate_sexp_round_trip;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/walk_forward/test/test_fold_gate.ml
+++ b/trading/trading/backtest/walk_forward/test/test_fold_gate.ml
@@ -1,0 +1,2 @@
+(* TODO: stub - to be filled in next commit *)
+let () = ()

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
@@ -1,2 +1,239 @@
-(* TODO: stub - to be filled in next commit *)
-let () = ()
+(** Unit tests for {!Walk_forward.Walk_forward_report}. Pure markdown shape
+    checks — no backtest invocation. *)
+
+open OUnit2
+open Core
+open Matchers
+module Report = Walk_forward.Walk_forward_report
+module FG = Walk_forward.Fold_gate
+
+let _fa ~fold ~variant ~ret ~sharpe ~maxdd ~calmar : Report.fold_actual =
+  {
+    fold_name = fold;
+    variant_label = variant;
+    total_return_pct = ret;
+    sharpe_ratio = sharpe;
+    max_drawdown_pct = maxdd;
+    calmar_ratio = calmar;
+  }
+
+let _baseline_gate ?(metric = FG.Sharpe) ?(m = 2) ?(n = 3) ?(worst_delta = 0.5)
+    () : FG.t =
+  { metric; m; n; worst_delta }
+
+(* ---------- Validation ---------- *)
+
+let test_empty_folds_raises _ =
+  assert_raises
+    (Failure "Walk_forward_report.render: fold_actuals must be non-empty")
+    (fun () ->
+      Report.render ~baseline_label:"baseline" ~gate:(_baseline_gate ())
+        ~fold_actuals:[])
+
+let test_baseline_not_present_raises _ =
+  let folds =
+    [
+      _fa ~fold:"fold-000" ~variant:"A" ~ret:1.0 ~sharpe:1.0 ~maxdd:5.0
+        ~calmar:1.0;
+    ]
+  in
+  let exn =
+    try
+      let _ =
+        Report.render ~baseline_label:"baseline" ~gate:(_baseline_gate ~n:1 ())
+          ~fold_actuals:folds
+      in
+      None
+    with Failure _ as e -> Some e
+  in
+  assert_that exn
+    (is_some_and
+       (matching ~msg:"Expected Failure baseline-not-present"
+          (function
+            | Failure msg
+              when String.is_substring msg ~substring:"baseline_label" ->
+                Some ()
+            | _ -> None)
+          (equal_to ())))
+
+(* ---------- Section headings present ---------- *)
+
+let _three_fold_two_variant_setup () =
+  let baseline =
+    [
+      _fa ~fold:"fold-000" ~variant:"baseline" ~ret:5.0 ~sharpe:0.5 ~maxdd:8.0
+        ~calmar:0.6;
+      _fa ~fold:"fold-001" ~variant:"baseline" ~ret:6.0 ~sharpe:0.6 ~maxdd:9.0
+        ~calmar:0.7;
+      _fa ~fold:"fold-002" ~variant:"baseline" ~ret:4.0 ~sharpe:0.4 ~maxdd:7.0
+        ~calmar:0.5;
+    ]
+  in
+  let variant =
+    [
+      _fa ~fold:"fold-000" ~variant:"cellE" ~ret:8.0 ~sharpe:0.9 ~maxdd:6.0
+        ~calmar:1.1;
+      _fa ~fold:"fold-001" ~variant:"cellE" ~ret:7.0 ~sharpe:0.7 ~maxdd:10.0
+        ~calmar:0.8;
+      _fa ~fold:"fold-002" ~variant:"cellE" ~ret:5.0 ~sharpe:0.45 ~maxdd:8.0
+        ~calmar:0.55;
+    ]
+  in
+  baseline @ variant
+
+let test_render_contains_all_four_section_headers _ =
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 () in
+  let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s ->
+             String.is_substring s ~substring:"# Walk-forward CV report")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"## 1. Per-fold metrics")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"## 2. Stability")
+           (equal_to true);
+         field
+           (fun s ->
+             String.is_substring s ~substring:"## 3. Cross-fold sensitivity")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"## 4. Go/no-go verdict")
+           (equal_to true);
+       ])
+
+let test_render_contains_pass_when_variant_wins _ =
+  (* cellE wins 3/3 on Sharpe (0.9>0.5, 0.7>0.6, 0.45>0.4). Gate m=2/3, Δ=0.5
+     — no fold trails so should PASS. *)
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 ~worst_delta:0.5 () in
+  let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"cellE")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"PASS")
+           (equal_to true);
+       ])
+
+let test_render_contains_fail_when_m_threshold_missed _ =
+  (* baseline > cellE on all 3 folds; require cellE wins ≥2 — must FAIL. *)
+  let folds =
+    [
+      _fa ~fold:"fold-000" ~variant:"baseline" ~ret:9.0 ~sharpe:1.5 ~maxdd:5.0
+        ~calmar:1.5;
+      _fa ~fold:"fold-001" ~variant:"baseline" ~ret:9.0 ~sharpe:1.5 ~maxdd:5.0
+        ~calmar:1.5;
+      _fa ~fold:"fold-002" ~variant:"baseline" ~ret:9.0 ~sharpe:1.5 ~maxdd:5.0
+        ~calmar:1.5;
+      _fa ~fold:"fold-000" ~variant:"cellE" ~ret:1.0 ~sharpe:0.2 ~maxdd:10.0
+        ~calmar:0.2;
+      _fa ~fold:"fold-001" ~variant:"cellE" ~ret:1.0 ~sharpe:0.2 ~maxdd:10.0
+        ~calmar:0.2;
+      _fa ~fold:"fold-002" ~variant:"cellE" ~ret:1.0 ~sharpe:0.2 ~maxdd:10.0
+        ~calmar:0.2;
+    ]
+  in
+  let gate = _baseline_gate ~m:2 ~n:3 ~worst_delta:100.0 () in
+  let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
+  assert_that md
+    (field (fun s -> String.is_substring s ~substring:"FAIL") (equal_to true))
+
+let test_per_fold_table_renders_decimal_metrics _ =
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 () in
+  let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
+  (* baseline fold-000 has return 5.0 and Sharpe 0.5 — should appear formatted *)
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"5.00")
+           (equal_to true);
+         field
+           (fun s -> String.is_substring s ~substring:"0.500")
+           (equal_to true);
+       ])
+
+let test_stability_row_shows_mean_and_stdev _ =
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 () in
+  let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
+  (* The stability table uses "μ ± σ" header; verify the symbol pair appears. *)
+  assert_that md
+    (field (fun s -> String.is_substring s ~substring:"μ ± σ") (equal_to true))
+
+let test_sensitivity_row_per_variant _ =
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 () in
+  let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
+  (* cellE wins on 3 folds (0.9>0.5, 0.7>0.6, 0.45>0.4). Sensitivity table
+     should report "cellE | 3 | 3". *)
+  assert_that md
+    (all_of
+       [
+         field
+           (fun s -> String.is_substring s ~substring:"| cellE | 3 | 3 |")
+           (equal_to true);
+       ])
+
+(* ---------- Determinism ---------- *)
+
+let test_render_is_deterministic _ =
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 () in
+  let md1 =
+    Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds
+  in
+  let md2 =
+    Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds
+  in
+  assert_that md1 (equal_to md2)
+
+(* ---------- Sexp round-trip ---------- *)
+
+let test_fold_actual_sexp_round_trip _ =
+  let fa =
+    _fa ~fold:"fold-007" ~variant:"X" ~ret:12.3 ~sharpe:0.8 ~maxdd:6.7
+      ~calmar:1.2
+  in
+  let parsed = Report.fold_actual_of_sexp (Report.sexp_of_fold_actual fa) in
+  assert_that parsed
+    (all_of
+       [
+         field
+           (fun (f : Report.fold_actual) -> f.fold_name)
+           (equal_to "fold-007");
+         field
+           (fun (f : Report.fold_actual) -> f.total_return_pct)
+           (float_equal 12.3);
+       ])
+
+let suite =
+  "Walk_forward_report"
+  >::: [
+         "empty folds raises" >:: test_empty_folds_raises;
+         "baseline not present raises" >:: test_baseline_not_present_raises;
+         "render contains all 4 section headers"
+         >:: test_render_contains_all_four_section_headers;
+         "render PASS when variant wins"
+         >:: test_render_contains_pass_when_variant_wins;
+         "render FAIL when M-threshold missed"
+         >:: test_render_contains_fail_when_m_threshold_missed;
+         "per-fold table formats decimals"
+         >:: test_per_fold_table_renders_decimal_metrics;
+         "stability row shows μ ± σ" >:: test_stability_row_shows_mean_and_stdev;
+         "sensitivity row per variant" >:: test_sensitivity_row_per_variant;
+         "render is deterministic" >:: test_render_is_deterministic;
+         "fold_actual sexp round-trip" >:: test_fold_actual_sexp_round_trip;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
@@ -88,23 +88,11 @@ let test_render_contains_all_four_section_headers _ =
   assert_that md
     (all_of
        [
-         field
-           (fun s ->
-             String.is_substring s ~substring:"# Walk-forward CV report")
-           (equal_to true);
-         field
-           (fun s -> String.is_substring s ~substring:"## 1. Per-fold metrics")
-           (equal_to true);
-         field
-           (fun s -> String.is_substring s ~substring:"## 2. Stability")
-           (equal_to true);
-         field
-           (fun s ->
-             String.is_substring s ~substring:"## 3. Cross-fold sensitivity")
-           (equal_to true);
-         field
-           (fun s -> String.is_substring s ~substring:"## 4. Go/no-go verdict")
-           (equal_to true);
+         contains_substring "# Walk-forward CV report";
+         contains_substring "## 1. Per-fold metrics";
+         contains_substring "## 2. Stability";
+         contains_substring "## 3. Cross-fold sensitivity";
+         contains_substring "## 4. Go/no-go verdict";
        ])
 
 let test_render_contains_pass_when_variant_wins _ =
@@ -114,15 +102,7 @@ let test_render_contains_pass_when_variant_wins _ =
   let gate = _baseline_gate ~m:2 ~n:3 ~worst_delta:0.5 () in
   let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
   assert_that md
-    (all_of
-       [
-         field
-           (fun s -> String.is_substring s ~substring:"cellE")
-           (equal_to true);
-         field
-           (fun s -> String.is_substring s ~substring:"PASS")
-           (equal_to true);
-       ])
+    (all_of [ contains_substring "cellE"; contains_substring "PASS" ])
 
 let test_render_contains_fail_when_m_threshold_missed _ =
   (* baseline > cellE on all 3 folds; require cellE wins ≥2 — must FAIL. *)
@@ -144,8 +124,7 @@ let test_render_contains_fail_when_m_threshold_missed _ =
   in
   let gate = _baseline_gate ~m:2 ~n:3 ~worst_delta:100.0 () in
   let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
-  assert_that md
-    (field (fun s -> String.is_substring s ~substring:"FAIL") (equal_to true))
+  assert_that md (contains_substring "FAIL")
 
 let test_per_fold_table_renders_decimal_metrics _ =
   let folds = _three_fold_two_variant_setup () in
@@ -153,23 +132,14 @@ let test_per_fold_table_renders_decimal_metrics _ =
   let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
   (* baseline fold-000 has return 5.0 and Sharpe 0.5 — should appear formatted *)
   assert_that md
-    (all_of
-       [
-         field
-           (fun s -> String.is_substring s ~substring:"5.00")
-           (equal_to true);
-         field
-           (fun s -> String.is_substring s ~substring:"0.500")
-           (equal_to true);
-       ])
+    (all_of [ contains_substring "5.00"; contains_substring "0.500" ])
 
 let test_stability_row_shows_mean_and_stdev _ =
   let folds = _three_fold_two_variant_setup () in
   let gate = _baseline_gate ~m:2 ~n:3 () in
   let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
   (* The stability table uses "μ ± σ" header; verify the symbol pair appears. *)
-  assert_that md
-    (field (fun s -> String.is_substring s ~substring:"μ ± σ") (equal_to true))
+  assert_that md (contains_substring "μ ± σ")
 
 let test_sensitivity_row_per_variant _ =
   let folds = _three_fold_two_variant_setup () in
@@ -177,13 +147,7 @@ let test_sensitivity_row_per_variant _ =
   let md = Report.render ~baseline_label:"baseline" ~gate ~fold_actuals:folds in
   (* cellE wins on 3 folds (0.9>0.5, 0.7>0.6, 0.45>0.4). Sensitivity table
      should report "cellE | 3 | 3". *)
-  assert_that md
-    (all_of
-       [
-         field
-           (fun s -> String.is_substring s ~substring:"| cellE | 3 | 3 |")
-           (equal_to true);
-       ])
+  assert_that md (contains_substring "| cellE | 3 | 3 |")
 
 (* ---------- Determinism ---------- *)
 

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
@@ -1,0 +1,2 @@
+(* TODO: stub - to be filled in next commit *)
+let () = ()

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
@@ -121,15 +121,9 @@ let test_description_marks_fold_and_variant _ =
     (all_of
        [
          (* Both labels present *)
-         field
-           (fun d -> String.is_substring d ~substring:"fold-007")
-           (equal_to true);
-         field
-           (fun d -> String.is_substring d ~substring:"cellX")
-           (equal_to true);
-         field
-           (fun d -> String.is_substring d ~substring:"orig desc")
-           (equal_to true);
+         contains_substring "fold-007";
+         contains_substring "cellX";
+         contains_substring "orig desc";
        ])
 
 (* ---------- build_all: cross product order ---------- *)

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
@@ -1,2 +1,214 @@
-(* TODO: stub - to be filled in next commit *)
-let () = ()
+(** Unit tests for {!Walk_forward.Walk_forward_runner}. Pure scenario-shape
+    checks — no backtest invocation. *)
+
+open OUnit2
+open Core
+open Matchers
+module WFR = Walk_forward.Walk_forward_runner
+module WS = Walk_forward.Window_spec
+module Scenario = Scenario_lib.Scenario
+
+let _date y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+let _make_base ?(name = "base-test") ?(description = "base-desc")
+    ?(universe_path = "universes/parity-7sym.sexp") ?(config_overrides = [])
+    ?(slippage_bps = None) ?(strategy = Backtest.Strategy_choice.default) () :
+    Scenario.t =
+  let expected : Scenario.expected =
+    {
+      total_return_pct = { min_f = -100.0; max_f = 500.0 };
+      total_trades = { min_f = 0.0; max_f = 1000.0 };
+      win_rate = { min_f = 0.0; max_f = 100.0 };
+      sharpe_ratio = { min_f = -2.0; max_f = 3.0 };
+      max_drawdown_pct = { min_f = 0.0; max_f = 90.0 };
+      avg_holding_days = { min_f = 0.0; max_f = 500.0 };
+      open_positions_value = None;
+      unrealized_pnl = None;
+      sortino_ratio_annualized = None;
+      calmar_ratio = None;
+      ulcer_index = None;
+      wall_seconds = None;
+    }
+  in
+  {
+    name;
+    description;
+    period = { start_date = _date 2020 1 1; end_date = _date 2020 1 31 };
+    universe_path;
+    config_overrides;
+    strategy;
+    slippage_bps;
+    expected;
+  }
+
+let _make_fold ?(index = 0) ?(name = "fold-000") ?(train = None)
+    ?(test_start = _date 2021 1 1) ?(test_end = _date 2021 6 30) () : WS.fold =
+  {
+    index;
+    name;
+    train_period = train;
+    test_period = { start_date = test_start; end_date = test_end };
+  }
+
+(* ---------- build_fold_scenario ---------- *)
+
+let test_name_composes_base_variant_fold _ =
+  let base = _make_base ~name:"sp500" () in
+  let fold = _make_fold ~name:"fold-005" () in
+  let variant : WFR.variant = { label = "cell-E"; overrides = [] } in
+  let s = WFR.build_fold_scenario ~base ~fold ~variant in
+  assert_that s.name (equal_to "sp500-cell-E-fold-005")
+
+let test_period_is_test_period_of_fold _ =
+  let base = _make_base () in
+  let fold =
+    _make_fold ~test_start:(_date 2021 5 1) ~test_end:(_date 2021 8 31) ()
+  in
+  let variant : WFR.variant = { label = "v"; overrides = [] } in
+  let s = WFR.build_fold_scenario ~base ~fold ~variant in
+  assert_that s.period
+    (all_of
+       [
+         field
+           (fun (p : Scenario.period) -> p.start_date)
+           (equal_to (_date 2021 5 1));
+         field
+           (fun (p : Scenario.period) -> p.end_date)
+           (equal_to (_date 2021 8 31));
+       ])
+
+let test_overrides_appended_last _ =
+  let base_ov = Sexp.of_string "((initial_stop_buffer 1.05))" in
+  let variant_ov = Sexp.of_string "((initial_stop_buffer 1.20))" in
+  let base = _make_base ~config_overrides:[ base_ov ] () in
+  let fold = _make_fold () in
+  let variant : WFR.variant = { label = "v"; overrides = [ variant_ov ] } in
+  let s = WFR.build_fold_scenario ~base ~fold ~variant in
+  (* Variant override appended last; the [Backtest.Runner._apply_overrides]
+     contract is last-writer-wins, so 1.20 should be the effective value. *)
+  assert_that s.config_overrides
+    (elements_are [ equal_to base_ov; equal_to variant_ov ])
+
+let test_universe_and_strategy_preserved _ =
+  let base = _make_base ~universe_path:"universes/custom.sexp" () in
+  let fold = _make_fold () in
+  let variant : WFR.variant = { label = "v"; overrides = [] } in
+  let s = WFR.build_fold_scenario ~base ~fold ~variant in
+  assert_that s
+    (all_of
+       [
+         field
+           (fun (sc : Scenario.t) -> sc.universe_path)
+           (equal_to "universes/custom.sexp");
+         field
+           (fun (sc : Scenario.t) -> sc.strategy)
+           (equal_to Backtest.Strategy_choice.default);
+       ])
+
+let test_slippage_bps_preserved _ =
+  let base = _make_base ~slippage_bps:(Some 5) () in
+  let fold = _make_fold () in
+  let variant : WFR.variant = { label = "v"; overrides = [] } in
+  let s = WFR.build_fold_scenario ~base ~fold ~variant in
+  assert_that s.slippage_bps (is_some_and (equal_to 5))
+
+let test_description_marks_fold_and_variant _ =
+  let base = _make_base ~description:"orig desc" () in
+  let fold = _make_fold ~name:"fold-007" () in
+  let variant : WFR.variant = { label = "cellX"; overrides = [] } in
+  let s = WFR.build_fold_scenario ~base ~fold ~variant in
+  assert_that s.description
+    (all_of
+       [
+         (* Both labels present *)
+         field
+           (fun d -> String.is_substring d ~substring:"fold-007")
+           (equal_to true);
+         field
+           (fun d -> String.is_substring d ~substring:"cellX")
+           (equal_to true);
+         field
+           (fun d -> String.is_substring d ~substring:"orig desc")
+           (equal_to true);
+       ])
+
+(* ---------- build_all: cross product order ---------- *)
+
+let test_build_all_cross_product _ =
+  let base = _make_base ~name:"X" () in
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 6 30;
+      train_days = 0;
+      test_days = 30;
+      step_days = 60;
+    }
+  in
+  (* Folds at 01-01, 03-01, 05-01 (step=60) = 3 folds. Wait: 01-01 + 60 = 03-01,
+     +60 = 05-01. test 05-01..05-30 ends by 06-30. fold-3 anchor 06-30, test
+     ends past 06-30 → drop. So 3 folds. *)
+  let variants : WFR.variant list =
+    [ { label = "A"; overrides = [] }; { label = "B"; overrides = [] } ]
+  in
+  let scenarios = WFR.build_all ~base ~spec ~variants in
+  let names = List.map scenarios ~f:(fun (s : Scenario.t) -> s.name) in
+  assert_that names
+    (elements_are
+       [
+         equal_to "X-A-fold-000";
+         equal_to "X-A-fold-001";
+         equal_to "X-A-fold-002";
+         equal_to "X-B-fold-000";
+         equal_to "X-B-fold-001";
+         equal_to "X-B-fold-002";
+       ])
+
+let test_build_all_empty_variants_yields_empty _ =
+  let base = _make_base () in
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 6 30;
+      train_days = 0;
+      test_days = 30;
+      step_days = 30;
+    }
+  in
+  let scenarios = WFR.build_all ~base ~spec ~variants:[] in
+  assert_that scenarios (size_is 0)
+
+(* ---------- Variant sexp round-trip ---------- *)
+
+let test_variant_sexp_round_trip _ =
+  let ov = Sexp.of_string "((some_key 0.5))" in
+  let v : WFR.variant = { label = "cell-X"; overrides = [ ov ] } in
+  let parsed = WFR.variant_of_sexp (WFR.sexp_of_variant v) in
+  assert_that parsed
+    (all_of
+       [
+         field (fun (v : WFR.variant) -> v.label) (equal_to "cell-X");
+         field
+           (fun (v : WFR.variant) -> v.overrides)
+           (elements_are [ equal_to ov ]);
+       ])
+
+let suite =
+  "Walk_forward_runner"
+  >::: [
+         "name composes base/variant/fold"
+         >:: test_name_composes_base_variant_fold;
+         "period is fold's test_period" >:: test_period_is_test_period_of_fold;
+         "overrides appended last" >:: test_overrides_appended_last;
+         "universe + strategy preserved"
+         >:: test_universe_and_strategy_preserved;
+         "slippage_bps preserved" >:: test_slippage_bps_preserved;
+         "description marks fold + variant"
+         >:: test_description_marks_fold_and_variant;
+         "build_all cross product order" >:: test_build_all_cross_product;
+         "build_all empty variants yields empty"
+         >:: test_build_all_empty_variants_yields_empty;
+         "variant sexp round-trip" >:: test_variant_sexp_round_trip;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
@@ -1,0 +1,2 @@
+(* TODO: stub - to be filled in next commit *)
+let () = ()

--- a/trading/trading/backtest/walk_forward/test/test_window_spec.ml
+++ b/trading/trading/backtest/walk_forward/test/test_window_spec.ml
@@ -1,0 +1,308 @@
+(** Unit tests for {!Walk_forward.Window_spec}. Pure date-arithmetic checks — no
+    backtest invocation. *)
+
+open OUnit2
+open Core
+open Matchers
+module WS = Walk_forward.Window_spec
+module Scenario = Scenario_lib.Scenario
+
+let _date y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+(* ---------- Validation ---------- *)
+
+let test_negative_train_days_raises _ =
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 12 31;
+      train_days = -1;
+      test_days = 30;
+      step_days = 30;
+    }
+  in
+  assert_raises (Failure "WindowSpec.generate: train_days must be >= 0, got -1")
+    (fun () -> WS.generate spec)
+
+let test_zero_test_days_raises _ =
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 12 31;
+      train_days = 30;
+      test_days = 0;
+      step_days = 30;
+    }
+  in
+  assert_raises (Failure "WindowSpec.generate: test_days must be > 0, got 0")
+    (fun () -> WS.generate spec)
+
+let test_zero_step_days_raises _ =
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 12 31;
+      train_days = 30;
+      test_days = 30;
+      step_days = 0;
+    }
+  in
+  assert_raises (Failure "WindowSpec.generate: step_days must be > 0, got 0")
+    (fun () -> WS.generate spec)
+
+(* ---------- Empty-range cases ---------- *)
+
+let test_start_after_end_yields_empty _ =
+  let spec : WS.t =
+    {
+      start_date = _date 2020 12 31;
+      end_date = _date 2020 1 1;
+      train_days = 0;
+      test_days = 30;
+      step_days = 30;
+    }
+  in
+  assert_that (WS.generate spec) (size_is 0)
+
+let test_no_fold_fits_yields_empty _ =
+  (* Window is 60 days (0 + 60) but available range is 30 days. *)
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 1 30;
+      train_days = 0;
+      test_days = 60;
+      step_days = 60;
+    }
+  in
+  assert_that (WS.generate spec) (size_is 0)
+
+(* ---------- Train-period None when train_days = 0 ---------- *)
+
+let test_train_days_zero_yields_no_train_period _ =
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 6 30;
+      train_days = 0;
+      test_days = 30;
+      step_days = 30;
+    }
+  in
+  let folds = WS.generate spec in
+  assert_that folds
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (f : WS.fold) -> f.train_period) is_none;
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2020 1 1));
+             field
+               (fun (f : WS.fold) -> f.test_period.end_date)
+               (equal_to (_date 2020 1 30));
+           ];
+         all_of
+           [
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2020 1 31));
+             field
+               (fun (f : WS.fold) -> f.test_period.end_date)
+               (equal_to (_date 2020 2 29));
+           ];
+         all_of
+           [
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2020 3 1));
+             field
+               (fun (f : WS.fold) -> f.test_period.end_date)
+               (equal_to (_date 2020 3 30));
+           ];
+         all_of
+           [
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2020 3 31));
+             field
+               (fun (f : WS.fold) -> f.test_period.end_date)
+               (equal_to (_date 2020 4 29));
+           ];
+         all_of
+           [
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2020 4 30));
+             field
+               (fun (f : WS.fold) -> f.test_period.end_date)
+               (equal_to (_date 2020 5 29));
+           ];
+         all_of
+           [
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2020 5 30));
+             field
+               (fun (f : WS.fold) -> f.test_period.end_date)
+               (equal_to (_date 2020 6 28));
+           ];
+       ])
+
+(* ---------- Train + test back-to-back ---------- *)
+
+let test_train_followed_by_test _ =
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 12 31;
+      train_days = 60;
+      test_days = 30;
+      step_days = 90;
+    }
+  in
+  let folds = WS.generate spec in
+  (* First fold: train 01-01..03-01 (60d), test 03-01..03-30 (30d). *)
+  let first = List.hd_exn folds in
+  assert_that first
+    (all_of
+       [
+         field (fun (f : WS.fold) -> f.index) (equal_to 0);
+         field (fun (f : WS.fold) -> f.name) (equal_to "fold-000");
+         field
+           (fun (f : WS.fold) ->
+             match f.train_period with
+             | Some p -> p.start_date
+             | None -> _date 1900 1 1)
+           (equal_to (_date 2020 1 1));
+         field
+           (fun (f : WS.fold) ->
+             match f.train_period with
+             | Some p -> p.end_date
+             | None -> _date 1900 1 1)
+           (equal_to (_date 2020 2 29));
+         field
+           (fun (f : WS.fold) -> f.test_period.start_date)
+           (equal_to (_date 2020 3 1));
+         field
+           (fun (f : WS.fold) -> f.test_period.end_date)
+           (equal_to (_date 2020 3 30));
+       ])
+
+(* ---------- Step < test = overlapping rolling folds ---------- *)
+
+let test_overlapping_step_yields_overlapping_test_windows _ =
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 4 30;
+      train_days = 0;
+      test_days = 60;
+      step_days = 30;
+    }
+  in
+  let folds = WS.generate spec in
+  let test_starts =
+    List.map folds ~f:(fun (f : WS.fold) -> f.test_period.start_date)
+  in
+  let test_ends =
+    List.map folds ~f:(fun (f : WS.fold) -> f.test_period.end_date)
+  in
+  assert_that test_starts
+    (elements_are
+       [
+         equal_to (_date 2020 1 1);
+         equal_to (_date 2020 1 31);
+         equal_to (_date 2020 3 1);
+       ]);
+  assert_that test_ends
+    (elements_are
+       [
+         equal_to (_date 2020 2 29);
+         equal_to (_date 2020 3 30);
+         equal_to (_date 2020 4 29);
+       ])
+
+(* ---------- Drop folds extending past end_date ---------- *)
+
+let test_drops_folds_past_end_date _ =
+  (* start=01-01, end=01-31, test_days=30, step=15. Possible test windows:
+     [01-01..01-30] (ok), [01-16..02-14] (PAST end), drop. *)
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 1 31;
+      train_days = 0;
+      test_days = 30;
+      step_days = 15;
+    }
+  in
+  let folds = WS.generate spec in
+  assert_that folds (size_is 1)
+
+(* ---------- Index + name shape ---------- *)
+
+let test_fold_names_zero_padded _ =
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2020 4 30;
+      train_days = 0;
+      test_days = 30;
+      step_days = 30;
+    }
+  in
+  let folds = WS.generate spec in
+  let names = List.map folds ~f:(fun (f : WS.fold) -> f.name) in
+  assert_that names
+    (elements_are
+       [
+         equal_to "fold-000";
+         equal_to "fold-001";
+         equal_to "fold-002";
+         equal_to "fold-003";
+       ])
+
+(* ---------- Sexp round-trip ---------- *)
+
+let test_sexp_round_trip _ =
+  let spec : WS.t =
+    {
+      start_date = _date 2020 1 1;
+      end_date = _date 2024 12 31;
+      train_days = 365;
+      test_days = 182;
+      step_days = 91;
+    }
+  in
+  let parsed = WS.t_of_sexp (WS.sexp_of_t spec) in
+  assert_that parsed
+    (all_of
+       [
+         field (fun (s : WS.t) -> s.start_date) (equal_to spec.start_date);
+         field (fun (s : WS.t) -> s.end_date) (equal_to spec.end_date);
+         field (fun (s : WS.t) -> s.train_days) (equal_to spec.train_days);
+         field (fun (s : WS.t) -> s.test_days) (equal_to spec.test_days);
+         field (fun (s : WS.t) -> s.step_days) (equal_to spec.step_days);
+       ])
+
+let suite =
+  "Window_spec"
+  >::: [
+         "negative train_days raises" >:: test_negative_train_days_raises;
+         "zero test_days raises" >:: test_zero_test_days_raises;
+         "zero step_days raises" >:: test_zero_step_days_raises;
+         "start after end yields empty" >:: test_start_after_end_yields_empty;
+         "no fold fits yields empty" >:: test_no_fold_fits_yields_empty;
+         "train_days=0 yields no train_period"
+         >:: test_train_days_zero_yields_no_train_period;
+         "train followed by test back-to-back" >:: test_train_followed_by_test;
+         "overlapping step yields overlapping test windows"
+         >:: test_overlapping_step_yields_overlapping_test_windows;
+         "drops folds past end_date" >:: test_drops_folds_past_end_date;
+         "fold names zero-padded" >:: test_fold_names_zero_padded;
+         "sexp round-trip" >:: test_sexp_round_trip;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

First PR of the Phase 2 walk-forward CV track per `dev/notes/next-session-priorities-2026-05-15.md` and `dev/plans/walk-forward-cv-harness-2026-05-15.md`.

The existing `dev/experiments/cell-e-walk-forward-2026-05-08/` is 8 hand-curated scenarios. This PR ships the harness that scales it to ~30 rolling folds with a machine-checkable go/no-go gate ("variant wins on >=M of N folds, no fold worse than baseline by Delta") — the gate language that both M5.5 axis-2 (PR #1086) and the continuation-combined sweep (PR #1095) would have failed.

## What's in this PR

Four pure modules + one thin CLI + 43 tests, all under `trading/trading/backtest/walk_forward/`:

- **`Window_spec`** — pure date arithmetic generating rolling `fold` records (optional train period + required test period). Drops folds extending past `end_date`. 11 tests.
- **`Fold_gate`** — pure go/no-go evaluator encoding "variant wins >=M of N folds AND no fold worse than baseline by >Delta". `MaxDrawdownPct` inverts direction (lower is better). 13 tests covering validation errors, pass cases, M-threshold miss, Delta-threshold miss, baseline-tie, drawdown inversion, exact-boundary, sexp round-trip.
- **`Walk_forward_runner`** — pure scenario builder. Composes base scenario + Window_spec folds + variant overrides into the list of `Scenario.t` the harness runs. Variant overrides appended LAST so they win on conflicts (last-writer-wins, matching `Bayesian_runner_evaluator.build`). 9 tests.
- **`Walk_forward_report`** — pure markdown renderer. Emits 4 sections: per-fold metrics, stability (mean+-stdev per variant), cross-fold sensitivity (variant win-counts), go/no-go verdict per non-baseline variant. Deterministic — same inputs yield byte-identical markdown. 10 tests.
- **`walk_forward_runner.exe`** — thin CLI that reads a top-level sexp spec, invokes `Backtest.Runner.run_backtest` sequentially per (variant, fold), writes `fold_actuals.sexp` + `walk_forward_report.md` under `--out-dir`. Same per-suggestion shape as `Bayesian_runner_evaluator` so Phase 3 BO can swap variant overrides for BO suggestions without rebuilding the harness.

## Scope discipline

- Pure addition. Touches no existing surface (`Backtest.Runner`, `Scenario`, tuner libs all unmodified).
- 43 tests pass via `dune runtest trading/backtest/walk_forward`.
- Full repo `dune build && dune runtest` clean.
- Linters clean (`@fmt`, nesting, magic numbers, mli coverage, fn-length, cc).
- ~1200 LOC including tests + plan + status file.

## Test plan

- [x] `dune build && dune runtest trading/backtest/walk_forward` — 43/43 pass
- [x] `dune build && dune runtest` repo-wide passes (sliced run, all linters green)
- [x] `dune build @fmt` clean
- [x] `./walk_forward_runner.exe --help` smoke check works

## Out of scope (deferred)

- Actual ~30-fold sweep run — first production sweep is a local follow-up.
- Phase 3 Bayesian-optimizer integration — separate PRs; the harness exposes the interface a BO loop will consume.
- Parallel fold execution via fork-pool — sequential works for first sweeps; pattern from `Scenario_runner._run_scenarios_parallel` available when wall-time demands it.
- Multi-universe sweeps in a single spec.

## Plan + status

- Plan: `dev/plans/walk-forward-cv-harness-2026-05-15.md`
- Status: `dev/status/walk-forward-cv.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)