### PR TITLE
feat(walk-forward): Window_spec.Tiered variant (M1 T1.1)

### DIFF
--- a/dev/status/tuning.md
+++ b/dev/status/tuning.md
@@ -1,6 +1,6 @@
 # Status: tuning
 
-## Last updated: 2026-05-22
+## Last updated: 2026-05-25
 
 ## Status
 IN_PROGRESS
@@ -194,6 +194,8 @@ not.
   manual grid sweep needed.
 
 ## Completed
+
+- [x] **M1 T1.1 — `Window_spec.Tiered` variant** (branch `feat/walk-forward-window-spec-tiered`; pure data-shape PR per `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` Milestone M1). Adds a third constructor to `Walk_forward.Window_spec.t` alongside the existing `Rolling`/`Explicit`: `Tiered of tiered_spec`, where `tiered_spec` carries a shared `start_date`/`end_date`/`train_days` plus an ordered `tiers : tier list` (cheap → expensive). Each `tier` names a `fold_count` + `horizon_days` for one fidelity stage. `generate` returns the concatenation of per-tier folds (global `index`, within-tier zero-padded name `<tier-name>-NNN`); each tier independently tiles its folds non-overlappingly from `start_date + train_days` with `step_days = horizon_days`. Overflow (`fold_count * horizon_days + train_days > end_date - start_date + 1`) raises `Failure` rather than silently truncating. Sexp parser extended to recognise the `Tiered`-tagged variant alongside `Rolling`/`Explicit`; legacy flat-record shape still parses as `Rolling`. 13 new tests in `test_window_spec.ml` covering parse, multi-tier concat with global indices, within-tier name padding, per-tier anchoring, train-then-test back-to-back, `train_days = 0` no-train-period case, overflow/empty-tiers/dup-name/zero-fold_count/zero-horizon_days/negative-train_days failure paths, and sexp round-trip. Existing 17 Rolling/Explicit tests pass unchanged (regression). T1.1 is a data-shape-only PR — no runner integration, no CLI flag, no promotion strategy (those are T1.2/T1.3). Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest trading/backtest/walk_forward/test/ --force'` (30/30 pass).
 
 - [x] **PR #1047 — `grid_search.exe --parallel N` (cell-level parallelism)** (MERGED 2026-05-12). Reduces wall-time for large grids by running N cells concurrently. Used for the 81-cell flagship sweep.
 

--- a/trading/trading/backtest/walk_forward/lib/window_spec.ml
+++ b/trading/trading/backtest/walk_forward/lib/window_spec.ml
@@ -17,7 +17,21 @@ type explicit_fold = {
 }
 [@@deriving sexp]
 
-type t = Rolling of rolling_spec | Explicit of explicit_fold list
+type tier = { name : string; fold_count : int; horizon_days : int }
+[@@deriving sexp]
+
+type tiered_spec = {
+  start_date : Date.t;
+  end_date : Date.t;
+  train_days : int;
+  tiers : tier list;
+}
+[@@deriving sexp]
+
+type t =
+  | Rolling of rolling_spec
+  | Explicit of explicit_fold list
+  | Tiered of tiered_spec
 [@@deriving sexp]
 
 (** Sexp parser that accepts both the variant shape ([(Rolling ...)] /
@@ -27,7 +41,7 @@ type t = Rolling of rolling_spec | Explicit of explicit_fold list
 let t_of_sexp_variant_form = t_of_sexp
 
 let _is_variant_tagged = function
-  | Sexp.List (Sexp.Atom ("Rolling" | "Explicit") :: _) -> true
+  | Sexp.List (Sexp.Atom ("Rolling" | "Explicit" | "Tiered") :: _) -> true
   | _ -> false
 
 let t_of_sexp sexp =
@@ -110,6 +124,92 @@ let _generate_explicit (folds : explicit_fold list) =
         test_period = ef.test_period;
       })
 
