### PR TITLE
fix(csv-storage-tests): _reset_reconcile_dir uses rm -rf for any state shape

### DIFF
--- a/trading/analysis/data/storage/csv/test/test_csv_storage.ml
+++ b/trading/analysis/data/storage/csv/test/test_csv_storage.ml
@@ -554,15 +554,14 @@ let _reconcile_dir = Fpath.(test_dir / "_reconcile_log")
    reset the reconcile-log tree up front to be order-independent. *)
 let _reset_reconcile_dir () =
   let path = Fpath.to_string _reconcile_dir in
-  match Sys_unix.file_exists path with
-  | `No | `Unknown -> ()
-  | `Yes -> (
-      (* The dir may have been replaced with a regular file by the
-         failure-injection test; try the file removal first, then the
-         recursive-directory removal as a fallback. *)
-      try Stdlib.Sys.remove path
-      with _ ->
-        ok_or_failwith_os_error (OS.Dir.delete ~recurse:true _reconcile_dir))
+  (* Use rm -rf to remove the reconcile dir regardless of whether the path
+     or any of its children is a regular file (planted by
+     test_reconcile_failure_is_non_fatal's failure-injection setup) or a
+     proper directory. Ignore exit status — a missing path is fine. *)
+  let _ : int =
+    Stdlib.Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote path))
+  in
+  ()
 
 (* True iff a per-symbol reconcile entry has been written under any date shard
    below [_reconcile_dir]. Used to assert presence/absence without baking in


### PR DESCRIPTION
## Summary

Third recurrence of CSV-storage state-pollution flake: `test_reconcile_writes_entry_when_content_changes` (test #26) crashed on PR #1161's CI because `_reset_reconcile_dir` doesn't fully clean up the file/dir mixed state planted by `test_reconcile_failure_is_non_fatal`.

PRs #1153 and #1158 were point fixes for downstream symptoms (readdir guards on consumers). This PR fixes the root cause by replacing `_reset_reconcile_dir` with `rm -rf` which handles any path-type combination.

## Fix

- `_reset_reconcile_dir` now shells out to `rm -rf <reconcile_dir>` instead of try-Sys.remove-then-OS.Dir.delete. Handles all state shapes uniformly including the case where `_reconcile_log/<date>` is a regular FILE rather than a directory (planted by `test_reconcile_failure_is_non_fatal`'s failure-injection setup).

## Test plan

- [x] 30 csv tests pass 5x in a row (no flake) — verified locally
- [x] `dune runtest devtools/checks/` clean (0 FAIL)
- [x] `dune build @fmt` clean

## Why not OCaml-level recursive walker?

`rm -rf` is one line, ubiquitously correct, and bypasses every quirk in `Bos.OS.Dir.delete`'s handling of mixed file/dir trees. The test setup helper isn't performance-critical.