### PR TITLE
docs(plan): hold-period deep-dive + cross-cycle Weinstein validation

### DIFF
--- a/dev/plans/cross-cycle-weinstein-validation-2026-05-19.md
+++ b/dev/plans/cross-cycle-weinstein-validation-2026-05-19.md
@@ -1,0 +1,237 @@
+# Cross-cycle Weinstein validation — multi-milestone plan
+
+Date: 2026-05-19. Companion to
+`dev/notes/deep-history-data-pointers-2026-05-16.md` and
+`memory/reference_deep_history_data_sources.md`.
+
+## Problem statement
+
+Stan Weinstein's *Secrets for Profiting in Bull and Bear Markets* was
+published 1988, calibrated on tape from the 1970s-80s (post-Bretton Woods
+stagflation through the start of the 1982-2000 secular bull). Our
+current backtest universe is **sp500-2010-2026** — a single regime
+(post-GFC QE through 2022 hike cycle). Cell-E's 0.94 Sharpe on 15y is
+a useful baseline but tells us nothing about robustness across:
+
+- 1929-39 depression
+- 1945-66 post-WWII secular bull
+- 1966-82 stagflation
+- 1973-74 bear
+- 1982-2000 secular bull (incl. 1987 crash, 1990 recession)
+- 2000-02 tech bust
+- 2007-09 GFC
+- 2020 COVID flash crash
+- 2022 hike cycle (partially covered by current backtest)
+
+The strategy may be **regime-specific**. A Weinstein-faithful
+implementation should profit in every regime where the 30-week MA
+stage framework is informative — broadly, anywhere there are
+distinguishable Stage-2 advancers vs Stage-4 decliners. The
+secular bull of 1982-2000 likely flatters the framework; the
+range-bound 1966-82 stagflation may destroy it.
+
+## Data constraints (the load-bearing reality)
+
+Per `dev/notes/deep-history-data-pointers-2026-05-16.md`:
+
+- **Per-stock daily 1925-1999**: CRSP. Institutional-only. Morningstar
+  acquired Feb 2026; access uncertain. **Assume unavailable.**
+- **Index-level S&P from 1871**: Shiller dataset (XLS / CSV / JSON
+  mirrors). FREE. Monthly granularity (daily not available pre-1962
+  for free).
+- **Portfolio-level from 1926**: Kenneth French Data Library. FREE.
+  49 industries, size × value × momentum sorts, daily granularity.
+- **Tier-2 commodities + international**: deferred to later milestones.
+
+The plan is shaped by what's free.
+
+## Milestones
+
+### M1: Shiller index Weinstein reduction (cheapest)
+
+**Goal**: run a single-symbol Weinstein on monthly S&P data
+1871-2025. Validate the framework on 155y of regime variation.
+
+**Deliverable**: decade-by-decade Sharpe + MaxDD table.
+
+**Scope** (~2 PRs, ~400 LOC):
+
+1. **PR-A**: Shiller ingest. Pull `ie_data.xls` (or the JSON mirror at
+   `posix4e.github.io/shiller_wrapper_data`). Normalise to
+   `Daily_price.t`-shaped monthly rows: date, close = real S&P
+   (CPI-deflated), volume = N/A (zero or NaN). Store as a pinned
+   fixture under `analysis/data/sources/shiller/`. ~200 LOC.
+
+2. **PR-B**: monthly-bar Weinstein reduction. The full strategy
+   requires daily bars + cross-sectional ranking; the reduction runs
+   on **one symbol** (S&P index) with the **simplest stage
+   classifier** (price vs 30-month MA = ~30-week × 4-week aggregate).
+   No screener cascade, no relative strength. Strategy:
+   - Long S&P when price > rising 30-month MA
+   - Cash when price < 30-month MA
+   - Optional short variant: short S&P when price < falling 30-month MA
+   
+   ~200 LOC. Standalone strategy module; does not touch the production
+   Weinstein impl.
+
+**Output**: a single table:
+
+```
+Decade        | Strategy CAGR | B&H CAGR | Strategy Sharpe | Strategy MaxDD
+1871-1880     |  X.X%         |  X.X%    | X.XX            | -X.X%
+1880-1890     |  ...
+...
+2020-2025     |  ...
+```
+
+Plus a chart: cumulative-return curves (strategy vs buy-and-hold)
+overlaid 1871-2025.
+
+**Limitations**: index-level only. No cross-sectional ranking, no
+sector rotation, no per-stock RS. The 30-month MA is a coarse proxy
+for 30-week. Monthly granularity means we can't measure intra-month
+stop performance. But for the question "does the stage framework
+profit at all in 1929 / 1973 / 2000?" this is sufficient.
+
+**Sequencing**: pursue immediately after v1 sweep lands. ~1 week of
+work.
+
+### M2: French 49-industry portfolio Weinstein
+
+**Goal**: extend M1 to cross-sectional cadence — run Weinstein-style
+ranking across 49 French industry portfolios, daily, 1926-2025.
+
+**Deliverable**: per-decade Sharpe + DD on a Long-top-K-industries /
+Short-bottom-K-industries rotation strategy.
+
+**Scope** (~3 PRs, ~1k LOC):
+
+1. **PR-C**: French Data Library ingest. The library exposes 49
+   daily-industry-return series + Fama-French factor series. Pull
+   from the Dartmouth/Tuck CSVs. Normalise to `Daily_price.t`-shaped
+   (synthetic price levels reconstructed from cumulative returns).
+   ~300 LOC. Storage under `analysis/data/sources/french/`.
+
+2. **PR-D**: daily-bar Weinstein-style industry rotation. Strategy:
+   - For each industry, compute 30-week MA + stage classification.
+   - Rank Stage-2 industries by 13-week relative strength vs market.
+   - Long the top-5 industries; short the bottom-5 (or cash variant
+     for long-only comparison).
+   - Rebalance weekly.
+   
+   ~500 LOC. Standalone strategy module.
+
+3. **PR-E**: 100y decade-by-decade results write-up.
+
+**Limitations**: still not per-stock. Industry-level granularity
+hides intra-industry dispersion. But this DOES test the
+**cross-sectional core** of Weinstein (Stage-2 advancers outperform
+Stage-4 decliners) on 100y of data. If this fails in
+1966-82 stagflation, the framework is regime-specific.
+
+**Sequencing**: depends on M1 result. If M1 shows the framework profits
+in every regime, M2 is a higher-confidence test. If M1 fails in some
+regime, M2 may explain why (industry rotation gives more degrees of
+freedom than index timing).
+
+### M3: Synthesised per-stock 1925-1999
+
+**Goal**: run the FULL production strategy (525-symbol cascade with
+sector ETFs, AD breadth, etc.) on synthesised pre-2000 per-stock data.
+
+**Deliverable**: per-decade Sharpe + DD using the same strategy
+artifact we're shipping today, on 1925-1999 + 2000-2025 = ~100y.
+
+**Scope** (~5 PRs, ~3k LOC, multi-week effort):
+
+1. **PR-F**: factor-anchored synthesis methodology. Use French
+   portfolios as the systematic skeleton (size × value × momentum ×
+   industry); layer idiosyncratic noise calibrated to cross-sectional
+   dispersion; rescale so the cap-weighted aggregate reproduces
+   Shiller's S&P composite. ~1.5k LOC. Most expensive PR.
+
+2. **PR-G**: synthesis validation. Compare synthesised 2000-2025
+   universe-aggregate against ACTUAL EODHD 2000-2025 universe-aggregate.
+   If the synthesis matches actual cross-sectional dispersion + factor
+   loadings + return distribution within tolerance, we can trust the
+   pre-2000 synthesis. ~300 LOC. **This is the make-or-break PR — if
+   synthesis fails validation, M3 is not viable.**
+
+3. **PR-H, I, J**: pin the synthesised pre-2000 universe as a backtest
+   fixture; run the production cascade; emit decade-by-decade results.
+
+**Limitations**: synthesised data, not real. We're testing whether the
+strategy profits in a counterfactual 1929/1973 that's been hand-rolled
+to match observable factor structure. Findings are weaker than M1/M2
+which use real (if index-level) data.
+
+**Sequencing**: blocks on M1 + M2 demonstrating the index/industry
+levels show interesting regime variance worth investigating at
+per-stock level. If M1 shows the framework profits uniformly, M3
+adds little. If M1 shows regime collapse in 1973-82 stagflation, M3
+becomes critical for figuring out which sub-population (large vs
+small, value vs growth) drove the collapse.
+
+### M4 (stretch): CRSP access via Morningstar
+
+**Goal**: real per-stock 1925-1999 daily, no synthesis. The
+gold-standard test.
+
+**Status**: blocked on Morningstar institutional terms post-Feb 2026
+acquisition. Not actionable today.
+
+**Scope**: pure data-acquisition cost; ingest is a small PR if access
+materialises. Park.
+
+## Decision tree
+
+```
+v1 Bayesian sweep lands → cell-E baseline pinned on 2010-2025
+  ↓
+M1 Shiller index Weinstein (1-week effort)
+  ↓
+  ├─ Framework profits in every regime → great, low-priority M2-M3
+  │   (proceed only if curiosity or regulatory ask)
+  │
+  └─ Framework collapses in 1 or 2 regimes (e.g. stagflation, depression)
+      ↓
+      M2 French industry-rotation (2-week effort)
+      ↓
+      ├─ Industry rotation works where index fails → cross-sectional
+      │   ranking IS the value-add. Production strategy is well-grounded.
+      │
+      └─ Industry rotation ALSO collapses in same regimes → cross-sectional
+          ranking does not save the framework. M3 becomes load-bearing
+          (need per-stock granularity to find what does work).
+```
+
+## What this is NOT
+
+- Not a "go fetch CRSP / Sharadar / Norgate" plan. We've ruled those
+  out (paywall + Windows-only for Norgate).
+- Not a full historical-universe-construction plan (that's Phase 1.x
+  per `dev/notes/vendor-comparison-historical-universe-2026-05-16.md`).
+  This is the *complementary* deep-history validation lane.
+- Not a path to running the production strategy on real per-stock
+  1925-1999 data. That requires CRSP, which we can't get.
+
+## Effort summary
+
+| Milestone | PRs | LOC | Wall time | Data source |
+|---|---:|---:|---|---|
+| M1: Shiller index | 2 | ~400 | 1 week | Shiller (free) |
+| M2: French industry | 3 | ~1000 | 2 weeks | French (free) |
+| M3: Synthesised per-stock | 5 | ~3000 | 3-4 weeks | Synthesis (free) |
+| M4: CRSP | 1 (data only) | ~200 | TBD | CRSP (paywall) |
+
+Total realistic-effort budget: ~5-8 weeks for M1+M2+M3, gated by M1
+results. M4 stays parked.
+
+## Cross-references
+
+- `dev/notes/deep-history-data-pointers-2026-05-16.md` — vendor matrix
+- `dev/notes/vendor-comparison-historical-universe-2026-05-16.md` —
+  IWV / SP500 historical-universe sub-plan (orthogonal to this one)
+- `memory/reference_deep_history_data_sources.md` — source list
+- `docs/design/weinstein-book-reference.md` — domain reference (book
+  rules + parameter values)

