### PR TITLE
feat(weinstein): SPY-only Stage-4 short leg (default-off testbed)

### DIFF
--- a/dev/status/spy-only-reference.md
+++ b/dev/status/spy-only-reference.md
@@ -1,0 +1,97 @@
+# Status: spy-only-reference
+
+## Last updated: 2026-06-01
+
+## Status
+IN_PROGRESS
+
+## Interface stable
+YES
+
+`Spy_only_weinstein_strategy` is a deliberately minimal single-instrument
+testbed (long/flat by default, `enable_stage4_short` opt-in), separate
+from the production `Weinstein_strategy`. Lives at
+`trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.{ml,mli}`
++ `spy_only_transitions.{ml,mli}`. Constructed via
+`Strategy_choice.Spy_only_weinstein { symbol; ma_period_weeks;
+enable_stage4_short }`.
+
+## Goal
+
+A research-ladder testbed that isolates Weinstein stage timing on the
+cleanest possible signal (the index itself), to learn which mechanism
+helps at which layer. Objective: drawdown defense / risk-adjusted
+return (operationalized as win-size ≫ loss-size asymmetry), NOT raw
+return.
+
+## Completed
+
+- **SPY-only long/flat reference** (PR #1397, MERGED). Long/flat,
+  reuses `Stage.classify` + `Weinstein_stops`, strips
+  screener/sizing/macro. On the deep window it cut MaxDD to ~18.8%
+  (vs BAH SPY ~34-55%) by going flat in Stage 4. 70% win, Calmar 0.48
+  > BAH 0.37.
+- **Investor 30wk vs trader 10wk MA dial** (PR #1401). 10wk trader
+  REJECTED — strictly worse than 30wk investor on both bull + deep
+  windows. Investor 30wk is the drawdown-insurance sweet spot.
+- **Stage-4 short leg** (`enable_stage4_short`, default-off testbed
+  dial — THIS PR, `feat/spy-longshort`). When ON, the strategy goes
+  short in Stage 4 instead of sitting flat: short sized like the long
+  (`floor(cash/close)`), short stop via `Weinstein_stops ~side:Short`
+  (above entry, ratchets down), covers when SPY leaves Stage 4 (Stage
+  1/2) or on a short-stop hit. Default-off = bit-identical long/flat
+  per `.claude/rules/experiment-flag-discipline.md` R1. Expressible as
+  a scenario via `(enable_stage4_short true)`; scenario
+  `spy-longshort.sexp`.
+
+## Stage-4 short-leg result (report only — NOT promoted)
+
+**Headline: the short leg does NOT lower MaxDD vs the long/flat twin
+on either window — it RAISES it.** Same failure mode as the SP500
+multi-symbol long-short: Stage-4 shorts get squeezed on fast-V bounces.
+
+| window | scenario | Return | Sharpe | Calmar | MaxDD | Win% | trades | avg-win% | avg-loss% | win/loss ratio |
+|---|---|---|---|---|---|---|---|---|---|---|
+| 2009-2026 (post-GFC bull) | spy-investor (long/flat) | 317.9% | 0.77 | 0.48 | **18.8%** | 70.0% | 10 | 23.70 | -3.26 | 7.27 |
+| 2009-2026 | spy-longshort (short ON) | 98.1% | 0.35 | 0.13 | **32.6%** | 36.0% | 25 | 18.68 | -5.26 | 3.55 |
+| 1995-2025 (deep: dot-com + GFC + COVID) | spy-investor-deep (long/flat) | 1168.8% | 0.73 | 0.35 | **24.3%** | 52.4% | 21 | 30.79 | -2.81 | 10.97 |
+| 1995-2025 | spy-longshort-deep (short ON) | 593.1% | 0.47 | 0.18 | **35.7%** | 37.5% | 48 | 21.97 | -4.60 | 4.77 |
+
+Deep long-short trade decomposition (the smoking gun): of 48 closed
+trades, the 21 LONGs are bit-identical to the long/flat twin (52.4%
+win, +30.8/-2.8 asymmetry); the 27 SHORTs win only **25.9%** with
+avg-win +8.1% / avg-loss -5.5% — a losing, drawdown-raising overlay.
+On a deeper, macro-regime-diverse window (the regime where shorting
+should help most), the short leg still halves return and raises MaxDD
+24.3% → 35.7%.
+
+Verdict: keep `enable_stage4_short = false` default. Shorting a single
+clean instrument in sustained Stage-4 bears does NOT beat the long/flat
+twin's drawdown — the V-bounce squeeze dominates even with the index's
+clean signal. No promotion; testbed-only per R3.
+
+## Next Steps
+
+1. (Open question, not dispatched) If short-side drawdown defense is
+   still wanted, the lever is NOT a naive Stage-4 short — test instead
+   a regime-conditioned short (only short when the Stage-4 read has
+   persisted N weeks AND the prior trend extreme is far below), or a
+   put-overlay proxy. Both are new mechanisms, not dials; gate via the
+   experiment ledger.
+2. The long/flat investor 30wk remains the reference floor; selection
+   (Cell E multi-symbol) ≫ timing for total return — see
+   `dev/notes/spy-mode-comparison-2026-06-01.md`.
+
+## References
+
+- `trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.mli`
+  — `config` + `enable_stage4_short` short mechanics.
+- `trading/trading/weinstein/stops/lib/weinstein_stops.mli` — `~side:Short`
+  stop (above entry, ratchets down; `check_stop_hit` on `high ≥ stop`).
+- `trading/test_data/backtest_scenarios/spy-longshort.sexp` — short-on
+  scenario (2009-2026 window; deep companion run reported, not pinned).
+- `docs/design/weinstein-book-reference.md` §Short-Selling Rules — shorting
+  Stage-4 declines is faithful (the spine permits it; W1 intact).
+
+## Ownership
+`feat-weinstein` agent.

--- a/trading/test_data/backtest_scenarios/spy-longshort.sexp
+++ b/trading/test_data/backtest_scenarios/spy-longshort.sexp
@@ -1,0 +1,45 @@
+;; perf-tier: research
+;; perf-tier-rationale: SPY-only single-instrument Weinstein stage-timing
+;; reference strategy with the Stage-4 SHORT leg enabled (long-short, investor
+;; preset 30wk MA). Single-symbol universe (universes/spy-only), so the run is
+;; fast despite the long 2009-2026 window. NOT a pinned golden — wide expected
+;; bands; this is a direction-finding / risk-defense diagnostic.
+;;
+;; Strategy: [Spy_only_weinstein (symbol SPY) (ma_period_weeks 30)
+;;           (enable_stage4_short true)] — see
+;; [trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.mli]. The
+;; ONLY dial that differs from the long/flat investor preset (spy-investor.sexp)
+;; is [enable_stage4_short]. Each Friday it classifies SPY's own 30wk-MA stage:
+;;   - enters LONG (all-cash) when flat and SPY is Stage 2 (above a rising MA),
+;;   - goes SHORT (all-cash) when flat and SPY is Stage 4 (below a falling MA),
+;;   - exits the long on the Stage 3->4 roll-over / Stage 4 (to flat, then short),
+;;   - covers the short when SPY leaves Stage 4 (re-enters Stage 1/2),
+;;   - exits/covers on a Weinstein trailing-stop hit (checked every day; the
+;;     short stop sits ABOVE entry and ratchets DOWN as price falls).
+;;
+;; Headline question (drawdown defense): does the short leg LOWER MaxDD vs the
+;; long/flat twin (spy-investor.sexp) on the same window+universe? Prior art
+;; (sp500-2010-2026-longshort) FAILED this bar — individual-name shorts get
+;; squeezed on fast-V bounces and RAISED drawdown. This testbed asks whether
+;; shorting a single clean instrument (SPY) in sustained Stage-4 bears does
+;; better. Default-off testbed dial — NOT promoted; see
+;; [.claude/rules/experiment-flag-discipline.md].
+;;
+;; SPY data range on disk (committed test_data): 2009-01-02 .. ~2026-05-01 —
+;; covers this window. A deeper 1993-2026 SPY (dot-com bust + GFC) is the
+;; macro-regime-diverse companion run reported in the PR body, not pinned here.
+((name "spy-longshort")
+ (description "SPY-only Weinstein long-short investor preset (30wk MA, Stage-4 short leg ON) 2009-06-01 to 2025-12-31 — drawdown-defense diagnostic vs spy-investor (long/flat).")
+ (period ((start_date 2009-06-01) (end_date 2025-12-31)))
+ (universe_path "universes/spy-only.sexp")
+ (universe_size 1)
+ (config_overrides ())
+ (strategy (Spy_only_weinstein (symbol SPY) (ma_period_weeks 30) (enable_stage4_short true)))
+ (expected
+  ((total_return_pct       ((min -90.0)    (max 5000.0)))
+   (total_trades           ((min   0.0)    (max  400.0)))
+   (win_rate               ((min   0.0)    (max  100.0)))
+   (sharpe_ratio           ((min  -2.0)    (max    5.0)))
+   (max_drawdown_pct       ((min   0.0)    (max   95.0)))
+   (avg_holding_days       ((min   0.0)    (max 5000.0)))
+   (wall_seconds           ((min   0.5)    (max 3600.0))))))

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -27,11 +27,10 @@ module Spy_only = Weinstein_strategy.Spy_only_weinstein_strategy
     The Weinstein branch threads the runner's deps-loaded inputs (AD bars,
     sector map, config) through {!Weinstein_strategy.make}. The [Bah_benchmark]
     branch ignores all of that machinery — BAH is a single-symbol passive
-    strategy that needs only its own [config.symbol] — and constructs
-    {!Trading_strategy.Bah_benchmark_strategy.make}. The [bar_reader] /
-    [audit_recorder] are intentionally dropped on the BAH branch: BAH reads
-    prices via [get_price] (the simulator's per-tick callback, wired through the
-    snapshot-backed [Market_data_adapter]) and emits no audit events. *)
+    strategy that needs only its own [config.symbol]. The [bar_reader] /
+    [audit_recorder] are dropped on the BAH branch: BAH reads prices via
+    [get_price] (the snapshot-backed [Market_data_adapter]) and emits no audit
+    events. *)
 
 let _build_strategy (input : input) ~strategy_choice ~bar_reader ~audit_recorder
     =
