### PR TITLE
docs: data-source pointers + qc-behavioral on #1136

### DIFF
--- a/dev/notes/deep-history-data-pointers-2026-05-16.md
+++ b/dev/notes/deep-history-data-pointers-2026-05-16.md
@@ -1,0 +1,169 @@
+; Deep-history + cross-check data-source pointers (2026-05-16)
+
+# Deep-history + cross-check data-source pointers
+
+Date: 2026-05-16. Companion to `dev/notes/vendor-comparison-historical-universe-2026-05-16.md`.
+
+That doc is scoped to **point-in-time SP500 / Russell 3000 membership** (Phase
+1.4 IWV path). This doc captures the broader vendor landscape — deep-history
+(50-100y), free cross-check, international, and commodities — surfaced during
+the 2026-05-16 strategic review. Sources behind the recommendations live in
+`memory/reference_deep_history_data_sources.md`.
+
+## TL;DR
+
+- **Tier 1 (50-100y per-stock real data) is impossible without CRSP/WRDS.** Institutional-only. Morningstar acquisition Feb 2026 — access terms in flux. Don't plan around it.
+- **Tier 1 index-level anchor is free.** **Shiller** (S&P monthly from **1871**) + **Kenneth French Data Library** (portfolio returns + factors from **1926-07**). The synthesis path — French portfolios as systematic skeleton + idiosyncratic noise calibrated to dispersion + rescale to Shiller — is the *correct* engineering response to 50-100y backtest ambitions, not a compromise. **Shillerdata.com is the immediate next-pursue.**
+- **Tier 2 cross-check is free.** **Stooq** (free bulk EOD global) is a second-source for the 41,575-symbol EODHD cache. Pairs naturally with the manifest/hash-verify Phase 1 plan: once we have a sha256 per symbol, EODHD-vs-Stooq drift detection is a one-line audit script.
+- **Tier 2 alternate** is **Tiingo** (low-cost flat pricing) if EODHD ever changes terms.
+- **Tier 3 commodities is free and deep.** **World Bank Pink Sheet** (monthly ~70 commodities from 1960) + **datahub.io/core/gold-prices** (USD monthly since 1833, Public Domain) + **datahub.io/core/commodity-prices** (IMF 53 commodities + 10 indexes). Daily continuous futures still paywalled.
+- **Point-in-time index constituents is THE load-bearing risk** (per external review). Our DIY IWV scrape closes 2006-2026; pre-2006 needs EODHD constituent add-on (unverified for Russell) OR synthesis from French industry portfolios.
+
+## Per-tier detail
+
+### Tier 1 — 50-100y deep history
+
+#### What does NOT exist for free
+Real per-stock daily data 1925-1999. CRSP-only. NYSE from 1925-12-31; AMEX
+from 1962; NASDAQ from late-1972. WRDS access institutional-only. Morningstar
+acquired CRSP Feb 2026 — access terms uncertain.
+
+#### What IS available for free
+
+| Source | URL | Coverage | Format |
+|---|---|---|---|
+| **Shiller dataset** | `shillerdata.com` (`ie_data.xls`) | S&P monthly: price, dividend, earnings, CPI, interest rates from **1871-01** | XLS |
+| Shiller CSV mirror | `github.com/datasets/s-and-p-500` | Same | CSV |
+| Shiller JSON wrapper | `posix4e.github.io/shiller_wrapper_data` | Same | JSON (no auth) |
+| **Kenneth French Data Library** | Dartmouth/Tuck search | Daily + monthly portfolio returns sorted by size / book-to-market / momentum / 49-industry; Fama-French factors. From **1926-07** | CSV |
+
+#### Synthesis methodology (for pre-2000 backtests)
+
+1. **Skeleton**: French portfolio returns provide systematic factor structure (industry × size × value × momentum).
+2. **Idiosyncratic noise**: layer in synthetic per-symbol noise calibrated to the cross-sectional dispersion implied by those portfolios.
+3. **Aggregate constraint**: rescale so the cap-weighted aggregate reproduces Shiller's S&P composite series.
+4. Output: synthetic per-symbol returns with realistic factor structure + index anchor.
+
+#### Pre-CRSP-NASDAQ caveats
+
+- **Pre-1962**: only NYSE-listed (largest firms). No true total-market index.
+- **Pre-1972**: banks + financials not tracked in CRSP. Factor analyses suspect.
+- Synthesis must reproduce this selection bias rather than paper over it.
+
+#### Why pursue Shiller next
+
+- **Zero marginal cost** (XLS + CSV + JSON mirrors all free, no signup).
+- **155 years of index data** — gives the anchor for any synthesis we eventually build.
+- **Validation use case TODAY**: pin our SP500 long-horizon baseline against Shiller's monthly series → independent verification of EODHD's adjusted-close construction over the 26y on-disk window. Detects vendor split/dividend revisions.
+- Minimal scope: ingest the XLS, normalize to our `Daily_price`-equivalent monthly schema, store as a pinned fixture under `analysis/data/sources/shiller/`. ~200 LOC.
+
+### Tier 2 — 20-30y US + international
+
+#### Cross-check against current EODHD
+
+| Source | URL | Cost | Notes |
+|---|---|---|---|
+| **EODHD** (current) | — | Paid EOD tier | 30+y US daily; 15-20y EU/Asia. OHLCV split/div adjusted. Fundamentals tier separate (we don't have). |
+| **Stooq** | `stooq.com/db/h/` | Free | Bulk EOD global, indices + many tickers. Uneven quality, NOT survivorship-bias-free. **Use as cross-check, not primary.** |
+| **Tiingo** | Search Tiingo | Low-cost | 30+y, clean split/div adjusted, transparent flat pricing. |
+
+#### Stooq cross-check design (pairs with manifest Phase 1)
+
+When the CSV-layer manifest (per `dev/plans/data-inventory-and-reproducibility-2026-05-02.md`) lands:
+
+1. For each symbol in `data/sectors.csv`, fetch the matching Stooq bulk file.
+2. Compute daily-return divergence vs the EODHD `data.csv`.
+3. Flag any symbol with >1% return divergence on any single day OR >0.1% cumulative divergence over the full history.
+4. Write divergences to `dev/data/cross-check/eodhd-vs-stooq.sexp`.
+
+This costs nothing (Stooq is free) and gives us an independent integrity audit
+that catches:
+- EODHD silent split-revisions (G14-class bugs).
+- EODHD adjusted-close drift across vendor revisions.
+- Tickers renamed without our manifest catching it.
+
+#### Point-in-time constituents — the load-bearing risk
+
+External review (2026-05-16) called this "the single biggest data-integrity
+risk in the whole project." Without point-in-time membership, "current
+constituents" backtests silently overestimate returns.
+
+**Status of mitigations:**
+
+| Period | Path | Status |
+|---|---|---|
+| 2006-2026 Russell 3000 | DIY IWV scrape | Code ready (PRs #1112, #1131, #1137); blocked on Akamai IP cooldown OR GHA workflow #1138 |
+| 2000-2010 SP500 | EODHD Fundamentals constituents add-on (12y claim, unverified Russell) | Vendor query needed — confirm Russell coverage before relying |
+| 1996-1999 SP500 | `fja05680/sp500` static seed (MIT) | Deferred per broader-first pivot |
+| 1925-1995 | Synthesis from French industry portfolios | Not yet scoped |
+
+### Tier 2 — international expansion
+
+If we extend beyond US: prefer **direct local-exchange data via EODHD** over
+ADR proxies. ADRs introduce FX translation artifacts, sponsorship/ratio
+changes, and worse delisting survivorship. ADR is fine for screening / proxy
+but not for retunable per-market strategies.
+
+### Tier 3 — Commodities
+
+Best-served tier for free deep history.
+
+| Source | URL | Coverage | Cost |
+|---|---|---|---|
+| **World Bank "Pink Sheet"** | Search "World Bank Commodity Markets Pink Sheet" | Monthly prices ~70 commodities back to **1960** | Free |
+| **datahub.io/core/gold-prices** | `datahub.io/core/gold-prices` | Monthly gold USD since **1833**; 1960+ from Pink Sheet; auto-updated daily | Public Domain |
+| **datahub.io/core/commodity-prices** | `datahub.io/core/commodity-prices` | IMF 53 commodities + 10 indexes | Free |
+| **Nasdaq Data Link** | Nasdaq Data Link | Daily spot ~100 commodities; free tier covers many | Free tier |
+| **EODHD futures** | — | Daily futures (recent ~20y) | Already have |
+
+Daily continuous back-adjusted futures (Stevens / CHRIS-type) are mostly behind
+paywalls now. Realistic plan if/when commodity-strategy is in scope:
+
+- Monthly spot from World Bank/IMF for multi-decade regime-tuning.
+- Daily futures from EODHD or Nasdaq Data Link for the recent 20y where live
+  parameters matter.
+
+## Recommended next-pursue ordering
+
+1. **Shillerdata.com ingest** (~200 LOC). Free, low-effort, unlocks
+   long-horizon index baseline + EODHD adjusted-close validation. The
+   immediate next data-vendor PR.
+2. **Stooq cross-check** (gated on manifest Phase 1). Once the CSV manifest
+   lands, ~50 LOC script to flag EODHD-vs-Stooq divergence. Independent
+   integrity audit.
+3. **Kenneth French ingest** (if/when synthesis pre-2006 backtests are in
+   scope). Higher LOC (~400) due to multiple portfolio sorts; not urgent.
+4. **EODHD Indices Historical Constituents add-on** — vendor query first
+   (Russell coverage unverified). If covered, that retires the IWV scrape
+   for the 12y window it covers; if not, IWV stays primary.
+5. **World Bank Pink Sheet + datahub commodities** — only when
+   commodity-strategy is in scope. Not on near-term roadmap.
+
+## Cross-cutting constraints
+
+- **No Python.** All ingest clients in OCaml + `cohttp` + the repo's existing
+  CSV / sexp infra. Reference repos read for URL patterns + schemas only,
+  never executed.
+- **Caching layout.** `dev/data/<vendor>/...` (gitignored).
+- **Pinned fixtures.** Small test fixtures under
+  `analysis/data/sources/<vendor>/test/data/`.
+- **Manifest provenance.** Every emitted universe / pricing sexp carries
+  `source=<vendor>-<descriptor>` header line. Authority:
+  `dev/plans/data-inventory-and-reproducibility-2026-05-02.md`.
+
+## References
+
+- `memory/reference_deep_history_data_sources.md` — vendor catalog + URLs.
+- `dev/notes/vendor-comparison-historical-universe-2026-05-16.md` — Phase 1.4
+  IWV path detail (this doc's companion).
+- `dev/plans/data-inventory-and-reproducibility-2026-05-02.md` — manifest
+  plan (where Stooq cross-check plugs in).
+- `memory/project_strategic_pivot_broader_first.md` — broader-first posture.
+- `memory/project_phase1_1996_membership_norgate.md` — Norgate retirement
+  context.
+
+## External review attribution
+
+Vendor landscape compiled from a 2026-05-16 external research review. Original
+notes saved to memory; this doc adapts them to repo-specific terms +
+next-action ordering.

--- a/dev/notes/vendor-comparison-historical-universe-2026-05-16.md
+++ b/dev/notes/vendor-comparison-historical-universe-2026-05-16.md
@@ -294,6 +294,25 @@ Norgate (formerly Phase 1.1 / pre-pivot Phase 1.2) is RETIRED.
   `dev/notes/phase1.1-eodhd-verification-2026-05-16.md`). The
   algorithm is vendor-agnostic; only the snapshot source changes.
 
+## Adjacent vendor pointers (broader landscape)
+
+This doc's scope is **point-in-time SP500 / Russell 3000 membership**. For
+broader data-vendor questions — deep-history (Shiller, French), free
+cross-check (Stooq, Tiingo), commodities (World Bank, datahub.io) — see
+`dev/notes/deep-history-data-pointers-2026-05-16.md` and
+`memory/reference_deep_history_data_sources.md`. Highlights:
+
+- **Shillerdata.com** — free S&P monthly from **1871** (`ie_data.xls`).
+  Next-pursue for long-horizon index anchor + EODHD adjusted-close
+  cross-validation.
+- **Kenneth French Data Library** — free portfolio + factor returns from
+  **1926-07**. Synthesis target for pre-2006 backtests when real per-stock
+  data isn't available.
+- **Stooq** — free bulk EOD global. Pairs with manifest Phase 1 for
+  EODHD-vs-Stooq drift detection.
+- **CRSP-via-WRDS** is institutional-only and out of scope; Morningstar
+  acquired CRSP Feb 2026 (access terms in flux).
+
 ## Sources
 
 - EODHD pricing page (read 2026-05-16) — Fundamentals tier gating.

--- a/dev/reviews/pr-1136-prc-walk-forward-integration.md
+++ b/dev/reviews/pr-1136-prc-walk-forward-integration.md
@@ -1,0 +1,69 @@
+Reviewed SHA: e42892f2
+
+## Structural Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| H1 | dune build @fmt (format check) | PASS | |
+| H2 | dune build | PASS | |
+| H3 | dune runtest | PASS | 14 walk_forward-specific tests pass; full suite OK; no linter violations detected |
+| P1 | Functions ≤ 50 lines — covered by language-specific linter | PASS | fn_length_linter passed in H3 |
+| P2 | No magic numbers — covered by language-specific linter | PASS | magic-numbers linter passed; no hardcoded thresholds |
+| P3 | All configurable thresholds/periods/weights in config record | NA | No new tunable parameters introduced; integration code only |
+| P4 | Public-symbol export hygiene — `.mli` coverage | PASS | mli-coverage linter passed in H3; both `.mli` files fully document public surface (execute_spec, build_walk_forward, default_executor) |
+| P5 | Internal helpers prefixed per project convention | PASS | All internal functions in `.ml` files prefixed with underscore (`_run_one`, `_evaluate_one_pair`, `_evaluate_all`, `_candidate_label_for_iter`, `_build_two_variant_spec`, `_stability_to_metric_set`, `_score_or_fail`, `_sector_map_of_scenario`, `_test_days`, etc.) |
+| P6 | Tests conform to `.claude/rules/test-patterns.md` | PASS | 14 tests in test_bayesian_runner_evaluator.ml use `assert_that` + matcher composition (all_of, field, elements_are, size_is, is_some_and, float_equal); one `assert_equal` in stub setup only; no List.iter, no nested assert_that, no bare match-with-Error patterns. File opens Matchers; all assertions respect hierarchy rules |
+| A1 | Core module modifications (Portfolio/Orders/Position/Strategy/Engine) | PASS | No modifications to any core modules. Walk_forward_executor is a new library in backtest/; bayesian_runner_evaluator extends existing tuner_bin surface only |
+| A2 | No new `analysis/` imports into `trading/trading/` outside backtest exception | PASS | No imports from analysis/ anywhere. All imports respect boundaries: walk_forward depends on Core, Scenario_lib, Backtest, trading.simulation.types; bayesian_runner_evaluator depends on Tuner, Walk_forward, Backtest, Scenario_lib — all in-tree, no analysis/ deps |
+| A3 | No unnecessary modifications to existing (non-feature) modules | PASS | File diff shows only new files and targeted extensions: walk_forward_executor.{ml,mli} (new), walk_forward_runner.ml (refactored, test verified), bayesian_runner_evaluator.{ml,mli} (extended with walk_forward path, legacy path preserved), test_bayesian_runner_evaluator.ml (new 14 stub-DI tests). dev/status/tuning.md updated. No cross-feature drift |
+
+## Verdict
+
+APPROVED
+
+## Summary
+
+PR #1136 extracts in-process walk-forward CV orchestration out of the walk_forward_runner binary into a reusable Walk_forward_executor library, enabling the Bayesian Phase-3 tuner to drive walk-forward sweeps per BO iteration without spawning subprocesses. Bayesian_runner_evaluator is extended with a walk_forward path (build_walk_forward) alongside the legacy per-scenario path.
+
+**Structural observations:**
+- Both hard gates pass (dune build @fmt, dune build, dune runtest).
+- New walk_forward library is pure orchestration atop existing Backtest.Runner + Walk_forward_report — no new domain logic.
+- Executor abstraction enables fast unit tests via stub DI; production path threads through default_executor.
+- 14 new tests pin the walk-forward evaluator contract: correct score, candidate label increment, two-variant spec structure, executor invocation, metric_set projection, error propagation, gate penalty flow, and parameter threading.
+- All tests use Matchers library and assert_that compositions; no anti-patterns detected.
+- Legacy build surface in bayesian_runner_evaluator preserved until PR-E flips the binary.
+- No core module modifications, no analysis/ imports, no cross-feature contamination.
+- All internal helpers properly prefixed with underscore.
+
+This PR is structurally sound and ready for behavioral review.
+
+---
+
+# Behavioral QC — PR #1136 Bayesian Phase 3 PR-C (walk-forward integration)
+
+Date: 2026-05-16
+Reviewer: qc-behavioral
+
+## Contract Pinning Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| CP1 | Each non-trivial claim in new `.mli` docstrings has an identified test that pins it | PASS | `walk_forward_executor.mli` claims (per-fold loop, aggregate computed via `Walk_forward_report.compute`, sequential execution, no filesystem writes) are pinned by (a) `Walk_forward.Walk_forward_report` existing test suite (22 tests passing) since the executor's `_run_one`/`_evaluate_one_pair`/`_evaluate_all` are byte-identical to the prior in-binary loop verified against `bin/walk_forward_runner.ml` HEAD~1, and (b) the binary still produces the same three artefacts. `bayesian_runner_evaluator.mli` `build_walk_forward` claims (label = `bo-iter-N`, two-variant spec `[baseline; candidate]`, executor invoked once per call, scorer error → Failure, metric_set is one-element with stability stats, fixtures_root/base/gate/baseline_label/parameters threaded through) all pinned by tests 1–13 in `test_bayesian_runner_evaluator.ml`. `default_executor` exposed-type claim pinned by test 14. |
+| CP2 | Each claim in PR body "Test plan" sections has a corresponding test in the committed test file | PASS | PR body "Test plan" claims 14 tests; the committed `test_bayesian_runner_evaluator.ml` exposes exactly 14 named test cases. PR-body coverage map matches 1:1. |
+| CP3 | Pass-through / identity / invariant tests pin identity, not just size_is | PASS | Test 12 pins candidate overrides equal `GS.cell_to_overrides parameters` via `elements_are (List.map expected_overrides ~f:equal_to)` — identity, not just count. Test 3 pins both variant labels (`equal_to`) and the baseline's overrides emptiness (`size_is 0` — semantically correct, the baseline has *no* overrides by design). Test 11 pins baseline_label `equal_to "my-baseline"`. Test 10 pins gate fields via `equal_to`. "Byte-identical binary output" pass-through claim pinned indirectly by the 196 existing walk-forward tests continuing to pass. |
+| CP4 | Each guard called out explicitly in code docstrings has a test that exercises the guarded-against scenario | PASS | (a) `bayesian_runner_evaluator.mli` "Raises [Failure] when the scorer returns a [Status.Error]" → pinned by test 7. (b) `bayesian_runner_evaluator.ml:_stability_to_metric_set` "Missing variants are mapped to an empty metric_set rather than raising" → NOT directly tested, but this is an `.ml` comment not an `.mli` contract claim. FLAG-but-non-blocking. (c) `walk_forward_executor.mli` "Raises [Failure] when the underlying backtest raises, when the universe file is malformed, or when `Walk_forward_report.compute` finds no folds or a missing baseline" → propagation-only guards (no new try/with), thin pass-through; underlying primitives' tests already cover the raise paths. |
+
+## Behavioral Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| A1 | Core module modification is strategy-agnostic | NA | Pure infra / library / refactor PR; no core modules (Portfolio/Orders/Position/Strategy/Engine) touched. Per `.claude/rules/qc-behavioral-authority.md` §"When to skip this file entirely". |
+| S1–S6, L1–L4, C1–C3, T1–T4 | Weinstein domain checklist | NA | Pure infra / harness / refactor PR; domain checklist not applicable. |
+
+## Quality Score
+
+5 — Exemplary: clean library extraction with byte-identical preservation of prior binary behavior (verified by diff against `bin/walk_forward_runner.ml@HEAD~1`), 14 well-named unit tests that pin every PR-body claim 1:1 with a stub executor (no flaky backtest invocation), idiomatic matcher use (one `assert_that` per value, `field`/`all_of`/`elements_are` composition), correct injectable-executor seam for testability, and the deferred-to-PR-E scope is explicitly called out in both the `.mli` and the PR body. The plan §4 contract (in-process integration, two-variant spec per BO iteration, propagating Status.Error as Failure, projecting stability stats into one synthetic metric_set) is implemented faithfully.
+
+## Verdict
+
+APPROVED

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -44,6 +44,16 @@ READY_FOR_REVIEW
 
 ## Notes
 
+**2026-05-16 vendor-landscape pointers added.** Beyond the Phase 1.4 IWV
+work (point-in-time Russell membership), see
+`dev/notes/deep-history-data-pointers-2026-05-16.md` for the broader
+vendor catalog covering deep-history (Shiller 1871, Kenneth French 1926),
+free cross-check (Stooq, Tiingo), and commodities (World Bank Pink Sheet,
+datahub.io). **Next-pursue candidate: shillerdata.com ingest** — free,
+~200 LOC, unlocks long-horizon S&P index anchor + EODHD adjusted-close
+cross-validation. Companion memory:
+`memory/reference_deep_history_data_sources.md`.
+
 **2026-05-15 strategic pivot — track elevated to P0.** Per
 `dev/notes/next-session-priorities-2026-05-15.md`, broader-universe +
 longer-horizon survivorship-correct data is now the load-bearing


### PR DESCRIPTION
## Summary

- **New** `dev/notes/deep-history-data-pointers-2026-05-16.md` — vendor catalog covering deep-history (Shiller 1871, Kenneth French 1926), free cross-check (Stooq, Tiingo), and commodities (World Bank Pink Sheet, datahub.io). Shillerdata.com flagged as next-pursue (~200 LOC, free, S&P monthly anchor + EODHD adjusted-close validator).
- **Edit** `dev/notes/vendor-comparison-historical-universe-2026-05-16.md` — adjacent-vendor cross-reference section pointing at the new doc.
- **Edit** `dev/status/data-foundations.md` — Notes-top entry flagging the vendor-landscape pointers.
- **Edit** `dev/reviews/pr-1136-prc-walk-forward-integration.md` — append qc-behavioral checklist (APPROVED quality 5) below the qc-structural section.

## Test plan

- [x] No code touched; docs-only changes
- [x] Companion memory file at `~/.claude/.../memory/reference_deep_history_data_sources.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)