### PR TITLE
feat(cost-model): wire scenario.cost_model + simulator on_trade_fill (P1.2 items 1+2)

### DIFF
--- a/dev/status/cost-model.md
+++ b/dev/status/cost-model.md
@@ -1,6 +1,6 @@
 # Status: cost-model
 
-## Last updated: 2026-05-17
+## Last updated: 2026-05-23
 
 ## Status
 READY_FOR_REVIEW
@@ -36,28 +36,46 @@ YES
 
 ## Completed
 
-- [x] **Cost-model module** (PR pending, 2026-05-17). Module +
+- [x] **Cost-model module** (PR #1151, 2026-05-17). Module +
   test (27 cases, all green). ~85 LOC impl, ~130 LOC mli, ~290 LOC
   test. Wired into nothing — standalone, callers can opt in. Verify:
   `dune runtest trading/backtest/cost_model` (27/27 pass).
+- [x] **Wire `cost_model` sexp field into `scenario.mli`** (PR
+  pending, 2026-05-23 — feat/cost-model-wiring-phase1). Added
+  `cost_model : Cost_model.t option` with `[@sexp.option]` so every
+  existing scenario file omits the field and continues to parse
+  with `None`. Threaded through `scenario_runner` →
+  `Runner.run_backtest` → `Panel_runner.run`. Verify: `dune runtest
+  trading/backtest/scenarios/test/test_scenario` (15/15 pass
+  including 3 new cost_model round-trip cases).
+- [x] **Wire `apply_per_trade_commission` into the simulator's
+  post-fill hook** (PR pending, 2026-05-23 — same PR). Added
+  strategy-agnostic `?on_trade_fill : (trade -> trade)` optional
+  dep on `Simulator.create_deps` (default `None` → byte-equal
+  baseline). `Panel_runner.run` constructs the hook from
+  `Cost_model.apply_per_trade_commission` when `?cost_model` is
+  supplied. Architectural note: simulator does NOT depend on
+  `Backtest_cost_model` (avoids inverting the layering — backtest
+  already depends on simulation); the cost-model module lives one
+  layer up and the hook surface keeps simulator generic. Verify:
+  `dune runtest trading/simulation/test/test_simulator_cost_model`
+  (3/3 pass — None preserves baseline, retail_default per_trade=0
+  preserves baseline, custom per_trade=$1.50 subtracts exact
+  delta). No goldens needed re-pinning since every existing
+  scenario file has `cost_model = None`.
 
 ## Open work
 
-- [ ] **Wire `cost_model` sexp field into `scenario.mli`** — add
-  `cost_model : Cost_model.t option` so scenarios can declare costs
-  declaratively. Lifts the existing `slippage_bps : int option`
-  into the broader config. Defer until at least one scenario needs
-  per-trade or impact, since `slippage_bps` already covers the
-  bid-ask-spread case.
-- [ ] **Wire `apply_per_trade_commission` into the simulator's
-  post-fill hook** — currently a standalone helper. Likely the
-  cleanest place is `Simulator._apply_trades_best_effort` (map
-  trades through the adjustment before applying to portfolio).
-  Trade-off: when this lands, every scenario re-pin is needed.
 - [ ] **Wire market-impact into the engine** — requires ADV
   plumbing. ADV needs to be loaded alongside bars; not yet in the
   simulation data layer. Defer until empirical evidence shows
   impact dominates over spread for realistic order sizes.
+- [ ] **Re-pin Cell E baseline with retail/institutional cost
+  overlay** — once items 1+2 above land, run Cell E (15y SP500)
+  with `cost_model = Some retail_default` and `Some
+  institutional_default` to quantify the cost attrition curve
+  beyond bid-ask-spread. The `slippage_bps` knob (PR #920) already
+  approximates the spread component.
 
 ## Follow-up experiments
 

--- a/trading/trading/backtest/lib/dune
+++ b/trading/trading/backtest/lib/dune
@@ -16,6 +16,7 @@
   trading.simulation.data
   trading.simulation.types
   trading.strategy
+  backtest_cost_model
   weinstein.snapshot_pipeline
   weinstein.snapshot_runtime
   weinstein_trading.strategy

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -5,6 +5,7 @@ open Trading_simulation
 module Daily_panels = Snapshot_runtime.Daily_panels
 module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
 module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Cost_model = Backtest_cost_model.Cost_model
 
 type input = {
   data_dir_fpath : Fpath.t;
@@ -51,8 +52,8 @@ let _build_market_data_adapter ~daily_panels =
   Bar_data_source.build_adapter_from_panels daily_panels
 
 let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
-    ~end_date ~warmup_days ~initial_cash ~commission ?slippage_bps ~strategy
-    ~market_data_adapter () =
+    ~end_date ~warmup_days ~initial_cash ~commission ?slippage_bps
+    ?on_trade_fill ~strategy ~market_data_adapter () =
   let warmup_start = Date.add_days start_date (-warmup_days) in
   let strategy = Strategy_wrapper.wrap ~stop_log strategy in
   let sim_deps =
@@ -60,7 +61,7 @@ let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
       ~data_dir:input.data_dir_fpath ~strategy ~commission
       ~metric_suite:(Metric_computers.default_metric_suite ~initial_cash ())
       ~market_data_adapter ~stale_hold_log ?slippage_bps
-      ~margin_config:input.config.margin_config ()
+      ~margin_config:input.config.margin_config ?on_trade_fill ()
   in
   let sim_config =
     Simulator.
@@ -215,9 +216,15 @@ let _create_recorders () : _recorders =
     audit_recorder;
   }
 
+(* Build the simulator's per-trade post-fill adjustment from the optional
+   [cost_model]. [None] returns [None] — the simulator stays on its
+   byte-equal default path. *)
+let _on_trade_fill_of_cost_model cost_model =
+  Option.map cost_model ~f:Cost_model.apply_per_trade_commission
+
 let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     ~commission ?(strategy_choice = Strategy_choice.default) ?trace ?gc_trace
-    ?bar_data_source ?progress_emitter ?slippage_bps () =
+    ?bar_data_source ?progress_emitter ?slippage_bps ?cost_model () =
   let warmup_start = Date.add_days start_date (-warmup_days) in
   eprintf
     "Panel_runner: simulator window %s..%s (warmup %d days, strategy %s)\n%!"
@@ -233,10 +240,11 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     _setup_hybrid input ~strategy_choice ~snapshot_dir ~manifest ~warmup_start
       ~end_date ~audit_recorder:r.audit_recorder
   in
+  let on_trade_fill = _on_trade_fill_of_cost_model cost_model in
   let sim =
     _make_simulator input ~stop_log:r.stop_log ~stale_hold_log:r.stale_hold_log
       ~start_date ~end_date ~warmup_days ~initial_cash ~commission ?slippage_bps
-      ~strategy ~market_data_adapter ()
+      ?on_trade_fill ~strategy ~market_data_adapter ()
   in
   let progress_acc =
     Panel_step_loop.build_progress_acc ~progress_emitter ~warmup_start ~end_date

--- a/trading/trading/backtest/lib/panel_runner.mli
+++ b/trading/trading/backtest/lib/panel_runner.mli
@@ -51,6 +51,7 @@ val run :
   ?bar_data_source:Bar_data_source.t ->
   ?progress_emitter:Backtest_progress.emitter ->
   ?slippage_bps:int ->
+  ?cost_model:Backtest_cost_model.Cost_model.t ->
   unit ->
   Trading_simulation_types.Simulator_types.run_result
   * Stop_log.t
@@ -118,4 +119,14 @@ val run :
     the only difference is whether the snapshot directory was materialised
     in-process or supplied externally. See
     `dev/notes/path-dependent-regression-848-investigation-2026-05-05.md` for
-    the path-dependence surface this rewiring closes. *)
+    the path-dependence surface this rewiring closes.
+
+    [cost_model], when passed, threads a {!Backtest_cost_model.Cost_model.t}
+    overlay through the simulator. The runner builds an [on_trade_fill] hook
+    from {!Cost_model.apply_per_trade_commission} and passes it to
+    {!Trading_simulation.Simulator.create_deps}, which applies the adjustment to
+    every accepted fill before the portfolio accounts for it. [None] (the
+    default) preserves the zero-cost baseline byte-for-byte. Item 2 of the
+    four-item cost-model wiring plan in [dev/status/cost-model.md]; the
+    per-share-commission, bid-ask-spread and market-impact components of
+    [cost_model] are not yet routed through the runner. *)

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -230,12 +230,12 @@ let _panel_input_of_deps (deps : _deps) : Panel_runner.input =
 
 let _run_panel_backtest ~deps ~start_date ~end_date ~warmup_days
     ?strategy_choice ?trace ?gc_trace ?bar_data_source ?progress_emitter
