### PR TITLE
fix(simulator): satisfy nesting linter in portfolio_valuation.compute

### DIFF
--- a/trading/trading/simulation/lib/portfolio_valuation.ml
+++ b/trading/trading/simulation/lib/portfolio_valuation.ml
@@ -74,6 +74,26 @@ let _prices_for_held_positions ~adapter ~date ~portfolio ~today_bars
 let _held_symbols (portfolio : Trading_portfolio.Portfolio.t) : string list =
   List.map portfolio.positions ~f:(fun p -> p.Trading_portfolio.Types.symbol)
 
+(* Unreachable in healthy runs: the four-tier chain in [_resolve_price]
+   guarantees every held position has a price (today's bar, adapter
+   forward-fill, run cache, or avg-cost last-resort). If [portfolio_value]
+   still reports a missing price, the chain's invariant is broken — fail loud
+   with a diagnostic naming the held symbols and the date.
+
+   Prior behaviour silently substituted [portfolio.current_cash] here, which
+   corrupted [equity_curve.csv] (NAV flatlined to cash-only during the gap and
+   silently masked the underlying issue). See
+   memory/project_simulator_nav_fallback_bug.md. *)
+let _fail_loud_on_missing_mark ~date ~portfolio err =
+  failwithf
+    "Portfolio_valuation.compute: price-resolution chain produced no valid \
+     mark for one or more held positions on %s — equity-curve corruption \
+     avoided by failing loud. Held symbols: [%s]. Underlying calculations \
+     error: %s"
+    (Date.to_string date)
+    (String.concat ~sep:"; " (_held_symbols portfolio))
+    (Status.show err) ()
+
 let compute ~adapter ~date ~portfolio ~today_bars ~last_known_prices
     ~valuation_failure_count =
   let prices =
@@ -86,23 +106,4 @@ let compute ~adapter ~date ~portfolio ~today_bars ~last_known_prices
       prices
   with
   | Ok value -> value
-  | Error err ->
-      (* Unreachable in healthy runs: the four-tier chain in
-         [_resolve_price] guarantees every held position has a price
-         (today's bar, adapter forward-fill, run cache, or avg-cost
-         last-resort). If [portfolio_value] still reports a missing
-         price, the chain's invariant is broken — fail loud with a
-         diagnostic naming the held symbols and the date.
-
-         Prior behaviour silently substituted [portfolio.current_cash]
-         here, which corrupted [equity_curve.csv] (NAV flatlined to
-         cash-only during the gap and silently masked the underlying
-         issue). See memory/project_simulator_nav_fallback_bug.md. *)
-      failwithf
-        "Portfolio_valuation.compute: price-resolution chain produced no valid \
-         mark for one or more held positions on %s — equity-curve corruption \
-         avoided by failing loud. Held symbols: [%s]. Underlying calculations \
-         error: %s"
-        (Date.to_string date)
-        (String.concat ~sep:"; " (_held_symbols portfolio))
-        (Status.show err) ()
+  | Error err -> _fail_loud_on_missing_mark ~date ~portfolio err


### PR DESCRIPTION
## Summary

Main CI red since PR #1123. `nesting_linter` reports `compute` in
`trading/simulation/lib/portfolio_valuation.ml:77` at avg 3.03 (limit
3.0) — the inline `Error err -> failwithf "…"` branch with embedded
multi-line context comment pushed it over.

Extract the diagnostic into a top-level `_fail_loud_on_missing_mark`
helper; move the explanatory context comment with it. No behavior
change — same `failwithf` payload, same callers.

## Test plan

- [x] Local nesting linter: `OK — all 2284 functions within limits` (avg 1.45)
- [x] `dune build @fmt --auto-promote` clean
- [x] `dune runtest trading/simulation/test/` green