### PR TITLE
feat(walk-forward): --lifetime-trials for population-aware DSR

### DIFF
--- a/trading/trading/backtest/walk_forward/bin/rank_variants.ml
+++ b/trading/trading/backtest/walk_forward/bin/rank_variants.ml
@@ -9,14 +9,23 @@
       ([fold_actuals.sexp] from the runner). Optional; required for DSR.
     - [--baseline-label <label>] — header annotation; defaults to "baseline".
     - [--output <path>] — write markdown there; default stdout.
+    - [--lifetime-trials <N>] — best-of-N trial budget for the DSR
+      selection-bias correction (positive int). Defaults to the number of
+      variants in this surface; supply a larger value when the search spans
+      multiple surfaces / rounds so DSR corrects against the whole
+      population-search lifetime, not a single matrix. Must be at least the
+      surface's variant count (a smaller lifetime budget than this surface is a
+      user error and fails fast). Omitting it reproduces the single-surface
+      behaviour exactly (bit-identical).
 
     DSR is per-variant: feeds the variant's [sharpe_ratio.mean] (from the
     aggregate) as the observed Sharpe, the variant's per-fold [total_return_pct]
     series (from fold_actuals) as the fold returns, and the across-variant
-    Sharpe-mean variance as the best-of-N selection-bias correction. Variants
-    with fewer than two non-NaN fold returns or zero return-variance are skipped
-    (no DSR column for that row); the rendering treats missing labels as "n/a"
-    per {!Walk_forward.Variant_ranking.render}.
+    Sharpe-mean variance as the best-of-N selection-bias correction. The
+    best-of-N trial count is [--lifetime-trials] when given, else the surface's
+    variant count. Variants with fewer than two non-NaN fold returns or zero
+    return-variance are skipped (no DSR column for that row); the rendering
+    treats missing labels as "n/a" per {!Walk_forward.Variant_ranking.render}.
 
     Gap C of [dev/plans/experiment-platform-2026-05-29.md]: every future verdict
     ranks via the same committed pipeline rather than an ad-hoc exe. *)
@@ -33,16 +42,28 @@ type cli_args = {
   fold_actuals_path : string option;
   baseline_label : string;
   output_path : string option;
+  lifetime_trials : int option;
 }
 
 let _default_baseline_label = "baseline"
 
 let _usage_msg =
   "Usage: rank_variants.exe --aggregate <aggregate.sexp> [--fold-actuals \
-   <fold_actuals.sexp>] [--baseline-label <label>] [--output <path>]"
+   <fold_actuals.sexp>] [--baseline-label <label>] [--output <path>] \
+   [--lifetime-trials <N>]"
+
+(** Parse a [--lifetime-trials] argument: a positive integer, else exit 1. *)
+let _parse_lifetime_trials raw =
+  match Int.of_string_opt raw with
+  | Some n when n > 0 -> n
+  | _ ->
+      eprintf
+        "Error: --lifetime-trials must be a positive integer, got %S\n%s\n" raw
+        _usage_msg;
+      Stdlib.exit 1
 
 let _parse_args argv =
-  let rec loop agg folds baseline out = function
+  let rec loop agg folds baseline out lifetime = function
     | [] -> (
         match agg with
         | Some a ->
@@ -52,14 +73,20 @@ let _parse_args argv =
               baseline_label =
                 Option.value baseline ~default:_default_baseline_label;
               output_path = out;
+              lifetime_trials = lifetime;
             }
         | None ->
             eprintf "Error: --aggregate is required\n%s\n" _usage_msg;
             Stdlib.exit 1)
-    | "--aggregate" :: p :: rest -> loop (Some p) folds baseline out rest
-    | "--fold-actuals" :: p :: rest -> loop agg (Some p) baseline out rest
-    | "--baseline-label" :: l :: rest -> loop agg folds (Some l) out rest
-    | "--output" :: p :: rest -> loop agg folds baseline (Some p) rest
+    | "--aggregate" :: p :: rest ->
+        loop (Some p) folds baseline out lifetime rest
+    | "--fold-actuals" :: p :: rest ->
+        loop agg (Some p) baseline out lifetime rest
+    | "--baseline-label" :: l :: rest ->
+        loop agg folds (Some l) out lifetime rest
+    | "--output" :: p :: rest -> loop agg folds baseline (Some p) lifetime rest
+    | "--lifetime-trials" :: n :: rest ->
+        loop agg folds baseline out (Some (_parse_lifetime_trials n)) rest
     | ("--help" | "-h") :: _ ->
         printf "%s\n" _usage_msg;
         Stdlib.exit 0
