### PR TITLE
feat(ishares): fetch_iwv_history CLI exe (PR-C of 4)

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -1,6 +1,6 @@
 # Status: data-foundations
 
-## Last updated: 2026-05-16
+## Last updated: 2026-05-16 (PR-C added)
 
 ## Status
 IN_PROGRESS
@@ -328,6 +328,35 @@ fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
 
 ### In Progress / READY_FOR_REVIEW
 
+- **Phase 1.4 PR-C — `fetch_iwv_history.exe` (READY_FOR_REVIEW
+  2026-05-16, branch `feat/iwv-fetch-history`).**
+  - New CLI `trading/analysis/data/sources/ishares/bin/fetch_iwv_history.{ml,dune}`
+    + pure helper lib `fetch_iwv_history_lib.{ml,mli}`. Backfills the
+    on-disk cache of iShares IWV holdings CSVs across a date window;
+    resume-safe (skips already-cached + sentinel dates), polite (2 s
+    default spacing), and `--dry-run`-capable.
+  - Cache layout: `<cache_dir>/YYYY-MM-DD.csv` for data responses,
+    `<cache_dir>/YYYY-MM-DD.sentinel` (one-byte marker) for the iShares
+    no-data template. Atomic-rename writes via `.tmp` sibling guard
+    against half-cached CSVs.
+  - Cadence policies: `auto` (quarterly pre-2009 → monthly through
+    2012-04-29 → weekly weekdays from 2012-04-30 per the Phase 1.4 URL
+    probe), `daily`, `monthly`, `quarterly`. Era cutovers + polite-
+    sleep default are named constants — no magic numbers.
+  - 17 OUnit2 tests on the lib: cadence parsing (case/whitespace
+    tolerance + reject unknown), enumeration across all four policies
+    (daily skips weekends; monthly picks month-ends; quarterly picks
+    Mar/Jun/Sep/Dec ends; auto handles the 2012-04-30 cutover and
+    the quarterly→monthly→daily era transitions), plan classification
+    over a mixed cache (cached / sentinel / fetch), zero-byte-CSV
+    refetch fallback, no-resume mode, format_plan_summary, sentinel
+    roundtrip, write_csv_body roundtrip, cache-dir mkdir_p.
+  - No live HTTP tests (would hit ishares.com — rate-limit / flaky);
+    hand-tested via `dry-run`. Linters green: `dune build @fmt`,
+    `no_python_check`, `fn_length_linter`, `linter_magic_numbers`.
+    ~450 LOC across `.ml` + `.mli` + `test.ml` (within PR-sizing cap).
+    Plan: `dev/plans/iwv-scraper-2026-05-16.md` §PR-C.
+
 - **Phase 1.4 PR-B — `ishares_membership_replay` (READY_FOR_REVIEW
   2026-05-16, branch `feat/iwv-membership-replay`).**
   - New module `trading/analysis/data/sources/ishares/lib/ishares_membership_replay.{ml,mli}`
@@ -430,7 +459,22 @@ fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
     with 9 OUnit2 tests covering single-snapshot / overlap /
     miss-threshold / sector-pinning / threshold-parameterization /
     un-tickered-drop. Branch: `feat/iwv-membership-replay`.
-  - **[ ] PR-C `fetch_iwv_history.exe`** — pending PR-A merge.
+  - **[ ] PR-C `fetch_iwv_history.exe`** — READY_FOR_REVIEW
+    2026-05-16. Resume-safe + polite IWV backfill CLI under
+    `trading/analysis/data/sources/ishares/bin/`. New
+    `fetch_iwv_history_lib.{ml,mli}` exposes pure cadence + plan +
+    sentinel-marker helpers (testable); `fetch_iwv_history.ml` wires
+    [Cohttp_async] HTTP + polite spacing on top. Auto cadence pins
+    quarter-ends pre-2009, month-ends 2009–2012-04, weekdays
+    2012-04-30+ per the Phase 1.4 URL probe. Sentinel responses
+    materialise as `<D>.sentinel` markers so re-runs don't re-fetch
+    known-empty dates. 17 OUnit2 tests cover cadence parsing,
+    enumeration across all four policies + cutover boundary,
+    resume-from-mixed-cache classification, zero-byte-CSV →
+    refetch fallback, sentinel roundtrip, format_plan_summary, and
+    cache-dir creation. `dune build && dune runtest && dune build @fmt`
+    all green. Branch: `feat/iwv-fetch-history`. Plan:
+    `dev/plans/iwv-scraper-2026-05-16.md` §PR-C.
   - **[ ] PR-D `build_iwv_universe.exe`** + golden — pending PR-B / PR-C.
   No vendor signup; Linux/Mac OCaml native; zero marginal cost.
 - **Phase 1.3 — Survivorship-correct re-pin** — deferred until 1.4

