### PR TITLE
feat(tuner): add int_keys to cell_to_overrides for BO int-knob rounding

### DIFF
--- a/trading/trading/backtest/tuner/lib/grid_search.ml
+++ b/trading/trading/backtest/tuner/lib/grid_search.ml
@@ -58,15 +58,30 @@ let cells_of_spec spec =
   if List.exists spec ~f:(fun (_, vs) -> List.is_empty vs) then []
   else _cartesian spec
 
-let _binding_to_sexp (key, value) =
-  let key_eq_value = sprintf "%s=%.17g" key value in
+(** Format a binding's value as either an integer or a float literal. Int keys
+    round the BO-sampled float to the nearest integer and emit a bare integer
+    atom (e.g. ["4"], not ["4.0"]); float keys emit the raw [%.17g] form. The
+    integer-atom branch matters for Option/int sexp deserializers downstream:
+    [int_of_sexp (Atom "3.8…")] throws, but [int_of_sexp (Atom "4")] succeeds.
+*)
+let _format_binding_value ~is_int value =
+  if is_int then sprintf "%d" (Float.to_int (Float.round_nearest value))
+  else sprintf "%.17g" value
+
+let _binding_to_sexp ~int_keys (key, value) =
+  let is_int = Set.mem int_keys key in
+  let key_eq_value =
+    sprintf "%s=%s" key (_format_binding_value ~is_int value)
+  in
   match Backtest.Config_override.parse_to_sexp key_eq_value with
   | Ok sexp -> sexp
   | Error err ->
       failwithf "cell_to_overrides: failed to parse %s: %s" key_eq_value
         (Status.show err) ()
 
-let cell_to_overrides cell = List.map cell ~f:_binding_to_sexp
+let cell_to_overrides ?(int_keys = []) cell =
+  let int_keys_set = Set.of_list (module String) int_keys in
+  List.map cell ~f:(_binding_to_sexp ~int_keys:int_keys_set)
 
 (** {1 Evaluation} *)
 
@@ -227,8 +242,8 @@ let _write_csv_to ~objective result oc =
 let write_csv ~output_path ~objective result =
   Out_channel.with_file output_path ~f:(_write_csv_to ~objective result)
 
-let write_best_sexp ~output_path result =
-  let sexps = cell_to_overrides result.best_cell in
+let write_best_sexp ?(int_keys = []) ~output_path result =
+  let sexps = cell_to_overrides ~int_keys result.best_cell in
   let combined = Sexp.List sexps in
   Out_channel.with_file output_path ~f:(fun oc ->
       Out_channel.output_string oc (Sexp.to_string_hum combined);

--- a/trading/trading/backtest/tuner/lib/grid_search.mli
+++ b/trading/trading/backtest/tuner/lib/grid_search.mli
@@ -107,11 +107,28 @@ val cells_of_spec : param_spec -> cell list
     [[[]]] — the single empty cell, representing "no overrides". An empty
     [values] list for any spec entry yields the empty cell list. *)
 
-val cell_to_overrides : cell -> Sexp.t list
+val cell_to_overrides : ?int_keys:string list -> cell -> Sexp.t list
 (** Convert a cell to the list of partial-config sexps consumed by
     [Backtest.Runner.run_backtest]'s [overrides] argument. Each [(key, value)]
     becomes one sexp via {!Backtest.Config_override.parse_to_sexp}; a malformed
-    [key_path] raises [Failure]. *)
+    [key_path] raises [Failure].
+
+    [int_keys] names cell keys whose downstream config field is integer-typed.
+    For each binding [(k, v)] where [k] is in [int_keys], the value is rounded
+    to the nearest integer ([Float.round_nearest]) and emitted as a bare integer
+    atom (e.g. [4], not [4.0] or [3.8004…]).
+
+    {b Why this matters:} the grid sampler enumerates [param_values] (floats),
+    so integer-valued floats like [40.0] format as [40.] and parse back as
+    [Some 40] for [int option] fields. Bayesian optimisation, however, samples
+    continuous floats from the bounded box — a sample of [3.8004…] for an
+    int-typed knob like [screening_config.weights.w_positive_rs] reaches the
+    config's [int_of_sexp] deserializer and crashes. The [int_keys] list opts
+    each int-typed knob into the rounding path so the emitted atom is always a
+    valid integer literal.
+
+    Default [int_keys = []] preserves the existing behavior. Unmarked keys
+    continue to round-trip their raw [%.17g] form. *)
 
 (** {1 Evaluation} *)
 
@@ -207,12 +224,16 @@ val write_csv : output_path:string -> objective:objective -> result -> unit
     {!Backtest.Comparison.metric_label}, then [objective_<label>]. Rows ordered
     by enumeration. *)
 
