### PR TITLE
fix(csv-storage-tests): is_directory guard on test_reconcile_log_path_layout readdir

### DIFF
--- a/trading/analysis/data/storage/csv/test/test_csv_storage.ml
+++ b/trading/analysis/data/storage/csv/test/test_csv_storage.ml
@@ -668,7 +668,13 @@ let test_reconcile_log_path_layout _ =
   in
   ok_or_failwith_status (save storage ~override:true mutated_prices);
   let date_shards =
-    Sys_unix.readdir (Fpath.to_string _reconcile_dir) |> Array.to_list
+    match Sys_unix.is_directory (Fpath.to_string _reconcile_dir) with
+    | `Yes -> Sys_unix.readdir (Fpath.to_string _reconcile_dir) |> Array.to_list
+    | `No | `Unknown ->
+        assert_failure
+          (Printf.sprintf
+             "_reconcile_dir is missing or not a directory after save: %s"
+             (Fpath.to_string _reconcile_dir))
   in
   assert_that (List.length date_shards) (equal_to 1);
   let shard_name = List.hd_exn date_shards in


### PR DESCRIPTION
## Summary
PR #1153 fixed `is_directory` guard in `_reconcile_log_for` helper (line 579). `test_reconcile_log_path_layout` (line 671) calls `Sys_unix.readdir` directly without the same guard; this hit CI for PR #1157 with \`Sys_error("test_data/_reconcile_log: Not a directory")\`.

No second-order bug found in `csv_storage.ml` — `_ensure_parent_dir` uses `Bos.OS.Dir.create ~path:true` which is correct. The failure is purely a test-state-pollution readdir crash.

## Fix
Adds `is_directory` guard inline at line 671. On state pollution the test now emits a diagnosable `assert_failure` message instead of raising `Sys_error`. Audit-scanned all other `readdir` calls in the same file — only two instances existed, both now guarded.

## Test plan
- `dune runtest analysis/data/storage/csv/` runs 3× in a row clean.
- `dune build @fmt` clean.