### PR TITLE
docs: Option B pivot 2026-05-16 — IWV scrape as primary, EODHD Fundamentals retired

### DIFF
--- a/dev/decisions.md
+++ b/dev/decisions.md
@@ -43,6 +43,55 @@ _(None yet — system just initialized.)_
 
 ## Direction Changes
 
+### 2026-05-16 — Option B pivot — IWV scrape as primary, EODHD Fundamentals retired
+
+Follow-on to the 2026-05-16 morning vendor pivot, after the two
+verification dispatches landed.
+
+Phase 1.1 (EODHD Fundamentals `HistoricalTickerComponents` on
+`GSPC.INDX`) FAILED at verification per PR #1106. The 10-URL probe
+returned HTTP 403 across every variant of the Fundamentals endpoint
+— including bulk and historical-market-cap with an explicit
+`Forbidden. You have no access to Historical Market Cap Data Feed.`
+denial message. Our subscription is the EOD-only tier; the Fundamentals
+add-on costs $59.99/mo standalone or €99.99/mo bundled (All-In-One).
+
+Phase 1.4 (DIY iShares IWV holdings scrape, Russell 3000 2006-present)
+PASSED verification per PR #1108. 31 probes (3 primary + 28 boundary)
+returned HTTP 200 across the full 2006-09-29 → 2026-05-08 range with
+byte-identical line-10 headers. Sentinel for unavailable dates is an
+HTTP 200 + 4585-byte template body with `Fund Holdings as of,"-"` on
+line 2 (parse content, not status code). Cadence is asymmetric:
+quarterly through 2008-12, monthly through 2012-04, daily thereafter.
+~3550 total snapshots, ~1.5 GB raw, ~3 hr backfill at 2s polite
+spacing.
+
+Decision: **Option B — IWV scrape becomes the PRIMARY survivorship-
+correct source for the data-foundations track.** No EODHD tier
+upgrade is being purchased. Phase 1.1 is parked indefinitely
+(reviving it would require a tier upgrade and a re-verification of
+the schema, which EODHD's public docs hedge between two shapes —
+`HistoricalTickerComponents` per-row tenure vs `Components` /
+`HistoricalComponents` per-date snapshots). Phase 1.4 implementation
+is the load-bearing item; plan-first dispatch to `feat-data` against
+`analysis/data/sources/ishares/` is the next action.
+
+Russell 3000 strictly contains every SP500 name, so we don't lose
+SP500 coverage — we gain 2500 additional symbols (mid + small cap)
+for free, in exchange for a 4y horizon reduction (2006 vs 2000) that
+the strategic posture in `memory/project_strategic_pivot_broader_first.md`
+already prefers (broader-first beats deeper-history at this stage).
+
+Full ranked vendor matrix:
+`dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
+Verification transcripts:
+`dev/notes/phase1.1-eodhd-verification-2026-05-16.md` (FAIL) +
+`dev/notes/phase1.4-iwv-url-probe-2026-05-16.md` (PASS).
+Track state: `dev/status/data-foundations.md` (Phase 1.4 IN_PROGRESS
+as primary; Phase 1.1 PARKED; Phase 1.5 fja05680 tail deferred).
+Successor priorities doc:
+`dev/notes/next-session-priorities-2026-05-16.md`.
+
 ### 2026-05-16 — Vendor pivot — Norgate retired
 
 Norgate Data is removed from the data-foundations roadmap. Their NDU

--- a/dev/notes/next-session-priorities-2026-05-16.md
+++ b/dev/notes/next-session-priorities-2026-05-16.md
@@ -1,52 +1,66 @@
-# Next-session priorities (2026-05-16) — vendor pivot
+# Next-session priorities (2026-05-16) — Option B pivot
 
-Supersedes `dev/notes/next-session-priorities-2026-05-15.md`. Carries
-forward all P0/P1/P2/P3 items; the only material change is Phase 1
-sourcing.
+Supersedes `dev/notes/next-session-priorities-2026-05-15.md`. Revised
+2026-05-16 evening after the Phase 1.1 (EODHD Fundamentals) and Phase
+1.4 (IWV scrape) verifications landed. Carries forward all P0/P1/P2/P3
+items; the only material change is **Phase 1 sourcing**.
 
 ## TL;DR
 
-**Vendor pivot — Norgate retired.** Norgate's NDU client is
-Windows-only; incompatible with our Mac/Linux Docker toolchain.
-Replacements:
+**Phase 1.1 FAILED at verification (PR #1106).** Our EODHD subscription
+is the EOD-only tier; the Fundamentals endpoint returns HTTP 403
+across every variant probed. Tier upgrade rejected per the Option B
+decision.
 
-- **SP500 PI 2000-present:** EODHD Fundamentals API
-  (`GSPC.INDX?historical=1`, same client we already use).
-- **Russell 3000 2006-present:** DIY iShares IWV scrape (pure HTTP,
-  no vendor signup).
-- **SP500 1996-1999 (optional):** `fja05680/sp500` static seed.
+**Phase 1.4 PASSED verification (PR #1108).** iShares IWV URL pattern
+works HTTP 200 across the full 2006-09-29 → 2026-05-08 range with
+byte-identical line-10 headers. Pure HTTP, no auth, free.
 
-Full reasoning in
-`dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
+**Result — Option B pivot.** Russell 3000 via DIY IWV scrape is now
+the **primary** survivorship-correct universe source. SP500 PI 2000-
+present via EODHD Fundamentals is parked indefinitely. SP500 1996-1999
+tail (fja05680) remains deferred. Strategy can now pin a 20y × 3000-
+name baseline that strictly contains every SP500 member.
 
 Strategic posture from 2026-05-15 unchanged: broader-first beats
