### PR TITLE
chore: gitignore fetched bars + in-container backtest outputs (jj-wipe guardrail)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,28 @@ dev/backtest/**/steps.csv
 
 # Scenario runner output dirs are timestamped per-run artefacts
 # (trades.csv, trade_audit.sexp, summary.sexp, etc.); regenerable and large.
+# NOTE: the runner's _repo_root resolves to the dune root (.../trading) when
+# invoked in-container, so outputs land under BOTH paths depending on cwd —
+# ignore both. (The trading/-prefixed path was previously un-ignored, which let
+# a concurrent jj-writing agent wipe an in-flight run's output dir mid-write and
+# crash the backtest — see memory/feedback_no_parent_backtest_during_jj_agent.)
 dev/backtest/scenarios-*/
+trading/dev/backtest/scenarios-*/
+# Ad-hoc diagnostic scenario scratch dirs (scenario sexps are reproducible from
+# the diagnosis docs; their run outputs are large + regenerable).
+dev/backtest/*-diag/
+dev/backtest/*-gate/
+dev/backtest/broad-lever1/
+trading/dev/backtest/
+
+# Fetched experiment bars: the canonical store tracks only committed golden
+# symbols; broad/sector/experiment fetches (e.g. top-3000, SPDR sectors) are
+# ephemeral local inputs (the ops-data agent writes them untracked, 100s of MB).
+# Ignoring NEW data files protects them from jj tree-op wipes AND keeps the repo
+# lean. Already-tracked golden bars are UNAFFECTED (gitignore is consulted only
+# for untracked files). To commit a new golden's bars deliberately: `git add -f`.
+trading/test_data/**/data.csv
+trading/test_data/**/data.metadata.sexp
 
 .claude/worktrees/
 


### PR DESCRIPTION
Prevents the jj-contamination class that wiped fetched bars + crashed an in-flight backtest this session.

**Two bugs fixed:**
1. The runner's `_repo_root` resolves to the dune root (`.../trading`) in-container, so scenario outputs land under `trading/dev/backtest/scenarios-*` — which the existing root-anchored `dev/backtest/scenarios-*/` rule did NOT match. A concurrent jj-writing agent then wiped an in-flight run's untracked output dir mid-write and crashed it. Now both paths (+ ad-hoc `*-diag`/`*-gate` scratch dirs) are ignored.
2. Fetched experiment bars (top-3000, SPDR sectors — 100s of MB, ephemeral local inputs) were untracked-not-ignored, so any jj tree op deleted them. Now `trading/test_data/**/data.csv` + `data.metadata.sexp` are ignored.

**Safety verified:** the 650 committed golden bars stay tracked (gitignore is consulted only for untracked files — `git status` shows no change to them; `git ls-files` still counts 650). New fetches become ignored → survive jj ops. To commit a new golden's bars deliberately: `git add -f`.

Pairs with `memory/feedback_no_parent_backtest_during_jj_agent`. .gitignore-only — no code/test surface (QC N/A); CI runs the linters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)