@@ -67,7 +94,7 @@ let _parse_args argv =
         eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
         Stdlib.exit 1
   in
-  loop None None None None argv
+  loop None None None None None argv
 
 (* -------------- input loading -------------- *)
 
@@ -151,18 +178,36 @@ let _compute_dsr_one ~variant_label ~observed_sharpe ~fold_actuals ~n_trials
       Computed dsr
     with Invalid_argument msg -> Skipped (sprintf "%s: %s" variant_label msg)
 
+(** Resolve the best-of-N trial count from the surface size and an optional
+    [lifetime_trials] override. Defaults to [surface_n] (reproducing the
+    single-surface behaviour). A lifetime budget smaller than this surface is a
+    user error — fail fast rather than silently clamping. *)
+let _resolve_n_trials ~surface_n ~lifetime_trials =
+  match lifetime_trials with
+  | None -> surface_n
+  | Some lt when lt >= surface_n -> lt
+  | Some lt ->
+      eprintf
+        "Error: --lifetime-trials (%d) is smaller than this surface's variant \
+         count (%d); the lifetime trial budget cannot be smaller than the \
+         surface it ranks\n"
+        lt surface_n;
+      Stdlib.exit 1
+
 (** Walk the aggregate's [stability] list, computing DSR for each variant and
     collecting both the assoc list passed to the renderer and a list of skip
-    reasons surfaced on stderr. *)
-let _build_dsr_table (aggregate : T.aggregate) fold_actuals =
+    reasons surfaced on stderr. [lifetime_trials], when given, overrides the
+    best-of-N trial count (defaults to the surface's variant count). *)
+let _build_dsr_table (aggregate : T.aggregate) fold_actuals ~lifetime_trials =
   let stability = aggregate.stability in
-  let n_trials = List.length stability in
-  if n_trials < _min_fold_count then
+  let surface_n = List.length stability in
+  let n_trials = _resolve_n_trials ~surface_n ~lifetime_trials in
+  if surface_n < _min_fold_count then
     (* expected_max_sharpe needs n >= 2; if we have one variant, DSR is
        undefined for the whole table. *)
     ( [],
       [
-        sprintf "n_trials = %d; need at least %d for DSR" n_trials
+        sprintf "surface has %d variant(s); need at least %d for DSR" surface_n
           _min_fold_count;
       ] )
   else
@@ -177,7 +222,7 @@ let _build_dsr_table (aggregate : T.aggregate) fold_actuals =
           sprintf
             "Sharpe variance across %d variants is zero; DSR undefined for \
              every variant"
-            n_trials;
+            surface_n;
         ] )
     else
       let dsrs, skips =
@@ -216,6 +261,7 @@ let _main () =
     | Some path ->
         let fold_actuals = _load_fold_actuals path in
         _build_dsr_table aggregate fold_actuals
+          ~lifetime_trials:args.lifetime_trials
   in
   List.iter skips ~f:(fun msg ->
       eprintf "[rank_variants] skipped DSR — %s\n" msg);

--- a/trading/trading/backtest/walk_forward/test/test_rank_variants.ml
+++ b/trading/trading/backtest/walk_forward/test/test_rank_variants.ml
@@ -85,6 +85,57 @@ let _invoke ~dir args =
   let stderr = In_channel.read_all stderr_path in
   { exit_code; stdout; stderr }
 
