### PR TITLE
feat(tuning): Bayesian Phase 3 PR-A — scoring function + walk-forward aggregate consumer

### DIFF
--- a/dev/status/tuning.md
+++ b/dev/status/tuning.md
@@ -1,6 +1,6 @@
 # Status: tuning
 
-## Last updated: 2026-05-15
+## Last updated: 2026-05-16
 
 ## Status
 IN_PROGRESS
@@ -91,6 +91,38 @@ Per `.claude/rules/no-python.md`. OCaml-native or FFI to C libs only.
 - **Bayesian Phase 3 PR-A** (scoring function, PR #1126, branch `feat/bayesian-phase3-pr-a`) — structural_qc: APPROVED; behavioral_qc: APPROVED (2026-05-16, quality 5). CP1–CP4 all PASS; domain rows NA (pure tuner-side scoring policy). See `dev/reviews/tuning.md` §"Behavioral Checklist — Bayesian Phase 3 PR-A".
 - T-A lib + CLI, T-B lib + CLI, and `min_score_override` / `max_score_override` knobs all MERGED. First 81-cell flagship sweep run published (PR #1051) but invalidated by key-path bug (PR #1061). Next queued: 81-cell rerun with corrected `w_positive_rs/w_strong_volume/w_stage2_breakout/w_sector_strong` field paths + sweep-path validation linter to prevent silent-no-op repeats.
 
+### Bayesian Phase 3 — multi-parameter scaling (5-PR stack, plan PR #1124 MERGED)
+
+Plan authority: `dev/plans/bayesian-multi-param-scaling-2026-05-16.md`.
+Plan splits into 5 stacked PRs (~200-400 LOC each):
+
+- **PR-A: scoring function + walk-forward aggregate consumer** —
+  IN REVIEW (branch `feat/bayesian-phase3-pr-a`). Adds
+  `Tuner_bin.Bayesian_runner_scoring` (pure scorer over a
+  `Walk_forward_types.aggregate` + Cell E baseline aggregate) with
+  loss = `-mean_sharpe + lambda_dd*max(0, maxdd_excess) + lambda_gate*gate_penalty`;
+  hyperparameters as named constants (`_lambda_dd=0.10`,
+  `_gate_penalty_value=10.0`, `_lambda_gate=1.0`,
+  `_degenerate_fold_floor_return_pct=-50.0`). Returns
+  `float Status.status_or` so missing-variant lookups surface as
+  structured errors. 15 unit tests cover identity case, MaxDD hinge
+  zero/linear, gate Pass/Fail diff = -10.0 exactly, synthetic Fail ≡
+  regular Fail, lookup errors (3 paths), zero-fold guard, boundary
+  cases, parameters-not-affecting-score contract, and constant
+  pinning. No wiring into the BO evaluator/runner yet — that's PR-C.
+- **PR-B: knob inventory + parameter space encoding** — pending.
+- **PR-C: walk-forward in-process integration** — pending.
+- **PR-D: int/Option encoding + GP length-scale tuning + early-stop** — pending.
+- **PR-E: end-to-end runner + OOS holdout validator** — pending.
+
+Operational follow-ups (unblock when capacity allows):
+
+- **81-cell flagship rerun with corrected field paths** — sweep
+  `screening.weights.{w_positive_rs, w_strong_volume, w_stage2_breakout, w_sector_strong}`
+  paired with `min_score_override` / `max_score_override` tightening.
+- **Sweep-path validation linter** in `runner.ml:_merge_records` —
+  fail on unrecognized keys to prevent silent-no-op overlays.
+
 ## Completed
 
 - [x] **PR #1047 — `grid_search.exe --parallel N` (cell-level parallelism)** (MERGED 2026-05-12). Reduces wall-time for large grids by running N cells concurrently. Used for the 81-cell flagship sweep.
@@ -109,11 +141,14 @@ Per `.claude/rules/no-python.md`. OCaml-native or FFI to C libs only.
 1. ~~Wire CLI binary at `trading/trading/backtest/tuner/bin/grid_search.ml`~~ — done (#893).
 2. ~~Wire CLI binary at `trading/trading/backtest/tuner/bin/bayesian_runner.ml`~~ — done (#914).
 3. ~~Run 81-cell flagship sweep~~ — first run published #1051; invalidated by PR #1061 (key-path bug in overlays).
-4. **Rerun the 81-cell flagship sweep with corrected field paths** — sweep `screening.weights.{w_positive_rs, w_strong_volume, w_stage2_breakout, w_sector_strong}` (the real `Screener.scoring_weights` field names; see PR #1068 `.mli` clarifications). Pair with `min_score_override` / `max_score_override` tightening to surface a cell-discriminating signal.
-5. **Sweep-path validation linter** in `runner.ml:_merge_records` — fail on unrecognized keys to prevent silent-no-op overlays (closes the hazard surfaced by PR #1051 → #1061).
-6. After corrected grid sweep results land, validate T-B converges to the same (or better) cell within ~30 evals using the same param surface — the convergence acceptance criterion in `m5-experiments-roadmap-2026-05-02.md` §M5.5 T-B.
-7. T-C only after `data-foundations` Norgate ingest (need long enough train/test split).
-8. Hyperparameter learning for T-B (Type-II MLE on length scales) — defer until 4-dim / 6-dim sweeps show that fixed length scales miss the optimum.
+4. **Bayesian Phase 3 PR-A** (scoring + aggregate consumer) — IN REVIEW
+   (`feat/bayesian-phase3-pr-a`). 15 unit tests passing. PR-B (knob
+   inventory) is the next deliverable in the 5-PR stack.
+5. **Rerun the 81-cell flagship sweep with corrected field paths** — sweep `screening.weights.{w_positive_rs, w_strong_volume, w_stage2_breakout, w_sector_strong}` (the real `Screener.scoring_weights` field names; see PR #1068 `.mli` clarifications). Pair with `min_score_override` / `max_score_override` tightening to surface a cell-discriminating signal.
+6. **Sweep-path validation linter** in `runner.ml:_merge_records` — fail on unrecognized keys to prevent silent-no-op overlays (closes the hazard surfaced by PR #1051 → #1061).
+7. After corrected grid sweep results land, validate T-B converges to the same (or better) cell within ~30 evals using the same param surface — the convergence acceptance criterion in `m5-experiments-roadmap-2026-05-02.md` §M5.5 T-B.
+8. T-C only after `data-foundations` Norgate ingest (need long enough train/test split).
+9. Hyperparameter learning for T-B (Type-II MLE on length scales) — defer until 4-dim / 6-dim sweeps show that fixed length scales miss the optimum.
 
 ## Out of scope
 

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml
@@ -13,33 +13,29 @@ let _degenerate_fold_floor_return_pct = -50.0
 let _lookup_stability ~(label : string) (agg : Wf.aggregate) :
     Wf.variant_stability Status.status_or =
   match
-    List.find agg.stability ~f:(fun v ->
-        String.equal v.variant_label label)
+    List.find agg.stability ~f:(fun v -> String.equal v.variant_label label)
   with
   | Some v -> Ok v
   | None ->
       Status.error_not_found
         (Printf.sprintf
-           "bayesian_runner_scoring: variant %S not found in aggregate.stability \
-            (have: [%s])"
+           "bayesian_runner_scoring: variant %S not found in \
+            aggregate.stability (have: [%s])"
            label
            (String.concat ~sep:"; "
               (List.map agg.stability ~f:(fun v -> v.variant_label))))
 
 let _lookup_verdict ~(label : string) (agg : Wf.aggregate) :
     Walk_forward.Fold_gate.verdict Status.status_or =
-  match
-    List.Assoc.find agg.verdicts ~equal:String.equal label
-  with
+  match List.Assoc.find agg.verdicts ~equal:String.equal label with
   | Some v -> Ok v
   | None ->
       Status.error_not_found
         (Printf.sprintf
-           "bayesian_runner_scoring: variant %S not found in aggregate.verdicts \
-            (have: [%s])"
+           "bayesian_runner_scoring: variant %S not found in \
+            aggregate.verdicts (have: [%s])"
            label
-           (String.concat ~sep:"; "
-              (List.map agg.verdicts ~f:fst)))
+           (String.concat ~sep:"; " (List.map agg.verdicts ~f:fst)))
 
 (* ---------- component computations ---------- *)
 
@@ -48,15 +44,13 @@ let _compute_maxdd_hinge ~(candidate_maxdd : float) ~(baseline_maxdd : float) :
   Float.max 0.0 (candidate_maxdd -. baseline_maxdd)
 
 let _compute_gate_penalty (verdict : Walk_forward.Fold_gate.verdict) : float =
-  match verdict with
-  | Pass _ -> 0.0
-  | Fail _ -> _gate_penalty_value
+  match verdict with Pass _ -> 0.0 | Fail _ -> _gate_penalty_value
 
 (* ---------- top-level scorer ---------- *)
 
 let score_cell ~parameters:_ ~candidate_label ~baseline_label
-    ~(candidate_aggregate : Wf.aggregate)
-    ~(baseline_aggregate : Wf.aggregate) : float Status.status_or =
+    ~(candidate_aggregate : Wf.aggregate) ~(baseline_aggregate : Wf.aggregate) :
+    float Status.status_or =
   if candidate_aggregate.fold_count = 0 then
     Status.error_invalid_argument
       "bayesian_runner_scoring: candidate_aggregate.fold_count = 0; no folds \
@@ -75,12 +69,10 @@ let score_cell ~parameters:_ ~candidate_label ~baseline_label
     let mean_sharpe = candidate_stab.sharpe_ratio.mean in
     let candidate_maxdd = candidate_stab.max_drawdown_pct.mean in
     let baseline_maxdd = baseline_stab.max_drawdown_pct.mean in
-    let maxdd_hinge =
-      _compute_maxdd_hinge ~candidate_maxdd ~baseline_maxdd
-    in
+    let maxdd_hinge = _compute_maxdd_hinge ~candidate_maxdd ~baseline_maxdd in
     let gate_penalty = _compute_gate_penalty candidate_verdict in
     let loss =
-      (-.mean_sharpe)
+      -.mean_sharpe
       +. (_lambda_dd *. maxdd_hinge)
       +. (_lambda_gate *. gate_penalty)
     in

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml
@@ -1,0 +1,87 @@
+open Core
+module Wf = Walk_forward.Walk_forward_types
+
+(* Hyperparameter constants — see the mli for rationale. *)
+
+let _lambda_dd = 0.10
+let _gate_penalty_value = 10.0
+let _lambda_gate = 1.0
+let _degenerate_fold_floor_return_pct = -50.0
+
+(* ---------- variant lookup helpers ---------- *)
+
+let _lookup_stability ~(label : string) (agg : Wf.aggregate) :
+    Wf.variant_stability Status.status_or =
+  match
+    List.find agg.stability ~f:(fun v ->
+        String.equal v.variant_label label)
+  with
+  | Some v -> Ok v
+  | None ->
+      Status.error_not_found
+        (Printf.sprintf
+           "bayesian_runner_scoring: variant %S not found in aggregate.stability \
+            (have: [%s])"
+           label
+           (String.concat ~sep:"; "
+              (List.map agg.stability ~f:(fun v -> v.variant_label))))
+
+let _lookup_verdict ~(label : string) (agg : Wf.aggregate) :
+    Walk_forward.Fold_gate.verdict Status.status_or =
+  match
+    List.Assoc.find agg.verdicts ~equal:String.equal label
+  with
+  | Some v -> Ok v
+  | None ->
+      Status.error_not_found
+        (Printf.sprintf
+           "bayesian_runner_scoring: variant %S not found in aggregate.verdicts \
+            (have: [%s])"
+           label
+           (String.concat ~sep:"; "
+              (List.map agg.verdicts ~f:fst)))
+
+(* ---------- component computations ---------- *)
+
+let _compute_maxdd_hinge ~(candidate_maxdd : float) ~(baseline_maxdd : float) :
+    float =
+  Float.max 0.0 (candidate_maxdd -. baseline_maxdd)
+
+let _compute_gate_penalty (verdict : Walk_forward.Fold_gate.verdict) : float =
+  match verdict with
+  | Pass _ -> 0.0
+  | Fail _ -> _gate_penalty_value
+
+(* ---------- top-level scorer ---------- *)
+
+let score_cell ~parameters:_ ~candidate_label ~baseline_label
+    ~(candidate_aggregate : Wf.aggregate)
+    ~(baseline_aggregate : Wf.aggregate) : float Status.status_or =
+  if candidate_aggregate.fold_count = 0 then
+    Status.error_invalid_argument
+      "bayesian_runner_scoring: candidate_aggregate.fold_count = 0; no folds \
+       to score"
+  else
+    let open Result.Let_syntax in
+    let%bind candidate_stab =
+      _lookup_stability ~label:candidate_label candidate_aggregate
+    in
+    let%bind baseline_stab =
+      _lookup_stability ~label:baseline_label baseline_aggregate
+    in
+    let%bind candidate_verdict =
+      _lookup_verdict ~label:candidate_label candidate_aggregate
+    in
+    let mean_sharpe = candidate_stab.sharpe_ratio.mean in
+    let candidate_maxdd = candidate_stab.max_drawdown_pct.mean in
+    let baseline_maxdd = baseline_stab.max_drawdown_pct.mean in
+    let maxdd_hinge =
+      _compute_maxdd_hinge ~candidate_maxdd ~baseline_maxdd
+    in
+    let gate_penalty = _compute_gate_penalty candidate_verdict in
+    let loss =
+      (-.mean_sharpe)
+      +. (_lambda_dd *. maxdd_hinge)
+      +. (_lambda_gate *. gate_penalty)
+    in
+    Ok (-.loss)

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.mli
@@ -1,22 +1,23 @@
 (** Pure scoring function for the Phase 3 Bayesian optimizer.
 
-    Consumes a per-cell walk-forward {!Walk_forward.Walk_forward_types.aggregate}
-    plus a baseline aggregate (always Cell E on the same walk-forward spec) and
-    returns the BO loop's "higher is better" score for that cell. Splitting the
-    scorer out of {!Tuner_bin.Bayesian_runner_evaluator} keeps it pure and
-    unit-testable: the evaluator (PR-C) calls this function after running the
-    walk-forward CV; this module never touches the filesystem, never spawns a
-    subprocess, never reads a config.
+    Consumes a per-cell walk-forward
+    {!Walk_forward.Walk_forward_types.aggregate} plus a baseline aggregate
+    (always Cell E on the same walk-forward spec) and returns the BO loop's
+    "higher is better" score for that cell. Splitting the scorer out of
+    {!Tuner_bin.Bayesian_runner_evaluator} keeps it pure and unit-testable: the
+    evaluator (PR-C) calls this function after running the walk-forward CV; this
+    module never touches the filesystem, never spawns a subprocess, never reads
+    a config.
 
-    Scoring formula (plan
-    [dev/plans/bayesian-multi-param-scaling-2026-05-16.md] §3.1):
+    Scoring formula (plan [dev/plans/bayesian-multi-param-scaling-2026-05-16.md]
+    §3.1):
 
-    {[
-      loss(cell) = -mean_sharpe(cell)
-                 + lambda_dd  * max(0, mean_maxdd(cell) - baseline_maxdd)
-                 + lambda_gate * gate_penalty(cell)
+    {v
+      loss(cell)  = -mean_sharpe(cell)
+                  + lambda_dd  * max(0, mean_maxdd(cell) - baseline_maxdd)
+                  + lambda_gate * gate_penalty(cell)
       score(cell) = -loss(cell)
-    ]}
+    v}
 
     where:
 
@@ -46,13 +47,13 @@
       {!Walk_forward.Walk_forward_report.compute}) collapses to the same penalty
       — no special case.
 
-    Hyperparameter tuning rationale lives in the plan §3.1; the constants
-    below are exposed in the mli so callers can introspect them (e.g. for
-    diagnostic output) but the values are pinned, not overridable. *)
+    Hyperparameter tuning rationale lives in the plan §3.1; the constants below
+    are exposed in the mli so callers can introspect them (e.g. for diagnostic
+    output) but the values are pinned, not overridable. *)
 
 val _lambda_dd : float
-(** Penalty coefficient on excess MaxDD over baseline. Default [0.10] —
-    every 1pp of excess MaxDD costs 0.10 units of Sharpe-equivalent loss. *)
+(** Penalty coefficient on excess MaxDD over baseline. Default [0.10] — every
+    1pp of excess MaxDD costs 0.10 units of Sharpe-equivalent loss. *)
 
 val _gate_penalty_value : float
 (** Magnitude of the gate-fail penalty. Default [10.0] — chosen to dominate any
@@ -93,8 +94,8 @@ val score_cell :
     [candidate_aggregate] and [baseline_aggregate] are produced by
     {!Walk_forward.Walk_forward_report.compute}. The candidate aggregate is the
     output of the walk-forward run for the cell under test; the baseline
-    aggregate is the Cell E reference run on the SAME walk-forward spec
-    (window / fold layout / gate).
+    aggregate is the Cell E reference run on the SAME walk-forward spec (window
+    / fold layout / gate).
 
     Error cases (each carrying a structured {!Status.t}):
 
@@ -104,8 +105,8 @@ val score_cell :
       [candidate_aggregate.verdicts].
     - [Status.NotFound] when [baseline_label] is not present in
       [baseline_aggregate.stability].
-    - [Status.Invalid_argument] when [candidate_aggregate.fold_count = 0] —
-      a zero-fold aggregate cannot yield a meaningful mean Sharpe.
+    - [Status.Invalid_argument] when [candidate_aggregate.fold_count = 0] — a
+      zero-fold aggregate cannot yield a meaningful mean Sharpe.
 
     Determinism: same inputs → byte-identical [float] output (modulo IEEE-754
     quirks; no floating-point reduction order dependencies because the

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.mli
@@ -1,0 +1,112 @@
+(** Pure scoring function for the Phase 3 Bayesian optimizer.
+
+    Consumes a per-cell walk-forward {!Walk_forward.Walk_forward_types.aggregate}
+    plus a baseline aggregate (always Cell E on the same walk-forward spec) and
+    returns the BO loop's "higher is better" score for that cell. Splitting the
+    scorer out of {!Tuner_bin.Bayesian_runner_evaluator} keeps it pure and
+    unit-testable: the evaluator (PR-C) calls this function after running the
+    walk-forward CV; this module never touches the filesystem, never spawns a
+    subprocess, never reads a config.
+
+    Scoring formula (plan
+    [dev/plans/bayesian-multi-param-scaling-2026-05-16.md] §3.1):
+
+    {[
+      loss(cell) = -mean_sharpe(cell)
+                 + lambda_dd  * max(0, mean_maxdd(cell) - baseline_maxdd)
+                 + lambda_gate * gate_penalty(cell)
+      score(cell) = -loss(cell)
+    ]}
+
+    where:
+
+    - [mean_sharpe(cell)] is the cell's mean per-fold Sharpe ratio, computed
+      from the {!Walk_forward.Walk_forward_types.aggregate}'s [stability] entry
+      for the candidate variant. NOTE: the precomputed
+      [stability[v].sharpe_ratio.mean] is used as-is. Plan §3.1 calls for
+      excluding folds whose return is below the degenerate-portfolio floor
+      ([-50%]); the aggregate's mean does not carry the per-fold return so the
+      exclusion is implemented at the upstream walk-forward harness when
+      relevant — for the scorer's signature here, only the aggregate is in
+      scope. The signature is reserved to accept a per-fold list in a future
+      revision; PR-A delivers the aggregate-only path with the constant
+      {!_degenerate_fold_floor_return_pct} declared for documentation.
+
+    - [mean_maxdd(cell)] is the cell's mean per-fold MaxDD%, also drawn from
+      [stability[v].max_drawdown_pct.mean].
+
+    - [baseline_maxdd] is read from the baseline aggregate's
+      [stability[<baseline_label>].max_drawdown_pct.mean]; PR-A reads the
+      baseline dynamically rather than hardcoding a value, so the score remains
+      correct when the Cell E baseline re-pins.
+
+    - [gate_penalty(cell)] is [0.0] if the candidate variant's [verdicts] entry
+      is [Pass _], else {!_gate_penalty_value}. The synthetic Fail variant from
+      a fold-pair count mismatch (see
+      {!Walk_forward.Walk_forward_report.compute}) collapses to the same penalty
+      — no special case.
+
+    Hyperparameter tuning rationale lives in the plan §3.1; the constants
+    below are exposed in the mli so callers can introspect them (e.g. for
+    diagnostic output) but the values are pinned, not overridable. *)
+
+val _lambda_dd : float
+(** Penalty coefficient on excess MaxDD over baseline. Default [0.10] —
+    every 1pp of excess MaxDD costs 0.10 units of Sharpe-equivalent loss. *)
+
+val _gate_penalty_value : float
+(** Magnitude of the gate-fail penalty. Default [10.0] — chosen to dominate any
+    marginal Sharpe improvement so cells failing the M-of-N gate are pushed to
+    the tail of the search distribution. *)
+
+val _lambda_gate : float
+(** Penalty coefficient on the gate verdict. Default [1.0]. The product
+    [lambda_gate * gate_penalty_value = 10.0] is the effective loss bump on
+    [Fail]. *)
+
+val _degenerate_fold_floor_return_pct : float
+(** Per-fold total-return floor below which the fold is considered
+    degenerate-portfolio (mass liquidation cascade). Default [-50.0].
+
+    Reserved for the per-fold scoring path; the aggregate-only path here uses
+    the aggregate's precomputed mean Sharpe directly. Documented in the mli so
+    callers in PR-C can wire per-fold exclusion when the walk-forward harness
+    surfaces per-fold returns to the scorer. *)
+
+val score_cell :
+  parameters:(string * float) list ->
+  candidate_label:string ->
+  baseline_label:string ->
+  candidate_aggregate:Walk_forward.Walk_forward_types.aggregate ->
+  baseline_aggregate:Walk_forward.Walk_forward_types.aggregate ->
+  float Status.status_or
+(** [score_cell ~parameters ~candidate_label ~baseline_label
+     ~candidate_aggregate ~baseline_aggregate] returns the BO score
+    (higher-is-better) for the candidate cell.
+
+    [parameters] is accepted for logging-shape symmetry with the existing
+    evaluator surface; the score does not depend on the parameter values
+    directly (it depends only on the walk-forward outcomes). It is required so
+    callers cannot accidentally pass a "blank" assignment when the BO loop
+    expects per-iteration cells.
+
+    [candidate_aggregate] and [baseline_aggregate] are produced by
+    {!Walk_forward.Walk_forward_report.compute}. The candidate aggregate is the
+    output of the walk-forward run for the cell under test; the baseline
+    aggregate is the Cell E reference run on the SAME walk-forward spec
+    (window / fold layout / gate).
+
+    Error cases (each carrying a structured {!Status.t}):
+
+    - [Status.NotFound] when [candidate_label] is not present in
+      [candidate_aggregate.stability].
+    - [Status.NotFound] when [candidate_label] is not present in
+      [candidate_aggregate.verdicts].
+    - [Status.NotFound] when [baseline_label] is not present in
+      [baseline_aggregate.stability].
+    - [Status.Invalid_argument] when [candidate_aggregate.fold_count = 0] —
+      a zero-fold aggregate cannot yield a meaningful mean Sharpe.
+
+    Determinism: same inputs → byte-identical [float] output (modulo IEEE-754
+    quirks; no floating-point reduction order dependencies because the
+    aggregate's [mean] fields are already pre-reduced). *)

--- a/trading/trading/backtest/tuner/bin/dune
+++ b/trading/trading/backtest/tuner/bin/dune
@@ -6,17 +6,20 @@
   grid_search_runner
   bayesian_runner_spec
   bayesian_runner_evaluator
-  bayesian_runner_runner)
+  bayesian_runner_runner
+  bayesian_runner_scoring)
  (libraries
   core
   core_unix
   core_unix.filename_unix
+  status
   tuner
   backtest
   scenario_lib
-  trading.simulation.types)
+  trading.simulation.types
+  walk_forward)
  (preprocess
-  (pps ppx_sexp_conv)))
+  (pps ppx_sexp_conv ppx_let)))
 
 (executable
  (name grid_search)

--- a/trading/trading/backtest/tuner/bin/test/dune
+++ b/trading/trading/backtest/tuner/bin/test/dune
@@ -1,13 +1,18 @@
 (tests
- (names test_grid_search_bin test_bayesian_runner_bin)
+ (names
+  test_grid_search_bin
+  test_bayesian_runner_bin
+  test_bayesian_runner_scoring)
  (libraries
   ounit2
   core
   core_unix.filename_unix
   core_unix.sys_unix
   matchers
+  status
   tuner
   tuner_bin
+  walk_forward
   trading.simulation.types)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_scoring.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_scoring.ml
@@ -1,0 +1,501 @@
+(** Unit tests for {!Tuner_bin.Bayesian_runner_scoring}.
+
+    The scorer is pure: input = two pre-computed walk-forward aggregates, output
+    = float (or [Status.t] error on bad lookup). Tests construct synthetic
+    {!Walk_forward.Walk_forward_types.aggregate} records by hand — no real
+    walk-forward run, no backtest invocation. This keeps the test suite fast and
+    the failure surface localised to the scoring formula itself.
+
+    Coverage map (plan §7 PR-A):
+
+    - Identity case: candidate == baseline → score = +mean_sharpe(baseline).
+    - MaxDD hinge zero: candidate MaxDD ≤ baseline → no penalty.
+    - MaxDD hinge linear: candidate MaxDD > baseline by Δpp → penalty =
+      lambda_dd * Δ exactly.
+    - Gate Pass / Fail boundary: same Sharpe/MaxDD, only verdict differs → score
+      diff = -lambda_gate * gate_penalty_value = -10.0.
+    - Missing-variant lookups in stability and verdicts return Status.Error.
+    - Sharpe improvement: candidate Sharpe > baseline Sharpe → score strictly
+      greater than baseline self-score.
+    - Edge cases: zero-fold aggregate, exactly-at-baseline-MaxDD, exact
+      gate-Pass at zero penalty, baseline label missing from baseline aggregate,
+      candidate MaxDD < baseline (negative hinge clipped). *)
+
+open OUnit2
+open Core
+open Matchers
+module Scoring = Tuner_bin.Bayesian_runner_scoring
+module Wf = Walk_forward.Walk_forward_types
+module FG = Walk_forward.Fold_gate
+
+(* ---------- synthetic-aggregate builders ---------- *)
+
+let _stats ?(stdev = Float.nan) ?(min = Float.nan) ?(max = Float.nan) ~mean () :
+    Wf.per_metric_stats =
+  { mean; stdev; min; max }
+
+let _stability_record ~label ~sharpe_mean ~maxdd_mean : Wf.variant_stability =
+  {
+    variant_label = label;
+    total_return_pct = _stats ~mean:0.0 ();
+    sharpe_ratio = _stats ~mean:sharpe_mean ();
+    max_drawdown_pct = _stats ~mean:maxdd_mean ();
+    calmar_ratio = _stats ~mean:0.0 ();
+    cagr_pct = _stats ~mean:Float.nan ();
+  }
+
+(** Build a synthetic aggregate with two variants and the requested verdict on
+    the candidate. The baseline verdict is always [Pass] (one row in the
+    [verdicts] list); the candidate verdict is the caller-supplied row. *)
+let _make_aggregate ~baseline_label ~candidate_label ~baseline_sharpe
+    ~baseline_maxdd ~candidate_sharpe ~candidate_maxdd ~candidate_verdict
+    ?(fold_count = 3) () : Wf.aggregate =
+  let baseline_stab =
+    _stability_record ~label:baseline_label ~sharpe_mean:baseline_sharpe
+      ~maxdd_mean:baseline_maxdd
+  in
+  let candidate_stab =
+    _stability_record ~label:candidate_label ~sharpe_mean:candidate_sharpe
+      ~maxdd_mean:candidate_maxdd
+  in
+  {
+    fold_count;
+    baseline_label;
+    metric_label = "sharpe_ratio";
+    stability = [ baseline_stab; candidate_stab ];
+    sensitivity = [];
+    verdicts = [ (candidate_label, candidate_verdict) ];
+  }
+
+let _pass_verdict ?(wins = 3) ?(n = 3) () : FG.verdict = Pass { wins; n }
+
+let _fail_verdict ?(wins = 0) ?(n = 3) ?(worst_fold = "fold-001")
+    ?(worst_gap = 0.5) ?(reason = "M-threshold miss") () : FG.verdict =
+  Fail { wins; n; worst_fold; worst_gap; reason }
+
+(* ---------- shared constants ---------- *)
+
+let _candidate_label = "bo-iter-7"
+let _baseline_label = "cell-E"
+let _no_params : (string * float) list = []
+let _epsilon = 1e-9
+
+(* ---------- 1. Identity case ---------- *)
+
+(** When candidate aggregate == baseline aggregate (same variant labels, same
+    metrics, gate Pass), score = +mean_sharpe (since MaxDD hinge is 0.0 and gate
+    penalty is 0.0). *)
+let test_identity_candidate_equals_baseline _ =
+  let agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.85
+      ~baseline_maxdd:12.0 ~candidate_sharpe:0.85 ~candidate_maxdd:12.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:agg
+      ~baseline_aggregate:agg
+  in
+  assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 0.85))
+
+(* ---------- 2. MaxDD hinge zero (improvement) ---------- *)
+
+(** Candidate MaxDD (10.0) < baseline MaxDD (15.0) → no penalty. Score equals
+    +mean_sharpe(candidate). *)
+let test_maxdd_hinge_zero_on_improvement _ =
+  let candidate_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:1.2 ~candidate_maxdd:10.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let baseline_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_baseline_label ~baseline_sharpe:0.5 ~baseline_maxdd:15.0
+      ~candidate_sharpe:0.5 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 1.2))
+
+(* ---------- 3. MaxDD hinge linear on excess ---------- *)
+
+(** Candidate MaxDD = 20.0 vs baseline = 15.0 → Δ = 5.0pp; penalty = lambda_dd
+    (0.10) * 5.0 = 0.5; score = +mean_sharpe (1.0) - 0.5 = 0.5. *)
+let test_maxdd_hinge_linear_on_excess _ =
+  let candidate_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:1.0 ~candidate_maxdd:20.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let baseline_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_baseline_label ~baseline_sharpe:0.5 ~baseline_maxdd:15.0
+      ~candidate_sharpe:0.5 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 0.5))
+
+(* ---------- 4. Gate Pass / Fail boundary ---------- *)
+
+(** Two candidates differ only in verdict. Score difference must equal exactly
+    -lambda_gate * gate_penalty_value = -1.0 * 10.0 = -10.0. *)
+let test_gate_pass_vs_fail_score_difference _ =
+  let pass_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:0.9 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let fail_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:0.9 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_fail_verdict ()) ()
+  in
+  let baseline_agg = pass_agg in
+  let pass_result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:pass_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  let fail_result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:fail_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  match (pass_result, fail_result) with
+  | Ok p, Ok f -> assert_that (p -. f) (float_equal ~epsilon:_epsilon 10.0)
+  | _ ->
+      assert_failure
+        "expected both score_cell calls to succeed for pass/fail comparison"
+
+(* ---------- 5. Synthetic Fail variant (fold-pair count mismatch) ---------- *)
+
+(** Per walk_forward_report.mli:30-35, fold-pair count mismatch yields a Fail
+    verdict. The scorer must treat it identically to a regular Fail (same
+    penalty magnitude). *)
+let test_synthetic_fail_treated_as_regular_fail _ =
+  let synthetic_fail : FG.verdict =
+    Fail
+      {
+        wins = 0;
+        n = 3;
+        worst_fold = "(none)";
+        worst_gap = 0.0;
+        reason = "fold-pair count mismatch (synthetic)";
+      }
+  in
+  let regular_fail = _fail_verdict () in
+  let make_agg verdict =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:0.9 ~candidate_maxdd:15.0
+      ~candidate_verdict:verdict ()
+  in
+  let synth_agg = make_agg synthetic_fail in
+  let regular_agg = make_agg regular_fail in
+  let baseline_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_baseline_label ~baseline_sharpe:0.5 ~baseline_maxdd:15.0
+      ~candidate_sharpe:0.5 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let synth =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:synth_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  let regular =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:regular_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  match (synth, regular) with
+  | Ok s, Ok r -> assert_that s (float_equal ~epsilon:_epsilon r)
+  | _ -> assert_failure "expected both score_cell calls to succeed"
+
+(* ---------- 6. Sharpe improvement ---------- *)
+
+(** Candidate Sharpe (1.5) > baseline Sharpe (0.5), same MaxDD, both Pass →
+    candidate score (1.5) > baseline self-score (0.5). *)
+let test_sharpe_improvement_increases_score _ =
+  let candidate_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:1.5 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let baseline_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_baseline_label ~baseline_sharpe:0.5 ~baseline_maxdd:15.0
+      ~candidate_sharpe:0.5 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let candidate_score =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  let baseline_score =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_baseline_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  match (candidate_score, baseline_score) with
+  | Ok c, Ok b -> assert_that c (gt (module Float_ord) b)
+  | _ -> assert_failure "expected both score_cell calls to succeed"
+
+(* ---------- 7. Missing variant in stability ---------- *)
+
+let test_missing_candidate_in_stability_returns_error _ =
+  (* Build an aggregate whose stability does NOT contain the requested
+     candidate label. *)
+  let agg : Wf.aggregate =
+    {
+      fold_count = 3;
+      baseline_label = _baseline_label;
+      metric_label = "sharpe_ratio";
+      stability =
+        [
+          _stability_record ~label:_baseline_label ~sharpe_mean:0.5
+            ~maxdd_mean:15.0;
+        ];
+      sensitivity = [];
+      verdicts = [ (_candidate_label, _pass_verdict ()) ];
+    }
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:agg
+      ~baseline_aggregate:agg
+  in
+  assert_that result (is_error_with Status.NotFound)
+
+(* ---------- 8. Missing variant in verdicts ---------- *)
+
+let test_missing_candidate_in_verdicts_returns_error _ =
+  let agg : Wf.aggregate =
+    {
+      fold_count = 3;
+      baseline_label = _baseline_label;
+      metric_label = "sharpe_ratio";
+      stability =
+        [
+          _stability_record ~label:_baseline_label ~sharpe_mean:0.5
+            ~maxdd_mean:15.0;
+          _stability_record ~label:_candidate_label ~sharpe_mean:1.0
+            ~maxdd_mean:15.0;
+        ];
+      sensitivity = [];
+      (* No verdict for candidate_label. *)
+      verdicts = [];
+    }
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:agg
+      ~baseline_aggregate:agg
+  in
+  assert_that result (is_error_with Status.NotFound)
+
+(* ---------- 9. Missing baseline in baseline_aggregate ---------- *)
+
+let test_missing_baseline_in_baseline_aggregate_returns_error _ =
+  let candidate_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:1.0 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let baseline_agg : Wf.aggregate =
+    {
+      fold_count = 3;
+      baseline_label = _baseline_label;
+      metric_label = "sharpe_ratio";
+      stability =
+        [
+          _stability_record ~label:"some-other-label" ~sharpe_mean:0.5
+            ~maxdd_mean:15.0;
+        ];
+      sensitivity = [];
+      verdicts = [];
+    }
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  assert_that result (is_error_with Status.NotFound)
+
+(* ---------- 10. Zero-fold aggregate ---------- *)
+
+let test_zero_fold_aggregate_returns_error _ =
+  let agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:1.0 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ~fold_count:0 ()
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:agg
+      ~baseline_aggregate:agg
+  in
+  assert_that result (is_error_with Status.Invalid_argument)
+
+(* ---------- 11. Exactly at baseline MaxDD ---------- *)
+
+(** Candidate MaxDD == baseline MaxDD → hinge = 0 (boundary). *)
+let test_exactly_at_baseline_maxdd_zero_hinge _ =
+  let baseline_maxdd = 18.0 in
+  let candidate_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5 ~baseline_maxdd
+      ~candidate_sharpe:0.8 ~candidate_maxdd:baseline_maxdd
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let baseline_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_baseline_label ~baseline_sharpe:0.5 ~baseline_maxdd
+      ~candidate_sharpe:0.5 ~candidate_maxdd:baseline_maxdd
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  (* No MaxDD penalty, no gate penalty → score = +0.8. *)
+  assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 0.8))
+
+(* ---------- 12. Negative-Sharpe candidate (Pass) ---------- *)
+
+(** Candidate with negative Sharpe (e.g. -0.3), Pass verdict, identical MaxDD.
+    Score = +(-0.3) = -0.3. Confirms sign-handling does not collapse. *)
+let test_negative_sharpe_candidate_score_negative _ =
+  let agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.0
+      ~baseline_maxdd:10.0 ~candidate_sharpe:(-0.3) ~candidate_maxdd:10.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:agg
+      ~baseline_aggregate:agg
+  in
+  assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon (-0.3)))
+
+(* ---------- 13. Both penalties simultaneously ---------- *)
+
+(** Candidate over-MaxDD by 4.0pp AND verdict Fail. Penalty = 0.10*4.0 +
+    1.0*10.0 = 10.4; score = sharpe - 10.4. *)
+let test_both_maxdd_and_gate_penalties_combine _ =
+  let candidate_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:1.0 ~candidate_maxdd:19.0
+      ~candidate_verdict:(_fail_verdict ()) ()
+  in
+  let baseline_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_baseline_label ~baseline_sharpe:0.5 ~baseline_maxdd:15.0
+      ~candidate_sharpe:0.5 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
+      ~baseline_aggregate:baseline_agg
+  in
+  (* Expected: -loss = -(-1.0 + 0.10*4.0 + 1.0*10.0) = -(9.4) = -9.4 *)
+  assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon (-9.4)))
+
+(* ---------- 14. parameters argument does not affect score ---------- *)
+
+(** Two calls with the same aggregates but different [~parameters] return
+    identical scores. Pins the API contract that parameters are for logging
+    only. *)
+let test_parameters_do_not_affect_score _ =
+  let agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:0.9 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let s1 =
+    Scoring.score_cell
+      ~parameters:[ ("x", 0.0); ("y", 0.0) ]
+      ~candidate_label:_candidate_label ~baseline_label:_baseline_label
+      ~candidate_aggregate:agg ~baseline_aggregate:agg
+  in
+  let s2 =
+    Scoring.score_cell
+      ~parameters:[ ("x", 99.0); ("y", -42.0); ("z", 1.5) ]
+      ~candidate_label:_candidate_label ~baseline_label:_baseline_label
+      ~candidate_aggregate:agg ~baseline_aggregate:agg
+  in
+  match (s1, s2) with
+  | Ok a, Ok b -> assert_that a (float_equal ~epsilon:_epsilon b)
+  | _ -> assert_failure "expected both score_cell calls to succeed"
+
+(* ---------- 15. Hyperparameter constants are pinned ---------- *)
+
+(** CP4 — pin the documented constants. If anyone changes a constant they must
+    also change the test, which is the desired contract. *)
+let test_hyperparameter_constants_pinned _ =
+  assert_that Scoring._lambda_dd (float_equal ~epsilon:_epsilon 0.10);
+  assert_that Scoring._gate_penalty_value (float_equal ~epsilon:_epsilon 10.0);
+  assert_that Scoring._lambda_gate (float_equal ~epsilon:_epsilon 1.0);
+  assert_that Scoring._degenerate_fold_floor_return_pct
+    (float_equal ~epsilon:_epsilon (-50.0))
+
+let suite =
+  "Tuner_bin.Bayesian_runner_scoring"
+  >::: [
+         "identity: candidate==baseline → score = +mean_sharpe"
+         >:: test_identity_candidate_equals_baseline;
+         "MaxDD hinge: improvement → no penalty"
+         >:: test_maxdd_hinge_zero_on_improvement;
+         "MaxDD hinge: Δpp excess → linear penalty"
+         >:: test_maxdd_hinge_linear_on_excess;
+         "gate verdict: Pass vs Fail → score diff = -10.0"
+         >:: test_gate_pass_vs_fail_score_difference;
+         "synthetic Fail (fold-pair mismatch) ≡ regular Fail"
+         >:: test_synthetic_fail_treated_as_regular_fail;
+         "Sharpe improvement strictly raises score"
+         >:: test_sharpe_improvement_increases_score;
+         "missing candidate in stability → Status.NotFound"
+         >:: test_missing_candidate_in_stability_returns_error;
+         "missing candidate in verdicts → Status.NotFound"
+         >:: test_missing_candidate_in_verdicts_returns_error;
+         "missing baseline in baseline_aggregate → Status.NotFound"
+         >:: test_missing_baseline_in_baseline_aggregate_returns_error;
+         "zero-fold aggregate → Status.Invalid_argument"
+         >:: test_zero_fold_aggregate_returns_error;
+         "MaxDD exactly at baseline → zero hinge"
+         >:: test_exactly_at_baseline_maxdd_zero_hinge;
+         "negative-Sharpe candidate → negative score"
+         >:: test_negative_sharpe_candidate_score_negative;
+         "both MaxDD + gate penalties combine additively"
+         >:: test_both_maxdd_and_gate_penalties_combine;
+         "parameters argument does not affect score"
+         >:: test_parameters_do_not_affect_score;
+         "hyperparameter constants pinned"
+         >:: test_hyperparameter_constants_pinned;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

PR-A of the 5-PR Bayesian Phase 3 stack (plan PR #1124 / `dev/plans/bayesian-multi-param-scaling-2026-05-16.md`).

Adds `Tuner_bin.Bayesian_runner_scoring` — the pure scoring function that consumes a candidate cell's walk-forward `aggregate.sexp` plus the Cell E baseline aggregate and returns the BO loop's higher-is-better score.

Loss formula (plan §3.1):

```
loss(cell)  = -mean_sharpe(cell)
            + lambda_dd  * max(0, mean_maxdd(cell) - baseline_maxdd)
            + lambda_gate * gate_penalty(cell)
score(cell) = -loss(cell)
```

Hyperparameters as named constants in the `.mli` (no magic numbers): `_lambda_dd = 0.10`, `_gate_penalty_value = 10.0`, `_lambda_gate = 1.0`, `_degenerate_fold_floor_return_pct = -50.0`.

The function returns `float Status.status_or` so that missing-variant lookups (label not in `aggregate.stability` / `aggregate.verdicts`) and zero-fold aggregates surface as structured errors rather than uncatchable `assert_failure`s.

This PR delivers the function **standalone**. Wiring into `bayesian_runner_evaluator.ml` / `bayesian_runner_runner.ml` is PR-C's scope.

## Out of scope (per plan §7)

- Spec field `holdout_folds` (PR-B).
- Walk-forward in-process executor + evaluator rewrite (PR-C).
- GP length-scale tuning, early-stop, int/Option encoding (PR-D).
- OOS validator + end-to-end smoke (PR-E).
- Sentinel encoding for Option-typed knobs (deferred to PR-D per plan §8).
- Per-fold degenerate-fold exclusion at the scorer's seam — the constant is declared in the `.mli` but applied at the walk-forward harness (the aggregate's pre-computed `sharpe_ratio.mean` is consumed as-is in PR-A; PR-C may revise the boundary).

## Files

| Path | Lines |
|---|---|
| `trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml` (new) | ~85 |
| `trading/trading/backtest/tuner/bin/bayesian_runner_scoring.mli` (new) | ~114 |
| `trading/trading/backtest/tuner/bin/test/test_bayesian_runner_scoring.ml` (new) | ~500 (15 tests) |
| `trading/trading/backtest/tuner/bin/dune` (edit) | +3 lines |
| `trading/trading/backtest/tuner/bin/test/dune` (edit) | +5 lines |
| `dev/status/tuning.md` (edit) | status sync |

Implementation: ~85 LOC; tests: 15 unit tests, ~500 LOC.

## Test plan

- [x] `dune build` clean on the full tree.
- [x] `dune build @fmt` clean.
- [x] `./test_bayesian_runner_scoring.exe` → 15/15 pass in ~130ms.
- [x] Coverage against plan §7 PR-A acceptance:
  - Identity case (candidate == baseline → score = +mean_sharpe).
  - MaxDD hinge zero on improvement.
  - MaxDD hinge linear on Δpp excess (exact arithmetic check).
  - Gate Pass vs Fail score diff = -10.0 exactly.
  - Synthetic Fail (fold-pair count mismatch) ≡ regular Fail.
  - Sharpe improvement strictly raises score.
  - 3 Status.NotFound paths.
  - Status.Invalid_argument on zero-fold aggregate.
  - Boundary case: MaxDD exactly at baseline → zero hinge.
  - Negative-Sharpe candidate → negative score.
  - Combined MaxDD + gate penalties additive.
  - `parameters` argument has no effect on score.
  - Hyperparameter constants pinned (CP4).

Pre-existing SIGILL on `test_grid_search_bin` / `test_bayesian_runner_bin` is unrelated (also fails on `origin/main`; Owl native-code CPU-instruction issue on this runner).

## Authority

Plan §3 (loss formula), §7 PR-A (file list + acceptance), §8 open questions 1 & 4 (answered: baseline aggregate is the Cell E walk-forward run, dynamically read; sentinel encoding deferred to PR-D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)