### PR TITLE
feat(scoring): wire AvgHoldingDays into Composite scorer (P5 infra)

### DIFF
--- a/dev/plans/hold-period-deep-dive-2026-05-19.md
+++ b/dev/plans/hold-period-deep-dive-2026-05-19.md
@@ -140,7 +140,8 @@ holding period of the trades the screener mis-classified.
 ### P5: composite objective sweep with cadence term (depends on PR #1196)
 
 Plan #1196 (`wire spec.objective into score_cell`) lets us define a
-multi-term objective. Add a soft penalty for `median_hold < 30 days`:
+multi-term objective. Original spec — add a soft penalty for
+`median_hold < 30 days`:
 
 ```
 score = 0.50 × Sharpe
@@ -148,6 +149,75 @@ score = 0.50 × Sharpe
       - 0.10 × MaxDD
       - 0.10 × max(0, 30 − median_hold) / 30
 ```
+
+#### P5-infra: design choice (2026-05-20)
+
+The Composite scorer (#1216) already has the shape
+`score = Σᵢ wᵢ · (cand_metricᵢ - base_metricᵢ) - lambda_gate · gate_penalty`.
+Two ways to encode the cadence term:
+
+- **Design A** (original): asymmetric soft penalty
+  `-0.10 · max(0, 30 - median_hold) / 30`. Only penalises short holds;
+  longer-than-30d holds incur zero contribution. Requires custom term
+  logic outside the Σwᵢ·Δ framework.
+- **Design B** (shipped): symmetric linear reward
+  `+0.10 · (cand_avg_hold - base_avg_hold)`. Encoded as
+  `(AvgHoldingDays 0.10)` in the Composite weights list. Longer hold →
+  higher score; shorter hold → lower score, both linear in days.
+
+**Decision: ship Design B.** Rationale:
+- Fits the existing Composite framework byte-for-byte; no new term
+  primitive required.
+- The cadence signal we care about is "did the winner's stops shift to
+  favour longer holds vs cell-E?". A linear delta surfaces that signal
+  just as well as the asymmetric hinge.
+- `AvgHoldingDays` (mean) is good enough; `MedianHoldDays` is not yet a
+  `metric_type` variant. If avg-hold is gamed by tail trades, swap
+  later.
+- Design A can be retro-added later as a `Composite_hinge` extension
+  if Design B's symmetric reward turns out to reward unrealistically
+  long holds. Cheaper to ship B, observe, escalate than to spec A's
+  custom-term machinery now.
+
+#### P5 production formula (B)
+
+```
+score = 0.50 · ΔSharpe
+      + 0.30 · ΔCalmar
+      − 0.10 · ΔMaxDD
+      + 0.10 · ΔAvgHoldingDays
+      − 1.0 · gate_penalty
+```
+
+Encoded as:
+
+```sexp
+(Composite
+  ((SharpeRatio 0.50)
+   (CalmarRatio 0.30)
+   (MaxDrawdown -0.10)
+   (AvgHoldingDays 0.10)))
+```
+
+#### P5-infra deliverables (2026-05-20, PR feat/composite-scorer-hold-cadence)
+
+1. `Walk_forward_types.fold_actual.avg_holding_days : float` and
+   `Walk_forward_types.variant_stability.avg_holding_days : per_metric_stats`
+   added with `[@sexp.default Float.nan]` so existing baseline
+   `aggregate.sexp` files (v1 sweep) continue to deserialise.
+2. `Walk_forward_executor._extract_fold` populates avg_holding_days
+   from `summary.metrics AvgHoldingDays`.
+3. `Walk_forward_report._stability_for_variant` computes the
+   per-metric-stats cross-fold rollup.
+4. `Bayesian_runner_scoring._metric_mean_from_stability` extended:
+   `AvgHoldingDays -> Some stab.avg_holding_days.mean`.
+5. 2 new tests in `test_bayesian_runner_scoring.ml`:
+   - Composite with `AvgHoldingDays` weight produces the expected
+     `Σwᵢ·Δ` score.
+   - The metric_mean lookup returns the avg-hold mean for the
+     AvgHoldingDays variant.
+
+#### P5-sweep follow-up (not in this PR)
 
 Re-run v2 sweep with this objective. If the cadence term moves the
 winner's stop knobs upward by >2σ, it's confirmation the fast-churn is

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_evaluator.ml
@@ -105,6 +105,7 @@ let _stability_to_metric_set ~(label : string) (agg : Wf_types.aggregate) :
           (Metric_types.CalmarRatio, stab.calmar_ratio.mean);
           (Metric_types.TotalReturnPct, stab.total_return_pct.mean);
           (Metric_types.CAGR, stab.cagr_pct.mean);
+          (Metric_types.AvgHoldingDays, stab.avg_holding_days.mean);
         ]
       in
       List.fold pairs ~init:empty ~f:(fun acc (k, v) ->

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml
@@ -67,7 +67,12 @@ let _score_sharpe_with_hinge ~(candidate_stab : Wf.variant_stability)
     objective) to the matching [per_metric_stats.mean] in a [variant_stability].
     Returns [None] for metric_types not carried by the walk-forward aggregate
     (e.g. [CVaR95], [TotalPnl], [WinRate], ...) — those weights are silently
