### PR TITLE
feat(ishares): membership replay (PR-B of 4)

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -328,6 +328,33 @@ fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
 
 ### In Progress / READY_FOR_REVIEW
 
+- **Phase 1.4 PR-B — `ishares_membership_replay` (READY_FOR_REVIEW
+  2026-05-16, branch `feat/iwv-membership-replay`).**
+  - New module `trading/analysis/data/sources/ishares/lib/ishares_membership_replay.{ml,mli}`
+    — pure tenure-replay layer. Consumes the forward-ordered
+    `(Date.t * Ishares_holdings_client.snapshot)` stream from PR-A and
+    emits one `tenure_record` per `(ticker)` observed.
+  - `replay : ?index:string -> threshold_consecutive_misses:int -> _ list -> tenure_record list`.
+    `tenure_record = { ticker; first_seen; last_seen; sector_at_first;
+    index }`. Default `index = "IWV"`; the `threshold_consecutive_misses`
+    knob defaults to 3 in callers (per plan §2.3.2) but is required-named
+    in the lib to keep the policy explicit.
+  - Algorithm: forward scan with a per-ticker `absent_streak` counter;
+    threshold misses close the tenure at the last-observed date, and
+    re-appearance opens a fresh tenure. Un-tickered escrow rows
+    (`ticker = "-"`) are dropped; other vendor-specific filters
+    (Asset Class, location) are intentionally deferred to the
+    universe-builder CLI (PR-D) so per-backtest policy varies cleanly.
+  - 9 OUnit2 tests pass: single snapshot, 2-snapshot overlap,
+    single-miss-below-threshold preservation, 3-consecutive-miss
+    closure-at-last-seen, era-mixing `sector_at_first` pinning,
+    `threshold=1` collapse + re-open, un-tickered drop, empty input,
+    custom `?index` plumbing.
+  - Linters green: `dune build @fmt`, `no_python_check`,
+    `fn_length_linter`. ~490 LOC across `.ml` + `.mli` + `test.ml`
+    (under PR-sizing cap; status / plan / fixtures don't count). Plan:
+    `dev/plans/iwv-scraper-2026-05-16.md` §PR-B.
+
 - **Phase 1.4 PR-A — `ishares_holdings_client` (READY_FOR_REVIEW
   2026-05-16, branch `feat/iwv-holdings-client`).**
   - New module `trading/analysis/data/sources/ishares/lib/ishares_holdings_client.{ml,mli}`
@@ -397,7 +424,12 @@ fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
     modern 2020, sentinel) and 14 tests covering all three eras +
     sentinel + header-drift + empty input. Branch:
     `feat/iwv-holdings-client`.
-  - **[ ] PR-B `ishares_membership_replay`** — pending PR-A merge.
+  - **[ ] PR-B `ishares_membership_replay`** — READY_FOR_REVIEW
+    2026-05-16. Pure tenure-replay layer under
+    `trading/analysis/data/sources/ishares/lib/ishares_membership_replay.{ml,mli}`
+    with 9 OUnit2 tests covering single-snapshot / overlap /
+    miss-threshold / sector-pinning / threshold-parameterization /
+    un-tickered-drop. Branch: `feat/iwv-membership-replay`.
   - **[ ] PR-C `fetch_iwv_history.exe`** — pending PR-A merge.
   - **[ ] PR-D `build_iwv_universe.exe`** + golden — pending PR-B / PR-C.
   No vendor signup; Linux/Mac OCaml native; zero marginal cost.

--- a/trading/analysis/data/sources/ishares/lib/ishares_membership_replay.ml
+++ b/trading/analysis/data/sources/ishares/lib/ishares_membership_replay.ml
@@ -55,6 +55,33 @@ let _seen_in_snapshot (snap : Ishares_holdings_client.snapshot) :
         | `Ok | `Duplicate -> ());
   tbl
 
