### PR TITLE
feat(eodhd): parse Asset_type from /api/exchange-symbol-list response

### DIFF
--- a/trading/analysis/data/pipelines/fetch_prices/bin/main.ml
+++ b/trading/analysis/data/pipelines/fetch_prices/bin/main.ml
@@ -43,7 +43,8 @@ let main ~num_symbols () =
       | Error status ->
           printf "Error fetching symbols: %s\n" (Status.show status);
           return ()
-      | Ok symbols ->
+      | Ok metadata ->
+          let symbols = List.map metadata ~f:(fun m -> m.code) in
           let selected_symbols = random_sample ~n:num_symbols symbols in
           fetch_and_save_prices ~token ~symbols:selected_symbols ()
           >>| print_results)

--- a/trading/analysis/data/sources/eodhd/lib/asset_type.ml
+++ b/trading/analysis/data/sources/eodhd/lib/asset_type.ml
@@ -1,0 +1,51 @@
+open Core
+
+type t =
+  | Common_stock
+  | Preferred_stock
+  | ETF
+  | Mutual_fund
+  | Fund
+  | ADR
+  | GDR
+  | Bond
+  | Index
+  | Currency
+  | Commodity
+  | Other of string
+[@@deriving show, eq]
+
+let of_eodhd_string raw =
+  match String.strip raw with
+  | "Common Stock" -> Common_stock
+  | "Preferred Stock" -> Preferred_stock
+  | "ETF" -> ETF
+  | "Mutual Fund" -> Mutual_fund
+  | "FUND" | "Fund" | "Closed-End Fund" -> Fund
+  | "ADR" -> ADR
+  | "GDR" -> GDR
+  | "Bond" -> Bond
+  | "INDEX" | "Index" -> Index
+  | "Currency" | "CURRENCY" | "FOREX" -> Currency
+  | "Commodity" | "COMMODITY" | "Future" -> Commodity
+  | "" -> Other ""
+  | other -> Other other
+
+let to_string = function
+  | Common_stock -> "Common Stock"
+  | Preferred_stock -> "Preferred Stock"
+  | ETF -> "ETF"
+  | Mutual_fund -> "Mutual Fund"
+  | Fund -> "Fund"
+  | ADR -> "ADR"
+  | GDR -> "GDR"
+  | Bond -> "Bond"
+  | Index -> "Index"
+  | Currency -> "Currency"
+  | Commodity -> "Commodity"
+  | Other s -> s
+
+let is_equity_like = function
+  | Common_stock | Preferred_stock | ADR | GDR -> true
+  | ETF | Mutual_fund | Fund | Bond | Index | Currency | Commodity | Other _ ->
+      false

--- a/trading/analysis/data/sources/eodhd/lib/asset_type.mli
+++ b/trading/analysis/data/sources/eodhd/lib/asset_type.mli
@@ -1,0 +1,34 @@
+(** Asset classification per EODHD's [/api/exchange-symbol-list] [Type] field.
+    Used downstream to drop mutual funds, ETFs, and other non-common-stock
+    instruments from Weinstein universe-build (see
+    [dev/plans/custom-universe-bidirectional-2026-05-17.md] §Q1). *)
+
+type t =
+  | Common_stock
+  | Preferred_stock
+  | ETF
+  | Mutual_fund
+  | Fund  (** Closed-end fund or other generic fund. *)
+  | ADR
+  | GDR
+  | Bond
+  | Index
+  | Currency
+  | Commodity
+  | Other of string
+      (** Catch-all for unrecognised values. The raw string is preserved so
+          downstream filters can still discriminate without code changes. *)
+[@@deriving show, eq]
+
+val of_eodhd_string : string -> t
+(** Parses the raw [Type] string from EODHD's response. Recognised values are
+    listed in this module's source. Anything else returns [Other raw]. Empty or
+    whitespace-only input also returns [Other ""]. *)
+
+val to_string : t -> string
+(** Round-trips through [of_eodhd_string] for recognised cases. *)
+
+val is_equity_like : t -> bool
+(** [true] for instruments that trade like a common stock: [Common_stock],
+    [Preferred_stock], [ADR], [GDR]. [false] for everything else, including
+    [Other _]. Useful default filter for Weinstein universe-build. *)

