### PR TITLE
feat(walk-forward): Explicit fold spec + structured aggregate (Phase 2.2 PR-A)

### DIFF
--- a/dev/status/walk-forward-cv.md
+++ b/dev/status/walk-forward-cv.md
@@ -1,6 +1,6 @@
 # Status: walk-forward-cv
 
-## Last updated: 2026-05-15
+## Last updated: 2026-05-16
 
 ## Status
 READY_FOR_REVIEW
@@ -56,11 +56,38 @@ dune exec trading/backtest/walk_forward/bin/walk_forward_runner.exe -- --help
 
 ## In Progress
 
-None for this PR. The harness is complete in its first-PR scope.
+### Second PR — Phase 2.2 PR-A: Explicit folds + structured aggregate (in flight)
+
+Per `dev/plans/walk-forward-cv-rolling-30fold-2026-05-16.md`. This is the
+first of the plan's two-PR split (PR-A = steps 1-2; PR-B = steps 3-5,
+defer).
+
+- [x] `Window_spec.t` promoted to variant `Rolling of rolling_spec | Explicit of explicit_fold list`. Backwards-compatible `t_of_sexp` accepts the legacy flat-record shape and silently promotes to `Rolling`. 6 new tests covering Explicit pass-through, empty/duplicate rejection, train_period preservation, sexp round-trip for both variants, and legacy-flat fallback.
+- [x] `Walk_forward_report.compute` returns a structured `aggregate` record (fold_count, baseline_label, metric_label, per-variant stability, per-variant sensitivity, per-variant verdicts). Programmatic surface for Phase 3 Bayesian optimizer to score candidates without parsing markdown. Existing `render` now delegates to `compute` then to a new `Walk_forward_render.to_markdown` helper module — markdown output preserved byte-identically. 5 new tests covering per-variant stability (mean/stdev/min/max), sensitivity exclusion of baseline, Pass verdict shape, baseline-label validation, and aggregate sexp round-trip.
+- [x] Type surface extracted to `Walk_forward_types` module so `Walk_forward_render` (the markdown emitter) can depend on the types without cycling back through `Walk_forward_report.compute`. `Walk_forward_report.mli` re-exports via `include module type of Walk_forward_types`.
+
+### Verify (PR-A)
+
+```
+dune build && dune runtest trading/backtest/walk_forward/test && dune build @fmt
+```
+
+54 tests across the 4 modules (9 + 17 + 13 + 15), all pass. All linters
+(nesting, fn-length, mli-coverage, file-length, magic-numbers, fmt) clean.
+
+### Deferred to PR-B (same plan)
+
+Plan §3-5: multi-metric sensitivity in markdown (4-col wins table),
+`cagr_pct` derived field in the binary, the two new fixture spec sexps
+(`cell-e-walk-forward-2026-05-08-harness/spec.sexp` regression fixture
+re-expressing the 8 hand-curated scenarios via `Window_spec.Explicit`,
+and `walk-forward-cell-e-30fold-2026-05-16/spec.sexp` production
+30-fold).
 
 ## Completed
 
-- **PR #1100** (this PR, 2026-05-15) — walk-forward CV harness first PR. Plan + 4 lib modules + binary + tests. ~1200 LOC including tests. All four checklist items satisfied (`dune build`, `dune runtest`, `dune fmt`, nesting + magic-number linters clean).
+- **PR #1100** (2026-05-15) — walk-forward CV harness first PR. Plan + 4 lib modules + binary + tests. ~1200 LOC including tests. All four checklist items satisfied (`dune build`, `dune runtest`, `dune fmt`, nesting + magic-number linters clean).
+- **PR #1107** (2026-05-16) — Phase 2.2 plan: rolling 30-fold harness extension. Plan file only; implementation tracked across the PR-A + PR-B split.
 
 ## Next Steps
 

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_render.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_render.ml
@@ -1,0 +1,93 @@
+open Core
+module T = Walk_forward_types
+
+let _per_fold_table (folds : T.fold_actual list) =
+  let header =
+    "| Fold | Variant | Return % | Sharpe | MaxDD % | Calmar |\n\
+     |------|---------|---------:|-------:|--------:|-------:|"
+  in
+  let rows =
+    List.map folds ~f:(fun (fa : T.fold_actual) ->
+        sprintf "| %s | %s | %.2f | %.3f | %.2f | %.3f |" fa.fold_name
+          fa.variant_label fa.total_return_pct fa.sharpe_ratio
+          fa.max_drawdown_pct fa.calmar_ratio)
+  in
+  String.concat ~sep:"\n" (header :: rows)
+
+let _stability_row (s : T.variant_stability) =
+  sprintf "| %s | %.2f ± %.2f | %.3f ± %.3f | %.2f ± %.2f | %.3f ± %.3f |"
+    s.variant_label s.total_return_pct.mean s.total_return_pct.stdev
+    s.sharpe_ratio.mean s.sharpe_ratio.stdev s.max_drawdown_pct.mean
+    s.max_drawdown_pct.stdev s.calmar_ratio.mean s.calmar_ratio.stdev
+
+let _stability_table (agg : T.aggregate) =
+  let header =
+    "| Variant | Return % (μ ± σ) | Sharpe (μ ± σ) | MaxDD % (μ ± σ) | Calmar \
+     (μ ± σ) |\n\
+     |---------|-----------------:|---------------:|----------------:|--------------:|"
+  in
+  let rows = List.map agg.stability ~f:_stability_row in
+  String.concat ~sep:"\n" (header :: rows)
+
+let _sensitivity_row ~fold_count (s : T.variant_sensitivity) =
+  sprintf "| %s | %d | %d |" s.variant_label s.wins_on_gate_metric fold_count
+
+let _sensitivity_table (agg : T.aggregate) =
+  let header =
+    sprintf
+      "Variant wins per fold on **%s** (vs baseline `%s`, %d folds total):\n\n\
+       | Variant | Wins | of |\n\
+       |---------|-----:|---:|"
+      agg.metric_label agg.baseline_label agg.fold_count
+  in
+  let rows =
+    List.map agg.sensitivity ~f:(_sensitivity_row ~fold_count:agg.fold_count)
+  in
+  String.concat ~sep:"\n" (header :: rows)
+
+let _is_skipped_fail ~worst_fold ~worst_gap =
+  String.is_empty worst_fold && Float.is_nan worst_gap
+
+let _fail_line ~variant_label ~wins ~n ~worst_fold ~worst_gap ~reason =
+  if _is_skipped_fail ~worst_fold ~worst_gap then
+    sprintf "- **%s**: SKIPPED — %s" variant_label reason
+  else
+    sprintf
+      "- **%s**: FAIL (%d / %d wins; worst fold `%s` gap %.4f). Reason: %s"
+      variant_label wins n worst_fold worst_gap reason
+
+let _one_verdict ~(gate : Fold_gate.t) ~variant_label (v : Fold_gate.verdict) =
+  match v with
+  | Fold_gate.Pass { wins; n } ->
+      sprintf "- **%s**: PASS (%d / %d wins, Δ≤%.4f satisfied)" variant_label
+        wins n gate.worst_delta
+  | Fold_gate.Fail { wins; n; worst_fold; worst_gap; reason } ->
+      _fail_line ~variant_label ~wins ~n ~worst_fold ~worst_gap ~reason
+
+let _verdict_block ~(gate : Fold_gate.t) (agg : T.aggregate) =
+  let header =
+    sprintf
+      "Gate: variant wins ≥%d of %d folds on **%s** vs baseline `%s`, no fold \
+       worse by Δ>%.4f.\n"
+      gate.m gate.n agg.metric_label agg.baseline_label gate.worst_delta
+  in
+  let lines =
+    List.map agg.verdicts ~f:(fun (variant_label, v) ->
+        _one_verdict ~gate ~variant_label v)
+  in
+  String.concat ~sep:"\n" (header :: lines)
+
+let to_markdown ~(gate : Fold_gate.t) ~(fold_actuals : T.fold_actual list)
+    (agg : T.aggregate) =
+  String.concat ~sep:"\n\n"
+    [
+      "# Walk-forward CV report";
+      "## 1. Per-fold metrics";
+      _per_fold_table fold_actuals;
+      "## 2. Stability (mean ± stdev across folds)";
+      _stability_table agg;
+      "## 3. Cross-fold sensitivity";
+      _sensitivity_table agg;
+      "## 4. Go/no-go verdict";
+      _verdict_block ~gate agg;
+    ]

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_render.mli
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_render.mli
@@ -1,0 +1,15 @@
+(** Pure markdown renderer for a {!Walk_forward_types.aggregate} + the raw
+    per-(fold, variant) measurements that produced it.
+
+    Split out of {!Walk_forward_report} only to keep that module under the
+    repo's file-length limit; the public entry point is
+    {!Walk_forward_report.render} which delegates to this module. *)
+
+val to_markdown :
+  gate:Fold_gate.t ->
+  fold_actuals:Walk_forward_types.fold_actual list ->
+  Walk_forward_types.aggregate ->
+  string
+(** [to_markdown ~gate ~fold_actuals agg] returns the four-section markdown
+    report: per-fold metrics, stability, cross-fold sensitivity, go/no-go
+    verdict. Deterministic — same inputs produce byte-identical output. *)

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_report.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_report.ml
@@ -1,16 +1,7 @@
 open Core
