### PR TITLE
feat(weinstein): macro-bearish held-exposure trim (default-off)

### DIFF
--- a/dev/status/stage-accuracy.md
+++ b/dev/status/stage-accuracy.md
@@ -1,6 +1,6 @@
 # Status: stage-accuracy
 
-## Last updated: 2026-06-04
+## Last updated: 2026-06-06
 
 ## Status
 IN_PROGRESS
@@ -18,6 +18,42 @@ trigger (Stage-4 flip) lagged every top by 5-29 weeks (price already
 down 5-44%).
 
 ## Completed
+
+- **Macro-bearish held-exposure trim** (default-off, 2026-06-06). New
+  module `Macro_bearish_trim_runner`
+  (`trading/trading/weinstein/strategy/lib/macro_bearish_trim_runner.{ml,mli}`):
+  on a screening (Friday) day, when the macro tape is confirmed `Bearish`,
+  caps total held long exposure at
+  `config.macro_bearish_max_long_exposure_pct` of portfolio value and
+  exits the excess **weakest-RS-first** (reusing the laggard RS window
+  return via the newly-exposed `Laggard_rotation_runner.window_return`).
+  `0.0` = full flat; `1.0` (or higher) = no-op. Shorts never trimmed;
+  never force-buys (re-entry naturally damped through the normal Stage-2
+  breakout+volume screen). Wired into `weinstein_strategy.ml`
+  `_process_market_day` as `_run_macro_bearish_trim`, after
+  `_run_special_exits`; the macro result is hoisted into a new `_run_macro`
+  helper (split out of `_run_macro_and_entries` → `_run_entries`) so the
+  trend is available to the trim pass without computing macro twice.
+  Respects the single-exit collision rule (skip-id union of stop /
+  Stage-3 / laggard / force-liq exits).
+  - Config fields (both default to baseline no-op):
+    `enable_macro_bearish_exposure_trim : bool [@sexp.default false]`,
+    `macro_bearish_max_long_exposure_pct : float [@sexp.default 0.70]`
+    (mirrors the normal long cap → no-op even when flag flipped on).
+  - Flag-discipline: default-off (R1, flag-off path bit-identical to
+    baseline), real config fields → `Variant_matrix` flag + key axes
+    (R2, pinned in `test_variant_matrix.ml`), NOT promoted (R3).
+  - Weinstein-faithful: extends the macro gate (spine item #6) from
+    "block buys" to "raise cash on a bear tape" — an exit-aggressiveness
+    dial, book §Macro Analysis / §Stage 4. Spine untouched.
+  - Tests: `test_macro_bearish_trim_runner.ml` (9 cases) — trim to cap,
+    full-flat, under-cap no-op, no-op cap (1.0), non-positive portfolio
+    value, shorts-not-trimmed, exit-reason label / never-force-buy,
+    unranked-position-excluded, skip-id single-exit collision.
+  - Plan: `dev/plans/macro-bearish-exposure-trim-2026-06-06.md`. Branch
+    `feat/macro-bearish-trim`. Supersedes the late-dial as the deep-window
+    DD lever (the late `late` flag resets on fast crashes; the macro gate
+    fires early + persists through 2000/2008).
 
 - **Late-Stage-2 trailing-stop tightening dial** (default-off). New
   module `Late_stage2_stop_runner`

--- a/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
+++ b/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
@@ -143,6 +143,63 @@ let test_neutral_blocks_longs_flag_axis_expands _ =
               [ equal_to (Sexp.of_string "((neutral_blocks_longs false))") ]);
        ])
 
+(* Proves R2 (experiment-flag-discipline) for the macro-bearish held-exposure
+   trim mechanism: both [enable_macro_bearish_exposure_trim] (flag) and
+   [macro_bearish_max_long_exposure_pct] (float key) are real top-level
+   [Weinstein_strategy.config] fields, so the combined axis expands and passes
+   [Overlay_validator] validation. This is the "axis the day it lands" gate. *)
+let test_macro_bearish_trim_axes_expand _ =
+  let flag_axis =
+    VM.Flag
+      {
+        name = "enable_macro_bearish_exposure_trim";
+        values = Sexp.[ Atom "true"; Atom "false" ];
+      }
+  in
+  let cap_axis =
+    VM.Key
+      {
+        path = [ "macro_bearish_max_long_exposure_pct" ];
+        values = Sexp.[ Atom "0.0"; Atom "0.35" ];
+      }
+  in
+  let t = { VM.axes = [ flag_axis; cap_axis ]; expansion = VM.Cartesian } in
+  (* 2 flag values * 2 cap values = 4 cells; first axis varies slowest. *)
+  assert_that (VM.expand t)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (v : WFR.variant) -> v.label)
+               (equal_to
+                  "enable_macro_bearish_exposure_trim=true__macro_bearish_max_long_exposure_pct=0.0");
+             field
+               (fun (v : WFR.variant) -> v.overrides)
+               (elements_are
+                  [
+                    equal_to
+                      (Sexp.of_string
+                         "((enable_macro_bearish_exposure_trim true))");
+                    equal_to
+                      (Sexp.of_string
+                         "((macro_bearish_max_long_exposure_pct 0.0))");
+                  ]);
+           ];
+         field
+           (fun (v : WFR.variant) -> v.label)
+           (equal_to
+              "enable_macro_bearish_exposure_trim=true__macro_bearish_max_long_exposure_pct=0.35");
+         field
+           (fun (v : WFR.variant) -> v.label)
+           (equal_to
+              "enable_macro_bearish_exposure_trim=false__macro_bearish_max_long_exposure_pct=0.0");
+         field
+           (fun (v : WFR.variant) -> v.label)
+           (equal_to
+              "enable_macro_bearish_exposure_trim=false__macro_bearish_max_long_exposure_pct=0.35");
+       ])
+
 (* ---------- Sampled determinism + fallback ---------- *)
 
 let test_sampled_determinism _ =
@@ -221,6 +278,8 @@ let suite =
          >:: test_single_component_override_shape;
          "neutral_blocks_longs flag axis expands + validates"
          >:: test_neutral_blocks_longs_flag_axis_expands;
+         "macro-bearish trim flag + cap axes expand + validate"
+         >:: test_macro_bearish_trim_axes_expand;
          "sampled determinism (same seed -> same labels)"
          >:: test_sampled_determinism;
          "sampled different seed -> different subset"

--- a/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.ml
@@ -18,6 +18,10 @@ let _window_return ~(n : int) (bars : Types.Daily_price.t list) : float option =
     _simple_return ~oldest:arr.(0).close_price
       ~latest:arr.(Array.length arr - 1).close_price
 