+(* Record a ticker observed in the current snapshot: either extend an
+   existing tenure ([last_seen] moves forward, miss counter resets) or open
+   a new one. Mutates [state] in place. *)
+let _record_seen ~as_of ~state ~ticker
+    ~(holding : Ishares_holdings_client.holding) : unit =
+  match Hashtbl.find state ticker with
+  | Some ip ->
+      Hashtbl.set state ~key:ticker
+        ~data:{ ip with last_seen = as_of; absent_streak = 0 }
+  | None ->
+      Hashtbl.set state ~key:ticker ~data:(_new_in_progress ~as_of ~holding)
+
+(* For a ticker absent in the current snapshot, bump its miss counter.
+   Returns [Some ip] (and removes the entry from [state]) if the bumped
+   counter has hit the configured threshold — signalling the tenure should
+   be closed. Otherwise writes the bumped counter back to [state] and
+   returns [None]. *)
+let _bump_miss_counter ~threshold ~state ~ticker (ip : _in_progress) :
+    _in_progress option =
+  let bumped = ip.absent_streak + 1 in
+  if bumped >= threshold then (
+    Hashtbl.remove state ticker;
+    Some ip)
+  else (
+    Hashtbl.set state ~key:ticker ~data:{ ip with absent_streak = bumped };
+    None)
+
 (* Process one snapshot: update [state] in-place and return the list of
    tenure_records closed by hitting the miss threshold during this step. *)
 let _step_snapshot ~threshold ~index ~(state : (string, _in_progress) Hashtbl.t)
@@ -63,12 +90,7 @@ let _step_snapshot ~threshold ~index ~(state : (string, _in_progress) Hashtbl.t)
   let seen = _seen_in_snapshot snap in
   (* Update entries for tickers present in this snapshot. *)
   Hashtbl.iteri seen ~f:(fun ~key:ticker ~data:holding ->
-      match Hashtbl.find state ticker with
-      | Some ip ->
-          Hashtbl.set state ~key:ticker
-            ~data:{ ip with last_seen = as_of; absent_streak = 0 }
-      | None ->
-          Hashtbl.set state ~key:ticker ~data:(_new_in_progress ~as_of ~holding));
+      _record_seen ~as_of ~state ~ticker ~holding);
   (* Increment miss counters for tickers in state but absent in this
      snapshot. Core's Hashtbl forbids mutation during fold/iter, so we
      materialize an explicit "absent" list first, then mutate, then
@@ -79,13 +101,7 @@ let _step_snapshot ~threshold ~index ~(state : (string, _in_progress) Hashtbl.t)
   in
   let to_close =
     List.filter_map absent ~f:(fun (ticker, ip) ->
-        let bumped = ip.absent_streak + 1 in
-        if bumped >= threshold then (
-          Hashtbl.remove state ticker;
-          Some ip)
-        else (
-          Hashtbl.set state ~key:ticker ~data:{ ip with absent_streak = bumped };
-          None))
+        _bump_miss_counter ~threshold ~state ~ticker ip)
   in
   (* Determinism: emit closures sorted by (first_seen, ticker) so the output
      is independent of hashtable iteration order. *)

