### PR TITLE
docs(plans): v8 round-3 — address BLOCKING + 5 MAJOR from #1343 critique

### DIFF
--- a/dev/plans/v8-bo-design-2026-05-28.md
+++ b/dev/plans/v8-bo-design-2026-05-28.md
@@ -4,6 +4,17 @@
 **Supersedes:** preliminary v8 plan in `dev/notes/v7-results-2026-05-28.md` (3 axes).
 **Authority:** v7 results (`dev/notes/v7-results-2026-05-28.md`) + promote failure analysis.
 
+**Round-3 redesign (this revision)** — addresses the BLOCKING + 5 MAJOR findings from `dev/reviews/v8-hard-gate-critique.md` on the Round-2 hard-gate design:
+
+- **BLOCKING F4 (GP/EI undefined under disjoint acceptance)** → `score(unacceptable) := −∞_proxy` (large finite, see § "BO acceptance logic — corrected"). Surrogate, EI, and best-pointer now share one objective.
+- **MAJOR F1 (knife-edge gaming at N_cagr = 1pp)** → soft margin-bonus term `+μ·min_w(cand_CAGR_w − spy_CAGR_w − N_cagr)` inside the acceptable region, so the BO is rewarded for clearing the floor with cushion (not parking exactly at it).
+- **MAJOR F2 (acceptable-set sparsity ≈ 16/80 in 11-dim)** → mandatory **pre-flight Sobol-100 smoke sweep on v7's WF spec** that estimates empirical pass-rate; gates the v8 launch decision. Knob count reduced from 11 to **9** (already in Decision 4). Combined target acceptable-set size ≥ 25 / 80.
+- **MAJOR F3 (holdout asymmetry)** → symmetric thresholds on W4: drop holdout `CAGR Δ ≥ 0` fallback (looser than train), drop holdout `MaxDD ≤ 25%` fallback (tighter than train). W4 uses the same G1/G2/G3 as train.
+- **MAJOR F5 (G3 = 50% too permissive)** → tighten G3 to **25%** absolute (symmetric with what was the holdout fallback). Catastrophic-DD floor closer to actual investor tolerance.
+- **MAJOR F6 (NO_ACCEPTABLE_CONFIG diagnostic non-actionable)** → fallback report adds (i) per-gate failure histogram by window, (ii) closest-rejected config + per-gate violation distance, (iii) SPY benchmark per window, (iv) suggested operator action.
+
+Round-3 leaves Decisions 1, 3, 4, 5 unchanged (windows, baseline, knobs, BO mechanics). All changes are local to Decision 2. Round-2 worked-examples A–H are preserved (verified arithmetically by the critique's Finding 9). Example B is updated to show the Round-3 soft-score with margin_bonus. Example I is updated to reflect G3 = 25% (still rejects). Example I' is added to demonstrate a config that passed Round-2 G3 = 50% but fails Round-3 G3 = 25%. Examples J + K are net-new for the Round-3 failure modes (min-window-skater under margin_bonus + NO_ACCEPTABLE_CONFIG fallback with the new diagnostic).
+
 ## Why a redesign, not just bounds widening
 
 v7's BO found a config (iter 42) that wins its objective (paired-Δ on 28-fold walk-forward, +0.380) but loses the gate that matters (sp500-2010-2026 Sharpe, -0.155 vs cell-E). The mismatch isn't tuneable through wider bounds. It's structural.
@@ -39,14 +50,19 @@ Why this structure:
 
 Per-window evaluation: run full backtest, record `(CAGR, Sharpe, MaxDD%, total_trades)` for both candidate and SPY benchmark. SPY benchmark per window is precomputed once and cached.
 
-### Decision 2: Scoring metric → **Hard acceptance gate + SPY-anchored soft score**
+### Decision 2: Scoring metric → **Hard acceptance gate + SPY-anchored soft score (with sentinel for unacceptable + margin bonus)**
 
-The acceptance criterion is split into two stages:
+The acceptance criterion has three layers (Round-3 structure):
 
-1. **Hard gate (binary acceptance predicate).** A config is `acceptable` iff it beats SPY by ≥ N pp CAGR in *every* train window *and* its per-window MaxDD is bounded both in absolute terms and relative to SPY. The gate is BINARY: a config either qualifies or it does not. The smooth score is *not consulted* for this decision.
-2. **Soft score (ranking within the acceptable set).** Among acceptable configs, the SPY-anchored alpha score (formula below) ranks them against each other. The BO's "best-so-far" pointer is only updated by configs that pass the hard gate; unacceptable configs still inform the GP surrogate (their score is computed and recorded) but they cannot be the BO's reported optimum.
+1. **Hard gate (binary acceptance predicate).** A config is `acceptable` iff it beats SPY by ≥ N pp CAGR in *every* train window *and* its per-window MaxDD is bounded both in absolute terms (≤ 25%) and relative to SPY (≤ +10pp).
+2. **Single scalar objective fed to the BO** — `objective(params)`. This is what the GP fits, what EI is computed against, and what `best_so_far` ranks. Two regions, one function:
+    - If `acceptable(params)`: `objective(params) := soft_score(params)` (see formula below).
+    - Else: `objective(params) := SENTINEL_REJECT` where `SENTINEL_REJECT = −1.0e6` (a finite constant chosen well below any reachable acceptable soft-score; rationale and the alternative of `−∞` discussed in § "BO acceptance logic — corrected").
+3. **Soft score** (formula below) operates only inside the acceptable region. It includes a **margin-bonus term** (Round-3 addition) that rewards configs for clearing the G1 floor with cushion, removing the knife-edge-gaming incentive flagged by critique Finding 1.
 
-This structure is the response to PR #1341's BLOCKING finding F1 (single-window blockbuster gameable). A soft penalty term — no matter how large — can always be outweighed by a sufficiently extreme winning window, because every smooth term has a finite gradient. A *binary* gate has no gradient to exploit: a config that ties SPY in any train window cannot pass, regardless of how spectacularly it wins elsewhere. The user's strategic decision: **soft penalties can always be gamed. Move to a hard gate as the BO acceptance condition.**
+The BO sees one function. The GP fits one function. EI is computed against one `f*` (the best `objective` value seen so far, which is the best soft-score among acceptable points, or `SENTINEL_REJECT` if no acceptable point has been found). The "best-so-far reported to the user" is identical to `argmax_{evaluated x} objective(x)`. The Round-2 mechanic — "surrogate sees all values but best-pointer is filtered" — is replaced by this single-objective formulation. See § "BO acceptance logic — corrected" for the full pseudocode and the consistency proof.
+
+This structure is the response to PR #1341's BLOCKING finding F1 (single-window blockbuster gameable). A soft penalty term — no matter how large — can always be outweighed by a sufficiently extreme winning window, because every smooth term has a finite gradient. A *binary* gate has no gradient to exploit: a config that ties SPY in any train window cannot pass, regardless of how spectacularly it wins elsewhere. The user's strategic decision: **soft penalties can always be gamed. Move to a hard gate as the BO acceptance condition.** Round-3 preserves this strategic decision and fixes the BO mechanic that was incompatible with it.
 
 #### Hard gate — formal definition
 
@@ -55,20 +71,20 @@ A config's per-window metrics tuple is `(cand_CAGR_w, cand_Sharpe_w, cand_MaxDD_
 The gate has THREE conditions, all must hold for every training window `w`:
 
 ```
-G1 (CAGR-alpha floor):           cand_CAGR_w   - spy_CAGR_w   ≥ +N_cagr      where N_cagr = 0.01 (1pp)
+G1 (CAGR-alpha floor):           cand_CAGR_w   - spy_CAGR_w   ≥ +N_cagr      where N_cagr   = 0.01 (1pp)
 G2 (relative-DD ceiling):        cand_MaxDD_w  - spy_MaxDD_w  ≤ +N_dd_rel    where N_dd_rel = 0.10 (10pp)
-G3 (absolute-DD ceiling):        cand_MaxDD_w                  ≤ +N_dd_abs    where N_dd_abs = 0.50 (50%)
+G3 (absolute-DD ceiling):        cand_MaxDD_w                  ≤ +N_dd_abs    where N_dd_abs = 0.25 (25%)   [Round-3 tightened]
 
 acceptable(params) := ∀ w ∈ train_windows. G1(w) ∧ G2(w) ∧ G3(w)
 ```
 
-`W4` (holdout) is *not* in the hard-gate predicate — see §"Holdout treatment" below.
+`W4` (holdout) is *not* in the hard-gate predicate for *BO acceptance*, but the *post-BO verdict* applies the SAME G1/G2/G3 thresholds on W4 — symmetric application out-of-sample. See § "Holdout treatment" for the symmetric verdict structure.
 
 **Why these three predicates (and not e.g. Sharpe-alpha floor):**
 
 - **G1 (CAGR-alpha floor).** This is the verdict criterion the existing v7 plan already names ("Best iter beats SPY by ≥ 1pp CAGR in ALL 3 train windows"). Lifting it from a post-hoc verdict-check into the BO's acceptance predicate is what closes F1. Sharpe-alpha is *not* used in the gate because Sharpe is a ratio — a config that delivers low absolute returns at very low vol can beat SPY on Sharpe without delivering capital growth. The investor consumes CAGR, not Sharpe; the gate must reflect that.
 - **G2 (relative-DD ceiling).** Closes F3 (calm-window DD gaming). Without this, a config that takes 15% DD in W3 (SPY DD ≈ 5%) only pays a soft γ·(0.10)² = 1.0 score-point penalty — easily covered by even modest CAGR alpha. With G2 at 10pp, the same config is immediately rejected.
-- **G3 (absolute-DD ceiling).** Provides an absolute floor for cases where the paired comparison alone leaves catastrophic risk on the table. Concretely: if SPY's own DD is, say, 45% in a particular window (GFC W2), a config taking 54% (excess = +9pp, within G2's 10pp budget) still passes G2 — but is structurally unacceptable to a real investor. G3 cuts this off at 50% absolute regardless of what SPY did.
+- **G3 (absolute-DD ceiling).** Provides an absolute floor for cases where the paired comparison alone leaves catastrophic risk on the table. Concretely: if SPY's own DD is, say, 45% in a particular window (GFC W2), a config taking 54% (excess = +9pp, within G2's 10pp budget) still passes G2 — but is structurally unacceptable to a real investor. G3 cuts this off at 25% absolute regardless of what SPY did. *[Round-3 change: G3 tightened from 50% → 25% per critique Finding 5. See § "Why G3 = 25%, not 50%" below for the full rationale.]*
 
 **Why N_cagr = 0.01 (1pp), not 0 or 3:**
 
@@ -76,14 +92,26 @@ acceptable(params) := ∀ w ∈ train_windows. G1(w) ∧ G2(w) ∧ G3(w)
 - N_cagr = 3pp is tight enough to be empty for most BO iterations on a strategy that historically delivers modest alpha (v7 evidence: iter-42 *lost* on cell-E by 0.155 Sharpe; observed CAGR alpha was typically in the ±1-2pp range across folds). A 3pp gate would render most BO iterations unacceptable and force the BO to report no winner.
 - N_cagr = 1pp matches the v7 post-hoc verdict criterion that has been in the plan since the start. Lifting it from verdict-check to acceptance-predicate is a strict tightening of the optimization surface, not a new criterion. Worked example "ties-SPY config" (Example G below) demonstrates rejection.
 
