### PR TITLE
feat(scenario-snapshots): derive warmup-windowed all-symbols warehouse from a scenario

### DIFF
--- a/trading/analysis/scripts/build_snapshots/build_runner.ml
+++ b/trading/analysis/scripts/build_snapshots/build_runner.ml
@@ -1,0 +1,261 @@
+open Core
+module Pipeline = Snapshot_pipeline.Pipeline
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Snapshot_verifier = Snapshot_pipeline.Snapshot_verifier
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+
+let default_progress_every = 50
+
+type progress = {
+  symbols_total : int;
+  symbols_done : int;
+  last_completed : string;
+  started_at : float;
+  updated_at : float;
+}
+[@@deriving sexp]
+
+let _csv_mtime ~data_dir ~symbol =
+  let dir = Csv.Csv_storage.symbol_data_dir ~data_dir symbol in
+  let csv_path = Fpath.add_seg dir "data.csv" |> Fpath.to_string in
+  if Stdlib.Sys.file_exists csv_path then
+    Some (Core_unix.stat csv_path).st_mtime
+  else None
+
+let _load_bars ~data_dir ~symbol =
+  match Csv.Csv_storage.create ~data_dir symbol with
+  | Error err ->
+      Error
+        (Status.invalid_argument_error
+           (Printf.sprintf "create %s: %s" symbol (Status.show err)))
+  | Ok storage -> Csv.Csv_storage.get storage ()
+
+(* Window a symbol's loaded bars to the inclusive [start_date, end_date] range
+   before the snapshot pipeline sees them. Mirrors [Csv_snapshot_builder]'s
+   windowing so a snapshot-mode warehouse stays cache-friendly (see
+   {!Bar_window} for the perf rationale + warmup caveat). When both bounds are
+   [None] the bars pass through unchanged. *)
+let _window_bars ~start_date ~end_date bars =
+  Bar_window.filter ?start:start_date ?end_:end_date bars
+
+let _load_windowed_bars ~data_dir ~start_date ~end_date ~symbol =
+  match _load_bars ~data_dir ~symbol with
+  | Error _ as err -> err
+  | Ok bars -> Ok (_window_bars ~start_date ~end_date bars)
+
+let _file_path ~output_dir ~symbol =
+  Filename.concat output_dir (symbol ^ ".snap")
+
+let _existing_manifest ~output_dir =
+  let path = Filename.concat output_dir "manifest.sexp" in
+  match Snapshot_manifest.read ~path with Ok m -> Some m | Error _ -> None
+
+let _entry_is_current ~csv_mtime (e : Snapshot_manifest.file_metadata) =
+  Float.( <= ) csv_mtime e.csv_mtime && Stdlib.Sys.file_exists e.path
+
+let _should_skip ~existing ~symbol ~csv_mtime ~schema =
+  match existing with
+  | None -> false
+  | Some (m : Snapshot_manifest.t) ->
+      String.equal m.schema_hash schema.Snapshot_schema.schema_hash
+      && Option.value_map
+           (Snapshot_manifest.find m ~symbol)
+           ~default:false
+           ~f:(_entry_is_current ~csv_mtime)
+
+let _file_metadata ~symbol ~path ~csv_mtime ~active_through =
+  let bytes = In_channel.read_all path in
+  {
+    Snapshot_manifest.symbol;
+    path;
+    byte_size = String.length bytes;
+    payload_md5 = Stdlib.Digest.to_hex (Stdlib.Digest.string bytes);
+    csv_mtime;
+    active_through;
+  }
+
+(* Last-bar [active_through] is the symbol's delisting marker. The CSV loader
+   sets the same value on every row of a symbol's history, so reading the tail
+   is equivalent to reading any row. *)
+let _active_through_of_bars (bars : Types.Daily_price.t list) : Date.t option =
+  List.last bars
+  |> Option.bind ~f:(fun (b : Types.Daily_price.t) -> b.active_through)
+
+let _write_and_checksum ~symbol ~path ~csv_mtime ~active_through rows =
+  match Snapshot_format.write ~path rows with
+  | Error err -> Error err
+  | Ok () -> Ok (_file_metadata ~symbol ~path ~csv_mtime ~active_through)
+
+let _build_one_symbol ~symbol ~bars ~schema ~benchmark_bars ~output_dir
+    ~csv_mtime =
+  let path = _file_path ~output_dir ~symbol in
+  let active_through = _active_through_of_bars bars in
+  match Pipeline.build_for_symbol ~symbol ~bars ~schema ?benchmark_bars () with
+  | Error err -> Error err
+  | Ok rows -> _write_and_checksum ~symbol ~path ~csv_mtime ~active_through rows
+
+let _maybe_reuse ~existing ~symbol =
+  match existing with
+  | None -> None
+  | Some m -> Snapshot_manifest.find m ~symbol
+
+let _checkpoint_manifest ~manifest_path ~schema entry =
+  match
+    Snapshot_manifest.update_for_symbol ~path:manifest_path ~schema entry
+  with
+  | Ok () -> ()
+  | Error err ->
+      Printf.eprintf "manifest checkpoint failed for %s: %s\n%!"
+        entry.Snapshot_manifest.symbol (Status.show err)
+
+let _build_or_log ~symbol ~bars ~schema ~benchmark_bars ~output_dir ~csv_mtime
+    ~manifest_path ~checkpoint =
+  match
+    _build_one_symbol ~symbol ~bars ~schema ~benchmark_bars ~output_dir
+      ~csv_mtime
+  with
+  | Error err ->
+      Printf.eprintf "skip %s: build: %s\n%!" symbol (Status.show err);
+      None
+  | Ok entry ->
+      if checkpoint then _checkpoint_manifest ~manifest_path ~schema entry;
+      Some entry
+
+let _try_build_and_checkpoint ~data_dir ~start_date ~end_date ~schema
+    ~benchmark_bars ~output_dir ~manifest_path ~checkpoint ~csv_mtime symbol =
+  match _load_windowed_bars ~data_dir ~start_date ~end_date ~symbol with
+  | Error err ->
+      Printf.eprintf "skip %s: load: %s\n%!" symbol (Status.show err);
+      None
+  | Ok bars ->
+      _build_or_log ~symbol ~bars ~schema ~benchmark_bars ~output_dir ~csv_mtime
+        ~manifest_path ~checkpoint
+
+let _process_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
+    ~output_dir ~existing ~manifest_path ~checkpoint symbol =
+  match _csv_mtime ~data_dir ~symbol with
+  | None ->
+      Printf.eprintf "skip %s: no CSV\n%!" symbol;
+      None
+  | Some csv_mtime ->
+      if _should_skip ~existing ~symbol ~csv_mtime ~schema then
+        _maybe_reuse ~existing ~symbol
+      else
+        _try_build_and_checkpoint ~data_dir ~start_date ~end_date ~schema
+          ~benchmark_bars ~output_dir ~manifest_path ~checkpoint ~csv_mtime
+          symbol
+
+let _load_benchmark_bars ~data_dir ~start_date ~end_date sym =
+  match _load_windowed_bars ~data_dir ~start_date ~end_date ~symbol:sym with
+  | Ok bars -> Some bars
+  | Error err ->
+      Printf.eprintf "warning: benchmark %s load failed: %s\n%!" sym
+        (Status.show err);
+      None
+
+let _benchmark_bars_opt ~data_dir ~start_date ~end_date ~benchmark_symbol =
+  Option.bind benchmark_symbol
+    ~f:(_load_benchmark_bars ~data_dir ~start_date ~end_date)
+
+let _verify_or_warn ~manifest_path =
+  match Snapshot_verifier.verify_directory ~manifest_path with
+  | Error err ->
+      Printf.eprintf "verify failed: %s\n%!" (Status.show err);
+      exit 2
+  | Ok r ->
+      Printf.printf "verify: %d/%d files OK (failed=%d)\n%!" r.passed r.total
+        r.failed;
+      if r.failed > 0 then exit 3
+
+let _ensure_dir path =
+  if not (Stdlib.Sys.file_exists path) then Stdlib.Sys.mkdir path 0o755
+
+let _write_progress ~output_dir ~progress =
+  let path = Filename.concat output_dir "progress.sexp" in
+  let tmp = path ^ ".tmp" in
+  try
+    let data = Sexp.to_string_hum (sexp_of_progress progress) in
+    Out_channel.write_all tmp ~data;
+    Stdlib.Sys.rename tmp path
+  with Sys_error msg | Failure msg -> (
+    Printf.eprintf "progress write failed: %s\n%!" msg;
+    try Stdlib.Sys.remove tmp with _ -> ())
+
+let _make_progress ~symbols_total ~symbols_done ~last_completed ~started_at =
+  {
+    symbols_total;
+    symbols_done;
+    last_completed;
+    started_at;
+    updated_at = Core_unix.time ();
+  }
+
+let _maybe_emit_progress ~output_dir ~progress_every ~symbols_total
+    ~symbols_done ~last_completed ~started_at =
+  if symbols_done > 0 && symbols_done mod progress_every = 0 then
+    _write_progress ~output_dir
+      ~progress:
+        (_make_progress ~symbols_total ~symbols_done ~last_completed ~started_at)
+
+let _last_symbol entries =
+  match List.last entries with
+  | Some e -> e.Snapshot_manifest.symbol
+  | None -> ""
+
+let _emit_final_progress ~output_dir ~symbols_total ~entries ~started_at =
+  let symbols_done = List.length entries in
+  let last_completed = _last_symbol entries in
+  _write_progress ~output_dir
+    ~progress:
+      (_make_progress ~symbols_total ~symbols_done ~last_completed ~started_at)
+
+let _write_final_manifest ~manifest_path ~schema ~entries ~elapsed =
+  let manifest = Snapshot_manifest.create ~schema ~entries in
+  match Snapshot_manifest.write ~path:manifest_path manifest with
+  | Ok () ->
+      Printf.printf "wrote %d entries to %s in %.2fs\n%!" (List.length entries)
+        manifest_path
+        (Time_ns.Span.to_sec elapsed)
+  | Error err ->
+      Printf.eprintf "manifest write failed: %s\n%!" (Status.show err);
+      exit 1
+
+let _fold_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
+    ~output_dir ~existing ~manifest_path ~progress_every ~symbols_total
+    ~started_at i acc symbol =
+  match
+    _process_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
+      ~output_dir ~existing ~manifest_path ~checkpoint:true symbol
+  with
+  | None -> acc
+  | Some entry ->
+      let symbols_done = i + 1 in
+      _maybe_emit_progress ~output_dir ~progress_every ~symbols_total
+        ~symbols_done ~last_completed:symbol ~started_at;
+      acc @ [ entry ]
+
+let build ~symbols ~csv_data_dir ~output_dir ~benchmark_symbol ~start_date
+    ~end_date ~incremental ~progress_every () =
+  _ensure_dir output_dir;
+  let schema = Snapshot_schema.default in
+  let symbols_total = List.length symbols in
+  let data_dir = Fpath.v csv_data_dir in
+  let benchmark_bars =
+    _benchmark_bars_opt ~data_dir ~start_date ~end_date ~benchmark_symbol
+  in
+  let existing = if incremental then _existing_manifest ~output_dir else None in
+  let manifest_path = Filename.concat output_dir "manifest.sexp" in
+  let started_at = Core_unix.time () in
+  let t0 = Time_ns.now () in
+  let entries =
+    List.foldi symbols ~init:[]
+      ~f:
+        (_fold_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
+           ~output_dir ~existing ~manifest_path ~progress_every ~symbols_total
+           ~started_at)
+  in
+  let elapsed = Time_ns.diff (Time_ns.now ()) t0 in
+  _write_final_manifest ~manifest_path ~schema ~entries ~elapsed;
+  _emit_final_progress ~output_dir ~symbols_total ~entries ~started_at;
+  _verify_or_warn ~manifest_path

