### PR TITLE
feat(simulation): capital-relative drawdown metric (MaxUnderwaterVsInitialPct)

### DIFF
--- a/trading/trading/simulation/lib/capital_relative_drawdown_computer.ml
+++ b/trading/trading/simulation/lib/capital_relative_drawdown_computer.ml
@@ -1,0 +1,38 @@
+(** Capital-relative drawdown computer. See .mli for spec. *)
+
+open Core
+module Metric_types = Trading_simulation_types.Metric_types
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+type state = {
+  initial_cash : float;
+  max_underwater_pct : float;  (** Running max of the per-day shortfall pct. *)
+}
+
+(** Per-day shortfall of [value] below [initial_cash], as a percent of initial,
+    clamped at 0 when the value is at or above the initial stake. Returns [0.0]
+    when [initial_cash <= 0.0] (no meaningful baseline). *)
+let _underwater_pct ~initial_cash ~value =
+  if Float.(initial_cash <= 0.0) then 0.0
+  else Float.max 0.0 ((initial_cash -. value) /. initial_cash *. 100.0)
+
+let _update ~state ~step =
+  if not (Metric_computer_utils.is_trading_day_step step) then state
+  else
+    let dd =
+      _underwater_pct ~initial_cash:state.initial_cash
+        ~value:step.Simulator_types.portfolio_value
+    in
+    { state with max_underwater_pct = Float.max state.max_underwater_pct dd }
+
+let _finalize ~state ~config:_ =
+  Metric_types.singleton MaxUnderwaterVsInitialPct state.max_underwater_pct
+
+let computer ?(initial_cash = 0.0) () : Simulator_types.any_metric_computer =
+  Simulator_types.wrap_computer
+    {
+      name = "capital_relative_drawdown";
+      init = (fun ~config:_ -> { initial_cash; max_underwater_pct = 0.0 });
+      update = _update;
+      finalize = _finalize;
+    }

--- a/trading/trading/simulation/lib/capital_relative_drawdown_computer.mli
+++ b/trading/trading/simulation/lib/capital_relative_drawdown_computer.mli
@@ -1,0 +1,28 @@
+(** Capital-relative drawdown computer.
+
+    Emits the single metric [MaxUnderwaterVsInitialPct]: the worst shortfall of
+    portfolio value below the {b initial} capital, as a percent of initial. This
+    is distinct from the peak-relative [MaxDrawdown] — it measures psychological
+    depth against the starting stake rather than against the running high-water
+    mark.
+
+    The model: for each trading-day step, capital-relative drawdown percent =
+    [max(0, (initial_cash - portfolio_value) / initial_cash × 100)]. The metric
+    is the maximum of this series across the run — a strategy that 3×'d then
+    fell 40% never dips below its initial stake and reads 0; one whose NAV fell
+    below its starting money reads positive.
+
+    Pure: same step list → same output. See
+    {!Trading_simulation_types.Metric_types.MaxUnderwaterVsInitialPct} for the
+    full semantic spec. *)
+
+val computer :
+  ?initial_cash:float ->
+  unit ->
+  Trading_simulation_types.Simulator_types.any_metric_computer
+(** Build the capital-relative drawdown computer.
+
+    @param initial_cash
+      The starting capital, used as the baseline the NAV is compared against.
+      Pass the simulator's configured [initial_cash]; if absent or [<= 0.0] the
+      metric reports [0.0] (defensive fallback, mirroring [AvgTradeSizePct]). *)

--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -31,6 +31,7 @@
   antifragility_computer
   benchmark_relative_computer
   stability_turnover_computer
+  capital_relative_drawdown_computer
   portfolio_valuation
   stale_hold
   margin_runner)

--- a/trading/trading/simulation/lib/metric_computers.ml
+++ b/trading/trading/simulation/lib/metric_computers.ml
@@ -35,6 +35,9 @@ let antifragility_computer = Antifragility_computer.computer
 let benchmark_relative_computer = Benchmark_relative_computer.computer
 let stability_turnover_computer = Stability_turnover_computer.computer
 
