### PR TITLE
test(tuner): pin int_keys merge + reject malformed marker + fix .mli example

### DIFF
--- a/trading/trading/backtest/tuner/bin/bayesian_runner_spec.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_spec.mli
@@ -184,19 +184,21 @@ type t = {
           the emitted sexp. *)
 }
 [@@deriving sexp]
-(** A Bayesian-optimisation spec on disk. Example sexp:
-    {[
+(** A Bayesian-optimisation spec on disk. Example sexp (verbatim — the [(int)]
+    marker on the third binding must be parenthesised; the bare atom [int] is
+    rejected by {!t_of_sexp}'s pre-processor — see {!int_keys}):
+    {v
     (bounds
        (("screening.weights.rs" (0.1 0.5))
           ("screening.weights.volume" (0.1 0.5))
-          ("screening.weights.w_positive_rs" (5.0 40.0) int)))
+          ("screening.weights.w_positive_rs" (5.0 40.0) (int))))
       (acquisition Expected_improvement)
       (initial_random 5) (total_budget 30) (seed 17)
       (n_acquisition_candidates ())
       (objective Sharpe)
       (scenarios "trading/test_data/backtest_scenarios/smoke/bull-2019.sexp")
       (holdout_folds (27 28 29 30))
-    ]}
+    v}
     The [holdout_folds] tag is optional ([\@sexp.option]): omit it entirely for
     [None]; write [(holdout_folds (k1 ... kn))] for [Some [k1; ...; kn]]; write
     [(holdout_folds ())] for [Some []]. *)

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
@@ -192,6 +192,139 @@ let test_load_no_int_marker_defaults_to_empty_int_keys _ =
       let spec = Spec.load path in
       assert_that spec.int_keys (equal_to []))
 
