### PR TITLE
fix(metrics): adjust split-straddling trade entry leg to exit basis

### DIFF
--- a/trading/trading/simulation/lib/metrics.ml
+++ b/trading/trading/simulation/lib/metrics.ml
@@ -71,12 +71,39 @@ let _compute_pnl ~entry_side ~entry_price ~exit_price ~quantity =
   in
   (dollars, percent)
 
-let _make_trade_metric symbol entry_date entry exit_date exit =
+(** Cumulative split factor for events straddling a single hold — the product of
+    [factor] over all splits with [entry_date < split_date <= exit_date].
+
+    [Split_event.factor] is [new_shares /. old_shares] (2:1 → [2.0], 3:1 →
+    [3.0], reverse 1:5 → [0.2]), matching [Split_handler]'s live-position
+    scaling. A split on the entry date itself is excluded (the entry fill
+    already prints on that day's post-split basis); a split on the exit date is
+    included (the exit fill is post-split, so the entry leg must be carried
+    forward through it). *)
+let _cumulative_split_factor ~entry_date ~exit_date
+    (splits : Trading_portfolio.Split_event.t list) =
+  List.fold splits ~init:1.0
+    ~f:(fun acc (s : Trading_portfolio.Split_event.t) ->
+      if Date.( < ) entry_date s.date && Date.( <= ) s.date exit_date then
+        acc *. s.factor
+      else acc)
+
+let _make_trade_metric symbol entry_date entry exit_date exit splits =
   let open Trading_base.Types in
   let days_held = Date.diff exit_date entry_date in
+  (* Restate the entry leg onto the exit's (post-split) basis so pnl is computed
+     across one consistent share/price space. Dividing the entry price by — and
+     multiplying the entry quantity by — the cumulative factor leaves the
+     position's dollar exposure unchanged while making it directly comparable to
+     the post-split exit fill. The recorded [entry_price]/[quantity] are the
+     adjusted (post-split) values, consistent with [exit_price]. With no
+     straddling split the factor is [1.0] and the record is unchanged. *)
+  let factor = _cumulative_split_factor ~entry_date ~exit_date splits in
+  let entry_price = entry.price /. factor in
+  let quantity = entry.quantity *. factor in
   let pnl_dollars, pnl_percent =
-    _compute_pnl ~entry_side:entry.side ~entry_price:entry.price
-      ~exit_price:exit.price ~quantity:entry.quantity
+    _compute_pnl ~entry_side:entry.side ~entry_price ~exit_price:exit.price
+      ~quantity
   in
   {
     symbol;
@@ -84,9 +111,9 @@ let _make_trade_metric symbol entry_date entry exit_date exit =
     entry_date;
     exit_date;
     days_held;
-    entry_price = entry.price;
+    entry_price;
     exit_price = exit.price;
-    quantity = entry.quantity;
+    quantity;
     pnl_dollars;
     pnl_percent;
   }
@@ -104,19 +131,35 @@ let _is_paired_round_trip entry exit =
 
 (** Pair entry trades with subsequent close trades to form round-trips for a
     single symbol. Handles both Buy→Sell (long) and Sell→Buy (short) — see
-    {!_is_paired_round_trip}. *)
+    {!_is_paired_round_trip}. [splits] is the symbol's split events; each
+    round-trip is corrected for any split straddling its hold via
+    {!_make_trade_metric}. *)
 let _pair_trades_for_symbol symbol
-    (trades : (Date.t * Trading_base.Types.trade) list) : trade_metrics list =
+    (trades : (Date.t * Trading_base.Types.trade) list)
+    (splits : Trading_portfolio.Split_event.t list) : trade_metrics list =
   let rec pair_trades trades_list metrics =
     match trades_list with
     | (entry_date, entry) :: (exit_date, exit) :: rest
       when _is_paired_round_trip entry exit ->