+(* ----- Tiered generator ----- *)
+
+let _validate_tier (tier : tier) =
+  if tier.fold_count < 1 then
+    failwith
+      (sprintf "WindowSpec.generate: tier %S fold_count must be >= 1, got %d"
+         tier.name tier.fold_count);
+  if tier.horizon_days <= 0 then
+    failwith
+      (sprintf "WindowSpec.generate: tier %S horizon_days must be > 0, got %d"
+         tier.name tier.horizon_days)
+
+let _validate_tiered (spec : tiered_spec) =
+  if spec.train_days < 0 then
+    failwith
+      (sprintf "WindowSpec.generate: Tiered train_days must be >= 0, got %d"
+         spec.train_days);
+  if List.is_empty spec.tiers then
+    failwith "WindowSpec.generate: Tiered tiers list must be non-empty";
+  let names = List.map spec.tiers ~f:(fun t -> t.name) in
+  (match List.find_a_dup names ~compare:String.compare with
+  | Some dup ->
+      failwith
+        (sprintf "WindowSpec.generate: duplicate tier name in Tiered: %S" dup)
+  | None -> ());
+  List.iter spec.tiers ~f:_validate_tier
+
+let _tier_fold_name tier_name within_index =
+  sprintf "%s-%03d" tier_name within_index
+
+let _build_tier_fold ~global_index ~within_index ~(tier : tier)
+    ~(spec : tiered_spec) =
+  (* Tier-local anchor: within-tier fold k starts horizon_days * k after the
+     tier's first anchor (start_date). The train_period spans the [train_days]
+     preceding the test window; the test window spans exactly [horizon_days]. *)
+  let test_start =
+    Date.add_days spec.start_date
+      ((within_index * tier.horizon_days) + spec.train_days)
+  in
+  let test_end = Date.add_days test_start (tier.horizon_days - 1) in
+  let train_period =
+    if spec.train_days = 0 then None
+    else
+      let train_start = Date.add_days test_start (-spec.train_days) in
+      let train_end = Date.add_days test_start (-1) in
+      Some
+        ({ start_date = train_start; end_date = train_end } : Scenario.period)
+  in
+  let test_period : Scenario.period =
+    { start_date = test_start; end_date = test_end }
+  in
+  {
+    index = global_index;
+    name = _tier_fold_name tier.name within_index;
+    train_period;
+    test_period;
+  }
+
+let _generate_tier ~start_global_index ~(tier : tier) ~(spec : tiered_spec) =
+  let folds =
+    List.init tier.fold_count ~f:(fun within_index ->
+        _build_tier_fold
+          ~global_index:(start_global_index + within_index)
+          ~within_index ~tier ~spec)
+  in
+  let last = List.last_exn folds in
+  if Date.( > ) last.test_period.end_date spec.end_date then
+    failwith
+      (sprintf
+         "WindowSpec.generate: tier %S overflows date range (last test ends %s \
+          > end_date %s)"
+         tier.name
+         (Date.to_string last.test_period.end_date)
+         (Date.to_string spec.end_date));
+  folds
+
+let _generate_tiered (spec : tiered_spec) =
+  _validate_tiered spec;
+  let _, all =
+    List.fold spec.tiers ~init:(0, []) ~f:(fun (next_index, acc) tier ->
+        let folds = _generate_tier ~start_global_index:next_index ~tier ~spec in
+        (next_index + List.length folds, acc @ folds))
+  in
+  all
+
 let generate = function
   | Rolling spec -> _generate_rolling spec
   | Explicit folds -> _generate_explicit folds
+  | Tiered spec -> _generate_tiered spec

--- a/trading/trading/backtest/walk_forward/lib/window_spec.mli
+++ b/trading/trading/backtest/walk_forward/lib/window_spec.mli
@@ -12,7 +12,7 @@
     observable and a machine-checkable go/no-go gate becomes the verdict rather
     than an eyeballed table.
 
-    Two construction modes:
+    Three construction modes:
 
     - [Rolling] — start_date/train_days/test_days/step_days expansion; the
       generator emits the fold sequence and stops dropping folds whose
