### PR TITLE
rules: promote session-tested QC + merge + rampup norms from memory to repo

### DIFF
--- a/.claude/rules/code-health-discipline.md
+++ b/.claude/rules/code-health-discipline.md
@@ -1,0 +1,76 @@
+---
+description: Code-health follow-ups must actually land. Don't bump linter limits, add `@large-module` markers, or paper over linter trips with escape-hatch flags as a substitute for the underlying refactor.
+harness: project
+---
+
+# Code-health discipline
+
+Splitting work into separate PRs for review focus is valid; **deferring
+the follow-up code-health work indefinitely is not**. When a linter or
+quality check trips, the answer is to fix the underlying issue, not
+bump the limit or add an escape-hatch marker.
+
+## What NOT to do
+
+- Bump `HARD_LIMIT` / `SOFT_LIMIT` / `MAX_LARGE_PCT` as a workaround.
+- Add `@large-module` markers to files just to satisfy a linter — the
+  marker is reserved for legitimately-large coordinator modules whose
+  fragmentation would damage per-cycle reading order, not for skipping
+  refactors.
+- Add path exceptions to `linter_exceptions.conf` without both:
+  - A clear `review_at` trigger (date or PR number).
+  - A real, documented reason — not "follow-up tracked in #N" without
+    the follow-up actually being opened and worked.
+- Land "follow-up tracked in #N" comments without opening + working
+  the follow-up. Trackers without action are not deferral; they're
+  permanent debt.
+
+## Why
+
+Per `feedback_no_deferred_codehealth.md` 2026-05-07: PR #916 (P1
+stale-hold detector) pushed `simulator.ml` to 519 lines (>500 hard
+limit). The dune-runtest cache had been hiding the violation; PR #919
+merging invalidated the cache and revealed it — plus **8 other
+file-length violations, 5 function-length, 99 nesting, and multiple
+magic-number / status-integrity violations** that had accumulated
+unnoticed across the codebase. Main went red and 4 PRs blocked
+simultaneously.
+
+The accumulation happened because earlier PRs had used `@large-module`
+markers + cache-skipped CI runs to defer the actual extraction. Code
+health that "wasn't strictly required for the feature" got pushed off
+the immediate critical path; it accumulated silently until a single
+cache invalidation fired all alarms at once.
+
+## What TO do
+
+When a linter trips:
+
+1. **First instinct: extract / refactor the offending code.** The
+   linter is the canonical signal that the module/function is too
+   large or too nested; the fix is to reduce it.
+2. **Only then consider an `@large-module` marker** if the file is
+   genuinely a coordinator (e.g., orchestrates a multi-stage pipeline
+   with sequential reading-order dependencies) and the alternative is
+   harming readability. The marker is rare — its presence in the
+   codebase should be unusual enough that adding one prompts review.
+3. **Bumping limits is a last resort** that must be accompanied by:
+   - A concrete refactor plan, ideally as a separate PR scoped to the
+     extraction.
+   - A tracking issue with a real owner + date.
+   - The bump landing in the same PR as the plan + issue link.
+4. **Cleanup work should be proactive, not reactive.** If the cleanup
+   agent (`code-health`) only fires on linter failure, it's already
+   too late — accumulation is a leading indicator. Watch trends:
+   file-length growth across multiple PRs, new `@large-module` markers
+   landing, function-length being dialled up — those are signals to
+   schedule cleanup *now*, not "we'll get to it" notes.
+
+## Splitting fixes from features
+
+Splitting a feature into "fix" + "feature" PRs (per the PR-structure
+guidance in CLAUDE.md) is still right — but each split must actually
+land. "Out of scope for this PR" is fine in a PR body; "deferred
+forever" is not. If the fix-half PR doesn't land within a few sessions
+of the feature-half, the feature-half should be reverted, not left as
+a permanent debt on main.

