### PR TITLE
fix(engine): lazy intraday-path generation to clear N=3000 OOM

### DIFF
--- a/trading/trading/engine/lib/dune
+++ b/trading/trading/engine/lib/dune
@@ -2,6 +2,6 @@
  (public_name trading.engine)
  (name trading_engine)
  (libraries trading.base trading.orders status)
- (modules types engine price_path buffer_pool)
+ (modules types engine market_state price_path buffer_pool)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/engine/lib/engine.ml
+++ b/trading/trading/engine/lib/engine.ml
@@ -6,64 +6,19 @@ open Types
 
 type t = {
   config : engine_config;
-  market_state : (symbol, intraday_path) Hashtbl.t;
-  path_scratches : (symbol, Price_path.Scratch.t) Hashtbl.t;
+  market_state : Market_state.t;
+      (** Per-symbol bars + lazy intraday-path generation; see {!Market_state}.
+      *)
 }
-(** Per-symbol scratch buffers for [Price_path] path generation. PR-3 of the
-    engine-pooling plan ([dev/plans/engine-layer-pooling.md]) threads these
-    through the per-tick [update_market] loop so the dominant per-tick
-    allocation (Brownian-bridge intermediate float arrays inside [Price_path])
-    drops to zero after each symbol's first day.
 
-    Lazy creation: a scratch is allocated on first sight of a symbol, sized to
-    the [path_config] passed in that call. If a later [update_market] call
-    arrives with a larger [total_points] than the cached scratch can hold, the
-    scratch is grown lazily by re-allocation. Across a typical backtest
-    [path_config] is constant, so the post-warmup steady state is one
-    pre-allocated scratch per symbol and zero allocation per [update_market]
-    inside [Price_path].
+let create config = { config; market_state = Market_state.create () }
 
-    Not thread-safe: see {!Price_path.Scratch} — one scratch per logical caller
-    (here, per symbol) and the engine is single-threaded by construction. *)
-
-let create config =
-  {
-    config;
-    market_state = Hashtbl.create (module String);
-    path_scratches = Hashtbl.create (module String);
-  }
-
-(* Look up (or lazily create) a [Price_path.Scratch.t] for [symbol] sized for
-   [path_config]. The capacity probe is pure — no scratch is allocated unless
-   one is actually missing or too small.
-
-   PR-4 of the engine-pooling plan: use [Hashtbl.find_or_add] (which calls
-   [default ()] only on miss) instead of [Hashtbl.find] + match on
-   [Some]/[None]. The earlier [match Hashtbl.find …] form allocated a fresh
-   [Some] tag on every call — the largest per-call cost left in
-   [Engine.update_market.(fun)] after PR-3 per the post-PR-A memtrace
-   ([dev/notes/panels-memtrace-postA-2026-04-26.md]). *)
-let _scratch_for_symbol engine ~symbol ~path_config =
-  let required = Price_path.Scratch.required_capacity path_config in
-  let scratch =
-    Hashtbl.find_or_add engine.path_scratches symbol ~default:(fun () ->
-        Price_path.Scratch.for_config path_config)
-  in
-  if Price_path.Scratch.capacity scratch >= required then scratch
-  else
-    let grown = Price_path.Scratch.for_config path_config in
-    Hashtbl.set engine.path_scratches ~key:symbol ~data:grown;
-    grown
-
+(* Store today's bars; intraday [Price_path] generation is deferred to
+   [Market_state.path_for] at order-processing time, so paths are materialized
+   only for the few symbols an order references rather than the whole universe.
+   See {!Market_state}. *)
 let update_market ?(path_config = Price_path.default_config) engine bars =
-  List.iter bars ~f:(fun bar ->
-      let scratch =
-        _scratch_for_symbol engine ~symbol:bar.symbol ~path_config
-      in
-      let path =
-        Price_path.generate_path_into ~scratch ~config:path_config bar
-      in
-      Hashtbl.set engine.market_state ~key:bar.symbol ~data:path)
+  Market_state.update engine.market_state ~path_config bars
 
 let _calculate_commission config quantity =
   Float.max (quantity *. config.commission.per_share) config.commission.minimum
@@ -214,7 +169,9 @@ let _apply_slippage_to_fill engine ~side (fill : fill_result) : float =
 (* Execute market order - returns Some trade if successful, None otherwise *)
 let _execute_market_order engine (ord : Trading_orders.Types.order) =
   let open Option.Let_syntax in
-  let%bind path = Hashtbl.find engine.market_state ord.symbol in
+  let%bind path =
+    Market_state.path_for engine.market_state ~symbol:ord.symbol
+  in
   let%bind fill = _would_fill_market path in
   let commission = _calculate_commission engine.config ord.quantity in
   let price = _apply_slippage_to_fill engine ~side:ord.side fill in
@@ -224,7 +181,9 @@ let _execute_market_order engine (ord : Trading_orders.Types.order) =
 (* Execute limit order - returns Some trade if successful, None otherwise *)
 let _execute_limit_order engine (ord : Trading_orders.Types.order) limit_price =
   let open Option.Let_syntax in
