### PR TITLE
feat(tuning): Bayesian Phase 3 PR-B — knob inventory + parameter space encoding

### DIFF
--- a/trading/test_data/tuner/bayesian-multi-param-2026-05-16.sexp
+++ b/trading/test_data/tuner/bayesian-multi-param-2026-05-16.sexp
@@ -1,0 +1,77 @@
+;; Phase-3 Bayesian-optimisation spec — 11-knob multi-parameter scaling
+;; per dev/plans/bayesian-multi-param-scaling-2026-05-16.md (PR-B).
+;;
+;; Knob curation: §2.1 of the plan enumerates an 18-knob surface
+;; (Tracks A/B/C/D/E); PR-B drops Track C (stage classifier, mostly
+;; near-fixed per memory/project_m5-5-tuning-exhausted.md) and further
+;; trims Tracks A/B/D/E to 11 high-confidence dimensions to stay under
+;; the in-house GP's "≤10 dimensions" effective ceiling (per
+;; Tuner.Bayesian_opt.mli + plan §5.2). The Option-typed knobs from
+;; §2.5 (e.g. max_sector_exposure_pct, min_score_override) and binary
+;; feature flags (§Track D) are deferred to PR-D.
+;;
+;; Final 11-knob breakdown:
+;;   Track A — entry / stop geometry (4)
+;;     initial_stop_buffer                  (top-level, §2.1 known sensitive)
+;;     candidate_params.initial_stop_pct    (§2.1 known sensitive)
+;;     candidate_params.installed_stop_min_pct (§2.1 axis-1 winner @ 0.08)
+;;     candidate_params.entry_buffer_pct    (§2.1 plausible)
+;;   Track B — sizing / exposure (3)
+;;     max_position_pct_long                (§2.1 known sensitive — PR #855)
+;;     max_long_exposure_pct                (§2.1 known sensitive)
+;;     risk_per_trade_pct                   (§2.1 plausible)
+;;   Track D — Cell E mechanics (2)
+;;     stage3_force_exit_config.hysteresis_weeks  (§2.1 known sensitive — Cell E h=1)
+;;     laggard_rotation_config.hysteresis_weeks   (§2.1 known sensitive — Cell E h=2)
+;;   Track E — screening cascade (2)
+;;     screening_config.weights.w_positive_rs   (int — rounded by cell_to_overrides)
+;;     screening_config.weights.w_strong_volume (int — rounded by cell_to_overrides)
+;;
+;; Budget arithmetic (plan §5.1): each BO iteration = one
+;; walk-forward run = 30 folds; per-fold ≈ 30s wall ⇒ ≈15 min per
+;; iteration. total_budget=100 ⇒ ≈25 hours; aligns with the
+;; priorities doc's "50-150 hour" cadence at 100-300 iterations.
+;;
+;; initial_random=25 ≈ 2.3× knob count (plan §5.3 suggests 10× ideal
+;; but trims aggressively to leave compute headroom for GP-driven
+;; phase). seed=2026 is the year — reproducible without colliding
+;; with any other pinned seed in the harness.
+;;
+;; The scenarios list is empty here because Phase 3's evaluator runs
+;; the walk-forward harness (PR-C) instead of per-scenario backtests;
+;; the field is retained for backward compatibility with the parser
+;; (PR-B does not modify Bayesian_runner_evaluator). The empty list
+;; will become a single placeholder scenario in PR-C once the
+;; walk-forward-in-process integration lands.
+;;
+;; holdout_folds: (27 28 29 30) — last 4 folds of the 30-fold
+;; cell_e_30fold_2026_05_16 spec (~13% holdout per plan §6.2).
+;; PR-B only PINS the parsed shape; PR-C will thread the list into
+;; the walk-forward executor's fold filter; PR-E will re-run the
+;; best cell on these folds as OOS validation.
+((bounds
+  (;; Track A — entry / stop geometry
+   ("initial_stop_buffer" (0.5 2.0))
+   ("screening_config.candidate_params.initial_stop_pct" (0.04 0.15))
+   ("screening_config.candidate_params.installed_stop_min_pct" (0.0 0.12))
+   ("screening_config.candidate_params.entry_buffer_pct" (0.0 0.02))
+   ;; Track B — sizing / exposure
+   ("portfolio_config.max_position_pct_long" (0.05 0.25))
+   ("portfolio_config.max_long_exposure_pct" (0.50 0.95))
+   ("portfolio_config.risk_per_trade_pct" (0.005 0.03))
+   ;; Track D — Cell E mechanics (int knobs, rounded at evaluator
+   ;; boundary; plan §2.5 — grid_search.mli:56-65 already encodes
+   ;; integer-valued floats correctly)
+   ("stage3_force_exit_config.hysteresis_weeks" (1.0 5.0))
+   ("laggard_rotation_config.hysteresis_weeks" (1.0 8.0))
+   ;; Track E — screening cascade weights (int)
+   ("screening_config.weights.w_positive_rs" (5.0 40.0))
+   ("screening_config.weights.w_strong_volume" (5.0 40.0))))
+ (acquisition Expected_improvement)
+ (initial_random 25)
+ (total_budget 100)
+ (seed (2026))
+ (n_acquisition_candidates ())
+ (objective Sharpe)
+ (scenarios ())
+ (holdout_folds (27 28 29 30)))

--- a/trading/test_data/walk_forward/cell_e_30fold_2026_05_16.sexp
+++ b/trading/test_data/walk_forward/cell_e_30fold_2026_05_16.sexp
@@ -41,4 +41,11 @@
  ;; fold worse by >0.30 Sharpe. We're gating on cell-A vs cell-E
  ;; (cell-E is baseline), so a PASS would mean cell-E feature
  ;; bundle is NOT a net win — signal worth investigating.
- (gate ((metric Sharpe) (m 17) (n 30) (worst_delta 0.30))))
+ (gate ((metric Sharpe) (m 17) (n 30) (worst_delta 0.30)))
+ ;; Phase 3 BO holdout: the last 4 folds (1-indexed 27-30, covering
+ ;; ~2024-04 to 2026-04 by anchor stride) are reserved as
+ ;; out-of-sample validation for the Bayesian tuner per plan §6.2.
+ ;; The walk-forward runner ignores this field
+ ;; ([\@\@sexp.allow_extra_fields] on Spec.t); the BO scorer consumes
+ ;; it via the Phase-3 Bayesian_runner_spec.
+ (holdout_folds (27 28 29 30)))

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_spec.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_spec.ml
@@ -21,6 +21,7 @@ type t = {
   n_acquisition_candidates : int option;
   objective : objective_spec;
   scenarios : string list;
+  holdout_folds : int list option; [@sexp.option]
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]
 

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_spec.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_spec.mli
@@ -59,6 +59,15 @@ type t = {
       (** Paths to scenario sexp files, resolved relative to the current working
           directory and loaded via {!Scenario_lib.Scenario.load} when the binary
           runs the evaluator. *)
+  holdout_folds : int list option;
+      (** Phase-3 walk-forward holdout (PR-B). When [Some [k1; ...; kn]], the
+          listed 1-indexed fold positions are reserved as out-of-sample
+          validation and excluded from BO scoring per plan §6.2 of
+          [dev/plans/bayesian-multi-param-scaling-2026-05-16.md]. When [None]
+          (or omitted from the sexp), the BO uses every fold as in-sample. PR-B
+          only pins the parsed shape; PR-C will thread the list through the
+          walk-forward executor's fold filter, and PR-E will re-run the best
+          cell on the held-out folds. *)
 }
 [@@deriving sexp]
 (** A Bayesian-optimisation spec on disk. Example sexp:
@@ -71,7 +80,11 @@ type t = {
       (n_acquisition_candidates ())
       (objective Sharpe)
       (scenarios "trading/test_data/backtest_scenarios/smoke/bull-2019.sexp")
-    ]} *)
+      (holdout_folds (27 28 29 30))
+    ]}
+    The [holdout_folds] tag is optional ([\@sexp.option]): omit it entirely for
+    [None]; write [(holdout_folds (k1 ... kn))] for [Some [k1; ...; kn]]; write
+    [(holdout_folds ())] for [Some []]. *)
 
 val load : string -> t
 (** Load and parse a spec sexp file. Raises [Failure] on malformed input. *)

