### PR TITLE
feat(experiment-platform): matrix-aware ranking + Deflated Sharpe (PR-3, Gap C)

### DIFF
--- a/dev/status/experiment-platform.md
+++ b/dev/status/experiment-platform.md
@@ -47,6 +47,20 @@ present it prepends the auto-baseline cell then appends the expanded
 matrix (explicit `variants`, if any, kept first). De-dups by label.
 Axes-absent specs parse 100% backward-compatibly.
 
+`Backtest_stats` + `Walk_forward.Variant_ranking` surface (PR-3):
+- `Backtest_stats.Normal_dist` — `cdf` / `inv_cdf` (Gaussian CDF and
+  quantile via `Owl.Maths.erf` / `erfinv`).
+- `Backtest_stats.Deflated_sharpe` — `psr` (Probabilistic Sharpe),
+  `expected_max_sharpe` (best-of-N benchmark SR*), `deflated_sharpe`
+  (PSR at that benchmark), plus `skewness` / `kurtosis` population
+  moment helpers. Pure; shared with the BO tuner (new `backtest_stats`
+  lib, deps `core` / `owl` only — no heavy `backtest` coupling).
+- `Walk_forward.Variant_ranking` — `dominates` (Pareto over Sharpe up /
+  Calmar up / MaxDD% down), `rank` (frontier + `dominated_by` per
+  variant over `Walk_forward_types.variant_stability`), `render`
+  (deterministic markdown frontier + per-variant table with a Deflated
+  Sharpe column passed in by the caller).
+
 ## Work
 
 ### Gap A — Variant-matrix generator (PR-1)
@@ -91,20 +105,47 @@ Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && 
 (9/9 tests: round-trip, config-hash equal/differ/stable, append-only raise,
 build_index, lookup hit/miss, load_index round-trip).
 
+### Gap C — Matrix-aware ranking + Deflated Sharpe (PR-3)
+- [x] **`Backtest_stats.Deflated_sharpe`** + **`Backtest_stats.Normal_dist`**
+  — pure Bailey & López de Prado closed form. New `backtest_stats` lib at
+  `trading/trading/backtest/stats/lib/{deflated_sharpe,normal_dist}.{ml,mli}`
+  (deps `core` / `owl` only, so both this matrix path and the BO tuner can
+  reuse it without pulling the heavy `backtest` lib). No prior DSR existed
+  in-repo (grep clean); `Normal_dist` wraps `Owl.Maths.erf` / `erfinv` for
+  Φ / Φ⁻¹. Pinned reference values: PSR(SR̂=0.5, T=24, normal, SR*=0)=
+  0.9881134547; PSR(…SR*=0.3)=0.8170846532; PSR(SR̂=0.8, T=36, γ3=−0.5,
+  γ4=4, SR*=0.2)=0.9951851034; expected_max_sharpe(N=12, var=0.04)=
+  0.3329622776; end-to-end DSR(obs=0.5, folds=[1..5], N=12, var=0.04)=
+  0.6281656469. Φ(1.96)≈0.975, Φ⁻¹(0.975)≈1.96. Degenerate guards
+  (n_obs<2, n_trials<2, zero variance) raise `Invalid_argument` and are
+  pinned.
+- [x] **`Walk_forward.Variant_ranking`** — Pareto dominance over (Sharpe ↑,
+  Calmar ↑, MaxDD% ↓) reusing the emitted
+  `Walk_forward_types.variant_stability`. `rank` returns per-variant
+  `{ label; stability; on_frontier; dominated_by }` + the frontier set;
+  `render` is a deterministic markdown frontier + per-variant table with a
+  Deflated-Sharpe column (DSR passed in by the caller, so the ranking lib
+  stays decoupled from `backtest_stats`). At
+  `trading/trading/backtest/walk_forward/lib/variant_ranking.{ml,mli}`.
+
+Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && dune build && dune exec trading/backtest/stats/test/test_normal_dist.exe && dune exec trading/backtest/stats/test/test_deflated_sharpe.exe && dune exec trading/backtest/walk_forward/test/test_variant_ranking.exe'`
+(normal_dist 5/5; deflated_sharpe 12/12; variant_ranking 6/6).
+
 ## Next Steps
 
-1. **PR-3 — Matrix ranking + Deflated Sharpe**: cross-variant best-of-N
-   correction on top of `Fold_gate`; Pareto rank over (Sharpe, MaxDD,
-   Calmar). Shares the DSR module with the BO program.
-2. **Skill (Gap F)** — now unblocked (PR-1 + PR-2 give it the matrix
-   generator and the ledger lookup); build after PR-3.
-3. **First real use** — re-attack the autopsy missed-gain (modes 1+2) as
+1. **Skill (Gap F)** — now unblocked (PR-1 + PR-2 + PR-3 give it the
+   matrix generator, the ledger lookup, and the DSR ranking); build next.
+2. **First real use** — re-attack the autopsy missed-gain (modes 1+2) as
    a surface: hysteresis_weeks grid × exit_margin grid × relevant
    `enable_*` flags through WF-CV, ranked with DSR.
+3. **Wire DSR into the BO tuner** — the `backtest_stats` lib is shared;
+   the BO program can adopt `Deflated_sharpe` for its own best-of-N
+   correction (deferred to that program).
 
-## Out of scope (PR-2)
+## Out of scope (PR-3)
 
-- DSR ranking (PR-3), the skill (Gap F).
+- The skill (Gap F).
+- Wiring `Variant_ranking` / `Deflated_sharpe` into the WF runner or the
+  BO tuner (this PR ships the pure libs + tests only).
 - Any change to the WF runner / gate / report (reused unchanged).
-- Ledger-consuming dedup wiring into the WF runner / skill (PR-3 + skill).
 - Promotion automation (stays manual, ledger-backed).

--- a/trading/trading/backtest/stats/lib/deflated_sharpe.ml
+++ b/trading/trading/backtest/stats/lib/deflated_sharpe.ml
@@ -2,6 +2,11 @@ open Core
 
 let euler_mascheroni = 0.5772156649
 
+(* The PSR variance-adjustment term is ((kurtosis - 1) / 4) * SR^2 — the 4 is the
+   Bailey/Lopez de Prado denominator on the excess-kurtosis correction. Named to
+   keep it out of the bare-literal linter and document its origin. *)
+let psr_kurtosis_divisor = 4.0
+
 (* Population central moments of [xs]: mean and the k-th standardised moment.
    Divisor is [n] (population), matching the Bailey/Lopez de Prado convention
    for the skew/kurtosis adjustment terms. *)
