### PR TITLE
feat(simulator): margin accrual + maintenance force-cover (Phase 2)

### DIFF
--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -1,9 +1,21 @@
 # Status: short-side-strategy
 
-## Last updated: 2026-05-02
+## Last updated: 2026-05-16
 
 ## Status
-MERGED
+IN_PROGRESS
+
+## Interface stable
+YES
+
+Issue #859 margin work is in progress. Phase 1 (margin_config + Portfolio
+extensions + Portfolio_margin module) landed via #1113 + #1115. Phase 2
+(simulator wiring — daily borrow fee accrual + maintenance-margin
+force-cover) opened today as #1119. Both phases gate behind
+`Margin_config.enabled = false` so prior MERGED baselines stay bit-equal
+until a scenario opts in.
+
+**Earlier MERGED note retained below.**
 
 Track wrapped on the MVP + initial follow-up axis. New follow-ups surfaced overnight in `dev/notes/force-liq-cascade-findings-2026-05-01.md` (G14 split-adjustment on Position.t Holding state) and `dev/notes/g14-deep-dive-2026-05-01.md` (Option 1 fix recommendation). G15 (short-side risk control) also filed. Both are `feat-weinstein` — strategy + position state machine; current `feat-weinstein` scope is closed. See §Follow-ups below for the new items.
 

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -59,7 +59,8 @@ let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
     Simulator.create_deps ~symbols:input.all_symbols
       ~data_dir:input.data_dir_fpath ~strategy ~commission
       ~metric_suite:(Metric_computers.default_metric_suite ~initial_cash ())
-      ~market_data_adapter ~stale_hold_log ?slippage_bps ()
+      ~market_data_adapter ~stale_hold_log ?slippage_bps
+      ~margin_config:input.config.margin_config ()
   in
   let sim_config =
     Simulator.

--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -31,6 +31,7 @@
   benchmark_relative_computer
   stability_turnover_computer
   portfolio_valuation
-  stale_hold)
+  stale_hold
+  margin_runner)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/simulation/lib/margin_runner.ml
+++ b/trading/trading/simulation/lib/margin_runner.ml
@@ -1,0 +1,67 @@
+open Core
+module Margin_config = Trading_portfolio.Margin_config
+module Portfolio = Trading_portfolio.Portfolio
+module Portfolio_margin = Trading_portfolio.Portfolio_margin
+module Position = Trading_strategy.Position
+
+(* Forensic detail string emitted on margin_call exit transitions. Kept
+   ASCII-only + key=value so simple parsers (trades.csv readers, audit
+   reports) can extract fields without OCaml-side helpers. *)
+let _margin_call_detail ~entry_avg_cost ~current_price =
+  Printf.sprintf "entry_avg_cost=%.6f current_price=%.6f" entry_avg_cost
+    current_price
+
+let mark_prices (today_bars : Trading_engine.Types.price_bar list) :
+    (string * float) list =
+  List.map today_bars ~f:(fun bar ->
+      (bar.Trading_engine.Types.symbol, bar.Trading_engine.Types.close_price))
+
+let accrue_borrow_fee ~(margin_config : Margin_config.t) ~portfolio ~prices =
+  Portfolio_margin.accrue_daily_borrow_fee ~margin_config portfolio prices
+
+(* Find the strategy-side Position.t for a flagged symbol. Match only
+   positions currently in Holding state — Entering/Exiting are mid-flight
+   under the regular order machinery and reissuing a TriggerExit on top
+   would conflict with their existing transitions. *)
+let _find_holding_short_for_symbol positions symbol =
+  Map.to_alist positions
+  |> List.find ~f:(fun (_, pos) ->
+      String.equal pos.Position.symbol symbol
+      &&
+      match Position.get_state pos with
+      | Position.Holding _ -> true
+      | _ -> false)
+
+let _entry_price_from_holding (pos : Position.t) : float =
+  match Position.get_state pos with
+  | Position.Holding h -> h.entry_price
+  | _ -> 0.0
+
+let _margin_call_exit_reason ~entry_avg_cost ~current_price :
+    Position.exit_reason =
+  let detail = _margin_call_detail ~entry_avg_cost ~current_price in
+  Position.StrategySignal { label = "margin_call"; detail = Some detail }
+
+let _build_margin_call_transition ~date ~current_price (id, pos) =
+  let entry_avg_cost = _entry_price_from_holding pos in
+  let exit_reason = _margin_call_exit_reason ~entry_avg_cost ~current_price in
+  let kind = Position.TriggerExit { exit_reason; exit_price = current_price } in
+  { Position.position_id = id; date; kind }
+
+let _transition_for_flagged_symbol ~date ~price_map ~positions symbol =
+  let%bind.Option current_price = Map.find price_map symbol in
+  let%bind.Option holding = _find_holding_short_for_symbol positions symbol in
+  Some (_build_margin_call_transition ~date ~current_price holding)
+
+let margin_call_transitions ~margin_config ~portfolio ~positions ~prices ~date =
+  if not margin_config.Margin_config.enabled then []
+  else
+    let flagged =
+      Portfolio_margin.check_maintenance_margin ~margin_config portfolio prices
+    in
+    match flagged with
+    | [] -> []
+    | _ ->
+        let price_map = Map.of_alist_exn (module String) prices in
+        List.filter_map flagged
+          ~f:(_transition_for_flagged_symbol ~date ~price_map ~positions)