-  let%bind path = Hashtbl.find engine.market_state ord.symbol in
+  let%bind path =
+    Market_state.path_for engine.market_state ~symbol:ord.symbol
+  in
   let%bind fill = _would_fill_limit ~path ~side:ord.side ~limit_price in
   let commission = _calculate_commission engine.config ord.quantity in
   let price = _apply_slippage_to_fill engine ~side:ord.side fill in
@@ -255,7 +214,9 @@ let _process_limit_order engine order_mgr order limit_price =
 (* Execute stop order - returns Some trade if triggered, None otherwise *)
 let _execute_stop_order engine (ord : Trading_orders.Types.order) stop_price =
   let open Option.Let_syntax in
-  let%bind path = Hashtbl.find engine.market_state ord.symbol in
+  let%bind path =
+    Market_state.path_for engine.market_state ~symbol:ord.symbol
+  in
   let%bind fill = _would_fill_stop ~path ~side:ord.side ~stop_price in
   let commission = _calculate_commission engine.config ord.quantity in
   let price = _apply_slippage_to_fill engine ~side:ord.side fill in
@@ -272,7 +233,9 @@ let _process_stop_order engine order_mgr order stop_price =
 let _execute_stop_limit_order engine (ord : Trading_orders.Types.order)
     stop_price limit_price =
   let open Option.Let_syntax in
-  let%bind path = Hashtbl.find engine.market_state ord.symbol in
+  let%bind path =
+    Market_state.path_for engine.market_state ~symbol:ord.symbol
+  in
   let%bind fill =
     _would_fill_stop_limit ~path ~side:ord.side ~stop_price ~limit_price
   in

--- a/trading/trading/engine/lib/market_state.ml
+++ b/trading/trading/engine/lib/market_state.ml
@@ -1,0 +1,63 @@
+(** Per-symbol market state + lazy intraday-path generation. See
+    [market_state.mli]. *)
+
+open Core
+open Trading_base.Types
+open Types
+
+type t = {
+  bars : (symbol, price_bar) Hashtbl.t;
+      (** Most-recent bar per symbol, set by {!update}. *)
+  scratches : (symbol, Price_path.Scratch.t) Hashtbl.t;
+      (** Reusable per-symbol [Price_path] scratch buffers. PR-3 of the
+          engine-pooling plan ([dev/plans/engine-layer-pooling.md]): one
+          pre-allocated scratch per symbol means zero per-call allocation inside
+          [Price_path] in steady state. Grown lazily if a later config needs a
+          larger capacity. *)
+  generated : (symbol, intraday_path) Hashtbl.t;
+      (** Per-tick memo of paths already generated this tick; cleared by
+          {!update}. *)
+  mutable path_config : Price_path.path_config;
+      (** [path_config] from the latest {!update}, threaded to lazy generation.
+      *)
+}
+
+let create () =
+  {
+    bars = Hashtbl.create (module String);
+    scratches = Hashtbl.create (module String);
+    generated = Hashtbl.create (module String);
+    path_config = Price_path.default_config;
+  }
+
+let update t ~path_config bars =
+  t.path_config <- path_config;
+  Hashtbl.clear t.generated;
+  List.iter bars ~f:(fun bar -> Hashtbl.set t.bars ~key:bar.symbol ~data:bar)
+
+(* Look up (or lazily create / grow) the scratch for [symbol] sized for the
+   current [path_config]. [find_or_add] allocates only on a miss. *)
+let _scratch_for t ~symbol =
+  let required = Price_path.Scratch.required_capacity t.path_config in
+  let scratch =
+    Hashtbl.find_or_add t.scratches symbol ~default:(fun () ->
+        Price_path.Scratch.for_config t.path_config)
+  in
+  if Price_path.Scratch.capacity scratch >= required then scratch
+  else
+    let grown = Price_path.Scratch.for_config t.path_config in
+    Hashtbl.set t.scratches ~key:symbol ~data:grown;
+    grown
+
+let _generate t ~symbol bar =
+  let scratch = _scratch_for t ~symbol in
+  Price_path.generate_path_into ~scratch ~config:t.path_config bar
+
+let path_for t ~symbol =
+  match Hashtbl.find t.generated symbol with
+  | Some path -> Some path
+  | None ->
+      Option.map (Hashtbl.find t.bars symbol) ~f:(fun bar ->
+          let path = _generate t ~symbol bar in
+          Hashtbl.set t.generated ~key:symbol ~data:path;
+          path)

