### PR TITLE
feat(weinstein): macro-gate dial on sector-rotation (default-off)

### DIFF
--- a/trading/test_data/backtest_scenarios/sector-rotation-k3-macrogate.sexp
+++ b/trading/test_data/backtest_scenarios/sector-rotation-k3-macrogate.sexp
@@ -1,0 +1,37 @@
+;; perf-tier: research
+;; perf-tier-rationale: Sector-rotation Weinstein stage-timing reference strategy
+;; (long/flat), INVESTOR preset (30-week MA), K=3 — hold the top-3 strongest
+;; Stage-2 SPDR sector ETF ranked by RS vs SPY. 12-symbol universe (11 sectors +
+;; SPY benchmark), so the run is fast despite the long 2009-2025 window. NOT a
+;; pinned golden — wide expected bands; this is a direction-finding / selection
+;; diagnostic (the multi-symbol generalization of spy-investor.sexp).
+;;
+;; Strategy: [Sector_rotation_weinstein (k 3) (ma_period_weeks 30)
+;;   (enable_macro_gate true)] — see
+;; [trading/trading/weinstein/strategy/lib/sector_rotation_weinstein_strategy.mli].
+;; Each Friday it classifies every tradable sector ETF's own 30wk-MA stage,
+;; keeps the Stage-2 names, ranks them by RS vs SPY, and holds the top-3:
+;;   - enters the top-3 Stage-2 sectors (cash split equally across open slots) when a slot is open,
+;;   - exits a held sector when it leaves the top-3 set or rolls to Stage 3/4, or
+;;   - exits on a Weinstein trailing-stop hit (checked every day).
+;; The MACRO GATE is ON: on any Friday where SPY itself is in Stage 4, no new
+;; sector entries open and every held sector is force-flat (spine item 6). The
+;; gate-off twin is sector-rotation-k3.sexp.
+;; Long/flat only — no shorting, no portfolio-risk sizing. SPY is the RS
+;; benchmark and is never traded. The spine (Stage-2-only entry, Stage 3/4 exit,
+;; stop below base, RS for selection, macro gate) is faithful.
+((name "sector-rotation-k3-macrogate")
+ (description "Sector-rotation Weinstein investor preset (30wk MA, long/flat), K=3 + MACRO GATE — top-3 Stage-2 SPDR sectors by RS vs SPY, SPY-Stage-4 blocks buys + forces flat, 2009-06-01 to 2025-12-31.")
+ (period ((start_date 2009-06-01) (end_date 2025-12-31)))
+ (universe_path "universes/spdr-sectors-11-plus-spy.sexp")
+ (universe_size 12)
+ (config_overrides ())
+ (strategy (Sector_rotation_weinstein (k 3) (ma_period_weeks 30) (enable_macro_gate true)))
+ (expected
+  ((total_return_pct       ((min -90.0)    (max 5000.0)))
+   (total_trades           ((min   0.0)    (max  500.0)))
+   (win_rate               ((min   0.0)    (max  100.0)))
+   (sharpe_ratio           ((min  -2.0)    (max    5.0)))
+   (max_drawdown_pct       ((min   0.0)    (max   95.0)))
+   (avg_holding_days       ((min   0.0)    (max 5000.0)))
+   (wall_seconds           ((min   0.5)    (max 3600.0))))))

--- a/trading/trading/backtest/lib/panel_strategy_builder.ml
+++ b/trading/trading/backtest/lib/panel_strategy_builder.ml
@@ -17,6 +17,8 @@ let build ~ad_bars ~ticker_sectors ~config ~strategy_choice ~bar_reader
         Spy_only.config_with ~symbol ~enable_stage4_short ~ma_period_weeks ()
       in
       Spy_only.make ~config ~bar_reader ()
-  | Sector_rotation_weinstein { k; ma_period_weeks } ->
-      let config = Sector_rotation.config_with ~k ~ma_period_weeks () in
+  | Sector_rotation_weinstein { k; ma_period_weeks; enable_macro_gate } ->
+      let config =
+        Sector_rotation.config_with ~k ~ma_period_weeks ~enable_macro_gate ()
+      in
       Sector_rotation.make ~config ~bar_reader ()

