### PR TITLE
feat(sweep): bayesian_runner refuses --out-dir outside /tmp/sweeps/

### DIFF
--- a/trading/trading/backtest/tuner/bin/bayesian_runner.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner.ml
@@ -65,6 +65,7 @@ module Wf_spec = Walk_forward.Spec
 module Wf_executor = Walk_forward.Walk_forward_executor
 module Wf_report = Walk_forward.Walk_forward_report
 module Oos_validator = Tuner_bin.Bayesian_runner_oos_validator
+module Out_dir_check = Tuner_bin.Bayesian_runner_out_dir_check
 
 let _usage_msg =
   "Usage: bayesian_runner.exe --spec <spec.sexp> --out-dir <dir>\n\
@@ -304,6 +305,8 @@ let _run_walk_forward_mode ~(args : cli_args) ~(spec : Spec.t)
 let _main () =
   let argv = Sys.get_argv () |> Array.to_list |> List.tl_exn in
   let args = _parse_args argv in
+  (* Belt-and-suspenders even if launch_sweep.sh was bypassed. *)
+  Out_dir_check.validate_or_exit ~out_dir:args.out_dir;
   let spec = Spec.load args.spec_path in
   match (args.walk_forward_spec_path, args.baseline_aggregate_path) with
   | None, None -> _run_legacy_mode ~args ~spec

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_out_dir_check.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_out_dir_check.ml
@@ -1,0 +1,34 @@
+open Core
+
+(** The single permitted parent for sweep output. Bind-mounted to the host in
+    [.devcontainer/setup.sh]; sweep output written under any other path inflates
+    the container's writable layer (i.e. [Docker.raw]) instead. *)
+let _allowed_prefix = "/tmp/sweeps/"
+
+(** Documented override. Sole accepted value is the string ["1"]; any other
+    value (including unset) is treated as "not overridden" so accidental
+    [BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT=0] does not silently disable the
+    check. *)
+let _override_env = "BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT"
+
+let _override_enabled env_lookup =
+  match env_lookup _override_env with Some "1" -> true | _ -> false
+
+let validate ~out_dir ?(env_lookup = Sys.getenv) () =
+  if String.is_prefix out_dir ~prefix:_allowed_prefix then Result.return ()
+  else if _override_enabled env_lookup then Result.return ()
+  else
+    Status.error_invalid_argument
+      (sprintf
+         "Refusing --out-dir %S — sweep output must start with %S per \
+          .claude/rules/sweep-hygiene.md (otherwise it inflates the \
+          container's writable layer + Docker.raw on macOS hosts). Override at \
+          your own risk: set %s=1."
+         out_dir _allowed_prefix _override_env)
+
+let validate_or_exit ~out_dir =
+  match validate ~out_dir () with
+  | Ok () -> ()
+  | Error status ->
+      eprintf "Error: %s\n%!" (Status.show status);
+      Stdlib.exit 2

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_out_dir_check.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_out_dir_check.mli
@@ -1,0 +1,29 @@
+(** Belt-and-suspenders [--out-dir] guard for [bayesian_runner.exe].
+
+    Sweep output must be written under [/tmp/sweeps/] so that snapshot churn
+    inflates the bind-mounted host directory, not the container's writable layer
+    (which is what caused the 2026-05-23..25 ~16h-of-wall-time Docker.raw
+    runaway). [dev/scripts/launch_sweep.sh] enforces this at launch time; this
+    module enforces it at the binary's own arg-parse time so a direct
+    [dune exec ... bayesian_runner.exe --out-dir <bad>] also fails fast.
+
+    Authority: [.claude/rules/sweep-hygiene.md] +
+    [dev/plans/sweep-and-qc-architecture-2026-05-26.md]. *)
+
+val validate :
+  out_dir:string ->
+  ?env_lookup:(string -> string option) ->
+  unit ->
+  unit Status.status_or
+(** [validate ?env_lookup ~out_dir] returns [Ok ()] when [out_dir] starts with
+    [/tmp/sweeps/], OR when [env_lookup] returns [Some "1"] for the documented
+    override env var [BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT]. Returns [Error]
+    (an [invalid_argument] [Status.t]) otherwise; the message names both the
+    violated rule + the override.
+
+    [env_lookup] defaults to [Sys.getenv]; injected for unit tests. *)
+
+val validate_or_exit : out_dir:string -> unit
+(** [validate_or_exit ~out_dir] runs [validate] with the live [Sys.getenv]. On
+    [Ok ()] returns [unit]; on [Error] writes the message to stderr and calls
+    [Stdlib.exit 2]. *)

--- a/trading/trading/backtest/tuner/bin/dune
+++ b/trading/trading/backtest/tuner/bin/dune
@@ -8,7 +8,8 @@
   bayesian_runner_evaluator
   bayesian_runner_runner
   bayesian_runner_scoring
-  bayesian_runner_oos_validator)
+  bayesian_runner_oos_validator
+  bayesian_runner_out_dir_check)
  (libraries
   core
   core_unix

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
@@ -23,6 +23,7 @@ open Matchers
 module Spec = Tuner_bin.Bayesian_runner_spec
 module Runner = Tuner_bin.Bayesian_runner_runner
 module Evaluator = Tuner_bin.Bayesian_runner_evaluator
+module Out_dir_check = Tuner_bin.Bayesian_runner_out_dir_check
 module GS = Tuner.Grid_search
 module Metric_types = Trading_simulation_types.Metric_types
 
@@ -1116,6 +1117,77 @@ let test_missing_checkpoint_starts_fresh _ =
         (!calls, List.length result.observations, ck_exists)
         (equal_to (6, 6, true)))
 