--- a/.claude/rules/pr-merge-gates.md
+++ b/.claude/rules/pr-merge-gates.md
@@ -1,0 +1,126 @@
+---
+description: PR merge policy — all 3 gates (CI + qc-structural + qc-behavioral) must be green AND completed before merge. `gh pr merge` does not enforce CI on this repo's main branch protection; verify manually.
+harness: project
+---
+
+# PR merge gates
+
+A PR is mergeable only when **all three** are green:
+
+1. **GitHub CI** — `build-and-test` + `perf-tier1-smoke` (and any other
+   required PR workflows). Status must be `COMPLETED SUCCESS`, never
+   `IN_PROGRESS` or `PENDING`.
+2. **qc-structural** — APPROVED verdict at the current PR tip, recorded
+   in `dev/reviews/<feature>.md`.
+3. **qc-behavioral** — APPROVED verdict at the current PR tip, recorded
+   in `dev/reviews/<feature>-behavioral.md`. NA only for the cases
+   listed in `.claude/rules/qc-behavioral-authority.md` §"When to skip
+   this file entirely" (pure infra / refactor / harness PRs that touch
+   no domain logic — still requires the generic CP1–CP4 review).
+
+## Why each gate matters
+
+- **CI catches what local + QC cannot.** Local `dune build && dune runtest`
+  skips the linter steps that GHA runs as part of the PR build
+  (`fn_length_linter`, `nesting_linter`, `linter_magic_numbers.sh`,
+  `file_length_linter`, `status_file_integrity_linter`). QC agents
+  inherit the same blind spot when their host environment lacks opam
+  deps. Per `feedback_pr_merge_gates.md` 2026-05-03: ~28 PRs merged in
+  autonomous mode on QC alone caused linter regressions on main because
+  their local QC environments couldn't run the full linter suite. CI is
+  the only place the full lint surface runs.
+- **QC structural catches what CI doesn't.** Architecture constraints
+  (A1–A3), test patterns (P6), pattern-match exhaustivity, naming
+  hygiene — these are not in any linter; they're in `.claude/agents/
+  qc-structural.md` + `.claude/rules/qc-structural-authority.md`.
+- **QC behavioral catches contract drift.** The .mli docstring,
+  feature plan, and PR body each name claims; qc-behavioral pins each
+  claim against a test. Without it, "the test suite is green" is a
+  much weaker guarantee than "every documented contract is pinned."
+
+## Verifying CI before merge
+
+`gh pr merge --squash` does **not** automatically block on CI when
+branch protection isn't enforcing required checks. This repo's main
+branch DOES have `build-and-test` + `perf-tier1-smoke` as required
+checks with `strict: true` since 2026-05-09, but the requirement
+applies to `--squash` only when the PR is up-to-date; a stale PR will
+fail with "GraphQL: 2 of 2 required status checks are expected" and
+must be rebased (`gh pr update-branch <N>`) before re-attempting. Per
+`feedback_pr_merge_ci_gate.md` 2026-05-06: PR #883 merged with
+`build-and-test: FAILURE` because the merge command was invoked while
+build-and-test was still `IN_PROGRESS` and finished red seconds later.
+
+### The hard rule
+
+Before `gh pr merge`:
+
+```bash
+gh pr checks <N>
+```
+
+Read column 3 on every line — `pass` / `fail` / `pending`. **If any
+line shows `pending` or `fail`, DO NOT merge.** This is non-negotiable
+even with `--admin` privileges. Per `feedback_pr_merge_ci_gate.md`
+2026-05-15: PR #1113 admin-merged with `build-and-test: fail` despite
+QC double-approval; the linter failures (file_length, nesting) landed
+on main and blocked 12 subsequent PRs.
+
+### When `fail` is admissible (rare exception)
+
+A `fail` is treated as an actionable failure unless ALL of:
+
+1. Reproducibly the same silent failure on 2+ reruns — same step, no
+   test assertion message, no source-level error.
+2. Verifiable infra signal in the log (e.g. sandbox-race `find: …
+   No such file or directory`).
+3. PR content has QC structural + behavioral APPROVED with no findings
+   that would interact with the failing step.
+4. Main is blocked on this merge (the PR is itself the unblock).
+
+If any of (1)–(4) is missing, treat as a real fail. Even when an
+exception fires, file a follow-up to fix the underlying infra race.
+
+### Hard stop: any `^FAIL:` line means real failure
+
+```bash
+gh run view <run_id> --log 2>&1 | grep -E 'FAIL:'
+```
+
+`FAIL: nesting linter`, `FAIL: file length linter`, `FAIL: magic
+numbers`, `FAIL: status_file_integrity_linter`, `FAIL: fn_length`,
+`FAIL: mli_coverage`, OUnit `FAIL:` — none of these are ever infra
+flakes. Reject the exception. Fix on a new PR before merging anything
+else.
+
+### Hard stop: main must be green BEFORE merging the next PR
+
+```bash
+gh run list --branch main --workflow CI --limit 1 \
+  --json conclusion,headSha,status
+```
+
+If main is red, fix main first via a dedicated `[main-fix]`-prefixed
+PR (single commit, scope = revert/fix the violation, no new feature
+work). Do not pile new merges on a red main — diagnosis ambiguity
+multiplies as each successive PR adds noise, and watchdog issue
+comments accumulate without a recovery trigger.
+
+## Polling pattern
+
+```bash
+# Poll until all checks are COMPLETED SUCCESS, then merge
+until [ "$(gh pr view <N> --json statusCheckRollup \
+  -q '[.statusCheckRollup[] | select(.status != "COMPLETED" or .conclusion != "SUCCESS")] | length')" = "0" ]; do
+  sleep 30
+done
+gh pr merge <N> --squash --delete-branch
+```
+
+Or simpler: `gh pr checks <N>`, eyeball, only merge if all `pass`.
+
+## Don't trust stale "CI was green" reads
+
+CI status can change between QC approval and merge invocation if a
+rework was pushed during QC. Always re-verify `gh pr checks <N>`
+immediately before `gh pr merge`, not 5 minutes earlier.

--- a/.claude/rules/qc-behavioral-authority.md
+++ b/.claude/rules/qc-behavioral-authority.md
@@ -115,6 +115,19 @@ note: "Pure infra / harness / refactor PR; domain checklist not applicable."
 qc-structural's A1 row will not be flagged for such PRs because there is
 no domain logic to leak into core modules.
 
+## Operational requirements for QC agents in this repo
+
+Same invariants as qc-structural — see
+`.claude/rules/qc-structural-authority.md` §"Operational requirements
+for QC agents in this repo":
+
+1. Dispatch with **`isolation: "worktree"`**. qc-behavioral may run
+   `jj edit` on the PR branch to inspect; without isolation the parent
+   workspace's shared `.jj/repo/` is mutated.
+2. Run every `dune build` / `dune runtest` via `docker exec trading-1-dev`.
+   Native invocations produce ENVFAIL on the ocamlformat / opam skew
+   between host and container.
+
 ## What the generic agent doesn't know about
 
 - The five Weinstein authority docs above.

--- a/.claude/rules/qc-structural-authority.md
+++ b/.claude/rules/qc-structural-authority.md
@@ -33,6 +33,39 @@ After completing the generic checklist (H1–H3, P1–P5), append these rows:
 | A3 | No unnecessary modifications to existing (non-feature) modules | PASS/FAIL/NA | Look for cross-feature drift using `$PR_FILES` from Step 3 (file list per `gh pr view <N> --json files`), NOT from a git-log ancestry walk. This is where PR #687's false-positive originated: the agent walked git ancestry and saw 128 unrelated files; `gh pr view 687 --json files` showed 6. |
 ```
 
