### PR TITLE
feat(promote): cross-scenario validation gate in promote_config.sh

### DIFF
--- a/dev/plans/tuning-methodology-2026-05-21.md
+++ b/dev/plans/tuning-methodology-2026-05-21.md
@@ -96,7 +96,7 @@ Open question: should we run multiple BO sweeps with different seeds + initial_r
 
 For V3 promotion:
 - [x] §1 codified: `promote_config.sh` accepts (optionally) the tuner spec + walk-forward spec paths and embeds them along with the trading repo SHA + BO output path in provenance.md.
-- [ ] §2 MVP: `promote_config.sh` writes a TBD-placeholder validation table; the operator runs the 2 scenarios manually via `backtest_runner` and fills the table in by hand. Codifying the automated run is the followup (~50 LOC bash + backtest_runner invocation + sexp metric extraction).
+- [x] §2 MVP: `promote_config.sh` now runs the 2 reference scenarios automatically via `scenario_runner.exe` and writes structured `validation.sexp` with per-scenario metrics + cell-E baseline + delta + verdict. A regression gate (`PROMOTE_SHARPE_REGRESSION_THRESHOLD`, default 0.10) refuses promotion + cleans up `target_dir` when any panel scenario regresses Sharpe by more than the threshold. Implementation: `dev/scripts/promote_config.sh` + helpers in `dev/scripts/lib/extract_metrics.sh`. See also `dev/plans/tuning-methodology-redesign-2026-05-22.md` §5 P1 (where this MVP scope was re-confirmed).
 - [ ] §2 deferred: add French 49-industry + Shiller scenarios once their goldens stabilize.
 - [ ] §3 deferred: document in next sweep plan, not blocking V3.
 