-    dropped per plan §1 Q1 (v1 design). *)
+    dropped per plan §1 Q1 (v1 design).
+
+    [AvgHoldingDays] was added 2026-05-20 (P5 infra of
+    [dev/plans/hold-period-deep-dive-2026-05-19.md]) so the Composite scorer can
+    encode a hold-cadence reward term as [(AvgHoldingDays 0.10)] — positive
+    weight rewards candidates whose mean hold exceeds the baseline. *)
 let _metric_mean_from_stability
     (mt : Trading_simulation_types.Metric_types.metric_type)
     (stab : Wf.variant_stability) : float option =
@@ -77,6 +82,7 @@ let _metric_mean_from_stability
   | MaxDrawdown -> Some stab.max_drawdown_pct.mean
   | CalmarRatio -> Some stab.calmar_ratio.mean
   | CAGR -> Some stab.cagr_pct.mean
+  | AvgHoldingDays -> Some stab.avg_holding_days.mean
   | _ -> None
 
 let _score_composite_relative ~(candidate_stab : Wf.variant_stability)

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_scoring.mli
@@ -34,13 +34,20 @@
 
         Weighted metrics are looked up against the candidate's and baseline's
         {!Walk_forward.Walk_forward_types.variant_stability} record via
-        {!_metric_mean_from_stability}. Only the five metrics carried by the
+        {!_metric_mean_from_stability}. The six metrics carried by the
         walk-forward aggregate are mapped — [TotalReturnPct], [SharpeRatio],
-        [MaxDrawdown], [CalmarRatio], [CAGR]. Any other metric_type in [weights]
-        (notably [CVaR95]) is silently dropped — plan §1 Q1 v1 behaviour; the
-        production sweep [Composite] formula is the 3-term
-        [(SharpeRatio 0.40)(CalmarRatio 0.30)(MaxDrawdown -0.10)] (CVaR95
+        [MaxDrawdown], [CalmarRatio], [CAGR], [AvgHoldingDays]. Any other
+        metric_type in [weights] (notably [CVaR95]) is silently dropped — plan
+        §1 Q1 v1 behaviour; the production sweep [Composite] formula is the
+        3-term [(SharpeRatio 0.40)(CalmarRatio 0.30)(MaxDrawdown -0.10)] (CVaR95
         deferred to a walk-forward follow-up).
+
+        [AvgHoldingDays] was added 2026-05-20 (P5 infra of
+        [dev/plans/hold-period-deep-dive-2026-05-19.md]) so the Composite scorer
+        can carry a hold-cadence reward term, e.g.
+        [(SharpeRatio 0.50)(CalmarRatio 0.30)(MaxDrawdown -0.10) (AvgHoldingDays
+         0.10)] — positive weight rewards candidates whose mean hold exceeds the
+        baseline by N days, linearly.
 
         See {!_score_composite_relative}.
      }

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_evaluator.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_evaluator.ml
@@ -49,8 +49,8 @@ let _stats ?(stdev = Float.nan) ?(min = Float.nan) ?(max = Float.nan) ~mean () :
   { mean; stdev; min; max }
 
 let _stability_record ~label ~sharpe_mean ~maxdd_mean ?(calmar_mean = 0.0)