-**Why N_dd_rel = 0.10 (10pp) and N_dd_abs = 0.50 (50%):**
+**Why N_dd_rel = 0.10 (10pp) and N_dd_abs = 0.25 (25%):**
 
 - N_dd_rel = 10pp matches the spirit of the existing promote-gate ("MaxDD increase ≤ 5pp vs cell-E"); 5pp is too tight for a paired-vs-SPY predicate (cell-E itself takes less DD than SPY in some windows so 5pp-vs-cell-E was a softer condition than 5pp-vs-SPY would be). 10pp gives the BO some optimization room while preventing the calm-window DD-gaming pattern from F3.
-- N_dd_abs = 50% is the "investor doesn't tolerate this regardless of context" floor. SPY itself took roughly 55% DD in W2 at the GFC trough (depending on weekly vs. daily measurement), so SPY itself would *not* pass G3 in W2 — but SPY itself is the reference baseline, not a candidate. The asymmetry is intentional: SPY's DD in a particular window is what the investor would have lived through anyway; a *candidate strategy* that adds active risk on top must hold itself to a tighter absolute floor than the passive baseline. A config taking more than 50% absolute DD in any train window is structurally unacceptable — capital recovery from a 50% DD requires a 100% subsequent return.
+
+#### Why G3 = 25%, not 50% (Round-3 change)
+
+Round-2 used G3 = 50% on the reasoning that SPY itself drew down ~55% in W2 (GFC), so a candidate at 50% was "better than passive." Critique Finding 5 rejected this on the substance: 50% is not "structurally acceptable to an investor" — capital recovery from a 50% DD requires a 100% subsequent return, which is multi-year even in strong bulls. Compounding the issue, Round-2's holdout treatment (now removed — see § "Holdout treatment") used a `MaxDD ≤ 25%` fallback that was *tighter* than train G3, an inverted asymmetry: a config passing train at W2-DD=48% could fail holdout at W4-DD=26%, despite the same investor presumably consuming both windows. The asymmetry was wrong-signed.
+
+Round-3 tightens G3 to **25%** and applies the same threshold on holdout (W4). This makes the gate consistent with what the redesign was already implicitly accepting as the investor's actual tolerance:
+
+- **Symmetric across train and holdout.** A config that passes G3 on all train windows will be evaluated against the same threshold on W4. No verdict-vs-acceptance asymmetry remains.
+- **The "SPY took ~55% in W2 so SPY would fail G3" objection still holds** — SPY is not a candidate, it is the reference baseline. The candidate is being evaluated for whether *adding active risk* on top of SPY's passive risk is worthwhile, and the strategic claim is that "active risk worth taking" looks like 25% peak-to-trough, not 50%.
+- **G3 = 25% does narrow the acceptable set.** Mitigated by the smoke-sweep pre-flight (§ "Acceptable-set sparsity mitigation" below): if Sobol-100 against v7's WF spec returns < 5% empirical pass-rate at G1+G2+G3=25%, the v8 launch is deferred for a re-relaxation discussion before spend rather than discovered post-launch.
+- **The Round-2 50% threshold did not actually correspond to anyone's risk tolerance** — it corresponded to "the largest DD a passive baseline could plausibly have." That's a benchmark fact, not a candidate constraint.
+
+Trade-off accepted: in GFC-shaped windows where SPY took ~55%, *any* candidate that experienced the same crash will fail G3 even if it materially outperformed SPY. The hard read is that the v8 design is biased toward strategies that *avoid* the GFC drawdown (early de-risking, sector caps, stop-cascade), not strategies that *ride through* it with smaller-but-still-large drawdowns. This is a deliberate design bias matching the user's stated risk tolerance.
 
 #### Soft score — SPY-anchored alpha (within the acceptable set)
 
-For configs that pass the hard gate, the soft score from PR #1339 ranks them. The formula is unchanged from PR #1339 — only its role changes (it is no longer the BO's acceptance criterion, only its in-set ranker).
+For configs that pass the hard gate, the soft score ranks them. The formula extends PR #1339 with a **margin-bonus term** (Round-3 addition, addresses critique Finding 1):
 
 ```
 score_per_window(w) =
@@ -92,10 +120,19 @@ score_per_window(w) =
   - γ · [ max(0, cand_MaxDD_w - spy_MaxDD_w) ]²           # convex excess-DD
   - δ · max(0, spy_CAGR_w - cand_CAGR_w - spy_tol)        # asymmetric SPY-loss gate
 
-score(params) = mean_w(score_per_window) - ε · var_w(cand_Sharpe_w - spy_Sharpe_w)
+# Margin bonus on the worst-train-window's headroom above the G1 floor.
+# Saturates: once min-window margin clears the gate by ≥ margin_sat,
+# additional cushion contributes no further bonus.
+worst_margin     = min_{w ∈ train}( (cand_CAGR_w - spy_CAGR_w) - N_cagr )    # ≥ 0 for any acceptable config
+margin_clipped   = min(worst_margin, margin_sat)
+margin_bonus     = μ · margin_clipped                                          # Round-3 addition
+
+score(params) = mean_w(score_per_window)
+              - ε · var_w(cand_Sharpe_w - spy_Sharpe_w)
+              + margin_bonus                                                   # Round-3 addition
 ```
 
