### PR TITLE
feat(sweep): wire sweep_disk_watcher.sh into launch_sweep.sh + cross-VM kill

### DIFF
--- a/dev/scripts/launch_sweep.sh
+++ b/dev/scripts/launch_sweep.sh
@@ -321,3 +321,24 @@ if [[ -n "${PID}" ]]; then
 fi
 log "monitor:    ${DOCKER_BIN} exec ${CONTAINER} pgrep -af 'bayesian_runner\\.exe.*${SWEEP_NAME}'"
 log "tail log:   ${DOCKER_BIN} exec ${CONTAINER} tail -f ${LOG_FILE}"
+
+# ---------------------------------------------------------------------------
+# Spawn the disk watcher (PR-C, #1296) in the background ON THE HOST.
+# Conditional: only if the script is present (older checkouts won't have it).
+#
+# The watcher polls host-only probes (df / Docker.raw) that aren't visible
+# inside the container, so it must run host-side. The watcher's --container
+# flag forwards kill -0/-TERM through `docker exec` so it can address the
+# container-internal sweep PID even on macOS Docker (where the host kernel
+# does NOT share a PID namespace with the container).
+# ---------------------------------------------------------------------------
+WATCHER="${SCRIPT_DIR}/sweep_disk_watcher.sh"
+if [[ -x "${WATCHER}" && -n "${PID}" ]]; then
+  nohup "${WATCHER}" \
+    --sweep-pid "${PID}" \
+    --sweep-name "${SWEEP_NAME}" \
+    --container "${CONTAINER}" \
+    >/dev/null 2>&1 &
+  WATCHER_PID=$!
+  log "spawned disk watcher pid=${WATCHER_PID} (log .sweep-output/${SWEEP_NAME}.watcher.log)"
+fi

--- a/dev/scripts/sweep_disk_watcher.sh
+++ b/dev/scripts/sweep_disk_watcher.sh
@@ -144,6 +144,22 @@ kb_to_gb() {
 }
 
 # ---------------------------------------------------------------------------
+# Cross-VM kill helper. Routes `kill -SIG <pid>` through `docker exec
+# <container> kill -SIG <pid>` when --container is set, otherwise calls
+# KILL_BIN directly. Required on macOS Docker Desktop where the container
+# runs in a Linux VM and its PID namespace is NOT visible from the host —
+# direct `kill -0 <container-pid>` always fails there.
+# ---------------------------------------------------------------------------
+_kill() {
+  local signal="$1" pid="$2"
+  if [[ -n "${CONTAINER:-}" ]]; then
+    "${DOCKER_BIN}" exec "${CONTAINER}" kill "${signal}" "${pid}" 2>/dev/null
+  else
+    "${KILL_BIN}" "${signal}" "${pid}" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Threshold evaluator — returns 0 if all clear, 1 if a KILL threshold tripped.
 # Always emits warnings; only ever emits one KILL line per invocation.
 # ---------------------------------------------------------------------------
@@ -190,7 +206,7 @@ while true; do
   iteration=$(( iteration + 1 ))
 
   # Check sweep PID liveness first. `kill -0` returns 0 if PID exists.
-  if ! "${KILL_BIN}" -0 "${SWEEP_PID}" 2>/dev/null; then
+  if ! _kill -0 "${SWEEP_PID}"; then
     log "sweep pid=${SWEEP_PID} exited — watcher done"
     exit 0
   fi
@@ -199,7 +215,7 @@ while true; do
 
   if (( should_kill == 1 )); then
     log "ABORT: ${kill_reason} — SIGTERM-ing pid=${SWEEP_PID} so BO can write a final checkpoint"
-    "${KILL_BIN}" -TERM "${SWEEP_PID}" 2>/dev/null || true
+    _kill -TERM "${SWEEP_PID}" || true
     exit 2
   fi
 

--- a/dev/scripts/sweep_disk_watcher_test.sh
+++ b/dev/scripts/sweep_disk_watcher_test.sh
@@ -52,17 +52,33 @@ EOF
 echo "${raw_kb}	\$2"
 EOF
 
+  # docker mock: handles `exec <container> du -sk /tmp` AND `exec <container> kill -SIG <pid>`.
+  # The watcher routes kill through `docker exec` whenever --container is set
+  # (needed on macOS Docker where the container's PID namespace is not visible
+  # from the host). The mock records TERMs into kill_calls + reads pid_alive
+  # to answer liveness probes.
   cat > "${dir}/docker" <<EOF
 #!/bin/sh
 case "\$1 \$3" in
   "exec du")
     echo "${tmp_kb}	/tmp"
     ;;
