### PR TITLE
feat(walk-forward): hysteresis 30-fold spec for stage3 revisit

### DIFF
--- a/trading/test_data/walk_forward/hysteresis_30fold_2026_05_29.sexp
+++ b/trading/test_data/walk_forward/hysteresis_30fold_2026_05_29.sexp
@@ -1,0 +1,58 @@
+;; Walk-forward fixture — stage3 hysteresis revisit via 30-fold OOS CV.
+;;
+;; Authored 2026-05-29 PM after PR-B panel re-pin was REJECTED on data
+;; (single-window-overfit: 5y win, 15y loss). See
+;; `dev/notes/stage3-hysteresis-panel-rejected-2026-05-29.md` (PR #1364).
+;;
+;; Question this spec answers: does the autopsy-recommended hysteresis
+;; setting `(hysteresis_weeks=2, stage3_exit_margin_pct=0.02)` beat the
+;; current panel pin `(hysteresis_weeks=1, stage3_exit_margin_pct=0.0)`
+;; across many OOS windows, not just on one 5y or one 15y panel?
+;;
+;; Fold geometry: identical to cell_e_30fold_2026_05_16.sexp — 30 rolling
+;; OOS folds across 2010-2026 sp500 historical, test_days=365 step_days=182.
+;;
+;; Baseline = "h1-m0" (matches current panel pin, empty overrides).
+;; Variant  = "h2-m02" (the autopsy candidate that lost on the 15y panel).
+;;
+;; Gate: variant "h2-m02" must beat baseline "h1-m0" on Sharpe in
+;; ≥ 17 of 30 folds (>50%, simple majority), with no fold worse than
+;; baseline by more than 0.20 Sharpe. Calibrated to be FAILABLE on the
+;; same kind of disagreement that killed the 15y panel (the 15y panel
+;; was 1 window worse by 0.16 Sharpe — would have been within tolerance,
+;; but the failure-mode this spec catches is fold-distribution skew,
+;; not single-window magnitude).
+;;
+;; Runner invocation (multi-hour, local-only, route output to bind-mount):
+;;   docker exec -d trading-1-dev bash -c \
+;;     "mkdir -p /tmp/sweeps/hysteresis-wf-30fold-2026-05-29 && \
+;;      cd /workspaces/trading-1/trading && eval \$(opam env) && \
+;;      nohup dune exec --no-build trading/backtest/walk_forward/bin/walk_forward_runner.exe -- \
+;;        --spec trading/test_data/walk_forward/hysteresis_30fold_2026_05_29.sexp \
+;;        --out-dir /tmp/sweeps/hysteresis-wf-30fold-2026-05-29 \
+;;        --parallel 4 \
+;;        > /tmp/sweeps/hysteresis-wf-30fold-2026-05-29.log 2>&1 &"
+;;
+;; Expected wall ≈ 60-90 min (30 folds × 2 variants × ~3 min / fold ÷ 4 parallel ≈ 50 min)
+
+((base_scenario "goldens-sp500-historical/sp500-2010-2026.sexp")
+ (window_spec
+  (Rolling
+   ((start_date 2010-01-01)
+    (end_date 2026-04-30)
+    (train_days 0)
+    (test_days 365)
+    (step_days 182))))
+ (variants
+  (;; h1-m0: matches the current panel pin (sp500-2010-2026.sexp already
+   ;; pins `stage3_force_exit_config.hysteresis_weeks=1` and
+   ;; `stage3_exit_margin_pct` defaults to 0.0). Empty overrides.
+   ((label "h1-m0") (overrides ()))
+   ;; h2-m02: the autopsy-recommended candidate that lost on the 15y
+   ;; panel single-window test. Both knobs overridden on top of base.
+   ((label "h2-m02")
+    (overrides
+     (((stage3_force_exit_config ((hysteresis_weeks 2))))
+      ((stage3_exit_margin_pct 0.02)))))))
+ (baseline_label "h1-m0")
+ (gate ((metric Sharpe) (m 17) (n 30) (worst_delta 0.20))))

--- a/trading/trading/backtest/walk_forward/test/test_spec.ml
+++ b/trading/trading/backtest/walk_forward/test/test_spec.ml
@@ -193,6 +193,31 @@ let test_28fold_gate_is_non_firing _ =
          field (fun (g : Walk_forward.Fold_gate.t) -> g.n) (equal_to 28);
        ])
 
