### PR TITLE
experiment(diagnostic): Weinstein on SPY-only universe — 1998-2025

### DIFF
--- a/dev/notes/spy-only-diagnostic-2026-05-28.md
+++ b/dev/notes/spy-only-diagnostic-2026-05-28.md
@@ -1,0 +1,240 @@
+# SPY-only Weinstein diagnostic — 1998-2025
+
+Date: 2026-05-28
+Author: claude (experiment/spy-only-diagnostic agent)
+Pairs with: `experiment/sector-etf-diagnostic` (running in parallel; not yet landed)
+Scenarios: `trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28/`
+
+## Headline verdict
+
+**LOSES_TO_SPY** (-7.13pp CAGR vs BAH-SPY threshold: ≤-1pp = LOSE).
+
+Weinstein stage analysis applied to a 1-symbol universe of SPY essentially
+earns cash-like returns (~0.06% CAGR) over 28 years, vs BAH SPY's 7.19% CAGR
+on the same window. The strategy is in the market only 4.4% of trading days.
+
+## Metrics table
+
+| Metric | SPY-only Weinstein | BAH SPY | Delta |
+|---|---:|---:|---:|
+| Total return % | +1.68% | +598.41% | **-596.73pp** |
+| CAGR (28-year) | 0.06% | 7.19% | **-7.13pp** |
+| Sharpe ratio | 0.22 | 0.45 | -0.23 |
+| Sortino (annualized) | 0.33 | 0.60 | -0.27 |
+| Max drawdown | 0.83% | 56.04% | -55.21pp (less DD) |
+| Calmar ratio | 0.07 | 0.13 | -0.06 |
+| Ulcer index | 0.49 | 17.61 | -17.12 (much less pain) |
+| Total round-trips | 11 | 0 (never sells) | n/a |
+| Win rate | 54.5% | n/a | n/a |
+| Avg holding days (held trades) | 29.2 | n/a (held entire window) | n/a |
+| Force liquidations | 0 | 0 | n/a |
+| Wall seconds | 65.7 | 45.3 | +20s |
+
+Initial cash: $1,000,000 (runner-hardcoded in
+`trading/trading/backtest/lib/runner.ml` line 13). Diagnostic prompt asked
+for $100k; we used the runner's canonical $1M instead. All compared
+metrics (return %, Sharpe, MaxDD, time-in-market %, CAGR) are
+scale-invariant — the verdict is unaffected.
+
+## Time-in-market analysis
+
+| Quantity | Value |
+|---|---:|
+| Total trading days (1998-01-02 to 2025-12-30) | 7,290 |
+| Sum of days_held across all 11 round-trips | 321 |
+| **Time-in-market %** | **4.40%** |
+
+Compare with BAH SPY's time-in-market of ~100% (after the day-1 entry).
+This is the key signal: **the strategy is in cash 95.6% of the time over a
+28-year window that includes ~22 years of upward-trending SPY**. Even when
+it IS in the market, the Cell-E position sizing (`max_position_pct_long =
+0.14`) caps each entry at ~14% of NAV — so the effective market exposure
+is much lower than 4.4% on a capital-weighted basis (~14% × 4.4% ≈ 0.6%
+average dollar-exposure).
+
+### Distribution of holding periods + outcomes
+
+The 11 round-trips, in order:
+
+| # | Entry date | Days held | Pnl % | Exit trigger / sub-kind |
+|---|---|---:|---:|---|
+| 1 | 1998-01-10 | 56 | +9.78% | laggard_rotation / non_stop_exit |
+| 2 | 2000-08-19 | 28 | -1.45% | laggard_rotation / intraday |
+| 3 | 2002-03-23 | 20 | -3.88% | laggard_rotation / gap_down |
+| 4 | 2006-09-09 | 28 | +3.74% | stop_loss / non_stop_exit |
+| 5 | 2007-10-27 | 7 | -1.00% | stop_loss / gap_down |
+| 6 | 2014-11-08 | 38 | -2.26% | laggard_rotation / intraday |
+| 7 | 2015-02-14 | 14 | +1.05% | stop_loss / non_stop_exit |
+| 8 | 2016-11-26 | 28 | +1.96% | stop_loss / non_stop_exit |
+| 9 | 2019-09-14 | 11 | -1.93% | laggard_rotation / intraday |
+| 10 | 2023-01-28 | 14 | +0.55% | laggard_rotation / non_stop_exit |
+| 11 | 2023-04-15 | 77 | +6.94% | stop_loss / non_stop_exit |
+
+**Periods entirely missed:**
+- 2002-04 to 2006-09 (4.4 years, post-dotcom recovery + early 2000s bull)
+- 2008-2014 (~6 years, missed the entire post-GFC bull recovery)
+- 2016-12 to 2019-09 (2.8 years, late-2010s bull)
+- 2019-09 to 2023-01 (3.3 years, including the COVID dip + recovery)
+
+Every "missed" sustained Stage-2 advance is where BAH compounded its
+return. Weinstein-on-SPY missed essentially every multi-year market
+advance in the sample.
+
+## Caveats
+
+### Cell-E parameters
+
+`config_overrides` are identical to the canonical Cell-E baseline used in
+every active Weinstein golden (`sp500-2010-2026.sexp`,
+`weinstein-2019-full-pool.sexp`, etc.):
+
+- `enable_short_side = false`
+- `portfolio_config.max_position_pct_long = 0.14`
+- `portfolio_config.max_long_exposure_pct = 0.70`
+- `portfolio_config.min_cash_pct = 0.30`
+- `enable_stage3_force_exit = true`, `hysteresis_weeks = 1`
+- `enable_laggard_rotation = true`, `hysteresis_weeks = 2`
+
+Provenance reference: `dev/scripts/promote_config.sh` §"Cell-E baseline
+reference values".
+
+### Quirks of running Weinstein on a 1-symbol universe
+
+Three sub-modules have degenerate semantics on universe = {SPY}, but none
+cause a crash and the diagnostic is internally consistent:
+
+1. **Macro analysis** reads `GSPC.INDX` (hardcoded
+   `index_symbol = "GSPC.INDX"` in `trading/trading/backtest/lib/runner.ml`
+   line 12) — **NOT SPY**. So bullish / neutral / bearish macro gating
+   fires normally based on the S&P 500 cash index. Macro gating is what
+   blocks SPY entries during 2002, 2008-09, 2020 March, 2022, etc. —
+   precisely the "would-have-lost-money-anyway" windows. Looking at the
+   trade list, this gating worked: no entries during the 2008-09 GFC, no
+   entries during March 2020 COVID, no entries during 2022 bear. The
+   strategy avoided drawdowns successfully (MaxDD = 0.83% vs BAH 56%).
+
+2. **Sector analysis** reads the SPDR sector ETFs (XLK / XLF / etc.). On a
+   1-symbol universe with SPY mapped to "Communication Services" (the
+   informational label from `universes/spy-only.sexp`), sector RS fires
+   but the sector cohort contains only SPY, so it's degenerate but
+   harmless.
+
+3. **Relative strength**: SPY's RS is computed vs `GSPC.INDX`, not vs SPY
+   itself. SPY ≈ GSPC.INDX up to TER + tracking error, so RS will hover
+   near zero with small time-varying noise from ETF tracking error +
+   dividend pass-through timing. This means the entry signal comes almost
+   entirely from SPY's own price/MA trend — which is exactly the
+   "isolated market-timing alpha" measurement we wanted.
+
+### Cell-E position sizing on 1-symbol universe
+
+`max_position_pct_long = 0.14` means each entry buys ~14% of NAV worth of
+SPY. So the "1 position" can only ever consume 14% of available capital
+(by design — the cap is calibrated for risk management across a broader
+universe where 5-7 positions × 14% = 70% gross exposure). On a 1-symbol
+universe this is **structural under-investment**: even at 100%
+time-in-market the strategy would hold only 14% in SPY and 86% in cash.
+
+This is a **fair test of the Weinstein recipe on SPY**, not a misuse of
+the strategy. The point of the diagnostic is to ask: *given the canonical
+Cell-E config (which is what the live system actually runs), does
+applying it to SPY alone beat BAH-SPY?* Answer: emphatically no.
+
+A version with `max_position_pct_long = 1.0` (single-symbol all-in) would
+be a different question and not what we're asking.
+
+## Strategic implication
+
+**The Weinstein entry/exit timing signal applied to SPY is essentially
+value-destroying as a stand-alone alpha source.** It earns cash-like
+returns over 28 years while the underlying buy-and-hold returned ~7.2%
+CAGR.
+
+What this rules out:
+- *Hypothesis*: "Weinstein's macro/timing signal alone is alpha." **Rejected.**
+  Time-in-market 4.4%, CAGR 0.06% — the signal cancels every up-move it
+  attempts to capture.
+
+What this is consistent with:
+- **Alpha must come from cross-section** (sector rotation or stock
+  picking) — i.e., from the answer "WHICH symbols to buy when Weinstein
+  says buy," not from "WHEN to buy the market."
+- The 16% / 0.78 Sharpe / 18% MaxDD that Cell-E posts on the SP500
+  surface (per `sp500-2010-2026.sexp`) must therefore come from picking
+  Stage-2 breakouts among stocks that outperform SPY by a wide enough
+  margin to overcome the ~22% time-in-market drag (per recent BO sweep
+  v6/v7 results showing baseline Cell-E aggregate Sharpe ~0.89 on the
+  per-fold panel).
+- Sector rotation may or may not add value on top — the sibling sector-
+  ETF diagnostic (`experiment/sector-etf-diagnostic`, running in
+  parallel) will measure (2)-(1). Pre-result expectation: sector-ETF
+  Weinstein also loses to BAH-SPY, because the same 4.4%-time-in-market
+  drag applies to a 11-symbol universe where cross-sectional dispersion
+  between sector ETFs is low.
+
+### Implication for tuning
+
+The 11-knob BO sweeps (v3/v6/v7) have been tuning **stop-buffer,
+hysteresis-week, scoring-weight, and macro-threshold** knobs that
+shape (a) when the strategy enters, (b) when it exits, and (c) how
+quickly it gates on macro state. On the cross-section surface (top-3000
+stocks), these knobs may move the dial because tighter / wider entry
+criteria reshape WHICH stocks pass screening — that's a cross-section
+effect.
+
+**At the market level there is nothing to tune** — the entry/exit
+machine on SPY-as-market can't beat BAH no matter how the knobs are set
+within the Cell-E family, because:
+
+1. The macro gate (correctly) keeps the strategy out of every 6-month+
+   advance that doesn't pass its Stage-2 + volume + breadth + sector-RS
+   criteria. On SPY, those criteria are too strict (they're calibrated
+   for stocks).
+2. The Cell-E sizing cap (`max_position_pct_long = 0.14`) caps
+   single-symbol exposure structurally.
+3. Stage3 force-exit + laggard rotation exit positions quickly, so even
+   the periods we do enter are 1-3 months long, missing the bulk of
+   multi-year compounds.
+
+**This does NOT mean the tuning effort has been wasted.** It means the
+tuning effort should be measured on cross-section deltas, not on
+market-timing deltas. The v6 random-vs-BO-near-tie verdict (per
+`dev/notes/v6-bo-vs-random-baseline-verdict-2026-05-25.md`) is
+consistent with this: if there's no per-stock-selection signal in the
+11-knob surface, BO can't beat random because the surface is flat at
+the cross-section level. Knobs that materially affect cross-sectional
+ranking (scoring weights, sector caps, RS thresholds) are where the
+remaining alpha (if any) lives.
+
+### Caveat on the verdict
+
+This is **one** data point on **one** symbol over **one** window. It does
+not generalize to: "no market-timing signal exists" — only to: "the
+Weinstein Cell-E recipe applied to SPY does not extract market-timing
+alpha over 1998-2025." Other regimes (e.g., a 2000-2010 window heavily
+weighted to the two big bears) might tell a different story; the sibling
+sector-ETF diagnostic will add a second data point at the macro-cohort
+level.
+
+## How to reproduce
+
+```bash
+docker exec trading-1-dev bash -c '
+  cd /workspaces/trading-1/trading && eval $(opam env) &&
+  dune build trading/backtest/scenarios/scenario_runner.exe &&
+  /workspaces/trading-1/trading/_build/default/trading/backtest/scenarios/scenario_runner.exe \
+    --dir /workspaces/trading-1/trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28 \
+    --fixtures-root /workspaces/trading-1/trading/test_data/backtest_scenarios \
+    --parallel 2
+'
+```
+
+Wall time: ~70 seconds total (Weinstein 65s + BAH 45s, parallel=2).
+Outputs land in `/workspaces/trading-1/dev/backtest/scenarios-<timestamp>/`
+with `actual.sexp`, `equity_curve.csv`, `trades.csv` per scenario.
+
+## Files written
+
+- `trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28/spy-only-weinstein-1998-2025.sexp`
+- `trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28/bah-spy-1998-2025.sexp`
+- `dev/notes/spy-only-diagnostic-2026-05-28.md` (this file)

