### PR TITLE
feat(tuner): bo_checkpoint.sexp for resume after crash

### DIFF
--- a/dev/plans/bayesian-checkpoint-resume-2026-05-21.md
+++ b/dev/plans/bayesian-checkpoint-resume-2026-05-21.md
@@ -1,0 +1,173 @@
+# Bayesian sweep checkpoint + resume (2026-05-21)
+
+## Motivation
+
+V2 production sweep (2026-05-20) lost ~5 hours to a power-loss restart
+because `bayesian_runner_runner.ml` holds all state in memory and only
+writes artefacts after the full ask/tell loop completes. If the process
+dies mid-run, every evaluated iteration is lost.
+
+Memory: `project_bayesian_sweep_checkpoint_needed.md`.
+
+## Goal
+
+Allow `bayesian_runner.exe` to **resume from disk** if a prior run on the
+same `out_dir` was interrupted, and to **stream artefacts to disk
+incrementally** so a kill at any iteration loses at most one
+in-flight evaluation.
+
+Non-goals:
+- Changing the public `run_and_write` signature.
+- Distributed coordination (still single-process).
+- Backward compatibility with checkpoint files written by an older binary
+  version — schema is fixed at v1, mismatch errors loud.
+
+## Design
+
+### Checkpoint file: `<out_dir>/bo_checkpoint.sexp`
+
+Atomic write via `<path>.tmp` + `Sys.rename`. Sexp shape:
+
+```sexp
+((schema_version 1)
+ (spec_signature <md5 hex of Sexp.to_string (sexp_of_spec spec)>)
+ (rng_seed <int>)
+ (iterations
+  (((parameters ((k1 v1) (k2 v2)))
+    (metric m)
+    (per_scenario_metrics (<metric_set> ...))) ...)))
+```
+
+`spec_signature` is the digest of the parsed spec serialized — covers
+bounds, acquisition, total_budget, initial_random, seed, scenarios,
+objective, holdout_folds, sentinel_bounds, length_scales, early_stop.
+Any change → resume refused.
+
+### Incremental writes
+
+- After each `observe`:
+  1. Write `bo_checkpoint.sexp.tmp` then rename.
+  2. Append the iteration's CSV row(s) to `bo_log.csv` (one row per
+     scenario, same as today). Open the channel for the loop's lifetime,
+     `Out_channel.flush` after each row.
+- After the loop terminates:
+  3. Write `best.sexp` (full rewrite).
+  4. Write `convergence.md` (full rewrite — derived from observations).
+
+The bo_log.csv header is written once on a clean start; on resume we skip
+re-writing it (file already has the header + earlier rows).
+
+### Resume protocol
+
+In `run_and_write`:
+
+```
+if exists out_dir/bo_checkpoint.sexp:
+    cp = load_checkpoint
+    require cp.schema_version = 1
+    require cp.spec_signature = digest(spec)
+    require cp.rng_seed = spec.seed (or default 42)
+    bo = BO.create (Bayesian_runner_spec.to_bo_config spec)
+    for each saved_iter in cp.iterations:
+        replayed_params = _suggest spec bo
+        require replayed_params ≈ saved_iter.parameters  (float epsilon 1e-12)
+        bo = BO.observe bo { parameters = saved_iter.parameters; metric = saved_iter.metric }
+    iter_offset = List.length cp.iterations
+    open bo_log.csv in append mode (no header)
+else:
+    bo = BO.create config
+    iter_offset = 0
+    open bo_log.csv in truncate mode, write header
+```
+
+Loop continues from `iter_offset` for `total_budget - iter_offset` more
+iterations, persisting checkpoint after every `observe`.
+
+### RNG state invariant
+
+`BO.suggest_next` mutates the RNG inside `t`. Replaying `_suggest`
+deterministically advances the RNG identically to the original run,
+**provided the seed and observations match exactly**. We do not persist
+`Stdlib.Random.State.t` directly (no public sexp), we re-create it from
+the seed.
+
+Validation: replayed `_suggest` must produce the same parameters as
+the saved iteration. If float comparison fails by more than 1e-12 in any
+key, raise `Failure "resume RNG mismatch"`. This catches subtle
+non-determinism (lib upgrades, threading) early.
+
+### Failure modes
+
+| Situation | Behaviour |
+|---|---|
+| `out_dir` missing | mkdir_p, fresh run |
+| `bo_checkpoint.sexp` missing | fresh run (overwrite any partial `bo_log.csv`) |
+| Checkpoint schema_version ≠ 1 | `failwith "checkpoint schema mismatch (got N, want 1)"` |
+| Spec signature mismatch | `failwith "checkpoint spec mismatch — delete bo_checkpoint.sexp to start over"` |
+| Replay parameter mismatch | `failwith "resume RNG mismatch at iter N"` |
+| Already at `total_budget` on resume | write final artefacts, return; no extra iterations |
+| Checkpoint corrupt (parse error) | propagate sexp parse error with path |
+
+### Cost
+
+- Checkpoint write per iter: ~150-500 bytes per iter × budget=60 → ~30 KB file. Negligible.
+- bo_log.csv flush per iter: already at row granularity; just need explicit flush.
+- atomic rename: O(1) syscall.
+
+## Files to touch
+
+| File | Change |
+|---|---|
+| `trading/trading/backtest/tuner/bin/bayesian_runner_runner.ml` | Add `_load_checkpoint`, `_save_checkpoint`, `_replay_observations`. Modify `_run_loop` to accept initial `(bo, rev_obs, rev_metrics, iter_offset)`. Modify `_write_bo_log` to append-vs-truncate based on resume flag. |
+| `trading/trading/backtest/tuner/bin/bayesian_runner_runner.mli` | Document new behaviour in `run_and_write` docstring. Add `type checkpoint` if exposed. |
+| `trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml` | Add tests: resume-equivalence (run-N then resume vs run-2N), spec-mismatch-fails, schema-version-fails, missing-checkpoint-fresh-run, already-at-budget-on-resume. |
+| (optional) `dev/notes/checkpoint-design-2026-05-21.md` | Skip — this file IS the design doc. |
+
+## Test plan
+
+OUnit2 tests with the existing `_parabola_evaluator` stub:
+
+1. **resume_equivalent_to_full_run** — run total_budget=20 from scratch;
+   capture bo_log.csv and best.sexp. Repeat: run budget=10, then call
+   `run_and_write` again on the same out_dir with budget=20. Assert the
+   final bo_log.csv and best.sexp byte-equal the from-scratch version.
+
+2. **checkpoint_written_per_iter** — run with custom evaluator that
+   checks `out_dir/bo_checkpoint.sexp` exists and parses after each call.
+
+3. **spec_mismatch_refuses_resume** — write a checkpoint, then run again
+   with different bounds → expect `Failure` with substring "spec
+   mismatch".
+
+4. **schema_version_mismatch** — hand-craft a checkpoint with
+   `schema_version 99` → expect `Failure`.
+
+5. **resume_at_budget_writes_artefacts** — checkpoint with full budget of
+   observations + matching total_budget → expect zero extra evaluator
+   calls + best.sexp / convergence.md written.
+
+6. **missing_checkpoint_starts_fresh** — empty out_dir → behaves
+   identically to today's code path.
+
+## Estimated size
+
+| File | LOC delta |
+|---|---|
+| bayesian_runner_runner.ml | +150 |
+| bayesian_runner_runner.mli | +30 (docs) |
+| test_bayesian_runner_bin.ml | +180 |
+| **Total** | **~360 LOC** |
+
+Single session, single PR.
+
+## Out of scope (followups)
+
+- Persisting `Stdlib.Random.State.t` directly to avoid replay-cost on
+  resume. Replay of 60 iterations of `_suggest` takes <1s — not worth
+  the marshalling complexity.
+- Resuming with a *larger* total_budget than the checkpointed run. Today
+  the spec check refuses any budget change. If demand emerges, relax
+  the signature to bind only "bounds/objective/seed/initial_random" and
+  not "total_budget".
+- Telemetry: checkpoint-resume should log to stderr — kept minimal in
+  PR-1, add structured log in followup if multiple operators use it.

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_runner.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_runner.ml
@@ -18,12 +18,105 @@ type result = {
 type evaluator =
   parameters:(string * float) list -> float * Metric_types.metric_set list
 
+(** {1 Checkpoint state}
+
+    [bo_checkpoint.sexp] is written atomically under [out_dir] after every
+    [observe] call. On a subsequent [run_and_write] against the same [out_dir],
+    the file is loaded and the BO state is reconstructed by replaying the saved
+    observations through {!Tuner.Bayesian_opt.observe} — advancing the RNG
+    identically to the original run via discarded
+    {!Tuner.Bayesian_opt.suggest_next} calls.
+
+    The on-disk shape is private to this module; consumers should treat
+    [bo_checkpoint.sexp] as an opaque resume token. *)
+
+type _saved_iteration = {
+  parameters : (string * float) list;
+  metric : float;
+  per_scenario_metrics : Metric_types.metric_set list;
+}
+[@@deriving sexp]
+
+type _checkpoint = {
+  schema_version : int;
+  spec : Bayesian_runner_spec.t;
+  iterations : _saved_iteration list;
+}
+[@@deriving sexp]
+
+let _checkpoint_schema_version = 1
+let _checkpoint_filename = "bo_checkpoint.sexp"
+
+(** RNG-mismatch tolerance: replayed {!_suggest} must reproduce each saved
+    parameter to within this many ULP. Pinned tight (1e-12) so any
+    non-determinism — lib upgrade, threading, NaN handling — fails loud. *)
+let _replay_epsilon = 1e-12
+
+let _checkpoint_path out_dir = Filename.concat out_dir _checkpoint_filename
+
+let _save_checkpoint ~out_dir ~checkpoint =
+  let path = _checkpoint_path out_dir in
+  let tmp = path ^ ".tmp" in
+  Out_channel.with_file tmp ~f:(fun oc ->
+      Out_channel.output_string oc
+        (Sexp.to_string_hum (sexp_of__checkpoint checkpoint));
+      Out_channel.output_string oc "\n");
+  Sys_unix.rename tmp path
+
+let _load_checkpoint_if_exists out_dir =
+  let path = _checkpoint_path out_dir in
+  if Sys_unix.file_exists_exn path then
+    Some (_checkpoint_of_sexp (Sexp.load_sexp path))
+  else None
+
+(** Project a spec into the form compared for resume-equality. Excludes
+    [total_budget] so a partial run can be resumed under a larger (or smaller)
+    budget — the search surface, RNG, scenarios, and objective are what must
+    stay constant; the budget only governs when the loop stops. *)
+let _spec_for_resume_check (spec : Bayesian_runner_spec.t) =
+  { spec with total_budget = 0 }
+
+let _validate_checkpoint ~ck ~spec =
+  if ck.schema_version <> _checkpoint_schema_version then
+    failwithf "checkpoint schema mismatch — found version %d, expected %d"
+      ck.schema_version _checkpoint_schema_version ();
+  let expected = Bayesian_runner_spec.sexp_of_t (_spec_for_resume_check spec) in
+  let found = Bayesian_runner_spec.sexp_of_t (_spec_for_resume_check ck.spec) in
+  if not (Sexp.equal expected found) then
+    failwith
+      "checkpoint spec mismatch — delete bo_checkpoint.sexp to start over"
+
 (** {1 BO loop} *)
 
 let _suggest spec bo =
   match spec.Bayesian_runner_spec.n_acquisition_candidates with
   | None -> BO.suggest_next bo
   | Some n -> BO.suggest_next_with_candidates bo ~n_candidates:n
+
+let _params_match a b =
+  match List.zip a b with
+  | Unequal_lengths -> false
+  | Ok pairs ->
+      List.for_all pairs ~f:(fun ((ka, va), (kb, vb)) ->
+          String.equal ka kb && Float.(abs (va -. vb) <= _replay_epsilon))
+
+let _verify_replay ~iter ~replayed ~saved =
+  if not (_params_match replayed saved) then
+    failwithf "resume RNG mismatch at iter %d" iter ()
+
+(** Re-create the BO state by replaying each saved observation through
+    {!BO.observe} after discarding a {!_suggest} call (which advances the RNG
+    identically to the original run). The replayed [_suggest] must reproduce the
+    saved [parameters] within {!_replay_epsilon}; mismatch aborts with [Failure]
+    so silent non-determinism surfaces as a hard failure rather than a corrupted
+    resume. *)
+let _replay_to_state spec iterations =
+  let config = Bayesian_runner_spec.to_bo_config spec in
+  let initial = BO.create config in
+  List.foldi iterations ~init:initial ~f:(fun i bo it ->
+      let replayed = _suggest spec bo in
+      _verify_replay ~iter:i ~replayed ~saved:it.parameters;
+      BO.observe bo { parameters = it.parameters; metric = it.metric })
 
 let _running_best_so_far rev_obs =
   let observations = List.rev rev_obs in
@@ -35,16 +128,19 @@ let _running_best_so_far rev_obs =
   in
   List.rev rev_running
 
-(** Run the BO ask/tell loop, accumulating
-    [(observation, per-scenario metric sets)] in evaluation order. Honours the
-    optional [early_stop_config] on the BO config: if set, after each iteration
-    computes the running-best curve and checks the early-stop predicate before
-    issuing the next [suggest_next]. *)
-let _run_loop spec ~evaluator =
+(** Run the BO ask/tell loop from an arbitrary starting BO state, accumulating
+    [(observation, per-scenario metric sets)] in evaluation order. Calls
+    [on_observation] after every successful [observe] so the caller can persist
+    a checkpoint to disk before the next iteration begins. Honours the optional
+    [early_stop_config] on the BO config. *)
+let _run_loop spec ~evaluator ~initial_bo ~prior_obs ~prior_metric_sets
+    ~iter_offset ~on_observation =
   let config = Bayesian_runner_spec.to_bo_config spec in
-  let initial = BO.create config in
   let early_stop_cfg = config.early_stop_config in
   let initial_random = config.initial_random in
+  let iters_left = spec.total_budget - iter_offset in
+  let prior_rev_obs = List.rev prior_obs in
+  let prior_rev_metrics = List.rev prior_metric_sets in
   let rec loop bo iter_idx iters_left rev_obs rev_metrics =
     if iters_left <= 0 then
       (bo, List.rev rev_obs, List.rev rev_metrics, Budget_exhausted)
@@ -62,10 +158,11 @@ let _run_loop spec ~evaluator =
           let metric, per_scenario = evaluator ~parameters in
           let obs = { BO.parameters; metric } in
           let bo = BO.observe bo obs in
+          on_observation ~obs ~per_scenario;
           loop bo (iter_idx + 1) (iters_left - 1) (obs :: rev_obs)
             (per_scenario :: rev_metrics)
   in
-  loop initial 0 spec.total_budget [] []
+  loop initial_bo iter_offset iters_left prior_rev_obs prior_rev_metrics
 
 (** {1 Output writers} *)
 
@@ -178,11 +275,71 @@ let _result_of bo observations per_iteration_metrics stop_reason =
         stop_reason;
       }
 
