### PR TITLE
docs(plans): v8 hard-gate acceptance criterion (responds to PR #1341 critique)

### DIFF
--- a/dev/plans/v8-bo-design-2026-05-28.md
+++ b/dev/plans/v8-bo-design-2026-05-28.md
@@ -39,9 +39,51 @@ Why this structure:
 
 Per-window evaluation: run full backtest, record `(CAGR, Sharpe, MaxDD%, total_trades)` for both candidate and SPY benchmark. SPY benchmark per window is precomputed once and cached.
 
-### Decision 2: Scoring metric → **SPY-anchored alpha with convex excess-DD penalty**
+### Decision 2: Scoring metric → **Hard acceptance gate + SPY-anchored soft score**
 
-Replace `paired_delta vs cell-E` with a formula whose every signal term is *paired against SPY* in the same window. This makes the SPY benchmark itself the natural zero of the score: any positive score is signed alpha over SPY in that regime, any negative score is signed regret.
+The acceptance criterion is split into two stages:
+
+1. **Hard gate (binary acceptance predicate).** A config is `acceptable` iff it beats SPY by ≥ N pp CAGR in *every* train window *and* its per-window MaxDD is bounded both in absolute terms and relative to SPY. The gate is BINARY: a config either qualifies or it does not. The smooth score is *not consulted* for this decision.
+2. **Soft score (ranking within the acceptable set).** Among acceptable configs, the SPY-anchored alpha score (formula below) ranks them against each other. The BO's "best-so-far" pointer is only updated by configs that pass the hard gate; unacceptable configs still inform the GP surrogate (their score is computed and recorded) but they cannot be the BO's reported optimum.
+
+This structure is the response to PR #1341's BLOCKING finding F1 (single-window blockbuster gameable). A soft penalty term — no matter how large — can always be outweighed by a sufficiently extreme winning window, because every smooth term has a finite gradient. A *binary* gate has no gradient to exploit: a config that ties SPY in any train window cannot pass, regardless of how spectacularly it wins elsewhere. The user's strategic decision: **soft penalties can always be gamed. Move to a hard gate as the BO acceptance condition.**
+
+#### Hard gate — formal definition
+
+A config's per-window metrics tuple is `(cand_CAGR_w, cand_Sharpe_w, cand_MaxDD_w)` for each training window `w ∈ {W1, W2, W3}`. SPY's per-window metrics tuple is `(spy_CAGR_w, spy_Sharpe_w, spy_MaxDD_w)`, pre-computed once per window and cached.
+
+The gate has THREE conditions, all must hold for every training window `w`:
+
+```
+G1 (CAGR-alpha floor):           cand_CAGR_w   - spy_CAGR_w   ≥ +N_cagr      where N_cagr = 0.01 (1pp)
+G2 (relative-DD ceiling):        cand_MaxDD_w  - spy_MaxDD_w  ≤ +N_dd_rel    where N_dd_rel = 0.10 (10pp)
+G3 (absolute-DD ceiling):        cand_MaxDD_w                  ≤ +N_dd_abs    where N_dd_abs = 0.50 (50%)
+
+acceptable(params) := ∀ w ∈ train_windows. G1(w) ∧ G2(w) ∧ G3(w)
+```
+
+`W4` (holdout) is *not* in the hard-gate predicate — see §"Holdout treatment" below.
+
+**Why these three predicates (and not e.g. Sharpe-alpha floor):**
+
+- **G1 (CAGR-alpha floor).** This is the verdict criterion the existing v7 plan already names ("Best iter beats SPY by ≥ 1pp CAGR in ALL 3 train windows"). Lifting it from a post-hoc verdict-check into the BO's acceptance predicate is what closes F1. Sharpe-alpha is *not* used in the gate because Sharpe is a ratio — a config that delivers low absolute returns at very low vol can beat SPY on Sharpe without delivering capital growth. The investor consumes CAGR, not Sharpe; the gate must reflect that.
+- **G2 (relative-DD ceiling).** Closes F3 (calm-window DD gaming). Without this, a config that takes 15% DD in W3 (SPY DD ≈ 5%) only pays a soft γ·(0.10)² = 1.0 score-point penalty — easily covered by even modest CAGR alpha. With G2 at 10pp, the same config is immediately rejected.
+- **G3 (absolute-DD ceiling).** Provides an absolute floor for cases where the paired comparison alone leaves catastrophic risk on the table. Concretely: if SPY's own DD is, say, 45% in a particular window (GFC W2), a config taking 54% (excess = +9pp, within G2's 10pp budget) still passes G2 — but is structurally unacceptable to a real investor. G3 cuts this off at 50% absolute regardless of what SPY did.
+
+**Why N_cagr = 0.01 (1pp), not 0 or 3:**
+
+- N_cagr = 0 makes the gate empty (any config matching SPY ties the floor and would pass) — fails to prevent v7-iter42 (which has *negative* alpha in W1/W2, so even N=0 would reject it on those windows individually, but allows the "ties SPY in W1/W2/W3, wins in W4-only" pattern from the critique math).
+- N_cagr = 3pp is tight enough to be empty for most BO iterations on a strategy that historically delivers modest alpha (v7 evidence: iter-42 *lost* on cell-E by 0.155 Sharpe; observed CAGR alpha was typically in the ±1-2pp range across folds). A 3pp gate would render most BO iterations unacceptable and force the BO to report no winner.
+- N_cagr = 1pp matches the v7 post-hoc verdict criterion that has been in the plan since the start. Lifting it from verdict-check to acceptance-predicate is a strict tightening of the optimization surface, not a new criterion. Worked example "ties-SPY config" (Example G below) demonstrates rejection.
+
+**Why N_dd_rel = 0.10 (10pp) and N_dd_abs = 0.50 (50%):**
+
+- N_dd_rel = 10pp matches the spirit of the existing promote-gate ("MaxDD increase ≤ 5pp vs cell-E"); 5pp is too tight for a paired-vs-SPY predicate (cell-E itself takes less DD than SPY in some windows so 5pp-vs-cell-E was a softer condition than 5pp-vs-SPY would be). 10pp gives the BO some optimization room while preventing the calm-window DD-gaming pattern from F3.
+- N_dd_abs = 50% is the "investor doesn't tolerate this regardless of context" floor. SPY itself took roughly 55% DD in W2 at the GFC trough (depending on weekly vs. daily measurement), so SPY itself would *not* pass G3 in W2 — but SPY itself is the reference baseline, not a candidate. The asymmetry is intentional: SPY's DD in a particular window is what the investor would have lived through anyway; a *candidate strategy* that adds active risk on top must hold itself to a tighter absolute floor than the passive baseline. A config taking more than 50% absolute DD in any train window is structurally unacceptable — capital recovery from a 50% DD requires a 100% subsequent return.
+
+#### Soft score — SPY-anchored alpha (within the acceptable set)
+
+For configs that pass the hard gate, the soft score from PR #1339 ranks them. The formula is unchanged from PR #1339 — only its role changes (it is no longer the BO's acceptance criterion, only its in-set ranker).
 
 ```
 score_per_window(w) =
@@ -53,109 +95,195 @@ score_per_window(w) =
 score(params) = mean_w(score_per_window) - ε · var_w(cand_Sharpe_w - spy_Sharpe_w)
 ```
 
