### PR TITLE
chore: weekly opam dependency update

### DIFF
--- a/trading/deps-snapshot.txt
+++ b/trading/deps-snapshot.txt
@@ -79,8 +79,8 @@ ocaml-compiler-libs         v0.17.0
 ocaml-config                3
 ocaml-options-vanilla       1
 ocaml-syntax-shims          1.0.0
-ocaml-version               4.1.0
-ocaml_intrinsics_kernel     v0.17.1
+ocaml-version               4.1.1
+ocaml_intrinsics_kernel     v0.17.2
 ocamlbuild                  0.16.1
 ocamlfind                   1.9.8
 ocamlformat                 0.29.0


### PR DESCRIPTION
## Summary

The CI image was rebuilt this week and the opam solver picked
different package versions than last week's snapshot. This PR
updates `trading/deps-snapshot.txt` to reflect the new state.

**Review the diff** to see what changed. Merge = opt-in to the
new versions. If a version bump is undesirable, pin it in
`.devcontainer/Dockerfile` before merging.

🤖 Generated by the weekly deps-update workflow.