### PR TITLE
perf(universe): drop bars from _scored to fix multi-year × multi-size OOM

### DIFF
--- a/trading/analysis/data/universe/lib/build_from_individuals.ml
+++ b/trading/analysis/data/universe/lib/build_from_individuals.ml
@@ -107,7 +107,17 @@ let _forward_return ~date bars =
 (* Build pipeline                                                      *)
 (* ------------------------------------------------------------------ *)
 
-type _scored = { symbol : string; score : float; bars : BR.bar list }
+(* Per-symbol scoring result. [forward_return] is computed eagerly at
+   scoring time so [bars] can be dropped immediately — the prior shape
+   retained [bars : BR.bar list] across every candidate symbol (post-filter
+   ~5-7k symbols × ~1k bars × ~50 bytes ≈ 250 MB at the broad-universe
+   scale), which OOMed multi-year × multi-size runner invocations. Both
+   the dollar-volume score (trailing window) and the forward-return
+   (forward window) read disjoint slices of the same [bars] list, so the
+   bars only need to be live for the duration of one
+   [_dollar_volume_score] + [_forward_return] call pair, not until the
+   downstream rank + take + aggregate steps. *)
+type _scored = { symbol : string; score : float; forward_return : float option }
 
 let _score_symbol ~date ~config symbol : _scored option =
   match BR.read_bars ~bars_root:config.bars_root symbol with
@@ -115,7 +125,9 @@ let _score_symbol ~date ~config symbol : _scored option =
   | Some bars -> (
       match _dollar_volume_score ~date ~config bars with
       | None -> None
-      | Some score -> Some { symbol; score; bars })
+      | Some score ->
+          let forward_return = _forward_return ~date bars in
+          Some { symbol; score; forward_return })
 
 let _score_all ~date ~config symbols : _scored list =
   List.filter_map symbols ~f:(_score_symbol ~date ~config)
@@ -134,9 +146,9 @@ let _make_entry ~sector_lookup ~uniform_weight scored : Snapshot.entry =
     synthetic = false;
   }
 
-let _aggregate_period_return ~date scored_kept =
+let _aggregate_period_return scored_kept =
   let per_symbol_returns =
-    List.filter_map scored_kept ~f:(fun s -> _forward_return ~date s.bars)
+    List.filter_map scored_kept ~f:(fun s -> s.forward_return)
   in
   match per_symbol_returns with
   | [] -> 0.0
@@ -183,7 +195,7 @@ let _build_validated ~date ~config ~inventory ~equity_like_lookup ~sector_lookup
   let%bind.Result kept = _take_top_n_or_error ~size:config.size ranked in
   let uniform_weight = 1.0 /. Float.of_int config.size in
   let entries = List.map kept ~f:(_make_entry ~sector_lookup ~uniform_weight) in
-  let aggregate_period_return = _aggregate_period_return ~date kept in
+  let aggregate_period_return = _aggregate_period_return kept in
   Ok (_make_snapshot ~date ~config ~entries ~aggregate_period_return)
 
 let build ~date ~config =


### PR DESCRIPTION
## Summary

The composition pipeline's `_scored` record retained `bars : BR.bar list` for every candidate symbol, then only used those bars again at aggregate time via `_forward_return`. At broad-universe scale (~5-7k candidate symbols × ~1k bars × ~50 bytes per bar ≈ 250 MB), this retention spiked RSS enough to OOM multi-year × multi-size `build_synthetic_universes_runner` invocations. The existing 2025 + 1998-2025 sweeps were worked around with one-year-at-a-time invocations (~12 min wall each) until this fix.

The forward-return is deterministic given the same bars used for the score, so compute it eagerly inside `_score_symbol` and drop bars immediately. `_aggregate_period_return` now reads the precomputed `forward_return` field instead of re-scanning bars post-rank.

This is P1 from `dev/notes/next-session-priorities-2026-05-19.md`: Q2-A composition memory optimization.

## Behaviour invariant

Output of `build` is unchanged. Both the score-time and aggregate-time consumers of bars read disjoint date-windows, so eager-forward-return + bars-drop is exactly equivalent to the prior lazy-forward-return + bars-retain shape. Float-rounding order is unchanged (per-symbol forward-return is computed in the same order as before).

## Test plan

- [x] `dune runtest analysis/data/universe` — all 13 cases pass (covers `aggregate_period_return` mean-of-forward-returns + inactive/synthetic-filter regressions).
- [x] `dune runtest` (full repo) — clean. No downstream consumer of `_scored` exists outside `build_from_individuals.ml` (private type).

## Expected impact

When the broad-universe runner is rerun, peak RSS should drop by ~250 MB. The existing 2025 single-year invocations should now fit comfortably; multi-year batched invocations should work without OOM. Wall time is essentially unchanged (the same bars are read, scored, and forward-return-computed; only the retention period differs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)