### PR TITLE
feat(portfolio): margin accounting Phase 1 — flag-gated Reg-T short collateral + borrow fee

### DIFF
--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -193,7 +193,32 @@ Wire short-side entries into `Weinstein_strategy` so the simulation emits short 
      is currently unwired — placeholder for future RS-conditioned
      tuning.
 
-9. **#887 — Laggard rotation detector for capital recycling on the
+10. **#859 — Margin accounting Phase 1** (filed 2026-05-13 via
+    `dev/plans/short-side-margin-2026-05-13.md`; PR #1113 opened
+    2026-05-16). First of 5 PRs implementing Reg-T-style short-side
+    margin accounting. Adds `Margin_config.t` (enabled/initial_margin_pct
+    /maintenance_margin_pct/short_borrow_fee_annual_pct, default OFF) +
+    `Portfolio.locked_collateral` + `Portfolio.accrued_borrow_fee` +
+    new APIs `available_cash`, `apply_single_trade_with_margin`,
+    `apply_trades_with_margin`, `accrue_daily_borrow_fee`,
+    `check_maintenance_margin`, `sum_short_notional`. With the flag
+    off, all margin-aware APIs are bit-equal pass-throughs of the
+    legacy entry points — long-only goldens stay pinned. 21 new tests
+    pin flag-off bit-equality, initial collateral lock, maintenance
+    threshold boundaries (exactly-at-threshold, 1bp past), partial
+    cover proportional release, multi-year borrow fee math, and
+    sorted-output of flagged shorts. **Out of scope** in this PR:
+    `Portfolio_risk.compute_position_size` plumbing for `sizing_cash`
+    (deferred to a follow-up for review focus); simulator/strategy
+    wiring of the daily borrow-fee tick + maintenance-margin
+    force-cover (Phase 2 of the plan); `Weinstein_strategy_config`
+    flag plumbing (Phase 2). A1 watch-list note: change modifies
+    `trading/trading/portfolio/` but is strategy-agnostic — margin is
+    a broker-side concept that applies identically to any strategy
+    opening shorts. Default-off invariant is the load-bearing
+    mitigation.
+
+11. **#887 — Laggard rotation detector for capital recycling on the
    long side** (filed 2026-05-06, PR #909, `feat-weinstein` scope).
    Implements Weinstein Ch.4 §portfolio sizing rotation rule (book-ref
    §5.6): "if it's lagging badly and acting poorly, lighten up on that

--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -132,6 +132,8 @@ let _make_portfolio ~positions : Trading_portfolio.Portfolio.t =
     positions;
     accounting_method = Trading_portfolio.Types.AverageCost;
     unrealized_pnl_per_position = [];
+    locked_collateral = 0.0;
+    accrued_borrow_fee = 0.0;
   }
 
 (** Build a [step_result] with the supplied portfolio + splits_applied. The

--- a/trading/trading/portfolio/lib/dune
+++ b/trading/trading/portfolio/lib/dune
@@ -2,6 +2,6 @@
  (public_name trading.portfolio)
  (name trading_portfolio)
  (libraries core trading.base core_unix.time_ns_unix status)
- (modules types portfolio calculations split_event)
+ (modules types portfolio calculations split_event margin_config)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/portfolio/lib/margin_config.ml
+++ b/trading/trading/portfolio/lib/margin_config.ml
@@ -1,0 +1,35 @@
+(* Margin accounting configuration — see [.mli] for full contract.
+
+   The module exposes the parameters needed to model Reg-T-style short
+   selling. Numeric defaults below are named constants so the magic-number
+   linter is satisfied; downstream code should always read the parameters
+   from [t], never hardcode them. *)
+
+open Core
+
+type t = {
+  enabled : bool;
+  initial_margin_pct : float;
+  maintenance_margin_pct : float;
+  short_borrow_fee_annual_pct : float;
+}
+[@@deriving show, eq, sexp]
+
+let default_enabled = false
+let default_initial_margin_pct = 0.50
+let default_maintenance_margin_pct = 0.25
+let default_short_borrow_fee_annual_pct = 0.005
+let trading_days_per_year = 252.0
+
+let default_config =
+  {
+    enabled = default_enabled;
+    initial_margin_pct = default_initial_margin_pct;
+    maintenance_margin_pct = default_maintenance_margin_pct;
+    short_borrow_fee_annual_pct = default_short_borrow_fee_annual_pct;
+  }
+
+let total_collateral_factor (cfg : t) : float = 1.0 +. cfg.initial_margin_pct
+
+let daily_borrow_rate (cfg : t) : float =
+  cfg.short_borrow_fee_annual_pct /. trading_days_per_year

--- a/trading/trading/portfolio/lib/margin_config.mli
+++ b/trading/trading/portfolio/lib/margin_config.mli
@@ -1,0 +1,54 @@
+(** Margin accounting configuration (issue #859 Phase 1).
+
+    Captures the broker-side parameters needed to model Reg-T-style short
+    selling: initial collateral above-and-beyond proceeds, maintenance margin
+    threshold, and the daily borrow fee.
+
+    The [enabled] field is the master switch. When [enabled = false] (the
+    default), all margin-aware portfolio APIs are bit-equal no-ops: short
+    proceeds credit cash exactly as in the legacy Stance A semantics and no
+    collateral is locked, no fee accrues, no maintenance check fires.
+
+    The fields are intentionally strategy-agnostic — they describe broker
+    mechanics, not Weinstein-specific entry rules. Any strategy that opens short
+    positions in this simulator benefits from realistic margin modeling without
+    leaking strategy state into the portfolio layer.
+
+    Authority: [dev/plans/short-side-margin-2026-05-13.md] §1. *)
+
+type t = {
+  enabled : bool;  (** Master switch; default [false]. *)
+  initial_margin_pct : float;
+      (** Reg-T initial-margin requirement on top of short proceeds (default
+          [0.50] — i.e., 50% of notional locked alongside the proceeds, for a
+          total of 150% notional in collateral). *)
+  maintenance_margin_pct : float;
+      (** Maintenance equity ratio: when
+          [(entry_price * qty + initial_locked - current_price * qty) /
+           (current_price * qty) < maintenance_margin_pct] the position is
+          flagged for forced buy-to-cover (default [0.25]). *)
+  short_borrow_fee_annual_pct : float;
+      (** Annualized borrow fee charged on short notional (default [0.005] = 50
+          bps — liquid SP500 reference rate per issue #859). Accrued daily as
+          [notional * rate / trading_days_per_year]. *)
+}
+[@@deriving show, eq, sexp]
+
+val default_config : t
+(** Default config: margin off, 50% initial extra, 25% maintenance, 50bps annual
+    borrow fee. With [enabled = false] the other fields are dormant. *)
+
+val trading_days_per_year : float
+(** Conventional trading-day count (252) used to convert annual borrow fee to a
+    daily rate. Exposed so tests can pin expectations against the same constant
+    the production code uses. *)
+
+val total_collateral_factor : t -> float
+(** Total cash factor backing one unit of short notional, expressed as a
+    multiplier on [entry_price * qty]: [1.0 + initial_margin_pct]. With the
+    default [0.50] this is [1.50], i.e., 150% of notional ties up cash on a new
+    short entry (100% from the credited proceeds + 50% from existing cash). *)
+
+val daily_borrow_rate : t -> float
+(** Per-trading-day borrow rate:
+    [short_borrow_fee_annual_pct /. trading_days_per_year]. *)

--- a/trading/trading/portfolio/lib/portfolio.ml
+++ b/trading/trading/portfolio/lib/portfolio.ml
@@ -17,6 +17,14 @@ type t = {
       (* Mark-to-market state, sorted by symbol. Updated externally via
          mark_to_market; consumed by _check_sufficient_cash to compute the
          effective cash floor. *)
+  locked_collateral : cash_value;
+      (* Cash pledged against open shorts under Reg-T-style margin accounting
+         (issue #859 Phase 1). 0.0 under legacy Stance-A semantics; the
+         apply_*_with_margin APIs are the sole writers. *)
+  accrued_borrow_fee : cash_value;
+      (* Running total of borrow fees debited from current_cash. 0.0 unless
+         accrue_daily_borrow_fee has been called with Margin_config.enabled
+         = true. Audit-only field; not consumed by trading logic. *)
 }
 [@@deriving show, eq, sexp]
 
@@ -28,6 +36,8 @@ let create ?(accounting_method = AverageCost) ~initial_cash () =
     positions = [];
     accounting_method;
     unrealized_pnl_per_position = [];
+    locked_collateral = 0.0;
+    accrued_borrow_fee = 0.0;
   }
 
 let _find_position_in_list positions symbol =
@@ -466,3 +476,159 @@ let validate portfolio =
     ]
   in
   combine_status_list validations
+
+(* ========================================================================== *)
+(* Margin accounting (issue #859 Phase 1)                                     *)
+(* ========================================================================== *)
+
+(* available_cash = current_cash net of pledged short collateral. Strategy
+   code should read this rather than current_cash when sizing new entries. *)
+let available_cash portfolio =
+  portfolio.current_cash -. portfolio.locked_collateral
+
+(* Classify a Sell or Buy trade against the current position into one of four
+   margin-relevant cases. Phase 1 only treats opening short / closing short
+   specially; long-side cases pass straight through. *)
+type margin_trade_kind =
+  | Long_side (* Buy opening long, Sell closing long, etc. *)
+  | Short_open of float (* Sell opening / growing short; carries qty *)
+  | Short_close of float (* Buy reducing a short; carries closed-qty (>0) *)
+
+let _classify_trade portfolio (trade : Trading_base.Types.trade) :
+    margin_trade_kind =
+  let existing_qty =
+    match get_position portfolio trade.symbol with
+    | None -> 0.0
+    | Some p -> Calculations.position_quantity p
+  in
+  match trade.side with
+  | Sell when Float.O.(existing_qty <= 0.0) ->
+      (* Selling into a flat or already-short position grows the short. *)
+      Short_open trade.quantity
+  | Buy when Float.O.(existing_qty < 0.0) ->
+      (* Buying covers part or all of a short. closed_qty is bounded by the
+         existing short size so an over-cover that flips long is split:
+         the short-close portion releases collateral here; the new-long
+         portion is regular long-side accounting (no collateral change). *)
+      let closed = Float.min trade.quantity (Float.abs existing_qty) in
+      Short_close closed
+  | _ -> Long_side
+
+(* Total collateral required for a new short of [qty] shares at [price]:
+   (1.0 + initial_margin_pct) * qty * price. *)
+let _initial_collateral_for_short ~(margin_config : Margin_config.t) ~price ~qty
+    : cash_value =
+  Margin_config.total_collateral_factor margin_config *. price *. qty
+
+(* Release a proportional share of the locked collateral when covering. The
+   portfolio tracks one aggregate [locked_collateral] number rather than
+   per-symbol locks (sufficient for Phase 1 — the locked amount on each
+   symbol is implicit in its position's avg_cost). *)
+let _collateral_release_on_cover ~(margin_config : Margin_config.t) ~closed_qty
+    ~(existing_avg_cost : float) : cash_value =
+  let factor = Margin_config.total_collateral_factor margin_config in
+  (* Released = factor * closed_qty * avg_entry_cost. Using the position's
+     own avg cost (not the cover trade's price) keeps the release symmetric
+     with the lock at entry. *)
+  factor *. closed_qty *. existing_avg_cost
+
+let _existing_avg_cost portfolio symbol : float =
+  match get_position portfolio symbol with
+  | None -> 0.0
+  | Some p -> Calculations.avg_cost_of_position p
+
+(* Apply margin-mode side-effects on top of the base [apply_single_trade]
+   result. Called only when [margin_config.enabled = true]. *)
+let _apply_margin_effects ~(margin_config : Margin_config.t) ~portfolio_before
+    ~(portfolio_after : t) (trade : Trading_base.Types.trade) : t status_or =
+  match _classify_trade portfolio_before trade with
+  | Long_side -> return portfolio_after
+  | Short_open qty ->
+      let lock =
+        _initial_collateral_for_short ~margin_config ~price:trade.price ~qty
+      in
+      let new_locked = portfolio_after.locked_collateral +. lock in
+      let new_available = portfolio_after.current_cash -. new_locked in
+      if Float.O.(new_available < 0.0) then
+        error_invalid_argument
+          ("Insufficient cash for short collateral. Required lock: "
+         ^ Float.to_string lock ^ ", available_cash before: "
+          ^ Float.to_string (available_cash portfolio_after))
+      else return { portfolio_after with locked_collateral = new_locked }
+  | Short_close closed_qty ->
+      let avg_cost = _existing_avg_cost portfolio_before trade.symbol in
+      let release =
+        _collateral_release_on_cover ~margin_config ~closed_qty
+          ~existing_avg_cost:avg_cost
+      in
+      (* Guard against floating-point drift pushing locked below 0. *)
+      let new_locked =
+        Float.max 0.0 (portfolio_after.locked_collateral -. release)
+      in
+      return { portfolio_after with locked_collateral = new_locked }
+
+let apply_single_trade_with_margin ~(margin_config : Margin_config.t)
+    (portfolio : t) (trade : Trading_base.Types.trade) : t status_or =
+  if not margin_config.enabled then apply_single_trade portfolio trade
+  else
+    let%bind portfolio_after = apply_single_trade portfolio trade in
+    _apply_margin_effects ~margin_config ~portfolio_before:portfolio
+      ~portfolio_after trade
+
+let apply_trades_with_margin ~margin_config portfolio trades =
+  List.fold_result trades ~init:portfolio
+    ~f:(apply_single_trade_with_margin ~margin_config)
+
+(* Sum |qty * price| across short positions present in the price list. *)
+let sum_short_notional portfolio market_prices : float =
+  let price_map = Map.of_alist_exn (module String) market_prices in
+  List.fold portfolio.positions ~init:0.0 ~f:(fun acc p ->
+      let qty = Calculations.position_quantity p in
+      if Float.O.(qty < 0.0) then
+        match Map.find price_map p.symbol with
+        | None -> acc
+        | Some price -> acc +. (Float.abs qty *. price)
+      else acc)
+
+let accrue_daily_borrow_fee ~(margin_config : Margin_config.t) (portfolio : t)
+    (market_prices : (symbol * price) list) : t =
+  if not margin_config.enabled then portfolio
+  else
+    let notional = sum_short_notional portfolio market_prices in
+    let fee = notional *. Margin_config.daily_borrow_rate margin_config in
+    {
+      portfolio with
+      current_cash = portfolio.current_cash -. fee;
+      accrued_borrow_fee = portfolio.accrued_borrow_fee +. fee;
+    }
+
+(* Equity ratio for a short position whose qty is negative.
+   See [.mli] for the derivation: equity_ratio = ((1+im) c0 - p) / p. *)
+let _short_equity_ratio ~(margin_config : Margin_config.t)
+    ~(entry_avg_cost : float) ~(current_price : float) : float =
+  if Float.O.(current_price <= 0.0) then Float.infinity
+  else
+    let factor = Margin_config.total_collateral_factor margin_config in
+    ((factor *. entry_avg_cost) -. current_price) /. current_price
+
+let check_maintenance_margin ~(margin_config : Margin_config.t) (portfolio : t)
+    (market_prices : (symbol * price) list) : symbol list =
+  if not margin_config.enabled then []
+  else
+    let price_map = Map.of_alist_exn (module String) market_prices in
+    List.filter_map portfolio.positions ~f:(fun p ->
+        let qty = Calculations.position_quantity p in
+        if Float.O.(qty >= 0.0) then None
+        else
+          match Map.find price_map p.symbol with
+          | None -> None
+          | Some price ->
+              let entry_avg_cost = Calculations.avg_cost_of_position p in
+              let ratio =
+                _short_equity_ratio ~margin_config ~entry_avg_cost
+                  ~current_price:price
+              in
+              if Float.O.(ratio < margin_config.maintenance_margin_pct) then
+                Some p.symbol
+              else None)
+    |> List.sort ~compare:String.compare

--- a/trading/trading/portfolio/lib/portfolio.mli
+++ b/trading/trading/portfolio/lib/portfolio.mli
@@ -11,6 +11,8 @@ type t = {
   positions : portfolio_position list;
   accounting_method : accounting_method;
   unrealized_pnl_per_position : (symbol * float) list;
+  locked_collateral : cash_value;
+  accrued_borrow_fee : cash_value;
 }
 [@@deriving show, eq, sexp]
 (** Portfolio type. All fields are accessible for pattern matching and direct
@@ -33,7 +35,18 @@ type t = {
       sorted by symbol. Updated by [mark_to_market]; consumed by
       [apply_single_trade] when computing the effective cash floor. Empty when
       the portfolio has never been marked, or for positions with no market price
-      feed. *)
+      feed.
+    - [locked_collateral]: Cash pledged against open short positions under
+      Reg-T-style margin accounting (issue #859 Phase 1). [0.0] under the legacy
+      Stance-A semantics and whenever [Margin_config.enabled = false].
+      Maintained by the margin-aware APIs ([apply_single_trade_with_margin],
+      [apply_trades_with_margin]); the [available_cash] helper exposes
+      [current_cash -. locked_collateral] as the spendable balance.
+    - [accrued_borrow_fee]: Running total of borrow fees deducted from
+      [current_cash] over the portfolio's lifetime (issue #859 Phase 1). [0.0]
+      unless [Margin_config.enabled = true] and [accrue_daily_borrow_fee] has
+      been called. Exposed for audit reporting and tests — not consumed by
+      trading logic. *)
 
 val create :
   ?accounting_method:accounting_method -> initial_cash:cash_value -> unit -> t
@@ -91,5 +104,98 @@ val validate : t -> status
 (** Validate internal consistency by reconstructing portfolio from initial_cash
     and trade_history, then comparing with stored state. Should always succeed
     for portfolios created via [create] and modified via [apply_trades]. The
-    [unrealized_pnl_per_position] field is mark-to-market state, not derivable
-    from trade history alone, so it is excluded from this check. *)
+    [unrealized_pnl_per_position], [locked_collateral], and [accrued_borrow_fee]
+    fields are mark-to-market / margin-mode state, not derivable from trade
+    history alone, so they are excluded from this check. *)
+
+(** {1 Margin accounting (issue #859 Phase 1)}
+
+    Strict-broker semantics for short selling: collateral pre-locked at short
+    entry, refunded on cover, plus a daily borrow-fee debit. Gated behind
+    [Margin_config.enabled]. When the flag is [false], every API in this section
+    is a bit-equal pass-through to the corresponding legacy entry point — no
+    field outside [unrealized_pnl_per_position] is touched. *)
+
+val available_cash : t -> cash_value
+(** Spendable cash net of locked short collateral:
+    [current_cash -. locked_collateral]. Equals [current_cash] under the legacy
+    semantics (where [locked_collateral = 0.0]). Strategy code that needs to
+    size new entries against actually-spendable cash should consume this rather
+    than [current_cash] directly. *)
+
+val apply_single_trade_with_margin :
+  margin_config:Margin_config.t -> t -> trade -> t status_or
+(** Margin-aware single-trade application.
+
+    {b When [margin_config.enabled = false]}: bit-equal to [apply_single_trade].
+    [locked_collateral] and [accrued_borrow_fee] are untouched.
+
+    {b When [margin_config.enabled = true]}:
+    - {b Opening a short} (Sell adding to a flat / short position): credits
+      proceeds to [current_cash] as usual, then locks
+      [(1.0 +. initial_margin_pct) *. (price *. quantity)] of cash into
+      [locked_collateral]. The cash floor check uses [available_cash] rather
+      than [current_cash], so an opening short that cannot meet the collateral
+      requirement is rejected with an [error_invalid_argument].
+    - {b Closing a short} (Buy reducing a short position): debits the cover cash
+      as usual, then releases collateral proportional to the fraction of the
+      short closed: [released = factor *. closed_qty *. existing_avg_cost].
+      Per-symbol locked amounts are tracked implicitly through total
+      [locked_collateral] under the Phase 1 design — the entry locks at cost
+      basis, the cover releases at the same proportional fraction.
+    - {b Long-side trades} (Buy opening / adding to long, Sell closing long):
+      identical to [apply_single_trade]. [locked_collateral] unchanged.
+
+    The function is the only writer of [locked_collateral]; all other portfolio
+    APIs leave it alone. *)
+
+val apply_trades_with_margin :
+  margin_config:Margin_config.t -> t -> trade list -> t status_or
+(** Margin-aware batch trade application. Folds [apply_single_trade_with_margin]
+    over the list; returns Error on the first rejection. *)
+
+val accrue_daily_borrow_fee :
+  margin_config:Margin_config.t -> t -> (symbol * price) list -> t
+(** Debit one trading day of borrow fee from [current_cash] and add it to
+    [accrued_borrow_fee]. No-op when [margin_config.enabled = false] or when the
+    portfolio holds no short positions.
+
+    The fee is computed against current marked notional:
+    [sum_of_short_notional *. daily_borrow_rate], where
+    [daily_borrow_rate = short_borrow_fee_annual_pct /. trading_days_per_year]
+    (see {!Margin_config.daily_borrow_rate}). Symbols missing from the price
+    list are treated as zero-fee (the caller is expected to mark every short on
+    each trading-day tick — same convention as [mark_to_market]). *)
+
+val sum_short_notional : t -> (symbol * price) list -> float
+(** Sum of [|qty *. price|] across all currently-open short positions whose
+    symbol appears in the price list. Pure helper exposed for tests and for
+    callers that need notional for sizing checks. *)
+
+val check_maintenance_margin :
+  margin_config:Margin_config.t -> t -> (symbol * price) list -> symbol list
+(** Identify short positions whose equity ratio has fallen below the
+    [maintenance_margin_pct] threshold. Returns the symbols (sorted) that should
+    be forcibly covered by the caller's risk-management layer.
+
+    For each short of [qty] shares at entry-avg-cost [c0] now marked at [p],
+    total cash backing the position is
+    [(1.0 +. initial_margin_pct) *. c0 *. qty]; the cover liability is
+    [p *. qty]; equity is the difference, and equity_ratio is:
+    {[
+    equity_ratio = (((1.0 +. initial_margin_pct) *. c0) -. p) /. p
+    ]}
+    A position is flagged when
+    [equity_ratio < margin_config.maintenance_margin_pct].
+
+    Equivalent trigger price:
+    [p_trigger = c0 *. (1.0 +. initial_margin_pct) /. (1.0 +.
+     maintenance_margin_pct)]. With the defaults (0.50 / 0.25) this is
+    [p_trigger = 1.2 *. c0], i.e., a 20% adverse move on the short.
+
+    Returns the empty list when [margin_config.enabled = false], when there are
+    no short positions, or when no shorts breach the threshold.
+
+    {b Note}: the function is a pure check — it does not mutate the portfolio or
+    fire any trade. The caller (strategy / simulator) is responsible for routing
+    flagged symbols through the standard force-cover audit path. *)

--- a/trading/trading/portfolio/test/dune
+++ b/trading/trading/portfolio/test/dune
@@ -11,3 +11,14 @@
  (libraries ounit2 trading.portfolio trading.base matchers)
  (preprocess
   (pps ppx_test_matcher)))
+
+(test
+ (name test_margin_accounting)
+ (libraries
+  core
+  core_unix.time_ns_unix
+  ounit2
+  trading.portfolio
+  trading.base
+  status
+  matchers))

--- a/trading/trading/portfolio/test/test_margin_accounting.ml
+++ b/trading/trading/portfolio/test/test_margin_accounting.ml
@@ -1,0 +1,512 @@
+(* Tests for margin accounting Phase 1 (issue #859).
+
+   Covers four behavioural surfaces:
+   - flag-off bit-equality: apply_*_with_margin under default config is a
+     pass-through of apply_single_trade / apply_trades
+   - flag-on initial collateral lock on short entry + release on cover
+   - flag-on borrow-fee accrual
+   - flag-on maintenance-margin threshold (boundary + breach + no-trigger)
+
+   The flag-off regression is the load-bearing invariant: enabling this
+   work behind a config flag must not perturb any existing baseline. *)
+
+open Core
+open OUnit2
+open Trading_base.Types
+open Trading_portfolio.Portfolio
+module Margin_config = Trading_portfolio.Margin_config
+open Matchers
+
+(* Test data builder — mirrors the one in test_portfolio.ml. Kept inline
+   per .claude/rules/test-patterns.md (simple constructors stay in test
+   files). *)
+let make_trade ~id ~order_id ~symbol ~side ~quantity ~price ?(commission = 0.0)
+    () =
+  {
+    id;
+    order_id;
+    symbol;
+    side;
+    quantity;
+    price;
+    commission;
+    timestamp = Time_ns_unix.now ();
+  }
+
+(* Domain helper: Ok-or-fail for setup paths that should never fail. *)
+let apply_trades_with_margin_exn portfolio trades ~margin_config ~error_msg =
+  match apply_trades_with_margin ~margin_config portfolio trades with
+  | Ok value -> value
+  | Error err -> assert_failure (error_msg ^ ": " ^ Status.show err)
+
+let apply_trades_exn portfolio trades ~error_msg =
+  match apply_trades portfolio trades with
+  | Ok value -> value
+  | Error err -> assert_failure (error_msg ^ ": " ^ Status.show err)
+
+(* ========================================================================== *)
+(* Flag-off bit-equality regression                                           *)
+(* ========================================================================== *)
+
+(* The single most important guarantee: with [enabled = false], all
+   margin-aware APIs collapse to no-ops that produce portfolios bit-equal
+   to the legacy entry points. This is what lets us land this change
+   without re-pinning every long-only golden. *)
+
+let test_flag_off_short_entry_matches_legacy _ =
+  let cash = 10_000.0 in
+  let trades =
+    [
+      make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+        ~quantity:100.0 ~price:50.0 ();
+    ]
+  in
+  let legacy =
+    apply_trades_exn
+      (create ~initial_cash:cash ())
+      trades ~error_msg:"legacy short entry"
+  in
+  assert_that
+    (apply_trades_with_margin ~margin_config:Margin_config.default_config
+       (create ~initial_cash:cash ())
+       trades)
+    (is_ok_and_holds (equal_to (legacy : t)))
+
+let test_flag_off_long_only_sequence_bit_equal _ =
+  (* Run a multi-trade long-only sequence through both code paths and
+     assert bit-equal final portfolios. This is the regression that
+     guards every long-only golden. *)
+  let cash = 100_000.0 in
+  let trades =
+    [
+      make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Buy
+        ~quantity:100.0 ~price:150.0 ~commission:1.0 ();
+      make_trade ~id:"t2" ~order_id:"o2" ~symbol:"MSFT" ~side:Buy ~quantity:50.0
+        ~price:200.0 ~commission:1.0 ();
+      make_trade ~id:"t3" ~order_id:"o3" ~symbol:"AAPL" ~side:Sell
+        ~quantity:30.0 ~price:160.0 ~commission:1.0 ();
+      make_trade ~id:"t4" ~order_id:"o4" ~symbol:"MSFT" ~side:Sell
+        ~quantity:50.0 ~price:220.0 ~commission:1.0 ();
+    ]
+  in
+  let legacy =
+    apply_trades_exn (create ~initial_cash:cash ()) trades ~error_msg:"legacy"
+  in
+  assert_that
+    (apply_trades_with_margin ~margin_config:Margin_config.default_config
+       (create ~initial_cash:cash ())
+       trades)
+    (is_ok_and_holds (equal_to (legacy : t)))
+
+let test_flag_off_borrow_fee_is_noop _ =
+  let portfolio =
+    apply_trades_exn
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"short entry"
+  in
+  let after_fee =
+    accrue_daily_borrow_fee ~margin_config:Margin_config.default_config
+      portfolio
+      [ ("AAPL", 60.0) ]
+  in
+  assert_that after_fee (equal_to (portfolio : t))
+
+let test_flag_off_maintenance_check_returns_empty _ =
+  let portfolio =
+    apply_trades_exn
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"short entry"
+  in
+  (* Even with the price moved well past the would-be trigger, no symbols
+     are flagged because the flag is off. *)
+  assert_that
+    (check_maintenance_margin ~margin_config:Margin_config.default_config
+       portfolio
+       [ ("AAPL", 100.0) ])
+    (elements_are [])
+
+(* ========================================================================== *)
+(* Flag-on: initial collateral lock on short entry                            *)
+(* ========================================================================== *)
+
+let on_config =
+  { Margin_config.default_config with Margin_config.enabled = true }
+
+let test_short_entry_locks_collateral _ =
+  (* 100 shares @ $50, notional $5000. With initial_margin_pct=0.50, total
+     collateral = 1.5 * 5000 = $7500. current_cash credits proceeds as
+     usual (+$5000); available_cash = 10000 + 5000 - 7500 = $7500. *)
+  let portfolio = create ~initial_cash:10_000.0 () in
+  let trade =
+    make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell ~quantity:100.0
+      ~price:50.0 ()
+  in
+  assert_that
+    (apply_single_trade_with_margin ~margin_config:on_config portfolio trade)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun p -> p.current_cash) (float_equal 15_000.0);
+            field (fun p -> p.locked_collateral) (float_equal 7_500.0);
+            field (fun p -> available_cash p) (float_equal 7_500.0);
+          ]))
+
+let test_short_entry_rejected_when_insufficient_collateral _ =
+  (* 100 shares @ $50, notional $5000, collateral 7500. Cash $5000 means
+     after proceeds = $10000, but lock would be $7500, leaving only $2500
+     of available cash — still positive, so accept. Bump to a tighter
+     case: cash $1000 → after proceeds = $6000, lock $7500 → available
+     -$1500 < 0 → reject. *)
+  let portfolio = create ~initial_cash:1_000.0 () in
+  let trade =
+    make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell ~quantity:100.0
+      ~price:50.0 ()
+  in
+  assert_that
+    (apply_single_trade_with_margin ~margin_config:on_config portfolio trade)
+    is_error
+
+let test_short_cover_releases_collateral _ =
+  (* Open short 100 @ $50 (lock $7500), then cover all 100 @ $50.
+     Cover cash change: -5000. Released collateral: factor * 100 * 50 =
+     1.5 * 5000 = $7500. Final: current_cash = 10000, locked = 0. *)
+  let portfolio = create ~initial_cash:10_000.0 () in
+  let trades =
+    [
+      make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+        ~quantity:100.0 ~price:50.0 ();
+      make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAPL" ~side:Buy
+        ~quantity:100.0 ~price:50.0 ();
+    ]
+  in
+  assert_that
+    (apply_trades_with_margin ~margin_config:on_config portfolio trades)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun p -> p.current_cash) (float_equal 10_000.0);
+            field (fun p -> p.locked_collateral) (float_equal 0.0);
+          ]))
+
+let test_short_partial_cover_releases_proportional_collateral _ =
+  (* Open short 100 @ $50 (lock $7500), then cover 40 @ $50.
+     Released: 1.5 * 40 * 50 = $3000. Final locked = $4500.
+     Cash: 10000 + 5000 - 2000 = $13000. *)
+  let portfolio = create ~initial_cash:10_000.0 () in
+  let trades =
+    [
+      make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+        ~quantity:100.0 ~price:50.0 ();
+      make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAPL" ~side:Buy ~quantity:40.0
+        ~price:50.0 ();
+    ]
+  in
+  assert_that
+    (apply_trades_with_margin ~margin_config:on_config portfolio trades)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun p -> p.current_cash) (float_equal 13_000.0);
+            field (fun p -> p.locked_collateral) (float_equal 4_500.0);
+          ]))
+
+let test_long_trade_under_margin_on_does_not_lock _ =
+  (* Buy of 100 @ $50: pure long entry, no collateral changes. Confirms
+     classification routes correctly when margin is on. *)
+  let portfolio = create ~initial_cash:10_000.0 () in
+  let trade =
+    make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Buy ~quantity:100.0
+      ~price:50.0 ()
+  in
+  assert_that
+    (apply_single_trade_with_margin ~margin_config:on_config portfolio trade)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun p -> p.current_cash) (float_equal 5_000.0);
+            field (fun p -> p.locked_collateral) (float_equal 0.0);
+          ]))
+
+(* ========================================================================== *)
+(* Flag-on: maintenance margin breach                                         *)
+(* ========================================================================== *)
+
+(* With defaults im=0.50, mm=0.25, trigger price for short at entry $50:
+     p_trigger = 50 * 1.50 / 1.25 = $60.
+   At price < $60 the ratio is >= 0.25 → no trigger.
+   At price = $60 the ratio is exactly 0.25 (borderline → no trigger because
+     the rule is strict-less-than).
+   At price > $60 (even by a cent) the ratio is < 0.25 → trigger. *)
+
+let test_maintenance_breach_far_past_trigger _ =
+  let portfolio =
+    apply_trades_with_margin_exn ~margin_config:on_config
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"short entry"
+  in
+  assert_that
+    (check_maintenance_margin ~margin_config:on_config portfolio
+       [ ("AAPL", 70.0) ])
+    (elements_are [ equal_to "AAPL" ])
+
+let test_maintenance_at_threshold_no_trigger _ =
+  (* Exactly at the trigger price → ratio = maintenance_margin_pct.
+     Rule is strict less-than, so this must NOT fire. *)
+  let portfolio =
+    apply_trades_with_margin_exn ~margin_config:on_config
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"short entry"
+  in
+  assert_that
+    (check_maintenance_margin ~margin_config:on_config portfolio
+       [ ("AAPL", 60.0) ])
+    (elements_are [])
+
+let test_maintenance_one_bp_above_threshold_triggers _ =
+  (* Just past the trigger by 1 bp ($60.006) → ratio dips below 0.25,
+     symbol flagged. *)
+  let portfolio =
+    apply_trades_with_margin_exn ~margin_config:on_config
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"short entry"
+  in
+  assert_that
+    (check_maintenance_margin ~margin_config:on_config portfolio
+       [ ("AAPL", 60.006) ])
+    (elements_are [ equal_to "AAPL" ])
+
+let test_maintenance_well_below_trigger_no_flag _ =
+  (* Price moved against entry but still inside the cushion. *)
+  let portfolio =
+    apply_trades_with_margin_exn ~margin_config:on_config
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"short entry"
+  in
+  assert_that
+    (check_maintenance_margin ~margin_config:on_config portfolio
+       [ ("AAPL", 55.0) ])
+    (elements_are [])
+
+let test_maintenance_long_position_ignored _ =
+  (* Maintenance margin applies only to shorts. A long position is
+     never returned by check_maintenance_margin even if its price has
+     halved. *)
+  let portfolio =
+    apply_trades_exn
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Buy
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"long entry"
+  in
+  assert_that
+    (check_maintenance_margin ~margin_config:on_config portfolio
+       [ ("AAPL", 1.0) ])
+    (elements_are [])
+
+let test_maintenance_check_sorts_flagged_symbols _ =
+  (* Two shorts both breach — the returned list should be sorted by
+     symbol so downstream audit ordering is deterministic. *)
+  let portfolio =
+    apply_trades_with_margin_exn ~margin_config:on_config
+      (create ~initial_cash:30_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"ZZZ" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+        make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAA" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"two shorts"
+  in
+  assert_that
+    (check_maintenance_margin ~margin_config:on_config portfolio
+       [ ("AAA", 70.0); ("ZZZ", 70.0) ])
+    (elements_are [ equal_to "AAA"; equal_to "ZZZ" ])
+
+(* ========================================================================== *)
+(* Flag-on: daily borrow-fee accrual                                          *)
+(* ========================================================================== *)
+
+(* Default config: 50 bps annual, 252 trading days → daily rate ≈
+   1.984e-5. On 100 shares short at $50 (notional $5000), one day of fee =
+   5000 * (0.005 / 252) ≈ $0.0992. *)
+
+let _expected_daily_fee notional cfg =
+  notional *. Margin_config.daily_borrow_rate cfg
+
+let test_borrow_fee_single_day _ =
+  let portfolio =
+    apply_trades_with_margin_exn ~margin_config:on_config
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"short entry"
+  in
+  let prices = [ ("AAPL", 50.0) ] in
+  let expected_fee = _expected_daily_fee 5_000.0 on_config in
+  let after =
+    accrue_daily_borrow_fee ~margin_config:on_config portfolio prices
+  in
+  assert_that after
+    (all_of
+       [
+         field
+           (fun p -> p.current_cash)
+           (float_equal (portfolio.current_cash -. expected_fee));
+         field (fun p -> p.accrued_borrow_fee) (float_equal expected_fee);
+       ])
+
+let test_borrow_fee_one_trading_year _ =
+  (* Accruing 252 daily fees at constant notional should sum to almost
+     exactly the annual rate * notional. *)
+  let cfg = on_config in
+  let entry_price = 50.0 in
+  let qty = 100.0 in
+  let notional = entry_price *. qty in
+  let portfolio =
+    apply_trades_with_margin_exn ~margin_config:cfg
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:qty ~price:entry_price ();
+      ]
+      ~error_msg:"short entry"
+  in
+  let prices = [ ("AAPL", entry_price) ] in
+  let n_days = Float.to_int Margin_config.trading_days_per_year in
+  let final =
+    List.init n_days ~f:(fun _ -> ())
+    |> List.fold ~init:portfolio ~f:(fun acc () ->
+        accrue_daily_borrow_fee ~margin_config:cfg acc prices)
+  in
+  let expected_total = notional *. cfg.short_borrow_fee_annual_pct in
+  assert_that final.accrued_borrow_fee
+    (float_equal ~epsilon:1e-9 expected_total)
+
+let test_borrow_fee_zero_when_no_shorts _ =
+  let portfolio =
+    apply_trades_exn
+      (create ~initial_cash:10_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Buy
+          ~quantity:50.0 ~price:50.0 ();
+      ]
+      ~error_msg:"long entry"
+  in
+  let after =
+    accrue_daily_borrow_fee ~margin_config:on_config portfolio
+      [ ("AAPL", 50.0) ]
+  in
+  assert_that after
+    (all_of
+       [
+         field (fun p -> p.current_cash) (float_equal portfolio.current_cash);
+         field (fun p -> p.accrued_borrow_fee) (float_equal 0.0);
+       ])
+
+let test_sum_short_notional_combines_positions _ =
+  let portfolio =
+    apply_trades_with_margin_exn ~margin_config:on_config
+      (create ~initial_cash:30_000.0 ())
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+        make_trade ~id:"t2" ~order_id:"o2" ~symbol:"MSFT" ~side:Sell
+          ~quantity:50.0 ~price:100.0 ();
+      ]
+      ~error_msg:"two shorts"
+  in
+  (* AAPL marked $60: 100 * 60 = 6000. MSFT marked $110: 50 * 110 = 5500.
+     Total: 11500. *)
+  assert_that
+    (sum_short_notional portfolio [ ("AAPL", 60.0); ("MSFT", 110.0) ])
+    (float_equal 11_500.0)
+
+(* ========================================================================== *)
+(* Default config sanity                                                      *)
+(* ========================================================================== *)
+
+let test_default_config_is_disabled _ =
+  assert_that Margin_config.default_config.enabled (equal_to false)
+
+let test_default_config_factor_matches_book _ =
+  (* Default initial_margin_pct = 0.50 → factor = 1.50. *)
+  assert_that
+    (Margin_config.total_collateral_factor Margin_config.default_config)
+    (float_equal 1.5)
+
+(* ========================================================================== *)
+(* Test suite                                                                 *)
+(* ========================================================================== *)
+
+let suite =
+  "test_margin_accounting"
+  >::: [
+         "test_flag_off_short_entry_matches_legacy"
+         >:: test_flag_off_short_entry_matches_legacy;
+         "test_flag_off_long_only_sequence_bit_equal"
+         >:: test_flag_off_long_only_sequence_bit_equal;
+         "test_flag_off_borrow_fee_is_noop" >:: test_flag_off_borrow_fee_is_noop;
+         "test_flag_off_maintenance_check_returns_empty"
+         >:: test_flag_off_maintenance_check_returns_empty;
+         "test_short_entry_locks_collateral"
+         >:: test_short_entry_locks_collateral;
+         "test_short_entry_rejected_when_insufficient_collateral"
+         >:: test_short_entry_rejected_when_insufficient_collateral;
+         "test_short_cover_releases_collateral"
+         >:: test_short_cover_releases_collateral;
+         "test_short_partial_cover_releases_proportional_collateral"
+         >:: test_short_partial_cover_releases_proportional_collateral;
+         "test_long_trade_under_margin_on_does_not_lock"
+         >:: test_long_trade_under_margin_on_does_not_lock;
+         "test_maintenance_breach_far_past_trigger"
+         >:: test_maintenance_breach_far_past_trigger;
+         "test_maintenance_at_threshold_no_trigger"
+         >:: test_maintenance_at_threshold_no_trigger;
+         "test_maintenance_one_bp_above_threshold_triggers"
+         >:: test_maintenance_one_bp_above_threshold_triggers;
+         "test_maintenance_well_below_trigger_no_flag"
+         >:: test_maintenance_well_below_trigger_no_flag;
+         "test_maintenance_long_position_ignored"
+         >:: test_maintenance_long_position_ignored;
+         "test_maintenance_check_sorts_flagged_symbols"
+         >:: test_maintenance_check_sorts_flagged_symbols;
+         "test_borrow_fee_single_day" >:: test_borrow_fee_single_day;
+         "test_borrow_fee_one_trading_year" >:: test_borrow_fee_one_trading_year;
+         "test_borrow_fee_zero_when_no_shorts"
+         >:: test_borrow_fee_zero_when_no_shorts;
+         "test_sum_short_notional_combines_positions"
+         >:: test_sum_short_notional_combines_positions;
+         "test_default_config_is_disabled" >:: test_default_config_is_disabled;
+         "test_default_config_factor_matches_book"
+         >:: test_default_config_factor_matches_book;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/portfolio/test/test_portfolio.ml
+++ b/trading/trading/portfolio/test/test_portfolio.ml
@@ -40,6 +40,8 @@ let test_create_portfolio _ accounting_method =
       positions = [];
       accounting_method;
       unrealized_pnl_per_position = [];
+      locked_collateral = 0.0;
+      accrued_borrow_fee = 0.0;
     }
   in
   assert_equal expected portfolio ~msg:"Portfolio should match expected state"


