### PR TITLE
analysis(p4): per-stage hold-period decomposition — Probe P4

### DIFF
--- a/dev/notes/hold-period-p4-per-stage-2026-05-20.md
+++ b/dev/notes/hold-period-p4-per-stage-2026-05-20.md
@@ -1,0 +1,71 @@
+# Hold-period P4 — per-stage hold-distribution analysis (2026-05-20)
+
+Probe P4 from `dev/plans/hold-period-deep-dive-2026-05-19.md`. Companion to P1 / P3 (not yet run).
+
+## Headline
+
+**P4 hypothesis falsified.** The plan asked whether the cell-E strategy admits a meaningful number of Stage-3 or Stage-4 entries that the screener filter mis-classifies, and whether laggard-rotation's longer hold (P50=28d) is in fact catching those mis-classifications. The data answers cleanly: **every single one of 2075 cell-E entries is classified `Stage2`**. There are zero `Stage1`, zero `Stage2_late`, zero `Stage3`, zero `Stage4` entries. The screener cascade is doing its job — only Stage 2 candidates reach entry.
+
+The follow-up question — does the laggard-rotation branch catch stocks that became "wrong-direction" after entry — is therefore not answerable by stage decomposition. The 600 laggard-rotation trades and 1382 stop-loss trades are drawn from the same Stage-2 entry pool; whatever separates them lives downstream of stage classification.
+
+## Pivoted-axis finding — screener-score quartiles
+
+Since `entry_stage` is uniform, I bucketed the same 2075 trades by `screener_score_at_entry` quartile (Q25=60, Q50=70, Q75=75) instead. **The relationship is inverse to what the cascade-as-quality-filter premise would predict:**
+
+| Bucket | N | P50 | P75 | P95 | Mean hold | Mean P&L % | Win-rate % |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Q1 (lowest, score < 60) | 230 | 14 | 63 | 161 | 43.4 | **1.71** | **42.6** |
+| Q2 (60-69) | 755 | 13 | 47 | 175 | 40.8 | 1.24 | 35.8 |
+| Q3 (70-74) | 299 | 11 | 56 | 196 | 44.3 | 1.59 | 38.8 |
+| Q4 (highest, score >= 75) | 791 | 12 | 35 | 161 | 35.9 | **0.74** | 33.8 |
+
+Lowest-score entries (Q1) deliver **2.3x the mean P&L** (1.71% vs 0.74%) and the **highest win rate** (42.6% vs 33.8%) of the highest-score entries (Q4). They also hold longest on average (43.4d vs 35.9d). Q4 trades exit on stop-loss 69.5% of the time vs 65.2% for Q1.
+
+This is a single-run observation, not a robust finding — but it's a meaningful signal that the **screener score is anti-predictive of trade outcome on this universe / period**. The score system is probably ranking on "Stage 2 momentum strength," and the strongest-momentum names are precisely the ones most prone to mean-revert hard before the trade matures.
+
+## Setup
+
+- **Source data**: `dev/backtest/scenarios-2026-05-10-215704/15y-cell-e-stage3-k1-laggard-h2/trades.csv` (510-symbol SP500 historical universe, 2010-01-01 to 2026-04-30, 2075 round-trips).
+- The canonical cell-E baseline at `dev/experiments/cell-e-15y-2026-05-07/trades.csv` (2090 trades, Sharpe 0.94) was rejected: its M5.2e audit columns (`entry_stage`, `entry_volume_ratio`, `stop_initial_distance_pct`, `screener_score_at_entry`) are all empty for every row, even though M5.2e was merged in #769 on 2026-05-02 before this 2026-05-07 backtest ran. The audit-writer did not flow data into that run; subsequent backtests from 2026-05-10+ do populate it.
+- Substitute run is the same scenario name (`15y-cell-e-stage3-k1-laggard-h2`), same universe and window, 2075 trades vs canonical's 2090 — within 1%. Sharpe is 0.70 vs the canonical's 0.94 — different by enough that this run is NOT a baseline-equivalent for absolute numbers, but the structural per-bucket conclusions (stage uniformity, score-quartile inversion) should generalize.
+- **Code**: `trading/analysis/scripts/hold_period_per_stage_analysis/hold_period_per_stage_analysis.ml`.
+- **Reproduce**:
+  ```
+  docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && \
+    eval $(opam env) && dune build analysis/scripts/hold_period_per_stage_analysis && \
+    _build/default/analysis/scripts/hold_period_per_stage_analysis/hold_period_per_stage_analysis.exe \
+    -trades /workspaces/trading-1/dev/backtest/scenarios-2026-05-10-215704/15y-cell-e-stage3-k1-laggard-h2/trades.csv'
+  ```
+
+## Exit-trigger composition is invariant across score quartiles
+
+| Bucket | Trigger | Count | % of bucket |
+|---|---|---:|---:|
+| Q1 (lowest) | stop_loss | 150 | 65.2 |
+| Q1 (lowest) | laggard_rotation | 63 | 27.4 |
+| Q1 (lowest) | stage3_force_exit | 16 | 7.0 |
+| Q2 | stop_loss | 493 | 65.3 |
+| Q2 | laggard_rotation | 214 | 28.3 |
+| Q2 | stage3_force_exit | 47 | 6.2 |
+| Q3 | stop_loss | 179 | 59.9 |
+| Q3 | laggard_rotation | 106 | 35.5 |
+| Q3 | stage3_force_exit | 14 | 4.7 |
+| Q4 (highest) | stop_loss | 550 | 69.5 |
+| Q4 (highest) | laggard_rotation | 209 | 26.4 |
+| Q4 (highest) | stage3_force_exit | 29 | 3.7 |
+
+The 60-70% stop_loss share holds across all 4 quartiles. Q4 (highest score) tilts a bit more stop_loss-heavy (69.5%); Q3 (mid-high score) tilts more laggard_rotation-heavy (35.5%). No quartile breaks the fast-churn pattern.
+
+## What this means for the plan
+
+1. **P4 as originally framed is closed.** Stage uniformity means there is no "Stage-3 entries to weed out" sub-population. The probe should be marked `done — falsified hypothesis` in the parent plan.
+
+2. **The screener score is a new lead.** Q1 vs Q4 mean-P&L of 1.71% vs 0.74% with the same exit-trigger composition is a 130 bp gap on identical-stage entries. That's strategy-relevant if it replicates on the canonical baseline. **Recommendation:** when the v2 Bayesian sweep finishes (PID 90733), re-run this same per-quartile analysis on its winning config's trade log to confirm. If the inversion holds, propose a follow-up experiment: **invert the score gate** (rank candidates ascending by screener_score for entry selection, capped at min_score=55 or similar).
+
+3. **Audit coverage gap discovered.** The canonical cell-E-15y-2026-05-07 trade log lacks audit columns. We should rerun that scenario (or pin a newer cell-E run that has audit on) before further per-trade decomposition work — otherwise every P1 / P3 / P5 follow-up has to use the 2026-05-10 substitute, which has a different Sharpe.
+
+## What this is NOT
+
+- Not a replacement for P1 (exit-trigger × P&L decomposition) — that still needs to be run. The exit-trigger numbers above are *within-bucket* composition, not the unconditional cross-tab P1 asks for.
+- Not a defense of the score-quartile-inversion finding as a tradeable signal until it replicates on a second backtest config.
+- Not a recommendation to drop the screener score: ranking still gives us 200-800 candidates per tick that filter to ~30 long entries. The finding only says the score is anti-predictive of *trade outcome conditional on entering* — that's a portfolio-construction signal, not a screener-replacement.

