### PR TITLE
[main-fix] correct opam switch invocation for 5.3.0+flambda

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,7 +33,7 @@ FROM docker.io/ocaml/opam:ubuntu-22.04-ocaml-5.3 AS ci
 # This enables cross-module inlining + -O3 optimisation in release builds.
 # See dev/plans/v7-sweep-speedup-2026-05-26.md §Win #3.
 # -----------------------------------------------------------------------------
-RUN opam switch create 5.3.0+flambda --packages=ocaml-variants.5.3.0+flambda --yes
+RUN opam switch create 5.3.0+flambda --packages=ocaml-variants.5.3.0+options,ocaml-option-flambda --yes
 ENV OPAMSWITCH=5.3.0+flambda
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix the opam switch invocation in `.devcontainer/Dockerfile` introduced by PR #1323 (sweep-perf Win #3). The package `ocaml-variants.5.3.0+flambda` does not exist in opam-repository — only `5.3.0+options` and `5.3.0+BER` are published for the 5.3 series. The canonical form for 5.3.0+flambda layers the standalone `ocaml-option-flambda` package on top of the `+options` variant.

## Why

Post-merge of #1323 (`c53bfa7d`), the `Build CI image` workflow failed:

```
[ERROR] Could not determine which packages to install for this switch:
  * Missing dependency:
    - ocaml-variants > 5.6.1~
    no matching version
```

See: https://github.com/dayfine/trading/actions/runs/26443172854

Verified against opam-repository via REST API:
- `packages/ocaml-variants/` returns only `5.3.0+options` and `5.3.0+BER` for the 5.3 series.
- `packages/ocaml-option-flambda/` returns `ocaml-option-flambda.1`.

`Build CI image` is not a required check (`build-and-test` + `perf-tier1-smoke` are the only required gates), so #1323's merge wasn't blocked. But the manual ghcr.io rebuild path that #1323 documents as the follow-up would also fail until this fix lands.

## Test plan

- [ ] CI `build-and-test` passes (the existing pre-flambda image is still in use; no behavior change in the dune build).
- [ ] `Build CI image` workflow on this PR's merge succeeds (this is what was failing on #1323).
