### PR TITLE
feat(scenario-runner): add --snapshot-dir for snapshot-mode bar reads

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -1,9 +1,34 @@
 # Status: backtest-perf
 
-## Last updated: 2026-05-22
+## Last updated: 2026-06-04
 
 ## Status
 IN_PROGRESS
+
+### Recent activity (2026-06-04)
+
+- **[x] `scenario_runner --snapshot-dir <path>`** (READY_FOR_REVIEW,
+  branch `feat/scenario-runner-snapshot-dir`). Exposes snapshot
+  (streaming) bar-reading at the `--dir` golden entry point so a
+  large-N golden cell (e.g. N=3000) reads OHLCV from a pre-built
+  snapshot warehouse instead of building the whole universe's bars
+  in-process from CSVs (~14 GB resident at N=3000). Mirrors
+  `backtest_runner.exe --snapshot-dir` exactly: the manifest at
+  `<dir>/manifest.sexp` is read once at parse time and the resulting
+  `Bar_data_source.Snapshot {…}` is reused for every cell; missing /
+  corrupt manifest exits 1. With no flag, behaviour is bit-identical
+  to today's CSV mode.
+  - Surface: new `Scenario_lib.Bar_source_resolver.resolve` (lib
+    module + `.mli`, mirrors `backtest_runner._resolve_bar_data_source`
+    so the manifest-read + error path is unit-testable);
+    `scenario_runner.ml` parses `--snapshot-dir`, resolves once, and
+    threads `?bar_data_source` into `Backtest.Runner.run_backtest`.
+  - Verify: `dune runtest trading/backtest/scenarios/test/` (new
+    `test_bar_source_resolver` — `resolve None -> None`;
+    `resolve (Some dir) -> Snapshot {…}` over a real written manifest).
+  - Unblocks running large-N goldens locally in snapshot mode at
+    bounded RSS — a prerequisite step toward the tier-4 release-gate
+    at N≥5000 (see § Blocked on).
 
 ### Recent activity (2026-05-14..22, since last refresh)
 

