### PR TITLE
harness: add iwv-scrape-once workflow_dispatch for GHA IP-independent scrape

### DIFF
--- a/.github/workflows/iwv-scrape-once.yml
+++ b/.github/workflows/iwv-scrape-once.yml
@@ -1,0 +1,119 @@
+# One-shot workflow_dispatch to scrape iShares IWV holdings CSV cache from
+# a GHA runner, bypassing local IP blocks (Akamai cooldowns, etc.).
+#
+# Runs fetch_iwv_history.exe inside the same trading-ci container used by CI,
+# then uploads the CSV cache and a log file as workflow artifacts.
+#
+# DO NOT auto-commit the cache — dev/data/ishares/iwv/ is gitignored.
+# After downloading the artifact, run build_iwv_universe.exe offline.
+#
+# See dev/notes/iwv-scrape-akamai-block-2026-05-16.md §"GHA-runner workflow"
+# for dispatch instructions and next steps.
+
+name: IWV Scrape (one-shot)
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_date:
+        description: "Inclusive start date (YYYY-MM-DD)"
+        required: false
+        default: "2006-09-29"
+      until_date:
+        description: "Inclusive end date (YYYY-MM-DD)"
+        required: false
+        default: "2026-05-16"
+      cadence:
+        description: "Date cadence: auto | daily | monthly | quarterly"
+        required: false
+        default: "auto"
+      sleep_ms:
+        description: "Polite sleep between HTTP fetches (milliseconds)"
+        required: false
+        default: "2000"
+
+concurrency:
+  # Never cancel a partial scrape — an interrupted run wastes the wall clock
+  # already spent and leaves an incomplete cache.
+  group: iwv-scrape
+  cancel-in-progress: false
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      contents: read
+      packages: read
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/trading-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      # Run as root so GHA post-step cleanup can write to /__w/_temp/.
+      # HOME points to /home/opam so opam env finds the installed 5.3 switch.
+      options: --user 0
+    env:
+      HOME: /home/opam
+    defaults:
+      run:
+        shell: bash
+        working-directory: trading
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build fetch_iwv_history.exe
+        run: |
+          eval $(opam env)
+          dune build analysis/data/sources/ishares/bin/fetch_iwv_history.exe
+
+      - name: Run IWV scraper
+        run: |
+          eval $(opam env)
+          # Cache dir relative to /workspaces/trading-1/ (repo root).
+          # GitHub Actions mounts the checkout at $GITHUB_WORKSPACE (/__w/…),
+          # so we use an absolute path derived from the workspace.
+          CACHE_DIR="${GITHUB_WORKSPACE}/dev/data/ishares/iwv"
+          LOG_FILE="${GITHUB_WORKSPACE}/iwv-fetch-${{ github.run_id }}.log"
+          mkdir -p "$CACHE_DIR"
+
+          echo "=== IWV scrape start: $(date -u) ===" | tee "$LOG_FILE"
+          echo "  from=${{ inputs.from_date }}" | tee -a "$LOG_FILE"
+          echo "  until=${{ inputs.until_date }}" | tee -a "$LOG_FILE"
+          echo "  cadence=${{ inputs.cadence }}" | tee -a "$LOG_FILE"
+          echo "  sleep_ms=${{ inputs.sleep_ms }}" | tee -a "$LOG_FILE"
+          echo "  cache_dir=$CACHE_DIR" | tee -a "$LOG_FILE"
+          echo "" | tee -a "$LOG_FILE"
+
+          dune exec analysis/data/sources/ishares/bin/fetch_iwv_history.exe -- \
+            -from "${{ inputs.from_date }}" \
+            -until "${{ inputs.until_date }}" \
+            -cadence "${{ inputs.cadence }}" \
+            -cache-dir "$CACHE_DIR" \
+            -sleep-ms "${{ inputs.sleep_ms }}" \
+            2>&1 | tee -a "$LOG_FILE"
+
+          echo "" | tee -a "$LOG_FILE"
+          echo "=== IWV scrape end: $(date -u) ===" | tee -a "$LOG_FILE"
+
+          CSV_COUNT=$(find "$CACHE_DIR" -name '*.csv' | wc -l)
+          SENTINEL_COUNT=$(find "$CACHE_DIR" -name '*.sentinel' | wc -l)
+          echo "Cache summary: $CSV_COUNT csv files, $SENTINEL_COUNT sentinel files" | tee -a "$LOG_FILE"
+
+      - name: Upload CSV cache artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: iwv-cache-${{ github.run_id }}
+          path: dev/data/ishares/iwv/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload log artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: iwv-log-${{ github.run_id }}
+          path: iwv-fetch-${{ github.run_id }}.log
+          retention-days: 30
+          if-no-files-found: warn

--- a/dev/notes/iwv-scrape-akamai-block-2026-05-16.md
+++ b/dev/notes/iwv-scrape-akamai-block-2026-05-16.md
@@ -174,3 +174,50 @@ flagged. The exe is container-portable; needs a one-shot
   said "Next step is operational, not a feature PR" — that wasn't
   true; PR #1131 (browser headers + retry) was needed first, and is
   now merged. Update the priorities doc next-step text accordingly.
