### PR TITLE
feat(weinstein): neutral_blocks_longs default-off entry-gate axis

### DIFF
--- a/dev/status/screener.md
+++ b/dev/status/screener.md
@@ -1,9 +1,11 @@
 # Status: screener
 
-## Last updated: 2026-05-25
+## Last updated: 2026-06-01
 
 ## Status
 MERGED
+
+**2026-06-01**: `feat(weinstein): neutral_blocks_longs default-off entry-gate axis` (branch `feat/neutral-blocks-longs-axis`, OPEN) — lever #2 of the Cell E 2020-2026 stall diagnosis. Adds `Screener.config.neutral_blocks_longs : bool [@sexp.default false]` plus a mirrored top-level `Weinstein_strategy.config.neutral_blocks_longs` field threaded into `screening_config` at screen time. When `true`, a macro-`Neutral` tape blocks new long candidates exactly as `Bearish` does (only `Bullish` admits longs); default `false` preserves the historical gate bit-equally. The short-side gate is unaffected. A *tightening* of Weinstein's unconditional macro gate (a faithful dial, spine intact). Default-off axis per `.claude/rules/experiment-flag-discipline.md` — proven `Variant_matrix`-expressible (`(flag neutral_blocks_longs)`) by `test_variant_matrix.ml`. No default flipped; no golden config_overrides touched. Tests: bit-identical-when-off + flag-on-blocks-Neutral + Bullish-unaffected + short-side-unchanged in `test_screener_e2e.ml`.
 
 **2026-05-25**: `fix(screener): NaN/inf guards in resistance/support/volume` (PR #1309) MERGED at `bee5e663c`. Defensive guards in `resistance.ml` (`_bucket_idx`), `support.ml` (`_bucket_idx_below`), and `volume.ml` (`_result_of_volumes`) are now pinned with three regression tests addressing the prior CP4 finding (band_size=0.0 → +inf offsets short-circuited; Float.nan event volume → None). Re-QC verdict on tip `774edc7f4`: structural APPROVED + behavioral APPROVED quality_score 4 (see `dev/reviews/screener-nan-inf-guards.md`); CI green (build-and-test + perf-tier1-smoke + golden-runs-custom-universe). Auto-merged via Step 6.5 after one branch-update cycle (got behind when #1313 merged ahead).
 

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -45,6 +45,7 @@ type config = {
   max_buy_candidates : int;
   max_short_candidates : int;
   cascade_post_stop_cooldown_weeks : int; [@sexp.default 0]
+  neutral_blocks_longs : bool; [@sexp.default false]
 }
 [@@deriving sexp]
 
@@ -60,6 +61,7 @@ let default_config =
     max_buy_candidates = 20;
     max_short_candidates = 10;
     cascade_post_stop_cooldown_weeks = 0;
+    neutral_blocks_longs = false;
   }
 
 type scored_candidate = {
@@ -334,18 +336,30 @@ let _count_short_phases ~weights ~thresholds ~min_grade ~min_score_override
 let _filter_and_cap ~candidate_fn ~max_n candidates =
   List.filter_map candidates ~f:candidate_fn |> _top_n max_n
 
+(** Whether the macro tape admits new long entries.
+
+    [neutral_blocks_longs] defaults to [false] = the historical gate (longs
+    admitted under both [Bullish] and [Neutral]; blocked only under [Bearish]).
+    When [true], [Neutral] also blocks longs — only [Bullish] admits. This
+    tightens Weinstein's unconditional macro gate so a non-confirmed ([Neutral])
+    tape no longer admits buys. The short-side gate is unaffected. *)
+let _longs_admitted_by_macro ~neutral_blocks_longs macro_trend =
+  match macro_trend with
+  | Bearish -> false
+  | Neutral -> not neutral_blocks_longs
+  | Bullish -> true
+
 (** Filter, score, grade, sort, and cap long candidates. *)
 let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~min_score_override
     ~max_score_override ~volume_ratio_exclude_range ~max_buy_candidates
-    ~candidates ~macro_trend : scored_candidate list =
-  match macro_trend with
-  | Bearish -> []
-  | Bullish | Neutral ->
-      let candidate_fn =
-        _long_candidate ~weights ~thresholds ~params ~min_grade
-          ~min_score_override ~max_score_override ~volume_ratio_exclude_range
-      in
-      _filter_and_cap ~candidate_fn ~max_n:max_buy_candidates candidates
+    ~neutral_blocks_longs ~candidates ~macro_trend : scored_candidate list =
+  if not (_longs_admitted_by_macro ~neutral_blocks_longs macro_trend) then []
+  else
+    let candidate_fn =
+      _long_candidate ~weights ~thresholds ~params ~min_grade
+        ~min_score_override ~max_score_override ~volume_ratio_exclude_range
+    in
+    _filter_and_cap ~candidate_fn ~max_n:max_buy_candidates candidates
 
 (** Filter, score, grade, sort, and cap short candidates. *)
 let _evaluate_shorts ~weights ~thresholds ~params ~min_grade ~min_score_override
@@ -443,11 +457,12 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
     max_buy_candidates;
     max_short_candidates;
     cascade_post_stop_cooldown_weeks = _;
+    neutral_blocks_longs;
   } =
     config
   in
   let buys_active =
-    match macro_trend with Bullish | Neutral -> true | Bearish -> false
+    _longs_admitted_by_macro ~neutral_blocks_longs macro_trend
   in
   let total_stocks = List.length stocks in
   let candidates =
@@ -458,7 +473,7 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
     _evaluate_longs ~weights ~thresholds:grade_thresholds
       ~params:candidate_params ~min_grade ~min_score_override
       ~max_score_override ~volume_ratio_exclude_range ~max_buy_candidates