+include Walk_forward_types
 
-type fold_actual = {
-  fold_name : string;
-  variant_label : string;
-  total_return_pct : float;
-  sharpe_ratio : float;
-  max_drawdown_pct : float;
-  calmar_ratio : float;
-}
-[@@deriving sexp]
-
-(* -------------- helpers -------------- *)
+(* -------------- ordering helpers -------------- *)
 
 let _variant_labels_in_order (folds : fold_actual list) =
   let seen = Hash_set.create (module String) in
@@ -28,6 +19,8 @@ let _fold_names_in_order (folds : fold_actual list) =
         Hash_set.add seen fa.fold_name;
         Some fa.fold_name))
 
+(* -------------- summary stats -------------- *)
+
 let _mean xs =
   let n = List.length xs in
   if n = 0 then Float.nan
@@ -41,87 +34,32 @@ let _stdev xs =
     let s = List.fold xs ~init:0.0 ~f:(fun acc x -> acc +. ((x -. m) ** 2.0)) in
     Float.sqrt (s /. Float.of_int (n - 1))
 
+let _min_or_nan xs =
+  match xs with
+  | [] -> Float.nan
+  | x :: rest -> List.fold rest ~init:x ~f:Float.min
+
+let _max_or_nan xs =
+  match xs with
+  | [] -> Float.nan
+  | x :: rest -> List.fold rest ~init:x ~f:Float.max
+
+let _stats xs : per_metric_stats =
+  {
+    mean = _mean xs;
+    stdev = _stdev xs;
+    min = _min_or_nan xs;
+    max = _max_or_nan xs;
+  }
+
+(* -------------- gate-metric projection -------------- *)
+
 let _project_metric (gate : Fold_gate.t) (fa : fold_actual) =
   match gate.metric with
   | Sharpe -> fa.sharpe_ratio
   | Calmar -> fa.calmar_ratio
   | TotalReturnPct -> fa.total_return_pct
   | MaxDrawdownPct -> fa.max_drawdown_pct
