### PR TITLE
fix(ci): rebuild image with -march=x86-64-v2 + CPU-flag smoke test for #1129

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -64,12 +64,19 @@ RUN sudo apt-get update && sudo apt-get install -y \
 # TA-Lib (Technical Analysis Library)
 # -----------------------------------------------------------------------------
 # Required by ta_ocaml. Not in apt; built from source.
+#
+# CFLAGS: pinned to x86-64-v2 baseline (Nehalem+SSE4.2, ~2009) for portability
+# across the GHA runner pool. Without this, the compiler defaults to the build
+# host's native CPU flags (e.g. AVX-512 on the image-build runner), producing
+# a libta-lib.so that triggers SIGILL on runners without those instructions.
+# x86-64-v2 is supported by all modern GHA ubuntu-latest runners.
+# See issue #1129.
 # -----------------------------------------------------------------------------
 RUN cd /tmp && \
     curl -L https://github.com/ta-lib/ta-lib/releases/download/v0.6.4/ta-lib-0.6.4-src.tar.gz -o ta-lib.tar.gz && \
     tar xzf ta-lib.tar.gz && \
     cd ta-lib-0.6.4 && \
-    ./configure --prefix=/usr && \
+    ./configure --prefix=/usr CFLAGS="-O2 -mtune=generic -march=x86-64-v2" && \
     make -j$(nproc) && \
     sudo make install && \
     cd / && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,33 @@ jobs:
           path: trading/_build
           key: dune-${{ runner.os }}-${{ hashFiles('trading/**/*.opam', 'trading/**/dune', 'trading/**/dune-project', 'trading/**/*.ml', 'trading/**/*.mli') }}
 
+      # Smoke-test: print CPU flags and verify ta-lib loads without SIGILL.
+      # When this failure recurs, the log will show the CPU flag set and the
+      # exact exit code (132 = SIGILL) at the top of the job rather than
+      # buried mid-suite. Runs before dune build so failures are immediately
+      # visible. See issue #1129.
+      - name: CPU-flag + ta-lib smoke test
+        run: |
+          echo "=== CPU flags ==="
+          grep '^flags' /proc/cpuinfo | head -1
+          echo "=== ta-lib linkage ==="
+          # Find libta-lib.so and verify it contains no AVX-512 instructions.
+          # AVX-512 instructions (zmm registers, evex prefix, KNC) cause SIGILL
+          # on GHA runners that don't support AVX-512 (most ubuntu-latest hosts).
+          TA_LIB_SO=$(ldconfig -p | grep 'libta-lib' | awk '{print $NF}' | head -1)
+          if [ -z "$TA_LIB_SO" ]; then
+            echo "WARNING: libta-lib.so not found via ldconfig — may not be installed yet"
+          else
+            echo "libta-lib.so found at: $TA_LIB_SO"
+            echo "=== Verifying libta-lib.so ISA (objdump check) ==="
+            if objdump -d "$TA_LIB_SO" 2>/dev/null | grep -q 'zmm\|evex\|knc'; then
+              echo "FAIL: libta-lib.so contains AVX-512 instructions — will SIGILL on non-AVX512 runners"
+              exit 1
+            else
+              echo "OK: libta-lib.so contains no AVX-512 instructions"
+            fi
+          fi
+
       - name: dune build
         run: |
           eval $(opam env)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,15 @@ jobs:
           # Find libta-lib.so and verify it contains no AVX-512 instructions.
           # AVX-512 instructions (zmm registers, evex prefix, KNC) cause SIGILL
           # on GHA runners that don't support AVX-512 (most ubuntu-latest hosts).
