### PR TITLE
feat(tuning): M1 T1.4 — proxy-fidelity calibration exe + Spearman ρ helper

### DIFF
--- a/dev/notes/t1-4-calibration-procedure-2026-05-26.md
+++ b/dev/notes/t1-4-calibration-procedure-2026-05-26.md
@@ -1,0 +1,120 @@
+# T1.4 — Proxy-fidelity calibration procedure
+
+Owner: feat-backtest (track: `tuning`).
+Plan: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` §M1 T1.4.
+
+## What the calibrator does
+
+`proxy_calibration.exe` (built at
+`trading/trading/backtest/tuner/bin/proxy_calibration.ml`) consumes two
+`fold_actuals.sexp` files produced by `walk_forward_runner.exe` — one for
+the cheap (e.g. 6-fold) walk-forward spec and one for the expensive (e.g.
+26-fold) spec. Both runs should evaluate Cell E on the same base scenario;
+the cheap fold layout is expected to be a subset of the expensive one (so
+matching fold-names share a market regime).
+
+For each fold whose `fold_name` appears in both inputs (after filtering to
+the requested `variant_label`, default `cell-E`), the exe projects a chosen
+per-fold metric (default `sharpe_ratio`) into a paired observation. It then
+computes the Spearman rank correlation between the cheap and expensive
+sequences. The verdict is **PASS** iff `ρ ≥ threshold` (default `0.7` per
+plan §M1 T1.4 acceptance row).
+
+Output is a self-contained markdown report with the matched-fold count, the
+ρ value, the verdict, and a per-fold table for inspection. Exit code is
+`0` on PASS, `1` on FAIL — so a CI gate can branch on the verdict directly.
+
+## Why fold_actuals.sexp, not aggregate.sexp
+
+The dispatch text loosely referred to "aggregate.sexp" but Spearman ρ
+requires per-fold samples. The `aggregate.sexp` file carries cross-fold
+summary stats only (mean / stdev / min / max). The sibling `fold_actuals.sexp`
+artefact (written by `Walk_forward.Walk_forward_runner._write_fold_actuals`)
+carries the per-fold rows we need.
+
+## CLI surface
+
+```bash
+proxy_calibration.exe \
+  --cheap <path-to-cheap/fold_actuals.sexp> \
+  --expensive <path-to-expensive/fold_actuals.sexp> \
+  [--metric sharpe|totalreturn|calmar|cagr|maxdrawdown] \
+  [--threshold <float>] \
+  [--variant <label>] \
+  [--out <markdown_path>]
+```
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--cheap` | (required) | path to cheap walk-forward `fold_actuals.sexp` |
+| `--expensive` | (required) | path to expensive walk-forward `fold_actuals.sexp` |
+| `--metric` | `sharpe` | metric column to correlate; accepts `sharpe`/`totalreturn`/`calmar`/`cagr`/`maxdrawdown` (case-insensitive, hyphens or underscores OK) |
+| `--threshold` | `0.7` | acceptance threshold for ρ |
+| `--variant` | `cell-E` | variant_label filter; both inputs are restricted before joining (multi-variant `fold_actuals.sexp` files otherwise produce non-deterministic last-writer-wins joins) |
+| `--out` | (stdout) | optional markdown report path |
+
+## Local-only production run
+
+The v6 / v4 production sweep `fold_actuals.sexp` files are NOT accessible
+in GHA. They live on the maintainer's local machine under:
+
+```
+/Users/difan/Projects/trading-1/.sweep-output/v6-11knob/<cell-name>/fold_actuals.sexp
+/Users/difan/Projects/trading-1/.sweep-output/v4-9knob/<cell-name>/fold_actuals.sexp
+```
+
+The canonical T1.4 calibration runs Cell E on:
+
+- the **cheap proxy** — the 6-fold subset spec used in the BO inner loop; and
+- the **expensive set** — the 26-fold full-history spec used for promote-gate
+  validation.
+
+To produce both inputs (one-time pre-flight before T1.4 calibration), run
+`walk_forward_runner.exe` against the cheap spec and the expensive spec for
+Cell E's parameter assignment. Each produces a `fold_actuals.sexp` in its
+output directory.
+
+Then point the calibrator at both:
+
+```bash
+docker exec trading-1-dev bash -c \
+  "cd /workspaces/trading-1/trading && eval \$(opam env) && \
+   dune exec --no-build trading/backtest/tuner/bin/proxy_calibration.exe -- \
+     --cheap /path/to/cheap-6fold/fold_actuals.sexp \
+     --expensive /path/to/expensive-26fold/fold_actuals.sexp \
+     --metric sharpe \
+     --threshold 0.7 \
+     --variant cell-E \
+     --out /tmp/t1-4-calibration-verdict.md"
+```
+
+The exe will emit a one-line `eprintf` summary
+(`matched=N rho=X.XXXXXX threshold=0.7000 verdict=PASS|FAIL`) to stderr and
+the full markdown to the `--out` file (or stdout if omitted). Exit code is
+the verdict.
+
+## Where the verdict goes
+
+When the local operator runs the calibrator against real cheap/expensive
+fold_actuals data, the verdict goes to
+`dev/notes/t1-4-calibration-verdict-<YYYY-MM-DD>.md`. The verdict file
+should record:
+
+- which cheap and expensive specs were used (paths + fold counts);
+- which metric was correlated (Sharpe is the default; CAGR and MaxDD are
+  also worth recording for a sanity-check column);
+- the calibrator's `eprintf` summary line (`matched=N rho=X.XXXXXX
+  threshold=0.7000 verdict=PASS|FAIL`);
+- the full markdown report inline (or as an attachment);
+- the verdict — PASS unblocks T1.2 successive-halving (the cheap tier is
+  a faithful proxy for the expensive); FAIL means the cheap proxy must
+  be redesigned (e.g. wider fold span or different fold selection).
+
+## Acceptance criterion (plan §M1 T1.4)
+
+> Cell E on the 6-fold cheap proxy vs the 26-fold expensive walk-forward
+> set; require **ρ ≥ 0.7** for the proxy to be acceptable.
+
+PASS at the local-only run unblocks downstream T1.2 successive-halving
+(which assumes the cheap-tier ranking is preserved at the expensive tier).
+FAIL pauses T1.2 until a better cheap-tier design is identified.

--- a/dev/status/tuning.md
+++ b/dev/status/tuning.md
@@ -208,13 +208,51 @@ verdict (random matches BO ⇒ surface is the bind, not the optimiser).
   is the immediate consumer (re-score v4+v6 on-disk checkpoints).
   Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest trading/backtest/tuner/bin/test/'`
   (33/33 pass).
-- [ ] **T1.4 — Calibration: proxy-fidelity correlation.** Owner:
+- [~] **T1.4 — Calibration: proxy-fidelity correlation.** Owner:
   feat-backtest. ~30 LOC OCaml exe computing Spearman ρ between Cell E
   on the 6-fold cheap proxy vs the 26-fold expensive walk-forward set;
   acceptance ρ ≥ 0.7. Spec: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md`
   §M1 T1.4. Branch: `feat/tuning/m1-t1-4-proxy-calibration`.
+
+  **Status 2026-05-26:** OCaml implementation + tests landed (PR
+  pending). New surface:
+  - `Tuner.Proxy_calibration_lib`
+    (`trading/trading/backtest/tuner/lib/proxy_calibration_lib.{ml,mli}`)
+    — pure-function Spearman ρ with mid-rank tie handling +
+    matched_pairs fold join with optional variant_label filter +
+    Pass/Fail classifier. 18 unit tests (identical/reverse/known/ties/
+    length-mismatch/empty/single/zero-variance for spearman_rho, plus
+    subset/disjoint/metric-dispatch/variant-filter for matched_pairs +
+    end-to-end PASS/FAIL + classify boundary/below/NaN).
+  - `Tuner_bin.Proxy_calibration_runner`
+    (`trading/trading/backtest/tuner/bin/proxy_calibration_runner.{ml,mli}`)
+    — CLI arg parser + fold_actuals.sexp loader + markdown renderer +
+    end-to-end orchestrator. 14 unit tests (metric parsing recognised/
+    unknown, arg-parsing required-only/all-flags/missing/unknown,
+    sexp load round-trip/missing, markdown render PASS/FAIL, end-to-end
+    PASS/FAIL/multi-variant-filtered/disjoint-raises).
+  - Thin executable `trading/trading/backtest/tuner/bin/proxy_calibration.exe`
+    — wraps `Proxy_calibration_runner.main`. Exits 0 on PASS, 1 on FAIL
+    so a CI gate can branch on the verdict.
+  - Design note in `dev/notes/t1-4-calibration-procedure-2026-05-26.md`
+    documents the local-only production-run incantation (cheap +
+    expensive `fold_actuals.sexp` paths under
+    `/Users/difan/Projects/trading-1/.sweep-output/`) and where the
+    verdict file lands. Reads `fold_actuals.sexp`, NOT `aggregate.sexp`
+    (the aggregate carries only cross-fold means; Spearman requires
+    per-fold samples).
+
+  **Remaining work (local-only):** run Cell E through the 6-fold cheap
+  walk-forward spec and the 26-fold expensive walk-forward spec on the
+  maintainer's machine, then point
+  `proxy_calibration.exe --cheap ... --expensive ...` at the two
+  `fold_actuals.sexp` outputs to produce the calibration verdict.
+  Write the verdict to `dev/notes/t1-4-calibration-verdict-<date>.md`
+  and flip this row to `[x]`.
+
+  Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune runtest trading/backtest/tuner/ --force'` (215+18+14 new pass).
 - [~] **T1.5 — Re-score v4/v6 checkpoints with paired-Δ.** Owner:
-  feat-backtest. PR OPEN on branch `feat/tuning/m1-t1-5-rescore-checkpoints`.
+  feat-backtest. MERGED #1328 on branch `feat/tuning/m1-t1-5-rescore-checkpoints`.
   Surface (per option (a) in the original dispatch — synthetic fixtures
   only, production data is local-only):
   - **Lib** `Tuner_bin.Bayesian_runner_rescore` (.ml 156 LOC / .mli 175 LOC)

--- a/trading/trading/backtest/tuner/bin/dune
+++ b/trading/trading/backtest/tuner/bin/dune
@@ -11,7 +11,8 @@
   bayesian_runner_scoring
   bayesian_runner_successive_halving
   bayesian_runner_oos_validator
-  bayesian_runner_out_dir_check)
+  bayesian_runner_out_dir_check
+  proxy_calibration_runner)
  (libraries
   core
   core_unix
@@ -47,3 +48,8 @@
  (name rescore_checkpoints)
  (modules rescore_checkpoints)
  (libraries core tuner_bin))
+
+(executable
+ (name proxy_calibration)
+ (modules proxy_calibration)
+ (libraries tuner_bin))

--- a/trading/trading/backtest/tuner/bin/proxy_calibration.ml
+++ b/trading/trading/backtest/tuner/bin/proxy_calibration.ml
@@ -1,0 +1,6 @@
+(** Thin executable wrapper around {!Tuner_bin.Proxy_calibration_runner.main}.
+
+    See the runner module for the substantive logic and the CLI flag
+    documentation. *)
+
+let () = Tuner_bin.Proxy_calibration_runner.main ()

