### PR TITLE
[main-fix] strip parenthetical from sweep-perf.md Last updated

### DIFF
--- a/dev/status/sweep-perf.md
+++ b/dev/status/sweep-perf.md
@@ -1,6 +1,6 @@
 # Status: sweep-perf
 
-## Last updated: 2026-05-26 (post Win #2 + Win #4 merge; only Win #3 remaining)
+## Last updated: 2026-05-26
 
 ## Status
 IN_PROGRESS


### PR DESCRIPTION
## Summary

- Strip the parenthetical "(post Win #2 + Win #4 merge; only Win #3 remaining)" from the `## Last updated:` line in `dev/status/sweep-perf.md`.
- `status_file_integrity.sh` requires the value to be a bare `YYYY-MM-DD`; the parenthetical made the value malformed.

## Why

CI on `main` went red on `c67b07cf` (orchestrator-summary merge #1319) because the linter caught the malformed field on the next post-merge run. The failing line from the CI log:

```
FAIL: status file integrity linter — malformed or missing fields in dev/status/:
sweep-perf.md: '## Last updated' is not YYYY-MM-DD: '2026-05-26 (post Win #2 + Win #4 merge; only Win #3 remaining)'
```

Status of the sweep-perf wins is tracked in the body of the file (Status / Goal / Next steps) and `dev/daily/2026-05-26.md`; nothing is lost by removing the parenthetical from the heading.

## Test plan

- [x] `sh trading/devtools/checks/status_file_integrity.sh` exits 0 locally.
- [ ] CI build-and-test passes.