+(** Resume-or-fresh: if a valid checkpoint exists under [out_dir], reconstruct
+    BO state from it; otherwise start from a fresh [BO.create]. Returns
+    [(initial_bo, prior_obs, prior_metric_sets, iter_offset)]. *)
+let _load_or_init spec ~out_dir =
+  match _load_checkpoint_if_exists out_dir with
+  | None ->
+      let bo = BO.create (Bayesian_runner_spec.to_bo_config spec) in
+      (bo, [], [], 0)
+  | Some ck ->
+      _validate_checkpoint ~ck ~spec;
+      let bo = _replay_to_state spec ck.iterations in
+      let prior_obs =
+        List.map ck.iterations ~f:(fun it ->
+            { BO.parameters = it.parameters; metric = it.metric })
+      in
+      let prior_metrics =
+        List.map ck.iterations ~f:(fun it -> it.per_scenario_metrics)
+      in
+      (bo, prior_obs, prior_metrics, List.length ck.iterations)
+
+(** Build the streaming on-observation callback. Each call appends the new
+    iteration to [iterations_ref] (kept in reverse for O(1) prepend) and
+    persists the full checkpoint atomically. *)
+let _make_checkpoint_writer ~out_dir ~spec ~iterations_ref =
+ fun ~(obs : BO.observation) ~per_scenario ->
+  let saved =
+    {
+      parameters = obs.parameters;
+      metric = obs.metric;
+      per_scenario_metrics = per_scenario;
+    }
+  in
+  iterations_ref := saved :: !iterations_ref;
+  let checkpoint =
+    {
+      schema_version = _checkpoint_schema_version;
+      spec;
+      iterations = List.rev !iterations_ref;
+    }
+  in
+  _save_checkpoint ~out_dir ~checkpoint
+
+let _initial_iterations_rev ~prior_obs ~prior_metric_sets =
+  List.rev
+    (List.map2_exn prior_obs prior_metric_sets
+       ~f:(fun (obs : BO.observation) per_scenario_metrics ->
+         {
+           parameters = obs.parameters;
+           metric = obs.metric;
+           per_scenario_metrics;
+         }))
+
 let run_and_write ~(spec : Bayesian_runner_spec.t) ~out_dir ~evaluator =
   Core_unix.mkdir_p out_dir;
   let objective = Bayesian_runner_spec.to_grid_objective spec.objective in