+  "exec kill")
+    # \$2 is the container name, \$3 is "kill", \$4 is the signal, \$5 is the PID.
+    case "\$4" in
+      -0)
+        [ "${pid_alive}" = "1" ] && exit 0 || exit 1
+        ;;
+      -TERM)
+        echo "TERM sent to pid=\$5" >> "${dir}/kill_calls"
+        exit 0
+        ;;
+    esac
+    ;;
 esac
 EOF
 
-  # kill mock: -0 = liveness probe (returns based on pid_alive)
-  #            -TERM = record to a marker file
+  # kill mock: --container-less fallback path (KILL_BIN); same semantics.
   cat > "${dir}/kill" <<EOF
 #!/bin/sh
 case "\$1" in


### PR DESCRIPTION
## Summary

Closes the Program-B PR-A↔PR-C integration: after a successful sweep launch, `launch_sweep.sh` now spawns `sweep_disk_watcher.sh` in the background as the watcher side-car. Together they close the t=0 (preconditions) and t>0 (mid-flight disk fill) safety windows that caused the 2026-05-23..25 sweep crashes.

Two changes in one PR — they're coupled by the same bug:

### 1. Wire `sweep_disk_watcher.sh` into `launch_sweep.sh`

After the launch succeeds + the sweep PID is resolved, spawn the watcher on the host with the sweep PID + container name. Logged with the watcher's PID for tracking. Conditional: only if the watcher script is present (older checkouts without PR-C skip cleanly).

### 2. Watcher: route `kill -0` / `kill -TERM` through `docker exec` on macOS

PR-C's watcher used the host's `kill` binary against the container's PID. That works on Linux Docker (shared PID namespace via `--pid=host`) but **silently fails on macOS Docker Desktop**, where the container runs in a Linux VM whose PID namespace the host kernel cannot see — every `kill -0` returns "no such process" and the watcher would exit immediately thinking the sweep had died.

Fix: new `_kill` helper. When `--container <name>` is set, route `kill -SIG <pid>` through `docker exec <container> kill -SIG <pid>`. Otherwise fall back to the existing `${KILL_BIN}` path (preserves the unit-test mock pattern).

## Test plan

Both suites pass locally:

```
$ bash dev/scripts/launch_sweep_test.sh    →  10/10 PASS (unchanged)
$ bash dev/scripts/sweep_disk_watcher_test.sh →  9/9 PASS
```

The watcher test's mock `docker` was extended to handle `exec <container> kill -0` and `exec <container> kill -TERM` cases (in addition to the existing `exec <container> du`). The same `pid_alive` / `kill_calls` markers verify both the liveness-check path and the SIGTERM dispatch through the new `_kill` helper.

## Why one PR (not two)

The wire-up and the cross-VM kill fix are coupled by the same operational defect: spawning the watcher on macOS would have produced an immediately-exiting watcher (silent no-op) without the kill-via-docker fix. Shipping them separately would have either (a) left PR-C dead-on-arrival on macOS or (b) required a PR-C revert mid-flight. Single-PR coupling is the right shape per the discipline note in `.claude/rules/code-health-discipline.md` — fix the operational gap, don't ship a known-broken thing.

## Operational note

PR-A's wrapper now produces:
```
[launch_sweep] launched — out-dir: /tmp/sweeps/foo
[launch_sweep] launched — log:     /tmp/sweeps/foo.log
[launch_sweep] launched — pid:     12345
[launch_sweep] spawned disk watcher pid=67890 (log .sweep-output/foo.watcher.log)
[launch_sweep] monitor:    docker exec trading-1-dev pgrep -af 'bayesian_runner\.exe.*foo'
```

The watcher log path is the bind-mount destination (`.sweep-output/` on host = `/tmp/` related; see PR-A for the bind-mount discipline).

## Out of scope

- PR-D' — orchestrator + audit-script migration to `gh pr view` reads.