--- a/dev/plans/hold-period-deep-dive-2026-05-19.md
+++ b/dev/plans/hold-period-deep-dive-2026-05-19.md
@@ -1,0 +1,187 @@
+# Hold-period deep dive — does the strategy actually exit on Weinstein cadence?
+
+Date: 2026-05-19. Companion to the v1 Bayesian sweep currently in flight
+(`dev/notes/bayesian-prod-sweep-dispatch-2026-05-19.md`).
+
+## Problem statement
+
+Stan Weinstein's strategy (1988) is built around the **30-week
+moving average**. Stage transitions take weeks; held positions are
+intended to ride Stage-2 advances for months. The book is explicit:
+this is **not a scalping strategy**.
+
+Our current shipped strategy (cell-E, 2010-2025 backtest, 2090 trades)
+exits on a very different cadence:
+
+| Percentile | Days held |
+|---:|---:|
+| P50 | **12** |
+| P75 | 42 |
+| P90 | 119 |
+| P95 | 175 |
+| P99 | 273 |
+| Max | 434 |
+| Mean | 39.4 |
+
+Half the trades close within 2 weeks. The mean hold is ~8 weeks — already
+short for a 30-week-MA framework. **We are scalping a Weinstein-shaped
+breakout signal, not riding Weinstein-style Stage-2 advances.**
+
+### Where the fast churn comes from
+
+Decomposing by `exit_trigger`:
+
+| Exit trigger | N | % | P50 hold | P75 | P95 |
+|---|---:|---:|---:|---:|---:|
+| `stop_loss` | 1382 | 66.1% | **10** | 25 | 112 |
+| `laggard_rotation` | 600 | 28.7% | 28 | 105 | 231 |
+| `stage3_force_exit` | 102 | 4.9% | 14 | 63 | 196 |
+
+The fast-churn population IS the `stop_loss` branch (P50=10d). The
+laggard-rotation and stage3-force-exit branches hold roughly as long
+as Weinstein would expect (P50=14-28d, P75=63-105d, P95=196-231d).
+
+**Hypothesis (load-bearing):** the trailing stop tightens / triggers
+on noise inside the first 1-2 weeks of every entry, exiting before
+the Stage-2 thesis has time to play out. Two-thirds of entries die
+this way.
+
+## Why this might be fine, or might be wrong
+
+### Why it might be FINE
+
+- A tight stop is a valid trading style. If the median fast-exit loses
+  only ~1% per trade and the few survivors do ≥+10R, the expectancy
+  could still beat the loose-stop alternative.
+- Cell-E's 5-year Sharpe (0.94 on 15y per `memory/project_sp500_baseline_conflict.md`)
+  is not bad. So the current scalp-on-Weinstein-signal is profitable.
+- The fast-churn population may be "early stage-2 false positives" the
+  trailing stop correctly filters out — the framework's adverse-selection
+  pruning, not a flaw.
+
+### Why it might be WRONG
+
+- Weinstein's book is explicit: weekly-bar timeframe + 30-week MA. The
+  stop is meant to ride **beneath** the rising MA, not 5-8% beneath
+  entry. Our `initial_stop_buffer` (1.00-1.10) + `installed_stop_min_pct`
+  (0.04-0.15) produce far tighter stops than that.
+- The 66% stop-loss share might be cutting winners that would have run
+  for 3-6 months if given room. Selection bias in the survivors: only
+  the trades that pass *both* the initial-stop gauntlet *and* the
+  laggard-rotation gauntlet are reaching weeks-to-months holds.
+- If we re-run with a Weinstein-faithful stop (e.g. 15-20% buffer below
+  entry, OR explicit "exit only on weekly close below 30-week MA"),
+  total return may be *higher* because surviving Stage-2 trades have
+  more upside than the per-trade gain we capture today.
+
+## Bayesian-sweep evidence
+
+The v1 sweep currently running (4 knobs, budget=60) tunes:
+- `initial_stop_buffer` ∈ [1.00, 1.10]
+- `installed_stop_min_pct` ∈ [0.04, 0.15]
+
+Two of four knobs ARE stop-placement. The Sharpe-objective winner will
+implicitly answer:
+
+- If winner's stop knobs are at the **upper** bound (loose stops), the
+  fast-churn cost is real and the strategy wants to hold longer.
+- If at the **lower** bound (tight stops), the current cadence is
+  near-optimal and the median-12d hold is by design.
+
+**Caveat**: the sweep optimises Sharpe, not hold-period. A winner with
+loose stops + lower Sharpe than baseline still proves nothing about
+cadence; sharpness penalises drawdown which loose stops increase.
+**This sweep is a useful signal but not a definitive test.**
+
+## Probes (post-v1)
+
+Five experiments, each independent, ordered by cost:
+
+### P1: exit-trigger × P&L decomposition (1 PR, ~50 LOC analysis)
+
+Already have the data. Aggregate cell-E 15y trades by `exit_trigger`
+and compute per-bucket: mean R, win-rate, mean P&L %, total contribution
+to PnL. Answers "are the 1382 stop-loss exits net-positive or
+net-negative? do they justify their 66% share?". One-shot analysis,
+no new backtest.
+
+### P2: stop-only ablation runs (1 sweep, ~6 hr)
+
+Run 5 configs sweeping ONLY stops, holding other knobs at cell-E:
+1. tight (initial_stop_buffer=1.00, installed_stop_min_pct=0.04) — current floor
+2. cell-E baseline
+3. loose (initial_stop_buffer=1.10, installed_stop_min_pct=0.15) — current ceiling
+4. very-loose (initial_stop_buffer=1.20, installed_stop_min_pct=0.20) — outside current bounds
+5. weinstein-faithful (initial_stop_buffer=1.20, installed_stop_min_pct=0.05,
+   PLUS a flag "exit only on weekly close below 30-week MA" if implementable)
+
+Per config: full 15y backtest. Report median/P75/P95 hold-days +
+Sharpe + MaxDD + total return. If config #4 or #5 dominates on Sharpe
+AND has 3-5× longer median hold, the current bounds were too tight and
+v2 sweep should widen them.
+
+### P3: time-to-first-stop-trigger histogram (1 PR, ~30 LOC analysis)
+
+Existing column `days_to_first_stop_trigger` on each trade. Plot
+histogram for the 1382 stop-loss exits. If the mode is days 1-3, the
+stop is firing on entry-bar noise — we're stopping out before the
+position even establishes. Fix: add a 5-day or 10-day "settling
+window" after entry where the stop is disabled. Tunable knob.
+
+### P4: per-stage hold-distribution (1 PR, ~30 LOC analysis)
+
+Existing column `entry_stage`. Decompose hold-days by stage at entry.
+If we have many Stage-3 or Stage-4 entries (despite the screener
+filter), those may have wrong-direction risk and short holds.
+Hypothesis: laggard-rotation eviction is correctly catching false
+Stage-2 entries; the 600 laggard-rotation trades' P50=28d is the
+holding period of the trades the screener mis-classified.
+
+### P5: composite objective sweep with cadence term (depends on PR #1196)
+
+Plan #1196 (`wire spec.objective into score_cell`) lets us define a
+multi-term objective. Add a soft penalty for `median_hold < 30 days`:
+
+```
+score = 0.50 × Sharpe
+      + 0.30 × Calmar
+      - 0.10 × MaxDD
+      - 0.10 × max(0, 30 − median_hold) / 30
+```
+
+Re-run v2 sweep with this objective. If the cadence term moves the
+winner's stop knobs upward by >2σ, it's confirmation the fast-churn is
+a real cost the Sharpe-only objective hides.
+
+## Decision tree
+
+```
+After v1 lands:
+├─ P1 + P3 + P4 (cheap analyses) — establish whether fast-churn is profitable
+│   ├─ Net-positive contribution → fast-churn is by design, close this plan
+│   └─ Net-negative or marginal → continue
+├─ P2 (widen-stops ablation) — does loosening dominate?
+│   ├─ Loose wins on Sharpe → file PR to widen v2 sweep bounds
+│   └─ Loose loses on Sharpe → continue to P5
+└─ P5 (composite-objective sweep) — does the cadence-aware scorer find a longer-hold winner?
+    ├─ Yes → that's the v3 winner; ship
+    └─ No → the strategy genuinely is a scalp-on-Weinstein-signal; document and close
+```
+
+## What this is NOT
+
+- This plan is **not** advocating for a Weinstein-purist rewrite. The
+  shipped strategy may be a legitimate (if non-canonical) interpretation.
+  The plan is "measure what we have, then decide".
+- Not a quick-win — these probes will take 1-2 weeks of analysis +
+  sweep wall-time. Sequencing should follow v1 + plan #1196 landing.
+
+## Sizing + sequencing
+
+- P1, P3, P4: tiny analysis PRs, ~30-50 LOC each. Independent. Land in
+  one session after v1 lands.
+- P2: 1 sweep (~6 hr wall at parallel=4 with the now-shipped Fork_pool).
+- P5: blocked on plan #1196 (Composite scorer). ~12 hr wall once #1196
+  lands.
+
+Total wall to a decision: ~1 week if motivated.