--- a/trading/analysis/scripts/build_snapshots/build_runner.mli
+++ b/trading/analysis/scripts/build_snapshots/build_runner.mli
@@ -1,0 +1,53 @@
+(** Per-symbol snapshot-warehouse build loop, factored out of
+    [build_snapshots.exe] so multiple entry points share one build path.
+
+    Given an explicit symbol list, this runs {!Snapshot_pipeline.Pipeline} once
+    per symbol, writes one [<symbol>.snap] file per symbol under [output_dir],
+    and produces an atomically-checkpointed [<output_dir>/manifest.sexp]. The
+    contract (windowing, incremental skip, progress emission, final verify) is
+    identical to the historical [build_snapshots] [main]; the only difference is
+    the symbol set is supplied by the caller rather than read from a universe
+    file — so {!Build_scenario_snapshots} can stage the runner's derived
+    [all_symbols] set, and [build_snapshots.exe] can stage a universe file's
+    symbols, via the same code. *)
+
+val default_progress_every : int
+(** Default [progress.sexp] emission cadence: write a progress checkpoint after
+    every 50 symbols. CLIs surface this as the [--progress-every] default. *)
+
+val build :
+  symbols:string list ->
+  csv_data_dir:string ->
+  output_dir:string ->
+  benchmark_symbol:string option ->
+  start_date:Core.Date.t option ->
+  end_date:Core.Date.t option ->
+  incremental:bool ->
+  progress_every:int ->
+  unit ->
+  unit
+(** [build ~symbols ~csv_data_dir ~output_dir ~benchmark_symbol ~start_date
+     ~end_date ~incremental ~progress_every ()] builds the snapshot warehouse.
+
+    - [symbols] — the exact set of tickers to build [.snap] files for. Symbols
+      with no source CSV under [csv_data_dir] are logged and skipped (the
+      warehouse simply omits them).
+    - [csv_data_dir] — directory containing per-symbol CSV history (the
+      {!Csv.Csv_storage} layout).
+    - [output_dir] — created if absent; receives one [<symbol>.snap] per built
+      symbol plus [manifest.sexp] and [progress.sexp].
+    - [benchmark_symbol] — when [Some sym], its windowed bars are routed into
+      the pipeline's [benchmark_bars] so {!Snapshot_schema.RS_line} /
+      {!Snapshot_schema.Macro_composite} are populated; [None] leaves those
+      columns NaN.
+    - [start_date] / [end_date] — inclusive bar window applied to every symbol
+      (and the benchmark) before building. Pass the backtest's {e warmup_start}
+      (not its [start_date]) as [start_date] — indicators warm up over in-window
+      bars only, exactly as {!Csv_snapshot_builder} is invoked with
+      [~warmup_start]. [None] on either bound means full history on that side.
+    - [incremental] — when [true], symbols whose source CSV mtime is [<=] the
+      existing manifest's recorded [csv_mtime] are reused rather than rebuilt.
+    - [progress_every] — emit [progress.sexp] every N symbols processed.
+
+    Exits the process non-zero on manifest-write or verification failure (the
+    historical [build_snapshots] semantics). *)

