### PR TITLE
feat(manifest): CSV-layer manifest writer — Phase 1

### DIFF
--- a/trading/analysis/data/storage/manifest/bin/dune
+++ b/trading/analysis/data/storage/manifest/bin/dune
@@ -1,0 +1,5 @@
+(executable
+ (name manifest_inspect)
+ (public_name manifest_inspect)
+ (package storage)
+ (libraries core core_unix.sys_unix status storage.manifest))

--- a/trading/analysis/data/storage/manifest/bin/manifest_inspect.ml
+++ b/trading/analysis/data/storage/manifest/bin/manifest_inspect.ml
@@ -1,0 +1,171 @@
+(** [manifest_inspect <data-dir>] walks the L1/L2-sharded data directory and
+    prints an inventory summary: total symbols on disk, count of manifest
+    entries found, missing-manifest count (CSVs with no entry), stale-manifest
+    count (entry whose recorded sha256 disagrees with the current file hash), a
+    per-source breakdown, and the oldest/newest [fetched_at] across all entries.
+
+    Phase 1 does not yet wire manifest writes into [Csv_storage.save] — so the
+    expected baseline output on the existing cache is "0 manifests / N missing",
+    where N is the number of [<L1>/<L2>/<SYM>/data.csv] files. The CLI is
+    shipped so Phase 2 can use it as a probe / smoke-test once the writes are
+    integrated. *)
+
+open Core
+
+(* Walk [data_dir] and collect (shard_dir, csv_path) pairs.
+
+   Shape: [data_dir / <L1> / <L2> / <SYM> / data.csv]. Anything that doesn't
+   match the layout is ignored (e.g. [breadth/], [backtest_scenarios/],
+   [universes/] under [trading/test_data/]). *)
+let _is_shard_dir name = String.length name = 1
+
+let _scan_symbol_dir ~shard_dir ~sym_dir =
+  let csv = Filename.concat sym_dir "data.csv" in
+  if Stdlib.Sys.file_exists csv then Some (shard_dir, csv) else None
+
+let _scan_l2_shard l2_dir =
+  if not (Stdlib.Sys.is_directory l2_dir) then []
+  else
+    Stdlib.Sys.readdir l2_dir |> Array.to_list
+    |> List.filter_map ~f:(fun sym ->
+        let sym_dir = Filename.concat l2_dir sym in
+        if Stdlib.Sys.is_directory sym_dir then
+          _scan_symbol_dir ~shard_dir:l2_dir ~sym_dir
+        else None)
+
+let _scan_l1_shard l1_dir =
+  if not (Stdlib.Sys.is_directory l1_dir) then []
+  else
+    Stdlib.Sys.readdir l1_dir |> Array.to_list
+    |> List.filter ~f:_is_shard_dir
+    |> List.concat_map ~f:(fun l2 -> _scan_l2_shard (Filename.concat l1_dir l2))
+
+let _scan_data_dir data_dir =
+  if not (Stdlib.Sys.is_directory data_dir) then []
+  else
+    Stdlib.Sys.readdir data_dir
+    |> Array.to_list
+    |> List.filter ~f:_is_shard_dir
+    |> List.concat_map ~f:(fun l1 ->
+        _scan_l1_shard (Filename.concat data_dir l1))
+
+(* For each unique L1/L2 shard we discover, load its [manifest.sexp] (if any)
+   and tally entries by symbol. Returns a hashtable keyed by L2 shard
+   directory path -> (manifest option). *)
+let _load_manifests_per_shard csvs =
+  let shard_paths =
+    csvs |> List.map ~f:fst |> List.dedup_and_sort ~compare:String.compare
+  in
+  let table = Hashtbl.create (module String) in
+  List.iter shard_paths ~f:(fun shard ->
+      let mpath = Filename.concat shard "manifest.sexp" in
+      let m =
+        if Stdlib.Sys.file_exists mpath then
+          match Manifest.read ~path:mpath with
+          | Ok m -> Some m
+          | Error _ -> None
+        else None
+      in
+      Hashtbl.set table ~key:shard ~data:m);
+  table
+
+(* Returns [(sym, entry option, csv_path)] tuples. *)
+let _zip_csvs_with_manifest csvs shard_table =
+  List.map csvs ~f:(fun (shard, csv_path) ->
+      let sym = Filename.basename (Filename.dirname csv_path) in
+      let entry =
+        match Hashtbl.find shard_table shard with
+        | None | Some None -> None
+        | Some (Some m) -> Manifest.find m ~symbol:sym
+      in
+      (sym, entry, csv_path))
+
+type summary = {
+  total_symbols : int;
+  manifest_entries : int;
+  missing_manifests : int;
+  stale_manifests : int;
+  per_source : (string * int) list;
+  oldest_fetched_at : Time_ns.Alternate_sexp.t option;
+  newest_fetched_at : Time_ns.Alternate_sexp.t option;
+}
+
+let _is_stale (entry : Manifest.file_metadata) ~csv_path =
+  match Manifest.sha256_of_file ~path:csv_path with
+  | Error _ ->
+      false (* unreadable file is reported by missing/total count, not stale *)
+  | Ok actual -> not (String.equal actual entry.sha256)
+
+let _accumulate (sym, entry, csv_path) acc =
+  let entries, missing, stale, sources, oldest, newest = acc in
+  match entry with
+  | None ->
+      let _ = sym in
+      let _ = csv_path in
+      (entries, missing + 1, stale, sources, oldest, newest)
+  | Some (e : Manifest.file_metadata) ->
+      let stale' = if _is_stale e ~csv_path then stale + 1 else stale in
+      let sources' =
+        List.Assoc.find sources ~equal:String.equal e.source
+        |> Option.value ~default:0
+        |> fun n -> List.Assoc.add sources ~equal:String.equal e.source (n + 1)
+      in
+      let oldest' =
+        match oldest with
+        | None -> Some e.fetched_at
+        | Some o when Time_ns.( < ) e.fetched_at o -> Some e.fetched_at
+        | _ -> oldest
+      in
+      let newest' =
+        match newest with
+        | None -> Some e.fetched_at
+        | Some n when Time_ns.( > ) e.fetched_at n -> Some e.fetched_at
+        | _ -> newest
+      in
+      (entries + 1, missing, stale', sources', oldest', newest')
+
+let _summarize zipped =
+  let entries, missing, stale, sources, oldest, newest =
+    List.fold zipped ~init:(0, 0, 0, [], None, None) ~f:(fun acc x ->
+        _accumulate x acc)
+  in
+  {
+    total_symbols = List.length zipped;
+    manifest_entries = entries;
+    missing_manifests = missing;
+    stale_manifests = stale;
+    per_source =
+      List.sort sources ~compare:(fun (a, _) (b, _) -> String.compare a b);
+    oldest_fetched_at = oldest;
+    newest_fetched_at = newest;
+  }
+
+let _time_str = function
+  | None -> "<none>"
+  | Some t -> Sexp.to_string (Time_ns.Alternate_sexp.sexp_of_t t)
+
+let _print_summary s =
+  printf "Manifest inventory summary\n";
+  printf "  total_symbols      = %d\n" s.total_symbols;
+  printf "  manifest_entries   = %d\n" s.manifest_entries;
+  printf "  missing_manifests  = %d\n" s.missing_manifests;
+  printf "  stale_manifests    = %d\n" s.stale_manifests;
+  printf "  oldest_fetched_at  = %s\n" (_time_str s.oldest_fetched_at);
+  printf "  newest_fetched_at  = %s\n" (_time_str s.newest_fetched_at);
+  printf "  per_source:\n";
+  if List.is_empty s.per_source then printf "    (no manifest entries)\n"
+  else List.iter s.per_source ~f:(fun (src, n) -> printf "    %-20s %d\n" src n)
+
+let run ~data_dir =
+  let csvs = _scan_data_dir data_dir in
+  let shard_table = _load_manifests_per_shard csvs in
+  let zipped = _zip_csvs_with_manifest csvs shard_table in
+  let summary = _summarize zipped in
+  _print_summary summary
+
+let () =
+  let argv = Sys.get_argv () in
+  if Array.length argv <> 2 then (
+    prerr_endline "usage: manifest_inspect <data-dir>";
+    Stdlib.exit 2);
+  run ~data_dir:argv.(1)

