### PR TITLE
feat(backtest): --parallel CLI flag on walk_forward + bayesian runners

### DIFF
--- a/trading/trading/backtest/tuner/bin/bayesian_runner.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner.ml
@@ -20,6 +20,7 @@
     {v
       bayesian_runner.exe --spec <spec.sexp> --out-dir <dir>
                           [--fixtures-root <path>]
+                          [--parallel N]    (default 1, max 16)
                           [--walk-forward-spec <spec.sexp>
                            --baseline-aggregate <aggregate.sexp>]
     v}
@@ -45,7 +46,14 @@
     spec's [holdout_folds] for OOS validation. The Bayesian spec's own
     [scenarios] list is ignored in walk-forward mode (the production fixture
     leaves it empty); the binary synthesises a single "walk-forward" scenario
-    label for the [bo_log.csv] writer's per-row column. *)
+    label for the [bo_log.csv] writer's per-row column.
+
+    [--parallel N] (default [1], max [Fork_pool.max_parallel] = 16) controls
+    fan-out of the (variant, fold) grid inside each BO iteration. The BO loop
+    itself remains serial (each iteration's score informs the next acquisition);
+    only the walk-forward CV grid parallelises. With 5 folds × 2 variants = 10
+    cells per iteration, [--parallel 4] processes them in 3 batches of 4 + 1
+    batch of 2. Plan #1197 §7 PR-3. *)
 
 open Core
 module Scenario = Scenario_lib.Scenario
@@ -61,7 +69,31 @@ module Oos_validator = Tuner_bin.Bayesian_runner_oos_validator
 let _usage_msg =
   "Usage: bayesian_runner.exe --spec <spec.sexp> --out-dir <dir>\n\
   \  [--fixtures-root <path>]\n\
+  \  [--parallel N]    (default 1, max 16)\n\
   \  [--walk-forward-spec <spec.sexp> --baseline-aggregate <aggregate.sexp>]"
+
+(** Default [--parallel] value. [1] preserves the pre-#1197 sequential path
+    bit-exactly (no fork, no marshal). *)
+let _default_parallel = 1
+
+(** Parse and validate the [--parallel N] flag at CLI time. Out-of-range values
+    would otherwise surface from inside [Fork_pool.run_parallel] as an
+    [Invalid_argument] after the spec has loaded — failing fast at parse time
+    gives the operator a clearer error. *)
+let _parse_parallel raw =
+  let n =
+    try Int.of_string raw
+    with _ ->
+      eprintf "Error: --parallel expects an integer, got %S\n%s\n" raw
+        _usage_msg;
+      Stdlib.exit 1
+  in
+  if n < 1 || n > Fork_pool.max_parallel then begin
+    eprintf "Error: --parallel must be in [1, %d], got %d\n%s\n"
+      Fork_pool.max_parallel n _usage_msg;
+    Stdlib.exit 1
+  end;
+  n
 
 (** Label assigned to the best cell when it is re-executed end-to-end for OOS
     validation. Distinct from the [bo-iter-N] labels the evaluator's iteration
@@ -79,10 +111,11 @@ type cli_args = {
   fixtures_root : string option;
   walk_forward_spec_path : string option;
   baseline_aggregate_path : string option;
+  parallel : int;
 }
 
 let _parse_args argv =
-  let rec loop spec out fixtures wf_spec baseline = function
+  let rec loop spec out fixtures wf_spec baseline parallel = function
     | [] -> (
         match (spec, out) with
         | Some s, Some o ->
@@ -92,19 +125,23 @@ let _parse_args argv =
               fixtures_root = fixtures;
               walk_forward_spec_path = wf_spec;
               baseline_aggregate_path = baseline;
+              parallel = Option.value parallel ~default:_default_parallel;
             }
         | _ ->
             eprintf "%s\n" _usage_msg;
             Stdlib.exit 1)
-    | "--spec" :: p :: rest -> loop (Some p) out fixtures wf_spec baseline rest
+    | "--spec" :: p :: rest ->
+        loop (Some p) out fixtures wf_spec baseline parallel rest
     | "--out-dir" :: p :: rest ->
-        loop spec (Some p) fixtures wf_spec baseline rest
+        loop spec (Some p) fixtures wf_spec baseline parallel rest
     | "--fixtures-root" :: p :: rest ->
-        loop spec out (Some p) wf_spec baseline rest
+        loop spec out (Some p) wf_spec baseline parallel rest
     | "--walk-forward-spec" :: p :: rest ->
-        loop spec out fixtures (Some p) baseline rest
+        loop spec out fixtures (Some p) baseline parallel rest
     | "--baseline-aggregate" :: p :: rest ->
-        loop spec out fixtures wf_spec (Some p) rest
+        loop spec out fixtures wf_spec (Some p) parallel rest
+    | "--parallel" :: n :: rest ->
+        loop spec out fixtures wf_spec baseline (Some (_parse_parallel n)) rest
     | "--help" :: _ | "-h" :: _ ->
         printf "%s\n" _usage_msg;
         Stdlib.exit 0
@@ -112,7 +149,7 @@ let _parse_args argv =
         eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
         Stdlib.exit 1
   in
-  loop None None None None None argv
+  loop None None None None None None argv
 
 (* -------------- legacy per-scenario mode -------------- *)
 
@@ -168,10 +205,12 @@ let _wf_spec_with_placeholder_scenario (s : Spec.t) : Spec.t =
 
 (** Re-execute the walk-forward sweep for the BO's best cell. Returns the
     fold_actuals list (per-fold, per-variant rows) that
-    {!Oos_validator.validate} partitions into in-sample vs OOS slices. *)
+    {!Oos_validator.validate} partitions into in-sample vs OOS slices. The
+    [parallel] degree is threaded through so the OOS re-run fans out the same
+    way the BO loop's per-iteration sweeps did. *)
 let _execute_best_cell_walk_forward ~(best_params : (string * float) list)
     ~(walk_forward_spec : Wf_spec.t) ~(base : Scenario.t)
-    ~(fixtures_root : string) : Wf_report.fold_actual list =
+    ~(fixtures_root : string) ~(parallel : int) : Wf_report.fold_actual list =
   let candidate =
     {
       Walk_forward.Walk_forward_runner.label = _walk_forward_candidate_label;
@@ -189,11 +228,13 @@ let _execute_best_cell_walk_forward ~(best_params : (string * float) list)
     }
   in
   eprintf
-    "[bayesian_runner] re-running walk-forward on best cell for OOS validation\n\
-     %!";
+    "[bayesian_runner] re-running walk-forward on best cell for OOS validation \
+     (parallel=%d)\n\
+     %!"
+    parallel;
   let result =
     Wf_executor.execute_spec ~base ~spec:two_variant_spec ~fixtures_root
-      ~progress:Wf_executor.noop_progress ()
+      ~progress:Wf_executor.noop_progress ~parallel ()
   in
   result.fold_actuals
 
@@ -219,13 +260,15 @@ let _run_walk_forward_mode ~(args : cli_args) ~(spec : Spec.t)
   let holdout_folds = Option.value spec.holdout_folds ~default:[] in
   eprintf
     "[bayesian_runner] mode=walk-forward; total_budget=%d; initial_random=%d; \
-     bounds=%d; holdout_folds=%d\n\
+     bounds=%d; holdout_folds=%d; parallel=%d\n\
      %!"
     spec.total_budget spec.initial_random (List.length spec.bounds)
-    (List.length holdout_folds);
+    (List.length holdout_folds)
+    args.parallel;
   let evaluator : Runner.evaluator =
-    Evaluator.build_walk_forward ~executor:Evaluator.default_executor ~base
-      ~walk_forward_spec ~baseline_aggregate ~fixtures_root ()
+    Evaluator.build_walk_forward
+      ~executor:(Evaluator.make_executor ~parallel:args.parallel ())
+      ~base ~walk_forward_spec ~baseline_aggregate ~fixtures_root ()
   in
   let runner_spec = _wf_spec_with_placeholder_scenario spec in
   let result =
@@ -239,7 +282,7 @@ let _run_walk_forward_mode ~(args : cli_args) ~(spec : Spec.t)
      per-fold results, emit oos_report.md. *)
   let fold_actuals =
     _execute_best_cell_walk_forward ~best_params:result.best_params
