### PR TITLE
feat(screener): min_price liquidity floor (default-off)

### DIFF
--- a/dev/status/screener.md
+++ b/dev/status/screener.md
@@ -1,9 +1,11 @@
 # Status: screener
 
-## Last updated: 2026-06-01
+## Last updated: 2026-06-02
 
 ## Status
 MERGED
+
+**2026-06-02**: `feat(screener): min_price liquidity floor (default-off)` (branch `feat/screener-min-price`, PR #1428, OPEN) — adds `Screener.config.min_price : float [@sexp.default 0.0]`, a default-off liquidity floor that excludes penny / illiquid names from buy and short candidates (faithful screener filter; Weinstein trades liquid leaders — book §4.2). `0.0` = no floor, bit-identical to pre-floor behaviour; positive values (1/5/10) exclude candidates whose setup price (`breakout_price` longs / `breakdown_price` shorts) is below the floor or unknown. Gate helper `Screener_admission.passes_price_floor` (kept out of the already-large `screener.ml`); threaded through `_long_candidate`/`_short_candidate`/`_evaluate_*`/`screen`/`screen_with_cooldown` mirroring `min_score_override`, folds into the breakout/breakdown diagnostics phase. Reachable from the scenario/strategy override path via `((screening_config ((min_price 5.0))))` (two deep-merge tests in `test_runner_hypothesis_overrides.ml`). 6 new `test_screener.ml` cases (no-op / floor-rejects-below / short-side / missing-price). Note: brief assumed a `Stock_analysis.t.get_high` accessor that doesn't exist on main — gated on the `float option` setup price instead (matches the `None`-rejection semantics). **Follow-up:** wire `min_price` into the automated tuner sweep surface (`grid_search` / `bayesian_runner_spec`).
 
 **2026-06-01**: `feat(weinstein): neutral_blocks_longs default-off entry-gate axis` (branch `feat/neutral-blocks-longs-axis`, OPEN) — lever #2 of the Cell E 2020-2026 stall diagnosis. Adds `Screener.config.neutral_blocks_longs : bool [@sexp.default false]` plus a mirrored top-level `Weinstein_strategy.config.neutral_blocks_longs` field threaded into `screening_config` at screen time. When `true`, a macro-`Neutral` tape blocks new long candidates exactly as `Bearish` does (only `Bullish` admits longs); default `false` preserves the historical gate bit-equally. The short-side gate is unaffected. A *tightening* of Weinstein's unconditional macro gate (a faithful dial, spine intact). Default-off axis per `.claude/rules/experiment-flag-discipline.md` — proven `Variant_matrix`-expressible (`(flag neutral_blocks_longs)`) by `test_variant_matrix.ml`. No default flipped; no golden config_overrides touched. Tests: bit-identical-when-off + flag-on-blocks-Neutral + Bullish-unaffected + short-side-unchanged in `test_screener_e2e.ml`.
 

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -45,6 +45,7 @@ type config = {
   max_short_candidates : int;
   cascade_post_stop_cooldown_weeks : int; [@sexp.default 0]
   neutral_blocks_longs : bool; [@sexp.default false]
+  min_price : float; [@sexp.default 0.0]
 }
 [@@deriving sexp]
 
@@ -61,6 +62,7 @@ let default_config =
     max_short_candidates = 10;
     cascade_post_stop_cooldown_weeks = 0;
     neutral_blocks_longs = false;
+    min_price = 0.0;
   }
 
 type scored_candidate = {
@@ -159,10 +161,13 @@ let _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
       (_build_candidate ~params ~sector ~a ~score ~reasons ~thresholds ~is_short)
 
 (** Evaluate one (analysis, sector) pair as a long candidate. Returns [None] if
-    excluded by the sector gate, breakout test, volume band, or score floor. *)
+    excluded by the price floor, sector gate, breakout test, volume band, or
+    score floor. *)
 let _long_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
-  if equal_sector_rating sector.rating Weak then None
+    ~max_score_override ~volume_ratio_exclude_range ~min_price (a, sector) =
+  if not (passes_price_floor ~min_price ~price:a.Stock_analysis.breakout_price)
+  then None
+  else if equal_sector_rating sector.rating Weak then None
   else if not (Stock_analysis.is_breakout_candidate a) then None
   else if not (passes_volume_band ~excl:volume_ratio_exclude_range a) then None
   else
