### PR TITLE
feat(csv-manifest): Phase 2 — wire manifest into Csv_storage.save + load_with_verify

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -428,6 +428,52 @@ fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
     `analysis/`. Bulk-fetch across the full 41k EODHD cache and
     auto-driven detection over many symbols are deferred (Phase 2+).
 
+### READY_FOR_REVIEW (CSV-manifest Phase 2 — hash-verify on load — 2026-05-17)
+
+- **`csv_storage` manifest integration** (branch `feat/csv-manifest-phase2`,
+  `trading/analysis/data/storage/csv/`). Phase 2 of
+  `dev/plans/data-inventory-and-reproducibility-2026-05-02.md`. Wires the
+  Phase 1 manifest module (#1142) into `Csv_storage.save` + adds a new
+  `load_with_verify` that consults the manifest's sha256.
+  - `Csv_storage.save` now also writes/upserts a per-shard manifest entry
+    at `<data-dir>/<L1>/<L2>/manifest.sexp` after every successful CSV
+    write. New optional provenance params: `?source` (default
+    `"unknown"`), `?endpoint`, `?vendor_revision_tag`, `?fetch_id`,
+    `?api_key_id` — backward-compatible (all defaults are empty / sane).
+    Manifest write failures are **non-fatal**: a warning is logged to
+    stderr and `save` itself returns `Ok ()` so existing pipelines do not
+    break when the sidecar cannot be updated.
+  - `Csv_storage.load_with_verify : ?strictness:[ \`Strict | \`Warn | \`Off ]`
+    is a new function (sibling to `get`) that reads the manifest entry
+    and compares the on-disk file's MD5 against the recorded value.
+    `\`Strict` returns `Error (Status.Internal ...)` on mismatch; `\`Warn`
+    (default) logs and returns `Ok`; `\`Off` skips verification entirely.
+    A missing manifest / missing entry is tolerated under all strictness
+    settings — pre-Phase-2 data still loads.
+  - `Csv_storage.shard_manifest_path` exposed as a public helper for
+    callers (inspectors, bulk-rehash tools in Phase 3) that need to
+    locate the manifest without re-implementing sharding.
+  - `t` now carries `data_dir` + `symbol` in addition to `path` so the
+    manifest extension can locate the shard sidecar. Existing `t` is
+    abstract; the change is invisible to callers.
+  - 8 new OUnit2 tests under `csv/test/test_csv_storage.ml` (Matchers
+    library wired in): manifest entry written + sha256 matches CSV;
+    save-twice upserts (not appends); round-trip `load_with_verify`;
+    tampered file detected under `\`Strict` (Internal); tampered file
+    tolerated under `\`Warn` + `\`Off`; missing manifest tolerated
+    under `\`Strict` + `\`Warn`.
+  - Out-of-scope (deferred to Phase 3): reconcile-on-refetch diff log;
+    bulk-rehash CLI for the existing 41k cached symbols; cross-source
+    dispatch (Shiller, Stooq, etc.).
+  - Linters green: `dune build @fmt`, `no_python_check`,
+    `fn_length_linter` (longest new function ≤ 24 LOC),
+    `linter_magic_numbers`. `dune runtest analysis/data/storage` clean
+    (25 csv tests + 14 manifest tests + 12 metadata tests + 5
+    interface tests = 56 total).
+  - Sizing: ~140 LOC added to `csv_storage.{ml,mli}` + ~30 LOC dune
+    edits (libraries) + ~155 LOC new tests (status + plan + fixtures
+    don't count). Plan:
+    `dev/plans/data-inventory-and-reproducibility-2026-05-02.md` §Phase 2.
 ### READY_FOR_REVIEW (Shiller deep-history ingest — 2026-05-17)
 
 - **`shiller` data source** (branch `feat/shiller-ingest`,

--- a/trading/analysis/data/storage/csv/lib/csv_storage.ml
+++ b/trading/analysis/data/storage/csv/lib/csv_storage.ml
@@ -53,6 +53,13 @@ let symbol_data_dir ~data_dir symbol =
   let last_char = String.get symbol (String.length symbol - 1) in
   Fpath.(data_dir / String.make 1 first_char / String.make 1 last_char / symbol)
 
+let shard_manifest_path ~data_dir symbol =
+  let first_char = String.get symbol 0 in
+  let last_char = String.get symbol (String.length symbol - 1) in
+  Fpath.(
+    data_dir / String.make 1 first_char / String.make 1 last_char
+    / "manifest.sexp")
+
 let _create_symbol_dirs data_dir symbol =
   if String.is_empty symbol then
     Status.error_invalid_argument "Symbol cannot be empty"
@@ -162,12 +169,12 @@ let _handle_existing_and_new_prices path ~override existing_prices new_prices =
         in
         _write_prices_to_file path merged
 
-type t = { path : string }
+type t = { path : string; data_dir : Fpath.t; symbol : string }
 
 let create ?(data_dir = _default_data_dir) symbol =
   let%bind symbol_dir = _create_symbol_dirs data_dir symbol in
   let path = Fpath.(symbol_dir / "data.csv") in
-  Ok { path = Fpath.to_string path }
+  Ok { path = Fpath.to_string path; data_dir; symbol }
 
 let _in_date_range ~start_date ~end_date (price : Types.Daily_price.t) =
   let date = price.date in
@@ -239,11 +246,24 @@ let get t ?start_date ?end_date () =
         "start_date must be before or equal to end_date"
   | _ -> Ok prices
 
-let save t ?(override = false) prices =
+let save t ?(override = false) ?(source = "unknown") ?(endpoint = "")
+    ?(vendor_revision_tag = "") ?(fetch_id = "") ?(api_key_id = "") prices =
   let open Result.Let_syntax in
   let%bind () = _validate_prices prices in
-  let exists = Sys_unix.file_exists t.path in
-  if phys_equal exists `Yes then
-    let%bind existing_prices = get t () in
-    _handle_existing_and_new_prices t.path ~override existing_prices prices
-  else _write_prices_to_file t.path prices
+  let%bind () =
+    let exists = Sys_unix.file_exists t.path in
+    if phys_equal exists `Yes then
+      let%bind existing_prices = get t () in
+      _handle_existing_and_new_prices t.path ~override existing_prices prices
+    else _write_prices_to_file t.path prices
+  in
+  Csv_storage_manifest.update_for_save ~data_dir:t.data_dir ~symbol:t.symbol
+    ~path:t.path ~source ~endpoint ~vendor_revision_tag ~fetch_id ~api_key_id
+
+let load_with_verify t ?(strictness = `Warn) ?start_date ?end_date () =
+  let open Result.Let_syntax in
+  let%bind () =
+    Csv_storage_manifest.verify ~data_dir:t.data_dir ~symbol:t.symbol
+      ~path:t.path ~strictness
+  in
+  get t ?start_date ?end_date ()

--- a/trading/analysis/data/storage/csv/lib/csv_storage.mli
+++ b/trading/analysis/data/storage/csv/lib/csv_storage.mli
@@ -1,4 +1,21 @@
-(** CSV-based implementation of the HistoricalDailyPriceStorage interface *)
+(** CSV-based implementation of the HistoricalDailyPriceStorage interface.
+
+    {2 Phase 2 — manifest integration}
+
+    Every successful {!save} also writes (or upserts) a per-shard manifest entry
+    under [<data-dir>/<L1>/<L2>/manifest.sexp]. The entry records the file's MD5
+    hash, row count, date range, and provenance fields supplied by the caller
+    (source, endpoint, vendor revision tag, fetch id, api key id). Manifest
+    write failures are {b non-fatal} — the CSV write itself returns [Ok ()] and
+    a warning is logged to stderr so existing pipelines do not break when the
+    manifest sidecar cannot be updated.
+
+    {!load_with_verify} mirrors {!get} but additionally consults the manifest
+    and compares the on-disk file's hash against the recorded value. The
+    [strictness] parameter controls the response to a mismatch (or a missing
+    manifest entry): [`Strict] fails with [Status.Internal]; [`Warn] (the
+    default) logs and returns the data; [`Off] suppresses the check entirely so
+    legacy callers can opt out. *)
 
 open Storage
 include HistoricalDailyPriceStorage
@@ -11,13 +28,42 @@ val symbol_data_dir : data_dir:Fpath.t -> string -> Fpath.t
     data files are stored: [data_dir / first_char / last_char / symbol]. Pure
     path computation — does not create directories. *)
 
+val shard_manifest_path : data_dir:Fpath.t -> string -> Fpath.t
+(** [shard_manifest_path ~data_dir symbol] returns the manifest path for the
+    [<L1>/<L2>] shard containing [symbol]:
+    [data_dir / first_char / last_char / manifest.sexp]. Pure path computation.
+    Exposed so callers (e.g. inspectors, bulk-rehash tools) can locate the
+    manifest without re-implementing the sharding rule. *)
+
 val create : ?data_dir:Fpath.t -> string -> (t, Status.t) Result.t
 (** Create a new CSV storage with the given symbol and optional data directory.
     If no data directory is provided, a default value is used. *)
 
 val save :
-  t -> ?override:bool -> Types.Daily_price.t list -> (unit, Status.t) Result.t
-(** Save prices to CSV file *)
+  t ->
+  ?override:bool ->
+  ?source:string ->
+  ?endpoint:string ->
+  ?vendor_revision_tag:string ->
+  ?fetch_id:string ->
+  ?api_key_id:string ->
+  Types.Daily_price.t list ->
+  (unit, Status.t) Result.t
+(** [save t ?override ?source ?endpoint ?vendor_revision_tag ?fetch_id
+     ?api_key_id prices] writes [prices] to the CSV file and then upserts the
+    matching manifest entry under the per-shard manifest.
+
+    Provenance defaults:
+    - [source]: ["unknown"]
+    - [endpoint]: [""]
+    - [vendor_revision_tag]: [""]
+    - [fetch_id]: [""]
+    - [api_key_id]: [""]
+
+    Callers that have richer fetch context (EODHD client, Norgate ingest, etc.)
+    should pass them explicitly. The manifest write is best-effort: a failure to
+    update the shard manifest is logged to stderr but does not cause [save]
+    itself to return [Error]. *)
 
 val get :
   t ->
@@ -25,4 +71,29 @@ val get :
   ?end_date:Date.t ->
   unit ->
   (Types.Daily_price.t list, Status.t) Result.t
-(** Get prices from CSV file, optionally filtered by date range *)
+(** Get prices from CSV file, optionally filtered by date range. Does not verify
+    the manifest hash — for that, use {!load_with_verify}. *)
+
+val load_with_verify :
+  t ->
+  ?strictness:[ `Strict | `Warn | `Off ] ->
+  ?start_date:Date.t ->
+  ?end_date:Date.t ->
+  unit ->
+  (Types.Daily_price.t list, Status.t) Result.t
+(** [load_with_verify t ?strictness ?start_date ?end_date ()] loads the CSV
+    contents like {!get} and additionally checks the on-disk file's MD5 against
+    the manifest entry for the symbol.
+
+    Behavior is governed by [strictness] (default [`Warn]):
+    - [`Strict]: a mismatch returns
+      [Error Status.Internal "data corruption: <symbol> sha256 mismatch
+       (manifest=<X>, file=<Y>)"]. A missing manifest or missing entry is
+      tolerated (treated as "no claim to verify") so that data fetched before
+      Phase 2 still loads.
+    - [`Warn]: same checks as [`Strict] but a mismatch (or absent manifest /
+      entry) is logged to stderr and the data is returned [Ok].
+    - [`Off]: no manifest read or hash check; identical to {!get}.
+
+    The CSV read itself can still fail with [Error] (file missing, malformed
+    rows, invalid date range) just like {!get}. *)