+let capital_relative_drawdown_computer =
+  Capital_relative_drawdown_computer.computer
+
 (** {1 Derived Metric Computers} *)
 
 let calmar_ratio_derived : Simulator_types.derived_metric_computer =
@@ -109,6 +112,7 @@ let create_computer (metric_type : Metric_types.metric_type) :
   | TradeFrequencyAnnualized ->
       _derived_only_stub ~name:"trade_freq_annualized_stub"
         TradeFrequencyAnnualized
+  | MaxUnderwaterVsInitialPct -> capital_relative_drawdown_computer ()
 
 (** {1 Default Computer Set} *)
 
@@ -127,6 +131,7 @@ let default_computers ?(risk_free_rate = 0.0) ?(initial_cash = 0.0) () =
     antifragility_computer ();
     benchmark_relative_computer ();
     stability_turnover_computer ();
+    capital_relative_drawdown_computer ~initial_cash ();
   ]
 
 let default_derived_computers () =

--- a/trading/trading/simulation/lib/metric_computers.mli
+++ b/trading/trading/simulation/lib/metric_computers.mli
@@ -125,6 +125,19 @@ val stability_turnover_computer : unit -> Simulator.any_metric_computer
     [PositionTurnover], [PositionConcentrationHhi]. [TradeFrequencyAnnualized]
     ships as a {b derived} metric (see {!default_derived_computers}). *)
 
+(** {1 Capital-Relative Drawdown Computer} *)
+
+val capital_relative_drawdown_computer :
+  ?initial_cash:float -> unit -> Simulator.any_metric_computer
+(** Computer that emits [MaxUnderwaterVsInitialPct]: the worst shortfall of
+    portfolio value below the initial capital, as a percent of initial. Unlike
+    the peak-relative max drawdown, this is measured against the starting stake.
+
+    @param initial_cash
+      Baseline the NAV is compared against. Pass the simulator's configured
+      [initial_cash]; if absent or [<= 0.0] the metric reports 0.0. See
+      {!Capital_relative_drawdown_computer} for spec. *)
+
 (** {1 Default Computer Set} *)
 
 val default_computers :

--- a/trading/trading/simulation/lib/types/metric_info_registry.ml
+++ b/trading/trading/simulation/lib/types/metric_info_registry.ml
@@ -402,87 +402,30 @@ let get_metric_info = function
            number of trading days). Reported in percent·days.";
         unit = Ratio;
       }
-  | Skewness ->
+  | MaxUnderwaterVsInitialPct ->
       {
-        display_name = "Skewness";
+        display_name = "Max Underwater vs Initial";
         description =
-          "Third standardized moment of the per-step return distribution. \
-           Positive = heavier right tail (gains); negative = heavier left tail \
-           (losses).";
-        unit = Ratio;
-      }
-  | Kurtosis ->
-      {
-        display_name = "Kurtosis (Excess)";
-        description =
-          "Fourth standardized moment of the per-step return distribution \
-           minus 3. 0 = Gaussian; positive = fat-tailed; negative = \
-           thin-tailed.";
-        unit = Ratio;
-      }
-  | CVaR95 ->
-      {
-        display_name = "CVaR (95%)";
-        description =
-          "Conditional Value-at-Risk at 95% (Expected Shortfall): mean of the \
-           worst 5% of step returns.";
+          "Worst shortfall of portfolio value below the initial capital, as a \
+           percent of initial. Unlike Max Drawdown (peak-relative), measured \
+           against the starting stake — a strategy that 3×'d then fell 40% \
+           reads 0; one that dipped below its starting money reads positive.";
         unit = Percent;
       }
