### PR TITLE
feat(bayesian-scoring): thread spec.objective through score_cell (PR-1 of #1196)

### DIFF
--- a/trading/trading/backtest/tuner/bin/bayesian_runner.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner.ml
@@ -258,17 +258,19 @@ let _run_walk_forward_mode ~(args : cli_args) ~(spec : Spec.t)
   let base = Scenario.load base_scenario_path in
   let baseline_aggregate = _load_aggregate baseline_aggregate_path in
   let holdout_folds = Option.value spec.holdout_folds ~default:[] in
+  let objective = Spec.to_grid_objective spec.objective in
+  let obj_label = Tuner.Grid_search.objective_label objective in
   eprintf
     "[bayesian_runner] mode=walk-forward; total_budget=%d; initial_random=%d; \
-     bounds=%d; holdout_folds=%d; parallel=%d\n\
+     bounds=%d; holdout_folds=%d; parallel=%d; objective=%s\n\
      %!"
     spec.total_budget spec.initial_random (List.length spec.bounds)
     (List.length holdout_folds)
-    args.parallel;
+    args.parallel obj_label;
   let evaluator : Runner.evaluator =
     Evaluator.build_walk_forward
       ~executor:(Evaluator.make_executor ~parallel:args.parallel ())
-      ~base ~walk_forward_spec ~baseline_aggregate ~fixtures_root ()
+      ~base ~walk_forward_spec ~baseline_aggregate ~objective ~fixtures_root ()
   in
   let runner_spec = _wf_spec_with_placeholder_scenario spec in
   let result =

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.ml
@@ -111,10 +111,10 @@ let _stability_to_metric_set ~(label : string) (agg : Wf_types.aggregate) :
           Map.set acc ~key:k ~data:v)
 
 let _score_or_fail ~candidate_label ~baseline_label ~candidate_aggregate
-    ~baseline_aggregate ~parameters : float =
+    ~baseline_aggregate ~objective ~parameters : float =
   let result =
     Bayesian_runner_scoring.score_cell ~parameters ~candidate_label
-      ~baseline_label ~candidate_aggregate ~baseline_aggregate
+      ~baseline_label ~candidate_aggregate ~baseline_aggregate ~objective
   in
   match result with
   | Ok score -> score
@@ -125,8 +125,8 @@ let _score_or_fail ~candidate_label ~baseline_label ~candidate_aggregate
 
 let build_walk_forward ~(executor : executor) ~(base : Scenario.t)
     ~(walk_forward_spec : Walk_forward.Spec.t)
-    ~(baseline_aggregate : Wf_types.aggregate) ~(fixtures_root : string) () : t
-    =
+    ~(baseline_aggregate : Wf_types.aggregate) ~(objective : GS.objective)
+    ~(fixtures_root : string) () : t =
   let iter_counter = ref 0 in
   let baseline_label = walk_forward_spec.baseline_label in
   fun ~parameters ->
@@ -140,7 +140,8 @@ let build_walk_forward ~(executor : executor) ~(base : Scenario.t)
     let result = executor ~base ~spec ~fixtures_root in
     let score =
       _score_or_fail ~candidate_label ~baseline_label
-        ~candidate_aggregate:result.aggregate ~baseline_aggregate ~parameters
+        ~candidate_aggregate:result.aggregate ~baseline_aggregate ~objective
+        ~parameters
     in
     let metric_set =
       _stability_to_metric_set ~label:candidate_label result.aggregate

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.mli
@@ -92,11 +92,22 @@ val build_walk_forward :
   base:Scenario_lib.Scenario.t ->
   walk_forward_spec:Walk_forward.Spec.t ->
   baseline_aggregate:Walk_forward.Walk_forward_types.aggregate ->