+(* ---------- Out_dir_check: --out-dir prefix guard ---------- *)
+
+let _no_env (_ : string) : string option = None
+
+let _override_env name =
+  if String.equal name "BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT" then Some "1"
+  else None
+
+let _override_set_to_zero name =
+  if String.equal name "BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT" then Some "0"
+  else None
+
+let test_out_dir_check_accepts_tmp_sweeps_path _ =
+  assert_that
+    (Out_dir_check.validate ~out_dir:"/tmp/sweeps/test-foo" ~env_lookup:_no_env
+       ())
+    is_ok
+
+let test_out_dir_check_rejects_repo_path _ =
+  assert_that
+    (Out_dir_check.validate ~out_dir:"dev/experiments/grid-screening"
+       ~env_lookup:_no_env ())
+    is_error
+
+let test_out_dir_check_rejects_other_tmp_paths _ =
+  (* /tmp/foo (without the /sweeps/ segment) must still fail; the prefix is
+     strict and intentionally excludes /tmp/scratch, /tmp/x, etc. *)
+  assert_that
+    (Out_dir_check.validate ~out_dir:"/tmp/foo/bar" ~env_lookup:_no_env ())
+    is_error
+
+let test_out_dir_check_rejects_tmp_sweeps_without_trailing_slash _ =
+  (* "/tmp/sweeps" (no trailing slash) is a literal path, not a parent —
+     and an output written there clobbers a sibling-style file. Strict
+     prefix match (with the trailing slash) forces a subdirectory. *)
+  assert_that
+    (Out_dir_check.validate ~out_dir:"/tmp/sweeps" ~env_lookup:_no_env ())
+    is_error
+
+let test_out_dir_check_override_one_allows_bad_path _ =
+  assert_that
+    (Out_dir_check.validate ~out_dir:"dev/experiments/grid-screening"
+       ~env_lookup:_override_env ())
+    is_ok
+
+let test_out_dir_check_override_set_to_zero_does_not_allow _ =
+  (* Only "1" enables the override; "0" or any other value is treated as
+     "not overridden". Prevents an accidental
+     BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT=0 from silently disabling the
+     check (which would be the worst possible failure mode). *)
+  assert_that
+    (Out_dir_check.validate ~out_dir:"dev/experiments/grid-screening"
+       ~env_lookup:_override_set_to_zero ())
+    is_error
+
+let test_out_dir_check_error_message_names_override _ =
+  (* Operators reading the error in CI logs need to see the override name
+     so they can decide whether to set it (rather than guess). *)
+  match
+    Out_dir_check.validate ~out_dir:"dev/experiments/grid-screening"
+      ~env_lookup:_no_env ()
+  with
+  | Ok () -> assert_failure "expected Error"
+  | Error status ->
+      let msg = Status.show status in
+      assert_bool
+        ("expected error message to mention \
+          BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT, got: " ^ msg)
+        (String.is_substring msg
+           ~substring:"BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT")
+
 let suite =
   "Tuner_bin.Bayesian_runner"
   >::: [
@@ -1216,6 +1288,20 @@ let suite =
          >:: test_resume_with_wrong_schema_version_raises;
          "checkpoint: missing checkpoint starts fresh"
          >:: test_missing_checkpoint_starts_fresh;
+         "Out_dir_check accepts /tmp/sweeps/<name>"
+         >:: test_out_dir_check_accepts_tmp_sweeps_path;
+         "Out_dir_check rejects repo-relative path"
+         >:: test_out_dir_check_rejects_repo_path;
+         "Out_dir_check rejects other /tmp paths"
+         >:: test_out_dir_check_rejects_other_tmp_paths;
+         "Out_dir_check rejects /tmp/sweeps (no trailing slash)"
+         >:: test_out_dir_check_rejects_tmp_sweeps_without_trailing_slash;
+         "Out_dir_check override=1 allows bad path"
+         >:: test_out_dir_check_override_one_allows_bad_path;
+         "Out_dir_check override=0 does not disable check"
+         >:: test_out_dir_check_override_set_to_zero_does_not_allow;
+         "Out_dir_check error message names override env var"
+         >:: test_out_dir_check_error_message_names_override;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_bin.ml
@@ -1175,18 +1175,11 @@ let test_out_dir_check_override_set_to_zero_does_not_allow _ =
 let test_out_dir_check_error_message_names_override _ =
   (* Operators reading the error in CI logs need to see the override name
      so they can decide whether to set it (rather than guess). *)
-  match
-    Out_dir_check.validate ~out_dir:"dev/experiments/grid-screening"
-      ~env_lookup:_no_env ()
-  with
-  | Ok () -> assert_failure "expected Error"
-  | Error status ->
-      let msg = Status.show status in
-      assert_bool
-        ("expected error message to mention \
-          BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT, got: " ^ msg)
-        (String.is_substring msg
-           ~substring:"BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT")
+  assert_that
+    (Out_dir_check.validate ~out_dir:"dev/experiments/grid-screening"
+       ~env_lookup:_no_env ())
+    (is_error_with Status.Invalid_argument
+       ~msg:"BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT")
 
 let suite =
   "Tuner_bin.Bayesian_runner"


### PR DESCRIPTION
## Summary

Belt-and-suspenders companion to #1293 (`launch_sweep.sh`). Even if the wrapper is bypassed by a direct `dune exec ... bayesian_runner.exe --out-dir <bad>`, the binary itself now refuses to start.

New module `Tuner_bin.Bayesian_runner_out_dir_check`:
- `validate ~out_dir ?env_lookup ()` — returns `Ok ()` if `out_dir` starts with `/tmp/sweeps/`, or if `env_lookup` returns `Some "1"` for `BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT`. `Error invalid_argument` otherwise.
- `validate_or_exit ~out_dir` — invokes `validate` with live `Sys.getenv`; on Error writes message to stderr + `Stdlib.exit 2`.

Wired into `bayesian_runner.ml::_main` immediately after `_parse_args`, before `Spec.load`.

## Why

`.claude/rules/sweep-hygiene.md` + the 2026-05-23..25 ~16h-of-wall-time post-mortem: sweep output anywhere other than the bind-mounted `/tmp/sweeps/` inflates the container's writable layer + `Docker.raw`, the proximate cause of every disk-fill crash this past week. PR-A enforced the rule at launch time; this PR enforces it at the binary's own arg-parse time.

## Test plan

7 new unit tests in `test_bayesian_runner_bin.ml`:

| # | Scenario | Verdict pinned |
|---|---|---|
| 1 | `/tmp/sweeps/<name>` path | `Ok` |
| 2 | `dev/experiments/...` repo path | `Error` |
| 3 | `/tmp/foo/bar` (other `/tmp` subtree) | `Error` |
| 4 | `/tmp/sweeps` (no trailing slash — literal-file form) | `Error` |
| 5 | bad path + `BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT=1` | `Ok` |
| 6 | bad path + `BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT=0` | `Error` (only `"1"` enables) |
| 7 | error message names the override env var | passes substring check |

Local: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest trading/backtest/tuner/'` → 57/57 OK across the suite. `dune build` clean. `dune build @fmt --auto-promote` no further changes.

## Exit codes

- Success → `0` (no change)
- Usage / parse error → `1` (no change)
- `--out-dir` outside `/tmp/sweeps/` (and no override) → **`2`** (new)

## Override

`BAYESIAN_RUNNER_ALLOW_NON_SWEEP_OUTPUT=1` allows any path — intentionally undocumented in the binary's `--help` (per the architecture plan, "don't make this discoverable"). Anyone setting it has read this PR + the sweep-hygiene rule.

## Out of scope

- PR-C: `dev/scripts/sweep_disk_watcher.sh` daemon — spawned by `launch_sweep.sh` once it lands.
- PR-D: QC review comments via `gh pr review`.
- PR-E: QC plain `git worktree` checkouts.