-      ~candidates ~macro_trend
+      ~neutral_blocks_longs ~candidates ~macro_trend
   in
   let short_candidates =
     _evaluate_shorts ~weights ~thresholds:grade_thresholds

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -2,6 +2,7 @@
 open Core
 open Weinstein_types
 include Screener_scoring
+include Screener_admission
 
 type candidate_params = {
   entry_buffer_pct : float;
@@ -31,8 +32,6 @@ let default_candidate_params =
     breakout_fallback_pct = 0.05;
     installed_stop_min_pct = 0.0;
   }
-
-type volume_ratio_band = { low : float; high : float } [@@deriving sexp]
 
 type config = {
   weights : scoring_weights;
@@ -145,43 +144,19 @@ let _build_candidate ~params ~sector ~(a : Stock_analysis.t) ~score ~reasons
     rationale = reasons;
   }
 
-(** Score gate: [true] iff [score] passes both the configured floor and the
-    optional ceiling. [min_score_override = Some n] makes the floor [score >= n]
-    and bypasses {!min_grade}; [None] (default) uses the grade-derived floor.
-    [max_score_override = Some m] adds a strict [score < m] ceiling.
-
-    Single source of truth so the score-and-build path and the
-    diagnostics-counting predicates can't drift. *)
-let _passes_score_floor ~thresholds ~min_grade ~min_score_override
-    ~max_score_override score =
-  (match min_score_override with
-    | Some n -> score >= n
-    | None -> compare_grade (grade_of_score ~thresholds score) min_grade <= 0)
-  && match max_score_override with Some m -> score < m | None -> true
-
 (** Score, grade, and build a candidate after passing preliminary gates. Returns
-    [None] if [score] does not pass {!_passes_score_floor}. *)
+    [None] if [score] does not pass {!Screener_admission.passes_score_floor}. *)
 let _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
     ~max_score_override ~is_short ~scorer ~sector a =
   let score, reasons = scorer ~weights ~sector a in
   if
     not
-      (_passes_score_floor ~thresholds ~min_grade ~min_score_override
+      (passes_score_floor ~thresholds ~min_grade ~min_score_override
          ~max_score_override score)
   then None
   else
     Some
       (_build_candidate ~params ~sector ~a ~score ~reasons ~thresholds ~is_short)
-
-(** Volume-band exclusion: rejects iff the candidate's volume_ratio is in the
-    half-open interval from [low] (inclusive) to [high] (exclusive). Candidates
-    without a [volume] result pass through. *)
-let _passes_volume_band ~excl (a : Stock_analysis.t) =
-  match (excl, a.volume) with
-  | None, _ | _, None -> true
-  | Some { low; high }, Some v ->
-      let r = v.Volume.volume_ratio in
-      not Float.(low <= r && r < high)
 
 (** Evaluate one (analysis, sector) pair as a long candidate. Returns [None] if
     excluded by the sector gate, breakout test, volume band, or score floor. *)
@@ -189,31 +164,19 @@ let _long_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
     ~max_score_override ~volume_ratio_exclude_range (a, sector) =
   if equal_sector_rating sector.rating Weak then None
   else if not (Stock_analysis.is_breakout_candidate a) then None
-  else if not (_passes_volume_band ~excl:volume_ratio_exclude_range a) then None
+  else if not (passes_volume_band ~excl:volume_ratio_exclude_range a) then None
   else
     _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
       ~max_score_override ~is_short:false ~scorer:score_long ~sector a
 
-(** Hard gate per Weinstein Ch. 11: never short a stock with strong relative
-    strength, even if it breaks down. Rejects candidates whose RS trend is
-    positive ([Positive_rising], [Positive_flat], [Bullish_crossover]).
-    [Negative_improving] stays eligible — the stock is still rated negative
-    overall and the scorer reflects the weaker signal. Absent RS data is treated
-    as not-strong (doesn't block shorts). *)
-let _rs_blocks_short = function
-  | Some { Rs.trend = Positive_rising | Positive_flat | Bullish_crossover; _ }
-    ->
-      true
-  | _ -> false
-
 (** Evaluate one (analysis, sector) pair as a short candidate. Bearish/Neutral
-    only: score must pass {!_passes_score_floor}. *)
+    only: score must pass {!Screener_admission.passes_score_floor}. *)
 let _short_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
     ~max_score_override ~volume_ratio_exclude_range (a, sector) =
   if equal_sector_rating sector.rating Strong then None
   else if not (Stock_analysis.is_breakdown_candidate a) then None
-  else if _rs_blocks_short a.Stock_analysis.rs then None
-  else if not (_passes_volume_band ~excl:volume_ratio_exclude_range a) then None
+  else if rs_blocks_short a.Stock_analysis.rs then None
+  else if not (passes_volume_band ~excl:volume_ratio_exclude_range a) then None
   else
     _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
       ~max_score_override ~is_short:true ~scorer:score_short ~sector a
@@ -258,78 +221,6 @@ let _top_n n lst =
       let by_score = Int.compare b.score a.score in
       if by_score <> 0 then by_score else String.compare a.ticker b.ticker)
   |> fun l -> List.sub l ~pos:0 ~len:(min n (List.length l))
-
-(** Long-side admission predicates: per-pair, returns one bool per phase that
-    actually got evaluated. Phases short-circuit (a [false] earlier means later
-    bools are [false]) so [(true, true, true)] means the pair passed all three
-    gates. *)
-let _long_admission ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
-  (* Volume-band exclusion is folded into breakout phase: keeps the
-     cascade-diagnostics record stable (no new counter) while gating downstream
-     counts. *)
-  let passes_breakout =
-    Stock_analysis.is_breakout_candidate a
-    && _passes_volume_band ~excl:volume_ratio_exclude_range a
-  in
-  let passes_sector =
-    passes_breakout && not (equal_sector_rating sector.rating Weak)
-  in
-  let passes_grade =
-    if not passes_sector then false
-    else
-      let score, _ = score_long ~weights ~sector a in
-      _passes_score_floor ~thresholds ~min_grade ~min_score_override
-        ~max_score_override score
-  in
-  (passes_breakout, passes_sector, passes_grade)
-
-(** Bump the counter by one when [b] is [true]. *)
-let _bump n b = if b then n + 1 else n
-
-(** Long-side phase counts for the cascade-diagnostics record. Folds the
-    per-pair predicate triple into running counts. *)
-let _count_long_phases ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range ~candidates =
-  List.fold candidates ~init:(0, 0, 0)
-    ~f:(fun (breakout, sector_ok, grade_ok) pair ->
-      let pb, ps, pg =
-        _long_admission ~weights ~thresholds ~min_grade ~min_score_override
-          ~max_score_override ~volume_ratio_exclude_range pair
-      in
-      (_bump breakout pb, _bump sector_ok ps, _bump grade_ok pg))
-
-(** Short-side admission predicates. Mirrors [_long_admission] with the RS hard
-    gate inserted between sector and grade — see [_short_candidate]. *)
-let _short_admission ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
-  let passes_breakdown =
-    Stock_analysis.is_breakdown_candidate a
-    && _passes_volume_band ~excl:volume_ratio_exclude_range a
-  in
-  let passes_sector =
-    passes_breakdown && not (equal_sector_rating sector.rating Strong)
-  in
-  let passes_rs = passes_sector && not (_rs_blocks_short a.Stock_analysis.rs) in
-  let passes_grade =
-    if not passes_rs then false
-    else
-      let score, _ = score_short ~weights ~sector a in
-      _passes_score_floor ~thresholds ~min_grade ~min_score_override
-        ~max_score_override score
-  in
-  (passes_breakdown, passes_sector, passes_rs, passes_grade)
-
-(** Short-side phase counts mirroring [_count_long_phases]. *)
-let _count_short_phases ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range ~candidates =
-  List.fold candidates ~init:(0, 0, 0, 0)
-    ~f:(fun (breakdown, sector_ok, rs_ok, grade_ok) pair ->
-      let pb, ps, pr, pg =
-        _short_admission ~weights ~thresholds ~min_grade ~min_score_override
-          ~max_score_override ~volume_ratio_exclude_range pair
-      in
-      (_bump breakdown pb, _bump sector_ok ps, _bump rs_ok pr, _bump grade_ok pg))
 
 (** Apply [candidate_fn] to each pair, drop [None]s, sort by score, and cap at
     [max_n]. Shared by the long and short evaluation paths. *)
@@ -405,12 +296,12 @@ let _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade
     ~total_stocks ~candidates_after_held ~macro_trend ~candidates
     ~buy_candidates ~short_candidates =
   let long_phases =
-    _count_long_phases ~weights ~thresholds:grade_thresholds ~min_grade
+    count_long_phases ~weights ~thresholds:grade_thresholds ~min_grade
       ~min_score_override ~max_score_override ~volume_ratio_exclude_range
       ~candidates
   in
   let short_phases =
-    _count_short_phases ~weights ~thresholds:grade_thresholds ~min_grade
+    count_short_phases ~weights ~thresholds:grade_thresholds ~min_grade
       ~min_score_override ~max_score_override ~volume_ratio_exclude_range
       ~candidates
   in
@@ -443,54 +334,58 @@ let _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map ~is_member =
       else if not (is_member a.ticker) then None
       else Some (a, _resolve_sector ~sector_map a.ticker))
 