+  objective:Tuner.Grid_search.objective ->
   fixtures_root:string ->
   unit ->
   t
 (** [build_walk_forward ~executor ~base ~walk_forward_spec ~baseline_aggregate
-     ~fixtures_root ()] returns a per-iteration walk-forward evaluator.
+     ~objective ~fixtures_root ()] returns a per-iteration walk-forward
+    evaluator.
+
+    [objective] is the spec-level scoring objective (per
+    {!Tuner_bin.Bayesian_runner_spec.t.objective} →
+    {!Tuner_bin.Bayesian_runner_spec.to_grid_objective}). It is captured at
+    build time (not per-iter) and threaded into
+    {!Tuner_bin.Bayesian_runner_scoring.score_cell}. PR-1 of the wire-spec plan:
+    only [Sharpe] is implemented; passing any other objective causes
+    [score_cell] to return [Status.Unimplemented], which the evaluator's
+    [_score_or_fail] surfaces as [Failure].
 
     Each [~parameters] call:
 

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml
@@ -46,11 +46,38 @@ let _compute_maxdd_hinge ~(candidate_maxdd : float) ~(baseline_maxdd : float) :
 let _compute_gate_penalty (verdict : Walk_forward.Fold_gate.verdict) : float =
   match verdict with Pass _ -> 0.0 | Fail _ -> _gate_penalty_value
 
+(* ---------- per-objective scoring branches ---------- *)
+
+let _score_sharpe_with_hinge ~(candidate_stab : Wf.variant_stability)
+    ~(baseline_stab : Wf.variant_stability) ~(gate_penalty : float) : float =
+  let mean_sharpe = candidate_stab.sharpe_ratio.mean in
+  let candidate_maxdd = candidate_stab.max_drawdown_pct.mean in
+  let baseline_maxdd = baseline_stab.max_drawdown_pct.mean in
+  let maxdd_hinge = _compute_maxdd_hinge ~candidate_maxdd ~baseline_maxdd in
+  let loss =
+    -.mean_sharpe
+    +. (_lambda_dd *. maxdd_hinge)
+    +. (_lambda_gate *. gate_penalty)
+  in
+  -.loss
+
+let _unimplemented_objective_error (label : string) : 'a Status.status_or =
+  Error
+    {
+      code = Status.Unimplemented;
+      message =
+        Printf.sprintf
+          "bayesian_runner_scoring: objective %S is not implemented yet (PR-2 \
+           of dev/plans/wire-spec-objective-into-score-cell-2026-05-18.md \
+           lands the Composite-relative + single-metric-relative formulas)"
+          label;
+    }
+
 (* ---------- top-level scorer ---------- *)
 
 let score_cell ~parameters:_ ~candidate_label ~baseline_label
-    ~(candidate_aggregate : Wf.aggregate) ~(baseline_aggregate : Wf.aggregate) :
-    float Status.status_or =
+    ~(candidate_aggregate : Wf.aggregate) ~(baseline_aggregate : Wf.aggregate)
+    ~(objective : Tuner.Grid_search.objective) : float Status.status_or =
   if candidate_aggregate.fold_count = 0 then
     Status.error_invalid_argument
       "bayesian_runner_scoring: candidate_aggregate.fold_count = 0; no folds \
@@ -66,14 +93,11 @@ let score_cell ~parameters:_ ~candidate_label ~baseline_label
     let%bind candidate_verdict =
       _lookup_verdict ~label:candidate_label candidate_aggregate
     in
-    let mean_sharpe = candidate_stab.sharpe_ratio.mean in
-    let candidate_maxdd = candidate_stab.max_drawdown_pct.mean in
-    let baseline_maxdd = baseline_stab.max_drawdown_pct.mean in
-    let maxdd_hinge = _compute_maxdd_hinge ~candidate_maxdd ~baseline_maxdd in
     let gate_penalty = _compute_gate_penalty candidate_verdict in
-    let loss =
-      -.mean_sharpe
-      +. (_lambda_dd *. maxdd_hinge)
-      +. (_lambda_gate *. gate_penalty)
-    in
-    Ok (-.loss)
+    match objective with
+    | Tuner.Grid_search.Sharpe ->
+        Ok
+          (_score_sharpe_with_hinge ~candidate_stab ~baseline_stab ~gate_penalty)
+    | Composite _ | Calmar | TotalReturn | Concavity_coef ->
+        _unimplemented_objective_error
+          (Tuner.Grid_search.objective_label objective)

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.mli
@@ -9,15 +9,27 @@
     module never touches the filesystem, never spawns a subprocess, never reads
     a config.
 
