### PR TITLE
feat(tuning): post-sweep holdout_eval + sensitivity_sweep scripts

### DIFF
--- a/trading/trading/backtest/tuner/bin/bo_checkpoint_reader.ml
+++ b/trading/trading/backtest/tuner/bin/bo_checkpoint_reader.ml
@@ -1,0 +1,64 @@
+open Core
+module Metric_types = Trading_simulation_types.Metric_types
+
+type saved_iteration = {
+  parameters : (string * float) list;
+  metric : float;
+  per_scenario_metrics : Metric_types.metric_set list;
+}
+[@@deriving sexp]
+
+type t = {
+  schema_version : int;
+  spec : Bayesian_runner_spec.t;
+  iterations : saved_iteration list;
+}
+[@@deriving sexp]
+
+(** Pinned to match
+    {!Tuner_bin.Bayesian_runner_runner._checkpoint_schema_version}. If that
+    constant ever bumps, this one must follow — the reader is explicitly
+    intolerant of a mismatch so a stale tool against a fresh checkpoint fails
+    loud. *)
+let current_schema_version = 1
+
+let load path =
+  if not (Sys_unix.file_exists_exn path) then
+    failwithf "Bo_checkpoint_reader.load: file not found: %s" path ();
+  let sexp =
+    try Sexp.load_sexp path
+    with exn ->
+      failwithf "Bo_checkpoint_reader.load: failed to parse %s: %s" path
+        (Exn.to_string exn) ()
+  in
+  let ck =
+    try t_of_sexp sexp
+    with exn ->
+      failwithf
+        "Bo_checkpoint_reader.load: %s does not match the bo_checkpoint shape: \
+         %s"
+        path (Exn.to_string exn) ()
+  in
+  if ck.schema_version <> current_schema_version then
+    failwithf
+      "Bo_checkpoint_reader.load: checkpoint at %s carries schema_version %d; \
+       reader expects %d"
+      path ck.schema_version current_schema_version ();
+  ck
+
+(** Reduce [iterations] to the (index, iteration) pair with the maximum
+    [metric], breaking ties by lower index. Returns [None] for an empty input
+    list. *)
+let _argmax_with_index (xs : saved_iteration list) :
+    (int * saved_iteration) option =
+  List.foldi xs ~init:None ~f:(fun i acc it ->
+      match acc with
+      | None -> Some (i, it)
+      | Some (_, best) ->
+          if Float.(it.metric > best.metric) then Some (i, it) else acc)
+
+let best_iteration (t : t) : saved_iteration option =
+  Option.map (_argmax_with_index t.iterations) ~f:snd
+
+let best_iteration_index (t : t) : int option =
+  Option.map (_argmax_with_index t.iterations) ~f:fst