-
-(* -------------- section renderers -------------- *)
-
-let _render_per_fold_table (folds : fold_actual list) =
-  let header =
-    "| Fold | Variant | Return % | Sharpe | MaxDD % | Calmar |\n\
-     |------|---------|---------:|-------:|--------:|-------:|"
-  in
-  let rows =
-    List.map folds ~f:(fun fa ->
-        sprintf "| %s | %s | %.2f | %.3f | %.2f | %.3f |" fa.fold_name
-          fa.variant_label fa.total_return_pct fa.sharpe_ratio
-          fa.max_drawdown_pct fa.calmar_ratio)
-  in
-  String.concat ~sep:"\n" (header :: rows)
-
-let _variant_metric_lists (folds : fold_actual list) label =
-  List.filter folds ~f:(fun fa -> String.equal fa.variant_label label)
-
-let _render_stability_table (folds : fold_actual list) =
-  let header =
-    "| Variant | Return % (μ ± σ) | Sharpe (μ ± σ) | MaxDD % (μ ± σ) | Calmar \
-     (μ ± σ) |\n\
-     |---------|-----------------:|---------------:|----------------:|--------------:|"
-  in
-  let labels = _variant_labels_in_order folds in
-  let rows =
-    List.map labels ~f:(fun label ->
-        let vs = _variant_metric_lists folds label in
-        let r = List.map vs ~f:(fun fa -> fa.total_return_pct) in
-        let s = List.map vs ~f:(fun fa -> fa.sharpe_ratio) in
-        let d = List.map vs ~f:(fun fa -> fa.max_drawdown_pct) in
-        let c = List.map vs ~f:(fun fa -> fa.calmar_ratio) in
-        sprintf "| %s | %.2f ± %.2f | %.3f ± %.3f | %.2f ± %.2f | %.3f ± %.3f |"
-          label (_mean r) (_stdev r) (_mean s) (_stdev s) (_mean d) (_stdev d)
-          (_mean c) (_stdev c))
-  in
-  String.concat ~sep:"\n" (header :: rows)
-
-(** Lookup a fold actual by (fold_name, variant_label). Returns [None] when no
-    such measurement exists. *)
-let _find_fold_actual (folds : fold_actual list) ~fold_name ~variant_label =
-  List.find folds ~f:(fun fa ->
-      String.equal fa.fold_name fold_name
-      && String.equal fa.variant_label variant_label)
-
-(** True iff [variant] strictly beats [baseline] on the named fold, per the
-    gate's metric direction (higher-is-better vs drawdown). *)
-let _variant_beats_baseline ~(gate : Fold_gate.t) ~hib ~folds ~baseline_label
-    ~variant_label ~fold_name =
-  let b = _find_fold_actual folds ~fold_name ~variant_label:baseline_label in
-  let v = _find_fold_actual folds ~fold_name ~variant_label in
-  match (b, v) with
-  | Some b, Some v ->
-      let bv = _project_metric gate b in
-      let vv = _project_metric gate v in
-      if hib then Float.(vv > bv) else Float.(vv < bv)
-  | _ -> false
-
-let _wins_for_variant ~gate ~hib ~folds ~baseline_label ~variant_label =
-  let fold_names = _fold_names_in_order folds in
-  List.count fold_names ~f:(fun fold_name ->
-      _variant_beats_baseline ~gate ~hib ~folds ~baseline_label ~variant_label
-        ~fold_name)
-
-let _wins_per_variant_on_metric (folds : fold_actual list)
-    ~(baseline_label : string) ~(gate : Fold_gate.t) =
-  let labels = _variant_labels_in_order folds in
-  let hib = Fold_gate.higher_is_better gate.metric in
-  List.filter labels ~f:(fun l -> not (String.equal l baseline_label))
-  |> List.map ~f:(fun variant_label ->
-      let wins =
-        _wins_for_variant ~gate ~hib ~folds ~baseline_label ~variant_label
-      in
-      (variant_label, wins))
 
 let _metric_str (gate : Fold_gate.t) =
   match gate.metric with
@@ -130,115 +68,124 @@ let _metric_str (gate : Fold_gate.t) =
   | TotalReturnPct -> "TotalReturn%"
   | MaxDrawdownPct -> "MaxDD%"
 
-let _render_sensitivity_table ~baseline_label ~(gate : Fold_gate.t)
-    (folds : fold_actual list) =
-  let n = List.length (_fold_names_in_order folds) in
-  let header =
-    sprintf
-      "Variant wins per fold on **%s** (vs baseline `%s`, %d folds total):\n\n\
-       | Variant | Wins | of |\n\
-       |---------|-----:|---:|"
-      (_metric_str gate) baseline_label n
-  in
-  let rows =
-    _wins_per_variant_on_metric folds ~baseline_label ~gate
-    |> List.map ~f:(fun (label, wins) ->
-        sprintf "| %s | %d | %d |" label wins n)
-  in
-  String.concat ~sep:"\n" (header :: rows)
+(* -------------- stability + fold-pair helpers -------------- *)
 
-(** Build one [Fold_gate.fold_result] for the (baseline, variant) pair on the
-    named fold. Returns [None] when either side's measurement is missing. *)
-let _fold_result_for_one ~(gate : Fold_gate.t) ~folds ~baseline_label
+let _stability_for_variant (folds : fold_actual list) label : variant_stability
+    =
+  let vs =
+    List.filter folds ~f:(fun fa -> String.equal fa.variant_label label)
+  in
+  {
+    variant_label = label;
+    total_return_pct = _stats (List.map vs ~f:(fun fa -> fa.total_return_pct));
+    sharpe_ratio = _stats (List.map vs ~f:(fun fa -> fa.sharpe_ratio));
+    max_drawdown_pct = _stats (List.map vs ~f:(fun fa -> fa.max_drawdown_pct));
+    calmar_ratio = _stats (List.map vs ~f:(fun fa -> fa.calmar_ratio));
+  }
+
+let _find_fold_actual (folds : fold_actual list) ~fold_name ~variant_label =
+  List.find folds ~f:(fun fa ->
+      String.equal fa.fold_name fold_name
+      && String.equal fa.variant_label variant_label)
+
+let _fold_result_for_one (folds : fold_actual list) ~gate ~baseline_label
     ~variant_label ~fold_name : Fold_gate.fold_result option =
   let b = _find_fold_actual folds ~fold_name ~variant_label:baseline_label in
   let v = _find_fold_actual folds ~fold_name ~variant_label in
   match (b, v) with
   | Some b, Some v ->
-      let baseline_score = _project_metric gate b in
-      let variant_score = _project_metric gate v in
-      Some { fold_name; variant_score; baseline_score }
+      Some
+        ({
+           fold_name;
+           variant_score = _project_metric gate v;
+           baseline_score = _project_metric gate b;
+         }
+          : Fold_gate.fold_result)
   | _ -> None
 
-(** Build [Fold_gate.fold_result] list for a single (variant vs baseline)
-    pairing. Returns folds in baseline-side ordering — anchors on the unique
-    fold-name list. *)
 let _fold_results_for_pair (folds : fold_actual list) ~baseline_label
-    ~variant_label ~gate =
-  let fold_names = _fold_names_in_order folds in
-  List.filter_map fold_names ~f:(fun fold_name ->
-      _fold_result_for_one ~gate ~folds ~baseline_label ~variant_label
-        ~fold_name)
+    ~variant_label ~gate : Fold_gate.fold_result list =
+  _fold_names_in_order folds
+  |> List.filter_map ~f:(fun fold_name ->
+      _fold_result_for_one folds ~gate ~baseline_label ~variant_label ~fold_name)
 
-let _render_verdict_for_variant ~(gate : Fold_gate.t) ~variant_label
-    fold_results =
-  let n_folds = List.length fold_results in
-  if n_folds <> gate.n then
-    sprintf "- **%s**: SKIPPED — measured %d folds but gate expects %d"
-      variant_label n_folds gate.n
-  else
-    match Fold_gate.evaluate gate fold_results with
-    | Fold_gate.Pass { wins; n } ->
-        sprintf "- **%s**: PASS (%d / %d wins, Δ≤%.4f satisfied)" variant_label
-          wins n gate.worst_delta
-    | Fold_gate.Fail { wins; n; worst_fold; worst_gap; reason } ->
-        sprintf
-          "- **%s**: FAIL (%d / %d wins; worst fold `%s` gap %.4f). Reason: %s"
-          variant_label wins n worst_fold worst_gap reason
+let _wins_for_variant ~(gate : Fold_gate.t) frs =
+  let hib = Fold_gate.higher_is_better gate.metric in
+  List.count frs ~f:(fun (fr : Fold_gate.fold_result) ->
+      if hib then Float.(fr.variant_score > fr.baseline_score)
+      else Float.(fr.variant_score < fr.baseline_score))
 
-let _render_verdict_block ~baseline_label ~(gate : Fold_gate.t)
-    (folds : fold_actual list) =
-  let labels = _variant_labels_in_order folds in
-  let non_baseline =
-    List.filter labels ~f:(fun l -> not (String.equal l baseline_label))
-  in
-  let header =
-    sprintf
-      "Gate: variant wins ≥%d of %d folds on **%s** vs baseline `%s`, no fold \
-       worse by Δ>%.4f.\n"
-      gate.m gate.n (_metric_str gate) baseline_label gate.worst_delta
-  in
-  let lines =
-    List.map non_baseline ~f:(fun variant_label ->
-        let frs =
-          _fold_results_for_pair folds ~baseline_label ~variant_label ~gate
-        in
-        _render_verdict_for_variant ~gate ~variant_label frs)
-  in
-  String.concat ~sep:"\n" (header :: lines)
-
-(* -------------- top-level render -------------- *)
+(* -------------- top-level compute -------------- *)
 
 let _validate ~baseline_label folds =
   if List.is_empty folds then
-    failwith "Walk_forward_report.render: fold_actuals must be non-empty";
+    failwith "Walk_forward_report.compute: fold_actuals must be non-empty";
   let labels = _variant_labels_in_order folds in
   if not (List.mem labels baseline_label ~equal:String.equal) then
     failwith
       (sprintf
-         "Walk_forward_report.render: baseline_label %S not present in \
+         "Walk_forward_report.compute: baseline_label %S not present in \
           fold_actuals (labels: %s)"
          baseline_label
          (String.concat ~sep:", " labels))
 
+let _mismatch_verdict ~(gate : Fold_gate.t) frs : Fold_gate.verdict =
+  Fail
+    {
+      wins = _wins_for_variant ~gate frs;
+      n = List.length frs;
+      worst_fold = "";
+      worst_gap = Float.nan;
+      reason =
+        sprintf "fold-pair count mismatch: measured %d, gate expects %d"
+          (List.length frs) gate.n;
+    }
+
+let _verdict_for_variant ~(gate : Fold_gate.t) ~variant_label frs =
+  let verdict =
+    if List.length frs <> gate.n then _mismatch_verdict ~gate frs
+    else Fold_gate.evaluate gate frs
+  in
+  (variant_label, verdict)
+
+let _is_non_baseline ~baseline_label l = not (String.equal l baseline_label)
+
+let _pair_one fold_actuals ~baseline_label ~gate variant_label =
+  let frs =
+    _fold_results_for_pair fold_actuals ~baseline_label ~variant_label ~gate
+  in
+  (variant_label, frs)
+
+let _pair_results_per_variant ~baseline_label ~gate ~labels fold_actuals =
+  labels
+  |> List.filter ~f:(_is_non_baseline ~baseline_label)
+  |> List.map ~f:(_pair_one fold_actuals ~baseline_label ~gate)
+
+let _sensitivity_from_pairs ~gate pair_results : variant_sensitivity list =
+  List.map pair_results ~f:(fun (variant_label, frs) ->
+      { variant_label; wins_on_gate_metric = _wins_for_variant ~gate frs })
+
+let _verdicts_from_pairs ~gate pair_results =
+  List.map pair_results ~f:(fun (variant_label, frs) ->
+      _verdict_for_variant ~gate ~variant_label frs)
+
+let compute ~baseline_label ~(gate : Fold_gate.t)
+    ~(fold_actuals : fold_actual list) : aggregate =
+  _validate ~baseline_label fold_actuals;
+  let labels = _variant_labels_in_order fold_actuals in
+  let pair_results =
+    _pair_results_per_variant ~baseline_label ~gate ~labels fold_actuals
+  in
+  {
+    fold_count = List.length (_fold_names_in_order fold_actuals);
+    baseline_label;
+    metric_label = _metric_str gate;
+    stability = List.map labels ~f:(_stability_for_variant fold_actuals);
+    sensitivity = _sensitivity_from_pairs ~gate pair_results;
+    verdicts = _verdicts_from_pairs ~gate pair_results;
+  }
+
 let render ~baseline_label ~(gate : Fold_gate.t)
     ~(fold_actuals : fold_actual list) =
-  _validate ~baseline_label fold_actuals;
-  let per_fold = _render_per_fold_table fold_actuals in
-  let stability = _render_stability_table fold_actuals in
-  let sensitivity =
-    _render_sensitivity_table ~baseline_label ~gate fold_actuals
-  in
-  let verdict = _render_verdict_block ~baseline_label ~gate fold_actuals in
-  String.concat ~sep:"\n\n"
-    [
-      "# Walk-forward CV report";
-      "## 1. Per-fold metrics";
-      per_fold;
-      "## 2. Stability (mean ± stdev across folds)";
-      stability;
-      "## 3. Cross-fold sensitivity";
-      sensitivity;
-      "## 4. Go/no-go verdict";
-      verdict;
-    ]
+  let agg = compute ~baseline_label ~gate ~fold_actuals in
+  Walk_forward_render.to_markdown ~gate ~fold_actuals agg

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_report.mli
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_report.mli
@@ -1,24 +1,38 @@
-(** Pure markdown renderer for walk-forward CV results.
+(** Pure aggregate + markdown renderer for walk-forward CV results.
 
     Consumes a flat list of per-(fold, variant) measurements + a baseline label
-    \+ a {!Fold_gate.t}, and emits a four-section markdown report:
+    + a {!Fold_gate.t}, and produces:
 
-    1. **Per-fold metrics table** — one row per fold × variant, columns: fold
-    name, variant label, total return %, Sharpe, MaxDD %, Calmar. 2. **Stability
-    table** — one row per variant: mean ± stdev of each metric across folds. 3.
-    **Cross-fold parameter sensitivity** — variant win-count per metric. 4.
-    **Go/no-go verdict block** — calls {!Fold_gate.evaluate} on the
-    gate-selected metric and renders Pass/Fail with the diagnostic fields. *)
+    - {!compute} — a structured {!aggregate} record (per-variant stability,
+      per-variant gate verdict, win-counts on the gate metric) suitable for
+      programmatic consumption by Phase 3's Bayesian optimizer.
+    - {!render} — a four-section markdown report: per-fold metrics, stability,
+      cross-fold sensitivity, go/no-go verdict. Internally calls {!compute} and
+      delegates the markdown emission to {!Walk_forward_render}. *)
 
-type fold_actual = {
-  fold_name : string;
-  variant_label : string;
-  total_return_pct : float;
-  sharpe_ratio : float;
-  max_drawdown_pct : float;
-  calmar_ratio : float;
-}
-[@@deriving sexp]
+include module type of Walk_forward_types
+(** The type surface ({!fold_actual}, {!aggregate}, {!variant_stability},
+    {!variant_sensitivity}, {!per_metric_stats}) lives in {!Walk_forward_types}
+    and is re-exported here unchanged. *)
+
+val compute :
+  baseline_label:string ->
+  gate:Fold_gate.t ->
+  fold_actuals:fold_actual list ->
+  aggregate
+(** [compute ~baseline_label ~gate ~fold_actuals] returns the structured
+    aggregate.
+
+    Validation matches {!render}: raises [Failure] if [fold_actuals] is empty or
+    if [baseline_label] is not present among the variant labels in
+    [fold_actuals].
+
+    The stability list aggregates by variant label in first-appearance order.
+    The sensitivity and verdicts lists exclude the baseline. Each verdict is a
+    synthetic Fail with a "fold-pair count mismatch" reason when the (variant,
+    baseline) fold-pair count doesn't match [gate.n] — the gate's [evaluate]
+    would raise in that case; we produce a uniform diagnostic surface for
+    downstream consumers instead. *)
 
 val render :
   baseline_label:string ->
@@ -26,16 +40,9 @@ val render :
   fold_actuals:fold_actual list ->
   string
 (** [render ~baseline_label ~gate ~fold_actuals] returns a markdown report
-    string. The renderer is deterministic — same inputs produce byte-identical
-    output (modulo timestamp, which is intentionally omitted).
+    string. Internally calls {!compute} then {!Walk_forward_render.to_markdown}.
 
-    Raises [Failure] if [fold_actuals] is empty or if [baseline_label] is not
-    present among the variant labels in [fold_actuals].
+    Deterministic — same inputs produce byte-identical output (modulo timestamp,
+    which is intentionally omitted).
 
-    The per-fold table preserves the input ordering of [fold_actuals]. The
-    stability and sensitivity tables aggregate by variant label, in the order
-    the labels first appear in [fold_actuals].
-
-    The go/no-go verdict block pairs each non-baseline variant against the
-    baseline on the gate's [metric] and renders a separate Pass/Fail line per
-    variant. *)
+    Raises [Failure] under the same conditions as {!compute}. *)

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_types.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_types.ml
@@ -1,0 +1,41 @@
+open Core
+
+type fold_actual = {
+  fold_name : string;
+  variant_label : string;
+  total_return_pct : float;
+  sharpe_ratio : float;
+  max_drawdown_pct : float;
+  calmar_ratio : float;
+}
+[@@deriving sexp]
+
+type per_metric_stats = {
+  mean : float;
+  stdev : float;
+  min : float;
+  max : float;
+}
+[@@deriving sexp]
+
+type variant_stability = {
+  variant_label : string;
+  total_return_pct : per_metric_stats;
+  sharpe_ratio : per_metric_stats;
+  max_drawdown_pct : per_metric_stats;
+  calmar_ratio : per_metric_stats;
+}
+[@@deriving sexp]
+
+type variant_sensitivity = { variant_label : string; wins_on_gate_metric : int }
+[@@deriving sexp]
+
+type aggregate = {
+  fold_count : int;
+  baseline_label : string;
+  metric_label : string;
+  stability : variant_stability list;
+  sensitivity : variant_sensitivity list;
+  verdicts : (string * Fold_gate.verdict) list;
+}
+[@@deriving sexp]

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_types.mli
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_types.mli
@@ -1,0 +1,50 @@
+(** Shared types for walk-forward CV reports.
+
+    Split out of {!Walk_forward_report} so that {!Walk_forward_render} (the
+    markdown emitter) can depend on the types without creating a cycle with the
+    [compute → render] call edge. *)
+
+type fold_actual = {
+  fold_name : string;
+  variant_label : string;
+  total_return_pct : float;
+  sharpe_ratio : float;
+  max_drawdown_pct : float;
+  calmar_ratio : float;
+}
+[@@deriving sexp]
+(** One per-(fold, variant) measurement row. *)
+
+type per_metric_stats = {
+  mean : float;
+  stdev : float;  (** Sample stdev; [Float.nan] when N < 2. *)
+  min : float;  (** Minimum over folds; [Float.nan] when N = 0. *)
+  max : float;  (** Maximum over folds; [Float.nan] when N = 0. *)
+}
+[@@deriving sexp]
+(** Cross-fold summary statistics for one (variant, metric) cell. *)
+
+type variant_stability = {
+  variant_label : string;
+  total_return_pct : per_metric_stats;
+  sharpe_ratio : per_metric_stats;
+  max_drawdown_pct : per_metric_stats;
+  calmar_ratio : per_metric_stats;
+}
+[@@deriving sexp]
+(** All four metric summaries for one variant. *)
+
+type variant_sensitivity = { variant_label : string; wins_on_gate_metric : int }
+[@@deriving sexp]
+(** Per-variant win-count on the gate's metric. Excludes the baseline itself. *)
+
+type aggregate = {
+  fold_count : int;
+  baseline_label : string;
+  metric_label : string;
+  stability : variant_stability list;
+  sensitivity : variant_sensitivity list;
+  verdicts : (string * Fold_gate.verdict) list;
+}
+[@@deriving sexp]
+(** Programmatic surface the Bayesian optimizer (Phase 3) consumes. *)

--- a/trading/trading/backtest/walk_forward/lib/window_spec.ml
+++ b/trading/trading/backtest/walk_forward/lib/window_spec.ml
@@ -1,7 +1,7 @@
 open Core
 module Scenario = Scenario_lib.Scenario
 
-type t = {
+type rolling_spec = {
   start_date : Date.t;
   end_date : Date.t;
   train_days : int;
@@ -9,6 +9,30 @@ type t = {
   step_days : int;
 }
 [@@deriving sexp]
+
+type explicit_fold = {
+  name : string;
+  train_period : Scenario.period option;
+  test_period : Scenario.period;
+}
+[@@deriving sexp]
+
+type t = Rolling of rolling_spec | Explicit of explicit_fold list
+[@@deriving sexp]
+
+(** Sexp parser that accepts both the variant shape ([(Rolling ...)] /
+    [(Explicit ...)]) and the legacy flat-record shape. The legacy shape is
+    silently promoted to [Rolling] for backwards compatibility with in-tree spec
+    files written before the variant was introduced. *)
+let t_of_sexp_variant_form = t_of_sexp
+
+let _is_variant_tagged = function
+  | Sexp.List (Sexp.Atom ("Rolling" | "Explicit") :: _) -> true
+  | _ -> false
+
+let t_of_sexp sexp =
+  if _is_variant_tagged sexp then t_of_sexp_variant_form sexp
+  else Rolling (rolling_spec_of_sexp sexp)
 
 type fold = {
   index : int;
@@ -18,7 +42,9 @@ type fold = {
 }
 [@@deriving sexp]
 
-let _validate spec =
+(* ----- Rolling generator ----- *)
+
+let _validate_rolling (spec : rolling_spec) =
   if spec.train_days < 0 then
     failwith
       (sprintf "WindowSpec.generate: train_days must be >= 0, got %d"
@@ -34,7 +60,7 @@ let _validate spec =
 
 let _fold_name index = sprintf "fold-%03d" index
 
-let _build_fold ~index ~spec ~anchor =
+let _build_rolling_fold ~index ~(spec : rolling_spec) ~anchor =
   let train_start = anchor in
   let train_end = Date.add_days anchor (spec.train_days - 1) in
   let test_start = Date.add_days anchor spec.train_days in
@@ -50,10 +76,10 @@ let _build_fold ~index ~spec ~anchor =
   in
   { index; name = _fold_name index; train_period; test_period }
 
-let generate spec =
-  _validate spec;
+let _generate_rolling (spec : rolling_spec) =
+  _validate_rolling spec;
   let rec loop ~index ~anchor acc =
-    let candidate = _build_fold ~index ~spec ~anchor in
+    let candidate = _build_rolling_fold ~index ~spec ~anchor in
     if Date.( > ) candidate.test_period.end_date spec.end_date then List.rev acc
     else
       let next_anchor = Date.add_days anchor spec.step_days in
@@ -61,3 +87,29 @@ let generate spec =
   in
   if Date.( > ) spec.start_date spec.end_date then []
   else loop ~index:0 ~anchor:spec.start_date []
+
+(* ----- Explicit generator ----- *)
+
+let _validate_explicit (folds : explicit_fold list) =
+  if List.is_empty folds then
+    failwith "WindowSpec.generate: Explicit folds list must be non-empty";
+  let names = List.map folds ~f:(fun f -> f.name) in
+  match List.find_a_dup names ~compare:String.compare with
+  | Some dup ->
+      failwith
+        (sprintf "WindowSpec.generate: duplicate fold name in Explicit: %S" dup)
+  | None -> ()
+
+let _generate_explicit (folds : explicit_fold list) =
+  _validate_explicit folds;
+  List.mapi folds ~f:(fun index (ef : explicit_fold) ->
+      {
+        index;
+        name = ef.name;
+        train_period = ef.train_period;
+        test_period = ef.test_period;
+      })
+
+let generate = function
+  | Rolling spec -> _generate_rolling spec
+  | Explicit folds -> _generate_explicit folds

--- a/trading/trading/backtest/walk_forward/lib/window_spec.mli
+++ b/trading/trading/backtest/walk_forward/lib/window_spec.mli
@@ -1,8 +1,8 @@
-(** Rolling window specification for walk-forward cross-validation.
+(** Window specification for walk-forward cross-validation.
 
-    A [WindowSpec.t] is a pure description of how to roll a fixed-shape
-    train/test window forward across a calendar range. {!generate} expands the
-    spec into a list of {!fold}s; each fold carries a name and the train + test
+    A [WindowSpec.t] is a pure description of how to lay out a sequence of
+    train/test windows across a calendar range. {!generate} expands the spec
+    into a list of {!fold}s; each fold carries a name and the train + test
     {!Scenario_lib.Scenario.period}s the walk-forward runner will instantiate
     base scenarios over.
 
@@ -12,13 +12,23 @@
     observable and a machine-checkable go/no-go gate becomes the verdict rather
     than an eyeballed table.
 
+    Two construction modes:
+
+    - [Rolling] — start_date/train_days/test_days/step_days expansion; the
+      generator emits the fold sequence and stops dropping folds whose
+      test_period extends past [end_date].
+    - [Explicit] — hand-curated list of fold periods, used to migrate the
+      2026-05-08 8-fold experiment as a regression fixture (its windows are not
+      a rolling pattern). Folds pass through verbatim with their input-order
+      indexes and operator-supplied names.
+
     All date arithmetic is in calendar days (not trading days). Conversion to
     trading-day windows is the backtest runner's job — the spec only constrains
     the wall-clock period each fold runs over. *)
 
 open Core
 
-type t = {
+type rolling_spec = {
   start_date : Date.t;
       (** Inclusive earliest day for the first fold's train (or test, when
           [train_days = 0]) period. *)
@@ -39,19 +49,44 @@ type t = {
           windows tile without overlap. *)
 }
 [@@deriving sexp]
-(** Sexp shape (one record):
-    [((start_date 2010-01-01) (end_date 2024-12-31) (train_days 730) (test_days
-     365) (step_days 182))]. *)
+
+type explicit_fold = {
+  name : string;
+      (** Human-readable fold name used verbatim as [fold.name] in the generated
+          fold record. Must be unique within the [Explicit] list. *)
+  train_period : Scenario_lib.Scenario.period option;
+      (** Optional in-sample period, same semantics as the rolling case. *)
+  test_period : Scenario_lib.Scenario.period;
+}
+[@@deriving sexp]
+(** One hand-curated fold for the [Explicit] mode. *)
+
+(** Sexp shape: [(Rolling ((start_date ...) (end_date ...) ...))] or
+    [(Explicit (((name "...") (train_period ...) (test_period ...)) ...))].
+
+    {b Legacy flat-shape compatibility:} the [t_of_sexp] override below accepts
+    the pre-variant shape
+    [((start_date ...) (end_date ...) (train_days ...) (test_days ...)
+     (step_days ...))] and parses it as [Rolling]. The plan tracks this
+    temporarily; new spec files should use the variant shape. *)
+type t = Rolling of rolling_spec | Explicit of explicit_fold list
+[@@deriving sexp]
+
+val t_of_sexp : Sexp.t -> t
+(** [t_of_sexp sexp] parses both the variant shape ([Rolling]/[Explicit]) and
+    the legacy flat-record shape (silently promoted to [Rolling]). Raises
+    [Failure] on shapes matching neither. *)
 
 type fold = {
   index : int;  (** Zero-based fold index in generation order. *)
   name : string;
-      (** Human-readable fold name, shape ["fold-NNN"] where [NNN] is [index]
-          zero-padded to width 3. Used as a suffix in generated scenario names.
-      *)
+      (** Human-readable fold name. For [Rolling] folds shape is ["fold-NNN"]
+          where [NNN] is [index] zero-padded to width 3. For [Explicit] folds
+          the name is the operator-supplied {!explicit_fold.name} verbatim. *)
   train_period : Scenario_lib.Scenario.period option;
-      (** [Some] when [WindowSpec.train_days > 0], else [None]. The train period
-          precedes the test period back-to-back. *)
+      (** [Some] when there is an in-sample period, else [None]. The train
+          period precedes the test period back-to-back in [Rolling] mode; the
+          [Explicit] case passes through whatever the operator supplied. *)
   test_period : Scenario_lib.Scenario.period;
 }
 [@@deriving sexp]
@@ -59,7 +94,7 @@ type fold = {
 val generate : t -> fold list
 (** [generate spec] expands a spec into its sequence of folds.
 
-    Algorithm: starting from [spec.start_date], the first fold's train_period
+    [Rolling]: starting from [spec.start_date], the first fold's train_period
     runs [start_date .. start_date + train_days - 1] (inclusive) and its
     test_period runs
     [start_date + train_days .. start_date + train_days + test_days - 1]. Each
@@ -68,6 +103,9 @@ val generate : t -> fold list
     fold whose test_period would extend past [end_date] is dropped along with
     all later folds.
 
-    Returns an empty list when [start_date > end_date] or no fold fits the
-    bounds. Raises [Failure] when [train_days < 0], [test_days <= 0], or
-    [step_days <= 0]. *)
+    [Explicit]: passes the list through verbatim, assigning [index] in input
+    order. Raises [Failure] on an empty list or on duplicate names.
+
+    Returns an empty list when [Rolling]'s [start_date > end_date] or no fold
+    fits the bounds. Raises [Failure] when [Rolling.train_days < 0],
+    [Rolling.test_days <= 0], or [Rolling.step_days <= 0]. *)

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
@@ -25,7 +25,7 @@ let _baseline_gate ?(metric = FG.Sharpe) ?(m = 2) ?(n = 3) ?(worst_delta = 0.5)
 
 let test_empty_folds_raises _ =
   assert_raises
-    (Failure "Walk_forward_report.render: fold_actuals must be non-empty")
+    (Failure "Walk_forward_report.compute: fold_actuals must be non-empty")
     (fun () ->
       Report.render ~baseline_label:"baseline" ~gate:(_baseline_gate ())
         ~fold_actuals:[])
@@ -162,6 +162,142 @@ let test_render_is_deterministic _ =
   in
   assert_that md1 (equal_to md2)
 
+(* ---------- compute aggregate ---------- *)
+
+let test_compute_stability_per_variant _ =
+  (* baseline Sharpe = mean(0.5, 0.6, 0.4) = 0.5, stdev = 0.1.
+     cellE Sharpe = mean(0.9, 0.7, 0.45) = 0.6833…, stdev ~ 0.2255. *)
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 () in
+  let agg =
+    Report.compute ~baseline_label:"baseline" ~gate ~fold_actuals:folds
+  in
+  assert_that agg
+    (all_of
+       [
+         field (fun (a : Report.aggregate) -> a.fold_count) (equal_to 3);
+         field
+           (fun (a : Report.aggregate) -> a.baseline_label)
+           (equal_to "baseline");
+         field
+           (fun (a : Report.aggregate) -> a.metric_label)
+           (equal_to "Sharpe");
+         field
+           (fun (a : Report.aggregate) -> a.stability)
+           (elements_are
+              [
+                all_of
+                  [
+                    field
+                      (fun (s : Report.variant_stability) -> s.variant_label)
+                      (equal_to "baseline");
+                    field
+                      (fun (s : Report.variant_stability) ->
+                        s.sharpe_ratio.mean)
+                      (float_equal ~epsilon:1e-4 0.5);
+                    field
+                      (fun (s : Report.variant_stability) ->
+                        s.sharpe_ratio.stdev)
+                      (float_equal ~epsilon:1e-4 0.1);
+                    field
+                      (fun (s : Report.variant_stability) -> s.sharpe_ratio.min)
+                      (float_equal ~epsilon:1e-4 0.4);
+                    field
+                      (fun (s : Report.variant_stability) -> s.sharpe_ratio.max)
+                      (float_equal ~epsilon:1e-4 0.6);
+                  ];
+                all_of
+                  [
+                    field
+                      (fun (s : Report.variant_stability) -> s.variant_label)
+                      (equal_to "cellE");
+                    field
+                      (fun (s : Report.variant_stability) ->
+                        s.sharpe_ratio.mean)
+                      (float_equal ~epsilon:1e-3 0.6833);
+                  ];
+              ]);
+       ])
+
+let test_compute_sensitivity_excludes_baseline _ =
+  (* cellE strictly wins 3/3 on Sharpe vs baseline. *)
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 () in
+  let agg =
+    Report.compute ~baseline_label:"baseline" ~gate ~fold_actuals:folds
+  in
+  assert_that agg.sensitivity
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (s : Report.variant_sensitivity) -> s.variant_label)
+               (equal_to "cellE");
+             field
+               (fun (s : Report.variant_sensitivity) -> s.wins_on_gate_metric)
+               (equal_to 3);
+           ];
+       ])
+
+let test_compute_verdict_pass _ =
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 ~worst_delta:0.5 () in
+  let agg =
+    Report.compute ~baseline_label:"baseline" ~gate ~fold_actuals:folds
+  in
+  assert_that agg.verdicts
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (label, _) -> label) (equal_to "cellE");
+             field
+               (fun (_, v) -> v)
+               (matching ~msg:"Expected Pass verdict with 3/3 wins"
+                  (function FG.Pass { wins; n } -> Some (wins, n) | _ -> None)
+                  (equal_to (3, 3)));
+           ];
+       ])
+
+let test_compute_validates_baseline _ =
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 () in
+  assert_raises
+    (Failure
+       "Walk_forward_report.compute: baseline_label \"missing\" not present in \
+        fold_actuals (labels: baseline, cellE)") (fun () ->
+      Report.compute ~baseline_label:"missing" ~gate ~fold_actuals:folds
+      |> ignore)
+
+let test_aggregate_sexp_round_trip _ =
+  let folds = _three_fold_two_variant_setup () in
+  let gate = _baseline_gate ~m:2 ~n:3 () in
+  let agg =
+    Report.compute ~baseline_label:"baseline" ~gate ~fold_actuals:folds
+  in
+  let parsed = Report.aggregate_of_sexp (Report.sexp_of_aggregate agg) in
+  assert_that parsed
+    (all_of
+       [
+         field (fun (a : Report.aggregate) -> a.fold_count) (equal_to 3);
+         field
+           (fun (a : Report.aggregate) -> a.baseline_label)
+           (equal_to "baseline");
+         field
+           (fun (a : Report.aggregate) -> a.metric_label)
+           (equal_to "Sharpe");
+         field
+           (fun (a : Report.aggregate) -> List.length a.stability)
+           (equal_to 2);
+         field
+           (fun (a : Report.aggregate) -> List.length a.sensitivity)
+           (equal_to 1);
+         field
+           (fun (a : Report.aggregate) -> List.length a.verdicts)
+           (equal_to 1);
+       ])
+
 (* ---------- Sexp round-trip ---------- *)
 
 let test_fold_actual_sexp_round_trip _ =