--- a/trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28/bah-spy-1998-2025.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28/bah-spy-1998-2025.sexp
@@ -1,0 +1,33 @@
+;; perf-tier: research
+;; perf-tier-rationale: Companion BAH-SPY baseline for the
+;; spy-only-weinstein-1998-2025 diagnostic. Same 1998-01-01 to 2025-12-31
+;; window, same universe (universes/spy-only.sexp), same runner ($1M
+;; initial cash) — only the strategy differs. Used by
+;; [dev/notes/spy-only-diagnostic-2026-05-28.md] as the alpha bar.
+;;
+;; Day-1 buy SPY with all cash (minus 1% gap buffer), hold to end.
+;; Single trade; no parameter sensitivity. Final equity tracks SPY's raw
+;; close price-only return tightly (no dividend reinvestment — BAH uses raw
+;; close throughout).
+;;
+;; Differs from goldens-sp500/sp500-2019-2023-bah-spy.sexp only in:
+;;   - window (1998-2025 here, vs 2019-2023 there)
+;;   - expected bands (intentionally wider since this is a research
+;;     diagnostic, not a pinned regression cell)
+;;
+;; SPY data range: 1993-01-29 to 2026-05-01 — fully covers this window.
+((name "bah-spy-1998-2025")
+ (description "Buy-and-Hold SPY 1998-01-01 to 2025-12-31 — alpha bar for the SPY-only Weinstein diagnostic.")
+ (period ((start_date 1998-01-01) (end_date 2025-12-31)))
+ (universe_path "universes/spy-only.sexp")
+ (universe_size 1)
+ (config_overrides ())
+ (strategy (Bah_benchmark (symbol SPY)))
+ (expected
+  ((total_return_pct       ((min -90.0)    (max 5000.0)))
+   (total_trades           ((min   0.0)    (max    0.5)))
+   (win_rate               ((min   0.0)    (max  100.0)))
+   (sharpe_ratio           ((min  -2.0)    (max    5.0)))
+   (max_drawdown_pct       ((min   0.0)    (max   95.0)))
+   (avg_holding_days       ((min   0.0)    (max    1.0)))
+   (wall_seconds           ((min   1.0)    (max  3600.0))))))

