### PR TITLE
fix(promote): place validation tmpdir under repo bind-mount (dev/_tmp/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,11 @@ dev/perf/
 # Was getting wiped mid-run by jj auto-snapshot before this entry landed.
 dev/data/
 
+# Promote-config validation scratch dirs (composed scratch scenarios for
+# the cross-scenario gate). Live under dev/_tmp/ so docker (scenario_runner)
+# can see them via the bind-mount; cleaned up by promote_config.sh on exit.
+dev/_tmp/
+
 # jj conflict materialization directories (never commit these)
 .jjconflict-base-*/
 .jjconflict-side-*/

--- a/dev/scripts/promote_config.sh
+++ b/dev/scripts/promote_config.sh
@@ -196,7 +196,11 @@ sp500-2019-2023 trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-20
 EOF
 
 validation_sexp="$target_dir/validation.sexp"
-validation_dir="$(mktemp -d -t promote-validation-XXXXXX)"
+# Place validation_dir under the repo bind-mount so docker (running
+# scenario_runner.exe) can see the composed scratch scenarios. Host TMPDIR
+# (/var/folders/... on macOS) is NOT bind-mounted into trading-1-dev.
+mkdir -p "$trading_repo_root/dev/_tmp"
+validation_dir="$(mktemp -d "$trading_repo_root/dev/_tmp/promote-validation-XXXXXX")"
 trap 'rm -rf "$validation_dir"' EXIT
 
 # Build validation.sexp incrementally as scenarios complete; the final form


### PR DESCRIPTION
## Summary

P0 V3 promotion E2E (per `dev/notes/next-session-priorities-2026-05-22.md`) surfaced a host/docker path bug: `mktemp -d -t promote-validation-XXXXXX` puts the validation scratch dir under host `TMPDIR` (`/var/folders/...` on macOS), which is NOT bind-mounted into `trading-1-dev`. `scenario_runner.exe` (run inside docker) cannot see the composed scratch scenarios; the run fails with `No such file or directory` on `<tmpdir>/scenarios/`.

Fix: `mktemp` the validation scratch dir under `$trading_repo_root/dev/_tmp/` so docker sees it via the existing `/Users/difan/Projects/trading-1 → /workspaces/trading-1` bind-mount. The `trap rm -rf "$validation_dir" EXIT` still cleans up after each run.

Also: add `dev/_tmp/` to `.gitignore` (transient scratch — never commit).

## Why this is a separate fix-forward

Same class of bug as #1241 (route `dune build` through docker), but on a different variable. #1241 handled the path the script *constructs* for the dune command; this PR handles the path `mktemp` *chooses by default* (host TMPDIR). Both stem from `feedback_docker_vs_host_dune` — any host path the script hands to a docker process must be inside the bind-mount.

## Test plan

- [x] `bash -n dev/scripts/promote_config.sh` — syntax check passes.
- [ ] Post-merge: re-run V3 promotion E2E and verify `scenario_runner.exe` completes (this is the P0 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)