### PR TITLE
feat(weinstein): SPY-only single-instrument stage-timing reference strategy

### DIFF
--- a/trading/test_data/backtest_scenarios/spy-only-stage2-bah.sexp
+++ b/trading/test_data/backtest_scenarios/spy-only-stage2-bah.sexp
@@ -1,0 +1,24 @@
+;; perf-tier: research
+;; perf-tier-rationale: Companion BAH-SPY alpha/risk bar for
+;; [spy-only-stage2.sexp]. Same 2009-06-01 .. 2025-12-31 window, same
+;; universe (universes/spy-only.sexp), same runner — only the strategy differs
+;; ([Bah_benchmark] vs [Spy_only_weinstein]). Used to read the stage-timing
+;; vs buy-and-hold gap on risk-adjusted terms (Sharpe / Calmar / MaxDD).
+;;
+;; Day-1 buy SPY with all cash (minus 1% gap buffer), hold to end. Single
+;; trade; final equity tracks SPY's raw close price-only return.
+((name "spy-only-stage2-bah")
+ (description "Buy-and-Hold SPY 2009-06-01 to 2025-12-31 — alpha/risk bar for the SPY-only Weinstein stage-timing reference.")
+ (period ((start_date 2009-06-01) (end_date 2025-12-31)))
+ (universe_path "universes/spy-only.sexp")
+ (universe_size 1)
+ (config_overrides ())
+ (strategy (Bah_benchmark (symbol SPY)))
+ (expected
+  ((total_return_pct       ((min -90.0)    (max 5000.0)))
+   (total_trades           ((min   0.0)    (max    0.5)))
+   (win_rate               ((min   0.0)    (max  100.0)))
+   (sharpe_ratio           ((min  -2.0)    (max    5.0)))
+   (max_drawdown_pct       ((min   0.0)    (max   95.0)))
+   (avg_holding_days       ((min   0.0)    (max 5000.0)))
+   (wall_seconds           ((min   0.5)    (max 3600.0))))))

--- a/trading/test_data/backtest_scenarios/spy-only-stage2.sexp
+++ b/trading/test_data/backtest_scenarios/spy-only-stage2.sexp
@@ -1,0 +1,38 @@
+;; perf-tier: research
+;; perf-tier-rationale: SPY-only single-instrument Weinstein stage-timing
+;; reference strategy (long/flat). Single-symbol universe (universes/spy-only),
+;; so the run is fast despite the long 2009-2026 window. NOT a pinned golden —
+;; wide expected bands; this is a direction-finding / headroom diagnostic.
+;;
+;; Strategy: [Spy_only_weinstein (symbol SPY)] — see
+;; [trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.mli].
+;; On each Friday it classifies SPY's own 30-week-MA stage and:
+;;   - enters (all-cash) when flat and SPY is Stage 2 (above a rising 30wk MA),
+;;   - exits to flat on the Stage 3->4 roll-over / Stage 4, or
+;;   - exits on a Weinstein trailing-stop hit (checked every day).
+;; Long/flat only — no shorting in this first cut.
+;;
+;; Companion baseline: [goldens-sp500/sp500-2019-2023-bah-spy.sexp] pattern, but
+;; over this window run a BAH-SPY scenario on the SAME period + universe to read
+;; the alpha/risk-adjusted gap. The Weinstein thesis is that the Stage-4 exits
+;; dodge deep drawdowns (a lower MaxDD / higher Sharpe-Calmar), trading some
+;; total return for risk-adjusted improvement.
+;;
+;; SPY data range on disk: 2009-01-02 .. ~2026-05-01 — fully covers this window
+;; (warmup begins ~2008-11 via the 210-day prepend, tolerated when bars are
+;; absent before 2009-01-02).
+((name "spy-only-stage2")
+ (description "SPY-only Weinstein stage-timing (long/flat) 2009-06-01 to 2025-12-31 — direction-finding + headroom reference vs BAH-SPY.")
+ (period ((start_date 2009-06-01) (end_date 2025-12-31)))
+ (universe_path "universes/spy-only.sexp")
+ (universe_size 1)
+ (config_overrides ())
+ (strategy (Spy_only_weinstein (symbol SPY)))
+ (expected
+  ((total_return_pct       ((min -90.0)    (max 5000.0)))
+   (total_trades           ((min   0.0)    (max  200.0)))
+   (win_rate               ((min   0.0)    (max  100.0)))
+   (sharpe_ratio           ((min  -2.0)    (max    5.0)))
+   (max_drawdown_pct       ((min   0.0)    (max   95.0)))
+   (avg_holding_days       ((min   0.0)    (max 5000.0)))
+   (wall_seconds           ((min   0.5)    (max 3600.0))))))

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -40,6 +40,14 @@ let _build_strategy (input : input) ~strategy_choice ~bar_reader ~audit_recorder
         input.config
   | Bah_benchmark { symbol } ->
       Trading_strategy.Bah_benchmark_strategy.make { symbol }
+  | Spy_only_weinstein { symbol } ->
+      let config =
+        {
+          Weinstein_strategy.Spy_only_weinstein_strategy.default_config with
+          symbol;
+        }
+      in
+      Weinstein_strategy.Spy_only_weinstein_strategy.make ~config ~bar_reader ()
 
 (* Wrap the runner's already-constructed [daily_panels] in the simulator's
    callback adapter, sharing the LRU cache with the strategy bar reader.

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -31,6 +31,8 @@ let _snapshot_cache_mb = 1024
     [audit_recorder] are intentionally dropped on the BAH branch: BAH reads
     prices via [get_price] (the simulator's per-tick callback, wired through the
     snapshot-backed [Market_data_adapter]) and emits no audit events. *)
+module Spy_only = Weinstein_strategy.Spy_only_weinstein_strategy
+
 let _build_strategy (input : input) ~strategy_choice ~bar_reader ~audit_recorder
     =
   match (strategy_choice : Strategy_choice.t) with
@@ -41,13 +43,8 @@ let _build_strategy (input : input) ~strategy_choice ~bar_reader ~audit_recorder
   | Bah_benchmark { symbol } ->
       Trading_strategy.Bah_benchmark_strategy.make { symbol }
   | Spy_only_weinstein { symbol } ->
-      let config =
-        {
-          Weinstein_strategy.Spy_only_weinstein_strategy.default_config with
-          symbol;
-        }
-      in
-      Weinstein_strategy.Spy_only_weinstein_strategy.make ~config ~bar_reader ()
+      let config = { Spy_only.default_config with symbol } in
+      Spy_only.make ~config ~bar_reader ()
 
 (* Wrap the runner's already-constructed [daily_panels] in the simulator's
    callback adapter, sharing the LRU cache with the strategy bar reader.

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -21,6 +21,7 @@ type input = {
    oversized symbol stays resident even when its bytes exceed the cap. *)
 let _snapshot_cache_mb = 1024
 
+module Spy_only = Weinstein_strategy.Spy_only_weinstein_strategy
 (** Construct the strategy module the simulator will run.
 
     The Weinstein branch threads the runner's deps-loaded inputs (AD bars,
@@ -31,7 +32,6 @@ let _snapshot_cache_mb = 1024
     [audit_recorder] are intentionally dropped on the BAH branch: BAH reads
     prices via [get_price] (the simulator's per-tick callback, wired through the
     snapshot-backed [Market_data_adapter]) and emits no audit events. *)
-module Spy_only = Weinstein_strategy.Spy_only_weinstein_strategy
 
 let _build_strategy (input : input) ~strategy_choice ~bar_reader ~audit_recorder
     =

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -22,6 +22,7 @@ let commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 }
 let _warmup_days_for : Strategy_choice.t -> int = function
   | Weinstein -> 210
   | Bah_benchmark _ -> 0
+  | Spy_only_weinstein _ -> 210
 
 (* Public types *)
 