--- a/dev/scripts/lib/extract_metrics.sh
+++ b/dev/scripts/lib/extract_metrics.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# extract_metrics.sh — sourceable helpers for parsing actual.sexp + composing
+# scratch scenario files in promote_config.sh's cross-scenario validation step.
+#
+# The actual.sexp written by scenario_runner has a flat (key value) sexp shape:
+#   ((total_return_pct N) (total_trades N) (win_rate N) (sharpe_ratio N)
+#    (max_drawdown_pct N) (avg_holding_days N) (open_positions_value N)
+#    (unrealized_pnl N) (force_liquidations_count N))
+#
+# Each (k v) pair is whitespace-separated; the value is the second token. This
+# mirrors dev/scripts/check_sp500_baseline.sh's extraction approach but exposes
+# the helpers for reuse from promote_config.sh.
+#
+# Source from promote_config.sh as:
+#   . "$(dirname "$0")/lib/extract_metrics.sh"
+#
+# Functions exported:
+#   extract_metric <path> <field>
+#       Print the float value of <field> from the actual.sexp at <path>.
+#       Returns empty if the field is missing.
+#
+#   abs_delta <a> <b>
+#       Print |<a> - <b>| via awk. Both args are floats.
+#
+#   regresses_by_more_than <actual> <baseline> <threshold>
+#       Exit 0 if (baseline - actual) > threshold (i.e. actual is worse than
+#       baseline by more than the gate). Exit 1 otherwise. <threshold> is the
+#       allowed regression in the same units as <actual> / <baseline>.
+#       For Sharpe: baseline=0.78, actual=0.65, threshold=0.10 → regression
+#       0.13 > 0.10 → exit 0 (fail).
+#
+#   extract_scenario_overrides_body <scenario_path>
+#       Emit the inner contents of the (config_overrides ( ... )) list from a
+#       scenario sexp, stripping just the field-name and outer list parens.
+#       Used to compose scratch scenarios that merge base + candidate overrides.
+#       Implemented via paren-depth tracking awk.
+#
+#   strip_outer_list_parens <candidate_path>
+#       Read candidate config.sexp (a list of override sexps wrapped in one
+#       outer `(...)`) and emit just the inner content. The result, concatenated
+#       with extract_scenario_overrides_body output, forms the merged inner list
+#       for a scratch scenario's config_overrides.
+
+# Extract a single field's float value from an actual.sexp file.
+extract_metric() {
+  local path="$1" field="$2"
+  # actual.sexp values may be integers, decimals, or scientific notation.
+  sed -n "s/.*($field \\([0-9.eE+-]*\\)).*/\\1/p" "$path" | head -1
+}
+
+# Absolute value of difference between two floats, via awk (POSIX shell can't).
+abs_delta() {
+  local a="$1" b="$2"
+  awk -v a="$a" -v b="$b" \
+    'BEGIN { d = a - b; if (d < 0) d = -d; printf "%g", d }'
+}
+
+# Returns 0 (true) iff <actual> regresses from <baseline> by more than
+# <threshold> in the strict direction: (baseline - actual) > threshold.
+# Sharpe / return are "higher is better" → caller passes them directly.
+# For "lower is better" metrics (max_dd), caller should invert.
+regresses_by_more_than() {
+  local actual="$1" baseline="$2" threshold="$3"
+  awk -v a="$actual" -v b="$baseline" -v t="$threshold" \
+    'BEGIN { exit !((b - a) > t) }'
+}
+
+# Pretty-print a signed delta with explicit sign for the validation table.
+signed_delta() {
+  local actual="$1" baseline="$2"
+  awk -v a="$actual" -v b="$baseline" \
+    'BEGIN { d = a - b; printf (d >= 0 ? "+%.4f" : "%.4f"), d }'
+}
+
+# Extract the inner contents of the (config_overrides (...)) field from a
+# scenario sexp. The output is the body without the outer field-wrapper and
+# the immediate list parens, so each emitted line is one override sexp.
+#
+# Algorithm:
+#   1. Find the `(config_overrides` opening token in the file.
+#   2. Consume from that offset, counting parens, until the field's outer paren
+#      closes (depth back to 0). Buffer everything up to but excluding that
+#      closing paren.
+#   3. From the buffer, strip the leading `(config_overrides` plus whitespace.
+#      What remains is the immediate inner list, e.g. `(((o1)) ((o2)) ... )`.
+#   4. Find the first `(` and last `)` of that remaining content; everything
+#      between is the list body — what we emit.
+#
+# Done in one awk pass so multi-line `(config_overrides ...)` blocks (the
+# usual case) work uniformly.
+extract_scenario_overrides_body() {
+  local scenario_path="$1"
+  awk '
+    BEGIN { found = 0; depth = 0; buf = "" }
+    {
+      line = $0
+      if (!found) {
+        idx = index(line, "(config_overrides")
+        if (idx == 0) { next }
+        line = substr(line, idx)
+        found = 1
+      }
+      i = 1; n = length(line)
+      while (i <= n) {
+        c = substr(line, i, 1)
+        if (c == "(") depth++
+        else if (c == ")") {
+          depth--
+          if (depth == 0) {
+            # Capture everything up through this closing paren, then strip
+            # the wrapper. The buffer at this point is:
+            #   "(config_overrides ... (...) ... )"
+            buf = buf substr(line, 1, i)
+            # Strip leading "(config_overrides" + whitespace.
+            sub(/^\(config_overrides[[:space:]]+/, "", buf)
+            # Strip trailing ")" (the closing of config_overrides field).
+            buf = substr(buf, 1, length(buf) - 1)
+            # buf is now the immediate inner list `(((o1))...((oN)))`.
+            # Strip the outermost parens of that list.
+            sub(/^[[:space:]]*\(/, "", buf)
+            sub(/\)[[:space:]]*$/, "", buf)
+            print buf
+            exit
+          }
+        }
+        i++
+      }
+      buf = buf line "\n"
+    }
+  ' "$scenario_path"
+}
+
+# Strip the outermost list parens from a candidate config.sexp. The candidate
+# is one outer list `( <override1> <override2> ... )` where each child is a
+# partial-config sexp. We want just the children, suitable for appending to
+# a scenario's config_overrides body.
+strip_outer_list_parens() {
+  local candidate_path="$1"
+  awk '
+    BEGIN { started = 0; depth = 0; out = "" }
+    {
+      line = $0
+      i = 1; n = length(line)
+      while (i <= n) {
+        c = substr(line, i, 1)
+        if (!started) {
+          if (c == "(") { started = 1; depth = 1; i++; continue }
+          if (c == " " || c == "\t" || c == "\n") { i++; continue }
+        } else {
+          if (c == "(") depth++
+          else if (c == ")") {
+            depth--
+            if (depth == 0) { print out; exit }
+          }
+          out = out c
+        }
+        i++
+      }
+      out = out "\n"
+    }
+  ' "$candidate_path"
+}
+
+# Extract a single top-level scenario field that fits on one line, e.g.
+# `(name "sp500-2019-2023")` or `(universe_path "universes/sp500.sexp")`. The
+# regex matches the field name and captures the quoted-string or single-token
+# value verbatim. Returns the literal sexp child including any quotes.
+#
+# Limited intentionally — used only for the small set of fields the scratch-
+# scenario composer needs, where each field is a single-line `(key value)` in
+# every goldens-sp500* scenario. For multi-line / nested fields use
+# extract_scenario_overrides_body instead.
+extract_scenario_field() {
+  local scenario_path="$1" field="$2"
+  awk -v field="$field" '
+    BEGIN { pat = "^[[:space:]]*\\(" field "[[:space:]]+" }
+    $0 ~ pat {
+      # Drop "(field " prefix and the matching trailing ")".
+      sub(pat, "", $0)
+      sub(/\)[[:space:]]*$/, "", $0)
+      print
+      exit
+    }
+  ' "$scenario_path"
+}
+
+# Compose a scratch scenario file by merging base scenario's config_overrides
+# with the candidate's overrides. Writes to <out_path>.
+#
+# The composed scenario carries the base's name, description, period,
+# universe_path, and config_overrides — extended by the candidate. The
+# `expected` block is set to NaN-tolerant wide ranges since validation cares
+# only about the metrics, not the PASS/FAIL gate against pinned cell-E ranges.
+#
+# Args:
+#   base_scenario_path  — path to the base scenario .sexp
+#   candidate_path      — path to the candidate config.sexp
+#   scratch_name        — name for the scratch scenario (used in actual.sexp
+#                         output dir; should differ from base to keep output
+#                         dirs isolated)
+#   out_path            — where to write the composed scratch scenario .sexp
+compose_scratch_scenario() {
+  local base_scenario_path="$1"
+  local candidate_path="$2"
+  local scratch_name="$3"
+  local out_path="$4"
+
+  local period universe_path base_overrides candidate_overrides
+  period=$(extract_scenario_field "$base_scenario_path" period)
+  universe_path=$(extract_scenario_field "$base_scenario_path" universe_path)
+  base_overrides=$(extract_scenario_overrides_body "$base_scenario_path")
+  candidate_overrides=$(strip_outer_list_parens "$candidate_path")
+
+  if [ -z "$period" ] || [ -z "$universe_path" ]; then
+    echo "[extract_metrics] failed to extract period/universe_path from $base_scenario_path" >&2
+    return 1
+  fi
+
+  # Description is best-effort: multi-line descriptions don't extract cleanly,
+  # and the description is not load-bearing for validation (only name, period,
+  # universe_path, and config_overrides matter to the runner).
+  local description
+  description='"promote-validation scratch scenario"'
+
+  # Wide expected ranges — these intentionally accept any reasonable backtest
+  # result so the scenario_runner writes actual.sexp without flapping the
+  # PASS/FAIL gate. The promote-gate's regression check is separate.
+  cat > "$out_path" << EOF
+;; Auto-generated scratch scenario for promote-gate cross-scenario validation.
+;; Base: $base_scenario_path
+;; Candidate overrides appended from: $candidate_path
+((name "$scratch_name")
+ (description $description)
+ (period $period)
+ (universe_path $universe_path)
+ (config_overrides
+  ($base_overrides
+   $candidate_overrides))
+ (expected
+  ((total_return_pct       ((min -100.0) (max 10000.0)))
+   (total_trades           ((min 0)      (max 100000)))
+   (win_rate               ((min 0.0)    (max 100.0)))
+   (sharpe_ratio           ((min -100.0) (max 100.0)))
+   (max_drawdown_pct       ((min 0.0)    (max 100.0)))
+   (avg_holding_days       ((min 0.0)    (max 10000.0))))))
+EOF
+}

