### PR TITLE
docs(orchestrator): Stage 4 audit call passes --pr-number (PR-D'b)

### DIFF
--- a/.claude/agents/lead-orchestrator.md
+++ b/.claude/agents/lead-orchestrator.md
@@ -1289,18 +1289,42 @@ agent didn't open as draft), the mutation is a no-op and returns
 was not run). Runs for both APPROVED and NEEDS_REWORK outcomes.
 
 Call `trading/devtools/checks/record_qc_audit.sh` to extract verdicts and
-quality score from `dev/reviews/<feature>.md` and write the structured audit
-record to `dev/audit/YYYY-MM-DD-<feature>.json`:
+quality score. The script accepts two sources and prefers the PR review
+comments path (PR-D'a, #1299) when `--pr-number N` is supplied; otherwise
+it falls back to reading `dev/reviews/<feature>.md`:
 
 ```bash
 DATE="$(date +%Y-%m-%d)"
 FEATURE="<feature>"
 BRANCH="feat/<feature>"   # or harness/<name> for harness work
+PR_NUMBER="<N>"           # from `gh pr view --head $BRANCH --json number` if not already in hand
 
+# Preferred — reads verdicts from `gh pr view <N> --json reviews`:
+bash trading/devtools/checks/record_qc_audit.sh \
+  "$FEATURE" "$BRANCH" "$DATE" --pr-number "$PR_NUMBER"
+
+# Legacy fallback — when no PR exists yet (review file is the sole audit trail):
 bash trading/devtools/checks/record_qc_audit.sh "$FEATURE" "$BRANCH" "$DATE"
 ```
 
-The script extracts from `dev/reviews/<feature>.md`:
+The script writes the structured audit record to
+`dev/audit/YYYY-MM-DD-<feature>.json`. In `--pr-number` mode it extracts:
+
+- **Structural verdict** from the latest PR review whose body contains
+  `## Structural QC` (or `## Structural Checklist`). State `APPROVED` →
+  `APPROVED`; `CHANGES_REQUESTED` → `NEEDS_REWORK`; `COMMENTED`/`DISMISSED`
+  falls back to the `## Verdict` block in the body (self-approval-blocked
+  QC agents post `--comment` reviews with the verdict in the body).
+- **Behavioral verdict** — same logic against `## Behavioral QC` (or
+  `## Behavioral Checklist` / `## Contract Pinning Checklist`).
+- **Quality score** from the last `## Quality Score` / `### Quality Score`
+  block in any review body.
+
+If the PR has no matching reviews, the script falls back to the file path
+below — same behavior as the legacy invocation. The transitional dual-source
+contract is documented in PR-D'a (#1299).
+
+In file mode the script extracts from `dev/reviews/<feature>.md`:
 - **Structural verdict**: `structural_qc: APPROVED|NEEDS_REWORK` field, or the
   first `## Verdict` block (bare or `**bold**` format); defaults to SKIPPED.
 - **Behavioral verdict**: `behavioral_qc: APPROVED|NEEDS_REWORK` field, or the


### PR DESCRIPTION
## Summary

Second sub-PR of the PR-D' follow-up. Updates `.claude/agents/lead-orchestrator.md` Stage 4 (audit-record write) to opt into the new `--pr-number` flag added by PR-D'a (#1299). The orchestrator now writes audit records keyed on the GitHub PR's review comments instead of `dev/reviews/<feature>.md`.

## What changed

`.claude/agents/lead-orchestrator.md` Stage 4 section:

- Stage 4 example invocation now includes `--pr-number "$PR_NUMBER"` (with a `PR_NUMBER="<N>"` placeholder + a one-liner showing how to derive it via `gh pr view --head $BRANCH --json number`).
- The legacy file-mode invocation is retained as the fallback path for the rare "PR not yet open" case.
- Inline doc block describes the PR-mode extraction semantics (state → verdict; COMMENTED falls back to body `## Verdict`; quality_score from PR comment bodies).
- Mentions the transitional dual-source contract documented in PR-D'a.

## Why a minimal change rather than 30 touch points

The PR-D plan acceptance bullet 2 ("review files are NOT created") was the trigger for a full orchestrator rewrite. PR-D'a's **dual-source** approach moots that: `dev/reviews/<feature>.md` keeps being written by QC agents (transitional), so every other orchestrator touch point that reads the file (Step 1.5 idempotency, Step 4 dispatch prompts pasting prior review content, Step 5 fail-list verification) keeps working unchanged. The audit script call is the ONE place where new behavior is required — and that's a 2-line change.

PR-D'c will remove the dual-write once we've verified the PR-comment path is reliable across a few sessions.

## Test plan

Pure docs PR (`.claude/agents/*.md` only) → docs-only per `.claude/rules/pr-merge-gates.md` → admin-mergeable after CI passes. No code, no build, no runtime.

- [x] Diff scope: 1 file, 32 added / 4 deleted in `.claude/agents/lead-orchestrator.md`.
- [x] Stage 4 invocation example uses the new `--pr-number "$PR_NUMBER"` flag and references PR-D'a (#1299).
- [x] Legacy file-mode invocation kept as fallback (transitional).

## Sequencing

- **PR-D'a (#1299)**: dual-source `record_qc_audit.sh` — merging.
- **PR-D'b (this)**: orchestrator opts into `--pr-number` in Stage 4.
- **PR-D'c (next)**: drop the Step 2 file-write block from `qc-structural.md` + `qc-behavioral.md` once the dual-source has been exercised across a session or two.

## Out of scope

- Step 1.5 idempotency migration (still reads `dev/reviews/<feature>.md`; works because of dual-write).
- Step 4 dispatch-prompt rewriting (still pastes `dev/reviews/<feature>.md` content; same reason).
- PR-D'c agent file-write removal.