+(** Evaluate the long and short cascade paths for one screen call. Returns
+    [(buy_candidates, short_candidates)]; decoupled from [_screen] so the latter
+    stays within the 50-line linter cap. *)
+let _evaluate_candidates ~config ~candidates ~macro_trend =
+  let buy_candidates =
+    _evaluate_longs ~weights:config.weights ~thresholds:config.grade_thresholds
+      ~params:config.candidate_params ~min_grade:config.min_grade
+      ~min_score_override:config.min_score_override
+      ~max_score_override:config.max_score_override
+      ~volume_ratio_exclude_range:config.volume_ratio_exclude_range
+      ~max_buy_candidates:config.max_buy_candidates
+      ~neutral_blocks_longs:config.neutral_blocks_longs ~candidates ~macro_trend
+  in
+  let short_candidates =
+    _evaluate_shorts ~weights:config.weights ~thresholds:config.grade_thresholds
+      ~params:config.candidate_params ~min_grade:config.min_grade
+      ~min_score_override:config.min_score_override
+      ~max_score_override:config.max_score_override
+      ~volume_ratio_exclude_range:config.volume_ratio_exclude_range
+      ~max_short_candidates:config.max_short_candidates ~candidates ~macro_trend
+  in
+  (buy_candidates, short_candidates)
+
 let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
     ~is_member : result =
   let held_set = String.Set.of_list held_tickers in
-  let {
-    weights;
-    grade_thresholds;
-    candidate_params;
-    min_grade;
-    min_score_override;
-    max_score_override;
-    volume_ratio_exclude_range;
-    max_buy_candidates;
-    max_short_candidates;
-    cascade_post_stop_cooldown_weeks = _;
-    neutral_blocks_longs;
-  } =
-    config
-  in
   let buys_active =
-    _longs_admitted_by_macro ~neutral_blocks_longs macro_trend
+    _longs_admitted_by_macro ~neutral_blocks_longs:config.neutral_blocks_longs
+      macro_trend
   in
   let total_stocks = List.length stocks in
   let candidates =
     _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map ~is_member
   in
   let candidates_after_held = List.length candidates in
