### PR TITLE
feat(promote): extend gate to MaxDD + N_trades + add smoke test

### DIFF
--- a/dev/scripts/lib/extract_metrics.sh
+++ b/dev/scripts/lib/extract_metrics.sh
@@ -58,11 +58,23 @@ abs_delta() {
 # Returns 0 (true) iff <actual> regresses from <baseline> by more than
 # <threshold> in the strict direction: (baseline - actual) > threshold.
 # Sharpe / return are "higher is better" → caller passes them directly.
-# For "lower is better" metrics (max_dd), caller should invert.
+# For "lower is better" metrics (max_dd), caller should invert the args:
+# `regresses_by_more_than <baseline> <actual> <threshold>` returns 0 iff
+# (actual - baseline) > threshold.
 regresses_by_more_than() {
   local actual="$1" baseline="$2" threshold="$3"
   awk -v a="$actual" -v b="$baseline" -v t="$threshold" \
     'BEGIN { exit !((b - a) > t) }'
+}
+
+# Returns 0 (true) iff <actual> is outside [<baseline>/<ratio>, <baseline>*<ratio>].
+# Used for the N_trades gate: a candidate that trades 5x more or 5x less than
+# baseline is treated as a different strategy, even if Sharpe survives.
+# Ratio must be > 1.0; ratio=2.0 means "within 2x in either direction".
+trades_out_of_ratio() {
+  local actual="$1" baseline="$2" ratio="$3"
+  awk -v a="$actual" -v b="$baseline" -v r="$ratio" \
+    'BEGIN { exit !(a > b * r || a * r < b) }'
 }
 
 # Pretty-print a signed delta with explicit sign for the validation table.

--- a/dev/scripts/promote_config.sh
+++ b/dev/scripts/promote_config.sh
@@ -46,6 +46,18 @@
 #       in absolute Sharpe units. Default 0.10 (i.e. a candidate may not score
 #       0.10 lower Sharpe than cell-E on any panel scenario).
 #
+#   PROMOTE_MAXDD_INCREASE_THRESHOLD
+#       Maximum allowed MaxDD increase vs cell-E baseline on any scenario, in
+#       absolute percentage points. Default 5.0 (i.e. a candidate whose MaxDD
+#       exceeds cell-E by more than 5pp on any panel scenario is refused).
+#       Per Option E (dev/plans/bayesian-production-sweep-2026-05-18.md §6).
+#
+#   PROMOTE_TRADES_RATIO_MAX
+#       Maximum allowed ratio between candidate and baseline total_trades on
+#       any scenario (in either direction). Default 2.0 (i.e. a candidate that
+#       trades more than 2x or less than 0.5x of cell-E is refused).
+#       Catches strategies that trade radically differently from baseline.
+#
 #   PROMOTE_SKIP_VALIDATION
 #       If set to "1", skip cross-scenario validation entirely. Useful for
 #       smoke-testing the promote machinery in environments that lack the
@@ -184,15 +196,18 @@ fi
 #     §"Measured 2026-05-12 (Cell E, post-#1052 force-liq fix + #1053 schema)"
 
 PROMOTE_SHARPE_REGRESSION_THRESHOLD="${PROMOTE_SHARPE_REGRESSION_THRESHOLD:-0.10}"
+PROMOTE_MAXDD_INCREASE_THRESHOLD="${PROMOTE_MAXDD_INCREASE_THRESHOLD:-5.0}"
+PROMOTE_TRADES_RATIO_MAX="${PROMOTE_TRADES_RATIO_MAX:-2.0}"
 PROMOTE_SKIP_VALIDATION="${PROMOTE_SKIP_VALIDATION:-0}"
 PROMOTE_VALIDATION_PARALLEL="${PROMOTE_VALIDATION_PARALLEL:-2}"
 
-# Panel: (scenario_name | base_scenario_sexp_path | cell_e_sharpe | cell_e_return | cell_e_max_dd)
+# Panel: (scenario_name | base_scenario_sexp_path | cell_e_sharpe | cell_e_return | cell_e_max_dd | cell_e_trades)
 # When the panel grows (P7 broad-universe / French-49 / Shiller), append rows
-# here. Each row is a single space-separated record.
+# here. Each row is a single space-separated record. cell_e_trades pinned from
+# the scenario sexp headers; re-pin whenever the scenario is re-measured.
 read -r -d '' PROMOTE_VALIDATION_PANEL << 'EOF' || true
-sp500-2010-2026 trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp 0.78 341.69 18.36
-sp500-2019-2023 trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp 0.56 50.66 21.56
+sp500-2010-2026 trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp 0.78 341.69 18.36 806
+sp500-2019-2023 trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023.sexp 0.56 50.66 21.56 264
 EOF
 
 validation_sexp="$target_dir/validation.sexp"
@@ -221,7 +236,7 @@ else
   mkdir -p "$scratch_scenarios_dir"
 
   # Compose scratch scenarios for every panel row.
-  while IFS=' ' read -r scenario_name base_path _ _ _; do
+  while IFS=' ' read -r scenario_name base_path _ _ _ _; do
     [ -z "$scenario_name" ] && continue
     full_base_path="$trading_repo_root/$base_path"
     if [ ! -f "$full_base_path" ]; then
@@ -305,7 +320,7 @@ else
   echo "scenario_runner output root: $runner_output_root"
 
   # Extract metrics + apply gate per scenario.
-  while IFS=' ' read -r scenario_name base_path cell_e_sharpe cell_e_return cell_e_max_dd; do
+  while IFS=' ' read -r scenario_name base_path cell_e_sharpe cell_e_return cell_e_max_dd cell_e_trades; do
     [ -z "$scenario_name" ] && continue
     actual_sexp="$runner_output_root/scratch-$scenario_name/actual.sexp"
     if [ ! -f "$actual_sexp" ]; then
@@ -331,8 +346,12 @@ else
     sharpe_delta=$(signed_delta "$actual_sharpe" "$cell_e_sharpe")
     return_delta=$(signed_delta "$actual_return" "$cell_e_return")
     max_dd_delta=$(signed_delta "$actual_max_dd" "$cell_e_max_dd")
+    trades_delta=$(signed_delta "$actual_trades" "$cell_e_trades")
 
-    # Gate: candidate must not regress Sharpe by more than the threshold.
+    # Gates (Option E, per dev/plans/bayesian-production-sweep-2026-05-18.md §6):
+    #  - Sharpe regression ≤ threshold (higher-is-better)
+    #  - MaxDD increase ≤ threshold (lower-is-better; swap regresses_by_more_than args)
+    #  - total_trades within ratio (catches strategies that trade radically differently)
     verdict="pass"
     if regresses_by_more_than \
         "$actual_sharpe" "$cell_e_sharpe" \
@@ -340,14 +359,26 @@ else
       verdict="fail"
       gate_failures+=("$scenario_name: sharpe $actual_sharpe vs cell-E $cell_e_sharpe (delta $sharpe_delta) regresses > $PROMOTE_SHARPE_REGRESSION_THRESHOLD")
     fi
+    if regresses_by_more_than \
+        "$cell_e_max_dd" "$actual_max_dd" \
+        "$PROMOTE_MAXDD_INCREASE_THRESHOLD"; then
+      verdict="fail"
+      gate_failures+=("$scenario_name: max_drawdown_pct $actual_max_dd vs cell-E $cell_e_max_dd (delta $max_dd_delta) increases > $PROMOTE_MAXDD_INCREASE_THRESHOLD pp")
+    fi
+    if trades_out_of_ratio \
+        "$actual_trades" "$cell_e_trades" \
+        "$PROMOTE_TRADES_RATIO_MAX"; then
+      verdict="fail"
+      gate_failures+=("$scenario_name: total_trades $actual_trades vs cell-E $cell_e_trades (delta $trades_delta) outside ratio ${PROMOTE_TRADES_RATIO_MAX}x")
+    fi
 
-    echo "  $scenario_name: sharpe=$actual_sharpe (cell-E $cell_e_sharpe, delta $sharpe_delta) return=$actual_return%% (cell-E $cell_e_return%%, delta $return_delta) verdict=$verdict"
+    echo "  $scenario_name: sharpe=$actual_sharpe (cell-E $cell_e_sharpe, delta $sharpe_delta) max_dd=$actual_max_dd (cell-E $cell_e_max_dd, delta $max_dd_delta) trades=$actual_trades (cell-E $cell_e_trades, delta $trades_delta) verdict=$verdict"
 
     validation_rows+=("((scenario $scenario_name)
    (verdict $verdict)
-   (cell_e_baseline ((sharpe $cell_e_sharpe) (total_return_pct $cell_e_return) (max_drawdown_pct $cell_e_max_dd)))
+   (cell_e_baseline ((sharpe $cell_e_sharpe) (total_return_pct $cell_e_return) (max_drawdown_pct $cell_e_max_dd) (total_trades $cell_e_trades)))
    (candidate ((sharpe $actual_sharpe) (total_return_pct $actual_return) (max_drawdown_pct $actual_max_dd) (total_trades $actual_trades) (win_rate $actual_win_rate)))
-   (delta ((sharpe $sharpe_delta) (total_return_pct $return_delta) (max_drawdown_pct $max_dd_delta))))")
+   (delta ((sharpe $sharpe_delta) (total_return_pct $return_delta) (max_drawdown_pct $max_dd_delta) (total_trades $trades_delta))))")
   done <<< "$PROMOTE_VALIDATION_PANEL"
 fi
 
