### PR TITLE
feat(enrichment): shares-outstanding bulk enrichment lib + bin (Q2-A PR1)

### DIFF
--- a/dev/plans/custom-universe-bidirectional-2026-05-17.md
+++ b/dev/plans/custom-universe-bidirectional-2026-05-17.md
@@ -106,12 +106,53 @@ Tests pin the equity-only contract over a 12-listing fixture covering
 every named `Asset_type.t` variant plus `Other _` and absent-from-index;
 a second test pins order preservation.
 
-## 2. Q2 — Pre-1996 SP500 backbone (synthesis)
+## 2. Q2 — Market-cap composition + pre-1996 SP500 backbone
 
-Q1's filter narrows the inventory we already have. Q2 widens history past
-the EODHD floor (2000) and the fja05680/sp500 floor (1996).
+Q1's filter narrows the inventory we already have. Q2 has two sub-tracks:
 
-### Q2-A — Decomposition (1996-2000 gap)
+- **Q2-A — Market-cap composition** (PR1: shares-outstanding enrichment;
+  PR2: rank-by-market-cap composition builder). Once we have current
+  shares-outstanding for every equity-like symbol, we can construct
+  market-cap-ranked historical universes (top-500, top-1000, etc.) without
+  depending on IWV scrape. The approximation: `current_shares ×
+  historical_close_price`. Buybacks and IPO phantom market caps before
+  listing introduce drift; a cross-validation PR will measure this vs
+  Shiller's actual SP composite.
+- **Q2-B — Pre-1996 SP500 backbone**: widens history past the EODHD floor
+  (2000) and the fja05680/sp500 floor (1996).
+
+### Q2-A PR1 — Shares-outstanding bulk enrichment (THIS PR)
+
+Adds `analysis/scripts/shares_outstanding_enrichment/` with a pure `join`
+library (filter-then-sort: keeps only fundamentals with
+`shares_outstanding > 0.0`, sorted by symbol ascending), an executable
+that filters the inventory to equity-like via Q1 PR3's filter, calls
+`/api/fundamentals/{symbol}?filter=General,SharesStats` per symbol, and
+writes `data/shares_outstanding.sexp`.
+
+Also extends `Eodhd.Http_client.fundamentals` to carry the new
+`shares_outstanding : float` field, parsed from `SharesStats.SharesOutstanding`
+(NOT `General.SharesOutstanding` — the latter does not exist). Missing
+section → 0.0 sentinel; enrichment-lib's join then drops zero-share
+entries.
+
+Token-tier dependency: the `/api/fundamentals/` endpoint requires an
+EODHD plan with the "Fundamentals API" add-on. Tokens without this
+add-on receive HTTP 403 even when `/api/eod` keeps working — the bin
+treats 5 consecutive 403s as token-tier gating and aborts to preserve
+quota. **The current repo-local secrets token does not have this
+add-on.** The bulk artifact `data/shares_outstanding.sexp` is therefore
+NOT included in this PR; producing it is gated on a plan upgrade or a
+swap to an alternate fundamentals source (Sharadar via Nasdaq Data
+Link, AlphaVantage, etc.).
+
+### Q2-A PR2 — Composition builder (NOT YET STARTED)
+
+Will consume `shares_outstanding.sexp` + the cached daily bars and emit
+top-N point-in-time universes by `current_shares × close_price` for each
+quarter-end in the historical window.
+
+### Q2-B (Stooq) — Decomposition (1996-2000 gap)
 
 Between fja05680/sp500's earliest commit (1996-01-02) and EODHD's
 earliest daily OHLCV (2000-01-03), we have membership but no per-symbol
@@ -127,10 +168,10 @@ prices. The two viable closures are:
    forward. Names whose history starts inside the backtest window are
    excluded for that window's purposes.
 
-Q2-A PR: `analysis/data/sources/stooq/` — minimal client + bulk fetch
+Q2-B Stooq PR: `analysis/data/sources/stooq/` — minimal client + bulk fetch
 for a fixed SP500 1996-1999 backbone list. Not yet started.
 
-### Q2-B — Decomposition (1926-1997 industry-aggregate synthesis)
+### Q2-B (French) — Decomposition (1926-1997 industry-aggregate synthesis)
 
 Pre-1996 we abandon individual-name coverage entirely. The substitute is
 Kenneth French's 5-industry daily-portfolio returns (already landed via
@@ -144,7 +185,7 @@ against an equal-weight subuniverse of every SP500 member at the time.
 The information content is lower per-bar (5 series instead of 500), but
 that's the price of a 1926 backbone.
 
-Q2-B PR: `analysis/data/synthetic/french_industry_universe/` —
+Q2-B French PR: `analysis/data/synthetic/french_industry_universe/` —
 wraps the existing French daily output as a Weinstein-compatible
 universe. Not yet started.
 
@@ -152,11 +193,13 @@ universe. Not yet started.
 
 | PR | Name | Status |
 |----|------|--------|