-  | CVaR99 ->
-      {
-        display_name = "CVaR (99%)";
-        description =
-          "Conditional Value-at-Risk at 99%: mean of the worst 1% of step \
-           returns.";
-        unit = Percent;
-      }
-  | TailRatio ->
-      {
-        display_name = "Tail Ratio";
-        description =
-          "mean(top 5% returns) / |mean(bottom 5% returns)|. > 1 means upside \
-           tail dominates downside tail.";
-        unit = Ratio;
-      }
-  | GainToPain ->
-      {
-        display_name = "Gain-to-Pain";
-        description =
-          "Sum of positive step returns divided by absolute sum of negative \
-           step returns. > 1 means cumulative gains exceed cumulative losses.";
-        unit = Ratio;
-      }
-  | ConcavityCoef ->
-      {
-        display_name = "Concavity Coefficient (γ)";
-        description =
-          "Antifragility coefficient from r_strat = α + β·r_bench + \
-           γ·r_bench². γ > 0 = convex/antifragile; γ < 0 = concave/fragile. \
-           Reported as 0 when no benchmark series is supplied.";
-        unit = Ratio;
-      }
-  | BucketAsymmetry ->
-      {
-        display_name = "Bucket Asymmetry";
-        description =
-          "(Q1 + Q5) / (Q2 + Q3 + Q4) of strategy step returns bucketed by \
-           benchmark quintile. > 1 means barbell (strategy concentrates \
-           returns in extremes). Reported as 0 when no benchmark series is \
-           supplied.";
-        unit = Ratio;
-      }
-  | ( BenchmarkAlphaPctAnnualized | BenchmarkBeta | TrackingErrorPctAnnualized
-    | InformationRatio | CorrelationToBenchmark | RollingSharpeStability
-    | TradeFrequencyAnnualized | PositionTurnover | PositionConcentrationHhi )
-    as t -> (
+  | ( Skewness | Kurtosis | CVaR95 | CVaR99 | TailRatio | GainToPain
+    | ConcavityCoef | BucketAsymmetry | BenchmarkAlphaPctAnnualized
+    | BenchmarkBeta | TrackingErrorPctAnnualized | InformationRatio
+    | CorrelationToBenchmark | RollingSharpeStability | TradeFrequencyAnnualized
+    | PositionTurnover | PositionConcentrationHhi ) as t ->
       let open Metric_info_registry_extras in
-      match info_for_benchmark_relative t with
-      | Some i -> i
-      | None ->
-          Option.value_exn
-            (info_for_stability_turnover t)
-            ~message:(sprintf "missing extras info for %s" (show_metric_type t))
-      )
+      Option.value_exn
+        (List.find_map
+           [
+             info_for_distribution_antifragility;
+             info_for_benchmark_relative;
+             info_for_stability_turnover;
+           ] ~f:(fun f -> f t))
+        ~message:(sprintf "missing extras info for %s" (show_metric_type t))
 
 let format_metric metric_type value =
   let info = get_metric_info metric_type in

--- a/trading/trading/simulation/lib/types/metric_info_registry_extras.ml
+++ b/trading/trading/simulation/lib/types/metric_info_registry_extras.ml
@@ -60,3 +60,60 @@ let info_for_stability_turnover : metric_type -> metric_info option = function
             diversified."
            Ratio)
   | _ -> None
+
+let info_for_distribution_antifragility : metric_type -> metric_info option =
+  function
+  | Skewness ->
+      Some
+        (_info "Skewness"
+           "Third standardized moment of the per-step return distribution. \
+            Positive = heavier right tail (gains); negative = heavier left \
+            tail (losses)."
+           Ratio)
+  | Kurtosis ->
+      Some
+        (_info "Kurtosis (Excess)"
+           "Fourth standardized moment of the per-step return distribution \
+            minus 3. 0 = Gaussian; positive = fat-tailed; negative = \
+            thin-tailed."
+           Ratio)
+  | CVaR95 ->
+      Some
+        (_info "CVaR (95%)"
+           "Conditional Value-at-Risk at 95% (Expected Shortfall): mean of the \
+            worst 5% of step returns."
+           Percent)
+  | CVaR99 ->
+      Some
+        (_info "CVaR (99%)"
+           "Conditional Value-at-Risk at 99%: mean of the worst 1% of step \
+            returns."
+           Percent)
+  | TailRatio ->
+      Some
+        (_info "Tail Ratio"
+           "mean(top 5% returns) / |mean(bottom 5% returns)|. > 1 means upside \
+            tail dominates downside tail."
+           Ratio)
+  | GainToPain ->
+      Some
+        (_info "Gain-to-Pain"
+           "Sum of positive step returns divided by absolute sum of negative \
+            step returns. > 1 means cumulative gains exceed cumulative losses."
+           Ratio)
+  | ConcavityCoef ->
+      Some
+        (_info "Concavity Coefficient (γ)"
+           "Antifragility coefficient from r_strat = α + β·r_bench + \
+            γ·r_bench². γ > 0 = convex/antifragile; γ < 0 = concave/fragile. \
+            Reported as 0 when no benchmark series is supplied."
+           Ratio)
+  | BucketAsymmetry ->
+      Some
+        (_info "Bucket Asymmetry"
+           "(Q1 + Q5) / (Q2 + Q3 + Q4) of strategy step returns bucketed by \
+            benchmark quintile. > 1 means barbell (strategy concentrates \
+            returns in extremes). Reported as 0 when no benchmark series is \
+            supplied."
+           Ratio)
+  | _ -> None