-val write_best_sexp : output_path:string -> result -> unit
+val write_best_sexp :
+  ?int_keys:string list -> output_path:string -> result -> unit
 (** Write [result.best_cell] as a list of partial-config sexps (one per param)
     to [output_path]. The output file shape is
     [((<key1> <value1>) (<key2> <value2>) ...)] where each entry is the
     {!Backtest.Config_override.parse_to_sexp} of the cell's binding — the same
-    shape consumed by [Backtest.Runner.run_backtest]'s [overrides]. *)
+    shape consumed by [Backtest.Runner.run_backtest]'s [overrides].
+
+    [int_keys] is threaded through to {!cell_to_overrides} so int-typed knobs
+    are emitted as integer atoms (see {!cell_to_overrides} for rationale). *)
 
 val write_sensitivity_md :
   output_path:string -> objective:objective -> sensitivity_row list -> unit

--- a/trading/trading/backtest/tuner/test/test_grid_search.ml
+++ b/trading/trading/backtest/tuner/test/test_grid_search.ml
@@ -105,6 +105,87 @@ let test_cell_to_overrides_nested _ =
              (equal_to true));
        ])
 
+(* ---------- int_keys rounding (issue #1249: 11-knob BO crash) ---------- *)
+
+(** Render the override sexps as a flat string for substring assertions. *)
+let _overrides_string sexps = Sexp.to_string (Sexp.List sexps)
+
+(** Substring predicates over [string]. Wrapped in [field] so the outer
+    [assert_that] checks a single derived value — keeps the test conformant with
+    the one-assert-per-value rule (.claude/rules/test-patterns.md). *)
+let _contains substring =
+  field (fun s -> String.is_substring s ~substring) (equal_to true)
+
+let _excludes substring =
+  field (fun s -> String.is_substring s ~substring) (equal_to false)
+
+(** Reproduces the crash documented in
+    [dev/notes/bayesian-11knob-int-knob-crash-2026-05-22.md]: a BO sampler
+    handed [3.8004…] to an int-typed knob, and [int_of_sexp] threw. With
+    [int_keys] set, the binding is rounded to the nearest integer and emitted as
+    a bare integer atom — safe for [int_of_sexp] downstream. *)
+let test_cell_to_overrides_int_keys_rounds_to_nearest _ =
+  let cell =
+    [ ("stage3_force_exit_config.hysteresis_weeks", 3.8004091733819) ]
+  in
+  let sexps =
+    GS.cell_to_overrides
+      ~int_keys:[ "stage3_force_exit_config.hysteresis_weeks" ]
+      cell
+  in
+  assert_that (_overrides_string sexps)
+    (all_of [ _contains "hysteresis_weeks 4"; _excludes "3.8" ])
+
+(** Rounding uses [Float.round_nearest] semantics — verified at the boundary
+    case [4.6 → 5] so the rounding rule is pinned (not "always truncate"). *)
+let test_cell_to_overrides_int_keys_rounds_above_half _ =
+  let cell = [ ("k", 4.6) ] in
+  let sexps = GS.cell_to_overrides ~int_keys:[ "k" ] cell in
+  assert_that (_overrides_string sexps) (_contains "k 5")
+
+(** Regression guard: the int marker is per-key, not global. A float-typed knob
+    in the same call must still round-trip its full precision. *)
+let test_cell_to_overrides_float_key_unchanged_when_int_keys_present _ =
+  let cell =
+    [
+      ("stage3_force_exit_config.hysteresis_weeks", 3.8);
+      ("initial_stop_buffer", 1.0541234567);
+    ]
+  in
+  let sexps =
+    GS.cell_to_overrides
+      ~int_keys:[ "stage3_force_exit_config.hysteresis_weeks" ]
+      cell
+  in
+  assert_that (_overrides_string sexps)
+    (all_of
+       [
+         _contains "hysteresis_weeks 4";
+         _contains "1.0541234567";
+         _excludes "hysteresis_weeks 3.8";
+       ])
+
+(** When [int_keys] is omitted (default), behavior is identical to the legacy
+    [%.17g] form. Pins backward compatibility — existing callers that don't pass
+    [int_keys] keep the pre-fix behavior.
+
+    Uses [3.5] (exactly representable in binary) so the [%.17g] form is the bare
+    ["3.5"] — avoids float-printing quirks like [3.8 → "3.7999…"]. *)
+let test_cell_to_overrides_default_int_keys_preserves_float_form _ =
+  let cell = [ ("k", 3.5) ] in
+  let sexps_default = GS.cell_to_overrides cell in
+  let sexps_empty = GS.cell_to_overrides ~int_keys:[] cell in
+  assert_that
+    (_overrides_string sexps_default)
+    (all_of
+       [
+         equal_to (_overrides_string sexps_empty);
+         (* The value must still contain the fractional digit (not rounded). *)
+         _contains "3.5";
+         (* And must NOT have been rounded to "4". *)
+         _excludes "k 4";
+       ])
+
 (* ---------- Objectives ---------- *)
 
 let test_objective_label _ =
@@ -373,6 +454,14 @@ let suite =
          "cell_to_overrides: top-level field"
          >:: test_cell_to_overrides_top_level;
          "cell_to_overrides: nested field" >:: test_cell_to_overrides_nested;
+         "cell_to_overrides: int_keys rounds 3.8004… to integer atom 4"
+         >:: test_cell_to_overrides_int_keys_rounds_to_nearest;
+         "cell_to_overrides: int_keys rounds 4.6 to 5 (nearest-int semantics)"
+         >:: test_cell_to_overrides_int_keys_rounds_above_half;
+         "cell_to_overrides: float key keeps precision when int_keys is set"
+         >:: test_cell_to_overrides_float_key_unchanged_when_int_keys_present;
+         "cell_to_overrides: default int_keys preserves legacy float form"
+         >:: test_cell_to_overrides_default_int_keys_preserves_float_form;
          "objective_label" >:: test_objective_label;
          "objective_metric_type" >:: test_objective_metric_type_simple;
          "evaluate_objective: simple metric lookup"


### PR DESCRIPTION
## Summary

Unblocks P3 (11-knob Bayesian sweep) per `dev/notes/next-session-priorities-2026-05-22-pm.md`. Implements Option A of the fix path documented in `dev/notes/bayesian-11knob-int-knob-crash-2026-05-22.md` (#1249).

## Problem

`cell_to_overrides` emits raw `%.17g` floats for every cell binding. When Bayesian optimization samples a continuous float (e.g. `3.8004…`) for an int-typed config knob like `screening_config.weights.w_positive_rs` or `stage3_force_exit_config.hysteresis_weeks`, the override sexp atom `\"3.8004…\"` reaches the downstream `int_of_sexp` deserializer and throws — crashing the entire sweep at iter-1 (observed 2026-05-22 with the 11-knob V1 spec).

The 4-knob V3 spec works because all 4 knobs are float-typed. The 11-knob V1 spec has 4 int knobs (Track D `hysteresis_weeks` x 2 + Track E screener weights x 2) — the bug fires on the first random sample.

## Fix (Option A from crash doc)

Add `?int_keys:string list` to `cell_to_overrides`:

- When a binding's key appears in `int_keys`, the BO-sampled float is rounded via `Float.round_nearest` and emitted as a bare integer atom (`\"4\"`), not a float literal (`\"3.8004…\"`).
- Unmarked keys keep the legacy `%.17g` form — backward compatible default.
- `write_best_sexp` accepts the same parameter so the final winning sexp also round-trips cleanly for int knobs.

~25 LOC in lib + 89 LOC of tests, per crash-doc estimate.

## Scope

**Lib-only capability.** Touches only:
- `trading/trading/backtest/tuner/lib/grid_search.ml`
- `trading/trading/backtest/tuner/lib/grid_search.mli`
- `trading/trading/backtest/tuner/test/test_grid_search.ml`

**Follow-up (P2 — not in this PR):**
- Parse `?(int)` marker in `bayesian_runner_spec.ml` bound shape.
- Thread `int_keys` through `bayesian_runner_evaluator.ml`.
- Update `spec_prod_11knob_v1.sexp` with the markers + relaunch sweep.

## Test plan

- [x] `dune build` clean (full repo)
- [x] `dune runtest trading/backtest/tuner/test/` — 28/28 pass (24 existing + 4 new)
- [x] `dune build @fmt` clean
- [x] Crash-repro test: cell sample `(\"stage3_force_exit_config.hysteresis_weeks\", 3.8004…)` round-trips to integer sexp atom `\"4\"` (was the exact value that crashed the sweep).
- [x] Float-key regression: float knob in the same call as an int knob keeps its full precision.
- [x] Backward-compat regression: default `int_keys = []` behavior is byte-identical to the prior `cell_to_overrides`.
- [x] Boundary case: `4.6 → 5` (pins `Float.round_nearest` semantics).

## References

- Crash doc: `dev/notes/bayesian-11knob-int-knob-crash-2026-05-22.md`
- Priorities: `dev/notes/next-session-priorities-2026-05-22-pm.md` P1
- Memory: `memory/project_bayesian_int_knob_crash.md`
- Source: `trading/trading/backtest/tuner/lib/grid_search.ml:61-67` (pre-fix)