-| Q1 PR1 | `Eodhd.Asset_type` parser | MERGED (#1156) |
-| Q1 PR2 | Bulk enrichment exe + `symbol_types.sexp` | MERGED (#1157) |
-| Q1 PR3 | `filter_equity_like_symbols` | THIS PR |
-| Q2-A   | Stooq 1996-1999 backbone | NOT STARTED |
-| Q2-B   | French-industry universe (1926-1997) | NOT STARTED |
+| Q1 PR1   | `Eodhd.Asset_type` parser | MERGED (#1156) |
+| Q1 PR2   | Bulk enrichment exe + `symbol_types.sexp` | MERGED (#1157) |
+| Q1 PR3   | `filter_equity_like_symbols` | MERGED (#1159) |
+| Q2-A PR1 | Shares-outstanding bulk enrichment (this PR) | gated on EODHD Fundamentals tier |
+| Q2-A PR2 | Composition builder (`current_shares × historical_close`) | NOT STARTED |
+| Q2-B     | Stooq 1996-1999 backbone | NOT STARTED |
+| Q2-B     | French-industry universe (1926-1997) | NOT STARTED |
 
 Q1 is self-contained — it doesn't depend on Q2 and unblocks downstream
 broader-universe backtests immediately. Q2 is sequenced after the
@@ -174,4 +217,7 @@ the deep-history extension is worth the synthesis complexity.
   2010-present (already landed).
 - Companion `.mli`:
   - `trading/analysis/data/sources/eodhd/lib/asset_type.mli`
+  - `trading/analysis/data/sources/eodhd/lib/http_client.mli` (Q2-A PR1
+    extends `fundamentals` with `shares_outstanding`)
   - `trading/analysis/scripts/asset_type_enrichment/lib/asset_type_enrichment_lib.mli`
+  - `trading/analysis/scripts/shares_outstanding_enrichment/lib/shares_outstanding_enrichment_lib.mli`

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -260,6 +260,28 @@ Status carries forward from `hybrid-tier` track — that track stays IN_PROGRESS
 Synth-v1/v2/v3 all MERGED. EODHD multi-market MERGED. 15y memory-cliff
 fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
 
+### Custom-universe bidirectional Q2-A PR1 — shares-outstanding enrichment (2026-05-17)
+
+- [x] Lib + bin + tests built. `Eodhd.Http_client.fundamentals` extended
+  with `shares_outstanding : float` parsed from
+  `SharesStats.SharesOutstanding` (NOT `General` — that field does not
+  exist). Two-section filter (`General,SharesStats`) keeps the response
+  small. Lib joins by filtering to positive shares + sorting by symbol
+  ascending; bin walks the equity-like inventory and writes
+  `data/shares_outstanding.sexp`.
+- [ ] Bulk run NOT YET PRODUCED. The `/api/fundamentals/` endpoint
+  requires an EODHD plan with the "Fundamentals API" add-on; the
+  repo-local token returns HTTP 403 across all variants probed
+  (consistent with the Phase 1.1 failure noted in §"Blocking Refactors"
+  above). Production of `data/shares_outstanding.sexp` is gated on a
+  plan upgrade or a swap to an alternate fundamentals source
+  (Sharadar via Nasdaq Data Link, AlphaVantage, etc.). The bin handles
+  this gracefully: 5 consecutive 403s abort the run to preserve API
+  quota.
+- Authority: `dev/plans/custom-universe-bidirectional-2026-05-17.md`
+  §Q2-A PR1. Companion `.mli`:
+  `trading/analysis/scripts/shares_outstanding_enrichment/lib/shares_outstanding_enrichment_lib.mli`.
+
 ### Merged (data-pipeline-automation track)
 
 - **#819** — Automation PR 1/4: snapshot build checkpointing

--- a/trading/analysis/data/sources/eodhd/lib/fundamentals_endpoint.ml
+++ b/trading/analysis/data/sources/eodhd/lib/fundamentals_endpoint.ml
@@ -1,0 +1,112 @@
+open Async
+open Core
+
+type fundamentals = {
+  symbol : string;
+  name : string;
+  sector : string;
+  industry : string;
+  market_cap : float;
+  exchange : string;
+  shares_outstanding : float;
+}
+[@@deriving show, eq]
+
+let _api_host = "eodhd.com"
+
+let _string_or_null_of_yojson = function
+  | `String s -> Ok s
+  | `Null -> Ok ""
+  | v ->
+      Status.error_invalid_argument
+        ("Expected string or null, got: " ^ Yojson.Safe.to_string v)
+
+let _float_or_null_of_yojson = function
+  | `Float f -> Ok f
+  | `Int i -> Ok (float_of_int i)
+  | `Null -> Ok 0.0
+  | v ->
+      Status.error_invalid_argument
+        ("Expected float, int, or null, got: " ^ Yojson.Safe.to_string v)
+
+let _find_str_in fields key =
+  match List.Assoc.find ~equal:String.equal fields key with
+  | Some v -> _string_or_null_of_yojson v
+  | None -> Ok ""
+
+let _find_float_in fields key =
+  match List.Assoc.find ~equal:String.equal fields key with
+  | Some v -> _float_or_null_of_yojson v
+  | None -> Ok 0.0
+
+let _find_section fields name =
+  match List.Assoc.find ~equal:String.equal fields name with
+  | Some (`Assoc kvs) -> Ok (Some kvs)
+  | Some `Null -> Ok None
+  | Some _ ->
+      Status.error_invalid_argument
+        (Printf.sprintf "fundamentals: %s field is not an object" name)
+  | None -> Ok None
+
+(* [SharesStats] is optional on the response — older / sparser symbols may
+   omit it entirely. Missing section -> [shares_outstanding = 0.0], matching
+   the "no fundamentals data" sentinel documented on the [fundamentals]
+   record. *)
+let _shares_outstanding_from_shares_stats = function
+  | None -> Ok 0.0
+  | Some kvs -> _find_float_in kvs "SharesOutstanding"
+
+let _parse_fundamentals_sections symbol ~general ~shares_stats =
+  let open Result.Let_syntax in
+  let%bind name = _find_str_in general "Name" in
+  let%bind sector = _find_str_in general "Sector" in
+  let%bind industry = _find_str_in general "Industry" in
+  let%bind market_cap = _find_float_in general "MarketCapitalization" in
+  let%bind exchange = _find_str_in general "Exchange" in
+  let%bind shares_outstanding =
+    _shares_outstanding_from_shares_stats shares_stats
+  in
+  Ok
+    { symbol; name; sector; industry; market_cap; exchange; shares_outstanding }
+
+let _require_general_section symbol = function
+  | Some general -> Ok general
+  | None ->
+      Status.error_not_found
+        (Printf.sprintf "fundamentals[%s]: General section missing" symbol)
+
+let _parse_assoc_fields symbol fields =
+  let open Result.Let_syntax in
+  let%bind general_opt = _find_section fields "General" in
+  let%bind general = _require_general_section symbol general_opt in
+  let%bind shares_stats = _find_section fields "SharesStats" in
+  _parse_fundamentals_sections symbol ~general ~shares_stats
+
+let _parse_yojson_root symbol = function
+  | `Assoc fields -> _parse_assoc_fields symbol fields
+  | _ -> Status.error_invalid_argument "Invalid response format"
+
+let _parse_response symbol body_str =
+  match Yojson.Safe.from_string body_str with
+  | exception Yojson.Json_error msg ->
+      Status.error_invalid_argument ("Invalid JSON: " ^ msg)
+  | json -> _parse_yojson_root symbol json
+
+(* Two-section filter: keeps the response small (drops Earnings, Highlights,
+   Splits, etc.) while still returning the SharesOutstanding number under
+   [SharesStats]. *)
+let _query token =
+  [
+    ("api_token", [ token ]);
+    ("filter", [ "General,SharesStats" ]);
+    ("fmt", [ "json" ]);
+  ]
+
+let _make_uri ~token ~symbol =
+  let path = "/api/fundamentals/" ^ symbol in
+  Uri.make ~scheme:"https" ~host:_api_host ~path ~query:(_query token) ()
+
+let get_fundamentals ~token ~symbol ?(fetch = Http_client.default_fetch) () :
+    fundamentals Status.status_or Deferred.t =
+  let uri = _make_uri ~token ~symbol in
+  fetch uri >>| Result.bind ~f:(_parse_response symbol)

--- a/trading/analysis/data/sources/eodhd/lib/fundamentals_endpoint.mli
+++ b/trading/analysis/data/sources/eodhd/lib/fundamentals_endpoint.mli
@@ -1,0 +1,47 @@
+(** EODHD fundamentals endpoint client.
+
+    Wraps the [/api/fundamentals/{symbol}] endpoint, requesting only the
+    [General] and [SharesStats] sections (the two we currently need for sector /
+    industry / market-cap metadata and the shares-outstanding enrichment pass).
+    Following the {!Splits_endpoint} / {!Dividends_endpoint} pattern, this
+    module sits alongside {!Http_client} rather than inside it, keeping each
+    endpoint module small and independently testable.
+
+    {1 Stubbing}
+
+    {!get_fundamentals} accepts an optional [?fetch] argument; tests inject a
+    fixture-backed [fetch] to avoid live network calls. Production callers omit
+    it and get the default Cohttp client via {!Http_client.default_fetch}. *)
+
+open Async
+
+type fundamentals = {
+  symbol : string;
+  name : string;
+  sector : string;
+  industry : string;
+  market_cap : float;
+  exchange : string;
+  shares_outstanding : float;
+      (** Total shares outstanding as reported by EODHD. Sourced from the
+          [SharesStats.SharesOutstanding] field of the fundamentals response
+          (NOT [General]). [0.0] when the field is missing or null — caller
+          should treat zero as "no fundamentals data available for ranking". *)
+}
+[@@deriving show, eq]
+(** Fundamental data for a security, including sector and industry metadata. *)
+
+val get_fundamentals :
+  token:string ->
+  symbol:string ->
+  ?fetch:Http_client.fetch_fn ->
+  unit ->
+  fundamentals Status.status_or Deferred.t
+(** Fetch fundamental data (sector, industry, market cap, shares-outstanding)
+    for a symbol. Requests the [General] and [SharesStats] sections of the
+    [/api/fundamentals/{symbol}] response.
+
+    Note on token tier: the fundamentals endpoint requires an EODHD plan with
+    the "Fundamentals API" add-on. Tokens without this add-on return HTTP 403
+    even though [/api/eod] continues to work — callers should handle the 403
+    distinctly from other errors when wiring bulk enrichment runs. *)

--- a/trading/analysis/data/sources/eodhd/lib/http_client.ml
+++ b/trading/analysis/data/sources/eodhd/lib/http_client.ml
@@ -10,16 +10,6 @@ type historical_price_params = {
   period : Types.Cadence.t;
 }
 
-type fundamentals = {
-  symbol : string;
-  name : string;
-  sector : string;
-  industry : string;
-  market_cap : float;
-  exchange : string;
-}
-[@@deriving show, eq]
-
 type symbol_metadata = {
   code : string;
   name : string;
@@ -77,14 +67,6 @@ let _float_of_yojson = function
   | v ->
       Status.error_invalid_argument
         ("Expected float or int, got: " ^ Yojson.Safe.to_string v)
-
-let _float_or_null_of_yojson = function
-  | `Float f -> Ok f
-  | `Int i -> Ok (float_of_int i)
-  | `Null -> Ok 0.0
-  | v ->
-      Status.error_invalid_argument
-        ("Expected float, int, or null, got: " ^ Yojson.Safe.to_string v)
 
 let _int_of_yojson = function
   | `Int i -> Ok i
@@ -225,57 +207,6 @@ let get_bulk_last_day ~token ~exchange ?(fetch = _fetch_body) () :
       ()
   in
   fetch uri >>| Result.bind ~f:_parse_bulk_last_day_prices
-
-(* Fundamentals parsing *)
-
-let _parse_general_section symbol general =
-  let open Result.Let_syntax in
-  let find_str key =
-    match List.Assoc.find ~equal:String.equal general key with
-    | Some v -> _string_or_null_of_yojson v
-    | None -> Ok ""
-  in
-  let find_float key =
-    match List.Assoc.find ~equal:String.equal general key with
-    | Some v -> _float_or_null_of_yojson v
-    | None -> Ok 0.0
-  in
-  let%bind name = find_str "Name" in
-  let%bind sector = find_str "Sector" in
-  let%bind industry = find_str "Industry" in
-  let%bind market_cap = find_float "MarketCapitalization" in
-  let%bind exchange = find_str "Exchange" in
-  Ok { symbol; name; sector; industry; market_cap; exchange }
-
-let _parse_general_field symbol = function
-  | Some (`Assoc general) -> _parse_general_section symbol general
-  | Some _ -> Status.error_invalid_argument "General field is not an object"
-  | None -> Status.error_not_found "General section not found in response"
-
-let _parse_fundamentals_response symbol body_str =
-  try
-    match Yojson.Safe.from_string body_str with
-    | `Assoc fields ->
-        let general = List.Assoc.find ~equal:String.equal fields "General" in
-        _parse_general_field symbol general
-    | _ -> Status.error_invalid_argument "Invalid response format"
-  with Yojson.Json_error msg ->
-    Status.error_invalid_argument ("Invalid JSON: " ^ msg)
-
-let get_fundamentals ~token ~symbol ?(fetch = _fetch_body) () :
-    fundamentals Status.status_or Deferred.t =
-  let uri =
-    Uri.make ~scheme:"https" ~host:_api_host
-      ~path:("/api/fundamentals/" ^ symbol)
-      ~query:
-        [
-          ("api_token", [ token ]);
-          ("filter", [ "General" ]);
-          ("fmt", [ "json" ]);
-        ]
-      ()
-  in
-  fetch uri >>| Result.bind ~f:(_parse_fundamentals_response symbol)
 
 (* Index symbols *)
 

--- a/trading/analysis/data/sources/eodhd/lib/http_client.mli
+++ b/trading/analysis/data/sources/eodhd/lib/http_client.mli
@@ -19,17 +19,6 @@ type historical_price_params = {
   period : Types.Cadence.t;  (** Cadence of price bars. *)
 }
 
-type fundamentals = {
-  symbol : string;
-  name : string;
-  sector : string;
-  industry : string;
-  market_cap : float;
-  exchange : string;
-}
-[@@deriving show, eq]
-(** Fundamental data for a security, including sector and industry metadata. *)
-
 type symbol_metadata = {
   code : string;  (** Ticker symbol, e.g. ["AAPL"]. *)
   name : string;
@@ -55,14 +44,6 @@ val get_historical_price :
     The [params.period] field controls whether daily, weekly, or monthly bars
     are returned. Use [Types.Cadence.Weekly] for Weinstein-style weekly
     analysis. *)
-
-val get_fundamentals :
-  token:string ->
-  symbol:string ->
-  ?fetch:fetch_fn ->
-  unit ->
-  fundamentals Status.status_or Deferred.t
-(** Fetch fundamental data (sector, industry, market cap) for a symbol. *)
 
 val get_index_symbols :
   token:string ->

--- a/trading/analysis/data/sources/eodhd/test/data/get_fundamentals_response.json
+++ b/trading/analysis/data/sources/eodhd/test/data/get_fundamentals_response.json
@@ -6,5 +6,9 @@
     "Industry": "Consumer Electronics",
     "MarketCapitalization": 2800000000000.0,
     "Exchange": "NASDAQ"
+  },
+  "SharesStats": {
+    "SharesOutstanding": 14687356000,
+    "SharesFloat": 14662534368
   }
 }

--- a/trading/analysis/data/sources/eodhd/test/data/get_fundamentals_response_no_shares_stats.json
+++ b/trading/analysis/data/sources/eodhd/test/data/get_fundamentals_response_no_shares_stats.json
@@ -1,0 +1,10 @@
+{
+  "General": {
+    "Code": "OBSC",
+    "Name": "Obscure Listing",
+    "Sector": "Technology",
+    "Industry": "Software",
+    "MarketCapitalization": null,
+    "Exchange": "NASDAQ"
+  }
+}

--- a/trading/analysis/data/sources/eodhd/test/dune
+++ b/trading/analysis/data/sources/eodhd/test/dune
@@ -3,6 +3,7 @@
   test_http_client
   test_splits_endpoint
   test_dividends_endpoint
+  test_fundamentals_endpoint
   test_exchange_resolver
   test_multi_market
   test_asset_type)

--- a/trading/analysis/data/sources/eodhd/test/test_fundamentals_endpoint.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_fundamentals_endpoint.ml
@@ -1,0 +1,99 @@
+open Core
+open Async
+open OUnit2
+open Matchers
+open Eodhd
+
+(* Driver: synchronous wrapper around the async endpoint, with an injectable
+   stub fetcher. *)
+let _run_get_fundamentals ~fetch ~symbol () =
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      Fundamentals_endpoint.get_fundamentals ~fetch ~token:"test_token" ~symbol
+        ())
+
+let _fixture_fetch ~expected_uri ~body_path : Http_client.fetch_fn =
+ fun uri ->
+  assert_that (Uri.to_string uri) (equal_to expected_uri);
+  Deferred.return (Ok (In_channel.read_all body_path))
+
+let test_get_fundamentals _ =
+  let fetch =
+    _fixture_fetch
+      ~expected_uri:
+        "https://eodhd.com/api/fundamentals/AAPL?api_token=test_token&filter=General%2CSharesStats&fmt=json"
+      ~body_path:"./data/get_fundamentals_response.json"
+  in
+  let result = _run_get_fundamentals ~fetch ~symbol:"AAPL" () in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) -> f.symbol)
+              (equal_to "AAPL");
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) -> f.name)
+              (equal_to "Apple Inc");
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) -> f.sector)
+              (equal_to "Technology");
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) -> f.industry)
+              (equal_to "Consumer Electronics");
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) -> f.exchange)
+              (equal_to "NASDAQ");
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) -> f.market_cap)
+              (float_equal 2800000000000.0);
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) ->
+                f.shares_outstanding)
+              (float_equal 14687356000.0);
+          ]))
+
+(* When the response omits the [SharesStats] section entirely (some
+   thinly-covered listings on EODHD), [shares_outstanding] falls back to
+   [0.0]. Downstream consumers (e.g. shares_outstanding_enrichment) treat
+   0.0 as a sentinel for "no fundamentals data" and skip the symbol. *)
+let test_get_fundamentals_missing_shares_stats _ =
+  let fetch _uri =
+    Deferred.return
+      (Ok
+         (In_channel.read_all
+            "./data/get_fundamentals_response_no_shares_stats.json"))
+  in
+  let result = _run_get_fundamentals ~fetch ~symbol:"OBSC" () in
+  assert_that result
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) -> f.symbol)
+              (equal_to "OBSC");
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) ->
+                f.shares_outstanding)
+              (float_equal 0.0);
+            field
+              (fun (f : Fundamentals_endpoint.fundamentals) -> f.market_cap)
+              (float_equal 0.0);
+          ]))
+
+let test_get_fundamentals_error _ =
+  let fetch _uri =
+    Deferred.return (Error (Status.internal_error "API rate limit exceeded"))
+  in
+  let result = _run_get_fundamentals ~fetch ~symbol:"AAPL" () in
+  assert_that result is_error
+
+let suite =
+  "fundamentals_endpoint_test"
+  >::: [
+         "get_fundamentals" >:: test_get_fundamentals;
+         "get_fundamentals_missing_shares_stats"
+         >:: test_get_fundamentals_missing_shares_stats;
+         "get_fundamentals_error" >:: test_get_fundamentals_error;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/data/sources/eodhd/test/test_http_client.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_http_client.ml
@@ -463,47 +463,6 @@ let test_get_historical_price_weekly _ =
   | Ok prices -> assert_equal ~printer:Int.to_string 3 (List.length prices)
   | Error err -> assert_failure (Status.show err)
 
-let test_get_fundamentals _ =
-  let mock_fetch uri =
-    let actual_uri_str = Uri.to_string uri in
-    let expected_uri_str =
-      "https://eodhd.com/api/fundamentals/AAPL?api_token=test_token&filter=General&fmt=json"
-    in
-    assert_equal ~printer:Fn.id actual_uri_str expected_uri_str;
-    let test_data =
-      In_channel.read_all "./data/get_fundamentals_response.json"
-    in
-    Deferred.return (Ok test_data)
-  in
-  let result =
-    Async.Thread_safe.block_on_async_exn (fun () ->
-        get_fundamentals ~fetch:mock_fetch ~token:"test_token" ~symbol:"AAPL" ())
-  in
-  match result with
-  | Ok f ->
-      assert_equal ~printer:Fn.id "AAPL" f.Eodhd.Http_client.symbol;
-      assert_equal ~printer:Fn.id "Apple Inc" f.name;
-      assert_equal ~printer:Fn.id "Technology" f.sector;
-      assert_equal ~printer:Fn.id "Consumer Electronics" f.industry;
-      assert_equal ~printer:Fn.id "NASDAQ" f.exchange;
-      assert_bool "market_cap should be positive" Float.(f.market_cap > 0.0)
-  | Error err -> assert_failure (Status.show err)
-
-let test_get_fundamentals_error _ =
-  let mock_fetch _uri =
-    Deferred.return (Error (Status.internal_error "API rate limit exceeded"))
-  in
-  let result =
-    Async.Thread_safe.block_on_async_exn (fun () ->
-        get_fundamentals ~fetch:mock_fetch ~token:"test_token" ~symbol:"AAPL" ())
-  in
-  match result with
-  | Ok _ -> assert_failure "Expected Error result"
-  | Error status ->
-      assert_equal ~printer:Status.show
-        (Status.internal_error "API rate limit exceeded")
-        status
-
 let test_get_index_symbols _ =
   let mock_fetch uri =
     let actual_uri_str = Uri.to_string uri in
@@ -539,8 +498,6 @@ let suite =
          "get_historical_price_invalid_date_range"
          >:: test_get_historical_price_invalid_date_range;
          "get_historical_price_weekly" >:: test_get_historical_price_weekly;
-         "get_fundamentals" >:: test_get_fundamentals;
-         "get_fundamentals_error" >:: test_get_fundamentals_error;
          "get_index_symbols" >:: test_get_index_symbols;
          "get_symbols" >:: test_get_symbols;
          "get_symbols_extracts_name_and_exchange"

--- a/trading/analysis/scripts/shares_outstanding_enrichment/bin/dune
+++ b/trading/analysis/scripts/shares_outstanding_enrichment/bin/dune
@@ -1,0 +1,15 @@
+(executable
+ (name main)
+ (libraries
+  core
+  core_unix.command_unix
+  async
+  async_ssl
+  status
+  eodhd
+  file.sexp
+  weinstein.data_source
+  asset_type_enrichment_lib
+  shares_outstanding_enrichment_lib)
+ (preprocess
+  (pps ppx_let)))

--- a/trading/analysis/scripts/shares_outstanding_enrichment/bin/main.ml
+++ b/trading/analysis/scripts/shares_outstanding_enrichment/bin/main.ml
@@ -1,0 +1,256 @@
+(** Bulk-enrich equity-like inventory symbols with shares-outstanding sourced
+    from EODHD's [/api/fundamentals/{symbol}] endpoint.
+
+    Reads [inventory.sexp] (one entry per cached symbol) and [symbol_types.sexp]
+    (Q1 PR2 artifact), filters the inventory to equity-like instruments
+    (Common_stock / Preferred_stock / ADR / GDR), calls EODHD fundamentals for
+    each, and writes [shares_outstanding.sexp].
+
+    Typical usage:
+    {v
+      shares_outstanding_enrichment.exe \
+        --inventory-path  data/inventory.sexp \
+        --symbol-types-path data/symbol_types.sexp \
+        --output-path     data/shares_outstanding.sexp \
+        --secrets-path    trading/analysis/data/sources/eodhd/secrets \
+        --sleep-ms        200
+    v}
+
+    Token tier: the [/api/fundamentals/] endpoint requires an EODHD plan with
+    the "Fundamentals API" add-on. Tokens without this add-on return HTTP 403
+    even though [/api/eod] continues to work. When the run hits 403s for the
+    first few symbols, it aborts early (no point burning the API quota on locked
+    endpoints). *)
+
+open Core
+open Async
+
+(* Per-call sleep between fetches. Even at the paid-plan rate limit
+   (1200 req/min), a 200ms gap keeps us comfortably under the cap while
+   leaving headroom for the bursty filter / parsing work inside [get_fundamentals]. *)
+let _default_sleep_ms = 200
+let _default_secrets_path = "trading/analysis/data/sources/eodhd/secrets"
+
+(* Abort after this many consecutive auth failures — treat as token-tier
+   gating, not transient. *)
+let _max_consecutive_auth_failures = 5
+
+let _read_token ~secrets_path =
+  try Ok (In_channel.read_all secrets_path |> String.strip)
+  with Sys_error msg ->
+    Status.error_invalid_argument
+      (Printf.sprintf "failed to read secrets %s: %s" secrets_path msg)
+
+let _load_inventory ~inventory_path =
+  let path = Fpath.v inventory_path in
+  File_sexp.Sexp.load
+    (module struct
+      type t = Inventory.t
+
+      let sexp_of_t = Inventory.sexp_of_t
+      let t_of_sexp = Inventory.t_of_sexp
+    end)
+    ~path
+
+let _load_symbol_types ~symbol_types_path =
+  Asset_type_enrichment_lib.load ~path:(Fpath.v symbol_types_path)
+
+(* ---- Per-symbol fetch + classification ---- *)
+
+(* The fetch result classes:
+   - Got the data (possibly with shares = 0.0; downstream filters that out)
+   - Auth-level failure: 403 from a gated tier — increments the auth-failure
+     counter and may abort the run.
+   - Other transient / not-found error: log + continue, do not abort. *)
+type fetch_outcome =
+  | Fetched of Eodhd.Fundamentals_endpoint.fundamentals
+  | Auth_failed of string
+  | Other_failed of string
+
+let _is_auth_error_message msg =
+  let lower = String.lowercase msg in
+  String.is_substring lower ~substring:"403"
+  || String.is_substring lower ~substring:"forbidden"
+
+let _fetch_one ~token symbol =
+  Eodhd.Fundamentals_endpoint.get_fundamentals ~token ~symbol () >>| function
+  | Ok f -> Fetched f
+  | Error status ->
+      let msg = Status.show status in
+      if _is_auth_error_message msg then Auth_failed msg else Other_failed msg
+
+(* ---- Progress accumulator ---- *)
+
+type progress = {
+  attempted : int;
+  fetched : int;
+  with_positive_shares : int;
+  consecutive_auth_failures : int;
+  recent_fundamentals : Eodhd.Fundamentals_endpoint.fundamentals list;
+      (* Accumulated in REVERSE order; reversed once at end of run. *)
+}
+
+let _initial_progress =
+  {
+    attempted = 0;
+    fetched = 0;
+    with_positive_shares = 0;
+    consecutive_auth_failures = 0;
+    recent_fundamentals = [];
+  }
+
+(* Single step: increment [attempted] and route per outcome. Inlined so the
+   fetch loop body reads top-to-bottom without indirection. *)
+let _step_progress progress outcome =
+  let base = { progress with attempted = progress.attempted + 1 } in
+  match outcome with
+  | Fetched f ->
+      let positive =
+        Float.(f.Eodhd.Fundamentals_endpoint.shares_outstanding > 0.0)
+      in
+      {
+        base with
+        fetched = base.fetched + 1;
+        with_positive_shares =
+          (base.with_positive_shares + if positive then 1 else 0);
+        consecutive_auth_failures = 0;
+        recent_fundamentals = f :: base.recent_fundamentals;
+      }
+  | Auth_failed _ ->
+      {
+        base with
+        consecutive_auth_failures = base.consecutive_auth_failures + 1;
+      }
+  | Other_failed _ -> { base with consecutive_auth_failures = 0 }
+
+(* ---- Main fetch loop ---- *)
+
+let _log_progress progress symbol = function
+  | Fetched f ->
+      Core.printf "[%d] %s -> %.0f shares\n%!" progress.attempted symbol
+        f.Eodhd.Fundamentals_endpoint.shares_outstanding
+  | Auth_failed msg ->
+      Core.printf "[%d] %s -> AUTH FAIL: %s\n%!" progress.attempted symbol msg
+  | Other_failed msg ->
+      Core.printf "[%d] %s -> ERROR: %s\n%!" progress.attempted symbol msg
+
+let _sleep_seconds ~sleep_ms =
+  Clock.after (Time_float.Span.of_sec (float_of_int sleep_ms /. 1_000.0))
+
+(* True if we've hit the auth-failure threshold and should abort the run. *)
+let _should_abort progress =
+  progress.consecutive_auth_failures >= _max_consecutive_auth_failures
+
+let _log_abort progress =
+  Core.printf
+    "Aborting: %d consecutive auth failures (token likely lacks Fundamentals \
+     API access).\n\
+     %!"
+    progress.consecutive_auth_failures
+
+(* Fetch a single symbol, update the progress accumulator, and log. Returns
+   the updated progress; the caller decides whether to continue. *)
+let _process_symbol ~token ~progress symbol =
+  _fetch_one ~token symbol >>| fun outcome ->
+  let progress' = _step_progress progress outcome in
+  _log_progress progress' symbol outcome;
+  progress'
+
+(* Walks the symbol list, fetching one at a time with [sleep_ms] in between.
+   Bails out on [_max_consecutive_auth_failures] sequential auth errors —
+   continuing past that point only burns API quota on a locked endpoint. *)
+let rec _fetch_loop ~token ~sleep_ms ~progress = function
+  | [] -> return progress
+  | symbol :: rest ->
+      _process_symbol ~token ~progress symbol >>= fun progress' ->
+      if _should_abort progress' then (
+        _log_abort progress';
+        return progress')
+      else
+        _sleep_seconds ~sleep_ms >>= fun () ->
+        _fetch_loop ~token ~sleep_ms ~progress:progress' rest
+
+let _equity_like_inventory ~inventory ~symbol_types =
+  let inventory_symbols =
+    List.map inventory.Inventory.symbols ~f:(fun e -> e.Inventory.symbol)
+  in
+  Asset_type_enrichment_lib.filter_equity_like_symbols ~symbol_types
+    ~symbols:inventory_symbols
+
+let _print_summary progress =
+  Core.printf "\n---- Summary ----\n";
+  Core.printf "Attempted:               %d\n" progress.attempted;
+  Core.printf "Fetched successfully:    %d\n" progress.fetched;
+  Core.printf "With shares > 0:         %d\n" progress.with_positive_shares;
+  Core.printf "Consecutive auth fails:  %d\n%!"
+    progress.consecutive_auth_failures
+
+(* ---- Composition + writeout ---- *)
+
+let _build_and_save ~output_path ~progress =
+  let today = Date.today ~zone:Time_float.Zone.utc in
+  let fundamentals = List.rev progress.recent_fundamentals in
+  let enriched =
+    Shares_outstanding_enrichment_lib.join ~fundamentals ~generated_at:today
+      ~source_endpoints:
+        [ ("/api/fundamentals/{symbol}?filter=General,SharesStats", today) ]
+  in
+  Shares_outstanding_enrichment_lib.save enriched ~path:(Fpath.v output_path)
+
+let _run ~inventory_path ~symbol_types_path ~output_path ~secrets_path ~sleep_ms
+    =
+  let open Deferred.Result.Let_syntax in
+  let%bind token = _read_token ~secrets_path |> Deferred.return in
+  let%bind inventory = _load_inventory ~inventory_path |> Deferred.return in
+  let%bind symbol_types =
+    _load_symbol_types ~symbol_types_path |> Deferred.return
+  in
+  let equity_like = _equity_like_inventory ~inventory ~symbol_types in
+  Core.printf "Inventory: %d symbols. Equity-like (post-filter): %d.\n%!"
+    (List.length inventory.Inventory.symbols)
+    (List.length equity_like);
+  let%bind progress =
+    _fetch_loop ~token ~sleep_ms ~progress:_initial_progress equity_like
+    |> Deferred.map ~f:Result.return
+  in
+  _print_summary progress;
+  let%bind () = _build_and_save ~output_path ~progress |> Deferred.return in
+  Core.printf "Wrote %s\n%!" output_path;
+  Deferred.Result.return ()
+
+let _main ~inventory_path ~symbol_types_path ~output_path ~secrets_path
+    ~sleep_ms () =
+  _run ~inventory_path ~symbol_types_path ~output_path ~secrets_path ~sleep_ms
+  >>= function
+  | Ok () -> return ()
+  | Error e ->
+      Core.eprintf "Error: %s\n" (Status.show e);
+      exit 1
+
+let command =
+  Command.async
+    ~summary:
+      "Bulk-enrich equity-like inventory symbols with EODHD shares-outstanding \
+       (Q2-A PR1 of custom-universe-bidirectional)"
+    (let%map_open.Command inventory_path =
+       flag "inventory-path" (required string)
+         ~doc:"PATH Path to inventory.sexp"
+     and symbol_types_path =
+       flag "symbol-types-path" (required string)
+         ~doc:"PATH Path to symbol_types.sexp (Q1 PR2 output)"
+     and output_path =
+       flag "output-path" (required string)
+         ~doc:"PATH Where to write shares_outstanding.sexp"
+     and secrets_path =
+       flag "secrets-path"
+         (optional_with_default _default_secrets_path string)
+         ~doc:"PATH EODHD API token file (default: repo-local secrets)"
+     and sleep_ms =
+       flag "sleep-ms"
+         (optional_with_default _default_sleep_ms int)
+         ~doc:"MS Sleep between per-symbol fetches (default: 200ms)"
+     in
+     _main ~inventory_path ~symbol_types_path ~output_path ~secrets_path
+       ~sleep_ms)
+
+let () = Command_unix.run command

--- a/trading/analysis/scripts/shares_outstanding_enrichment/lib/dune
+++ b/trading/analysis/scripts/shares_outstanding_enrichment/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name shares_outstanding_enrichment_lib)
+ (libraries core status eodhd file.sexp)
+ (preprocess
+  (pps ppx_let ppx_deriving.show ppx_deriving.eq)))

