### PR TITLE
feat(backtest): cost-model overlay — 4 independent cost knobs

### DIFF
--- a/dev/plans/cost-model-overlay-2026-05-17.md
+++ b/dev/plans/cost-model-overlay-2026-05-17.md
@@ -1,0 +1,99 @@
+# Cost-model overlay — 2026-05-17
+
+## Why
+
+Cell E baseline (~341.69% / 0.78 Sharpe on 15y per
+`memory/project_sp500_baseline_conflict.md`) was measured frictionless.
+Real costs (commission + slippage + bid-ask spread + market impact) will
+reduce realized returns. Listed as the next-after-M5.5 priority in
+`memory/project_m5-5-tuning-exhausted.md`.
+
+## State of cost knobs today
+
+The engine already exposes two cost knobs (`trading/trading/engine/lib/types.mli`):
+
+1. **`commission_config { per_share : float; minimum : float }`** — wired
+   through `Simulator.create_deps ~commission` and applied via
+   `Engine._calculate_commission`: `max(per_share * qty, minimum)`.
+2. **`slippage_bps : int`** — one-side bps applied symmetrically at fill
+   price via `Engine._apply_slippage_to_fill` (PR #920). Plumbed into
+   scenarios as `slippage_bps : int option`.
+
+These cover **per-share commission** and **bid-ask spread** from the task
+spec. Missing knobs:
+
+- **`per_trade_commission`** — flat dollars per trade independent of share
+  count.
+- **`market_impact_bps_per_pct_adv`** — impact bps that scale with order
+  size as a fraction of average daily volume.
+
+## Decision: build `cost_model` as a scenario-facing canonical record
+
+Rather than touch `engine/types.mli` (would force every engine_config
+caller to change) or build a parallel engine, we add a new
+`Cost_model` module under `trading/trading/backtest/cost_model/lib/`
+that:
+
+1. Defines a single canonical `Cost_model.t` config record (the four
+   knobs from the task spec, as `float`s).
+2. Provides `to_engine_costs : t -> (commission_config * int)` to convert
+   into the existing engine wiring. Bid-ask-bps float is rounded to int
+   for engine consumption (engine API is `int`; preserve byte-equal
+   baseline for zero-cost defaults).
+3. Provides `apply_per_trade_commission : t -> trade -> trade` — a
+   post-fill `Trade.t` adjustment hook that adds the flat per-trade
+   commission to `trade.commission`. This is the cleanest Trade-record
+   adjustment layer: it does not require engine changes and is easily
+   composable.
+4. Provides `market_impact_bps : t -> adv_pct:float -> float` — a pure
+   function returning the impact bps for an order of `adv_pct` percent of
+   average daily volume. Currently not auto-applied (ADV is not plumbed
+   into the engine yet); shipped pure + tested so we can wire it later
+   from an analysis script or a future engine extension without
+   reshaping the API. Documenting this as deferred wiring is explicit
+   in the .mli.
+5. `zero : t` — back-compat default for scenarios that omit cost_model.
+
+### Integration point
+
+- `Cost_model.t` lives independently in `trading/trading/backtest/cost_model/lib/`.
+- Wiring into the simulator happens via `to_engine_costs` at the call
+  site (caller passes the result into `Simulator.create_deps
+  ~commission ~slippage_bps`).
+- Per-trade flat commission is applied as a post-fill `Trade.t`
+  rewrite by passing the simulator's emitted trades through
+  `Cost_model.apply_per_trade_commission` — but for **this PR** we ship
+  the module standalone (not yet wired into runner.ml). Wiring into
+  one canonical scenario sexp is a one-line change in `scenario.mli`
+  to add the optional `cost_model` field; we do that minimally so
+  scenarios CAN reference it without breaking back-compat.
+
+This keeps the PR clean and the cost model isolated and testable.
+Re-pinning baselines under cost overlay is **explicitly out of scope**
+per the task brief.
+
+## Files to touch
+
+New:
+- `trading/trading/backtest/cost_model/lib/cost_model.ml` (~120 LOC)
+- `trading/trading/backtest/cost_model/lib/cost_model.mli` (~90 LOC)
+- `trading/trading/backtest/cost_model/lib/dune` (~6 LOC)
+- `trading/trading/backtest/cost_model/test/test_cost_model.ml` (~150 LOC)
+- `trading/trading/backtest/cost_model/test/dune` (~8 LOC)
+
+No changes to engine, simulator, portfolio, or strategy code.
+Scenarios with cost_model integration land in a follow-up PR (one
+scenario at a time, deliberate baseline-re-pin work).
+
+## Test plan
+
+Covers:
+1. Zero-cost default — every output is identity / zero.
+2. Per-share commission only — engine_costs.per_share is correctly
+   forwarded.
+3. Per-trade flat commission — adds correct delta to `trade.commission`
+   regardless of share count.
+4. Bid-ask spread bps → engine slippage_bps int (round-trip + truncation).
+5. Market impact — linear scaling with adv_pct; zero when coef is zero.
+6. Combined retail-default and institutional-default round-trips.
+7. Negative parameters rejected via `validate`.

--- a/dev/status/cost-model.md
+++ b/dev/status/cost-model.md
@@ -1,0 +1,82 @@
+# Status: cost-model
+
+## Last updated: 2026-05-17
+
+## Status
+READY_FOR_REVIEW
+
+Canonical scenario-facing cost-overlay configuration module. Listed
+as the next-after-M5.5 priority in
+`memory/project_m5-5-tuning-exhausted.md`.
+
+## Interface stable
+
+`Backtest_cost_model.Cost_model` (`trading/trading/backtest/cost_model/lib/`):
+- `type t = { per_trade_commission; per_share_commission;
+  bid_ask_spread_bps; market_impact_bps_per_pct_adv }` — four
+  independent non-negative `float` knobs.
+- `zero : t` — frictionless baseline.
+- `retail_default : t` — $0/trade, $0/share, 5 bps, no impact.
+- `institutional_default : t` — $0/trade, $0.005/share, 2 bps, 1 bps
+  per 1% ADV.
+- `validate : t -> (unit, Status.t) result` — rejects negative or
+  non-finite values.
+- `to_engine_costs : t -> commission_config * int` — converts to the
+  engine's existing wiring. Spread bps rounds to int.
+- `apply_per_trade_commission : t -> trade -> trade` — post-fill
+  Trade-record adjustment that adds the flat per-trade commission.
+- `market_impact_bps : t -> adv_pct:float -> float` — pure linear
+  impact bps function.
+- `apply_market_impact : t -> adv_pct -> side -> fill_price -> float`
+  — symmetric one-side impact-adjusted fill price.
+
+## Completed
+
+- [x] **Cost-model module** (PR pending, 2026-05-17). Module +
+  test (27 cases, all green). ~85 LOC impl, ~130 LOC mli, ~290 LOC
+  test. Wired into nothing — standalone, callers can opt in. Verify:
+  `dune runtest trading/backtest/cost_model` (27/27 pass).
+
+## Open work
+
+- [ ] **Wire `cost_model` sexp field into `scenario.mli`** — add
+  `cost_model : Cost_model.t option` so scenarios can declare costs
+  declaratively. Lifts the existing `slippage_bps : int option`
+  into the broader config. Defer until at least one scenario needs
+  per-trade or impact, since `slippage_bps` already covers the
+  bid-ask-spread case.
+- [ ] **Wire `apply_per_trade_commission` into the simulator's
+  post-fill hook** — currently a standalone helper. Likely the
+  cleanest place is `Simulator._apply_trades_best_effort` (map
+  trades through the adjustment before applying to portfolio).
+  Trade-off: when this lands, every scenario re-pin is needed.
+- [ ] **Wire market-impact into the engine** — requires ADV
+  plumbing. ADV needs to be loaded alongside bars; not yet in the
+  simulation data layer. Defer until empirical evidence shows
+  impact dominates over spread for realistic order sizes.
+
+## Follow-up experiments
+
+- Sweep `bid_ask_spread_bps` from 0 to 50 bps and pin returns / Sharpe
+  attrition curve for Cell E (15y SP500). Already partly probed by
+  the existing `slippage_bps` knob (PR #920); this would extend to
+  more bps levels with the cost_model harness.
+- Once per-trade commission is wired, sweep $0 / $0.50 / $1 / $5 per
+  trade. Strategies that trade more frequently will suffer
+  disproportionately — a useful signal for sizing dynamics work.
+
+## Notes
+
+- The pre-existing `Trading_engine.Types.engine_config` already
+  exposes `per_share` commission + `slippage_bps`. The cost_model
+  module is intentionally **additive**: it does not reshape engine
+  types; it converts into them. This preserves byte-equal baselines
+  for any scenario that opts out by passing `Cost_model.zero`.
+- Negative `adv_pct` is clamped to zero in `market_impact_bps` to
+  prevent sell-side orders against thin tape from producing a
+  negative-impact "bonus" (artefact of linear extrapolation).
+- The engine's `commission_config.minimum` floor is intentionally NOT
+  exposed by `Cost_model.t`. It's a different concept from a flat
+  per-trade fee (per-share calculations with a floor vs flat per
+  trade). If a future scenario needs it, route through engine config
+  directly.

--- a/dev/status/cost-model.md
+++ b/dev/status/cost-model.md
@@ -11,6 +11,10 @@ as the next-after-M5.5 priority in
 
 ## Interface stable
 
+YES
+
+### Surface
+
 `Backtest_cost_model.Cost_model` (`trading/trading/backtest/cost_model/lib/`):
 - `type t = { per_trade_commission; per_share_commission;
   bid_ask_spread_bps; market_impact_bps_per_pct_adv }` — four

--- a/trading/trading/backtest/cost_model/lib/cost_model.ml
+++ b/trading/trading/backtest/cost_model/lib/cost_model.ml
@@ -1,0 +1,87 @@
+(** Cost-model overlay for backtest pipelines. See [cost_model.mli] for the
+    contract. *)
+
+open Core
+
+type t = {
+  per_trade_commission : float;
+  per_share_commission : float;
+  bid_ask_spread_bps : float;
+  market_impact_bps_per_pct_adv : float;
+}
+[@@deriving sexp, show, eq]
+
+let zero =
+  {
+    per_trade_commission = 0.0;
+    per_share_commission = 0.0;
+    bid_ask_spread_bps = 0.0;
+    market_impact_bps_per_pct_adv = 0.0;
+  }
+
+let retail_default =
+  {
+    per_trade_commission = 0.0;
+    per_share_commission = 0.0;
+    bid_ask_spread_bps = 5.0;
+    market_impact_bps_per_pct_adv = 0.0;
+  }
+
+(* IBKR Pro tiered ≈ $0.005/share; bid-ask ≈ 2 bps for top-of-book
+   liquid US equities; impact coefficient ≈ 1 bps per 1% ADV is a
+   conservative-end published baseline (Almgren–Chriss and Kissell
+   give similar magnitudes for small-mid caps). *)
+let institutional_default =
+  {
+    per_trade_commission = 0.0;
+    per_share_commission = 0.005;
+    bid_ask_spread_bps = 2.0;
+    market_impact_bps_per_pct_adv = 1.0;
+  }
+
+(* Returns Ok () if [x] is non-negative and finite; Error otherwise. *)
+let _check_nonneg_finite ~field x =
+  if Float.is_nan x || Float.is_inf x then
+    Error
+      (Status.invalid_argument_error
+         (Printf.sprintf "%s must be finite: %f" field x))
+  else if Float.(x < 0.0) then
+    Error
+      (Status.invalid_argument_error
+         (Printf.sprintf "%s must be >= 0: %f" field x))
+  else Ok ()
+
+let validate t =
+  let validations =
+    [
+      _check_nonneg_finite ~field:"per_trade_commission" t.per_trade_commission;
+      _check_nonneg_finite ~field:"per_share_commission" t.per_share_commission;
+      _check_nonneg_finite ~field:"bid_ask_spread_bps" t.bid_ask_spread_bps;
+      _check_nonneg_finite ~field:"market_impact_bps_per_pct_adv"
+        t.market_impact_bps_per_pct_adv;
+    ]
+  in
+  Status.combine_status_list validations
+
+let to_engine_costs t =
+  let commission =
+    { Trading_engine.Types.per_share = t.per_share_commission; minimum = 0.0 }
+  in
+  let slippage_bps = Float.iround_nearest_exn t.bid_ask_spread_bps in
+  (commission, slippage_bps)
+
+let apply_per_trade_commission t (trade : Trading_base.Types.trade) =
+  if Float.(t.per_trade_commission = 0.0) then trade
+  else { trade with commission = trade.commission +. t.per_trade_commission }
+
+let market_impact_bps t ~adv_pct =
+  let clamped = Float.max adv_pct 0.0 in
+  t.market_impact_bps_per_pct_adv *. clamped
+
+let apply_market_impact t ~adv_pct ~(side : Trading_base.Types.side) ~fill_price
+    =
+  let bps = market_impact_bps t ~adv_pct in
+  if Float.(bps = 0.0) then fill_price
+  else
+    let factor = 1.0 +. (bps /. 10_000.0) in
+    match side with Buy -> fill_price *. factor | Sell -> fill_price /. factor

--- a/trading/trading/backtest/cost_model/lib/cost_model.mli
+++ b/trading/trading/backtest/cost_model/lib/cost_model.mli
@@ -1,0 +1,129 @@
+(** Cost-model overlay for backtest pipelines.
+
+    Canonical, scenario-facing cost-configuration record. Four orthogonal cost
+    components, each parameterised so scenarios can sweep them independently:
+
+    - {b Per-trade flat commission} — dollars per executed trade, independent of
+      share count (typical of "flat-fee" retail brokers).
+    - {b Per-share commission} — dollars per share traded (typical of
+      institutional commissions). Composes with the existing
+      {!Trading_engine.Types.commission_config.minimum} floor when converted via
+      {!to_engine_costs}.
+    - {b Bid-ask spread, basis points} — one-side spread paid at fill. Buys pay
+      the offer (price up), sells take the bid (price down). Composes with the
+      engine's existing intraday-path slippage.
+    - {b Market impact, bps per 1% ADV} — additional bps charged per 1% of
+      average daily volume the order represents. Shipped as a pure function for
+      now; not auto-applied because ADV is not yet plumbed into the fill path.
+      See {!market_impact_bps}.
+
+    The four-component design isolates each cost so scenarios can sweep them
+    independently and so unit tests can pin each in isolation.
+
+    {1 Wiring}
+
+    This module is intentionally separate from the engine. The
+    {!Trading_engine.Types.engine_config} already exposes per-share commission +
+    slippage_bps; rather than reshape that API, this module is the canonical
+    scenario-facing config record and converts via {!to_engine_costs} into the
+    engine's existing surface. The two extra knobs (flat per-trade, market
+    impact) are exposed as pure functions over {!Trading_base.Types.trade} so
+    callers can apply them as a post-fill {!Trading_base.Types.trade} adjustment
+    layer.
+
+    {1 Realistic defaults}
+
+    - {!zero} — frictionless. The default; preserves byte-equal baselines.
+    - {!retail_default} — flat-fee retail: $0/trade, $0/share, 5 bps spread, no
+      impact. Approximates Robinhood / IBKR Lite circa 2026.
+    - {!institutional_default} — institutional: $0/trade, $0.005/share, 2 bps
+      spread, 1 bps per 1% ADV. Approximates IBKR Pro tiered + a conservative
+      impact coefficient. *)
+
+type t = {
+  per_trade_commission : float;
+      (** Dollars per executed trade, independent of share count. Must be
+          {m \geq 0}. Default {m 0.0}. *)
+  per_share_commission : float;
+      (** Dollars per share traded. Must be {m \geq 0}. Default {m 0.0}. Maps to
+          {!Trading_engine.Types.commission_config.per_share}. *)
+  bid_ask_spread_bps : float;
+      (** One-side spread in basis points. Must be {m \geq 0}. Default {m 0.0}.
+          {m 5.0} bps = 0.05% one-side. Converted to the engine's [int]
+          slippage_bps via {!to_engine_costs}. *)
+  market_impact_bps_per_pct_adv : float;
+      (** Impact bps per 1% of average daily volume. Must be {m \geq 0}. Default
+          {m 0.0}. Used by {!market_impact_bps}. *)
+}
+[@@deriving sexp, show, eq]
+(** Cost-model configuration record. Each field is non-negative and
+    independently sweepable. Zero in every field reduces to the frictionless
+    baseline. *)
+
+val zero : t
+(** Frictionless cost model — every component is {m 0.0}. Use as the back-compat
+    default for scenarios that omit cost_model. *)
+
+val retail_default : t
+(** Approximate flat-fee retail broker: $0/trade, $0/share, 5 bps bid-ask, no
+    market impact. *)
+
+val institutional_default : t
+(** Approximate institutional broker: $0/trade, $0.005/share, 2 bps bid-ask, 1
+    bps per 1% ADV market impact. *)
+
+val validate : t -> (unit, Status.t) result
+(** [validate t] returns [Ok ()] iff every field is non-negative and finite.
+    Negative or NaN/infinite values yield an [invalid_argument_error] explaining
+    the offending field. *)
+
+val to_engine_costs : t -> Trading_engine.Types.commission_config * int
+(** [to_engine_costs t] converts the cost-model record into the engine's
+    existing per-share commission record + integer slippage bps. Used to wire
+    scenarios into {!Trading_simulation.Simulator.create_deps}.
+
+    Mapping:
+    - [commission_config.per_share = t.per_share_commission]
+    - [commission_config.minimum   = 0.0] (the flat per-trade component is
+      applied separately via {!apply_per_trade_commission}; the engine's
+      [minimum] floor is a different concept that this module intentionally does
+      not expose)
+    - [slippage_bps = round(t.bid_ask_spread_bps)] (engine API is [int];
+      rounding nearest-half-to-even).
+
+    Per-trade flat commission and market-impact bps are NOT folded into the
+    engine config — they require per-trade information (commission flat: trade
+    count; impact: order size and ADV) and are applied via the helpers below. *)
+
+val apply_per_trade_commission :
+  t -> Trading_base.Types.trade -> Trading_base.Types.trade
+(** [apply_per_trade_commission t trade] returns a trade whose [commission]
+    field has been increased by [t.per_trade_commission]. When
+    [t.per_trade_commission = 0.0] this is the identity function and the input
+    is returned unchanged (byte-equal preservation of the zero-cost baseline).
+*)
+
+val market_impact_bps : t -> adv_pct:float -> float
+(** [market_impact_bps t ~adv_pct] returns the bid-side impact in basis points
+    for an order whose size is [adv_pct] percent of ADV. Linear in [adv_pct]:
+
+    {[
+    result = t.market_impact_bps_per_pct_adv *. adv_pct
+    ]}
+
+    Pure, side-effect-free. Negative [adv_pct] is clamped to zero so sell-side
+    orders against a thin tape never produce a negative impact bonus. This
+    function is currently NOT wired into the simulator (ADV plumbing pending);
+    shipped pure-and-tested so callers can apply it from analysis scripts and so
+    the future wiring change is a thin call-site edit. *)
+
+val apply_market_impact :
+  t ->
+  adv_pct:float ->
+  side:Trading_base.Types.side ->
+  fill_price:float ->
+  float
+(** [apply_market_impact t ~adv_pct ~side ~fill_price] returns the fill price
+    adjusted by the {!market_impact_bps} for the given [adv_pct]. Buys pay up,
+    sells take down — symmetric one-side impact. When the coefficient is zero
+    the input price is returned unchanged. *)

--- a/trading/trading/backtest/cost_model/lib/dune
+++ b/trading/trading/backtest/cost_model/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name backtest_cost_model)
+ (libraries core status trading.base trading.engine)
+ (preprocess
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/cost_model/test/dune
+++ b/trading/trading/backtest/cost_model/test/dune
@@ -1,0 +1,10 @@
+(tests
+ (names test_cost_model)
+ (libraries
+  ounit2
+  core
+  core_unix.time_ns_unix
+  matchers
+  trading.base
+  trading.engine
+  backtest_cost_model))

--- a/trading/trading/backtest/cost_model/test/test_cost_model.ml
+++ b/trading/trading/backtest/cost_model/test/test_cost_model.ml
@@ -1,0 +1,289 @@
+(** Unit tests for [Backtest_cost_model.Cost_model].
+
+    Covers the four cost components in isolation, the zero-cost default,
+    per-trade vs per-share commission interaction, the engine-config conversion,
+    and the validate guard. Follows [.claude/rules/test-patterns.md] — one
+    [assert_that] per value, no nested asserts inside callbacks. *)
+
+open OUnit2
+open Core
+open Matchers
+module CM = Backtest_cost_model.Cost_model
+
+(* ------------------------------------------------------------------ *)
+(* Test data builders                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let make_trade ?(id = "T1") ?(order_id = "O1") ?(symbol = "AAPL")
+    ?(side = Trading_base.Types.Buy) ?(quantity = 100.0) ?(price = 50.0)
+    ?(commission = 0.0) () : Trading_base.Types.trade =
+  {
+    id;
+    order_id;
+    symbol;
+    side;
+    quantity;
+    price;
+    commission;
+    timestamp = Time_ns_unix.epoch;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* zero / defaults                                                      *)
+(* ------------------------------------------------------------------ *)
+
+let test_zero_is_frictionless _ =
+  assert_that CM.zero
+    (all_of
+       [
+         field (fun (t : CM.t) -> t.per_trade_commission) (float_equal 0.0);
+         field (fun (t : CM.t) -> t.per_share_commission) (float_equal 0.0);
+         field (fun (t : CM.t) -> t.bid_ask_spread_bps) (float_equal 0.0);
+         field
+           (fun (t : CM.t) -> t.market_impact_bps_per_pct_adv)
+           (float_equal 0.0);
+       ])
+
+let test_retail_default_has_only_spread _ =
+  assert_that CM.retail_default
+    (all_of
+       [
+         field (fun (t : CM.t) -> t.per_trade_commission) (float_equal 0.0);
+         field (fun (t : CM.t) -> t.per_share_commission) (float_equal 0.0);
+         field (fun (t : CM.t) -> t.bid_ask_spread_bps) (float_equal 5.0);
+         field
+           (fun (t : CM.t) -> t.market_impact_bps_per_pct_adv)
+           (float_equal 0.0);
+       ])
+
+let test_institutional_default_has_per_share_and_impact _ =
+  assert_that CM.institutional_default
+    (all_of
+       [
+         field (fun (t : CM.t) -> t.per_share_commission) (float_equal 0.005);
+         field (fun (t : CM.t) -> t.bid_ask_spread_bps) (float_equal 2.0);
+         field
+           (fun (t : CM.t) -> t.market_impact_bps_per_pct_adv)
+           (float_equal 1.0);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* validate                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let test_validate_zero_ok _ = assert_that (CM.validate CM.zero) is_ok
+
+let test_validate_retail_ok _ =
+  assert_that (CM.validate CM.retail_default) is_ok
+
+let test_validate_negative_per_trade_rejected _ =
+  let bad = { CM.zero with per_trade_commission = -1.0 } in
+  assert_that (CM.validate bad) is_error
+
+let test_validate_negative_per_share_rejected _ =
+  let bad = { CM.zero with per_share_commission = -0.0001 } in
+  assert_that (CM.validate bad) is_error
+
+let test_validate_negative_spread_rejected _ =
+  let bad = { CM.zero with bid_ask_spread_bps = -1.0 } in
+  assert_that (CM.validate bad) is_error
+
+let test_validate_negative_impact_rejected _ =
+  let bad = { CM.zero with market_impact_bps_per_pct_adv = -0.5 } in
+  assert_that (CM.validate bad) is_error
+
+let test_validate_nan_rejected _ =
+  let bad = { CM.zero with bid_ask_spread_bps = Float.nan } in
+  assert_that (CM.validate bad) is_error
+
+let test_validate_inf_rejected _ =
+  let bad = { CM.zero with per_share_commission = Float.infinity } in
+  assert_that (CM.validate bad) is_error
+
+(* ------------------------------------------------------------------ *)
+(* to_engine_costs                                                      *)
+(* ------------------------------------------------------------------ *)
+
+let test_engine_costs_zero _ =
+  let commission, slippage = CM.to_engine_costs CM.zero in
+  assert_that (commission, slippage)
+    (all_of
+       [
+         field
+           (fun (c, _) -> c.Trading_engine.Types.per_share)
+           (float_equal 0.0);
+         field (fun (c, _) -> c.Trading_engine.Types.minimum) (float_equal 0.0);
+         field (fun (_, s) -> s) (equal_to 0);
+       ])
+
+let test_engine_costs_per_share_forwarded _ =
+  let cm = { CM.zero with per_share_commission = 0.005 } in
+  let commission, slippage = CM.to_engine_costs cm in
+  assert_that (commission, slippage)
+    (all_of
+       [
+         field
+           (fun (c, _) -> c.Trading_engine.Types.per_share)
+           (float_equal 0.005);
+         field (fun (c, _) -> c.Trading_engine.Types.minimum) (float_equal 0.0);
+         field (fun (_, s) -> s) (equal_to 0);
+       ])
+
+let test_engine_costs_spread_rounded_to_int _ =
+  (* 4.6 bps rounds to 5; 2.0 bps stays 2 *)
+  let cm = { CM.zero with bid_ask_spread_bps = 4.6 } in
+  let _, slippage = CM.to_engine_costs cm in
+  assert_that slippage (equal_to 5)
+
+let test_engine_costs_spread_truncates_fractional _ =
+  let cm = { CM.zero with bid_ask_spread_bps = 2.0 } in
+  let _, slippage = CM.to_engine_costs cm in
+  assert_that slippage (equal_to 2)
+
+let test_engine_costs_per_trade_NOT_in_engine_costs _ =
+  (* Flat per-trade commission is applied via apply_per_trade_commission,
+     NOT folded into the engine's per-share record. *)
+  let cm = { CM.zero with per_trade_commission = 1.0 } in
+  let commission, _ = CM.to_engine_costs cm in
+  assert_that commission.Trading_engine.Types.per_share (float_equal 0.0)
+
+(* ------------------------------------------------------------------ *)
+(* apply_per_trade_commission                                           *)
+(* ------------------------------------------------------------------ *)
+
+let test_per_trade_commission_adds_flat _ =
+  let cm = { CM.zero with per_trade_commission = 1.50 } in
+  let trade = make_trade ~commission:0.0 () in
+  let adjusted = CM.apply_per_trade_commission cm trade in
+  assert_that adjusted.commission (float_equal 1.50)
+
+let test_per_trade_commission_independent_of_share_count _ =
+  (* Same flat fee whether the trade is 1 share or 10_000 *)
+  let cm = { CM.zero with per_trade_commission = 0.50 } in
+  let small = CM.apply_per_trade_commission cm (make_trade ~quantity:1.0 ()) in
+  let large =
+    CM.apply_per_trade_commission cm (make_trade ~quantity:10_000.0 ())
+  in
+  assert_that
+    (small.commission, large.commission)
+    (all_of
+       [
+         field (fun (s, _) -> s) (float_equal 0.50);
+         field (fun (_, l) -> l) (float_equal 0.50);
+       ])
+
+let test_per_trade_commission_stacks_on_existing _ =
+  let cm = { CM.zero with per_trade_commission = 1.0 } in
+  let trade = make_trade ~commission:2.50 () in
+  let adjusted = CM.apply_per_trade_commission cm trade in
+  assert_that adjusted.commission (float_equal 3.50)
+
+let test_per_trade_commission_zero_is_identity _ =
+  let cm = CM.zero in
+  let trade = make_trade ~commission:1.23 () in
+  let adjusted = CM.apply_per_trade_commission cm trade in
+  assert_that adjusted (equal_to trade)
+
+(* ------------------------------------------------------------------ *)
+(* market_impact_bps                                                    *)
+(* ------------------------------------------------------------------ *)
+
+let test_market_impact_zero_coef_is_zero _ =
+  let bps = CM.market_impact_bps CM.zero ~adv_pct:5.0 in
+  assert_that bps (float_equal 0.0)
+
+let test_market_impact_linear_in_adv _ =
+  (* 2 bps/1%ADV * 3% ADV = 6 bps *)
+  let cm = { CM.zero with market_impact_bps_per_pct_adv = 2.0 } in
+  let bps = CM.market_impact_bps cm ~adv_pct:3.0 in
+  assert_that bps (float_equal 6.0)
+
+let test_market_impact_negative_adv_clamped _ =
+  let cm = { CM.zero with market_impact_bps_per_pct_adv = 2.0 } in
+  let bps = CM.market_impact_bps cm ~adv_pct:(-1.0) in
+  assert_that bps (float_equal 0.0)
+
+(* ------------------------------------------------------------------ *)
+(* apply_market_impact                                                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_apply_market_impact_buy_pays_up _ =
+  (* 10 bps impact: buy fills at 100 * 1.001 = 100.10 *)
+  let cm = { CM.zero with market_impact_bps_per_pct_adv = 10.0 } in
+  let p = CM.apply_market_impact cm ~adv_pct:1.0 ~side:Buy ~fill_price:100.0 in
+  assert_that p (float_equal ~epsilon:1e-6 100.10)
+
+let test_apply_market_impact_sell_takes_down _ =
+  (* 10 bps impact: sell fills at 100 / 1.001 = 99.9001 *)
+  let cm = { CM.zero with market_impact_bps_per_pct_adv = 10.0 } in
+  let p = CM.apply_market_impact cm ~adv_pct:1.0 ~side:Sell ~fill_price:100.0 in
+  assert_that p (float_equal ~epsilon:1e-6 (100.0 /. 1.001))
+
+let test_apply_market_impact_zero_coef_identity _ =
+  let p =
+    CM.apply_market_impact CM.zero ~adv_pct:5.0 ~side:Buy ~fill_price:75.0
+  in
+  assert_that p (float_equal 75.0)
+
+let test_apply_market_impact_zero_adv_identity _ =
+  let cm = { CM.zero with market_impact_bps_per_pct_adv = 10.0 } in
+  let p = CM.apply_market_impact cm ~adv_pct:0.0 ~side:Buy ~fill_price:75.0 in
+  assert_that p (float_equal 75.0)
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let suite =
+  "cost_model"
+  >::: [
+         "zero_is_frictionless" >:: test_zero_is_frictionless;
+         "retail_default_has_only_spread"
+         >:: test_retail_default_has_only_spread;
+         "institutional_default_has_per_share_and_impact"
+         >:: test_institutional_default_has_per_share_and_impact;
+         "validate_zero_ok" >:: test_validate_zero_ok;
+         "validate_retail_ok" >:: test_validate_retail_ok;
+         "validate_negative_per_trade_rejected"
+         >:: test_validate_negative_per_trade_rejected;
+         "validate_negative_per_share_rejected"
+         >:: test_validate_negative_per_share_rejected;
+         "validate_negative_spread_rejected"
+         >:: test_validate_negative_spread_rejected;
+         "validate_negative_impact_rejected"
+         >:: test_validate_negative_impact_rejected;
+         "validate_nan_rejected" >:: test_validate_nan_rejected;
+         "validate_inf_rejected" >:: test_validate_inf_rejected;
+         "engine_costs_zero" >:: test_engine_costs_zero;
+         "engine_costs_per_share_forwarded"
+         >:: test_engine_costs_per_share_forwarded;
+         "engine_costs_spread_rounded_to_int"
+         >:: test_engine_costs_spread_rounded_to_int;
+         "engine_costs_spread_truncates_fractional"
+         >:: test_engine_costs_spread_truncates_fractional;
+         "engine_costs_per_trade_NOT_in_engine_costs"
+         >:: test_engine_costs_per_trade_NOT_in_engine_costs;
+         "per_trade_commission_adds_flat"
+         >:: test_per_trade_commission_adds_flat;
+         "per_trade_commission_independent_of_share_count"
+         >:: test_per_trade_commission_independent_of_share_count;
+         "per_trade_commission_stacks_on_existing"
+         >:: test_per_trade_commission_stacks_on_existing;
+         "per_trade_commission_zero_is_identity"
+         >:: test_per_trade_commission_zero_is_identity;
+         "market_impact_zero_coef_is_zero"
+         >:: test_market_impact_zero_coef_is_zero;
+         "market_impact_linear_in_adv" >:: test_market_impact_linear_in_adv;
+         "market_impact_negative_adv_clamped"
+         >:: test_market_impact_negative_adv_clamped;
+         "apply_market_impact_buy_pays_up"
+         >:: test_apply_market_impact_buy_pays_up;
+         "apply_market_impact_sell_takes_down"
+         >:: test_apply_market_impact_sell_takes_down;
+         "apply_market_impact_zero_coef_identity"
+         >:: test_apply_market_impact_zero_coef_identity;
+         "apply_market_impact_zero_adv_identity"
+         >:: test_apply_market_impact_zero_adv_identity;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Adds `Backtest_cost_model.Cost_model` — a canonical, scenario-facing
cost-overlay config record with four independent non-negative `float`
knobs:

- `per_trade_commission` — flat dollars per trade (independent of share count)
- `per_share_commission` — dollars per share (maps to engine `commission_config.per_share`)
- `bid_ask_spread_bps` — one-side spread bps (maps to engine `slippage_bps`)
- `market_impact_bps_per_pct_adv` — linear impact bps scaling with order size as % of ADV

Listed as the next-after-M5.5 priority in `memory/project_m5-5-tuning-exhausted.md` —
the Cell E 15y baseline (~341.69% / 0.78 Sharpe) was measured frictionless;
this module is the harness for re-pinning under realistic costs.

## What changed

New, additive only — no engine / simulator / strategy code touched.

- `trading/trading/backtest/cost_model/lib/cost_model.{ml,mli,dune}` (~85 LOC impl + ~130 LOC mli)
- `trading/trading/backtest/cost_model/test/{test_cost_model.ml,dune}` (~290 LOC, 27 tests)
- `dev/plans/cost-model-overlay-2026-05-17.md` — design rationale
- `dev/status/cost-model.md` — new tracked work area + follow-up items

## Integration point

**Standalone module, not yet wired in.** The cost_model record converts to
the engine's existing wiring via `Cost_model.to_engine_costs : t ->
(commission_config * int)`, so callers can opt in by passing the result
through `Simulator.create_deps ~commission ~slippage_bps` without
touching engine types. The two new knobs (`per_trade_commission`,
`market_impact_bps_per_pct_adv`) are exposed as pure functions over
`Trading_base.Types.trade`:

- `apply_per_trade_commission : t -> trade -> trade` — post-fill Trade
  adjustment hook (flat fee not foldable into per-share engine config)
- `market_impact_bps / apply_market_impact` — pure linear-impact helpers;
  not auto-applied since ADV plumbing into the engine is pending

Wiring into `runner.ml` + `scenario.mli` and baseline re-pinning are
**deferred to separate PRs** per the task brief.

## Design notes

- Pre-existing `engine_config` already covers per-share commission +
  bid-ask bps via `commission_config { per_share; minimum }` +
  `slippage_bps : int`. The cost_model module is **additive**: it does
  not reshape engine types — it composes onto them. Zero-cost defaults
  (`Cost_model.zero`) preserve byte-equal baselines.
- `commission_config.minimum` (per-share floor) is intentionally NOT
  exposed by `Cost_model.t` — it's a different concept from a flat
  per-trade fee. Future scenarios that need it route through engine
  config directly.
- `bid_ask_spread_bps` is `float` in the cost_model record (scenarios
  should sweep fractional bps); rounded to int via
  `Float.iround_nearest_exn` at `to_engine_costs`.
- Negative `adv_pct` is clamped to zero so sell-side orders against
  thin tape never produce a negative-impact "bonus".

## Test plan

- [x] `dune build && dune runtest trading/backtest/cost_model` — 27/27 pass
- [x] `dune build @fmt` — clean
- [x] Full `dune build` — green
- [x] Full `dune runtest` — green (no regressions; module is purely additive)

Tests cover:
- Zero-cost default + retail / institutional defaults (3 cases)
- `validate` — accepts zero/retail, rejects negative on each field + NaN + Inf (8 cases)
- `to_engine_costs` — zero, per-share forwarding, bps rounding (4.6 → 5), bps truncation (2.0 → 2), per-trade NOT folded into engine (5 cases)
- `apply_per_trade_commission` — adds flat fee, share-count independent, stacks on existing, zero is identity (4 cases)
- `market_impact_bps` — zero coef, linear scaling, negative-ADV clamping (3 cases)
- `apply_market_impact` — buy pays up, sell takes down, zero-coef identity, zero-ADV identity (4 cases)

## Out of scope

- Wiring into `runner.ml` / scenario sexp (follow-up PR; small but requires baseline re-pin coordination)
- Re-pinning Cell E + smaller scenarios under cost overlay (separate session)
- Tax modeling, borrow-rate / short-financing cost, multi-currency frictions

## Follow-up

Tracked in `dev/status/cost-model.md` § Open work.