### PR TITLE
feat(tuning): Bayesian Phase 3 PR-E — end-to-end runner + OOS holdout validator

### DIFF
--- a/dev/experiments/bayesian-multi-param-2026-05-17/hypothesis.md
+++ b/dev/experiments/bayesian-multi-param-2026-05-17/hypothesis.md
@@ -1,0 +1,152 @@
+# Bayesian multi-parameter optimisation — pre-registered hypothesis
+
+## Date
+
+2026-05-17
+
+## Authority
+
+`dev/plans/bayesian-multi-param-scaling-2026-05-16.md` §6 (validation
+acceptance criterion). Predecessor PRs that produced this run's
+ingredients:
+
+- PR #1126 (PR-A) — scoring function + walk-forward aggregate consumer
+- PR #1132 (PR-B) — knob inventory + 11-knob parameter space
+- PR #1136 (PR-C) — walk-forward in-process integration
+- PR #1143 (PR-D) — length-scale + early-stop + Option encoding
+- PR-E (this PR) — end-to-end runner + OOS holdout validator
+
+## Hypothesis
+
+> The Phase-3 Bayesian optimiser on the 11-knob curated surface (PR-B
+> bounds) converges to a cell whose mean walk-forward Sharpe on the
+> 26 in-sample folds (1..26) of `cell_e_30fold_2026_05_16.sexp`
+> exceeds Cell E's by ≥0.05 with MaxDD no worse by more than 1pp,
+> AND whose out-of-sample mean Sharpe on the 4 held-out folds
+> (27..30) is within 0.10 of the in-sample mean Sharpe.
+
+The hypothesis is **pre-registered** before any production sweep. The
+production sweep itself is an ops-session deliverable per plan §10 —
+this experiment file pins the acceptance criteria so the verdict
+cannot be retrofitted to a post-hoc result.
+
+## Setup
+
+| Lever | Value |
+|---|---|
+| BO spec | `trading/test_data/tuner/bayesian-multi-param-2026-05-16.sexp` |
+| Walk-forward spec | `trading/test_data/walk_forward/cell_e_30fold_2026_05_16.sexp` |
+| Universe | sp500-2010-2026 (`goldens-sp500-historical/sp500-2010-2026.sexp`) |
+| Knob count | 11 (Tracks A/B/D/E per plan §2.1) |
+| Initial random samples | 25 |
+| Total budget | 100 BO iterations (~25 wall-clock hours) |
+| Acquisition | Expected_improvement |
+| GP length-scales | default (~`sqrt(d) * 0.25`) |
+| Early-stop | disabled in v1 (plan §5.4) |
+| Seed | 2026 |
+| Baseline | Cell E (no-op overrides on `cell_e_30fold_2026_05_16` baseline) |
+| Holdout folds | (27 28 29 30) — last ~13% of the 30-fold spec |
+| Score formula | `mean_sharpe(cell) - λ_dd * max(0, excess_maxdd) - λ_gate * gate_penalty` (plan §3.1; PR-A) |
+
+## Acceptance criteria (per plan §6)
+
+### In-sample (§6.1)
+
+The best cell's mean walk-forward Sharpe (over folds 1..26) must:
+
+1. **Beat Cell E by ≥0.05 Sharpe.**
+   - Cell E baseline mean Sharpe on folds 1..26: TBD (read from the
+     baseline aggregate produced by running Cell E through the full
+     spec).
+2. **MaxDD no worse than Cell E by more than 1pp.**
+3. **Pass the M-of-N gate** (Sharpe, M=17, N=30, worst_delta=0.30 —
+   per the walk-forward spec).
+
+### Out-of-sample (§6.2 + §6.3 — no-overfit hurdle)
+
+After in-sample acceptance, re-run the best cell on the held-out folds
+(27..30) and confirm:
+
+4. **OOS mean Sharpe is within 0.10 of in-sample mean Sharpe**
+   (`abs(oos_mean_sharpe - in_sample_mean_sharpe) <= 0.10`).
+
+A gap > 0.10 signals the BO over-fit the in-sample folds; the cell is
+rejected for production pinning regardless of how strong the in-sample
+result is. This guardrail is the discipline shift from prior M5.5
+sweeps that landed winners on a single window without an OOS check —
+several of which (axis-1 ×2 cross sweep 2026-05-14, continuation-
+combined 2026-05-14) failed 16y validation despite winning the short
+window. The PR-E OOS validator emits `oos_report.md` automating this
+check.
+
+## Falsification criteria
+
+The hypothesis is **not supported** if any of:
+
+1. The BO budget exhausts (100 iterations) without producing a cell
+   that meets in-sample criterion (1) — the best cell improves Sharpe
+   by <0.05, OR improves Sharpe but worsens MaxDD by >1pp, OR fails
+   the M-of-N gate.
+2. The best cell meets in-sample criteria 1-3 but fails the no-overfit
+   hurdle (criterion 4): `|OOS - in-sample| > 0.10`.
+3. The BO converges to a degenerate cell — one whose mean Sharpe is
+   driven by the gate penalty hinge (e.g. `-9.x` score from a Fail
+   verdict). The `oos_report.md` shows `Reject_insufficient_data`
+   verdict when no OOS folds match (operational failure mode, not a
+   strategy failure).
+
+Any of these falsifications is itself a useful finding: the 11-knob
+curated surface (which deliberately omits Tracks C and the
+Option-typed knobs) does not contain a cell that beats Cell E on both
+in-sample and held-out folds. The follow-up is plan §10's "Path A
+(extend the in-house GP) + Path B (random-search-only mode)"
+fork-choice question, with the random-search baseline run as a
+sanity-check on whether the surface itself is the limiting factor.
+
+## What this experiment does NOT prove
+
+- It does not prove Cell E is optimal on the surface; the curated
+  11-knob surface excludes Track C (stage classifier) entirely. A
+  cell beating Cell E on Tracks A/B/D/E is consistent with another
+  cell, on the full 18+ knob surface, beating it by more.
+- It does not prove the strategy generalises beyond 2010-2026. The
+  Russell-3000 pre-2010 universe is a Phase-1 follow-up (per plan §10
+  "Out of scope"); when that lands, this experiment should be re-run
+  on the wider window before re-pinning Cell F.
+- It does not prove the `λ_dd = 0.10` hyperparameter is correct.
+  λ_dd is the operator-policy MaxDD-vs-Sharpe trade-off; a different
+  value produces a different optimum even on the same surface. Plan
+  §3.1 fixes λ_dd at 0.10 for v1; a follow-up may sweep.
+
+## Run plan
+
+The actual sweep is an ops-session deliverable per plan §10. This
+hypothesis file is committed alongside PR-E. The sweep run produces
+`out_dir/oos_report.md` whose verdict block plus the in-sample/OOS
+gap is the experiment's report.
+
+## How the verdict is logged
+
+Once the BO has run and PR-E emitted `oos_report.md`:
+
+- If `Accept`: pin the best cell as Cell F in a follow-up PR, then
+  re-run the 15y golden against it for the long-window check.
+- If `Reject_overfit`: file an issue noting which knobs the BO moved
+  and which holdout fold(s) drove the gap; consider whether the BO
+  surface needs further curation OR whether random-search is the
+  better path.
+- If `Reject_insufficient_data`: operational failure (no holdout folds
+  matched); fix the spec's `holdout_folds` and re-run.
+
+## Reproducibility
+
+- BO seed pinned to 2026 in `bayesian-multi-param-2026-05-16.sexp`.
+- Walk-forward spec pinned via `cell_e_30fold_2026_05_16.sexp`.
+- Universe pinned via the baseline scenario sexp (which itself pins
+  the 2026-05-13 510-symbol roster).
+- All PR-A through PR-E commits land on `main` before the sweep.
+
+Re-running the sweep with the same inputs is byte-deterministic per
+the BO library's determinism contract (`bayesian_opt.mli` §"Pinned by
+test_determinism_same_seed_same_sequence"). The OOS validator is
+pure (no I/O during scoring); same fold_actuals → same verdict.