--- a/trading/trading/simulation/lib/margin_runner.mli
+++ b/trading/trading/simulation/lib/margin_runner.mli
@@ -1,0 +1,68 @@
+(** Per-step margin mechanics for the simulator (issue #859 Phase 2).
+
+    Adapts the Phase-1 {!Trading_portfolio.Portfolio_margin} primitives to the
+    simulator's per-day tick: accrue one trading day of short borrow fee, then
+    flag any short position whose maintenance margin has been breached. Both
+    operations are strategy-agnostic — margin is a broker mechanic that any
+    strategy opening short positions benefits from, not Weinstein-specific
+    logic.
+
+    All entry points are pure functions; the simulator's caller threads the
+    updated [Portfolio.t] and the generated margin-call transitions back into
+    its per-step state.
+
+    {b Default-off invariant.} When [margin_config.enabled = false] (the
+    {!Trading_portfolio.Margin_config} default), every function in this module
+    is a bit-equal no-op: portfolio state is returned unchanged and no
+    transitions are generated. This lets the simulator hold long-only baselines
+    bit-equal until the flag is opted into via configuration.
+
+    Authority: [dev/plans/short-side-margin-2026-05-13.md] §2. *)
+
+open Core
+module Margin_config = Trading_portfolio.Margin_config
+module Portfolio = Trading_portfolio.Portfolio
+module Position = Trading_strategy.Position
+
+val mark_prices : Trading_engine.Types.price_bar list -> (string * float) list
+(** Project per-symbol [(symbol, close_price)] from today's price bars. Pure
+    helper exposed so callers (tests, runner) can build the same input the
+    margin primitives consume. *)
+
+val accrue_borrow_fee :
+  margin_config:Margin_config.t ->
+  portfolio:Portfolio.t ->
+  prices:(string * float) list ->
+  Portfolio.t
+(** Apply one trading day of borrow-fee accrual to [portfolio]. Thin wrapper
+    over {!Trading_portfolio.Portfolio_margin.accrue_daily_borrow_fee}.
+
+    Returns [portfolio] unchanged when [margin_config.enabled = false] or when
+    the portfolio holds no short positions. *)
+
+val margin_call_transitions :
+  margin_config:Margin_config.t ->
+  portfolio:Portfolio.t ->
+  positions:Position.t String.Map.t ->
+  prices:(string * float) list ->
+  date:Date.t ->
+  Position.transition list
+(** Build [TriggerExit] transitions for every short position whose maintenance
+    margin has been breached on this tick.
+
+    For each symbol flagged by
+    {!Trading_portfolio.Portfolio_margin.check_maintenance_margin}, the
+    corresponding strategy-side {!Position.t} is located by matching on symbol
+    + [Holding] state (other states represent positions already in the
+      open/close pipeline; the simulator's regular fill machinery handles them).
+      The transition carries
+      [exit_reason = StrategySignal { label = "margin_call"; detail = Some
+       "<key=value>" }] so downstream audit / trades.csv writers group the exits
+      correctly. The free-form [detail] payload encodes the entry-avg-cost and
+      current price for forensic review without adding a new variant to the
+      shared {!Position.exit_reason} surface.
+
+    Returns the empty list when [margin_config.enabled = false], when there are
+    no shorts breaching maintenance, or when no matching [Holding] position can
+    be located for the flagged symbol (e.g. the short is already mid-exit on
+    this tick). *)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -42,12 +42,22 @@ type dependencies = {
           as [None] on every step (default; preserves prior behaviour). *)
   stale_hold_policy : Stale_hold.config;
   stale_hold_log : Stale_hold.Log.t;
+  margin_config : Trading_portfolio.Margin_config.t;
+      (** Phase 2 margin-accounting parameters (issue #859). Default
+          {!Trading_portfolio.Margin_config.default_config} — i.e. disabled, so
+          every Phase-1 / Phase-2 surface is a bit-equal no-op and existing
+          long-only goldens stay pinned. When [margin_config.enabled = true] the
+          simulator accrues a daily short borrow fee against [current_cash] and
+          emits margin-call [TriggerExit] transitions on shorts whose
+          maintenance equity ratio has fallen below [maintenance_margin_pct]
+          (see {!Margin_runner}). *)
 }
 
 let create_deps ~symbols ~data_dir ~strategy ~commission
     ?(metric_suite = { computers = []; derived = [] }) ?benchmark_symbol
     ?market_data_adapter ?(stale_hold_policy = Stale_hold.default_config)
-    ?stale_hold_log ?(slippage_bps = 0) () =
+    ?stale_hold_log ?(slippage_bps = 0)
+    ?(margin_config = Trading_portfolio.Margin_config.default_config) () =
   let engine_config = { Trading_engine.Types.commission; slippage_bps } in
   let engine = Trading_engine.Engine.create engine_config in
   let order_manager = Trading_orders.Manager.create () in
@@ -70,6 +80,7 @@ let create_deps ~symbols ~data_dir ~strategy ~commission
     benchmark_symbol;
     stale_hold_policy;
     stale_hold_log;
+    margin_config;
   }
 
 (** {1 Simulator State} *)
@@ -392,6 +403,25 @@ let _build_step_result t ~portfolio ~portfolio_value ~trades ~orders ~today_bars
     had_market_bars = not (List.is_empty today_bars);
   }
 
