### PR TITLE
feat(rolling-start): pure dispersion-stats core for rolling-start eval (part 1)

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -5,6 +5,38 @@
 ## Status
 IN_PROGRESS
 
+### Recent activity (2026-06-07)
+
+- **[x] Rolling-start dispersion — pure stats core (PR-1 of 2)**
+  (branch `feat/rolling-start-dispersion`). P1 ("highest value") of
+  `dev/plans/evaluation-objective-and-metrics-2026-06-07.md` §2: judge a
+  strategy on the *distribution* of terminal outcomes across many
+  backtest start dates (to a fixed end), not one full-window number —
+  start-date robustness as the primary evaluation lens (plan §1.3).
+  - Surface: new `rolling_start` lib at
+    `trading/trading/backtest/rolling_start/lib/`:
+    - `Dispersion_stats` — pure `percentile` (NumPy linear / type-7),
+      `median`, `iqr`, and a `summarize` → `summary`
+      (median / p10 / IQR / min / max / n) over a `float list`. The
+      rock-solid numeric core; unit-tested against hand-computed values
+      with no backtest.
+    - `Rolling_start_types` — `per_start` row (start_date + CAGR +
+      `MaxUnderwaterVsInitialPct` capital-relative DD (#1471) +
+      peak-relative MaxDD), `report` (one `Dispersion_stats.summary` per
+      metric), `build`, and a `to_markdown` renderer mirroring the
+      `walk_forward_render` table style + a derived sexp.
+  - Additive / analysis-only: no strategy behaviour, runs nothing in the
+    default pipeline → no experiment-flag gate.
+  - Verify: `dune runtest trading/backtest/rolling_start/` (27 tests:
+    19 dispersion-stats + 8 types).
+  - **Follow-up (PR-2):** the `rolling_start_eval` exe that enumerates
+    start dates (quarterly cadence, `-start-stride-days` default 91),
+    runs `Backtest.Runner.run_backtest` per start (with `--snapshot-dir`
+    threaded via `Scenario_lib.Bar_source_resolver.resolve`, reusing the
+    `walk_forward_executor` per-fold run + metric-map extraction
+    pattern), collects per-start metrics, and emits the `report`. Split
+    out to keep this PR's pure-core diff small and reviewable.
+
 ### Recent activity (2026-06-04)
 
 - **[x] `scenario_runner --snapshot-dir <path>`** (READY_FOR_REVIEW,

--- a/trading/trading/backtest/rolling_start/lib/dispersion_stats.ml
+++ b/trading/trading/backtest/rolling_start/lib/dispersion_stats.ml
@@ -1,0 +1,93 @@
+open Core
+
+(* Bounds for the percentile argument, named so the magic-number linter does not
+   trip on the [0.0]/[100.0] literals and so the contract is self-documenting. *)
+let _pct_min = 0.0
+let _pct_max = 100.0
+
+(** Read [sorted] at fractional [rank] via linear interpolation between the
+    bracketing integer ranks. When [rank] is an integer, [lo = hi] and
+    [frac = 0.0], so this returns [sorted.(rank)] exactly — subsuming the
+    no-interpolation case without a branch. [rank] is always in [0, n-1] for the
+    callers here. *)
+let _interp (sorted : float array) ~rank =
+  let lo = Int.of_float (Float.round_down rank) in
+  let hi = Int.of_float (Float.round_up rank) in
+  let frac = rank -. float_of_int lo in
+  sorted.(lo) +. (frac *. (sorted.(hi) -. sorted.(lo)))
+
+(** Linear-interpolation percentile over an ascending [sorted] array. Caller has
+    already established [n > 0]. Mirrors NumPy's default ("linear" / type-7):
+    rank [r = p/100 * (n - 1)], read between the bracketing ranks. *)
+let _percentile_of_sorted (sorted : float array) ~p =
+  let n = Array.length sorted in
+  if n = 1 then sorted.(0)
+  else _interp sorted ~rank:(p /. _pct_max *. float_of_int (n - 1))
+
+let _sorted_array xs =
+  let arr = Array.of_list xs in
+  Array.sort arr ~compare:Float.compare;
+  arr
+
+let percentile xs ~p =
+  if Float.( < ) p _pct_min || Float.( > ) p _pct_max then
+    invalid_arg
+      (Printf.sprintf "percentile: p=%g out of [%g, %g]" p _pct_min _pct_max);
+  match xs with
+  | [] -> Float.nan
+  | _ -> _percentile_of_sorted (_sorted_array xs) ~p
+
+(* Cut points (named so the magic-number linter does not trip and the contract
+   is self-documenting). *)
+let _p25 = 25.0
+let _p50 = 50.0
+let _p75 = 75.0
+let median xs = percentile xs ~p:_p50
+
+let iqr xs =
+  match xs with
+  | [] -> Float.nan
+  | _ ->
+      let sorted = _sorted_array xs in
+      _percentile_of_sorted sorted ~p:_p75
+      -. _percentile_of_sorted sorted ~p:_p25
+
+type summary = {
+  n : int;
+  median : float;
+  p10 : float;
+  iqr : float;
+  min : float;
+  max : float;
+}
+[@@deriving sexp, equal]
+
+(* 10th-percentile cut point (pessimistic tail). *)
+let _p10 = 10.0
+
+(* Empty-input summary: all-NaN with a zero count. *)
+let _empty_summary =
+  {
+    n = 0;
+    median = Float.nan;
+    p10 = Float.nan;
+    iqr = Float.nan;
+    min = Float.nan;
+    max = Float.nan;
+  }
+
+let summarize xs =
+  match xs with
+  | [] -> _empty_summary
+  | _ ->
+      let sorted = _sorted_array xs in
+      let n = Array.length sorted in
+      let pct p = _percentile_of_sorted sorted ~p in
+      {
+        n;
+        median = pct _p50;
+        p10 = pct _p10;
+        iqr = pct _p75 -. pct _p25;
+        min = sorted.(0);
+        max = sorted.(n - 1);
+      }

--- a/trading/trading/backtest/rolling_start/lib/dispersion_stats.mli
+++ b/trading/trading/backtest/rolling_start/lib/dispersion_stats.mli
@@ -1,0 +1,69 @@
+(** Pure dispersion statistics over a [float list].
+
+    The rock-solid numeric core of the rolling-start evaluation harness (plan
+    [dev/plans/evaluation-objective-and-metrics-2026-06-07.md] §2 P1). The
+    harness runs a backtest from many start dates to a fixed end and collects
+    one metric value (CAGR, capital-relative drawdown, etc.) per start; this
+    module turns that raw [float list] of per-start outcomes into a {!summary} —
+    median, 10th percentile, IQR spread, min, max, n — so a strategy can be
+    judged on the {b distribution} of outcomes rather than a single full-window
+    number.
+
+    Robustness (sensitivity to start time) is the primary evaluation lens (plan
+    §1.3): a robust strategy shows a tight, positive distribution; a fragile one
+    shows huge spread. These statistics make that measurable.
+
+    Every function here is pure (same input -> same output, no I/O), so it is
+    unit-tested directly against hand-computed values without running any
+    backtest. NaN handling and the empty-list case are documented per function;
+    callers downstream filter or surface NaN explicitly rather than silently
+    dropping it. *)
+
+val percentile : float list -> p:float -> float
+(** [percentile xs ~p] is the [p]-th percentile of [xs] (0.0 <= [p] <= 100.0)
+    using linear interpolation between closest ranks (the "linear" / type-7
+    method, matching NumPy's default and most spreadsheet [PERCENTILE]).
+
+    The input need not be sorted — it is sorted internally (ascending). For a
+    sorted [xs] of length [n], the value at rank [r = p/100 * (n - 1)] is
+    [xs.(floor r) + (r - floor r) * (xs.(ceil r) - xs.(floor r))].
+
+    - [p = 0.0] returns the minimum, [p = 100.0] the maximum, [p = 50.0] the
+      median (identical to {!median}).
+    - A singleton list returns its only element for every [p].
+    - Returns [Float.nan] when [xs] is empty.
+
+    @raise Invalid_argument if [p < 0.0] or [p > 100.0]. *)
+
+val median : float list -> float
+(** [median xs] is the 50th percentile of [xs] — the middle element for odd [n],
+    the mean of the two middle elements for even [n]. The input need not be
+    sorted. Returns [Float.nan] when [xs] is empty. Equivalent to
+    [percentile xs ~p:50.0]. *)
+
+val iqr : float list -> float
+(** [iqr xs] is the inter-quartile range: the 75th percentile minus the 25th
+    percentile (both via {!percentile}). A small IQR means a tight,
+    start-insensitive distribution; a large IQR is the fragility tell. Returns
+    [Float.nan] when [xs] is empty. Never negative for a non-empty list. *)
+
+type summary = {
+  n : int;  (** Number of samples the summary was computed over. *)
+  median : float;  (** 50th percentile. [Float.nan] when [n = 0]. *)
+  p10 : float;
+      (** 10th percentile — the pessimistic-tail outcome the robustness lens
+          cares about most (plan §1.4 reports median + 10th pct + spread).
+          [Float.nan] when [n = 0]. *)
+  iqr : float;
+      (** Inter-quartile range (p75 - p25). [Float.nan] when [n = 0]. *)
+  min : float;  (** Smallest sample. [Float.nan] when [n = 0]. *)
+  max : float;  (** Largest sample. [Float.nan] when [n = 0]. *)
+}
+[@@deriving sexp, equal]
+(** The dispersion dashboard for one metric across all start dates. Built by
+    {!summarize}. *)
+
+val summarize : float list -> summary
+(** [summarize xs] computes the full {!summary} for [xs]. For an empty [xs]
+    every float field is [Float.nan] and [n = 0] — the caller decides how to
+    render "no data" rather than this module inventing a sentinel. *)

--- a/trading/trading/backtest/rolling_start/lib/dune
+++ b/trading/trading/backtest/rolling_start/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name rolling_start)
+ (libraries core)
+ (preprocess
+  (pps ppx_compare ppx_sexp_conv)))

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_types.ml
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_types.ml
@@ -1,0 +1,109 @@
+open Core
+
+type per_start = {
+  start_date : Date.t;
+  cagr_pct : float;
+  max_underwater_vs_initial_pct : float;
+  max_drawdown_pct : float;
+}
+[@@deriving sexp, equal]
+
+type report = {
+  end_date : Date.t;
+  starts : per_start list;
+  cagr : Dispersion_stats.summary;
+  max_underwater_vs_initial : Dispersion_stats.summary;
+  max_drawdown : Dispersion_stats.summary;
+}
+[@@deriving sexp, equal]
+
+let build ~end_date starts =
+  let sorted =
+    List.sort starts ~compare:(fun a b ->
+        Date.compare a.start_date b.start_date)
+  in
+  {
+    end_date;
+    starts = sorted;
+    cagr = Dispersion_stats.summarize (List.map sorted ~f:(fun s -> s.cagr_pct));
+    max_underwater_vs_initial =
+      Dispersion_stats.summarize
+        (List.map sorted ~f:(fun s -> s.max_underwater_vs_initial_pct));
+    max_drawdown =
+      Dispersion_stats.summarize
+        (List.map sorted ~f:(fun s -> s.max_drawdown_pct));
+  }
+
+(** A markdown table row: pipe-joined cells with leading/trailing pipes. *)
+let _row cells = "| " ^ String.concat ~sep:" | " cells ^ " |"
+
+let _f2 x = Printf.sprintf "%.2f" x
+
+(** One dispersion-summary line in the per-metric table. *)
+let _summary_row ~label (s : Dispersion_stats.summary) =
+  _row
+    [
+      label;
+      _f2 s.median;
+      _f2 s.p10;
+      _f2 s.iqr;
+      _f2 s.min;
+      _f2 s.max;
+      Int.to_string s.n;
+    ]
+
+(** The per-metric dispersion table (median / 10th-pct / IQR / min / max / n).
+*)
+let _dispersion_table report =
+  String.concat ~sep:"\n"
+    [
+      _row [ "metric"; "median"; "p10"; "IQR"; "min"; "max"; "n" ];
+      _row [ "---"; "---"; "---"; "---"; "---"; "---"; "---" ];
+      _summary_row ~label:"CAGR %" report.cagr;
+      _summary_row ~label:"MaxUnderwaterVsInitial %"
+        report.max_underwater_vs_initial;
+      _summary_row ~label:"MaxDrawdown %" report.max_drawdown;
+    ]
+
+(** One per-start detail row. *)
+let _start_row (s : per_start) =
+  _row
+    [
+      Date.to_string s.start_date;
+      _f2 s.cagr_pct;
+      _f2 s.max_underwater_vs_initial_pct;
+      _f2 s.max_drawdown_pct;
+    ]
+
+(** The per-start detail table (one row per start date). *)
+let _starts_table report =
+  let header =
+    [
+      _row [ "start"; "CAGR %"; "MaxUnderwaterVsInitial %"; "MaxDrawdown %" ];
+      _row [ "---"; "---"; "---"; "---" ];
+    ]
+  in
+  String.concat ~sep:"\n" (header @ List.map report.starts ~f:_start_row)
+
+(** Full report body (non-empty case): header + dispersion table + per-start
+    detail, trailing newline. *)
+let _render_full report ~header =
+  String.concat ~sep:"\n\n"
+    [
+      header;
+      "## Dispersion across starts";
+      _dispersion_table report;
+      "## Per-start detail";
+      _starts_table report;
+    ]
+  ^ "\n"
+
+let to_markdown report =
+  let header =
+    Printf.sprintf "# Rolling-start dispersion (end %s, %d starts)"
+      (Date.to_string report.end_date)
+      (List.length report.starts)
+  in
+  match report.starts with
+  | [] -> header ^ "\n\n_No starts._\n"
+  | _ -> _render_full report ~header

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_types.mli
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_types.mli
@@ -1,0 +1,67 @@
+(** Types + renderers for the rolling-start dispersion report.
+
+    A rolling-start evaluation runs the same scenario from many start dates to a
+    fixed end date and collects, per start, a small set of terminal metrics.
+    This module names the per-start row ({!per_start}), aggregates the per-start
+    rows into a {!report} (a {!Dispersion_stats.summary} per metric), and
+    renders the report as both a sexp (machine-readable, for downstream tooling)
+    and a human-readable markdown table — mirroring the [walk_forward_render] /
+    [walk_forward_report] output style.
+
+    Plan: [dev/plans/evaluation-objective-and-metrics-2026-06-07.md] §2 P1. The
+    runner that actually executes the N backtests and fills {!per_start} lands
+    in a follow-up; this module is the pure assembly + presentation layer the
+    runner will call, kept separate so it is testable without a backtest. *)
+
+open Core
+
+type per_start = {
+  start_date : Date.t;
+      (** The clipped start date this run began from (every run shares one fixed
+          end date, omitted here since it is constant across the report). *)
+  cagr_pct : float;
+      (** Annualised terminal return over [start_date .. end_date]. The primary
+          return axis. *)
+  max_underwater_vs_initial_pct : float;
+      (** Worst (NAV - initial_capital) / initial_capital, in percent, over the
+          run — how far below the {b starting stake} NAV ever went (0.0 if never
+          below). The capital-relative drawdown metric
+          ([MaxUnderwaterVsInitialPct], PR #1471). The psychological-depth lens.
+      *)
+  max_drawdown_pct : float;
+      (** Worst peak-relative drawdown over the run, in percent. Kept alongside
+          the capital-relative measure for contrast (plan §1.2: MaxDD demoted
+          but not dropped). *)
+}
+[@@deriving sexp, equal]
+(** One backtest's terminal outcome, tagged with the start date it ran from. *)
+
+type report = {
+  end_date : Date.t;  (** The fixed end date every run terminated on. *)
+  starts : per_start list;
+      (** Per-start rows in start-date order (earliest first). *)
+  cagr : Dispersion_stats.summary;
+      (** Dispersion of {!per_start.cagr_pct} across [starts]. *)
+  max_underwater_vs_initial : Dispersion_stats.summary;
+      (** Dispersion of {!per_start.max_underwater_vs_initial_pct} across
+          [starts]. *)
+  max_drawdown : Dispersion_stats.summary;
+      (** Dispersion of {!per_start.max_drawdown_pct} across [starts]. *)
+}
+[@@deriving sexp, equal]
+(** The full rolling-start dispersion report: the raw per-start rows plus one
+    {!Dispersion_stats.summary} per collected metric. *)
+
+val build : end_date:Date.t -> per_start list -> report
+(** [build ~end_date starts] sorts [starts] by [start_date] (ascending) and
+    computes a {!Dispersion_stats.summary} for each metric column via
+    {!Dispersion_stats.summarize}. An empty [starts] yields all-zero-n summaries
+    — see {!Dispersion_stats.summarize}'s empty-list contract. *)
+
+val to_markdown : report -> string
+(** [to_markdown report] renders a human-readable report: a header line naming
+    the fixed end date and start count, a per-metric dispersion table (one row
+    per metric: median / 10th-pct / IQR / min / max / n), and a per-start detail
+    table. Mirrors the [walk_forward_render] table style. Floats are formatted
+    to two decimals; an empty report renders the header with a "no starts" note.
+*)

--- a/trading/trading/backtest/rolling_start/test/dune
+++ b/trading/trading/backtest/rolling_start/test/dune
@@ -1,0 +1,5 @@
+(tests
+ (names test_dispersion_stats test_rolling_start_types)
+ (libraries ounit2 core matchers rolling_start)
+ (preprocess
+  (pps ppx_compare ppx_sexp_conv)))

--- a/trading/trading/backtest/rolling_start/test/test_dispersion_stats.ml
+++ b/trading/trading/backtest/rolling_start/test/test_dispersion_stats.ml
@@ -1,0 +1,133 @@
+open Core
+open OUnit2
+open Matchers
+module DS = Rolling_start.Dispersion_stats
+
+(* Matcher: the float under test is NaN. Composed via [matching] so it obeys the
+   one-assert_that-per-value rule. *)
+let is_nan : float matcher =
+  matching ~msg:"expected NaN"
+    (fun x -> if Float.is_nan x then Some () else None)
+    __
+
+(* All expected values below are hand-computed with the NumPy-default "linear"
+   (type-7) percentile method: for a sorted list of length n, the p-th
+   percentile reads at rank r = p/100 * (n - 1) with linear interpolation. *)
+
+let test_median_odd _ =
+  (* sorted [1;2;3;4;5], middle element = 3 *)
+  assert_that (DS.median [ 3.0; 1.0; 5.0; 2.0; 4.0 ]) (float_equal 3.0)
+
+let test_median_even _ =
+  (* sorted [1;2;3;4], mean of 2 and 3 = 2.5 *)
+  assert_that (DS.median [ 4.0; 1.0; 3.0; 2.0 ]) (float_equal 2.5)
+
+let test_median_singleton _ = assert_that (DS.median [ 7.0 ]) (float_equal 7.0)
+let test_median_empty _ = assert_that (DS.median []) is_nan
+
+let test_percentile_min _ =
+  assert_that (DS.percentile [ 4.0; 1.0; 3.0 ] ~p:0.0) (float_equal 1.0)
+
+let test_percentile_max _ =
+  assert_that (DS.percentile [ 4.0; 1.0; 3.0 ] ~p:100.0) (float_equal 4.0)
+
+let test_percentile_interpolation _ =
+  (* sorted [10;20;30;40;50], n=5. p25 rank = 0.25*4 = 1.0 -> exactly 20.
+     p10 rank = 0.10*4 = 0.4 -> 10 + 0.4*(20-10) = 14. *)
+  assert_that
+    (DS.percentile [ 50.0; 10.0; 40.0; 20.0; 30.0 ] ~p:25.0)
+    (float_equal 20.0);
+  assert_that
+    (DS.percentile [ 50.0; 10.0; 40.0; 20.0; 30.0 ] ~p:10.0)
+    (float_equal 14.0)
+
+let test_percentile_p75_interp _ =
+  (* sorted [0;1;2;3], n=4. p75 rank = 0.75*3 = 2.25 -> 2 + 0.25*(3-2) = 2.25. *)
+  assert_that (DS.percentile [ 3.0; 0.0; 2.0; 1.0 ] ~p:75.0) (float_equal 2.25)
+
+let test_percentile_empty _ = assert_that (DS.percentile [] ~p:50.0) is_nan
+
+let test_percentile_singleton _ =
+  assert_that (DS.percentile [ 9.0 ] ~p:33.0) (float_equal 9.0)
+
+let test_percentile_out_of_range_low _ =
+  assert_raises (Invalid_argument "percentile: p=-1 out of [0, 100]") (fun () ->
+      DS.percentile [ 1.0 ] ~p:(-1.0))
+
+let test_percentile_out_of_range_high _ =
+  assert_raises (Invalid_argument "percentile: p=101 out of [0, 100]")
+    (fun () -> DS.percentile [ 1.0 ] ~p:101.0)
+
+let test_iqr _ =
+  (* sorted [0;1;2;3], p75=2.25, p25=0.75, iqr = 1.5 *)
+  assert_that (DS.iqr [ 3.0; 0.0; 2.0; 1.0 ]) (float_equal 1.5)
+
+let test_iqr_constant _ =
+  (* all equal -> zero spread *)
+  assert_that (DS.iqr [ 5.0; 5.0; 5.0; 5.0 ]) (float_equal 0.0)
+
+let test_iqr_empty _ = assert_that (DS.iqr []) is_nan
+
+let test_summarize_full _ =
+  (* sorted [10;20;30;40;50], n=5.
+     median(p50)=30; p10 rank 0.4 -> 14; p25=20; p75=40 -> iqr=20; min=10; max=50 *)
+  assert_that
+    (DS.summarize [ 50.0; 10.0; 40.0; 20.0; 30.0 ])
+    (all_of
+       [
+         field (fun s -> s.DS.n) (equal_to 5);
+         field (fun s -> s.DS.median) (float_equal 30.0);
+         field (fun s -> s.DS.p10) (float_equal 14.0);
+         field (fun s -> s.DS.iqr) (float_equal 20.0);
+         field (fun s -> s.DS.min) (float_equal 10.0);
+         field (fun s -> s.DS.max) (float_equal 50.0);
+       ])
+
+let test_summarize_empty _ =
+  assert_that (DS.summarize []) (field (fun s -> s.DS.n) (equal_to 0))
+
+let test_summarize_empty_fields_nan _ =
+  let s = DS.summarize [] in
+  assert_that s.DS.median is_nan;
+  assert_that s.DS.p10 is_nan;
+  assert_that s.DS.iqr is_nan;
+  assert_that s.DS.min is_nan;
+  assert_that s.DS.max is_nan
+
+(* Negative values must be ordered correctly (drawdown metrics can be negative). *)
+let test_summarize_negatives _ =
+  (* sorted [-50;-30;-10], n=3. median=-30; min=-50; max=-10 *)
+  assert_that
+    (DS.summarize [ -10.0; -50.0; -30.0 ])
+    (all_of
+       [
+         field (fun s -> s.DS.median) (float_equal (-30.0));
+         field (fun s -> s.DS.min) (float_equal (-50.0));
+         field (fun s -> s.DS.max) (float_equal (-10.0));
+       ])
+
+let suite =
+  "dispersion_stats"
+  >::: [
+         "median_odd" >:: test_median_odd;
+         "median_even" >:: test_median_even;
+         "median_singleton" >:: test_median_singleton;
+         "median_empty" >:: test_median_empty;
+         "percentile_min" >:: test_percentile_min;
+         "percentile_max" >:: test_percentile_max;
+         "percentile_interpolation" >:: test_percentile_interpolation;
+         "percentile_p75_interp" >:: test_percentile_p75_interp;
+         "percentile_empty" >:: test_percentile_empty;
+         "percentile_singleton" >:: test_percentile_singleton;
+         "percentile_out_of_range_low" >:: test_percentile_out_of_range_low;
+         "percentile_out_of_range_high" >:: test_percentile_out_of_range_high;
+         "iqr" >:: test_iqr;
+         "iqr_constant" >:: test_iqr_constant;
+         "iqr_empty" >:: test_iqr_empty;
+         "summarize_full" >:: test_summarize_full;
+         "summarize_empty" >:: test_summarize_empty;
+         "summarize_empty_fields_nan" >:: test_summarize_empty_fields_nan;
+         "summarize_negatives" >:: test_summarize_negatives;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/rolling_start/test/test_rolling_start_types.ml
+++ b/trading/trading/backtest/rolling_start/test/test_rolling_start_types.ml
@@ -1,0 +1,120 @@
+open Core
+open OUnit2
+open Matchers
+module RT = Rolling_start.Rolling_start_types
+module DS = Rolling_start.Dispersion_stats
+
+let make_start ~y ~m ~d ~cagr ~underwater ~maxdd : RT.per_start =
+  {
+    start_date = Date.create_exn ~y ~m ~d;
+    cagr_pct = cagr;
+    max_underwater_vs_initial_pct = underwater;
+    max_drawdown_pct = maxdd;
+  }
+
+let sample_starts =
+  [
+    (* Deliberately out of date order to pin the sort in [build]. *)
+    make_start ~y:2012 ~m:Month.Apr ~d:1 ~cagr:30.0 ~underwater:0.0
+      ~maxdd:(-20.0);
+    make_start ~y:2011 ~m:Month.Jan ~d:1 ~cagr:10.0 ~underwater:(-5.0)
+      ~maxdd:(-40.0);
+    make_start ~y:2011 ~m:Month.Jul ~d:1 ~cagr:50.0 ~underwater:0.0
+      ~maxdd:(-10.0);
+  ]
+
+let end_date = Date.create_exn ~y:2020 ~m:Month.Dec ~d:31
+
+(* CAGR values across starts: [30;10;50] -> sorted [10;30;50], median=30, min=10,
+   max=50. The report must compute these via Dispersion_stats. *)
+let test_build_cagr_summary _ =
+  let report = RT.build ~end_date sample_starts in
+  assert_that report.cagr
+    (all_of
+       [
+         field (fun s -> s.DS.n) (equal_to 3);
+         field (fun s -> s.DS.median) (float_equal 30.0);
+         field (fun s -> s.DS.min) (float_equal 10.0);
+         field (fun s -> s.DS.max) (float_equal 50.0);
+       ])
+
+(* Underwater values [0;-5;0] -> sorted [-5;0;0], median=0, min=-5. *)
+let test_build_underwater_summary _ =
+  let report = RT.build ~end_date sample_starts in
+  assert_that report.max_underwater_vs_initial
+    (all_of
+       [
+         field (fun s -> s.DS.median) (float_equal 0.0);
+         field (fun s -> s.DS.min) (float_equal (-5.0));
+       ])
+
+(* [build] sorts the per-start rows ascending by start_date. *)
+let test_build_sorts_starts _ =
+  let report = RT.build ~end_date sample_starts in
+  assert_that report.starts
+    (elements_are
+       [
+         field
+           (fun s -> s.RT.start_date)
+           (equal_to (Date.create_exn ~y:2011 ~m:Month.Jan ~d:1));
+         field
+           (fun s -> s.RT.start_date)
+           (equal_to (Date.create_exn ~y:2011 ~m:Month.Jul ~d:1));
+         field
+           (fun s -> s.RT.start_date)
+           (equal_to (Date.create_exn ~y:2012 ~m:Month.Apr ~d:1));
+       ])
+
+let test_build_preserves_end_date _ =
+  let report = RT.build ~end_date sample_starts in
+  assert_that report.end_date (equal_to end_date)
+
+let test_build_empty _ =
+  let report = RT.build ~end_date [] in
+  assert_that report.cagr (field (fun s -> s.DS.n) (equal_to 0))
+
+(* The markdown renderer surfaces the header, the dispersion table, and a
+   per-start detail row. *)
+let test_to_markdown_contains_sections _ =
+  let md = RT.to_markdown (RT.build ~end_date sample_starts) in
+  assert_that md
+    (all_of
+       [
+         contains_substring "Rolling-start dispersion";
+         contains_substring "Dispersion across starts";
+         contains_substring "Per-start detail";
+         contains_substring "CAGR %";
+         contains_substring "MaxUnderwaterVsInitial %";
+         contains_substring "2011-01-01";
+         contains_substring "2020-12-31";
+       ])
+
+let test_to_markdown_empty _ =
+  let md = RT.to_markdown (RT.build ~end_date []) in
+  assert_that md
+    (all_of
+       [
+         contains_substring "Rolling-start dispersion";
+         contains_substring "No starts";
+       ])
+
+(* Round-trip the report through sexp to pin the derived serializer. *)
+let test_sexp_roundtrip _ =
+  let report = RT.build ~end_date sample_starts in
+  let back = RT.report_of_sexp (RT.sexp_of_report report) in
+  assert_that back (equal_to ~cmp:RT.equal_report report)
+
+let suite =
+  "rolling_start_types"
+  >::: [
+         "build_cagr_summary" >:: test_build_cagr_summary;
+         "build_underwater_summary" >:: test_build_underwater_summary;
+         "build_sorts_starts" >:: test_build_sorts_starts;
+         "build_preserves_end_date" >:: test_build_preserves_end_date;
+         "build_empty" >:: test_build_empty;
+         "to_markdown_contains_sections" >:: test_to_markdown_contains_sections;
+         "to_markdown_empty" >:: test_to_markdown_empty;
+         "sexp_roundtrip" >:: test_sexp_roundtrip;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What
**Part 1** of the rolling-start dispersion harness — plan P1 ("highest value") of `dev/plans/evaluation-objective-and-metrics-2026-06-07.md` §2. The pure, backtest-free numeric + assembly/presentation core. The runner that executes N backtests (one per quarter-start to a fixed end date) lands in a **follow-up** (part 2).

## Why
Robustness — sensitivity to start time — should be the primary evaluation lens (plan §1.3). The macro-trim verdict turned on it (same config, 2011-start vs 2006-start flipped +700pp → −half). This harness judges a strategy on the *distribution* of outcomes across start dates: tight+positive = robust; wide spread = fragile.

## Contents
- `Dispersion_stats`: `percentile` (type-7 linear-interp, NumPy default), `median`, `iqr`, `summarize` → `{n; median; p10; iqr; min; max}`. Pure; NaN on empty list; documented per function.
- `Rolling_start_types`: `per_start` row (start_date, CAGR, `MaxUnderwaterVsInitialPct` [#1471 capital-relative DD], MaxDrawdown), `report` (a `Dispersion_stats.summary` per metric), `build` + `to_markdown`/sexp renderers mirroring `walk_forward_render`.

## Split rationale
The harness > 500 lines total; this PR is the rock-solid pure core (separately unit-testable without a backtest). Part 2 wires the N-run executor (reuses `Runner.run_backtest` + `--snapshot-dir`).

## Test plan
- `test_dispersion_stats.ml`: percentile interpolation (hand-computed type-7 values: p25/p10/p75 on known lists), median odd/even/singleton/empty, IQR, out-of-range `Invalid_argument`, NaN-on-empty.
- `test_rolling_start_types.ml`: `build` sorts by start + computes per-metric summaries; `to_markdown` renders + empty-report case.

## Notes
- Additive analysis-only module — runs nothing in the default pipeline, no strategy-behaviour change → no experiment-flag-discipline gate.
- Full `dune runtest` clean (exit 0, no FAIL); `dune build @fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)