### PR TITLE
feat(backtest): configurable snapshot LRU cache size + hit/miss/eviction counter

### DIFF
--- a/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.ml
@@ -30,6 +30,9 @@ let _per_symbol_overhead_bytes = 128
    never revised. *)
 type cache_entry = { symbol : string; rows : Snapshot.t array; bytes : int }
 
+type stats = { hits : int; misses : int; evictions : int }
+[@@deriving sexp, equal]
+
 type t = {
   snapshot_dir : string;
   manifest : Snapshot_manifest.t;
@@ -40,6 +43,11 @@ type t = {
      tail = LRU. Eviction pops from tail. *)
   lru : cache_entry Doubly_linked.t;
   mutable bytes : int;
+  (* Cumulative cache-access counters since [create]. Surfaced via [cache_stats]
+     for thrash diagnosis; never reset, not even by [close]. *)
+  mutable hits : int;
+  mutable misses : int;
+  mutable evictions : int;
 }
 
 (* --- Path resolution -------------------------------------------------- *)
@@ -73,6 +81,7 @@ let _evict_one t =
       Doubly_linked.remove t.lru elt;
       Hashtbl.remove t.cache entry.symbol;
       t.bytes <- t.bytes - entry.bytes;
+      t.evictions <- t.evictions + 1;
       true
 
 (* Drop entries until the budget is restored. Always leaves at least one
@@ -119,6 +128,7 @@ let _insert_rows t ~symbol rows_list =
   _insert_into_cache t ~symbol ~rows
 
 let _load_and_insert t ~symbol =
+  t.misses <- t.misses + 1;
   match Snapshot_manifest.find t.manifest ~symbol with
   | None ->
       Status.error_not_found
@@ -128,6 +138,7 @@ let _load_and_insert t ~symbol =
 
 (* Cache hit: promote to MRU and return the resident entry. *)
 let _hit_path t (elt : cache_entry Doubly_linked.Elt.t) =
+  t.hits <- t.hits + 1;
   _promote_to_mru t elt;
   Ok (Doubly_linked.Elt.value elt)
 
@@ -148,6 +159,9 @@ let _empty_cache ~snapshot_dir ~manifest ~max_cache_bytes =
     cache = Hashtbl.create (module String);
     lru = Doubly_linked.create ();
     bytes = 0;
+    hits = 0;
+    misses = 0;
+    evictions = 0;
   }
 
 let create ~snapshot_dir ~manifest ~max_cache_mb =
@@ -204,6 +218,9 @@ let active_through_for t ~symbol =
     ~f:(fun (e : Snapshot_manifest.file_metadata) -> e.active_through)
 
 let cache_bytes t = t.bytes
+
+let cache_stats t =
+  { hits = t.hits; misses = t.misses; evictions = t.evictions }
 
 let close t =
   Doubly_linked.clear t.lru;

--- a/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.mli
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.mli
@@ -130,6 +130,26 @@ val cache_bytes : t -> int
 (** [cache_bytes t] returns the current sum of estimated bytes resident in the
     cache. Useful for tests that assert eviction kicked in. *)
 