@@ -197,6 +333,12 @@ let suite =
          "stability row shows μ ± σ" >:: test_stability_row_shows_mean_and_stdev;
          "sensitivity row per variant" >:: test_sensitivity_row_per_variant;
          "render is deterministic" >:: test_render_is_deterministic;
+         "compute stability per variant" >:: test_compute_stability_per_variant;
+         "compute sensitivity excludes baseline"
+         >:: test_compute_sensitivity_excludes_baseline;
+         "compute verdict Pass" >:: test_compute_verdict_pass;
+         "compute validates baseline_label" >:: test_compute_validates_baseline;
+         "aggregate sexp round-trip" >:: test_aggregate_sexp_round_trip;
          "fold_actual sexp round-trip" >:: test_fold_actual_sexp_round_trip;
        ]
 

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
@@ -131,13 +131,14 @@ let test_description_marks_fold_and_variant _ =
 let test_build_all_cross_product _ =
   let base = _make_base ~name:"X" () in
   let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 6 30;
-      train_days = 0;
-      test_days = 30;
-      step_days = 60;
-    }
+    Rolling
+      {
+        start_date = _date 2020 1 1;
+        end_date = _date 2020 6 30;
+        train_days = 0;
+        test_days = 30;
+        step_days = 60;
+      }
   in
   (* Folds at 01-01, 03-01, 05-01 (step=60) = 3 folds. Wait: 01-01 + 60 = 03-01,
      +60 = 05-01. test 05-01..05-30 ends by 06-30. fold-3 anchor 06-30, test
@@ -161,13 +162,14 @@ let test_build_all_cross_product _ =
 let test_build_all_empty_variants_yields_empty _ =
   let base = _make_base () in
   let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 6 30;
-      train_days = 0;
-      test_days = 30;
-      step_days = 30;
-    }
+    Rolling
+      {
+        start_date = _date 2020 1 1;
+        end_date = _date 2020 6 30;
+        train_days = 0;
+        test_days = 30;
+        step_days = 30;
+      }
   in
   let scenarios = WFR.build_all ~base ~spec ~variants:[] in
   assert_that scenarios (size_is 0)

