### PR TITLE
test(universe): tighten broad-3000 cardinality pin to 3000

### DIFF
--- a/trading/trading/backtest/scenarios/test/test_universe_file.ml
+++ b/trading/trading/backtest/scenarios/test/test_universe_file.ml
@@ -163,8 +163,7 @@ let test_broad_3000_2010_universe_parses _ =
         (when_pinned
            (all_of
               [
-                field List.length
-                  (is_between (module Int_ord) ~low:2500 ~high:3500);
+                field List.length (equal_to 3000);
                 field _distinct_sector_count (ge (module Int_ord) 8);
                 field _is_alpha_sorted (equal_to true);
                 field _all_sectors_non_empty (equal_to true);


### PR DESCRIPTION
## Summary

Follow-up to qc-behavioral R1 on PR #1103: tighten the cardinality assertion in `test_broad_3000_2010_universe_parses` from the wide range `is_between 2500..3500` to `equal_to 3000`.

The committed fixture has exactly 3000 symbols, and `_default_target_size = 3000` is hardcoded in `pick_broad_3000.ml`. The previous range would silently allow ~17% drift without failing — pinning the exact value catches accidental drift in the picker or the fixture.

Source: `dev/reviews/broad-3000-2010-universe.md` §"Non-blocking recommendations" R1.

## Test plan

- [x] `dune build @fmt` — passes
- [x] `dune build` — passes
- [x] `dune runtest trading/backtest/scenarios/test/` — all 4 universe tests pass

Single-line test change.