-    ?slippage_bps () =
+    ?slippage_bps ?cost_model () =
   Panel_runner.run
     ~input:(_panel_input_of_deps deps)
     ~start_date ~end_date ~warmup_days ~initial_cash ~commission
     ?strategy_choice ?trace ?gc_trace ?bar_data_source ?progress_emitter
-    ?slippage_bps ()
+    ?slippage_bps ?cost_model ()
 
 (** Drop simulator-side [stop_info]s whose [entry_date] is before [start_date] —
     i.e. positions opened during the warmup window. The simulator runs from
@@ -406,7 +406,7 @@ let _log_backtest_window ~start_date ~end_date ~warmup_start ~all_symbols =
 
 let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     ?(strategy_choice = Strategy_choice.default) ?trace ?gc_trace
-    ?bar_data_source ?progress_emitter ?slippage_bps () =
+    ?bar_data_source ?progress_emitter ?slippage_bps ?cost_model () =
   let deps = _load_deps ?trace ?gc_trace ~overrides ~sector_map_override () in
   let warmup_days = _warmup_days_for strategy_choice in
   let warmup_start = Date.add_days start_date (-warmup_days) in
@@ -420,7 +420,7 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
         final_close_prices ) =
     _run_panel_backtest ~deps ~start_date ~end_date ~warmup_days
       ~strategy_choice ?trace ?gc_trace ?bar_data_source ?progress_emitter