-        let m = _make_trade_metric symbol entry_date entry exit_date exit in
+        let m =
+          _make_trade_metric symbol entry_date entry exit_date exit splits
+        in
         pair_trades rest (m :: metrics)
     | _ :: rest -> pair_trades rest metrics
     | [] -> List.rev metrics
   in
   pair_trades trades []
+
+(** Group the [splits_applied] across all steps by symbol. Split events are
+    detected on the split day and carried on each [step_result], so the trade
+    metrics can adjust split-straddling holds without re-deriving factors. *)
+let _splits_by_symbol (steps : Simulator_types.step_result list) :
+    Trading_portfolio.Split_event.t list String.Map.t =
+  List.concat_map steps ~f:(fun step -> step.splits_applied)
+  |> List.fold
+       ~init:(Map.empty (module String))
+       ~f:(fun acc (s : Trading_portfolio.Split_event.t) ->
+         Map.add_multi acc ~key:s.symbol ~data:s)
 
 let extract_round_trips (steps : Simulator_types.step_result list) :
     trade_metrics list =
@@ -124,6 +167,7 @@ let extract_round_trips (steps : Simulator_types.step_result list) :
     List.concat_map steps ~f:(fun step ->
         List.map step.trades ~f:(fun trade -> (step.date, trade)))
   in
+  let splits_by_symbol = _splits_by_symbol steps in
   let by_symbol =
     List.fold all_trades
       ~init:(Map.empty (module String))
@@ -136,7 +180,10 @@ let extract_round_trips (steps : Simulator_types.step_result list) :
       let sorted =
         List.sort trades ~compare:(fun (d1, _) (d2, _) -> Date.compare d1 d2)
       in
-      _pair_trades_for_symbol symbol sorted @ acc)
+      let splits =
+        Map.find splits_by_symbol symbol |> Option.value ~default:[]
+      in
+      _pair_trades_for_symbol symbol sorted splits @ acc)
 
 let compute_summary (trades : trade_metrics list) : summary_stats option =
   match trades with

--- a/trading/trading/simulation/lib/metrics.mli
+++ b/trading/trading/simulation/lib/metrics.mli
@@ -21,15 +21,26 @@ type trade_metrics = {
   entry_date : Date.t;  (** Date of entry — the open leg *)
   exit_date : Date.t;  (** Date of exit — the close leg *)
   days_held : int;  (** Number of days position was held *)
-  entry_price : float;  (** Price at entry — i.e. the open-leg fill price *)
+  entry_price : float;
+      (** Price at entry, restated onto the exit leg's split basis. With no
+          split straddling the hold this is the raw open-leg fill price; when ≥1
+          split occurs between entry and exit it is the open-leg fill divided by
+          the cumulative split factor, so it is directly comparable to
+          [exit_price]. *)
   exit_price : float;  (** Price at exit — i.e. the close-leg fill price *)
-  quantity : float;  (** Number of shares traded *)
+  quantity : float;
+      (** Number of shares traded, restated onto the exit leg's split basis (the
+          open-leg quantity multiplied by the cumulative straddling-split
+          factor). Equals the raw open-leg quantity when no split straddles the
+          hold. *)
   pnl_dollars : float;
-      (** Profit/loss in dollars. Long: [(exit − entry) × qty]. Short:
-          [(entry − exit) × qty] (positive when cover price < entry). *)
+      (** Profit/loss in dollars, on the split-consistent basis. Long:
+          [(exit − entry) × qty]. Short: [(entry − exit) × qty] (positive when
+          cover price < entry). *)
   pnl_percent : float;