+(** Build a [Spec.t] record carrying the given [int_keys]. Used by the
+    round-trip + merge-semantics tests below. *)
+let _spec_record_with_int_keys int_keys : Spec.t =
+  {
+    bounds =
+      [
+        ("screening.weights.rs", (0.1, 0.5));
+        ("stage3_force_exit_config.hysteresis_weeks", (1.0, 8.0));
+        ("screening.weights.w_positive_rs", (5.0, 40.0));
+      ];
+    acquisition = Spec.Expected_improvement;
+    initial_random = 5;
+    total_budget = 30;
+    seed = Some 17;
+    n_acquisition_candidates = None;
+    objective = Spec.Sharpe;
+    scenarios = [ "path/to/bull.sexp" ];
+    holdout_folds = None;
+    sentinel_bounds = None;
+    length_scales = None;
+    early_stop = None;
+    gate_penalty_value = None;
+    int_keys;
+  }
+
+let test_int_keys_round_trip_non_empty _ =
+  (* Round-trip [t -> sexp -> t] preserves a non-empty [int_keys]. The .mli
+     pins [t_of_sexp ∘ sexp_of_t = id] for any [t] — checkpoint validation
+     in the BO runner depends on this. The emitter writes per-binding
+     [(int)] markers and drops the top-level [(int_keys ...)] field; the
+     parser re-extracts them into [t.int_keys]. *)
+  let original =
+    _spec_record_with_int_keys
+      [
+        "stage3_force_exit_config.hysteresis_weeks";
+        "screening.weights.w_positive_rs";
+      ]
+  in
+  let round_tripped = Spec.t_of_sexp (Spec.sexp_of_t original) in
+  assert_that round_tripped.int_keys
+    (elements_are
+       [
+         equal_to "stage3_force_exit_config.hysteresis_weeks";
+         equal_to "screening.weights.w_positive_rs";
+       ])
+
+let _int_marker_with_explicit_field_spec_text =
+  (* Carries BOTH a top-level [(int_keys ...)] field AND per-binding [(int)]
+     markers. Pins the merge semantics documented at
+     bayesian_runner_spec.mli §int_keys and implemented in
+     [_preprocess_spec_sexp] (explicit-first, then per-binding markers). *)
+  String.concat
+    [
+      "((bounds";
+      "  ((screening.weights.rs (0.1 0.5))";
+      "   (stage3_force_exit_config.hysteresis_weeks (1.0 8.0) (int))";
+      "   (screening.weights.w_positive_rs (5.0 40.0) (int))))";
+      " (acquisition Expected_improvement)";
+      " (initial_random 5)";
+      " (total_budget 30)";
+      " (seed (17))";
+      " (n_acquisition_candidates ())";
+      " (objective Sharpe)";
+      " (scenarios (\"path/to/bull.sexp\"))";
+      " (int_keys (laggard_rotation_config.hysteresis_weeks)))";
+    ]
+    ~sep:"\n"
+
+let test_load_explicit_int_keys_field_merges_with_per_binding_markers _ =
+  (* Per .mli: "explicit-first, per-binding markers appended". The merged
+     order is the explicit field's contents followed by the per-binding
+     marker keys in their bounds-list order. *)
+  _with_temp_dir (fun dir ->
+      let path =
+        _write_spec_file dir _int_marker_with_explicit_field_spec_text
+      in
+      let spec = Spec.load path in
+      assert_that spec.int_keys
+        (elements_are
+           [
+             equal_to "laggard_rotation_config.hysteresis_weeks";
+             equal_to "stage3_force_exit_config.hysteresis_weeks";
+             equal_to "screening.weights.w_positive_rs";
+           ]))
+
+(** Build a spec sexp whose third [bounds] entry's trailing marker is
+    [marker_text]. Used to pin that malformed markers (e.g. [(int extra)],
+    [(int_alias)], bare atom [int]) are not silently treated as int-flags — they
+    fall through [_is_int_marker]'s exact match and cause [Spec.load] to raise
+    [Failure]. *)
+let _malformed_marker_spec_text ~marker_text =
+  String.concat
+    [
+      "((bounds";
+      "  ((screening.weights.rs (0.1 0.5))";
+      "   (screening.weights.w_positive_rs (5.0 40.0) " ^ marker_text ^ ")))";
+      " (acquisition Expected_improvement)";
+      " (initial_random 5)";
+      " (total_budget 30)";
+      " (seed (17))";
+      " (n_acquisition_candidates ())";
+      " (objective Sharpe)";
+      " (scenarios (\"path/to/bull.sexp\")))";
+    ]
+    ~sep:"\n"
+
+let _spec_load_raises_failure dir marker_text =
+  let path = _write_spec_file dir (_malformed_marker_spec_text ~marker_text) in
+  try
+    let _ = Spec.load path in
+    false
+  with Failure msg -> String.is_substring msg ~substring:"failed to parse"
+
+let test_load_malformed_int_marker_with_extra_atom_raises _ =
+  (* [(int extra)] is a two-atom list — [_is_int_marker] requires exactly
+     one atom, so the marker is not stripped. The 3-element binding then
+     fails the derived (string * (float * float)) parser. *)
+  _with_temp_dir (fun dir ->
+      assert_that (_spec_load_raises_failure dir "(int extra)") (equal_to true))
+
+let test_load_int_alias_marker_raises _ =
+  (* [(int_alias)] is rejected because [_is_int_marker] checks
+     [String.equal a "int"] exactly — typos do not silently parse. *)
+  _with_temp_dir (fun dir ->
+      assert_that (_spec_load_raises_failure dir "(int_alias)") (equal_to true))
+
+let test_load_bare_int_atom_marker_raises _ =
+  (* Bare atom [int] (not wrapped in parens) is a [Sexp.Atom], not a
+     [Sexp.List] — fails [_is_int_marker]'s outer [List ...] pattern.
+     Pins that the docstring example MUST use parenthesised [(int)]. *)
+  _with_temp_dir (fun dir ->
+      assert_that (_spec_load_raises_failure dir "int") (equal_to true))
+
 (* ---------- to_grid_objective + to_acquisition coverage ---------- *)
 
 let test_to_grid_objective_simple_variants _ =
@@ -995,6 +1128,16 @@ let suite =
          >:: test_load_int_marker_per_binding;
          "Spec.load: no (int) markers -> int_keys = []"
          >:: test_load_no_int_marker_defaults_to_empty_int_keys;