-      ?slippage_bps ()
+      ?slippage_bps ?cost_model ()
   in
   Gc_trace.record ?trace:gc_trace ~phase:"fill_done" ();
   let steps_in_range, steps = _filter_steps ~sim_result ~start_date in

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -151,6 +151,7 @@ val run_backtest :
   ?bar_data_source:Bar_data_source.t ->
   ?progress_emitter:Backtest_progress.emitter ->
   ?slippage_bps:int ->
+  ?cost_model:Backtest_cost_model.Cost_model.t ->
   unit ->
   result
 (** Run the simulator from [start_date - warmup] to [end_date], filter to the
@@ -233,4 +234,15 @@ val run_backtest :
     cadence. Resumability is intentionally NOT in this PR — the checkpoint is
     read-only progress information; restartability of the simulator state is a
     follow-up (deferred per the data-pipeline-automation plan, §"Open question
-    4"). *)
+    4").
+
+    [cost_model], when passed, threads a {!Backtest_cost_model.Cost_model.t}
+    overlay through the simulator. The runner builds a per-trade post-fill
+    adjustment from {!Backtest_cost_model.Cost_model.apply_per_trade_commission}
+    and threads it through {!Panel_runner.run} into
+    {!Trading_simulation.Simulator.create_deps}. [None] (the default) preserves
+    the zero-cost baseline byte-for-byte — every existing scenario file omits
+    the field and is unaffected. Item 2 of the four-item cost-model wiring plan
+    tracked in [dev/status/cost-model.md]; the per-share-commission,
+    bid-ask-spread and market-impact components are not yet routed through the
+    runner. *)

--- a/trading/trading/backtest/scenarios/dune
+++ b/trading/trading/backtest/scenarios/dune
@@ -7,7 +7,14 @@
   fixtures_root
   smoke_catalog
   scenario_progress)
- (libraries core fpath weinstein.data_source backtest universe status)
+ (libraries
+  core
+  fpath
+  weinstein.data_source
+  backtest
+  backtest_cost_model
+  universe
+  status)
  (preprocess
   (pps ppx_sexp_conv)))
 

--- a/trading/trading/backtest/scenarios/scenario.ml
+++ b/trading/trading/backtest/scenarios/scenario.ml
@@ -62,6 +62,7 @@ type t = {
   strategy : Backtest.Strategy_choice.t;
       [@sexp.default Backtest.Strategy_choice.default]
   slippage_bps : int option; [@sexp.option]
+  cost_model : Backtest_cost_model.Cost_model.t option; [@sexp.option]
   expected : expected;
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]

--- a/trading/trading/backtest/scenarios/scenario.mli
+++ b/trading/trading/backtest/scenarios/scenario.mli
@@ -99,6 +99,19 @@ type t = {
           non-negative int for cost-overlay runs (e.g. M5.6 slippage sweep,
           2026-05-14). The runner applies buy fills at [price * (1 + bps/10000)]
           and sell fills at [price / (1 + bps/10000)] symmetrically. *)
+  cost_model : Backtest_cost_model.Cost_model.t option; [@sexp.option]
+      (** Declarative cost-model overlay threaded into
+          {!Backtest.Runner.run_backtest}'s [?cost_model] argument. [None]
+          preserves the zero-cost baseline byte-for-byte — every existing
+          scenario file omits the field and is unaffected. When [Some cm] is
+          set, the runner applies [Cost_model.apply_per_trade_commission cm] to
+          every fill, bumping each [trade.commission] by
+          [cm.per_trade_commission] before the portfolio accounts for it.
+          Composes with [slippage_bps] above (engine-level bid-ask slippage
+          stays orthogonal until ADV is plumbed and [cm.bid_ask_spread_bps] can
+          replace it). The per-share-commission and market-impact knobs in [cm]
+          are not yet wired into the simulator — items 3 and 4 of the four-item
+          plan tracked in [dev/status/cost-model.md]. *)
   expected : expected;
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -269,7 +269,7 @@ let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
     Backtest.Runner.run_backtest ~start_date:s.period.start_date
       ~end_date:s.period.end_date ~overrides:s.config_overrides
       ?sector_map_override ~strategy_choice:s.strategy ~progress_emitter