--- a/trading/trading/backtest/tuner/bin/bayesian_runner.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner.ml
@@ -1,18 +1,30 @@
 (** Bayesian-optimisation CLI — wires {!Tuner.Bayesian_opt}'s ask/tell loop to a
     {!Backtest.Runner.run_backtest}-backed evaluator. Reads a spec sexp file
     describing per-parameter bounds, the acquisition function, the objective to
-    maximise, and the list of scenario sexp files to evaluate each suggested
-    point against; writes [bo_log.csv], [best.sexp], and [convergence.md] under
-    the requested output directory.
+    maximise, and either:
+
+    - the list of scenario sexp files to evaluate each suggested point against
+      (legacy per-scenario mode), or
+    - a walk-forward spec + a baseline aggregate.sexp (Phase-3 walk-forward
+      mode, per plan §7 PR-E of
+      [dev/plans/bayesian-multi-param-scaling-2026-05-16.md]).
+
+    Writes [bo_log.csv], [best.sexp], and [convergence.md] in both modes; the
+    walk-forward mode additionally writes [oos_report.md] after the BO
+    converges, by re-running the walk-forward executor on the best cell and
+    feeding the per-fold results to
+    {!Tuner_bin.Bayesian_runner_oos_validator.validate}.
 
     Usage:
 
     {v
       bayesian_runner.exe --spec <spec.sexp> --out-dir <dir>
                           [--fixtures-root <path>]
+                          [--walk-forward-spec <spec.sexp>
+                           --baseline-aggregate <aggregate.sexp>]
     v}
 
-    [--spec] — path to a sexp file in the shape declared by
+    [--spec] — path to a Bayesian spec sexp file in the shape declared by
     {!Tuner_bin.Bayesian_runner_spec.t}. The example shape is documented in that
     module's [.mli].
 
@@ -21,7 +33,19 @@
     [--fixtures-root] — directory each scenario's [universe_path] is resolved
     against. Defaults to [TRADING_DATA_DIR/backtest_scenarios] via
     {!Scenario_lib.Fixtures_root.resolve}, matching [scenario_runner.exe] and
-    [grid_search.exe]. *)
+    [grid_search.exe].
+
+    [--walk-forward-spec] and [--baseline-aggregate] — when both are supplied,
+    the binary switches to walk-forward mode: each BO suggestion drives one
+    walk-forward CV sweep via
+    {!Tuner_bin.Bayesian_runner_evaluator.build_walk_forward}, scored by
+    {!Tuner_bin.Bayesian_runner_scoring.score_cell} against the supplied
+    [baseline_aggregate]. After the BO completes, the binary re-runs the best
+    cell on the full window and partitions the per-fold results against the BO
+    spec's [holdout_folds] for OOS validation. The Bayesian spec's own
+    [scenarios] list is ignored in walk-forward mode (the production fixture
+    leaves it empty); the binary synthesises a single "walk-forward" scenario
+    label for the [bo_log.csv] writer's per-row column. *)
 
 open Core
 module Scenario = Scenario_lib.Scenario
@@ -29,29 +53,58 @@ module Fixtures_root = Scenario_lib.Fixtures_root
 module Spec = Tuner_bin.Bayesian_runner_spec
 module Evaluator = Tuner_bin.Bayesian_runner_evaluator
 module Runner = Tuner_bin.Bayesian_runner_runner
+module Wf_spec = Walk_forward.Spec
+module Wf_executor = Walk_forward.Walk_forward_executor
+module Wf_report = Walk_forward.Walk_forward_report
+module Oos_validator = Tuner_bin.Bayesian_runner_oos_validator
 
 let _usage_msg =
-  "Usage: bayesian_runner.exe --spec <spec.sexp> --out-dir <dir> \
-   [--fixtures-root <path>]"
+  "Usage: bayesian_runner.exe --spec <spec.sexp> --out-dir <dir>\n\
+  \  [--fixtures-root <path>]\n\
+  \  [--walk-forward-spec <spec.sexp> --baseline-aggregate <aggregate.sexp>]"
+
+(** Label assigned to the best cell when it is re-executed end-to-end for OOS
+    validation. Distinct from the [bo-iter-N] labels the evaluator's iteration
+    counter emits during the BO loop. *)
+let _walk_forward_candidate_label = "bo-iter-best"
+
+(** Synthetic scenario label injected into [bo_log.csv]'s [scenario] column in
+    walk-forward mode (the Bayesian spec's own [scenarios] list is empty in
+    production walk-forward specs). *)
+let _walk_forward_scenarios_label = "walk-forward"
 
 type cli_args = {
   spec_path : string;
   out_dir : string;
   fixtures_root : string option;
+  walk_forward_spec_path : string option;
+  baseline_aggregate_path : string option;
 }
 
 let _parse_args argv =
-  let rec loop spec out fixtures = function
+  let rec loop spec out fixtures wf_spec baseline = function
     | [] -> (
         match (spec, out) with
         | Some s, Some o ->
-            { spec_path = s; out_dir = o; fixtures_root = fixtures }
+            {
+              spec_path = s;
+              out_dir = o;
+              fixtures_root = fixtures;
+              walk_forward_spec_path = wf_spec;
+              baseline_aggregate_path = baseline;
+            }
         | _ ->
             eprintf "%s\n" _usage_msg;
             Stdlib.exit 1)