-      ~walk_forward_spec ~base ~fixtures_root
+      ~walk_forward_spec ~base ~fixtures_root ~parallel:args.parallel
   in
   let oos_result =
     Oos_validator.validate ~candidate_label:_walk_forward_candidate_label

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.ml
@@ -64,11 +64,12 @@ type executor =
   fixtures_root:string ->
   Wf_executor.result
 
-let default_executor : executor =
+let make_executor ?(parallel = 1) () : executor =
  fun ~base ~spec ~fixtures_root ->
   Wf_executor.execute_spec ~base ~spec ~fixtures_root
-    ~progress:Wf_executor.noop_progress ()
+    ~progress:Wf_executor.noop_progress ~parallel ()
 
+let default_executor : executor = make_executor ()
 let _candidate_label_for_iter (iter : int) : string = sprintf "bo-iter-%d" iter
 
 let _build_two_variant_spec ~(baseline_label : string)

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.mli
@@ -71,10 +71,21 @@ type executor =
     iteration scoring path can be exercised without invoking
     {!Backtest.Runner.run_backtest}. *)
 
+val make_executor : ?parallel:int -> unit -> executor
+(** [make_executor ?parallel ()] builds a production executor that calls
+    {!Walk_forward.Walk_forward_executor.execute_spec} with
+    {!Walk_forward.Walk_forward_executor.noop_progress} and the supplied
+    [?parallel] degree (default [1] — sequential, bit-identical to the pre-#1200
+    path). Validation of [parallel] against [Fork_pool.max_parallel] is deferred
+    to {!execute_spec}, which raises [Invalid_argument] on out-of-range values.
+    Plan #1197 §7 PR-3. *)
+
 val default_executor : executor
 (** Production executor: thin wrapper that calls
     {!Walk_forward.Walk_forward_executor.execute_spec} with
-    {!Walk_forward.Walk_forward_executor.noop_progress}. *)
+    {!Walk_forward.Walk_forward_executor.noop_progress}. Equivalent to
+    [make_executor ()] — kept as a separate value for the pre-#1197 callers that
+    bind it directly. *)
 
 val build_walk_forward :
   executor:executor ->