--- a/trading/trading/simulation/lib/types/metric_info_registry_extras.mli
+++ b/trading/trading/simulation/lib/types/metric_info_registry_extras.mli
@@ -14,3 +14,8 @@ val info_for_stability_turnover :
 (** Stability + turnover family: [RollingSharpeStability],
     [TradeFrequencyAnnualized], [PositionTurnover], [PositionConcentrationHhi].
 *)
+
+val info_for_distribution_antifragility :
+  Metric_types.metric_type -> Metric_info_types.metric_info option
+(** Distribution-shape + antifragility family: [Skewness], [Kurtosis], [CVaR95],
+    [CVaR99], [TailRatio], [GainToPain], [ConcavityCoef], [BucketAsymmetry]. *)

--- a/trading/trading/simulation/lib/types/metric_types.ml
+++ b/trading/trading/simulation/lib/types/metric_types.ml
@@ -78,6 +78,7 @@ module Metric_type = struct
       | TradeFrequencyAnnualized
       | PositionTurnover
       | PositionConcentrationHhi
+      | MaxUnderwaterVsInitialPct
     [@@deriving show, eq, compare, sexp]
   end
 
@@ -157,6 +158,7 @@ type metric_type = Metric_type.t =
   | TradeFrequencyAnnualized
   | PositionTurnover
   | PositionConcentrationHhi
+  | MaxUnderwaterVsInitialPct
 [@@deriving show, eq, compare, sexp]
 
 include (Metric_type : Comparator.S with type t := metric_type)

--- a/trading/trading/simulation/lib/types/metric_types.mli
+++ b/trading/trading/simulation/lib/types/metric_types.mli
@@ -254,6 +254,17 @@ module Metric_type : sig
             symbol-level diversity is the available proxy for the
             rotation-vs-concentration question. Reported as [0.0] when no Friday
             step has any open position. *)
+    (* ---- Capital-relative drawdown ---- *)
+    | MaxUnderwaterVsInitialPct
+        (** Worst shortfall of portfolio value below the {b initial} capital, as
+            a percent of initial:
+            [max over days of (initial - NAV) / initial × 100], clamped at 0
+            when NAV never dips below the initial stake. Unlike [MaxDrawdown]
+            (peak-relative), this is measured against the starting capital — a
+            strategy that 3×'d then fell 40% reads 0 here; one that dipped below
+            its starting money reads positive. Captures psychological depth in
+            capital terms. Reported as [0.0] when no initial cash is supplied
+            ([initial_cash] absent or ≤ 0). *)
   [@@deriving show, eq, compare, sexp]
 
   include Comparator.S with type t := t
@@ -332,6 +343,7 @@ type metric_type = Metric_type.t =
   | TradeFrequencyAnnualized
   | PositionTurnover
   | PositionConcentrationHhi
+  | MaxUnderwaterVsInitialPct
 [@@deriving show, eq, compare, sexp]
 
 (** {1 Metric Set} *)