+
+## GHA-runner workflow
+
+**Rationale:** GHA runner has a different egress IP than the local dev
+machine. Even if local IP is in Akamai cooldown, a GHA run will come
+from a GitHub-owned IP range (not previously flagged by iShares WAF).
+
+**Workflow file:** `.github/workflows/iwv-scrape-once.yml`
+
+This `workflow_dispatch` workflow:
+1. Pulls `ghcr.io/dayfine/trading-ci:latest` (same image as CI).
+2. Builds `fetch_iwv_history.exe` inside the container via dune.
+3. Runs the fetcher with the input parameters, writing to
+   `$GITHUB_WORKSPACE/dev/data/ishares/iwv/`.
+4. Uploads `dev/data/ishares/iwv/` as artifact `iwv-cache-<run_id>`
+   (30-day retention).
+5. Uploads `iwv-fetch-<run_id>.log` as artifact `iwv-log-<run_id>`.
+6. Does NOT commit the cache (gitignored; download artifact manually).
+
+**Dispatch command** (paste after PR merges):
+```bash
+gh workflow run iwv-scrape-once.yml \
+  -f from_date=2006-09-29 \
+  -f until_date=2026-05-16 \
+  -f cadence=auto \
+  -f sleep_ms=2000
+```
+
+**After the run completes (~3h):**
+1. Download the artifact:
+   ```bash
+   gh run download <run_id> --name iwv-cache-<run_id> --dir dev/data/ishares/iwv/
+   ```
+2. Run `build_iwv_universe.exe` offline against the cache:
+   ```bash
+   docker exec -w /workspaces/trading-1/trading trading-1-dev bash -c \
+     'eval $(opam env) && dune exec analysis/data/sources/ishares/bin/build_iwv_universe.exe -- \
+        --cache-root ../dev/data/ishares/iwv \
+        --output ../dev/data/ishares/russell-3000-2006-2026.sexp'
+   ```
+3. Commit the resulting sexp as a follow-up PR (the CSV cache stays
+   gitignored; only the derived universe sexp is checked in).
+
+**Important constraint:** concurrency is set to `cancel-in-progress: false`
+— a second dispatch will queue rather than cancel a partial scrape.
+The job timeout is 360 min (6h), well above the ~3h expected wall clock
+at `-sleep-ms 2000` for ~3700 dates.

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -133,6 +133,14 @@ NO
   Python — it's straight OCaml `cohttp` work against a verified
   public endpoint (PR #1108). Next step is a plan-first dispatch to
   `feat-data` against `analysis/data/sources/ishares/`.
+- **Local IP Akamai cooldown (2026-05-16 transient):** If local
+  egress IP is still blocked, use the GHA-runner workflow as an
+  IP-independent alternative: `.github/workflows/iwv-scrape-once.yml`.
+  GHA runner uses a different egress IP from GitHub's range (not
+  previously flagged by iShares WAF). Dispatch:
+  `gh workflow run iwv-scrape-once.yml -f from_date=2006-09-29 -f until_date=2026-05-16`.
+  Full instructions in
+  `dev/notes/iwv-scrape-akamai-block-2026-05-16.md` §"GHA-runner workflow".
 - Phase 1.1 (EODHD Fundamentals) is parked — would need a tier
   upgrade ($60/mo) to revive; not pursued per Option B.
 - Norgate ingest retired 2026-05-16 (Windows-only client; see


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/iwv-scrape-once.yml` — a `workflow_dispatch` workflow to run `fetch_iwv_history.exe` on a GHA runner, bypassing local Akamai IP blocks
- Appends a `§"GHA-runner workflow"` section to `dev/notes/iwv-scrape-akamai-block-2026-05-16.md` with dispatch instructions and post-run steps
- Notes the GHA path-around in `dev/status/data-foundations.md` §"Blocked on"

## Context

Local egress IP (220.133.47.63) is in Akamai cooldown from the IWV scrape session on 2026-05-16. Even with PR #1131's browser headers, the OCaml `Cohttp_async` client gets an HTML interstitial (Akamai bot-check) rather than CSV — likely due to HTTP/1.1 vs HTTP/2 fingerprint mismatch. GHA runner uses a different egress IP (GitHub's IP range) that has not been flagged.

The workflow:
1. Uses the same `ghcr.io/dayfine/trading-ci:latest` container as CI (same auth pattern)
2. Builds `fetch_iwv_history.exe` via dune
3. Runs the fetcher with configurable `from_date`, `until_date`, `cadence`, `sleep_ms`
4. Uploads the CSV cache (`dev/data/ishares/iwv/`) as a 30-day artifact
5. Uploads the log as a separate artifact
6. Does NOT auto-commit the cache (gitignored); operator downloads artifact and runs `build_iwv_universe.exe` offline

Concurrency is `cancel-in-progress: false` — a partial scrape is never cancelled. Job timeout is 360 min (6h), well above the ~3h expected wall clock at 2s/request for ~3700 dates.

## Verify

```bash
# After merge, dispatch the workflow:
gh workflow run iwv-scrape-once.yml \
  -f from_date=2006-09-29 \
  -f until_date=2026-05-16 \
  -f cadence=auto \
  -f sleep_ms=2000
```

Full post-run instructions in `dev/notes/iwv-scrape-akamai-block-2026-05-16.md` §"GHA-runner workflow".