### PR TITLE
feat(stage): default-off dual-MA early Stage-2 admission flag

### DIFF
--- a/dev/status/experiment-platform.md
+++ b/dev/status/experiment-platform.md
@@ -142,12 +142,35 @@ Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && 
   hard lessons (autopsy = labeller-not-recommender; test a surface, not a
   point) and the continuous-vs-discrete reframe.
 
+### Gap-closing experiments — landed mechanisms (default-off, awaiting sweep)
+
+- [x] **`late_stage2_admission` Step 1 — dual-MA early Stage-2 admission**
+  (PR #1378, branch `feat/weinstein/early-admission`). Adds default-off
+  `Stage.config.early_admission_ma_period : int option` (`[@sexp.default
+  None]`). When `None` the classifier is bit-identical to today (all 26
+  pre-existing stage golden tests stay green); when `Some fast_p` a fast
+  confirmation SMA of the most recent `fast_p` closes (read self-contained
+  from `get_close`) can promote a would-be Stage1 to Stage2 or prevent a
+  demotion of a prior Stage2 while the fast MA is rising and price is above
+  it — never blocks a slow-MA Stage2, never forces an exit, hands back on
+  rollover. Mechanism extracted into a sibling `Early_admission` module
+  (`compute` + `apply`) to keep `stage.ml` under the file-length limit.
+  Flag-discipline R1/R2 satisfied; **R3 pending** — not wired into any
+  default config, awaits a surface-sweep ACCEPT in the ledger. Targets the
+  autopsy failure mode where the slow 30-week MA admits Stage 2 months late
+  off bear bottoms (Mar 2009 / Mar 2020). Verify: `dune runtest
+  analysis/weinstein/stage/` → 33 tests OK.
+
 ## Next Steps
 
 1. **First real use** — re-attack the autopsy missed-gain (modes 1+2) as
    a surface: hysteresis_weeks grid × exit_margin grid × relevant
    `enable_*` flags through WF-CV, ranked with DSR. This is the canonical
    end-to-end exercise of the whole platform.
+   - **Now also available as an axis:** the early-admission flag (PR #1378)
+     — sweep the `int option` sexp shape `(early_admission_ma_period (13))`
+     vs the `None` baseline through WF-CV to decide whether it earns
+     promotion for the `late_stage2_admission` gap.
 2. **Wire DSR into the BO tuner** — the `backtest_stats` lib is shared;
    the BO program can adopt `Deflated_sharpe` for its own best-of-N
    correction (deferred to that program).

--- a/trading/analysis/weinstein/stage/lib/early_admission.ml
+++ b/trading/analysis/weinstein/stage/lib/early_admission.ml
@@ -33,7 +33,8 @@ let _is_rising ~threshold ~current ~back : bool =
 (** Fast MA rising from [back] to [current] AND price [close] above it — the
     early-admission condition once all three reads are present. *)
 let _admit ~slope_threshold ~current ~back ~close : bool =
-  _is_rising ~threshold:slope_threshold ~current ~back && Float.(close > current)
+  let fast_rising = _is_rising ~threshold:slope_threshold ~current ~back in
+  fast_rising && Float.(close > current)
 
 let compute ~get_close ~early_admission_ma_period ~slope_threshold
     ~slope_lookback : bool =

--- a/trading/analysis/weinstein/stage/lib/early_admission.ml
+++ b/trading/analysis/weinstein/stage/lib/early_admission.ml
@@ -30,20 +30,23 @@ let _is_rising ~threshold ~current ~back : bool =
     let slope_pct = (current -. back) /. Float.abs back in
     Float.(slope_pct > threshold)
 
+(** Fast MA rising from [back] to [current] AND price [close] above it — the
+    early-admission condition once all three reads are present. *)
+let _admit ~slope_threshold ~current ~back ~close : bool =
+  _is_rising ~threshold:slope_threshold ~current ~back && Float.(close > current)
+
 let compute ~get_close ~early_admission_ma_period ~slope_threshold
     ~slope_lookback : bool =
   match early_admission_ma_period with
   | None -> false
   | Some fast_p -> (
-      let fast_now = _fast_ma ~get_close ~period:fast_p ~off:0 in
-      let fast_back = _fast_ma ~get_close ~period:fast_p ~off:slope_lookback in
-      match (fast_now, fast_back, get_close ~week_offset:0) with
+      match
+        ( _fast_ma ~get_close ~period:fast_p ~off:0,
+          _fast_ma ~get_close ~period:fast_p ~off:slope_lookback,
+          get_close ~week_offset:0 )
+      with
       | Some current, Some back, Some close ->
-          let fast_rising =
-            _is_rising ~threshold:slope_threshold ~current ~back
-          in
-          let fast_above = Float.(close > current) in
-          fast_rising && fast_above
+          _admit ~slope_threshold ~current ~back ~close
       | _ -> false)
 
 let apply ~early_admit ~prior_stage ~(standard_stage : stage) : stage =

--- a/trading/analysis/weinstein/stage/lib/early_admission.ml
+++ b/trading/analysis/weinstein/stage/lib/early_admission.ml
@@ -1,0 +1,57 @@
+open Core
+open Weinstein_types
+
+(* Dual-MA early Stage-2 admission (default-off). The fast confirmation MA is a
+   simple moving average of recent closes, read self-contained from the
+   [get_close] callback so no new panel callback is needed. *)
+
+(** Simple moving average of the [period] closes ending [off] weeks back. Reads
+    closes at offsets [off .. off + period - 1] via [get_close]; returns [None]
+    if any one of those closes is missing (insufficient history for a full
+    window). *)
+let _fast_ma ~get_close ~period ~off : float option =
+  let rec loop i sum =
+    if i >= period then Some (sum /. Float.of_int period)
+    else
+      match get_close ~week_offset:(off + i) with
+      | Some c -> loop (i + 1) (sum +. c)
+      | None -> None
+  in
+  if period <= 0 then None else loop 0 0.0
+
+(** Whether the fast MA is rising from [back] to [current]. Mirrors the rising
+    branch of [Stage]'s [_classify_direction]:
+    [slope_pct = (current - back) / |back|], rising iff [slope_pct > threshold],
+    and never rising when [back = 0.0]. Kept local so this module stays
+    independent of [Stage]'s internals. *)
+let _is_rising ~threshold ~current ~back : bool =
+  if Float.(back = 0.0) then false
+  else
+    let slope_pct = (current -. back) /. Float.abs back in
+    Float.(slope_pct > threshold)
+
+let compute ~get_close ~early_admission_ma_period ~slope_threshold
+    ~slope_lookback : bool =
+  match early_admission_ma_period with
+  | None -> false
+  | Some fast_p -> (
+      let fast_now = _fast_ma ~get_close ~period:fast_p ~off:0 in
+      let fast_back = _fast_ma ~get_close ~period:fast_p ~off:slope_lookback in
+      match (fast_now, fast_back, get_close ~week_offset:0) with
+      | Some current, Some back, Some close ->
+          let fast_rising =
+            _is_rising ~threshold:slope_threshold ~current ~back
+          in
+          let fast_above = Float.(close > current) in
+          fast_rising && fast_above
+      | _ -> false)
+
+let apply ~early_admit ~prior_stage ~(standard_stage : stage) : stage =
+  if not early_admit then standard_stage
+  else
+    match (standard_stage, prior_stage) with
+    | Stage1 _, _ -> Stage2 { weeks_advancing = 0; late = false }
+    | Stage2 _, _ -> standard_stage
+    | (Stage3 _ | Stage4 _), Some (Stage2 { weeks_advancing; late }) ->
+        Stage2 { weeks_advancing = weeks_advancing + 1; late }
+    | (Stage3 _ | Stage4 _), _ -> standard_stage

--- a/trading/analysis/weinstein/stage/lib/early_admission.mli
+++ b/trading/analysis/weinstein/stage/lib/early_admission.mli
@@ -1,0 +1,55 @@
+open Weinstein_types
+
+(** Dual-MA early Stage-2 admission (default-off mechanism).
+
+    A gap-closing experiment for the [late_stage2_admission] failure mode: the
+    slow 30-week MA admits Stage 2 months late off bear bottoms (e.g. Mar 2009 /
+    Mar 2020). This module computes a fast confirmation MA self-contained from
+    the [get_close] callback (no new panel callback) and uses it to {b promote}
+    a would-be [Stage1] to [Stage2] or {b prevent a demotion} of a prior
+    [Stage2] while the fast MA is rising and price is above it.
+
+    All functions are pure. The mechanism is a strict no-op when
+    [early_admission_ma_period = None] (see {!compute}). *)
+
+val compute :
+  get_close:(week_offset:int -> float option) ->
+  early_admission_ma_period:int option ->
+  slope_threshold:float ->
+  slope_lookback:int ->
+  bool
+(** [compute ~get_close ~early_admission_ma_period ~slope_threshold
+     ~slope_lookback] is the early-admission signal.
+
+    Returns [false] immediately when [early_admission_ma_period = None] (the
+    off-path), guaranteeing the mechanism is a no-op unless the flag is set.
+
+    When [Some fast_p]: builds a simple [fast_p]-week MA of recent closes and
+    returns [fast_rising && fast_above] where
+
+    - [fast_rising] — the fast MA at offset 0 vs offset [slope_lookback] is
+      rising, using the same slope-vs-threshold rule as the slow-MA direction
+      classifier ([slope_pct = (cur - back) / |back|]; rising iff
+      [slope_pct > slope_threshold]; never rising when [back = 0]).
+    - [fast_above] — the current close exceeds the current fast MA.
+
+    Any missing close (current close or either fast-MA window) makes the signal
+    [false]. *)
+
+val apply :
+  early_admit:bool -> prior_stage:stage option -> standard_stage:stage -> stage
+(** [apply ~early_admit ~prior_stage ~standard_stage] post-processes the
+    standard classifier output with the early-admission override.
+
+    When [early_admit = false] this is the identity ([standard_stage] is
+    returned unchanged) — the proof that the mechanism is a no-op when off. When
+    [early_admit = true]:
+
+    - a would-be [Stage1] is promoted to a fresh [Stage2]
+      ([weeks_advancing = 0]);
+    - a prior [Stage2] that the slow-MA logic would demote ([standard_stage] is
+      not itself a [Stage2]) is held advancing ([weeks_advancing] increments,
+      prior [late] flag preserved);
+    - any other case (standard already [Stage2], or prior not [Stage2] with a
+      non-[Stage1] standard) is left untouched — early admission never blocks a
+      slow-MA [Stage2] and never forces an exit. *)

--- a/trading/analysis/weinstein/stage/lib/stage.ml
+++ b/trading/analysis/weinstein/stage/lib/stage.ml
@@ -23,6 +23,7 @@ type config = {
   confirm_weeks : int;
   late_stage2_decel : float;
   stage_method : stage_method;
+  early_admission_ma_period : int option; [@sexp.default None]
 }
 [@@deriving sexp]
 
@@ -35,6 +36,7 @@ let default_config =
     confirm_weeks = 6;
     late_stage2_decel = 0.5;
     stage_method = MaSlope;
+    early_admission_ma_period = None;
   }
 
 (* ------------------------------------------------------------------ *)
@@ -377,10 +379,13 @@ let _stage1_default_result : result =
     [classify_with_callbacks] so the latter stays a flat sequence of
     let-bindings. *)
 let _build_result ~current_ma ~ma_dir ~ma_slope_pct ~prior_stage ~above_ma_count
-    ~below_ma_count ~is_late ~confirm_weeks : result =
-  let new_stage =
+    ~below_ma_count ~is_late ~early_admit ~confirm_weeks : result =
+  let standard_stage =
     _classify_new_stage ~ma_dir ~prior_stage ~above_ma_count ~below_ma_count
       ~is_late ~confirm_weeks
+  in
+  let new_stage =
+    Early_admission.apply ~early_admit ~prior_stage ~standard_stage
   in
   let transition = _detect_transition ~prior_stage ~new_stage in
   {
@@ -413,8 +418,14 @@ let _classify_signals ~config ~get_ma ~get_close ~prior_stage ~current_ma :
     _is_late_stage2_callback ~get_ma ~decel_threshold:config.late_stage2_decel
       ~slope_lookback:config.slope_lookback
   in
+  let early_admit =
+    Early_admission.compute ~get_close
+      ~early_admission_ma_period:config.early_admission_ma_period
+      ~slope_threshold:config.slope_threshold
+      ~slope_lookback:config.slope_lookback
+  in
   _build_result ~current_ma ~ma_dir ~ma_slope_pct ~prior_stage ~above_ma_count
-    ~below_ma_count ~is_late ~confirm_weeks:config.confirm_weeks
+    ~below_ma_count ~is_late ~early_admit ~confirm_weeks:config.confirm_weeks
 
 let classify_with_callbacks ~config ~get_ma ~get_close ~prior_stage : result =
   match get_ma ~week_offset:0 with

--- a/trading/analysis/weinstein/stage/lib/stage.mli
+++ b/trading/analysis/weinstein/stage/lib/stage.mli
@@ -49,6 +49,28 @@ type config = {
       (** Method for determining MA direction. Default: [MaSlope] (current
           behavior). [Segmentation] enables the feature-flagged piecewise linear
           regression path (see {!stage_method}). *)
+  early_admission_ma_period : int option; [@sexp.default None]
+      (** Default-off dual-MA early Stage-2 admission flag (gap-closing
+          experiment for the [late_stage2_admission] failure mode: the slow
+          30-week MA admits Stage 2 months late off bear bottoms, e.g. Mar 2009
+          / Mar 2020).
+
+          [None] (default): no behavioural change — [classify] is bit-identical
+          to the pre-flag classifier on every input.
+
+          [Some fast_p]: a fast confirmation SMA of the most recent [fast_p]
+          closes (read self-contained from [get_close], no new panel callback)
+          can {b promote} a would-be [Stage1] to [Stage2] or
+          {b prevent a demotion} of a prior [Stage2] — but only while the fast
+          MA is both rising (per [slope_threshold] / [slope_lookback]) and below
+          the current close. It never blocks a slow-MA [Stage2] and never forces
+          an exit; when the fast MA rolls over, classification hands back to the
+          standard slow-MA result (no lock-in).
+
+          Wired as a config field so it routes through [Overlay_validator] and
+          is expressible as a [Variant_matrix] axis. Not wired into any default
+          config; awaits a surface-sweep ACCEPT per the experiment-flag
+          discipline. *)
 }
 [@@deriving sexp]
 (** Configuration for stage classification. All thresholds are configurable to

--- a/trading/analysis/weinstein/stage/test/test_stage.ml
+++ b/trading/analysis/weinstein/stage/test/test_stage.ml
@@ -512,6 +512,166 @@ let test_segmentation_single_ma_point_falls_back_to_flat _ =
          field (fun r -> r.ma_value) (float_equal 100.0);
        ])
 
+(* ------------------------------------------------------------------ *)
+(* Dual-MA early Stage-2 admission (default-off flag)                  *)
+(*                                                                      *)
+(* These tests drive [classify_with_callbacks] directly so the slow MA *)
+(* ([get_ma]) and the close series ([get_close], which the fast MA is  *)
+(* derived from) can be controlled independently. The contract is the  *)
+(* CONTRAST between [early_admission_ma_period = None] and [Some 13] on *)
+(* the SAME callbacks — so each test asserts both configs.             *)
+(* ------------------------------------------------------------------ *)
+
+let cfg_early = { default_config with early_admission_ma_period = Some 13 }
+
+(** Slow-MA callback over a value array (oldest at index 0, newest at the end).
+    Independent from {!make_get_close_arr} so a flat slow MA can coexist with a
+    rising close series. *)
+let make_get_ma_arr (values : float array) ~week_offset =
+  let n = Array.length values in
+  let idx = n - 1 - week_offset in
+  if idx < 0 || idx >= n then None else Some values.(idx)
+
+(** Close callback over a value array (oldest at index 0, newest at the end). *)
+let make_get_close_arr (closes : float array) ~week_offset =
+  let n = Array.length closes in
+  let idx = n - 1 - week_offset in
+  if idx < 0 || idx >= n then None else Some closes.(idx)
+
+(** A flat slow-MA series (40 weeks at 100.0): standard classification reads it
+    as [Flat], so a prior [Stage1] stays [Stage1] and a prior [Stage2] would be
+    demoted toward [Stage3]. *)
+let flat_slow_ma = Array.create ~len:40 100.0
+
+(** A declining slow-MA series (ramps 130 → 100 over 40 weeks): reads as
+    [Declining]. The slow MA still has not turned up — the bear-bottom shape the
+    early-admission flag is meant to catch. *)
+let declining_slow_ma =
+  Array.init 40 ~f:(fun i -> 130.0 -. (Float.of_int i *. (30.0 /. 39.0)))
+
+(** A rising close series (ramps 80 → 130 over 40 weeks). The 13-week fast SMA
+    is rising and the current close sits above it — [early_admit] fires. *)
+let rising_closes =
+  Array.init 40 ~f:(fun i -> 80.0 +. (Float.of_int i *. (50.0 /. 39.0)))
+
+(** Early admission fires: with the slow MA flat (standard → [Stage1]) but the
+    fast MA rising and price above it, [Some 13] promotes to a fresh [Stage2]
+    while [None] stays [Stage1]. The contrast IS the contract. *)
+let test_early_admission_promotes_stage1_to_stage2 _ =
+  let get_ma = make_get_ma_arr flat_slow_ma in
+  let get_close = make_get_close_arr rising_closes in
+  let prior = Some (Stage1 { weeks_in_base = 4 }) in
+  let off =
+    classify_with_callbacks ~config:default_config ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  let on =
+    classify_with_callbacks ~config:cfg_early ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  assert_that (off.stage, on.stage)
+    (all_of
+       [
+         field fst is_stage1;
+         field snd
+           (equal_to (Stage2 { weeks_advancing = 0; late = false } : stage));
+       ])
+
+(** Hold on the fast MA: a prior [Stage2] that the slow MA (flat → [Stage3])
+    would demote is held advancing while the fast MA is still rising+above.
+    [None] demotes to [Stage3]; [Some 13] keeps [Stage2] with an incremented
+    [weeks_advancing] and the prior [late] flag preserved. *)
+let test_early_admission_holds_prior_stage2 _ =
+  let get_ma = make_get_ma_arr flat_slow_ma in
+  let get_close = make_get_close_arr rising_closes in
+  let prior = Some (Stage2 { weeks_advancing = 7; late = true }) in
+  let off =
+    classify_with_callbacks ~config:default_config ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  let on =
+    classify_with_callbacks ~config:cfg_early ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  assert_that (off.stage, on.stage)
+    (all_of
+       [
+         field fst is_stage3;
+         field snd
+           (equal_to (Stage2 { weeks_advancing = 8; late = true } : stage));
+       ])
+
+(** Rollover hands back: when the fast MA rolls over (current close below the
+    fast SMA), [early_admit] is [false] and the [Some 13] result is identical to
+    the [None] (standard slow-MA) result — no lock-in. We use a declining close
+    series so the fast SMA is falling and price is below it. *)
+let test_early_admission_rollover_hands_back _ =
+  let falling_closes =
+    Array.init 40 ~f:(fun i -> 130.0 -. (Float.of_int i *. (50.0 /. 39.0)))
+  in
+  let get_ma = make_get_ma_arr declining_slow_ma in
+  let get_close = make_get_close_arr falling_closes in
+  let prior = Some (Stage2 { weeks_advancing = 7; late = false }) in
+  let off =
+    classify_with_callbacks ~config:default_config ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  let on =
+    classify_with_callbacks ~config:cfg_early ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  assert_that on.stage (equal_to (off.stage : stage))
+
+(** Slow-MA Stage 2 unaffected: when the slow MA itself is rising and price is
+    above it (a genuine slow-MA [Stage2]), the flag changes nothing — [Some 13]
+    yields the same [Stage2] as [None]. Early admission only ever promotes /
+    holds; it never alters an existing slow-MA [Stage2]. *)
+let test_early_admission_slow_ma_stage2_unaffected _ =
+  let get_ma = make_get_ma_arr rising_closes in
+  let get_close = make_get_close_arr rising_closes in
+  let prior = Some (Stage2 { weeks_advancing = 5; late = false }) in
+  let off =
+    classify_with_callbacks ~config:default_config ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  let on =
+    classify_with_callbacks ~config:cfg_early ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  assert_that (off.stage, on.stage)
+    (all_of [ field fst is_stage2; field snd (equal_to (off.stage : stage)) ])
+
+(** Default config leaves the flag off. *)
+let test_default_config_early_admission_none _ =
+  assert_that default_config.early_admission_ma_period is_none
+
+(* ------------------------------------------------------------------ *)
+(* Sexp round-trip: defaulted field tolerates omission                 *)
+(* ------------------------------------------------------------------ *)
+
+(** A serialized [config] sexp that omits [early_admission_ma_period] (every
+    pre-flag golden / spec) parses with the field defaulting to [None]. *)
+let test_config_sexp_omitted_field_defaults_none _ =
+  let sexp =
+    Sexp.of_string
+      "((ma_period 30) (ma_type Wma) (slope_threshold 0.005) (slope_lookback \
+       4) (confirm_weeks 6) (late_stage2_decel 0.5) (stage_method MaSlope))"
+  in
+  let cfg = config_of_sexp sexp in
+  assert_that cfg.early_admission_ma_period is_none
+
+(** A serialized [config] sexp that includes [(early_admission_ma_period (13))]
+    parses to [Some 13]. *)
+let test_config_sexp_present_field_parses _ =
+  let sexp =
+    Sexp.of_string
+      "((ma_period 30) (ma_type Wma) (slope_threshold 0.005) (slope_lookback \
+       4) (confirm_weeks 6) (late_stage2_decel 0.5) (stage_method MaSlope) \
+       (early_admission_ma_period (13)))"
+  in
+  let cfg = config_of_sexp sexp in
+  assert_that cfg.early_admission_ma_period (is_some_and (equal_to 13))
+
 let suite =
   "stage_tests"
   >::: [
@@ -552,6 +712,20 @@ let suite =
          >:: test_segmentation_history_truncation_no_bias;
          "test_segmentation_single_ma_point_falls_back_to_flat"
          >:: test_segmentation_single_ma_point_falls_back_to_flat;
+         "test_early_admission_promotes_stage1_to_stage2"
+         >:: test_early_admission_promotes_stage1_to_stage2;
+         "test_early_admission_holds_prior_stage2"
+         >:: test_early_admission_holds_prior_stage2;
+         "test_early_admission_rollover_hands_back"
+         >:: test_early_admission_rollover_hands_back;
+         "test_early_admission_slow_ma_stage2_unaffected"
+         >:: test_early_admission_slow_ma_stage2_unaffected;
+         "test_default_config_early_admission_none"
+         >:: test_default_config_early_admission_none;
+         "test_config_sexp_omitted_field_defaults_none"
+         >:: test_config_sexp_omitted_field_defaults_none;
+         "test_config_sexp_present_field_parses"
+         >:: test_config_sexp_present_field_parses;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Adds a default-off config flag to the Weinstein stage classifier:

```ocaml
early_admission_ma_period : int option; [@sexp.default None]
```

(`Stage.config`, defaulting to `None` in `default_config`).

**Step 1** of the `late_stage2_admission` gap-closing experiment — the autopsy
failure mode where the slow 30-week MA admits Stage 2 months late off bear
bottoms (e.g. Mar 2009 / Mar 2020). This PR lands ONE mechanism behind ONE
default-off flag. It is **not wired into any default config** and runs no
backtest — a later surface sweep decides promotion per the experiment-flag
discipline.

### Mechanism

When `None` (default): no behavioural change whatsoever — `Stage.classify` is
bit-identical to today on every input.

When `Some fast_p`:
- A fast confirmation SMA of the most recent `fast_p` closes is computed
  self-contained from the existing `get_close` callback (no new MA callback, no
  panel-code change).
- `early_admit = fast_rising && fast_above`, where `fast_rising` uses the same
  slope-vs-threshold rule as the slow-MA direction classifier
  (`slope_threshold` / `slope_lookback`), and `fast_above` = current close above
  the current fast MA.
- Effect — early admission can only ever **promote** a would-be Stage1 to a
  fresh Stage2, or **prevent a demotion** of a prior Stage2 while the fast MA is
  rising+above. It never blocks a genuine slow-MA Stage2 and never forces an
  exit. On fast-MA rollover, classification hands back to the standard slow-MA
  result (no lock-in).

The mechanism is extracted into a sibling `Early_admission` module
(`compute` + `apply`) to keep `stage.ml` under the file-length hard limit.

### No-op-when-off guarantee

The off-path is a proven no-op: `Early_admission.compute` returns `false`
immediately when `early_admission_ma_period = None`, and
`Early_admission.apply` with `early_admit = false` is the identity on the
standard stage. All **26 pre-existing stage golden tests stay green untouched**.

### Flag discipline

- **R1 default-off:** new field carries `[@sexp.default None]`; the no-op equals
  prior behaviour.
- **R2 searchable:** it is a real `Stage.config` field (embedded in
  `Weinstein_strategy.config`), so it routes through `Overlay_validator` and is
  expressible as a `Variant_matrix` axis.
- **R3 promotion needs a verdict:** not flipped on anywhere; awaits a
  surface-sweep ACCEPT in the experiment ledger.

## Test plan

New tests in `analysis/weinstein/stage/test/test_stage.ml` (OUnit2 + Matchers),
each asserting the contrast between `None` and `Some 13` on the SAME callbacks:

1. **No-op regression (flag off):** all 26 existing golden tests unchanged and green.
2. **Early admission fires:** flat slow MA (standard → Stage1) + rising fast MA above price ⇒ `None` → Stage1, `Some 13` → `Stage2 {weeks_advancing=0; late=false}`.
3. **Hold on fast MA:** prior Stage2, flat slow MA (standard → Stage3), fast MA still rising+above ⇒ `None` → Stage3, `Some 13` → `Stage2 {weeks_advancing=prior+1; late=preserved}`.
4. **Rollover hands back:** fast MA rolls over (price below fast MA) ⇒ `Some 13` result identical to `None` (no lock-in).
5. **Slow-MA Stage2 unaffected:** genuine slow-MA Stage2 ⇒ identical result on vs off.
6. **Sexp round-trip:** a `config` sexp omitting the field parses to `None`; one with `(early_admission_ma_period (13))` parses to `Some 13`.

Final: `dune runtest analysis/weinstein/stage/` → `Ran: 33 tests ... OK`.
`dune build`, `dune build @fmt`, file-length / magic-numbers / mli-coverage
linters all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)