-Coefficients (unchanged from PR #1339):
+Coefficients:
 
 | Coef | Value | Term it weights | Derivation |
 |---|---|---|---|
@@ -105,6 +142,16 @@ Coefficients (unchanged from PR #1339):
 | δ | 20.0 | SPY-loss gate (asymmetric) | symmetric with α; δ · 0.05 = 1.0 score-point per 5pp loss past tolerance (7pp absolute) |
 | ε | 1.0 | cross-window Sharpe-alpha variance | ε · 0.05 = 0.05 score-point for "typical-stable" winner; ε · 0.50 = 0.50 for a fragile winner |
 | `spy_tol` | 0.02 | gate dead-band | losses ≤ 2pp below SPY are "near-tied", no gate-fire |
+| μ (Round-3) | 30.0 | margin bonus on worst-window G1 headroom | μ · 0.005 = 0.15 score-point per 0.5pp headroom above gate; saturates at margin_sat = 0.02 → max bonus = 0.60 |
+| `margin_sat` (Round-3) | 0.02 (2pp) | margin-bonus saturation | beyond 2pp worst-window cushion, additional headroom adds nothing (don't reward arbitrary over-clearing — only the knife-edge avoidance) |
+
+**Why the margin-bonus term (Finding 1 fix).** The Round-2 gate created a knife-edge incentive: the BO learns the gate boundary and parks at `min_w(cand_CAGR_w − spy_CAGR_w) ≈ N_cagr + ε` to preserve maximum optimization headroom for α-on-other-windows / β / γ / δ. The "min-window-skater" failure mode of critique Finding 1.
+
+`margin_bonus` makes the surface near the floor non-flat. A config at worst-margin = 0pp (just barely passing G1 on its weakest window) gets 0.0 from the bonus. A config at worst-margin = 1pp gets +0.30 score-points; at worst-margin = 2pp gets the saturated +0.60. The bonus is *capped* (margin_sat = 2pp) so that the BO cannot game it the other way by pushing margin arbitrarily large at the expense of the rest of the score.
+
+The size of `μ` is calibrated so that the bonus is meaningful but not dominating. At worst-margin = 2pp (saturated), the bonus = +0.60 score-points — roughly the same magnitude as a +3pp CAGR alpha contribution from the α-term (3pp × 20 = 0.60). A config that *needs* to skate the floor to obtain this score is therefore competing against a config that has +3pp/+3pp/+3pp uniform alpha + 0pp margin — and the latter wins on the α-term while the former wins on `margin_bonus`. The two cancel out, and the soft score ranks by the *next* term (β, γ, etc.). The min-window-skater optimum that Round-2 had a clean preference for becomes a wash, which is the goal.
+
+`margin_bonus` is computed *only inside* the acceptable set (worst_margin ≥ 0 is guaranteed). It plays no role in the unacceptable region, where the objective is `SENTINEL_REJECT` regardless.
 
 The soft score's role in the new structure is narrower than in PR #1339: it ranks configs that have *already* survived the binary gate. The critique's F5 (coefficients calibrated to aspirational magnitudes) is materially weakened because the gate has already filtered the population — within the acceptable set, the surface is denser around small-positive-alpha winners, and the BO is comparing genuine candidates rather than gameable extremes. Coefficients still matter for ranking, but they no longer decide acceptance.
 
@@ -130,106 +177,230 @@ The constraint-satisfaction approach is borrowed from constrained optimization l
 - **γ = 100.0** (convex excess-DD): magnitude-normalize at +10pp excess DD → penalty = 1.0. At +20pp, penalty = 4.0 (dominating).
 - **δ = 20.0** (asymmetric SPY-loss gate): symmetric with α. `spy_tol = 0.02`. A 7pp absolute loss (5pp past tolerance) yields δ·0.05 = 1.0 score-point penalty (correcting the PR #1339 prose finding #9, which incorrectly said "5pp absolute loss" → 1.0 penalty; it's actually 7pp).
 - **ε = 1.0** (cross-window stability via *population* variance, sum-of-squared-deviations / N).
+- **μ = 30.0, margin_sat = 0.02** (Round-3 margin bonus): chosen so that saturating bonus (worst-margin = 2pp on every train window) yields +0.60 score-points, comparable to a +3pp CAGR alpha contribution. The bonus is capped at 2pp worst-window margin so further headroom adds nothing — preventing the BO from pushing margin arbitrarily high at the expense of other terms. The choice trades off "knife-edge avoidance signal" (want μ large enough that the BO doesn't park at the boundary) against "dominance avoidance" (want μ·margin_sat smaller than the score range so margin-bonus doesn't tank into a single-knob fitness). μ·margin_sat = 0.60 vs typical acceptable-region soft-score range ≈ 0.0 to +2.0 gives 30% relative weight — strong incentive without being load-bearing.
 
-#### BO acceptance logic (pseudocode)
+#### BO acceptance logic — corrected (pseudocode)
 
-The change is local to `Bayesian_runner_scoring` and `Bayesian_runner` (current state: scoring returns a single float; BO compares floats to find the optimum). The integration point is the "is this new evaluation the best-so-far?" comparison and the final "report the iter-best" call.
+**Round-3 redesign — fixes critique Finding 4 (BLOCKING).**
+
+The Round-2 design split the BO into two views: the GP surrogate fit `soft_score(x)` over all evaluations, while the "best-so-far" pointer ranked only acceptable evaluations. This was mathematically incoherent: Expected Improvement is `EI(x) = E[max(0, f(x) − f*)]` where `f(x)` comes from the GP surrogate and `f*` is the best-so-far. If the surrogate is fit to one population and `f*` is taken from a different population, the EI maximum can sit deep in the unacceptable region — wherever the surrogate predicts high soft-score peaks — and the BO burns its budget re-sampling configs that the runner correctly classifies as rejected. The "acceptable best-so-far" never advances because the BO doesn't explore the acceptable region. The critique's worked example: a soft-score-2.45 blockbuster sits in the unacceptable region, the GP fits that peak, EI peaks there, BO re-samples nearby; acceptable best-so-far stuck at 0.82.
+
+**Round-3 fix.** Use a single `objective(x)` everywhere — GP fits it, EI computes against it, best-so-far ranks it:
 
 ```
+SENTINEL_REJECT := -1.0e6   # well below any reachable acceptable soft-score;
+                              # see "Why a finite sentinel" below.
+
 # Module: Bayesian_runner_scoring (additive — does not break the existing
 # `score_cell_with_penalty` callers in v7).
 
 type evaluation = {
   params : config_overrides;
-  per_window_metrics : (window_label * metrics) list;  # K = 3 train + 1 holdout
-  soft_score : float;
-  acceptable : bool;          # NEW: result of hard-gate predicate on train only
-  gate_failures : string list; # NEW: which of {G1, G2, G3} failed for which window
+  per_window_metrics : (window_label * metrics) list;   # K = 3 train + 1 holdout
+  soft_score : float;          # always computed; used inside acceptable set for ranking + reporting
+  acceptable : bool;           # result of hard-gate predicate on train only
+  gate_failures : string list; # which of {G1, G2, G3} failed for which window
+  per_window_margins : (window_label * float) list;  # G1 margin per train window: (CAGR_alpha - N_cagr); negative = G1 fail
+  per_window_dd_excess : (window_label * float) list; # G2 excess: (cand_DD - spy_DD); positive over N_dd_rel = G2 fail
+  per_window_dd_abs : (window_label * float) list;    # for G3 closeness: cand_DD over N_dd_abs = G3 fail
+  objective : float;           # NEW: single scalar the BO consumes. == soft_score if acceptable, == SENTINEL_REJECT otherwise.
 }
 
 function evaluate_one(params, spec, spy_benchmark_per_window):
     per_window = run_multi_window_backtest(params, spec)
-    soft_score = score_absolute_alpha(per_window, spy_benchmark_per_window)
+    soft_score = score_absolute_alpha(per_window, spy_benchmark_per_window)  # includes margin_bonus
     (acceptable, gate_failures) =
         check_hard_gate(per_window, spy_benchmark_per_window, train_windows_only=true)
-    return { params; per_window; soft_score; acceptable; gate_failures }
+    margins        = compute_per_window_g1_margins(per_window, spy_benchmark_per_window)
+    dd_excess      = compute_per_window_g2_excess(per_window, spy_benchmark_per_window)
+    dd_abs         = compute_per_window_g3_abs(per_window)
+    objective      = if acceptable then soft_score else SENTINEL_REJECT
+    return { params; per_window_metrics; soft_score; acceptable; gate_failures;
+             per_window_margins; per_window_dd_excess; per_window_dd_abs;
+             objective }
 
 function check_hard_gate(per_window, spy, train_windows_only):
     failures = []
     for w in (if train_windows_only then train_windows else all_windows):
-        if (cand_CAGR_w - spy_CAGR_w) < N_CAGR:
-            failures.append("G1 failed on " + w)
-        if (cand_MaxDD_w - spy_MaxDD_w) > N_DD_REL:
-            failures.append("G2 failed on " + w)
-        if cand_MaxDD_w > N_DD_ABS:
-            failures.append("G3 failed on " + w)
+        if (cand_CAGR_w - spy_CAGR_w) < N_CAGR:    failures.append("G1 failed on " + w)
+        if (cand_MaxDD_w - spy_MaxDD_w) > N_DD_REL: failures.append("G2 failed on " + w)
+        if cand_MaxDD_w > N_DD_ABS:                  failures.append("G3 failed on " + w)   # N_DD_ABS = 0.25
     return (failures.empty(), failures)
 
-# Module: Bayesian_runner — BO loop modification.
+# Module: Bayesian_runner — single-objective BO loop.
 #
 # CURRENT (v7):
 #   best_so_far := argmax_over_evaluations(soft_score)
 #
-# NEW (v8):
-#   acceptable_set := { e in evaluations : e.acceptable == true }
-#   if acceptable_set is non-empty:
-#       best_so_far := argmax_over(acceptable_set, soft_score)
-#       termination_state := "OK"
-#   else:
-#       best_so_far := argmax_over(all evaluations, soft_score)
-#       termination_state := "NO_ACCEPTABLE_CONFIG"   # warning to caller
-#
-# In both cases the GP surrogate sees ALL evaluations (acceptable or not),
-# so unacceptable points still inform exploration. Only the "iter-best"
-# reporting and the acquisition function's exploitation target use the
-# filtered set.
+# NEW (v8, Round-3):
+#   For every evaluation e:
+#     GP_train_points.append((e.params, e.objective))   # ONE function fit, not two
+#   Best-so-far:
+#     best_so_far := argmax_over(all evaluations, objective)
+#   Acquisition:
+#     EI(x) := E[max(0, GP(x) - best_so_far)]            # ONE objective in both terms
+#   Termination state:
+#     if any evaluation has acceptable == true:
+#        termination_state := "OK"
+#        # best_so_far is the highest soft-score among acceptable points (since
+#        # SENTINEL_REJECT << any reachable acceptable soft-score, the argmax
+#        # over all evaluations on `objective` collapses to argmax over the
+#        # acceptable subset on `soft_score`).
+#     else:
+#        termination_state := "NO_ACCEPTABLE_CONFIG"
+#        # best_so_far is SENTINEL_REJECT (every objective is SENTINEL_REJECT).
+#        # Report the highest-soft-score config among the unacceptable population
+#        # as the "closest-rejected" point in the fallback diagnostic (see § Sobol).
 ```
 
-The `acceptable` field and `gate_failures` field are also serialized into the per-iter checkpoint (`bo_checkpoint.sexp`) so post-hoc analysis can characterize the pass-rate of the hard gate across the BO trajectory.
+**Why a finite sentinel (`-1.0e6`), not `-∞`.** Two reasons:
 
-#### Sobol initial-random phase handling
+1. **GP numerics.** Most GP kernel implementations (RBF, Matérn) expect bounded target values; `-∞` produces NaN gradients in the marginal-likelihood optimizer when the GP fits the kernel hyperparameters. A finite sentinel ~10⁶ below any reachable acceptable value is functionally equivalent (EI prefers any acceptable point by a factor of 10⁶+) but keeps the GP fit numerically stable.
+2. **Sentinel below any reachable acceptable score.** The acceptable region's soft-score floor is bounded below by α · N_cagr · |train_windows| / |train_windows| + margin_bonus(0) = 20 · 0.01 = +0.20 (the G1 floor contribution to the α-term alone, before β/γ/δ contributions). The acceptable soft-score ceiling is bounded above by approximately α · 0.10 + β · 1.0 + margin_bonus(margin_sat) = 2.0 + 1.4 + 0.6 = +4.0 even for extreme +10pp/+1.0-Sharpe winners. So acceptable soft-scores live in roughly [+0.20, +4.0]. SENTINEL_REJECT = −10⁶ sits 250,000× below the acceptable floor — vastly larger than the GP's posterior uncertainty at any train point, so EI is guaranteed to prefer any acceptable region over any unacceptable region with probability indistinguishable from 1.
+
+**Consistency proof — surrogate, EI, and best-pointer are mutually compatible:**
+
+- **Surrogate consistency.** The GP fits `(x_i, objective(x_i))` for all `i`. Both regions are present in the training data with their true (cliff-discontinuous) objective value. Predictions `GP(x)` for unseen `x` interpolate between SENTINEL_REJECT and acceptable soft-scores; near a known unacceptable evaluation, `GP(x) ≈ SENTINEL_REJECT`; near a known acceptable evaluation, `GP(x) ≈ that point's soft-score`. The GP learns the cliff edge from data; it does not learn a smooth peak in the unacceptable region (the Round-2 failure mode).
+- **EI consistency.** `EI(x) = E[max(0, GP(x) − f*)]`. `f*` is best-so-far on objective. If at least one acceptable evaluation exists, `f* ≥ +0.20` (acceptable soft-score floor). For unacceptable regions where `GP(x) ≈ SENTINEL_REJECT = −10⁶`, the integrand `max(0, GP(x) − f*) ≈ max(0, −10⁶ − 0.20) = 0`. EI in unacceptable regions ≈ 0 (modulo the GP's posterior std which is also negligible at this scale). EI in acceptable regions or near-acceptable regions (where `GP(x)` may predict close to or above `f*`) is the dominant contribution. Acquisition selects from the acceptable region as desired.
+- **Best-pointer consistency.** `best_so_far := argmax_x objective(x)`. If acceptable set non-empty, every acceptable point has `objective = soft_score ∈ [+0.20, +4.0]` while every unacceptable point has `objective = −10⁶`. `argmax` collapses to the highest soft-score acceptable point. If acceptable set empty, `best_so_far = SENTINEL_REJECT` and the runner reports `NO_ACCEPTABLE_CONFIG` per § "Sobol initial-random phase handling" with the new diagnostic (next subsection).
+
+This is sound vanilla BO on a discontinuous objective — not a hybrid construction. The cost of the simplification (vs full constrained BO/cBO with a second GP on the acceptance indicator) is that the GP fit is noisier near the gate boundary (the cliff is not band-limited). In practice this expresses as slightly more EI mass within ε of the boundary on the acceptable side — which is the right behaviour: the BO should *explore* the boundary because that's where the highest-margin-bonus + highest-CAGR-alpha trade-off lives.
+
+**Alternative considered: full constrained BO (cBO/PESC).** Train two GPs — one on soft_score, one on the binary acceptable-indicator — and multiply `EI(x) × P_GP_constraint(acceptable(x))`. Standard in the literature; would converge faster on the boundary. Not adopted for Round-3 because (a) it requires a second GP implementation with classification-target support, materially more BO infrastructure work than the sentinel fix, (b) the sentinel approach is sufficient when the acceptable set is non-tiny (target ≥ 25 / 80 per § "Acceptable-set sparsity mitigation"), and (c) if Round-3 v8 results show the sentinel approach is too slow on the gate boundary, cBO is the obvious upgrade path.
+
+The `acceptable` field, `gate_failures` field, `per_window_margins`, `per_window_dd_excess`, `per_window_dd_abs`, and `objective` are all serialized into the per-iter checkpoint (`bo_checkpoint.sexp`) so post-hoc analysis can characterize gate pass-rate and gate-proximity across the BO trajectory.
+
+#### Sobol initial-random phase handling + NO_ACCEPTABLE_CONFIG diagnostic
 
 The Sobol phase samples 20 initial points uniformly over the knob space. There is no guarantee that any of them pass the hard gate — particularly on the first run on a new spec, where the surface shape is unknown.
 
-**Policy: Option (a) — report the soft-score winner with a `NO_ACCEPTABLE_CONFIG` warning.**
+**Policy: Option (a) — report the soft-score winner with a `NO_ACCEPTABLE_CONFIG` warning, plus an actionable diagnostic (Round-3 addition).**
 
 - The BO does not block on the gate. It runs the full 80-iteration budget regardless.
-- If by termination no point has passed the hard gate, the runner reports the highest-soft-score config among the unacceptable population, prefixed in the report with `[WARNING: no config passed the hard gate; reported is best-by-soft-score among unacceptable candidates]`.
-- The reported config is *not* eligible for promotion (the promote gate, separately, applies the same hard-gate logic). The warning is operationally a signal to the user: either the knob bounds need widening, or this strategy on this universe cannot meet the gate at all.
+- If by termination no point has passed the hard gate, the runner reports the highest-soft-score config among the unacceptable population, prefixed with `[WARNING: no config passed the hard gate]`.
+- The reported config is *not* eligible for promotion (the promote gate, separately, applies the same hard-gate logic).
+
+**NO_ACCEPTABLE_CONFIG diagnostic block (Round-3 addition — addresses critique Finding 6).** The Round-2 warning was non-actionable: "BO failed" doesn't tell the operator whether the gate is too tight, the strategy is fundamentally weak, the spec is misconfigured, or the universe lacks coverage. The Round-3 report adds four sections, all derived from data the runner already has on hand:
+
+```
+[NO_ACCEPTABLE_CONFIG diagnostic]
+
+Section 1 — Per-gate failure histogram (by train window):
+  G1 (CAGR-alpha < +1pp) failures: W1: 78/80  W2: 71/80  W3: 65/80
+  G2 (rel-DD > +10pp)    failures: W1:  4/80  W2: 12/80  W3:  3/80
+  G3 (abs-DD > 25%)      failures: W1:  0/80  W2: 22/80  W3:  0/80
+
+  Reading: 78/80 configs failed G1 on W1 -> W1 is the binding window for CAGR alpha.
+  22/80 G3 fails on W2 are GFC-shaped configs taking >25% DD in the GFC window.
+
+Section 2 — Closest-rejected config (smallest aggregate gate-violation distance):
+  iter:                  37
+  params:                <full sexp of overrides>
+  per-window G1 margins: W1: -0.003  W2: +0.001  W3: -0.002    (W1 binding, off by 0.3pp)
+  per-window G2 excess:  W1: +0.04   W2: +0.06   W3: +0.03     (all ≤ 0.10, G2 ✓)
+  per-window G3 absDD:   W1:  0.12   W2:  0.22   W3:  0.08     (all ≤ 0.25, G3 ✓)
+  per-window soft-score: W1: +0.18   W2: +0.21   W3: +0.31
+  total soft-score:      +0.23
+  closest gate distance: 0.003 (G1 on W1)
+  reading: "this config is 0.3pp CAGR alpha away from passing on W1; it
+   already passes G2/G3 on every train window. If W1 G1 floor relaxed
+   from 1.0pp -> 0.7pp, this config qualifies."
+
+Section 3 — SPY benchmark by window (the reference baseline the gate measures against):
+  W1 (1998-2004): SPY CAGR  3.2%, Sharpe 0.18, MaxDD 49.1%
+  W2 (2005-2011): SPY CAGR  0.4%, Sharpe 0.02, MaxDD 54.7%
+  W3 (2012-2018): SPY CAGR 12.8%, Sharpe 1.18, MaxDD 19.4%
+  reading: "W1 had near-zero SPY CAGR; G1 +1pp on W1 is achievable. W2
+   was negative-SPY-CAGR + 55% DD GFC; G3 at 25% rules out any candidate
+   that rode the GFC down passively. W3 was the post-GFC bull; beating
+   12.8% by 1pp requires CAGR ≥ 13.8%."
+
+Section 4 — Suggested operator action (rule-based):
+  RULE: if dominant failure is G1 on a high-SPY-CAGR window
+        -> universe / strategy alpha-source mismatch; widen bounds OR change strategy
+  RULE: if dominant failure is G3 on a window with SPY MaxDD > 50%
+        -> gate inherently rejects "rode-it-down" configs (intentional bias);
+           consider whether a sector cap / hard de-risk knob is being explored
+  RULE: if all configs fail G1 on a single specific train window by <0.5pp
+        -> consider relaxing N_cagr to 0.005 (0.5pp) and re-launching
+  RULE: if G2 / G3 are the binding constraints and G1 margins are healthy
+        -> the BO is finding alpha but with excess risk; either widen DD knobs
+           or tighten knob bounds to lower-risk regions
+
+  In this run the dominant failure is G1 on W1 (78/80 = 97.5%); closest-rejected
+  is 0.3pp short on W1. Suggested action: either (a) widen bounds on
+  `max_long_exposure_pct` upward (the closest-rejected has 0.85 exposure -
+  the cap is 1.0), or (b) relax N_cagr to 0.005 for a re-launch and treat
+  any pass as marginal-quality.
+```
+
+Each section is mechanically computable from the per-iter checkpoint data the runner already serializes (per Round-3 § "BO acceptance logic — corrected"). No additional backtest passes required. The implementation lives alongside the existing report-emission code; the new sections are wrapped behind a `is NO_ACCEPTABLE_CONFIG` predicate and emit nothing in the OK case.
 
 **Rejected alternative — Option (b) "refuse to terminate until M acceptable points found".**
 
 - Risk of unbounded compute: the gate could be unsatisfiable for the strategy/universe combination (genuine alpha doesn't exist), and the runner would loop forever.
 - v7 evidence supports the unsatisfiability concern: if the underlying strategy genuinely can't beat SPY by 1pp CAGR in all of W1/W2/W3, the runner shouldn't pretend by extending the budget.
-- A loud termination with `NO_ACCEPTABLE_CONFIG` warning + best-by-soft-score is more actionable: the user sees the surface shape, can compare to SPY, and can decide whether to widen bounds, change windows, change the universe, or drop the strategy.
+- A loud termination with `NO_ACCEPTABLE_CONFIG` warning + the four-section diagnostic + best-by-soft-score is more actionable: the user sees the surface shape, the binding constraint, the closest near-pass, the baseline reference, and a rule-based suggestion.
 
-#### Holdout treatment (W4)
+#### Acceptable-set sparsity mitigation — pre-flight smoke sweep (Round-3 addition)
 
-The hard gate applies *only* to the three training windows. The holdout window (W4, 2019-2025) is reserved for verdict criteria *after* BO completion, not for BO acceptance.
+Critique Finding 2: the Round-2 design risks landing fewer than 16 acceptable points in 80 iters × 11 dims. At G3 = 25% (Round-3 tightening) the gate is *narrower*, making sparsity worse, not better. The mitigation has two parts:
 
-Rationale: if the holdout participated in the gate, it would no longer be held out — every BO iteration would have used holdout information to decide whether to be reported as iter-best, and the apparent "out-of-sample" performance would be conditional on the holdout having passed the gate during selection. This is a textbook information-leakage failure mode that the train/holdout split exists to prevent.
+1. **Knob count reduced to 9** (already in Decision 4). Cuts the GP's dimensionality from 11 to 9; the acceptable-set density needed for meaningful GP interpolation drops.
+2. **Mandatory pre-flight Sobol-100 smoke sweep on v7's WF spec** (Round-3 launch precondition):
 
-The verdict criteria for the iter-best (after BO termination) are:
+   - Before launching v8, run **100 Sobol points** (3-4h wall-time at parallel=6) against the v7 walk-forward spec, scoring each point with Round-3 `objective` (gate + soft score + margin bonus).
+   - Compute empirical acceptable-set fraction. Decision rule:
+     - `≥ 25%` acceptable: green-light v8 launch. Target acceptable-set size at 80 iter ≈ 20+; GP-interpolation viable.
+     - `5% - 25%` acceptable: yellow. Discuss relaxing N_cagr from 1pp → 0.5pp before launch, OR widening one or two knob bounds, OR running a second Sobol-100 to firm up the estimate.
+     - `< 5%` acceptable: red. Defer v8 launch entirely. The acceptable region is too sparse for BO to find — the strategy/universe combination genuinely can't meet the gate. The user's options: relax the gate, change the strategy, or change the universe. None are "run v8 and see what happens."
+   - Cost: 3-4h wall-time on existing infrastructure (smoke sweep uses the same backtest passes the real v8 will use). Saves potentially 12h+ of v8 BO wall-time on a gate that's structurally unsatisfiable.
+   - Reuses the existing `bayesian_runner` binary with `--max-iter 0 --num-sobol 100` (the BO loop is skipped; only Sobol evaluations are performed).
+
+**Why on v7's spec, not v8's spec.** v7's spec already exists, with bounds the user has been operating against. Round-3 v8 differs by 1 dropped knob + 1 new knob + 4 widened bounds (Decision 4). If v7's spec produces < 5% acceptable, v8's wider bounds *might* increase the rate, but the smoke sweep on v7 establishes a lower bound on the acceptable region's density. If even the v7 spec's tighter bounds produce 20%+ acceptable, v8's wider bounds will almost-certainly produce ≥ 20%.
+
+**Worst-case fallback if smoke sweep is yellow / red.** Round-3 explicitly *accepts* the limitation rather than re-relaxing the gate silently. The gate's purpose is to encode the user's risk tolerance; relaxing N_cagr from 1pp → 0.5pp would be a substantive policy change requiring user decision, not an in-design auto-correction. If the smoke sweep shows the user's stated risk tolerance is genuinely too tight for the strategy class, that *is* the answer, and it points at the broader-universe / strategy-redesign axes from `memory/project_strategic_pivot_broader_first.md` rather than at more BO tuning.
+
+#### Holdout treatment (W4) — Round-3 symmetric
+
+The hard gate applies *only* to the three training windows during the BO. The holdout window (W4, 2019-2025) is reserved for verdict criteria *after* BO completion, not for BO acceptance.
+
+Rationale: if the holdout participated in the BO gate, it would no longer be held out — every BO iteration would have used holdout information to decide whether to be reported as iter-best, and the apparent "out-of-sample" performance would be conditional on the holdout having passed the gate during selection. This is a textbook information-leakage failure mode that the train/holdout split exists to prevent.
+
+**Round-3 change.** Round-2 verdict had two asymmetries vs train (critique Finding 3): a *looser* CAGR fallback (`Δ ≥ 0` on W4 vs `≥ +1pp` on train) and a *tighter* MaxDD fallback (`≤ 25%` on W4 vs train's old `≤ 50%`). The looser CAGR fallback undermines the design's structural claim that "winning is +1pp or it doesn't count"; the tighter MaxDD fallback creates the inverted-asymmetry problem where a config can pass train at W2-DD = 48% but fail W4 at 26%.
+
+Round-3 drops both fallbacks. Train and holdout use the **same** G1/G2/G3 thresholds — including the Round-3 G3 tightening to 25% on both. Verdict table:
 
 | Criterion | What it tells us | Reuses gate logic? |
 |---|---|---|
-| iter-best is `acceptable` on TRAIN (W1, W2, W3) | BO produced a structurally non-fragile config | YES (G1/G2/G3 on W1-W3) |
-| iter-best is `acceptable` on HOLDOUT (W4) | Generalizes out-of-sample | YES (G1/G2/G3 on W4, same thresholds) |
-| holdout CAGR Δ ≥ 0 vs SPY | Looser fallback if the strict gate is too tight on W4 alone | NO (just sign check) |
-| holdout MaxDD ≤ 25% | Tighter than G3=50% — the verdict cares more about absolute risk than the BO acceptance does | NO (custom threshold) |
+| iter-best is `acceptable` on TRAIN (W1, W2, W3) | BO produced a structurally non-fragile config | YES (G1/G2/G3 on W1-W3, N_cagr=1pp, N_dd_rel=10pp, N_dd_abs=25%) |
+| iter-best is `acceptable` on HOLDOUT (W4) | Generalizes out-of-sample | YES (G1/G2/G3 on W4, SAME thresholds) |
 | `promote_config.sh` gate passes for sp500-2010-2026 | Aligned with promote | NO (existing promote pipeline) |
 
-The G1/G2/G3 thresholds on W4 are the same as on W1-W3 — symmetric application of the criterion the user actually cares about. The "looser fallback" line (holdout CAGR Δ ≥ 0) is the existing v7 verdict criterion preserved as a softer reporting line: if the iter-best passes the strict gate on W4, great; if not but the holdout CAGR alpha is still positive, that's a softer "marginal-pass" outcome that the verdict reports but does not auto-promote.
+The verdict is binary on each line: pass or fail. There is no "marginal-pass" / "looser fallback" middle ground. The user's stated risk tolerance is encoded once in {N_cagr, N_dd_rel, N_dd_abs}, and that one encoding governs both BO acceptance (on train) and verdict (on holdout). The asymmetry the critique called out is removed.
 
-#### Worked examples (with N_cagr = 0.01, N_dd_rel = 0.10, N_dd_abs = 0.50)
+**Trade-off accepted.** A real v8 winner might pass train cleanly but fail holdout because W4 had different regime characteristics (e.g. 2020 COVID volatility, 2022 bear). Under Round-2's softer holdout, such a config would have been reported as "marginal-pass." Under Round-3, it is reported as fail. The promote_config gate then has the last word — if the promote panel still passes, that's an "OK on broader scenarios, fragile on this specific 7y holdout" finding, which is a meaningful signal in its own right. Better than a soft "marginal" verdict that obscures whether to deploy.
 
-All examples use the 4-window structure (W1: 1998-2004, W2: 2005-2011, W3: 2012-2018, W4: 2019-2025). Hard gate is evaluated on W1/W2/W3 only.
+#### Worked examples (with N_cagr = 0.01, N_dd_rel = 0.10, N_dd_abs = 0.25)
+
+All examples use the 4-window structure (W1: 1998-2004, W2: 2005-2011, W3: 2012-2018, W4: 2019-2025). Hard gate is evaluated on W1/W2/W3 only. Round-3 changes: N_dd_abs tightened from 0.50 → 0.25, soft score includes margin_bonus, objective is `soft_score` (acceptable) or `SENTINEL_REJECT` (otherwise).
+
+Examples A–I are preserved from Round-2 with arithmetic re-verified under N_dd_abs = 0.25 (Example I now passes G3 trivially; the new Example I' covers the G3-tightening case). Examples J and K are net-new for Round-3 failure modes.
 
 **Example A — SPY itself.**
 Per train-window: `cand_CAGR_w - spy_CAGR_w = 0`. **G1 fails on every window** (0 < 1pp). → **REJECT (unacceptable).** Soft score = 0.00 (anchor). Outcome: SPY itself does not pass the gate, by design. The gate measures "decisively beats SPY," not "is SPY-or-better." SPY is the reference baseline; it would be incoherent for the BO to "discover" SPY itself as its winner.
 
 **Example B — genuine winner: consistent +2pp CAGR alpha across all 4 windows, +0.3 Sharpe alpha, −5pp DD vs SPY.**
-Per train-window: G1 (+2pp ≥ 1pp ✓), G2 (−5pp ≤ +10pp ✓), G3 (cand_DD < spy_DD ≤ ~55% ✓). → **ACCEPTABLE.** Soft score = 0.82 (per the unchanged formula). Outcome: passes the gate and ranks high on the soft score. This is the BO's target.
+Per train-window: G1 (+2pp ≥ 1pp ✓), G2 (−5pp ≤ +10pp ✓), G3 (cand_DD < spy_DD ≤ ~25% in W1/W3; W2 needs check — assume cand_DD = 20% < 25% ✓). → **ACCEPTABLE.** Soft score under Round-3:
+- α contribution: 20 · (0.02+0.02+0.02+0.02)/4 = 0.40
+- β contribution: 1.4 · (0.3+0.3+0.3+0.3)/4 = 0.42
+- γ contribution: 0 (excess_DD < 0 everywhere — paired floor at 0)
+- δ contribution: 0 (cand_CAGR > spy_CAGR everywhere)
+- ε contribution: − 1.0 · var(0.3, 0.3, 0.3, 0.3) = 0
+- margin_bonus (Round-3): worst_margin = min(2pp − 1pp) = +0.01 (= 1pp on every window). Capped by margin_sat = 0.02 (not yet saturated). margin_bonus = 30 · 0.01 = +0.30
+- **total soft_score = 0.40 + 0.42 + 0 + 0 + 0 + 0.30 = +1.12.** Objective = +1.12 (in acceptable region; the GP fits this value at this point).
+
+Note the Round-2 value was +0.82 (no margin_bonus). The +0.30 increase from the margin_bonus reflects this config's uniform 1pp clearance of the gate floor — exactly the behavior the term was added to reward. This is the BO's target.
 
 **Example C — marginal config: matches SPY CAGR ±0pp, matches Sharpe ±0, takes +2pp excess DD per window.**
 Per train-window: **G1 fails** (0 < 1pp). → **REJECT (unacceptable).** Soft score = −0.04. Outcome: a config that does not measurably beat SPY is rejected regardless of how close to neutral the soft score is. Closes the "indistinguishable from SPY but cheaper" loophole.
@@ -249,29 +420,109 @@ Per train-window: **G1 fails on W1** (0.5pp < 1pp), **G1 fails on W2** (0.5pp < 
 Per train-window: **G1 fails on W1, W2** (0pp < 1pp) — already enough to reject. → **REJECT.** Even if W1/W2 hadn't failed, **G2 would fail on W3** (15pp > 10pp). The gate stops the calm-window DD game before the soft γ-term has any chance to be net-positive.
 
 **Example I — catastrophic absolute DD (G2-without-G3 escape case)**: passes G1 (+2pp CAGR alpha) in all train windows, passes G2 (excess DD ≤ +10pp in all train windows; assume W2 SPY DD is 45% and candidate takes 54%, excess = +9pp), but takes 54% absolute DD in W2.
-Per train-window: G1 ✓, G2 ✓ in W2 (54−45 = 9pp ≤ 10pp), but **G3 fails on W2** (54% > 50%). → **REJECT.** This is the case where G2 alone would not have caught the problem (the candidate is only modestly worse than SPY in paired terms) — G3 provides the absolute floor.
+Per train-window: G1 ✓, G2 ✓ in W2 (54−45 = 9pp ≤ 10pp), but **G3 fails on W2** (54% > 25%). → **REJECT.** Objective = SENTINEL_REJECT. This is the case where G2 alone would not have caught the problem (the candidate is only modestly worse than SPY in paired terms) — G3 provides the absolute floor. Under Round-2 (G3 = 50%) this still rejected (54 > 50). Under Round-3 (G3 = 25%) the rejection is decisive — 54 > 25 by a wide margin.
+
+**Example I' (Round-3 net-new) — G3-tightening case**: passes G1 (+2pp CAGR alpha) in all train windows, passes G2 (assume W2 SPY DD is 25%, candidate takes 30%, excess = +5pp), but takes 30% absolute DD in W2.
+Per train-window: G1 ✓, G2 ✓ in W2 (30 − 25 = 5pp ≤ 10pp), **G3 fails on W2 under Round-3** (30% > 25%) but passed under Round-2 (30% < 50%). → **REJECT under Round-3.** Objective = SENTINEL_REJECT. This is the case the G3 = 25% tightening was designed to catch. A config that takes 30% DD on a window where SPY took 25% is only +5pp worse than SPY (G2 passes), and Round-2 would have rated this as "acceptable" — but 30% absolute drawdown still requires ~43% recovery and is structurally too risky on a user-tolerance basis. Round-3 cuts it off.
+
+**Example J (Round-3 net-new) — min-window-skater vs uniform-winner (critique Finding 1 fix verification)**:
+
+Two candidates being ranked within the acceptable set. Each passes G1/G2/G3 on all train windows; differentiate them by the soft score (with margin_bonus).
+
+| Sub-case | W1 CAGR-α | W2 CAGR-α | W3 CAGR-α | worst-margin | margin_bonus | α-term mean | total soft-score (approx) |
+|---|---|---|---|---|---|---|---|
+| J-skater   | +5pp | +1.01pp | +5pp | +0.0001 (≈ 0) | μ · 0.0001 ≈ +0.003 | 20·(0.05+0.0101+0.05)/3 = +0.74 | +0.74 + 0.003 + (other terms) ≈ **+0.74** |
+| J-uniform  | +3pp | +3pp    | +3pp | +0.02 (saturated at margin_sat) | μ · 0.02 = **+0.60** | 20·(0.03+0.03+0.03)/3 = +0.60 | +0.60 + 0.60 + (other terms) ≈ **+1.20** |
+
+Outcome: J-uniform wins by +0.46 score-points (+1.20 vs +0.74). Without margin_bonus (Round-2), J-skater would win (+0.74 vs +0.60 — pure α-mean comparison). The margin_bonus inverts the ranking in favour of the uniform-winner.
+
+Why this matters. Under Round-2, the BO's exploration trajectory was: "find configurations that maximize total α-mean subject to G1 ≥ 0 on every window." The optimal way to do this is to push CAGR alpha as high as possible *on the easiest windows* while just clearing G1 on the *hardest* window. The "min-window-skater" pattern — high alpha on two windows, marginal on one — dominates uniform-winners. Critique Finding 1 named this as a new overfit mode introduced by Round-2.
+
+Under Round-3, J-uniform is preferred. The margin_bonus is calibrated (μ = 30, margin_sat = 0.02) so that a uniform +3pp/+3pp/+3pp winner with full margin (+2pp worst margin) gets a 0.60-score-point boost that more than offsets the skater's α-mean advantage (~0.14). The BO's exploration now targets the *interior* of the acceptable region rather than the gate boundary.
+
+This does NOT re-open critique Finding 1 from PR #1341 (the soft-only single-window blockbuster). That failure mode is rejected by the hard gate (Example E above), independent of the soft score. margin_bonus operates only on the worst-window margin — there is no way to game it by piling alpha into one window because the "min" operator ignores anything above the worst.
+
+Edge case: an acceptable config with two windows at +5pp and one window at +1.01pp gets only +0.003 from margin_bonus (worst-margin ≈ 0). An acceptable config with all three windows at +1.5pp gets +0.15 from margin_bonus (worst-margin = 0.5pp). Both are acceptable; both are decently uniform; the margin bonus differentiates them in favour of the uniform-margin-half-way-clear one. This is the desired ordering.
+
+**Example K (Round-3 net-new) — NO_ACCEPTABLE_CONFIG fallback with the new diagnostic (critique Finding 6 fix verification)**:
+
+Suppose the v8 BO completes 80 iterations and no point passes the hard gate. The runner emits:
+
+```
+[NO_ACCEPTABLE_CONFIG]
+best_so_far = SENTINEL_REJECT (no acceptable point found)
+highest-soft-score among unacceptable population: iter 37, soft_score = +0.23
+
+Section 1 — Per-gate failure histogram:
+  G1 (CAGR-alpha < +1pp): W1: 78/80,  W2: 71/80,  W3: 65/80
+  G2 (rel-DD > +10pp):    W1:  4/80,  W2: 12/80,  W3:  3/80
+  G3 (abs-DD > 25%):      W1:  0/80,  W2: 22/80,  W3:  0/80
+
+Section 2 — Closest-rejected config (iter 37):
+  params:                <full sexp of overrides>
+  G1 margins:            W1: -0.003, W2: +0.001, W3: -0.002    (W1 binding)
+  G2 excess:             W1: +0.04,  W2: +0.06,  W3: +0.03     (G2 ✓)
+  G3 absDD:              W1:  0.12,  W2:  0.22,  W3:  0.08     (G3 ✓)
+  smallest gate distance: 0.003 (G1 on W1; 0.3pp short)
+
+Section 3 — SPY benchmark by window:
+  W1 SPY: CAGR  3.2%, Sharpe 0.18, MaxDD 49.1%
+  W2 SPY: CAGR  0.4%, Sharpe 0.02, MaxDD 54.7%
+  W3 SPY: CAGR 12.8%, Sharpe 1.18, MaxDD 19.4%
+
+Section 4 — Suggested operator action:
+  - Dominant binding constraint: G1 on W1 (97.5% failure rate).
+  - Closest-rejected is 0.3pp short on W1 — within "near-miss" range.
+  - 22/80 G3 fails on W2 reflect candidates that rode the GFC down >25%
+    (intentional design bias under Round-3 G3 = 25%).
+  - Suggested actions, in order of preference:
+    (a) Widen `max_long_exposure_pct` bound upward (currently 0.5-1.0;
+        closest-rejected has 0.85 — already at the high end of v7's old
+        range. If still binding, the strategy genuinely lacks W1 alpha at
+        current sizing.)
+    (b) Relax N_cagr to 0.005 (0.5pp) for a follow-up sweep, but treat any
+        resulting "pass" as marginal-quality and require holdout-clean
+        before promotion.
+    (c) Switch universe (per project_strategic_pivot_broader_first.md) —
+        the W1 (1998-2004) period had near-zero SPY CAGR; +1pp alpha may
+        be unreachable on top-3000 large-cap. Broader universes had higher
+        small-cap dispersion in this era.
+```
+
+What this example demonstrates. Round-2's NO_ACCEPTABLE_CONFIG warning would have been:
+
+```
+[WARNING: no config passed the hard gate; reported is best-by-soft-score among unacceptable]
+iter 37, soft_score = 0.23
+```
+
+Operator response: "BO failed, no idea why; rerun with different seed?" This is the non-actionable failure mode the critique flagged.
+
+Round-3's diagnostic concretely identifies (a) W1 is the binding window, (b) the closest-rejected is only 0.3pp away, (c) max_long_exposure_pct is at its high bound, suggesting that's the binding knob, (d) the historical SPY CAGR on W1 was 3.2% — beating it by 1pp is materially harder than beating W3's 12.8% by 1pp. The operator now has four concrete actions with explicit trade-offs. Same data the runner already had; just surfaced legibly.
 
 #### Sanity table (within the acceptable set only)
 
-The PR #1339 score → verdict table still applies, but its scope is now restricted: every row presupposes `acceptable == true`. The "≤ −0.05" rows in particular almost never apply (a config that has passed the hard gate at +1pp CAGR alpha in every window scores at least +0.20 on the α-term alone, plus β contribution).
+The PR #1339 score → verdict table still applies, but its scope is now restricted: every row presupposes `acceptable == true`. The "≤ −0.05" rows in particular almost never apply (a config that has passed the hard gate at +1pp CAGR alpha in every window scores at least +0.20 on the α-term alone, plus β contribution + margin_bonus contribution).
 
 | Score range (acceptable configs only) | Interpretation |
 |---|---|
-| ≥ +0.50 | Decisively beats SPY across all 3 train windows |
-| +0.20 to +0.50 | Solid pass — α-term dominates from N_cagr-floor satisfaction |
-| 0.00 to +0.20 | Marginal acceptable — minor risk-adjusted offsets from β/γ/δ |
-| < 0.00 | Rare; configs that pass G1-G3 but score negative on β + γ + δ aggregate (uncommon — implies very poor Sharpe or persistent DD-drag) |
+| ≥ +1.00 | Decisively beats SPY with uniform margin (high α-mean + saturated margin_bonus) |
+| +0.50 to +1.00 | Solid pass — strong α-mean OR moderate α-mean + healthy margin_bonus |
+| +0.20 to +0.50 | Marginal acceptable — α-mean near the floor, margin_bonus small |
+| 0.00 to +0.20 | Floor-clinger — barely above gate on every term; expect ranking by β/γ/δ tiebreakers |
+| < 0.00 | Very rare; would require strongly negative β/γ/δ outweighing α + margin_bonus |
 
-For unacceptable configs, the soft score is reported in the iter log but not used for selection.
+For unacceptable configs, the objective is `SENTINEL_REJECT` (used by GP + EI + best-pointer). The underlying soft_score is reported in the iter log for post-hoc diagnostics (esp. the closest-rejected analysis in NO_ACCEPTABLE_CONFIG), but is not used for selection.
 
 #### Post-hoc verification (Meta-CV per approach #4)
 
 After the BO completes:
 
-1. **Hard-gate sensitivity**: vary N_cagr in {0.005, 0.01, 0.02} and N_dd_rel in {0.05, 0.10, 0.15} and check whether the iter-best identity changes. If the iter-best flips when N_cagr moves from 0.01 to 0.02, the result is sensitive to a 1pp threshold — that's a fragility signal, log it. If it flips from 0.01 to 0.005, the iter-best is borderline-marginal and should be treated as such.
-2. **Soft-score sensitivity** (existing PR #1339 plan): perturb α/β/γ/δ/ε by ±50% and check iter-best stability *within the acceptable set*. This now runs only against the acceptable population, not the full BO trajectory.
+1. **Hard-gate sensitivity**: vary N_cagr in {0.005, 0.01, 0.02}, N_dd_rel in {0.05, 0.10, 0.15}, and N_dd_abs in {0.20, 0.25, 0.30}, and check whether the iter-best identity changes. If the iter-best flips when N_cagr moves from 0.01 to 0.02, the result is sensitive to a 1pp threshold — fragility signal, log it. If it flips from 0.01 to 0.005, the iter-best is borderline-marginal — treat as such. N_dd_abs sensitivity is the new Round-3 dimension: a flip at 0.25 → 0.30 means the iter-best is close to the G3 ceiling, which is acceptable but bears noting; a flip 0.25 → 0.20 means the iter-best is on the cusp of "too risky."
+2. **Soft-score sensitivity** (existing PR #1339 plan): perturb α/β/γ/δ/ε/μ by ±50% and check iter-best stability *within the acceptable set*. μ is new (Round-3); a ±50% perturbation tests whether the margin_bonus is load-bearing vs. comfort-padding for the iter-best ranking.
+3. **Margin-bonus sensitivity** (Round-3 net-new): set μ to 0 (disable margin_bonus entirely) and re-rank acceptable configs. If the iter-best changes, the margin_bonus is doing real work — that's a positive signal for the Round-3 design (it's preventing min-window-skater outcomes). If the iter-best is unchanged, the margin_bonus didn't bind (the BO converged to a uniform-winner naturally), also fine.
 
-The expected outcome is that the iter-best identity is much *more* stable than under PR #1339's soft-only formula because the gate has pre-filtered the population — the within-acceptable-set surface is denser and more locally convex.
+The expected outcome is that the iter-best identity is much *more* stable than under PR #1339's soft-only formula because the gate has pre-filtered the population — the within-acceptable-set surface is denser and more locally convex — and the margin_bonus has pulled the BO away from the gate boundary into the interior.
 
 #### Response to PR #1341 critique findings
 
@@ -284,6 +535,24 @@ The expected outcome is that the iter-best identity is much *more* stable than u
 | F5 | "Typical winner extreme" coefficients (α anchored at +5pp) are aspirational; v7 evidence ~+1-2pp | MAJOR | **Materially weakened by the gate-first structure.** Coefficients only matter for ranking within the acceptable set; the gate makes the acceptance decision. F5's specific concern — "γ=100 dominates the gradient at realistic ±1-2pp operating point" — is now constrained: the acceptable set has CAGR alpha ≥ +1pp in every train window, so the α-term contributes at least +0.20 per window (+0.60 mean) before any other term fires. Within that set, γ's role is comparative (does config A take more DD than config B at the same CAGR-alpha tier), not deciding (does this config qualify at all). Coefficients still tuned to PR #1339's magnitudes; recalibration to v7-observed magnitudes is reserved as a follow-up if within-set ranking proves unstable. |
 
 Findings F6-F11 from the critique (worked-example arithmetic verifications, ε term magnitude observations, δ verbiage clarification, Bessel-vs-population pin, defensive-bias observation) are unchanged — they apply to the soft score, which is unchanged in formula. F9 (δ verbiage: "5pp loss" → actually "7pp absolute loss") is corrected in the per-coefficient derivation above.
+
+#### Response to PR #1343 (Round-2) critique findings
+
+The Round-2 hard-gate redesign was critiqued in `dev/reviews/v8-hard-gate-critique.md` (PR #1343). Round-3 addresses each finding:
+
+| # | Critique finding | Severity | Round-3 Resolution |
+|---|---|---|---|
+| R2-F1 | Knife-edge gaming at N_cagr = 1pp: `{1.01, 1.01, 1.01}` passes, `{4.0, 0.99, 4.0}` fails. BO trajectory: GP learns gate boundary, suggests configs that barely clear the floor on the worst window. New overfit mode ("min-window-skater"). | MAJOR | **RESOLVED via margin_bonus term in soft score (Round-3 addition).** `margin_bonus = μ · min(worst_margin, margin_sat)` with μ = 30, margin_sat = 2pp. Worked Example J above compares J-skater (+0.74 total) vs J-uniform (+1.20 total) — the margin_bonus inverts the ranking against the min-window-skater. The hard gate at 1pp is preserved; the BO no longer prefers the knife-edge. Trade-off: μ·margin_sat = 0.60 is large enough to bind but capped (margin_sat saturates) so the bonus can't be over-pushed. |
+| R2-F2 | Acceptable-set size at convergence likely too small (16/80 in 11-dim; potentially 0-3 if strategy delivers ≤ 1pp alpha). | MAJOR | **MITIGATED via (i) knob count reduced to 9 (already in Decision 4) AND (ii) mandatory pre-flight Sobol-100 smoke sweep on v7's WF spec.** See § "Acceptable-set sparsity mitigation" above. Smoke sweep gates the v8 launch decision (green ≥25% pass-rate, yellow 5-25% requires gate-relaxation discussion before launch, red <5% defers v8 entirely). Mitigation does NOT eliminate the limitation — if the underlying strategy genuinely can't meet the gate at +1pp on top-3000, the v8 spend is correctly deferred rather than wasted; the answer is broader-universe or strategy-redesign, not BO-knob tweaking. |
+| R2-F3 | Holdout asymmetry: train CAGR = +1pp but holdout fallback CAGR Δ ≥ 0 (looser); train G3 = 50% but holdout MaxDD ≤ 25% (tighter). Inverted-asymmetry. | MAJOR | **RESOLVED: drop both holdout fallbacks; W4 uses the same G1/G2/G3 thresholds as train.** See § "Holdout treatment (W4) — Round-3 symmetric". Combined with the R2-F5 resolution (G3 = 25%), the holdout asymmetry is fully removed: the verdict criteria match the BO acceptance criteria, applied out-of-sample. A config passes train if and only if it satisfies the same predicate the verdict applies on W4. |
+| R2-F4 | **BLOCKING: GP/EI undefined under disjoint acceptance.** Surrogate fits all-points soft_score, EI ranks against acceptable-only best-so-far. EI peaks in unacceptable region (where the soft-score peaks live); BO burns budget on rejected configs. | **BLOCKING** | **RESOLVED via single-objective formulation: `objective(x) := if acceptable then soft_score else SENTINEL_REJECT` (= -1.0e6).** See § "BO acceptance logic — corrected" for full pseudocode and the surrogate/EI/best-pointer consistency proof. The GP fits one function; EI computes against one f*; best-pointer ranks one function. Finite sentinel (not -∞) for GP numerical stability. SENTINEL_REJECT sits ~10⁶ below any reachable acceptable soft-score so EI in unacceptable regions ≈ 0. Alternative considered (cBO with second GP on acceptance indicator) noted as future upgrade if sentinel approach proves slow on boundary. |
+| R2-F5 | G3 = 50% absolute DD unacceptably permissive: a 45% DD requires +82% recovery; "better than passive" buys "non-cratering," not "structurally acceptable." Compounds with R2-F3: holdout fallback says 25%, so G3 should be ≤ 25%. | MAJOR | **RESOLVED: G3 tightened to 25% (Round-3).** See § "Why G3 = 25%, not 50% (Round-3 change)". Symmetric application across train AND holdout removes the inverted-asymmetry from R2-F3. Worked Example I' added to demonstrate the new G3 = 25% catch case (a config at 30% DD on a 25%-SPY window passes Round-2 but fails Round-3). Trade-off accepted: v8 will be biased toward strategies that avoid GFC-shaped drawdowns rather than ride through them — a deliberate design bias matching the user's stated risk tolerance. |
+| R2-F6 | NO_ACCEPTABLE_CONFIG warning non-actionable: operator sees "BO failed" without knowing whether gate is too tight, strategy is weak, spec is buggy, or universe is wrong. | MAJOR | **RESOLVED: four-section diagnostic added to the NO_ACCEPTABLE_CONFIG report.** Section 1 = per-gate failure histogram by window. Section 2 = closest-rejected config (smallest aggregate gate-violation distance) with full per-window margins and the specific binding constraint. Section 3 = SPY benchmark per window for context. Section 4 = rule-based suggested action. See § "Sobol initial-random phase handling + NO_ACCEPTABLE_CONFIG diagnostic" and worked Example K. All data already on hand in the checkpoint; the change is purely report-emission. |
+| R2-F7 | Example D depends on assumed CAGR vector (v7-iter42 per-fold Sharpe deltas are recorded but per-fold CAGR alphas aren't). | OBSERVATION | **Acknowledged.** Example D's "v7-iter42 structurally rejected" claim is conditional on the assumed CAGR pattern matching the recorded Sharpe sign pattern. Plausible but unverified. A pre-launch validation task is added to verify Example D's CAGR vector against the v7 WF checkpoint before publishing the v8 retrospective — but this does not block the v8 design itself (any of the broad pattern shapes — `{neg, neg, pos, pos}` style — would fail G1 on the negative windows). |
+| R2-F8 | F2 response incomplete on Sharpe-α-only blowouts: `{1.5, 1.5, 1.5, 1.5}` CAGR α (G1 ✓) + `{0, 0, 0, +2.0}` Sharpe α slips through. | MINOR | **Acknowledged as known within-set limitation.** Under Round-3, this config DOES pass the gate (G1 +1.5pp ≥ 1pp on every train window). The β-term + ε-term provide the only signal: β · (0+0+0)/3 = 0 from train; ε · var(0,0,0,2) = ε · 1.0 = 1.0 penalty *if* the variance is computed across all 4 windows including W4. (It is — soft score is `mean_w` where `w` ranges over all 4 windows.) So the W4 Sharpe blowout is penalized via ε. Not a clean rejection — but materially worse than the Round-2 weak signal. The critique's suggested count-based fragility detector remains a future-iteration replacement for ε if within-set ranking proves unstable. |
+| R2-F9 | Arithmetic verification (all examples reproduce). | INFO | **Acknowledged with thanks; Round-3 worked examples re-verify under N_dd_abs = 0.25 (Example I still rejects on G3 by a wider margin; new Example I' covers the tightening case). New Examples J and K added for the Round-3 net-new failure modes (margin-bonus + NO_ACCEPTABLE_CONFIG diagnostic).** |
+
+The BLOCKING finding (R2-F4) and 5 MAJORs (R2-F1, R2-F2, R2-F3, R2-F5, R2-F6) are addressed. R2-F7 is acknowledged as a pre-launch validation task that doesn't block the design. R2-F8 is acknowledged as a known limitation with a documented mitigation path.
 
 ### Decision 3: Baseline → **BAH SPY (and BAH BRK-A for reference)**
 
@@ -330,53 +599,66 @@ Add new module `trading/trading/backtest/multi_window/`:
 - Reuses existing `Walk_forward_runner` infrastructure (just non-overlapping windows without the train/test split semantics)
 - Unit tests pinning the per-window metrics output
 
-### PR-2: Absolute-alpha scoring function + hard-gate predicate
+### PR-2: Absolute-alpha scoring function + hard-gate predicate + margin bonus + single-objective
 In `trading/trading/backtest/tuner/bin/bayesian_runner_scoring.ml`:
 - Add `score_absolute_alpha` variant of the existing `score_cell_with_penalty`
 - Inputs: per-window candidate metrics + per-window SPY benchmark metrics
-- Output: scalar score per the formula in Decision 2
-- Add `check_hard_gate` returning `{ acceptable : bool; gate_failures : string list }` per Decision 2 §"BO acceptance logic"
-- Constants: `N_cagr = 0.01`, `N_dd_rel = 0.10`, `N_dd_abs = 0.50` exposed via spec config
-- Unit tests pinning each of the 5 soft-score terms independently + composite
+- Output: scalar `soft_score` per the formula in Decision 2 (includes margin_bonus per Round-3)
+- Add `check_hard_gate` returning `{ acceptable : bool; gate_failures : string list; per_window_margins; per_window_dd_excess; per_window_dd_abs }` per Decision 2 §"BO acceptance logic — corrected"
+- Add `compute_objective` that returns `if acceptable then soft_score else SENTINEL_REJECT` (Round-3) — this is the function the BO consumes
+- Constants: `N_cagr = 0.01`, `N_dd_rel = 0.10`, `N_dd_abs = 0.25` (Round-3 G3 tightening), `SENTINEL_REJECT = -1.0e6`, `μ = 30.0`, `margin_sat = 0.02` exposed via spec config
+- Unit tests pinning each of the 6 soft-score terms (α, β, γ, δ, ε, μ) independently + composite
 - Unit tests pinning the SPY-itself = 0 anchor on the soft score
-- Unit tests pinning hard-gate behavior on the 9 worked examples (A-I) in Decision 2
+- Unit tests pinning hard-gate behavior on the 11 worked examples (A–I, I', J, K) in Decision 2
+- Unit tests pinning the objective collapse: acceptable → soft_score; unacceptable → SENTINEL_REJECT exactly
+- Unit tests pinning Example J's ranking inversion (J-uniform > J-skater under Round-3, J-skater > J-uniform under Round-2 with μ=0)
 - Pin: variance is population (÷ N), not Bessel (per critique finding F10)
 
-### PR-3: bayesian_runner integration (gate-aware BO loop)
+### PR-3: bayesian_runner integration (single-objective BO loop)
 - Add CLI flags `--multi-window-spec <path>` and `--objective absolute_alpha`
-- When set, runner uses `Multi_window_runner` + `score_absolute_alpha` + `check_hard_gate` instead of WF + paired-Δ
-- Modify the BO "best-so-far" comparison per Decision 2 §"BO acceptance logic": iter-best updates only when `acceptable == true`; unacceptable evaluations still inform the GP surrogate
-- Add `NO_ACCEPTABLE_CONFIG` termination state and surface as a warning in the runner's final report
-- Serialize `acceptable` + `gate_failures` per iter into `bo_checkpoint.sexp` for post-hoc analysis
+- When set, runner uses `Multi_window_runner` + `score_absolute_alpha` + `check_hard_gate` + `compute_objective` instead of WF + paired-Δ
+- **Single-objective BO loop (Round-3 fix for R2-F4)**: GP fits `(x, objective(x))` for every evaluation; EI computed against `f* = argmax objective` (which equals `SENTINEL_REJECT` until the first acceptable point lands, then equals the best acceptable soft_score). `best_so_far` is `argmax objective` end-to-end — no separate filtered ranking. See Decision 2 §"BO acceptance logic — corrected" for the consistency proof.
+- Add `NO_ACCEPTABLE_CONFIG` termination state and surface as a warning + the four-section diagnostic (per-gate failure histogram, closest-rejected config, SPY benchmark by window, suggested operator action) per Decision 2 §"Sobol initial-random phase handling"
+- Serialize `acceptable`, `gate_failures`, `per_window_margins`, `per_window_dd_excess`, `per_window_dd_abs`, `soft_score`, and `objective` per iter into `bo_checkpoint.sexp` for post-hoc analysis and the diagnostic
 - Spec file format extends to declare windows + SPY-benchmark source + (optional) gate-threshold overrides
-- Backward compatible: existing v7-style specs still work
+- Backward compatible: existing v7-style specs still work (when `--objective absolute_alpha` flag is absent)
+
+### PR-3.5: Pre-flight Sobol-100 smoke sweep (Round-3 launch precondition)
+- Use the existing `bayesian_runner` binary with `--max-iter 0 --num-sobol 100` to skip the BO loop and perform only Sobol-phase evaluations.
+- Run against v7's existing WF spec at the Round-3 thresholds (N_cagr = 0.01, N_dd_rel = 0.10, N_dd_abs = 0.25, μ = 30, margin_sat = 0.02).
+- Output: empirical acceptable-set fraction (count of `acceptable == true` / 100), per-gate failure histogram.
+- Decision rule: green ≥25% pass-rate → v8 launch; yellow 5-25% → discuss gate relaxation; red <5% → defer v8.
+- ~3-4h wall-time at parallel=6. Output goes to `dev/notes/v8-smoke-sweep-results-<date>.md`.
+- The PR is the smoke-sweep results note + a `v8_launch_decision.md` that the user signs off on before PR-4 fixtures are committed.
 
 ### PR-4: v8 spec + SPY benchmark fixtures
 - Create `dev/experiments/bayesian-production-sweep-2026-05-28/spec_prod_v8_9knob.sexp`
 - Create per-window SPY aggregates (`baseline_spy_w1.sexp`, ..., `baseline_spy_w4.sexp`) — pre-compute once, check in.
 - Walk-forward spec equivalent for `--multi-window-spec`: declares 3 train + 1 holdout window.
 - Launch script `launch_v8.sh`.
+- **Precondition: PR-3.5 smoke-sweep returned green or yellow-after-policy-decision.** Red defers PR-4 indefinitely.
 
 ### PR-5: Post-sweep analysis extensions
-- Extend `holdout_eval` to support multi-window mode (already mostly compatible — just needs to call multi_window_runner for the holdout window)
-- Fix `sensitivity_sweep` baseline-label bug (independent task #36; already dispatched)
+- Extend `holdout_eval` to support multi-window mode (already mostly compatible — just needs to call multi_window_runner for the holdout window) and to apply the symmetric G1/G2/G3 verdict per Round-3 §"Holdout treatment"
+- Fix `sensitivity_sweep` baseline-label bug (independent task #36; landed as #1340)
+- Add margin-bonus sensitivity sweep (μ ∈ {0, 15, 30, 45, 60}) and N_dd_abs sensitivity (∈ {0.20, 0.25, 0.30}) per Decision 2 §"Post-hoc verification"
 - Optional: `promote_config.sh` panel expansion (broader scenarios — but defer to v8 results before deciding)
 
 ## Expected outcomes + verdict criteria
 
-**Wall-time projection:** v7 was 3d at parallel=4 with pre-perf binary. v8 with post-perf binary (parallel 6 + Flambda + active_through pruning) on 3 train windows × ~3min each per iter × 80 iters / parallel = **~6-12h**. Fast.
+**Wall-time projection:** v7 was 3d at parallel=4 with pre-perf binary. v8 with post-perf binary (parallel 6 + Flambda + active_through pruning) on 3 train windows × ~3min each per iter × 80 iters / parallel = **~6-12h** for the BO sweep itself. Add ~3-4h for the PR-3.5 pre-flight smoke sweep (run once, before v8 launches).
 
-**Verdict criteria when v8 completes:**
+**Verdict criteria when v8 completes (Round-3 symmetric):**
 
-(Cross-reference Decision 2 §"Holdout treatment" for the full table — the criteria below are the operational summary.)
+(Cross-reference Decision 2 §"Holdout treatment (W4) — Round-3 symmetric" for the rationale — the criteria below are the operational summary.)
 
 | Criterion | What it tells us |
 |---|---|
-| iter-best `acceptable` on TRAIN (W1/W2/W3) — passes G1/G2/G3 | Hard gate held during BO selection (will be true if the BO returned anything other than `NO_ACCEPTABLE_CONFIG`) |
-| iter-best `acceptable` on HOLDOUT (W4) — passes G1/G2/G3 with same thresholds | Generalizes out-of-sample under the strict gate |
-| Holdout (W4) CAGR Δ ≥ 0 vs SPY | Looser fallback if W4 gate is tight; marginal-pass signal |
-| Holdout MaxDD ≤ 25% | Tighter than G3=50% — verdict cares more about absolute risk than BO acceptance does |
-| promote_config gate passes for sp500-2010-2026 (the v7 fail) | Aligned with promote — but see F4 below: a promote-fail config is not necessarily a v8 design failure if the failure is baseline-mismatch (cell-E vs SPY) |
+| iter-best `acceptable` on TRAIN (W1/W2/W3) — passes G1/G2/G3 (N_cagr=1pp, N_dd_rel=10pp, N_dd_abs=25%) | Hard gate held during BO selection (true unless `NO_ACCEPTABLE_CONFIG`) |
+| iter-best `acceptable` on HOLDOUT (W4) — passes G1/G2/G3 with **identical thresholds** | Generalizes out-of-sample under the same predicate |
+| promote_config gate passes for sp500-2010-2026 (the v7 fail) | Aligned with promote — but see R2-F4 below: a promote-fail config is not necessarily a v8 design failure if the failure is baseline-mismatch (cell-E vs SPY) |
+
+Round-2's "looser CAGR fallback" and "tighter MaxDD fallback" rows are removed (per critique R2-F3 + Round-3 § "Holdout treatment — Round-3 symmetric"). The verdict is binary on each line.
 
 If criteria fail: signal that even multi-window + SPY-aligned scoring isn't enough — pivot to broader-universe sweep (per the existing strategic backlog memory `project_strategic_pivot_broader_first.md`).
 
@@ -384,11 +666,16 @@ If criteria fail: signal that even multi-window + SPY-aligned scoring isn't enou
 
 | Risk | Mitigation |
 |---|---|
-| 3 training samples is too few — BO converges to noise | Holdout (W4 alone) is a strong tiebreaker; verdict criteria require holdout pass |
-| Score formula coefficients (α-ε) are themselves overfit | Post-hoc sensitivity-sweep at ±50% per coefficient (Decision 2 §"Post-hoc verification"); pin via cross-validation if iter-best identity flips |
-| BAH SPY benchmark per window is annoyingly path-dependent on start/end dates | Pin window dates exactly; document SPY values per window in spec |
-| Multi-window code is new + only used here | PR-1 has unit tests; PR-3 integration is small once PR-1 lands |
-| v7-iter42 was a "bull-window winner" — v8 might similarly be a "multi-window-but-still-overfit winner" | The hard gate (G1: CAGR alpha ≥ +1pp in every train window; G2: relative DD ≤ +10pp; G3: absolute DD ≤ 50%) structurally rejects single-window blockbusters before the soft score is consulted. Example D (v7-iter42) and Example E (single-window blockbuster) in Decision 2 both fail G1 on multiple windows. Within the acceptable set, the soft score (ε for Sharpe-α variance, γ for excess-DD shape) provides additional ranking discipline. |
+| 3 training samples is too few — BO converges to noise | Holdout (W4) under SAME thresholds as train is a strong out-of-sample tiebreaker; verdict criteria require holdout pass under Round-3 symmetric. |
+| Score formula coefficients (α–ε, μ) are themselves overfit | Post-hoc sensitivity-sweep at ±50% per coefficient + μ-disable rerun (Decision 2 §"Post-hoc verification"). If iter-best flips, pin via cross-validation. |
+| BAH SPY benchmark per window is path-dependent on start/end dates | Pin window dates exactly; document SPY values per window in spec. |
+| Multi-window code is new + only used here | PR-1 has unit tests; PR-3 integration is small once PR-1 lands. |
+| v7-iter42 was a "bull-window winner" — v8 might similarly be a "multi-window-but-still-overfit winner" | The hard gate (G1: CAGR alpha ≥ +1pp in every train window; G2: relative DD ≤ +10pp; G3: absolute DD ≤ 25% — Round-3 tightened) structurally rejects single-window blockbusters before the soft score is consulted. Within the acceptable set, the soft score (ε for Sharpe-α variance, γ for excess-DD shape, μ for worst-window margin) provides additional ranking discipline. |
+| Acceptable set is too sparse for GP interpolation (critique R2-F2) — at the Round-3 thresholds the gate may admit <16/80 points in 9-dim space | (i) Knob count reduced to 9 (already in Decision 4). (ii) Mandatory PR-3.5 pre-flight Sobol-100 smoke sweep gates the v8 launch decision (green ≥25% / yellow 5-25% / red <5%). Red defers v8 entirely rather than wasting BO budget on an unsatisfiable gate. |
+| BO mechanic incoherence under split surrogate / best-pointer (critique R2-F4 BLOCKING) | Resolved via single-objective formulation (Round-3 §"BO acceptance logic — corrected"): `objective = if acceptable then soft_score else SENTINEL_REJECT`. GP + EI + best-pointer all see one function. Consistency proof in Decision 2. Cost: GP slightly noisier near the gate boundary; mitigated by the gate-boundary being where the optimal margin_bonus trade-off lives anyway. |
+| Knife-edge gaming at the gate boundary (critique R2-F1) — BO parks at min-window-margin ≈ N_cagr | Resolved via margin_bonus term (μ = 30, margin_sat = 2pp): the BO is rewarded for worst-window margin up to 2pp; the min-window-skater optimum is dominated by uniform-margin winners (Example J above). Cap on margin_sat prevents over-pushing. |
+| G3 = 25% is too tight for a GFC-shaped window — bias toward GFC-avoiding configs | Acknowledged design bias. The redesign is explicit: a strategy that rode the GFC down 30%+ is not acceptable to the user. The acceptable region biases toward strategies with active de-risking (sector caps, stop cascades, faster de-leverage). If the smoke sweep shows this bias eliminates the acceptable set, the gate was wrong and v8 launch is deferred. |
+| Sentinel approach (single-objective with discontinuity) is slower to convergence than full cBO | Acknowledged trade-off (Decision 2 §"BO acceptance logic — corrected" §"Alternative considered"). If Round-3 v8 results show the sentinel approach burns too many iterations on the gate boundary, the upgrade path is cBO/PESC with a second GP on the binary acceptance indicator. Not adopted for Round-3 to keep the BO infrastructure change minimal. |
 
 ## What v8 explicitly does NOT do
 


### PR DESCRIPTION
## Summary

Round-3 redesign of the v8 BO acceptance criterion. Addresses every finding from PR #1343's critique of the Round-2 hard-gate design (PR #1342):

- **BLOCKING R2-F4 (GP/EI undefined under disjoint acceptance)** → single-objective formulation: `objective(x) := if acceptable then soft_score else SENTINEL_REJECT` (= −1.0e6). GP, EI, and best-pointer all see the same function. Consistency proof in Decision 2 § "BO acceptance logic — corrected". Finite sentinel (not −∞) for GP numerical stability.
- **MAJOR R2-F1 (knife-edge gaming at N_cagr = 1pp)** → soft margin-bonus term `+μ · min(worst_margin, margin_sat)` (μ=30, margin_sat=2pp). Worked Example J shows the min-window-skater pattern (J-skater: 0.74) loses to the uniform-winner (J-uniform: 1.20) under Round-3 — the inversion the term was designed to produce.
- **MAJOR R2-F2 (acceptable-set sparsity ≈ 16/80 in 11-dim)** → (i) knob count reduced to 9 (already in Decision 4), (ii) mandatory pre-flight Sobol-100 smoke sweep on v7's WF spec (new PR-3.5) that gates the v8 launch decision: green ≥25% pass-rate, yellow 5–25% requires gate-relaxation discussion, red <5% defers v8 entirely. Saves 12h+ of v8 BO wall-time on a structurally unsatisfiable gate.
- **MAJOR R2-F3 (holdout asymmetry)** → drop both Round-2 holdout fallbacks (CAGR Δ ≥ 0 and MaxDD ≤ 25%). W4 uses the SAME G1/G2/G3 thresholds as train. The verdict is binary on each line.
- **MAJOR R2-F5 (G3 = 50% too permissive)** → tighten G3 to 25% absolute, symmetric across train AND holdout. Worked Example I' added to demonstrate the new catch case (30% DD on a 25%-SPY window now fails). Documented design bias: v8 prefers strategies that avoid GFC-shaped drawdowns vs ride them through.
- **MAJOR R2-F6 (NO_ACCEPTABLE_CONFIG non-actionable)** → four-section diagnostic added: (i) per-gate failure histogram by window, (ii) closest-rejected config + per-gate violation distance, (iii) SPY benchmark per window, (iv) rule-based suggested operator action. Worked Example K shows the diagnostic in action.

Decisions 1, 3, 4, 5 unchanged. All changes are local to Decision 2 + implementation sequencing (PR-2/PR-3 specs updated, new PR-3.5 for the smoke sweep).

## What it does

- Replaces the Round-2 split-surrogate / filtered-best-pointer BO mechanic with single-objective BO on a discontinuous function. GP fits the cliff edge from data; EI in unacceptable regions ≈ 0 because the sentinel is ~10⁶ below any reachable acceptable score.
- Adds margin_bonus term that saturates at 2pp worst-window margin, preventing both (a) BO from parking at the gate boundary (Round-2 failure mode) and (b) BO from pushing margin arbitrarily large at the expense of other terms (the symmetric over-game).
- Tightens G3 from 50% to 25% absolute DD, symmetric across train and holdout. Removes the inverted asymmetry from Round-2 (train looser CAGR + tighter holdout MaxDD).
- Adds the pre-flight Sobol-100 smoke sweep as a launch precondition. If the gate is structurally unsatisfiable on v7's spec, v8 is not launched.
- Replaces non-actionable "BO failed" warning with a four-section diagnostic derived from data already on hand in the checkpoint.

## Test plan

- [ ] Doc-only PR: CI must pass (`build-and-test` linters incl. `status_file_integrity_linter`, `linter_magic_numbers.sh` — the doc contains specific numeric thresholds explained in prose).
- [ ] All 11 worked examples (A–I, I', J, K) arithmetically verify; per-coefficient derivations sum to the documented totals.
- [ ] No QC review required (docs-only per `.claude/rules/pr-merge-gates.md`).
- [ ] Critique findings table (Round-3 §"Response to PR #1343 critique findings") maps each of the 6 findings to a specific resolution location in the doc.

## Notes for reviewers

This PR stacks on top of `docs/v8-hard-gate-redesign` (PR #1342). The base diff against main shows both commits; the round-3 changes are the second commit. The PR base is set to `docs/v8-hard-gate-redesign` for clarity, but if PR #1342 lands first, this PR will rebase to target main automatically.

The pre-flight smoke sweep (PR-3.5) is gating: if v7's spec at the Round-3 thresholds returns <5% acceptable, the v8 launch is deferred and the user's options surface (broader-universe, strategy redesign) per `memory/project_strategic_pivot_broader_first.md`. This is a deliberate decision to *learn earlier* that the strategy/universe combination is wrong, rather than spend 12h+ on a v8 sweep that can't converge.