+(* Public alias so {!Macro_bearish_trim_runner}'s caller can compute the same
+   window return for its RS ranking, keeping the two RS notions consistent. *)
+let window_return = _window_return
+
 (** Build the [TriggerExit] transition for a laggard-rotation exit. Same fill
     convention as {!Stage3_force_exit_runner._make_exit_transition}: the exit
     fires at the close of the current bar (discretionary exit at the close).

--- a/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/laggard_rotation_runner.mli
@@ -62,6 +62,15 @@
 open Core
 open Trading_strategy
 
+val window_return : n:int -> Types.Daily_price.t list -> float option
+(** [window_return ~n bars] = the simple return over the most recent rolling
+    window of [n] weekly bars: [close[last] / close[first] - 1.0], computed from
+    a chronological [bars] list with [List.length bars >= n + 1]. Returns [None]
+    when the list is shorter than [n + 1] bars or its oldest close is
+    non-positive (degenerate snapshot). Exposed so the macro-bearish trim's RS
+    ranking ({!Macro_bearish_trim_runner}) reuses the identical window-return
+    primitive, keeping the laggard and trim RS notions consistent. *)
+
 val update :
   config:Laggard_rotation.config ->
   benchmark_symbol:string ->

--- a/trading/trading/weinstein/strategy/lib/macro_bearish_trim_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/macro_bearish_trim_runner.ml
@@ -1,0 +1,110 @@
+(** Macro-bearish held-exposure trim. See [macro_bearish_trim_runner.mli]. *)
+
+open Core
+open Trading_strategy
+
+(** The exit reason stamped on every trimmed position — a generic
+    [StrategySignal] so the position state machine + simulator already handle
+    it; the ["macro_bearish_trim"] label surfaces in the [exit_trigger] column
+    of trades.csv. *)
+let _exit_reason : Position.exit_reason =
+  Position.StrategySignal { label = "macro_bearish_trim"; detail = None }
+
+(** Signed long market value of a single [Holding] long position. Returns [None]
+    for non-Holding positions, for short positions, and for symbols without a
+    price this tick. Long-only by design — the trim caps {e long} exposure; a
+    bearish tape is the natural environment for shorts, so they are never
+    trimmed here. *)
+let _long_market_value ~get_price (pos : Position.t) : float option =
+  match (pos.side, pos.state) with
+  | Trading_base.Types.Long, Position.Holding { quantity; _ } ->
+      Option.map (get_price pos.symbol) ~f:(fun bar ->
+          quantity *. bar.Types.Daily_price.close_price)
+  | _ -> None
+
+type _candidate = { pos : Position.t; market_value : float; rs : float }
+(** A held long position eligible for trimming, with its mark-to-market value
+    and RS score (lower = weaker, exited first). Positions without a price or an
+    RS read are excluded upstream. *)
+
+(** Build the trim candidate for one position when it is a priced long Holding
+    not already exiting via an earlier channel this tick. [rs_ranking] supplies
+    the weakest-first sort key (lower = weaker); a position with no RS read is
+    skipped (it cannot be ranked against the others). *)
+let _candidate_of_position ~get_price ~rs_ranking ~skip_position_ids
+    (pos : Position.t) : _candidate option =
+  if Set.mem skip_position_ids pos.Position.id then None
+  else
+    match (_long_market_value ~get_price pos, rs_ranking pos) with
+    | Some market_value, Some rs -> Some { pos; market_value; rs }
+    | _ -> None
+
+(** Collect the trimmable candidates from [positions], in arbitrary order. Only
+    priced long Holdings not on the skip-list with a known RS score qualify. *)
+let _collect_candidates ~get_price ~rs_ranking ~skip_position_ids positions =
+  Map.fold positions ~init:[] ~f:(fun ~key:_ ~data:pos acc ->
+      match
+        _candidate_of_position ~get_price ~rs_ranking ~skip_position_ids pos
+      with
+      | Some c -> c :: acc
+      | None -> acc)
+
+(** Build the [TriggerExit] transition closing the entire position at the
+    current bar close ([exit_price = bar.close_price]). [bar] is the candidate's
+    already-fetched price bar, so no [get_price] round-trip is needed here. *)
+let _exit_transition ~current_date (pos : Position.t)
+    (bar : Types.Daily_price.t) : Position.transition =
+  {
+    Position.position_id = pos.id;
+    date = current_date;
+    kind =
+      Position.TriggerExit
+        { exit_reason = _exit_reason; exit_price = bar.close_price };
+  }
+
+(** One step of the weakest-first trim fold: while held exposure is still above
+    [target_value], exit the next candidate (subtracting its value); otherwise
+    leave the running state unchanged. [get_price] is guaranteed [Some] here —
+    the candidate was only built when a price existed — so the [None] branch is
+    defensive. *)
+let _trim_step ~get_price ~current_date ~target_value (remaining, acc)
+    (c : _candidate) =
+  if Float.( <= ) remaining target_value then (remaining, acc)
+  else
+    match get_price c.pos.symbol with
+    | None -> (remaining, acc)
+    | Some bar ->
+        ( remaining -. c.market_value,
+          _exit_transition ~current_date c.pos bar :: acc )
+
+(** Walk the weakest-first candidate list, exiting positions until the remaining
+    held long exposure is at or below [target_value]. [held] is the total long
+    market value before trimming. Returns the exit transitions in trim order. *)
+let _trim_to_target ~get_price ~current_date ~target_value ~held candidates =
+  let _remaining, transitions =
+    List.fold candidates ~init:(held, [])
+      ~f:(_trim_step ~get_price ~current_date ~target_value)
+  in
+  List.rev transitions
+
+(** Decide the trim for an already-collected candidate set. No-op ([[]]) when
+    held long exposure is at or below the cap; otherwise orders weakest-RS-first
+    and trims down to [target_value]. *)
+let _trim_candidates ~get_price ~current_date ~target_value candidates =
+  let held =
+    List.fold candidates ~init:0.0 ~f:(fun acc c -> acc +. c.market_value)
+  in
+  if Float.( <= ) held target_value then []
+  else
+    List.sort candidates ~compare:(fun a b -> Float.compare a.rs b.rs)
+    |> _trim_to_target ~get_price ~current_date ~target_value ~held
+
+let update ~max_long_exposure_pct ~portfolio_value ~positions ~get_price
+    ~rs_ranking ~skip_position_ids ~current_date =
+  if Float.( <= ) portfolio_value 0.0 then []
+  else
+    let target_value = max_long_exposure_pct *. portfolio_value in
+    let candidates =
+      _collect_candidates ~get_price ~rs_ranking ~skip_position_ids positions
+    in
+    _trim_candidates ~get_price ~current_date ~target_value candidates

--- a/trading/trading/weinstein/strategy/lib/macro_bearish_trim_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/macro_bearish_trim_runner.mli
@@ -1,0 +1,99 @@
+(** Macro-bearish held-exposure trim — caps total held {e long} exposure when
+    the macro tape is confirmed Bearish, trimming the excess weakest-RS-first.
+
+    {1 Motivation}
+
+    Weinstein's macro gate (spine item #6) is normally an {e entry} filter: a
+    Bearish tape blocks new long entries. Held longs, however, only exit via
+    their own stops / Stage-3 / drawdown force-liquidation — so on a slow
+    distribution top (2000, 2008) the gate turns Bearish months before the
+    waterfall while existing longs ride all the way down to their individual
+    stops. That lag is the bulk of the deep-window drawdown.
+
+    This runner closes that gap. It extends the macro gate from "block buys" to
+    "also raise cash": on a Bearish tape it caps total held long exposure at a
+    (tighter) fraction of portfolio value and exits the excess. It is a faithful
+    {e exit-aggressiveness} dial — Weinstein explicitly says to raise cash / get
+    defensive when the major trend turns down
+    ([docs/design/weinstein-book-reference.md] §Macro Analysis, §Stage 4). Plan:
+    [dev/plans/macro-bearish-exposure-trim-2026-06-06.md].
+
+    {1 Side & ordering}
+
+    Long positions only. Shorts are never trimmed — a bearish tape is their
+    natural environment, and capping {e long} exposure says nothing about the
+    short book. Among the held longs, the weakest-RS positions are exited first
+    (the trim keeps the relative-strength leaders, per Weinstein's RS-selection
+    principle), until held long exposure is at or below the cap.
+
+    {1 Re-entry is naturally damped (anti-whipsaw)}
+
+    The runner only {e trims}; it never force-buys. Coming back requires the
+    normal Stage-2 breakout + volume screen, so a Bearish→Bullish whipsaw does
+    not auto-rebuy — re-entry is gated by the ordinary entry criteria.
+
+    {1 Cadence & gating}
+
+    The {e caller} is responsible for gating: this runner is invoked only when
+    [config.enable_macro_bearish_exposure_trim = true], the macro trend is
+    [Bearish], and it is a screening (Friday) day. The runner itself is a pure
+    function of its inputs — it does not re-check the macro trend or the
+    calendar. Modelled on {!Force_liquidation_runner} (portfolio-wide,
+    threshold-triggered, emits [TriggerExit]s, integrates with the single-exit
+    collision rules) but driven by the {e predictive} macro gate rather than the
+    {e reactive} drawdown floor. *)
+
+open Core
+open Trading_strategy
+
+val update :
+  max_long_exposure_pct:float ->
+  portfolio_value:float ->
+  positions:Position.t Map.M(String).t ->
+  get_price:Strategy_interface.get_price_fn ->
+  rs_ranking:(Position.t -> float option) ->
+  skip_position_ids:String.Set.t ->
+  current_date:Core.Date.t ->
+  Position.transition list
+(** [update] caps total held long exposure at
+    [max_long_exposure_pct * portfolio_value] and returns [TriggerExit]
+    transitions trimming the excess, weakest-RS-first.
+
+    {2 Behaviour}
+
+    - Returns [[]] when [portfolio_value <= 0.0] (degenerate snapshot — no
+      meaningful cap can be derived).
+    - Computes [held] = the signed long market value of every held long
+      [Holding] position that has a price this tick. Shorts, non-Holding states,
+      and symbols without a price are excluded from [held] and never trimmed.
+    - Returns [[]] when [held <= max_long_exposure_pct * portfolio_value] —
+      already at or under the cap, nothing to do. [max_long_exposure_pct = 1.0]
+      (or higher) is therefore a no-op; [0.0] flattens the entire long book.
+    - Otherwise orders the trimmable longs by [rs_ranking] ascending (lowest =
+      weakest, exited first) and emits a full-position [TriggerExit] for each in
+      turn, subtracting its market value from the running held total, until the
+      remaining held long exposure is at or below the cap.
+
+    {2 Collision with earlier exits}
+
+    A position whose [position_id] is in [skip_position_ids] — already exiting
+    this tick via a stop / Stage-3 / laggard / force-liquidation channel — is
+    excluded from the candidate set and never double-exited. The caller passes
+    the union of all earlier-channel exit ids. Its market value is also excluded
+    from [held] (an already-exiting long is no longer held exposure to cap).
+
+    {2 RS ranking}
+
+    [rs_ranking pos] returns the position's relative-strength score (lower =
+    weaker). A position for which [rs_ranking] returns [None] (insufficient bar
+    history to rank) is {e excluded} from trimming — it cannot be ordered
+    against the others, so the runner leaves it held rather than exiting it
+    arbitrarily. Its market value is likewise excluded from [held].
+
+    {2 Exit semantics}
+
+    Each emitted [TriggerExit] closes the {e entire} position at the current
+    bar's close ([exit_price = bar.close_price]), with
+    [exit_reason = StrategySignal { label = "macro_bearish_trim"; detail = None
+     }]. Never emits a buy / entry transition. Empty list when no trim is needed
+    — the common case (most days are not Bearish). *)