@@ -42,8 +41,10 @@ let _build_strategy (input : input) ~strategy_choice ~bar_reader ~audit_recorder
         input.config
   | Bah_benchmark { symbol } ->
       Trading_strategy.Bah_benchmark_strategy.make { symbol }
-  | Spy_only_weinstein { symbol; ma_period_weeks } ->
-      let config = Spy_only.config_with ~symbol ~ma_period_weeks () in
+  | Spy_only_weinstein { symbol; ma_period_weeks; enable_stage4_short } ->
+      let config =
+        Spy_only.config_with ~symbol ~enable_stage4_short ~ma_period_weeks ()
+      in
       Spy_only.make ~config ~bar_reader ()
 
 (* Wrap the runner's already-constructed [daily_panels] in the simulator's

--- a/trading/trading/backtest/lib/strategy_choice.ml
+++ b/trading/trading/backtest/lib/strategy_choice.ml
@@ -7,12 +7,17 @@ open Core
    bit-identical to the investor preset. *)
 let default_spy_ma_period_weeks = 30
 
+(* Stage-4 short leg off by default: a scenario that omits [enable_stage4_short]
+   gets the long/flat strategy, bit-identical to the pre-short-leg behaviour. *)
+let default_spy_enable_stage4_short = false
+
 type t =
   | Weinstein
   | Bah_benchmark of { symbol : string }
   | Spy_only_weinstein of {
       symbol : string;
       ma_period_weeks : int; [@sexp.default default_spy_ma_period_weeks]
+      enable_stage4_short : bool; [@sexp.default default_spy_enable_stage4_short]
     }
 [@@deriving sexp, eq, show]
 
@@ -21,5 +26,6 @@ let default = Weinstein
 let name = function
   | Weinstein -> "Weinstein"
   | Bah_benchmark { symbol } -> sprintf "Bah_benchmark(%s)" symbol
-  | Spy_only_weinstein { symbol; ma_period_weeks } ->
-      sprintf "Spy_only_weinstein(%s,ma=%dwk)" symbol ma_period_weeks
+  | Spy_only_weinstein { symbol; ma_period_weeks; enable_stage4_short } ->
+      sprintf "Spy_only_weinstein(%s,ma=%dwk%s)" symbol ma_period_weeks
+        (if enable_stage4_short then ",short" else "")

--- a/trading/trading/backtest/lib/strategy_choice.mli
+++ b/trading/trading/backtest/lib/strategy_choice.mli
@@ -33,6 +33,7 @@ type t =
   | Spy_only_weinstein of {
       symbol : string;
       ma_period_weeks : int; [@sexp.default 30]
+      enable_stage4_short : bool; [@sexp.default false]
     }
       (** Single-instrument Weinstein stage-timing reference strategy on
           [symbol] (default [SPY]). Constructs
@@ -41,9 +42,9 @@ type t =
           for stage classification and the trailing-stop support floor). Like
           {!Bah_benchmark}, the runner's universe / sector-map / AD-bars
           machinery is loaded but unused; [symbol] must be present in the
-          scenario's universe. Long/flat only — no shorting.
+          scenario's universe.
 
