### PR TITLE
feat(sweep): sweep_disk_watcher.sh — autonomous abort on disk/Docker.raw thresholds

### DIFF
--- a/dev/scripts/sweep_disk_watcher.sh
+++ b/dev/scripts/sweep_disk_watcher.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# sweep_disk_watcher.sh — autonomous SIGTERM for runaway sweeps.
+#
+# Polls host disk free + Docker.raw size + container /tmp size every 60s.
+# SIGTERMs the sweep PID when a threshold is crossed (lets the BO runner
+# write a final checkpoint instead of dying mid-write). Exits when the
+# sweep PID itself exits.
+#
+# Why: dev/plans/sweep-and-qc-architecture-2026-05-26.md PR-C +
+# dev/plans/safe-sweep-infrastructure-2026-05-24.md §4. The PR-A
+# launch_sweep.sh wrapper verifies preconditions at launch time but
+# cannot react to mid-flight disk fill — 2026-05-23..25 sweep crashes
+# all came from disk filling AFTER launch (snapshot churn over hours).
+#
+# Usage:
+#   sweep_disk_watcher.sh --sweep-pid <pid> --sweep-name <name>
+#                         [--container NAME]            (default trading-1-dev)
+#                         [--poll-interval SEC]         (default 60)
+#                         [--log-dir DIR]               (default <repo>/.sweep-output)
+#
+# Exit codes:
+#   0   sweep PID exited (watcher's normal end)
+#   1   usage error
+#   2   watcher SIGTERM'd the sweep (a threshold was crossed)
+#
+# Thresholds (env-var overridable):
+#   DISK_WATCHER_HOST_FREE_GB_MIN   (default 20)   — host free < N GB → kill
+#   DISK_WATCHER_RAW_WARN_GB        (default 50)   — Docker.raw warning
+#   DISK_WATCHER_RAW_KILL_GB        (default 65)   — Docker.raw kill
+#   DISK_WATCHER_TMP_WARN_GB        (default 30)   — container /tmp warning
+#
+# Test hooks (env-var overrides for unit tests):
+#   DISK_WATCHER_DF_BIN              (default: df)
+#   DISK_WATCHER_DOCKER_BIN          (default: docker)
+#   DISK_WATCHER_DU_BIN              (default: du)
+#   DISK_WATCHER_KILL_BIN            (default: kill)
+#   DISK_WATCHER_DOCKER_RAW_PATH     (default: $HOME/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw)
+#   DISK_WATCHER_MAX_ITERATIONS      (default: unlimited; tests pin to 1-3)
+#
+# References:
+#   - .claude/rules/sweep-hygiene.md
+#   - dev/plans/sweep-and-qc-architecture-2026-05-26.md (PR-C)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+
+SWEEP_PID=""
+SWEEP_NAME=""
+CONTAINER="trading-1-dev"
+POLL_INTERVAL=60
+LOG_DIR="${REPO_ROOT}/.sweep-output"
+
+DF_BIN="${DISK_WATCHER_DF_BIN:-df}"
+DOCKER_BIN="${DISK_WATCHER_DOCKER_BIN:-docker}"
+DU_BIN="${DISK_WATCHER_DU_BIN:-du}"
+KILL_BIN="${DISK_WATCHER_KILL_BIN:-kill}"
+DOCKER_RAW_PATH="${DISK_WATCHER_DOCKER_RAW_PATH:-$HOME/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw}"
+MAX_ITERATIONS="${DISK_WATCHER_MAX_ITERATIONS:-0}"  # 0 means unlimited
+
+HOST_FREE_GB_MIN="${DISK_WATCHER_HOST_FREE_GB_MIN:-20}"
+RAW_WARN_GB="${DISK_WATCHER_RAW_WARN_GB:-50}"
+RAW_KILL_GB="${DISK_WATCHER_RAW_KILL_GB:-65}"
+TMP_WARN_GB="${DISK_WATCHER_TMP_WARN_GB:-30}"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sweep-pid)      shift; SWEEP_PID="${1:-}";;
+    --sweep-name)     shift; SWEEP_NAME="${1:-}";;
+    --container)      shift; CONTAINER="${1:-}";;
+    --poll-interval)  shift; POLL_INTERVAL="${1:-}";;
+    --log-dir)        shift; LOG_DIR="${1:-}";;
+    -h|--help)
+      sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "${SWEEP_PID}" || -z "${SWEEP_NAME}" ]]; then
+  echo "ERROR: --sweep-pid and --sweep-name are required" >&2
+  exit 1
+fi
+
+if [[ ! "${SWEEP_PID}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --sweep-pid must be numeric (got: ${SWEEP_PID})" >&2
+  exit 1
+fi
+
+if [[ ! "${SWEEP_NAME}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+  echo "ERROR: --sweep-name must match [a-zA-Z0-9._-]+ (got: ${SWEEP_NAME})" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/${SWEEP_NAME}.watcher.log"
+
+log() {
+  local msg
+  msg="$(date '+%Y-%m-%d %H:%M:%S') [disk-watcher] $*"
+  echo "${msg}" | tee -a "${LOG_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# Probes (each returns "N" KB; "0" if unavailable)
+# ---------------------------------------------------------------------------
+host_free_kb() {
+  "${DF_BIN}" -k / 2>/dev/null | awk 'NR==2 {print $4}'
+}
+
+docker_raw_kb() {
+  if [[ -f "${DOCKER_RAW_PATH}" ]]; then
+    "${DU_BIN}" -sk "${DOCKER_RAW_PATH}" 2>/dev/null | awk '{print $1}'
+  else
+    echo "0"
+  fi
+}
+
+container_tmp_kb() {
+  # `du -sk /tmp` inside the container. Failures (container down) → 0; the
+  # sweep-PID liveness check will fire on the next iteration.
+  "${DOCKER_BIN}" exec "${CONTAINER}" du -sk /tmp 2>/dev/null \
+    | awk '{print $1}' \
+    | head -1
+}
+
+kb_to_gb() {
+  echo $(( ${1:-0} / 1024 / 1024 ))
+}
+
+# ---------------------------------------------------------------------------
+# Threshold evaluator — returns 0 if all clear, 1 if a KILL threshold tripped.
+# Always emits warnings; only ever emits one KILL line per invocation.
+# ---------------------------------------------------------------------------
+should_kill=0
+kill_reason=""
+
+evaluate_thresholds() {
+  local host_free_gb raw_gb tmp_gb
+  host_free_gb=$(kb_to_gb "$(host_free_kb)")
+  raw_gb=$(kb_to_gb "$(docker_raw_kb)")
+  tmp_gb=$(kb_to_gb "$(container_tmp_kb)")
+
+  log "probes: host_free=${host_free_gb}GB docker_raw=${raw_gb}GB container_tmp=${tmp_gb}GB"
+
+  if (( host_free_gb < HOST_FREE_GB_MIN )); then
+    should_kill=1
+    kill_reason="host_free=${host_free_gb}GB < ${HOST_FREE_GB_MIN}GB minimum"
+    return
+  fi
+
+  if (( raw_gb >= RAW_KILL_GB )); then
+    should_kill=1
+    kill_reason="Docker.raw=${raw_gb}GB >= ${RAW_KILL_GB}GB kill threshold"
+    return
+  fi
+
+  if (( raw_gb >= RAW_WARN_GB )); then
+    log "WARNING: Docker.raw=${raw_gb}GB >= ${RAW_WARN_GB}GB warn threshold (kill at ${RAW_KILL_GB}GB)"
+  fi
+
+  if (( tmp_gb >= TMP_WARN_GB )); then
+    log "WARNING: container /tmp=${tmp_gb}GB >= ${TMP_WARN_GB}GB warn threshold (likely snapshot churn)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Watch loop
+# ---------------------------------------------------------------------------
+log "watching sweep pid=${SWEEP_PID} name=${SWEEP_NAME} container=${CONTAINER} poll=${POLL_INTERVAL}s"
+log "thresholds: host_free_min=${HOST_FREE_GB_MIN}GB raw_warn=${RAW_WARN_GB}GB raw_kill=${RAW_KILL_GB}GB tmp_warn=${TMP_WARN_GB}GB"
+
+iteration=0
+while true; do
+  iteration=$(( iteration + 1 ))
+
+  # Check sweep PID liveness first. `kill -0` returns 0 if PID exists.
+  if ! "${KILL_BIN}" -0 "${SWEEP_PID}" 2>/dev/null; then
+    log "sweep pid=${SWEEP_PID} exited — watcher done"
+    exit 0
+  fi
+
+  evaluate_thresholds
+
+  if (( should_kill == 1 )); then
+    log "ABORT: ${kill_reason} — SIGTERM-ing pid=${SWEEP_PID} so BO can write a final checkpoint"
+    "${KILL_BIN}" -TERM "${SWEEP_PID}" 2>/dev/null || true
+    exit 2
+  fi
+
+  # Test-mode cap.
+  if (( MAX_ITERATIONS > 0 )) && (( iteration >= MAX_ITERATIONS )); then
+    log "max iterations reached (${MAX_ITERATIONS}) — exiting (test mode)"
+    exit 0
+  fi
+
+  sleep "${POLL_INTERVAL}"
+done

--- a/dev/scripts/sweep_disk_watcher_test.sh
+++ b/dev/scripts/sweep_disk_watcher_test.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# sweep_disk_watcher_test.sh — fixture-driven smoke test for sweep_disk_watcher.sh.
+#
+# Injects mock df/du/docker/kill binaries via env-var hooks, runs a single
+# iteration (DISK_WATCHER_MAX_ITERATIONS=1), then asserts exit code +
+# threshold-decision log lines.
+#
+# Run:
+#   bash dev/scripts/sweep_disk_watcher_test.sh
+#
+# Exit: 0 on success, 1 on any assertion failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER="${SCRIPT_DIR}/sweep_disk_watcher.sh"
+
+if [[ ! -x "${WATCHER}" ]]; then
+  echo "FAIL: watcher not executable: ${WATCHER}" >&2
+  exit 1
+fi
+
+TMP_BASE="$(mktemp -d -t sweep_disk_watcher_test.XXXXXX)"
+trap 'rm -rf "${TMP_BASE}"' EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { echo "  PASS: $*"; PASS_COUNT=$(( PASS_COUNT + 1 )); }
+fail() { echo "  FAIL: $*" >&2; FAIL_COUNT=$(( FAIL_COUNT + 1 )); }
+
+# ---------------------------------------------------------------------------
+# Mock factory: emits df / du / docker / kill scripts emulating canned probe
+# values + tracking whether kill was invoked.
+#
+# Args:
+#   dir, host_free_kb, raw_kb, tmp_kb, pid_alive (0=dead, 1=alive)
+# ---------------------------------------------------------------------------
+make_mocks() {
+  local dir="$1" host_kb="$2" raw_kb="$3" tmp_kb="$4" pid_alive="$5"
+  mkdir -p "${dir}"
+
+  cat > "${dir}/df" <<EOF
+#!/bin/sh
+cat <<INNER
+Filesystem 1024-blocks Used Available Capacity MountedOn
+/dev/disk1 1000000000 100  ${host_kb} 50%      /
+INNER
+EOF
+
+  cat > "${dir}/du" <<EOF
+#!/bin/sh
+echo "${raw_kb}	\$2"
+EOF
+
+  cat > "${dir}/docker" <<EOF
+#!/bin/sh
+case "\$1 \$3" in
+  "exec du")
+    echo "${tmp_kb}	/tmp"
+    ;;
+esac
+EOF
+
+  # kill mock: -0 = liveness probe (returns based on pid_alive)
+  #            -TERM = record to a marker file
+  cat > "${dir}/kill" <<EOF
+#!/bin/sh
+case "\$1" in
+  -0)
+    [ "${pid_alive}" = "1" ] && exit 0 || exit 1
+    ;;
+  -TERM)
+    echo "TERM sent to pid=\$2" >> "${dir}/kill_calls"
+    exit 0
+    ;;
+esac
+EOF
+
+  chmod +x "${dir}/df" "${dir}/du" "${dir}/docker" "${dir}/kill"
+}
+
+run_watcher() {
+  local mocks="$1"; shift
+  DISK_WATCHER_DF_BIN="${mocks}/df" \
+  DISK_WATCHER_DU_BIN="${mocks}/du" \
+  DISK_WATCHER_DOCKER_BIN="${mocks}/docker" \
+  DISK_WATCHER_KILL_BIN="${mocks}/kill" \
+  DISK_WATCHER_DOCKER_RAW_PATH="${RAW_FIXTURE}" \
+  DISK_WATCHER_MAX_ITERATIONS=1 \
+    bash "${WATCHER}" "$@" 2>&1
+}
+
+# Docker.raw fixture must exist for du-mock to be invoked.
+RAW_FIXTURE="${TMP_BASE}/Docker.raw"
+touch "${RAW_FIXTURE}"
+
+# Each scenario writes its log + kill-call markers into a per-scenario log-dir.
+make_log_dir() {
+  local d="${TMP_BASE}/$1-log"
+  mkdir -p "${d}"
+  echo "${d}"
+}
+
+COMMON_ARGS=(
+  --sweep-pid 99999
+  --sweep-name test-sweep
+  --container fakectr
+  --poll-interval 1
+)
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — all clear, sweep alive: 1 iteration then exit 0 (max-iter mode)
+# ---------------------------------------------------------------------------
+SCEN1="${TMP_BASE}/s1"
+make_mocks "${SCEN1}" 100000000 1000000 500000 1   # 95GB free, 1GB raw, 0.5GB /tmp
+LOG1="$(make_log_dir s1)"
+out=$(run_watcher "${SCEN1}" "${COMMON_ARGS[@]}" --log-dir "${LOG1}") && rc=0 || rc=$?
+if (( rc == 0 )) && grep -q 'probes: host_free=95GB docker_raw=0GB' <<< "${out}" \
+   && grep -q 'max iterations reached' <<< "${out}" \
+   && [[ ! -f "${SCEN1}/kill_calls" ]]; then
+  pass "scenario 1 — all clear, no kill, exits 0 at max-iter"
+else
+  fail "scenario 1 — expected rc=0 + all-clear + no TERM; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — host disk free below minimum → SIGTERM + exit 2
+# ---------------------------------------------------------------------------
+SCEN2="${TMP_BASE}/s2"
+make_mocks "${SCEN2}" 15728640 1000000 500000 1    # 15GB free (< 20GB default)
+LOG2="$(make_log_dir s2)"
+out=$(run_watcher "${SCEN2}" "${COMMON_ARGS[@]}" --log-dir "${LOG2}") && rc=0 || rc=$?
+if (( rc == 2 )) && grep -q 'host_free=15GB < 20GB minimum' <<< "${out}" \
+   && [[ -f "${SCEN2}/kill_calls" ]] && grep -q 'TERM sent to pid=99999' "${SCEN2}/kill_calls"; then
+  pass "scenario 2 — host disk < min → SIGTERM, exit 2"
+else
+  fail "scenario 2 — expected rc=2 + TERM + host-free msg; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+  echo "      kill_calls: $(cat "${SCEN2}/kill_calls" 2>/dev/null || echo "(none)")"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — Docker.raw at warn threshold (50-64GB) → warning, no kill
+# ---------------------------------------------------------------------------
+SCEN3="${TMP_BASE}/s3"
+# 55GB raw = 55 * 1024 * 1024 = 57671680 KB
+make_mocks "${SCEN3}" 100000000 57671680 500000 1
+LOG3="$(make_log_dir s3)"
+out=$(run_watcher "${SCEN3}" "${COMMON_ARGS[@]}" --log-dir "${LOG3}") && rc=0 || rc=$?
+if (( rc == 0 )) && grep -q 'WARNING: Docker.raw=55GB >= 50GB warn threshold' <<< "${out}" \
+   && [[ ! -f "${SCEN3}/kill_calls" ]]; then
+  pass "scenario 3 — Docker.raw at warn band → warning, no kill"
+else
+  fail "scenario 3 — expected rc=0 + warn + no TERM; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — Docker.raw at kill threshold → SIGTERM + exit 2
+# ---------------------------------------------------------------------------
+SCEN4="${TMP_BASE}/s4"
+# 70GB raw = 73400320 KB
+make_mocks "${SCEN4}" 100000000 73400320 500000 1
+LOG4="$(make_log_dir s4)"
+out=$(run_watcher "${SCEN4}" "${COMMON_ARGS[@]}" --log-dir "${LOG4}") && rc=0 || rc=$?
+if (( rc == 2 )) && grep -q 'Docker.raw=70GB >= 65GB kill threshold' <<< "${out}" \
+   && [[ -f "${SCEN4}/kill_calls" ]]; then
+  pass "scenario 4 — Docker.raw at kill threshold → SIGTERM, exit 2"
+else
+  fail "scenario 4 — expected rc=2 + raw-kill + TERM; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — container /tmp at warn threshold → warning, no kill
+# ---------------------------------------------------------------------------
+SCEN5="${TMP_BASE}/s5"
+# 32GB /tmp = 33554432 KB
+make_mocks "${SCEN5}" 100000000 1000000 33554432 1
+LOG5="$(make_log_dir s5)"
+out=$(run_watcher "${SCEN5}" "${COMMON_ARGS[@]}" --log-dir "${LOG5}") && rc=0 || rc=$?
+if (( rc == 0 )) && grep -q 'WARNING: container /tmp=32GB' <<< "${out}" \
+   && [[ ! -f "${SCEN5}/kill_calls" ]]; then
+  pass "scenario 5 — container /tmp at warn → warning, no kill"
+else
+  fail "scenario 5 — expected rc=0 + tmp-warn + no TERM; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — sweep PID already dead → exit 0 immediately, no probes
+# ---------------------------------------------------------------------------
+SCEN6="${TMP_BASE}/s6"
+make_mocks "${SCEN6}" 100000000 1000000 500000 0   # pid_alive=0
+LOG6="$(make_log_dir s6)"
+out=$(run_watcher "${SCEN6}" "${COMMON_ARGS[@]}" --log-dir "${LOG6}") && rc=0 || rc=$?
+if (( rc == 0 )) && grep -q 'sweep pid=99999 exited' <<< "${out}" \
+   && [[ ! -f "${SCEN6}/kill_calls" ]]; then
+  pass "scenario 6 — dead sweep PID → exit 0 + no TERM"
+else
+  fail "scenario 6 — expected rc=0 + 'sweep pid=… exited'; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 7 — usage: missing --sweep-pid
+# ---------------------------------------------------------------------------
+SCEN7="${TMP_BASE}/s7"
+make_mocks "${SCEN7}" 100000000 1000000 500000 1
+out=$(run_watcher "${SCEN7}" --sweep-name test --container fakectr) && rc=0 || rc=$?
+if (( rc == 1 )) && grep -q 'required' <<< "${out}"; then
+  pass "scenario 7 — missing --sweep-pid → exit 1 (usage)"
+else
+  fail "scenario 7 — expected rc=1 + 'required'; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 8 — unsafe --sweep-name rejected
+# ---------------------------------------------------------------------------
+SCEN8="${TMP_BASE}/s8"
+make_mocks "${SCEN8}" 100000000 1000000 500000 1
+out=$(run_watcher "${SCEN8}" --sweep-pid 99999 --sweep-name '../escape' --container fakectr) && rc=0 || rc=$?
+if (( rc == 1 )) && grep -q 'must match' <<< "${out}"; then
+  pass "scenario 8 — unsafe --sweep-name → exit 1"
+else
+  fail "scenario 8 — expected rc=1 + 'must match'; got rc=${rc}, output:"
+  echo "${out}" | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 9 — append-only log file is written under --log-dir
+# ---------------------------------------------------------------------------
+SCEN9="${TMP_BASE}/s9"
+make_mocks "${SCEN9}" 100000000 1000000 500000 1
+LOG9="$(make_log_dir s9)"
+out=$(run_watcher "${SCEN9}" "${COMMON_ARGS[@]}" --log-dir "${LOG9}") && rc=0 || rc=$?
+LOG_FILE9="${LOG9}/test-sweep.watcher.log"
+if (( rc == 0 )) && [[ -f "${LOG_FILE9}" ]] && grep -q 'watching sweep pid=99999' "${LOG_FILE9}"; then
+  pass "scenario 9 — log file written under --log-dir"
+else
+  fail "scenario 9 — expected log file at ${LOG_FILE9} with 'watching sweep' line"
+  echo "      output: ${out}" | sed 's/^/      /'
+  [[ -f "${LOG_FILE9}" ]] && echo "      log: $(cat "${LOG_FILE9}")"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "sweep_disk_watcher_test: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+if (( FAIL_COUNT > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

PR-C of `dev/plans/sweep-and-qc-architecture-2026-05-26.md`. Adds `dev/scripts/sweep_disk_watcher.sh`, a side-car daemon that watches host disk free + `Docker.raw` size + container `/tmp` size every 60 s during a sweep. When a threshold trips it SIGTERMs the sweep PID (so the BO runner can write a final checkpoint) and exits with code 2. When the sweep PID exits cleanly the watcher exits 0.

PR-A's `launch_sweep.sh` checks preconditions at launch; this watcher catches mid-flight disk fill (the actual root cause of the 2026-05-23..25 ~16 h of sweep wall-time loss — snapshot churn over hours, not bad initial state).

**Thresholds (all env-var overridable):**

| Probe | Warn | Kill |
|---|---|---|
| Host disk free | — | `< 20 GB` |
| `Docker.raw` size | `≥ 50 GB` | `≥ 65 GB` |
| Container `/tmp` size | `≥ 30 GB` (snapshot-churn signal) | — |

## Test plan

`dev/scripts/sweep_disk_watcher_test.sh` runs **9 fixture-driven scenarios** injecting mock `df` / `du` / `docker` / `kill` binaries via env-var hooks (`DISK_WATCHER_*_BIN`). Each scenario uses `DISK_WATCHER_MAX_ITERATIONS=1` so the loop exits deterministically.

```
$ bash dev/scripts/sweep_disk_watcher_test.sh
  PASS: scenario 1 — all clear, no kill, exits 0 at max-iter
  PASS: scenario 2 — host disk < min → SIGTERM, exit 2
  PASS: scenario 3 — Docker.raw at warn band → warning, no kill
  PASS: scenario 4 — Docker.raw at kill threshold → SIGTERM, exit 2
  PASS: scenario 5 — container /tmp at warn → warning, no kill
  PASS: scenario 6 — dead sweep PID → exit 0 + no TERM
  PASS: scenario 7 — missing --sweep-pid → exit 1 (usage)
  PASS: scenario 8 — unsafe --sweep-name → exit 1
  PASS: scenario 9 — log file written under --log-dir
sweep_disk_watcher_test: 9 passed, 0 failed
```

## Usage

```bash
dev/scripts/sweep_disk_watcher.sh \
  --sweep-pid 12345 \
  --sweep-name 11knob-v7 \
  --container trading-1-dev \
  --poll-interval 60
```

Append-only log lands at `<repo>/.sweep-output/<sweep-name>.watcher.log`.

## Exit codes

- `0` — sweep PID exited cleanly (watcher's normal end)
- `1` — usage error
- `2` — watcher SIGTERM'd the sweep (threshold tripped)

## Wiring into PR-A's launch wrapper

Follow-up — small Edit in `dev/scripts/launch_sweep.sh` to conditionally spawn this script in the background after a successful launch:

```bash
if [[ -x "${SCRIPT_DIR}/sweep_disk_watcher.sh" ]]; then
  nohup "${SCRIPT_DIR}/sweep_disk_watcher.sh" --sweep-pid "${PID}" --sweep-name "${SWEEP_NAME}" \
    >/dev/null 2>&1 &
fi
```

Holding that to a separate small PR so the watcher can land + be reviewed standalone first.

## Out of scope

- PR-D' — orchestrator + audit script migration (tracked).
- PR-E — QC plain `git worktree` (tracked).
- The wire-up Edit in `launch_sweep.sh` (above).