### PR TITLE
feat(walk_forward): rank_variants CLI

### DIFF
--- a/dev/status/experiment-platform.md
+++ b/dev/status/experiment-platform.md
@@ -1,6 +1,6 @@
 # Status: experiment-platform
 
-## Last updated: 2026-05-30 (rank_variants CLI landed)
+## Last updated: 2026-05-30
 
 ## Status
 IN_PROGRESS

--- a/dev/status/experiment-platform.md
+++ b/dev/status/experiment-platform.md
@@ -1,6 +1,6 @@
 # Status: experiment-platform
 
-## Last updated: 2026-05-30
+## Last updated: 2026-05-30 (rank_variants CLI landed)
 
 ## Status
 IN_PROGRESS
@@ -196,10 +196,16 @@ Verify: `docker exec trading-1-dev bash -c 'cd /workspaces/trading-1/trading && 
 2. **Wire DSR into the BO tuner** — the `backtest_stats` lib is shared;
    the BO program can adopt `Deflated_sharpe` for its own best-of-N
    correction (deferred to that program).
-3. **(nice-to-have) Commit a `rank-variants` CLI** — `Variant_ranking` /
-   `Deflated_sharpe` have no in-repo driver; the verdict above used an
-   ad-hoc one. A committed CLI over `aggregate.sexp`+`fold_actuals.sexp`
-   would make every future verdict reproducible.
+3. [x] **Commit a `rank-variants` CLI** — landed via
+   `trading/trading/backtest/walk_forward/bin/rank_variants.{ml}` (+
+   `test/test_rank_variants.ml`). Pure consumer of `aggregate.sexp`
+   (+ optional `fold_actuals.sexp` for DSR), computes per-variant
+   Deflated Sharpe via `Backtest_stats.Deflated_sharpe`, renders via
+   `Walk_forward.Variant_ranking.{rank,render}`. Replaces the ad-hoc
+   throwaway exe used in #1375 / #1379 verdicts; future rankings are
+   reproducible. Verify:
+   `dune exec trading/backtest/walk_forward/bin/rank_variants.exe -- --aggregate <path> [--fold-actuals <path>] [--baseline-label <label>] [--output <path>]`
+   and `dune runtest trading/backtest/walk_forward/test/` (5/5 new tests).
 
 ## Out of scope (PR-3)
 

--- a/trading/trading/backtest/walk_forward/bin/dune
+++ b/trading/trading/backtest/walk_forward/bin/dune
@@ -10,3 +10,10 @@
   walk_forward)
  (preprocess
   (pps ppx_sexp_conv)))
+
+(executable
+ (name rank_variants)
+ (modules rank_variants)
+ (libraries core backtest_stats walk_forward)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/walk_forward/bin/rank_variants.ml
+++ b/trading/trading/backtest/walk_forward/bin/rank_variants.ml
@@ -1,0 +1,227 @@
+(** Rank walk-forward CV variants by Pareto frontier (Sharpe up, Calmar up,
+    MaxDD% down) and report each variant's Deflated Sharpe Ratio (DSR).
+
+    Pure consumer of artefacts already on disk:
+    - [--aggregate <path>] — a {!Walk_forward.Walk_forward_types.aggregate} sexp
+      (the same shape {!Walk_forward.Walk_forward_runner} writes to
+      [aggregate.sexp]). Mandatory.
+    - [--fold-actuals <path>] — a [Walk_forward_types.fold_actual list] sexp
+      ([fold_actuals.sexp] from the runner). Optional; required for DSR.
+    - [--baseline-label <label>] — header annotation; defaults to "baseline".
+    - [--output <path>] — write markdown there; default stdout.
+
+    DSR is per-variant: feeds the variant's [sharpe_ratio.mean] (from the
+    aggregate) as the observed Sharpe, the variant's per-fold [total_return_pct]
+    series (from fold_actuals) as the fold returns, and the across-variant
+    Sharpe-mean variance as the best-of-N selection-bias correction. Variants
+    with fewer than two non-NaN fold returns or zero return-variance are
+    skipped (no DSR column for that row); the rendering treats missing labels
+    as "n/a" per {!Walk_forward.Variant_ranking.render}.
+
+    Gap C of [dev/plans/experiment-platform-2026-05-29.md]: every future
+    verdict ranks via the same committed pipeline rather than an ad-hoc exe.
+*)
+
+open Core
+module T = Walk_forward.Walk_forward_types
+module VR = Walk_forward.Variant_ranking
+module DS = Backtest_stats.Deflated_sharpe
+
+(* -------------- argument parsing -------------- *)
+
+type cli_args = {
+  aggregate_path : string;
+  fold_actuals_path : string option;
+  baseline_label : string;
+  output_path : string option;
+}
+
+let _default_baseline_label = "baseline"
+
+let _usage_msg =
+  "Usage: rank_variants.exe --aggregate <aggregate.sexp> \
+   [--fold-actuals <fold_actuals.sexp>] [--baseline-label <label>] \
+   [--output <path>]"
+
+let _parse_args argv =
+  let rec loop agg folds baseline out = function
+    | [] -> (
+        match agg with
+        | Some a ->
+            {
+              aggregate_path = a;
+              fold_actuals_path = folds;
+              baseline_label =
+                Option.value baseline ~default:_default_baseline_label;
+              output_path = out;
+            }
+        | None ->
+            eprintf "Error: --aggregate is required\n%s\n" _usage_msg;
+            Stdlib.exit 1)
+    | "--aggregate" :: p :: rest -> loop (Some p) folds baseline out rest
+    | "--fold-actuals" :: p :: rest -> loop agg (Some p) baseline out rest
+    | "--baseline-label" :: l :: rest -> loop agg folds (Some l) out rest
+    | "--output" :: p :: rest -> loop agg folds baseline (Some p) rest
+    | ("--help" | "-h") :: _ ->
+        printf "%s\n" _usage_msg;
+        Stdlib.exit 0
+    | unknown :: _ ->
+        eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
+        Stdlib.exit 1
+  in
+  loop None None None None argv
+
+(* -------------- input loading -------------- *)
+
+(** Load a sexp file, exiting non-zero with a path-quoted message on any I/O or
+    parse error. Both inputs go through this helper so the error shape is
+    consistent. *)
+let _load_sexp ~label ~path ~of_sexp =
+  try
+    let sexp = Sexp.load_sexp path in
+    of_sexp sexp
+  with
+  | Sys_error msg ->
+      eprintf "Error: cannot read %s %S: %s\n" label path msg;
+      Stdlib.exit 1
+  | Sexp.Of_sexp_error (exn, _) ->
+      eprintf "Error: failed to parse %s %S: %s\n" label path (Exn.to_string exn);
+      Stdlib.exit 1
+  | exn ->
+      eprintf "Error: failed to load %s %S: %s\n" label path (Exn.to_string exn);
+      Stdlib.exit 1
+
+let _load_aggregate path =
+  _load_sexp ~label:"aggregate" ~path ~of_sexp:T.aggregate_of_sexp
+
+let _load_fold_actuals path =
+  _load_sexp ~label:"fold-actuals" ~path
+    ~of_sexp:(fun sexp -> [%of_sexp: T.fold_actual list] sexp)
+
+(* -------------- DSR computation -------------- *)
+
+(** Minimum number of finite fold returns required to compute DSR (PSR's
+    [sqrt (n_obs - 1)] term needs at least 2 observations). *)
+let _min_fold_count = 2
+
+(** Population variance of [xs] using a two-pass mean / sum-of-squares walk.
+    Empty / single-element inputs return [0.0]; the caller filters those out
+    earlier so this is defensive. *)
+let _population_variance xs =
+  match xs with
+  | [] | [ _ ] -> 0.0
+  | _ ->
+      let n = List.length xs in
+      let mean = List.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int n in
+      let ss =
+        List.fold xs ~init:0.0 ~f:(fun acc x ->
+            let d = x -. mean in
+            acc +. (d *. d))
+      in
+      ss /. Float.of_int n
+
+(** Per-variant fold returns from [fold_actuals], filtering by [variant_label]
+    and dropping NaN entries. *)
+let _fold_returns_for ~variant_label fold_actuals =
+  List.filter_map fold_actuals ~f:(fun (fa : T.fold_actual) ->
+      if String.equal fa.variant_label variant_label then
+        if Float.is_finite fa.total_return_pct then Some fa.total_return_pct
+        else None
+      else None)
+
+type dsr_outcome =
+  | Computed of float
+  | Skipped of string  (** Reason string for the stderr note. *)
+
+(** Compute DSR for one variant, or explain why we skipped it. *)
+let _compute_dsr_one ~variant_label ~observed_sharpe ~fold_actuals ~n_trials
+    ~sharpe_variance_across_trials =
+  let fold_returns = _fold_returns_for ~variant_label fold_actuals in
+  if List.length fold_returns < _min_fold_count then
+    Skipped
+      (sprintf "%s: only %d finite fold return(s); need at least %d"
+         variant_label (List.length fold_returns) _min_fold_count)
+  else if Float.( <= ) (_population_variance fold_returns) 0.0 then
+    Skipped (sprintf "%s: zero variance across fold returns" variant_label)
+  else
+    try
+      let dsr =
+        DS.deflated_sharpe ~observed_sharpe ~fold_returns ~n_trials
+          ~sharpe_variance_across_trials
+      in
+      Computed dsr
+    with Invalid_argument msg ->
+      Skipped (sprintf "%s: %s" variant_label msg)
+
+(** Walk the aggregate's [stability] list, computing DSR for each variant and
+    collecting both the assoc list passed to the renderer and a list of skip
+    reasons surfaced on stderr. *)
+let _build_dsr_table (aggregate : T.aggregate) fold_actuals =
+  let stability = aggregate.stability in
+  let n_trials = List.length stability in
+  if n_trials < _min_fold_count then
+    (* expected_max_sharpe needs n >= 2; if we have one variant, DSR is
+       undefined for the whole table. *)
+    ([], [ sprintf "n_trials = %d; need at least %d for DSR" n_trials _min_fold_count ])
+  else
+    let sharpe_means =
+      List.map stability ~f:(fun s -> s.sharpe_ratio.mean)
+      |> List.filter ~f:Float.is_finite
+    in
+    let sharpe_variance_across_trials = _population_variance sharpe_means in
+    if Float.( <= ) sharpe_variance_across_trials 0.0 then
+      ( [],
+        [
+          sprintf
+            "Sharpe variance across %d variants is zero; DSR undefined for \
+             every variant"
+            n_trials;
+        ] )
+    else
+      let dsrs, skips =
+        List.fold stability ~init:([], [])
+          ~f:(fun (acc_dsr, acc_skip) (s : T.variant_stability) ->
+            match
+              _compute_dsr_one ~variant_label:s.variant_label
+                ~observed_sharpe:s.sharpe_ratio.mean ~fold_actuals ~n_trials
+                ~sharpe_variance_across_trials
+            with
+            | Computed dsr -> ((s.variant_label, dsr) :: acc_dsr, acc_skip)
+            | Skipped msg -> (acc_dsr, msg :: acc_skip))
+      in
+      (List.rev dsrs, List.rev skips)
+
+(* -------------- output -------------- *)
+
+let _render ~baseline_label ~ranking ~deflated_sharpe_by_label =
+  let body = VR.render ranking ~deflated_sharpe_by_label in
+  sprintf "# Variant ranking\n\nBaseline: %s\n\n%s\n" baseline_label body
+
+let _write_output ~output_path md =
+  match output_path with
+  | None -> print_string md
+  | Some path -> Out_channel.write_all path ~data:md
+
+(* -------------- main -------------- *)
+
+let _main () =
+  let argv = Sys.get_argv () |> Array.to_list |> List.tl_exn in
+  let args = _parse_args argv in
+  let aggregate = _load_aggregate args.aggregate_path in
+  let dsr_table, skips =
+    match args.fold_actuals_path with
+    | None -> ([], [])
+    | Some path ->
+        let fold_actuals = _load_fold_actuals path in
+        _build_dsr_table aggregate fold_actuals
+  in
+  List.iter skips ~f:(fun msg ->
+      eprintf "[rank_variants] skipped DSR — %s\n" msg);
+  let ranking = VR.rank aggregate.stability in
+  let md =
+    _render ~baseline_label:args.baseline_label ~ranking
+      ~deflated_sharpe_by_label:dsr_table
+  in
+  _write_output ~output_path:args.output_path md
+
+let () = _main ()

--- a/trading/trading/backtest/walk_forward/bin/rank_variants.ml
+++ b/trading/trading/backtest/walk_forward/bin/rank_variants.ml
@@ -14,13 +14,12 @@
     aggregate) as the observed Sharpe, the variant's per-fold [total_return_pct]
     series (from fold_actuals) as the fold returns, and the across-variant
     Sharpe-mean variance as the best-of-N selection-bias correction. Variants
-    with fewer than two non-NaN fold returns or zero return-variance are
-    skipped (no DSR column for that row); the rendering treats missing labels
-    as "n/a" per {!Walk_forward.Variant_ranking.render}.
+    with fewer than two non-NaN fold returns or zero return-variance are skipped
+    (no DSR column for that row); the rendering treats missing labels as "n/a"
+    per {!Walk_forward.Variant_ranking.render}.
 
-    Gap C of [dev/plans/experiment-platform-2026-05-29.md]: every future
-    verdict ranks via the same committed pipeline rather than an ad-hoc exe.
-*)
+    Gap C of [dev/plans/experiment-platform-2026-05-29.md]: every future verdict
+    ranks via the same committed pipeline rather than an ad-hoc exe. *)
 
 open Core
 module T = Walk_forward.Walk_forward_types
@@ -39,9 +38,8 @@ type cli_args = {
 let _default_baseline_label = "baseline"
 
 let _usage_msg =
-  "Usage: rank_variants.exe --aggregate <aggregate.sexp> \
-   [--fold-actuals <fold_actuals.sexp>] [--baseline-label <label>] \
-   [--output <path>]"
+  "Usage: rank_variants.exe --aggregate <aggregate.sexp> [--fold-actuals \
+   <fold_actuals.sexp>] [--baseline-label <label>] [--output <path>]"
 
 let _parse_args argv =
   let rec loop agg folds baseline out = function
@@ -85,7 +83,8 @@ let _load_sexp ~label ~path ~of_sexp =
       eprintf "Error: cannot read %s %S: %s\n" label path msg;
       Stdlib.exit 1
   | Sexp.Of_sexp_error (exn, _) ->
-      eprintf "Error: failed to parse %s %S: %s\n" label path (Exn.to_string exn);
+      eprintf "Error: failed to parse %s %S: %s\n" label path
+        (Exn.to_string exn);
       Stdlib.exit 1
   | exn ->
       eprintf "Error: failed to load %s %S: %s\n" label path (Exn.to_string exn);
@@ -95,8 +94,8 @@ let _load_aggregate path =
   _load_sexp ~label:"aggregate" ~path ~of_sexp:T.aggregate_of_sexp
 
 let _load_fold_actuals path =
-  _load_sexp ~label:"fold-actuals" ~path
-    ~of_sexp:(fun sexp -> [%of_sexp: T.fold_actual list] sexp)
+  _load_sexp ~label:"fold-actuals" ~path ~of_sexp:(fun sexp ->
+      [%of_sexp: T.fold_actual list] sexp)
 
 (* -------------- DSR computation -------------- *)
 
@@ -150,8 +149,7 @@ let _compute_dsr_one ~variant_label ~observed_sharpe ~fold_actuals ~n_trials
           ~sharpe_variance_across_trials
       in
       Computed dsr
-    with Invalid_argument msg ->
-      Skipped (sprintf "%s: %s" variant_label msg)
+    with Invalid_argument msg -> Skipped (sprintf "%s: %s" variant_label msg)
 
 (** Walk the aggregate's [stability] list, computing DSR for each variant and
     collecting both the assoc list passed to the renderer and a list of skip
@@ -162,7 +160,11 @@ let _build_dsr_table (aggregate : T.aggregate) fold_actuals =
   if n_trials < _min_fold_count then
     (* expected_max_sharpe needs n >= 2; if we have one variant, DSR is
        undefined for the whole table. *)
-    ([], [ sprintf "n_trials = %d; need at least %d for DSR" n_trials _min_fold_count ])
+    ( [],
+      [
+        sprintf "n_trials = %d; need at least %d for DSR" n_trials
+          _min_fold_count;
+      ] )
   else
     let sharpe_means =
       List.map stability ~f:(fun s -> s.sharpe_ratio.mean)

--- a/trading/trading/backtest/walk_forward/test/dune
+++ b/trading/trading/backtest/walk_forward/test/dune
@@ -7,7 +7,8 @@
   test_walk_forward_executor_parallel
   test_spec
   test_variant_matrix
-  test_variant_ranking)
+  test_variant_ranking
+  test_rank_variants)
  (libraries
   ounit2
   core
@@ -20,4 +21,5 @@
  (preprocess
   (pps ppx_sexp_conv))
  (deps
-  (glob_files_rec %{workspace_root}/test_data/walk_forward/*.sexp)))
+  (glob_files_rec %{workspace_root}/test_data/walk_forward/*.sexp)
+  (file ../bin/rank_variants.exe)))

--- a/trading/trading/backtest/walk_forward/test/test_rank_variants.ml
+++ b/trading/trading/backtest/walk_forward/test/test_rank_variants.ml
@@ -1,0 +1,283 @@
+(** Integration tests for the [rank_variants] CLI.
+
+    The binary lives at [../bin/rank_variants.exe] in the [_build] tree; each
+    test writes synthesised aggregate / fold_actuals sexp inputs to a per-test
+    tmpdir, invokes the binary via [Sys.command] (capturing stdout / stderr to
+    files), and asserts on the captured markdown. *)
+
+open OUnit2
+open Core
+open Matchers
+module T = Walk_forward.Walk_forward_types
+
+(* -------------- locating the binary -------------- *)
+
+let _binary_path =
+  Filename.concat
+    (Filename.dirname Stdlib.Sys.executable_name)
+    "../bin/rank_variants.exe"
+
+(* -------------- tmpdir scaffolding -------------- *)
+
+(* Per-test tmpdir under the system /tmp; cleaned up via OUnit's [bracket_tmpdir]
+   facility — but we use plain Core_unix.mkdtemp here so the test file has no
+   filename_unix dependency. *)
+let _make_tmpdir () = Stdlib.Filename.temp_dir "rank_variants_test_" ""
+
+let _write_sexp ~dir ~name sexp =
+  let path = Filename.concat dir name in
+  Out_channel.write_all path ~data:(Sexp.to_string_hum sexp);
+  path
+
+(* -------------- input builders -------------- *)
+
+let _stat mean : T.per_metric_stats =
+  { mean; stdev = 0.0; min = mean; max = mean }
+
+let _make_stability ~label ~sharpe ~calmar ~max_dd : T.variant_stability =
+  {
+    variant_label = label;
+    total_return_pct = _stat 0.0;
+    sharpe_ratio = _stat sharpe;
+    max_drawdown_pct = _stat max_dd;
+    calmar_ratio = _stat calmar;
+    cagr_pct = _stat 0.0;
+    avg_holding_days = _stat 0.0;
+  }
+
+let _make_aggregate ~stability : T.aggregate =
+  {
+    fold_count = 4;
+    baseline_label = "baseline";
+    metric_label = "Sharpe";
+    stability;
+    sensitivity = [];
+    verdicts = [];
+  }
+
+let _make_fold_actual ~fold_name ~variant_label ~total_return : T.fold_actual =
+  {
+    fold_name;
+    variant_label;
+    total_return_pct = total_return;
+    sharpe_ratio = 0.0;
+    max_drawdown_pct = 0.0;
+    calmar_ratio = 0.0;
+    cagr_pct = 0.0;
+    avg_holding_days = Float.nan;
+  }
+
+(* -------------- invocation helper -------------- *)
+
+type invoke_result = { exit_code : int; stdout : string; stderr : string }
+
+let _invoke ~dir args =
+  let stdout_path = Filename.concat dir "stdout.txt" in
+  let stderr_path = Filename.concat dir "stderr.txt" in
+  let cmd =
+    sprintf "%s %s > %s 2> %s" _binary_path
+      (String.concat ~sep:" " args)
+      (Filename.quote stdout_path)
+      (Filename.quote stderr_path)
+  in
+  let exit_code = Stdlib.Sys.command cmd in
+  let stdout = In_channel.read_all stdout_path in
+  let stderr = In_channel.read_all stderr_path in
+  { exit_code; stdout; stderr }
+
+(* -------------- tests -------------- *)
+
+(* 1. End-to-end on a 3-variant aggregate + matching fold_actuals. Output
+   should carry every variant label, the "Pareto frontier" header, and a
+   non-empty DSR column (at least one numeric DSR value). *)
+let test_end_to_end_3_variants _ =
+  let dir = _make_tmpdir () in
+  let stability =
+    [
+      _make_stability ~label:"A" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0;
+      _make_stability ~label:"B" ~sharpe:0.9 ~calmar:0.9 ~max_dd:25.0;
+      _make_stability ~label:"C" ~sharpe:0.5 ~calmar:0.4 ~max_dd:30.0;
+    ]
+  in
+  let agg = _make_aggregate ~stability in
+  let agg_path =
+    _write_sexp ~dir ~name:"aggregate.sexp" (T.sexp_of_aggregate agg)
+  in
+  (* Three folds × three variants; returns chosen so each variant has nonzero
+     variance and the across-variant Sharpe variance is positive. *)
+  let folds =
+    [
+      _make_fold_actual ~fold_name:"f0" ~variant_label:"A" ~total_return:10.0;
+      _make_fold_actual ~fold_name:"f1" ~variant_label:"A" ~total_return:5.0;
+      _make_fold_actual ~fold_name:"f2" ~variant_label:"A" ~total_return:15.0;
+      _make_fold_actual ~fold_name:"f0" ~variant_label:"B" ~total_return:8.0;
+      _make_fold_actual ~fold_name:"f1" ~variant_label:"B" ~total_return:3.0;
+      _make_fold_actual ~fold_name:"f2" ~variant_label:"B" ~total_return:12.0;
+      _make_fold_actual ~fold_name:"f0" ~variant_label:"C" ~total_return:(-2.0);
+      _make_fold_actual ~fold_name:"f1" ~variant_label:"C" ~total_return:(-5.0);
+      _make_fold_actual ~fold_name:"f2" ~variant_label:"C" ~total_return:1.0;
+    ]
+  in
+  let folds_path =
+    _write_sexp ~dir ~name:"fold_actuals.sexp"
+      ([%sexp_of: T.fold_actual list] folds)
+  in
+  let res =
+    _invoke ~dir
+      [
+        "--aggregate";
+        agg_path;
+        "--fold-actuals";
+        folds_path;
+        "--baseline-label";
+        "A";
+      ]
+  in
+  assert_that res.exit_code (equal_to 0);
+  assert_that res.stdout
+    (all_of
+       [
+         contains_substring "# Variant ranking";
+         contains_substring "Baseline: A";
+         contains_substring "## Pareto frontier";
+         contains_substring "| A |";
+         contains_substring "| B |";
+         contains_substring "| C |";
+         (* DSR computed for at least one variant: a numeric entry appears
+            in the Deflated Sharpe column. The renderer prints DSRs as
+            four-decimal floats; if every row showed "n/a", DSR was never
+            computed. Asserting on "0." catches both small-DSR (0.0001) and
+            large-DSR (0.9876) cases without being fragile to the exact
+            value. *)
+         contains_substring "0.";
+       ])
+
+(* 2. With --fold-actuals omitted, the renderer falls back to "n/a" everywhere
+   in the DSR column and exits 0. *)
+let test_no_fold_actuals _ =
+  let dir = _make_tmpdir () in
+  let stability =
+    [
+      _make_stability ~label:"X" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0;
+      _make_stability ~label:"Y" ~sharpe:0.9 ~calmar:0.9 ~max_dd:25.0;
+    ]
+  in
+  let agg_path =
+    _write_sexp ~dir ~name:"aggregate.sexp"
+      (T.sexp_of_aggregate (_make_aggregate ~stability))
+  in
+  let res = _invoke ~dir [ "--aggregate"; agg_path ] in
+  assert_that res.exit_code (equal_to 0);
+  assert_that res.stdout
+    (all_of
+       [
+         contains_substring "| X |";
+         contains_substring "| Y |";
+         contains_substring "n/a";
+       ])
+
+(* 3. A variant with only one fold return is skipped from DSR but still appears
+   in the rendered table. Stderr carries a skip note for that label. *)
+let test_skip_variant_with_too_few_folds _ =
+  let dir = _make_tmpdir () in
+  let stability =
+    [
+      _make_stability ~label:"M" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0;
+      _make_stability ~label:"N" ~sharpe:0.5 ~calmar:0.4 ~max_dd:30.0;
+      _make_stability ~label:"O" ~sharpe:0.8 ~calmar:0.7 ~max_dd:25.0;
+    ]
+  in
+  let agg_path =
+    _write_sexp ~dir ~name:"aggregate.sexp"
+      (T.sexp_of_aggregate (_make_aggregate ~stability))
+  in
+  let folds =
+    [
+      _make_fold_actual ~fold_name:"f0" ~variant_label:"M" ~total_return:10.0;
+      _make_fold_actual ~fold_name:"f1" ~variant_label:"M" ~total_return:5.0;
+      _make_fold_actual ~fold_name:"f2" ~variant_label:"M" ~total_return:15.0;
+      (* N has only one fold — gets skipped from DSR. *)
+      _make_fold_actual ~fold_name:"f0" ~variant_label:"N" ~total_return:(-2.0);
+      _make_fold_actual ~fold_name:"f0" ~variant_label:"O" ~total_return:8.0;
+      _make_fold_actual ~fold_name:"f1" ~variant_label:"O" ~total_return:3.0;
+      _make_fold_actual ~fold_name:"f2" ~variant_label:"O" ~total_return:12.0;
+    ]
+  in
+  let folds_path =
+    _write_sexp ~dir ~name:"fold_actuals.sexp"
+      ([%sexp_of: T.fold_actual list] folds)
+  in
+  let res =
+    _invoke ~dir [ "--aggregate"; agg_path; "--fold-actuals"; folds_path ]
+  in
+  assert_that res.exit_code (equal_to 0);
+  (* N still appears in the rendered table (Pareto ranking did not skip it),
+     and the skip note for N is on stderr. *)
+  assert_that res.stdout
+    (all_of
+       [
+         contains_substring "| M |";
+         contains_substring "| N |";
+         contains_substring "| O |";
+       ]);
+  assert_that res.stderr (contains_substring "N: only 1")
+
+(* 4. --aggregate missing → exit code non-zero, stderr explains. *)
+let test_missing_aggregate _ =
+  let dir = _make_tmpdir () in
+  let res = _invoke ~dir [] in
+  assert_that res.exit_code (gt (module Int_ord) 0);
+  assert_that res.stderr (contains_substring "--aggregate is required")
+
+(* 5. Pareto frontier renders correctly with one dominant + one dominated cell
+   — the frontier section lists only the winner. *)
+let test_pareto_single_dominator _ =
+  let dir = _make_tmpdir () in
+  let stability =
+    [
+      _make_stability ~label:"winner" ~sharpe:1.5 ~calmar:1.2 ~max_dd:10.0;
+      _make_stability ~label:"loser" ~sharpe:0.5 ~calmar:0.4 ~max_dd:30.0;
+    ]
+  in
+  let agg_path =
+    _write_sexp ~dir ~name:"aggregate.sexp"
+      (T.sexp_of_aggregate (_make_aggregate ~stability))
+  in
+  let res = _invoke ~dir [ "--aggregate"; agg_path ] in
+  assert_that res.exit_code (equal_to 0);
+  assert_that res.stdout
+    (all_of
+       [
+         (* The frontier markdown bullet list contains only "winner". *)
+         contains_substring "- winner";
+         (* "loser" appears in the per-variant table row but its frontier flag
+            is "no"; check by string match. *)
+         contains_substring "| loser |";
+       ]);
+  (* "- loser" as a frontier bullet should NOT appear; check by exact-frontier
+     section dump — the frontier section ends at "## Variants", so we slice
+     the prefix. *)
+  let frontier_end_offset =
+    match String.substr_index res.stdout ~pattern:"## Variants" with
+    | Some i -> i
+    | None -> String.length res.stdout
+  in
+  let frontier_section =
+    String.sub res.stdout ~pos:0 ~len:frontier_end_offset
+  in
+  assert_that frontier_section (not_ (contains_substring "- loser"))
+
+(* -------------- suite -------------- *)
+
+let suite =
+  "rank_variants_cli"
+  >::: [
+         "end_to_end_3_variants" >:: test_end_to_end_3_variants;
+         "no_fold_actuals" >:: test_no_fold_actuals;
+         "skip_variant_with_too_few_folds"
+         >:: test_skip_variant_with_too_few_folds;
+         "missing_aggregate" >:: test_missing_aggregate;
+         "pareto_single_dominator" >:: test_pareto_single_dominator;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Summary

Commits a `rank_variants` executable at
`trading/trading/backtest/walk_forward/bin/rank_variants.ml` that wraps
`Walk_forward.Variant_ranking.{rank,render}` over a `Walk_forward_runner`
`aggregate.sexp` (and optional `fold_actuals.sexp` for per-variant
Deflated Sharpe).

Pure consumer: the CLI does not modify `Variant_ranking` /
`Deflated_sharpe` — both libraries are battle-tested in their own suites
(6 + 14 tests respectively). Adds 5 new integration tests for the CLI
itself (subprocess-driven per the `cc_linter` test pattern).

Replaces the ad-hoc throwaway exes used in the #1375 (exit-timing
reject) and #1379 (early-admission inconclusive) verdicts; every future
ranking now has a committed, reproducible driver.

Closes Gap C's missing CLI surface from
`dev/plans/experiment-platform-2026-05-29.md`. Flips
`dev/status/experiment-platform.md` §Next Steps item 3.

## CLI surface

```
rank_variants \
  --aggregate <path-to-aggregate.sexp> \
  [--fold-actuals <path-to-fold_actuals.sexp>] \
  [--baseline-label <label>] \
  [--output <path>]