--- a/trading/trading/backtest/walk_forward/test/test_window_spec.ml
+++ b/trading/trading/backtest/walk_forward/test/test_window_spec.ml
@@ -9,85 +9,58 @@ module Scenario = Scenario_lib.Scenario
 
 let _date y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
 
-(* ---------- Validation ---------- *)
+let _rolling ~start_date ~end_date ~train_days ~test_days ~step_days : WS.t =
+  Rolling { start_date; end_date; train_days; test_days; step_days }
+
+(* ---------- Validation (Rolling) ---------- *)
 
 let test_negative_train_days_raises _ =
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 12 31;
-      train_days = -1;
-      test_days = 30;
-      step_days = 30;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:(-1) ~test_days:30 ~step_days:30
   in
   assert_raises (Failure "WindowSpec.generate: train_days must be >= 0, got -1")
     (fun () -> WS.generate spec)
 
 let test_zero_test_days_raises _ =
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 12 31;
-      train_days = 30;
-      test_days = 0;
-      step_days = 30;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:30 ~test_days:0 ~step_days:30
   in
   assert_raises (Failure "WindowSpec.generate: test_days must be > 0, got 0")
     (fun () -> WS.generate spec)
 
 let test_zero_step_days_raises _ =
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 12 31;
-      train_days = 30;
-      test_days = 30;
-      step_days = 0;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:30 ~test_days:30 ~step_days:0
   in
   assert_raises (Failure "WindowSpec.generate: step_days must be > 0, got 0")
     (fun () -> WS.generate spec)
 
