### PR TITLE
fix(walk-forward): hysteresis spec gate.n 30->31 to match generated fold count

### DIFF
--- a/trading/test_data/walk_forward/hysteresis_30fold_2026_05_29.sexp
+++ b/trading/test_data/walk_forward/hysteresis_30fold_2026_05_29.sexp
@@ -16,8 +16,11 @@
 ;; Variant  = "h2-m02" (the autopsy candidate that lost on the 15y panel).
 ;;
 ;; Gate: variant "h2-m02" must beat baseline "h1-m0" on Sharpe in
-;; ≥ 17 of 30 folds (>50%, simple majority), with no fold worse than
-;; baseline by more than 0.20 Sharpe. Calibrated to be FAILABLE on the
+;; ≥ 16 of 31 folds (>50%, simple majority), with no fold worse than
+;; baseline by more than 0.20 Sharpe. The Rolling geometry below yields
+;; 31 OOS folds (fold-000..fold-030) over 2010-2026 — n is set to 31 to
+;; match the generated count so the gate evaluates rather than SKIPs on a
+;; fold-count guard mismatch. Calibrated to be FAILABLE on the
 ;; same kind of disagreement that killed the 15y panel (the 15y panel
 ;; was 1 window worse by 0.16 Sharpe — would have been within tolerance,
 ;; but the failure-mode this spec catches is fold-distribution skew,
@@ -55,4 +58,4 @@
      (((stage3_force_exit_config ((hysteresis_weeks 2))))
       ((stage3_exit_margin_pct 0.02)))))))
  (baseline_label "h1-m0")
- (gate ((metric Sharpe) (m 17) (n 30) (worst_delta 0.20))))
+ (gate ((metric Sharpe) (m 16) (n 31) (worst_delta 0.20))))

--- a/trading/trading/backtest/walk_forward/test/test_spec.ml
+++ b/trading/trading/backtest/walk_forward/test/test_spec.ml
@@ -207,7 +207,7 @@ let test_hysteresis_spec_parses _ =
            (equal_to "goldens-sp500-historical/sp500-2010-2026.sexp");
          field (fun (s : Spec.t) -> s.baseline_label) (equal_to "h1-m0");
          field (fun (s : Spec.t) -> List.length s.variants) (equal_to 2);
-         field (fun (s : Spec.t) -> s.gate.n) (equal_to 30);
+         field (fun (s : Spec.t) -> s.gate.n) (equal_to 31);
        ])
 
 let test_hysteresis_variants_are_h1m0_and_h2m02 _ =
@@ -217,6 +217,15 @@ let test_hysteresis_variants_are_h1m0_and_h2m02 _ =
       ~f:(fun (v : Walk_forward.Walk_forward_runner.variant) -> v.label)
   in
   assert_that labels (elements_are [ equal_to "h1-m0"; equal_to "h2-m02" ])
+
+(** Pins the gate-count contract: the Rolling geometry yields exactly 31 OOS
+    folds and [gate.n] must equal that count, otherwise [Fold_gate.evaluate]'s
+    fold-count guard makes the runner SKIP the verdict (observed on the
+    2026-05-29 run, which authored n=30 against 31 generated folds). *)
+let test_hysteresis_gate_n_matches_generated_fold_count _ =
+  let spec = Spec.load (_fixture_path _hysteresis_fixture) in
+  let generated = List.length (WS.generate spec.window_spec) in
+  assert_that generated (all_of [ equal_to 31; equal_to spec.gate.n ])
 
 let suite =
   "Walk_forward_spec"
@@ -243,6 +252,8 @@ let suite =
          "hysteresis 30-fold spec parses" >:: test_hysteresis_spec_parses;
          "hysteresis 30-fold variants are h1-m0 and h2-m02"
          >:: test_hysteresis_variants_are_h1m0_and_h2m02;
+         "hysteresis gate.n matches generated fold count (31)"
+         >:: test_hysteresis_gate_n_matches_generated_fold_count;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What

The `hysteresis_30fold_2026_05_29.sexp` Rolling geometry (2010-01-01→2026-04-30, test=365, step=182) generates **31** OOS folds (`fold-000`..`fold-030`), but the gate was authored with `n=30`. `Fold_gate.evaluate`'s fold-count guard then `failwith`s on the mismatch and the runner renders the verdict **SKIPPED** instead of evaluating it — observed on the 2026-05-29 run (`dev/notes/stage3-hysteresis-walkforward-cv-2026-05-29.md`, PR #1366).

## Fix

- Gate `(m 17) (n 30)` → `(m 16) (n 31)`: `n` matches the generated fold count; `m=16` preserves the spec's ">50% simple majority" intent (16/31 = 51.6%). Header comment updated.
- New test `test_hysteresis_gate_n_matches_generated_fold_count` pins `generate count == 31 == gate.n` so the off-by-one can't regress.

Verdict is unchanged either way (variant won 4/31 folds — decisive NO-GO); this just lets the gate compute the formal verdict rather than skip it, and prevents the same authoring error in future re-runs.

## Test

`dune build @fmt` + `dune build` clean; `test_spec.exe` 15/15 pass (was 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)