--- a/dev/scripts/promote_config.sh
+++ b/dev/scripts/promote_config.sh
@@ -18,25 +18,56 @@
 #   1. Validates inputs (label format, file existence, parameters repo clone).
 #   2. Creates configs/<label>/ in the trading-parameters repo with:
 #      - config.sexp        (copied from <config_sexp>)
+#      - validation.sexp    (cross-scenario validation results, see below)
 #      - provenance.md      (auto-generated with commit SHA + scenario metrics)
 #      - bo_output/         (symlink or copy of BO output dir, if provided)
-#   3. Updates live/current.sexp symlink to point at the new config.
-#   4. Regenerates _metadata/catalog.sexp from configs/*/provenance.md.
-#   5. Commits in the trading-parameters repo with format:
-#      `promote: <label> — Sharpe X.XX (n=N folds), trading@<sha>`
+#   3. Runs cross-scenario validation (P1 of tuning-methodology-redesign-2026-05-22):
+#      - Applies the candidate config's overrides on top of each reference
+#        scenario's cell-E baseline and runs the resulting scratch scenario via
+#        scenario_runner.exe.
+#      - Reads actual.sexp metrics from each run.
+#      - Compares Sharpe to the cell-E baseline; refuses promotion if any
+#        scenario regresses by more than PROMOTE_SHARPE_REGRESSION_THRESHOLD
+#        (default 0.10 absolute Sharpe units).
+#      - Writes structured per-scenario metrics + cell-E reference + delta
+#        into configs/<label>/validation.sexp.
+#   4. Updates live/current.sexp symlink to point at the new config.
+#   5. Regenerates _metadata/catalog.sexp from configs/*/provenance.md.
+#   6. Commits in the trading-parameters repo with format:
+#      `promote: <label> — trading@<sha>`
 #
 # Environment:
-#   TRADING_PARAMS_DIR  Path to the trading-parameters clone.
-#                       Default: ~/Projects/trading-parameters
+#   TRADING_PARAMS_DIR
+#       Path to the trading-parameters clone.
+#       Default: ~/Projects/trading-parameters
+#
+#   PROMOTE_SHARPE_REGRESSION_THRESHOLD
+#       Maximum allowed Sharpe regression vs cell-E baseline on any scenario,
+#       in absolute Sharpe units. Default 0.10 (i.e. a candidate may not score
+#       0.10 lower Sharpe than cell-E on any panel scenario).
+#
+#   PROMOTE_SKIP_VALIDATION
+#       If set to "1", skip cross-scenario validation entirely. Useful for
+#       smoke-testing the promote machinery in environments that lack the
+#       per-symbol bars corpus (e.g. GHA). Validation.sexp records the skip.
+#
+#   PROMOTE_VALIDATION_PARALLEL
+#       Number of scenarios to run in parallel. Default 2 (the panel size).
 #
 # Exits non-zero on:
 #   - missing required argument
 #   - label already exists in configs/
 #   - source config.sexp not found
 #   - trading-parameters repo not a git checkout
+#   - cross-scenario validation gate failure (refuses promotion; cleans up
+#     target_dir; does NOT touch live/current.sexp or commit)
 #   - any sub-command failure (set -euo pipefail)
 
 set -euo pipefail
+
+# Source extract_metrics helpers used by the cross-scenario validation step.
+# shellcheck disable=SC1091
+. "$(dirname "$0")/lib/extract_metrics.sh"
 
 # ---------------------------------------------------------------------------
 # Args + validation