--- a/trading/analysis/data/storage/csv/lib/csv_storage_manifest.ml
+++ b/trading/analysis/data/storage/csv/lib/csv_storage_manifest.ml
@@ -1,0 +1,147 @@
+open Core
+open Result.Let_syntax
+
+let shard_manifest_path ~data_dir symbol =
+  let first_char = String.get symbol 0 in
+  let last_char = String.get symbol (String.length symbol - 1) in
+  Fpath.(
+    data_dir / String.make 1 first_char / String.make 1 last_char
+    / "manifest.sexp")
+
+let _log_warning fmt = Printf.eprintf (fmt ^^ "\n%!")
+
+let _read_or_create ~manifest_path =
+  match Manifest.read ~path:manifest_path with
+  | Ok m -> Ok m
+  | Error { code = Status.NotFound; _ } -> Ok (Manifest.create ())
+  | Error _ as e -> e
+
+let _date_of_csv_line line =
+  match line |> String.split ~on:',' |> List.hd with
+  | None -> None
+  | Some s -> ( try Some (Date.of_string s) with _ -> None)
+
+let _date_range_of_path path =
+  try
+    let chan = In_channel.create path in
+    let _header = In_channel.input_line chan in
+    let first = Option.bind (In_channel.input_line chan) ~f:_date_of_csv_line in
+    let last = ref first in
+    In_channel.iter_lines chan ~f:(fun line ->
+        match _date_of_csv_line line with
+        | Some d -> last := Some d
+        | None -> ());
+    In_channel.close chan;
+    match (first, !last) with
+    | Some f, Some l -> Some (f, l)
+    | Some f, None -> Some (f, f)
+    | _ -> None
+  with Sys_error _ -> None
+
+let _row_count_of_path path =
+  try
+    let total =
+      In_channel.with_file path ~f:(fun chan ->
+          In_channel.fold_lines chan ~init:0 ~f:(fun acc _ -> acc + 1))
+    in
+    Int.max 0 (total - 1)
+  with Sys_error _ -> 0
+
+let _build_entry ~symbol ~path ~source ~endpoint ~vendor_revision_tag ~fetch_id
+    ~api_key_id ~sha256 : Manifest.file_metadata =
+  {
+    symbol;
+    source;
+    endpoint;
+    date_range = _date_range_of_path path;
+    rows_count = _row_count_of_path path;
+    sha256;
+    vendor_revision_tag;
+    fetched_at = Time_ns.now ();
+    fetch_id;
+    api_key_id;
+  }
+
+let _write_or_warn ~manifest_path ~symbol m =
+  match Manifest.write ~path:manifest_path m with
+  | Ok () -> Ok ()
+  | Error err ->
+      _log_warning "csv_storage: manifest write failed for %s: %s" symbol
+        err.message;
+      Ok ()
+
+let _upsert_to_disk ~manifest_path ~symbol ~entry =
+  match _read_or_create ~manifest_path with
+  | Error err ->
+      _log_warning "csv_storage: manifest read failed for %s: %s" symbol
+        err.message;
+      Ok ()
+  | Ok m ->
+      _write_or_warn ~manifest_path ~symbol (Manifest.upsert_entry m entry)
+
+let update_for_save ~data_dir ~symbol ~path ~source ~endpoint
+    ~vendor_revision_tag ~fetch_id ~api_key_id =
+  let manifest_path = shard_manifest_path ~data_dir symbol |> Fpath.to_string in
+  match Manifest.sha256_of_file ~path with
+  | Error err ->
+      _log_warning "csv_storage: sha256 failed for %s: %s" symbol err.message;
+      Ok ()
+  | Ok sha256 ->
+      let entry =
+        _build_entry ~symbol ~path ~source ~endpoint ~vendor_revision_tag
+          ~fetch_id ~api_key_id ~sha256
+      in
+      _upsert_to_disk ~manifest_path ~symbol ~entry
+
+let _corruption_msg ~symbol ~claimed ~actual =
+  Printf.sprintf "data corruption: %s sha256 mismatch (manifest=%s, file=%s)"
+    symbol claimed actual
+
+let _verify_hash ~strictness ~symbol ~claimed ~actual =
+  if String.equal claimed actual then Ok ()
+  else
+    match strictness with
+    | `Off -> Ok ()
+    | `Strict ->
+        Status.error_internal (_corruption_msg ~symbol ~claimed ~actual)
+    | `Warn ->
+        _log_warning "csv_storage: %s"
+          (_corruption_msg ~symbol ~claimed ~actual);
+        Ok ()
+
+let _warn_missing ~strictness ~symbol ~reason =
+  match strictness with
+  | `Warn ->
+      _log_warning "csv_storage: no manifest entry for %s (%s); skipping verify"
+        symbol reason
+  | `Strict | `Off -> ()
+
+let _verify_entry_against_file ~strictness ~symbol ~path ~entry =
+  let%bind actual = Manifest.sha256_of_file ~path in
+  _verify_hash ~strictness ~symbol ~claimed:entry.Manifest.sha256 ~actual
+
+let _verify_loaded ~strictness ~symbol ~path m =
+  match Manifest.find m ~symbol with
+  | None ->
+      _warn_missing ~strictness ~symbol ~reason:"no entry for symbol";
+      Ok ()
+  | Some entry -> _verify_entry_against_file ~strictness ~symbol ~path ~entry
+
+let _verify_active ~strictness ~symbol ~path ~manifest_path =
+  match Manifest.read ~path:manifest_path with
+  | Error { code = Status.NotFound; _ } ->
+      _warn_missing ~strictness ~symbol ~reason:"no manifest";
+      Ok ()
+  | Error err ->
+      _warn_missing ~strictness ~symbol ~reason:err.message;
+      Ok ()
+  | Ok m -> _verify_loaded ~strictness ~symbol ~path m
+
+let verify ~data_dir ~symbol ~path ~strictness =
+  match strictness with
+  | `Off -> Ok ()
+  | `Strict | `Warn ->
+      let manifest_path =
+        shard_manifest_path ~data_dir symbol |> Fpath.to_string
+      in
+      _verify_active ~strictness ~symbol ~path ~manifest_path

--- a/trading/analysis/data/storage/csv/lib/csv_storage_manifest.mli
+++ b/trading/analysis/data/storage/csv/lib/csv_storage_manifest.mli
@@ -1,0 +1,45 @@
+(** CSV-storage ↔ Manifest plumbing.
+
+    Pure helpers extracted from [csv_storage] to keep the main module under the
+    300-line file-length limit and to flatten nesting on the [update_for_save] /
+    [verify] flows.
+
+    Both entry points are non-fatal at the manifest layer: a manifest read or
+    write failure returns [Ok ()] (the CSV operation succeeds either way) after
+    logging a warning to stderr. The only exception is [verify] under [`Strict]
+    when the sha256 actually mismatches — that surfaces a [Status.Internal]
+    error so callers can act on detected corruption. *)
+
+val shard_manifest_path : data_dir:Fpath.t -> string -> Fpath.t
+(** Compute the per-shard manifest path for a symbol given the cache root. *)
+
+val update_for_save :
+  data_dir:Fpath.t ->
+  symbol:string ->
+  path:string ->
+  source:string ->
+  endpoint:string ->
+  vendor_revision_tag:string ->
+  fetch_id:string ->
+  api_key_id:string ->
+  unit Status.status_or
+(** After [csv_storage.save] writes a CSV, call this to update the manifest
+    entry. Hashes the on-disk file, derives the date range + row count, and
+    upserts the entry into [<data_dir>/<L1>/<L2>/manifest.sexp].
+
+    Always returns [Ok ()] — manifest failures log a warning but do not surface
+    as errors. *)
+
+val verify :
+  data_dir:Fpath.t ->
+  symbol:string ->
+  path:string ->
+  strictness:[ `Strict | `Warn | `Off ] ->
+  unit Status.status_or
+(** Verify the on-disk CSV against the manifest's sha256 claim under the given
+    strictness:
+
+    - [`Off]: no-op, returns [Ok ()].
+    - [`Warn]: mismatch or missing-entry logs a warning, returns [Ok ()].
+    - [`Strict]: mismatch returns [Status.Internal] error; missing entry still
+      returns [Ok ()] (legacy data tolerance). *)

