### PR TITLE
fix(promote): route dune build + scenario_runner.exe through docker exec

### DIFF
--- a/dev/reviews/fix-promote-docker-dune-build.md
+++ b/dev/reviews/fix-promote-docker-dune-build.md
@@ -1,0 +1,29 @@
+Reviewed SHA: 58aab1aebc982f8ab5b831fd82ee36c38eea66af
+
+## Structural Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| H1 | dune build @fmt | PASS | No OCaml changes, shell-only |
+| H2 | dune build | PASS | Full build succeeds |
+| H3 | dune runtest | PASS | All tests pass; no-python + magic-numbers linters clean |
+| P1 | Functions ≤ 50 lines (linter) | NA | No OCaml functions |
+| P2 | No magic numbers (linter) | NA | No OCaml changes |
+| P3 | Config completeness | NA | No tunable parameters |
+| P4 | Public-symbol export hygiene (linter) | NA | No OCaml changes |
+| P5 | Internal helpers prefixed per convention | NA | No OCaml changes |
+| P6 | Tests conform to test-patterns | NA | No test changes |
+| A1 | Core module modifications | NA | No modifications to Portfolio/Orders/Position/Strategy/Engine |
+| A2 | No new analysis/ imports into trading/trading/ | NA | No new dependencies |
+| A3 | No unnecessary modifications to existing modules | PASS | Only dev/scripts/promote_config.sh changed (non-core) |
+
+## Verdict
+
+APPROVED
+
+Notes:
+- Shell syntax check passes (`bash -n`).
+- Fix is mechanical: routes `dune build` and `scenario_runner.exe` invocations through `docker exec trading-1-dev` instead of running on host.
+- Path rewriting uses safe bash parameter expansion; no injection risk.
+- Two QC review files bundled (from #1240) are documentation only — not functional changes.
+- Ancestry clean: one commit directly off main.

--- a/dev/scripts/promote_config.sh
+++ b/dev/scripts/promote_config.sh
@@ -236,11 +236,15 @@ else
     echo "Composed scratch scenario: $scratch_path"
   done <<< "$PROMOTE_VALIDATION_PANEL"
 
-  # Build scenario_runner.exe (idempotent if already built).
-  echo "Building scenario_runner.exe..."
-  ( cd "$trading_repo_root/trading" && dune build trading/backtest/scenarios/scenario_runner.exe ) \
+  # Build scenario_runner.exe via docker (idempotent if already built).
+  # This repo's OCaml toolchain lives in the trading-1-dev container; the
+  # host opam switch is intentionally minimal and missing libraries like
+  # core_unix.
+  echo "Building scenario_runner.exe (inside docker)..."
+  docker exec "${PROMOTE_DOCKER_CONTAINER:-trading-1-dev}" bash -c \
+    'cd /workspaces/trading-1/trading && eval $(opam env) && dune build trading/backtest/scenarios/scenario_runner.exe' \
     >/dev/null 2>&1 || {
-      echo "Error: dune build scenario_runner.exe failed" >&2
+      echo "Error: dune build scenario_runner.exe failed inside docker" >&2
       rm -rf "$target_dir"
       exit 1
     }
@@ -252,22 +256,30 @@ else
     exit 1
   fi
 
-  # Run all scratch scenarios. We tolerate non-zero exit from scenario_runner
-  # because its PASS/FAIL gate compares against pinned cell-E ranges that the
-  # candidate may legitimately exceed (in either direction). The validation
-  # gate below reads actual.sexp directly.
+  # Run all scratch scenarios via docker (same toolchain as the build). We
+  # tolerate non-zero exit because the runner's PASS/FAIL gate compares
+  # against pinned cell-E ranges that the candidate may legitimately exceed
+  # (in either direction). The validation gate below reads actual.sexp
+  # directly.
   runner_log="$validation_dir/runner.log"
   # Capture the pre-run state of dev/backtest/scenarios-* so we can identify
   # the runner's new output dir even when other backtests created dirs before.
   pre_run_marker="$validation_dir/pre_run_marker"
   touch "$pre_run_marker"
   echo "Running scratch scenarios (this may take 15-60 min per scenario)..."
+  # Translate host paths to docker-visible paths (the bind-mount maps
+  # /Users/difan/Projects/trading-1 → /workspaces/trading-1).
+  docker_repo_root="/workspaces/trading-1"
+  docker_scratch_dir="${scratch_scenarios_dir/$trading_repo_root/$docker_repo_root}"
+  docker_runner_exe="${scenario_runner_exe/$trading_repo_root/$docker_repo_root}"
   set +e
-  "$scenario_runner_exe" \
-    --dir "$scratch_scenarios_dir" \
-    --fixtures-root "$trading_repo_root/trading/test_data/backtest_scenarios" \
-    --parallel "$PROMOTE_VALIDATION_PARALLEL" \
-    --no-emit-all-eligible \
+  docker exec "${PROMOTE_DOCKER_CONTAINER:-trading-1-dev}" bash -c "
+    cd $docker_repo_root/trading && eval \$(opam env) &&
+    $docker_runner_exe \\
+      --dir $docker_scratch_dir \\
+      --fixtures-root $docker_repo_root/trading/test_data/backtest_scenarios \\
+      --parallel $PROMOTE_VALIDATION_PARALLEL \\
+      --no-emit-all-eligible" \
     > "$runner_log" 2>&1
   runner_exit=$?
   set -e


### PR DESCRIPTION
## Summary

Fix-forward for #1240 caught during the first real-bars V3-winner promotion attempt. The promote_config.sh validation step shipped in #1240 tries to run \`dune build\` + \`scenario_runner.exe\` on the HOST, but this repo's OCaml toolchain lives only inside the \`trading-1-dev\` container. Host opam env is minimal and missing libraries like \`core_unix\`.

Reproducer:
\`\`\`sh
dev/scripts/promote_config.sh 2026-05-22-bayesian-v3-winner \
  dev/experiments/.../output-v3-parallel4/best.sexp ...
# Error: dune build scenario_runner.exe failed (host build fails on missing core_unix)
\`\`\`

This is the gap qc-behavioral flagged on #1240 (\`harness_gap: ONGOING_REVIEW\`): the real-bars end-to-end run was never exercised pre-merge.

## What it does

1. Routes \`dune build scenario_runner.exe\` through \`docker exec trading-1-dev bash -c '... eval \$(opam env) && dune build ...'\`.
2. Invokes \`scenario_runner.exe\` via the same docker exec path. Host paths (\`/Users/difan/Projects/trading-1/...\`) are rewritten to docker-visible paths (\`/workspaces/trading-1/...\`) before being passed to the container.
3. Adds \`PROMOTE_DOCKER_CONTAINER\` env var override (default \`trading-1-dev\`) for future container-rename scenarios.
4. Includes the QC review files (\`dev/reviews/p1-cross-scenario-validation{,-behavioral}.md\`) generated during #1240's review, for the audit trail.

## Test plan

- [x] \`bash -n dev/scripts/promote_config.sh\` passes.
- [ ] **Post-merge:** re-attempt V3 winner promotion. Confirm scenario_runner.exe builds + runs successfully via docker. Track regression-gate verdict (PASS or FAIL).

## Sequencing

This is a fix-forward; the post-merge test will be the actual E2E exercise of the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)