### PR TITLE
feat(cost-model): wire to_engine_costs through Panel_runner.run

### DIFF
--- a/dev/status/cost-model.md
+++ b/dev/status/cost-model.md
@@ -87,19 +87,35 @@ YES
 
 ## Open work
 
-- [ ] **Wire `Cost_model.to_engine_costs` through `Panel_runner.run`**
-  so `bid_ask_spread_bps` + `per_share_commission` actually take
-  effect when `cost_model` is set. Single-file change (~30 LOC) in
-  `panel_runner.ml`: when `cost_model = Some cm`, derive
-  `(commission, slippage_bps)` from `to_engine_costs cm`, falling
-  back to the runner default for `None`. After this lands, re-run
-  the small goldens to confirm pinned ranges still gate; if any
-  break, re-pin from the new run. Cell E expected to drift ≈1%
-  return — well inside the current ±15% tolerance.
 - [ ] **Wire market-impact into the engine** — requires ADV
   plumbing. ADV needs to be loaded alongside bars; not yet in the
   simulation data layer. Defer until empirical evidence shows
   impact dominates over spread for realistic order sizes.
+
+## Completed (continued)
+
+- [x] **Wire `Cost_model.to_engine_costs` through `Panel_runner.run`**
+  (PR pending, 2026-05-23 — feat/cost-model-to-engine-wiring). Added
+  pure helper `Panel_runner.engine_costs_with_overlay` (exposed in
+  the .mli for tests): when `cost_model = Some cm`, derives
+  `(commission, slippage_bps)` from `Cost_model.to_engine_costs cm`
+  and fully replaces both the runner default commission
+  (`{ per_share = 0.01; minimum = 1.0 }`) and the caller's
+  `?slippage_bps`; when `cost_model = None`, the runner defaults
+  flow through unchanged (byte-equal baseline). Wired into the
+  `_make_simulator` call site in `Panel_runner.run`. Two new test
+  cases pin the resolution
+  (`trading/backtest/test/test_panel_runner_cost_model.ml`):
+  `cost_model=None preserves runner defaults` and `cost_model=Some
+  retail_default overrides commission + slippage`. Goldens not
+  re-pinned in this PR — the 7 cost_model-annotated scenarios
+  exercise the full path under nightly perf-tier; Cell E expected
+  to drift ≈1% return inside the existing ±15% tolerance per
+  `dev/notes/cost-model-overlay-repin-2026-05-23.md` (spread drag
+  partially offset by per-share commission dropping $0.01 → $0.00).
+  Verify: `dune runtest trading/backtest/test/test_panel_runner_cost_model.exe`
+  (2/2 pass); `dune runtest trading/backtest/cost_model` (27/27
+  pass); full `dune runtest` green.
 
 ## Follow-up experiments
 

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -222,6 +222,28 @@ let _create_recorders () : _recorders =
 let _on_trade_fill_of_cost_model cost_model =
   Option.map cost_model ~f:Cost_model.apply_per_trade_commission
 