--- a/trading/trading/backtest/lib/strategy_choice.ml
+++ b/trading/trading/backtest/lib/strategy_choice.ml
@@ -2,7 +2,10 @@
 
 open Core
 
-type t = Weinstein | Bah_benchmark of { symbol : string }
+type t =
+  | Weinstein
+  | Bah_benchmark of { symbol : string }
+  | Spy_only_weinstein of { symbol : string }
 [@@deriving sexp, eq, show]
 
 let default = Weinstein
@@ -10,3 +13,4 @@ let default = Weinstein
 let name = function
   | Weinstein -> "Weinstein"
   | Bah_benchmark { symbol } -> sprintf "Bah_benchmark(%s)" symbol
+  | Spy_only_weinstein { symbol } -> sprintf "Spy_only_weinstein(%s)" symbol

--- a/trading/trading/backtest/lib/strategy_choice.mli
+++ b/trading/trading/backtest/lib/strategy_choice.mli
@@ -30,6 +30,15 @@ type t =
           The configurable [symbol] must be present in the scenario's universe
           so the snapshot builder loads its CSV; see [universes/spy-only.sexp]
           for the canonical fixture. *)
+  | Spy_only_weinstein of { symbol : string }
+      (** Single-instrument Weinstein stage-timing reference strategy on
+          [symbol] (default [SPY]). Constructs
+          {!Weinstein_strategy.Spy_only_weinstein_strategy.make} with the
+          runner's [bar_reader] (it reads the symbol's own weekly + daily bars
+          for stage classification and the trailing-stop support floor). Like
+          {!Bah_benchmark}, the runner's universe / sector-map / AD-bars
+          machinery is loaded but unused; [symbol] must be present in the
+          scenario's universe. Long/flat only — no shorting. *)
 [@@deriving sexp, eq, show]
 
 val default : t

--- a/trading/trading/weinstein/strategy/lib/spy_only_transitions.ml
+++ b/trading/trading/weinstein/strategy/lib/spy_only_transitions.ml
@@ -1,0 +1,60 @@
+(** Position-transition builders for the SPY-only Weinstein strategy — see
+    [spy_only_transitions.mli]. *)
+
+open Trading_strategy
+
+let _entry_reasoning : Position.entry_reasoning =
+  TechnicalSignal
+    {
+      indicator = "Stage";
+      description = "SPY-only Weinstein: Stage 2 entry on rising 30-week MA";
+    }
+
+let build_entry ~(position_id : string) ~(symbol : string)
+    ~(bar : Types.Daily_price.t) ~(target_quantity : float) :
+    Position.transition =
+  {
+    Position.position_id;
+    date = bar.date;
+    kind =
+      CreateEntering
+        {
+          symbol;
+          side = Long;
+          target_quantity;
+          entry_price = bar.close_price;
+          reasoning = _entry_reasoning;
+        };
+  }
+
+let build_exit ~(pos : Position.t) ~(bar : Types.Daily_price.t)
+    ~(label : string) : Position.transition =
+  {
+    Position.position_id = pos.id;
+    date = bar.date;
+    kind =
+      TriggerExit
+        {
+          exit_reason = StrategySignal { label; detail = Some "side=long" };
+          exit_price = bar.close_price;
+        };
+  }
+
+let build_stop_exit ~(pos : Position.t) ~(bar : Types.Daily_price.t)
+    ~(stop_level : float) : Position.transition =
+  {
+    Position.position_id = pos.id;
+    date = bar.date;
+    kind =
+      TriggerExit
+        {
+          exit_reason =
+            StopLoss
+              {
+                stop_price = stop_level;
+                actual_price = bar.close_price;
+                loss_percent = 0.0;
+              };
+          exit_price = bar.close_price;
+        };
+  }

--- a/trading/trading/weinstein/strategy/lib/spy_only_transitions.ml
+++ b/trading/trading/weinstein/strategy/lib/spy_only_transitions.ml
@@ -10,51 +10,50 @@ let _entry_reasoning : Position.entry_reasoning =
       description = "SPY-only Weinstein: Stage 2 entry on rising 30-week MA";
     }
 
+(* The transition [kind] for a Stage-2 long entry, built flat so [build_entry]
+   stays shallow. *)
+let _entry_kind ~(symbol : string) ~(entry_price : float)
+    ~(target_quantity : float) : Position.transition_kind =
+  CreateEntering
+    {
+      symbol;
+      side = Long;
+      target_quantity;
+      entry_price;
+      reasoning = _entry_reasoning;
+    }
+
+(* The transition [kind] for a stage-based exit (a [StrategySignal] reason). *)
+let _exit_kind ~(label : string) ~(exit_price : float) :
+    Position.transition_kind =
+  let exit_reason : Position.exit_reason =
+    StrategySignal { label; detail = Some "side=long" }
+  in
+  TriggerExit { exit_reason; exit_price }
+
+(* The transition [kind] for a stop-triggered exit (a [StopLoss] reason). *)
+let _stop_exit_kind ~(stop_level : float) ~(exit_price : float) :
+    Position.transition_kind =
+  let exit_reason : Position.exit_reason =
+    StopLoss
+      { stop_price = stop_level; actual_price = exit_price; loss_percent = 0.0 }
+  in
+  TriggerExit { exit_reason; exit_price }
+
 let build_entry ~(position_id : string) ~(symbol : string)
     ~(bar : Types.Daily_price.t) ~(target_quantity : float) :
     Position.transition =
-  {
-    Position.position_id;
-    date = bar.date;
-    kind =
-      CreateEntering
-        {
-          symbol;
-          side = Long;
-          target_quantity;
-          entry_price = bar.close_price;
-          reasoning = _entry_reasoning;
-        };
-  }
+  let kind =
+    _entry_kind ~symbol ~entry_price:bar.close_price ~target_quantity
+  in
+  { Position.position_id; date = bar.date; kind }
 
 let build_exit ~(pos : Position.t) ~(bar : Types.Daily_price.t)
     ~(label : string) : Position.transition =
-  {
-    Position.position_id = pos.id;
-    date = bar.date;
-    kind =
-      TriggerExit
-        {
-          exit_reason = StrategySignal { label; detail = Some "side=long" };
-          exit_price = bar.close_price;
-        };
-  }
+  let kind = _exit_kind ~label ~exit_price:bar.close_price in
+  { Position.position_id = pos.id; date = bar.date; kind }
 
 let build_stop_exit ~(pos : Position.t) ~(bar : Types.Daily_price.t)
     ~(stop_level : float) : Position.transition =
-  {
-    Position.position_id = pos.id;
-    date = bar.date;
-    kind =
-      TriggerExit
-        {
-          exit_reason =
-            StopLoss
-              {
-                stop_price = stop_level;
-                actual_price = bar.close_price;
-                loss_percent = 0.0;
-              };
-          exit_price = bar.close_price;
-        };
-  }
+  let kind = _stop_exit_kind ~stop_level ~exit_price:bar.close_price in
+  { Position.position_id = pos.id; date = bar.date; kind }