--- a/trading/analysis/data/sources/ishares/lib/ishares_membership_replay.ml
+++ b/trading/analysis/data/sources/ishares/lib/ishares_membership_replay.ml
@@ -1,0 +1,120 @@
+open Core
+
+type tenure_record = {
+  ticker : string;
+  first_seen : Date.t;
+  last_seen : Date.t;
+  sector_at_first : string;
+  index : string;
+}
+[@@deriving show, eq]
+
+(* In-progress tenure carried in the working state. [absent_streak] counts the
+   number of consecutive snapshots in which [ticker] has been missing since
+   [last_seen]; when it reaches the configured threshold, the tenure is
+   closed. *)
+type _in_progress = {
+  ticker : string;
+  first_seen : Date.t;
+  last_seen : Date.t;
+  sector_at_first : string;
+  absent_streak : int;
+}
+
+let _untickered = "-"
+
+let _new_in_progress ~as_of ~(holding : Ishares_holdings_client.holding) =
+  {
+    ticker = holding.ticker;
+    first_seen = as_of;
+    last_seen = as_of;
+    sector_at_first = holding.sector;
+    absent_streak = 0;
+  }
+
+let _to_tenure ~index (ip : _in_progress) : tenure_record =
+  {
+    ticker = ip.ticker;
+    first_seen = ip.first_seen;
+    last_seen = ip.last_seen;
+    sector_at_first = ip.sector_at_first;
+    index;
+  }
+
+(* Index a snapshot's holdings by ticker, dropping the [_untickered] sentinel
+   rows. Asset-class and location filters are NOT applied here — see [.mli]
+   note on the deliberate split. If a ticker appears twice in one snapshot
+   (vendor quirk; not observed in the Phase 1.4 probe but cheap to guard
+   against), the first occurrence wins so [sector_at_first] stays stable. *)
+let _seen_in_snapshot (snap : Ishares_holdings_client.snapshot) :
+    (string, Ishares_holdings_client.holding) Hashtbl.t =
+  let tbl = Hashtbl.create (module String) in
+  List.iter snap.holdings ~f:(fun h ->
+      if not (String.equal h.ticker _untickered) then
+        match Hashtbl.add tbl ~key:h.ticker ~data:h with
+        | `Ok | `Duplicate -> ());
+  tbl
+
+(* Process one snapshot: update [state] in-place and return the list of
+   tenure_records closed by hitting the miss threshold during this step. *)
+let _step_snapshot ~threshold ~index ~(state : (string, _in_progress) Hashtbl.t)
+    ((as_of, snap) : Date.t * Ishares_holdings_client.snapshot) :
+    tenure_record list =
+  let seen = _seen_in_snapshot snap in
+  (* Update entries for tickers present in this snapshot. *)
+  Hashtbl.iteri seen ~f:(fun ~key:ticker ~data:holding ->
+      match Hashtbl.find state ticker with
+      | Some ip ->
+          Hashtbl.set state ~key:ticker
+            ~data:{ ip with last_seen = as_of; absent_streak = 0 }
+      | None ->
+          Hashtbl.set state ~key:ticker ~data:(_new_in_progress ~as_of ~holding));
+  (* Increment miss counters for tickers in state but absent in this
+     snapshot. Core's Hashtbl forbids mutation during fold/iter, so we
+     materialize an explicit "absent" list first, then mutate, then
+     filter out closures. *)
+  let absent =
+    Hashtbl.fold state ~init:[] ~f:(fun ~key:ticker ~data:ip acc ->
+        if Hashtbl.mem seen ticker then acc else (ticker, ip) :: acc)
+  in
+  let to_close =
+    List.filter_map absent ~f:(fun (ticker, ip) ->
+        let bumped = ip.absent_streak + 1 in
+        if bumped >= threshold then (
+          Hashtbl.remove state ticker;
+          Some ip)
+        else (
+          Hashtbl.set state ~key:ticker ~data:{ ip with absent_streak = bumped };
+          None))
+  in
+  (* Determinism: emit closures sorted by (first_seen, ticker) so the output
+     is independent of hashtable iteration order. *)
+  to_close
+  |> List.sort ~compare:(fun a b ->
+      match Date.compare a.first_seen b.first_seen with
+      | 0 -> String.compare a.ticker b.ticker
+      | c -> c)
+  |> List.map ~f:(_to_tenure ~index)
+
+(* Drain any still-open tenures at end of stream, sorted by (first_seen,
+   ticker) ascending. *)
+let _flush_state ~index (state : (string, _in_progress) Hashtbl.t) :
+    tenure_record list =
+  Hashtbl.data state
+  |> List.sort ~compare:(fun a b ->
+      match Date.compare a.first_seen b.first_seen with
+      | 0 -> String.compare a.ticker b.ticker
+      | c -> c)
+  |> List.map ~f:(_to_tenure ~index)
+
+let replay ?(index = "IWV") ~threshold_consecutive_misses
+    (snapshots : (Date.t * Ishares_holdings_client.snapshot) list) :
+    tenure_record list =
+  let state : (string, _in_progress) Hashtbl.t =
+    Hashtbl.create (module String)
+  in
+  let closures =
+    List.concat_map snapshots
+      ~f:(_step_snapshot ~threshold:threshold_consecutive_misses ~index ~state)
+  in
+  closures @ _flush_state ~index state

