### PR TITLE
ops: daily orchestrator summary 2026-05-20-run2

### DIFF
--- a/dev/budget/2026-05-20-26165048704.json
+++ b/dev/budget/2026-05-20-26165048704.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-05-20-26165048704",
+  "timestamp": "2026-05-20T13:23:21Z",
+  "commit_sha": "6b7cff4545a34cab84584726d15b3236dd835473",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 2.1149,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/daily/2026-05-20-run2.md
+++ b/dev/daily/2026-05-20-run2.md
@@ -1,0 +1,108 @@
+# Status — 2026-05-20 [run 2]
+
+**Run ID:** 2026-05-20-run-2
+**Generated:** 2026-05-20T13:21Z
+**HEAD at run start:** `6b7cff45` (`feat(scoring): wire AvgHoldingDays into Composite scorer (P5 infra) (#1220)`, tip of `main`).
+**Mode:** NO-OP (saturated-queue fast-exit)
+
+## Saturated-queue check result
+
+All four Step 0.5 conditions passed — no dispatch this run:
+
+- **Condition 1** PASS — **0 open PRs** at run start (verified via REST `GET /repos/${OWNER}/${REPO}/pulls?state=open`). Trivially satisfied — no PRs to compare `tip_sha` against `Reviewed_SHA`. Review queue fully drained (run-1's ops PR #1218 merged at 2026-05-20T08:42:51Z; the only two non-ops commits since are maintainer-direct merges that did not pass through an open-PR window in this orchestrator's view).
+- **Condition 2** PASS — 0 non-`ops:` commits touching `dev/status/*.md` since prior summary `0ddb5252 ops: daily orchestrator summary 2026-05-20 (#1218)` at 2026-05-20T08:42:51Z. Two substantive PRs landed in the ~4.6h window (see Context below) — neither touched per-track status files. Per-track staleness continues to accumulate without orchestrator action; per-track file refresh is agent- / maintainer-owned per the Step 5.5 contract.
+- **Condition 3** PASS — Step 1b drift cross-reference: prior run-1 summary had no `## Pending work` rows in `dispatched` or `awaiting-merge` state (it was itself a NO-OP fast-exit; `## Dispatched this run` table contained only the `Step 0.5 fast-exit fired` sentinel). No rows to compare ⇒ no `[drift]` warnings emitted.
+- **Condition 4** PASS — `dev/status/harness.md` and `dev/status/cleanup.md` unchanged since prior summary (`git log --since="2026-05-20T08:42:51" -- dev/status/harness.md dev/status/cleanup.md` returns 0 commits).
+
+Escape hatch (first-run-of-day) did NOT fire: prior summary `dev/daily/2026-05-20.md` (committed `2026-05-20T08:42:51Z`) is ~4.6h old — well under the 24-hour threshold — so Step 0.5 conditions evaluated normally.
+
+No-op run: orchestrator-eligible surface is empty; review queue is fully drained (0 open PRs); no new status drift; exiting before dispatch.
+
+## Step 1c carried-forward verification
+
+Prior summary (`dev/daily/2026-05-20.md`) had ZERO `[critical]` tags — only `[critical-decision-needed]`, `[high-decision-needed]`, and `[info]` routing tags. Per protocol, those are human-decision routing tags, NOT the GHA-gate-triggering `[critical]` tag. No still-real `[critical]` items to carry forward. No live build verification ran this session (Step 0.5 no-op exit skips Step 6 deterministic health gates).
+
+## Context (carried forward — not gating)
+
+**Substantive maintainer activity** since prior summary (2 merged PRs in the run-1→this-run window, ~4.6h elapsed):
+
+- **#1219** `analysis(p4): per-stage hold-period decomposition — Probe P4` — continuation of the post-Bayesian-v1 hold-period deep-dive specified in `dev/notes/next-session-priorities-2026-05-21.md` (#1215).
+- **#1220** `feat(scoring): wire AvgHoldingDays into Composite scorer (P5 infra)` — extends the spec.objective scoring stack (#1214/#1216/#1217) with the AvgHoldingDays metric for the Composite scorer; P5 infra wiring.
+
+**Net effect**: the maintainer's autonomous session has continued the post-Bayesian-v1 hold-period investigation (P4 probe + P5 scoring wiring) per the active priorities doc. Review queue stayed at 0 open PRs (PRs landed direct-to-main without a window long enough for the orchestrator to QC). None of the affected tracks have per-track status files (post-Bayesian-v1 hold-period work is the same Weinstein cross-cycle validation sub-area as #1207/#1209/#1211/#1213 from the prior run window — still without a tracked `dev/status/<track>.md` row in `_index.md`).
+
+## Dispatched this run
+
+| Track | State | Branch | PR | Next step |
+|-------|-------|--------|----|-----------|
+| — | — | — | — | NO-OP run (Step 0.5 fast-exit) |
+
+| Track | Agent | Outcome | Notes |
+|-------|-------|---------|-------|
+| — | — | — | Step 0.5 fast-exit fired. Steps 2–7 skipped per protocol. |
+
+**Total subagents dispatched: 0**
+
+## QC Status
+
+(carried forward from prior summary — no change)
+
+- All tracks: no open feature PRs needing orchestrator QC. Review queue fully drained.
+
+## Budget
+
+- Budget cap: $50.00 (from `dev/config/merge-policy.json`)
+- Target utilization: 60%–80% ($30–$40)
+- Subagents dispatched: **0**
+- Per-subagent breakdown: (none — no subagent spawns)
+- Any subagent killed mid-flight: NO
+
+**Measured cost (from GHA execution file):**
+- Not yet available — `dev/budget/2026-05-20-<run-id>.json` is written by the GHA "Capture run cost" step after this orchestrator exits.
+- Estimated total (orchestrator state-read only, no subagents): **~$0.30 of $50 cap (<1%)**.
+
+- Utilization assessment: **negligible** — no-op fast-exit by design. Step 0.5 exists exactly for this state ("review queue stable, no new status drift; exiting before dispatch") to save ~10–15 min of orchestrator overhead and the corresponding quota.
+- Scope reduced due to budget: NO. Work surface was the constraint, not budget.
+
+## Escalations
+
+[info] **No `[critical]` escalations this run.** See "Step 1c carried-forward verification" above.
+
+[critical-decision-needed] **IWV scrape unblock — paid path required (human vendor decision)** — carried 8+ reconciles. **Decision pressure remains reduced** per the 2026-05-18 delisted-roster discovery (#1183 → #1187 stack + #1190 P4 + #1194 P5): the EODHD `/api/delisted-symbols` endpoint we already pay for now provides a parallel survivorship-correct path. Per `next-session-priorities-2026-05-19.md` §P2: SUPERSEDED — "the delisted-roster discovery obsoletes the Sharadar / AlphaVantage decision for the broader-first agenda; Q2-A bulk run is no longer blocked on a vendor decision." Full Russell-3000 2006-present coverage via IWV would still benefit from the paid scraper path (~$20–50 one-shot), but it is no longer the blocking single-point-of-failure. Recommend reclassifying to `[info]` on next reconcile unless `data-foundations` track surfaces a fresh hard block.
+
+[high-decision-needed] **`orchestrator-automation` track Phase 2 close-or-prioritize.** 9th consecutive reconcile. Phase 2 (background execution for scrapers / golden re-runs / cross-feature QC) has had no dispatch since 2026-05-04 (16+ days). Either spin up the empirical tests or wrap the track MERGED on Phase 1's stable daily-cron-summary operating state. The continuing IN_PROGRESS state indefinitely holds an active row in the index that no longer reflects real intent.
+
+[info] **Cost-model wiring deferral conflict** (carry-forward, 8+ reconciles). `dev/status/cost-model.md` body defers items 1+2 ("defer until at least one scenario needs per-trade or impact"). The 2026-05-19/21 priorities docs do NOT re-list cost-model wiring as P1. Decision item dormant; the conflict is stale on both sides. Recommend either dropping or maintainer clarification on next reconcile.
+
+[info] **Stale status files** continuing to accumulate (carry-forward + persistent). Pacer 2026-05-17 §P2 cited: `simulation.md`, `tuning.md` `## In Progress` block stale post-PR-E, `experiments.md` (#1073 reference stale), `harness.md`, `backtest-perf.md`. Also `walk-forward-cv.md` + `tuning.md` are stale w.r.t. the Fork_pool / `--parallel` parallelism work that landed 2026-05-18 (#1199–#1203). Weinstein cross-cycle validation (M1 #1207, M2 #1209/#1211, M3 deferred per #1213) plus the new post-Bayesian-v1 hold-period probe sub-area (#1219 P4 + #1220 P5 this window) is a sub-area landed without a tracked `dev/status/<track>.md` row in `_index.md`. Per-track status-file bodies are agent- / maintainer-owned; orchestrator's Step 5.5 contract only reconciles `_index.md` when per-track state shifts. Not orchestrator-dispatchable to fix.
+
+[info] **Recurring `[info]` items** (carried verbatim from run-1):
+  - qc-structural H3 false-positive on advisory linter text (carried 13+ reconciles since 2026-05-03). Pacer recommends ESCALATE_TO_MAINTAINER.
+  - qc-structural review-file persistence gap (`/w/...` vs `/__w/...` path typo on some runs; carried since 2026-04-30). Dormant — no recent orchestrator-driven QC dispatches; "formally mark RESOLVED" exit on the table next reconcile if dormant.
+
+[info] **15y split-day adjustment regression on `weinstein_strategy.ml`** (carried 10+ reconciles). Investigation #998 root-caused; fix work pending. Touches core `weinstein_strategy.ml` (feat-weinstein scope). No scoped plan file against this regression yet.
+
+[info] **Cleanup `[~]` rows still pending reconcile** (carried 16+ runs). `dev/status/cleanup.md` §Backlog has 4 `[~]` (in-flight) rows whose corresponding work substantially landed via the 2026-05-08 cleanup batch + follow-on PRs. Not orchestrator-dispatchable; recommend code-health agent flips them on next dispatch (when a `[ ]` item surfaces from a deep scan).
+
+[info] **`test_http_client.ml` mechanical refactor** (carry-forward — per `next-session-priorities-2026-05-19.md` §P1). PR #1184 sidestepped P6 enforcement by putting the new delisted-endpoint test in a standalone file. The original file has ~12 tests using `match result with | Ok ... | Error -> assert_failure` patterns. qc-structural P6 will block any future PR that touches this file until refactored. ~60–90 min mechanical. Carry-forward but not orchestrator-dispatchable today (no PR proposes touching `test_http_client.ml`).
+
+## Integration Queue
+
+(none — 0 orchestrator-tracked PRs in flight. Review queue fully drained.)
+
+This run's `ops/daily-2026-05-20-run2` PR will be opened by Step 8 below.
+
+## Current Milestone Target
+
+Strategic posture unchanged at the orchestrator-eligible level. The maintainer's autonomous-session pace has shipped 2 additional PRs in the run-1→this-run window (~4.6h): (a) #1219 per-stage hold-period decomposition (P4 probe of the post-Bayesian-v1 strategic deep-dive); (b) #1220 AvgHoldingDays Composite scorer wiring (P5 infra, extending the spec.objective stack from #1196). **Next-session plan**: `dev/notes/next-session-priorities-2026-05-21.md` (#1215) remains the active priorities doc; P4/P5 dispatch is already underway as part of the autonomous-session cadence. Per the prior run-1 summary, P0 remains Bayesian production sweep — operator-driven manual + background dispatch (not orchestrator-eligible from GHA cron window).
+
+## Per-run links
+
+- [run 1] `dev/daily/2026-05-20.md` (NO-OP — Step 0.5 fast-exit; 0 dispatches.)
+- [run 2] `dev/daily/2026-05-20-run2.md` (this file — NO-OP — Step 0.5 fast-exit; 0 dispatches; Step 7 minimal summary + Step 8 PR push are the entire scope.)
+
+---
+
+## Your Response
+
+(Edit this section. Run `dev/run.sh` after editing to start the next session.)


### PR DESCRIPTION
Automated daily orchestrator run. See `dev/daily/2026-05-20-run2.md` for the full summary.