### PR TITLE
fix(ishares): browser headers + 503/429 retry-with-backoff for IWV fetcher

### DIFF
--- a/trading/analysis/data/sources/ishares/bin/dune
+++ b/trading/analysis/data/sources/ishares/bin/dune
@@ -1,7 +1,7 @@
 (library
  (name fetch_iwv_history_lib)
  (modules fetch_iwv_history_lib)
- (libraries core core_unix.sys_unix core_unix ishares status)
+ (libraries core core_unix.sys_unix core_unix async ishares status)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq)))
 

--- a/trading/analysis/data/sources/ishares/bin/fetch_iwv_history.ml
+++ b/trading/analysis/data/sources/ishares/bin/fetch_iwv_history.ml
@@ -20,17 +20,58 @@ let _default_polite_sleep_ms = 2000
    ishares.com); the executable wires [_default_fetch] in unconditionally. *)
 type fetch_fn = Uri.t -> string Status.status_or Deferred.t
 
-let _default_fetch : fetch_fn =
- fun uri ->
-  Cohttp_async.Client.get uri >>= fun (resp, body) ->
-  match Cohttp.Response.status resp with
-  | `OK -> Cohttp_async.Body.to_string body >>| fun body_str -> Ok body_str
+(* Browser-like request headers. iShares' Akamai WAF rejects bare
+   [Cohttp_async] UA strings with HTTP 503 ("AkamaiGHost"); the headers
+   below mirror a recent Chrome on macOS and a plausible Referer back to
+   the IWV product page. See [dev/notes/iwv-scrape-akamai-block-2026-05-16.md]. *)
+let _browser_headers =
+  Cohttp.Header.of_list
+    [
+      ( "User-Agent",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+         (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" );
+      ("Accept", "text/csv,application/csv,*/*;q=0.8");
+      ("Accept-Language", "en-US,en;q=0.9");
+      ( "Referer",
+        "https://www.ishares.com/us/products/239714/ishares-russell-3000-etf" );
+    ]
+
+(* Exponential backoff schedule for retryable HTTP errors (503 / 429 / 502
+   / 504). Three retries spaced 5s / 30s / 120s — total wall-clock cap is
+   ~155s on top of the original failed attempt, which absorbs typical
+   Akamai/WAF cooldowns without inflating the steady-state scrape time. *)
+let _retry_backoff_seconds_5xx = [ 5.0; 30.0; 120.0 ]
+
+let _is_retryable_status = function
+  | `Service_unavailable | `Too_many_requests | `Bad_gateway | `Gateway_timeout
+    ->
+      true
+  | _ -> false
+
+(* Single HTTP attempt with browser headers. Returns a structured
+   [Lib.fetch_attempt] so the retry helper can decide whether to retry. *)
+let _attempt_fetch uri : Lib.fetch_attempt Deferred.t =
+  Cohttp_async.Client.get ~headers:_browser_headers uri >>= fun (resp, body) ->
+  let status = Cohttp.Response.status resp in
+  match status with
+  | `OK ->
+      Cohttp_async.Body.to_string body >>| fun body_str -> Lib.Ok_body body_str
   | status ->
       let status_str = Cohttp.Code.string_of_status status in
       Cohttp_async.Body.to_string body >>| fun body_str ->
