### PR TITLE
feat(delisted-pipeline): parallel fetcher + orchestrator + next-session notes

### DIFF
--- a/dev/notes/next-session-priorities-2026-05-20.md
+++ b/dev/notes/next-session-priorities-2026-05-20.md
@@ -1,0 +1,187 @@
+# Next-session priorities (2026-05-20) — autonomous session 2026-05-18
+
+Written end-of-session 2026-05-18 after an 8-PR delisted-universe sprint.
+
+## TL;DR
+
+The delisted-aware universe agenda's CODE is shipped end-to-end:
+P1 (#1184 endpoint) → P2 (#1185 bulk-fetch binary) → P3 (#1186 enrichment
+flag). What's left is **operational** + **P4 validation**.
+
+If the background `fetch_delisted_bars.exe` run started 2026-05-18 05:30 UTC
+has finished by next session (~10 hr wall expected), the entire remaining
+work fits in ~30-60 min.
+
+## P0 — finish the delisted-aware composition goldens (if P2-run done)
+
+The post-P2 sequence is **3 commands + 1 scenario rerun**. All shipped
+binaries; no new code needed.
+
+```sh
+# 0. Verify P2-run completed:
+tail -5 /workspaces/trading-1/dev/logs/fetch-delisted-bars.log
+# Expect: "Delisted-bar fetch summary: ... Targets 15766 ... Fetched OK ~14000-15000".
+# If it's still running, monitor cycles_done and wait.
+
+# 1. Refresh inventory.sexp with the new delisted-symbol metadata:
+docker exec trading-1-dev bash -c '
+  cd /workspaces/trading-1/trading && eval $(opam env) &&
+  dune exec --no-build analysis/scripts/build_inventory/build_inventory.exe -- \
+    -data-dir /workspaces/trading-1/data
+'
+# Wall: ~10 s (just scans data/<X>/<Y>/<SYM>/data.metadata.sexp files).
+
+# 2. Re-enrich symbol_types.sexp with both live + delisted endpoints (P3):
+docker exec -e EODHD_API_KEY="$EODHD_API_KEY" trading-1-dev bash -c '
+  cd /workspaces/trading-1/trading && eval $(opam env) &&
+  echo "$EODHD_API_KEY" > /tmp/eodhd-secrets &&
+  dune exec --no-build analysis/scripts/asset_type_enrichment/bin/main.exe -- \
+    -inventory-path /workspaces/trading-1/data/inventory.sexp \
+    -output-path /workspaces/trading-1/data/symbol_types.sexp \
+    -secrets-path /tmp/eodhd-secrets \
+    -include-delisted
+'
+# Wall: ~30 s (2 HTTP calls + concat + join + write).
+
+# 3. Rebuild composition goldens against the unified pool:
+docker exec trading-1-dev bash -c '
+  cd /workspaces/trading-1/trading && eval $(opam env) &&
+  dune exec --no-build analysis/data/universe/bin/build_composition_universes_runner.exe
+'
+# Wall: ~5-10 min (75 sexp files: top-{500,1000,3000}-{1998..2026}).
+# Overwrites trading/test_data/goldens-custom-universe/composition/*.sexp.
+# Diff-check expected — old goldens drop survivor-bias-only names; new
+# goldens include delisted names that were active at each snapshot date.
+
+# 4. (Optional sanity) Spot-check that delisted names made it in:
+grep -c "TWTR\b\|FIT\b\|AABA\b" \
+  trading/test_data/goldens-custom-universe/composition/top-500-2019.sexp
+# Expect non-zero (Twitter delisted 2022, Fitbit 2021, Altaba ex-Yahoo 2019 —
+# all active at 2019-05-31).
+```
+
+## P0b — re-run the random-universe sweep against delisted-aware goldens (P4)
+
+After step 3 above, the `top-3000-2019.sexp` pool now includes ~3000
+delisted-aware names. Re-sample 5 subsets + re-run the scenarios from
+`dev/experiments/random-universe-sweep-2026-05-18/scenarios/` (committed in
+#1180 as universes/random-2019/sample-{1..5}.sexp).
+
+But the random-2019/sample-*.sexp universes were built from the OLD
+top-3000-2019.sexp (live-only). To get a fair P4 comparison, either:
+
+(a) Re-sample 5 new subsets from the new delisted-aware top-3000-2019.sexp
+    and run those. Best comparison; small re-derivation work
+    (~20 LOC awk in `dev/notes/random-universe-sweep-2026-05-18.md`).
+
+(b) Just re-run the existing 5 sample scenarios. Their `(Pinned ...)` lists
+    are the OLD names (survivors-only); the SCENARIOS show what the
+    Cell-E strategy does on those exact names with current bar data.
+    NOT a P4 test of the universe-construction fix; just a regression.
+
+(c) Best: do BOTH. (a) confirms the central claim ("delisted-aware
+    universes narrow the σ gap"); (b) confirms strategy stability.
+
+Re-run command per scenario:
+
+```sh
+docker exec trading-1-dev bash -c '
+  cd /workspaces/trading-1/trading && eval $(opam env) &&
+  dune exec --no-build trading/backtest/scenarios/scenario_runner.exe -- \
+    --dir /workspaces/trading-1/dev/experiments/random-universe-sweep-2026-05-18/scenarios \
+    --parallel 3 \
+    --fixtures-root /workspaces/trading-1/trading/test_data/backtest_scenarios \
+    --no-emit-all-eligible
+'
+# Wall: ~10 min for 5 scenarios at parallel 3 (no all_eligible).
+```
+
+Plus the comparison cell:
+
+```sh
+docker exec trading-1-dev bash -c '
+  cd /workspaces/trading-1/trading && eval $(opam env) &&
+  dune exec --no-build trading/backtest/scenarios/scenario_runner.exe -- \
+    --dir /workspaces/trading-1/trading/test_data/backtest_scenarios/goldens-custom-universe-scenarios \
+    --parallel 1 \
+    --fixtures-root /workspaces/trading-1/trading/test_data/backtest_scenarios
+'
+# Wall: ~5 min for the weinstein-2019-top-500-composition cell.
+# Compare metrics to #1179's pinned baseline (174.69% / Sharpe 0.62 / MaxDD 59.06).
+# Expected: return drops toward market-neutral; the σ gap to random samples
+# narrows substantially.
+```
+
+## P0c — write up findings
+
+After P4 results land:
+
+- `dev/notes/random-universe-sweep-followup-2026-05-XX.md` — the
+  delisted-aware re-run. Same comparison table shape as
+  `random-universe-sweep-2026-05-18.md`. Pin: before/after random-sample
+  mean; before/after top-500-2019 baseline; observed σ gap reduction.
+- Update `trading/test_data/backtest_scenarios/goldens-custom-universe-scenarios/weinstein-2019-top-500.sexp`
+  header: revise the "BRIDGE SMOKE TEST" warning if the new run shows the
+  cell is now closer to a fair alpha benchmark.
+- `memory/project_eodhd_delisted_unlock.md` — mark P4 done, capture
+  whether the survivor-bias claim was fully borne out.
+
+## P1 — Bayesian production sweep (was IWV-gated)
+
+Per `dev/notes/next-session-priorities-2026-05-19.md` §"Bayesian production
+sweep": this was gated on IWV / paid-scraper / Sharadar / EODHD tier. The
+delisted-roster discovery (#1183/#1184) ungates it — see
+`memory/project_eodhd_delisted_unlock.md`.
+
+Now that delisted-aware composition goldens exist (after P0), the Bayesian
+sweep can target a TRUE point-in-time universe pool. Concrete next step:
+
+```
+dev/plans/bayesian-phase3-production-sweep-2026-05-XX.md
+```
+
+Should specify: which parameters, which years, walk-forward CV folds,
+quality metric (Sharpe? Calmar? Custom?). Probably ~4-8 hr of orchestrator
+wall time on N=24 parallel candidates.
+
+## P2 — Optional / smaller items
+
+### Refactor pre-existing match-statement tests in `test_http_client.ml`
+
+PR #1184 sidestepped this by putting the new test in a standalone file.
+The original file still has ~12 tests using `match result with | Ok ... | Error -> assert_failure`.
+qc-structural P6 will block any future PR that touches this file until the
+patterns are refactored.
+
+Effort: ~60-90 min (mechanical conversion to `assert_that (is_ok_and_holds ...)`
++ matcher composition).
+
+### Add CI for the new fetch_delisted_bars / fetch_delisted_symbols binaries
+
+Currently the only smoke test is the local end-to-end run. Could add a
+tiny integration test that mocks the HTTP fetch and verifies the on-disk
+sexp shape.
+
+Effort: ~30 min per binary. Low priority since the binaries are
+human-operated, not invoked by automated pipelines.
+
+### Stooq drift check / IWV scrape
+
+Both still blocked. Stooq drift check (existing branch) might be cheap to
+revisit if the user wants alt-vendor cross-validation. IWV is permanently
+Akamai-blocked (confirmed 2026-05-18).
+
+## Open follow-ups (carry from prior sessions)
+
+- `dev/status/cost-model.md` 4 deferred items — still deferred
+- Tunable-parameter inventory + private tuned-configs repo (`dev/notes/tunable-parameters-inventory-2026-05-18.md`) — apply once a config is worth blessing
+- Decomposition + Composition unification — close as not-worth (deferred per priorities-2026-05-19)
+- Update `dev/notes/vendor-comparison-historical-universe-2026-05-16.md` to demote IWV → fallback once delisted-aware goldens land
+
+## Recommended sequencing for 2026-05-20
+
+1. **Step 0**: check P2-run log; if not complete, monitor + delay.
+2. **P0 sequence** (steps 1-3 above, ~10-15 min wall).
+3. **P0b sub-step (a)** — re-sample 5 universes from new top-3000-2019 + run.
+4. **P0c writeup**.
+5. If time permits, **P1 Bayesian sweep prep**.

--- a/dev/scripts/run_delisted_pipeline.sh
+++ b/dev/scripts/run_delisted_pipeline.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# Orchestrator for the delisted-aware composition-goldens pipeline.
+#
+# After fetch_delisted_bars.exe (P2) has populated bars under data/, this
+# script chains the 3 follow-on steps:
+#
+#   1. build_inventory.exe          → refresh data/inventory.sexp
+#   2. asset_type_enrichment.exe    → refresh data/symbol_types.sexp
+#                                     (with -include-delisted)
+#   3. build_composition_universes_runner.exe
+#                                   → re-emit goldens-custom-universe/composition/*.sexp
+#
+# Designed to be safe to re-run after each P2 increment lands. Each step
+# is idempotent and overwrites its output file via atomic temp+rename.
+#
+# Prerequisites:
+#   - data/delisted_symbols.sexp (output of fetch_delisted_symbols.exe, P1)
+#   - data/<X>/<Y>/<SYM>/data.csv for the delisted symbols you care about
+#     (P2 output; partial caches are fine but limit downstream coverage)
+#   - EODHD_API_KEY env var available (used by step 2)
+#
+# Usage:
+#   dev/scripts/run_delisted_pipeline.sh
+#   dev/scripts/run_delisted_pipeline.sh --skip-rebuild   # steps 1+2 only
+#
+# Designed to run on the developer host wrapping docker exec. The
+# in-container path mirrors what we'd run by hand.
+#
+# Exit codes: 0 on success, non-zero on the first step that fails.
+#
+# Companion docs:
+#   dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md §"Concrete unblock path"
+#   dev/notes/next-session-priorities-2026-05-20.md §P0
+#
+# Companion PRs: #1184 (P1), #1185 (P2), #1186 (P3).
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CONTAINER="${TRADING_CONTAINER:-trading-1-dev}"
+
+SKIP_REBUILD=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --skip-rebuild) SKIP_REBUILD=1; shift ;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+      exit 0 ;;
+    *)
+      printf 'Unknown arg: %s (use --help)\n' "$1" >&2
+      exit 1 ;;
+  esac
+done
+
+if [ -z "${EODHD_API_KEY:-}" ]; then
+  printf 'FAIL: EODHD_API_KEY env var is required (set on the host before running)\n' >&2
+  exit 1
+fi
+
+if ! docker exec "$CONTAINER" true 2>/dev/null; then
+  printf 'FAIL: docker container "%s" is not responsive\n' "$CONTAINER" >&2
+  exit 1
+fi
+
+_run_in_container() {
+  docker exec -e EODHD_API_KEY="$EODHD_API_KEY" "$CONTAINER" bash -c "$1"
+}
+
+printf '=== Step 1/3: build_inventory.exe ===\n'
+_run_in_container '
+  cd /workspaces/trading-1/trading && eval $(opam env) > /dev/null
+  dune exec --no-build analysis/scripts/build_inventory/build_inventory.exe -- \
+    -data-dir /workspaces/trading-1/data
+'
+
+printf '\n=== Step 2/3: asset_type_enrichment.exe (with -include-delisted) ===\n'
+_run_in_container '
+  cd /workspaces/trading-1/trading && eval $(opam env) > /dev/null
+  echo "$EODHD_API_KEY" > /tmp/eodhd-secrets
+  dune exec --no-build analysis/scripts/asset_type_enrichment/bin/main.exe -- \
+    -inventory-path /workspaces/trading-1/data/inventory.sexp \
+    -output-path /workspaces/trading-1/data/symbol_types.sexp \
+    -secrets-path /tmp/eodhd-secrets \
+    -include-delisted
+'
+
+if [ "$SKIP_REBUILD" = "1" ]; then
+  printf '\n--skip-rebuild: stopping after enrichment.\n'
+  printf 'Run step 3 manually when ready:\n'
+  printf '  dune exec analysis/data/universe/bin/build_composition_universes_runner.exe\n'
+  exit 0
+fi
+
+printf '\n=== Step 3/3: build_composition_universes_runner.exe ===\n'
+_run_in_container '
+  cd /workspaces/trading-1/trading && eval $(opam env) > /dev/null
+  dune exec --no-build analysis/data/universe/bin/build_composition_universes_runner.exe
+'
+
+printf '\n=== Done ===\n'
+printf 'Pipeline complete. The 75 composition goldens at\n'
+printf '  trading/test_data/goldens-custom-universe/composition/top-N-YYYY.sexp\n'
+printf 'are now delisted-aware. P4 (re-run #1180 scenarios) is unblocked.\n'

--- a/trading/analysis/scripts/fetch_delisted_bars/bin/main.ml
+++ b/trading/analysis/scripts/fetch_delisted_bars/bin/main.ml
@@ -10,10 +10,16 @@
     Idempotent: if a symbol's CSV already exists under [data_dir], the fetch is
     skipped. Re-running picks up where the prior run left off.
 
-    Resumability + politeness: sequential fetch with configurable inter-request
-    sleep (default 600 ms ≈ 100 req/min). For the ~15.8k NASDAQ/NYSE Common
-    Stock subset the full run takes ~3-5 hr wall at the default rate, assuming
-    the EODHD tier's per-day quota isn't exhausted sooner.
+    Resumability + politeness: bounded-concurrency fetch with per-fetch sleep
+    (default `-parallel 1` for backward compat with the original sequential
+    pattern; `-parallel 5` cuts wall time by ~3-5x because per-request wall is
+    network-bound, not sleep-bound). Each fetch sleeps `-sleep-ms` (default 600
+    ms) after completing.
+
+    Empirical wall (2026-05-18): `-parallel 1 -sleep-ms 400` averages ~10-25
+    symbols/min on EODHD's base tier — network roundtrip dominates, so dropping
+    sleep_ms helps marginally; lifting `-parallel` to 5 cuts wall to ~50-100
+    symbols/min (full ~15.8k subset → ~2-3 hr).
 
     Typical usage (smoke):
     {v
@@ -95,14 +101,18 @@ let _sleep_if_polite ms =
   if ms > 0 then Clock.after (Time_float.Span.of_ms (float_of_int ms))
   else return ()
 
-(** Fetch + cache one target. Returns the updated triple [(ok, err, skipped)].
-    Refactored out of [_fetch_all]'s closure to keep nesting within linter
-    limits. *)
-let _step_one ~token ~data_dir_path ~total ~sleep_ms idx (ok, err, skipped)
+type counters = { mutable ok : int; mutable err : int; mutable skipped : int }
+(** Counters mutated by parallel fetch workers. Async is cooperative-single-
+    threaded so a plain ref is race-free as long as updates happen in
+    Async-aware code paths only. *)
+
+(** Fetch + cache one target. Updates the shared [counters] in place. *)
+let _step_one ~token ~data_dir_path ~total ~sleep_ms ~counters idx
     (entry : roster_entry) =
   if _is_cached ~data_dir:(Fpath.to_string data_dir_path) entry.code then (
     printf "[%d/%d] SKIP %s (already cached)\n%!" (idx + 1) total entry.code;
-    return (ok, err, skipped + 1))
+    counters.skipped <- counters.skipped + 1;
+    return ())
   else (
     printf "[%d/%d] FETCH %s (%s, %s)\n%!" (idx + 1) total entry.code
       entry.exchange entry.name;
@@ -110,17 +120,28 @@ let _step_one ~token ~data_dir_path ~total ~sleep_ms idx (ok, err, skipped)
       Fetch_symbols_lib.fetch_one ~token ~data_dir:data_dir_path entry.code
     in
     let%bind () = _sleep_if_polite sleep_ms in
-    match result with
-    | Ok _ -> return (ok + 1, err, skipped)
-    | Error _ -> return (ok, err + 1, skipped))
+    (match result with
+    | Ok _ -> counters.ok <- counters.ok + 1
+    | Error _ -> counters.err <- counters.err + 1);
+    return ())
 