@@ -172,8 +177,10 @@ let _long_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
 (** Evaluate one (analysis, sector) pair as a short candidate. Bearish/Neutral
     only: score must pass {!Screener_admission.passes_score_floor}. *)
 let _short_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
-  if equal_sector_rating sector.rating Strong then None
+    ~max_score_override ~volume_ratio_exclude_range ~min_price (a, sector) =
+  if not (passes_price_floor ~min_price ~price:a.Stock_analysis.breakdown_price)
+  then None
+  else if equal_sector_rating sector.rating Strong then None
   else if not (Stock_analysis.is_breakdown_candidate a) then None
   else if rs_blocks_short a.Stock_analysis.rs then None
   else if not (passes_volume_band ~excl:volume_ratio_exclude_range a) then None
@@ -242,26 +249,29 @@ let _longs_admitted_by_macro ~neutral_blocks_longs macro_trend =
 
 (** Filter, score, grade, sort, and cap long candidates. *)
 let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range ~max_buy_candidates
-    ~neutral_blocks_longs ~candidates ~macro_trend : scored_candidate list =
+    ~max_score_override ~volume_ratio_exclude_range ~min_price
+    ~max_buy_candidates ~neutral_blocks_longs ~candidates ~macro_trend :
+    scored_candidate list =
   if not (_longs_admitted_by_macro ~neutral_blocks_longs macro_trend) then []
   else
     let candidate_fn =
       _long_candidate ~weights ~thresholds ~params ~min_grade
         ~min_score_override ~max_score_override ~volume_ratio_exclude_range
+        ~min_price
     in
     _filter_and_cap ~candidate_fn ~max_n:max_buy_candidates candidates
 
 (** Filter, score, grade, sort, and cap short candidates. *)
 let _evaluate_shorts ~weights ~thresholds ~params ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range ~max_short_candidates
-    ~candidates ~macro_trend : scored_candidate list =
+    ~max_score_override ~volume_ratio_exclude_range ~min_price
+    ~max_short_candidates ~candidates ~macro_trend : scored_candidate list =
   match macro_trend with
   | Bullish -> []
   | Bearish | Neutral ->
       let candidate_fn =
         _short_candidate ~weights ~thresholds ~params ~min_grade
           ~min_score_override ~max_score_override ~volume_ratio_exclude_range
+          ~min_price
       in
       _filter_and_cap ~candidate_fn ~max_n:max_short_candidates candidates
 
@@ -293,17 +303,17 @@ let _resolve_sector ~sector_map ticker =
     [screen] so the latter stays within the 50-line linter cap. *)
 let _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade
     ~min_score_override ~max_score_override ~volume_ratio_exclude_range
-    ~total_stocks ~candidates_after_held ~macro_trend ~candidates
+    ~min_price ~total_stocks ~candidates_after_held ~macro_trend ~candidates
     ~buy_candidates ~short_candidates =
   let long_phases =
     count_long_phases ~weights ~thresholds:grade_thresholds ~min_grade
       ~min_score_override ~max_score_override ~volume_ratio_exclude_range
-      ~candidates
+      ~min_price ~candidates
   in
   let short_phases =
     count_short_phases ~weights ~thresholds:grade_thresholds ~min_grade
       ~min_score_override ~max_score_override ~volume_ratio_exclude_range
-      ~candidates
+      ~min_price ~candidates
   in
   Screener_cascade_diagnostics.build ~total_stocks ~candidates_after_held
     ~macro_trend ~long_phases ~short_phases
@@ -344,7 +354,7 @@ let _evaluate_candidates ~config ~candidates ~macro_trend =
       ~min_score_override:config.min_score_override
       ~max_score_override:config.max_score_override
       ~volume_ratio_exclude_range:config.volume_ratio_exclude_range
-      ~max_buy_candidates:config.max_buy_candidates
+      ~min_price:config.min_price ~max_buy_candidates:config.max_buy_candidates
       ~neutral_blocks_longs:config.neutral_blocks_longs ~candidates ~macro_trend
   in
   let short_candidates =
