### PR TITLE
fix(backtest): clean Csv_snapshot_builder tmp dirs on abnormal exit

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -658,6 +658,20 @@ mechanics + release-gate procedure.
    (portfolio briefly $25K during AAPL/Tesla split window) — flagged
    for trade-audit follow-up.
 
+## Follow-up
+
+- **Panel_runner per-fold tmp-dir leak fix (#1393)** — landed via
+  `feat/panel-runner-tmp-cleanup`. `Csv_snapshot_builder` now registers
+  every `/tmp/panel_runner_csv_snapshot_*` dir in a process-wide
+  cleanup ledger; `Stdlib.at_exit` removes any dir still in the ledger
+  on exit, and SIGTERM/SIGINT/SIGHUP handlers re-raise as
+  `exit 130` so the at_exit chain fires on graceful kill. Adds
+  `cleanup`, `register_for_cleanup`, `registered_dirs`,
+  `startup_orphan_sweep` to the .mli. Closes the 1895-dir / 53 GB
+  orphan accumulation observed 2026-05-31. SIGKILL remains uncoverable
+  by design; `startup_orphan_sweep` is the belt-and-suspenders
+  mitigation for that residual.
+
 ## Ownership
 
 `feat-backtest` agent (sibling of backtest-infra and backtest-scale).

--- a/trading/trading/backtest/lib/csv_snapshot_builder.ml
+++ b/trading/trading/backtest/lib/csv_snapshot_builder.ml
@@ -7,6 +7,111 @@ module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
 module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
 module Pipeline = Snapshot_pipeline.Pipeline
 
+(* ===== Cleanup ledger and signal/at_exit handlers ============================
+
+   Each call to [build] allocates a /tmp/panel_runner_csv_snapshot_<hash>/ dir
+   (~26-30 MB at 530 symbols). Long-running walk-forward rigs accumulate one
+   per fold. The success path of the caller cleans these via [cleanup]; the
+   leak we guard against here is the {b abnormal} exit path (issue #1393):
+
+   - Uncaught exception: [Stdlib.at_exit] still fires.
+   - Graceful SIGTERM / SIGINT / SIGHUP: we install handlers that re-raise as
+     [Stdlib.exit 130], which lets at_exit run.
+   - SIGKILL: uncoverable by design; [startup_orphan_sweep] is the
+     belt-and-suspenders mitigation.
+
+   The ledger is a plain hashtbl keyed by dir path. The codebase is
+   single-domain; if Domain.spawn shows up later we can add a Mutex. *)
+
+let _ledger : (string, unit) Hashtbl.t = Hashtbl.create (module String) ~size:64
+
+(* Recursive rm-rf via Sys.command. The path comes from Filename.temp_dir so
+   we trust its shape, but quote anyway for safety. Errors are swallowed —
+   on a partial-cleanup the OS reaper / next startup_orphan_sweep handles it. *)
+let _rm_rf path =
+  if Stdlib.Sys.file_exists path then
+    let cmd = Printf.sprintf "rm -rf %s" (Stdlib.Filename.quote path) in
+    ignore (Stdlib.Sys.command cmd : int)
+
+let _at_exit_cleanup () =
+  Hashtbl.iter_keys _ledger ~f:_rm_rf;
+  Hashtbl.clear _ledger
+
+(* Signal handler that re-raises as exit 130. Stdlib.exit invokes the at_exit
+   chain in registration order, so our cleanup runs before the process dies.
+   Code 130 is the conventional "terminated by SIGINT" exit code (128 + 2);
+   we use it uniformly for SIGTERM / SIGINT / SIGHUP since the caller cares
+   only that we exited cleanly. *)
+let _on_signal _ = Stdlib.exit 130
+let _handlers_installed = ref false
+
+let _install_handlers_once () =
+  if not !_handlers_installed then (
+    _handlers_installed := true;
+    Stdlib.at_exit _at_exit_cleanup;
+    let h = Stdlib.Sys.Signal_handle _on_signal in
+    (* Sys.set_signal raises Invalid_argument on platforms that don't know
+       the signal (e.g. SIGHUP on Windows). Swallow — we are best-effort. *)
+    let safe_set sig_ =
+      try Stdlib.Sys.set_signal sig_ h with Invalid_argument _ -> ()
+    in
+    safe_set Stdlib.Sys.sigterm;
+    safe_set Stdlib.Sys.sigint;
+    safe_set Stdlib.Sys.sighup)
+
+let register_for_cleanup dir =
+  _install_handlers_once ();
+  Hashtbl.set _ledger ~key:dir ~data:()
+
+let cleanup dir =
+  Hashtbl.remove _ledger dir;
+  _rm_rf dir
+
+let registered_dirs () = Hashtbl.keys _ledger
+
+(* Belt-and-suspenders sweep: SIGKILL / power-loss can still leave orphans.
+   Sweep /tmp/panel_runner_csv_snapshot_* with mtime older than max_age_hours
+   and remove. Errors per-dir are swallowed so one bad entry doesn't abort
+   the sweep. *)
+let _default_max_age_hours = 24.0
+
+(* Read mtime for [full] if it is an existing directory; None otherwise.
+   Swallows stat / is_directory errors uniformly (permission, race with
+   another sweeper). *)
+let _dir_mtime full =
+  match Stdlib.Sys.is_directory full with
+  | false -> None
+  | exception _ -> None
+  | true -> (
+      match Core_unix.stat full with
+      | exception _ -> None
+      | stat -> Some stat.st_mtime)
+
+let _sweep_one ~now ~max_age_seconds tmp_dir entry =
+  if not (String.is_prefix entry ~prefix:"panel_runner_csv_snapshot_") then 0
+  else
+    let full = Filename.concat tmp_dir entry in
+    match _dir_mtime full with
+    | None -> 0
+    | Some mtime ->
+        let age = now -. mtime in
+        if Float.( <= ) age max_age_seconds then 0
+        else (
+          _rm_rf full;
+          1)
+
+let startup_orphan_sweep ?(max_age_hours = _default_max_age_hours) () =
+  let tmp_dir = Stdlib.Filename.get_temp_dir_name () in
+  match Stdlib.Sys.readdir tmp_dir with
+  | exception _ -> 0
+  | entries ->
+      let now = Core_unix.gettimeofday () in
+      let max_age_seconds = max_age_hours *. 3600.0 in
+      Array.fold entries ~init:0 ~f:(fun acc entry ->
+          acc + _sweep_one ~now ~max_age_seconds tmp_dir entry)
+
+(* ===== Per-symbol CSV → .snap pipeline (unchanged from F.3.a-3) ============= *)
+
 (* Read one symbol's CSV; tolerate NotFound / missing CSV by returning an
    empty bar list (mirrors the legacy Ohlcv_panels.load_from_csv_calendar
    path's "row stays NaN" semantics). Other errors fail the runner. *)
@@ -84,6 +189,9 @@ let _read_build_write_one ~data_dir ~start_date ~end_date ~dir symbol =
 
 let build ~data_dir ~universe ~start_date ~end_date =
   let dir = Stdlib.Filename.temp_dir "panel_runner_csv_snapshot_" "" in
+  (* Register before doing any work — if [List.map] below raises, the at_exit
+     hook still cleans the partially-populated dir. Closes #1393. *)
+  register_for_cleanup dir;
   let entries =
     List.map universe
       ~f:(_read_build_write_one ~data_dir ~start_date ~end_date ~dir)

--- a/trading/trading/backtest/lib/csv_snapshot_builder.mli
+++ b/trading/trading/backtest/lib/csv_snapshot_builder.mli
@@ -8,14 +8,31 @@
     serialises them to per-symbol [.snap] files under a tmp directory. The
     downstream setup is then identical to a pre-built snapshot mode run.
 
-    No [benchmark_bars] is supplied to the pipeline, so [RS_line] /
-    [Macro_composite] columns are NaN — the bar-shaped views
-    ([Snapshot_runtime.Snapshot_bar_views]) only read OHLCV columns, so the
-    strategy's bar reads are unaffected.
+    {2 Cleanup of [/tmp/panel_runner_csv_snapshot_*] dirs}
 
-    The tmp directory is left in place after the call returns; the OS reaps it
-    on reboot. Long-running rigs that build many snapshots in one process should
-    plumb a teardown hook (out of scope for F.3.a-3). *)
+    Each call to {!build} creates a fresh tmp directory under
+    [Filename.temp_dir_name] (typically
+    [/tmp/panel_runner_csv_snapshot_<hash>/], ~26-30 MB at 530 symbols). The
+    {b normal} success path of long-running walk-forward rigs cleans these
+    per-fold via {!cleanup} (caller invokes it after the fold completes).
+
+    The {b abnormal} exit path (uncaught exception, [Stdlib.exit], graceful
+    signal kill) is handled by this module itself:
+
+    - Every dir returned by {!build} is registered in a process-wide cleanup
+      ledger and scheduled for [Stdlib.at_exit] removal.
+    - The first call to {!build} also installs handlers for [SIGTERM], [SIGINT],
+      and [SIGHUP] that re-raise as [Stdlib.exit 130], so the at_exit chain runs
+      on a graceful kill.
+    - {!cleanup} removes a dir explicitly {b and} unregisters it from the
+      ledger, so the at_exit handler does not double-rm.
+    - [SIGKILL] is uncoverable — the kernel destroys the process before any
+      handler runs. {!startup_orphan_sweep} provides a belt-and-suspenders sweep
+      that removes orphans older than a threshold on startup.
+
+    See {{!issue_1393} issue #1393} for the failure mode this guards: a killed
+    or crashed walk-forward run accumulated ~53 GB of orphans over many days,
+    eventually exhausting [/tmp] and ENOSPC-killing a fresh deep run. *)
 
 open Core
 
@@ -35,8 +52,44 @@ val build :
     Returns [(snapshot_dir, manifest)]: the path to the tmp directory and the
     in-memory directory manifest (also serialised to [<dir>/manifest.sexp]).
 
+    The returned [snapshot_dir] is registered for cleanup on abnormal exit — see
+    the module docstring. Callers should still call {!cleanup} explicitly on the
+    success path; the at_exit hook then becomes a no-op for that dir.
+
     Missing-CSV / [NotFound] errors are tolerated: the symbol contributes an
     empty bar list, mirroring the legacy CSV loader's "row stays NaN" semantics.
     Any other [Csv_storage] / pipeline / serialisation error fails via
     [failwith] with a descriptive message — these all indicate programming or
     environment errors that the runner cannot recover from. *)
+
+val cleanup : string -> unit
+(** [cleanup dir] removes [dir] recursively if it exists and unregisters it from
+    the at_exit cleanup ledger. Idempotent: calling it twice (or on a dir that
+    does not exist) is a no-op.
+
+    Use this on the success path immediately after the consumer is done with the
+    snapshot directory. The at_exit hook will then skip this dir on process
+    exit. *)
+
+val register_for_cleanup : string -> unit
+(** [register_for_cleanup dir] adds [dir] to the at_exit cleanup ledger and
+    installs the SIGTERM / SIGINT / SIGHUP handlers (idempotent across calls).
+    {!build} calls this internally on every dir it creates; tests and callers
+    that allocate snapshot dirs through some other path can call it directly. *)
+
+val registered_dirs : unit -> string list
+(** [registered_dirs ()] returns the dirs currently in the cleanup ledger (i.e.
+    created via {!build} and not yet {!cleanup}-ed). Intended for tests and
+    diagnostics. *)
+
+val startup_orphan_sweep : ?max_age_hours:float -> unit -> int
+(** [startup_orphan_sweep ?max_age_hours ()] sweeps [Filename.temp_dir_name] for
+    [panel_runner_csv_snapshot_*] directories whose mtime is older than
+    [max_age_hours] (default 24) and removes them. Returns the count removed.
+
+    This is a belt-and-suspenders defense against the SIGKILL / power-loss case
+    the at_exit hook cannot cover. The per-call at_exit registration is the
+    load-bearing fix; this sweep handles the residual long-tail.
+
+    Safe to call multiple times. Errors removing individual dirs (e.g.
+    permission, EBUSY) are swallowed; the sweep continues. *)

--- a/trading/trading/backtest/test/csv_snapshot_builder_cleanup_subject.ml
+++ b/trading/trading/backtest/test/csv_snapshot_builder_cleanup_subject.ml
@@ -1,0 +1,33 @@
+(** Test subject for [test_csv_snapshot_builder_cleanup]. Allocates a
+    [/tmp/panel_runner_csv_snapshot_*] dir via
+    [Csv_snapshot_builder.register_for_cleanup], prints the dir path on stdout,
+    then exits abnormally per its argv:
+
+    - "raise" — raises an OCaml exception (uncaught -> at_exit fires).
+    - "sigterm" — sends itself SIGTERM (signal handler -> exit 130 -> at_exit
+      fires).
+
+    The parent test reads the dir from stdout and asserts the dir is gone after
+    the subprocess exits. *)
+
+let () =
+  let dir = Filename.temp_dir "panel_runner_csv_snapshot_" "_subject" in
+  Backtest.Csv_snapshot_builder.register_for_cleanup dir;
+  (* Print path BEFORE the abnormal exit and flush, so the parent can read it
+     even when the process dies before stdout is naturally flushed. *)
+  print_endline dir;
+  flush stdout;
+  match Sys.argv with
+  | [| _; "raise" |] -> failwith "subject: intentional abnormal exit"
+  | [| _; "sigterm" |] ->
+      Unix.kill (Unix.getpid ()) Sys.sigterm;
+      (* Sleep a few seconds so the SIGTERM has time to actually fire the
+         handler; if we exit normally before the signal lands, the test would
+         not exercise the SIGTERM path. *)
+      Unix.sleep 5;
+      print_endline "subject: SIGTERM did not fire — handler not installed?";
+      exit 99
+  | _ ->
+      prerr_endline
+        "usage: csv_snapshot_builder_cleanup_subject.exe (raise|sigterm)";
+      exit 2

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -25,7 +25,8 @@
   test_release_perf_report
   test_determinism
   test_bah_runner_e2e
-  test_macro_trend_writer)
+  test_macro_trend_writer
+  test_csv_snapshot_builder_cleanup)
  (libraries
   ounit2
   core
@@ -61,3 +62,12 @@
   matchers)
  (preprocess
   (pps ppx_sexp_conv ppx_deriving.eq ppx_deriving.show)))