-  let buy_candidates =
-    _evaluate_longs ~weights ~thresholds:grade_thresholds
-      ~params:candidate_params ~min_grade ~min_score_override
-      ~max_score_override ~volume_ratio_exclude_range ~max_buy_candidates
-      ~neutral_blocks_longs ~candidates ~macro_trend
-  in
-  let short_candidates =
-    _evaluate_shorts ~weights ~thresholds:grade_thresholds
-      ~params:candidate_params ~min_grade ~min_score_override
-      ~max_score_override ~volume_ratio_exclude_range ~max_short_candidates
-      ~candidates ~macro_trend
+  let buy_candidates, short_candidates =
+    _evaluate_candidates ~config ~candidates ~macro_trend
   in
   {
     buy_candidates;
     short_candidates;
     watchlist =
-      _build_watchlist ~weights ~thresholds:grade_thresholds ~candidates
-        ~buy_candidates ~buys_active;
+      _build_watchlist ~weights:config.weights
+        ~thresholds:config.grade_thresholds ~candidates ~buy_candidates
+        ~buys_active;
     macro_trend;
     cascade_diagnostics =
-      _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade
-        ~min_score_override ~max_score_override ~volume_ratio_exclude_range
+      _diagnostics_for_screen ~weights:config.weights
+        ~grade_thresholds:config.grade_thresholds ~min_grade:config.min_grade
+        ~min_score_override:config.min_score_override
+        ~max_score_override:config.max_score_override
+        ~volume_ratio_exclude_range:config.volume_ratio_exclude_range
         ~total_stocks ~candidates_after_held ~macro_trend ~candidates
         ~buy_candidates ~short_candidates;
   }

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -159,6 +159,23 @@ type config = {
           in response to the same-week re-fire pattern documented in
           dev/notes/sp500-trade-quality-findings-2026-04-30.md §"Cascade
           re-firing within days of stop-out". *)
+  neutral_blocks_longs : bool; [@sexp.default false]
+      (** When [true], a macro-[Neutral] tape blocks new long candidates exactly
+          as a [Bearish] tape does — only [Bullish] admits longs. Default
+          [false] preserves the historical gate bit-equally: longs are admitted
+          under both [Bullish] and [Neutral], blocked only under [Bearish].
+
+          This is a *tightening* of Weinstein's unconditional macro gate
+          (weinstein-book-reference.md §Macro Analysis: "don't buy in a
+          non-confirmed tape"): it removes the bear-rally [Neutral] blips that
+          admit longs during a predominantly-bearish year. The short-side gate
+          ([Bullish] blocks; [Bearish]/[Neutral] admit) is unaffected by this
+          flag.
+
+          Default-off entry-gate axis (lever #2 of the Cell E 2020-2026 stall
+          diagnosis). Mirrored from the top-level
+          [Weinstein_strategy.config.neutral_blocks_longs] field so the flag is
+          a [Variant_matrix] axis. *)
 }
 [@@deriving sexp]
 (** Main screener configuration. *)

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -18,6 +18,12 @@ include module type of Screener_scoring
     [Screener.scoring_weights], etc. without importing the sub-module directly.
 *)
 