-more-knobs. P2 walk-forward CV (PR #1100 landed) and P3 Bayesian
-optimizer continue on the existing 510-sym 2010-2026 universe while
-Phase 1 lands.
+more-knobs. P2 walk-forward CV (PR #1100 / #1107 landed) and P3
+Bayesian optimizer continue on the existing 510-sym 2010-2026
+universe in parallel.
 
-## Phase 1 ordering (updated 2026-05-16)
+Full reasoning + ranked vendor table in
+`dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
+
+## Phase 1 ordering (revised 2026-05-16 evening)
 
 | # | Item | Source | Status |
 |---|---|---|---|
-| 1.1 | SP500 PI membership 2000-present | EODHD Fundamentals `HistoricalTickerComponents` | Pending 4-item EODHD-tier verification (`dev/status/data-foundations.md` §"Blocking Refactors") |
+| 1.1 | SP500 PI membership 2000-present | EODHD Fundamentals `HistoricalTickerComponents` | **FAILED at verification (PR #1106)** — subscription tier does not include Fundamentals; tier upgrade rejected per Option B. Parked. |
 | 1.2 | `broad-3000-2010-01-01.sexp` cohort (sectors.csv proxy) | EODHD + sectors.csv | **MERGED 2026-05-15** (PR #1103); forward-looking-biased; superseded by 1.4 |
-| 1.3 | Survivorship-correct re-pin of `sp500-2010-2026.sexp` baseline | derived from 1.1 + PR #1076 active_through | Pending 1.1 |
-| 1.4 | Russell 3000 true historical reconstitution | DIY iShares IWV scrape 2006-present | Pending plan-first; independent of 1.1 |
+| 1.3 | Survivorship-correct re-pin of `sp500-2010-2026.sexp` baseline | derived from 1.1 + PR #1076 active_through | **DEFERRED** until 1.4 lands (no longer downstream of 1.1) |
+| 1.4 | Russell 3000 true historical reconstitution | DIY iShares IWV scrape 2006-present | **IN_PROGRESS (PRIMARY PATH)** — URL pattern verified (PR #1108); next step is plan-first dispatch to `feat-data` |
 | 1.5 | SP500 1996-1999 tail (optional) | `fja05680/sp500` static seed | Deferred per broader-first pivot |
 
-Recommended dispatch order:
+Recommended dispatch order (revised):
 
-1. **1.1 verification** — zero-code; hit EODHD dashboard + spot-check
-   5 events (LEH 2008, KODK 2009, FB 2013, TSLA 2020, GE 2018). Once
-   green, dispatch feat-data.
-2. **1.4 IWV scrape** in parallel with 1.1 — spot-curl the URL
-   pattern recent + 2010-01-04, then plan-first.
-3. **1.3 re-pin** after 1.1 lands.
+1. **1.4 PR 1 (client)** — plan landed as PR #1109
+   (`dev/plans/iwv-scraper-2026-05-16.md`, 4-PR stack). Dispatch
+   `feat-data` against the first PR: `ishares_holdings_client.{ml,mli}`
+   (cohttp HTTPS GET + CSV decode + pinned fixture). Authority for
+   the URL pattern / sentinel / header stability:
+   `dev/notes/phase1.4-iwv-url-probe-2026-05-16.md`.
+2. **1.4 PR 2-4** — `ishares_membership_replay` →
+   `fetch_iwv_history` CLI → `build_iwv_universe` CLI, per the plan.
+   Each PR aims for 400-500 LOC. Backfill ~3 hr at 2s polite spacing.
+3. **1.3 re-pin** — once 1.4 lands, re-pin the 2010-2026 baseline
+   on the IWV-derived Russell 3000 cohort (now wider than SP500,
+   so the baseline numbers will differ; this needs fresh
+   sign-off, not a like-for-like comparison).
 
 ## P2 / P3 / P1 — unchanged from 2026-05-15
 
-- **P2 walk-forward CV** — owner `feat-backtest`; PR #1100 landed
-  first PR; continue scaling to ~30 rolling folds.
+- **P2 walk-forward CV** — owner `feat-backtest`; PR #1100 landed the
+  first PR; PR #1107 landed the 30-fold rolling extension. Continue
+  scaling.
 - **P3 Bayesian optimizer** — owner `feat-backtest`; scale
   `bayesian_runner.exe` to full Cell E knob set with MaxDD-penalized
   loss on walk-forward CV.
@@ -66,18 +80,20 @@ F variants all explicitly deferred. See
 
 The only credible >30y step-up for non-institutional pricing is
 **Sharadar via Nasdaq Data Link** ($150–$300/mo personal; SP500
-changes since 1957). Deferred until 1.1 proves out at 30y.
+changes since 1957). Deferred until 1.4 proves out at 20y.
 Institutional vendors (CRSP/WRDS, Refinitiv, Bloomberg) not viable.
 See vendor-comparison doc §Option 4.
 
-## Carry-forward in-flight from 2026-05-15
+## Carry-forward in-flight
 
-- PR #1095 / #1097 / #1098 / #1100 / #1101 / #1103 — all MERGED.
-- PR #1101 (Phase 1.1 Norgate blocker note) superseded 2026-05-16
+- PR #1095 / #1097 / #1098 / #1100 / #1103 / #1105 / #1106 / #1107 /
+  #1108 / #1109 — all MERGED.
+- PR #1101 (Phase 1.1 Norgate blocker note) — superseded 2026-05-16
   by the vendor pivot; original analysis preserved at the bottom of
   `dev/notes/phase1.1-1996-membership-blocker-2026-05-15.md`.
 
-## What the user said (2026-05-16)
+## What the user said (2026-05-16, evening)
 
-"Norgate is OUT (Windows-only); EODHD + IWV scrape + fja05680 are
-IN." Phase 1.1 re-scoped; Phase 1.4 added.
+"Option B — IWV scrape is the primary path. No Fundamentals tier
+upgrade. Park Phase 1.1; promote Phase 1.4." Phase 1.1 retired;
+Phase 1.4 promoted to primary; Phase 1.3 deferred until 1.4 lands.

--- a/dev/notes/phase1.1-eodhd-verification-2026-05-16.md
+++ b/dev/notes/phase1.1-eodhd-verification-2026-05-16.md
@@ -209,3 +209,24 @@ the 100k/day cap.
   `memory/project_jj_workspace_docker_path.md` (not `/tmp/` which is
   invisible to docker — though docker wasn't needed for any probe;
   all curl ran on the host).
+
+## 2026-05-16 follow-up — Option B chosen; no tier upgrade pursued
+
+Per `dev/decisions.md` 2026-05-16 §"Option B pivot — IWV scrape as
+primary, EODHD Fundamentals retired", the recommendation from the
+verification doc's §"Option B — drop Phase 1.1; Phase 1.4 (IWV
+scrape) becomes the primary survivorship-correct source" was
+selected. No Fundamentals tier upgrade was purchased; the Unicorn
+Bay marketplace add-on was likewise rejected.
+
+Phase 1.4 verification (PR #1108) returned green the same day —
+iShares IWV URL pattern works HTTP 200 across the full 2006-09-29 →
+2026-05-08 range with byte-identical headers. Full transcript in
+`dev/notes/phase1.4-iwv-url-probe-2026-05-16.md`.
+
+Phase 1.1 is now PARKED indefinitely. If the strategy ever needs
+the 2000-2005 SP500 tail that IWV cannot cover, the cheapest revival
+path is still the standalone Fundamentals Data Feed tier ($59.99/mo),
+not the marketplace Unicorn Bay add-on (12y coverage doesn't reach
+back further than IWV does). At that point this doc's
+§"Schema caveat" must be re-verified before any parser work.

--- a/dev/notes/vendor-comparison-historical-universe-2026-05-16.md
+++ b/dev/notes/vendor-comparison-historical-universe-2026-05-16.md
@@ -1,0 +1,309 @@
+# Vendor comparison — historical universe (2026-05-16, Option B pivot)
+
+Survivorship-correct point-in-time membership for a US equity
+historical universe spanning 2006 → present (minimum) or 1996 →
+present (stretch). Originally authored 2026-05-16 as part of the
+Norgate retirement (vendor-pivot PR #1105); regenerated 2026-05-16
+after the Phase 1.1 EODHD-Fundamentals verification (PR #1106) came
+back FAIL and the Phase 1.4 IWV URL probe (PR #1108) came back
+green.
+
+## TL;DR
+
+- **#1 — iShares IWV holdings scrape (NEW PRIMARY).** Pure HTTP, no
+  auth, no vendor signup. Confirmed working 2006-09-29 → 2026-05-08
+  via PR #1108 probes. Russell 3000 universe (~3000 names) is
+  strictly broader than SP500 (every SP500 name is in IWV). Zero
+  marginal cost.
+- **#2 — `fja05680/sp500` static seed.** MIT-licensed GitHub repo
+  shipping `sp500_ticker_start_end.csv` covering 1996 → present. Use
+  only for the 1996–2005 SP500 tail (iShares IWV pre-dates 2006-09).
+  Author flags first ~5 years as best-effort; deferred per the
+  broader-first pivot in `memory/project_strategic_pivot_broader_first.md`.
+- **#3 — EODHD Fundamentals API.** RETIRED for our use case after the
+  2026-05-16 verification — our current EODHD subscription is the
+  EOD-only tier; the Fundamentals endpoint returns HTTP 403 across
+  every variant probed. Tier upgrade ($59.99/mo Fundamentals Data Feed
+  or €99.99/mo All-In-One) was rejected per the Option B pivot.
+- **#4 — Sharadar via Nasdaq Data Link.** Deferred. The only credible
+  >30y step-up for non-institutional pricing; revisit once Phase 1.4
+  proves out at 20y.
+- **#5 — Norgate.** Retired 2026-05-16 (Windows-only NDU client;
+  incompatible with our Mac/Linux Docker toolchain).
+
+Strategic posture (`memory/project_strategic_pivot_broader_first.md`):
+broader-first beats more-knobs. The next round of strategy tuning
+needs a wider, longer, survivorship-correct universe more than it
+needs deeper history on the existing 510-symbol baseline. Russell
+3000 from 2006 is enough to clear that bar.
+
+## Decision
+
+**Option B — IWV scrape as PRIMARY source.** Phase 1.4 in
+`dev/status/data-foundations.md` becomes the load-bearing item.
+Phase 1.1 (EODHD Fundamentals) is FAILED at verification and parked
+indefinitely. Phase 1.5 (fja05680 1996-1999 tail) remains deferred.
+
+## Per-option detail
+
+### Option 1 — iShares IWV holdings scrape (PRIMARY)
+
+| Field | Value |
+|---|---|
+| Vendor | BlackRock / iShares (public website; no key) |
+| Coverage start | 2006-09-29 (probed; PR #1108) |
+| Coverage end | Current trading day |
+| Cadence (early) | Quarterly 2006-09 → 2008-12 |
+| Cadence (mid) | Monthly 2009-01 → 2012-04 |
+| Cadence (late) | Daily 2012-04-30 → present |
+| Universe | Russell 3000 (≈3000 large + mid + small caps) |
+| SP500 coverage | Yes — every SP500 name is also in Russell 3000 |
+| Delisted symbols | Yes (by inference — symbol present on date `D`, absent on `D+1` ⇒ exited universe; tenure reconstructed via diffing consecutive snapshots) |
+| Cost | $0 |
+| Auth | None (no API key, no cookies) |
+| Rate limit | Unpublished; PR #1108 used 2s polite spacing across 31 probes without throttling |
+| URL template | `https://www.ishares.com/us/products/239714/ishares-russell-3000-etf/1467271812596.ajax?fileType=csv&fileName=IWV_holdings&dataType=fund&asOfDate=YYYYMMDD` |
+| Sentinel for unavailable dates | HTTP 200 + 4585-byte template body with `Fund Holdings as of,"-"` on line 2 (must parse content, not status code) |
+| Header stability | Line 10 header byte-identical 2006-12-29 → 2026-05-08 (28 boundary tests pinned in PR #1108) |
+| File size | ~430 KB/snapshot; ~3550 total snapshots; ~1.5 GB raw uncompressed |
+| Backfill wall time | ~3 hr at 2s polite spacing |
+| ToS / licensing | iShares website is public; fund holdings are required US-SEC disclosures. Cache CSVs locally; do not redistribute. Mark manifest `source=ishares-iwv-public` |
+| Native client | OCaml `cohttp` HTTPS GET + repo's existing `analysis/data/storage/csv` decoder — no Python dependency |
+| Pre-existing reference impl | `talsan/ishares` (Python; we read it as a reference doc only) |
+
+**Sibling ETFs (same URL pattern, different product ID):**
+
+| ETF | Universe | Product ID | Notes |
+|---|---|---|---|
+| IWV | Russell 3000 | 239714 / 1467271812596 | This option |
+| IWB | Russell 1000 (large + mid) | 239707 | Subset of IWV; redundant if scraping IWV |
+| IWM | Russell 2000 (small cap) | 239710 | Subset of IWV; redundant if scraping IWV |
+
+Would-this-work assessment: yes, this is the recommended path. The
+2006-09-29 coverage start is acceptable — 20y is in the
+broader-first sweet spot, and the gap to our existing 2010 baseline
+is a 4y prepend, not a redesign.
+
+### Option 2 — `fja05680/sp500` static seed (1996–1999 tail; DEFERRED)
+
+| Field | Value |
+|---|---|
+| Vendor | GitHub `fja05680/sp500` (hobbyist) |
+| License | MIT |
+| Coverage start | 1996-01-02 (best-effort; author flags first ~5 years as incomplete) |
+| Coverage end | Author-maintained; pinned commit recommended |
+| Universe | SP500 only |
+| Schema | `sp500_ticker_start_end.csv` — `ticker,start_date,end_date` |
+| Delisted symbols | Yes (carried in csv) |
+| Cost | $0 |
+| Auth | None |
+| Native client | OCaml + `analysis/data/storage/csv` |
+| ToS / licensing | MIT — pin a commit, vendor under `analysis/data/sources/fja05680/data/` |
+| Manifest tag | `source=fja05680-best-effort` (per author's reliability caveat) |
+
+Would-this-work assessment: usable only for the 1996–2005 SP500 tail
+that IWV cannot cover. Deferred 2026-05-16 per the broader-first
+pivot — better to spend the implementation budget on a broader
+2006+ universe than on a deeper SP500-only seed with reliability
+caveats.
+
+### Option 3 — EODHD Fundamentals API (RETIRED for our use case)
+
+| Field | Value |
+|---|---|
+| Vendor | EOD Historical Data |
+| Coverage start (claimed) | Jan 2000 (`HistoricalTickerComponents` on `GSPC.INDX`) |
+| Coverage start (per vendor docs) | "1960s, though the most complete data starts from 2016" — EODHD marketing copy |
+| Universe | Indices: SP500, Dow Jones, FTSE, NASDAQ100, etc. via `<INDEX>.INDX` |
+| Delisted symbols | Per-row `IsDelisted: true` flag claimed; schema not verified |
+| Cost | $59.99/mo Fundamentals Data Feed standalone; €99.99/mo All-In-One (Fundamentals + EOD + Live + Options) |
+| Our subscription | EOD-only tier — does NOT include Fundamentals |
+| Probed result (2026-05-16) | HTTP 403 across all 10 URL variants, including bulk + historical-market-cap with explicit denial messages (PR #1106) |
+| Native client | Yes — reuses existing `analysis/data/sources/eodhd/lib/eodhd_client` |
+| Schema caveat | Public docs describe `Components` + `HistoricalComponents` (snapshot-based) rather than per-row `StartDate`/`EndDate` tenure intervals — schema may differ from what `data-foundations.md` Track 1 originally assumed |
+
+**Marketplace alternative — Unicorn Bay product** (rejected separately):
+
+| Field | Value |
+|---|---|
+| Product | "S&P and Dow Jones: Indices Historical Constituents Data API" |
+| URL | `eodhd.com/marketplace/unicornbay/spgloical` |
+| Cost | $29.99/mo regular; $50 for first 3 months promo |
+| Coverage | "up to 12 years" = 2014-present — does not cover our 2010 baseline |
+| Schema | Not published on marketplace page; would need sales-team trial |
+
+Would-this-work assessment: no, retired 2026-05-16. Both the
+mainline Fundamentals tier ($60/mo) and the marketplace add-on
+($30/mo) lose to the free IWV scrape on cost, coverage, and
+provenance certainty. The EOD tier we already pay for stays in use
+for price bars; only the Fundamentals add-on is rejected.
+
+### Option 4 — Sharadar via Nasdaq Data Link (>30y; DEFERRED)
+
+| Field | Value |
+|---|---|
+| Vendor | Quandl/Sharadar via Nasdaq Data Link (`SHARADAR/SP500`) |
+| Coverage start | 1957 for SP500 changes; equity prices from 1998 |
+| Universe | SP500 + delisted; Sharadar's broader US equity table for prices |
+| Delisted symbols | Yes (load-bearing for the product) |
+| Cost | $150–$300/mo personal tier (varies by package) |
+| Auth | API key |
+| Native client | New — would need `analysis/data/sources/sharadar/` |
+| Reliability | Commercial, institutionally-used |
+
+Would-this-work assessment: the only credible non-institutional
+>30y step-up. Defer until Phase 1.4 IWV scrape proves out at 20y
+and the strategy demonstrates it needs deeper history (per
+`memory/project_m5-5-tuning-exhausted.md` and the broader-first
+pivot, 20y on a 3000-name universe is far from tapped out).
+
+### Option 5 — Norgate Data (RETIRED)
+
+| Field | Value |
+|---|---|
+| Vendor | Norgate |
+| Coverage start | 1990 SP500 + R1k + R2k PI membership; institutional-grade |
+| Cost | ≈$30/mo personal |
+| Auth | NDU desktop application |
+| Native client | **Windows-only** — would require running Windows in Docker or a separate VM |
+| Verdict | Retired 2026-05-16 (Decisions log entry). Adds an OS to our supported stack for one ingest path; not justifiable when IWV scrape covers 20y for $0 |
+
+### Option 6 — FMP (Financial Modeling Prep)
+
+| Field | Value |
+|---|---|
+| Vendor | FMP |
+| Coverage | SP500 historical constituents from ~2014 |
+| Cost | Free tier 250 req/day; paid tiers from $14/mo |
+| Auth | API key |
+| Native client | New — would need an `analysis/data/sources/fmp/` |
+
+Would-this-work assessment: no. Coverage starts post-2014; we
+already have 2010-present locally. Adds a vendor surface without
+extending horizon.
+
+### Option 7 — Polygon.io
+
+| Field | Value |
+|---|---|
+| Vendor | Polygon |
+| Coverage | Equities back to 2003; SP500 constituents via the `/reference/tickers` snapshots since ~2017 |
+| Cost | Free tier 5 req/min, no historical; paid from $29/mo |
+| Auth | API key |
+| Native client | New |
+
+Would-this-work assessment: no — best for intraday / tick data, not
+historical PI membership. Membership history is shallow (post-2017
+only).
+
+### Option 8 — Tiingo
+
+| Field | Value |
+|---|---|
+| Vendor | Tiingo |
+| Coverage | EOD from 1962 for some symbols; no published PI membership endpoint |
+| Cost | $30/mo paid tier |
+| Auth | API key |
+
+Would-this-work assessment: no — Tiingo is a price-bar vendor, not
+an index-membership vendor. Skip.
+
+### Option 9 — SPDR SPY direct scrape (DIY, SP500 only)
+
+| Field | Value |
+|---|---|
+| Vendor | State Street SPY ETF holdings page |
+| Coverage | SP500 only |
+| Cost | $0 |
+| Auth | None |
+| Schema | XLSX export rather than CSV; different parser to write |
+
+Would-this-work assessment: redundant with IWV (every SPY name is in
+IWV). The XLSX-only export and the SP500-only scope make it strictly
+worse than IWV for our needs. Skip.
+
+### Option 10 — CRSP / WRDS
+
+| Field | Value |
+|---|---|
+| Vendor | CRSP via Wharton WRDS |
+| Coverage | 1925 → present, NYSE-grade institutional data |
+| Cost | $5,000+/yr institutional access only |
+| Auth | WRDS account (university or institutional sponsorship) |
+
+Would-this-work assessment: no — institutional access only. The
+100y NYSE data is the load-bearing reason CRSP exists; we are not
+buying it for this project. Listed for completeness only.
+
+## Ranked recommendation (post-2026-05-16 verification)
+
+1. **iShares IWV scrape** — primary; 2006-present Russell 3000 free.
+   Phase 1.4 in `dev/status/data-foundations.md`.
+2. **fja05680/sp500 static seed** — optional 1996–2005 SP500 tail.
+   Phase 1.5 (deferred).
+3. **Sharadar / Nasdaq Data Link** — Phase 1.6 (deferred) if/when
+   IWV's 20y horizon is exhausted.
+
+EODHD Fundamentals (Phase 1.1) is FAILED and NOT being pursued.
+Norgate (formerly Phase 1.1 / pre-pivot Phase 1.2) is RETIRED.
+
+## 2026-05-16 verification appendix
+
+### PR #1106 — EODHD Fundamentals tier: FAIL
+
+- 10 URL variants probed; all returned HTTP 403.
+- `/api/user` returned `subscriptionType:"monthly"` (a paid plan, EOD
+  tier).
+- `/api/historical-market-cap/AAPL.US` returned the explicit
+  `Forbidden. You have no access to Historical Market Cap Data Feed.`
+  message, confirming the 403 is scope-not-auth.
+- The originally-planned 5-event spot-check (LEH/KODK/FB/TSLA/GE)
+  could not be executed.
+- Full transcript: `dev/notes/phase1.1-eodhd-verification-2026-05-16.md`.
+
+### PR #1108 — IWV URL pattern: PASS
+
+- 31 total probes (3 primary + 28 boundary).
+- HTTP 200 across full 2006-09-29 → 2026-05-08 range.
+- Line 10 header byte-identical across the entire date range.
+- Sentinel for unavailable dates is `Fund Holdings as of,"-"` on line
+  2 of an HTTP 200 response — must parse content, not status code.
+- Coverage cadence: quarterly (2006-09 → 2008-12) → monthly (2009 →
+  2012-04) → daily (2012-04-30+).
+- Full transcript: `dev/notes/phase1.4-iwv-url-probe-2026-05-16.md`.
+
+## Cross-cutting notes
+
+- **No Python.** All clients live in OCaml + `cohttp` + the repo's
+  existing CSV / sexp infra. Reference Python repos (`talsan/ishares`,
+  `fja05680/sp500`) are read for their URL patterns and CSV schemas
+  only — never executed.
+- **Caching layout.** All vendor-derived raw files go under
+  `dev/data/<vendor>/...` (gitignored, per
+  `.claude/rules/no-python.md` and the data-foundations agent's
+  scope). Small pinned fixtures for tests go under
+  `analysis/data/sources/<vendor>/test/data/`.
+- **Manifest provenance.** Every emitted universe sexp must carry a
+  `source=<vendor>-<descriptor>` header line so downstream backtests
+  can audit which source / cadence / coverage window underlies a
+  given run (per `dev/plans/data-inventory-and-reproducibility-2026-05-02.md`).
+- **Survivorship handling.** IWV diff-based tenure inference is the
+  same algorithm Phase 1.1's EODHD parser would have used had the
+  schema turned out to be the snapshot-based `Components` /
+  `HistoricalComponents` shape (per the schema caveat in
+  `dev/notes/phase1.1-eodhd-verification-2026-05-16.md`). The
+  algorithm is vendor-agnostic; only the snapshot source changes.
+
+## Sources
+
+- EODHD pricing page (read 2026-05-16) — Fundamentals tier gating.
+- EODHD `/api/user` + `/api/fundamentals/*` 2026-05-16 probes (PR
+  #1106).
+- iShares IWV holdings ajax endpoint, probed 2026-05-16 (PR #1108).
+- `fja05680/sp500` GitHub repo (MIT, sp500_ticker_start_end.csv).
+- Norgate Data product pages — Windows-only NDU client confirmation.
+- Sharadar / Nasdaq Data Link product pages — coverage + pricing.
+- `memory/project_strategic_pivot_broader_first.md` — strategic
+  posture rationale.
+- `memory/project_m5-5-tuning-exhausted.md` — tuning-surface
+  exhaustion context.

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -6,33 +6,41 @@
 IN_PROGRESS
 
 ## Blocking Refactors
-- **2026-05-16 vendor pivot — Norgate retired.** Norgate's NDU client
-  is Windows-only and incompatible with our Mac/Linux Docker toolchain.
-  Phase 1.1 re-scoped to EODHD Fundamentals (`HistoricalTickerComponents`
-  on `GSPC.INDX`) for SP500 2000-present, with optional `fja05680/sp500`
-  static seed for the 1996–1999 tail. Russell 3000 history moves to a
-  new Phase 1.4 via DIY iShares IWV scrape (2006-present). Full
-  reasoning in `dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
+- **2026-05-16 Option B pivot — IWV scrape becomes the primary
+  survivorship-correct source.** Phase 1.1 (EODHD Fundamentals
+  `HistoricalTickerComponents` on `GSPC.INDX`) FAILED verification per
+  PR #1106 — our EODHD subscription is the EOD-only tier; the
+  Fundamentals endpoint returns HTTP 403 across every variant probed
+  (including bulk + historical-market-cap with explicit denial
+  messages). Tier upgrade ($59.99/mo Fundamentals Data Feed or
+  €99.99/mo All-In-One) rejected per the Option B decision.
+  Phase 1.4 (DIY iShares IWV scrape, 2006-present) was promoted to
+  primary path: URL pattern verified working HTTP 200 across the full
+  2006-09-29 → 2026-05-08 range with byte-identical line-10 headers
+  per PR #1108. Phase 1.1 is parked indefinitely. Full reasoning in
+  `dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
 
-  Phase 1.1 verification checklist (do before starting implementation):
-  - [ ] Confirm our current EODHD plan tier includes Fundamentals
-    (free EOD-only plan does *not* — needs Fundamentals Data Feed at
-    $59.99/mo or All-In-One at €99.99/mo). Check EODHD account
-    dashboard.
-  - [ ] Spot-check 5 known SP500 events (e.g. LEH 2008-09-15 delisting,
-    KODK 2009-12 removal, FB 2013-12-23 addition, TSLA 2020-12-21
-    addition, GE 2018-06-26 removal) — `StartDate`/`EndDate` match
-    S&P official press releases.
+  Phase 1.1 verification checklist — outcome:
+  - [x] Confirm current EODHD plan tier includes Fundamentals —
+    **FAIL** (EOD-only tier; HTTP 403 across 10 URL variants per PR
+    #1106).
+  - [ ] Spot-check 5 known SP500 events (LEH 2008-09-15 / KODK 2009-12
+    / FB 2013-12-23 / TSLA 2020-12-21 / GE 2018-06-26) —
+    **NOT_RUN** (blocked on tier 403).
   - [ ] Confirm `IsDelisted` symbols include OHLCV history in our
-    existing EODHD price subscription (or whether delisted prices
-    require a separate add-on).
+    existing EODHD price subscription — **NOT_RUN** (blocked on tier
+    403).
   - [ ] Verify the JSON path: `HistoricalTickerComponents` vs
-    `Components` — schema may have changed since the EODHD blog post.
+    `Components` — **NOT_RUN** (blocked on tier 403; vendor public
+    docs hedge between the two shapes per
+    `dev/notes/phase1.1-eodhd-verification-2026-05-16.md` §"Schema
+    caveat").
 
 - Historical record: Phase 1.1 had previously been BLOCKED on Norgate
   signup (`dev/notes/phase1.1-1996-membership-blocker-2026-05-15.md` —
-  Wikipedia-only path insufficient pre-2010). Superseded by the
-  2026-05-16 vendor pivot above.
+  Wikipedia-only path insufficient pre-2010); re-scoped 2026-05-16
+  morning to EODHD Fundamentals, then FAILED-and-parked 2026-05-16
+  evening per the Option B pivot above.
 
 ## Notes
 
@@ -46,15 +54,15 @@ exposes; the limiting factor is what the optimizer is looking at. New
 Phase 1 work below:
 
 1. **SP500 PI membership via EODHD Fundamentals (2000-present) +
-   optional fja05680 tail (1996-1999)** — re-scoped 2026-05-16 from
-   the Norgate-blocked path. Source: `/api/fundamentals/GSPC.INDX?historical=1`
-   exposes `HistoricalTickerComponents` with `StartDate`/`EndDate`/
-   `IsDelisted` per ticker from Jan 2000. Pre-flight verification
-   gate (4 items) listed under §"Blocking Refactors" above — confirm
-   before starting implementation. The 1996-1999 patch is optional;
-   `fja05680/sp500` (MIT, free) ships
-   `sp500_ticker_start_end.csv` for the gap. Authority:
-   `dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
+   optional fja05680 tail (1996-1999)** — **PARKED 2026-05-16**
+   after verification FAILED (PR #1106; subscription tier does not
+   include Fundamentals, tier upgrade rejected per Option B). Source
+   was `/api/fundamentals/GSPC.INDX?historical=1` exposing
+   `HistoricalTickerComponents`. Phase 1.4 (IWV scrape) is now the
+   primary path and strictly contains SP500 in its Russell 3000
+   universe. Authority:
+   `dev/notes/vendor-comparison-historical-universe-2026-05-16.md` +
+   `dev/notes/phase1.1-eodhd-verification-2026-05-16.md`.
 2. **[x] `broad-3000-2010-01-01.sexp` cohort** — DONE 2026-05-15
    (PR #1103). 3000-symbol Pinned-shape universe sourced
    alphabetically from `data/sectors.csv` via new
@@ -73,21 +81,30 @@ Phase 1 work below:
    data per #1076's hypothesis) with one where PI filter is ON by
    default.
 4. **Russell 3000 true historical reconstitution via DIY iShares IWV
-   scrape** — PENDING (added 2026-05-16). Pure HTTP GET against
+   scrape** — **IN_PROGRESS, PRIMARY PATH** (added 2026-05-16; URL
+   pattern verified 2026-05-16 per PR #1108). Pure HTTP GET against
    `https://www.ishares.com/us/products/239714/ishares-russell-3000-etf/1467271812596.ajax?fileType=csv&fileName=IWV_holdings&dataType=fund&asOfDate=YYYYMMDD`;
    no auth; CSV per `asOfDate`; tenure inferred by diffing
-   consecutive daily snapshots (entry = first appearance, exit =
-   first disappearance). 2006-present coverage. Implementation in
-   OCaml `cohttp` — no Python dependency; `talsan/ishares` is a
-   reference doc only, not a runtime dep. ~5,000 trading days ×
-   2,500 syms/day = ~12.5M rows compressed. Replaces the sectors.csv
-   proxy used by PR #1103. Authority:
+   consecutive snapshots (entry = first appearance, exit = first
+   disappearance). Coverage 2006-09-29 → present (cadence:
+   quarterly through 2008-12, monthly through 2012-04, daily
+   thereafter). Sentinel for unavailable dates is HTTP 200 + 4585-
+   byte template with `Fund Holdings as of,"-"` on line 2 — must
+   parse line 2, not status code. Implementation in OCaml `cohttp` —
+   no Python dependency; `talsan/ishares` is a reference doc only,
+   not a runtime dep. ~3,550 snapshots × ~430 KB ≈ 1.5 GB raw
+   uncompressed; ~3 hr backfill at 2s polite spacing. Replaces the
+   sectors.csv proxy used by PR #1103 and replaces the parked
+   Phase 1.1. Next step: plan-first dispatch to `feat-data`.
+   Authority:
    `dev/notes/vendor-comparison-historical-universe-2026-05-16.md`
-   §Option 7.
+   §Option 1 + `dev/notes/phase1.4-iwv-url-probe-2026-05-16.md`.
 
 Owner: feat-data. Status flipped READY_FOR_REVIEW → IN_PROGRESS on
-the strategic pivot (2026-05-15) and re-confirmed IN_PROGRESS on the
-2026-05-16 vendor pivot.
+the strategic pivot (2026-05-15), re-confirmed IN_PROGRESS on the
+2026-05-16 vendor pivot, and re-confirmed IN_PROGRESS again on the
+2026-05-16 Option B pivot — Phase 1.4 (IWV scrape) is now the
+load-bearing item.
 
 **Prior notes retained below.**
 
@@ -97,12 +114,13 @@ M5.3 streaming Phases A + A.1 + B + C + D + E + F.1 all merged (#779/#786/#781/#
 
 **15y memory-cliff fixes MERGED 2026-05-08** — three parallel fixes from `dev/notes/15y-memory-cliff-2026-05-08.md`: Fix A (#992 dedupe `Daily_panels` LRU caches), Fix B (#993 skinny `step_result.portfolio` projection), Fix C (#988 stream `csv_snapshot_builder` per-symbol); root-cause investigation (#987); split-day-adjustment investigation (#998). Combined with simulator-side #1024 (Closed-positions prune) the 15y wall dropped 5h → 13.6 min (~22×).
 
-**2026-05-16 vendor pivot:** Norgate retired (Windows-only). New
-Phase 1 surface = EODHD Fundamentals (SP500 2000-present) + DIY
-iShares IWV scrape (Russell 3000 2006-present) + optional fja05680
-static seed (SP500 1996-1999). Owner authorized: feat-data per
-`dev/decisions.md` 2026-05-03 §"Agent scope" and 2026-05-16 §"Vendor
-pivot — Norgate retired".
+**2026-05-16 Option B pivot:** Norgate retired (Windows-only); EODHD
+Fundamentals path FAILED at verification (PR #1106) and parked. New
+Phase 1 surface = DIY iShares IWV scrape (Russell 3000 2006-present)
+as primary, with optional fja05680 static seed (SP500 1996-1999)
+deferred. Owner authorized: feat-data per `dev/decisions.md`
+2026-05-03 §"Agent scope" and 2026-05-16 §"Option B pivot — IWV
+scrape as primary, EODHD Fundamentals retired".
 
 Track created 2026-05-02 to absorb M5.3 (scale infra: streaming + Norgate) + M7.0 (data foundations: Norgate, multi-market, synthetic). Plans: `dev/plans/m5-experiments-roadmap-2026-05-02.md` + `dev/plans/m7-data-and-tuning-2026-05-02.md`. Authority: `docs/design/weinstein-trading-system-v2.md` §7 sub-milestones M5.3 + M7.0 (added 2026-05-02).
 
@@ -110,47 +128,53 @@ Track created 2026-05-02 to absorb M5.3 (scale infra: streaming + Norgate) + M7.
 NO
 
 ## Blocked on
-- **Phase 1.1 (SP500 PI via EODHD Fundamentals)** is unblocked
-  pending the 4-item EODHD-tier verification checklist under
-  §"Blocking Refactors". Once that gate passes, implementation is
-  feat-data work on existing infrastructure (same EODHD client
-  pattern we already use). No vendor signup needed.
+- **Nothing blocking.** Phase 1.4 (DIY iShares IWV scrape) is the
+  primary path and needs no vendor signup, no subscription, no
+  Python — it's straight OCaml `cohttp` work against a verified
+  public endpoint (PR #1108). Next step is a plan-first dispatch to
+  `feat-data` against `analysis/data/sources/ishares/`.
+- Phase 1.1 (EODHD Fundamentals) is parked — would need a tier
+  upgrade ($60/mo) to revive; not pursued per Option B.
 - Norgate ingest retired 2026-05-16 (Windows-only client; see
   vendor-comparison doc). Synth ladder rungs (v1, v2, v3) all
   shipped; EODHD multi-market shipped (#772).
 
 ## Scope
 
-### Track 1 — Historical universe ingestion (RETIRED Norgate, 2026-05-16)
+### Track 1 — Historical universe ingestion (Option B pivot, 2026-05-16)
 
-**Vendor pivot 2026-05-16:** Norgate retired (Windows-only NDU
-client). Replaced by a two-source approach. Full vendor comparison
-in `dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
+**Option B pivot 2026-05-16:** Phase 1.1 (EODHD Fundamentals)
+FAILED verification (PR #1106) — our subscription is EOD-only,
+Fundamentals returns HTTP 403. Tier upgrade rejected. Phase 1.4
+(DIY iShares IWV scrape, 2006-present) is now the **primary
+survivorship-correct source** — URL pattern verified working per
+PR #1108. Russell 3000 strictly contains every SP500 name. Full
+vendor comparison in
+`dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
 
-**SP500 (2000-present): EODHD Fundamentals API**
+**SP500 (2000-present) via EODHD Fundamentals: PARKED**
 
 | Item | Value |
 |---|---|
-| Vendor | EODHD — already paid; Fundamentals Data Feed tier required ($59.99/mo or All-In-One €99.99/mo) |
-| Coverage | SP500 from Jan 2000; `HistoricalTickerComponents` returns `Code`/`Name`/`StartDate`/`EndDate`/`IsActiveNow`/`IsDelisted` per ticker |
-| Why | Same vendor / client / Docker stack we already use. Linux/Mac native. 25 of 30y horizon at zero marginal infra cost. |
-| Endpoint | `GET /api/fundamentals/GSPC.INDX?api_token=...&historical=1&from=YYYY-MM-DD&to=YYYY-MM-DD` |
-| Storage | Same EODHD cache layout we use today (gitignored under `dev/data/eodhd/`) |
+| Vendor | EODHD Fundamentals Data Feed tier ($59.99/mo standalone) |
+| Status | **PARKED 2026-05-16** — current EODHD subscription does NOT include Fundamentals; tier upgrade rejected per Option B |
+| Reference | `dev/notes/phase1.1-eodhd-verification-2026-05-16.md` |
 
-Likely new paths (subject to plan-first pass):
-- `analysis/data/sources/eodhd/lib/index_membership.{ml,mli}` — parser for `HistoricalTickerComponents`
-- `analysis/data/sources/eodhd/bin/build_sp500_universe.ml` — CLI emitting `sp500-<as-of>.sexp`
-- `analysis/data/sources/eodhd/test/test_index_membership.ml` — fixtures from spot-check events
-
-**Russell 3000 (2006-present): DIY iShares IWV scrape (Phase 1.4)**
+**Russell 3000 (2006-present) via DIY iShares IWV scrape: PRIMARY PATH (Phase 1.4)**
 
 | Item | Value |
 |---|---|
 | Source | iShares.com per-date holdings CSV (no auth, no key) |
-| Coverage | Russell 3000 from 2006; daily snapshots; tenure inferred by diffing consecutive snapshots |
+| Coverage | 2006-09-29 → present (verified PR #1108); cadence quarterly through 2008-12, monthly through 2012-04, daily thereafter |
+| Universe | Russell 3000 (~3000 names; strictly contains every SP500 name) |
+| Tenure | Inferred by diffing consecutive snapshots (entry = first appearance, exit = first disappearance) |
 | URL pattern | `https://www.ishares.com/us/products/239714/ishares-russell-3000-etf/1467271812596.ajax?fileType=csv&fileName=IWV_holdings&dataType=fund&asOfDate=YYYYMMDD` |
+| Header stability | Line 10 header byte-identical 2006-12-29 → 2026-05-08 (verified PR #1108) |
+| Sentinel | Unavailable date returns HTTP 200 + 4585-byte template with `Fund Holdings as of,"-"` on line 2 — parse content, not status code |
 | Sibling ETFs | IWB (Russell 1000) and IWM (Russell 2000) follow the same URL pattern with different product IDs |
-| Storage | `dev/data/ishares/iwv/<YYYYMMDD>.csv` (gitignored — vendor terms TBD) |
+| Storage | `dev/data/ishares/iwv/<YYYYMMDD>.csv` (gitignored — public website, cache locally, do not redistribute) |
+| Volume | ~3,550 snapshots × ~430 KB ≈ 1.5 GB raw uncompressed |
+| Backfill | ~3 hr at 2s polite spacing |
 
 Likely new paths (subject to plan-first pass):
 - `analysis/data/sources/ishares/lib/iwv_client.{ml,mli}` — `cohttp` GET + CSV decode (no Python)
@@ -337,13 +361,23 @@ fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
 
 ### Pending
 
-- **Phase 1.1 — SP500 PI via EODHD Fundamentals** (active; pending
-  4-item EODHD-tier verification checklist — see §"Blocking Refactors").
-- **Phase 1.4 — Russell 3000 via IWV scrape** (added 2026-05-16; no
-  vendor signup; Linux/Mac OCaml native).
-- **fja05680 SP500 1996-1999 static seed** (optional tail).
-- **Phase 5 — screener point-in-time filter** (next natural step;
-  ~250–400 LOC per design note §4).
+- **Phase 1.4 — Russell 3000 via IWV scrape (PRIMARY PATH)** — URL
+  pattern verified PR #1108; plan landed PR #1109
+  (`dev/plans/iwv-scraper-2026-05-16.md`, 4-PR stack). Next step is
+  dispatching `feat-data` against PR 1 of the stack
+  (`ishares_holdings_client`). No vendor signup; Linux/Mac OCaml
+  native; zero marginal cost.
+- **Phase 1.3 — Survivorship-correct re-pin** — deferred until 1.4
+  lands (no longer downstream of the parked 1.1).
+- **Phase 1.5 — fja05680 SP500 1996-1999 static seed** — deferred
+  per the broader-first pivot.
+- **Phase 5 — screener point-in-time filter** — independent of
+  Phase 1 source; can run in parallel (~250-400 LOC per design
+  note §4).
+
+- **Phase 1.1 — PARKED** (SP500 PI via EODHD Fundamentals; failed
+  verification PR #1106). Not actively scheduled; would require a
+  tier upgrade to revive.
 
 ### Detail (kept for reference; all entries below are MERGED on main)
 
@@ -421,23 +455,30 @@ EODHD multi-market expansion MERGED (#772). M5.3 Phase F retirement
 COMPLETE. 15y memory-cliff fixes MERGED (#988/#992/#993 + #1024).
 broad-3000-2010-01-01 cohort MERGED (#1103, sectors.csv proxy).
 
-**2026-05-16 vendor pivot:** Phase 1 work is now sourced from EODHD
-Fundamentals + DIY iShares IWV scrape + optional fja05680 static
-seed. Norgate retired. See
+**2026-05-16 Option B pivot:** Phase 1 work is sourced from DIY
+iShares IWV scrape (primary, 2006-present Russell 3000) with
+fja05680 1996-1999 SP500 tail deferred. EODHD Fundamentals
+parked after verification FAIL (PR #1106). Norgate retired. See
 `dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
 
-1. **Phase 1.1 verification** — confirm EODHD Fundamentals tier
-   subscription + spot-check 5 SP500 events + confirm delisted OHLCV
-   coverage + verify JSON schema path (see §"Blocking Refactors"
-   checklist). Once green, dispatch feat-data on the EODHD
-   `index_membership` library + SP500 universe builder.
-2. **Phase 1.4 — Russell 3000 via IWV scrape** — independent of
-   Phase 1.1. Can run in parallel; no vendor signup needed. First
-   step: spot-curl the URL pattern against a recent date + an older
-   date (e.g. 2010-01-04) to confirm both work in 2026, then plan-first.
+1. **Phase 1.4 implementation** — plan landed PR #1109
+   (`dev/plans/iwv-scraper-2026-05-16.md`); 4-PR stack under
+   `analysis/data/sources/ishares/`
+   (`ishares_holdings_client.{ml,mli}` →
+   `ishares_membership_replay.{ml,mli}` → `fetch_iwv_history.ml` CLI
+   → `build_iwv_universe.ml` CLI). Mirrors the `wiki_sp500` layout
+   (PRs #803/#808/#809/#813). Dispatch `feat-data` against PR 1 of
+   the stack. Authority for URL pattern / sentinel / header
+   stability: `dev/notes/phase1.4-iwv-url-probe-2026-05-16.md`.
+2. **Phase 1.3 re-pin** — once 1.4 lands, re-pin the
+   `goldens-sp500-historical/sp500-2010-2026.sexp` baseline on the
+   IWV-derived cohort. The new cohort is wider than SP500 (Russell
+   3000) so the baseline numbers will differ; this needs fresh
+   sign-off, not a like-for-like comparison against the current
+   510-symbol baseline.
 3. **Phase 5 — screener point-in-time filter** — `membership_at`
-   callback in `Screener.screen`. Highest-leverage gain once Phase 1.1
-   lands.
+   callback in `Screener.screen`. Independent of which Phase 1
+   source feeds it. Can run in parallel with 1.4.
 4. Optional follow-ups (non-blocking):
    - Strategy-side smoke test on a Synth-v3 universe (Sharpe/MaxDD) —
      belongs in `feat-backtest`, not feat-data.
@@ -454,9 +495,9 @@ seed. Norgate retired. See
   scale matters.
 - **Sharadar via Nasdaq Data Link**: $150–$300/mo personal tier;
   SP500 changes since 1957. The only credible >30y step-up for
-  non-institutional pricing. Deferred until 30y horizon (post Phase
-  1.1) proves out. See vendor-comparison-historical-universe doc
-  §Option 4.
+  non-institutional pricing. Deferred until 20y horizon (post Phase
+  1.4 IWV scrape) proves out. See vendor-comparison-historical-universe
+  doc §Option 4.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary

Consolidates the 2026-05-16 overnight findings into the data-foundations track and addresses three loose ends:

1. **Recreates `dev/notes/vendor-comparison-historical-universe-2026-05-16.md`** — referenced from PR #1105 / #1106 / decisions but never actually committed. Full ranked vendor matrix (IWV scrape #1, fja05680 #2, EODHD Fundamentals retired, Sharadar deferred, Norgate retired, plus FMP / Polygon / Tiingo / SPY / CRSP for completeness).
2. **Flips Phase 1.1 to FAILED-and-PARKED** across `dev/status/data-foundations.md` and `dev/notes/next-session-priorities-2026-05-16.md` per PR #1106's verification result. EODHD subscription is EOD-only; Fundamentals returns HTTP 403; tier upgrade rejected per Option B.
3. **Promotes Phase 1.4 (IWV scrape) to PRIMARY PATH** with PR #1108's verified URL-pattern findings (2006-09-29 → 2026-05-08 HTTP 200, byte-identical line-10 headers, `Fund Holdings as of,"-"` sentinel) baked into the Track 1 table. Aligns the Next Steps text with PR #1109's 4-PR plan stack.
4. **Adds a 2026-05-16 Decisions log entry** ("Option B pivot — IWV scrape as primary, EODHD Fundamentals retired") above the morning's Norgate-retired entry.
5. **Appends a follow-up appendix** to `dev/notes/phase1.1-eodhd-verification-2026-05-16.md` recording that Option B was selected and no tier upgrade was pursued.

Doc-only — zero source code touched.

## Files

- `dev/notes/vendor-comparison-historical-universe-2026-05-16.md` — NEW (309 lines). Per-option detail for 10 vendor candidates with 2026-05-16 verification appendix linking to PR #1106 (FAIL) and PR #1108 (PASS).
- `dev/notes/next-session-priorities-2026-05-16.md` — revised TL;DR, Phase 1.1 → FAILED row, Phase 1.4 → IN_PROGRESS PRIMARY PATH row, dispatch order rewritten to reference PR #1109's plan.
- `dev/status/data-foundations.md` — Blocking Refactors / Notes / Blocked-on / Track 1 table / In Progress / Next Steps / Sharadar defer all updated. `## Status: IN_PROGRESS`, `## Interface stable: NO` (linter passes).
- `dev/decisions.md` — new 2026-05-16 Option B entry above the morning's Norgate-retired entry.
- `dev/notes/phase1.1-eodhd-verification-2026-05-16.md` — follow-up appendix at the bottom.

## Test plan

- [x] Doc-only — no OCaml touched
- [x] `dune runtest devtools/checks/` passes (status linter green, no_python_check green, magic_numbers green)
- [x] Diff is exactly the 5 expected files; no stray contamination
- [x] Cross-references verified: PR #1105 / #1106 / #1108 / #1109 all confirmed MERGED via `gh pr view`
- [x] `## Interface stable: NO` matches the new state (Phase 1.4 implementation pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)