@@ -29,7 +34,8 @@ let psr ~observed_sharpe ~benchmark_sharpe ~n_obs ~skewness ~kurtosis =
       (Printf.sprintf "Deflated_sharpe.psr: n_obs must be >= 2, got %d" n_obs);
   let sr = observed_sharpe in
   let variance_term =
-    1.0 -. (skewness *. sr) +. ((kurtosis -. 1.0) /. 4.0 *. sr *. sr)
+    1.0 -. (skewness *. sr)
+    +. ((kurtosis -. 1.0) /. psr_kurtosis_divisor *. sr *. sr)
   in
   if Float.(variance_term <= 0.0) then
     invalid_arg

--- a/trading/trading/backtest/stats/lib/deflated_sharpe.ml
+++ b/trading/trading/backtest/stats/lib/deflated_sharpe.ml
@@ -1,0 +1,73 @@
+open Core
+
+let euler_mascheroni = 0.5772156649
+
+(* Population central moments of [xs]: mean and the k-th standardised moment.
+   Divisor is [n] (population), matching the Bailey/Lopez de Prado convention
+   for the skew/kurtosis adjustment terms. *)
+let _standardised_moment xs ~order =
+  let n = List.length xs in
+  if n < 2 then
+    invalid_arg
+      (Printf.sprintf "Deflated_sharpe: need at least 2 observations, got %d" n);
+  let nf = Float.of_int n in
+  let mean = List.sum (module Float) xs ~f:Fn.id /. nf in
+  let variance =
+    List.sum (module Float) xs ~f:(fun x -> (x -. mean) ** 2.0) /. nf
+  in
+  if Float.(variance <= 0.0) then
+    invalid_arg "Deflated_sharpe: zero variance, higher moment undefined";
+  let stdev = Float.sqrt variance in
+  List.sum (module Float) xs ~f:(fun x -> ((x -. mean) /. stdev) ** order) /. nf
+
+let skewness xs = _standardised_moment xs ~order:3.0
+let kurtosis xs = _standardised_moment xs ~order:4.0
+
+let psr ~observed_sharpe ~benchmark_sharpe ~n_obs ~skewness ~kurtosis =
+  if n_obs < 2 then
+    invalid_arg
+      (Printf.sprintf "Deflated_sharpe.psr: n_obs must be >= 2, got %d" n_obs);
+  let sr = observed_sharpe in
+  let variance_term =
+    1.0 -. (skewness *. sr) +. ((kurtosis -. 1.0) /. 4.0 *. sr *. sr)
+  in
+  if Float.(variance_term <= 0.0) then
+    invalid_arg
+      (Printf.sprintf
+         "Deflated_sharpe.psr: non-positive variance term %.17g (degenerate \
+          higher moments)"
+         variance_term);
+  let z =
+    (sr -. benchmark_sharpe)
+    *. Float.sqrt (Float.of_int n_obs -. 1.0)
+    /. Float.sqrt variance_term
+  in
+  Normal_dist.cdf z
+
+let expected_max_sharpe ~n_trials ~sharpe_variance =
+  if n_trials < 2 then
+    invalid_arg
+      (Printf.sprintf
+         "Deflated_sharpe.expected_max_sharpe: n_trials must be >= 2, got %d"
+         n_trials);
+  if Float.(sharpe_variance < 0.0) then
+    invalid_arg
+      (Printf.sprintf
+         "Deflated_sharpe.expected_max_sharpe: sharpe_variance must be >= 0, \
+          got %.17g"
+         sharpe_variance);
+  let nf = Float.of_int n_trials in
+  let g = euler_mascheroni in
+  let term1 = (1.0 -. g) *. Normal_dist.inv_cdf (1.0 -. (1.0 /. nf)) in
+  let term2 =
+    g *. Normal_dist.inv_cdf (1.0 -. (1.0 /. (nf *. Float.exp 1.0)))
+  in
+  Float.sqrt sharpe_variance *. (term1 +. term2)
+
+let deflated_sharpe ~observed_sharpe ~fold_returns ~n_trials
+    ~sharpe_variance_across_trials =
+  let benchmark_sharpe =
+    expected_max_sharpe ~n_trials ~sharpe_variance:sharpe_variance_across_trials
+  in
+  psr ~observed_sharpe ~benchmark_sharpe ~n_obs:(List.length fold_returns)
+    ~skewness:(skewness fold_returns) ~kurtosis:(kurtosis fold_returns)