### PR DESCRIPTION
## Summary

Two plan-only docs for follow-ups surfaced during the v1 Bayesian
sweep investigation today.

### `dev/plans/hold-period-deep-dive-2026-05-19.md`

The shipped strategy's hold-period distribution (P50=12d, P95=175d)
is much shorter than Weinstein's intended weeks-to-months cadence.
Decomposition by `exit_trigger` localises the issue: 66% of trades
exit on `stop_loss` with P50=10d, while the 29% that exit via
`laggard_rotation` hold at P50=28d (closer to book cadence). Five
sequenced probes cheapest-first:

- P1: exit_trigger × P&L decomposition (analysis-only, existing data)
- P2: stop-only ablation sweep (~6 hr at parallel=4)
- P3: time-to-first-stop-trigger histogram
- P4: per-stage hold-distribution
- P5: composite-objective sweep with cadence penalty (blocked on #1196)

Decision tree at the bottom: a cheap analysis loop tells us whether
the fast-churn is by-design (profitable) or a real cost.

### `dev/plans/cross-cycle-weinstein-validation-2026-05-19.md`

Stan Weinstein's *Secrets for Profiting in Bull and Bear Markets*
(1988) was calibrated on 1970s-80s tape. Our backtest covers
2010-2025 (a single QE-era regime). Four milestones to test the
stage framework across the 1929 depression, 1966-82 stagflation,
1982-2000 secular bull, 2000s tech bust, etc:

- **M1** (1 week, free): Shiller monthly S&P 1871-2025 single-symbol
  Weinstein reduction. Decade-by-decade Sharpe + DD.
- **M2** (2 weeks, free): French 49-industry daily 1926-2025
  cross-sectional rotation. Tests whether Stage-2 vs Stage-4
  ranking adds value beyond simple index-timing.
- **M3** (3-4 weeks, gated on M1+M2): factor-anchored per-stock
  synthesis from French + Shiller. Make-or-break PR is the
  validation against actual 2000-2025 distribution.
- **M4** (parked): CRSP real per-stock 1925-1999. Institutional
  paywall, Morningstar acquisition Feb 2026 made terms uncertain.

Data constraint: per-stock pre-2000 daily is institutional-only;
everything else (Shiller, French, World Bank, datahub.io) is free.

## Why two plans together

Both surfaced from the same v1-sweep investigation thread. Both depend
on v1 results landing before execution. Both reference the same
upstream notes (`dev/notes/deep-history-data-pointers-2026-05-16.md`,
`docs/design/weinstein-book-reference.md`). Bundling keeps the
review context coherent.

## Test plan

- [x] `dune build` clean (docs-only PR — no code).
- [ ] Plans reviewed for the priority + sequencing trade-offs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)