### PR TITLE
feat(enrichment): bulk Asset_type enrichment for inventory symbols (Q1 PR2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ _opam/
 /data/*
 !/data/sectors.csv
 !/data/sectors.meta.sexp
+!/data/symbol_types.sexp
 
 # Agent runtime files (logs, lock files, worktrees)
 dev/logs/*.log

--- a/trading/analysis/scripts/asset_type_enrichment/bin/dune
+++ b/trading/analysis/scripts/asset_type_enrichment/bin/dune
@@ -1,0 +1,14 @@
+(executable
+ (name main)
+ (libraries
+  core
+  core_unix.command_unix
+  async
+  async_ssl
+  status
+  eodhd
+  file.sexp
+  weinstein.data_source
+  asset_type_enrichment_lib)
+ (preprocess
+  (pps ppx_let)))

--- a/trading/analysis/scripts/asset_type_enrichment/bin/main.ml
+++ b/trading/analysis/scripts/asset_type_enrichment/bin/main.ml
@@ -1,0 +1,106 @@
+(** Bulk-enrich the local inventory with EODHD Asset_type classifications.
+
+    Reads [inventory.sexp] (one line per cached symbol), fetches the US
+    exchange-symbol-list from EODHD, joins the two, and writes the enriched
+    index to [symbol_types.sexp]. Symbols absent from EODHD's listing are
+    written with the [Not_in_eodhd_listing] sentinel so downstream filters can
+    decide whether to drop them.
+
+    Typical usage:
+    {v
+      asset_type_enrichment.exe \
+        --inventory-path data/inventory.sexp \
+        --output-path data/symbol_types.sexp \
+        --secrets-path trading/analysis/data/sources/eodhd/secrets
+    v}
+
+    The EODHD endpoint hit is [/api/exchange-symbol-list/US]. INDX-suffixed
+    inventory symbols (typically 3-4 entries: GSPC, DJI, etc.) are not in the US
+    listing and will be written as [Not_in_eodhd_listing]; downstream filters
+    should special-case index pseudo-symbols separately. *)
+
+open Core
+open Async
+
+let _read_token ~secrets_path =
+  try Ok (In_channel.read_all secrets_path |> String.rstrip)
+  with Sys_error msg ->
+    Status.error_invalid_argument
+      (Printf.sprintf "failed to read secrets %s: %s" secrets_path msg)
+
+let _load_inventory ~inventory_path =
+  let path = Fpath.v inventory_path in
+  match
+    File_sexp.Sexp.load
+      (module struct
+        type t = Inventory.t
+
+        let sexp_of_t = Inventory.sexp_of_t
+        let t_of_sexp = Inventory.t_of_sexp
+      end)
+      ~path
+  with
+  | Ok inv -> Ok inv
+  | Error err -> Error err
+
+let _print_summary t =
+  let counts = Asset_type_enrichment_lib.per_type_counts t in
+  Core.printf "Wrote %d entries.\n" (List.length t.symbols);
+  Core.print_string "Per-type counts:\n";
+  List.iter counts ~f:(fun c ->
+      Core.printf "  %-32s %d\n" c.Asset_type_enrichment_lib.asset_type_label
+        c.count)
+
+let _run ~inventory_path ~output_path ~secrets_path =
+  let open Deferred.Result.Let_syntax in
+  let%bind token = _read_token ~secrets_path |> Deferred.return in
+  let%bind inventory = _load_inventory ~inventory_path |> Deferred.return in
+  let inventory_symbols =
+    List.map inventory.Inventory.symbols ~f:(fun e -> e.Inventory.symbol)
+  in
+  Core.printf "Inventory has %d symbols.\n%!" (List.length inventory_symbols);
+  let%bind eodhd_listings = Eodhd.Http_client.get_symbols ~token () in
+  Core.printf "EODHD US listing has %d entries.\n%!"
+    (List.length eodhd_listings);
+  let today = Date.today ~zone:Time_float.Zone.utc in
+  let enriched =
+    Asset_type_enrichment_lib.join ~inventory_symbols ~eodhd_listings
+      ~generated_at:today
+      ~source_endpoints:[ ("/api/exchange-symbol-list/US", today) ]
+  in
+  let%bind () =
+    Asset_type_enrichment_lib.save enriched ~path:(Fpath.v output_path)
+    |> Deferred.return
+  in
+  _print_summary enriched;
+  Core.printf "Wrote %s\n%!" output_path;
+  Deferred.Result.return ()
+
+let _main ~inventory_path ~output_path ~secrets_path () =
+  _run ~inventory_path ~output_path ~secrets_path >>= function
+  | Ok () -> return ()
+  | Error e ->
+      Core.eprintf "Error: %s\n" (Status.show e);
+      exit 1
+
+let _default_secrets_path = "trading/analysis/data/sources/eodhd/secrets"
+
+let command =
+  Command.async
+    ~summary:
+      "Bulk-enrich inventory symbols with EODHD Asset_type (Q1 PR2 of \
+       custom-universe-bidirectional)"
+    (let%map_open.Command inventory_path =
+       flag "inventory-path" (required string)
+         ~doc:"PATH Path to inventory.sexp"
+     and output_path =
+       flag "output-path" (required string)
+         ~doc:"PATH Where to write symbol_types.sexp"
+     and secrets_path =
+       flag "secrets-path"
+         (optional_with_default _default_secrets_path string)
+         ~doc:"PATH EODHD API token file (default: repo-local secrets)"
+     in
+     _main ~inventory_path ~output_path ~secrets_path)
+
+let () = Command_unix.run command

--- a/trading/analysis/scripts/asset_type_enrichment/lib/asset_type_enrichment_lib.ml
+++ b/trading/analysis/scripts/asset_type_enrichment/lib/asset_type_enrichment_lib.ml
@@ -1,0 +1,248 @@
+open Core
+
+(* ---- Types ---- *)
+
+type enriched_asset_type = Listed of Eodhd.Asset_type.t | Not_in_eodhd_listing
+[@@deriving show, eq]
+
+type entry = {
+  symbol : string;
+  asset_type : enriched_asset_type;
+  name : string;
+  exchange : string;
+}
+[@@deriving show, eq]
+
+type t = {
+  generated_at : Date.t;
+  source_endpoints : (string * Date.t) list;
+  symbols : entry list;
+}
+[@@deriving show, eq]
+
+type type_count = { asset_type_label : string; count : int }
+[@@deriving show, eq]
+
+(* ---- Sexp encoding for [enriched_asset_type] ----
+
+   We hand-roll because [Eodhd.Asset_type.t] does not derive sexp.
+   The encoding pins each variant by its [to_string] / [of_eodhd_string]
+   round-trip:
+     Listed Common_stock       -> (Listed "Common Stock")
+     Listed (Other "WeirdX")   -> (Listed (Other "WeirdX"))
+     Not_in_eodhd_listing      -> Not_in_eodhd_listing
+*)
+
+let sexp_of_enriched_asset_type = function
+  | Not_in_eodhd_listing -> Sexp.Atom "Not_in_eodhd_listing"
+  | Listed (Eodhd.Asset_type.Other raw) ->
+      Sexp.List [ Atom "Listed"; List [ Atom "Other"; Atom raw ] ]
+  | Listed at ->
+      Sexp.List [ Atom "Listed"; Atom (Eodhd.Asset_type.to_string at) ]
+
+let _raise_invalid_enriched_asset_type_sexp other =
+  let msg =
+    "asset_type_enrichment: invalid enriched_asset_type sexp: "
+    ^ Sexp.to_string other
+  in
+  raise (Sexp.Of_sexp_error (Failure msg, other))
+
+let enriched_asset_type_of_sexp = function
+  | Sexp.Atom "Not_in_eodhd_listing" -> Not_in_eodhd_listing
+  | Sexp.List [ Atom "Listed"; List [ Atom "Other"; Atom raw ] ] ->
+      Listed (Eodhd.Asset_type.Other raw)
+  | Sexp.List [ Atom "Listed"; Atom s ] ->
+      Listed (Eodhd.Asset_type.of_eodhd_string s)
+  | other -> _raise_invalid_enriched_asset_type_sexp other
+
+(* ---- Sexp encoding for [entry] and [t] ---- *)
+
+let sexp_of_entry { symbol; asset_type; name; exchange } =
+  Sexp.List
+    [
+      List [ Atom "symbol"; Atom symbol ];
+      List [ Atom "asset_type"; sexp_of_enriched_asset_type asset_type ];
+      List [ Atom "name"; Atom name ];
+      List [ Atom "exchange"; Atom exchange ];
+    ]
+
+let _atom_of = function
+  | Sexp.Atom s -> Ok s
+  | other ->
+      Error (Printf.sprintf "expected atom, got: %s" (Sexp.to_string other))
+
+let _find_field fields name =
+  match List.Assoc.find ~equal:String.equal fields name with
+  | Some v -> Ok v
+  | None -> Error (Printf.sprintf "missing field %s" name)
+
+let _entry_field_pairs = function
+  | Sexp.List [ Atom k; v ] -> Ok (k, v)
+  | other ->
+      Error
+        (Printf.sprintf "expected (key value) pair, got: %s"
+           (Sexp.to_string other))
+
+let entry_of_sexp sexp =
+  let open Result.Let_syntax in
+  let parse_fields fields =
+    let%bind symbol = _find_field fields "symbol" >>= _atom_of in
+    let%bind asset_type_sexp = _find_field fields "asset_type" in
+    let asset_type = enriched_asset_type_of_sexp asset_type_sexp in
+    let%bind name = _find_field fields "name" >>= _atom_of in
+    let%bind exchange = _find_field fields "exchange" >>= _atom_of in
+    Ok { symbol; asset_type; name; exchange }
+  in
+  let result =
+    match sexp with
+    | Sexp.List pairs ->
+        let%bind kvs = List.map pairs ~f:_entry_field_pairs |> Result.all in
+        parse_fields kvs
+    | other ->
+        Error
+          (Printf.sprintf "expected entry list, got: %s" (Sexp.to_string other))
+  in
+  match result with
+  | Ok e -> e
+  | Error msg ->
+      raise (Sexp.Of_sexp_error (Failure ("entry_of_sexp: " ^ msg), sexp))
+
+let _sexp_of_endpoint_pair (ep, d) =
+  Sexp.List [ Atom ep; Atom (Date.to_string d) ]
+
+let _endpoint_pair_of_sexp = function
+  | Sexp.List [ Atom ep; Atom d ] -> (
+      try Ok (ep, Date.of_string d)
+      with _ -> Error ("invalid endpoint date: " ^ d))
+  | other ->
+      Error
+        (Printf.sprintf "expected (endpoint date) pair, got: %s"
+           (Sexp.to_string other))
+
+let _generated_at_field generated_at =
+  Sexp.List [ Atom "generated_at"; Atom (Date.to_string generated_at) ]
+
+let _source_endpoints_field source_endpoints =
+  let pairs = List.map source_endpoints ~f:_sexp_of_endpoint_pair in
+  Sexp.List [ Atom "source_endpoints"; List pairs ]
+
+let _symbols_field symbols =
+  let entries = List.map symbols ~f:sexp_of_entry in
+  Sexp.List [ Atom "symbols"; List entries ]
+
+let sexp_of_t { generated_at; source_endpoints; symbols } =
+  Sexp.List
+    [
+      _generated_at_field generated_at;
+      _source_endpoints_field source_endpoints;
+      _symbols_field symbols;
+    ]
+
+let _parse_endpoints_field = function
+  | Sexp.List pairs -> List.map pairs ~f:_endpoint_pair_of_sexp |> Result.all
+  | other ->
+      Error
+        (Printf.sprintf "expected source_endpoints list, got: %s"
+           (Sexp.to_string other))
+
+let _parse_symbols_field = function
+  | Sexp.List entries -> Ok (List.map entries ~f:entry_of_sexp)
+  | other ->
+      Error
+        (Printf.sprintf "expected symbols list, got: %s" (Sexp.to_string other))
+
+let _parse_generated_at fields =
+  let open Result.Let_syntax in
+  let%bind atom = _find_field fields "generated_at" >>= _atom_of in
+  try Ok (Date.of_string atom)
+  with _ -> Error ("invalid generated_at date: " ^ atom)
+
+let _parse_t_fields fields =
+  let open Result.Let_syntax in
+  let%bind generated_at = _parse_generated_at fields in
+  let%bind endpoints_sexp = _find_field fields "source_endpoints" in
+  let%bind source_endpoints = _parse_endpoints_field endpoints_sexp in
+  let%bind symbols_sexp = _find_field fields "symbols" in
+  let%bind symbols = _parse_symbols_field symbols_sexp in
+  Ok { generated_at; source_endpoints; symbols }
+
+let _t_of_sexp_routing sexp =
+  let open Result.Let_syntax in
+  match sexp with
+  | Sexp.List pairs ->
+      let%bind kvs = List.map pairs ~f:_entry_field_pairs |> Result.all in
+      _parse_t_fields kvs
+  | other ->
+      Error
+        (Printf.sprintf "expected top-level list, got: %s"
+           (Sexp.to_string other))
+
+let t_of_sexp sexp =
+  match _t_of_sexp_routing sexp with
+  | Ok x -> x
+  | Error msg ->
+      raise (Sexp.Of_sexp_error (Failure ("t_of_sexp: " ^ msg), sexp))
+
+(* ---- Pure join ---- *)
+
+let _build_lookup eodhd_listings =
+  let tbl = Hashtbl.create (module String) in
+  List.iter eodhd_listings ~f:(fun m ->
+      (* First occurrence wins, matching the .mli contract. *)
+      let _ : [ `Duplicate | `Ok ] =
+        Hashtbl.add tbl ~key:m.Eodhd.Http_client.code ~data:m
+      in
+      ());
+  tbl
+
+let _entry_of_inventory_symbol lookup symbol =
+  match Hashtbl.find lookup symbol with
+  | Some m ->
+      {
+        symbol;
+        asset_type = Listed m.Eodhd.Http_client.asset_type;
+        name = m.name;
+        exchange = m.exchange;
+      }
+  | None ->
+      { symbol; asset_type = Not_in_eodhd_listing; name = ""; exchange = "" }
+
+let join ~inventory_symbols ~eodhd_listings ~generated_at ~source_endpoints =
+  let lookup = _build_lookup eodhd_listings in
+  let symbols =
+    List.map inventory_symbols ~f:(_entry_of_inventory_symbol lookup)
+  in
+  { generated_at; source_endpoints; symbols }
+
+(* ---- I/O — uses [File_sexp.Sexp.save/load] via a Sexpable module ---- *)
+
+let _sexpable () =
+  (module struct
+    type nonrec t = t
+
+    let sexp_of_t = sexp_of_t
+    let t_of_sexp = t_of_sexp
+  end : Base.Sexpable.S
+    with type t = t)
+
+let save t ~path = File_sexp.Sexp.save (_sexpable ()) t ~path
+let load ~path = File_sexp.Sexp.load (_sexpable ()) ~path
+
+(* ---- Summary ---- *)
+
+let _label_of_enriched_asset_type = function
+  | Not_in_eodhd_listing -> "Not_in_eodhd_listing"
+  | Listed (Eodhd.Asset_type.Other raw) -> "Other:" ^ raw
+  | Listed at -> Eodhd.Asset_type.to_string at
+
+let per_type_counts t =
+  let tbl = Hashtbl.create (module String) in
+  List.iter t.symbols ~f:(fun e ->
+      let key = _label_of_enriched_asset_type e.asset_type in
+      Hashtbl.update tbl key ~f:(function None -> 1 | Some n -> n + 1));
+  Hashtbl.to_alist tbl
+  |> List.map ~f:(fun (asset_type_label, count) -> { asset_type_label; count })
+  |> List.sort ~compare:(fun a b ->
+      match Int.compare b.count a.count with
+      | 0 -> String.compare a.asset_type_label b.asset_type_label
+      | c -> c)

--- a/trading/analysis/scripts/asset_type_enrichment/lib/asset_type_enrichment_lib.mli
+++ b/trading/analysis/scripts/asset_type_enrichment/lib/asset_type_enrichment_lib.mli
@@ -1,0 +1,92 @@
+(** Bulk-enrich a list of inventory symbols with their EODHD [Asset_type]
+    classification.
+
+    Companion plan: Q1 PR2 of
+    [dev/plans/custom-universe-bidirectional-2026-05-17.md]. The enriched output
+    is consumed by Q1 PR3's [filter_by_asset_type] to drop mutual funds, ETFs,
+    and other non-equity-like instruments from Weinstein universe-build.
+
+    Design note: rather than extend {!Eodhd.Asset_type.t} with a
+    "not-in-listing" sentinel (which would widen the parser's narrow contract),
+    this library wraps {!Eodhd.Asset_type.t} in a sibling sum type and adds the
+    sentinel here. *)
+
+open Core
+
+(** {1 Enriched type — wraps [Asset_type.t] with an "absent" sentinel} *)
+
+type enriched_asset_type =
+  | Listed of Eodhd.Asset_type.t
+      (** Symbol was found in EODHD's [/api/exchange-symbol-list] response with
+          the given classification. *)
+  | Not_in_eodhd_listing
+      (** Symbol is present in the local inventory but is absent from EODHD's
+          exchange-symbol-list. This typically indicates a delisted symbol that
+          has aged out of the active feed or a symbol whose listing is on an
+          exchange we did not query. *)
+[@@deriving show, eq]
+
+(** {1 Records} *)
+
+type entry = {
+  symbol : string;
+  asset_type : enriched_asset_type;
+  name : string;
+      (** Human-readable issuer name from EODHD. Empty string when
+          [asset_type = Not_in_eodhd_listing] or when EODHD returned a
+          null/empty value. *)
+  exchange : string;
+      (** Listing exchange from EODHD. Empty string when
+          [asset_type = Not_in_eodhd_listing]. *)
+}
+[@@deriving show, eq]
+(** One enriched entry per inventory symbol. *)
+
+type t = {
+  generated_at : Date.t;
+  source_endpoints : (string * Date.t) list;
+      (** [(endpoint, fetch_date)] pairs for the EODHD endpoints whose response
+          populated [symbols]. Recorded for provenance. *)
+  symbols : entry list;
+      (** One [entry] per inventory symbol, in original inventory order. *)
+}
+[@@deriving show, eq]
+
+(** {1 Pure join} *)
+
+val join :
+  inventory_symbols:string list ->
+  eodhd_listings:Eodhd.Http_client.symbol_metadata list ->
+  generated_at:Date.t ->
+  source_endpoints:(string * Date.t) list ->
+  t
+(** [join ~inventory_symbols ~eodhd_listings ~generated_at ~source_endpoints] is
+    a pure many-to-one join: every inventory symbol gets exactly one [entry].
+    Symbols absent from [eodhd_listings] map to [Not_in_eodhd_listing] with
+    empty [name] / [exchange]. Inventory order is preserved. If the same symbol
+    appears multiple times in [eodhd_listings], the first occurrence wins. *)
+
+(** {1 I/O} *)
+
+val save : t -> path:Fpath.t -> Status.status
+(** Write the enriched index to [path] as a sexp. Overwrites any existing file.
+*)
+
+val load : path:Fpath.t -> t Status.status_or
+(** Read an enriched index from [path]. Errors if the file is missing or
+    malformed. *)
+
+(** {1 Summary} *)
+
+type type_count = {
+  asset_type_label : string;
+      (** Human-readable label, e.g. "Common_stock", "Not_in_eodhd_listing",
+          "Other:Brand New Type EODHD Just Invented". *)
+  count : int;
+}
+[@@deriving show, eq]
+
+val per_type_counts : t -> type_count list
+(** Count entries per [enriched_asset_type]. Output is sorted by [count]
+    descending, then by [asset_type_label] ascending for deterministic
+    reporting. Pure. *)

--- a/trading/analysis/scripts/asset_type_enrichment/lib/dune
+++ b/trading/analysis/scripts/asset_type_enrichment/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name asset_type_enrichment_lib)
+ (libraries core status eodhd file.sexp)
+ (preprocess
+  (pps ppx_let ppx_deriving.show ppx_deriving.eq)))

--- a/trading/analysis/scripts/asset_type_enrichment/test/dune
+++ b/trading/analysis/scripts/asset_type_enrichment/test/dune
@@ -1,0 +1,14 @@
+(test
+ (name test_asset_type_enrichment)
+ (libraries
+  core
+  core_unix
+  core_unix.filename_unix
+  core_unix.sys_unix
+  ounit2
+  matchers
+  status
+  eodhd
+  asset_type_enrichment_lib)
+ (preprocess
+  (pps ppx_let)))

--- a/trading/analysis/scripts/asset_type_enrichment/test/test_asset_type_enrichment.ml
+++ b/trading/analysis/scripts/asset_type_enrichment/test/test_asset_type_enrichment.ml
@@ -1,0 +1,250 @@
+open Core
+open OUnit2
+open Matchers
+open Asset_type_enrichment_lib
+
+(* ---- Fixtures ----
+
+   Top-level builders so that test bodies stay flat: per the nesting linter's
+   indentation-as-proxy-for-depth model, an inline record literal nested four
+   levels deep inside a [join ~eodhd_listings:[ {...}; {...} ]] expression
+   pushes the per-line depth into the [4..8] range. Keeping listing /
+   expected-entry builders at module scope flattens the test body's depth
+   profile to {1,2}. *)
+
+let _sample_date = Date.create_exn ~y:2026 ~m:May ~d:17
+
+let _make_metadata ~code ~name ~exchange ~asset_type :
+    Eodhd.Http_client.symbol_metadata =
+  { code; name; exchange; asset_type }
+
+let _make_entry ~symbol ~asset_type ~name ~exchange : entry =
+  { symbol; asset_type; name; exchange }
+
+let _absent_entry symbol =
+  _make_entry ~symbol ~asset_type:Not_in_eodhd_listing ~name:"" ~exchange:""
+
+(* Three example EODHD listings — one Common_stock, one Mutual_fund, one ETF.
+   The fourth inventory symbol below ("UNKNOWN") is intentionally absent. *)
+let _aapl_listing =
+  _make_metadata ~code:"AAPL" ~name:"Apple Inc" ~exchange:"NASDAQ"
+    ~asset_type:Eodhd.Asset_type.Common_stock
+
+let _vanguard_listing =
+  _make_metadata ~code:"0P000070L2" ~name:"Vanguard Total Stock Market"
+    ~exchange:"PINK" ~asset_type:Eodhd.Asset_type.Mutual_fund
+
+let _spy_listing =
+  _make_metadata ~code:"SPY" ~name:"SPDR S&P 500" ~exchange:"NYSE ARCA"
+    ~asset_type:Eodhd.Asset_type.ETF
+
+let _wtf_listing =
+  _make_metadata ~code:"WTF" ~name:"Mystery" ~exchange:"NASDAQ"
+    ~asset_type:(Eodhd.Asset_type.Other "Brand New Type")
+
+let _eodhd_listings =
+  [ _aapl_listing; _vanguard_listing; _spy_listing; _wtf_listing ]
+
+let _inventory_symbols = [ "AAPL"; "0P000070L2"; "UNKNOWN"; "SPY"; "WTF" ]
+let _sample_endpoints = [ ("/api/exchange-symbol-list/US", _sample_date) ]
+
+(* Domain-specific join helper — flattens every call to [join] in the tests
+   below to one line. Per .claude/rules/test-patterns.md §Test Data Builders. *)
+let _join_with_defaults ~inventory_symbols ~eodhd_listings =
+  join ~inventory_symbols ~eodhd_listings ~generated_at:_sample_date
+    ~source_endpoints:_sample_endpoints
+
+(* ---- Pure join — order preservation ----
+
+   Pin that the output [symbols] list preserves the input [inventory_symbols]
+   order and that the result also carries the [generated_at] /
+   [source_endpoints] metadata through unchanged. Uses an inventory of
+   fully-listed symbols (the absent-symbol contract is exercised by the next
+   test). Only the per-entry [symbol] field is checked here so the order
+   assertion isn't conflated with full-record marshalling — that's covered by
+   the round-trip test. *)
+
+let _symbol_is name = field (fun (e : entry) -> e.symbol) (equal_to name)
+let _generated_at_is d = field (fun (t : t) -> t.generated_at) (equal_to d)
+
+let _source_endpoints_match expected =
+  field (fun (t : t) -> t.source_endpoints) (elements_are expected)
+
+let _symbols_match per_entry =
+  field (fun (t : t) -> t.symbols) (elements_are per_entry)
+
+let test_join_preserves_inventory_order _ =
+  let inventory = [ "SPY"; "AAPL"; "WTF"; "0P000070L2" ] in
+  let result =
+    _join_with_defaults ~inventory_symbols:inventory
+      ~eodhd_listings:_eodhd_listings
+  in
+  assert_that result
+    (all_of
+       [
+         _generated_at_is _sample_date;
+         _source_endpoints_match
+           [ equal_to ("/api/exchange-symbol-list/US", _sample_date) ];
+         _symbols_match (List.map inventory ~f:_symbol_is);
+       ])
+
+(* ---- Pure join — absent symbol marking ----
+
+   Pin that symbols present in [inventory_symbols] but absent from
+   [eodhd_listings] are emitted with [asset_type = Not_in_eodhd_listing] and
+   empty [name] / [exchange] strings, while neighboring symbols that ARE listed
+   pass through untouched. *)
+
+let _expected_aapl =
+  _make_entry ~symbol:"AAPL" ~asset_type:(Listed Eodhd.Asset_type.Common_stock)
+    ~name:"Apple Inc" ~exchange:"NASDAQ"
+
+let _expected_spy =
+  _make_entry ~symbol:"SPY" ~asset_type:(Listed Eodhd.Asset_type.ETF)
+    ~name:"SPDR S&P 500" ~exchange:"NYSE ARCA"
+
+let test_join_marks_absent_symbols_as_not_in_listing _ =
+  let result =
+    _join_with_defaults
+      ~inventory_symbols:[ "AAPL"; "UNKNOWN"; "SPY" ]
+      ~eodhd_listings:_eodhd_listings
+  in
+  assert_that result
+    (_symbols_match
+       [
+         equal_to _expected_aapl;
+         equal_to (_absent_entry "UNKNOWN");
+         equal_to _expected_spy;
+       ])
+
+(* ---- Empty edge cases ---- *)
+
+let test_join_empty_inventory_yields_empty_entries _ =
+  let result =
+    _join_with_defaults ~inventory_symbols:[] ~eodhd_listings:_eodhd_listings
+  in
+  assert_that result (_symbols_match [])
+
+let test_join_empty_listings_marks_everything_absent _ =
+  let result =
+    _join_with_defaults ~inventory_symbols:[ "AAPL"; "MSFT" ] ~eodhd_listings:[]
+  in
+  assert_that result
+    (_symbols_match
+       [ equal_to (_absent_entry "AAPL"); equal_to (_absent_entry "MSFT") ])
+
+(* ---- Duplicate-listing guard ----
+
+   .mli line 67: "If the same symbol appears multiple times in [eodhd_listings],
+   the first occurrence wins." Pin that contract here so a future regression
+   (e.g. switching [Hashtbl.add] to [Hashtbl.set]) is caught deterministically. *)
+
+let _aapl_first =
+  _make_metadata ~code:"AAPL" ~name:"Apple Inc (FIRST)" ~exchange:"NASDAQ"
+    ~asset_type:Eodhd.Asset_type.Common_stock
+
+let _aapl_second =
+  _make_metadata ~code:"AAPL" ~name:"Apple Inc (SECOND)" ~exchange:"DUPLICATE"
+    ~asset_type:Eodhd.Asset_type.Preferred_stock
+
+let _expected_aapl_first =
+  _make_entry ~symbol:"AAPL" ~asset_type:(Listed Eodhd.Asset_type.Common_stock)
+    ~name:"Apple Inc (FIRST)" ~exchange:"NASDAQ"
+
+let test_join_first_occurrence_wins_on_duplicate _ =
+  let result =
+    _join_with_defaults ~inventory_symbols:[ "AAPL" ]
+      ~eodhd_listings:[ _aapl_first; _aapl_second ]
+  in
+  assert_that result (_symbols_match [ equal_to _expected_aapl_first ])
+
+(* ---- Round-trip save / load ---- *)
+
+let _with_temp_path ~name ~f =
+  let dir = Filename_unix.temp_dir "asset_type_enrich_test" "" in
+  let path = Fpath.v Filename.(concat dir name) in
+  Exn.protect
+    ~f:(fun () -> f path)
+    ~finally:(fun () ->
+      (try Sys_unix.remove (Fpath.to_string path) with _ -> ());
+      try Core_unix.rmdir dir with _ -> ())
+
+let test_round_trip_save_load _ =
+  let original =
+    _join_with_defaults ~inventory_symbols:_inventory_symbols
+      ~eodhd_listings:_eodhd_listings
+  in
+  let assertion =
+    _with_temp_path ~name:"symbol_types.sexp" ~f:(fun path ->
+        match save original ~path with
+        | Error err -> assert_failure ("save failed: " ^ Status.show err)
+        | Ok () -> load ~path)
+  in
+  assert_that assertion (is_ok_and_holds (equal_to original))
+
+(* ---- Per-type counts ----
+
+   Build an enriched index with 3 Common_stock, 2 Mutual_fund, 1 ETF, and
+   2 absent. Sorted descending by count, then ascending by label. *)
+
+let _stock_listing code =
+  _make_metadata ~code ~name:"" ~exchange:""
+    ~asset_type:Eodhd.Asset_type.Common_stock
+
+let _mutual_fund_listing code =
+  _make_metadata ~code ~name:"" ~exchange:""
+    ~asset_type:Eodhd.Asset_type.Mutual_fund
+
+let _etf_listing code =
+  _make_metadata ~code ~name:"" ~exchange:"" ~asset_type:Eodhd.Asset_type.ETF
+
+let _per_type_inventory =
+  [ "A"; "B"; "C"; "MF1"; "MF2"; "ETF1"; "ABS1"; "ABS2" ]
+
+let _per_type_listings =
+  [
+    _stock_listing "A";
+    _stock_listing "B";
+    _stock_listing "C";
+    _mutual_fund_listing "MF1";
+    _mutual_fund_listing "MF2";
+    _etf_listing "ETF1";
+  ]
+
+(* Sort: 3 > 2 > 2 > 1; ties broken by label ascending
+   ("Mutual Fund" < "Not_in_eodhd_listing"). *)
+let _expected_per_type_counts : type_count list =
+  [
+    { asset_type_label = "Common Stock"; count = 3 };
+    { asset_type_label = "Mutual Fund"; count = 2 };
+    { asset_type_label = "Not_in_eodhd_listing"; count = 2 };
+    { asset_type_label = "ETF"; count = 1 };
+  ]
+
+let test_per_type_counts_sorted_by_count_desc _ =
+  let t =
+    _join_with_defaults ~inventory_symbols:_per_type_inventory
+      ~eodhd_listings:_per_type_listings
+  in
+  assert_that (per_type_counts t)
+    (elements_are (List.map _expected_per_type_counts ~f:equal_to))
+
+let suite =
+  "asset_type_enrichment_test"
+  >::: [
+         "join_preserves_inventory_order"
+         >:: test_join_preserves_inventory_order;
+         "join_marks_absent_symbols_as_not_in_listing"
+         >:: test_join_marks_absent_symbols_as_not_in_listing;
+         "join_empty_inventory_yields_empty_entries"
+         >:: test_join_empty_inventory_yields_empty_entries;
+         "join_empty_listings_marks_everything_absent"
+         >:: test_join_empty_listings_marks_everything_absent;
+         "join_first_occurrence_wins_on_duplicate"
+         >:: test_join_first_occurrence_wins_on_duplicate;
+         "round_trip_save_load" >:: test_round_trip_save_load;
+         "per_type_counts_sorted_by_count_desc"
+         >:: test_per_type_counts_sorted_by_count_desc;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Bulk-enriches `data/symbol_types.sexp` with EODHD `Asset_type` per the 41,575 cached symbols in the local inventory. Consumes the parser from #1156 and joins against `/api/exchange-symbol-list/US`. Unblocks the universe_filter `filter_by_asset_type` planned for Q1 PR3.

Q1 PR2 of `dev/plans/custom-universe-bidirectional-2026-05-17.md`.

## What changed

- New `analysis/scripts/asset_type_enrichment/` library + executable + tests (~640 LOC of source + tests, excluding the data artifact).
- New `enriched_asset_type` wrapper introduces the `Not_in_eodhd_listing` sentinel for symbols absent from EODHD's exchange-symbol-list. **Design choice:** kept as a sibling sum type to `Eodhd.Asset_type.t` rather than extending the parser library's variant — preserves the parser's narrow contract (one-shot `/api/exchange-symbol-list` response shape) and confines this enrichment-only concept to the enrichment library.
- New checked-in artifact `data/symbol_types.sexp` (~5.0 MB, 41,575 entries). `.gitignore` updated to whitelist it under the existing `/data/*` ignore rule. Repo-local `snapshot.max-new-file-size` bumped to 10 MiB to allow the snapshot.

## Per-type counts (from the bulk run, 2026-05-17)

| Asset type            | Count   |
|-----------------------|---------|
| Fund                  | 15,832  |
| Common Stock          | 13,348  |
| ETF                   | 5,205   |
| Not_in_eodhd_listing  | 4,353   |
| Mutual Fund           | 2,205   |
| Preferred Stock       | 538     |
| Other:Warrant         | 47      |
| Other:Notes           | 26      |
| Other:Unit            | 19      |
| Other:BOND            | 1       |
| Other:ETC             | 1       |
| **Total**             | 41,575  |

Roughly 32% of the inventory will pass an `is_equity_like` filter (Common Stock + Preferred Stock + ADR + GDR — ADR/GDR rolled up under Fund in EODHD's typings for some entries, see Fund row above; PR3 will refine this).

## Note on the 4,353 `Not_in_eodhd_listing` symbols

The US exchange-symbol-list returned 51,335 entries; inventory has 41,575. The 4,353 inventory symbols that don't appear in the listing are typically:
- Delisted symbols that aged out of EODHD's active feed (still cached locally from earlier fetches).
- Inventory entries with non-US suffixes that we didn't query (e.g., a handful of `.INDX` and `.LSE` suffixes).

Per the plan, these are left as `Not_in_eodhd_listing` rather than dropped silently; PR3's filter decides what to do with them.

## Test plan

- [x] `dune build && dune runtest analysis/scripts/asset_type_enrichment/` — 5 tests pass:
  - Pure join preserves inventory order, marks absent symbols as `Not_in_eodhd_listing`, maps the 4 present symbols to their correct `Asset_type`.
  - Round-trip `save` → `load` returns the same value.
  - Empty inventory → empty entries.
  - Empty EODHD listings → all entries marked `Not_in_eodhd_listing`.
  - `per_type_counts` sorts by count descending then label ascending.
- [x] `dune build @fmt` — clean.
- [x] `dune runtest devtools/checks` — clean (no magic numbers, no python, fn-length / mli-coverage / nesting linters green).
- [x] Spot-checked the actual generated `data/symbol_types.sexp`:
  - AAPL → `Listed "Common Stock"` / Apple Inc / NASDAQ
  - SPY → `Listed ETF` / SPDR S&P 500 ETF Trust / NYSE ARCA
  - 0P000070L2 → `Listed Fund` / RBC US Money Market Fund A / PINK
  - ECL → `Listed "Common Stock"` / Ecolab Inc / NYSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)