### PR TITLE
feat(walk-forward): variant-matrix generator + flag-discipline rule (PR-1)

### DIFF
--- a/.claude/rules/experiment-flag-discipline.md
+++ b/.claude/rules/experiment-flag-discipline.md
@@ -1,0 +1,67 @@
+# Experiment flag discipline
+
+Every new strategy mechanism lands behind a **default-off** config flag
+(or a value defaulting to the no-op), becomes an **experiment axis** the
+day it lands, and is **not wired into the default config** until it has
+an **ACCEPT verdict in the experiment ledger**.
+
+This codifies de-facto practice (E2 segmentation, the stage3 exit-margin
+knob in #1362) so it is checkable. It is Gap E of the systematic
+experiment-platform program (`dev/plans/experiment-platform-2026-05-29.md`).
+
+## The three rules
+
+1. **Default-off on merge.** A new mechanism's flag (e.g.
+   `enable_laggard_rotation : bool [@sexp.default false]`) or its no-op
+   value (e.g. `stage3_exit_margin_pct : float [@sexp.default 0.0]`)
+   must default to the behaviour the system had *before* the mechanism
+   existed. Merging the mechanism changes no backtest result until a
+   spec explicitly flips the flag. Backward-compat is preserved on
+   merge, always.
+
+2. **An axis the day it lands.** The mechanism is only useful if it is
+   searchable. The same PR (or its immediate follow-up) that adds the
+   flag should make it expressible as a `Variant_matrix` axis — i.e.
+   the flag is a real `Weinstein_strategy.config` field that
+   `Overlay_validator.apply_overrides` resolves, so
+   `((flag <name>) (values (true false)))` expands and validates.
+   (`Variant_matrix` lives at
+   `trading/trading/backtest/walk_forward/lib/variant_matrix.mli`.)
+
+3. **No default-on without an ACCEPT.** A mechanism is wired into the
+   default config (flipped on by default, or its no-op value changed)
+   **only after** it earns an ACCEPT verdict in the experiment ledger —
+   i.e. it survived walk-forward CV with proper best-of-N correction
+   (Deflated Sharpe), not a single-window win. Until then it stays
+   default-off and lives as an axis.
+
+## Why
+
+The 2026-05-29 hysteresis episode and the 2026-05-13 continuation
+combined-axis rejection both came from promoting a mechanism on a
+single-window win that did not generalise. The discipline forces every
+mechanism through the same gate: land safe (default-off), search the
+surface (axis), promote only on a ledger-backed ACCEPT.
+
+It also keeps `main` always shippable — no half-wired mechanism ever
+changes live/backtest behaviour silently, because the default is the
+pre-existing no-op.
+
+## What QC can check
+
+For a PR that adds a strategy mechanism:
+
+- **R1 — default-off.** The new `config` field carries a
+  `[@sexp.default <no-op>]` and the no-op equals the prior behaviour.
+  FAIL if a new mechanism is on by default with no ledger ACCEPT cited.
+- **R2 — searchable.** The flag/knob is a real `Weinstein_strategy.config`
+  field (not a hardcoded constant), so it routes through
+  `Overlay_validator` and can be an axis. FAIL if the mechanism is
+  gated by anything other than a config field.
+- **R3 — promotion needs a verdict.** A PR that flips a default
+  (default-off → default-on, or changes a no-op default value) must
+  cite the ledger ACCEPT entry that justifies it. FAIL otherwise.
+
+These are mechanical: grep the `config` record diff for the new field +
+its `[@sexp.default ...]`; check the PR body for a ledger citation when
+a default changes.

--- a/dev/status/experiment-platform.md
+++ b/dev/status/experiment-platform.md
@@ -26,7 +26,11 @@ Sequencing (per plan §Sequencing):
 - Skill — Experimentation gap-closing skill (Gap F).
 
 ## Interface stable
-PARTIAL
+NO
+
+The PR-1 `Walk_forward.Variant_matrix` surface below is the stable part;
+the program-level interface (ledger schema, ranking output) is still
+forming across PR-2/PR-3, so the track is NO until those land.
 
 `Walk_forward.Variant_matrix` surface (PR-1):
 - `type axis = Key of { path; values } | Flag of { name; values }`