--- a/trading/trading/simulation/test/dune
+++ b/trading/trading/simulation/test/dune
@@ -290,6 +290,20 @@
   matchers))
 
 (test
+ (name test_capital_relative_drawdown_computer)
+ (modules test_capital_relative_drawdown_computer)
+ (libraries
+  ounit2
+  core
+  trading.simulation
+  trading.simulation.types
+  trading.base
+  trading.engine
+  trading.portfolio
+  types
+  matchers))
+
+(test
  (name test_distributional_computer)
  (modules test_distributional_computer)
  (libraries

--- a/trading/trading/simulation/test/test_capital_relative_drawdown_computer.ml
+++ b/trading/trading/simulation/test/test_capital_relative_drawdown_computer.ml
@@ -1,0 +1,110 @@
+(** Pinned tests for {!Capital_relative_drawdown_computer}.
+
+    Each test pins [MaxUnderwaterVsInitialPct] against a hand-computed value. *)
+
+open OUnit2
+open Core
+open Trading_simulation_types.Metric_types
+open Matchers
+module Simulator_types = Trading_simulation_types.Simulator_types
+
+let _date s = Date.of_string s
+
+let _make_step ~date ~portfolio_value : Simulator_types.step_result =
+  {
+    date;
+    portfolio = Trading_simulation_types.Portfolio_summary.empty;
+    portfolio_value;
+    trades = [];
+    orders_submitted = [];
+    splits_applied = [];
+    benchmark_return = None;
+    had_market_bars = true;
+  }
+
+let _config =
+  {
+    Simulator_types.start_date = _date "2024-01-01";
+    end_date = _date "2024-12-31";
+    initial_cash = 1_000.0;
+    commission = { Trading_engine.Types.per_share = 0.0; minimum = 0.0 };
+    strategy_cadence = Types.Cadence.Daily;
+  }
+
+let _run ?initial_cash steps =
+  let computer =
+    Trading_simulation.Capital_relative_drawdown_computer.computer ?initial_cash
+      ()
+  in
+  computer.run ~config:_config ~steps
+
+(* ----- NAV dips below initial → positive metric ----- *)
+
+(** Initial 1000; curve [1000, 900, 850, 950]. Worst NAV is 850, so the worst
+    shortfall vs initial is (1000 - 850) / 1000 × 100 = 15%. *)
+let test_dips_below_initial _ =
+  let steps =
+    [
+      _make_step ~date:(_date "2024-01-02") ~portfolio_value:1_000.0;
+      _make_step ~date:(_date "2024-01-03") ~portfolio_value:900.0;
+      _make_step ~date:(_date "2024-01-04") ~portfolio_value:850.0;
+      _make_step ~date:(_date "2024-01-05") ~portfolio_value:950.0;
+    ]
+  in
+  let metrics = _run ~initial_cash:1_000.0 steps in
+  assert_that metrics
+    (map_includes
+       [ (MaxUnderwaterVsInitialPct, float_equal ~epsilon:1e-6 15.0) ])
+
+(* ----- 2× then halve but stays at/above initial → metric 0 ----- *)
+
+(** Initial 1000; curve [1000, 2000, 1000]. The peak-relative max drawdown would
+    be 50% (2000 → 1000), but the NAV never falls below the initial stake, so
+    the capital-relative metric is 0. This is the key contrast with
+    [MaxDrawdown]. *)
+let test_doubles_then_halves_stays_at_initial _ =
+  let steps =
+    [
+      _make_step ~date:(_date "2024-01-02") ~portfolio_value:1_000.0;
+      _make_step ~date:(_date "2024-01-03") ~portfolio_value:2_000.0;
+      _make_step ~date:(_date "2024-01-04") ~portfolio_value:1_000.0;
+    ]
+  in
+  let metrics = _run ~initial_cash:1_000.0 steps in
+  assert_that metrics
+    (map_includes [ (MaxUnderwaterVsInitialPct, float_equal 0.0) ])
+
+(* ----- initial_cash absent → 0.0 ----- *)
+
+let test_no_initial_cash_yields_zero _ =
+  let steps =
+    [
+      _make_step ~date:(_date "2024-01-02") ~portfolio_value:1_000.0;
+      _make_step ~date:(_date "2024-01-03") ~portfolio_value:500.0;
+    ]
+  in
+  let metrics = _run steps in
+  assert_that metrics
+    (map_includes [ (MaxUnderwaterVsInitialPct, float_equal 0.0) ])
+
+(* ----- initial_cash <= 0 → 0.0 ----- *)
+
+let test_nonpositive_initial_cash_yields_zero _ =
+  let steps =
+    [ _make_step ~date:(_date "2024-01-02") ~portfolio_value:500.0 ]
+  in
+  let metrics = _run ~initial_cash:0.0 steps in
+  assert_that metrics
+    (map_includes [ (MaxUnderwaterVsInitialPct, float_equal 0.0) ])
+
+let suite =
+  "Capital_relative_drawdown_computer"
+  >::: [
+         "NAV dips below initial → positive metric" >:: test_dips_below_initial;
+         "2× then halve but stays at initial → 0"
+         >:: test_doubles_then_halves_stays_at_initial;
+         "initial_cash absent → 0" >:: test_no_initial_cash_yields_zero;
+         "initial_cash <= 0 → 0" >:: test_nonpositive_initial_cash_yields_zero;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/simulation/test/test_metrics.ml
+++ b/trading/trading/simulation/test/test_metrics.ml
@@ -823,8 +823,9 @@ let test_default_computers _ =
      trade_aggregates (M5.2b), return_basics (M5.2b), omega_ratio (M5.2c),
      drawdown_analytics (M5.2c), distributional (M5.2d), antifragility
      (M5.2d), benchmark_relative (CAPM-style alpha/beta/IR), stability +
-     turnover (rolling-sharpe stability, position turnover, HHI). *)
-  assert_that computers (size_is 13)
+     turnover (rolling-sharpe stability, position turnover, HHI),
+     capital_relative_drawdown (MaxUnderwaterVsInitialPct). *)
+  assert_that computers (size_is 14)
 
 (* ==================== Factory Tests ==================== *)
 


### PR DESCRIPTION
## What
Adds `MaxUnderwaterVsInitialPct`: worst shortfall of portfolio value below the **initial** capital, as a percent of initial — `max` over days of `max(0,(initial-NAV)/initial*100)`; `0` if NAV never dips below the starting stake. Unlike peak-relative `MaxDrawdown`, this measures *psychological depth vs the starting money*: a strategy that 3×'d then fell 40% reads 0 here.

Plan **P2** of `dev/plans/evaluation-objective-and-metrics-2026-06-07.md` §2.

## Why
The macro-bearish-trim study showed raw peak-relative MaxDD% misled a verdict (ranked a strategy that fell below its starting stake as 'safer' than one whose worst trough was still 4.4× the stake). This metric captures the capital-relative depth MaxDD can't.

## Test plan
`test_capital_relative_drawdown_computer.ml` pins 4 cases:
- NAV dips to 850 from 1000 initial → 15.0
- NAV 2×'s then halves but stays ≥ initial → **0.0** (the key contrast; MaxDrawdown would read ~50)
- `initial_cash` absent → 0.0
- `initial_cash` ≤ 0 → 0.0

## Notes
- Additive — new reported metric, **no strategy-behaviour change**, so no experiment-flag-discipline gate applies.
- Pure post-processing of the daily equity curve; mirrors `drawdown_analytics_computer` sweep + `trade_aggregates_computer` `?initial_cash` plumbing.
- **Code-health:** `metric_info_registry.ml` was at the declared-large 500-line hard cap; to stay under it I moved the cohesive distribution/antifragility group (Skewness, Kurtosis, CVaR95/99, TailRatio, GainToPain, ConcavityCoef, BucketAsymmetry) into `Metric_info_registry_extras` via a new `info_for_distribution_antifragility` delegate — mirroring the existing benchmark/stability extras groups. Registry 509→~440, no behavior change. (Refactor + feature in one PR since the feature can't land under the cap without it.)
- Full `dune runtest` clean (no FAIL lines), `dune build @fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)