### PR TITLE
[main-fix] revert cost-model.md Last-updated to bare YYYY-MM-DD

### DIFF
--- a/dev/status/cost-model.md
+++ b/dev/status/cost-model.md
@@ -1,6 +1,6 @@
 # Status: cost-model
 
-## Last updated: 2026-05-23 (run-2 reconcile — full wiring landed)
+## Last updated: 2026-05-23
 
 ## Status
 MERGED


### PR DESCRIPTION
## Summary

PR #1279 (daily orchestrator summary, run 2) added a parenthetical annotation to `dev/status/cost-model.md`'s `## Last updated:` line:

```
## Last updated: 2026-05-23 (run-2 reconcile — full wiring landed)
```

`devtools/checks/status_file_integrity.sh` enforces the strict format `## Last updated: YYYY-MM-DD` with no trailing text. CI failed on main at SHA `4eeaac8d` (run 26333477166).

This PR strips the parenthetical to restore the linter's accepted shape.

## Test plan

- [ ] CI green — `build-and-test` should now pass `status_file_integrity_linter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)