### PR TITLE
feat(ishares): build_iwv_universe CLI (PR-D of 4) — completes IWV scraper

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -1,6 +1,6 @@
 # Status: data-foundations
 
-## Last updated: 2026-05-16 (PR-C added)
+## Last updated: 2026-05-16 (PR-D added)
 
 ## Status
 IN_PROGRESS
@@ -327,6 +327,49 @@ fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
   Combined with simulator-side #1024 (Closed-positions prune), 15y wall dropped 5h → 13.6 min (~22×). See `dev/status/backtest-perf.md` for the simulator-side share.
 
 ### In Progress / READY_FOR_REVIEW
+
+- **Phase 1.4 PR-D — `build_iwv_universe.exe` (READY_FOR_REVIEW
+  2026-05-16, branch `feat/iwv-build-universe`).**
+  - New CLI `trading/analysis/data/sources/ishares/bin/build_iwv_universe.{ml,dune}`
+    + pure helper lib `build_iwv_universe_lib.{ml,mli}` — completes the
+    IWV scraper stack (PR-A → PR-B → PR-C → PR-D). Reads the cached
+    snapshot directory produced by PR-C's `fetch_iwv_history.exe`,
+    pipes parsed snapshots through PR-B's
+    `Ishares_membership_replay.replay`, and emits a point-in-time
+    universe sexp matching the existing `broad-3000-2010-01-01.sexp`
+    shape (PR #1103).
+  - CLI flags: `--cache-root`, `--output`, `--start`, `--end`, `--as-of`,
+    `--threshold-misses`. Defaults: `--start 2006-09-29`, `--end today`,
+    `--as-of = --end`, `--threshold-misses 3`. All knobs routed through
+    the lib's `run` entry point — no magic numbers.
+  - Equity + US-location filter applied in the lib (per plan §2.3.3,
+    NOT in the replay layer), exposed as `filter_config` so per-backtest
+    policy can vary. Default drops `Asset Class != Equity` (futures hedges,
+    cash) and `Location != United States` (pre-2012 cross-listings).
+  - Sample fixture: 5 hand-curated snapshots × 9 tickers under
+    `test/data/sample_history/2007-09-28.csv` through `2020-06-01.csv`.
+    Covers: always-present (AAPL/MSFT/JNJ/IBM), single-miss survival
+    (KODK absent in 1 of 5 → tenure stays open with threshold=3),
+    confirmed removal via 3 misses (LEH only in 2007 → closed by snap 4,
+    excluded from output), late-entry (TSLA/FB first seen 2012), futures
+    filter (ESM6 dropped before replay).
+  - 14 OUnit2 tests pass: cache-entry scanning (window filter; missing
+    dir error), load_and_filter (default filter drops ESM6 → 7 equity
+    tickers; no-filter keeps 8; full-window loads all 5 snapshots in
+    ascending date order), build_universe (7 members at as_of=2020-06-01
+    with full sexp shape pinned; mid-window pi-filter excludes pre-2012
+    arrivals; threshold=1 closes KODK and re-opens with new
+    sector_at_first), write_outcome_to_file (header comment + sexp body;
+    sexp roundtrips via Sexp.of_string), run end-to-end pipeline,
+    schema parity check vs `broad-3000-2010-01-01.sexp`.
+  - Does NOT generate the actual `russell-3000-2006-2026.sexp` fixture —
+    that requires running the full ~3 hour scrape against iShares;
+    follow-up ops session ships the artifact. This PR ships the TOOL.
+  - Linters green: `dune build @fmt`, `no_python_check`,
+    `fn_length_linter` (all functions ≤ 25 LOC). 386 source LOC
+    (`.ml` + `.mli` 86+185+115); 408 test LOC. Sample CSV fixtures
+    (5 files, ~6 KB) excluded per PR-sizing rules. Plan:
+    `dev/plans/iwv-scraper-2026-05-16.md` §PR-D.
 
 - **Phase 1.4 PR-C — `fetch_iwv_history.exe` (READY_FOR_REVIEW
   2026-05-16, branch `feat/iwv-fetch-history`).**

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -1,6 +1,6 @@
 # Status: data-foundations
 
-## Last updated: 2026-05-16 (PR-D added)
+## Last updated: 2026-05-16
 
 ## Status
 IN_PROGRESS

--- a/trading/analysis/data/sources/ishares/bin/build_iwv_universe.ml
+++ b/trading/analysis/data/sources/ishares/bin/build_iwv_universe.ml
@@ -1,0 +1,86 @@
+(** [build_iwv_universe.exe] CLI entry point.
+
+    Reads the iShares IWV holdings CSV cache produced by
+    [fetch_iwv_history.exe], pipes the parsed snapshots through
+    {!Ishares.Ishares_membership_replay.replay}, and writes a point-in-time
+    universe sexp matching the existing [broad-3000-2010-01-01.sexp] shape.
+
+    See [build_iwv_universe_lib.mli] and [dev/plans/iwv-scraper-2026-05-16.md]
+    §PR-D for the planning contract. *)
+
+open Core
+module Lib = Build_iwv_universe_lib
+
+let _default_cache_dir = "../dev/data/ishares/iwv"
+let _default_threshold_misses = 3
+let _default_start_str = "2006-09-29"
+let _today () = Date.today ~zone:Time_float.Zone.utc
+
+let _print_summary (outcome : Lib.outcome) =
+  printf
+    "Wrote universe: %d members | %d snapshots replayed | %d tenures removed.\n"
+    outcome.member_count outcome.snapshot_count outcome.removed_count
+
+let _run ~cache_dir ~output ~from_str ~until_str ~as_of_str
+    ~threshold_consecutive_misses =
+  let from = Date.of_string from_str in
+  let until = Date.of_string until_str in
+  let as_of =
+    match as_of_str with Some s -> Date.of_string s | None -> until
+  in
+  match
+    Lib.run ~cache_dir ~output ~from ~until ~as_of ~threshold_consecutive_misses
+      ()
+  with
+  | Error err ->
+      eprintf "Error: %s\n" (Status.show err);
+      Stdlib.exit 1
+  | Ok outcome -> _print_summary outcome
+
+let command =
+  Command.basic
+    ~summary:
+      "Build a point-in-time Russell 3000 universe sexp from the iShares IWV \
+       holdings CSV cache."
+    ~readme:(fun () ->
+      "Reads <cache-dir>/YYYY-MM-DD.csv files in [--start..--end], pipes the\n\
+       parsed snapshots through Ishares_membership_replay.replay, and writes\n\
+       a (Pinned ...) universe sexp for [--as-of] (defaults to --end). The\n\
+       output sexp shape matches\n\
+      \  \
+       trading/test_data/backtest_scenarios/universes/broad-3000-2010-01-01.sexp\n\
+       so existing consumers (Universe_file.load + scenario runners) work\n\
+       unchanged.\n\n\
+       Sentinel marker files (.sentinel) in the cache are ignored. Cached\n\
+       bodies that contain the iShares no-data template are also skipped at\n\
+       parse time. See dev/plans/iwv-scraper-2026-05-16.md §PR-D.")
+    (let%map_open.Command cache_dir =
+       flag "cache-root"
+         (optional_with_default _default_cache_dir string)
+         ~doc:"PATH local IWV CSV cache (default: ../dev/data/ishares/iwv)"
+     and output =
+       flag "output" (required string)
+         ~doc:"PATH where to write the universe sexp"
+     and from_str =
+       flag "start"
+         (optional_with_default _default_start_str string)
+         ~doc:"YYYY-MM-DD inclusive window start (default: 2006-09-29)"
+     and until_str =
+       flag "end" (optional string)
+         ~doc:"YYYY-MM-DD inclusive window end (default: today UTC)"
+     and as_of_str =
+       flag "as-of" (optional string)
+         ~doc:"YYYY-MM-DD point-in-time membership snapshot (default: --end)"
+     and threshold_consecutive_misses =
+       flag "threshold-misses"
+         (optional_with_default _default_threshold_misses int)
+         ~doc:"N consecutive missing snapshots to close a tenure (default: 3)"
+     in
+     fun () ->
+       let until_str =
+         match until_str with Some s -> s | None -> Date.to_string (_today ())
+       in
+       _run ~cache_dir ~output ~from_str ~until_str ~as_of_str
+         ~threshold_consecutive_misses)
+
+let () = Command_unix.run command

--- a/trading/analysis/data/sources/ishares/bin/build_iwv_universe_lib.ml
+++ b/trading/analysis/data/sources/ishares/bin/build_iwv_universe_lib.ml
@@ -1,0 +1,185 @@
+open Core
+module Client = Ishares.Ishares_holdings_client
+module Replay = Ishares.Ishares_membership_replay
+
+type cache_entry = { as_of : Date.t; csv_path : string } [@@deriving show, eq]
+
+type filter_config = {
+  require_equity_asset_class : bool;
+  require_us_location : bool;
+}
+[@@deriving show, eq]
+
+let default_filter_config =
+  { require_equity_asset_class = true; require_us_location = true }
+
+let _equity_asset_class = "Equity"
+let _us_location = "United States"
+let _csv_extension = ".csv"
+
+(* [YYYY-MM-DD.csv] filename → Date.t. Returns [None] on any structural
+   mismatch so the caller can skip non-matching entries (e.g. README files
+   or sentinel markers) without aborting the scan. *)
+let _date_of_basename basename =
+  if not (String.is_suffix basename ~suffix:_csv_extension) then None
+  else
+    let stem = String.drop_suffix basename (String.length _csv_extension) in
+    try Some (Date.of_string stem) with _ -> None
+
+let _list_dir_entries dir =
+  try Ok (Array.to_list (Sys_unix.readdir dir))
+  with Sys_error msg ->
+    Status.error_invalid_argument
+      (Printf.sprintf "failed to list cache directory %s: %s" dir msg)
+
+let _entry_in_window ~from ~until (entry : cache_entry) =
+  Date.( <= ) from entry.as_of && Date.( <= ) entry.as_of until
+
+let list_cache_entries ~cache_dir ~from ~until =
+  let%bind.Result names = _list_dir_entries cache_dir in
+  let candidates =
+    List.filter_map names ~f:(fun name ->
+        match _date_of_basename name with
+        | None -> None
+        | Some as_of ->
+            Some { as_of; csv_path = Filename.concat cache_dir name })
+  in
+  let in_window = List.filter candidates ~f:(_entry_in_window ~from ~until) in
+  Ok (List.sort in_window ~compare:(fun a b -> Date.compare a.as_of b.as_of))
+
+let _read_file path =
+  try Ok (In_channel.read_all path)
+  with Sys_error msg ->
+    Status.error_invalid_argument
+      (Printf.sprintf "failed to read %s: %s" path msg)
+
+(* Apply both row-level filters per the [filter_config]. Order doesn't matter
+   for the [&&] composition but writing them as separate steps keeps the
+   intent clear. *)
+let _row_passes_filter ~(filter : filter_config) (h : Client.holding) =
+  let asset_ok =
+    (not filter.require_equity_asset_class)
+    || String.equal h.asset_class _equity_asset_class
+  in
+  let location_ok =
+    (not filter.require_us_location) || String.equal h.location _us_location
+  in
+  asset_ok && location_ok
+
+let _filter_snapshot ~filter (snap : Client.snapshot) : Client.snapshot =
+  {
+    snap with
+    holdings = List.filter snap.holdings ~f:(_row_passes_filter ~filter);
+  }
+
+(* Load one cache entry. Returns [Ok None] when the body parses to
+   [No_data_sentinel] (skippable) or [Ok (Some (date, snap))] when it carries
+   data. [Error] propagates structural parse failures. *)
+let _load_one ~filter (entry : cache_entry) :
+    (Date.t * Client.snapshot) option Status.status_or =
+  let%bind.Result body = _read_file entry.csv_path in
+  let%bind.Result outcome = Client.parse body in
+  match outcome with
+  | Client.No_data_sentinel -> Ok None
+  | Client.Parsed snap -> Ok (Some (entry.as_of, _filter_snapshot ~filter snap))
+
+let load_and_filter ~entries ~filter =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | entry :: rest -> (
+        match _load_one ~filter entry with
+        | Error _ as e -> e
+        | Ok None -> loop acc rest
+        | Ok (Some pair) -> loop (pair :: acc) rest)
+  in
+  loop [] entries
+
+type outcome = {
+  universe_sexp : Sexp.t;
+  member_count : int;
+  snapshot_count : int;
+  removed_count : int;
+}
+
+let _active_on ~as_of (t : Replay.tenure_record) =
+  Date.( <= ) t.first_seen as_of && Date.( <= ) as_of t.last_seen
+
+let _tenure_to_sexp_pair (t : Replay.tenure_record) =
+  Sexp.List
+    [
+      Sexp.List [ Sexp.Atom "symbol"; Sexp.Atom t.ticker ];
+      Sexp.List [ Sexp.Atom "sector"; Sexp.Atom t.sector_at_first ];
+    ]
+
+let _to_universe_sexp (tenures : Replay.tenure_record list) =
+  let sorted =
+    List.sort tenures ~compare:(fun a b -> String.compare a.ticker b.ticker)
+  in
+  let entries = List.map sorted ~f:_tenure_to_sexp_pair in
+  Sexp.List [ Sexp.Atom "Pinned"; Sexp.List entries ]
+
+let build_universe ~snapshots ~threshold_consecutive_misses ~as_of =
+  let snapshot_count = List.length snapshots in
+  let tenures = Replay.replay ~threshold_consecutive_misses snapshots in
+  let active = List.filter tenures ~f:(_active_on ~as_of) in
+  let removed_count = List.length tenures - List.length active in
+  let universe_sexp = _to_universe_sexp active in
+  {
+    universe_sexp;
+    member_count = List.length active;
+    snapshot_count;
+    removed_count;
+  }
+
+let _header_comment ~as_of ~from ~until ~snapshot_count ~member_count
+    ~removed_count =
+  Printf.sprintf
+    ";; Russell 3000 universe (IWV-derived) — build_iwv_universe.exe.\n\
+     ;; as-of: %s | members: %d | snapshots replayed: %d | tenures removed in \
+     window: %d\n\
+     ;; window: %s .. %s\n\
+     ;; Source: pinned iShares IWV holdings via fetch_iwv_history.exe;\n\
+     ;; replay via Ishares_membership_replay.replay (3-snapshot threshold).\n\
+     ;; Caveat: IWV is a sampled tracker of the Russell 3000 index;\n\
+     ;; tracking error ~5-15 bps and membership lists are close-but-not-\n\
+     ;; identical (plan §6 risk 1). See\n\
+     ;; dev/plans/iwv-scraper-2026-05-16.md §PR-D.\n\
+     ;;\n"
+    (Date.to_string as_of) member_count snapshot_count removed_count
+    (Date.to_string from) (Date.to_string until)
+
+let _write_atomic ~path ~contents =
+  let tmp = path ^ ".tmp" in
+  try
+    (try Core_unix.mkdir_p (Filename.dirname path) with _ -> ());
+    Out_channel.with_file tmp ~f:(fun oc ->
+        Out_channel.output_string oc contents);
+    Core_unix.rename ~src:tmp ~dst:path;
+    Ok ()
+  with
+  | Sys_error msg ->
+      Status.error_internal (Printf.sprintf "write %s failed: %s" path msg)
+  | Core_unix.Unix_error (err, _, _) ->
+      Status.error_internal
+        (Printf.sprintf "rename to %s failed: %s" path
+           (Core_unix.Error.message err))
+
+let write_outcome_to_file ~path ~as_of ~from ~until (outcome : outcome) =
+  let header =
+    _header_comment ~as_of ~from ~until ~snapshot_count:outcome.snapshot_count
+      ~member_count:outcome.member_count ~removed_count:outcome.removed_count
+  in
+  let body = Sexp.to_string_hum outcome.universe_sexp ^ "\n" in
+  _write_atomic ~path ~contents:(header ^ body)
+
+let run ~cache_dir ~output ~from ~until ~as_of ~threshold_consecutive_misses
+    ?(filter = default_filter_config) () =
+  let%bind.Result entries = list_cache_entries ~cache_dir ~from ~until in
+  let%bind.Result snapshots = load_and_filter ~entries ~filter in
+  let outcome =
+    build_universe ~snapshots ~threshold_consecutive_misses ~as_of
+  in
+  let%bind.Result () =
+    write_outcome_to_file ~path:output ~as_of ~from ~until outcome
+  in
+  Ok outcome

--- a/trading/analysis/data/sources/ishares/bin/build_iwv_universe_lib.mli
+++ b/trading/analysis/data/sources/ishares/bin/build_iwv_universe_lib.mli
@@ -1,0 +1,115 @@
+(** Glue layer for [build_iwv_universe.exe] CLI.
+
+    Companion plan: [dev/plans/iwv-scraper-2026-05-16.md] §PR-D. Reads a
+    snapshot cache produced by [fetch_iwv_history.exe] (PR-C), pipes the parsed
+    snapshots through {!Ishares.Ishares_membership_replay.replay} (PR-B), and
+    emits a point-in-time universe sexp matching the existing
+    [broad-3000-2010-01-01.sexp] shape (PR #1103).
+
+    All file I/O lives in this module; the [.ml] CLI is a thin wrapper. The
+    underlying replay + parser layers remain pure. *)
+
+open Core
+
+type cache_entry = { as_of : Date.t; csv_path : string } [@@deriving show, eq]
+(** A single cached snapshot to load: file at [csv_path] holds the raw CSV body
+    fetched on [as_of]. Sentinel marker files (extension [.sentinel]) are
+    deliberately excluded from this list — the loader skips them. *)
+
+val list_cache_entries :
+  cache_dir:string ->
+  from:Date.t ->
+  until:Date.t ->
+  cache_entry list Status.status_or
+(** [list_cache_entries ~cache_dir ~from ~until] scans [cache_dir] for files
+    matching [YYYY-MM-DD.csv], parses the date from the filename, filters to
+    [from <= as_of <= until], and returns the entries sorted by [as_of]
+    ascending. Sentinel marker files are skipped. Returns [Error] if [cache_dir]
+    cannot be opened. Returns [Ok []] if no in-window CSV files are found. *)
+
+type filter_config = {
+  require_equity_asset_class : bool;
+      (** When [true], drop rows whose [asset_class] is not ["Equity"] (futures
+          hedges, cash, bonds). Default: [true]. *)
+  require_us_location : bool;
+      (** When [true], drop rows whose [location] is not ["United States"]
+          (pre-2012 cross-listings on LSE / XETRA). Default: [true]. *)
+}
+[@@deriving show, eq]
+
+val default_filter_config : filter_config
+(** Production defaults: equity-only + US-only. Per plan §2.3.3 these filters
+    belong in the universe-builder, not in the replay layer, so callers can vary
+    them per backtest. *)
+
+val load_and_filter :
+  entries:cache_entry list ->
+  filter:filter_config ->
+  (Date.t * Ishares.Ishares_holdings_client.snapshot) list Status.status_or
+(** [load_and_filter ~entries ~filter] reads each [csv_path], parses via
+    {!Ishares.Ishares_holdings_client.parse}, drops [No_data_sentinel] outcomes
+    (cached sentinel bodies that slipped past the marker-file check), and
+    returns the surviving snapshots paired with their [as_of] dates.
+
+    Each snapshot's holdings are filtered per [filter] BEFORE the replay layer
+    consumes them. Returns [Error] on the first structural parse failure (header
+    drift, malformed row, unparseable date); a sentinel body in the body is
+    treated as "skip this entry, keep going". *)
+
+type outcome = {
+  universe_sexp : Sexp.t;
+      (** Emitted [(Pinned ((symbol …) (sector …)) …)] sexp matching
+          [broad-3000-2010-01-01.sexp]. Symbols sorted by ticker ascending. *)
+  member_count : int;  (** Cardinality of the emitted universe. *)
+  snapshot_count : int;  (** Number of in-window snapshots replayed. *)
+  removed_count : int;
+      (** Number of [tenure_record]s closed during the replay (tickers that
+          exited the index during the window). These are NOT in the output sexp.
+      *)
+}
+
+val build_universe :
+  snapshots:(Date.t * Ishares.Ishares_holdings_client.snapshot) list ->
+  threshold_consecutive_misses:int ->
+  as_of:Date.t ->
+  outcome
+(** [build_universe ~snapshots ~threshold_consecutive_misses ~as_of] replays the
+    input snapshots, filters the resulting tenure records to those that were
+    active on [as_of] (i.e. [first_seen <= as_of <= last_seen]), and renders the
+    surviving members as a universe sexp.
+
+    The [as_of] filter pins the universe to a single point-in-time: a tenure
+    that closed before [as_of] is excluded; a tenure that opened after [as_of]
+    is excluded. For full-membership emission across the whole window, callers
+    can set [as_of] to the most recent snapshot date.
+
+    The function is total — empty input yields an empty universe sexp. *)
+
+val run :
+  cache_dir:string ->
+  output:string ->
+  from:Date.t ->
+  until:Date.t ->
+  as_of:Date.t ->
+  threshold_consecutive_misses:int ->
+  ?filter:filter_config ->
+  unit ->
+  outcome Status.status_or
+(** End-to-end pipeline: list cache entries → load and filter → build universe →
+    write to [output] (atomic rename). Writes a comment-header block at the top
+    of [output] citing [as_of], [from..until] window, snapshot count, and member
+    count.
+
+    Defaults: [filter = default_filter_config]. *)
+
+val write_outcome_to_file :
+  path:string ->
+  as_of:Date.t ->
+  from:Date.t ->
+  until:Date.t ->
+  outcome ->
+  unit Status.status_or
+(** Write [outcome.universe_sexp] to [path] prefixed with a comment header. The
+    comment block cites [as_of], window, snapshot count, member count, and notes
+    the IWV-tracks-but-is-not-exactly-Russell-3000 caveat. Used by both [run]
+    and tests that exercise the file-shape directly. *)

--- a/trading/analysis/data/sources/ishares/bin/dune
+++ b/trading/analysis/data/sources/ishares/bin/dune
@@ -5,6 +5,13 @@
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq)))
 
