### PR TITLE
chore(agents): fix feat-agent finish-step — container-visible jj workspace + mandatory Finish Protocol

### DIFF
--- a/.claude/agents/feat-agent-template.md
+++ b/.claude/agents/feat-agent-template.md
@@ -32,7 +32,7 @@ Before reading any file or writing any code, create an isolated jj workspace:
 
 ```bash
 AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
-AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+AGENT_WS=".claude/worktrees/jjws-${AGENT_ID}"
 jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
 cd "$AGENT_WS"
 # Verify: @ should be an empty commit on top of main@origin
@@ -180,7 +180,8 @@ status to READY_FOR_REVIEW.
 - [ ] No function exceeds 50 lines
 - [ ] PR diff respects `## PR sizing` rules (≤500 LOC, one new module per PR; status / plan / fixtures don't count)
 - [ ] All configurable parameters routed through config record — no magic numbers
-- [ ] `dune build && dune runtest` passes with zero warnings **on a clean checkout of the branch** — not just on your local worktree. If you are running in `isolation: "worktree"` (the orchestrator default), your working copy is usually but not always a clean checkout — follow `.claude/rules/worktree-isolation.md` to verify (`jj diff --stat` pre-commit, branch ancestry check pre-push, PR file list post-push). If you are NOT in a worktree (rare, legacy runs), re-verify by checking that every module your branch references is either in your commits or already on `main@origin` — do not rely on files sitting in the shared working copy that you did not explicitly commit.
+- [ ] `dune build && dune runtest` passes with zero warnings **on a clean checkout of the branch** — not just on your local worktree. Run in the **foreground** and check the **exit code** (not `grep FAIL:` — OUnit/linter failures may not print that literal; and `… | tail; echo $?` captures `tail`'s exit, not dune's). If you are running in `isolation: "worktree"` (the orchestrator default), your working copy is usually but not always a clean checkout — follow `.claude/rules/worktree-isolation.md` to verify (`jj diff --stat` pre-commit, branch ancestry check pre-push, PR file list post-push). If you are NOT in a worktree (rare, legacy runs), re-verify by checking that every module your branch references is either in your commits or already on `main@origin` — do not rely on files sitting in the shared working copy that you did not explicitly commit.
+- [ ] **Finish Protocol** followed (`.claude/rules/worktree-isolation.md` §"Finish Protocol") — REQUIRED for every feat-agent: verify in foreground → `jj describe` → `jj bookmark set feat/<name> -r @` → `jj git push -b feat/<name>` → `gh pr create`, atomically as the last actions with no turn-end in between; then confirm `jj diff -r @ --stat` is non-empty AND `gh pr view <N> --json files` lists your files; on any push/PR failure, retry once then report **bookmark + commit id + "PR NOT opened"**. **Never end a turn with an un-pushed commit** — a green local build that was never pushed is lost work (2026-06-07: 3 agent commits lost this way).
 - [ ] `dune build @fmt` passes (formatter in check mode; equivalent: `dune fmt` produces no diff)
 - [ ] `Interface stable: YES` is set in `dev/status/<feature>.md` once `.mli` is finalized
 - [ ] **PR description is non-empty.** `jst submit` does NOT populate the PR body from commit messages — the body field stays empty unless you write it explicitly. After `jst submit`, run `gh pr edit <N> --body-file <path>` (or `curl PATCH /pulls/<N> -d '{"body":"..."}'`) to set the body. The description should mirror the extended commit message: what changed, why, test plan. Bodies matter for reviewers scanning `gh pr list` and for future archaeology. Empty-body PRs were an observed gap — see run-5 on 2026-04-19.