--- a/trading/trading/backtest/lib/strategy_choice.ml
+++ b/trading/trading/backtest/lib/strategy_choice.ml
@@ -16,6 +16,11 @@ let default_spy_enable_stage4_short = false
 let default_sector_rotation_k = 1
 let default_sector_rotation_ma_period_weeks = 30
 
+(* Macro gate off by default: a scenario that omits [enable_macro_gate] gets the
+   ungated selection-only sector strategy, bit-identical to the pre-gate
+   behaviour. *)
+let default_sector_rotation_enable_macro_gate = false
+
 type t =
   | Weinstein
   | Bah_benchmark of { symbol : string }
@@ -28,6 +33,8 @@ type t =
       k : int; [@sexp.default default_sector_rotation_k]
       ma_period_weeks : int;
           [@sexp.default default_sector_rotation_ma_period_weeks]
+      enable_macro_gate : bool;
+          [@sexp.default default_sector_rotation_enable_macro_gate]
     }
 [@@deriving sexp, eq, show]
 
@@ -39,5 +46,6 @@ let name = function
   | Spy_only_weinstein { symbol; ma_period_weeks; enable_stage4_short } ->
       sprintf "Spy_only_weinstein(%s,ma=%dwk%s)" symbol ma_period_weeks
         (if enable_stage4_short then ",short" else "")
-  | Sector_rotation_weinstein { k; ma_period_weeks } ->
-      sprintf "Sector_rotation_weinstein(k=%d,ma=%dwk)" k ma_period_weeks
+  | Sector_rotation_weinstein { k; ma_period_weeks; enable_macro_gate } ->
+      sprintf "Sector_rotation_weinstein(k=%d,ma=%dwk%s)" k ma_period_weeks
+        (if enable_macro_gate then ",macrogate" else "")

--- a/trading/trading/backtest/lib/strategy_choice.mli
+++ b/trading/trading/backtest/lib/strategy_choice.mli
@@ -66,6 +66,7 @@ type t =
   | Sector_rotation_weinstein of {
       k : int; [@sexp.default 1]
       ma_period_weeks : int; [@sexp.default 30]
+      enable_macro_gate : bool; [@sexp.default false]
     }
       (** Sector-rotation Weinstein stage-timing reference strategy — the
           multi-symbol generalization of {!Spy_only_weinstein}. Constructs
@@ -75,19 +76,25 @@ type t =
           them by relative strength vs SPY, and holds the top [k]; held names
           that leave the top-[k] set or roll into Stage 3/4 exit to flat, and a
           per-symbol Weinstein trailing stop is checked daily. Long/flat only —
-          no shorting, no macro gate, no portfolio-risk sizing (cash is
-          equal-weighted across the entry slots filled each Friday). The default
-          tradable symbols are the 11 SPDR sector ETFs and the benchmark is SPY;
-          all must be present in the scenario's universe so the bar reader loads
-          their bars (SPY is the RS benchmark and is never traded). See
+          no shorting, no portfolio-risk sizing (cash is equal-weighted across
+          the entry slots filled each Friday). The default tradable symbols are
+          the 11 SPDR sector ETFs and the benchmark is SPY; all must be present
+          in the scenario's universe so the bar reader loads their bars (SPY is
+          the RS benchmark and is never traded). See
           {!Weinstein_strategy.Sector_rotation_weinstein_strategy.config}.
 
           [k] ([@sexp.default 1]) is the maximum number of concurrent holdings.
           [ma_period_weeks] ([@sexp.default 30], the investor preset) is the
           Weinstein-faithful MA dial (per
           [.claude/rules/weinstein-faithful-core.md]); [10] is the trader