@@ -355,11 +386,15 @@ fi
 {
   echo ";; Cross-scenario validation results for $label"
   echo ";; Generated by promote_config.sh on $promotion_date"
-  echo ";; Sharpe regression threshold: $PROMOTE_SHARPE_REGRESSION_THRESHOLD"
+  echo ";; Gates: Sharpe regression ≤ $PROMOTE_SHARPE_REGRESSION_THRESHOLD,"
+  echo ";;        MaxDD increase ≤ ${PROMOTE_MAXDD_INCREASE_THRESHOLD}pp,"
+  echo ";;        total_trades within ${PROMOTE_TRADES_RATIO_MAX}x"
   echo "((label $label)"
   echo " (promotion_date \"$promotion_date\")"
   echo " (trading_sha $trading_short_sha)"
   echo " (sharpe_regression_threshold $PROMOTE_SHARPE_REGRESSION_THRESHOLD)"
+  echo " (maxdd_increase_threshold_pp $PROMOTE_MAXDD_INCREASE_THRESHOLD)"
+  echo " (trades_ratio_max $PROMOTE_TRADES_RATIO_MAX)"
   echo " (results ("
   for row in "${validation_rows[@]}"; do
     echo "  $row"
@@ -398,13 +433,17 @@ cat > "$target_dir/provenance.md" << EOF
 
 ## Cross-scenario validation
 
-Sharpe regression threshold: \`$PROMOTE_SHARPE_REGRESSION_THRESHOLD\` absolute units.
+Gates applied:
+- Sharpe regression ≤ \`$PROMOTE_SHARPE_REGRESSION_THRESHOLD\` absolute units
+- MaxDD increase ≤ \`${PROMOTE_MAXDD_INCREASE_THRESHOLD}\` percentage points
+- total_trades within \`${PROMOTE_TRADES_RATIO_MAX}x\` of baseline (either direction)
+
 See \`validation.sexp\` for full structured results.
 
 $(if [ "$PROMOTE_SKIP_VALIDATION" = "1" ]; then
     echo "**SKIPPED** — PROMOTE_SKIP_VALIDATION=1 at promote time. validation.sexp records the skip; this config has not been verified against the panel."
   else
-    echo "All panel scenarios passed the Sharpe regression gate."
+    echo "All panel scenarios passed every gate (Sharpe + MaxDD + trades-ratio)."
   fi)
 
 ## How to use

--- a/trading/devtools/checks/dune
+++ b/trading/devtools/checks/dune
@@ -346,6 +346,18 @@
  (action
   (run sh %{dep:no_python_check.sh})))
 
+; promote_config.sh gate-helper smoke test: pins the runtime semantics of
+; regresses_by_more_than (Sharpe + MaxDD), trades_out_of_ratio, and
+; extract_metric. Reads dev/scripts/lib/extract_metrics.sh via repo_root().
+; No dune dep on dev/scripts/* (outside workspace); cache invalidates when
+; the test script itself changes.
+
+(rule
+ (alias runtest)
+ (deps _check_lib.sh)
+ (action
+  (run sh %{dep:extract_metrics_gate_smoke.sh})))
+
 ; Sweep stale worktrees smoke test: verifies (1) --stale-hours 0 is rejected,
 ; (2) locked worktrees appear as "skip" in dry-run mode, (3) --stale-hours 0
 ; combined with --include-active is also rejected. Uses a tmp git repo so it

--- a/trading/devtools/checks/extract_metrics_gate_smoke.sh
+++ b/trading/devtools/checks/extract_metrics_gate_smoke.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Smoke test: pin the runtime semantics of the gate helpers in
+# dev/scripts/lib/extract_metrics.sh used by dev/scripts/promote_config.sh.
+#
+# Exercises three helpers without invoking scenario_runner (which costs
+# 15-60 min per panel scenario). Mocked actual.sexp values cover:
+#   - regresses_by_more_than for Sharpe (higher-is-better): pass + fail
+#   - regresses_by_more_than swapped for MaxDD (lower-is-better): pass + fail
+#   - trades_out_of_ratio: within bounds + above + below
+#
+# Required per memory feedback_promote_config_3_bugs_one_week.md — the
+# script has had 3 fix-forward bugs in 24h that surfaced only at first
+# real usage. Catches future gate-logic regressions before they ship.
+
+set -eu
+
+. "$(dirname "$0")/_check_lib.sh"
+
+LABEL="extract_metrics_gate_smoke"
+
+REPO="$(repo_root)"
+LIB="$REPO/dev/scripts/lib/extract_metrics.sh"
+
+if [ ! -f "$LIB" ]; then
+  die "${LABEL} — missing $LIB"
+fi
+
+# shellcheck disable=SC1090
+. "$LIB"
+
+fail_count=0
+check() {
+  desc="$1"
+  expected="$2"
+  actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  ok: $desc"
+  else
+    echo "  FAIL: $desc (expected exit=$expected, got exit=$actual)" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+# Run a predicate and capture its exit code without tripping set -e.
+exit_of() {
+  set +e
+  "$@" >/dev/null 2>&1
+  rc=$?
+  set -e
+  echo "$rc"
+}
+
+# --- regresses_by_more_than: Sharpe (higher-is-better) ---
+# baseline 0.78, actual 0.65, threshold 0.10 → (0.78-0.65)=0.13 > 0.10 → fail (exit 0)
+check "Sharpe regression > threshold flags fail" "0" \
+  "$(exit_of regresses_by_more_than 0.65 0.78 0.10)"
+# baseline 0.78, actual 0.75, threshold 0.10 → (0.78-0.75)=0.03 ≤ 0.10 → pass (exit 1)
+check "Sharpe regression within threshold flags pass" "1" \
+  "$(exit_of regresses_by_more_than 0.75 0.78 0.10)"
+# baseline 0.78, actual 0.85 (better), threshold 0.10 → improvement → pass (exit 1)
+check "Sharpe improvement flags pass" "1" \
+  "$(exit_of regresses_by_more_than 0.85 0.78 0.10)"
+
+# --- regresses_by_more_than: MaxDD (lower-is-better, args swapped) ---
+# call form: regresses_by_more_than <cell_e_max_dd> <actual_max_dd> <threshold>
+# cell_e=21.56, actual=30.58, threshold=5.0 → (30.58-21.56)=9.02 > 5.0 → fail (exit 0)
+check "MaxDD increase > 5pp flags fail" "0" \
+  "$(exit_of regresses_by_more_than 21.56 30.58 5.0)"
+# cell_e=21.56, actual=25.0, threshold=5.0 → (25.0-21.56)=3.44 ≤ 5.0 → pass (exit 1)
+check "MaxDD increase within 5pp flags pass" "1" \
+  "$(exit_of regresses_by_more_than 21.56 25.0 5.0)"
+# cell_e=21.56, actual=18.0 (lower MaxDD is improvement) → pass (exit 1)
+check "MaxDD improvement flags pass" "1" \
+  "$(exit_of regresses_by_more_than 21.56 18.0 5.0)"
+
+# --- trades_out_of_ratio ---
+# baseline 264, actual 259, ratio 2.0 → within → pass (exit 1)
+check "trades within ratio flags pass" "1" \
+  "$(exit_of trades_out_of_ratio 259 264 2.0)"
+# baseline 264, actual 600, ratio 2.0 → 600 > 264*2=528 → fail (exit 0)
+check "trades above 2x ratio flags fail" "0" \
+  "$(exit_of trades_out_of_ratio 600 264 2.0)"
+# baseline 264, actual 100, ratio 2.0 → 100*2=200 < 264 → fail (exit 0)
+check "trades below 0.5x ratio flags fail" "0" \
+  "$(exit_of trades_out_of_ratio 100 264 2.0)"
+# boundary: baseline 264, actual exactly 528 → at ratio (not strictly above) → pass (exit 1)
+check "trades at exactly 2x boundary flags pass" "1" \
+  "$(exit_of trades_out_of_ratio 528 264 2.0)"
+
+# --- extract_metric: sanity-check on a synthetic actual.sexp ---
+tmp_actual="$(mktemp)"
+trap 'rm -f "$tmp_actual"' EXIT
+cat > "$tmp_actual" << 'SEXP'
+((total_return_pct 50.66) (total_trades 264) (win_rate 37.5) (sharpe_ratio 0.56)
+ (max_drawdown_pct 21.56) (avg_holding_days 40.78) (open_positions_value 1221041)
+ (unrealized_pnl 0) (force_liquidations_count 0))
+SEXP
+check "extract_metric sharpe_ratio" "0.56" "$(extract_metric "$tmp_actual" sharpe_ratio)"
+check "extract_metric total_trades" "264" "$(extract_metric "$tmp_actual" total_trades)"
+check "extract_metric max_drawdown_pct" "21.56" "$(extract_metric "$tmp_actual" max_drawdown_pct)"
+
+if [ "$fail_count" -gt 0 ]; then
+  die "${LABEL} — $fail_count check(s) failed."
+fi
+
+echo "OK: ${LABEL} — all gate-helper smoke checks passed."


### PR DESCRIPTION
## Summary

- **P0** from `dev/notes/next-session-priorities-2026-05-22-pm.md` — extend `dev/scripts/promote_config.sh` gate per Option E (`dev/plans/bayesian-production-sweep-2026-05-18.md` §6).
- Adds two new gates per panel scenario:
  - **MaxDD increase ≤ 5pp** (default; `PROMOTE_MAXDD_INCREASE_THRESHOLD`). Today's V3 winner promotion passed Sharpe but had +9pp MaxDD on sp500-2019-2023 — would be caught by this gate.
  - **total_trades within 2x** of baseline (default; `PROMOTE_TRADES_RATIO_MAX`). Catches candidates that trade radically differently from cell-E.
- New helper `trades_out_of_ratio` in `dev/scripts/lib/extract_metrics.sh`; doc-string on `regresses_by_more_than` updated to spell out the swapped-arg form used for lower-is-better metrics like MaxDD.
- Panel rows now carry `cell_e_trades` (806 sp500-2010-2026; 264 sp500-2019-2023), pinned from current scenario sexp headers.
- `validation.sexp` schema extended: top-level adds `maxdd_increase_threshold_pp` + `trades_ratio_max`; per-scenario `cell_e_baseline` + `candidate` + `delta` blocks include `total_trades`.

## Smoke test (per `feedback_promote_config_3_bugs_one_week.md`)

`promote_config.sh` had 3 fix-forward bugs in 24h that each surfaced only at first real usage. To break that pattern, this PR ships `trading/devtools/checks/extract_metrics_gate_smoke.sh` — a `dune runtest`-wired sh script that pins the runtime semantics of the gate helpers without invoking scenario_runner (which costs 15-60 min per panel scenario).

13 assertions:
- Sharpe regression > / ≤ / improvement (3 cases)
- MaxDD increase > / ≤ / improvement, using swapped-arg form (3 cases)
- total_trades within / above / below / at-2x-boundary ratio (4 cases)
- `extract_metric` sanity on a synthetic actual.sexp (3 cases)

## Test plan

- [x] \`dune runtest devtools/checks/ --force\` — all OK including \`extract_metrics_gate_smoke\`
- [x] \`dune build @fmt\` clean
- [x] \`dune build\` clean
- [ ] Will use the extended gate to validate V8 seed 2027 / 2028 winners after seed 2028 OOS finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)