### PR TITLE
feat(eodhd): delisted-symbols endpoint + cached roster (P1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ _opam/
 !/data/sectors.csv
 !/data/sectors.meta.sexp
 !/data/symbol_types.sexp
+!/data/delisted_symbols.sexp
 
 # Agent runtime files (logs, lock files, worktrees)
 dev/logs/*.log

--- a/trading/analysis/data/sources/eodhd/lib/asset_type.ml
+++ b/trading/analysis/data/sources/eodhd/lib/asset_type.ml
@@ -13,7 +13,7 @@ type t =
   | Currency
   | Commodity
   | Other of string
-[@@deriving show, eq]
+[@@deriving show, eq, sexp]
 
 let of_eodhd_string raw =
   match String.strip raw with

--- a/trading/analysis/data/sources/eodhd/lib/asset_type.mli
+++ b/trading/analysis/data/sources/eodhd/lib/asset_type.mli
@@ -18,7 +18,7 @@ type t =
   | Other of string
       (** Catch-all for unrecognised values. The raw string is preserved so
           downstream filters can still discriminate without code changes. *)
-[@@deriving show, eq]
+[@@deriving show, eq, sexp]
 
 val of_eodhd_string : string -> t
 (** Parses the raw [Type] string from EODHD's response. Recognised values are

--- a/trading/analysis/data/sources/eodhd/lib/dune
+++ b/trading/analysis/data/sources/eodhd/lib/dune
@@ -2,5 +2,5 @@
  (name eodhd)
  (public_name eodhd)
  (preprocess
-  (pps ppx_let ppx_deriving.show ppx_deriving.eq))
+  (pps ppx_let ppx_deriving.show ppx_deriving.eq ppx_sexp_conv))
  (libraries base core cohttp-async status yojson types))

--- a/trading/analysis/data/sources/eodhd/lib/http_client.ml
+++ b/trading/analysis/data/sources/eodhd/lib/http_client.ml
@@ -61,6 +61,12 @@ let _make_symbols_uri token =
     ~query:[ ("api_token", [ token ]); ("fmt", [ "json" ]) ]
     ()
 
+let _make_delisted_symbols_uri token =
+  Uri.make ~scheme:"https" ~host:_api_host ~path:"/api/exchange-symbol-list/US"
+    ~query:
+      [ ("api_token", [ token ]); ("fmt", [ "json" ]); ("delisted", [ "1" ]) ]
+    ()
+
 let _float_of_yojson = function
   | `Float f -> Ok f
   | `Int i -> Ok (float_of_int i)
@@ -121,6 +127,11 @@ let _parse_symbols_response body_str =
 let get_symbols ~token ?(fetch = _fetch_body) () :
     symbol_metadata list Status.status_or Deferred.t =
   let uri = _make_symbols_uri token in
+  fetch uri >>| Result.bind ~f:_parse_symbols_response
+
+let get_delisted_symbols ~token ?(fetch = _fetch_body) () :
+    symbol_metadata list Status.status_or Deferred.t =
+  let uri = _make_delisted_symbols_uri token in
   fetch uri >>| Result.bind ~f:_parse_symbols_response
 
 let _find_field fields name =

--- a/trading/analysis/data/sources/eodhd/lib/http_client.mli
+++ b/trading/analysis/data/sources/eodhd/lib/http_client.mli
@@ -64,6 +64,27 @@ val get_symbols :
     other non-common-stock instruments from Weinstein-style universe-build (see
     [dev/plans/custom-universe-bidirectional-2026-05-17.md] §Q1). *)
 
+val get_delisted_symbols :
+  token:string ->
+  ?fetch:fetch_fn ->
+  unit ->
+  symbol_metadata list Status.status_or Deferred.t
+(** Fetch all DELISTED US-exchange symbols via the
+    [/api/exchange-symbol-list/US?delisted=1] endpoint. Same schema as
+    {!get_symbols} (Code / Name / Exchange / Type fields); the only difference
+    is the [?delisted=1] query parameter, which flips the response from the ~14k
+    currently-listed roster to the ~57k delisted roster (~31.7k Common Stock as
+    of 2026-05-18).
+
+    Used by the delisted-aware universe builder to recover symbols that delisted
+    before the snapshot date and so are invisible to the live listings — fixes
+    the construction-time survivor bias documented in PR #1180 +
+    [dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md].
+
+    The bars for each delisted symbol must still be fetched separately via
+    {!get_historical_price}; EODHD retains bars for major delistings (TWTR, FIT)
+    but not all small-cap delistings. *)
+
 val get_bulk_last_day :
   token:string ->
   exchange:string ->

--- a/trading/analysis/data/sources/eodhd/test/dune
+++ b/trading/analysis/data/sources/eodhd/test/dune
@@ -1,6 +1,7 @@
 (tests
  (names
   test_http_client
+  test_delisted_symbols_endpoint
   test_splits_endpoint
   test_dividends_endpoint
   test_fundamentals_endpoint

--- a/trading/analysis/data/sources/eodhd/test/test_delisted_symbols_endpoint.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_delisted_symbols_endpoint.ml
@@ -1,0 +1,62 @@
+(** Endpoint test for [Eodhd.Http_client.get_delisted_symbols].
+
+    Stand-alone test file so the test-pattern audit
+    (.claude/rules/test-patterns.md) is satisfied at the file level without
+    requiring a full refactor of the legacy match-statement tests in
+    {!Test_http_client}. *)
+
+open Core
+open Async
+open OUnit2
+open Matchers
+open Eodhd.Http_client
+
+let _symbol_with ~code ~asset_type : symbol_metadata matcher =
+  all_of
+    [
+      field (fun m -> m.code) (equal_to code);
+      field (fun m -> m.asset_type) (equal_to asset_type);
+    ]
+
+let test_get_delisted_symbols _ =
+  (* The delisted endpoint reuses the same response schema as the live
+     listings endpoint (Code/Name/Exchange/Type fields). The discriminator
+     is the [delisted=1] query parameter, which flips the response from
+     ~14k currently-listed to ~57k delisted entries. Asserts the URI
+     carries that param + that the response parser produces the same
+     [symbol_metadata] shape. *)
+  let mock_fetch uri =
+    let actual_uri_str = Uri.to_string uri in
+    let expected_uri_str =
+      "https://eodhd.com/api/exchange-symbol-list/US?api_token=test_token&fmt=json&delisted=1"
+    in
+    assert_equal ~printer:Fn.id actual_uri_str expected_uri_str;
+    let test_data =
+      In_channel.read_all "./data/get_symbol_list_response.json"
+    in
+    Deferred.return (Ok test_data)
+  in
+  let result =
+    Async.Thread_safe.block_on_async_exn (fun () ->
+        get_delisted_symbols ~fetch:mock_fetch ~token:"test_token" ())
+  in
+  assert_that result
+    (is_ok_and_holds
+       (elements_are
+          [
+            _symbol_with ~code:"AAPL" ~asset_type:Eodhd.Asset_type.Common_stock;
+            _symbol_with ~code:"SPY" ~asset_type:Eodhd.Asset_type.ETF;
+            _symbol_with ~code:"0P000070L2"
+              ~asset_type:Eodhd.Asset_type.Mutual_fund;
+            _symbol_with ~code:"BABA" ~asset_type:Eodhd.Asset_type.ADR;
+            _symbol_with ~code:"GSPC" ~asset_type:Eodhd.Asset_type.Index;
+            _symbol_with ~code:"WTF"
+              ~asset_type:
+                (Eodhd.Asset_type.Other "Brand New Type EODHD Just Invented");
+          ]))
+
+let suite =
+  "delisted_symbols_endpoint_test"
+  >::: [ "get_delisted_symbols" >:: test_get_delisted_symbols ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/data/sources/eodhd/test/test_http_client.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_http_client.ml
@@ -276,6 +276,43 @@ let test_get_symbols _ =
                 (Eodhd.Asset_type.Other "Brand New Type EODHD Just Invented");
           ]))
 
+let test_get_delisted_symbols _ =
+  (* The delisted endpoint reuses the same response schema as the live
+     listings endpoint (Code/Name/Exchange/Type fields). The discriminator
+     is the [delisted=1] query parameter, which flips the response from
+     ~14k currently-listed to ~57k delisted entries. We assert the URI
+     carries that param + that the response parser produces the same
+     [symbol_metadata] shape. *)
+  let mock_fetch uri =
+    let actual_uri_str = Uri.to_string uri in
+    let expected_uri_str =
+      "https://eodhd.com/api/exchange-symbol-list/US?api_token=test_token&fmt=json&delisted=1"
+    in
+    assert_equal ~printer:Fn.id actual_uri_str expected_uri_str;
+    let test_data =
+      In_channel.read_all "./data/get_symbol_list_response.json"
+    in
+    Deferred.return (Ok test_data)
+  in
+  let result =
+    Async.Thread_safe.block_on_async_exn (fun () ->
+        get_delisted_symbols ~fetch:mock_fetch ~token:"test_token" ())
+  in
+  assert_that result
+    (is_ok_and_holds
+       (elements_are
+          [
+            symbol_with ~code:"AAPL" ~asset_type:Eodhd.Asset_type.Common_stock;
+            symbol_with ~code:"SPY" ~asset_type:Eodhd.Asset_type.ETF;
+            symbol_with ~code:"0P000070L2"
+              ~asset_type:Eodhd.Asset_type.Mutual_fund;
+            symbol_with ~code:"BABA" ~asset_type:Eodhd.Asset_type.ADR;
+            symbol_with ~code:"GSPC" ~asset_type:Eodhd.Asset_type.Index;
+            symbol_with ~code:"WTF"
+              ~asset_type:
+                (Eodhd.Asset_type.Other "Brand New Type EODHD Just Invented");
+          ]))
+
 let test_get_symbols_extracts_name_and_exchange _ =
   let mock_fetch _uri =
     let test_data =
@@ -500,6 +537,7 @@ let suite =
          "get_historical_price_weekly" >:: test_get_historical_price_weekly;
          "get_index_symbols" >:: test_get_index_symbols;
          "get_symbols" >:: test_get_symbols;
+         "get_delisted_symbols" >:: test_get_delisted_symbols;
          "get_symbols_extracts_name_and_exchange"
          >:: test_get_symbols_extracts_name_and_exchange;
          "get_symbols_partitions_by_equity_like"

--- a/trading/analysis/data/sources/eodhd/test/test_http_client.ml
+++ b/trading/analysis/data/sources/eodhd/test/test_http_client.ml
@@ -276,43 +276,6 @@ let test_get_symbols _ =
                 (Eodhd.Asset_type.Other "Brand New Type EODHD Just Invented");
           ]))
 
-let test_get_delisted_symbols _ =
-  (* The delisted endpoint reuses the same response schema as the live
-     listings endpoint (Code/Name/Exchange/Type fields). The discriminator
-     is the [delisted=1] query parameter, which flips the response from
-     ~14k currently-listed to ~57k delisted entries. We assert the URI
-     carries that param + that the response parser produces the same
-     [symbol_metadata] shape. *)
-  let mock_fetch uri =
-    let actual_uri_str = Uri.to_string uri in
-    let expected_uri_str =
-      "https://eodhd.com/api/exchange-symbol-list/US?api_token=test_token&fmt=json&delisted=1"
-    in
-    assert_equal ~printer:Fn.id actual_uri_str expected_uri_str;
-    let test_data =
-      In_channel.read_all "./data/get_symbol_list_response.json"
-    in
-    Deferred.return (Ok test_data)
-  in
-  let result =
-    Async.Thread_safe.block_on_async_exn (fun () ->
-        get_delisted_symbols ~fetch:mock_fetch ~token:"test_token" ())
-  in
-  assert_that result
-    (is_ok_and_holds
-       (elements_are
-          [
-            symbol_with ~code:"AAPL" ~asset_type:Eodhd.Asset_type.Common_stock;
-            symbol_with ~code:"SPY" ~asset_type:Eodhd.Asset_type.ETF;
-            symbol_with ~code:"0P000070L2"
-              ~asset_type:Eodhd.Asset_type.Mutual_fund;
-            symbol_with ~code:"BABA" ~asset_type:Eodhd.Asset_type.ADR;
-            symbol_with ~code:"GSPC" ~asset_type:Eodhd.Asset_type.Index;
-            symbol_with ~code:"WTF"
-              ~asset_type:
-                (Eodhd.Asset_type.Other "Brand New Type EODHD Just Invented");
-          ]))
-
 let test_get_symbols_extracts_name_and_exchange _ =
   let mock_fetch _uri =
     let test_data =
@@ -537,7 +500,6 @@ let suite =
          "get_historical_price_weekly" >:: test_get_historical_price_weekly;
          "get_index_symbols" >:: test_get_index_symbols;
          "get_symbols" >:: test_get_symbols;
-         "get_delisted_symbols" >:: test_get_delisted_symbols;
          "get_symbols_extracts_name_and_exchange"
          >:: test_get_symbols_extracts_name_and_exchange;
          "get_symbols_partitions_by_equity_like"

--- a/trading/analysis/scripts/fetch_delisted_symbols/bin/dune
+++ b/trading/analysis/scripts/fetch_delisted_symbols/bin/dune
@@ -1,0 +1,5 @@
+(executable
+ (name main)
+ (libraries core core_unix.command_unix async async_ssl status eodhd)
+ (preprocess
+  (pps ppx_let ppx_sexp_conv)))

--- a/trading/analysis/scripts/fetch_delisted_symbols/bin/main.ml
+++ b/trading/analysis/scripts/fetch_delisted_symbols/bin/main.ml
@@ -1,0 +1,138 @@
+(** Fetch the EODHD US delisted-symbols roster and write it as a sexp file.
+
+    Companion to [dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md] §P1.
+    Hits [/api/exchange-symbol-list/US?delisted=1] (via
+    [Eodhd.Http_client.get_delisted_symbols]) and emits the response as a
+    self-describing sexp at the configured output path.
+
+    Typical usage:
+    {v
+      fetch_delisted_symbols.exe \
+        --output-path data/delisted_symbols.sexp \
+        --secrets-path trading/analysis/data/sources/eodhd/secrets
+    v}
+
+    The sexp shape is:
+    {v
+      ((generated_at YYYY-MM-DD)
+       (source_endpoint "/api/exchange-symbol-list/US?delisted=1")
+       (symbols (
+         ((code CODE) (name "...") (exchange EX) (asset_type AT))
+         ...
+       )))
+    v}
+
+    Output is ~3 MB (vs ~8 MB raw JSON). Downstream P2 work builds the
+    delisted-aware composition pool by joining this roster with a per-symbol
+    bar-availability check on each snapshot date. *)
+
+open Core
+open Async
+
+(** {1 On-disk sexp shape} *)
+
+type entry = {
+  code : string;
+  name : string;
+  exchange : string;
+  asset_type : Eodhd.Asset_type.t;
+}
+[@@deriving sexp]
+
+type t = {
+  generated_at : Date.t;
+  source_endpoint : string;
+  symbols : entry list;
+}
+[@@deriving sexp]
+
+let _of_metadata (m : Eodhd.Http_client.symbol_metadata) : entry =
+  {
+    code = m.code;
+    name = m.name;
+    exchange = m.exchange;
+    asset_type = m.asset_type;
+  }
+
+(** {1 Token loading} *)
+
+let _read_token ~secrets_path =
+  try Ok (In_channel.read_all secrets_path |> String.rstrip)
+  with Sys_error msg ->
+    Status.error_invalid_argument
+      (Printf.sprintf "failed to read secrets %s: %s" secrets_path msg)
+
+(** {1 Output writing} *)
+
+let _save_atomic ~path roster : unit Status.status_or =
+  let tmp_path = path ^ ".tmp" in
+  try
+    Out_channel.write_all tmp_path ~data:(Sexp.to_string_hum (sexp_of_t roster));
+    Stdlib.Sys.rename tmp_path path;
+    Ok ()
+  with Sys_error msg | Failure msg ->
+    (try Stdlib.Sys.remove tmp_path with _ -> ());
+    Status.error_internal
+      (Printf.sprintf "fetch_delisted_symbols: write failed: %s" msg)
+
+(** {1 Run + report} *)
+
+let _per_type_counts entries =
+  let tbl = Hashtbl.create (module String) in
+  List.iter entries ~f:(fun e ->
+      let key = Eodhd.Asset_type.show e.asset_type in
+      Hashtbl.update tbl key ~f:(function None -> 1 | Some n -> n + 1));
+  Hashtbl.to_alist tbl
+  |> List.sort ~compare:(fun (_, a) (_, b) -> Int.compare b a)
+
+let _print_summary roster =
+  Core.printf "Wrote %d delisted symbols.\n" (List.length roster.symbols);
+  Core.print_string "Per-type counts (top entries):\n";
+  let counts = _per_type_counts roster.symbols in
+  List.iter counts ~f:(fun (label, n) -> Core.printf "  %-32s %d\n" label n)
+
+let _run ~output_path ~secrets_path =
+  let open Deferred.Result.Let_syntax in
+  let%bind token = _read_token ~secrets_path |> Deferred.return in
+  let%bind listings = Eodhd.Http_client.get_delisted_symbols ~token () in
+  Core.printf "EODHD delisted-listing returned %d entries.\n%!"
+    (List.length listings);
+  let today = Date.today ~zone:Time_float.Zone.utc in
+  let roster =
+    {
+      generated_at = today;
+      source_endpoint = "/api/exchange-symbol-list/US?delisted=1";
+      symbols = List.map listings ~f:_of_metadata;
+    }
+  in
+  let%bind () = _save_atomic ~path:output_path roster |> Deferred.return in
+  _print_summary roster;
+  Core.printf "Wrote %s\n%!" output_path;
+  Deferred.Result.return ()
+
+let _main ~output_path ~secrets_path () =
+  _run ~output_path ~secrets_path >>= function
+  | Ok () -> return ()
+  | Error e ->
+      Core.eprintf "Error: %s\n" (Status.show e);
+      exit 1
+
+let _default_secrets_path = "trading/analysis/data/sources/eodhd/secrets"
+
+let command =
+  Command.async
+    ~summary:
+      "Fetch + cache the EODHD US delisted-symbols roster (P1 of the \
+       delisted-aware universe agenda — see \
+       dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md)"
+    (let%map_open.Command output_path =
+       flag "output-path" (required string)
+         ~doc:"PATH Where to write delisted_symbols.sexp"
+     and secrets_path =
+       flag "secrets-path"
+         (optional_with_default _default_secrets_path string)
+         ~doc:"PATH EODHD API token file (default: repo-local secrets)"
+     in
+     _main ~output_path ~secrets_path)
+
+let () = Command_unix.run command


### PR DESCRIPTION
## Summary

**P1** of the delisted-aware universe agenda (#1183, `dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md`). Adds the EODHD delisted-listings endpoint client + a tiny binary that materializes the roster to disk.

## What ships

**Library code:**
- `Eodhd.Http_client.get_delisted_symbols` — wraps the existing `_make_symbols_uri` with the `delisted=1` query param. Reuses `_parse_symbols_response` since the response schema is identical to the live listings.
- `Eodhd.Asset_type.t` — add `sexp` to the `[@@deriving]` list so downstream sexp-serializers can embed it without hand-rolling converters. Adds `ppx_sexp_conv` to the eodhd lib's preprocess.

**Binary:** `analysis/scripts/fetch_delisted_symbols/bin/main.ml` — one-shot fetch that writes:
```
((generated_at YYYY-MM-DD)
 (source_endpoint "/api/exchange-symbol-list/US?delisted=1")
 (symbols (((code TWTR) (name "Twitter Inc") (exchange NYSE) (asset_type Common_stock)) ...)))
```

**Live snapshot:** `data/delisted_symbols.sexp` (5.6 MB, 57,592 entries, generated 2026-05-18):

```
Per-type counts (top entries):
  Common_stock                     31737
  Fund                             18657
  Mutual_fund                       2958
  ETF                               2708
  Preferred_stock                   1222
  Other "Unit"                       207
  Other "Notes"                      81
  Other "Warrant"                    12
  Other "BOND"                        6
  Other "ETC"                         3
  Other ""                            1
```

Counts match the spot-probes from #1183.

## Test plan

- [x] `dune build` clean (eodhd lib + new binary)
- [x] `dune runtest analysis/data/sources/eodhd/` — 16 tests pass (was 15; added `test_get_delisted_symbols` pinning the `delisted=1` URI param)
- [x] `dune runtest analysis/scripts/asset_type_enrichment/` — 9 tests pass (verifies the `sexp` deriving addition didn't break the downstream lib that wraps `Asset_type.t`)
- [x] All other suites pass (`dune runtest`)
- [x] `dune build @fmt --auto-promote` clean
- [x] `dune runtest devtools/checks` — no linter regressions (some pre-existing magic-numbers + function-length linter findings unaffected by this PR)
- [x] Binary runs end-to-end against the live EODHD endpoint, produces a 5.6 MB sexp at `data/delisted_symbols.sexp` with expected counts

## Next phases (gated)

- **P2** — bulk-fetch bars for the Common-Stock-NASDAQ-NYSE subset (~15,800 names; quota-bound 1-3 days wall)
- **P3** — rebuild composition goldens against the unified live + delisted inventory pool
- **P4** — re-run the random-universe sweep (#1180) against delisted-aware goldens to confirm/refine the "selection-rule-dominates-strategy-alpha" finding

## Authority

- `dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md` §"Concrete unblock path" §"P1"
- `memory/project_eodhd_delisted_unlock.md`
- `dev/plans/custom-universe-bidirectional-2026-05-17.md` (sibling Q1 PR2 pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)