### PR TITLE
docs(agents): QC agents use plain `git worktree` instead of `jj edit` (PR-E)

### DIFF
--- a/.claude/agents/qc-behavioral.md
+++ b/.claude/agents/qc-behavioral.md
@@ -11,33 +11,33 @@ You do NOT check code style, formatting, or architecture patterns; those are qc-
 
 **Project-specific augmentation lives at `.claude/rules/qc-behavioral-authority.md`.** Read it after the generic Contract Pinning Checklist (CP1–CP4): it carries the project's authority document hierarchy (e.g. domain reference docs) and the domain-specific checklist rows that get appended for domain-feature PRs.
 
-## VCS choice (automatic)
+## VCS choice (plain git, both modes)
 
-If `$TRADING_IN_CONTAINER` is set (GHA runs), use **git** — jj is not available.
-
-**Critical — GHA working-tree isolation:** The orchestrator and all QC subagents share a single git working tree on GHA. To read the feature branch content without moving the working tree off main, use a **detached HEAD** checkout:
+**Use plain `git worktree` for the PR checkout — NEVER `jj edit` / `jj new feat/...@origin`.** Plain git worktrees are filesystem-only; they do not mutate the parent workspace's shared `.jj/repo/` op-heads or default WorkspaceName, so concurrent QC agents cannot race the parent's `@` or revert each other's working files. The prior `jj edit` pattern caused two documented contamination incidents (`memory/feedback_qc_agents_need_worktree_isolation.md`, `memory/project_jj_worktree_root_cause.md`).
 
 ```bash
-# Fetch and resolve the feature branch tip SHA; detach to that SHA.
-git fetch origin <branch>
-FEAT_SHA="$(git rev-parse origin/<branch>)"
-git checkout --detach "$FEAT_SHA"
-# ... read implementation and test files relative to this detached HEAD ...
-# When done, return to main so the orchestrator's tree is unmodified:
-git checkout main
+PR_BRANCH="feat/<feature-name>"
+WT="/tmp/qc-pr-${PR_NUMBER:-no-pr}-$$"
+
+git fetch origin "${PR_BRANCH}"
+FEAT_SHA="$(git rev-parse "origin/${PR_BRANCH}")"
+git worktree add --detach "${WT}" "${FEAT_SHA}"
+cd "${WT}"
+# ... read implementation and test files relative to ${WT} ...
+# When done:
+cd /
+git worktree remove --force "${WT}"
 ```
 
-`git checkout --detach <sha>` does not move any named ref, so the orchestrator's working tree is unchanged when the subagent exits. Never run `git checkout <branch>` (without `--detach`) — that moves `HEAD` to the branch, mutating the shared working tree for all subsequent orchestrator steps.
+`git worktree add --detach` is the load-bearing form: detaching from any named ref means no orchestrator-visible branch state changes, even if the agent forgets to clean up. On GHA the same pattern works (replace `/tmp/qc-pr-...` with a path under `${GITHUB_WORKSPACE}/../qc-...` if needed for the shared runner filesystem).
 
-Write (append to) `dev/reviews/<feature>.md` using an absolute path derived from `${GITHUB_WORKSPACE}`:
+Write (append to) `dev/reviews/<feature>.md` against the **parent workspace's** repo root (NOT `${WT}`, which the orchestrator does not see):
 
 ```bash
-REVIEW_FILE="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}/dev/reviews/<feature>.md"
+REVIEW_FILE="${GITHUB_WORKSPACE:-${PARENT_REPO_ROOT:-$(pwd)}}/dev/reviews/<feature>.md"
 ```
 
-Using `${GITHUB_WORKSPACE}` ensures the file lands in the orchestrator's working tree regardless of which SHA the agent currently has detached. Do NOT commit or push. The orchestrator reads the file directly from the filesystem after the subagent returns.
-
-Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
+Here `${PARENT_REPO_ROOT}` is the orchestrator's working tree (typically the dispatch prompt's cwd before this agent ran into the worktree). On GHA, `${GITHUB_WORKSPACE}` carries the same value. Do NOT commit or push. The orchestrator reads the file directly from the parent's filesystem after the subagent returns.
 
 ## Allowed tools
 

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -49,25 +49,35 @@ You check: build health, format compliance, code patterns, architecture constrai
 
 ## Process
 