-          # awk's no-match exit code is 0 (unlike grep's 1), so this survives
-          # `set -eo pipefail` when libta-lib is absent — the case we want to
-          # report as a WARNING below, not silently abort.
-          TA_LIB_SO=$(ldconfig -p | awk '/libta-lib/ {print $NF; exit}')
+          #
+          # We scan the filesystem rather than `ldconfig -p` because TA-Lib is
+          # built from source and installs into /usr/lib (not the ubuntu
+          # /usr/lib/x86_64-linux-gnu/ path that ldconfig auto-scans), so
+          # `ldconfig -p` silently misses it. `find` returns exit 0 on no
+          # match so `set -eo pipefail` doesn't kill the step.
+          TA_LIB_SO=$(find /usr/lib /usr/local/lib -maxdepth 3 -name 'libta-lib.so*' -type f 2>/dev/null | head -1)
           if [ -z "$TA_LIB_SO" ]; then
-            echo "WARNING: libta-lib.so not found via ldconfig — may not be installed yet"
+            echo "WARNING: libta-lib.so not found under /usr/lib or /usr/local/lib — may not be installed yet"
           else
             echo "libta-lib.so found at: $TA_LIB_SO"
             echo "=== Verifying libta-lib.so ISA (objdump check) ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,10 @@ jobs:
           # Find libta-lib.so and verify it contains no AVX-512 instructions.
           # AVX-512 instructions (zmm registers, evex prefix, KNC) cause SIGILL
           # on GHA runners that don't support AVX-512 (most ubuntu-latest hosts).
-          TA_LIB_SO=$(ldconfig -p | grep 'libta-lib' | awk '{print $NF}' | head -1)
+          # awk's no-match exit code is 0 (unlike grep's 1), so this survives
+          # `set -eo pipefail` when libta-lib is absent — the case we want to
+          # report as a WARNING below, not silently abort.
+          TA_LIB_SO=$(ldconfig -p | awk '/libta-lib/ {print $NF; exit}')
           if [ -z "$TA_LIB_SO" ]; then
             echo "WARNING: libta-lib.so not found via ldconfig — may not be installed yet"
           else


### PR DESCRIPTION
## Summary

- Fixes the `Command got signal ILL` (SIGILL) CI failures that began 2026-05-15 22:11Z, tracked in issue #1129
- Patches `.devcontainer/Dockerfile` to pin TA-Lib's build flags to `x86-64-v2` (Nehalem+SSE4.2, ~2009), the canonical portable x86_64 baseline guaranteed on all GHA ubuntu-latest runners
- Adds a pre-build smoke step to `.github/workflows/ci.yml` that detects AVX-512 instructions in the installed `libta-lib.so` and fails loudly before any test runs

## Why this works

Without explicit `CFLAGS`, the C compiler defaults to the build host's native instruction set. The GHA runner that builds the `ghcr.io/dayfine/trading-ci:latest` image likely has AVX-512 support (newer Skylake-SP / Ice Lake server CPUs), so `libta-lib.so` was compiled with `zmm`/`evex` instructions. When the image is then *used* by CI test runners (which may be different physical hosts without AVX-512), every executable that `dlopen`s `libta-lib.so` hits an illegal instruction trap on the first AVX-512 opcode.

Pinning to `CFLAGS="-O2 -mtune=generic -march=x86-64-v2"` compiles TA-Lib against SSE4.2 at most, which every modern x86_64 GHA runner supports.

## Test plan

- [ ] Image rebuild workflow (`image.yml`) triggers automatically on merge to main because `.devcontainer/Dockerfile` is in its path filter
- [ ] After the image rebuild completes (~5-10 min), the next CI run on main should pass the new smoke step with `OK: libta-lib.so contains no AVX-512 instructions`
- [ ] `dune runtest` passes on all previously-failing `ta_ocaml`-linked tests
- [ ] If SIGILL recurs in the future, the smoke step at the top of the job log will show the exact CPU flags and fail with a clear `FAIL: libta-lib.so contains AVX-512 instructions` message rather than `Command got signal ILL` buried mid-suite

## Files touched

- `.devcontainer/Dockerfile` — added `CFLAGS="-O2 -mtune=generic -march=x86-64-v2"` to `./configure` invocation for TA-Lib, with explanatory comment citing issue #1129
- `.github/workflows/ci.yml` — added `CPU-flag + ta-lib smoke test` step before `dune build`, printing `/proc/cpuinfo` flags and running `objdump` on the installed `libta-lib.so` to detect AVX-512 instructions