--- a/trading/trading/backtest/tuner/bin/test/dune
+++ b/trading/trading/backtest/tuner/bin/test/dune
@@ -10,4 +10,6 @@
   tuner_bin
   trading.simulation.types)
  (preprocess
-  (pps ppx_sexp_conv)))
+  (pps ppx_sexp_conv))
+ (deps
+  (glob_files_rec %{workspace_root}/test_data/tuner/*.sexp)))

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
@@ -86,7 +86,10 @@ let test_load_simple_spec_parses _ =
       assert_that spec.initial_random (equal_to 5);
       assert_that spec.total_budget (equal_to 30);
       assert_that spec.seed (is_some_and (equal_to 17));
-      assert_that spec.n_acquisition_candidates is_none)
+      assert_that spec.n_acquisition_candidates is_none;
+      (* The simple fixture omits [holdout_folds]; [@sexp.option] parses
+         the absence as [None]. *)
+      assert_that spec.holdout_folds is_none)
 
 let _ucb_spec_text =
   String.concat
@@ -166,6 +169,7 @@ let test_to_bo_config_propagates_fields _ =
       n_acquisition_candidates = None;
       objective = Spec.Sharpe;
       scenarios = [ "s" ];
+      holdout_folds = None;
     }
   in
   let config = Spec.to_bo_config spec in
@@ -198,6 +202,7 @@ let _parabola_spec ~total_budget ~seed : Spec.t =
     n_acquisition_candidates = None;
     objective = Spec.Sharpe;
     scenarios = [ "stub-scenario" ];
+    holdout_folds = None;
   }
 
 let test_run_and_write_emits_three_artefacts _ =
@@ -281,6 +286,173 @@ let test_evaluator_unknown_scenario_raises _ =
   in
   assert_that raised (equal_to true)
 
+(* ---------- holdout_folds field (PR-B) ---------- *)
+
+(** PR-B: pin the parsed shape of the optional [holdout_folds] field. The field
+    uses [\@sexp.option] so absence in the sexp parses as [None]; presence
+    parses as [Some [..]] (including the empty-list edge case). PR-C will thread
+    the list into the walk-forward executor; PR-B is shape-only. *)
+
+let _spec_with_holdout_text holdout_clause =
+  String.concat
+    [
+      "((bounds (";
+      "  (initial_stop_buffer (0.5 2.0))))";
+      " (acquisition Expected_improvement)";
+      " (initial_random 5)";
+      " (total_budget 30)";
+      " (seed (7))";
+      " (n_acquisition_candidates ())";
+      " (objective Sharpe)";
+      " (scenarios ())";
+      " ";
+      holdout_clause;
+      ")";
+    ]
+    ~sep:"\n"
+
+let test_holdout_folds_present_parses_to_some _ =
+  _with_temp_dir (fun dir ->
+      let path =
+        _write_spec_file dir
+          (_spec_with_holdout_text "(holdout_folds (27 28 29 30))")
+      in
+      let spec = Spec.load path in
+      assert_that spec.holdout_folds
+        (is_some_and
+           (elements_are [ equal_to 27; equal_to 28; equal_to 29; equal_to 30 ])))
+
+let test_holdout_folds_empty_list_parses_to_some_empty _ =
+  (* Edge case: a present-but-empty list is distinct from an omitted field
+     under [\@sexp.option]: [(holdout_folds ())] parses to [Some []], while
+     omission parses to [None]. Pinning both keeps PR-C honest when it adds
+     a fold filter — an empty list should mean "explicitly no holdouts",
+     not "default to all folds in-sample". *)
+  _with_temp_dir (fun dir ->
+      let path =
+        _write_spec_file dir (_spec_with_holdout_text "(holdout_folds ())")
+      in
+      let spec = Spec.load path in
+      assert_that spec.holdout_folds (is_some_and (size_is 0)))
+
+let test_holdout_folds_omitted_parses_to_none _ =
+  (* Already covered by [test_load_simple_spec_parses]; re-pin here as the
+     primary holdout-folds contract so the file's intent is greppable. *)
+  _with_temp_dir (fun dir ->
+      let path = _write_spec_file dir _spec_text in
+      let spec = Spec.load path in
+      assert_that spec.holdout_folds is_none)
+
+let _spec_record_with_holdout holdout : Spec.t =
+  {
+    bounds = [ ("initial_stop_buffer", (0.5, 2.0)) ];
+    acquisition = Spec.Expected_improvement;
+    initial_random = 5;
+    total_budget = 30;
+    seed = Some 7;
+    n_acquisition_candidates = None;
+    objective = Spec.Sharpe;
+    scenarios = [];
+    holdout_folds = holdout;
+  }
+
+let test_holdout_folds_round_trip_none _ =
+  (* Round-trip: [t -> sexp -> t] preserves [holdout_folds = None]. With
+     [\@sexp.option], the serialised sexp omits the field entirely, and
+     re-parsing yields [None] (not e.g. [Some []]). *)
+  let original = _spec_record_with_holdout None in
+  let round_tripped = Spec.t_of_sexp (Spec.sexp_of_t original) in
+  assert_that round_tripped.holdout_folds is_none
+
+let test_holdout_folds_round_trip_some _ =
+  let original = _spec_record_with_holdout (Some [ 27; 28; 29; 30 ]) in
+  let round_tripped = Spec.t_of_sexp (Spec.sexp_of_t original) in
+  assert_that round_tripped.holdout_folds
+    (is_some_and
+       (elements_are [ equal_to 27; equal_to 28; equal_to 29; equal_to 30 ]))
+
+let test_holdout_folds_round_trip_some_empty _ =
+  let original = _spec_record_with_holdout (Some []) in
+  let round_tripped = Spec.t_of_sexp (Spec.sexp_of_t original) in
+  assert_that round_tripped.holdout_folds (is_some_and (size_is 0))
+
+(* ---------- production fixture: bayesian-multi-param-2026-05-16.sexp ---- *)
+
+(** Walk the cwd up until we hit a directory containing
+    [trading/test_data/tuner/]. Mirrors the helper in [Walk_forward.test_spec];
+    needed because [dune runtest]'s cwd is
+    [_build/default/trading/backtest/tuner/bin/test]. *)
+let _tuner_fixtures_root () =
+  let target = "trading/test_data/tuner" in
+  let rec walk_up dir tries_left =
+    if tries_left = 0 then None
+    else
+      let candidate = Filename.concat dir target in
+      if try Stdlib.Sys.is_directory candidate with _ -> false then
+        Some candidate
+      else
+        let parent = Filename.dirname dir in
+        if String.equal parent dir then None else walk_up parent (tries_left - 1)
+  in
+  walk_up (Stdlib.Sys.getcwd ()) 10
+
+let _tuner_fixture_path name =
+  match _tuner_fixtures_root () with
+  | Some root -> Filename.concat root name
+  | None ->
+      OUnit2.assert_failure
+        (sprintf "tuner fixtures dir not found from cwd %s"
+           (Stdlib.Sys.getcwd ()))
+
+let test_phase3_fixture_parses _ =
+  (* PR-B acceptance criterion: the production Phase-3 BO spec sexp parses
+     without error and pins the 11-knob curated surface + the (27 28 29 30)
+     OOS holdout. Asserting on [List.length spec.bounds] guards against
+     accidental knob churn. *)
+  let spec =
+    Spec.load (_tuner_fixture_path "bayesian-multi-param-2026-05-16.sexp")
+  in
+  assert_that spec
+    (all_of
+       [
+         field (fun (s : Spec.t) -> s.bounds) (size_is 11);
+         field
+           (fun (s : Spec.t) -> s.acquisition)
+           (equal_to Spec.Expected_improvement);
+         field (fun (s : Spec.t) -> s.initial_random) (equal_to 25);
+         field (fun (s : Spec.t) -> s.total_budget) (equal_to 100);
+         field (fun (s : Spec.t) -> s.seed) (is_some_and (equal_to 2026));
+         field
+           (fun (s : Spec.t) -> s.holdout_folds)
+           (is_some_and
+              (elements_are
+                 [ equal_to 27; equal_to 28; equal_to 29; equal_to 30 ]));
+       ])
+
+let test_phase3_fixture_bounds_cover_expected_tracks _ =
+  (* The 11-knob curation is structured across four tracks. Asserting the
+     full key list (in order) guards against silent drift between the plan
+     and the fixture. *)
+  let spec =
+    Spec.load (_tuner_fixture_path "bayesian-multi-param-2026-05-16.sexp")
+  in
+  let keys = List.map spec.bounds ~f:fst in
+  assert_that keys
+    (elements_are
+       [
+         equal_to "initial_stop_buffer";
+         equal_to "screening_config.candidate_params.initial_stop_pct";
+         equal_to "screening_config.candidate_params.installed_stop_min_pct";
+         equal_to "screening_config.candidate_params.entry_buffer_pct";
+         equal_to "portfolio_config.max_position_pct_long";
+         equal_to "portfolio_config.max_long_exposure_pct";
+         equal_to "portfolio_config.risk_per_trade_pct";
+         equal_to "stage3_force_exit_config.hysteresis_weeks";
+         equal_to "laggard_rotation_config.hysteresis_weeks";
+         equal_to "screening_config.weights.w_positive_rs";
+         equal_to "screening_config.weights.w_strong_volume";
+       ])
+
 let suite =
   "Tuner_bin.Bayesian_runner"
   >::: [
@@ -304,6 +476,22 @@ let suite =
          >:: test_determinism_same_seed_byte_identical_log;
          "Evaluator.build: unknown scenario path raises Failure"
          >:: test_evaluator_unknown_scenario_raises;
+         "Spec.load: holdout_folds present -> Some [..]"
+         >:: test_holdout_folds_present_parses_to_some;
+         "Spec.load: holdout_folds () -> Some []"
+         >:: test_holdout_folds_empty_list_parses_to_some_empty;
+         "Spec.load: holdout_folds omitted -> None"
+         >:: test_holdout_folds_omitted_parses_to_none;
+         "Spec round-trip: holdout_folds = None"
+         >:: test_holdout_folds_round_trip_none;
+         "Spec round-trip: holdout_folds = Some [..]"
+         >:: test_holdout_folds_round_trip_some;
+         "Spec round-trip: holdout_folds = Some []"
+         >:: test_holdout_folds_round_trip_some_empty;
+         "Phase-3 fixture: bayesian-multi-param-2026-05-16.sexp parses"
+         >:: test_phase3_fixture_parses;
+         "Phase-3 fixture: 11 knobs in expected order"
+         >:: test_phase3_fixture_bounds_cover_expected_tracks;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/walk_forward/lib/spec.ml
+++ b/trading/trading/backtest/walk_forward/lib/spec.ml
@@ -7,6 +7,6 @@ type t = {
   baseline_label : string;
   gate : Fold_gate.t;
 }
-[@@deriving sexp]
+[@@deriving sexp] [@@sexp.allow_extra_fields]
 
 let load path : t = t_of_sexp (Sexp.load_sexp path)

--- a/trading/trading/backtest/walk_forward/lib/spec.mli
+++ b/trading/trading/backtest/walk_forward/lib/spec.mli
@@ -12,7 +12,13 @@ type t = {
   gate : Fold_gate.t;
 }
 [@@deriving sexp]
-(** Top-level spec the binary reads via [Sexp.load_sexp] + [t_of_sexp]. *)
+(** Top-level spec the binary reads via [Sexp.load_sexp] + [t_of_sexp].
+
+    The underlying record allows extra sexp fields
+    ([\@\@sexp.allow_extra_fields]) so spec files may carry metadata that the
+    runner does not consume directly (e.g. a [holdout_folds] block used by the
+    Bayesian tuner to mark folds excluded from BO scoring — the walk-forward
+    runner itself ignores the list). *)
 
 val load : string -> t
 (** [load path] = [Sexp.load_sexp path |> t_of_sexp]. Raises [Failure] / sexp


### PR DESCRIPTION
## Summary

PR-B of the Phase-3 Bayesian-optimizer plan (`dev/plans/bayesian-multi-param-scaling-2026-05-16.md`). Extends the 4-D BO surface (PR #914) to an **11-knob curated multi-parameter surface** and adds the **holdout-folds spec field** that PR-C/E will consume for walk-forward in-process integration + OOS validation.

PR-A (`feat(tuning): scoring function + walk-forward aggregate consumer`) landed in #1126; PR-B builds on it. PR-C/D/E follow.

## Why now

PR-A delivered the scoring function (`-mean_sharpe + λ_dd · MaxDD_hinge + λ_gate · gate_penalty`) consuming a pre-computed `aggregate.sexp`. PR-B materializes the parameter space the scorer will optimize over — without it PR-C (walk-forward in-process integration) has no production surface to wire into.

## What ships

| Path | Change |
|------|--------|
| `trading/trading/backtest/tuner/bin/bayesian_runner_spec.{ml,mli}` | + `holdout_folds : int list option` field, `[@sexp.option]` so absence parses as `None`; existing fields unchanged |
| `trading/test_data/tuner/bayesian-multi-param-2026-05-16.sexp` (new) | Phase-3 BO spec — 11-knob bounds, EI acquisition, 100-iteration budget, `(holdout_folds (27 28 29 30))` |
| `trading/test_data/walk_forward/cell_e_30fold_2026_05_16.sexp` | Adds documentary `(holdout_folds (27 28 29 30))` block — the BO scorer consumes it; walk-forward runner ignores it via `[@@sexp.allow_extra_fields]` on `Spec.t` |
| `trading/trading/backtest/walk_forward/lib/spec.{ml,mli}` | Adds `[@@sexp.allow_extra_fields]` so the new sexp tag doesn't break the parser; behavior unchanged |
| `trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml` | + 8 new tests (round-trip Some/None/Some[], parsed-shape None/Some/Some[], production fixture parses, 11-knob key list pinned) |
| `trading/trading/backtest/tuner/bin/test/dune` | + `(deps (glob_files_rec %{workspace_root}/test_data/tuner/*.sexp))` |

## Surface curation

The plan §2.1 enumerates an 18-knob aspirational surface across five tracks. PR-B curates down to 11 for two reasons:

1. **GP dimensionality ceiling** — `Tuner.Bayesian_opt.mli` is explicit that the in-house GP is "meaningful at ≤10 dimensions". 11 is at the boundary; 15-18 would degrade.
2. **Known-sensitive vs. plausible** — per `memory/project_m5-5-tuning-exhausted.md`, most M5.5 single-axis sweeps rejected or neutral, with `installed_stop_min_pct=0.08` as the only durable signal. PR-B keeps every known-sensitive knob and a small set of high-confidence adjacent knobs.

| Track | Knobs | Count |
|-------|-------|-------|
| A (entry/stop geometry) | `initial_stop_buffer`, `screening_config.candidate_params.{initial_stop_pct, installed_stop_min_pct, entry_buffer_pct}` | 4 |
| B (sizing/exposure) | `portfolio_config.{max_position_pct_long, max_long_exposure_pct, risk_per_trade_pct}` | 3 |
| C (stage classifier) | **DROPPED** per plan §5.2 — near-fixed | 0 |
| D (Cell E mechanics) | `stage3_force_exit_config.hysteresis_weeks`, `laggard_rotation_config.hysteresis_weeks` | 2 |
| E (screening cascade) | `screening_config.weights.{w_positive_rs, w_strong_volume}` | 2 |

Option-typed knobs (`max_sector_exposure_pct`, `min_score_override`) and binary feature flags (`enable_*`) are deferred to PR-D per plan §2.5.

## Out of scope (subsequent PRs)

- **PR-C**: walk-forward in-process integration — `Walk_forward_executor` library entry point + `Bayesian_runner_evaluator` rewrite to compute scores from `aggregate.sexp` per iteration.
- **PR-D**: Option/binary encoding + GP length-scale tuning + early-stop.
- **PR-E**: end-to-end runner, OOS validator using the `holdout_folds` field, `oos_report.md` writer.

## Test plan

- [x] `dune build` clean (no warnings)
- [x] `dune build @fmt` clean (no diffs)
- [x] `dune runtest trading/backtest/tuner/`: 19 tests pass (11 existing + 8 new)
- [x] `dune runtest trading/backtest/walk_forward/`: 22 tests pass (existing 30-fold spec parses with the new `holdout_folds` block via `[@@sexp.allow_extra_fields]`)
- [x] Nesting linter: 0 findings on tuner / walk_forward paths
- [x] `dune runtest devtools/`: linters all green (file length / fn length / magic numbers / mli coverage / fmt)
- [x] Production fixture `bayesian-multi-param-2026-05-16.sexp` parses with 11 bounds + `Some [27; 28; 29; 30]` (test `test_phase3_fixture_parses`)
- [x] Edge case: omitted field → `None`; `(holdout_folds ())` → `Some []`; `(holdout_folds (..))` → `Some [..]` (three tests)
- [x] Round-trip: `t -> sexp_of_t -> t_of_sexp -> t` preserves `None`, `Some []`, `Some [..]` (three tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)