+include module type of Screener_admission
+(** Per-candidate admission predicates, cascade-phase counters, and the
+    {!Screener_admission.volume_ratio_band} type — re-exported from
+    {!Screener_admission} so callers continue to reference them as
+    [Screener.volume_ratio_band], [Screener.passes_score_floor], etc. *)
+
 type candidate_params = {
   entry_buffer_pct : float;
       (** Fraction above breakout price for the suggested entry. Default: 0.005.
@@ -65,13 +71,6 @@ type candidate_params = {
 
 val default_candidate_params : candidate_params
 (** [default_candidate_params] provides the reference parameters. *)
-
-type volume_ratio_band = { low : float; high : float } [@@deriving sexp]
-(** Half-open volume-ratio exclusion band used by
-    {!config.volume_ratio_exclude_range}. The named-field record (rather than a
-    plain [float * float] tuple) keeps the on-disk sexp shape outside the
-    runner's deep-merge "looks like a record" heuristic, so a partial-config
-    overlay that sets just this field deep-merges correctly. *)
 
 type config = {
   weights : scoring_weights;

--- a/trading/analysis/weinstein/screener/lib/screener_admission.ml
+++ b/trading/analysis/weinstein/screener/lib/screener_admission.ml
@@ -1,0 +1,87 @@
+open Core
+open Weinstein_types
+open Screener_scoring
+
+type volume_ratio_band = { low : float; high : float } [@@deriving sexp]
+
+let passes_score_floor ~thresholds ~min_grade ~min_score_override
+    ~max_score_override score =
+  (match min_score_override with
+    | Some n -> score >= n
+    | None -> compare_grade (grade_of_score ~thresholds score) min_grade <= 0)
+  && match max_score_override with Some m -> score < m | None -> true
+
+let passes_volume_band ~excl (a : Stock_analysis.t) =
+  match (excl, a.volume) with
+  | None, _ | _, None -> true
+  | Some { low; high }, Some v ->
+      let r = v.Volume.volume_ratio in
+      not Float.(low <= r && r < high)
+
+let rs_blocks_short = function
+  | Some { Rs.trend = Positive_rising | Positive_flat | Bullish_crossover; _ }
+    ->
+      true
+  | _ -> false
+
+let _long_admission ~weights ~thresholds ~min_grade ~min_score_override
+    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
+  (* Volume-band exclusion is folded into breakout phase: keeps the
+     cascade-diagnostics record stable (no new counter) while gating downstream
+     counts. *)
+  let passes_breakout =
+    Stock_analysis.is_breakout_candidate a
+    && passes_volume_band ~excl:volume_ratio_exclude_range a
+  in
+  let passes_sector =
+    passes_breakout && not (equal_sector_rating sector.rating Weak)
+  in
+  let passes_grade =
+    if not passes_sector then false
+    else
+      let score, _ = score_long ~weights ~sector a in
+      passes_score_floor ~thresholds ~min_grade ~min_score_override
+        ~max_score_override score
+  in
+  (passes_breakout, passes_sector, passes_grade)
+
+let _bump n b = if b then n + 1 else n
+
+let count_long_phases ~weights ~thresholds ~min_grade ~min_score_override
+    ~max_score_override ~volume_ratio_exclude_range ~candidates =
+  List.fold candidates ~init:(0, 0, 0)
+    ~f:(fun (breakout, sector_ok, grade_ok) pair ->
+      let pb, ps, pg =
+        _long_admission ~weights ~thresholds ~min_grade ~min_score_override
+          ~max_score_override ~volume_ratio_exclude_range pair
+      in
+      (_bump breakout pb, _bump sector_ok ps, _bump grade_ok pg))
+
+let _short_admission ~weights ~thresholds ~min_grade ~min_score_override
+    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
+  let passes_breakdown =
+    Stock_analysis.is_breakdown_candidate a
+    && passes_volume_band ~excl:volume_ratio_exclude_range a
+  in
+  let passes_sector =
+    passes_breakdown && not (equal_sector_rating sector.rating Strong)
+  in
+  let passes_rs = passes_sector && not (rs_blocks_short a.Stock_analysis.rs) in
+  let passes_grade =
+    if not passes_rs then false
+    else
+      let score, _ = score_short ~weights ~sector a in
+      passes_score_floor ~thresholds ~min_grade ~min_score_override
+        ~max_score_override score
+  in
+  (passes_breakdown, passes_sector, passes_rs, passes_grade)
+
+let count_short_phases ~weights ~thresholds ~min_grade ~min_score_override
+    ~max_score_override ~volume_ratio_exclude_range ~candidates =
+  List.fold candidates ~init:(0, 0, 0, 0)
+    ~f:(fun (breakdown, sector_ok, rs_ok, grade_ok) pair ->
+      let pb, ps, pr, pg =
+        _short_admission ~weights ~thresholds ~min_grade ~min_score_override
+          ~max_score_override ~volume_ratio_exclude_range pair
+      in
+      (_bump breakdown pb, _bump sector_ok ps, _bump rs_ok pr, _bump grade_ok pg))

--- a/trading/analysis/weinstein/screener/lib/screener_admission.mli
+++ b/trading/analysis/weinstein/screener/lib/screener_admission.mli
@@ -1,0 +1,70 @@
+(** Per-candidate admission predicates and cascade-phase counters for the
+    Weinstein screener.
+
+    Extracted from [Screener] to keep the cascade coordinator within the
+    500-line linter cap. All functions are pure. Callers outside the screener
+    library reference these through {!Screener}, which re-exports this module
+    via [include module type of]. *)
+
+open Screener_scoring
+
+type volume_ratio_band = { low : float; high : float } [@@deriving sexp]
+(** Half-open volume-ratio exclusion band used by the screener config. The
+    named-field record (rather than a plain [float * float] tuple) keeps the
+    on-disk sexp shape outside the runner's deep-merge "looks like a record"
+    heuristic, so a partial-config overlay that sets just this field deep-merges
+    correctly. *)
+
+val passes_score_floor :
+  thresholds:grade_thresholds ->
+  min_grade:Weinstein_types.grade ->
+  min_score_override:int option ->
+  max_score_override:int option ->
+  int ->
+  bool
+(** Score gate: [true] iff [score] passes both the configured floor and the
+    optional ceiling. [min_score_override = Some n] makes the floor [score >= n]
+    and bypasses [min_grade]; [None] uses the grade-derived floor.
+    [max_score_override = Some m] adds a strict [score < m] ceiling.
+
+    Single source of truth so the score-and-build path and the
+    diagnostics-counting predicates can't drift. *)
+
+val passes_volume_band :
+  excl:volume_ratio_band option -> Stock_analysis.t -> bool
+(** Volume-band exclusion: rejects iff the candidate's volume_ratio is in the
+    half-open interval from [low] (inclusive) to [high] (exclusive). Candidates
+    without a [volume] result pass through. *)
+
+val rs_blocks_short : Rs.result option -> bool
+(** Hard gate per Weinstein Ch. 11: never short a stock with strong relative
+    strength, even if it breaks down. Returns [true] for candidates whose RS
+    trend is positive ([Positive_rising], [Positive_flat], [Bullish_crossover]).
+    [Negative_improving] stays eligible; absent RS data is treated as not-strong
+    (doesn't block shorts). *)
+
+val count_long_phases :
+  weights:scoring_weights ->
+  thresholds:grade_thresholds ->
+  min_grade:Weinstein_types.grade ->
+  min_score_override:int option ->
+  max_score_override:int option ->
+  volume_ratio_exclude_range:volume_ratio_band option ->
+  candidates:(Stock_analysis.t * sector_context) list ->
+  int * int * int
+(** Long-side cascade-phase counts [(breakout, sector, grade)] for the
+    diagnostics record. Each phase short-circuits (a [false] earlier phase keeps
+    later phases [false]) so the triple is monotone non-increasing. *)
+
+val count_short_phases :
+  weights:scoring_weights ->
+  thresholds:grade_thresholds ->
+  min_grade:Weinstein_types.grade ->
+  min_score_override:int option ->
+  max_score_override:int option ->
+  volume_ratio_exclude_range:volume_ratio_band option ->
+  candidates:(Stock_analysis.t * sector_context) list ->
+  int * int * int * int
+(** Short-side cascade-phase counts [(breakdown, sector, rs, grade)] mirroring
+    {!count_long_phases}, with the RS hard gate inserted between sector and
+    grade. *)

--- a/trading/analysis/weinstein/screener/test/test_screener_e2e.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener_e2e.ml
@@ -352,6 +352,91 @@ let test_ch11_no_shorts_under_bullish_macro_2022 _ =
        ])
 
 (* ------------------------------------------------------------------ *)
+(* neutral_blocks_longs entry-gate axis (default-off)                   *)
+(* ------------------------------------------------------------------ *)
+
+let _config_neutral_blocks_longs blocks =
+  { Screener.default_config with Screener.neutral_blocks_longs = blocks }
+
+(** Default-off / bit-identical: passing [neutral_blocks_longs = false]
+    explicitly produces the exact same Neutral-macro buy list as
+    {!Screener.default_config} (where the field also defaults to [false]). Pins
+    against the canonical 2021-2023 four-name buy list, so a regression that
+    couples the flag-off path to a different gate is caught. *)
+let test_neutral_blocks_longs_off_is_identity _ =
+  let stocks =
+    _analyze_universe
+      ~start_date:(Date.of_string "2021-01-01")
+      ~end_date:(Date.of_string "2023-12-29")
+  in
+  let result =
+    Screener.screen
+      ~config:(_config_neutral_blocks_longs false)
+      ~macro_trend:Neutral ~sector_map:(_empty_sector_map ()) ~stocks
+      ~held_tickers:[]
+  in
+  assert_that result.Screener.buy_candidates
+    (elements_are _expected_2021_2023_buy_matchers)
+
+(** Flag on: a [Neutral] macro admits {b zero} long candidates — exactly as a
+    [Bearish] tape does — even though the same window admits four buys with the
+    flag off (pinned by {!test_neutral_blocks_longs_off_is_identity}). *)
+let test_neutral_blocks_longs_on_blocks_neutral_buys _ =
+  let stocks =
+    _analyze_universe
+      ~start_date:(Date.of_string "2021-01-01")
+      ~end_date:(Date.of_string "2023-12-29")
+  in
+  let result =
+    Screener.screen
+      ~config:(_config_neutral_blocks_longs true)
+      ~macro_trend:Neutral ~sector_map:(_empty_sector_map ()) ~stocks
+      ~held_tickers:[]
+  in
+  assert_that result
+    (all_of
+       [
+         field (fun (r : Screener.result) -> r.macro_trend) (equal_to Neutral);
+         field (fun (r : Screener.result) -> r.buy_candidates) is_empty;
+       ])
+
+(** Flag on: a [Bullish] macro still admits the full long list — the flag only
+    tightens the [Neutral] case, never the confirmed-bull case. *)
+let test_neutral_blocks_longs_on_bullish_unaffected _ =
+  let stocks =
+    _analyze_universe
+      ~start_date:(Date.of_string "2021-01-01")
+      ~end_date:(Date.of_string "2023-12-29")
+  in
+  let result =
+    Screener.screen
+      ~config:(_config_neutral_blocks_longs true)
+      ~macro_trend:Bullish ~sector_map:(_empty_sector_map ()) ~stocks
+      ~held_tickers:[]
+  in
+  assert_that result.Screener.buy_candidates
+    (elements_are _expected_2021_2023_buy_matchers)
+
+(** Short side is unaffected by the flag: under a [Neutral] macro the short
+    candidate list is identical whether [neutral_blocks_longs] is on or off.
+    Uses the 2018-2020 COVID-crash window where Stage-4 names produce shorts. *)
+let test_neutral_blocks_longs_short_side_unchanged _ =
+  let stocks =
+    _analyze_universe
+      ~start_date:(Date.of_string "2018-01-01")
+      ~end_date:(Date.of_string "2020-03-20")
+  in
+  let shorts_with blocks =
+    (Screener.screen
+       ~config:(_config_neutral_blocks_longs blocks)
+       ~macro_trend:Neutral ~sector_map:(_empty_sector_map ()) ~stocks
+       ~held_tickers:[])
+      .Screener.short_candidates
+    |> List.map ~f:(fun c -> c.Screener.ticker)
+  in
+  assert_that (shorts_with true) (equal_to (shorts_with false))
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -371,4 +456,12 @@ let () =
            >:: test_ch11_spotcheck_2022_bear;
            "Ch.11 negative: bullish macro emits zero shorts (2022 window)"
            >:: test_ch11_no_shorts_under_bullish_macro_2022;
+           "neutral_blocks_longs off = identity (neutral buys preserved)"
+           >:: test_neutral_blocks_longs_off_is_identity;
+           "neutral_blocks_longs on blocks neutral buys"
+           >:: test_neutral_blocks_longs_on_blocks_neutral_buys;
+           "neutral_blocks_longs on leaves bullish buys unaffected"
+           >:: test_neutral_blocks_longs_on_bullish_unaffected;
+           "neutral_blocks_longs leaves short side unchanged"
+           >:: test_neutral_blocks_longs_short_side_unchanged;
          ])

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -48,6 +48,7 @@ let _permissive_screener_config (config : config) : Screener.config =
     max_buy_candidates = Int.max_value;
     max_short_candidates = Int.max_value;
     cascade_post_stop_cooldown_weeks = 0;
+    neutral_blocks_longs = false;
   }
 
 (** Whether [trend] would have admitted longs at the macro gate. *)

--- a/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
+++ b/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
@@ -36,6 +36,15 @@ let _laggard_axis =
       values = Sexp.[ Atom "true"; Atom "false" ];
     }
 
+(* [neutral_blocks_longs] is a top-level bool flag on [Weinstein_strategy.config]
+   — proves the entry-gate axis resolves through [Overlay_validator]. *)
+let _neutral_blocks_longs_axis =
+  VM.Flag
+    {
+      name = "neutral_blocks_longs";
+      values = Sexp.[ Atom "true"; Atom "false" ];
+    }
+
 (* Catch a [Failure] from [thunk]; returns [true] iff one was raised. *)
 let _raises_failure thunk =
   try
@@ -111,6 +120,27 @@ let test_single_component_override_shape _ =
            (fun (v : WFR.variant) -> v.overrides)
            (elements_are
               [ equal_to (Sexp.of_string "((stage3_exit_margin_pct 0.02))") ]);
+       ])
+
+(* Proves R2 (experiment-flag-discipline): the [neutral_blocks_longs] entry-gate
+   flag is a real top-level [Weinstein_strategy.config] field, so the flag axis
+   expands and passes [Overlay_validator] validation, yielding the expected
+   single-component override sexps. *)
+let test_neutral_blocks_longs_flag_axis_expands _ =
+  let t =
+    { VM.axes = [ _neutral_blocks_longs_axis ]; expansion = VM.Cartesian }
+  in
+  assert_that (VM.expand t)
+    (elements_are
+       [
+         field
+           (fun (v : WFR.variant) -> v.overrides)
+           (elements_are
+              [ equal_to (Sexp.of_string "((neutral_blocks_longs true))") ]);
+         field
+           (fun (v : WFR.variant) -> v.overrides)
+           (elements_are
+              [ equal_to (Sexp.of_string "((neutral_blocks_longs false))") ]);
        ])
 
 (* ---------- Sampled determinism + fallback ---------- *)