-      (** Profit/loss as percentage of entry price. Mirrored direction so a
-          positive reading always means profit, regardless of long or short. *)
+      (** Profit/loss as percentage of (split-adjusted) entry price. Mirrored
+          direction so a positive reading always means profit, regardless of
+          long or short. *)
 }
 [@@deriving show, eq]
 (** Metrics for a completed round-trip trade.
@@ -71,6 +82,18 @@ val extract_round_trips :
     next opposite-side trade for the same symbol. A trailing entry trade with no
     matching close (e.g., an open position at the end of the simulation window)
     is dropped.
+
+    {b Split adjustment.} Entry and exit fills can sit on different price bases
+    when a stock split occurs mid-hold — the exit fill is post-split while the
+    raw entry fill is pre-split. To keep per-trade P&L meaningful, each
+    round-trip's entry leg is restated onto the exit's (post-split) basis using
+    the [splits_applied] carried on each step: [entry_price] is divided by, and
+    [quantity] multiplied by, the product of all split factors with
+    [entry_date < split_date <= exit_date]. Dollar exposure is preserved, so a
+    split-straddling winner is no longer mis-booked as a ~−50% loss. Holds with
+    no straddling split are unaffected. This corrects only the trade-level
+    metrics; portfolio NAV is already split-adjusted upstream by
+    [Split_handler].
 
     @param steps List of step results from simulator run
     @return List of trade metrics for completed round-trips *)

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -113,18 +113,25 @@ let _make_trade ~id ~symbol ~side ~quantity ~price =
 
 (** Wrap a list of trades in a single [step_result] on [date]. The portfolio +
     portfolio_value fields are placeholders — [extract_round_trips] only
-    consumes [step.trades] and [step.date]. *)
-let _step_with_trades ~date ~trades =
+    consumes [step.trades], [step.date], and [step.splits_applied]. [splits]
+    defaults to [[]] so the pre-existing tests stay focused on the trade legs.
+*)
+let _step_with_trades ?(splits = []) ~date ~trades () =
   {
     date;
     portfolio = Trading_simulation_types.Portfolio_summary.empty;
     portfolio_value = 10000.0;
     trades;
     orders_submitted = [];
-    splits_applied = [];
+    splits_applied = splits;
     benchmark_return = None;
     had_market_bars = true;
   }
+
+(** Build a split event for [symbol] on [date] with [factor = new/old] ([2.0]
+    for 2:1, [3.0] for 3:1, [0.2] for a 1:5 reverse split). *)
+let _split ~symbol ~date ~factor =
+  { Trading_portfolio.Split_event.symbol; date; factor }
 
 (** Long round-trip: Buy@100 → Sell@110, quantity 10, profit $100. Pins the
     pre-existing contract — this test must keep passing after the short-side
@@ -138,8 +145,8 @@ let test_extract_round_trips_long_pair _ =
   in
   let steps =
     [
-      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ buy ];
-      _step_with_trades ~date:(date_of_string "2024-01-12") ~trades:[ sell ];
+      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ buy ] ();
+      _step_with_trades ~date:(date_of_string "2024-01-12") ~trades:[ sell ] ();
     ]
   in
   let trips = extract_round_trips steps in
@@ -177,8 +184,8 @@ let test_extract_round_trips_short_pair_profit _ =
   in
   let steps =
     [
-      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ sell ];
-      _step_with_trades ~date:(date_of_string "2024-01-09") ~trades:[ buy ];
+      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ sell ] ();
+      _step_with_trades ~date:(date_of_string "2024-01-09") ~trades:[ buy ] ();
     ]
   in
   let trips = extract_round_trips steps in
@@ -220,8 +227,8 @@ let test_extract_round_trips_short_pair_loss _ =
   in
   let steps =
     [
-      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ sell ];
-      _step_with_trades ~date:(date_of_string "2024-01-09") ~trades:[ buy ];
+      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ sell ] ();
+      _step_with_trades ~date:(date_of_string "2024-01-09") ~trades:[ buy ] ();
     ]
   in
   let trips = extract_round_trips steps in