-Final coefficients (in fractional units throughout: 0.05 means 5pp, not 5.0):
+Coefficients (unchanged from PR #1339):
 
 | Coef | Value | Term it weights | Derivation |
 |---|---|---|---|
 | α | 20.0 | CAGR alpha (paired) | magnitude-normalized: α · 0.05 = 1.0 score-point at +5pp typical-winner alpha |
 | β | 1.4 | Sharpe alpha (paired) | magnitude-normalized: β · 0.7 = 0.98 score-point at +0.7 Sharpe-alpha extreme |
 | γ | 100.0 | excess-DD² (paired floor at 0) | convex; γ · (0.10)² = 1.0 score-point penalty for cand 10pp worse than SPY |
-| δ | 20.0 | SPY-loss gate (asymmetric) | symmetric with α; δ · 0.05 = 1.0 score-point for losing 5pp below tolerance |
-| ε | 1.0 | cross-window Sharpe-alpha variance | ε · 0.05 = 0.05 score-point for a "typical-stable" winner; ε · 0.50 = 0.50 for a fragile single-window winner |
+| δ | 20.0 | SPY-loss gate (asymmetric) | symmetric with α; δ · 0.05 = 1.0 score-point per 5pp loss past tolerance (7pp absolute) |
+| ε | 1.0 | cross-window Sharpe-alpha variance | ε · 0.05 = 0.05 score-point for "typical-stable" winner; ε · 0.50 = 0.50 for a fragile winner |
 | `spy_tol` | 0.02 | gate dead-band | losses ≤ 2pp below SPY are "near-tied", no gate-fire |
+
+The soft score's role in the new structure is narrower than in PR #1339: it ranks configs that have *already* survived the binary gate. The critique's F5 (coefficients calibrated to aspirational magnitudes) is materially weakened because the gate has already filtered the population — within the acceptable set, the surface is denser around small-positive-alpha winners, and the BO is comparing genuine candidates rather than gameable extremes. Coefficients still matter for ranking, but they no longer decide acceptance.
 
 #### Methodology — hybrid: reference-point anchor + magnitude-normalization
 
-Of the four candidate approaches enumerated for this refinement, the chosen methodology is a hybrid:
+The soft-score methodology is unchanged from PR #1339 (hybrid of approaches #2/#1/#3/#4 enumerated there). The hard gate is a fifth methodology axis added on top: a **constraint-satisfaction predicate** that is *prior* to the smooth score. It addresses a problem the four soft-score approaches cannot solve in isolation: every smooth aggregator (mean, weighted sum, Tchebycheff) has some configuration of inputs that exploits its gradient.
 
-1. **Reference-point calibration (approach #2)** sets the formula *shape* — every signal term is paired against SPY in the same window so that SPY itself scores exactly 0. Any positive score is signed alpha; any negative score is signed regret. This makes "did the BO find something better than free?" a directly readable property of the score, not an inference.
-2. **Magnitude-normalization (approach #1)** sets the coefficient *values* — each term is scaled so its contribution at a "typical winner extreme" is roughly ±1 score-point. This keeps the BO's acquisition-function gradients balanced across terms; no one term dominates and silently turns the BO into a single-knob optimizer (the v7 problem).
-3. **CRRA utility (approach #3)** informs only the convex-DD term's *shape* (quadratic on excess), not its magnitude — we anchor magnitude via #1. Picking a domain-specific λ for this codebase has no principled foundation; using CRRA only for the shape sidesteps that.
-4. **Meta-CV (approach #4)** is reserved for *post-hoc verification*, not derivation. After the BO completes, we sensitivity-sweep the coefficients themselves to confirm the iter-best identity is stable under ±50% perturbation per coefficient.
-
-Why a hybrid rather than any single approach in pure form:
-- Pure #1 alone gives a magnitude-balanced but reference-free score — SPY itself scores nonzero, making "beats SPY" require an extra subtraction at every analysis step.
-- Pure #2 alone (e.g. *only* the α·alpha term) ignores risk-adjusted performance and tail-risk shape.
-- Pure #3 (CRRA from λ) requires picking a risk-aversion λ with no principled value in this domain.
-- Pure #4 is verification, not derivation.
-
-The hybrid uses each approach where it has the most authority.
+The constraint-satisfaction approach is borrowed from constrained optimization literature where it is standard. BO with constraints (e.g. cBO, PESC) treats the constraint set as a binary indicator function multiplied into the acquisition; that is exactly the role of `acceptable(params)` here. The implementation simplification we adopt is that the constraint *evaluation* requires the same per-window backtest as the score evaluation, so there is no extra computational cost.
 
 #### Two corrections to the starting formula
 
-While deriving, two issues in the starting formula were found and fixed:
+(Unchanged from PR #1339 — listed for completeness:)
 
-1. **Sign error in the SPY-loss gate.** The starting form was `δ · max(0, spy_CAGR - cand_CAGR + spy_tol)`. At cand = SPY this evaluates to `δ · spy_tol > 0` — the penalty fires when matching SPY exactly. The intent (per the surrounding comment) is for the penalty to fire only when cand loses to SPY by *more* than `spy_tol`. Correct form: `max(0, spy_CAGR - cand_CAGR - spy_tol)`. Adopted.
-2. **Absolute DD threshold broke the SPY anchor.** The starting form was `γ · max(0, cand_DD - dd_threshold)²` with `dd_threshold = 0.15`. SPY itself takes ~55% DD in W2 (GFC) and ~34% in W4 (2022 bear) — those windows would score SPY at −3 to −7 score-points just from the DD term, breaking the SPY-anchor. Replacing the absolute threshold with paired excess over SPY (`max(0, cand_DD - spy_DD)²`) recovers the SPY = 0 anchor while still convexly penalizing strategies that take more DD than SPY does in the same regime. The absolute catastrophic-DD floor is not needed in the smooth score — it lives as a hard barrier in `promote_config.sh` (catastrophic-DD veto, independent of the smooth BO objective).
+1. **Sign error in the SPY-loss gate.** Original `δ · max(0, spy_CAGR - cand_CAGR + spy_tol)` fired at cand = SPY exactly. Corrected to `max(0, spy_CAGR - cand_CAGR - spy_tol)`.
+2. **Absolute DD threshold broke the SPY anchor in the soft score.** Original `γ · max(0, cand_DD - dd_threshold)²` would score SPY itself at −3 to −7 score-points in bear windows. Replaced with paired-excess `max(0, cand_DD - spy_DD)²`. The absolute catastrophic-DD floor that was deferred to `promote_config.sh` in PR #1339 has now been brought *into* the BO acceptance criterion as gate predicate G3 (above).
 
-#### Per-coefficient derivation
+#### Per-coefficient derivation (soft score)
 
-**α = 20.0** (CAGR alpha). Typical-winner extreme is ≈ +5pp = 0.05 per window (the verdict criteria require ≥ +1pp; +5pp is "decisively winning"). Magnitude-normalize: α · 0.05 = 1.0. → α = 20.0. Lower-bound check: at the verdict-threshold +1pp, this term contributes +0.20 — small but positive, correctly distinguishing marginal-winner from neutral.
+(Unchanged from PR #1339; abbreviated here. The full derivations remain authoritative for coefficient values and Bessel-vs-population variance convention.)
 
-**β = 1.4** (Sharpe alpha). Plausible Sharpe range per window is [−1, +2.5]; a competitive strategy's Sharpe alpha vs SPY is roughly [−1.5, +1.5]; "typical winner extreme" Sharpe alpha ≈ +0.7. β · 0.7 = 0.98 ≈ 1.0. → β = 1.4. Rationale for keeping this term despite α already covering returns: a strategy with the same CAGR alpha but lower volatility-of-returns earns extra credit. Two strategies tied on CAGR alpha are correctly ranked by β.
+- **α = 20.0** (CAGR alpha): magnitude-normalize at +5pp typical-winner extreme → score = 1.0.
+- **β = 1.4** (Sharpe alpha): magnitude-normalize at +0.7 Sharpe-alpha extreme → score ≈ 1.0.
+- **γ = 100.0** (convex excess-DD): magnitude-normalize at +10pp excess DD → penalty = 1.0. At +20pp, penalty = 4.0 (dominating).
+- **δ = 20.0** (asymmetric SPY-loss gate): symmetric with α. `spy_tol = 0.02`. A 7pp absolute loss (5pp past tolerance) yields δ·0.05 = 1.0 score-point penalty (correcting the PR #1339 prose finding #9, which incorrectly said "5pp absolute loss" → 1.0 penalty; it's actually 7pp).
+- **ε = 1.0** (cross-window stability via *population* variance, sum-of-squared-deviations / N).
 
-**γ = 100.0** (convex excess-DD). The form `γ · [excess_DD]²` is CRRA-flavored (quadratic loss) without requiring a domain-specific λ. Magnitude anchor: at +10pp excess DD over SPY ("moderately worse risk profile"), penalty = γ · (0.10)² = 1.0. → γ = 100. Convexity check: at +20pp excess DD, penalty = γ · 0.04 = 4.0 — dominates ~4 windows' worth of alpha credit (typical winner accumulates ~4 × 1.0 = 4.0 alpha credit). At +30pp excess, penalty = 9.0 — eliminating. Symmetric inversion: a strategy with *less* DD than SPY (excess_DD < 0) receives no DD credit (the `max(0,·)` floor); the DD term only penalizes, never rewards. Lower DD is rewarded indirectly via the β·Sharpe-alpha term.
+#### BO acceptance logic (pseudocode)
 
-**δ = 20.0** (asymmetric SPY-loss gate). Mirrors α by symmetry — losing 5pp to SPY in any window incurs 1.0 score-point penalty *on top of* the α·alpha penalty (which is already −1.0 for a 5pp loss). Combined: a 5pp loss in a single window costs 2.0 score-points (mean-aggregated across 4 windows = 0.5). The two-fold weighting reflects the verdict criterion that the strategy must beat SPY in *all* windows, not on average. `spy_tol = 0.02`: losses up to 2pp are within bounds of fold-level noise (we don't want the BO chasing 1-2pp differences that won't survive holdout); larger gaps are progressively penalized.
+The change is local to `Bayesian_runner_scoring` and `Bayesian_runner` (current state: scoring returns a single float; BO compares floats to find the optimum). The integration point is the "is this new evaluation the best-so-far?" comparison and the final "report the iter-best" call.
 
-**ε = 1.0** (cross-window stability). All variance numbers below are *population* variance (sum-of-squared-deviations divided by N, the natural reduction across exactly-4 windows). A "typical stable winner" has Sharpe alpha {+0.5, +0.3, +0.4, +0.6} → mean = 0.45, var ≈ 0.0125, penalty = 0.013 (negligible — correct: we don't penalize natural cross-regime variation). A "fragile single-window winner" (v7-iter42 pattern) has Sharpe alpha {−0.4, −0.5, +0.3, +1.5} → mean = 0.225, var = 2.5475/4 ≈ 0.637, penalty = 0.637 (substantial — correct: ε actively penalizes the v7-iter42 failure mode, flipping a marginally-positive mean into a clearly-negative score). Magnitude-normalize at the fragile boundary: ε · 0.5 ≈ 0.5 → ε = 1.0.
+```
+# Module: Bayesian_runner_scoring (additive — does not break the existing
+# `score_cell_with_penalty` callers in v7).
 
-**`dd_threshold` dropped.** Absolute DD threshold replaced by paired-excess DD (above). The absolute catastrophic-DD veto lives in `promote_config.sh`, not in the smooth score.
+type evaluation = {
+  params : config_overrides;
+  per_window_metrics : (window_label * metrics) list;  # K = 3 train + 1 holdout
+  soft_score : float;
+  acceptable : bool;          # NEW: result of hard-gate predicate on train only
+  gate_failures : string list; # NEW: which of {G1, G2, G3} failed for which window
+}
 
-**`spy_tol = 0.02`.** Two-percentage-point dead-band on the gate term. Empirically defensible as roughly the standard error of CAGR over a 7-year window — narrower would chase noise; wider would let real underperformance through.
+function evaluate_one(params, spec, spy_benchmark_per_window):
+    per_window = run_multi_window_backtest(params, spec)
+    soft_score = score_absolute_alpha(per_window, spy_benchmark_per_window)
+    (acceptable, gate_failures) =
+        check_hard_gate(per_window, spy_benchmark_per_window, train_windows_only=true)
+    return { params; per_window; soft_score; acceptable; gate_failures }
 
-#### Worked examples (with the final coefficients)
+function check_hard_gate(per_window, spy, train_windows_only):
+    failures = []
+    for w in (if train_windows_only then train_windows else all_windows):
+        if (cand_CAGR_w - spy_CAGR_w) < N_CAGR:
+            failures.append("G1 failed on " + w)
+        if (cand_MaxDD_w - spy_MaxDD_w) > N_DD_REL:
+            failures.append("G2 failed on " + w)
+        if cand_MaxDD_w > N_DD_ABS:
+            failures.append("G3 failed on " + w)
+    return (failures.empty(), failures)
 
-All five use the 4-window structure (W1: 1998-2004, W2: 2005-2011, W3: 2012-2018, W4: 2019-2025).
+# Module: Bayesian_runner — BO loop modification.
+#
+# CURRENT (v7):
+#   best_so_far := argmax_over_evaluations(soft_score)
+#
+# NEW (v8):
+#   acceptable_set := { e in evaluations : e.acceptable == true }
+#   if acceptable_set is non-empty:
+#       best_so_far := argmax_over(acceptable_set, soft_score)
+#       termination_state := "OK"
+#   else:
+#       best_so_far := argmax_over(all evaluations, soft_score)
+#       termination_state := "NO_ACCEPTABLE_CONFIG"   # warning to caller
+#
+# In both cases the GP surrogate sees ALL evaluations (acceptable or not),
+# so unacceptable points still inform exploration. Only the "iter-best"
+# reporting and the acquisition function's exploitation target use the
+# filtered set.
+```
 
-**Example A — SPY itself (anchor verification).**
-Every paired term is 0; gate is 0; var is 0. **Score = 0.00 exactly.** ✓ The anchor holds — SPY scores exactly the reference value, independent of the per-window DD/Sharpe magnitudes that vary widely across the four windows.
+The `acceptable` field and `gate_failures` field are also serialized into the per-iter checkpoint (`bo_checkpoint.sexp`) so post-hoc analysis can characterize the pass-rate of the hard gate across the BO trajectory.
 
-**Example B — typical winner** (consistent +2pp CAGR alpha, +0.3 Sharpe alpha, −5pp DD vs SPY, all 4 windows).
-Per-window: 20·(0.02) + 1.4·(0.3) − 100·(0)² − 0 = 0.40 + 0.42 = +0.82.
-Var of Sharpe-alpha = 0 (all four +0.3).
-**Score = 0.82.** Strong positive — recognizable winner.
+#### Sobol initial-random phase handling
 
-**Example C — marginal config** (matches SPY CAGR ±0pp, matches Sharpe ±0, takes +2pp excess DD in each window).
-Per-window: 0 + 0 − 100·(0.02)² − 0 = −0.04.
-Var = 0 → ε·0 = 0.
-**Score = −0.04.** Slightly negative — correctly identifies "no edge, mild DD drag."
+The Sobol phase samples 20 initial points uniformly over the knob space. There is no guarantee that any of them pass the hard gate — particularly on the first run on a new spec, where the surface shape is unknown.
 
-**Example D — v7-iter42 pattern** (bull-window winner, bear-window loser). Per-window assumed Sharpe alpha {−0.4, −0.5, +0.3, +1.5}, CAGR alpha {−0.03, −0.05, +0.04, +0.10}, excess-DD {+0.03, +0.05, +0.01, +0.02}:
+**Policy: Option (a) — report the soft-score winner with a `NO_ACCEPTABLE_CONFIG` warning.**
 
-| Window | α·CAGR-α | β·Sharpe-α | γ·excess-DD² | δ·gate | Per-window |
-|---|---|---|---|---|---|
-| W1 (dot-com) | 20·(−0.03)=−0.60 | 1.4·(−0.4)=−0.56 | 100·(0.03)²=−0.09 | 20·max(0,0.03−0.02)=−0.20 | **−1.45** |
-| W2 (GFC) | 20·(−0.05)=−1.00 | 1.4·(−0.5)=−0.70 | 100·(0.05)²=−0.25 | 20·(0.05−0.02)=−0.60 | **−2.55** |
-| W3 (post-GFC bull) | 20·(0.04)=+0.80 | 1.4·(0.3)=+0.42 | 100·(0.01)²=−0.01 | 0 | **+1.21** |
-| W4 (mixed) | 20·(0.10)=+2.00 | 1.4·(1.5)=+2.10 | 100·(0.02)²=−0.04 | 0 | **+4.06** |
+- The BO does not block on the gate. It runs the full 80-iteration budget regardless.
+- If by termination no point has passed the hard gate, the runner reports the highest-soft-score config among the unacceptable population, prefixed in the report with `[WARNING: no config passed the hard gate; reported is best-by-soft-score among unacceptable candidates]`.
+- The reported config is *not* eligible for promotion (the promote gate, separately, applies the same hard-gate logic). The warning is operationally a signal to the user: either the knob bounds need widening, or this strategy on this universe cannot meet the gate at all.
 
-Mean = (−1.45 − 2.55 + 1.21 + 4.06)/4 = +0.32.
-Var(Sharpe-α) with values {−0.4, −0.5, +0.3, +1.5}: mean = +0.225, sum-of-squared-deviations = 0.391 + 0.526 + 0.006 + 1.626 = 2.548; population var = 2.548 / 4 ≈ 0.637. ε·var = −0.637.
-**Score = 0.32 − 0.637 = −0.32.**
+**Rejected alternative — Option (b) "refuse to terminate until M acceptable points found".**
 
-This is correctly rejected — the cross-window variance term alone is enough to flip the verdict from "barely positive" to "decisively negative." The ε·variance term is doing exactly the work it was designed for: catching v7-iter42-style fragile winners that the per-window mean alone would let through.
+- Risk of unbounded compute: the gate could be unsatisfiable for the strategy/universe combination (genuine alpha doesn't exist), and the runner would loop forever.
+- v7 evidence supports the unsatisfiability concern: if the underlying strategy genuinely can't beat SPY by 1pp CAGR in all of W1/W2/W3, the runner shouldn't pretend by extending the budget.
+- A loud termination with `NO_ACCEPTABLE_CONFIG` warning + best-by-soft-score is more actionable: the user sees the surface shape, can compare to SPY, and can decide whether to widen bounds, change windows, change the universe, or drop the strategy.
 
-**Example E — catastrophic single-window blow-up** (matches SPY in W1/W3/W4, +20pp excess DD in W2 with −10pp CAGR alpha).
-W1/W3/W4 per-window: 0 each.
-W2: 20·(−0.10) + 1.4·0 − 100·(0.20)² − 20·(0.10−0.02) = −2.00 + 0 − 4.00 − 1.60 = **−7.60**.
-Mean = −7.60/4 = −1.90.
-Var(Sharpe-α) ≈ 0 (only W2 deviates; small).
-**Score ≈ −1.90.** Eliminating.
+#### Holdout treatment (W4)
 
-#### Sanity table — score → verdict mapping
+The hard gate applies *only* to the three training windows. The holdout window (W4, 2019-2025) is reserved for verdict criteria *after* BO completion, not for BO acceptance.
 
-| Score range | Interpretation | Verdict implication |
+Rationale: if the holdout participated in the gate, it would no longer be held out — every BO iteration would have used holdout information to decide whether to be reported as iter-best, and the apparent "out-of-sample" performance would be conditional on the holdout having passed the gate during selection. This is a textbook information-leakage failure mode that the train/holdout split exists to prevent.
+
+The verdict criteria for the iter-best (after BO termination) are:
+
+| Criterion | What it tells us | Reuses gate logic? |
 |---|---|---|
-| ≥ +0.50 | Decisively beats SPY across most windows | Likely passes promote gate |
-| +0.05 to +0.50 | Marginal positive alpha | Pass conditional on holdout |
-| −0.05 to +0.05 | Indistinguishable from SPY | No edge worth capital allocation |
-| −0.50 to −0.05 | Worse than SPY on signal or risk | Reject |
-| ≤ −0.50 | Materially worse than SPY | Reject; likely catastrophic in ≥1 window |
+| iter-best is `acceptable` on TRAIN (W1, W2, W3) | BO produced a structurally non-fragile config | YES (G1/G2/G3 on W1-W3) |
+| iter-best is `acceptable` on HOLDOUT (W4) | Generalizes out-of-sample | YES (G1/G2/G3 on W4, same thresholds) |
+| holdout CAGR Δ ≥ 0 vs SPY | Looser fallback if the strict gate is too tight on W4 alone | NO (just sign check) |
+| holdout MaxDD ≤ 25% | Tighter than G3=50% — the verdict cares more about absolute risk than the BO acceptance does | NO (custom threshold) |
+| `promote_config.sh` gate passes for sp500-2010-2026 | Aligned with promote | NO (existing promote pipeline) |
+
+The G1/G2/G3 thresholds on W4 are the same as on W1-W3 — symmetric application of the criterion the user actually cares about. The "looser fallback" line (holdout CAGR Δ ≥ 0) is the existing v7 verdict criterion preserved as a softer reporting line: if the iter-best passes the strict gate on W4, great; if not but the holdout CAGR alpha is still positive, that's a softer "marginal-pass" outcome that the verdict reports but does not auto-promote.
+
+#### Worked examples (with N_cagr = 0.01, N_dd_rel = 0.10, N_dd_abs = 0.50)
+
+All examples use the 4-window structure (W1: 1998-2004, W2: 2005-2011, W3: 2012-2018, W4: 2019-2025). Hard gate is evaluated on W1/W2/W3 only.
+
+**Example A — SPY itself.**
+Per train-window: `cand_CAGR_w - spy_CAGR_w = 0`. **G1 fails on every window** (0 < 1pp). → **REJECT (unacceptable).** Soft score = 0.00 (anchor). Outcome: SPY itself does not pass the gate, by design. The gate measures "decisively beats SPY," not "is SPY-or-better." SPY is the reference baseline; it would be incoherent for the BO to "discover" SPY itself as its winner.
+
+**Example B — genuine winner: consistent +2pp CAGR alpha across all 4 windows, +0.3 Sharpe alpha, −5pp DD vs SPY.**
+Per train-window: G1 (+2pp ≥ 1pp ✓), G2 (−5pp ≤ +10pp ✓), G3 (cand_DD < spy_DD ≤ ~55% ✓). → **ACCEPTABLE.** Soft score = 0.82 (per the unchanged formula). Outcome: passes the gate and ranks high on the soft score. This is the BO's target.
+
+**Example C — marginal config: matches SPY CAGR ±0pp, matches Sharpe ±0, takes +2pp excess DD per window.**
+Per train-window: **G1 fails** (0 < 1pp). → **REJECT (unacceptable).** Soft score = −0.04. Outcome: a config that does not measurably beat SPY is rejected regardless of how close to neutral the soft score is. Closes the "indistinguishable from SPY but cheaper" loophole.
+
+**Example D — v7-iter42 pattern**: CAGR alpha {−0.03, −0.05, +0.04, +0.10}, Sharpe alpha {−0.4, −0.5, +0.3, +1.5}, excess-DD {+0.03, +0.05, +0.01, +0.02}.
+Per train-window: **G1 fails on W1** (−3pp < 1pp) and **G1 fails on W2** (−5pp < 1pp). → **REJECT (unacceptable).** Soft score = −0.32 (per PR #1339 computation). Outcome: rejected by the gate before the soft score is even consulted. This is the BLOCKING-finding case from the critique — it is now structurally impossible for v7-iter42 to be reported as iter-best, regardless of how the soft-score coefficients are tuned.
+
+**Example E — single-window blockbuster (critique BLOCKING case)**: matches SPY exactly in W1/W2/W3 (`cand_CAGR_w = spy_CAGR_w, cand_Sharpe_w = spy_Sharpe_w, cand_MaxDD_w = spy_MaxDD_w`), wins +20pp CAGR / +1.0 Sharpe in W4 only.
+Per train-window: **G1 fails on W1, W2, W3** (all 0 < 1pp). → **REJECT (unacceptable).** Soft score per critique computation = +1.16. Outcome: REJECTED by the gate despite scoring well above the PR #1339 "Decisively beats SPY" band on the soft score. **This is the critical test the redesign was built for** — the v7-iter42 fragility pattern is no longer reachable by the BO's acceptance criterion. Even the more extreme +50pp/+2.0-Sharpe variant (soft score +2.45) fails on the same predicate. The single-window blockbuster failure mode is now structurally rejected, not just softly penalized.
+
+**Example F — single-window blockbuster + holdout-only winner (the critique's worst case)**: matches SPY in W1/W2/W3 *exactly* but with +50pp CAGR in W4. Same as Example E for train. → **REJECT on train gate.** The W4 win is never seen by the BO acceptance criterion. (If somehow a config DID pass train and showed a W4 blockbuster pattern, the verdict criteria would apply the same gate to W4 and reject it. The gate is symmetric.)
+
+**Example G — marginal config: +0.5pp CAGR alpha in W1, +0.5pp in W2, −0.5pp in W3.**
+Per train-window: **G1 fails on W1** (0.5pp < 1pp), **G1 fails on W2** (0.5pp < 1pp), **G1 fails on W3** (−0.5pp < 1pp). → **REJECT.** All three windows fail; this is the "marginal positive on average but does not decisively beat SPY in any window" case. Even a single +1.5pp window paired with two +0.5pp windows would still reject (G1 fails on the two 0.5pp windows).
+
+**Example H — calm-window DD game (critique F3 case)**: matches SPY CAGR in W1/W2 (+0pp ≤ within tolerance) but with +5pp CAGR alpha and +15pp absolute DD in W3 (W3 SPY DD ≈ 5%, so cand_DD ≈ 20%; excess DD = 15pp).
+Per train-window: **G1 fails on W1, W2** (0pp < 1pp) — already enough to reject. → **REJECT.** Even if W1/W2 hadn't failed, **G2 would fail on W3** (15pp > 10pp). The gate stops the calm-window DD game before the soft γ-term has any chance to be net-positive.
+
+**Example I — catastrophic absolute DD (G2-without-G3 escape case)**: passes G1 (+2pp CAGR alpha) in all train windows, passes G2 (excess DD ≤ +10pp in all train windows; assume W2 SPY DD is 45% and candidate takes 54%, excess = +9pp), but takes 54% absolute DD in W2.
+Per train-window: G1 ✓, G2 ✓ in W2 (54−45 = 9pp ≤ 10pp), but **G3 fails on W2** (54% > 50%). → **REJECT.** This is the case where G2 alone would not have caught the problem (the candidate is only modestly worse than SPY in paired terms) — G3 provides the absolute floor.
+
+#### Sanity table (within the acceptable set only)
+
+The PR #1339 score → verdict table still applies, but its scope is now restricted: every row presupposes `acceptable == true`. The "≤ −0.05" rows in particular almost never apply (a config that has passed the hard gate at +1pp CAGR alpha in every window scores at least +0.20 on the α-term alone, plus β contribution).
+
+| Score range (acceptable configs only) | Interpretation |
+|---|---|
+| ≥ +0.50 | Decisively beats SPY across all 3 train windows |
+| +0.20 to +0.50 | Solid pass — α-term dominates from N_cagr-floor satisfaction |
+| 0.00 to +0.20 | Marginal acceptable — minor risk-adjusted offsets from β/γ/δ |
+| < 0.00 | Rare; configs that pass G1-G3 but score negative on β + γ + δ aggregate (uncommon — implies very poor Sharpe or persistent DD-drag) |
+
+For unacceptable configs, the soft score is reported in the iter log but not used for selection.
 
 #### Post-hoc verification (Meta-CV per approach #4)
 
-After the BO completes, run `sensitivity_sweep` over the score coefficients themselves (perturb each by ±50%) and verify the iter-best identity is stable. If the winner flips under a 50% perturbation of any one coefficient, the result is coefficient-overfit and not a real alpha signal. Tracked in the Risk Register below as "score formula coefficients (α-ε) are themselves overfit" — this is the post-hoc check that retires that risk.
+After the BO completes:
+
+1. **Hard-gate sensitivity**: vary N_cagr in {0.005, 0.01, 0.02} and N_dd_rel in {0.05, 0.10, 0.15} and check whether the iter-best identity changes. If the iter-best flips when N_cagr moves from 0.01 to 0.02, the result is sensitive to a 1pp threshold — that's a fragility signal, log it. If it flips from 0.01 to 0.005, the iter-best is borderline-marginal and should be treated as such.
+2. **Soft-score sensitivity** (existing PR #1339 plan): perturb α/β/γ/δ/ε by ±50% and check iter-best stability *within the acceptable set*. This now runs only against the acceptable population, not the full BO trajectory.
+
+The expected outcome is that the iter-best identity is much *more* stable than under PR #1339's soft-only formula because the gate has pre-filtered the population — the within-acceptable-set surface is denser and more locally convex.
+
+#### Response to PR #1341 critique findings
+
+| # | Critique finding | Severity | Resolution |
+|---|---|---|---|
+| F1 | Single-window blockbuster gameable: +20pp/+50pp-in-W4-only scores +1.16/+2.45, passing "Decisively beats SPY" | BLOCKING | **RESOLVED by the hard gate (G1).** Example E above shows the exact case from the critique — G1 rejects it on W1/W2/W3 each (0pp < 1pp threshold), regardless of the soft score. The blockbuster pattern is structurally unreachable as iter-best. |
+| F2 | ε term is a narrow filter (Sharpe-α variance only) — uniform-CAGR-mediocre-with-DD-blowout configs pass | MAJOR | **Mostly moot.** Within the acceptable set, ε still penalizes Sharpe-α variance (its original PR #1339 role) but it no longer carries the load of preventing fragility — that's now G1's job. The "uniform-CAGR-mediocre" failure mode the critique names is rejected by G1 (uniform-mediocre = doesn't beat SPY by 1pp). The DD-blowout sub-case is rejected by G2/G3. Acknowledged as a known-limitation within-set: ε remains a slightly weak Sharpe-stability signal; in practice the count-based fragility detector suggested in the critique could replace it in a future iteration if the within-set ranking is observed to favor unstable configs. |
+| F3 | DD-term incentivizes risk in calm windows: 4pp excess DD justified by 1pp CAGR alpha at small excess | MAJOR | **RESOLVED by G2 (relative-DD ceiling at +10pp).** Example H above shows the calm-window DD game is rejected before the soft γ-term has any chance to net-pay. Within the acceptable set, the γ-term still discourages high-DD configs (γ·(excess)² is monotonic in DD), but the gate has already removed the structurally-unacceptable region of the surface. |
+| F4 | Promote-gate baseline mismatch: promote uses cell-E baseline; v8 scores against SPY | MAJOR | **Deliberate design choice: v8 aligns with SPY, accepts that promote may still fail on its current cell-E-aligned gates, requires a separate `promote_config.sh` redesign.** v7 evidence (iter-42 beating cell-E by +0.380 paired-Δ but failing promote on Sharpe regression vs cell-E) shows that the cell-E-aligned promote gate has its own pathology: it rewards configs that beat a hand-tuned baseline that may itself underperform SPY. Aligning v8 with SPY is structurally cleaner: SPY is the free baseline any real strategy needs to beat. The promote-gate redesign is out of scope for this PR but is flagged as a known follow-up: a v8-pass-promote-fail config is *not* a v8 design failure — it's a promote-gate-misalignment problem to be addressed separately. |
+| F5 | "Typical winner extreme" coefficients (α anchored at +5pp) are aspirational; v7 evidence ~+1-2pp | MAJOR | **Materially weakened by the gate-first structure.** Coefficients only matter for ranking within the acceptable set; the gate makes the acceptance decision. F5's specific concern — "γ=100 dominates the gradient at realistic ±1-2pp operating point" — is now constrained: the acceptable set has CAGR alpha ≥ +1pp in every train window, so the α-term contributes at least +0.20 per window (+0.60 mean) before any other term fires. Within that set, γ's role is comparative (does config A take more DD than config B at the same CAGR-alpha tier), not deciding (does this config qualify at all). Coefficients still tuned to PR #1339's magnitudes; recalibration to v7-observed magnitudes is reserved as a follow-up if within-set ranking proves unstable. |
+
+Findings F6-F11 from the critique (worked-example arithmetic verifications, ε term magnitude observations, δ verbiage clarification, Bessel-vs-population pin, defensive-bias observation) are unchanged — they apply to the soft score, which is unchanged in formula. F9 (δ verbiage: "5pp loss" → actually "7pp absolute loss") is corrected in the per-coefficient derivation above.
 
 ### Decision 3: Baseline → **BAH SPY (and BAH BRK-A for reference)**
 
@@ -202,18 +330,25 @@ Add new module `trading/trading/backtest/multi_window/`:
 - Reuses existing `Walk_forward_runner` infrastructure (just non-overlapping windows without the train/test split semantics)
 - Unit tests pinning the per-window metrics output
 
-### PR-2: Absolute-alpha scoring function
+### PR-2: Absolute-alpha scoring function + hard-gate predicate
 In `trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml`:
 - Add `score_absolute_alpha` variant of the existing `score_cell_with_penalty`
 - Inputs: per-window candidate metrics + per-window SPY benchmark metrics
 - Output: scalar score per the formula in Decision 2
-- Unit tests pinning each of the 5 score terms independently + composite
-- Unit tests pinning the SPY-itself = 0 anchor at the chosen coefficients
+- Add `check_hard_gate` returning `{ acceptable : bool; gate_failures : string list }` per Decision 2 §"BO acceptance logic"
+- Constants: `N_cagr = 0.01`, `N_dd_rel = 0.10`, `N_dd_abs = 0.50` exposed via spec config
+- Unit tests pinning each of the 5 soft-score terms independently + composite
+- Unit tests pinning the SPY-itself = 0 anchor on the soft score
+- Unit tests pinning hard-gate behavior on the 9 worked examples (A-I) in Decision 2
+- Pin: variance is population (÷ N), not Bessel (per critique finding F10)
 
-### PR-3: bayesian_runner integration
+### PR-3: bayesian_runner integration (gate-aware BO loop)
 - Add CLI flags `--multi-window-spec <path>` and `--objective absolute_alpha`
-- When set, runner uses `Multi_window_runner` + `score_absolute_alpha` instead of WF + paired-Δ
-- Spec file format extends to declare windows + SPY-benchmark source
+- When set, runner uses `Multi_window_runner` + `score_absolute_alpha` + `check_hard_gate` instead of WF + paired-Δ
+- Modify the BO "best-so-far" comparison per Decision 2 §"BO acceptance logic": iter-best updates only when `acceptable == true`; unacceptable evaluations still inform the GP surrogate
+- Add `NO_ACCEPTABLE_CONFIG` termination state and surface as a warning in the runner's final report
+- Serialize `acceptable` + `gate_failures` per iter into `bo_checkpoint.sexp` for post-hoc analysis
+- Spec file format extends to declare windows + SPY-benchmark source + (optional) gate-threshold overrides
 - Backward compatible: existing v7-style specs still work
 
 ### PR-4: v8 spec + SPY benchmark fixtures
@@ -233,12 +368,15 @@ In `trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml`:
 
 **Verdict criteria when v8 completes:**
 
+(Cross-reference Decision 2 §"Holdout treatment" for the full table — the criteria below are the operational summary.)
+
 | Criterion | What it tells us |
 |---|---|
-| Best iter beats SPY by **≥ 1pp CAGR** in ALL 3 train windows | Real alpha, not lucky-fold artifact |
-| Holdout (W4 2019-2025) shows **CAGR Δ ≥ 0** vs SPY | Generalizes out-of-sample |
-| MaxDD on holdout **≤ 25%** | Acceptable tail behavior |
-| promote_config gate passes for **sp500-2010-2026** (the v7 fail) | Aligned with promote |
+| iter-best `acceptable` on TRAIN (W1/W2/W3) — passes G1/G2/G3 | Hard gate held during BO selection (will be true if the BO returned anything other than `NO_ACCEPTABLE_CONFIG`) |
+| iter-best `acceptable` on HOLDOUT (W4) — passes G1/G2/G3 with same thresholds | Generalizes out-of-sample under the strict gate |
+| Holdout (W4) CAGR Δ ≥ 0 vs SPY | Looser fallback if W4 gate is tight; marginal-pass signal |
+| Holdout MaxDD ≤ 25% | Tighter than G3=50% — verdict cares more about absolute risk than BO acceptance does |
+| promote_config gate passes for sp500-2010-2026 (the v7 fail) | Aligned with promote — but see F4 below: a promote-fail config is not necessarily a v8 design failure if the failure is baseline-mismatch (cell-E vs SPY) |
 
 If criteria fail: signal that even multi-window + SPY-aligned scoring isn't enough — pivot to broader-universe sweep (per the existing strategic backlog memory `project_strategic_pivot_broader_first.md`).
 
@@ -250,7 +388,7 @@ If criteria fail: signal that even multi-window + SPY-aligned scoring isn't enou
 | Score formula coefficients (α-ε) are themselves overfit | Post-hoc sensitivity-sweep at ±50% per coefficient (Decision 2 §"Post-hoc verification"); pin via cross-validation if iter-best identity flips |
 | BAH SPY benchmark per window is annoyingly path-dependent on start/end dates | Pin window dates exactly; document SPY values per window in spec |
 | Multi-window code is new + only used here | PR-1 has unit tests; PR-3 integration is small once PR-1 lands |
-| v7-iter42 was a "bull-window winner" — v8 might similarly be a "multi-window-but-still-overfit winner" | The δ term (penalty for losing to SPY in any window) AND the ε term (cross-window Sharpe-alpha variance) explicitly force winners to be uniformly competitive, not just average-positive. Example D in Decision 2 shows the v7-iter42 pattern correctly rejected. |
+| v7-iter42 was a "bull-window winner" — v8 might similarly be a "multi-window-but-still-overfit winner" | The hard gate (G1: CAGR alpha ≥ +1pp in every train window; G2: relative DD ≤ +10pp; G3: absolute DD ≤ 50%) structurally rejects single-window blockbusters before the soft score is consulted. Example D (v7-iter42) and Example E (single-window blockbuster) in Decision 2 both fail G1 on multiple windows. Within the acceptable set, the soft score (ε for Sharpe-α variance, γ for excess-DD shape) provides additional ranking discipline. |
 
 ## What v8 explicitly does NOT do
 


### PR DESCRIPTION
## Summary

Redesigns § Decision 2 of `dev/plans/v8-bo-design-2026-05-28.md` from a
**soft-only score formula** to a **hard-gate + soft-score** structure. The
soft score (PR #1339 formula) is unchanged; what changes is its role.

## Why

PR #1341 (RECOMMENDS_REVISION on PR #1339) showed the soft-only formula
does NOT prevent a v7-iter42-redux: a config that ties SPY in W1/W2/W3
and wins +20pp/+50pp CAGR in W4 alone scores +1.16 to +2.45, passing the
formula's own "Decisively beats SPY" threshold. Any smooth aggregator
can be gamed by a sufficiently extreme single-window winner.

The user's strategic decision: **soft penalties can always be gamed.
Move to a hard gate as the BO acceptance condition.**

## What changed

| | Old (PR #1339) | New (this PR) |
|---|---|---|
| BO acceptance | argmax over soft score | argmax over soft score, but **only within configs that pass the hard gate** |
| Hard gate | none | G1 (CAGR alpha >= +1pp), G2 (paired DD <= +10pp), G3 (absolute DD <= 50%) — all must hold in every train window |
| Soft score formula | 5 terms (alpha/beta/gamma/delta/epsilon) | Unchanged |
| Soft score coefficients | alpha=20, beta=1.4, gamma=100, delta=20, epsilon=1 | Unchanged |
| Sobol-phase no-passers | n/a | Run to budget end; report best-by-soft-score with NO_ACCEPTABLE_CONFIG warning |
| Holdout treatment | post-hoc verdict only | Verdict criteria reuse G1/G2/G3 on W4 with same thresholds |

## Critique findings response (all 5)

- **F1 (BLOCKING, single-window blockbuster):** RESOLVED by G1. Worked Example E shows the +20pp-in-W4-only config rejected on each of W1/W2/W3 (each 0pp alpha < 1pp threshold), regardless of soft score.
- **F2 (MAJOR, epsilon term too narrow):** Mostly moot — uniform-CAGR-mediocre configs fail G1; DD-blowout cases fail G2/G3. Epsilon remains a within-set Sharpe-stability signal (acknowledged limitation, future replacement candidate).
- **F3 (MAJOR, calm-window DD gaming):** RESOLVED by G2. Worked Example H shows the 15pp-excess-DD-in-W3 config rejected.
- **F4 (MAJOR, promote-gate baseline mismatch):** Deliberate design choice — v8 aligns with SPY, accepts that promote may still fail on its cell-E-aligned gates, requires a separate `promote_config.sh` redesign (flagged as out-of-scope follow-up).
- **F5 (MAJOR, aspirational coefficients):** Materially weakened — gate handles acceptance; coefficients only rank within the acceptable set, where CAGR alpha >= +1pp per window is guaranteed.

Minor findings F6-F11 from the critique apply to the unchanged soft score; F9 (delta verbiage prose error: "5pp loss" should be "7pp absolute loss") is corrected in the per-coefficient derivation.

## Worked examples

9 examples (A-I) cover the full taxonomy:

| | Example | Hard gate | Soft score |
|---|---|---|---|
| A | SPY itself | REJECT (G1: 0 < 1pp) | 0.00 |
| B | Genuine winner: +2pp alpha all windows | ACCEPT | +0.82 |
| C | Marginal: matches SPY +0pp | REJECT (G1) | -0.04 |
| D | v7-iter42 pattern | REJECT (G1 on W1/W2) | -0.32 |
| E | Single-window blockbuster (+20pp W4 only) | REJECT (G1 on W1/W2/W3) | +1.16 |
| F | Blockbuster + W4-only winner extreme | REJECT (G1 on W1/W2/W3) | +2.45 |
| G | Near-miss: +0.5pp / +0.5pp / -0.5pp | REJECT (G1 all 3) | small +/- |
| H | Calm-window DD game: +15pp DD in W3 | REJECT (G1 first, G2 fallback) | varies |
| I | G2-passing but G3-failing: 54% DD with 45% SPY DD | REJECT (G3 on W2) | varies |

The critical test is Example E — the BLOCKING-finding case from the critique. It is now structurally impossible for the BO to converge on this pattern, regardless of soft-score coefficient tuning.

## Impact on implementation sequencing

- PR-2: extended to include `check_hard_gate` predicate + unit tests on the 9 worked examples + population-variance pin per critique F10.
- PR-3: modified to gate-aware BO loop with NO_ACCEPTABLE_CONFIG termination state and per-iter `acceptable`/`gate_failures` checkpoint serialization.
- PR-1, PR-4, PR-5: unchanged.

## Out of scope (deliberate)

- No OCaml implementation — doc-only (PR-2/PR-3 land the code).
- Decisions 1, 3, 4, 5 unchanged.
- `promote_config.sh` redesign deferred (separate PR; F4 acknowledges the wedge but doesn't fix it here).
- `dev/status/_index.md` not modified.

## Test plan

- [ ] Reviewer verifies the gate predicates G1/G2/G3 correctly reject Examples A, C, D, E, F, G, H, I (smoke-trace through the gate logic by hand).
- [ ] Reviewer verifies Example B is the only one in the worked set that passes the gate.
- [ ] Reviewer verifies the N_cagr / N_dd_rel / N_dd_abs constant rationale (especially N_dd_abs=50% vs SPY's own ~55% in W2 — the asymmetry is intentional).
- [ ] Reviewer verifies F4 follow-up framing (deliberate misalignment with promote, requires separate PR).
- [ ] CI: docs-only PR, no QC gates (per `.claude/rules/pr-merge-gates.md` § Docs-only PRs).