### PR TITLE
feat(asset-type-enrichment): -include-delisted flag for P3 delisted-aware enrichment

### DIFF
--- a/trading/analysis/scripts/asset_type_enrichment/bin/main.ml
+++ b/trading/analysis/scripts/asset_type_enrichment/bin/main.ml
@@ -51,7 +51,7 @@ let _print_summary t =
       Core.printf "  %-32s %d\n" c.Asset_type_enrichment_lib.asset_type_label
         c.count)
 
-let _run ~inventory_path ~output_path ~secrets_path =
+let _run ~inventory_path ~output_path ~secrets_path ~include_delisted =
   let open Deferred.Result.Let_syntax in
   let%bind token = _read_token ~secrets_path |> Deferred.return in
   let%bind inventory = _load_inventory ~inventory_path |> Deferred.return in
@@ -59,14 +59,29 @@ let _run ~inventory_path ~output_path ~secrets_path =
     List.map inventory.Inventory.symbols ~f:(fun e -> e.Inventory.symbol)
   in
   Core.printf "Inventory has %d symbols.\n%!" (List.length inventory_symbols);
-  let%bind eodhd_listings = Eodhd.Http_client.get_symbols ~token () in
-  Core.printf "EODHD US listing has %d entries.\n%!"
-    (List.length eodhd_listings);
+  let%bind live = Eodhd.Http_client.get_symbols ~token () in
+  Core.printf "EODHD US LIVE listing has %d entries.\n%!" (List.length live);
+  let%bind delisted =
+    if include_delisted then (
+      let%bind d = Eodhd.Http_client.get_delisted_symbols ~token () in
+      Core.printf "EODHD US DELISTED listing has %d entries.\n%!"
+        (List.length d);
+      Deferred.Result.return d)
+    else Deferred.Result.return []
+  in
+  let eodhd_listings = live @ delisted in
   let today = Date.today ~zone:Time_float.Zone.utc in
+  let source_endpoints =
+    if include_delisted then
+      [
+        ("/api/exchange-symbol-list/US", today);
+        ("/api/exchange-symbol-list/US?delisted=1", today);
+      ]
+    else [ ("/api/exchange-symbol-list/US", today) ]
+  in
   let enriched =
     Asset_type_enrichment_lib.join ~inventory_symbols ~eodhd_listings
-      ~generated_at:today
-      ~source_endpoints:[ ("/api/exchange-symbol-list/US", today) ]
+      ~generated_at:today ~source_endpoints
   in
   let%bind () =
     Asset_type_enrichment_lib.save enriched ~path:(Fpath.v output_path)
@@ -76,8 +91,8 @@ let _run ~inventory_path ~output_path ~secrets_path =
   Core.printf "Wrote %s\n%!" output_path;
   Deferred.Result.return ()
 
-let _main ~inventory_path ~output_path ~secrets_path () =
-  _run ~inventory_path ~output_path ~secrets_path >>= function
+let _main ~inventory_path ~output_path ~secrets_path ~include_delisted () =
+  _run ~inventory_path ~output_path ~secrets_path ~include_delisted >>= function
   | Ok () -> return ()
   | Error e ->
       Core.eprintf "Error: %s\n" (Status.show e);
@@ -89,7 +104,10 @@ let command =
   Command.async
     ~summary:
       "Bulk-enrich inventory symbols with EODHD Asset_type (Q1 PR2 of \
-       custom-universe-bidirectional)"
+       custom-universe-bidirectional). Pass -include-delisted to merge in the \
+       /api/exchange-symbol-list/US?delisted=1 roster (P3 of the \
+       delisted-aware universe agenda — see \
+       dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md)."
     (let%map_open.Command inventory_path =
        flag "inventory-path" (required string)
          ~doc:"PATH Path to inventory.sexp"
@@ -100,7 +118,13 @@ let command =
        flag "secrets-path"
          (optional_with_default _default_secrets_path string)
          ~doc:"PATH EODHD API token file (default: repo-local secrets)"
+     and include_delisted =
+       flag "include-delisted" no_arg
+         ~doc:
+           "If set, also fetch /api/exchange-symbol-list/US?delisted=1 and \
+            merge results so delisted-symbol inventory entries get \
+            attribution. Required for the delisted-aware composition agenda."
      in
-     _main ~inventory_path ~output_path ~secrets_path)
+     _main ~inventory_path ~output_path ~secrets_path ~include_delisted)
 
 let () = Command_unix.run command


### PR DESCRIPTION
## Summary

**P3** of the delisted-aware universe agenda (`dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md`). Extends `asset_type_enrichment.exe` with a `-include-delisted` flag that also pulls the `/api/exchange-symbol-list/US?delisted=1` roster (~57k entries) and merges into the live-listings response before joining against `inventory.sexp`.

**Why needed.** The composition builder filters via `symbol_types.sexp`'s equity-like lookup. Symbols not in that table get treated as `Not_in_eodhd_listing` and dropped. Without `-include-delisted`, all 15.8k Common Stock delisted symbols (whose bars will be cached by `fetch_delisted_bars.exe` from #1185) would be filtered out of any rebuilt composition golden — defeating the point.

## Operational sequence (post-P2 completion)

```sh
# 1. Refresh inventory to include delisted-symbol bars cached by P2:
dune exec analysis/scripts/build_inventory/build_inventory.exe -- -data-dir data

# 2. Re-enrich symbol_types.sexp with both live + delisted endpoints:
dune exec analysis/scripts/asset_type_enrichment/bin/main.exe -- \
  -inventory-path data/inventory.sexp \
  -output-path data/symbol_types.sexp \
  -include-delisted

# 3. Rebuild composition goldens (no change here — same binary, wider pool):
dune exec analysis/data/universe/bin/build_composition_universes_runner.exe
```

The composition builder's existing date-active filter (`data_start_date <= YYYY-04-01 && data_end_date >= YYYY-05-31`) handles point-in-time membership naturally — names that delisted *before* the snapshot date have `data_end_date < snapshot` and get dropped from that year's snapshot.

## Implementation

- New `-include-delisted` flag, default off (backward-compatible).
- When set: calls both `Eodhd.Http_client.get_symbols` and `get_delisted_symbols`, concatenates results, joins as before.
- `source_endpoints` records both URLs.
- ~32 lines net change in `bin/main.ml`; lib unchanged.

## Test plan

- [x] `dune build analysis/scripts/asset_type_enrichment/` clean
- [x] `dune runtest analysis/scripts/asset_type_enrichment/` — 9/9 pass (lib unchanged; bin-only change isn't covered by existing tests, but the bin's only new behaviour is "call one more endpoint + concatenate" which the lib's `join` already tested)
- [x] `dune build @fmt` clean
- [x] Backward compatibility: without the flag, the binary's output is byte-identical to the prior version

## Live smoke (deferred)

Running this end-to-end requires P2-run to finish (kicked off in the background, ~15.8k symbols at ~25/min ≈ 10 hours wall, currently at ~210 fetched). Once that completes, the sequence above will produce a fresh `symbol_types.sexp` with delisted-symbol attribution + a delisted-aware composition-goldens set. P4 (re-run #1180 random-universe sweep against the new goldens) is then unblocked.

## Authority

- `dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md` §"Concrete unblock path" §P3
- `memory/project_eodhd_delisted_unlock.md`
- PR #1184 (delisted endpoint client)
- PR #1185 (bulk-fetch binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)