--- a/trading/trading/backtest/tuner/bin/proxy_calibration.mli
+++ b/trading/trading/backtest/tuner/bin/proxy_calibration.mli
@@ -1,0 +1,86 @@
+(** CLI entry point for the M1 T1.4 proxy-fidelity calibration step.
+
+    Reads two on-disk [fold_actuals.sexp] files (cheap-proxy and expensive
+    walk-forward runs of Cell E), joins by [fold_name], computes the Spearman
+    rank correlation of a chosen per-fold metric, and emits a verdict against
+    the {!Tuner.Proxy_calibration_lib.acceptance_threshold} (default [0.7]).
+
+    {b Why [fold_actuals.sexp], not [aggregate.sexp].} The aggregate carries
+    only cross-fold summary statistics (mean / stdev / min / max per metric);
+    Spearman ρ between cheap and expensive requires the per-fold sample lists,
+    which live in [fold_actuals.sexp] (the sibling artefact written by
+    {!Walk_forward_runner.main}). See
+    `dev/notes/t1-4-calibration-procedure-<date>.md` for the operator's
+    incantation.
+
+    Spec: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md`
+    §M1 T1.4. *)
+
+type metric_arg = Sharpe | TotalReturn | Calmar | CAGR | MaxDrawdown
+[@@deriving show, eq]
+(** CLI-visible metric selector. The CamelCased constructors are matched
+    case-insensitively against the [--metric] argument. *)
+
+val metric_arg_of_string : string -> metric_arg
+(** Parse a CLI [--metric] argument. Accepts the four token aliases (case
+    insensitive): [sharpe], [totalreturn] / [total_return] / [total-return],
+    [calmar], [cagr], [maxdrawdown] / [max_drawdown] / [max-drawdown].
+
+    @raise Failure on unrecognised metric. *)
+
+val metric_arg_to_lib :
+  metric_arg ->
+  [ `Sharpe | `Total_return_pct | `Calmar | `CAGR | `Max_drawdown_pct ]
+(** Adapter: maps {!metric_arg} to the polymorphic-variant input shape that
+    {!Tuner.Proxy_calibration_lib.matched_pairs} expects. *)
+
+type cli_args = {
+  cheap_path : string;
+      (** Path to the cheap-proxy [fold_actuals.sexp] (e.g. the 6-fold run). *)
+  expensive_path : string;
+      (** Path to the expensive [fold_actuals.sexp] (e.g. the 26-fold run). *)
+  metric : metric_arg;  (** Default [Sharpe]. *)
+  threshold : float;
+      (** Acceptance threshold for ρ. Default
+          {!Tuner.Proxy_calibration_lib.acceptance_threshold} (= 0.7). *)
+  out_path : string option;
+      (** Optional markdown report path; [None] = print to stdout. *)
+}
+[@@deriving show, eq]
+
+val parse_args : string list -> cli_args
+(** Parse a [Sys.get_argv |> Array.to_list |> List.tl] arg list into the
+    structured {!cli_args}. Recognised flags:
+
+    - [--cheap <path>] (required)
+    - [--expensive <path>] (required)
+    - [--metric sharpe|totalreturn|calmar|cagr|maxdrawdown] (default [sharpe])
+    - [--threshold <float>] (default {!Tuner.Proxy_calibration_lib.acceptance_threshold})
+    - [--out <path>] (optional)
+
+    @raise Failure on missing required flags, unknown flags, or malformed
+      values. *)
+
+val load_fold_actuals :
+  string -> Walk_forward.Walk_forward_types.fold_actual list
+(** Load a [fold_actuals.sexp] file produced by {!Walk_forward_runner}. The
+    on-disk shape is a [Sexp.List] of [fold_actual_of_sexp]-shaped records.
+
+    @raise Failure with a contextualised message when the file is missing or
+      the sexp doesn't parse. *)
+
+val render_markdown :
+  cheap_path:string ->
+  expensive_path:string ->
+  metric:metric_arg ->
+  threshold:float ->
+  pairs:Tuner.Proxy_calibration_lib.fold_pair list ->
+  rho:float ->
+  verdict:Tuner.Proxy_calibration_lib.verdict ->
+  string
+(** Render the calibration result as a self-contained markdown report.
+    Deterministic — same inputs produce byte-identical output. *)
+
+val main : unit -> unit
+(** Standard executable entry point. Exits with status [0] on PASS and [1] on
+    FAIL so CI gates can branch on the verdict. *)

--- a/trading/trading/backtest/tuner/bin/proxy_calibration_runner.ml
+++ b/trading/trading/backtest/tuner/bin/proxy_calibration_runner.ml
@@ -1,0 +1,201 @@
+open Core
+module PC = Tuner.Proxy_calibration_lib
+module Wf = Walk_forward.Walk_forward_types
+
+(* ----------------- metric_arg ---------------------------------------- *)
+
+type metric_arg = Sharpe | TotalReturn | Calmar | CAGR | MaxDrawdown
+[@@deriving show, eq]
+
+let default_variant_label = "cell-E"
+
+let _usage_msg =
+  "Usage: proxy_calibration.exe --cheap <fold_actuals.sexp> --expensive \
+   <fold_actuals.sexp> [--metric sharpe|totalreturn|calmar|cagr|maxdrawdown] \
+   [--threshold <float>] [--variant <label>] [--out <markdown_path>]"
+
+let metric_arg_of_string s =
+  match String.lowercase s with
+  | "sharpe" -> Sharpe
+  | "totalreturn" | "total_return" | "total-return" -> TotalReturn
+  | "calmar" -> Calmar
+  | "cagr" -> CAGR
+  | "maxdrawdown" | "max_drawdown" | "max-drawdown" -> MaxDrawdown
+  | other -> failwith (Printf.sprintf "unknown metric: %S" other)
+
+let metric_arg_to_lib = function
+  | Sharpe -> `Sharpe
+  | TotalReturn -> `Total_return_pct
+  | Calmar -> `Calmar
+  | CAGR -> `CAGR
+  | MaxDrawdown -> `Max_drawdown_pct
+
+let metric_label = function
+  | Sharpe -> "sharpe_ratio"
+  | TotalReturn -> "total_return_pct"
+  | Calmar -> "calmar_ratio"
+  | CAGR -> "cagr_pct"
+  | MaxDrawdown -> "max_drawdown_pct"
+
+(* ----------------- cli_args ------------------------------------------ *)
+
+type cli_args = {
+  cheap_path : string;
+  expensive_path : string;
+  metric : metric_arg;
+  threshold : float;
+  variant_label : string;
+  out_path : string option;
+}
+[@@deriving show, eq]
+
+let _min_matched_folds = 2
+
+let parse_args (argv : string list) : cli_args =
+  let rec loop cheap expensive metric threshold variant out_path = function
+    | [] -> (
+        match (cheap, expensive) with
+        | Some c, Some e ->
+            {
+              cheap_path = c;
+              expensive_path = e;
+              metric = Option.value metric ~default:Sharpe;
+              threshold =
+                Option.value threshold ~default:PC.acceptance_threshold;
+              variant_label =
+                Option.value variant ~default:default_variant_label;
+              out_path;
+            }
+        | _ ->
+            failwith
+              ("proxy_calibration: --cheap and --expensive are required; "
+             ^ _usage_msg))
+    | "--cheap" :: p :: rest ->
+        loop (Some p) expensive metric threshold variant out_path rest
+    | "--expensive" :: p :: rest ->
+        loop cheap (Some p) metric threshold variant out_path rest
+    | "--metric" :: m :: rest ->
+        loop cheap expensive
+          (Some (metric_arg_of_string m))
+          threshold variant out_path rest
+    | "--threshold" :: t :: rest ->
+        loop cheap expensive metric
+          (Some (Float.of_string t))
+          variant out_path rest
+    | "--variant" :: v :: rest ->
+        loop cheap expensive metric threshold (Some v) out_path rest
+    | "--out" :: p :: rest ->
+        loop cheap expensive metric threshold variant (Some p) rest
+    | ("--help" | "-h") :: _ ->
+        printf "%s\n" _usage_msg;
+        Stdlib.exit 0
+    | unknown :: _ ->
+        failwith (Printf.sprintf "unknown argument: %S\n%s" unknown _usage_msg)
+  in
+  loop None None None None None None argv
+
+(* ----------------- I/O ----------------------------------------------- *)
+
+let load_fold_actuals (path : string) : Wf.fold_actual list =
+  if not (Sys_unix.file_exists_exn path) then
+    failwith (Printf.sprintf "fold_actuals file not found: %s" path)
+  else
+    let sexp = Sexp.load_sexp path in
+    match sexp with
+    | List items -> List.map items ~f:Wf.fold_actual_of_sexp
+    | _ ->
+        failwith
+          (Printf.sprintf
+             "fold_actuals file %s: top-level sexp must be a list, got an atom"
+             path)
+
+(* ----------------- markdown rendering --------------------------------- *)
+
+let _format_pair_row (p : PC.fold_pair) : string =
+  Printf.sprintf "| %s | %.6f | %.6f | %.6f |" p.fold_name p.cheap p.expensive
+    (p.cheap -. p.expensive)
+
+let render_markdown ~(cheap_path : string) ~(expensive_path : string)
+    ~(metric : metric_arg) ~(threshold : float) ~(variant_label : string)
+    ~(pairs : PC.fold_pair list) ~(rho : float) ~(verdict : PC.verdict) : string
+    =
+  let n = List.length pairs in
+  let verdict_str =
+    match verdict with PC.Pass -> "PASS" | PC.Fail -> "FAIL"
+  in
+  let header =
+    Printf.sprintf
+      "# Proxy-fidelity calibration\n\n\
+       - **Cheap proxy:** `%s`\n\
+       - **Expensive set:** `%s`\n\
+       - **Variant:** `%s`\n\
+       - **Metric:** `%s`\n\
+       - **Threshold:** %.4f\n\
+       - **Matched folds:** %d\n\
+       - **Spearman ρ:** %.6f\n\
+       - **Verdict:** %s\n\n"
+      cheap_path expensive_path variant_label (metric_label metric) threshold n
+      rho verdict_str
+  in
+  let table_header =
+    "| fold_name | cheap | expensive | Δ (cheap - expensive) |\n\
+     |-----------|-------|-----------|-----------------------|\n"
+  in
+  let table_body =
+    String.concat ~sep:"\n" (List.map pairs ~f:_format_pair_row)
+  in
+  header ^ table_header ^ table_body ^ "\n"
+
+(* ----------------- run + main ----------------------------------------- *)
+
+type run_result = {
+  pairs : PC.fold_pair list;
+  rho : float;
+  verdict : PC.verdict;
+  report : string;
+}
+
+let run_calibration (args : cli_args) : run_result =
+  let cheap = load_fold_actuals args.cheap_path in
+  let expensive = load_fold_actuals args.expensive_path in
+  let pairs =
+    PC.matched_pairs ~variant_label:args.variant_label ~cheap_actuals:cheap
+      ~expensive_actuals:expensive
+      ~metric:(metric_arg_to_lib args.metric)
+      ()
+  in
+  let n = List.length pairs in
+  if n < _min_matched_folds then
+    failwith
+      (Printf.sprintf
+         "proxy_calibration: need >=%d matched folds (got %d) — cheap and \
+          expensive runs must share fold_names for variant_label=%S"
+         _min_matched_folds n args.variant_label);
+  let xs = List.map pairs ~f:(fun p -> p.cheap) |> Array.of_list in
+  let ys = List.map pairs ~f:(fun p -> p.expensive) |> Array.of_list in
+  let rho = PC.spearman_rho xs ys in
+  let verdict = PC.classify ~threshold:args.threshold ~rho in
+  let report =
+    render_markdown ~cheap_path:args.cheap_path
+      ~expensive_path:args.expensive_path ~metric:args.metric
+      ~threshold:args.threshold ~variant_label:args.variant_label ~pairs ~rho
+      ~verdict
+  in
+  { pairs; rho; verdict; report }
+
+let main () =
+  let argv = Sys.get_argv () |> Array.to_list |> List.tl_exn in
+  let args = parse_args argv in
+  let result = run_calibration args in
+  eprintf
+    "[proxy_calibration] matched=%d rho=%.6f threshold=%.4f verdict=%s\n%!"
+    (List.length result.pairs) result.rho args.threshold
+    (match result.verdict with PC.Pass -> "PASS" | PC.Fail -> "FAIL");
+  (match args.out_path with
+  | None -> printf "%s" result.report
+  | Some p ->
+      Out_channel.write_all p ~data:result.report;
+      eprintf "[proxy_calibration] wrote %s\n%!" p);
+  match result.verdict with
+  | PC.Pass -> Stdlib.exit 0
+  | PC.Fail -> Stdlib.exit 1

--- a/trading/trading/backtest/tuner/bin/proxy_calibration_runner.mli
+++ b/trading/trading/backtest/tuner/bin/proxy_calibration_runner.mli
@@ -1,4 +1,6 @@
-(** CLI entry point for the M1 T1.4 proxy-fidelity calibration step.
+(** Logic for the M1 T1.4 proxy-fidelity calibration CLI, factored out of the
+    thin executable {!Proxy_calibration} so the pure helpers (arg parsing, sexp
+    loading, markdown rendering) can be unit-tested.
 
     Reads two on-disk [fold_actuals.sexp] files (cheap-proxy and expensive
     walk-forward runs of Cell E), joins by [fold_name], computes the Spearman
@@ -13,16 +15,16 @@
     `dev/notes/t1-4-calibration-procedure-<date>.md` for the operator's
     incantation.
 
-    Spec: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md`
-    §M1 T1.4. *)
+    Spec: `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` §M1 T1.4.
+*)
 
-type metric_arg = Sharpe | TotalReturn | Calmar | CAGR | MaxDrawdown
-[@@deriving show, eq]
 (** CLI-visible metric selector. The CamelCased constructors are matched
     case-insensitively against the [--metric] argument. *)
+type metric_arg = Sharpe | TotalReturn | Calmar | CAGR | MaxDrawdown
+[@@deriving show, eq]
 
 val metric_arg_of_string : string -> metric_arg