-    | "--spec" :: p :: rest -> loop (Some p) out fixtures rest
-    | "--out-dir" :: p :: rest -> loop spec (Some p) fixtures rest
-    | "--fixtures-root" :: p :: rest -> loop spec out (Some p) rest
+    | "--spec" :: p :: rest -> loop (Some p) out fixtures wf_spec baseline rest
+    | "--out-dir" :: p :: rest ->
+        loop spec (Some p) fixtures wf_spec baseline rest
+    | "--fixtures-root" :: p :: rest ->
+        loop spec out (Some p) wf_spec baseline rest
+    | "--walk-forward-spec" :: p :: rest ->
+        loop spec out fixtures (Some p) baseline rest
+    | "--baseline-aggregate" :: p :: rest ->
+        loop spec out fixtures wf_spec (Some p) rest
     | "--help" :: _ | "-h" :: _ ->
         printf "%s\n" _usage_msg;
         Stdlib.exit 0
@@ -59,7 +112,9 @@ let _parse_args argv =
         eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
         Stdlib.exit 1
   in
-  loop None None None argv
+  loop None None None None None argv
+
+(* -------------- legacy per-scenario mode -------------- *)
 
 let _load_scenarios paths =
   let table = Hashtbl.create (module String) in
@@ -68,10 +123,7 @@ let _load_scenarios paths =
       Hashtbl.set table ~key:p ~data:s);
   table
 
-let _main () =
-  let argv = Sys.get_argv () |> Array.to_list |> List.tl_exn in
-  let args = _parse_args argv in
-  let spec = Spec.load args.spec_path in
+let _run_legacy_mode ~(args : cli_args) ~(spec : Spec.t) =
   let fixtures_root =
     Fixtures_root.resolve ?fixtures_root:args.fixtures_root ()
   in
@@ -79,7 +131,7 @@ let _main () =
   let objective = Spec.to_grid_objective spec.objective in
   let obj_label = Tuner.Grid_search.objective_label objective in
   eprintf
-    "[bayesian_runner] loaded %d scenario(s); total_budget=%d; \
+    "[bayesian_runner] mode=legacy; loaded %d scenario(s); total_budget=%d; \
      initial_random=%d; objective=%s\n\
      %!"
     (List.length spec.scenarios)
@@ -94,5 +146,124 @@ let _main () =
     (Sexp.to_string
        (Sexp.List (Tuner.Grid_search.cell_to_overrides result.best_params)));
   eprintf "[bayesian_runner] outputs written under %s\n%!" args.out_dir