-          [ma_period_weeks] is the {b only} tunable dial (per
+          [ma_period_weeks] is the primary tunable dial (per
           [.claude/rules/weinstein-faithful-core.md] — the MA period is the
           documented investor/trader dial). It sets the stage-classifier moving
           average period in weeks. [30] (the [@sexp.default]) is Weinstein's
@@ -51,7 +52,17 @@ type t =
           deserialises bit-identically to it; [10] is the faster trader preset.
           The strategy spine (Stage-2-only entry, Stage 3/4 exit, stop below
           base) is untouched by this dial — only the MA window, and the
-          proportional weekly-bar lookback derived from it, change. *)
+          proportional weekly-bar lookback derived from it, change.
+
+          [enable_stage4_short] turns the Stage-4 short leg on ([false] default
+          = long/flat, bit-identical to the pre-short-leg strategy; every
+          pre-existing scenario that omits the field deserialises to it). When
+          [true] the strategy goes short in Stage 4 instead of sitting flat — a
+          faithful Weinstein adaptation (he shorts Stage-4 declines), gated as a
+          default-off testbed dial per
+          [.claude/rules/experiment-flag-discipline.md]. See
+          {!Weinstein_strategy.Spy_only_weinstein_strategy.config} for the short
+          mechanics. *)
 [@@deriving sexp, eq, show]
 
 val default : t

--- a/trading/trading/weinstein/strategy/lib/spy_only_signals.ml
+++ b/trading/trading/weinstein/strategy/lib/spy_only_signals.ml
@@ -1,0 +1,39 @@
+(** Pure stage-signal predicates for the SPY-only Weinstein strategy — see
+    [spy_only_signals.mli]. *)
+
+open Trading_strategy
+
+let is_exit_signal (result : Stage.result) : bool =
+  match result.stage with
+  | Weinstein_types.Stage4 _ -> true
+  | Weinstein_types.Stage3 _ | Weinstein_types.Stage2 _
+  | Weinstein_types.Stage1 _ -> (
+      match result.transition with
+      | Some (Weinstein_types.Stage3 _, Weinstein_types.Stage4 _) -> true
+      | _ -> false)
+
+let is_entry_signal (result : Stage.result) : bool =
+  match result.stage with
+  | Weinstein_types.Stage2 _ ->
+      Weinstein_types.equal_ma_direction result.ma_direction
+        Weinstein_types.Rising
+  | Weinstein_types.Stage1 _ | Weinstein_types.Stage3 _
+  | Weinstein_types.Stage4 _ ->
+      false
+
+let is_cover_signal (result : Stage.result) : bool =
+  match result.stage with
+  | Weinstein_types.Stage1 _ | Weinstein_types.Stage2 _ -> true
+  | Weinstein_types.Stage3 _ | Weinstein_types.Stage4 _ -> false
+
+let stage_exit_label_for_side ~(side : Position.position_side)
+    (r : Stage.result) : string option =
+  match side with
+  | Position.Long -> if is_exit_signal r then Some "stage4_exit" else None
+  | Position.Short -> if is_cover_signal r then Some "stage4_cover" else None
+
+let flat_entry_side ~(enable_stage4_short : bool) (r : Stage.result) :
+    Position.position_side option =
+  if is_entry_signal r then Some Position.Long
+  else if enable_stage4_short && is_exit_signal r then Some Position.Short
+  else None

--- a/trading/trading/weinstein/strategy/lib/spy_only_signals.mli
+++ b/trading/trading/weinstein/strategy/lib/spy_only_signals.mli
@@ -1,0 +1,35 @@
+(** Pure stage-signal predicates for the SPY-only Weinstein strategy.
+
+    Extracted from [spy_only_weinstein_strategy.ml] so the strategy module stays
+    under the file-length limit. Each predicate maps a {!Stage.result} (and, for
+    the entry decision, the side configuration) to an enter / exit / cover
+    verdict. No I/O, no mutable state — same input, same output. *)
+
+open Trading_strategy
+
+val is_exit_signal : Stage.result -> bool
+(** A long "exit to flat" signal: the symbol has rolled from a topping Stage 3
+    into a declining Stage 4, or is already in Stage 4. Stage 1/2 and a bare
+    Stage 3 (still topping, not yet broken) do not exit. *)
+
+val is_entry_signal : Stage.result -> bool
+(** A long entry signal: the symbol is in Stage 2 (advancing) {e and} the MA is
+    rising — never a flat-MA basing tape. *)
+
+val is_cover_signal : Stage.result -> bool
+(** A short-cover signal: the symbol has LEFT Stage 4 — based (Stage 1) or
+    resumed advancing (Stage 2). The mirror of {!is_exit_signal} for a short. *)
+
+val stage_exit_label_for_side :
+  side:Position.position_side -> Stage.result -> string option
+(** The stage-driven exit LABEL for a held position on [side], if the weekly
+    read fires one: a LONG exits on a Stage-4 roll-over ([stage4_exit]); a SHORT
+    covers when the tape LEAVES Stage 4 ([stage4_cover]). [None] = no
+    stage-based exit this tick. *)
+
+val flat_entry_side :
+  enable_stage4_short:bool -> Stage.result -> Position.position_side option
+(** The flat-tape entry decision for a weekly stage read: a LONG on a Stage-2
+    advance, or — only when [enable_stage4_short] is set — a SHORT on a Stage-4
+    decline. [None] = stay flat. With the short leg off this collapses to the
+    long-only rule, bit-identical to the pre-short-leg strategy. *)

--- a/trading/trading/weinstein/strategy/lib/spy_only_transitions.ml
+++ b/trading/trading/weinstein/strategy/lib/spy_only_transitions.ml
@@ -3,31 +3,40 @@
 
 open Trading_strategy
 
-let _entry_reasoning : Position.entry_reasoning =
-  TechnicalSignal
-    {
-      indicator = "Stage";
-      description = "SPY-only Weinstein: Stage 2 entry on rising 30-week MA";
-    }
+(* Entry reasoning, parameterised by side: a Stage-2 long entry on a rising MA,
+   or a Stage-4 short entry on a falling MA. *)
+let _entry_reasoning (side : Position.position_side) : Position.entry_reasoning
+    =
+  let description =
+    match side with
+    | Long -> "SPY-only Weinstein: Stage 2 entry on rising 30-week MA"
+    | Short -> "SPY-only Weinstein: Stage 4 short entry on falling 30-week MA"
+  in
+  TechnicalSignal { indicator = "Stage"; description }
 
-(* The transition [kind] for a Stage-2 long entry, built flat so [build_entry]
-   stays shallow. *)
-let _entry_kind ~(symbol : string) ~(entry_price : float)
-    ~(target_quantity : float) : Position.transition_kind =
+(* The transition [kind] for a stage-driven entry on [side], built flat so
+   [build_entry] stays shallow. *)
+let _entry_kind ~(symbol : string) ~(side : Position.position_side)
+    ~(entry_price : float) ~(target_quantity : float) : Position.transition_kind
+    =
   CreateEntering
     {
       symbol;
-      side = Long;
+      side;
       target_quantity;
       entry_price;
-      reasoning = _entry_reasoning;
+      reasoning = _entry_reasoning side;
     }
 
+(* "side=long" / "side=short" detail tag for a [StrategySignal] exit reason. *)
+let _side_detail (side : Position.position_side) : string =
+  match side with Long -> "side=long" | Short -> "side=short"
+
 (* The transition [kind] for a stage-based exit (a [StrategySignal] reason). *)