+(library
+ (name build_iwv_universe_lib)
+ (modules build_iwv_universe_lib)
+ (libraries core core_unix.sys_unix core_unix ishares status)
+ (preprocess
+  (pps ppx_let ppx_deriving.show ppx_deriving.eq)))
+
 (executable
  (name fetch_iwv_history)
  (modules fetch_iwv_history)
@@ -22,3 +29,16 @@
   uri)
  (preprocess
   (pps ppx_jane)))
+
+(executable
+ (name build_iwv_universe)
+ (modules build_iwv_universe)
+ (libraries
+  core
+  core_unix.command_unix
+  core_unix.time_float_unix
+  build_iwv_universe_lib
+  ishares
+  status)
+ (preprocess
+  (pps ppx_let ppx_jane)))

--- a/trading/analysis/data/sources/ishares/test/data/sample_history/2007-09-28.csv
+++ b/trading/analysis/data/sources/ishares/test/data/sample_history/2007-09-28.csv
@@ -1,0 +1,20 @@
+iShares Russell 3000 ETF
+Fund Holdings as of,"Sep 28, 2007"
+
+Inception Date,"May 22, 2000"
+Shares Outstanding,"10,000,000"
+Stock,99.50
+Bonds,0.00
+Other,0.50
+
+Ticker,Name,Sector,Asset Class,Market Value,Weight (%),Notional Value,Quantity,Price,Location,Exchange,Currency,FX Rate,Market Currency,Accrual Date
+"LEH","LEHMAN BROTHERS HOLDINGS INC","-","Equity","98,765,432.10","1.50","98,765,432.10","1500000.00","65.84","United States","NYSE","USD","1.00","-","-"
+"IBM","INTERNATIONAL BUSINESS MACHINES","-","Equity","234,567,890.12","3.40","234,567,890.12","2000000.00","117.28","United States","NYSE","USD","1.00","-","-"
+"MSFT","MICROSOFT CORP","-","Equity","187,654,321.00","2.85","187,654,321.00","6300000.00","29.79","United States","NASDAQ","USD","1.00","-","-"
+"AAPL","APPLE INC","-","Equity","123,456,789.01","1.87","123,456,789.01","800000.00","154.32","United States","NASDAQ","USD","1.00","-","-"
+"JNJ","JOHNSON & JOHNSON","-","Equity","154,321,098.76","2.34","154,321,098.76","2350000.00","65.67","United States","NYSE","USD","1.00","-","-"
+"KODK","EASTMAN KODAK CO","-","Equity","12,345,678.90","0.18","12,345,678.90","430000.00","28.71","United States","NYSE","USD","1.00","-","-"
+
+The fund holdings are subject to change. Holdings information is based on the trade date for portfolio transactions.
+;; PROVENANCE: synthetic 6-row sample of the iShares IWV holdings CSV in the
+;; pre-2009 quarterly era. Sectors are "-" per Phase 1.4 probe doc.