--- a/trading/analysis/scripts/build_snapshots/build_snapshots.ml
+++ b/trading/analysis/scripts/build_snapshots/build_snapshots.ml
@@ -3,6 +3,10 @@
     Reads a universe sexp + per-symbol CSVs, runs {!Snapshot_pipeline.Pipeline}
     once per symbol, writes one snapshot file per symbol under the output
     directory, and produces [<output-dir>/manifest.sexp] indexing the result.
+    The actual per-symbol build loop (windowing, incremental skip, manifest
+    checkpointing, progress emission, verification) lives in {!Build_runner} so
+    it is shared with {!Build_scenario_snapshots}; this module owns only the
+    universe-file read and the CLI surface.
 
     Optional [--incremental]: skips symbols whose source CSV is older than the
     existing snapshot file's recorded [csv_mtime] in a previous manifest at the
@@ -25,187 +29,16 @@
     computed only over the bars passed in, so the caller must set [--start-date]
     to the backtest's {e warmup_start} (early enough to cover 50-day / 30-week
     lookback), exactly as [Csv_snapshot_builder.build] is invoked with
-    [~warmup_start]. The durable fix is a Phase-F windowed/mmap decode in
-    {!Daily_panels}; this flag is the cheap interim mitigation.
+    [~warmup_start]. {!Build_scenario_snapshots} derives that warmup window
+    automatically from a scenario. The durable fix is a Phase-F windowed/mmap
+    decode in {!Daily_panels}; this flag is the cheap interim mitigation.
 
-    Checkpointing (added per dev/plans/data-pipeline-automation-2026-05-03.md):
-
-    - Per-symbol atomic manifest update via
-      {!Snapshot_pipeline.Snapshot_manifest.update_for_symbol}: after each
-      [.snap] file lands, the directory manifest is rewritten via tempfile +
-      atomic rename. Crash mid-run leaves a well-formed manifest with N entries
-      where N is the number of symbols completed; [--incremental] on restart
-      resumes correctly.
-    - Periodic [progress.sexp] emission: every [--progress-every N] symbols
-      (default 50), an atomic [progress.sexp] is written to the output dir so a
-      tail-able tool can gauge progress mid-run.
-
-    See [dev/plans/daily-snapshot-streaming-2026-04-27.md] §Phasing Phase B and
-    [dev/plans/data-pipeline-automation-2026-05-03.md] for the checkpointing
-    contract. *)
+    Checkpointing: per-symbol atomic manifest update + periodic [progress.sexp]
+    emission, both handled by {!Build_runner}. See
+    [dev/plans/daily-snapshot-streaming-2026-04-27.md] §Phasing Phase B and
+    [dev/plans/data-pipeline-automation-2026-05-03.md] for the contract. *)
 
 open Core