@@ -353,6 +363,7 @@ let _evaluate_candidates ~config ~candidates ~macro_trend =
       ~min_score_override:config.min_score_override
       ~max_score_override:config.max_score_override
       ~volume_ratio_exclude_range:config.volume_ratio_exclude_range
+      ~min_price:config.min_price
       ~max_short_candidates:config.max_short_candidates ~candidates ~macro_trend
   in
   (buy_candidates, short_candidates)
@@ -386,8 +397,8 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
         ~min_score_override:config.min_score_override
         ~max_score_override:config.max_score_override
         ~volume_ratio_exclude_range:config.volume_ratio_exclude_range
-        ~total_stocks ~candidates_after_held ~macro_trend ~candidates
-        ~buy_candidates ~short_candidates;
+        ~min_price:config.min_price ~total_stocks ~candidates_after_held
+        ~macro_trend ~candidates ~buy_candidates ~short_candidates;
   }
 
 let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -175,6 +175,25 @@ type config = {
           diagnosis). Mirrored from the top-level
           [Weinstein_strategy.config.neutral_blocks_longs] field so the flag is
           a [Variant_matrix] axis. *)
+  min_price : float; [@sexp.default 0.0]
+      (** Minimum candidate price to admit — a liquidity floor. [0.0] (default)
+          = no floor, bit-identical to pre-floor behaviour. A positive value
+          excludes candidates whose setup price ([breakout_price] for longs,
+          [breakdown_price] for shorts) is below it, or whose setup price is
+          unknown (liquidity can't be verified). Applies symmetrically to long
+          and short candidates.
+
+          Faithful screener filter: Weinstein trades liquid leaders, not penny /
+          thin names (weinstein-book-reference.md §4.2 Volume Confirmation —
+          "never trust a breakout that isn't accompanied by a significant
+          increase in volume"). The intent is to keep broad-universe backtests
+          honest by excluding un-fillable sub-$1 names; typical settings are 1.0
+          / 5.0 / 10.0.
+
+          Default-off liquidity dial reachable from the scenario/strategy
+          override path via [((screening_config ((min_price 5.0))))] — see
+          [Weinstein_strategy.config.screening_config]. Not wired into any
+          default config or the automated tuner sweep surface. *)
 }
 [@@deriving sexp]
 (** Main screener configuration. *)

--- a/trading/analysis/weinstein/screener/lib/screener_admission.ml
+++ b/trading/analysis/weinstein/screener/lib/screener_admission.ml
@@ -18,6 +18,15 @@ let passes_volume_band ~excl (a : Stock_analysis.t) =
       let r = v.Volume.volume_ratio in
       not Float.(low <= r && r < high)
 
+let passes_price_floor ~min_price ~price =
+  (* Liquidity floor: disabled when [min_price <= 0.0] (the default no-op).
+     Otherwise the candidate's setup price ([breakout_price] for longs,
+     [breakdown_price] for shorts) must be known and at/above the floor; an
+     unknown price ([None]) is REJECTED under a positive floor since liquidity
+     can't be verified. *)
+  if Float.(min_price <= 0.0) then true
+  else match price with Some p -> Float.(p >= min_price) | None -> false
+
 let rs_blocks_short = function
   | Some { Rs.trend = Positive_rising | Positive_flat | Bullish_crossover; _ }
     ->
@@ -25,12 +34,14 @@ let rs_blocks_short = function
   | _ -> false
 
 let _long_admission ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
-  (* Volume-band exclusion is folded into breakout phase: keeps the
-     cascade-diagnostics record stable (no new counter) while gating downstream
-     counts. *)
+    ~max_score_override ~volume_ratio_exclude_range ~min_price (a, sector) =
+  (* Volume-band exclusion and the min-price liquidity floor are folded into the
+     breakout phase: keeps the cascade-diagnostics record stable (no new
+     counter) while gating downstream counts. The long-side setup price is
+     [breakout_price]. *)
   let passes_breakout =
-    Stock_analysis.is_breakout_candidate a
+    passes_price_floor ~min_price ~price:a.Stock_analysis.breakout_price
+    && Stock_analysis.is_breakout_candidate a
     && passes_volume_band ~excl:volume_ratio_exclude_range a
   in
   let passes_sector =
@@ -48,19 +59,22 @@ let _long_admission ~weights ~thresholds ~min_grade ~min_score_override
 let _bump n b = if b then n + 1 else n
 
 let count_long_phases ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range ~candidates =
+    ~max_score_override ~volume_ratio_exclude_range ~min_price ~candidates =
   List.fold candidates ~init:(0, 0, 0)
     ~f:(fun (breakout, sector_ok, grade_ok) pair ->
       let pb, ps, pg =
         _long_admission ~weights ~thresholds ~min_grade ~min_score_override
-          ~max_score_override ~volume_ratio_exclude_range pair
+          ~max_score_override ~volume_ratio_exclude_range ~min_price pair
       in
       (_bump breakout pb, _bump sector_ok ps, _bump grade_ok pg))
 
 let _short_admission ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range (a, sector) =
+    ~max_score_override ~volume_ratio_exclude_range ~min_price (a, sector) =
+  (* The short-side setup price is [breakdown_price]; the floor folds into the
+     breakdown phase, mirroring [_long_admission]. *)
   let passes_breakdown =
-    Stock_analysis.is_breakdown_candidate a
+    passes_price_floor ~min_price ~price:a.Stock_analysis.breakdown_price
+    && Stock_analysis.is_breakdown_candidate a
     && passes_volume_band ~excl:volume_ratio_exclude_range a
   in
   let passes_sector =
@@ -77,11 +91,11 @@ let _short_admission ~weights ~thresholds ~min_grade ~min_score_override
   (passes_breakdown, passes_sector, passes_rs, passes_grade)
 
 let count_short_phases ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range ~candidates =
+    ~max_score_override ~volume_ratio_exclude_range ~min_price ~candidates =
   List.fold candidates ~init:(0, 0, 0, 0)
     ~f:(fun (breakdown, sector_ok, rs_ok, grade_ok) pair ->
       let pb, ps, pr, pg =
         _short_admission ~weights ~thresholds ~min_grade ~min_score_override
-          ~max_score_override ~volume_ratio_exclude_range pair
+          ~max_score_override ~volume_ratio_exclude_range ~min_price pair
       in
       (_bump breakdown pb, _bump sector_ok ps, _bump rs_ok pr, _bump grade_ok pg))

--- a/trading/analysis/weinstein/screener/lib/screener_admission.mli
+++ b/trading/analysis/weinstein/screener/lib/screener_admission.mli
@@ -36,6 +36,14 @@ val passes_volume_band :
     half-open interval from [low] (inclusive) to [high] (exclusive). Candidates
     without a [volume] result pass through. *)
 