--- a/trading/trading/weinstein/strategy/lib/macro_bearish_trim_wiring.ml
+++ b/trading/trading/weinstein/strategy/lib/macro_bearish_trim_wiring.ml
@@ -1,0 +1,63 @@
+(** Strategy-integration layer for {!Macro_bearish_trim_runner}. See
+    [macro_bearish_trim_wiring.mli]. *)
+
+open Core
+open Trading_strategy
+open Weinstein_strategy_config
+
+(** Relative-strength score for a held position over the laggard RS window
+    (default 13 weeks): the position's window return minus the benchmark's.
+    Lower = weaker (the trim exits weakest-first). Returns [None] when either
+    the position or the benchmark has insufficient weekly history — the trim
+    then leaves the position held rather than ranking it arbitrarily. Reuses the
+    same window-return primitive the laggard runner uses, so the two RS notions
+    stay consistent. *)
+let _rs_score ~config ~bar_reader ~benchmark_window_return ~current_date
+    (pos : Position.t) : float option =
+  let n = config.laggard_rotation_config.Laggard_rotation.rs_window_weeks in
+  let pos_bars =
+    Bar_reader.weekly_bars_for bar_reader ~symbol:pos.symbol ~n:(n + 1)
+      ~as_of:current_date
+  in
+  match
+    (Laggard_rotation_runner.window_return ~n pos_bars, benchmark_window_return)
+  with
+  | Some pos_ret, Some bench_ret -> Some (pos_ret -. bench_ret)
+  | _ -> None
+
+(** Whether the trim should fire this tick: flag on, a screening (Friday) day,
+    and a confirmed Bearish macro trend. *)
+let _should_fire ~config ~is_screening_day ~macro_result_opt =
+  let is_bearish =
+    match macro_result_opt with
+    | Some ({ trend = Weinstein_types.Bearish; _ } : Macro.result) -> true
+    | _ -> false
+  in
+  config.enable_macro_bearish_exposure_trim && is_screening_day && is_bearish
+
+(** Benchmark RS window return for the weakest-first ranking — the same
+    rolling-window return the laggard runner uses on the primary index. *)
+let _benchmark_return ~config ~bar_reader ~current_date =
+  let n = config.laggard_rotation_config.Laggard_rotation.rs_window_weeks in
+  Laggard_rotation_runner.window_return ~n
+    (Bar_reader.weekly_bars_for bar_reader ~symbol:config.indices.primary
+       ~n:(n + 1) ~as_of:current_date)
+
+let run ~config ~positions ~(portfolio : Portfolio_view.t) ~get_price
+    ~bar_reader ~current_date ~is_screening_day ~macro_result_opt ~skip_ids =
+  if not (_should_fire ~config ~is_screening_day ~macro_result_opt) then []
+  else
+    let benchmark_window_return =
+      _benchmark_return ~config ~bar_reader ~current_date
+    in
+    let portfolio_value =
+      Portfolio_view.portfolio_value
+        { cash = portfolio.cash; positions }
+        ~get_price
+    in
+    Macro_bearish_trim_runner.update
+      ~max_long_exposure_pct:config.macro_bearish_max_long_exposure_pct
+      ~portfolio_value ~positions ~get_price
+      ~rs_ranking:
+        (_rs_score ~config ~bar_reader ~benchmark_window_return ~current_date)
+      ~skip_position_ids:skip_ids ~current_date