-### Step 1: Checkout the feature branch (read-only)
+### Step 1: Checkout the feature branch (read-only, plain git worktree)
+
+**Use plain `git worktree`, NOT `jj edit` / `jj new feat/...@origin`.** Plain git worktrees are filesystem-only — they don't touch the parent workspace's shared `.jj/repo/` op-heads or default WorkspaceName, so concurrent QC agents cannot race the parent's `@` or revert each other's working files. The prior `jj edit` pattern caused two documented contamination incidents (`memory/feedback_qc_agents_need_worktree_isolation.md`, `memory/project_jj_worktree_root_cause.md`).
 
 ```bash
-jj git init --colocate 2>/dev/null || true
-jj git fetch
-jj new feat/<feature-name>@origin   # read-only — do NOT write files here
+PR_BRANCH="feat/<feature-name>"
+WT="/tmp/qc-pr-${PR_NUMBER:-no-pr}-$$"
+
+git fetch origin "${PR_BRANCH}"
+FEAT_SHA="$(git rev-parse "origin/${PR_BRANCH}")"
+git worktree add --detach "${WT}" "${FEAT_SHA}"
+cd "${WT}"
+# ... run build/diff/read steps relative to ${WT} ...
+# When done:
+cd /
+git worktree remove --force "${WT}"
 ```
 
-After fetching, check staleness — how many commits is `main@origin` ahead of this branch's
-merge base? Run:
+`git worktree add --detach` is the load-bearing form: detaching from any named ref means no orchestrator-visible branch state changes, even if the agent forgets to clean up.
+
+After fetching, check staleness — how many commits is `main` ahead of this branch's merge base?
 
 ```bash
-# Count commits on main not reachable from the feature branch
-jj log --revset "main@origin ~ ancestors(feat/<feature-name>@origin)" --no-graph -T "commit_id\n" | wc -l
+# Count commits on origin/main not reachable from the feature branch
+git fetch origin main
+git rev-list --count "${FEAT_SHA}..origin/main"
 ```
 
-If this count is > 10, add a **FLAG** note to the checklist: "Branch is N commits behind
-main@origin — consider rebasing before merge." This is a FLAG, not a FAIL: it does not
-block APPROVED, but the orchestrator escalation policy should note it.
+If this count is > 10, add a **FLAG** note to the checklist: "Branch is N commits behind `main` — consider rebasing before merge." This is a FLAG, not a FAIL: it does not block APPROVED, but the orchestrator escalation policy should note it.
 
 ### Step 2: Hard deterministic gates
 
@@ -89,7 +99,7 @@ When multiple agents work concurrently, ancestry diffs can include commits from 
 
 ```
 WARNING: Do NOT derive the file list from `git log` walks, `jj log`-based ancestry,
-or `jj diff --from main@origin`. Concurrent feature development on adjacent branches
+or `git log` ancestry. Concurrent feature development on adjacent branches
 will pollute that view with unrelated commits. The PR scope is what
 `gh pr view <N> --json files` returns, period.
 ```
@@ -107,27 +117,27 @@ git diff origin/main...origin/<branch> --stat
 git diff origin/main...origin/<branch>
 ```
 
-Local jj mode:
+Local mode (plain git inside the worktree set up in Step 1):
 ```bash
 # Enumerate files in this PR — canonical scope
 PR_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path')
 echo "$PR_FILES"
 
 # Read the diff for content inspection
-jj diff --from main@origin --to feat/<feature-name>@origin --stat
-jj diff --from main@origin --to feat/<feature-name>@origin
+git diff "origin/main...origin/<branch>" --stat
+git diff "origin/main...origin/<branch>"
 ```
 
 **If `$PR_NUMBER` is not known** (e.g., branch not yet submitted):
 ```bash
-# Fall back to jj/git diff for content, but add a checklist note:
-# "PR_NUMBER unavailable — file list derived from jj diff; verify matches PR
+# Fall back to git diff for content, but add a checklist note:
+# "PR_NUMBER unavailable — file list derived from git diff; verify matches PR
 #  once submitted via: gh pr view <N> --json files --jq '.files[].path'"
-jj diff --from main@origin --to feat/<feature-name>@origin --stat
-jj diff --from main@origin --to feat/<feature-name>@origin
+git diff "origin/main...origin/<branch>" --stat
+git diff "origin/main...origin/<branch>"
 ```
 
-Use `$PR_FILES` as the file list for all downstream checklist items (P6, A1, A2, A3). When `$PR_FILES` differs from what `jj diff --stat` shows, trust `$PR_FILES` — the discrepancy means ancestry contamination is present.
+Use `$PR_FILES` as the file list for all downstream checklist items (P6, A1, A2, A3). When `$PR_FILES` differs from what `git diff --stat` shows, trust `$PR_FILES` — the discrepancy means ancestry contamination is present.
 
 ### Step 4: Fill in the structural checklist
 
@@ -138,7 +148,7 @@ Work through each item below. Use Grep and Glob to verify claims — do not gues
 After filling the checklist, capture the tip commit SHA of the feature branch:
 
 ```bash
-REVIEWED_SHA=$(jj log -r 'feat/<feature-name>@origin' -T 'commit_id' --no-graph)
+REVIEWED_SHA="${FEAT_SHA}"  # already resolved via `git rev-parse origin/<branch>` in Step 1
 ```
 
 Write this as the **first line** of `dev/reviews/<feature>.md` before the checklist:
@@ -237,14 +247,15 @@ Reviewed SHA: <sha captured in Step 5>
 
 Then append the structural checklist below it.
 
+Write the file using the Edit/Write tool, with the review path resolved against the PARENT workspace's repo root (NOT the per-agent git worktree at `${WT}`, which the orchestrator does not see):
+
 ```bash