```

- `--aggregate` required (parses `Walk_forward_types.aggregate`).
- `--fold-actuals` optional — when present, computes per-variant DSR via
  `Backtest_stats.Deflated_sharpe.deflated_sharpe`. Skipped variants
  (fewer than 2 finite fold returns, or zero fold-return variance, or
  zero across-variant Sharpe variance) get a one-line stderr note and
  `n/a` in the rendered DSR column.
- `--baseline-label` defaults to `"baseline"`; informational only.
- `--output` defaults to stdout.

## DSR computation

For each variant in the aggregate's `stability` list:
- `observed_sharpe` = `sharpe_ratio.mean` from the aggregate row.
- `fold_returns` = filter `fold_actuals` by `variant_label`, drop NaN
  `total_return_pct`.
- `n_trials` = number of variants in the aggregate.
- `sharpe_variance_across_trials` = population variance of every
  variant's `sharpe_ratio.mean` (two-pass mean + sumsq).

## Test plan

- [x] `dune build` — clean
- [x] `dune build @fmt` — clean
- [x] `dune runtest trading/backtest/walk_forward/test/` — 5 new tests
  OK; full walk_forward suite green
- [x] Full `dune runtest` — exit 0

## PR sizing

- Impl: ~230 LOC (`rank_variants.ml`, single file + dune target update)
- Tests: ~290 LOC (`test_rank_variants.ml`, single file + dune target
  update)
- Status: 1 file, +11/-5
- One new module, no existing modules modified.

🤖 Dispatched by GHA orchestrator run [26685621924](https://github.com/dayfine/trading/actions/runs/26685621924)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
