### PR TITLE
feat(qc): drop dev/reviews/ file writes (PR-D'c)

### DIFF
--- a/.claude/agents/qc-behavioral.md
+++ b/.claude/agents/qc-behavioral.md
@@ -31,14 +31,6 @@ git worktree remove --force "${WT}"
 
 `git worktree add --detach` is the load-bearing form: detaching from any named ref means no orchestrator-visible branch state changes, even if the agent forgets to clean up. On GHA the same pattern works (replace `/tmp/qc-pr-...` with a path under `${GITHUB_WORKSPACE}/../qc-...` if needed for the shared runner filesystem).
 
-Write (append to) `dev/reviews/<feature>.md` against the **parent workspace's** repo root (NOT `${WT}`, which the orchestrator does not see):
-
-```bash
-REVIEW_FILE="${GITHUB_WORKSPACE:-${PARENT_REPO_ROOT:-$(pwd)}}/dev/reviews/<feature>.md"
-```
-
-Here `${PARENT_REPO_ROOT}` is the orchestrator's working tree (typically the dispatch prompt's cwd before this agent ran into the worktree). On GHA, `${GITHUB_WORKSPACE}` carries the same value. Do NOT commit or push. The orchestrator reads the file directly from the parent's filesystem after the subagent returns.
-
 ## Allowed tools
 
 Read, Glob, Grep (no Write, no Edit, no Bash — review only).
@@ -72,9 +64,14 @@ Read the relevant design doc for this feature before reviewing any code. Do not 
 
 ### Step 2: Read the diff
 
-Use the structural QC agent's checklist (already in `dev/reviews/<feature>.md`) for the file list. Read the implementation files and their test files directly via the Read tool.
+Use the file list from `gh pr view $PR_NUMBER --json files --jq '.files[].path'` and read
+the implementation files and their test files directly via the Read tool. Read the
+structural QC review from `gh pr view $PR_NUMBER --json reviews` if you need the structural
+checklist for context.
 
-Note: `dev/reviews/<feature>.md` starts with a `Reviewed SHA:` line pinned by qc-structural. This is an idempotency sentinel used by the orchestrator — do not remove or modify it.
+The structural QC PR review comment begins with `Reviewed SHA: <sha>` — that is the
+idempotency sentinel used by the orchestrator. Include the same SHA in your behavioral
+review comment body.
 
 ### Step 3: Fill in the checklists
 
@@ -182,14 +179,13 @@ APPROVED | NEEDS_REWORK
 
 ## Writing the review
 
-The review is delivered in **two places**:
+The review is delivered via **GitHub PR review comment** — the single source of truth.
+The verdict is visible directly on the PR and queryable via `gh pr view <N> --json reviews`.
 
-1. **GitHub PR review comment** (preferred medium — reviewers see the verdict directly on the PR).
-2. **`dev/reviews/<feature>.md` file** (transitional — appended below qc-structural's content; the lead-orchestrator's Step 1.5 idempotency check still reads it).
+### Post the GitHub PR review comment
 
-### Step 1 — post the GitHub PR review comment
-
-If `$PR_NUMBER` is known, post the behavioral verdict + checklist as a PR review. Use GitHub's native verdict flag so the merge-gate signal is first-class:
+Post the behavioral verdict + checklist as a PR review. Use GitHub's native verdict flag
+so the merge-gate signal is first-class:
 
 ```bash
 case "$VERDICT" in
@@ -199,51 +195,27 @@ case "$VERDICT" in
 esac
 
 gh pr review "$PR_NUMBER" $REVIEW_FLAG --body "$(cat <<'EOF'
-Reviewed SHA: <sha from dev/reviews/<feature>.md first line>
+Reviewed SHA: <sha — same as qc-structural's pin for this review pass>
 
 ## Behavioral QC — <feature-name>
 
-<filled Contract Pinning Checklist + Behavioral Checklist + Quality Score + Verdict, same content as the file append below>
+<filled Contract Pinning Checklist + Behavioral Checklist + Quality Score + Verdict>
 EOF
 )"
 ```
 