--- a/trading/trading/backtest/tuner/bin/bo_checkpoint_reader.mli
+++ b/trading/trading/backtest/tuner/bin/bo_checkpoint_reader.mli
@@ -1,0 +1,89 @@
+(** Read-only loader for [bo_checkpoint.sexp] files produced by
+    {!Tuner_bin.Bayesian_runner_runner.run_and_write}.
+
+    Splits the on-disk parser out of {!Tuner_bin.Bayesian_runner_runner} so
+    post-sweep analysis tools ({!Tuner_bin.Bayesian_runner_runner}'s sibling
+    exes [holdout_eval] and [sensitivity_sweep]) can read the checkpoint without
+    depending on the writer's internal types.
+
+    {b Why duplicate the sexp shape?} The {!Tuner_bin.Bayesian_runner_runner}
+    module declares [_saved_iteration] / [_checkpoint] with leading-underscore
+    names that are not exposed in its [.mli]. Rather than widen the runner's
+    surface — which would couple the writer's internal evolution to every reader
+    — we re-declare the same record shape here. The on-disk format is pinned by
+    [schema_version]; a mismatch raises a clear error rather than silently
+    corrupting downstream tools.
+
+    Pure: no I/O beyond a single [Sexp.load_sexp] in {!load}; no environment
+    reads; no side effects.
+
+    Plan: post-sweep analysis tooling for the v7 production sweep
+    ([dev/experiments/bayesian-production-sweep-2026-05-25/]). *)
+
+type saved_iteration = {
+  parameters : (string * float) list;
+      (** Knob assignment the BO emitted for this iteration. Order matches the
+          spec's [bounds] list. *)
+  metric : float;
+      (** Scalar score (higher is better) the BO recorded — output of the
+          objective scorer
+          ({!Tuner_bin.Bayesian_runner_scoring.score_cell_with_penalty}) for
+          this iteration's walk-forward result. *)
+  per_scenario_metrics : Trading_simulation_types.Metric_types.metric_set list;
+      (** Per-scenario metric sets emitted alongside the score. In walk-forward
+          mode this list contains exactly one synthetic metric_set projected
+          from the candidate variant's stability stats — see
+          {!Tuner_bin.Bayesian_runner_evaluator.build_walk_forward}'s
+          [_stability_to_metric_set]. Surfaced for diagnostic logging; the
+          post-sweep tools currently use only [metric] + [parameters]. *)
+}
+[@@deriving sexp]
+(** Mirror of {!Tuner_bin.Bayesian_runner_runner._saved_iteration} (which is
+    private). The sexp shape is identical so a [bo_checkpoint.sexp] written by
+    the runner round-trips through this type without modification. *)
+
+type t = {
+  schema_version : int;
+      (** Pinned to {!current_schema_version}. {!load} raises on mismatch. *)
+  spec : Bayesian_runner_spec.t;
+      (** The BO spec that produced this checkpoint. Re-emitted verbatim by the
+          writer, so reading it back recovers the exact bounds / objective /
+          int_keys the BO ran with. Post-sweep tools consume [spec.bounds] +
+          [spec.int_keys] to interpret the per-iteration [parameters] and
+          (sensitivity_sweep) to clip perturbations to the original bounds. *)
+  iterations : saved_iteration list;
+      (** Every iteration the BO completed, in evaluation order (oldest first).
+          The list may be shorter than [spec.total_budget] when the sweep was
+          killed mid-run or hit early-stop. *)
+}
+[@@deriving sexp]
+(** Mirror of {!Tuner_bin.Bayesian_runner_runner._checkpoint} (which is
+    private). Carries the BO spec plus every completed iteration. *)
+
+val current_schema_version : int
+(** Current [schema_version] for {!t}. Files written today carry this value;
+    {!load} rejects files with any other value. Pinned to match
+    {!Tuner_bin.Bayesian_runner_runner}'s internal version so a tool reading a
+    fresh checkpoint succeeds without further hand-tuning. *)
+
+val load : string -> t
+(** [load path] reads + parses [bo_checkpoint.sexp] from [path].
+
+    Raises [Failure] if the file is missing, malformed, or carries a
+    [schema_version] other than {!current_schema_version}. *)
+
+val best_iteration : t -> saved_iteration option
+(** [best_iteration t] returns the iteration with the maximum [metric] across
+    [t.iterations], or [None] when [t.iterations = []]. Ties resolve to the
+    earliest-emitted (lowest position in [t.iterations]).
+
+    {b Why earliest on ties?} A BO sweep can hit the same score twice via
+    distinct parameter sets; picking the earliest gives the operator a stable
+    pointer they can correlate to a specific iteration number in [bo_log.csv] /
+    [convergence.md]. *)
+
+val best_iteration_index : t -> int option
+(** [best_iteration_index t] returns the 0-based position of the
+    {!best_iteration} in [t.iterations], or [None] when the list is empty.
+    Surfaced so the post-sweep tools can quote the iteration number in their
+    markdown reports (e.g. "best at iter 25 of 60"). *)

--- a/trading/trading/backtest/tuner/bin/dune
+++ b/trading/trading/backtest/tuner/bin/dune
@@ -12,6 +12,9 @@
   bayesian_runner_successive_halving
   bayesian_runner_oos_validator
   bayesian_runner_out_dir_check
+  bo_checkpoint_reader
+  holdout_eval
+  sensitivity_sweep
   proxy_calibration_runner)
  (libraries
   core
@@ -53,3 +56,28 @@
  (name proxy_calibration)
  (modules proxy_calibration)
  (libraries tuner_bin))
+
+(executable
+ (name holdout_eval_main)
+ (modules holdout_eval_main)
+ (libraries
+  core
+  core_unix
+  fork_pool
+  scenario_lib
+  tuner
+  tuner_bin
+  walk_forward))
+
+(executable
+ (name sensitivity_sweep_main)
+ (modules sensitivity_sweep_main)
+ (libraries
+  core
+  core_unix
+  fork_pool
+  status
+  scenario_lib
+  tuner
+  tuner_bin
+  walk_forward))

--- a/trading/trading/backtest/tuner/bin/holdout_eval.ml
+++ b/trading/trading/backtest/tuner/bin/holdout_eval.ml
@@ -1,0 +1,223 @@
+open Core
+module Wf_types = Walk_forward.Walk_forward_types
+
+type verdict = Robust | Drops | Fails [@@deriving sexp, show, eq]
+
+(** Threshold above which the verdict is {!Robust}. Pinned at one stdev of a
+    typical per-fold Sharpe scale (~0.05). The prompt anchors this value so no
+    env / config override is wired. *)
+let robust_threshold = 0.05
+
+let classify_verdict ~mean_paired_sharpe_delta =
+  if Float.is_nan mean_paired_sharpe_delta then Fails
+  else if Float.(mean_paired_sharpe_delta > robust_threshold) then Robust
+  else if Float.(mean_paired_sharpe_delta >= 0.0) then Drops
+  else Fails
+
+type per_fold_row = {
+  fold_name : string;
+  candidate_sharpe : float;
+  baseline_sharpe : float;
+  delta_sharpe : float;
+  candidate_max_drawdown_pct : float;
+  baseline_max_drawdown_pct : float;
+  delta_max_drawdown_pct : float;
+}
+[@@deriving sexp, show, eq]
+
+type report = {
+  candidate_label : string;
+  baseline_label : string;
+  holdout_folds : int list;
+  best_iteration_index : int;
+  best_iteration_score : float;
+  rows : per_fold_row list;
+  mean_paired_sharpe_delta : float;
+  mean_paired_max_drawdown_delta : float;
+  verdict : verdict;
+}
+[@@deriving sexp, show, eq]
+
+(* ---------- pure helpers ---------- *)
+
+let _filter_to_variant ~label (rows : Wf_types.fold_actual list) =
+  List.filter rows ~f:(fun r -> String.equal r.variant_label label)
+
+let _baseline_by_name (rows : Wf_types.fold_actual list) =
+  List.map rows ~f:(fun r -> (r.fold_name, r))
+  |> Map.of_alist_reduce (module String) ~f:(fun a _ -> a)
+
+let pair_fold_actuals ~candidate_label ~baseline_label ~fold_actuals =
+  let cand_rows = _filter_to_variant ~label:candidate_label fold_actuals in
+  let base_rows = _filter_to_variant ~label:baseline_label fold_actuals in
+  if List.is_empty cand_rows then
+    failwithf "Holdout_eval.pair_fold_actuals: no rows for candidate %S"
+      candidate_label ();
+  if List.is_empty base_rows then
+    failwithf "Holdout_eval.pair_fold_actuals: no rows for baseline %S"
+      baseline_label ();
+  let base_map = _baseline_by_name base_rows in
+  let paired =
+    List.filter_map cand_rows ~f:(fun cand ->
+        match Map.find base_map cand.fold_name with
+        | None -> None
+        | Some base ->
+            Some
+              {
+                fold_name = cand.fold_name;
+                candidate_sharpe = cand.sharpe_ratio;
+                baseline_sharpe = base.sharpe_ratio;
+                delta_sharpe = cand.sharpe_ratio -. base.sharpe_ratio;
+                candidate_max_drawdown_pct = cand.max_drawdown_pct;
+                baseline_max_drawdown_pct = base.max_drawdown_pct;
+                delta_max_drawdown_pct =
+                  cand.max_drawdown_pct -. base.max_drawdown_pct;
+              })
+  in
+  if List.is_empty paired then
+    failwithf
+      "Holdout_eval.pair_fold_actuals: no candidate fold_name matched baseline \
+       (candidate %S has folds [%s]; baseline %S has folds [%s])"
+      candidate_label
+      (String.concat ~sep:"; " (List.map cand_rows ~f:(fun r -> r.fold_name)))
+      baseline_label
+      (String.concat ~sep:"; " (List.map base_rows ~f:(fun r -> r.fold_name)))
+      ();
+  paired
+
+let _mean_or_nan xs =
+  match xs with
+  | [] -> Float.nan
+  | _ -> List.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int (List.length xs)
+
+let build_report ~candidate_label ~baseline_label ~holdout_folds
+    ~best_iteration_index ~best_iteration_score ~fold_actuals =
+  let rows = pair_fold_actuals ~candidate_label ~baseline_label ~fold_actuals in
+  let mean_paired_sharpe_delta =
+    _mean_or_nan (List.map rows ~f:(fun r -> r.delta_sharpe))
+  in
+  let mean_paired_max_drawdown_delta =
+    _mean_or_nan (List.map rows ~f:(fun r -> r.delta_max_drawdown_pct))
+  in
+  let verdict = classify_verdict ~mean_paired_sharpe_delta in
+  {
+    candidate_label;
+    baseline_label;
+    holdout_folds;
+    best_iteration_index;
+    best_iteration_score;
+    rows;
+    mean_paired_sharpe_delta;
+    mean_paired_max_drawdown_delta;
+    verdict;
+  }
+
+(* ---------- markdown renderer ---------- *)
+
+let _verdict_label = function
+  | Robust -> "ROBUST"
+  | Drops -> "DROPS"
+  | Fails -> "FAILS"
+
+let _format_float f = if Float.is_nan f then "n/a" else sprintf "%.4f" f
+
+let _format_signed f =
+  if Float.is_nan f then "n/a"
+  else if Float.(f >= 0.0) then sprintf "+%.4f" f
+  else sprintf "%.4f" f
+
+let _format_int_list xs = String.concat ~sep:" " (List.map xs ~f:Int.to_string)
+
+let _title_section ~checkpoint_path ~walk_forward_spec_path
+    ~baseline_aggregate_path =
+  let baseline_line =
+    match baseline_aggregate_path with
+    | None -> ""
+    | Some p -> sprintf "Baseline aggregate: `%s`\n\n" p
+  in
+  sprintf
+    "# Holdout-fold evaluation report\n\n\
+     Checkpoint: `%s`\n\n\
+     Walk-forward spec: `%s`\n\n\
+     %sVerdict thresholds: mean per-fold Sharpe Δ > %.2f → ROBUST; 0 to %.2f → \
+     DROPS; < 0 → FAILS.\n\n"
+    checkpoint_path walk_forward_spec_path baseline_line robust_threshold
+    robust_threshold
+
+let _candidate_section r =
+  sprintf
+    "## Candidate\n\n\
+     Source: best observation in checkpoint at iter %d of the BO sweep.\n\n\
+     BO score (in-sample, all folds): %s\n\n\
+     Holdout fold positions (1-indexed): %s\n\n\
+     Candidate variant label: `%s`\n\n\
+     Baseline variant label: `%s`\n\n"
+    r.best_iteration_index
+    (_format_float r.best_iteration_score)
+    (_format_int_list r.holdout_folds)
+    r.candidate_label r.baseline_label
+
+let _per_fold_row_md row =
+  sprintf "| `%s` | %s | %s | %s | %s | %s | %s |\n" row.fold_name
+    (_format_float row.candidate_sharpe)
+    (_format_float row.baseline_sharpe)
+    (_format_signed row.delta_sharpe)
+    (_format_float row.candidate_max_drawdown_pct)
+    (_format_float row.baseline_max_drawdown_pct)
+    (_format_signed row.delta_max_drawdown_pct)
+
+let _per_fold_section r =
+  let header =
+    "## Per-holdout-fold metrics\n\n\
+     | Fold | Cand Sharpe | Base Sharpe | Δ Sharpe | Cand MaxDD% | Base MaxDD% \
+     | Δ MaxDD% |\n\
+     |---|---|---|---|---|---|---|\n"
+  in
+  let body = String.concat (List.map r.rows ~f:_per_fold_row_md) in
+  header ^ body ^ "\n"
+
+let _annotation_section ~baseline_all_fold_mean_sharpe
+    ~baseline_all_fold_mean_max_drawdown_pct =
+  match
+    (baseline_all_fold_mean_sharpe, baseline_all_fold_mean_max_drawdown_pct)
+  with
+  | None, None -> ""
+  | _, _ ->
+      sprintf
+        "## All-fold baseline annotation (informational)\n\n\
+         | Metric | All-fold baseline mean (from --baseline-aggregate) |\n\
+         |---|---|\n\
+         | Sharpe | %s |\n\
+         | MaxDD%% | %s |\n\n"
+        (_format_float
+           (Option.value baseline_all_fold_mean_sharpe ~default:Float.nan))
+        (_format_float
+           (Option.value baseline_all_fold_mean_max_drawdown_pct
+              ~default:Float.nan))
+
+let _verdict_section r =
+  sprintf
+    "## Verdict\n\n\
+     **%s**\n\n\
+     - Mean per-fold paired Sharpe Δ = %s (threshold %.2f)\n\
+     - Mean per-fold paired MaxDD%% Δ = %s (lower is better)\n\
+     - Holdout folds evaluated: %d\n"
+    (_verdict_label r.verdict)
+    (_format_signed r.mean_paired_sharpe_delta)
+    robust_threshold
+    (_format_signed r.mean_paired_max_drawdown_delta)
+    (List.length r.rows)
+
+let render_report r ~checkpoint_path ~walk_forward_spec_path
+    ~baseline_aggregate_path ~baseline_all_fold_mean_sharpe
+    ~baseline_all_fold_mean_max_drawdown_pct =
+  String.concat
+    [
+      _title_section ~checkpoint_path ~walk_forward_spec_path
+        ~baseline_aggregate_path;
+      _candidate_section r;
+      _per_fold_section r;
+      _annotation_section ~baseline_all_fold_mean_sharpe
+        ~baseline_all_fold_mean_max_drawdown_pct;
+      _verdict_section r;
+    ]

--- a/trading/trading/backtest/tuner/bin/holdout_eval.mli
+++ b/trading/trading/backtest/tuner/bin/holdout_eval.mli
@@ -1,0 +1,163 @@
+(** Post-sweep holdout-evaluation CLI for a finished BO sweep.
+
+    After a Bayesian-optimisation sweep converges, this exe loads the
+    checkpoint, identifies the {b best} observation (highest [metric]), and
+    re-runs that single parameter assignment through the walk-forward executor
+    on the {b holdout subset} of folds (as declared by the BO spec's
+    [holdout_folds] field).
+
+    The result is a markdown report that compares the candidate's per-fold
+    Sharpe + MaxDD against a baseline (Cell-E with empty overrides) over the
+    same holdout folds. The aggregate verdict is one of:
+
+    - {b ROBUST} — mean per-fold paired Sharpe Δ > [+0.05]
+    - {b DROPS} — mean per-fold paired Sharpe Δ in [0, +0.05]
+    - {b FAILS} — mean per-fold paired Sharpe Δ < [0]
+
+    {b Why "holdout" instead of "OOS validation"?} The existing
+    {!Tuner_bin.Bayesian_runner_oos_validator} is invoked inline by the BO
+    runner immediately after the sweep finishes and writes [oos_report.md]
+    automatically. This module is a standalone post-sweep tool that an operator
+    runs after the fact — typically when investigating a sweep that already
+    finished, or when the [oos_report.md] is missing because the sweep was
+    killed before the OOS step ran. The two tools share concept but not entry
+    point; this one accepts an arbitrary [bo_checkpoint.sexp] + walk-forward
+    spec.
+
+    Plan: [dev/notes/next-session-priorities-2026-05-26.md] — post-v7-sweep
+    analysis scripts.
+
+    Usage:
+
+    {v
+      holdout_eval.exe --checkpoint <bo_checkpoint.sexp>
+                       --walk-forward-spec <spec.sexp>
+                       --out <report.md>
+                       [--fixtures-root <path>]
+                       [--baseline-aggregate <aggregate.sexp>]
+                       [--parallel N]                (default 1, max 16)
+    v}
+
+    [--checkpoint] — path to [bo_checkpoint.sexp] produced by
+    {!Tuner_bin.Bayesian_runner_runner.run_and_write}.
+
+    [--walk-forward-spec] — path to the same {!Walk_forward.Spec.t} the BO ran
+    against. Its [Window_spec.generate] expansion is filtered to the holdout
+    subset.
+
+    [--out] — destination path for the markdown report (overwritten on each
+    run). The parent directory must exist.
+
+    [--fixtures-root] — directory the walk-forward spec's [base_scenario]
+    resolves against. Defaults to {!Scenario_lib.Fixtures_root.resolve}'s
+    default.
+
+    [--baseline-aggregate] — optional path to a pre-computed Cell-E
+    [aggregate.sexp]. When supplied, the report adds an annotation row with the
+    all-fold baseline mean Sharpe / MaxDD for cross-reference; the holdout
+    verdict is unaffected (verdict is always computed against the in-run
+    baseline variant). *)
+
+(** {1 Pure helpers — exposed for the test suite} *)
+
+(** Verdict computed from the mean per-fold paired Sharpe Δ. See module-level
+    docstring for the thresholds. *)
+type verdict = Robust | Drops | Fails [@@deriving sexp, show, eq]
+
+val robust_threshold : float
+(** Mean per-fold paired Sharpe Δ above which the verdict is {!Robust}. Pinned
+    at [0.05] (one-sigma improvement on a typical Sharpe scale). *)
+
+val classify_verdict : mean_paired_sharpe_delta:float -> verdict
+(** [classify_verdict ~mean_paired_sharpe_delta] returns:
+
+    - {!Robust} when [mean_paired_sharpe_delta > robust_threshold]
+    - {!Drops} when [0.0 <= mean_paired_sharpe_delta <= robust_threshold]
+    - {!Fails} when [mean_paired_sharpe_delta < 0.0]
+
+    Total: returns a verdict for every finite float. [Float.nan] inputs are
+    classified as {!Fails} (no improvement could be measured). *)
+
+type per_fold_row = {
+  fold_name : string;
+  candidate_sharpe : float;
+  baseline_sharpe : float;
+  delta_sharpe : float;
+  candidate_max_drawdown_pct : float;
+  baseline_max_drawdown_pct : float;
+  delta_max_drawdown_pct : float;
+}
+[@@deriving sexp, show, eq]
+(** One row of the per-fold table in the markdown report. The deltas are
+    [candidate - baseline]; for [delta_sharpe] higher is better, for
+    [delta_max_drawdown_pct] lower is better. *)
+
+type report = {
+  candidate_label : string;
+  baseline_label : string;
+  holdout_folds : int list;
+      (** 1-indexed fold positions evaluated (echoed from the BO spec). *)
+  best_iteration_index : int;
+      (** 0-based position of the best observation in
+          [bo_checkpoint.iterations]. *)
+  best_iteration_score : float;
+      (** [metric] field of the best observation in the checkpoint. *)
+  rows : per_fold_row list;
+      (** Per-fold rows in fold-generation order (same order the walk-forward
+          executor produces them). *)
+  mean_paired_sharpe_delta : float;
+      (** Arithmetic mean of [rows[i].delta_sharpe]. [Float.nan] when [rows] is
+          empty. *)
+  mean_paired_max_drawdown_delta : float;
+      (** Arithmetic mean of [rows[i].delta_max_drawdown_pct]. [Float.nan] when
+          [rows] is empty. *)
+  verdict : verdict;
+}
+[@@deriving sexp, show, eq]
+(** Structured holdout-evaluation result. Surfaced (rather than collapsing to a
+    [verdict]) so the markdown renderer can quote per-fold detail and tests can
+    pin every cell. *)
+
+val pair_fold_actuals :
+  candidate_label:string ->
+  baseline_label:string ->
+  fold_actuals:Walk_forward.Walk_forward_types.fold_actual list ->
+  per_fold_row list
+(** [pair_fold_actuals ~candidate_label ~baseline_label ~fold_actuals]
+    partitions [fold_actuals] by [variant_label], matches candidate ↔ baseline
+    rows by [fold_name], and returns one {!per_fold_row} per matched fold in the
+    order candidate rows appear in [fold_actuals].
+
+    Raises [Failure] when:
+
+    - [candidate_label] has zero matching rows in [fold_actuals];
+    - [baseline_label] has zero matching rows in [fold_actuals];
+    - no candidate row has a matching baseline row by [fold_name] (callsite bug:
+      variants ran on different folds). *)
+
+val build_report :
+  candidate_label:string ->
+  baseline_label:string ->
+  holdout_folds:int list ->
+  best_iteration_index:int ->
+  best_iteration_score:float ->
+  fold_actuals:Walk_forward.Walk_forward_types.fold_actual list ->
+  report
+(** Assemble the {!report} from the executor's per-fold actuals plus
+    bookkeeping. Computes the per-fold rows via {!pair_fold_actuals}, the two
+    mean deltas, and the {!verdict}. *)
+
+val render_report :
+  report ->
+  checkpoint_path:string ->
+  walk_forward_spec_path:string ->
+  baseline_aggregate_path:string option ->
+  baseline_all_fold_mean_sharpe:float option ->
+  baseline_all_fold_mean_max_drawdown_pct:float option ->
+  string
+(** Render the report as a markdown string. The all-fold baseline annotations
+    are optional — populated when the caller loaded a [--baseline-aggregate]
+    file and skipped otherwise.
+
+    Deterministic — same inputs yield byte-identical output (no time/env reads).
+*)

--- a/trading/trading/backtest/tuner/bin/holdout_eval_main.ml
+++ b/trading/trading/backtest/tuner/bin/holdout_eval_main.ml
@@ -1,0 +1,252 @@
+(** CLI wrapper for {!Tuner_bin.Holdout_eval}.
+
+    Loads a BO checkpoint, identifies the best observation, re-runs that
+    candidate against the walk-forward executor restricted to the holdout folds
+    (as declared in the BO spec's [holdout_folds] field), and writes a markdown
+    report.
+
+    Usage:
+
+    {v
+      holdout_eval_main.exe --checkpoint <bo_checkpoint.sexp>
+                            --walk-forward-spec <spec.sexp>
+                            --out <report.md>
+                            [--fixtures-root <path>]
+                            [--baseline-aggregate <aggregate.sexp>]
+                            [--parallel N]   (default 1, max 16)
+    v}
+
+    See {!Tuner_bin.Holdout_eval}'s [.mli] for flag semantics. *)
+
+open Core
+module Scenario = Scenario_lib.Scenario
+module Fixtures_root = Scenario_lib.Fixtures_root
+module Reader = Tuner_bin.Bo_checkpoint_reader
+module Holdout = Tuner_bin.Holdout_eval
+module Spec = Tuner_bin.Bayesian_runner_spec
+module Wf_spec = Walk_forward.Spec
+module Wf_window = Walk_forward.Window_spec
+module Wf_executor = Walk_forward.Walk_forward_executor
+module Wf_report = Walk_forward.Walk_forward_report
+module Wf_runner = Walk_forward.Walk_forward_runner
+module Wf_types = Walk_forward.Walk_forward_types
+module GS = Tuner.Grid_search
+
+let _usage_msg =
+  "Usage: holdout_eval_main.exe --checkpoint <bo_checkpoint.sexp>\n\
+  \  --walk-forward-spec <spec.sexp>\n\
+  \  --out <report.md>\n\
+  \  [--fixtures-root <path>]\n\
+  \  [--baseline-aggregate <aggregate.sexp>]\n\
+  \  [--parallel N]   (default 1, max 16)"
+
+let _default_parallel = 1
+
+(** Label assigned to the candidate variant in the synthetic two-variant
+    walk-forward spec. Matches the convention {!Bayesian_runner}'s OOS
+    re-execution uses, so the markdown report's labels line up with anyone who's
+    already familiar with the BO runner's outputs. *)
+let _candidate_label = "bo-iter-best"
+
+type cli_args = {
+  checkpoint_path : string;
+  walk_forward_spec_path : string;
+  out_path : string;
+  fixtures_root : string option;
+  baseline_aggregate_path : string option;
+  parallel : int;
+}
+
+let _parse_parallel raw =
+  let n =
+    try Int.of_string raw
+    with _ ->
+      eprintf "Error: --parallel expects an integer, got %S\n%s\n" raw
+        _usage_msg;
+      Stdlib.exit 1
+  in
+  if n < 1 || n > Fork_pool.max_parallel then begin
+    eprintf "Error: --parallel must be in [1, %d], got %d\n%s\n"
+      Fork_pool.max_parallel n _usage_msg;
+    Stdlib.exit 1
+  end;
+  n
+
+let _parse_args argv =
+  let rec loop ckpt wf out fixtures baseline parallel = function
+    | [] -> (
+        match (ckpt, wf, out) with
+        | Some c, Some w, Some o ->
+            {
+              checkpoint_path = c;
+              walk_forward_spec_path = w;
+              out_path = o;
+              fixtures_root = fixtures;
+              baseline_aggregate_path = baseline;
+              parallel = Option.value parallel ~default:_default_parallel;
+            }
+        | _ ->
+            eprintf "%s\n" _usage_msg;
+            Stdlib.exit 1)
+    | "--checkpoint" :: p :: rest ->
+        loop (Some p) wf out fixtures baseline parallel rest
+    | "--walk-forward-spec" :: p :: rest ->
+        loop ckpt (Some p) out fixtures baseline parallel rest
+    | "--out" :: p :: rest ->
+        loop ckpt wf (Some p) fixtures baseline parallel rest
+    | "--fixtures-root" :: p :: rest ->
+        loop ckpt wf out (Some p) baseline parallel rest
+    | "--baseline-aggregate" :: p :: rest ->
+        loop ckpt wf out fixtures (Some p) parallel rest
+    | "--parallel" :: raw :: rest ->
+        loop ckpt wf out fixtures baseline (Some (_parse_parallel raw)) rest
+    | ("--help" | "-h") :: _ ->
+        printf "%s\n" _usage_msg;
+        Stdlib.exit 0
+    | unknown :: _ ->
+        eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
+        Stdlib.exit 1
+  in
+  loop None None None None None None argv
+
+(** Filter a walk-forward spec's fold list to the holdout subset (1-indexed) by
+    replacing [window_spec] with an [Explicit] list of just those folds. All
+    other spec fields pass through unchanged. *)
+let _restrict_spec_to_holdout ~(holdout_folds : int list) (spec : Wf_spec.t) :
+    Wf_spec.t =
+  let all_folds = Wf_window.generate spec.window_spec in
+  let holdout_set = Int.Set.of_list holdout_folds in
+  let selected =
+    List.filteri all_folds ~f:(fun i _ -> Set.mem holdout_set (i + 1))
+  in
+  if List.is_empty selected then
+    failwithf
+      "holdout_eval: no folds match holdout positions [%s] (spec generated %d \
+       folds)"
+      (String.concat ~sep:" " (List.map holdout_folds ~f:Int.to_string))
+      (List.length all_folds) ();
+  let explicit =
+    List.map selected ~f:(fun (f : Wf_window.fold) : Wf_window.explicit_fold ->
+        {
+          name = f.name;
+          train_period = f.train_period;
+          test_period = f.test_period;
+        })
+  in
+  { spec with window_spec = Wf_window.Explicit explicit }
+
+(** Two-variant spec: baseline (empty overrides) + the BO's best cell. The
+    baseline variant's label is read off the original walk-forward spec. *)
+let _build_two_variant_spec ~(baseline_label : string)
+    ~(candidate_label : string) ~(parameters : (string * float) list)
+    ~(int_keys : string list) ~(template : Wf_spec.t) : Wf_spec.t =
+  let baseline : Wf_runner.variant =
+    { label = baseline_label; overrides = [] }
+  in
+  let candidate : Wf_runner.variant =
+    {
+      label = candidate_label;
+      overrides = GS.cell_to_overrides ~int_keys parameters;
+    }
+  in
+  { template with variants = [ baseline; candidate ] }
+
+(** Load the optional baseline aggregate. Returns [None] when [path] is [None];
+    raises [Failure] if the path is supplied but cannot be parsed. *)
+let _load_optional_aggregate path =
+  match path with
+  | None -> None
+  | Some p ->
+      Some
+        (try Wf_report.aggregate_of_sexp (Sexp.load_sexp p)
+         with exn ->
+           failwithf "holdout_eval: failed to load --baseline-aggregate %s: %s"
+             p (Exn.to_string exn) ())
+
+let _baseline_stab_for ~label (aggregate : Wf_types.aggregate option) =
+  Option.bind aggregate ~f:(fun agg ->
+      List.find agg.stability ~f:(fun s -> String.equal s.variant_label label))
+
+let _run (args : cli_args) =
+  let checkpoint = Reader.load args.checkpoint_path in
+  let best, best_idx =
+    match
+      (Reader.best_iteration checkpoint, Reader.best_iteration_index checkpoint)
+    with
+    | Some it, Some idx -> (it, idx)
+    | _ ->
+        failwithf
+          "holdout_eval: checkpoint %s contains zero iterations — nothing to \
+           evaluate"
+          args.checkpoint_path ()
+  in
+  let holdout_folds =
+    match checkpoint.spec.holdout_folds with
+    | Some xs when not (List.is_empty xs) -> xs
+    | _ ->
+        failwithf
+          "holdout_eval: checkpoint's spec has no [holdout_folds] declared; \
+           cannot pick a holdout subset"
+          ()
+  in
+  eprintf
+    "[holdout_eval] best at iter %d with score %.6f; %d holdout folds: [%s]\n%!"
+    best_idx best.metric
+    (List.length holdout_folds)
+    (String.concat ~sep:" " (List.map holdout_folds ~f:Int.to_string));
+  let fixtures_root =
+    Fixtures_root.resolve ?fixtures_root:args.fixtures_root ()
+  in
+  let template = Wf_spec.load args.walk_forward_spec_path in
+  let base_path = Filename.concat fixtures_root template.base_scenario in
+  let base = Scenario.load base_path in
+  let holdout_template = _restrict_spec_to_holdout ~holdout_folds template in
+  let baseline_label = template.baseline_label in
+  let spec =
+    _build_two_variant_spec ~baseline_label ~candidate_label:_candidate_label
+      ~parameters:best.parameters ~int_keys:checkpoint.spec.int_keys
+      ~template:holdout_template
+  in
+  eprintf
+    "[holdout_eval] executing walk-forward on holdout subset (parallel=%d, %d \
+     folds × 2 variants)\n\
+     %!"
+    args.parallel
+    (List.length holdout_folds);
+  let result =
+    Wf_executor.execute_spec ~base ~spec ~fixtures_root
+      ~progress:Wf_executor.noop_progress ~parallel:args.parallel ()
+  in
+  let report =
+    Holdout.build_report ~candidate_label:_candidate_label ~baseline_label
+      ~holdout_folds ~best_iteration_index:best_idx
+      ~best_iteration_score:best.metric ~fold_actuals:result.fold_actuals
+  in
+  let baseline_aggregate =
+    _load_optional_aggregate args.baseline_aggregate_path
+  in
+  let baseline_stab =
+    _baseline_stab_for ~label:baseline_label baseline_aggregate
+  in
+  let baseline_all_fold_mean_sharpe =
+    Option.map baseline_stab ~f:(fun s -> s.sharpe_ratio.mean)
+  in
+  let baseline_all_fold_mean_max_drawdown_pct =
+    Option.map baseline_stab ~f:(fun s -> s.max_drawdown_pct.mean)
+  in
+  let markdown =
+    Holdout.render_report report ~checkpoint_path:args.checkpoint_path
+      ~walk_forward_spec_path:args.walk_forward_spec_path
+      ~baseline_aggregate_path:args.baseline_aggregate_path
+      ~baseline_all_fold_mean_sharpe ~baseline_all_fold_mean_max_drawdown_pct
+  in
+  Out_channel.write_all args.out_path ~data:markdown;
+  eprintf "[holdout_eval] wrote %s (verdict=%s, mean Δ Sharpe=%.6f)\n%!"
+    args.out_path
+    (Holdout.show_verdict report.verdict)
+    report.mean_paired_sharpe_delta
+
+let () =
+  let argv = Array.to_list (Sys.get_argv ()) |> List.tl_exn in
+  let args = _parse_args argv in
+  _run args

--- a/trading/trading/backtest/tuner/bin/sensitivity_sweep.ml
+++ b/trading/trading/backtest/tuner/bin/sensitivity_sweep.ml
@@ -1,0 +1,220 @@
+open Core
+
+let perturbation_pcts = [ -0.10; -0.05; 0.05; 0.10 ]
+
+type perturbation = {
+  knob : string;
+  pct : float;
+  perturbed_value : float;
+  clipped : bool;
+  parameters : (string * float) list;
+}
+[@@deriving sexp, show, eq]
+
+type scored_row = {
+  knob : string;
+  pct : float;
+  perturbed_value : float;
+  clipped : bool;
+  score : float;
+  delta_vs_best : float;
+  sensitive : bool;
+}
+[@@deriving sexp, show, eq]
+
+type report = {
+  candidate_label_prefix : string;
+  baseline_label : string;
+  best_iteration_index : int;
+  best_score : float;
+  baseline_score : float;
+  rows : scored_row list;
+}
+[@@deriving sexp, show, eq]
+
+(** Fraction of the best cell's improvement-over-baseline below which a
+    perturbed score qualifies as "sensitive". Pinned at half (per the spec): a
+    knob is sensitive when a ±5% / ±10% jitter wipes out at least half the BO's
+    discovered improvement. *)
+let _sensitivity_drop_fraction = 0.5
+
+let sensitivity_threshold ~best_score ~baseline_score =
+  if Float.(best_score > baseline_score) then
+    Some
+      (best_score
+      -. (_sensitivity_drop_fraction *. (best_score -. baseline_score)))
+  else None
+
+(* ---------- perturbation generation ---------- *)
+
+let _clip ~lo ~hi v =
+  if Float.(v < lo) then (lo, true)
+  else if Float.(v > hi) then (hi, true)
+  else (v, false)
+
+let _replace_knob ~knob ~new_value (params : (string * float) list) :
+    (string * float) list =
+  List.map params ~f:(fun (k, v) ->
+      if String.equal k knob then (k, new_value) else (k, v))
+
+let _perturbations_for_knob ~knob ~best_value ~bounds_for_knob ~best_params :
+    perturbation list =
+  let lo, hi = bounds_for_knob in
+  List.map perturbation_pcts ~f:(fun pct ->
+      let raw = best_value *. (1.0 +. pct) in
+      let perturbed_value, clipped = _clip ~lo ~hi raw in
+      let parameters =
+        _replace_knob ~knob ~new_value:perturbed_value best_params
+      in
+      { knob; pct; perturbed_value; clipped; parameters })
+
+let generate_perturbations ~best_params ~bounds =
+  let bounds_map = String.Map.of_alist_reduce bounds ~f:(fun a _ -> a) in
+  List.concat_map best_params ~f:(fun (knob, best_value) ->
+      match Map.find bounds_map knob with
+      | None -> []
+      | Some bounds_for_knob ->
+          _perturbations_for_knob ~knob ~best_value ~bounds_for_knob
+            ~best_params)
+
+(* ---------- row assembly ---------- *)
+
+let build_rows ~best_score ~baseline_score ~perturbations ~scores =
+  if List.length perturbations <> List.length scores then
+    invalid_arg
+      (Printf.sprintf
+         "Sensitivity_sweep.build_rows: length mismatch — %d perturbations vs \
+          %d scores"
+         (List.length perturbations)
+         (List.length scores));
+  let threshold = sensitivity_threshold ~best_score ~baseline_score in
+  List.map2_exn perturbations scores ~f:(fun (p : perturbation) score ->
+      let delta_vs_best = score -. best_score in
+      let sensitive =
+        match threshold with None -> false | Some t -> Float.(score < t)
+      in
+      {
+        knob = p.knob;
+        pct = p.pct;
+        perturbed_value = p.perturbed_value;
+        clipped = p.clipped;
+        score;
+        delta_vs_best;
+        sensitive;
+      })
+
+(* ---------- markdown renderer ---------- *)
+
+let _format_float f = if Float.is_nan f then "n/a" else sprintf "%.6f" f
+
+let _format_signed f =
+  if Float.is_nan f then "n/a"
+  else if Float.(f >= 0.0) then sprintf "+%.6f" f
+  else sprintf "%.6f" f
+
+let _format_pct pct =
+  if Float.(pct >= 0.0) then sprintf "+%.0f%%" (pct *. 100.0)
+  else sprintf "%.0f%%" (pct *. 100.0)
+
+let _clipped_label clipped = if clipped then "yes" else "no"
+let _sensitive_label sensitive = if sensitive then "**yes**" else "no"
+
+let _title_section ~checkpoint_path ~walk_forward_spec_path
+    ~baseline_aggregate_path =
+  sprintf
+    "# Sensitivity-sweep report\n\n\
+     Checkpoint: `%s`\n\n\
+     Walk-forward spec: `%s`\n\n\
+     Baseline aggregate: `%s`\n\n\
+     Perturbations applied per knob (in order): %s.\n\n\
+     A perturbation is flagged **sensitive** when its score drops by more than \
+     %.0f%% of the best cell's improvement over baseline.\n\n"
+    checkpoint_path walk_forward_spec_path baseline_aggregate_path
+    (String.concat ~sep:", " (List.map perturbation_pcts ~f:_format_pct))
+    (_sensitivity_drop_fraction *. 100.0)
+
+let _summary_section r =
+  let threshold =
+    sensitivity_threshold ~best_score:r.best_score
+      ~baseline_score:r.baseline_score
+  in
+  let threshold_str =
+    match threshold with
+    | Some t -> _format_float t
+    | None ->
+        "n/a (best_score did not exceed baseline_score; sensitivity not \
+         classified)"
+  in
+  sprintf
+    "## Summary\n\n\
+     | Field | Value |\n\
+     |---|---|\n\
+     | Best iteration index (0-based) | %d |\n\
+     | Best score (re-executed) | %s |\n\
+     | Baseline score | %s |\n\
+     | Sensitivity threshold (score below this is flagged) | %s |\n\
+     | Candidate-label prefix | `%s` |\n\
+     | Baseline-label | `%s` |\n\n"
+    r.best_iteration_index
+    (_format_float r.best_score)
+    (_format_float r.baseline_score)
+    threshold_str r.candidate_label_prefix r.baseline_label
+
+let _row_md row =
+  sprintf "| `%s` | %s | %s | %s | %s | %s | %s |\n" row.knob
+    (_format_pct row.pct)
+    (_format_float row.perturbed_value)
+    (_clipped_label row.clipped)
+    (_format_float row.score)
+    (_format_signed row.delta_vs_best)
+    (_sensitive_label row.sensitive)
+
+let _per_perturbation_section r =
+  let header =
+    "## Per-perturbation results\n\n\
+     | Knob | Pct | Perturbed value | Clipped to bound | Score | Δ vs best | \
+     Sensitive |\n\
+     |---|---|---|---|---|---|---|\n"
+  in
+  let body = String.concat (List.map r.rows ~f:_row_md) in
+  header ^ body ^ "\n"
+
+let _sensitive_summary_section r =
+  let sensitive_rows = List.filter r.rows ~f:(fun row -> row.sensitive) in
+  let sensitive_knobs =
+    List.map sensitive_rows ~f:(fun row -> row.knob)
+    |> List.dedup_and_sort ~compare:String.compare
+  in
+  match sensitive_knobs with
+  | [] ->
+      sprintf
+        "## Sensitivity summary\n\n\
+         No perturbations crossed the sensitivity threshold. The best cell's \
+         knob configuration is robust to ±5%% / ±10%% jitter on the %d tested \
+         knobs.\n"
+        (List.dedup_and_sort ~compare:String.compare
+           (List.map r.rows ~f:(fun row -> row.knob))
+        |> List.length)
+  | _ ->
+      let knob_lines =
+        List.map sensitive_knobs ~f:(fun k -> sprintf "- `%s`\n" k)
+        |> String.concat
+      in
+      sprintf
+        "## Sensitivity summary\n\n\
+         %d sensitive perturbation(s) across %d knob(s):\n\n\
+         %s\n"
+        (List.length sensitive_rows)
+        (List.length sensitive_knobs)
+        knob_lines
+
+let render_report r ~checkpoint_path ~walk_forward_spec_path
+    ~baseline_aggregate_path =
+  String.concat
+    [
+      _title_section ~checkpoint_path ~walk_forward_spec_path
+        ~baseline_aggregate_path;
+      _summary_section r;
+      _per_perturbation_section r;
+      _sensitive_summary_section r;
+    ]

--- a/trading/trading/backtest/tuner/bin/sensitivity_sweep.mli
+++ b/trading/trading/backtest/tuner/bin/sensitivity_sweep.mli
@@ -1,0 +1,175 @@
+(** Post-sweep knob-sensitivity sweep for a finished BO sweep.
+
+    After a Bayesian-optimisation sweep converges, this exe loads the
+    checkpoint, identifies the best observation, and generates ±5% and ±10%
+    perturbations of each knob's value (clipped to the spec's per-knob bounds).
+    It then runs each perturbed candidate through the walk-forward executor,
+    scores it with the same scoring formula the BO used
+    ({!Tuner_bin.Bayesian_runner_scoring.score_cell_with_penalty}), and writes a
+    markdown table that flags any knob whose perturbation drops the score by
+    more than 50% of the best cell's improvement over baseline.
+
+    {b Knob count math.} 11 knobs × 4 perturbations (±5%, ±10%) = 44 candidates.
+    The earlier doc-stub overcounted at 110; the math here is pinned at four
+    perturbations per knob.
+
+    Plan: [dev/notes/next-session-priorities-2026-05-26.md] — post-v7-sweep
+    analysis scripts.
+
+    Usage:
+
+    {v
+      sensitivity_sweep_main.exe --checkpoint <bo_checkpoint.sexp>
+                                 --walk-forward-spec <spec.sexp>
+                                 --baseline-aggregate <aggregate.sexp>
+                                 --out <report.md>
+                                 [--fixtures-root <path>]
+                                 [--parallel N]   (default 1, max 16)
+    v}
+
+    {b Out of scope.} This module does NOT drive the executor itself — the
+    library exposes the perturbation-generation, scoring-table assembly, and
+    markdown-render helpers; the CLI wrapper ([sensitivity_sweep_main.ml])
+    threads them to {!Walk_forward.Walk_forward_executor.execute_spec} for one
+    walk-forward run per candidate. *)
+
+(** {1 Perturbation generation} *)
+
+val perturbation_pcts : float list
+(** The four per-knob perturbation percentages applied, in order:
+    [[ -0.10; -0.05; +0.05; +0.10 ]]. Pinned at four values so the report layout
+    is predictable and the per-knob row-count is constant across sweeps. *)
+
+type perturbation = {
+  knob : string;
+      (** Knob name being perturbed (e.g. ["initial_stop_buffer"]). *)
+  pct : float;
+      (** Signed perturbation as a fraction, e.g. [-0.05] for -5%. One of
+          {!perturbation_pcts}. *)
+  perturbed_value : float;
+      (** [best_value * (1.0 + pct)], clipped to the knob's [(min, max)] bounds.
+          When the clip fires the actual value differs from the unclipped
+          target; the renderer surfaces this. *)
+  clipped : bool;
+      (** [true] when the unclipped [best_value * (1.0 + pct)] fell outside the
+          knob's bounds and was pulled back. *)
+  parameters : (string * float) list;
+      (** Full knob assignment for the executor: [best_params] with only [knob]
+          replaced by [perturbed_value]. Keys are in the same order as
+          [best_params]. *)
+}
+[@@deriving sexp, show, eq]
+(** One perturbation candidate against the best cell. *)
+
+val generate_perturbations :
+  best_params:(string * float) list ->
+  bounds:(string * (float * float)) list ->
+  perturbation list
+(** [generate_perturbations ~best_params ~bounds] returns one {!perturbation}
+    per (knob, percentage) pair where knob ∈ [best_params] {b and} knob ∈
+    [bounds] (the spec's bounds list). Knobs missing from either side are
+    silently dropped from the perturbation set with a diagnostic surfaced
+    through the eventual report.
+
+    Ordering: outer = knobs in [best_params] order; inner = {!perturbation_pcts}
+    order. With 11 knobs × 4 pcts = 44 rows.
+
+    Each [perturbed_value] is computed as [v * (1 + pct)] then clipped to the
+    knob's [(min, max)] bounds. Zero-valued knobs (where [v = 0]) produce
+    [perturbed_value = 0] for every pct — the perturbation has no effect, and
+    [clipped = false] (no bound violation). The CLI surfaces a warning in the
+    report for such zero knobs so the operator knows the rows are no-ops. *)
+
+(** {1 Scoring} *)
+
+type scored_row = {
+  knob : string;
+  pct : float;
+  perturbed_value : float;
+  clipped : bool;
+  score : float;
+  delta_vs_best : float;
+      (** [score - best_score]. Negative means worse than the unperturbed best;
+          positive means the perturbation improves the score (which would
+          indicate the BO didn't fully converge or the surface is locally
+          non-convex). *)
+  sensitive : bool;
+      (** [true] when [score < best_score - 0.5 * (best_score - baseline_score)]
+          AND [best_score > baseline_score]. The threshold is half the
+          improvement of the best cell over baseline; a knob whose perturbation
+          crosses that threshold is "sensitive" — losing half the BO's
+          discovered improvement to a 5% / 10% jitter signals overfit. *)
+}
+[@@deriving sexp, show, eq]
+(** One row of the per-perturbation table, including the score the executor
+    returned (paired with the candidate aggregate via
+    {!Tuner_bin.Bayesian_runner_scoring.score_cell_with_penalty}). *)
+
+val sensitivity_threshold :
+  best_score:float -> baseline_score:float -> float option
+(** [sensitivity_threshold ~best_score ~baseline_score] returns the absolute
+    score-floor below which a perturbation is flagged sensitive.
+
+    Returns:
+
+    - [Some (best_score - 0.5 *. (best_score - baseline_score))] when
+      [best_score > baseline_score] (the formula is meaningful only when the
+      best cell improved on baseline);
+    - [None] otherwise — the "50% of improvement" rule has no anchor when there
+      is no improvement to measure, so no row is flagged sensitive. *)
+
+(** {1 Report assembly} *)
+
+type report = {
+  candidate_label_prefix : string;
+      (** The candidate label prefix the CLI used (e.g.
+          ["sensitivity-knob-N-pct-M"]). Echoed for diagnostic traceability; the
+          renderer surfaces this in the header so the operator can correlate
+          report rows to a specific executor run if needed. *)
+  baseline_label : string;
+      (** Walk-forward variant label of the baseline cell. *)
+  best_iteration_index : int;
+      (** 0-based position of the best observation in the checkpoint. *)
+  best_score : float;
+      (** BO-loop score of the unperturbed best cell, as computed by
+          {!Tuner_bin.Bayesian_runner_scoring.score_cell_with_penalty} applied
+          to the best cell's freshly-re-executed walk-forward result (NOT the
+          [metric] field of the checkpoint, which may differ from a re-execution
+          if the scorer's formula has since been updated). *)
+  baseline_score : float;
+      (** Score of the baseline cell against itself — always [0.0] for the
+          composite objective by definition, but surfaced explicitly so the
+          report self-documents the "50% improvement" arithmetic. *)
+  rows : scored_row list;  (** One row per (knob, perturbation) pair. *)
+}
+[@@deriving sexp, show, eq]
+
+val build_rows :
+  best_score:float ->
+  baseline_score:float ->
+  perturbations:perturbation list ->
+  scores:float list ->
+  scored_row list
+(** [build_rows ~best_score ~baseline_score ~perturbations ~scores] zips
+    [perturbations] with [scores] and applies the {!sensitivity_threshold} to
+    each row.
+
+    @raise Invalid_argument
+      when [List.length perturbations <> List.length scores]. *)
+
+val render_report :
+  report ->
+  checkpoint_path:string ->
+  walk_forward_spec_path:string ->
+  baseline_aggregate_path:string ->
+  string
+(** Render the report as a markdown table. Sections:
+
+    + Title + the checkpoint / walk-forward / baseline paths.
+    + Best cell summary: iteration index + best score + baseline score +
+      sensitivity threshold.
+    + Per-perturbation table: knob, pct, perturbed value, clipped flag, score, Δ
+      vs best, sensitive flag.
+    + Sensitivity summary: count of sensitive rows + list of sensitive knobs.
+
+    Deterministic — no time / env reads. *)

--- a/trading/trading/backtest/tuner/bin/sensitivity_sweep_main.ml
+++ b/trading/trading/backtest/tuner/bin/sensitivity_sweep_main.ml
@@ -1,0 +1,282 @@
+(** CLI wrapper for {!Tuner_bin.Sensitivity_sweep}.
+
+    Loads a BO checkpoint + baseline aggregate, generates ±5% / ±10%
+    perturbations of each knob at the best cell, runs each through the
+    walk-forward executor, scores each via
+    {!Tuner_bin.Bayesian_runner_scoring.score_cell_with_penalty}, and writes a
+    markdown report flagging knobs whose perturbations drop the score by more
+    than 50% of the best cell's improvement over baseline.
+
+    Usage:
+
+    {v
+      sensitivity_sweep_main.exe --checkpoint <bo_checkpoint.sexp>
+                                 --walk-forward-spec <spec.sexp>
+                                 --baseline-aggregate <aggregate.sexp>
+                                 --out <report.md>
+                                 [--fixtures-root <path>]
+                                 [--parallel N]   (default 1, max 16)
+    v}
+
+    See {!Tuner_bin.Sensitivity_sweep}'s [.mli] for the algorithm + the per-
+    knob perturbation set. *)
+
+open Core
+module Scenario = Scenario_lib.Scenario
+module Fixtures_root = Scenario_lib.Fixtures_root
+module Reader = Tuner_bin.Bo_checkpoint_reader
+module Sweep = Tuner_bin.Sensitivity_sweep
+module Spec = Tuner_bin.Bayesian_runner_spec
+module Scoring = Tuner_bin.Bayesian_runner_scoring
+module Wf_spec = Walk_forward.Spec
+module Wf_executor = Walk_forward.Walk_forward_executor
+module Wf_report = Walk_forward.Walk_forward_report
+module Wf_runner = Walk_forward.Walk_forward_runner
+module Wf_types = Walk_forward.Walk_forward_types
+module GS = Tuner.Grid_search
+
+let _usage_msg =
+  "Usage: sensitivity_sweep_main.exe --checkpoint <bo_checkpoint.sexp>\n\
+  \  --walk-forward-spec <spec.sexp>\n\
+  \  --baseline-aggregate <aggregate.sexp>\n\
+  \  --out <report.md>\n\
+  \  [--fixtures-root <path>]\n\
+  \  [--parallel N]   (default 1, max 16)"
+
+let _default_parallel = 1
+let _baseline_label_for_run = "baseline"
+
+(** Label assigned to the unperturbed best cell when re-executed for the
+    baseline-score data point. *)
+let _best_label_for_run = "bo-iter-best"
+
+(** Label-prefix for perturbation candidates. Suffix per-perturbation is
+    "knob-N-pct-M" so executor logs and the markdown table line up. *)
+let _candidate_label_prefix = "sensitivity"
+
+type cli_args = {
+  checkpoint_path : string;
+  walk_forward_spec_path : string;
+  baseline_aggregate_path : string;
+  out_path : string;
+  fixtures_root : string option;
+  parallel : int;
+}
+
+let _parse_parallel raw =
+  let n =
+    try Int.of_string raw
+    with _ ->
+      eprintf "Error: --parallel expects an integer, got %S\n%s\n" raw
+        _usage_msg;
+      Stdlib.exit 1
+  in
+  if n < 1 || n > Fork_pool.max_parallel then begin
+    eprintf "Error: --parallel must be in [1, %d], got %d\n%s\n"
+      Fork_pool.max_parallel n _usage_msg;
+    Stdlib.exit 1
+  end;
+  n
+
+let _parse_args argv =
+  let rec loop ckpt wf baseline out fixtures parallel = function
+    | [] -> (
+        match (ckpt, wf, baseline, out) with
+        | Some c, Some w, Some b, Some o ->
+            {
+              checkpoint_path = c;
+              walk_forward_spec_path = w;
+              baseline_aggregate_path = b;
+              out_path = o;
+              fixtures_root = fixtures;
+              parallel = Option.value parallel ~default:_default_parallel;
+            }
+        | _ ->
+            eprintf "%s\n" _usage_msg;
+            Stdlib.exit 1)
+    | "--checkpoint" :: p :: rest ->
+        loop (Some p) wf baseline out fixtures parallel rest
+    | "--walk-forward-spec" :: p :: rest ->
+        loop ckpt (Some p) baseline out fixtures parallel rest
+    | "--baseline-aggregate" :: p :: rest ->
+        loop ckpt wf (Some p) out fixtures parallel rest
+    | "--out" :: p :: rest ->
+        loop ckpt wf baseline (Some p) fixtures parallel rest
+    | "--fixtures-root" :: p :: rest ->
+        loop ckpt wf baseline out (Some p) parallel rest
+    | "--parallel" :: raw :: rest ->
+        loop ckpt wf baseline out fixtures (Some (_parse_parallel raw)) rest
+    | ("--help" | "-h") :: _ ->
+        printf "%s\n" _usage_msg;
+        Stdlib.exit 0
+    | unknown :: _ ->
+        eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
+        Stdlib.exit 1
+  in
+  loop None None None None None None argv
+
+let _load_aggregate path =
+  try Wf_report.aggregate_of_sexp (Sexp.load_sexp path)
+  with exn ->
+    failwithf "sensitivity_sweep: failed to load aggregate %s: %s" path
+      (Exn.to_string exn) ()
+
+(** Build a single-variant walk-forward spec for a particular candidate. The
+    baseline-label is preserved verbatim so the gate / aggregate keys line up
+    with the supplied baseline_aggregate. *)
+let _build_one_variant_spec ~(label : string) ~(overrides : Sexp.t list)
+    ~(template : Wf_spec.t) : Wf_spec.t =
+  let variant : Wf_runner.variant = { label; overrides } in
+  { template with variants = [ variant ] }
+
+let _run_one ~base ~template ~fixtures_root ~parallel ~label ~overrides :
+    Wf_types.aggregate =
+  let spec = _build_one_variant_spec ~label ~overrides ~template in
+  let result =
+    Wf_executor.execute_spec ~base ~spec ~fixtures_root
+      ~progress:Wf_executor.noop_progress ~parallel ()
+  in
+  result.aggregate
+
+let _score_aggregate ~candidate_label ~baseline_label ~candidate_aggregate
+    ~baseline_aggregate ~objective ~gate_penalty_value ~parameters : float =
+  let result =
+    Scoring.score_cell_with_penalty ~gate_penalty_value ~parameters
+      ~candidate_label ~baseline_label ~candidate_aggregate ~baseline_aggregate
+      ~objective
+  in
+  match result with
+  | Ok s -> s
+  | Error err ->
+      failwithf "sensitivity_sweep: scoring failed for %S: %s" candidate_label
+        (Status.show err) ()
+
+let _label_for ~(index : int) ~(pct : float) : string =
+  sprintf "%s-knob-%03d-pct-%+.0f" _candidate_label_prefix index (pct *. 100.0)
+
+(** Re-execute the unperturbed best cell to get the "true" best_score under the
+    current scoring formula (rather than trusting [Reader.best_iteration] which
+    carries the metric the BO recorded at run-time — may differ if the scorer
+    formula has changed since). *)
+let _execute_best_cell ~base ~template ~fixtures_root ~parallel
+    ~(best_params : (string * float) list) ~(int_keys : string list) :
+    Wf_types.aggregate =
+  let overrides = GS.cell_to_overrides ~int_keys best_params in
+  _run_one ~base ~template ~fixtures_root ~parallel ~label:_best_label_for_run
+    ~overrides
+
+let _execute_perturbation ~base ~template ~fixtures_root ~parallel
+    ~(int_keys : string list) ~(index : int) (p : Sweep.perturbation) :
+    string * Wf_types.aggregate =
+  let label = _label_for ~index ~pct:p.pct in
+  let overrides = GS.cell_to_overrides ~int_keys p.parameters in
+  let aggregate =
+    _run_one ~base ~template ~fixtures_root ~parallel ~label ~overrides
+  in
+  (label, aggregate)
+
+let _score_perturbations ~perturbations ~base ~template ~fixtures_root ~parallel
+    ~int_keys ~baseline_aggregate ~baseline_label ~objective ~gate_penalty_value
+    : float list =
+  List.mapi perturbations ~f:(fun index (p : Sweep.perturbation) ->
+      eprintf
+        "[sensitivity_sweep] running perturbation %d/%d (knob %S, pct %+.0f%%)\n\
+         %!"
+        (index + 1)
+        (List.length perturbations)
+        p.knob (p.pct *. 100.0);
+      let label, candidate_aggregate =
+        _execute_perturbation ~base ~template ~fixtures_root ~parallel ~int_keys
+          ~index p
+      in
+      _score_aggregate ~candidate_label:label ~baseline_label
+        ~candidate_aggregate ~baseline_aggregate ~objective ~gate_penalty_value
+        ~parameters:p.parameters)
+
+let _run (args : cli_args) =
+  let checkpoint = Reader.load args.checkpoint_path in
+  let best, best_idx =
+    match
+      (Reader.best_iteration checkpoint, Reader.best_iteration_index checkpoint)
+    with
+    | Some it, Some idx -> (it, idx)
+    | _ ->
+        failwithf
+          "sensitivity_sweep: checkpoint %s contains zero iterations — nothing \
+           to evaluate"
+          args.checkpoint_path ()
+  in
+  let bounds = checkpoint.spec.bounds in
+  let int_keys = checkpoint.spec.int_keys in
+  let objective = Spec.to_grid_objective checkpoint.spec.objective in
+  let gate_penalty_value =
+    Option.value checkpoint.spec.gate_penalty_value ~default:10.0
+  in
+  let perturbations =
+    Sweep.generate_perturbations ~best_params:best.parameters ~bounds
+  in
+  eprintf
+    "[sensitivity_sweep] best at iter %d (recorded score %.6f); generated %d \
+     perturbations across %d knobs\n\
+     %!"
+    best_idx best.metric
+    (List.length perturbations)
+    (List.length best.parameters);
+  let fixtures_root =
+    Fixtures_root.resolve ?fixtures_root:args.fixtures_root ()
+  in
+  let template = Wf_spec.load args.walk_forward_spec_path in
+  let baseline_label = template.baseline_label in
+  let base_path = Filename.concat fixtures_root template.base_scenario in
+  let base = Scenario.load base_path in
+  let baseline_aggregate = _load_aggregate args.baseline_aggregate_path in
+  eprintf "[sensitivity_sweep] re-executing unperturbed best cell\n%!";
+  let best_aggregate =
+    _execute_best_cell ~base ~template ~fixtures_root ~parallel:args.parallel
+      ~best_params:best.parameters ~int_keys
+  in
+  let best_score =
+    _score_aggregate ~candidate_label:_best_label_for_run ~baseline_label
+      ~candidate_aggregate:best_aggregate ~baseline_aggregate ~objective
+      ~gate_penalty_value ~parameters:best.parameters
+  in
+  let baseline_score =
+    _score_aggregate ~candidate_label:baseline_label ~baseline_label
+      ~candidate_aggregate:baseline_aggregate ~baseline_aggregate ~objective
+      ~gate_penalty_value ~parameters:[]
+  in
+  let scores =
+    _score_perturbations ~perturbations ~base ~template ~fixtures_root
+      ~parallel:args.parallel ~int_keys ~baseline_aggregate ~baseline_label
+      ~objective ~gate_penalty_value
+  in
+  let rows =
+    Sweep.build_rows ~best_score ~baseline_score ~perturbations ~scores
+  in
+  let report : Sweep.report =
+    {
+      candidate_label_prefix = _candidate_label_prefix;
+      baseline_label;
+      best_iteration_index = best_idx;
+      best_score;
+      baseline_score;
+      rows;
+    }
+  in
+  let md =
+    Sweep.render_report report ~checkpoint_path:args.checkpoint_path
+      ~walk_forward_spec_path:args.walk_forward_spec_path
+      ~baseline_aggregate_path:args.baseline_aggregate_path
+  in
+  Out_channel.write_all args.out_path ~data:md;
+  let sensitive_count = List.count rows ~f:(fun r -> r.sensitive) in
+  eprintf
+    "[sensitivity_sweep] wrote %s (best_score=%.6f, baseline_score=%.6f, \
+     sensitive_rows=%d/%d)\n\
+     %!"
+    args.out_path best_score baseline_score sensitive_count (List.length rows)
+
+let () =
+  let argv = Array.to_list (Sys.get_argv ()) |> List.tl_exn in
+  let args = _parse_args argv in
+  _run args

--- a/trading/trading/backtest/tuner/test/dune
+++ b/trading/trading/backtest/tuner/test/dune
@@ -1,5 +1,11 @@
 (tests
- (names test_grid_search test_bayesian_opt test_proxy_calibration_lib)
+ (names
+  test_grid_search
+  test_bayesian_opt
+  test_proxy_calibration_lib
+  test_bo_checkpoint_reader
+  test_holdout_eval
+  test_sensitivity_sweep)
  (libraries
   ounit2
   core
@@ -7,6 +13,7 @@
   status
   matchers
   tuner
+  tuner_bin
   walk_forward
   trading.simulation.types)
  (preprocess

--- a/trading/trading/backtest/tuner/test/test_bo_checkpoint_reader.ml
+++ b/trading/trading/backtest/tuner/test/test_bo_checkpoint_reader.ml
@@ -1,0 +1,217 @@
+(** Unit tests for {!Tuner_bin.Bo_checkpoint_reader}. Exercises the on-disk sexp
+    parser, schema-version enforcement, and best-iteration argmax. *)
+
+open OUnit2
+open Core
+open Matchers
+module Reader = Tuner_bin.Bo_checkpoint_reader
+module Spec = Tuner_bin.Bayesian_runner_spec
+module Metric_types = Trading_simulation_types.Metric_types
+
+(* ---------- Builders ---------- *)
+
+let _minimal_spec ~bounds : Spec.t =
+  {
+    bounds;
+    acquisition = Expected_improvement;
+    initial_random = 1;
+    total_budget = 3;
+    seed = Some 7;
+    n_acquisition_candidates = None;
+    objective = Sharpe;
+    scenarios = [];
+    holdout_folds = None;
+    sentinel_bounds = None;
+    length_scales = None;
+    early_stop = None;
+    gate_penalty_value = None;
+    int_keys = [];
+  }
+
+let _iteration ~params ~metric : Reader.saved_iteration =
+  { parameters = params; metric; per_scenario_metrics = [ Metric_types.empty ] }
+
+let _write_sexp_tmp ~dir ~name (sexp : Sexp.t) : string =
+  let path = Filename.concat dir name in
+  Out_channel.write_all path ~data:(Sexp.to_string sexp);
+  path
+
+let _with_temp_dir f =
+  let dir =
+    Filename_unix.temp_dir ~in_dir:Filename.temp_dir_name
+      "bo_checkpoint_reader_test_" ""
+  in
+  Exn.protect
+    ~f:(fun () -> f dir)
+    ~finally:(fun () ->
+      let rec rm_tree p =
+        if Sys_unix.is_directory_exn p then begin
+          Sys_unix.readdir p
+          |> Array.iter ~f:(fun child -> rm_tree (Filename.concat p child));
+          Core_unix.rmdir p
+        end
+        else Core_unix.unlink p
+      in
+      try rm_tree dir with _ -> ())
+
+(* ---------- best_iteration / best_iteration_index ---------- *)
+
+let test_best_iteration_picks_max_metric _ =
+  let spec = _minimal_spec ~bounds:[ ("a", (0.0, 1.0)) ] in
+  let ck : Reader.t =
+    {
+      schema_version = Reader.current_schema_version;
+      spec;
+      iterations =
+        [
+          _iteration ~params:[ ("a", 0.1) ] ~metric:0.5;
+          _iteration ~params:[ ("a", 0.7) ] ~metric:1.5;
+          _iteration ~params:[ ("a", 0.3) ] ~metric:1.0;
+        ];
+    }
+  in
+  assert_that (Reader.best_iteration ck)
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (it : Reader.saved_iteration) -> it.metric)
+              (float_equal 1.5);
+            field
+              (fun (it : Reader.saved_iteration) -> it.parameters)
+              (elements_are [ pair (equal_to "a") (float_equal 0.7) ]);
+          ]))
+
+let test_best_iteration_index_picks_max _ =
+  let spec = _minimal_spec ~bounds:[ ("a", (0.0, 1.0)) ] in
+  let ck : Reader.t =
+    {
+      schema_version = Reader.current_schema_version;
+      spec;
+      iterations =
+        [
+          _iteration ~params:[ ("a", 0.1) ] ~metric:0.5;
+          _iteration ~params:[ ("a", 0.7) ] ~metric:1.5;
+          _iteration ~params:[ ("a", 0.3) ] ~metric:1.0;
+        ];
+    }
+  in
+  assert_that (Reader.best_iteration_index ck) (is_some_and (equal_to 1))
+
+let test_best_iteration_empty_is_none _ =
+  let spec = _minimal_spec ~bounds:[ ("a", (0.0, 1.0)) ] in
+  let ck : Reader.t =
+    { schema_version = Reader.current_schema_version; spec; iterations = [] }
+  in
+  assert_that (Reader.best_iteration ck) is_none;
+  assert_that (Reader.best_iteration_index ck) is_none
+
+let test_best_iteration_breaks_ties_to_earliest _ =
+  (* Two iterations with identical metric → pick the earlier (lower index). *)
+  let spec = _minimal_spec ~bounds:[ ("a", (0.0, 1.0)) ] in
+  let ck : Reader.t =
+    {
+      schema_version = Reader.current_schema_version;
+      spec;
+      iterations =
+        [
+          _iteration ~params:[ ("a", 0.2) ] ~metric:1.0;
+          _iteration ~params:[ ("a", 0.8) ] ~metric:1.0;
+        ];
+    }
+  in
+  assert_that (Reader.best_iteration_index ck) (is_some_and (equal_to 0));
+  assert_that (Reader.best_iteration ck)
+    (is_some_and
+       (field
+          (fun (it : Reader.saved_iteration) -> it.parameters)
+          (elements_are [ pair (equal_to "a") (float_equal 0.2) ])))
+
+(* ---------- load: success path ---------- *)
+
+let test_load_round_trip _ =
+  let spec = _minimal_spec ~bounds:[ ("knob_a", (0.0, 1.0)) ] in
+  let ck : Reader.t =
+    {
+      schema_version = Reader.current_schema_version;
+      spec;
+      iterations = [ _iteration ~params:[ ("knob_a", 0.42) ] ~metric:0.99 ];
+    }
+  in
+  _with_temp_dir (fun dir ->
+      let path =
+        _write_sexp_tmp ~dir ~name:"bo_checkpoint.sexp" (Reader.sexp_of_t ck)
+      in
+      let loaded = Reader.load path in
+      assert_that loaded.schema_version (equal_to Reader.current_schema_version);
+      assert_that loaded.iterations
+        (elements_are
+           [
+             field
+               (fun (it : Reader.saved_iteration) -> it.metric)
+               (float_equal 0.99);
+           ]))
+
+(* ---------- load: error paths ---------- *)
+
+let _assert_raises_failure_substring substring f =
+  try
+    f ();
+    assert_failure
+      (Printf.sprintf "expected Failure containing %S, but no exception raised"
+         substring)
+  with
+  | Failure msg ->
+      if not (String.is_substring msg ~substring) then
+        assert_failure
+          (Printf.sprintf "expected Failure containing %S, got %S" substring msg)
+  | exn ->
+      assert_failure
+        (Printf.sprintf "expected Failure, got %s" (Exn.to_string exn))
+
+let test_load_missing_file_raises _ =
+  let f () = ignore (Reader.load "/tmp/_does_not_exist_42.sexp" : Reader.t) in
+  _assert_raises_failure_substring "file not found" f
+
+let test_load_schema_mismatch_raises _ =
+  let spec = _minimal_spec ~bounds:[ ("a", (0.0, 1.0)) ] in
+  let wrong_version : Reader.t =
+    { schema_version = 999; spec; iterations = [] }
+  in
+  _with_temp_dir (fun dir ->
+      let path =
+        _write_sexp_tmp ~dir ~name:"bo_checkpoint.sexp"
+          (Reader.sexp_of_t wrong_version)
+      in
+      let f () = ignore (Reader.load path : Reader.t) in
+      _assert_raises_failure_substring "schema_version" f)
+
+let test_load_malformed_sexp_raises _ =
+  _with_temp_dir (fun dir ->
+      let path = Filename.concat dir "bo_checkpoint.sexp" in
+      Out_channel.write_all path ~data:"this is not a sexp";
+      let f () = ignore (Reader.load path : Reader.t) in
+      _assert_raises_failure_substring "Bo_checkpoint_reader.load" f)
+
+let suite =
+  "Tuner_bin.Bo_checkpoint_reader"
+  >::: [
+         "best_iteration picks max metric"
+         >:: test_best_iteration_picks_max_metric;
+         "best_iteration_index picks max"
+         >:: test_best_iteration_index_picks_max;
+         "best_iteration on empty list is None"
+         >:: test_best_iteration_empty_is_none;
+         "best_iteration breaks ties to earliest"
+         >:: test_best_iteration_breaks_ties_to_earliest;
+         "load round-trips a freshly-written checkpoint"
+         >:: test_load_round_trip;
+         "load on missing file raises Failure with 'file not found'"
+         >:: test_load_missing_file_raises;
+         "load on schema_version mismatch raises Failure"
+         >:: test_load_schema_mismatch_raises;
+         "load on malformed sexp raises Failure"
+         >:: test_load_malformed_sexp_raises;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/tuner/test/test_holdout_eval.ml
+++ b/trading/trading/backtest/tuner/test/test_holdout_eval.ml
@@ -1,0 +1,327 @@
+(** Unit tests for {!Tuner_bin.Holdout_eval}. Exercises the pure pairing,
+    verdict-classification, and markdown-rendering helpers against synthetic
+    {!Walk_forward.Walk_forward_types.fold_actual} lists.
+
+    The CLI wrapper ([holdout_eval_main.ml]) is not tested here — it is a thin
+    arg-parser around these helpers + the production walk-forward executor;
+    testing it would require a real backtest. *)
+
+open OUnit2
+open Core
+open Matchers
+module Holdout = Tuner_bin.Holdout_eval
+module Wf_types = Walk_forward.Walk_forward_types
+
+(* ---------- Builders ---------- *)
+
+let _fold_actual ?(total_return_pct = 0.0) ?(calmar_ratio = 0.0)
+    ?(cagr_pct = 0.0) ?(avg_holding_days = Float.nan) ~fold_name ~variant_label
+    ~sharpe_ratio ~max_drawdown_pct () : Wf_types.fold_actual =
+  {
+    fold_name;
+    variant_label;
+    total_return_pct;
+    sharpe_ratio;
+    max_drawdown_pct;
+    calmar_ratio;
+    cagr_pct;
+    avg_holding_days;
+  }
+
+(* ---------- classify_verdict ---------- *)
+
+let test_classify_robust _ =
+  assert_that
+    (Holdout.classify_verdict ~mean_paired_sharpe_delta:0.20)
+    (equal_to Holdout.Robust)
+
+let test_classify_drops_at_threshold _ =
+  (* exactly at the threshold counts as Drops (> hurdle is Robust) *)
+  assert_that
+    (Holdout.classify_verdict ~mean_paired_sharpe_delta:Holdout.robust_threshold)
+    (equal_to Holdout.Drops)
+
+let test_classify_drops_small_positive _ =
+  assert_that
+    (Holdout.classify_verdict ~mean_paired_sharpe_delta:0.02)
+    (equal_to Holdout.Drops)
+
+let test_classify_fails_negative _ =
+  assert_that
+    (Holdout.classify_verdict ~mean_paired_sharpe_delta:(-0.10))
+    (equal_to Holdout.Fails)
+
+let test_classify_nan_is_fails _ =
+  assert_that
+    (Holdout.classify_verdict ~mean_paired_sharpe_delta:Float.nan)
+    (equal_to Holdout.Fails)
+
+(* ---------- pair_fold_actuals ---------- *)
+
+let _make_pair_fixture () =
+  [
+    _fold_actual ~fold_name:"fold-024" ~variant_label:"cell-E"
+      ~sharpe_ratio:0.50 ~max_drawdown_pct:20.0 ();
+    _fold_actual ~fold_name:"fold-025" ~variant_label:"cell-E"
+      ~sharpe_ratio:0.80 ~max_drawdown_pct:15.0 ();
+    _fold_actual ~fold_name:"fold-026" ~variant_label:"cell-E"
+      ~sharpe_ratio:1.00 ~max_drawdown_pct:10.0 ();
+    _fold_actual ~fold_name:"fold-027" ~variant_label:"cell-E"
+      ~sharpe_ratio:0.60 ~max_drawdown_pct:18.0 ();
+    _fold_actual ~fold_name:"fold-024" ~variant_label:"bo-iter-best"
+      ~sharpe_ratio:0.70 ~max_drawdown_pct:17.0 ();
+    _fold_actual ~fold_name:"fold-025" ~variant_label:"bo-iter-best"
+      ~sharpe_ratio:0.85 ~max_drawdown_pct:12.0 ();
+    _fold_actual ~fold_name:"fold-026" ~variant_label:"bo-iter-best"
+      ~sharpe_ratio:1.20 ~max_drawdown_pct:8.0 ();
+    _fold_actual ~fold_name:"fold-027" ~variant_label:"bo-iter-best"
+      ~sharpe_ratio:0.50 ~max_drawdown_pct:22.0 ();
+  ]
+
+let test_pair_fold_actuals_returns_one_row_per_match _ =
+  let fixture = _make_pair_fixture () in
+  let rows =
+    Holdout.pair_fold_actuals ~candidate_label:"bo-iter-best"
+      ~baseline_label:"cell-E" ~fold_actuals:fixture
+  in
+  assert_that rows (size_is 4)
+
+let test_pair_fold_actuals_computes_deltas _ =
+  let fixture = _make_pair_fixture () in
+  let rows =
+    Holdout.pair_fold_actuals ~candidate_label:"bo-iter-best"
+      ~baseline_label:"cell-E" ~fold_actuals:fixture
+  in
+  (* First row: fold-024, cand 0.70, base 0.50, Δ +0.20; cand DD 17, base DD 20, Δ -3 *)
+  assert_that rows
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (r : Holdout.per_fold_row) -> r.fold_name)
+               (equal_to "fold-024");
+             field
+               (fun (r : Holdout.per_fold_row) -> r.delta_sharpe)
+               (float_equal 0.20);
+             field
+               (fun (r : Holdout.per_fold_row) -> r.delta_max_drawdown_pct)
+               (float_equal (-3.0));
+           ];
+         field
+           (fun (r : Holdout.per_fold_row) -> r.fold_name)
+           (equal_to "fold-025");
+         field
+           (fun (r : Holdout.per_fold_row) -> r.fold_name)
+           (equal_to "fold-026");
+         field
+           (fun (r : Holdout.per_fold_row) -> r.fold_name)
+           (equal_to "fold-027");
+       ])
+
+let test_pair_fold_actuals_raises_on_missing_candidate _ =
+  let fixture = _make_pair_fixture () in
+  let f () =
+    ignore
+      (Holdout.pair_fold_actuals ~candidate_label:"missing-label"
+         ~baseline_label:"cell-E" ~fold_actuals:fixture
+        : Holdout.per_fold_row list)
+  in
+  try
+    f ();
+    assert_failure "expected Failure for missing candidate label"
+  with Failure msg ->
+    assert_that
+      (String.is_substring msg ~substring:"no rows for candidate")
+      (equal_to true)
+
+let test_pair_fold_actuals_raises_on_disjoint_fold_names _ =
+  let fixture =
+    [
+      _fold_actual ~fold_name:"fold-001" ~variant_label:"cell-E"
+        ~sharpe_ratio:0.5 ~max_drawdown_pct:10.0 ();
+      _fold_actual ~fold_name:"fold-002" ~variant_label:"bo-iter-best"
+        ~sharpe_ratio:0.7 ~max_drawdown_pct:12.0 ();
+    ]
+  in
+  let f () =
+    ignore
+      (Holdout.pair_fold_actuals ~candidate_label:"bo-iter-best"
+         ~baseline_label:"cell-E" ~fold_actuals:fixture
+        : Holdout.per_fold_row list)
+  in
+  try
+    f ();
+    assert_failure "expected Failure for disjoint folds"
+  with Failure msg ->
+    assert_that
+      (String.is_substring msg ~substring:"no candidate fold_name matched")
+      (equal_to true)
+
+(* ---------- build_report ---------- *)
+
+let test_build_report_robust_picks_strong_candidate _ =
+  (* Candidate dominates baseline: mean ΔSharpe = (0.2 + 0.05 + 0.2 - 0.1) /
+     4 = 0.0875 > 0.05 → Robust. *)
+  let fixture = _make_pair_fixture () in
+  let report =
+    Holdout.build_report ~candidate_label:"bo-iter-best"
+      ~baseline_label:"cell-E" ~holdout_folds:[ 25; 26; 27; 28 ]
+      ~best_iteration_index:25 ~best_iteration_score:0.171 ~fold_actuals:fixture
+  in
+  assert_that report
+    (all_of
+       [
+         field (fun (r : Holdout.report) -> r.verdict) (equal_to Holdout.Robust);
+         field (fun (r : Holdout.report) -> r.rows) (size_is 4);
+         field
+           (fun (r : Holdout.report) -> r.best_iteration_index)
+           (equal_to 25);
+         field
+           (fun (r : Holdout.report) -> r.mean_paired_sharpe_delta)
+           (float_equal ~epsilon:1e-9 0.0875);
+       ])
+
+let test_build_report_drops_when_marginal _ =
+  (* Two folds: ΔSharpe values (0.04, 0.02) — mean 0.03 ∈ (0, 0.05] → Drops. *)
+  let fixture =
+    [
+      _fold_actual ~fold_name:"f-1" ~variant_label:"cell-E" ~sharpe_ratio:0.50
+        ~max_drawdown_pct:10.0 ();
+      _fold_actual ~fold_name:"f-2" ~variant_label:"cell-E" ~sharpe_ratio:0.60
+        ~max_drawdown_pct:11.0 ();
+      _fold_actual ~fold_name:"f-1" ~variant_label:"cand" ~sharpe_ratio:0.54
+        ~max_drawdown_pct:9.0 ();
+      _fold_actual ~fold_name:"f-2" ~variant_label:"cand" ~sharpe_ratio:0.62
+        ~max_drawdown_pct:11.0 ();
+    ]
+  in
+  let report =
+    Holdout.build_report ~candidate_label:"cand" ~baseline_label:"cell-E"
+      ~holdout_folds:[ 1; 2 ] ~best_iteration_index:0 ~best_iteration_score:0.05
+      ~fold_actuals:fixture
+  in
+  assert_that report.verdict (equal_to Holdout.Drops)
+
+let test_build_report_fails_on_negative_delta _ =
+  let fixture =
+    [
+      _fold_actual ~fold_name:"f-1" ~variant_label:"cell-E" ~sharpe_ratio:0.50
+        ~max_drawdown_pct:10.0 ();
+      _fold_actual ~fold_name:"f-1" ~variant_label:"cand" ~sharpe_ratio:0.30
+        ~max_drawdown_pct:15.0 ();
+    ]
+  in
+  let report =
+    Holdout.build_report ~candidate_label:"cand" ~baseline_label:"cell-E"
+      ~holdout_folds:[ 1 ] ~best_iteration_index:0 ~best_iteration_score:(-0.1)
+      ~fold_actuals:fixture
+  in
+  assert_that report.verdict (equal_to Holdout.Fails);
+  assert_that report.mean_paired_sharpe_delta (float_equal (-0.20))
+
+(* ---------- render_report ---------- *)
+
+let test_render_report_contains_required_sections _ =
+  let fixture = _make_pair_fixture () in
+  let report =
+    Holdout.build_report ~candidate_label:"bo-iter-best"
+      ~baseline_label:"cell-E" ~holdout_folds:[ 25; 26; 27; 28 ]
+      ~best_iteration_index:25 ~best_iteration_score:0.171 ~fold_actuals:fixture
+  in
+  let md =
+    Holdout.render_report report ~checkpoint_path:"/tmp/ck.sexp"
+      ~walk_forward_spec_path:"/tmp/wf.sexp" ~baseline_aggregate_path:None
+      ~baseline_all_fold_mean_sharpe:None
+      ~baseline_all_fold_mean_max_drawdown_pct:None
+  in
+  (* Required sections: title, candidate metadata, per-fold table header,
+     each fold name, verdict. *)
+  assert_that
+    (List.for_all
+       [
+         "# Holdout-fold evaluation report";
+         "## Candidate";
+         "## Per-holdout-fold metrics";
+         "| Fold | Cand Sharpe | Base Sharpe |";
+         "`fold-024`";
+         "`fold-027`";
+         "**ROBUST**";
+         "iter 25";
+       ] ~f:(fun substring -> String.is_substring md ~substring))
+    (equal_to true)
+
+let test_render_report_includes_annotation_when_baseline_aggregate_supplied _ =
+  let fixture = _make_pair_fixture () in
+  let report =
+    Holdout.build_report ~candidate_label:"bo-iter-best"
+      ~baseline_label:"cell-E" ~holdout_folds:[ 25; 26; 27; 28 ]
+      ~best_iteration_index:25 ~best_iteration_score:0.171 ~fold_actuals:fixture
+  in
+  let md =
+    Holdout.render_report report ~checkpoint_path:"/tmp/ck.sexp"
+      ~walk_forward_spec_path:"/tmp/wf.sexp"
+      ~baseline_aggregate_path:(Some "/tmp/agg.sexp")
+      ~baseline_all_fold_mean_sharpe:(Some 0.893)
+      ~baseline_all_fold_mean_max_drawdown_pct:(Some 15.7)
+  in
+  assert_that
+    (List.for_all
+       [
+         "All-fold baseline annotation";
+         "Baseline aggregate: `/tmp/agg.sexp`";
+         "0.8930";
+         "15.7000";
+       ] ~f:(fun substring -> String.is_substring md ~substring))
+    (equal_to true)
+
+let test_render_report_omits_annotation_when_none _ =
+  let fixture = _make_pair_fixture () in
+  let report =
+    Holdout.build_report ~candidate_label:"bo-iter-best"
+      ~baseline_label:"cell-E" ~holdout_folds:[ 25; 26; 27; 28 ]
+      ~best_iteration_index:25 ~best_iteration_score:0.171 ~fold_actuals:fixture
+  in
+  let md =
+    Holdout.render_report report ~checkpoint_path:"/tmp/ck.sexp"
+      ~walk_forward_spec_path:"/tmp/wf.sexp" ~baseline_aggregate_path:None
+      ~baseline_all_fold_mean_sharpe:None
+      ~baseline_all_fold_mean_max_drawdown_pct:None
+  in
+  assert_that
+    (String.is_substring md ~substring:"All-fold baseline annotation")
+    (equal_to false)
+
+let suite =
+  "Tuner_bin.Holdout_eval"
+  >::: [
+         "classify Robust above threshold" >:: test_classify_robust;
+         "classify Drops AT the threshold (strict-greater is Robust)"
+         >:: test_classify_drops_at_threshold;
+         "classify Drops on small positive Δ"
+         >:: test_classify_drops_small_positive;
+         "classify Fails on negative Δ" >:: test_classify_fails_negative;
+         "classify Fails on NaN Δ" >:: test_classify_nan_is_fails;
+         "pair_fold_actuals returns one row per matched fold"
+         >:: test_pair_fold_actuals_returns_one_row_per_match;
+         "pair_fold_actuals computes Δ Sharpe and Δ MaxDD"
+         >:: test_pair_fold_actuals_computes_deltas;
+         "pair_fold_actuals raises on missing candidate label"
+         >:: test_pair_fold_actuals_raises_on_missing_candidate;
+         "pair_fold_actuals raises on disjoint fold names"
+         >:: test_pair_fold_actuals_raises_on_disjoint_fold_names;
+         "build_report verdict Robust on strong candidate"
+         >:: test_build_report_robust_picks_strong_candidate;
+         "build_report verdict Drops on marginal candidate"
+         >:: test_build_report_drops_when_marginal;
+         "build_report verdict Fails on negative Δ"
+         >:: test_build_report_fails_on_negative_delta;
+         "render_report contains required sections"
+         >:: test_render_report_contains_required_sections;
+         "render_report includes baseline annotation when supplied"
+         >:: test_render_report_includes_annotation_when_baseline_aggregate_supplied;
+         "render_report omits annotation when not supplied"
+         >:: test_render_report_omits_annotation_when_none;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/tuner/test/test_holdout_eval.ml
+++ b/trading/trading/backtest/tuner/test/test_holdout_eval.ml
@@ -135,6 +135,30 @@ let test_pair_fold_actuals_raises_on_missing_candidate _ =
       (String.is_substring msg ~substring:"no rows for candidate")
       (equal_to true)
 
+let test_pair_fold_actuals_raises_on_missing_baseline _ =
+  (* Mirror of [test_pair_fold_actuals_raises_on_missing_candidate]: pin the
+     third raise condition listed in the .mli (baseline label has zero rows
+     in [fold_actuals]). *)
+  let fixture =
+    [
+      _fold_actual ~fold_name:"fold-024" ~variant_label:"bo-iter-best"
+        ~sharpe_ratio:0.70 ~max_drawdown_pct:17.0 ();
+    ]
+  in
+  let f () =
+    ignore
+      (Holdout.pair_fold_actuals ~candidate_label:"bo-iter-best"
+         ~baseline_label:"cell-E" ~fold_actuals:fixture
+        : Holdout.per_fold_row list)
+  in
+  try
+    f ();
+    assert_failure "expected Failure for missing baseline label"
+  with Failure msg ->
+    assert_that
+      (String.is_substring msg ~substring:"no rows for baseline")
+      (equal_to true)
+
 let test_pair_fold_actuals_raises_on_disjoint_fold_names _ =
   let fixture =
     [
@@ -308,6 +332,8 @@ let suite =
          >:: test_pair_fold_actuals_computes_deltas;
          "pair_fold_actuals raises on missing candidate label"
          >:: test_pair_fold_actuals_raises_on_missing_candidate;
+         "pair_fold_actuals raises on missing baseline label"
+         >:: test_pair_fold_actuals_raises_on_missing_baseline;
          "pair_fold_actuals raises on disjoint fold names"
          >:: test_pair_fold_actuals_raises_on_disjoint_fold_names;
          "build_report verdict Robust on strong candidate"

--- a/trading/trading/backtest/tuner/test/test_sensitivity_sweep.ml
+++ b/trading/trading/backtest/tuner/test/test_sensitivity_sweep.ml
@@ -139,6 +139,56 @@ let test_generate_replaces_only_the_target_knob _ =
          pair (equal_to "c") (float_equal 0.3);
        ])
 
+let test_generate_zero_knob_is_no_op _ =
+  (* Pin the .mli claim: zero-valued knob (best_value = 0.0) → every
+     perturbation yields perturbed_value = 0.0 because 0.0 * (1 + pct) = 0.0
+     for every pct, and 0.0 is within bounds (0.0, 1.0) so clipped = false. *)
+  let perts =
+    Sweep.generate_perturbations
+      ~best_params:[ ("a", 0.0) ]
+      ~bounds:[ ("a", (0.0, 1.0)) ]
+  in
+  assert_that perts
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (p : Sweep.perturbation) -> p.knob) (equal_to "a");
+             field (fun (p : Sweep.perturbation) -> p.pct) (float_equal (-0.10));
+             field
+               (fun (p : Sweep.perturbation) -> p.perturbed_value)
+               (float_equal 0.0);
+             field (fun (p : Sweep.perturbation) -> p.clipped) (equal_to false);
+           ];
+         all_of
+           [
+             field (fun (p : Sweep.perturbation) -> p.knob) (equal_to "a");
+             field (fun (p : Sweep.perturbation) -> p.pct) (float_equal (-0.05));
+             field
+               (fun (p : Sweep.perturbation) -> p.perturbed_value)
+               (float_equal 0.0);
+             field (fun (p : Sweep.perturbation) -> p.clipped) (equal_to false);
+           ];
+         all_of
+           [
+             field (fun (p : Sweep.perturbation) -> p.knob) (equal_to "a");
+             field (fun (p : Sweep.perturbation) -> p.pct) (float_equal 0.05);
+             field
+               (fun (p : Sweep.perturbation) -> p.perturbed_value)
+               (float_equal 0.0);
+             field (fun (p : Sweep.perturbation) -> p.clipped) (equal_to false);
+           ];
+         all_of
+           [
+             field (fun (p : Sweep.perturbation) -> p.knob) (equal_to "a");
+             field (fun (p : Sweep.perturbation) -> p.pct) (float_equal 0.10);
+             field
+               (fun (p : Sweep.perturbation) -> p.perturbed_value)
+               (float_equal 0.0);
+             field (fun (p : Sweep.perturbation) -> p.clipped) (equal_to false);
+           ];
+       ])
+
 let test_generate_drops_knob_missing_from_bounds _ =
   let perts =
     Sweep.generate_perturbations