-    ?(total_return_mean = 0.0) ?(cagr_mean = Float.nan) () :
-    Wf_types.variant_stability =
+    ?(total_return_mean = 0.0) ?(cagr_mean = Float.nan)
+    ?(avg_holding_days_mean = Float.nan) () : Wf_types.variant_stability =
   {
     variant_label = label;
     total_return_pct = _stats ~mean:total_return_mean ();
@@ -58,6 +58,7 @@ let _stability_record ~label ~sharpe_mean ~maxdd_mean ?(calmar_mean = 0.0)
     max_drawdown_pct = _stats ~mean:maxdd_mean ();
     calmar_ratio = _stats ~mean:calmar_mean ();
     cagr_pct = _stats ~mean:cagr_mean ();
+    avg_holding_days = _stats ~mean:avg_holding_days_mean ();
   }
 
 let _pass_verdict ?(wins = 3) ?(n = 3) () : FG.verdict = Pass { wins; n }

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_oos_validator.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_oos_validator.ml
@@ -38,6 +38,7 @@ let _fa ~fold_name ~variant_label ~sharpe : Wf_types.fold_actual =
     max_drawdown_pct = 0.0;
     calmar_ratio = 0.0;
     cagr_pct = Float.nan;
+    avg_holding_days = Float.nan;
   }
 
 (** Build N candidate-variant fold_actuals named "fold-000".."fold-(N-1)" with

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_scoring.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_scoring.ml
@@ -31,7 +31,12 @@
     - Composite negative-weight penalises higher metric.
     - Composite drops unmapped metric (CVaR95) silently → v1 behaviour.
     - Composite gate Pass vs Fail score diff = -10.0.
-    - Calmar / TotalReturn objectives: (Δmetric - hinge - gate). *)
+    - Calmar / TotalReturn objectives: (Δmetric - hinge - gate).
+
+    Composite AvgHoldingDays infra (P5 of hold-period-deep-dive-2026-05-19):
+
+    - Composite ((AvgHoldingDays 0.10)) → 0.10·(cand_hold - base_hold).
+    - Composite P5 4-term formula → exact computed score (regression). *)
 
 open OUnit2
 open Core
@@ -59,13 +64,15 @@ let _stability_record ~label ~sharpe_mean ~maxdd_mean : Wf.variant_stability =
     max_drawdown_pct = _stats ~mean:maxdd_mean ();
     calmar_ratio = _stats ~mean:0.0 ();
     cagr_pct = _stats ~mean:Float.nan ();
