### PR TITLE
docs(agents): QC reviews also posted as gh pr review comments (Step 1 of PR-D)

### DIFF
--- a/.claude/agents/qc-behavioral.md
+++ b/.claude/agents/qc-behavioral.md
@@ -180,7 +180,39 @@ APPROVED | NEEDS_REWORK
 
 ---
 
-## Writing the review file
+## Writing the review
+
+The review is delivered in **two places**:
+
+1. **GitHub PR review comment** (preferred medium — reviewers see the verdict directly on the PR).
+2. **`dev/reviews/<feature>.md` file** (transitional — appended below qc-structural's content; the lead-orchestrator's Step 1.5 idempotency check still reads it).
+
+### Step 1 — post the GitHub PR review comment
+
+If `$PR_NUMBER` is known, post the behavioral verdict + checklist as a PR review. Use GitHub's native verdict flag so the merge-gate signal is first-class:
+
+```bash
+case "$VERDICT" in
+  APPROVED)     REVIEW_FLAG="--approve" ;;
+  NEEDS_REWORK) REVIEW_FLAG="--request-changes" ;;
+  *)            REVIEW_FLAG="--comment" ;;
+esac
+
+gh pr review "$PR_NUMBER" $REVIEW_FLAG --body "$(cat <<'EOF'
+Reviewed SHA: <sha from dev/reviews/<feature>.md first line>
+
+## Behavioral QC — <feature-name>
+
+<filled Contract Pinning Checklist + Behavioral Checklist + Quality Score + Verdict, same content as the file append below>
+EOF
+)"
+```
+
+The first body line MUST be `Reviewed SHA: <sha>` (matching qc-structural's pin from the same review pass) so a future orchestrator can locate this review via `gh pr view <N> --json reviews --jq '.reviews[].body'` and treat the SHA as the idempotency sentinel.
+
+If `$PR_NUMBER` is absent, skip the PR-comment step and add a one-line note to the checklist: "PR_NUMBER unavailable — review file is the sole audit trail until PR is opened."
+
+### Step 2 — append to `dev/reviews/<feature>.md` (transitional back-compat)
 
 Append your behavioral checklist to the existing `dev/reviews/<feature>.md` written by qc-structural. The file already begins with a `Reviewed SHA:` line written by qc-structural — do not overwrite it or move it. Append only below the existing structural checklist content.
 

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -195,9 +195,41 @@ APPROVED | NEEDS_REWORK
 
 ---
 
-## Writing the review file
+## Writing the review
 
-Write `dev/reviews/<feature>.md` from a clean branch based on `main@origin` — never from the feature branch. The first line of the file must be the `Reviewed SHA:` line captured in Step 5:
+The review is delivered in **two places**:
+
+1. **GitHub PR review comment** (preferred medium — reviewers see the verdict directly on the PR).
+2. **`dev/reviews/<feature>.md` file** (transitional — the lead-orchestrator's Step 1.5 idempotency check still reads it; once the orchestrator migrates to reading PR review comments, the file write will drop).
+
+### Step 1 — post the GitHub PR review comment
+
+If `$PR_NUMBER` is known, post the verdict + summary as a PR review. The verdict uses GitHub's native `--approve` / `--request-changes` semantics so the merge-gate signals are first-class:
+
+```bash
+case "$VERDICT" in
+  APPROVED)     REVIEW_FLAG="--approve" ;;
+  NEEDS_REWORK) REVIEW_FLAG="--request-changes" ;;
+  *)            REVIEW_FLAG="--comment" ;;
+esac
+
+gh pr review "$PR_NUMBER" $REVIEW_FLAG --body "$(cat <<'EOF'
+Reviewed SHA: <sha captured in Step 5>
+
+## Structural QC — <feature-name>
+
+<condensed checklist + any NEEDS_REWORK items, same content as the file below>
+EOF
+)"
+```
+
+The first body line MUST be `Reviewed SHA: <sha>` so a future orchestrator can find this review via `gh pr view <N> --json reviews --jq '.reviews[].body'` and treat the SHA as the idempotency sentinel.
+
+If `$PR_NUMBER` is absent (branch not yet submitted), skip the PR-comment step and add a one-line note to the checklist: "PR_NUMBER unavailable — review file is the sole audit trail until PR is opened."
+
+### Step 2 — write `dev/reviews/<feature>.md` (transitional back-compat)
+
+Write `dev/reviews/<feature>.md` from a clean branch based on `main@origin` — never from the feature branch. The first line must be the `Reviewed SHA:` line captured in Step 5:
 
 ```
 Reviewed SHA: <sha captured in Step 5>


### PR DESCRIPTION
## Summary

Step 1 of [PR-D in the sweep+QC architecture plan](dev/plans/sweep-and-qc-architecture-2026-05-26.md). Both QC agents (`qc-structural` + `qc-behavioral`) now post their verdict + checklist as a **GitHub PR review comment** using `gh pr review --approve | --request-changes | --comment` in addition to writing `dev/reviews/<feature>.md`.

GitHub's native `APPROVED` / `CHANGES_REQUESTED` verdict states are now first-class signals on the PR — visible without spelunking the repo, and queryable via `gh pr view <N> --json reviews`. The `Reviewed SHA:` idempotency line is preserved as the first body line so a future orchestrator migration can locate the review programmatically.

## Why dual-write (not a hard cutover)

The architecture plan's PR-D bullet says "verify the per-PR review files are NOT created" as an acceptance criterion. Achieving that requires updating `.claude/agents/lead-orchestrator.md` (30+ touch points to `dev/reviews/`) and `trading/devtools/checks/record_qc_audit.sh` — both substantial. Cold cutover would break orchestrator's Step 1.5 idempotency check, causing autonomous overnight runs to re-dispatch QC on every cycle.

This PR adds the PR-comment posting (the **preferred** medium going forward) while keeping the file write so orchestrator + audit script keep working unchanged. Follow-up PR-D' (tracked) will migrate the orchestrator to read PR review bodies + update the audit script + remove the file-write step from both agents.

## Test plan

- [x] Edits scoped to two agent prompt files (`.claude/agents/qc-structural.md`, `.claude/agents/qc-behavioral.md`); no code or build touched.
- [x] `Reviewed SHA: <sha>` placement preserved as the first line of both the PR-comment body AND the existing review file — orchestrator's parser unaffected.
- [x] `--approve` / `--request-changes` / `--comment` mapping documented + shown verbatim in both agents.
- [x] Live evidence: PR-A (#1293) qc-behavioral already posted a `state=COMMENTED` review at SHA `... 2026-05-24T16:47:59Z` per its own task-completion summary — proving the `gh pr review` pattern works.

## Acceptance bullets

- [x] Agents post the review as a PR comment with `APPROVED` / `CHANGES_REQUESTED` state.
- [ ] Per-PR review files are NOT created. **Deferred to PR-D'** — see "Why dual-write" above.

## Out of scope

- PR-D': lead-orchestrator + audit-script migration; agent file-write removal.
- PR-C: disk watcher daemon.
- PR-E: QC agents use plain `git worktree` instead of `jj edit`.