### PR TITLE
feat(build-snapshots): optional --start-date/--end-date bar windowing

### DIFF
--- a/trading/analysis/scripts/build_snapshots/bar_window.ml
+++ b/trading/analysis/scripts/build_snapshots/bar_window.ml
@@ -1,0 +1,16 @@
+(** Inclusive date-windowing of a symbol's daily bars — see [bar_window.mli]. *)
+
+open Core
+
+let _at_or_after start (b : Types.Daily_price.t) = Date.( >= ) b.date start
+let _at_or_before end_ (b : Types.Daily_price.t) = Date.( <= ) b.date end_
+
+let filter ?start ?end_ bars =
+  let bars =
+    match start with
+    | None -> bars
+    | Some start -> List.filter bars ~f:(_at_or_after start)
+  in
+  match end_ with
+  | None -> bars
+  | Some end_ -> List.filter bars ~f:(_at_or_before end_)

--- a/trading/analysis/scripts/build_snapshots/bar_window.mli
+++ b/trading/analysis/scripts/build_snapshots/bar_window.mli
@@ -1,0 +1,39 @@
+(** Inclusive date-windowing of a symbol's daily bars for the snapshot warehouse
+    writer.
+
+    [build_snapshots] loads each symbol's {e entire} CSV history and, when no
+    window is requested, builds the snapshot off that full history. A
+    full-history warehouse is pathologically slow to run: the snapshot runtime
+    ({!Daily_panels}) decodes the whole per-symbol file on first access, and for
+    a multi-hundred-symbol warehouse the decoded working set blows the 1 GB LRU
+    cache → thrash → re-decode every symbol every cycle (~100x slower than CSV
+    mode). {!Csv_snapshot_builder} avoids this by windowing each symbol's bars
+    to the backtest range (incl. warmup) before building; this module gives the
+    warehouse writer the same windowing as a pure, unit-testable helper.
+
+    {b Warmup caveat.} Indicators (50-day SMA, 30-week MA, …) are computed by
+    {!Snapshot_pipeline.Pipeline.build_for_symbol} walking {e only} the bars it
+    is given. Bars before [start] are excluded here, so the windowed warehouse's
+    earliest in-window dates carry NaN indicators until enough in-window samples
+    accumulate — identical to the CSV path's contract. The {e caller} is
+    therefore responsible for passing a [start] early enough to cover indicator
+    warmup before the backtest's actual start — i.e. the backtest's
+    {e warmup_start}, exactly as {!Csv_snapshot_builder.build} is invoked with
+    [~warmup_start] from [panel_runner]. This helper does not auto-extend the
+    lookback. *)
+
+val filter :
+  ?start:Core.Date.t ->
+  ?end_:Core.Date.t ->
+  Types.Daily_price.t list ->
+  Types.Daily_price.t list
+(** [filter ?start ?end_ bars] keeps only bars whose [date] falls in the
+    inclusive window:
+
+    - both [start] and [end_] given → [start <= date <= end_];
+    - only [start] → [date >= start];
+    - only [end_] → [date <= end_];
+    - neither → [bars] unchanged (returned as-is).
+
+    Relative bar order is preserved. The window is inclusive of both endpoints,
+    matching {!Csv_storage.get}'s [~start_date]/[~end_date] semantics. *)

--- a/trading/analysis/scripts/build_snapshots/build_snapshots.ml
+++ b/trading/analysis/scripts/build_snapshots/build_snapshots.ml
@@ -13,6 +13,21 @@
     {!Snapshot_schema.Macro_composite} are populated. Without it those columns
     are NaN per {!Snapshot_pipeline.Pipeline.build_for_symbol}'s contract.
 
+    Optional [--start-date YYYY-MM-DD] / [--end-date YYYY-MM-DD]: window each
+    symbol's loaded bars to the inclusive [start, end] range {e before} building
+    (the benchmark bars get the same window so RS_line / Macro_composite stay
+    consistent). Omitting both is unchanged behaviour (full history). This makes
+    a snapshot-mode warehouse cache-friendly: a full-history warehouse forces
+    {!Daily_panels} to decode whole per-symbol files and blows the 1 GB LRU
+    cache → thrash → re-decode every symbol every cycle (~100x slower than CSV
+    mode). Windowing mirrors {!Csv_snapshot_builder}'s contract — see
+    {!Bar_window} for the rationale and the {b warmup caveat}: indicators are
+    computed only over the bars passed in, so the caller must set [--start-date]
+    to the backtest's {e warmup_start} (early enough to cover 50-day / 30-week
+    lookback), exactly as [Csv_snapshot_builder.build] is invoked with
+    [~warmup_start]. The durable fix is a Phase-F windowed/mmap decode in
+    {!Daily_panels}; this flag is the cheap interim mitigation.
+
     Checkpointing (added per dev/plans/data-pipeline-automation-2026-05-03.md):
 
     - Per-symbol atomic manifest update via
@@ -67,6 +82,22 @@ let _load_bars ~data_dir ~symbol =
         (Status.invalid_argument_error
            (Printf.sprintf "create %s: %s" symbol (Status.show err)))
   | Ok storage -> Csv.Csv_storage.get storage ()
+
+(* Window a symbol's loaded bars to the inclusive [start_date, end_date] range
+   before the snapshot pipeline sees them. Mirrors [Csv_snapshot_builder]'s
+   windowing so a snapshot-mode warehouse stays cache-friendly (see
+   {!Bar_window} for the perf rationale + warmup caveat). When both bounds are
+   [None] the bars pass through unchanged. *)
+let _window_bars ~start_date ~end_date bars =
+  Bar_window.filter ?start:start_date ?end_:end_date bars
+
+(* Load a symbol's bars and apply the date window. The window is also threaded
+   into the benchmark load (see [_load_benchmark_bars]) so RS_line /
+   Macro_composite are computed over the same range. *)
+let _load_windowed_bars ~data_dir ~start_date ~end_date ~symbol =
+  match _load_bars ~data_dir ~symbol with
+  | Error _ as err -> err
+  | Ok bars -> Ok (_window_bars ~start_date ~end_date bars)
 
 let _file_path ~output_dir ~symbol =
   Filename.concat output_dir (symbol ^ ".snap")
@@ -152,9 +183,9 @@ let _build_or_log ~symbol ~bars ~schema ~benchmark_bars ~output_dir ~csv_mtime
 (** Load bars for [symbol] and build its snapshot entry. Returns [None] on load
     or build failure (logs the error). On success, optionally checkpoints the
     manifest entry if [checkpoint] is set. *)
-let _try_build_and_checkpoint ~data_dir ~schema ~benchmark_bars ~output_dir
-    ~manifest_path ~checkpoint ~csv_mtime symbol =
-  match _load_bars ~data_dir ~symbol with
+let _try_build_and_checkpoint ~data_dir ~start_date ~end_date ~schema
+    ~benchmark_bars ~output_dir ~manifest_path ~checkpoint ~csv_mtime symbol =
+  match _load_windowed_bars ~data_dir ~start_date ~end_date ~symbol with
   | Error err ->
       Printf.eprintf "skip %s: load: %s\n%!" symbol (Status.show err);
       None
@@ -162,8 +193,8 @@ let _try_build_and_checkpoint ~data_dir ~schema ~benchmark_bars ~output_dir
       _build_or_log ~symbol ~bars ~schema ~benchmark_bars ~output_dir ~csv_mtime
         ~manifest_path ~checkpoint
 
-let _process_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
-    ~manifest_path ~checkpoint symbol =
+let _process_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
+    ~output_dir ~existing ~manifest_path ~checkpoint symbol =
   match _csv_mtime ~data_dir ~symbol with
   | None ->
       Printf.eprintf "skip %s: no CSV\n%!" symbol;
@@ -172,8 +203,9 @@ let _process_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
       if _should_skip ~existing ~symbol ~csv_mtime ~schema then
         _maybe_reuse ~existing ~symbol
       else
-        _try_build_and_checkpoint ~data_dir ~schema ~benchmark_bars ~output_dir
-          ~manifest_path ~checkpoint ~csv_mtime symbol
+        _try_build_and_checkpoint ~data_dir ~start_date ~end_date ~schema
+          ~benchmark_bars ~output_dir ~manifest_path ~checkpoint ~csv_mtime
+          symbol
 
 (* Universe-file reader. Accepts either the [Pinned] shape
    ([scenario_lib/universe_file]) or an [analysis/data/universe] composition
@@ -187,16 +219,17 @@ let _load_universe ~universe_path =
       Printf.eprintf "build_snapshots: %s\n%!" (Status.show err);
       exit 1
 
-let _load_benchmark_bars ~data_dir sym =
-  match _load_bars ~data_dir ~symbol:sym with
+let _load_benchmark_bars ~data_dir ~start_date ~end_date sym =
+  match _load_windowed_bars ~data_dir ~start_date ~end_date ~symbol:sym with
   | Ok bars -> Some bars
   | Error err ->
       Printf.eprintf "warning: benchmark %s load failed: %s\n%!" sym
         (Status.show err);
       None
 
-let _benchmark_bars_opt ~data_dir ~benchmark_symbol =
-  Option.bind benchmark_symbol ~f:(_load_benchmark_bars ~data_dir)
+let _benchmark_bars_opt ~data_dir ~start_date ~end_date ~benchmark_symbol =
+  Option.bind benchmark_symbol
+    ~f:(_load_benchmark_bars ~data_dir ~start_date ~end_date)
 
 let _verify_or_warn ~manifest_path =
   match Snapshot_verifier.verify_directory ~manifest_path with
@@ -263,11 +296,12 @@ let _write_final_manifest ~manifest_path ~schema ~entries ~elapsed =
       Printf.eprintf "manifest write failed: %s\n%!" (Status.show err);
       exit 1
 
-let _fold_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
-    ~manifest_path ~progress_every ~symbols_total ~started_at i acc symbol =
+let _fold_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
+    ~output_dir ~existing ~manifest_path ~progress_every ~symbols_total
+    ~started_at i acc symbol =
   match
-    _process_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
-      ~manifest_path ~checkpoint:true symbol
+    _process_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
+      ~output_dir ~existing ~manifest_path ~checkpoint:true symbol
   with
   | None -> acc
   | Some entry ->
@@ -276,14 +310,16 @@ let _fold_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
         ~symbols_done ~last_completed:symbol ~started_at;
       acc @ [ entry ]
 
-let main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol ~incremental
-    ~progress_every () =
+let main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol ~start_date
+    ~end_date ~incremental ~progress_every () =
   _ensure_dir output_dir;
   let schema = Snapshot_schema.default in
   let symbols = _load_universe ~universe_path in
   let symbols_total = List.length symbols in
   let data_dir = Fpath.v csv_data_dir in
-  let benchmark_bars = _benchmark_bars_opt ~data_dir ~benchmark_symbol in
+  let benchmark_bars =
+    _benchmark_bars_opt ~data_dir ~start_date ~end_date ~benchmark_symbol
+  in
   let existing = if incremental then _existing_manifest ~output_dir else None in
   let manifest_path = Filename.concat output_dir "manifest.sexp" in
   let started_at = Core_unix.time () in
@@ -291,8 +327,9 @@ let main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol ~incremental
   let entries =
     List.foldi symbols ~init:[]
       ~f:
-        (_fold_symbol ~data_dir ~schema ~benchmark_bars ~output_dir ~existing
-           ~manifest_path ~progress_every ~symbols_total ~started_at)
+        (_fold_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
+           ~output_dir ~existing ~manifest_path ~progress_every ~symbols_total
+           ~started_at)
   in
   let elapsed = Time_ns.diff (Time_ns.now ()) t0 in
   _write_final_manifest ~manifest_path ~schema ~entries ~elapsed;
@@ -318,6 +355,21 @@ let command =
          ~doc:
            "SYM Optional benchmark ticker for RS_line / Macro_composite \
             (default: NaN columns)"
+     and start_date =
+       flag "start-date"
+         (optional (Command.Arg_type.create Date.of_string))
+         ~doc:
+           "YYYY-MM-DD Optional inclusive lower bound: drop each symbol's bars \
+            before this date before building (default: full history). Pass the \
+            backtest's WARMUP_START, not its start — indicators warm up over \
+            in-window bars only, so earlier dates carry NaN indicators (same \
+            contract as Csv_snapshot_builder's ~warmup_start)."
+     and end_date =
+       flag "end-date"
+         (optional (Command.Arg_type.create Date.of_string))
+         ~doc:
+           "YYYY-MM-DD Optional inclusive upper bound: drop each symbol's bars \
+            after this date before building (default: full history)."
      and incremental =
        flag "incremental" no_arg
          ~doc:
@@ -332,6 +384,6 @@ let command =
      in
      fun () ->
        main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol
-         ~incremental ~progress_every ())
+         ~start_date ~end_date ~incremental ~progress_every ())
 
 let () = Command_unix.run command