-jj new main@origin
-jj describe -m "QC structural review: <feature-name>"
+REVIEW_FILE="${GITHUB_WORKSPACE:-${PARENT_REPO_ROOT:-$(pwd)}}/dev/reviews/<feature>.md"
 ```
 
-Write the file using the Edit/Write tool.
+Here `${PARENT_REPO_ROOT}` is the orchestrator's working tree (typically the dispatch prompt's cwd before this agent ran). On GHA, `${GITHUB_WORKSPACE}` carries the same value.
 
-**IMPORTANT: Do NOT push your changes to origin.** The review file is written in-place in your worktree for the lead-orchestrator to read directly. Pushing creates orphan `dev/reviews/*` branches on origin that accumulate as clutter. Write the file and return — the orchestrator reads your output text and the file you wrote.
+**IMPORTANT: Do NOT push your changes to origin.** The review file is written in-place in the parent worktree for the lead-orchestrator to read directly. Pushing creates orphan `dev/reviews/*` branches on origin that accumulate as clutter. Write the file and return — the orchestrator reads your output text and the file you wrote.
 
 ### Update status
 


### PR DESCRIPTION
## Summary

PR-E of `dev/plans/sweep-and-qc-architecture-2026-05-26.md`. Replaces the `jj edit feat/<branch>@origin` checkout pattern in both QC agent prompts with plain `git worktree add --detach`.

Plain git worktrees are filesystem-only: they do NOT touch the parent workspace's shared `.jj/repo/` op-heads or default `WorkspaceName`. The prior `jj edit` pattern caused two documented contamination incidents:

- `memory/feedback_qc_agents_need_worktree_isolation.md` — QC's `jj edit` mutated parent `@`, reverted unrelated working files.
- `memory/project_jj_worktree_root_cause.md` — Claude Code's `isolation: "worktree"` creates **git** worktrees while `jj` operations race the shared backend.

### Pattern changes

| Step | Before | After |
|---|---|---|
| Checkout | `jj git fetch && jj new feat/<branch>@origin` (writes to parent's `.jj/repo/`) | `git fetch origin <branch> && git worktree add --detach "${WT}" "${FEAT_SHA}"` (filesystem-only, in `/tmp/qc-pr-<N>-$$`) |
| Diff source | `jj diff --from main@origin --to feat/<branch>@origin` | `git diff origin/main...origin/<branch>` |
| Staleness check | `jj log --revset "main@origin ~ ancestors(...)"` | `git rev-list --count "${FEAT_SHA}..origin/main"` |
| Reviewed SHA | `jj log -r 'feat/<branch>@origin' -T 'commit_id'` | `${FEAT_SHA}` (already resolved by `git rev-parse`) |
| Review file write | `jj new main@origin && jj describe -m "..."` then write | Drop the jj commit; write to `${PARENT_REPO_ROOT}/dev/reviews/<feature>.md` (already-existing pattern on GHA via `${GITHUB_WORKSPACE}`) |

`git worktree add --detach` is the load-bearing form: detaching from any named ref means no orchestrator-visible branch state changes, even if the agent forgets to clean up.

## Test plan

Pure prompt edits in two `.md` files; no code, no build, no runtime. Verification:

- [x] `grep -E '\bjj\s+(edit|new|describe|git fetch|log -r|diff)' .claude/agents/qc-*.md` returns only the two rationale-prose lines that reference the prior `jj edit` pattern by name.
- [x] All `git worktree add` invocations include `--detach` to keep refs unchanged.
- [x] Review-file write path uses `${PARENT_REPO_ROOT}` / `${GITHUB_WORKSPACE}` (NOT the agent's per-worktree path at `${WT}`, which the orchestrator does not see).
- [x] Diff scope: 2 files, no unrelated edits.

This PR is `.claude/agents/*.md`-only → docs-only per `pr-merge-gates.md` → admin-mergeable after CI.

## Live evidence

The recent PR #1296 (qc-structural / qc-behavioral on `sweep_disk_watcher.sh`) was reviewed via this pattern directly — the dispatch prompt forced `git fetch + git worktree add` instead of `jj edit`, and both reviews completed cleanly with no parent-workspace contamination. This PR bakes that into the agent prompts so all future dispatches inherit the safer pattern.

## Out of scope

- PR-D' — orchestrator + audit script migration to read PR review comments + drop `dev/reviews/*.md` file writes (tracked).
- The inconsistency in qc-behavioral.md line 44 (`no Write, no Edit, no Bash`) vs. the file-write step elsewhere — pre-existing; will be resolved by PR-D' when file writes drop.