-module Pipeline = Snapshot_pipeline.Pipeline
-module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
-module Snapshot_verifier = Snapshot_pipeline.Snapshot_verifier
-module Snapshot_format = Data_panel_snapshot.Snapshot_format
-module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
-
-(** Default progress.sexp emission cadence: write a progress checkpoint after
-    every 50 symbols. Configurable via [--progress-every N]. *)
-let _default_progress_every = 50
-
-type progress = {
-  symbols_total : int;
-  symbols_done : int;
-  last_completed : string;
-  started_at : float;
-  updated_at : float;
-}
-[@@deriving sexp]
-(** On-disk progress checkpoint shape. Atomically rewritten every
-    [progress_every] symbols. Tail-able via standard shell tooling (sexp print).
-    The fields use the canonical sexp serialization (Float.t ↔ "1234567890.5");
-    start/update times are unix seconds since epoch. *)
-
-let _csv_mtime ~data_dir ~symbol =
-  let dir = Csv.Csv_storage.symbol_data_dir ~data_dir symbol in
-  let csv_path = Fpath.add_seg dir "data.csv" |> Fpath.to_string in
-  if Stdlib.Sys.file_exists csv_path then
-    Some (Core_unix.stat csv_path).st_mtime
-  else None
-
-let _load_bars ~data_dir ~symbol =
-  match Csv.Csv_storage.create ~data_dir symbol with
-  | Error err ->
-      Error
-        (Status.invalid_argument_error
-           (Printf.sprintf "create %s: %s" symbol (Status.show err)))
-  | Ok storage -> Csv.Csv_storage.get storage ()
-
-(* Window a symbol's loaded bars to the inclusive [start_date, end_date] range
-   before the snapshot pipeline sees them. Mirrors [Csv_snapshot_builder]'s
-   windowing so a snapshot-mode warehouse stays cache-friendly (see
-   {!Bar_window} for the perf rationale + warmup caveat). When both bounds are
-   [None] the bars pass through unchanged. *)
-let _window_bars ~start_date ~end_date bars =
-  Bar_window.filter ?start:start_date ?end_:end_date bars
-
-(* Load a symbol's bars and apply the date window. The window is also threaded
-   into the benchmark load (see [_load_benchmark_bars]) so RS_line /
-   Macro_composite are computed over the same range. *)
-let _load_windowed_bars ~data_dir ~start_date ~end_date ~symbol =
-  match _load_bars ~data_dir ~symbol with
-  | Error _ as err -> err
-  | Ok bars -> Ok (_window_bars ~start_date ~end_date bars)
-
-let _file_path ~output_dir ~symbol =
-  Filename.concat output_dir (symbol ^ ".snap")
-
-let _existing_manifest ~output_dir =
-  let path = Filename.concat output_dir "manifest.sexp" in
-  match Snapshot_manifest.read ~path with Ok m -> Some m | Error _ -> None
-
-let _entry_is_current ~csv_mtime (e : Snapshot_manifest.file_metadata) =
-  Float.( <= ) csv_mtime e.csv_mtime && Stdlib.Sys.file_exists e.path
-
-let _should_skip ~existing ~symbol ~csv_mtime ~schema =
-  match existing with
-  | None -> false
-  | Some (m : Snapshot_manifest.t) ->
-      String.equal m.schema_hash schema.Snapshot_schema.schema_hash
-      && Option.value_map
-           (Snapshot_manifest.find m ~symbol)
-           ~default:false
-           ~f:(_entry_is_current ~csv_mtime)
-
-let _file_metadata ~symbol ~path ~csv_mtime ~active_through =
-  let bytes = In_channel.read_all path in
-  {
-    Snapshot_manifest.symbol;
-    path;
-    byte_size = String.length bytes;
-    payload_md5 = Stdlib.Digest.to_hex (Stdlib.Digest.string bytes);
-    csv_mtime;
-    active_through;
-  }
-
-(** Last-bar [active_through] is the symbol's delisting marker. The CSV loader
-    sets the same value on every row of a symbol's history (or [None] throughout
-    for still-trading symbols), so reading the tail is equivalent to reading any
-    row. Surfaces to the runtime via the manifest → [Daily_panels] →
-    [Snapshot_callbacks] → reconstituted [Daily_price.t] rows path so the
-    screener PI filter can see it. *)
-let _active_through_of_bars (bars : Types.Daily_price.t list) : Date.t option =
-  List.last bars
-  |> Option.bind ~f:(fun (b : Types.Daily_price.t) -> b.active_through)
-
-let _write_and_checksum ~symbol ~path ~csv_mtime ~active_through rows =
-  match Snapshot_format.write ~path rows with
-  | Error err -> Error err
-  | Ok () -> Ok (_file_metadata ~symbol ~path ~csv_mtime ~active_through)
-
-let _build_one_symbol ~symbol ~bars ~schema ~benchmark_bars ~output_dir
-    ~csv_mtime =
-  let path = _file_path ~output_dir ~symbol in
-  let active_through = _active_through_of_bars bars in
-  match Pipeline.build_for_symbol ~symbol ~bars ~schema ?benchmark_bars () with
-  | Error err -> Error err
-  | Ok rows -> _write_and_checksum ~symbol ~path ~csv_mtime ~active_through rows
-
-let _maybe_reuse ~existing ~symbol =
-  match existing with
-  | None -> None
-  | Some m -> Snapshot_manifest.find m ~symbol
-
-let _checkpoint_manifest ~manifest_path ~schema entry =
-  match
-    Snapshot_manifest.update_for_symbol ~path:manifest_path ~schema entry
-  with
-  | Ok () -> ()
-  | Error err ->
-      Printf.eprintf "manifest checkpoint failed for %s: %s\n%!"
-        entry.Snapshot_manifest.symbol (Status.show err)
-
-let _build_or_log ~symbol ~bars ~schema ~benchmark_bars ~output_dir ~csv_mtime
-    ~manifest_path ~checkpoint =
-  match
-    _build_one_symbol ~symbol ~bars ~schema ~benchmark_bars ~output_dir
-      ~csv_mtime
-  with
-  | Error err ->
-      Printf.eprintf "skip %s: build: %s\n%!" symbol (Status.show err);
-      None
-  | Ok entry ->
-      if checkpoint then _checkpoint_manifest ~manifest_path ~schema entry;
-      Some entry
-
-(** Load bars for [symbol] and build its snapshot entry. Returns [None] on load
-    or build failure (logs the error). On success, optionally checkpoints the
-    manifest entry if [checkpoint] is set. *)
-let _try_build_and_checkpoint ~data_dir ~start_date ~end_date ~schema
-    ~benchmark_bars ~output_dir ~manifest_path ~checkpoint ~csv_mtime symbol =
-  match _load_windowed_bars ~data_dir ~start_date ~end_date ~symbol with
-  | Error err ->
-      Printf.eprintf "skip %s: load: %s\n%!" symbol (Status.show err);
-      None
-  | Ok bars ->
-      _build_or_log ~symbol ~bars ~schema ~benchmark_bars ~output_dir ~csv_mtime
-        ~manifest_path ~checkpoint
-
-let _process_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
-    ~output_dir ~existing ~manifest_path ~checkpoint symbol =
-  match _csv_mtime ~data_dir ~symbol with
-  | None ->
-      Printf.eprintf "skip %s: no CSV\n%!" symbol;
-      None
-  | Some csv_mtime ->
-      if _should_skip ~existing ~symbol ~csv_mtime ~schema then
-        _maybe_reuse ~existing ~symbol
-      else
-        _try_build_and_checkpoint ~data_dir ~start_date ~end_date ~schema
-          ~benchmark_bars ~output_dir ~manifest_path ~checkpoint ~csv_mtime
-          symbol
 
 (* Universe-file reader. Accepts either the [Pinned] shape
    ([scenario_lib/universe_file]) or an [analysis/data/universe] composition
@@ -219,122 +52,11 @@ let _load_universe ~universe_path =
       Printf.eprintf "build_snapshots: %s\n%!" (Status.show err);
       exit 1
 
-let _load_benchmark_bars ~data_dir ~start_date ~end_date sym =
-  match _load_windowed_bars ~data_dir ~start_date ~end_date ~symbol:sym with
-  | Ok bars -> Some bars
-  | Error err ->
-      Printf.eprintf "warning: benchmark %s load failed: %s\n%!" sym
-        (Status.show err);
-      None
-
-let _benchmark_bars_opt ~data_dir ~start_date ~end_date ~benchmark_symbol =
-  Option.bind benchmark_symbol
-    ~f:(_load_benchmark_bars ~data_dir ~start_date ~end_date)
-
-let _verify_or_warn ~manifest_path =
-  match Snapshot_verifier.verify_directory ~manifest_path with
-  | Error err ->
-      Printf.eprintf "verify failed: %s\n%!" (Status.show err);
-      exit 2
-  | Ok r ->
-      Printf.printf "verify: %d/%d files OK (failed=%d)\n%!" r.passed r.total
-        r.failed;
-      if r.failed > 0 then exit 3
-
-let _ensure_dir path =
-  if not (Stdlib.Sys.file_exists path) then Stdlib.Sys.mkdir path 0o755
-
-(** Atomically write [progress.sexp] under [output_dir]. Tempfile + rename so a
-    tailing reader never observes a torn write. *)
-let _write_progress ~output_dir ~progress =
-  let path = Filename.concat output_dir "progress.sexp" in
-  let tmp = path ^ ".tmp" in
-  try
-    let data = Sexp.to_string_hum (sexp_of_progress progress) in
-    Out_channel.write_all tmp ~data;
-    Stdlib.Sys.rename tmp path
-  with Sys_error msg | Failure msg -> (
-    Printf.eprintf "progress write failed: %s\n%!" msg;
-    try Stdlib.Sys.remove tmp with _ -> ())
-
-let _make_progress ~symbols_total ~symbols_done ~last_completed ~started_at =
-  {
-    symbols_total;
-    symbols_done;
-    last_completed;
-    started_at;
-    updated_at = Core_unix.time ();
-  }
-
-let _maybe_emit_progress ~output_dir ~progress_every ~symbols_total
-    ~symbols_done ~last_completed ~started_at =
-  if symbols_done > 0 && symbols_done mod progress_every = 0 then
-    _write_progress ~output_dir
-      ~progress:
-        (_make_progress ~symbols_total ~symbols_done ~last_completed ~started_at)
-
-let _last_symbol entries =
-  match List.last entries with
-  | Some e -> e.Snapshot_manifest.symbol
-  | None -> ""
-
-let _emit_final_progress ~output_dir ~symbols_total ~entries ~started_at =
-  let symbols_done = List.length entries in
-  let last_completed = _last_symbol entries in
-  _write_progress ~output_dir
-    ~progress:
-      (_make_progress ~symbols_total ~symbols_done ~last_completed ~started_at)
-
-let _write_final_manifest ~manifest_path ~schema ~entries ~elapsed =
-  let manifest = Snapshot_manifest.create ~schema ~entries in
-  match Snapshot_manifest.write ~path:manifest_path manifest with
-  | Ok () ->
-      Printf.printf "wrote %d entries to %s in %.2fs\n%!" (List.length entries)
-        manifest_path
-        (Time_ns.Span.to_sec elapsed)
-  | Error err ->
-      Printf.eprintf "manifest write failed: %s\n%!" (Status.show err);
-      exit 1
-
-let _fold_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
-    ~output_dir ~existing ~manifest_path ~progress_every ~symbols_total
-    ~started_at i acc symbol =
-  match
-    _process_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
-      ~output_dir ~existing ~manifest_path ~checkpoint:true symbol
-  with
-  | None -> acc
-  | Some entry ->
-      let symbols_done = i + 1 in
-      _maybe_emit_progress ~output_dir ~progress_every ~symbols_total
-        ~symbols_done ~last_completed:symbol ~started_at;
-      acc @ [ entry ]
-
 let main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol ~start_date
     ~end_date ~incremental ~progress_every () =
-  _ensure_dir output_dir;
-  let schema = Snapshot_schema.default in
   let symbols = _load_universe ~universe_path in
-  let symbols_total = List.length symbols in
-  let data_dir = Fpath.v csv_data_dir in
-  let benchmark_bars =
-    _benchmark_bars_opt ~data_dir ~start_date ~end_date ~benchmark_symbol
-  in
-  let existing = if incremental then _existing_manifest ~output_dir else None in
-  let manifest_path = Filename.concat output_dir "manifest.sexp" in
-  let started_at = Core_unix.time () in
-  let t0 = Time_ns.now () in
-  let entries =
-    List.foldi symbols ~init:[]
-      ~f:
-        (_fold_symbol ~data_dir ~start_date ~end_date ~schema ~benchmark_bars
-           ~output_dir ~existing ~manifest_path ~progress_every ~symbols_total
-           ~started_at)
-  in
-  let elapsed = Time_ns.diff (Time_ns.now ()) t0 in
-  _write_final_manifest ~manifest_path ~schema ~entries ~elapsed;
-  _emit_final_progress ~output_dir ~symbols_total ~entries ~started_at;
-  _verify_or_warn ~manifest_path
+  Build_runner.build ~symbols ~csv_data_dir ~output_dir ~benchmark_symbol
+    ~start_date ~end_date ~incremental ~progress_every ()
 
 let command =
   Command.basic
@@ -376,11 +98,11 @@ let command =
            "Skip symbols whose CSV mtime <= the existing manifest's csv_mtime"
      and progress_every =
        flag "progress-every"
-         (optional_with_default _default_progress_every int)
+         (optional_with_default Build_runner.default_progress_every int)
          ~doc:
            (Printf.sprintf
               "N Emit progress.sexp every N symbols processed (default %d)"
-              _default_progress_every)
+              Build_runner.default_progress_every)
      in
      fun () ->
        main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol

--- a/trading/analysis/scripts/build_snapshots/build_snapshots.ml
+++ b/trading/analysis/scripts/build_snapshots/build_snapshots.ml
@@ -58,51 +58,61 @@ let main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol ~start_date
   Build_runner.build ~symbols ~csv_data_dir ~output_dir ~benchmark_symbol
     ~start_date ~end_date ~incremental ~progress_every ()
 
+(* Flag [~doc] strings are hoisted to top-level bindings so the [Command.basic]
+   flag block below stays flat (one line per flag) — the multi-line doc text is
+   the only deeply-indented content in this thin CLI shell, so lifting it keeps
+   the file's structural nesting low. The build contract lives in
+   {!Build_runner}. *)
+let doc_universe_path =
+  "PATH Universe sexp (Pinned shape or analysis/data/universe composition \
+   snapshot)"
+
+let doc_csv_data_dir = "PATH Directory containing per-symbol CSV history"
+
+let doc_output_dir =
+  "PATH Directory where snapshot files + manifest are written"
+
+let doc_benchmark_symbol =
+  "SYM Optional benchmark ticker for RS_line / Macro_composite (default: NaN \
+   columns)"
+
+let doc_start_date =
+  "YYYY-MM-DD Optional inclusive lower bound: drop each symbol's bars before \
+   this date before building (default: full history). Pass the backtest's \
+   WARMUP_START, not its start — indicators warm up over in-window bars only, \
+   so earlier dates carry NaN indicators (same contract as \
+   Csv_snapshot_builder's ~warmup_start)."
+
+let doc_end_date =
+  "YYYY-MM-DD Optional inclusive upper bound: drop each symbol's bars after \
+   this date before building (default: full history)."
+
+let doc_incremental =
+  "Skip symbols whose CSV mtime <= the existing manifest's csv_mtime"
+
+let doc_progress_every =
+  Printf.sprintf "N Emit progress.sexp every N symbols processed (default %d)"
+    Build_runner.default_progress_every
+
+let date_arg = Command.Param.optional (Command.Arg_type.create Date.of_string)
+
 let command =
   Command.basic
     ~summary:"Build per-symbol snapshot files for the daily-snapshot warehouse"
     (let%map_open.Command universe_path =
-       flag "universe-path" (required string)
-         ~doc:
-           "PATH Universe sexp (Pinned shape or analysis/data/universe \
-            composition snapshot)"
+       flag "universe-path" (required string) ~doc:doc_universe_path
      and csv_data_dir =
-       flag "csv-data-dir" (required string)
-         ~doc:"PATH Directory containing per-symbol CSV history"
-     and output_dir =
-       flag "output-dir" (required string)
-         ~doc:"PATH Directory where snapshot files + manifest are written"
+       flag "csv-data-dir" (required string) ~doc:doc_csv_data_dir
+     and output_dir = flag "output-dir" (required string) ~doc:doc_output_dir
      and benchmark_symbol =
-       flag "benchmark-symbol" (optional string)
-         ~doc:
-           "SYM Optional benchmark ticker for RS_line / Macro_composite \
-            (default: NaN columns)"
-     and start_date =
-       flag "start-date"
-         (optional (Command.Arg_type.create Date.of_string))
-         ~doc:
-           "YYYY-MM-DD Optional inclusive lower bound: drop each symbol's bars \
-            before this date before building (default: full history). Pass the \
-            backtest's WARMUP_START, not its start — indicators warm up over \
-            in-window bars only, so earlier dates carry NaN indicators (same \
-            contract as Csv_snapshot_builder's ~warmup_start)."
-     and end_date =
-       flag "end-date"
-         (optional (Command.Arg_type.create Date.of_string))
-         ~doc:
-           "YYYY-MM-DD Optional inclusive upper bound: drop each symbol's bars \
-            after this date before building (default: full history)."
-     and incremental =
-       flag "incremental" no_arg
-         ~doc:
-           "Skip symbols whose CSV mtime <= the existing manifest's csv_mtime"
+       flag "benchmark-symbol" (optional string) ~doc:doc_benchmark_symbol
+     and start_date = flag "start-date" date_arg ~doc:doc_start_date
+     and end_date = flag "end-date" date_arg ~doc:doc_end_date
+     and incremental = flag "incremental" no_arg ~doc:doc_incremental
      and progress_every =
        flag "progress-every"
          (optional_with_default Build_runner.default_progress_every int)
-         ~doc:
-           (Printf.sprintf
-              "N Emit progress.sexp every N symbols processed (default %d)"
-              Build_runner.default_progress_every)
+         ~doc:doc_progress_every
      in
      fun () ->
        main ~universe_path ~csv_data_dir ~output_dir ~benchmark_symbol

--- a/trading/analysis/scripts/build_snapshots/dune
+++ b/trading/analysis/scripts/build_snapshots/dune
@@ -7,8 +7,26 @@
 
 (library
  (name bar_window)
+ (public_name scripts.bar_window)
  (modules bar_window)
  (libraries core types)
+ (preprocess
+  (pps ppx_jane)))
+
+(library
+ (name build_runner)
+ (public_name scripts.build_runner)
+ (modules build_runner)
+ (libraries
+  core
+  core_unix
+  status
+  types
+  fpath
+  trading.data_panel.snapshot
+  bar_window
+  weinstein.snapshot_pipeline
+  csv)
  (preprocess
   (pps ppx_jane)))
 
@@ -19,12 +37,8 @@
   core
   core_unix
   core_unix.command_unix
-  core_unix.filename_unix
   status
-  trading.data_panel.snapshot
-  bar_window
   universe_loader
-  weinstein.snapshot_pipeline
-  csv)
+  build_runner)
  (preprocess
   (pps ppx_jane)))

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -19,7 +19,7 @@ let commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 }
     enter its single position at [warmup_start] instead of [start_date], which
     corrupts the day-1-entry semantics the BAH baseline is pinned against.
     Strategy-dispatched (#882) rather than a single constant. *)
-let _warmup_days_for : Strategy_choice.t -> int = function
+let warmup_days_for : Strategy_choice.t -> int = function
   | Weinstein -> 210
   | Bah_benchmark _ -> 0
   | Spy_only_weinstein _ -> 210
@@ -28,6 +28,10 @@ let _warmup_days_for : Strategy_choice.t -> int = function
      the larger of its 30-week stage MA and the 52-week RS window — ~52 weeks =
      ~364 days. *)
   | Sector_rotation_weinstein _ -> 364