--- a/.claude/agents/feat-backtest.md
+++ b/.claude/agents/feat-backtest.md
@@ -44,7 +44,7 @@ Before reading any file or writing any code, create an isolated jj workspace:
 
 ```bash
 AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
-AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+AGENT_WS=".claude/worktrees/jjws-${AGENT_ID}"
 jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
 cd "$AGENT_WS"
 # Verify: @ should be an empty commit on top of main@origin
@@ -188,7 +188,8 @@ status to READY_FOR_REVIEW.
 - [ ] All configurable parameters routed through config record — no magic numbers
 - [ ] If experiment: scenario files parse via `Scenario.load` (run `dune build`)
 - [ ] If experiment: `dev/experiments/<name>/report.md` includes a comparative table + falsifiable conclusion
-- [ ] `dune build && dune runtest` passes with zero warnings
+- [ ] `dune build && dune runtest` passes with zero warnings — run in the **foreground**, check the **exit code** (not `grep FAIL:`; not `… | tail; echo $?` which captures tail not dune)
+- [ ] **Finish Protocol** followed (`.claude/rules/worktree-isolation.md` §"Finish Protocol"): verify → `jj describe`→`bookmark set`→`git push`→`gh pr create` atomically as the last actions; `jj diff -r @ --stat` non-empty + `gh pr view <N> --json files` lists your files; on push/PR failure report bookmark+commit+"PR NOT opened". Never end a turn with an un-pushed commit.
 - [ ] `dune build @fmt` passes (formatter in check mode; equivalent: `dune fmt` produces no diff)
 - [ ] The relevant status file (`backtest-infra.md` or `backtest-scale.md`) updated: tick off the item under the relevant subsection, add a Completed entry with what was built, where it lives, and how to verify
 - [ ] Trading-behaviour-impact items also link back to `## Potential experiments` if they originated there

--- a/.claude/agents/feat-data.md
+++ b/.claude/agents/feat-data.md
@@ -45,7 +45,7 @@ Before reading any file or writing any code, create an isolated jj workspace:
 
 ```bash
 AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
-AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+AGENT_WS=".claude/worktrees/jjws-${AGENT_ID}"
 jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
 cd "$AGENT_WS"
 # Verify: @ should be an empty commit on top of main@origin
@@ -181,7 +181,8 @@ status to READY_FOR_REVIEW.
 - [ ] **No Python** — confirmed via `find <touched paths> -name '*.py'` returning zero matches; `trading/devtools/checks/no_python_check.sh` (wired into `dune runtest`) catches this on CI
 - [ ] **Pinned data fixtures are committed** — any HTML / CSV / sexp the test depends on lives under `test/data/` and is referenced by relative path. Do not depend on network fetches in tests.
 - [ ] **Cached data is gitignored** — `dev/data/<vendor>/` (anything fetched at runtime) is in `.gitignore`; small samples for tests live under `test/data/` and are checked in.
-- [ ] `dune build && dune runtest` passes with zero warnings on a clean checkout of the branch
+- [ ] `dune build && dune runtest` passes with zero warnings on a clean checkout of the branch — run in the **foreground**, check the **exit code** (not `grep FAIL:`; not `… | tail; echo $?` which captures tail not dune)
+- [ ] **Finish Protocol** followed (`.claude/rules/worktree-isolation.md` §"Finish Protocol"): verify → `jj describe`→`bookmark set`→`git push`→`gh pr create` atomically as the last actions; `jj diff -r @ --stat` non-empty + `gh pr view <N> --json files` lists your files; on push/PR failure report bookmark+commit+"PR NOT opened". Never end a turn with an un-pushed commit.
 - [ ] `dune build @fmt` passes (formatter in check mode)
 - [ ] `dev/status/data-foundations.md` updated: tick off the item, add a Completed entry with what was built, where it lives, and how to verify
 - [ ] PR body is non-empty — after `jst submit`, write the PR description (what/why/test plan) via `gh pr edit <N> --body-file <path>`. `jst submit` does not populate the body.

--- a/.claude/agents/feat-weinstein.md
+++ b/.claude/agents/feat-weinstein.md
@@ -26,7 +26,7 @@ Before reading any file or writing any code, create an isolated jj workspace:
 
 ```bash
 AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
-AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+AGENT_WS=".claude/worktrees/jjws-${AGENT_ID}"
 jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
 cd "$AGENT_WS"
 # Verify: @ should be an empty commit on top of main@origin
