### PR TITLE
fix(ishares): Sec-Fetch-* + sec-ch-ua-* + --http2 on IWV curl fetch

### DIFF
--- a/trading/analysis/data/sources/ishares/bin/iwv_curl_fetch.ml
+++ b/trading/analysis/data/sources/ishares/bin/iwv_curl_fetch.ml
@@ -20,6 +20,23 @@ let _accept_language_header = "en-US,en;q=0.9"
 let _referer_header =
   "https://www.ishares.com/us/products/239714/ishares-russell-3000-etf"
 
+(* Browser-fingerprint hint headers Chrome emits on every request. The
+   ajax CSV endpoint is a same-origin XHR from the iShares product page,
+   so the Sec-Fetch trio mirrors what a real browser would send. The
+   sec-ch-ua client hints announce the brand list (Chrome 120 on macOS,
+   non-mobile). 2026-05-16: PR #1137 (curl shell-out) was insufficient
+   on both local and GHA runner egress IPs; this is the cheapest
+   remaining probe before paying for a scraper-API.
+   See [dev/notes/iwv-scrape-akamai-block-2026-05-16.md] §"Next options" #1. *)
+let _sec_fetch_dest_header = "empty"
+let _sec_fetch_mode_header = "cors"
+let _sec_fetch_site_header = "same-origin"
+
+let _sec_ch_ua_header =
+  "\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Google Chrome\";v=\"120\""
+
+let _sec_ch_ua_mobile_header = "?0"
+let _sec_ch_ua_platform_header = "\"macOS\""
 let curl_path = "curl"
 let curl_max_time_seconds = 30
 let curl_retryable_exit_codes = [ 6; 7; 28; 35; 52; 56 ]
@@ -34,6 +51,7 @@ let _is_retryable_http_status = function
 let curl_args ~body_tempfile uri : string list =
   [
     "-sS";
+    "--http2";
     "--max-time";
     Int.to_string curl_max_time_seconds;
     "-H";
@@ -44,6 +62,18 @@ let curl_args ~body_tempfile uri : string list =
     "Accept-Language: " ^ _accept_language_header;
     "-H";
     "Referer: " ^ _referer_header;
+    "-H";
+    "Sec-Fetch-Dest: " ^ _sec_fetch_dest_header;
+    "-H";
+    "Sec-Fetch-Mode: " ^ _sec_fetch_mode_header;
+    "-H";
+    "Sec-Fetch-Site: " ^ _sec_fetch_site_header;
+    "-H";
+    "sec-ch-ua: " ^ _sec_ch_ua_header;
+    "-H";
+    "sec-ch-ua-mobile: " ^ _sec_ch_ua_mobile_header;
+    "-H";
+    "sec-ch-ua-platform: " ^ _sec_ch_ua_platform_header;
     "-o";
     body_tempfile;
     "-w";

--- a/trading/analysis/data/sources/ishares/bin/iwv_curl_fetch.mli
+++ b/trading/analysis/data/sources/ishares/bin/iwv_curl_fetch.mli
@@ -41,8 +41,16 @@ val curl_args : body_tempfile:string -> Uri.t -> string list
     [body_tempfile] (curl's [-o]); the HTTP status code is written to curl's
     stdout (curl's [-w "%{http_code}"]).
 
-    Browser-mimicking headers (UA / Accept / Accept-Language / Referer) are
-    added unconditionally. *)
+    Forces HTTP/2 ([--http2]) to match the browser's negotiated protocol —
+    Akamai fingerprints the UA-vs-HTTP-version mismatch and serves an HTML
+    interstitial on HTTP/1.1 with a Chrome UA.
+
+    Browser-mimicking headers added unconditionally:
+    - [User-Agent], [Accept], [Accept-Language], [Referer] (PR #1131).
+    - [Sec-Fetch-Dest], [Sec-Fetch-Mode], [Sec-Fetch-Site] — browser same-origin
+      XHR fingerprint.
+    - [sec-ch-ua], [sec-ch-ua-mobile], [sec-ch-ua-platform] — Chrome client
+      hints (brand list, mobile flag, platform). *)
 
 val classify_curl_output :
   uri:Uri.t -> body:string -> Process.Output.t -> Lib.fetch_attempt

--- a/trading/analysis/data/sources/ishares/test/test_iwv_curl_fetch.ml
+++ b/trading/analysis/data/sources/ishares/test/test_iwv_curl_fetch.ml
@@ -23,6 +23,7 @@ let test_curl_args_full_argv_shape _ =
     (elements_are
        [
          equal_to "-sS";
+         equal_to "--http2";
          equal_to "--max-time";
          equal_to (Int.to_string Curl_fetch.curl_max_time_seconds);
          equal_to "-H";
@@ -37,6 +38,23 @@ let test_curl_args_full_argv_shape _ =
          contains_substring "Accept-Language: en-US";
          equal_to "-H";
          contains_substring "Referer: https://www.ishares.com/";
+         equal_to "-H";
+         contains_substring "Sec-Fetch-Dest: empty";
+         equal_to "-H";
+         contains_substring "Sec-Fetch-Mode: cors";
+         equal_to "-H";
+         contains_substring "Sec-Fetch-Site: same-origin";
+         equal_to "-H";
+         all_of
+           [
+             contains_substring "sec-ch-ua:";
+             contains_substring "Google Chrome";
+             contains_substring "v=\"120\"";
+           ];
+         equal_to "-H";
+         contains_substring "sec-ch-ua-mobile: ?0";
+         equal_to "-H";
+         contains_substring "sec-ch-ua-platform: \"macOS\"";
          equal_to "-o";
          equal_to "/tmp/iwv_body_abc.csv";
          equal_to "-w";


### PR DESCRIPTION
## Summary

Add full Chrome browser-fingerprint headers and force HTTP/2 negotiation on the IWV curl shell-out (introduced by PR #1137). Cheapest probe to evade Akamai's bot WAF before paying for a scraper API.

**Probe outcome: STILL BLOCKED.** A single-date fetch (`2024-03-01`, local egress IP) still returns the HTML bot-check interstitial body, not CSV. Sec-Fetch / sec-ch-ua headers + `--http2` alone are not sufficient against this WAF posture. Landing as incremental hardening regardless — these headers will need to be in place once the next layer (rotating residential proxy, paid scraper API, or headless browser) is bolted on.

See `dev/notes/iwv-scrape-akamai-block-2026-05-16.md` §"Next options" for the path forward.

## What changed

In `analysis/data/sources/ishares/bin/iwv_curl_fetch.ml` `curl_args`:

- `--http2` flag (curl defaults to HTTP/1.1; Akamai fingerprints UA-vs-HTTP-version mismatch).
- `-H "Sec-Fetch-Dest: empty"`
- `-H "Sec-Fetch-Mode: cors"`
- `-H "Sec-Fetch-Site: same-origin"`
- `-H "sec-ch-ua: \"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Google Chrome\";v=\"120\""`
- `-H "sec-ch-ua-mobile: ?0"`
- `-H "sec-ch-ua-platform: \"macOS\""`

The `.mli` doc on `curl_args` is updated to enumerate the new headers and explain the HTTP/2 rationale. The argv-shape test in `test_iwv_curl_fetch.ml` is extended to pin the new entries in order.

## Test plan

- [x] `dune build analysis/data/sources/ishares/` — clean, zero warnings.
- [x] `dune runtest analysis/data/sources/ishares/test/` — all 5 test files pass (79 total).
- [x] `dune build @fmt` — formatter clean.
- [x] Live probe via `fetch_iwv_history.exe -from 2024-03-01 -until 2024-03-01 -cadence daily` — still returns HTML interstitial (documented above; the probe is the load-bearing signal, and it failed).

## Files touched

```
analysis/data/sources/ishares/bin/iwv_curl_fetch.ml    (+30)
analysis/data/sources/ishares/bin/iwv_curl_fetch.mli   (+12, -2)
analysis/data/sources/ishares/test/test_iwv_curl_fetch.ml (+18)
```

Total: ~58 LOC. No new modules. No imports from `trading/trading/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)