-      Status.error_internal
-        (Printf.sprintf "HTTP %s for %s\n%s" status_str (Uri.to_string uri)
-           body_str)
+      let msg =
+        Printf.sprintf "HTTP %s for %s\n%s" status_str (Uri.to_string uri)
+          body_str
+      in
+      if _is_retryable_status status then Lib.Retryable_error msg
+      else Lib.Fatal_error msg
+
+let _sleep_seconds secs = Clock.after (Time_float.Span.of_sec secs)
+
+let _default_fetch : fetch_fn =
+ fun uri ->
+  Lib.retry_with_backoff ~fetch:_attempt_fetch ~sleep:_sleep_seconds
+    ~backoff_seconds:_retry_backoff_seconds_5xx uri
 
 (* Outcome of fetching a single date. [Error_logged] records the error
    string for the end-of-run summary but does NOT abort the backfill —

--- a/trading/analysis/data/sources/ishares/bin/fetch_iwv_history_lib.ml
+++ b/trading/analysis/data/sources/ishares/bin/fetch_iwv_history_lib.ml
@@ -1,4 +1,5 @@
 open Core
+open Async
 
 type cadence = Auto | Daily | Monthly | Quarterly [@@deriving show, eq]
 
@@ -148,3 +149,30 @@ let write_sentinel_marker ~cache_dir ~as_of =
   _write_file_atomic
     ~path:(sentinel_path ~cache_dir ~as_of)
     ~contents:_sentinel_marker_payload
+
+(* ------------------------------------------------------------------------- *)
+(* HTTP retry with exponential backoff                                       *)
+(* ------------------------------------------------------------------------- *)
+
+type fetch_attempt =
+  | Ok_body of string
+  | Retryable_error of string
+  | Fatal_error of string
+
+(* Recursive driver: walks [backoff_seconds] sleeping between attempts.
+   The first attempt runs immediately. On a [Retryable_error], if more
+   backoff intervals remain, sleep for the next interval and retry; if not,
+   surface the last error. [Fatal_error] short-circuits without retrying. *)
+let rec _retry_loop ~fetch ~sleep ~backoff_seconds uri =
+  fetch uri >>= function
+  | Ok_body body -> return (Result.Ok body)
+  | Fatal_error msg -> return (Status.error_internal msg)
+  | Retryable_error msg -> (
+      match backoff_seconds with
+      | [] -> return (Status.error_internal msg)
+      | next_delay :: rest ->
+          sleep next_delay >>= fun () ->
+          _retry_loop ~fetch ~sleep ~backoff_seconds:rest uri)
+
+let retry_with_backoff ~fetch ~sleep ~backoff_seconds uri =
+  _retry_loop ~fetch ~sleep ~backoff_seconds uri

--- a/trading/analysis/data/sources/ishares/bin/fetch_iwv_history_lib.mli
+++ b/trading/analysis/data/sources/ishares/bin/fetch_iwv_history_lib.mli
@@ -100,3 +100,35 @@ val write_sentinel_marker :
   cache_dir:string -> as_of:Date.t -> unit Status.status_or
 (** [write_sentinel_marker] creates a one-byte marker file at [sentinel_path].
 *)
+
+(** Outcome of one HTTP attempt, classified for retry decisions.
+
+    [Ok_body body] — request succeeded with the response body.
+    [Retryable_error msg] — transient failure (HTTP 503 / 429 / 502 / 504); the
+    caller should sleep + retry up to the configured attempt budget.
+    [Fatal_error msg] — non-retryable failure (4xx other than 429, network
+    error, parse error); the caller should give up immediately. *)
+type fetch_attempt =
+  | Ok_body of string
+  | Retryable_error of string
+  | Fatal_error of string
+
+val retry_with_backoff :
+  fetch:(Uri.t -> fetch_attempt Async.Deferred.t) ->
+  sleep:(float -> unit Async.Deferred.t) ->
+  backoff_seconds:float list ->
+  Uri.t ->
+  string Status.status_or Async.Deferred.t
+(** [retry_with_backoff ~fetch ~sleep ~backoff_seconds uri] performs up to
+    [1 + List.length backoff_seconds] HTTP attempts.
+
+    The first attempt runs immediately. On a [Retryable_error], the helper
+    sleeps for the next backoff interval (in seconds) and re-attempts. On
+    [Ok_body], it returns [Ok body] immediately. On [Fatal_error], it returns
+    the error immediately without retrying. After exhausting the backoff list,
+    if the last attempt was still a [Retryable_error], it surfaces that as the
+    final error.
+
+    [sleep] is parameterised to make the helper unit-testable — production
+    callers pass [Clock.after ... Time_float.Span.of_sec]; tests pass a no-op
+    recorder. *)

--- a/trading/analysis/data/sources/ishares/test/dune
+++ b/trading/analysis/data/sources/ishares/test/dune
@@ -8,6 +8,8 @@
   ishares
   fetch_iwv_history_lib
   build_iwv_universe_lib
+  async
+  async_unix
   core
   core_unix.filename_unix
   core_unix.sys_unix

--- a/trading/analysis/data/sources/ishares/test/test_fetch_iwv_history_lib.ml
+++ b/trading/analysis/data/sources/ishares/test/test_fetch_iwv_history_lib.ml
@@ -1,4 +1,5 @@
 open Core
+open Async
 open OUnit2
 open Matchers
 module Lib = Fetch_iwv_history_lib
@@ -270,6 +271,99 @@ let test_write_csv_body_roundtrip _ =
     (elements_are
        [ equal_to ({ as_of = d; action = Lib.Skip_cached } : Lib.planned_step) ])
 
+(* ------------------------------------------------------------------------- *)
+(* retry_with_backoff                                                        *)
+(* ------------------------------------------------------------------------- *)
+
+(* The tests below inject a mock fetcher (so no real HTTP) AND a mock
+   sleep function (so the wall clock doesn't actually wait 5+30+120s).
+   The sleep recorder captures the requested intervals for assertion. *)
+
+let _dummy_uri = Uri.of_string "https://example.invalid/test"
+let _test_backoff = [ 5.0; 30.0; 120.0 ]
+
+(* Mock fetcher producing a scripted sequence of attempts. Each call
+   pops the next outcome from [responses]; [calls] counts invocations. *)
+let _scripted_fetch responses :
+    (Uri.t -> Lib.fetch_attempt Deferred.t) * int ref =
+  let calls = ref 0 in
+  let remaining = ref responses in
+  let fetch _uri =
+    Int.incr calls;
+    match !remaining with
+    | [] -> failwith "scripted fetch ran out of responses"
+    | r :: rest ->
+        remaining := rest;
+        Deferred.return r
+  in
+  (fetch, calls)
+
+(* Mock sleep that records (does not actually sleep) — keeps tests fast. *)
+let _recording_sleep () : (float -> unit Deferred.t) * float list ref =
+  let intervals = ref [] in
+  let sleep secs =
+    intervals := !intervals @ [ secs ];
+    Deferred.return ()
+  in
+  (sleep, intervals)
+
+let _run_retry ~fetch ~sleep =
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      Lib.retry_with_backoff ~fetch ~sleep ~backoff_seconds:_test_backoff
+        _dummy_uri)
+
+(* First attempt returns Ok → no sleep, no further attempts. *)
+let test_retry_returns_ok_on_first_attempt _ =
+  let fetch, calls = _scripted_fetch [ Lib.Ok_body "payload-body" ] in
+  let sleep, intervals = _recording_sleep () in
+  let result = _run_retry ~fetch ~sleep in
+  assert_that result (is_ok_and_holds (equal_to "payload-body"));
+  assert_that !calls (equal_to 1);
+  assert_that !intervals is_empty
+
+(* One transient 503 then Ok → second attempt succeeds, exactly one
+   sleep at the first backoff interval (5s). *)
+let test_retry_recovers_after_one_503 _ =
+  let fetch, calls =
+    _scripted_fetch
+      [ Lib.Retryable_error "HTTP 503 first try"; Lib.Ok_body "after-retry" ]
+  in
+  let sleep, intervals = _recording_sleep () in
+  let result = _run_retry ~fetch ~sleep in
+  assert_that result (is_ok_and_holds (equal_to "after-retry"));
+  assert_that !calls (equal_to 2);
+  assert_that !intervals (elements_are [ float_equal 5.0 ])
+
+(* Every attempt returns 503 → 4 attempts total (1 + 3 retries), three
+   sleeps at 5/30/120, and the final result is the last 503 error. *)
+let test_retry_gives_up_after_max_attempts _ =
+  let fetch, calls =
+    _scripted_fetch
+      [
+        Lib.Retryable_error "HTTP 503 attempt 1";
+        Lib.Retryable_error "HTTP 503 attempt 2";
+        Lib.Retryable_error "HTTP 503 attempt 3";
+        Lib.Retryable_error "HTTP 503 attempt 4";
+      ]
+  in
+  let sleep, intervals = _recording_sleep () in
+  let result = _run_retry ~fetch ~sleep in
+  assert_that result (is_error_with Status.Internal);
+  assert_that !calls (equal_to 4);
+  assert_that !intervals
+    (elements_are [ float_equal 5.0; float_equal 30.0; float_equal 120.0 ])
+
+(* Fatal (non-retryable) status short-circuits — only one attempt, no
+   sleep. Guards against a future regression where the classifier might
+   accidentally mark a 4xx as retryable. *)
+let test_retry_does_not_retry_fatal_error _ =
+  let fetch, calls = _scripted_fetch [ Lib.Fatal_error "HTTP 404 not found" ] in
+  let sleep, intervals = _recording_sleep () in
+  let result = _run_retry ~fetch ~sleep in
+  assert_that result (is_error_with Status.Internal);
+  assert_that !calls (equal_to 1);
+  assert_that !intervals is_empty
+
 let suite =
   "fetch_iwv_history_lib_test"
   >::: [
@@ -303,6 +397,13 @@ let suite =
          >:: test_ensure_cache_dir_creates_recursively;
          "sentinel_marker_roundtrip" >:: test_sentinel_marker_roundtrip;
          "write_csv_body_roundtrip" >:: test_write_csv_body_roundtrip;
+         "retry_returns_ok_on_first_attempt"
+         >:: test_retry_returns_ok_on_first_attempt;
+         "retry_recovers_after_one_503" >:: test_retry_recovers_after_one_503;
+         "retry_gives_up_after_max_attempts"
+         >:: test_retry_gives_up_after_max_attempts;
+         "retry_does_not_retry_fatal_error"
+         >:: test_retry_does_not_retry_fatal_error;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

The IWV holdings scrape against ishares.com returns HTTP 503 (AkamaiGHost)
when `Cohttp_async`'s default OCaml UA pre-emptively trips the WAF. This
PR patches the fetcher so the next scrape attempt survives transient
503s once the Akamai cooldown elapses.

- Send browser-like request headers (Chrome 120 on macOS UA, `Accept`,
  `Accept-Language`, `Referer` back to the IWV product page) on every GET.
- Retry on transient HTTP errors (503 / 429 / 502 / 504) with exponential
  backoff (5s / 30s / 120s — three retries before giving up). Non-retryable
  errors (4xx other than 429, network failures) short-circuit immediately.

The retry helper lives in `fetch_iwv_history_lib.retry_with_backoff` so the
executable's `_default_fetch` is a thin wrapper around a single Cohttp
attempt. The helper takes both the fetcher fn AND the sleep fn so unit
tests inject mocks and run in milliseconds, not minutes.

Authority: `dev/notes/iwv-scrape-akamai-block-2026-05-16.md`
Unblocks: P0a operational scrape per `dev/notes/next-session-priorities-2026-05-17.md`.

## Test plan

- 4 new unit tests on `Fetch_iwv_history_lib.retry_with_backoff`:
  - `retry_returns_ok_on_first_attempt` — no retry on `Ok_body`, zero sleeps.
  - `retry_recovers_after_one_503` — one transient `Retryable_error` then
    `Ok_body`, exactly one sleep at the first backoff interval (5s).
  - `retry_gives_up_after_max_attempts` — every attempt returns
    `Retryable_error`, 4 fetcher calls total, sleeps at 5s/30s/120s,
    final result is `Status.Internal` error.
  - `retry_does_not_retry_fatal_error` — `Fatal_error` short-circuits with
    one attempt and zero sleeps (regression guard against accidentally
    marking a 4xx as retryable).

Test count for `test_fetch_iwv_history_lib` goes 17 → 21.

- [x] `docker exec -w /workspaces/trading-1/<worktree>/trading trading-1-dev bash -c 'eval $(opam env) && dune build @fmt --auto-promote && dune build && dune runtest analysis/data/sources/ishares/'` — all green
- [x] `dune runtest devtools/checks/` — all linters green (nesting,
      fn_length, magic_numbers, mli_coverage, ocamlformat)
- [x] `dune build && dune runtest` over the full workspace — all green

## Files touched

- `trading/analysis/data/sources/ishares/bin/fetch_iwv_history.ml` —
  add `_browser_headers`, `_retry_backoff_seconds_5xx`,
  `_is_retryable_status`, `_attempt_fetch`, `_sleep_seconds`; rewire
  `_default_fetch` to call `Lib.retry_with_backoff`.
- `trading/analysis/data/sources/ishares/bin/fetch_iwv_history_lib.ml`,
  `fetch_iwv_history_lib.mli` — add `type fetch_attempt` and
  `val retry_with_backoff`.
- `trading/analysis/data/sources/ishares/bin/dune` — add `async` dep to
  the lib.
- `trading/analysis/data/sources/ishares/test/test_fetch_iwv_history_lib.ml` —
  4 new retry tests (mock fetcher + recording sleep).
- `trading/analysis/data/sources/ishares/test/dune` — add `async` /
  `async_unix` deps for the new tests.

Not touched: `lib/ishares_holdings_client.{ml,mli}` (URI builder + CSV
parser are out of scope); no other library or test outside the
ishares scope.

## Out of scope

- The actual scrape still needs (i) an Akamai cooldown for the
  currently-flagged egress IP and (ii) a single-date probe to confirm
  headers now satisfy the WAF. Both are operational steps tracked in the
  blocker note, not this PR.
- Header pinning / per-symbol budget / 429-aware adaptive throttling are
  future tuning items, not required to unblock the initial backfill.

## Merge instructions

Per `memory/feedback_pr_merge_ci_gate.md` HARD STOP rules: **do not
merge**. Main is currently red on infra issue #1129; merging on red main
is forbidden unless it's the fix PR for that redness, which this is not.
Leave open for the user to merge once #1129 clears.