+
+(* Backwards-compatible internal alias kept so the rest of this module reads as
+   before; [warmup_days_for] is the exported name (see [runner.mli]). *)
+let _warmup_days_for = warmup_days_for
 
 (* Public types *)
 
@@ -186,6 +190,20 @@ let _all_runner_symbols ~(config : Weinstein_strategy.config) ~universe =
   in
   (index_symbol :: universe) @ sector_etf_symbols @ global_index_symbols
   |> List.dedup_and_sort ~compare:String.compare
+
+(* The primary index symbol every run loads bars for and feeds the macro / RS
+   pipeline. Surfaced via [runner.mli] so warehouse-building tooling can stage
+   the same benchmark the runner reads, rather than hardcoding it. *)
+let primary_index_symbol = index_symbol
+
+(* All symbols a default [Weinstein] run would stage bars for over [universe]:
+   the (post-cap) universe, the primary index, and the full SPDR sector-ETF +
+   global-index macro set with the hypothesis-testing skip toggles at their
+   defaults (i.e. nothing skipped). Reuses the same [_runner_base_config] +
+   [_all_runner_symbols] the runner builds [_deps.all_symbols] from, so the two
+   agree by construction. See [runner.mli]. *)
+let all_snapshot_symbols ~universe =
+  _all_runner_symbols ~config:(_runner_base_config ~universe) ~universe
 
 let _load_deps ?trace ?gc_trace ~overrides ~sector_map_override () =
   let data_dir_fpath = Data_path.default_data_dir () in

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -4,6 +4,34 @@
 
 open Core
 