--- a/trading/trading/backtest/scenarios/bar_source_resolver.ml
+++ b/trading/trading/backtest/scenarios/bar_source_resolver.ml
@@ -1,0 +1,23 @@
+open Core
+
+(* Mirrors [backtest_runner._resolve_bar_data_source] (PR #788). Kept
+   byte-faithful to that helper: same manifest path convention
+   ([<dir>/manifest.sexp]), same [Snapshot_manifest.read] call, same
+   diagnostic + [exit 1] on a missing/corrupt manifest. The manifest is read
+   exactly once here so the resulting selector is reused across every cell of a
+   [--dir] run. *)
+let resolve snapshot_dir =
+  Option.map snapshot_dir ~f:(fun dir ->
+      let manifest_path = Filename.concat dir "manifest.sexp" in
+      match Snapshot_pipeline.Snapshot_manifest.read ~path:manifest_path with
+      | Ok manifest ->
+          eprintf
+            "[snapshot-mode] loaded manifest at %s (schema_hash=%s, %d entries)\n\
+             %!"
+            manifest_path manifest.schema_hash
+            (List.length manifest.entries);
+          Backtest.Bar_data_source.Snapshot { snapshot_dir = dir; manifest }
+      | Error err ->
+          eprintf "Error: failed to read snapshot manifest at %s: %s\n"
+            manifest_path (Status.show err);
+          Stdlib.exit 1)

--- a/trading/trading/backtest/scenarios/bar_source_resolver.mli
+++ b/trading/trading/backtest/scenarios/bar_source_resolver.mli
@@ -1,0 +1,30 @@
+(** Resolve a [--snapshot-dir] CLI value into a [Backtest.Bar_data_source.t].
+
+    This is the [scenario_runner.exe] counterpart of [backtest_runner.ml]'s
+    [_resolve_bar_data_source] (PR #788 snapshot-mode wiring). It is factored
+    into [scenario_lib] (rather than living inline in the executable) so the
+    manifest-read + error path is unit-testable without forking a full backtest.
+
+    Snapshot (streaming) mode lets a large-N golden cell read OHLCV from a
+    pre-built snapshot warehouse instead of building the whole universe's bars
+    in-process from CSVs — the latter is ~14 GB resident at N=3000 and will not
+    fit a local dev container. With no [--snapshot-dir], the resolver returns
+    [None] and the run stays bit-identical to the pre-existing CSV mode. *)
+
+val resolve : string option -> Backtest.Bar_data_source.t option
+(** [resolve snapshot_dir] maps the parsed [--snapshot-dir] flag to an optional
+    [Bar_data_source.t]:
+
+    - [None] -> [None]. The caller omits [?bar_data_source], so
+      [Backtest.Runner.run_backtest] defaults to [Bar_data_source.Csv] — the
+      pre-snapshot CSV behaviour, unchanged.
+    - [Some dir] -> [Some (Snapshot { snapshot_dir = dir; manifest })] where
+      [manifest] is read from [<dir>/manifest.sexp] via
+      [Snapshot_pipeline.Snapshot_manifest.read].
+
+    Exits the process with status 1 (writing a diagnostic to [stderr]) on a
+    missing or corrupt manifest, so the "snapshot dir not yet built" failure
+    mode surfaces immediately at parse time rather than as a runner-internal
+    error mid-run. Mirrors [backtest_runner._resolve_bar_data_source] exactly:
+    the manifest is read once here and the resulting selector is reused across
+    every cell in a [--dir] run. *)

--- a/trading/trading/backtest/scenarios/dune
+++ b/trading/trading/backtest/scenarios/dune
@@ -6,11 +6,13 @@
   universe_snapshot
   fixtures_root
   smoke_catalog
-  scenario_progress)
+  scenario_progress
+  bar_source_resolver)
  (libraries
   core
   fpath
   weinstein.data_source
+  weinstein.snapshot_pipeline
   backtest
   backtest_cost_model
   universe

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -3,12 +3,20 @@
 
     Usage: scenario_runner
     [--goldens-small | --goldens-broad | --goldens | --smoke | --dir <path>]
-    [--parallel N] [--fixtures-root <path>] [--progress-every N]
-    [--no-emit-all-eligible]
+    [--parallel N] [--fixtures-root <path>] [--snapshot-dir <path>]
+    [--progress-every N] [--no-emit-all-eligible]
 
     [--goldens-small] — small-universe goldens (~300 symbols; local-friendly).
     [--goldens-broad] — broad-universe goldens (full sector-map; nightly/GHA).
     [--goldens] — alias for [--goldens-small] for backwards compat.
+
+    [--snapshot-dir <path>] — run every cell in snapshot (streaming) mode,
+    reading OHLCV from the pre-built snapshot warehouse at [path] instead of
+    building per-symbol bars in-process from CSVs. The manifest at
+    [<path>/manifest.sexp] is read once at parse time and the resulting
+    [Bar_data_source.t] is reused for every cell. With no [--snapshot-dir], the
+    run stays bit-identical to CSV mode. The load-bearing use is large-N goldens
+    (e.g. N=3000) that OOM the dev container in CSV mode (~14 GB resident).
 
     [--fixtures-root <path>] — directory the scenario [universe_path] field is
     resolved against (defaults to [TRADING_DATA_DIR/backtest_scenarios]). The
@@ -46,6 +54,7 @@ module Scenario = Scenario_lib.Scenario
 module Universe_file = Scenario_lib.Universe_file
 module Fixtures_root = Scenario_lib.Fixtures_root
 module Scenario_progress = Scenario_lib.Scenario_progress
+module Bar_source_resolver = Scenario_lib.Bar_source_resolver
 
 (* Universe resolution *)
 
@@ -252,7 +261,7 @@ let _actual_path ~output_root (s : Scenario.t) =
 (* Run one scenario inside a child process *)
 
 let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
-    ~emit_all_eligible ~scenario_path (s : Scenario.t) =
+    ~emit_all_eligible ~bar_data_source ~scenario_path (s : Scenario.t) =
   eprintf "\n>>> Running %s: %s (%s to %s)\n%!" s.name s.description
     (Date.to_string s.period.start_date)
     (Date.to_string s.period.end_date);
@@ -269,7 +278,7 @@ let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
     Backtest.Runner.run_backtest ~start_date:s.period.start_date
       ~end_date:s.period.end_date ~overrides:s.config_overrides
       ?sector_map_override ~strategy_choice:s.strategy ~progress_emitter
-      ?slippage_bps:s.slippage_bps ?cost_model:s.cost_model ()
+      ?slippage_bps:s.slippage_bps ?cost_model:s.cost_model ?bar_data_source ()
   in
   let wall_seconds =
     Time_ns.Span.to_sec (Time_ns.diff (Time_ns_unix.now ()) t_start)
@@ -309,12 +318,12 @@ let _write_crashed_actual ~output_root (s : Scenario.t) ~msg =
     (sexp_of_actual (_crashed_actual ~msg))
 
 let _fork_scenario ~output_root ~fixtures_root ~progress_every
-    ~emit_all_eligible ~scenario_path (s : Scenario.t) =
+    ~emit_all_eligible ~bar_data_source ~scenario_path (s : Scenario.t) =
   match Core_unix.fork () with
   | `In_the_child -> (
       try
         _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
-          ~emit_all_eligible ~scenario_path s;
+          ~emit_all_eligible ~bar_data_source ~scenario_path s;
         Stdlib.exit 0
       with e ->
         let msg = Exn.to_string e in
@@ -338,8 +347,8 @@ let _await_one running =
   match Core_unix.waitpid pid with Ok () -> Succeeded | Error _ -> Crashed
 
 let _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
-    ~progress_every ~emit_all_eligible (scenarios : (string * Scenario.t) list)
-    =
+    ~progress_every ~emit_all_eligible ~bar_data_source
+    (scenarios : (string * Scenario.t) list) =
   let running = Queue.create () in
   let statuses = Hashtbl.create (module String) in
   let reap () =
@@ -352,7 +361,7 @@ let _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
       if Queue.length running >= parallel then reap ();
       let pid =
         _fork_scenario ~output_root ~fixtures_root ~progress_every
-          ~emit_all_eligible ~scenario_path s
+          ~emit_all_eligible ~bar_data_source ~scenario_path s
       in
       Queue.enqueue running (s, pid));
   while not (Queue.is_empty running) do
@@ -398,6 +407,15 @@ type _cli_args = {
   dir : string;
   parallel : int;
   fixtures_root : string option;
+  snapshot_dir : string option;
+      (* When [Some dir], every cell reads OHLCV from the snapshot warehouse at
+         [dir] (streaming / snapshot mode) instead of building per-symbol bars
+         in-process from CSVs. Resolved once at parse time via
+         [Bar_source_resolver.resolve]; the resulting [Bar_data_source.t] is
+         reused for every cell in the [--dir] run. [None] (the default) keeps
+         the pre-existing CSV behaviour bit-identical. The load-bearing use is
+         large-N goldens (e.g. N=3000) that OOM the dev container in CSV mode
+         (~14 GB resident). *)
   progress_every : int;
       (* Friday-cycle cadence for [progress.sexp] emission, threaded into each
          scenario's [Backtest.Runner.run_backtest] call. Always populated:
@@ -420,7 +438,7 @@ let _usage () =
   eprintf
     "Usage: scenario_runner [--goldens-small | --goldens-broad | --goldens | \
      --smoke | --dir <path>] [--parallel N] [--fixtures-root <path>] \
-     [--progress-every N] [--no-emit-all-eligible]\n";
+     [--snapshot-dir <path>] [--progress-every N] [--no-emit-all-eligible]\n";
   Stdlib.exit 1
 
 let _parse_progress_every n_str =
@@ -430,65 +448,100 @@ let _parse_progress_every n_str =
       eprintf "--progress-every requires a positive integer argument\n";
       Stdlib.exit 1
 
+(* Mutable accumulator for the parse. Using a record (rather than threading 7
+   positionals through a recursive [loop]) keeps each flag case a one-line field
+   update and stays well under the function-length limit as flags grow. *)
+type _parse_acc = {
+  mutable dir : string option;
+  mutable parallel : int option;
+  mutable fixtures_root : string option;
+  mutable snapshot_dir : string option;
+  mutable progress_every : int option;
+  mutable emit_all_eligible : bool;
+}
+
+let _finalize_acc (acc : _parse_acc) : _cli_args =
+  {
+    dir = Option.value acc.dir ~default:(_goldens_small_dir ());
+    parallel = Option.value acc.parallel ~default:_default_parallel;
+    fixtures_root = acc.fixtures_root;
+    snapshot_dir = acc.snapshot_dir;
+    progress_every =
+      Option.value acc.progress_every
+        ~default:Scenario_progress.default_every_n_fridays;
+    emit_all_eligible = acc.emit_all_eligible;
+  }
+
 let _parse_flag args =
-  let rec loop args dir parallel fixtures_root progress_every emit_all_eligible
-      =
+  let acc =
+    {
+      dir = None;
+      parallel = None;
+      fixtures_root = None;
+      snapshot_dir = None;
+      progress_every = None;
+      emit_all_eligible = true;
+    }
+  in
+  let rec loop args =
     match args with
-    | [] ->
-        let dir = Option.value dir ~default:(_goldens_small_dir ()) in
-        {
-          dir;
-          parallel = Option.value parallel ~default:_default_parallel;
-          fixtures_root;
-          progress_every =
-            Option.value progress_every
-              ~default:Scenario_progress.default_every_n_fridays;
-          emit_all_eligible;
-        }
-    | "--goldens-small" :: rest ->
+    | [] -> _finalize_acc acc
+    | "--goldens-small" :: rest | "--goldens" :: rest ->
+        acc.dir <- Some (_goldens_small_dir ());
         loop rest
-          (Some (_goldens_small_dir ()))
-          parallel fixtures_root progress_every emit_all_eligible
     | "--goldens-broad" :: rest ->
+        acc.dir <- Some (_goldens_broad_dir ());
         loop rest
-          (Some (_goldens_broad_dir ()))
-          parallel fixtures_root progress_every emit_all_eligible
-    | "--goldens" :: rest ->
-        loop rest
-          (Some (_goldens_small_dir ()))
-          parallel fixtures_root progress_every emit_all_eligible
     | "--smoke" :: rest ->
+        acc.dir <- Some (_smoke_dir ());
         loop rest
-          (Some (_smoke_dir ()))
-          parallel fixtures_root progress_every emit_all_eligible
     | "--dir" :: path :: rest ->
-        loop rest (Some path) parallel fixtures_root progress_every
-          emit_all_eligible
+        acc.dir <- Some path;
+        loop rest
     | "--parallel" :: n :: rest ->
-        loop rest dir
-          (Some (Int.of_string n))
-          fixtures_root progress_every emit_all_eligible
+        acc.parallel <- Some (Int.of_string n);
+        loop rest
     | "--fixtures-root" :: path :: rest ->
-        loop rest dir parallel (Some path) progress_every emit_all_eligible
+        acc.fixtures_root <- Some path;
+        loop rest
+    | "--snapshot-dir" :: path :: rest ->
+        acc.snapshot_dir <- Some path;
+        loop rest
+    | [ "--snapshot-dir" ] ->
+        eprintf "--snapshot-dir requires a directory-path argument\n";
+        Stdlib.exit 1
     | "--progress-every" :: n :: rest ->
-        loop rest dir parallel fixtures_root
-          (Some (_parse_progress_every n))
-          emit_all_eligible
+        acc.progress_every <- Some (_parse_progress_every n);
+        loop rest
     | "--no-emit-all-eligible" :: rest ->
-        loop rest dir parallel fixtures_root progress_every false
+        acc.emit_all_eligible <- false;
+        loop rest
     | _ -> _usage ()
   in
-  loop args None None None None true
+  loop args
 
 let _parse_args () =
   let argv = Sys.get_argv () in
   _parse_flag (List.tl_exn (Array.to_list argv))
 
 let () =
-  let { dir; parallel; fixtures_root; progress_every; emit_all_eligible } =
+  let ({
+         dir;
+         parallel;
+         fixtures_root;
+         snapshot_dir;
+         progress_every;
+         emit_all_eligible;
+       }
+        : _cli_args) =
     _parse_args ()
   in
   let fixtures_root = Fixtures_root.resolve ?fixtures_root () in
+  (* Resolve the snapshot warehouse once at parse time; the same
+     [Bar_data_source.t] is reused for every cell in the run. [None] keeps the
+     pre-existing CSV behaviour bit-identical. Exits 1 on a missing/corrupt
+     manifest. *)
+  let bar_data_source = Bar_source_resolver.resolve snapshot_dir in
   let files = _list_scenario_files dir in
   if List.is_empty files then (
     eprintf "No .sexp scenario files found in %s\n" dir;
@@ -497,6 +550,10 @@ let () =
   eprintf "Loading %d scenarios from %s (parallel=%d)\n%!" (List.length files)
     dir parallel;
   eprintf "Fixtures root: %s\n%!" fixtures_root;
+  eprintf "Bar data source: %s\n%!"
+    (match snapshot_dir with
+    | Some d -> sprintf "snapshot mode (%s)" d
+    | None -> "CSV mode");
   eprintf "Progress emission: every %d Friday cycle(s) per scenario\n%!"
     progress_every;
   eprintf "All-eligible diagnostic: %s\n%!"
@@ -508,7 +565,7 @@ let () =
   eprintf "Output root: %s\n%!" output_root;
   let results =
     _run_scenarios_parallel ~output_root ~fixtures_root ~parallel
-      ~progress_every ~emit_all_eligible scenarios_with_paths
+      ~progress_every ~emit_all_eligible ~bar_data_source scenarios_with_paths
   in
   _print_header ();
   let pass_flags = List.map results ~f:(_process_result ~output_root) in

--- a/trading/trading/backtest/scenarios/test/dune
+++ b/trading/trading/backtest/scenarios/test/dune
@@ -6,7 +6,8 @@
   test_fixtures_root
   test_scenario_runner_isolation
   test_scenario_runner_actual_sexp
-  test_scenario_progress)
+  test_scenario_progress
+  test_bar_source_resolver)
  (modules
   test_scenario
   test_universe_file
@@ -14,19 +15,24 @@
   test_fixtures_root
   test_scenario_runner_isolation
   test_scenario_runner_actual_sexp
-  test_scenario_progress)
+  test_scenario_progress
+  test_bar_source_resolver)
  (libraries
   ounit2
   core
   core_unix
+  core_unix.filename_unix
   fpath
   scenario_lib
   matchers
   backtest
   backtest_cost_model
   weinstein.data_source
+  weinstein.snapshot_pipeline
+  trading.data_panel.snapshot
   trading.simulation
   universe
+  types
   status)
  (preprocess
   (pps ppx_sexp_conv ppx_deriving.eq ppx_deriving.show)))

--- a/trading/trading/backtest/scenarios/test/test_bar_source_resolver.ml
+++ b/trading/trading/backtest/scenarios/test/test_bar_source_resolver.ml
@@ -1,0 +1,130 @@
+(** Unit test for {!Scenario_lib.Bar_source_resolver.resolve} — the
+    [scenario_runner.exe] helper that maps the [--snapshot-dir] CLI value into a
+    [Backtest.Bar_data_source.t option].
+
+    Two contracts pinned here:
+
+    - [resolve None] -> [None]. The runner then omits [?bar_data_source] and
+      [Backtest.Runner.run_backtest] defaults to CSV mode — the pre-snapshot
+      behaviour, unchanged.
+    - [resolve (Some dir)] -> [Some (Snapshot { snapshot_dir = dir; manifest })]
+      where [manifest] is the one written at [<dir>/manifest.sexp]. The snapshot
+      dir + a written manifest are built with the same Phase-B pipeline trick
+      [test_snapshot_mode_parity.ml] uses, so this exercises the real
+      [Snapshot_manifest.read] path the resolver depends on rather than a stub.
+
+    The missing/corrupt-manifest path calls [Stdlib.exit 1], so it is not
+    asserted here (an [exit] inside an OUnit child would abort the runner);
+    [backtest_runner]'s equivalent helper has the same exit semantics and is the
+    canonical reference. *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_data_source = Backtest.Bar_data_source
+module Bar_source_resolver = Scenario_lib.Bar_source_resolver
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Pipeline = Snapshot_pipeline.Pipeline
+
+let _ymd y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+(* A handful of deterministic bars — just enough for the Phase-B pipeline to
+   produce a valid [.snap] file + manifest entry. *)
+let _bars ~n =
+  let start = _ymd 2020 1 2 in
+  List.init n ~f:(fun i ->
+      let close = 100.0 +. (Float.of_int i *. 0.5) in
+      {
+        Types.Daily_price.date = Date.add_days start i;
+        open_price = close -. 0.10;
+        high_price = close +. 0.20;
+        low_price = close -. 0.30;
+        close_price = close;
+        volume = 1_000_000 + (i * 1000);
+        adjusted_close = close;
+        active_through = None;
+      })
+
+(* Build a minimal snapshot warehouse at [snapshot_dir]: one [.snap] file per
+   symbol via the Phase-B pipeline, plus the directory manifest written to
+   [<snapshot_dir>/manifest.sexp] — the exact path the resolver reads. *)
+let _write_snapshot_warehouse ~snapshot_dir symbols =
+  let schema = Snapshot_schema.default in
+  let entries =
+    List.map symbols ~f:(fun symbol ->
+        let bars = _bars ~n:40 in
+        let rows =
+          match Pipeline.build_for_symbol ~symbol ~bars ~schema () with
+          | Ok r -> r
+          | Error err ->
+              assert_failure ("Pipeline.build_for_symbol: " ^ Status.show err)
+        in
+        let path = Filename.concat snapshot_dir (symbol ^ ".snap") in
+        (match Snapshot_format.write ~path rows with
+        | Ok () -> ()
+        | Error err ->
+            assert_failure ("Snapshot_format.write: " ^ Status.show err));
+        let stat = Core_unix.stat path in
+        ({
+           symbol;
+           path;
+           byte_size = Int64.to_int_exn stat.st_size;
+           payload_md5 = "ignored";
+           csv_mtime = stat.st_mtime;
+           active_through = None;
+         }
+          : Snapshot_manifest.file_metadata))
+  in
+  let manifest = Snapshot_manifest.create ~schema ~entries in
+  let manifest_path = Filename.concat snapshot_dir "manifest.sexp" in
+  (match Snapshot_manifest.write ~path:manifest_path manifest with
+  | Ok () -> ()
+  | Error err -> assert_failure ("Snapshot_manifest.write: " ^ Status.show err));
+  manifest
+
+let test_resolve_none_is_csv_default _ =
+  (* No [--snapshot-dir]: resolver yields [None] so the runner stays in CSV
+     mode, bit-identical to the pre-snapshot behaviour. *)
+  assert_that (Bar_source_resolver.resolve None) is_none
+
+let test_resolve_some_builds_snapshot_selector _ =
+  let snapshot_dir =
+    Filename_unix.temp_dir ~in_dir:"/tmp" "snapdir_resolve_" ""
+  in
+  let symbols = [ "AAA"; "BBB" ] in
+  let written = _write_snapshot_warehouse ~snapshot_dir symbols in
+  (* [resolve (Some dir)] reads [<dir>/manifest.sexp] and constructs a
+     [Snapshot] selector carrying the same dir + the on-disk manifest. We pin
+     the dir and the manifest's [schema_hash] + entry count (the manifest [t]
+     has no derived [equal], so we assert its observable fields). *)
+  assert_that
+    (Bar_source_resolver.resolve (Some snapshot_dir))
+    (is_some_and
+       (matching ~msg:"Expected Snapshot selector"
+          (function
+            | Bar_data_source.Snapshot { snapshot_dir = d; manifest } ->
+                Some (d, manifest)
+            | Bar_data_source.Csv -> None)
+          (all_of
+             [
+               field (fun (d, _) -> d) (equal_to snapshot_dir);
+               field
+                 (fun (_, m) -> m.Snapshot_manifest.schema_hash)
+                 (equal_to written.Snapshot_manifest.schema_hash);
+               field
+                 (fun (_, m) -> List.length m.Snapshot_manifest.entries)
+                 (equal_to (List.length symbols));
+             ])))
+
+let suite =
+  "bar_source_resolver"
+  >::: [
+         "resolve None -> CSV default (None)"
+         >:: test_resolve_none_is_csv_default;
+         "resolve (Some dir) -> Snapshot selector"
+         >:: test_resolve_some_builds_snapshot_selector;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## The gap

The backtest engine already supports snapshot-mode bar reading
(`Backtest.Runner.run_backtest` / `Panel_runner.run` take an optional
`?bar_data_source:Bar_data_source.t = Csv | Snapshot {…}`), and
`backtest_runner.exe` already exposes `--snapshot-mode --snapshot-dir`.
But `scenario_runner` — the `--dir` entry point the goldens use — did
**not** expose `bar_data_source`, so a golden cell always ran CSV mode,
which builds the whole universe's bars in-process (~14 GB resident at
N=3000, won't fit local memory).

## The change (mirrors `backtest_runner`)

Adds `--snapshot-dir <path>` to `scenario_runner`:

1. **New lib module `Scenario_lib.Bar_source_resolver`** (`.ml` + `.mli`)
   — `resolve : string option -> Backtest.Bar_data_source.t option`.
   `None -> None`; `Some dir -> Some (Snapshot { snapshot_dir = dir;
   manifest = Snapshot_manifest.read "<dir>/manifest.sexp" })`, exiting 1
   with a clear stderr message on a missing/corrupt manifest. This is a
   byte-faithful mirror of `backtest_runner._resolve_bar_data_source`,
   factored into the library so the manifest-read + error path is
   unit-testable without forking a full backtest.

2. **`scenario_runner.ml`** parses `--snapshot-dir` (bare trailing flag
   → clear error, like `backtest_runner`), resolves it **once at parse
   time**, and threads the resulting `?bar_data_source` into every cell's
   `Backtest.Runner.run_backtest` call. The same selector is reused for
   every cell in the `--dir` run (one manifest read). The parser was
   refactored from positional threading to a small record accumulator so
   the 7th flag stays under the function-length limit and each case is a
   one-line field update.

`Bar_data_source`, `Panel_runner`, `Backtest.Runner`, and the engine are
**not** touched — they already support this; the PR only exposes it at
the `scenario_runner` CLI.

## Default-unchanged guarantee

With no `--snapshot-dir`, `resolve None = None`, the runner omits
`?bar_data_source`, and `run_backtest` defaults to `Bar_data_source.Csv`
— **bit-identical** to today's behaviour. Confirmed by the existing
scenario tests (`test_scenario_runner_isolation`,
`test_scenario_runner_actual_sexp`) which exercise
`_run_scenario_in_child` → `run_backtest` on the no-flag path and pass
unchanged.

## Test plan

- New `test_bar_source_resolver`:
  - `resolve None -> None` (CSV-default path).
  - `resolve (Some dir) -> Snapshot {…}` over a **real** snapshot
    warehouse: builds one `.snap` per symbol via the Phase-B pipeline
    (same trick as `test_snapshot_mode_parity.ml`) + writes
    `<dir>/manifest.sexp`, then asserts the resolver returns a `Snapshot`
    selector carrying the same dir, the manifest's `schema_hash`, and the
    right entry count. Exercises the real `Snapshot_manifest.read` path.
- `dune build && dune runtest trading/backtest/` green (incl. the
  dune-wired fn_length / nesting / magic-numbers / mli_coverage linters).
- Full `dune build` + `dune runtest` green; `ocamlformat` clean on all
  changed files.

## Why this matters

Unlocks running large-N goldens (e.g. N=3000) locally in snapshot
(streaming) mode at bounded RSS — a prerequisite step toward the tier-4
release-gate at N≥5000, which is blocked on daily-snapshot streaming
(`dev/plans/daily-snapshot-streaming-2026-04-27.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