-(** Parse a CLI [--metric] argument. Accepts the four token aliases (case
+(** Parse a CLI [--metric] argument. Accepts the five token aliases (case
     insensitive): [sharpe], [totalreturn] / [total_return] / [total-return],
     [calmar], [cagr], [maxdrawdown] / [max_drawdown] / [max-drawdown].
 
@@ -34,6 +36,15 @@ val metric_arg_to_lib :
 (** Adapter: maps {!metric_arg} to the polymorphic-variant input shape that
     {!Tuner.Proxy_calibration_lib.matched_pairs} expects. *)
 
+val metric_label : metric_arg -> string
+(** Map a [metric_arg] to its {!Walk_forward.Walk_forward_types.fold_actual}
+    field name. Used in markdown rendering for traceability. *)
+
+val default_variant_label : string
+(** [default_variant_label = "cell-E"]. Per plan §M1 T1.4, the calibration is
+    always run on Cell E's per-fold actuals; the default keeps the CLI ergonomic
+    while still surfacing the variant in error messages. *)
+
 type cli_args = {
   cheap_path : string;
       (** Path to the cheap-proxy [fold_actuals.sexp] (e.g. the 6-fold run). *)
@@ -43,8 +54,11 @@ type cli_args = {
   threshold : float;
       (** Acceptance threshold for ρ. Default
           {!Tuner.Proxy_calibration_lib.acceptance_threshold} (= 0.7). *)
+  variant_label : string;
+      (** Variant the fold_actuals files are filtered to before joining. Default
+          {!default_variant_label}. *)
   out_path : string option;
-      (** Optional markdown report path; [None] = print to stdout. *)
+      (** Optional markdown report path; [None] = stdout. *)
 }
 [@@deriving show, eq]
 
@@ -55,25 +69,29 @@ val parse_args : string list -> cli_args
     - [--cheap <path>] (required)
     - [--expensive <path>] (required)
     - [--metric sharpe|totalreturn|calmar|cagr|maxdrawdown] (default [sharpe])
-    - [--threshold <float>] (default {!Tuner.Proxy_calibration_lib.acceptance_threshold})
-    - [--out <path>] (optional)
+    - [--threshold <float>] (default
+      {!Tuner.Proxy_calibration_lib.acceptance_threshold})
+    - [--variant <label>] (default {!default_variant_label})
+    - [--out <path>] (optional; absent ⇒ stdout)
 
-    @raise Failure on missing required flags, unknown flags, or malformed
-      values. *)
+    @raise Failure
+      on missing required flags, unknown flags, or malformed values. *)
 
 val load_fold_actuals :
   string -> Walk_forward.Walk_forward_types.fold_actual list
 (** Load a [fold_actuals.sexp] file produced by {!Walk_forward_runner}. The
     on-disk shape is a [Sexp.List] of [fold_actual_of_sexp]-shaped records.
 
-    @raise Failure with a contextualised message when the file is missing or
-      the sexp doesn't parse. *)
+    @raise Failure
+      with a contextualised message when the file is missing or the sexp doesn't
+      parse. *)
 
 val render_markdown :
   cheap_path:string ->
   expensive_path:string ->
   metric:metric_arg ->
   threshold:float ->
+  variant_label:string ->
   pairs:Tuner.Proxy_calibration_lib.fold_pair list ->
   rho:float ->
   verdict:Tuner.Proxy_calibration_lib.verdict ->
@@ -81,6 +99,25 @@ val render_markdown :
 (** Render the calibration result as a self-contained markdown report.
     Deterministic — same inputs produce byte-identical output. *)
 
+type run_result = {
+  pairs : Tuner.Proxy_calibration_lib.fold_pair list;
+  rho : float;
+  verdict : Tuner.Proxy_calibration_lib.verdict;
+  report : string;
+}
+(** Structured result returned by {!run_calibration}. The [report] field is the
+    fully-rendered markdown the caller may write to disk or stdout. *)
+
+val run_calibration : cli_args -> run_result
+(** Pure orchestration: load the two fold_actuals files, project the chosen
+    metric, compute ρ + verdict, and render the markdown report. Performs
+    filesystem reads (load) but no writes.
+
+    @raise Failure
+      when matched-fold count is [< 2] (correlation with a single point is
+      ill-defined). *)
+
 val main : unit -> unit
-(** Standard executable entry point. Exits with status [0] on PASS and [1] on
-    FAIL so CI gates can branch on the verdict. *)
+(** Standard executable entry point. Parses argv, runs {!run_calibration},
+    writes the rendered report (to [--out] or stdout), and exits with status [0]
+    on PASS or [1] on FAIL so CI gates can branch on the verdict. *)

--- a/trading/trading/backtest/tuner/bin/test/dune
+++ b/trading/trading/backtest/tuner/bin/test/dune
@@ -6,7 +6,8 @@
   test_bayesian_runner_scoring
   test_bayesian_runner_evaluator
   test_bayesian_runner_oos_validator
-  test_bayesian_runner_successive_halving)
+  test_bayesian_runner_successive_halving
+  test_proxy_calibration_runner)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/tuner/bin/test/test_proxy_calibration_runner.ml
+++ b/trading/trading/backtest/tuner/bin/test/test_proxy_calibration_runner.ml
@@ -1,0 +1,423 @@
+(** Unit tests for {!Tuner_bin.Proxy_calibration_runner}. Pin the CLI-arg
+    parser, sexp loader, markdown renderer, and the end-to-end orchestrator
+    against synthetic fold_actuals fixtures written to a temp dir.
+
+    No real walk-forward run is invoked — the pure-math primitive
+    {!Tuner.Proxy_calibration_lib.spearman_rho} is exercised in its own sibling
+    test suite. *)
+
+open OUnit2
+open Core
+open Matchers
+module PCR = Tuner_bin.Proxy_calibration_runner
+module PC = Tuner.Proxy_calibration_lib
+module Wf = Walk_forward.Walk_forward_types
+
+(* ---------- temp-dir helper (mirrors test_grid_search_bin.ml) ---------- *)
+
+let _with_temp_dir f =
+  let dir =
+    Filename_unix.temp_dir ~in_dir:Filename.temp_dir_name
+      "proxy_calibration_test_" ""
+  in
+  Exn.protect
+    ~f:(fun () -> f dir)
+    ~finally:(fun () ->
+      let rec rm_tree p =
+        if Sys_unix.is_directory_exn p then begin
+          Sys_unix.readdir p
+          |> Array.iter ~f:(fun child -> rm_tree (Filename.concat p child));
+          Core_unix.rmdir p
+        end
+        else Core_unix.unlink p
+      in
+      try rm_tree dir with _ -> ())
+
+(* ---------- fixture writer --------------------------------------------- *)
+
+let _fold_actual ?(variant_label = "cell-E") ?(total_return_pct = Float.nan)
+    ?(sharpe_ratio = Float.nan) ?(max_drawdown_pct = Float.nan)
+    ?(calmar_ratio = Float.nan) ?(cagr_pct = Float.nan)
+    ?(avg_holding_days = Float.nan) ~fold_name () : Wf.fold_actual =
+  {
+    fold_name;
+    variant_label;
+    total_return_pct;
+    sharpe_ratio;
+    max_drawdown_pct;
+    calmar_ratio;
+    cagr_pct;
+    avg_holding_days;
+  }
+
+let _write_fold_actuals path (actuals : Wf.fold_actual list) =
+  let sexp = Sexp.List (List.map actuals ~f:Wf.sexp_of_fold_actual) in
+  Sexp.save_hum path sexp
+
+(* ---------- metric_arg_of_string -------------------------------------- *)
+
+let test_metric_arg_of_string_recognised _ =
+  assert_that
+    (PCR.metric_arg_of_string "sharpe")
+    (equal_to (PCR.Sharpe : PCR.metric_arg));
+  assert_that
+    (PCR.metric_arg_of_string "SHARPE")
+    (equal_to (PCR.Sharpe : PCR.metric_arg));
+  assert_that
+    (PCR.metric_arg_of_string "totalreturn")
+    (equal_to (PCR.TotalReturn : PCR.metric_arg));
+  assert_that
+    (PCR.metric_arg_of_string "total_return")
+    (equal_to (PCR.TotalReturn : PCR.metric_arg));
+  assert_that
+    (PCR.metric_arg_of_string "total-return")
+    (equal_to (PCR.TotalReturn : PCR.metric_arg));
+  assert_that
+    (PCR.metric_arg_of_string "calmar")
+    (equal_to (PCR.Calmar : PCR.metric_arg));
+  assert_that
+    (PCR.metric_arg_of_string "CAGR")
+    (equal_to (PCR.CAGR : PCR.metric_arg));
+  assert_that
+    (PCR.metric_arg_of_string "maxdrawdown")
+    (equal_to (PCR.MaxDrawdown : PCR.metric_arg))
+
+let test_metric_arg_of_string_unknown_raises _ =
+  let f () =
+    let _ = PCR.metric_arg_of_string "bogus" in
+    ()
+  in
+  assert_raises (Failure "unknown metric: \"bogus\"") f
+
+(* ---------- parse_args ------------------------------------------------- *)
+
+let test_parse_args_required_only _ =
+  let args =
+    PCR.parse_args [ "--cheap"; "/c.sexp"; "--expensive"; "/e.sexp" ]
+  in
+  assert_that args
+    (equal_to
+       ({
+          PCR.cheap_path = "/c.sexp";
+          expensive_path = "/e.sexp";
+          metric = PCR.Sharpe;
+          threshold = PC.acceptance_threshold;
+          variant_label = PCR.default_variant_label;
+          out_path = None;
+        }
+         : PCR.cli_args))
+
+let test_parse_args_all_flags _ =
+  let args =
+    PCR.parse_args
+      [
+        "--cheap";
+        "/c.sexp";
+        "--expensive";
+        "/e.sexp";
+        "--metric";
+        "calmar";
+        "--threshold";
+        "0.85";
+        "--variant";
+        "custom-cell";
+        "--out";
+        "/tmp/r.md";
+      ]
+  in
+  assert_that args
+    (equal_to
+       ({
+          PCR.cheap_path = "/c.sexp";
+          expensive_path = "/e.sexp";
+          metric = PCR.Calmar;
+          threshold = 0.85;
+          variant_label = "custom-cell";
+          out_path = Some "/tmp/r.md";
+        }
+         : PCR.cli_args))
+
+let _assert_raises_failure_containing f expected_substr =
+  try
+    f ();
+    assert_failure "expected Failure to be raised"
+  with Failure msg ->
+    if String.is_substring msg ~substring:expected_substr then ()
+    else
+      assert_failure
+        (Printf.sprintf "Failure message %S did not contain %S" msg
+           expected_substr)
+
+let test_parse_args_missing_cheap _ =
+  let f () =
+    let _ = PCR.parse_args [ "--expensive"; "/e.sexp" ] in
+    ()
+  in
+  _assert_raises_failure_containing f "--cheap and --expensive are required"
+
+let test_parse_args_unknown_flag _ =
+  let f () =
+    let _ =
+      PCR.parse_args
+        [ "--cheap"; "/c.sexp"; "--expensive"; "/e.sexp"; "--bogus"; "x" ]
+    in
+    ()
+  in
+  _assert_raises_failure_containing f "unknown argument"
+
+(* ---------- load_fold_actuals ----------------------------------------- *)
+
+let test_load_fold_actuals_round_trip _ =
+  _with_temp_dir (fun dir ->
+      let path = Filename.concat dir "fa.sexp" in
+      let actuals =
+        [
+          _fold_actual ~fold_name:"fold-000" ~sharpe_ratio:1.0
+            ~total_return_pct:10.0 ();
+          _fold_actual ~fold_name:"fold-001" ~sharpe_ratio:2.0
+            ~total_return_pct:20.0 ();
+        ]
+      in
+      _write_fold_actuals path actuals;
+      let loaded = PCR.load_fold_actuals path in
+      assert_that
+        (List.map loaded ~f:(fun fa -> fa.Wf.fold_name))
+        (elements_are [ equal_to "fold-000"; equal_to "fold-001" ]);
+      assert_that
+        (List.map loaded ~f:(fun fa -> fa.Wf.sharpe_ratio))
+        (elements_are [ float_equal 1.0; float_equal 2.0 ]))
+
+let test_load_fold_actuals_missing _ =
+  let f () =
+    let _ = PCR.load_fold_actuals "/nonexistent/path.sexp" in
+    ()
+  in
+  _assert_raises_failure_containing f "not found"
+
+(* ---------- render_markdown ------------------------------------------- *)
+
+let test_render_markdown_pass_verdict _ =
+  let pairs =
+    [
+      { PC.fold_name = "f0"; cheap = 1.0; expensive = 1.5 };
+      { PC.fold_name = "f1"; cheap = 2.0; expensive = 2.5 };
+    ]
+  in
+  let md =
+    PCR.render_markdown ~cheap_path:"/cheap.sexp" ~expensive_path:"/exp.sexp"
+      ~metric:PCR.Sharpe ~threshold:0.7 ~variant_label:"cell-E" ~pairs ~rho:0.95
+      ~verdict:PC.Pass
+  in
+  assert_bool "report contains PASS verdict"
+    (String.is_substring md ~substring:"PASS");
+  assert_bool "report contains Spearman ρ"
+    (String.is_substring md ~substring:"0.950000");
+  assert_bool "report contains fold rows"
+    (String.is_substring md ~substring:"f0");
+  assert_bool "report contains metric label"
+    (String.is_substring md ~substring:"sharpe_ratio");
+  assert_bool "report contains variant label"
+    (String.is_substring md ~substring:"cell-E")
+
+let test_render_markdown_fail_verdict _ =
+  let pairs = [ { PC.fold_name = "f0"; cheap = 1.0; expensive = 2.0 } ] in
+  let md =
+    PCR.render_markdown ~cheap_path:"/c.sexp" ~expensive_path:"/e.sexp"
+      ~metric:PCR.Sharpe ~threshold:0.7 ~variant_label:"cell-E" ~pairs ~rho:0.5
+      ~verdict:PC.Fail
+  in
+  assert_bool "report contains FAIL verdict"
+    (String.is_substring md ~substring:"FAIL");
+  assert_bool "report contains threshold"
+    (String.is_substring md ~substring:"0.7000")
+
+(* ---------- run_calibration end-to-end -------------------------------- *)
+
+(** PASS path: cheap is a 6-fold sample (indices 0,5,10,15,20,25) from a 26-fold
+    expensive set, Sharpe values are perfectly monotone, so the Spearman ρ
+    between cheap and expensive on the matched subset is 1.0 and the verdict is
+    PASS at the default threshold of 0.7. *)
+let test_run_calibration_pass _ =
+  _with_temp_dir (fun dir ->
+      let cheap_path = Filename.concat dir "cheap.sexp" in
+      let exp_path = Filename.concat dir "expensive.sexp" in
+      let expensive =
+        List.init 26 ~f:(fun i ->
+            _fold_actual
+              ~fold_name:(Printf.sprintf "fold-%03d" i)
+              ~sharpe_ratio:(Float.of_int i *. 0.1)
+              ())
+      in
+      let cheap_indices = [ 0; 5; 10; 15; 20; 25 ] in
+      let cheap =
+        List.map cheap_indices ~f:(fun i ->
+            _fold_actual
+              ~fold_name:(Printf.sprintf "fold-%03d" i)
+              ~sharpe_ratio:(Float.of_int i *. 0.1)
+              ())
+      in
+      _write_fold_actuals cheap_path cheap;
+      _write_fold_actuals exp_path expensive;
+      let args =
+        {
+          PCR.cheap_path;
+          expensive_path = exp_path;
+          metric = PCR.Sharpe;
+          threshold = PC.acceptance_threshold;
+          variant_label = PCR.default_variant_label;
+          out_path = None;
+        }
+      in
+      let result = PCR.run_calibration args in
+      assert_that (List.length result.pairs) (equal_to 6);
+      assert_that result.rho (float_equal ~epsilon:1e-12 1.0);
+      assert_that result.verdict (equal_to (PC.Pass : PC.verdict)))
+
+(** FAIL path: cheap and expensive disagree fold-by-fold (perfectly inverse
+    Sharpe ranks) so ρ = -1.0 < 0.7 ⇒ FAIL. *)
+let test_run_calibration_fail _ =
+  _with_temp_dir (fun dir ->
+      let cheap_path = Filename.concat dir "cheap.sexp" in
+      let exp_path = Filename.concat dir "expensive.sexp" in
+      let expensive =
+        [
+          _fold_actual ~fold_name:"f0" ~sharpe_ratio:1.0 ();
+          _fold_actual ~fold_name:"f1" ~sharpe_ratio:2.0 ();
+          _fold_actual ~fold_name:"f2" ~sharpe_ratio:3.0 ();
+          _fold_actual ~fold_name:"f3" ~sharpe_ratio:4.0 ();
+        ]
+      in
+      let cheap =
+        [
+          _fold_actual ~fold_name:"f0" ~sharpe_ratio:4.0 ();
+          _fold_actual ~fold_name:"f1" ~sharpe_ratio:3.0 ();
+          _fold_actual ~fold_name:"f2" ~sharpe_ratio:2.0 ();
+          _fold_actual ~fold_name:"f3" ~sharpe_ratio:1.0 ();
+        ]
+      in
+      _write_fold_actuals cheap_path cheap;
+      _write_fold_actuals exp_path expensive;
+      let args =
+        {
+          PCR.cheap_path;
+          expensive_path = exp_path;
+          metric = PCR.Sharpe;
+          threshold = PC.acceptance_threshold;
+          variant_label = PCR.default_variant_label;
+          out_path = None;
+        }
+      in
+      let result = PCR.run_calibration args in
+      assert_that result.rho (float_equal ~epsilon:1e-12 (-1.0));
+      assert_that result.verdict (equal_to (PC.Fail : PC.verdict)))
+
+(** Multi-variant fold_actuals: when both cheap and expensive contain Cell E AND
+    candidate variants, the calibration filters to the requested variant_label
+    and joins only Cell E rows. Without the filter, the hashtable's
+    last-writer-wins behaviour would mix candidate values into the Cell E
+    correlation. *)
+let test_run_calibration_multi_variant_filtered _ =
+  _with_temp_dir (fun dir ->
+      let cheap_path = Filename.concat dir "cheap.sexp" in
+      let exp_path = Filename.concat dir "expensive.sexp" in
+      (* Both Cell E and candidate variants are in the same file. The candidate
+         carries radically different Sharpe values; if the filter is wrong, the
+         join would pick up candidate's Sharpe and ρ would diverge from 1. *)
+      _write_fold_actuals cheap_path
+        [
+          _fold_actual ~variant_label:"cell-E" ~fold_name:"f0" ~sharpe_ratio:1.0
+            ();
+          _fold_actual ~variant_label:"candidate" ~fold_name:"f0"
+            ~sharpe_ratio:99.0 ();
+          _fold_actual ~variant_label:"cell-E" ~fold_name:"f1" ~sharpe_ratio:2.0
+            ();
+          _fold_actual ~variant_label:"candidate" ~fold_name:"f1"
+            ~sharpe_ratio:99.0 ();
+          _fold_actual ~variant_label:"cell-E" ~fold_name:"f2" ~sharpe_ratio:3.0
+            ();
+        ];
+      _write_fold_actuals exp_path
+        [
+          _fold_actual ~variant_label:"cell-E" ~fold_name:"f0" ~sharpe_ratio:1.0
+            ();
+          _fold_actual ~variant_label:"candidate" ~fold_name:"f0"
+            ~sharpe_ratio:99.0 ();
+          _fold_actual ~variant_label:"cell-E" ~fold_name:"f1" ~sharpe_ratio:2.0
+            ();
+          _fold_actual ~variant_label:"candidate" ~fold_name:"f1"
+            ~sharpe_ratio:99.0 ();
+          _fold_actual ~variant_label:"cell-E" ~fold_name:"f2" ~sharpe_ratio:3.0
+            ();
+        ];
+      let args =
+        {
+          PCR.cheap_path;
+          expensive_path = exp_path;
+          metric = PCR.Sharpe;
+          threshold = PC.acceptance_threshold;
+          variant_label = "cell-E";
+          out_path = None;
+        }
+      in
+      let result = PCR.run_calibration args in
+      assert_that (List.length result.pairs) (equal_to 3);
+      assert_that result.rho (float_equal ~epsilon:1e-12 1.0);
+      assert_that result.verdict (equal_to (PC.Pass : PC.verdict)))
+
+(** Disjoint fold_names raise (no matched pairs). *)
+let test_run_calibration_disjoint_raises _ =
+  _with_temp_dir (fun dir ->
+      let cheap_path = Filename.concat dir "cheap.sexp" in
+      let exp_path = Filename.concat dir "expensive.sexp" in
+      _write_fold_actuals cheap_path
+        [
+          _fold_actual ~fold_name:"alpha" ~sharpe_ratio:1.0 ();
+          _fold_actual ~fold_name:"beta" ~sharpe_ratio:2.0 ();
+        ];
+      _write_fold_actuals exp_path
+        [
+          _fold_actual ~fold_name:"gamma" ~sharpe_ratio:1.0 ();
+          _fold_actual ~fold_name:"delta" ~sharpe_ratio:2.0 ();
+        ];
+      let args =
+        {
+          PCR.cheap_path;
+          expensive_path = exp_path;
+          metric = PCR.Sharpe;
+          threshold = PC.acceptance_threshold;
+          variant_label = PCR.default_variant_label;
+          out_path = None;
+        }
+      in
+      let f () =
+        let _ = PCR.run_calibration args in
+        ()
+      in
+      _assert_raises_failure_containing f "need >=2 matched folds")
+
+(* ---------- suite ------------------------------------------------------ *)
+
+let suite =
+  "test_proxy_calibration_runner"
+  >::: [
+         "metric_arg_of_string_recognised"
+         >:: test_metric_arg_of_string_recognised;
+         "metric_arg_of_string_unknown_raises"
+         >:: test_metric_arg_of_string_unknown_raises;
+         "parse_args_required_only" >:: test_parse_args_required_only;
+         "parse_args_all_flags" >:: test_parse_args_all_flags;
+         "parse_args_missing_cheap" >:: test_parse_args_missing_cheap;
+         "parse_args_unknown_flag" >:: test_parse_args_unknown_flag;
+         "load_fold_actuals_round_trip" >:: test_load_fold_actuals_round_trip;
+         "load_fold_actuals_missing" >:: test_load_fold_actuals_missing;
+         "render_markdown_pass_verdict" >:: test_render_markdown_pass_verdict;
+         "render_markdown_fail_verdict" >:: test_render_markdown_fail_verdict;
+         "run_calibration_pass" >:: test_run_calibration_pass;
+         "run_calibration_fail" >:: test_run_calibration_fail;
+         "run_calibration_multi_variant_filtered"
+         >:: test_run_calibration_multi_variant_filtered;
+         "run_calibration_disjoint_raises"
+         >:: test_run_calibration_disjoint_raises;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/tuner/lib/dune
+++ b/trading/trading/backtest/tuner/lib/dune
@@ -1,5 +1,12 @@
 (library
  (name tuner)
- (libraries core fpath status backtest trading.simulation.types owl)
+ (libraries
+  core
+  fpath
+  status
+  backtest
+  trading.simulation.types
+  walk_forward
+  owl)
  (preprocess
-  (pps ppx_let ppx_sexp_conv)))
+  (pps ppx_let ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/tuner/lib/proxy_calibration_lib.ml
+++ b/trading/trading/backtest/tuner/lib/proxy_calibration_lib.ml
@@ -43,8 +43,7 @@ let _ranks (xs : float array) : float array =
 
 let _mean (xs : float array) : float =
   let n = Array.length xs in
-  if n = 0 then 0.0
-  else Array.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int n
+  if n = 0 then 0.0 else Array.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int n
 
 let _pearson (xs : float array) (ys : float array) : float =
   let n = Array.length xs in
@@ -79,19 +78,12 @@ let spearman_rho (xs : float array) (ys : float array) : float =
 
 (* -------------------------- fold-actual joining ---------------------- *)
 
-type fold_pair = {
-  fold_name : string;
-  cheap : float;
-  expensive : float;
-}
+type fold_pair = { fold_name : string; cheap : float; expensive : float }
 
 let _metric_of (fa : Wf.fold_actual)
     (metric :
-      [ `Sharpe
-      | `Total_return_pct
-      | `Calmar
-      | `CAGR
-      | `Max_drawdown_pct ]) : float =
+      [ `Sharpe | `Total_return_pct | `Calmar | `CAGR | `Max_drawdown_pct ]) :
+    float =
   match metric with
   | `Sharpe -> fa.sharpe_ratio
   | `Total_return_pct -> fa.total_return_pct
@@ -99,14 +91,20 @@ let _metric_of (fa : Wf.fold_actual)
   | `CAGR -> fa.cagr_pct
   | `Max_drawdown_pct -> fa.max_drawdown_pct
 
-let matched_pairs ~(cheap_actuals : Wf.fold_actual list)
+let _filter_variant ?variant_label (actuals : Wf.fold_actual list) :
+    Wf.fold_actual list =
+  match variant_label with
+  | None -> actuals
+  | Some label ->
+      List.filter actuals ~f:(fun fa -> String.equal fa.variant_label label)
+
+let matched_pairs ?variant_label ~(cheap_actuals : Wf.fold_actual list)
     ~(expensive_actuals : Wf.fold_actual list)
     ~(metric :
-       [ `Sharpe
-       | `Total_return_pct
-       | `Calmar
-       | `CAGR
-       | `Max_drawdown_pct ]) : fold_pair list =
+       [ `Sharpe | `Total_return_pct | `Calmar | `CAGR | `Max_drawdown_pct ]) ()
+    : fold_pair list =
+  let cheap_actuals = _filter_variant ?variant_label cheap_actuals in
+  let expensive_actuals = _filter_variant ?variant_label expensive_actuals in
   let exp_table = String.Table.create () in
   List.iter expensive_actuals ~f:(fun fa ->
       Hashtbl.set exp_table ~key:fa.fold_name ~data:fa);

--- a/trading/trading/backtest/tuner/lib/proxy_calibration_lib.ml
+++ b/trading/trading/backtest/tuner/lib/proxy_calibration_lib.ml
@@ -1,0 +1,131 @@
+open Core
+module Wf = Walk_forward.Walk_forward_types
+
+(* Plan-pinned acceptance ρ for proxy-fidelity calibration. See
+   `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` §M1 T1.4. *)
+let acceptance_threshold = 0.7
+
+(* -------------------------- ranking ----------------------------------- *)
+
+(* [_ranks xs] returns the mid-rank vector: equal values share the average of
+   the ranks they would occupy if distinguishable. Ranks are 1-based to match
+   the textbook Spearman definition (though the correlation is invariant under
+   a constant shift, the convention keeps debug output familiar). *)
+let _ranks (xs : float array) : float array =
+  let n = Array.length xs in
+  if n = 0 then [||]
+  else
+    let indexed = Array.mapi xs ~f:(fun i x -> (x, i)) in
+    Array.sort indexed ~compare:(fun (a, _) (b, _) -> Float.compare a b);
+    let ranks = Array.create ~len:n 0.0 in
+    let i = ref 0 in
+    while !i < n do
+      let j = ref (!i + 1) in
+      (* Walk forward while values tie. *)
+      while !j < n && Float.equal (fst indexed.(!j)) (fst indexed.(!i)) do
+        incr j
+      done;
+      (* The tied block spans [!i, !j). Assign each the average rank. *)
+      let block_lo = !i + 1 in
+      (* 1-based *)
+      let block_hi = !j in
+      (* 1-based, inclusive *)
+      let avg = Float.of_int (block_lo + block_hi) /. 2.0 in
+      for k = !i to !j - 1 do
+        let _, original_idx = indexed.(k) in
+        ranks.(original_idx) <- avg
+      done;
+      i := !j
+    done;
+    ranks
+
+(* -------------------------- Pearson correlation ----------------------- *)
+
+let _mean (xs : float array) : float =
+  let n = Array.length xs in
+  if n = 0 then 0.0
+  else Array.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int n
+
+let _pearson (xs : float array) (ys : float array) : float =
+  let n = Array.length xs in
+  if n <= 1 then 0.0
+  else
+    let mx = _mean xs in
+    let my = _mean ys in
+    let num = ref 0.0 in
+    let sxx = ref 0.0 in
+    let syy = ref 0.0 in
+    for i = 0 to n - 1 do
+      let dx = xs.(i) -. mx in
+      let dy = ys.(i) -. my in
+      num := !num +. (dx *. dy);
+      sxx := !sxx +. (dx *. dx);
+      syy := !syy +. (dy *. dy)
+    done;
+    let denom = Float.sqrt (!sxx *. !syy) in
+    if Float.( <= ) denom 0.0 then 0.0 else !num /. denom
+
+let spearman_rho (xs : float array) (ys : float array) : float =
+  let nx = Array.length xs in
+  let ny = Array.length ys in
+  if nx <> ny then
+    invalid_arg
+      (Printf.sprintf "spearman_rho: array length mismatch (%d vs %d)" nx ny)
+  else if nx = 0 then 0.0
+  else
+    let rx = _ranks xs in
+    let ry = _ranks ys in
+    _pearson rx ry
+
+(* -------------------------- fold-actual joining ---------------------- *)
+
+type fold_pair = {
+  fold_name : string;
+  cheap : float;
+  expensive : float;
+}
+
+let _metric_of (fa : Wf.fold_actual)
+    (metric :
+      [ `Sharpe
+      | `Total_return_pct
+      | `Calmar
+      | `CAGR
+      | `Max_drawdown_pct ]) : float =
+  match metric with
+  | `Sharpe -> fa.sharpe_ratio
+  | `Total_return_pct -> fa.total_return_pct
+  | `Calmar -> fa.calmar_ratio
+  | `CAGR -> fa.cagr_pct
+  | `Max_drawdown_pct -> fa.max_drawdown_pct
+
+let matched_pairs ~(cheap_actuals : Wf.fold_actual list)
+    ~(expensive_actuals : Wf.fold_actual list)
+    ~(metric :
+       [ `Sharpe
+       | `Total_return_pct
+       | `Calmar
+       | `CAGR
+       | `Max_drawdown_pct ]) : fold_pair list =
+  let exp_table = String.Table.create () in
+  List.iter expensive_actuals ~f:(fun fa ->
+      Hashtbl.set exp_table ~key:fa.fold_name ~data:fa);
+  List.filter_map cheap_actuals ~f:(fun cheap_fa ->
+      match Hashtbl.find exp_table cheap_fa.fold_name with
+      | None -> None
+      | Some exp_fa ->
+          Some
+            {
+              fold_name = cheap_fa.fold_name;
+              cheap = _metric_of cheap_fa metric;
+              expensive = _metric_of exp_fa metric;
+            })
+
+(* -------------------------- verdict ---------------------------------- *)
+
+type verdict = Pass | Fail [@@deriving show, eq]
+
+let classify ~threshold ~rho =
+  if Float.is_nan rho then Fail
+  else if Float.( >= ) rho threshold then Pass
+  else Fail

--- a/trading/trading/backtest/tuner/lib/proxy_calibration_lib.ml
+++ b/trading/trading/backtest/tuner/lib/proxy_calibration_lib.ml
@@ -45,24 +45,34 @@ let _mean (xs : float array) : float =
   let n = Array.length xs in
   if n = 0 then 0.0 else Array.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int n
 
+(* Accumulate the three Pearson sums (cross + each squared) in one pass. *)
+let _pearson_sums (xs : float array) (ys : float array) ~(mx : float)
+    ~(my : float) : float * float * float =
+  let n = Array.length xs in
+  let num = ref 0.0 in
+  let sxx = ref 0.0 in
+  let syy = ref 0.0 in
+  for i = 0 to n - 1 do
+    let dx = xs.(i) -. mx in
+    let dy = ys.(i) -. my in
+    num := !num +. (dx *. dy);
+    sxx := !sxx +. (dx *. dx);
+    syy := !syy +. (dy *. dy)
+  done;
+  (!num, !sxx, !syy)
+
+let _pearson_from_sums ~num ~sxx ~syy : float =
+  let denom = Float.sqrt (sxx *. syy) in
+  if Float.( <= ) denom 0.0 then 0.0 else num /. denom
+
 let _pearson (xs : float array) (ys : float array) : float =
   let n = Array.length xs in
   if n <= 1 then 0.0
   else
     let mx = _mean xs in
     let my = _mean ys in
-    let num = ref 0.0 in
-    let sxx = ref 0.0 in
-    let syy = ref 0.0 in
-    for i = 0 to n - 1 do
-      let dx = xs.(i) -. mx in
-      let dy = ys.(i) -. my in
-      num := !num +. (dx *. dy);
-      sxx := !sxx +. (dx *. dx);
-      syy := !syy +. (dy *. dy)
-    done;
-    let denom = Float.sqrt (!sxx *. !syy) in
-    if Float.( <= ) denom 0.0 then 0.0 else !num /. denom
+    let num, sxx, syy = _pearson_sums xs ys ~mx ~my in
+    _pearson_from_sums ~num ~sxx ~syy
 
 let spearman_rho (xs : float array) (ys : float array) : float =
   let nx = Array.length xs in
@@ -98,6 +108,27 @@ let _filter_variant ?variant_label (actuals : Wf.fold_actual list) :
   | Some label ->
       List.filter actuals ~f:(fun fa -> String.equal fa.variant_label label)
 
+let _make_fold_name_table (actuals : Wf.fold_actual list) :
+    (string, Wf.fold_actual) Hashtbl.t =
+  let table = String.Table.create () in
+  List.iter actuals ~f:(fun fa -> Hashtbl.set table ~key:fa.fold_name ~data:fa);
+  table
+
+let _try_make_pair
+    ~(metric :
+       [ `Sharpe | `Total_return_pct | `Calmar | `CAGR | `Max_drawdown_pct ])
+    ~(exp_table : (string, Wf.fold_actual) Hashtbl.t)
+    (cheap_fa : Wf.fold_actual) : fold_pair option =
+  match Hashtbl.find exp_table cheap_fa.fold_name with
+  | None -> None
+  | Some exp_fa ->
+      Some
+        {
+          fold_name = cheap_fa.fold_name;
+          cheap = _metric_of cheap_fa metric;
+          expensive = _metric_of exp_fa metric;
+        }
+
 let matched_pairs ?variant_label ~(cheap_actuals : Wf.fold_actual list)
     ~(expensive_actuals : Wf.fold_actual list)
     ~(metric :
@@ -105,19 +136,8 @@ let matched_pairs ?variant_label ~(cheap_actuals : Wf.fold_actual list)
     : fold_pair list =
   let cheap_actuals = _filter_variant ?variant_label cheap_actuals in
   let expensive_actuals = _filter_variant ?variant_label expensive_actuals in
-  let exp_table = String.Table.create () in
-  List.iter expensive_actuals ~f:(fun fa ->
-      Hashtbl.set exp_table ~key:fa.fold_name ~data:fa);
-  List.filter_map cheap_actuals ~f:(fun cheap_fa ->
-      match Hashtbl.find exp_table cheap_fa.fold_name with
-      | None -> None
-      | Some exp_fa ->
-          Some
-            {
-              fold_name = cheap_fa.fold_name;
-              cheap = _metric_of cheap_fa metric;
-              expensive = _metric_of exp_fa metric;
-            })
+  let exp_table = _make_fold_name_table expensive_actuals in
+  List.filter_map cheap_actuals ~f:(_try_make_pair ~metric ~exp_table)
 
 (* -------------------------- verdict ---------------------------------- *)
 

--- a/trading/trading/backtest/tuner/lib/proxy_calibration_lib.mli
+++ b/trading/trading/backtest/tuner/lib/proxy_calibration_lib.mli
@@ -1,5 +1,5 @@
-(** Pure functions for the M1 T1.4 cheap-vs-expensive proxy-fidelity
-    calibration step.
+(** Pure functions for the M1 T1.4 cheap-vs-expensive proxy-fidelity calibration
+    step.
 
     The Spearman rank correlation between Cell E's per-fold metric on the cheap
     proxy spec (6 folds) and the same metric on the expensive walk-forward spec
@@ -21,19 +21,18 @@ val spearman_rho : float array -> float array -> float
 (** [spearman_rho xs ys] returns the Spearman rank correlation coefficient
     between paired observations [(xs.(i), ys.(i))].
 
-    Computed by:
-    1. Convert each input to ranks. Equal values receive the average of the
-       ranks they would occupy if distinguishable (standard mid-rank tie
-       handling).
-    2. Compute the Pearson correlation coefficient of the rank vectors.
+    Computed by: 1. Convert each input to ranks. Equal values receive the
+    average of the ranks they would occupy if distinguishable (standard mid-rank
+    tie handling). 2. Compute the Pearson correlation coefficient of the rank
+    vectors.
 
     Return value range is [-1.0] (perfect anti-monotone) through [0.0]
     (uncorrelated) to [1.0] (perfect monotone).
 
     Edge cases:
     - When either input has zero variance after ranking (all values equal),
-      returns [0.0]. This matches the convention used by SciPy when the
-      Pearson denominator collapses.
+      returns [0.0]. This matches the convention used by SciPy when the Pearson
+      denominator collapses.
     - [n = 0] returns [0.0] (no signal to correlate).
     - [n = 1] returns [0.0] (a single point has no rank variance).
 
@@ -41,36 +40,41 @@ val spearman_rho : float array -> float array -> float
 
 (** {1 Fold-actual joining} *)
 
-type fold_pair = {
-  fold_name : string;
-  cheap : float;
-  expensive : float;
-}
+type fold_pair = { fold_name : string; cheap : float; expensive : float }
 (** A single matched (cheap, expensive) per-fold observation. *)
 
 val matched_pairs :
+  ?variant_label:string ->
   cheap_actuals:Walk_forward.Walk_forward_types.fold_actual list ->
   expensive_actuals:Walk_forward.Walk_forward_types.fold_actual list ->
   metric:[ `Sharpe | `Total_return_pct | `Calmar | `CAGR | `Max_drawdown_pct ] ->
+  unit ->
   fold_pair list
-(** [matched_pairs ~cheap_actuals ~expensive_actuals ~metric] returns the
-    intersection by [fold_name] of the two per-fold actual lists, projected onto
-    the chosen metric.
+(** [matched_pairs ?variant_label ~cheap_actuals ~expensive_actuals ~metric ()]
+    returns the intersection by [fold_name] of the two per-fold actual lists,
+    projected onto the chosen metric.
 
     Matching is by [fold_name], not positional. Order in the returned list
     follows the order of [cheap_actuals] for stability. Folds present in only
     one side are silently dropped — the caller asserts the resulting size is
-    meaningful (T1.4 expects ~6 matched folds for the canonical 6-vs-26
-    spec).
+    meaningful (T1.4 expects ~6 matched folds for the canonical 6-vs-26 spec).
 
     [metric] selects which per-fold field of
     {!Walk_forward.Walk_forward_types.fold_actual} is differenced. [`Sharpe] is
-    the default T1.4 metric per the plan. *)
+    the default T1.4 metric per the plan.
+
+    [variant_label] (optional) filters both inputs to entries whose
+    [variant_label] matches. T1.4 expects [variant_label = "cell-E"] since Cell
+    E is the only relevant variant for the calibration step. Defaults to no
+    filter — useful when the caller has already restricted upstream. When a file
+    carries multiple variants (e.g. both Cell E and a candidate), omitting the
+    filter leads to last-writer-wins on duplicate fold_names, which is rarely
+    what the caller wants. *)
 
 (** {1 Verdict} *)
 
-type verdict = Pass | Fail [@@deriving show, eq]
 (** Acceptance verdict after applying the calibration threshold. *)
+type verdict = Pass | Fail [@@deriving show, eq]
 
 val classify : threshold:float -> rho:float -> verdict
 (** [classify ~threshold ~rho] returns [Pass] when [rho >= threshold], else

--- a/trading/trading/backtest/tuner/lib/proxy_calibration_lib.mli
+++ b/trading/trading/backtest/tuner/lib/proxy_calibration_lib.mli
@@ -1,0 +1,78 @@
+(** Pure functions for the M1 T1.4 cheap-vs-expensive proxy-fidelity
+    calibration step.
+
+    The Spearman rank correlation between Cell E's per-fold metric on the cheap
+    proxy spec (6 folds) and the same metric on the expensive walk-forward spec
+    (26 folds) must be {b ρ ≥ 0.7} for the cheap proxy to be acceptable as a
+    BO-search-time substitute for the expensive set (per
+    `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` §M1 T1.4
+    acceptance row).
+
+    This module contains the pure-math primitive {!spearman_rho} plus the
+    {!matched_pairs} helper that joins two per-fold lists by [fold_name]. The
+    CLI driver and sexp I/O live in {!Tuner_bin.Proxy_calibration}. *)
+
+val acceptance_threshold : float
+(** The proxy is accepted at [ρ ≥ acceptance_threshold]. Plan §M1 T1.4 fixes
+    this at [0.7]; exposed as a named constant so callers / docs can introspect
+    rather than scatter the literal in code. *)
+
+val spearman_rho : float array -> float array -> float
+(** [spearman_rho xs ys] returns the Spearman rank correlation coefficient
+    between paired observations [(xs.(i), ys.(i))].
+
+    Computed by:
+    1. Convert each input to ranks. Equal values receive the average of the
+       ranks they would occupy if distinguishable (standard mid-rank tie
+       handling).
+    2. Compute the Pearson correlation coefficient of the rank vectors.
+
+    Return value range is [-1.0] (perfect anti-monotone) through [0.0]
+    (uncorrelated) to [1.0] (perfect monotone).
+
+    Edge cases:
+    - When either input has zero variance after ranking (all values equal),
+      returns [0.0]. This matches the convention used by SciPy when the
+      Pearson denominator collapses.
+    - [n = 0] returns [0.0] (no signal to correlate).
+    - [n = 1] returns [0.0] (a single point has no rank variance).
+
+    @raise Invalid_argument when [Array.length xs <> Array.length ys]. *)
+
+(** {1 Fold-actual joining} *)
+
+type fold_pair = {
+  fold_name : string;
+  cheap : float;
+  expensive : float;
+}
+(** A single matched (cheap, expensive) per-fold observation. *)
+
+val matched_pairs :
+  cheap_actuals:Walk_forward.Walk_forward_types.fold_actual list ->
+  expensive_actuals:Walk_forward.Walk_forward_types.fold_actual list ->
+  metric:[ `Sharpe | `Total_return_pct | `Calmar | `CAGR | `Max_drawdown_pct ] ->
+  fold_pair list
+(** [matched_pairs ~cheap_actuals ~expensive_actuals ~metric] returns the
+    intersection by [fold_name] of the two per-fold actual lists, projected onto
+    the chosen metric.
+
+    Matching is by [fold_name], not positional. Order in the returned list
+    follows the order of [cheap_actuals] for stability. Folds present in only
+    one side are silently dropped — the caller asserts the resulting size is
+    meaningful (T1.4 expects ~6 matched folds for the canonical 6-vs-26
+    spec).
+
+    [metric] selects which per-fold field of
+    {!Walk_forward.Walk_forward_types.fold_actual} is differenced. [`Sharpe] is
+    the default T1.4 metric per the plan. *)
+
+(** {1 Verdict} *)
+
+type verdict = Pass | Fail [@@deriving show, eq]
+(** Acceptance verdict after applying the calibration threshold. *)
+
+val classify : threshold:float -> rho:float -> verdict
+(** [classify ~threshold ~rho] returns [Pass] when [rho >= threshold], else
+    [Fail]. NaN [rho] (only reachable via abuse — the public {!spearman_rho}
+    never returns NaN given non-NaN inputs) classifies as [Fail]. *)

--- a/trading/trading/backtest/tuner/test/dune
+++ b/trading/trading/backtest/tuner/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_grid_search test_bayesian_opt)
+ (names test_grid_search test_bayesian_opt test_proxy_calibration_lib)
  (libraries
   ounit2
   core
@@ -7,6 +7,7 @@
   status
   matchers
   tuner
+  walk_forward
   trading.simulation.types)
  (preprocess
-  (pps ppx_sexp_conv)))
+  (pps ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/tuner/test/test_proxy_calibration_lib.ml
+++ b/trading/trading/backtest/tuner/test/test_proxy_calibration_lib.ml
@@ -1,0 +1,299 @@
+(** Unit tests for {!Tuner.Proxy_calibration_lib}. Synthetic float arrays;
+    no walk-forward run, no sexp I/O. Pins the Spearman ρ formula at known
+    expected values + edge cases. *)
+
+open OUnit2
+open Core
+open Matchers
+module PC = Tuner.Proxy_calibration_lib
+module Wf = Walk_forward.Walk_forward_types
+
+(* ----------------- Spearman ρ ------------------------------------------ *)
+
+(** Identical inputs ⇒ ρ = 1.0 (perfect monotone match). *)
+let test_spearman_identical _ =
+  let xs = [| 1.0; 2.0; 3.0; 4.0; 5.0 |] in
+  assert_that (PC.spearman_rho xs xs) (float_equal ~epsilon:1e-12 1.0)
+
+(** Reverse inputs ⇒ ρ = -1.0 (perfect anti-monotone). *)
+let test_spearman_reverse _ =
+  let xs = [| 1.0; 2.0; 3.0; 4.0; 5.0 |] in
+  let ys = [| 5.0; 4.0; 3.0; 2.0; 1.0 |] in
+  assert_that (PC.spearman_rho xs ys) (float_equal ~epsilon:1e-12 (-1.0))
+
+(** Hand-computed Spearman on a 5-element example.
+
+    xs = [1; 2; 3; 4; 5]  -> ranks = [1; 2; 3; 4; 5]
+    ys = [3; 1; 4; 2; 5]  -> ranks = [3; 1; 4; 2; 5]
+    Differences d_i: [1-3; 2-1; 3-4; 4-2; 5-5] = [-2; 1; -1; 2; 0]
+    Σd² = 4 + 1 + 1 + 4 + 0 = 10
+    ρ_textbook = 1 - 6·Σd² / (n(n²-1)) = 1 - 60/(5·24) = 1 - 0.5 = 0.5 *)
+let test_spearman_known_value _ =
+  let xs = [| 1.0; 2.0; 3.0; 4.0; 5.0 |] in
+  let ys = [| 3.0; 1.0; 4.0; 2.0; 5.0 |] in
+  assert_that (PC.spearman_rho xs ys) (float_equal ~epsilon:1e-10 0.5)
+
+(** Weak-correlation case. Hand computation:
+    xs = [1; 2; 3; 4; 5]    ranks rx = [1; 2; 3; 4; 5]
+    ys = [3; 1; 5; 2; 4]    ranks ry = [3; 1; 5; 2; 4]
+    d_i = rx - ry = [-2; 1; -2; 2; 1]
+    Σd² = 4 + 1 + 4 + 4 + 1 = 14
+    ρ = 1 - 6·14 / (5·24) = 1 - 84/120 = 0.3 *)
+let test_spearman_low_correlation _ =
+  let xs = [| 1.0; 2.0; 3.0; 4.0; 5.0 |] in
+  let ys = [| 3.0; 1.0; 5.0; 2.0; 4.0 |] in
+  assert_that (PC.spearman_rho xs ys) (float_equal ~epsilon:1e-10 0.3)
+
+(** Tie handling: equal values receive the average of their would-be ranks.
+
+    xs = [1; 1; 2; 2; 3]
+      Sorted: 1,1,2,2,3 → mid-ranks: avg(1,2)=1.5 for the two 1s, avg(3,4)=3.5
+        for the two 2s, 5 for the 3. So ranks = [1.5; 1.5; 3.5; 3.5; 5].
+    ys = [1; 2; 3; 4; 5]   ranks = [1; 2; 3; 4; 5]
+    Pearson of those rank vectors = ? Compute by hand below.
+
+    Σ(rx)  = 1.5+1.5+3.5+3.5+5 = 15 ; mean rx = 3
+    Σ(ry)  = 1+2+3+4+5 = 15 ; mean ry = 3
+    rx - mean rx: [-1.5; -1.5; 0.5; 0.5; 2]
+    ry - mean ry: [-2; -1; 0; 1; 2]
+    Cov num = (-1.5*-2) + (-1.5*-1) + (0.5*0) + (0.5*1) + (2*2) = 3 + 1.5 + 0 + 0.5 + 4 = 9
+    sxx = 1.5²·2 + 0.5²·2 + 2² = 4.5 + 0.5 + 4 = 9 → wait: 2.25*2 = 4.5; 0.25*2 = 0.5; 4. Σ = 9
+    syy = 4 + 1 + 0 + 1 + 4 = 10
+    denom = sqrt(9*10) = sqrt(90) ≈ 9.4868
+    ρ = 9 / 9.4868 ≈ 0.9487 *)
+let test_spearman_ties _ =
+  let xs = [| 1.0; 1.0; 2.0; 2.0; 3.0 |] in
+  let ys = [| 1.0; 2.0; 3.0; 4.0; 5.0 |] in
+  assert_that
+    (PC.spearman_rho xs ys)
+    (float_equal ~epsilon:1e-4 0.9487)
+
+(** Length mismatch raises Invalid_argument. *)
+let test_spearman_length_mismatch _ =
+  let xs = [| 1.0; 2.0; 3.0 |] in
+  let ys = [| 1.0; 2.0 |] in
+  let f () =
+    let _ = PC.spearman_rho xs ys in
+    ()
+  in
+  assert_raises
+    (Invalid_argument "spearman_rho: array length mismatch (3 vs 2)") f
+
+(** Empty inputs ⇒ ρ = 0.0 (no signal). *)
+let test_spearman_empty _ =
+  assert_that (PC.spearman_rho [||] [||]) (float_equal ~epsilon:1e-12 0.0)
+
+(** Single-point inputs ⇒ ρ = 0.0 (no rank variance). *)
+let test_spearman_single _ =
+  let xs = [| 7.0 |] in
+  let ys = [| 9.0 |] in
+  assert_that (PC.spearman_rho xs ys) (float_equal ~epsilon:1e-12 0.0)
+
+(** All-equal inputs ⇒ ρ = 0.0 (denominator collapses; matches SciPy
+    convention). *)
+let test_spearman_zero_variance _ =
+  let xs = [| 1.0; 1.0; 1.0; 1.0 |] in
+  let ys = [| 2.0; 4.0; 6.0; 8.0 |] in
+  assert_that (PC.spearman_rho xs ys) (float_equal ~epsilon:1e-12 0.0)
+
+(* ----------------- matched_pairs --------------------------------------- *)
+
+let _fold_actual ?(variant_label = "cell-E") ?(total_return_pct = Float.nan)
+    ?(sharpe_ratio = Float.nan) ?(max_drawdown_pct = Float.nan)
+    ?(calmar_ratio = Float.nan) ?(cagr_pct = Float.nan)
+    ?(avg_holding_days = Float.nan) ~fold_name () : Wf.fold_actual =
+  {
+    fold_name;
+    variant_label;
+    total_return_pct;
+    sharpe_ratio;
+    max_drawdown_pct;
+    calmar_ratio;
+    cagr_pct;
+    avg_holding_days;
+  }
+
+(** Cheap (6 folds) is a subset of expensive (26 folds); matched_pairs returns
+    the intersection in cheap-order. *)
+let test_matched_pairs_subset _ =
+  let cheap =
+    [
+      _fold_actual ~fold_name:"fold-005" ~sharpe_ratio:0.5 ();
+      _fold_actual ~fold_name:"fold-010" ~sharpe_ratio:1.0 ();
+      _fold_actual ~fold_name:"fold-020" ~sharpe_ratio:2.0 ();
+    ]
+  in
+  let expensive =
+    List.init 26 ~f:(fun i ->
+        _fold_actual
+          ~fold_name:(Printf.sprintf "fold-%03d" i)
+          ~sharpe_ratio:(Float.of_int i *. 0.1)
+          ())
+  in
+  let pairs =
+    PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
+      ~metric:`Sharpe
+  in
+  assert_that pairs
+    (elements_are
+       [
+         equal_to
+           ({ PC.fold_name = "fold-005"; cheap = 0.5; expensive = 0.5 }
+             : PC.fold_pair);
+         equal_to
+           ({ PC.fold_name = "fold-010"; cheap = 1.0; expensive = 1.0 }
+             : PC.fold_pair);
+         equal_to
+           ({ PC.fold_name = "fold-020"; cheap = 2.0; expensive = 2.0 }
+             : PC.fold_pair);
+       ])
+
+(** Disjoint inputs (no shared fold_name) return the empty list. *)
+let test_matched_pairs_disjoint _ =
+  let cheap =
+    [
+      _fold_actual ~fold_name:"alpha" ~sharpe_ratio:0.5 ();
+      _fold_actual ~fold_name:"beta" ~sharpe_ratio:1.0 ();
+    ]
+  in
+  let expensive =
+    [
+      _fold_actual ~fold_name:"gamma" ~sharpe_ratio:0.5 ();
+      _fold_actual ~fold_name:"delta" ~sharpe_ratio:1.0 ();
+    ]
+  in
+  let pairs =
+    PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
+      ~metric:`Sharpe
+  in
+  assert_that pairs (size_is 0)
+
+(** Metric dispatch: requesting `Total_return_pct projects the right field. *)
+let test_matched_pairs_metric_dispatch _ =
+  let cheap =
+    [ _fold_actual ~fold_name:"f0" ~total_return_pct:10.0 ~sharpe_ratio:0.5 () ]
+  in
+  let expensive =
+    [ _fold_actual ~fold_name:"f0" ~total_return_pct:20.0 ~sharpe_ratio:1.0 () ]
+  in
+  let pairs =
+    PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
+      ~metric:`Total_return_pct
+  in
+  assert_that pairs
+    (elements_are
+       [
+         equal_to
+           ({ PC.fold_name = "f0"; cheap = 10.0; expensive = 20.0 }
+             : PC.fold_pair);
+       ])
+
+(* ----------------- end-to-end calibration ------------------------------ *)
+
+(** End-to-end on the T1.4 acceptance pattern. Cheap (6 folds) is a strict
+    subset of expensive (26 folds), all Cell E, and the per-fold Sharpe values
+    are PERFECTLY monotone — so ρ = 1.0 ≥ 0.7 ⇒ PASS. Demonstrates the full
+    matched-pairs → spearman_rho → classify pipeline. *)
+let test_end_to_end_pass _ =
+  let n_expensive = 26 in
+  let cheap_indices = [ 0; 5; 10; 15; 20; 25 ] in
+  let expensive =
+    List.init n_expensive ~f:(fun i ->
+        _fold_actual
+          ~fold_name:(Printf.sprintf "fold-%03d" i)
+          ~sharpe_ratio:(Float.of_int i *. 0.1)
+          ())
+  in
+  let cheap =
+    List.map cheap_indices ~f:(fun i ->
+        _fold_actual
+          ~fold_name:(Printf.sprintf "fold-%03d" i)
+          ~sharpe_ratio:(Float.of_int i *. 0.1)
+          ())
+  in
+  let pairs =
+    PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
+      ~metric:`Sharpe
+  in
+  let cheap_xs = List.map pairs ~f:(fun p -> p.cheap) |> Array.of_list in
+  let exp_ys = List.map pairs ~f:(fun p -> p.expensive) |> Array.of_list in
+  let rho = PC.spearman_rho cheap_xs exp_ys in
+  let verdict = PC.classify ~threshold:PC.acceptance_threshold ~rho in
+  assert_that rho (float_equal ~epsilon:1e-12 1.0);
+  assert_that verdict (equal_to (PC.Pass : PC.verdict))
+
+(** End-to-end FAIL case: cheap proxy is anti-correlated with expensive
+    (perfect inverse) so ρ = -1.0 < 0.7 ⇒ FAIL. *)
+let test_end_to_end_fail _ =
+  let expensive =
+    [
+      _fold_actual ~fold_name:"f0" ~sharpe_ratio:1.0 ();
+      _fold_actual ~fold_name:"f1" ~sharpe_ratio:2.0 ();
+      _fold_actual ~fold_name:"f2" ~sharpe_ratio:3.0 ();
+      _fold_actual ~fold_name:"f3" ~sharpe_ratio:4.0 ();
+    ]
+  in
+  let cheap =
+    [
+      _fold_actual ~fold_name:"f0" ~sharpe_ratio:4.0 ();
+      _fold_actual ~fold_name:"f1" ~sharpe_ratio:3.0 ();
+      _fold_actual ~fold_name:"f2" ~sharpe_ratio:2.0 ();
+      _fold_actual ~fold_name:"f3" ~sharpe_ratio:1.0 ();
+    ]
+  in
+  let pairs =
+    PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
+      ~metric:`Sharpe
+  in
+  let cheap_xs = List.map pairs ~f:(fun p -> p.cheap) |> Array.of_list in
+  let exp_ys = List.map pairs ~f:(fun p -> p.expensive) |> Array.of_list in
+  let rho = PC.spearman_rho cheap_xs exp_ys in
+  let verdict = PC.classify ~threshold:PC.acceptance_threshold ~rho in
+  assert_that rho (float_equal ~epsilon:1e-12 (-1.0));
+  assert_that verdict (equal_to (PC.Fail : PC.verdict))
+
+(* ----------------- classify -------------------------------------------- *)
+
+(** Classify returns Pass when rho equals the threshold exactly. *)
+let test_classify_boundary _ =
+  assert_that
+    (PC.classify ~threshold:0.7 ~rho:0.7)
+    (equal_to (PC.Pass : PC.verdict))
+
+(** Classify returns Fail just below the threshold. *)
+let test_classify_below _ =
+  assert_that
+    (PC.classify ~threshold:0.7 ~rho:0.6999)
+    (equal_to (PC.Fail : PC.verdict))
+
+(** NaN rho classifies as Fail (defensive). *)
+let test_classify_nan _ =
+  assert_that
+    (PC.classify ~threshold:0.7 ~rho:Float.nan)
+    (equal_to (PC.Fail : PC.verdict))
+
+(* ----------------- suite ----------------------------------------------- *)
+
+let suite =
+  "test_proxy_calibration_lib"
+  >::: [
+         "spearman_identical" >:: test_spearman_identical;
+         "spearman_reverse" >:: test_spearman_reverse;
+         "spearman_known_value" >:: test_spearman_known_value;
+         "spearman_low_correlation" >:: test_spearman_low_correlation;
+         "spearman_ties" >:: test_spearman_ties;
+         "spearman_length_mismatch" >:: test_spearman_length_mismatch;
+         "spearman_empty" >:: test_spearman_empty;
+         "spearman_single" >:: test_spearman_single;
+         "spearman_zero_variance" >:: test_spearman_zero_variance;
+         "matched_pairs_subset" >:: test_matched_pairs_subset;
+         "matched_pairs_disjoint" >:: test_matched_pairs_disjoint;
+         "matched_pairs_metric_dispatch" >:: test_matched_pairs_metric_dispatch;
+         "end_to_end_pass" >:: test_end_to_end_pass;
+         "end_to_end_fail" >:: test_end_to_end_fail;
+         "classify_boundary" >:: test_classify_boundary;
+         "classify_below" >:: test_classify_below;
+         "classify_nan" >:: test_classify_nan;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/tuner/test/test_proxy_calibration_lib.ml
+++ b/trading/trading/backtest/tuner/test/test_proxy_calibration_lib.ml
@@ -1,6 +1,6 @@
-(** Unit tests for {!Tuner.Proxy_calibration_lib}. Synthetic float arrays;
-    no walk-forward run, no sexp I/O. Pins the Spearman ρ formula at known
-    expected values + edge cases. *)
+(** Unit tests for {!Tuner.Proxy_calibration_lib}. Synthetic float arrays; no
+    walk-forward run, no sexp I/O. Pins the Spearman ρ formula at known expected
+    values + edge cases. *)
 
 open OUnit2
 open Core
@@ -23,22 +23,19 @@ let test_spearman_reverse _ =
 
 (** Hand-computed Spearman on a 5-element example.
 
-    xs = [1; 2; 3; 4; 5]  -> ranks = [1; 2; 3; 4; 5]
-    ys = [3; 1; 4; 2; 5]  -> ranks = [3; 1; 4; 2; 5]
-    Differences d_i: [1-3; 2-1; 3-4; 4-2; 5-5] = [-2; 1; -1; 2; 0]
-    Σd² = 4 + 1 + 1 + 4 + 0 = 10
-    ρ_textbook = 1 - 6·Σd² / (n(n²-1)) = 1 - 60/(5·24) = 1 - 0.5 = 0.5 *)
+    xs = [1; 2; 3; 4; 5] -> ranks = [1; 2; 3; 4; 5] ys = [3; 1; 4; 2; 5] ->
+    ranks = [3; 1; 4; 2; 5] Differences d_i: [1-3; 2-1; 3-4; 4-2; 5-5] =
+    [-2; 1; -1; 2; 0] Σd² = 4 + 1 + 1 + 4 + 0 = 10 ρ_textbook = 1 - 6·Σd² /
+    (n(n²-1)) = 1 - 60/(5·24) = 1 - 0.5 = 0.5 *)
 let test_spearman_known_value _ =
   let xs = [| 1.0; 2.0; 3.0; 4.0; 5.0 |] in
   let ys = [| 3.0; 1.0; 4.0; 2.0; 5.0 |] in
   assert_that (PC.spearman_rho xs ys) (float_equal ~epsilon:1e-10 0.5)
 
-(** Weak-correlation case. Hand computation:
-    xs = [1; 2; 3; 4; 5]    ranks rx = [1; 2; 3; 4; 5]
-    ys = [3; 1; 5; 2; 4]    ranks ry = [3; 1; 5; 2; 4]
-    d_i = rx - ry = [-2; 1; -2; 2; 1]
-    Σd² = 4 + 1 + 4 + 4 + 1 = 14
-    ρ = 1 - 6·14 / (5·24) = 1 - 84/120 = 0.3 *)
+(** Weak-correlation case. Hand computation: xs = [1; 2; 3; 4; 5] ranks rx =
+    [1; 2; 3; 4; 5] ys = [3; 1; 5; 2; 4] ranks ry = [3; 1; 5; 2; 4] d_i = rx -
+    ry = [-2; 1; -2; 2; 1] Σd² = 4 + 1 + 4 + 4 + 1 = 14 ρ = 1 - 6·14 / (5·24) =
+    1 - 84/120 = 0.3 *)
 let test_spearman_low_correlation _ =
   let xs = [| 1.0; 2.0; 3.0; 4.0; 5.0 |] in
   let ys = [| 3.0; 1.0; 5.0; 2.0; 4.0 |] in
@@ -46,27 +43,21 @@ let test_spearman_low_correlation _ =
 
 (** Tie handling: equal values receive the average of their would-be ranks.
 
-    xs = [1; 1; 2; 2; 3]
-      Sorted: 1,1,2,2,3 → mid-ranks: avg(1,2)=1.5 for the two 1s, avg(3,4)=3.5
-        for the two 2s, 5 for the 3. So ranks = [1.5; 1.5; 3.5; 3.5; 5].
-    ys = [1; 2; 3; 4; 5]   ranks = [1; 2; 3; 4; 5]
+    xs = [1; 1; 2; 2; 3] Sorted: 1,1,2,2,3 → mid-ranks: avg(1,2)=1.5 for the two
+    1s, avg(3,4)=3.5 for the two 2s, 5 for the 3. So ranks =
+    [1.5; 1.5; 3.5; 3.5; 5]. ys = [1; 2; 3; 4; 5] ranks = [1; 2; 3; 4; 5]
     Pearson of those rank vectors = ? Compute by hand below.
 
-    Σ(rx)  = 1.5+1.5+3.5+3.5+5 = 15 ; mean rx = 3
-    Σ(ry)  = 1+2+3+4+5 = 15 ; mean ry = 3
-    rx - mean rx: [-1.5; -1.5; 0.5; 0.5; 2]
-    ry - mean ry: [-2; -1; 0; 1; 2]
-    Cov num = (-1.5*-2) + (-1.5*-1) + (0.5*0) + (0.5*1) + (2*2) = 3 + 1.5 + 0 + 0.5 + 4 = 9
-    sxx = 1.5²·2 + 0.5²·2 + 2² = 4.5 + 0.5 + 4 = 9 → wait: 2.25*2 = 4.5; 0.25*2 = 0.5; 4. Σ = 9
-    syy = 4 + 1 + 0 + 1 + 4 = 10
-    denom = sqrt(9*10) = sqrt(90) ≈ 9.4868
-    ρ = 9 / 9.4868 ≈ 0.9487 *)
+    Σ(rx) = 1.5+1.5+3.5+3.5+5 = 15 ; mean rx = 3 Σ(ry) = 1+2+3+4+5 = 15 ; mean
+    ry = 3 rx - mean rx: [-1.5; -1.5; 0.5; 0.5; 2] ry - mean ry:
+    [-2; -1; 0; 1; 2] Cov num = (-1.5*-2) + (-1.5*-1) + (0.5*0) + (0.5*1) +
+    (2*2) = 3 + 1.5 + 0 + 0.5 + 4 = 9 sxx = 1.5²·2 + 0.5²·2 + 2² = 4.5 + 0.5 + 4
+    = 9 → wait: 2.25*2 = 4.5; 0.25*2 = 0.5; 4. Σ = 9 syy = 4 + 1 + 0 + 1 + 4 =
+    10 denom = sqrt(9*10) = sqrt(90) ≈ 9.4868 ρ = 9 / 9.4868 ≈ 0.9487 *)
 let test_spearman_ties _ =
   let xs = [| 1.0; 1.0; 2.0; 2.0; 3.0 |] in
   let ys = [| 1.0; 2.0; 3.0; 4.0; 5.0 |] in
-  assert_that
-    (PC.spearman_rho xs ys)
-    (float_equal ~epsilon:1e-4 0.9487)
+  assert_that (PC.spearman_rho xs ys) (float_equal ~epsilon:1e-4 0.9487)
 
 (** Length mismatch raises Invalid_argument. *)
 let test_spearman_length_mismatch _ =
@@ -132,7 +123,7 @@ let test_matched_pairs_subset _ =
   in
   let pairs =
     PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
-      ~metric:`Sharpe
+      ~metric:`Sharpe ()
   in
   assert_that pairs
     (elements_are
@@ -164,7 +155,7 @@ let test_matched_pairs_disjoint _ =
   in
   let pairs =
     PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
-      ~metric:`Sharpe
+      ~metric:`Sharpe ()
   in
   assert_that pairs (size_is 0)
 
@@ -178,13 +169,49 @@ let test_matched_pairs_metric_dispatch _ =
   in
   let pairs =
     PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
-      ~metric:`Total_return_pct
+      ~metric:`Total_return_pct ()
   in
   assert_that pairs
     (elements_are
        [
          equal_to
            ({ PC.fold_name = "f0"; cheap = 10.0; expensive = 20.0 }
+             : PC.fold_pair);
+       ])
+
+(** variant_label filter: when the input list carries multiple variants per
+    fold, the filter restricts to one variant. Without the filter, the
+    last-writer-wins behaviour of the hashtable join leaves a non-deterministic
+    pairing — pinning the filter behaviour catches that drift. *)
+let test_matched_pairs_variant_filter _ =
+  let cheap =
+    [
+      _fold_actual ~variant_label:"cell-E" ~fold_name:"f0" ~sharpe_ratio:1.0 ();
+      _fold_actual ~variant_label:"candidate" ~fold_name:"f0" ~sharpe_ratio:9.0
+        ();
+      _fold_actual ~variant_label:"cell-E" ~fold_name:"f1" ~sharpe_ratio:2.0 ();
+    ]
+  in
+  let expensive =
+    [
+      _fold_actual ~variant_label:"cell-E" ~fold_name:"f0" ~sharpe_ratio:1.5 ();
+      _fold_actual ~variant_label:"candidate" ~fold_name:"f0" ~sharpe_ratio:9.5
+        ();
+      _fold_actual ~variant_label:"cell-E" ~fold_name:"f1" ~sharpe_ratio:2.5 ();
+    ]
+  in
+  let pairs =
+    PC.matched_pairs ~variant_label:"cell-E" ~cheap_actuals:cheap
+      ~expensive_actuals:expensive ~metric:`Sharpe ()
+  in
+  assert_that pairs
+    (elements_are
+       [
+         equal_to
+           ({ PC.fold_name = "f0"; cheap = 1.0; expensive = 1.5 }
+             : PC.fold_pair);
+         equal_to
+           ({ PC.fold_name = "f1"; cheap = 2.0; expensive = 2.5 }
              : PC.fold_pair);
        ])
 
@@ -213,7 +240,7 @@ let test_end_to_end_pass _ =
   in
   let pairs =
     PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
-      ~metric:`Sharpe
+      ~metric:`Sharpe ()
   in
   let cheap_xs = List.map pairs ~f:(fun p -> p.cheap) |> Array.of_list in
   let exp_ys = List.map pairs ~f:(fun p -> p.expensive) |> Array.of_list in
@@ -222,8 +249,8 @@ let test_end_to_end_pass _ =
   assert_that rho (float_equal ~epsilon:1e-12 1.0);
   assert_that verdict (equal_to (PC.Pass : PC.verdict))
 
-(** End-to-end FAIL case: cheap proxy is anti-correlated with expensive
-    (perfect inverse) so ρ = -1.0 < 0.7 ⇒ FAIL. *)
+(** End-to-end FAIL case: cheap proxy is anti-correlated with expensive (perfect
+    inverse) so ρ = -1.0 < 0.7 ⇒ FAIL. *)
 let test_end_to_end_fail _ =
   let expensive =
     [
@@ -243,7 +270,7 @@ let test_end_to_end_fail _ =
   in
   let pairs =
     PC.matched_pairs ~cheap_actuals:cheap ~expensive_actuals:expensive
-      ~metric:`Sharpe
+      ~metric:`Sharpe ()
   in
   let cheap_xs = List.map pairs ~f:(fun p -> p.cheap) |> Array.of_list in
   let exp_ys = List.map pairs ~f:(fun p -> p.expensive) |> Array.of_list in
@@ -289,6 +316,7 @@ let suite =
          "matched_pairs_subset" >:: test_matched_pairs_subset;
          "matched_pairs_disjoint" >:: test_matched_pairs_disjoint;
          "matched_pairs_metric_dispatch" >:: test_matched_pairs_metric_dispatch;
+         "matched_pairs_variant_filter" >:: test_matched_pairs_variant_filter;
          "end_to_end_pass" >:: test_end_to_end_pass;
          "end_to_end_fail" >:: test_end_to_end_fail;
          "classify_boundary" >:: test_classify_boundary;


### PR DESCRIPTION
## Summary

Implements **M1 T1.4** (proxy-fidelity calibration) from
`dev/plans/tuning-research-driven-program-v2-2026-05-25.md`. Adds a pure
Spearman ρ helper + a thin CLI that reads two `fold_actuals.sexp` files
(cheap-proxy and expensive walk-forward runs of Cell E), joins by
`fold_name`, computes ρ between the chosen per-fold metric, and emits a
PASS/FAIL verdict against the acceptance threshold (default `ρ ≥ 0.7` per
plan §M1 T1.4 acceptance row).

- New lib module `Tuner.Proxy_calibration_lib`
  (`trading/trading/backtest/tuner/lib/proxy_calibration_lib.{ml,mli}`) —
  pure-function `spearman_rho` with mid-rank tie handling + `matched_pairs`
  fold join (optional `?variant_label` filter for multi-variant files) +
  `Pass`/`Fail` classifier.
- New CLI logic module `Tuner_bin.Proxy_calibration_runner`
  (`trading/trading/backtest/tuner/bin/proxy_calibration_runner.{ml,mli}`) —
  CLI arg parser + sexp loader + markdown renderer + end-to-end
  orchestrator.
- Thin executable
  `trading/trading/backtest/tuner/bin/proxy_calibration.exe` — exits `0` on
  PASS, `1` on FAIL so a CI gate can branch on the verdict.
- Procedure doc `dev/notes/t1-4-calibration-procedure-2026-05-26.md` —
  local-only incantation (cheap + expensive `fold_actuals.sexp` paths
  under `/Users/difan/Projects/trading-1/.sweep-output/`) + verdict-file
  convention.

## CLI

```bash
proxy_calibration.exe \
  --cheap <cheap-fold_actuals.sexp> \
  --expensive <expensive-fold_actuals.sexp> \
  [--metric sharpe|totalreturn|calmar|cagr|maxdrawdown] \
  [--threshold <float>] \
  [--variant <label>] \
  [--out <markdown_path>]
```

## Why `fold_actuals.sexp`, not `aggregate.sexp`

The dispatch text loosely referred to `aggregate.sexp`, but Spearman ρ
requires per-fold samples. The `aggregate.sexp` file carries only
cross-fold summary stats (mean / stdev / min / max). The sibling
`fold_actuals.sexp` file (written by
`Walk_forward.Walk_forward_runner._write_fold_actuals`) carries the per-fold
records needed for the rank correlation. Documented in both the `.mli`
docstrings and the procedure note.

## Test plan

- [x] `dune build` clean (no warnings)
- [x] `dune build @fmt` clean
- [x] `dune runtest` clean (no `FAIL:` lines, no nesting / fn-length /
  magic-number / mli-coverage / status-integrity linter regressions)
- [x] `dune test trading/backtest/tuner/ --force` — 253/253 pass
  - 18 new in `test_proxy_calibration_lib.ml`:
    `spearman_rho` identical / reverse / known-value (hand-computed) /
    low-correlation / ties (mid-rank average) / length-mismatch raises /
    empty / single / zero-variance; `matched_pairs`
    subset / disjoint / metric-dispatch / variant-filter; end-to-end
    PASS (ρ=1) / FAIL (ρ=-1); `classify` boundary / below / NaN.
  - 14 new in `test_proxy_calibration_runner.ml`:
    `metric_arg_of_string` recognised / unknown raises;
    `parse_args` required-only / all-flags / missing-cheap / unknown-flag;
    `load_fold_actuals` round-trip / missing file;
    `render_markdown` PASS / FAIL (substring assertions);
    `run_calibration` PASS / FAIL / multi-variant-filtered /
    disjoint-raises.
- [x] Smoke-tested the exe end-to-end against an existing
  `fold_actuals.sexp` on the GHA host (matched=62 folds, ρ=0.881,
  verdict=PASS — self-correlation of a multi-variant file, used to
  validate the join + filter shape; the production cheap-vs-expensive
  run is local-only).

## Remaining work (local-only)

The production cheap-vs-expensive calibration requires the v6/v4
walk-forward outputs that live only on the maintainer's machine. Per the
T1.5 sibling dispatch handling pattern: this PR ships the infra
(lib + exe + tests + procedure doc); the operator runs the actual
calibration locally and writes the verdict to
`dev/notes/t1-4-calibration-verdict-<date>.md`. Status file row remains
`[~]` until the verdict lands.

## Plan reference

- `dev/plans/tuning-research-driven-program-v2-2026-05-25.md` §M1 T1.4
- Sibling work: M1 T1.3 (`paired_delta` scoring, merged #1308);
  M1 T1.5 (re-score historical checkpoints, branch
  `feat/tuning/m1-t1-5-rescore-checkpoints`).

🤖 Dispatched by GHA orchestrator run [26453609310](https://github.com/dayfine/trading/actions/runs/26453609310)