+val warmup_days_for : Strategy_choice.t -> int
+(** Number of calendar days the runner prepends before a scenario's [start_date]
+    when it runs [strategy] — i.e.
+    [warmup_start = start_date - warmup_days_for strategy]. The Weinstein /
+    SPY-only stage classifier needs ~30 weeks (210 days) of bar history;
+    sector-rotation needs ~52 weeks (364 days) for its RS window; the stateless
+    Buy-and-Hold benchmark needs none (0). Exposed (#882-dispatched) so
+    snapshot-warehouse tooling derives the same warmup window the runner uses,
+    rather than copying the magic numbers. *)
+
+val primary_index_symbol : string
+(** The primary index ([GSPC.INDX]) every run loads bars for and feeds into the
+    macro / relative-strength pipeline. Exposed so warehouse-building tooling
+    stages the same benchmark symbol the runner reads, instead of hardcoding it.
+*)
+
+val all_snapshot_symbols : universe:string list -> string list
+(** [all_snapshot_symbols ~universe] is the deduped, sorted union of every
+    symbol a default [Weinstein] run stages bars for over [universe]: the
+    universe itself, {!primary_index_symbol}, every SPDR sector ETF
+    ({!Weinstein_strategy.Macro_inputs.spdr_sector_etfs}), and every global
+    macro index ({!Weinstein_strategy.Macro_inputs.default_global_indices}).
+    Reuses the exact assembly the runner builds its internal [all_symbols] from
+    (with the hypothesis-testing skip toggles at their defaults), so a snapshot
+    warehouse built over this set carries every macro / RS column the runner
+    reads. Omitting these auxiliary symbols leaves those columns degenerate and
+    the strategy produces zero trades. *)
+
 type result = {
   summary : Summary.t;
   round_trips : Trading_simulation.Metrics.trade_metrics list;

--- a/trading/trading/backtest/snapshot_warehouse/build_scenario_snapshots.ml
+++ b/trading/trading/backtest/snapshot_warehouse/build_scenario_snapshots.ml
@@ -1,0 +1,111 @@
+(** Build the {e exact} snapshot warehouse a backtest scenario needs to run
+    correctly in snapshot mode.
+
+    [build_snapshots.exe] builds a warehouse over a universe file with whatever
+    date window the operator passes. Getting either wrong silently corrupts a
+    snapshot-mode run:
+
+    - {b Warmup window.} The stage classifier is path-dependent on where the
+      indicator series starts. Building over [scenario.start_date] (instead of
+      [scenario.start_date - warmup_days]) shifts every weekly bar and changes
+      results — an observed run flipped from the correct 41.3% to 81.5% return
+      purely from a 2018 vs 2019-06 warehouse start.
+    - {b Symbol completeness.} The runner loads bars for the universe {e plus}
+      the primary index {e plus} the global macro indices {e plus} the 11 SPDR
+      sector ETFs. Omit them and the macro / relative-strength columns are
+      degenerate → the strategy produces {b 0 trades}.
+
+    This tool derives both from the scenario itself, so a snapshot run matches a
+    CSV-mode run by construction. It resolves the scenario's universe exactly as
+    {!Scenario_runner} does (via {!Scenario_lib.Universe_file}), derives the
+    warmup-windowed [all_symbols] set via {!Scenario_snapshot_plan.derive}
+    (which reuses {!Backtest.Runner.warmup_days_for} +
+    {!Backtest.Runner.all_snapshot_symbols}), and delegates the warehouse build
+    to the shared {!Build_runner.build}. Unblocks running large-N (e.g. N=3000)
+    goldens locally in snapshot mode. *)
+
+open Core
+module Scenario = Scenario_lib.Scenario
+module Universe_file = Scenario_lib.Universe_file
+module Plan = Scenario_snapshot_plan
+
+(* Resolve the scenario's [universe_path] against [fixtures_root] and project it
+   to its trading symbols, exactly as [Scenario_runner] does:
+   [Universe_file.load] handles the Pinned shape, the composition-snapshot shape
+   the goldens use, and the [Full_sector_map] sentinel.
+   [to_sector_map_override] returns [None] only for [Full_sector_map] (the broad
+   tier that defers to data/sectors.csv) — which this tool cannot window, so we
+   exit with an actionable message rather than build an unbounded warehouse. *)
+let _resolve_universe ~fixtures_root ~universe_path =
+  let resolved = Filename.concat fixtures_root universe_path in
+  match Universe_file.to_sector_map_override (Universe_file.load resolved) with
+  | Some tbl -> Hashtbl.keys tbl |> List.sort ~compare:String.compare
+  | None ->
+      Printf.eprintf
+        "build_scenario_snapshots: universe %s resolves to Full_sector_map \
+         (the broad tier). This tool windows a bounded universe; point \
+         -scenario at a scenario whose universe_path is a Pinned or \
+         composition-snapshot universe instead.\n\
+         %!"
+        resolved;
+      exit 1
+
+let _log_plan (plan : Plan.t) ~scenario_path =
+  Printf.eprintf
+    "build_scenario_snapshots: %s -> %d symbols, window [%s, %s], benchmark %s\n\
+     %!"
+    scenario_path
+    (List.length plan.all_symbols)
+    (Date.to_string plan.warmup_start)
+    (Date.to_string plan.end_date)
+    plan.benchmark_symbol
+
+let main ~scenario_path ~fixtures_root ~csv_data_dir ~output_dir ~incremental
+    ~progress_every () =
+  let scenario = Scenario.load scenario_path in
+  let universe =
+    _resolve_universe ~fixtures_root ~universe_path:scenario.universe_path
+  in
+  let plan = Plan.derive ~scenario ~universe in
+  _log_plan plan ~scenario_path;
+  Build_runner.build ~symbols:plan.all_symbols ~csv_data_dir ~output_dir
+    ~benchmark_symbol:(Some plan.benchmark_symbol)
+    ~start_date:(Some plan.warmup_start) ~end_date:(Some plan.end_date)
+    ~incremental ~progress_every ()
+
+let command =
+  Command.basic
+    ~summary:
+      "Build the warmup-windowed all-symbols snapshot warehouse a scenario \
+       needs to run in snapshot mode"
+    (let%map_open.Command scenario_path =
+       flag "scenario" (required string)
+         ~doc:"PATH Scenario sexp (Scenario_lib.Scenario.t) to derive from"
+     and fixtures_root =
+       flag "fixtures-root" (required string)
+         ~doc:
+           "PATH Directory the scenario's universe_path is resolved against \
+            (same as scenario_runner --fixtures-root)"
+     and csv_data_dir =
+       flag "csv-data-dir" (required string)
+         ~doc:"PATH Directory containing per-symbol CSV history"
+     and output_dir =
+       flag "output-dir" (required string)
+         ~doc:"PATH Directory where snapshot files + manifest are written"
+     and incremental =
+       flag "incremental" no_arg
+         ~doc:
+           "Skip symbols whose CSV mtime <= the existing manifest's csv_mtime"
+     and progress_every =
+       flag "progress-every"
+         (optional_with_default Build_runner.default_progress_every int)
+         ~doc:
+           (Printf.sprintf
+              "N Emit progress.sexp every N symbols processed (default %d)"
+              Build_runner.default_progress_every)
+     in
+     fun () ->
+       main ~scenario_path ~fixtures_root ~csv_data_dir ~output_dir ~incremental
+         ~progress_every ())
+
+let () = Command_unix.run command

--- a/trading/trading/backtest/snapshot_warehouse/dune
+++ b/trading/trading/backtest/snapshot_warehouse/dune
@@ -1,0 +1,22 @@
+(library
+ (name scenario_snapshot_plan)
+ (modules scenario_snapshot_plan)
+ (libraries core backtest scenario_lib)
+ (preprocess
+  (pps ppx_jane)))
+
+(executable
+ (name build_scenario_snapshots)
+ (modules build_scenario_snapshots)
+ (libraries
+  core
+  core_unix
+  core_unix.command_unix
+  fpath
+  status
+  backtest
+  scenario_lib
+  scripts.build_runner
+  scenario_snapshot_plan)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/trading/backtest/snapshot_warehouse/scenario_snapshot_plan.ml
+++ b/trading/trading/backtest/snapshot_warehouse/scenario_snapshot_plan.ml
@@ -1,0 +1,21 @@
+open Core
+module Scenario = Scenario_lib.Scenario
+module Runner = Backtest.Runner
+
+type t = {
+  all_symbols : string list;
+  warmup_start : Date.t;
+  end_date : Date.t;
+  benchmark_symbol : string;
+}
+[@@deriving sexp_of]
+
+let derive ~(scenario : Scenario.t) ~universe =
+  let start_date = scenario.period.start_date in
+  let warmup_days = Runner.warmup_days_for scenario.strategy in
+  {
+    all_symbols = Runner.all_snapshot_symbols ~universe;
+    warmup_start = Date.add_days start_date (-warmup_days);
+    end_date = scenario.period.end_date;
+    benchmark_symbol = Runner.primary_index_symbol;
+  }

--- a/trading/trading/backtest/snapshot_warehouse/scenario_snapshot_plan.mli
+++ b/trading/trading/backtest/snapshot_warehouse/scenario_snapshot_plan.mli
@@ -1,0 +1,48 @@
+(** Pure derivation of the snapshot-warehouse build parameters a backtest
+    scenario needs to run correctly in snapshot mode.
+
+    {!Build_scenario_snapshots} resolves a scenario's universe from disk, then
+    calls {!derive} to compute the two things a hand-built warehouse routinely
+    gets wrong:
+
+    1. The {b warmup-windowed date range}:
+    [warmup_start = scenario.start_date - Backtest.Runner.warmup_days_for
+     scenario.strategy]. The stage classifier is path-dependent on the
+    indicator-series start, so a too-wide or too-narrow window silently changes
+    results. 2. The {b complete symbol set}: the scenario's resolved universe
+    {e plus} the primary index {e plus} the global macro indices {e plus} the
+    SPDR sector ETFs — exactly {!Backtest.Runner.all_snapshot_symbols}. Omitting
+    the auxiliary symbols leaves the macro / relative-strength columns
+    degenerate and the strategy produces zero trades.
+
+    Keeping the derivation pure (scenario + resolved-universe → plan, no
+    filesystem) makes it unit-testable. *)
+
+open Core
+
+type t = {
+  all_symbols : string list;
+      (** Deduped, sorted union of the resolved universe, the primary index, the
+          global macro indices, and the SPDR sector ETFs —
+          {!Backtest.Runner.all_snapshot_symbols} applied to [universe]. The
+          warehouse must cover every one of these for the run to reproduce. *)
+  warmup_start : Date.t;
+      (** [scenario.start_date - Backtest.Runner.warmup_days_for
+           scenario.strategy]: the inclusive lower bar-window bound to pass to
+          {!Build_runner.build} as [start_date] (NOT the scenario's
+          [start_date]). *)
+  end_date : Date.t;  (** The scenario's [period.end_date], passed through. *)
+  benchmark_symbol : string;
+      (** The primary index ({!Backtest.Runner.primary_index_symbol}), staged as
+          the warehouse benchmark so RS / macro columns are populated. *)
+}
+[@@deriving sexp_of]
+
+val derive : scenario:Scenario_lib.Scenario.t -> universe:string list -> t
+(** [derive ~scenario ~universe] computes the build plan. [universe] is the
+    scenario's already-resolved trading symbols (the keys of the sector-map
+    override produced from [scenario.universe_path], with synthetics dropped).
+    The warmup window is derived from [scenario.strategy] and
+    [scenario.period.start_date]; the symbol set from [universe] via
+    {!Backtest.Runner.all_snapshot_symbols}; the benchmark from
+    {!Backtest.Runner.primary_index_symbol}. *)

--- a/trading/trading/backtest/snapshot_warehouse/test/dune
+++ b/trading/trading/backtest/snapshot_warehouse/test/dune
@@ -1,0 +1,5 @@
+(test
+ (name test_scenario_snapshot_plan)
+ (libraries core ounit2 matchers scenario_lib scenario_snapshot_plan)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/trading/backtest/snapshot_warehouse/test/test_scenario_snapshot_plan.ml
+++ b/trading/trading/backtest/snapshot_warehouse/test/test_scenario_snapshot_plan.ml
@@ -1,0 +1,78 @@
+open Core
+open OUnit2
+open Matchers
+module Scenario = Scenario_lib.Scenario
+module Plan = Scenario_snapshot_plan
+
+(* A minimal Weinstein scenario built from sexp so we don't hand-construct the
+   large [expected] record. start_date 2020-01-02, end_date 2024-12-31, a small
+   pinned universe of two symbols. *)
+let weinstein_scenario_sexp =
+  {|
+  ((name "test")
+   (description "fixture")
+   (period ((start_date 2020-01-02) (end_date 2024-12-31)))
+   (universe_path "universes/small.sexp")
+   (config_overrides ())
+   (strategy Weinstein)
+   (expected
+    ((total_return_pct ((min -90.0) (max 5000.0)))
+     (total_trades     ((min   0.0) (max  500.0)))
+     (win_rate         ((min   0.0) (max  100.0)))
+     (sharpe_ratio     ((min  -2.0) (max    5.0)))
+     (max_drawdown_pct ((min   0.0) (max   95.0)))
+     (avg_holding_days ((min   0.0) (max 5000.0))))))
+  |}
+
+let scenario () = Scenario.t_of_sexp (Sexp.of_string weinstein_scenario_sexp)
+
+(* The auxiliary symbols every Weinstein run also stages bars for: the primary
+   index, the 11 SPDR sector ETFs, and the 3 global macro indices. Hardcoded
+   here so the test pins the contract independently of the runner internals. *)
+let primary_index = "GSPC.INDX"
+
+let sector_etfs =
+  [
+    "XLK"; "XLF"; "XLE"; "XLV"; "XLI"; "XLP"; "XLY"; "XLU"; "XLB"; "XLRE"; "XLC";
+  ]
+
+let global_indices = [ "GDAXI.INDX"; "N225.INDX"; "ISF.LSE" ]
+let universe = [ "AAPL"; "MSFT" ]
+let required = (universe @ (primary_index :: sector_etfs)) @ global_indices
+
+(* Count how many of [required] appear in [all_symbols]. Using List.count keeps a
+   single assert_that over the count (per .claude/rules/test-patterns.md). *)
+let _count_present all_symbols =
+  List.count required ~f:(fun s -> List.mem all_symbols s ~equal:String.equal)
+
+let test_derive _ =
+  let plan = Plan.derive ~scenario:(scenario ()) ~universe in
+  assert_that plan
+    (all_of
+       [
+         (* warmup_start = 2020-01-02 - 210 days = 2019-06-06 *)
+         field
+           (fun (p : Plan.t) -> p.warmup_start)
+           (equal_to (Date.of_string "2019-06-06"));
+         field
+           (fun (p : Plan.t) -> p.end_date)
+           (equal_to (Date.of_string "2024-12-31"));
+         field (fun (p : Plan.t) -> p.benchmark_symbol) (equal_to primary_index);
+         (* every required symbol (universe ∪ index ∪ ETFs ∪ global indices) is
+            present *)
+         field
+           (fun (p : Plan.t) -> _count_present p.all_symbols)
+           (equal_to (List.length required));
+         (* no duplicates: raw length equals deduped length *)
+         field
+           (fun (p : Plan.t) -> List.length p.all_symbols)
+           (equal_to
+              (List.length
+                 (List.dedup_and_sort required ~compare:String.compare)));
+       ])
+
+let suite =
+  "scenario_snapshot_plan"
+  >::: [ "derive computes warmup window + complete symbol set" >:: test_derive ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

Adds `build_scenario_snapshots` — given a backtest scenario, it builds the **exact** snapshot warehouse that scenario needs to run correctly in `scenario_runner --snapshot-dir` mode, auto-deriving the two properties a hand-built `build_snapshots` warehouse routinely gets wrong.

## Why — the two gotchas this prevents

1. **Warmup-windowed date range.** `warmup_start = scenario.start_date − Runner.warmup_days_for scenario.strategy` (Weinstein/SPY-only = 210d, sector-rotation = 364d, BAH = 0). The stage classifier is path-dependent on where the indicator series starts — a warehouse built from a 2018 start vs the correct 2019-06 warmup start flipped an observed run from the correct **41.3%** to **81.5%** return.
2. **Complete symbol set.** `all_symbols = universe + primary index + Macro_inputs.default_global_indices + Macro_inputs.spdr_sector_etfs` (the 11 SPDR `XL*`). Omitting the index/ETF/global-index auxiliaries leaves the macro / relative-strength columns degenerate → the strategy produces **0 trades**.

## The derivation (reuses, doesn't re-derive)

- Exposes `Runner.warmup_days_for`, `Runner.primary_index_symbol`, and `Runner.all_snapshot_symbols ~universe` in `runner.mli`. `all_snapshot_symbols` wraps the same `_all_runner_symbols`/`_runner_base_config` the runner builds its internal `all_symbols` from, so the warehouse and the runner agree **by construction** (no copied magic numbers, no duplicated assembly). Read-only val exports; no behaviour change.
- Universe resolution reuses `Scenario_lib.Universe_file.load` + `to_sector_map_override` against `--fixtures-root`, exactly as `scenario_runner` does (handles Pinned + composition snapshots + drops synthetics). `Full_sector_map` (the broad tier) is rejected with an actionable message since it can't be windowed.
- The per-symbol build loop (windowing, incremental skip, manifest checkpointing, progress emission, verification) is factored into a shared `build_runner` library so `build_snapshots.exe` and the new exe use one build path. The benchmark symbol is staged as the primary index.

## Layout

- `runner.mli` / `runner.ml` (trading/trading/backtest/lib): three read-only val exports.
- `build_runner.{ml,mli}` (analysis/scripts/build_snapshots): factored build loop, given a public_name so the new exe can dep it cross-dune-project.
- `scenario_snapshot_plan.{ml,mli}` + `build_scenario_snapshots.ml` + test (trading/trading/backtest/snapshot_warehouse): the pure derivation + CLI. Placed under `trading/trading/backtest/` because it needs the private `backtest` + `scenario_lib` libs (not reachable from the `analysis/scripts` dune-project). A2 direction note: this is an `analysis/scripts`-style exe depending on trading libs, not an `analysis/` library imported into `trading/trading/`.

## Test plan

- `test_scenario_snapshot_plan.ml`: a Weinstein scenario (start 2020-01-02 / end 2024-12-31, 2-symbol universe) asserts `warmup_start = 2019-06-06` (start − 210), `end_date` passthrough, `benchmark_symbol = GSPC.INDX`, and that `all_symbols` ⊇ universe ∪ {11 XL* ETFs} ∪ {3 global indices} ∪ {GSPC.INDX} with no duplicates.
- `dune build && dune runtest` green across the full project; `dune build @fmt` clean; existing `build_snapshots` tests + the full `backtest` test suite pass after the refactor.

Unblocks running local N=3000 goldens in snapshot mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)