-          preset. The strategy spine (Stage-2-only entry, Stage 3/4 exit, stop
-          below base, RS for selection) is untouched by both dials. *)
+          preset. [enable_macro_gate] ([@sexp.default false]) turns on the
+          broad-tape macro gate: when SPY itself is in Stage 4, new sector buys
+          are blocked and held sectors are forced flat (Weinstein spine item 6,
+          omitted from the bare testbed to isolate selection). Default-off keeps
+          every pre-existing sector scenario bit-identical; it is a searchable
+          dial per [.claude/rules/experiment-flag-discipline.md]. The strategy
+          spine (Stage-2-only entry, Stage 3/4 exit, stop below base, RS for
+          selection) is untouched by all dials. *)
 [@@deriving sexp, eq, show]
 
 val default : t

--- a/trading/trading/weinstein/strategy/lib/sector_rotation_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/sector_rotation_weinstein_strategy.ml
@@ -12,6 +12,7 @@ type config = {
   stops_config : Weinstein_stops.config;
   rs_config : Rs.config;
   fallback_stop_buffer : float;
+  enable_macro_gate : bool;
 }
 
 let name = "SectorRotationWeinstein"
@@ -26,6 +27,7 @@ let default_symbols =
 let default_benchmark_symbol = "SPY"
 let default_k = 1
 let default_fallback_stop_buffer = 0.92
+let default_enable_macro_gate = false
 
 let default_config =
   {
@@ -36,10 +38,12 @@ let default_config =
     stops_config = Weinstein_stops.default_config;
     rs_config = Rs.default_config;
     fallback_stop_buffer = default_fallback_stop_buffer;
+    enable_macro_gate = default_enable_macro_gate;
   }
 
 let config_with ?(symbols = default_symbols)
