### PR TITLE
feat(tuning): M1 T1.5 — re-score checkpoints with paired-Δ

### DIFF
--- a/dev/notes/t1-5-rescore-procedure-2026-05-26.md
+++ b/dev/notes/t1-5-rescore-procedure-2026-05-26.md
@@ -1,0 +1,105 @@
+# T1.5 — Re-score procedure for v4/v6 checkpoints
+
+Owner: feat-backtest (track: `tuning`).
+Plan: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` §M1 T1.5.
+
+## What the rescorer does
+
+`rescore_checkpoints.exe` (built at
+`trading/trading/backtest/tuner/bin/rescore_checkpoints.ml`) consumes:
+
+1. `--input <bo_rescore_input.sexp>` — per-BO-iteration parameters + per-fold
+   actuals. Shape documented in the lib
+   `Tuner_bin.Bayesian_runner_rescore.bo_rescore_input` (`.mli` docstring).
+2. `--baseline <fold_actuals.sexp>` — Cell-E reference per-fold actuals (same
+   on-disk shape as the `fold_actuals.sexp` produced by
+   `Walk_forward.Walk_forward_runner._write_fold_actuals`).
+
+It re-scores every candidate via
+`Tuner_bin.Bayesian_runner_scoring.paired_delta` (merged #1308 / M1 T1.3) —
+per-fold `Δ_i = candidate.metric_i - baseline.metric_i`, matched by
+`fold_name`, then mean / stdev across folds. The acceptance gate is
+`spread = max(mean Δ) - min(mean Δ)` across all candidates;
+the default `--min-spread 4.05` is `5 × 0.81` (the v3–v6 flat-surface
+historical reference). Output is a markdown report (PASS / FAIL verdict +
+per-candidate row + spread anchor).
+
+## Local-only production run (v4 / v6)
+
+The production `bo_checkpoint.sexp` files are NOT accessible to GHA:
+
+```
+/Users/difan/Projects/trading-1/.sweep-output/<sweep-name>/bo_checkpoint.sexp
+```
+
+**Important caveat:** the production `bo_checkpoint.sexp` shape (see
+`Tuner_bin.Bayesian_runner_runner._checkpoint`) does NOT carry per-fold
+actuals — only the per-iteration aggregated `metric` + the synthetic
+walk-forward `metric_set`. The rescorer's input shape
+(`bo_rescore_input.sexp`) is an {i enriched} sibling file that pairs each
+iteration with its `fold_actuals` list. An upstream adapter is required to
+produce this enriched file from the production sweep output. Two options
+for that adapter (out of scope for this PR; track as a follow-up if
+operator wants to run the production re-score):
+
+1. **Re-run path:** for each saved iteration's `parameters` in
+   `bo_checkpoint.sexp`, re-execute the walk-forward CV (one cell at a time,
+   not the full BO loop). Capture each per-iter `fold_actuals.sexp` via
+   `Walk_forward.Walk_forward_runner`. Cost: one walk-forward CV per BO
+   iteration in the original sweep (~26 folds × N iterations). Bigger; safer.
+
+2. **Inline path:** patch the BO runner to persist `fold_actuals` inline as
+   part of each saved iteration (extend `Bayesian_runner_runner._saved_iteration`
+   with a `fold_actuals` field). Cost: a follow-up PR to the runner;
+   subsequent sweeps automatically write the enriched checkpoint.
+
+### Suggested incantation once the enriched files exist
+
+```bash
+# v6 sweep (most recent flat-surface diagnosis)
+dune exec --no-build trading/backtest/tuner/bin/rescore_checkpoints.exe -- \
+  --input /Users/difan/Projects/trading-1/.sweep-output/v6-11knob/bo_rescore_input.sexp \
+  --baseline /Users/difan/Projects/trading-1/.sweep-output/v6-11knob/baseline_fold_actuals.sexp \
+  --metric Sharpe \
+  --out dev/notes/t1-5-rescore-verdict-v6-2026-05-26.md
+
+# v4 sweep (flat-surface counterpart)
+dune exec --no-build trading/backtest/tuner/bin/rescore_checkpoints.exe -- \
+  --input /Users/difan/Projects/trading-1/.sweep-output/v4-9knob/bo_rescore_input.sexp \
+  --baseline /Users/difan/Projects/trading-1/.sweep-output/v4-9knob/baseline_fold_actuals.sexp \
+  --metric Sharpe \
+  --out dev/notes/t1-5-rescore-verdict-v4-2026-05-26.md
+```
+
+Acceptance per plan §M1 T1.5:
+"v4+v6 data on paired-Δ shows >5× wider spread than the original flat -10
+plateau" — the rescorer's PASS/FAIL line reports this directly.
+
+## GHA validation (this PR)
+
+In CI the rescorer is exercised end-to-end against synthetic fixtures via
+`test_bayesian_runner_rescore.ml` (17 unit tests, including a sexp round-trip
+through `load_input` + `load_baseline_fold_actuals`). The fixtures
+construct a 3-candidate × 4-fold scenario whose hand-computed mean Δ values
+yield a spread of 5.0, exceeding the default 4.05 threshold by a margin —
+the PASS path is therefore covered. A second fixture (3-candidate spread =
+0.5) covers the FAIL path. The strict-inequality boundary
+(spread == min_spread → FAIL) is pinned by a third test.
+
+The plumbing — read → re-score → render → verdict — is therefore validated;
+the {b only} GHA gap is the absence of the v4/v6 enriched input files,
+which is a data-access limitation (production data is on local disk only),
+not a code limitation.
+
+## Where the verdict goes
+
+When the local operator runs the rescorer against real v4/v6 data, the
+verdict goes to `dev/notes/t1-5-rescore-verdict-<date>.md`. The verdict
+file should record:
+
+- which sweep (`v4-9knob`, `v6-11knob`, etc.) was re-scored;
+- the rescorer's `eprintf` summary line (`candidates=N spread=X.XX
+  min_spread=4.05 verdict=PASS|FAIL`);
+- the full markdown report inline (or as an attachment);
+- whether the v4 result and the v6 result both PASS — that's the plan §M1
+  T1.5 acceptance requirement.

--- a/dev/status/tuning.md
+++ b/dev/status/tuning.md
@@ -213,21 +213,47 @@ verdict (random matches BO ⇒ surface is the bind, not the optimiser).
   on the 6-fold cheap proxy vs the 26-fold expensive walk-forward set;
   acceptance ρ ≥ 0.7. Spec: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md`
   §M1 T1.4. Branch: `feat/tuning/m1-t1-4-proxy-calibration`.
