### PR TITLE
feat(sweep): launch_sweep.sh wrapper — refuses to launch on 6 precondition fails

### DIFF
--- a/dev/scripts/launch_sweep.sh
+++ b/dev/scripts/launch_sweep.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# launch_sweep.sh — mandatory entry point for Bayesian-sweep launches.
+#
+# Refuses to launch unless six preconditions are met. On success, launches
+# `bayesian_runner.exe` inside the `trading-1-dev` container via
+# `docker exec -d` and prints the PID + a monitor command line.
+#
+# Why a wrapper exists: 2026-05-23/24/25 lost ~16h of sweep wall-time to
+# repeated violations of `.claude/rules/sweep-hygiene.md` preconditions
+# (sweep output in a repo path, host-disk fill, Docker.raw runaway). The
+# discipline doc is not enough on its own; this script is the enforcement
+# layer. PR-A of `dev/plans/sweep-and-qc-architecture-2026-05-26.md`.
+#
+# Usage:
+#   launch_sweep.sh --name <sweep-name> \
+#                   --spec <runner-spec.sexp> \
+#                   --walk-forward-spec <wf-spec.sexp> \
+#                   --baseline-aggregate <agg.sexp> \
+#                   [--parallel N]         (default 4)
+#                   [--container NAME]     (default trading-1-dev)
+#                   [--dry-run]
+#
+# Exit codes:
+#   0   sweep launched (or `--dry-run` summary printed)
+#   1   usage error
+#   2   precondition failure (one or more of the six gates)
+#
+# Preconditions (all must pass — every failure is printed):
+#   1. Host disk free  >= LAUNCH_SWEEP_DISK_FREE_GB_MIN (default 50 GB)
+#   2. Docker.raw size <  LAUNCH_SWEEP_DOCKER_RAW_GB_MAX (default 30 GB)
+#                         (skipped if Docker.raw path is absent — Linux hosts)
+#   3. Container       running
+#   4. /tmp/sweeps/    bind-mounted into the container
+#   5. No other        `bayesian_runner.exe` already running in the container
+#   6. No stale agent worktrees older than
+#                      LAUNCH_SWEEP_WORKTREE_STALE_HRS (default 24 h)
+#
+# Test hooks (env-var overrides for `launch_sweep_test.sh`):
+#   LAUNCH_SWEEP_DF_BIN              (default: df)
+#   LAUNCH_SWEEP_DOCKER_BIN          (default: docker)
+#   LAUNCH_SWEEP_DU_BIN              (default: du)
+#   LAUNCH_SWEEP_DOCKER_RAW_PATH     (default: $HOME/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw)
+#   LAUNCH_SWEEP_WORKTREES_DIR       (default: <repo-root>/.claude/worktrees)
+#   LAUNCH_SWEEP_DISK_FREE_GB_MIN    (default: 50)
+#   LAUNCH_SWEEP_DOCKER_RAW_GB_MAX   (default: 30)
+#   LAUNCH_SWEEP_WORKTREE_STALE_HRS  (default: 24)
+#
+# References:
+#   - .claude/rules/sweep-hygiene.md
+#   - dev/plans/sweep-and-qc-architecture-2026-05-26.md (PR-A)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+
+SWEEP_NAME=""
+SPEC=""
+WF_SPEC=""
+BASELINE_AGG=""
+PARALLEL="4"
+CONTAINER="trading-1-dev"
+DRY_RUN=0
+
+DF_BIN="${LAUNCH_SWEEP_DF_BIN:-df}"
+DOCKER_BIN="${LAUNCH_SWEEP_DOCKER_BIN:-docker}"
+DU_BIN="${LAUNCH_SWEEP_DU_BIN:-du}"
+DOCKER_RAW_PATH="${LAUNCH_SWEEP_DOCKER_RAW_PATH:-$HOME/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw}"
+WORKTREES_DIR="${LAUNCH_SWEEP_WORKTREES_DIR:-${REPO_ROOT}/.claude/worktrees}"
+DISK_FREE_GB_MIN="${LAUNCH_SWEEP_DISK_FREE_GB_MIN:-50}"
+DOCKER_RAW_GB_MAX="${LAUNCH_SWEEP_DOCKER_RAW_GB_MAX:-30}"
+WORKTREE_STALE_HRS="${LAUNCH_SWEEP_WORKTREE_STALE_HRS:-24}"
+
+usage() {
+  sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-1}"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)                shift; SWEEP_NAME="${1:-}";;
+    --spec)                shift; SPEC="${1:-}";;
+    --walk-forward-spec)   shift; WF_SPEC="${1:-}";;
+    --baseline-aggregate)  shift; BASELINE_AGG="${1:-}";;
+    --parallel)            shift; PARALLEL="${1:-}";;
+    --container)           shift; CONTAINER="${1:-}";;
+    --dry-run)             DRY_RUN=1;;
+    -h|--help)             usage 0;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage 1
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "${SWEEP_NAME}" || -z "${SPEC}" || -z "${WF_SPEC}" || -z "${BASELINE_AGG}" ]]; then
+  echo "ERROR: --name, --spec, --walk-forward-spec, --baseline-aggregate are required" >&2
+  usage 1
+fi
+
+# Sweep name must be a safe single path segment.
+if [[ ! "${SWEEP_NAME}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+  echo "ERROR: --name must match [a-zA-Z0-9._-]+ (got: ${SWEEP_NAME})" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+log() { echo "[launch_sweep] $*"; }
+err() { echo "[launch_sweep] FAIL: $*" >&2; }
+
+# Each check returns 0 on success, 1 on failure. Failures append to FAILURES;
+# we report every failure (not first-fail) so the operator can fix the host
+# state in one pass.
+FAILURES=()
+
+# ---------------------------------------------------------------------------
+# Check 1 — host disk free
+# ---------------------------------------------------------------------------
+# `df -k <path>` (POSIX) returns "Available" in 1024-byte blocks at field 4
+# on row 2. Both macOS and Linux honor `-k`.
+check_disk_free() {
+  local avail_kb avail_gb
+  avail_kb="$("${DF_BIN}" -k / 2>/dev/null | awk 'NR==2 {print $4}')"
+  if [[ -z "${avail_kb}" || ! "${avail_kb}" =~ ^[0-9]+$ ]]; then
+    err "could not read host disk free (${DF_BIN} -k / returned: '${avail_kb}')"
+    return 1
+  fi
+  avail_gb=$(( avail_kb / 1024 / 1024 ))
+  if (( avail_gb < DISK_FREE_GB_MIN )); then
+    err "host disk free ${avail_gb} GB < ${DISK_FREE_GB_MIN} GB minimum (clean first)"
+    return 1
+  fi
+  log "host disk free: ${avail_gb} GB (>= ${DISK_FREE_GB_MIN} GB)"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Check 2 — Docker.raw size
+# ---------------------------------------------------------------------------
+# Docker.raw is Docker Desktop's macOS VM disk image (sparse). When it grows
+# past ~30 GB, the host runs out of free space even though `df -h /` looks OK.
+# Linux hosts have no equivalent file — skip the check there.
+check_docker_raw() {
+  if [[ ! -f "${DOCKER_RAW_PATH}" ]]; then
+    log "Docker.raw not at ${DOCKER_RAW_PATH} — skipping (non-mac host)"
+    return 0
+  fi
+  local raw_kb raw_gb
+  raw_kb="$("${DU_BIN}" -sk "${DOCKER_RAW_PATH}" 2>/dev/null | awk '{print $1}')"
+  if [[ -z "${raw_kb}" || ! "${raw_kb}" =~ ^[0-9]+$ ]]; then
+    err "could not read Docker.raw size (${DU_BIN} -sk ${DOCKER_RAW_PATH} returned: '${raw_kb}')"
+    return 1
+  fi
+  raw_gb=$(( raw_kb / 1024 / 1024 ))
+  if (( raw_gb >= DOCKER_RAW_GB_MAX )); then
+    err "Docker.raw at ${raw_gb} GB >= ${DOCKER_RAW_GB_MAX} GB cap (recompact via Docker Desktop → Settings → Resources → Apply & restart)"
+    return 1
+  fi
+  log "Docker.raw size: ${raw_gb} GB (< ${DOCKER_RAW_GB_MAX} GB)"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Check 3 — container running
+# ---------------------------------------------------------------------------
+check_container_running() {
+  local state
+  state="$("${DOCKER_BIN}" inspect -f '{{.State.Running}}' "${CONTAINER}" 2>/dev/null || true)"
+  if [[ "${state}" != "true" ]]; then
+    err "container '${CONTAINER}' is not running (docker inspect → '${state:-not-found}')"
+    return 1
+  fi
+  log "container '${CONTAINER}' is running"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Check 4 — /tmp/sweeps/ bind-mounted
+# ---------------------------------------------------------------------------
+# Without a bind-mount, the sweep's output is written into the container's
+# writable layer, which inflates Docker.raw and is the root cause of the
+# 2026-05 disk-fill incidents.
+check_bind_mount() {
+  local destinations
+  destinations="$("${DOCKER_BIN}" inspect -f '{{range .Mounts}}{{.Destination}}{{"\n"}}{{end}}' "${CONTAINER}" 2>/dev/null || true)"
+  if ! echo "${destinations}" | grep -q '^/tmp/sweeps$'; then
+    err "/tmp/sweeps is not bind-mounted into '${CONTAINER}' (run: .devcontainer/setup.sh rebuild && .devcontainer/setup.sh start)"
+    return 1
+  fi
+  log "/tmp/sweeps bind-mount: present"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Check 5 — no other bayesian_runner.exe running
+# ---------------------------------------------------------------------------
+# Concurrent sweeps fight for the container's _build/ directory and writable
+# layer. One sweep at a time, by hard rule.
+check_no_existing_runner() {
+  local hits
+  hits="$("${DOCKER_BIN}" exec "${CONTAINER}" pgrep -f 'bayesian_runner\.exe' 2>/dev/null || true)"
+  if [[ -n "${hits}" ]]; then
+    err "another bayesian_runner.exe is already running in '${CONTAINER}' (PIDs: $(echo "${hits}" | tr '\n' ' '))"
+    return 1
+  fi
+  log "no other bayesian_runner.exe in '${CONTAINER}'"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Check 6 — no stale agent worktrees
+# ---------------------------------------------------------------------------
+# A worktree older than the stale threshold is either a forgotten cleanup or
+# a still-locked active agent. Either way it's blocking disk on the writable
+# layer and we should not start a long sweep on top of it.
+check_no_stale_worktrees() {
+  if [[ ! -d "${WORKTREES_DIR}" ]]; then
+    log "worktrees dir absent (${WORKTREES_DIR}) — nothing stale"
+    return 0
+  fi
+  local stale_mmin stale_dirs
+  stale_mmin=$(( WORKTREE_STALE_HRS * 60 ))
+  # Avoid pipe-into-while subshell scoping; capture with mapfile.
+  mapfile -t stale_dirs < <(
+    find "${WORKTREES_DIR}" -maxdepth 1 -mindepth 1 -type d -name 'agent-*' \
+      -mmin "+${stale_mmin}" 2>/dev/null | sort
+  )
+  if (( ${#stale_dirs[@]} > 0 )); then
+    err "${#stale_dirs[@]} stale worktree(s) older than ${WORKTREE_STALE_HRS}h under ${WORKTREES_DIR}:"
+    local d
+    for d in "${stale_dirs[@]}"; do echo "    ${d}" >&2; done
+    echo "    (run: bash dev/scripts/sweep_stale_worktrees.sh --force)" >&2
+    return 1
+  fi
+  log "no agent worktrees older than ${WORKTREE_STALE_HRS}h"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all six checks (do NOT short-circuit — report every failure)
+# ---------------------------------------------------------------------------
+run_check() {
+  local name="$1"; shift
+  if ! "$@"; then
+    FAILURES+=("${name}")
+  fi
+}
+
+log "running preconditions for sweep '${SWEEP_NAME}'"
+run_check disk_free            check_disk_free
+run_check docker_raw           check_docker_raw
+run_check container_running    check_container_running
+run_check bind_mount           check_bind_mount
+run_check no_existing_runner   check_no_existing_runner
+run_check no_stale_worktrees   check_no_stale_worktrees
+
+if (( ${#FAILURES[@]} > 0 )); then
+  echo "" >&2
+  echo "[launch_sweep] REFUSING TO LAUNCH — ${#FAILURES[@]} precondition(s) failed: ${FAILURES[*]}" >&2
+  echo "[launch_sweep] see .claude/rules/sweep-hygiene.md for recovery guidance" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Build the launch command
+# ---------------------------------------------------------------------------
+OUT_DIR="/tmp/sweeps/${SWEEP_NAME}"
+LOG_FILE="/tmp/sweeps/${SWEEP_NAME}.log"
+
+# Single-quote the inner bash -c body so $ is interpreted inside the
+# container, not the host. The outer double-quote interpolation is limited to
+# the values we set on the host side (paths, parallel, sweep name).
+RUNNER_CMD="mkdir -p ${OUT_DIR} && \
+cd /workspaces/trading-1/trading && eval \$(opam env) && \
+nohup dune exec --no-build trading/backtest/tuner/bin/bayesian_runner.exe -- \
+  --spec ${SPEC} \
+  --walk-forward-spec ${WF_SPEC} \
+  --baseline-aggregate ${BASELINE_AGG} \
+  --out-dir ${OUT_DIR} \
+  --parallel ${PARALLEL} \
+  > ${LOG_FILE} 2>&1 &"
+
+# ---------------------------------------------------------------------------
+# Dry-run summary
+# ---------------------------------------------------------------------------
+if (( DRY_RUN == 1 )); then
+  log "DRY RUN — would launch the following:"
+  echo ""
+  echo "  ${DOCKER_BIN} exec -d ${CONTAINER} bash -c '${RUNNER_CMD}'"
+  echo ""
+  log "DRY RUN — out-dir:   ${OUT_DIR}"
+  log "DRY RUN — log file:  ${LOG_FILE}"
+  log "DRY RUN — parallel:  ${PARALLEL}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Launch + report
+# ---------------------------------------------------------------------------
+log "launching sweep '${SWEEP_NAME}' in container '${CONTAINER}'"
+"${DOCKER_BIN}" exec -d "${CONTAINER}" bash -c "${RUNNER_CMD}"
+
+# Give the runner a moment to fork before we resolve the PID; without this
+# pgrep can return empty on a slow container.
+sleep 2
+PID="$("${DOCKER_BIN}" exec "${CONTAINER}" pgrep -f 'bayesian_runner\.exe' 2>/dev/null | head -1 || true)"
+
+log "launched — out-dir: ${OUT_DIR}"
+log "launched — log:     ${LOG_FILE}"
+if [[ -n "${PID}" ]]; then
+  log "launched — pid:     ${PID}"
+fi
+log "monitor:    ${DOCKER_BIN} exec ${CONTAINER} pgrep -af 'bayesian_runner\\.exe.*${SWEEP_NAME}'"
+log "tail log:   ${DOCKER_BIN} exec ${CONTAINER} tail -f ${LOG_FILE}"

--- a/dev/scripts/launch_sweep_test.sh
+++ b/dev/scripts/launch_sweep_test.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# launch_sweep_test.sh — fixture-driven smoke test for launch_sweep.sh.
+#
+# Uses env-var hooks (LAUNCH_SWEEP_DF_BIN, LAUNCH_SWEEP_DOCKER_BIN, etc.)
+# to inject mock binaries that return controlled output, then asserts the
+# script's exit code + error messages per precondition.
+#
+# Run:
+#   bash dev/scripts/launch_sweep_test.sh
+#
+# Exit: 0 on success, 1 on any assertion failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCHER="${SCRIPT_DIR}/launch_sweep.sh"
+
+if [[ ! -x "${LAUNCHER}" ]]; then
+  echo "FAIL: launcher not executable: ${LAUNCHER}" >&2
+  exit 1
+fi
+
+TMP_BASE="$(mktemp -d -t launch_sweep_test.XXXXXX)"
+trap 'rm -rf "${TMP_BASE}"' EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "  PASS: $*"; PASS_COUNT=$(( PASS_COUNT + 1 )); }
+fail() { echo "  FAIL: $*" >&2; FAIL_COUNT=$(( FAIL_COUNT + 1 )); }
+
+# ---------------------------------------------------------------------------
+# Build a fresh mock-bin dir for each scenario.
+# Each mock is a tiny shell script that emits canned output for the
+# specific flags the launcher uses.
+# ---------------------------------------------------------------------------
+make_mocks() {
+  local dir="$1"
+  local df_free_kb="$2"        # numeric KB for `df -k /` Available column
+  local du_kb="$3"             # numeric KB for `du -sk <path>` (0 = no Docker.raw)
+  local container_running="$4" # true / false / notfound
+  local has_bind_mount="$5"    # 1 / 0
+  local existing_runner="$6"   # PID string (empty = none)
+
+  mkdir -p "${dir}"
+
+  cat > "${dir}/df" <<EOF
+#!/bin/sh
+# Mock df: emit canned 2-line output with Available field = ${df_free_kb}
+cat <<INNER
+Filesystem 1024-blocks Used Available Capacity MountedOn
+/dev/disk1 1000000000 100  ${df_free_kb} 50%      /
+INNER
+EOF
+
+  cat > "${dir}/du" <<EOF
+#!/bin/sh
+# Mock du: emit "<kb>\t<path>" for any input
+echo "${du_kb}	\$2"
+EOF
+
+  cat > "${dir}/docker" <<EOF
+#!/bin/sh
+# Mock docker — handles the subset of flags launch_sweep.sh uses.
+case "\$1 \$2" in
+  "inspect -f")
+    # \$3 is the template, \$4 is the container.
+    case "\$3" in
+      *State.Running*)
+        case "${container_running}" in
+          true)     echo "true";;
+          false)    echo "false";;
+          notfound) exit 1;;
+        esac
+        ;;
+      *Mounts*)
+        if [ "${has_bind_mount}" = "1" ]; then
+          printf "/tmp/sweeps\n/workspaces/trading-1\n"
+        else
+          printf "/workspaces/trading-1\n"
+        fi
+        ;;
+    esac
+    ;;
+  "exec "*)
+    # \$2 is the container, \$3 is "pgrep" (or other) — handle pgrep only.
+    if [ "\$3" = "pgrep" ]; then
+      if [ -n "${existing_runner}" ]; then
+        echo "${existing_runner}"
+      fi
+      # exit 0 either way; pgrep returns 1 if no match but we tolerate || true in caller
+    fi
+    ;;
+esac
+EOF
+
+  chmod +x "${dir}/df" "${dir}/du" "${dir}/docker"
+}
+
+# A fake Docker.raw fixture (used when du-mock is nonzero — we still need the
+# file to exist so the launcher progresses past the file-existence test).
+RAW_FIXTURE="${TMP_BASE}/Docker.raw"
+touch "${RAW_FIXTURE}"
+
+# A fresh worktrees dir (used to control the stale-worktree check).
+WORKTREES_FIXTURE="${TMP_BASE}/worktrees"
+mkdir -p "${WORKTREES_FIXTURE}"
+
+# Common args — every scenario invokes the launcher with --dry-run + these.
+COMMON_ARGS=(
+  --name test-sweep
+  --spec /spec.sexp
+  --walk-forward-spec /wf.sexp
+  --baseline-aggregate /agg.sexp
+  --container fakectr
+  --dry-run
+)
+
+# Helper: run the launcher with given mock-dir + env overrides.
+run_launcher() {
+  local mocks="$1"
+  shift
+  LAUNCH_SWEEP_DF_BIN="${mocks}/df" \
+  LAUNCH_SWEEP_DU_BIN="${mocks}/du" \
+  LAUNCH_SWEEP_DOCKER_BIN="${mocks}/docker" \
+  LAUNCH_SWEEP_DOCKER_RAW_PATH="${RAW_FIXTURE}" \
+  LAUNCH_SWEEP_WORKTREES_DIR="${WORKTREES_FIXTURE}" \
+    bash "${LAUNCHER}" "$@" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — all preconditions pass (--dry-run prints the launch command)
+# ---------------------------------------------------------------------------
+SCEN1="${TMP_BASE}/s1"
+make_mocks "${SCEN1}" 100000000 1000000 true 1 ""
+# df_free_kb=100_000_000 KB ≈ 95 GB free
+# du_kb=1_000_000 KB ≈ 0.95 GB Docker.raw
+out=$(run_launcher "${SCEN1}" "${COMMON_ARGS[@]}") && rc=0 || rc=$?
+if (( rc == 0 )) && grep -q 'DRY RUN' <<< "${out}" && grep -q '/tmp/sweeps/test-sweep' <<< "${out}"; then
+  pass "scenario 1 — all preconditions pass; --dry-run prints the launch line"
+else
+  fail "scenario 1 — expected rc=0 + 'DRY RUN' + out-dir; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — disk free too low (35 GB < 50 GB default)
+# ---------------------------------------------------------------------------
+SCEN2="${TMP_BASE}/s2"
+make_mocks "${SCEN2}" 36700160 1000000 true 1 ""   # 36_700_160 KB ≈ 35 GB
+out=$(run_launcher "${SCEN2}" "${COMMON_ARGS[@]}") && rc=0 || rc=$?
+if (( rc == 2 )) && grep -q 'host disk free.*GB <' <<< "${out}" && grep -q 'disk_free' <<< "${out}"; then
+  pass "scenario 2 — low disk fails check 1 with exit 2"
+else
+  fail "scenario 2 — expected rc=2 + disk_free failure; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — Docker.raw too large (40 GB >= 30 GB cap)
+# ---------------------------------------------------------------------------
+SCEN3="${TMP_BASE}/s3"
+make_mocks "${SCEN3}" 100000000 41943040 true 1 ""  # 41_943_040 KB = 40 GB
+out=$(run_launcher "${SCEN3}" "${COMMON_ARGS[@]}") && rc=0 || rc=$?
+if (( rc == 2 )) && grep -q 'Docker.raw at .* GB >= ' <<< "${out}" && grep -q 'docker_raw' <<< "${out}"; then
+  pass "scenario 3 — oversized Docker.raw fails check 2 with exit 2"
+else
+  fail "scenario 3 — expected rc=2 + docker_raw failure; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — container not running
+# ---------------------------------------------------------------------------
+SCEN4="${TMP_BASE}/s4"
+make_mocks "${SCEN4}" 100000000 1000000 false 1 ""
+out=$(run_launcher "${SCEN4}" "${COMMON_ARGS[@]}") && rc=0 || rc=$?
+if (( rc == 2 )) && grep -q "container 'fakectr' is not running" <<< "${out}"; then
+  pass "scenario 4 — stopped container fails check 3 with exit 2"
+else
+  fail "scenario 4 — expected rc=2 + container-not-running; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — missing /tmp/sweeps bind-mount
+# ---------------------------------------------------------------------------
+SCEN5="${TMP_BASE}/s5"
+make_mocks "${SCEN5}" 100000000 1000000 true 0 ""
+out=$(run_launcher "${SCEN5}" "${COMMON_ARGS[@]}") && rc=0 || rc=$?
+if (( rc == 2 )) && grep -q '/tmp/sweeps is not bind-mounted' <<< "${out}"; then
+  pass "scenario 5 — missing bind-mount fails check 4 with exit 2"
+else
+  fail "scenario 5 — expected rc=2 + bind-mount failure; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — another bayesian_runner.exe is running
+# ---------------------------------------------------------------------------
+SCEN6="${TMP_BASE}/s6"
+make_mocks "${SCEN6}" 100000000 1000000 true 1 "12345"
+out=$(run_launcher "${SCEN6}" "${COMMON_ARGS[@]}") && rc=0 || rc=$?
+if (( rc == 2 )) && grep -q 'another bayesian_runner.exe is already running' <<< "${out}"; then
+  pass "scenario 6 — concurrent runner fails check 5 with exit 2"
+else
+  fail "scenario 6 — expected rc=2 + concurrent-runner failure; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 7 — stale worktree under the worktrees dir
+# ---------------------------------------------------------------------------
+SCEN7="${TMP_BASE}/s7"
+make_mocks "${SCEN7}" 100000000 1000000 true 1 ""
+STALE_WT_DIR="${TMP_BASE}/stale-worktrees"
+mkdir -p "${STALE_WT_DIR}/agent-stale-1"
+# Backdate the agent-stale-1 dir's mtime to 30h ago. `touch -t` accepts
+# [[CC]YY]MMDDhhmm[.ss]; we compute "now minus 30h" portably.
+if date -v -30H +'%Y%m%d%H%M' >/dev/null 2>&1; then
+  past="$(date -v -30H +'%Y%m%d%H%M')"            # BSD/macOS date
+else
+  past="$(date -d '30 hours ago' +'%Y%m%d%H%M')"  # GNU/Linux date
+fi
+touch -t "${past}" "${STALE_WT_DIR}/agent-stale-1"
+out=$(LAUNCH_SWEEP_DF_BIN="${SCEN7}/df" \
+      LAUNCH_SWEEP_DU_BIN="${SCEN7}/du" \
+      LAUNCH_SWEEP_DOCKER_BIN="${SCEN7}/docker" \
+      LAUNCH_SWEEP_DOCKER_RAW_PATH="${RAW_FIXTURE}" \
+      LAUNCH_SWEEP_WORKTREES_DIR="${STALE_WT_DIR}" \
+      bash "${LAUNCHER}" "${COMMON_ARGS[@]}" 2>&1) && rc=0 || rc=$?
+if (( rc == 2 )) && grep -q 'stale worktree(s) older than' <<< "${out}" && grep -q 'no_stale_worktrees' <<< "${out}"; then
+  pass "scenario 7 — stale worktree fails check 6 with exit 2"
+else
+  fail "scenario 7 — expected rc=2 + stale worktree failure; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 8 — usage error: missing required --name
+# ---------------------------------------------------------------------------
+SCEN8="${TMP_BASE}/s8"
+make_mocks "${SCEN8}" 100000000 1000000 true 1 ""
+out=$(run_launcher "${SCEN8}" --spec /a --walk-forward-spec /b --baseline-aggregate /c --dry-run) && rc=0 || rc=$?
+if (( rc == 1 )) && grep -q 'required' <<< "${out}"; then
+  pass "scenario 8 — missing --name returns exit 1 (usage error, not 2)"
+else
+  fail "scenario 8 — expected rc=1 + 'required'; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 9 — multiple failures reported together (disk + docker_raw)
+# ---------------------------------------------------------------------------
+SCEN9="${TMP_BASE}/s9"
+make_mocks "${SCEN9}" 36700160 41943040 true 1 ""   # both fail
+out=$(run_launcher "${SCEN9}" "${COMMON_ARGS[@]}") && rc=0 || rc=$?
+if (( rc == 2 )) \
+   && grep -q 'disk_free' <<< "${out}" \
+   && grep -q 'docker_raw' <<< "${out}" \
+   && grep -qE '2 precondition\(s\) failed' <<< "${out}"; then
+  pass "scenario 9 — multiple failures reported in one run (no short-circuit)"
+else
+  fail "scenario 9 — expected rc=2 + both failures listed; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 10 — invalid --name (path-traversal char)
+# ---------------------------------------------------------------------------
+SCEN10="${TMP_BASE}/s10"
+make_mocks "${SCEN10}" 100000000 1000000 true 1 ""
+out=$(run_launcher "${SCEN10}" --name '../escape' --spec /a --walk-forward-spec /b --baseline-aggregate /c --dry-run) && rc=0 || rc=$?
+if (( rc == 1 )) && grep -q 'must match' <<< "${out}"; then
+  pass "scenario 10 — unsafe --name rejected with exit 1"
+else
+  fail "scenario 10 — expected rc=1 + 'must match'; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "launch_sweep_test: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+if (( FAIL_COUNT > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

PR-A of `dev/plans/sweep-and-qc-architecture-2026-05-26.md` — adds the mandatory entry-point wrapper for Bayesian-sweep launches.

`dev/scripts/launch_sweep.sh` checks six host-state preconditions, refusing the launch on any failure and printing every failure in one pass (no short-circuit) so the operator can fix host state once.

**Preconditions:**

| # | Check | Default |
|---|---|---|
| 1 | Host disk free | ≥ 50 GB |
| 2 | Docker.raw size | < 30 GB (skipped on non-mac hosts) |
| 3 | `trading-1-dev` container | running |
| 4 | `/tmp/sweeps` | bind-mounted into container |
| 5 | No other `bayesian_runner.exe` | running in container |
| 6 | No agent worktrees | older than 24 h |

All six thresholds + the container name + binary paths are env-var overridable (`LAUNCH_SWEEP_DISK_FREE_GB_MIN`, `LAUNCH_SWEEP_DOCKER_BIN`, `LAUNCH_SWEEP_DOCKER_RAW_PATH`, etc.) — both for site-local tuning and to make the script unit-testable.

## Why

2026-05-23..25 lost ~16 h of sweep wall-time to repeated violations of `.claude/rules/sweep-hygiene.md` preconditions: sweep output in a repo path, host-disk fill, `Docker.raw` runaway. The discipline doc isn't enough on its own; this is the enforcement layer. PR-B (`bayesian_runner.exe` refuses non-`/tmp/sweeps/` output paths) and PR-C (disk-watcher daemon) follow as separate PRs per the architecture plan.

## Test plan

`dev/scripts/launch_sweep_test.sh` runs **10 fixture-driven scenarios** that inject mock `df`/`du`/`docker` binaries via the env-var hooks and assert exit code + error messages per precondition. Local run:

```
$ bash dev/scripts/launch_sweep_test.sh
  PASS: scenario 1 — all preconditions pass; --dry-run prints the launch line
  PASS: scenario 2 — low disk fails check 1 with exit 2
  PASS: scenario 3 — oversized Docker.raw fails check 2 with exit 2
  PASS: scenario 4 — stopped container fails check 3 with exit 2
  PASS: scenario 5 — missing bind-mount fails check 4 with exit 2
  PASS: scenario 6 — concurrent runner fails check 5 with exit 2
  PASS: scenario 7 — stale worktree fails check 6 with exit 2
  PASS: scenario 8 — missing --name returns exit 1 (usage error, not 2)
  PASS: scenario 9 — multiple failures reported in one run (no short-circuit)
  PASS: scenario 10 — unsafe --name rejected with exit 1
launch_sweep_test: 10 passed, 0 failed
```

- [x] Each precondition has a unit test (plan acceptance row 1).
- [x] `--dry-run` shows what would be launched without firing (plan acceptance row 2).
- [x] Disk-free fixture at 35 GB fails fast with explicit error; 95 GB fixture passes (plan acceptance row 3).
- [x] Multiple-failure scenario shows preconditions are reported all at once, not first-fail.

## Exit codes

- `0` — sweep launched (or `--dry-run` summary printed)
- `1` — usage error (missing required arg, unsafe `--name`)
- `2` — precondition failure

## Out of scope

- PR-B: `bayesian_runner.exe` belt-and-suspenders refusal of non-`/tmp/sweeps/` `--out-dir`.
- PR-C: `dev/scripts/sweep_disk_watcher.sh` daemon (the wrapper will conditionally spawn it once it lands).
- PR-D/E: QC architecture (gh pr review-based + plain git worktrees) — separate program.