@@ -91,7 +91,8 @@ Do **not** modify the state machine itself (Initial → FirstCorrection → Trai
 - [ ] `Support_floor.find_recent_low` implemented + unit tests: peak + pullback identification, depth threshold, lookback truncation, no-pullback returns None, empty bars returns None
 - [ ] `Stops.compute_initial_stop` accepts the output; behaviour under `None` is identical to today's fixed-buffer code path
 - [ ] Smoke test: run `Weinstein_strategy` on cached 2018-2023 data and confirm at least one Stage-2 entry places its initial stop based on a support-floor value (not the fixed-buffer proxy)
-- [ ] `dune build && dune runtest` passes, `dune build @fmt` passes
+- [ ] `dune build && dune runtest` passes, `dune build @fmt` passes — run in the **foreground**, check the **exit code** (not `grep FAIL:`; not `… | tail; echo $?` which captures tail)
+- [ ] **Finish Protocol** followed (`.claude/rules/worktree-isolation.md` §"Finish Protocol"): verify → `jj describe`→`bookmark set`→`git push`→`gh pr create` atomically as the last actions; `jj diff -r @ --stat` non-empty + `gh pr view <N> --json files` lists your files; on push/PR failure report bookmark+commit+"PR NOT opened". Never end a turn with an un-pushed commit.
 - [ ] PR diff respects `## PR sizing` rules from `feat-agent-template.md` (≤500 LOC, one new module per PR)
 - [ ] No changes to screener, portfolio_risk, order_gen, or trading_state
 

--- a/.claude/agents/harness-maintainer.md
+++ b/.claude/agents/harness-maintainer.md
@@ -16,7 +16,7 @@ Before reading any file or writing any code, create an isolated jj workspace:
 
 ```bash
 AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
-AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+AGENT_WS=".claude/worktrees/jjws-${AGENT_ID}"
 jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
 cd "$AGENT_WS"
 # Verify: @ should be an empty commit on top of main@origin

--- a/.claude/agents/ops-data.md
+++ b/.claude/agents/ops-data.md
@@ -18,7 +18,7 @@ Before reading any file or writing any code, create an isolated jj workspace:
 
 ```bash
 AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
-AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+AGENT_WS=".claude/worktrees/jjws-${AGENT_ID}"
 jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
 cd "$AGENT_WS"
 # Verify: @ should be an empty commit on top of main@origin

--- a/.claude/rules/worktree-isolation.md
+++ b/.claude/rules/worktree-isolation.md
@@ -108,14 +108,27 @@ Standard boilerplate for every feat-* / harness-maintainer / ops-data agent:
 # Claude Code's isolation:"worktree" creates a git-worktree, NOT a jj-workspace.
 # Without this step, concurrent agents race the shared op_heads / default WorkspaceName.
 # See .claude/rules/worktree-isolation.md §"jj workspace isolation".
+#
+# CRITICAL: the workspace MUST live under the repo (.claude/worktrees/) so it is
+# visible inside the Docker container via the bind-mount. A /tmp path is
+# INVISIBLE to `docker exec trading-1-dev` — the agent would edit files jj+host
+# can see but dune (run in the container) cannot, silently building the parent
+# tree instead. This was the 2026-06-07 contamination root cause. See
+# memory/project_jj_workspace_docker_path.
 
 AGENT_ID="${HOSTNAME}-$$-$(date +%s)"
-AGENT_WS="/tmp/agent-ws-${AGENT_ID}"
+AGENT_WS=".claude/worktrees/jjws-${AGENT_ID}"          # repo-local → container-visible
 jj workspace add "$AGENT_WS" --name "$AGENT_ID" -r main@origin
 cd "$AGENT_WS"
 
 # Verify isolation: the new workspace's @ should be off main@origin
 jj log -n 1 -r @
+
+# Run EVERY dune command against THIS workspace's trading dir (NOT the parent):
+#   docker exec trading-1-dev bash -c \
+#     'cd /workspaces/trading-1/'"$AGENT_WS"'/trading && eval $(opam env) && dune build'
+# If you cd the container to /workspaces/trading-1/trading you build the parent,
+# not your edits — that is the bug this whole section exists to prevent.
 ```
 
 **After work is complete, clean up:**
@@ -127,13 +140,44 @@ rm -rf "$AGENT_WS"
 ```
 
 **Notes:**
-- `$AGENT_WS` is under `/tmp/` — outside the repo — so it cannot contaminate
-  the parent worktree's git index.
+- `$AGENT_WS` is **repo-local** (`.claude/worktrees/jjws-…`) so it is bind-mounted
+  into the container; jj runs on the host, dune runs in the container, and both
+  see the same files. A `/tmp` path breaks this (host-only) — never use it.
 - The `-r main@origin` flag ensures the new `@` starts from main, not from
   whatever `@` the parent had at dispatch time.
 - This fix applies to local jj runs only. GHA runs use `$TRADING_IN_CONTAINER`
   mode (plain git, no jj) and are unaffected.
-- Reference: `memory/project_jj_worktree_root_cause.md` (root cause writeup).
+- Reference: `memory/project_jj_worktree_root_cause.md` +
+  `memory/project_jj_workspace_docker_path.md` (root cause writeups).
+
+## Finish Protocol (required — prevents lost-work / un-opened PRs)
+
+The 2026-06-07 session lost three feat-agent commits because agents (a)
+backgrounded the final `dune runtest` and ended the turn "standing by" before
+ever committing, and (b) relied on workspace isolation to protect *uncommitted*
+state. The work survived only because it could be recovered from disk by hand.
+
+Every jj-writing agent MUST finish with this exact sequence, **in the foreground,
+as its last actions, without ending the turn in between:**
+
+1. **Verify in the foreground.** Run `dune build @fmt && dune build && dune runtest`
+   and read the **exit code** (not a `grep FAIL:` — OUnit failures and some
+   linters don't print that literal; and `… | tail; echo $?` captures `tail`'s
+   exit, not dune's). Blocking ~10 min here is expected and correct. Do NOT
+   background it and wait for an event.
+2. **Commit → bookmark → push → open PR, atomically:**
+   `jj describe -m "…"` → `jj bookmark set feat/<name> -r @` →
+   `jj git push -b feat/<name>` → `gh pr create …`.
+3. **Verify the push landed:** `jj diff -r @ --stat` must list your files (a
+   commit that shows 0 files = the working copy never snapshotted into it — STOP
+   and fix) **and** `gh pr view <N> --json files` must show them.
+4. **On any push/PR failure:** retry once; if it still fails, report the
+   **bookmark name + commit id + "PR NOT opened"** explicitly so the dispatcher
+   can open it (the dispatcher's recovery path, `feat-agent-dispatch.md` §2).
+
+Never end a turn with an un-pushed commit. The PR being open on origin is the
+only durable proof of done — a green local build that was never pushed is lost
+work.
 
 ## Cleanup
 


### PR DESCRIPTION
Fixes the 2026-06-07 lost-commit episode (3 feat-agent commits needed hand-recovery; see memory `feedback_feat_agents_lose_commits` + PR #1474 writeup).

**1. jj-workspace path bug.** `/tmp/agent-ws-*` → `.claude/worktrees/jjws-*` (repo-local → bind-mounted → **container-visible**). A `/tmp` path is invisible to `docker exec trading-1-dev`, so an agent edits files jj+host see but dune (run in-container) does not → silently builds the parent tree. Root cause: memory `project_jj_workspace_docker_path`. Fixed in all 6 agent boilerplates + `worktree-isolation.md` (path + corrected rationale + a 'run dune at the workspace path' note).

**2. Mandatory Finish Protocol** (new section in `worktree-isolation.md`, + acceptance-checklist item in the template and the 3 active feat-agents): verify in the **foreground** (check exit code — not `grep FAIL:`, not `… | tail; echo $?` which captures tail); then **commit→bookmark→push→PR atomically** as the last actions; verify the push landed (`jj diff -r @ --stat` non-empty + `gh pr view --json files`); on failure report bookmark+commit+'PR NOT opened'. **Never end a turn with an un-pushed commit.** This directly addresses the observed failure (agents backgrounded the final verify and ended before opening the PR).

Docs/config only (all `.md`). 🤖 Generated with [Claude Code](https://claude.com/claude-code)