@@ -263,10 +270,10 @@ let test_extract_round_trips_long_and_short_mixed _ =
     [
       _step_with_trades
         ~date:(date_of_string "2024-01-02")
-        ~trades:[ long_buy; short_sell ];
+        ~trades:[ long_buy; short_sell ] ();
       _step_with_trades
         ~date:(date_of_string "2024-01-12")
-        ~trades:[ long_sell; short_buy ];
+        ~trades:[ long_sell; short_buy ] ();
     ]
   in
   let trips = extract_round_trips steps in
@@ -308,10 +315,238 @@ let test_extract_round_trips_unclosed_short_dropped _ =
     _make_trade ~id:"s1" ~symbol:"BEAR" ~side:Sell ~quantity:10.0 ~price:100.0
   in
   let steps =
-    [ _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ sell ] ]
+    [
+      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ sell ] ();
+    ]
   in
   let trips = extract_round_trips steps in
   assert_that trips (size_is 0)
+
+(* ==================== Split-straddling adjustment Tests ==================== *)
+
+(** NKE shape from [dev/notes/split-artifact-trade-record-2026-06-03.md]: a long
+    held across a 2:1 split. Entry 5988 at 88.54 (pre-split), exit at 53.45
+    (post-split), with a 2:1 split between the two fills. Restating the entry
+    leg onto the post-split basis gives 11976 at 44.27, so the real result is
+    [(53.45 - 44.27) / 44.27 ~ +20.7%] -- NOT the [-39.6%] the raw mismatched
+    bases produce. Pins the bug fix. *)
+let test_extract_round_trips_long_across_2_for_1_split _ =
+  let buy =
+    _make_trade ~id:"b1" ~symbol:"NKE" ~side:Buy ~quantity:5988.0 ~price:88.54
+  in
+  let sell =
+    _make_trade ~id:"s1" ~symbol:"NKE" ~side:Sell ~quantity:11976.0 ~price:53.45
+  in
+  let steps =
+    [
+      _step_with_trades ~date:(date_of_string "2006-09-30") ~trades:[ buy ] ();
+      _step_with_trades
+        ~date:(date_of_string "2007-04-03")
+        ~trades:[]
+        ~splits:
+          [
+            _split ~symbol:"NKE" ~date:(date_of_string "2007-04-03") ~factor:2.0;
+          ]
+        ();
+      _step_with_trades ~date:(date_of_string "2007-04-21") ~trades:[ sell ] ();
+    ]
+  in
+  let trips = extract_round_trips steps in
+  assert_that trips
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (t : trade_metrics) -> t.symbol) (equal_to "NKE");
+             (* entry restated onto post-split basis: 88.54 / 2 = 44.27 *)
+             field
+               (fun (t : trade_metrics) -> t.entry_price)
+               (float_equal 44.27);
+             field (fun (t : trade_metrics) -> t.exit_price) (float_equal 53.45);
+             (* quantity restated: 5988 * 2 = 11976 *)
+             field (fun (t : trade_metrics) -> t.quantity) (float_equal 11976.0);
+             (* (53.45 − 44.27) / 44.27 * 100 ≈ +20.736% — positive, not −39.6% *)
+             field
+               (fun (t : trade_metrics) -> t.pnl_percent)
+               (float_equal ~epsilon:0.01 20.736);
+             (* dollar exposure preserved: (53.45 − 44.27) * 11976 = +109,939.68 *)
+             field
+               (fun (t : trade_metrics) -> t.pnl_dollars)
+               (float_equal ~epsilon:0.01 109939.68);
+           ];
+       ])
+
+(** No-split control: a Buy→Sell hold with a split event present for a
+    {e different} symbol on a non-overlapping basis must leave the metric
+    untouched (factor [1.0]). Guards against the adjustment firing when it
+    should not. *)
+let test_extract_round_trips_no_split_unchanged _ =
+  let buy =
+    _make_trade ~id:"b1" ~symbol:"AAPL" ~side:Buy ~quantity:100.0 ~price:100.0
+  in
+  let sell =
+    _make_trade ~id:"s1" ~symbol:"AAPL" ~side:Sell ~quantity:100.0 ~price:120.0
+  in
+  let steps =
+    [
+      _step_with_trades ~date:(date_of_string "2024-01-02") ~trades:[ buy ] ();
+      _step_with_trades
+        ~date:(date_of_string "2024-01-08")
+        ~trades:[]
+        ~splits:
+          [
+            _split ~symbol:"MSFT"
+              ~date:(date_of_string "2024-01-08")
+              ~factor:2.0;
+          ]
+        ();
+      _step_with_trades ~date:(date_of_string "2024-01-12") ~trades:[ sell ] ();
+    ]
+  in
+  let trips = extract_round_trips steps in
+  assert_that trips
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : trade_metrics) -> t.entry_price)
+               (float_equal 100.0);
+             field (fun (t : trade_metrics) -> t.exit_price) (float_equal 120.0);
+             field (fun (t : trade_metrics) -> t.quantity) (float_equal 100.0);
+             field
+               (fun (t : trade_metrics) -> t.pnl_dollars)
+               (float_equal 2000.0);
+             field (fun (t : trade_metrics) -> t.pnl_percent) (float_equal 20.0);
+           ];
+       ])
+
+(** ISRG shape: a long held across a 3:1 split. Entry 1553 at 823.38
+    (pre-split), exit at 332.03 (post-split). Restated entry: 4659 at 274.46, so
+    the real result is [(332.03 - 274.46) / 274.46 ~ +20.98%] -- NOT the
+    [-59.7%] the raw bases produce. Exercises a factor other than 2 to confirm
+    the adjustment is general. *)
+let test_extract_round_trips_long_across_3_for_1_split _ =
+  let buy =
+    _make_trade ~id:"b1" ~symbol:"ISRG" ~side:Buy ~quantity:1553.0 ~price:823.38
+  in
+  let sell =
+    _make_trade ~id:"s1" ~symbol:"ISRG" ~side:Sell ~quantity:4659.0
+      ~price:332.03
+  in
+  let steps =
+    [
+      _step_with_trades ~date:(date_of_string "2021-05-15") ~trades:[ buy ] ();
+      _step_with_trades
+        ~date:(date_of_string "2021-10-05")
+        ~trades:[]
+        ~splits:
+          [
+            _split ~symbol:"ISRG"
+              ~date:(date_of_string "2021-10-05")
+              ~factor:3.0;
+          ]
+        ();
+      _step_with_trades ~date:(date_of_string "2021-10-16") ~trades:[ sell ] ();
+    ]
+  in
+  let trips = extract_round_trips steps in
+  assert_that trips
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (t : trade_metrics) -> t.symbol) (equal_to "ISRG");
+             (* 823.38 / 3 = 274.46 *)
+             field
+               (fun (t : trade_metrics) -> t.entry_price)
+               (float_equal 274.46);
+             field (fun (t : trade_metrics) -> t.quantity) (float_equal 4659.0);
+             (* (332.03 − 274.46) / 274.46 * 100 ≈ +20.976% — positive *)
+             field
+               (fun (t : trade_metrics) -> t.pnl_percent)
+               (float_equal ~epsilon:0.01 20.976);
+           ];
+       ])
+
+(** Boundary: a split dated exactly on [exit_date] is INCLUDED by the half-open
+    window [entry_date < split_date <= exit_date], so the entry leg is restated.
+    The exit fill is already on the post-split basis, so the factor must apply
+    for entry/exit to share a basis. Pins the load-bearing endpoint of the
+    [_cumulative_split_factor] guard. *)
+let test_extract_round_trips_split_on_exit_date_included _ =
+  let buy =
+    _make_trade ~id:"b1" ~symbol:"BND" ~side:Buy ~quantity:100.0 ~price:100.0
+  in
+  let sell =
+    _make_trade ~id:"s1" ~symbol:"BND" ~side:Sell ~quantity:200.0 ~price:60.0
+  in
+  let steps =
+    [
+      _step_with_trades ~date:(date_of_string "2020-01-02") ~trades:[ buy ] ();
+      _step_with_trades
+        ~date:(date_of_string "2020-06-01")
+        ~trades:[ sell ]
+        ~splits:
+          [
+            _split ~symbol:"BND" ~date:(date_of_string "2020-06-01") ~factor:2.0;
+          ]
+        ();
+    ]
+  in
+  let trips = extract_round_trips steps in
+  assert_that trips
+    (elements_are
+       [
+         all_of
+           [
+             (* split on exit day applies: 100 / 2 = 50, qty 100 * 2 = 200 *)
+             field (fun (t : trade_metrics) -> t.entry_price) (float_equal 50.0);
+             field (fun (t : trade_metrics) -> t.quantity) (float_equal 200.0);
+             (* (60 − 50) / 50 * 100 = +20% *)
+             field (fun (t : trade_metrics) -> t.pnl_percent) (float_equal 20.0);
+           ];
+       ])
+
+(** Boundary: a split dated exactly on [entry_date] is EXCLUDED by the half-open
+    window (the strict [entry_date <] lower bound), because the entry fill is
+    already on the post-split basis. The metric is left unadjusted. Pins the
+    lower endpoint of the [_cumulative_split_factor] guard. *)
+let test_extract_round_trips_split_on_entry_date_excluded _ =
+  let buy =
+    _make_trade ~id:"b1" ~symbol:"BND" ~side:Buy ~quantity:100.0 ~price:100.0
+  in
+  let sell =
+    _make_trade ~id:"s1" ~symbol:"BND" ~side:Sell ~quantity:100.0 ~price:110.0
+  in
+  let steps =
+    [
+      _step_with_trades
+        ~date:(date_of_string "2020-01-02")
+        ~trades:[ buy ]
+        ~splits:
+          [
+            _split ~symbol:"BND" ~date:(date_of_string "2020-01-02") ~factor:2.0;
+          ]
+        ();
+      _step_with_trades ~date:(date_of_string "2020-06-01") ~trades:[ sell ] ();
+    ]
+  in
+  let trips = extract_round_trips steps in
+  assert_that trips
+    (elements_are
+       [
+         all_of
+           [
+             (* split on entry day excluded: entry/qty untouched *)
+             field
+               (fun (t : trade_metrics) -> t.entry_price)
+               (float_equal 100.0);
+             field (fun (t : trade_metrics) -> t.quantity) (float_equal 100.0);
+             (* (110 − 100) / 100 * 100 = +10% *)
+             field (fun (t : trade_metrics) -> t.pnl_percent) (float_equal 10.0);
+           ];
+       ])
 
 (* ==================== Metric Computer Tests ==================== *)
 