--- a/trading/analysis/scripts/hold_period_per_stage_analysis/dune
+++ b/trading/analysis/scripts/hold_period_per_stage_analysis/dune
@@ -1,0 +1,5 @@
+(executable
+ (name hold_period_per_stage_analysis)
+ (libraries core core_unix.command_unix)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/scripts/hold_period_per_stage_analysis/hold_period_per_stage_analysis.ml
+++ b/trading/analysis/scripts/hold_period_per_stage_analysis/hold_period_per_stage_analysis.ml
@@ -1,0 +1,218 @@
+(** hold_period_per_stage_analysis — Probe P4 from
+    [dev/plans/hold-period-deep-dive-2026-05-19.md].
+
+    Decomposes a backtest [trades.csv] by [entry_stage] (and optionally by
+    [screener_score_at_entry] quartile, since the cell-E run has uniform Stage 2
+    entries) and emits a Markdown table:
+
+    - count, P50 / P75 / P95 hold-days
+    - mean P&L %, win rate
+    - exit-trigger breakdown within each bucket
+
+    Pure analysis — no backtest reruns. Reads the CSV produced by
+    [Trading.Backtest.Result_writer]. Columns 1-based, schema is
+    [symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,
+     quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger,
+     entry_stage,entry_volume_ratio,stop_initial_distance_pct,
+     stop_trigger_kind,days_to_first_stop_trigger,screener_score_at_entry]. *)
+
+open Core
+
+type trade = {
+  days_held : int;
+  pnl_percent : float;
+  exit_trigger : string;
+  entry_stage : string; (* empty string when missing *)
+  screener_score : float option;
+}
+
+(* CSV column indices (0-based) for the fields we care about. The schema is
+   pinned by Trading.Backtest.Result_writer; if it changes, update here. *)
+let _col_days_held = 4
+let _col_pnl_percent = 9
+let _col_exit_trigger = 12
+let _col_entry_stage = 13
+let _col_screener_score = 18
+
+let _parse_row (fields : string array) : trade option =
+  if Array.length fields < 19 then None
+  else
+    let days_held =
+      try Some (Int.of_string fields.(_col_days_held)) with _ -> None
+    in
+    let pnl_percent =
+      try Some (Float.of_string fields.(_col_pnl_percent)) with _ -> None
+    in
+    match (days_held, pnl_percent) with
+    | Some d, Some p ->
+        let screener_score =
+          let raw = fields.(_col_screener_score) in
+          if String.is_empty raw then None
+          else try Some (Float.of_string raw) with _ -> None
+        in
+        Some
+          {
+            days_held = d;
+            pnl_percent = p;
+            exit_trigger = fields.(_col_exit_trigger);
+            entry_stage = fields.(_col_entry_stage);
+            screener_score;
+          }
+    | _ -> None
+
+let _load_trades ~path =
+  let lines = In_channel.read_lines path in
+  match lines with
+  | [] | [ _ ] -> []
+  | _header :: rows ->
+      List.filter_map rows ~f:(fun row ->
+          _parse_row (Array.of_list (String.split row ~on:',')))
+
+let _percentile (sorted : float array) ~p =
+  if Array.is_empty sorted then Float.nan
+  else
+    let n = Array.length sorted in
+    let idx = Float.iround_down_exn (p *. Float.of_int (n - 1)) in
+    sorted.(idx)
+
+type bucket_stats = {
+  n : int;
+  p50_hold : float;
+  p75_hold : float;
+  p95_hold : float;
+  mean_hold : float;
+  mean_pnl_pct : float;
+  win_rate : float;
+  by_trigger : (string * int) list;
+}
+
+let _stats_of_bucket (ts : trade list) : bucket_stats =
+  let n = List.length ts in
+  if n = 0 then
+    {
+      n;
+      p50_hold = Float.nan;
+      p75_hold = Float.nan;
+      p95_hold = Float.nan;
+      mean_hold = Float.nan;
+      mean_pnl_pct = Float.nan;
+      win_rate = Float.nan;
+      by_trigger = [];
+    }
+  else
+    let holds =
+      Array.of_list (List.map ts ~f:(fun t -> Float.of_int t.days_held))
+    in
+    Array.sort holds ~compare:Float.compare;
+    let pnls = List.map ts ~f:(fun t -> t.pnl_percent) in
+    let mean_pnl_pct = List.fold pnls ~init:0.0 ~f:( +. ) /. Float.of_int n in
+    let mean_hold = Array.fold holds ~init:0.0 ~f:( +. ) /. Float.of_int n in
+    let wins = List.count ts ~f:(fun t -> Float.( > ) t.pnl_percent 0.0) in
+    let by_trigger =
+      List.map ts ~f:(fun t -> t.exit_trigger)
+      |> List.sort ~compare:String.compare
+      |> List.group ~break:String.( <> )
+      |> List.map ~f:(fun group -> (List.hd_exn group, List.length group))
+      |> List.sort ~compare:(fun (_, a) (_, b) -> Int.compare b a)
+    in
+    {
+      n;
+      p50_hold = _percentile holds ~p:0.50;
+      p75_hold = _percentile holds ~p:0.75;
+      p95_hold = _percentile holds ~p:0.95;
+      mean_hold;
+      mean_pnl_pct;
+      win_rate = Float.of_int wins /. Float.of_int n *. 100.0;
+      by_trigger;
+    }
+
+let _group_by (ts : trade list) ~(key : trade -> string) :
+    (string * trade list) list =
+  ts
+  |> List.sort ~compare:(fun a b -> String.compare (key a) (key b))
+  |> List.group ~break:(fun a b -> String.( <> ) (key a) (key b))
+  |> List.map ~f:(fun group -> (key (List.hd_exn group), group))
+
+let _bucket_label_for_stage (t : trade) =
+  if String.is_empty t.entry_stage then "(missing)" else t.entry_stage
+
+let _score_quartile (score : float option) ~(thresholds : float * float * float)
+    =
+  let q25, q50, q75 = thresholds in
+  match score with
+  | None -> "(missing)"
+  | Some s ->
+      if Float.( < ) s q25 then "Q1 (lowest)"
+      else if Float.( < ) s q50 then "Q2"
+      else if Float.( < ) s q75 then "Q3"
+      else "Q4 (highest)"
+
+let _compute_score_thresholds (ts : trade list) =
+  let arr =
+    List.filter_map ts ~f:(fun t -> t.screener_score) |> Array.of_list
+  in
+  if Array.is_empty arr then (Float.nan, Float.nan, Float.nan)
+  else (
+    Array.sort arr ~compare:Float.compare;
+    (_percentile arr ~p:0.25, _percentile arr ~p:0.50, _percentile arr ~p:0.75))
+
+let _print_bucket_table ~title ~(buckets : (string * bucket_stats) list) =
+  printf "## %s\n\n" title;
+  printf
+    "| Bucket | N | P50 | P75 | P95 | Mean hold | Mean P&L %% | Win-rate %% |\n";
+  printf "|---|---:|---:|---:|---:|---:|---:|---:|\n";
+  List.iter buckets ~f:(fun (label, s) ->
+      printf "| %s | %d | %.0f | %.0f | %.0f | %.1f | %.2f | %.1f |\n" label s.n
+        s.p50_hold s.p75_hold s.p95_hold s.mean_hold s.mean_pnl_pct s.win_rate);
+  printf "\n"
+
+let _print_cross_tab ~(buckets : (string * bucket_stats) list) =
+  printf "### Exit-trigger breakdown within each bucket\n\n";
+  printf "| Bucket | Trigger | Count | %% of bucket |\n";
+  printf "|---|---|---:|---:|\n";
+  List.iter buckets ~f:(fun (label, s) ->
+      List.iter s.by_trigger ~f:(fun (trig, c) ->
+          let pct = Float.of_int c /. Float.of_int s.n *. 100.0 in
+          let trig_label = if String.is_empty trig then "(blank)" else trig in
+          printf "| %s | %s | %d | %.1f |\n" label trig_label c pct));
+  printf "\n"
+
+let _report ~trades_path =
+  let ts = _load_trades ~path:trades_path in
+  let total = List.length ts in
+  printf "# Hold-period per-stage analysis — Probe P4\n\n";
+  printf "Source: `%s` (%d trades)\n\n" trades_path total;
+  let by_stage =
+    _group_by ts ~key:_bucket_label_for_stage
+    |> List.map ~f:(fun (k, group) -> (k, _stats_of_bucket group))
+  in
+  _print_bucket_table ~title:"Per-stage hold distribution" ~buckets:by_stage;
+  _print_cross_tab ~buckets:by_stage;
+  let thresholds = _compute_score_thresholds ts in
+  let by_score =
+    _group_by ts ~key:(fun t -> _score_quartile t.screener_score ~thresholds)
+    |> List.map ~f:(fun (k, group) -> (k, _stats_of_bucket group))
+    |> List.sort ~compare:(fun (a, _) (b, _) -> String.compare a b)
+  in
+  let q25, q50, q75 = thresholds in
+  printf
+    "Screener-score quartile thresholds (when stage is uniform): Q25=%.1f, \
+     Q50=%.1f, Q75=%.1f\n\n"
+    q25 q50 q75;
+  _print_bucket_table
+    ~title:"Per-screener-score-quartile hold distribution (auxiliary)"
+    ~buckets:by_score;
+  _print_cross_tab ~buckets:by_score
+
+let _command =
+  Command.basic
+    ~summary:
+      "Decompose a backtest trades.csv by entry_stage (P4) and by \
+       screener-score quartile, emit a Markdown report on hold-distribution \
+       and exit-trigger composition per bucket."
+    (let%map_open.Command trades_path =
+       flag "-trades" (required string) ~doc:"PATH backtest trades.csv"
+     in
+     fun () -> _report ~trades_path)
+
+let () = Command_unix.run _command

--- a/trading/devtools/checks/linter_exceptions.conf
+++ b/trading/devtools/checks/linter_exceptions.conf
@@ -38,3 +38,4 @@ nesting devtools/ppx_test_matcher  ppxlib AST construction is inherently nested 
 nesting analysis/scripts/universe_filter  CSV parsing + multi-rule sexp pattern matching inherently nests; splitting each branch into helpers doubles the code without improving readability  # review_at: never (operator script)
 nesting analysis/scripts/fetch_finviz_sectors  HTTP fetch + HTML parsing + manifest I/O inherently nests; these are one-shot operator scripts not hot-path code  # review_at: never (operator script)
 nesting analysis/scripts/shiller_weinstein_decades  one-shot analysis script (M1 cross-cycle plan); CSV parsing + degenerate-input guards in compute helpers; no hot-path callers  # review_at: never (analysis script)
+nesting analysis/scripts/hold_period_per_stage_analysis  one-shot analysis script (P4 hold-period probe); CSV parser handles 10+ optional columns; no hot-path callers  # review_at: never (analysis script)


### PR DESCRIPTION
## Summary

Probe P4 from `dev/plans/hold-period-deep-dive-2026-05-19.md` — decomposes the cell-E 15y trade log by `entry_stage` and emits per-bucket hold/P&L/win-rate/exit-trigger stats. Pure analysis, no backtest reruns.

## Headline findings

- **P4 hypothesis falsified**: 100% of 2075 cell-E entries are `Stage2` (zero Stage1 / Stage2_late / Stage3 / Stage4). The screener cascade filters perfectly to Stage 2. Therefore the 600 laggard-rotation trades are NOT catching mis-classified-by-stage entries; whatever separates them from the 1382 stop-loss trades lives downstream of the stage gate.
- **Pivoted-axis surprise (auxiliary)**: when bucketing the same trades by `screener_score_at_entry` quartile, the relationship is INVERSE — Q1 (lowest score) trades deliver **2.3x the mean P&L (1.71% vs 0.74%)** and 8.8pp higher win-rate (42.6% vs 33.8%) than Q4 (highest score). One-run observation, recommended replication on v2 Bayesian-sweep winner.
- **Data-coverage gap discovered**: the canonical `dev/experiments/cell-e-15y-2026-05-07/trades.csv` has empty M5.2e audit columns despite being generated 5 days after #769 merged. We had to substitute `dev/backtest/scenarios-2026-05-10-215704/15y-cell-e-stage3-k1-laggard-h2/trades.csv` (same scenario, 2075 vs 2090 trades, Sharpe 0.70 vs 0.94). Recommendation: rerun cell-E with audit on, pin the result.

## What's in the diff

- `trading/analysis/scripts/hold_period_per_stage_analysis/{dune,hold_period_per_stage_analysis.ml}` — single-file OCaml exe (~220 LOC), reads trades.csv, prints Markdown report.
- `dev/notes/hold-period-p4-per-stage-2026-05-20.md` — full writeup with setup, tables, falsification statement, and follow-up recommendations.

## Test plan

- [x] `dune build analysis/scripts/hold_period_per_stage_analysis` — green
- [x] `dune build` (full) — green (exit 0)
- [x] `dune build @fmt` — green
- [x] Executable runs and produces tables on the substitute cell-E trade log (2075 trades parsed, all columns covered)
- [x] All functions under 50 LOC per `.claude/rules/ocaml-patterns.md`
- [x] No new Python (`.claude/rules/no-python.md`)
- [x] No analysis/ → trading/ imports introduced; this exe is under trading/analysis/scripts/ which is the established home for one-off analysis tools