+(* Resolve the effective [(commission, slippage_bps)] pair the simulator
+   receives.
+
+   When [cost_model = Some cm], the overlay takes precedence: the engine's
+   per-share commission + integer slippage_bps are derived from
+   {!Cost_model.to_engine_costs}, fully replacing the runner's default
+   commission and the caller's [?slippage_bps]. This is the explicit
+   scenario-facing surface — scenarios that declare a [cost_model] expect
+   their declared cost regime to be exactly what the engine bills.
+
+   When [cost_model = None], the function returns the runner-side defaults
+   unchanged: the [~default_commission] passed by the runner constants
+   table and the caller's [?default_slippage_bps] (typically [None] →
+   engine's own slippage default). Byte-equal to pre-#1260 baselines. *)
+let engine_costs_with_overlay ~default_commission ?default_slippage_bps
+    ?cost_model () =
+  match cost_model with
+  | None -> (default_commission, default_slippage_bps)
+  | Some cm ->
+      let commission, slip_bps = Cost_model.to_engine_costs cm in
+      (commission, Some slip_bps)
+
 let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     ~commission ?(strategy_choice = Strategy_choice.default) ?trace ?gc_trace
     ?bar_data_source ?progress_emitter ?slippage_bps ?cost_model () =
@@ -241,9 +263,14 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
       ~end_date ~audit_recorder:r.audit_recorder
   in
   let on_trade_fill = _on_trade_fill_of_cost_model cost_model in
+  let effective_commission, effective_slippage_bps =
+    engine_costs_with_overlay ~default_commission:commission
+      ?default_slippage_bps:slippage_bps ?cost_model ()
+  in
   let sim =
     _make_simulator input ~stop_log:r.stop_log ~stale_hold_log:r.stale_hold_log
-      ~start_date ~end_date ~warmup_days ~initial_cash ~commission ?slippage_bps
+      ~start_date ~end_date ~warmup_days ~initial_cash
+      ~commission:effective_commission ?slippage_bps:effective_slippage_bps
       ?on_trade_fill ~strategy ~market_data_adapter ()
   in
   let progress_acc =

--- a/trading/trading/backtest/lib/panel_runner.mli
+++ b/trading/trading/backtest/lib/panel_runner.mli
@@ -122,11 +122,34 @@ val run :
     the path-dependence surface this rewiring closes.
 
     [cost_model], when passed, threads a {!Backtest_cost_model.Cost_model.t}
-    overlay through the simulator. The runner builds an [on_trade_fill] hook
-    from {!Cost_model.apply_per_trade_commission} and passes it to
-    {!Trading_simulation.Simulator.create_deps}, which applies the adjustment to
-    every accepted fill before the portfolio accounts for it. [None] (the
-    default) preserves the zero-cost baseline byte-for-byte. Item 2 of the
-    four-item cost-model wiring plan in [dev/status/cost-model.md]; the
-    per-share-commission, bid-ask-spread and market-impact components of
-    [cost_model] are not yet routed through the runner. *)
+    overlay through the simulator on two surfaces:
+
+    - {!Cost_model.apply_per_trade_commission} becomes the simulator's
+      [on_trade_fill] hook (item 2 of the cost-model wiring plan in
+      [dev/status/cost-model.md]).
+    - {!Cost_model.to_engine_costs} derives the engine's per-share commission
+      and integer slippage_bps, fully replacing both the runner's default
+      commission (typically [{ per_share = 0.01; minimum = 1.0 }]) and the
+      caller's [?slippage_bps]. This makes [bid_ask_spread_bps] and
+      [per_share_commission] material at every fill. See
+      {!engine_costs_with_overlay} for the pure helper that performs the
+      resolution (exposed for tests).
+
+    [None] (the default) preserves the byte-equal baseline: the runner's default
+    commission and the caller's [?slippage_bps] flow through unchanged, and no
+    [on_trade_fill] is set. The market-impact component of [cost_model] is not
+    yet routed through the runner — it requires ADV plumbing that lives on the
+    simulation data layer. *)
+
+val engine_costs_with_overlay :
+  default_commission:Trading_engine.Types.commission_config ->
+  ?default_slippage_bps:int ->
+  ?cost_model:Backtest_cost_model.Cost_model.t ->
+  unit ->
+  Trading_engine.Types.commission_config * int option
+(** Pure helper that mirrors the overlay rule applied inside {!run}: when
+    [cost_model = Some cm], the returned [(commission, slippage_bps)] pair is
+    derived from {!Cost_model.to_engine_costs} (fully replacing the runner
+    defaults); when [cost_model = None], the runner defaults flow through
+    unchanged. Exposed so tests can pin the resolution without spinning up a
+    full simulator. *)

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -20,6 +20,7 @@
   test_fuzz_distribution
   test_gc_trace
   test_panel_runner_gc_trace
+  test_panel_runner_cost_model
   test_backtest_progress
   test_release_perf_report
   test_determinism
@@ -47,6 +48,7 @@
   trading.data_panel.snapshot
   trading.engine
   trading.portfolio
+  backtest_cost_model
   trading.simulation
   trading.simulation.data
   trading.simulation.types