--- a/trading/trading/weinstein/strategy/lib/macro_bearish_trim_wiring.mli
+++ b/trading/trading/weinstein/strategy/lib/macro_bearish_trim_wiring.mli
@@ -1,0 +1,31 @@
+(** Strategy-integration layer for {!Macro_bearish_trim_runner}.
+
+    Builds the pure runner's inputs from the live strategy context — the macro
+    trend / screening-day gate, the portfolio mark-to-market value, and the
+    weakest-first RS ranking (reusing {!Laggard_rotation_runner.window_return}
+    so the laggard and trim RS notions stay consistent). Extracted from
+    {!Weinstein_strategy} so the top-level strategy module stays within its
+    length budget. *)
+
+open Core
+open Trading_strategy
+
+val run :
+  config:Weinstein_strategy_config.config ->
+  positions:Position.t Map.M(String).t ->
+  portfolio:Portfolio_view.t ->
+  get_price:Strategy_interface.get_price_fn ->
+  bar_reader:Bar_reader.t ->
+  current_date:Date.t ->
+  is_screening_day:bool ->
+  macro_result_opt:Macro.result option ->
+  skip_ids:String.Set.t ->
+  Position.transition list
+(** Run the macro-bearish held-exposure trim pass. No-op [[]] unless
+    [config.enable_macro_bearish_exposure_trim] is set, [is_screening_day] is
+    true, and [macro_result_opt] is [Some] with a [Bearish] trend. Otherwise
+    caps held long exposure at [config.macro_bearish_max_long_exposure_pct] of
+    portfolio value and exits weakest-RS longs first via
+    {!Macro_bearish_trim_runner.update}. [skip_ids] is the union of all
+    earlier-channel exit ids this tick (stop / Stage-3 / laggard / force-liq) so
+    a position already exiting is never double-exited. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -12,6 +12,8 @@ module Stops_split_runner = Stops_split_runner
 module Force_liquidation_runner = Force_liquidation_runner
 module Stage3_force_exit_runner = Stage3_force_exit_runner
 module Late_stage2_stop_runner = Late_stage2_stop_runner
+module Macro_bearish_trim_runner = Macro_bearish_trim_runner
+module Macro_bearish_trim_wiring = Macro_bearish_trim_wiring
 module Laggard_rotation_runner = Laggard_rotation_runner
 module Stage3_force_exit = Stage3_force_exit
 module Laggard_rotation = Laggard_rotation
@@ -214,25 +216,28 @@ let _run_late_stage2_tighten ~config ~positions ~get_price ~prior_stages
       ~buffer_pct:config.late_stage2_stop_buffer_pct ~is_screening_day:is_friday
       ~positions ~get_price ~prior_stages ~current_date
 
-let _run_macro_and_entries ~fold_start_date ~config ~ad_bars ~stop_states
-    ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
-    ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price
-    ~portfolio ~current_date ~index_view ~audit_recorder =
-  let is_screening_day =
-    Weinstein_strategy_screening.is_screening_day_view index_view
-  in
-  let macro_result_opt =
-    if is_screening_day then (
-      let prev = !prior_macro in
-      let r =
-        Weinstein_strategy_macro.run_macro_only ~config ~ad_bars ~prior_macro
-          ~prior_macro_result ~bar_reader ~prior_stages ~current_date
-          ~index_view
-      in
-      _maybe_reset_halt ~peak_tracker ~prior_macro:prev ~current_macro:r.trend;
-      Some r)
-    else None
-  in
+(** Compute the macro result for [current_date] (Friday only) and run the
+    halt-reset side effect. Returns [None] on non-screening days. Mutates
+    [prior_macro] / [prior_macro_result] via {!run_macro_only}. Hoisted out of
+    {!_run_macro_and_entries} so the macro trend is available to the
+    macro-bearish trim pass (which runs before the entry walk) without computing
+    the macro result twice. *)
+let _run_macro ~config ~ad_bars ~prior_macro ~prior_macro_result ~peak_tracker
+    ~bar_reader ~prior_stages ~current_date ~index_view ~is_screening_day =
+  if not is_screening_day then None
+  else
+    let prev = !prior_macro in
+    let r =
+      Weinstein_strategy_macro.run_macro_only ~config ~ad_bars ~prior_macro
+        ~prior_macro_result ~bar_reader ~prior_stages ~current_date ~index_view
+    in
+    _maybe_reset_halt ~peak_tracker ~prior_macro:prev ~current_macro:r.trend;
+    Some r
+
+let _run_entries ~fold_start_date ~config ~stop_states ~last_stop_out_dates
+    ~peak_tracker ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors
+    ~get_price ~portfolio ~current_date ~index_view ~audit_recorder
+    ~is_screening_day ~macro_result_opt =
   let halted =
     match
       Portfolio_risk.Force_liquidation.Peak_tracker.halt_state peak_tracker
@@ -246,10 +251,41 @@ let _run_macro_and_entries ~fold_start_date ~config ~ad_bars ~stop_states
     ~ticker_sectors ~get_price ~portfolio ~current_date ~index_view
     ~audit_recorder
 
+(** Compute the macro result (mutating the macro refs via {!_run_macro}) and run
+    the macro-bearish trim pass, returning both. Extracted from
+    {!_process_market_day} so that function stays within the length / nesting
+    limits; the skip-id union (stop / Stage-3 / laggard / force-liq exits) is
+    assembled here. *)
+let _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
+    ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages ~get_price
+    ~current_date ~index_view ~is_screening_day ~stop_exited_ids
+    ~stage3_exited_ids ~laggard_exited_ids ~force_exit_transitions =
+  let macro_result_opt =
+    _run_macro ~config ~ad_bars ~prior_macro ~prior_macro_result ~peak_tracker
+      ~bar_reader ~prior_stages ~current_date ~index_view ~is_screening_day
+  in
+  let skip_ids =
+    Set.union_list
+      (module String)
+      [
+        stop_exited_ids;
+        stage3_exited_ids;
+        laggard_exited_ids;
+        _trigger_exit_ids_of force_exit_transitions;
+      ]
+  in
+  let macro_trim_transitions =
+    Macro_bearish_trim_wiring.run ~config ~positions ~portfolio ~get_price
+      ~bar_reader ~current_date ~is_screening_day ~macro_result_opt ~skip_ids
+  in
+  (macro_result_opt, macro_trim_transitions)
+
 let _assemble_output ~exit_transitions ~stage3_force_exit_transitions
-    ~laggard_rotation_transitions ~force_exit_transitions ~adjust_transitions
-    ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids =
+    ~laggard_rotation_transitions ~force_exit_transitions
+    ~macro_trim_transitions ~adjust_transitions ~entry_transitions
+    ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids =
   let force_liq_exited_ids = _trigger_exit_ids_of force_exit_transitions in
+  let macro_trim_exited_ids = _trigger_exit_ids_of macro_trim_transitions in
   let all_exited_ids =
     Set.union_list
       (module String)
@@ -258,6 +294,7 @@ let _assemble_output ~exit_transitions ~stage3_force_exit_transitions
         stage3_exited_ids;
         laggard_exited_ids;
         force_liq_exited_ids;
+        macro_trim_exited_ids;
       ]
   in
   let adjust_transitions =