--- a/trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28/spy-only-weinstein-1998-2025.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28/spy-only-weinstein-1998-2025.sexp
@@ -1,0 +1,116 @@
+;; perf-tier: research
+;; perf-tier-rationale: One-time diagnostic — Weinstein-on-SPY-only over the
+;; 1998-2025 window. Pairs with [bah-spy-1998-2025.sexp] in this same
+;; directory. Not in CI rotation; consumer is the writeup at
+;; [dev/notes/spy-only-diagnostic-2026-05-28.md].
+;;
+;; {1 Diagnostic purpose}
+;;
+;; This scenario is part of a 3-way decomposition of where Weinstein's alpha
+;; (or lack thereof) comes from:
+;;
+;;   1. SPY-only Weinstein vs BAH-SPY = isolated market-timing alpha (this).
+;;   2. SPDR sector ETFs Weinstein vs BAH-SPY = market-timing + sector
+;;      rotation (sibling scenario, experiment/sector-etf-diagnostic).
+;;   3. Stocks Weinstein vs BAH-SPY = market-timing + sector + stock picking
+;;      (the established BO sweep result on top-3000).
+;;
+;; Differences:
+;;   (2) - (1) = pure sector-rotation alpha
+;;   (3) - (2) = pure stock-picking alpha
+;;
+;; If SPY-only loses to BAH-SPY, market-timing at the index level is
+;; value-neutral or harmful and any Weinstein alpha must come from the
+;; cross-section (sector / stock picking).
+;;
+;; {1 Universe handling on a 1-symbol universe}
+;;
+;; Universe = {SPY}; Weinstein's screener cascade still runs but with
+;; degenerate semantics on a 1-symbol set:
+;;
+;;   - Macro analysis ([Weinstein_strategy.indices.primary]) reads
+;;     [GSPC.INDX] (NOT SPY) per [trading/trading/backtest/lib/runner.ml]'s
+;;     hardcoded [index_symbol = "GSPC.INDX"]. So macro state is well-defined
+;;     and unaffected by the universe shrink — bullish / neutral / bearish
+;;     macro gating fires normally.
+;;
+;;   - Sector analysis reads the SPDR sector ETFs (XLK / XLF / etc.) per
+;;     [Weinstein_strategy.Macro_inputs.spdr_sector_etfs]. SPY's GICS sector
+;;     in [universes/spy-only.sexp] is "Communication Services" (informational
+;;     only — BAH ignores it, but Weinstein's sector RS step may use it to
+;;     map SPY into a sector cohort. With a 1-symbol universe, the cohort
+;;     contains only SPY, so sector RS is degenerate but not harmful.
+;;
+;;   - Relative strength: SPY's RS is computed vs the macro benchmark
+;;     [GSPC.INDX], not vs SPY itself. SPY ≈ GSPC.INDX up to TER + tracking
+;;     error, so RS will hover near zero (small, time-varying noise from the
+;;     ETF tracking error + dividend pass-through timing). This means
+;;     entry/exit signal comes almost entirely from SPY's own price/MA
+;;     trend, not from cross-section ranking.
+;;
+;; This is the "isolated market-timing alpha" measurement we want — what
+;; happens if you ONLY use Weinstein's stage classifier + stop machine on the
+;; market itself?
+;;
+;; {1 Cell-E config}
+;;
+;; Identical config_overrides to [sp500-2010-2026.sexp] and
+;; [sp500-1998-2026.sexp] — the canonical Cell-E config:
+;;   - max_position_pct_long  = 0.14
+;;   - max_long_exposure_pct  = 0.70
+;;   - min_cash_pct           = 0.30
+;;   - enable_stage3_force_exit = true (h=1)
+;;   - enable_laggard_rotation  = true (h=2)
+;;
+;; On a 1-symbol universe, the position-sizing caps are effectively
+;; meaningless (you can only ever hold SPY or be in cash). max_position_pct
+;; = 0.14 means each entry buys ~14% of NAV worth of SPY — so the strategy
+;; is mostly-cash even when holding. This is intentional: the question is
+;; "does Weinstein TIMING beat BAH" not "does Weinstein on equal sizing
+;; beat BAH" — the cap reflects the same risk discipline used in the full
+;; surface.
+;;
+;; {1 Initial cash}
+;;
+;; Runner hardcodes [initial_cash = 1_000_000.0] in
+;; [trading/trading/backtest/lib/runner.ml] line 13. The diagnostic prompt
+;; asks for $100k initial cash; we use the runner's canonical $1M instead.
+;; All compared metrics (return %, Sharpe, MaxDD, time-in-market %, CAGR)
+;; are scale-invariant, so the diagnostic verdict is unaffected.
+;;
+;; {1 End date}
+;;
+;; 2025-12-31 caps the window before the small 2026-01..2026-05 tail.
+;; [GSPC.INDX] data extends to 2026-04-10; SPY to 2026-05-01.
+;;
+;; {1 Expected bands}
+;;
+;; Intentionally WIDE — research scenario, no prior measurement to pin
+;; against. Catch-only sentinels for NaN / crash regressions.
+((name "spy-only-weinstein-1998-2025")
+ (description
+  "SPY-only Weinstein (1-symbol universe) 1998-01-01 to 2025-12-31 — isolated market-timing diagnostic. Cell-E config. Pairs with bah-spy-1998-2025.sexp in same dir.")
+ (period ((start_date 1998-01-01) (end_date 2025-12-31)))
+ (universe_path "universes/spy-only.sexp")
+ (universe_size 1)
+ ;; Cell-E config — identical to sp500-2010-2026.sexp.
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ ;; Research bands — wide, catch only NaN / crash sentinels. The diagnostic
+ ;; report (dev/notes/spy-only-diagnostic-2026-05-28.md) carries the
+ ;; analysis; this scenario's PASS/FAIL gate isn't load-bearing.
+ (expected
+  ((total_return_pct  ((min -90.0)   (max 5000.0)))
+   (total_trades      ((min   0.0)   (max  10000.0)))
+   (win_rate          ((min   0.0)   (max   100.0)))
+   (sharpe_ratio      ((min  -2.0)   (max     5.0)))
+   (max_drawdown_pct  ((min   0.0)   (max    95.0)))
+   (avg_holding_days  ((min   0.0)   (max   365.0)))
+   (wall_seconds      ((min   1.0)   (max  3600.0))))))


### PR DESCRIPTION
## Summary

Adds a 3-way alpha-decomposition diagnostic asking where Weinstein's alpha (or lack thereof) comes from. This PR is layer (1) of the decomposition:

1. **SPY-only Weinstein vs BAH-SPY** = isolated market-timing alpha (this PR)
2. SPDR sector ETFs Weinstein vs BAH-SPY = + sector rotation (sibling agent on branch `experiment/sector-etf-diagnostic`)
3. Stocks Weinstein vs BAH-SPY = + stock picking (already done — v7 sweep result)

The differences tell us which signal layer carries the alpha:
- (2) − (1) = pure sector-rotation alpha
- (3) − (2) = pure stock-picking alpha

## Verdict

**LOSES_TO_SPY** by **−7.13pp CAGR** (threshold: ≤−1pp = LOSE).

| Metric | SPY-only Weinstein | BAH-SPY | Delta |
|---|---:|---:|---:|
| Total return % | +1.68% | +598.41% | −596.73pp |
| CAGR | 0.06% | 7.19% | **−7.13pp** |
| Sharpe | 0.22 | 0.45 | −0.23 |
| MaxDD | 0.83% | 56.04% | −55.21pp (less DD) |
| Total trades | 11 | 0 (BAH never sells) | n/a |
| Avg holding days | 29.2 | n/a | n/a |
| **Time-in-market** | **4.40%** | ~100% | n/a |

Weinstein on SPY-only earns cash-like returns (~0.06% CAGR) over 28 years vs BAH-SPY's 7.19%. The strategy is in cash 95.6% of the time and misses every multi-year market advance in the sample (2002–2006, 2008–2014, 2016–2019, 2019–2023).

## Strategic implication

- *Hypothesis*: "Weinstein's macro/timing signal alone is alpha." **Rejected.**
- Alpha must come from cross-section (sector rotation or stock picking) — i.e., "WHICH symbols to buy when Weinstein says buy," not "WHEN to buy the market."
- The 11-knob BO sweeps (v3/v6/v7) tune knobs that primarily reshape cross-section ranking; the v6 random-vs-BO near-tie verdict is consistent with this finding (if there's no per-stock-selection signal at the surface, BO can't beat random).

Full analysis (caveats on 1-symbol universe semantics for Weinstein's macro / sector / RS sub-modules, per-trade table, missed-period analysis, reproduction recipe) in `dev/notes/spy-only-diagnostic-2026-05-28.md`.

## Test plan

- [x] `dune build` clean (via `docker exec trading-1-dev`).
- [x] Both scenarios run via `scenario_runner.exe --dir <experiments/spy-only-diagnostic-2026-05-28>`; both PASS the (intentionally wide) sentinel bands.
- [x] BAH-SPY result (+598.4%, MaxDD 56.0%) matches expected SPY 1998-2025 raw price-only return.
- [x] Weinstein-on-SPY trade log shows 11 round-trips, all entered in Stage2, exits via stop_loss or laggard_rotation (Cell-E behavior). Force-liquidations = 0.
- [x] No code changes; only 2 scenario sexp files + 1 diagnostic report.

## Files

- `trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28/spy-only-weinstein-1998-2025.sexp` — Cell-E Weinstein scenario, 1-symbol universe = {SPY}
- `trading/test_data/backtest_scenarios/experiments/spy-only-diagnostic-2026-05-28/bah-spy-1998-2025.sexp` — Companion BAH-SPY baseline
- `dev/notes/spy-only-diagnostic-2026-05-28.md` — Diagnostic writeup

## Coordination

Sibling agent on branch `experiment/sector-etf-diagnostic` runs the same diagnostic on the 11-symbol SPDR sector ETF universe. The two reports together will isolate sector-rotation alpha from market-timing alpha.

Do not modify `dev/status/_index.md` from this PR — orchestrator reconciles after merge.