### PR TITLE
fix(promote): real fix for #1257 — --diff-filter=M skips intent-to-add

### DIFF
--- a/dev/experiments/bayesian-production-sweep-2026-05-18/spec_prod_v3_seed2028.sexp
+++ b/dev/experiments/bayesian-production-sweep-2026-05-18/spec_prod_v3_seed2028.sexp
@@ -1,0 +1,51 @@
+;; V3 Bayesian production sweep — Composite scorer + tighter bounds.
+;;
+;; V2 (spec_prod_v2.sexp) result — REJECT
+;; (dev/notes/bayesian-prod-v2-result-2026-05-21.md):
+;; BO never improved past iter-1; -10×gate_fail penalty flattened the
+;; search surface. Iter-1 random sample won at exposure=0.330 (too low)
+;; + initial_stop_buffer=1.072 (too wide) — caused fold-017 MaxDD
+;; regression + fold-029 OOS Sharpe = -0.996.
+;;
+;; V3 changes:
+;; - Composite scorer (Sharpe 0.40 + Calmar 0.30 + MaxDrawdown -0.10),
+;;   per #1196 PR-2: replaces the single-term Sharpe scorer that V1/V2
+;;   used. Multi-axis objective gives the GP a smoother search surface.
+;; - Tighten `max_long_exposure_pct` lower bound from 0.30 → 0.45:
+;;   V2 winner exposure=0.33 hurt trending years. The new bound rules
+;;   out the deep-underexposure region without forcing canonical 0.70.
+;; - Tighten `initial_stop_buffer` upper bound from 1.10 → 1.05: V2
+;;   winner 1.072 caused fold-017 MaxDD regression. Tighter ceiling
+;;   keeps stops disciplined.
+;; - Tighten `max_position_pct_long` from V2's (0.02 0.20) to (0.04 0.15):
+;;   V2 winners on this axis clustered near 0.07-0.10; rule out the
+;;   too-small / too-large tails that adds noise without payoff.
+;; - Tighten `installed_stop_min_pct` from V2's (0.04 0.15) to (0.06 0.13):
+;;   V2 best-cell at 0.114 (upper-mid); the wider V2 range admitted
+;;   degenerate stops <0.06 that fired too often to be useful.
+;; - Same seed (2026) for cross-version comparability.
+;; - Same budget=60 / initial_random=10 / holdout 27-30.
+;;
+;; V3 baseline — NO AvgHoldingDays cadence term. The cadence-aware run
+;; (V3-cadence, spec_prod_v3_cadence.sexp) is a separate follow-up
+;; sweep gated on this baseline landing. See P1 in
+;; `dev/notes/next-session-priorities-2026-05-21-pm.md`.
+((bounds
+  (;; Axis A — position sizing (2)
+   ("portfolio_config.max_position_pct_long" (0.04 0.15))
+   ("portfolio_config.max_long_exposure_pct" (0.45 0.85))
+   ;; Axis B — stop placement (2)
+   ("initial_stop_buffer" (1.00 1.05))
+   ("screening_config.candidate_params.installed_stop_min_pct" (0.06 0.13))))
+ (acquisition Expected_improvement)
+ (initial_random 10)
+ (total_budget 60)
+ (seed (2028))
+ (n_acquisition_candidates ())
+ (objective
+  (Composite
+   ((SharpeRatio 0.40)
+    (CalmarRatio 0.30)
+    (MaxDrawdown -0.10))))
+ (scenarios ())
+ (holdout_folds (27 28 29 30)))

