### PR TITLE
feat(backtest): wire Fork_pool into Walk_forward_executor

### DIFF
--- a/trading/trading/backtest/walk_forward/lib/dune
+++ b/trading/trading/backtest/walk_forward/lib/dune
@@ -1,5 +1,5 @@
 (library
  (name walk_forward)
- (libraries core scenario_lib backtest trading.simulation.types)
+ (libraries core fork_pool scenario_lib backtest trading.simulation.types)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_executor.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_executor.ml
@@ -17,6 +17,8 @@ type progress_callback =
   test_end:Date.t ->
   unit
 
+type fold_runner = Scenario.t -> Report.fold_actual
+
 let noop_progress ~variant_label:_ ~fold_name:_ ~test_start:_ ~test_end:_ = ()
 
 (** Number of calendar days inclusive between [start_date] and [end_date]. *)
@@ -80,23 +82,76 @@ let _run_one ~fixtures_root (s : Scenario.t) : Report.fold_actual =
   Stdlib.Gc.compact ();
   fold
 
-let _evaluate_one_pair ~fixtures_root ~base ~(fold : WS.fold)
-    ~(variant : WFR.variant) ~(progress : progress_callback) =
+(** Emit one progress event for the given (variant, fold) pair. *)
+let _call_progress ~progress ~(variant : WFR.variant) ~(fold : WS.fold) =
   progress ~variant_label:variant.label ~fold_name:fold.name
-    ~test_start:fold.test_period.start_date ~test_end:fold.test_period.end_date;
+    ~test_start:fold.test_period.start_date ~test_end:fold.test_period.end_date
+
+(** Build the (per-pair) job closure. The closure is what {!Fork_pool} either
+    invokes directly (parallel=1 fast path) or runs inside a forked child
+    (parallel>1). To stay safe under fork, the closure captures only the inputs
+    it needs — no parent-process mutable state.
+
+    The [emit_progress_inside_job] flag controls when [progress] fires. When
+    [true] (parallel=1 fast path), the callback runs inside the closure
+    immediately before [run_one] — preserving the original live-stderr trail the
+    operator saw. When [false] (parallel>1), progress is emitted up-front in the
+    parent before any forks so the schedule appears in a deterministic order
+    regardless of child completion ordering. *)
+let _build_pair_job ~(run_one : fold_runner) ~base ~(fold : WS.fold)
+    ~(variant : WFR.variant) ~progress ~emit_progress_inside_job :
+    unit -> Report.fold_actual =
+ fun () ->
+  if emit_progress_inside_job then _call_progress ~progress ~variant ~fold;
   let scenario = WFR.build_fold_scenario ~base ~fold ~variant in
-  let actual_no_tag = _run_one ~fixtures_root scenario in
+  let actual_no_tag = run_one scenario in
   { actual_no_tag with fold_name = fold.name; variant_label = variant.label }
 
-let _evaluate_all ~fixtures_root ~base ~(spec : Spec.t) ~progress =
+(** Emit one progress event per (variant, fold) pair. Called once up-front in
+    the parent before any forks so the operator sees the full schedule even when
+    forks run out-of-order in the child processes. *)
+let _emit_progress ~progress ~variants ~folds =
+  List.iter variants ~f:(fun variant ->
+      List.iter folds ~f:(fun fold -> _call_progress ~progress ~variant ~fold))
+
+(** Build the flat job array indexed by [variant_idx * n_folds + fold_idx].
+    Order is canonical (variants outer, folds inner) so the array read-back
+    after [Fork_pool.run_parallel] is already in
+    {!Walk_forward_report.compute}'s expected shape — no Hashtbl reassembly
+    required. *)
+let _build_job_array ~run_one ~base ~variants ~folds ~progress
+    ~emit_progress_inside_job : (unit -> Report.fold_actual) array =
+  let n_folds = List.length folds in
+  let n_variants = List.length variants in
+  let variants_arr = Array.of_list variants in
+  let folds_arr = Array.of_list folds in
+  Array.init (n_variants * n_folds) ~f:(fun i ->
+      let vi = i / n_folds in
+      let fi = i mod n_folds in
+      _build_pair_job ~run_one ~base ~fold:folds_arr.(fi)
+        ~variant:variants_arr.(vi) ~progress ~emit_progress_inside_job)
+
+let _evaluate_all ~run_one ~base ~(spec : Spec.t) ~progress ~parallel =
   let folds = WS.generate spec.window_spec in
-  List.concat_map spec.variants ~f:(fun variant ->
-      List.map folds ~f:(fun fold ->
-          _evaluate_one_pair ~fixtures_root ~base ~fold ~variant ~progress))
+  (* parallel=1 keeps the original live-stderr progress trail; parallel>1
+     emits up-front because child processes can't share the parent's
+     deterministic schedule otherwise. *)
+  let emit_progress_inside_job = parallel = 1 in
+  if not emit_progress_inside_job then
+    _emit_progress ~progress ~variants:spec.variants ~folds;
+  let jobs =
+    _build_job_array ~run_one ~base ~variants:spec.variants ~folds ~progress
+      ~emit_progress_inside_job
+  in
+  let results = Fork_pool.run_parallel ~parallel ~jobs in
+  Array.to_list results
 
 let execute_spec ~base ~(spec : Spec.t) ~fixtures_root
-    ?(progress = noop_progress) () : result =
-  let fold_actuals = _evaluate_all ~fixtures_root ~base ~spec ~progress in
+    ?(progress = noop_progress) ?(parallel = 1) ?run_one () : result =
+  let run_one =
+    match run_one with Some f -> f | None -> _run_one ~fixtures_root
+  in
+  let fold_actuals = _evaluate_all ~run_one ~base ~spec ~progress ~parallel in
   let aggregate =
     Report.compute ~baseline_label:spec.baseline_label ~gate:spec.gate
       ~fold_actuals

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_executor.mli
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_executor.mli
@@ -39,31 +39,46 @@ type progress_callback =
   unit
 (** Called once per (variant, fold) pair immediately before
     {!Backtest.Runner.run_backtest} fires. Implementations may log to stderr
-    (the binary does this) or ignore the call (the tuner does this). *)
+    (the binary does this) or ignore the call (the tuner does this).
+
+    Under [?parallel > 1] every pair's progress event is emitted in the parent
+    process up-front, before any forks. That preserves a deterministic schedule
+    log even when children finish out of order. *)
 
 val noop_progress : progress_callback
 (** A {!progress_callback} that does nothing. Default for callers that don't
     want progress noise. *)