+
+(* -------------- walk-forward mode (PR-E) -------------- *)
+
+(** Load an [aggregate.sexp] file (the structured walk-forward report shape
+    Phase 2 pinned). Used both for the BO scorer's [baseline_aggregate] arg and
+    for OOS validation. *)
+let _load_aggregate path =
+  try Wf_report.aggregate_of_sexp (Sexp.load_sexp path)
+  with exn ->
+    failwithf "bayesian_runner: failed to load aggregate.sexp %s: %s" path
+      (Exn.to_string exn) ()
+
+(** Synthesise a placeholder [scenarios] list of length 1 so the runner's
+    [bo_log.csv] writer (which pairs scenarios with per-iteration metric_sets
+    via [List.iter2_exn]) does not raise on the production walk-forward fixture
+    (which carries [scenarios = []]). The evaluator returns
+    [(score, [ metric_set ])] in walk-forward mode — exactly one element. *)
+let _wf_spec_with_placeholder_scenario (s : Spec.t) : Spec.t =
+  { s with scenarios = [ _walk_forward_scenarios_label ] }
+
+(** Re-execute the walk-forward sweep for the BO's best cell. Returns the
+    fold_actuals list (per-fold, per-variant rows) that
+    {!Oos_validator.validate} partitions into in-sample vs OOS slices. *)
+let _execute_best_cell_walk_forward ~(best_params : (string * float) list)
+    ~(walk_forward_spec : Wf_spec.t) ~(base : Scenario.t)
+    ~(fixtures_root : string) : Wf_report.fold_actual list =
+  let candidate =
+    {
+      Walk_forward.Walk_forward_runner.label = _walk_forward_candidate_label;
+      overrides = Tuner.Grid_search.cell_to_overrides best_params;
+    }
+  in
+  let two_variant_spec : Wf_spec.t =
+    {
+      walk_forward_spec with
+      variants =
+        [
+          { label = walk_forward_spec.baseline_label; overrides = [] };
+          candidate;
+        ];
+    }
+  in
+  eprintf
+    "[bayesian_runner] re-running walk-forward on best cell for OOS validation\n\
+     %!";
+  let result =
+    Wf_executor.execute_spec ~base ~spec:two_variant_spec ~fixtures_root
+      ~progress:Wf_executor.noop_progress ()
+  in
+  result.fold_actuals
+
+let _write_oos_report ~(out_dir : string)
+    ~(oos_result : Oos_validator.oos_result) ~(spec_path : string)
+    ~(baseline_label : string) : unit =
+  let path = Filename.concat out_dir "oos_report.md" in
+  Oos_validator.write_report path oos_result ~spec_path ~baseline_label;
+  eprintf "[bayesian_runner] wrote %s (verdict=%s)\n%!" path
+    (Sexp.to_string (Oos_validator.sexp_of_verdict oos_result.verdict))
+
+let _run_walk_forward_mode ~(args : cli_args) ~(spec : Spec.t)
+    ~(walk_forward_spec_path : string) ~(baseline_aggregate_path : string) =
+  let fixtures_root =
+    Fixtures_root.resolve ?fixtures_root:args.fixtures_root ()
+  in
+  let walk_forward_spec = Wf_spec.load walk_forward_spec_path in
+  let base_scenario_path =
+    Filename.concat fixtures_root walk_forward_spec.base_scenario
+  in
+  let base = Scenario.load base_scenario_path in
+  let baseline_aggregate = _load_aggregate baseline_aggregate_path in
+  let holdout_folds = Option.value spec.holdout_folds ~default:[] in
+  eprintf
+    "[bayesian_runner] mode=walk-forward; total_budget=%d; initial_random=%d; \
+     bounds=%d; holdout_folds=%d\n\
+     %!"
+    spec.total_budget spec.initial_random (List.length spec.bounds)
+    (List.length holdout_folds);
+  let evaluator : Runner.evaluator =
+    Evaluator.build_walk_forward ~executor:Evaluator.default_executor ~base
+      ~walk_forward_spec ~baseline_aggregate ~fixtures_root ()
+  in
+  let runner_spec = _wf_spec_with_placeholder_scenario spec in
+  let result =
+    Runner.run_and_write ~spec:runner_spec ~out_dir:args.out_dir ~evaluator
+  in
+  eprintf "[bayesian_runner] best_score=%.6f best_params=%s\n%!"
+    result.best_score
+    (Sexp.to_string
+       (Sexp.List (Tuner.Grid_search.cell_to_overrides result.best_params)));
+  (* OOS validation: re-run walk-forward on the best cell, partition the
+     per-fold results, emit oos_report.md. *)
+  let fold_actuals =
+    _execute_best_cell_walk_forward ~best_params:result.best_params
+      ~walk_forward_spec ~base ~fixtures_root
+  in
+  let oos_result =
+    Oos_validator.validate ~candidate_label:_walk_forward_candidate_label
+      ~holdout_folds ~fold_actuals
+  in
+  _write_oos_report ~out_dir:args.out_dir ~oos_result ~spec_path:args.spec_path
+    ~baseline_label:walk_forward_spec.baseline_label;
+  eprintf "[bayesian_runner] outputs written under %s\n%!" args.out_dir
+
+let _main () =
+  let argv = Sys.get_argv () |> Array.to_list |> List.tl_exn in
+  let args = _parse_args argv in
+  let spec = Spec.load args.spec_path in
+  match (args.walk_forward_spec_path, args.baseline_aggregate_path) with
+  | None, None -> _run_legacy_mode ~args ~spec
+  | Some wf_path, Some baseline_path ->
+      _run_walk_forward_mode ~args ~spec ~walk_forward_spec_path:wf_path
+        ~baseline_aggregate_path:baseline_path
+  | _ ->
+      eprintf
+        "Error: --walk-forward-spec and --baseline-aggregate must be supplied \
+         together\n\
+         %s\n"
+        _usage_msg;
+      Stdlib.exit 1
 
 let () = _main ()

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_oos_validator.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_oos_validator.ml
@@ -1,0 +1,156 @@
+open Core
+module Wf_types = Walk_forward.Walk_forward_types
+
+let _no_overfit_hurdle_sharpe = 0.10
+
+type verdict = Accept | Reject_overfit | Reject_insufficient_data
+[@@deriving sexp]
+
+type oos_result = {
+  candidate_label : string;
+  in_sample_mean_sharpe : float;
+  oos_mean_sharpe : float;
+  gap : float;
+  in_sample_fold_count : int;
+  oos_fold_count : int;
+  per_oos_fold : (string * float) list;
+  verdict : verdict;
+}
+[@@deriving sexp]
+
+(* ---------- partitioning helpers ---------- *)
+
+let _filter_to_candidate ~(candidate_label : string)
+    (fold_actuals : Wf_types.fold_actual list) : Wf_types.fold_actual list =
+  List.filter fold_actuals ~f:(fun fa ->
+      String.equal fa.variant_label candidate_label)
+
+(** Partition the candidate's per-fold rows into (in-sample, oos) by 1-indexed
+    position in [holdout_folds]. The 1-indexed position of the [i]-th row in the
+    input list is [i + 1]. *)
+let _partition_in_sample_vs_oos ~(holdout_folds : int list)
+    (rows : Wf_types.fold_actual list) :
+    Wf_types.fold_actual list * Wf_types.fold_actual list =
+  let holdout_set = Int.Set.of_list holdout_folds in
+  List.foldi rows ~init:([], []) ~f:(fun i (acc_in, acc_oos) row ->
+      let pos_one_indexed = i + 1 in
+      if Set.mem holdout_set pos_one_indexed then (acc_in, row :: acc_oos)
+      else (row :: acc_in, acc_oos))
+  |> fun (in_rev, oos_rev) -> (List.rev in_rev, List.rev oos_rev)
+
+let _mean_sharpe (rows : Wf_types.fold_actual list) : float =
+  match rows with
+  | [] -> Float.nan
+  | _ ->
+      let sum =
+        List.fold rows ~init:0.0 ~f:(fun acc fa -> acc +. fa.sharpe_ratio)
+      in
+      sum /. Float.of_int (List.length rows)
+
+let _verdict_of ~(in_sample_count : int) ~(oos_count : int) ~(gap : float) :
+    verdict =
+  if in_sample_count = 0 || oos_count = 0 then Reject_insufficient_data
+  else if Float.(abs gap > _no_overfit_hurdle_sharpe) then Reject_overfit
+  else Accept
+
+(* ---------- public API ---------- *)
+
+let validate ~(candidate_label : string) ~(holdout_folds : int list)
+    ~(fold_actuals : Wf_types.fold_actual list) : oos_result =
+  let candidate_rows = _filter_to_candidate ~candidate_label fold_actuals in
+  let in_sample_rows, oos_rows =
+    _partition_in_sample_vs_oos ~holdout_folds candidate_rows
+  in
+  let in_sample_mean_sharpe = _mean_sharpe in_sample_rows in
+  let oos_mean_sharpe = _mean_sharpe oos_rows in
+  let gap = oos_mean_sharpe -. in_sample_mean_sharpe in
+  let in_sample_fold_count = List.length in_sample_rows in
+  let oos_fold_count = List.length oos_rows in
+  let per_oos_fold =
+    List.map oos_rows ~f:(fun fa -> (fa.fold_name, fa.sharpe_ratio))
+  in
+  let verdict =
+    _verdict_of ~in_sample_count:in_sample_fold_count ~oos_count:oos_fold_count
+      ~gap:(if Float.is_nan gap then 0.0 else gap)
+  in
+  {
+    candidate_label;
+    in_sample_mean_sharpe;
+    oos_mean_sharpe;
+    gap;
+    in_sample_fold_count;
+    oos_fold_count;
+    per_oos_fold;
+    verdict;
+  }
+
+(* ---------- markdown renderer ---------- *)
+
+let _verdict_label (v : verdict) : string =
+  match v with
+  | Accept -> "ACCEPT"
+  | Reject_overfit -> "REJECT (over-fit: |gap| > 0.10)"
+  | Reject_insufficient_data ->
+      "REJECT (insufficient data: zero in-sample or OOS folds)"
+
+let _format_float f = if Float.is_nan f then "n/a" else sprintf "%.4f" f
+
+let _title_section ~spec_path ~candidate_label ~baseline_label =
+  sprintf
+    "# OOS validation report\n\n\
+     BO spec: `%s`\n\n\
+     Candidate variant: `%s`\n\n\
+     Baseline variant: `%s`\n\n\
+     Acceptance rule: per plan \
+     [dev/plans/bayesian-multi-param-scaling-2026-05-16.md] §6.3 — OOS mean \
+     Sharpe must be within %.2f of in-sample mean Sharpe.\n\n"
+    spec_path candidate_label baseline_label _no_overfit_hurdle_sharpe
+
+let _summary_section (r : oos_result) =
+  sprintf
+    "## In-sample vs OOS mean Sharpe\n\n\
+     | Slice | Fold count | Mean Sharpe |\n\
+     |---|---|---|\n\
+     | In-sample | %d | %s |\n\
+     | OOS | %d | %s |\n\
+     | Gap (OOS - in-sample) | — | %s |\n\n"
+    r.in_sample_fold_count
+    (_format_float r.in_sample_mean_sharpe)
+    r.oos_fold_count
+    (_format_float r.oos_mean_sharpe)
+    (_format_float r.gap)
+
+let _per_fold_section (r : oos_result) =
+  match r.per_oos_fold with
+  | [] -> "## Per-OOS-fold Sharpe\n\n(no OOS folds — see verdict)\n\n"
+  | rows ->
+      let row_strs =
+        List.map rows ~f:(fun (name, sharpe) ->
+            sprintf "| `%s` | %s |\n" name (_format_float sharpe))
+      in
+      sprintf "## Per-OOS-fold Sharpe\n\n| Fold | Sharpe |\n|---|---|\n%s\n"
+        (String.concat row_strs)
+
+let _verdict_section (r : oos_result) =
+  sprintf
+    "## Verdict\n\n\
+     **%s**\n\n\
+     - Gap (OOS - in-sample) = %s\n\
+     - Hurdle = %.2f (absolute)\n"
+    (_verdict_label r.verdict) (_format_float r.gap) _no_overfit_hurdle_sharpe
+
+let render_report (r : oos_result) ~(spec_path : string)
+    ~(baseline_label : string) : string =
+  String.concat
+    [
+      _title_section ~spec_path ~candidate_label:r.candidate_label
+        ~baseline_label;
+      _summary_section r;
+      _per_fold_section r;
+      _verdict_section r;
+    ]
+
+let write_report (path : string) (r : oos_result) ~(spec_path : string)
+    ~(baseline_label : string) : unit =
+  let md = render_report r ~spec_path ~baseline_label in
+  Out_channel.with_file path ~f:(fun oc -> Out_channel.output_string oc md)

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_oos_validator.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_oos_validator.mli
@@ -1,0 +1,123 @@
+(** Out-of-sample (OOS) validation for the Phase-3 Bayesian optimizer's best
+    cell.
+
+    After the BO loop converges, this module re-evaluates the best cell on the
+    held-out folds (per the spec's [holdout_folds] field) and decides whether
+    the cell generalises out-of-sample.
+
+    The acceptance rule is plan §6.3 of
+    [dev/plans/bayesian-multi-param-scaling-2026-05-16.md] — the "no-overfit
+    hurdle": OOS mean Sharpe must be within [0.10] of the in-sample mean Sharpe.
+    A larger gap signals the BO over-fit the in-sample folds and the cell is
+    {b rejected} for production pinning.
+
+    Pure split: this module {b never} runs a backtest. It consumes a flat list
+    of per-fold measurements (the {!Walk_forward.Walk_forward_types.fold_actual}
+    list the walk-forward executor produces) and the {!Bayesian_runner_spec.t}
+    holdout-fold positions, partitions the measurements, and emits a structured
+    {!oos_result} + a markdown {!oos_report.md}-shaped string. The caller (the
+    [bayesian_runner.exe] binary in PR-E) is responsible for actually executing
+    the best cell's walk-forward sweep and supplying the per-fold rows. *)
+
+module Wf_types = Walk_forward.Walk_forward_types
+
+val _no_overfit_hurdle_sharpe : float
+(** Maximum permitted absolute gap between in-sample mean Sharpe and
+    out-of-sample mean Sharpe before the cell is rejected as over-fit. Plan §6.3
+    pins this at [0.10]. Exposed for diagnostic logging and for the test suite.
+*)
+
+(** Outcome of the OOS validation step.
+
+    - [Accept]: the OOS Sharpe is within {!_no_overfit_hurdle_sharpe} of the
+      in-sample Sharpe.
+    - [Reject_overfit]: the OOS Sharpe gap exceeds the hurdle (over-fit).
+    - [Reject_insufficient_data]: there are not enough OOS folds to compute a
+      meaningful mean (zero OOS rows after partitioning). The caller's spec must
+      list at least one valid holdout fold position. *)
+type verdict = Accept | Reject_overfit | Reject_insufficient_data
+[@@deriving sexp]
+
+type oos_result = {
+  candidate_label : string;
+      (** Walk-forward variant label the OOS validator scored (e.g.
+          [bo-iter-best]). Recorded for the markdown report. *)
+  in_sample_mean_sharpe : float;
+      (** Arithmetic mean of [sharpe_ratio] across {b in-sample} folds (those
+          whose 1-indexed position is NOT in
+          [Bayesian_runner_spec.holdout_folds]) for the [candidate_label]
+          variant. [Float.nan] when no in-sample folds remain after
+          partitioning. *)
+  oos_mean_sharpe : float;
+      (** Arithmetic mean of [sharpe_ratio] across {b out-of-sample} folds
+          (those whose 1-indexed position IS in
+          [Bayesian_runner_spec.holdout_folds]). [Float.nan] when no OOS folds
+          matched. *)
+  gap : float;
+      (** Signed difference [oos_mean_sharpe - in_sample_mean_sharpe]. The
+          {!verdict} rejects when [abs(gap) > _no_overfit_hurdle_sharpe]. *)
+  in_sample_fold_count : int;
+      (** Number of in-sample folds the means were computed over. *)
+  oos_fold_count : int;
+      (** Number of OOS folds the means were computed over. *)
+  per_oos_fold : (string * float) list;
+      (** [(fold_name, sharpe_ratio)] pairs for each OOS fold, in
+          first-appearance order. The renderer surfaces these per-fold so the
+          operator can see whether the gap is driven by a single anomalous fold.
+      *)
+  verdict : verdict;  (** Accept / Reject decision. *)
+}
+[@@deriving sexp]
+(** Output of {!validate}. The full structured shape is exposed (rather than
+    just the verdict) so the binary can log it, persist it as [oos_result.sexp],
+    and use it as input to {!render_report}. *)
+
+val validate :
+  candidate_label:string ->
+  holdout_folds:int list ->
+  fold_actuals:Wf_types.fold_actual list ->
+  oos_result
+(** [validate ~candidate_label ~holdout_folds ~fold_actuals] partitions
+    [fold_actuals] (already filtered to the candidate variant, OR carrying
+    multiple variants — the function filters internally by
+    [variant_label = candidate_label]) into in-sample vs OOS by 1-indexed fold
+    position.
+
+    The fold-position-to-name mapping follows
+    {!Walk_forward.Window_spec.generate}'s output order: fold position [k]
+    (1-indexed) corresponds to the [k-1]-th fold in [fold_actuals] (filtered to
+    the candidate variant, then ordered by appearance). This matches how the
+    walk-forward runner produces fold actuals — outer = variants, inner = folds
+    in generation order — so the caller can pass the executor's [fold_actuals]
+    verbatim.
+
+    Returns an {!oos_result} with [verdict = Reject_insufficient_data] when no
+    OOS rows match (e.g. empty [holdout_folds] or positions beyond the fold
+    count); [Reject_overfit] when [abs(gap) > _no_overfit_hurdle_sharpe];
+    otherwise [Accept].
+
+    Pure: no I/O, no exceptions on well-formed inputs (positions beyond the fold
+    count are silently dropped — they produce [Reject_insufficient_data] rather
+    than raising). *)
+
+val render_report :
+  oos_result -> spec_path:string -> baseline_label:string -> string
+(** [render_report result ~spec_path ~baseline_label] returns a markdown string
+    suitable for writing to [oos_report.md].
+
+    Sections (deterministic, byte-stable for the same input):
+
+    + Title + the BO spec path + the candidate / baseline labels.
+    + In-sample vs OOS mean Sharpe table.
+    + Per-OOS-fold table.
+    + Verdict block — [Accept] / [Reject_overfit] / [Reject_insufficient_data]
+      with the gap value and the [_no_overfit_hurdle_sharpe] hurdle.
+
+    The markdown is plain text; no images, no escaping needed for the inputs
+    this binary produces. *)
+
+val write_report :
+  string -> oos_result -> spec_path:string -> baseline_label:string -> unit
+(** [write_report path result ~spec_path ~baseline_label] writes the rendered
+    report to [path] via [Out_channel.with_file]. Creates / truncates the file;
+    parent directory must already exist. *)

--- a/trading/trading/backtest/tuner/bin/dune
+++ b/trading/trading/backtest/tuner/bin/dune
@@ -7,7 +7,8 @@
   bayesian_runner_spec
   bayesian_runner_evaluator
   bayesian_runner_runner
-  bayesian_runner_scoring)
+  bayesian_runner_scoring
+  bayesian_runner_oos_validator)
  (libraries
   core
   core_unix
@@ -29,4 +30,11 @@
 (executable
  (name bayesian_runner)
  (modules bayesian_runner)
- (libraries core core_unix tuner backtest scenario_lib tuner_bin))
+ (libraries
+  core
+  core_unix
+  tuner
+  backtest
+  scenario_lib
+  tuner_bin
+  walk_forward))