+(** Apply the Phase-2 margin per-tick mechanics: accrue daily borrow fee, then
+    build margin-call [TriggerExit] transitions for any short whose maintenance
+    margin has been breached. No-op when [margin_config.enabled = false]
+    (preserves baselines bit-equal). The margin transitions are appended to the
+    strategy's transitions so they flow through the same {!_apply_transitions}
+    + {!Order_generator} pipeline as any other exit. *)
+let _apply_margin_tick t ~portfolio ~positions ~today_bars ~strategy_transitions
+    =
+  let margin_config = t.deps.margin_config in
+  let prices = Margin_runner.mark_prices today_bars in
+  let portfolio =
+    Margin_runner.accrue_borrow_fee ~margin_config ~portfolio ~prices
+  in
+  let margin_trans =
+    Margin_runner.margin_call_transitions ~margin_config ~portfolio ~positions
+      ~prices ~date:t.current_date
+  in
+  (portfolio, strategy_transitions @ margin_trans)
+
 (** Process one day: execute pending orders, call strategy, generate new orders,
     and assemble the [step_result]. Returns the next simulator state paired with
     this day's [step_result]. *)
@@ -405,7 +435,12 @@ let _process_step_day t ~portfolio ~positions ~today_bars ~split_events =
   let%bind positions =
     _update_positions_from_trades ~date:t.current_date ~positions ~trades
   in
-  let%bind transitions = _call_strategy { t with portfolio; positions } in
+  let%bind strategy_transitions =
+    _call_strategy { t with portfolio; positions }
+  in
+  let portfolio, transitions =
+    _apply_margin_tick t ~portfolio ~positions ~today_bars ~strategy_transitions
+  in
   let%bind positions = _apply_transitions ~positions ~transitions in
   let%bind orders =
     Order_generator.transitions_to_orders ~current_date:t.current_date

--- a/trading/trading/simulation/lib/simulator.mli
+++ b/trading/trading/simulation/lib/simulator.mli
@@ -38,6 +38,10 @@ type dependencies = {
   stale_hold_log : Stale_hold.Log.t;
       (** Per-run collector populated by every step where at least one held
           position is stale. Drained by the runner at end-of-run. *)
+  margin_config : Trading_portfolio.Margin_config.t;
+      (** Phase-2 margin-accounting parameters (issue #859). When
+          [enabled = false] (the default), every margin code path is a no-op and
+          existing baselines are bit-equal. *)
 }
 
 val create_deps :
@@ -51,6 +55,7 @@ val create_deps :
   ?stale_hold_policy:Stale_hold.config ->
   ?stale_hold_log:Stale_hold.Log.t ->
   ?slippage_bps:int ->
+  ?margin_config:Trading_portfolio.Margin_config.t ->
   unit ->
   dependencies
 (** Create standard dependencies with default engine, order manager, and
@@ -79,7 +84,12 @@ val create_deps :
       (no slippage — preserves the no-friction baseline). Plumbed directly into
       {!Trading_engine.Types.engine_config.slippage_bps}. Use non-zero for
       cost-overlay runs (P4 from
-      [dev/notes/next-session-priorities-2026-05-07.md]). *)
+      [dev/notes/next-session-priorities-2026-05-07.md]).
+    @param margin_config
+      Phase-2 margin-accounting parameters (issue #859). Default
+      {!Trading_portfolio.Margin_config.default_config} — disabled, so the
+      simulator's per-step margin code paths are no-ops and existing baselines
+      are bit-equal. *)
 
 (** {1 Creation} *)
 

--- a/trading/trading/simulation/test/dune
+++ b/trading/trading/simulation/test/dune
@@ -344,3 +344,19 @@
   trading.strategy
   types
   matchers))
+
+(test
+ (name test_margin_runner)
+ (modules test_margin_runner)
+ (libraries
+  ounit2
+  core
+  trading.simulation
+  trading.simulation.types
+  trading.base
+  trading.engine
+  trading.portfolio
+  trading.strategy
+  types
+  matchers
+  simulation_test_helpers))