-      ?slippage_bps:s.slippage_bps ()
+      ?slippage_bps:s.slippage_bps ?cost_model:s.cost_model ()
   in
   let wall_seconds =
     Time_ns.Span.to_sec (Time_ns.diff (Time_ns_unix.now ()) t_start)

--- a/trading/trading/backtest/scenarios/test/dune
+++ b/trading/trading/backtest/scenarios/test/dune
@@ -23,6 +23,7 @@
   scenario_lib
   matchers
   backtest
+  backtest_cost_model
   weinstein.data_source
   trading.simulation
   universe

--- a/trading/trading/backtest/scenarios/test/test_scenario.ml
+++ b/trading/trading/backtest/scenarios/test/test_scenario.ml
@@ -248,6 +248,92 @@ let test_loader_strategy_extra_field_tolerated _ =
   in
   assert_that s.universe_path (equal_to Scenario.default_universe_path)
 
+(* Pre-existing scenario sexps that don't pin [cost_model] continue to parse
+   with [None] (skip-the-overlay semantic — runs on the byte-equal zero-cost
+   baseline path). Item 1 of the four-item cost-model wiring plan tracked in
+   [dev/status/cost-model.md]. *)
+let test_cost_model_field_absent _ =
+  let s =
+    Scenario.t_of_sexp (Sexp.of_string (_make_sexp ~extra_expected_fields:""))
+  in
+  assert_that s.cost_model is_none
+
+let _make_sexp_with_cost_model ~cost_model_sexp =
+  sprintf
+    {|
+  ((name "test-scenario")
+   (description "Unit-test fixture")
+   (period ((start_date 2023-01-02) (end_date 2023-12-31)))
+   (config_overrides ())
+   (cost_model %s)
+   (expected
+    (%s)))
+  |}
+    cost_model_sexp _base_expected_fields
+
+(* A scenario that pins [cost_model] parses the record correctly. The runner
+   threads it through to {!Backtest_cost_model.Cost_model.apply_per_trade_commission}
+   inside the simulator's accept-trades path. *)
+let test_cost_model_field_present _ =
+  let cm_sexp =
+    {|((per_trade_commission 1.0)
+       (per_share_commission 0.005)
+       (bid_ask_spread_bps 5.0)
+       (market_impact_bps_per_pct_adv 0.0))|}
+  in
+  let s =
+    Scenario.t_of_sexp
+      (Sexp.of_string (_make_sexp_with_cost_model ~cost_model_sexp:cm_sexp))
+  in
+  assert_that s.cost_model
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (c : Backtest_cost_model.Cost_model.t) ->
+                c.per_trade_commission)
+              (float_equal 1.0);
+            field
+              (fun (c : Backtest_cost_model.Cost_model.t) ->
+                c.per_share_commission)
+              (float_equal 0.005);
+            field
+              (fun (c : Backtest_cost_model.Cost_model.t) ->
+                c.bid_ask_spread_bps)
+              (float_equal 5.0);
+            field
+              (fun (c : Backtest_cost_model.Cost_model.t) ->
+                c.market_impact_bps_per_pct_adv)
+              (float_equal 0.0);
+          ]))
+
+(* The [cost_model] field round-trips through sexp_of_t / t_of_sexp. *)
+let test_cost_model_roundtrip _ =
+  let cm_sexp =
+    {|((per_trade_commission 0.50)
+       (per_share_commission 0.0)
+       (bid_ask_spread_bps 2.0)
+       (market_impact_bps_per_pct_adv 1.0))|}
+  in
+  let original =
+    Scenario.t_of_sexp
+      (Sexp.of_string (_make_sexp_with_cost_model ~cost_model_sexp:cm_sexp))
+  in
+  let roundtripped = Scenario.t_of_sexp (Scenario.sexp_of_t original) in
+  assert_that roundtripped.cost_model
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (c : Backtest_cost_model.Cost_model.t) ->
+                c.per_trade_commission)
+              (float_equal 0.50);
+            field
+              (fun (c : Backtest_cost_model.Cost_model.t) ->
+                c.market_impact_bps_per_pct_adv)
+              (float_equal 1.0);
+          ]))
+
 let suite =
   "Scenario"
   >::: [
@@ -268,6 +354,9 @@ let suite =
          "universe_path sexp round-trips" >:: test_universe_path_roundtrip;
          "extra loader_strategy field is tolerated (post-3.4 backward compat)"
          >:: test_loader_strategy_extra_field_tolerated;
+         "cost_model absent => None" >:: test_cost_model_field_absent;
+         "cost_model present => Some record" >:: test_cost_model_field_present;
+         "cost_model sexp round-trips" >:: test_cost_model_roundtrip;
          "all scenario files parse" >:: test_all_scenario_files_parse;
        ]
 

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_evaluator.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_evaluator.ml
@@ -151,6 +151,7 @@ let _make_base_scenario () : Scenario.t =
     config_overrides = [];
     strategy = Backtest.Strategy_choice.default;
     slippage_bps = None;
