### PR TITLE
fix(ishares): IWV fetcher curl shellout — bypass Cohttp_async fingerprint

### DIFF
--- a/trading/analysis/data/sources/ishares/bin/dune
+++ b/trading/analysis/data/sources/ishares/bin/dune
@@ -6,6 +6,20 @@
   (pps ppx_let ppx_deriving.show ppx_deriving.eq)))
 
 (library
+ (name iwv_curl_fetch)
+ (modules iwv_curl_fetch)
+ (libraries
+  core
+  core_unix.filename_unix
+  core_unix.sys_unix
+  async
+  async_unix
+  fetch_iwv_history_lib
+  uri)
+ (preprocess
+  (pps ppx_let)))
+
+(library
  (name build_iwv_universe_lib)
  (modules build_iwv_universe_lib)
  (libraries core core_unix.sys_unix core_unix ishares status)
@@ -20,10 +34,8 @@
   core_unix.command_unix
   async
   async_unix
-  cohttp
-  cohttp-async
-  async_ssl
   fetch_iwv_history_lib
+  iwv_curl_fetch
   ishares
   status
   uri)

--- a/trading/analysis/data/sources/ishares/bin/fetch_iwv_history.ml
+++ b/trading/analysis/data/sources/ishares/bin/fetch_iwv_history.ml
@@ -6,11 +6,14 @@
     polite sleep (default 2,000 ms).
 
     See [dev/plans/iwv-scraper-2026-05-16.md] §PR-C and
-    [fetch_iwv_history_lib.mli] for the planning / cache-layout contract. *)
+    [fetch_iwv_history_lib.mli] for the planning / cache-layout contract. See
+    [dev/notes/iwv-scrape-akamai-block-2026-05-16.md] §Option (c) for why this
+    exe shells out to system curl rather than [Cohttp_async]. *)
 
 open Core
 open Async
 module Lib = Fetch_iwv_history_lib
+module Curl_fetch = Iwv_curl_fetch
 module Client = Ishares.Ishares_holdings_client
 
 let _default_cache_dir = "../dev/data/ishares/iwv"
@@ -20,51 +23,14 @@ let _default_polite_sleep_ms = 2000
    ishares.com); the executable wires [_default_fetch] in unconditionally. *)
 type fetch_fn = Uri.t -> string Status.status_or Deferred.t
 