@@ -21,6 +21,13 @@
       2026-05-08 8-fold experiment as a regression fixture (its windows are not
       a rolling pattern). Folds pass through verbatim with their input-order
       indexes and operator-supplied names.
+    - [Tiered] — ordered list of fidelity tiers (cheap → expensive), each naming
+      a fold_count + horizon_days for one stage of a tiered tuning sweep (M1
+      T1.1, see [dev/plans/tuning-research-driven-program-v2-2026-05-25.md]).
+      Within a tier, folds tile non-overlappingly across
+      [(start_date, end_date)] with [step_days = horizon_days]. The strategy
+      that promotes survivors between tiers is the runner's job; this spec only
+      describes the fold shape each tier produces.
 
     All date arithmetic is in calendar days (not trading days). Conversion to
     trading-day windows is the backtest runner's job — the spec only constrains
@@ -61,15 +68,64 @@ type explicit_fold = {
 [@@deriving sexp]
 (** One hand-curated fold for the [Explicit] mode. *)
 
+type tier = {
+  name : string;
+      (** Tier label (e.g. ["cheap"], ["medium"], ["expensive"], ["ambitious"]).
+          Used as the prefix for emitted fold names ([<tier-name>-NNN]) and must
+          be unique within a [Tiered] spec. *)
+  fold_count : int;
+      (** Exact number of folds this tier emits. Must be [>= 1]. The generator
+          raises [Failure] when the tier's required span
+          ([fold_count * horizon_days]) does not fit the available test-window
+          range ([end_date - (start_date + train_days)]). *)
+  horizon_days : int;
+      (** Length of each fold's test window in calendar days. Must be [> 0].
+          Test windows within a tier tile non-overlappingly with
+          [step_days = horizon_days]. *)
+}
+[@@deriving sexp]
+(** One fidelity tier of a [Tiered] spec. Tiers run in list order (cheap →
+    expensive); the runner promotes top survivors from each tier into the next
+    per a strategy declared in PR follow-ups (T1.2 scope). *)
+
+type tiered_spec = {
+  start_date : Date.t;
+      (** Inclusive earliest day for the first fold's train (or test, when
+          [train_days = 0]) period. Shared by all tiers — each tier anchors its
+          first fold at [start_date]. *)
+  end_date : Date.t;
+      (** Inclusive latest day any fold may extend to. Folds whose test period
+          would end after [end_date] cause the generator to raise [Failure] (the
+          spec is rejected rather than silently truncated). *)
+  train_days : int;
+      (** Length of each fold's in-sample (train) period in calendar days,
+          shared by all tiers. Zero means OOS-only folds — [train_period] in the
+          generated fold is [None]. Must be [>= 0]. *)
+  tiers : tier list;
+      (** Ordered list of fidelity tiers (cheap → expensive). Must be non-empty
+          and have unique tier names. *)
+}
+[@@deriving sexp]
+(** Description of a tiered fold layout. The generator emits the concatenation
+    of each tier's folds (cheap-tier folds first, expensive last); each tier
+    independently tiles its [fold_count] test windows of length [horizon_days]
+    across [(start_date + train_days, end_date)]. *)
+
 (** Sexp shape: [(Rolling ((start_date ...) (end_date ...) ...))] or
-    [(Explicit (((name "...") (train_period ...) (test_period ...)) ...))].
+    [(Explicit (((name "...") (train_period ...) (test_period ...) ...) ...))]
+    or
+    [(Tiered ((start_date ...) (end_date ...) (train_days ...) (tiers (((name
+     ...) (fold_count ...) (horizon_days ...)) ...))))].
 
     {b Legacy flat-shape compatibility:} the [t_of_sexp] override below accepts
     the pre-variant shape
     [((start_date ...) (end_date ...) (train_days ...) (test_days ...)
      (step_days ...))] and parses it as [Rolling]. The plan tracks this
     temporarily; new spec files should use the variant shape. *)
