### PR TITLE
docs: Weinstein trader/investor presets + faithful-core principle + SPY trade analysis

### DIFF
--- a/.claude/rules/weinstein-faithful-core.md
+++ b/.claude/rules/weinstein-faithful-core.md
@@ -1,0 +1,79 @@
+# Weinstein-faithful core — the spine/dials guardrail
+
+**Strictly follow Weinstein's strategy and methodology; adapt details only to the
+extent the core stays intact.** This is the governing principle for all strategy
+work and the experiment program. It constrains the search space to
+Weinstein-faithful configurations and faithful adaptations of them — not an
+arbitrary knob-soup. It is the antidote to the over-exploration the program has
+repeatedly been burned by (`feedback_strategy_mechanic_changes_too_explorative`,
+the hysteresis / continuation / early-admission rejections).
+
+Source of authority: `docs/design/weinstein-book-reference.md` (the distilled
+decision rules) and Stan Weinstein, *Secrets for Profiting in Bull and Bear
+Markets*.
+
+## The spine — NEVER adapt (change any of these and it is no longer Weinstein)
+
+1. **Stage classification off the weekly MA.** Every instrument is in exactly one
+   of Stages 1–4, determined by price vs a weekly moving average, the MA slope,
+   and prior-stage context. (The MA *period* is a dial — see below — but the
+   stage framework itself is the spine.)
+2. **Buy ONLY in Stage 2.** No long entries in Stage 1, 3, or 4.
+3. **Entry on a breakout above resistance WITH volume confirmation.** Not on price
+   alone; volume expansion is required.
+4. **Sell in Stage 3 / Stage 4.** Exit as the stock tops and rolls over; never
+   ride a Stage 4 decline.
+5. **Initial stop below the base / below the MA.** Risk is defined at entry by the
+   base low or the MA, not an arbitrary percentage divorced from structure.
+6. **Macro gate + sector gating are unconditional filters.** A bearish macro tape
+   blocks buys; sector relative strength gates candidates. (Degenerate for a
+   single-instrument index strategy like SPY-only — there the macro gate is the
+   instrument itself, so it collapses to a no-op, which is faithful, not a
+   violation.)
+7. **Relative strength for selection** (multi-symbol): rank by RS vs the market,
+   not absolute performance.
+
+## The dials — adapt freely (Weinstein himself parameterizes these)
+
+- **MA period.** He gives **30-week for investors, 10-week for traders**
+  explicitly (daily for very short-term traders). Changing the period is faithful.
+- **Entry mode.** Initial base breakout (investor) vs **continuation / pullback
+  re-breakout** (trader, "The Trader's Way") — both his.
+- **Sizing.** Scale-in (½ on breakout, ½ on pullback — investor) vs **full size on
+  the breakout** (trader, "home run") — both his.
+- **Exit aggressiveness.** Hold to Stage 3→4 (investor) vs **get out as the Stage-3
+  top starts forming** (trader) — both his.
+- **Numeric thresholds** tuned for the modern regime. Weinstein's own caveat that
+  program trading "made [the day-to-day gyrations] even wilder" licenses adapting
+  threshold values for a faster, choppier market than 1988 — *provided the spine
+  is untouched*.
+
+## Trader vs Investor are two config PRESETS, not two strategies
+
+The trader/investor distinction is a **bundle of dial values** applied to the one
+parameterized strategy — not two code paths. See
+`dev/plans/weinstein-trader-investor-presets-2026-05-31.md` for the preset table.
+
+## What QC / agents can check
+
+For any PR that adds or changes strategy logic:
+
+- **W1 — spine intact.** The change does not alter any spine item (1–7 above). A
+  PR that, e.g., buys outside Stage 2, drops volume confirmation, or removes the
+  macro gate is a FAIL regardless of backtest numbers.
+- **W2 — adaptation is a dial, and config-expressed.** Any adaptation is one of
+  the listed dials, lands as a config field (per `experiment-flag-discipline.md`),
+  and cites Weinstein authority (book reference section) for why it is faithful.
+  A mechanism that is *not* a documented dial or a faithful adaptation of one is
+  out of scope — it must be justified against the book, not invented.
+- **W3 — experiments are Weinstein-faithful presets.** Population-search arms and
+  promotion candidates are presets/variants within this space, not arbitrary
+  configs (`dev/plans/population-search-2026-05-31.md`).
+
+## Why this is load-bearing
+
+The program's three big rejections (continuation-buys #1366, early-admission deep,
+stage3-hysteresis) were all *trader-mode dials grafted one-at-a-time onto the
+investor base*. That is neither faithful (it mixes two presets incoherently) nor
+how Weinstein frames them. This rule prevents that failure mode: adapt a dial only
+within a coherent preset, keep the spine fixed, and test presets as wholes.