--- a/trading/trading/backtest/tuner/bin/test/dune
+++ b/trading/trading/backtest/tuner/bin/test/dune
@@ -3,7 +3,8 @@
   test_grid_search_bin
   test_bayesian_runner_bin
   test_bayesian_runner_scoring
-  test_bayesian_runner_evaluator)
+  test_bayesian_runner_evaluator
+  test_bayesian_runner_oos_validator)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_oos_validator.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_oos_validator.ml
@@ -1,0 +1,389 @@
+(** Unit tests for {!Tuner_bin.Bayesian_runner_oos_validator}.
+
+    Pins the no-overfit hurdle (plan
+    [dev/plans/bayesian-multi-param-scaling-2026-05-16.md] §6.3) and the report
+    renderer. The validator is pure — no I/O, no executor invocation — so each
+    test hand-builds a list of {!Walk_forward.Walk_forward_types.fold_actual}
+    rows and asserts on the resulting verdict + means.
+
+    Coverage:
+
+    - {!Validator.validate}: in-sample / OOS partitioning by 1-indexed fold
+      position; mean Sharpe accuracy on each slice; gap sign + verdict mapping
+      (Accept / Reject_overfit / Reject_insufficient_data); per-fold list shape.
+    - {!Validator.render_report}: the markdown sections (title, summary,
+      per-fold, verdict) appear and carry the expected numeric content. *)
+
+open OUnit2
+open Core
+open Matchers
+module Validator = Tuner_bin.Bayesian_runner_oos_validator
+module Wf_types = Walk_forward.Walk_forward_types
+
+(* ---------- shared helpers ---------- *)
+
+let _epsilon = 1e-9
+let _candidate_label = "bo-iter-best"
+let _baseline_label = "cell-E"
+
+(** Build one {!Wf_types.fold_actual} with only the fields the validator
+    consumes. The other metric fields are set to zero — the validator filters by
+    [variant_label] and means by [sharpe_ratio]; nothing else is read. *)
+let _fa ~fold_name ~variant_label ~sharpe : Wf_types.fold_actual =
+  {
+    fold_name;
+    variant_label;
+    total_return_pct = 0.0;
+    sharpe_ratio = sharpe;
+    max_drawdown_pct = 0.0;
+    calmar_ratio = 0.0;
+    cagr_pct = Float.nan;
+  }
+
+(** Build N candidate-variant fold_actuals named "fold-000".."fold-(N-1)" with
+    given per-fold sharpe values. The 1-indexed positions are 1..N. *)
+let _make_candidate_rows sharpe_values =
+  List.mapi sharpe_values ~f:(fun i s ->
+      let fold_name = sprintf "fold-%03d" i in
+      _fa ~fold_name ~variant_label:_candidate_label ~sharpe:s)
+
+(* ---------- 1. Accept when gap is within hurdle ---------- *)
+
+let test_accept_when_gap_within_hurdle _ =
+  (* 5 in-sample folds (sharpe=1.0 each), 2 OOS folds (positions 6,7;
+     sharpe=0.95 each). In-sample mean=1.0, OOS mean=0.95, gap=-0.05. Within
+     the 0.10 hurdle → Accept. *)
+  let rows = _make_candidate_rows [ 1.0; 1.0; 1.0; 1.0; 1.0; 0.95; 0.95 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 6; 7 ]
+      ~fold_actuals:rows
+  in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Validator.oos_result) -> r.verdict)
+           (equal_to Validator.Accept);
+         field
+           (fun (r : Validator.oos_result) -> r.in_sample_mean_sharpe)
+           (float_equal ~epsilon:_epsilon 1.0);
+         field
+           (fun (r : Validator.oos_result) -> r.oos_mean_sharpe)
+           (float_equal ~epsilon:_epsilon 0.95);
+         field
+           (fun (r : Validator.oos_result) -> r.gap)
+           (float_equal ~epsilon:_epsilon (-0.05));
+         field
+           (fun (r : Validator.oos_result) -> r.in_sample_fold_count)
+           (equal_to 5);
+         field (fun (r : Validator.oos_result) -> r.oos_fold_count) (equal_to 2);
+       ])
+
+(* ---------- 2. Reject_overfit when OOS drops more than hurdle ---------- *)
+
+let test_reject_overfit_when_oos_drops _ =
+  (* 4 in-sample folds (sharpe=1.2 each), 2 OOS folds (positions 5,6;
+     sharpe=0.5 each). In-sample mean=1.2, OOS mean=0.5, gap=-0.7. |gap|>0.10
+     → Reject_overfit. *)
+  let rows = _make_candidate_rows [ 1.2; 1.2; 1.2; 1.2; 0.5; 0.5 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 5; 6 ]
+      ~fold_actuals:rows
+  in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Validator.oos_result) -> r.verdict)
+           (equal_to Validator.Reject_overfit);
+         field
+           (fun (r : Validator.oos_result) -> r.gap)
+           (float_equal ~epsilon:_epsilon (-0.7));
+       ])
+
+(* ---------- 3. Reject_overfit also fires when OOS spikes upward ---------- *)
+
+let test_reject_overfit_when_oos_spikes_upward _ =
+  (* The hurdle is on absolute gap, not signed. A +0.5 OOS surprise also
+     trips Reject_overfit — the operator wants to investigate why, not
+     silently accept. *)
+  let rows = _make_candidate_rows [ 0.5; 0.5; 0.5; 1.5; 1.5 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 4; 5 ]
+      ~fold_actuals:rows
+  in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Validator.oos_result) -> r.verdict)
+           (equal_to Validator.Reject_overfit);
+         field
+           (fun (r : Validator.oos_result) -> r.gap)
+           (float_equal ~epsilon:_epsilon 1.0);
+       ])
+
+(* ---------- 4. Boundary case: gap just inside hurdle → Accept ---------- *)
+
+let test_boundary_gap_just_inside_hurdle_accepts _ =
+  (* Gap ≈ +0.099 (strictly less than the 0.10 hurdle in floating-point).
+     The hurdle uses strict ">" so anything strictly less than 0.10 must
+     Accept. We avoid testing exactly 0.10 because 1.1 - 1.0 is not
+     bit-exact in IEEE-754; the strict-inequality boundary is what the
+     production code's [Float.(abs gap > hurdle)] guarantees. *)
+  let rows = _make_candidate_rows [ 1.0; 1.0; 1.099 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 3 ]
+      ~fold_actuals:rows
+  in
+  assert_that result.verdict (equal_to Validator.Accept)
+
+(* ---------- 5. Boundary case: gap just past hurdle → Reject ---------- *)
+
+let test_boundary_gap_just_past_hurdle_rejects _ =
+  (* Gap > 0.10 by 1e-3 → Reject. *)
+  let rows = _make_candidate_rows [ 1.0; 1.0; 1.101 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 3 ]
+      ~fold_actuals:rows
+  in
+  assert_that result.verdict (equal_to Validator.Reject_overfit)
+
+(* ---------- 6. Reject_insufficient_data when no OOS folds match ---------- *)
+
+let test_reject_insufficient_data_when_no_oos_folds _ =
+  (* holdout_folds is empty: no OOS rows; verdict is Reject_insufficient_data
+     regardless of in-sample shape. *)
+  let rows = _make_candidate_rows [ 1.0; 1.0; 1.0 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[]
+      ~fold_actuals:rows
+  in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Validator.oos_result) -> r.verdict)
+           (equal_to Validator.Reject_insufficient_data);
+         field (fun (r : Validator.oos_result) -> r.oos_fold_count) (equal_to 0);
+       ])
+
+(* ---------- 7. holdout_folds positions beyond fold count are dropped ---------- *)
+
+let test_holdout_positions_beyond_fold_count_silently_dropped _ =
+  (* Only 3 candidate rows exist; holdout positions 27..30 (from the
+     production spec) reference positions that don't exist. The validator
+     drops them silently — verdict becomes Reject_insufficient_data. *)
+  let rows = _make_candidate_rows [ 1.0; 1.0; 1.0 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label
+      ~holdout_folds:[ 27; 28; 29; 30 ] ~fold_actuals:rows
+  in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Validator.oos_result) -> r.verdict)
+           (equal_to Validator.Reject_insufficient_data);
+         field (fun (r : Validator.oos_result) -> r.oos_fold_count) (equal_to 0);
+         field
+           (fun (r : Validator.oos_result) -> r.in_sample_fold_count)
+           (equal_to 3);
+       ])
+
+(* ---------- 8. Multi-variant rows: validator filters to candidate ---------- *)
+
+let test_filters_to_candidate_variant _ =
+  (* Mixed rows: baseline + candidate, each with 3 folds. The validator
+     must use only the candidate rows for both means; the baseline rows
+     are noise. *)
+  let baseline_rows =
+    List.init 3 ~f:(fun i ->
+        _fa ~fold_name:(sprintf "fold-%03d" i) ~variant_label:_baseline_label
+          ~sharpe:5.0)
+  in
+  let candidate_rows = _make_candidate_rows [ 1.0; 1.0; 0.95 ] in
+  let mixed = baseline_rows @ candidate_rows in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 3 ]
+      ~fold_actuals:mixed
+  in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Validator.oos_result) -> r.in_sample_mean_sharpe)
+           (float_equal ~epsilon:_epsilon 1.0);
+         field
+           (fun (r : Validator.oos_result) -> r.oos_mean_sharpe)
+           (float_equal ~epsilon:_epsilon 0.95);
+       ])
+
+(* ---------- 9. Per-OOS-fold list carries (name, sharpe) in order ---------- *)
+
+let test_per_oos_fold_list_carries_names_and_sharpe _ =
+  let rows = _make_candidate_rows [ 0.8; 0.9; 1.0; 1.1 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 2; 4 ]
+      ~fold_actuals:rows
+  in
+  assert_that result.per_oos_fold
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (n, _) -> n) (equal_to "fold-001");
+             field (fun (_, s) -> s) (float_equal ~epsilon:_epsilon 0.9);
+           ];
+         all_of
+           [
+             field (fun (n, _) -> n) (equal_to "fold-003");
+             field (fun (_, s) -> s) (float_equal ~epsilon:_epsilon 1.1);
+           ];
+       ])
+
+(* ---------- 10. Candidate label preserved in result ---------- *)
+
+let test_candidate_label_preserved_in_result _ =
+  let rows = _make_candidate_rows [ 1.0; 1.0; 0.95 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 3 ]
+      ~fold_actuals:rows
+  in
+  assert_that result.candidate_label (equal_to _candidate_label)
+
+(* ---------- 11. Render: report contains title + verdict tag ---------- *)
+
+let test_render_report_includes_title_and_verdict _ =
+  let rows = _make_candidate_rows [ 1.0; 1.0; 0.95 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 3 ]
+      ~fold_actuals:rows
+  in
+  let md =
+    Validator.render_report result ~spec_path:"/path/to/spec.sexp"
+      ~baseline_label:_baseline_label
+  in
+  assert_that md
+    (all_of
+       [
+         (* Title section *)
+         matching ~msg:"title section present"
+           (fun s ->
+             if String.is_substring s ~substring:"# OOS validation report" then
+               Some ()
+             else None)
+           (equal_to ());
+         (* Spec path threaded through *)
+         matching ~msg:"spec path present"
+           (fun s ->
+             if String.is_substring s ~substring:"/path/to/spec.sexp" then
+               Some ()
+             else None)
+           (equal_to ());
+         (* Verdict block tag *)
+         matching ~msg:"verdict ACCEPT tag present"
+           (fun s ->
+             if String.is_substring s ~substring:"ACCEPT" then Some () else None)
+           (equal_to ());
+       ])
+
+(* ---------- 12. Render: Reject_overfit message present ---------- *)
+
+let test_render_report_reject_overfit_message _ =
+  let rows = _make_candidate_rows [ 1.2; 1.2; 0.4 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 3 ]
+      ~fold_actuals:rows
+  in
+  let md =
+    Validator.render_report result ~spec_path:"spec.sexp"
+      ~baseline_label:_baseline_label
+  in
+  assert_that md
+    (matching ~msg:"REJECT over-fit message present"
+       (fun s ->
+         if String.is_substring s ~substring:"REJECT (over-fit" then Some ()
+         else None)
+       (equal_to ()))
+
+(* ---------- 13. Render: per-fold table rows present ---------- *)
+
+let test_render_report_per_fold_rows_present _ =
+  let rows = _make_candidate_rows [ 1.0; 1.0; 0.95; 0.93 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[ 3; 4 ]
+      ~fold_actuals:rows
+  in
+  let md =
+    Validator.render_report result ~spec_path:"spec.sexp"
+      ~baseline_label:_baseline_label
+  in
+  assert_that md
+    (all_of
+       [
+         matching ~msg:"fold-002 row present"
+           (fun s ->
+             if String.is_substring s ~substring:"`fold-002`" then Some ()
+             else None)
+           (equal_to ());
+         matching ~msg:"fold-003 row present"
+           (fun s ->
+             if String.is_substring s ~substring:"`fold-003`" then Some ()
+             else None)
+           (equal_to ());
+       ])
+
+(* ---------- 14. Render: Reject_insufficient_data message present ---------- *)
+
+let test_render_report_insufficient_data_message _ =
+  let rows = _make_candidate_rows [ 1.0; 1.0 ] in
+  let result =
+    Validator.validate ~candidate_label:_candidate_label ~holdout_folds:[]
+      ~fold_actuals:rows
+  in
+  let md =
+    Validator.render_report result ~spec_path:"spec.sexp"
+      ~baseline_label:_baseline_label
+  in
+  assert_that md
+    (matching ~msg:"insufficient-data verdict present"
+       (fun s ->
+         if String.is_substring s ~substring:"insufficient data" then Some ()
+         else None)
+       (equal_to ()))
+
+let suite =
+  "Tuner_bin.Bayesian_runner_oos_validator"
+  >::: [
+         "Accept when |gap| within hurdle"
+         >:: test_accept_when_gap_within_hurdle;
+         "Reject_overfit when OOS Sharpe drops too far"
+         >:: test_reject_overfit_when_oos_drops;
+         "Reject_overfit also fires on upward OOS spike"
+         >:: test_reject_overfit_when_oos_spikes_upward;
+         "Boundary case: gap just inside +0.10 -> Accept"
+         >:: test_boundary_gap_just_inside_hurdle_accepts;
+         "Boundary case: gap just past +0.10 -> Reject_overfit"
+         >:: test_boundary_gap_just_past_hurdle_rejects;
+         "Reject_insufficient_data when no OOS folds match"
+         >:: test_reject_insufficient_data_when_no_oos_folds;
+         "holdout positions beyond fold count silently dropped"
+         >:: test_holdout_positions_beyond_fold_count_silently_dropped;
+         "validator filters to candidate variant"
+         >:: test_filters_to_candidate_variant;
+         "per_oos_fold list carries (name, sharpe) in order"
+         >:: test_per_oos_fold_list_carries_names_and_sharpe;
+         "candidate_label preserved in result"
+         >:: test_candidate_label_preserved_in_result;
+         "render_report: title + verdict tag present"
+         >:: test_render_report_includes_title_and_verdict;
+         "render_report: Reject_overfit message"
+         >:: test_render_report_reject_overfit_message;
+         "render_report: per-OOS-fold rows present"
+         >:: test_render_report_per_fold_rows_present;
+         "render_report: Reject_insufficient_data message"
+         >:: test_render_report_insufficient_data_message;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Closes the Phase-3 Bayesian-optimisation stack per `dev/plans/bayesian-multi-param-scaling-2026-05-16.md` §7 PR-E. Wires the walk-forward evaluator (PR-C #1136), scoring (PR-A #1126), knob inventory (PR-B #1132), and length-scale / early-stop / Option encoding (PR-D #1143) into the `bayesian_runner.exe` binary, and adds the OOS holdout validator that emits `oos_report.md` per plan §6.3 no-overfit hurdle.

## What it does

**New module** `Tuner_bin.Bayesian_runner_oos_validator`:
- Pure split — never runs a backtest.
- Partitions an executor's per-fold `fold_actual` list by 1-indexed fold position against the spec's `holdout_folds`.
- Computes in-sample vs OOS mean Sharpe.
- Emits `Accept` / `Reject_overfit` / `Reject_insufficient_data` verdict.
- No-overfit hurdle `abs(gap) <= 0.10` pinned by `_no_overfit_hurdle_sharpe`.
- Markdown renderer for `oos_report.md` (title + summary table + per-OOS-fold table + verdict block).

**Binary change** `bayesian_runner.exe`:
- New flags `--walk-forward-spec <path>` + `--baseline-aggregate <path>`.
- When both supplied, switches to walk-forward mode: each BO suggestion drives one walk-forward CV sweep via `build_walk_forward`, scored by `score_cell` against the loaded baseline aggregate.
- After BO completes, re-runs the best cell on the full window with label `bo-iter-best`, partitions per-fold results against the BO spec's `holdout_folds`, writes `oos_report.md`.
- Legacy per-scenario mode preserved (no flag → existing `Evaluator.build` path).

**Pre-registered experiment hypothesis** `dev/experiments/bayesian-multi-param-2026-05-17/hypothesis.md`:
- Acceptance criteria for the production BO sweep (an ops-session deliverable per plan §10).
- In-sample Sharpe beats Cell E by ≥0.05 with MaxDD no worse by 1pp.
- OOS gap is within 0.10 (no-overfit hurdle).

## Test plan

- [x] `dune build` clean (zero warnings).
- [x] `dune runtest trading/backtest/tuner/` green — 14 new OOS validator tests + all existing Phase-3 tests (43 in the bin suite, 24 in the lib suite).
- [x] `dune fmt` clean.
- [x] Test coverage on the OOS validator pins each verdict path (Accept / Reject_overfit / Reject_insufficient_data), boundary cases just inside / outside the 0.10 hurdle, multi-variant filtering, holdout positions beyond the fold count, per-fold list shape, and the markdown report sections.

## Out of scope (deferred)

- The actual production BO sweep — ops-session deliverable per plan §10.
- Re-pinning goldens after the BO finds a new cell — separate PR.

## Predecessors (all merged)

- PR #1126 PR-A scoring function
- PR #1132 PR-B knob inventory
- PR #1136 PR-C walk-forward in-process integration
- PR #1143 PR-D length-scale + early-stop + Option encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)