### PR TITLE
docs(data): Phase 1.1 sp500-1996 blocker — Wikipedia data insufficient pre-2010

### DIFF
--- a/dev/notes/phase1.1-1996-membership-blocker-2026-05-15.md
+++ b/dev/notes/phase1.1-1996-membership-blocker-2026-05-15.md
@@ -1,0 +1,166 @@
+Phase 1.1 — sp500-1996-01-01.sexp membership blocker (2026-05-15)
+==================================================================
+
+**Status:** BLOCKED on Norgate vendor signup.
+**Dispatched task:** Build `sp500-1996-01-01.sexp` membership data with
+per-symbol `active_through` columns by extending PR #1076's pattern back
+to 1996.
+**Verdict:** Not buildable from Wikipedia changes alone. The
+Wikipedia "Selected changes to the list of S&P 500 components" table
+documents ~25 events for the entire 1976–2006 window vs. ~360 events for
+2010–2026 alone — the pre-2007 data is editorial/selective, not a full
+historical log. Wait for Norgate signup before retrying.
+
+## 1. What the data shows
+
+Year-by-year event counts in the pinned 2026-05-03 Wikipedia HTML
+snapshot
+(`trading/analysis/data/sources/wiki_sp500/test/data/changes_table_2026-05-03.html`,
+3273 lines, ~395 events total per the existing module docstrings):
+
+| Year | Unique event dates | Total event rows |
+|------|---:|---:|
+| 1976 | 1  | 2 |
+| 1994 | 1  | 1 |
+| 1997 | 1  | 1 |
+| 1998 | 1  | 3 |
+| 1999 | 3  | 3 |
+| 2000 | 4  | 7 |
+| 2003 | 1  | 1 |
+| 2005 | 2  | 2 |
+| 2006 | 1  | 1 |
+| **1976–2006 total** | **15** | **21** |
+| 2007 | 11 | 11 |
+| 2008 | 6  | 8 |
+| 2009 | 8  | 13 |
+| **2007–2009 total** | **25** | **32** |
+| 2010 | 8  | 11 |
+| 2011 | 17 | 19 |
+| 2012 | 16 | 18 |
+| 2013 | 16 | 19 |
+| 2014 | 14 | 16 |
+| 2015 | 22 | 29 |
+| 2016 | 26 | 30 |
+| 2017 | 18 | 28 |
+| 2018 | 18 | 23 |
+| 2019 | 19 | 24 |
+| 2020 | 13 | 20 |
+| 2021 | 13 | 20 |
+| 2022 | 15 | 21 |
+| 2023 | 12 | 17 |
+| 2024 | 11 | 19 |
+| 2025 | 14 | 21 |
+| 2026 | 3  | 6  |
+| **2010–2026 total** | **255** | **361** |
+
+Counted via:
+
+```bash
+grep -oE '(January|...|December)[[:space:]]+[0-9]{1,2},?[[:space:]]+[0-9]{4}' \
+  trading/analysis/data/sources/wiki_sp500/test/data/changes_table_2026-05-03.html \
+  | grep -oE '[0-9]{4}$' | sort | uniq -c
+```
+
+## 2. Why this means the 1996 universe is not reconstructible
+
+Replay direction is reverse-time (newest-first), via
+`Membership_replay.replay_back` per
+`trading/analysis/data/sources/wiki_sp500/lib/membership_replay.mli` line
+51. Starting from 2026-05-03's 503 constituents, we'd need to undo every
+change event with `effective_date > 1996-01-01` to land on the
+1996-01-01 universe.
+
+The S&P 500 turns over **~25 names per year** during normal periods (and
+more during regime breaks like 2000–2002 and 2008–2009). Over the 30
+years from 1996-01-01 → 2026-05-03 that is ~750 expected events. The
+pinned table contains 376 events post-1996, of which **354 are
+2010-or-later** and only **22 cover 1996–2009**.
+
+The shortfall:
+- Required: ~750 events for full 1996 → 2026 replay.
+- Available: 376 events.
+- Missing: ~370 events — and the gap is concentrated in 1996–2009
+  exactly where we need them.
+
+The `replay_back` function silently no-ops un-doable drops (per
+`membership_replay.mli` line 75 — *"if event.added.symbol is not present
+in the current working set when its event fires, the drop is silently
+skipped"*) so we wouldn't get a hard error: we'd get a "1996" universe
+that is actually closer to 2007's constituent set plus 22 random
+adjustments. That's invalid data, not a blocker.
+
+## 3. What would be reproducible from Wikipedia alone
+
+Reasonable cutoffs given the pinned data:
+
+| As-of date | Reconstruction confidence | Notes |
+|---|---|---|
+| 2010-01-01 | High (already pinned: `universes/sp500-historical/sp500-2010-01-01.sexp`, 510 syms) | The current production universe. |
+| 2007-01-01 | Medium — limited by 2007 being the first "dense" Wikipedia year. ~50 missed events from late 2007 alone (the 11 dated rows likely under-count). | Useful for a 19y window 2007 → 2026 if needed. |
+| 2000-01-01 | Low — 4 unique dates and 7 events cover all of 2000. Industry mid-cycle saw ~30 changes/year. | Universe would mostly equal the 2007 reconstruction +/- 7 ad-hoc adjustments. |
+| 1996-01-01 | **None.** No viable reconstruction. Need vendor source. | Reject. |
+
+## 4. What Norgate would buy us
+
+Per `dev/status/data-foundations.md` §"Track 1 — Norgate Data
+ingestion":
+
+- US 1990-present per-day point-in-time SP500 / Russell 1000 / Russell
+  2000 membership snapshots.
+- Delisted symbols included with per-symbol delisting date — this is
+  exactly the `active_through` field PR #1076 added to
+  `Types.Daily_price.t`.
+- Licensed redistribution-restricted (cache under `dev/data/norgate/`,
+  gitignored).
+
+Effort estimate from
+`dev/notes/historical-universe-status-2026-05-13.md` §4:
+
+- Norgate ingest itself: M effort (`analysis/data/sources/norgate/`
+  client + index_membership module + fetch_universe CLI). User-confirmed
+  budget OK ($32–66/mo). Vendor signup pending.
+
+Total cost to reach 1996 universe once Norgate access is live:
+
+1. `analysis/data/sources/norgate/` library + CLI — M (200–400 LOC, 1
+   PR).
+2. `build_universe.exe --as-of 1996-01-01` over Norgate substrate — S
+   (~100 LOC adapter, 1 PR).
+3. `sp500-1996-01-01.sexp` golden — XS (data + perf-tier header).
+4. Per-symbol bar history 1990–2026 via EODHD with Norgate-sourced
+   `active_through` — M+ (existing infra, but ~750 net-new historical
+   delisted-symbol fetches; need to verify quota and EODHD
+   ticker-resolution against Norgate symbols).
+
+Estimated 3–5 stacked PRs after vendor signup completes.
+
+## 5. Recommended next action
+
+Per `memory/project_phase1_1996_membership_norgate.md` and the next
+priorities doc, three options:
+
+| Option | Verdict |
+|---|---|
+| (a) Wait for Norgate signup, then build sp500-1996-01-01 properly. | **Recommended for honest 1996 data.** Single-source-of-truth from a licensed vendor; carries `active_through` natively. |
+| (b) Narrow scope: build sp500-2007-01-01.sexp as the "broader baseline" instead. | **Useful interim.** 19y window (2007→2026) covers the 2008 GFC + post-GFC + 2020 COVID regimes; still gives the survivorship-aware re-baseline the strategic-pivot doc wants. Wikipedia data density at 2007-01-01 is borderline (~32 documented changes 2007–2009 vs. ~75 expected; might be 50% complete) — qualitatively closer to "honest" than 1996 but not vendor-grade. |
+| (c) Pivot to Phase 1.2 (`broad-3000-2010-01-01.sexp` cohort). | **Higher-ROI next step per the memory caveat.** Builds entirely on Wikipedia + EODHD data we have; expands universe breadth (current 510 syms → ~3000); 2010-2026 window is the period for which our membership data is dense and trustworthy. Does not need Norgate. |
+
+The user should pick one before re-dispatching feat-data.
+
+## 6. Files inspected (none modified)
+
+- `dev/notes/next-session-priorities-2026-05-15.md` (Phase 1 §1)
+- `dev/notes/historical-universe-status-2026-05-13.md` (sparse pre-2007
+  caveat)
+- `dev/status/data-foundations.md` (Norgate block confirmed)
+- `memory/project_phase1_1996_membership_norgate.md` (caveat verbatim)
+- `trading/analysis/data/sources/wiki_sp500/lib/changes_parser.{ml,mli}`
+- `trading/analysis/data/sources/wiki_sp500/lib/membership_replay.{ml,mli}`
+- `trading/analysis/data/sources/wiki_sp500/bin/build_universe.ml`
+- `trading/analysis/data/sources/wiki_sp500/test/data/changes_table_2026-05-03.html`
+- `trading/test_data/backtest_scenarios/universes/sp500-historical/sp500-2010-01-01.sexp`
+- `trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp`
+- Git history of PR #1076 (`3a776411`) confirming the `active_through`
+  pattern.
+
+No code was changed. No data was invented.

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -5,6 +5,13 @@
 ## Status
 IN_PROGRESS
 
+## Blocking Refactors
+- Phase 1.1 (`sp500-1996-01-01.sexp`) confirmed blocked on Norgate
+  vendor signup — see
+  `dev/notes/phase1.1-1996-membership-blocker-2026-05-15.md`.
+  Pivot recommendation: Phase 1.2 (`broad-3000-2010-01-01.sexp`)
+  is unblocked and higher-ROI on existing substrate.
+
 ## Notes
 
 **2026-05-15 strategic pivot — track elevated to P0.** Per
@@ -19,8 +26,18 @@ Phase 1 work below:
 1. **`sp500-1996-01-01.sexp` membership data** — mirror PR #1076's
    per-symbol `active_through` columns back to 1996, sourced from
    the Wikipedia changelog infra in PR #813 (`Changes_parser`).
+   **BLOCKED on Norgate vendor signup (2026-05-15).** Wikipedia
+   changes table covers only ~22 events for 1996–2009 vs. the
+   ~750 expected; full diagnosis in
+   `dev/notes/phase1.1-1996-membership-blocker-2026-05-15.md`.
+   Three resolution options offered in that doc: (a) wait on
+   Norgate, (b) narrow to sp500-2007-01-01, (c) pivot to Phase 1.2
+   (broad-3000-2010-01-01).
 2. **`broad-3000-2010-01-01.sexp` cohort** — expand beyond SP500 to
    the full Russell 3000 with PI-aware `active_through` data.
+   Per the Phase 1.1 blocker findings, this is the recommended
+   higher-ROI next step while Norgate signup is pending —
+   reproducible entirely from existing Wikipedia + EODHD substrate.
 3. **Survivorship-correct re-pin of `goldens-sp500-historical/sp500-2010-2026.sexp`** —
    replace current pinned baseline (measured on survivorship-biased
    data per #1076's hypothesis) with one where PI filter is ON by


### PR DESCRIPTION
## Summary

Phase 1.1 from `dev/notes/next-session-priorities-2026-05-15.md` ("build `sp500-1996-01-01.sexp` membership data with per-symbol `active_through` columns, mirror PR #1076's pattern back to 1996") is **not reproducible from Wikipedia changes alone**. This PR documents the blocker rather than inventing data — exactly the outcome the dispatch prompt called out as the acceptable alternative.

## Finding

Per-year event counts in the pinned 2026-05-03 Wikipedia "Selected changes to the list of S&P 500 components" HTML snapshot:

| Window | Unique event dates | Total event rows |
|---|---:|---:|
| 1976–2006 | 15 | 21 |
| 2007–2009 | 25 | 32 |
| 2010–2026 | 255 | 361 |

Expected SP500 turnover is ~25 names/year. To replay current → 1996-01-01 we need to undo ~750 change events; Wikipedia gives us 376, of which 354 are 2010-or-later. The pre-2007 data is editorial/selective, not a full historical log.

`Membership_replay.replay_back` silently no-ops un-doable drops, so we wouldn't get a hard error — we'd silently produce a "1996" universe that is in fact ~2007's constituents plus 22 ad-hoc adjustments. That's invalid data, not a blocker, and worse than admitting the gap.

## What this PR contains

- **`dev/notes/phase1.1-1996-membership-blocker-2026-05-15.md`** — full diagnosis (per-year counts, reproducible-cutoff table, Norgate cost estimate, three resolution options).
- **`dev/status/data-foundations.md`** — Phase 1.1 task annotated BLOCKED; Phase 1.2 (broad-3000-2010-01-01) flagged as the recommended pivot; new "Blocking Refactors" section records the dependency.

No code changed. No data invented.

## Recommended resolution options (per the findings doc §5)

1. **(a) Wait for Norgate vendor signup** — single-source-of-truth point-in-time SP500 membership 1990-present with native `active_through`. User-confirmed budget OK ($32–66/mo); signup pending.
2. **(b) Narrow scope to `sp500-2007-01-01.sexp`** — 19y window covering GFC + post-GFC + COVID. Borderline Wikipedia density (32 events 2007–2009 vs. ~75 expected) — better than 1996 but not vendor-grade.
3. **(c) Pivot to Phase 1.2 `broad-3000-2010-01-01.sexp`** — recommended. Builds entirely on existing Wikipedia + EODHD substrate; expands universe breadth from 510 → ~3000; uses the period where membership data is dense and trustworthy. Does not need Norgate.

## Test plan

- [ ] Doc-only PR — no build/test impact. Verify the per-year counts can be reproduced from the pinned HTML via the `grep` one-liner in §1 of the findings doc.
- [ ] User picks one of options (a/b/c) before re-dispatching `feat-data`.