+val passes_price_floor : min_price:float -> price:float option -> bool
+(** Liquidity floor (Weinstein trades liquid leaders — book §4.2 Volume
+    Confirmation). [true] iff the floor is disabled ([min_price <= 0.0], the
+    default no-op) or [price] is known and at/above [min_price]. A [None] price
+    is REJECTED under a positive floor (liquidity can't be verified) and
+    admitted when the floor is [0.0]. Callers pass the candidate's setup price —
+    [breakout_price] for longs, [breakdown_price] for shorts. *)
+
 val rs_blocks_short : Rs.result option -> bool
 (** Hard gate per Weinstein Ch. 11: never short a stock with strong relative
     strength, even if it breaks down. Returns [true] for candidates whose RS
@@ -50,11 +58,13 @@ val count_long_phases :
   min_score_override:int option ->
   max_score_override:int option ->
   volume_ratio_exclude_range:volume_ratio_band option ->
+  min_price:float ->
   candidates:(Stock_analysis.t * sector_context) list ->
   int * int * int
 (** Long-side cascade-phase counts [(breakout, sector, grade)] for the
     diagnostics record. Each phase short-circuits (a [false] earlier phase keeps
-    later phases [false]) so the triple is monotone non-increasing. *)
+    later phases [false]) so the triple is monotone non-increasing. The
+    [min_price] liquidity floor folds into the breakout phase. *)
 
 val count_short_phases :
   weights:scoring_weights ->
@@ -63,8 +73,9 @@ val count_short_phases :
   min_score_override:int option ->
   max_score_override:int option ->
   volume_ratio_exclude_range:volume_ratio_band option ->