--- a/trading/analysis/data/sources/ishares/test/data/sample_history/2010-01-29.csv
+++ b/trading/analysis/data/sources/ishares/test/data/sample_history/2010-01-29.csv
@@ -1,0 +1,20 @@
+iShares Russell 3000 ETF
+Fund Holdings as of,"Jan 29, 2010"
+
+Inception Date,"May 22, 2000"
+Shares Outstanding,"15,000,000"
+Stock,99.40
+Bonds,0.00
+Other,0.60
+
+Ticker,Name,Sector,Asset Class,Market Value,Weight (%),Notional Value,Quantity,Price,Location,Exchange,Currency,FX Rate,Market Currency,Accrual Date
+"IBM","INTERNATIONAL BUSINESS MACHINES","Information Technology","Equity","267,890,123.45","3.65","267,890,123.45","2200000.00","121.77","United States","NYSE","USD","1.00","USD","-"
+"MSFT","MICROSOFT CORP","Information Technology","Equity","209,876,543.21","2.95","209,876,543.21","6800000.00","30.86","United States","NASDAQ","USD","1.00","USD","-"
+"AAPL","APPLE INC","Information Technology","Equity","156,789,012.34","2.12","156,789,012.34","780000.00","201.01","United States","NASDAQ","USD","1.00","USD","-"
+"JNJ","JOHNSON & JOHNSON","Health Care","Equity","178,901,234.56","2.40","178,901,234.56","2750000.00","65.06","United States","NYSE","USD","1.00","USD","-"
+"KODK","EASTMAN KODAK CO","Information Technology","Equity","8,234,567.89","0.11","8,234,567.89","1200000.00","6.86","United States","NYSE","USD","1.00","USD","-"
+
+The fund holdings are subject to change. Holdings information is based on the trade date for portfolio transactions.
+;; PROVENANCE: synthetic 5-row sample of the iShares IWV holdings CSV in the
+;; monthly era (2009-01 to 2012-04). Sectors populated; LEH no longer present
+;; (delisted post-bankruptcy 2008).