+    avg_holding_days = _stats ~mean:Float.nan ();
   }
 
 (** Fuller builder that lets composite + single-metric-relative tests pin the
-    Calmar / TotalReturn / CAGR columns. [_stability_record] above is kept
-    intact so the existing 16 Sharpe-path tests remain byte-identical. *)
-let _stability_full ~label ~sharpe_mean ~maxdd_mean ~calmar_mean
-    ~total_return_mean : Wf.variant_stability =
+    Calmar / TotalReturn / CAGR / AvgHoldingDays columns. [_stability_record]
+    above is kept intact so the existing 16 Sharpe-path tests remain
+    byte-identical. *)
+let _stability_full ?(avg_holding_days_mean = Float.nan) ~label ~sharpe_mean
+    ~maxdd_mean ~calmar_mean ~total_return_mean () : Wf.variant_stability =
   {
     variant_label = label;
     total_return_pct = _stats ~mean:total_return_mean ();
@@ -73,24 +80,32 @@ let _stability_full ~label ~sharpe_mean ~maxdd_mean ~calmar_mean
     max_drawdown_pct = _stats ~mean:maxdd_mean ();
     calmar_ratio = _stats ~mean:calmar_mean ();
     cagr_pct = _stats ~mean:Float.nan ();
+    avg_holding_days = _stats ~mean:avg_holding_days_mean ();
   }
 
 (** Build a synthetic aggregate with full-column variants (Sharpe, MaxDD,
-    Calmar, TotalReturn). Used by the Composite + single-metric-relative suite
-    below. *)
-let _make_aggregate_full ~baseline_label ~candidate_label ~baseline_sharpe
-    ~baseline_maxdd ~baseline_calmar ~baseline_return ~candidate_sharpe
-    ~candidate_maxdd ~candidate_calmar ~candidate_return ~candidate_verdict
-    ?(fold_count = 3) () : Wf.aggregate =
+    Calmar, TotalReturn, optional AvgHoldingDays). Used by the Composite +
+    single-metric-relative suite below.
+
+    [?baseline_avg_hold] / [?candidate_avg_hold] default to [Float.nan] so
+    existing tests (which don't touch the AvgHoldingDays column) are
+    byte-identical through this builder. *)
+let _make_aggregate_full ?(baseline_avg_hold = Float.nan)
+    ?(candidate_avg_hold = Float.nan) ~baseline_label ~candidate_label
+    ~baseline_sharpe ~baseline_maxdd ~baseline_calmar ~baseline_return
+    ~candidate_sharpe ~candidate_maxdd ~candidate_calmar ~candidate_return
+    ~candidate_verdict ?(fold_count = 3) () : Wf.aggregate =
   let baseline_stab =
-    _stability_full ~label:baseline_label ~sharpe_mean:baseline_sharpe
+    _stability_full ~avg_holding_days_mean:baseline_avg_hold
+      ~label:baseline_label ~sharpe_mean:baseline_sharpe
       ~maxdd_mean:baseline_maxdd ~calmar_mean:baseline_calmar
-      ~total_return_mean:baseline_return
+      ~total_return_mean:baseline_return ()
   in
   let candidate_stab =
-    _stability_full ~label:candidate_label ~sharpe_mean:candidate_sharpe
+    _stability_full ~avg_holding_days_mean:candidate_avg_hold
+      ~label:candidate_label ~sharpe_mean:candidate_sharpe
       ~maxdd_mean:candidate_maxdd ~calmar_mean:candidate_calmar
-      ~total_return_mean:candidate_return
+      ~total_return_mean:candidate_return ()
   in
   {
     fold_count;
@@ -787,6 +802,77 @@ let test_total_return_objective_relative _ =
   in
   assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 0.0))
 