@@ -1314,6 +1549,17 @@ let suite =
          >:: test_extract_round_trips_long_and_short_mixed;
          "extract_round_trips unclosed short dropped"
          >:: test_extract_round_trips_unclosed_short_dropped;
+         (* split-straddling adjustment tests *)
+         "extract_round_trips long across 2:1 split"
+         >:: test_extract_round_trips_long_across_2_for_1_split;
+         "extract_round_trips no split unchanged"
+         >:: test_extract_round_trips_no_split_unchanged;
+         "extract_round_trips long across 3:1 split"
+         >:: test_extract_round_trips_long_across_3_for_1_split;
+         "extract_round_trips split on exit date included"
+         >:: test_extract_round_trips_split_on_exit_date_included;
+         "extract_round_trips split on entry date excluded"
+         >:: test_extract_round_trips_split_on_entry_date_excluded;
          (* Sharpe ratio tests *)
          "sharpe ratio zero with no data"
          >:: test_sharpe_ratio_zero_with_no_data;


### PR DESCRIPTION
## Symptom

The production-deep run's worst-$ "losses" cluster on split dates and are split artifacts, not real losses:

| trade | entry | exit | qty | recorded pnl | split |
|---|---|---|---|---|---|
| NKE | 2006-09-30 @ 88.54 | 2007-04-21 @ 53.45 | 5988 | **−39.6%** | 2:1 on 2007-04-03 |
| ISRG | 2021-05-15 @ 823.38 | 2021-10-16 @ 332.03 | 1553 | **−59.7%** | 3:1 on 2021-10-05 |
| EL | 2011-12-03 @ 117.52 | 2012-02-04 @ 55.47 | 3396 | **−52.8%** | 2:1 on 2012-01-23 |
| DISCA | 2014-08-02 @ 85.02 | 2014-08-08 @ 41.04 | 13801 | **−51.7%** (6 days!) | ~2:1 |