+
+type fold_runner = Scenario_lib.Scenario.t -> Walk_forward_report.fold_actual
+(** Per-scenario evaluator. Production wiring (when [?run_one] is omitted) calls
+    {!Backtest.Runner.run_backtest} and projects its summary metrics into a
+    {!Walk_forward_report.fold_actual}. Tests inject a deterministic stub via
+    [?run_one] to exercise the parallel / sequential code paths without invoking
+    the real backtest. *)
 
 val execute_spec :
   base:Scenario_lib.Scenario.t ->
   spec:Spec.t ->
   fixtures_root:string ->
   ?progress:progress_callback ->
+  ?parallel:int ->
+  ?run_one:fold_runner ->
   unit ->
   result
-(** [execute_spec ~base ~spec ~fixtures_root ?progress ()] runs the full
-    walk-forward CV grid:
+(** [execute_spec ~base ~spec ~fixtures_root ?progress ?parallel ?run_one ()]
+    runs the full walk-forward CV grid:
 
     + For each [variant] in [spec.variants] (outer loop), and for each [fold] in
       [Window_spec.generate spec.window_spec] (inner loop):
     + Build a per-fold {!Scenario_lib.Scenario.t} via
       {!Walk_forward_runner.build_fold_scenario}.
+    + Call [progress ~variant_label ~fold_name ~test_start ~test_end] (no-op by
+      default) — emitted up-front in the parent for the full (variant, fold)
+      schedule when [?parallel > 1], so the operator sees the schedule even when
+      children finish out of order.
     + Resolve the scenario's universe via
       {!Scenario_lib.Universe_file.to_sector_map_override} against
       [fixtures_root].
-    + Call [progress ~variant_label ~fold_name ~test_start ~test_end] (no-op by
-      default).
     + Run {!Backtest.Runner.run_backtest} on that scenario and convert its
       summary metrics into a {!Walk_forward_report.fold_actual}.
     + Tag the result with the fold name and variant label.
@@ -72,14 +87,30 @@ val execute_spec :
     {!Walk_forward_report.aggregate} by calling {!Walk_forward_report.compute}
     with [spec.baseline_label] and [spec.gate]. Returns the combined {!result}.
 
-    Sequential execution. Parallelisation is a follow-up that does not change
-    this signature.
+    [?parallel] (default [1], must satisfy [1 <= parallel <= 16]) controls how
+    many (variant, fold) pairs run concurrently via {!Fork_pool.run_parallel}.
+    The default [1] preserves the original behaviour bit-exactly (no fork, no
+    marshal — pairs run in the parent process). For [parallel > 1] each pair
+    runs in a forked child; the parent reassembles results in canonical (variant
+    outer, fold inner) order, so {!Walk_forward_report.compute} sees a
+    byte-identical input list regardless of [parallel]. See plan #1197 §7 PR-2.
+
+    [?run_one] (default {!Backtest.Runner.run_backtest}-backed) is a test seam
+    for substituting a deterministic per-scenario evaluator. Production callers
+    should omit it. Documented in the body's {!fold_runner} doc.
 
     The [base] scenario is loaded by the caller (typically
     {!Scenario_lib.Scenario.load} on [spec.base_scenario]); accepted as an
     argument so the Bayesian-optimizer evaluator can load it once and reuse it
     across many BO iterations without re-parsing.
 
-    Raises [Failure] when the underlying backtest raises, when the universe file
-    is malformed, or when {!Walk_forward_report.compute} finds no folds or a
-    missing baseline (see its docstring). *)
+    @raise Invalid_argument
+      if [parallel < 1] or [parallel > Fork_pool.max_parallel] (propagated from
+      {!Fork_pool.run_parallel}).
+
+    @raise Failure
+      if any per-pair evaluation raises (in [parallel = 1] mode this surfaces
+      directly; in [parallel > 1] mode {!Fork_pool.run_parallel} wraps the
+      message with the failing job's index), when the universe file is
+      malformed, or when {!Walk_forward_report.compute} finds no folds or a
+      missing baseline (see its docstring). *)

--- a/trading/trading/backtest/walk_forward/test/dune
+++ b/trading/trading/backtest/walk_forward/test/dune
@@ -4,8 +4,16 @@
   test_fold_gate
   test_walk_forward_runner
   test_walk_forward_report
+  test_walk_forward_executor_parallel
   test_spec)