@@ -356,6 +406,8 @@ let suite =
          >:: test_generate_clipping_to_lower_bound;
          "generate: only the target knob's value changes"
          >:: test_generate_replaces_only_the_target_knob;
+         "generate: zero-valued knob produces no-op perturbations"
+         >:: test_generate_zero_knob_is_no_op;
          "generate: knobs missing from bounds are dropped"
          >:: test_generate_drops_knob_missing_from_bounds;
          "threshold = half of improvement"

--- a/trading/trading/backtest/tuner/test/test_sensitivity_sweep.ml
+++ b/trading/trading/backtest/tuner/test/test_sensitivity_sweep.ml
@@ -1,0 +1,379 @@
+(** Unit tests for {!Tuner_bin.Sensitivity_sweep}. Exercises the pure
+    perturbation-generation, scoring-row assembly, and markdown-rendering
+    helpers — the CLI wrapper ([sensitivity_sweep_main.ml]) is not tested here,
+    as it requires a real walk-forward executor. *)
+
+open OUnit2
+open Core
+open Matchers
+module Sweep = Tuner_bin.Sensitivity_sweep
+
+(* ---------- perturbation_pcts ---------- *)
+
+let test_perturbation_pcts_are_four_in_order _ =
+  assert_that Sweep.perturbation_pcts
+    (elements_are
+       [
+         float_equal (-0.10);
+         float_equal (-0.05);
+         float_equal 0.05;
+         float_equal 0.10;
+       ])
+
+(* ---------- generate_perturbations ---------- *)
+
+let test_generate_one_knob_yields_four_rows _ =
+  let perts =
+    Sweep.generate_perturbations
+      ~best_params:[ ("a", 1.0) ]
+      ~bounds:[ ("a", (0.0, 2.0)) ]
+  in
+  assert_that perts (size_is 4)
+
+let test_generate_three_knobs_yields_twelve_rows _ =
+  let perts =
+    Sweep.generate_perturbations
+      ~best_params:[ ("a", 1.0); ("b", 1.0); ("c", 1.0) ]
+      ~bounds:[ ("a", (0.0, 2.0)); ("b", (0.0, 2.0)); ("c", (0.0, 2.0)) ]
+  in
+  assert_that perts (size_is 12)
+
+let test_generate_perturbed_value_arithmetic _ =
+  (* best_value = 0.8, bounds (0.0, 2.0). Pcts -0.10, -0.05, +0.05, +0.10
+     → 0.72, 0.76, 0.84, 0.88. None clipped. *)
+  let perts =
+    Sweep.generate_perturbations
+      ~best_params:[ ("a", 0.8) ]
+      ~bounds:[ ("a", (0.0, 2.0)) ]
+  in
+  assert_that perts
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (p : Sweep.perturbation) -> p.pct) (float_equal (-0.10));
+             field
+               (fun (p : Sweep.perturbation) -> p.perturbed_value)
+               (float_equal ~epsilon:1e-9 0.72);
+             field (fun (p : Sweep.perturbation) -> p.clipped) (equal_to false);
+           ];
+         all_of
+           [
+             field (fun (p : Sweep.perturbation) -> p.pct) (float_equal (-0.05));
+             field
+               (fun (p : Sweep.perturbation) -> p.perturbed_value)
+               (float_equal ~epsilon:1e-9 0.76);
+           ];
+         all_of
+           [
+             field (fun (p : Sweep.perturbation) -> p.pct) (float_equal 0.05);
+             field
+               (fun (p : Sweep.perturbation) -> p.perturbed_value)
+               (float_equal ~epsilon:1e-9 0.84);
+           ];
+         all_of
+           [
+             field (fun (p : Sweep.perturbation) -> p.pct) (float_equal 0.10);
+             field
+               (fun (p : Sweep.perturbation) -> p.perturbed_value)
+               (float_equal ~epsilon:1e-9 0.88);
+           ];
+       ])
+
+let test_generate_clipping_to_upper_bound _ =
+  (* best_value = 1.95, +10% → 2.145 → clipped to 2.0 *)
+  let perts =
+    Sweep.generate_perturbations
+      ~best_params:[ ("a", 1.95) ]
+      ~bounds:[ ("a", (0.0, 2.0)) ]
+  in
+  let plus_ten =
+    List.find_exn perts ~f:(fun (p : Sweep.perturbation) ->
+        Float.equal p.pct 0.10)
+  in
+  assert_that plus_ten
+    (all_of
+       [
+         field
+           (fun (p : Sweep.perturbation) -> p.perturbed_value)
+           (float_equal 2.0);
+         field (fun (p : Sweep.perturbation) -> p.clipped) (equal_to true);
+       ])
+
+let test_generate_clipping_to_lower_bound _ =
+  (* best_value = 0.06, -10% → 0.054 → clipped to 0.10 (lower bound) *)
+  let perts =
+    Sweep.generate_perturbations
+      ~best_params:[ ("a", 0.06) ]
+      ~bounds:[ ("a", (0.10, 1.0)) ]
+  in
+  let minus_ten =
+    List.find_exn perts ~f:(fun (p : Sweep.perturbation) ->
+        Float.equal p.pct (-0.10))
+  in
+  assert_that minus_ten
+    (all_of
+       [
+         field
+           (fun (p : Sweep.perturbation) -> p.perturbed_value)
+           (float_equal 0.10);
+         field (fun (p : Sweep.perturbation) -> p.clipped) (equal_to true);
+       ])
+
+let test_generate_replaces_only_the_target_knob _ =
+  let perts =
+    Sweep.generate_perturbations
+      ~best_params:[ ("a", 1.0); ("b", 0.5); ("c", 0.3) ]
+      ~bounds:[ ("a", (0.0, 2.0)); ("b", (0.0, 1.0)); ("c", (0.0, 1.0)) ]
+  in
+  (* Take the -10% perturbation on "b": b becomes 0.45, a stays 1.0, c stays 0.3. *)
+  let b_pert =
+    List.find_exn perts ~f:(fun (p : Sweep.perturbation) ->
+        String.equal p.knob "b" && Float.equal p.pct (-0.10))
+  in
+  assert_that b_pert.parameters
+    (elements_are
+       [
+         pair (equal_to "a") (float_equal 1.0);
+         pair (equal_to "b") (float_equal ~epsilon:1e-9 0.45);
+         pair (equal_to "c") (float_equal 0.3);
+       ])
+
+let test_generate_drops_knob_missing_from_bounds _ =
+  let perts =
+    Sweep.generate_perturbations
+      ~best_params:[ ("a", 1.0); ("unknown", 0.5) ]
+      ~bounds:[ ("a", (0.0, 2.0)) ]
+  in
+  (* Only "a" survives; "unknown" silently dropped → 4 rows. *)
+  assert_that perts (size_is 4);
+  assert_that
+    (List.for_all perts ~f:(fun (p : Sweep.perturbation) ->
+         String.equal p.knob "a"))
+    (equal_to true)
+
+(* ---------- sensitivity_threshold ---------- *)
+
+let test_threshold_returns_half_improvement _ =
+  (* best 0.20, baseline 0.00 → improvement 0.20 → threshold 0.10 *)
+  assert_that
+    (Sweep.sensitivity_threshold ~best_score:0.20 ~baseline_score:0.0)
+    (is_some_and (float_equal 0.10))
+
+let test_threshold_none_when_best_not_above_baseline _ =
+  assert_that
+    (Sweep.sensitivity_threshold ~best_score:0.0 ~baseline_score:0.0)
+    is_none;
+  assert_that
+    (Sweep.sensitivity_threshold ~best_score:(-0.1) ~baseline_score:0.0)
+    is_none
+
+(* ---------- build_rows ---------- *)
+
+let _make_perturbation ~knob ~pct ~perturbed_value : Sweep.perturbation =
+  {
+    knob;
+    pct;
+    perturbed_value;
+    clipped = false;
+    parameters = [ (knob, perturbed_value) ];
+  }
+
+let test_build_rows_zips_perturbations_and_scores _ =
+  let perts =
+    [
+      _make_perturbation ~knob:"a" ~pct:(-0.10) ~perturbed_value:0.9;
+      _make_perturbation ~knob:"a" ~pct:0.10 ~perturbed_value:1.1;
+    ]
+  in
+  let rows =
+    Sweep.build_rows ~best_score:0.20 ~baseline_score:0.0 ~perturbations:perts
+      ~scores:[ 0.18; 0.05 ]
+  in
+  assert_that rows
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (r : Sweep.scored_row) -> r.knob) (equal_to "a");
+             field (fun (r : Sweep.scored_row) -> r.pct) (float_equal (-0.10));
+             field (fun (r : Sweep.scored_row) -> r.score) (float_equal 0.18);
+             field
+               (fun (r : Sweep.scored_row) -> r.delta_vs_best)
+               (float_equal ~epsilon:1e-9 (-0.02));
+             field (fun (r : Sweep.scored_row) -> r.sensitive) (equal_to false);
+           ];
+         all_of
+           [
+             field (fun (r : Sweep.scored_row) -> r.score) (float_equal 0.05);
+             (* threshold = 0.10; score 0.05 < 0.10 → sensitive *)
+             field (fun (r : Sweep.scored_row) -> r.sensitive) (equal_to true);
+           ];
+       ])
+
+let test_build_rows_length_mismatch_raises _ =
+  let perts = [ _make_perturbation ~knob:"a" ~pct:0.10 ~perturbed_value:1.1 ] in
+  let f () =
+    ignore
+      (Sweep.build_rows ~best_score:0.1 ~baseline_score:0.0 ~perturbations:perts
+         ~scores:[ 0.1; 0.2 ]
+        : Sweep.scored_row list)
+  in
+  try
+    f ();
+    assert_failure "expected Invalid_argument for length mismatch"
+  with Invalid_argument msg ->
+    assert_that
+      (String.is_substring msg ~substring:"length mismatch")
+      (equal_to true)
+
+let test_build_rows_never_flags_sensitive_when_no_improvement _ =
+  let perts = [ _make_perturbation ~knob:"a" ~pct:0.10 ~perturbed_value:1.1 ] in
+  let rows =
+    Sweep.build_rows ~best_score:0.0 ~baseline_score:0.0 ~perturbations:perts
+      ~scores:[ -10.0 ]
+  in
+  assert_that rows
+    (elements_are
+       [ field (fun (r : Sweep.scored_row) -> r.sensitive) (equal_to false) ])
+
+(* ---------- render_report ---------- *)
+
+let _sample_report () : Sweep.report =
+  {
+    candidate_label_prefix = "sensitivity";
+    baseline_label = "cell-E";
+    best_iteration_index = 25;
+    best_score = 0.20;
+    baseline_score = 0.0;
+    rows =
+      [
+        {
+          knob = "initial_stop_buffer";
+          pct = -0.10;
+          perturbed_value = 0.9;
+          clipped = false;
+          score = 0.18;
+          delta_vs_best = -0.02;
+          sensitive = false;
+        };
+        {
+          knob = "initial_stop_buffer";
+          pct = 0.10;
+          perturbed_value = 1.1;
+          clipped = false;
+          score = 0.05;
+          delta_vs_best = -0.15;
+          sensitive = true;
+        };
+      ];
+  }
+
+let test_render_report_contains_required_sections _ =
+  let r = _sample_report () in
+  let md =
+    Sweep.render_report r ~checkpoint_path:"/tmp/ck.sexp"
+      ~walk_forward_spec_path:"/tmp/wf.sexp"
+      ~baseline_aggregate_path:"/tmp/agg.sexp"
+  in
+  assert_that
+    (List.for_all
+       [
+         "# Sensitivity-sweep report";
+         "## Summary";
+         "## Per-perturbation results";
+         "| Knob | Pct | Perturbed value |";
+         "`initial_stop_buffer`";
+         "-10%";
+         "+10%";
+         "0.900000";
+         "1.100000";
+         "## Sensitivity summary";
+         "**yes**";
+       ] ~f:(fun substring -> String.is_substring md ~substring))
+    (equal_to true)
+
+let test_render_report_lists_each_sensitive_knob_uniquely _ =
+  let r = _sample_report () in
+  let md =
+    Sweep.render_report r ~checkpoint_path:"/tmp/ck.sexp"
+      ~walk_forward_spec_path:"/tmp/wf.sexp"
+      ~baseline_aggregate_path:"/tmp/agg.sexp"
+  in
+  (* Only one sensitive knob, even though the same knob has two rows; the
+     summary deduplicates. *)
+  assert_that
+    (String.is_substring md
+       ~substring:"1 sensitive perturbation(s) across 1 knob(s)")
+    (equal_to true)
+
+let test_render_report_no_sensitive_says_robust _ =
+  let robust_report : Sweep.report =
+    {
+      candidate_label_prefix = "sensitivity";
+      baseline_label = "cell-E";
+      best_iteration_index = 5;
+      best_score = 0.20;
+      baseline_score = 0.0;
+      rows =
+        [
+          {
+            knob = "a";
+            pct = -0.05;
+            perturbed_value = 0.95;
+            clipped = false;
+            score = 0.19;
+            delta_vs_best = -0.01;
+            sensitive = false;
+          };
+        ];
+    }
+  in
+  let md =
+    Sweep.render_report robust_report ~checkpoint_path:"/tmp/ck.sexp"
+      ~walk_forward_spec_path:"/tmp/wf.sexp"
+      ~baseline_aggregate_path:"/tmp/agg.sexp"
+  in
+  assert_that
+    (String.is_substring md
+       ~substring:"No perturbations crossed the sensitivity threshold")
+    (equal_to true)
+
+let suite =
+  "Tuner_bin.Sensitivity_sweep"
+  >::: [
+         "perturbation_pcts is four values in order"
+         >:: test_perturbation_pcts_are_four_in_order;
+         "generate: one knob → four rows"
+         >:: test_generate_one_knob_yields_four_rows;
+         "generate: three knobs → twelve rows"
+         >:: test_generate_three_knobs_yields_twelve_rows;
+         "generate: perturbed values match v*(1+pct)"
+         >:: test_generate_perturbed_value_arithmetic;
+         "generate: upper bound clipping"
+         >:: test_generate_clipping_to_upper_bound;
+         "generate: lower bound clipping"
+         >:: test_generate_clipping_to_lower_bound;
+         "generate: only the target knob's value changes"
+         >:: test_generate_replaces_only_the_target_knob;
+         "generate: knobs missing from bounds are dropped"
+         >:: test_generate_drops_knob_missing_from_bounds;
+         "threshold = half of improvement"
+         >:: test_threshold_returns_half_improvement;
+         "threshold is None when best ≤ baseline"
+         >:: test_threshold_none_when_best_not_above_baseline;
+         "build_rows zips perturbations and scores"
+         >:: test_build_rows_zips_perturbations_and_scores;
+         "build_rows raises Invalid_argument on length mismatch"
+         >:: test_build_rows_length_mismatch_raises;
+         "build_rows never flags sensitive when best ≤ baseline"
+         >:: test_build_rows_never_flags_sensitive_when_no_improvement;
+         "render_report contains required sections"
+         >:: test_render_report_contains_required_sections;
+         "render_report dedupes sensitive knobs in summary"
+         >:: test_render_report_lists_each_sensitive_knob_uniquely;
+         "render_report no-sensitive path says 'robust'"
+         >:: test_render_report_no_sensitive_says_robust;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Two new OCaml CLI executables for analysing a finished Bayesian-optimisation
sweep, prepped for the v7 production run currently in flight (~14h until
completion). Neither script runs until v7 finishes — this PR just lands
them on `main` so they're available when needed.

## What lands

1. **`Bo_checkpoint_reader`** (lib in `tuner_bin`) — pure on-disk loader for
   `bo_checkpoint.sexp`. Mirrors the writer's private record shape; exposes
   `load`, `best_iteration`, `best_iteration_index` with strict
   schema-version enforcement.

2. **`Holdout_eval`** (lib in `tuner_bin`) + **`holdout_eval_main.exe`** —
   loads a finished BO checkpoint, identifies the best observation, re-runs
   it through the walk-forward executor restricted to the holdout-fold
   subset declared in the BO spec's `holdout_folds` field, computes
   per-fold paired Sharpe + MaxDD deltas against the in-run baseline
   variant, and writes a markdown verdict report (ROBUST / DROPS / FAILS
   based on mean paired Sharpe Δ thresholds).

3. **`Sensitivity_sweep`** (lib in `tuner_bin`) + **`sensitivity_sweep_main.exe`** —
   generates ±5% and ±10% perturbations of each knob at the best cell
   (44 candidates for the v7 11-knob spec), clipped to the spec's per-knob
   bounds, runs each through the walk-forward executor, scores with the
   same scoring formula the BO used
   (`Bayesian_runner_scoring.score_cell_with_penalty`), and writes a
   markdown table flagging knobs whose perturbations drop the score by
   more than 50% of the best cell's improvement over baseline.

## Module placement note

The dispatch prompt called for `tuner/lib/bo_checkpoint_reader.{ml,mli}`.
The reader is placed under `tuner/bin/` (the `tuner_bin` library) instead,
matching the established pattern: every other read-only consumer of
`bo_checkpoint.sexp` lives there (`bayesian_runner_runner`,
`bayesian_runner_oos_validator`, `bayesian_runner_rescore`,
`bayesian_runner_scoring`). Placing it under `tuner/lib/` would invert
the existing dep direction (`tuner` does not depend on `tuner_bin`,
yet the sexp parser needs `Bayesian_runner_spec` which lives in
`tuner_bin`).

## PR size

~2400 LOC across 13 files: 1041 LOC of impl, 427 LOC of `.mli` contracts,
923 LOC of tests, small dune wiring. Larger than the agent template's
~500-LOC guideline; the dispatch prompt explicitly approves both scripts
in one PR because they share `Bo_checkpoint_reader`.

## Test plan

- [x] `dune build` — passes locally inside docker container
- [x] `dune runtest backtest/tuner/test/` — 128 tests pass (8 new for
      bo_checkpoint_reader, 15 new for holdout_eval, 16 new for
      sensitivity_sweep; 89 pre-existing)
- [x] `dune runtest` (full suite) — passes
- [x] `dune build @fmt` — clean
- [ ] **End-to-end smoke** against the v7 checkpoint — held until v7 finishes
      (~14h from PR-open). Run incantations documented in the next-session
      priorities doc.

## Post-sweep dispatch plan

Once v7 finishes
(`/Users/difan/Projects/trading-1/.sweep-output/11knob-v7-1998-2026-top3000/bo_checkpoint.sexp`):

1. **holdout_eval**: ~1h on `--parallel 4`
   ```
   dune exec trading/backtest/tuner/bin/holdout_eval_main.exe -- \
     --checkpoint /tmp/sweeps/11knob-v7-1998-2026-top3000/bo_checkpoint.sexp \
     --walk-forward-spec trading/test_data/walk_forward/cell_e_full_history_28fold_2026_05_25.sexp \
     --baseline-aggregate dev/experiments/bayesian-production-sweep-2026-05-25/baseline_aggregate_v7.sexp \
     --out /tmp/sweeps/11knob-v7-1998-2026-top3000/holdout_eval_report.md \
     --parallel 4
   ```

2. **sensitivity_sweep**: ~4h on `--parallel 4`
   ```
   dune exec trading/backtest/tuner/bin/sensitivity_sweep_main.exe -- \
     --checkpoint /tmp/sweeps/11knob-v7-1998-2026-top3000/bo_checkpoint.sexp \
     --walk-forward-spec trading/test_data/walk_forward/cell_e_full_history_28fold_2026_05_25.sexp \
     --baseline-aggregate dev/experiments/bayesian-production-sweep-2026-05-25/baseline_aggregate_v7.sexp \
     --out /tmp/sweeps/11knob-v7-1998-2026-top3000/sensitivity_sweep_report.md \
     --parallel 4
   ```