@@ -189,6 +219,8 @@ let suite =
          >:: test_known_matrix_labels_and_overrides;
          "single-component path override shape"
          >:: test_single_component_override_shape;
+         "neutral_blocks_longs flag axis expands + validates"
+         >:: test_neutral_blocks_longs_flag_axis_expands;
          "sampled determinism (same seed -> same labels)"
          >:: test_sampled_determinism;
          "sampled different seed -> different subset"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -341,6 +341,15 @@ type config = {
           {!Trading_portfolio.Margin_config.default_config} (disabled) preserves
           bit-equality with prior baselines. See [Weinstein_strategy_config] for
           full semantics. *)
+  neutral_blocks_longs : bool; [@sexp.default false]
+      (** Entry-gate axis (default-off): when [true], a macro-[Neutral] tape
+          blocks new long entries (only [Bullish] admits longs). Default [false]
+          preserves the historical macro gate where both [Bullish] and [Neutral]
+          admit longs. Tightens the macro gate only; the Stage-2-only entry,
+          stops, and short-side gate are unaffected. Threaded into
+          [screening_config.neutral_blocks_longs] at screen time so it is a
+          [Variant_matrix] flag axis. See [Weinstein_strategy_config] for full
+          semantics. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -80,6 +80,11 @@ type config = {
       [@sexp.default Trading_portfolio.Margin_config.default_config]
       (** Phase-2 margin-accounting parameters (issue #859,
           [dev/plans/short-side-margin-2026-05-13.md] §2). See [.mli]. *)
+  neutral_blocks_longs : bool; [@sexp.default false]
+      (** When [true], a macro-[Neutral] tape blocks new long entries (only
+          [Bullish] admits longs); default [false] preserves the historical gate
+          where both [Bullish] and [Neutral] admit longs. Threaded into
+          [screening_config.neutral_blocks_longs] at screen time. See [.mli]. *)
 }
 [@@deriving sexp]
 
@@ -113,6 +118,7 @@ let default_config ~universe ~index_symbol =
     continuation_config = Continuation.default_config;
     enable_pi_filter = false;
     margin_config = Trading_portfolio.Margin_config.default_config;
+    neutral_blocks_longs = false;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -87,6 +87,29 @@ type config = {
           borrow fee + maintenance-margin force-cover). Default
           {!Trading_portfolio.Margin_config.default_config} (disabled) preserves
           bit-equality with prior baselines. See [.ml] for full semantics. *)