--- a/trading/analysis/data/sources/ishares/test/data/sample_history/2012-04-30.csv
+++ b/trading/analysis/data/sources/ishares/test/data/sample_history/2012-04-30.csv
@@ -1,0 +1,22 @@
+iShares Russell 3000 ETF
+Fund Holdings as of,"Apr 30, 2012"
+
+Inception Date,"May 22, 2000"
+Shares Outstanding,"25,000,000"
+Stock,99.50
+Bonds,0.00
+Other,0.50
+
+Ticker,Name,Sector,Asset Class,Market Value,Weight (%),Notional Value,Quantity,Price,Location,Exchange,Currency,FX Rate,Market Currency,Accrual Date
+"AAPL","APPLE INC","Information Technology","Equity","456,789,012.34","6.20","456,789,012.34","780000.00","585.63","United States","NASDAQ","USD","1.00","USD","-"
+"IBM","INTERNATIONAL BUSINESS MACHINES","Information Technology","Equity","298,765,432.10","4.05","298,765,432.10","1450000.00","206.05","United States","NYSE","USD","1.00","USD","-"
+"MSFT","MICROSOFT CORP","Information Technology","Equity","234,567,890.12","3.18","234,567,890.12","7300000.00","32.13","United States","NASDAQ","USD","1.00","USD","-"
+"JNJ","JOHNSON & JOHNSON","Health Care","Equity","189,012,345.67","2.55","189,012,345.67","2900000.00","65.18","United States","NYSE","USD","1.00","USD","-"
+"FB","FACEBOOK INC CLASS A","Communication Services","Equity","34,567,890.12","0.46","34,567,890.12","900000.00","38.41","United States","NASDAQ","USD","1.00","USD","-"
+"TSLA","TESLA INC","Consumer Discretionary","Equity","6,789,012.34","0.09","6,789,012.34","210000.00","32.33","United States","NASDAQ","USD","1.00","USD","-"
+
+The fund holdings are subject to change. Holdings information is based on the trade date for portfolio transactions.
+;; PROVENANCE: synthetic 6-row sample of the iShares IWV holdings CSV at the
+;; 2012-04-30 daily-era cutover. KODK temporarily absent (single-snapshot
+;; data glitch; threshold=3 keeps tenure open). New entries: FB (synthetic
+;; date — real FB IPO was 2012-05-18), TSLA.

--- a/trading/analysis/data/sources/ishares/test/data/sample_history/2018-06-15.csv
+++ b/trading/analysis/data/sources/ishares/test/data/sample_history/2018-06-15.csv
@@ -1,0 +1,22 @@
+iShares Russell 3000 ETF
+Fund Holdings as of,"Jun 15, 2018"
+
+Inception Date,"May 22, 2000"
+Shares Outstanding,"40,000,000"
+Stock,99.40
+Bonds,0.00
+Other,0.60
+
+Ticker,Name,Sector,Asset Class,Market Value,Weight (%),Notional Value,Quantity,Price,Location,Exchange,Currency,FX Rate,Market Currency,Accrual Date
+"AAPL","APPLE INC","Information Technology","Equity","678,901,234.56","6.50","678,901,234.56","3600000.00","188.58","United States","NASDAQ","USD","1.00","USD","-"
+"MSFT","MICROSOFT CORP","Information Technology","Equity","523,456,789.01","5.05","523,456,789.01","5300000.00","98.77","United States","NASDAQ","USD","1.00","USD","-"
+"FB","FACEBOOK INC CLASS A","Communication Services","Equity","389,012,345.67","3.78","389,012,345.67","2000000.00","194.51","United States","NASDAQ","USD","1.00","USD","-"
+"JNJ","JOHNSON & JOHNSON","Health Care","Equity","234,567,890.12","2.30","234,567,890.12","1900000.00","123.46","United States","NYSE","USD","1.00","USD","-"
+"IBM","INTERNATIONAL BUSINESS MACHINES","Information Technology","Equity","123,456,789.01","1.20","123,456,789.01","860000.00","143.55","United States","NYSE","USD","1.00","USD","-"
+"TSLA","TESLA INC","Consumer Discretionary","Equity","98,765,432.10","0.95","98,765,432.10","280000.00","352.73","United States","NASDAQ","USD","1.00","USD","-"
+"KODK","EASTMAN KODAK CO","Information Technology","Equity","2,345,678.90","0.02","2,345,678.90","430000.00","5.45","United States","NYSE","USD","1.00","USD","-"
+
+The fund holdings are subject to change. Holdings information is based on the trade date for portfolio transactions.
+;; PROVENANCE: synthetic 7-row sample of the iShares IWV holdings CSV in the
+;; daily era. KODK re-appears (returning after single-snapshot glitch in
+;; 2012-04-30 fixture); LEH long gone (closed by threshold=3 misses).