+    cost_model = None;
     expected;
   }
 

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_runner.ml
@@ -20,6 +20,7 @@ let build_fold_scenario ~(base : Scenario.t) ~(fold : Window_spec.fold)
     config_overrides = base.config_overrides @ variant.overrides;
     strategy = base.strategy;
     slippage_bps = base.slippage_bps;
+    cost_model = None;
     expected = base.expected;
   }
 

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_executor_parallel.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_executor_parallel.ml
@@ -69,6 +69,7 @@ let _make_base () : Scenario.t =
     config_overrides = [];
     strategy = Backtest.Strategy_choice.default;
     slippage_bps = None;
+    cost_model = None;
     expected;
   }
 

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_runner.ml
@@ -38,6 +38,7 @@ let _make_base ?(name = "base-test") ?(description = "base-desc")
     config_overrides;
     strategy;
     slippage_bps;
+    cost_model = None;
     expected;
   }
 

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -42,22 +42,16 @@ type dependencies = {
           as [None] on every step (default; preserves prior behaviour). *)
   stale_hold_policy : Stale_hold.config;
   stale_hold_log : Stale_hold.Log.t;
-  margin_config : Trading_portfolio.Margin_config.t;
-      (** Phase 2 margin-accounting parameters (issue #859). Default
-          {!Trading_portfolio.Margin_config.default_config} — i.e. disabled, so
-          every Phase-1 / Phase-2 surface is a bit-equal no-op and existing
-          long-only goldens stay pinned. When [margin_config.enabled = true] the
-          simulator accrues a daily short borrow fee against [current_cash] and
-          emits margin-call [TriggerExit] transitions on shorts whose
-          maintenance equity ratio has fallen below [maintenance_margin_pct]
-          (see {!Margin_runner}). *)
+  margin_config : Trading_portfolio.Margin_config.t;  (** See .mli. *)
+  on_trade_fill : (Trading_base.Types.trade -> Trading_base.Types.trade) option;
 }
 
 let create_deps ~symbols ~data_dir ~strategy ~commission
     ?(metric_suite = { computers = []; derived = [] }) ?benchmark_symbol
     ?market_data_adapter ?(stale_hold_policy = Stale_hold.default_config)
     ?stale_hold_log ?(slippage_bps = 0)
-    ?(margin_config = Trading_portfolio.Margin_config.default_config) () =
+    ?(margin_config = Trading_portfolio.Margin_config.default_config)
+    ?on_trade_fill () =
   let engine_config = { Trading_engine.Types.commission; slippage_bps } in
   let engine = Trading_engine.Engine.create engine_config in
   let order_manager = Trading_orders.Manager.create () in
@@ -81,6 +75,7 @@ let create_deps ~symbols ~data_dir ~strategy ~commission
     stale_hold_policy;
     stale_hold_log;
     margin_config;
+    on_trade_fill;
   }
 
 (** {1 Simulator State} *)
@@ -360,10 +355,12 @@ let _try_apply_trade portfolio trade =
   | Ok p -> (p, `Accepted trade)
   | Error _ -> (portfolio, `Rejected trade)
 