### PR DESCRIPTION
## Summary

First of five PRs from `dev/plans/short-side-margin-2026-05-13.md` (issue #859). Adds Reg-T-style margin accounting to `Portfolio.t` under a default-off `Margin_config.enabled` flag. With the flag off, every margin-aware API is a bit-equal pass-through of the legacy entry points — long-only goldens stay pinned without re-pinning.

Three concepts wired:

- **Initial collateral lock** on short entry: `(1.0 + initial_margin_pct) * notional` of cash is pledged into `Portfolio.locked_collateral`. Default `initial_margin_pct = 0.50` ⇒ 150% notional total (proceeds + extra 50% from existing cash).
- **Maintenance margin check**: `Portfolio.check_maintenance_margin` returns the symbols whose equity ratio has fallen below `maintenance_margin_pct` (default 0.25). With defaults this fires at `1.2 × entry_price` — a 20% adverse move on the short. Pure check; caller wires the buy-to-cover.
- **Daily borrow fee** debit: `Portfolio.accrue_daily_borrow_fee` deducts `notional * (annual_pct / 252)` from `current_cash` and adds it to `accrued_borrow_fee`. Default `short_borrow_fee_annual_pct = 0.005` (50 bps liquid SP500).

New seam: `Portfolio.available_cash = current_cash - locked_collateral`. Strategy code that needs spendable cash should consume this — but the existing `Portfolio_risk.compute_position_size` is **not** wired through in this PR (deferred to a follow-up; the prompt's `sizing_cash` plumbing is split out for review focus).

## A1 watch-list note (qc-structural / qc-behavioral)

This PR modifies `trading/trading/portfolio/`, which is on the qc-structural A1 watch-list. The change is unavoidable — cash and collateral accounting live in `Portfolio.t`. Per `dev/plans/short-side-margin-2026-05-13.md` §1.3, the change is **strategy-agnostic**: margin is a broker concept, not Weinstein-specific. The new `locked_collateral` / `accrued_borrow_fee` fields, the `Margin_config.t` record, and the maintenance-margin trigger are all broker-level abstractions that apply identically to a momentum, mean-reversion, or pairs strategy.

The default-off invariant is the load-bearing mitigation: with `enable_margin_accounting = false` (default), behavior is bit-identical to today's Stance-A semantics. Strategy / simulator integration (Phase 2 in the plan) is out of scope here.

## Test plan

- [x] `dune build && dune runtest && dune build @fmt` clean inside docker (`trading-1-dev`)
- [x] 21 new tests in `test_margin_accounting.ml`:
  - Flag-off bit-equality: short entry, multi-trade long sequence, borrow-fee no-op, maintenance-check returns empty
  - Flag-on initial collateral: lock on short entry; cover releases proportional collateral; insufficient-collateral rejection; long trade under margin-on does not lock
  - Maintenance margin: boundary tests (1bp past threshold triggers; exactly at threshold does NOT trigger), well-below-trigger no flag, long positions ignored, sorted output
  - Borrow fee: single-day math, 252-day annual sum, zero-fee on long-only, multi-position notional sum
  - Default config sanity: disabled, 1.5 factor
- [x] All 45 pre-existing `test_portfolio.ml` cases still pass with new fields
- [x] Full repo `dune runtest` green (magic-numbers linter clean, fn-length linter clean)

## Files changed

- `trading/trading/portfolio/lib/margin_config.{ml,mli}` (new) — config record + defaults + `daily_borrow_rate` / `total_collateral_factor` helpers
- `trading/trading/portfolio/lib/portfolio.{ml,mli}` — two new fields on `Portfolio.t`; `available_cash`, `apply_single_trade_with_margin`, `apply_trades_with_margin`, `accrue_daily_borrow_fee`, `check_maintenance_margin`, `sum_short_notional`
- `trading/trading/portfolio/lib/dune` — register `margin_config` module
- `trading/trading/portfolio/test/test_margin_accounting.ml` (new) — 21 tests
- `trading/trading/portfolio/test/dune` — register new test
- `trading/trading/portfolio/test/test_portfolio.ml`, `trading/trading/backtest/test/test_result_writer.ml` — add `locked_collateral = 0.0; accrued_borrow_fee = 0.0` to the two existing literal `Portfolio.t` constructions

## Out of scope (follow-ups)

- `Portfolio_risk.compute_position_size` plumbing for `sizing_cash` (deferred — needs caller updates in `entry_audit_capture` and is reviewable independently)
- Simulator / strategy wiring (daily borrow-fee tick, force-cover routing through audit) — Phase 2 of the plan
- `Weinstein_strategy_config` flag plumbing — Phase 2 (sexp-default migration)
- Goldens re-pin under margin-on — Phase 4/5 of the plan (gated on Stage A validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)