-    Scoring formula (plan [dev/plans/bayesian-multi-param-scaling-2026-05-16.md]
-    §3.1):
+    Scoring formula — per-objective dispatch (plan
+    [dev/plans/wire-spec-objective-into-score-cell-2026-05-18.md] §1 Q5):
 
-    {v
-      loss(cell)  = -mean_sharpe(cell)
-                  + lambda_dd  * max(0, mean_maxdd(cell) - baseline_maxdd)
-                  + lambda_gate * gate_penalty(cell)
-      score(cell) = -loss(cell)
-    v}
+    {ul
+     {- [Sharpe] (default) — preserves the legacy formula byte-for-byte (plan
+        [dev/plans/bayesian-multi-param-scaling-2026-05-16.md] §3.1):
+        {v
+          loss(cell)  = -mean_sharpe(cell)
+                      + lambda_dd  * max(0, mean_maxdd(cell) - baseline_maxdd)
+                      + lambda_gate * gate_penalty(cell)
+          score(cell) = -loss(cell)
+        v}
+        See {!_score_sharpe_with_hinge}.
+     }
+     {- [Composite _] / [Calmar] / [TotalReturn] / [Concavity_coef] — return
+        [Status.Unimplemented]. PR-2 of the wire-spec plan implements the
+        Composite-relative and single-metric-relative branches. PR-1 (this
+        change) ships the signature plumbing only; the BO sweep should set
+        [objective = Sharpe] until PR-2 lands.
+     }
+    }
 
     where:
 
@@ -74,15 +86,34 @@ val _degenerate_fold_floor_return_pct : float
     callers in PR-C can wire per-fold exclusion when the walk-forward harness
     surfaces per-fold returns to the scorer. *)
 
+val _score_sharpe_with_hinge :
+  candidate_stab:Walk_forward.Walk_forward_types.variant_stability ->
+  baseline_stab:Walk_forward.Walk_forward_types.variant_stability ->
+  gate_penalty:float ->
+  float
+(** Pure Sharpe-with-MaxDD-hinge formula. Exposed so tests can introspect the
+    branch directly (mirrors the existing [_lambda_dd] / [_gate_penalty_value]
+    exposure). The top-level [score_cell] routes [objective = Sharpe] through
+    this helper.
+
+    {v
+      loss  = -candidate_stab.sharpe_ratio.mean
+            + _lambda_dd  * max(0, candidate_stab.max_drawdown_pct.mean
+                                   - baseline_stab.max_drawdown_pct.mean)
+            + _lambda_gate * gate_penalty
+      score = -loss
+    v} *)
+
 val score_cell :
   parameters:(string * float) list ->
   candidate_label:string ->
   baseline_label:string ->
   candidate_aggregate:Walk_forward.Walk_forward_types.aggregate ->
   baseline_aggregate:Walk_forward.Walk_forward_types.aggregate ->
+  objective:Tuner.Grid_search.objective ->
   float Status.status_or
 (** [score_cell ~parameters ~candidate_label ~baseline_label
-     ~candidate_aggregate ~baseline_aggregate] returns the BO score
+     ~candidate_aggregate ~baseline_aggregate ~objective] returns the BO score
     (higher-is-better) for the candidate cell.
 
     [parameters] is accepted for logging-shape symmetry with the existing
@@ -90,6 +121,14 @@ val score_cell :
     directly (it depends only on the walk-forward outcomes). It is required so
     callers cannot accidentally pass a "blank" assignment when the BO loop
     expects per-iteration cells.
+
+    [objective] selects the scoring branch (see top-of-module docstring):
+
+    - [Sharpe] (default for existing sweeps) — preserves the legacy
+      Sharpe-with-MaxDD-hinge formula. All existing tests + production sweeps
+      continue to use this path.
+    - [Composite _] / [Calmar] / [TotalReturn] / [Concavity_coef] — return
+      [Status.Unimplemented] until PR-2 implements them.
 
     [candidate_aggregate] and [baseline_aggregate] are produced by
     {!Walk_forward.Walk_forward_report.compute}. The candidate aggregate is the
