### PR TITLE
chore(agent-memory): export barbell-on-stocks durable memory snapshot

### DIFF
--- a/dev/agent-memory/README.md
+++ b/dev/agent-memory/README.md
@@ -12,6 +12,7 @@ list). Generated file — edit the source memories, not this directory.
 
 ## Index
 
+- [`project_barbell_on_stocks.md`](./project_barbell_on_stocks.md) — Barbell (SPY-timing floor + Cell-E stock-selection engine) NAV blend dominates both standalone legs on Calmar in BOTH regimes; 70/30 regime-robust. Resolves the 918%-vs-drawdown tension.
 - [`project_bayesian_int_knob_crash.md`](./project_bayesian_int_knob_crash.md) — 11-knob BO sweep crashes int_of_sexp because cell_to_overrides emits raw %.17g floats for int-typed knobs. P3 BLOCKED until per-knob round added.
 - [`project_bayesian_sweep_checkpoint_needed.md`](./project_bayesian_sweep_checkpoint_needed.md) — V2 sweep lost ~5h of work to power-loss-induced restart (2026-05-20). User flagged checkpointing as a needed improvement for future frequent sweeps.
 - [`project_broad_universe_semantics.md`](./project_broad_universe_semantics.md) — Broad backtest universes (data/sectors.csv, ~10k symbols) should NOT pre-filter by bar coverage; the runner skips per-symbol when no bars exist.

--- a/dev/agent-memory/project_barbell_on_stocks.md
+++ b/dev/agent-memory/project_barbell_on_stocks.md
@@ -1,0 +1,40 @@
+---
+name: project-barbell-on-stocks
+description: Barbell (SPY-timing floor + Cell-E stock-selection engine) NAV blend dominates both standalone legs on Calmar in BOTH regimes; 70/30 regime-robust. Resolves the 918%-vs-drawdown tension.
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: ca50bd58-52e8-4bfa-b1b2-6e777091a945
+---
+
+P0 of the 2026-06-03 arc, DONE 2026-06-02 (PRs #1434/#1435). Post-hoc
+constant-weight daily-return NAV blend of two legs, both re-run fresh on deep
+(2000-2026) and bull (2010-2026): FLOOR = `Spy_only_weinstein` SPY 30wk
+long/flat (index-timing); ENGINE = full Cell E production strategy on clean PIT
+S&P 500 (`universes/sp500-historical/sp500-2000-01-01.sexp`).
+
+**Result — the barbell strictly dominates BOTH pure legs on Calmar in BOTH
+regimes; diversification pushes blended DD *below the floor leg itself*.**
+
+| | pure floor | 70/30 | pure engine |
+|---|---|---|---|
+| deep 2000-26 | 387%/18.8%/0.32 | **534%/17.8%/0.39** | 918%/37.3%/0.24 |
+| bull 2010-26 | 239%/18.8%/0.40 | **247%/16.4%/0.47** | 238%/17.5%/0.43 |
+
+- Deep: return trades monotonically for DD; Calmar-max at defensive **80/20**
+  (0.414, DD 16.2% < floor's 18.8%). Bull: legs ~equal return → blend is pure DD
+  reduction; Calmar-max at **50/50** (0.479). **70/30 beats both pure legs in
+  each regime → regime-robust.** Matches ETF-lab barbell's 70/30 (#1426).
+- 70/30 ≈ raw BAH-SPY return at HALF the drawdown.
+- Deep engine reproduced doc's 918%/37.3%/0.25 exactly; bull engine 237.6%.
+
+**Why:** resolves the 918%-vs-DD tension — you trade return for DD along the
+frontier but never pick between the two pure strategies. The mandate picks the
+point (drawdown-defense → 80/20; return-respecting-risk → 70/30).
+
+Tool: `/tmp/blendw.awk` (`awk -v w=<floor-weight> -f blendw.awk floor.csv engine.csv`).
+Writeup: `dev/notes/barbell-on-stocks-2026-06-02.md`. Extends
+[[project_sector_rotation_layer_attribution]] (ETF lab) onto individual stocks;
+relates to [[project_cell_e_2020_stall_regime]] (breadth is the lever for the
+engine leg). Next: few-feature carrier as a better engine leg (lighter machinery
+→ engine return at lower DD?).


### PR DESCRIPTION
Routine post-session memory snapshot refresh (session-rampup maintenance). Adds project_barbell_on_stocks (P0 result). Docs-only (.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)