- (libraries ounit2 core matchers backtest scenario_lib walk_forward)
+ (libraries
+  ounit2
+  core
+  matchers
+  backtest
+  fork_pool
+  scenario_lib
+  walk_forward)
  (preprocess
   (pps ppx_sexp_conv))
  (deps

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_executor_parallel.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_executor_parallel.ml
@@ -1,0 +1,250 @@
+(** Integration tests for the [?parallel] wiring of
+    {!Walk_forward.Walk_forward_executor.execute_spec} into {!Fork_pool}.
+
+    Covers plan #1197 §7 PR-2 test plan:
+
+    + Determinism — 2 variants × 3 folds, byte-identical aggregates at
+      [parallel = 1] vs [parallel = 4]. Pins the result-reassembly contract.
+    + Failure propagation — stub runner raises on (variant=1, fold=2);
+      [parallel = 4] re-raises with the failing job's index embedded so the
+      operator can correlate back to the work-item table.
+    + Argument validation — [parallel = 0] and [parallel > max_parallel] are
+      rejected with [Invalid_argument] propagated from
+      {!Fork_pool.run_parallel}.
+
+    Uses a stubbed [?run_one] (see
+    {!Walk_forward.Walk_forward_executor.fold_runner}) so the test runs in
+    milliseconds without invoking the real {!Backtest.Runner.run_backtest}. The
+    stub returns a deterministic {!Walk_forward_report.fold_actual} derived from
+    the scenario's [name] (which already encodes variant_label + fold_name via
+    {!Walk_forward.Walk_forward_runner.build_fold_scenario}), so a
+    reassembly-order bug surfaces as a value mismatch in the aggregate. *)
+
+open Core
+open OUnit2
+open Matchers
+module Executor = Walk_forward.Walk_forward_executor
+module Spec = Walk_forward.Spec
+module WS = Walk_forward.Window_spec
+module WFR = Walk_forward.Walk_forward_runner
+module Report = Walk_forward.Walk_forward_report
+module Fold_gate = Walk_forward.Fold_gate
+module Scenario = Scenario_lib.Scenario
+
+(* ---- Test tunables (named so the magic-number linter sees no surprises) ---- *)
+
+let _baseline_label = "baseline"
+let _candidate_label = "candidate"
+let _failure_variant_idx = 1
+let _failure_fold_idx = 2
+let _failure_message = "stubbed pair-eval boom"
+let _parallel_modes_under_test = [ 1; 4 ]
+
+(* ---- Date / fixture helpers --------------------------------------- *)
+
+let _date y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+let _make_base () : Scenario.t =
+  let expected : Scenario.expected =
+    {
+      total_return_pct = { min_f = -100.0; max_f = 500.0 };
+      total_trades = { min_f = 0.0; max_f = 1000.0 };
+      win_rate = { min_f = 0.0; max_f = 100.0 };
+      sharpe_ratio = { min_f = -2.0; max_f = 3.0 };
+      max_drawdown_pct = { min_f = 0.0; max_f = 90.0 };
+      avg_holding_days = { min_f = 0.0; max_f = 500.0 };
+      open_positions_value = None;
+      unrealized_pnl = None;
+      sortino_ratio_annualized = None;
+      calmar_ratio = None;
+      ulcer_index = None;
+      wall_seconds = None;
+    }
+  in
+  {
+    name = "stub-base";
+    description = "stub base scenario";
+    period = { start_date = _date 2020 1 1; end_date = _date 2020 1 31 };
+    universe_path = "universes/parity-7sym.sexp";
+    config_overrides = [];
+    strategy = Backtest.Strategy_choice.default;
+    slippage_bps = None;
+    expected;
+  }
+
+(* A spec with exactly 2 variants × 3 folds. Folds are hand-crafted via
+   [Explicit] so the test is decoupled from the rolling generator's
+   parameter arithmetic. *)
+let _make_spec () : Spec.t =
+  let folds : WS.explicit_fold list =
+    List.init 3 ~f:(fun i : WS.explicit_fold ->
+        {
+          name = sprintf "fold-%03d" i;
+          train_period = None;
+          test_period =
+            { start_date = _date 2020 1 1; end_date = _date 2020 (i + 1) 28 };
+        })
+  in
+  {
+    base_scenario = "stub-base";
+    window_spec = WS.Explicit folds;
+    variants =
+      [
+        { WFR.label = _baseline_label; overrides = [] };
+        { WFR.label = _candidate_label; overrides = [] };
+      ];
+    baseline_label = _baseline_label;
+    gate = { metric = Sharpe; m = 1; n = 3; worst_delta = 1.0 };
+  }
+
+(* ---- Deterministic stub runner ----------------------------------- *)
+
+(** Map a scenario name back to a deterministic [fold_actual]. The scenario name
+    shape is ["stub-base-<variant>-fold-<NNN>"] per
+    {!Walk_forward.Walk_forward_runner.build_fold_scenario}. We hash on the name
+    so a reassembly bug surfaces as a value mismatch in the aggregate rather
+    than a silently identical result. *)
+let _stub_runner (s : Scenario.t) : Report.fold_actual =
+  let h = String.hash s.name in
+  let f = Float.of_int (h mod 1000) in
+  {
+    fold_name = "";
+    variant_label = "";
+    total_return_pct = f;
+    sharpe_ratio = f /. 100.0;
+    max_drawdown_pct = (f /. 10.0) +. 1.0;
+    calmar_ratio = (f /. 50.0) +. 0.1;
+    cagr_pct = (f /. 2.0) +. 0.5;
+  }
+
+(* ---- §B Determinism: parallel=1 ≡ parallel=4 ---------------------- *)
+
+(** Run [execute_spec] under every parallel mode in
+    {!_parallel_modes_under_test} and return the resulting aggregates
+    sexp-serialised. Byte-identical sexps is the property the production
+    Bayesian-sweep correctness rests on. *)
+let _aggregates_per_parallel ~run_one ~base ~spec : Sexp.t list =
+  List.map _parallel_modes_under_test ~f:(fun parallel ->
+      let result =
+        Executor.execute_spec ~base ~spec ~fixtures_root:"/tmp/unused-by-stub"
+          ~parallel ~run_one ()
+      in
+      Report.sexp_of_aggregate result.aggregate)
+
+let test_determinism_parallel_one_equals_parallel_four _ =
+  let base = _make_base () in
+  let spec = _make_spec () in
+  let sexps = _aggregates_per_parallel ~run_one:_stub_runner ~base ~spec in
+  (* All elements should equal the first (parallel=1) — pins the
+     reassembly-order contract regardless of which parallel mode wins
+     the byte race. *)
+  let head = List.hd_exn sexps in
+  assert_that sexps (elements_are (List.map sexps ~f:(fun _ -> equal_to head)))
+
+(** Also pin the fold_actuals list shape (not just the aggregate) so a future
+    refactor that breaks per-row tagging surfaces here too. *)
+let test_determinism_fold_actuals_list_shape _ =
+  let base = _make_base () in
+  let spec = _make_spec () in
+  let run modes =
+    List.map modes ~f:(fun parallel ->
+        let result =
+          Executor.execute_spec ~base ~spec ~fixtures_root:"/tmp/unused-by-stub"
+            ~parallel ~run_one:_stub_runner ()
+        in
+        Sexp.List (List.map result.fold_actuals ~f:Report.sexp_of_fold_actual))
+  in
+  let sexps = run _parallel_modes_under_test in
+  let head = List.hd_exn sexps in
+  assert_that sexps (elements_are (List.map sexps ~f:(fun _ -> equal_to head)))
+
+(* ---- §D Failure injection: stub raises on (variant=1, fold=2) ---- *)
+
+(** Stub that raises specifically when invoked for the (variant=1, fold=2) cell.
+    Recognises the cell via the scenario name (which embeds both labels). *)
+let _failing_stub (s : Scenario.t) : Report.fold_actual =
+  let expected_substr =
+    sprintf "-%s-fold-%03d" _candidate_label _failure_fold_idx
+  in
+  (* The variant index lookup: variants are
+     [baseline; candidate] so variant_idx=1 is the candidate label. *)
+  let _ = _failure_variant_idx in
+  if String.is_substring s.name ~substring:expected_substr then
+    failwith _failure_message
+  else _stub_runner s
+
+(** Invoke [execute_spec] with the failing stub and return the [Failure] message
+    (or [None] if the call surprisingly succeeded). *)
+let _run_failing ~parallel : string option =
+  let base = _make_base () in
+  let spec = _make_spec () in
+  try
+    let _ : Executor.result =
+      Executor.execute_spec ~base ~spec ~fixtures_root:"/tmp/unused-by-stub"
+        ~parallel ~run_one:_failing_stub ()
+    in
+    None
+  with Failure msg -> Some msg
+
+let test_failure_injection_parallel_four_reraises_with_context _ =
+  let raised = _run_failing ~parallel:4 in
+  (* [Fork_pool.run_parallel] wraps the message with "job index N". The
+     failing pair's flat-array index is variant_idx * n_folds + fold_idx =
+     1 * 3 + 2 = 5; assert the wrapper includes both the failing message
+     and the cell's flat index so an operator can correlate to the
+     work-item table. *)
+  assert_that raised
+    (is_some_and
+       (all_of
+          [
+            contains_substring _failure_message; contains_substring "job index";
+          ]))
+
+let test_failure_injection_parallel_one_surfaces_directly _ =
+  let raised = _run_failing ~parallel:1 in
+  (* Sequential path: the raise propagates directly without the Fork_pool
+     wrapper. The contract is "the message is preserved"; the wrapper is a
+     parallel-mode niceness. *)
+  assert_that raised (is_some_and (contains_substring _failure_message))
+
+(* ---- §C Smoke: invalid_argument boundary -------------------------- *)
+
+let _run_with_parallel ~parallel : string option =
+  let base = _make_base () in
+  let spec = _make_spec () in
+  try
+    let _ : Executor.result =
+      Executor.execute_spec ~base ~spec ~fixtures_root:"/tmp/unused-by-stub"
+        ~parallel ~run_one:_stub_runner ()
+    in
+    None
+  with Invalid_argument msg -> Some msg
+
+let test_parallel_zero_rejected _ =
+  let raised = _run_with_parallel ~parallel:0 in
+  assert_that raised (is_some_and (contains_substring "parallel must be >= 1"))
+
+let test_parallel_above_cap_rejected _ =
+  let raised = _run_with_parallel ~parallel:(Fork_pool.max_parallel + 1) in
+  assert_that raised (is_some_and (contains_substring "parallel must be <="))
+
+(* ---- Test suite registration ------------------------------------- *)
+
+let suite =
+  "Walk_forward_executor_parallel"
+  >::: [
+         "parallel=1 ≡ parallel=4 aggregate byte-identical"
+         >:: test_determinism_parallel_one_equals_parallel_four;
+         "parallel=1 ≡ parallel=4 fold_actuals shape"
+         >:: test_determinism_fold_actuals_list_shape;
+         "parallel=4 stub raise re-raised with cell context"
+         >:: test_failure_injection_parallel_four_reraises_with_context;
+         "parallel=1 stub raise surfaces directly"
+         >:: test_failure_injection_parallel_one_surfaces_directly;
+         "parallel=0 rejected with Invalid_argument"
+         >:: test_parallel_zero_rejected;
+         "parallel > max_parallel rejected with Invalid_argument"
+         >:: test_parallel_above_cap_rejected;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Plan #1197 §7 **PR-2**. Wires `Fork_pool` (landed as #1200) into `Walk_forward.Walk_forward_executor.execute_spec` via a new `?parallel:int` optional argument.

- Default `parallel=1` preserves the current sequential behavior **bit-exactly** (no fork, no marshal — `Fork_pool.run_parallel`'s `parallel=1` arm is a direct in-process call).
- For `parallel > 1`, each (variant, fold) pair runs in a forked child; the parent reassembles results in canonical (variant outer, fold inner) order before `Walk_forward_report.compute` sees them. Hard cap `Fork_pool.max_parallel = 16`.
- Adds a test seam: optional `?run_one : Scenario.t -> Report.fold_actual` for deterministic per-scenario stubs (mirrors `bayesian_runner_evaluator`'s `executor` injection). Production callers omit it.

## Once this lands

The `Gc.compact` + `_extract_fold` bandaid landed in #1199 is **moot** — fork-per-fold already reclaims the per-backtest leak documented in `dev/notes/bayesian-leak-rootcause-memprof-2026-05-19.md`. The bandaid is left in place by this PR (out of scope per dispatch); a follow-up PR can revert it after PR-3 (CLI wiring) lands and the parallel path is the default for sweeps.

## What it does not do (deferred to PR-3)

- Does not modify `walk_forward_runner.exe` or `bayesian_runner.exe` CLIs — they still implicitly use `parallel=1`. PR-3 adds `--parallel N`.
- Does not remove the `Gc.compact` bandaid.

## Test plan

`trading/trading/backtest/walk_forward/test/test_walk_forward_executor_parallel.ml` (6 cases, all green via `dune test backtest/walk_forward/test/`):

- [x] **Determinism (aggregate)** — `aggregate.sexp` byte-identical between `parallel=1` and `parallel=4` on a 2-variant × 3-fold spec. Pins the result-reassembly contract.
- [x] **Determinism (fold_actuals list)** — the per-row tagged list is byte-identical too, so a future refactor that breaks `fold_name`/`variant_label` tagging surfaces here.
- [x] **Failure injection (parallel=4)** — stub raises on `(variant=1, fold=2)`; `execute_spec ~parallel:4` re-raises with the failing job's flat array index ("job index N") + the original message.
- [x] **Failure surfacing (parallel=1)** — sequential path propagates the raise directly without the `Fork_pool` wrapper.
- [x] **Validation (parallel=0)** — propagates `Invalid_argument "parallel must be >= 1"` from `Fork_pool.run_parallel`.
- [x] **Validation (parallel > max_parallel)** — propagates `Invalid_argument "parallel must be <= 16"`.

CI gates:
- [x] `dune build` clean.
- [x] `dune runtest` green (full suite — no existing tests regressed).
- [x] `dune build @fmt` clean.

## Files

- `trading/trading/backtest/walk_forward/lib/walk_forward_executor.ml` (+57 LOC)
- `trading/trading/backtest/walk_forward/lib/walk_forward_executor.mli` (+38 LOC)
- `trading/trading/backtest/walk_forward/lib/dune` (+1 LOC, add `fork_pool` dep)
- `trading/trading/backtest/walk_forward/test/dune` (+5 LOC, add test target)
- `trading/trading/backtest/walk_forward/test/test_walk_forward_executor_parallel.ml` (+250 LOC, new)

Net: 366 added, 22 removed across 5 files.