### PR TITLE
fix(ci): remove cache restore-keys to prevent stale-binary corruption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,13 @@ jobs:
       #
       # Key strategy: hash everything dune sees as input. On a hit we get
       # the prior build artefacts; on a miss (any source/dep file changed)
-      # we fall back to restore-keys for a partial cache, then dune does
-      # incremental work from there.
+      # we do a full rebuild. No restore-keys fallback: partial caches with
+      # mismatched .exe files cause SIGILL on module splits (e.g. #1113/#1115).
       - name: Cache _build
         uses: actions/cache@v4
         with:
           path: trading/_build
           key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
-          restore-keys: |
-            dune-${{ runner.os }}-
 
       - name: dune build
         run: |

--- a/.github/workflows/golden-runs-sp500-15y.yml
+++ b/.github/workflows/golden-runs-sp500-15y.yml
@@ -54,8 +54,6 @@ jobs:
         with:
           path: trading/_build
           key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/*.ml', 'trading/**/*.mli') }}
-          restore-keys: |
-            dune-${{ runner.os }}-
 
       - name: Run SP500 15y golden
         id: golden_sp500_15y

--- a/.github/workflows/golden-runs-sp500-5y.yml
+++ b/.github/workflows/golden-runs-sp500-5y.yml
@@ -63,8 +63,6 @@ jobs:
         with:
           path: trading/_build
           key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/*.ml', 'trading/**/*.mli') }}
-          restore-keys: |
-            dune-${{ runner.os }}-
 
       - name: Run SP500 5y golden postsubmit
         id: golden_sp500_5y

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -67,8 +67,6 @@ jobs:
         with:
           path: trading/_build
           key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
-          restore-keys: |
-            dune-${{ runner.os }}-
 
       - name: Run tier-2 perf nightly
         id: tier2

--- a/.github/workflows/perf-tier1.yml
+++ b/.github/workflows/perf-tier1.yml
@@ -53,8 +53,6 @@ jobs:
         with:
           path: trading/_build
           key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
-          restore-keys: |
-            dune-${{ runner.os }}-
 
       - name: Run tier-1 perf smoke
         id: tier1

--- a/.github/workflows/perf-weekly.yml
+++ b/.github/workflows/perf-weekly.yml
@@ -69,8 +69,6 @@ jobs:
         with:
           path: trading/_build
           key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
-          restore-keys: |
-            dune-${{ runner.os }}-
 
       - name: Run tier-3 perf weekly
         id: tier3


### PR DESCRIPTION
## Problem

`actions/cache@v4` with `restore-keys: dune-${{ runner.os }}-` allows a stale partial cache to be restored when the exact key misses. After module splits (PRs #1113 and #1115), the restored `_build/` contains `.exe` files compiled against the old module layout. Running those binaries causes `Command got signal ILL` across many test binaries — observed across PRs #1115–#1120.

## Fix

Remove the `restore-keys:` fallback from every `actions/cache@v4` block that caches `trading/_build`. Cache hits (exact key match) continue to work as before. Cache misses now trigger a full rebuild (~10 min) instead of restoring a stale partial cache.

**Files changed:**
- `.github/workflows/ci.yml` — also updated the inline comment that described the fallback strategy
- `.github/workflows/perf-tier1.yml`
- `.github/workflows/perf-nightly.yml`
- `.github/workflows/perf-weekly.yml`
- `.github/workflows/golden-runs-sp500-15y.yml`
- `.github/workflows/golden-runs-sp500-5y.yml`

## Tradeoff

Each CI run after a source change will rebuild from scratch (~10 min cold build) rather than using a partial cache (~3 min warm build). This is acceptable: correctness trumps speed, and the exact-match key still provides a fast path when source files haven't changed between runs.

## Verify

Run any CI job after merging — check that `Cache _build` step shows either an exact cache hit or a cache miss (no "restored from partial key" message).