-(* ---------- Empty-range cases ---------- *)
+(* ---------- Empty-range cases (Rolling) ---------- *)
 
 let test_start_after_end_yields_empty _ =
-  let spec : WS.t =
-    {
-      start_date = _date 2020 12 31;
-      end_date = _date 2020 1 1;
-      train_days = 0;
-      test_days = 30;
-      step_days = 30;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 12 31) ~end_date:(_date 2020 1 1)
+      ~train_days:0 ~test_days:30 ~step_days:30
   in
   assert_that (WS.generate spec) (size_is 0)
 
 let test_no_fold_fits_yields_empty _ =
   (* Window is 60 days (0 + 60) but available range is 30 days. *)
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 1 30;
-      train_days = 0;
-      test_days = 60;
-      step_days = 60;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 1 30)
+      ~train_days:0 ~test_days:60 ~step_days:60
   in
   assert_that (WS.generate spec) (size_is 0)
 
 (* ---------- Train-period None when train_days = 0 ---------- *)
 
 let test_train_days_zero_yields_no_train_period _ =
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 6 30;
-      train_days = 0;
-      test_days = 30;
-      step_days = 30;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 6 30)
+      ~train_days:0 ~test_days:30 ~step_days:30
   in
   let folds = WS.generate spec in
   assert_that folds