-    ?(benchmark_symbol = default_benchmark_symbol) ~k ~ma_period_weeks () =
+    ?(benchmark_symbol = default_benchmark_symbol)
+    ?(enable_macro_gate = default_enable_macro_gate) ~k ~ma_period_weeks () =
   {
     default_config with
     symbols;
@@ -47,6 +51,7 @@ let config_with ?(symbols = default_symbols)
     k;
     stage_config =
       { default_config.stage_config with ma_period = ma_period_weeks };
+    enable_macro_gate;
   }
 
 (* Number of weekly bars fed to [Stage.classify] / [Rs.analyze]: twice the MA
@@ -135,13 +140,47 @@ let _target_set ~config ~bar_reader ~prior_stage ~(as_of : Date.t) :
   in
   Sector_rotation_signals.rank_top_k ~candidates ~k:config.k
 
-(* The target set for this tick: the top-[k] Stage-2 names on a weekly close
-   (which also refreshes [prior_stage] for all symbols), else empty (no rotation
-   decision mid-week). [as_of] anchors the weekly reads. *)
+let _is_stage4 (stage : Weinstein_types.stage) : bool =
+  match stage with Weinstein_types.Stage4 _ -> true | _ -> false
+
+(* The broad-tape macro gate (spine item 6). When [enable_macro_gate] is on and
+   the benchmark (e.g. SPY) is itself in Stage 4, new buys are blocked and held
+   sectors are forced flat. Returns [true] iff the gate fires. Classifies the
+   benchmark on its own weekly bars, threading [prior_stage] keyed by the
+   benchmark symbol for flat-MA continuity; a benchmark still in warmup (no
+   bars) never gates. Default-off, so the strategy is bit-identical to the
+   ungated testbed unless a scenario opts in. *)
+let _macro_blocks ~config ~bar_reader ~prior_stage ~(as_of : Date.t) : bool =
+  if not config.enable_macro_gate then false
+  else
+    let prior = Map.find !prior_stage config.benchmark_symbol in
+    match
+      _classify_stage ~config ~bar_reader ~prior ~symbol:config.benchmark_symbol
+        ~as_of
+    with
+    | None -> false
+    | Some r ->
+        prior_stage :=
+          Map.set !prior_stage ~key:config.benchmark_symbol ~data:r.stage;
+        _is_stage4 r.stage
+
+(* The Friday target: the top-[k] Stage-2 names by RS (computing it also
+   refreshes [prior_stage] for every tradable symbol), forced empty when the
+   macro gate fires. An empty target both blocks entries and, via the
+   rotation-out path in [Sector_rotation_transitions.holding_exits], force-flats
+   every held sector. *)
+let _weekly_target ~config ~bar_reader ~prior_stage ~(as_of : Date.t) :
+    String.Set.t =
+  let base = _target_set ~config ~bar_reader ~prior_stage ~as_of in
+  if _macro_blocks ~config ~bar_reader ~prior_stage ~as_of then String.Set.empty
+  else base
+
+(* The target set for this tick: the Friday target on a weekly close, else empty
+   (no rotation decision mid-week). [as_of] anchors the weekly reads. *)
 let _target_for_tick ~config ~bar_reader ~prior_stage ~(as_of : Date.t) :
     String.Set.t =
   if _is_weekly_close ~date:as_of then
-    _target_set ~config ~bar_reader ~prior_stage ~as_of
+    _weekly_target ~config ~bar_reader ~prior_stage ~as_of
   else String.Set.empty
 
 (* One tick's transitions, anchored at [date]: exit rotated-out / Stage-4 /

--- a/trading/trading/weinstein/strategy/lib/sector_rotation_weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/sector_rotation_weinstein_strategy.mli
@@ -81,6 +81,20 @@ type config = {
           [entry_price *. fallback_stop_buffer] when the support-floor lookup
           finds no qualifying correction. Default
           {!default_fallback_stop_buffer} ([0.92] = an 8% stop). *)
+  enable_macro_gate : bool;
+      (** Broad-tape macro gate (Weinstein spine item 6). Default
+          {!default_enable_macro_gate} ([false] — the ungated testbed,
+          bit-identical to the pre-gate strategy). When [true], on each Friday
+          the {!benchmark_symbol} (e.g. SPY) is itself stage-classified, and if
+          it is in {b Stage 4} the gate fires: no new sector entries open and
+          every held sector is forced flat (mechanically, the Friday target set
+          is forced empty — this both suppresses entries and routes every
+          holding through the rotation-out exit in
+          {!Sector_rotation_transitions.holding_exits}). This is the faithful
+          "bearish tape blocks buys / get out" rule (weinstein-book-reference.md
+          §Macro Analysis) the bare testbed omits. A {e default-off dial} per
+          [.claude/rules/experiment-flag-discipline.md] R1/R2: a config field,
+          searchable as an axis, not wired on until a ledger ACCEPT (R3). *)
 }
 
 val name : string
@@ -100,22 +114,30 @@ val default_fallback_stop_buffer : float
 (** [0.92] — an 8% loose initial stop, matching Weinstein's 8% correction rule
     (book §5.1) when no structural support floor is available. *)
 
+val default_enable_macro_gate : bool
+(** [false] — the macro gate is off by default, keeping the strategy
+    bit-identical to the ungated selection-only testbed. *)
+
 val default_config : config
 (** [default_config] uses {!default_symbols}, {!default_benchmark_symbol},
     {!default_k}, {!Stage.default_config}, {!Weinstein_stops.default_config},
-    {!Rs.default_config}, and {!default_fallback_stop_buffer}. *)
+    {!Rs.default_config}, {!default_fallback_stop_buffer}, and
+    {!default_enable_macro_gate}. *)
 
 val config_with :
   ?symbols:string list ->
   ?benchmark_symbol:string ->
+  ?enable_macro_gate:bool ->
   k:int ->
   ma_period_weeks:int ->
   unit ->
   config