+## Operational requirements for QC agents in this repo
+
+QC agents dispatched on this repo MUST be invoked with both of:
+
+1. **`isolation: "worktree"`** — qc-structural and qc-behavioral aren't
+   read-only. They run `jj edit <branch>` to check out the PR. Without
+   isolation, those edits mutate the parent workspace's shared `.jj/repo/`
+   and snapshot unrelated files into surprise commits. Observed
+   2026-05-14: two non-isolated QC agents rebased the parent `@` onto
+   `experiments/continuation-tuning` and reverted `dev/status/screener.md`
+   to pre-fix content on disk. Same rule as `feat-*` per
+   `.claude/rules/worktree-isolation.md`.
+
+2. **Run `dune` inside docker** — the dispatch prompt must explicitly
+   instruct the agent to run every `dune build` / `dune build @fmt` /
+   `dune runtest` via:
+
+   ```bash
+   docker exec trading-1-dev bash -c \
+     'cd /workspaces/trading-1/trading && eval $(opam env) && dune build'
+   ```
+
+   Running natively against the host's opam state produces ENVFAIL
+   reports (ocamlformat 0.27.0 vs 0.29.0 skew, missing `core` / `owl`
+   libraries) that aren't about the PR. The container is named
+   `trading-1-dev`; dune root is `/workspaces/trading-1/trading`.
+   Observed 2026-05-14 PR #1090: qc-structural reported ENVFAIL despite
+   the PR being clean and its CI green.
+
+If a QC review comes back ENVFAIL or with bookmark conflicts after the
+agent ran, suspect one of these was skipped — re-dispatch with the
+correct invariants rather than treating the verdict as authoritative.
+
 ## Project-specific reusable references
 
 When filling notes:

--- a/.claude/rules/session-rampup.md
+++ b/.claude/rules/session-rampup.md
@@ -1,0 +1,103 @@
+---
+description: New-session ramp-up sequence for this repo — main CI health check + most-recent priorities doc read, before any agent dispatch or feature work.
+harness: project
+---
+
+# Session ramp-up
+
+At the start of every new Claude Code session in this repo, run these
+two steps **before** dispatching any agent, reading status files, or
+starting feature work.
+
+## Step 0 — Check main CI is green
+
+```bash
+gh run list --branch main --limit 3 \
+  --json conclusion,name,headSha,status
+```
+
+If the latest `CI` workflow conclusion is `failure` (or status is
+`completed` with `conclusion != success`), main is red. **Stop and
+ship a fix PR before doing anything else.** Also scan open watchdog
+issues:
+
+```bash
+gh issue list --label ci-red --state open --limit 5
+```
+
+An open `[ci-watchdog] main CI red on <sha>` issue is the same signal.
+
+### Why
+
+Per `feedback_session_rampup_check_main_ci.md` 2026-05-15: PR #1113
+merged with red CI; watchdog issue #1114 fired and was ignored 12 times
+across 14 hours while 12 more PRs piled on. The 2026-05-16 morning
+session diagnosed red main only after the user flagged it manually.
+Without the step-0 check, the rampup defaults to dispatching feature
+work on a broken base — the fix lands on top of stale broken state
+and obscures the original cause.
+
+### Exception
+
+If the failure is a confirmed CI-infra flake (sandbox race, GHA cache
+state), document and proceed. The hard rule from
+`.claude/rules/pr-merge-gates.md` applies: any `^FAIL:` line in the CI
+log (linter, OUnit test) is never an infra flake.
+
+### Recovery
+
+After closing a red-main incident:
+
+```bash
+gh issue close <N> \
+  --comment "Fixed by PR #<fix>; main green on <new-sha>."
+```
+
+## Step 1 — Read the newest priorities doc
+
+```bash
+ls -1t dev/notes/next-session-priorities-*.md | head -1
+```
+
+`Read` that file. It carries the current P0/P1/defer framing, the
+specific in-flight work items, the rationale, and the sequencing. The
+file is the load-bearing handoff artefact between sessions.
+
+The most recent doc supersedes older ones (header pointers usually
+call out the supersession explicitly).
+
+### Context-on-demand (do NOT auto-read)
+
+These files are reference material — `Read` only if the priorities-doc
+content points at them:
+
+- `dev/status/*.md` — per-track Status + Next-task rows.
+- `dev/plans/*.md` — open design plans.
+- Memory files cited by the priorities doc.
+
+Do NOT pre-load every memory or every status file at session start —
+only the priorities doc + main-CI status. The rest is context-on-demand.
+
+## Step 2 — Confirm + dispatch
+
+After reading the priorities doc, briefly state to the user:
+
+- Main CI status.
+- The P0 task per the doc.
+- Any in-flight work that's still open (PRs, agents, long-running
+  experiments).
+
+Ask whether to dispatch P0 work or focus elsewhere. Two sessions in a
+row have flipped strategy based on intra-session findings (see
+`memory/project_strategic_pivot_broader_first.md`), so the priorities
+doc is the most recent snapshot but not authoritative if the user
+starts the session with new information.
+
+## What NOT to do
+
+- Don't dispatch new feature work on top of a red main.
+- Don't auto-dispatch P0 without confirming the priorities doc still
+  matches the user's current intent.
+- Don't read every status file at session start — they're stale-prone
+  (see `memory/feedback_status_refresh_must_verify.md`), and only the
+  ones the priorities doc cites are load-bearing for this session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,44 @@ implement iteratively step by step:
 - A sub-unit is done when it builds, has tests, and tests pass
 - Plan the full sequence upfront, but execute one step at a time
 