@@ -153,14 +126,9 @@ let test_train_days_zero_yields_no_train_period _ =
 (* ---------- Train + test back-to-back ---------- *)
 
 let test_train_followed_by_test _ =
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 12 31;
-      train_days = 60;
-      test_days = 30;
-      step_days = 90;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:60 ~test_days:30 ~step_days:90
   in
   let folds = WS.generate spec in
   (* First fold: train 01-01..03-01 (60d), test 03-01..03-30 (30d). *)
@@ -193,14 +161,9 @@ let test_train_followed_by_test _ =
 (* ---------- Step < test = overlapping rolling folds ---------- *)
 
 let test_overlapping_step_yields_overlapping_test_windows _ =
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 4 30;
-      train_days = 0;
-      test_days = 60;
-      step_days = 30;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 4 30)
+      ~train_days:0 ~test_days:60 ~step_days:30
   in
   let folds = WS.generate spec in
   let test_starts =
@@ -229,14 +192,9 @@ let test_overlapping_step_yields_overlapping_test_windows _ =
 let test_drops_folds_past_end_date _ =
   (* start=01-01, end=01-31, test_days=30, step=15. Possible test windows:
      [01-01..01-30] (ok), [01-16..02-14] (PAST end), drop. *)
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 1 31;
-      train_days = 0;
-      test_days = 30;
-      step_days = 15;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 1 31)
+      ~train_days:0 ~test_days:30 ~step_days:15
   in
   let folds = WS.generate spec in
   assert_that folds (size_is 1)
@@ -244,14 +202,9 @@ let test_drops_folds_past_end_date _ =
 (* ---------- Index + name shape ---------- *)
 
 let test_fold_names_zero_padded _ =
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2020 4 30;
-      train_days = 0;
-      test_days = 30;
-      step_days = 30;
-    }
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 4 30)
+      ~train_days:0 ~test_days:30 ~step_days:30
   in
   let folds = WS.generate spec in
   let names = List.map folds ~f:(fun (f : WS.fold) -> f.name) in
@@ -264,28 +217,167 @@ let test_fold_names_zero_padded _ =
          equal_to "fold-003";
        ])
 
-(* ---------- Sexp round-trip ---------- *)
+(* ---------- Sexp round-trip (variant shape) ---------- *)
 
-let test_sexp_round_trip _ =
-  let spec : WS.t =
-    {
-      start_date = _date 2020 1 1;
-      end_date = _date 2024 12 31;
-      train_days = 365;
-      test_days = 182;
-      step_days = 91;
-    }
+let test_sexp_round_trip_rolling _ =
+  let spec =
+    _rolling ~start_date:(_date 2020 1 1) ~end_date:(_date 2024 12 31)
+      ~train_days:365 ~test_days:182 ~step_days:91
   in
   let parsed = WS.t_of_sexp (WS.sexp_of_t spec) in
   assert_that parsed
-    (all_of
+    (matching ~msg:"Expected Rolling variant"
+       (function WS.Rolling r -> Some r | _ -> None)
+       (all_of
+          [
+            field
+              (fun (r : WS.rolling_spec) -> r.start_date)
+              (equal_to (_date 2020 1 1));
+            field (fun (r : WS.rolling_spec) -> r.train_days) (equal_to 365);
+            field (fun (r : WS.rolling_spec) -> r.test_days) (equal_to 182);
+            field (fun (r : WS.rolling_spec) -> r.step_days) (equal_to 91);
+          ]))
+
+(* ---------- Legacy flat-record sexp parses as Rolling ---------- *)
+
+let test_legacy_flat_sexp_parses_as_rolling _ =
+  let legacy_sexp =
+    Sexp.of_string
+      "((start_date 2020-01-01) (end_date 2024-12-31) (train_days 365) \
+       (test_days 182) (step_days 91))"
+  in
+  let parsed = WS.t_of_sexp legacy_sexp in
+  assert_that parsed
+    (matching ~msg:"Expected Rolling variant from legacy shape"
+       (function WS.Rolling r -> Some r | _ -> None)
+       (all_of
+          [
+            field
+              (fun (r : WS.rolling_spec) -> r.start_date)
+              (equal_to (_date 2020 1 1));
+            field (fun (r : WS.rolling_spec) -> r.train_days) (equal_to 365);
+          ]))
+
+(* ---------- Explicit constructor: pass-through with input order ---------- *)
+
+let _ef ~name ?train_start ?train_end ~test_start ~test_end () :
+    WS.explicit_fold =
+  let train_period =
+    match (train_start, train_end) with
+    | Some ts, Some te ->
+        Some ({ start_date = ts; end_date = te } : Scenario.period)
+    | _ -> None
+  in
+  {
+    name;
+    train_period;
+    test_period = { start_date = test_start; end_date = test_end };
+  }
+
+let test_explicit_passes_through_in_input_order _ =
+  let spec : WS.t =
+    Explicit
+      [
+        _ef ~name:"bull-2015-2017" ~test_start:(_date 2015 1 2)
+          ~test_end:(_date 2017 12 29) ();
+        _ef ~name:"covid-2020-2022h1" ~test_start:(_date 2020 1 2)
+          ~test_end:(_date 2022 6 30) ();
+        _ef ~name:"bull-2018-2020" ~test_start:(_date 2018 1 2)
+          ~test_end:(_date 2020 12 31) ();
+      ]
+  in
+  let folds = WS.generate spec in
+  assert_that folds
+    (elements_are
        [
-         field (fun (s : WS.t) -> s.start_date) (equal_to spec.start_date);
-         field (fun (s : WS.t) -> s.end_date) (equal_to spec.end_date);
-         field (fun (s : WS.t) -> s.train_days) (equal_to spec.train_days);
-         field (fun (s : WS.t) -> s.test_days) (equal_to spec.test_days);
-         field (fun (s : WS.t) -> s.step_days) (equal_to spec.step_days);
+         all_of
+           [
+             field (fun (f : WS.fold) -> f.index) (equal_to 0);
+             field (fun (f : WS.fold) -> f.name) (equal_to "bull-2015-2017");
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2015 1 2));
+             field (fun (f : WS.fold) -> f.train_period) is_none;
+           ];
+         all_of
+           [
+             field (fun (f : WS.fold) -> f.index) (equal_to 1);
+             field (fun (f : WS.fold) -> f.name) (equal_to "covid-2020-2022h1");
+           ];
+         all_of
+           [
+             field (fun (f : WS.fold) -> f.index) (equal_to 2);
+             field (fun (f : WS.fold) -> f.name) (equal_to "bull-2018-2020");
+           ];
        ])