--- a/trading/trading/simulation/test/test_margin_runner.ml
+++ b/trading/trading/simulation/test/test_margin_runner.ml
@@ -1,0 +1,418 @@
+(** Tests for the simulator's Phase-2 margin wiring (issue #859).
+
+    Phase-1 already pins the {!Trading_portfolio.Portfolio_margin} primitives
+    (initial collateral lock, borrow-fee accrual math, maintenance-margin check)
+    at unit-test scope in [trading/portfolio/test/test_margin_accounting.ml].
+
+    This file pins the {b simulator-loop} contract added in Phase 2:
+    - per-tick borrow fee accrual lands on [Portfolio.t] in the simulator,
+    - maintenance-margin breaches generate force-cover [TriggerExit] transitions
+      that flow through {!Order_generator} into buy-to-cover orders, and
+    - {b crucially} every above behaviour is a bit-equal no-op when
+      [margin_config.enabled = false] (the default). The default-off regression
+      is the load-bearing invariant that lets us land this work without
+      re-pinning long-only goldens. *)
+
+open OUnit2
+open Core
+open Trading_simulation.Simulator
+open Matchers
+open Test_helpers
+module Margin_config = Trading_portfolio.Margin_config
+module Portfolio = Trading_portfolio.Portfolio
+module Position = Trading_strategy.Position
+module Strategy_interface = Trading_strategy.Strategy_interface
+
+(* Local epsilon for cash / fee asserts. 1 cent is plenty for fee math
+   accumulated over a few days; tests that go a full trading year use the
+   default float_equal epsilon (~1e-9). *)
+let _cash_epsilon = 0.01
+let _date s = Date.of_string s
+
+let _make_bar ~date ~close =
+  Types.Daily_price.
+    {
+      date;
+      open_price = close;
+      high_price = close;
+      low_price = close;
+      close_price = close;
+      adjusted_close = close;
+      volume = 1_000_000;
+      active_through = None;
+    }
+
+let _commission = { Trading_engine.Types.per_share = 0.0; minimum = 0.0 }
+
+let _config_for ~start_date ~end_date ~initial_cash =
+  {
+    Trading_simulation_types.Simulator_types.start_date;
+    end_date;
+    initial_cash;
+    commission = _commission;
+    strategy_cadence = Types.Cadence.Daily;
+  }
+
+(* On-margin config. We use the Phase-1 defaults but flip [enabled = true]. *)
+let _on_config = { Margin_config.default_config with enabled = true }
+
+(* ------------------------------------------------------------------ *)
+(* Test strategies                                                    *)
+(* ------------------------------------------------------------------ *)
+
+(* Build a one-shot strategy module that emits a single [CreateEntering]
+   transition for [symbol] on its first call, then holds passively. The
+   per-call closure captures a fresh mutable [entered] ref, so each
+   builder call yields an independent strategy state (essential for tests
+   that re-run the same configuration twice in one process — a shared
+   module-level [ref] would skip the second entry). *)
+let _make_one_shot_strategy ~side ~symbol ~quantity ~position_id ~description :
+    (module Strategy_interface.STRATEGY) =
+  let entered = ref false in
+  let module S : Strategy_interface.STRATEGY = struct
+    let name = "OneShot"
+
+    let on_market_close ~get_price ~get_indicator:_ ~portfolio:_ =
+      if !entered then Ok { Strategy_interface.transitions = [] }
+      else
+        match get_price symbol with
+        | None -> Ok { Strategy_interface.transitions = [] }
+        | Some (bar : Types.Daily_price.t) ->
+            entered := true;
+            let open Position in
+            let trans =
+              {
+                position_id;
+                date = bar.date;
+                kind =
+                  CreateEntering
+                    {
+                      symbol;
+                      side;
+                      target_quantity = quantity;
+                      entry_price = bar.close_price;
+                      reasoning =
+                        TechnicalSignal
+                          { indicator = "margin-test"; description };
+                    };
+              }
+            in
+            Ok { Strategy_interface.transitions = [ trans ] }
+  end
+  in
+  (module S)
+
+let _short_strategy ~symbol ~quantity =
+  _make_one_shot_strategy ~side:Position.Short ~symbol ~quantity
+    ~position_id:(symbol ^ "-short") ~description:"short"
+
+let _long_strategy ~symbol ~quantity =
+  _make_one_shot_strategy ~side:Position.Long ~symbol ~quantity
+    ~position_id:(symbol ^ "-long") ~description:"long"
+
+(* ------------------------------------------------------------------ *)
+(* Common scenario runner                                              *)
+(* ------------------------------------------------------------------ *)
+
+let _run_with_margin ~test_name ~symbols_with_data ~strategy ~margin_config
+    ~config =
+  let result_ref = ref None in
+  with_test_data test_name symbols_with_data ~f:(fun data_dir ->
+      let symbols = List.map symbols_with_data ~f:fst in
+      let deps =
+        create_deps ~symbols ~data_dir ~strategy ~commission:config.commission
+          ~margin_config ()
+      in
+      let sim = create_exn ~config ~deps in
+      match run sim with
+      | Ok r -> result_ref := Some r
+      | Error err -> assert_failure ("simulation failed: " ^ Status.show err));
+  match !result_ref with Some r -> r | None -> assert_failure "no result"
+
+(* ------------------------------------------------------------------ *)
+(* Fixtures                                                            *)
+(* ------------------------------------------------------------------ *)
+
+(* A flat-price, multi-day fixture used for borrow-fee math. Price held at
+   $50 across 10 consecutive trading days; entry happens on day 1, fee
+   accrues on days 2..10. *)
+let _aapl_flat_50 =
+  List.map
+    [
+      "2024-01-02";
+      "2024-01-03";
+      "2024-01-04";
+      "2024-01-05";
+      "2024-01-08";
+      "2024-01-09";
+      "2024-01-10";
+      "2024-01-11";
+      "2024-01-12";
+      "2024-01-15";
+    ] ~f:(fun d -> _make_bar ~date:(_date d) ~close:50.0)
+
+(* Rising-price fixture: entry at $50, then a steep climb to $70 over 6
+   trading days. With on_config defaults (50% IM / 25% MM), the trigger
+   price for a $50 short is $60. By the 4th day price = $65 — well past
+   the trigger — the simulator should fire a buy-to-cover. *)
+let _aapl_rising_50_to_70 =
+  [
+    _make_bar ~date:(_date "2024-01-02") ~close:50.0;
+    _make_bar ~date:(_date "2024-01-03") ~close:52.0;
+    _make_bar ~date:(_date "2024-01-04") ~close:58.0;
+    _make_bar ~date:(_date "2024-01-05") ~close:65.0;
+    _make_bar ~date:(_date "2024-01-08") ~close:68.0;
+    _make_bar ~date:(_date "2024-01-09") ~close:70.0;
+    _make_bar ~date:(_date "2024-01-10") ~close:70.0;
+  ]
+
+(* Equity-relevant projection of a portfolio for bit-equality comparison.
+
+   The full [Portfolio.t] equality includes [trade_history] which carries
+   per-trade [timestamp = Time_ns_unix.now ()] (engine.ml:206) — i.e.
+   wall-clock-dependent fields that differ between runs even on identical
+   trade flows. Equity-equality is what matters for the "default-off does
+   not perturb baselines" claim; the wall-clock timestamps are auxiliary.
+
+   The projection keeps cash, position lots (signed quantity + cost
+   basis), and the new margin bookkeeping fields. If any of these
+   differ, the equity curve and metrics differ; if all agree, the
+   long-only run is observably bit-equal. *)
+type _equity_state = {
+  cash : float;
+  positions : Trading_simulation_types.Portfolio_summary.position_summary list;
+  locked_collateral : float;
+  accrued_borrow_fee : float;
+}
+[@@deriving show, eq]
+
+let _equity_state_of_portfolio (p : Portfolio.t) : _equity_state =
+  let summary =
+    Trading_simulation_types.Portfolio_summary.of_portfolio p
+      ~position_value_total:0.0
+  in
+  {
+    cash = summary.current_cash;
+    positions = summary.positions;
+    locked_collateral = p.locked_collateral;
+    accrued_borrow_fee = p.accrued_borrow_fee;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* Tests                                                              *)
+(* ------------------------------------------------------------------ *)
+
+(* T1: Default-off bit-equality regression. A long buy-and-hold run with
+   margin_config disabled must produce a portfolio bit-equal to running
+   without the new code path. We can't compare against "before-the-change"
+   directly, but we can compare against a sibling run that takes the new
+   code path with [enabled = false] vs an opt-in [enabled = true] but no
+   shorts — both should produce identical portfolios because the
+   accrue+force-cover code paths are no-ops in that case. *)
+let test_default_off_long_only_bit_equal _ =
+  let config =
+    _config_for ~start_date:(_date "2024-01-02") ~end_date:(_date "2024-01-15")
+      ~initial_cash:10_000.0
+  in
+  let r_off =
+    _run_with_margin ~test_name:"margin_default_off"
+      ~symbols_with_data:[ ("AAPL", _aapl_flat_50) ]
+      ~strategy:(_long_strategy ~symbol:"AAPL" ~quantity:50.0)
+      ~margin_config:Margin_config.default_config ~config
+  in
+  let r_on_no_shorts =
+    _run_with_margin ~test_name:"margin_on_long_only"
+      ~symbols_with_data:[ ("AAPL", _aapl_flat_50) ]
+      ~strategy:(_long_strategy ~symbol:"AAPL" ~quantity:50.0)
+      ~margin_config:_on_config ~config
+  in
+  (* Both runs must agree exactly on the equity-relevant state: long-only
+     flow touches neither [accrue_daily_borrow_fee] nor maintenance-margin
+     checks (no shorts to flag), so cash, positions, locked collateral,
+     and accrued fee must all match. (We compare the equity-state
+     projection rather than full [Portfolio.t] because the latter carries
+     wall-clock trade timestamps that differ between sibling runs even
+     on identical trade flows.) *)
+  assert_that
+    (_equity_state_of_portfolio r_off.final_portfolio)
+    (equal_to
+       (_equity_state_of_portfolio r_on_no_shorts.final_portfolio
+         : _equity_state))
+
+(* T2: Daily borrow-fee accrual. With margin enabled, a single short of
+   100 shares at $50 (notional $5000) running for N market-close ticks
+   must accrue exactly N * (5000 * 0.005 / 252) in [accrued_borrow_fee],
+   and [current_cash] must drop by the same amount.
+
+   The fixture has 10 trading days. The strategy emits a short order on
+   day 1 (Jan 2); the order fills on day 2 (Jan 3), so the short is open
+   at the START of subsequent ticks. The margin tick in
+   [Simulator._process_step_day] runs AFTER trade application — so the
+   fee accrues on every trading-day tick from the fill day onward
+   (Jan 3..15 = 9 trading days). We compute the expected total
+   dynamically from the count of trading-day step_results that hold a
+   short, so the test does not bake in calendar arithmetic. *)
+let test_borrow_fee_accrual_multi_day _ =
+  let config =
+    _config_for ~start_date:(_date "2024-01-02") ~end_date:(_date "2024-01-16")
+      ~initial_cash:50_000.0
+  in
+  let result =
+    _run_with_margin ~test_name:"margin_borrow_fee"
+      ~symbols_with_data:[ ("AAPL", _aapl_flat_50) ]
+      ~strategy:(_short_strategy ~symbol:"AAPL" ~quantity:100.0)
+      ~margin_config:_on_config ~config
+  in
+  (* Count post-entry steps: those where the short is held at the START
+     of the tick, i.e. the short exists in the previous step's portfolio.
+     For a flat-price hold, every step after the fill has the short
+     held — that's all steps where [Portfolio_summary.find_position
+     "AAPL"] reports a non-zero (negative) quantity. *)
+  (* Fee accrues only on bar-bearing trading days where the short already
+     exists in the portfolio (mark_prices is empty otherwise). Weekends /
+     holidays carry the position across via had_market_bars = false. *)
+  let _has_short_on_trading_day
+      (step : Trading_simulation_types.Simulator_types.step_result) =
+    step.had_market_bars
+    && Trading_simulation_types.Portfolio_summary.find_position step.portfolio
+         ~symbol:"AAPL"
+       |> Option.exists
+            ~f:(fun
+                (p :
+                  Trading_simulation_types.Portfolio_summary.position_summary)
+              -> Float.O.(p.quantity < 0.0))
+  in
+  let steps_with_short = List.count result.steps ~f:_has_short_on_trading_day in
+  let expected_daily_fee =
+    50.0 *. 100.0 *. Margin_config.daily_borrow_rate _on_config
+  in
+  let expected_total = expected_daily_fee *. Float.of_int steps_with_short in
+  (* Composed assertion: portfolio fee accumulator must equal the expected
+     N-day total within float epsilon, and [current_cash] must have been
+     debited by the same amount (the fee is taken out of cash). Phase 2
+     does NOT cover the entry-time collateral-lock seam — that is
+     {!Portfolio_margin.apply_single_trade_with_margin}'s domain and the
+     simulator currently calls the legacy
+     {!Portfolio.apply_single_trade} for trade application. So
+     [locked_collateral] stays [0.0] here; we assert against that
+     explicitly so a future Phase-2.x change that wires the margin-aware
+     apply path notices this test. *)
+  assert_that result.final_portfolio
+    (all_of
+       [
+         field
+           (fun (p : Portfolio.t) -> p.accrued_borrow_fee)
+           (float_equal ~epsilon:1e-9 expected_total);
+         field (fun (p : Portfolio.t) -> p.locked_collateral) (float_equal 0.0);
+       ]);
+  (* Sanity: total cash decrement matches the fee. The short proceeds
+     credited [entry_price * quantity] = 5000.0 to cash on the fill; the
+     accrued fee debits [expected_total]. So final cash should be
+     initial_cash + proceeds - fee. *)
+  let expected_cash =
+    config.initial_cash +. (50.0 *. 100.0) -. expected_total
+  in
+  assert_that result.final_portfolio.current_cash
+    (float_equal ~epsilon:1e-9 expected_cash)
+
+(* T3: Maintenance margin breach -> force buy-to-cover order generated.
+
+   With the default config (initial 50%, maintenance 25%), the trigger
+   price on a $50 short is p_trigger = 50 * 1.5 / 1.25 = $60. Our
+   rising fixture reaches $65 on day 4 (2024-01-05), well past the
+   trigger.
+
+   The expected sequence:
+     day 1 (01-02): strategy emits short order at close $50; engine
+                    submits for next-day fill.
+     day 2 (01-03): order fills at $52. Short held; equity_ratio at $52
+                    is ((1.5 * 50) - 52)/52 = 23/52 ≈ 0.44 > 0.25 (OK).
+     day 3 (01-04): close $58. equity_ratio = (75 - 58)/58 ≈ 0.29 > 0.25.
+     day 4 (01-05): close $65. equity_ratio = (75 - 65)/65 ≈ 0.154 <
+                    0.25 — flagged. Simulator emits a margin-call
+                    TriggerExit; Order_generator turns it into a Buy
+                    (cover) order submitted for next-day fill.
+     day 5 (01-08): cover fill at open $68. Short closed.
+
+   What we assert here:
+     1. The final portfolio holds NO AAPL position (covered).
+     2. The trade audit shows at least one Buy trade on AAPL after the
+        original Sell. *)
+let test_maintenance_margin_force_cover _ =
+  let config =
+    _config_for ~start_date:(_date "2024-01-02") ~end_date:(_date "2024-01-11")
+      ~initial_cash:50_000.0
+  in
+  let result =
+    _run_with_margin ~test_name:"margin_maintenance"
+      ~symbols_with_data:[ ("AAPL", _aapl_rising_50_to_70) ]
+      ~strategy:(_short_strategy ~symbol:"AAPL" ~quantity:100.0)
+      ~margin_config:_on_config ~config
+  in
+  let aapl_trade_sides =
+    List.concat_map result.steps ~f:(fun s -> s.trades)
+    |> List.filter_map ~f:(fun (t : Trading_base.Types.trade) ->
+        if String.equal t.symbol "AAPL" then Some t.side else None)
+  in
+  (* Expect exactly two AAPL trades — the short entry (Sell) and the
+     forced cover (Buy). The final portfolio must show locked_collateral
+     restored to 0 and no open AAPL position. *)
+  assert_that aapl_trade_sides
+    (elements_are
+       [
+         equal_to (Trading_base.Types.Sell : Trading_base.Types.side);
+         equal_to (Trading_base.Types.Buy : Trading_base.Types.side);
+       ]);
+  assert_that result.final_portfolio
+    (all_of
+       [
+         field
+           (fun (p : Portfolio.t) -> Portfolio.get_position p "AAPL")
+           is_none;
+         field
+           (fun (p : Portfolio.t) -> p.locked_collateral)
+           (float_equal ~epsilon:_cash_epsilon 0.0);
+         field
+           (fun (p : Portfolio.t) -> p.accrued_borrow_fee)
+           (gt (module Float_ord) 0.0);
+       ])
+
+(* T4: Flag-on, no shorts: full bit-equality with flag-off. Long-only
+   strategy with margin enabled must still produce a portfolio identical
+   to the same run with margin disabled. *)
+let test_flag_on_long_only_bit_equal _ =
+  let config =
+    _config_for ~start_date:(_date "2024-01-02") ~end_date:(_date "2024-01-11")
+      ~initial_cash:10_000.0
+  in
+  let r_off =
+    _run_with_margin ~test_name:"margin_long_off"
+      ~symbols_with_data:[ ("AAPL", _aapl_flat_50) ]
+      ~strategy:(_long_strategy ~symbol:"AAPL" ~quantity:50.0)
+      ~margin_config:Margin_config.default_config ~config
+  in
+  let r_on =
+    _run_with_margin ~test_name:"margin_long_on"
+      ~symbols_with_data:[ ("AAPL", _aapl_flat_50) ]
+      ~strategy:(_long_strategy ~symbol:"AAPL" ~quantity:50.0)
+      ~margin_config:_on_config ~config
+  in
+  (* Long-only: fee accrual is 0 (no shorts) and maintenance check is a
+     no-op. Equity-state projections must be bit-equal across the two
+     margin modes. *)
+  assert_that
+    (_equity_state_of_portfolio r_off.final_portfolio)
+    (equal_to (_equity_state_of_portfolio r_on.final_portfolio : _equity_state))
+
+let suite =
+  "margin_runner"
+  >::: [
+         "default_off_long_only_bit_equal"
+         >:: test_default_off_long_only_bit_equal;
+         "borrow_fee_accrual_multi_day" >:: test_borrow_fee_accrual_multi_day;
+         "maintenance_margin_force_cover"
+         >:: test_maintenance_margin_force_cover;
+         "flag_on_long_only_bit_equal" >:: test_flag_on_long_only_bit_equal;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -8,6 +8,7 @@
   trading.base
   trading.data_panel
   trading.data_panel.snapshot
+  trading.portfolio
   trading.strategy
   weinstein.snapshot_pipeline
   weinstein.snapshot_runtime

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -317,6 +317,14 @@ type config = {
           pinned numbers as the underlying [active_through] column propagates
           through the snapshot pipeline. Re-pinning goldens is a separate
           post-merge step. *)
+  margin_config : Trading_portfolio.Margin_config.t;
+      [@sexp.default Trading_portfolio.Margin_config.default_config]
+      (** Phase-2 margin-accounting parameters (issue #859 / Phase 2). When
+          [enabled = true], the runner threads the value into the simulator's
+          per-tick margin mechanics. Default
+          {!Trading_portfolio.Margin_config.default_config} (disabled) preserves
+          bit-equality with prior baselines. See [Weinstein_strategy_config] for
+          full semantics. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -72,6 +72,10 @@ type config = {
           pinned numbers as the underlying [active_through] column propagates
           through the snapshot pipeline. Re-pinning goldens is a separate
           post-merge step. *)
+  margin_config : Trading_portfolio.Margin_config.t;
+      [@sexp.default Trading_portfolio.Margin_config.default_config]
+      (** Phase-2 margin-accounting parameters (issue #859,
+          [dev/plans/short-side-margin-2026-05-13.md] §2). See [.mli]. *)
 }
 [@@deriving sexp]
 
@@ -103,6 +107,7 @@ let default_config ~universe ~index_symbol =
     enable_continuation_buys = false;
     continuation_config = Continuation.default_config;
     enable_pi_filter = false;
+    margin_config = Trading_portfolio.Margin_config.default_config;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -53,6 +53,14 @@ type config = {
       (** Master switch for the screener point-in-time universe-membership
           filter (universe plan phase P5). Default [false] preserves existing
           baselines. See [.ml] for full semantics. *)
+  margin_config : Trading_portfolio.Margin_config.t;
+      [@sexp.default Trading_portfolio.Margin_config.default_config]
+      (** Phase-2 margin-accounting parameters (issue #859 / Phase 2). Opting in
+          via [margin_config.enabled = true] threads the value through the
+          backtest runner into the simulator's per-tick margin mechanics (daily
+          borrow fee + maintenance-margin force-cover). Default
+          {!Trading_portfolio.Margin_config.default_config} (disabled) preserves
+          bit-equality with prior baselines. See [.ml] for full semantics. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for


### PR DESCRIPTION
## Summary

Phase 2 of issue #859 wires the Phase-1 `Portfolio_margin` primitives into the
simulator's daily tick. With `margin_config.enabled = true`, each
market-close step now:

1. accrues one trading day of short borrow fee against `current_cash` and
   into `accrued_borrow_fee` (Portfolio_margin.accrue_daily_borrow_fee);
2. flags any short position whose maintenance equity ratio has fallen
   below `maintenance_margin_pct` (Portfolio_margin.check_maintenance_margin)
   and emits a margin-call `TriggerExit` transition that flows through the
   existing `Order_generator` path into a buy-to-cover order.

**Default-off invariant.** Both new code paths are no-ops when
`margin_config.enabled = false` (the `Margin_config.default_config`
default), preserving bit-equality with prior long-only and short-side
baselines until a scenario sexp opts in via
`margin_config.enabled = true`.

**Strategy-agnostic.** All new logic lives in a small `Margin_runner`
module under `trading/trading/simulation/lib/`. The Simulator and the
Weinstein strategy config both gain a `margin_config` field; the panel
runner reads the config field and threads it to `Simulator.create_deps`.
The margin-call exit reuses `StrategySignal { label = \"margin_call\"; ... }`
so the broker layer doesn't have to add a new variant to the shared
`Position.exit_reason` surface.

**Scope boundaries.** Phase 2 covers the daily accrual + maintenance
check only. Entry-time collateral lock (`apply_single_trade_with_margin`)
is Phase-1 territory and the simulator currently uses
`Portfolio.apply_single_trade` directly — so `locked_collateral` stays
0 in this PR's tests. Reported explicitly in the test assertions so a
future wiring change notices.

## Files

- `trading/trading/simulation/lib/margin_runner.{ml,mli}` (new):
  per-tick margin mechanics.
- `trading/trading/simulation/lib/simulator.{ml,mli}`:
  new `margin_config` field on `dependencies` (default
  `Margin_config.default_config`); new `_apply_margin_tick` helper
  called from `_process_step_day`.
- `trading/trading/simulation/test/test_margin_runner.ml` (new):
  4 tests covering default-off bit-equality, daily fee accrual,
  force-cover, and flag-on long-only equality.
- `trading/trading/weinstein/strategy/lib/weinstein_strategy_config.{ml,mli}`
  + `weinstein_strategy.mli`: new `margin_config` config field with the
  same default.
- `trading/trading/backtest/lib/panel_runner.ml`: thread
  `input.config.margin_config` into `Simulator.create_deps`.

## Test plan

- [x] \`dune build\`
- [x] \`dune build @fmt\`
- [x] \`dune runtest --force\` (EXIT=0; pre-existing
      \`stub_intentional_crash\` entries in unrelated test files remain
      as-is)
- [x] new tests run under \`simulation/test/test_margin_runner\`:
  - \`default_off_long_only_bit_equal\` — confirms long-only run is
    equity-bit-equal with margin_config disabled vs enabled
  - \`borrow_fee_accrual_multi_day\` — pins fee = N * notional *
    daily_rate exactly, with \`current_cash\` debited by the same amount
  - \`maintenance_margin_force_cover\` — rising-price short crosses the
    \$60 trigger; simulator emits a buy-to-cover and position closes
  - \`flag_on_long_only_bit_equal\` — second flag-on/off equity-state
    parity check

## A1 watchlist

Simulator carries the new code path. qc-structural will FLAG; the change
is strategy-agnostic (margin is a broker mechanic, not
Weinstein-specific): the new \`Margin_runner\` module + \`margin_config\`
config field encode broker semantics, and the margin-call \`TriggerExit\`
uses the existing \`StrategySignal\` escape hatch in
\`Position.exit_reason\` so the shared core surface gains no new variants.

Authority: \`dev/plans/short-side-margin-2026-05-13.md\` §2. Issue #859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)