### PR TITLE
docs(sweep): update §6 axis-3 from 'Sharpe ≥ 0.50' to Option E (≥ baseline − 0.10)

### DIFF
--- a/dev/plans/bayesian-production-sweep-2026-05-18.md
+++ b/dev/plans/bayesian-production-sweep-2026-05-18.md
@@ -209,7 +209,7 @@ catastrophes by averaging; the floors enforce per-fold sanity.
 
 - **Mean-fold composite score ≥ baseline Cell-E + 0.05** (5% relative improvement) — composite-axis gate (per #1196 Q4, v1 uses mean; median is a follow-up)
 - **No fold loses to Cell-E by more than -0.10 composite** (no single-fold catastrophe) — composite-axis floor
-- **OOS Sharpe ≥ 0.50** on every fold (strategy still risk-adjusted-positive everywhere) — orthogonal hard floor
+- **OOS Sharpe ≥ baseline Cell-E Sharpe − 0.10** on every fold (per-fold relative floor — Option E, adopted from `dev/notes/axis-3-gate-fitness-2026-05-21.md` §Recommendation). Replaces the original v1 axis-3 "OOS Sharpe ≥ 0.50 every fold," which (per #1232 + #1237 §10) was unfit: it held candidates to a higher bar than the canonical baseline meets on structurally-bad folds (e.g. fold-29 cell-E Sharpe = −1.14), and locked out productive sweeps.
 - **MaxDD ≤ baseline Cell-E + 5pp** on every fold (no risk-budget blowout) — orthogonal hard floor
 - **N_trades within 2x of baseline** (consistency with mechanic-invariant claim) — orthogonal hard floor
 


### PR DESCRIPTION
## Summary

Per #1232 + #1237 §10 + `dev/notes/axis-3-gate-fitness-2026-05-21.md` §Recommendation:

The v1 axis-3 of the 5-axis promote gate (`OOS Sharpe ≥ 0.50` on every fold) was unfit:

- Cell-E baseline has fold-29 Sharpe = **−1.14** (well below 0.50). Any candidate that is strictly better than cell-E on this fold (say, Sharpe −0.66) still **fails** the absolute floor.
- This makes axis-3 reject strictly-better candidates and lock out productive sweeps. Under v1, V2 + V3 + V4 winners all REJECT regardless of how much they beat cell-E.

Option E (per-fold relative floor: `OOS Sharpe ≥ baseline_Cell-E_Sharpe − 0.10`) preserves the "no catastrophic-fold" intent while accepting that on structurally-bad folds, candidates only need to hold near baseline rather than exceed an absolute threshold.

This PR codifies the decision in `dev/plans/bayesian-production-sweep-2026-05-18.md` §6 — single bullet swap. `promote_config.sh` (#1240) already implements Option E.

## Test plan

- [x] Diff is 1 file × 1 bullet (`-1/+1` LOC).
- [x] No-QC per #1239 (docs-only PR exception).

🤖 Generated with [Claude Code](https://claude.com/claude-code)