### PR TITLE
ops: gitignore Bayesian sweep output dirs to survive jj working-copy ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,10 @@ dev/data/
 # macOS metadata
 .DS_Store
 **/.DS_Store
+
+# Bayesian sweep output dirs — long-running (~12h) experiment outputs
+# that must survive jj working-copy operations (jj new / jj rebase
+# would otherwise wipe them when the working copy materializes to a
+# tree without them). Cf. memory: jj operations during sweeps.
+dev/experiments/bayesian-production-sweep-*/output-v*-parallel*/
+dev/experiments/bayesian-production-sweep-*/output-v*-smoke/


### PR DESCRIPTION
## Summary

V3 Bayesian sweep self-destructed mid-run today (2026-05-21 ~09:00 UTC) because `jj new main@origin` (run while creating an unrelated PR commit) auto-snapshotted the `output-v3-parallel4/` directory into the working-copy commit, then materialized main's tree which has no such dir — wiping the output mid-write. The runner crashed; the iter-1 checkpoint was lost.

This PR gitignores the canonical `output-v*-parallel*/` and `output-v*-smoke/` paths under `dev/experiments/bayesian-production-sweep-*/` so future jj working-copy operations cannot touch them. The bind-mounted host directory remains visible to docker, the runner continues to write into it, but jj treats the dir as untracked = preserved across `jj new`.

## What it does

Adds 2 path globs to `.gitignore`:
- `dev/experiments/bayesian-production-sweep-*/output-v*-parallel*/`
- `dev/experiments/bayesian-production-sweep-*/output-v*-smoke/`

Header comment in `.gitignore` documents WHY (to prevent same-day mistake repeating).

## Test plan

- [x] `.gitignore` syntactically valid (glob pattern).
- [x] Existing winner-fullrun + output-v1/v2 dirs unaffected (they're under different naming).
- [ ] After this merges: relaunch V3 sweep + verify the output dir survives a manual `jj new main@origin` while the runner is alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)