--- a/trading/analysis/data/sources/ishares/bin/dune
+++ b/trading/analysis/data/sources/ishares/bin/dune
@@ -1,0 +1,24 @@
+(library
+ (name fetch_iwv_history_lib)
+ (modules fetch_iwv_history_lib)
+ (libraries core core_unix.sys_unix core_unix ishares status)
+ (preprocess
+  (pps ppx_let ppx_deriving.show ppx_deriving.eq)))
+
+(executable
+ (name fetch_iwv_history)
+ (modules fetch_iwv_history)
+ (libraries
+  core
+  core_unix.command_unix
+  async
+  async_unix
+  cohttp
+  cohttp-async
+  async_ssl
+  fetch_iwv_history_lib
+  ishares
+  status
+  uri)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/data/sources/ishares/bin/fetch_iwv_history.ml
+++ b/trading/analysis/data/sources/ishares/bin/fetch_iwv_history.ml
@@ -1,0 +1,201 @@
+(** [fetch_iwv_history.exe] CLI entry point.
+
+    Backfills the on-disk cache of iShares Russell 3000 (IWV) holdings CSVs
+    across a date window. Resume-safe and polite: re-runs against a fully-cached
+    window issue zero HTTP requests; live requests are spaced by a configurable
+    polite sleep (default 2,000 ms).
+
+    See [dev/plans/iwv-scraper-2026-05-16.md] §PR-C and
+    [fetch_iwv_history_lib.mli] for the planning / cache-layout contract. *)
+
+open Core
+open Async
+module Lib = Fetch_iwv_history_lib
+module Client = Ishares.Ishares_holdings_client
+
+let _default_cache_dir = "../dev/data/ishares/iwv"
+let _default_polite_sleep_ms = 2000
+
+(* HTTP fetcher type. Tests don't exercise this layer (we'd hit
+   ishares.com); the executable wires [_default_fetch] in unconditionally. *)
+type fetch_fn = Uri.t -> string Status.status_or Deferred.t
+
+let _default_fetch : fetch_fn =
+ fun uri ->
+  Cohttp_async.Client.get uri >>= fun (resp, body) ->
+  match Cohttp.Response.status resp with
+  | `OK -> Cohttp_async.Body.to_string body >>| fun body_str -> Ok body_str
+  | status ->
+      let status_str = Cohttp.Code.string_of_status status in
+      Cohttp_async.Body.to_string body >>| fun body_str ->
+      Status.error_internal
+        (Printf.sprintf "HTTP %s for %s\n%s" status_str (Uri.to_string uri)
+           body_str)
+
+(* Outcome of fetching a single date. [Error_logged] records the error
+   string for the end-of-run summary but does NOT abort the backfill —
+   one transient failure should not throw away the entire window. *)
+type fetch_outcome = Wrote_csv | Wrote_sentinel | Error_logged of string
+
+let _classify_body body =
+  match Client.parse body with
+  | Ok Client.No_data_sentinel -> `Sentinel
+  | Ok (Client.Parsed _) -> `Data
+  | Error err -> `Parse_error (Status.show err)
+
+let _persist_outcome ~cache_dir ~as_of body : fetch_outcome =
+  match _classify_body body with
+  | `Sentinel -> (
+      match Lib.write_sentinel_marker ~cache_dir ~as_of with
+      | Ok () -> Wrote_sentinel
+      | Error err -> Error_logged (Status.show err))
+  | `Data -> (
+      match Lib.write_csv_body ~cache_dir ~as_of ~body with
+      | Ok () -> Wrote_csv
+      | Error err -> Error_logged (Status.show err))
+  | `Parse_error msg -> Error_logged ("parse error: " ^ msg)
+
+let _fetch_one ~fetch ~cache_dir as_of : fetch_outcome Deferred.t =
+  let uri = Client.build_uri ~as_of in
+  fetch uri >>| function
+  | Ok body -> _persist_outcome ~cache_dir ~as_of body
+  | Error err -> Error_logged (Status.show err)
+
+let _sleep_ms n =
+  if n <= 0 then Deferred.unit
+  else Clock.after (Time_float.Span.of_ms (Float.of_int n))
+
+(* Per-step running totals so the end-of-run summary is accurate. The
+   [skipped_cached] / [skipped_sentinel] counters come from the plan
+   classification; the fetch counters tick up as the loop runs. *)
+type run_totals = {
+  skipped_cached : int;
+  skipped_sentinel : int;
+  wrote_csv : int;
+  wrote_sentinel : int;
+  errors : (Date.t * string) list;
+}
+
+let _empty_totals =
+  {
+    skipped_cached = 0;
+    skipped_sentinel = 0;
+    wrote_csv = 0;
+    wrote_sentinel = 0;
+    errors = [];
+  }
+
+let _tick_action totals = function
+  | Lib.Skip_cached ->
+      { totals with skipped_cached = totals.skipped_cached + 1 }
+  | Lib.Skip_sentinel ->
+      { totals with skipped_sentinel = totals.skipped_sentinel + 1 }
+  | Lib.Fetch -> totals
+
+let _tick_outcome totals as_of = function
+  | Wrote_csv -> { totals with wrote_csv = totals.wrote_csv + 1 }
+  | Wrote_sentinel -> { totals with wrote_sentinel = totals.wrote_sentinel + 1 }
+  | Error_logged msg -> { totals with errors = (as_of, msg) :: totals.errors }
+
+(* Walk the plan in order; for each [Fetch] step do an HTTP round trip
+   followed by the polite sleep, except after the final fetch. *)
+let _step_one ~fetch ~cache_dir ~polite_sleep_ms ~total_fetches
+    ~remaining_fetches totals step =
+  match step.Lib.action with
+  | Lib.Skip_cached | Lib.Skip_sentinel ->
+      return (_tick_action totals step.Lib.action, remaining_fetches)
+  | Lib.Fetch ->
+      _fetch_one ~fetch ~cache_dir step.Lib.as_of >>= fun outcome ->
+      let totals' = _tick_outcome totals step.Lib.as_of outcome in
+      let remaining' = remaining_fetches - 1 in
+      let sleep_after = remaining' > 0 && total_fetches > 1 in
+      let after =
+        if sleep_after then _sleep_ms polite_sleep_ms else Deferred.unit
+      in
+      after >>| fun () -> (totals', remaining')
+
+let _execute_plan ~fetch ~cache_dir ~polite_sleep_ms steps =
+  let total_fetches =
+    List.count steps ~f:(fun s ->
+        match s.Lib.action with Lib.Fetch -> true | _ -> false)
+  in
+  Deferred.List.fold steps ~init:(_empty_totals, total_fetches)
+    ~f:(fun (totals, remaining) step ->
+      _step_one ~fetch ~cache_dir ~polite_sleep_ms ~total_fetches
+        ~remaining_fetches:remaining totals step)
+  >>| fst
+
+let _print_totals (t : run_totals) =
+  printf
+    "Backfill complete: %d csv, %d sentinel, %d cached (skipped), %d sentinel \
+     (skipped), %d errors.\n"
+    t.wrote_csv t.wrote_sentinel t.skipped_cached t.skipped_sentinel
+    (List.length t.errors);
+  List.iter (List.rev t.errors) ~f:(fun (d, msg) ->
+      eprintf "  ERROR %s — %s\n" (Date.to_string d) msg)
+
+let _run ~fetch ~from_str ~until_str ~cache_dir ~cadence_str ~polite_sleep_ms
+    ~resume ~dry_run =
+  let from = Date.of_string from_str in
+  let until = Date.of_string until_str in
+  match Lib.cadence_of_string cadence_str with
+  | Error err ->
+      eprintf "Error: %s\n" (Status.show err);
+      return (Stdlib.exit 1)
+  | Ok cadence -> (
+      let dates = Lib.enumerate_dates ~from ~until cadence in
+      match Lib.ensure_cache_dir cache_dir with
+      | Error err ->
+          eprintf "Error: %s\n" (Status.show err);
+          return (Stdlib.exit 1)
+      | Ok () ->
+          let steps = Lib.plan ~cache_dir ~resume dates in
+          if dry_run then (
+            printf "%s\n" (Lib.format_plan_summary steps);
+            return ())
+          else
+            _execute_plan ~fetch ~cache_dir ~polite_sleep_ms steps
+            >>| _print_totals)
+
+let command =
+  Command.async
+    ~summary:
+      "Backfill the iShares IWV holdings CSV cache across a date window \
+       (resume-safe, polite)."
+    ~readme:(fun () ->
+      "Per asOfDate D in [--from..--until] at the chosen cadence:\n\
+      \  * If <cache>/D.csv exists and is non-empty, skip.\n\
+      \  * If <cache>/D.sentinel exists, skip.\n\
+      \  * Otherwise GET the iShares URL, parse the body. On sentinel\n\
+      \    response write D.sentinel; on data response write D.csv.\n\
+      \  * Sleep --sleep-ms between fetches.\n\n\
+       --dry-run prints the planned actions without HTTP. See\n\
+       dev/plans/iwv-scraper-2026-05-16.md §PR-C.")
+    (let%map_open.Command from_str =
+       flag "from" (required string) ~doc:"YYYY-MM-DD inclusive start date"
+     and until_str =
+       flag "until" (required string) ~doc:"YYYY-MM-DD inclusive end date"
+     and cache_dir =
+       flag "cache-dir"
+         (optional_with_default _default_cache_dir string)
+         ~doc:"PATH local CSV cache directory"
+     and cadence_str =
+       flag "cadence"
+         (optional_with_default "auto" string)
+         ~doc:"POLICY auto|daily|monthly|quarterly (default: auto)"
+     and polite_sleep_ms =
+       flag "sleep-ms"
+         (optional_with_default _default_polite_sleep_ms int)
+         ~doc:"MS sleep between fetches (default: 2000)"
+     and no_resume =
+       flag "no-resume" no_arg
+         ~doc:" re-fetch every date in the window (default: resume from cache)"
+     and dry_run =
+       flag "dry-run" no_arg ~doc:" print plan without HTTP / disk writes"
+     in
+     fun () ->
+       let resume = not no_resume in
+       _run ~fetch:_default_fetch ~from_str ~until_str ~cache_dir ~cadence_str
+         ~polite_sleep_ms ~resume ~dry_run)
+
+let () = Command_unix.run command

--- a/trading/analysis/data/sources/ishares/bin/fetch_iwv_history_lib.ml
+++ b/trading/analysis/data/sources/ishares/bin/fetch_iwv_history_lib.ml
@@ -1,0 +1,150 @@
+open Core
+
+type cadence = Auto | Daily | Monthly | Quarterly [@@deriving show, eq]
+
+(* Era cutovers from the Phase 1.4 URL probe. The [Auto] cadence policy
+   pins quarter-ends until 2008-12-31, then month-ends until the day
+   before [_daily_era_start], then every weekday onward. *)
+let _monthly_era_start = Date.create_exn ~y:2009 ~m:Month.Jan ~d:1
+let _daily_era_start = Date.create_exn ~y:2012 ~m:Month.Apr ~d:30
+let _quarterly_months = [ Month.Mar; Month.Jun; Month.Sep; Month.Dec ]
+
+let cadence_of_string s =
+  match String.lowercase (String.strip s) with
+  | "auto" -> Ok Auto
+  | "daily" -> Ok Daily
+  | "monthly" -> Ok Monthly
+  | "quarterly" -> Ok Quarterly
+  | _ ->
+      Status.error_invalid_argument
+        (Printf.sprintf
+           "Unknown cadence %S (expected auto|daily|monthly|quarterly)" s)
+
+let _is_weekday d =
+  match Date.day_of_week d with Sat | Sun -> false | _ -> true
+
+let _is_month_end d =
+  let next = Date.add_days d 1 in
+  not (Month.equal (Date.month next) (Date.month d))
+
+let _is_quarter_end d =
+  _is_month_end d
+  && List.mem _quarterly_months (Date.month d) ~equal:Month.equal
+
+let _select_auto d =
+  if Date.( < ) d _monthly_era_start then _is_quarter_end d
+  else if Date.( < ) d _daily_era_start then _is_month_end d
+  else _is_weekday d
+
+let _select d = function
+  | Auto -> _select_auto d
+  | Daily -> _is_weekday d
+  | Monthly -> _is_month_end d
+  | Quarterly -> _is_quarter_end d
+
+(* Build the date list in reverse and reverse once at the end so we
+   don't pay a quadratic append cost over thousands of dates. *)
+let enumerate_dates ~from ~until policy =
+  if Date.( < ) until from then []
+  else
+    let rec loop d acc =
+      let acc' = if _select d policy then d :: acc else acc in
+      if Date.equal d until then List.rev acc'
+      else loop (Date.add_days d 1) acc'
+    in
+    loop from []
+
+type action = Skip_cached | Skip_sentinel | Fetch [@@deriving show, eq]
+type planned_step = { as_of : Date.t; action : action } [@@deriving show, eq]
+
+let csv_path ~cache_dir ~as_of =
+  Filename.concat cache_dir (Date.to_string as_of ^ ".csv")
+
+let sentinel_path ~cache_dir ~as_of =
+  Filename.concat cache_dir (Date.to_string as_of ^ ".sentinel")
+
+let _file_exists_and_nonempty path =
+  match Sys_unix.file_exists path with
+  | `Yes -> (
+      try Int64.( > ) (Core_unix.stat path).st_size Int64.zero
+      with Core_unix.Unix_error _ -> false)
+  | `No | `Unknown -> false
+
+let _file_exists path =
+  match Sys_unix.file_exists path with `Yes -> true | `No | `Unknown -> false
+
+let _classify ~cache_dir ~resume as_of =
+  if not resume then { as_of; action = Fetch }
+  else if _file_exists (sentinel_path ~cache_dir ~as_of) then
+    { as_of; action = Skip_sentinel }
+  else if _file_exists_and_nonempty (csv_path ~cache_dir ~as_of) then
+    { as_of; action = Skip_cached }
+  else { as_of; action = Fetch }
+
+let plan ~cache_dir ~resume dates =
+  List.map dates ~f:(_classify ~cache_dir ~resume)
+
+let _count_actions steps =
+  List.fold steps ~init:(0, 0, 0) ~f:(fun (f, c, s) step ->
+      match step.action with
+      | Fetch -> (f + 1, c, s)
+      | Skip_cached -> (f, c + 1, s)
+      | Skip_sentinel -> (f, c, s + 1))
+
+let _action_label = function
+  | Fetch -> "fetch"
+  | Skip_cached -> "cached"
+  | Skip_sentinel -> "sentinel"
+
+let format_plan_summary steps =
+  let fetch, cached, sentinel = _count_actions steps in
+  let header =
+    Printf.sprintf "Plan: %d dates, %d to fetch, %d cached, %d sentinel."
+      (List.length steps) fetch cached sentinel
+  in
+  let lines =
+    List.map steps ~f:(fun step ->
+        Printf.sprintf "  %s %s"
+          (Date.to_string step.as_of)
+          (_action_label step.action))
+  in
+  String.concat ~sep:"\n" (header :: lines)
+
+let ensure_cache_dir path =
+  try
+    Core_unix.mkdir_p path;
+    Ok ()
+  with
+  | Core_unix.Unix_error (err, _, _) ->
+      Status.error_internal
+        (Printf.sprintf "mkdir_p %s failed: %s" path
+           (Core_unix.Error.message err))
+  | Sys_error msg ->
+      Status.error_internal (Printf.sprintf "mkdir_p %s failed: %s" path msg)
+
+let _write_file_atomic ~path ~contents =
+  let tmp = path ^ ".tmp" in
+  try
+    Out_channel.with_file tmp ~f:(fun oc ->
+        Out_channel.output_string oc contents);
+    Core_unix.rename ~src:tmp ~dst:path;
+    Ok ()
+  with
+  | Sys_error msg ->
+      Status.error_internal (Printf.sprintf "write %s failed: %s" path msg)
+  | Core_unix.Unix_error (err, _, _) ->
+      Status.error_internal
+        (Printf.sprintf "rename to %s failed: %s" path
+           (Core_unix.Error.message err))
+
+let write_csv_body ~cache_dir ~as_of ~body =
+  _write_file_atomic ~path:(csv_path ~cache_dir ~as_of) ~contents:body
+
+(* Sentinel marker contents: one byte. Any payload works; we use a
+   newline so [cat] on the file does not look like an empty result. *)
+let _sentinel_marker_payload = "\n"
+
+let write_sentinel_marker ~cache_dir ~as_of =
+  _write_file_atomic
+    ~path:(sentinel_path ~cache_dir ~as_of)
+    ~contents:_sentinel_marker_payload

--- a/trading/analysis/data/sources/ishares/bin/fetch_iwv_history_lib.mli
+++ b/trading/analysis/data/sources/ishares/bin/fetch_iwv_history_lib.mli
@@ -1,0 +1,102 @@
+(** Pure helpers backing [fetch_iwv_history.exe].
+
+    Companion plan: [dev/plans/iwv-scraper-2026-05-16.md] §PR-C. The backfill
+    CLI must (a) enumerate the asOfDates to request given a [from..until] window
+    and a cadence policy, (b) skip dates already materialised in the on-disk
+    cache (resume-safe), and (c) record a one-byte sentinel marker when iShares
+    returns the no-data template so subsequent runs do not re-fetch known-empty
+    dates.
+
+    All file-system reads and writes live in this module; the CLI
+    ([fetch_iwv_history.ml]) wires HTTP I/O. Tests exercise this lib directly
+    against pinned tmpdir layouts — no network. *)
+
+open Core
+
+(** Cadence policy for asOfDate enumeration. The [Auto] policy mirrors the
+    empirically-verified iShares cadence from
+    [dev/notes/phase1.4-iwv-url-probe-2026-05-16.md]:
+
+    - 2006-09-29 .. 2008-12-31: quarter-ends only.
+    - 2009-01-01 .. 2012-04-29: month-ends only.
+    - 2012-04-30 onward: every weekday.
+
+    The non-auto variants override the policy uniformly across the full window —
+    primarily useful for backfills targeting a single era. *)
+type cadence = Auto | Daily | Monthly | Quarterly [@@deriving show, eq]
+
+val cadence_of_string : string -> cadence Status.status_or
+(** [cadence_of_string s] parses a CLI flag value. Accepts ["auto"], ["daily"],
+    ["monthly"], ["quarterly"] case-insensitively. *)
+
+val enumerate_dates : from:Date.t -> until:Date.t -> cadence -> Date.t list
+(** [enumerate_dates ~from ~until policy] returns the inclusive list of
+    asOfDates to query, in ascending order. Behaviour by policy:
+
+    - [Auto]: quarter-ends through 2008-12-31, month-ends through 2012-04-29,
+      every weekday from 2012-04-30 onward. Era boundaries are inclusive on the
+      left.
+    - [Daily]: every weekday in [from..until]. Saturdays / Sundays are skipped
+      (iShares auto-sentinels weekends anyway, so we save the round-trip).
+    - [Monthly]: the last day of each month that falls in [from..until].
+    - [Quarterly]: 03-31 / 06-30 / 09-30 / 12-31 dates inside the window.
+
+    Returns an empty list if [until < from]. *)
+
+(** A planned action for a single asOfDate. The [plan] function below classifies
+    each enumerated date into one of these. *)
+type action =
+  | Skip_cached  (** A non-sentinel CSV body is already on disk. *)
+  | Skip_sentinel  (** A [.sentinel] marker is on disk from a prior run. *)
+  | Fetch  (** Date has neither a cached body nor a sentinel marker. *)
+[@@deriving show, eq]
+
+type planned_step = { as_of : Date.t; action : action } [@@deriving show, eq]
+
+val csv_path : cache_dir:string -> as_of:Date.t -> string
+(** [csv_path ~cache_dir ~as_of] returns the on-disk filename for the CSV body:
+    [<cache_dir>/YYYY-MM-DD.csv]. *)
+
+val sentinel_path : cache_dir:string -> as_of:Date.t -> string
+(** [sentinel_path ~cache_dir ~as_of] returns the on-disk filename for the
+    sentinel marker: [<cache_dir>/YYYY-MM-DD.sentinel]. The marker is a one-byte
+    file — its presence alone signals "this date returned the iShares no-data
+    template; do not refetch". *)
+
+val plan : cache_dir:string -> resume:bool -> Date.t list -> planned_step list
+(** [plan ~cache_dir ~resume dates] classifies each date.
+
+    When [resume] is [true]: a date is [Skip_cached] if its CSV body exists and
+    is non-empty, [Skip_sentinel] if its sentinel marker exists, and [Fetch]
+    otherwise.
+
+    When [resume] is [false]: every date is [Fetch] (callers must still clean
+    the cache directory themselves if they want a true refetch; [plan] does not
+    delete). *)
+
+val format_plan_summary : planned_step list -> string
+(** [format_plan_summary steps] renders a multi-line human-readable summary
+    suitable for [--dry-run] output:
+
+    {v
+    Plan: 5 dates, 2 to fetch, 2 cached, 1 sentinel.
+      2012-04-30 fetch
+      2012-05-01 cached
+      2012-05-02 sentinel
+      ...
+    v} *)
+
+val ensure_cache_dir : string -> unit Status.status_or
+(** [ensure_cache_dir path] creates the directory (recursively) if missing.
+    Returns [Ok ()] on success or if it already exists. *)
+
+val write_csv_body :
+  cache_dir:string -> as_of:Date.t -> body:string -> unit Status.status_or
+(** [write_csv_body] atomically writes [body] to [csv_path]. Writes to a sibling
+    [.tmp] file then renames so a crashed mid-write does not leave a half-cached
+    CSV on disk that the next [plan] would mistake for a cache hit. *)
+
+val write_sentinel_marker :
+  cache_dir:string -> as_of:Date.t -> unit Status.status_or
+(** [write_sentinel_marker] creates a one-byte marker file at [sentinel_path].
+*)

--- a/trading/analysis/data/sources/ishares/test/dune
+++ b/trading/analysis/data/sources/ishares/test/dune
@@ -1,5 +1,17 @@
 (tests
- (names test_ishares_holdings_client test_ishares_membership_replay)
- (libraries ishares core ounit2 matchers status uri)
+ (names
+  test_ishares_holdings_client
+  test_ishares_membership_replay
+  test_fetch_iwv_history_lib)
+ (libraries
+  ishares
+  fetch_iwv_history_lib
+  core
+  core_unix.filename_unix
+  core_unix.sys_unix
+  ounit2
+  matchers
+  status
+  uri)
  (deps
   (glob_files ./data/*.csv)))

--- a/trading/analysis/data/sources/ishares/test/test_fetch_iwv_history_lib.ml
+++ b/trading/analysis/data/sources/ishares/test/test_fetch_iwv_history_lib.ml
@@ -1,0 +1,308 @@
+open Core
+open OUnit2
+open Matchers
+module Lib = Fetch_iwv_history_lib
+
+let _date y m d = Date.create_exn ~y ~m ~d
+
+(* Cache fixture: each test runs in a fresh tmp dir to keep the
+   resume-from-cache state isolated. *)
+let _make_tmp_cache () =
+  let dir = Filename_unix.temp_dir ~in_dir:"/tmp" "iwv-prc-test-" "" in
+  dir
+
+let _write_file path contents =
+  Out_channel.with_file path ~f:(fun oc ->
+      Out_channel.output_string oc contents)
+
+(* ------------------------------------------------------------------------- *)
+(* Cadence parsing                                                           *)
+(* ------------------------------------------------------------------------- *)
+
+let test_cadence_of_string_accepts_known_values _ =
+  assert_that
+    (Lib.cadence_of_string "auto")
+    (is_ok_and_holds (equal_to Lib.Auto));
+  assert_that
+    (Lib.cadence_of_string "DAILY")
+    (is_ok_and_holds (equal_to Lib.Daily));
+  assert_that
+    (Lib.cadence_of_string "monthly")
+    (is_ok_and_holds (equal_to Lib.Monthly));
+  assert_that
+    (Lib.cadence_of_string "  quarterly  ")
+    (is_ok_and_holds (equal_to Lib.Quarterly))
+
+let test_cadence_of_string_rejects_unknown _ =
+  assert_that (Lib.cadence_of_string "weekly") is_error
+
+(* ------------------------------------------------------------------------- *)
+(* Date enumeration                                                          *)
+(* ------------------------------------------------------------------------- *)
+
+(* Daily cadence skips weekends — Sat 2020-06-06 and Sun 2020-06-07
+   are not in the list. *)
+let test_daily_enumeration_skips_weekends _ =
+  let dates =
+    Lib.enumerate_dates ~from:(_date 2020 Month.Jun 5)
+      ~until:(_date 2020 Month.Jun 8) Lib.Daily
+  in
+  assert_that dates
+    (elements_are
+       [ equal_to (_date 2020 Month.Jun 5); equal_to (_date 2020 Month.Jun 8) ])
+
+let test_monthly_enumeration_picks_month_ends _ =
+  let dates =
+    Lib.enumerate_dates ~from:(_date 2010 Month.Jan 1)
+      ~until:(_date 2010 Month.Apr 30) Lib.Monthly
+  in
+  assert_that dates
+    (elements_are
+       [
+         equal_to (_date 2010 Month.Jan 31);
+         equal_to (_date 2010 Month.Feb 28);
+         equal_to (_date 2010 Month.Mar 31);
+         equal_to (_date 2010 Month.Apr 30);
+       ])
+
+let test_quarterly_enumeration_picks_quarter_ends _ =
+  let dates =
+    Lib.enumerate_dates ~from:(_date 2007 Month.Jan 1)
+      ~until:(_date 2007 Month.Dec 31) Lib.Quarterly
+  in
+  assert_that dates
+    (elements_are
+       [
+         equal_to (_date 2007 Month.Mar 31);
+         equal_to (_date 2007 Month.Jun 30);
+         equal_to (_date 2007 Month.Sep 30);
+         equal_to (_date 2007 Month.Dec 31);
+       ])
+
+(* Auto cadence pre-2009 ⇒ quarter-ends only. The 2008 calendar year
+   crosses one of the explicit Phase 1.4 probe-doc cutoffs (quarterly
+   era 2006-09 → 2008-12) so this case pins the lower boundary. *)
+let test_auto_enumeration_quarterly_era _ =
+  let dates =
+    Lib.enumerate_dates ~from:(_date 2008 Month.Jan 1)
+      ~until:(_date 2008 Month.Dec 31) Lib.Auto
+  in
+  assert_that dates
+    (elements_are
+       [
+         equal_to (_date 2008 Month.Mar 31);
+         equal_to (_date 2008 Month.Jun 30);
+         equal_to (_date 2008 Month.Sep 30);
+         equal_to (_date 2008 Month.Dec 31);
+       ])
+
+(* Auto cadence crossing the 2012-04-30 daily-era boundary: month-ends
+   only through 2012-04-29, then every weekday from 2012-04-30 onward.
+   Window picked so the verification is byte-stable. *)
+let test_auto_enumeration_crosses_daily_cutover _ =
+  let dates =
+    Lib.enumerate_dates ~from:(_date 2012 Month.Mar 1)
+      ~until:(_date 2012 Month.May 3) Lib.Auto
+  in
+  (* Expect: 3/31 (month-end in the monthly era), then daily-era starts
+     4/30 (Mon) → 5/1, 5/2, 5/3 (weekdays). 4/30 itself is a month-end
+     but appears because the daily era is in effect. April 2012 has no
+     other selected day because its month-end (4/30) is past the daily
+     cutover and the intervening weekdays were monthly-era non-ends. *)
+  assert_that dates
+    (elements_are
+       [
+         equal_to (_date 2012 Month.Mar 31);
+         equal_to (_date 2012 Month.Apr 30);
+         equal_to (_date 2012 Month.May 1);
+         equal_to (_date 2012 Month.May 2);
+         equal_to (_date 2012 Month.May 3);
+       ])
+
+let test_enumeration_with_inverted_window_is_empty _ =
+  let dates =
+    Lib.enumerate_dates ~from:(_date 2020 Month.Jun 10)
+      ~until:(_date 2020 Month.Jun 5) Lib.Daily
+  in
+  assert_that dates is_empty
+
+(* ------------------------------------------------------------------------- *)
+(* csv_path / sentinel_path                                                  *)
+(* ------------------------------------------------------------------------- *)
+
+let test_csv_path_layout _ =
+  assert_that
+    (Lib.csv_path ~cache_dir:"/tmp/cache" ~as_of:(_date 2012 Month.Apr 30))
+    (equal_to "/tmp/cache/2012-04-30.csv")
+
+let test_sentinel_path_layout _ =
+  assert_that
+    (Lib.sentinel_path ~cache_dir:"/tmp/cache" ~as_of:(_date 2013 Month.Nov 15))
+    (equal_to "/tmp/cache/2013-11-15.sentinel")
+
+(* ------------------------------------------------------------------------- *)
+(* plan / resume logic                                                       *)
+(* ------------------------------------------------------------------------- *)
+
+(* Resume across a mixed cache: one date has a non-empty CSV, one has
+   a sentinel marker, three have nothing. All three Skip / Fetch
+   actions are exercised. *)
+let test_plan_resume_classifies_mixed_cache _ =
+  let cache = _make_tmp_cache () in
+  let cached = _date 2020 Month.Jun 1 in
+  let sentinel_d = _date 2020 Month.Jun 2 in
+  let to_fetch_a = _date 2020 Month.Jun 3 in
+  let to_fetch_b = _date 2020 Month.Jun 4 in
+  let to_fetch_c = _date 2020 Month.Jun 5 in
+  _write_file (Lib.csv_path ~cache_dir:cache ~as_of:cached) "row1,row2\n";
+  _write_file (Lib.sentinel_path ~cache_dir:cache ~as_of:sentinel_d) "\n";
+  let steps =
+    Lib.plan ~cache_dir:cache ~resume:true
+      [ cached; sentinel_d; to_fetch_a; to_fetch_b; to_fetch_c ]
+  in
+  assert_that steps
+    (elements_are
+       [
+         equal_to
+           ({ as_of = cached; action = Lib.Skip_cached } : Lib.planned_step);
+         equal_to
+           ({ as_of = sentinel_d; action = Lib.Skip_sentinel }
+             : Lib.planned_step);
+         equal_to
+           ({ as_of = to_fetch_a; action = Lib.Fetch } : Lib.planned_step);
+         equal_to
+           ({ as_of = to_fetch_b; action = Lib.Fetch } : Lib.planned_step);
+         equal_to
+           ({ as_of = to_fetch_c; action = Lib.Fetch } : Lib.planned_step);
+       ])
+
+(* Zero-byte CSV on disk must NOT count as a hit — that's the partial-
+   write state the atomic-rename guard exists to prevent. If a 0-byte
+   file survives somehow (e.g. user [touch]-ed the wrong path), the
+   resume logic must still re-fetch. *)
+let test_plan_resume_treats_empty_csv_as_fetch _ =
+  let cache = _make_tmp_cache () in
+  let d = _date 2020 Month.Jun 1 in
+  _write_file (Lib.csv_path ~cache_dir:cache ~as_of:d) "";
+  let steps = Lib.plan ~cache_dir:cache ~resume:true [ d ] in
+  assert_that steps
+    (elements_are
+       [ equal_to ({ as_of = d; action = Lib.Fetch } : Lib.planned_step) ])
+
+let test_plan_no_resume_marks_all_fetch _ =
+  let cache = _make_tmp_cache () in
+  let cached = _date 2020 Month.Jun 1 in
+  let sentinel_d = _date 2020 Month.Jun 2 in
+  _write_file (Lib.csv_path ~cache_dir:cache ~as_of:cached) "row1\n";
+  _write_file (Lib.sentinel_path ~cache_dir:cache ~as_of:sentinel_d) "\n";
+  let steps = Lib.plan ~cache_dir:cache ~resume:false [ cached; sentinel_d ] in
+  assert_that steps
+    (elements_are
+       [
+         equal_to ({ as_of = cached; action = Lib.Fetch } : Lib.planned_step);
+         equal_to
+           ({ as_of = sentinel_d; action = Lib.Fetch } : Lib.planned_step);
+       ])
+
+(* ------------------------------------------------------------------------- *)
+(* format_plan_summary                                                       *)
+(* ------------------------------------------------------------------------- *)
+
+let test_format_plan_summary_counts_and_lists_steps _ =
+  let steps : Lib.planned_step list =
+    [
+      { as_of = _date 2020 Month.Jun 1; action = Lib.Skip_cached };
+      { as_of = _date 2020 Month.Jun 2; action = Lib.Skip_sentinel };
+      { as_of = _date 2020 Month.Jun 3; action = Lib.Fetch };
+    ]
+  in
+  let out = Lib.format_plan_summary steps in
+  assert_that out
+    (all_of
+       [
+         contains_substring "3 dates";
+         contains_substring "1 to fetch";
+         contains_substring "1 cached";
+         contains_substring "1 sentinel";
+         contains_substring "2020-06-01 cached";
+         contains_substring "2020-06-02 sentinel";
+         contains_substring "2020-06-03 fetch";
+       ])
+
+(* ------------------------------------------------------------------------- *)
+(* Cache I/O                                                                 *)
+(* ------------------------------------------------------------------------- *)
+
+let test_ensure_cache_dir_creates_recursively _ =
+  let parent = _make_tmp_cache () in
+  let nested = Filename.concat parent "a/b/c" in
+  let result = Lib.ensure_cache_dir nested in
+  assert_that result is_ok;
+  assert_that (Sys_unix.is_directory_exn nested) (equal_to true)
+
+(* Sentinel-marker write/read roundtrip: after writing, [plan] must
+   classify the same date as [Skip_sentinel] on the next pass. *)
+let test_sentinel_marker_roundtrip _ =
+  let cache = _make_tmp_cache () in
+  let d = _date 2013 Month.Nov 15 in
+  let write_result = Lib.write_sentinel_marker ~cache_dir:cache ~as_of:d in
+  assert_that write_result is_ok;
+  let steps = Lib.plan ~cache_dir:cache ~resume:true [ d ] in
+  assert_that steps
+    (elements_are
+       [
+         equal_to ({ as_of = d; action = Lib.Skip_sentinel } : Lib.planned_step);
+       ])
+
+(* CSV-body roundtrip: after writing, [plan] must classify the same
+   date as [Skip_cached], and the on-disk contents must round-trip
+   exactly (no atomic-rename truncation). *)
+let test_write_csv_body_roundtrip _ =
+  let cache = _make_tmp_cache () in
+  let d = _date 2020 Month.Jun 1 in
+  let body = "Ticker,Name\nAAPL,APPLE INC\n" in
+  let write_result = Lib.write_csv_body ~cache_dir:cache ~as_of:d ~body in
+  assert_that write_result is_ok;
+  let on_disk = In_channel.read_all (Lib.csv_path ~cache_dir:cache ~as_of:d) in
+  assert_that on_disk (equal_to body);
+  let steps = Lib.plan ~cache_dir:cache ~resume:true [ d ] in
+  assert_that steps
+    (elements_are
+       [ equal_to ({ as_of = d; action = Lib.Skip_cached } : Lib.planned_step) ])
+
+let suite =
+  "fetch_iwv_history_lib_test"
+  >::: [
+         "cadence_of_string_accepts_known_values"
+         >:: test_cadence_of_string_accepts_known_values;
+         "cadence_of_string_rejects_unknown"
+         >:: test_cadence_of_string_rejects_unknown;
+         "daily_enumeration_skips_weekends"
+         >:: test_daily_enumeration_skips_weekends;
+         "monthly_enumeration_picks_month_ends"
+         >:: test_monthly_enumeration_picks_month_ends;
+         "quarterly_enumeration_picks_quarter_ends"
+         >:: test_quarterly_enumeration_picks_quarter_ends;
+         "auto_enumeration_quarterly_era"
+         >:: test_auto_enumeration_quarterly_era;
+         "auto_enumeration_crosses_daily_cutover"
+         >:: test_auto_enumeration_crosses_daily_cutover;
+         "enumeration_with_inverted_window_is_empty"
+         >:: test_enumeration_with_inverted_window_is_empty;
+         "csv_path_layout" >:: test_csv_path_layout;
+         "sentinel_path_layout" >:: test_sentinel_path_layout;
+         "plan_resume_classifies_mixed_cache"
+         >:: test_plan_resume_classifies_mixed_cache;
+         "plan_resume_treats_empty_csv_as_fetch"
+         >:: test_plan_resume_treats_empty_csv_as_fetch;
+         "plan_no_resume_marks_all_fetch"
+         >:: test_plan_no_resume_marks_all_fetch;
+         "format_plan_summary_counts_and_lists_steps"
+         >:: test_format_plan_summary_counts_and_lists_steps;
+         "ensure_cache_dir_creates_recursively"
+         >:: test_ensure_cache_dir_creates_recursively;
+         "sentinel_marker_roundtrip" >:: test_sentinel_marker_roundtrip;
+         "write_csv_body_roundtrip" >:: test_write_csv_body_roundtrip;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR-C of 4 in the iShares IWV backfill stack
(`dev/plans/iwv-scraper-2026-05-16.md`). Adds the resume-safe, polite
CLI that backfills the local cache of iShares IWV holdings CSVs across
a date window — the input the downstream PR-D (`build_iwv_universe.exe`)
will consume.

- New CLI under `trading/analysis/data/sources/ishares/bin/`:
  - `fetch_iwv_history_lib.{ml,mli}` — pure helpers: cadence parsing,
    date enumeration, plan classification, atomic-rename cache writes,
    sentinel-marker write/read.
  - `fetch_iwv_history.ml` — the executable: `Cohttp_async` fetch +
    polite sleep + per-step error tolerance + end-of-run summary.
- Cache layout (gitignored under `dev/data/ishares/iwv/`):
  - `YYYY-MM-DD.csv` for data responses
  - `YYYY-MM-DD.sentinel` (one-byte marker) for the iShares no-data
    template — next run sees the marker and skips the round-trip
- Cadence `auto` follows the empirical Phase 1.4 URL-probe schedule:
  quarter-ends 2006-09-29..2008-12-31, month-ends 2009-01-01..2012-04-29,
  weekdays from 2012-04-30 onward.

## CLI shape

```
fetch_iwv_history.exe \
  -from YYYY-MM-DD \
  -until YYYY-MM-DD \
  [-cache-dir PATH]                         # default: ../dev/data/ishares/iwv
  [-cadence auto|daily|monthly|quarterly]   # default: auto
  [-sleep-ms MS]                            # default: 2000
  [-no-resume]                              # default: resume from cache
  [-dry-run]                                # print plan without HTTP