-- [ ] **T1.5 — Re-score v4/v6 checkpoints with paired-Δ.** Owner:
-  feat-backtest. ~30 LOC OCaml exe reading existing `bo_checkpoint.sexp`
-  files and applying `Bayesian_runner_scoring.paired_delta` (merged
-  #1308) to produce a re-score report; verifies spread > 5× the old
-  0.81 flat surface. Spec: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md`
-  §M1 T1.5. Branch: `feat/tuning/m1-t1-5-rescore-checkpoints`.
-  **Data note:** v4/v6 checkpoints live at
-  `/Users/difan/Projects/trading-1/.sweep-output/<sweep-name>/bo_checkpoint.sexp`
-  on the local machine only — not accessible in the GHA runtime. The
-  dispatched agent must either (a) skip the live re-score and instead
-  generate synthetic `bo_checkpoint.sexp` fixtures of the correct shape
-  to validate the `paired_delta` plumbing end-to-end, then document the
-  production run as a local-only step, OR (b) if run locally, point
-  `--checkpoint` at the real paths above and emit a verdict doc to
-  `dev/notes/t1-5-rescore-verdict-<date>.md`.
+- [~] **T1.5 — Re-score v4/v6 checkpoints with paired-Δ.** Owner:
+  feat-backtest. PR OPEN on branch `feat/tuning/m1-t1-5-rescore-checkpoints`.
+  Surface (per option (a) in the original dispatch — synthetic fixtures
+  only, production data is local-only):
+  - **Lib** `Tuner_bin.Bayesian_runner_rescore` (.ml 156 LOC / .mli 175 LOC)
+    — pure helpers consuming a new `bo_rescore_input.sexp` shape (a
+    per-iteration enriched companion to `bo_checkpoint.sexp` that carries
+    per-fold `fold_actual` lists alongside the BO parameters) + a Cell-E
+    `fold_actuals.sexp`. Calls `Bayesian_runner_scoring.paired_delta`
+    (#1308) per candidate, computes `spread = max(mean Δ) - min(mean Δ)`
+    across candidates, returns a `report` record with `PASS | FAIL`
+    verdict against the configurable acceptance gate
+    (default `4.05 = 5 × 0.81`, three named constants
+    `historical_flat_surface` / `flat_surface_multiplier` /
+    `default_min_spread`).
+  - **CLI** `rescore_checkpoints.exe` (`trading/backtest/tuner/bin/rescore_checkpoints.ml`,
+    ~120 LOC) — five flags: `--input` / `--baseline` / `--metric`
+    (Sharpe | TotalReturn | Calmar | CAGR, default Sharpe) /
+    `--min-spread` / `--out`. Emits a markdown report to stdout or the
+    `--out` path.
+  - **Tests** `test_bayesian_runner_rescore.ml` (17 cases, ~500 LOC) —
+    spread_of basic / empty / singleton; default-min-spread constants
+    pinned; rescore_candidate identity / constant-offset / partial-overlap
+    / disjoint-raises / Total_return_pct metric dispatch;
+    build_report 3-candidate Pass (spread 5.0) / below-threshold Fail
+    (spread 0.5) / strict-greater-boundary Fail (spread == threshold) /
+    empty-input Fail; markdown PASS/FAIL anchors;
+    sexp round-trip via public loaders; schema_version mismatch rejected.
+  - **Procedure doc** `dev/notes/t1-5-rescore-procedure-2026-05-26.md`
+    — what the exe does, the local-only incantation pointing at
+    `/Users/difan/Projects/trading-1/.sweep-output/v4-9knob/` and
+    `.sweep-output/v6-11knob/`, plus the gap (production
+    `bo_checkpoint.sexp` does NOT carry per-fold actuals — an upstream
+    adapter is required to produce the enriched `bo_rescore_input.sexp`;
+    documented as a follow-up).
+  - **Verdict doc location** `dev/notes/t1-5-rescore-verdict-<date>.md`
+    (only written when the local operator runs the exe against real
+    v4/v6 data).
+  Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest trading/backtest/tuner/bin/test/ --force'`
+  (167 + 17 new = 184 tests pass).
+  Spec: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` §M1 T1.5.
 
 ### Operational follow-ups
 

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_rescore.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_rescore.ml
@@ -11,10 +11,7 @@ type candidate = {
 }
 [@@deriving sexp]
 
-type bo_rescore_input = {
-  schema_version : int;
-  candidates : candidate list;
-}
+type bo_rescore_input = { schema_version : int; candidates : candidate list }
 [@@deriving sexp]
 
 let current_schema_version = 1
@@ -149,11 +146,11 @@ let report_to_markdown (report : report)
   Buffer.add_string buf
     (sprintf "max(mean \xCE\x94) - min(mean \xCE\x94) = %.6f\n" report.spread);
   Buffer.add_string buf
-    (sprintf "Historical flat-surface spread: %.2f (v3\xE2\x80\x93v6 \
-              absolute-Sharpe scoring).\n"
+    (sprintf
+       "Historical flat-surface spread: %.2f (v3\xE2\x80\x93v6 absolute-Sharpe \
+        scoring).\n"
        historical_flat_surface);
   Buffer.add_string buf
-    (sprintf
-       "Acceptance gate: spread > %.6f (= %g \xC3\x97 %.2f by default).\n"
+    (sprintf "Acceptance gate: spread > %.6f (= %g \xC3\x97 %.2f by default).\n"
        report.min_spread flat_surface_multiplier historical_flat_surface);
   Buffer.contents buf

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_rescore.ml
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_rescore.ml
@@ -1,0 +1,159 @@
+open Core
+module Wf = Walk_forward.Walk_forward_types
+module Scoring = Bayesian_runner_scoring
+
+(* ---------- on-disk shapes ---------- *)
+
+type candidate = {
+  label : string;
+  parameters : (string * float) list;
+  fold_actuals : Wf.fold_actual list;
+}
+[@@deriving sexp]
+
+type bo_rescore_input = {
+  schema_version : int;
+  candidates : candidate list;
+}
+[@@deriving sexp]
+
+let current_schema_version = 1
+
+(* ---------- report shapes ---------- *)
+
+type candidate_rescore = {
+  label : string;
+  parameters : (string * float) list;
+  mean_delta : float;
+  stdev_delta : float;
+  n_matched : int;
+}
+[@@deriving sexp]
+
+type verdict = Pass | Fail [@@deriving sexp]
+
+type report = {
+  candidates : candidate_rescore list;
+  spread : float;
+  min_spread : float;
+  verdict : verdict;
+}
+[@@deriving sexp]
+
+(* ---------- named constants (extract magic numbers) ---------- *)
+
+let historical_flat_surface = 0.81
+let flat_surface_multiplier = 5.0
+let default_min_spread = historical_flat_surface *. flat_surface_multiplier
+
+(* ---------- file loaders ---------- *)
+
+let load_input (path : string) : bo_rescore_input =
+  let sexp = Sexp.load_sexp path in
+  let parsed = bo_rescore_input_of_sexp sexp in
+  if parsed.schema_version <> current_schema_version then
+    failwithf
+      "bayesian_runner_rescore.load_input: schema_version mismatch for %s — \
+       file=%d, current=%d"
+      path parsed.schema_version current_schema_version ()
+  else parsed
+
+let load_baseline_fold_actuals (path : string) : Wf.fold_actual list =
+  let sexp = Sexp.load_sexp path in
+  match sexp with
+  | Sexp.List items -> List.map items ~f:Wf.fold_actual_of_sexp
+  | Sexp.Atom _ ->
+      failwithf
+        "bayesian_runner_rescore.load_baseline_fold_actuals: expected a \
+         top-level sexp list of fold_actual records in %s"
+        path ()
+
+(* ---------- pure computation ---------- *)
+
+let rescore_candidate (cand : candidate)
+    ~(baseline_fold_actuals : Wf.fold_actual list)
+    ~(metric : [ `Sharpe | `Total_return_pct | `Calmar | `CAGR ]) :
+    candidate_rescore =
+  let stats =
+    Scoring.paired_delta ~candidate_actuals:cand.fold_actuals
+      ~baseline_actuals:baseline_fold_actuals ~metric
+  in
+  {
+    label = cand.label;
+    parameters = cand.parameters;
+    mean_delta = stats.mean_delta;
+    stdev_delta = stats.stdev_delta;
+    n_matched = stats.n_matched;
+  }
+
+let spread_of (xs : float list) : float =
+  match xs with
+  | [] -> 0.0
+  | first :: rest ->
+      let min_v, max_v =
+        List.fold rest ~init:(first, first) ~f:(fun (lo, hi) x ->
+            (Float.min lo x, Float.max hi x))
+      in
+      max_v -. min_v
+
+let _verdict_of_spread ~spread ~min_spread =
+  if Float.( > ) spread min_spread then Pass else Fail
+
+let build_report ~(input : bo_rescore_input)
+    ~(baseline_fold_actuals : Wf.fold_actual list)
+    ~(metric : [ `Sharpe | `Total_return_pct | `Calmar | `CAGR ])
+    ~(min_spread : float) : report =
+  let rescored =
+    List.map input.candidates ~f:(fun cand ->
+        rescore_candidate cand ~baseline_fold_actuals ~metric)
+  in
+  let means = List.map rescored ~f:(fun r -> r.mean_delta) in
+  let spread = spread_of means in
+  let verdict = _verdict_of_spread ~spread ~min_spread in
+  { candidates = rescored; spread; min_spread; verdict }
+
+(* ---------- markdown rendering ---------- *)
+
+let _metric_label = function
+  | `Sharpe -> "Sharpe"
+  | `Total_return_pct -> "TotalReturn"
+  | `Calmar -> "Calmar"
+  | `CAGR -> "CAGR"
+
+let _verdict_label = function Pass -> "PASS" | Fail -> "FAIL"
+
+let _parameters_to_string params =
+  List.map params ~f:(fun (k, v) -> sprintf "%s=%.6g" k v)
+  |> String.concat ~sep:" "
+
+let _candidate_row (r : candidate_rescore) : string =
+  sprintf "| %s | %s | %.6f | %.6f | %d |\n" r.label
+    (_parameters_to_string r.parameters)
+    r.mean_delta r.stdev_delta r.n_matched
+
+let report_to_markdown (report : report)
+    ~(metric : [ `Sharpe | `Total_return_pct | `Calmar | `CAGR ]) : string =
+  let buf = Buffer.create 512 in
+  Buffer.add_string buf "# Paired-\xCE\x94 re-score report\n\n";
+  Buffer.add_string buf (sprintf "Metric: %s\n" (_metric_label metric));
+  Buffer.add_string buf
+    (sprintf "Verdict: %s (threshold: spread > %.6f)\n\n"
+       (_verdict_label report.verdict)
+       report.min_spread);
+  Buffer.add_string buf
+    "| Candidate | parameters | mean \xCE\x94 | stdev \xCE\x94 | n_matched |\n";
+  Buffer.add_string buf "| --- | --- | --- | --- | --- |\n";
+  List.iter report.candidates ~f:(fun r ->
+      Buffer.add_string buf (_candidate_row r));
+  Buffer.add_string buf "\n## Spread\n";
+  Buffer.add_string buf
+    (sprintf "max(mean \xCE\x94) - min(mean \xCE\x94) = %.6f\n" report.spread);
+  Buffer.add_string buf
+    (sprintf "Historical flat-surface spread: %.2f (v3\xE2\x80\x93v6 \
+              absolute-Sharpe scoring).\n"
+       historical_flat_surface);
+  Buffer.add_string buf
+    (sprintf
+       "Acceptance gate: spread > %.6f (= %g \xC3\x97 %.2f by default).\n"
+       report.min_spread flat_surface_multiplier historical_flat_surface);
+  Buffer.contents buf

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_rescore.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_rescore.mli
@@ -1,0 +1,199 @@
+(** Pure helpers for re-scoring existing BO sweep outputs with paired-Δ.
+
+    Plan: [dev/plans/tuning-research-driven-program-v2-2026-05-25.md] §M1 T1.5.
+
+    The v3–v6 production sweeps measured a flat ~0.81-spread score surface
+    across 60+ candidates because per-fold absolute-Sharpe variance dominated
+    knob-to-knob signal. T1.3 added the
+    {!Bayesian_runner_scoring.paired_delta} primitive which cancels that
+    common-mode noise by differencing each fold's candidate vs. Cell-E baseline.
+    T1.5 (this module) is the consumer: read the per-iteration fold actuals
+    from a previously-run BO sweep + Cell-E's per-fold actuals from the
+    walk-forward baseline, re-score every candidate with paired-Δ, and report
+    the spread across candidates.
+
+    {b Input file shape — [bo_rescore_input].}
+
+    The production [bo_checkpoint.sexp] (see {!Bayesian_runner_runner}) does
+    not persist per-fold actuals per iteration — only the aggregated score.
+    T1.5 expects an {i enriched} input file that pairs each BO iteration's
+    parameters / label with the per-fold {!Walk_forward.Walk_forward_types.fold_actual}
+    list that produced its score. The shape is:
+
+    {v
+      ((schema_version 1)
+       (candidates
+         (((label "bo-iter-000")
+           (parameters ((knob_a 0.30) (knob_b 0.65)))
+           (fold_actuals
+             (((fold_name "fold-000") (variant_label "bo-iter-000")
+               (total_return_pct 5.0) (sharpe_ratio 0.7)
+               (max_drawdown_pct -8.0) (calmar_ratio 0.6)
+               (cagr_pct 5.0) (avg_holding_days 22.0))
+              ...)))
+          ((label "bo-iter-001") ...))))
+    v}
+
+    Production runs after T1.5 lands will need a small adapter to produce this
+    file from BO sweep outputs (re-running each iteration's walk-forward CV
+    captures the [fold_actuals]; the alternative is patching the BO runner to
+    persist fold actuals inline as part of each iteration — out of scope here).
+    The synthetic fixtures in the unit tests exercise the rescorer end-to-end
+    without touching production data. *)
+
+(** Per-iteration record carried in the input file: parameters that produced
+    the iteration plus its per-fold actuals (used for paired-Δ matching). *)
+type candidate = {
+  label : string;
+      (** Stable label for this candidate (e.g. ["bo-iter-007"]). Surfaced in
+          the report so the operator can correlate to the BO log. *)
+  parameters : (string * float) list;
+      (** Knob assignment that produced this candidate's score. Surfaced in
+          the report only — the rescorer does not act on it. *)
+  fold_actuals : Walk_forward.Walk_forward_types.fold_actual list;
+      (** Per-fold actuals for this candidate. Matched by [fold_name] against
+          the baseline fold_actuals; matching is order-independent. *)
+}
+[@@deriving sexp]
+
+(** Top-level shape of the rescore input sexp file. [schema_version] guards
+    against future shape drift; the current version is [1]. *)
+type bo_rescore_input = {
+  schema_version : int;
+  candidates : candidate list;
+}
+[@@deriving sexp]
+
+val current_schema_version : int
+(** Current [schema_version] for {!bo_rescore_input}. Files written today
+    carry this value; the loader rejects files with a different value so the
+    sexp shape can evolve safely. *)
+
+(** Per-candidate re-score result. Carries the candidate identity plus the
+    paired-Δ stats produced by {!Bayesian_runner_scoring.paired_delta}.
+
+    The stats are flattened into individual fields (rather than embedding
+    {!Bayesian_runner_scoring.paired_delta_stats}) because that type does not
+    derive [sexp] — flattening keeps the [sexp]-derived shape stable for
+    on-disk debug dumps without coupling to upstream sexp annotations. *)
+type candidate_rescore = {
+  label : string;
+  parameters : (string * float) list;
+  mean_delta : float;
+      (** Mirror of {!Bayesian_runner_scoring.paired_delta_stats.mean_delta}. *)
+  stdev_delta : float;
+      (** Mirror of
+          {!Bayesian_runner_scoring.paired_delta_stats.stdev_delta}. *)
+  n_matched : int;
+      (** Mirror of {!Bayesian_runner_scoring.paired_delta_stats.n_matched}. *)
+}
+[@@deriving sexp]
+
+(** Verdict on whether the re-scored surface meets the T1.5 acceptance gate
+    (spread > 5× the historical 0.81 flat surface = 4.05). *)
+type verdict = Pass | Fail [@@deriving sexp]
+
+(** Full re-score report — one row per candidate plus the aggregate spread
+    metric and verdict. *)
+type report = {
+  candidates : candidate_rescore list;
+  spread : float;
+      (** [max(mean_delta) - min(mean_delta)] across candidates. Empty
+          candidate list yields [0.0] (will FAIL the acceptance gate). *)
+  min_spread : float;
+      (** Acceptance threshold the spread is compared against. Default
+          {!default_min_spread}; CLI [--min-spread] overrides. *)
+  verdict : verdict;
+}
+[@@deriving sexp]
+
+val historical_flat_surface : float
+(** The v3–v6 production flat-surface score range, in absolute-Sharpe units.
+    Value: [0.81]. Source: per-track diagnosis recorded in
+    `dev/notes/bayesian-prod-v6-result-*.md` (referenced from plan §M1 T1.3).
+    Exposed so the report can quote it next to the threshold. *)
+
+val flat_surface_multiplier : float
+(** Multiplier on {!historical_flat_surface} that defines the acceptance gate.
+    Value: [5.0]. Plan §M1 T1.5: "spread > 5× the old 0.81". *)
+
+val default_min_spread : float
+(** Default minimum-spread acceptance threshold —
+    [historical_flat_surface *. flat_surface_multiplier = 4.05]. The CLI's
+    [--min-spread] flag overrides this value. *)
+
+val load_input : string -> bo_rescore_input
+(** [load_input path] loads + sexp-parses the {!bo_rescore_input} from
+    [path]. Raises [Failure] if [schema_version] does not equal
+    {!current_schema_version}. *)
+
+val load_baseline_fold_actuals :
+  string -> Walk_forward.Walk_forward_types.fold_actual list
+(** [load_baseline_fold_actuals path] loads the Cell-E baseline's per-fold
+    actuals from [path]. The expected on-disk shape matches the
+    [fold_actuals.sexp] produced by
+    {!Walk_forward.Walk_forward_runner._write_fold_actuals}: a top-level
+    [Sexp.List] of {!Walk_forward.Walk_forward_types.fold_actual} sexps. *)
+
+val rescore_candidate :
+  candidate ->
+  baseline_fold_actuals:Walk_forward.Walk_forward_types.fold_actual list ->
+  metric:[ `Sharpe | `Total_return_pct | `Calmar | `CAGR ] ->
+  candidate_rescore
+(** [rescore_candidate cand ~baseline_fold_actuals ~metric] re-scores a single
+    candidate by computing per-fold Δ vs. the baseline via
+    {!Bayesian_runner_scoring.paired_delta}, matched by [fold_name].
+
+    Raises [Failure] (propagated from {!Bayesian_runner_scoring.paired_delta})
+    when no fold names overlap between [cand.fold_actuals] and
+    [baseline_fold_actuals]. A disjoint pair is a callsite bug — the candidate
+    and baseline must have been run on the same walk-forward spec. *)
+
+val spread_of : float list -> float
+(** [spread_of xs] returns [max xs - min xs], or [0.0] for an empty list.
+    Pure helper exposed for test introspection. *)
+
+val build_report :
+  input:bo_rescore_input ->
+  baseline_fold_actuals:Walk_forward.Walk_forward_types.fold_actual list ->
+  metric:[ `Sharpe | `Total_return_pct | `Calmar | `CAGR ] ->
+  min_spread:float ->
+  report
+(** [build_report ~input ~baseline_fold_actuals ~metric ~min_spread] re-scores
+    every candidate in [input] and returns the assembled {!report}.
+
+    Per-candidate semantics match {!rescore_candidate}: each candidate's fold
+    actuals are matched against [baseline_fold_actuals] by [fold_name]. The
+    overall [spread] is [max(mean_delta) - min(mean_delta)] across all
+    candidates; verdict is {!Pass} when [spread > min_spread], else {!Fail}.
+
+    [min_spread] defaults to {!default_min_spread} at the CLI surface; this
+    function does not apply a default — the caller passes it explicitly so the
+    test cases can pin the boundary. *)
+
+val report_to_markdown :
+  report ->
+  metric:[ `Sharpe | `Total_return_pct | `Calmar | `CAGR ] ->
+  string
+(** [report_to_markdown report ~metric] renders the re-score report as
+    markdown. Layout:
+
+    {v
+      # Paired-Δ re-score report
+
+      Metric: <metric>
+      Verdict: PASS | FAIL (threshold: spread > <min_spread>)
+
+      | Candidate | parameters | mean Δ | stdev Δ | n_matched |
+      | --- | --- | --- | --- | --- |
+      | <label> | <k1>=<v1> ... | <m> | <s> | <n> |
+      | ... |
+
+      ## Spread
+      max(mean Δ) - min(mean Δ) = <spread>
+      Historical flat-surface spread: 0.81 (v3–v6 absolute-Sharpe scoring).
+      Acceptance gate: spread > <min_spread> (= 5 × 0.81 by default).
+    v}
+
+    The renderer is pure — no I/O, no time, no environment reads — so the
+    test suite can pin its output byte-for-byte. *)

--- a/trading/trading/backtest/tuner/bin/bayesian_runner_rescore.mli
+++ b/trading/trading/backtest/tuner/bin/bayesian_runner_rescore.mli
@@ -4,20 +4,19 @@
 
     The v3–v6 production sweeps measured a flat ~0.81-spread score surface
     across 60+ candidates because per-fold absolute-Sharpe variance dominated
-    knob-to-knob signal. T1.3 added the
-    {!Bayesian_runner_scoring.paired_delta} primitive which cancels that
-    common-mode noise by differencing each fold's candidate vs. Cell-E baseline.
-    T1.5 (this module) is the consumer: read the per-iteration fold actuals
-    from a previously-run BO sweep + Cell-E's per-fold actuals from the
-    walk-forward baseline, re-score every candidate with paired-Δ, and report
-    the spread across candidates.
+    knob-to-knob signal. T1.3 added the {!Bayesian_runner_scoring.paired_delta}
+    primitive which cancels that common-mode noise by differencing each fold's
+    candidate vs. Cell-E baseline. T1.5 (this module) is the consumer: read the
+    per-iteration fold actuals from a previously-run BO sweep + Cell-E's
+    per-fold actuals from the walk-forward baseline, re-score every candidate
+    with paired-Δ, and report the spread across candidates.
 
     {b Input file shape — [bo_rescore_input].}
 
-    The production [bo_checkpoint.sexp] (see {!Bayesian_runner_runner}) does
-    not persist per-fold actuals per iteration — only the aggregated score.
-    T1.5 expects an {i enriched} input file that pairs each BO iteration's
-    parameters / label with the per-fold {!Walk_forward.Walk_forward_types.fold_actual}
+    The production [bo_checkpoint.sexp] (see {!Bayesian_runner_runner}) does not
+    persist per-fold actuals per iteration — only the aggregated score. T1.5
+    expects an {i enriched} input file that pairs each BO iteration's parameters
+    / label with the per-fold {!Walk_forward.Walk_forward_types.fold_actual}
     list that produced its score. The shape is:
 
     {v
@@ -41,71 +40,68 @@
     The synthetic fixtures in the unit tests exercise the rescorer end-to-end
     without touching production data. *)
 
-(** Per-iteration record carried in the input file: parameters that produced
-    the iteration plus its per-fold actuals (used for paired-Δ matching). *)
 type candidate = {
   label : string;
       (** Stable label for this candidate (e.g. ["bo-iter-007"]). Surfaced in
           the report so the operator can correlate to the BO log. *)
   parameters : (string * float) list;
-      (** Knob assignment that produced this candidate's score. Surfaced in
-          the report only — the rescorer does not act on it. *)
+      (** Knob assignment that produced this candidate's score. Surfaced in the
+          report only — the rescorer does not act on it. *)
   fold_actuals : Walk_forward.Walk_forward_types.fold_actual list;
       (** Per-fold actuals for this candidate. Matched by [fold_name] against
           the baseline fold_actuals; matching is order-independent. *)
 }
 [@@deriving sexp]
+(** Per-iteration record carried in the input file: parameters that produced the
+    iteration plus its per-fold actuals (used for paired-Δ matching). *)
 
+type bo_rescore_input = { schema_version : int; candidates : candidate list }
+[@@deriving sexp]
 (** Top-level shape of the rescore input sexp file. [schema_version] guards
     against future shape drift; the current version is [1]. *)
-type bo_rescore_input = {
-  schema_version : int;
-  candidates : candidate list;
-}
-[@@deriving sexp]
 
 val current_schema_version : int
-(** Current [schema_version] for {!bo_rescore_input}. Files written today
-    carry this value; the loader rejects files with a different value so the
-    sexp shape can evolve safely. *)
+(** Current [schema_version] for {!bo_rescore_input}. Files written today carry
+    this value; the loader rejects files with a different value so the sexp
+    shape can evolve safely. *)
 
-(** Per-candidate re-score result. Carries the candidate identity plus the
-    paired-Δ stats produced by {!Bayesian_runner_scoring.paired_delta}.
-
-    The stats are flattened into individual fields (rather than embedding
-    {!Bayesian_runner_scoring.paired_delta_stats}) because that type does not
-    derive [sexp] — flattening keeps the [sexp]-derived shape stable for
-    on-disk debug dumps without coupling to upstream sexp annotations. *)
 type candidate_rescore = {
   label : string;
   parameters : (string * float) list;
   mean_delta : float;
       (** Mirror of {!Bayesian_runner_scoring.paired_delta_stats.mean_delta}. *)
   stdev_delta : float;
-      (** Mirror of
-          {!Bayesian_runner_scoring.paired_delta_stats.stdev_delta}. *)
+      (** Mirror of {!Bayesian_runner_scoring.paired_delta_stats.stdev_delta}.
+      *)
   n_matched : int;
       (** Mirror of {!Bayesian_runner_scoring.paired_delta_stats.n_matched}. *)
 }
 [@@deriving sexp]
+(** Per-candidate re-score result. Carries the candidate identity plus the
+    paired-Δ stats produced by {!Bayesian_runner_scoring.paired_delta}.
+
+    The stats are flattened into individual fields (rather than embedding
+    {!Bayesian_runner_scoring.paired_delta_stats}) because that type does not
+    derive [sexp] — flattening keeps the [sexp]-derived shape stable for on-disk
+    debug dumps without coupling to upstream sexp annotations. *)
 
 (** Verdict on whether the re-scored surface meets the T1.5 acceptance gate
     (spread > 5× the historical 0.81 flat surface = 4.05). *)
 type verdict = Pass | Fail [@@deriving sexp]
 
-(** Full re-score report — one row per candidate plus the aggregate spread
-    metric and verdict. *)
 type report = {
   candidates : candidate_rescore list;
   spread : float;
-      (** [max(mean_delta) - min(mean_delta)] across candidates. Empty
-          candidate list yields [0.0] (will FAIL the acceptance gate). *)
+      (** [max(mean_delta) - min(mean_delta)] across candidates. Empty candidate
+          list yields [0.0] (will FAIL the acceptance gate). *)
   min_spread : float;
       (** Acceptance threshold the spread is compared against. Default
           {!default_min_spread}; CLI [--min-spread] overrides. *)
   verdict : verdict;
 }
 [@@deriving sexp]
+(** Full re-score report — one row per candidate plus the aggregate spread
+    metric and verdict. *)
 
 val historical_flat_surface : float
 (** The v3–v6 production flat-surface score range, in absolute-Sharpe units.
@@ -123,8 +119,8 @@ val default_min_spread : float
     [--min-spread] flag overrides this value. *)
 
 val load_input : string -> bo_rescore_input
-(** [load_input path] loads + sexp-parses the {!bo_rescore_input} from
-    [path]. Raises [Failure] if [schema_version] does not equal
+(** [load_input path] loads + sexp-parses the {!bo_rescore_input} from [path].
+    Raises [Failure] if [schema_version] does not equal
     {!current_schema_version}. *)
 
 val load_baseline_fold_actuals :
@@ -150,8 +146,8 @@ val rescore_candidate :
     and baseline must have been run on the same walk-forward spec. *)
 
 val spread_of : float list -> float
-(** [spread_of xs] returns [max xs - min xs], or [0.0] for an empty list.
-    Pure helper exposed for test introspection. *)
+(** [spread_of xs] returns [max xs - min xs], or [0.0] for an empty list. Pure
+    helper exposed for test introspection. *)
 
 val build_report :
   input:bo_rescore_input ->
@@ -172,11 +168,9 @@ val build_report :
     test cases can pin the boundary. *)
 
 val report_to_markdown :
-  report ->
-  metric:[ `Sharpe | `Total_return_pct | `Calmar | `CAGR ] ->
-  string
-(** [report_to_markdown report ~metric] renders the re-score report as
-    markdown. Layout:
+  report -> metric:[ `Sharpe | `Total_return_pct | `Calmar | `CAGR ] -> string
+(** [report_to_markdown report ~metric] renders the re-score report as markdown.
+    Layout:
 
     {v
       # Paired-Δ re-score report
@@ -195,5 +189,5 @@ val report_to_markdown :
       Acceptance gate: spread > <min_spread> (= 5 × 0.81 by default).
     v}
 
-    The renderer is pure — no I/O, no time, no environment reads — so the
-    test suite can pin its output byte-for-byte. *)
+    The renderer is pure — no I/O, no time, no environment reads — so the test
+    suite can pin its output byte-for-byte. *)

--- a/trading/trading/backtest/tuner/bin/dune
+++ b/trading/trading/backtest/tuner/bin/dune
@@ -7,6 +7,7 @@
   bayesian_runner_spec
   bayesian_runner_evaluator
   bayesian_runner_runner
+  bayesian_runner_rescore
   bayesian_runner_scoring
   bayesian_runner_successive_halving
   bayesian_runner_oos_validator

--- a/trading/trading/backtest/tuner/bin/dune
+++ b/trading/trading/backtest/tuner/bin/dune
@@ -42,3 +42,8 @@
   scenario_lib
   tuner_bin
   walk_forward))
+
+(executable
+ (name rescore_checkpoints)
+ (modules rescore_checkpoints)
+ (libraries core tuner_bin))

--- a/trading/trading/backtest/tuner/bin/rescore_checkpoints.ml
+++ b/trading/trading/backtest/tuner/bin/rescore_checkpoints.ml
@@ -1,0 +1,147 @@
+(** CLI for re-scoring an existing BO sweep output with paired-Δ.
+
+    Plan: [dev/plans/tuning-research-driven-program-v2-2026-05-25.md] §M1 T1.5.
+
+    Reads:
+
+    - [--input <bo_rescore_input.sexp>] — per-iteration candidate parameters +
+      per-fold actuals (shape
+      {!Tuner_bin.Bayesian_runner_rescore.bo_rescore_input}).
+    - [--baseline <fold_actuals.sexp>] — Cell-E baseline's per-fold actuals
+      (same shape as walk_forward_runner's [fold_actuals.sexp] output).
+
+    Emits a markdown report (stdout by default; [--out <path>] redirects)
+    containing:
+
+    - per-candidate (label, parameters, mean Δ, stdev Δ, n_matched);
+    - overall spread = max(mean Δ) - min(mean Δ);
+    - PASS / FAIL verdict against [--min-spread] (default 4.05 = 5 × 0.81).
+
+    Usage:
+
+    {v
+      rescore_checkpoints.exe --input <bo_rescore_input.sexp>
+                              --baseline <fold_actuals.sexp>
+                              [--metric Sharpe|TotalReturn|Calmar|CAGR]
+                              [--min-spread <float>]
+                              [--out <path>]
+    v}
+
+    {b Production-run procedure (local-only):} the v4/v6 production
+    [bo_checkpoint.sexp] files at
+    [/Users/difan/Projects/trading-1/.sweep-output/<sweep-name>/] do {b not}
+    persist per-fold actuals — only the aggregated per-iter score. T1.5
+    therefore requires an upstream adapter (out of scope for this PR) that
+    re-emits each iteration's walk-forward CV with [fold_actuals] captured,
+    serialised to the [bo_rescore_input] shape documented in the lib's
+    {!Tuner_bin.Bayesian_runner_rescore} module. See
+    [dev/notes/t1-5-rescore-procedure-2026-05-26.md] for the local-run
+    incantation. *)
+
+open Core
+module Rescore = Tuner_bin.Bayesian_runner_rescore
+
+let _usage_msg =
+  "Usage: rescore_checkpoints.exe --input <bo_rescore_input.sexp>\n\
+  \  --baseline <fold_actuals.sexp>\n\
+  \  [--metric Sharpe|TotalReturn|Calmar|CAGR]   (default Sharpe)\n\
+  \  [--min-spread <float>]                       (default 4.05 = 5 × 0.81)\n\
+  \  [--out <path>]                               (default stdout)"
+
+type cli_args = {
+  input_path : string;
+  baseline_path : string;
+  metric : [ `Sharpe | `Total_return_pct | `Calmar | `CAGR ];
+  min_spread : float;
+  out_path : string option;
+}
+
+let _default_metric : [ `Sharpe | `Total_return_pct | `Calmar | `CAGR ] =
+  `Sharpe
+
+let _parse_metric raw =
+  match String.lowercase raw with
+  | "sharpe" -> `Sharpe
+  | "totalreturn" | "total_return" | "total_return_pct" -> `Total_return_pct
+  | "calmar" -> `Calmar
+  | "cagr" -> `CAGR
+  | other ->
+      eprintf
+        "Error: --metric expects 'Sharpe' | 'TotalReturn' | 'Calmar' | 'CAGR', \
+         got %S\n\
+         %s\n"
+        other _usage_msg;
+      Stdlib.exit 1
+
+let _parse_float raw =
+  try Float.of_string raw
+  with _ ->
+    eprintf "Error: expected float, got %S\n%s\n" raw _usage_msg;
+    Stdlib.exit 1
+
+let _parse_args argv =
+  let rec loop input baseline metric min_spread out = function
+    | [] -> (
+        match (input, baseline) with
+        | Some i, Some b ->
+            {
+              input_path = i;
+              baseline_path = b;
+              metric = Option.value metric ~default:_default_metric;
+              min_spread =
+                Option.value min_spread ~default:Rescore.default_min_spread;
+              out_path = out;
+            }
+        | _ ->
+            eprintf "%s\n" _usage_msg;
+            Stdlib.exit 1)
+    | "--input" :: p :: rest ->
+        loop (Some p) baseline metric min_spread out rest
+    | "--baseline" :: p :: rest ->
+        loop input (Some p) metric min_spread out rest
+    | "--metric" :: raw :: rest ->
+        loop input baseline (Some (_parse_metric raw)) min_spread out rest
+    | "--min-spread" :: raw :: rest ->
+        loop input baseline metric (Some (_parse_float raw)) out rest
+    | "--out" :: p :: rest ->
+        loop input baseline metric min_spread (Some p) rest
+    | ("--help" | "-h") :: _ ->
+        printf "%s\n" _usage_msg;
+        Stdlib.exit 0
+    | unknown :: _ ->
+        eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
+        Stdlib.exit 1
+  in
+  loop None None None None None argv
+
+let _emit_report ~out_path markdown =
+  match out_path with
+  | None -> printf "%s" markdown
+  | Some path ->
+      Out_channel.write_all path ~data:markdown;
+      eprintf "[rescore_checkpoints] wrote %s\n%!" path
+
+let _verdict_label = function Rescore.Pass -> "PASS" | Rescore.Fail -> "FAIL"
+
+let _run (args : cli_args) =
+  let input = Rescore.load_input args.input_path in
+  let baseline_fold_actuals =
+    Rescore.load_baseline_fold_actuals args.baseline_path
+  in
+  let report =
+    Rescore.build_report ~input ~baseline_fold_actuals ~metric:args.metric
+      ~min_spread:args.min_spread
+  in
+  eprintf
+    "[rescore_checkpoints] candidates=%d spread=%.6f min_spread=%.6f verdict=%s\n\
+     %!"
+    (List.length report.candidates)
+    report.spread report.min_spread
+    (_verdict_label report.verdict);
+  let markdown = Rescore.report_to_markdown report ~metric:args.metric in
+  _emit_report ~out_path:args.out_path markdown
+
+let () =
+  let argv = Array.to_list (Sys.get_argv ()) |> List.tl_exn in
+  let args = _parse_args argv in
+  _run args

--- a/trading/trading/backtest/tuner/bin/test/dune
+++ b/trading/trading/backtest/tuner/bin/test/dune
@@ -2,6 +2,7 @@
  (names
   test_grid_search_bin
   test_bayesian_runner_bin
+  test_bayesian_runner_rescore
   test_bayesian_runner_scoring
   test_bayesian_runner_evaluator
   test_bayesian_runner_oos_validator

--- a/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_rescore.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_bayesian_runner_rescore.ml
@@ -1,0 +1,503 @@
+(** Unit tests for {!Tuner_bin.Bayesian_runner_rescore}.
+
+    The rescorer is pure: input = per-iter fold actuals + baseline fold actuals
+    + metric + threshold, output = a {!report} record (also pure markdown via
+      {!Bayesian_runner_rescore.report_to_markdown}). Tests construct synthetic
+      [bo_rescore_input] + [fold_actual list] inputs by hand — no real BO sweep,
+      no walk-forward run, no file I/O except a single round-trip fixture to
+      validate {!load_input} / {!load_baseline_fold_actuals} parsing.
+
+    Coverage map (plan §M1 T1.5):
+
+    - Identity (candidate == baseline) → mean Δ = 0 across all candidates →
+      spread = 0 → verdict = Fail (acceptance gate requires > 0).
+    - Hand-pinned 3-candidate × 4-fold fixture: per-candidate mean Δ computed
+      against a known baseline; verifies the matching-by-fold-name plumbing.
+    - Spread acceptance boundaries: spread = 5.0 (Pass), spread = 0.5 (Fail);
+      pin the comparison strictly-greater contract.
+    - Partial overlap: candidate carries a fold absent in baseline → silently
+      dropped (matches {!Bayesian_runner_scoring.paired_delta} semantics);
+      candidate with zero overlap → exception bubbles up (the disjoint-pair
+      callsite-bug contract is preserved through the rescorer).
+    - Sexp round-trip: dump a synthetic input + baseline, load via the public
+      loaders, re-score, assert the round-trip is faithful. Pins the on-disk
+      schema_version contract.
+    - Schema-mismatch loader rejects future shape drift.
+    - Markdown renderer pins the verdict line / metric label / spread row. *)
+
+open OUnit2
+open Core
+open Matchers
+module Rescore = Tuner_bin.Bayesian_runner_rescore
+module Wf = Walk_forward.Walk_forward_types
+
+let _epsilon = 1e-9
+
+(* ---------- synthetic fold_actual builders ---------- *)
+
+(** Construct a synthetic [fold_actual]. Mirrors the helper in
+    [test_bayesian_runner_scoring.ml]: NaN defaults for fields the test does not
+    pin, so a typo or wrong-metric dispatch fails loudly. *)
+let _fold_actual ?(variant_label = "candidate") ?(total_return_pct = Float.nan)
+    ?(sharpe_ratio = Float.nan) ?(max_drawdown_pct = Float.nan)
+    ?(calmar_ratio = Float.nan) ?(cagr_pct = Float.nan)
+    ?(avg_holding_days = Float.nan) ~fold_name () : Wf.fold_actual =
+  {
+    fold_name;
+    variant_label;
+    total_return_pct;
+    sharpe_ratio;
+    max_drawdown_pct;
+    calmar_ratio;
+    cagr_pct;
+    avg_holding_days;
+  }
+
+let _baseline_sharpes =
+  [ ("fold-000", 0.5); ("fold-001", 0.7); ("fold-002", 0.3); ("fold-003", 1.0) ]
+
+let _baseline_actuals () =
+  List.map _baseline_sharpes ~f:(fun (fold_name, s) ->
+      _fold_actual ~fold_name ~sharpe_ratio:s ~variant_label:"cell-E" ())
+
+(** Build a synthetic candidate whose per-fold Sharpe equals baseline_Sharpe +
+    [delta_per_fold]: yields a constant-Δ candidate whose mean Δ =
+    delta_per_fold and stdev Δ = 0. *)
+let _make_constant_offset_candidate ~label ~delta : Rescore.candidate =
+  let actuals =
+    List.map _baseline_sharpes ~f:(fun (fold_name, s) ->
+        _fold_actual ~fold_name ~sharpe_ratio:(s +. delta) ~variant_label:label
+          ())
+  in
+  { label; parameters = [ ("knob", delta) ]; fold_actuals = actuals }
+
+(** Build a synthetic input with N candidates whose mean Δ values are the list
+    [deltas], in order. Each candidate is named ["bo-iter-NNN"]. *)
+let _make_synthetic_input (deltas : float list) : Rescore.bo_rescore_input =
+  let candidates =
+    List.mapi deltas ~f:(fun i delta ->
+        let label = sprintf "bo-iter-%03d" i in
+        _make_constant_offset_candidate ~label ~delta)
+  in
+  { schema_version = Rescore.current_schema_version; candidates }
+
+(* ---------- spread_of ---------- *)
+
+(** Hand-pinned: spread of a list with known min/max. *)
+let test_spread_of_basic _ =
+  assert_that
+    (Rescore.spread_of [ 1.0; 5.0; 2.0; -1.0; 4.0 ])
+    (float_equal ~epsilon:_epsilon 6.0)
+
+(** Empty input collapses to 0.0 — the report renderer wants a total function.
+*)
+let test_spread_of_empty _ =
+  assert_that (Rescore.spread_of []) (float_equal ~epsilon:_epsilon 0.0)
+
+(** Singleton: max == min, spread 0. Pins the no-spread degenerate case. *)
+let test_spread_of_singleton _ =
+  assert_that (Rescore.spread_of [ 3.14 ]) (float_equal ~epsilon:_epsilon 0.0)
+
+(* ---------- named constants ---------- *)
+
+(** Pin the three named constants extracted from magic numbers — historical
+    surface, multiplier, and the derived default. Future tuning that changes any
+    of these will be caught here, forcing the change to be deliberate. *)
+let test_default_min_spread_is_5x_historical _ =
+  assert_that Rescore.historical_flat_surface
+    (float_equal ~epsilon:_epsilon 0.81);
+  assert_that Rescore.flat_surface_multiplier
+    (float_equal ~epsilon:_epsilon 5.0);
+  assert_that Rescore.default_min_spread (float_equal ~epsilon:_epsilon 4.05);
+  assert_that Rescore.default_min_spread
+    (float_equal ~epsilon:_epsilon
+       (Rescore.flat_surface_multiplier *. Rescore.historical_flat_surface))
+
+(* ---------- rescore_candidate ---------- *)
+
+(** Identity: candidate fold_actuals == baseline fold_actuals → mean Δ = 0,
+    stdev Δ = 0, n_matched = 4. The constant-offset builder with delta = 0.0
+    produces exactly this. *)
+let test_rescore_candidate_identity _ =
+  let cand = _make_constant_offset_candidate ~label:"id" ~delta:0.0 in
+  let result =
+    Rescore.rescore_candidate cand ~baseline_fold_actuals:(_baseline_actuals ())
+      ~metric:`Sharpe
+  in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : Rescore.candidate_rescore) -> r.label) (equal_to "id");
+         field
+           (fun (r : Rescore.candidate_rescore) -> r.mean_delta)
+           (float_equal ~epsilon:_epsilon 0.0);
+         field
+           (fun (r : Rescore.candidate_rescore) -> r.stdev_delta)
+           (float_equal ~epsilon:_epsilon 0.0);
+         field (fun (r : Rescore.candidate_rescore) -> r.n_matched) (equal_to 4);
+       ])
+
+(** Constant offset: candidate Sharpe = baseline + 0.25 on every fold → mean Δ =
+    0.25, stdev = 0. *)
+let test_rescore_candidate_constant_offset _ =
+  let cand = _make_constant_offset_candidate ~label:"c" ~delta:0.25 in
+  let result =
+    Rescore.rescore_candidate cand ~baseline_fold_actuals:(_baseline_actuals ())
+      ~metric:`Sharpe
+  in
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Rescore.candidate_rescore) -> r.mean_delta)
+           (float_equal ~epsilon:_epsilon 0.25);
+         field
+           (fun (r : Rescore.candidate_rescore) -> r.stdev_delta)
+           (float_equal ~epsilon:_epsilon 0.0);
+         field (fun (r : Rescore.candidate_rescore) -> r.n_matched) (equal_to 4);
+       ])
+
+(** Partial overlap: candidate carries one fold not in baseline + one baseline
+    fold not in candidate. Only the intersecting folds contribute. Pins the
+    silently-drop-mismatched-folds contract inherited from
+    {!Bayesian_runner_scoring.paired_delta}. *)
+let test_rescore_candidate_partial_overlap _ =
+  let baseline =
+    [
+      _fold_actual ~fold_name:"f0" ~sharpe_ratio:0.5 ();
+      _fold_actual ~fold_name:"f1" ~sharpe_ratio:1.0 ();
+      _fold_actual ~fold_name:"f2" ~sharpe_ratio:0.3 () (* not in candidate *);
+    ]
+  in
+  let cand : Rescore.candidate =
+    {
+      label = "partial";
+      parameters = [];
+      fold_actuals =
+        [
+          _fold_actual ~fold_name:"f0" ~sharpe_ratio:0.8 ();
+          _fold_actual ~fold_name:"f1" ~sharpe_ratio:1.4 ();
+          _fold_actual ~fold_name:"f3" ~sharpe_ratio:99.0 ()
+          (* dropped — not in baseline *);
+        ];
+    }
+  in
+  let result =
+    Rescore.rescore_candidate cand ~baseline_fold_actuals:baseline
+      ~metric:`Sharpe
+  in
+  (* Δ on f0 = 0.3; Δ on f1 = 0.4; mean = 0.35; n_matched = 2. *)
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Rescore.candidate_rescore) -> r.mean_delta)
+           (float_equal ~epsilon:_epsilon 0.35);
+         field (fun (r : Rescore.candidate_rescore) -> r.n_matched) (equal_to 2);
+       ])
+
+(** Disjoint pair: no shared fold names → exception bubbles up from
+    {!Bayesian_runner_scoring.paired_delta}. Verifies the rescorer does not
+    swallow the disjoint-pair signal. *)
+let test_rescore_candidate_disjoint_raises _ =
+  let baseline =
+    [
+      _fold_actual ~fold_name:"a0" ~sharpe_ratio:0.5 ();
+      _fold_actual ~fold_name:"a1" ~sharpe_ratio:1.0 ();
+    ]
+  in
+  let cand : Rescore.candidate =
+    {
+      label = "disjoint";
+      parameters = [];
+      fold_actuals =
+        [
+          _fold_actual ~fold_name:"b0" ~sharpe_ratio:0.8 ();
+          _fold_actual ~fold_name:"b1" ~sharpe_ratio:1.5 ();
+        ];
+    }
+  in
+  let f () =
+    let _ =
+      Rescore.rescore_candidate cand ~baseline_fold_actuals:baseline
+        ~metric:`Sharpe
+    in
+    ()
+  in
+  match
+    try
+      f ();
+      None
+    with
+    | Failure msg -> Some msg
+    | exn -> assert_failure ("expected Failure, got: " ^ Exn.to_string exn)
+  with
+  | None -> assert_failure "expected Failure on disjoint fold names"
+  | Some msg ->
+      assert_bool
+        ("Failure message should mention no fold names matched: " ^ msg)
+        (String.is_substring msg ~substring:"no fold names matched")
+
+(* ---------- build_report end-to-end ---------- *)
+
+(** Hand-pinned 3-candidate × 4-fold fixture. Pins the per-candidate mean Δ
+    values + the overall spread + the verdict. Each candidate's offset against
+    the baseline is the [delta] argument; spread = max - min across the three
+    candidate mean Δ values.
+
+    Three candidates with deltas [-1.0; 2.0; 4.0]: means are [-1.0; 2.0; 4.0],
+    spread = 4.0 - (-1.0) = 5.0; passes the default threshold 4.05. *)
+let test_build_report_three_candidate_passes _ =
+  let input = _make_synthetic_input [ -1.0; 2.0; 4.0 ] in
+  let baseline_actuals = _baseline_actuals () in
+  let report =
+    Rescore.build_report ~input ~baseline_fold_actuals:baseline_actuals
+      ~metric:`Sharpe ~min_spread:Rescore.default_min_spread
+  in
+  assert_that report
+    (all_of
+       [
+         field (fun (r : Rescore.report) -> r.candidates) (size_is 3);
+         field
+           (fun (r : Rescore.report) -> r.spread)
+           (float_equal ~epsilon:_epsilon 5.0);
+         field
+           (fun (r : Rescore.report) -> r.min_spread)
+           (float_equal ~epsilon:_epsilon Rescore.default_min_spread);
+         field (fun (r : Rescore.report) -> r.verdict) (equal_to Rescore.Pass);
+       ])
+
+(** Boundary FAIL: spread exactly 0.5 — well below the default 4.05. *)
+let test_build_report_below_threshold_fails _ =
+  let input = _make_synthetic_input [ 0.0; 0.25; 0.5 ] in
+  let baseline_actuals = _baseline_actuals () in
+  let report =
+    Rescore.build_report ~input ~baseline_fold_actuals:baseline_actuals
+      ~metric:`Sharpe ~min_spread:Rescore.default_min_spread
+  in
+  assert_that report
+    (all_of
+       [
+         field
+           (fun (r : Rescore.report) -> r.spread)
+           (float_equal ~epsilon:_epsilon 0.5);
+         field (fun (r : Rescore.report) -> r.verdict) (equal_to Rescore.Fail);
+       ])
+
+(** Strictly-greater contract: spread == min_spread → Fail (not Pass). The plan
+    §M1 T1.5 acceptance gate is "spread > 5× 0.81", a strict inequality. *)
+let test_build_report_exactly_at_threshold_fails _ =
+  let input = _make_synthetic_input [ 0.0; 2.0 ] in
+  let baseline_actuals = _baseline_actuals () in
+  let report =
+    Rescore.build_report ~input ~baseline_fold_actuals:baseline_actuals
+      ~metric:`Sharpe ~min_spread:2.0
+  in
+  assert_that report
+    (all_of
+       [
+         field
+           (fun (r : Rescore.report) -> r.spread)
+           (float_equal ~epsilon:_epsilon 2.0);
+         field (fun (r : Rescore.report) -> r.verdict) (equal_to Rescore.Fail);
+       ])
+
+(** Empty input: zero candidates → spread 0 → Fail. The report still renders
+    successfully (does not raise). *)
+let test_build_report_empty_input_fails _ =
+  let input : Rescore.bo_rescore_input =
+    { schema_version = Rescore.current_schema_version; candidates = [] }
+  in
+  let baseline_actuals = _baseline_actuals () in
+  let report =
+    Rescore.build_report ~input ~baseline_fold_actuals:baseline_actuals
+      ~metric:`Sharpe ~min_spread:Rescore.default_min_spread
+  in
+  assert_that report
+    (all_of
+       [
+         field (fun (r : Rescore.report) -> r.candidates) (size_is 0);
+         field
+           (fun (r : Rescore.report) -> r.spread)
+           (float_equal ~epsilon:_epsilon 0.0);
+         field (fun (r : Rescore.report) -> r.verdict) (equal_to Rescore.Fail);
+       ])
+
+(* ---------- markdown rendering ---------- *)
+
+(** Verdict line + metric label + spread row appear in the markdown output. The
+    test is intentionally substring-based: the renderer's exact pixel layout is
+    allowed to drift (formatting, headers), but these three semantic anchors
+    must remain. *)
+let test_markdown_pass_contains_verdict_and_spread _ =
+  let input = _make_synthetic_input [ -1.0; 2.0; 4.0 ] in
+  let baseline_actuals = _baseline_actuals () in
+  let report =
+    Rescore.build_report ~input ~baseline_fold_actuals:baseline_actuals
+      ~metric:`Sharpe ~min_spread:Rescore.default_min_spread
+  in
+  let md = Rescore.report_to_markdown report ~metric:`Sharpe in
+  assert_bool "markdown contains PASS verdict"
+    (String.is_substring md ~substring:"PASS");
+  assert_bool "markdown contains metric label Sharpe"
+    (String.is_substring md ~substring:"Sharpe");
+  assert_bool "markdown contains spread value 5.000000"
+    (String.is_substring md ~substring:"5.000000");
+  assert_bool "markdown contains historical flat-surface anchor 0.81"
+    (String.is_substring md ~substring:"0.81")
+
+(** FAIL verdict surfaces in the markdown when the spread is below threshold. *)
+let test_markdown_fail_contains_fail_label _ =
+  let input = _make_synthetic_input [ 0.0; 0.5 ] in
+  let baseline_actuals = _baseline_actuals () in
+  let report =
+    Rescore.build_report ~input ~baseline_fold_actuals:baseline_actuals
+      ~metric:`Sharpe ~min_spread:Rescore.default_min_spread
+  in
+  let md = Rescore.report_to_markdown report ~metric:`Sharpe in
+  assert_bool "markdown contains FAIL verdict"
+    (String.is_substring md ~substring:"FAIL")
+
+(* ---------- file I/O round-trip ---------- *)
+
+(** Create a fresh per-test scratch path under the OUnit-provided directory.
+    OUnit's [bracket_tmpdir] would be the canonical choice, but the simple
+    [Filename_unix.temp_dir] is enough — the file content is overwritten on each
+    test invocation and the cleanup is left to the OS / next CI run. Used only
+    by the round-trip tests below. *)
+let _tmp_dir () = Filename_unix.temp_dir "rescore_test_" ""
+
+(** Round-trip a synthetic input + baseline via the public loaders. Pins the
+    on-disk shape: the schema_version is required and matches
+    [current_schema_version]; the baseline is a flat sexp list of fold_actuals
+    (matches the existing walk_forward_runner output shape). *)
+let test_sexp_round_trip _ =
+  let tmp = _tmp_dir () in
+  let input = _make_synthetic_input [ -1.0; 2.0; 4.0 ] in
+  let baseline = _baseline_actuals () in
+  let input_path = Filename.concat tmp "rescore_input.sexp" in
+  let baseline_path = Filename.concat tmp "baseline_fold_actuals.sexp" in
+  Out_channel.write_all input_path
+    ~data:(Sexp.to_string_hum (Rescore.sexp_of_bo_rescore_input input));
+  Out_channel.write_all baseline_path
+    ~data:
+      (Sexp.to_string_hum
+         (Sexp.List (List.map baseline ~f:Wf.sexp_of_fold_actual)));
+  let loaded_input = Rescore.load_input input_path in
+  let loaded_baseline = Rescore.load_baseline_fold_actuals baseline_path in
+  let report =
+    Rescore.build_report ~input:loaded_input
+      ~baseline_fold_actuals:loaded_baseline ~metric:`Sharpe
+      ~min_spread:Rescore.default_min_spread
+  in
+  assert_that report
+    (all_of
+       [
+         field
+           (fun (r : Rescore.report) -> r.spread)
+           (float_equal ~epsilon:_epsilon 5.0);
+         field (fun (r : Rescore.report) -> r.verdict) (equal_to Rescore.Pass);
+       ])
+
+(** load_input rejects a file with a different schema_version. Pins the
+    forward-compat contract: future shape drift must be deliberate. *)
+let test_load_input_rejects_schema_mismatch _ =
+  let tmp = _tmp_dir () in
+  let input_path = Filename.concat tmp "wrong_version.sexp" in
+  let wrong_version : Rescore.bo_rescore_input =
+    { schema_version = 999; candidates = [] }
+  in
+  Out_channel.write_all input_path
+    ~data:(Sexp.to_string_hum (Rescore.sexp_of_bo_rescore_input wrong_version));
+  let f () =
+    let _ = Rescore.load_input input_path in
+    ()
+  in
+  match
+    try
+      f ();
+      None
+    with
+    | Failure msg -> Some msg
+    | exn -> assert_failure ("expected Failure, got: " ^ Exn.to_string exn)
+  with
+  | None -> assert_failure "expected Failure on schema_version mismatch"
+  | Some msg ->
+      assert_bool
+        ("Failure message should mention schema_version mismatch: " ^ msg)
+        (String.is_substring msg ~substring:"schema_version")
+
+(** Discriminator dispatch: the [metric] argument is plumbed through to
+    [paired_delta]. Pins that the rescorer honours [`Total_return_pct]
+    correctly. *)
+let test_total_return_metric_dispatch _ =
+  let baseline =
+    [
+      _fold_actual ~fold_name:"f0" ~sharpe_ratio:0.5 ~total_return_pct:10.0 ();
+      _fold_actual ~fold_name:"f1" ~sharpe_ratio:1.0 ~total_return_pct:20.0 ();
+    ]
+  in
+  let cand : Rescore.candidate =
+    {
+      label = "tr-test";
+      parameters = [];
+      fold_actuals =
+        [
+          _fold_actual ~fold_name:"f0" ~sharpe_ratio:99.0 ~total_return_pct:15.0
+            ();
+          _fold_actual ~fold_name:"f1" ~sharpe_ratio:99.0 ~total_return_pct:30.0
+            ();
+        ];
+    }
+  in
+  let result =
+    Rescore.rescore_candidate cand ~baseline_fold_actuals:baseline
+      ~metric:`Total_return_pct
+  in
+  (* Δ on f0 = 5.0; Δ on f1 = 10.0; mean = 7.5. Sharpe noise (99.0) on
+     candidate must NOT corrupt the score — proves dispatch is correct. *)
+  assert_that result
+    (all_of
+       [
+         field
+           (fun (r : Rescore.candidate_rescore) -> r.mean_delta)
+           (float_equal ~epsilon:_epsilon 7.5);
+         field (fun (r : Rescore.candidate_rescore) -> r.n_matched) (equal_to 2);
+       ])
+
+let suite =
+  "Tuner_bin.Bayesian_runner_rescore"
+  >::: [
+         "spread_of basic" >:: test_spread_of_basic;
+         "spread_of empty" >:: test_spread_of_empty;
+         "spread_of singleton" >:: test_spread_of_singleton;
+         "default_min_spread = 5 * historical_flat_surface"
+         >:: test_default_min_spread_is_5x_historical;
+         "rescore_candidate identity → mean Δ = 0"
+         >:: test_rescore_candidate_identity;
+         "rescore_candidate constant offset → mean Δ = offset"
+         >:: test_rescore_candidate_constant_offset;
+         "rescore_candidate partial overlap drops mismatched folds"
+         >:: test_rescore_candidate_partial_overlap;
+         "rescore_candidate disjoint folds raises"
+         >:: test_rescore_candidate_disjoint_raises;
+         "build_report 3-candidate spread 5.0 → Pass"
+         >:: test_build_report_three_candidate_passes;
+         "build_report spread 0.5 < threshold → Fail"
+         >:: test_build_report_below_threshold_fails;
+         "build_report spread == threshold → Fail (strict >)"
+         >:: test_build_report_exactly_at_threshold_fails;
+         "build_report empty candidates → Fail"
+         >:: test_build_report_empty_input_fails;
+         "markdown PASS contains verdict + spread + 0.81 anchor"
+         >:: test_markdown_pass_contains_verdict_and_spread;
+         "markdown FAIL contains FAIL label"
+         >:: test_markdown_fail_contains_fail_label;
+         "sexp round-trip via public loaders" >:: test_sexp_round_trip;
+         "load_input rejects schema_version mismatch"
+         >:: test_load_input_rejects_schema_mismatch;
+         "metric=`Total_return_pct dispatch"
+         >:: test_total_return_metric_dispatch;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