+
+; Subject binary for test_csv_snapshot_builder_cleanup's subprocess tests.
+; Allocates a /tmp/panel_runner_csv_snapshot_* dir, registers it for
+; cleanup, then exits abnormally per argv ("raise" or "sigterm"). Lives in
+; the same _build/test dir as the test exe so the test can locate it.
+
+(executable
+ (name csv_snapshot_builder_cleanup_subject)
+ (libraries backtest))

--- a/trading/trading/backtest/test/test_csv_snapshot_builder_cleanup.ml
+++ b/trading/trading/backtest/test/test_csv_snapshot_builder_cleanup.ml
@@ -1,0 +1,206 @@
+(** Unit + integration tests for {!Backtest.Csv_snapshot_builder} cleanup
+    surface — see issue #1393 for the abnormal-exit leak this fixes.
+
+    Three layers:
+
+    - {b unit}: [register_for_cleanup] + [cleanup] + [registered_dirs] are pure
+      ledger ops on string keys; no subprocess needed.
+    - {b orphan-sweep unit}: [startup_orphan_sweep] keys on the
+      [panel_runner_csv_snapshot_] prefix and an mtime threshold; verify it
+      removes old entries and spares fresh ones and non-matching dirs.
+    - {b abnormal-exit integration}: spawn a subprocess via the
+      [csv_snapshot_builder_cleanup_subject.exe] helper that allocates a tmp
+      dir, registers it, then either raises an uncaught exception or sends
+      itself a SIGTERM. The parent verifies the dir is gone after the child
+      exits. *)
+
+open OUnit2
+open Core
+open Matchers
+module Builder = Backtest.Csv_snapshot_builder
+
+(* -------------- subject binary path -------------- *)
+
+(* The subject binary lives next to this test exe in the _build tree (per
+   the [executables] stanza in test/dune). It supports two modes via argv:
+   "raise" — registers a tmp dir then raises an exception;
+   "sigterm" — registers a tmp dir then kills itself with SIGTERM.
+   In both cases it prints the dir path on stdout BEFORE the abnormal exit
+   so the parent can verify cleanup. *)
+let _subject_binary =
+  Filename.concat
+    (Filename.dirname Stdlib.Sys.executable_name)
+    "csv_snapshot_builder_cleanup_subject.exe"
+
+(* -------------- unit tests on the cleanup ledger -------------- *)
+
+(* Use a sibling tmp dir under /tmp/cstest_<pid>_<seq>/ for these tests — we
+   do NOT use Filename.temp_dir with the "panel_runner_csv_snapshot_" prefix
+   because the unit-test process is long-lived (runs many tests) and we
+   don't want the at_exit handler to fire mid-suite. The test-managed dirs
+   are removed via Sys.command rm -rf at the end of each test. *)
+let _seq = ref 0
+
+let _make_tmpdir () =
+  Int.incr _seq;
+  let dir =
+    Printf.sprintf "/tmp/cstest_%d_%d_%f"
+      (Pid.to_int (Core_unix.getpid ()))
+      !_seq
+      (Core_unix.gettimeofday ())
+  in
+  Core_unix.mkdir_p dir;
+  dir
+
+let _rm_rf path =
+  if Stdlib.Sys.file_exists path then
+    ignore
+      (Stdlib.Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote path))
+        : int)
+
+let test_register_then_cleanup_removes_dir _ =
+  let dir = _make_tmpdir () in
+  Builder.register_for_cleanup dir;
+  assert_that
+    (List.mem (Builder.registered_dirs ()) dir ~equal:String.equal)
+    (equal_to true);
+  Builder.cleanup dir;
+  assert_that (Stdlib.Sys.file_exists dir) (equal_to false);
+  assert_that
+    (List.mem (Builder.registered_dirs ()) dir ~equal:String.equal)
+    (equal_to false)
+
+let test_cleanup_is_idempotent _ =
+  let dir = _make_tmpdir () in
+  Builder.register_for_cleanup dir;
+  Builder.cleanup dir;
+  (* Second cleanup on an already-removed dir must not raise. *)
+  Builder.cleanup dir;
+  assert_that (Stdlib.Sys.file_exists dir) (equal_to false)
+
+let test_cleanup_on_unregistered_dir_is_noop _ =
+  let dir = _make_tmpdir () in
+  (* Never registered — cleanup should still remove the dir but the ledger
+     is unchanged for other entries. *)
+  let dir_other = _make_tmpdir () in
+  Builder.register_for_cleanup dir_other;
+  Builder.cleanup dir;
+  assert_that (Stdlib.Sys.file_exists dir) (equal_to false);
+  assert_that
+    (List.mem (Builder.registered_dirs ()) dir_other ~equal:String.equal)
+    (equal_to true);
+  Builder.cleanup dir_other
+
+let test_register_is_idempotent _ =
+  let dir = _make_tmpdir () in
+  Builder.register_for_cleanup dir;
+  Builder.register_for_cleanup dir;
+  Builder.register_for_cleanup dir;
+  let n_matching =
+    Builder.registered_dirs () |> List.count ~f:(String.equal dir)
+  in
+  assert_that n_matching (equal_to 1);
+  Builder.cleanup dir
+
+(* -------------- orphan sweep unit tests -------------- *)
+
+let test_orphan_sweep_removes_old_panel_runner_dirs _ =
+  (* Create a dir that matches the prefix and backdate its mtime. The
+     sweep should remove it. We use a 0.001-hour threshold (3.6 seconds)
+     to avoid flakiness with the system clock. *)
+  let dir =
+    Stdlib.Filename.temp_dir "panel_runner_csv_snapshot_" "_test_orphan_old"
+  in
+  (* Backdate mtime to 1 hour ago. *)
+  let one_hour_ago = Core_unix.gettimeofday () -. 3600.0 in
+  Core_unix.utimes dir ~access:one_hour_ago ~modif:one_hour_ago;
+  let removed = Builder.startup_orphan_sweep ~max_age_hours:0.001 () in
+  assert_that (Stdlib.Sys.file_exists dir) (equal_to false);
+  (* At least our test dir was removed; other CI residue could push count higher. *)
+  assert_that removed (ge (module Int_ord) 1)
+
+let test_orphan_sweep_spares_fresh_panel_runner_dirs _ =
+  (* A freshly-created dir (mtime ~now) should be spared by a 1-hour
+     threshold sweep. *)
+  let dir =
+    Stdlib.Filename.temp_dir "panel_runner_csv_snapshot_" "_test_orphan_fresh"
+  in
+  let _ = Builder.startup_orphan_sweep ~max_age_hours:1.0 () in
+  assert_that (Stdlib.Sys.file_exists dir) (equal_to true);
+  _rm_rf dir
+
+let test_orphan_sweep_ignores_non_matching_dirs _ =
+  let dir = _make_tmpdir () in
+  (* Backdate so we'd remove if the prefix matched. *)
+  let one_hour_ago = Core_unix.gettimeofday () -. 3600.0 in
+  Core_unix.utimes dir ~access:one_hour_ago ~modif:one_hour_ago;
+  let _ = Builder.startup_orphan_sweep ~max_age_hours:0.001 () in
+  assert_that (Stdlib.Sys.file_exists dir) (equal_to true);
+  _rm_rf dir
+
+(* -------------- integration tests via subject subprocess -------------- *)
+
+let _run_subject ~arg =
+  let stdout_path = Stdlib.Filename.temp_file "cstest_stdout_" "" in
+  let cmd =
+    Printf.sprintf "%s %s > %s 2>&1" _subject_binary arg
+      (Filename.quote stdout_path)
+  in
+  let exit_code = Stdlib.Sys.command cmd in
+  let stdout = In_channel.read_all stdout_path in
+  _rm_rf stdout_path;
+  (* The subject prints the dir on its FIRST line (always), then EITHER
+     raises (uncaught -> exit 2) OR sigterms itself (exit 130 via our handler
+     OR raw 143 if our handler didn't install). *)
+  let dir =
+    match String.split_lines stdout with
+    | first :: _ -> String.strip first
+    | [] -> failwith "subject produced no output"
+  in
+  (dir, exit_code, stdout)
+
+let test_abnormal_exit_via_uncaught_exception _ =
+  let dir, _exit_code, _out = _run_subject ~arg:"raise" in
+  (* The dir name must look like a panel_runner_csv_snapshot_ tmp dir so
+     we know the subject ran the code path we intended. *)
+  assert_that
+    (String.is_substring dir ~substring:"panel_runner_csv_snapshot_")
+    (equal_to true);
+  (* And the dir must be gone — at_exit fires on uncaught exceptions. *)
+  assert_that (Stdlib.Sys.file_exists dir) (equal_to false)
+
+let test_abnormal_exit_via_sigterm _ =
+  let dir, exit_code, _out = _run_subject ~arg:"sigterm" in
+  assert_that
+    (String.is_substring dir ~substring:"panel_runner_csv_snapshot_")
+    (equal_to true);
+  (* Exit code is 130 (our handler maps SIGTERM -> exit 130). If our
+     handler weren't installed the shell would surface 143 (128 + SIGTERM=15)
+     and the dir would leak. *)
+  assert_that exit_code (equal_to 130);
+  assert_that (Stdlib.Sys.file_exists dir) (equal_to false)
+
+(* -------------- suite -------------- *)
+
+let suite =
+  "Csv_snapshot_builder cleanup"
+  >::: [
+         "register + cleanup removes dir and ledger entry"
+         >:: test_register_then_cleanup_removes_dir;
+         "cleanup is idempotent" >:: test_cleanup_is_idempotent;
+         "cleanup on unregistered dir does not touch other entries"
+         >:: test_cleanup_on_unregistered_dir_is_noop;
+         "register is idempotent" >:: test_register_is_idempotent;
+         "orphan sweep removes old panel_runner dirs"
+         >:: test_orphan_sweep_removes_old_panel_runner_dirs;
+         "orphan sweep spares fresh panel_runner dirs"
+         >:: test_orphan_sweep_spares_fresh_panel_runner_dirs;
+         "orphan sweep ignores non-panel_runner dirs"
+         >:: test_orphan_sweep_ignores_non_matching_dirs;
+         "abnormal exit (uncaught exception) cleans up dir"
+         >:: test_abnormal_exit_via_uncaught_exception;
+         "abnormal exit (SIGTERM) cleans up dir"
+         >:: test_abnormal_exit_via_sigterm;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
Closes #1393.

## What

Every walk-forward folds Panel_runner builds an in-process snapshot under `/tmp/panel_runner_csv_snapshot_<hash>/` (~26-30 MB at 530 symbols). The normal success path cleans these per-fold. The leak is on ABNORMAL exit (uncaught exception, kill -TERM, etc.) — a run that crashes or is killed orphans its in-flight + already-built snapshots, which persist forever.

Observed 2026-05-31 maintainer session: 1895 orphans ~= 53 GB of /tmp, ENOSPC-killing a fresh deep walk-forward run.

## Why this fix

The fix routes through the producer: `Csv_snapshot_builder.build` now registers every allocated dir in a process-wide cleanup ledger. The first call also installs:

- `Stdlib.at_exit` → removes any dir still in the ledger on exit (covers uncaught exception, `Stdlib.exit`, normal-return-without-cleanup).
- `Sys.signal` handlers for `SIGTERM` / `SIGINT` / `SIGHUP` → re-raise as `Stdlib.exit 130` so the at_exit chain runs on graceful kill.

`cleanup dir` is the success-path entry point: removes dir + unregisters from the ledger so at_exit is a no-op. `SIGKILL` is uncoverable by design; `startup_orphan_sweep ?max_age_hours ()` is the belt-and-suspenders mitigation for that residual (sweeps `panel_runner_csv_snapshot_*` older than max_age_hours, default 24h).

## Surface added to `csv_snapshot_builder.mli`

- `val cleanup : string -> unit`
- `val register_for_cleanup : string -> unit`
- `val registered_dirs : unit -> string list`
- `val startup_orphan_sweep : ?max_age_hours:float -> unit -> int`

## Test plan

9 new tests, all green:

- **unit**: register + cleanup ledger semantics, idempotency, cleanup-on-unregistered-dir, register-is-idempotent.
- **orphan-sweep**: removes old `panel_runner_` dirs (backdated mtime), spares fresh ones (1h threshold), ignores non-matching prefixes.
- **abnormal-exit integration**: subject subprocess raises an uncaught exception → parent verifies dir is gone after exit.
- **abnormal-exit integration**: subject subprocess sends itself SIGTERM → parent verifies dir is gone + exit code is 130 (proves our handler fired, not the default 143).

Verify:
```
cd trading && dune build && dune runtest trading/backtest/test/
```

## Files

- `trading/trading/backtest/lib/csv_snapshot_builder.{ml,mli}` — ledger + signal handlers + orphan sweep + `register` on `build`.
- `trading/trading/backtest/test/test_csv_snapshot_builder_cleanup.ml` — 9 tests.
- `trading/trading/backtest/test/csv_snapshot_builder_cleanup_subject.ml` — subject binary for subprocess tests.
- `trading/trading/backtest/test/dune` — register both.
- `dev/status/backtest-perf.md` — Follow-up note.

🤖 Dispatched by GHA orchestrator run [26722638076](https://github.com/dayfine/trading/actions/runs/26722638076)