### PR TITLE
feat(build-snapshots): accept composition universe snapshots

### DIFF
--- a/trading/analysis/scripts/build_snapshots/build_snapshots.ml
+++ b/trading/analysis/scripts/build_snapshots/build_snapshots.ml
@@ -175,25 +175,17 @@ let _process_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
         _try_build_and_checkpoint ~data_dir ~schema ~benchmark_bars ~output_dir
           ~manifest_path ~checkpoint ~csv_mtime symbol
 
-(* Minimal universe-file reader — only the [Pinned] shape is supported in
-   Phase B, which is all this writer needs (Full_sector_map requires the
-   sectors.csv side channel that the runner threads in, irrelevant to the
-   snapshot writer). The sexp shape mirrors [scenario_lib/universe_file.mli]:
-   [(Pinned ((symbol AAPL) (sector "Information Technology")) ...)]. *)
-type _pinned_entry = { symbol : string; sector : string [@warning "-69"] }
-[@@deriving sexp]
-
-type _universe_kind = Pinned of _pinned_entry list | Full_sector_map
-[@@deriving sexp]
-
+(* Universe-file reader. Accepts either the [Pinned] shape
+   ([scenario_lib/universe_file]) or an [analysis/data/universe] composition
+   snapshot (the shape the goldens' universes use). See {!Universe_loader}.
+   Exits non-zero on an unsupported shape (Full_sector_map, all-synthetic, or a
+   malformed sexp) rather than building an empty warehouse silently. *)
 let _load_universe ~universe_path =
-  let sexp = Sexp.load_sexp universe_path in
-  match _universe_kind_of_sexp sexp with
-  | Pinned entries -> List.map entries ~f:(fun e -> e.symbol)
-  | Full_sector_map ->
-      failwith
-        "build_snapshots: Full_sector_map universes are not supported in Phase \
-         B; pass a Pinned universe sexp"
+  match Universe_loader.symbols_of_path ~path:universe_path with
+  | Ok symbols -> symbols
+  | Error err ->
+      Printf.eprintf "build_snapshots: %s\n%!" (Status.show err);
+      exit 1
 
 let _load_benchmark_bars ~data_dir sym =
   match _load_bars ~data_dir ~symbol:sym with
@@ -312,7 +304,9 @@ let command =
     ~summary:"Build per-symbol snapshot files for the daily-snapshot warehouse"
     (let%map_open.Command universe_path =
        flag "universe-path" (required string)
-         ~doc:"PATH Universe sexp (Pinned shape required in Phase B)"
+         ~doc:
+           "PATH Universe sexp (Pinned shape or analysis/data/universe \
+            composition snapshot)"
      and csv_data_dir =
        flag "csv-data-dir" (required string)
          ~doc:"PATH Directory containing per-symbol CSV history"

--- a/trading/analysis/scripts/build_snapshots/dune
+++ b/trading/analysis/scripts/build_snapshots/dune
@@ -1,5 +1,13 @@
+(library
+ (name universe_loader)
+ (modules universe_loader)
+ (libraries core status universe)
+ (preprocess
+  (pps ppx_jane)))
+
 (executable
  (name build_snapshots)
+ (modules build_snapshots)
  (libraries
   core
   core_unix
@@ -7,6 +15,7 @@
   core_unix.filename_unix
   status
   trading.data_panel.snapshot
+  universe_loader
   weinstein.snapshot_pipeline
   csv)
  (preprocess

--- a/trading/analysis/scripts/build_snapshots/test/dune
+++ b/trading/analysis/scripts/build_snapshots/test/dune
@@ -1,0 +1,5 @@
+(test
+ (name test_universe_loader)
+ (libraries core ounit2 matchers status universe universe_loader)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/scripts/build_snapshots/test/test_universe_loader.ml
+++ b/trading/analysis/scripts/build_snapshots/test/test_universe_loader.ml
@@ -1,0 +1,116 @@
+open Core
+open OUnit2
+open Matchers
+module Snapshot = Universe.Snapshot
+
+(* --- Helpers ------------------------------------------------------------- *)
+
+(* The Pinned universe shape mirrors [scenario_lib/universe_file]:
+   [(Pinned ((symbol AAPL) (sector "...")) ...)]. Built as a raw sexp string so
+   the test pins the exact on-disk shape [build_snapshots] must accept. *)
+let pinned_sexp symbols =
+  let entries =
+    List.map symbols ~f:(fun s ->
+        Printf.sprintf "((symbol %s) (sector \"\"))" s)
+  in
+  Sexp.of_string
+    (Printf.sprintf "(Pinned (%s))" (String.concat ~sep:" " entries))
+
+let entry ~symbol ~synthetic ~sector : Snapshot.entry =
+  { symbol; weight = 0.001; sector; synthetic }
+
+(* A composition snapshot in the on-disk shape [Universe.Snapshot.save] writes.
+   Serialized via [sexp_of_t] so the test exercises the real decode path. *)
+let composition_sexp entries =
+  Snapshot.sexp_of_t
+    {
+      date = Date.of_string "1998-05-31";
+      method_ = Composition_from_individuals;
+      size = List.length entries;
+      entries;
+      aggregate_period_return = 0.0;
+    }
+
+(* --- Pinned (regression) ------------------------------------------------- *)
+
+let test_pinned_returns_symbols_verbatim _ctx =
+  let result =
+    Universe_loader.symbols_of_sexp (pinned_sexp [ "AAPL"; "MSFT" ])
+  in
+  assert_that result
+    (is_ok_and_holds (elements_are [ equal_to "AAPL"; equal_to "MSFT" ]))
+
+let test_full_sector_map_is_unimplemented _ctx =
+  let result =
+    Universe_loader.symbols_of_sexp (Sexp.of_string "Full_sector_map")
+  in
+  assert_that result (is_error_with Status.Unimplemented)
+
+(* --- Composition --------------------------------------------------------- *)
+
+let test_composition_returns_real_tickers _ctx =
+  let sexp =
+    composition_sexp
+      [
+        entry ~symbol:"AAPL" ~synthetic:false ~sector:"Information Technology";
+        entry ~symbol:"JPM" ~synthetic:false ~sector:"Financials";
+      ]
+  in
+  let result = Universe_loader.symbols_of_sexp sexp in
+  assert_that result
+    (is_ok_and_holds (elements_are [ equal_to "AAPL"; equal_to "JPM" ]))
+
+(* Synthetic [SYNTH_*] entries carry no CSV bars, so the loader must drop them —
+   mirrors [universe_snapshot]'s synthetic-dropping. *)
+let test_composition_drops_synthetic_entries _ctx =
+  let sexp =
+    composition_sexp
+      [
+        entry ~symbol:"AAPL" ~synthetic:false ~sector:"Information Technology";
+        entry ~symbol:"SYNTH_HiTec_0042" ~synthetic:true ~sector:"HiTec";
+        entry ~symbol:"JPM" ~synthetic:false ~sector:"Financials";
+      ]
+  in
+  let result = Universe_loader.symbols_of_sexp sexp in
+  assert_that result
+    (is_ok_and_holds (elements_are [ equal_to "AAPL"; equal_to "JPM" ]))
+
+(* All-synthetic → no tradeable symbols, mirroring [universe_snapshot]'s
+   [Failed_precondition] guard. *)
+let test_all_synthetic_is_failed_precondition _ctx =
+  let sexp =
+    composition_sexp
+      [
+        entry ~symbol:"SYNTH_HiTec_0001" ~synthetic:true ~sector:"HiTec";
+        entry ~symbol:"SYNTH_Manuf_0002" ~synthetic:true ~sector:"Manuf";
+      ]
+  in
+  let result = Universe_loader.symbols_of_sexp sexp in
+  assert_that result (is_error_with Status.Failed_precondition)
+
+(* --- Unrecognized shape -------------------------------------------------- *)
+
+let test_unrecognized_shape_is_failed_precondition _ctx =
+  let result =
+    Universe_loader.symbols_of_sexp (Sexp.of_string "(not a universe)")
+  in
+  assert_that result (is_error_with Status.Failed_precondition)
+
+let suite =
+  "universe_loader"
+  >::: [
+         "pinned returns symbols verbatim"
+         >:: test_pinned_returns_symbols_verbatim;
+         "full_sector_map is unimplemented"
+         >:: test_full_sector_map_is_unimplemented;
+         "composition returns real tickers"
+         >:: test_composition_returns_real_tickers;
+         "composition drops synthetic entries"
+         >:: test_composition_drops_synthetic_entries;
+         "all-synthetic is failed_precondition"
+         >:: test_all_synthetic_is_failed_precondition;
+         "unrecognized shape is failed_precondition"
+         >:: test_unrecognized_shape_is_failed_precondition;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/scripts/build_snapshots/universe_loader.ml
+++ b/trading/analysis/scripts/build_snapshots/universe_loader.ml
@@ -1,0 +1,83 @@
+(** Universe-file reader for the snapshot warehouse writer — see
+    [universe_loader.mli]. *)
+
+open Core
+module Snapshot = Universe.Snapshot
+
+(* The [Pinned] universe shape mirrors [scenario_lib/universe_file.mli]:
+   [(Pinned ((symbol AAPL) (sector "Information Technology")) ...)]. Only the
+   symbol is needed by the snapshot writer; the sector field is retained for
+   sexp-shape fidelity but otherwise unused. *)
+type _pinned_entry = { symbol : string; sector : string [@warning "-69"] }
+[@@deriving sexp]
+
+type _universe_kind = Pinned of _pinned_entry list | Full_sector_map
+[@@deriving sexp]
+
+let _full_sector_map_error =
+  Error
+    Status.
+      {
+        code = Unimplemented;
+        message =
+          "build_snapshots: Full_sector_map universes are not supported; pass \
+           a Pinned universe sexp or a composition snapshot.";
+      }
+
+let _unrecognized_shape_error =
+  Error
+    Status.
+      {
+        code = Failed_precondition;
+        message =
+          "build_snapshots: universe sexp is neither a Pinned/Full_sector_map \
+           universe nor a composition snapshot.";
+      }
+
+(* Mirrors [universe_snapshot._empty_after_filter_error]: a snapshot with no
+   non-synthetic entries yields no tradeable symbols, so the writer cannot
+   meaningfully consume it. *)
+let _all_synthetic_error =
+  Error
+    Status.
+      {
+        code = Failed_precondition;
+        message =
+          "build_snapshots: composition snapshot has no non-synthetic entries; \
+           the writer has no synthetic-bar source so there are no symbols to \
+           build.";
+      }
+
+(* Real-ticker symbol of a snapshot entry, or [None] for synthetic entries —
+   those carry pseudo-tickers like [SYNTH_HiTec_0042] that the writer has no CSV
+   bars for. Mirrors [universe_snapshot._entry_to_pair]. *)
+let _entry_to_symbol (e : Snapshot.entry) : string option =
+  if e.synthetic then None else Some e.symbol
+
+let _symbols_of_snapshot (snapshot : Snapshot.t) : string list Status.status_or
+    =
+  let symbols = List.filter_map snapshot.entries ~f:_entry_to_symbol in
+  if List.is_empty symbols then _all_synthetic_error else Ok symbols
+
+(* Try the [Universe.Snapshot.t] sexp shape. A composition snapshot is the
+   expected hit here; any sexp that fails to decode as a snapshot is reported as
+   an unrecognized universe shape rather than the raw decode failure. *)
+let _try_composition sexp =
+  match Snapshot.t_of_sexp sexp with
+  | snapshot -> _symbols_of_snapshot snapshot
+  | exception _ -> _unrecognized_shape_error
+
+let symbols_of_sexp sexp =
+  match _universe_kind_of_sexp sexp with
+  | Pinned entries -> Ok (List.map entries ~f:(fun e -> e.symbol))
+  | Full_sector_map -> _full_sector_map_error
+  | exception _ -> _try_composition sexp
+
+let symbols_of_path ~path =
+  match Sexp.load_sexp path with
+  | sexp -> symbols_of_sexp sexp
+  | exception exn ->
+      Status.error_internal
+        (Printf.sprintf
+           "build_snapshots: failed to read universe sexp at %s: %s" path
+           (Exn.to_string exn))

--- a/trading/analysis/scripts/build_snapshots/universe_loader.mli
+++ b/trading/analysis/scripts/build_snapshots/universe_loader.mli
@@ -1,0 +1,37 @@
+(** Universe-file reader for the snapshot warehouse writer.
+
+    [build_snapshots] needs the list of real-ticker symbols to build per-symbol
+    snapshots for. Two on-disk universe shapes are accepted; [symbols_of_sexp]
+    auto-detects by shape:
+
+    - {b Pinned} — the [scenario_lib/universe_file] shape
+      [(Pinned ((symbol AAPL) (sector "Information Technology")) ...)]. The
+      [symbol] of each entry is returned verbatim. [Full_sector_map] is
+      recognised but unsupported (it needs the sectors.csv side channel the
+      runner threads in, which is irrelevant to the snapshot writer).
+
+    - {b Composition snapshot} — an [analysis/data/universe]
+      {!Universe.Snapshot.t} with [method_ = Composition_from_individuals], the
+      shape the goldens' universes use. Each non-synthetic entry's real ticker
+      is returned; synthetic pseudo-symbols ([SYNTH_*], [synthetic = true]) are
+      dropped because the writer has no CSV bars for them. Mirrors the
+      extraction in [trading/trading/backtest/scenarios/universe_snapshot.ml].
+*)
+
+val symbols_of_sexp : Core.Sexp.t -> string list Status.status_or
+(** [symbols_of_sexp sexp] extracts the real-ticker symbol list from a parsed
+    universe sexp.
+
+    Returns:
+    - [Ok symbols] when [sexp] parses as a [Pinned] universe (symbols verbatim)
+      or as a composition {!Universe.Snapshot.t} (non-synthetic tickers only).
+    - [Error Unimplemented] when [sexp] parses as [Full_sector_map].
+    - [Error Failed_precondition] when a composition snapshot has no
+      non-synthetic entries (every member is synthetic), mirroring
+      [universe_snapshot]'s all-synthetic guard.
+    - [Error Failed_precondition] when [sexp] matches neither shape. *)
+
+val symbols_of_path : path:string -> string list Status.status_or
+(** [symbols_of_path ~path] loads the sexp at [path] and applies
+    {!symbols_of_sexp}. Returns [Error Internal] on a filesystem / sexp-parse
+    failure reading the file. *)


### PR DESCRIPTION
## Gap

`build_snapshots.exe` builds the per-symbol snapshot warehouse from a universe sexp + per-symbol CSVs. Its `_load_universe` only parsed the `Pinned`/`Full_sector_map` shape and **failed on anything else**.

The goldens-broad cells (migrated in #1449) reference **composition universe snapshots** under `trading/test_data/goldens-custom-universe/composition/top-{N}-{year}.sexp`. Those are `analysis/data/universe` `Snapshot.t` values (`Composition_from_individuals`) — a different sexp shape. So `build_snapshots` could not build a snapshot warehouse for a golden's universe, a blocker for running large-N goldens locally in snapshot mode (step 2 of that enablement).

## Change

Factor the universe-loading logic out of the exe into a small testable `Universe_loader` library that **auto-detects by shape**:

1. **Try the existing `Pinned`/`Full_sector_map` parse first** — `Pinned` returns its symbols verbatim (unchanged behaviour); `Full_sector_map` returns `Unimplemented` (was a `failwith` before).
2. **Otherwise load as a composition snapshot** via `Universe.Snapshot.t_of_sexp` and extract the **real-ticker symbols** from its entries.
3. **Drop synthetic pseudo-symbols** (`synthetic = true` / `SYNTH_*`) — they have no CSV bars — and return `Failed_precondition` when a snapshot is **all-synthetic**. This extraction + synthetic-dropping + all-synthetic guard **mirrors `trading/trading/backtest/scenarios/universe_snapshot.ml`** (`load_path_as_pairs`).
4. **Dep:** the new `universe_loader` lib depends on `universe` (`analysis/data/universe`). This is `analysis` → `analysis`, no cross-`trading/trading/` boundary — no A2 concern. (Did not depend on `scenario_lib`, which lives under `trading/trading/backtest/scenarios/` and would have pulled the whole backtest surface into an `analysis/scripts` exe.)

Only widens what `-universe-path` accepts; all flags/behaviour intact. Auto-detect by shape, no new flag.

## Where the logic lives

- `trading/analysis/scripts/build_snapshots/universe_loader.{ml,mli}` — new lib. `symbols_of_sexp` / `symbols_of_path`.
- `build_snapshots.ml` `_load_universe` now delegates to `Universe_loader.symbols_of_path` and `exit 1`s with the status message on an unsupported shape (rather than silently building an empty warehouse).

## Test plan (`trading/analysis/scripts/build_snapshots/test/test_universe_loader.ml`, 6 tests, all green)

- **Pinned regression** — a `Pinned` sexp returns symbols verbatim (`["AAPL"; "MSFT"]`).
- **Full_sector_map** → `Error Unimplemented`.
- **Composition** → real tickers (`["AAPL"; "JPM"]`).
- **Composition drops synthetics** — a 3-entry snapshot with one `SYNTH_HiTec_0042` (`synthetic = true`) returns only the 2 real tickers.
- **All-synthetic** → `Error Failed_precondition` (mirrors `universe_snapshot`).
- **Unrecognized shape** → `Error Failed_precondition`.

End-to-end: ran the exe against the real committed `composition/top-1000-1998.sexp` with an empty CSV dir — it loaded the real tickers (AKR, AMZN, AAPL, …) and attempted to build each, confirming `-universe-path` now accepts a composition snapshot.

`dune build` + `dune runtest analysis/scripts/build_snapshots/` green; `dune build @fmt` clean; full `dune build` exit 0.

## Unblocks

Building snapshot warehouses for the goldens' composition universes — step 2 of enabling large-N goldens to run locally in snapshot mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
