### PR TITLE
fix(csv-manifest-tests): use is_directory before readdir in _reconcile_log_for

### DIFF
--- a/trading/analysis/data/storage/csv/test/test_csv_storage.ml
+++ b/trading/analysis/data/storage/csv/test/test_csv_storage.ml
@@ -566,10 +566,14 @@ let _reset_reconcile_dir () =
 
 (* True iff a per-symbol reconcile entry has been written under any date shard
    below [_reconcile_dir]. Used to assert presence/absence without baking in
-   today's UTC date as a literal. *)
+   today's UTC date as a literal.
+
+   Returns [None] if [_reconcile_dir] is missing OR is a regular file
+   (which happens transiently inside [test_reconcile_failure_is_non_fatal]'s
+   failure-injection setup); readdir on a non-directory would raise. *)
 let _reconcile_log_for symbol =
   let recon_path = Fpath.to_string _reconcile_dir in
-  match Sys_unix.file_exists recon_path with
+  match Sys_unix.is_directory recon_path with
   | `No | `Unknown -> None
   | `Yes ->
       let dates = Sys_unix.readdir recon_path |> Array.to_list in


### PR DESCRIPTION
## Summary

`_reconcile_log_for` in `test_csv_storage.ml` checks `Sys_unix.file_exists` before `readdir`, but `file_exists` returns `Yes` for both files and directories. When a prior test (specifically `test_reconcile_failure_is_non_fatal`) plants a regular file at `_reconcile_dir`, the subsequent test's call to `_reconcile_log_for` crashes with `Sys_error("test_data/_reconcile_log: Not a directory")`.

Triggered fix-forward after PR #1152 (Kenneth French ingest) hit this failure on CI rebased onto main post-#1150. PR #1151 also hit it but coincidentally passed on retry (the planted-file state was cleaned up between the two CI passes).

## Fix

Switch `_reconcile_log_for` from `Sys_unix.file_exists` (which yields `Yes` for files OR dirs) to `Sys_unix.is_directory` (which yields `Yes` only for directories). When `_reconcile_dir` is missing OR is a regular file, return `None` instead of crashing.

## Test plan

- [x] `dune runtest analysis/data/storage` clean (30 csv tests + 14 manifest tests pass)
- [x] `dune build @fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)