--- a/trading/analysis/data/storage/manifest/lib/dune
+++ b/trading/analysis/data/storage/manifest/lib/dune
@@ -1,0 +1,6 @@
+(library
+ (name manifest)
+ (public_name storage.manifest)
+ (libraries core core_unix.time_ns_unix status)
+ (preprocess
+  (pps ppx_compare ppx_deriving.eq ppx_deriving.show ppx_sexp_conv)))

--- a/trading/analysis/data/storage/manifest/lib/manifest.ml
+++ b/trading/analysis/data/storage/manifest/lib/manifest.ml
@@ -1,0 +1,123 @@
+open Core
+
+(* Plain [Core.Time_ns.t] is sexp-deprecated as of 2021-03; the two
+   replacements are [Time_ns_unix] (local-zone-aware) and
+   [Time_ns.Alternate_sexp] (UTC ISO-8601). We use [Alternate_sexp] because
+   [Time_ns_unix.sexp_of_t] reads [/etc/localtime] at first call, which is
+   missing inside dune's test sandbox and was tripping the round-trip tests
+   even though the file exists at container scope. UTC also gives a stable
+   on-disk form that diff'ing is meaningful for. *)
+type time_ns = Time_ns.Alternate_sexp.t [@@deriving sexp, compare, equal]
+
+type file_metadata = {
+  symbol : string;
+  source : string;
+  endpoint : string;
+  date_range : (Date.t * Date.t) option; [@sexp.option]
+  rows_count : int;
+  sha256 : string;
+  vendor_revision_tag : string;
+  fetched_at : time_ns;
+  fetch_id : string;
+  api_key_id : string;
+}
+[@@deriving sexp, compare, equal]
+
+type t = {
+  schema_version : int;
+  created_at : time_ns;
+  last_updated : time_ns;
+  entries : file_metadata list;
+}
+[@@deriving sexp]
+
+let current_schema_version = 1
+
+let create ?(entries = []) () =
+  let now = Time_ns.now () in
+  {
+    schema_version = current_schema_version;
+    created_at = now;
+    last_updated = now;
+    entries;
+  }
+
+let _atomic_write_sexp ~path sexp =
+  let tmp_path = path ^ ".tmp" in
+  try
+    Out_channel.write_all tmp_path ~data:(Sexp.to_string_hum sexp);
+    Stdlib.Sys.rename tmp_path path;
+    Ok ()
+  with Sys_error msg | Failure msg ->
+    (try Stdlib.Sys.remove tmp_path with _ -> ());
+    Status.error_internal (Printf.sprintf "Manifest.write: %s" msg)
+
+let write ~path t = _atomic_write_sexp ~path (sexp_of_t t)
+
+let _decode_sexp ~path =
+  try
+    let sexp = Sexp.load_sexp path in
+    Ok (t_of_sexp sexp)
+  with
+  | Sys_error msg | Failure msg ->
+      Status.error_internal (Printf.sprintf "Manifest.read: %s" msg)
+  | Sexp.Of_sexp_error (exn, _) ->
+      Status.error_internal
+        (Printf.sprintf "Manifest.read: sexp decode: %s" (Exn.to_string exn))
+
+let _check_schema_version t ~path =
+  if t.schema_version <> current_schema_version then
+    Error
+      Status.
+        {
+          code = Failed_precondition;
+          message =
+            Printf.sprintf "Manifest.read: %s schema_version=%d expected %d"
+              path t.schema_version current_schema_version;
+        }
+  else Ok t
+
+let read ~path =
+  if not (Stdlib.Sys.file_exists path) then
+    Status.error_not_found
+      (Printf.sprintf "Manifest.read: %s does not exist" path)
+  else
+    match _decode_sexp ~path with
+    | Error _ as e -> e
+    | Ok t -> _check_schema_version t ~path
+
+let _replace_or_mark entries entry =
+  let replaced = ref false in
+  let mapped =
+    List.map entries ~f:(fun e ->
+        if String.equal e.symbol entry.symbol then (
+          replaced := true;
+          entry)
+        else e)
+  in
+  (mapped, !replaced)
+
+let upsert_entry t entry =
+  let mapped, replaced = _replace_or_mark t.entries entry in
+  let entries = if replaced then mapped else mapped @ [ entry ] in
+  { t with entries; last_updated = Time_ns.now () }
+
+(* Stream the file in [chunk_size] blocks so even multi-GB CSVs hash without
+   pulling everything into memory. Stdlib.Digest's [channel] helper handles
+   this; the explicit chunk variant is only here for unit-test
+   parity. *)
+let _hash_channel chan = Stdlib.Digest.to_hex (Stdlib.Digest.channel chan (-1))
+
+let sha256_of_file ~path =
+  if not (Stdlib.Sys.file_exists path) then
+    Status.error_not_found
+      (Printf.sprintf "Manifest.sha256_of_file: %s does not exist" path)
+  else
+    try
+      let hex = In_channel.with_file path ~binary:true ~f:_hash_channel in
+      Ok hex
+    with Sys_error msg ->
+      Status.error_internal (Printf.sprintf "Manifest.sha256_of_file: %s" msg)
+
+let find t ~symbol =
+  List.find t.entries ~f:(fun e -> String.equal e.symbol symbol)

--- a/trading/analysis/data/storage/manifest/lib/manifest.ml
+++ b/trading/analysis/data/storage/manifest/lib/manifest.ml
@@ -65,16 +65,16 @@ let _decode_sexp ~path =
       Status.error_internal
         (Printf.sprintf "Manifest.read: sexp decode: %s" (Exn.to_string exn))
 
+let _schema_version_error ~path ~got =
+  let message =
+    Printf.sprintf "Manifest.read: %s schema_version=%d expected %d" path got
+      current_schema_version
+  in
+  Status.{ code = Failed_precondition; message }
+
 let _check_schema_version t ~path =
   if t.schema_version <> current_schema_version then
-    Error
-      Status.
-        {
-          code = Failed_precondition;
-          message =
-            Printf.sprintf "Manifest.read: %s schema_version=%d expected %d"
-              path t.schema_version current_schema_version;
-        }
+    Error (_schema_version_error ~path ~got:t.schema_version)
   else Ok t
 
 let read ~path =

--- a/trading/analysis/data/storage/manifest/lib/manifest.mli
+++ b/trading/analysis/data/storage/manifest/lib/manifest.mli
@@ -1,0 +1,126 @@
+(** CSV-layer manifest for the trading-system data cache.
+
+    Phase 1 of {b dev/plans/data-inventory-and-reproducibility-2026-05-02.md}.
+    The manifest captures per-symbol fetch provenance for every cached CSV under
+    [data/<L1>/<L2>/<SYM>/data.csv]: source, endpoint, date range, row count,
+    content hash, vendor revision tag, fetch timestamp, request id and API key
+    id.
+
+    {2 Sharding}
+
+    Manifests are stored {b distributed by L1/L2 shard}. For a data root
+    [cache-root/], the manifest for symbols sharing the same first/last
+    character lives at [cache-root/<L1>/<L2>/manifest.sexp]. This mirrors the
+    existing CSV layout (the per-symbol CSV is at
+    [cache-root/<L1>/<L2>/<SYM>/data.csv]) and bounds the worst-case contention
+    to 26 x 26 = 676 manifests so concurrent fetches across different shards do
+    not race.
+
+    {2 Hash algorithm}
+
+    The [sha256] field is named for the long-term intent; the v1 implementation
+    uses {b MD5} via [Stdlib.Digest] because the in-container opam set does not
+    include a SHA-256 library. MD5 is sufficient for detecting accidental
+    corruption or unintended overwrites (the threat model Phase 2 hash-verify
+    will enforce) but is {b not} cryptographically secure. A follow-up should
+    swap the implementation to true SHA-256 once [digestif] (or equivalent) is
+    added to the toolchain; the field name and on-disk format stay the same so
+    existing manifests continue to read.
+
+    {2 Timestamps}
+
+    [fetched_at], [created_at] and [last_updated] are serialized in UTC ISO-8601
+    via [Time_ns.Alternate_sexp] rather than [Time_ns_unix]. The [Time_ns_unix]
+    sexp converter resolves the local timezone at first call, which requires
+    [/etc/localtime] to be present in the executing environment; this caused
+    round-trip failures inside dune's test sandbox. The UTC form also keeps
+    shard manifests diff-friendly across hosts. *)
+
+open Core
+
+type file_metadata = {
+  symbol : string;  (** Vendor ticker, e.g. ["AAPL.US"]. *)
+  source : string;
+      (** Data provider tag, e.g. ["EODHD"], ["shiller"], ["stooq"]. Free-form
+          string; per-source vocabulary lives in the source's ingest module. *)
+  endpoint : string;
+      (** API endpoint or URL pattern the row was fetched from, e.g.
+          ["/eod/AAPL.US"]. Free-form string. *)
+  date_range : (Date.t * Date.t) option; [@sexp.option]
+      (** First and last bar dates in the CSV, inclusive. [None] when the source
+          is empty or the writer did not record a range. *)
+  rows_count : int;  (** Number of OHLCV rows in the CSV. *)
+  sha256 : string;
+      (** Hex digest of the CSV file contents at [fetched_at]. See module-level
+          docstring for the v1 MD5 vs. long-term SHA-256 distinction. *)
+  vendor_revision_tag : string;
+      (** Vendor-side revision identifier when available (e.g. an [As-Of-Date]
+          header, or an EODHD adjusted-close revision string). [""] when
+          unavailable; in that case the [fetched_at] timestamp is the only
+          revision proxy. *)
+  fetched_at : Time_ns.t;
+      (** Wall-clock timestamp at which the fetch completed and the CSV was
+          written. *)
+  fetch_id : string;
+      (** Local fetch/request identifier — useful for cross-referencing the
+          fetch_log (Phase 3). [""] permitted when the call site has no id. *)
+  api_key_id : string;
+      (** Identifier (not the secret) of the API key that issued the fetch, e.g.
+          ["eodhd-prod"]. Audit-only; safe to store in plaintext. *)
+}
+[@@deriving sexp, compare, equal]
+(** Per-symbol provenance record. *)
+
+type t = {
+  schema_version : int;
+      (** Bumped on incompatible changes to {!file_metadata}. Readers check this
+          before decoding the entries. *)
+  created_at : Time_ns.t;  (** Time the manifest file was first created. *)
+  last_updated : Time_ns.t;
+      (** Time of the most recent {!upsert_entry} + {!write}. *)
+  entries : file_metadata list;
+      (** Per-symbol entries within this shard. Order is the order
+          {!upsert_entry} produced (insertion-at-tail; replacements preserve
+          position). *)
+}
+[@@deriving sexp]
+(** Shard-level manifest, one per [<L1>/<L2>] directory. *)
+
+val current_schema_version : int
+(** [current_schema_version] is the {!t.schema_version} value emitted by
+    {!create}. Tests pin this to detect accidental schema drift. *)
+
+val create : ?entries:file_metadata list -> unit -> t
+(** [create ~entries ()] builds a fresh manifest at the current [schema_version]
+    with [created_at = last_updated = Time_ns.now ()] and the given entries
+    (default: empty). *)
+
+val write : path:string -> t -> unit Status.status_or
+(** [write ~path t] serializes [t] to [path] using [Sexp.to_string_hum] for
+    diff-friendly output. Writes via a [.tmp] sibling and [Stdlib.Sys.rename] so
+    a crashed writer never produces a torn manifest. Returns [Error Internal] on
+    filesystem error. *)
+
+val read : path:string -> t Status.status_or
+(** [read ~path] deserializes a manifest. Returns
+    - [Error NotFound] if [path] does not exist;
+    - [Error Internal] on parse failure or filesystem error;
+    - [Error Failed_precondition] when the file's [schema_version] does not
+      match {!current_schema_version}. The mismatch message includes both
+      versions so the caller can decide whether to upgrade or refetch. *)
+
+val upsert_entry : t -> file_metadata -> t
+(** [upsert_entry t entry] returns a manifest in which [entry] replaces any
+    existing record for [entry.symbol], or is appended at the tail when no prior
+    entry exists. [last_updated] is refreshed to [Time_ns.now ()]. Pure apart
+    from the clock read; does not touch disk. *)
+
+val sha256_of_file : path:string -> string Status.status_or
+(** [sha256_of_file ~path] computes the hex digest of the file at [path]. v1
+    uses MD5 (32 hex chars) per the module docstring. Returns [Error NotFound]
+    when [path] is missing; [Error Internal] on read failure. *)
+
+val find : t -> symbol:string -> file_metadata option
+(** [find t ~symbol] returns the entry for [symbol] or [None]. O(N) in entry
+    count; per-shard manifests max out around 62 entries on average so a linear
+    scan is fine. *)

--- a/trading/analysis/data/storage/manifest/test/dune
+++ b/trading/analysis/data/storage/manifest/test/dune
@@ -1,0 +1,10 @@
+(test
+ (name test_manifest)
+ (libraries
+  core
+  core_unix.filename_unix
+  core_unix.time_ns_unix
+  matchers
+  ounit2
+  status
+  storage.manifest))

--- a/trading/analysis/data/storage/manifest/test/test_manifest.ml
+++ b/trading/analysis/data/storage/manifest/test/test_manifest.ml
@@ -1,0 +1,223 @@
+open Core
+open OUnit2
+open Matchers
+open Manifest
+
+(* Use [Alternate_sexp] for parity with the manifest's on-disk form so the
+   round-trip equality check compares the exact same int64-nanos value the
+   serializer wrote. The serializer emits ["YYYY-MM-DD HH:MM:SSZ"] (UTC,
+   space separator). *)
+let _sample_fetched_at =
+  Time_ns.Alternate_sexp.t_of_sexp (Sexp.Atom "2026-05-17 10:31:14Z")
+
+let _sample_date_from = Date.create_exn ~y:2026 ~m:Month.Jan ~d:1
+let _sample_date_to = Date.create_exn ~y:2026 ~m:Month.May ~d:17
+
+let _sample_entry ?(symbol = "AAPL.US") ?(rows_count = 100)
+    ?(sha256 = "deadbeef00000000deadbeef00000000") () =
+  {
+    symbol;
+    source = "EODHD";
+    endpoint = "/eod/" ^ symbol;
+    date_range = Some (_sample_date_from, _sample_date_to);
+    rows_count;
+    sha256;
+    vendor_revision_tag = "2026-05-16";
+    fetched_at = _sample_fetched_at;
+    fetch_id = "req-1c8f3d4e";
+    api_key_id = "eodhd-prod";
+  }
+
+let _with_tmp_file ~contents f =
+  let path =
+    Filename_unix.temp_file ~in_dir:Filename.temp_dir_name "manifest_test"
+      ".bin"
+  in
+  Out_channel.write_all path ~data:contents;
+  Exn.protect
+    ~f:(fun () -> f path)
+    ~finally:(fun () -> try Stdlib.Sys.remove path with _ -> ())
+
+let _with_tmp_path f =
+  let path =
+    Filename_unix.temp_file ~in_dir:Filename.temp_dir_name "manifest" ".sexp"
+  in
+  (* [Filename.temp_file] creates an empty file; some tests want a missing
+     path so they remove it up front and rely on the cleanup below. *)
+  (try Stdlib.Sys.remove path with _ -> ());
+  Exn.protect
+    ~f:(fun () -> f path)
+    ~finally:(fun () -> try Stdlib.Sys.remove path with _ -> ())
+
+(* {1 [create]} *)
+
+let test_create_empty _ =
+  let m = create () in
+  assert_that m
+    (all_of
+       [
+         field (fun m -> m.schema_version) (equal_to current_schema_version);
+         field (fun m -> List.length m.entries) (equal_to 0);
+       ])
+
+let test_create_with_entries _ =
+  let entry = _sample_entry () in
+  let m = create ~entries:[ entry ] () in
+  assert_that m.entries (elements_are [ equal_to entry ])
+
+(* {1 [upsert_entry]} *)
+
+let test_upsert_appends_new_entry _ =
+  let m = create () in
+  let e1 = _sample_entry ~symbol:"AAPL.US" () in
+  let m' = upsert_entry m e1 in
+  assert_that m'.entries (elements_are [ equal_to e1 ])
+
+let test_upsert_replaces_existing_symbol_in_place _ =
+  let e1 = _sample_entry ~symbol:"AAPL.US" ~rows_count:100 () in
+  let e2 = _sample_entry ~symbol:"MSFT.US" ~rows_count:50 () in
+  let e1_updated = _sample_entry ~symbol:"AAPL.US" ~rows_count:200 () in
+  let m = create ~entries:[ e1; e2 ] () in
+  let m' = upsert_entry m e1_updated in
+  (* AAPL is replaced in place at index 0; MSFT stays at index 1. *)
+  assert_that m'.entries (elements_are [ equal_to e1_updated; equal_to e2 ])
+
+let test_upsert_is_idempotent_for_identical_entry _ =
+  let e = _sample_entry () in
+  let m = upsert_entry (create ()) e in
+  let m' = upsert_entry m e in
+  assert_that m'.entries (elements_are [ equal_to e ])
+
+(* {1 [find]} *)
+
+let test_find_returns_some_when_symbol_present _ =
+  let e = _sample_entry ~symbol:"AAPL.US" () in
+  let m = create ~entries:[ e ] () in
+  assert_that (find m ~symbol:"AAPL.US") (is_some_and (equal_to e))
+
+let test_find_returns_none_when_symbol_absent _ =
+  let m = create ~entries:[ _sample_entry ~symbol:"AAPL.US" () ] () in
+  assert_that (find m ~symbol:"MSFT.US") is_none
+
+(* {1 [write] + [read] round-trip} *)
+
+let test_write_then_read_round_trip _ =
+  let entries =
+    [
+      _sample_entry ~symbol:"AAPL.US" ();
+      _sample_entry ~symbol:"MSFT.US" ~rows_count:42 ();
+    ]
+  in
+  let m = create ~entries () in
+  _with_tmp_path (fun path ->
+      let result =
+        match write ~path m with Error e -> Error e | Ok () -> read ~path
+      in
+      assert_that result
+        (is_ok_and_holds
+           (all_of
+              [
+                field
+                  (fun r -> r.schema_version)
+                  (equal_to current_schema_version);
+                field
+                  (fun r -> r.entries)
+                  (elements_are (List.map entries ~f:equal_to));
+              ])))
+
+(* Writing an entry without a [date_range] exercises the [@sexp.option] path
+   so we know an absent field decodes back to [None] cleanly. *)
+let test_round_trip_preserves_none_date_range _ =
+  let entry = { (_sample_entry ()) with date_range = None } in
+  let m = create ~entries:[ entry ] () in
+  _with_tmp_path (fun path ->
+      let result =
+        match write ~path m with Error e -> Error e | Ok () -> read ~path
+      in
+      assert_that result
+        (is_ok_and_holds
+           (field (fun r -> r.entries) (elements_are [ equal_to entry ]))))
+
+(* {1 [read] error paths} *)
+
+let test_read_missing_path_returns_not_found _ =
+  let result = read ~path:"/tmp/manifest_test_does_not_exist_12345.sexp" in
+  assert_that result (is_error_with Status.NotFound)
+
+(* A manifest written with a different [schema_version] must be rejected so
+   downstream readers do not silently mis-decode evolving schemas. The cleanest
+   way to forge a future-version manifest is to write a valid one and then
+   bump the version field in the sexp file directly — that way the rest of
+   the record (timestamps in whatever local-zone form Time_ns_unix produced)
+   continues to parse and only the version field trips the check. *)
+let test_read_rejects_mismatched_schema_version _ =
+  _with_tmp_path (fun path ->
+      let m = create () in
+      (match write ~path m with
+      | Ok () -> ()
+      | Error e -> assert_failure ("write failed: " ^ Status.show e));
+      let original = In_channel.read_all path in
+      let bumped =
+        String.substr_replace_first original
+          ~pattern:(Printf.sprintf "(schema_version %d)" current_schema_version)
+          ~with_:"(schema_version 99)"
+      in
+      Out_channel.write_all path ~data:bumped;
+      let result = read ~path in
+      assert_that result (is_error_with Status.Failed_precondition))
+
+(* {1 [sha256_of_file]} *)
+
+(* MD5 of the empty string per RFC 1321 §A.5 is "d41d8cd98f00b204e9800998ecf8427e".
+   Pinning this value catches the case where the hash algorithm is silently
+   swapped (e.g. to a real SHA-256 producing a 64-hex digest of zero bytes
+   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"). The
+   field name is [sha256] aspirationally; v1 is MD5. *)
+let test_sha256_of_empty_file _ =
+  _with_tmp_file ~contents:"" (fun path ->
+      let result = sha256_of_file ~path in
+      assert_that result
+        (is_ok_and_holds (equal_to "d41d8cd98f00b204e9800998ecf8427e")))
+
+(* MD5 of "hello world" per the RFC 1321 reference implementation is
+   "5eb63bbbe01eeed093cb22bb8f5acdc3". *)
+let test_sha256_of_known_content _ =
+  _with_tmp_file ~contents:"hello world" (fun path ->
+      let result = sha256_of_file ~path in
+      assert_that result
+        (is_ok_and_holds (equal_to "5eb63bbbe01eeed093cb22bb8f5acdc3")))
+
+let test_sha256_missing_path_returns_not_found _ =
+  let result =
+    sha256_of_file ~path:"/tmp/manifest_sha_test_does_not_exist_67890.csv"
+  in
+  assert_that result (is_error_with Status.NotFound)
+
+let suite =
+  "manifest_test_suite"
+  >::: [
+         "test_create_empty" >:: test_create_empty;
+         "test_create_with_entries" >:: test_create_with_entries;
+         "test_upsert_appends_new_entry" >:: test_upsert_appends_new_entry;
+         "test_upsert_replaces_existing_symbol_in_place"
+         >:: test_upsert_replaces_existing_symbol_in_place;
+         "test_upsert_is_idempotent_for_identical_entry"
+         >:: test_upsert_is_idempotent_for_identical_entry;
+         "test_find_returns_some_when_symbol_present"
+         >:: test_find_returns_some_when_symbol_present;
+         "test_find_returns_none_when_symbol_absent"
+         >:: test_find_returns_none_when_symbol_absent;
+         "test_write_then_read_round_trip" >:: test_write_then_read_round_trip;
+         "test_round_trip_preserves_none_date_range"
+         >:: test_round_trip_preserves_none_date_range;
+         "test_read_missing_path_returns_not_found"
+         >:: test_read_missing_path_returns_not_found;
+         "test_read_rejects_mismatched_schema_version"
+         >:: test_read_rejects_mismatched_schema_version;
+         "test_sha256_of_empty_file" >:: test_sha256_of_empty_file;
+         "test_sha256_of_known_content" >:: test_sha256_of_known_content;
+         "test_sha256_missing_path_returns_not_found"
+         >:: test_sha256_missing_path_returns_not_found;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Phase 1 of `dev/plans/data-inventory-and-reproducibility-2026-05-02.md`. Foundational module for data integrity across the 41,575-symbol cache.

## What changed

- New `analysis/data/storage/manifest/{lib,bin,test}/` module (~600 LOC)
- `manifest.{ml,mli}` — read/write/upsert/inspect of per-shard `manifest.sexp` files
- `manifest_inspect.exe` — CLI: prints inventory summary (total symbols, oldest/newest fetch, missing/stale counts, per-source breakdown)
- Schema: `symbol`, `source`, `endpoint`, `date_range`, `rows_count`, `sha256`, `vendor_revision_tag`, `fetched_at`, `fetch_id`, `api_key_id`

## Sharding decision

Per-shard manifest at `data/<L1>/<L2>/manifest.sexp` — matches existing 41k-symbol sharding, no global mutex on concurrent fetches.

## Out of scope (Phase 2 / 3)

- Wiring manifest writes into `csv_storage.save` — Phase 2
- Hash-verify on load — Phase 2
- Reconcile-on-refetch diff log — Phase 3

## Test plan

- [x] dune build clean
- [x] dune runtest analysis/data/storage/manifest — 14 tests pass
- [x] dune build @fmt clean (after one auto-promote)
- [x] No `trading/trading/` imports (pure storage layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)