--- a/dev/reviews/feat-bo-int-knob-structural.md
+++ b/dev/reviews/feat-bo-int-knob-structural.md
@@ -1,0 +1,24 @@
+Reviewed SHA: 705bd0de6421d0c849f66b520b540c589394ffad
+
+## Structural Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| H1 | dune build @fmt (format check) | PASS | No violations |
+| H2 | dune build | PASS | Full build succeeds |
+| H3 | dune runtest | PASS | 28 tests, 28 passed, 0 failed |
+| P1 | Functions ≤ 50 lines (linter) | PASS | No functions exceed 50-line hard limit; linter passed via H3 |
+| P2 | No magic numbers (linter) | PASS | Linter passed via H3 |
+| P3 | Config completeness | PASS | All new parameters (`int_keys`) route through function arguments, no hardcoded tunable values introduced |
+| P4 | Public-symbol export hygiene (mli-coverage) | PASS | 12 public exports documented in .mli; 13 internal helpers prefixed with `_`; linter passed via H3 |
+| P5 | Internal helpers prefixed per convention | PASS | All internal helpers in grid_search.ml use `_` prefix convention: `_format_binding_value`, `_binding_to_sexp`, etc. |
+| P6 | Tests conform to test-patterns.md | PASS | All 5 new test functions use single `assert_that` with `all_of`/`field` composition; no nested assertions; no `List.exists equal_to true`; no bare match/Error patterns. Test helpers `_contains` and `_excludes` properly wrapped in `field`. |
+| A1 | Core module modifications | PASS | No modifications to Portfolio/Orders/Position/Strategy/Engine; changes confined to trading/backtest/tuner/ subsystem |
+| A2 | No new analysis/ imports into trading/trading/ outside backtest exception | PASS | No analysis/ dependencies added; tuner lib uses only core + backtest + simulation.types |
+| A3 | No unnecessary cross-feature drift | PASS | Exactly 3 files touched (grid_search.ml/.mli + test), all within tuner subsystem; no stray modifications |
+
+## Verdict
+
+APPROVED
+
+The change adds integer-key rounding support to the grid-search tuner to fix the BO int-knob crash (issue #1249). Implementation is clean: new optional `int_keys` parameter threads through the call chain, comprehensive test coverage with 4 new tests pinning rounding semantics and backward-compatibility, and structural gates all pass.

--- a/dev/reviews/fix-promote-git-diff-behavioral.md
+++ b/dev/reviews/fix-promote-git-diff-behavioral.md
@@ -1,0 +1,68 @@
+---
+
+# Behavioral QC — fix/promote-git-diff (PR #1257)
+Date: 2026-05-23
+Reviewer: qc-behavioral
+Reviewed SHA: 7dfa04dd6436d0f1a3f09fa0969f4afe74e899c2
+
+## Classification
+
+Pure infra / tooling fix. One bash file changed (`dev/scripts/promote_config.sh`),
+no OCaml, no domain logic. Per `.claude/rules/qc-behavioral-authority.md`
+§"When to skip this file entirely", the Weinstein domain checklist
+(S*/L*/C*/T*) is NA — generic CP1–CP4 from the qc-behavioral agent
+constitutes the full review.
+
+## Contract Pinning Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| CP1 | Each non-trivial claim in new .mli docstrings has an identified test that pins it | NA | No .mli files; bash script only. The expanded shell comment (lines 148–155) is documentation-only, not a contract. |
+| CP2 | Each claim in PR body "Test plan"/"Test coverage" sections has a corresponding test in the committed test file | PASS-with-caveat | PR body claims: (a) `dune build` clean, (b) `dune build @fmt` clean (no .ml/.mli touched), (c) `dune runtest devtools/checks/` clean — all 3 verified via docker exec (exit=0 for build; exit=0 for runtest of devtools/checks/). Claim (d) "live-tested today on V8 seed 2027 promote run" cannot be re-verified post-hoc — the original dirty-state has been resolved. Author self-attestation accepted; no committed test pins this behavior. |
+| CP3 | Pass-through / identity / invariant tests pin identity (elements_are [equal_to ...]), not just size_is | NA | No pass-through semantics in this PR. |
+| CP4 | Each guard called out explicitly in code docstrings has a test that exercises the guarded-against scenario | FAIL-soft | The new comment block (lines 148–155) explicitly distinguishes two cases: (i) "modifications to tracked files" should still trigger error, (ii) "intent-to-add markers + untracked files" should not. Neither case has a committed regression test — the script has no test harness for the cleanness-check itself. **Practical impact: low** — the surface is a 1-line bash check, the failure mode (over-strict) was the original bug. But if a future maintainer reverts the change ("why not diff-index — they're equivalent?"), nothing catches the regression except another live failure. |
+
+### CP4 follow-up empirical finding (FLAG, not a blocker)
+
+I attempted to empirically validate the PR's core semantic claim — "`git diff` (worktree vs HEAD, tracked-only) tolerates intent-to-add markers; `git diff-index` (index vs HEAD) does not" — in a fresh git 2.41.0 + jj 0.39.0 sandbox. In all my reproduced scenarios (untracked + `git add -N`, jj-colocated snapshot, empty intent-to-add, deleted intent-to-add), **both** `git diff-index --quiet HEAD --` and `git diff --quiet HEAD --` returned the same exit code:
+
+| Scenario | `git diff-index --quiet HEAD --` | `git diff --quiet HEAD --` |
+|---|---|---|
+| Clean state | 0 (PASS) | 0 (PASS) |
+| Untracked file (no -N) | 0 (PASS) | 0 (PASS) |
+| Untracked + `git add -N` | 1 (FAIL) | 1 (FAIL) |
+| jj-colocated untracked + `jj status` snapshot | 1 (FAIL) | 1 (FAIL) |
+| Modified tracked (unstaged) | 1 (FAIL) | 1 (FAIL) |
+| Modified tracked (staged) | 1 (FAIL) | 1 (FAIL) |
+| Stale -N + file deleted | 0 (PASS) | 0 (PASS) |
+
+In every test, the two commands behave **identically**. The PR's stated mechanism for the fix is not confirmed by my reproduction.
+
+**Why this is still a FLAG, not a FAIL:**
+- The PR author observed the original bug live (V8 seed 2027 blocked) and verified the fix worked in the same session.
+- The fix is **strictly more permissive** than the original — it cannot introduce a new failure mode beyond admitting an extra clean state.
+- Even if my empirical finding is correct (the two commands are equivalent in this case), the change is harmless. The only downside is that the PR-body explanation may overstate the mechanism.
+- The expanded doc-comment is genuinely useful regardless — it pins intent, which has documentation value even if the mechanism description is imprecise.
+
+**Recommended follow-up (not blocking):** the PR author should re-test in the exact session state where the original failure occurred to confirm the mechanism description in the comment. If `git diff` and `git diff-index` are in fact equivalent for this case, the comment should be revised to describe the actual mechanism (which may be more subtle, e.g., a different jj snapshot timing). The change itself is safe to land.
+
+## Quality Score
+
+3 — The change is safe, surgical, and improves operability for a real blocker the author hit live. The expanded doc-comment is good practice. The score reflects an unverified mechanism claim in the comment + PR body (my empirical reproduction shows `git diff` and `git diff-index` behave identically for intent-to-add markers in standard git, but the author's live evidence trumps a sandbox test). Score does not affect verdict.
+
+## Verdict
+
+APPROVED
+
+(CP1=NA, CP2=PASS-with-caveat, CP3=NA, CP4=FAIL-soft → APPROVED with a documented FLAG. The CP4-soft is recorded as ONGOING_REVIEW / LINTER_CANDIDATE for future maintainers, not a blocker for this PR because the change is strictly safer than the original.)
+
+## NEEDS_REWORK Items
+
+None. The flagged items above are documented for tracking but do not block merge:
+
+### CP4-follow-up: Mechanism claim in comment may overstate
+- Finding: My empirical test (git 2.41.0 + jj 0.39.0) shows `git diff --quiet HEAD --` and `git diff-index --quiet HEAD --` behave identically for intent-to-add markers in all reproducible scenarios. The PR's mechanism explanation (diff-index sees intent-to-add as changed, diff does not) was not confirmed.
+- Location: dev/scripts/promote_config.sh, lines 148–155 (the new comment block)
+- Authority: PR #1257 body §Fix "BEFORE / AFTER" semantics + the comment text itself
+- Required fix (post-merge, optional): Author should re-test in the exact failure state to confirm the mechanism. If equivalent, revise comment to describe the actual cause (perhaps a subtle jj timing issue, or a git config flag, or a state transition the sandbox missed). The fix itself is safe to land regardless.
+- harness_gap: ONGOING_REVIEW — verifying a git-command semantic claim in a jj-colocated workflow requires reproducing the exact dirty state; not amenable to a deterministic golden test.

--- a/dev/reviews/fix-promote-git-diff-structural.md
+++ b/dev/reviews/fix-promote-git-diff-structural.md
@@ -1,0 +1,42 @@
+Reviewed SHA: 7dfa04dd6e7a1c6c4e7c8f9e6d5c4b3a2f1e0d
+
+## Structural Checklist
+
+| # | Check | Status | Notes |
+|---|-------|--------|-------|
+| H1 | dune build @fmt (format check) | PASS | No OCaml code; shell script syntax verified via bash -n |
+| H2 | dune build | PASS | Full build succeeds (dune built inside docker) |
+| H3 | dune runtest | PASS | All tests pass; extract_metrics_gate_smoke.sh: 13/13 checks OK |
+| P1 | Functions ≤ 50 lines (linter) | NA | Pure shell tooling; no linter applies |
+| P2 | No magic numbers (linter) | NA | Pure shell tooling; no numeric thresholds in the change |
+| P3 | Config completeness | NA | Not applicable; no new configuration added |
+| P4 | Public-symbol export hygiene (linter) | NA | Pure shell tooling; no OCaml modules |
+| P5 | Internal helpers prefixed per convention | NA | Pure shell tooling; no internal helpers added |
+| P6 | Tests conform to `.claude/rules/test-patterns.md` | NA | Pure infra PR; domain test patterns not applicable |
+| A1 | Core module modifications (Portfolio/Orders/Position/Strategy/Engine) — FLAG if any found | NA | Pure infra PR; no core module modifications |
+| A2 | No new `analysis/` imports into `trading/trading/` | NA | Pure infra PR; no dune files modified |
+| A3 | No unnecessary modifications to existing (non-feature) modules | PASS | One file changed: dev/scripts/promote_config.sh; change is surgical (git command + comment expansion) |
+
+## Verdict
+
+APPROVED
+
+## Technical Justification
+
+**Change summary:** Replaces `git diff-index --quiet HEAD --` with `git diff --quiet HEAD --` in the working-tree cleanness check (line 156), with expanded docstring explaining the rationale.
+
+**Correctness of fix:**
+- `git diff-index` compares index (staging area) vs HEAD and sees intent-to-add markers on untracked files as changes
+- jj-colocated workflows can leave such markers on untracked files without modifying tracked content
+- Intent-to-add markers do not affect SHA reproducibility (they don't represent modifications to committed history)
+- `git diff` compares worktree vs HEAD and only sees changes to files actually modified in the working tree
+- The replacement correctly gates only on tracked-file modifications while tolerating untracked intent-to-add markers
+- Verified: `git diff --quiet HEAD --` still detects actual tracked-file changes (returns exit code 1)
+
+**Gate coverage:**
+- H1–H3: dune build @fmt, dune build, dune runtest all pass (extract_metrics_gate_smoke.sh passes 13/13 smoke checks)
+- The change is a one-line command swap + docstring; shell syntax verified (bash -n)
+- Affects only the promote_config.sh script (pure infra tooling, no domain/test logic touched)
+- No new dependencies, no changes to extract_metrics helpers, no changes to validation logic
+
+**No structural issues found.**

--- a/dev/scripts/promote_config.sh
+++ b/dev/scripts/promote_config.sh
@@ -145,16 +145,22 @@ trading_repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 trading_sha="$(cd "$trading_repo_root" && git rev-parse HEAD)"
 trading_short_sha="$(cd "$trading_repo_root" && git rev-parse --short HEAD)"
 
-# If the trading repo working copy has uncommitted changes to TRACKED files,
-# refuse. The captured SHA must exist in the local clone for consumers to
-# reproduce. We use `git diff` (worktree vs HEAD, tracked-only) rather than
-# `git diff-index` (index vs HEAD) because the latter treats intent-to-add
-# markers — left behind by jj-colocated workflows on untracked files — as
-# uncommitted changes, even though they're not modifications to tracked
-# content. Untracked + intent-to-add files are not load-bearing for SHA
-# reproducibility; only modifications to tracked files are.
-if ! (cd "$trading_repo_root" && git diff --quiet HEAD --); then
-  echo "Error: trading repo working copy has uncommitted changes to tracked files" >&2
+# If the trading repo working copy has MODIFICATIONS to tracked files, refuse.
+# The captured SHA must exist in the local clone for consumers to reproduce.
+#
+# We use `--diff-filter=M` to filter to Modifications only (excluding Added /
+# Deleted / Renamed) — both `git diff` and `git diff-index` treat intent-to-add
+# markers (set by jj-colocated workflows on untracked files when git status is
+# invoked) as Added entries, even though those files aren't modifications of
+# tracked content. The `M`-only filter excludes intent-to-add (which shows up
+# as `A`) but still catches real worktree-vs-HEAD modifications of tracked
+# files — which is what actually affects SHA reproducibility.
+#
+# (PR #1257 first attempted `git diff` vs `git diff-index` — qc-behavioral
+# correctly noted the two are equivalent for intent-to-add markers in modern
+# git. This second iteration uses the diff-filter approach instead.)
+if ! (cd "$trading_repo_root" && git diff --diff-filter=M --quiet HEAD --); then
+  echo "Error: trading repo working copy has uncommitted modifications to tracked files" >&2
   echo "Hint: commit + push your changes, or use git stash, before promoting" >&2
   exit 1
 fi


### PR DESCRIPTION
## Problem

PR #1257 attempted to fix `promote_config.sh`'s dirty-state check by switching `git diff-index --quiet HEAD --` → `git diff --quiet HEAD --`, claiming the latter ignored intent-to-add markers left by jj-colocated workflows. **qc-behavioral on #1257 (review file: `dev/reviews/fix-promote-git-diff-behavioral.md`) correctly flagged that the two commands return identical exit codes across 7 scenarios** — both treat intent-to-add as a difference. The PR was approved because it's strictly more permissive than the original, but the underlying issue wasn't actually fixed.

Reproduced today (2026-05-23): running `promote_config.sh` on the post-#1257 main with QC review docs + spec sexp present (all intent-to-add) failed with "uncommitted changes to tracked files" — same as before.

## Fix

Use `git diff --diff-filter=M --quiet HEAD --`. The `M` filter restricts to Modified entries (excluding Added / Deleted / Renamed). Intent-to-add markers register as `A` (Added) under git's diff semantics; the `M` filter excludes them while still catching real modifications to tracked files.

Verified locally on the same dirty state:
- Before my edit (intent-to-add markers only): `--diff-filter=M --quiet` exit=0 (clean — correct)
- After my edit (promote_config.sh modified + intent-to-add markers): `--diff-filter=M --quiet` exit=1 (dirty — correct)

The doc-comment now spells out *why* this filter is needed + references #1257 + qc-behavioral feedback so a future maintainer doesn't accidentally simplify it back to bare `git diff`.

## Test plan

- [x] `dune build` + `dune build @fmt` clean (no .ml/.mli touched)
- [x] `dune runtest devtools/checks/` clean (extract_metrics_gate_smoke still passes; the gate-helper smoke test is orthogonal to the script's dirty-state check)
- [x] Manual test on current dirty state: `--diff-filter=M --quiet HEAD --` exits 0 when only intent-to-add markers are present; exits 1 when there's a real modification to a tracked file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)