--- a/trading/analysis/scripts/shares_outstanding_enrichment/lib/shares_outstanding_enrichment_lib.ml
+++ b/trading/analysis/scripts/shares_outstanding_enrichment/lib/shares_outstanding_enrichment_lib.ml
@@ -1,0 +1,188 @@
+open Core
+
+(* ---- Types ---- *)
+
+type entry = { symbol : string; shares_outstanding : float }
+[@@deriving show, eq]
+
+type t = {
+  generated_at : Date.t;
+  source_endpoints : (string * Date.t) list;
+  entries : entry list;
+}
+[@@deriving show, eq]
+
+(* ---- Sexp encoding for [entry] ---- *)
+
+let _kv_sexp key value = Sexp.List [ Atom key; Atom value ]
+let _symbol_field s = _kv_sexp "symbol" s
+
+let _shares_outstanding_field n =
+  _kv_sexp "shares_outstanding" (Printf.sprintf "%.6f" n)
+
+let sexp_of_entry { symbol; shares_outstanding } =
+  Sexp.List
+    [ _symbol_field symbol; _shares_outstanding_field shares_outstanding ]
+
+let _atom_of = function
+  | Sexp.Atom s -> Ok s
+  | other ->
+      Error (Printf.sprintf "expected atom, got: %s" (Sexp.to_string other))
+
+let _find_field fields name =
+  match List.Assoc.find ~equal:String.equal fields name with
+  | Some v -> Ok v
+  | None -> Error (Printf.sprintf "missing field %s" name)
+
+let _entry_field_pairs = function
+  | Sexp.List [ Atom k; v ] -> Ok (k, v)
+  | other ->
+      Error
+        (Printf.sprintf "expected (key value) pair, got: %s"
+           (Sexp.to_string other))
+
+let _parse_float_atom atom =
+  try Ok (Float.of_string atom)
+  with _ -> Error (Printf.sprintf "invalid float atom: %s" atom)
+
+let _entry_of_fields fields =
+  let open Result.Let_syntax in
+  let%bind symbol = _find_field fields "symbol" >>= _atom_of in
+  let%bind shares_atom = _find_field fields "shares_outstanding" >>= _atom_of in
+  let%bind shares_outstanding = _parse_float_atom shares_atom in
+  Ok { symbol; shares_outstanding }
+
+let entry_of_sexp sexp =
+  let result =
+    let open Result.Let_syntax in
+    match sexp with
+    | Sexp.List pairs ->
+        let%bind kvs = List.map pairs ~f:_entry_field_pairs |> Result.all in
+        _entry_of_fields kvs
+    | other ->
+        Error
+          (Printf.sprintf "expected entry list, got: %s" (Sexp.to_string other))
+  in
+  match result with
+  | Ok e -> e
+  | Error msg ->
+      raise (Sexp.Of_sexp_error (Failure ("entry_of_sexp: " ^ msg), sexp))
+
+(* ---- Sexp encoding for [t] ---- *)
+
+let _sexp_of_endpoint_pair (ep, d) =
+  Sexp.List [ Atom ep; Atom (Date.to_string d) ]
+
+let _endpoint_pair_of_sexp = function
+  | Sexp.List [ Atom ep; Atom d ] -> (
+      try Ok (ep, Date.of_string d)
+      with _ -> Error ("invalid endpoint date: " ^ d))
+  | other ->
+      Error
+        (Printf.sprintf "expected (endpoint date) pair, got: %s"
+           (Sexp.to_string other))
+
+let _generated_at_field generated_at =
+  Sexp.List [ Atom "generated_at"; Atom (Date.to_string generated_at) ]
+
+let _source_endpoints_field source_endpoints =
+  let pairs = List.map source_endpoints ~f:_sexp_of_endpoint_pair in
+  Sexp.List [ Atom "source_endpoints"; List pairs ]
+
+let _entries_field entries =
+  Sexp.List [ Atom "entries"; List (List.map entries ~f:sexp_of_entry) ]
+
+let sexp_of_t { generated_at; source_endpoints; entries } =
+  Sexp.List
+    [
+      _generated_at_field generated_at;
+      _source_endpoints_field source_endpoints;
+      _entries_field entries;
+    ]
+
+let _parse_endpoints_field = function
+  | Sexp.List pairs -> List.map pairs ~f:_endpoint_pair_of_sexp |> Result.all
+  | other ->
+      Error
+        (Printf.sprintf "expected source_endpoints list, got: %s"
+           (Sexp.to_string other))
+
+let _parse_entries_field = function
+  | Sexp.List entries -> Ok (List.map entries ~f:entry_of_sexp)
+  | other ->
+      Error
+        (Printf.sprintf "expected entries list, got: %s" (Sexp.to_string other))
+
+let _parse_generated_at fields =
+  let open Result.Let_syntax in
+  let%bind atom = _find_field fields "generated_at" >>= _atom_of in
+  try Ok (Date.of_string atom)
+  with _ -> Error ("invalid generated_at date: " ^ atom)
+
+let _parse_t_fields fields =
+  let open Result.Let_syntax in
+  let%bind generated_at = _parse_generated_at fields in
+  let%bind endpoints_sexp = _find_field fields "source_endpoints" in
+  let%bind source_endpoints = _parse_endpoints_field endpoints_sexp in
+  let%bind entries_sexp = _find_field fields "entries" in
+  let%bind entries = _parse_entries_field entries_sexp in
+  Ok { generated_at; source_endpoints; entries }
+
+let _t_of_sexp_routing sexp =
+  let open Result.Let_syntax in
+  match sexp with
+  | Sexp.List pairs ->
+      let%bind kvs = List.map pairs ~f:_entry_field_pairs |> Result.all in
+      _parse_t_fields kvs
+  | other ->
+      Error
+        (Printf.sprintf "expected top-level list, got: %s"
+           (Sexp.to_string other))
+
+let t_of_sexp sexp =
+  match _t_of_sexp_routing sexp with
+  | Ok x -> x
+  | Error msg ->
+      raise (Sexp.Of_sexp_error (Failure ("t_of_sexp: " ^ msg), sexp))
+
+(* ---- Pure join ---- *)
+
+let _has_positive_shares (f : Eodhd.Fundamentals_endpoint.fundamentals) =
+  Float.(f.shares_outstanding > 0.0)
+
+(* Deduplicate by symbol, keeping the first occurrence. *)
+let _dedupe_by_symbol fundamentals =
+  let seen = Hash_set.create (module String) in
+  List.filter fundamentals ~f:(fun f ->
+      let symbol = f.Eodhd.Fundamentals_endpoint.symbol in
+      if Hash_set.mem seen symbol then false
+      else (
+        Hash_set.add seen symbol;
+        true))
+
+let _entry_of_fundamentals (f : Eodhd.Fundamentals_endpoint.fundamentals) =
+  { symbol = f.symbol; shares_outstanding = f.shares_outstanding }
+
+let join ~fundamentals ~generated_at ~source_endpoints =
+  let entries =
+    fundamentals
+    |> List.filter ~f:_has_positive_shares
+    |> _dedupe_by_symbol
+    |> List.map ~f:_entry_of_fundamentals
+    |> List.sort ~compare:(fun a b -> String.compare a.symbol b.symbol)
+  in
+  { generated_at; source_endpoints; entries }
+
+(* ---- I/O — uses [File_sexp.Sexp.save/load] via a Sexpable module ---- *)
+
+let _sexpable () =
+  (module struct
+    type nonrec t = t
+
+    let sexp_of_t = sexp_of_t
+    let t_of_sexp = t_of_sexp
+  end : Base.Sexpable.S
+    with type t = t)
+
+let save t ~path = File_sexp.Sexp.save (_sexpable ()) t ~path
+let load ~path = File_sexp.Sexp.load (_sexpable ()) ~path

