### PR TITLE
fix(check): no_python_check.sh race-proof prune against dune sandbox cleanup

### DIFF
--- a/trading/devtools/checks/no_python_check.sh
+++ b/trading/devtools/checks/no_python_check.sh
@@ -11,10 +11,18 @@
 #
 # Excluded from the scan (not part of the source tree):
 #   .git/         VCS internals
-#   _build/       Dune build artifacts
+#   _build/       Dune build artifacts — pruned by NAME, not by path, so all
+#                 nested _build dirs (e.g. trading/_build) are covered.
+#                 Path-anchored prunes (e.g. -path "$REPO_ROOT/_build") fail
+#                 when _build is nested below the repo root (common in CI where
+#                 $REPO_ROOT is the repo root but _build is inside
+#                 trading/_build). A mid-walk sandbox cleanup then causes find
+#                 to exit non-zero, killing the script via set -e with no
+#                 error message.  See PR #1108 / #1115 for CI failure evidence.
 #   node_modules/ Front-end dependencies (not present; excluded defensively)
 #   vendor/       Third-party vendored code (not present; excluded defensively)
 #   .devcontainer/ Docker image build context (may include Python install steps)
+#   worktrees/    .claude/worktrees/ agent checkouts (may contain any language)
 #
 # Output:
 #   OK: no-python check -- no *.py files found.
@@ -27,14 +35,18 @@ set -e
 REPO_ROOT="$(repo_root)"
 
 # Collect *.py files, excluding generated/non-source directories.
+# Name-anchored prunes (-name X -prune) match at any depth in the tree, so
+# all _build dirs are pruned regardless of nesting level.  This avoids the CI
+# race where a path-anchored prune misses a nested _build and find descends
+# into a dune sandbox that dune is simultaneously cleaning up.
+# The trailing "|| true" is belt-and-suspenders: if find still exits non-zero
+# due to a transient TOCTOU deletion, we treat it as "no .py files found"
+# rather than crashing the script via set -e.
 FOUND=$(find "$REPO_ROOT" \
-  -path "$REPO_ROOT/.git" -prune -o \
-  -path "$REPO_ROOT/_build" -prune -o \
-  -path "$REPO_ROOT/node_modules" -prune -o \
-  -path "$REPO_ROOT/vendor" -prune -o \
-  -path "$REPO_ROOT/.devcontainer" -prune -o \
+  \( -name '.git' -o -name '_build' -o -name 'node_modules' \
+     -o -name 'vendor' -o -name '.devcontainer' -o -name 'worktrees' \) -prune -o \
   -name '*.py' -print \
-  2>/dev/null)
+  2>/dev/null || true)
 
 if [ -n "$FOUND" ]; then
   echo "FAIL: no-python check -- unexpected *.py files found:"


### PR DESCRIPTION
## What

Fix a CI race condition in `trading/devtools/checks/no_python_check.sh`.

The script used path-anchored prunes like `-path "$REPO_ROOT/_build" -prune` to exclude the dune build directory. This silently fails in CI where `$REPO_ROOT` resolves to `/__w/trading/trading` (the git repo root) but `_build` lives at `/__w/trading/trading/trading/_build`. The path-anchored prune never matches, so `find` descends into the dune sandbox. When dune is simultaneously cleaning up sandboxes during `dune runtest`, directories disappear mid-walk, and `find` exits non-zero. With `set -e` at the top of the script, that kills the whole script with no visible error message.

CI evidence from PR #1108 / #1115:
```
find: '/__w/trading/trading/trading/_build/.sandbox/.../test_data/V': No such file or directory
```

## Fix

Switch from path-anchored prunes to name-anchored prunes (`-name X -prune`). Name-anchored prunes match `_build` at any depth in the tree, so nested `_build` dirs like `trading/_build` are pruned regardless of nesting level.

Also:
- Added `worktrees` to the prune list (`.claude/worktrees/` agent checkouts may contain any language)
- Added `|| true` belt-and-suspenders so a transient `find` TOCTOU exit doesn't kill the script via `set -e`

## Verify

```bash
# Run three times to confirm no flakiness
sh trading/devtools/checks/no_python_check.sh
sh trading/devtools/checks/no_python_check.sh
sh trading/devtools/checks/no_python_check.sh
# Expected: "OK: no-python check -- no *.py files found." each time

# Full dune test suite
dune build && dune runtest devtools/checks/
```

## Follow-up items (not in this PR — scope is tight)

Scan of all other `devtools/checks/*.sh` scripts for the same anti-pattern (path-anchored `find` prunes + `set -e`) found **no other instances**. The only scripts that use `find` with repo-root-relative paths (`$REPO_ROOT`) are:

- `no_python_check.sh` — fixed here

Scripts like `linter_magic_numbers.sh`, `linter_file_length.sh`, and `linter_mli_coverage.sh` use `$TRADING_DIR` (the `trading_dir()` helper, which returns a path relative to the dune sandbox) with glob-based `*/_build/*` patterns — these are not vulnerable to the same issue since they operate inside the sandbox mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)