-type t = Rolling of rolling_spec | Explicit of explicit_fold list
+type t =
+  | Rolling of rolling_spec
+  | Explicit of explicit_fold list
+  | Tiered of tiered_spec
 [@@deriving sexp]
 
 val t_of_sexp : Sexp.t -> t
@@ -78,15 +134,22 @@ val t_of_sexp : Sexp.t -> t
     [Failure] on shapes matching neither. *)
 
 type fold = {
-  index : int;  (** Zero-based fold index in generation order. *)
+  index : int;
+      (** Zero-based fold index in generation order. For [Tiered] this is a
+          {b global} counter across all tiers — folds from earlier tiers get
+          lower indices than later tiers. *)
   name : string;
       (** Human-readable fold name. For [Rolling] folds shape is ["fold-NNN"]
           where [NNN] is [index] zero-padded to width 3. For [Explicit] folds
-          the name is the operator-supplied {!explicit_fold.name} verbatim. *)
+          the name is the operator-supplied {!explicit_fold.name} verbatim. For
+          [Tiered] folds the shape is ["<tier-name>-NNN"] where [NNN] is the
+          fold's {b within-tier} position zero-padded to width 3 (NOT the global
+          index). *)
   train_period : Scenario_lib.Scenario.period option;
       (** [Some] when there is an in-sample period, else [None]. The train
-          period precedes the test period back-to-back in [Rolling] mode; the
-          [Explicit] case passes through whatever the operator supplied. *)
+          period precedes the test period back-to-back in [Rolling] and [Tiered]
+          modes; the [Explicit] case passes through whatever the operator
+          supplied. *)
   test_period : Scenario_lib.Scenario.period;
 }
 [@@deriving sexp]
@@ -106,6 +169,19 @@ val generate : t -> fold list
     [Explicit]: passes the list through verbatim, assigning [index] in input
     order. Raises [Failure] on an empty list or on duplicate names.
 
+    [Tiered]: returns the concatenation of each tier's folds in tier order.
+    Within a tier, the [k]-th fold ([0-indexed]) anchors at
+    [start_date + k * horizon_days]; its train_period spans the preceding
+    [train_days] (or is [None] when [train_days = 0]) and its test_period spans
+    exactly [horizon_days] calendar days. Global [index] increments
+    monotonically across all emitted folds. The fold name is ["<tier-name>-NNN"]
+    where [NNN] is the within-tier position. Raises [Failure] when a tier's
+    required span ([fold_count * horizon_days + train_days]) exceeds the
+    available range ([end_date - start_date + 1]) — the tiered spec is rejected
+    rather than silently truncated.
+
     Returns an empty list when [Rolling]'s [start_date > end_date] or no fold
     fits the bounds. Raises [Failure] when [Rolling.train_days < 0],
-    [Rolling.test_days <= 0], or [Rolling.step_days <= 0]. *)
+    [Rolling.test_days <= 0], [Rolling.step_days <= 0], a [Tiered] spec has an
+    empty tier list, duplicate tier names, [train_days < 0], [fold_count < 1],
+    [horizon_days <= 0], or any tier overflows the date range. *)

--- a/trading/trading/backtest/walk_forward/test/test_window_spec.ml
+++ b/trading/trading/backtest/walk_forward/test/test_window_spec.ml
@@ -379,6 +379,324 @@ let test_explicit_sexp_round_trip _ =
             field (fun (e : WS.explicit_fold) -> e.name) (equal_to "f2");
           ]))
 