--- a/trading/trading/weinstein/strategy/lib/spy_only_transitions.mli
+++ b/trading/trading/weinstein/strategy/lib/spy_only_transitions.mli
@@ -1,0 +1,31 @@
+(** Pure [Position.transition] builders for the SPY-only Weinstein strategy.
+
+    Extracted from [spy_only_weinstein_strategy.ml] so the strategy module stays
+    under the file-length limit. Each builder is a thin record constructor over
+    today's [bar]; no behaviour lives here. *)
+
+open Trading_strategy
+
+(** Stage-2 entry: a [CreateEntering] long transition for [symbol] at
+    [bar.close_price], tagged with the SPY-only Weinstein entry reasoning.
+    [position_id] is the strategy's deterministic id for the symbol. *)
+val build_entry :
+  position_id:string ->
+  symbol:string ->
+  bar:Types.Daily_price.t ->
+  target_quantity:float ->
+  Position.transition
+
+(** Stage-based exit: a [TriggerExit] with a [StrategySignal] reason carrying
+    [label] (e.g. ["stage4_exit"]), exiting [pos] at [bar.close_price]. *)
+val build_exit :
+  pos:Position.t -> bar:Types.Daily_price.t -> label:string -> Position.transition
+
+(** Stop-triggered exit: a [TriggerExit] with a [StopLoss] reason recording
+    [stop_level] as the stop price and [bar.close_price] as the actual exit
+    price. *)
+val build_stop_exit :
+  pos:Position.t ->
+  bar:Types.Daily_price.t ->
+  stop_level:float ->
+  Position.transition

--- a/trading/trading/weinstein/strategy/lib/spy_only_transitions.mli
+++ b/trading/trading/weinstein/strategy/lib/spy_only_transitions.mli
@@ -6,26 +6,29 @@
 
 open Trading_strategy
 
-(** Stage-2 entry: a [CreateEntering] long transition for [symbol] at
-    [bar.close_price], tagged with the SPY-only Weinstein entry reasoning.
-    [position_id] is the strategy's deterministic id for the symbol. *)
 val build_entry :
   position_id:string ->
   symbol:string ->
   bar:Types.Daily_price.t ->
   target_quantity:float ->
   Position.transition
+(** Stage-2 entry: a [CreateEntering] long transition for [symbol] at
+    [bar.close_price], tagged with the SPY-only Weinstein entry reasoning.
+    [position_id] is the strategy's deterministic id for the symbol. *)
 
+val build_exit :
+  pos:Position.t ->
+  bar:Types.Daily_price.t ->
+  label:string ->
+  Position.transition
 (** Stage-based exit: a [TriggerExit] with a [StrategySignal] reason carrying
     [label] (e.g. ["stage4_exit"]), exiting [pos] at [bar.close_price]. *)
-val build_exit :
-  pos:Position.t -> bar:Types.Daily_price.t -> label:string -> Position.transition
 
-(** Stop-triggered exit: a [TriggerExit] with a [StopLoss] reason recording
-    [stop_level] as the stop price and [bar.close_price] as the actual exit
-    price. *)
 val build_stop_exit :
   pos:Position.t ->
   bar:Types.Daily_price.t ->
   stop_level:float ->
   Position.transition
+(** Stop-triggered exit: a [TriggerExit] with a [StopLoss] reason recording
+    [stop_level] as the stop price and [bar.close_price] as the actual exit
+    price. *)

--- a/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
@@ -120,61 +120,6 @@ let _is_entry_signal (result : Stage.result) : bool =
   | Weinstein_types.Stage4 _ ->
       false
 
-let _entry_reasoning : Position.entry_reasoning =
-  TechnicalSignal
-    {
-      indicator = "Stage";
-      description = "SPY-only Weinstein: Stage 2 entry on rising 30-week MA";
-    }
-
-let _build_entry_transition ~(symbol : string) ~(bar : Types.Daily_price.t)
-    ~(target_quantity : float) : Position.transition =
-  {
-    Position.position_id = _position_id_of_symbol symbol;
-    date = bar.date;
-    kind =
-      CreateEntering
-        {
-          symbol;
-          side = Long;
-          target_quantity;
-          entry_price = bar.close_price;
-          reasoning = _entry_reasoning;
-        };
-  }
-
-let _build_exit_transition ~(pos : Position.t) ~(bar : Types.Daily_price.t)
-    ~(label : string) : Position.transition =
-  {
-    Position.position_id = pos.id;
-    date = bar.date;
-    kind =
-      TriggerExit
-        {
-          exit_reason = StrategySignal { label; detail = Some "side=long" };
-          exit_price = bar.close_price;
-        };
-  }
-
-let _build_stop_exit_transition ~(pos : Position.t) ~(bar : Types.Daily_price.t)
-    ~(stop_level : float) : Position.transition =
-  {
-    Position.position_id = pos.id;
-    date = bar.date;
-    kind =
-      TriggerExit
-        {
-          exit_reason =
-            StopLoss
-              {
-                stop_price = stop_level;
-                actual_price = bar.close_price;
-                loss_percent = 0.0;
-              };
-          exit_price = bar.close_price;
-        };
-  }
-
 (* Seed the initial trailing stop from a support-floor lookup on entry, falling
    back to the fixed buffer when no qualifying correction is found. Reads the
    accumulated daily bars for the symbol so the floor reflects real structure.
@@ -199,7 +144,7 @@ let _step_stop ~config ~(stage_result : Stage.result option)
   if Weinstein_stops.check_stop_hit ~state ~side:Long ~bar then
     ( state,
       Some
-        (_build_stop_exit_transition ~pos ~bar
+        (Spy_only_transitions.build_stop_exit ~pos ~bar
            ~stop_level:(Weinstein_stops.get_stop_level state)) )
   else if not (_is_weekly_close ~date:bar.date) then (state, None)
   else
@@ -214,7 +159,7 @@ let _step_stop ~config ~(stage_result : Stage.result option)
         let exit_tr =
           match event with
           | Weinstein_stops.Stop_hit { stop_level; _ } ->
-              Some (_build_stop_exit_transition ~pos ~bar ~stop_level)
+              Some (Spy_only_transitions.build_stop_exit ~pos ~bar ~stop_level)
           | Weinstein_stops.Stop_raised _ | Weinstein_stops.Entered_tightening _
           | Weinstein_stops.No_change ->
               None
@@ -254,7 +199,7 @@ let _on_holding ~config ~bar_reader ~stop_state ~prior_stage ~(pos : Position.t)
       match (is_friday, stage_result) with
       | true, Some r when _is_exit_signal r ->
           stop_state := None;
-          [ _build_exit_transition ~pos ~bar ~label:"stage4_exit" ]
+          [ Spy_only_transitions.build_exit ~pos ~bar ~label:"stage4_exit" ]
       | _ -> [])
 
 (* Flat branch: only act on a weekly close. Classify, and enter when the stage
@@ -273,8 +218,9 @@ let _on_flat ~config ~bar_reader ~prior_stage ~(cash : float)
         | None -> []
         | Some target_quantity ->
             [
-              _build_entry_transition ~symbol:config.symbol ~bar
-                ~target_quantity;
+              Spy_only_transitions.build_entry
+                ~position_id:(_position_id_of_symbol config.symbol)
+                ~symbol:config.symbol ~bar ~target_quantity;
             ])
     | _ -> []
 

--- a/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
@@ -1,0 +1,312 @@
+(** Single-instrument Weinstein stage-timing strategy — see
+    [spy_only_weinstein_strategy.mli]. *)
+
+open Core
+open Trading_strategy
+
+type config = {
+  symbol : string;
+  stage_config : Stage.config;
+  stops_config : Weinstein_stops.config;
+  fallback_stop_buffer : float;
+}
+
+let name = "SpyOnlyWeinstein"
+let default_symbol = "SPY"
+let default_fallback_stop_buffer = 0.92
+
+let default_config =
+  {
+    symbol = default_symbol;
+    stage_config = Stage.default_config;
+    stops_config = Weinstein_stops.default_config;
+    fallback_stop_buffer = default_fallback_stop_buffer;
+  }
+
+(* Number of weekly bars fed to [Stage.classify]. The 30-week MA plus slope
+   lookback need a comfortable margin; 60 weeks (~14 months) is enough to warm
+   up the MA and still bound the read. *)
+let _stage_weeks = 60
+
+(* Overnight gap buffer for all-cash sizing, identical in spirit to
+   [Bah_benchmark_strategy._entry_gap_buffer_pct]: size against
+   [close * (1 + buffer)] so a small gap-up between today's sizing close and
+   tomorrow's fill open does not bust the cash budget and stall the entry. *)
+let _entry_gap_buffer_pct = 0.01
+
+let _position_id_of_symbol (symbol : string) : string =
+  Printf.sprintf "%s-spy-only-weinstein" symbol
+
+let _is_weekly_close ~(date : Date.t) : bool =
+  Date.day_of_week date |> Day_of_week.equal Day_of_week.Fri
+
+(* All-cash sizing: whole shares affordable at [close_price], with the gap
+   buffer applied. Returns [None] when the cash cannot buy a single share or
+   inputs are non-positive. *)
+let _shares_from_cash ~(cash : float) ~(close_price : float) : float option =
+  if Float.(cash <= 0.0) || Float.(close_price <= 0.0) then None
+  else
+    let sizing_price = close_price *. (1.0 +. _entry_gap_buffer_pct) in
+    let shares = Float.round_down (cash /. sizing_price) in
+    Option.some_if Float.(shares > 0.0) shares
+
+(* The strategy's single live position, if any, drawn from the portfolio
+   snapshot. Returns the position only when it is in [Entering] or [Holding]
+   for our configured symbol — a [Closed] / [Exiting] record is treated as "not
+   live" so we neither double-enter nor re-exit. *)
+let _live_position ~(symbol : string) ~(positions : Position.t String.Map.t) :
+    Position.t option =
+  Map.data positions
+  |> List.find ~f:(fun (p : Position.t) ->
+      String.equal p.symbol symbol
+      &&
+      match p.state with
+      | Position.Entering _ | Position.Holding _ -> true
+      | Position.Exiting _ | Position.Closed _ -> false)
+
+(* True when [pos] is in [Holding] — the only state in which the trailing stop
+   is live and an exit signal can fire. *)
+let _holding_quantity (pos : Position.t) : float option =
+  match pos.state with
+  | Position.Holding h -> Some h.quantity
+  | Position.Entering _ | Position.Exiting _ | Position.Closed _ -> None
+
+(* The [(entry_price, entry_date)] of a [Holding] position — the anchor the
+   initial stop's support floor is computed against (NOT today's close, which on
+   a crash bar would place the stop far below the trigger and silently disarm
+   it). Returns [None] for any non-[Holding] state. *)
+let _holding_entry (pos : Position.t) : (float * Date.t) option =
+  match pos.state with
+  | Position.Holding h -> Some (h.entry_price, h.entry_date)
+  | Position.Entering _ | Position.Exiting _ | Position.Closed _ -> None
+
+(* Stage signal from the symbol's own weekly bars. [prior_stage] threads the
+   previous classification for flat-MA Stage1/Stage3 disambiguation. Returns
+   [None] when there are no weekly bars yet (warmup). *)
+let _classify_stage ~config ~bar_reader ~prior_stage ~(as_of : Date.t) :
+    Stage.result option =
+  let bars =
+    Bar_reader.weekly_bars_for bar_reader ~symbol:config.symbol ~n:_stage_weeks
+      ~as_of
+  in
+  match bars with
+  | [] -> None
+  | _ ->
+      Some
+        (Stage.classify ~config:config.stage_config ~bars
+           ~prior_stage:!prior_stage)
+
+(* A Weinstein "exit to flat" signal: the symbol has rolled from a topping
+   Stage 3 into a declining Stage 4, or is already in Stage 4. Stage 1/2 and a
+   bare Stage 3 (still topping, not yet broken) do not exit. *)
+let _is_exit_signal (result : Stage.result) : bool =
+  match result.stage with
+  | Weinstein_types.Stage4 _ -> true
+  | Weinstein_types.Stage3 _ | Weinstein_types.Stage2 _
+  | Weinstein_types.Stage1 _ -> (
+      match result.transition with
+      | Some (Weinstein_types.Stage3 _, Weinstein_types.Stage4 _) -> true
+      | _ -> false)
+
+(* An entry signal: the symbol is in Stage 2 (advancing above a rising 30-week
+   MA). The classifier already encodes "above rising MA"; we additionally
+   require the MA itself to be rising so we never buy a flat-MA basing tape. *)
+let _is_entry_signal (result : Stage.result) : bool =
+  match result.stage with
+  | Weinstein_types.Stage2 _ ->
+      Weinstein_types.equal_ma_direction result.ma_direction
+        Weinstein_types.Rising
+  | Weinstein_types.Stage1 _ | Weinstein_types.Stage3 _
+  | Weinstein_types.Stage4 _ ->
+      false
+
+let _entry_reasoning : Position.entry_reasoning =
+  TechnicalSignal
+    {
+      indicator = "Stage";
+      description = "SPY-only Weinstein: Stage 2 entry on rising 30-week MA";
+    }
+
+let _build_entry_transition ~(symbol : string) ~(bar : Types.Daily_price.t)
+    ~(target_quantity : float) : Position.transition =
+  {
+    Position.position_id = _position_id_of_symbol symbol;
+    date = bar.date;
+    kind =
+      CreateEntering
+        {
+          symbol;
+          side = Long;
+          target_quantity;
+          entry_price = bar.close_price;
+          reasoning = _entry_reasoning;
+        };
+  }
+
+let _build_exit_transition ~(pos : Position.t) ~(bar : Types.Daily_price.t)
+    ~(label : string) : Position.transition =
+  {
+    Position.position_id = pos.id;
+    date = bar.date;
+    kind =
+      TriggerExit
+        {
+          exit_reason = StrategySignal { label; detail = Some "side=long" };
+          exit_price = bar.close_price;
+        };
+  }
+
+let _build_stop_exit_transition ~(pos : Position.t) ~(bar : Types.Daily_price.t)
+    ~(stop_level : float) : Position.transition =
+  {
+    Position.position_id = pos.id;
+    date = bar.date;
+    kind =
+      TriggerExit
+        {
+          exit_reason =
+            StopLoss
+              {
+                stop_price = stop_level;
+                actual_price = bar.close_price;
+                loss_percent = 0.0;
+              };
+          exit_price = bar.close_price;
+        };
+  }
+
+(* Seed the initial trailing stop from a support-floor lookup on entry, falling
+   back to the fixed buffer when no qualifying correction is found. Reads the
+   accumulated daily bars for the symbol so the floor reflects real structure.
+*)
+let _seed_stop ~config ~bar_reader ~(entry_price : float) ~(as_of : Date.t) :
+    Weinstein_stops.stop_state =
+  let bars =
+    Bar_reader.daily_bars_for bar_reader ~symbol:config.symbol ~as_of
+  in
+  Weinstein_stops.compute_initial_stop_with_floor ~config:config.stops_config
+    ~side:Long ~entry_price ~bars ~as_of
+    ~fallback_buffer:config.fallback_stop_buffer
+
+(* Advance the trailing stop one tick on a held position and decide whether it
+   triggers an exit. On a weekly close the state machine advances (raises /
+   tightens); mid-week only the trigger check runs. Returns the (possibly
+   updated) stop state and an optional exit transition. *)
+let _step_stop ~config ~(stage_result : Stage.result option)
+    ~(state : Weinstein_stops.stop_state) ~(pos : Position.t)
+    ~(bar : Types.Daily_price.t) :
+    Weinstein_stops.stop_state * Position.transition option =
+  if Weinstein_stops.check_stop_hit ~state ~side:Long ~bar then
+    ( state,
+      Some
+        (_build_stop_exit_transition ~pos ~bar
+           ~stop_level:(Weinstein_stops.get_stop_level state)) )
+  else if not (_is_weekly_close ~date:bar.date) then (state, None)
+  else
+    match stage_result with
+    | None -> (state, None)
+    | Some r ->
+        let new_state, event =
+          Weinstein_stops.update ~config:config.stops_config ~side:Long ~state
+            ~current_bar:bar ~ma_value:r.ma_value ~ma_direction:r.ma_direction
+            ~stage:r.stage
+        in
+        let exit_tr =
+          match event with
+          | Weinstein_stops.Stop_hit { stop_level; _ } ->
+              Some (_build_stop_exit_transition ~pos ~bar ~stop_level)
+          | Weinstein_stops.Stop_raised _ | Weinstein_stops.Entered_tightening _
+          | Weinstein_stops.No_change ->
+              None
+        in
+        (new_state, exit_tr)
+
+(* Holding branch: run the stop, and on a weekly close also test the
+   stage-based exit signal. The stop takes precedence — if it fires we exit on
+   it and ignore the (less urgent) stage exit. Mutates [stop_state] /
+   [prior_stage] for the next tick. *)
+let _on_holding ~config ~bar_reader ~stop_state ~prior_stage ~(pos : Position.t)
+    ~(bar : Types.Daily_price.t) : Position.transition list =
+  let as_of = bar.date in
+  let stage_result = _classify_stage ~config ~bar_reader ~prior_stage ~as_of in
+  (* Seed the stop the first time we observe the position in Holding (the entry
+     tick created it in Entering; the fill lands the following tick). The seed
+     anchors on the position's recorded entry price/date — not today's bar — so
+     the support floor reflects the structure around entry. *)
+  let state =
+    match !stop_state with
+    | Some s -> s
+    | None ->
+        let entry_price, entry_date =
+          Option.value (_holding_entry pos) ~default:(bar.close_price, as_of)
+        in
+        _seed_stop ~config ~bar_reader ~entry_price ~as_of:entry_date
+  in
+  let new_state, stop_exit =
+    _step_stop ~config ~stage_result ~state ~pos ~bar
+  in
+  stop_state := Some new_state;
+  Option.iter stage_result ~f:(fun r -> prior_stage := Some r.stage);
+  match stop_exit with
+  | Some t -> [ t ]
+  | None -> (
+      let is_friday = _is_weekly_close ~date:bar.date in
+      match (is_friday, stage_result) with
+      | true, Some r when _is_exit_signal r ->
+          stop_state := None;
+          [ _build_exit_transition ~pos ~bar ~label:"stage4_exit" ]
+      | _ -> [])
+
+(* Flat branch: only act on a weekly close. Classify, and enter when the stage
+   signal fires. The stop is seeded later, on the first Holding tick. *)
+let _on_flat ~config ~bar_reader ~prior_stage ~(cash : float)
+    ~(bar : Types.Daily_price.t) : Position.transition list =
+  if not (_is_weekly_close ~date:bar.date) then []
+  else
+    let stage_result =
+      _classify_stage ~config ~bar_reader ~prior_stage ~as_of:bar.date
+    in
+    Option.iter stage_result ~f:(fun r -> prior_stage := Some r.stage);
+    match stage_result with
+    | Some r when _is_entry_signal r -> (
+        match _shares_from_cash ~cash ~close_price:bar.close_price with
+        | None -> []
+        | Some target_quantity ->
+            [
+              _build_entry_transition ~symbol:config.symbol ~bar
+                ~target_quantity;
+            ])
+    | _ -> []
+
+let _on_market_close config ~bar_reader ~stop_state ~prior_stage ~get_price
+    ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
+  let transitions =
+    match get_price config.symbol with
+    | None -> []
+    | Some bar -> (
+        match
+          _live_position ~symbol:config.symbol ~positions:portfolio.positions
+        with
+        | Some pos when Option.is_some (_holding_quantity pos) ->
+            _on_holding ~config ~bar_reader ~stop_state ~prior_stage ~pos ~bar
+        | Some _ ->
+            (* Position exists but is still Entering (awaiting fill) — nothing to
+               do until it reaches Holding. *)
+            []
+        | None ->
+            stop_state := None;
+            _on_flat ~config ~bar_reader ~prior_stage ~cash:portfolio.cash ~bar)
+  in
+  Result.return { Strategy_interface.transitions }
+
+let make ?(config = default_config) ~bar_reader () :
+    (module Strategy_interface.STRATEGY) =
+  let stop_state : Weinstein_stops.stop_state option ref = ref None in
+  let prior_stage : Weinstein_types.stage option ref = ref None in
+  let module M = struct
+    let on_market_close =
+      _on_market_close config ~bar_reader ~stop_state ~prior_stage
+
+    let name = name
+  end in
+  (module M : Strategy_interface.STRATEGY)

--- a/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
@@ -133,6 +133,31 @@ let _seed_stop ~config ~bar_reader ~(entry_price : float) ~(as_of : Date.t) :
     ~side:Long ~entry_price ~bars ~as_of
     ~fallback_buffer:config.fallback_stop_buffer
 
+(* Map a stop state-machine event to an optional exit transition: only a
+   [Stop_hit] produces one. Kept separate so [_advance_stop] stays shallow. *)
+let _exit_of_stop_event ~(pos : Position.t) ~(bar : Types.Daily_price.t)
+    ~(event : Weinstein_stops.stop_event) : Position.transition option =
+  match event with
+  | Weinstein_stops.Stop_hit { stop_level; _ } ->
+      Some (Spy_only_transitions.build_stop_exit ~pos ~bar ~stop_level)
+  | Weinstein_stops.Stop_raised _ | Weinstein_stops.Entered_tightening _
+  | Weinstein_stops.No_change ->
+      None
+
+(* Weekly-close advance: run the stop state machine one tick against the stage
+   read [r] and report the (new state, optional exit). Only called on a Friday
+   with a live stage result. *)
+let _advance_stop ~config ~(r : Stage.result)
+    ~(state : Weinstein_stops.stop_state) ~(pos : Position.t)
+    ~(bar : Types.Daily_price.t) :
+    Weinstein_stops.stop_state * Position.transition option =
+  let new_state, event =
+    Weinstein_stops.update ~config:config.stops_config ~side:Long ~state
+      ~current_bar:bar ~ma_value:r.ma_value ~ma_direction:r.ma_direction
+      ~stage:r.stage
+  in
+  (new_state, _exit_of_stop_event ~pos ~bar ~event)
+
 (* Advance the trailing stop one tick on a held position and decide whether it
    triggers an exit. On a weekly close the state machine advances (raises /
    tightens); mid-week only the trigger check runs. Returns the (possibly
@@ -142,29 +167,13 @@ let _step_stop ~config ~(stage_result : Stage.result option)
     ~(bar : Types.Daily_price.t) :
     Weinstein_stops.stop_state * Position.transition option =
   if Weinstein_stops.check_stop_hit ~state ~side:Long ~bar then
-    ( state,
-      Some
-        (Spy_only_transitions.build_stop_exit ~pos ~bar
-           ~stop_level:(Weinstein_stops.get_stop_level state)) )
+    let stop_level = Weinstein_stops.get_stop_level state in
+    (state, Some (Spy_only_transitions.build_stop_exit ~pos ~bar ~stop_level))
   else if not (_is_weekly_close ~date:bar.date) then (state, None)
   else
     match stage_result with
     | None -> (state, None)
-    | Some r ->
-        let new_state, event =
-          Weinstein_stops.update ~config:config.stops_config ~side:Long ~state
-            ~current_bar:bar ~ma_value:r.ma_value ~ma_direction:r.ma_direction
-            ~stage:r.stage
-        in
-        let exit_tr =
-          match event with
-          | Weinstein_stops.Stop_hit { stop_level; _ } ->
-              Some (Spy_only_transitions.build_stop_exit ~pos ~bar ~stop_level)
-          | Weinstein_stops.Stop_raised _ | Weinstein_stops.Entered_tightening _
-          | Weinstein_stops.No_change ->
-              None
-        in
-        (new_state, exit_tr)
+    | Some r -> _advance_stop ~config ~r ~state ~pos ~bar
 
 (* Holding branch: run the stop, and on a weekly close also test the
    stage-based exit signal. The stop takes precedence — if it fires we exit on
@@ -202,6 +211,20 @@ let _on_holding ~config ~bar_reader ~stop_state ~prior_stage ~(pos : Position.t)
           [ Spy_only_transitions.build_exit ~pos ~bar ~label:"stage4_exit" ]
       | _ -> [])
 
+(* Build the (at most one) entry transition for [bar] when the all-cash sizing
+   affords a whole share; otherwise no transition. Kept separate so [_on_flat]
+   stays shallow. *)
+let _entry_transitions ~config ~(cash : float) ~(bar : Types.Daily_price.t) :
+    Position.transition list =
+  match _shares_from_cash ~cash ~close_price:bar.close_price with
+  | None -> []
+  | Some target_quantity ->
+      let position_id = _position_id_of_symbol config.symbol in
+      [
+        Spy_only_transitions.build_entry ~position_id ~symbol:config.symbol ~bar
+          ~target_quantity;
+      ]
+
 (* Flat branch: only act on a weekly close. Classify, and enter when the stage
    signal fires. The stop is seeded later, on the first Holding tick. *)
 let _on_flat ~config ~bar_reader ~prior_stage ~(cash : float)
@@ -213,35 +236,31 @@ let _on_flat ~config ~bar_reader ~prior_stage ~(cash : float)
     in
     Option.iter stage_result ~f:(fun r -> prior_stage := Some r.stage);
     match stage_result with
-    | Some r when _is_entry_signal r -> (
-        match _shares_from_cash ~cash ~close_price:bar.close_price with
-        | None -> []
-        | Some target_quantity ->
-            [
-              Spy_only_transitions.build_entry
-                ~position_id:(_position_id_of_symbol config.symbol)
-                ~symbol:config.symbol ~bar ~target_quantity;
-            ])
+    | Some r when _is_entry_signal r -> _entry_transitions ~config ~cash ~bar
     | _ -> []
+
+(* Dispatch one bar to the holding or flat branch based on the live position.
+   A still-[Entering] position (awaiting fill) yields no transitions. Kept
+   separate so [_on_market_close] stays shallow. *)
+let _transitions_for_bar ~config ~bar_reader ~stop_state ~prior_stage
+    ~(portfolio : Portfolio_view.t) ~(bar : Types.Daily_price.t) :
+    Position.transition list =
+  match _live_position ~symbol:config.symbol ~positions:portfolio.positions with
+  | Some pos when Option.is_some (_holding_quantity pos) ->
+      _on_holding ~config ~bar_reader ~stop_state ~prior_stage ~pos ~bar
+  | Some _ -> []
+  | None ->
+      stop_state := None;
+      _on_flat ~config ~bar_reader ~prior_stage ~cash:portfolio.cash ~bar
 
 let _on_market_close config ~bar_reader ~stop_state ~prior_stage ~get_price
     ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
   let transitions =
     match get_price config.symbol with
     | None -> []
-    | Some bar -> (
-        match
-          _live_position ~symbol:config.symbol ~positions:portfolio.positions
-        with
-        | Some pos when Option.is_some (_holding_quantity pos) ->
-            _on_holding ~config ~bar_reader ~stop_state ~prior_stage ~pos ~bar
-        | Some _ ->
-            (* Position exists but is still Entering (awaiting fill) — nothing to
-               do until it reaches Holding. *)
-            []
-        | None ->
-            stop_state := None;
-            _on_flat ~config ~bar_reader ~prior_stage ~cash:portfolio.cash ~bar)
+    | Some bar ->
+        _transitions_for_bar ~config ~bar_reader ~stop_state ~prior_stage
+          ~portfolio ~bar
   in
   Result.return { Strategy_interface.transitions }
 

--- a/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.mli
@@ -1,0 +1,95 @@
+(** Single-instrument Weinstein stage-timing strategy — a long/flat reference
+    strategy that trades exactly one symbol (default SPY).
+
+    This is a deliberately minimal testbed, {b separate} from the production
+    {!Weinstein_strategy}. It exists to answer two questions cheaply:
+
+    - {b Direction-finding.} On the cleanest possible signal (the index itself),
+      does Weinstein stage timing — enter in Stage 2, exit on the Stage 3→4
+      roll-over or a trailing-stop hit — beat buy-and-hold on {e risk-adjusted}
+      terms? The Weinstein thesis is that Stage-4 exits dodge the deep
+      drawdowns, trading some total return for a higher Sharpe / Calmar.
+    - {b Headroom bound.} It puts a realizable floor under the trade-autopsy's
+      perfect-hindsight estimates: a real, causal stage-timing rule on one
+      symbol is something the autopsy's idealized exits can be measured against.
+
+    {1 What it reuses}
+
+    - {!Stage.classify} on the symbol's own weekly bars (read via
+      {!Bar_reader.weekly_bars_for}) for the stage signal. The symbol {e is} the
+      market, so there is no macro gate — entries are never blocked on a
+      market-breadth read (the production strategy's macro gate is degenerate
+      here and is omitted entirely).
+    - {!Weinstein_stops} for the per-position trailing stop: the initial stop is
+      seeded from a support-floor lookup on entry, then advanced daily by the
+      {!Weinstein_stops.update} state machine and triggered by
+      {!Weinstein_stops.check_stop_hit}.
+
+    {1 What it does NOT do}
+
+    - No shorting. Stage 4 means "exit to flat", never "go short". Stage-4
+      shorting is an explicit follow-on, not this module.
+    - No screener, no portfolio-risk position sizing, no sector gating. Sizing
+      is all-cash ([floor(cash / close)]), mirroring {!Bah_benchmark_strategy}.
+
+    {1 Cadence}
+
+    - {b Friday (weekly close):} re-classify the stage and make the
+      enter/exit-on-signal decision.
+    - {b Every day:} advance + check the trailing stop on a held position.
+
+    {1 Statefulness}
+
+    Like the production strategy, the instance carries closure-scoped mutable
+    state across [on_market_close] calls: the current trailing-stop state and
+    the prior stage (for Stage1/Stage3 flat-MA disambiguation). The state is
+    seeded fresh per {!make}. *)
+
+type config = {
+  symbol : string;
+      (** Instrument to trade. Default {!default_symbol} ([SPY]). Bare ticker,
+          no exchange suffix — matches the on-disk CSV layout under
+          [data/S/Y/SPY/]. *)
+  stage_config : Stage.config;
+      (** Stage-classifier parameters (30-week MA period, slope thresholds,
+          etc). Default {!Stage.default_config}. *)
+  stops_config : Weinstein_stops.config;
+      (** Trailing-stop parameters (correction depth, buffers, support-floor
+          lookback). Default {!Weinstein_stops.default_config}. *)
+  fallback_stop_buffer : float;
+      (** Multiplicative buffer used to place the initial stop when the
+          support-floor lookup finds no qualifying correction. For a long the
+          stop falls at [entry_price *. fallback_stop_buffer]; a value below 1.0
+          (default {!default_fallback_stop_buffer}, [0.92] = an 8% stop)
+          therefore sits below entry. *)
+}
+
+val name : string
+(** Human-readable strategy name, [SpyOnlyWeinstein]. *)
+
+val default_symbol : string
+(** [SPY]. *)
+
+val default_fallback_stop_buffer : float
+(** [0.92] — an 8% loose initial stop, matching Weinstein's 8% correction rule
+    (book §5.1) when no structural support floor is available. *)
+
+val default_config : config
+(** [default_config] uses {!default_symbol}, {!Stage.default_config},
+    {!Weinstein_stops.default_config}, and {!default_fallback_stop_buffer}. *)
+
+val make :
+  ?config:config ->
+  bar_reader:Bar_reader.t ->
+  unit ->
+  (module Trading_strategy.Strategy_interface.STRATEGY)
+(** [make ?config ~bar_reader ()] constructor. Returns a first-class
+    {!Trading_strategy.Strategy_interface.STRATEGY} module whose
+    [on_market_close] implements the cadence above.
+
+    @param config Strategy parameters. Defaults to {!default_config}.
+    @param bar_reader
+      The snapshot-backed bar source the runner constructs; used to read the
+      symbol's weekly aggregates (for {!Stage.classify}) and daily bars (for the
+      support-floor seed). The simulator's per-tick [get_price] supplies today's
+      OHLC bar for the stop check and sizing. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -5,6 +5,7 @@
 open Core
 open Trading_strategy
 module Bar_reader = Bar_reader
+module Spy_only_weinstein_strategy = Spy_only_weinstein_strategy
 module Stops_runner = Stops_runner
 module Stops_split_runner = Stops_split_runner
 module Force_liquidation_runner = Force_liquidation_runner

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -39,6 +39,10 @@ module Ad_bars = Ad_bars
 module Bar_reader = Bar_reader
 (** Panel-backed bar source. See {!Bar_reader}. *)
 
+module Spy_only_weinstein_strategy = Spy_only_weinstein_strategy
+(** Single-instrument long/flat Weinstein stage-timing reference strategy. See
+    {!Spy_only_weinstein_strategy}. *)
+
 module Stops_runner = Stops_runner
 (** Trailing-stop state machine loop over held positions. See {!Stops_runner}.
 *)

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -11,6 +11,7 @@
   test_panel_callbacks
   test_pi_filter_wiring
   test_short_side_bear_window
+  test_spy_only_weinstein_strategy
   test_stage3_force_exit_runner
   test_laggard_rotation_runner
   test_stops_runner

--- a/trading/trading/weinstein/strategy/test/test_spy_only_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_spy_only_weinstein_strategy.ml
@@ -1,0 +1,283 @@
+open OUnit2
+open Core
+open Matchers
+module Spy = Weinstein_strategy.Spy_only_weinstein_strategy
+module Bar_reader = Weinstein_strategy.Bar_reader
+module Strategy_interface = Trading_strategy.Strategy_interface
+module Portfolio_view = Trading_strategy.Portfolio_view
+
+let symbol = "SPY"
+
+(* One daily bar; [open]/[high]/[low] default around [close]. *)
+let make_bar date ~close ?low ?high () : Types.Daily_price.t =
+  let low = Option.value low ~default:(close *. 0.99) in
+  let high = Option.value high ~default:(close *. 1.01) in
+  {
+    date = Date.of_string date;
+    open_price = close;
+    high_price = high;
+    low_price = low;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+    active_through = None;
+  }
+
+(* Generate [n] weekly bars, one per consecutive Friday ending at [last_friday],
+   with [close i] giving the close of the i-th bar (0 = oldest). ISO-week
+   grouping in [daily_to_weekly] turns one Friday-dated daily bar into one
+   weekly bar, so the resulting weekly series is exactly the [close]
+   trajectory. *)
+let weekly_closes ~last_friday ~n ~close : Types.Daily_price.t list =
+  let last = Date.of_string last_friday in
+  List.init n ~f:(fun i ->
+      let d = Date.add_days last (-7 * (n - 1 - i)) in
+      make_bar (Date.to_string d) ~close:(close i) ())
+
+(* A long, smoothly rising trajectory: price climbs well above a rising 30-week
+   MA → Stage 2. *)
+let rising_closes i = 50.0 +. (Float.of_int i *. 1.5)
+
+(* A long, smoothly falling trajectory off a prior peak: price below a declining
+   30-week MA → Stage 4. *)
+let falling_closes ~peak i = peak -. (Float.of_int i *. 1.5)
+let last_friday = "2021-12-31"
+let n_weeks = 60
+let bar_reader_of bars = Bar_reader.of_in_memory_bars [ (symbol, bars) ]
+
+let make_portfolio ~cash ?position () : Portfolio_view.t =
+  let positions =
+    match position with
+    | None -> String.Map.empty
+    | Some (p : Trading_strategy.Position.t) -> String.Map.singleton p.id p
+  in
+  { cash; positions }
+
+(* Build a Holding SPY position at [entry_price] / [entry_date]. *)
+let make_holding ~entry_price ~entry_date ~quantity :
+    Trading_strategy.Position.t =
+  let pos_id = symbol ^ "-spy-only-weinstein" in
+  let make_trans kind =
+    { Trading_strategy.Position.position_id = pos_id; date = entry_date; kind }
+  in
+  let unwrap = function
+    | Ok p -> p
+    | Error e ->
+        OUnit2.assert_failure ("position setup failed: " ^ Status.show e)
+  in
+  let open Trading_strategy.Position in
+  create_entering
+    (make_trans
+       (CreateEntering
+          {
+            symbol;
+            side = Long;
+            target_quantity = quantity;
+            entry_price;
+            reasoning = ManualDecision { description = "test" };
+          }))
+  |> unwrap
+  |> fun p ->
+  apply_transition p
+    (make_trans
+       (EntryFill { filled_quantity = quantity; fill_price = entry_price }))
+  |> unwrap
+  |> fun p ->
+  apply_transition p
+    (make_trans
+       (EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = None;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+let no_indicator : Strategy_interface.get_indicator_fn = fun _ _ _ _ -> None
+
+let run_once (module M : Strategy_interface.STRATEGY) ~today_bar ~portfolio =
+  M.on_market_close
+    ~get_price:(fun s -> if String.equal s symbol then Some today_bar else None)
+    ~get_indicator:no_indicator ~portfolio
+
+(* A matcher pinning a single CreateEntering(Long) transition for SPY. The
+   inlined record from [CreateEntering] cannot escape the match, so the matcher
+   projects its [(symbol, side)] into a tuple. *)
+let is_long_entry =
+  is_ok_and_holds
+    (field
+       (fun (o : Strategy_interface.output) -> o.transitions)
+       (elements_are
+          [
+            field
+              (fun (t : Trading_strategy.Position.transition) -> t.kind)
+              (matching ~msg:"Expected CreateEntering Long"
+                 (function
+                   | Trading_strategy.Position.CreateEntering c ->
+                       Some (c.symbol, c.side)
+                   | _ -> None)
+                 (equal_to
+                    ((symbol, Trading_strategy.Position.Long)
+                      : string * Trading_strategy.Position.position_side)));
+          ]))
+
+(* A matcher pinning a single TriggerExit transition whose exit_reason satisfies
+   [reason_ok]. The inlined [TriggerExit] record cannot escape, so the matcher
+   projects out [exit_reason] (a regular top-level variant) inside the match. *)
+let is_exit ~reason_ok =
+  is_ok_and_holds
+    (field
+       (fun (o : Strategy_interface.output) -> o.transitions)
+       (elements_are
+          [
+            field
+              (fun (t : Trading_strategy.Position.transition) -> t.kind)
+              (matching ~msg:"Expected TriggerExit"
+                 (function
+                   | Trading_strategy.Position.TriggerExit e ->
+                       Some e.exit_reason
+                   | _ -> None)
+                 reason_ok);
+          ]))
+
+let is_no_transitions =
+  is_ok_and_holds
+    (field (fun (o : Strategy_interface.output) -> o.transitions) is_empty)
+
+(* ---------------------------------------------------------------- *)
+(* Sanity: the synthetic trajectories classify as intended.         *)
+(* ---------------------------------------------------------------- *)
+
+let stage_of bars =
+  (Stage.classify ~config:Stage.default_config ~bars ~prior_stage:None).stage
+
+let test_rising_is_stage2 _ =
+  let bars = weekly_closes ~last_friday ~n:n_weeks ~close:rising_closes in
+  assert_that (stage_of bars)
+    (matching ~msg:"rising series should be Stage2"
+       (function Weinstein_types.Stage2 _ -> Some () | _ -> None)
+       (equal_to ()))
+
+let test_falling_is_stage4 _ =
+  let bars =
+    weekly_closes ~last_friday ~n:n_weeks ~close:(falling_closes ~peak:140.0)
+  in
+  assert_that (stage_of bars)
+    (matching ~msg:"falling series should be Stage4"
+       (function Weinstein_types.Stage4 _ -> Some () | _ -> None)
+       (equal_to ()))
+
+(* ---------------------------------------------------------------- *)
+(* Behavioural tests.                                               *)
+(* ---------------------------------------------------------------- *)
+
+let test_stage2_friday_enters_when_flat _ =
+  (* Flat (no position), Stage 2, on a Friday → buy SPY with all cash. *)
+  let bars = weekly_closes ~last_friday ~n:n_weeks ~close:rising_closes in
+  let today = List.last_exn bars in
+  let strat = Spy.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:today
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that result is_long_entry
+
+let test_stage2_non_friday_no_entry _ =
+  (* Same Stage-2 tape, but mid-week (Wednesday) → no action when flat. *)
+  let bars = weekly_closes ~last_friday ~n:n_weeks ~close:rising_closes in
+  let wed_bar = make_bar "2021-12-29" ~close:(rising_closes (n_weeks - 1)) () in
+  let strat = Spy.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:wed_bar
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that result is_no_transitions
+
+let test_stage4_friday_exits_when_holding _ =
+  (* Holding SPY into a Stage-4 Friday → sell-all via the stage signal. The
+     entry is anchored at today's close so the trailing stop sits ~8% BELOW
+     today's bar and does not fire — isolating the stage-exit path from the
+     (higher-precedence) stop-exit path. *)
+  let bars =
+    weekly_closes ~last_friday ~n:n_weeks ~close:(falling_closes ~peak:140.0)
+  in
+  let today = List.last_exn bars in
+  let pos =
+    make_holding ~entry_price:today.close_price ~entry_date:today.date
+      ~quantity:700.0
+  in
+  let strat = Spy.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:today
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:pos ())
+  in
+  assert_that result
+    (is_exit
+       ~reason_ok:
+         (matching ~msg:"Expected StrategySignal stage4_exit"
+            (function
+              | Trading_strategy.Position.StrategySignal s -> Some s.label
+              | _ -> None)
+            (equal_to "stage4_exit")))
+
+let test_stop_hit_exits_when_holding _ =
+  (* Holding SPY; today's bar gaps the low far below entry so the trailing
+     stop's trigger fires immediately, producing a StopLoss exit — independent
+     of the day-of-week (trigger is continuous). *)
+  let bars = weekly_closes ~last_friday ~n:n_weeks ~close:rising_closes in
+  let entry_price = rising_closes (n_weeks - 1) in
+  (* A violent down-day well below any plausible support floor. *)
+  let crash_bar =
+    make_bar "2021-12-30" ~close:(entry_price *. 0.5) ~low:(entry_price *. 0.5)
+      ~high:entry_price ()
+  in
+  let pos =
+    make_holding ~entry_price
+      ~entry_date:(Date.of_string "2021-12-24")
+      ~quantity:700.0
+  in
+  let strat = Spy.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:crash_bar
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:pos ())
+  in
+  assert_that result
+    (is_exit
+       ~reason_ok:
+         (matching ~msg:"Expected StopLoss"
+            (function
+              | Trading_strategy.Position.StopLoss s -> Some s.actual_price
+              | _ -> None)
+            (float_equal (entry_price *. 0.5))))
+
+let test_stage1_friday_no_entry_when_flat _ =
+  (* A flat, choppy tape that never establishes a Stage-2 advance: no entry. *)
+  let flat_closes _ = 50.0 in
+  let bars = weekly_closes ~last_friday ~n:n_weeks ~close:flat_closes in
+  let today = List.last_exn bars in
+  let strat = Spy.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:today
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that result is_no_transitions
+
+let suite =
+  "spy_only_weinstein_strategy"
+  >::: [
+         "rising series classifies Stage2" >:: test_rising_is_stage2;
+         "falling series classifies Stage4" >:: test_falling_is_stage4;
+         "Stage2 Friday enters when flat"
+         >:: test_stage2_friday_enters_when_flat;
+         "Stage2 mid-week does not enter" >:: test_stage2_non_friday_no_entry;
+         "Stage4 Friday exits when holding"
+         >:: test_stage4_friday_exits_when_holding;
+         "stop hit exits when holding" >:: test_stop_hit_exits_when_holding;
+         "flat tape Friday does not enter"
+         >:: test_stage1_friday_no_entry_when_flat;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

New **long/flat Weinstein 30-week-MA stage-timing strategy that trades exactly one symbol (default SPY)** — `trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.{ml,mli}`. It is a separate, minimal testbed; it does **not** change the production multi-symbol `Weinstein_strategy`'s defaults or behavior.

Purpose: (a) direction-finding on the cleanest possible signal (the index itself), and (b) a realizable headroom bound for the trade-autopsy's perfect-hindsight estimates.

### Behavior (this first cut — long/flat, no shorting)
- **Friday:** classify SPY's own stage via `Stage.classify` on its weekly bars. Stage 2 (above a rising 30-week MA) + flat → enter all-cash `floor(cash/close)` (mirrors `Bah_benchmark`). Stage 3→4 roll-over / Stage 4 while holding → exit to flat.
- **Daily:** advance + check the `Weinstein_stops` trailing stop; exit on stop hit (continuous trigger).
- Macro gate omitted — SPY *is* the market.

### Reuse / wiring
- `Stage.classify` and `Weinstein_stops` reused as-is (initial stop seeded from a support-floor lookup anchored on the position's entry price/date, fallback 8% buffer).
- New `Strategy_choice.Spy_only_weinstein { symbol }` variant + `panel_runner._build_strategy` arm + `runner._warmup_days_for` (210d, like Weinstein) + `weinstein_strategy.{ml,mli}` re-export alias.

## Test plan
`dune build && dune runtest` green. New `test_spy_only_weinstein_strategy.ml` (OUnit2 + Matchers) covers: rising series classifies Stage2 / falling classifies Stage4 (input sanity), Stage2-Friday→enter-when-flat, Stage2-midweek→no-entry, Stage4-Friday→exit-when-holding, stop-hit→exit, flat-tape-Friday→no-entry.

## Backtest: SPY-stage-timing vs BAH-SPY (2009-06-01..2025-12-31, $1M, scenario-runner)

| Metric | BAH-SPY | SPY-stage-timing |
|---|---|---|
| Total return | 619.1% | 337.3% |
| Sharpe | 0.768 | 0.761 |
| Sortino (ann.) | 1.164 | 1.127 |
| **Calmar** | 0.372 | **0.483** |
| **MaxDD** | 34.0% | **18.8%** |
| Trades | 0 (single hold) | 10 (win rate 10%) |

**Headline:** stage timing **halves the max drawdown (34.0%→18.8%) and lifts Calmar ~30% (0.37→0.48)**, but **Sharpe is flat** and total return is far lower over this bull-dominated window. The Weinstein "Stage-4 exits dodge drawdowns" thesis is confirmed on the drawdown/Calmar axis, not on Sharpe — and the 10% win rate shows the stops get whipsawed in a sustained bull, the cost paid for the drawdown protection.

Scenarios: `trading/test_data/backtest_scenarios/spy-only-stage2.sexp` (+ companion `-bah.sexp`), universe `universes/spy-only.sexp`.

Do not modify `dev/status/_index.md` from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