--- a/trading/trading/engine/lib/market_state.mli
+++ b/trading/trading/engine/lib/market_state.mli
@@ -1,0 +1,34 @@
+(** Per-symbol market state for the execution engine: the most-recent bar for
+    every symbol, the reusable [Price_path] scratch pool, and a per-tick memo of
+    already-generated intraday paths.
+
+    Memory note: [update] stores only the per-symbol
+    {!Trading_engine.Types.price_bar} (a handful of floats). The intraday
+    [Price_path] — a boxed [intraday_path] list of ~390 points, ~19 KB each — is
+    generated lazily in {!path_for}, and only for the handful of symbols an
+    order actually references each tick. The prior design generated one path per
+    symbol with a bar every tick, allocating ~N (universe-size) of these per day
+    even though >99% were never read. At broad-N (3000-symbol PIT universes)
+    that per-tick churn dominated the major heap and OOM'd the container;
+    deferring it flattens the heap with no change to fill prices (same bar +
+    scratch + config -> same path). *)
+
+type t
+
+val create : unit -> t
+(** Empty market state: no bars observed, empty scratch pool and memo. *)
+
+val update :
+  t -> path_config:Price_path.path_config -> Types.price_bar list -> unit
+(** Record [bars] as the most-recent bar for each symbol and retain
+    [path_config] for later lazy path generation. Clears the per-tick path memo
+    so the next {!path_for} for any symbol regenerates from the new bar. *)
+
+val path_for :
+  t -> symbol:Trading_base.Types.symbol -> Types.intraday_path option
+(** Intraday path for [symbol], generated from its most-recent stored bar and
+    memoized for the current tick. [None] when no bar has been observed for
+    [symbol]. Repeated calls within one tick return the {e same} path, matching
+    the prior eager design where each symbol's path was generated exactly once
+    per tick (so sibling orders on one symbol see one path, not independent
+    random draws). *)


### PR DESCRIPTION
## What

Fixes the N=3000 full-history backtest OOM. A 15y top-3000 PIT run
OOM-killed the 7.75 GB container at cycle ~510/829, blocking every
full-history broad-PIT re-baseline (see
`dev/notes/p1-pit-rebaseline-n3000-oom-2026-06-07.md` #1474). The
snapshot-cache fix (#1468) already removed bar-decode thrash; this
removes the remaining dominant memory grower.

## Root cause

`Engine.update_market` eagerly generated an intraday `Price_path`
(`path_point list`, ~390 boxed points ≈ 19 KB) for **every** symbol with
a bar on **every** tick — ~N (3000) paths/day. But the engine reads
`market_state` only in the four order-execution sites, each keyed on
`ord.symbol`, i.e. only for the handful of symbols an order references
(~5/day). >99% of the per-tick path allocation was pure churn; it
ballooned the major heap (`top_heap` ~4.6 GB held) and the steady
`live_words` growth (~1.4 MB/Friday-cycle, ~+700 MB over 15y) crossed
the container ceiling as cycles accumulated.

GC-instrumented on a 2018-2021 probe (instrumentation removed before this
PR): `live_words` 1551→1845 MB over 212 cycles = **1.39 MB/cycle**;
`top_heap` flat at 4082 MB.

## Fix

New `Market_state` engine sub-module
(`trading/trading/engine/lib/market_state.{ml,mli}`):

- `update` stores only the per-symbol `price_bar` (a few floats).
- `path_for` generates the intraday `Price_path` **lazily**, memoized
  per tick, only for symbols an order touches.

`Engine.update_market` delegates to `Market_state.update`; the four
fill sites call `Market_state.path_for`. `Engine.update_market`'s public
signature and `Engine.t`'s abstract type are unchanged.

**Parity is exact, not approximate:**
- Market orders (the only type the strategy emits) fill at the path head
  = the bar's open, which is RNG-independent — same bar + scratch +
  config ⇒ same fill.
- `market_state` is populated for the same set of symbols as before (all
  bars stored), so the engine's reliance on *stale* entries (orders on a
  symbol with no bar on the processing day) is preserved.
- The per-tick memo guarantees sibling orders on one symbol observe the
  same generated path, matching the prior single-generation-per-tick
  semantics.

## Validation

- **Parity (results unchanged):** 2018-2021 N=3000 probe =
  **56.4% / 150 trades / 32.7% win / 25.2% MaxDD** — bit-identical to the
  unfixed baseline (verified pre-fix, post-fix, and a determinism re-run
  of the original). `dune runtest` for `trading/engine`,
  `trading/simulation`, `trading/backtest` all green (golden-metric e2e
  tests included).
- **Memory:** per-cycle `live_words` growth **1.39 → ~0.01 MB/cycle**
  (~100× flatter); peak `top_heap` 4082 → 3910 MB.
- **15y N=3000 run:** the full 15y top-3000-2011 PIT run now **completes** — `cycles_done 829/829`, `actual.sexp` written, "1/1 scenarios passed", `(crashed false)`. It survived the COVID-crash region (cycle ~512, 2020-03-27) where the unfixed baseline OOM-killed (cycle 508-516). Container RSS held flat at ~5.8 GB for the whole run (vs the prior climb to >7.75 GB). First honest full-15y broad-PIT Cell-E scorecard: **total_return 790.5%, 671 trades, win_rate 34.9%, Sharpe 0.712, MaxDD 29.2%, Calmar 0.526, Sortino 1.225, Ulcer 9.78, force_liquidations 2**.

## Rejected first approach

Filtering `update_market`'s bar list to active-order symbols at the
simulator level **broke parity** (−20.7% vs +56.4%): the engine relies
on stale `market_state` entries for symbols without a bar on the
processing day, and filtering changed which stale entries existed. The
lazy-generation fix keeps `market_state` population identical and only
defers materialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