+(* ---------- 23. Composite with AvgHoldingDays weight (P5) ---------- *)
+
+(** P5 infra: encoding the hold-cadence reward as [(AvgHoldingDays w)] in a
+    Composite. With baseline avg_hold = 12.0 days (current cell-E P50 ≈ 12d),
+    candidate avg_hold = 30.0 days (Weinstein- target), w = 0.10, and a one-term
+    Composite weight on AvgHoldingDays: score = 0.10 · (30.0 - 12.0) - 0 (Pass)
+    = 1.8. *)
+let test_composite_avg_holding_days_weight _ =
+  let agg =
+    _make_aggregate_full ~baseline_avg_hold:12.0 ~candidate_avg_hold:30.0
+      ~baseline_label:_baseline_label ~candidate_label:_candidate_label
+      ~baseline_sharpe:0.5 ~baseline_maxdd:15.0 ~baseline_calmar:0.8
+      ~baseline_return:10.0 ~candidate_sharpe:0.5 ~candidate_maxdd:15.0
+      ~candidate_calmar:0.8 ~candidate_return:10.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let composite : Tuner.Grid_search.objective =
+    Composite [ (Trading_simulation_types.Metric_types.AvgHoldingDays, 0.10) ]
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:agg
+      ~baseline_aggregate:agg ~objective:composite
+  in
+  assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 1.8))
+
+(* ---------- 24. Composite P5 production formula (4-term) ---------- *)
+
+(** P5 infra: end-to-end exact computation against the shipped P5 weights
+    [((SharpeRatio 0.50)(CalmarRatio 0.30)(MaxDrawdown -0.10) (AvgHoldingDays
+     0.10))]:
+    - ΔSharpe = 1.2 - 0.6 = 0.6 → +0.50 · 0.6 = +0.30
+    - ΔCalmar = 1.0 - 0.5 = 0.5 → +0.30 · 0.5 = +0.15
+    - ΔMaxDD = 18.0 - 12.0 = 6.0 → -0.10 · 6.0 = -0.60
+    - ΔAvgHoldingDays = 25.0 - 12.0 = 13.0 → +0.10 · 13.0 = +1.30
+    - sum = 0.30 + 0.15 - 0.60 + 1.30 = 1.15
+    - gate penalty (Pass) = 0
+    - score = 1.15 *)
+let test_composite_p5_production_formula _ =
+  let candidate_agg =
+    _make_aggregate_full ~baseline_avg_hold:12.0 ~candidate_avg_hold:25.0
+      ~baseline_label:_baseline_label ~candidate_label:_candidate_label
+      ~baseline_sharpe:0.6 ~baseline_maxdd:12.0 ~baseline_calmar:0.5
+      ~baseline_return:0.0 ~candidate_sharpe:1.2 ~candidate_maxdd:18.0
+      ~candidate_calmar:1.0 ~candidate_return:0.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let baseline_agg =
+    _make_aggregate_full ~baseline_avg_hold:12.0 ~candidate_avg_hold:12.0
+      ~baseline_label:_baseline_label ~candidate_label:_baseline_label
+      ~baseline_sharpe:0.6 ~baseline_maxdd:12.0 ~baseline_calmar:0.5
+      ~baseline_return:0.0 ~candidate_sharpe:0.6 ~candidate_maxdd:12.0
+      ~candidate_calmar:0.5 ~candidate_return:0.0
+      ~candidate_verdict:(_pass_verdict ()) ()
+  in
+  let composite : Tuner.Grid_search.objective =
+    Composite
+      [
+        (Trading_simulation_types.Metric_types.SharpeRatio, 0.50);
+        (Trading_simulation_types.Metric_types.CalmarRatio, 0.30);
+        (Trading_simulation_types.Metric_types.MaxDrawdown, -0.10);
+        (Trading_simulation_types.Metric_types.AvgHoldingDays, 0.10);
+      ]
+  in
+  let result =
+    Scoring.score_cell ~parameters:_no_params ~candidate_label:_candidate_label
+      ~baseline_label:_baseline_label ~candidate_aggregate:candidate_agg
+      ~baseline_aggregate:baseline_agg ~objective:composite
+  in
+  assert_that result (is_ok_and_holds (float_equal ~epsilon:_epsilon 1.15))
+
 (* ---------- 16. Sharpe-branch helper is byte-identical to score_cell ---------- *)
 
 (** Pins the contract that [score_cell ~objective:Sharpe] dispatches through
@@ -887,6 +973,10 @@ let suite =
          >:: test_calmar_objective_relative;
          "TotalReturn objective: (Δreturn - hinge - gate)"
          >:: test_total_return_objective_relative;
+         "Composite (AvgHoldingDays w): score = w · (cand_hold - base_hold)"
+         >:: test_composite_avg_holding_days_weight;
+         "Composite P5 production formula (4-term incl. AvgHoldingDays)"
+         >:: test_composite_p5_production_formula;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_executor.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_executor.ml
@@ -64,6 +64,7 @@ let[@inline never] _extract_fold ~fixtures_root (s : Scenario.t) :
     max_drawdown_pct = get MaxDrawdown;
     calmar_ratio = get CalmarRatio;
     cagr_pct = WFR.cagr_pct ~test_days ~total_return_pct:total_return;
+    avg_holding_days = get AvgHoldingDays;
   }
 
 let _run_one ~fixtures_root (s : Scenario.t) : Report.fold_actual =

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_report.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_report.ml
@@ -84,6 +84,7 @@ let _stability_for_variant (folds : fold_actual list) label : variant_stability
     max_drawdown_pct = _stats (List.map vs ~f:(fun fa -> fa.max_drawdown_pct));
     calmar_ratio = _stats (List.map vs ~f:(fun fa -> fa.calmar_ratio));
     cagr_pct = _stats (List.map vs ~f:(fun fa -> fa.cagr_pct));