--- a/trading/analysis/data/sources/eodhd/lib/http_client.ml
+++ b/trading/analysis/data/sources/eodhd/lib/http_client.ml
@@ -20,6 +20,14 @@ type fundamentals = {
 }
 [@@deriving show, eq]
 
+type symbol_metadata = {
+  code : string;
+  name : string;
+  exchange : string;
+  asset_type : Asset_type.t;
+}
+[@@deriving show, eq]
+
 let _api_host = "eodhd.com"
 
 let default_fetch uri : string Status.status_or Deferred.t =
@@ -63,30 +71,6 @@ let _make_symbols_uri token =
     ~query:[ ("api_token", [ token ]); ("fmt", [ "json" ]) ]
     ()
 
-let _extract_symbol_from_json = function
-  | `Assoc fields -> (
-      match List.find fields ~f:(fun (k, _) -> String.equal k "Code") with
-      | Some (_, `String code) -> Ok code
-      | Some (_, _) ->
-          Status.error_invalid_argument "Code field is not a string"
-      | None -> Status.error_not_found "Code field not found")
-  | _ -> Status.error_invalid_argument "Invalid symbol format"
-
-let _parse_symbols_response body_str =
-  try
-    match Yojson.Safe.from_string body_str with
-    | `List symbols ->
-        let results = List.map symbols ~f:_extract_symbol_from_json in
-        Result.all results
-    | _ -> Status.error_invalid_argument "Invalid response format"
-  with Yojson.Json_error msg ->
-    Status.error_invalid_argument ("Invalid JSON: " ^ msg)
-
-let get_symbols ~token ?(fetch = _fetch_body) () :
-    string list Status.status_or Deferred.t =
-  let uri = _make_symbols_uri token in
-  fetch uri >>| Result.bind ~f:_parse_symbols_response
-
 let _float_of_yojson = function
   | `Float f -> Ok f
   | `Int i -> Ok (float_of_int i)
@@ -120,6 +104,42 @@ let _string_or_null_of_yojson = function
   | v ->
       Status.error_invalid_argument
         ("Expected string or null, got: " ^ Yojson.Safe.to_string v)
+
+let _lookup_string_or_null fields name =
+  match List.Assoc.find ~equal:String.equal fields name with
+  | Some v -> _string_or_null_of_yojson v
+  | None -> Ok ""
+
+let _extract_symbol_from_json = function
+  | `Assoc fields ->
+      let open Result.Let_syntax in
+      let%bind code =
+        match List.Assoc.find ~equal:String.equal fields "Code" with
+        | Some (`String c) -> Ok c
+        | Some _ -> Status.error_invalid_argument "Code field is not a string"
+        | None -> Status.error_not_found "Code field not found"
+      in
+      let%bind name = _lookup_string_or_null fields "Name" in
+      let%bind exchange = _lookup_string_or_null fields "Exchange" in
+      let%bind type_raw = _lookup_string_or_null fields "Type" in
+      let asset_type = Asset_type.of_eodhd_string type_raw in
+      Ok { code; name; exchange; asset_type }
+  | _ -> Status.error_invalid_argument "Invalid symbol format"
+
+let _parse_symbols_response body_str =
+  try
+    match Yojson.Safe.from_string body_str with
+    | `List symbols ->
+        let results = List.map symbols ~f:_extract_symbol_from_json in
+        Result.all results
+    | _ -> Status.error_invalid_argument "Invalid response format"
+  with Yojson.Json_error msg ->
+    Status.error_invalid_argument ("Invalid JSON: " ^ msg)
+
+let get_symbols ~token ?(fetch = _fetch_body) () :
+    symbol_metadata list Status.status_or Deferred.t =
+  let uri = _make_symbols_uri token in
+  fetch uri >>| Result.bind ~f:_parse_symbols_response
 
 let _find_field fields name =
   match List.Assoc.find ~equal:String.equal fields name with
@@ -259,6 +279,9 @@ let get_fundamentals ~token ~symbol ?(fetch = _fetch_body) () :
 
 (* Index symbols *)
 
+let _parse_symbol_codes body =
+  Result.map (_parse_symbols_response body) ~f:(List.map ~f:(fun m -> m.code))
+
 let get_index_symbols ~token ~index ?(fetch = _fetch_body) () :
     string list Status.status_or Deferred.t =
   let uri =
@@ -267,4 +290,4 @@ let get_index_symbols ~token ~index ?(fetch = _fetch_body) () :
       ~query:[ ("api_token", [ token ]); ("fmt", [ "json" ]) ]
       ()
   in
-  fetch uri >>| Result.bind ~f:_parse_symbols_response
+  fetch uri >>| Result.bind ~f:_parse_symbol_codes

--- a/trading/analysis/data/sources/eodhd/lib/http_client.mli
+++ b/trading/analysis/data/sources/eodhd/lib/http_client.mli
@@ -30,6 +30,20 @@ type fundamentals = {
 [@@deriving show, eq]
 (** Fundamental data for a security, including sector and industry metadata. *)
 
+type symbol_metadata = {
+  code : string;  (** Ticker symbol, e.g. ["AAPL"]. *)
+  name : string;
+      (** Human-readable issuer / instrument name. Empty string if missing or
+          null in the source. *)
+  exchange : string;
+      (** Listing exchange, e.g. ["NASDAQ"], ["NYSE ARCA"], ["PINK"]. Empty if
+          missing or null. *)
+  asset_type : Asset_type.t;
+      (** Instrument classification used downstream by universe filters. *)
+}
+[@@deriving show, eq]
+(** Per-symbol metadata returned by [/api/exchange-symbol-list/{ex}]. *)
+
 val get_historical_price :
   token:string ->
   params:historical_price_params ->
@@ -63,8 +77,11 @@ val get_symbols :
   token:string ->
   ?fetch:fetch_fn ->
   unit ->
-  string list Status.status_or Deferred.t
-(** Get a list of symbols for a given exchange *)
+  symbol_metadata list Status.status_or Deferred.t
+(** Fetch the full US exchange symbol listing, including per-symbol [asset_type]
+    / [name] / [exchange] metadata. Used downstream to drop mutual funds and
+    other non-common-stock instruments from Weinstein-style universe-build (see
+    [dev/plans/custom-universe-bidirectional-2026-05-17.md] §Q1). *)
 
 val get_bulk_last_day :
   token:string ->

--- a/trading/analysis/data/sources/eodhd/test/data/get_symbol_list_response.json
+++ b/trading/analysis/data/sources/eodhd/test/data/get_symbol_list_response.json
@@ -1,47 +1,56 @@
 [
   {
-    "Code": "0P000070L2",
-    "Name": "RBC $U.S. Money Market Fund A",
-    "Country": "USA",
-    "Exchange": "OTC",
-    "Currency": "USD",
-    "Type": "FUND",
-    "Isin": null
-  },
-  {
-    "Code": "0P0000A2WI",
-    "Name": "Fidelity American High Yield Sr B",
-    "Country": "USA",
-    "Exchange": "US",
-    "Currency": "USD",
-    "Type": "FUND",
-    "Isin": null
-  },
-  {
-    "Code": "ZZHGY",
-    "Name": "ZhongAn Online P & C Insurance Co. Ltd",
-    "Country": "USA",
-    "Exchange": "PINK",
-    "Currency": "USD",
-    "Type": "Common Stock",
-    "Isin": null
-  },
-  {
-    "Code": "ZZZ",
-    "Name": "Cyber Hornet S&P 500 and Bitcoin 75/25 Strategy ETF",
+    "Code": "AAPL",
+    "Name": "Apple Inc",
     "Country": "USA",
     "Exchange": "NASDAQ",
     "Currency": "USD",
-    "Type": "ETF",
-    "Isin": "US45407J4094"
+    "Type": "Common Stock",
+    "Isin": "US0378331005"
   },
   {
-    "Code": "ZZZOF",
-    "Name": "Zinc One Resources Inc",
+    "Code": "SPY",
+    "Name": "SPDR S&P 500",
+    "Country": "USA",
+    "Exchange": "NYSE ARCA",
+    "Currency": "USD",
+    "Type": "ETF",
+    "Isin": null
+  },
+  {
+    "Code": "0P000070L2",
+    "Name": "Vanguard Total Stock Market",
     "Country": "USA",
     "Exchange": "PINK",
     "Currency": "USD",
-    "Type": "Common Stock",
+    "Type": "Mutual Fund",
+    "Isin": null
+  },
+  {
+    "Code": "BABA",
+    "Name": "Alibaba ADR",
+    "Country": "USA",
+    "Exchange": "NYSE",
+    "Currency": "USD",
+    "Type": "ADR",
+    "Isin": null
+  },
+  {
+    "Code": "GSPC",
+    "Name": "S&P 500 Index",
+    "Country": "USA",
+    "Exchange": "INDEX",
+    "Currency": "USD",
+    "Type": "INDEX",
+    "Isin": null
+  },
+  {
+    "Code": "WTF",
+    "Name": "Mystery",
+    "Country": "USA",
+    "Exchange": "NASDAQ",
+    "Currency": "USD",
+    "Type": "Brand New Type EODHD Just Invented",
     "Isin": null
   }
 ]

--- a/trading/analysis/data/sources/eodhd/test/dune
+++ b/trading/analysis/data/sources/eodhd/test/dune
@@ -4,7 +4,8 @@
   test_splits_endpoint
   test_dividends_endpoint
   test_exchange_resolver
-  test_multi_market)
+  test_multi_market
+  test_asset_type)
  (libraries eodhd core async async_unix ounit2 csv matchers status)
  (deps
   (glob_files ./data/*.json)))

--- a/trading/analysis/data/sources/eodhd/test/test_asset_type.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_asset_type.ml
@@ -1,0 +1,114 @@
+open Core
+open OUnit2
+open Matchers
+open Eodhd
+
+let test_of_eodhd_string_common_stock _ =
+  assert_that
+    (Asset_type.of_eodhd_string "Common Stock")
+    (equal_to Asset_type.Common_stock)
+
+let test_of_eodhd_string_preferred_stock _ =
+  assert_that
+    (Asset_type.of_eodhd_string "Preferred Stock")
+    (equal_to Asset_type.Preferred_stock)
+
+let test_of_eodhd_string_etf _ =
+  assert_that (Asset_type.of_eodhd_string "ETF") (equal_to Asset_type.ETF)
+
+let test_of_eodhd_string_mutual_fund _ =
+  assert_that
+    (Asset_type.of_eodhd_string "Mutual Fund")
+    (equal_to Asset_type.Mutual_fund)
+
+let test_of_eodhd_string_fund_variants _ =
+  (* All three legacy EODHD spellings collapse to [Fund]. *)
+  assert_that
+    (List.map
+       [ "FUND"; "Fund"; "Closed-End Fund" ]
+       ~f:Asset_type.of_eodhd_string)
+    (elements_are
+       [
+         equal_to Asset_type.Fund;
+         equal_to Asset_type.Fund;
+         equal_to Asset_type.Fund;
+       ])
+
+let test_of_eodhd_string_adr _ =
+  assert_that (Asset_type.of_eodhd_string "ADR") (equal_to Asset_type.ADR)
+
+let test_of_eodhd_string_gdr _ =
+  assert_that (Asset_type.of_eodhd_string "GDR") (equal_to Asset_type.GDR)
+
+let test_of_eodhd_string_index_variants _ =
+  assert_that
+    (List.map [ "INDEX"; "Index" ] ~f:Asset_type.of_eodhd_string)
+    (elements_are [ equal_to Asset_type.Index; equal_to Asset_type.Index ])
+
+let test_of_eodhd_string_unknown_preserves_raw _ =
+  assert_that
+    (Asset_type.of_eodhd_string "Brand New Type EODHD Just Invented")
+    (equal_to (Asset_type.Other "Brand New Type EODHD Just Invented"))
+
+let test_of_eodhd_string_empty _ =
+  assert_that (Asset_type.of_eodhd_string "") (equal_to (Asset_type.Other ""))
+
+let test_of_eodhd_string_whitespace _ =
+  (* Whitespace-only collapses to [Other ""] after the [String.strip]. *)
+  assert_that
+    (Asset_type.of_eodhd_string "   ")
+    (equal_to (Asset_type.Other ""))
+
+(* Per the [.mli] contract: [Common_stock; Preferred_stock; ADR; GDR] are
+   equity-like; everything else (including [Other _]) is not. *)
+
+let test_is_equity_like_true_cases _ =
+  let inputs =
+    [
+      Asset_type.Common_stock;
+      Asset_type.Preferred_stock;
+      Asset_type.ADR;
+      Asset_type.GDR;
+    ]
+  in
+  assert_that
+    (List.count inputs ~f:Asset_type.is_equity_like)
+    (equal_to (List.length inputs))
+
+let test_is_equity_like_false_cases _ =
+  let inputs =
+    [
+      Asset_type.ETF;
+      Asset_type.Mutual_fund;
+      Asset_type.Fund;
+      Asset_type.Bond;
+      Asset_type.Index;
+      Asset_type.Currency;
+      Asset_type.Commodity;
+      Asset_type.Other "anything";
+    ]
+  in
+  assert_that (List.count inputs ~f:Asset_type.is_equity_like) (equal_to 0)
+
+let suite =
+  "asset_type_test"
+  >::: [
+         "of_eodhd_string_common_stock" >:: test_of_eodhd_string_common_stock;
+         "of_eodhd_string_preferred_stock"
+         >:: test_of_eodhd_string_preferred_stock;
+         "of_eodhd_string_etf" >:: test_of_eodhd_string_etf;
+         "of_eodhd_string_mutual_fund" >:: test_of_eodhd_string_mutual_fund;
+         "of_eodhd_string_fund_variants" >:: test_of_eodhd_string_fund_variants;
+         "of_eodhd_string_adr" >:: test_of_eodhd_string_adr;
+         "of_eodhd_string_gdr" >:: test_of_eodhd_string_gdr;
+         "of_eodhd_string_index_variants"
+         >:: test_of_eodhd_string_index_variants;
+         "of_eodhd_string_unknown_preserves_raw"
+         >:: test_of_eodhd_string_unknown_preserves_raw;
+         "of_eodhd_string_empty" >:: test_of_eodhd_string_empty;
+         "of_eodhd_string_whitespace" >:: test_of_eodhd_string_whitespace;
+         "is_equity_like_true_cases" >:: test_is_equity_like_true_cases;
+         "is_equity_like_false_cases" >:: test_is_equity_like_false_cases;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/data/sources/eodhd/test/test_http_client.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_http_client.ml
@@ -1,6 +1,7 @@
 open Core
 open Async
 open OUnit2
+open Matchers
 open Eodhd.Http_client
 
 (* data from /trading/analysis/data/sources/eodhd/test/data/get_historical_price.json *)
@@ -235,6 +236,15 @@ let test_get_historical_price_invalid_date_range _ =
            "start_date must be before or equal to end_date")
         status
 
+(* Asserts (code, asset_type) for one symbol_metadata entry. Composed into
+   elements_are below. *)
+let symbol_with ~code ~asset_type : symbol_metadata matcher =
+  all_of
+    [
+      field (fun m -> m.code) (equal_to code);
+      field (fun m -> m.asset_type) (equal_to asset_type);
+    ]
+
 let test_get_symbols _ =
   let mock_fetch uri =
     let actual_uri_str = Uri.to_string uri in
@@ -251,15 +261,90 @@ let test_get_symbols _ =
     Async.Thread_safe.block_on_async_exn (fun () ->
         get_symbols ~fetch:mock_fetch ~token:"test_token" ())
   in
-  match result with
-  | Ok symbols ->
-      let expected_symbols =
-        [ "0P000070L2"; "0P0000A2WI"; "ZZHGY"; "ZZZ"; "ZZZOF" ]
-      in
-      assert_equal
-        ~printer:(fun xs -> String.concat ~sep:"," xs)
-        expected_symbols symbols
-  | Error err -> assert_failure (Status.show err)
+  assert_that result
+    (is_ok_and_holds
+       (elements_are
+          [
+            symbol_with ~code:"AAPL" ~asset_type:Eodhd.Asset_type.Common_stock;
+            symbol_with ~code:"SPY" ~asset_type:Eodhd.Asset_type.ETF;
+            symbol_with ~code:"0P000070L2"
+              ~asset_type:Eodhd.Asset_type.Mutual_fund;
+            symbol_with ~code:"BABA" ~asset_type:Eodhd.Asset_type.ADR;
+            symbol_with ~code:"GSPC" ~asset_type:Eodhd.Asset_type.Index;
+            symbol_with ~code:"WTF"
+              ~asset_type:
+                (Eodhd.Asset_type.Other "Brand New Type EODHD Just Invented");
+          ]))
+
+let test_get_symbols_extracts_name_and_exchange _ =
+  let mock_fetch _uri =
+    let test_data =
+      In_channel.read_all "./data/get_symbol_list_response.json"
+    in
+    Deferred.return (Ok test_data)
+  in
+  let result =
+    Async.Thread_safe.block_on_async_exn (fun () ->
+        get_symbols ~fetch:mock_fetch ~token:"test_token" ())
+  in
+  assert_that result
+    (is_ok_and_holds
+       (elements_are
+          [
+            all_of
+              [
+                field (fun m -> m.name) (equal_to "Apple Inc");
+                field (fun m -> m.exchange) (equal_to "NASDAQ");
+              ];
+            all_of
+              [
+                field (fun m -> m.name) (equal_to "SPDR S&P 500");
+                field (fun m -> m.exchange) (equal_to "NYSE ARCA");
+              ];
+            all_of
+              [
+                field (fun m -> m.name) (equal_to "Vanguard Total Stock Market");
+                field (fun m -> m.exchange) (equal_to "PINK");
+              ];
+            all_of
+              [
+                field (fun m -> m.name) (equal_to "Alibaba ADR");
+                field (fun m -> m.exchange) (equal_to "NYSE");
+              ];
+            all_of
+              [
+                field (fun m -> m.name) (equal_to "S&P 500 Index");
+                field (fun m -> m.exchange) (equal_to "INDEX");
+              ];
+            all_of
+              [
+                field (fun m -> m.name) (equal_to "Mystery");
+                field (fun m -> m.exchange) (equal_to "NASDAQ");
+              ];
+          ]))
+
+let test_get_symbols_partitions_by_equity_like _ =
+  let mock_fetch _uri =
+    let test_data =
+      In_channel.read_all "./data/get_symbol_list_response.json"
+    in
+    Deferred.return (Ok test_data)
+  in
+  let result =
+    Async.Thread_safe.block_on_async_exn (fun () ->
+        get_symbols ~fetch:mock_fetch ~token:"test_token" ())
+  in
+  let equity_like_codes metadata =
+    metadata
+    |> List.filter ~f:(fun m -> Eodhd.Asset_type.is_equity_like m.asset_type)
+    |> List.map ~f:(fun m -> m.code)
+  in
+  (* AAPL (Common_stock) and BABA (ADR) are equity-like; SPY (ETF),
+     0P000070L2 (Mutual_fund), GSPC (Index) and WTF (Other) are not. *)
+  assert_that result
+    (is_ok_and_holds
+       (field equity_like_codes
+          (elements_are [ equal_to "AAPL"; equal_to "BABA" ])))
 
 let test_get_symbols_error _ =
   let mock_fetch _uri =
@@ -458,6 +543,10 @@ let suite =
          "get_fundamentals_error" >:: test_get_fundamentals_error;
          "get_index_symbols" >:: test_get_index_symbols;
          "get_symbols" >:: test_get_symbols;
+         "get_symbols_extracts_name_and_exchange"
+         >:: test_get_symbols_extracts_name_and_exchange;
+         "get_symbols_partitions_by_equity_like"
+         >:: test_get_symbols_partitions_by_equity_like;
          "get_symbols_error" >:: test_get_symbols_error;
          "get_symbols_malformed_data" >:: test_get_symbols_malformed_data;
          "get_bulk_last_day" >:: test_get_bulk_last_day;

--- a/trading/analysis/scripts/above_30w_ema/bin/main.ml
+++ b/trading/analysis/scripts/above_30w_ema/bin/main.ml
@@ -23,7 +23,10 @@ let random_sample ~n symbols =
 let main ~num_symbols () =
   let token = read_token () in
   Eodhd.Http_client.get_symbols ~token () >>= function
-  | Ok all_symbols ->
+  | Ok all_metadata ->
+      let all_symbols =
+        List.map all_metadata ~f:(fun m -> m.Eodhd.Http_client.code)
+      in
       let symbols = random_sample ~n:num_symbols all_symbols in
       above_30w_ema ~token ~symbols () >>| print_results >>= fun () -> return ()
   | Error status ->


### PR DESCRIPTION
## Summary

Parse the `Type` field from EODHD's `/api/exchange-symbol-list/{ex}` response so downstream universe-build can drop mutual funds and non-common-stock instruments.

This is Q1 PR1 of `dev/plans/custom-universe-bidirectional-2026-05-17.md`. PR2 will add a bulk-enrichment exe that writes `data/symbol_types.sexp`; PR3 will add the `universe_filter.filter_by_asset_type` consumer.

## What changed

- New `Eodhd.Asset_type.t` variant with 11 named cases + `Other of string` catch-all for forward-compat
- New helpers: `of_eodhd_string`, `to_string`, `is_equity_like` (`Common_stock`/`Preferred_stock`/`ADR`/`GDR` -> true; everything else, including `Other _`, -> false)
- `get_symbols` now returns `symbol_metadata` records (`{ code; name; exchange; asset_type }`) instead of bare strings, so callers can filter / enrich without re-parsing
- `get_index_symbols` keeps its `string list` return type (extracts `.code` internally)
- Fixture `get_symbol_list_response.json` expanded from 5 to 6 entries covering Common_stock / ETF / Mutual_fund / ADR / Index / Other
- 13 unit tests in `test_asset_type.ml` (mapping + partitioning) and 3 integration tests in `test_http_client.ml` (code + asset_type + name + exchange round-trip)
- Two call-site updates extract `.code` from the new record:
  - `analysis/scripts/above_30w_ema/bin/main.ml`
  - `analysis/data/pipelines/fetch_prices/bin/main.ml`

## Test plan

- `dune build && dune runtest analysis/data/sources/eodhd/` — local pass (13 asset_type + 21 http_client + 6+5+7 sibling tests)
- `dune build @fmt` clean
- All `get_symbols` call sites audited and updated