+(* ---------- Hysteresis 30-fold fixture (stage3 revisit, 2026-05-29) ---------- *)
+
+let _hysteresis_fixture = "hysteresis_30fold_2026_05_29.sexp"
+
+let test_hysteresis_spec_parses _ =
+  let spec = Spec.load (_fixture_path _hysteresis_fixture) in
+  assert_that spec
+    (all_of
+       [
+         field
+           (fun (s : Spec.t) -> s.base_scenario)
+           (equal_to "goldens-sp500-historical/sp500-2010-2026.sexp");
+         field (fun (s : Spec.t) -> s.baseline_label) (equal_to "h1-m0");
+         field (fun (s : Spec.t) -> List.length s.variants) (equal_to 2);
+         field (fun (s : Spec.t) -> s.gate.n) (equal_to 30);
+       ])
+
+let test_hysteresis_variants_are_h1m0_and_h2m02 _ =
+  let spec = Spec.load (_fixture_path _hysteresis_fixture) in
+  let labels =
+    List.map spec.variants
+      ~f:(fun (v : Walk_forward.Walk_forward_runner.variant) -> v.label)
+  in
+  assert_that labels (elements_are [ equal_to "h1-m0"; equal_to "h2-m02" ])
+
 let suite =
   "Walk_forward_spec"
   >::: [
@@ -215,6 +240,9 @@ let suite =
          >:: test_28fold_variants_is_cellE_only;
          "28-fold gate is non-firing placeholder"
          >:: test_28fold_gate_is_non_firing;
+         "hysteresis 30-fold spec parses" >:: test_hysteresis_spec_parses;
+         "hysteresis 30-fold variants are h1-m0 and h2-m02"
+         >:: test_hysteresis_variants_are_h1m0_and_h2m02;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Walk-forward fixture for revisiting stage3 hysteresis with statistical basis instead of single-window panel reads. Companion to the PR-B retraction (#1364) — the WF sweep is the principled re-run that the rejection note pointed at.

## What it does

- NEW `trading/test_data/walk_forward/hysteresis_30fold_2026_05_29.sexp` (30-fold rolling OOS, 2010-2026 sp500 historical, identical fold geometry to `cell_e_30fold_2026_05_16.sexp`):
  - Baseline `h1-m0`: empty overrides (= current panel pin: `hysteresis_weeks=1`, `stage3_exit_margin_pct=0.0`)
  - Variant `h2-m02`: applies the autopsy-recommended `hysteresis_weeks=2 + stage3_exit_margin_pct=0.02`
  - Gate: variant beats baseline on Sharpe in ≥17 of 30 folds (simple majority), no fold worse than baseline by >0.20 Sharpe
- UPDATE `trading/trading/backtest/walk_forward/test/test_spec.ml`: 2 new tests pin the fixture's spec shape (parses, has 2 variants, baseline_label, gate.n=30, variant labels h1-m0/h2-m02)

No source-code change. No runtime impact. The sweep itself is a separate local-only run; results land as a follow-up note.

## Why

Per `dev/notes/stage3-hysteresis-panel-rejected-2026-05-29.md` (PR #1364) — the single-window panel test rejected `(h=2, m=0.02)` on a 5y win / 15y loss disagreement. The retraction note's own follow-up #2 ("Walk-forward CV infrastructure is the right unblock surface") is the basis for this fixture. The infrastructure is already merged (PR #1100 / #1111 / #1116, 2026-05-16); this PR just adds the spec to drive it.

## Test plan

- [x] `dune runtest trading/backtest/walk_forward/test` — 14 tests pass including 2 new
- [x] `dune build @fmt` — clean
- [x] Local sweep launched against this spec — log accumulating at `/tmp/sweeps/hysteresis-wf-30fold-2026-05-29.log` (ETA ~50-90 min)
- [ ] Follow-up: results note + Fold_gate verdict landed as a separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)