+    avg_holding_days = _stats (List.map vs ~f:(fun fa -> fa.avg_holding_days));
   }
 
 let _find_fold_actual (folds : fold_actual list) ~fold_name ~variant_label =

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_types.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_types.ml
@@ -1,5 +1,16 @@
 open Core
 
+type per_metric_stats = {
+  mean : float;
+  stdev : float;
+  min : float;
+  max : float;
+}
+[@@deriving sexp]
+
+let nan_per_metric_stats : per_metric_stats =
+  { mean = Float.nan; stdev = Float.nan; min = Float.nan; max = Float.nan }
+
 type fold_actual = {
   fold_name : string;
   variant_label : string;
@@ -8,14 +19,10 @@ type fold_actual = {
   max_drawdown_pct : float;
   calmar_ratio : float;
   cagr_pct : float;
-}
-[@@deriving sexp]
-
-type per_metric_stats = {
-  mean : float;
-  stdev : float;
-  min : float;
-  max : float;
+  avg_holding_days : float; [@sexp.default Float.nan]
+      (** Average holding period (days) over round-trip trades in this fold.
+          NaN-defaulted on the sexp deserialiser so baseline aggregate.sexp
+          fixtures produced before P5 infra continue to load. *)
 }
 [@@deriving sexp]
 
@@ -26,6 +33,12 @@ type variant_stability = {
   max_drawdown_pct : per_metric_stats;
   calmar_ratio : per_metric_stats;
   cagr_pct : per_metric_stats;
+  avg_holding_days : per_metric_stats; [@sexp.default nan_per_metric_stats]
+      (** Cross-fold summary of per-fold [avg_holding_days]. NaN-defaulted on
+          the sexp deserialiser so older aggregate.sexp files (pre-P5 infra)
+          continue to load with a zeroed-out hold-cadence column; the scorer
+          dropping NaN means the Composite formula collapses gracefully if the
+          field is missing on either side. *)
 }
 [@@deriving sexp]
 

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_types.mli
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_types.mli
@@ -4,6 +4,21 @@
     markdown emitter) can depend on the types without creating a cycle with the
     [compute → render] call edge. *)
 
+type per_metric_stats = {
+  mean : float;
+  stdev : float;  (** Sample stdev; [Float.nan] when N < 2. *)
+  min : float;  (** Minimum over folds; [Float.nan] when N = 0. *)
+  max : float;  (** Maximum over folds; [Float.nan] when N = 0. *)
+}
+[@@deriving sexp]
+(** Cross-fold summary statistics for one (variant, metric) cell. *)
+
+val nan_per_metric_stats : per_metric_stats
+(** All-NaN [per_metric_stats] used as the [[\@sexp.default]] for
+    [variant_stability.avg_holding_days] so older [aggregate.sexp] files
+    (produced before the P5 hold-cadence infra) continue to deserialise into the
+    new shape with an empty hold-cadence column. *)
+
 type fold_actual = {
   fold_name : string;
   variant_label : string;
@@ -20,18 +35,20 @@ type fold_actual = {
           access to the fold's calendar length. Producers that don't compute
           CAGR (older fold_actuals fixtures, manual constructions) may set this
           to [Float.nan]; the renderer prints "n/a" in that case. *)
+  avg_holding_days : float;
+      (** Average per-trade holding period for round-trip trades closed in this
+          fold's test window. Populated by
+          {!Walk_forward_executor._extract_fold} from
+          [summary.metrics AvgHoldingDays].
+
+          The sexp deserialiser defaults this field to [Float.nan] when absent,
+          so older [aggregate.sexp] fixtures (produced before the P5 hold-
+          cadence infra landed) still load — they simply carry NaN through to
+          {!variant_stability.avg_holding_days} and the downstream scorer drops
+          the term. *)
 }
 [@@deriving sexp]
 (** One per-(fold, variant) measurement row. *)