--- a/dev/notes/spy-stage-timing-trades-2026-05-31.md
+++ b/dev/notes/spy-stage-timing-trades-2026-05-31.md
@@ -1,0 +1,84 @@
+# SPY stage-timing — trade-by-trade analysis (2009-2026, investor preset)
+
+The realized trades of the SPY-only Weinstein strategy (PR #1397, 30-week MA,
+long/flat, 2009-06-01→2025-12-31), vs buy-and-hold SPY. This is the empirical test
+of the capital-preservation/compounding thesis: *does avoiding drawdowns compound
+into a higher final NAV?* Answer: **only when the strategy re-enters lower than it
+exited — which the 30-week MA achieves on sustained bears but not on fast V-dips.**
+
+## Headline
+
+| | BAH-SPY | Stage-timing (investor) |
+|---|--:|--:|
+| Total return | 619.1% | 317.9% |
+| Final NAV ($1M start) | $7.19M | $4.18M |
+| CAGR | 12.63% | 9.01% |
+| Sharpe | 0.78 | 0.77 |
+| Sortino (ann.) | 1.15 | 1.08 |
+| **Calmar** | 0.37 | **0.48** |
+| **MaxDD** | 34.0% | **18.8%** |
+| Trades | 0 | 10 closed (+1 open), **70% win** |
+
+Nearly identical Sharpe; stage-timing wins drawdown/Calmar decisively but trails
+on final NAV. (Note: the round-trip win rate is **70%**, not the 10% first
+reported — that was a misread of the metric.)
+
+## The trades (portfolio all-in, so NAV ≈ shares × SPY price)
+
+| # | Entry→Exit | SPY in→out | P&L | Note |
+|---|---|---|--:|---|
+| 1 | 2009-08→2010-06 | 98.65→108.19 | +9.7% | stopped out |
+| 2 | 2010-10→2011-08 | 114.99→114.07 | −0.8% | |
+| 3 | 2012-01→2015-08 | 128.20→198.50 | +54.8% | big bull leg |
+| 4 | 2016-04→2018-12 | 204.35→269.46 | +31.9% | |
+| 5 | 2019-03→2020-03 | 280.44→284.64 | +1.5% | exited into COVID |
+| 6 | 2020-07→2022-02 | 314.31→443.73 | +41.2% | |
+| 7 | 2022-12→2022-12 | 402.25→379.23 | −5.7% | 17-day whipsaw |
+| 8 | 2023-01→2023-03 | 403.66→390.50 | −3.3% | SVB whipsaw |
+| 9 | 2023-04→2023-10 | 412.81→425.98 | +3.2% | |
+| 10 | 2023-11→2025-03 | 455.07→562.83 | +23.7% | |
+
+7 winners / 3 losers. Final NAV $4.18M (incl. an 11th position held long into
+year-end 2025).
+
+## The gap analysis — exit price vs the NEXT entry price (the 80/60 test)
+
+Re-enter **lower** = captured the round-trip (capital compounds). Re-enter
+**higher** = whipsaw: gave up the gap AND sat in cash through the recovery.
+
+| Gap | Exit→next Entry | Result | Regime |
+|---|---|--:|---|
+| 1→2 | 108.19→114.99 | +6.9% higher ✗ | 2010 flash crash |
+| 2→3 | 114.07→128.20 | +12.4% higher ✗ | 2011 debt ceiling |
+| 3→4 | 198.50→204.35 | +2.9% higher ✗ | 2015-16 correction |
+| 4→5 | 269.46→280.44 | +4.1% higher ✗ | 2018-Q4 selloff |
+| 5→6 | 284.64→314.31 | +10.4% higher ✗ | COVID: dodged −22% (bottom 222) but missed the 222→314 snap-back |
+| 6→7 | 443.73→402.25 | **−9.3% LOWER ✓** | **2022 bear — thesis works** |
+| 7→8 | 379.23→403.66 | +6.4% higher ✗ | late-2022 chop |
+| 8→9 | 390.50→412.81 | +5.7% higher ✗ | SVB Mar-2023 |
+| 9→10 | 425.98→455.07 | +6.8% higher ✗ | 2023 summer dip |
+
+**8 of 9 re-entries were higher (whipsaw); 1 was lower (the sustained 2022 bear).**
+
+## Interpretation
+
+The compounding thesis is correct in principle and fires exactly once — the 2022
+*sustained* bear, the regime Weinstein designed for. The other 8 dips were **fast
+V's**; the 30-week MA lags ~7 months, so it confirmed re-entry *after* the bounce
+→ re-entered higher and missed the recovery from cash. COVID is the canonical
+failure: correctly dodged the −22% fall but missed the entire 222→314 rebound. In
+a bull-with-fast-dips window, that missed-upside-in-cash costs more than the
+drawdown protection saves → final NAV trails BAH despite half the MaxDD.
+
+## What this motivates (pre-registered hypotheses)
+
+1. **10-week trader preset.** A faster MA confirms re-entry sooner → re-enters
+   closer to the V-bottom → should flip several of the 8 whipsaws toward the
+   favorable round-trip. Test investor (30wk) vs trader (10wk) on this same SPY
+   testbed. (`dev/plans/weinstein-trader-investor-presets-2026-05-31.md`)
+2. **Deep 2000-2026 window.** Two *sustained* 100→50→100 bears (dot-com −49%, GFC
+   −57%) — the 1-of-9 favorable case should become the norm there. Predict the
+   final-NAV gap vs BAH narrows hard or flips.
+
+Run dir (reproducible): `scenario_runner --dir <{spy-only-stage2, -bah}>` on the
+`feat/spy-only-strategy` build.