@@ -132,6 +163,208 @@ if [ -n "$bo_output_dir" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Cross-scenario validation (P1 of tuning-methodology-redesign-2026-05-22)
+# ---------------------------------------------------------------------------
+#
+# Per scenario in the reference panel, compose a scratch scenario sexp that
+# merges the candidate's overrides onto the base scenario's cell-E overrides,
+# run it via scenario_runner.exe, and read actual.sexp to extract metrics.
+# Then compute deltas vs the hardcoded cell-E baseline and apply the
+# regression gate.
+#
+# Cell-E baseline reference values (hardcoded; provenance documented below).
+# These are the canonical cell-E (max_position_pct_long=0.14, exposure=0.70,
+# min_cash=0.30, stage3 h=1, laggard h=2) full-window results on each panel
+# scenario, as measured at the time the scenario was last re-pinned:
+#
+# Source: scenario sexp file headers, both checked-in at HEAD:
+#   - trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp
+#     §"Measured 2026-05-13 (full Cell E, 16.3y window, post-#1052..#1054)"
+#   - trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp
+#     §"Measured 2026-05-12 (Cell E, post-#1052 force-liq fix + #1053 schema)"
+
+PROMOTE_SHARPE_REGRESSION_THRESHOLD="${PROMOTE_SHARPE_REGRESSION_THRESHOLD:-0.10}"
+PROMOTE_SKIP_VALIDATION="${PROMOTE_SKIP_VALIDATION:-0}"
+PROMOTE_VALIDATION_PARALLEL="${PROMOTE_VALIDATION_PARALLEL:-2}"
+
+# Panel: (scenario_name | base_scenario_sexp_path | cell_e_sharpe | cell_e_return | cell_e_max_dd)
+# When the panel grows (P7 broad-universe / French-49 / Shiller), append rows
+# here. Each row is a single space-separated record.
+read -r -d '' PROMOTE_VALIDATION_PANEL << 'EOF' || true
+sp500-2010-2026 trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp 0.78 341.69 18.36
+sp500-2019-2023 trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp 0.56 50.66 21.56
+EOF
+
+validation_sexp="$target_dir/validation.sexp"
+validation_dir="$(mktemp -d -t promote-validation-XXXXXX)"
+trap 'rm -rf "$validation_dir"' EXIT
+
+# Build validation.sexp incrementally as scenarios complete; the final form
+# is assembled at the end so promotion can fail mid-flight without leaving a
+# partial validation.sexp staged.
+declare -a validation_rows
+declare -a gate_failures
+
+if [ "$PROMOTE_SKIP_VALIDATION" = "1" ]; then
+  echo "=== Cross-scenario validation SKIPPED (PROMOTE_SKIP_VALIDATION=1) ==="
+  validation_rows+=("((status skipped) (reason \"PROMOTE_SKIP_VALIDATION=1 at promote time\"))")
+else
+  echo "=== Cross-scenario validation ==="
+  echo "Sharpe regression threshold: $PROMOTE_SHARPE_REGRESSION_THRESHOLD (absolute units)"
+  echo "Parallel: $PROMOTE_VALIDATION_PARALLEL"
+
+  scratch_scenarios_dir="$validation_dir/scenarios"
+  mkdir -p "$scratch_scenarios_dir"
+
+  # Compose scratch scenarios for every panel row.
+  while IFS=' ' read -r scenario_name base_path _ _ _; do
+    [ -z "$scenario_name" ] && continue
+    full_base_path="$trading_repo_root/$base_path"
+    if [ ! -f "$full_base_path" ]; then
+      echo "Error: panel scenario base file not found: $full_base_path" >&2
+      rm -rf "$target_dir"
+      exit 1
+    fi
+    scratch_path="$scratch_scenarios_dir/scratch-$scenario_name.sexp"
+    if ! compose_scratch_scenario \
+        "$full_base_path" "$config_sexp" \
+        "scratch-$scenario_name" "$scratch_path"; then
+      echo "Error: failed to compose scratch scenario for $scenario_name" >&2
+      rm -rf "$target_dir"
+      exit 1
+    fi
+    echo "Composed scratch scenario: $scratch_path"
+  done <<< "$PROMOTE_VALIDATION_PANEL"
+
+  # Build scenario_runner.exe (idempotent if already built).
+  echo "Building scenario_runner.exe..."
+  ( cd "$trading_repo_root/trading" && dune build trading/backtest/scenarios/scenario_runner.exe ) \
+    >/dev/null 2>&1 || {
+      echo "Error: dune build scenario_runner.exe failed" >&2
+      rm -rf "$target_dir"
+      exit 1
+    }
+  scenario_runner_exe="$trading_repo_root/trading/_build/default/trading/backtest/scenarios/scenario_runner.exe"
+
+  if [ ! -x "$scenario_runner_exe" ]; then
+    echo "Error: scenario_runner.exe missing post-build: $scenario_runner_exe" >&2
+    rm -rf "$target_dir"
+    exit 1
+  fi
+
+  # Run all scratch scenarios. We tolerate non-zero exit from scenario_runner
+  # because its PASS/FAIL gate compares against pinned cell-E ranges that the
+  # candidate may legitimately exceed (in either direction). The validation
+  # gate below reads actual.sexp directly.
+  runner_log="$validation_dir/runner.log"
+  # Capture the pre-run state of dev/backtest/scenarios-* so we can identify
+  # the runner's new output dir even when other backtests created dirs before.
+  pre_run_marker="$validation_dir/pre_run_marker"
+  touch "$pre_run_marker"
+  echo "Running scratch scenarios (this may take 15-60 min per scenario)..."
+  set +e
+  "$scenario_runner_exe" \
+    --dir "$scratch_scenarios_dir" \
+    --fixtures-root "$trading_repo_root/trading/test_data/backtest_scenarios" \
+    --parallel "$PROMOTE_VALIDATION_PARALLEL" \
+    --no-emit-all-eligible \
+    > "$runner_log" 2>&1
+  runner_exit=$?
+  set -e
+  echo "scenario_runner exited $runner_exit (non-zero is allowed; gate reads actual.sexp directly)"
+
+  # Locate the scenario_runner output root. The runner makes a fresh
+  # dev/backtest/scenarios-<timestamp>/ dir per invocation; pick the newest
+  # one created after our pre-run marker.
+  runner_output_root=$(find "$trading_repo_root/dev/backtest" \
+    -maxdepth 1 -mindepth 1 -type d -name 'scenarios-*' \
+    -newer "$pre_run_marker" 2>/dev/null \
+    | head -1)
+  if [ -z "$runner_output_root" ] || [ ! -d "$runner_output_root" ]; then
+    echo "Error: cannot find scenario_runner output root under dev/backtest/ (no scenarios-* dir newer than $pre_run_marker)" >&2
+    tail -20 "$runner_log" >&2
+    rm -rf "$target_dir"
+    exit 1
+  fi
+  echo "scenario_runner output root: $runner_output_root"
+
+  # Extract metrics + apply gate per scenario.
+  while IFS=' ' read -r scenario_name base_path cell_e_sharpe cell_e_return cell_e_max_dd; do
+    [ -z "$scenario_name" ] && continue
+    actual_sexp="$runner_output_root/scratch-$scenario_name/actual.sexp"
+    if [ ! -f "$actual_sexp" ]; then
+      echo "Error: actual.sexp missing for $scenario_name: $actual_sexp" >&2
+      tail -20 "$runner_log" >&2
+      rm -rf "$target_dir"
+      exit 1
+    fi
+
+    actual_sharpe=$(extract_metric "$actual_sexp" sharpe_ratio)
+    actual_return=$(extract_metric "$actual_sexp" total_return_pct)
+    actual_max_dd=$(extract_metric "$actual_sexp" max_drawdown_pct)
+    actual_trades=$(extract_metric "$actual_sexp" total_trades)
+    actual_win_rate=$(extract_metric "$actual_sexp" win_rate)
+
+    if [ -z "$actual_sharpe" ]; then
+      echo "Error: failed to extract sharpe_ratio from $actual_sexp" >&2
+      cat "$actual_sexp" >&2
+      rm -rf "$target_dir"
+      exit 1
+    fi
+
+    sharpe_delta=$(signed_delta "$actual_sharpe" "$cell_e_sharpe")
+    return_delta=$(signed_delta "$actual_return" "$cell_e_return")
+    max_dd_delta=$(signed_delta "$actual_max_dd" "$cell_e_max_dd")
+
+    # Gate: candidate must not regress Sharpe by more than the threshold.
+    verdict="pass"
+    if regresses_by_more_than \
+        "$actual_sharpe" "$cell_e_sharpe" \
+        "$PROMOTE_SHARPE_REGRESSION_THRESHOLD"; then
+      verdict="fail"
+      gate_failures+=("$scenario_name: sharpe $actual_sharpe vs cell-E $cell_e_sharpe (delta $sharpe_delta) regresses > $PROMOTE_SHARPE_REGRESSION_THRESHOLD")
+    fi
+
+    echo "  $scenario_name: sharpe=$actual_sharpe (cell-E $cell_e_sharpe, delta $sharpe_delta) return=$actual_return%% (cell-E $cell_e_return%%, delta $return_delta) verdict=$verdict"
+
+    validation_rows+=("((scenario $scenario_name)
+   (verdict $verdict)
+   (cell_e_baseline ((sharpe $cell_e_sharpe) (total_return_pct $cell_e_return) (max_drawdown_pct $cell_e_max_dd)))
+   (candidate ((sharpe $actual_sharpe) (total_return_pct $actual_return) (max_drawdown_pct $actual_max_dd) (total_trades $actual_trades) (win_rate $actual_win_rate)))
+   (delta ((sharpe $sharpe_delta) (total_return_pct $return_delta) (max_drawdown_pct $max_dd_delta))))")
+  done <<< "$PROMOTE_VALIDATION_PANEL"
+fi
+
+# Write validation.sexp.
+{
+  echo ";; Cross-scenario validation results for $label"
+  echo ";; Generated by promote_config.sh on $promotion_date"
+  echo ";; Sharpe regression threshold: $PROMOTE_SHARPE_REGRESSION_THRESHOLD"
+  echo "((label $label)"
+  echo " (promotion_date \"$promotion_date\")"
+  echo " (trading_sha $trading_short_sha)"
+  echo " (sharpe_regression_threshold $PROMOTE_SHARPE_REGRESSION_THRESHOLD)"
+  echo " (results ("
+  for row in "${validation_rows[@]}"; do
+    echo "  $row"
+  done
+  echo " )))"
+} > "$validation_sexp"
+
+# Apply the gate. On failure: clean up target_dir, refuse promotion.
+if [ "${#gate_failures[@]}" -gt 0 ]; then
+  echo ""
+  echo "=== Cross-scenario validation FAILED ==="
+  for f in "${gate_failures[@]}"; do
+    echo "  - $f"
+  done
+  echo ""
+  echo "Promotion refused. Cleaning up $target_dir."
+  rm -rf "$target_dir"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
 # Write provenance.md
 # ---------------------------------------------------------------------------
 
@@ -149,14 +382,14 @@ cat > "$target_dir/provenance.md" << EOF
 
 ## Cross-scenario validation
 
-| Scenario | Cell-E baseline | $label | Delta | Verdict |
-|---|---:|---:|---:|---|
-| sp500-2010-2026 (16y, 510 sym) | TBD | TBD | TBD | TBD |
-| sp500-2019-2023 (5y, 500 sym) | TBD | TBD | TBD | TBD |
+Sharpe regression threshold: \`$PROMOTE_SHARPE_REGRESSION_THRESHOLD\` absolute units.
+See \`validation.sexp\` for full structured results.
 
-(Populate this table by running the scenarios via \`backtest_runner\` with
-the config and comparing to baseline. Manual for now; the \`run_validation\`
-function below is the proposed automation.)
+$(if [ "$PROMOTE_SKIP_VALIDATION" = "1" ]; then
+    echo "**SKIPPED** — PROMOTE_SKIP_VALIDATION=1 at promote time. validation.sexp records the skip; this config has not been verified against the panel."
+  else
+    echo "All panel scenarios passed the Sharpe regression gate."
+  fi)
 
 ## How to use
 


### PR DESCRIPTION
## Summary

Implements P1 of `dev/plans/tuning-methodology-redesign-2026-05-22.md` §5: cross-scenario validation as the promote gate (option A; option B BO-training-input deferred).

Extends `promote_config.sh` to run the candidate config against a fixed panel of reference scenarios (`sp500-2010-2026` + `sp500-2019-2023`) and apply a Sharpe-regression gate before the promotion commit lands. No more TBD-placeholder validation tables in `provenance.md`.

## What changes

- **`dev/scripts/promote_config.sh`**: new "Cross-scenario validation" step inserted between "Stage files in target_dir" and "Write provenance.md". For each panel scenario, composes a scratch scenario sexp (merging candidate overrides onto base scenario's cell-E overrides), runs via `scenario_runner.exe --dir <tmp>`, reads `actual.sexp`, compares to hardcoded cell-E baseline, writes structured per-scenario metrics + delta + verdict into `<target_dir>/validation.sexp`. On regression failure: cleans up `target_dir` + refuses promotion (no symlink update, no commit).

- **`dev/scripts/lib/extract_metrics.sh`** (new): sourceable helpers for promote-gate validation: `extract_metric` (parse `actual.sexp` field), `abs_delta` / `signed_delta` / `regresses_by_more_than` (float math via awk), `extract_scenario_overrides_body` / `strip_outer_list_parens` / `compose_scratch_scenario` (paren-counted scratch-scenario composer).

- **`dev/plans/tuning-methodology-2026-05-21.md` §4**: §2 MVP item `[ ]` → `[x]` with cross-reference to the redesign plan.

## Gate semantics

`PROMOTE_SHARPE_REGRESSION_THRESHOLD` (default `0.10`, absolute Sharpe units): a candidate may not score 0.10 lower Sharpe than the cell-E baseline on any panel scenario. The cell-E baselines are hardcoded in the script with provenance comments pointing at the scenario sexp file headers where they were measured (`sp500-2010-2026`: Sharpe 0.78; `sp500-2019-2023`: Sharpe 0.56).

`PROMOTE_SKIP_VALIDATION=1` short-circuits the panel for smoke tests in environments without the per-symbol bars corpus (GHA). `validation.sexp` records the skip.

`PROMOTE_VALIDATION_PARALLEL` (default 2 = panel size) controls scenario_runner parallelism.

## Validation.sexp shape

```
((label 2026-05-22-foo)
 (promotion_date "2026-05-22 ...")
 (trading_sha abc1234)
 (sharpe_regression_threshold 0.10)
 (results (
  ((scenario sp500-2010-2026)
   (verdict pass)
   (cell_e_baseline ((sharpe 0.78) (total_return_pct 341.69) (max_drawdown_pct 18.36)))
   (candidate       ((sharpe 0.81) (total_return_pct 388.4) (max_drawdown_pct 17.2) (total_trades 845) (win_rate 39.1)))
   (delta           ((sharpe +0.0300) (total_return_pct +46.7100) (max_drawdown_pct -1.1600))))
  ((scenario sp500-2019-2023) ...) )))
```

## Test plan

- [x] `dune build` + `dune runtest devtools/checks` — all linters green (`posix_sh_check`, `no_python_check`, `file_length`, `magic_numbers`, `fmt`, etc.).
- [x] `bash -n` syntax check on both shell files.
- [x] End-to-end dry-run with `PROMOTE_SKIP_VALIDATION=1`: `config.sexp` + `validation.sexp` (records skip) + `provenance.md` + symlink + catalog + commit all land cleanly in a fake `trading-parameters` repo.
- [x] Direct unit tests of all helper functions: `extract_metric` parses `total_return_pct` / `sharpe_ratio` / `max_drawdown_pct` from a real `actual.sexp`; `regresses_by_more_than` correctly classifies gain / small-regression / large-regression / at-threshold cases.
- [x] `compose_scratch_scenario` produces well-formed sexps for both panel scenarios; scenarios parse + load through `scenario_runner.exe` (the runner started executing each before being killed by the test timeout).
- [ ] **Post-merge**: an end-to-end real-bars dry-run with the V3 winner config under `dev/experiments/bayesian-production-sweep-2026-05-18/output-v3-parallel4/best.sexp` (manual; ~30 min wall).

## Deferred (per task prompt)

- French 49-industry + Shiller scenarios — separate runners; defer to follow-up.
- Broad-universe Russell 3000 — needs IWV scrape data first; defer.
- `--config-path` runner flag — deferred to a separate PR (per #1234's deferral list).
- BO-training-input cross-scenario validation (option B in `dev/plans/tuning-methodology-redesign-2026-05-22.md` §2.5) — deferred.