--- a/dev/status/experiment-platform.md
+++ b/dev/status/experiment-platform.md
@@ -1,0 +1,83 @@
+# Status: experiment-platform
+
+## Last updated: 2026-05-29
+
+## Status
+IN_PROGRESS
+
+## Notes
+
+Track created 2026-05-29 by `feat-backtest` per the systematic
+experiment-platform program plan
+(`dev/plans/experiment-platform-2026-05-29.md`, PR #1368). The program
+makes discrete feature/mechanism exploration systematic: hypotheses
+become variant matrices, evaluated by walk-forward CV, ranked with
+proper statistics (Deflated Sharpe), recorded in an append-only ledger.
+
+Filed after the 2026-05-29 stage3-hysteresis WF-CV rejection
+(`dev/notes/stage3-hysteresis-walkforward-cv-2026-05-29.md`): we tested
+one point, never a surface. PR-1 lets a spec declare axes that expand
+into the `variants` list the WF runner already consumes.
+
+Sequencing (per plan §Sequencing):
+- **PR-1** — Variant-matrix generator (Gap A) + flag-discipline rule (Gap E).
+- PR-2 — Experiment ledger + retroactive seed (Gap D).
+- PR-3 — Matrix ranking + Deflated Sharpe (Gap C; shares DSR w/ BO program).
+- Skill — Experimentation gap-closing skill (Gap F).
+
+## Interface stable
+PARTIAL
+
+`Walk_forward.Variant_matrix` surface (PR-1):
+- `type axis = Key of { path; values } | Flag of { name; values }`
+  (on-disk record shape: `((key (a b)) (values (...)))` /
+  `((flag name) (values (...)))`).
+- `type expansion = Cartesian | Sampled of { n; seed }`.
+- `type t = { axes; expansion }`.
+- `val expand : t -> Walk_forward_runner.variant list` — validates every
+  generated override against the canonical default config at expansion
+  time (raises `Failure` on a typo'd key, the 2026-05-12 81-cell guard).
+
+`Walk_forward.Spec.load` now accepts an optional `axes` block; when
+present it prepends the auto-baseline cell then appends the expanded
+matrix (explicit `variants`, if any, kept first). De-dups by label.
+Axes-absent specs parse 100% backward-compatibly.
+
+## Work
+
+### Gap A — Variant-matrix generator (PR-1)
+- [x] **`Walk_forward.Variant_matrix`** — `axis` / `expansion` / `t`
+  types + `expand`, with expansion-time `Overlay_validator` validation.
+  Surface at
+  `trading/trading/backtest/walk_forward/lib/variant_matrix.{ml,mli}`.
+- [x] **`Walk_forward.Spec` axes wiring** — optional `axes` field;
+  `load` expands + prepends auto-baseline + de-dups by label; backward-
+  compatible with hand-written `variants`. At
+  `trading/trading/backtest/walk_forward/lib/spec.{ml,mli}`.
+- [x] **Flag-discipline rule (Gap E)** — `.claude/rules/experiment-flag-discipline.md`.
+
+Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune build && dune exec backtest/walk_forward/test/test_variant_matrix.exe && dune exec backtest/walk_forward/test/test_spec.exe'`
+(variant_matrix 10/10; spec 19/19 = 15 legacy + 4 axes-on-load).
+
+### Gap B — Loud override validation
+- [x] Already shipped (#1069) and reused at expansion time by PR-1.
+
+## Next Steps
+
+1. **PR-2 — Experiment ledger** (`dev/experiments/_ledger/`): append-only
+   per-experiment sexp + machine-readable index, config-hash dedup,
+   retroactive seed with known rejections (hysteresis ×2, continuation
+   combined-axis, M5.5 4-axis, laggard-disable).
+2. **PR-3 — Matrix ranking + Deflated Sharpe**: cross-variant best-of-N
+   correction on top of `Fold_gate`; Pareto rank over (Sharpe, MaxDD,
+   Calmar). Shares the DSR module with the BO program.
+3. **Skill (Gap F)** — once PR-1+PR-2 give it tools.
+4. **First real use** — re-attack the autopsy missed-gain (modes 1+2) as
+   a surface: hysteresis_weeks grid × exit_margin grid × relevant
+   `enable_*` flags through WF-CV, ranked with DSR.
+
+## Out of scope (PR-1)
+
+- Ledger (PR-2), DSR ranking (PR-3), the skill (Gap F).
+- Any change to the WF runner / gate / report (reused unchanged).
+- Promotion automation (stays manual, ledger-backed).

--- a/trading/trading/backtest/walk_forward/lib/dune
+++ b/trading/trading/backtest/walk_forward/lib/dune
@@ -1,5 +1,11 @@
 (library
  (name walk_forward)
- (libraries core fork_pool scenario_lib backtest trading.simulation.types)
+ (libraries
+  core
+  fork_pool
+  scenario_lib
+  backtest
+  weinstein_trading.strategy
+  trading.simulation.types)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/walk_forward/lib/spec.ml
+++ b/trading/trading/backtest/walk_forward/lib/spec.ml
@@ -9,4 +9,57 @@ type t = {
 }
 [@@deriving sexp] [@@sexp.allow_extra_fields]
 
-let load path : t = t_of_sexp (Sexp.load_sexp path)
+(* Raw on-disk shape. [variants] is optional (empty when only [axes] is given);
+   [axes] is the optional matrix-declaration block (plan Gap A). The public {!t}
+   carries only the *resolved* variant list — [axes] is a parse-time concern
+   that {!load} expands away, so the constructor surface and all downstream
+   consumers stay unchanged. *)
+type _raw = {
+  base_scenario : string;
+  window_spec : Window_spec.t;
+  variants : Walk_forward_runner.variant list; [@sexp.default []]
+  baseline_label : string;
+  gate : Fold_gate.t;
+  axes : Variant_matrix.t option; [@sexp.option]
+}
+[@@deriving of_sexp] [@@sexp.allow_extra_fields]
+
+(* The auto-included baseline cell: all-default / empty-override, labelled from
+   [baseline_label]. Prepended ahead of the expanded matrix so every axes-driven
+   run carries its own reference point (plan Gap A: "Baseline = the all-default
+   / empty-override cell, auto-included"). *)
+let _baseline_variant ~baseline_label : Walk_forward_runner.variant =
+  { label = baseline_label; overrides = [] }
+
+(* De-dup by label; raise on collision so a typo or an overlapping
+   explicit/matrix label fails loudly rather than silently dropping a cell. *)
+let _check_unique_labels (variants : Walk_forward_runner.variant list) =
+  let seen = String.Hash_set.create () in
+  List.iter variants ~f:(fun v ->
+      if Hash_set.mem seen v.label then
+        failwithf "Spec: duplicate variant label %S" v.label ()
+      else Hash_set.add seen v.label)
+
+(* Resolve the raw record into the public {!t}. When [axes] is present, the
+   final list is: explicit variants (if any), then the auto-baseline, then the
+   expanded matrix. When [axes] is absent, the variants pass through unchanged
+   (100% backward-compatible with the hand-written-variants path). *)
+let _resolve (raw : _raw) : t =
+  let variants =
+    match raw.axes with
+    | None -> raw.variants
+    | Some axes ->
+        raw.variants
+        @ [ _baseline_variant ~baseline_label:raw.baseline_label ]
+        @ Variant_matrix.expand axes
+  in
+  _check_unique_labels variants;
+  {
+    base_scenario = raw.base_scenario;
+    window_spec = raw.window_spec;
+    variants;
+    baseline_label = raw.baseline_label;
+    gate = raw.gate;
+  }
+
+let load path : t = _resolve (_raw_of_sexp (Sexp.load_sexp path))

--- a/trading/trading/backtest/walk_forward/lib/spec.mli
+++ b/trading/trading/backtest/walk_forward/lib/spec.mli
@@ -21,5 +21,21 @@ type t = {
     runner itself ignores the list). *)
 
 val load : string -> t
-(** [load path] = [Sexp.load_sexp path |> t_of_sexp]. Raises [Failure] / sexp
-    parse errors per the underlying functions. *)
+(** [load path] parses the spec sexp at [path] and returns the resolved {!t}.
+
+    The on-disk sexp may declare an optional [axes] block (a
+    {!Variant_matrix.t}) instead of, or in addition to, hand-written [variants]:
+
+    - If [axes] is present, [t.variants] = the explicit [variants] (if any, kept
+      first) followed by the auto-included baseline cell (empty-override,
+      labelled [baseline_label]) followed by the expanded matrix
+      ({!Variant_matrix.expand}). Expansion validates every generated override
+      against the canonical default config, so a typo'd axis key raises
+      [Failure] here, at load time.
+    - If [axes] is absent, [t.variants] = the hand-written [variants] verbatim —
+      100% backward-compatible with pre-matrix spec files.
+
+    Variants are de-duplicated by [label]; a collision (whether between two
+    explicit variants, the baseline, or two matrix cells) raises [Failure].
+
+    Raises [Failure] / sexp parse errors per the underlying functions. *)

--- a/trading/trading/backtest/walk_forward/lib/variant_matrix.ml
+++ b/trading/trading/backtest/walk_forward/lib/variant_matrix.ml
@@ -4,15 +4,18 @@ type axis =
   | Key of { path : string list; values : Sexp.t list }
   | Flag of { name : string; values : Sexp.t list }
 
+(* Parse one record entry [(field args...)] into a [field, args] pair. *)
+let _parse_field (entry : Sexp.t) : string * Sexp.t list =
+  match entry with
+  | Sexp.List (Sexp.Atom k :: rest) -> (k, rest)
+  | other ->
+      failwithf "Variant_matrix.axis_of_sexp: bad field %s"
+        (Sexp.to_string other) ()
+
 (* Parse a record-shaped axis sexp into a [field -> args] assoc. *)
 let _axis_fields (sexp : Sexp.t) : (string * Sexp.t list) list =
   match sexp with
-  | Sexp.List entries ->
-      List.map entries ~f:(function
-        | Sexp.List (Sexp.Atom k :: rest) -> (k, rest)
-        | other ->
-            failwithf "Variant_matrix.axis_of_sexp: bad field %s"
-              (Sexp.to_string other) ())
+  | Sexp.List entries -> List.map entries ~f:_parse_field
   | other ->
       failwithf "Variant_matrix.axis_of_sexp: expected record, saw %s"
         (Sexp.to_string other) ()

--- a/trading/trading/backtest/walk_forward/lib/variant_matrix.ml
+++ b/trading/trading/backtest/walk_forward/lib/variant_matrix.ml
@@ -1,0 +1,146 @@
+open Core
+
+type axis =
+  | Key of { path : string list; values : Sexp.t list }
+  | Flag of { name : string; values : Sexp.t list }
+
+(* Parse a record-shaped axis sexp into a [field -> args] assoc. *)
+let _axis_fields (sexp : Sexp.t) : (string * Sexp.t list) list =
+  match sexp with
+  | Sexp.List entries ->
+      List.map entries ~f:(function
+        | Sexp.List (Sexp.Atom k :: rest) -> (k, rest)
+        | other ->
+            failwithf "Variant_matrix.axis_of_sexp: bad field %s"
+              (Sexp.to_string other) ())
+  | other ->
+      failwithf "Variant_matrix.axis_of_sexp: expected record, saw %s"
+        (Sexp.to_string other) ()
+
+(* On-disk axis shape is a record, not a variant tag, so a spec reads naturally:
+     ((key (stage3_force_exit_config hysteresis_weeks)) (values (1 2 3)))
+     ((flag enable_laggard_rotation) (values (true false)))
+   Exactly one of [key] / [flag] must be present alongside [values]. *)
+let axis_of_sexp (sexp : Sexp.t) : axis =
+  let assoc = _axis_fields sexp in
+  let find k = List.Assoc.find assoc k ~equal:String.equal in
+  let values =
+    match find "values" with
+    | Some [ Sexp.List vs ] -> vs
+    | _ ->
+        failwithf "Variant_matrix.axis_of_sexp: missing (values (...)) in %s"
+          (Sexp.to_string sexp) ()
+  in
+  match (find "key", find "flag") with
+  | Some [ Sexp.List path ], None ->
+      Key { path = List.map path ~f:Sexp.to_string; values }
+  | None, Some [ Sexp.Atom name ] -> Flag { name; values }
+  | _ ->
+      failwithf
+        "Variant_matrix.axis_of_sexp: exactly one of (key (...)) / (flag name) \
+         required in %s"
+        (Sexp.to_string sexp) ()
+
+let sexp_of_axis (axis : axis) : Sexp.t =
+  let values_field values =
+    Sexp.List [ Sexp.Atom "values"; Sexp.List values ]
+  in
+  match axis with
+  | Key { path; values } ->
+      let path = Sexp.List (List.map path ~f:(fun s -> Sexp.Atom s)) in
+      Sexp.List [ Sexp.List [ Sexp.Atom "key"; path ]; values_field values ]
+  | Flag { name; values } ->
+      Sexp.List
+        [ Sexp.List [ Sexp.Atom "flag"; Sexp.Atom name ]; values_field values ]
+
+type expansion = Cartesian | Sampled of { n : int; seed : int }
+[@@deriving sexp]
+
+type t = { axes : axis list; expansion : expansion } [@@deriving sexp]
+
+(* A flag is sugar for a single-component key-path axis. Normalising up-front
+   means the rest of the module never special-cases [Flag]. *)
+let _path_and_values = function
+  | Key { path; values } -> (path, values)
+  | Flag { name; values } -> ([ name ], values)
+
+(* [path_to_override [a; b] v = ((a ((b v))))] and [[a] v = ((a v))].
+   Mirrors the partial-config override shape consumed by [Overlay_validator]. *)
+let _path_to_override path value : Sexp.t =
+  let rec nest = function
+    | [] -> value
+    | key :: rest -> Sexp.List [ Sexp.List [ Sexp.Atom key; nest rest ] ]
+  in
+  match path with
+  | [] -> failwith "Variant_matrix: axis key-path must be non-empty"
+  | _ -> nest path
+
+(* Compact, deterministic [leaf=value] label segment for one axis cell. *)
+let _label_segment path value =
+  let leaf = List.last_exn path in
+  sprintf "%s=%s" leaf (Sexp.to_string value)
+
+(* The canonical default config to validate overrides against. The universe is
+   irrelevant to override key-resolution (we only check that each dot-path
+   resolves to a real field), so a single placeholder symbol suffices. *)
+let _index_symbol = "GSPC.INDX"
+
+let _default_config () =
+  Weinstein_strategy.default_config ~universe:[ "AAPL" ]
+    ~index_symbol:_index_symbol
+
+(* Validate one axis's override sexp against the default config. Raises [Failure]
+   (via [Overlay_validator.apply_overrides]) on any unknown key-path, AT
+   EXPANSION TIME — the 2026-05-12 81-cell silent-no-op guard. *)
+let _validate_override override =
+  ignore
+    (Backtest.Overlay_validator.apply_overrides (_default_config ())
+       [ override ])
+
+(* One normalised axis: leaf name + the per-value (label-segment, override)
+   pairs, validated. *)
+type _axis_cells = { segments : (string * Sexp.t) list }
+
+let _normalise_axis axis =
+  let path, values = _path_and_values axis in
+  let segments =
+    List.map values ~f:(fun value ->
+        let override = _path_to_override path value in
+        _validate_override override;
+        (_label_segment path value, override))
+  in
+  { segments }
+
+(* Full cartesian product of the per-axis cell lists. Output order: first axis
+   varies slowest (lexicographic). Each product element is the list of one
+   (label-segment, override) pick per axis, in axis order. *)
+let _cartesian (axes : _axis_cells list) : (string * Sexp.t) list list =
+  List.fold_right axes ~init:[ [] ] ~f:(fun axis acc ->
+      List.concat_map axis.segments ~f:(fun cell ->
+          List.map acc ~f:(fun rest -> cell :: rest)))
+
+let _cell_to_variant (cell : (string * Sexp.t) list) :
+    Walk_forward_runner.variant =
+  let label = String.concat ~sep:"__" (List.map cell ~f:fst) in
+  let overrides = List.map cell ~f:snd in
+  { label; overrides }
+
+(* Deterministic seeded subset of [n] distinct cells. Shuffles a copy of the
+   full product with a fresh [Random.State.t] (no global state), then takes the
+   first [n]. Falls back to the full product when [n >= size]. *)
+let _sample ~n ~seed (product : 'a list) : 'a list =
+  if n >= List.length product then product
+  else
+    let state = Random.State.make [| seed |] in
+    List.take (List.permute ~random_state:state product) n
+
+let expand (t : t) : Walk_forward_runner.variant list =
+  if List.is_empty t.axes then failwith "Variant_matrix: axes must be non-empty";
+  let axes = List.map t.axes ~f:_normalise_axis in
+  let product = _cartesian axes in
+  let cells =
+    match t.expansion with
+    | Cartesian -> product
+    | Sampled { n; seed } -> _sample ~n ~seed product
+  in
+  List.map cells ~f:_cell_to_variant

--- a/trading/trading/backtest/walk_forward/lib/variant_matrix.mli
+++ b/trading/trading/backtest/walk_forward/lib/variant_matrix.mli
@@ -1,0 +1,76 @@
+(** Variant-matrix generator for walk-forward CV.
+
+    Declares experiment *axes* in a spec and expands them into the
+    {!Walk_forward_runner.variant} list the runner already consumes. An axis is
+    a config key-path (or a single-component flag) paired with a list of values;
+    the matrix expands either as the full cartesian product of axis values
+    ([Cartesian]) or as a deterministic seeded subset ([Sampled]).
+
+    Motivation (plan Gap A, 2026-05-29): every variant used to be hand-written
+    in the spec sexp, so a combination experiment
+    (["enable_X" in on/off cross "knob" in 0, 0.02, 0.05]) needed 6+
+    hand-written cells. This lets the spec declare the axes and have them
+    expand. The 2026-05-29 hysteresis rejection exposed the deeper problem: we
+    tested one *point*, never a *surface*.
+
+    Hardening (plan Gap B): every generated override is validated against the
+    canonical default {!Weinstein_strategy.config} via
+    [Overlay_validator.apply_overrides] *at expansion time*, so a typo'd axis
+    key raises [Failure] loudly rather than silently producing a no-op cell that
+    yields bit-identical metrics (the 2026-05-12 81-cell bug class). *)
+
+open Core
+
+(** On-disk an axis is a record (not a variant tag), with exactly one of [key] /
+    [flag] alongside [values]:
+    {[
+    ((key (stage3_force_exit_config hysteresis_weeks)) (values (1 2 3)))
+      ((flag enable_laggard_rotation) (values (true false)))
+    ]}
+    [key]'s value is the dotted key-path as a flat sexp list; [flag]'s value is
+    a single atom. *)
+type axis =
+  | Key of { path : string list; values : Sexp.t list }
+      (** A config key-path axis. [path = [a; b]] with value [v] generates the
+          partial-config override sexp [((a ((b v))))]; a single-component path
+          [[a]] generates [((a v))]. [values] are arbitrary sexp atoms
+          (int/float/bool/string). *)
+  | Flag of { name : string; values : Sexp.t list }
+      (** Sugar for a single-component {!Key} axis: [Flag { name; values }] is
+          exactly [Key { path = [ name ]; values }]. Reads naturally for the
+          [enable_*] boolean toggles. *)
+[@@deriving sexp]
+
+type expansion =
+  | Cartesian  (** Full cartesian product of all axis values. *)
+  | Sampled of { n : int; seed : int }
+      (** Deterministic seeded subset of [n] cells drawn (without replacement)
+          from the full cartesian product, using a {!Core.Random.State.t} seeded
+          by [seed] — no global [Random] state is touched. If
+          [n >= product_size], falls back to the full cartesian product. *)
+[@@deriving sexp]
+
+type t = { axes : axis list; expansion : expansion } [@@deriving sexp]
+(** An axis declaration block. [axes] are expanded according to [expansion]. *)
+
+val expand : t -> Walk_forward_runner.variant list
+(** [expand t] = the generated variant list.
+
+    - [Cartesian]: one variant per cell of the full cartesian product, in
+      lexicographic axis order (first axis varies slowest).
+    - [Sampled { n; seed }]: a deterministic subset of [n] distinct cells; same
+      [seed] gives the same cells and the same labels. Falls back to the full
+      cartesian product when [n] is at least the product size.
+
+    Each generated variant:
+    - [label] = a deterministic compact join of [key=value] pairs joined by
+      ["__"], e.g. ["hysteresis_weeks=2__enable_laggard_rotation=false"]. The
+      key segment is the last component of the axis key-path (the flag/leaf
+      name).
+    - [overrides] = one partial-config sexp per axis (see {!axis}).
+
+    Raises [Failure] if any generated override fails
+    [Overlay_validator.apply_overrides] against the canonical default config —
+    i.e. an axis key-path that does not resolve to a real config field.
+    Validation happens once per (axis, value) pair (cheaper than per full cell,
+    same guarantee). Also raises [Failure] if [axes] is empty. *)

--- a/trading/trading/backtest/walk_forward/test/dune
+++ b/trading/trading/backtest/walk_forward/test/dune
@@ -5,7 +5,8 @@
   test_walk_forward_runner
   test_walk_forward_report
   test_walk_forward_executor_parallel
-  test_spec)
+  test_spec
+  test_variant_matrix)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/walk_forward/test/test_spec.ml
+++ b/trading/trading/backtest/walk_forward/test/test_spec.ml
@@ -302,6 +302,30 @@ let test_axes_bad_key_raises_on_load _ =
   in
   assert_that raised (equal_to true)
 
+(* A label collision must fail at load (Spec.load's [_check_unique_labels]
+   fail-loud contract, qc-behavioral CP1/CP4). Here an explicit variant labeled
+   "base" collides with the auto-injected baseline cell (label = baseline_label
+   "base"). *)
+let _colliding_label_spec =
+  {|
+((base_scenario "stub.sexp")
+ (window_spec (Explicit (((name f0) (train_period ()) (test_period ((start_date 2020-01-01) (end_date 2020-12-31)))))))
+ (variants (((label "base") (overrides ()))))
+ (baseline_label "base")
+ (gate ((metric Sharpe) (m 1) (n 1) (worst_delta 1.0)))
+ (axes ((axes (((flag enable_laggard_rotation) (values (true false))))) (expansion Cartesian))))
+|}
+
+let test_axes_label_collision_raises_on_load _ =
+  let path = _write_temp_spec _colliding_label_spec in
+  let raised =
+    try
+      ignore (Spec.load path);
+      false
+    with Failure _ -> true
+  in
+  assert_that raised (equal_to true)
+
 (* Backward-compat: an axes-absent spec resolves to its hand-written variants
    verbatim (no baseline injected, no reordering). *)
 let test_no_axes_is_backward_compatible _ =
@@ -341,6 +365,8 @@ let suite =
          "explicit variants + axes concatenate"
          >:: test_explicit_plus_axes_concatenates;
          "axes bad key raises on load" >:: test_axes_bad_key_raises_on_load;
+         "axes label collision raises on load"
+         >:: test_axes_label_collision_raises_on_load;
          "no-axes spec is backward-compatible"
          >:: test_no_axes_is_backward_compatible;
        ]

--- a/trading/trading/backtest/walk_forward/test/test_spec.ml
+++ b/trading/trading/backtest/walk_forward/test/test_spec.ml
@@ -227,6 +227,88 @@ let test_hysteresis_gate_n_matches_generated_fold_count _ =
   let generated = List.length (WS.generate spec.window_spec) in
   assert_that generated (all_of [ equal_to 31; equal_to spec.gate.n ])
 
+(* ---------- axes -> variants expansion on load (plan Gap A) ---------- *)
+
+(* Write [contents] to a fresh temp file and return its path. The spec [load]
+   path only reads the file, so a throwaway temp file is the simplest fixture. *)
+let _write_temp_spec contents =
+  let path = Stdlib.Filename.temp_file "wf_spec_axes" ".sexp" in
+  Out_channel.write_all path ~data:contents;
+  path
+
+let _variant_labels (spec : Spec.t) =
+  List.map spec.variants
+    ~f:(fun (v : Walk_forward.Walk_forward_runner.variant) -> v.label)
+
+(* axes-only: resolved variants = auto-baseline first, then the 2-cell matrix. *)
+let _axes_only_spec =
+  {|
+((base_scenario "stub.sexp")
+ (window_spec (Explicit (((name f0) (train_period ()) (test_period ((start_date 2020-01-01) (end_date 2020-12-31)))))))
+ (baseline_label "base")
+ (gate ((metric Sharpe) (m 1) (n 1) (worst_delta 1.0)))
+ (axes ((axes (((key (stage3_exit_margin_pct)) (values (0.0 0.02))))) (expansion Cartesian))))
+|}
+
+let test_axes_only_expands_with_baseline _ =
+  let spec = Spec.load (_write_temp_spec _axes_only_spec) in
+  assert_that (_variant_labels spec)
+    (elements_are
+       [
+         equal_to "base";
+         equal_to "stage3_exit_margin_pct=0.0";
+         equal_to "stage3_exit_margin_pct=0.02";
+       ])
+
+(* explicit variants + axes: explicit first, then baseline, then matrix. *)
+let _explicit_plus_axes_spec =
+  {|
+((base_scenario "stub.sexp")
+ (window_spec (Explicit (((name f0) (train_period ()) (test_period ((start_date 2020-01-01) (end_date 2020-12-31)))))))
+ (variants (((label "hand") (overrides ()))))
+ (baseline_label "base")
+ (gate ((metric Sharpe) (m 1) (n 1) (worst_delta 1.0)))
+ (axes ((axes (((flag enable_laggard_rotation) (values (true false))))) (expansion Cartesian))))
+|}
+
+let test_explicit_plus_axes_concatenates _ =
+  let spec = Spec.load (_write_temp_spec _explicit_plus_axes_spec) in
+  assert_that (_variant_labels spec)
+    (elements_are
+       [
+         equal_to "hand";
+         equal_to "base";
+         equal_to "enable_laggard_rotation=true";
+         equal_to "enable_laggard_rotation=false";
+       ])
+
+(* A typo'd axis key must fail at load (expansion-time validation, Gap B). *)
+let _bad_axis_spec =
+  {|
+((base_scenario "stub.sexp")
+ (window_spec (Explicit (((name f0) (train_period ()) (test_period ((start_date 2020-01-01) (end_date 2020-12-31)))))))
+ (baseline_label "base")
+ (gate ((metric Sharpe) (m 1) (n 1) (worst_delta 1.0)))
+ (axes ((axes (((key (not_a_real_config_key)) (values (1))))) (expansion Cartesian))))
+|}
+
+let test_axes_bad_key_raises_on_load _ =
+  let path = _write_temp_spec _bad_axis_spec in
+  let raised =
+    try
+      ignore (Spec.load path);
+      false
+    with Failure _ -> true
+  in
+  assert_that raised (equal_to true)
+
+(* Backward-compat: an axes-absent spec resolves to its hand-written variants
+   verbatim (no baseline injected, no reordering). *)
+let test_no_axes_is_backward_compatible _ =
+  let spec = Spec.load (_fixture_path "cell_e_8fold_2026_05_08.sexp") in
+  assert_that (_variant_labels spec)
+    (elements_are [ equal_to "cell-A"; equal_to "cell-E" ])
+
 let suite =
   "Walk_forward_spec"
   >::: [
@@ -254,6 +336,13 @@ let suite =
          >:: test_hysteresis_variants_are_h1m0_and_h2m02;
          "hysteresis gate.n matches generated fold count (31)"
          >:: test_hysteresis_gate_n_matches_generated_fold_count;
+         "axes-only expands with auto-baseline"
+         >:: test_axes_only_expands_with_baseline;
+         "explicit variants + axes concatenate"
+         >:: test_explicit_plus_axes_concatenates;
+         "axes bad key raises on load" >:: test_axes_bad_key_raises_on_load;
+         "no-axes spec is backward-compatible"
+         >:: test_no_axes_is_backward_compatible;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
+++ b/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
@@ -1,0 +1,205 @@
+(** Unit tests for {!Walk_forward.Variant_matrix}.
+
+    Pins the expansion contract: cartesian cell count, deterministic seeded
+    sampling, exact labels + override sexps for a small known matrix, and the
+    expansion-time validation that turns a typo'd axis key into a loud [Failure]
+    rather than a silent no-op cell. *)
+
+open OUnit2
+open Core
+open Matchers
+module VM = Walk_forward.Variant_matrix
+module WFR = Walk_forward.Walk_forward_runner
+
+(* Real config key-paths so [Overlay_validator] accepts the generated overrides.
+   [stage3_exit_margin_pct] is a top-level float field; [hysteresis_weeks] lives
+   under [stage3_force_exit_config]; [enable_laggard_rotation] is a top-level
+   bool flag. *)
+let _margin_axis =
+  VM.Key
+    {
+      path = [ "stage3_exit_margin_pct" ];
+      values = Sexp.[ Atom "0.0"; Atom "0.02" ];
+    }
+
+let _hysteresis_axis =
+  VM.Key
+    {
+      path = [ "stage3_force_exit_config"; "hysteresis_weeks" ];
+      values = Sexp.[ Atom "1"; Atom "2"; Atom "3" ];
+    }
+
+let _laggard_axis =
+  VM.Flag
+    {
+      name = "enable_laggard_rotation";
+      values = Sexp.[ Atom "true"; Atom "false" ];
+    }
+
+(* Catch a [Failure] from [thunk]; returns [true] iff one was raised. *)
+let _raises_failure thunk =
+  try
+    ignore (thunk ());
+    false
+  with Failure _ -> true
+
+(* ---------- Cartesian count = product of axis sizes ---------- *)
+
+let test_cartesian_count_is_product _ =
+  let t =
+    { VM.axes = [ _hysteresis_axis; _laggard_axis ]; expansion = VM.Cartesian }
+  in
+  (* 3 hysteresis values * 2 laggard values = 6 cells. *)
+  assert_that (List.length (VM.expand t)) (equal_to 6)
+
+let test_single_axis_cartesian_count _ =
+  let t = { VM.axes = [ _hysteresis_axis ]; expansion = VM.Cartesian } in
+  assert_that (List.length (VM.expand t)) (equal_to 3)
+
+(* ---------- Exact labels + overrides for a known small matrix ---------- *)
+
+let test_known_matrix_labels_and_overrides _ =
+  let t =
+    { VM.axes = [ _hysteresis_axis; _laggard_axis ]; expansion = VM.Cartesian }
+  in
+  (* First axis varies slowest: (h=1,lr=true),(h=1,lr=false),(h=2,lr=true),... *)
+  assert_that (VM.expand t)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (v : WFR.variant) -> v.label)
+               (equal_to "hysteresis_weeks=1__enable_laggard_rotation=true");
+             field
+               (fun (v : WFR.variant) -> v.overrides)
+               (elements_are
+                  [
+                    equal_to
+                      (Sexp.of_string
+                         "((stage3_force_exit_config ((hysteresis_weeks 1))))");
+                    equal_to (Sexp.of_string "((enable_laggard_rotation true))");
+                  ]);
+           ];
+         field
+           (fun (v : WFR.variant) -> v.label)
+           (equal_to "hysteresis_weeks=1__enable_laggard_rotation=false");
+         field
+           (fun (v : WFR.variant) -> v.label)
+           (equal_to "hysteresis_weeks=2__enable_laggard_rotation=true");
+         field
+           (fun (v : WFR.variant) -> v.label)
+           (equal_to "hysteresis_weeks=2__enable_laggard_rotation=false");
+         field
+           (fun (v : WFR.variant) -> v.label)
+           (equal_to "hysteresis_weeks=3__enable_laggard_rotation=true");
+         field
+           (fun (v : WFR.variant) -> v.label)
+           (equal_to "hysteresis_weeks=3__enable_laggard_rotation=false");
+       ])
+
+let test_single_component_override_shape _ =
+  let t = { VM.axes = [ _margin_axis ]; expansion = VM.Cartesian } in
+  assert_that (VM.expand t)
+    (elements_are
+       [
+         field
+           (fun (v : WFR.variant) -> v.overrides)
+           (elements_are
+              [ equal_to (Sexp.of_string "((stage3_exit_margin_pct 0.0))") ]);
+         field
+           (fun (v : WFR.variant) -> v.overrides)
+           (elements_are
+              [ equal_to (Sexp.of_string "((stage3_exit_margin_pct 0.02))") ]);
+       ])
+
+(* ---------- Sampled determinism + fallback ---------- *)
+
+let test_sampled_determinism _ =
+  let t =
+    {
+      VM.axes = [ _hysteresis_axis; _laggard_axis ];
+      expansion = VM.Sampled { n = 3; seed = 7 };
+    }
+  in
+  let labels run =
+    List.map (VM.expand run) ~f:(fun (v : WFR.variant) -> v.label)
+  in
+  (* Same seed -> identical label sequence; size = n. *)
+  assert_that (labels t) (all_of [ size_is 3; equal_to (labels t) ])
+
+let test_sampled_different_seed_differs _ =
+  let mk seed =
+    {
+      VM.axes = [ _hysteresis_axis; _laggard_axis ];
+      expansion = VM.Sampled { n = 2; seed };
+    }
+  in
+  let labels run =
+    List.map (VM.expand run) ~f:(fun (v : WFR.variant) -> v.label)
+    |> List.sort ~compare:String.compare
+  in
+  (* Seeds 1 and 2 draw different 2-subsets of the 6-cell product. *)
+  assert_that
+    (List.equal String.equal (labels (mk 1)) (labels (mk 2)))
+    (equal_to false)
+
+let test_sampled_n_ge_product_is_full_cartesian _ =
+  let t =
+    {
+      VM.axes = [ _hysteresis_axis; _laggard_axis ];
+      (* n (100) >= product size (6) -> full cartesian fallback. *)
+      expansion = VM.Sampled { n = 100; seed = 0 };
+    }
+  in
+  assert_that (List.length (VM.expand t)) (equal_to 6)
+
+(* ---------- Expansion-time validation (the 81-cell guard) ---------- *)
+
+let test_bad_axis_key_raises _ =
+  let bad =
+    VM.Key
+      { path = [ "this_is_not_a_real_config_key" ]; values = Sexp.[ Atom "1" ] }
+  in
+  let t = { VM.axes = [ bad ]; expansion = VM.Cartesian } in
+  assert_that (_raises_failure (fun () -> VM.expand t)) (equal_to true)
+
+let test_bad_nested_key_raises _ =
+  let bad =
+    VM.Key
+      {
+        path = [ "stage3_force_exit_config"; "not_a_field" ];
+        values = Sexp.[ Atom "1" ];
+      }
+  in
+  let t = { VM.axes = [ bad ]; expansion = VM.Cartesian } in
+  assert_that (_raises_failure (fun () -> VM.expand t)) (equal_to true)
+
+let test_empty_axes_raises _ =
+  let t = { VM.axes = []; expansion = VM.Cartesian } in
+  assert_that (_raises_failure (fun () -> VM.expand t)) (equal_to true)
+
+let suite =
+  "Walk_forward_variant_matrix"
+  >::: [
+         "cartesian count = product of axis sizes"
+         >:: test_cartesian_count_is_product;
+         "single-axis cartesian count" >:: test_single_axis_cartesian_count;
+         "known matrix expands to exact labels + overrides"
+         >:: test_known_matrix_labels_and_overrides;
+         "single-component path override shape"
+         >:: test_single_component_override_shape;
+         "sampled determinism (same seed -> same labels)"
+         >:: test_sampled_determinism;
+         "sampled different seed -> different subset"
+         >:: test_sampled_different_seed_differs;
+         "sampled n >= product size falls back to full cartesian"
+         >:: test_sampled_n_ge_product_is_full_cartesian;
+         "bad top-level axis key raises at expansion time"
+         >:: test_bad_axis_key_raises;
+         "bad nested axis key raises at expansion time"
+         >:: test_bad_nested_key_raises;
+         "empty axes raises" >:: test_empty_axes_raises;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

PR-1 of the systematic experiment-platform program (`dev/plans/experiment-platform-2026-05-29.md`, #1368). Adds the **variant-matrix generator** (Gap A) + the **flag-discipline rule doc** (Gap E).

The 2026-05-29 stage3-hysteresis WF-CV rejection exposed the gap: we tested one *point*, never a *surface*. This PR lets a spec declare *axes* that expand into the `variants` list the walk-forward runner already consumes.

### New module: `Walk_forward.Variant_matrix`
`trading/trading/backtest/walk_forward/lib/variant_matrix.{ml,mli}` (pure):

- `type axis = Key of { path; values } | Flag of { name; values }` — a config key-path axis or a flag (sugar for a single-component key-path). On-disk record shape: `((key (a b)) (values (1 2 3)))` / `((flag enable_x) (values (true false)))`.
- `type expansion = Cartesian | Sampled of { n; seed }` — full cartesian product, or a deterministic seeded subset (threads a `Random.State.t`, **no global Random state**; falls back to full cartesian when `n >= product size`).
- `val expand : t -> Walk_forward_runner.variant list`:
  - `label` = compact `leaf=value` join, e.g. `hysteresis_weeks=2__enable_laggard_rotation=false`.
  - `overrides` = one partial-config sexp per axis (`[a;b] + v -> ((a ((b v))))`; `[a] + v -> ((a v))`).
  - **Expansion-time validation:** every generated override runs through `Overlay_validator.apply_overrides` against the canonical default config, so a typo'd axis key raises `Failure` AT EXPANSION TIME (the 2026-05-12 81-cell silent-no-op bug class). Validated once per (axis, value) — cheaper than per cell, same guarantee.

### `Walk_forward.Spec` axes wiring
`spec.{ml,mli}`: optional `axes` field (`[@sexp.option]`, record keeps `[@@sexp.allow_extra_fields]`). On `load`, if `axes` present: explicit `variants` first (if any), then the auto-baseline cell (empty-override, label from `baseline_label`), then the expanded matrix; de-duped by label (raises on collision). Axes-absent specs behave exactly as before.

### Flag-discipline rule (Gap E)
`.claude/rules/experiment-flag-discipline.md`: every new strategy mechanism lands default-off (or no-op default), becomes an experiment axis the day it lands, and is wired into the default config only after an ACCEPT verdict in the ledger. Includes mechanical QC checks (R1–R3).

## Integration decision

The public `Spec.t` is **unchanged** (still 5 fields; `variants` = the *resolved* list). `axes` is a parse-time concern handled by a private `_raw` record — so the `Spec.t` constructor surface and every downstream consumer (runner, executor, report) stay untouched, and the existing `_make_spec` test constructor still compiles. Expansion-time validation uses `Weinstein_strategy.default_config ~universe:["AAPL"] ~index_symbol:"GSPC.INDX"` — the universe is irrelevant to override key-resolution, so a single placeholder symbol suffices (no cheap-universe dependency needed). The axis `of_sexp`/`sexp_of` are hand-written (not ppx-derived) to match the plan's record-shaped on-disk syntax rather than the ppx variant-tag form.

## Test plan

`test_variant_matrix.ml` (10 tests): cartesian count = product of axis sizes; single-axis count; known 2×3 matrix expands to exact labels + override sexps (`elements_are`); single-component override shape; sampled determinism (same seed → same labels); different seed → different subset; `n >= product` → full-cartesian fallback; bad top-level key raises; bad nested key raises; empty axes raises.

`test_spec.ml` (+4, 19 total): axes-only expands with auto-baseline; explicit variants + axes concatenate (explicit, baseline, matrix); axes bad key raises on load; no-axes spec is backward-compatible. All 15 legacy spec tests unchanged.

Verify (docker):
```
docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune build @fmt && dune build && dune runtest backtest/walk_forward/'
```
All walk_forward tests green; `dune build @fmt` clean; zero warnings.

## Scope

Matrix generator + spec wiring + rule doc only. Ledger (PR-2) and DSR ranking (PR-3) are follow-ups. WF runner / gate / report reused unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