-(** [config_with ?symbols ?benchmark_symbol ~k ~ma_period_weeks ()] is
-    {!default_config} with [k] holdings and the stage-classifier moving-average
-    period overridden to [ma_period_weeks] weeks (and optionally a different
-    tradable [symbols] list / [benchmark_symbol]).
+(** [config_with ?symbols ?benchmark_symbol ?enable_macro_gate ~k
+     ~ma_period_weeks ()] is {!default_config} with [k] holdings and the
+    stage-classifier moving-average period overridden to [ma_period_weeks] weeks
+    (and optionally a different tradable [symbols] list / [benchmark_symbol],
+    and the macro gate flipped on via [enable_macro_gate], default
+    {!default_enable_macro_gate} = [false]).
 
     The MA period is the Weinstein-faithful dial distinguishing the investor
     preset ([30] weeks) from the trader preset ([10] weeks). Only

--- a/trading/trading/weinstein/strategy/test/test_sector_rotation_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_sector_rotation_weinstein_strategy.ml
@@ -148,6 +148,16 @@ let config_k ~k ~symbols =
   Sector.config_with ~k ~ma_period_weeks:30 ~symbols ~benchmark_symbol:benchmark
     ()
 
+(* Same as [config_k] but with the broad-tape macro gate turned on. *)
+let config_gate ~k ~symbols =
+  Sector.config_with ~k ~ma_period_weeks:30 ~symbols ~benchmark_symbol:benchmark
+    ~enable_macro_gate:true ()
+
+(* A benchmark (SPY) in Stage 4 — a steadily falling tape — used to fire the
+   macro gate. Distinct from [spy_bars] (rising = Stage 2). *)
+let spy_stage4_bars =
+  weekly_closes ~last_friday ~n:n_weeks ~close:(falling ~peak:140.0)
+
 (* ---------------------------------------------------------------- *)
 (* Tests.                                                            *)
 (* ---------------------------------------------------------------- *)
@@ -411,6 +421,100 @@ let test_mid_week_no_rotation _ =
     (is_ok_and_holds
        (field (fun (o : Strategy_interface.output) -> o.transitions) is_empty))
 
+let test_macro_gate_blocks_entry _ =
+  (* Gate ON and SPY itself in Stage 4: a Stage-2 sector (XLK, high RS vs the
+     falling benchmark) that would normally be entered is blocked — the macro
+     gate forces the target set empty. *)
+  let xlk = stage2_bars ~slope:2.0 in
+  let bar_reader =
+    bar_reader_of [ (benchmark, spy_stage4_bars); ("XLK", xlk) ]
+  in
+  let strat =
+    Sector.make ~config:(config_gate ~k:1 ~symbols:[ "XLK" ]) ~bar_reader ()
+  in
+  let result =
+    run_once strat
+      ~today_bars:[ ("XLK", friday_bar xlk) ]
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field (fun (o : Strategy_interface.output) -> o.transitions) is_empty))
+
+let test_macro_gate_force_exits_holding _ =
+  (* Gate ON and SPY in Stage 4: a held Stage-2 sector (XLK) that would normally
+     stay (it is the top-1 target) is force-flat via the rotation-out path
+     because the gate empties the target. Entry anchored at today's close so the
+     trailing stop does not fire — isolating the macro force-exit. No entry. *)
+  let xlk = stage2_bars ~slope:2.0 in
+  let today = friday_bar xlk in
+  let pos =
+    make_holding ~symbol:"XLK" ~entry_price:today.close_price
+      ~entry_date:today.date ~quantity:100.0 ()
+  in
+  let bar_reader =
+    bar_reader_of [ (benchmark, spy_stage4_bars); ("XLK", xlk) ]
+  in
+  let strat =
+    Sector.make ~config:(config_gate ~k:1 ~symbols:[ "XLK" ]) ~bar_reader ()
+  in
+  let result =
+    run_once strat
+      ~today_bars:[ ("XLK", today) ]
+      ~portfolio:(make_portfolio ~cash:0.0 ~positions:[ pos ] ())
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun (o : Strategy_interface.output) -> o.transitions)
+          (elements_are
+             [
+               field
+                 (fun (t : Position.transition) -> (t.position_id, t.kind))
+                 (matching
+                    ~msg:"Expected macro force-flat (rotation_out) on XLK"
+                    (function
+                      | id, Position.TriggerExit e -> (
+                          match e.exit_reason with
+                          | Position.StrategySignal s -> Some (id, s.label)
+                          | _ -> None)
+                      | _ -> None)
+                    (equal_to ("XLK-sector-rotation-weinstein", "rotation_out")));
+             ])))
+
+let test_macro_gate_off_ignores_benchmark_stage _ =
+  (* Gate OFF (default) with SPY in Stage 4: the benchmark's stage is irrelevant,
+     so the Stage-2 XLK is entered exactly as it would be under a rising
+     benchmark — proving the gate is a true no-op when off. *)
+  let xlk = stage2_bars ~slope:2.0 in
+  let bar_reader =
+    bar_reader_of [ (benchmark, spy_stage4_bars); ("XLK", xlk) ]
+  in
+  let strat =
+    Sector.make ~config:(config_k ~k:1 ~symbols:[ "XLK" ]) ~bar_reader ()
+  in
+  let result =
+    run_once strat
+      ~today_bars:[ ("XLK", friday_bar xlk) ]
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that (entered_symbols result) (equal_to [ "XLK" ])
+
+let test_macro_gate_dormant_when_benchmark_not_stage4 _ =
+  (* Gate ON but SPY in Stage 2 (rising): the gate is dormant (it fires only on a
+     Stage-4 benchmark), so normal selection proceeds and XLK is entered. *)
+  let xlk = stage2_bars ~slope:2.0 in
+  let bar_reader = bar_reader_of [ (benchmark, spy_bars); ("XLK", xlk) ] in
+  let strat =
+    Sector.make ~config:(config_gate ~k:1 ~symbols:[ "XLK" ]) ~bar_reader ()
+  in
+  let result =
+    run_once strat
+      ~today_bars:[ ("XLK", friday_bar xlk) ]
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that (entered_symbols result) (equal_to [ "XLK" ])
+
 let suite =
   "sector_rotation_weinstein_strategy"
   >::: [
@@ -422,6 +526,13 @@ let suite =
          "stop hit exits holding" >:: test_stop_hit_exits_holding;
          "no Stage2 means no entry" >:: test_no_stage2_no_entry;
          "mid-week does not rotate" >:: test_mid_week_no_rotation;
+         "macro gate blocks entry" >:: test_macro_gate_blocks_entry;
+         "macro gate force-exits holding"
+         >:: test_macro_gate_force_exits_holding;
+         "macro gate off ignores benchmark stage"
+         >:: test_macro_gate_off_ignores_benchmark_stage;
+         "macro gate dormant when benchmark not Stage4"
+         >:: test_macro_gate_dormant_when_benchmark_not_stage4;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
Adds `enable_macro_gate` (default **false**) to `Sector_rotation_weinstein`. When on, the benchmark (SPY) is stage-classified each Friday; if SPY is itself in **Stage 4** the gate fires — the Friday target set is forced empty, which both **blocks new sector entries** and **force-flats every held sector** (via the rotation-out path in `holding_exits`). This is the Weinstein-faithful broad-tape macro gate (spine item 6) the selection-only testbed deliberately stripped; re-adding it as a dial is *more* faithful, not less.

**Motivation** (`dev/notes/sector-rotation-k-ladder-2026-06-02.md`): sector-k3 beats buy-and-hold on every risk metric in both bull (2009-25) and deep (2000-25) windows, but its only weakness vs the SPY-only floor is the 28-32% drawdown it eats in bears. The macro gate is the hypothesised fix — block buys / get out when the broad tape is Stage 4.

**Discipline:** default-off per `experiment-flag-discipline.md` R1/R2 (a real `config` field, searchable as an axis); not wired on until a grid-robust ledger ACCEPT (R3, `promotion-confirmation.md`). Every pre-existing sector scenario deserialises bit-identically.

**Wiring:** `Strategy_choice.Sector_rotation_weinstein` gains `enable_macro_gate [@sexp.default false]`; `panel_strategy_builder` threads it. New scenario `sector-rotation-k3-macrogate.sexp`.

**Test plan** (4 new, 12/12 sector tests pass):
- `macro_gate_blocks_entry` — gate ON + SPY Stage 4 ⇒ a Stage-2 sector is NOT entered.
- `macro_gate_force_exits_holding` — gate ON + SPY Stage 4 ⇒ a held Stage-2 sector is force-flat (rotation_out).
- `macro_gate_off_ignores_benchmark_stage` — gate OFF + SPY Stage 4 ⇒ normal entry (no-op proof).
- `macro_gate_dormant_when_benchmark_not_stage4` — gate ON + SPY Stage 2 ⇒ gate dormant, normal entry.

Linters green locally: nesting / fn-length / file-length / mli-coverage / fmt (main module 240 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)