-(* Browser-like request headers. iShares' Akamai WAF rejects bare
-   [Cohttp_async] UA strings with HTTP 503 ("AkamaiGHost"); the headers
-   below mirror a recent Chrome on macOS and a plausible Referer back to
-   the IWV product page. See [dev/notes/iwv-scrape-akamai-block-2026-05-16.md]. *)
-let _browser_headers =
-  Cohttp.Header.of_list
-    [
-      ( "User-Agent",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
-         (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" );
-      ("Accept", "text/csv,application/csv,*/*;q=0.8");
-      ("Accept-Language", "en-US,en;q=0.9");
-      ( "Referer",
-        "https://www.ishares.com/us/products/239714/ishares-russell-3000-etf" );
-    ]
-
 (* Exponential backoff schedule for retryable HTTP errors (503 / 429 / 502
    / 504). Three retries spaced 5s / 30s / 120s — total wall-clock cap is
    ~155s on top of the original failed attempt, which absorbs typical
    Akamai/WAF cooldowns without inflating the steady-state scrape time. *)
 let _retry_backoff_seconds_5xx = [ 5.0; 30.0; 120.0 ]
 
-let _is_retryable_status = function
-  | `Service_unavailable | `Too_many_requests | `Bad_gateway | `Gateway_timeout
-    ->
-      true
-  | _ -> false
-
-(* Single HTTP attempt with browser headers. Returns a structured
-   [Lib.fetch_attempt] so the retry helper can decide whether to retry. *)
 let _attempt_fetch uri : Lib.fetch_attempt Deferred.t =
-  Cohttp_async.Client.get ~headers:_browser_headers uri >>= fun (resp, body) ->
-  let status = Cohttp.Response.status resp in
-  match status with
-  | `OK ->
-      Cohttp_async.Body.to_string body >>| fun body_str -> Lib.Ok_body body_str
-  | status ->
-      let status_str = Cohttp.Code.string_of_status status in
-      Cohttp_async.Body.to_string body >>| fun body_str ->
-      let msg =
-        Printf.sprintf "HTTP %s for %s\n%s" status_str (Uri.to_string uri)
-          body_str
-      in
-      if _is_retryable_status status then Lib.Retryable_error msg
-      else Lib.Fatal_error msg
+  Curl_fetch.attempt_fetch ~curl:Curl_fetch.real_curl_runner uri
 
 let _sleep_seconds secs = Clock.after (Time_float.Span.of_sec secs)
 
@@ -207,11 +173,15 @@ let command =
       "Per asOfDate D in [--from..--until] at the chosen cadence:\n\
       \  * If <cache>/D.csv exists and is non-empty, skip.\n\
       \  * If <cache>/D.sentinel exists, skip.\n\
-      \  * Otherwise GET the iShares URL, parse the body. On sentinel\n\
-      \    response write D.sentinel; on data response write D.csv.\n\
+      \  * Otherwise GET the iShares URL via system curl, parse the body.\n\
+      \    On sentinel response write D.sentinel; on data response write\n\
+      \    D.csv.\n\
       \  * Sleep --sleep-ms between fetches.\n\n\
        --dry-run prints the planned actions without HTTP. See\n\
-       dev/plans/iwv-scraper-2026-05-16.md §PR-C.")
+       dev/plans/iwv-scraper-2026-05-16.md §PR-C and\n\
+       dev/notes/iwv-scrape-akamai-block-2026-05-16.md §Option (c) for\n\
+       why this exe shells out to system curl rather than using\n\
+       Cohttp_async (Akamai WAF fingerprints HTTP/1.1 + OCaml TLS).")
     (let%map_open.Command from_str =
        flag "from" (required string) ~doc:"YYYY-MM-DD inclusive start date"
      and until_str =

--- a/trading/analysis/data/sources/ishares/bin/iwv_curl_fetch.ml
+++ b/trading/analysis/data/sources/ishares/bin/iwv_curl_fetch.ml
@@ -1,0 +1,121 @@
+open Core
+open Async
+module Lib = Fetch_iwv_history_lib
+
+(* Browser-like header values for the curl invocation. iShares' Akamai
+   WAF rejects the bare [Cohttp_async] UA with HTTP 503 ("AkamaiGHost");
+   even after PR #1131 added these headers via [Cohttp.Header.of_list],
+   the response body was an HTML bot-check page (HTTP/1.1 + OCaml TLS
+   fingerprint). System curl with the same headers negotiates HTTP/2 +
+   a real TLS stack and returns the genuine CSV.
+
+   See [dev/notes/iwv-scrape-akamai-block-2026-05-16.md] §Option (c). *)
+let _user_agent =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, \
+   like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+let _accept_header = "text/csv,application/csv,*/*;q=0.8"
+let _accept_language_header = "en-US,en;q=0.9"
+
+let _referer_header =
+  "https://www.ishares.com/us/products/239714/ishares-russell-3000-etf"
+
+let curl_path = "curl"
+let curl_max_time_seconds = 30
+let curl_retryable_exit_codes = [ 6; 7; 28; 35; 52; 56 ]
+
+(* HTTP status codes that warrant retry. Mirrors PR #1131's
+   [_is_retryable_status] semantics on the [Cohttp.Code.status]
+   variant; integer form matches what curl emits via [-w]. *)
+let _is_retryable_http_status = function
+  | 503 | 429 | 502 | 504 -> true
+  | _ -> false
+
+let curl_args ~body_tempfile uri : string list =
+  [
+    "-sS";
+    "--max-time";
+    Int.to_string curl_max_time_seconds;
+    "-H";
+    "User-Agent: " ^ _user_agent;
+    "-H";
+    "Accept: " ^ _accept_header;
+    "-H";
+    "Accept-Language: " ^ _accept_language_header;
+    "-H";
+    "Referer: " ^ _referer_header;
+    "-o";
+    body_tempfile;
+    "-w";
+    "%{http_code}";
+    Uri.to_string uri;
+  ]
+
+(* Classify a [Process.Output.t] (curl exit + stdout HTTP code +
+   response body read from the tempfile) into the [Lib.fetch_attempt]
+   retry vocabulary. Pure. *)
+let _classify_zero_exit_output ~uri ~body ~stdout : Lib.fetch_attempt =
+  let code_str = String.strip stdout in
+  match Int.of_string_opt code_str with
+  | None ->
+      Lib.Fatal_error
+        (Printf.sprintf "curl produced unparseable http_code %S for %s" code_str
+           (Uri.to_string uri))
+  | Some 200 -> Lib.Ok_body body
+  | Some code when _is_retryable_http_status code ->
+      Lib.Retryable_error
+        (Printf.sprintf "HTTP %d for %s\n%s" code (Uri.to_string uri) body)
+  | Some code ->
+      Lib.Fatal_error
+        (Printf.sprintf "HTTP %d for %s\n%s" code (Uri.to_string uri) body)
+
+let classify_curl_output ~uri ~body (output : Process.Output.t) :
+    Lib.fetch_attempt =
+  match output.exit_status with
+  | Ok () -> _classify_zero_exit_output ~uri ~body ~stdout:output.stdout
+  | Error (`Exit_non_zero code) ->
+      let stderr = String.strip output.stderr in
+      let msg =
+        Printf.sprintf "curl exit %d for %s\nstderr: %s" code
+          (Uri.to_string uri) stderr
+      in
+      if List.mem curl_retryable_exit_codes code ~equal:Int.equal then
+        Lib.Retryable_error msg
+      else Lib.Fatal_error msg
+  | Error (`Signal s) ->
+      Lib.Fatal_error
+        (Printf.sprintf "curl killed by signal %s for %s" (Signal.to_string s)
+           (Uri.to_string uri))
+
+type curl_runner =
+  prog:string -> args:string list -> Process.Output.t Deferred.Or_error.t
+
+let real_curl_runner : curl_runner =
+ fun ~prog ~args ->
+  Process.create ~prog ~args () >>=? fun proc ->
+  Process.collect_output_and_wait proc >>| Or_error.return
+
+(* Read [path] (returns "" if missing) and remove it. Used for both
+   success and failure paths so a failed attempt leaves no debris. *)
+let _read_and_remove path : string =
+  let body =
+    if Sys_unix.file_exists_exn path then In_channel.read_all path else ""
+  in
+  (try Sys_unix.remove path with _ -> ());
+  body
+
+let attempt_fetch ~(curl : curl_runner) uri : Lib.fetch_attempt Deferred.t =
+  let body_tempfile =
+    Filename_unix.temp_file ~in_dir:Filename.temp_dir_name "iwv_body" ".csv"
+  in
+  let args = curl_args ~body_tempfile uri in
+  curl ~prog:curl_path ~args >>| fun result ->
+  let body = _read_and_remove body_tempfile in
+  match result with
+  | Ok output -> classify_curl_output ~uri ~body output
+  | Error err ->
+      (* [Process.create] itself failed (e.g. could not fork / exec).
+         Treat as retryable since it's typically transient. *)
+      Lib.Retryable_error
+        (Printf.sprintf "process exec failed for %s: %s" (Uri.to_string uri)
+           (Error.to_string_hum err))

--- a/trading/analysis/data/sources/ishares/bin/iwv_curl_fetch.mli
+++ b/trading/analysis/data/sources/ishares/bin/iwv_curl_fetch.mli
@@ -1,0 +1,77 @@
+(** Curl-shellout HTTP fetcher for the IWV scraper.
+
+    Replaces the [Cohttp_async]-based GET path that PR #1131 added browser
+    headers to. Even with browser headers, the OCaml HTTP/1.1 client tripped
+    Akamai's bot fingerprint and got back an HTML challenge page (see
+    [dev/notes/iwv-scrape-akamai-block-2026-05-16.md] §"Cohttp_async still
+    serves HTML"). Shelling out to system curl — which negotiates HTTP/2
+    + a real TLS stack — sidesteps the fingerprint.
+
+    The module exposes:
+
+    - [curl_args] — pure argv-list construction (testable).
+    - [classify_curl_output] — pure classification of a [Process.Output.t] into
+      the lib's [fetch_attempt] retry vocabulary (testable).
+    - [attempt_fetch] — IO-shaped single HTTP attempt, with the underlying curl
+      runner injectable for tests.
+
+    All retry / backoff logic stays in
+    [Fetch_iwv_history_lib.retry_with_backoff] (contract-stable per PR #1131).
+*)
+
+open Async
+module Lib = Fetch_iwv_history_lib
+
+val curl_path : string
+(** The curl executable path. Currently ["curl"] (lookup via PATH). *)
+
+val curl_max_time_seconds : int
+(** Per-request curl timeout. iShares responses are typically well under 5 s;
+    this gives generous headroom for transient slowness. *)
+
+val curl_retryable_exit_codes : int list
+(** Curl exit codes that classify as transient network errors (suitable for
+    retry). 6=resolve, 7=connect, 28=op timeout, 35=ssl-handshake,
+    52=empty-reply, 56=recv. All other non-zero curl exits surface as fatal.
+    From the [curl(1)] man page. *)
+
+val curl_args : body_tempfile:string -> Uri.t -> string list
+(** [curl_args ~body_tempfile uri] returns the argv list (excluding the leading
+    ["curl"] program path) for a single GET. The output body is streamed to
+    [body_tempfile] (curl's [-o]); the HTTP status code is written to curl's
+    stdout (curl's [-w "%{http_code}"]).
+
+    Browser-mimicking headers (UA / Accept / Accept-Language / Referer) are
+    added unconditionally. *)
+
+val classify_curl_output :
+  uri:Uri.t -> body:string -> Process.Output.t -> Lib.fetch_attempt
+(** [classify_curl_output ~uri ~body output] turns a completed curl invocation
+    into the retry-decision vocabulary.
+
+    - Exit 0 + stdout-parses-as-200 → [Ok_body body].
+    - Exit 0 + stdout-parses-as one of [503] / [429] / [502] / [504] →
+      [Retryable_error _].
+    - Exit 0 + any other parseable HTTP code → [Fatal_error _].
+    - Exit 0 + unparseable stdout → [Fatal_error _].
+    - Exit non-zero with a curl code in [curl_retryable_exit_codes] →
+      [Retryable_error _].
+    - Exit non-zero otherwise → [Fatal_error _].
+    - Killed by signal → [Fatal_error _]. *)
+
+type curl_runner =
+  prog:string -> args:string list -> Process.Output.t Deferred.Or_error.t
+(** Curl-runner abstraction. The production runner shells out via
+    [Process.create] + [collect_output_and_wait]; tests inject a stub that
+    returns a scripted [Process.Output.t]. *)
+
+val real_curl_runner : curl_runner
+(** [real_curl_runner ~prog ~args] launches [prog] with [args] via
+    [Async.Process.create] and waits for it to terminate, returning its output
+    (stdout + stderr + exit status). *)
+
+val attempt_fetch : curl:curl_runner -> Uri.t -> Lib.fetch_attempt Deferred.t
+(** [attempt_fetch ~curl uri] performs a single HTTP attempt via the injected
+    curl runner. Manages the response-body tempfile (creation
+    + read + delete on every code path). Returns a [fetch_attempt] for
+      [Fetch_iwv_history_lib.retry_with_backoff] to decide on retries. *)

--- a/trading/analysis/data/sources/ishares/test/dune
+++ b/trading/analysis/data/sources/ishares/test/dune
@@ -3,10 +3,12 @@
   test_ishares_holdings_client
   test_ishares_membership_replay
   test_fetch_iwv_history_lib
+  test_iwv_curl_fetch
   test_build_iwv_universe_lib)
  (libraries
   ishares
   fetch_iwv_history_lib
+  iwv_curl_fetch
   build_iwv_universe_lib
   async
   async_unix

--- a/trading/analysis/data/sources/ishares/test/test_iwv_curl_fetch.ml
+++ b/trading/analysis/data/sources/ishares/test/test_iwv_curl_fetch.ml
@@ -1,0 +1,308 @@
+open Core
+open Async
+open OUnit2
+open Matchers
+module Curl_fetch = Iwv_curl_fetch
+module Lib = Fetch_iwv_history_lib
+
+let _dummy_uri = Uri.of_string "https://example.invalid/iwv.csv"
+
+(* ------------------------------------------------------------------------- *)
+(* curl_args — pure argv construction                                        *)
+(* ------------------------------------------------------------------------- *)
+
+(* Pin the full curl argv in order. This catches accidental flag
+   re-ordering, dropped flags, or a misplaced URI. The browser-header
+   values are matched via [contains_substring] so a future tweak of
+   the UA / Referer string doesn't force a brittle rebase. *)
+let test_curl_args_full_argv_shape _ =
+  let args =
+    Curl_fetch.curl_args ~body_tempfile:"/tmp/iwv_body_abc.csv" _dummy_uri
+  in
+  assert_that args
+    (elements_are
+       [
+         equal_to "-sS";
+         equal_to "--max-time";
+         equal_to (Int.to_string Curl_fetch.curl_max_time_seconds);
+         equal_to "-H";
+         all_of
+           [
+             contains_substring "User-Agent: Mozilla/5.0";
+             contains_substring "Chrome/120.0.0.0";
+           ];
+         equal_to "-H";
+         contains_substring "Accept: text/csv";
+         equal_to "-H";
+         contains_substring "Accept-Language: en-US";
+         equal_to "-H";
+         contains_substring "Referer: https://www.ishares.com/";
+         equal_to "-o";
+         equal_to "/tmp/iwv_body_abc.csv";
+         equal_to "-w";
+         equal_to "%{http_code}";
+         equal_to "https://example.invalid/iwv.csv";
+       ])
+
+(* ------------------------------------------------------------------------- *)
+(* classify_curl_output — pure classification                                *)
+(* ------------------------------------------------------------------------- *)
+
+let _output ~exit_status ~stdout ~stderr : Process.Output.t =
+  { stdout; stderr; exit_status }
+
+let test_classify_200_returns_ok_body _ =
+  let output = _output ~exit_status:(Ok ()) ~stdout:"200" ~stderr:"" in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"the-csv-body" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Ok_body"
+       (function Lib.Ok_body s -> Some s | _ -> None)
+       (equal_to "the-csv-body"))
+
+(* Trailing newline on the http_code is normal curl output when
+   stdout writers add it; the classifier must strip it before parsing. *)
+let test_classify_200_strips_whitespace _ =
+  let output = _output ~exit_status:(Ok ()) ~stdout:"200\n" ~stderr:"" in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"payload" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Ok_body"
+       (function Lib.Ok_body s -> Some s | _ -> None)
+       (equal_to "payload"))
+
+let test_classify_503_is_retryable _ =
+  let output = _output ~exit_status:(Ok ()) ~stdout:"503" ~stderr:"" in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"akamai html" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Retryable_error"
+       (function Lib.Retryable_error m -> Some m | _ -> None)
+       (all_of
+          [ contains_substring "HTTP 503"; contains_substring "akamai html" ]))
+
+let test_classify_429_is_retryable _ =
+  let output = _output ~exit_status:(Ok ()) ~stdout:"429" ~stderr:"" in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"rate-limit" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Retryable_error"
+       (function Lib.Retryable_error m -> Some m | _ -> None)
+       (contains_substring "HTTP 429"))
+
+let test_classify_404_is_fatal _ =
+  let output = _output ~exit_status:(Ok ()) ~stdout:"404" ~stderr:"" in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"not found" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Fatal_error"
+       (function Lib.Fatal_error m -> Some m | _ -> None)
+       (contains_substring "HTTP 404"))
+
+let test_classify_unparseable_http_code_is_fatal _ =
+  let output = _output ~exit_status:(Ok ()) ~stdout:"???" ~stderr:"" in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Fatal_error"
+       (function Lib.Fatal_error m -> Some m | _ -> None)
+       (contains_substring "unparseable http_code"))
+
+(* Curl exit codes the iShares scraper treats as transient (timeout,
+   connect refused, DNS fail). 28 = operation timeout — the most
+   common one on a slow Akamai response. *)
+let test_classify_curl_exit_28_is_retryable _ =
+  let output =
+    _output
+      ~exit_status:(Error (`Exit_non_zero 28))
+      ~stdout:"" ~stderr:"operation timed out"
+  in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Retryable_error"
+       (function Lib.Retryable_error m -> Some m | _ -> None)
+       (all_of
+          [ contains_substring "curl exit 28"; contains_substring "timed out" ]))
+
+let test_classify_curl_exit_7_is_retryable _ =
+  let output =
+    _output
+      ~exit_status:(Error (`Exit_non_zero 7))
+      ~stdout:"" ~stderr:"failed to connect"
+  in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Retryable_error"
+       (function Lib.Retryable_error m -> Some m | _ -> None)
+       (contains_substring "curl exit 7"))
+
+(* Exit codes outside the retryable allowlist are fatal — e.g. 22
+   (server returned 4xx via [-f], not in use here) or 99 (a value
+   curl will never emit; pinned here to lock the default-fatal
+   branch). *)
+let test_classify_curl_exit_99_is_fatal _ =
+  let output =
+    _output
+      ~exit_status:(Error (`Exit_non_zero 99))
+      ~stdout:"" ~stderr:"made-up failure"
+  in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Fatal_error"
+       (function Lib.Fatal_error m -> Some m | _ -> None)
+       (contains_substring "curl exit 99"))
+
+let test_classify_signal_is_fatal _ =
+  let output =
+    _output ~exit_status:(Error (`Signal Signal.term)) ~stdout:"" ~stderr:""
+  in
+  let result =
+    Curl_fetch.classify_curl_output ~uri:_dummy_uri ~body:"" output
+  in
+  assert_that result
+    (matching ~msg:"Expected Fatal_error"
+       (function Lib.Fatal_error m -> Some m | _ -> None)
+       (contains_substring "killed by signal"))
+
+(* ------------------------------------------------------------------------- *)
+(* attempt_fetch — DI'd curl runner, tempfile-lifecycle assertions           *)
+(* ------------------------------------------------------------------------- *)
+
+(* Stub curl runner that records the args it was passed and writes a
+   scripted body to the [-o <path>] tempfile before returning a
+   scripted [Process.Output.t]. This is the seam that lets us pin
+   end-to-end behaviour (body read, classification, tempfile cleanup)
+   without ever forking [curl]. *)
+let _extract_o_path args =
+  let rec loop = function
+    | [] -> None
+    | "-o" :: path :: _ -> Some path
+    | _ :: rest -> loop rest
+  in
+  loop args
+
+let _stub_runner_writing ~body_to_write ~output_to_return :
+    Curl_fetch.curl_runner * string list ref * string list ref =
+  let calls = ref [] in
+  let observed_args = ref [] in
+  let runner ~prog ~args =
+    calls := prog :: !calls;
+    observed_args := args;
+    (match _extract_o_path args with
+    | Some path ->
+        Out_channel.with_file path ~f:(fun oc ->
+            Out_channel.output_string oc body_to_write)
+    | None -> ());
+    Deferred.Or_error.return output_to_return
+  in
+  (runner, calls, observed_args)
+
+let _block_on f = Async.Thread_safe.block_on_async_exn f
+
+let test_attempt_fetch_returns_body_on_200 _ =
+  let curl, calls, _args =
+    _stub_runner_writing ~body_to_write:"col1,col2\na,b\n"
+      ~output_to_return:(_output ~exit_status:(Ok ()) ~stdout:"200" ~stderr:"")
+  in
+  let result =
+    _block_on (fun () -> Curl_fetch.attempt_fetch ~curl _dummy_uri)
+  in
+  assert_that result
+    (matching ~msg:"Expected Ok_body"
+       (function Lib.Ok_body s -> Some s | _ -> None)
+       (equal_to "col1,col2\na,b\n"));
+  (* Exactly one curl invocation; production prog name. *)
+  assert_that !calls (elements_are [ equal_to Curl_fetch.curl_path ])
+
+(* Tempfile lifecycle: after [attempt_fetch] returns, the [-o] path
+   must no longer exist on disk. This guards against the leak that
+   would silently accumulate /tmp/iwv_body_*.csv files over a
+   ~3700-date backfill. *)
+let test_attempt_fetch_cleans_up_tempfile _ =
+  let curl, _calls, args_ref =
+    _stub_runner_writing ~body_to_write:"body-x"
+      ~output_to_return:(_output ~exit_status:(Ok ()) ~stdout:"200" ~stderr:"")
+  in
+  let (_ : Lib.fetch_attempt) =
+    _block_on (fun () -> Curl_fetch.attempt_fetch ~curl _dummy_uri)
+  in
+  let tempfile_path = _extract_o_path !args_ref in
+  let path =
+    match tempfile_path with
+    | Some p -> p
+    | None -> assert_failure "stub runner did not see a -o argument"
+  in
+  assert_that (Sys_unix.file_exists_exn path) (equal_to false)
+
+(* 503 path: curl exits 0 but emits "503" on stdout. Classifier maps
+   to Retryable_error. *)
+let test_attempt_fetch_503_is_retryable _ =
+  let curl, _calls, _args =
+    _stub_runner_writing ~body_to_write:"<html>akamai bot check</html>"
+      ~output_to_return:(_output ~exit_status:(Ok ()) ~stdout:"503" ~stderr:"")
+  in
+  let result =
+    _block_on (fun () -> Curl_fetch.attempt_fetch ~curl _dummy_uri)
+  in
+  assert_that result
+    (matching ~msg:"Expected Retryable_error"
+       (function Lib.Retryable_error m -> Some m | _ -> None)
+       (contains_substring "HTTP 503"))
+
+(* Process.create failure path: [Or_error.error] from the curl runner
+   gets translated to [Retryable_error] (transient system condition,
+   not a permanent endpoint failure). *)
+let test_attempt_fetch_runner_error_is_retryable _ =
+  let curl ~prog:_ ~args:_ =
+    Deferred.return (Or_error.error_string "could not fork")
+  in
+  let result =
+    _block_on (fun () -> Curl_fetch.attempt_fetch ~curl _dummy_uri)
+  in
+  assert_that result
+    (matching ~msg:"Expected Retryable_error"
+       (function Lib.Retryable_error m -> Some m | _ -> None)
+       (contains_substring "process exec failed"))
+
+let suite =
+  "iwv_curl_fetch_test"
+  >::: [
+         "curl_args_full_argv_shape" >:: test_curl_args_full_argv_shape;
+         "classify_200_returns_ok_body" >:: test_classify_200_returns_ok_body;
+         "classify_200_strips_whitespace"
+         >:: test_classify_200_strips_whitespace;
+         "classify_503_is_retryable" >:: test_classify_503_is_retryable;
+         "classify_429_is_retryable" >:: test_classify_429_is_retryable;
+         "classify_404_is_fatal" >:: test_classify_404_is_fatal;
+         "classify_unparseable_http_code_is_fatal"
+         >:: test_classify_unparseable_http_code_is_fatal;
+         "classify_curl_exit_28_is_retryable"
+         >:: test_classify_curl_exit_28_is_retryable;
+         "classify_curl_exit_7_is_retryable"
+         >:: test_classify_curl_exit_7_is_retryable;
+         "classify_curl_exit_99_is_fatal"
+         >:: test_classify_curl_exit_99_is_fatal;
+         "classify_signal_is_fatal" >:: test_classify_signal_is_fatal;
+         "attempt_fetch_returns_body_on_200"
+         >:: test_attempt_fetch_returns_body_on_200;
+         "attempt_fetch_cleans_up_tempfile"
+         >:: test_attempt_fetch_cleans_up_tempfile;
+         "attempt_fetch_503_is_retryable"
+         >:: test_attempt_fetch_503_is_retryable;
+         "attempt_fetch_runner_error_is_retryable"
+         >:: test_attempt_fetch_runner_error_is_retryable;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

- Replace `Cohttp_async.Client.get` in `fetch_iwv_history.ml` with an `Async.Process.run` curl invocation
- Bypass the Akamai WAF fingerprint that classifies HTTP/1.1 + claimed Chrome UA as automation and returns the bot-challenge HTML (status 200) instead of CSV
- PR #1131's browser headers + retry classifier were correct; the gap was the TLS/HTTP-version fingerprint, not the headers

## Context

Per `dev/notes/iwv-scrape-akamai-block-2026-05-16.md` §2026-05-16 ~21:43Z update, option (c) — shell out to curl. curl uses HTTP/2 by default with a different TLS handshake; Akamai treats that as a real browser. The curl invocation reuses PR #1131's browser headers verbatim for traceability.

## What changed

- New module: `analysis/data/sources/ishares/bin/iwv_curl_fetch.{ml,mli}` (~200 LOC) — `Async.Process.create` + `collect_output_and_wait`, temp file body, ` -w \"%{http_code}\"` for status, DI'd `curl_runner` for tests
- `fetch_iwv_history.ml` — `_attempt_fetch` delegates to `Iwv_curl_fetch.attempt_fetch`
- `dune` — dropped `cohttp`, `cohttp-async`, `async_ssl` from the exe; added `core_unix.filename_unix`/`core_unix.sys_unix`
- 15 new stub-DI tests in `test_iwv_curl_fetch.ml`
- PR #1131's `Lib.retry_with_backoff` and its 4 retry tests untouched

## Test plan

- [x] `dune build` — clean across full project
- [x] `dune runtest` — all suites pass; 15 new tests in `test_iwv_curl_fetch` all green
- [x] `dune build @fmt` — clean
- [ ] End-to-end probe deferred — Akamai IP block re-engaged on this egress IP (220.133.47.63), confirmed at session end with 10,298,549-byte HTML body. Verify post-cooldown OR via a GHA-runner scrape PR