+         "Spec round-trip: non-empty int_keys preserved"
+         >:: test_int_keys_round_trip_non_empty;
+         "Spec.load: explicit (int_keys ...) merges with per-binding markers"
+         >:: test_load_explicit_int_keys_field_merges_with_per_binding_markers;
+         "Spec.load: malformed (int extra) marker -> Failure"
+         >:: test_load_malformed_int_marker_with_extra_atom_raises;
+         "Spec.load: (int_alias) marker -> Failure"
+         >:: test_load_int_alias_marker_raises;
+         "Spec.load: bare int atom marker -> Failure"
+         >:: test_load_bare_int_atom_marker_raises;
          "Spec.to_grid_objective: simple variants round-trip"
          >:: test_to_grid_objective_simple_variants;
          "Spec.to_acquisition: round-trips" >:: test_to_acquisition_round_trips;


### PR DESCRIPTION
## Summary

Non-blocking follow-ups from the qc-behavioral review of #1261 (captured as P5 in `dev/notes/next-session-priorities-2026-05-23.md`). One docstring fix + 5 new tests covering corners of the `int_keys` plumbing that #1261 added but did not pin.

## What changed

1. **`bayesian_runner_spec.mli` example sexp** — fix the docstring at the `type t` example block. The previous version used a bare atom `int` inside an OCaml `{[ ... ]}` code block; ocamlformat normalises any parenthesised `(int)` written there back to the bare atom, so the example was permanently wrong (the actual parser, `_is_int_marker`, requires the `Sexp.List [Sexp.Atom "int"]` form — bare atoms are rejected). Switched the example to a verbatim `{v ... v}` block so the literal `(int)` survives the formatter, and added a one-line caveat above the example pointing at the exact-match rule.

2. **`Spec round-trip: non-empty int_keys preserved`** — pins `t_of_sexp ∘ sexp_of_t = id` on a `Spec.t` value with `int_keys = ["…hysteresis_weeks"; "…w_positive_rs"]`. The .mli (line ~210) claims round-trip stability and checkpoint validation in the BO runner depends on it; no existing test exercises the non-empty path.

3. **`Spec.load: explicit (int_keys ...) merges with per-binding markers`** — pins the merge semantics documented at `.mli` §`int_keys`: when a spec carries BOTH a top-level `(int_keys (k0))` field AND per-binding `(int)` markers, the parser's output is `[k0; per-binding keys in bounds order]`. Matches `_preprocess_spec_sexp`'s `explicit @ extracted_int_keys` concatenation (no dedup).

4. **Three malformed-marker rejection tests** — `Spec.load` is expected to raise `Failure` (with `failed to parse` in the message) for three malformed forms that `_is_int_marker` claims to reject but that no test pinned:
   - `(int extra)` — two-atom list fails the exact one-atom match.
   - `(int_alias)` — atom name mismatch (`String.equal a "int"`).
   - bare atom `int` (not parenthesised) — falls outside the outer `Sexp.List` pattern.

   In all three cases `_split_binding` returns the binding unmodified, leaving a 3-element list that the derived `(string * (float * float)) list` parser then rejects. The test asserts on the wrapped failure, so the path through `_is_int_marker` is pinned end-to-end.

## Authority

- `dev/notes/next-session-priorities-2026-05-23.md` §P5
- qc-behavioral review of #1261 (cited from priorities doc; the disk path `dev/reviews/feat-bo-int-keys-spec-plumbing-behavioral.md` was named in the dispatch but the review's findings carried forward into the P5 itemisation)
- `dev/notes/bayesian-11knob-int-knob-crash-2026-05-22.md` (root cause of the `int_keys` machinery)

## Test plan

- [x] `dune build @fmt` — clean (with `{v ... v}` for the example).
- [x] `dune build` — clean.
- [x] `dune runtest trading/backtest/tuner` — 50 tests pass (was 45 before; 5 added).
- [x] Verified the 5 new test names appear via `test_bayesian_runner_bin.exe -list-test`.
- [ ] CI green at HEAD.

## Notes for review

- No production code changes. The `.mli` is the only non-test file touched, and the change is purely docstring (no signature, no field, no semantics).
- Test patterns conform to `.claude/rules/test-patterns.md`: one `assert_that` per value, `elements_are` for the merged-keys list, no nested `assert_that`.
- The malformed-marker tests follow the existing `test_load_malformed_raises` pattern (boolean flag + `equal_to true` against a substring of the `Failure` message), so the rejection contract is greppable.