--- a/trading/trading/backtest/tuner/bin/dune
+++ b/trading/trading/backtest/tuner/bin/dune
@@ -33,6 +33,7 @@
  (libraries
   core
   core_unix
+  fork_pool
   tuner
   backtest
   scenario_lib

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_evaluator.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_evaluator.ml
@@ -644,6 +644,21 @@ let test_default_executor_type_exists _ =
   let _ : Evaluator.executor = Evaluator.default_executor in
   assert_that true (equal_to true)
 
+(* ---------- 15. make_executor (plan #1197 §7 PR-3) -------------------- *)
+
+(** CP4: [make_executor] is the production wiring exposed in the mli that
+    accepts a [?parallel] degree (plan #1197 §7 PR-3). Pin that the function
+    returns a value of type [executor] for both the default (omitted) and
+    explicit-parallel forms — type-check only, no runtime invocation (which
+    would call the real backtest). *)
+let test_make_executor_default_type_exists _ =
+  let _ : Evaluator.executor = Evaluator.make_executor () in
+  assert_that true (equal_to true)
+
+let test_make_executor_with_parallel_type_exists _ =
+  let _ : Evaluator.executor = Evaluator.make_executor ~parallel:4 () in
+  assert_that true (equal_to true)
+
 let suite =
   "Tuner_bin.Bayesian_runner_evaluator.build_walk_forward"
   >::: [
@@ -675,6 +690,10 @@ let suite =
          >:: test_base_scenario_threaded_to_executor;
          "default_executor exists with expected signature"
          >:: test_default_executor_type_exists;
+         "make_executor () returns an executor (PR-3)"
+         >:: test_make_executor_default_type_exists;
+         "make_executor ~parallel:N returns an executor (PR-3)"
+         >:: test_make_executor_with_parallel_type_exists;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/walk_forward/bin/dune
+++ b/trading/trading/backtest/walk_forward/bin/dune
@@ -1,6 +1,12 @@
 (executable
  (name walk_forward_runner)
  (modules walk_forward_runner)
- (libraries core core_unix core_unix.filename_unix scenario_lib walk_forward)
+ (libraries
+  core
+  core_unix
+  core_unix.filename_unix
+  fork_pool
+  scenario_lib
+  walk_forward)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/walk_forward/bin/walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/bin/walk_forward_runner.ml
@@ -16,6 +16,7 @@
     {v
       walk_forward_runner.exe --spec <spec.sexp> --out-dir <dir>
                               [--fixtures-root <path>]
+                              [--parallel N]    (default 1, max 16)
     v}
 
     This binary is the integration seam for Phase 3: the Bayesian optimizer
@@ -34,28 +35,59 @@ module Executor = Walk_forward.Walk_forward_executor
 
 (* -------------- argument parsing -------------- *)
 
+(** Default [--parallel] value. [1] preserves the pre-#1197 sequential path
+    bit-exactly (no fork, no marshal). *)
+let _default_parallel = 1
+
 type cli_args = {
   spec_path : string;
   out_dir : string;
   fixtures_root : string option;
+  parallel : int;
 }
 
 let _usage_msg =
   "Usage: walk_forward_runner.exe --spec <spec.sexp> --out-dir <dir> \
-   [--fixtures-root <path>]"
+   [--fixtures-root <path>] [--parallel N]"
+
+(** Parse and validate the [--parallel N] flag at CLI time. Out-of-range values
+    would otherwise surface from inside [Fork_pool.run_parallel] as an
+    [Invalid_argument] after the spec has loaded — failing fast at parse time
+    gives the operator a clearer error. *)
+let _parse_parallel raw =
+  let n =
+    try Int.of_string raw
+    with _ ->
+      eprintf "Error: --parallel expects an integer, got %S\n%s\n" raw
+        _usage_msg;
+      Stdlib.exit 1
+  in
+  if n < 1 || n > Fork_pool.max_parallel then begin
+    eprintf "Error: --parallel must be in [1, %d], got %d\n%s\n"
+      Fork_pool.max_parallel n _usage_msg;
+    Stdlib.exit 1
+  end;
+  n
 
 let _parse_args argv =
-  let rec loop spec out fixtures = function
+  let rec loop spec out fixtures parallel = function
     | [] -> (
         match (spec, out) with
         | Some s, Some o ->
-            { spec_path = s; out_dir = o; fixtures_root = fixtures }
+            {
+              spec_path = s;
+              out_dir = o;
+              fixtures_root = fixtures;
+              parallel = Option.value parallel ~default:_default_parallel;
+            }
         | _ ->
             eprintf "%s\n" _usage_msg;
             Stdlib.exit 1)
-    | "--spec" :: p :: rest -> loop (Some p) out fixtures rest
-    | "--out-dir" :: p :: rest -> loop spec (Some p) fixtures rest
-    | "--fixtures-root" :: p :: rest -> loop spec out (Some p) rest
+    | "--spec" :: p :: rest -> loop (Some p) out fixtures parallel rest
+    | "--out-dir" :: p :: rest -> loop spec (Some p) fixtures parallel rest
+    | "--fixtures-root" :: p :: rest -> loop spec out (Some p) parallel rest
+    | "--parallel" :: n :: rest ->
+        loop spec out fixtures (Some (_parse_parallel n)) rest
     | ("--help" | "-h") :: _ ->
         printf "%s\n" _usage_msg;
         Stdlib.exit 0
@@ -63,7 +95,7 @@ let _parse_args argv =
         eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
         Stdlib.exit 1
   in
-  loop None None None argv
+  loop None None None None argv
 
 (* -------------- output writers -------------- *)
 
@@ -108,13 +140,16 @@ let _main () =
     Fixtures_root.resolve ?fixtures_root:args.fixtures_root ()
   in
   let base = Scenario.load spec.base_scenario in
-  eprintf "[walk_forward] spec=%s base=%s baseline=%s variants=%d folds=%d\n%!"
+  eprintf
+    "[walk_forward] spec=%s base=%s baseline=%s variants=%d folds=%d parallel=%d\n\
+     %!"
     args.spec_path spec.base_scenario spec.baseline_label
     (List.length spec.variants)
-    (List.length (WS.generate spec.window_spec));
+    (List.length (WS.generate spec.window_spec))
+    args.parallel;
   let result =
     Executor.execute_spec ~base ~spec ~fixtures_root ~progress:_stderr_progress
-      ()
+      ~parallel:args.parallel ()
   in
   _write_fold_actuals ~out_dir:args.out_dir result.fold_actuals;
   _write_report ~out_dir:args.out_dir ~spec result.fold_actuals;


### PR DESCRIPTION
## Summary

Closes the parallelisation sequence from plan [#1197 §7 PR-3](https://github.com/dayfine/trading/pull/1197) (PR-1 `Fork_pool` library #1200, PR-2 `Walk_forward_executor` wiring #1202, this is PR-3).

- `walk_forward_runner.exe`: add `--parallel N` (default 1, max 16). Validate at CLI time so out-of-range values surface as a clear error rather than `Invalid_argument` from inside `Fork_pool.run_parallel`.
- `bayesian_runner.exe`: add `--parallel N`. Thread through both the BO loop's per-iteration walk-forward sweep AND the OOS best-cell re-run.
- `Bayesian_runner_evaluator`: add `make_executor ?parallel ()` alongside `default_executor` (kept for backward compat — existing `default_executor` callers still type-check, and the bin-test pinning `default_executor`'s type still passes).

Default = 1 preserves the pre-#1200 sequential path bit-exactly. The BO loop itself remains serial (each iteration's score informs the next acquisition); only the walk-forward CV grid inside one BO iteration parallelises.

## Test plan

### Unit
- `dune build trading/backtest/walk_forward trading/backtest/tuner` clean (zero warnings).
- `dune runtest trading/backtest/walk_forward trading/backtest/tuner` — all green (16 walk-forward + 37 evaluator + 43 runner + others).
- Two new tests in `test_bayesian_runner_evaluator.ml`:
  - `make_executor () returns an executor (PR-3)` — type-check pin for the default form.
  - `make_executor ~parallel:N returns an executor (PR-3)` — type-check pin for the explicit form.
- Existing parallel-correctness tests in `test_walk_forward_executor_parallel.ml` (PR-2) already cover parallel=1 ≡ parallel=4 byte-identical aggregates, failure propagation, and `Invalid_argument` boundary — those remain green here.

### CLI smoke (manual)

Bad-arg validation:
```
$ walk_forward_runner.exe --parallel notanint ... → Error: --parallel expects an integer (exit 1)
$ walk_forward_runner.exe --parallel 0 ...        → Error: --parallel must be in [1, 16] (exit 1)
$ walk_forward_runner.exe --parallel 99 ...       → Error: --parallel must be in [1, 16] (exit 1)
$ bayesian_runner.exe --parallel 17 ...           → Error: --parallel must be in [1, 16] (exit 1)
```

### End-to-end smoke (walk_forward_runner.exe)

Tiny 2-fold spec on the existing 7-symbol parity scenario (`smoke/tiered-loader-parity.sexp`, 6-month sub-windows):

| mode          | wall time | user time | aggregate.sexp | fold_actuals.sexp |
|---------------|-----------|-----------|----------------|-------------------|
| `--parallel 1` | 2.074s    | 2.246s    | ✓              | ✓                 |
| `--parallel 2` | 1.161s    | 2.077s    | byte-identical | byte-identical    |

~1.78× wall-time speedup on 2 folds, user-time preserved (so parallelism is real, not just overlap). Aggregates byte-identical between modes, which is the contract the BO loop's correctness rests on.

### What's NOT in this PR
- The `Gc.compact` bandaid in `walk_forward_executor.ml` stays (per dispatch — follow-up after we verify end-to-end leak is gone via a real sweep with the new fork pool).
- Default = 1 is preserved (existing callers' behavior unchanged).
- No bayesian end-to-end smoke (would need real sp500 30-fold + baseline aggregate — multi-hour wall). The wiring is identical to the walk-forward path's smoke above; both paths route through the same `Wf_executor.execute_spec ~parallel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