+  neutral_blocks_longs : bool; [@sexp.default false]
+      (** Entry-gate axis (default-off): when [true], a macro-[Neutral] tape
+          blocks new long entries exactly as a [Bearish] tape does — only a
+          [Bullish] tape admits longs. Default [false] preserves the historical
+          macro gate bit-equally (longs admitted under both [Bullish] and
+          [Neutral], blocked only under [Bearish]).
+
+          This *tightens* Weinstein's unconditional macro gate
+          (weinstein-book-reference.md §Macro Analysis: do not buy in a
+          non-confirmed tape) — it is a faithful dial, not a spine change: the
+          Stage-2-only / breakout+volume entry criteria, the stops, and the
+          short-side gate are all unaffected. The short-side gate ([Bullish]
+          blocks; [Bearish]/[Neutral] admit) is independent of this flag.
+
+          Wired by threading into [screening_config.neutral_blocks_longs] at
+          screen time, so the flag is a single-component [Variant_matrix] flag
+          axis ([((flag neutral_blocks_longs) (values (true false)))]).
+
+          Motivation: lever #2 of the Cell E 2020-2026 stall diagnosis — in 2022
+          the macro gate was [Bearish] ~51% of the year but longs still entered
+          through the [Neutral]/[Bullish] bear-rally blips, contributing to the
+          false-breakout stop-out churn. Default-off until an experiment-ledger
+          ACCEPT (per [.claude/rules/experiment-flag-discipline.md]). *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -373,8 +373,17 @@ let screen_universe ?active_through_for ?fold_start_date ?membership_at ~config
     |> List.map ~f:analyze
   in
   _commit_prior_stages ~prior_stages classified;
+  (* Thread the top-level [neutral_blocks_longs] entry-gate flag into the
+     screener config so it is expressible as a [Weinstein_strategy.config] flag
+     axis. Default [false] leaves the screener config untouched bit-equally. *)
+  let screening_config =
+    {
+      config.screening_config with
+      Screener.neutral_blocks_longs = config.neutral_blocks_longs;
+    }
+  in
   let screen_result =
-    Screener.screen_with_cooldown ?membership_at ~config:config.screening_config
+    Screener.screen_with_cooldown ?membership_at ~config:screening_config
       ~macro_trend:macro_result.trend ~sector_map ~stocks
       ~held_tickers:(held_symbols portfolio) ~as_of:current_date
       ~last_stop_out_dates:(Hashtbl.to_alist last_stop_out_dates)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -344,6 +344,25 @@ let _sector_lookup_of ~sector_map symbol =
   Hashtbl.find sector_map symbol
   |> Option.map ~f:(fun (ctx : Screener.sector_context) -> ctx.sector_name)
 
+(** Run the cascade screener over the Phase-2 [stocks], threading the top-level
+    [neutral_blocks_longs] entry-gate flag into the screener config so it is
+    expressible as a [Weinstein_strategy.config] flag axis. Default [false]
+    leaves the screener config untouched bit-equally. Factored out of
+    {!screen_universe} to keep that function under the 50-line linter cap. *)
+let _run_screener ?membership_at ~config ~macro_result ~sector_map ~stocks
+    ~portfolio ~last_stop_out_dates ~current_date () =
+  let screening_config =
+    {
+      config.screening_config with
+      Screener.neutral_blocks_longs = config.neutral_blocks_longs;
+    }
+  in
+  Screener.screen_with_cooldown ?membership_at ~config:screening_config
+    ~macro_trend:macro_result.Macro.trend ~sector_map ~stocks
+    ~held_tickers:(held_symbols portfolio) ~as_of:current_date
+    ~last_stop_out_dates:(Hashtbl.to_alist last_stop_out_dates)
+    ()
+
 (** Screen the universe via the lazy cascade (Phase 1 stage filter → PR-B sector
     pre-filter → Phase 2 full {!Stock_analysis}). Macro-trend gating lives in
     the screener; concatenating [buy_candidates] + [short_candidates] yields the
@@ -373,21 +392,9 @@ let screen_universe ?active_through_for ?fold_start_date ?membership_at ~config
     |> List.map ~f:analyze
   in
   _commit_prior_stages ~prior_stages classified;
-  (* Thread the top-level [neutral_blocks_longs] entry-gate flag into the
-     screener config so it is expressible as a [Weinstein_strategy.config] flag
-     axis. Default [false] leaves the screener config untouched bit-equally. *)
-  let screening_config =
-    {
-      config.screening_config with
-      Screener.neutral_blocks_longs = config.neutral_blocks_longs;
-    }
-  in
   let screen_result =
-    Screener.screen_with_cooldown ?membership_at ~config:screening_config
-      ~macro_trend:macro_result.trend ~sector_map ~stocks
-      ~held_tickers:(held_symbols portfolio) ~as_of:current_date
-      ~last_stop_out_dates:(Hashtbl.to_alist last_stop_out_dates)
-      ()
+    _run_screener ?membership_at ~config ~macro_result ~sector_map ~stocks
+      ~portfolio ~last_stop_out_dates ~current_date ()
   in
   let combined_candidates =
     if config.enable_short_side then


### PR DESCRIPTION
## What it does

Lever #2 of the Cell E 2020-2026 stall diagnosis (`dev/notes/cell-e-2020-2026-stall-diagnosis-2026-06-02.md`, #1408). Adds a **default-off** entry-gate axis: when on, a macro-`Neutral` tape blocks new long candidates exactly as a `Bearish` tape does (only `Bullish` admits longs). Today longs are admitted under both `Bullish` and `Neutral`, blocked only under `Bearish` — so during a predominantly-bearish year (2022: macro gate Bearish ~51% of the year) longs still entered through the `Neutral`/`Bullish` bear-rally blips, feeding the false-breakout stop-out churn.

This is a **tightening of Weinstein's unconditional macro gate** (weinstein-book-reference.md §Macro Analysis: do not buy in a non-confirmed tape) — a faithful **dial**, spine intact. Stage-2-only entry, breakout+volume, stops, and the short-side gate are all unchanged. The short-side gate (`Bullish` blocks; `Bearish`/`Neutral` admit) is independent of this flag.

## Design

- `Screener.config.neutral_blocks_longs : bool [@sexp.default false]` — where the long-gate lives. `_longs_admitted_by_macro` is the single source of truth shared by `_evaluate_longs` and the watchlist `buys_active`.
- Top-level `Weinstein_strategy.config.neutral_blocks_longs : bool [@sexp.default false]` — mirrored into `screening_config` at screen time (`weinstein_strategy_screening.ml`), so the flag is a single-component `Variant_matrix` **flag axis** (`((flag neutral_blocks_longs) (values (true false)))`).

## Experiment-flag discipline

- **R1 (default-off):** both fields default `false` = bit-identical to prior behaviour. No golden `config_overrides` touched; Cell E untouched.
- **R2 (searchable):** proven `Variant_matrix`-expressible — `test_variant_matrix.ml::test_neutral_blocks_longs_flag_axis_expands` expands the flag axis and validates it through `Overlay_validator`.
- **R3 (no promotion):** no default flipped; lands purely as a default-off axis. No ledger citation needed.

## Tests

`test_screener_e2e.ml` (4 new):
- flag-off = identity (Neutral buys preserved — pins the canonical 2021-2023 four-name buy list)
- flag-on blocks Neutral buys (zero long candidates, as Bearish)
- flag-on leaves Bullish buys unaffected
- short side unchanged on/off under Neutral

`test_variant_matrix.ml` (1 new): flag axis expands + validates.

## Verification

- Full `dune build` (all linters: nesting / file-length / magic-numbers) — PASS.
- `dune runtest analysis/weinstein/screener/test` (11/11) + `dune runtest trading/backtest/walk_forward/test` — PASS.
- `dune fmt` — stable, no diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)