+  min_price:float ->
   candidates:(Stock_analysis.t * sector_context) list ->
   int * int * int * int
 (** Short-side cascade-phase counts [(breakdown, sector, rs, grade)] mirroring
     {!count_long_phases}, with the RS hard gate inserted between sector and
-    grade. *)
+    grade. The [min_price] liquidity floor folds into the breakdown phase. *)

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -1243,9 +1243,107 @@ let test_pi_filter_composes_with_cooldown _ =
   in
   assert_that result.buy_candidates is_empty
 
+(* ------------------------------------------------------------------ *)
+(* min_price: liquidity floor                                          *)
+(* ------------------------------------------------------------------ *)
+
+let _tickers cs = List.map cs ~f:(fun (c : scored_candidate) -> c.ticker)
+
+(** A low-priced (~$2.70 breakout) Stage1→Stage2 breakout candidate. *)
+let _cheap_long ticker =
+  let bars = rising_bars_with_spike ~n:35 1.5 3.0 ~spike_idx:31 in
+  make_analysis ticker (Some (Stage1 { weeks_in_base = 10 })) bars
+
+(** A higher-priced (~$9.00 breakout) Stage1→Stage2 breakout candidate. *)
+let _rich_long ticker =
+  let bars = rising_bars_with_spike ~n:35 5.0 10.0 ~spike_idx:31 in
+  make_analysis ticker (Some (Stage1 { weeks_in_base = 10 })) bars
+
+(** A low-priced (~$3.34 breakdown) Stage3→Stage4 short candidate. *)
+let _cheap_short ticker =
+  let bars = declining_bars_with_spike ~n:60 6.0 3.0 ~spike_idx:55 in
+  make_analysis ticker (Some (Stage3 { weeks_topping = 8 })) bars
+
+(** No-op proof: [min_price = 0.0] (the default) admits a low-priced (~$2.70)
+    Stage-2 breakout exactly as today. *)
+let test_min_price_zero_admits_low_priced _ =
+  let result =
+    screen ~config:cfg ~macro_trend:Bullish ~sector_map:(empty_sector_map ())
+      ~stocks:[ _cheap_long "CHEAP" ]
+      ~held_tickers:[]
+  in
+  assert_that
+    (_tickers result.buy_candidates)
+    (elements_are [ equal_to "CHEAP" ])
+
+(** Floor rejects: [min_price = 5.0] drops the ~$2.70 candidate but admits the
+    ~$9.00 one. *)
+let test_min_price_floor_rejects_below _ =
+  let floor_cfg = { cfg with min_price = 5.0 } in
+  let result =
+    screen ~config:floor_cfg ~macro_trend:Bullish
+      ~sector_map:(empty_sector_map ())
+      ~stocks:[ _cheap_long "CHEAP"; _rich_long "RICH" ]
+      ~held_tickers:[]
+  in
+  assert_that
+    (_tickers result.buy_candidates)
+    (elements_are [ equal_to "RICH" ])
+
+(** Short side: the floor also gates short candidates — a ~$3.34 breakdown short
+    is rejected at [min_price = 5.0]. *)
+let test_min_price_floor_rejects_short _ =
+  let floor_cfg = { cfg with min_price = 5.0 } in
+  let sector_map =
+    sector_map_of [ ("SHT", make_sector ~rating:Weak "Energy") ]
+  in
+  let result =
+    screen ~config:floor_cfg ~macro_trend:Bearish ~sector_map
+      ~stocks:[ _cheap_short "SHT" ]
+      ~held_tickers:[]
+  in
+  assert_that result.short_candidates is_empty
+
+(** The same ~$3.34 breakdown short is admitted when the floor is disabled
+    ([min_price = 0.0]) — confirms the short-side gate is the floor, not an
+    unrelated rejection. *)
+let test_min_price_zero_admits_short _ =
+  let sector_map =
+    sector_map_of [ ("SHT", make_sector ~rating:Weak "Energy") ]
+  in
+  let result =
+    screen ~config:cfg ~macro_trend:Bearish ~sector_map
+      ~stocks:[ _cheap_short "SHT" ]
+      ~held_tickers:[]
+  in
+  assert_that
+    (_tickers result.short_candidates)
+    (elements_are [ equal_to "SHT" ])
+
+(** Missing price under a positive floor is rejected — liquidity can't be
+    verified. *)
+let test_passes_price_floor_missing_price_rejected _ =
+  assert_that (passes_price_floor ~min_price:5.0 ~price:None) (equal_to false)
+
+(** Missing price with the floor disabled ([min_price = 0.0]) is admitted — the
+    no-op short-circuits before the price is examined. *)
+let test_passes_price_floor_missing_price_noop _ =
+  assert_that (passes_price_floor ~min_price:0.0 ~price:None) (equal_to true)
+
 let suite =
   "screener_tests"
   >::: [
+         "test_min_price_zero_admits_low_priced"
+         >:: test_min_price_zero_admits_low_priced;
+         "test_min_price_floor_rejects_below"
+         >:: test_min_price_floor_rejects_below;
+         "test_min_price_floor_rejects_short"
+         >:: test_min_price_floor_rejects_short;
+         "test_min_price_zero_admits_short" >:: test_min_price_zero_admits_short;
+         "test_passes_price_floor_missing_price_rejected"
+         >:: test_passes_price_floor_missing_price_rejected;
+         "test_passes_price_floor_missing_price_noop"
+         >:: test_passes_price_floor_missing_price_noop;
          "test_bearish_macro_no_buys" >:: test_bearish_macro_no_buys;
          "test_bullish_macro_no_shorts" >:: test_bullish_macro_no_shorts;
          "test_weak_sector_excluded_from_buys"

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -49,6 +49,7 @@ let _permissive_screener_config (config : config) : Screener.config =
     max_short_candidates = Int.max_value;
     cascade_post_stop_cooldown_weeks = 0;
     neutral_blocks_longs = false;
+    min_price = 0.0;
   }
 
 (** Whether [trend] would have admitted longs at the macro gate. *)