-let _exit_kind ~(label : string) ~(exit_price : float) :
-    Position.transition_kind =
+let _exit_kind ~(side : Position.position_side) ~(label : string)
+    ~(exit_price : float) : Position.transition_kind =
   let exit_reason : Position.exit_reason =
-    StrategySignal { label; detail = Some "side=long" }
+    StrategySignal { label; detail = Some (_side_detail side) }
   in
   TriggerExit { exit_reason; exit_price }
 
@@ -41,16 +50,16 @@ let _stop_exit_kind ~(stop_level : float) ~(exit_price : float) :
   TriggerExit { exit_reason; exit_price }
 
 let build_entry ~(position_id : string) ~(symbol : string)
-    ~(bar : Types.Daily_price.t) ~(target_quantity : float) :
-    Position.transition =
+    ~(side : Position.position_side) ~(bar : Types.Daily_price.t)
+    ~(target_quantity : float) : Position.transition =
   let kind =
-    _entry_kind ~symbol ~entry_price:bar.close_price ~target_quantity
+    _entry_kind ~symbol ~side ~entry_price:bar.close_price ~target_quantity
   in
   { Position.position_id; date = bar.date; kind }
 
 let build_exit ~(pos : Position.t) ~(bar : Types.Daily_price.t)
     ~(label : string) : Position.transition =
-  let kind = _exit_kind ~label ~exit_price:bar.close_price in
+  let kind = _exit_kind ~side:pos.side ~label ~exit_price:bar.close_price in
   { Position.position_id = pos.id; date = bar.date; kind }
 
 let build_stop_exit ~(pos : Position.t) ~(bar : Types.Daily_price.t)

--- a/trading/trading/weinstein/strategy/lib/spy_only_transitions.mli
+++ b/trading/trading/weinstein/strategy/lib/spy_only_transitions.mli
@@ -9,12 +9,14 @@ open Trading_strategy
 val build_entry :
   position_id:string ->
   symbol:string ->
+  side:Position.position_side ->
   bar:Types.Daily_price.t ->
   target_quantity:float ->
   Position.transition
-(** Stage-2 entry: a [CreateEntering] long transition for [symbol] at
-    [bar.close_price], tagged with the SPY-only Weinstein entry reasoning.
-    [position_id] is the strategy's deterministic id for the symbol. *)
+(** Stage-driven entry: a [CreateEntering] transition for [symbol] on [side] at
+    [bar.close_price], tagged with the SPY-only Weinstein entry reasoning
+    ([Long] = Stage-2 advance, [Short] = Stage-4 decline). [position_id] is the
+    strategy's deterministic id for the symbol. *)
 
 val build_exit :
   pos:Position.t ->
@@ -22,7 +24,9 @@ val build_exit :
   label:string ->
   Position.transition
 (** Stage-based exit: a [TriggerExit] with a [StrategySignal] reason carrying
-    [label] (e.g. ["stage4_exit"]), exiting [pos] at [bar.close_price]. *)
+    [label] (e.g. ["stage4_exit"] for a long, ["stage4_cover"] for a short) and
+    a ["side=long"]/["side=short"] detail tag drawn from [pos.side], exiting
+    [pos] at [bar.close_price]. *)
 
 val build_stop_exit :
   pos:Position.t ->

--- a/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
@@ -9,11 +9,13 @@ type config = {
   stage_config : Stage.config;
   stops_config : Weinstein_stops.config;
   fallback_stop_buffer : float;
+  enable_stage4_short : bool;
 }
 
 let name = "SpyOnlyWeinstein"
 let default_symbol = "SPY"
 let default_fallback_stop_buffer = 0.92
+let default_enable_stage4_short = false
 
 let default_config =
   {
@@ -21,26 +23,25 @@ let default_config =
     stage_config = Stage.default_config;
     stops_config = Weinstein_stops.default_config;
     fallback_stop_buffer = default_fallback_stop_buffer;
+    enable_stage4_short = default_enable_stage4_short;
   }
 
-let config_with ?(symbol = default_symbol) ~ma_period_weeks () =
+let config_with ?(symbol = default_symbol)
+    ?(enable_stage4_short = default_enable_stage4_short) ~ma_period_weeks () =
   {
     default_config with
     symbol;
     stage_config =
       { default_config.stage_config with ma_period = ma_period_weeks };
+    enable_stage4_short;
   }
 
-(* Number of weekly bars fed to [Stage.classify]. The MA plus its slope lookback
-   need a comfortable margin, so we read [ma_period] weeks for the MA itself
-   plus an equal margin for the slope/prior-stage context — i.e. twice the MA
-   period — floored at [_min_stage_weeks] so a very short trader MA still warms
-   up. At the 30-week investor default this is 60 weeks (~14 months), matching
-   the prior fixed read. *)
+(* Number of weekly bars fed to [Stage.classify]: twice the MA period (the MA
+   plus an equal slope/prior-stage margin), floored at [_min_stage_weeks] so a
+   short trader MA still warms up. 60 weeks at the 30-week investor default. *)
 let _min_stage_weeks = 12
 
-(* Window = ma_period weeks for the MA plus an equal margin for the slope
-   lookback, i.e. 2x the MA period. *)
+(* MA weeks plus an equal slope-lookback margin, i.e. 2x the MA period. *)
 let _stage_weeks_ma_multiplier = 2
 
 let _stage_weeks_of (config : config) : int =
@@ -92,8 +93,7 @@ let _holding_quantity (pos : Position.t) : float option =
 
 (* The [(entry_price, entry_date)] of a [Holding] position — the anchor the
    initial stop's support floor is computed against (NOT today's close, which on
-   a crash bar would place the stop far below the trigger and silently disarm
-   it). Returns [None] for any non-[Holding] state. *)
+   a crash bar would disarm the stop). [None] for any non-[Holding] state. *)
 let _holding_entry (pos : Position.t) : (float * Date.t) option =
   match pos.state with
   | Position.Holding h -> Some (h.entry_price, h.entry_date)
@@ -115,42 +115,17 @@ let _classify_stage ~config ~bar_reader ~prior_stage ~(as_of : Date.t) :
         (Stage.classify ~config:config.stage_config ~bars
            ~prior_stage:!prior_stage)
 
