### PR TITLE
feat(sim): stale-position force-exit (default-off) — #1484

### DIFF
--- a/dev/plans/stale-position-force-exit-2026-06-08.md
+++ b/dev/plans/stale-position-force-exit-2026-06-08.md
@@ -1,0 +1,102 @@
+# Plan — stale/delisted position force-exit (default-off) — issue #1484
+
+Date: 2026-06-08
+Track: backtest-infra (simulation-correctness)
+Branch: feat/backtest
+
+## Problem
+
+`Trading_simulation.Stale_hold` is a **detector only**: it records an event
+when a held position's symbol stops emitting bars, but emits no exit. A
+delisted/halted position is carried open indefinitely, marked at its last
+available close, and counted in terminal NAV — inflating it (8 of 9 terminal
+open positions in a top-3000 PIT 15y run were such zombies). See
+`dev/notes/p0-verify-broad-universe-790-2026-06-08.md` §3.
+
+## Goal
+
+A **default-off** force-exit: when configured, a held position whose bar gap
+≥ N is force-sold at its last available close as a **realized trade** — so it
+lands in `trades.csv` / realized PnL and frees cash, instead of perpetuating
+an open mark. Default-off ⇒ byte-identical to current behaviour
+(`.claude/rules/experiment-flag-discipline.md` R1).
+
+## Design
+
+### Config plumbing
+
+1. `Stale_hold.config` gains `stale_exit_after_days : int option`
+   (`[@sexp.default None]`). `None` = current detector-only (no exit);
+   `Some n` = force-exit once a held position's gap ≥ n. Keeps the simulator
+   generic — it still just takes a `Stale_hold.config`.
+2. `Weinstein_strategy.config` gains the same field
+   `stale_exit_after_days : int option [@sexp.default None]` — the axis-able
+   surface (flag-discipline R2). Routes through `config_overrides` /
+   `Overlay_validator`.
+3. `Backtest.Panel_runner._make_simulator` is the bridge: it already holds the
+   resolved `input.config` (a `Weinstein_strategy.config`) and constructs
+   `Simulator.create_deps`. Build the `Stale_hold.config` from the strategy
+   config's `stale_exit_after_days` (carry `enabled`/`stale_after_days`
+   defaults) and pass `~stale_hold_policy`.
+
+### Force-exit logic (simulator)
+
+In `_prepare_market_state` (where `detect_stale` is already called), after the
+detector pass, when `config.stale_exit_after_days = Some n`, for each held
+position with bar gap ≥ n:
+
+- Build a synthetic market-sell (long) / market-buy (short) trade for the full
+  position quantity at the last available close.
+- Apply it to the portfolio (`apply_single_trade`) → realized PnL, freed cash.
+- Drive the strategy `Position.t` Holding → Exiting → Closed via
+  `TriggerExit` + `ExitFill` + `ExitComplete` transitions
+  (`StrategySignal { label = "stale_force_exit"; ... }`), then drop the closed
+  position from the positions map (same `_set_or_drop_if_closed` convention).
+- Thread the resulting trades out of `_prepare_market_state` so they are merged
+  into the step's `trades` list (→ `trades.csv`).
+
+Why not route a `TriggerExit` through the normal order machinery (like
+`Margin_runner`)? The symbol has **no bar today** — the engine can't fill an
+order against absent market data, so the position would never close. The
+realized-trade path applies the exit directly at the last close.
+
+The candidate selection (which held positions to force-exit, the last close,
+the signed quantity) is a pure helper `Stale_hold.force_exit_candidates`. The
+trade construction + portfolio/position mutation are extracted into a new
+strategy-agnostic `Stale_exit_runner` module (mirroring `Margin_runner`) so
+`simulator.ml` stays under the 500-line hard limit; `_prepare_market_state`
+calls `Stale_exit_runner.tick` and threads its trades into the step.
+
+### Default-off invariant
+
+With the field `None` everywhere, the new branch is never entered → byte-
+identical to current behaviour. Verified by goldens + the existing
+`test_stale_hold` detector tests staying green.
+
+## Tests (TDD, write first)
+
+- `test_stale_hold.ml`: `force_exit_candidates` returns the long position at
+  its last close when `Some 5` and gap ≥ 5; returns `[]` when `None`.
+- `test_simulator.ml` (or focused new test): end-to-end —
+  - Delisted symbol, held, `stale_exit_after_days = Some 5`: exactly one
+    realized exit trade at the last close ~5 bar-days after the last bar;
+    position flat thereafter; freed cash available.
+  - `stale_exit_after_days = None`: no exit trade; position stays open marked
+    at last close (current behaviour).
+  - Exit PnL realized = (last_close − avg_cost) × qty.
+
+## Files
+
+- `trading/trading/simulation/lib/stale_hold.{ml,mli}` — config field +
+  `force_exit_candidates` pure helper.
+- `trading/trading/simulation/lib/stale_exit_runner.{ml,mli}` (new) — the
+  force-exit application (trade construction + portfolio/position mutation),
+  extracted to keep `simulator.ml` under the 500-line hard limit.
+- `trading/trading/simulation/lib/simulator.ml` — calls `Stale_exit_runner.tick`
+  in `_prepare_market_state`; threads the trades into the step.
+- `trading/trading/simulation/lib/dune` — register `stale_exit_runner`.
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy_config.{ml,mli}`
+  + `weinstein_strategy.mli` — the `stale_exit_after_days` axis field.
+- `trading/trading/backtest/lib/panel_runner.ml` — bridge.
+- `trading/trading/simulation/test/test_stale_hold.ml`
+  + `test_simulator.ml` — TDD tests.

--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -134,6 +134,28 @@ Merged in main:
 
 ## Completed
 
+- [x] **Stale/delisted position force-exit (default-off)** (2026-06-08,
+  `feat/backtest`, issue #1484). `Trading_simulation.Stale_hold` was a
+  detector only — a delisted/halted held position was carried open
+  indefinitely, marked at its last available close, and counted in
+  terminal NAV (8 of 9 terminal opens in a top-3000 PIT 15y run were such
+  zombies; see `dev/notes/p0-verify-broad-universe-790-2026-06-08.md` §3).
+  Added a **default-off** force-exit: `Stale_hold.config` gains
+  `stale_exit_after_days : int option [@sexp.default None]` and a pure
+  `force_exit_candidates` helper; `Weinstein_strategy.config` gains the
+  same field (axis-able via `Overlay_validator`, flag-discipline R2);
+  `Backtest.Panel_runner._make_simulator` threads it into the simulator's
+  `Stale_hold.config`. When `Some n`, a held position whose bar gap ≥ n is
+  force-sold at its last close as a **realised trade** (lands in
+  `trades.csv` / realised PnL, frees cash) — applied in
+  `Simulator._prepare_market_state`, only on bar-bearing days, and merged
+  into the step's `trades`. `None` everywhere ⇒ byte-identical to pre-#1484
+  (detector still records; no exit). Verify:
+  `dune runtest trading/simulation/test/` (new `force_exit_candidates` +
+  3 e2e simulator tests pinning realised-PnL = (last_close − avg_cost)×qty,
+  flat-after, and the disabled-keeps-open path). Plan:
+  `dev/plans/stale-position-force-exit-2026-06-08.md`.
+
 - [x] **15y SP500 trade-count investigation** (2026-05-05, PR #853).
   Root-cause investigation: `goldens-sp500-historical/sp500-2010-2026.sexp`
   produced 16 trades over 16y vs ~264 expected. **Dominant cause:

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -25,6 +25,18 @@ type input = {
 let _build_market_data_adapter ~daily_panels =
   Bar_data_source.build_adapter_from_panels daily_panels
 
+(* Stale-hold policy for the simulator, derived from the resolved strategy
+   config. The detector defaults ([enabled]/[stale_after_days]) are carried over
+   from [Stale_hold.default_config]; only [stale_exit_after_days] is threaded
+   from the strategy config. [None] (the default) keeps every existing backtest
+   byte-identical — the detector still records, but no force-exit fires. *)
+let _stale_hold_policy (config : Weinstein_strategy.config) : Stale_hold.config
+    =
+  {
+    Stale_hold.default_config with
+    stale_exit_after_days = config.stale_exit_after_days;
+  }
+
 let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
     ~end_date ~warmup_days ~initial_cash ~commission ?slippage_bps
     ?on_trade_fill ~strategy ~market_data_adapter () =
@@ -35,6 +47,7 @@ let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
       ~data_dir:input.data_dir_fpath ~strategy ~commission
       ~metric_suite:(Metric_computers.default_metric_suite ~initial_cash ())
       ~market_data_adapter ~stale_hold_log ?slippage_bps
+      ~stale_hold_policy:(_stale_hold_policy input.config)
       ~margin_config:input.config.margin_config ?on_trade_fill ()
   in
   let sim_config =

--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -34,6 +34,7 @@
   capital_relative_drawdown_computer
   portfolio_valuation
   stale_hold
+  stale_exit_runner
   margin_runner)
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -362,9 +362,11 @@ let _apply_trades_best_effort ?on_trade_fill portfolio trades =
   in
   (portfolio, List.rev accepted_rev, List.rev rejected_rev)
 
-(** Apply split detection, update market state, and record stale-held positions.
-    Returns the post-split portfolio, positions, today's bars, and the split
-    events (needed for [step_result.splits_applied]). *)
+(** Apply split detection, update market state, record stale-held positions, and
+    (when configured, default-off) force-exit stale/delisted positions at their
+    last close. Returns the post-split / post-force-exit portfolio, positions,
+    today's bars, split events, and the realised force-exit trades (merged into
+    the step's [trades] by the caller; see {!Stale_exit_runner}). *)
 let _prepare_market_state t =
   let split_events =
     Split_handler.detect_for_held_positions ~adapter:t.deps.market_data_adapter
@@ -373,18 +375,19 @@ let _prepare_market_state t =
   let portfolio = Split_handler.apply_events t.portfolio split_events in
   let positions = Split_handler.apply_to_positions t.positions split_events in
   let today_bars = _get_today_bars t in
-  (* Record stale-held positions (symbols without bars for K+ days) into
-     the per-run log. Detector only — no force-close; see [Stale_hold].
-     Runs only on bar-bearing days so weekend/holiday gaps don't trigger
-     false-positives every Saturday. *)
   if not (List.is_empty today_bars) then
     List.iter
       (Stale_hold.detect_stale ~adapter:t.deps.market_data_adapter
          ~date:t.current_date ~portfolio ~today_bars
          ~config:t.deps.stale_hold_policy)
       ~f:(Stale_hold.Log.record t.deps.stale_hold_log);
+  let portfolio, positions, stale_exit_trades =
+    Stale_exit_runner.tick ~adapter:t.deps.market_data_adapter
+      ~config:t.deps.stale_hold_policy ~commission:t.config.commission
+      ~date:t.current_date ~today_bars ~portfolio ~positions
+  in
   Trading_engine.Engine.update_market t.deps.engine today_bars;
-  (portfolio, positions, today_bars, split_events)
+  (portfolio, positions, today_bars, split_events, stale_exit_trades)
 
 (** Build the per-step [step_result]. Projection to the skinny
     [Portfolio_summary] mirrors Fix B from
@@ -433,11 +436,14 @@ let _process_fills_and_cancels t ~portfolio ~positions =
 (** Process one day: execute pending orders, call strategy, generate new orders,
     and assemble the [step_result]. Returns the next simulator state paired with
     this day's [step_result]. *)
-let _process_step_day t ~portfolio ~positions ~today_bars ~split_events =
+let _process_step_day t ~portfolio ~positions ~today_bars ~split_events
+    ~stale_exit_trades =
   let open Result.Let_syntax in
-  let%bind portfolio, positions, trades =
+  let%bind portfolio, positions, fill_trades =
     _process_fills_and_cancels t ~portfolio ~positions
   in
+  (* Surface the already-realised stale force-exits in this step's trades. *)
+  let trades = stale_exit_trades @ fill_trades in
   let%bind strategy_transitions =
     _call_strategy { t with portfolio; positions }
   in
@@ -474,10 +480,11 @@ let _process_step_day t ~portfolio ~positions ~today_bars ~split_events =
 let step t =
   if _is_complete t then Ok (Completed (_build_run_result t))
   else
-    let portfolio, positions, today_bars, split_events =
+    let portfolio, positions, today_bars, split_events, stale_exit_trades =
       _prepare_market_state t
     in
     _process_step_day t ~portfolio ~positions ~today_bars ~split_events
+      ~stale_exit_trades
 
 let get_config t = t.config
 

--- a/trading/trading/simulation/lib/stale_exit_runner.ml
+++ b/trading/trading/simulation/lib/stale_exit_runner.ml
@@ -61,33 +61,33 @@ let _set_or_drop_if_closed acc ~key ~data =
    unchanged when no Holding position for [symbol] exists (the portfolio is the
    source of truth for the realised trade; the strategy map is best-effort kept
    in sync). *)
+(* Drive a Holding [pos] (id [id]) through Exiting to Closed at [exit_price],
+   returning the closed position, or [None] if any transition is rejected. *)
+let _drive_holding_to_closed ~id ~date ~exit_price ~exit_reason pos =
+  let open Position in
+  let qty = match get_state pos with Holding h -> h.quantity | _ -> 0.0 in
+  let steps =
+    [
+      { position_id = id; date; kind = TriggerExit { exit_reason; exit_price } };
+      {
+        position_id = id;
+        date;
+        kind = ExitFill { filled_quantity = qty; fill_price = exit_price };
+      };
+      { position_id = id; date; kind = ExitComplete };
+    ]
+  in
+  List.fold_result steps ~init:pos ~f:(fun acc trans ->
+      apply_transition acc trans)
+  |> Result.ok
+
 let _close_strategy_position ~date ~exit_price ~exit_reason ~positions symbol =
   match _find_holding positions symbol with
   | None -> positions
   | Some (id, pos) -> (
-      let open Position in
-      let qty = match get_state pos with Holding h -> h.quantity | _ -> 0.0 in
-      let steps =
-        [
-          {
-            position_id = id;
-            date;
-            kind = TriggerExit { exit_reason; exit_price };
-          };
-          {
-            position_id = id;
-            date;
-            kind = ExitFill { filled_quantity = qty; fill_price = exit_price };
-          };
-          { position_id = id; date; kind = ExitComplete };
-        ]
-      in
-      match
-        List.fold_result steps ~init:pos ~f:(fun acc trans ->
-            apply_transition acc trans)
-      with
-      | Ok closed -> _set_or_drop_if_closed positions ~key:id ~data:closed
-      | Error _ -> positions)
+      match _drive_holding_to_closed ~id ~date ~exit_price ~exit_reason pos with
+      | Some closed -> _set_or_drop_if_closed positions ~key:id ~data:closed
+      | None -> positions)
 
 (* Apply one stale force-exit: realise the synthetic trade against the portfolio
    and close the matching strategy position. A trade the portfolio rejects (e.g.

--- a/trading/trading/simulation/lib/stale_exit_runner.ml
+++ b/trading/trading/simulation/lib/stale_exit_runner.ml
@@ -1,0 +1,120 @@
+(** Applies stale/delisted force-exits — see [stale_exit_runner.mli]. *)
+
+open Core
+module Position = Trading_strategy.Position
+
+(* Commission for the synthetic stale-exit trade, computed the same way the
+   engine computes fill commission: max(per_share * quantity, minimum). *)
+let _commission ~(commission : Trading_engine.Types.commission_config) ~quantity
+    =
+  Float.max (commission.per_share *. quantity) commission.minimum
+
+(* Build the synthetic market trade that flattens a stale force-exit candidate.
+   A long ([signed_quantity > 0]) is closed with a Sell; a short with a Buy. The
+   fill price is the candidate's last available close — there is no bar today, so
+   this is the only meaningful market price. *)
+let _exit_trade ~date ~commission (c : Stale_hold.force_exit) :
+    Trading_base.Types.trade =
+  let qty = Float.abs c.signed_quantity in
+  let side =
+    if Float.( > ) c.signed_quantity 0.0 then Trading_base.Types.Sell
+    else Trading_base.Types.Buy
+  in
+  {
+    id = sprintf "%s-stale-exit-%s" c.symbol (Date.to_string date);
+    order_id = sprintf "%s-stale-exit-order-%s" c.symbol (Date.to_string date);
+    symbol = c.symbol;
+    side;
+    quantity = qty;
+    price = c.last_close;
+    commission = _commission ~commission ~quantity:qty;
+    timestamp =
+      Time_ns_unix.of_date_ofday ~zone:Time_float.Zone.utc date
+        Time_ns_unix.Ofday.start_of_day;
+  }
+
+let _exit_reason (c : Stale_hold.force_exit) : Position.exit_reason =
+  let detail =
+    sprintf "last_bar_date=%s days_since_last_bar=%d"
+      (Date.to_string c.last_bar_date)
+      c.days_since_last_bar
+  in
+  Position.StrategySignal { label = "stale_force_exit"; detail = Some detail }
+
+(* The Holding strategy position for [symbol], if any. *)
+let _find_holding positions symbol =
+  Map.to_alist positions
+  |> List.find ~f:(fun (_, pos) ->
+      String.equal pos.Position.symbol symbol
+      &&
+      match Position.get_state pos with
+      | Position.Holding _ -> true
+      | _ -> false)
+
+(* Install [data] in [acc], or remove [key] when the position is Closed (Closed
+   positions are strategy-invisible; audit trails live elsewhere). *)
+let _set_or_drop_if_closed acc ~key ~data =
+  if Position.is_closed data then Map.remove acc key else Map.set acc ~key ~data
+
+(* Drive the strategy [Position.t] for [symbol] from Holding through Exiting to
+   Closed at [exit_price], then drop it from [positions]. Returns [positions]
+   unchanged when no Holding position for [symbol] exists (the portfolio is the
+   source of truth for the realised trade; the strategy map is best-effort kept
+   in sync). *)
+let _close_strategy_position ~date ~exit_price ~exit_reason ~positions symbol =
+  match _find_holding positions symbol with
+  | None -> positions
+  | Some (id, pos) -> (
+      let open Position in
+      let qty = match get_state pos with Holding h -> h.quantity | _ -> 0.0 in
+      let steps =
+        [
+          {
+            position_id = id;
+            date;
+            kind = TriggerExit { exit_reason; exit_price };
+          };
+          {
+            position_id = id;
+            date;
+            kind = ExitFill { filled_quantity = qty; fill_price = exit_price };
+          };
+          { position_id = id; date; kind = ExitComplete };
+        ]
+      in
+      match
+        List.fold_result steps ~init:pos ~f:(fun acc trans ->
+            apply_transition acc trans)
+      with
+      | Ok closed -> _set_or_drop_if_closed positions ~key:id ~data:closed
+      | Error _ -> positions)
+
+(* Apply one stale force-exit: realise the synthetic trade against the portfolio
+   and close the matching strategy position. A trade the portfolio rejects (e.g.
+   the position was already flattened) is skipped and not reported. *)
+let _apply_one ~date ~commission (portfolio, positions, trades)
+    (c : Stale_hold.force_exit) =
+  let trade = _exit_trade ~date ~commission c in
+  match Trading_portfolio.Portfolio.apply_single_trade portfolio trade with
+  | Error _ -> (portfolio, positions, trades)
+  | Ok portfolio ->
+      let positions =
+        _close_strategy_position ~date ~exit_price:c.last_close
+          ~exit_reason:(_exit_reason c) ~positions c.symbol
+      in
+      (portfolio, positions, trade :: trades)
+
+let tick ~adapter ~config ~commission ~date ~today_bars ~portfolio ~positions =
+  (* Only act on bar-bearing days, matching the detector's false-positive guard:
+     a weekend / holiday with no bars at all should not trip a force-exit. *)
+  if List.is_empty today_bars then (portfolio, positions, [])
+  else
+    let candidates =
+      Stale_hold.force_exit_candidates ~adapter ~date ~portfolio ~today_bars
+        ~config
+    in
+    let portfolio, positions, trades_rev =
+      List.fold candidates ~init:(portfolio, positions, [])
+        ~f:(_apply_one ~date ~commission)
+    in
+    (portfolio, positions, List.rev trades_rev)

--- a/trading/trading/simulation/lib/stale_exit_runner.mli
+++ b/trading/trading/simulation/lib/stale_exit_runner.mli
@@ -1,0 +1,53 @@
+(** Applies the stale/delisted force-exit selected by
+    {!Trading_simulation.Stale_hold.force_exit_candidates}.
+
+    The detector ({!Stale_hold.detect_stale}) only records stale holds; this
+    runner is the {b application} half of issue #1484. When
+    [config.stale_exit_after_days = Some n], a held position whose underlying
+    symbol has stopped emitting bars for [n] days is force-sold at its last
+    available close as a {b realised} trade — so it lands in [trades.csv] /
+    realised P&L and frees cash, instead of being carried open at a stale mark
+    indefinitely and counted in terminal NAV.
+
+    Why a realised trade rather than a routed [TriggerExit] (the
+    {!Margin_runner} pattern): the symbol has {b no bar today}, so the engine
+    cannot fill an order against absent market data — a routed exit order would
+    never complete. This runner applies the exit directly at the last close.
+
+    The runner is strategy-agnostic: it operates on the broker portfolio and the
+    generic [Position.t] state machine. Default-off
+    ([stale_exit_after_days = None]) makes [tick] an identity. *)
+
+open Core
+
+val tick :
+  adapter:Trading_simulation_data.Market_data_adapter.t ->
+  config:Stale_hold.config ->
+  commission:Trading_engine.Types.commission_config ->
+  date:Date.t ->
+  today_bars:Trading_engine.Types.price_bar list ->
+  portfolio:Trading_portfolio.Portfolio.t ->
+  positions:Trading_strategy.Position.t String.Map.t ->
+  Trading_portfolio.Portfolio.t
+  * Trading_strategy.Position.t String.Map.t
+  * Trading_base.Types.trade list
+(** Force-exit every stale held position selected by
+    {!Stale_hold.force_exit_candidates}. For each candidate:
+
+    - builds a synthetic market trade at the candidate's last close (a long is
+      flattened with a Sell, a short with a Buy) carrying the engine's
+      [max(per_share * qty, minimum)] commission;
+    - applies it to [portfolio] ([apply_single_trade]) — realising the P&L and
+      freeing cash;
+    - drives the matching Holding [Position.t] through Exiting to Closed and
+      drops it from [positions] (no-op when no Holding position for the symbol
+      exists — the portfolio is the source of truth).
+
+    Returns the post-exit [(portfolio, positions, trades)] with [trades] in
+    chronological (candidate) order, ready to merge into the step's trade list.
+    A trade the portfolio rejects is skipped and not reported. Returns the
+    inputs unchanged (empty trade list) when [today_bars] is empty (no
+    force-exit on a weekend / holiday — matches the detector's false-positive
+    guard), when [config.stale_exit_after_days = None] /
+    [config.enabled = false], or when no candidate has reached the threshold —
+    the default-off, byte-identical path. *)

--- a/trading/trading/simulation/lib/stale_hold.ml
+++ b/trading/trading/simulation/lib/stale_hold.ml
@@ -5,13 +5,21 @@ open Core
 
 (** {1 Configuration} *)
 
-type config = { enabled : bool; stale_after_days : int }
+type config = {
+  enabled : bool;
+  stale_after_days : int;
+  stale_exit_after_days : int option;
+}
 [@@deriving show, eq, sexp]
 
 let _default_stale_after_days = 5
 
 let default_config =
-  { enabled = true; stale_after_days = _default_stale_after_days }
+  {
+    enabled = true;
+    stale_after_days = _default_stale_after_days;
+    stale_exit_after_days = None;
+  }
 
 (** {1 Event} *)
 
@@ -78,6 +86,59 @@ let detect_stale ~adapter ~date ~portfolio ~today_bars ~config =
         _event_for_position ~adapter ~date ~today_set
           ~stale_after_days:config.stale_after_days pos)
 
+(** {1 Force-exit} *)
+
+type force_exit = {
+  symbol : string;
+  signed_quantity : float;
+  last_close : float;
+  last_bar_date : Date.t;
+  days_since_last_bar : int;
+}
+[@@deriving show, eq, sexp]
+
+(** Build a force-exit instruction for [pos] given its most recent prior bar
+    [prev]. Returns [None] when the gap is below [exit_after_days] or the
+    position is already flat. *)
+let _force_exit_for_bar ~date ~exit_after_days
+    (pos : Trading_portfolio.Types.portfolio_position)
+    (prev : Types.Daily_price.t) : force_exit option =
+  let last_bar_date = prev.Types.Daily_price.date in
+  let gap = Date.diff date last_bar_date in
+  let signed_quantity = Trading_portfolio.Calculations.position_quantity pos in
+  if gap < exit_after_days || Float.equal signed_quantity 0.0 then None
+  else
+    Some
+      {
+        symbol = pos.symbol;
+        signed_quantity;
+        last_close = prev.Types.Daily_price.close_price;
+        last_bar_date;
+        days_since_last_bar = gap;
+      }
+
+(** Build one force-exit for a held position, or [None] when the position has a
+    bar today, no prior bar, or the prior bar is recent enough. *)
+let _force_exit_for_position ~adapter ~date ~today_set ~exit_after_days
+    (pos : Trading_portfolio.Types.portfolio_position) : force_exit option =
+  if Set.mem today_set pos.symbol then None
+  else
+    let%bind.Option prev =
+      Trading_simulation_data.Market_data_adapter.get_previous_bar adapter
+        ~symbol:pos.symbol ~date
+    in
+    _force_exit_for_bar ~date ~exit_after_days pos prev
+
+let force_exit_candidates ~adapter ~date ~portfolio ~today_bars ~config =
+  match (config.enabled, config.stale_exit_after_days) with
+  | false, _ | _, None -> []
+  | true, Some exit_after_days ->
+      let today_set = _today_symbol_set today_bars in
+      List.filter_map portfolio.Trading_portfolio.Portfolio.positions
+        ~f:(fun pos ->
+          _force_exit_for_position ~adapter ~date ~today_set ~exit_after_days
+            pos)
+
 (** {1 Log} *)
 
 module Log = struct
@@ -96,7 +157,7 @@ module Log = struct
 
   let distinct_symbols t =
     events t
-    |> List.map ~f:(fun e -> e.symbol)
+    |> List.map ~f:(fun (e : event) -> e.symbol)
     |> List.dedup_and_sort ~compare:String.compare
 end
 

--- a/trading/trading/simulation/lib/stale_hold.ml
+++ b/trading/trading/simulation/lib/stale_hold.ml
@@ -129,15 +129,19 @@ let _force_exit_for_position ~adapter ~date ~today_set ~exit_after_days
     in
     _force_exit_for_bar ~date ~exit_after_days pos prev
 
+(* Scan all held positions for force-exit candidates under an active policy. *)
+let _collect_force_exits ~adapter ~date ~today_bars ~portfolio ~exit_after_days
+    =
+  let today_set = _today_symbol_set today_bars in
+  List.filter_map portfolio.Trading_portfolio.Portfolio.positions
+    ~f:(_force_exit_for_position ~adapter ~date ~today_set ~exit_after_days)
+
 let force_exit_candidates ~adapter ~date ~portfolio ~today_bars ~config =
   match (config.enabled, config.stale_exit_after_days) with
   | false, _ | _, None -> []
   | true, Some exit_after_days ->
-      let today_set = _today_symbol_set today_bars in
-      List.filter_map portfolio.Trading_portfolio.Portfolio.positions
-        ~f:(fun pos ->
-          _force_exit_for_position ~adapter ~date ~today_set ~exit_after_days
-            pos)
+      _collect_force_exits ~adapter ~date ~today_bars ~portfolio
+        ~exit_after_days
 
 (** {1 Log} *)
 

--- a/trading/trading/simulation/lib/stale_hold.mli
+++ b/trading/trading/simulation/lib/stale_hold.mli
@@ -5,12 +5,17 @@
     records each such {b held} symbol per step into a {!Log}, callers persist
     the log alongside other run artefacts.
 
-    {b This module does not force-close the position.} It is a pure detector +
-    recorder. The position continues to be valued via forward-fill (last-known
-    close from {!Market_data_adapter.get_previous_bar}). A future M&A track will
-    add explicit force-close on cash mergers and symbol-swap on stock mergers —
-    see [dev/notes/next-session-priorities-2026-05-07.md] §"Long-term M&A
-    track". *)
+    By default {b this module does not force-close the position} — it is a pure
+    detector + recorder, and the position continues to be valued via
+    forward-fill (last-known close from
+    {!Market_data_adapter.get_previous_bar}). When
+    [config.stale_exit_after_days] is set, {!force_exit_candidates} additionally
+    selects held positions whose bar gap has reached the configured threshold so
+    the simulator can force-sell them at the last available close — closing the
+    gap where a delisted/halted position is otherwise carried open indefinitely
+    and counted in terminal NAV (issue #1484). A future M&A track will add
+    explicit force-close on cash mergers and symbol-swap on stock mergers — see
+    [dev/notes/next-session-priorities-2026-05-07.md] §"Long-term M&A track". *)
 
 open Core
 
@@ -26,11 +31,21 @@ type config = {
           flagged as stale. Default [5] — covers typical weekend + long-weekend
           gaps without false-positives, fires within a week of a corporate
           action. *)
+  stale_exit_after_days : int option;
+      (** When [Some n], a held position whose bar gap has reached [n] calendar
+          days is force-exited at its last available close (see
+          {!force_exit_candidates}) — so a delisted/halted position is realised
+          out instead of carried open at a stale mark indefinitely (issue
+          #1484). When [None] (the default) no force-exit happens: the detector
+          still records events but the position is only forward-filled, which is
+          the pre-#1484 behaviour. Default [None] keeps every existing run
+          byte-identical. *)
 }
 [@@deriving show, eq, sexp]
 
 val default_config : config
-(** [{ enabled = true; stale_after_days = 5 }]. *)
+(** [{ enabled = true; stale_after_days = 5; stale_exit_after_days = None }] —
+    detector on, force-exit off (pre-#1484 behaviour). *)
 
 (** {1 Event} *)
 
@@ -76,6 +91,45 @@ val detect_stale :
     [date - last_bar_date >= config.stale_after_days], emit one event. Returns
     [[]] when [config.enabled = false], when no positions are held, or when no
     held position is stale. Pure with respect to the adapter's cache. *)
+
+(** {1 Force-exit} *)
+
+type force_exit = {
+  symbol : string;  (** Symbol of the held position to force-exit. *)
+  signed_quantity : float;
+      (** Held quantity, {b signed} — positive for a long position, negative for
+          a short. The simulator sells [signed_quantity] (Sell for a long, Buy
+          for a short) at [last_close] to flatten the position. *)
+  last_close : float;
+      (** Close on the most recent bar — the price the synthetic exit fills at.
+      *)
+  last_bar_date : Date.t;  (** Date of [last_close]'s bar. *)
+  days_since_last_bar : int;
+      (** Calendar gap [Date.diff date last_bar_date];
+          [>= stale_exit_after_days]. *)
+}
+[@@deriving show, eq, sexp]
+(** One force-exit instruction per held position whose bar gap has reached
+    [config.stale_exit_after_days]. The simulator turns each into a realised
+    market trade at [last_close]. *)
+
+val force_exit_candidates :
+  adapter:Trading_simulation_data.Market_data_adapter.t ->
+  date:Date.t ->
+  portfolio:Trading_portfolio.Portfolio.t ->
+  today_bars:Trading_engine.Types.price_bar list ->
+  config:config ->
+  force_exit list
+(** Select held positions to force-exit at [date]. For each held symbol with no
+    bar in [today_bars], query [adapter.get_previous_bar]; emit a {!force_exit}
+    when a prior bar exists and the gap [date - last_bar_date] is at least
+    [config.stale_exit_after_days].
+
+    Returns [[]] when [config.stale_exit_after_days = None] (force-exit
+    disabled), when [config.enabled = false], when no positions are held, or
+    when no held position has reached the exit threshold. Pure with respect to
+    the adapter's cache; the simulator owns the trade construction + portfolio /
+    position mutation. *)
 
 (** {1 Log} *)
 

--- a/trading/trading/simulation/test/test_simulator.ml
+++ b/trading/trading/simulation/test/test_simulator.ml
@@ -866,6 +866,155 @@ let test_forward_fill_uses_last_known_close_when_held_symbol_has_no_bar _ =
       assert_that result3.portfolio_value
         (gt (module Float_ord) (cash_after_buy +. 100.0)))
 
+(* ==================== Stale force-exit (#1484) ==================== *)
+
+(* Daily bars for a never-delisted symbol so [today_bars] stays non-empty
+   on the days AAPL has gone stale — the simulator force-exit (like the
+   detector) only runs on bar-bearing days. *)
+let keep_prices =
+  List.init 10 ~f:(fun i ->
+      let date = Date.add_days (date_of_string "2024-01-02") i in
+      make_daily_price ~date ~open_price:50.0 ~high:51.0 ~low:49.0 ~close:50.0
+        ~volume:500000)
+
+let stale_exit_deps data_dir ~stale_exit_after_days =
+  create_deps ~symbols:[ "AAPL"; "KEEP" ] ~data_dir
+    ~strategy:(module Noop_strategy)
+    ~commission:sample_config.commission
+    ~stale_hold_policy:
+      {
+        Trading_simulation.Stale_hold.enabled = true;
+        stale_after_days = 5;
+        stale_exit_after_days;
+      }
+    ()
+
+(* Submit a direct market buy for AAPL so the test pins the force-exit without
+   coupling to a strategy. The buy fills on day 1 at AAPL's open (150.0). *)
+let _submit_market_buy deps ~symbol ~quantity =
+  let order_params =
+    Trading_orders.Create_order.
+      {
+        symbol;
+        side = Trading_base.Types.Buy;
+        quantity;
+        order_type = Trading_base.Types.Market;
+        time_in_force = Trading_orders.Types.GTC;
+      }
+  in
+  let order =
+    match Trading_orders.Create_order.create_order order_params with
+    | Ok o -> o
+    | Error err -> failwith ("Failed to create order: " ^ Status.show err)
+  in
+  Trading_orders.Manager.submit_orders deps.order_manager [ order ] |> ignore
+
+(* AAPL has bars Jan 2 + Jan 3 only; KEEP trades every day. A market buy fills
+   10 AAPL on day 1. With [stale_exit_after_days = Some n], the simulator must
+   force-sell the 10 AAPL shares at the Jan-3 close (157.0) on the first
+   bar-bearing day whose gap from Jan 3 reaches n, then stay flat. *)
+let _run_stale_exit ~name ~stale_exit_after_days ~f =
+  let prices_through_jan_3 = List.take sample_aapl_prices 2 in
+  with_test_data
+    ("simulator_stale_exit_" ^ name)
+    [ ("AAPL", prices_through_jan_3); ("KEEP", keep_prices) ]
+    ~f:(fun data_dir ->
+      let deps = stale_exit_deps data_dir ~stale_exit_after_days in
+      _submit_market_buy deps ~symbol:"AAPL" ~quantity:10.0;
+      let config =
+        { sample_config with end_date = date_of_string "2024-01-09" }
+      in
+      let sim = Test_helpers.create_exn ~config ~deps in
+      match run sim with
+      | Error err -> failwith ("Run failed: " ^ Status.show err)
+      | Ok result -> f result)
+
+let _aapl_trades result =
+  List.concat_map result.steps ~f:(fun step -> step.trades)
+  |> List.filter ~f:(fun (t : Trading_base.Types.trade) ->
+      String.equal t.symbol "AAPL")
+
+let test_stale_exit_disabled_keeps_position_open _ =
+  (* [stale_exit_after_days = None]: only the entry buy trades; AAPL stays
+     held at its last close (the pre-#1484 behaviour). *)
+  _run_stale_exit ~name:"disabled" ~stale_exit_after_days:None ~f:(fun result ->
+      let aapl_trades = _aapl_trades result in
+      assert_that aapl_trades
+        (elements_are
+           [
+             all_of
+               [
+                 field
+                   (fun (t : Trading_base.Types.trade) -> t.side)
+                   (equal_to (Trading_base.Types.Buy : Trading_base.Types.side));
+                 field
+                   (fun (t : Trading_base.Types.trade) -> t.quantity)
+                   (float_equal 10.0);
+               ];
+           ]);
+      assert_that
+        (Trading_portfolio.Calculations.position_quantity
+           (List.find_exn result.final_portfolio.positions ~f:(fun p ->
+                String.equal p.symbol "AAPL")))
+        (float_equal 10.0))
+
+let test_stale_exit_realizes_sell_at_last_close _ =
+  (* [stale_exit_after_days = Some 2]: AAPL is force-sold at the Jan-3 close
+     (157.0) once its gap reaches 2 days. Exactly one entry Buy + one
+     force-exit Sell; the position is flat at end of run. *)
+  _run_stale_exit ~name:"realizes" ~stale_exit_after_days:(Some 2)
+    ~f:(fun result ->
+      let aapl_trades = _aapl_trades result in
+      assert_that aapl_trades
+        (elements_are
+           [
+             all_of
+               [
+                 field
+                   (fun (t : Trading_base.Types.trade) -> t.side)
+                   (equal_to (Trading_base.Types.Buy : Trading_base.Types.side));
+                 field
+                   (fun (t : Trading_base.Types.trade) -> t.quantity)
+                   (float_equal 10.0);
+               ];
+             all_of
+               [
+                 field
+                   (fun (t : Trading_base.Types.trade) -> t.side)
+                   (equal_to
+                      (Trading_base.Types.Sell : Trading_base.Types.side));
+                 field
+                   (fun (t : Trading_base.Types.trade) -> t.quantity)
+                   (float_equal 10.0);
+                 field
+                   (fun (t : Trading_base.Types.trade) -> t.price)
+                   (float_equal 157.0);
+               ];
+           ]);
+      (* AAPL no longer held after the force-exit. *)
+      assert_that
+        (List.find result.final_portfolio.positions ~f:(fun p ->
+             String.equal p.symbol "AAPL"))
+        is_none)
+
+let test_stale_exit_frees_cash_with_realized_pnl _ =
+  (* The realized force-exit proceeds (10 * 157.0 = 1570, minus commission)
+     return to cash. Entry filled 10 AAPL at the Jan-2 open (150.0). Net AAPL
+     P&L = (157.0 - 150.0) * 10 = +70, less two commissions. The KEEP symbol
+     is never bought, so final cash isolates the AAPL round-trip. *)
+  _run_stale_exit ~name:"frees-cash" ~stale_exit_after_days:(Some 2)
+    ~f:(fun result ->
+      let entry_cost = 10.0 *. 150.0 in
+      let exit_proceeds = 10.0 *. 157.0 in
+      let entry_commission = Float.max (0.01 *. 10.0) 1.0 in
+      let exit_commission = Float.max (0.01 *. 10.0) 1.0 in
+      let expected_cash =
+        10000.0 -. entry_cost -. entry_commission +. exit_proceeds
+        -. exit_commission
+      in
+      assert_that result.final_portfolio.current_cash
+        (float_equal ~epsilon:1e-6 expected_cash))
+
 (* ==================== Win #4 — per-fold universe pruning =============== *)
 
 (** Pure-function pin for the simulator's Win #4 active-through filter.
@@ -964,6 +1113,12 @@ let suite =
          "forward-fill: held symbol with no bar today values at last-known \
           close (PR #916 CP4)"
          >:: test_forward_fill_uses_last_known_close_when_held_symbol_has_no_bar;
+         "stale-exit (#1484): None keeps position open"
+         >:: test_stale_exit_disabled_keeps_position_open;
+         "stale-exit (#1484): Some n realizes sell at last close"
+         >:: test_stale_exit_realizes_sell_at_last_close;
+         "stale-exit (#1484): frees cash with realized PnL"
+         >:: test_stale_exit_frees_cash_with_realized_pnl;
          "step executes market order" >:: test_step_executes_market_order;
          "limit order executes on later day"
          >:: test_limit_order_executes_on_later_day;

--- a/trading/trading/simulation/test/test_stale_hold.ml
+++ b/trading/trading/simulation/test/test_stale_hold.ml
@@ -198,12 +198,96 @@ let test_detect_disabled_returns_no_events _ =
   let adapter =
     _adapter_of_table ~table:[ ("ANDV", _date "2018-09-28", 153.46) ]
   in
-  let config = { Stale_hold.enabled = false; stale_after_days = 5 } in
+  let config =
+    {
+      Stale_hold.enabled = false;
+      stale_after_days = 5;
+      stale_exit_after_days = None;
+    }
+  in
   let events =
     Stale_hold.detect_stale ~adapter ~date:(_date "2018-10-05") ~portfolio
       ~today_bars:[] ~config
   in
   assert_that events (size_is 0)
+
+(* -------------------------------------------------------------------- *)
+(* Force-exit candidate selection                                        *)
+(* -------------------------------------------------------------------- *)
+
+let test_force_exit_disabled_by_default _ =
+  (* Default config has [stale_exit_after_days = None] — no candidates even
+     for a clearly-stale held position. Pins the default-off invariant. *)
+  let portfolio =
+    _portfolio_with_position ~symbol:"ANDV" ~quantity:100.0 ~entry_price:80.0
+      ~entry_date:(_date "2018-06-01")
+  in
+  let adapter =
+    _adapter_of_table ~table:[ ("ANDV", _date "2018-09-28", 153.46) ]
+  in
+  let candidates =
+    Stale_hold.force_exit_candidates ~adapter ~date:(_date "2018-10-05")
+      ~portfolio ~today_bars:[] ~config:Stale_hold.default_config
+  in
+  assert_that candidates (size_is 0)
+
+let test_force_exit_emits_long_candidate_at_last_close _ =
+  (* Symbol last had a bar 7 days ago — past the configured exit threshold of
+     5. One candidate: full (positive) quantity, last close, gap = 7. *)
+  let portfolio =
+    _portfolio_with_position ~symbol:"ANDV" ~quantity:100.0 ~entry_price:80.0
+      ~entry_date:(_date "2018-06-01")
+  in
+  let adapter =
+    _adapter_of_table ~table:[ ("ANDV", _date "2018-09-28", 153.46) ]
+  in
+  let config =
+    { Stale_hold.default_config with stale_exit_after_days = Some 5 }
+  in
+  let candidates =
+    Stale_hold.force_exit_candidates ~adapter ~date:(_date "2018-10-05")
+      ~portfolio ~today_bars:[] ~config
+  in
+  assert_that candidates
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : Stale_hold.force_exit) -> c.symbol)
+               (equal_to "ANDV");
+             field
+               (fun (c : Stale_hold.force_exit) -> c.signed_quantity)
+               (float_equal 100.0);
+             field
+               (fun (c : Stale_hold.force_exit) -> c.last_close)
+               (float_equal 153.46);
+             field
+               (fun (c : Stale_hold.force_exit) -> c.last_bar_date)
+               (equal_to (_date "2018-09-28"));
+             field
+               (fun (c : Stale_hold.force_exit) -> c.days_since_last_bar)
+               (equal_to 7);
+           ];
+       ])
+
+let test_force_exit_skips_recent_gap _ =
+  (* Last bar only 2 days ago — under the Some 5 threshold. No candidate. *)
+  let portfolio =
+    _portfolio_with_position ~symbol:"AAPL" ~quantity:10.0 ~entry_price:100.0
+      ~entry_date:(_date "2024-01-02")
+  in
+  let adapter =
+    _adapter_of_table ~table:[ ("AAPL", _date "2024-01-13", 105.0) ]
+  in
+  let config =
+    { Stale_hold.default_config with stale_exit_after_days = Some 5 }
+  in
+  let candidates =
+    Stale_hold.force_exit_candidates ~adapter ~date:(_date "2024-01-15")
+      ~portfolio ~today_bars:[] ~config
+  in
+  assert_that candidates (size_is 0)
 
 (* -------------------------------------------------------------------- *)
 (* Log + persistence                                                     *)
@@ -289,6 +373,12 @@ let suite =
          >:: test_detect_held_position_with_no_prior_bar_is_dropped;
          "detect: enabled=false suppresses all events"
          >:: test_detect_disabled_returns_no_events;
+         "force_exit: disabled by default (None)"
+         >:: test_force_exit_disabled_by_default;
+         "force_exit: emits long candidate at last close"
+         >:: test_force_exit_emits_long_candidate_at_last_close;
+         "force_exit: skips position with recent gap"
+         >:: test_force_exit_skips_recent_gap;
          "log: events returned in chronological order"
          >:: test_log_records_events_in_chronological_order;
          "log: distinct_symbols dedupes" >:: test_log_distinct_symbols_dedupes;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -405,6 +405,13 @@ type config = {
           [enable_macro_bearish_exposure_trim = true]; default [0.70] mirrors
           the normal long-exposure cap (a no-op cap). See
           [Weinstein_strategy_config]. *)
+  stale_exit_after_days : int option; [@sexp.default None]
+      (** [Some n] force-sells a stale/delisted held position at its last close
+          after an [n]-day bar gap, as a realised trade — instead of carrying it
+          open at a stale mark indefinitely (issue #1484). [None] (default) is a
+          no-op (detector-only, byte-identical to pre-#1484). Threaded into the
+          simulator's [Trading_simulation.Stale_hold.config]. Searchable as a
+          [Variant_matrix] flag axis. See [Weinstein_strategy_config]. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -100,6 +100,10 @@ type config = {
       [@sexp.default macro_bearish_no_op_cap]
       (** Fraction of portfolio value the trim caps held long exposure at on a
           Bearish tape; default [0.70] is a no-op cap. See [.mli]. *)
+  stale_exit_after_days : int option; [@sexp.default None]
+      (** [Some n] force-sells a stale/delisted held position at its last close
+          after an [n]-day bar gap; default [None] is a no-op (#1484). Threaded
+          into the simulator's [Stale_hold.config]. See [.mli]. *)
 }
 [@@deriving sexp]
 
@@ -138,6 +142,7 @@ let default_config ~universe ~index_symbol =
     late_stage2_stop_buffer_pct = 0.0;
     enable_macro_bearish_exposure_trim = false;
     macro_bearish_max_long_exposure_pct = macro_bearish_no_op_cap;
+    stale_exit_after_days = None;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -170,6 +170,16 @@ type config = {
           the normal long-exposure cap, so even with the flag flipped on the
           value defaults to a no-op cap — only a tighter value changes
           behaviour. See {!Macro_bearish_trim_runner}. *)
+  stale_exit_after_days : int option; [@sexp.default None]
+      (** When [Some n], a held position whose underlying symbol has stopped
+          emitting bars for [n] calendar days is force-sold at its last
+          available close as a realised trade (instead of being carried open at
+          a stale mark indefinitely and counted in terminal NAV — issue #1484).
+          The runner threads this into the simulator's
+          [Trading_simulation.Stale_hold.config.stale_exit_after_days]. Default
+          [None] keeps every existing backtest byte-identical (detector still
+          records stale holds; no force-exit). Searchable as a [Variant_matrix]
+          flag axis ([((flag stale_exit_after_days) (values (() (5))))]). *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for


### PR DESCRIPTION
## What

Fixes #1484 — stale/delisted open positions never exit. Adds a **default-off**
force-exit to the backtest/simulation pipeline.

`Trading_simulation.Stale_hold` was a **detector only**: when a held position's
underlying symbol stops emitting bars it records a `Stale_hold.event` but emits
no exit. A delisted/halted position was therefore carried open indefinitely,
marked at its last available close, and counted in terminal NAV — inflating it
(8 of 9 terminal open positions in a top-3000 PIT 15y run were such zombies; see
`dev/notes/p0-verify-broad-universe-790-2026-06-08.md` §3, e.g. CPKI last bar
2011-07-07 still "held" at backtest end 2026-04-30).

## How

Config plumbing (all default-off, per `.claude/rules/experiment-flag-discipline.md`):

- `Stale_hold.config` gains `stale_exit_after_days : int option`
  (`[@sexp.default None]`) + a pure `force_exit_candidates` helper that selects
  held positions whose bar gap ≥ n (signed quantity, last close).
- `Weinstein_strategy.config` gains the same field — a real config field, so it
  resolves through `Overlay_validator` and is expressible as a `Variant_matrix`
  flag axis (R2).
- `Backtest.Panel_runner._make_simulator` is the bridge: builds the simulator's
  `Stale_hold.config` from the resolved strategy config and passes
  `~stale_hold_policy`.

Force-exit application — new strategy-agnostic `Stale_exit_runner` module
(mirrors `Margin_runner`), called from `Simulator._prepare_market_state`:

- builds a synthetic market trade at the last close (long → Sell, short → Buy)
  with the engine's `max(per_share*qty, minimum)` commission;
- applies it to the portfolio (`apply_single_trade`) → **realised** PnL, freed
  cash;
- drives the matching Holding `Position.t` through Exiting → Closed and drops it;
- the trade is merged into the step's `trades` → lands in `trades.csv` /
  realised PnL, not a perpetual open mark.

Runs only on bar-bearing days (matching the detector's false-positive guard). A
routed `TriggerExit` (the `Margin_runner` path) can't be used here because the
symbol has **no bar today** — the engine can't fill an order against absent
market data, so the exit is applied directly at the last close.

`Stale_exit_runner` was extracted (rather than inlined into `simulator.ml`) to
keep `simulator.ml` under the 500-line hard limit per
`.claude/rules/code-health-discipline.md`.

## Default-off invariant

With the field `None` everywhere, `force_exit_candidates` returns `[]` and the
new branch is never entered → byte-identical to pre-#1484. Confirmed by the full
golden suite (`dune runtest`) staying green and the existing `Stale_hold`
detector tests unchanged.

## Test plan

`dune build && dune runtest` (green, zero warnings) + `dune build @fmt`.

- `test_stale_hold.ml`: `force_exit_candidates` returns the long position at its
  last close when `Some 5` and gap ≥ 5; `[]` when `None`; `[]` for a recent gap.
- `test_simulator.ml` (e2e): delisted symbol held with `stale_exit_after_days =
  Some 2` → exactly one realised Sell at the last close (157.0), flat thereafter,
  freed cash; `None` → no exit, position stays open marked at last close; exit
  PnL realised = (last_close − avg_cost) × qty.

Plan: `dev/plans/stale-position-force-exit-2026-06-08.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