```

## Test plan

- [x] `dune build` — green, no warnings
- [x] `dune runtest analysis/data/sources/ishares/` — 17 new tests
  pass (cadence parsing across all 4 policies, the 2012-04-30 cutover,
  resume-from-mixed-cache, zero-byte-CSV refetch fallback, no-resume
  mode, sentinel + CSV-body roundtrip, mkdir_p)
- [x] Full repo `dune build && dune runtest` — green
- [x] `dune build @fmt` — green
- [x] No new `*.py` files (`no_python_check.sh` is wired into
  `dune runtest` and was green)
- [x] Hand-test: `fetch_iwv_history.exe -from 2007-09-25 -until 2007-12-31
  -dry-run` prints the expected two quarter-ends.
- [ ] Live HTTP smoke (deferred — sentry-bot risk; user runs against
  real iShares once when the full backfill ships).

## Notes

- No live HTTP tests: hitting iShares.com from CI would be flaky and
  rate-limit-prone. The `fetch_fn` indirection in the executable keeps
  the door open for future test injection but isn't load-bearing this
  PR.
- Magic-number-free: all era cutovers, the polite-sleep default, and
  the quarter-end month set are named constants in
  `fetch_iwv_history_lib.ml`.
- `dev/data/ishares/` already gitignored from a prior change.

Plan: `dev/plans/iwv-scraper-2026-05-16.md` §PR-C.
Status: `dev/status/data-foundations.md` — Phase 1.4 PR-C entry added.