### PR TITLE
harness(sweep-perf): Win #3 — Flambda + -O3 in release profile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,6 +26,17 @@
 FROM docker.io/ocaml/opam:ubuntu-22.04-ocaml-5.3 AS ci
 
 # -----------------------------------------------------------------------------
+# Flambda switch — ubuntu-22.04-ocaml-5.3-flambda does not exist on Docker Hub
+# (only the base ubuntu-22.04-ocaml-5.3 tag is available). Instead, create the
+# 5.3.0+flambda variant via opam so all subsequent RUN layers use it.
+# OPAMSWITCH is set as an ENV variable so it persists across Docker RUN layers.
+# This enables cross-module inlining + -O3 optimisation in release builds.
+# See dev/plans/v7-sweep-speedup-2026-05-26.md §Win #3.
+# -----------------------------------------------------------------------------
+RUN opam switch create 5.3.0+flambda --packages=ocaml-variants.5.3.0+flambda --yes
+ENV OPAMSWITCH=5.3.0+flambda
+
+# -----------------------------------------------------------------------------
 # System Dependencies
 # -----------------------------------------------------------------------------
 # Each dependency is annotated with which OCaml package requires it.

--- a/dev/status/sweep-perf.md
+++ b/dev/status/sweep-perf.md
@@ -36,7 +36,7 @@ flambda OFF.
   Expected speedup: 1.10-1.20×. Owner: orchestrator-eligible. Spec:
   `dev/plans/v7-sweep-speedup-2026-05-26.md` §Win #3. Dispatch as
   `harness-maintainer`. Note: requires devcontainer image rebuild + push to
-  ghcr.io after merge. **IN FLIGHT**: PR #TBD (`harness/sweep-perf-flambda-o3`).
+  ghcr.io after merge. **IN FLIGHT**: PR #1323 (`harness/sweep-perf-flambda-o3`).
 
 - [x] **Win #4: Per-fold universe pruning via `Daily_price.active_through`** —
   filter `all_symbols` in `simulator.ml:_get_today_bars` and `config.universe`

--- a/dev/status/sweep-perf.md
+++ b/dev/status/sweep-perf.md
@@ -30,13 +30,13 @@ flambda OFF.
   orchestrator-eligible. Spec: `dev/plans/v7-sweep-speedup-2026-05-26.md`
   §Win #2. Dispatch as `harness-maintainer`.
 
-- [ ] **Win #3: Enable Flambda + `-O3` compiler flags** — switch devcontainer
-  to `ocaml 5.3.0+flambda`; add `(env (release (flags (:standard -O3))))` to
-  dune-project. Config-only (~20-30 LOC in `.devcontainer/` + `dune-project`).
+- [~] **Win #3: Enable Flambda + `-O3` compiler flags** — switch devcontainer
+  to `ocaml 5.3.0+flambda`; add `(env (release (ocamlopt_flags (:standard -O3))))` to
+  `trading/dune-workspace`. Config-only (~10 LOC in `.devcontainer/` + `dune-workspace`).
   Expected speedup: 1.10-1.20×. Owner: orchestrator-eligible. Spec:
   `dev/plans/v7-sweep-speedup-2026-05-26.md` §Win #3. Dispatch as
   `harness-maintainer`. Note: requires devcontainer image rebuild + push to
-  ghcr.io after merge.
+  ghcr.io after merge. **IN FLIGHT**: PR #TBD (`harness/sweep-perf-flambda-o3`).
 
 - [x] **Win #4: Per-fold universe pruning via `Daily_price.active_through`** —
   filter `all_symbols` in `simulator.ml:_get_today_bars` and `config.universe`

--- a/trading/dune-workspace
+++ b/trading/dune-workspace
@@ -1,1 +1,5 @@
 (lang dune 3.17)
+
+(env
+ (release
+  (ocamlopt_flags (:standard -O3))))


### PR DESCRIPTION
## Summary

- Add `opam switch create 5.3.0+flambda` + `ENV OPAMSWITCH=5.3.0+flambda` to `.devcontainer/Dockerfile` — enables the Flambda cross-module inliner for all subsequent image layers (`ubuntu-22.04-ocaml-5.3-flambda` does not exist on Docker Hub; `opam switch create` is the fallback per the plan).
- Add `(env (release (ocamlopt_flags (:standard -O3))))` to `trading/dune-workspace` — passes `-O3` to `ocamlopt` in release profile. Uses `ocamlopt_flags` (not `flags`) to restrict to native compiler only; `flags` would also pass `-O3` to `ocamlc` (bytecode) which rejects it.
- Mark Win #3 `[~]` (in flight) in `dev/status/sweep-perf.md`.

Implements `dev/plans/v7-sweep-speedup-2026-05-26.md` §Win #3.

## Verification

- `dune build` — EXIT=0 (dev profile, no -O3, unchanged behavior)
- `dune runtest` — EXIT=0 (all tests pass)
- `dune rules --profile release trading/base/lib/` — confirms `-O3` in `ocamlopt.opt` invocations
- `status_file_integrity.sh` — EXIT=0
- Docker Hub tag check: `ubuntu-22.04-ocaml-5.3-flambda` confirmed absent; `opam switch create` fallback documented in commit message

## Manual follow-up required

This PR adds the source-level changes to enable Flambda + -O3 in release builds. The actual perf benefit only lands after the maintainer:

1. Rebuilds the devcontainer image: `docker build -f .devcontainer/Dockerfile -t ghcr.io/dayfine/trading-devcontainer:latest .devcontainer/`
2. Pushes to ghcr.io: `docker push ghcr.io/dayfine/trading-devcontainer:latest`

CI on this PR runs against the OLD image (no flambda yet) — `dune build` and `dune runtest` will pass because `-O3` is silently no-op without flambda. Once the new image is pushed, the NEXT CI run on main will use the flambda compiler and `-O3` becomes effective. Expected speedup: 1.10–1.20× per the plan file.