### PR TITLE
feat(rolling-start): time-underwater + antifragility convexity prototype metrics (P3)

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -1,11 +1,42 @@
 # Status: backtest-perf
 
-## Last updated: 2026-06-04
+## Last updated: 2026-06-08
 
 ## Status
 IN_PROGRESS
 
-### Recent activity (2026-06-07)
+### Recent activity (2026-06-08)
+
+- **[x] P3 — time-underwater + antifragility convexity prototypes**
+  (branch `feat/rolling-start-time-underwater`). P3 ("prototype, hold
+  skeptically") of `dev/plans/evaluation-objective-and-metrics-2026-06-07.md`
+  §P3: pure analysis-only metrics over an equity curve / period-return
+  `float list`, companion to `Dispersion_stats`.
+  - Surface: new `Convexity_stats` pure module at
+    `trading/trading/backtest/rolling_start/lib/convexity_stats.{ml,mli}`:
+    - `time_underwater_pct` — fraction of NAV observations strictly below
+      the running prior high-water mark, ×100 (monotone-up / flat /
+      empty / singleton → 0.0).
+    - `tail_ratio` — convexity tail-ratio `|p95| / |p5|` over a return
+      series (type-7 percentile via `Dispersion_stats.percentile`;
+      `+infinity` when p5 mag is 0 and p95 mag positive; 0.0 on empty /
+      both-tails-zero).
+    - `return_skew` — third standardized moment (population variance,
+      matching the simulation-layer `Skewness` convention; 0.0 on empty /
+      singleton / zero-variance).
+  - Additive / analysis-only: not wired into the default metric suite,
+    no strategy behaviour change, all existing goldens bit-identical →
+    no experiment-flag gate. (NB: step-based counterparts
+    `TimeInDrawdownPct` / `TailRatio` / `Skewness` already exist in the
+    simulation metrics layer; these are the equity-curve formulations the
+    rolling-start harness consumes.)
+  - **worst-vol-decile conditional return: DEFERRED** — it needs a
+    per-period volatility / regime tag not available from a plain return
+    series; the plan flags it the most involved prototype and explicitly
+    says not to build new regime-tagging infra here. Shipped
+    time_underwater + tail_ratio + skew only.
+  - Verify: `dune runtest trading/backtest/rolling_start/` (51 tests:
+    19 dispersion-stats + 17 convexity-stats + 8 types + 7 runner).
 
 - **[x] Rolling-start dispersion — pure stats core (PR-1 of 2)**
   (branch `feat/rolling-start-dispersion`). P1 ("highest value") of

--- a/trading/trading/backtest/rolling_start/lib/convexity_stats.ml
+++ b/trading/trading/backtest/rolling_start/lib/convexity_stats.ml
@@ -1,0 +1,71 @@
+open Core
+
+(* Percent scale factor for the underwater fraction → percent conversion. Named
+   so the magic-number linter does not trip on the literal. *)
+let _pct_scale = 100.0
+
+(* Tail cut percentiles for the tail-ratio (plan §1.4: |p95| / |p5|). Named so
+   the linter does not trip and the contract is self-documenting. *)
+let _tail_hi_p = 95.0
+let _tail_lo_p = 5.0
+
+let time_underwater_pct equity_curve =
+  match equity_curve with
+  | [] | [ _ ] -> 0.0
+  | first :: rest ->
+      let n = 1 + List.length rest in
+      let _peak, n_underwater =
+        List.fold rest ~init:(first, 0) ~f:(fun (peak, count) v ->
+            let peak' = Float.max peak v in
+            let count' = if Float.( < ) v peak then count + 1 else count in
+            (peak', count'))
+      in
+      Float.of_int n_underwater /. Float.of_int n *. _pct_scale
+
+let tail_ratio returns =
+  match returns with
+  | [] -> 0.0
+  | _ ->
+      let hi = Dispersion_stats.percentile returns ~p:_tail_hi_p in
+      let lo = Dispersion_stats.percentile returns ~p:_tail_lo_p in
+      let lo_mag = Float.abs lo in
+      if Float.( <= ) lo_mag 0.0 then
+        if Float.( > ) (Float.abs hi) 0.0 then Float.infinity else 0.0
+      else Float.abs hi /. lo_mag
+
+let _mean = function
+  | [] -> 0.0
+  | xs -> List.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int (List.length xs)
+
+(* Population variance (divides by N) — matches the simulation-layer [Skewness]
+   metric's convention so the two stay numerically consistent. *)
+let _variance ~mean returns =
+  match returns with
+  | [] | [ _ ] -> 0.0
+  | _ ->
+      let sum_sq =
+        List.fold returns ~init:0.0 ~f:(fun acc r ->
+            let d = r -. mean in
+            acc +. (d *. d))
+      in
+      sum_sq /. Float.of_int (List.length returns)
+
+let _third_central_moment ~mean returns =
+  let sum_cube =
+    List.fold returns ~init:0.0 ~f:(fun acc r ->
+        let d = r -. mean in
+        acc +. (d *. d *. d))
+  in
+  sum_cube /. Float.of_int (List.length returns)
+
+let return_skew returns =
+  match returns with
+  | [] | [ _ ] -> 0.0
+  | _ ->
+      let mean = _mean returns in
+      let var = _variance ~mean returns in
+      if Float.( <= ) var 0.0 then 0.0
+      else
+        let m3 = _third_central_moment ~mean returns in
+        let sigma = Float.sqrt var in
+        m3 /. (sigma *. sigma *. sigma)

--- a/trading/trading/backtest/rolling_start/lib/convexity_stats.ml
+++ b/trading/trading/backtest/rolling_start/lib/convexity_stats.ml
@@ -9,16 +9,21 @@ let _pct_scale = 100.0
 let _tail_hi_p = 95.0
 let _tail_lo_p = 5.0
 
+(* One fold step for [time_underwater_pct]: advance the running high-water
+   [peak] and bump [count] when [v] sits strictly below the prior peak.
+   Extracted to keep [time_underwater_pct] flat for the nesting linter. *)
+let _underwater_step (peak, count) v =
+  let peak' = Float.max peak v in
+  let count' = if Float.( < ) v peak then count + 1 else count in
+  (peak', count')
+
 let time_underwater_pct equity_curve =
   match equity_curve with
   | [] | [ _ ] -> 0.0
   | first :: rest ->
       let n = 1 + List.length rest in
       let _peak, n_underwater =
-        List.fold rest ~init:(first, 0) ~f:(fun (peak, count) v ->
-            let peak' = Float.max peak v in
-            let count' = if Float.( < ) v peak then count + 1 else count in
-            (peak', count'))
+        List.fold rest ~init:(first, 0) ~f:_underwater_step
       in
       Float.of_int n_underwater /. Float.of_int n *. _pct_scale
 
@@ -37,17 +42,19 @@ let _mean = function
   | [] -> 0.0
   | xs -> List.fold xs ~init:0.0 ~f:( +. ) /. Float.of_int (List.length xs)
 
+(* One fold step accumulating squared deviations from [mean]. Extracted to keep
+   [_variance] flat for the nesting linter. *)
+let _add_sq_dev ~mean acc r =
+  let d = r -. mean in
+  acc +. (d *. d)
+
 (* Population variance (divides by N) — matches the simulation-layer [Skewness]
    metric's convention so the two stay numerically consistent. *)
 let _variance ~mean returns =
   match returns with
   | [] | [ _ ] -> 0.0
   | _ ->
-      let sum_sq =
-        List.fold returns ~init:0.0 ~f:(fun acc r ->
-            let d = r -. mean in
-            acc +. (d *. d))
-      in
+      let sum_sq = List.fold returns ~init:0.0 ~f:(_add_sq_dev ~mean) in
       sum_sq /. Float.of_int (List.length returns)
 
 let _third_central_moment ~mean returns =

--- a/trading/trading/backtest/rolling_start/lib/convexity_stats.mli
+++ b/trading/trading/backtest/rolling_start/lib/convexity_stats.mli
@@ -1,0 +1,65 @@
+(** Pure antifragility / time-underwater prototype metrics over a [float list].
+
+    Companion to {!Dispersion_stats}: a small set of additive, analysis-only
+    metrics from the evaluation scorecard (plan
+    [dev/plans/evaluation-objective-and-metrics-2026-06-07.md] §P3). Every
+    function here is pure (same input -> same output, no I/O, no backtest), so
+    each is unit-tested directly against hand-built series.
+
+    {b Additive only.} These are reported metrics. They do not change any
+    strategy behaviour, are not wired into the default metric suite, and so
+    leave every existing golden result bit-identical. The simulation layer
+    already exposes step-based counterparts ([TimeInDrawdownPct], [TailRatio],
+    [Skewness] in {!Trading_simulation_types.Metric_types}); these are the
+    equity-curve / period-return-series formulations the rolling-start harness
+    consumes.
+
+    Treat the antifragility (convexity) metrics skeptically — per the plan they
+    are prototypes, validated for non-noise before promotion to the scorecard.
+
+    {b Deferred:} the worst-volatility-decile conditional return prototype
+    requires a per-period volatility / regime tag that is not available from a
+    plain return series; it is out of scope for this module. *)
+
+val time_underwater_pct : float list -> float
+(** [time_underwater_pct equity_curve] is the fraction of observations in the
+    chronological NAV series [equity_curve] that sit {b strictly below} the
+    running prior high-water mark (the max of all {e earlier} points), expressed
+    as a percent in [0.0, 100.0].
+
+    The first point establishes the initial high-water and is never counted as
+    underwater. Each subsequent point is underwater iff it is strictly less than
+    the high-water established by the points before it; the high-water then
+    advances to include that point.
+
+    - A monotone non-decreasing series (every point a new high or a tie) -> 0.0.
+    - A flat series -> 0.0 (no point is strictly below the prior high).
+    - An empty or singleton series -> 0.0 (no prior high to be below). *)
+
+val tail_ratio : float list -> float
+(** [tail_ratio returns] is the convexity tail-ratio [|p95| / |p5|] of the
+    period-return series [returns] (plan §1.4): the magnitude of the 95th
+    percentile return over the magnitude of the 5th percentile return. Both
+    percentiles use the type-7 (linear-interpolation) method via
+    {!Dispersion_stats.percentile}.
+
+    A value [> 1] means the upper tail dominates the lower tail (a convex,
+    barbell-shaped return distribution); [< 1] means the downside tail
+    dominates.
+
+    - Returns [Float.infinity] when the 5th-percentile magnitude is [0.0] while
+      the 95th-percentile magnitude is positive (an all-upside tail).
+    - Returns [0.0] for an empty list, and when both tail magnitudes are [0.0].
+*)
+
+val return_skew : float list -> float
+(** [return_skew returns] is the skewness (third standardized moment) of the
+    period-return series [returns]: [E[(r - mean)^3] / sigma^3], using the
+    {b population} variance (divide by N), matching the simulation-layer
+    [Skewness] metric's convention.
+
+    [0.0] for a symmetric distribution; positive means a heavier right (gain)
+    tail; negative means a heavier left (loss) tail.
+
+    - Returns [0.0] for an empty or singleton list (no defined spread).
+    - Returns [0.0] when the variance is [0.0] (a flat series). *)

--- a/trading/trading/backtest/rolling_start/test/dune
+++ b/trading/trading/backtest/rolling_start/test/dune
@@ -1,6 +1,7 @@
 (tests
  (names
   test_dispersion_stats
+  test_convexity_stats
   test_rolling_start_types
   test_rolling_start_runner)
  (libraries

--- a/trading/trading/backtest/rolling_start/test/test_convexity_stats.ml
+++ b/trading/trading/backtest/rolling_start/test/test_convexity_stats.ml
@@ -1,0 +1,133 @@
+open Core
+open OUnit2
+open Matchers
+module CS = Rolling_start.Convexity_stats
+
+(* Matcher: the float under test is +infinity. Composed via [matching] so it
+   obeys the one-assert_that-per-value rule. *)
+let is_pos_infinity : float matcher =
+  matching ~msg:"expected +infinity"
+    (fun x -> if Float.is_inf x && Float.( > ) x 0.0 then Some () else None)
+    __
+
+(* ---- time_underwater_pct ---- *)
+
+let test_tuw_empty _ = assert_that (CS.time_underwater_pct []) (float_equal 0.0)
+
+let test_tuw_singleton _ =
+  assert_that (CS.time_underwater_pct [ 100.0 ]) (float_equal 0.0)
+
+let test_tuw_monotone_up _ =
+  (* Every point is a new high; none is below the prior high -> 0%. *)
+  assert_that
+    (CS.time_underwater_pct [ 100.0; 101.0; 102.0; 110.0 ])
+    (float_equal 0.0)
+
+let test_tuw_flat _ =
+  (* No point strictly below the prior high -> 0%. *)
+  assert_that (CS.time_underwater_pct [ 100.0; 100.0; 100.0 ]) (float_equal 0.0)
+
+let test_tuw_drawdown_and_recover _ =
+  (* Series: 100, 90, 80, 120, 110.
+     point 1 (100): high-water set, not counted.
+     point 2 (90): < 100 -> underwater.
+     point 3 (80): < 100 -> underwater.
+     point 4 (120): new high, not underwater.
+     point 5 (110): < 120 -> underwater.
+     3 of 5 observations underwater -> 60%. *)
+  assert_that
+    (CS.time_underwater_pct [ 100.0; 90.0; 80.0; 120.0; 110.0 ])
+    (float_equal 60.0)
+
+let test_tuw_all_below_first _ =
+  (* 100, 50, 50, 50: points 2-4 all strictly below the high-water 100.
+     3 of 4 -> 75%. *)
+  assert_that
+    (CS.time_underwater_pct [ 100.0; 50.0; 50.0; 50.0 ])
+    (float_equal 75.0)
+
+(* ---- tail_ratio ---- *)
+
+let test_tail_ratio_empty _ = assert_that (CS.tail_ratio []) (float_equal 0.0)
+
+let test_tail_ratio_symmetric _ =
+  (* Symmetric series around 0; |p95| = |p5| -> ratio 1.0.
+     sorted [-10;-5;0;5;10], n=5.
+     p95 rank = 0.95*4 = 3.8 -> 5 + 0.8*(10-5) = 9.
+     p5  rank = 0.05*4 = 0.2 -> -10 + 0.2*(-5 - -10) = -9.
+     |9| / |-9| = 1.0. *)
+  assert_that (CS.tail_ratio [ 0.0; -10.0; 10.0; -5.0; 5.0 ]) (float_equal 1.0)
+
+let test_tail_ratio_upside_heavy _ =
+  (* Upper tail twice the lower in magnitude.
+     sorted [-5;-2;0;2;20], n=5.
+     p95 rank = 3.8 -> 2 + 0.8*(20-2) = 16.4.
+     p5  rank = 0.2 -> -5 + 0.2*(-2 - -5) = -4.4.
+     16.4 / 4.4 = 3.7272... *)
+  assert_that
+    (CS.tail_ratio [ 0.0; -5.0; 20.0; -2.0; 2.0 ])
+    (float_equal ~epsilon:1e-6 (16.4 /. 4.4))
+
+let test_tail_ratio_all_gains _ =
+  (* All-positive series: p5 magnitude is positive too here, so the ratio is
+     finite. Use a series whose p5 is exactly 0 to hit the infinity branch. *)
+  (* sorted [0;0;0;0;10], n=5. p5 rank = 0.2 -> 0 + 0.2*(0-0) = 0.
+     p95 rank = 3.8 -> 0 + 0.8*(10-0) = 8.  |8| / 0 -> +infinity. *)
+  assert_that (CS.tail_ratio [ 0.0; 0.0; 0.0; 0.0; 10.0 ]) is_pos_infinity
+
+let test_tail_ratio_all_zero _ =
+  (* Both tails zero magnitude -> 0.0. *)
+  assert_that (CS.tail_ratio [ 0.0; 0.0; 0.0 ]) (float_equal 0.0)
+
+(* ---- return_skew ---- *)
+
+let test_skew_empty _ = assert_that (CS.return_skew []) (float_equal 0.0)
+
+let test_skew_singleton _ =
+  assert_that (CS.return_skew [ 5.0 ]) (float_equal 0.0)
+
+let test_skew_flat _ =
+  (* Zero variance -> 0.0. *)
+  assert_that (CS.return_skew [ 3.0; 3.0; 3.0 ]) (float_equal 0.0)
+
+let test_skew_symmetric _ =
+  (* Symmetric distribution -> skew 0. [-2;-1;0;1;2] *)
+  assert_that (CS.return_skew [ 0.0; -2.0; 2.0; -1.0; 1.0 ]) (float_equal 0.0)
+
+let test_skew_right_tailed _ =
+  (* [0;0;0;0;10]: mean 2, population.
+     deviations: -2,-2,-2,-2,8.
+     m2 = (4+4+4+4+64)/5 = 80/5 = 16.  sigma = 4.
+     m3 = (-8-8-8-8+512)/5 = 480/5 = 96.
+     skew = 96 / 4^3 = 96 / 64 = 1.5. *)
+  assert_that (CS.return_skew [ 0.0; 0.0; 0.0; 0.0; 10.0 ]) (float_equal 1.5)
+
+let test_skew_left_tailed _ =
+  (* Mirror of the right-tailed case -> -1.5. *)
+  assert_that
+    (CS.return_skew [ 0.0; 0.0; 0.0; 0.0; -10.0 ])
+    (float_equal (-1.5))
+
+let suite =
+  "convexity_stats"
+  >::: [
+         "tuw_empty" >:: test_tuw_empty;
+         "tuw_singleton" >:: test_tuw_singleton;
+         "tuw_monotone_up" >:: test_tuw_monotone_up;
+         "tuw_flat" >:: test_tuw_flat;
+         "tuw_drawdown_and_recover" >:: test_tuw_drawdown_and_recover;
+         "tuw_all_below_first" >:: test_tuw_all_below_first;
+         "tail_ratio_empty" >:: test_tail_ratio_empty;
+         "tail_ratio_symmetric" >:: test_tail_ratio_symmetric;
+         "tail_ratio_upside_heavy" >:: test_tail_ratio_upside_heavy;
+         "tail_ratio_all_gains" >:: test_tail_ratio_all_gains;
+         "tail_ratio_all_zero" >:: test_tail_ratio_all_zero;
+         "skew_empty" >:: test_skew_empty;
+         "skew_singleton" >:: test_skew_singleton;
+         "skew_flat" >:: test_skew_flat;
+         "skew_symmetric" >:: test_skew_symmetric;
+         "skew_right_tailed" >:: test_skew_right_tailed;
+         "skew_left_tailed" >:: test_skew_left_tailed;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

P3 of `dev/plans/evaluation-objective-and-metrics-2026-06-07.md` — pure, additive, analysis-only convexity / time-underwater prototype metrics over an equity curve / period-return `float list`. New `Convexity_stats` module in the `rolling_start` lib, companion to `Dispersion_stats`.

- **`time_underwater_pct`** — fraction of NAV observations strictly below the running prior high-water mark, ×100. Monotone-up / flat / empty / singleton → 0.0.
- **`tail_ratio`** — convexity tail-ratio `|p95| / |p5|` over a return series (type-7 percentile via `Dispersion_stats.percentile`). `+infinity` when p5 magnitude is 0 and p95 magnitude positive; 0.0 on empty / both-tails-zero.
- **`return_skew`** — third standardized moment, population variance, matching the simulation-layer `Skewness` convention. 0.0 on empty / singleton / zero-variance.

## Why additive / no flag gate

These are reported metrics only. They are **not** wired into the default metric suite, change **no** strategy behaviour, and leave every existing golden bit-identical. Per the plan and `.claude/rules/experiment-flag-discipline.md`, additive reported-only metrics need no experiment-flag gate. (Step-based counterparts `TimeInDrawdownPct` / `TailRatio` / `Skewness` already exist in the simulation metrics layer; these are the equity-curve formulations the rolling-start harness consumes.)

## worst-vol-decile: DEFERRED

The plan's third convexity prototype (worst-volatility-decile conditional return) needs a per-period volatility / regime tag not available from a plain return series; the plan flags it the most involved prototype and says not to build new regime-tagging infra here. Shipped time_underwater + tail_ratio + skew only.

## Test plan

`dune runtest trading/backtest/rolling_start/` — 51 tests (19 dispersion-stats + **17 convexity-stats** + 8 types + 7 runner), all green. Convexity tests are data-free, hand-computed expected values (monotone-up → 0%, known drawdown-and-recover → exact fraction, symmetric → ratio 1 / skew 0, right-tailed → skew 1.5, all-upside p5=0 → +infinity). `dune build @fmt` clean.

🤖 Dispatched by GHA orchestrator run [27111918628](https://github.com/dayfine/trading/actions/runs/27111918628)