+
+let test_explicit_preserves_train_period_when_supplied _ =
+  let spec : WS.t =
+    Explicit
+      [
+        _ef ~name:"with-train" ~train_start:(_date 2019 1 1)
+          ~train_end:(_date 2019 12 31) ~test_start:(_date 2020 1 1)
+          ~test_end:(_date 2020 12 31) ();
+      ]
+  in
+  let folds = WS.generate spec in
+  assert_that folds
+    (elements_are
+       [
+         field
+           (fun (f : WS.fold) -> f.train_period)
+           (is_some_and
+              (all_of
+                 [
+                   field
+                     (fun (p : Scenario.period) -> p.start_date)
+                     (equal_to (_date 2019 1 1));
+                   field
+                     (fun (p : Scenario.period) -> p.end_date)
+                     (equal_to (_date 2019 12 31));
+                 ]));
+       ])
+
+let test_explicit_empty_list_raises _ =
+  let spec : WS.t = Explicit [] in
+  assert_raises
+    (Failure "WindowSpec.generate: Explicit folds list must be non-empty")
+    (fun () -> WS.generate spec)
+
+let test_explicit_duplicate_names_raise _ =
+  let spec : WS.t =
+    Explicit
+      [
+        _ef ~name:"dup" ~test_start:(_date 2020 1 1) ~test_end:(_date 2020 6 30)
+          ();
+        _ef ~name:"dup" ~test_start:(_date 2020 7 1)
+          ~test_end:(_date 2020 12 31) ();
+      ]
+  in
+  assert_raises
+    (Failure "WindowSpec.generate: duplicate fold name in Explicit: \"dup\"")
+    (fun () -> WS.generate spec)
+
+let test_explicit_sexp_round_trip _ =
+  let spec : WS.t =
+    Explicit
+      [
+        _ef ~name:"f1" ~test_start:(_date 2020 1 1) ~test_end:(_date 2020 6 30)
+          ();
+        _ef ~name:"f2" ~train_start:(_date 2019 1 1)
+          ~train_end:(_date 2019 12 31) ~test_start:(_date 2020 1 1)
+          ~test_end:(_date 2020 12 31) ();
+      ]
+  in
+  let parsed = WS.t_of_sexp (WS.sexp_of_t spec) in
+  assert_that parsed
+    (matching ~msg:"Expected Explicit variant"
+       (function WS.Explicit fs -> Some fs | _ -> None)
+       (elements_are
+          [
+            field (fun (e : WS.explicit_fold) -> e.name) (equal_to "f1");
+            field (fun (e : WS.explicit_fold) -> e.name) (equal_to "f2");
+          ]))
 
 let suite =
   "Window_spec"
@@ -302,7 +394,17 @@ let suite =
          >:: test_overlapping_step_yields_overlapping_test_windows;
          "drops folds past end_date" >:: test_drops_folds_past_end_date;
          "fold names zero-padded" >:: test_fold_names_zero_padded;
-         "sexp round-trip" >:: test_sexp_round_trip;
+         "sexp round-trip Rolling" >:: test_sexp_round_trip_rolling;
+         "legacy flat sexp parses as Rolling"
+         >:: test_legacy_flat_sexp_parses_as_rolling;
+         "Explicit passes through in input order"
+         >:: test_explicit_passes_through_in_input_order;
+         "Explicit preserves train_period when supplied"
+         >:: test_explicit_preserves_train_period_when_supplied;
+         "Explicit empty list raises" >:: test_explicit_empty_list_raises;
+         "Explicit duplicate names raise"
+         >:: test_explicit_duplicate_names_raise;
+         "Explicit sexp round-trip" >:: test_explicit_sexp_round_trip;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

First of two PRs implementing Phase 2.2 of the walk-forward CV harness, per
`dev/plans/walk-forward-cv-rolling-30fold-2026-05-16.md` (merged in PR #1107).
This PR covers plan steps 1-2 only; steps 3-5 are split into a follow-up
PR-B to stay within the LOC budget.

- **`Window_spec.t` promoted to variant** `Rolling of rolling_spec | Explicit of explicit_fold list`. The `Explicit` constructor accepts a hand-curated list of fold periods, used to migrate the 2026-05-08 8-fold experiment as a regression fixture (its windows are not a rolling pattern). Backwards-compatible `t_of_sexp` accepts the legacy flat-record shape and silently promotes to `Rolling`.
- **`Walk_forward_report.compute`** returns a structured `aggregate` record with per-variant `variant_stability` (mean / stdev / min / max for each of total_return_pct / sharpe / max_drawdown_pct / calmar), per-variant `variant_sensitivity` (win-counts on the gate metric), and per-variant `(label, Fold_gate.verdict)` pairs. Phase 3's Bayesian optimizer consumes this surface directly without parsing markdown. Existing `render` now delegates to `compute` then to a new `Walk_forward_render.to_markdown` helper. Markdown output preserved byte-identically by the existing pinned tests.
- **Type surface extracted to `Walk_forward_types`** so `Walk_forward_render` (the markdown emitter) can depend on the types without cycling back through `Walk_forward_report.compute`. `Walk_forward_report.mli` re-exports via `include module type of Walk_forward_types`.

## Test plan

- [x] `dune build` clean
- [x] `dune runtest trading/backtest/walk_forward/test` — 54 tests pass (9 fold_gate + 17 window_spec + 13 walk_forward_runner + 15 walk_forward_report)
- [x] `dune build @fmt` clean
- [x] All dune-wired linters green (`fn_length`, `nesting`, `mli_coverage`, `file_length`, `magic_numbers`)
- [x] Pre-push ancestry verified — single commit on top of `main@origin` (#1107)

## New tests

- `Window_spec.Explicit`: 6 new — pass-through-in-input-order, train_period preservation when supplied, empty-list rejection, duplicate-name rejection, sexp round-trip Explicit, legacy flat-shape parses as Rolling.
- `Walk_forward_report.compute`: 5 new — per-variant stability (asserts mean/stdev/min/max numbers byte-equal on a 3-fold fixture), sensitivity excludes baseline, Pass verdict shape, baseline-label validation error, aggregate sexp round-trip.

## Deferred to PR-B (same plan file)

Plan §3-5: multi-metric sensitivity in markdown (4-col wins table), `cagr_pct` derived field in the binary, the two new fixture spec sexps (`cell-e-walk-forward-2026-05-08-harness/spec.sexp` regression fixture re-expressing the 8 hand-curated scenarios via `Window_spec.Explicit`, and `walk-forward-cell-e-30fold-2026-05-16/spec.sexp` production 30-fold).

## LOC

12 files changed, **+872 / -356 = net +516**. The +872 includes ~430 lines of test additions and the type-extraction churn (re-naming types-only references in `walk_forward_report` to point at `Walk_forward_types`). Source LOC delta net of tests is ~370.