-let _apply_trades_best_effort portfolio trades =
+let _apply_trades_best_effort ?on_trade_fill portfolio trades =
+  let hook = Option.value on_trade_fill ~default:Fn.id in
   let portfolio, accepted_rev, rejected_rev =
     List.fold trades ~init:(portfolio, [], [])
       ~f:(fun (portfolio, accepted, rejected) trade ->
+        let trade = hook trade in
         let portfolio, outcome = _try_apply_trade portfolio trade in
         match outcome with
         | `Accepted t -> (portfolio, t :: accepted, rejected)
@@ -424,7 +421,8 @@ let _process_fills_and_cancels t ~portfolio ~positions =
   in
   let all_trades = _extract_trades execution_reports in
   let portfolio, trades, rejected_trades =
-    _apply_trades_best_effort portfolio all_trades
+    _apply_trades_best_effort ?on_trade_fill:t.deps.on_trade_fill portfolio
+      all_trades
   in
   let%bind positions =
     _update_positions_from_trades ~date:t.current_date ~positions ~trades

--- a/trading/trading/simulation/lib/simulator.mli
+++ b/trading/trading/simulation/lib/simulator.mli
@@ -42,6 +42,15 @@ type dependencies = {
       (** Phase-2 margin-accounting parameters (issue #859). When
           [enabled = false] (the default), every margin code path is a no-op and
           existing baselines are bit-equal. *)
+  on_trade_fill : (Trading_base.Types.trade -> Trading_base.Types.trade) option;
+      (** Optional post-fill per-trade adjustment, applied inside the
+          simulator's accept-trades path before the portfolio accounts for each
+          trade. [None] (the default) preserves byte-equal baselines.
+
+          Strategy-agnostic, cost-model-agnostic hook so the simulator does not
+          depend on the higher-layer [Backtest_cost_model.Cost_model]. Callers
+          in the backtest layer construct the hook from
+          [Cost_model.apply_per_trade_commission] and thread it through. *)
 }
 
 val create_deps :
@@ -56,6 +65,7 @@ val create_deps :
   ?stale_hold_log:Stale_hold.Log.t ->
   ?slippage_bps:int ->
   ?margin_config:Trading_portfolio.Margin_config.t ->
+  ?on_trade_fill:(Trading_base.Types.trade -> Trading_base.Types.trade) ->
   unit ->
   dependencies
 (** Create standard dependencies with default engine, order manager, and
@@ -89,7 +99,14 @@ val create_deps :
       Phase-2 margin-accounting parameters (issue #859). Default
       {!Trading_portfolio.Margin_config.default_config} — disabled, so the
       simulator's per-step margin code paths are no-ops and existing baselines
-      are bit-equal. *)
+      are bit-equal.
+    @param on_trade_fill
+      Optional per-trade adjustment applied to every accepted fill before the
+      portfolio accounts for it. Default [None] — preserves byte-equal
+      baselines. Used by the backtest layer to wire the
+      {!Backtest_cost_model.Cost_model} per-trade flat commission into the
+      simulator without giving [trading.simulation] a layering dependency on the
+      higher-layer cost-model module. *)
 
 (** {1 Creation} *)
 

--- a/trading/trading/simulation/test/dune
+++ b/trading/trading/simulation/test/dune
@@ -30,6 +30,24 @@
   simulation_test_helpers))
 
 (test
+ (name test_simulator_cost_model)
+ (modules test_simulator_cost_model)
+ (libraries
+  ounit2
+  core
+  trading.simulation
+  trading.simulation.types
+  trading.simulation.data
+  trading.base
+  trading.engine
+  trading.orders
+  trading.strategy
+  backtest_cost_model
+  types
+  matchers
+  simulation_test_helpers))
+
+(test
  (name test_time_series)
  (modules test_time_series)
  (libraries ounit2 core trading.simulation.data types matchers))

--- a/trading/trading/simulation/test/test_simulator_cost_model.ml
+++ b/trading/trading/simulation/test/test_simulator_cost_model.ml
@@ -1,0 +1,188 @@
+(** Pins the simulator's [on_trade_fill] post-fill adjustment hook.
+
+    Three variants exercise the wiring contract:
+
+    1. [on_trade_fill = None] — byte-equal to the pre-PR baseline (the
+    [_apply_trades_best_effort] path takes the identity branch). 2.
+    [on_trade_fill = Some Cost_model.apply_per_trade_commission retail_default]
+    — [retail_default.per_trade_commission = 0.0], so cash matches the baseline
+    byte-for-byte even though the hook is wired. 3.
+    [on_trade_fill = Some Cost_model.apply_per_trade_commission custom] with
+    [per_trade_commission = 1.50] — cash differs from the baseline by exactly
+    [N_trades * 1.50] (the per-trade flat commission is added to each trade's
+    [commission] field before the portfolio accounts for it).
+
+    The simulator hook is strategy-agnostic and cost-model-agnostic; tests
+    construct the hook directly from
+    [Backtest_cost_model.Cost_model.apply_per_trade_commission] to avoid
+    inverting the layering (the simulator does not depend on the higher-layer
+    cost-model module). *)
+
+open OUnit2
+open Core
+open Trading_simulation.Simulator
+open Matchers
+open Test_helpers
+module Cost_model = Backtest_cost_model.Cost_model
+
+let date_of_string s = Date.of_string s
+
+let make_daily_price ~date ~open_price ~high ~low ~close ~volume =
+  Types.Daily_price.
+    {
+      date;
+      open_price;
+      high_price = high;
+      low_price = low;
+      close_price = close;
+      volume;
+      adjusted_close = close;
+      active_through = None;
+    }
+
+(* Mirrors test_simulator.sample_config / sample_aapl_prices so the
+   baselines below stay legible. *)
+let sample_config =
+  {
+    start_date = date_of_string "2024-01-02";
+    end_date = date_of_string "2024-01-05";
+    initial_cash = 10000.0;
+    commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 };
+    strategy_cadence = Types.Cadence.Daily;
+  }
+
+let sample_aapl_prices =
+  [
+    make_daily_price
+      ~date:(date_of_string "2024-01-02")
+      ~open_price:150.0 ~high:155.0 ~low:149.0 ~close:154.0 ~volume:1000000;
+    make_daily_price
+      ~date:(date_of_string "2024-01-03")
+      ~open_price:154.0 ~high:158.0 ~low:153.0 ~close:157.0 ~volume:1200000;
+  ]
+
+(* Build deps with an optional [on_trade_fill] hook. The Noop strategy keeps
+   the test focused on the fill-path enrichment; we submit a market order
+   directly to the order manager rather than going through a strategy. *)
+let _make_deps ?on_trade_fill data_dir =
+  create_deps ~symbols:[ "AAPL" ] ~data_dir
+    ~strategy:(module Noop_strategy)
+    ~commission:sample_config.commission ?on_trade_fill ()
+
+(* Submit a 10-share AAPL market buy onto the order manager so the first
+   step's fill path produces one trade. *)
+let _submit_aapl_market_buy ~order_manager ~quantity =
+  let order_params =
+    Trading_orders.Create_order.
+      {
+        symbol = "AAPL";
+        side = Trading_base.Types.Buy;
+        quantity;
+        order_type = Trading_base.Types.Market;
+        time_in_force = Trading_orders.Types.GTC;
+      }
+  in
+  let order =
+    match Trading_orders.Create_order.create_order order_params with
+    | Ok o -> o
+    | Error err -> failwith ("Failed to create order: " ^ Status.show err)
+  in
+  ignore (Trading_orders.Manager.submit_orders order_manager [ order ])
+
+(* The pre-PR baseline cash after one filled market buy.
+   Quantity 10 @ open price 150.0 + 1.0 minimum-commission floor = 9000 - 1 = 8999. *)
+let _baseline_expected_cash =
+  let quantity = 10.0 in
+  let open_price = 150.0 in
+  let baseline_commission = 1.0 in
+  sample_config.initial_cash -. (quantity *. open_price) -. baseline_commission
+
+(* Variant 1: on_trade_fill = None preserves byte-equal baseline. *)
+let test_no_hook_matches_baseline _ =
+  with_test_data "simulator_cost_model_none"
+    [ ("AAPL", sample_aapl_prices) ]
+    ~f:(fun data_dir ->
+      let deps = _make_deps data_dir in
+      let sim = Test_helpers.create_exn ~config:sample_config ~deps in
+      _submit_aapl_market_buy ~order_manager:deps.order_manager ~quantity:10.0;
+      let _, result = step_exn sim in
+      assert_that result
+        (all_of
+           [
+             field (fun r -> r.trades) (size_is 1);
+             field
+               (fun r -> r.portfolio.current_cash)
+               (float_equal _baseline_expected_cash);
+           ]))
+
+(* Variant 2: on_trade_fill = Some retail_default's per_trade_commission
+   is 0.0, so the enrichment is the identity even though the hook is
+   wired. Pins the byte-equal-on-zero-cost contract. *)
+let test_retail_default_preserves_baseline _ =
+  with_test_data "simulator_cost_model_retail_default"
+    [ ("AAPL", sample_aapl_prices) ]
+    ~f:(fun data_dir ->
+      let deps =
+        _make_deps
+          ~on_trade_fill:
+            (Cost_model.apply_per_trade_commission Cost_model.retail_default)
+          data_dir
+      in
+      let sim = Test_helpers.create_exn ~config:sample_config ~deps in
+      _submit_aapl_market_buy ~order_manager:deps.order_manager ~quantity:10.0;
+      let _, result = step_exn sim in
+      assert_that result
+        (all_of
+           [
+             field (fun r -> r.trades) (size_is 1);
+             field
+               (fun r -> r.portfolio.current_cash)
+               (float_equal _baseline_expected_cash);
+           ]))
+
+(* Variant 3: a custom cost-model with per_trade_commission = 1.50 makes
+   cash drop by exactly that flat fee relative to the baseline. The trade
+   recorded on the step also carries the bumped commission, since the hook
+   runs before the trade is accepted into the step_result. *)
+let test_custom_per_trade_subtracts_exact_delta _ =
+  let flat_fee = 1.50 in
+  let custom_cm = { Cost_model.zero with per_trade_commission = flat_fee } in
+  with_test_data "simulator_cost_model_custom"
+    [ ("AAPL", sample_aapl_prices) ]
+    ~f:(fun data_dir ->
+      let deps =
+        _make_deps
+          ~on_trade_fill:(Cost_model.apply_per_trade_commission custom_cm)
+          data_dir
+      in
+      let sim = Test_helpers.create_exn ~config:sample_config ~deps in
+      _submit_aapl_market_buy ~order_manager:deps.order_manager ~quantity:10.0;
+      let _, result = step_exn sim in
+      assert_that result
+        (all_of
+           [
+             field (fun r -> r.trades) (size_is 1);
+             field
+               (fun r -> r.portfolio.current_cash)
+               (float_equal (_baseline_expected_cash -. flat_fee));
+             field
+               (fun r ->
+                 match r.trades with
+                 | [ t ] -> t.Trading_base.Types.commission
+                 | _ -> Float.nan)
+               (* Engine's baseline commission (1.0 minimum-floor at qty=10)
+                  plus the cost-model's 1.50 per-trade flat fee. *)
+               (float_equal 2.50);
+           ]))
+
+let suite =
+  "Simulator cost_model wiring"
+  >::: [
+         "on_trade_fill=None matches baseline" >:: test_no_hook_matches_baseline;
+         "on_trade_fill=retail_default (per_trade=0) preserves baseline"
+         >:: test_retail_default_preserves_baseline;
+         "on_trade_fill=custom per_trade=1.50 subtracts exact delta"
+         >:: test_custom_per_trade_subtracts_exact_delta;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
Items 1+2 of the 4-item plan in [dev/status/cost-model.md](dev/status/cost-model.md), building on PR #1151 which landed the standalone `Backtest_cost_model.Cost_model` module.

## Summary

- **Scenario field**: `scenario.{ml,mli}` gains `cost_model : Cost_model.t option [@sexp.option]` — every existing scenario file omits the field and continues to parse with `None`. Threaded through `scenario_runner` → `Backtest.Runner.run_backtest` → `Panel_runner.run`.
- **Simulator hook**: `Simulator.create_deps` gains `?on_trade_fill : (trade -> trade)` (default `None`). `_apply_trades_best_effort` enriches each accepted trade through the hook before the portfolio accounts for it. `Panel_runner` constructs the hook from `Cost_model.apply_per_trade_commission cm` when `?cost_model` is supplied.
- **Layering**: `trading.simulation` does NOT depend on `backtest_cost_model` (the cost-model lives one layer up; `trading.backtest` already depends on `trading.simulation`). The hook surface is strategy-agnostic and cost-model-agnostic so future cost components (market impact, etc.) compose into the same hook without changing the simulator surface.

## Items not in scope

- Item 3 (ADV plumbing for market-impact wiring) — needs separate design + perf check.
- Item 4 (Cell E re-pin with retail/institutional overlay) — separate dispatch after items 1+2 land.
- No existing scenario sexp is modified — every golden file continues to omit the field and runs on the byte-equal zero-cost baseline path.

## Test plan

- [x] `dune build` clean across the full tree.
- [x] `dune build @fmt` clean.
- [x] `dune runtest` full suite passes.
- [x] `dune runtest trading/simulation/test/test_simulator_cost_model` — 3 new cases:
  - `on_trade_fill = None` preserves baseline cash byte-for-byte.
  - `on_trade_fill = Some (apply_per_trade_commission retail_default)` (per_trade=0) preserves baseline.
  - `on_trade_fill = Some (apply_per_trade_commission custom)` with `per_trade=$1.50` subtracts exactly that delta from cash and bumps `trade.commission` accordingly.
- [x] `dune runtest trading/backtest/scenarios/test/test_scenario` — 3 new cases:
  - `cost_model` absent ⇒ `None`.
  - `cost_model` present ⇒ `Some record` with the right field values.
  - `cost_model` sexp round-trips through `sexp_of_t` / `t_of_sexp`.
- [x] `dune runtest trading/backtest/cost_model` — 27/27 standalone cost-model tests still pass.
- [x] All backtest goldens unchanged (no `cost_model` field added to any scenario sexp).

## PR sizing

~405 LOC total (16 files, 436 insertions, 30 deletions, including ~290 LOC of tests). Status-file refresh + test fixtures don't count per the PR-sizing rule; net production code is ~115 LOC.

Refs: PR #1151 (standalone Cost_model module); dev/status/cost-model.md.