@@ -107,6 +146,8 @@ val score_cell :
       [baseline_aggregate.stability].
     - [Status.Invalid_argument] when [candidate_aggregate.fold_count = 0] — a
       zero-fold aggregate cannot yield a meaningful mean Sharpe.
+    - [Status.Unimplemented] when [objective] is anything other than [Sharpe]
+      (lifted in PR-2 of the wire-spec plan).
 
     Determinism: same inputs → byte-identical [float] output (modulo IEEE-754
     quirks; no floating-point reduction order dependencies because the

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_evaluator.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_evaluator.ml
@@ -193,7 +193,8 @@ let test_score_matches_scoring_module _ =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let score, _metric_sets =
     evaluator ~parameters:[ ("initial_stop_buffer", 1.10) ]
@@ -240,7 +241,8 @@ let test_candidate_label_increments_per_call _ =
     Evaluator.build_walk_forward ~executor:exec ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let score_0, _ = evaluator ~parameters:[ ("x", 0.0) ] in
   let score_1, _ = evaluator ~parameters:[ ("x", 1.0) ] in
@@ -269,7 +271,8 @@ let test_two_variant_spec_carries_baseline_and_candidate _ =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let parameters = [ ("initial_stop_buffer", 1.20) ] in
   let _score, _metric_sets = evaluator ~parameters in
@@ -326,7 +329,8 @@ let test_executor_invoked_once_per_call _ =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let _score, _ = evaluator ~parameters:[ ("x", 0.0) ] in
   assert_that !calls (size_is 1)
@@ -351,7 +355,8 @@ let test_metric_set_list_is_single_element _ =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let _score, metric_sets = evaluator ~parameters:[ ("x", 0.0) ] in
   assert_that metric_sets (size_is 1)
@@ -378,7 +383,8 @@ let test_metric_set_contents_match_candidate_stability _ =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let _score, metric_sets = evaluator ~parameters:[ ("x", 0.0) ] in
   let metric_set = List.hd_exn metric_sets in
@@ -413,7 +419,8 @@ let test_scorer_error_propagates_as_failure _ =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let raised =
     try
@@ -446,7 +453,8 @@ let test_gate_fail_penalty_applied _ =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let score, _ = evaluator ~parameters:[ ("x", 0.0) ] in
   (* Expected: 0.9 - 10.0 = -9.1 *)
@@ -472,7 +480,8 @@ let test_fixtures_root_threaded_to_executor _ =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:"/custom/path" ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:"/custom/path" ()
   in
   let _ = evaluator ~parameters:[ ("x", 0.0) ] in
   assert_that !calls
@@ -503,7 +512,7 @@ let test_two_variant_spec_preserves_gate _ =
   let evaluator =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:template_spec ~baseline_aggregate:baseline_agg
-      ~fixtures_root:_fixtures_root ()
+      ~objective:Tuner.Grid_search.Sharpe ~fixtures_root:_fixtures_root ()
   in
   let _ = evaluator ~parameters:[ ("x", 0.0) ] in
   assert_that !calls
@@ -549,7 +558,8 @@ let test_baseline_label_passed_through_spec _ =
   let evaluator =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:(_make_walk_forward_spec ~baseline_label:"my-baseline")
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let _ = evaluator ~parameters:[ ("x", 0.0) ] in
   assert_that !calls
@@ -582,7 +592,8 @@ let test_parameters_thread_into_candidate_overrides _ =
     Evaluator.build_walk_forward ~executor ~base:(_make_base_scenario ())
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let parameters =
     [
@@ -628,7 +639,8 @@ let test_base_scenario_threaded_to_executor _ =
     Evaluator.build_walk_forward ~executor ~base
       ~walk_forward_spec:
         (_make_walk_forward_spec ~baseline_label:_baseline_label)
-      ~baseline_aggregate:baseline_agg ~fixtures_root:_fixtures_root ()
+      ~baseline_aggregate:baseline_agg ~objective:Tuner.Grid_search.Sharpe
+      ~fixtures_root:_fixtures_root ()
   in
   let _ = evaluator ~parameters:[ ("x", 0.0) ] in
   assert_that !calls

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_scoring.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_scoring.ml
@@ -28,6 +28,11 @@ module Scoring = Tuner_bin.Bayesian_runner_scoring
 module Wf = Walk_forward.Walk_forward_types
 module FG = Walk_forward.Fold_gate
 
+(** Default objective used by every test in this module. PR-1 of the wire-spec
+    plan ships the Sharpe-default branch only; existing tests must continue to
+    pass byte-for-byte through this branch. *)
+let _sharpe : Tuner.Grid_search.objective = Tuner.Grid_search.Sharpe
+
 (* ---------- synthetic-aggregate builders ---------- *)
 
 let _stats ?(stdev = Float.nan) ?(min = Float.nan) ?(max = Float.nan) ~mean () :
@@ -95,7 +100,7 @@ let test_identity_candidate_equals_baseline _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:agg
-      ~baseline_aggregate:agg
+      ~baseline_aggregate:agg ~objective:_sharpe
   in
   assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 0.85))
 
