### PR TITLE
feat(manifest): reconcile-on-refetch diff log (Phase 3 of CSV-manifest)

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -428,6 +428,59 @@ fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
     `analysis/`. Bulk-fetch across the full 41k EODHD cache and
     auto-driven detection over many symbols are deferred (Phase 2+).
 
+### READY_FOR_REVIEW (CSV-manifest Phase 3 — reconcile-on-refetch diff log — 2026-05-17)
+
+- **`Csv_storage_manifest.reconcile_on_save`** (branch
+  `feat/manifest-phase3-reconcile`,
+  `trading/analysis/data/storage/csv/lib/`). Closes the loop on the
+  three-phase CSV-manifest stack (#1142 manifest writer, #1148 hash-verify
+  on load, #1149 bulk-rehash CLI): when a refetch produces content that
+  differs from what the prior manifest entry recorded, the new
+  `reconcile_on_save` captures a structured diff entry under
+  `<data-dir>/_reconcile_log/<YYYY-MM-DD>/<symbol>.sexp` **before** the
+  manifest upsert overwrites the prior entry. Surfaces vendor revision
+  drift, accidental overwrites, and upstream point-in-time changes that
+  would otherwise be silent.
+  - `csv_storage_manifest.{ml,mli}` (+182 LOC) — new types
+    `reconcile_entry` and `reconcile_result = Reconciled _ | Unchanged`;
+    new entry points `reconcile_log_path` (pure path) and
+    `reconcile_on_save` (the wire-in). The diff schema records
+    `reconcile_at`, `symbol`, `old_sha256` / `new_sha256`, `old_date_range`
+    / `new_date_range`, `old_rows_count` / `new_rows_count`, and the
+    caller-supplied `fetch_id`. Date sharding is UTC so log entries are
+    stable across hosts.
+  - `csv_storage.ml` (+4 LOC) — `save` now invokes `reconcile_on_save`
+    between the CSV write and the manifest upsert. The reconcile pass is
+    best-effort: any failure (manifest read, sha256, log-file write) logs
+    a warning to stderr and surfaces as `Ok Unchanged`. The CSV write has
+    already succeeded by the time reconcile runs, so a failed reconcile
+    log must never block the save.
+  - 5 new OUnit2 tests under `csv/test/test_csv_storage.ml`: refetch with
+    byte-identical content writes no log; refetch with mutated content
+    writes a per-symbol sexp under the right date shard with all fields
+    populated; date-shard layout verified by listing the directory;
+    first save (no prior entry) skips reconcile entirely; non-fatal
+    failure path verified by planting a non-directory at the
+    `_reconcile_log` mount point.
+  - **Schema design note:** the plan
+    `dev/plans/data-inventory-and-reproducibility-2026-05-02.md` reserves
+    "Phase 3" for the fetch-log writer (JSONL) and "Phase 4" for a
+    reconciliation tool. This PR implements the **inline** reconciliation
+    half of Phase 4 (the part that lives in the save path itself) since
+    Phase 2 (#1148) explicitly listed it as out-of-scope-deferred-to-Phase-3.
+    The fetch-log writer remains a separate follow-up. Schema designed in
+    the .mli docstring per the task brief.
+  - Out-of-scope: querying / folding over the reconcile log (separate
+    CLI); automatic alerting on reconcile entries; fetch-log JSONL writer.
+  - Linters green: `dune build @fmt`, `no_python_check`,
+    `fn_length_linter` (longest new function ≤ 12 LOC),
+    `linter_magic_numbers`, `nesting_linter`. `dune runtest
+    analysis/data/storage/csv` clean (30 tests, +5 new reconcile tests).
+  - Sizing: 362 LOC total diff (105 in `csv_storage_manifest.ml`, 77 in
+    `.mli`, 4 in `csv_storage.ml`, 175 in tests, 1 dune line). Plan:
+    `dev/plans/data-inventory-and-reproducibility-2026-05-02.md` §Phase 4
+    (inline reconciliation half).
+
 ### READY_FOR_REVIEW (CSV-manifest Phase 3 — bulk-rehash CLI — 2026-05-17)
 
 - **`manifest_rehash` CLI** (branch `feat/manifest-bulk-rehash`,

--- a/trading/analysis/data/storage/csv/lib/csv_storage.ml
+++ b/trading/analysis/data/storage/csv/lib/csv_storage.ml
@@ -257,6 +257,10 @@ let save t ?(override = false) ?(source = "unknown") ?(endpoint = "")
       _handle_existing_and_new_prices t.path ~override existing_prices prices
     else _write_prices_to_file t.path prices
   in
+  let (_ : Csv_storage_manifest.reconcile_result Status.status_or) =
+    Csv_storage_manifest.reconcile_on_save ~data_dir:t.data_dir ~symbol:t.symbol
+      ~new_path:t.path ~fetch_id
+  in
   Csv_storage_manifest.update_for_save ~data_dir:t.data_dir ~symbol:t.symbol
     ~path:t.path ~source ~endpoint ~vendor_revision_tag ~fetch_id ~api_key_id
 

--- a/trading/analysis/data/storage/csv/lib/csv_storage_manifest.ml
+++ b/trading/analysis/data/storage/csv/lib/csv_storage_manifest.ml
@@ -1,6 +1,23 @@
 open Core
 open Result.Let_syntax
 
+type time_ns = Time_ns.Alternate_sexp.t [@@deriving sexp, compare, equal]
+
+type reconcile_entry = {
+  reconcile_at : time_ns;
+  symbol : string;
+  old_sha256 : string;
+  new_sha256 : string;
+  old_date_range : (Date.t * Date.t) option; [@sexp.option]
+  new_date_range : (Date.t * Date.t) option; [@sexp.option]
+  old_rows_count : int;
+  new_rows_count : int;
+  fetch_id : string;
+}
+[@@deriving sexp, compare, equal]
+
+type reconcile_result = Reconciled of reconcile_entry | Unchanged
+
 let shard_manifest_path ~data_dir symbol =
   let first_char = String.get symbol 0 in
   let last_char = String.get symbol (String.length symbol - 1) in
@@ -145,3 +162,91 @@ let verify ~data_dir ~symbol ~path ~strictness =
         shard_manifest_path ~data_dir symbol |> Fpath.to_string
       in
       _verify_active ~strictness ~symbol ~path ~manifest_path
+
+(* {1 Phase 3 — reconcile-on-refetch diff log} *)
+
+let _reconcile_log_dir = "_reconcile_log"
+
+let _date_shard_of_time t =
+  let date = Time_ns.to_date t ~zone:Time_float.Zone.utc in
+  Date.to_string date
+
+let reconcile_log_path ~data_dir ~reconcile_at symbol =
+  let date_shard = _date_shard_of_time reconcile_at in
+  Fpath.(data_dir / _reconcile_log_dir / date_shard / (symbol ^ ".sexp"))
+
+let _build_reconcile_entry ~prior ~new_sha256 ~new_path ~fetch_id =
+  {
+    reconcile_at = Time_ns.now ();
+    symbol = prior.Manifest.symbol;
+    old_sha256 = prior.Manifest.sha256;
+    new_sha256;
+    old_date_range = prior.Manifest.date_range;
+    new_date_range = _date_range_of_path new_path;
+    old_rows_count = prior.Manifest.rows_count;
+    new_rows_count = _row_count_of_path new_path;
+    fetch_id;
+  }
+
+let _ensure_parent_dir ~path =
+  let dir = Filename.dirname path in
+  match Bos.OS.Dir.create ~path:true (Fpath.v dir) with
+  | Ok _ -> Ok ()
+  | Error (`Msg msg) -> Status.error_internal msg
+
+let _append_sexp_to_file ~path sexp =
+  let oc = Stdlib.open_out_gen [ Open_append; Open_creat ] 0o644 path in
+  Exn.protect
+    ~f:(fun () ->
+      Out_channel.output_string oc (Sexp.to_string_hum sexp);
+      Out_channel.newline oc;
+      Ok ())
+    ~finally:(fun () -> Out_channel.close oc)
+  |> Result.map_error ~f:(fun e ->
+      Status.internal_error
+        (Printf.sprintf "Reconcile log write failed: %s" (Exn.to_string e)))
+
+let _write_reconcile_entry ~data_dir entry =
+  let path =
+    reconcile_log_path ~data_dir ~reconcile_at:entry.reconcile_at entry.symbol
+    |> Fpath.to_string
+  in
+  let%bind () = _ensure_parent_dir ~path in
+  _append_sexp_to_file ~path (sexp_of_reconcile_entry entry)
+
+let _persist_or_warn ~data_dir ~symbol entry =
+  match _write_reconcile_entry ~data_dir entry with
+  | Ok () -> Ok (Reconciled entry)
+  | Error err ->
+      _log_warning "csv_storage: reconcile log write failed for %s: %s" symbol
+        err.message;
+      Ok Unchanged
+
+let _reconcile_against_prior ~data_dir ~new_path ~fetch_id prior =
+  match Manifest.sha256_of_file ~path:new_path with
+  | Error err ->
+      _log_warning "csv_storage: reconcile sha256 failed for %s: %s"
+        prior.Manifest.symbol err.message;
+      Ok Unchanged
+  | Ok new_sha256 when String.equal new_sha256 prior.Manifest.sha256 ->
+      Ok Unchanged
+  | Ok new_sha256 ->
+      let entry =
+        _build_reconcile_entry ~prior ~new_sha256 ~new_path ~fetch_id
+      in
+      _persist_or_warn ~data_dir ~symbol:prior.Manifest.symbol entry
+
+let _reconcile_with_loaded ~data_dir ~symbol ~new_path ~fetch_id m =
+  match Manifest.find m ~symbol with
+  | None -> Ok Unchanged
+  | Some prior -> _reconcile_against_prior ~data_dir ~new_path ~fetch_id prior
+
+let reconcile_on_save ~data_dir ~symbol ~new_path ~fetch_id =
+  let manifest_path = shard_manifest_path ~data_dir symbol |> Fpath.to_string in
+  match Manifest.read ~path:manifest_path with
+  | Error { code = Status.NotFound; _ } -> Ok Unchanged
+  | Error err ->
+      _log_warning "csv_storage: reconcile manifest read failed for %s: %s"
+        symbol err.message;
+      Ok Unchanged
+  | Ok m -> _reconcile_with_loaded ~data_dir ~symbol ~new_path ~fetch_id m

--- a/trading/analysis/data/storage/csv/lib/csv_storage_manifest.mli
+++ b/trading/analysis/data/storage/csv/lib/csv_storage_manifest.mli
@@ -10,6 +10,8 @@
     when the sha256 actually mismatches — that surfaces a [Status.Internal]
     error so callers can act on detected corruption. *)
 
+open Core
+
 val shard_manifest_path : data_dir:Fpath.t -> string -> Fpath.t
 (** Compute the per-shard manifest path for a symbol given the cache root. *)
 
@@ -29,6 +31,81 @@ val update_for_save :
 
     Always returns [Ok ()] — manifest failures log a warning but do not surface
     as errors. *)
+
+(** {2 Phase 3 — reconcile-on-refetch diff log}
+
+    When a refetch replaces a previously-cached CSV, the old manifest entry's
+    sha256 records the previous content's digest. If the new on-disk hash
+    differs, we capture a structured diff entry under
+    [<data-dir>/_reconcile_log/<YYYY-MM-DD>/<symbol>.sexp] {b before} the
+    manifest upsert overwrites the prior entry. Subsequent inspections /
+    alerting tooling can fold over these per-day shards to surface vendor
+    revision drift, accidental overwrites, or upstream point-in-time changes.
+
+    The reconcile layer is best-effort: any failure to read the prior manifest
+    or write the log entry is logged to stderr and {b never} surfaces as an
+    error from {!reconcile_on_save}. The CSV write itself has already completed
+    by the time this is called. *)
+
+type reconcile_entry = {
+  reconcile_at : Time_ns.Alternate_sexp.t;
+      (** Wall-clock at which the reconcile diff was captured. Serialized in UTC
+          ISO-8601 via [Time_ns.Alternate_sexp] for parity with the manifest
+          on-disk format. *)
+  symbol : string;
+  old_sha256 : string;  (** Hex digest from the prior manifest entry. *)
+  new_sha256 : string;  (** Hex digest of the on-disk file post-save. *)
+  old_date_range : (Date.t * Date.t) option;
+      (** First/last bar dates of the prior cached file as recorded by the
+          manifest. [None] when the prior entry had no recorded range. *)
+  new_date_range : (Date.t * Date.t) option;
+      (** First/last bar dates of the new on-disk file derived post-save. *)
+  old_rows_count : int;  (** Row count from the prior manifest entry. *)
+  new_rows_count : int;  (** Row count of the new on-disk file. *)
+  fetch_id : string;
+      (** Fetch / request id supplied by the caller; [""] when unavailable. *)
+}
+[@@deriving sexp, compare, equal]
+(** Single reconcile diff record. One per refetch where the content changed. *)
+
+type reconcile_result =
+  | Reconciled of reconcile_entry
+      (** A prior manifest entry existed and its sha256 differed from the new
+          on-disk hash. A diff entry has been written to the reconcile log. *)
+  | Unchanged
+      (** Either no prior manifest entry existed (first save for this symbol),
+          or the prior sha256 matched the new on-disk hash (refetch produced
+          identical content). No diff entry written. *)
+
+val reconcile_log_path :
+  data_dir:Fpath.t -> reconcile_at:Time_ns.t -> string -> Fpath.t
+(** [reconcile_log_path ~data_dir ~reconcile_at symbol] returns the file path
+    where a reconcile entry for [symbol] captured at [reconcile_at] is written:
+    [data_dir / "_reconcile_log" / "YYYY-MM-DD" / "<symbol>.sexp"]. The date
+    shard uses UTC so log entries are stable across hosts. Pure path
+    computation. *)
+
+val reconcile_on_save :
+  data_dir:Fpath.t ->
+  symbol:string ->
+  new_path:string ->
+  fetch_id:string ->
+  reconcile_result Status.status_or
+(** [reconcile_on_save ~data_dir ~symbol ~new_path ~fetch_id] is called by
+    {!Csv_storage.save} {b after} the new CSV has been written but {b before}
+    {!update_for_save} overwrites the manifest entry. It:
+
+    + reads the prior manifest entry for [symbol] (if any);
+    + hashes [new_path] and compares against the prior entry's [sha256];
+    + on mismatch, builds a {!reconcile_entry} from the prior entry's
+      [(sha256, date_range, rows_count)] and the new file's
+      [(sha256, date_range, rows_count)] and appends it to the per-day shard
+      under [<data_dir>/_reconcile_log/<YYYY-MM-DD>/<symbol>.sexp].
+
+    Always returns [Ok _] under happy-path conditions. Manifest read failures,
+    sha256 failures, or reconcile-log write failures are logged to stderr and
+    surface as [Ok Unchanged] — the CSV write has already succeeded and a failed
+    reconcile log is not worth blocking the save on. *)
 
 val verify :
   data_dir:Fpath.t ->

--- a/trading/analysis/data/storage/csv/lib/dune
+++ b/trading/analysis/data/storage/csv/lib/dune
@@ -13,4 +13,4 @@
   types
   unix)
  (preprocess
-  (pps ppx_deriving.show ppx_let)))
+  (pps ppx_compare ppx_deriving.eq ppx_deriving.show ppx_let ppx_sexp_conv)))

--- a/trading/analysis/data/storage/csv/test/test_csv_storage.ml
+++ b/trading/analysis/data/storage/csv/test/test_csv_storage.ml
@@ -545,6 +545,172 @@ let test_load_with_verify_no_manifest_warn _ =
     (load_with_verify storage ~strictness:`Warn ())
     (is_ok_and_holds (size_is 1))
 
+(* {1 Phase 3 — reconcile-on-refetch diff log} *)
+
+let _reconcile_dir = Fpath.(test_dir / "_reconcile_log")
+
+(* The reconcile log is rooted at [test_data/_reconcile_log/]. Tests share the
+   same [test_dir] across cases (setup runs once), so each reconcile-test must
+   reset the reconcile-log tree up front to be order-independent. *)
+let _reset_reconcile_dir () =
+  let path = Fpath.to_string _reconcile_dir in
+  match Sys_unix.file_exists path with
+  | `No | `Unknown -> ()
+  | `Yes -> (
+      (* The dir may have been replaced with a regular file by the
+         failure-injection test; try the file removal first, then the
+         recursive-directory removal as a fallback. *)
+      try Stdlib.Sys.remove path
+      with _ ->
+        ok_or_failwith_os_error (OS.Dir.delete ~recurse:true _reconcile_dir))
+
+(* True iff a per-symbol reconcile entry has been written under any date shard
+   below [_reconcile_dir]. Used to assert presence/absence without baking in
+   today's UTC date as a literal. *)
+let _reconcile_log_for symbol =
+  let recon_path = Fpath.to_string _reconcile_dir in
+  match Sys_unix.file_exists recon_path with
+  | `No | `Unknown -> None
+  | `Yes ->
+      let dates = Sys_unix.readdir recon_path |> Array.to_list in
+      List.find_map dates ~f:(fun d ->
+          let p =
+            Fpath.(_reconcile_dir / d / (symbol ^ ".sexp")) |> Fpath.to_string
+          in
+          match Sys_unix.file_exists p with `Yes -> Some p | _ -> None)
+
+(* A refetch with byte-identical content produces no reconcile entry. The
+   sha256 of the new file matches the prior manifest entry, so [save] takes
+   the [Unchanged] branch and no per-symbol log file is written. *)
+let test_reconcile_no_op_when_content_unchanged _ =
+  _reset_reconcile_dir ();
+  let symbol = "REC1" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  ok_or_failwith_status (save storage ~override:true prices);
+  assert_that (_reconcile_log_for symbol) is_none
+
+(* Refetch with different rows on the same date triggers a reconcile entry.
+   The entry's [old_*] fields come from the prior manifest entry; [new_*]
+   fields are derived from the post-save on-disk file. *)
+let test_reconcile_writes_entry_when_content_changes _ =
+  _reset_reconcile_dir ();
+  let symbol = "REC2" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status
+    (save storage ~source:"EODHD" ~fetch_id:"req-old" prices);
+  let prior_manifest =
+    Manifest.read ~path:(_manifest_path_for symbol) |> ok_or_failwith_status
+  in
+  let prior_entry =
+    match Manifest.find prior_manifest ~symbol with
+    | Some e -> e
+    | None -> assert_failure "expected manifest entry from first save"
+  in
+  let mutated_prices =
+    List.map prices ~f:(fun p ->
+        { p with Types.Daily_price.close_price = p.close_price +. 1.0 })
+  in
+  ok_or_failwith_status
+    (save storage ~override:true ~source:"EODHD" ~fetch_id:"req-new"
+       mutated_prices);
+  let new_csv_hash =
+    Manifest.sha256_of_file ~path:(_csv_path_for symbol)
+    |> ok_or_failwith_status
+  in
+  let today_shard =
+    Time_ns.to_date (Time_ns.now ()) ~zone:Time_float.Zone.utc |> Date.to_string
+  in
+  let log_path =
+    Fpath.(_reconcile_dir / today_shard / (symbol ^ ".sexp")) |> Fpath.to_string
+  in
+  let log_contents = In_channel.read_all log_path in
+  let entry =
+    Csv.Csv_storage_manifest.reconcile_entry_of_sexp
+      (Sexp.of_string (String.strip log_contents))
+  in
+  assert_that entry
+    (all_of
+       [
+         field (fun e -> e.Csv.Csv_storage_manifest.symbol) (equal_to symbol);
+         field
+           (fun e -> e.Csv.Csv_storage_manifest.old_sha256)
+           (equal_to prior_entry.Manifest.sha256);
+         field
+           (fun e -> e.Csv.Csv_storage_manifest.new_sha256)
+           (equal_to new_csv_hash);
+         field
+           (fun e -> e.Csv.Csv_storage_manifest.old_rows_count)
+           (equal_to prior_entry.Manifest.rows_count);
+         field
+           (fun e -> e.Csv.Csv_storage_manifest.new_rows_count)
+           (equal_to (List.length prices));
+         field
+           (fun e -> e.Csv.Csv_storage_manifest.fetch_id)
+           (equal_to "req-new");
+       ])
+
+(* The reconcile log is sharded by UTC date directory. After a content-changing
+   refetch the date directory exists, contains the per-symbol sexp, and the
+   directory's name parses as a valid date. *)
+let test_reconcile_log_path_layout _ =
+  _reset_reconcile_dir ();
+  let symbol = "REC3" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  let mutated_prices =
+    List.map prices ~f:(fun p ->
+        { p with Types.Daily_price.volume = p.volume + 1 })
+  in
+  ok_or_failwith_status (save storage ~override:true mutated_prices);
+  let date_shards =
+    Sys_unix.readdir (Fpath.to_string _reconcile_dir) |> Array.to_list
+  in
+  assert_that (List.length date_shards) (equal_to 1);
+  let shard_name = List.hd_exn date_shards in
+  let _ = Date.of_string shard_name in
+  let symbol_file =
+    Fpath.(_reconcile_dir / shard_name / (symbol ^ ".sexp")) |> Fpath.to_string
+  in
+  let exists =
+    match Sys_unix.file_exists symbol_file with `Yes -> true | _ -> false
+  in
+  assert_that exists (equal_to true)
+
+(* First save (no prior manifest entry) skips the reconcile pass entirely.
+   The reconcile-log directory must not exist after a single fresh save. *)
+let test_reconcile_first_save_creates_no_log _ =
+  _reset_reconcile_dir ();
+  let symbol = "REC4" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  assert_that (_reconcile_log_for symbol) is_none
+
+(* A reconcile-log write failure must not surface as an error from [save].
+   We force the failure by pre-creating a non-directory at the reconcile-log
+   shard path so the [_ensure_parent_dir] call inside [reconcile_on_save]
+   fails. The save returns [Ok ()] regardless. *)
+let test_reconcile_failure_is_non_fatal _ =
+  _reset_reconcile_dir ();
+  let symbol = "REC5" in
+  let storage = create ~data_dir:test_dir symbol |> ok_or_failwith_status in
+  ok_or_failwith_status (save storage prices);
+  (* Plant a regular file where the reconcile-log directory would live so
+     [_ensure_parent_dir] fails when reconcile_on_save tries to create it. *)
+  let recon_dir = Fpath.to_string _reconcile_dir in
+  let oc = Stdlib.open_out recon_dir in
+  Out_channel.output_string oc "not a directory\n";
+  Out_channel.close oc;
+  let mutated_prices =
+    List.map prices ~f:(fun p ->
+        { p with Types.Daily_price.high_price = p.high_price +. 0.5 })
+  in
+  assert_that
+    (save storage ~override:true mutated_prices)
+    (is_ok_and_holds (equal_to ()));
+  (* Cleanup the planted file so teardown can run normally. *)
+  try Stdlib.Sys.remove recon_dir with _ -> ()
+
 let suite =
   "CSV Storage tests"
   >::: [
@@ -588,6 +754,15 @@ let suite =
          >:: test_load_with_verify_no_manifest_strict;
          "test_load_with_verify_no_manifest_warn"
          >:: test_load_with_verify_no_manifest_warn;
+         "test_reconcile_no_op_when_content_unchanged"
+         >:: test_reconcile_no_op_when_content_unchanged;
+         "test_reconcile_writes_entry_when_content_changes"
+         >:: test_reconcile_writes_entry_when_content_changes;
+         "test_reconcile_log_path_layout" >:: test_reconcile_log_path_layout;
+         "test_reconcile_first_save_creates_no_log"
+         >:: test_reconcile_first_save_creates_no_log;
+         "test_reconcile_failure_is_non_fatal"
+         >:: test_reconcile_failure_is_non_fatal;
        ]
 
 let () =


### PR DESCRIPTION
## Summary

Closes the loop on the three-phase CSV-manifest stack: when `Csv_storage.save` replaces a previously-cached CSV whose content differs from what the prior manifest entry recorded, capture a structured diff entry under `<data-dir>/_reconcile_log/<YYYY-MM-DD>/<symbol>.sexp` **before** the manifest upsert overwrites the prior entry. Without this, vendor revision drift, accidental overwrites, and upstream point-in-time changes are silent.

Stack:
- #1142 Phase 1 — manifest writer / reader
- #1148 Phase 2 — hash-verify on load
- #1149 Phase 3 — bulk-rehash CLI (deployment helper)
- this PR — reconcile-on-refetch (closes the loop)

## What it does

Adds two types and two entry points to `Csv_storage_manifest`:

- `reconcile_entry` — sexp-serializable record: `{ reconcile_at, symbol, old_sha256, new_sha256, old_date_range, new_date_range, old_rows_count, new_rows_count, fetch_id }`.
- `reconcile_result = Reconciled of reconcile_entry | Unchanged`.
- `reconcile_log_path : data_dir -> reconcile_at -> symbol -> Fpath.t` — pure path computation.
- `reconcile_on_save : data_dir -> symbol -> new_path -> fetch_id -> reconcile_result status_or` — called between the CSV write and the manifest upsert.

Wired into `Csv_storage.save` so every refetch that produces different content writes one log entry. Identical refetches (sha256 matches) write nothing; first saves (no prior entry) write nothing.

## Schema design

The plan `dev/plans/data-inventory-and-reproducibility-2026-05-02.md` does not detail a Phase 3 reconcile schema — it reserves "Phase 3" for a fetch-log JSONL writer and "Phase 4" for a separate reconciliation CLI. This PR implements the **inline** reconciliation half of Phase 4 (the part that lives in the save path itself) because Phase 2 (#1148) explicitly listed it as out-of-scope-deferred-to-Phase-3. The fetch-log JSONL writer remains a separate follow-up.

Schema decisions documented in the `.mli` docstring:

- **Per-day sharding**: log files live at `<data-dir>/_reconcile_log/<YYYY-MM-DD>/<symbol>.sexp`. The date shard uses UTC so log entries are stable across hosts. Keeps each shard small and rotates naturally.
- **Sexp, not JSONL**: parity with the existing manifest format (`<data-dir>/<L1>/<L2>/manifest.sexp`) and direct round-trip via `[@@deriving sexp]`. JSONL is reserved for the future fetch-log writer.
- **Append-only**: a file may contain multiple sexp entries (one per reconcile event for that symbol on that day). The reader is expected to fold over all sexps in the file.
- **`fetch_id` propagated from `Csv_storage.save`'s existing `?fetch_id` param**: ties a reconcile entry back to the fetch_log entry that produced it (once the fetch_log writer lands).

## Non-fatal failure semantics

The reconcile pass is best-effort. Any of:
- prior manifest read fails (other than `NotFound`),
- sha256 hash of the new file fails,
- reconcile-log directory create / file write fails

is logged to stderr and surfaces as `Ok Unchanged`. The CSV write has already succeeded by the time `reconcile_on_save` runs, so a failed reconcile log must never block the save.

## Test plan

- [x] `dune build` clean on a clean checkout
- [x] `dune build @fmt` clean
- [x] `dune runtest analysis/data/storage/csv` clean (30 tests, +5 new)
- [x] `dune runtest devtools` clean (`fn_length_linter`, `linter_magic_numbers`, `nesting_linter`, format check — all green)
- [x] `dune runtest analysis/data/storage` clean (all manifest + csv tests)

New OUnit2 coverage in `csv/test/test_csv_storage.ml`:

- `test_reconcile_no_op_when_content_unchanged` — refetch with byte-identical content writes no log file
- `test_reconcile_writes_entry_when_content_changes` — mutated refetch writes a per-symbol sexp; all fields populated (old/new sha256, old/new rows_count, fetch_id round-trip)
- `test_reconcile_log_path_layout` — log lives under a UTC-date shard directory; the date shard parses as a valid `Date.t`
- `test_reconcile_first_save_creates_no_log` — first save (no prior manifest entry) skips reconcile entirely
- `test_reconcile_failure_is_non_fatal` — planting a non-directory at the `_reconcile_log` mount point causes the log write to fail; `save` still returns `Ok ()` and a warning is logged

## Out of scope (future PRs)

- Querying / folding over the reconcile log (separate CLI; would surface "show me everything that changed in May 2026").
- Automatic alerting on reconcile entries (Slack / email).
- Fetch-log JSONL writer (the originally-numbered Phase 3 from the plan).

## Sizing

- 362 LOC total diff (excluding status):
  - `csv_storage_manifest.ml`: +105
  - `csv_storage_manifest.mli`: +77 (mostly docstrings)
  - `csv_storage.ml`: +4 (wire-in)
  - `dune`: +1 (added `ppx_compare ppx_deriving.eq ppx_sexp_conv` to preprocess)
  - `test/test_csv_storage.ml`: +175 (5 new tests + helpers)
- Longest new function: 12 LOC (`_reconcile_against_prior`). Fn-length linter clean.

Generated with Claude Code (https://claude.com/claude-code)