### PR TITLE
docs(notes): add SPY single-instrument reference strategy (P0)

### DIFF
--- a/dev/notes/next-session-priorities-2026-06-01.md
+++ b/dev/notes/next-session-priorities-2026-06-01.md
@@ -44,6 +44,54 @@ Confirm the fork with the user before dispatching. The default lean (mine): **A*
 — it's the apparatus that makes B and C *trustworthy*, and it's infra not
 strategy-exploration, so it's the safest high-value work to do unsupervised.
 
+## P0 · SPY single-instrument reference strategy (user-requested 2026-05-31)
+
+Build a **new, separate** Weinstein strategy that trades **only SPY** (single
+instrument) on 30-week-MA stage timing — long when SPY is in Stage 2 (above a
+rising 30-week MA), flat/short in Stage 4 — reusing what we have. It is a
+**testbed + reference**, NOT a production strategy and NOT a change to the main
+strategy's defaults. It cuts both ways:
+
+- **Direction-finder for the main strategy.** SPY is the cleanest possible
+  signal: no cross-sectional selection, no position sizing, no sector
+  concentration, no macro-gate confound (SPY *is* the market). A mechanism that
+  helps here is a strong candidate to port to the main multi-symbol strategy; one
+  that doesn't help even on the clean signal almost certainly won't survive the
+  noisier 500-symbol setting. It is the cheapest way to triage the autopsy's gap
+  modes — and a direct test of whether this session's three rejections
+  (early-admission, exit-timing, hysteresis) are *universe-specific* (they were
+  all measured on the 500-symbol SP500) or *mechanism-dead* (fail on SPY too).
+- **Realistic bound on the autopsy.** The trade-autopsy's missed-gain figures
+  (e.g. late_reentry + stage3_false_positive ~+2734% over 27y×12sym) are
+  **perfect-hindsight per-trade upper bounds**. A *tradeable* SPY stage strategy
+  gives a **realizable** number — how much of that claimed headroom a disciplined
+  rule actually captures — which bounds how much of the autopsy is real vs.
+  hindsight artifact. The autopsy is a labeller (`project_stage3_hysteresis_*`);
+  this puts a floor and a ceiling around its claims.
+
+**Reuse (the "try to reuse what we have" ask):** the existing `STRATEGY` module
+type + `on_market_close`; the stage classifier + 30-week MA; the Weinstein
+trailing-stop machinery; the simulator; the **BAH-SPY benchmark** (already exists,
+PR #882) as the bar to beat. A 1-symbol universe. **Strip** the screener cascade /
+ranking / sizing / macro gate — for a single instrument they're degenerate; the
+strategy is pure stage-timing on SPY's own series. Needs **SPY bars** (the ETF,
+`SPY.US`, tradeable since 1993 — fetch via `build_deep_universe.sh` / the
+`fetch-historical-data` skill; we have GSPC.INDX deep to 1999 for cross-check but
+SPY is the tradeable instrument).
+
+**The test.** vs BAH-SPY on the deep window (incl. dot-com + GFC): Weinstein's
+whole claim is that Stage-4 exits dodge the big drawdowns, so stage-timed SPY
+should win on **risk-adjusted** terms (Sharpe/Calmar) even if it trails on raw
+return in a bull run. Then **tweak toward the autopsy headroom** — apply the same
+gap-mode mechanisms (earlier re-entry, stage3 hysteresis/exit-margin, early
+Stage-2 admission) as axes on SPY and see which, if any, recover gain on the clean
+signal. Record in the ledger like any surface; the deep cell is mandatory.
+
+**Caveat.** SPY-only is a *market-timing* strategy, a different beast from the
+stock-picking main strategy — it informs direction and bounds the autopsy; it is
+not itself the product. Lands as a new strategy module behind its own scenario;
+touches no existing default (per `experiment-flag-discipline`).
+
 ## P1 · Population-search apparatus — the buildable, low-risk path toward (A)
 
 Each step is independently valuable even if the full multi-arm engine is never

--- a/dev/notes/next-session-priorities-2026-06-01.md
+++ b/dev/notes/next-session-priorities-2026-06-01.md
@@ -92,6 +92,41 @@ stock-picking main strategy — it informs direction and bounds the autopsy; it 
 not itself the product. Lands as a new strategy module behind its own scenario;
 touches no existing default (per `experiment-flag-discipline`).
 
+### Build plan (scoped 2026-05-31 — Explore reuse map)
+
+**Reuse as-is:** `Strategy_interface.STRATEGY` (symbol-agnostic `on_market_close`,
+`trading/trading/strategy/lib/strategy_interface.mli`), `Stage.classify` (pure,
+`analysis/weinstein/stage/lib/stage.mli`), `Macro.analyze`, `Weinstein_stops`,
+`Bar_reader`, and the **already-wired `Bah_benchmark` strategy +
+`universes/spy-only.sexp`** as the benchmark/universe.
+
+**New (the clean path — do NOT try to run the main strategy on a 1-symbol
+universe; its screener/ranking/sizing are too entangled):**
+- `trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.{mli,ml}`
+  (~250-350 lines). Friday: `Stage.classify` SPY → Stage2 buy `floor(cash/close)`,
+  Stage3→4 sell-all; daily: `Weinstein_stops` trailing. Reuses macro gate
+  optionally (degenerate for SPY — make it a no-op/flag).
+- `trading/test_data/backtest_scenarios/spy-only-stage2.sexp` scenario.
+- Wire `Spy_only_weinstein` into `Strategy_choice.{mli,ml}` + `Panel_runner`
+  `_build_strategy` (mirror the `Bah_benchmark` arm).
+
+**Data:** SPY bars present **2009-2026** (`test_data/S/Y/SPY/`) — enough for a
+first cut. **Deep 1998/2000-2026 SPY needs a fetch** (the autopsy ran SPY
+1998-2025, so it's available via the `fetch-historical-data` skill) — follow-on,
+required before the deep-cell test.
+
+**Sequence:** (1) module + scenario + tests, first result vs **BAH-SPY** on
+2009-2026 — does stage-timing win risk-adjusted (Sharpe/Calmar)? (2) fetch deep
+SPY, re-test on 2000-2026. (3) add the autopsy gap modes as axes (stage3
+hysteresis/exit-margin, early-admission, re-entry) — the same knobs rejected on
+500-symbol — and see which recover gain on the clean SPY signal. Ledger each;
+deep cell mandatory.
+
+**Autopsy headroom (the bound):** late_reentry +1557% / stage3_false_positive
++1176% / late_stage2_admission +505% (`dev/notes/trade-autopsy-2026-05-29.md`,
+SPY + 11 SPDR ETFs 1998-2025). These are perfect-hindsight upper bounds; the SPY
+strategy's realized capture is the floor that bounds them.
+
 ## P1 · Population-search apparatus — the buildable, low-risk path toward (A)
 
 Each step is independently valuable even if the full multi-arm engine is never


### PR DESCRIPTION
Adds the user-requested SPY-only Weinstein stage strategy to the 2026-06-01 priorities as P0. A testbed that (1) finds direction for the main strategy on the cleanest possible signal and (2) puts a realizable bound on the autopsy's hindsight headroom. Reuses existing strategy/classifier/stop machinery; strips the multi-symbol cascade. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)