@@ -268,7 +305,7 @@ let _assemble_output ~exit_transitions ~stage3_force_exit_transitions
       Strategy_interface.transitions =
         exit_transitions @ stage3_force_exit_transitions
         @ laggard_rotation_transitions @ force_exit_transitions
-        @ adjust_transitions @ entry_transitions;
+        @ macro_trim_transitions @ adjust_transitions @ entry_transitions;
     }
 
 let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
@@ -297,18 +334,28 @@ let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
       ~prior_stage_ma_values ~stage3_streaks ~laggard_streaks ~bar_reader
       ~index_view ~exit_transitions ~current_date
   in
+  let is_screening_day =
+    Weinstein_strategy_screening.is_screening_day_view index_view
+  in
+  let macro_result_opt, macro_trim_transitions =
+    _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
+      ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages ~get_price
+      ~current_date ~index_view ~is_screening_day ~stop_exited_ids
+      ~stage3_exited_ids ~laggard_exited_ids ~force_exit_transitions
+  in
   let late_tighten_transitions =
     _run_late_stage2_tighten ~config ~positions ~get_price ~prior_stages
       ~index_view ~current_date
   in
   let entry_transitions =
-    _run_macro_and_entries ~fold_start_date ~config ~ad_bars ~stop_states
-      ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
-      ~bar_reader ~prior_stages ~sector_prior_stages ~ticker_sectors ~get_price
-      ~portfolio ~current_date ~index_view ~audit_recorder
+    _run_entries ~fold_start_date ~config ~stop_states ~last_stop_out_dates
+      ~peak_tracker ~bar_reader ~prior_stages ~sector_prior_stages
+      ~ticker_sectors ~get_price ~portfolio ~current_date ~index_view
+      ~audit_recorder ~is_screening_day ~macro_result_opt
   in
   _assemble_output ~exit_transitions ~stage3_force_exit_transitions
     ~laggard_rotation_transitions ~force_exit_transitions
+    ~macro_trim_transitions
     ~adjust_transitions:(adjust_transitions @ late_tighten_transitions)
     ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -85,6 +85,15 @@ module Late_stage2_stop_runner = Late_stage2_stop_runner
     transitions (never exits). Default-off preserves all baselines. See
     {!Late_stage2_stop_runner}. *)
 