--- a/trading/analysis/scripts/build_snapshots/dune
+++ b/trading/analysis/scripts/build_snapshots/dune
@@ -5,6 +5,13 @@
  (preprocess
   (pps ppx_jane)))
 
+(library
+ (name bar_window)
+ (modules bar_window)
+ (libraries core types)
+ (preprocess
+  (pps ppx_jane)))
+
 (executable
  (name build_snapshots)
  (modules build_snapshots)
@@ -15,6 +22,7 @@
   core_unix.filename_unix
   status
   trading.data_panel.snapshot
+  bar_window
   universe_loader
   weinstein.snapshot_pipeline
   csv)

--- a/trading/analysis/scripts/build_snapshots/test/dune
+++ b/trading/analysis/scripts/build_snapshots/test/dune
@@ -1,5 +1,13 @@
-(test
- (name test_universe_loader)
- (libraries core ounit2 matchers status universe universe_loader)
+(tests
+ (names test_universe_loader test_bar_window)
+ (libraries
+  core
+  ounit2
+  matchers
+  status
+  types
+  universe
+  universe_loader
+  bar_window)
  (preprocess
   (pps ppx_jane)))

--- a/trading/analysis/scripts/build_snapshots/test/test_bar_window.ml
+++ b/trading/analysis/scripts/build_snapshots/test/test_bar_window.ml
@@ -1,0 +1,83 @@
+open Core
+open OUnit2
+open Matchers
+
+(* Minimal [Daily_price.t] builder: only [date] is load-bearing for the window
+   filter; the OHLCV fields are fixed placeholders. *)
+let bar date_str : Types.Daily_price.t =
+  {
+    date = Date.of_string date_str;
+    open_price = 100.0;
+    high_price = 101.0;
+    low_price = 99.0;
+    close_price = 100.5;
+    volume = 1_000;
+    adjusted_close = 100.5;
+    active_through = None;
+  }
+
+(* Five consecutive trading days spanning a clear before / window / after split
+   so each bound's behaviour is observable. *)
+let bars =
+  [
+    bar "2020-01-02";
+    bar "2020-01-03";
+    bar "2020-01-06";
+    bar "2020-01-07";
+    bar "2020-01-08";
+  ]
+
+let dates bars = List.map bars ~f:(fun (b : Types.Daily_price.t) -> b.date)
+
+let test_inclusive_window _ =
+  (* [start, end] keeps only the three in-range bars; both endpoints inclusive. *)
+  let result =
+    Bar_window.filter
+      ~start:(Date.of_string "2020-01-03")
+      ~end_:(Date.of_string "2020-01-07")
+      bars
+  in
+  assert_that (dates result)
+    (elements_are
+       [
+         equal_to (Date.of_string "2020-01-03");
+         equal_to (Date.of_string "2020-01-06");
+         equal_to (Date.of_string "2020-01-07");
+       ])
+
+let test_start_only _ =
+  (* start-only filters [date >= start]: drops the first bar, keeps the rest. *)
+  let result = Bar_window.filter ~start:(Date.of_string "2020-01-06") bars in
+  assert_that (dates result)
+    (elements_are
+       [
+         equal_to (Date.of_string "2020-01-06");
+         equal_to (Date.of_string "2020-01-07");
+         equal_to (Date.of_string "2020-01-08");
+       ])
+
+let test_end_only _ =
+  (* end-only filters [date <= end]: keeps the first two, drops the rest. *)
+  let result = Bar_window.filter ~end_:(Date.of_string "2020-01-03") bars in
+  assert_that (dates result)
+    (elements_are
+       [
+         equal_to (Date.of_string "2020-01-02");
+         equal_to (Date.of_string "2020-01-03");
+       ])
+
+let test_no_bounds_unchanged _ =
+  (* Neither bound → bars returned unchanged (same elements, same order). *)
+  assert_that (Bar_window.filter bars)
+    (elements_are (List.map bars ~f:(fun b -> equal_to b)))
+
+let suite =
+  "bar_window"
+  >::: [
+         "inclusive_window" >:: test_inclusive_window;
+         "start_only" >:: test_start_only;
+         "end_only" >:: test_end_only;
+         "no_bounds_unchanged" >:: test_no_bounds_unchanged;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

Adds two optional flags to `build_snapshots.exe`:

- `-start-date <YYYY-MM-DD>` — inclusive lower bound
- `-end-date <YYYY-MM-DD>` — inclusive upper bound

When provided, each symbol's loaded daily bars (and the `--benchmark-symbol`
bars) are windowed to the inclusive `[start, end]` range **before**
`Snapshot_pipeline.Pipeline.build_for_symbol` sees them. Omitting both is
unchanged behaviour (full history) — backward-compatible.

## Why — the diagnosed ~100x per-cycle perf cliff

The snapshot warehouse writer currently writes one `<SYMBOL>.snap` per symbol
containing that symbol's **entire CSV history** (AAPL 1980→2026 = 11,439 rows,
GE 1962→, …). At runtime `Daily_panels._load_symbol_file` decodes the **whole
file** into the OCaml heap on first access. For a ~1000-symbol warehouse
(~1.1 GB on disk, several× larger decoded) the working set blows the 1 GB LRU
cache → thrash → re-decode every symbol every cycle → CPU-bound ~100x slower
than CSV mode.

CSV mode (`Csv_snapshot_builder.build`) avoids this because it windows each
symbol's bars to `[start_date, end_date]` (the backtest range incl. warmup)
before building, keeping the in-process snapshot small. This PR gives the
warehouse writer the same windowing, making snapshot-mode warehouses
cache-friendly / runnable.

## Warmup-caveat contract (matches CSV path)

Indicators (50-day SMA, 30-week MA, …) are computed by `build_for_symbol`
walking **only** the bars it is given. Bars before `start-date` are excluded, so
the warehouse's earliest in-window dates carry NaN indicators until enough
in-window samples accumulate — identical to the CSV path's contract. The
**caller must pass the backtest's warmup_start** (early enough to cover
indicator lookback), exactly as `Csv_snapshot_builder.build` is invoked with
`~warmup_start` from `panel_runner`. This PR does not auto-extend the lookback;
it matches CSV mode's "caller passes warmup_start" contract and documents it in
both the flag doc and the `Bar_window` / module headers.

## Where the filter lives

`trading/analysis/scripts/build_snapshots/bar_window.{ml,mli}` — a new tiny pure
lib `bar_window` (`Bar_window.filter ?start ?end_ bars`), unit-testable without
running the exe. `build_snapshots.ml` threads the window through the per-symbol
and benchmark load paths.

## Test plan

`trading/analysis/scripts/build_snapshots/test/test_bar_window.ml`:

- `inclusive_window` — `[2020-01-03, 2020-01-07]` keeps exactly
  `{01-03, 01-06, 01-07}` (both endpoints inclusive).
- `start_only` — `start=2020-01-06` keeps `{01-06, 01-07, 01-08}` (`date >=`).
- `end_only` — `end=2020-01-03` keeps `{01-02, 01-03}` (`date <=`).
- `no_bounds_unchanged` — neither bound → bars returned unchanged.

`dune build && dune runtest` green, `dune build @fmt` clean (my files).

## Out of scope

The durable fix is a Phase-F windowed/mmap decode in `Daily_panels` so the
runtime never materializes whole per-symbol files. This PR is the cheap interim
mitigation at the warehouse-writer seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