--- a/trading/trading/backtest/stats/lib/deflated_sharpe.mli
+++ b/trading/trading/backtest/stats/lib/deflated_sharpe.mli
@@ -1,0 +1,97 @@
+(** Deflated Sharpe Ratio (Bailey and Lopez de Prado).
+
+    When the "best" variant is picked out of N trials, its observed Sharpe is
+    inflated by selection: the maximum of N noisy estimates exceeds the true
+    common mean even if every variant has zero edge. The Deflated Sharpe Ratio
+    (DSR) corrects this by testing the winner's Sharpe against the Sharpe a
+    best-of-N search would produce under the null of no skill.
+
+    Two closed forms are composed:
+
+    - {!psr} — the Probabilistic Sharpe Ratio PSR(SR_star): the probability that
+      the true Sharpe exceeds a benchmark SR_star, accounting for the higher
+      moments (skew, kurtosis) of the return series and the sample length T.
+    - {!expected_max_sharpe} — the benchmark SR_star itself: the expected
+      maximum Sharpe across N independent trials under the null.
+
+    {!deflated_sharpe} is [psr] evaluated at the SR_star from
+    {!expected_max_sharpe}, i.e. the probability the winner's Sharpe is real
+    after deflating for best-of-N. DSR and PSR return probabilities in the unit
+    interval; {!expected_max_sharpe} returns a Sharpe level.
+
+    Reference: Bailey and Lopez de Prado, "The Deflated Sharpe Ratio: Correcting
+    for Selection Bias, Backtest Overfitting and Non-Normality" (2014). Gap C of
+    [dev/plans/experiment-platform-2026-05-29.md]; shared with the Bayesian
+    optimizer's best-of-N correction. *)
+
+val euler_mascheroni : float
+(** The Euler-Mascheroni constant gamma (approximately [0.5772156649]), used by
+    {!expected_max_sharpe}. *)
+
+val skewness : float list -> float
+(** [skewness xs] is the population skewness gamma3 of [xs] (the third
+    standardised moment, divisor [n] not [n - 1]). Raises [Invalid_argument] if
+    [xs] has fewer than 2 elements or zero variance (skewness undefined). *)
+
+val kurtosis : float list -> float
+(** [kurtosis xs] is the population (non-excess) kurtosis gamma4 of [xs] (the
+    fourth standardised moment; equals [3.0] for a normal sample). Raises
+    [Invalid_argument] if [xs] has fewer than 2 elements or zero variance. *)
+
+val psr :
+  observed_sharpe:float ->
+  benchmark_sharpe:float ->
+  n_obs:int ->
+  skewness:float ->
+  kurtosis:float ->
+  float
+(** [psr ~observed_sharpe ~benchmark_sharpe ~n_obs ~skewness ~kurtosis] is the
+    Probabilistic Sharpe Ratio. With [observed_sharpe = s],
+    [benchmark_sharpe = b], [n_obs = t], [skewness = g3], [kurtosis = g4], it is
+
+    [Normal_dist.cdf ((s -. b) *. sqrt (t - 1) /. sqrt (1 -. g3 *. s +. (g4 - 1)
+     /. 4 *. s *. s))].
+
+    [kurtosis] is the non-excess kurtosis ([3.0] for a normal sample). Raises
+    [Invalid_argument] if [n_obs < 2] (the [sqrt (t - 1)] term needs at least 2
+    observations) or if the variance term under the square root is non-positive
+    (a degenerate higher-moment combination). *)
+
+val expected_max_sharpe : n_trials:int -> sharpe_variance:float -> float
+(** [expected_max_sharpe ~n_trials ~sharpe_variance] is the expected maximum
+    Sharpe across [n_trials] independent trials under the null of no skill. With
+    [n_trials = n] and [sharpe_variance = v] it is
+
+    [sqrt v *. ((1 -. gamma) *. Normal_dist.inv_cdf (1 -. 1 /. n) +. gamma *.
+     Normal_dist.inv_cdf (1 -. 1 /. (n *. e)))]
+
+    where [gamma] is {!euler_mascheroni} and [v] is the variance of the Sharpe
+    estimates across the [n_trials] trials. This is the SR_star benchmark
+    {!deflated_sharpe} deflates against. Raises [Invalid_argument] if
+    [n_trials < 2] (best-of-N is only meaningful for at least 2 trials; with one
+    trial there is no selection to correct) or if [sharpe_variance < 0]. *)
+
+val deflated_sharpe :
+  observed_sharpe:float ->
+  fold_returns:float list ->
+  n_trials:int ->
+  sharpe_variance_across_trials:float ->
+  float
+(** [deflated_sharpe ~observed_sharpe ~fold_returns ~n_trials
+     ~sharpe_variance_across_trials] is the Deflated Sharpe Ratio: the
+    probability the winner's Sharpe is real after correcting for best-of-N
+    selection.
+
+    - [observed_sharpe] — the winning variant's observed Sharpe.
+    - [fold_returns] — the per-observation (per-fold) return series the Sharpe
+      was estimated from; its length is the [n_obs] for {!psr}, and its skewness
+      / kurtosis feed the non-normality adjustment.
+    - [n_trials] — the number of variants the winner was selected from.
+    - [sharpe_variance_across_trials] — the variance of the Sharpe estimates
+      across the trials, feeding {!expected_max_sharpe}.
+
+    Equivalent to {!psr} with [benchmark_sharpe] taken from
+    {!expected_max_sharpe}, [n_obs] the length of [fold_returns], and the
+    moments taken from [fold_returns]. Raises [Invalid_argument] under the same
+    conditions as {!psr} and {!expected_max_sharpe} (in particular
+    [n_trials < 2], fewer than 2 fold returns, or zero fold-return variance). *)

--- a/trading/trading/backtest/stats/lib/dune
+++ b/trading/trading/backtest/stats/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name backtest_stats)
+ (libraries core owl)
+ (preprocess
+  (pps ppx_let ppx_sexp_conv ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/stats/lib/normal_dist.ml
+++ b/trading/trading/backtest/stats/lib/normal_dist.ml
@@ -1,0 +1,9 @@
+open Core
+
+let cdf z = 0.5 *. (1.0 +. Owl.Maths.erf (z /. Float.sqrt 2.0))
+
+let inv_cdf p =
+  if Float.(p <= 0.0) || Float.(p >= 1.0) then
+    invalid_arg
+      (Printf.sprintf "Normal_dist.inv_cdf: p must be in (0, 1), got %.17g" p);
+  Float.sqrt 2.0 *. Owl.Maths.erfinv ((2.0 *. p) -. 1.0)

--- a/trading/trading/backtest/stats/lib/normal_dist.mli
+++ b/trading/trading/backtest/stats/lib/normal_dist.mli
@@ -1,0 +1,18 @@
+(** Standard normal distribution CDF and its inverse (quantile function).
+
+    Thin wrappers around [Owl.Maths.erf] / [Owl.Maths.erfinv] expressing the
+    Gaussian CDF [Phi] and its inverse [Phi^-1] in the forms the Deflated Sharpe
+    closed form needs. Kept here (rather than inline in {!Deflated_sharpe}) so
+    the two primitives are independently testable against known reference
+    points. *)
+
+val cdf : float -> float
+(** [cdf z] is [Phi(z)], the probability that a standard normal variate is at
+    most [z]. Computed as [0.5 * (1 + erf (z / sqrt 2))]. Monotone increasing,
+    [cdf 0. = 0.5], [cdf neg_infinity = 0.], [cdf infinity = 1.]. *)
+
+val inv_cdf : float -> float
+(** [inv_cdf p] is [Phi^-1(p)], the [p]-quantile of the standard normal.
+    Computed as [sqrt 2 * erfinv (2p - 1)]. Defined for [p] strictly in
+    [(0, 1)]; raises [Invalid_argument] for [p <= 0.] or [p >= 1.] (the quantile
+    is [+/-infinity] there and the callers never need those endpoints). *)

--- a/trading/trading/backtest/stats/test/dune
+++ b/trading/trading/backtest/stats/test/dune
@@ -1,0 +1,3 @@
+(tests
+ (names test_normal_dist test_deflated_sharpe)
+ (libraries ounit2 core matchers backtest_stats))

--- a/trading/trading/backtest/stats/test/test_deflated_sharpe.ml
+++ b/trading/trading/backtest/stats/test/test_deflated_sharpe.ml
@@ -1,0 +1,124 @@
+open OUnit2
+open Matchers
+open Backtest_stats
+
+(* Population moments of a known symmetric series [1;2;3;4;5]: skew 0, non-excess
+   kurtosis 1.7 (platykurtic). Pins the moment helpers against hand-computed
+   values. *)
+let test_skewness_kurtosis_symmetric _ =
+  assert_that
+    (Deflated_sharpe.skewness [ 1.0; 2.0; 3.0; 4.0; 5.0 ])
+    (float_equal ~epsilon:1e-9 0.0);
+  assert_that
+    (Deflated_sharpe.kurtosis [ 1.0; 2.0; 3.0; 4.0; 5.0 ])
+    (float_equal ~epsilon:1e-9 1.7)
+
+(* Left-skewed series [-2;0;1;1]: skew -0.8164965809, kurt 2.0. *)
+let test_skewness_kurtosis_skewed _ =
+  assert_that
+    (Deflated_sharpe.skewness [ -2.0; 0.0; 1.0; 1.0 ])
+    (float_equal ~epsilon:1e-9 (-0.8164965809));
+  assert_that
+    (Deflated_sharpe.kurtosis [ -2.0; 0.0; 1.0; 1.0 ])
+    (float_equal ~epsilon:1e-9 2.0)
+
+let test_moments_reject_short _ =
+  assert_raises
+    (Invalid_argument "Deflated_sharpe: need at least 2 observations, got 1")
+    (fun () -> Deflated_sharpe.skewness [ 1.0 ])
+
+let test_moments_reject_zero_variance _ =
+  assert_raises
+    (Invalid_argument "Deflated_sharpe: zero variance, higher moment undefined")
+    (fun () -> Deflated_sharpe.kurtosis [ 3.0; 3.0; 3.0 ])
+
+(* PSR closed form against hand-computed Bailey/Lopez de Prado values.
+   Fixture A: SR_hat=0.5, SR*=0, T=24, normal (g3=0, g4=3) -> 0.9881134547.
+   Fixture B: same but SR*=0.3 -> 0.8170846532 (higher benchmark, lower prob).
+   Fixture C: non-normal SR_hat=0.8, SR*=0.2, T=36, g3=-0.5, g4=4 ->
+   0.9951851034. *)
+let test_psr_normal_zero_benchmark _ =
+  assert_that
+    (Deflated_sharpe.psr ~observed_sharpe:0.5 ~benchmark_sharpe:0.0 ~n_obs:24
+       ~skewness:0.0 ~kurtosis:3.0)
+    (float_equal ~epsilon:1e-9 0.9881134547)
+
+let test_psr_positive_benchmark _ =
+  assert_that
+    (Deflated_sharpe.psr ~observed_sharpe:0.5 ~benchmark_sharpe:0.3 ~n_obs:24
+       ~skewness:0.0 ~kurtosis:3.0)
+    (float_equal ~epsilon:1e-9 0.8170846532)
+
+let test_psr_non_normal _ =
+  assert_that
+    (Deflated_sharpe.psr ~observed_sharpe:0.8 ~benchmark_sharpe:0.2 ~n_obs:36
+       ~skewness:(-0.5) ~kurtosis:4.0)
+    (float_equal ~epsilon:1e-9 0.9951851034)
+
+let test_psr_rejects_one_obs _ =
+  assert_raises
+    (Invalid_argument "Deflated_sharpe.psr: n_obs must be >= 2, got 1")
+    (fun () ->
+      Deflated_sharpe.psr ~observed_sharpe:0.5 ~benchmark_sharpe:0.0 ~n_obs:1
+        ~skewness:0.0 ~kurtosis:3.0)
+
+(* expected_max_sharpe: N=12, var=0.04 -> 0.3329622776; N=10, var=0.01 ->
+   0.1574598301. *)
+let test_expected_max_sharpe _ =
+  assert_that
+    (Deflated_sharpe.expected_max_sharpe ~n_trials:12 ~sharpe_variance:0.04)
+    (float_equal ~epsilon:1e-9 0.3329622776);
+  assert_that
+    (Deflated_sharpe.expected_max_sharpe ~n_trials:10 ~sharpe_variance:0.01)
+    (float_equal ~epsilon:1e-9 0.1574598301)
+
+(* Best-of-N is undefined with a single trial: there is no selection bias to
+   correct, so the contract raises rather than returning a misleading value. *)
+let test_expected_max_sharpe_rejects_one_trial _ =
+  assert_raises
+    (Invalid_argument
+       "Deflated_sharpe.expected_max_sharpe: n_trials must be >= 2, got 1")
+    (fun () ->
+      Deflated_sharpe.expected_max_sharpe ~n_trials:1 ~sharpe_variance:0.04)
+
+(* End-to-end DSR: observed=0.5, fold_returns [1;2;3;4;5] (T=5, skew 0, kurt
+   1.7), N=12, variance 0.04. The benchmark SR_star is 0.3329622776, then PSR at
+   that benchmark is 0.6281656469. The DSR (0.628) is well below the raw PSR
+   against a zero benchmark (0.988), showing the best-of-12 deflation at work. *)
+let test_deflated_sharpe_end_to_end _ =
+  assert_that
+    (Deflated_sharpe.deflated_sharpe ~observed_sharpe:0.5
+       ~fold_returns:[ 1.0; 2.0; 3.0; 4.0; 5.0 ]
+       ~n_trials:12 ~sharpe_variance_across_trials:0.04)
+    (float_equal ~epsilon:1e-9 0.6281656469)
+
+(* Degenerate guard propagates from the inner moment computation: zero-variance
+   fold returns make skewness/kurtosis undefined. *)
+let test_deflated_sharpe_rejects_zero_variance_folds _ =
+  assert_raises
+    (Invalid_argument "Deflated_sharpe: zero variance, higher moment undefined")
+    (fun () ->
+      Deflated_sharpe.deflated_sharpe ~observed_sharpe:0.5
+        ~fold_returns:[ 2.0; 2.0; 2.0 ] ~n_trials:12
+        ~sharpe_variance_across_trials:0.04)
+
+let suite =
+  "deflated_sharpe"
+  >::: [
+         "skewness_kurtosis_symmetric" >:: test_skewness_kurtosis_symmetric;
+         "skewness_kurtosis_skewed" >:: test_skewness_kurtosis_skewed;
+         "moments_reject_short" >:: test_moments_reject_short;
+         "moments_reject_zero_variance" >:: test_moments_reject_zero_variance;
+         "psr_normal_zero_benchmark" >:: test_psr_normal_zero_benchmark;
+         "psr_positive_benchmark" >:: test_psr_positive_benchmark;
+         "psr_non_normal" >:: test_psr_non_normal;
+         "psr_rejects_one_obs" >:: test_psr_rejects_one_obs;
+         "expected_max_sharpe" >:: test_expected_max_sharpe;
+         "expected_max_sharpe_rejects_one_trial"
+         >:: test_expected_max_sharpe_rejects_one_trial;
+         "deflated_sharpe_end_to_end" >:: test_deflated_sharpe_end_to_end;
+         "deflated_sharpe_rejects_zero_variance_folds"
+         >:: test_deflated_sharpe_rejects_zero_variance_folds;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/stats/test/test_deflated_sharpe.ml
+++ b/trading/trading/backtest/stats/test/test_deflated_sharpe.ml
@@ -102,9 +102,39 @@ let test_deflated_sharpe_rejects_zero_variance_folds _ =
         ~fold_returns:[ 2.0; 2.0; 2.0 ] ~n_trials:12
         ~sharpe_variance_across_trials:0.04)
 
+(* Robust raise-pinning for the float-message guards (the %.17g value makes an
+   exact-message assert_raises brittle). Pins the two documented degenerate
+   raises the PR body claims are covered: psr's non-positive variance term and
+   expected_max_sharpe's negative variance. *)
+let _raises_invalid_arg f =
+  try
+    ignore (f ());
+    false
+  with Invalid_argument _ -> true
+
+(* skewness*sr drives the variance term 1 - skew*sr + ((kurt-1)/4)*sr^2 negative:
+   sr=2, skew=1, kurt=1 -> 1 - 2 + 0 = -1 <= 0 -> raise. *)
+let test_psr_rejects_non_positive_variance_term _ =
+  assert_that
+    (_raises_invalid_arg (fun () ->
+         Deflated_sharpe.psr ~observed_sharpe:2.0 ~benchmark_sharpe:0.0
+           ~n_obs:24 ~skewness:1.0 ~kurtosis:1.0))
+    (equal_to true)
+
+let test_expected_max_sharpe_rejects_negative_variance _ =
+  assert_that
+    (_raises_invalid_arg (fun () ->
+         Deflated_sharpe.expected_max_sharpe ~n_trials:12
+           ~sharpe_variance:(-0.04)))
+    (equal_to true)
+
 let suite =
   "deflated_sharpe"
   >::: [
+         "psr_rejects_non_positive_variance_term"
+         >:: test_psr_rejects_non_positive_variance_term;
+         "expected_max_sharpe_rejects_negative_variance"
+         >:: test_expected_max_sharpe_rejects_negative_variance;
          "skewness_kurtosis_symmetric" >:: test_skewness_kurtosis_symmetric;
          "skewness_kurtosis_skewed" >:: test_skewness_kurtosis_skewed;
          "moments_reject_short" >:: test_moments_reject_short;

--- a/trading/trading/backtest/stats/test/test_normal_dist.ml
+++ b/trading/trading/backtest/stats/test/test_normal_dist.ml
@@ -1,0 +1,46 @@
+open OUnit2
+open Matchers
+open Backtest_stats
+
+(* Reference points: Phi(0) = 0.5, Phi(1.96) ~ 0.975, Phi(-1) ~ 0.158655,
+   Phi(2.326348) ~ 0.99. *)
+let test_cdf_known_points _ =
+  assert_that (Normal_dist.cdf 0.0) (float_equal ~epsilon:1e-9 0.5);
+  assert_that (Normal_dist.cdf 1.96) (float_equal ~epsilon:1e-4 0.975);
+  assert_that (Normal_dist.cdf (-1.0)) (float_equal ~epsilon:1e-5 0.1586553);
+  assert_that (Normal_dist.cdf 2.326348) (float_equal ~epsilon:1e-5 0.99)
+
+(* Phi^-1(0.5) = 0, Phi^-1(0.975) ~ 1.959964, Phi^-1(0.99) ~ 2.326348. *)
+let test_inv_cdf_known_points _ =
+  assert_that (Normal_dist.inv_cdf 0.5) (float_equal ~epsilon:1e-9 0.0);
+  assert_that (Normal_dist.inv_cdf 0.975) (float_equal ~epsilon:1e-5 1.959964);
+  assert_that (Normal_dist.inv_cdf 0.99) (float_equal ~epsilon:1e-5 2.326348)
+
+(* cdf and inv_cdf are inverses on a mid-range probability. *)
+let test_round_trip _ =
+  assert_that
+    (Normal_dist.cdf (Normal_dist.inv_cdf 0.8))
+    (float_equal ~epsilon:1e-9 0.8)
+
+(* inv_cdf is undefined at the open-interval endpoints; the contract raises. *)
+let test_inv_cdf_rejects_zero _ =
+  assert_raises
+    (Invalid_argument "Normal_dist.inv_cdf: p must be in (0, 1), got 0")
+    (fun () -> Normal_dist.inv_cdf 0.0)
+
+let test_inv_cdf_rejects_one _ =
+  assert_raises
+    (Invalid_argument "Normal_dist.inv_cdf: p must be in (0, 1), got 1")
+    (fun () -> Normal_dist.inv_cdf 1.0)
+
+let suite =
+  "normal_dist"
+  >::: [
+         "cdf_known_points" >:: test_cdf_known_points;
+         "inv_cdf_known_points" >:: test_inv_cdf_known_points;
+         "round_trip" >:: test_round_trip;
+         "inv_cdf_rejects_zero" >:: test_inv_cdf_rejects_zero;
+         "inv_cdf_rejects_one" >:: test_inv_cdf_rejects_one;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/walk_forward/lib/variant_ranking.ml
+++ b/trading/trading/backtest/walk_forward/lib/variant_ranking.ml
@@ -38,24 +38,25 @@ let _check_unique_labels stabilities =
     invalid_arg
       "Variant_ranking.rank: duplicate variant label; labels must be unique"
 
+(* Labels of all variants that strictly dominate [s] (excluding [s] itself). *)
+let _dominators stabilities (s : T.variant_stability) =
+  List.filter_map stabilities ~f:(fun (other : T.variant_stability) ->
+      let is_self = String.equal other.variant_label s.variant_label in
+      if (not is_self) && dominates other s then Some other.variant_label
+      else None)
+
+let _rank_one stabilities (s : T.variant_stability) =
+  let dominated_by = _dominators stabilities s in
+  {
+    label = s.variant_label;
+    stability = s;
+    on_frontier = List.is_empty dominated_by;
+    dominated_by;
+  }
+
 let rank stabilities =
   _check_unique_labels stabilities;
-  let variants =
-    List.map stabilities ~f:(fun (s : T.variant_stability) ->
-        let dominated_by =
-          List.filter_map stabilities ~f:(fun (other : T.variant_stability) ->
-              let is_self = String.equal other.variant_label s.variant_label in
-              if (not is_self) && dominates other s then
-                Some other.variant_label
-              else None)
-        in
-        {
-          label = s.variant_label;
-          stability = s;
-          on_frontier = List.is_empty dominated_by;
-          dominated_by;
-        })
-  in
+  let variants = List.map stabilities ~f:(_rank_one stabilities) in
   let frontier =
     List.filter_map variants ~f:(fun v ->
         if v.on_frontier then Some v.label else None)

--- a/trading/trading/backtest/walk_forward/lib/variant_ranking.ml
+++ b/trading/trading/backtest/walk_forward/lib/variant_ranking.ml
@@ -1,0 +1,100 @@
+open Core
+module T = Walk_forward_types
+
+type ranked_variant = {
+  label : string;
+  stability : T.variant_stability;
+  on_frontier : bool;
+  dominated_by : string list;
+}
+[@@deriving sexp]
+
+type ranking = { variants : ranked_variant list; frontier : string list }
+[@@deriving sexp]
+
+(* One objective axis: the mean to compare and whether higher is better. We
+   normalise "lower is better" (MaxDrawdown%) by negating so every axis is a
+   plain "higher is better" comparison. *)
+let _objectives (s : T.variant_stability) =
+  [
+    s.sharpe_ratio.mean; s.calmar_ratio.mean; Float.neg s.max_drawdown_pct.mean;
+  ]
+
+(* [a] is at-least-as-good as [b] on an axis, and strictly-better, ignoring NaN
+   (a NaN on either side is not comparable: never at-least, never strictly). *)
+let _at_least x y = Float.is_finite x && Float.is_finite y && Float.(x >= y)
+let _strictly x y = Float.is_finite x && Float.is_finite y && Float.(x > y)
+
+let dominates (a : T.variant_stability) (b : T.variant_stability) =
+  let axes = List.zip_exn (_objectives a) (_objectives b) in
+  List.for_all axes ~f:(fun (x, y) -> _at_least x y)
+  && List.exists axes ~f:(fun (x, y) -> _strictly x y)
+
+let _check_unique_labels stabilities =
+  let labels =
+    List.map stabilities ~f:(fun (s : T.variant_stability) -> s.variant_label)
+  in
+  if List.contains_dup labels ~compare:String.compare then
+    invalid_arg
+      "Variant_ranking.rank: duplicate variant label; labels must be unique"
+
+let rank stabilities =
+  _check_unique_labels stabilities;
+  let variants =
+    List.map stabilities ~f:(fun (s : T.variant_stability) ->
+        let dominated_by =
+          List.filter_map stabilities ~f:(fun (other : T.variant_stability) ->
+              let is_self = String.equal other.variant_label s.variant_label in
+              if (not is_self) && dominates other s then
+                Some other.variant_label
+              else None)
+        in
+        {
+          label = s.variant_label;
+          stability = s;
+          on_frontier = List.is_empty dominated_by;
+          dominated_by;
+        })
+  in
+  let frontier =
+    List.filter_map variants ~f:(fun v ->
+        if v.on_frontier then Some v.label else None)
+  in
+  { variants; frontier }
+
+let _fmt_dsr deflated_sharpe_by_label label =
+  match List.Assoc.find deflated_sharpe_by_label label ~equal:String.equal with
+  | Some d -> sprintf "%.4f" d
+  | None -> "n/a"
+
+let _variant_row deflated_sharpe_by_label (v : ranked_variant) =
+  let s = v.stability in
+  sprintf "| %s | %.3f | %.3f | %.2f | %s | %s |" v.label s.sharpe_ratio.mean
+    s.calmar_ratio.mean s.max_drawdown_pct.mean
+    (if v.on_frontier then "yes" else "no")
+    (_fmt_dsr deflated_sharpe_by_label v.label)
+
+let render ranking ~deflated_sharpe_by_label =
+  let frontier_section =
+    sprintf "## Pareto frontier (Sharpe up, Calmar up, MaxDD down)\n\n%s"
+      (if List.is_empty ranking.frontier then "_(none)_"
+       else
+         String.concat ~sep:"\n"
+           (List.map ranking.frontier ~f:(fun l -> sprintf "- %s" l)))
+  in
+  let header =
+    "| Variant | Sharpe | Calmar | MaxDD % | Frontier | Deflated Sharpe |\n\
+     |---------|-------:|-------:|--------:|:--------:|----------------:|"
+  in
+  let rows =
+    List.map ranking.variants ~f:(_variant_row deflated_sharpe_by_label)
+  in
+  String.concat ~sep:"\n"
+    [
+      frontier_section;
+      "";
+      "## Variants";
+      "";
+      header;
+      String.concat ~sep:"\n" rows;
+    ]

--- a/trading/trading/backtest/walk_forward/lib/variant_ranking.mli
+++ b/trading/trading/backtest/walk_forward/lib/variant_ranking.mli
@@ -1,0 +1,72 @@
+(** Matrix-aware cross-variant ranking for walk-forward CV results.
+
+    [Fold_gate] is a per-variant go/no-go against ONE baseline. A variant matrix
+    of N cells is N trials, so picking "the best" is a multiple-testing /
+    selection-bias problem. This module adds a cross-variant layer on top of the
+    per-variant gate:
+
+    - {!rank} — Pareto dominance over three objectives (Sharpe up, Calmar up,
+      MaxDrawdown down). Surfaces the non-dominated frontier rather than one
+      blessed scalar, so the operator sees the Sharpe-vs-drawdown trade-off.
+    - {!render} — a deterministic markdown report: a frontier table plus a
+      per-variant table carrying a Deflated-Sharpe column (the best-of-N
+      selection-bias correction from {!Backtest_stats.Deflated_sharpe}).
+
+    Consumes the {!Walk_forward_types.variant_stability} the walk-forward runner
+    already emits in its [aggregate.sexp] — no parallel metric type is invented.
+    Gap C of [dev/plans/experiment-platform-2026-05-29.md]. *)
+
+type ranked_variant = {
+  label : string;
+  stability : Walk_forward_types.variant_stability;
+      (** The variant's cross-fold metric summary, carried through unchanged so
+          the renderer / caller can read every objective without a second
+          lookup. *)
+  on_frontier : bool;
+      (** [true] iff no other variant dominates this one — i.e. it sits on the
+          Pareto frontier. *)
+  dominated_by : string list;
+      (** Labels of the variants that strictly dominate this one (empty iff
+          [on_frontier]). Order follows the input variant order. *)
+}
+[@@deriving sexp]
+(** One variant's place in the cross-variant ranking. *)
+
+type ranking = {
+  variants : ranked_variant list;
+      (** Every input variant, in input order, annotated with its frontier
+          status. *)
+  frontier : string list;
+      (** Labels of the frontier variants, in input order. A convenience
+          projection of [variants] filtered to [on_frontier]. *)
+}
+[@@deriving sexp]
+(** The full cross-variant ranking. *)
+
+val dominates :
+  Walk_forward_types.variant_stability ->
+  Walk_forward_types.variant_stability ->
+  bool
+(** [dominates a b] is [true] iff [a] Pareto-dominates [b] over the three
+    objectives (Sharpe up, Calmar up, MaxDrawdown% down): [a] is at least as
+    good as [b] on all three and strictly better on at least one. Compares the
+    [.mean] of each metric's cross-fold [per_metric_stats]. NaN means on either
+    side are treated as not-comparable on that axis (a NaN never beats and is
+    never beaten), so a variant with a NaN objective can still be dominated via
+    the other two axes but never dominates on the NaN axis. *)
+
+val rank : Walk_forward_types.variant_stability list -> ranking
+(** [rank stabilities] computes the Pareto ranking. For each variant it records
+    whether any other variant dominates it ([on_frontier] = none do) and the
+    labels of those that do ([dominated_by]). Pure and order-stable: the output
+    [variants] follow input order and [frontier] is the input-order subset of
+    non-dominated variants. Raises [Invalid_argument] if two variants share a
+    label (the label is the identity used in [dominated_by] / [frontier]). *)
+
+val render : ranking -> deflated_sharpe_by_label:(string * float) list -> string
+(** [render ranking ~deflated_sharpe_by_label] returns a deterministic markdown
+    report: a frontier section (the non-dominated variants) and a per-variant
+    table with Sharpe / Calmar / MaxDD% means, a frontier marker, and a Deflated
+    Sharpe column looked up from [deflated_sharpe_by_label] (printed as "n/a"
+    when a label is absent — e.g. a single-fold variant for which DSR is
+    undefined). Same inputs produce byte-identical output. *)

--- a/trading/trading/backtest/walk_forward/test/dune
+++ b/trading/trading/backtest/walk_forward/test/dune
@@ -6,7 +6,8 @@
   test_walk_forward_report
   test_walk_forward_executor_parallel
   test_spec
-  test_variant_matrix)
+  test_variant_matrix
+  test_variant_ranking)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/walk_forward/test/test_variant_ranking.ml
+++ b/trading/trading/backtest/walk_forward/test/test_variant_ranking.ml
@@ -1,0 +1,141 @@
+open OUnit2
+open Matchers
+module T = Walk_forward.Walk_forward_types
+module VR = Walk_forward.Variant_ranking
+
+(* Build a [variant_stability] from just the three ranked objectives; the other
+   metric columns (return, cagr, holding) are not part of the Pareto comparison
+   so they get a neutral stat. *)
+let stat mean : T.per_metric_stats =
+  { mean; stdev = 0.0; min = mean; max = mean }
+
+let make_variant ~label ~sharpe ~calmar ~max_dd : T.variant_stability =
+  {
+    variant_label = label;
+    total_return_pct = stat 0.0;
+    sharpe_ratio = stat sharpe;
+    max_drawdown_pct = stat max_dd;
+    calmar_ratio = stat calmar;
+    cagr_pct = stat 0.0;
+    avg_holding_days = stat 0.0;
+  }
+
+(* Four-variant set with a known frontier (objectives: Sharpe up, Calmar up,
+   MaxDD% down):
+     A (1.0, 0.8, 20)  - frontier (best Sharpe)
+     B (0.9, 0.9, 25)  - frontier (best Calmar)
+     C (0.5, 0.4, 30)  - dominated by A, B and D
+     D (0.8, 0.7, 15)  - frontier (best MaxDD)
+   Only C is dominated; the other three trade off on a distinct axis. *)
+let variants =
+  [
+    make_variant ~label:"A" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0;
+    make_variant ~label:"B" ~sharpe:0.9 ~calmar:0.9 ~max_dd:25.0;
+    make_variant ~label:"C" ~sharpe:0.5 ~calmar:0.4 ~max_dd:30.0;
+    make_variant ~label:"D" ~sharpe:0.8 ~calmar:0.7 ~max_dd:15.0;
+  ]
+
+let test_dominates_true _ =
+  (* A strictly dominates C on all three axes. *)
+  assert_that
+    (VR.dominates
+       (make_variant ~label:"A" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0)
+       (make_variant ~label:"C" ~sharpe:0.5 ~calmar:0.4 ~max_dd:30.0))
+    (equal_to true)
+
+let test_dominates_false_tradeoff _ =
+  (* A has higher Sharpe but worse (larger) MaxDD than D, so neither dominates. *)
+  assert_that
+    (VR.dominates
+       (make_variant ~label:"A" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0)
+       (make_variant ~label:"D" ~sharpe:0.8 ~calmar:0.7 ~max_dd:15.0))
+    (equal_to false)
+
+let test_dominates_false_equal _ =
+  (* Equal on every axis: at-least-as-good holds but no strict improvement. *)
+  assert_that
+    (VR.dominates
+       (make_variant ~label:"A" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0)
+       (make_variant ~label:"A2" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0))
+    (equal_to false)
+
+let test_rank_frontier_and_dominators _ =
+  let ranking = VR.rank variants in
+  (* Frontier is A, B, D in input order; C is dominated by all three. *)
+  assert_that ranking.frontier
+    (elements_are [ equal_to "A"; equal_to "B"; equal_to "D" ]);
+  assert_that ranking.variants
+    (elements_are
+       [
+         all_of
+           [
+             field (fun v -> v.VR.label) (equal_to "A");
+             field (fun v -> v.VR.on_frontier) (equal_to true);
+             field (fun v -> v.VR.dominated_by) (elements_are []);
+           ];
+         all_of
+           [
+             field (fun v -> v.VR.label) (equal_to "B");
+             field (fun v -> v.VR.on_frontier) (equal_to true);
+             field (fun v -> v.VR.dominated_by) (elements_are []);
+           ];
+         all_of
+           [
+             field (fun v -> v.VR.label) (equal_to "C");
+             field (fun v -> v.VR.on_frontier) (equal_to false);
+             field
+               (fun v -> v.VR.dominated_by)
+               (elements_are [ equal_to "A"; equal_to "B"; equal_to "D" ]);
+           ];
+         all_of
+           [
+             field (fun v -> v.VR.label) (equal_to "D");
+             field (fun v -> v.VR.on_frontier) (equal_to true);
+             field (fun v -> v.VR.dominated_by) (elements_are []);
+           ];
+       ])
+
+let test_rank_rejects_duplicate_labels _ =
+  assert_raises
+    (Invalid_argument
+       "Variant_ranking.rank: duplicate variant label; labels must be unique")
+    (fun () ->
+      VR.rank
+        [
+          make_variant ~label:"A" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0;
+          make_variant ~label:"A" ~sharpe:0.5 ~calmar:0.4 ~max_dd:30.0;
+        ])
+
+(* Deterministic renderer: pin the exact markdown for the 4-variant set with a
+   DSR provided for A only (so C/B/D show "n/a"). *)
+let test_render_deterministic _ =
+  let ranking = VR.rank variants in
+  let md =
+    VR.render ranking ~deflated_sharpe_by_label:[ ("A", 0.6281656469) ]
+  in
+  assert_that md
+    (equal_to
+       "## Pareto frontier (Sharpe up, Calmar up, MaxDD down)\n\n\
+        - A\n\
+        - B\n\
+        - D\n\n\
+        ## Variants\n\n\
+        | Variant | Sharpe | Calmar | MaxDD % | Frontier | Deflated Sharpe |\n\
+        |---------|-------:|-------:|--------:|:--------:|----------------:|\n\
+        | A | 1.000 | 0.800 | 20.00 | yes | 0.6282 |\n\
+        | B | 0.900 | 0.900 | 25.00 | yes | n/a |\n\
+        | C | 0.500 | 0.400 | 30.00 | no | n/a |\n\
+        | D | 0.800 | 0.700 | 15.00 | yes | n/a |")
+
+let suite =
+  "variant_ranking"
+  >::: [
+         "dominates_true" >:: test_dominates_true;
+         "dominates_false_tradeoff" >:: test_dominates_false_tradeoff;
+         "dominates_false_equal" >:: test_dominates_false_equal;
+         "rank_frontier_and_dominators" >:: test_rank_frontier_and_dominators;
+         "rank_rejects_duplicate_labels" >:: test_rank_rejects_duplicate_labels;
+         "render_deterministic" >:: test_render_deterministic;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

PR-3 (Gap C) of the systematic experiment-platform program: matrix-aware
cross-variant ranking + Deflated Sharpe. `Fold_gate` is variant-vs-ONE-baseline;
a variant MATRIX of N cells is N trials, so picking "the best" is a
multiple-testing / selection-bias problem. This adds (a) Deflated Sharpe to
discount best-of-N, and (b) Pareto ranking over multiple objectives.

Plan: `dev/plans/experiment-platform-2026-05-29.md` §"Gap C". Builds on PR-1
(#1369, variant matrix) + PR-2 (#1371, ledger).

## Module placement decision

New **`backtest_stats`** lib at `trading/trading/backtest/stats/lib/`, deps
`core` + `owl` only. Chosen over putting it in the heavy `backtest` lib (pulls
engine/simulation/weinstein.*) because both the matrix ranking path
(`walk_forward`) AND the BO tuner need DSR, and neither should take a heavy
rebuild dep on a pure-math module. `owl` is needed for `erf` / `erfinv` (Φ /
Φ⁻¹) and the tuner already depends on it.

## Existing DSR?

None. Grep of `trading/` + `analysis/` for `deflated` / `probabilistic_sharpe` /
`psr` came back empty — the BO program's M3 plan named one but never built it.
Implemented fresh.

## What it does

- `Backtest_stats.Normal_dist` — `cdf` (Φ via `0.5*(1+erf(z/√2))`), `inv_cdf`
  (Φ⁻¹ via `√2·erfinv(2p−1)`; raises `Invalid_argument` outside (0,1)).
- `Backtest_stats.Deflated_sharpe` — Bailey & López de Prado closed form:
  `psr` (Probabilistic Sharpe with skew/kurtosis non-normality adjustment),
  `expected_max_sharpe` (best-of-N benchmark SR* using the Euler–Mascheroni
  expected-max formula), `deflated_sharpe` (PSR evaluated at that benchmark),
  plus population `skewness` / `kurtosis` helpers.
- `Walk_forward.Variant_ranking` — `dominates` (Pareto over Sharpe ↑, Calmar ↑,
  MaxDD% ↓, NaN-safe), `rank` (frontier + per-variant `dominated_by` over the
  emitted `Walk_forward_types.variant_stability` — no parallel metric type),
  and a deterministic markdown `render` (frontier list + per-variant table with
  a Deflated-Sharpe column passed in by the caller, keeping the ranking lib
  decoupled from `backtest_stats`).

## Pinned DSR fixture values (the load-bearing correctness claim)

Hand-computed against the closed form, asserted at ε=1e-9:
- PSR(SR̂=0.5, T=24, normal, SR*=0) = 0.9881134547
- PSR(SR̂=0.5, T=24, normal, SR*=0.3) = 0.8170846532
- PSR(SR̂=0.8, T=36, γ3=−0.5, γ4=4, SR*=0.2) = 0.9951851034
- expected_max_sharpe(N=12, var=0.04) = 0.3329622776
- end-to-end DSR(obs=0.5, folds=[1..5], N=12, var=0.04) = 0.6281656469
  (well below the raw PSR-vs-zero of 0.988 — best-of-12 deflation at work)
- Φ(0)=0.5, Φ(1.96)≈0.975, Φ⁻¹(0.975)≈1.96, Φ⁻¹(0.99)≈2.326348

## Test plan

23 tests, all green:
- `test_normal_dist` (5): cdf/inv_cdf at known points, round-trip, inv_cdf
  rejects p≤0 and p≥1.
- `test_deflated_sharpe` (12): skew/kurtosis vs hand values, PSR fixtures
  (×3), expected_max_sharpe (×2), end-to-end DSR, and degenerate guards
  (n_obs<2, n_trials<2, zero-variance moments, zero-variance folds).
- `test_variant_ranking` (6): dominates true/false-tradeoff/false-equal, a
  4-variant set with a known {A,B,D} frontier and C `dominated_by` [A;B;D],
  duplicate-label raise, deterministic renderer snapshot.

Every documented `raise` is pinned (PR-1 lesson). Matchers per
`.claude/rules/test-patterns.md` (one `assert_that`/value, `all_of`/`field`/
`elements_are`, no `List.iter`).

Verify:
```
docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && \
  dune build && \
  dune exec trading/backtest/stats/test/test_normal_dist.exe && \
  dune exec trading/backtest/stats/test/test_deflated_sharpe.exe && \
  dune exec trading/backtest/walk_forward/test/test_variant_ranking.exe && \
  dune runtest devtools/checks'
```

## Out of scope

The skill (Gap F); wiring `Variant_ranking` / `Deflated_sharpe` into the WF
runner or BO tuner (this PR ships the pure libs + tests only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