--- a/trading/analysis/data/sources/ishares/test/data/sample_history/2020-06-01.csv
+++ b/trading/analysis/data/sources/ishares/test/data/sample_history/2020-06-01.csv
@@ -1,0 +1,23 @@
+iShares Russell 3000 ETF
+Fund Holdings as of,"Jun 01, 2020"
+
+Inception Date,"May 22, 2000"
+Shares Outstanding,"50,400,000"
+Stock,99.30
+Bonds,0.00
+Other,0.70
+
+Ticker,Name,Sector,Asset Class,Market Value,Weight (%),Notional Value,Quantity,Price,Location,Exchange,Currency,FX Rate,Market Currency,Accrual Date
+"AAPL","APPLE INC","Information Technology","Equity","745,678,901.23","6.80","745,678,901.23","2400000.00","310.70","United States","NASDAQ","USD","1.00","USD","-"
+"MSFT","MICROSOFT CORP","Information Technology","Equity","634,567,890.12","5.78","634,567,890.12","3500000.00","181.30","United States","NASDAQ","USD","1.00","USD","-"
+"FB","FACEBOOK INC CLASS A","Communication Services","Equity","432,109,876.54","3.94","432,109,876.54","1950000.00","221.59","United States","NASDAQ","USD","1.00","USD","-"
+"JNJ","JOHNSON & JOHNSON","Health Care","Equity","298,765,432.10","2.72","298,765,432.10","2000000.00","149.38","United States","NYSE","USD","1.00","USD","-"
+"TSLA","TESLA INC","Consumer Discretionary","Equity","187,654,321.00","1.71","187,654,321.00","250000.00","750.62","United States","NASDAQ","USD","1.00","USD","-"
+"IBM","INTERNATIONAL BUSINESS MACHINES","Information Technology","Equity","134,567,890.12","1.22","134,567,890.12","1080000.00","124.60","United States","NYSE","USD","1.00","USD","-"
+"KODK","EASTMAN KODAK CO","Information Technology","Equity","876,543.21","0.01","876,543.21","450000.00","1.95","United States","NYSE","USD","1.00","USD","-"
+"ESM6","S&P 500 EMINI FUT JUN20","-","Futures","3,456,789.01","0.03","3,456,789.01","30.00","115226.30","United States","-","USD","1.00","USD","-"
+
+The fund holdings are subject to change. Holdings information is based on the trade date for portfolio transactions.
+;; PROVENANCE: synthetic 8-row sample of the iShares IWV holdings CSV in the
+;; daily era. Includes futures row (ESM6) to exercise the asset-class filter
+;; — should be excluded from the universe output.