+  let initial_bo, prior_obs, prior_metric_sets, iter_offset =
+    _load_or_init spec ~out_dir
+  in
+  let iterations_ref =
+    ref (_initial_iterations_rev ~prior_obs ~prior_metric_sets)
+  in
+  let on_observation = _make_checkpoint_writer ~out_dir ~spec ~iterations_ref in
   let bo, observations, per_iteration_metrics, stop_reason =
-    _run_loop spec ~evaluator
+    _run_loop spec ~evaluator ~initial_bo ~prior_obs ~prior_metric_sets
+      ~iter_offset ~on_observation
   in
   let result = _result_of bo observations per_iteration_metrics stop_reason in
   let log_path = Filename.concat out_dir "bo_log.csv" in

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_runner.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_runner.mli
@@ -67,4 +67,30 @@ val run_and_write :
       [(stop_reason early_stopped (iter <N>))] when early-stop fired.
 
     Creates [out_dir] via [mkdir -p] if it does not exist. Returns the {!result}
-    record so callers can log [best_score] without re-reading the artefacts. *)
+    record so callers can log [best_score] without re-reading the artefacts.
+
+    {b Checkpoint / resume.} After every successful evaluation, the runner
+    atomically writes [<out_dir>/bo_checkpoint.sexp] holding the spec + every
+    observation so far. On a subsequent call against the same [out_dir]:
+
+    - If [bo_checkpoint.sexp] is absent, the run starts fresh as above.
+    - If present, the runner reconstructs the BO state by replaying every saved
+      observation (advancing the RNG identically to the original run via
+      discarded [suggest_next] calls), then continues the loop from the next
+      iteration. The replayed [suggest_next] must reproduce each saved parameter
+      set within [1e-12]; mismatch raises [Failure] (silent non-determinism
+      becomes a hard failure rather than a corrupted resume).
+    - If the loaded checkpoint's [schema_version] is not the current version
+      (1), or if the embedded spec differs from the supplied [spec] in any field
+      other than [total_budget], raises [Failure]. (The [total_budget] field is
+      excluded from the equality check so a partial run can be resumed under a
+      larger budget; the bounds, seed, scenarios, objective, and acquisition
+      must stay constant.) To start over, delete [bo_checkpoint.sexp].
+    - When the checkpoint already contains [spec.total_budget] iterations, the
+      loop runs zero further evaluator calls and just re-emits the final
+      artefacts.
+
+    [bo_log.csv], [best.sexp], and [convergence.md] are whole-file rewrites on
+    every call — they are derived from [bo_checkpoint.sexp] + the completed
+    in-memory state. The checkpoint file is the resume source of truth; the
+    other three files are final artefacts. *)

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
@@ -754,6 +754,165 @@ let test_phase3_fixture_bounds_cover_expected_tracks _ =
          equal_to "screening_config.weights.w_strong_volume";
        ])
 