@@ -119,7 +124,7 @@ let test_maxdd_hinge_zero_on_improvement _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 1.2))
 
@@ -143,7 +148,7 @@ let test_maxdd_hinge_linear_on_excess _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 0.5))
 
@@ -168,12 +173,12 @@ let test_gate_pass_vs_fail_score_difference _ =
   let pass_result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:pass_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   let fail_result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:fail_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   match (pass_result, fail_result) with
   | Ok p, Ok f -> assert_that (p -. f) (float_equal ~epsilon:_epsilon 10.0)
@@ -215,12 +220,12 @@ let test_synthetic_fail_treated_as_regular_fail _ =
   let synth =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:synth_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   let regular =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:regular_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   match (synth, regular) with
   | Ok s, Ok r -> assert_that s (float_equal ~epsilon:_epsilon r)
@@ -246,12 +251,12 @@ let test_sharpe_improvement_increases_score _ =
   let candidate_score =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   let baseline_score =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_baseline_label
       ~baseline_label:_baseline_label ~candidate_aggregate:baseline_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   match (candidate_score, baseline_score) with
   | Ok c, Ok b -> assert_that c (gt (module Float_ord) b)
@@ -279,7 +284,7 @@ let test_missing_candidate_in_stability_returns_error _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:agg
-      ~baseline_aggregate:agg
+      ~baseline_aggregate:agg ~objective:_sharpe
   in
   assert_that result (is_error_with Status.NotFound)
 
@@ -306,7 +311,7 @@ let test_missing_candidate_in_verdicts_returns_error _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:agg
-      ~baseline_aggregate:agg
+      ~baseline_aggregate:agg ~objective:_sharpe
   in
   assert_that result (is_error_with Status.NotFound)
 
@@ -336,7 +341,7 @@ let test_missing_baseline_in_baseline_aggregate_returns_error _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   assert_that result (is_error_with Status.NotFound)
 
@@ -352,7 +357,7 @@ let test_zero_fold_aggregate_returns_error _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:agg
-      ~baseline_aggregate:agg
+      ~baseline_aggregate:agg ~objective:_sharpe
   in
   assert_that result (is_error_with Status.Invalid_argument)
 
@@ -376,7 +381,7 @@ let test_exactly_at_baseline_maxdd_zero_hinge _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   (* No MaxDD penalty, no gate penalty → score = +0.8. *)
   assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 0.8))
@@ -395,7 +400,7 @@ let test_negative_sharpe_candidate_score_negative _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:agg
-      ~baseline_aggregate:agg
+      ~baseline_aggregate:agg ~objective:_sharpe
   in
   assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon (-0.3)))
 
@@ -419,7 +424,7 @@ let test_both_maxdd_and_gate_penalties_combine _ =
   let result =
     Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
       ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