+(* Extract the Deflated-Sharpe cell for [label] from rendered markdown. The
+   per-variant row is "| label | sharpe | calmar | maxdd | frontier | dsr |";
+   the DSR is the last pipe-delimited field. Returns [None] when the row is
+   absent or its DSR cell is "n/a". *)
+let _extract_dsr ~label stdout =
+  let row_marker = sprintf "| %s |" label in
+  List.find_map (String.split_lines stdout) ~f:(fun line ->
+      if String.is_prefix line ~prefix:row_marker then
+        match
+          String.split line ~on:'|' |> List.map ~f:String.strip
+          |> List.filter ~f:(fun s -> not (String.is_empty s))
+          |> List.last
+        with
+        | Some cell -> Float.of_string_opt cell
+        | None -> None
+      else None)
+
+(* The three-variant aggregate + fold_actuals fixture used by the
+   lifetime-trials tests: identical to the end-to-end fixture above. Returns the
+   aggregate-sexp and fold-actuals-sexp paths in [dir]. *)
+let _write_three_variant_fixture ~dir =
+  let stability =
+    [
+      _make_stability ~label:"A" ~sharpe:1.0 ~calmar:0.8 ~max_dd:20.0;
+      _make_stability ~label:"B" ~sharpe:0.9 ~calmar:0.9 ~max_dd:25.0;
+      _make_stability ~label:"C" ~sharpe:0.5 ~calmar:0.4 ~max_dd:30.0;
+    ]
+  in
+  let agg_path =
+    _write_sexp ~dir ~name:"aggregate.sexp"
+      (T.sexp_of_aggregate (_make_aggregate ~stability))
+  in
+  let folds =
+    [
+      _make_fold_actual ~fold_name:"f0" ~variant_label:"A" ~total_return:10.0;
+      _make_fold_actual ~fold_name:"f1" ~variant_label:"A" ~total_return:5.0;
+      _make_fold_actual ~fold_name:"f2" ~variant_label:"A" ~total_return:15.0;
+      _make_fold_actual ~fold_name:"f0" ~variant_label:"B" ~total_return:8.0;
+      _make_fold_actual ~fold_name:"f1" ~variant_label:"B" ~total_return:3.0;
+      _make_fold_actual ~fold_name:"f2" ~variant_label:"B" ~total_return:12.0;
+      _make_fold_actual ~fold_name:"f0" ~variant_label:"C" ~total_return:(-2.0);
+      _make_fold_actual ~fold_name:"f1" ~variant_label:"C" ~total_return:(-5.0);
+      _make_fold_actual ~fold_name:"f2" ~variant_label:"C" ~total_return:1.0;
+    ]
+  in
+  let folds_path =
+    _write_sexp ~dir ~name:"fold_actuals.sexp"
+      ([%sexp_of: T.fold_actual list] folds)
+  in
+  (agg_path, folds_path)
+
 (* -------------- tests -------------- *)
 
 (* 1. End-to-end on a 3-variant aggregate + matching fold_actuals. Output
@@ -267,6 +318,71 @@ let test_pareto_single_dominator _ =
   in
   assert_that frontier_section (not_ (contains_substring "- loser"))
 
+(* 6. Backward-compat: passing --lifetime-trials equal to the surface variant
+   count reproduces the default (no-flag) DSR output byte-for-byte. *)
+let test_lifetime_trials_equals_surface_is_identical _ =
+  let dir = _make_tmpdir () in
+  let agg_path, folds_path = _write_three_variant_fixture ~dir in
+  let base_args = [ "--aggregate"; agg_path; "--fold-actuals"; folds_path ] in
+  let default_res = _invoke ~dir base_args in
+  let equal_res = _invoke ~dir (base_args @ [ "--lifetime-trials"; "3" ]) in
+  assert_that default_res.exit_code (equal_to 0);
+  assert_that equal_res.stdout (equal_to default_res.stdout)
+
+(* 7. Monotonicity: a --lifetime-trials value strictly larger than the surface
+   variant count yields a strictly lower DSR for every variant (more trials →
+   higher SR_star benchmark → more conservative DSR). *)
+let test_lifetime_trials_lowers_every_dsr _ =
+  let dir = _make_tmpdir () in
+  let agg_path, folds_path = _write_three_variant_fixture ~dir in
+  let base_args = [ "--aggregate"; agg_path; "--fold-actuals"; folds_path ] in
+  let default_res = _invoke ~dir base_args in
+  let big_res = _invoke ~dir (base_args @ [ "--lifetime-trials"; "50" ]) in
+  assert_that default_res.exit_code (equal_to 0);
+  assert_that big_res.exit_code (equal_to 0);
+  let dsr_of res label =
+    match _extract_dsr ~label res.stdout with
+    | Some d -> d
+    | None -> assert_failure (sprintf "no DSR for variant %s" label)
+  in
+  (* One assert per variant: the inflated-trial DSR is strictly below the
+     surface-N DSR for that variant. *)
+  assert_that (dsr_of big_res "A")
+    (lt (module Float_ord) (dsr_of default_res "A"));
+  assert_that (dsr_of big_res "B")
+    (lt (module Float_ord) (dsr_of default_res "B"));
+  assert_that (dsr_of big_res "C")
+    (lt (module Float_ord) (dsr_of default_res "C"))
+
+(* 8. Guard: --lifetime-trials below the surface variant count is a user error;
+   the binary exits non-zero and explains on stderr. *)
+let test_lifetime_trials_below_surface_errors _ =
+  let dir = _make_tmpdir () in
+  let agg_path, folds_path = _write_three_variant_fixture ~dir in
+  let res =
+    _invoke ~dir
+      [
+        "--aggregate";
+        agg_path;
+        "--fold-actuals";
+        folds_path;
+        "--lifetime-trials";
+        "2";
+      ]
+  in
+  assert_that res.exit_code (gt (module Int_ord) 0);
+  assert_that res.stderr (contains_substring "smaller than this surface")
+
+(* 9. Guard: a non-positive --lifetime-trials value is rejected at parse time. *)
+let test_lifetime_trials_non_positive_errors _ =
+  let dir = _make_tmpdir () in
+  let agg_path, _ = _write_three_variant_fixture ~dir in
+  let res =
+    _invoke ~dir [ "--aggregate"; agg_path; "--lifetime-trials"; "0" ]
+  in
+  assert_that res.exit_code (gt (module Int_ord) 0);
+  assert_that res.stderr (contains_substring "must be a positive integer")
+
 (* -------------- suite -------------- *)
 
 let suite =
@@ -278,6 +394,14 @@ let suite =
          >:: test_skip_variant_with_too_few_folds;
          "missing_aggregate" >:: test_missing_aggregate;
          "pareto_single_dominator" >:: test_pareto_single_dominator;
+         "lifetime_trials_equals_surface_is_identical"
+         >:: test_lifetime_trials_equals_surface_is_identical;
+         "lifetime_trials_lowers_every_dsr"
+         >:: test_lifetime_trials_lowers_every_dsr;
+         "lifetime_trials_below_surface_errors"
+         >:: test_lifetime_trials_below_surface_errors;
+         "lifetime_trials_non_positive_errors"
+         >:: test_lifetime_trials_non_positive_errors;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What

Add an optional `--lifetime-trials N` flag to `rank_variants.exe` so the
Deflated-Sharpe best-of-N correction counts the whole population-search trial
budget rather than the variants in a single surface.

## Why

`_build_dsr_table` previously set `n_trials = List.length stability`, i.e. the
DSR best-of-N correction counted only the variants in one `Variant_matrix`.
When a search spans multiple surfaces/rounds (the population-search lifetime),
best-of-N must count the entire trial budget — otherwise DSR under-corrects
and parallel search can report a spuriously significant winner.
`expected_max_sharpe ~n_trials` rises with `n_trials`, so a larger trial count
→ higher `SR_star` benchmark → lower (more conservative) DSR. That conservatism
is the point.

P2.1 of the population-search apparatus
(`dev/plans/population-search-2026-05-31.md`,
`dev/plans/experiment-platform-2026-05-29.md`).

## How

- New `lifetime_trials : int option` in the CLI args record + `--lifetime-trials`
  arm in `_parse_args` (positive-int parse, mirrors `--output` / `--baseline-label`).
- `_resolve_n_trials ~surface_n ~lifetime_trials`: defaults to `surface_n`;
  uses the override when `>= surface_n`; **fails fast** when a provided lifetime
  budget is smaller than the surface (user error, no silent clamp).
- Threaded into `_build_dsr_table ~lifetime_trials`. Doc comment + usage updated.

## Bit-identical when omitted

Omitting `--lifetime-trials` leaves `n_trials = surface_n` exactly as before.
Manual check on a 3-variant fixture:

| variant | default DSR | `--lifetime-trials 50` |
|---|---|---|
| A | 0.8616 | 0.7510 |
| B | 0.8200 | 0.6992 |
| C | 0.6699 | 0.5046 |

`--lifetime-trials 3` (== surface size) reproduces the default output
byte-for-byte (pinned by a new test). `--lifetime-trials 2` (< surface)
exits non-zero with `smaller than this surface`.

## Test plan

`dune build && dune runtest trading/backtest/walk_forward/` — green (9 tests in
`rank_variants_cli`). New tests:
- `lifetime_trials_equals_surface_is_identical` — `--lifetime-trials 3` ==
  default stdout byte-for-byte.
- `lifetime_trials_lowers_every_dsr` — `--lifetime-trials 50` yields a strictly
  lower DSR for every variant (`lt (module Float_ord)` per value).
- `lifetime_trials_below_surface_errors` — `--lifetime-trials 2` exits non-zero.
- `lifetime_trials_non_positive_errors` — `--lifetime-trials 0` rejected at parse.

Scope: `rank_variants.ml` + `test_rank_variants.ml` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