--- a/trading/analysis/scripts/shares_outstanding_enrichment/lib/shares_outstanding_enrichment_lib.mli
+++ b/trading/analysis/scripts/shares_outstanding_enrichment/lib/shares_outstanding_enrichment_lib.mli
@@ -1,0 +1,66 @@
+(** Bulk-enrich a list of inventory symbols with current shares-outstanding
+    sourced from EODHD's [/api/fundamentals/{symbol}] endpoint.
+
+    Companion plan: Q2-A PR1 of
+    [dev/plans/custom-universe-bidirectional-2026-05-17.md]. The enriched output
+    is consumed by Q2-A PR2's composition builder, which ranks symbols by
+    [current_shares × historical_close_price] to construct market-cap-weighted
+    historical universes.
+
+    Design choices:
+
+    - "Current shares × historical price" is an approximation (buyback
+      distortion, IPO phantom market cap pre-listing). A separate
+      cross-validation PR (not in this stack) will check drift vs the Shiller
+      SP500 composite to bound the error.
+
+    - Sentinel for "no fundamentals data": **skip the symbol entirely**. The
+      output [entries] list omits symbols whose EODHD fundamentals response came
+      back as missing or with [shares_outstanding = 0.0]. Downstream consumers
+      (Q2-A PR2) treat absent symbols as "ineligible for ranking".
+
+    - This library is pure (no HTTP). The bin/ executable handles fetching and
+      passes a list of [Eodhd.Fundamentals_endpoint.fundamentals] records to
+      [join]. *)
+
+open Core
+
+(** {1 Records} *)
+
+type entry = { symbol : string; shares_outstanding : float }
+[@@deriving show, eq]
+(** One enriched entry per equity-like symbol with non-zero shares outstanding.
+*)
+
+type t = {
+  generated_at : Date.t;
+  source_endpoints : (string * Date.t) list;
+      (** [(endpoint, fetch_date)] pairs for the EODHD endpoints whose response
+          populated [entries]. Recorded for provenance. *)
+  entries : entry list;
+      (** One [entry] per symbol that returned non-zero shares. Sorted by
+          [symbol] ascending for deterministic round-trip. *)
+}
+[@@deriving show, eq]
+
+(** {1 Pure join} *)
+
+val join :
+  fundamentals:Eodhd.Fundamentals_endpoint.fundamentals list ->
+  generated_at:Date.t ->
+  source_endpoints:(string * Date.t) list ->
+  t
+(** [join ~fundamentals ~generated_at ~source_endpoints] keeps every
+    fundamentals record with [shares_outstanding > 0.0] and drops the rest.
+    Output [entries] is sorted by [symbol] ascending. If the same symbol appears
+    multiple times in [fundamentals], the first occurrence wins. *)
+
+(** {1 I/O} *)
+
+val save : t -> path:Fpath.t -> Status.status
+(** Write the enriched index to [path] as a sexp. Overwrites any existing file.
+*)
+
+val load : path:Fpath.t -> t Status.status_or
+(** Read an enriched index from [path]. Errors if the file is missing or
+    malformed. *)