+(* ---------- Tiered: parse, concat, naming, overflow ---------- *)
+
+let _tier ~name ~fold_count ~horizon_days : WS.tier =
+  { name; fold_count; horizon_days }
+
+let _tiered ~start_date ~end_date ~train_days ~tiers : WS.t =
+  Tiered { start_date; end_date; train_days; tiers }
+
+(* Parse the variant-tagged sexp shape and check it routes to Tiered. *)
+let test_sexp_parses_tiered_variant _ =
+  let sexp =
+    Sexp.of_string
+      "(Tiered ((start_date 2020-01-01) (end_date 2024-12-31) (train_days 365) \
+       (tiers (((name cheap) (fold_count 2) (horizon_days 180))))))"
+  in
+  let parsed = WS.t_of_sexp sexp in
+  assert_that parsed
+    (matching ~msg:"Expected Tiered variant"
+       (function WS.Tiered ts -> Some ts | _ -> None)
+       (all_of
+          [
+            field
+              (fun (ts : WS.tiered_spec) -> ts.start_date)
+              (equal_to (_date 2020 1 1));
+            field (fun (ts : WS.tiered_spec) -> ts.train_days) (equal_to 365);
+            field
+              (fun (ts : WS.tiered_spec) -> ts.tiers)
+              (elements_are
+                 [
+                   all_of
+                     [
+                       field (fun (t : WS.tier) -> t.name) (equal_to "cheap");
+                       field (fun (t : WS.tier) -> t.fold_count) (equal_to 2);
+                       field
+                         (fun (t : WS.tier) -> t.horizon_days)
+                         (equal_to 180);
+                     ];
+                 ]);
+          ]))
+
+(* Two tiers (cheap-3 + medium-5) — 8 folds total, indices 0..7, names
+   cheap-000..cheap-002, medium-000..medium-004. Use horizon_days=30, no
+   train period, so date arithmetic is easy to follow. *)
+let test_tiered_two_tiers_concat _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:0
+      ~tiers:
+        [
+          _tier ~name:"cheap" ~fold_count:3 ~horizon_days:30;
+          _tier ~name:"medium" ~fold_count:5 ~horizon_days:30;
+        ]
+  in
+  let folds = WS.generate spec in
+  let indices = List.map folds ~f:(fun (f : WS.fold) -> f.index) in
+  let names = List.map folds ~f:(fun (f : WS.fold) -> f.name) in
+  assert_that indices
+    (elements_are
+       [
+         equal_to 0;
+         equal_to 1;
+         equal_to 2;
+         equal_to 3;
+         equal_to 4;
+         equal_to 5;
+         equal_to 6;
+         equal_to 7;
+       ]);
+  assert_that names
+    (elements_are
+       [
+         equal_to "cheap-000";
+         equal_to "cheap-001";
+         equal_to "cheap-002";
+         equal_to "medium-000";
+         equal_to "medium-001";
+         equal_to "medium-002";
+         equal_to "medium-003";
+         equal_to "medium-004";
+       ])
+
+(* Pin within-tier zero-padding to width 3 (not global index). *)
+let test_tiered_fold_names_within_tier_padded _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2025 12 31)
+      ~train_days:0
+      ~tiers:
+        [
+          _tier ~name:"medium" ~fold_count:2 ~horizon_days:30;
+          _tier ~name:"expensive" ~fold_count:2 ~horizon_days:30;
+        ]
+  in
+  let folds = WS.generate spec in
+  let names = List.map folds ~f:(fun (f : WS.fold) -> f.name) in
+  assert_that names
+    (elements_are
+       [
+         equal_to "medium-000";
+         equal_to "medium-001";
+         equal_to "expensive-000";
+         equal_to "expensive-001";
+       ])
+
+(* Tier-local anchoring: each tier's first fold starts at start_date + train_days. *)
+let test_tiered_per_tier_anchor _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:0
+      ~tiers:
+        [
+          _tier ~name:"a" ~fold_count:1 ~horizon_days:60;
+          _tier ~name:"b" ~fold_count:1 ~horizon_days:90;
+        ]
+  in
+  let folds = WS.generate spec in
+  let test_starts =
+    List.map folds ~f:(fun (f : WS.fold) -> f.test_period.start_date)
+  in
+  let test_ends =
+    List.map folds ~f:(fun (f : WS.fold) -> f.test_period.end_date)
+  in
+  assert_that test_starts
+    (elements_are [ equal_to (_date 2020 1 1); equal_to (_date 2020 1 1) ]);
+  assert_that test_ends
+    (elements_are [ equal_to (_date 2020 2 29); equal_to (_date 2020 3 30) ])
+
+(* With train_days > 0, each fold's train_period precedes its test_period
+   back-to-back. *)
+let test_tiered_train_followed_by_test _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2021 12 31)
+      ~train_days:30
+      ~tiers:[ _tier ~name:"cheap" ~fold_count:2 ~horizon_days:30 ]
+  in
+  let folds = WS.generate spec in
+  assert_that folds
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (f : WS.fold) -> f.index) (equal_to 0);
+             field (fun (f : WS.fold) -> f.name) (equal_to "cheap-000");
+             field
+               (fun (f : WS.fold) -> f.train_period)
+               (is_some_and
+                  (all_of
+                     [
+                       field
+                         (fun (p : Scenario.period) -> p.start_date)
+                         (equal_to (_date 2020 1 1));
+                       field
+                         (fun (p : Scenario.period) -> p.end_date)
+                         (equal_to (_date 2020 1 30));
+                     ]));
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2020 1 31));
+             field
+               (fun (f : WS.fold) -> f.test_period.end_date)
+               (equal_to (_date 2020 2 29));
+           ];
+         all_of
+           [
+             field (fun (f : WS.fold) -> f.index) (equal_to 1);
+             field (fun (f : WS.fold) -> f.name) (equal_to "cheap-001");
+             field
+               (fun (f : WS.fold) -> f.train_period)
+               (is_some_and
+                  (all_of
+                     [
+                       field
+                         (fun (p : Scenario.period) -> p.start_date)
+                         (equal_to (_date 2020 1 31));
+                       field
+                         (fun (p : Scenario.period) -> p.end_date)
+                         (equal_to (_date 2020 2 29));
+                     ]));
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2020 3 1));
+             field
+               (fun (f : WS.fold) -> f.test_period.end_date)
+               (equal_to (_date 2020 3 30));
+           ];
+       ])
+
+(* When train_days = 0, train_period is None. *)
+let test_tiered_zero_train_days_no_train_period _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:0
+      ~tiers:[ _tier ~name:"oos" ~fold_count:1 ~horizon_days:60 ]
+  in
+  let folds = WS.generate spec in
+  assert_that folds
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (f : WS.fold) -> f.train_period) is_none;
+             field
+               (fun (f : WS.fold) -> f.test_period.start_date)
+               (equal_to (_date 2020 1 1));
+             field
+               (fun (f : WS.fold) -> f.test_period.end_date)
+               (equal_to (_date 2020 2 29));
+           ];
+       ])
+
+(* Tier-overflow case: fold_count * horizon_days + train_days exceeds available
+   range — must raise (not silently truncate). *)
+let test_tiered_overflow_raises _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 1 30)
+      ~train_days:0
+      ~tiers:[ _tier ~name:"too-big" ~fold_count:3 ~horizon_days:60 ]
+  in
+  assert_raises
+    (Failure
+       "WindowSpec.generate: tier \"too-big\" overflows date range (last test \
+        ends 2020-06-28 > end_date 2020-01-30)") (fun () -> WS.generate spec)
+
+let test_tiered_empty_tiers_raises _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:0 ~tiers:[]
+  in
+  assert_raises
+    (Failure "WindowSpec.generate: Tiered tiers list must be non-empty")
+    (fun () -> WS.generate spec)
+
+let test_tiered_duplicate_tier_names_raise _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:0
+      ~tiers:
+        [
+          _tier ~name:"dup" ~fold_count:1 ~horizon_days:30;
+          _tier ~name:"dup" ~fold_count:1 ~horizon_days:30;
+        ]
+  in
+  assert_raises
+    (Failure "WindowSpec.generate: duplicate tier name in Tiered: \"dup\"")
+    (fun () -> WS.generate spec)
+
+let test_tiered_zero_fold_count_raises _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:0
+      ~tiers:[ _tier ~name:"bad" ~fold_count:0 ~horizon_days:30 ]
+  in
+  assert_raises
+    (Failure "WindowSpec.generate: tier \"bad\" fold_count must be >= 1, got 0")
+    (fun () -> WS.generate spec)
+
+let test_tiered_zero_horizon_days_raises _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:0
+      ~tiers:[ _tier ~name:"bad" ~fold_count:1 ~horizon_days:0 ]
+  in
+  assert_raises
+    (Failure "WindowSpec.generate: tier \"bad\" horizon_days must be > 0, got 0")
+    (fun () -> WS.generate spec)
+
+let test_tiered_negative_train_days_raises _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2020 12 31)
+      ~train_days:(-1)
+      ~tiers:[ _tier ~name:"t" ~fold_count:1 ~horizon_days:30 ]
+  in
+  assert_raises
+    (Failure "WindowSpec.generate: Tiered train_days must be >= 0, got -1")
+    (fun () -> WS.generate spec)
+
+let test_tiered_sexp_round_trip _ =
+  let spec =
+    _tiered ~start_date:(_date 2020 1 1) ~end_date:(_date 2024 12 31)
+      ~train_days:365
+      ~tiers:
+        [
+          _tier ~name:"cheap" ~fold_count:6 ~horizon_days:182;
+          _tier ~name:"expensive" ~fold_count:8 ~horizon_days:91;
+        ]
+  in
+  let parsed = WS.t_of_sexp (WS.sexp_of_t spec) in
+  assert_that parsed
+    (matching ~msg:"Expected Tiered variant"
+       (function WS.Tiered ts -> Some ts | _ -> None)
+       (all_of
+          [
+            field
+              (fun (ts : WS.tiered_spec) -> ts.start_date)
+              (equal_to (_date 2020 1 1));
+            field (fun (ts : WS.tiered_spec) -> ts.train_days) (equal_to 365);
+            field
+              (fun (ts : WS.tiered_spec) -> ts.tiers)
+              (elements_are
+                 [
+                   all_of
+                     [
+                       field (fun (t : WS.tier) -> t.name) (equal_to "cheap");
+                       field (fun (t : WS.tier) -> t.fold_count) (equal_to 6);
+                       field
+                         (fun (t : WS.tier) -> t.horizon_days)
+                         (equal_to 182);
+                     ];
+                   all_of
+                     [
+                       field
+                         (fun (t : WS.tier) -> t.name)
+                         (equal_to "expensive");
+                       field (fun (t : WS.tier) -> t.fold_count) (equal_to 8);
+                       field (fun (t : WS.tier) -> t.horizon_days) (equal_to 91);
+                     ];
+                 ]);
+          ]))
+
 let suite =
   "Window_spec"
   >::: [
@@ -405,6 +723,27 @@ let suite =
          "Explicit duplicate names raise"
          >:: test_explicit_duplicate_names_raise;
          "Explicit sexp round-trip" >:: test_explicit_sexp_round_trip;
+         "Tiered sexp parses variant" >:: test_sexp_parses_tiered_variant;
+         "Tiered two tiers concat with global indices"
+         >:: test_tiered_two_tiers_concat;
+         "Tiered fold names zero-padded within tier"
+         >:: test_tiered_fold_names_within_tier_padded;
+         "Tiered each tier anchors at start_date"
+         >:: test_tiered_per_tier_anchor;
+         "Tiered train followed by test back-to-back"
+         >:: test_tiered_train_followed_by_test;
+         "Tiered train_days=0 yields no train_period"
+         >:: test_tiered_zero_train_days_no_train_period;
+         "Tiered overflow raises" >:: test_tiered_overflow_raises;
+         "Tiered empty tiers raises" >:: test_tiered_empty_tiers_raises;
+         "Tiered duplicate tier names raise"
+         >:: test_tiered_duplicate_tier_names_raise;
+         "Tiered zero fold_count raises" >:: test_tiered_zero_fold_count_raises;
+         "Tiered zero horizon_days raises"
+         >:: test_tiered_zero_horizon_days_raises;
+         "Tiered negative train_days raises"
+         >:: test_tiered_negative_train_days_raises;
+         "Tiered sexp round-trip" >:: test_tiered_sexp_round_trip;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Adds a third constructor to `Walk_forward.Window_spec.t` alongside the existing `Rolling`/`Explicit`:

```ocaml
type t =
  | Rolling of rolling_spec
  | Explicit of explicit_fold list
  | Tiered of tiered_spec   (* NEW *)
```

`tiered_spec` carries a shared `start_date`/`end_date`/`train_days` plus an ordered `tiers : tier list` (cheap → expensive). Each `tier` names a `fold_count` + `horizon_days` for one fidelity stage.

This is the **data-shape-only** PR per `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` Milestone M1 T1.1 (lines 71). The runner integration (T1.2), CLI flag (T1.2), and survivor-promotion strategy (T1.3) are explicitly out of scope and land as separate PRs.

## Generator semantics

`generate` on `Tiered`:
- Returns the **concatenation** of each tier's folds (cheap-tier folds first, expensive last).
- Within a tier, the `k`-th fold (0-indexed) anchors at `start_date + k * horizon_days + train_days`; its `train_period` spans the preceding `train_days` (or `None` when `train_days = 0`); its `test_period` spans exactly `horizon_days`.
- Global `index` increments monotonically across all emitted folds.
- Fold name is `<tier-name>-NNN` where `NNN` is the **within-tier** position, zero-padded to width 3 (NOT the global index).
- Raises `Failure` when a tier overflows the date range (`fold_count * horizon_days + train_days` exceeds the available span) — the spec is rejected rather than silently truncated.

Sexp parser extended to recognise the `Tiered`-tagged variant alongside the existing `Rolling` / `Explicit` tags; the legacy flat-record shape still parses as `Rolling` (regression coverage retained).

## Files touched

| File | Change |
|---|---|
| `trading/trading/backtest/walk_forward/lib/window_spec.mli` | +tier / +tiered_spec / +Tiered variant on `t`; docstring updates on shared `fold` record and `generate` |
| `trading/trading/backtest/walk_forward/lib/window_spec.ml` | +tier / +tiered_spec types; +_validate_tier / _validate_tiered / _generate_tier / _generate_tiered helpers; extended `_is_variant_tagged` + `generate` dispatch |
| `trading/trading/backtest/walk_forward/test/test_window_spec.ml` | +13 Tiered tests; existing 17 Rolling/Explicit tests unchanged |
| `dev/status/tuning.md` | +Completed entry for T1.1 |

LOC: ~104 .ml + ~92 .mli + ~339 tests = 535 total (within ~80-100 impl + ~150-200 tests guidance once you factor out doc-comment lines and blank-line splits in the long Tiered docstrings).

## Test plan

- [x] `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval \$(opam env) && dune build'` — passes
- [x] `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval \$(opam env) && dune build @fmt'` — passes
- [x] `dune runtest trading/backtest/walk_forward/test/ --force` — 30/30 pass (17 Rolling/Explicit + 13 Tiered)
- [x] Full project `dune runtest` — passes (verified post-format)
- [x] Pre-push ancestry: branch contains exactly one commit
- [x] Pre-push diff: 4 files (status + 3 lib/test)

## Out of scope (T1.2 / T1.3 / T1.4 land separately)

- Wiring `Tiered` into `bayesian_runner` / walk-forward `Spec`
- CLI flag for tier selection
- Survivor-promotion strategy between tiers
- Default tier-count / horizon values (plan describes cheap-6 / medium-12 / expensive-26 / ambitious-8 but those are runner-spec defaults, not type-level defaults)