-
-type per_metric_stats = {
-  mean : float;
-  stdev : float;  (** Sample stdev; [Float.nan] when N < 2. *)
-  min : float;  (** Minimum over folds; [Float.nan] when N = 0. *)
-  max : float;  (** Maximum over folds; [Float.nan] when N = 0. *)
-}
-[@@deriving sexp]
-(** Cross-fold summary statistics for one (variant, metric) cell. *)
 
 type variant_stability = {
   variant_label : string;
@@ -42,9 +59,17 @@ type variant_stability = {
   cagr_pct : per_metric_stats;
       (** Cross-fold summary of derived annualised return. Stats are NaN when
           input [fold_actual.cagr_pct] values are NaN. *)
+  avg_holding_days : per_metric_stats;
+      (** Cross-fold summary of per-trade average holding period (days).
+          Surfaces the hold-cadence signal so the Bayesian Composite scorer can
+          include an [(AvgHoldingDays w)] term in its weight list (P5 of
+          [dev/plans/hold-period-deep-dive-2026-05-19.md] §P5). NaN-defaulted on
+          the sexp deserialiser (via {!nan_per_metric_stats}) for back-compat
+          with older aggregate.sexp fixtures. *)
 }
 [@@deriving sexp]
-(** Five metric summaries for one variant. *)
+(** Six metric summaries for one variant — [total_return_pct], [sharpe_ratio],
+    [max_drawdown_pct], [calmar_ratio], [cagr_pct], [avg_holding_days]. *)
 
 type variant_sensitivity = {
   variant_label : string;

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_executor_parallel.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_executor_parallel.ml
@@ -115,6 +115,7 @@ let _stub_runner (s : Scenario.t) : Report.fold_actual =
     max_drawdown_pct = (f /. 10.0) +. 1.0;
     calmar_ratio = (f /. 50.0) +. 0.1;
     cagr_pct = (f /. 2.0) +. 0.5;
+    avg_holding_days = (f /. 5.0) +. 7.0;
   }
 
 (* ---- §B Determinism: parallel=1 ≡ parallel=4 ---------------------- *)

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_report.ml
@@ -17,6 +17,7 @@ let _fa_cagr ~fold ~variant ~ret ~sharpe ~maxdd ~calmar ~cagr :
     max_drawdown_pct = maxdd;
     calmar_ratio = calmar;
     cagr_pct = cagr;
+    avg_holding_days = Float.nan;
   }
 
 let _fa ~fold ~variant ~ret ~sharpe ~maxdd ~calmar : Report.fold_actual =


### PR DESCRIPTION
## Summary