+type stats = { hits : int; misses : int; evictions : int }
+[@@deriving sexp, equal]
+(** Cumulative cache-access counters observed since {!create}.
+
+    - [hits] — reads served from a resident (already-decoded) symbol entry.
+    - [misses] — reads that had to load + decode a symbol file from disk. Each
+      miss is one full sexp decode, the dominant per-read cost.
+    - [evictions] — LRU evictions that actually dropped a resident entry to
+      restore the byte budget.
+
+    The decisive thrash metric is [misses / n_symbols]: ≈1 means each symbol was
+    decoded roughly once (the cache held the working set), whereas a value
+    approaching the number of strategy cycles means the cache is thrashing —
+    every cycle re-decoding a symbol it just evicted. *)
+
+val cache_stats : t -> stats
+(** [cache_stats t] returns the cumulative {!stats} since {!create}. {!close}
+    does not reset the counters — they measure lifetime cache behaviour, so a
+    caller can read them after the run to diagnose cache thrash. *)
+
 val close : t -> unit
 (** [close t] drops every cached symbol. After {!close}, [t] is logically empty;
     subsequent {!read_today} / {!read_history} calls will reload from disk on

--- a/trading/analysis/weinstein/snapshot_runtime/test/test_daily_panels.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/test/test_daily_panels.ml
@@ -282,6 +282,58 @@ let test_round_trip_30d_10sym _ =
     (is_ok_and_holds
        (field (fun (r : Snapshot.t) -> r.values.(0)) (float_equal 105.0)))
 
+(* --- cache stats counters ------------------------------------------- *)
+
+(* A first read of a fresh symbol is a miss (one disk decode), no hit, no
+   eviction. *)
+let test_cache_stats_first_read_is_a_miss _ =
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let _ =
+    match Daily_panels.read_today t ~symbol:"AAPL" ~date:_default_start with
+    | Ok r -> r
+    | Error err -> assert_failure ("read_today: " ^ Status.show err)
+  in
+  assert_that
+    (Daily_panels.cache_stats t)
+    (equal_to ({ hits = 0; misses = 1; evictions = 0 } : Daily_panels.stats))
+
+(* A second read of the same resident symbol is a hit; the miss count stays
+   at one. *)
+let test_cache_stats_second_read_is_a_hit _ =
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let read () =
+    match Daily_panels.read_today t ~symbol:"AAPL" ~date:_default_start with
+    | Ok _ -> ()
+    | Error err -> assert_failure ("read_today: " ^ Status.show err)
+  in
+  read ();
+  read ();
+  assert_that
+    (Daily_panels.cache_stats t)
+    (equal_to ({ hits = 1; misses = 1; evictions = 0 } : Daily_panels.stats))
+
+(* Under a tiny budget with several large symbols, loading them all forces at
+   least one eviction; each first-touch is a miss and none are hits. *)
+let test_cache_stats_counts_evictions_under_pressure _ =
+  let symbols = [ "A"; "B"; "C"; "D"; "E"; "F" ] in
+  let _dir, t = _setup ~symbols ~n_days:5000 ~max_cache_mb:1 in
+  List.iter symbols ~f:(fun symbol ->
+      match Daily_panels.read_today t ~symbol ~date:_default_start with
+      | Ok _ -> ()
+      | Error err -> assert_failure ("read_today: " ^ Status.show err));
+  assert_that
+    (Daily_panels.cache_stats t)
+    (all_of
+       [
+         field (fun (s : Daily_panels.stats) -> s.hits) (equal_to 0);
+         field
+           (fun (s : Daily_panels.stats) -> s.misses)
+           (equal_to (List.length symbols));
+         field
+           (fun (s : Daily_panels.stats) -> s.evictions)
+           (gt (module Int_ord) 0);
+       ])
+
 let suite =
   "Daily_panels tests"
   >::: [
@@ -305,6 +357,12 @@ let suite =
          "close then read reloads" >:: test_close_then_read_reloads;
          "schema mismatch fails loud" >:: test_schema_mismatch_fails_loud;
          "round trip 30d × 10 sym" >:: test_round_trip_30d_10sym;
+         "cache stats first read is a miss"
+         >:: test_cache_stats_first_read_is_a_miss;
+         "cache stats second read is a hit"
+         >:: test_cache_stats_second_read_is_a_hit;
+         "cache stats counts evictions under pressure"
+         >:: test_cache_stats_counts_evictions_under_pressure;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -15,11 +15,40 @@ type input = {
   all_symbols : string list;
 }
 
-(* LRU cap for the snapshot cache. Sized so a tier-3 sp500 run at a long
-   horizon fits resident; tier-4 release gates plumb this through
-   [Runner.config] when they land. Memory budget is best-effort — a single
-   oversized symbol stays resident even when its bytes exceed the cap. *)
-let _snapshot_cache_mb = 1024
+(* Default LRU cap (MB) for the snapshot cache. 4096 MB holds the decoded
+   working set of an N~3000 PIT universe (~1.5 GB on disk) resident, avoiding
+   the thrash that left N=3000 snapshot runs non-terminating under the old
+   1 GB cap (see dev/notes/macro-bearish-trim-grid-2026-06-07.md §7). N=1000
+   (~544 MB) fit under the old cap; the bump is what unlocks N=3000 locally.
+
+   Overridable via the [SNAPSHOT_CACHE_MB] env var (an infra knob, not a
+   strategy parameter, so it is not threaded through
+   [Weinstein_strategy.config]; the env var is the least-plumbing surface).
+   Memory budget is best-effort — a single oversized symbol stays resident even
+   when its bytes exceed the cap. *)
+let _default_snapshot_cache_mb = 4096
+let _snapshot_cache_mb_env_var = "SNAPSHOT_CACHE_MB"
+
+(* Resolve the snapshot LRU cap from [SNAPSHOT_CACHE_MB], falling back to the
+   default on an absent / unparseable / non-positive value. Logs the resolved
+   value once to stderr. *)
+let _resolve_snapshot_cache_mb () =
+  let resolved =
+    match Sys.getenv _snapshot_cache_mb_env_var with
+    | None -> _default_snapshot_cache_mb
+    | Some raw -> (
+        match Int.of_string_opt (String.strip raw) with
+        | Some n when n > 0 -> n
+        | _ ->
+            eprintf
+              "Panel_runner: ignoring unparseable %s=%S; using default %d MB\n\
+               %!"
+              _snapshot_cache_mb_env_var raw _default_snapshot_cache_mb;
+            _default_snapshot_cache_mb)
+  in
+  eprintf "Panel_runner: snapshot cache cap = %d MB (env %s)\n%!" resolved
+    _snapshot_cache_mb_env_var;
+  resolved
 
 (* Wrap the runner's already-constructed [daily_panels] in the simulator's
    callback adapter, sharing the LRU cache with the strategy bar reader.
@@ -152,7 +181,7 @@ let _setup_hybrid (input : input) ~strategy_choice ~snapshot_dir ~manifest
   let daily_panels =
     match
       Daily_panels.create ~snapshot_dir ~manifest
-        ~max_cache_mb:_snapshot_cache_mb
+        ~max_cache_mb:(_resolve_snapshot_cache_mb ())
     with
     | Ok p -> p
     | Error err ->
@@ -265,6 +294,21 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
   in
   Option.iter progress_acc ~f:Backtest_progress.emit_final;
   let final_close_prices = final_close_prices_thunk () in
+  (* Snapshot-cache thrash diagnostic. [misses_per_symbol] ≈ 1 means the cache
+     held the working set; a value approaching the cycle count means the cache
+     thrashed (every cycle re-decoding an evicted symbol) — the signal that the
+     cap is too small for this universe. Emit before [close] drops the cache. *)
+  let cache_stats = Daily_panels.cache_stats daily_panels in
+  let misses_per_symbol =
+    if n_all_symbols = 0 then 0.0
+    else Float.of_int cache_stats.misses /. Float.of_int n_all_symbols
+  in
+  eprintf
+    "Panel_runner: snapshot cache hits=%d misses=%d evictions=%d n_symbols=%d \
+     misses_per_symbol=%.2f\n\
+     %!"
+    cache_stats.hits cache_stats.misses cache_stats.evictions n_all_symbols
+    misses_per_symbol;
   (* Drop the Daily_panels LRU cache before returning. See
      dev/notes/bayesian-int-rounding-bug-2026-05-19.md §"Third failure". *)
   Daily_panels.close daily_panels;

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -15,41 +15,6 @@ type input = {
   all_symbols : string list;
 }
 
-(* Default LRU cap (MB) for the snapshot cache. 4096 MB holds the decoded
-   working set of an N~3000 PIT universe (~1.5 GB on disk) resident, avoiding
-   the thrash that left N=3000 snapshot runs non-terminating under the old
-   1 GB cap (see dev/notes/macro-bearish-trim-grid-2026-06-07.md §7). N=1000
-   (~544 MB) fit under the old cap; the bump is what unlocks N=3000 locally.
-
-   Overridable via the [SNAPSHOT_CACHE_MB] env var (an infra knob, not a
-   strategy parameter, so it is not threaded through
-   [Weinstein_strategy.config]; the env var is the least-plumbing surface).
-   Memory budget is best-effort — a single oversized symbol stays resident even
-   when its bytes exceed the cap. *)
-let _default_snapshot_cache_mb = 4096
-let _snapshot_cache_mb_env_var = "SNAPSHOT_CACHE_MB"
-
-(* Resolve the snapshot LRU cap from [SNAPSHOT_CACHE_MB], falling back to the
-   default on an absent / unparseable / non-positive value. Logs the resolved
-   value once to stderr. *)
-let _resolve_snapshot_cache_mb () =
-  let resolved =
-    match Sys.getenv _snapshot_cache_mb_env_var with
-    | None -> _default_snapshot_cache_mb
-    | Some raw -> (
-        match Int.of_string_opt (String.strip raw) with
-        | Some n when n > 0 -> n
-        | _ ->
-            eprintf
-              "Panel_runner: ignoring unparseable %s=%S; using default %d MB\n\
-               %!"
-              _snapshot_cache_mb_env_var raw _default_snapshot_cache_mb;
-            _default_snapshot_cache_mb)
-  in
-  eprintf "Panel_runner: snapshot cache cap = %d MB (env %s)\n%!" resolved
-    _snapshot_cache_mb_env_var;
-  resolved
-
 (* Wrap the runner's already-constructed [daily_panels] in the simulator's
    callback adapter, sharing the LRU cache with the strategy bar reader.
 
@@ -181,7 +146,7 @@ let _setup_hybrid (input : input) ~strategy_choice ~snapshot_dir ~manifest
   let daily_panels =
     match
       Daily_panels.create ~snapshot_dir ~manifest
-        ~max_cache_mb:(_resolve_snapshot_cache_mb ())
+        ~max_cache_mb:(Snapshot_cache_config.resolve_cache_mb ())
     with
     | Ok p -> p
     | Error err ->
@@ -294,23 +259,9 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
   in
   Option.iter progress_acc ~f:Backtest_progress.emit_final;
   let final_close_prices = final_close_prices_thunk () in
-  (* Snapshot-cache thrash diagnostic. [misses_per_symbol] ≈ 1 means the cache
-     held the working set; a value approaching the cycle count means the cache
-     thrashed (every cycle re-decoding an evicted symbol) — the signal that the
-     cap is too small for this universe. Emit before [close] drops the cache. *)
-  let cache_stats = Daily_panels.cache_stats daily_panels in
-  let misses_per_symbol =
-    if n_all_symbols = 0 then 0.0
-    else Float.of_int cache_stats.misses /. Float.of_int n_all_symbols
-  in
-  eprintf
-    "Panel_runner: snapshot cache hits=%d misses=%d evictions=%d n_symbols=%d \
-     misses_per_symbol=%.2f\n\
-     %!"
-    cache_stats.hits cache_stats.misses cache_stats.evictions n_all_symbols
-    misses_per_symbol;
-  (* Drop the Daily_panels LRU cache before returning. See
+  (* Emit the cache thrash diagnostic, then drop the LRU before returning. See
      dev/notes/bayesian-int-rounding-bug-2026-05-19.md §"Third failure". *)
+  Snapshot_cache_config.log_cache_stats ~daily_panels ~n_symbols:n_all_symbols;
   Daily_panels.close daily_panels;
   ( sim_result,
     r.stop_log,

--- a/trading/trading/backtest/lib/snapshot_cache_config.ml
+++ b/trading/trading/backtest/lib/snapshot_cache_config.ml
@@ -1,0 +1,40 @@
+(** Snapshot LRU cache configuration + diagnostics — see
+    [snapshot_cache_config.mli]. *)
+
+open Core
+module Daily_panels = Snapshot_runtime.Daily_panels
+
+(* 4096 MB unblocks N=3000 (the decoded working set thrashed under the old 1 GB
+   cap); env-overridable; an infra knob, not a strategy parameter (see
+   dev/notes/macro-bearish-trim-grid-2026-06-07.md §7). *)
+let _default_cache_mb = 4096
+let _env_var = "SNAPSHOT_CACHE_MB"
+
+(* Parse a strictly-positive int from [raw], tolerating surrounding whitespace.
+   Returns [None] on an unparseable or non-positive value. *)
+let _parse_positive_int raw =
+  match Int.of_string_opt (String.strip raw) with
+  | Some n when n > 0 -> Some n
+  | _ -> None
+
+let resolve_cache_mb () =
+  let resolved =
+    match Option.bind (Sys.getenv _env_var) ~f:_parse_positive_int with
+    | Some n -> n
+    | None -> _default_cache_mb
+  in
+  eprintf "Panel_runner: snapshot cache cap = %d MB (env %s)\n%!" resolved
+    _env_var;
+  resolved
+
+let log_cache_stats ~daily_panels ~n_symbols =
+  let stats = Daily_panels.cache_stats daily_panels in
+  let misses_per_symbol =
+    if n_symbols = 0 then 0.0
+    else Float.of_int stats.misses /. Float.of_int n_symbols
+  in
+  eprintf
+    "Panel_runner: snapshot cache hits=%d misses=%d evictions=%d n_symbols=%d \
+     misses_per_symbol=%.2f\n\
+     %!"
+    stats.hits stats.misses stats.evictions n_symbols misses_per_symbol

--- a/trading/trading/backtest/lib/snapshot_cache_config.mli
+++ b/trading/trading/backtest/lib/snapshot_cache_config.mli
@@ -1,0 +1,22 @@
+(** Snapshot LRU cache configuration + thrash diagnostics for the panel runner.
+
+    The cache cap is an infra knob (memory budget for the decoded snapshot
+    working set), not a strategy parameter, so it is resolved from an env var
+    rather than threaded through [Weinstein_strategy.config]. *)
+
+module Daily_panels = Snapshot_runtime.Daily_panels
+
+val resolve_cache_mb : unit -> int
+(** [resolve_cache_mb ()] returns the snapshot LRU cap (MB), read from the
+    [SNAPSHOT_CACHE_MB] env var and falling back to the built-in default on an
+    absent / unparseable / non-positive value. Logs the resolved value once to
+    stderr. The default (4096 MB) holds an N~3000 PIT universe resident; the
+    budget is best-effort (a single oversized symbol stays resident even when
+    its bytes exceed the cap). *)
+
+val log_cache_stats : daily_panels:Daily_panels.t -> n_symbols:int -> unit
+(** [log_cache_stats ~daily_panels ~n_symbols] emits the cumulative cache
+    hit/miss/eviction counters to stderr, plus [misses_per_symbol] — a thrash
+    signal where ≈ 1 means the cache held the working set and a value
+    approaching the cycle count means it thrashed (cap too small for the
+    universe). Call before [Daily_panels.close] drops the cache. *)


### PR DESCRIPTION
## What it does

Unblocks N=3000 local snapshot-mode backtests, which were non-terminating because the hardcoded 1 GB snapshot decode-cache thrashed against a ~1.5 GB working set (`dev/notes/macro-bearish-trim-grid-2026-06-07.md` §7).

### Part A — configurable cache size + bumped default (`panel_runner.ml`)
- Default `_snapshot_cache_mb` raised **1024 → 4096** so an N~3000 PIT-universe working set stays resident.
- Overridable via the **`SNAPSHOT_CACHE_MB`** env var, parsed with `Int.of_string_opt` + `String.strip`, with a safe fallback to the 4096 default on absent / unparseable / non-positive values. The resolved value is logged once to stderr.
- **Not** threaded through `Weinstein_strategy.config`: this is an infra knob (memory budget), not a strategy parameter, so the config-record / experiment-flag discipline does not apply. The env var is the least-plumbing surface and is not threaded as a CLI flag through scenario_runner.
- Single resolved value used at the `Daily_panels.create` call in `_setup_hybrid`.

### Part B — hit/miss/eviction counter (`daily_panels.ml` / `.mli`)
- Three `mutable int` counters on `Daily_panels.t` (`hits` / `misses` / `evictions`), initialised to 0 in `_empty_cache`, incremented at `_hit_path` (hit), `_load_and_insert` (miss = one full decode) and `_evict_one` (only when it actually evicts).
- New public `cache_stats : t -> stats` returning a `{ hits; misses; evictions }` record (`[@@deriving sexp, equal]`), documented in the `.mli`. Counters are never reset (not even by `close`) — they measure lifetime cache behaviour.
- `panel_runner.run` emits a one-line stderr summary after the simulator run, before `Daily_panels.close`:
  `Panel_runner: snapshot cache hits=%d misses=%d evictions=%d n_symbols=%d misses_per_symbol=%.2f`. `misses_per_symbol` is the decisive thrash metric (≈1 healthy, ≈n_cycles thrash).

### Verified on a real backtest path
`dune runtest trading/backtest/` exercised the hybrid path and emitted:
`Panel_runner: snapshot cache cap = 4096 MB (env SNAPSHOT_CACHE_MB)` and
`Panel_runner: snapshot cache hits=23132 misses=22 evictions=0 n_symbols=22 misses_per_symbol=1.00` — a healthy 1.00 ratio.

## Test coverage
3 new `test_daily_panels.ml` cases following `.claude/rules/test-patterns.md` (one `assert_that`, `all_of`/`field`, Matchers):
- first read of a fresh symbol → `{hits=0;misses=1;evictions=0}`
- second read of the same symbol → `{hits=1;misses=1;evictions=0}`
- many large symbols under `max_cache_mb:1` → `misses=n_symbols`, `evictions>0`, `hits=0`

`dune build`, `dune runtest analysis/weinstein/snapshot_runtime/test/` (15 daily_panels tests OK) and `trading/backtest/`, and `dune build @fmt` all pass in-container.

## Scope
Sibling runners (`optimal_strategy_runner.ml`, `all_eligible_runner.ml`, `_snapshot_cache_mb = 256`) left untouched — they run small universes. `dev/status/_index.md` not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)