### PR TITLE
docs(plans): v8 score-formula coefficients — principled derivation

### DIFF
--- a/dev/plans/v8-bo-design-2026-05-28.md
+++ b/dev/plans/v8-bo-design-2026-05-28.md
@@ -1,0 +1,264 @@
+# v8 BO sweep — design plan
+
+**Date:** 2026-05-28
+**Supersedes:** preliminary v8 plan in `dev/notes/v7-results-2026-05-28.md` (3 axes).
+**Authority:** v7 results (`dev/notes/v7-results-2026-05-28.md`) + promote failure analysis.
+
+## Why a redesign, not just bounds widening
+
+v7's BO found a config (iter 42) that wins its objective (paired-Δ on 28-fold walk-forward, +0.380) but loses the gate that matters (sp500-2010-2026 Sharpe, -0.155 vs cell-E). The mismatch isn't tuneable through wider bounds. It's structural.
+
+Two structural pathologies the v7 results exposed:
+
+1. **Aggregation pathology.** Walk-forward folds use fresh capital each fold. Per-fold Sharpe/Calmar are scale-invariant — averaging them ignores compounding. A -30% bear year reduces the capital base going into subsequent bulls; the equal-weighted fold-mean never sees this.
+2. **Baseline pathology.** BO maximizes Δ vs cell-E. cell-E is hand-tuned but may itself underperform BAH SPY. Beating cell-E ≠ beating the free baseline a buy-and-hold investor would have used.
+
+Plus two perennial concerns that should be addressed alongside:
+
+3. **Knob count vs samples.** v7 = 11 knobs × 28 fold-pairs ≈ 2.5 samples/dim. Sparse. Drop to 7-9 knobs.
+4. **Drawdown linearity.** v7 score has linear MaxDD weight (-0.1 × DD%). A 10% DD penalty = 1.0; a 30% DD penalty = 3.0. Real investor utility is convex — 30% DD is *catastrophically* worse than 3× annoying. Convex DD penalty fits actual risk tolerance.
+
+## v8 design — five decisions
+
+### Decision 1: Sample structure → **K disjoint multi-year backtests**
+
+Replace 28-fold annual WF with 3 disjoint **train windows** (~7y each) + 1 disjoint **holdout window** (~7y), each evaluated as a full compounded backtest.
+
+| Window | Years | Purpose | Regime characterization |
+|---|---|---|---|
+| W1 | 1998-2004 (7y) | TRAIN | Dot-com run-up + crash + recovery |
+| W2 | 2005-2011 (7y) | TRAIN | Pre-GFC bull + GFC + 2010 recovery |
+| W3 | 2012-2018 (7y) | TRAIN | Post-GFC secular bull + 2018 Q4 wobble |
+| W4 | 2019-2025 (7y) | **HOLDOUT** | COVID + 2022 bear + recovery |
+
+Why this structure:
+- **Compounding seen within each window.** Each window's metrics come from a single multi-year compounded equity curve.
+- **3-sample training set ≪ 24-fold but each sample is 6× longer.** A 7y window sees regime transitions and compounding; a 1y fold mostly doesn't. Information per sample dominates sample count.
+- **Holdout is 7y multi-regime**, not 4y (v7 holdout was 2022-2025 = bear+bull mix but short). Stronger generalization signal.
+- **Disjoint, not overlapping**, to keep samples independent.
+
+Per-window evaluation: run full backtest, record `(CAGR, Sharpe, MaxDD%, total_trades)` for both candidate and SPY benchmark. SPY benchmark per window is precomputed once and cached.
+
+### Decision 2: Scoring metric → **SPY-anchored alpha with convex excess-DD penalty**
+
+Replace `paired_delta vs cell-E` with a formula whose every signal term is *paired against SPY* in the same window. This makes the SPY benchmark itself the natural zero of the score: any positive score is signed alpha over SPY in that regime, any negative score is signed regret.
+
+```
+score_per_window(w) =
+  + α · (cand_CAGR_w  - spy_CAGR_w)                       # CAGR alpha
+  + β · (cand_Sharpe_w - spy_Sharpe_w)                    # risk-adjusted alpha
+  - γ · [ max(0, cand_MaxDD_w - spy_MaxDD_w) ]²           # convex excess-DD
+  - δ · max(0, spy_CAGR_w - cand_CAGR_w - spy_tol)        # asymmetric SPY-loss gate
+
+score(params) = mean_w(score_per_window) - ε · var_w(cand_Sharpe_w - spy_Sharpe_w)
+```
+
+Final coefficients (in fractional units throughout: 0.05 means 5pp, not 5.0):
+
+| Coef | Value | Term it weights | Derivation |
+|---|---|---|---|
+| α | 20.0 | CAGR alpha (paired) | magnitude-normalized: α · 0.05 = 1.0 score-point at +5pp typical-winner alpha |
+| β | 1.4 | Sharpe alpha (paired) | magnitude-normalized: β · 0.7 = 0.98 score-point at +0.7 Sharpe-alpha extreme |
+| γ | 100.0 | excess-DD² (paired floor at 0) | convex; γ · (0.10)² = 1.0 score-point penalty for cand 10pp worse than SPY |
+| δ | 20.0 | SPY-loss gate (asymmetric) | symmetric with α; δ · 0.05 = 1.0 score-point for losing 5pp below tolerance |
+| ε | 1.0 | cross-window Sharpe-alpha variance | ε · 0.05 = 0.05 score-point for a "typical-stable" winner; ε · 0.50 = 0.50 for a fragile single-window winner |
+| `spy_tol` | 0.02 | gate dead-band | losses ≤ 2pp below SPY are "near-tied", no gate-fire |
+
+#### Methodology — hybrid: reference-point anchor + magnitude-normalization
+
+Of the four candidate approaches enumerated for this refinement, the chosen methodology is a hybrid:
+
+1. **Reference-point calibration (approach #2)** sets the formula *shape* — every signal term is paired against SPY in the same window so that SPY itself scores exactly 0. Any positive score is signed alpha; any negative score is signed regret. This makes "did the BO find something better than free?" a directly readable property of the score, not an inference.
+2. **Magnitude-normalization (approach #1)** sets the coefficient *values* — each term is scaled so its contribution at a "typical winner extreme" is roughly ±1 score-point. This keeps the BO's acquisition-function gradients balanced across terms; no one term dominates and silently turns the BO into a single-knob optimizer (the v7 problem).
+3. **CRRA utility (approach #3)** informs only the convex-DD term's *shape* (quadratic on excess), not its magnitude — we anchor magnitude via #1. Picking a domain-specific λ for this codebase has no principled foundation; using CRRA only for the shape sidesteps that.
+4. **Meta-CV (approach #4)** is reserved for *post-hoc verification*, not derivation. After the BO completes, we sensitivity-sweep the coefficients themselves to confirm the iter-best identity is stable under ±50% perturbation per coefficient.
+
+Why a hybrid rather than any single approach in pure form:
+- Pure #1 alone gives a magnitude-balanced but reference-free score — SPY itself scores nonzero, making "beats SPY" require an extra subtraction at every analysis step.
+- Pure #2 alone (e.g. *only* the α·alpha term) ignores risk-adjusted performance and tail-risk shape.
+- Pure #3 (CRRA from λ) requires picking a risk-aversion λ with no principled value in this domain.
+- Pure #4 is verification, not derivation.
+
+The hybrid uses each approach where it has the most authority.
+
+#### Two corrections to the starting formula
+
+While deriving, two issues in the starting formula were found and fixed:
+
+1. **Sign error in the SPY-loss gate.** The starting form was `δ · max(0, spy_CAGR - cand_CAGR + spy_tol)`. At cand = SPY this evaluates to `δ · spy_tol > 0` — the penalty fires when matching SPY exactly. The intent (per the surrounding comment) is for the penalty to fire only when cand loses to SPY by *more* than `spy_tol`. Correct form: `max(0, spy_CAGR - cand_CAGR - spy_tol)`. Adopted.
+2. **Absolute DD threshold broke the SPY anchor.** The starting form was `γ · max(0, cand_DD - dd_threshold)²` with `dd_threshold = 0.15`. SPY itself takes ~55% DD in W2 (GFC) and ~34% in W4 (2022 bear) — those windows would score SPY at −3 to −7 score-points just from the DD term, breaking the SPY-anchor. Replacing the absolute threshold with paired excess over SPY (`max(0, cand_DD - spy_DD)²`) recovers the SPY = 0 anchor while still convexly penalizing strategies that take more DD than SPY does in the same regime. The absolute catastrophic-DD floor is not needed in the smooth score — it lives as a hard barrier in `promote_config.sh` (catastrophic-DD veto, independent of the smooth BO objective).
+
+#### Per-coefficient derivation
+
+**α = 20.0** (CAGR alpha). Typical-winner extreme is ≈ +5pp = 0.05 per window (the verdict criteria require ≥ +1pp; +5pp is "decisively winning"). Magnitude-normalize: α · 0.05 = 1.0. → α = 20.0. Lower-bound check: at the verdict-threshold +1pp, this term contributes +0.20 — small but positive, correctly distinguishing marginal-winner from neutral.
+
+**β = 1.4** (Sharpe alpha). Plausible Sharpe range per window is [−1, +2.5]; a competitive strategy's Sharpe alpha vs SPY is roughly [−1.5, +1.5]; "typical winner extreme" Sharpe alpha ≈ +0.7. β · 0.7 = 0.98 ≈ 1.0. → β = 1.4. Rationale for keeping this term despite α already covering returns: a strategy with the same CAGR alpha but lower volatility-of-returns earns extra credit. Two strategies tied on CAGR alpha are correctly ranked by β.
+
+**γ = 100.0** (convex excess-DD). The form `γ · [excess_DD]²` is CRRA-flavored (quadratic loss) without requiring a domain-specific λ. Magnitude anchor: at +10pp excess DD over SPY ("moderately worse risk profile"), penalty = γ · (0.10)² = 1.0. → γ = 100. Convexity check: at +20pp excess DD, penalty = γ · 0.04 = 4.0 — dominates ~4 windows' worth of alpha credit (typical winner accumulates ~4 × 1.0 = 4.0 alpha credit). At +30pp excess, penalty = 9.0 — eliminating. Symmetric inversion: a strategy with *less* DD than SPY (excess_DD < 0) receives no DD credit (the `max(0,·)` floor); the DD term only penalizes, never rewards. Lower DD is rewarded indirectly via the β·Sharpe-alpha term.
+
+**δ = 20.0** (asymmetric SPY-loss gate). Mirrors α by symmetry — losing 5pp to SPY in any window incurs 1.0 score-point penalty *on top of* the α·alpha penalty (which is already −1.0 for a 5pp loss). Combined: a 5pp loss in a single window costs 2.0 score-points (mean-aggregated across 4 windows = 0.5). The two-fold weighting reflects the verdict criterion that the strategy must beat SPY in *all* windows, not on average. `spy_tol = 0.02`: losses up to 2pp are within bounds of fold-level noise (we don't want the BO chasing 1-2pp differences that won't survive holdout); larger gaps are progressively penalized.
+
+**ε = 1.0** (cross-window stability). All variance numbers below are *population* variance (sum-of-squared-deviations divided by N, the natural reduction across exactly-4 windows). A "typical stable winner" has Sharpe alpha {+0.5, +0.3, +0.4, +0.6} → mean = 0.45, var ≈ 0.0125, penalty = 0.013 (negligible — correct: we don't penalize natural cross-regime variation). A "fragile single-window winner" (v7-iter42 pattern) has Sharpe alpha {−0.4, −0.5, +0.3, +1.5} → mean = 0.225, var = 2.5475/4 ≈ 0.637, penalty = 0.637 (substantial — correct: ε actively penalizes the v7-iter42 failure mode, flipping a marginally-positive mean into a clearly-negative score). Magnitude-normalize at the fragile boundary: ε · 0.5 ≈ 0.5 → ε = 1.0.
+
+**`dd_threshold` dropped.** Absolute DD threshold replaced by paired-excess DD (above). The absolute catastrophic-DD veto lives in `promote_config.sh`, not in the smooth score.
+
+**`spy_tol = 0.02`.** Two-percentage-point dead-band on the gate term. Empirically defensible as roughly the standard error of CAGR over a 7-year window — narrower would chase noise; wider would let real underperformance through.
+
+#### Worked examples (with the final coefficients)
+
+All five use the 4-window structure (W1: 1998-2004, W2: 2005-2011, W3: 2012-2018, W4: 2019-2025).
+
+**Example A — SPY itself (anchor verification).**
+Every paired term is 0; gate is 0; var is 0. **Score = 0.00 exactly.** ✓ The anchor holds — SPY scores exactly the reference value, independent of the per-window DD/Sharpe magnitudes that vary widely across the four windows.
+
+**Example B — typical winner** (consistent +2pp CAGR alpha, +0.3 Sharpe alpha, −5pp DD vs SPY, all 4 windows).
+Per-window: 20·(0.02) + 1.4·(0.3) − 100·(0)² − 0 = 0.40 + 0.42 = +0.82.
+Var of Sharpe-alpha = 0 (all four +0.3).
+**Score = 0.82.** Strong positive — recognizable winner.
+
+**Example C — marginal config** (matches SPY CAGR ±0pp, matches Sharpe ±0, takes +2pp excess DD in each window).
+Per-window: 0 + 0 − 100·(0.02)² − 0 = −0.04.
+Var = 0 → ε·0 = 0.
+**Score = −0.04.** Slightly negative — correctly identifies "no edge, mild DD drag."
+
+**Example D — v7-iter42 pattern** (bull-window winner, bear-window loser). Per-window assumed Sharpe alpha {−0.4, −0.5, +0.3, +1.5}, CAGR alpha {−0.03, −0.05, +0.04, +0.10}, excess-DD {+0.03, +0.05, +0.01, +0.02}:
+
+| Window | α·CAGR-α | β·Sharpe-α | γ·excess-DD² | δ·gate | Per-window |
+|---|---|---|---|---|---|
+| W1 (dot-com) | 20·(−0.03)=−0.60 | 1.4·(−0.4)=−0.56 | 100·(0.03)²=−0.09 | 20·max(0,0.03−0.02)=−0.20 | **−1.45** |
+| W2 (GFC) | 20·(−0.05)=−1.00 | 1.4·(−0.5)=−0.70 | 100·(0.05)²=−0.25 | 20·(0.05−0.02)=−0.60 | **−2.55** |
+| W3 (post-GFC bull) | 20·(0.04)=+0.80 | 1.4·(0.3)=+0.42 | 100·(0.01)²=−0.01 | 0 | **+1.21** |
+| W4 (mixed) | 20·(0.10)=+2.00 | 1.4·(1.5)=+2.10 | 100·(0.02)²=−0.04 | 0 | **+4.06** |
+
+Mean = (−1.45 − 2.55 + 1.21 + 4.06)/4 = +0.32.
+Var(Sharpe-α) with values {−0.4, −0.5, +0.3, +1.5}: mean = +0.225, sum-of-squared-deviations = 0.391 + 0.526 + 0.006 + 1.626 = 2.548; population var = 2.548 / 4 ≈ 0.637. ε·var = −0.637.
+**Score = 0.32 − 0.637 = −0.32.**
+
+This is correctly rejected — the cross-window variance term alone is enough to flip the verdict from "barely positive" to "decisively negative." The ε·variance term is doing exactly the work it was designed for: catching v7-iter42-style fragile winners that the per-window mean alone would let through.
+
+**Example E — catastrophic single-window blow-up** (matches SPY in W1/W3/W4, +20pp excess DD in W2 with −10pp CAGR alpha).
+W1/W3/W4 per-window: 0 each.
+W2: 20·(−0.10) + 1.4·0 − 100·(0.20)² − 20·(0.10−0.02) = −2.00 + 0 − 4.00 − 1.60 = **−7.60**.
+Mean = −7.60/4 = −1.90.
+Var(Sharpe-α) ≈ 0 (only W2 deviates; small).
+**Score ≈ −1.90.** Eliminating.
+
+#### Sanity table — score → verdict mapping
+
+| Score range | Interpretation | Verdict implication |
+|---|---|---|
+| ≥ +0.50 | Decisively beats SPY across most windows | Likely passes promote gate |
+| +0.05 to +0.50 | Marginal positive alpha | Pass conditional on holdout |
+| −0.05 to +0.05 | Indistinguishable from SPY | No edge worth capital allocation |
+| −0.50 to −0.05 | Worse than SPY on signal or risk | Reject |
+| ≤ −0.50 | Materially worse than SPY | Reject; likely catastrophic in ≥1 window |
+
+#### Post-hoc verification (Meta-CV per approach #4)
+
+After the BO completes, run `sensitivity_sweep` over the score coefficients themselves (perturb each by ±50%) and verify the iter-best identity is stable. If the winner flips under a 50% perturbation of any one coefficient, the result is coefficient-overfit and not a real alpha signal. Tracked in the Risk Register below as "score formula coefficients (α-ε) are themselves overfit" — this is the post-hoc check that retires that risk.
+
+### Decision 3: Baseline → **BAH SPY (and BAH BRK-A for reference)**
+
+- BAH SPY is the **universal free baseline.** Any real strategy needs to beat it after costs.
+- BAH BRK-A is the **"elite human manager" baseline.** Reported alongside but NOT in scoring (its volatility makes it a weird optimization target).
+- cell-E disappears as a baseline. v7-iter42 beating cell-E was meaningless because cell-E itself may have underperformed SPY. We score against SPY directly.
+
+This requires the BAH SPY full-window aggregate to be available per evaluation window. Use the existing BAH SPY aggregates from PR #1322 (T4.3 baseline) extended per window, OR compute on-the-fly (cheap, just buy-hold-sell SPY).
+
+### Decision 4: Knob set → **9 knobs (down from 11)**
+
+Drop the two truly-pinned ones from v7 (no signal at the bound). Add one new knob (sector cap, direct mitigant for bear-fragility seen in holdout). Widen bounds where v7 hit the boundary.
+
+| # | Knob | v7 bound | v7 winner | v8 bound | Rationale |
+|---|---|---|---|---|---|
+| 1 | `initial_stop_buffer` | [0.5, 2] | 1.395 (mid) | [0.5, 2] | mid-range, no signal change |
+| 2 | `initial_stop_pct` | [0.04, 0.15] | 0.045 (near-low) | **[0.02, 0.15]** | widen low; BO wanted lower |
+| 3 | `installed_stop_min_pct` | [0, 0.12] | 0.019 | [0, 0.12] | keep — informational |
+| 4 | `entry_buffer_pct` | [0, 0.02] | 0.019 (near-high) | **[0, 0.05]** | widen high |
+| 5 | `max_position_pct_long` | [0.05, 0.25] | 0.055 (near-low) | **[0.03, 0.25]** | widen low |
+| 6 | `max_long_exposure_pct` | [0.5, 0.95] | 0.939 (near-high) | **[0.5, 1.0]** | widen to 100% |
+| 7 | `risk_per_trade_pct` | [0.005, 0.03] | 0.012 (mid) | [0.005, 0.03] | no change |
+| 8 | `stage3_force_exit.hysteresis_weeks` | [1, 5] | 2 (low-mid) | [1, 5] | no change |
+| 9 | `laggard_rotation.hysteresis_weeks` | [1, 8] | 8 (**MAX**) | **[1, 20]** | widen high; BO pinned at cap |
+| -- | `w_positive_rs` | [5, 40] | 5 (**MIN**) | DROP | pinned at min → useless |
+| -- | `w_strong_volume` | [5, 40] | 21 (mid) | DROP | low-priority; revisit later |
+| 10 | `max_per_sector_pct` | -- | -- | **[0.10, 0.50]** | NEW; mitigates bear-year fragility (holdout fold 026 won by luck) |
+
+Net: 9 knobs (3 widened, 1 new, 2 dropped).
+
+### Decision 5: BO mechanics → **modest changes**
+
+- **Initial random:** 15 → **20**. More exploration since the scoring surface is reshaped.
+- **Total budget:** 60 → **80**. Allows more exploitation iterations given the larger search volume from widened bounds + new knob.
+- **Acquisition:** keep **Expected Improvement.** Works well for our setting.
+- **Seed:** new seed (e.g. 2027) to avoid reusing v7's Sobol sequence.
+
+## Implementation sequencing (5 PRs)
+
+### PR-1: Multi-window backtest infrastructure
+Add new module `trading/trading/backtest/multi_window/`:
+- `Multi_window_spec`: list of `(start_date, end_date, label)` windows
+- `Multi_window_runner`: given a strategy + multi-window spec → per-window full backtest, returns `(per_window_metrics, per_window_equity_curves)`
+- Reuses existing `Walk_forward_runner` infrastructure (just non-overlapping windows without the train/test split semantics)
+- Unit tests pinning the per-window metrics output
+
+### PR-2: Absolute-alpha scoring function
+In `trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml`:
+- Add `score_absolute_alpha` variant of the existing `score_cell_with_penalty`
+- Inputs: per-window candidate metrics + per-window SPY benchmark metrics
+- Output: scalar score per the formula in Decision 2
+- Unit tests pinning each of the 5 score terms independently + composite
+- Unit tests pinning the SPY-itself = 0 anchor at the chosen coefficients
+
+### PR-3: bayesian_runner integration
+- Add CLI flags `--multi-window-spec <path>` and `--objective absolute_alpha`
+- When set, runner uses `Multi_window_runner` + `score_absolute_alpha` instead of WF + paired-Δ
+- Spec file format extends to declare windows + SPY-benchmark source
+- Backward compatible: existing v7-style specs still work
+
+### PR-4: v8 spec + SPY benchmark fixtures
+- Create `dev/experiments/bayesian-production-sweep-2026-05-28/spec_prod_v8_9knob.sexp`
+- Create per-window SPY aggregates (`baseline_spy_w1.sexp`, ..., `baseline_spy_w4.sexp`) — pre-compute once, check in.
+- Walk-forward spec equivalent for `--multi-window-spec`: declares 3 train + 1 holdout window.
+- Launch script `launch_v8.sh`.
+
+### PR-5: Post-sweep analysis extensions
+- Extend `holdout_eval` to support multi-window mode (already mostly compatible — just needs to call multi_window_runner for the holdout window)
+- Fix `sensitivity_sweep` baseline-label bug (independent task #36; already dispatched)
+- Optional: `promote_config.sh` panel expansion (broader scenarios — but defer to v8 results before deciding)
+
+## Expected outcomes + verdict criteria
+
+**Wall-time projection:** v7 was 3d at parallel=4 with pre-perf binary. v8 with post-perf binary (parallel 6 + Flambda + active_through pruning) on 3 train windows × ~3min each per iter × 80 iters / parallel = **~6-12h**. Fast.
+
+**Verdict criteria when v8 completes:**
+
+| Criterion | What it tells us |
+|---|---|
+| Best iter beats SPY by **≥ 1pp CAGR** in ALL 3 train windows | Real alpha, not lucky-fold artifact |
+| Holdout (W4 2019-2025) shows **CAGR Δ ≥ 0** vs SPY | Generalizes out-of-sample |
+| MaxDD on holdout **≤ 25%** | Acceptable tail behavior |
+| promote_config gate passes for **sp500-2010-2026** (the v7 fail) | Aligned with promote |
+
+If criteria fail: signal that even multi-window + SPY-aligned scoring isn't enough — pivot to broader-universe sweep (per the existing strategic backlog memory `project_strategic_pivot_broader_first.md`).
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| 3 training samples is too few — BO converges to noise | Holdout (W4 alone) is a strong tiebreaker; verdict criteria require holdout pass |
+| Score formula coefficients (α-ε) are themselves overfit | Post-hoc sensitivity-sweep at ±50% per coefficient (Decision 2 §"Post-hoc verification"); pin via cross-validation if iter-best identity flips |
+| BAH SPY benchmark per window is annoyingly path-dependent on start/end dates | Pin window dates exactly; document SPY values per window in spec |
+| Multi-window code is new + only used here | PR-1 has unit tests; PR-3 integration is small once PR-1 lands |
+| v7-iter42 was a "bull-window winner" — v8 might similarly be a "multi-window-but-still-overfit winner" | The δ term (penalty for losing to SPY in any window) AND the ε term (cross-window Sharpe-alpha variance) explicitly force winners to be uniformly competitive, not just average-positive. Example D in Decision 2 shows the v7-iter42 pattern correctly rejected. |
+
+## What v8 explicitly does NOT do
+
+- **Not changing the universe** (still top-3000 sectors.csv pinned). Broader-universe sweep is a separate strategic axis.
+- **Not adding non-stop knobs** (sector rotation logic, short-side, etc.). Keep mechanism set fixed.
+- **Not bootstrapping fold orderings.** Block bootstrap was a candidate but the train/holdout split + window disjointness gives enough robustness signal at lower complexity.
+- **Not changing the strategy core** (Weinstein). The strategy works; the *tuning* didn't.
+
+## Open question (one)
+
+Should we score on `cand_CAGR - spy_CAGR` (linear alpha) or `cand_CAGR / spy_CAGR` (ratio alpha)? The former is what investors actually consume. The latter is scale-invariant across windows of different SPY returns. Default to linear (α term as written). Revisit if scoring across windows produces weird artifacts.


### PR DESCRIPTION
## Summary

Refines § Decision 2 of `dev/plans/v8-bo-design-2026-05-28.md` with a principled coefficient methodology in place of the intuition-based draft.

**Methodology: hybrid — reference-point anchor + magnitude-normalization.**
- Reference-point: every signal term is paired against SPY in the same window so SPY itself scores exactly 0. Any positive score = signed alpha; any negative = signed regret.
- Magnitude-normalization: each term scaled so its contribution at a "typical winner extreme" is ~±1 score-point — keeps BO gradients balanced across terms.
- CRRA only informs the convex-DD term's shape (quadratic), not its magnitude.
- Meta-CV reserved for post-hoc verification (sensitivity-sweep coefficients ±50%).

## Two corrections to the starting formula

1. **Sign error in SPY-loss gate.** Original `δ · max(0, spy_CAGR - cand_CAGR + spy_tol)` fired at cand = SPY exactly. Corrected to `max(0, spy_CAGR - cand_CAGR - spy_tol)`.
2. **Absolute DD threshold broke the SPY anchor.** Original `γ · max(0, cand_DD - 0.15)²` would score SPY itself at -3 to -7 in W2 (GFC ~55% DD) / W4 (2022 ~34% DD). Replaced with paired excess over SPY: `γ · max(0, cand_DD - spy_DD)²`. Catastrophic-DD floor stays in `promote_config.sh` as a hard veto.

## Final coefficients

| Coef | Value | Term |
|---|---|---|
| α | 20.0 | CAGR alpha (paired) |
| β | 1.4 | Sharpe alpha (paired) |
| γ | 100.0 | excess-DD² (paired) |
| δ | 20.0 | SPY-loss gate |
| ε | 1.0 | cross-window Sharpe-alpha variance |
| spy_tol | 0.02 | 2pp dead-band |

Worked examples (typical winner / typical loser / marginal config) included in the doc.

## Test plan

Doc-only. CI runs status-file-integrity linter; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)