-      ~baseline_aggregate:baseline_agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
   in
   (* Expected: -loss = -(-1.0 + 0.10*4.0 + 1.0*10.0) = -(9.4) = -9.4 *)
   assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon (-9.4)))
@@ -440,19 +445,88 @@ let test_parameters_do_not_affect_score _ =
     Scoring.score_cell
       ~parameters:[ ("x", 0.0); ("y", 0.0) ]
       ~candidate_label:_candidate_label ~baseline_label:_baseline_label
-      ~candidate_aggregate:agg ~baseline_aggregate:agg
+      ~candidate_aggregate:agg ~baseline_aggregate:agg ~objective:_sharpe
   in
   let s2 =
     Scoring.score_cell
       ~parameters:[ ("x", 99.0); ("y", -42.0); ("z", 1.5) ]
       ~candidate_label:_candidate_label ~baseline_label:_baseline_label
-      ~candidate_aggregate:agg ~baseline_aggregate:agg
+      ~candidate_aggregate:agg ~baseline_aggregate:agg ~objective:_sharpe
   in
   match (s1, s2) with
   | Ok a, Ok b -> assert_that a (float_equal ~epsilon:_epsilon b)
   | _ -> assert_failure "expected both score_cell calls to succeed"
 
-(* ---------- 15. Hyperparameter constants are pinned ---------- *)
+(* ---------- 15. Non-Sharpe objectives return Status.Unimplemented ---------- *)
+
+(** PR-1 of the wire-spec plan ships the Sharpe-default branch only; passing any
+    other [objective] yields [Status.Unimplemented]. PR-2 will replace these
+    stubs with the Composite-relative + single-metric-relative formulas and
+    remove this assertion. *)
+let test_non_sharpe_objective_returns_unimplemented _ =
+  let agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:0.9 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let composite : Tuner.Grid_search.objective =
+    Composite
+      [
+        (Trading_simulation_types.Metric_types.SharpeRatio, 0.5);
+        (Trading_simulation_types.Metric_types.MaxDrawdown, -0.1);
+      ]
+  in
+  let other_objectives : Tuner.Grid_search.objective list =
+    [ composite; Calmar; TotalReturn; Concavity_coef ]
+  in
+  List.iter other_objectives ~f:(fun obj ->
+      let result =
+        Scoring.score_cell ~parameters:_no_params
+          ~candidate_label:_candidate_label ~baseline_label:_baseline_label
+          ~candidate_aggregate:agg ~baseline_aggregate:agg ~objective:obj
+      in
+      assert_that result (is_error_with Status.Unimplemented))
+
+(* ---------- 16. Sharpe-branch helper is byte-identical to score_cell ---------- *)
+
+(** Pins the contract that [score_cell ~objective:Sharpe] dispatches through
+    [_score_sharpe_with_hinge] with no transformation. If a refactor breaks this
+    byte-equivalence, the BO loop's posterior drifts silently — this test
+    catches it. *)
+let test_sharpe_branch_equals_helper _ =
+  let agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_candidate_label ~baseline_sharpe:0.5
+      ~baseline_maxdd:15.0 ~candidate_sharpe:1.0 ~candidate_maxdd:19.0
+      ~candidate_verdict:(_fail_verdict ()) ()
+  in
+  let baseline_agg =
+    _make_aggregate ~baseline_label:_baseline_label
+      ~candidate_label:_baseline_label ~baseline_sharpe:0.5 ~baseline_maxdd:15.0
+      ~candidate_sharpe:0.5 ~candidate_maxdd:15.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let candidate_stab =
+    List.find_exn agg.stability ~f:(fun v ->
+        String.equal v.variant_label _candidate_label)
+  in
+  let baseline_stab =
+    List.find_exn baseline_agg.stability ~f:(fun v ->
+        String.equal v.variant_label _baseline_label)
+  in
+  let direct =
+    Scoring._score_sharpe_with_hinge ~candidate_stab ~baseline_stab
+      ~gate_penalty:Scoring._gate_penalty_value
+  in
+  let routed =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:agg
+      ~baseline_aggregate:baseline_agg ~objective:_sharpe
+  in
+  assert_that routed (is_ok_and_holds (float_equal ~epsilon:_epsilon direct))
+
+(* ---------- 17. Hyperparameter constants are pinned ---------- *)
 
 (** CP4 — pin the documented constants. If anyone changes a constant they must
     also change the test, which is the desired contract. *)