--- a/trading/analysis/data/sources/ishares/test/dune
+++ b/trading/analysis/data/sources/ishares/test/dune
@@ -2,10 +2,12 @@
  (names
   test_ishares_holdings_client
   test_ishares_membership_replay
-  test_fetch_iwv_history_lib)
+  test_fetch_iwv_history_lib
+  test_build_iwv_universe_lib)
  (libraries
   ishares
   fetch_iwv_history_lib
+  build_iwv_universe_lib
   core
   core_unix.filename_unix
   core_unix.sys_unix
@@ -14,4 +16,5 @@
   status
   uri)
  (deps
-  (glob_files ./data/*.csv)))
+  (glob_files ./data/*.csv)
+  (glob_files ./data/sample_history/*.csv)))

--- a/trading/analysis/data/sources/ishares/test/test_build_iwv_universe_lib.ml
+++ b/trading/analysis/data/sources/ishares/test/test_build_iwv_universe_lib.ml
@@ -63,6 +63,35 @@ let test_list_cache_entries_missing_dir_errors _ =
   in
   assert_that entries is_error
 
+(* Sentinel marker files (extension [.sentinel]) must be skipped by the
+   loader — pins the [cache_entry] docstring claim "deliberately excluded
+   from this list". The marker carries no date-bearing CSV body; emitting
+   it as a cache_entry would propagate to [load_and_filter] and fail. *)
+let _tmpdir () = Filename_unix.temp_dir ~in_dir:"/tmp" "iwv-prd-test-" ""
+
+let _write_file ~path ~contents =
+  Out_channel.with_file path ~f:(fun oc ->
+      Out_channel.output_string oc contents)
+
+let test_list_cache_entries_skips_sentinel_files _ =
+  let dir = _tmpdir () in
+  _write_file
+    ~path:(Filename.concat dir "2025-01-15.csv")
+    ~contents:"placeholder body\n";
+  _write_file ~path:(Filename.concat dir "2025-02-15.sentinel") ~contents:"\n";
+  let entries =
+    Lib.list_cache_entries ~cache_dir:dir ~from:(_date 2000 Month.Jan 1)
+      ~until:(_date 2030 Month.Jan 1)
+  in
+  assert_that entries
+    (is_ok_and_holds
+       (elements_are
+          [
+            field
+              (fun (e : Lib.cache_entry) -> e.as_of)
+              (equal_to (_date 2025 Month.Jan 15));
+          ]))
+
 (* ------------------------------------------------------------------------- *)
 (* load_and_filter                                                           *)
 (* ------------------------------------------------------------------------- *)
@@ -144,6 +173,34 @@ let test_load_and_filter_full_window _ =
   in
   assert_that dates
     (elements_are (List.map _sample_dates ~f:(fun d -> equal_to d)))
+
+(* Pins the [load_and_filter] docstring claim "drops [No_data_sentinel]
+   outcomes (cached sentinel bodies that slipped past the marker-file
+   check)". A cached CSV body whose line-2 cell is ["-"] parses to
+   [No_data_sentinel] (per [Ishares_holdings_client.parse]); the loader
+   must silently skip it rather than fail or emit a stub snapshot.
+
+   The minimal sentinel template is two lines: a placeholder line 1 and
+   ["Fund Holdings as of,\"-\""] on line 2 — see
+   [Ishares_holdings_client]'s parser, which only inspects line 2 before
+   returning [No_data_sentinel]. *)
+let _sentinel_body = "iShares Russell 3000 ETF\nFund Holdings as of,\"-\"\n"
+
+let test_load_and_filter_skips_in_body_sentinel _ =
+  let dir = _tmpdir () in
+  _write_file
+    ~path:(Filename.concat dir "2025-03-01.csv")
+    ~contents:_sentinel_body;
+  let entries =
+    match
+      Lib.list_cache_entries ~cache_dir:dir ~from:(_date 2000 Month.Jan 1)
+        ~until:(_date 2030 Month.Jan 1)
+    with
+    | Ok e -> e
+    | Error err -> assert_failure (Status.show err)
+  in
+  let result = Lib.load_and_filter ~entries ~filter:Lib.default_filter_config in
+  assert_that result (is_ok_and_holds is_empty)
 
 (* ------------------------------------------------------------------------- *)
 (* build_universe — end-to-end on the 5-snapshot sample                      *)
@@ -263,13 +320,33 @@ let test_build_universe_threshold_one_changes_kodk_sector _ =
   in
   assert_that kodk_sector (is_some_and (equal_to "Information Technology"))
 
+(* Pins the [build_universe] docstring claim "The function is total —
+   empty input yields an empty universe sexp." Empty snapshot input must
+   not raise; counts collapse to zero and the sexp is the empty Pinned
+   shape so downstream callers can [Sexp.of_string] the output without
+   special-casing. *)
+let test_build_universe_empty_input_is_total _ =
+  let outcome =
+    Lib.build_universe ~snapshots:[] ~threshold_consecutive_misses:3
+      ~as_of:(_date 2020 Month.Jun 1)
+  in
+  assert_that outcome
+    (all_of
+       [
+         field (fun o -> o.Lib.member_count) (equal_to 0);
+         field (fun o -> o.Lib.snapshot_count) (equal_to 0);
+         field (fun o -> o.Lib.removed_count) (equal_to 0);
+         field
+           (fun o -> o.Lib.universe_sexp)
+           (equal_to (Sexp.of_string "(Pinned ())"));
+       ])
+
 (* ------------------------------------------------------------------------- *)
 (* write_outcome_to_file — file format / atomicity                           *)
 (* ------------------------------------------------------------------------- *)
 
-(* Tmpdir helper: each file-write test uses a fresh sandbox to avoid stale
-   leftovers from prior runs. *)
-let _tmpdir () = Filename_unix.temp_dir ~in_dir:"/tmp" "iwv-prd-test-" ""
+(* Reuses [_tmpdir] defined above: each file-write test uses a fresh sandbox
+   to avoid stale leftovers from prior runs. *)
 
 let test_write_outcome_to_file_includes_header_and_body _ =
   let tmp = _tmpdir () in
@@ -383,11 +460,15 @@ let suite =
          >:: test_list_cache_entries_filters_window;
          "list_cache_entries_missing_dir_errors"
          >:: test_list_cache_entries_missing_dir_errors;
+         "list_cache_entries_skips_sentinel_files"
+         >:: test_list_cache_entries_skips_sentinel_files;
          "load_and_filter_drops_futures_row"
          >:: test_load_and_filter_drops_futures_row;
          "load_and_filter_no_filter_keeps_futures"
          >:: test_load_and_filter_no_filter_keeps_futures;
          "load_and_filter_full_window" >:: test_load_and_filter_full_window;
+         "load_and_filter_skips_in_body_sentinel"
+         >:: test_load_and_filter_skips_in_body_sentinel;
          "build_universe_yields_seven_members_at_end_of_window"
          >:: test_build_universe_yields_seven_members_at_end_of_window;
          "build_universe_sexp_shape_and_order"
@@ -396,6 +477,8 @@ let suite =
          >:: test_build_universe_mid_window_pi_filter;
          "build_universe_threshold_one_changes_kodk_sector"
          >:: test_build_universe_threshold_one_changes_kodk_sector;
+         "build_universe_empty_input_is_total"
+         >:: test_build_universe_empty_input_is_total;
          "write_outcome_to_file_includes_header_and_body"
          >:: test_write_outcome_to_file_includes_header_and_body;
          "written_sexp_roundtrips_via_sexp_of_string"

--- a/trading/analysis/data/sources/ishares/test/test_build_iwv_universe_lib.ml
+++ b/trading/analysis/data/sources/ishares/test/test_build_iwv_universe_lib.ml
@@ -1,0 +1,408 @@
+open Core
+open OUnit2
+open Matchers
+module Lib = Build_iwv_universe_lib
+module Client = Ishares.Ishares_holdings_client
+module Replay = Ishares.Ishares_membership_replay
+
+(* ------------------------------------------------------------------------- *)
+(* Fixture path helpers                                                      *)
+(*                                                                           *)
+(* Tests run from [trading/analysis/data/sources/ishares/test/], so all      *)
+(* fixture paths are relative to that directory.                             *)
+(* ------------------------------------------------------------------------- *)
+
+let _sample_dir = "./data/sample_history"
+let _date y m d = Date.create_exn ~y ~m ~d
+
+let _sample_dates =
+  [
+    _date 2007 Month.Sep 28;
+    _date 2010 Month.Jan 29;
+    _date 2012 Month.Apr 30;
+    _date 2018 Month.Jun 15;
+    _date 2020 Month.Jun 1;
+  ]
+
+(* ------------------------------------------------------------------------- *)
+(* list_cache_entries                                                        *)
+(* ------------------------------------------------------------------------- *)
+
+let test_list_cache_entries_returns_all_in_window _ =
+  let entries =
+    Lib.list_cache_entries ~cache_dir:_sample_dir ~from:(_date 2000 Month.Jan 1)
+      ~until:(_date 2030 Month.Jan 1)
+  in
+  assert_that entries
+    (is_ok_and_holds
+       (elements_are
+          (List.map _sample_dates ~f:(fun d ->
+               field (fun (e : Lib.cache_entry) -> e.as_of) (equal_to d)))))
+
+let test_list_cache_entries_filters_window _ =
+  let entries =
+    Lib.list_cache_entries ~cache_dir:_sample_dir ~from:(_date 2012 Month.Jan 1)
+      ~until:(_date 2019 Month.Jan 1)
+  in
+  assert_that entries
+    (is_ok_and_holds
+       (elements_are
+          [
+            field
+              (fun (e : Lib.cache_entry) -> e.as_of)
+              (equal_to (_date 2012 Month.Apr 30));
+            field
+              (fun (e : Lib.cache_entry) -> e.as_of)
+              (equal_to (_date 2018 Month.Jun 15));
+          ]))
+
+let test_list_cache_entries_missing_dir_errors _ =
+  let entries =
+    Lib.list_cache_entries ~cache_dir:"./data/does_not_exist"
+      ~from:(_date 2000 Month.Jan 1) ~until:(_date 2030 Month.Jan 1)
+  in
+  assert_that entries is_error
+
+(* ------------------------------------------------------------------------- *)
+(* load_and_filter                                                           *)
+(* ------------------------------------------------------------------------- *)
+
+(* When the equity + US filter is on (default), the futures row ESM6 in the
+   2020-06-01 fixture must be dropped. The other 8 rows survive. *)
+let test_load_and_filter_drops_futures_row _ =
+  let entries =
+    match
+      Lib.list_cache_entries ~cache_dir:_sample_dir
+        ~from:(_date 2020 Month.Jun 1) ~until:(_date 2020 Month.Jun 1)
+    with
+    | Ok e -> e
+    | Error err -> assert_failure (Status.show err)
+  in
+  let result = Lib.load_and_filter ~entries ~filter:Lib.default_filter_config in
+  let snap_holdings =
+    match result with
+    | Ok [ (_, snap) ] -> snap.Client.holdings
+    | _ -> assert_failure "expected exactly one snapshot"
+  in
+  let tickers =
+    List.map snap_holdings ~f:(fun h -> h.Client.ticker)
+    |> List.sort ~compare:String.compare
+  in
+  (* All 8 surviving rows in 2020-06-01 fixture — alphabetical. The futures
+     hedge ESM6 must be absent; the 7 equities plus the cash row USD pass
+     the equity filter as written... actually USD is asset_class=Cash so it
+     is also filtered. So expected = 7 equity tickers. *)
+  assert_that tickers
+    (elements_are
+       [
+         equal_to "AAPL";
+         equal_to "FB";
+         equal_to "IBM";
+         equal_to "JNJ";
+         equal_to "KODK";
+         equal_to "MSFT";
+         equal_to "TSLA";
+       ])
+
+(* When the filter is disabled, the futures row passes through. *)
+let test_load_and_filter_no_filter_keeps_futures _ =
+  let entries =
+    match
+      Lib.list_cache_entries ~cache_dir:_sample_dir
+        ~from:(_date 2020 Month.Jun 1) ~until:(_date 2020 Month.Jun 1)
+    with
+    | Ok e -> e
+    | Error err -> assert_failure (Status.show err)
+  in
+  let no_filter =
+    { Lib.require_equity_asset_class = false; require_us_location = false }
+  in
+  let result = Lib.load_and_filter ~entries ~filter:no_filter in
+  let snap_size =
+    match result with
+    | Ok [ (_, snap) ] -> List.length snap.Client.holdings
+    | _ -> assert_failure "expected exactly one snapshot"
+  in
+  assert_that snap_size (equal_to 8)
+
+(* All 5 sample fixtures load successfully and produce 5 (date, snapshot)
+   pairs in ascending date order. *)
+let test_load_and_filter_full_window _ =
+  let entries =
+    match
+      Lib.list_cache_entries ~cache_dir:_sample_dir
+        ~from:(_date 2000 Month.Jan 1) ~until:(_date 2030 Month.Jan 1)
+    with
+    | Ok e -> e
+    | Error err -> assert_failure (Status.show err)
+  in
+  let result = Lib.load_and_filter ~entries ~filter:Lib.default_filter_config in
+  let dates =
+    match result with
+    | Ok pairs -> List.map pairs ~f:fst
+    | Error err -> assert_failure (Status.show err)
+  in
+  assert_that dates
+    (elements_are (List.map _sample_dates ~f:(fun d -> equal_to d)))
+
+(* ------------------------------------------------------------------------- *)
+(* build_universe — end-to-end on the 5-snapshot sample                      *)
+(* ------------------------------------------------------------------------- *)
+
+let _load_all_snapshots () =
+  let entries =
+    match
+      Lib.list_cache_entries ~cache_dir:_sample_dir
+        ~from:(_date 2000 Month.Jan 1) ~until:(_date 2030 Month.Jan 1)
+    with
+    | Ok e -> e
+    | Error err -> assert_failure (Status.show err)
+  in
+  match Lib.load_and_filter ~entries ~filter:Lib.default_filter_config with
+  | Ok pairs -> pairs
+  | Error err -> assert_failure (Status.show err)
+
+(* Trace:
+   - AAPL, MSFT, JNJ, IBM, KODK: in 2007 → all 5 snapshots (KODK missing in
+     2012 only — 1 miss < threshold=3, tenure stays open).
+   - LEH: 2007 only; misses in 2010, 2012, 2018 → closed at snap 2018 with
+     last_seen=2007. Filter [as_of=2020] excludes it.
+   - TSLA, FB: first seen 2012, present 2012/2018/2020.
+   - ESM6: filtered before replay (asset_class=Futures).
+   Expected active members @ as_of=2020-06-01:
+     AAPL, FB, IBM, JNJ, KODK, MSFT, TSLA (7 symbols, alphabetical). *)
+let test_build_universe_yields_seven_members_at_end_of_window _ =
+  let snapshots = _load_all_snapshots () in
+  let outcome =
+    Lib.build_universe ~snapshots ~threshold_consecutive_misses:3
+      ~as_of:(_date 2020 Month.Jun 1)
+  in
+  assert_that outcome
+    (all_of
+       [
+         field (fun o -> o.Lib.member_count) (equal_to 7);
+         field (fun o -> o.Lib.snapshot_count) (equal_to 5);
+         field (fun o -> o.Lib.removed_count) (equal_to 1);
+       ])
+
+(* The output sexp must match the broad-3000 fixture shape exactly:
+   (Pinned (((symbol X) (sector Y)) ...)), sorted alphabetically. The
+   sector pinned per ticker is [sector_at_first] (which for the pre-2009
+   era is "-"). *)
+let test_build_universe_sexp_shape_and_order _ =
+  let snapshots = _load_all_snapshots () in
+  let outcome =
+    Lib.build_universe ~snapshots ~threshold_consecutive_misses:3
+      ~as_of:(_date 2020 Month.Jun 1)
+  in
+  let expected_sexp =
+    Sexp.of_string
+      "(Pinned\n\
+      \  (((symbol AAPL) (sector \"-\"))\n\
+      \   ((symbol FB) (sector \"Communication Services\"))\n\
+      \   ((symbol IBM) (sector \"-\"))\n\
+      \   ((symbol JNJ) (sector \"-\"))\n\
+      \   ((symbol KODK) (sector \"-\"))\n\
+      \   ((symbol MSFT) (sector \"-\"))\n\
+      \   ((symbol TSLA) (sector \"Consumer Discretionary\"))))"
+  in
+  assert_that outcome.Lib.universe_sexp (equal_to expected_sexp)
+
+(* Mid-window as_of: at 2010-01-29, LEH was already "missing once" but
+   below threshold=3 — the tenure_record for LEH stays in the replay,
+   so LEH at first_seen=2007 last_seen=2007. The as_of filter rejects
+   it (2010 > last_seen). TSLA/FB not yet observed → also excluded.
+   Expected: AAPL, IBM, JNJ, KODK, MSFT (5 symbols). *)
+let test_build_universe_mid_window_pi_filter _ =
+  let snapshots = _load_all_snapshots () in
+  let outcome =
+    Lib.build_universe ~snapshots ~threshold_consecutive_misses:3
+      ~as_of:(_date 2010 Month.Jan 29)
+  in
+  let symbols =
+    match outcome.Lib.universe_sexp with
+    | Sexp.List [ _; Sexp.List entries ] ->
+        List.map entries ~f:(function
+          | Sexp.List [ Sexp.List [ _; Sexp.Atom sym ]; _ ] -> sym
+          | _ -> assert_failure "bad entry shape")
+    | _ -> assert_failure "bad sexp shape"
+  in
+  assert_that symbols
+    (elements_are
+       [
+         equal_to "AAPL";
+         equal_to "IBM";
+         equal_to "JNJ";
+         equal_to "KODK";
+         equal_to "MSFT";
+       ])
+
+(* Threshold=1: KODK's single-snapshot absence in 2012-04-30 closes the
+   tenure. KODK re-appears in 2018 → opens a fresh tenure. At as_of=
+   2020-06-01, the second KODK tenure (first_seen=2018, last_seen=2020)
+   is active, but the first one (2007-2010) is not. Result: KODK still
+   appears once in the output universe, but its [sector_at_first] is now
+   "Information Technology" (from the 2018 re-observation), NOT "-".  *)
+let test_build_universe_threshold_one_changes_kodk_sector _ =
+  let snapshots = _load_all_snapshots () in
+  let outcome =
+    Lib.build_universe ~snapshots ~threshold_consecutive_misses:1
+      ~as_of:(_date 2020 Month.Jun 1)
+  in
+  let kodk_sector =
+    match outcome.Lib.universe_sexp with
+    | Sexp.List [ _; Sexp.List entries ] ->
+        List.find_map entries ~f:(function
+          | Sexp.List
+              [
+                Sexp.List [ _; Sexp.Atom "KODK" ]; Sexp.List [ _; Sexp.Atom s ];
+              ] ->
+              Some s
+          | _ -> None)
+    | _ -> assert_failure "bad sexp shape"
+  in
+  assert_that kodk_sector (is_some_and (equal_to "Information Technology"))
+
+(* ------------------------------------------------------------------------- *)
+(* write_outcome_to_file — file format / atomicity                           *)
+(* ------------------------------------------------------------------------- *)
+
+(* Tmpdir helper: each file-write test uses a fresh sandbox to avoid stale
+   leftovers from prior runs. *)
+let _tmpdir () = Filename_unix.temp_dir ~in_dir:"/tmp" "iwv-prd-test-" ""
+
+let test_write_outcome_to_file_includes_header_and_body _ =
+  let tmp = _tmpdir () in
+  let path = Filename.concat tmp "russell-3000-sample.sexp" in
+  let snapshots = _load_all_snapshots () in
+  let outcome =
+    Lib.build_universe ~snapshots ~threshold_consecutive_misses:3
+      ~as_of:(_date 2020 Month.Jun 1)
+  in
+  let write_result =
+    Lib.write_outcome_to_file ~path ~as_of:(_date 2020 Month.Jun 1)
+      ~from:(_date 2007 Month.Sep 28) ~until:(_date 2020 Month.Jun 1) outcome
+  in
+  assert_that write_result is_ok;
+  let on_disk = In_channel.read_all path in
+  assert_that on_disk
+    (all_of
+       [
+         contains_substring ";; Russell 3000 universe (IWV-derived)";
+         contains_substring "as-of: 2020-06-01";
+         contains_substring "members: 7";
+         contains_substring "snapshots replayed: 5";
+         contains_substring "(Pinned";
+         contains_substring "(symbol AAPL)";
+         contains_substring "(symbol TSLA)";
+       ])
+
+(* The output universe sexp parses cleanly: removing the comment block
+   leaves a single Sexp.t that round-trips through Sexp.of_string. *)
+let test_written_sexp_roundtrips_via_sexp_of_string _ =
+  let tmp = _tmpdir () in
+  let path = Filename.concat tmp "russell-3000-sample.sexp" in
+  let snapshots = _load_all_snapshots () in
+  let outcome =
+    Lib.build_universe ~snapshots ~threshold_consecutive_misses:3
+      ~as_of:(_date 2020 Month.Jun 1)
+  in
+  let _ =
+    Lib.write_outcome_to_file ~path ~as_of:(_date 2020 Month.Jun 1)
+      ~from:(_date 2007 Month.Sep 28) ~until:(_date 2020 Month.Jun 1) outcome
+  in
+  let on_disk = In_channel.read_all path in
+  let body_only =
+    String.split_lines on_disk
+    |> List.filter ~f:(fun l -> not (String.is_prefix l ~prefix:";;"))
+    |> String.concat ~sep:"\n"
+  in
+  let parsed = Sexp.of_string body_only in
+  assert_that parsed (equal_to outcome.Lib.universe_sexp)
+
+(* ------------------------------------------------------------------------- *)
+(* run — end-to-end pipeline                                                 *)
+(* ------------------------------------------------------------------------- *)
+
+let test_run_pipeline_full_stack _ =
+  let tmp = _tmpdir () in
+  let path = Filename.concat tmp "universe.sexp" in
+  let result =
+    Lib.run ~cache_dir:_sample_dir ~output:path ~from:(_date 2007 Month.Sep 28)
+      ~until:(_date 2020 Month.Jun 1) ~as_of:(_date 2020 Month.Jun 1)
+      ~threshold_consecutive_misses:3 ()
+  in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun o -> o.Lib.member_count) (equal_to 7);
+            field (fun o -> o.Lib.snapshot_count) (equal_to 5);
+            field (fun o -> o.Lib.removed_count) (equal_to 1);
+          ]));
+  assert_that (Sys_unix.file_exists path) (equal_to `Yes)
+
+(* ------------------------------------------------------------------------- *)
+(* Schema parity with broad-3000-2010-01-01.sexp                             *)
+(*                                                                           *)
+(* Verify the emitted sexp parses with the same shape PR #1103's consumer    *)
+(* expects: outermost (Pinned (entries...)); each entry is two key-value     *)
+(* pairs (symbol, sector). This is what Scenario_lib.Universe_file.load      *)
+(* reads.                                                                    *)
+(* ------------------------------------------------------------------------- *)
+
+let test_output_matches_broad_3000_schema _ =
+  let snapshots = _load_all_snapshots () in
+  let outcome =
+    Lib.build_universe ~snapshots ~threshold_consecutive_misses:3
+      ~as_of:(_date 2020 Month.Jun 1)
+  in
+  let entries =
+    match outcome.Lib.universe_sexp with
+    | Sexp.List [ Sexp.Atom "Pinned"; Sexp.List es ] -> es
+    | _ -> assert_failure "outermost shape mismatch"
+  in
+  let all_entries_well_formed =
+    List.for_all entries ~f:(function
+      | Sexp.List
+          [
+            Sexp.List [ Sexp.Atom "symbol"; Sexp.Atom _ ];
+            Sexp.List [ Sexp.Atom "sector"; Sexp.Atom _ ];
+          ] ->
+          true
+      | _ -> false)
+  in
+  assert_that all_entries_well_formed (equal_to true)
+
+let suite =
+  "build_iwv_universe_lib_test"
+  >::: [
+         "list_cache_entries_returns_all_in_window"
+         >:: test_list_cache_entries_returns_all_in_window;
+         "list_cache_entries_filters_window"
+         >:: test_list_cache_entries_filters_window;
+         "list_cache_entries_missing_dir_errors"
+         >:: test_list_cache_entries_missing_dir_errors;
+         "load_and_filter_drops_futures_row"
+         >:: test_load_and_filter_drops_futures_row;
+         "load_and_filter_no_filter_keeps_futures"
+         >:: test_load_and_filter_no_filter_keeps_futures;
+         "load_and_filter_full_window" >:: test_load_and_filter_full_window;
+         "build_universe_yields_seven_members_at_end_of_window"
+         >:: test_build_universe_yields_seven_members_at_end_of_window;
+         "build_universe_sexp_shape_and_order"
+         >:: test_build_universe_sexp_shape_and_order;
+         "build_universe_mid_window_pi_filter"
+         >:: test_build_universe_mid_window_pi_filter;
+         "build_universe_threshold_one_changes_kodk_sector"
+         >:: test_build_universe_threshold_one_changes_kodk_sector;
+         "write_outcome_to_file_includes_header_and_body"
+         >:: test_write_outcome_to_file_includes_header_and_body;
+         "written_sexp_roundtrips_via_sexp_of_string"
+         >:: test_written_sexp_roundtrips_via_sexp_of_string;
+         "run_pipeline_full_stack" >:: test_run_pipeline_full_stack;
+         "output_matches_broad_3000_schema"
+         >:: test_output_matches_broad_3000_schema;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Completes the IWV scraper stack (PR-A #1112 + PR-B #1118 + PR-C #1120 +
**PR-D**). PR-D is the final piece — the universe-builder CLI that
turns the cached snapshot directory into a point-in-time Russell 3000
universe sexp matching the existing `broad-3000-2010-01-01.sexp` shape.

- **New CLI** `analysis/data/sources/ishares/bin/build_iwv_universe.exe`
  with pure helper lib `build_iwv_universe_lib`.
- **Reads** cached snapshots produced by PR-C's `fetch_iwv_history.exe`
  (`<cache>/YYYY-MM-DD.csv`).
- **Pipes** parsed snapshots through PR-B's
  `Ishares_membership_replay.replay`.
- **Outputs** a `(Pinned ((symbol …) (sector …)) …)` sexp pinned to a
  given as-of date, sorted alphabetically by ticker, with the IWV
  caveat documented in the header comment.

## What it does

- **CLI flags** route every knob through config (no magic numbers):
  `--cache-root`, `--output`, `--start`, `--end`, `--as-of`,
  `--threshold-misses`. Defaults: `--start 2006-09-29`, `--end today`,
  `--as-of = --end`, `--threshold-misses 3`.
- **Equity + US-location filter** lives in this lib (not the replay
  layer, per plan §2.3.3). Exposed as `filter_config` so callers can
  vary policy per backtest. Default drops `Asset Class != Equity`
  (futures hedges, cash) and `Location != United States` (pre-2012
  cross-listings).
- **As-of filter** pins membership to a single point-in-time: tenure
  records active on `--as-of` (i.e. `first_seen <= as_of <= last_seen`)
  flow to the output sexp; removed tenures and not-yet-arrived tickers
  are excluded.
- **Atomic-rename** output writes (sibling `.tmp` then `rename`) so
  consumers never see a half-written file.

## What it does NOT do

- Does **not** generate the real `russell-3000-2006-2026.sexp` fixture
  — that requires running the full ~3 hour scrape against iShares.
  Follow-up ops session ships the artifact. This PR ships the tool.

## Test plan

- [x] 14 OUnit2 tests pin:
  - cache-entry scanning (window filter; missing-dir error)
  - `load_and_filter` (default filter drops ESM6 → 7 equity tickers;
    no-filter keeps 8; full-window loads all 5 snapshots in ascending
    date order)
  - `build_universe` (7 members at as_of=2020-06-01 with full sexp
    shape pinned via `Sexp.of_string` round-trip; mid-window pi-filter
    excludes pre-2012 arrivals; threshold=1 closes KODK and re-opens
    with new `sector_at_first`)
  - `write_outcome_to_file` (header comment + sexp body; sexp
    roundtrips via `Sexp.of_string`)
  - end-to-end `run` pipeline
  - schema parity vs `broad-3000-2010-01-01.sexp` (PR #1103)
- [x] 5 sample CSV fixtures under `test/data/sample_history/` covering
  always-present / single-miss survival / confirmed-removal / late-entry
  / futures-filter cases.
- [x] `dune build && dune runtest` green (14 + 17 + 17 + 9 = 57 tests
  pass across the four ishares test suites).
- [x] `dune build @fmt` clean.
- [x] `fn_length_linter`, `linter_magic_numbers`, `no_python_check`
  green on the new code.

## Notes

CI infra caveat (per dispatch): main has flaky linter CI tonight
(sandbox cleanup race in 1+ shell-linter scripts beyond `no_python`).
Local build clean. Admin-merge on QC after perf-tier1 pass.

Plan: `dev/plans/iwv-scraper-2026-05-16.md` §PR-D.

LOC delta: 386 source (`.ml`+`.mli`) + 408 tests. Sample fixtures
(~6 KB) and status update excluded per PR-sizing rules.