-(* A Weinstein "exit to flat" signal: the symbol has rolled from a topping
-   Stage 3 into a declining Stage 4, or is already in Stage 4. Stage 1/2 and a
-   bare Stage 3 (still topping, not yet broken) do not exit. *)
-let _is_exit_signal (result : Stage.result) : bool =
-  match result.stage with
-  | Weinstein_types.Stage4 _ -> true
-  | Weinstein_types.Stage3 _ | Weinstein_types.Stage2 _
-  | Weinstein_types.Stage1 _ -> (
-      match result.transition with
-      | Some (Weinstein_types.Stage3 _, Weinstein_types.Stage4 _) -> true
-      | _ -> false)
-
-(* An entry signal: the symbol is in Stage 2 (advancing above a rising 30-week
-   MA). The classifier already encodes "above rising MA"; we additionally
-   require the MA itself to be rising so we never buy a flat-MA basing tape. *)
-let _is_entry_signal (result : Stage.result) : bool =
-  match result.stage with
-  | Weinstein_types.Stage2 _ ->
-      Weinstein_types.equal_ma_direction result.ma_direction
-        Weinstein_types.Rising
-  | Weinstein_types.Stage1 _ | Weinstein_types.Stage3 _
-  | Weinstein_types.Stage4 _ ->
-      false
-
 (* Seed the initial trailing stop from a support-floor lookup on entry, falling
-   back to the fixed buffer when no qualifying correction is found. Reads the
-   accumulated daily bars for the symbol so the floor reflects real structure.
-*)
-let _seed_stop ~config ~bar_reader ~(entry_price : float) ~(as_of : Date.t) :
-    Weinstein_stops.stop_state =
+   back to the fixed buffer when no qualifying correction is found. Long: stop
+   below the correction low; short: above the counter-rally high ([side] is
+   threaded into the stop module). *)
+let _seed_stop ~config ~bar_reader ~(side : Position.position_side)
+    ~(entry_price : float) ~(as_of : Date.t) : Weinstein_stops.stop_state =
   let bars =
     Bar_reader.daily_bars_for bar_reader ~symbol:config.symbol ~as_of
   in
   Weinstein_stops.compute_initial_stop_with_floor ~config:config.stops_config
-    ~side:Long ~entry_price ~bars ~as_of
-    ~fallback_buffer:config.fallback_stop_buffer
+    ~side ~entry_price ~bars ~as_of ~fallback_buffer:config.fallback_stop_buffer
 
 (* Map a stop state-machine event to an optional exit transition: only a
    [Stop_hit] produces one. Kept separate so [_advance_stop] stays shallow. *)
@@ -164,99 +139,128 @@ let _exit_of_stop_event ~(pos : Position.t) ~(bar : Types.Daily_price.t)
       None
 
 (* Weekly-close advance: run the stop state machine one tick against the stage
-   read [r] and report the (new state, optional exit). Only called on a Friday
-   with a live stage result. *)
-let _advance_stop ~config ~(r : Stage.result)
+   read [r] and report the (new state, optional exit). *)
+let _advance_stop ~config ~(side : Position.position_side) ~(r : Stage.result)
     ~(state : Weinstein_stops.stop_state) ~(pos : Position.t)
     ~(bar : Types.Daily_price.t) :
     Weinstein_stops.stop_state * Position.transition option =
   let new_state, event =
-    Weinstein_stops.update ~config:config.stops_config ~side:Long ~state
+    Weinstein_stops.update ~config:config.stops_config ~side ~state
       ~current_bar:bar ~ma_value:r.ma_value ~ma_direction:r.ma_direction
       ~stage:r.stage
   in
   (new_state, _exit_of_stop_event ~pos ~bar ~event)
 
 (* Advance the trailing stop one tick on a held position and decide whether it
-   triggers an exit. On a weekly close the state machine advances (raises /
-   tightens); mid-week only the trigger check runs. Returns the (possibly
-   updated) stop state and an optional exit transition. *)
-let _step_stop ~config ~(stage_result : Stage.result option)
-    ~(state : Weinstein_stops.stop_state) ~(pos : Position.t)
-    ~(bar : Types.Daily_price.t) :
+   triggers an exit. On a weekly close the state machine advances (for a short,
+   ratchets the stop down); mid-week only the trigger check runs. [side] is the
+   held position's side. *)
+let _step_stop ~config ~(side : Position.position_side)
+    ~(stage_result : Stage.result option) ~(state : Weinstein_stops.stop_state)
+    ~(pos : Position.t) ~(bar : Types.Daily_price.t) :
     Weinstein_stops.stop_state * Position.transition option =
-  if Weinstein_stops.check_stop_hit ~state ~side:Long ~bar then
+  if Weinstein_stops.check_stop_hit ~state ~side ~bar then
     let stop_level = Weinstein_stops.get_stop_level state in
     (state, Some (Spy_only_transitions.build_stop_exit ~pos ~bar ~stop_level))
   else if not (_is_weekly_close ~date:bar.date) then (state, None)
   else
     match stage_result with
     | None -> (state, None)
-    | Some r -> _advance_stop ~config ~r ~state ~pos ~bar
+    | Some r -> _advance_stop ~config ~side ~r ~state ~pos ~bar
+
+(* Seed the stop the first time we observe the position in Holding (the entry
+   tick created it in Entering; the fill lands the following tick). The seed
+   anchors on the position's recorded entry price/date — not today's bar — so
+   the support floor reflects the structure around entry. *)
+let _seed_or_keep_stop ~config ~bar_reader ~stop_state
+    ~(side : Position.position_side) ~(pos : Position.t)
+    ~(bar : Types.Daily_price.t) : Weinstein_stops.stop_state =
+  match !stop_state with
+  | Some s -> s
+  | None ->
+      let entry_price, entry_date =
+        Option.value (_holding_entry pos) ~default:(bar.close_price, bar.date)
+      in
+      _seed_stop ~config ~bar_reader ~side ~entry_price ~as_of:entry_date
+
+(* The stage-based exit when the stop did not fire: only on a weekly close, and
+   only when the held [side]'s stage read warrants it (long Stage-4 exit / short
+   Stage-4 cover). Clears [stop_state] on a fire so the next entry re-seeds. *)
+let _stage_exit_when_holding ~stop_state ~(side : Position.position_side)
+    ~(stage_result : Stage.result option) ~(pos : Position.t)
+    ~(bar : Types.Daily_price.t) : Position.transition list =
+  let label =
+    if _is_weekly_close ~date:bar.date then
+      Option.bind stage_result
+        ~f:(Spy_only_signals.stage_exit_label_for_side ~side)
+    else None
+  in
+  match label with
+  | None -> []
+  | Some label ->
+      stop_state := None;
+      [ Spy_only_transitions.build_exit ~pos ~bar ~label ]
 
 (* Holding branch: run the stop, and on a weekly close also test the
-   stage-based exit signal. The stop takes precedence — if it fires we exit on
-   it and ignore the (less urgent) stage exit. Mutates [stop_state] /
-   [prior_stage] for the next tick. *)
+   stage-based exit signal for the held [side]. The stop takes precedence — if
+   it fires we exit on it and ignore the (less urgent) stage exit. Mutates
+   [stop_state] / [prior_stage] for the next tick. *)
 let _on_holding ~config ~bar_reader ~stop_state ~prior_stage ~(pos : Position.t)
     ~(bar : Types.Daily_price.t) : Position.transition list =