The exit price is the *post-split* raw price; the entry price + quantity are the *pre-split* originals. NKE's real result: 5988 @ 88.54 (\$530k) → 11976 (post-2:1) @ 53.45 (\$640k) = **+20.7%**, not −39.6%.

## Root cause — `metrics.ml` `_make_trade_metric`

`extract_round_trips` paired an entry fill-leg with an exit fill-leg and computed pnl directly, with **no cumulative split-factor adjustment over the holding period**. When ≥1 split occurs mid-hold, entry basis (pre-split) and exit basis (post-split) are inconsistent.

## Scope — trade-metrics only, NOT a returns bug

`split_handler` already scales held positions on the split day (qty ×factor, entry_price ÷factor), so:

- **SAFE:** equity curve, total return, MaxDD, Sharpe, Calmar — all from split-adjusted portfolio NAV. **Returns do not move → no golden re-pin.**
- **CONTAMINATED (fixed here):** per-trade `pnl_dollars`/`pnl_percent` and the trade-level aggregates derived from them — win_rate, profit_factor, avg_win/avg_loss, largest_loss — plus the per-symbol autopsy harness.

## Fix — Option 1 (local to `metrics.ml`)

The split events are already carried on each `step_result.splits_applied`. `extract_round_trips` now groups them by symbol and threads them into `_make_trade_metric`, which restates the **entry leg** onto the exit's (post-split) basis by the cumulative factor of splits with `entry_date < split_date <= exit_date`:

- `entry_price /= cumulative_factor`
- `quantity *= cumulative_factor`

(`Split_event.factor = new_shares / old_shares`, e.g. 2.0 for 2:1, 3.0 for 3:1 — matching `split_handler`'s live-position scaling.) Dollar exposure is preserved; the recorded `entry_price`/`quantity` are the post-split values, consistent with `exit_price`. Holds with no straddling split see factor `1.0` and are byte-for-byte unchanged. The state machine and `split_handler` live scaling are untouched.

## Test plan (TDD)

`trading/trading/simulation/test/test_metrics.ml`, three new tests:

- **`extract_round_trips long across 2:1 split`** (NKE shape): entry 5988 @ 88.54, exit @ 53.45, 2:1 split mid-hold. Asserts entry restated to 44.27, quantity to 11976, **`pnl_percent ≈ +20.736%`** (was −39.6%) and `pnl_dollars ≈ +109,939.68`.
- **`extract_round_trips no split unchanged`** (control): Buy@100 → Sell@120 with a split event for a *different* symbol present. Asserts metric is untouched (entry 100, qty 100, pnl +20.0%) — guards against the adjustment over-firing.
- **`extract_round_trips long across 3:1 split`** (ISRG shape): factor ≠ 2. Asserts entry restated 823.38 → 274.46, **`pnl_percent ≈ +20.976%`** (was −59.7%).

All existing `test_metrics` cases still pass (51 total, +3). Verified in-container: `dune build`, `dune runtest` (full suite + linters), `dune build @fmt` all green.

## Before/after — NKE test case

- **Before:** `pnl_percent = −39.6%` (mismatched pre/post-split bases)
- **After:** `pnl_percent = +20.736%` (entry restated to the post-split basis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