+(* ---------- checkpoint / resume (2026-05-21) ---------- *)
+
+(** Read every byte of a regular file as a single string. Used by checkpoint
+    tests to assert byte-equality of artefacts between fresh and resumed runs.
+*)
+let _read_all path = In_channel.read_all path
+
+let _artefact_paths out_dir =
+  ( Filename.concat out_dir "bo_log.csv",
+    Filename.concat out_dir "best.sexp",
+    Filename.concat out_dir "convergence.md" )
+
+(** A counting evaluator wrapper: records every parameter set passed to the
+    underlying evaluator. Lets resume tests assert that a checkpoint already
+    covering the budget triggers zero further evaluator calls. *)
+let _counting_evaluator inner =
+  let calls = ref 0 in
+  let eval : Runner.evaluator =
+   fun ~parameters ->
+    incr calls;
+    inner ~parameters
+  in
+  (eval, calls)
+
+let test_resume_equivalent_to_full_run _ =
+  (* Splitting a budget-20 run as 10 + 10 (with the second call resuming via
+     the checkpoint) must produce byte-identical bo_log.csv, best.sexp, and
+     convergence.md as a single budget-20 run from scratch. *)
+  let final_spec = _parabola_spec ~total_budget:20 ~seed:31 in
+  let partial_spec = _parabola_spec ~total_budget:10 ~seed:31 in
+  _with_temp_dir (fun fresh_dir ->
+      _with_temp_dir (fun resume_dir ->
+          let fresh_out = Filename.concat fresh_dir "out" in
+          let resume_out = Filename.concat resume_dir "out" in
+          let _ =
+            Runner.run_and_write ~spec:final_spec ~out_dir:fresh_out
+              ~evaluator:_parabola_evaluator
+          in
+          let _ =
+            Runner.run_and_write ~spec:partial_spec ~out_dir:resume_out
+              ~evaluator:_parabola_evaluator
+          in
+          let _ =
+            Runner.run_and_write ~spec:final_spec ~out_dir:resume_out
+              ~evaluator:_parabola_evaluator
+          in
+          let fresh_log, fresh_best, fresh_conv = _artefact_paths fresh_out in
+          let resume_log, resume_best, resume_conv =
+            _artefact_paths resume_out
+          in
+          assert_that
+            (_read_all fresh_log, _read_all fresh_best, _read_all fresh_conv)
+            (equal_to
+               ( _read_all resume_log,
+                 _read_all resume_best,
+                 _read_all resume_conv ))))
+
+let test_checkpoint_file_written_per_iter _ =
+  (* After a complete run, bo_checkpoint.sexp exists, parses as a sexp, and
+     records every iteration. The internal sexp shape is private but the file
+     itself must be parseable as a sexp so external tooling can at least
+     introspect its presence + content. *)
+  let spec = _parabola_spec ~total_budget:6 ~seed:11 in
+  _with_temp_dir (fun dir ->
+      let out_dir = Filename.concat dir "out" in
+      let _ =
+        Runner.run_and_write ~spec ~out_dir ~evaluator:_parabola_evaluator
+      in
+      let ck_path = Filename.concat out_dir "bo_checkpoint.sexp" in
+      assert_that (Sys_unix.file_exists_exn ck_path) (equal_to true);
+      let raised =
+        try
+          let _ = Sexp.load_sexp ck_path in
+          false
+        with _ -> true
+      in
+      assert_that raised (equal_to false))
+
+let test_resume_at_full_budget_skips_evaluator _ =
+  (* When the checkpoint already covers spec.total_budget iterations, a
+     second run_and_write with the same spec must perform zero evaluator
+     calls and just re-emit the final artefacts. *)
+  let spec = _parabola_spec ~total_budget:8 ~seed:19 in
+  _with_temp_dir (fun dir ->
+      let out_dir = Filename.concat dir "out" in
+      let first_eval, first_calls = _counting_evaluator _parabola_evaluator in
+      let _ = Runner.run_and_write ~spec ~out_dir ~evaluator:first_eval in
+      let calls_after_fresh = !first_calls in
+      let second_eval, second_calls = _counting_evaluator _parabola_evaluator in
+      let result = Runner.run_and_write ~spec ~out_dir ~evaluator:second_eval in
+      assert_that
+        (calls_after_fresh, !second_calls, List.length result.observations)
+        (equal_to (8, 0, 8)))
+
+let test_resume_with_changed_spec_raises _ =
+  (* Tightening the bounds between runs must be refused: the BO state was
+     produced under the original spec and any mid-run knob change invalidates
+     the saved observations' interpretation. *)
+  let original_spec = _parabola_spec ~total_budget:8 ~seed:23 in
+  let changed_spec : Spec.t =
+    { original_spec with bounds = [ ("x", (0.0, 5.0)) ] }
+  in
+  _with_temp_dir (fun dir ->
+      let out_dir = Filename.concat dir "out" in
+      let _ =
+        Runner.run_and_write ~spec:original_spec ~out_dir
+          ~evaluator:_parabola_evaluator
+      in
+      let raised =
+        try
+          let _ =
+            Runner.run_and_write ~spec:changed_spec ~out_dir
+              ~evaluator:_parabola_evaluator
+          in
+          false
+        with Failure msg ->
+          String.is_substring msg ~substring:"checkpoint spec mismatch"
+      in
+      assert_that raised (equal_to true))
+
+let test_resume_with_wrong_schema_version_raises _ =
+  (* A hand-crafted checkpoint sexp with the wrong schema_version must be
+     refused with a clear Failure naming the version mismatch. *)
+  let spec = _parabola_spec ~total_budget:6 ~seed:5 in
+  _with_temp_dir (fun dir ->
+      let out_dir = Filename.concat dir "out" in
+      Core_unix.mkdir_p out_dir;
+      let ck_path = Filename.concat out_dir "bo_checkpoint.sexp" in
+      let spec_sexp = Sexp.to_string_hum (Spec.sexp_of_t spec) in
+      Out_channel.write_all ck_path
+        ~data:
+          (sprintf "((schema_version 99) (spec %s) (iterations ()))" spec_sexp);
+      let raised =
+        try
+          let _ =
+            Runner.run_and_write ~spec ~out_dir ~evaluator:_parabola_evaluator
+          in
+          false
+        with Failure msg ->
+          String.is_substring msg ~substring:"checkpoint schema mismatch"
+      in
+      assert_that raised (equal_to true))
+
+let test_missing_checkpoint_starts_fresh _ =
+  (* Sanity-pin the legacy behaviour: with no bo_checkpoint.sexp in out_dir,
+     run_and_write performs total_budget evaluator calls and writes a fresh
+     checkpoint covering them. *)
+  let spec = _parabola_spec ~total_budget:6 ~seed:5 in
+  _with_temp_dir (fun dir ->
+      let out_dir = Filename.concat dir "out" in
+      let eval, calls = _counting_evaluator _parabola_evaluator in
+      let result = Runner.run_and_write ~spec ~out_dir ~evaluator:eval in
+      let ck_exists =
+        Sys_unix.file_exists_exn (Filename.concat out_dir "bo_checkpoint.sexp")
+      in
+      assert_that
+        (!calls, List.length result.observations, ck_exists)
+        (equal_to (6, 6, true)))
+
 let suite =
   "Tuner_bin.Bayesian_runner"
   >::: [
@@ -828,6 +987,18 @@ let suite =
          >:: test_early_stop_omitted_parses_to_none;
          "PR-D: to_bo_config propagates length_scales + early_stop"
          >:: test_to_bo_config_propagates_pr_d_fields;
+         "checkpoint: resume after partial run produces identical artefacts"
+         >:: test_resume_equivalent_to_full_run;
+         "checkpoint: bo_checkpoint.sexp present + parseable after run"
+         >:: test_checkpoint_file_written_per_iter;
+         "checkpoint: resume at full budget skips evaluator"
+         >:: test_resume_at_full_budget_skips_evaluator;
+         "checkpoint: resume with changed spec raises Failure"
+         >:: test_resume_with_changed_spec_raises;
+         "checkpoint: wrong schema_version raises Failure"
+         >:: test_resume_with_wrong_schema_version_raises;
+         "checkpoint: missing checkpoint starts fresh"
+         >:: test_missing_checkpoint_starts_fresh;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

V2 production sweep (2026-05-20) lost ~5h to a power-loss restart because
`bayesian_runner_runner.ml` keeps all state in memory and only writes artefacts
at end-of-loop. This PR introduces `bo_checkpoint.sexp` — an atomically-written
sexp persisted after every BO observation — and teaches `run_and_write` to
resume from it on a subsequent call against the same `out_dir`. Eliminates
restart-from-scratch risk before V3 production sweep launches.

## What it does

- New private types `_saved_iteration` + `_checkpoint` (schema_version=1) embed
  the spec + every observation. Stored at `<out_dir>/bo_checkpoint.sexp`, written
  via `.tmp` + atomic rename after each `BO.observe` call.
- On a subsequent `run_and_write` against the same `out_dir`:
  - Missing checkpoint → fresh run (legacy behaviour, byte-identical artefacts).
  - Present, valid checkpoint → replays every saved observation through
    `BO.observe` after discarding a `_suggest` call (advances RNG identically to
    the original run), then continues the loop from the next iteration.
  - Wrong schema_version → \`Failure \"checkpoint schema mismatch …\"\`.
  - Spec mismatch (any field except \`total_budget\`) → \`Failure \"checkpoint spec mismatch — delete bo_checkpoint.sexp to start over\"\`. \`total_budget\` is excluded so a partial run can be resumed under a larger budget.
  - Replayed \`_suggest\` must match each saved parameter within 1e-12 — silent
    non-determinism fails loud rather than corrupting the resume.
- Public \`run_and_write\` signature unchanged; \`result\` type unchanged; legacy
  artefacts (\`bo_log.csv\`, \`best.sexp\`, \`convergence.md\`) byte-identical when
  no checkpoint is present.

## Plan

\`dev/plans/bayesian-checkpoint-resume-2026-05-21.md\` — design + size estimate +
test plan landed alongside the implementation.

## Design notes (deviations from plan)

- **\`total_budget\` excluded from spec-equality check.** The plan deferred this to
  a followup; the resume-equivalence test exposed that extending a partial run
  to a larger budget is a legitimate use case (V3 launch could need it), so
  promoted into PR-1.
- **No incremental bo_log.csv writes.** Plan considered streaming CSV rows per
  iter; this version writes bo_log.csv as a whole-file rewrite at end of loop.
  The checkpoint is the durable state; the CSV is a derived artefact. Simpler
  code, durability guarantees identical.

## Test plan

OUnit2 tests under \`trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml\`:

- [x] \`resume_equivalent_to_full_run\` — budget=20 fresh vs budget=10 then
  budget=20 resume → byte-identical bo_log.csv + best.sexp + convergence.md
- [x] \`checkpoint_file_written_per_iter\` — \`bo_checkpoint.sexp\` present + parses
  after a complete run
- [x] \`resume_at_full_budget_skips_evaluator\` — checkpoint covering budget +
  same spec → zero evaluator calls + correct observation count
- [x] \`resume_with_changed_spec_raises\` — tightened bounds → \`Failure\`
- [x] \`resume_with_wrong_schema_version_raises\` — hand-crafted v99 checkpoint
  → \`Failure\`
- [x] \`missing_checkpoint_starts_fresh\` — empty out_dir → legacy behaviour
  unchanged

Full suite: 43/43 tests pass. \`dune build && dune runtest\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)