--- a/trading/analysis/data/sources/ishares/lib/ishares_membership_replay.mli
+++ b/trading/analysis/data/sources/ishares/lib/ishares_membership_replay.mli
@@ -1,0 +1,97 @@
+(** Membership replay over a stream of iShares ETF holdings snapshots.
+
+    Companion plan: [dev/plans/iwv-scraper-2026-05-16.md] §2.3 / §PR-B. Given a
+    forward-ordered sequence of parsed snapshots produced by
+    {!Ishares_holdings_client.parse}, reconstruct a per-ticker tenure record
+    capturing the first and last dates on which the ticker was observed in the
+    index.
+
+    All functions in this module are pure — no I/O, no global state. The caller
+    is responsible for loading and ordering snapshots; the future
+    [build_iwv_universe.exe] CLI ties the pieces together.
+
+    The 3-snapshot removal threshold (§2.3.2) prevents single-day data glitches
+    (e.g. iShares occasionally returns a sentinel mid-week between two valid
+    daily reports) from creating spurious tenure splits. Callers can tune the
+    threshold via [threshold_consecutive_misses] — 1 collapses to "any miss ends
+    the tenure", larger values are more conservative. *)
+
+open Core
+
+type tenure_record = {
+  ticker : string;
+      (** The verbatim ticker observed in the holdings stream. Holdings whose
+          [Ishares_holdings_client.holding.ticker] is ["-"] are dropped before
+          replay and never appear here. *)
+  first_seen : Date.t;  (** Earliest snapshot [as_of] containing [ticker]. *)
+  last_seen : Date.t;
+      (** Latest snapshot [as_of] on which [ticker] was observed before a run of
+          [threshold_consecutive_misses] absent snapshots ended its tenure. For
+          tickers still present in the most recent snapshot, this is the [as_of]
+          of that snapshot. *)
+  sector_at_first : string;
+      (** The [Ishares_holdings_client.holding.sector] value recorded when the
+          ticker was first observed. May be ["-"] (or ["" ] when era is
+          pre-2009, per plan §2.3 — the parser preserves whatever cell value
+          iShares returns; replay does not normalize). Subsequent
+          reclassifications during the tenure are ignored: the per-tenure sector
+          is pinned at first sighting to match the legacy [broad-3000-...sexp]
+          shape. *)
+  index : string;
+      (** The index label this tenure belongs to. Defaults to ["IWV"]; the
+          parameter is exposed in {!replay} so future IWB / IWM variants can
+          flow through the same replay without code change. *)
+}
+[@@deriving show, eq]
+
+val replay :
+  ?index:string ->
+  threshold_consecutive_misses:int ->
+  (Date.t * Ishares_holdings_client.snapshot) list ->
+  tenure_record list
+(** [replay ~threshold_consecutive_misses snapshots] consumes the forward-
+    ordered list of [(as_of, snapshot)] pairs and returns one {!tenure_record}
+    per [(ticker)] observed across the run.
+
+    The caller must supply [snapshots] in ascending [as_of] order; this is the
+    natural shape the on-disk cache produces (filenames sort chronologically).
+    Order is not validated.
+
+    Tenure semantics:
+
+    - First sighting of a ticker opens a new tenure with
+      [first_seen = last_seen = snap.as_of] and [sector_at_first = h.sector]
+      from that snapshot.
+    - Subsequent appearances move [last_seen] forward; the [sector_at_first]
+      field stays pinned to the original observation.
+    - A snapshot in which the ticker is absent increments an internal
+      consecutive-miss counter. The counter resets the moment the ticker
+      reappears.
+    - When the miss counter reaches [threshold_consecutive_misses], the tenure
+      is closed and emitted. Re-appearance after closure opens a brand-new
+      tenure record. A ticker can therefore appear in the output multiple times
+      if it falls out and re-enters the index.
+    - For tickers still active in the last snapshot, the tenure is emitted with
+      [last_seen] set to the most recent [as_of] on which the ticker was
+      observed.
+
+    Filtering (matches plan §2.3.3):
+
+    - Holdings with [ticker = "-"] are dropped (un-tickered escrow positions).
+
+    Other vendor-specific filters (Asset Class = "Futures" / "Cash", non-US
+    locations) are deliberately {b not} applied here. They belong to the
+    universe-builder CLI in PR-D, which has access to the policy knobs callers
+    may want to vary per backtest. This module ships the membership-as-observed
+    signal raw.
+
+    Returns the tenure records in the order they were emitted: closed tenures
+    (those that hit the miss threshold) are emitted at the snapshot that closed
+    them; still-active tenures are emitted after the final snapshot, sorted by
+    [first_seen] ascending then [ticker] ascending for determinism.
+
+    The function is total: any input list yields a list — the empty list yields
+    the empty list. There is no [Error] case because the only pre-condition
+    (ascending order) is the caller's responsibility and out-of-order input
+    simply produces a different, but still structurally-valid, tenure breakdown.
+*)

--- a/trading/analysis/data/sources/ishares/test/dune
+++ b/trading/analysis/data/sources/ishares/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_ishares_holdings_client)
+ (names test_ishares_holdings_client test_ishares_membership_replay)
  (libraries ishares core ounit2 matchers status uri)
  (deps
   (glob_files ./data/*.csv)))

--- a/trading/analysis/data/sources/ishares/test/test_ishares_membership_replay.ml
+++ b/trading/analysis/data/sources/ishares/test/test_ishares_membership_replay.ml
@@ -1,0 +1,274 @@
+open Core
+open OUnit2
+open Matchers
+open Ishares.Ishares_membership_replay
+module Client = Ishares.Ishares_holdings_client
+
+(* ------------------------------------------------------------------------- *)
+(* Test fixture builders                                                     *)
+(*                                                                           *)
+(* The replay layer is pure and operates on parsed [snapshot] values, so the *)
+(* tests construct snapshots in-line rather than reading CSV fixtures from   *)
+(* disk. PR-A's parser test suite is the place where the CSV-format          *)
+(* contract is pinned; here we focus on the diff-and-merge logic.            *)
+(* ------------------------------------------------------------------------- *)
+
+(* Default values for [Client.holding] fields we don't care about in the
+   replay-layer tests. Keeping the builder thin per
+   [.claude/rules/test-patterns.md] §"Test Data Builders". *)
+let _holding ~ticker ?(sector = "Information Technology")
+    ?(asset_class = "Equity") ?(location = "United States") () : Client.holding
+    =
+  {
+    ticker;
+    name = ticker ^ " INC";
+    sector;
+    asset_class;
+    market_value = 100.0;
+    weight_pct = 1.0;
+    notional_value = 100.0;
+    quantity = 1.0;
+    price = 100.0;
+    location;
+    exchange = "NASDAQ";
+    currency = "USD";
+    fx_rate = 1.0;
+    market_currency = "USD";
+    accrual_date = "-";
+  }
+
+let _date y m d = Date.create_exn ~y ~m ~d
+
+(* Build a [(date, snapshot)] pair from a list of ticker descriptors. Each
+   descriptor is [(ticker, sector_opt)]; passing [None] for sector uses the
+   default. *)
+let _snap (y, m, d) tickers =
+  let as_of = _date y m d in
+  let holdings =
+    List.map tickers ~f:(fun (ticker, sector_opt) ->
+        match sector_opt with
+        | Some sector -> _holding ~ticker ~sector ()
+        | None -> _holding ~ticker ())
+  in
+  (as_of, { Client.as_of; holdings })
+
+let _t s = (s, None)
+let _t_sec s sector = (s, Some sector)
+
+(* ------------------------------------------------------------------------- *)
+(* Tests                                                                     *)
+(* ------------------------------------------------------------------------- *)
+
+(* Single snapshot ⇒ one tenure record per non-sentinel ticker, with
+   first_seen = last_seen = that snapshot's date. *)
+let test_single_snapshot_emits_one_record_per_ticker _ =
+  let snap = _snap (2020, Month.Jun, 1) [ _t "AAPL"; _t "MSFT" ] in
+  let result = replay ~threshold_consecutive_misses:3 [ snap ] in
+  assert_that result
+    (elements_are
+       [
+         equal_to
+           ({
+              ticker = "AAPL";
+              first_seen = _date 2020 Month.Jun 1;
+              last_seen = _date 2020 Month.Jun 1;
+              sector_at_first = "Information Technology";
+              index = "IWV";
+            }
+             : tenure_record);
+         equal_to
+           ({
+              ticker = "MSFT";
+              first_seen = _date 2020 Month.Jun 1;
+              last_seen = _date 2020 Month.Jun 1;
+              sector_at_first = "Information Technology";
+              index = "IWV";
+            }
+             : tenure_record);
+       ])
+
+(* Two consecutive snapshots with overlapping tickers ⇒ tenure spans both
+   dates for the shared ticker, and a new tenure opens for the ticker
+   appearing only in snap 2. *)
+let test_two_snapshots_overlap_spans_dates _ =
+  let snaps =
+    [
+      _snap (2020, Month.Jun, 1) [ _t "AAPL"; _t "MSFT" ];
+      _snap (2020, Month.Jun, 2) [ _t "AAPL"; _t "GOOG" ];
+    ]
+  in
+  let result = replay ~threshold_consecutive_misses:3 snaps in
+  (* MSFT is absent in snap 2 (1 miss) which is below threshold=3, so its
+     tenure stays open and is emitted at flush time. AAPL is observed in
+     both, so last_seen advances. GOOG opens fresh in snap 2. All three
+     flush-time records are sorted by (first_seen, ticker). *)
+  assert_that result
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (r : tenure_record) -> r.ticker) (equal_to "AAPL");
+             field (fun r -> r.first_seen) (equal_to (_date 2020 Month.Jun 1));
+             field (fun r -> r.last_seen) (equal_to (_date 2020 Month.Jun 2));
+           ];
+         all_of
+           [
+             field (fun (r : tenure_record) -> r.ticker) (equal_to "MSFT");
+             field (fun r -> r.first_seen) (equal_to (_date 2020 Month.Jun 1));
+             field (fun r -> r.last_seen) (equal_to (_date 2020 Month.Jun 1));
+           ];
+         all_of
+           [
+             field (fun (r : tenure_record) -> r.ticker) (equal_to "GOOG");
+             field (fun r -> r.first_seen) (equal_to (_date 2020 Month.Jun 2));
+             field (fun r -> r.last_seen) (equal_to (_date 2020 Month.Jun 2));
+           ];
+       ])
+
+(* Single-snapshot data glitch (ticker absent for 1 snapshot, then back)
+   must NOT split the tenure when threshold >= 2. The original
+   first_seen/last_seen progression is preserved across the gap. *)
+let test_single_miss_below_threshold_keeps_tenure_open _ =
+  let snaps =
+    [
+      _snap (2020, Month.Jun, 1) [ _t "AAPL" ];
+      _snap (2020, Month.Jun, 2) [ _t "MSFT" ];
+      (* AAPL absent — 1 miss *)
+      _snap (2020, Month.Jun, 3) [ _t "AAPL" ];
+    ]
+  in
+  let result = replay ~threshold_consecutive_misses:3 snaps in
+  let aapl = List.find result ~f:(fun r -> String.equal r.ticker "AAPL") in
+  assert_that aapl
+    (is_some_and
+       (all_of
+          [
+            field (fun r -> r.first_seen) (equal_to (_date 2020 Month.Jun 1));
+            field (fun r -> r.last_seen) (equal_to (_date 2020 Month.Jun 3));
+          ]))
+
+(* Removal confirmed after 3 consecutive misses. The tenure is closed at the
+   snapshot that bumps the streak to 3, and last_seen retains the last
+   *observed* date — not the closure date. *)
+let test_three_consecutive_misses_closes_tenure_at_last_seen _ =
+  let snaps =
+    [
+      _snap (2020, Month.Jun, 1) [ _t "AAPL"; _t "MSFT" ];
+      _snap (2020, Month.Jun, 2) [ _t "MSFT" ];
+      (* AAPL miss 1 *)
+      _snap (2020, Month.Jun, 3) [ _t "MSFT" ];
+      (* AAPL miss 2 *)
+      _snap (2020, Month.Jun, 4) [ _t "MSFT" ];
+      (* AAPL miss 3 → close *)
+    ]
+  in
+  let result = replay ~threshold_consecutive_misses:3 snaps in
+  let aapl = List.find result ~f:(fun r -> String.equal r.ticker "AAPL") in
+  assert_that aapl
+    (is_some_and
+       (all_of
+          [
+            field (fun r -> r.first_seen) (equal_to (_date 2020 Month.Jun 1));
+            field (fun r -> r.last_seen) (equal_to (_date 2020 Month.Jun 1));
+          ]))
+
+(* Era mixing: snapshot 1 (2007) has empty sectors ("-"); snapshot 2 (2012)
+   has populated sectors. The replay must pin [sector_at_first] to whatever
+   the FIRST observation recorded — even if it's the pre-2009 sentinel
+   string. *)
+let test_sector_at_first_is_taken_from_first_observation _ =
+  let snaps =
+    [
+      _snap (2007, Month.Dec, 31) [ _t_sec "AAPL" "-" ];
+      _snap (2012, Month.Apr, 30) [ _t_sec "AAPL" "Information Technology" ];
+    ]
+  in
+  let result = replay ~threshold_consecutive_misses:3 snaps in
+  assert_that result
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (r : tenure_record) -> r.ticker) (equal_to "AAPL");
+             field (fun r -> r.sector_at_first) (equal_to "-");
+             field (fun r -> r.first_seen) (equal_to (_date 2007 Month.Dec 31));
+             field (fun r -> r.last_seen) (equal_to (_date 2012 Month.Apr 30));
+             field (fun r -> r.index) (equal_to "IWV");
+           ];
+       ])
+
+(* Threshold parameterization: with threshold=1 the same "1 miss" sequence
+   that previously kept the tenure open instead closes it at the first
+   miss. The re-appearance of the ticker after closure opens a brand-new
+   tenure with a later [first_seen]. *)
+let test_threshold_one_closes_on_single_miss _ =
+  let snaps =
+    [
+      _snap (2020, Month.Jun, 1) [ _t "AAPL" ];
+      _snap (2020, Month.Jun, 2) [ _t "MSFT" ];
+      (* AAPL miss 1 → closes at threshold=1 *)
+      _snap (2020, Month.Jun, 3) [ _t "AAPL" ];
+      (* Re-opens a fresh tenure *)
+    ]
+  in
+  let result = replay ~threshold_consecutive_misses:1 snaps in
+  let aapl_records =
+    List.filter result ~f:(fun r -> String.equal r.ticker "AAPL")
+  in
+  assert_that aapl_records
+    (elements_are
+       [
+         all_of
+           [
+             field (fun r -> r.first_seen) (equal_to (_date 2020 Month.Jun 1));
+             field (fun r -> r.last_seen) (equal_to (_date 2020 Month.Jun 1));
+           ];
+         all_of
+           [
+             field (fun r -> r.first_seen) (equal_to (_date 2020 Month.Jun 3));
+             field (fun r -> r.last_seen) (equal_to (_date 2020 Month.Jun 3));
+           ];
+       ])
+
+(* Un-tickered escrow positions ([ticker = "-"]) must be dropped before
+   replay per plan §2.3.3; they never appear in the output. *)
+let test_untickered_rows_are_dropped _ =
+  let snap = _snap (2007, Month.Dec, 31) [ _t "AAPL"; _t "-" ] in
+  let result = replay ~threshold_consecutive_misses:3 [ snap ] in
+  let tickers = List.map result ~f:(fun r -> r.ticker) in
+  assert_that tickers (elements_are [ equal_to "AAPL" ])
+
+(* Empty input list ⇒ empty output. *)
+let test_empty_input _ =
+  let result = replay ~threshold_consecutive_misses:3 [] in
+  assert_that result (size_is 0)
+
+(* The [?index] override is plumbed through to every emitted record. *)
+let test_custom_index_label _ =
+  let snap = _snap (2020, Month.Jun, 1) [ _t "AAPL" ] in
+  let result = replay ~index:"IWB" ~threshold_consecutive_misses:3 [ snap ] in
+  assert_that result
+    (elements_are
+       [ field (fun (r : tenure_record) -> r.index) (equal_to "IWB") ])
+
+let suite =
+  "ishares_membership_replay_test"
+  >::: [
+         "single_snapshot_emits_one_record_per_ticker"
+         >:: test_single_snapshot_emits_one_record_per_ticker;
+         "two_snapshots_overlap_spans_dates"
+         >:: test_two_snapshots_overlap_spans_dates;
+         "single_miss_below_threshold_keeps_tenure_open"
+         >:: test_single_miss_below_threshold_keeps_tenure_open;
+         "three_consecutive_misses_closes_tenure_at_last_seen"
+         >:: test_three_consecutive_misses_closes_tenure_at_last_seen;
+         "sector_at_first_is_taken_from_first_observation"
+         >:: test_sector_at_first_is_taken_from_first_observation;
+         "threshold_one_closes_on_single_miss"
+         >:: test_threshold_one_closes_on_single_miss;
+         "untickered_rows_are_dropped" >:: test_untickered_rows_are_dropped;
+         "empty_input" >:: test_empty_input;
+         "custom_index_label" >:: test_custom_index_label;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Adds the pure tenure-replay layer over the iShares holdings snapshot
stream from PR-A (#1112). Given a forward-ordered list of parsed
snapshots, emits one \`tenure_record\` per \`(ticker)\` capturing the
first and last dates the ticker was observed in the index.

## Why

PR-B is the second step in the 4-PR IWV stack
(\`dev/plans/iwv-scraper-2026-05-16.md\`). PR-A's parser turns one CSV
into one \`snapshot\`; this PR turns a stream of snapshots into a
membership tenure table the universe-builder (PR-D) can pin into the
existing \`broad-3000-...sexp\` shape. No HTTP, no Async, no I/O — a pure
function over typed data.

## Design highlights

- **3-consecutive-miss removal threshold** (plan §2.3.2) — single-day
  data glitches (vendor occasionally returns a sentinel mid-week between
  two valid daily reports) do not split tenures spuriously. The
  threshold is parametric so callers can tune.
- **\`sector_at_first\` pinned to first observation** — matches the
  one-sector-per-symbol shape of the legacy \`broad-3000-2010-01-01.sexp\`
  fixture. Post-2018 GICS reclassifications (e.g. FB Tech → Communication
  Services) are documented as a known limitation in the .mli.
- **Filter scope deliberately narrow** — only un-tickered escrow rows
  (\`ticker = \"-\"\`) are dropped here. Asset Class / Location filters
  (Futures, Cash, non-US cross-listings) are deferred to the
  universe-builder CLI in PR-D so per-backtest policy varies cleanly.
- **\`index\` label parametric** — defaults \"IWV\"; the parameter is
  exposed in \`replay\` so future IWB / IWM variants flow through the
  same replay without code change.

## Files

- \`trading/analysis/data/sources/ishares/lib/ishares_membership_replay.{ml,mli}\` — new
- \`trading/analysis/data/sources/ishares/test/test_ishares_membership_replay.ml\` — new
- \`trading/analysis/data/sources/ishares/test/dune\` — extend
- \`dev/status/data-foundations.md\` — tick + completed entry

## Test plan

9 OUnit2 tests cover the contract surface:

- [x] Single snapshot → one tenure record per ticker, first_seen=last_seen=that_date
- [x] Two consecutive snapshots with overlap → tenure spans both dates
- [x] Ticker present, gone for 1 snapshot, back → tenure preserved (below threshold=3)
- [x] Ticker present, gone for 3 snapshots → tenure ends at last_seen (closure)
- [x] Era handling: pre-2009 empty sector + 2012+ populated sector → sector_at_first pinned to first
- [x] Threshold=1: single miss closes tenure; re-appearance opens new tenure
- [x] Un-tickered (\"-\") rows dropped
- [x] Empty input → empty output
- [x] Custom \`?index\` plumbing

\`docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/.claude/worktrees/agent-iwv-replay-*/trading && eval \$(opam env) && dune build && dune runtest analysis/data/sources/ishares/ && dune build @fmt'\` — all green, zero warnings.

## LOC delta

525 lines added across 5 files. \`.ml\` + \`.mli\` + test = 491 lines (under
the 500 LOC PR-sizing cap); status + dune don't count.

## CI caveat

CI was reported flaky tonight (sandbox cleanup race in shell linters
producing \`find:\` errors + silent exit 1). If this PR's CI fails with
that signature, it's the known infra issue; the structural and
behavioral signal is on QC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)