+module Macro_bearish_trim_runner = Macro_bearish_trim_runner
+(** Macro-bearish held-exposure trim runner (default-off). Invoked AFTER the
+    special-exit passes on Friday ticks when
+    [config.enable_macro_bearish_exposure_trim = true] AND the macro trend is
+    Bearish: caps held long exposure at
+    [config.macro_bearish_max_long_exposure_pct] of portfolio value, trimming
+    the excess weakest-RS-first. Default-off preserves all baselines. See
+    {!Macro_bearish_trim_runner}. *)
+
 module Laggard_rotation_runner = Laggard_rotation_runner
 (** Laggard-rotation runner — capital recycling on the long side (issue #887).
     Invoked AFTER {!Stops_runner.update}, {!Force_liquidation_runner.update} and
@@ -378,6 +387,24 @@ type config = {
           [close *. (1.0 -. late_stage2_stop_buffer_pct)]. Only consulted when
           [enable_late_stage2_stop_tighten = true]; default [0.0] is the no-op
           buffer. See [Weinstein_strategy_config]. *)
+  enable_macro_bearish_exposure_trim : bool; [@sexp.default false]
+      (** Held-exposure risk dial (default-off): when [true] and the macro tape
+          is Bearish on a Friday tick, the {!Macro_bearish_trim_runner} caps
+          total held long exposure (see [macro_bearish_max_long_exposure_pct])
+          and trims the excess weakest-RS-first. Default [false] preserves all
+          baselines (the runner is never invoked). The {b spine} is untouched —
+          this is the macro gate (spine item #6) extended from "block buys" to
+          "raise cash on a bear tape", a faithful exit-aggressiveness dial; it
+          never force-buys. [Variant_matrix] flag axis. See
+          [Weinstein_strategy_config] / {!Macro_bearish_trim_runner} for full
+          semantics. *)
+  macro_bearish_max_long_exposure_pct : float; [@sexp.default 0.70]
+      (** Fraction of portfolio value at which held long exposure is capped when
+          the macro-bearish trim fires. [0.0] = full flat; [1.0] (or higher) =
+          no-op. Only consulted when
+          [enable_macro_bearish_exposure_trim = true]; default [0.70] mirrors
+          the normal long-exposure cap (a no-op cap). See
+          [Weinstein_strategy_config]. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -1,5 +1,9 @@
 open Core
 
+(* No-op default for [macro_bearish_max_long_exposure_pct]: equals the normal
+   long-exposure cap, so the trim never bites until a spec sets a tighter value. *)
+let macro_bearish_no_op_cap = 0.70
+
 type index_config = { primary : string; global : (string * string) list }
 [@@deriving sexp]
 
@@ -89,6 +93,13 @@ type config = {
       (** Master switch for the late-Stage-2 stop-tighten runner; see [.mli]. *)
   late_stage2_stop_buffer_pct : float; [@sexp.default 0.0]
       (** Buffer below close where the runner raises the stop; see [.mli]. *)
+  enable_macro_bearish_exposure_trim : bool; [@sexp.default false]
+      (** Master switch for the macro-bearish held-exposure trim runner; default
+          [false] is a no-op (bit-identical to baseline). See [.mli]. *)
+  macro_bearish_max_long_exposure_pct : float;
+      [@sexp.default macro_bearish_no_op_cap]
+      (** Fraction of portfolio value the trim caps held long exposure at on a
+          Bearish tape; default [0.70] is a no-op cap. See [.mli]. *)
 }
 [@@deriving sexp]
 
@@ -125,6 +136,8 @@ let default_config ~universe ~index_symbol =
     neutral_blocks_longs = false;
     enable_late_stage2_stop_tighten = false;
     late_stage2_stop_buffer_pct = 0.0;
+    enable_macro_bearish_exposure_trim = false;
+    macro_bearish_max_long_exposure_pct = macro_bearish_no_op_cap;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -149,6 +149,27 @@ type config = {
           buffer (and, because the runner is gated entirely by the flag, the
           disabled path is byte-identical to baseline regardless of this value).
           See {!Late_stage2_stop_runner}. *)
+  enable_macro_bearish_exposure_trim : bool; [@sexp.default false]
+      (** Master switch for the macro-bearish held-exposure trim runner
+          ({!Macro_bearish_trim_runner}, plan
+          [dev/plans/macro-bearish-exposure-trim-2026-06-06.md]). When [true]
+          and the macro tape is Bearish on a screening (Friday) day, held long
+          exposure is capped (see [macro_bearish_max_long_exposure_pct]) and the
+          excess is trimmed weakest-RS-first. Default [false] preserves all
+          existing baselines — the trim pass short-circuits to [[]] before any
+          work, so the disabled path is byte-identical to the pre-feature
+          strategy. Searchable as a [Variant_matrix] flag axis
+          ([((flag enable_macro_bearish_exposure_trim) (values (true false)))]).
+      *)
+  macro_bearish_max_long_exposure_pct : float; [@sexp.default 0.70]
+      (** Fraction of portfolio value at which total held long exposure is
+          capped when the macro-bearish trim fires; the excess is exited
+          weakest-RS-first. [0.0] = full flat (all cash in a bear tape); [1.0]
+          (or higher) = no-op. Only consulted when
+          [enable_macro_bearish_exposure_trim = true]. Default [0.70] mirrors
+          the normal long-exposure cap, so even with the flag flipped on the
+          value defaults to a no-op cap — only a tighter value changes
+          behaviour. See {!Macro_bearish_trim_runner}. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -15,6 +15,7 @@
   test_spy_only_weinstein_strategy
   test_stage3_force_exit_runner
   test_late_stage2_stop_runner
+  test_macro_bearish_trim_runner
   test_laggard_rotation_runner
   test_stops_runner
   test_stops_split_runner

--- a/trading/trading/weinstein/strategy/test/test_macro_bearish_trim_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_macro_bearish_trim_runner.ml
@@ -1,0 +1,340 @@
+(** Unit tests for {!Macro_bearish_trim_runner}.
+
+    Pins the trim contract: caps held long exposure at the configured fraction
+    of portfolio value on a Bearish tape, exits weakest-RS-first, is a no-op
+    when already under the cap, never emits a buy, and respects the single-exit
+    collision rule via [skip_position_ids]. The macro-trend / Friday gating is
+    the {e caller}'s responsibility (see [test_weinstein_strategy] integration),
+    so these unit tests drive the pure runner directly. *)
+
+open OUnit2
+open Core
+open Matchers
+open Weinstein_strategy
+module Position = Trading_strategy.Position
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let _date s = Date.of_string s
+
+let _make_bar ~date ~close =
+  Types.Daily_price.
+    {
+      date;
+      open_price = close;
+      high_price = close *. 1.01;
+      low_price = close *. 0.99;
+      close_price = close;
+      adjusted_close = close;
+      volume = 1_000_000;
+      active_through = None;
+    }
+
+(** Build a [Holding] position via the canonical entry chain so the result is
+    bit-equal to what the simulator would have produced. *)
+let _make_holding ~symbol ~side ~entry_date ~quantity ~entry_price =
+  let pos_id = symbol ^ "-1" in
+  let unwrap = function
+    | Ok p -> p
+    | Error err -> assert_failure ("position setup failed: " ^ Status.show err)
+  in
+  let trans kind = { Position.position_id = pos_id; date = entry_date; kind } in
+  let p =
+    Position.create_entering
+      (trans
+         (Position.CreateEntering
+            {
+              symbol;
+              side;
+              target_quantity = quantity;
+              entry_price;
+              reasoning =
+                Position.TechnicalSignal
+                  { indicator = "trim"; description = "test-entry" };
+            }))
+    |> unwrap
+  in
+  let p =
+    Position.apply_transition p
+      (trans
+         (Position.EntryFill
+            { filled_quantity = quantity; fill_price = entry_price }))
+    |> unwrap
+  in
+  Position.apply_transition p
+    (trans
+       (Position.EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = None;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+let _make_long ~symbol ~quantity ~entry_price =
+  _make_holding ~symbol ~side:Trading_base.Types.Long
+    ~entry_date:(_date "2024-01-02") ~quantity ~entry_price
+
+(* A [get_price] returning every symbol at its [(symbol, close)] mapping. *)
+let _get_price_of alist s =
+  List.Assoc.find alist s ~equal:String.equal
+  |> Option.map ~f:(fun close -> _make_bar ~date:(_date "2024-04-29") ~close)
+
+(* RS-ranking from an explicit [(symbol, score)] alist; unknown symbols return
+   [None]. Lower score = weaker. *)
+let _rs_of alist (pos : Position.t) =
+  List.Assoc.find alist pos.symbol ~equal:String.equal
+
+let _exit_symbols_of (transitions : Position.transition list) ~positions =
+  List.filter_map transitions ~f:(fun (t : Position.transition) ->
+      Map.data positions
+      |> List.find ~f:(fun (p : Position.t) -> String.equal p.id t.position_id)
+      |> Option.map ~f:(fun (p : Position.t) -> p.symbol))
+
+(* ------------------------------------------------------------------ *)
+(* Trims to cap                                                         *)
+(* ------------------------------------------------------------------ *)
+
+(** Three equal $30k longs (held $90k) in a $100k portfolio; cap 0.35 → target
+    $35k. The weakest two ($60k worth) must be exited so the remaining one
+    ($30k) sits under the $35k cap. *)
+let test_trims_excess_to_cap _ =
+  let positions =
+    String.Map.of_alist_exn
+      [
+        ( "STRONG",
+          _make_long ~symbol:"STRONG" ~quantity:300.0 ~entry_price:100.0 );
+        ("MID", _make_long ~symbol:"MID" ~quantity:300.0 ~entry_price:100.0);
+        ("WEAK", _make_long ~symbol:"WEAK" ~quantity:300.0 ~entry_price:100.0);
+      ]
+  in
+  let get_price =
+    _get_price_of [ ("STRONG", 100.0); ("MID", 100.0); ("WEAK", 100.0) ]
+  in
+  let rs_ranking =
+    _rs_of [ ("STRONG", 0.20); ("MID", 0.00); ("WEAK", -0.30) ]
+  in
+  let transitions =
+    Macro_bearish_trim_runner.update ~max_long_exposure_pct:0.35
+      ~portfolio_value:100_000.0 ~positions ~get_price ~rs_ranking
+      ~skip_position_ids:String.Set.empty ~current_date:(_date "2024-04-29")
+  in
+  (* Weakest-first: WEAK then MID exit; STRONG survives. Order is preserved. *)
+  assert_that
+    (_exit_symbols_of transitions ~positions)
+    (elements_are [ equal_to "WEAK"; equal_to "MID" ])
+
+(** Full-flat cap (0.0): every held long is exited regardless of RS. *)
+let test_full_flat_exits_all _ =
+  let positions =
+    String.Map.of_alist_exn
+      [
+        ("AAA", _make_long ~symbol:"AAA" ~quantity:100.0 ~entry_price:100.0);
+        ("BBB", _make_long ~symbol:"BBB" ~quantity:100.0 ~entry_price:100.0);
+      ]
+  in
+  let get_price = _get_price_of [ ("AAA", 100.0); ("BBB", 100.0) ] in
+  let rs_ranking = _rs_of [ ("AAA", 0.1); ("BBB", 0.2) ] in
+  let transitions =
+    Macro_bearish_trim_runner.update ~max_long_exposure_pct:0.0
+      ~portfolio_value:100_000.0 ~positions ~get_price ~rs_ranking
+      ~skip_position_ids:String.Set.empty ~current_date:(_date "2024-04-29")
+  in
+  assert_that transitions (size_is 2)
+
+(* ------------------------------------------------------------------ *)
+(* No-op cases                                                          *)
+(* ------------------------------------------------------------------ *)
+
+(** Already under the cap → no trim. Held $20k, cap 0.35 of $100k = $35k. *)
+let test_under_cap_is_noop _ =
+  let positions =
+    String.Map.singleton "AAA"
+      (_make_long ~symbol:"AAA" ~quantity:200.0 ~entry_price:100.0)
+  in
+  let get_price = _get_price_of [ ("AAA", 100.0) ] in
+  let rs_ranking = _rs_of [ ("AAA", 0.1) ] in
+  let transitions =
+    Macro_bearish_trim_runner.update ~max_long_exposure_pct:0.35
+      ~portfolio_value:100_000.0 ~positions ~get_price ~rs_ranking
+      ~skip_position_ids:String.Set.empty ~current_date:(_date "2024-04-29")
+  in
+  assert_that transitions is_empty
+
+(** No-op cap (1.0): even a fully-long book is left untouched. *)
+let test_noop_cap_leaves_book _ =
+  let positions =
+    String.Map.singleton "AAA"
+      (_make_long ~symbol:"AAA" ~quantity:900.0 ~entry_price:100.0)
+  in
+  let get_price = _get_price_of [ ("AAA", 100.0) ] in
+  let rs_ranking = _rs_of [ ("AAA", 0.1) ] in
+  let transitions =
+    Macro_bearish_trim_runner.update ~max_long_exposure_pct:1.0
+      ~portfolio_value:100_000.0 ~positions ~get_price ~rs_ranking
+      ~skip_position_ids:String.Set.empty ~current_date:(_date "2024-04-29")
+  in
+  assert_that transitions is_empty
+
+(** Degenerate portfolio value (<= 0) → no trim. *)
+let test_nonpositive_portfolio_value_is_noop _ =
+  let positions =
+    String.Map.singleton "AAA"
+      (_make_long ~symbol:"AAA" ~quantity:100.0 ~entry_price:100.0)
+  in
+  let get_price = _get_price_of [ ("AAA", 100.0) ] in
+  let rs_ranking = _rs_of [ ("AAA", 0.1) ] in
+  let transitions =
+    Macro_bearish_trim_runner.update ~max_long_exposure_pct:0.0
+      ~portfolio_value:0.0 ~positions ~get_price ~rs_ranking
+      ~skip_position_ids:String.Set.empty ~current_date:(_date "2024-04-29")
+  in
+  assert_that transitions is_empty
+
+(* ------------------------------------------------------------------ *)
+(* Side & ranking semantics                                            *)
+(* ------------------------------------------------------------------ *)
+
+(** Shorts are never trimmed and never counted toward held long exposure. A book
+    of one $90k SHORT in a $100k portfolio with cap 0.0 produces no exit — the
+    trim caps {e long} exposure only. *)
+let test_shorts_not_trimmed _ =
+  let positions =
+    String.Map.singleton "SH"
+      (_make_holding ~symbol:"SH" ~side:Trading_base.Types.Short
+         ~entry_date:(_date "2024-01-02") ~quantity:900.0 ~entry_price:100.0)
+  in
+  let get_price = _get_price_of [ ("SH", 100.0) ] in
+  let rs_ranking = _rs_of [ ("SH", -0.5) ] in
+  let transitions =
+    Macro_bearish_trim_runner.update ~max_long_exposure_pct:0.0
+      ~portfolio_value:100_000.0 ~positions ~get_price ~rs_ranking
+      ~skip_position_ids:String.Set.empty ~current_date:(_date "2024-04-29")
+  in
+  assert_that transitions is_empty
+
+(** Every emitted transition is a [TriggerExit] with the ["macro_bearish_trim"]
+    StrategySignal label — the runner never force-buys. Verifies the exit reason
+    \+ price for the trimmed weakest position. *)
+let test_emits_only_macro_bearish_trim_exits _ =
+  let positions =
+    String.Map.of_alist_exn
+      [
+        ("KEEP", _make_long ~symbol:"KEEP" ~quantity:300.0 ~entry_price:100.0);
+        ("DROP", _make_long ~symbol:"DROP" ~quantity:300.0 ~entry_price:100.0);
+      ]
+  in
+  let get_price = _get_price_of [ ("KEEP", 100.0); ("DROP", 90.0) ] in
+  let rs_ranking = _rs_of [ ("KEEP", 0.5); ("DROP", -0.5) ] in
+  let transitions =
+    Macro_bearish_trim_runner.update ~max_long_exposure_pct:0.35
+      ~portfolio_value:100_000.0 ~positions ~get_price ~rs_ranking
+      ~skip_position_ids:String.Set.empty ~current_date:(_date "2024-04-29")
+  in
+  assert_that transitions
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Position.transition) -> t.position_id)
+               (equal_to "DROP-1");
+             field
+               (fun (t : Position.transition) -> t.kind)
+               (matching ~msg:"Expected macro_bearish_trim TriggerExit"
+                  (function
+                    | Position.TriggerExit
+                        {
+                          exit_reason = Position.StrategySignal { label; _ };
+                          exit_price;
+                        } ->
+                        Some (label, exit_price)
+                    | _ -> None)
+                  (all_of
+                     [
+                       field fst (equal_to "macro_bearish_trim");
+                       field snd (float_equal 90.0);
+                     ]));
+           ];
+       ])
+
+(** A position whose RS is unknown ([None]) is excluded from trimming and from
+    the held total — it is left held rather than exited arbitrarily. Held = only
+    the RS-known long ($30k); cap 0.35 of $100k = $35k → no trim. *)
+let test_unranked_position_excluded _ =
+  let positions =
+    String.Map.of_alist_exn
+      [
+        ( "RANKED",
+          _make_long ~symbol:"RANKED" ~quantity:300.0 ~entry_price:100.0 );
+        ( "NORANK",
+          _make_long ~symbol:"NORANK" ~quantity:900.0 ~entry_price:100.0 );
+      ]
+  in
+  let get_price = _get_price_of [ ("RANKED", 100.0); ("NORANK", 100.0) ] in
+  (* NORANK absent from the alist → rs_ranking returns None for it. *)
+  let rs_ranking = _rs_of [ ("RANKED", -0.5) ] in
+  let transitions =
+    Macro_bearish_trim_runner.update ~max_long_exposure_pct:0.35
+      ~portfolio_value:100_000.0 ~positions ~get_price ~rs_ranking
+      ~skip_position_ids:String.Set.empty ~current_date:(_date "2024-04-29")
+  in
+  assert_that transitions is_empty
+
+(* ------------------------------------------------------------------ *)
+(* Single-exit collision                                               *)
+(* ------------------------------------------------------------------ *)
+
+(** A position already exiting this tick (its id in [skip_position_ids]) is
+    excluded from the candidate set and from the held total — never
+    double-exited. WEAK is already stop-exiting; with WEAK excluded the held
+    total is the remaining two $30k longs = $60k, cap 0.35 → target $35k, so
+    only MID (the now-weakest eligible) is trimmed, not WEAK. *)
+let test_skip_ids_prevents_double_exit _ =
+  let positions =
+    String.Map.of_alist_exn
+      [
+        ( "STRONG",
+          _make_long ~symbol:"STRONG" ~quantity:300.0 ~entry_price:100.0 );
+        ("MID", _make_long ~symbol:"MID" ~quantity:300.0 ~entry_price:100.0);
+        ("WEAK", _make_long ~symbol:"WEAK" ~quantity:300.0 ~entry_price:100.0);
+      ]
+  in
+  let get_price =
+    _get_price_of [ ("STRONG", 100.0); ("MID", 100.0); ("WEAK", 100.0) ]
+  in
+  let rs_ranking =
+    _rs_of [ ("STRONG", 0.20); ("MID", 0.00); ("WEAK", -0.30) ]
+  in
+  let transitions =
+    Macro_bearish_trim_runner.update ~max_long_exposure_pct:0.35
+      ~portfolio_value:100_000.0 ~positions ~get_price ~rs_ranking
+      ~skip_position_ids:(String.Set.singleton "WEAK-1")
+      ~current_date:(_date "2024-04-29")
+  in
+  assert_that
+    (_exit_symbols_of transitions ~positions)
+    (elements_are [ equal_to "MID" ])
+
+let suite =
+  "macro_bearish_trim_runner"
+  >::: [
+         "trims excess to cap" >:: test_trims_excess_to_cap;
+         "full flat exits all" >:: test_full_flat_exits_all;
+         "under cap is no-op" >:: test_under_cap_is_noop;
+         "no-op cap leaves book" >:: test_noop_cap_leaves_book;
+         "non-positive portfolio value is no-op"
+         >:: test_nonpositive_portfolio_value_is_noop;
+         "shorts not trimmed" >:: test_shorts_not_trimmed;
+         "emits only macro_bearish_trim exits"
+         >:: test_emits_only_macro_bearish_trim_exits;
+         "unranked position excluded" >:: test_unranked_position_excluded;
+         "skip ids prevents double exit" >:: test_skip_ids_prevents_double_exit;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

New **default-off** strategy mechanism: the **macro-bearish held-exposure trim** (`Macro_bearish_trim_runner`). On a screening (Friday) day, when the macro tape is confirmed `Bearish`, it caps total held **long** exposure at `config.macro_bearish_max_long_exposure_pct` of portfolio value and trims the excess by exiting the **weakest-RS positions first**, until held long exposure is at or below the cap. `0.0` = full flat; `1.0` (or higher) = no-op. Shorts are never trimmed; the runner never force-buys.

Plan: `dev/plans/macro-bearish-exposure-trim-2026-06-06.md`.

### Why (the deep-window drawdown lever)

The macro gate is normally an *entry* filter — a Bearish tape blocks new longs but held longs only exit via their own stops / Stage-3 / drawdown force-liquidation. On the slow distribution tops (2000, 2008) the gate turned Bearish *months* before the waterfall while existing longs rode all the way down. This mechanism extends the gate from "block buys" to "raise cash on a confirmed bear tape" — the lag closed is the bulk of the deep-window MaxDD. Re-entry is naturally damped (anti-whipsaw): the runner only trims; coming back requires the normal Stage-2 breakout+volume screen.

## Weinstein-faithfulness

- **Spine intact (W1).** No spine item is altered. This is the macro gate (spine item #6, "bearish macro is an unconditional filter") applied to held exposure, and RS-ranked exits (spine item #7, RS for selection — keep the leaders, drop the laggards).
- **Adaptation is a documented dial (W2).** Exit-aggressiveness — Weinstein explicitly says to raise cash / get defensive when the major trend turns down (`weinstein-book-reference.md` §Macro Analysis, §Stage 4). Config-expressed, default-off.

## Config (experiment-flag-discipline)

- `enable_macro_bearish_exposure_trim : bool [@sexp.default false]` (R1 default-off; flag-off path is bit-identical to baseline — the trim pass short-circuits to `[]` before any work).
- `macro_bearish_max_long_exposure_pct : float [@sexp.default 0.70]` (no-op cap mirroring the normal long cap; only a tighter value changes behaviour).
- **R2 searchable:** both are real `Weinstein_strategy.config` fields → resolve through `Overlay_validator.apply_overrides` → registered as `Variant_matrix` flag + key axes (pinned in `test_variant_matrix.ml`).
- **R3:** NOT promoted, no default flipped. Stays default-off pending a grid ACCEPT.

## Wiring

Wired into `weinstein_strategy.ml` `_process_market_day` as `_run_macro_bearish_trim`, **after** `_run_special_exits`. The macro result is hoisted into a new `_run_macro` helper (split out of `_run_macro_and_entries` → `_run_entries`) so the trend is available to the trim pass without computing macro twice. Respects the single-exit collision rule via the skip-id union of stop / Stage-3 / laggard / force-liq exits. The RS ranking reuses `Laggard_rotation_runner.window_return` (newly exposed) so the laggard and trim RS notions stay consistent.

## Test coverage

- `test_macro_bearish_trim_runner.ml` (9 cases): trims excess to cap (weakest-RS-first ordering pinned), full-flat (0.0) exits all, under-cap no-op, no-op cap (1.0), non-positive portfolio value no-op, shorts-not-trimmed, exit-reason label `macro_bearish_trim` / never-force-buys, unranked-position-excluded, skip-id single-exit collision.
- `test_variant_matrix.ml` (+1 case): both new config fields expand + validate as `Variant_matrix` axes.
- Full strategy test suite + full project build green; flag-off path leaves all golden scenarios unchanged.

## Files

- NEW `trading/trading/weinstein/strategy/lib/macro_bearish_trim_runner.{ml,mli}`
- NEW `trading/trading/weinstein/strategy/test/test_macro_bearish_trim_runner.ml`
- `weinstein_strategy.{ml,mli}`, `weinstein_strategy_config.{ml,mli}` (config fields + wiring)
- `laggard_rotation_runner.{ml,mli}` (expose `window_return`)
- `trading/trading/weinstein/strategy/test/dune`, `trading/trading/backtest/walk_forward/test/test_variant_matrix.ml`
- `dev/status/stage-accuracy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