-  let as_of = bar.date in
-  let stage_result = _classify_stage ~config ~bar_reader ~prior_stage ~as_of in
-  (* Seed the stop the first time we observe the position in Holding (the entry
-     tick created it in Entering; the fill lands the following tick). The seed
-     anchors on the position's recorded entry price/date — not today's bar — so
-     the support floor reflects the structure around entry. *)
+  let side = pos.side in
+  let stage_result =
+    _classify_stage ~config ~bar_reader ~prior_stage ~as_of:bar.date
+  in
   let state =
-    match !stop_state with
-    | Some s -> s
-    | None ->
-        let entry_price, entry_date =
-          Option.value (_holding_entry pos) ~default:(bar.close_price, as_of)
-        in
-        _seed_stop ~config ~bar_reader ~entry_price ~as_of:entry_date
+    _seed_or_keep_stop ~config ~bar_reader ~stop_state ~side ~pos ~bar
   in
   let new_state, stop_exit =
-    _step_stop ~config ~stage_result ~state ~pos ~bar
+    _step_stop ~config ~side ~stage_result ~state ~pos ~bar
   in
   stop_state := Some new_state;
   Option.iter stage_result ~f:(fun r -> prior_stage := Some r.stage);
   match stop_exit with
   | Some t -> [ t ]
-  | None -> (
-      let is_friday = _is_weekly_close ~date:bar.date in
-      match (is_friday, stage_result) with
-      | true, Some r when _is_exit_signal r ->
-          stop_state := None;
-          [ Spy_only_transitions.build_exit ~pos ~bar ~label:"stage4_exit" ]
-      | _ -> [])
+  | None -> _stage_exit_when_holding ~stop_state ~side ~stage_result ~pos ~bar
 
-(* Build the (at most one) entry transition for [bar] when the all-cash sizing
-   affords a whole share; otherwise no transition. Kept separate so [_on_flat]
-   stays shallow. *)
-let _entry_transitions ~config ~(cash : float) ~(bar : Types.Daily_price.t) :
-    Position.transition list =
+(* Build the (at most one) entry transition for [bar] on [side] when the
+   all-cash sizing affords a whole share; otherwise no transition. The short
+   side is sized identically to the long: [floor(cash / close)] notional. Kept
+   separate so [_on_flat] stays shallow. *)
+let _entry_transitions ~config ~(side : Position.position_side) ~(cash : float)
+    ~(bar : Types.Daily_price.t) : Position.transition list =
   match _shares_from_cash ~cash ~close_price:bar.close_price with
   | None -> []
   | Some target_quantity ->
       let position_id = _position_id_of_symbol config.symbol in
       [
-        Spy_only_transitions.build_entry ~position_id ~symbol:config.symbol ~bar
-          ~target_quantity;
+        Spy_only_transitions.build_entry ~position_id ~symbol:config.symbol
+          ~side ~bar ~target_quantity;
       ]
 
-(* Flat branch: only act on a weekly close. Classify, and enter when the stage
-   signal fires. The stop is seeded later, on the first Holding tick. *)
+(* Classify on this Friday, record [prior_stage], and resolve the flat-tape
+   entry side (long on Stage 2; short on Stage 4 when enabled), or [None]. *)
+let _flat_entry_side ~config ~bar_reader ~prior_stage
+    ~(bar : Types.Daily_price.t) : Position.position_side option =
+  let stage_result =
+    _classify_stage ~config ~bar_reader ~prior_stage ~as_of:bar.date
+  in
+  Option.iter stage_result ~f:(fun r -> prior_stage := Some r.stage);
+  Option.bind stage_result
+    ~f:
+      (Spy_only_signals.flat_entry_side
+         ~enable_stage4_short:config.enable_stage4_short)
+
+(* Flat branch: only act on a weekly close. Enter when the stage signal fires
+   (long on Stage 2; short on Stage 4 when enabled). The stop is seeded later,
+   on the first Holding tick. *)
 let _on_flat ~config ~bar_reader ~prior_stage ~(cash : float)
     ~(bar : Types.Daily_price.t) : Position.transition list =
   if not (_is_weekly_close ~date:bar.date) then []
   else
-    let stage_result =
-      _classify_stage ~config ~bar_reader ~prior_stage ~as_of:bar.date
-    in
-    Option.iter stage_result ~f:(fun r -> prior_stage := Some r.stage);
-    match stage_result with
-    | Some r when _is_entry_signal r -> _entry_transitions ~config ~cash ~bar
-    | _ -> []
+    match _flat_entry_side ~config ~bar_reader ~prior_stage ~bar with
+    | Some side -> _entry_transitions ~config ~side ~cash ~bar
+    | None -> []
 
 (* Dispatch one bar to the holding or flat branch based on the live position.
    A still-[Entering] position (awaiting fill) yields no transitions. Kept

--- a/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.mli
@@ -61,7 +61,31 @@ type config = {
           support-floor lookup finds no qualifying correction. For a long the
           stop falls at [entry_price *. fallback_stop_buffer]; a value below 1.0
           (default {!default_fallback_stop_buffer}, [0.92] = an 8% stop)
-          therefore sits below entry. *)
+          therefore sits below entry. For a short the mirror is used — the stop
+          sits {e above} entry at [entry_price /. fallback_stop_buffer]. *)
+  enable_stage4_short : bool;
+      (** Stage-4 short leg. When [false] ({b the default}, bit-identical to the
+          original long/flat strategy) a Stage-4 read means "exit to flat" and
+          the strategy is never short. When [true] the strategy {b goes short}
+          in Stage 4 instead of sitting flat — a faithful Weinstein adaptation
+          (he shorts Stage-4 declines; book §Short-Selling Rules). It is a
+          {e testbed dial} only: default-off per
+          [.claude/rules/experiment-flag-discipline.md] R1, and not promoted to
+          the default config (R3) without a ledger ACCEPT.
+
+          Short mechanics (mirror of the long side):
+          - {b Entry.} On a weekly close, when flat and SPY's stage read is a
+            Stage-4 exit signal (Stage 4, or a Stage 3→4 roll-over), open a
+            short sized by the same all-cash [floor(cash / close)] rule as the
+            long entry.
+          - {b Stop.} {!Weinstein_stops} with [side = Short]: the initial stop
+            sits {e above} the Stage-4 rally high (a counter-rally-high support
+            floor, or the fallback buffer above entry) and ratchets {e down} as
+            price falls. Triggered intraday by [high ≥ stop_level].
+          - {b Exit.} The short is covered when SPY leaves Stage 4 — i.e. the
+            weekly stage read becomes Stage 1 (basing) or Stage 2 (advancing) —
+            or on a short-stop hit. (A flat Stage-2 read on the same Friday then
+            opens a fresh long via the normal entry path.) *)
 }
 
 val name : string
@@ -74,14 +98,26 @@ val default_fallback_stop_buffer : float
 (** [0.92] — an 8% loose initial stop, matching Weinstein's 8% correction rule
     (book §5.1) when no structural support floor is available. *)
 
