### PR TITLE
docs(notes): v7 BO sweep results — ROBUST holdout, promote REFUSED on 16y panel

### DIFF
--- a/dev/notes/v7-results-2026-05-28.md
+++ b/dev/notes/v7-results-2026-05-28.md
@@ -1,0 +1,134 @@
+# v7 BO sweep results — 2026-05-28
+
+**Sweep:** `dev/experiments/bayesian-production-sweep-2026-05-25/spec_prod_11knob_v7.sexp`
+**Walk-forward:** 28-fold, 1998-2026 full history, top-3000 universe
+**Baseline:** Cell-E aggregate (`baseline_aggregate_v7.sexp`)
+**Status:** sweep complete (60/60); holdout DONE; promote DONE (REFUSED); sensitivity FAILED (bug)
+
+## Headline
+
+- **Best iter:** 42 (paired-Δ vs Cell-E = **+0.380**)
+- **BO converged early.** Iter 42 found the peak; remaining 18 iters explored without improving.
+- **Holdout verdict: ROBUST** (mean per-fold Δ Sharpe = +0.328 over 4 holdout folds), but **fragile** — 2 of 4 folds lose, the win is carried by one big bear-year fold.
+
+## Iter 42 — best params
+
+| Knob | Value | v7 bound | Status |
+|---|---|---|---|
+| `initial_stop_buffer` | 1.395 | [0.5, 2] | mid |
+| `initial_stop_pct` | 0.0448 | [0.04, 0.15] | **near LOW** |
+| `installed_stop_min_pct` | 0.0189 | [0, 0.12] | low |
+| `entry_buffer_pct` | 0.0186 | [0, 0.02] | **near HIGH** |
+| `max_position_pct_long` | 0.0553 | [0.05, 0.25] | **near LOW** |
+| `max_long_exposure_pct` | 0.9388 | [0.5, 0.95] | **near HIGH** |
+| `risk_per_trade_pct` | 0.0116 | [0.005, 0.03] | mid |
+| `stage3_force_exit_config.hysteresis_weeks` | 2 (int) | [1, 5] | low |
+| `laggard_rotation_config.hysteresis_weeks` | **8 (int) AT MAX** | [1, 8] | **PINNED** |
+| `w_positive_rs` | **6 (int) AT MIN** | [5, 40] | **PINNED** |
+| `w_strong_volume` | 21 (int) | [5, 40] | mid |
+
+**Iter 42 in-sample (all 28 folds):**
+Sharpe 0.65, CAGR 24.3%, MaxDD 13.2%, Calmar 2.40, AvgHoldingDays 35.6.
+
+## Holdout (folds 25-28) — ROBUST but fragile
+
+| Fold (1-indexed display) | Cand Sharpe | Base Sharpe | Δ Sharpe |
+|---|---|---|---|
+| 024 | -1.16 | -0.93 | **-0.23** |
+| 025 | +0.57 | +0.64 | **-0.08** |
+| 026 | -0.30 | -1.76 | **+1.47** |
+| 027 | +1.28 | +1.13 | **+0.15** |
+
+**Mean Δ Sharpe = +0.328** (threshold +0.05 → ROBUST).
+
+Caveats:
+- Display label off-by-one (says 024-027 but spec declares holdout folds 25-28); doesn't change the numeric verdict.
+- **2 of 4 folds lose.** The +0.328 mean is carried by fold 026's +1.47 (a bear year where Cand survived and Base did not).
+- Implication: candidate is **bear-robust** but no edge (or slight disadvantage) in normal markets. Not a uniform improvement.
+
+## What v7 tells us about v8
+
+### Pinned bounds — widen for v8
+
+BO pushed against the boundary on 2 knobs (true pinned) and 4 more knobs (near-pinned). These bounds were too tight:
+
+| Knob | v7 | Suggested v8 |
+|---|---|---|
+| `laggard_rotation_config.hysteresis_weeks` | [1, 8] pinned at 8 | [1, **20**] |
+| `w_positive_rs` | [5, 40] pinned at 5 | [**0**, 40] (or drop knob — see below) |
+| `initial_stop_pct` | [0.04, 0.15] near low | [**0.02**, 0.15] |
+| `entry_buffer_pct` | [0, 0.02] near high | [0, **0.05**] |
+| `max_position_pct_long` | [0.05, 0.25] near low | [**0.03**, 0.25] |
+| `max_long_exposure_pct` | [0.5, 0.95] near high | [0.5, **1.0**] |
+
+### Knob importance signals
+
+- `w_positive_rs` pinned to MIN → positive-RS weight isn't a winning lever. Consider dropping or testing `[0, 40]` to see if 0 dominates.
+- `laggard_rotation_config.hysteresis_weeks=8 at max` → BO wanted MORE patience on rotating laggards. Widen the cap.
+- `max_position_pct_long=0.055` near min + `max_long_exposure_pct=0.939` near max → "many small positions, fully invested." Combined signal: position-count > position-size matters.
+
+### Sensitivity sweep — CRASHED
+
+`sensitivity_sweep_main` ran for ~1h then died with:
+
+```
+Failure "Walk_forward_report.compute: baseline_label \"cell-E\" not present in fold_actuals (labels: bo-iter-best)"
+```
+
+Bug: builds 1-variant spec (`bo-iter-best` only) but calls `Walk_forward_report.compute` with `baseline_label="cell-E"`. Fix needed in `sensitivity_sweep_main.ml`. Tracked as task #36; deferred until after v8 (sensitivity isn't load-bearing for v8 design — see "Promote failure" below).
+
+## Promote failure — much stronger v8 signal than sensitivity would have given
+
+Ran `promote_config.sh 2026-05-28-v7-11knob-iter42` against the default 2-scenario panel. **Result: PROMOTION REFUSED.**
+
+| Scenario | Cand Sharpe | Cell-E Sharpe | Δ Sharpe | Cand MaxDD% | Cell-E MaxDD% | Δ MaxDD | Cand Trades | Cell-E Trades | Trades ratio | Verdict |
+|---|---|---|---|---|---|---|---|---|---|---|
+| sp500-2010-2026 (16y) | **0.625** | 0.78 | **-0.155** | 19.19 | 18.36 | +0.83 | 1096 | 806 | 1.36× | ❌ FAIL (Sharpe regression > 0.10) |
+| sp500-2019-2023 (4y) | 0.713 | 0.56 | +0.153 | 25.77 | 21.56 | +4.21 | 434 | 264 | 1.64× | ✅ PASS |
+
+**Interpretation:**
+
+- **The BO objective (paired-Δ on 28-fold walk-forward) does not predict full-window Sharpe.** Iter 42 wins paired-Δ by +0.380 yet loses full-window Sharpe by -0.155 on the canonical 16y panel. The walk-forward CV is missing the inter-fold dynamics (regime transitions, compounding effects).
+- **Iter 42 is a 4y-bull-window winner** (sp500-2019-2023 +0.153 Sharpe) but a 16y-multi-regime loser. The same high-exposure (0.94) + tight-stop (0.045) combo that captures bull rallies hurts in transitions/chops.
+- **Trades ratio is fine.** My pre-run concern about `max_position_pct_long=0.055 → 2.5× trades → trades_ratio gate failure` was wrong. Actual trade-count increase is 1.36×-1.64×, well within 2× cap.
+- **MaxDD on 4y panel close to cap.** +4.21pp vs +5.0pp threshold. Another knob (e.g. higher exposure) could trip it.
+
+## v8 plan — REVISED based on promote failure
+
+**Don't just widen bounds and re-run the same objective.** The promote failure tells us paired-Δ on 28-fold WF is the wrong target. Three v8 axes to consider:
+
+### Axis A: change the BO objective (HIGHEST PRIORITY)
+
+Current: BO objective = `score_cell_with_penalty` over 28 walk-forward folds (paired-Δ vs cell-E).
+Problem: maximizing paired-Δ across folds doesn't constrain full-window Sharpe.
+
+Options:
+
+- **(a1) Add full-window Sharpe constraint to the score.** Score becomes `paired_delta - λ_full × max(0, cell_e_full_sharpe - cand_full_sharpe - tolerance)`. Requires a single extra sp500-2010-2026 backtest per BO iteration (~30s); manageable overhead.
+- **(a2) Change objective entirely to sp500-2010-2026 full-window Sharpe.** Drop walk-forward CV. Simpler, directly aligned with promote gate. Loses the fold-level robustness signal.
+- **(a3) Multi-objective: maximize 28-fold paired-Δ AND sp500-2010-2026 full Sharpe.** Two-dimensional Pareto. Expressive but BO doesn't support natively; would need custom scalarization.
+
+Recommended: **(a1)** — minimum disruption, directly addresses failure mode.
+
+### Axis B: widen bounds (per v7 pinned-knobs table above)
+
+Already laid out. Still valid alongside Axis A.
+
+### Axis C: add new knobs
+
+- `portfolio_config.max_per_sector_pct` — bear-regime fragility mitigant. Holdout fold 026 won by luck; a sector cap would harden the win.
+- `stage_classifier.short_uptrend_block_weeks` — early-uptrend false-positive filter. Cuts trade churn (addresses the trades-ratio drift).
+
+Keep ~11 knobs total for v8. Drop `w_positive_rs` (pinned at min → 0-weight signal).
+
+### Operational
+
+- **Use perf wins:** binary built post-#1317 (parallel 6 + RAM 12GB), #1318 (active_through pruning), #1323 (Flambda + -O3). Expected wall-time: 1-1.5d vs v7's 3d.
+- **Same walk-forward fixture + baseline aggregate** (no fold-set churn so signal is comparable to v7).
+- **Widen promote panel** in a follow-up PR. The 2-scenario panel (sp500-2010-2026 + sp500-2019-2023) catches "regresses on 16y" but misses sector exposure / bear-year coverage. Candidates for additions: broader-universe-2010-2026, French-49 subset, multi-decade Shiller.
+
+## Open questions
+
+- Is the bear-robustness in fold 026 a generalizable feature, or a single-fold accident? Walk-forward CV over multiple bear years (2001, 2008, 2020, 2022) would tell us — but our 28-fold spec only includes one severe bear (2008-09).
+- Should we drop `w_positive_rs` entirely, or keep it at fixed 0? Sensitivity sweep is the deciding signal.
+- Does the iter-42 config beat Buy-and-Hold over the full window? The score is paired vs Cell-E, not BAH — need to add a BAH overlay run.