-(** Sequential fetch with polite sleep between requests. Returns
-    [(ok_count, err_count, skipped_count)]. *)
-let _fetch_all ~token ~data_dir ~sleep_ms ~targets =
+(** Bounded-concurrency fetch. Returns [(ok, err, skipped)]. The parallel case
+    relies on `Max_concurrent_jobs to cap in-flight fetches; counters are
+    mutated under Async's cooperative scheduler so updates are race-free without
+    explicit locking. *)
+let _fetch_all ~token ~data_dir ~sleep_ms ~parallel ~targets =
   let data_dir_path = Fpath.v data_dir in
   let total = List.length targets in
-  Deferred.List.foldi targets ~init:(0, 0, 0)
-    ~f:(_step_one ~token ~data_dir_path ~total ~sleep_ms)
+  let counters = { ok = 0; err = 0; skipped = 0 } in
+  let%bind () =
+    if parallel <= 1 then
+      Deferred.List.iteri ~how:`Sequential targets
+        ~f:(_step_one ~token ~data_dir_path ~total ~sleep_ms ~counters)
+    else
+      Deferred.List.iteri ~how:(`Max_concurrent_jobs parallel) targets
+        ~f:(_step_one ~token ~data_dir_path ~total ~sleep_ms ~counters)
+  in
+  return (counters.ok, counters.err, counters.skipped)
 
 let _print_summary ~targets ~ok ~err ~skipped =
   printf "\n%!";
@@ -132,7 +153,7 @@ let _print_summary ~targets ~ok ~err ~skipped =
 
 (** {1 Run + report} *)
 
-let _run ~roster_path ~secrets_path ~data_dir ~sleep_ms ~limit =
+let _run ~roster_path ~secrets_path ~data_dir ~sleep_ms ~parallel ~limit =
   let open Deferred.Result.Let_syntax in
   let%bind token = _read_token ~secrets_path |> Deferred.return in
   let%bind roster = _load_roster ~roster_path |> Deferred.return in
@@ -145,17 +166,18 @@ let _run ~roster_path ~secrets_path ~data_dir ~sleep_ms ~limit =
   let targets =
     match limit with None -> in_scope | Some n -> List.take in_scope n
   in
-  printf "Fetching %d symbols (sleep %d ms between fetches)\n%!"
-    (List.length targets) sleep_ms;
+  printf "Fetching %d symbols (parallel=%d, sleep %d ms per fetch)\n%!"
+    (List.length targets) parallel sleep_ms;
   let%bind ok, err, skipped =
-    _fetch_all ~token ~data_dir ~sleep_ms ~targets
+    _fetch_all ~token ~data_dir ~sleep_ms ~parallel ~targets
     |> Deferred.map ~f:Result.return
   in
   _print_summary ~targets ~ok ~err ~skipped;
   Deferred.Result.return ()
 
-let _main ~roster_path ~secrets_path ~data_dir ~sleep_ms ~limit () =
-  _run ~roster_path ~secrets_path ~data_dir ~sleep_ms ~limit >>= function
+let _main ~roster_path ~secrets_path ~data_dir ~sleep_ms ~parallel ~limit () =
+  _run ~roster_path ~secrets_path ~data_dir ~sleep_ms ~parallel ~limit
+  >>= function
   | Ok () -> return ()
   | Error e ->
       eprintf "Error: %s\n" (Status.show e);
@@ -164,6 +186,7 @@ let _main ~roster_path ~secrets_path ~data_dir ~sleep_ms ~limit () =
 let _default_secrets_path = "trading/analysis/data/sources/eodhd/secrets"
 let _default_data_dir () = Data_path.default_data_dir () |> Fpath.to_string
 let _default_sleep_ms = 600
+let _default_parallel = 1
 
 let command =
   Command.async
@@ -185,11 +208,17 @@ let command =
        flag "sleep-ms"
          (optional_with_default _default_sleep_ms int)
          ~doc:"MS Polite sleep between HTTP fetches (default 600 ms)"
+     and parallel =
+       flag "parallel"
+         (optional_with_default _default_parallel int)
+         ~doc:
+           "N In-flight concurrency cap (default 1 sequential; 5 is a sane \
+            ceiling on EODHD's base tier)"
      and limit =
        flag "limit" (optional int)
          ~doc:
            "N Smoke-test cap on the number of symbols to fetch (default: all)"
      in
-     _main ~roster_path ~secrets_path ~data_dir ~sleep_ms ~limit)
+     _main ~roster_path ~secrets_path ~data_dir ~sleep_ms ~parallel ~limit)
 
 let () = Command_unix.run command


### PR DESCRIPTION
## Summary

Three small ergonomic improvements to the delisted-aware universe pipeline (#1183 → #1184 → #1185 → #1186), shipped while the background P2-run is still completing:

### 1. Parallel fetcher (the main win)

`fetch_delisted_bars.exe` gains a `-parallel N` flag:

```sh
fetch_delisted_bars.exe \
  -roster-path data/delisted_symbols.sexp \
  -parallel 5 \
  -sleep-ms 200
```

Backward-compat: defaults to `1` (sequential). At `parallel=5 sleep-ms=200` empirical throughput is **~80-170 symbols/min** vs. **~10-25 sym/min** sequential — ~3-5x speedup. Full ~15.8k Common Stock NASDAQ/NYSE subset is now ~2-3 hr instead of ~10 hr.

Implementation: `Deferred.List.iteri ~how:(\`Max_concurrent_jobs N)`. Counters are a mutable record, race-free under Async's cooperative scheduler.

### 2. Post-P2 orchestrator

`dev/scripts/run_delisted_pipeline.sh` chains the 3 follow-on steps (build_inventory → asset_type_enrichment with `-include-delisted` → build_composition_universes_runner). After P2's bar-fetch completes, the user runs:

```sh
dev/scripts/run_delisted_pipeline.sh
```

and the composition goldens at `trading/test_data/goldens-custom-universe/composition/*.sexp` are re-emitted with delisted-symbol coverage. POSIX shell, idempotent, docker-aware via `TRADING_CONTAINER` (default `trading-1-dev`).

### 3. Next-session priorities note

`dev/notes/next-session-priorities-2026-05-20.md` captures the post-P2 sequence + the P4 random-universe sweep re-run plan + the unblocked Bayesian sweep work. Replaces the one-line forwarder previously living in #1186's PR body.

## Live verification

- Killed the sequential P2-run that had reached ~1325 symbols.
- Smoke-ran the parallel binary with `-limit 1340 -parallel 5 -sleep-ms 200`: 1326 cached → SKIP, 14 actual fetches in ~5 seconds wall (~170/min effective).
- Restarted full P2 in background with `-parallel 5 -sleep-ms 200`. Currently at ~1730/15766, fetching ~80/min effective. ETA ~3 hr.

## Test plan

- [x] `dune build analysis/scripts/fetch_delisted_bars/` clean (parallel and sequential paths both compile)
- [x] `dune build @fmt --auto-promote` clean
- [x] `dune runtest devtools/checks` — nesting linter still passes (2952 functions within limits), format clean, no magic numbers, posix-sh linter passes the new shell script
- [x] Smoke: `-parallel 5 -limit 1340` on the resumed run — 14 new fetches, 0 errors, 5 sec wall
- [x] Idempotent skip continues to work under `-parallel 5`

## Authority

- `dev/notes/eodhd-delisted-roster-unlock-2026-05-18.md` (full plan)
- `memory/project_eodhd_delisted_unlock.md`
- #1184 / #1185 / #1186 (the prior 3 PRs in the delisted-aware pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)