--- a/trading/analysis/data/storage/csv/lib/dune
+++ b/trading/analysis/data/storage/csv/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name csv)
  (public_name csv)
- (modules csv_storage parser)
+ (modules csv_storage csv_storage_manifest parser)
  (libraries
   bos
   core
@@ -9,6 +9,7 @@
   fpath
   ppx_deriving.runtime
   storage.interface
+  storage.manifest
   types
   unix)
  (preprocess

--- a/trading/analysis/data/storage/csv/test/dune
+++ b/trading/analysis/data/storage/csv/test/dune
@@ -1,6 +1,13 @@
 (test
  (name test_csv_storage)
- (libraries ounit2 csv storage.interface bos))
+ (libraries
+  bos
+  csv
+  matchers
+  ounit2
+  status
+  storage.interface
+  storage.manifest))
 
 (test
  (name test_csv_parser)

--- a/trading/analysis/data/storage/csv/test/test_csv_storage.ml
+++ b/trading/analysis/data/storage/csv/test/test_csv_storage.ml
@@ -2,6 +2,7 @@ open OUnit2
 open Bos
 open Core
 open Csv.Csv_storage
+open Matchers
 open Status
 
 let ok_or_failwith_status = function
@@ -395,6 +396,155 @@ let test_read_legacy_7col_csv _ =
       String.concat ~sep:"\n" (List.map ps ~f:Types.Daily_price.show))
     expected retrieved
 