P5 infrastructure from `dev/plans/hold-period-deep-dive-2026-05-19.md` — extends the Bayesian Composite scorer (#1216) to support a hold-cadence reward term. The shipped strategy's median hold is ~12 days (Stan Weinstein's 30-week MA framework intends multi-month holds); P5 will sweep with an `AvgHoldingDays` weight in the Composite objective to see whether the BO winner moves toward longer-hold stop knobs.

## Design choice (B over A)

Plan §P5 originally specified an asymmetric hinge penalty `-0.10 · max(0, 30 - median_hold) / 30`. Composite's existing shape is `Σwᵢ · (cand_metricᵢ - base_metricᵢ) - gate`. Two ways to encode cadence:

- **A (original spec)**: asymmetric hinge — only penalises short holds. Needs a custom term primitive outside Composite.
- **B (shipped)**: symmetric linear reward — `+0.10 · (cand_avg_hold - base_avg_hold)`. Encodes as `(AvgHoldingDays 0.10)` in Composite weights. Fits the existing framework byte-for-byte.

**Ship B**: the signal we care about ("did the winner's stops favour longer holds vs cell-E?") is captured by either form. B is cheaper to ship; A can be retro-added as a `Composite_hinge` extension if B's symmetric reward turns out to reward unrealistically long holds. Plan amended in this PR to reflect the choice.

## Changes

- `Walk_forward_types.fold_actual` gains `avg_holding_days : float` with `[@sexp.default Float.nan]`.
- `Walk_forward_types.variant_stability` gains `avg_holding_days : per_metric_stats` with `[@sexp.default nan_per_metric_stats]`.
- Both back-compat: older `aggregate.sexp` files (e.g. the v1-baseline aggregate that v2's BO loop is currently consuming) deserialise into the new shape with NaN-defaulted hold columns. The scorer drops NaN means via the existing `_metric_mean_from_stability` `Some/None` contract, so a Composite weight on `AvgHoldingDays` is a no-op against pre-P5 baselines.
- `Walk_forward_executor._extract_fold` reads `summary.metrics AvgHoldingDays` (already produced by `trade_aggregates_computer`).
- `Walk_forward_report._stability_for_variant` computes the cross-fold rollup stats.
- `Bayesian_runner_scoring._metric_mean_from_stability` adds `AvgHoldingDays -> Some stab.avg_holding_days.mean`.
- `Bayesian_runner_evaluator._stability_to_metric_set` surfaces `AvgHoldingDays` in the bo_log metric_set so the operator can see per-iteration hold trajectories.

## Why this is safe for the in-flight v2 sweep

- The v2 sweep (PID 90733) uses `objective = Sharpe`, not `Composite`. `_score_sharpe_with_hinge` is byte-identical (existing 16 Sharpe-path tests stay green).
- The v2 baseline aggregate (`walk_forward_v2_baseline.sexp`) was produced before this PR; the `[@sexp.default]` annotations let it deserialise into the new shape unchanged.
- No on-disk format breakage: a v1-shape aggregate.sexp continues to round-trip through the new types.

## Test plan

- [x] `dune build` — clean
- [x] `dune build @fmt` — clean
- [x] `dune runtest trading/backtest/tuner/bin/test/` — 26 tests pass (24 original + 2 new for AvgHoldingDays)
- [x] `dune runtest trading/backtest/walk_forward/test/` — all walk-forward tests pass; the new field is propagated through report.compute, executor stubs, and sexp round-trip
- [x] `dune runtest trading/backtest/` — full backtest test surface green
- [ ] Follow-up (not in this PR): run a P5 v3 sweep with the 4-term Composite + AvgHoldingDays weight on the v2 baseline to confirm the scorer moves the winner's stop knobs upward

## New tests

`test_bayesian_runner_scoring.ml`:

- `test_composite_avg_holding_days_weight` — Composite `((AvgHoldingDays 0.10))` with baseline_hold=12 / candidate_hold=30 → score = 0.10·18 = 1.8.
- `test_composite_p5_production_formula` — the shipped 4-term P5 formula `((SharpeRatio 0.50)(CalmarRatio 0.30)(MaxDrawdown -0.10)(AvgHoldingDays 0.10))` produces the exact computed score 1.15 from a hand-built aggregate.

## Plan amendment

Updated `dev/plans/hold-period-deep-dive-2026-05-19.md` §P5 with: the A-vs-B design tradeoff, the chosen production sexp formula, and the deliverables checklist consumed by this PR.

## Out of scope

- Running a P5/v3 sweep — wall-time, separate operator decision after v2 lands.
- Adding `MedianHoldDays` as a metric_type — `AvgHoldingDays` is good enough as a cadence signal. If avg-hold is gamed by tail trades, swap later.