### PR TITLE
harness(sweep-perf): Win #2 — --parallel 6 + RAM 7→12 GB

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -112,6 +112,7 @@ do_start() {
         log_info "Creating and starting container '$CONTAINER_NAME'..."
         docker run -d \
             --name "$CONTAINER_NAME" \
+            --memory 12g \
             -v "$PROJECT_ROOT:$WORKDIR" \
             -v "$SWEEP_OUTPUT_DIR:/tmp/sweeps" \
             -w "$WORKDIR/trading" \

--- a/dev/scripts/launch_sweep.sh
+++ b/dev/scripts/launch_sweep.sh
@@ -16,7 +16,7 @@
 #                   --spec <runner-spec.sexp> \
 #                   --walk-forward-spec <wf-spec.sexp> \
 #                   --baseline-aggregate <agg.sexp> \
-#                   [--parallel N]         (default 4)
+#                   [--parallel N]         (default 6)
 #                   [--container NAME]     (default trading-1-dev)
 #                   [--dry-run]
 #
@@ -61,7 +61,7 @@ SWEEP_NAME=""
 SPEC=""
 WF_SPEC=""
 BASELINE_AGG=""
-PARALLEL="4"
+PARALLEL="6"
 CONTAINER="trading-1-dev"
 DRY_RUN=0
 

--- a/dev/status/sweep-perf.md
+++ b/dev/status/sweep-perf.md
@@ -49,7 +49,7 @@ flambda OFF.
 
 ## Completed
 
-- **Win #2** (PR #TBD, `harness/sweep-parallel-6`): raised `PARALLEL` default
+- **Win #2** (PR #1317, `harness/sweep-parallel-6`): raised `PARALLEL` default
   from 4 to 6 in `dev/scripts/launch_sweep.sh` (1 line); added `--memory 12g`
   to the `docker run` incantation in `.devcontainer/setup.sh` (1 line). Total:
   3 files touched, 4 insertions, 3 deletions. Verify:

--- a/dev/status/sweep-perf.md
+++ b/dev/status/sweep-perf.md
@@ -23,7 +23,7 @@ flambda OFF.
 
 ## Open work — v7 sweep speedup (2026-05-26)
 
-- [ ] **Win #2: `--parallel 6` + container RAM 7→12 GB** — raise
+- [x] **Win #2: `--parallel 6` + container RAM 7→12 GB** — raise
   `launch_sweep.sh` default parallel from 4 to 6; raise devcontainer memory
   cap to 12 GB. Config-only (~20 LOC in `dev/scripts/launch_sweep.sh` +
   `.devcontainer/`). Expected speedup: 1.3-1.4×. Owner:
@@ -49,7 +49,12 @@ flambda OFF.
 
 ## Completed
 
-(none yet — track opened 2026-05-26)
+- **Win #2** (PR #TBD, `harness/sweep-parallel-6`): raised `PARALLEL` default
+  from 4 to 6 in `dev/scripts/launch_sweep.sh` (1 line); added `--memory 12g`
+  to the `docker run` incantation in `.devcontainer/setup.sh` (1 line). Total:
+  3 files touched, 4 insertions, 3 deletions. Verify:
+  `grep 'PARALLEL="6"' dev/scripts/launch_sweep.sh` and
+  `grep 'memory.*12' .devcontainer/setup.sh`.
 
 ## Ownership
 


### PR DESCRIPTION
## Summary

- `dev/scripts/launch_sweep.sh`: raise `PARALLEL` default from `"4"` to `"6"` and update usage comment (2 lines changed).
- `.devcontainer/setup.sh`: add `--memory 12g` to the `docker run` incantation (1 line added).

## Why

M2 Pro has 6 performance cores. Running `--parallel 4` left two perf cores idle between folds. Expected speedup: 1.3-1.4x. The memory cap raise (7 GB → 12 GB) is required to support 6 workers without OOM kills: each worker peaks ~1.5-2 GB during snapshot rebuild + warmup, so 6 × 2 GB = 12 GB ceiling.

## Memory cap location

The live source of the memory limit is the `docker run` incantation in `.devcontainer/setup.sh` `do_start()`. `devcontainer.json` has no `hostRequirements.memory` field and is VS Code-managed only; `setup.sh` is the authoritative launch path used by `launch_sweep.sh`.

**Note:** `--memory 12g` takes effect only when a new container is created. To apply to an existing container: `setup.sh stop && docker rm trading-1-dev && setup.sh start`.

## Verify

```bash
grep 'PARALLEL="6"' dev/scripts/launch_sweep.sh   # must match
grep 'memory.*12' .devcontainer/setup.sh           # must match
dune build && dune runtest                         # unchanged — no OCaml edits
```

## Files touched

| File | Change |
|---|---|
| `dev/scripts/launch_sweep.sh` | `PARALLEL="4"` → `"6"`, usage comment updated |
| `.devcontainer/setup.sh` | `--memory 12g` added to `docker run` |
| `dev/status/sweep-perf.md` | Win #2 marked `[x]`, Completed entry added |

Track: `dev/status/sweep-perf.md` | Plan: `dev/plans/v7-sweep-speedup-2026-05-26.md` §Win #2