### PR DESCRIPTION
## Summary

v7 11-knob BO sweep complete (60/60 iters). Best iter 42 paired-Δ +0.380 vs Cell-E.

Three downstream signals — one positive, two negative:

- **Holdout (folds 25-28): ROBUST** (mean Δ Sharpe +0.328) but fragile — 2/4 folds lose, win carried by fold 026 bear-year +1.47.
- **promote_config.sh: REFUSED** — sp500-2010-2026 (16y) Sharpe regresses by -0.155 vs cell-E baseline (gate threshold -0.10). sp500-2019-2023 (4y) passes with +0.153 improvement.
- **sensitivity_sweep: CRASHED** with a baseline_label bug in `sensitivity_sweep_main.ml`. Tracked as a follow-up; not blocking v8 because the promote signal is stronger evidence than per-knob sensitivity would have been.

## Key strategic finding

The BO objective (paired-Δ on 28-fold walk-forward) does **not** predict full-window Sharpe. Iter 42 wins the WF objective decisively while losing the canonical 16y full-window Sharpe by -0.155. The walk-forward CV is missing inter-fold dynamics (regime transitions, compounding).

## v8 plan (revised, 3 axes)

- **Axis A (NEW, highest priority):** add full-window Sharpe constraint to the BO score (`paired_delta - λ_full × max(0, cell_e_full_sharpe - cand_full_sharpe - tolerance)`). Requires one extra sp500-2010-2026 backtest per BO iteration (~30s overhead).
- **Axis B:** widen the 6 pinned/near-pinned bounds (laggard_hysteresis, w_positive_rs, initial_stop_pct, entry_buffer_pct, max_position, max_long_exposure).
- **Axis C:** add `max_per_sector_pct` + `short_uptrend_block_weeks`; drop `w_positive_rs`.

Don't launch v8 with bounds widening alone (Axes B+C) — it will likely fail promote the same way for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)