+### Status-file refreshes must verify claims against current main
+
+When refreshing a `dev/status/<track>.md` file, do not assume the
+existing prose is accurate. Status files routinely lag main by days
+or weeks — claims like "**M5.2a-d still PLANNED**" or "**blocked on
+M5.1**" can be wrong even when the file's "Last updated" date is
+recent.
+
+For each substantive claim in the file you're editing, verify before
+keeping or modifying it:
+
+1. **PR-number claims** (e.g. "M5.2a still PLANNED"): check whether
+   the work has shipped. `gh api "repos/dayfine/trading/pulls?state=closed&per_page=20" --jq '.[] | "\(.number) \(.title)"'`
+   for a recent window, or `ls trading/trading/<expected-path>/` to
+   check whether the named module exists on main.
+2. **Blocker claims** (e.g. "blocked on M5.1 split_day_stop_exit
+   fix"): check current CI status on main and recent PR history for
+   fix-commits — `git log --oneline | grep -E '<keyword>' | head`.
+3. **Status keyword** (`PLANNED` / `IN_PROGRESS` / `MERGED` /
+   `READY_FOR_REVIEW`): if the content body suggests work has shipped
+   (specific PR numbers, "merged" wording), the keyword should reflect
+   that.
+4. **"Next Steps" lists**: the first-position "Next Step" is the most
+   stale-prone. If it says "fix bug X" but bug X was fixed weeks ago,
+   the whole list needs reconciliation.
+
+**Pre-flight check before dispatching `feat-*` agents:** for any
+track listed in your dispatch reasoning, briefly verify the named
+module / file / PR doesn't already exist on main. ~30 seconds, saves
+a wrong dispatch.
+
+**Symptom of stale claims you've propagated:** an agent dispatch
+acting on the refreshed status file fails fast because the work was
+already shipped. If that happens, file a docs-reconcile PR immediately
+and update the status doc. Observed 2026-05-04: PR #832 carried
+forward "M5.2a-d still PLANNED" while M5.2a-d had already shipped via
+#756/#768/#774/#780, requiring docs-reconcile PR #836 to recover.
+
 ### Debugging Tips
 
 - For compilation errors with published packages, inspect opam/build to check


### PR DESCRIPTION
## Summary

Promote 5 process rules from my personal Claude memory into the repo's `.claude/rules/` so the same conventions apply to any teammate's Claude Code session (and survive a memory rebuild). Each rule traces back to a specific incident in `~/.claude/projects/.../memory/` and is documented with the date + recovery action.

## Rules promoted

| File | What it pins | Memory source |
|---|---|---|
| `.claude/rules/qc-structural-authority.md` (append) | QC agents must dispatch with `isolation: "worktree"` + run dune via `docker exec trading-1-dev` | `feedback_qc_agents_need_worktree_isolation.md` + `feedback_qc_agents_use_docker.md` |
| `.claude/rules/qc-behavioral-authority.md` (append) | Same invariants, cross-ref to structural | same |
| `.claude/rules/pr-merge-gates.md` (new) | 3-gate merge policy (CI + qc-structural + qc-behavioral) + hard rules for CI verification + admissible-fail exceptions | `feedback_pr_merge_gates.md` + `feedback_pr_merge_ci_gate.md` |
| `.claude/rules/session-rampup.md` (new) | Session start: main-CI green check + read newest priorities doc, BEFORE any dispatch | `feedback_session_rampup_check_main_ci.md` + `feedback_session_rampup_read_priorities.md` |
| `.claude/rules/code-health-discipline.md` (new) | Don't paper over linters with limit bumps / `@large-module` markers / deferred-forever follow-ups | `feedback_no_deferred_codehealth.md` |
| `CLAUDE.md` (append \"Development Workflow\") | Status-file refreshes must verify each claim against current main | `feedback_status_refresh_must_verify.md` |

## What stays in personal memory

- All `project_*` dated state files (ephemeral session summaries, baselines, etc.).
- Personal-style memories (`feedback_keep_going_until_goal`, `feedback_schedulewakeup_loop_only`, `feedback_no_questions_when_autonomous`).
- Already-promoted rules whose memory entries are now redundant: \`feedback_use_jj\`, \`feedback_review_commit_process\`, \`feedback_test_assertion_patterns\`, \`feedback_worktree_isolation\`, \`feedback_no_more_python\`.

## Test plan

- [x] No code changes; docs-only PR.
- [x] Existing `dune runtest` covers no regressions (these rules don't ship behavior).
- [ ] Trust check: future QC dispatches that read these rules don't change verdicts on already-merged PRs (smoke-verified against current main when this PR lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)