### PR TITLE
docs(notes+plans): 2026-05-26 handoff + harness architecture plan (5-PR program parallel to tuning)

### DIFF
--- a/dev/notes/next-session-priorities-2026-05-26.md
+++ b/dev/notes/next-session-priorities-2026-05-26.md
@@ -1,0 +1,84 @@
+# Next-session priorities (2026-05-26)
+
+Supersedes `dev/notes/next-session-priorities-2026-05-25.md`.
+
+## Session ramp-up
+
+Per `.claude/rules/session-rampup.md`:
+
+1. **Check main CI is green:** `gh run list --branch main --limit 3 --json conclusion,name,headSha,status`. If red, fix first.
+2. **Read this doc** (you're here). It points at the active roadmap docs.
+
+## Active roadmaps — two parallel programs
+
+### Program A — Tuning research-driven program (5-7 sessions)
+
+**Master plan:** `dev/plans/tuning-research-driven-program-v2-2026-05-25.md`
+
+Settles the 11-knob plateau verdict by attacking the noise floor + meta-overfit + hand-tuned-scalar problems all at once, per the 2026-05-25 frontier-BBO research triage.
+
+4 milestones + 1 sweep + 1 Phase-2 stretch:
+
+| Milestone | What |
+|---|---|
+| **M1 (PR-1)** | Multi-fidelity (fold-COUNT tiers: 6→12→26 folds × 12m + Ambitious 8-10 × 36m) + Common Random Numbers fold pairing |
+| M2 (PR-2) | qNEHVI multi-objective with multi-baseline constraint (Sharpe, MaxDD, pass-vs-BRK + SPY-pass as hard constraint) |
+| M3 (PR-3) | Deflated Sharpe Ratio + outer-holdout enforcement |
+| **M4 (PR-4)** | 1998-2026 + top-3000 (delisted-aware) primary sweep — the canonical experiment |
+| Phase 2 stretch | True PIT Russell 3000 membership (data engineering; deferred) |
+
+**Start M1.** Task list at the top of the plan doc.
+
+### Program B — Sweep + QC architecture improvements (3-4 sessions)
+
+**Master plan:** `dev/plans/sweep-and-qc-architecture-2026-05-26.md`
+
+Harness improvements that compound across all future sessions. **Parallel to Program A — neither blocks the other.**
+
+5 small PRs:
+
+| PR | What |
+|---|---|
+| **PR-A** | `dev/scripts/launch_sweep.sh` — mandatory entry point; refuses to launch if preconditions fail (disk, bind-mount, etc.) |
+| PR-B | `bayesian_runner.exe` refuses non-`/tmp/sweeps/` output paths |
+| PR-C | `dev/scripts/sweep_disk_watcher.sh` — autonomous abort on disk/Docker.raw thresholds |
+| PR-D | QC agents post via `gh pr review --comment` instead of writing `dev/reviews/<feature>.md` files |
+| PR-E | QC agents use plain `git worktree` instead of `jj edit` (fixes the shared-jj-backend race) |
+
+**Why this parallel work:** today's session lost ~16h of sweep wall-time to disk-fill recovery + multiple jj contamination incidents. The sweep-hygiene rule exists but isn't mechanically enforced — these PRs add the enforcement layer.
+
+## Order recommendation
+
+**Open PR-A first** (launch wrapper). Single highest-leverage change in either program. Once mechanically-safe sweep launches are in place, the rest of Program A's wall-time risk drops dramatically. Then choose freely between A and B based on bandwidth.
+
+## Operational reminders (carried forward from 2026-05-25)
+
+Documented in `.claude/rules/sweep-hygiene.md`. Will become enforced once Program B PR-A lands. Until then, observe manually:
+
+- **Sweep output to `/tmp/sweeps/<name>/`** (bind-mounted to host)
+- **`df -h /` every ~2h** of an active sweep
+- **No concurrent agent dispatches during a sweep** (share container's writable layer)
+- **`rm -rf .claude/worktrees/<agent-id>/`** after each agent's task-notification
+
+## Open follow-ups (carried forward; deferred)
+
+- 2 qc-structural `[info]` items (H3 false-positive, review-file persistence gap, carried 8+ weeks)
+- shares-outstanding fundamentals vendor decision (blocked on user)
+- Cross-scenario validation track decision (per track-pacer)
+- Sweep ↔ QC container contention — still real after Program B PR-A-E; needs separate-containers or sweep-runs-natively fix (out of current scope)
+
+## State at session end (2026-05-25)
+
+- Main green
+- No open PRs, no open issues
+- Docker container `trading-1-dev` healthy; bind-mount in place; Docker.raw < 30 GB
+- 22+ PRs merged today across the day's session
+- `.sweep-output/` exists as bind-mount target on host
+
+## References
+
+- `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` — Program A master plan
+- `dev/plans/sweep-and-qc-architecture-2026-05-26.md` — Program B master plan
+- `.claude/rules/sweep-hygiene.md` — operational rules
+- `.claude/rules/session-rampup.md` — the ramp-up protocol itself
+- `dev/notes/v6-random-baseline-verdict-2026-05-24.md` — the empirical evidence both programs respond to

--- a/dev/plans/sweep-and-qc-architecture-2026-05-26.md
+++ b/dev/plans/sweep-and-qc-architecture-2026-05-26.md
@@ -1,0 +1,191 @@
+# Sweep + QC architecture improvements (2026-05-26)
+
+Harness improvements that compound across all future sessions. Runs in
+**parallel** with the tuning research-driven program
+(`dev/plans/tuning-research-driven-program-v2-2026-05-25.md`) — neither
+gates the other.
+
+## Why
+
+Today's session (2026-05-23/24/25) exposed three failure modes that the
+existing `.claude/rules/sweep-hygiene.md` documents but doesn't enforce
+mechanically:
+
+| Failure mode | Cost today |
+|---|---|
+| Sweep output in repo path → snapshot churn grew `Docker.raw` to 186GB → host disk full → Docker daemon died → multiple sweep crashes | ~16h of sweep wall-time lost across v2 / v3 / v4 / v5 |
+| QC agents `jj edit <pr-branch>` mutated the shared `.jj/repo/`, contaminated parent workspace (PWD-in-deleted-worktree, gitignore reversion mid-sweep) | At least 2 separate jj contamination incidents |
+| QC agents write to `dev/reviews/<feature>.md` on the PR branch → merge conflicts + housekeeping churn + reviews scattered across PRs | Ongoing low-grade friction |
+
+These are addressable at the harness layer with bounded, well-scoped
+changes. The sweep-hygiene rule stays as the **discipline doc**; the
+changes below are the **enforcement layer**.
+
+## Five PRs, sequenceable
+
+### PR-A — Launch wrapper script: `dev/scripts/launch_sweep.sh`
+
+**What:** mandatory entry point for any sweep launch. Refuses to launch unless preconditions are met.
+
+**Preconditions checked:**
+
+- [ ] Host disk free ≥ 50 GB (`df -h /`)
+- [ ] `Docker.raw` actual size < 30 GB
+- [ ] `trading-1-dev` container is running
+- [ ] `/tmp/sweeps/` is bind-mounted to host (`docker inspect` check)
+- [ ] No other `bayesian_runner.exe` processes already running in the container
+- [ ] No locked agent worktrees > 24h old (`.claude/worktrees/`)
+
+If any check fails, **exit non-zero with a clear message** explaining what to fix.
+
+**On success:**
+- Creates `/tmp/sweeps/<sweep-name>/`
+- Launches `bayesian_runner.exe` via `docker exec -d`
+- Spawns the disk watcher (PR-C) as a child process
+- Prints PID + canonical "monitor with `docker exec ... pgrep -af`" line
+
+**Effort:** ~150 LOC POSIX shell + ~50 LOC tests. 1 small PR.
+
+**Acceptance:**
+- Each precondition has a unit test (fixture-driven; mock `df`/`docker inspect` output).
+- Running with `--dry-run` shows what would be launched without firing.
+- Running on a clean container with `disk_free=80GB` succeeds; running with `disk_free=10GB` fails fast with explicit error.
+
+### PR-B — Bind-mount assertion in `bayesian_runner.exe`
+
+**What:** belt-and-suspenders refusal to launch if `--out-dir` is not under `/tmp/sweeps/`. Even if someone bypasses PR-A's wrapper, the binary itself enforces the convention.
+
+**Change:** in `bayesian_runner.ml` arg parsing, after `--out-dir <path>` is resolved, assert `String.is_prefix path ~prefix:"/tmp/sweeps/"`. Fail with `Stdlib.exit 2` + an error message pointing at the sweep-hygiene rule.
+
+**Effort:** ~20 LOC + 1 unit test. 1 small PR.
+
+**Acceptance:**
+- Launch with `--out-dir /tmp/sweeps/foo` succeeds.
+- Launch with `--out-dir dev/experiments/...` exits 2 with the error message.
+- Documented exemption: env var `BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT=1` for genuine one-off use (don't make this discoverable).
+
+### PR-C — Disk watcher daemon: `dev/scripts/sweep_disk_watcher.sh`
+
+**What:** runs alongside any sweep. Polls host `df -h /` + container `/tmp` size + `Docker.raw` size every 60s. SIGTERMs the sweep if any threshold trips. Per the safe-sweep-infra plan §4.
+
+**Thresholds:**
+- Host disk free < 20 GB → SIGTERM (lets the BO runner write a final checkpoint)
+- `Docker.raw` > 50 GB → warning at 50, SIGTERM at 65
+- Container `/tmp` > 30 GB → warning (likely snapshot-churn buildup; spawn the cleanup hook)
+
+**Outputs:**
+- Append-only log at `.sweep-output/<sweep-name>.watcher.log`
+- Stderr to the same file
+- Exits when sweep PID exits
+
+**Effort:** ~80 LOC + ~50 LOC tests. 1 small PR.
+
+**Acceptance:**
+- Fixture: mock-disk-fill scenario triggers SIGTERM at the correct threshold.
+- Manual: launch a sweep + induce a 1GB disk consumption → watcher logs the breach.
+
+### PR-D — QC review storage: `gh pr review --comment` instead of `dev/reviews/<file>.md`
+
+**What:** replace the current pattern of QC agents writing `dev/reviews/<feature>-structural.md` / `<feature>-behavioral.md` files on the PR branch with **posting PR review comments via the GitHub API**.
+
+**Why:**
+- `dev/reviews/` files cause merge conflicts when multiple PRs touch the same review file
+- Review files are buried in the repo; PR comments are on the PR
+- GitHub natively supports `APPROVED` / `CHANGES_REQUESTED` / `COMMENTED` verdicts (matches our QC verdict shape)
+- Audit trail is searchable via `gh pr view <N> --json reviews`
+- Removes one source of jj/git contention (no PR-branch write)
+
+**Change:**
+
+- QC agent prompts: replace "write to `dev/reviews/<feature>.md`" with:
+  ```
+  Post the review as a PR comment via:
+    gh pr review <N> --comment --body "$(cat <<'EOF'
+    <verdict>
+    <findings>
+    EOF
+    )"
+  Then set the PR verdict via:
+    gh pr review <N> --approve | --request-changes | --comment
+  ```
+- Update `.claude/agents/qc-structural.md` and `.claude/agents/qc-behavioral.md` to bake this in.
+- Keep `dev/reviews/` for **batch reports** (track-pacer, weekly health-scanner) where a file IS the right artifact. Just stop using it for per-PR QC.
+
+**Effort:** ~50 LOC agent-prompt edits + retire `dev/reviews/<feature>.md` convention. 1 PR.
+
+**Acceptance:**
+- Dispatch a qc-structural review on a test PR; verify the verdict appears as a PR review comment with the correct APPROVED / REQUESTED-CHANGES state.
+- Verify the per-PR review files (e.g. `dev/reviews/fix-segmentation-epsilon.md`) are NOT created.
+
+### PR-E — QC worktree: plain `git worktree` instead of `jj edit`
+
+**What:** stop using `jj edit <pr-branch>` in QC agents. Use `git worktree add /tmp/qc-<pr-N> <pr-branch>` instead. Git worktrees are file-system-only; no shared `.jj/repo/` race.
+
+**Why:**
+- `jj edit` mutates the shared jj backend (`memory/feedback_qc_agents_need_worktree_isolation.md`)
+- Today: QC's `jj edit` pulled the parent workspace's `@` along (`memory/project_jj_worktree_root_cause.md`)
+- Today: QC's worktree was rm-rf'd while my PWD was still in it, then jj recreated the directory mid-session
+- Plain git worktrees don't have this class of bug
+
+**Change:**
+
+- Update QC agent prompts to use git rather than jj for the PR checkout:
+  ```bash
+  WT="/tmp/qc-pr-$N-$$"
+  git fetch origin <pr-branch>
+  git worktree add "$WT" origin/<pr-branch>
+  cd "$WT"
+  docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune build && dune runtest'
+  # ... write findings + post via gh pr review ...
+  cd /
+  git worktree remove "$WT"
+  ```
+- The QC agent NEVER calls `jj` directly. Plain git only. No shared-jj-backend race.
+
+**Effort:** ~80 LOC agent-prompt edits. 1 PR.
+
+**Acceptance:**
+- Two QC agents dispatched on different PRs in the same session do not contaminate each other's worktrees.
+- Parent workspace's `@` does not move when a QC agent runs.
+
+## Sequencing
+
+| Sequence | Why |
+|---|---|
+| PR-A first | The wrapper script is the highest-leverage single change. Once it's in place, sweep launches are mechanically safe. |
+| PR-B second | Belt-and-suspenders for the wrapper; trivial PR. |
+| PR-C third | Disk watcher; depends on PR-A's wrapper to spawn it. |
+| PR-D fourth | QC architecture refactor; independent of A/B/C but quality-of-life leverage compounds across QC dispatches. |
+| PR-E fifth | Same shape as D but solves the jj-backend race. |
+
+PRs A/B/C address sweep-hygiene enforcement; PRs D/E address QC architecture. The two halves are independent — could be done in either order.
+
+## What this does NOT fix
+
+- **Sweep ↔ QC container contention.** Both still write to the container's `_build/` directory. If you launch a QC agent while a sweep is running, dune build outputs collide. The right fix is **separate containers** OR **sweep-runs-natively** (host OCaml, not container). Out of scope for this plan; flagged for a future architectural conversation.
+
+- **Periodic snapshot-cleanup hook in `Panel_runner`.** Per `dev/plans/safe-sweep-infrastructure-2026-05-24.md` §3. Still useful; complementary to the disk watcher. Lower priority once the watcher is in place.
+
+## Effort estimate
+
+| | LOC | Sessions |
+|---|---:|---:|
+| PR-A — launch wrapper | ~200 | 1 |
+| PR-B — runner assertion | ~20 | 0.5 (combines with PR-A) |
+| PR-C — disk watcher | ~130 | 1 |
+| PR-D — QC via gh comments | ~100 | 1 |
+| PR-E — QC plain git worktree | ~80 | 0.5 |
+| **Total** | **~530** | **3-4** |
+
+Cheap. Compounds with every sweep + every QC dispatch indefinitely.
+
+## References
+
+- `.claude/rules/sweep-hygiene.md` — operational rules this plan enforces
+- `.claude/rules/worktree-isolation.md` — the jj-workspace-isolation contract this plan superseded for QC agents
+- `dev/plans/safe-sweep-infrastructure-2026-05-24.md` — the original framing of items 1-3
+- `memory/feedback_qc_agents_need_worktree_isolation.md`
+- `memory/project_jj_worktree_root_cause.md`
+- `memory/feedback_jj_restore_killed_sweep.md`
+- `memory/feedback_worktree_disk_kills_docker.md`
+- `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` — parallel work program; this plan does not block it


### PR DESCRIPTION
## Summary

Two new docs to close out today's session:

### 1. `dev/notes/next-session-priorities-2026-05-26.md` (the handoff)

Found automatically by `.claude/rules/session-rampup.md`'s `ls -1t dev/notes/next-session-priorities-*.md | head -1`. Points the next session at:
- **Program A** — Tuning research-driven program v2 (5-7 sessions; master plan = `dev/plans/tuning-research-driven-program-v2-2026-05-25.md`)
- **Program B** — Sweep + QC architecture improvements (3-4 sessions; master plan = the second new doc below)

The two programs run in parallel; neither blocks the other.

### 2. `dev/plans/sweep-and-qc-architecture-2026-05-26.md`

Codifies today's hard-won lessons as enforceable infrastructure rather than discipline doc. 5 small PRs:

| PR | What | Effort |
|---|---|---|
| PR-A | `dev/scripts/launch_sweep.sh` — mandatory entry point with pre-launch checklist | ~200 LOC |
| PR-B | `bayesian_runner.exe` refuses non-`/tmp/sweeps/` output paths | ~20 LOC |
| PR-C | `dev/scripts/sweep_disk_watcher.sh` — autonomous abort on threshold breach | ~130 LOC |
| PR-D | QC agents → `gh pr review --comment` (replace `dev/reviews/<feature>.md` per-PR pattern) | ~100 LOC |
| PR-E | QC agents → plain `git worktree` (fix the shared-jj-backend race) | ~80 LOC |

Total ~530 LOC across 3-4 sessions. Compounds with every future sweep + QC dispatch.

## Why now

Today's session lost ~16h of sweep wall-time to disk-fill cascades + 2 separate jj contamination incidents from QC agents. The `.claude/rules/sweep-hygiene.md` rule exists but isn't mechanically enforced — these PRs add the enforcement layer.

## Test plan

- [ ] CI green — docs-only PR per `.claude/rules/pr-merge-gates.md` allowlist (`dev/notes/`, `dev/plans/`). Both QC gates skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)