--- a/dev/plans/weinstein-trader-investor-presets-2026-05-31.md
+++ b/dev/plans/weinstein-trader-investor-presets-2026-05-31.md
@@ -1,0 +1,93 @@
+# Weinstein trader vs investor presets — design + first experiment
+
+**Status:** DESIGN + first experiment spec (2026-05-31). Source: Stan Weinstein,
+*Secrets for Profiting in Bull and Bear Markets* — confirmed against the book
+text (the user's PDF) this session. Reference: `docs/design/weinstein-book-reference.md`.
+
+## The design decision
+
+**Trader and Investor are not two strategy modules — they are two named config
+presets of the SAME parameterized strategy.** Every distinguishing value already
+exists (or has a natural home) in our config. This fits the codebase's
+"every parameter in config, never hardcoded" rule and keeps one code path.
+
+| Knob | **Investor** preset (what we built) | **Trader** preset | Config home |
+|---|---|---|---|
+| Stage MA period | **30-week** | **10-week** | `Stage.config` ma_period |
+| Entry mode | initial Stage 1→2 base breakout | **continuation** (advance → pullback to MA → re-breakout) | `enable_continuation_buys` |
+| Early-Stage-2 buying | more (patient, near base) | less | emergent |
+| Sizing | scale-in (½ on breakout, ½ on pullback) | **full size on breakout** ("home run"), fast profit, repurchase on pullback | sizing config |
+| Exit timing | hold to Stage 3→4 | **earlier — get out as the Stage-3 top starts forming** | `stage3_force_exit_config` |
+| Holding horizon | up to 12 months | "each significant 2–4 month move" | emergent |
+
+Book citations (the user's PDF): 30-week-for-investors / 10-week-for-traders
+(p.~15); "The Trader's Way" continuation buy (Ch.3); "purchase your entire
+intended position on the breakout… home run for a trader" (Ch.3); "once a Stage 3
+top starts to form, traders should get the heck out" (Ch.2).
+
+So `weinstein-investor.sexp` and `weinstein-trader.sexp` become two pinned config
+sexps run through the same strategy code and the same SPY testbed. Nothing new to
+invent — a re-parameterization.
+
+## The governing principle — Weinstein-faithful core
+
+**Strictly follow Weinstein's strategy/methodology; adapt details only to the
+extent the core stays intact.** Operationalized as spine vs dials:
+
+**The spine (NEVER adapt — this IS the strategy):**
+- Stage classification off the weekly MA (30 or 10-week); buy ONLY in Stage 2;
+  on a breakout above resistance WITH volume confirmation; sell in Stage 3/4;
+  initial stop below the base / below the MA; macro gate + sector gating;
+  relative-strength for selection. Change any of these → it is no longer Weinstein.
+
+**The dials (adapt freely — Weinstein himself parameterizes these):**
+- MA period (he gives 10 vs 30 explicitly), entry mode (base vs continuation —
+  both his), sizing (scale vs full — both his), exit aggressiveness (both his),
+  and numeric thresholds tuned for the modern regime — his own caveat that
+  program trading "made [the gyrations] even wilder" licenses regime adaptation.
+
+This guardrail constrains the experiment search space to **Weinstein-faithful
+configurations and faithful adaptations**, not an arbitrary knob-soup. It is the
+antidote to the over-exploration the program has repeatedly warned against
+(`feedback_strategy_mechanic_changes_too_explorative`).
+
+## How this reframes the program's three rejections
+
+Continuation-buys (#1366 combined-axis), early-admission (deep-rejected
+2026-05-31), and stage3-hysteresis were all killed **as bolt-ons grafted onto the
+30-week INVESTOR base, one knob at a time, on the SP500.** But they are
+**trader-mode components.** We have NEVER tested the *coherent trader preset*
+(10-week + continuation + early Stage-3 exit + full-size entry, together) against
+the investor preset. The rejections only say "don't half-graft trader-parts onto
+an investor body" — they say nothing about trader-mode as an integrated,
+Weinstein-faithful strategy. **That is the untested and principled experiment.**
+
+## First experiment — investor preset vs trader preset on the SPY testbed
+
+Once the SPY reference strategy merges (PR #1397):
+
+1. Define `weinstein-investor.sexp` (= the current SPY strategy config) and
+   `weinstein-trader.sexp` (the trader-preset deltas above) as two pinned configs.
+2. Run BOTH on the SPY testbed across **two regimes**:
+   - **2009-2026** (bull + fast V-dips) — where the 30-week investor preset
+     whipsawed (10% round-trip win rate, final NAV < BAH-SPY).
+   - **Deep 2000-2026** (dot-com -49% + GFC -57%) — needs the deep-SPY fetch
+     (`build_deep_universe.sh` / `fetch-historical-data`; the autopsy already ran
+     SPY 1998-2025, so it's available).
+3. **Metric = the compounding thesis, not just drawdown:** final NAV (capital
+   preserved across each round-trip compounds), round-trip win rate, and
+   exit-price-vs-subsequent-re-entry-price per trade — alongside Sharpe/Calmar/
+   MaxDD and BAH-SPY. The hypothesis: the 10-week trader preset exits sooner
+   (higher) and re-enters sooner (lower), realizing the favorable round-trip the
+   lagging 30-week MA misses on fast dips — and the gap vs BAH should be largest
+   on the deep window (two genuine 100→50→100 events to dodge).
+4. Ledger each preset×regime cell per the gap-closing loop; the deep cell is
+   mandatory (`.claude/rules/promotion-confirmation.md`).
+
+## Connection to population search
+
+The population-search apparatus (`dev/plans/population-search-2026-05-31.md`)
+gets its anchor here: **the arms are Weinstein-faithful presets** (investor,
+trader, and documented variants), not arbitrary configs. The spine/dials
+principle defines the boundary of a legitimate arm. This makes the discrete
+feature space principled and finite instead of an open knob-soup.


### PR DESCRIPTION
Three docs from the trader/investor design discussion + the SPY backtest. (1) `.claude/rules/weinstein-faithful-core.md` — the spine/dials guardrail. (2) the trader/investor-presets plan. (3) the trade-by-trade SPY analysis (70% win rate; 8/9 re-entries higher = whipsaw; the gap analysis behind why drawdown protection doesn't compound to higher NAV in a fast-dip bull window). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)