+val default_enable_stage4_short : bool
+(** [false] — the Stage-4 short leg is off by default, keeping the strategy
+    long/flat and bit-identical to its pre-short-leg behaviour. *)
+
 val default_config : config
 (** [default_config] uses {!default_symbol}, {!Stage.default_config},
-    {!Weinstein_stops.default_config}, and {!default_fallback_stop_buffer}. *)
+    {!Weinstein_stops.default_config}, {!default_fallback_stop_buffer}, and
+    {!default_enable_stage4_short} ([false] — long/flat). *)
 
-val config_with : ?symbol:string -> ma_period_weeks:int -> unit -> config
-(** [config_with ?symbol ~ma_period_weeks ()] is {!default_config} with the
-    stage-classifier moving-average period overridden to [ma_period_weeks] weeks
-    (and optionally a different [symbol]).
+val config_with :
+  ?symbol:string ->
+  ?enable_stage4_short:bool ->
+  ma_period_weeks:int ->
+  unit ->
+  config
+(** [config_with ?symbol ?enable_stage4_short ~ma_period_weeks ()] is
+    {!default_config} with the stage-classifier moving-average period overridden
+    to [ma_period_weeks] weeks (and optionally a different [symbol] and the
+    Stage-4 short leg flipped on via [enable_stage4_short], default
+    {!default_enable_stage4_short} = [false]).
 
     The MA period is the single Weinstein-faithful dial that distinguishes the
     investor preset ([30] weeks — Weinstein's default for position trading) from

--- a/trading/trading/weinstein/strategy/test/test_spy_only_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_spy_only_weinstein_strategy.ml
@@ -53,9 +53,10 @@ let make_portfolio ~cash ?position () : Portfolio_view.t =
   in
   { cash; positions }
 
-(* Build a Holding SPY position at [entry_price] / [entry_date]. *)
-let make_holding ~entry_price ~entry_date ~quantity :
-    Trading_strategy.Position.t =
+(* Build a Holding SPY position at [entry_price] / [entry_date] on [side]
+   (default Long). *)
+let make_holding ?(side = Trading_strategy.Position.Long) ~entry_price
+    ~entry_date ~quantity () : Trading_strategy.Position.t =
   let pos_id = symbol ^ "-spy-only-weinstein" in
   let make_trans kind =
     { Trading_strategy.Position.position_id = pos_id; date = entry_date; kind }
@@ -71,7 +72,7 @@ let make_holding ~entry_price ~entry_date ~quantity :
        (CreateEntering
           {
             symbol;
-            side = Long;
+            side;
             target_quantity = quantity;
             entry_price;
             reasoning = ManualDecision { description = "test" };
@@ -122,6 +123,34 @@ let is_long_entry =
                  (equal_to
                     ((symbol, Trading_strategy.Position.Long)
                       : string * Trading_strategy.Position.position_side)));
+          ]))
+
+(* A matcher pinning a single CreateEntering(Short) transition for SPY with a
+   given [target_quantity] — projects [(symbol, side, target_quantity)] out of
+   the inlined record. *)
+let is_short_entry ~target_quantity =
+  is_ok_and_holds
+    (field
+       (fun (o : Strategy_interface.output) -> o.transitions)
+       (elements_are
+          [
+            field
+              (fun (t : Trading_strategy.Position.transition) -> t.kind)
+              (matching ~msg:"Expected CreateEntering Short"
+                 (function
+                   | Trading_strategy.Position.CreateEntering c ->
+                       Some (c.symbol, c.side, c.target_quantity)
+                   | _ -> None)
+                 (all_of
+                    [
+                      field (fun (s, _, _) -> s) (equal_to symbol);
+                      field
+                        (fun (_, side, _) -> side)
+                        (equal_to Trading_strategy.Position.Short);
+                      field
+                        (fun (_, _, qty) -> qty)
+                        (float_equal target_quantity);
+                    ]));
           ]))
 
 (* A matcher pinning a single TriggerExit transition whose exit_reason satisfies
@@ -207,7 +236,7 @@ let test_stage4_friday_exits_when_holding _ =
   let today = List.last_exn bars in
   let pos =
     make_holding ~entry_price:today.close_price ~entry_date:today.date
-      ~quantity:700.0
+      ~quantity:700.0 ()
   in
   let strat = Spy.make ~bar_reader:(bar_reader_of bars) () in
   let result =
@@ -237,7 +266,7 @@ let test_stop_hit_exits_when_holding _ =
   let pos =
     make_holding ~entry_price
       ~entry_date:(Date.of_string "2021-12-24")
-      ~quantity:700.0
+      ~quantity:700.0 ()
   in
   let strat = Spy.make ~bar_reader:(bar_reader_of bars) () in
   let result =
@@ -303,6 +332,109 @@ let test_trader_preset_enters_where_investor_waits _ =
          field (fun (_, investor) -> investor) is_no_transitions;
        ])
 