@@ -494,6 +568,10 @@ let suite =
          >:: test_both_maxdd_and_gate_penalties_combine;
          "parameters argument does not affect score"
          >:: test_parameters_do_not_affect_score;
+         "non-Sharpe objectives → Status.Unimplemented (PR-1)"
+         >:: test_non_sharpe_objective_returns_unimplemented;
+         "Sharpe branch == _score_sharpe_with_hinge helper"
+         >:: test_sharpe_branch_equals_helper;
          "hyperparameter constants pinned"
          >:: test_hyperparameter_constants_pinned;
        ]


### PR DESCRIPTION
## Summary

PR-1 of plan #1196 (`dev/plans/wire-spec-objective-into-score-cell-2026-05-18.md`). Mechanical signature plumbing only — **zero behavior change** on the Sharpe path.

Today `Bayesian_runner_scoring.score_cell` hardcodes the Sharpe-with-MaxDD-penalty formula regardless of `spec.objective`. This PR threads `objective` through `score_cell` and `build_walk_forward` so PR-2 can implement the non-Sharpe branches. Existing Sharpe sweeps see no change.

## Changes (7 files, ~169 net LOC)

- **`bayesian_runner_scoring.{ml,mli}`** — extract the legacy formula into `_score_sharpe_with_hinge` (exposed for test introspection, mirrors `_lambda_dd` exposure). `score_cell` now takes `~objective` and pattern-matches:
  - `Sharpe` → `_score_sharpe_with_hinge` (byte-identical to today).
  - `Composite _` / `Calmar` / `TotalReturn` / `Concavity_coef` → `Status.Unimplemented` (PR-2 implements).
- **`bayesian_runner_evaluator.{ml,mli}`** — `build_walk_forward` takes `~objective`; `_score_or_fail` threads it into `score_cell`.
- **`bayesian_runner.ml`** — `_run_walk_forward_mode` computes `objective = Spec.to_grid_objective spec.objective` and passes through; startup log line now includes `objective=<label>` (mirrors legacy-mode log at line 132-138 — diagnostic-only, no test impact).
- **`test_bayesian_runner_scoring.ml`** — every `score_cell` call routed through `~objective:_sharpe` (a module-level alias for `Tuner.Grid_search.Sharpe`); **+2 tests**:
  - `non-Sharpe objectives → Status.Unimplemented (PR-1)` pins the gap PR-2 fills.
  - `Sharpe branch == _score_sharpe_with_hinge helper` pins byte-equivalence so a future refactor can't drift the BO posterior silently.
- **`test_bayesian_runner_evaluator.ml`** — every `build_walk_forward` call passes `~objective:Tuner.Grid_search.Sharpe`.

## Test plan

- [x] `dune build && dune runtest trading/backtest/tuner/bin/test/` → 17 (scoring) + 16 (evaluator) + 9 (bin) + 14 (oos) + 37 (grid) = 93 tests green.
- [x] `dune build @fmt` clean.
- [x] All 15 existing scoring tests untouched (now 17 total with the 2 new PR-1 tests); evaluator tests untouched (still 16).
- [x] Full `dune runtest` from the project root passes (no cross-suite regressions).

## Sequencing

- **PR-1 (this PR)**: signature plumbing only.
- **PR-2** (~300 LOC, not in this PR): Composite-relative + single-metric-relative implementations + 8 new tests.
- **PR-3** (~50 LOC doc, not in this PR): amend `dev/plans/bayesian-production-sweep-2026-05-18.md` to drop CVaR from the §4 Composite and reword "median" → "mean".

The in-flight V2 Bayesian production sweep (`spec.objective = Sharpe`) continues to optimise the exact same formula — no risk to live work.