+(* {1 Phase 2 — manifest integration} *)
+
+(* The shard manifest path is derived from the symbol's [<L1>/<L2>] sharding
+   rule so every test that wants to inspect or tamper with the manifest can
+   do so without re-implementing the path math. *)
+let _manifest_path_for symbol =
+  Csv.Csv_storage.shard_manifest_path ~data_dir:test_dir symbol
+  |> Fpath.to_string
+
+let _csv_path_for symbol =
+  let dir = Csv.Csv_storage.symbol_data_dir ~data_dir:test_dir symbol in
+  Fpath.(dir / "data.csv") |> Fpath.to_string
+
+(* After a successful [save], the per-shard manifest contains an entry for
+   the saved symbol whose sha256 matches the on-disk file. The row count
+   and date range are derived from the written CSV. *)
+let test_save_writes_manifest_entry _ =
+  let symbol = "MAN1" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status
+    (save storage ~source:"EODHD" ~endpoint:"/eod/MAN1" ~fetch_id:"req-1" prices);
+  let manifest =
+    Manifest.read ~path:(_manifest_path_for symbol) |> ok_or_failwith_status
+  in
+  let csv_hash =
+    Manifest.sha256_of_file ~path:(_csv_path_for symbol)
+    |> ok_or_failwith_status
+  in
+  assert_that
+    (Manifest.find manifest ~symbol)
+    (is_some_and
+       (all_of
+          [
+            field (fun e -> e.Manifest.symbol) (equal_to symbol);
+            field (fun e -> e.Manifest.source) (equal_to "EODHD");
+            field (fun e -> e.Manifest.endpoint) (equal_to "/eod/MAN1");
+            field (fun e -> e.Manifest.fetch_id) (equal_to "req-1");
+            field (fun e -> e.Manifest.sha256) (equal_to csv_hash);
+            field (fun e -> e.Manifest.rows_count) (equal_to 4);
+          ]))
+
+(* Two saves for the same symbol must produce a single entry — the second
+   write upserts the first rather than appending. *)
+let test_save_upserts_manifest_entry _ =
+  let symbol = "MAN2" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  ok_or_failwith_status (save storage ~override:true prices);
+  let manifest =
+    Manifest.read ~path:(_manifest_path_for symbol) |> ok_or_failwith_status
+  in
+  assert_that
+    (List.count manifest.entries ~f:(fun e -> String.equal e.symbol symbol))
+    (equal_to 1)
+
+(* [load_with_verify] returns the same rows as [get] when the manifest entry
+   matches the on-disk file. *)
+let test_load_with_verify_round_trip _ =
+  let symbol = "VER1" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  assert_that
+    (load_with_verify storage ~strictness:`Strict ())
+    (is_ok_and_holds (size_is (List.length prices)))
+
+(* Corrupting the on-disk CSV after save trips the strict-mode hash check
+   with a [Status.Internal] error. The Manifest's hash stays at the original
+   file's digest because we never call [save] again. *)
+let _tamper_csv path =
+  let oc = Stdlib.open_out_gen [ Open_append ] 0o666 path in
+  Out_channel.output_string oc "# tamper\n";
+  Out_channel.close oc
+
+let test_load_with_verify_strict_detects_tampering _ =
+  let symbol = "VER2" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  _tamper_csv (_csv_path_for symbol);
+  assert_that
+    (load_with_verify storage ~strictness:`Strict ())
+    (is_error_with Internal)
+
+(* [`Warn] mode tolerates a hash mismatch — the parser-valid replacement
+   loads as [Ok] and the mismatch is only logged to stderr. The replaced
+   CSV has one valid row so the parser succeeds; the on-disk sha256 differs
+   from the manifest entry written by [save]. *)
+let test_load_with_verify_warn_tolerates_mismatch _ =
+  let symbol = "VER3" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  let path = _csv_path_for symbol in
+  let oc = Stdlib.open_out path in
+  Out_channel.output_string oc
+    "date,open,high,low,close,adjusted_close,volume,active_through\n\
+     2024-03-19,100.0,105.0,98.0,103.0,103.0,9999,\n";
+  Out_channel.close oc;
+  assert_that
+    (load_with_verify storage ~strictness:`Warn ())
+    (is_ok_and_holds (size_is 1))
+
+(* [`Off] mode never reads the manifest and never errors on hash mismatch. *)
+let test_load_with_verify_off_skips_check _ =
+  let symbol = "VER4" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  let path = _csv_path_for symbol in
+  let oc = Stdlib.open_out path in
+  Out_channel.output_string oc
+    "date,open,high,low,close,adjusted_close,volume,active_through\n\
+     2024-03-19,100.0,105.0,98.0,103.0,103.0,1,\n";
+  Out_channel.close oc;
+  assert_that
+    (load_with_verify storage ~strictness:`Off ())
+    (is_ok_and_holds (size_is 1))
+
+(* Legacy data (CSV present, no manifest sidecar) must load cleanly under
+   both [`Strict] and [`Warn] — there is no claim to verify. *)
+let test_load_with_verify_no_manifest_strict _ =
+  let symbol = "LEG1" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  (* Write the CSV directly so no manifest is created. *)
+  let path = _csv_path_for symbol in
+  let oc = Stdlib.open_out path in
+  Out_channel.output_string oc
+    "date,open,high,low,close,adjusted_close,volume,active_through\n\
+     2024-03-19,100.0,105.0,98.0,103.0,103.0,1000,\n";
+  Out_channel.close oc;
+  (* The manifest sidecar should not exist for this shard before we load. *)
+  let manifest_path = _manifest_path_for symbol in
+  (try Stdlib.Sys.remove manifest_path with _ -> ());
+  assert_that
+    (load_with_verify storage ~strictness:`Strict ())
+    (is_ok_and_holds (size_is 1))
+
+let test_load_with_verify_no_manifest_warn _ =
+  let symbol = "LEG2" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  let path = _csv_path_for symbol in
+  let oc = Stdlib.open_out path in
+  Out_channel.output_string oc
+    "date,open,high,low,close,adjusted_close,volume,active_through\n\
+     2024-03-19,100.0,105.0,98.0,103.0,103.0,1000,\n";
+  Out_channel.close oc;
+  let manifest_path = _manifest_path_for symbol in
+  (try Stdlib.Sys.remove manifest_path with _ -> ());
+  assert_that
+    (load_with_verify storage ~strictness:`Warn ())
+    (is_ok_and_holds (size_is 1))
+
 let suite =
   "CSV Storage tests"
   >::: [
@@ -425,6 +575,19 @@ let suite =
          "test_save_and_get_with_active_through"
          >:: test_save_and_get_with_active_through;
          "test_read_legacy_7col_csv" >:: test_read_legacy_7col_csv;
+         "test_save_writes_manifest_entry" >:: test_save_writes_manifest_entry;
+         "test_save_upserts_manifest_entry" >:: test_save_upserts_manifest_entry;
+         "test_load_with_verify_round_trip" >:: test_load_with_verify_round_trip;
+         "test_load_with_verify_strict_detects_tampering"
+         >:: test_load_with_verify_strict_detects_tampering;
+         "test_load_with_verify_warn_tolerates_mismatch"
+         >:: test_load_with_verify_warn_tolerates_mismatch;
+         "test_load_with_verify_off_skips_check"
+         >:: test_load_with_verify_off_skips_check;
+         "test_load_with_verify_no_manifest_strict"
+         >:: test_load_with_verify_no_manifest_strict;
+         "test_load_with_verify_no_manifest_warn"
+         >:: test_load_with_verify_no_manifest_warn;
        ]
 
 let () =


### PR DESCRIPTION
## Summary

Phase 2 of `dev/plans/data-inventory-and-reproducibility-2026-05-02.md`. Wires the Phase 1 manifest module (#1142) into the CSV storage layer so every fetched CSV is hash-tracked, and adds a new `load_with_verify` that detects corruption on read.

- `Csv_storage.save` writes/upserts a per-shard manifest entry at `<data-dir>/<L1>/<L2>/manifest.sexp` after each successful CSV write. New optional provenance params (`?source` / `?endpoint` / `?vendor_revision_tag` / `?fetch_id` / `?api_key_id`) carry caller-supplied fetch context; defaults keep existing call sites backward-compatible. Manifest write failures are non-fatal (logged to stderr; `save` still returns `Ok`).
- `Csv_storage.load_with_verify : ?strictness:[ \`Strict | \`Warn | \`Off ]` consults the manifest's recorded sha256 and compares against the on-disk file. `\`Strict` returns `Error (Status.Internal ...)` on mismatch; `\`Warn` (default) logs and returns `Ok`; `\`Off` skips verification. Missing manifest / missing entry is tolerated under all modes so pre-Phase-2 data still loads.
- `Csv_storage.shard_manifest_path` exposed for downstream inspectors and Phase-3 bulk-rehash tools.

Out of scope (deferred to Phase 3): reconcile-on-refetch diff log; bulk-rehash CLI for the existing 41k cached symbols; cross-source dispatch (Shiller, Stooq, etc. writing to their own manifests).

## Test plan

- [x] `dune build && dune runtest analysis/data/storage` clean (56 tests: 25 csv + 14 manifest + 12 metadata + 5 interface)
- [x] `dune build @fmt` clean
- [x] `no_python_check.sh` clean
- [x] `fn_length_linter` clean (longest new function ≤ 24 LOC)
- [x] `linter_magic_numbers` clean
- [x] 8 new OUnit2 tests cover the integration:
  - `save` writes manifest entry with sha256 matching the on-disk file
  - second `save` for the same symbol upserts (not appends) the entry
  - `load_with_verify` round-trips an unmodified file under `\`Strict`
  - tampered file is detected under `\`Strict` (Internal status)
  - tampered file is tolerated (logs, returns Ok) under `\`Warn` and `\`Off`
  - missing manifest is tolerated under both `\`Strict` and `\`Warn`
- [x] Backward-compat: all 17 pre-existing `test_csv_storage` tests + 5 existing storage tests still pass

## Files

- `trading/analysis/data/storage/csv/lib/csv_storage.{ml,mli}` — extended
- `trading/analysis/data/storage/csv/lib/dune` — added `storage.manifest` lib
- `trading/analysis/data/storage/csv/test/test_csv_storage.ml` — 8 new tests
- `trading/analysis/data/storage/csv/test/dune` — added `matchers status storage.manifest` libs
- `dev/status/data-foundations.md` — READY_FOR_REVIEW entry