--- a/trading/analysis/scripts/shares_outstanding_enrichment/test/dune
+++ b/trading/analysis/scripts/shares_outstanding_enrichment/test/dune
@@ -1,0 +1,14 @@
+(test
+ (name test_shares_outstanding_enrichment)
+ (libraries
+  core
+  core_unix
+  core_unix.filename_unix
+  core_unix.sys_unix
+  ounit2
+  matchers
+  status
+  eodhd
+  shares_outstanding_enrichment_lib)
+ (preprocess
+  (pps ppx_let)))

--- a/trading/analysis/scripts/shares_outstanding_enrichment/test/test_shares_outstanding_enrichment.ml
+++ b/trading/analysis/scripts/shares_outstanding_enrichment/test/test_shares_outstanding_enrichment.ml
@@ -1,0 +1,170 @@
+open Core
+open OUnit2
+open Matchers
+open Shares_outstanding_enrichment_lib
+
+(* ---- Fixtures ----
+
+   Top-level builders keep the test bodies flat (per the nesting linter's
+   indentation-as-depth heuristic) and let the matcher assertions read at
+   depth {1,2}. *)
+
+let _sample_date = Date.create_exn ~y:2026 ~m:May ~d:17
+
+let _make_fundamentals ~symbol ~shares_outstanding :
+    Eodhd.Fundamentals_endpoint.fundamentals =
+  {
+    symbol;
+    name = symbol ^ " Inc";
+    sector = "Technology";
+    industry = "Software";
+    market_cap = 0.0;
+    exchange = "NASDAQ";
+    shares_outstanding;
+  }
+
+let _make_entry ~symbol ~shares_outstanding : entry =
+  { symbol; shares_outstanding }
+
+let _sample_endpoints =
+  [ ("/api/fundamentals/{symbol}?filter=General,SharesStats", _sample_date) ]
+
+let _join_with_defaults fundamentals =
+  join ~fundamentals ~generated_at:_sample_date
+    ~source_endpoints:_sample_endpoints
+
+(* Matcher helpers — single [field] extractors composed via [all_of]. *)
+
+let _generated_at_is d = field (fun (t : t) -> t.generated_at) (equal_to d)
+
+let _source_endpoints_match expected =
+  field (fun (t : t) -> t.source_endpoints) (elements_are expected)
+
+let _entries_match per_entry =
+  field (fun (t : t) -> t.entries) (elements_are per_entry)
+
+(* ---- Pure join — sorts entries by symbol ascending ---- *)
+
+(* Unsorted input fixtures, top-level to keep the test body flat. *)
+let _unsorted_three_fundamentals =
+  [
+    _make_fundamentals ~symbol:"MSFT" ~shares_outstanding:7_500_000_000.0;
+    _make_fundamentals ~symbol:"AAPL" ~shares_outstanding:14_687_356_000.0;
+    _make_fundamentals ~symbol:"GOOG" ~shares_outstanding:12_300_000_000.0;
+  ]
+
+let _expected_sorted_entries =
+  [
+    equal_to (_make_entry ~symbol:"AAPL" ~shares_outstanding:14_687_356_000.0);
+    equal_to (_make_entry ~symbol:"GOOG" ~shares_outstanding:12_300_000_000.0);
+    equal_to (_make_entry ~symbol:"MSFT" ~shares_outstanding:7_500_000_000.0);
+  ]
+
+let _expected_endpoints =
+  [
+    equal_to
+      ("/api/fundamentals/{symbol}?filter=General,SharesStats", _sample_date);
+  ]
+
+let test_join_sorts_entries_by_symbol_ascending _ =
+  let result = _join_with_defaults _unsorted_three_fundamentals in
+  assert_that result
+    (all_of
+       [
+         _generated_at_is _sample_date;
+         _source_endpoints_match _expected_endpoints;
+         _entries_match _expected_sorted_entries;
+       ])
+
+(* ---- Pure join — drops symbols with zero or negative shares ----
+
+   The .mli contract: shares_outstanding = 0.0 is the "no fundamentals data"
+   sentinel emitted by [Fundamentals_endpoint.get_fundamentals] when the
+   [SharesStats] section is absent. Such entries must NOT appear in the
+   output. *)
+
+let _mixed_shares_fundamentals =
+  [
+    _make_fundamentals ~symbol:"AAPL" ~shares_outstanding:14_687_356_000.0;
+    _make_fundamentals ~symbol:"NOSHARES" ~shares_outstanding:0.0;
+    _make_fundamentals ~symbol:"MSFT" ~shares_outstanding:7_500_000_000.0;
+    _make_fundamentals ~symbol:"NEGSHARES" ~shares_outstanding:(-1.0);
+  ]
+
+let _expected_positive_entries =
+  [
+    equal_to (_make_entry ~symbol:"AAPL" ~shares_outstanding:14_687_356_000.0);
+    equal_to (_make_entry ~symbol:"MSFT" ~shares_outstanding:7_500_000_000.0);
+  ]
+
+let test_join_drops_zero_shares_entries _ =
+  let result = _join_with_defaults _mixed_shares_fundamentals in
+  assert_that result (_entries_match _expected_positive_entries)
+
+(* ---- Empty input ---- *)
+
+let test_join_empty_input_yields_empty_entries _ =
+  let result = _join_with_defaults [] in
+  assert_that result (_entries_match [])
+
+(* ---- Duplicate-symbol guard ----
+
+   .mli line: "If the same symbol appears multiple times in [fundamentals],
+   the first occurrence wins." Pin so a future regression (e.g. switching to
+   "last wins") is caught deterministically. *)
+
+let test_join_first_occurrence_wins_on_duplicate _ =
+  let result =
+    _join_with_defaults
+      [
+        _make_fundamentals ~symbol:"AAPL" ~shares_outstanding:1_000.0;
+        _make_fundamentals ~symbol:"AAPL" ~shares_outstanding:2_000.0;
+      ]
+  in
+  assert_that result
+    (_entries_match
+       [ equal_to (_make_entry ~symbol:"AAPL" ~shares_outstanding:1_000.0) ])
+
+(* ---- Round-trip save / load ---- *)
+
+let _with_temp_path ~name ~f =
+  let dir = Filename_unix.temp_dir "shares_outstanding_test" "" in
+  let path = Fpath.v Filename.(concat dir name) in
+  Exn.protect
+    ~f:(fun () -> f path)
+    ~finally:(fun () ->
+      (try Sys_unix.remove (Fpath.to_string path) with _ -> ());
+      try Core_unix.rmdir dir with _ -> ())
+
+let test_round_trip_save_load _ =
+  let original =
+    _join_with_defaults
+      [
+        _make_fundamentals ~symbol:"AAPL" ~shares_outstanding:14_687_356_000.0;
+        _make_fundamentals ~symbol:"MSFT" ~shares_outstanding:7_500_000_000.0;
+        _make_fundamentals ~symbol:"GOOG" ~shares_outstanding:12_300_000_000.0;
+      ]
+  in
+  let assertion =
+    _with_temp_path ~name:"shares_outstanding.sexp" ~f:(fun path ->
+        match save original ~path with
+        | Error err -> assert_failure ("save failed: " ^ Status.show err)
+        | Ok () -> load ~path)
+  in
+  assert_that assertion (is_ok_and_holds (equal_to original))
+
+let suite =
+  "shares_outstanding_enrichment_test"
+  >::: [
+         "join_sorts_entries_by_symbol_ascending"
+         >:: test_join_sorts_entries_by_symbol_ascending;
+         "join_drops_zero_shares_entries"
+         >:: test_join_drops_zero_shares_entries;
+         "join_empty_input_yields_empty_entries"
+         >:: test_join_empty_input_yields_empty_entries;
+         "join_first_occurrence_wins_on_duplicate"
+         >:: test_join_first_occurrence_wins_on_duplicate;
+         "round_trip_save_load" >:: test_round_trip_save_load;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Q2-A PR1 of `dev/plans/custom-universe-bidirectional-2026-05-17.md`. Builds the shares-outstanding bulk enrichment library + executable so a future Q2-A PR2 can rank inventory symbols by `current_shares × historical_close_price` to construct market-cap-weighted historical universes (top-500, top-1000) without depending on the IWV scrape.

## EODHD fundamentals endpoint findings

- The `SharesOutstanding` field lives at `SharesStats.SharesOutstanding` (nested), NOT in `General`. Probed via the demo token; e.g. `curl 'https://eodhd.com/api/fundamentals/AAPL.US?api_token=demo&filter=SharesStats&fmt=json'` returns `{"SharesOutstanding":14687356000,...}`.
- We request the two-section filter `filter=General,SharesStats` so the parser still sees the existing `General.*` fields (name/sector/industry/market_cap/exchange) while picking up `SharesStats.SharesOutstanding`.
- **Token-tier dependency, NOT met by current secrets.** The `/api/fundamentals/` endpoint requires an EODHD plan with the "Fundamentals API" add-on. Our repo-local token (paid `monthly` plan, EOD-only tier) returns HTTP 403 across every variant probed. This matches the Phase 1.1 failure already documented in `dev/status/data-foundations.md` §"Blocking Refactors" and `dev/notes/phase1.1-eodhd-verification-2026-05-16.md`. The bin treats 5 consecutive auth failures as token-tier gating and aborts to preserve API quota.

## Enrichment run summary

**Not produced in this PR.** Building `data/shares_outstanding.sexp` is gated on a plan upgrade or a swap to an alternate fundamentals source (Sharadar via Nasdaq Data Link, AlphaVantage, etc.). Per the Option B decision (see status doc), tier upgrade is rejected; this PR leaves the artifact production hook in place but defers the actual fetch.

The lib + bin are both testable without the artifact: the lib has 5 OUnit tests over fixture-constructed `fundamentals` lists, and the http_client tests pin the parsing of both populated and missing-`SharesStats` responses.

## What changed

- **`Eodhd.Http_client`**: extended `fundamentals` record with `shares_outstanding : float`. Refactored `_parse_fundamentals_response` to look up both `General` and `SharesStats` sections (the latter optional — missing -> `0.0` sentinel). Updated the `get_fundamentals` query string to `filter=General,SharesStats`. Two new http_client tests cover the populated and missing-SharesStats cases.
- **`analysis/scripts/shares_outstanding_enrichment/lib/`**: new pure-join library. `join` filters fundamentals to `shares_outstanding > 0.0`, deduplicates by symbol (first-wins), sorts ascending by symbol. Sexp save/load round-trip via `File_sexp.Sexp`.
- **`analysis/scripts/shares_outstanding_enrichment/bin/`**: new executable. Loads `inventory.sexp` + `symbol_types.sexp`, filters to equity-like via Q1 PR3's `filter_equity_like_symbols`, walks each symbol calling `get_fundamentals` with a configurable per-call `--sleep-ms` (default 200ms). Logs progress per-symbol. Aborts on 5 consecutive auth-level failures.
- **Plan + status updates**: `dev/plans/custom-universe-bidirectional-2026-05-17.md` gains a Q2-A PR1 section and a sequencing-table row. `dev/status/data-foundations.md` In-Progress entry documents the artifact-gated state.

## Test plan

- [x] `dune runtest analysis/scripts/shares_outstanding_enrichment/` — 5 new OUnit tests:
  - `join_sorts_entries_by_symbol_ascending`
  - `join_drops_zero_shares_entries`
  - `join_empty_input_yields_empty_entries`
  - `join_first_occurrence_wins_on_duplicate`
  - `round_trip_save_load`
- [x] `dune runtest analysis/data/sources/eodhd/` — existing tests pass + 1 new test `get_fundamentals_missing_shares_stats` over a fixture without the `SharesStats` section. `get_fundamentals` test now also asserts the exact `shares_outstanding` value (14,687,356,000) via matcher library composition.
- [x] `dune runtest devtools/checks/` clean — no magic numbers, fn-length, nesting, mli-coverage, or no-python violations in the new files.
- [x] `dune build @fmt` clean.
- [ ] Bulk run end-to-end — gated on EODHD Fundamentals API tier (see "Token-tier dependency" above).

## Sanity checks pinned in tests

| Symbol | Shares outstanding (from EODHD demo probe) |
|---|---|
| AAPL | 14,687,356,000 |
| AAPL (no SharesStats fixture) | 0.0 (sentinel) |

