### PR TITLE
chore: weekly opam dependency update

### DIFF
--- a/trading/deps-snapshot.txt
+++ b/trading/deps-snapshot.txt
@@ -4,7 +4,7 @@ async                       v0.17.0
 async_kernel                v0.17.0
 async_log                   v0.17.0
 async_rpc_kernel            v0.17.0
-async_ssl                   v0.17.0-1
+async_ssl                   v0.17.0-2
 async_unix                  v0.17.0
 base                        v0.17.3
 base-bigarray               base
@@ -73,12 +73,12 @@ menhirSdk                   20260209
 npy                         0.0.9
 num                         1.6
 ocaml                       5.3.0
-ocaml-base-compiler         5.3.0
 ocaml-compiler              5.3.0
 ocaml-compiler-libs         v0.17.0
 ocaml-config                3
-ocaml-options-vanilla       1
+ocaml-option-flambda        1
 ocaml-syntax-shims          1.0.0
+ocaml-variants              5.3.0+options
 ocaml-version               4.1.1
 ocaml_intrinsics_kernel     v0.17.2
 ocamlbuild                  0.16.1
@@ -86,7 +86,6 @@ ocamlfind                   1.9.8
 ocamlformat                 0.29.0
 ocamlformat-lib             0.29.0
 ocp-indent                  1.9.0
-opam-depext                 1.2.3
 ounit2                      2.2.7
 owl                         1.2
 owl-base                    1.2


### PR DESCRIPTION
## Summary

The CI image was rebuilt this week and the opam solver picked
different package versions than last week's snapshot. This PR
updates `trading/deps-snapshot.txt` to reflect the new state.

**Review the diff** to see what changed. Merge = opt-in to the
new versions. If a version bump is undesirable, pin it in
`.devcontainer/Dockerfile` before merging.

🤖 Generated by the weekly deps-update workflow.