--- a/trading/trading/backtest/test/test_panel_runner_cost_model.ml
+++ b/trading/trading/backtest/test/test_panel_runner_cost_model.ml
@@ -1,0 +1,81 @@
+(** Unit tests for the [Panel_runner.engine_costs_with_overlay] helper.
+
+    Pins the rule that {!Backtest.Panel_runner.run} applies when resolving the
+    effective [(commission, slippage_bps)] pair passed to the simulator:
+
+    - [cost_model = None] → runner defaults flow through unchanged (byte-equal
+      baseline contract).
+    - [cost_model = Some cm] → {!Cost_model.to_engine_costs} fully replaces the
+      runner default commission and the caller's [?slippage_bps].
+
+    Open work item 1 in [dev/status/cost-model.md]. Follows
+    [.claude/rules/test-patterns.md]. *)
+
+open OUnit2
+open Matchers
+module CM = Backtest_cost_model.Cost_model
+
+(* The runner-side default commission constant from [Backtest.Runner].
+   Reproduced here so the test pins the resolved pair, not the source of
+   the default. *)
+let _runner_default_commission : Trading_engine.Types.commission_config =
+  { per_share = 0.01; minimum = 1.0 }
+
+let test_none_preserves_runner_defaults _ =
+  (* When the scenario does not declare a [cost_model], the helper must
+     return the runner's default commission verbatim and propagate the
+     caller's [?slippage_bps] unchanged ([None] in this case → simulator
+     uses its own slippage default, which is zero). Pins the byte-equal
+     baseline contract: scenarios that pre-date the wiring see no
+     behaviour change. *)
+  let resolved =
+    Backtest.Panel_runner.engine_costs_with_overlay
+      ~default_commission:_runner_default_commission ()
+  in
+  assert_that resolved
+    (all_of
+       [
+         field
+           (fun ((c : Trading_engine.Types.commission_config), _) -> c)
+           (equal_to
+              ({ per_share = 0.01; minimum = 1.0 }
+                : Trading_engine.Types.commission_config));
+         field (fun (_, s) -> s) is_none;
+       ])
+
+let test_some_retail_default_overrides_runner_defaults _ =
+  (* When the scenario declares [cost_model = Some retail_default], the
+     helper must derive the engine's commission + slippage from
+     [Cost_model.to_engine_costs]. Pin both fields explicitly:
+     - [commission.per_share = 0.0] (retail flat-fee has no per-share
+       component; the runner default's $0.01 is overridden).
+     - [commission.minimum  = 0.0] (the cost-model overlay does not surface
+       the engine's [minimum] floor; documented in [Cost_model.to_engine_costs]).
+     - [slippage_bps        = Some 5] (rounded from
+       [retail_default.bid_ask_spread_bps = 5.0]). *)
+  let resolved =
+    Backtest.Panel_runner.engine_costs_with_overlay
+      ~default_commission:_runner_default_commission
+      ~cost_model:CM.retail_default ()
+  in
+  assert_that resolved
+    (all_of
+       [
+         field
+           (fun ((c : Trading_engine.Types.commission_config), _) -> c)
+           (equal_to
+              ({ per_share = 0.0; minimum = 0.0 }
+                : Trading_engine.Types.commission_config));
+         field (fun (_, s) -> s) (is_some_and (equal_to 5));
+       ])
+
+let suite =
+  "Panel_runner_cost_model"
+  >::: [
+         "cost_model=None preserves runner defaults"
+         >:: test_none_preserves_runner_defaults;
+         "cost_model=Some retail_default overrides commission + slippage"
+         >:: test_some_retail_default_overrides_runner_defaults;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Open work item 1 from `dev/status/cost-model.md`. Wires
`Cost_model.to_engine_costs` through `Panel_runner.run` so that
`bid_ask_spread_bps` and `per_share_commission` actually take
effect when a scenario declares `cost_model`.

Behaviour:
- `cost_model = Some cm` → derive `(commission, slippage_bps)` from
  `Cost_model.to_engine_costs cm`. Fully replaces the runner's default
  commission (`{ per_share = 0.01; minimum = 1.0 }`) and the caller's
  `?slippage_bps`.
- `cost_model = None` → runner defaults flow through unchanged
  (byte-equal baseline contract preserved).

Adds a pure helper `Panel_runner.engine_costs_with_overlay` exposed
in the `.mli` so tests can pin the resolution without spinning up a
full simulator.

## Tests

Two new cases in `trading/backtest/test/test_panel_runner_cost_model.ml`:

1. `cost_model=None preserves runner defaults` — pins
   `commission = { per_share=0.01; minimum=1.0 }` and `slippage_bps = None`.
2. `cost_model=Some retail_default overrides commission + slippage` —
   pins `commission = { per_share=0.0; minimum=0.0 }` (engine `minimum`
   floor intentionally not surfaced by the cost-model overlay) and
   `slippage_bps = Some 5` (rounded from
   `retail_default.bid_ask_spread_bps = 5.0`).

## Goldens

The 7 cost_model-annotated Weinstein-strategy scenarios (#1273)
exercise the full path under nightly perf-tier, not in PR-time
`dune runtest`. No goldens re-pinned in this PR. Cell E expected to
drift ~1% return inside the existing ±15% tolerance — spread drag
(0 → 5 bps) partially offset by per-share commission dropping
$0.01 → $0.00. See `dev/notes/cost-model-overlay-repin-2026-05-23.md`
for the magnitude argument.

If nightly perf flags any range break post-merge, re-pinning is a
docs-only follow-up.

## Parent PRs

- #1260 — simulator `on_trade_fill` + `scenario.cost_model` field
- #1273 — declarative `retail_default` overlay on 7 goldens

## Test plan

- [x] `dune runtest trading/backtest/test/test_panel_runner_cost_model.exe` (2/2 pass)
- [x] `dune runtest trading/backtest/cost_model` (27/27 pass)
- [x] `dune build @fmt` clean
- [x] `dune runtest` full suite green