M1 T1.5 — re-score v4/v6 checkpoints with paired-Δ. Implements the immediate consumer of the paired-Δ primitive merged in #1308 (M1 T1.3). The rescorer takes a `bo_rescore_input.sexp` (per-iteration parameters + per-fold actuals) and a Cell-E `fold_actuals.sexp`, computes per-fold Δ via `Bayesian_runner_scoring.paired_delta` for every candidate, and emits a markdown report with a PASS / FAIL verdict against the historical-flat-surface acceptance gate (default `4.05 = 5 × 0.81`).

Plan: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` §M1 T1.5.

## What landed

- **Lib** `Tuner_bin.Bayesian_runner_rescore` (156 LOC `.ml` / 193 LOC `.mli`) — pure helpers:
  - On-disk shapes: `bo_rescore_input` (schema_version + candidates) and `candidate` (label + parameters + fold_actuals).
  - `load_input` / `load_baseline_fold_actuals` — file loaders with schema_version guard.
  - `rescore_candidate` — single-candidate paired-Δ.
  - `spread_of` — max − min helper (total on empty input).
  - `build_report` — full re-score with verdict.
  - `report_to_markdown` — pure renderer.
  - Named constants: `historical_flat_surface = 0.81`, `flat_surface_multiplier = 5.0`, `default_min_spread = 4.05` (no magic numbers).
- **CLI** `rescore_checkpoints.exe` (147 LOC) — `--input` / `--baseline` / `--metric` (Sharpe | TotalReturn | Calmar | CAGR) / `--min-spread` / `--out`.
- **Tests** `test_bayesian_runner_rescore.ml` (17 cases, ~503 LOC): identity / constant-offset / partial-overlap / disjoint-raises / Total_return_pct dispatch / spread_of basic-empty-singleton / named-constants pin / Pass+Fail boundary cases / strict-greater contract / empty input / markdown verdict + 0.81 anchor / sexp round-trip via public loaders / schema_version mismatch rejected.
- **Procedure doc** `dev/notes/t1-5-rescore-procedure-2026-05-26.md` — local-only incantation, the gap explanation (production `bo_checkpoint.sexp` does NOT carry per-fold actuals — an upstream adapter is required, tracked as a follow-up).

## Reuses #1308

The rescorer is the immediate consumer of `Bayesian_runner_scoring.paired_delta`. The CLI does not re-implement that primitive — it calls into it directly. Per-fold matching is by `fold_name` (not positional), inherited via the lib call.

## Why an "enriched input file" shape

The production `bo_checkpoint.sexp` (per `Bayesian_runner_runner._checkpoint`) only stores per-iter aggregate score + a synthetic walk-forward metric_set; it does NOT persist per-fold `fold_actual` lists. T1.5 therefore reads from an enriched companion file `bo_rescore_input.sexp` (new shape; documented in the lib's `.mli` § "Input file shape"). Producing this file from the production sweep is a documented follow-up — out of scope per the dispatch's option (a): "synthetic fixtures only, production data is local-only".

## Test plan

- [x] `dune build` — clean.
- [x] `dune build @fmt` — clean (formatter applied via `--auto-promote`).
- [x] `dune runtest trading/backtest/tuner/` — 238 tests pass (17 new + 221 existing across the tuner directory).
- [x] No magic numbers (verified via `devtools/checks/linter_magic_numbers.sh`).
- [x] All functions < 50 lines (manually verified).
- [x] `.mli` covers every public symbol with a docstring.
- [ ] **Local-only:** operator runs the exe against v4/v6 production data once an upstream adapter produces the enriched input file. Verdict goes to `dev/notes/t1-5-rescore-verdict-<date>.md`. The plan §M1 T1.5 acceptance claim ("v4+v6 data on paired-Δ shows >5× wider spread") is verified at that point.

## Dispatch context

🤖 Dispatched by GHA orchestrator. Per the dispatch's option (a): generate synthetic fixtures of the correct shape to validate the `paired_delta` plumbing end-to-end, document the production run as a local-only step. Both done.

Run ID: 26453609310