+(* ---------------------------------------------------------------- *)
+(* Stage-4 short leg (default-off testbed dial).                     *)
+(* ---------------------------------------------------------------- *)
+
+(* Expected whole-share notional for [cash] all-cash sizing at [close], mirroring
+   the strategy's [_shares_from_cash] (1% gap buffer, rounded down). *)
+let shares_at ~cash ~close = Float.round_down (cash /. (close *. 1.01))
+
+let short_falling_bars =
+  weekly_closes ~last_friday ~n:n_weeks ~close:(falling_closes ~peak:140.0)
+
+let test_stage4_flat_stays_flat_when_short_off _ =
+  (* Flag OFF (default): a flat portfolio on a Stage-4 Friday takes NO action —
+     long/flat stays flat, bit-identical to the pre-short-leg strategy. *)
+  let today = List.last_exn short_falling_bars in
+  let strat = Spy.make ~bar_reader:(bar_reader_of short_falling_bars) () in
+  let result =
+    run_once strat ~today_bar:today
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that result is_no_transitions
+
+let test_stage4_flat_goes_short_when_on _ =
+  (* Flag ON: the SAME Stage-4 Friday + flat portfolio now opens a SHORT, sized
+     by the same all-cash [floor(cash / (close * 1.01))] rule as the long. *)
+  let today = List.last_exn short_falling_bars in
+  let config =
+    Spy.config_with ~enable_stage4_short:true ~ma_period_weeks:30 ()
+  in
+  let strat =
+    Spy.make ~config ~bar_reader:(bar_reader_of short_falling_bars) ()
+  in
+  let result =
+    run_once strat ~today_bar:today
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that result
+    (is_short_entry
+       ~target_quantity:(shares_at ~cash:100_000.0 ~close:today.close_price))
+
+let test_short_stop_fires_when_holding _ =
+  (* Holding a SHORT; today's bar gaps the HIGH far above entry so the short
+     trailing stop (which sits above entry and ratchets down) triggers — a
+     StopLoss exit, independent of the day-of-week (trigger is continuous). *)
+  let entry_price = falling_closes ~peak:140.0 (n_weeks - 1) in
+  (* A violent up-day well above any plausible counter-rally-high floor. *)
+  let squeeze_bar =
+    make_bar "2021-12-30" ~close:(entry_price *. 2.0) ~low:entry_price
+      ~high:(entry_price *. 2.0) ()
+  in
+  let pos =
+    make_holding ~side:Trading_strategy.Position.Short ~entry_price
+      ~entry_date:(Date.of_string "2021-12-24")
+      ~quantity:1000.0 ()
+  in
+  let config =
+    Spy.config_with ~enable_stage4_short:true ~ma_period_weeks:30 ()
+  in
+  let strat =
+    Spy.make ~config ~bar_reader:(bar_reader_of short_falling_bars) ()
+  in
+  let result =
+    run_once strat ~today_bar:squeeze_bar
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:pos ())
+  in
+  assert_that result
+    (is_exit
+       ~reason_ok:
+         (matching ~msg:"Expected StopLoss"
+            (function
+              | Trading_strategy.Position.StopLoss s -> Some s.actual_price
+              | _ -> None)
+            (float_equal (entry_price *. 2.0))))
+
+let test_short_covers_on_stage2_friday _ =
+  (* Holding a SHORT into a Stage-2 (rising-tape) Friday → cover via the stage
+     signal. The short is anchored at today's close/date so its seeded stop sits
+     just ABOVE today's counter-rally high (the short stop sits above entry),
+     and today's bar therefore does not breach it — isolating the stage-cover
+     path from the (higher-precedence) short-stop path. *)
+  let bars = weekly_closes ~last_friday ~n:n_weeks ~close:rising_closes in
+  let today = List.last_exn bars in
+  let pos =
+    make_holding ~side:Trading_strategy.Position.Short
+      ~entry_price:today.close_price ~entry_date:today.date ~quantity:300.0 ()
+  in
+  let config =
+    Spy.config_with ~enable_stage4_short:true ~ma_period_weeks:30 ()
+  in
+  let strat = Spy.make ~config ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:today
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:pos ())
+  in
+  assert_that result
+    (is_exit
+       ~reason_ok:
+         (matching ~msg:"Expected StrategySignal stage4_cover"
+            (function
+              | Trading_strategy.Position.StrategySignal s -> Some s.label
+              | _ -> None)
+            (equal_to "stage4_cover")))
+
 let suite =
   "spy_only_weinstein_strategy"
   >::: [
@@ -318,6 +450,12 @@ let suite =
          >:: test_stage1_friday_no_entry_when_flat;
          "trader preset enters where investor waits"
          >:: test_trader_preset_enters_where_investor_waits;
+         "Stage4 flat stays flat when short off"
+         >:: test_stage4_flat_stays_flat_when_short_off;
+         "Stage4 flat goes short when short on"
+         >:: test_stage4_flat_goes_short_when_on;
+         "short stop fires when holding" >:: test_short_stop_fires_when_holding;
+         "short covers on Stage2 Friday" >:: test_short_covers_on_stage2_friday;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What

Adds a **default-off** Stage-4 short leg to the SPY-only Weinstein reference strategy (`Spy_only_weinstein_strategy`). Config field `enable_stage4_short : bool` (default `false`). When ON, the strategy goes SHORT in Stage 4 instead of sitting flat; default OFF = bit-identical long/flat (R1, `experiment-flag-discipline.md`). Testbed-only — **NOT promoted** (R3).

Short mechanics (mirror of the long side):
- **Entry**: on a weekly close, flat + Stage-4 exit signal → short sized like the long (`floor(cash/close)`).
- **Stop**: `Weinstein_stops` with `~side:Short` — initial stop ABOVE the counter-rally high (or fallback `entry/buffer`), ratchets DOWN as price falls, triggered intraday by `high ≥ stop`.
- **Exit (cover)**: SPY leaves Stage 4 (re-enters Stage 1/2) OR short-stop hit. A flat Stage-2 read on the same Friday then opens a fresh long via the normal path.

Spine intact (W1): long side, stage classifier, and Stage-2 entry are untouched. Shorting Stage-4 declines is faithful Weinstein (book §Short-Selling Rules).

Files: `spy_only_weinstein_strategy.{ml,mli}`, `spy_only_transitions.{ml,mli}` (entry/exit builders parameterised by side), new `spy_only_signals.{ml,mli}` (pure stage-signal predicates, extracted to keep the strategy module ≤300 lines), `strategy_choice.{ml,mli}` + `panel_runner.ml` (thread `enable_stage4_short` so a scenario can express `(enable_stage4_short true)`), scenario `spy-longshort.sexp`, status `dev/status/spy-only-reference.md`.

## Build + test

- FULL `dune build` (repo-root, committed tree): **exit 0**.
- FULL `dune build && dune runtest` (clean run): **exit 0** — file-length, nesting, fn-length, magic-numbers, mli-coverage, fmt all OK.
- 12 strategy unit tests pass (4 new: bit-identical-when-off, flag-on-goes-short with sizing, short-stop-fires, short-covers-on-Stage2).

## Bit-identical when off

Pinned by `test_stage4_flat_stays_flat_when_short_off` (flag false + Stage-4 flat → no transitions) and the unchanged existing Stage-4 long-exit test. Default config carries `enable_stage4_short = false`; scenarios omitting the field deserialise to long/flat.

## Headline: does the short leg lower MaxDD vs the long/flat twin? **NO — it raises it on BOTH windows.**

| window | scenario | Return | Sharpe | Calmar | **MaxDD** | Win% | trades | avg-win% | avg-loss% | win/loss ratio |
|---|---|---|---|---|---|---|---|---|---|---|
| 2009-2026 (post-GFC bull) | long/flat | 317.9% | 0.77 | 0.48 | **18.8%** | 70.0% | 10 | 23.70 | -3.26 | 7.27 |
| 2009-2026 | long-short | 98.1% | 0.35 | 0.13 | **32.6%** | 36.0% | 25 | 18.68 | -5.26 | 3.55 |
| 1995-2025 (deep: dot-com + GFC + COVID) | long/flat | 1168.8% | 0.73 | 0.35 | **24.3%** | 52.4% | 21 | 30.79 | -2.81 | 10.97 |
| 1995-2025 | long-short | 593.1% | 0.47 | 0.18 | **35.7%** | 37.5% | 48 | 21.97 | -4.60 | 4.77 |

Deep window run on the cost-test deep SPY (`1993-01-29 .. 2026-05-29`); committed `test_data/S/Y/SPY/` is 2009-2026.

Decomposition (deep, the smoking gun): of 48 long-short trades the 21 LONGs are bit-identical to the long/flat twin; the **27 SHORTs win only 25.9%** (avg-win +8.1% / avg-loss -5.5%) — a losing, drawdown-raising overlay. Same failure mode as the SP500 multi-symbol long-short: Stage-4 shorts get squeezed on fast-V bounces. Even on the macro-regime-diverse deep window (where shorting should help most), the short leg halves return and raises MaxDD 24.3% → 35.7%.

Verdict: keep `enable_stage4_short = false`. Shorting a single clean instrument in sustained Stage-4 bears does NOT beat the long/flat twin's drawdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)