-The first body line MUST be `Reviewed SHA: <sha>` (matching qc-structural's pin from the same review pass) so a future orchestrator can locate this review via `gh pr view <N> --json reviews --jq '.reviews[].body'` and treat the SHA as the idempotency sentinel.
+The first body line MUST be `Reviewed SHA: <sha>` (matching qc-structural's pin from the
+same review pass) so the orchestrator can locate this review via
+`gh pr view <N> --json reviews --jq '.reviews[].body'` and treat the SHA as the
+idempotency sentinel.
 
-If `$PR_NUMBER` is absent, skip the PR-comment step and add a one-line note to the checklist: "PR_NUMBER unavailable — review file is the sole audit trail until PR is opened."
-
-### Step 2 — append to `dev/reviews/<feature>.md` (transitional back-compat)
-
-Append your behavioral checklist to the existing `dev/reviews/<feature>.md` written by qc-structural. The file already begins with a `Reviewed SHA:` line written by qc-structural — do not overwrite it or move it. Append only below the existing structural checklist content.
-
-**IMPORTANT: Do NOT push your changes to origin.** The review file is written in-place in your worktree for the lead-orchestrator to read directly. Pushing creates orphan `dev/reviews/*` branches on origin that accumulate as clutter. Write the file and return — the orchestrator reads your output text and the file you wrote.
-
-Write the review file using the Edit/Write tool (do not run jj or git push):
-
-```markdown
----
-
-# Behavioral QC — <feature-name>
-Date: YYYY-MM-DD
-Reviewer: qc-behavioral
-
-## Contract Pinning Checklist
-... (filled CP1–CP4 checklist) ...
-
-## Behavioral Checklist
-... (filled A1/S*/L*/C*/T* checklist) ...
-
-## Quality Score
-<1–5> — <rationale>
-
-## Verdict
-APPROVED | NEEDS_REWORK
-```
+If `$PR_NUMBER` is absent (branch not yet submitted), skip the PR-comment step and note it
+in your return value: "PR_NUMBER unavailable — verdict in return text only until PR is opened."
 
 ### Update status
 
 - **APPROVED**: Update `dev/status/<feature>.md` — add `behavioral_qc: APPROVED` and the date. If both structural and behavioral are APPROVED, set overall status to APPROVED.
-- **NEEDS_REWORK**: Add `behavioral_qc: NEEDS_REWORK` and a note pointing to the review file.
+- **NEEDS_REWORK**: Add `behavioral_qc: NEEDS_REWORK` and a brief note.
 
 ### Return value
 

--- a/.claude/agents/qc-structural.md
+++ b/.claude/agents/qc-structural.md
@@ -27,14 +27,6 @@ git checkout main
 
 `git checkout --detach <sha>` does not move any named ref, so the orchestrator's working tree is unchanged when the subagent exits. Never run `git checkout <branch>` (without `--detach`) — that moves `HEAD` to the branch, mutating the shared working tree for all subsequent orchestrator steps.
 
-Write `dev/reviews/<feature>.md` to an absolute path derived from `${GITHUB_WORKSPACE}`:
-
-```bash
-REVIEW_FILE="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}/dev/reviews/<feature>.md"
-```
-
-Using `${GITHUB_WORKSPACE}` ensures the file lands in the orchestrator's working tree regardless of which SHA the agent currently has detached. Do NOT commit or push. The orchestrator reads the file directly from the filesystem after the subagent returns.
-
 Otherwise (local runs), use **jj** with a per-session workspace. The orchestrator's dispatch prompt tells you the exact commands — follow those over any jj/git references in the examples in this file. See `.claude/agents/lead-orchestrator.md` §"Step 4: Spawn feature agents" for the authoritative dispatch shape.
 
 ## Allowed tools
@@ -151,14 +143,14 @@ After filling the checklist, capture the tip commit SHA of the feature branch:
 REVIEWED_SHA="${FEAT_SHA}"  # already resolved via `git rev-parse origin/<branch>` in Step 1
 ```
 
-Write this as the **first line** of `dev/reviews/<feature>.md` before the checklist:
+Include `Reviewed SHA: <sha>` as the **first line** of your PR review comment body:
 
 ```
 Reviewed SHA: <sha>
 ```
 
-This line is the idempotency sentinel. The lead-orchestrator reads it in Step 1.5 to
-compare against the current tip SHA and skip re-QC when the branch hasn't advanced.
+This line is the idempotency sentinel. The lead-orchestrator reads it from the PR review
+comments (via `gh pr view <N> --json reviews`) to skip re-QC when the branch hasn't advanced.
 Do not omit it even on NEEDS_REWORK — the orchestrator needs it regardless of verdict.
 
 ---
@@ -207,14 +199,13 @@ APPROVED | NEEDS_REWORK
 
 ## Writing the review
 
-The review is delivered in **two places**:
+The review is delivered via **GitHub PR review comment** — the single source of truth.
+The verdict is visible directly on the PR and queryable via `gh pr view <N> --json reviews`.
 
-1. **GitHub PR review comment** (preferred medium — reviewers see the verdict directly on the PR).
-2. **`dev/reviews/<feature>.md` file** (transitional — the lead-orchestrator's Step 1.5 idempotency check still reads it; once the orchestrator migrates to reading PR review comments, the file write will drop).
+### Post the GitHub PR review comment
 
-### Step 1 — post the GitHub PR review comment
-
-If `$PR_NUMBER` is known, post the verdict + summary as a PR review. The verdict uses GitHub's native `--approve` / `--request-changes` semantics so the merge-gate signals are first-class:
+Post the verdict + checklist as a PR review. The verdict uses GitHub's native
+`--approve` / `--request-changes` semantics so the merge-gate signals are first-class:
 
 ```bash
 case "$VERDICT" in
@@ -228,39 +219,22 @@ Reviewed SHA: <sha captured in Step 5>
 
 ## Structural QC — <feature-name>
 
-<condensed checklist + any NEEDS_REWORK items, same content as the file below>
+<filled structural checklist + any NEEDS_REWORK items>
 EOF
 )"
 ```
 
-The first body line MUST be `Reviewed SHA: <sha>` so a future orchestrator can find this review via `gh pr view <N> --json reviews --jq '.reviews[].body'` and treat the SHA as the idempotency sentinel.
+The first body line MUST be `Reviewed SHA: <sha>` so the orchestrator can find this review
+via `gh pr view <N> --json reviews --jq '.reviews[].body'` and treat the SHA as the
+idempotency sentinel.
 
-If `$PR_NUMBER` is absent (branch not yet submitted), skip the PR-comment step and add a one-line note to the checklist: "PR_NUMBER unavailable — review file is the sole audit trail until PR is opened."
-
-### Step 2 — write `dev/reviews/<feature>.md` (transitional back-compat)
-
-Write `dev/reviews/<feature>.md` from a clean branch based on `main@origin` — never from the feature branch. The first line must be the `Reviewed SHA:` line captured in Step 5:
-
-```
-Reviewed SHA: <sha captured in Step 5>
-```
-
-Then append the structural checklist below it.
-
-Write the file using the Edit/Write tool, with the review path resolved against the PARENT workspace's repo root (NOT the per-agent git worktree at `${WT}`, which the orchestrator does not see):
-
-```bash
-REVIEW_FILE="${GITHUB_WORKSPACE:-${PARENT_REPO_ROOT:-$(pwd)}}/dev/reviews/<feature>.md"
-```
-
-Here `${PARENT_REPO_ROOT}` is the orchestrator's working tree (typically the dispatch prompt's cwd before this agent ran). On GHA, `${GITHUB_WORKSPACE}` carries the same value.
-
-**IMPORTANT: Do NOT push your changes to origin.** The review file is written in-place in the parent worktree for the lead-orchestrator to read directly. Pushing creates orphan `dev/reviews/*` branches on origin that accumulate as clutter. Write the file and return — the orchestrator reads your output text and the file you wrote.
+If `$PR_NUMBER` is absent (branch not yet submitted), skip the PR-comment step and note it
+in your return value: "PR_NUMBER unavailable — verdict in return text only until PR is opened."
 
 ### Update status
 
 - **APPROVED**: Update `dev/status/<feature>.md` — add `structural_qc: APPROVED` and the date.
-- **NEEDS_REWORK**: Add `structural_qc: NEEDS_REWORK` and a note: "See dev/reviews/<feature>.md. Behavioral QC blocked until structural passes."
+- **NEEDS_REWORK**: Add `structural_qc: NEEDS_REWORK` and a note: "Behavioral QC blocked until structural passes."
 
 ### Return value
 

--- a/.claude/rules/feat-agent-dispatch.md
+++ b/.claude/rules/feat-agent-dispatch.md
@@ -22,8 +22,8 @@ reality.
 <paste `dune runtest <target-test-dir>` output, OR "All passing" if clean>
 
 ### Last QC review findings
-<paste the relevant section of `dev/reviews/<feature>.md` if one exists,
- OR "No prior review" if first dispatch on this track>
+<paste relevant sections from `gh pr view <N> --json reviews --jq '.reviews[].body'`
+ if a prior QC review exists, OR "No prior review" if first dispatch on this track>
 
 ### Open follow-up items
 <paste the `## Follow-ups` section from `dev/status/<track>.md` if any,
@@ -83,9 +83,9 @@ Same cap applies here:
   needs human intent / scope renegotiation, not more agent cycles.
 
 In the rework brief itself, paste:
-- The full `dev/reviews/<feature>.md` contents (both structural and behavioral).
+- The full QC review comment bodies from `gh pr view <N> --json reviews --jq '.reviews[].body'` (both structural and behavioral).
 - The iteration number ("rework iteration 1 of 2") so the agent knows headroom.
-- An explicit instruction: "Address every checked-fail item in the review file. Do not introduce new scope. Commit with `fix(review): address QC rework iteration <N>`."
+- An explicit instruction: "Address every checked-fail item in the review comments. Do not introduce new scope. Commit with `fix(review): address QC rework iteration <N>`."
 
 The point of the cap is the third-iteration STOP. Without it, the
 loop drifts on stubborn findings.

--- a/.claude/rules/pr-merge-gates.md
+++ b/.claude/rules/pr-merge-gates.md
@@ -10,13 +10,13 @@ A PR is mergeable only when **all three** are green:
 1. **GitHub CI** — `build-and-test` + `perf-tier1-smoke` (and any other
    required PR workflows). Status must be `COMPLETED SUCCESS`, never
    `IN_PROGRESS` or `PENDING`.
-2. **qc-structural** — APPROVED verdict at the current PR tip, recorded
-   in `dev/reviews/<feature>.md`.
-3. **qc-behavioral** — APPROVED verdict at the current PR tip, recorded
-   in `dev/reviews/<feature>-behavioral.md`. NA only for the cases
-   listed in `.claude/rules/qc-behavioral-authority.md` §"When to skip
-   this file entirely" (pure infra / refactor / harness PRs that touch
-   no domain logic — still requires the generic CP1–CP4 review).
+2. **qc-structural** — APPROVED verdict at the current PR tip, posted as a
+   GitHub PR review comment (query: `gh pr view <N> --json reviews`).
+3. **qc-behavioral** — APPROVED verdict at the current PR tip, posted as a
+   GitHub PR review comment. NA only for the cases listed in
+   `.claude/rules/qc-behavioral-authority.md` §"When to skip this file
+   entirely" (pure infra / refactor / harness PRs that touch no domain
+   logic — still requires the generic CP1–CP4 review).
 
 ## Docs-only PRs — both QC gates skipped
 

--- a/.claude/rules/qc-behavioral-authority.md
+++ b/.claude/rules/qc-behavioral-authority.md
@@ -7,7 +7,7 @@ harness: project
 
 This file is the **project-specific augmentation** of the generic qc-behavioral
 agent. The agent's protocol (Contract Pinning Checklist CP1–CP4, quality
-score format, write `dev/reviews/<feature>.md`, harness_gap classification)
+score format, PR review comment delivery, harness_gap classification)
 lives in `.claude/agents/qc-behavioral.md` and is reusable across projects.
 The rows + authority list below are specific to *this* repo's domain.
 

--- a/.claude/rules/qc-structural-authority.md
+++ b/.claude/rules/qc-structural-authority.md
@@ -6,7 +6,7 @@ harness: project
 # qc-structural authority — Weinstein Trading System
 
 This file is the **project-specific augmentation** of the generic qc-structural
-agent. The agent's protocol (run order, FAIL/PASS rules, write `dev/reviews/<feature>.md`,
+agent. The agent's protocol (run order, FAIL/PASS rules, PR review comment delivery,
 harness_gap classification, etc.) is in `.claude/agents/qc-structural.md` and is
 reusable across projects. The rows below are specific to *this* repo's
 architecture and conventions.


### PR DESCRIPTION
## Summary

- **PR-D'b** (already merged) made the orchestrator read QC verdicts from PR review comments via `gh pr view --json reviews`. Writing to `dev/reviews/<feature>.md` is now redundant.
- The dual-write pattern caused at least one drift incident where the file said X and the PR comment said Y.
- This PR removes the file-write step from both QC agent definitions and updates all authority/rules files that reference the file as the verdict location.

## What changed

- `.claude/agents/qc-structural.md`: removed the GHA `REVIEW_FILE` env-var block and the entire "Step 2 — write `dev/reviews/<feature>.md`" section; updated Step 5 (idempotency sentinel) to reference the PR review comment body; collapsed "Writing the review" to single-source (PR comment only)
- `.claude/agents/qc-behavioral.md`: removed the `REVIEW_FILE` declaration block; updated Step 2 to read from `gh pr view --json reviews` instead of the file; collapsed "Writing the review" to PR comment only
- `.claude/rules/qc-structural-authority.md`: updated protocol description (removed "write `dev/reviews/`")
- `.claude/rules/qc-behavioral-authority.md`: same
- `.claude/rules/pr-merge-gates.md`: updated gate-2 and gate-3 to reference PR review comments as the verdict location instead of `dev/reviews/*.md` files
- `.claude/rules/feat-agent-dispatch.md`: updated pre-flight context injection and rework brief to read QC findings from `gh pr view --json reviews` instead of the file

## Verify

```bash
grep -rn "dev/reviews/" .claude/agents/qc-structural.md .claude/agents/qc-behavioral.md
# expected: 0 hits
```

Existing files in `dev/reviews/` are NOT deleted — they are historical record. New QC runs will stop creating new ones.

Note: `record_qc_audit.sh` retains its file-mode fallback for legacy compatibility and for the case where `--pr-number` is not passed. That cleanup is a follow-up once callers consistently pass `--pr-number`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)