### PR TITLE
feat(experiment-ledger): durable write_ledger_entry CLI

### DIFF
--- a/trading/trading/backtest/experiment_ledger/bin/dune
+++ b/trading/trading/backtest/experiment_ledger/bin/dune
@@ -1,0 +1,18 @@
+(library
+ (name ledger_entry_builder)
+ (modules ledger_entry_builder)
+ (libraries core experiment_ledger walk_forward)
+ (preprocess
+  (pps ppx_sexp_conv)))
+
+(executable
+ (name write_ledger_entry)
+ (modules write_ledger_entry)
+ (libraries
+  core
+  core_unix.filename_unix
+  experiment_ledger
+  walk_forward
+  ledger_entry_builder)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/experiment_ledger/bin/ledger_entry_builder.ml
+++ b/trading/trading/backtest/experiment_ledger/bin/ledger_entry_builder.ml
@@ -1,0 +1,66 @@
+open Core
+module T = Walk_forward.Walk_forward_types
+module EL = Experiment_ledger
+
+type metadata = {
+  date : string;
+  slug : string;
+  hypothesis : string;
+  base_scenario : string;
+  window_id : string;
+  baseline_label : string;
+  verdict : EL.verdict;
+  notes : string;
+}
+
+let hash_map_of_variants (pairs : (string * Sexp.t list) list) :
+    (string, string) Hashtbl.t =
+  let table = Hashtbl.create (module String) in
+  List.iter pairs ~f:(fun (label, overrides) ->
+      Hashtbl.set table ~key:label ~data:(EL.config_hash overrides));
+  table
+
+(* The four cross-fold means, as [Some fold_aggregate] when every metric is
+   finite. A NaN in any mean (degenerate fixture / fold that never traded)
+   yields [None] rather than recording a fabricated number — the lib documents
+   [None] as the valid "no machine aggregate" case. *)
+let _fold_aggregate_of_stability (s : T.variant_stability) :
+    EL.fold_aggregate option =
+  let mean_sharpe = s.sharpe_ratio.mean in
+  let mean_calmar = s.calmar_ratio.mean in
+  let mean_return_pct = s.total_return_pct.mean in
+  let mean_max_drawdown_pct = s.max_drawdown_pct.mean in
+  let all_finite =
+    List.for_all
+      [ mean_sharpe; mean_calmar; mean_return_pct; mean_max_drawdown_pct ]
+      ~f:Float.is_finite
+  in
+  if all_finite then
+    Some { EL.mean_sharpe; mean_calmar; mean_return_pct; mean_max_drawdown_pct }
+  else None
+
+let _variant_record_of_stability ~config_hash_for (s : T.variant_stability) :
+    EL.variant_record =
+  {
+    EL.label = s.variant_label;
+    config_hash = config_hash_for s.variant_label;
+    aggregate = _fold_aggregate_of_stability s;
+  }
+
+let build_entry ~(metadata : metadata) ~config_hash_for
+    (aggregate : T.aggregate) : EL.entry =
+  let variants =
+    List.map aggregate.stability
+      ~f:(_variant_record_of_stability ~config_hash_for)
+  in
+  {
+    EL.date = metadata.date;
+    slug = metadata.slug;
+    hypothesis = metadata.hypothesis;
+    base_scenario = metadata.base_scenario;
+    window_id = metadata.window_id;
+    baseline_label = metadata.baseline_label;
+    variants;
+    verdict = metadata.verdict;
+    notes = metadata.notes;
+  }

--- a/trading/trading/backtest/experiment_ledger/bin/ledger_entry_builder.mli
+++ b/trading/trading/backtest/experiment_ledger/bin/ledger_entry_builder.mli
@@ -1,0 +1,55 @@
+(** Pure mapping from a walk-forward aggregate to an {!Experiment_ledger.entry}.
+
+    Hoisted out of [write_ledger_entry.ml] so the entry-construction path is
+    unit -testable without invoking the process or touching disk. The CLI is a
+    thin flag-parsing wrapper around {!build_entry}.
+
+    The aggregate ({!Walk_forward.Walk_forward_types.aggregate}) carries each
+    variant's label plus its cross-fold metric means, but NOT its config-hash
+    (the hash is a function of the variant's override blob, which the aggregate
+    does not record). The caller therefore supplies a [config_hash_for] lookup —
+    typically built from the same [Variant_matrix] spec that produced the run
+    (see {!hash_map_of_variants}) — so the recorded hashes line up with the
+    ledger's dedup key. *)
+
+open Core
+
+type metadata = {
+  date : string;
+  slug : string;
+  hypothesis : string;
+  base_scenario : string;
+  window_id : string;
+  baseline_label : string;
+  verdict : Experiment_ledger.verdict;
+  notes : string;
+}
+(** The scalar (non-variant) entry fields the CLI collects from flags. Bundled
+    so {!build_entry} keeps a small, stable signature as fields are added. *)
+
+val hash_map_of_variants :
+  (string * Sexp.t list) list -> (string, string) Hashtbl.t
+(** [hash_map_of_variants pairs] maps each [(label, overrides)] to
+    [label -> Experiment_ledger.config_hash overrides]. Built once from a
+    [Spec.load]ed walk-forward spec's [variants] so per-variant hashes match the
+    ledger's dedup key. Raises [Failure] (via [config_hash]) if any override
+    blob fails to resolve against the canonical default config. *)
+
+val build_entry :
+  metadata:metadata ->
+  config_hash_for:(string -> string) ->
+  Walk_forward.Walk_forward_types.aggregate ->
+  Experiment_ledger.entry
+(** [build_entry ~metadata ~config_hash_for aggregate] maps each variant in
+    [aggregate.stability] to an {!Experiment_ledger.variant_record}:
+
+    - [label] = the variant's [variant_label];
+    - [config_hash] = [config_hash_for label], or [""] when [config_hash_for]
+      has no mapping for the label (e.g. no spec was supplied);
+    - [aggregate] = [Some] of the four cross-fold metric means
+      ([sharpe_ratio.mean], [calmar_ratio.mean], [total_return_pct.mean],
+      [max_drawdown_pct.mean]) when all four are finite, else [None] — a
+      degenerate fixture with NaN means records [None] rather than fabricating a
+      value, per {!Experiment_ledger.variant_record}'s documented contract.
+
+    The variant order is preserved from [aggregate.stability]. *)

--- a/trading/trading/backtest/experiment_ledger/bin/test/dune
+++ b/trading/trading/backtest/experiment_ledger/bin/test/dune
@@ -1,0 +1,12 @@
+(tests
+ (names test_ledger_entry_builder)
+ (libraries
+  ounit2
+  core
+  core_unix.filename_unix
+  matchers
+  experiment_ledger
+  walk_forward
+  ledger_entry_builder)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/experiment_ledger/bin/test/test_ledger_entry_builder.ml
+++ b/trading/trading/backtest/experiment_ledger/bin/test/test_ledger_entry_builder.ml
@@ -1,0 +1,207 @@
+(** Unit tests for {!Ledger_entry_builder} + the {!Experiment_ledger} save path
+    behind the [write_ledger_entry] CLI.
+
+    Pins the entry-construction contract on an in-memory walk-forward aggregate:
+    variant labels + verdict carry through, finite metric means become a [Some]
+    fold_aggregate while a NaN-mean variant records [None], a supplied
+    config-hash map populates the per-variant hash, and the built entry round
+    -trips through [save_entry]/[load_entry] while preserving the append-only
+    overwrite guarantee. *)
+
+open OUnit2
+open Core
+open Matchers
+module T = Walk_forward.Walk_forward_types
+module EL = Experiment_ledger
+module B = Ledger_entry_builder
+
+(* All four ranked metrics in one cell; [stdev]/[min]/[max] are irrelevant to the
+   builder (it reads only [.mean]) so they are filled with the same value. *)
+let _stats mean : T.per_metric_stats =
+  { mean; stdev = mean; min = mean; max = mean }
+
+let _stability ~label ~sharpe ~calmar ~return_pct ~maxdd : T.variant_stability =
+  {
+    variant_label = label;
+    total_return_pct = _stats return_pct;
+    sharpe_ratio = _stats sharpe;
+    max_drawdown_pct = _stats maxdd;
+    calmar_ratio = _stats calmar;
+    cagr_pct = _stats return_pct;
+    avg_holding_days = T.nan_per_metric_stats;
+  }
+
+(* A two-variant aggregate: a finite baseline and a finite knob variant. *)
+let _aggregate : T.aggregate =
+  {
+    fold_count = 31;
+    baseline_label = "baseline";
+    metric_label = "Sharpe";
+    stability =
+      [
+        _stability ~label:"baseline" ~sharpe:0.68 ~calmar:2.04 ~return_pct:16.7
+          ~maxdd:11.1;
+        _stability ~label:"knob=1" ~sharpe:0.66 ~calmar:2.02 ~return_pct:16.5
+          ~maxdd:11.2;
+      ];
+    sensitivity = [];
+    verdicts = [];
+  }
+
+let _metadata : B.metadata =
+  {
+    date = "2026-06-01";
+    slug = "builder-test";
+    hypothesis = "knob=1 recovers missed gain";
+    base_scenario = "goldens/sample.sexp";
+    window_id = "rolling-2010-2026-365-182-31fold";
+    baseline_label = "baseline";
+    verdict = EL.Reject;
+    notes = "lost on every axis";
+  }
+
+let _config_hash_for = function
+  | "baseline" -> "hashA"
+  | "knob=1" -> "hashB"
+  | _ -> ""
+
+(* ---------- build_entry: labels, hashes, verdict, aggregates ---------- *)
+
+let test_build_entry_maps_variants _ =
+  let entry =
+    B.build_entry ~metadata:_metadata ~config_hash_for:_config_hash_for
+      _aggregate
+  in
+  assert_that entry
+    (all_of
+       [
+         field (fun (e : EL.entry) -> e.verdict) (equal_to EL.Reject);
+         field (fun (e : EL.entry) -> e.slug) (equal_to "builder-test");
+         field
+           (fun (e : EL.entry) -> e.variants)
+           (elements_are
+              [
+                equal_to
+                  ({
+                     label = "baseline";
+                     config_hash = "hashA";
+                     aggregate =
+                       Some
+                         {
+                           mean_sharpe = 0.68;
+                           mean_calmar = 2.04;
+                           mean_return_pct = 16.7;
+                           mean_max_drawdown_pct = 11.1;
+                         };
+                   }
+                    : EL.variant_record);
+                equal_to
+                  ({
+                     label = "knob=1";
+                     config_hash = "hashB";
+                     aggregate =
+                       Some
+                         {
+                           mean_sharpe = 0.66;
+                           mean_calmar = 2.02;
+                           mean_return_pct = 16.5;
+                           mean_max_drawdown_pct = 11.2;
+                         };
+                   }
+                    : EL.variant_record);
+              ]);
+       ])
+
+(* ---------- build_entry: NaN mean records [None], not a fabricated value ---- *)
+
+let test_build_entry_nan_mean_is_none _ =
+  let aggregate =
+    {
+      _aggregate with
+      stability =
+        [
+          _stability ~label:"empty-fold" ~sharpe:Float.nan ~calmar:2.0
+            ~return_pct:1.0 ~maxdd:1.0;
+        ];
+    }
+  in
+  let entry =
+    B.build_entry ~metadata:_metadata ~config_hash_for:_config_hash_for
+      aggregate
+  in
+  assert_that entry
+    (field
+       (fun (e : EL.entry) -> e.variants)
+       (elements_are
+          [ field (fun (v : EL.variant_record) -> v.aggregate) is_none ]))
+
+(* ---------- build_entry: unknown label gets empty hash ---------- *)
+
+let test_build_entry_unknown_label_empty_hash _ =
+  let entry =
+    B.build_entry ~metadata:_metadata ~config_hash_for:(fun _ -> "") _aggregate
+  in
+  assert_that entry
+    (field
+       (fun (e : EL.entry) -> e.variants)
+       (elements_are
+          [
+            field (fun (v : EL.variant_record) -> v.config_hash) (equal_to "");
+            field (fun (v : EL.variant_record) -> v.config_hash) (equal_to "");
+          ]))
+
+(* ---------- hash_map_of_variants: hashes match config_hash ---------- *)
+
+let test_hash_map_matches_config_hash _ =
+  let overrides = [ Sexp.of_string "((stage3_exit_margin_pct 0.02))" ] in
+  let table = B.hash_map_of_variants [ ("v", overrides) ] in
+  assert_that (Hashtbl.find table "v")
+    (is_some_and (equal_to (EL.config_hash overrides)))
+
+(* ---------- save_entry: writes <date>-<slug>.sexp + round-trips ---------- *)
+
+let test_save_entry_round_trip _ =
+  let dir = Filename_unix.temp_dir "ledger_builder_test" "" in
+  let entry =
+    B.build_entry ~metadata:_metadata ~config_hash_for:_config_hash_for
+      _aggregate
+  in
+  EL.save_entry ~dir entry;
+  let loaded =
+    EL.load_entry (Filename.concat dir "2026-06-01-builder-test.sexp")
+  in
+  assert_that loaded (equal_to entry)
+
+(* ---------- save_entry: append-only, raises on overwrite ---------- *)
+
+let _raises_failure thunk =
+  try
+    ignore (thunk ());
+    false
+  with Failure _ -> true
+
+let test_save_entry_raises_on_overwrite _ =
+  let dir = Filename_unix.temp_dir "ledger_builder_test" "" in
+  let entry =
+    B.build_entry ~metadata:_metadata ~config_hash_for:_config_hash_for
+      _aggregate
+  in
+  EL.save_entry ~dir entry;
+  assert_that
+    (_raises_failure (fun () -> EL.save_entry ~dir entry))
+    (equal_to true)
+
+let suite =
+  "ledger_entry_builder"
+  >::: [
+         "build_entry_maps_variants" >:: test_build_entry_maps_variants;
+         "build_entry_nan_mean_is_none" >:: test_build_entry_nan_mean_is_none;
+         "build_entry_unknown_label_empty_hash"
+         >:: test_build_entry_unknown_label_empty_hash;
+         "hash_map_matches_config_hash" >:: test_hash_map_matches_config_hash;
+         "save_entry_round_trip" >:: test_save_entry_round_trip;
+         "save_entry_raises_on_overwrite"
+         >:: test_save_entry_raises_on_overwrite;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/experiment_ledger/bin/write_ledger_entry.ml
+++ b/trading/trading/backtest/experiment_ledger/bin/write_ledger_entry.ml
@@ -1,0 +1,189 @@
+(** Durable CLI that constructs a well-formed {!Experiment_ledger.entry} from a
+    walk-forward aggregate and writes it to the append-only ledger
+    ([dev/experiments/_ledger/]).
+
+    Closes P2.2 of the population-search apparatus
+    ([dev/plans/population-search-2026-05-31.md]): every ledger entry to date
+    was hand-authored sexp or written by a throwaway exe rebuilt repeatedly.
+    This is the committed writer so future experiments stop hand-authoring sexp.
+
+    Inputs:
+    - Scalar metadata via flags ([--date], [--slug], [--hypothesis],
+      [--base-scenario], [--window-id], [--baseline-label], [--verdict],
+      [--notes], [--out-dir]).
+    - [--aggregate <path>] — the {!Walk_forward.Walk_forward_types.aggregate}
+      sexp the run produced (same artefact [rank_variants.exe] consumes). The
+      per-variant labels + cross-fold metric means come from here.
+    - [--variant-spec <path>] (optional) — the walk-forward {!Walk_forward.Spec}
+      sexp that produced the run. When supplied, each variant's [config_hash] is
+      computed from its override blob (via the auto-included baseline + expanded
+      matrix) so the recorded hashes match the ledger's dedup key. When omitted,
+      hashes are [""].
+
+    Pairs with [rank_variants.exe]: that ranks the surface (Pareto + DSR), this
+    records the resulting verdict. Both are pure consumers of the same on-disk
+    aggregate. *)
+
+open Core
+module T = Walk_forward.Walk_forward_types
+module EL = Experiment_ledger
+module B = Ledger_entry_builder
+
+(* -------------- argument parsing -------------- *)
+
+type cli_args = {
+  aggregate_path : string;
+  variant_spec_path : string option;
+  out_dir : string;
+  metadata : B.metadata;
+}
+
+let _default_baseline_label = "baseline"
+let _default_out_dir = "dev/experiments/_ledger"
+
+let _usage_msg =
+  "Usage: write_ledger_entry.exe --date <YYYY-MM-DD> --slug <slug> \
+   --hypothesis <text> --base-scenario <path> --window-id <id> --verdict \
+   <accept|reject|inconclusive> --aggregate <aggregate.sexp> [--variant-spec \
+   <spec.sexp>] [--baseline-label <label>] [--notes <text>] [--out-dir <dir>]"
+
+let _fail msg =
+  eprintf "Error: %s\n%s\n" msg _usage_msg;
+  Stdlib.exit 1
+
+let _parse_verdict = function
+  | "accept" | "Accept" -> EL.Accept
+  | "reject" | "Reject" -> EL.Reject
+  | "inconclusive" | "Inconclusive" -> EL.Inconclusive
+  | other ->
+      _fail (sprintf "unknown --verdict %S (accept|reject|inconclusive)" other)
+
+(* Accumulator for the raw flag strings before they are validated into
+   [cli_args]. Every field optional so a missing required flag is reported with a
+   precise name rather than a partial-record exception. *)
+type raw = {
+  date : string option;
+  slug : string option;
+  hypothesis : string option;
+  base_scenario : string option;
+  window_id : string option;
+  baseline_label : string option;
+  verdict : string option;
+  notes : string option;
+  aggregate : string option;
+  variant_spec : string option;
+  out_dir : string option;
+}
+
+let _empty_raw =
+  {
+    date = None;
+    slug = None;
+    hypothesis = None;
+    base_scenario = None;
+    window_id = None;
+    baseline_label = None;
+    verdict = None;
+    notes = None;
+    aggregate = None;
+    variant_spec = None;
+    out_dir = None;
+  }
+
+let _require name = function
+  | Some v -> v
+  | None -> _fail (name ^ " is required")
+
+let _finalize (r : raw) : cli_args =
+  let metadata : B.metadata =
+    {
+      date = _require "--date" r.date;
+      slug = _require "--slug" r.slug;
+      hypothesis = _require "--hypothesis" r.hypothesis;
+      base_scenario = _require "--base-scenario" r.base_scenario;
+      window_id = _require "--window-id" r.window_id;
+      baseline_label =
+        Option.value r.baseline_label ~default:_default_baseline_label;
+      verdict = _parse_verdict (_require "--verdict" r.verdict);
+      notes = Option.value r.notes ~default:"";
+    }
+  in
+  {
+    aggregate_path = _require "--aggregate" r.aggregate;
+    variant_spec_path = r.variant_spec;
+    out_dir = Option.value r.out_dir ~default:_default_out_dir;
+    metadata;
+  }
+
+let rec _accumulate (r : raw) = function
+  | [] -> r
+  | "--date" :: v :: rest -> _accumulate { r with date = Some v } rest
+  | "--slug" :: v :: rest -> _accumulate { r with slug = Some v } rest
+  | "--hypothesis" :: v :: rest ->
+      _accumulate { r with hypothesis = Some v } rest
+  | "--base-scenario" :: v :: rest ->
+      _accumulate { r with base_scenario = Some v } rest
+  | "--window-id" :: v :: rest -> _accumulate { r with window_id = Some v } rest
+  | "--baseline-label" :: v :: rest ->
+      _accumulate { r with baseline_label = Some v } rest
+  | "--verdict" :: v :: rest -> _accumulate { r with verdict = Some v } rest
+  | "--notes" :: v :: rest -> _accumulate { r with notes = Some v } rest
+  | "--aggregate" :: v :: rest -> _accumulate { r with aggregate = Some v } rest
+  | "--variant-spec" :: v :: rest ->
+      _accumulate { r with variant_spec = Some v } rest
+  | "--out-dir" :: v :: rest -> _accumulate { r with out_dir = Some v } rest
+  | ("--help" | "-h") :: _ ->
+      printf "%s\n" _usage_msg;
+      Stdlib.exit 0
+  | unknown :: _ -> _fail (sprintf "unknown argument %S" unknown)
+
+let _parse_args argv = _finalize (_accumulate _empty_raw argv)
+
+(* -------------- input loading -------------- *)
+
+let _load_aggregate path : T.aggregate =
+  try Sexp.load_sexp path |> T.aggregate_of_sexp with
+  | Sys_error msg -> _fail (sprintf "cannot read aggregate %S: %s" path msg)
+  | exn ->
+      _fail
+        (sprintf "failed to parse aggregate %S: %s" path (Exn.to_string exn))
+
+(* [label -> config_hash] from the spec's resolved variant list (auto-included
+   baseline + expanded matrix). A missing spec yields the empty map, so
+   [config_hash_for] returns [""] for every label. *)
+let _config_hash_for path_opt : string -> string =
+  match path_opt with
+  | None -> fun _ -> ""
+  | Some path ->
+      let spec =
+        try Walk_forward.Spec.load path with
+        | Sys_error msg ->
+            _fail (sprintf "cannot read variant-spec %S: %s" path msg)
+        | exn ->
+            _fail
+              (sprintf "failed to load variant-spec %S: %s" path
+                 (Exn.to_string exn))
+      in
+      let pairs =
+        List.map spec.variants
+          ~f:(fun (v : Walk_forward.Walk_forward_runner.variant) ->
+            (v.label, v.overrides))
+      in
+      let table = B.hash_map_of_variants pairs in
+      fun label -> Option.value (Hashtbl.find table label) ~default:""
+
+(* -------------- main -------------- *)
+
+let _main () =
+  let argv = Sys.get_argv () |> Array.to_list |> List.tl_exn in
+  let args = _parse_args argv in
+  let aggregate = _load_aggregate args.aggregate_path in
+  let config_hash_for = _config_hash_for args.variant_spec_path in
+  let entry =
+    B.build_entry ~metadata:args.metadata ~config_hash_for aggregate
+  in
+  EL.save_entry ~dir:args.out_dir entry;
+  printf "Wrote ledger entry: %s\n"
+    (Filename.concat args.out_dir (sprintf "%s-%s.sexp" entry.date entry.slug))
+
+let () = _main ()


### PR DESCRIPTION
## What

A committed `write_ledger_entry.exe` CLI (+ a pure `Ledger_entry_builder` library) that constructs a well-formed `Experiment_ledger.entry` from a walk-forward aggregate and writes it to the append-only ledger (`dev/experiments/_ledger/`). Closes **P2.2** of the population-search apparatus (`dev/plans/population-search-2026-05-31.md`).

Surface added under `trading/trading/backtest/experiment_ledger/bin/`:
- `ledger_entry_builder.{ml,mli}` — pure mapping `aggregate → entry`, hoisted out of the CLI so the entry-construction path is unit-testable without a process or disk.
- `write_ledger_entry.ml` — thin flag-parsing wrapper calling `Experiment_ledger.save_entry`.
- `bin/test/test_ledger_entry_builder.ml` — 6 tests.

## Why

The `Experiment_ledger` lib has existed (entry type + `save_entry` + `config_hash`) but **no committed bin used it** — every ledger entry to date was hand-authored sexp or written by a throwaway exe rebuilt ~4× across the program (`memory/project_promotion_confirmation_grid`). This is the durable writer so future experiments stop hand-authoring sexp.

## How it maps

- `--aggregate <path>` → `Walk_forward.Walk_forward_types.aggregate` (same artefact `rank_variants.exe` consumes). Per-variant labels + the four cross-fold metric means (`sharpe/calmar/return/maxdd .mean`) come from here. A NaN mean records `aggregate = None` rather than fabricating a value (per the lib's documented `None` contract).
- `--variant-spec <path>` (optional) → `Walk_forward.Spec.load`, which auto-includes the baseline cell + expands the `Variant_matrix`. Each variant's `config_hash` is then computed from its override blob via `Experiment_ledger.config_hash`, so the recorded hashes line up with the ledger's dedup key. Omitting the spec yields `""` hashes.
- Scalar metadata via flags: `--date --slug --hypothesis --base-scenario --window-id --baseline-label --verdict (accept|reject|inconclusive) --notes --out-dir` (default `dev/experiments/_ledger`).

No change to the `Experiment_ledger` lib's public API.

## Test plan

`dune build && dune runtest trading/backtest/experiment_ledger/` — 15 tests pass (6 new builder + 9 existing lib), zero warnings; `dune build @fmt` clean. New tests:
- `build_entry` maps variant labels + verdict + finite metric means → `Some` aggregate.
- NaN mean → `aggregate = None` (no fabrication).
- unknown label → empty hash.
- `hash_map_of_variants` hashes match `Experiment_ledger.config_hash`.
- `save_entry` round-trips through `load_entry`.
- `save_entry` raises on overwrite (append-only guarantee).

## Golden-equivalence check

Ran the CLI against the deep aggregate that produced `dev/experiments/_ledger/2026-05-31-exit-timing-deep-2000-2026.sexp`:

```
dune exec trading/backtest/experiment_ledger/bin/write_ledger_entry.exe -- \
  --date 2026-05-31 --slug exit-timing-deep-2000-2026 \
  --hypothesis "..." --base-scenario goldens-sp500-historical/sp500-2000-2026.sexp \
  --window-id rolling-2000-2026-365-182-51fold-deep-ptinpoint2000 \
  --verdict reject --aggregate /tmp/sweeps/exit-deep/aggregate.sexp \
  --variant-spec trading/test_data/walk_forward/exit-timing-surface-deep-2000-2026.sexp \
  --out-dir /tmp/golden-check
```

Result: **structurally equivalent** to the golden — identical variant labels (`baseline` + 9 `hysteresis_weeks=N__stage3_exit_margin_pct=M` cells, same order), identical verdict (`Reject`), and metric means that round to the golden's hand-rounded 4-sig-fig values exactly (e.g. baseline `0.68062766…→0.6806`, `16.7255…→16.726`; h1-m02 `0.67978…→0.6798`). My CLI emits full-precision means; the golden was hand-rounded.

Config hashes differ from the golden by design: the golden's notes say its hashes were *carried over from the 2010-2026 surface* ("Config hashes are the shared axis-override hashes from the 2010-2026 surface"), whereas the CLI recomputes them freshly from the committed deep spec against the current canonical default config. Internal consistency holds — the no-op `hysteresis_weeks=2,margin=0.0` cell shares the baseline hash in both the golden and my output. The CLI computing hashes from the actual spec (not carrying stale provenance) is the correct behaviour.

No real ledger entry was written from this PR (the CLI is the deliverable; running it for record is a later step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