--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -271,6 +271,22 @@ let test_default_screening_volume_ratio_exclude_range_is_none _ =
   let cfg = _default_config () in
   assert_that cfg.screening_config.volume_ratio_exclude_range is_none
 
+(** Deep-merge path for [screening_config.min_price] — the liquidity floor. A
+    scenario's [config_overrides] can set it to 1.0 / 5.0 / 10.0 so
+    broad-universe backtests exclude penny / illiquid names. *)
+let test_override_screening_min_price _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string "((screening_config ((min_price 5.0))))")
+  in
+  assert_that merged.screening_config.min_price (float_equal 5.0)
+
+(** [0.0] (the default) is preserved when no override is applied. Pins the
+    bit-identical no-op contract documented in [Screener.config.min_price]. *)
+let test_default_screening_min_price_is_zero _ =
+  let cfg = _default_config () in
+  assert_that cfg.screening_config.min_price (float_equal 0.0)
+
 (** Fold-equivalent helper: applies a list of override sexps the same way
     [Backtest.Runner._apply_overrides] does — sequential deep-merge of each
     overlay into the running sexp, then a single [config_of_sexp] at the end.
@@ -462,6 +478,10 @@ let suite =
           through sexp" >:: test_override_screening_volume_ratio_exclude_range;
          "default: screening_config.volume_ratio_exclude_range = None"
          >:: test_default_screening_volume_ratio_exclude_range_is_none;
+         "override: screening_config.min_price round-trips through sexp"
+         >:: test_override_screening_min_price;
+         "default: screening_config.min_price = 0.0"
+         >:: test_default_screening_min_price_is_zero;
          "two overlays targeting same top-level field both apply"
          >:: test_two_overlays_same_top_level_field;
          "unknown top-level overlay key fails loudly (sweep-path linter)"


### PR DESCRIPTION
## What it does

Adds a **minimum-stock-price liquidity floor** to the Weinstein cascade screener as a **default-off** config dial. The floor excludes penny / illiquid names from both buy and short candidates so broad-universe backtests aren't flattered by un-fillable sub-\$1 symbols.

- `Screener.config.min_price : float [@sexp.default 0.0]`.
  - `0.0` (default) = **no floor, bit-identical to pre-floor behaviour**.
  - A positive value (e.g. `1.0` / `5.0` / `10.0`) excludes candidates whose **setup price** is below it — `breakout_price` for longs, `breakdown_price` for shorts — or whose setup price is unknown (`None` → rejected, liquidity can't be verified).
- `Screener_admission.passes_price_floor ~min_price ~price` — the gate helper, placed in `screener_admission.ml` (NOT `screener.ml`, which is already ~407 lines) next to `passes_score_floor`. Semantics: `min_price <= 0.0` → always true (no-op); else require `price = Some p && p >= min_price`; `None` → false.
- The gate is an **early gate** in both `_long_candidate` and `_short_candidate` (symmetric with the existing `passes_volume_band` line), threaded through `_evaluate_longs` / `_evaluate_shorts` / `_diagnostics_for_screen` / `screen` / `screen_with_cooldown` — **mirroring `min_score_override` one-for-one**. It folds into the breakout/breakdown diagnostics phase so the cascade-diagnostics counters stay consistent (same pattern the volume band uses; no new counter).

### Design note (deviation from the brief)

The brief assumed `Stock_analysis.t` exposes `get_high ~week_offset:0` as a current-price accessor. On current `main`, `Stock_analysis.t` has **no** `get_high` and no plain current-price field (`get_high` lives only on the `callbacks` record, not on `t`). The faithful "current price" available on `t` without re-walking bars is the **setup price** — `breakout_price` (longs) / `breakdown_price` (shorts). These are `float option`, which matches the brief's `None`-rejection semantics exactly, and are the prices the trade actually occurs near. The helper therefore takes `~price:float option` (side-agnostic) rather than `~(a : Stock_analysis.t)`; the long/short call sites pass the relevant field.

### Scenario-override reachability

`screening_config` is a full `Screener.config` sexp, so the new field is reachable from a scenario's `config_overrides` via `((screening_config ((min_price 5.0))))` through the runner's deep-merge `config_of_sexp` path — no extra wiring needed. Pinned by two deep-merge tests in `test_runner_hypothesis_overrides.ml` (mirroring `min_score_override`).

`stage_transition_scanner.ml` gets a one-line `min_price = 0.0` (record-completeness; it builds a full permissive `Screener.config` literal, same as the prior `neutral_blocks_longs` field).

## Faithful-core / flag-discipline

- **W2:** a liquidity / min-price floor is a faithful screener filter (not a spine change) — Weinstein trades liquid leaders, not thin / penny names (weinstein-book-reference.md §4.2 Volume Confirmation: "never trust a breakout that isn't accompanied by a significant increase in volume").
- **R1/R2:** default `0.0` = no-op (bit-identical); real config field, scenario-overridable. **R3 NA** (no default flipped).

## Deferred follow-up (out of scope)

Wiring `min_price` into the automated tuner sweep surface (`grid_search.mli`, `bayesian_runner_spec.mli`). Manual per-scenario overrides are enough for now; this PR keeps focus on the screener gate + scenario override path.

## Test plan

`test_screener.ml` (6 new):
- `min_price = 0.0` admits a low-priced (~\$2.70 breakout) Stage-2 candidate exactly as today (**no-op proof**).
- `min_price = 5.0` rejects the ~\$2.70 candidate but admits a ~\$9.00 one (**floor rejects below**).
- `min_price = 5.0` rejects a ~\$3.34 breakdown **short** candidate (**short side gated**).
- the same short is admitted at `min_price = 0.0` (confirms the rejection is the floor, not something else).
- `passes_price_floor ~min_price:5.0 ~price:None = false` (**missing price rejected** under a positive floor).
- `passes_price_floor ~min_price:0.0 ~price:None = true` (**missing price admitted** when floor disabled).

`test_runner_hypothesis_overrides.ml` (2 new):
- `((screening_config ((min_price 5.0))))` deep-merges to `5.0`.
- default `min_price = 0.0` when no override applied.

## Verification

- `dune build` clean; `dune build @fmt` clean (all 6 touched files format-clean).
- **Full** `dune runtest` green — nesting linter "all 3146 functions within limits", no `FAIL:` lines, no file-length / fn-length / magic-number / mli-coverage violations. `screener.ml` is 407 lines (< 500 hard limit) — the helper went in `screener_admission.ml` (87 lines) precisely to keep it there.
- `screener` test suite: 57 tests OK (51 prior + 6 new). Override-path suite: 22 tests OK.
- Diff is the 7 expected files only (~230 LOC). No `_index.md`, no `grid_search` / `bayesian` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)