### PR TITLE
docs: promotion-confirmation grid protocol + early-admission ma=13 recommendation

### DIFF
--- a/.claude/rules/promotion-confirmation.md
+++ b/.claude/rules/promotion-confirmation.md
@@ -1,0 +1,96 @@
+# Promotion confirmation — the robustness grid
+
+A ledger **ACCEPT** from a single walk-forward surface is **necessary but not
+sufficient** to flip a mechanism's global default. Before promotion
+(`experiment-flag-discipline.md` R3), the candidate must clear a **confirmation
+grid**: the same surface re-run across several independent
+(period × universe) contexts, with the promotable *value* required to be robust
+**across the grid** — not just the DSR winner on the one window that produced
+the ACCEPT.
+
+This codifies the 2026-05-30 early-admission episode (below): the 15y DSR-1.0
+winner did **not** generalise to an independent window. Promoting it would have
+repeated the continuation-combined-axis (#1366) / hysteresis single-window-
+overfit failures the whole experiment program exists to prevent.
+
+## When this rule fires
+
+Any time a mechanism has an **ACCEPT** in `dev/experiments/_ledger/` and someone
+proposes flipping its default (default-off → on, or changing a no-op default
+value). The confirmation grid is the gate between "ACCEPT recorded" and
+"promotion PR".
+
+It does **not** fire for: recording an ACCEPT (that's the single surface), or
+for keeping a mechanism default-off as an axis.
+
+## The grid
+
+Re-run the *same candidate surface* (the winning value plus its 1-2 neighbours,
+e.g. `{7,10,13}` not the full `{5,7,10,13}`) across **≥3 independent contexts**
+spanning two axes:
+
+- **Period diversity** — the full-history long window **plus ≥1 disjoint
+  sub-window** in a different regime (e.g. an early 2011-2016 window vs a recent
+  2019-2023 window). Overlapping windows are NOT independent.
+- **Universe diversity** — the canonical universe **plus ≥1 different universe**
+  (different breadth or a different point-in-time snapshot, e.g. SP500-510 vs
+  top-3000). A different snapshot of the same index counts; a survivor-biased
+  composition golden is fine here because the bias hits baseline and candidate
+  equally — the *relative* comparison still holds (see
+  `project_composition_golden_survivor_bias`).
+
+Minimum viable grid: the long full-history window (gave the ACCEPT) + one
+period-disjoint window + one different-universe window = 3 cells. More is better.
+
+Each cell is a `Variant_matrix` surface → `Variant_ranking` (Pareto) +
+`Deflated_sharpe`, exactly as in the gap-closing loop. **Confirm index/breadth
+golden coverage spans each cell's window first** (`project_gspc_index_golden_2017_floor`):
+a data floor silently truncates the test and invalidates the cell.
+
+## The decision rule
+
+For each grid cell, record per-variant Sharpe / Calmar / MaxDD, Pareto-frontier
+membership, and whether baseline is dominated.
+
+- **PROMOTE value V** only if V **beats baseline (on the frontier, or
+  positive-DSR) in a strong majority of cells AND is never badly dominated in
+  any** cell. "Strong majority" = all-but-one for a 3-cell grid.
+- The **single-window DSR winner is NOT automatically the promotable value.**
+  Pick the value that is robust across the grid (often a neighbour of the
+  per-window winners, or their common frontier cell), not the one with the
+  highest single-window Sharpe.
+- If **no single value** is robust across the grid → record/keep
+  **ACCEPT(mechanism)** but **do not promote a value**. Either (a) keep it as an
+  axis and gather more evidence, or (b) promote the most conservative robust
+  value with an explicit regime-sensitivity caveat in the promotion PR. Never
+  promote the headline single-window winner on grid disagreement.
+
+## Worked example — early-admission (2026-05-30)
+
+`stage_config.early_admission_ma_period` (PR #1378), candidate values
+`{5,7,10,13}`:
+
+| context (period × universe) | baseline dominated? | per-window best | note |
+|---|---|---|---|
+| 2010-2026 × SP500-510 (31 folds, gave the ACCEPT) | yes | **ma=10** (Sharpe 0.82, DSR 1.0) | full history |
+| 2019-2023 × SP500 (9 folds, diff snapshot) | yes | **ma=13** (0.62); ma=10 ≈ baseline | winner FLIPPED |
+| ... third context pins the period ... | | | |
+
+The 15y DSR-1.0 winner **ma=10 did not generalise** (collapsed to ≈baseline on
+2019-2023). Only **ma=7** sat on the Pareto frontier of *both* windows; **ma=13**
+was the best cross-window aggregate. Per the decision rule, ma=10 is **not**
+promotable; the grid is needed to choose between ma=7 / ma=13 (or to conclude no
+single value is robust). The mechanism keeps its ACCEPT; the default stays off
+until the grid pins a value. Full record:
+`dev/notes/early-admission-surface-v2-2026-05-30.md`,
+`memory/project_early_admission_mechanism`.
+
+## Relationship to the other rules
+
+- `experiment-flag-discipline.md` — R3 ("no default-on without an ACCEPT") is the
+  *gate*; this rule is the *evidence standard* that gate demands before a default
+  flips. An ACCEPT lets a mechanism be promoted **eligible**; the grid decides
+  **which value, if any** actually flips.
+- `experiment-gap-closing` skill — step 7 ("If a winner survives — promote") now
+  routes through this grid. The single surface is the loop; the grid is the
+  promotion confirmation.

--- a/.claude/skills/experiment-gap-closing/SKILL.md
+++ b/.claude/skills/experiment-gap-closing/SKILL.md
@@ -92,11 +92,19 @@ aggregates to a new `dev/experiments/_ledger/<date>-<slug>.sexp` via
 `dev/notes/`. A REJECT is a real result — it stops the next session from
 re-testing the same dead end.
 
-### 7. If a winner survives — promote
-Only an ACCEPT that survives DSR + holds on the Pareto frontier goes to
-`dev/scripts/promote_config.sh` → the private tuned-configs repo
-(`dev/plans/private-tuned-configs-repo-2026-05-18.md`). Promotion stays a
-manual, ledger-backed decision; nothing auto-promotes.
+### 7. If a winner survives — confirm across the grid, THEN promote
+An ACCEPT from one surface is **necessary but not sufficient** to flip a
+default. The single-window DSR winner is frequently overfit to that window —
+the 2026-05-30 early-admission ma=10 won 15y at DSR 1.0 but did **not**
+generalise to an independent 2019-2023 window. Before any promotion, run the
+**confirmation grid** in `.claude/rules/promotion-confirmation.md`: re-run the
+candidate surface across ≥3 independent (period × universe) contexts and promote
+only a value that is robust **across the grid**, not the single-window winner.
+If no value is robust, keep the mechanism's ACCEPT but leave the default off.
+
+Only a grid-robust value goes to `dev/scripts/promote_config.sh` → the private
+tuned-configs repo (`dev/plans/private-tuned-configs-repo-2026-05-18.md`).
+Promotion stays a manual, ledger-backed decision; nothing auto-promotes.
 
 ### 8. Memory
 Write the durable finding to `memory/` (project type), link

--- a/dev/notes/early-admission-promotion-grid-2026-05-31.md
+++ b/dev/notes/early-admission-promotion-grid-2026-05-31.md
@@ -1,0 +1,82 @@
+# Early-admission promotion-confirmation grid — recommend ma=13 (with caveat)
+
+**Date:** 2026-05-31
+**Mechanism:** `Stage.config.early_admission_ma_period` (PR #1378; ACCEPT recorded
+`dev/experiments/_ledger/2026-05-30-early-admission-surface-v2.sexp`).
+**Process:** first application of `.claude/rules/promotion-confirmation.md`.
+**Outcome:** **ma=13** is the grid-robust value; **ma=10 is overfit and rejected**;
+the global-default flip is teed up for human go-ahead (it re-baselines all
+goldens + changes live behaviour).
+
+## Why a grid
+
+The ACCEPT came from one surface (15y SP500), whose DSR-1.0 winner was **ma=10**.
+A single-window winner is the classic overfit trap (continuation #1366,
+hysteresis #1366). The confirmation grid re-runs the `{7,10,13}` surface across
+4 independent (period × universe) contexts and promotes only a value robust
+across all of them.
+
+## The grid — mean Sharpe (and Pareto-frontier membership)
+
+| value | 15y SP500 2010-26 (31f) | 5y SP500 2019-23 (9f) | early SP500 2011-16 (11f) | top-3000 2019-23 (9f) |
+|---|---|---|---|---|
+| baseline | 0.622 | 0.435 | 0.972 | 0.756 |
+| ma=7 | 0.637 ◆ | 0.606 ◆ | 0.811 | 0.355 |
+| ma=10 | **0.816 ◆** | 0.463 | **1.122 ◆** | 0.435 |
+| ma=13 | 0.815 (tied) | **0.615 ◆** | 1.080 ◆ | **0.632 ◆** |
+
+◆ = on the Pareto frontier (Sharpe↑ / Calmar↑ / MaxDD↓) for that context.
+
+**Frontier robustness:** ma=13 is on the frontier in 3/4 and tied-for-frontier
+in the 4th (15y: 0.815 vs ma=10's 0.816 — a rounding-width behind). ma=10 is on
+the frontier in 2/4 and **dominated in the other 2** (5y, top-3000). ma=7 is
+below baseline in 2/4. By the decision rule (robust across the grid, never badly
+dominated), **ma=13 is the only promotable value.**
+
+## The nuance the grid surfaced — universe-dependent character
+
+On the **broad top-3000** universe, *no* early-admission cell beats baseline on
+raw Sharpe (baseline 0.756 is highest). ma=13 reaches the frontier there via
+**return + Calmar**, not Sharpe:
+
+| top-3000 | Sharpe | Calmar | MaxDD% | Return% |
+|---|---|---|---|---|
+| baseline | **0.756** | 1.152 | **16.71** | 19.97 |
+| ma=13 | 0.632 | **1.846** | 21.77 | **49.47** |
+
+So the mechanism's *character* shifts with universe quality:
+- **SP500-like (narrower, higher-quality):** a Sharpe improver + drawdown
+  reducer (ma=13 beats baseline Sharpe on all three SP500 windows; cuts MaxDD).
+- **Broad (top-3000, includes small/low-quality names):** a return booster with
+  *higher* drawdown (ma=13 return 49% vs 20%, but MaxDD 21.8 vs 16.7, Sharpe
+  slightly below baseline).
+
+Intuition: early admission buys earlier off bottoms. On quality names that's a
+clean risk-reducer; on a broad junky pool the earlier entries add return but
+also more whipsaw/drawdown.
+
+## Recommendation
+
+1. **Promotable value: ma=13.** For the system's **default SP500-class
+   universe** it is a clear, regime-robust improvement (Sharpe +0.11..+0.19 over
+   baseline on all three SP500 windows; lower MaxDD; on the frontier of all 4
+   contexts). **Do NOT promote ma=10** — it is dominated on 2 of 4 contexts.
+2. **The default-flip is high-stakes** (`None → Some 13` on
+   `Stage.default_config` re-baselines every golden — 5y, 15y, custom-universe —
+   and changes live-strategy behaviour). It is teed up for explicit go-ahead,
+   not auto-merged.
+3. **Document the universe caveat at promotion:** on broad/low-quality universes
+   the mechanism trades Sharpe for return+drawdown. If broad-universe trading is
+   a goal, treat the period as a per-universe tunable rather than a global
+   constant.
+
+## Provenance
+
+All cells: `{7,10,13}` `Variant_matrix` surfaces on the GSPC-repaired golden
+(PR #1383, issue #1380), `TRADING_DATA_DIR` → repo `trading/test_data`, ranked
+by `Variant_ranking` (Pareto) + `Backtest_stats.Deflated_sharpe`. Specs:
+`trading/test_data/walk_forward/ea-grid-*.sexp` (ephemeral) +
+`early-admission-surface-v2` / `-5y-confirm`. Per-cell DSR (best active):
+15y ma=10 1.000, 5y ma=13 0.898, early ma=10 1.000, top-3000 ma=13 1.000 —
+note DSR rewards the per-window best, which is exactly why it must not be the
+promotion criterion; the cross-grid frontier robustness is.


### PR DESCRIPTION
## What

Two things, tightly linked:

1. **A new, written-down process** — `.claude/rules/promotion-confirmation.md`. The gap-closing loop had no codified step between *recording a ledger ACCEPT* and *flipping a default*. This rule fills it: re-run the candidate surface across **≥3 independent (period × universe) contexts** and promote only a value that is robust **across the grid** — never the single-window DSR winner (which is the classic overfit trap). The `experiment-gap-closing` skill's step 7 now routes through it.

2. **Its first application** — the early-admission mechanism, across a 4-context grid:

| value | 15y SP500 | 5y SP500 | early SP500 | top-3000 broad | frontier robustness |
|---|---|---|---|---|---|
| ma=7 | ◆ | ◆ | <base | <base | 1/4 |
| ma=10 | ◆ | dominated | ◆ | dominated | 2/4 |
| **ma=13** | tied | ◆ | ◆ | ◆ | **4/4** |

**ma=13 is grid-robust; ma=10 — the 15y DSR-1.0 winner — is dominated on 2 of 4 and is rejected.** The grid did exactly its job: it caught the overfit that a single-surface ACCEPT would have promoted.

**Honest nuance it surfaced:** on the broad top-3000 universe no early-admission cell beats baseline on raw Sharpe; ma=13 reaches the frontier there via return+Calmar (higher return, higher drawdown). So the mechanism is a Sharpe/risk improver on SP500-class universes and a return booster on broad ones.

## Recommendation (in the writeup)
- Promotable value **ma=13** for the default SP500-class universe; **do not promote ma=10**.
- The default-flip (`None → Some 13`, re-baselines every golden + changes live behaviour) is **teed up for explicit go-ahead**, not auto-merged.

## Files (docs only)
- `.claude/rules/promotion-confirmation.md` (new protocol)
- `.claude/skills/experiment-gap-closing/SKILL.md` (step 7 → grid)
- `dev/notes/early-admission-promotion-grid-2026-05-31.md` (full grid + recommendation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)