### PR TITLE
feat(walk-forward): --snapshot-dir for N>=1000 WF-CV

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -1,11 +1,41 @@
 # Status: backtest-perf
 
-## Last updated: 2026-06-08
+## Last updated: 2026-06-09
 
 ## Status
 IN_PROGRESS
 
-### Recent activity (2026-06-08)
+### Recent activity (2026-06-09)
+
+- **[x] `walk_forward_runner.exe --snapshot-dir`** (branch
+  `feat/backtest-wf-snapshot`). Threads a `Backtest.Bar_data_source.t`
+  through `Walk_forward.Walk_forward_executor` into every fold's
+  `Backtest.Runner.run_backtest`, so broad-universe (N≥1000) WF-CV can
+  read OHLCV from a pre-built snapshot warehouse instead of building the
+  whole universe's bars in-process from CSV (superlinear / OOMs at
+  N≥1000 per `feedback_large_n_needs_snapshot_mode`). Default-off:
+  omitting the flag is byte-identical to the prior CSV path. Unblocks
+  the broad-PIT WF-CV experiment agenda.
+  - Surface:
+    - `walk_forward_executor.{ml,mli}` — `execute_spec` gains
+      `?bar_data_source:Backtest.Bar_data_source.t`, threaded down
+      through `_run_one` → `_extract_fold` → `run_backtest` (the
+      `[@inline never]` + `Gc.compact` memory discipline kept intact).
+    - `bin/walk_forward_runner.ml` — `--snapshot-dir <path>` flag,
+      resolved via the shared `Scenario_lib.Bar_source_resolver.resolve`
+      (same resolver `rolling_start_eval` / `scenario_runner` use; reads
+      `<dir>/manifest.sexp`, exits non-zero on a missing/corrupt
+      manifest at parse time).
+  - Tests:
+    `trading/trading/backtest/walk_forward/test/test_walk_forward_snapshot_parity.ml`
+    — (1) end-to-end snapshot-vs-CSV parity: same synthetic OHLCV stream
+    built into both a CSV dir (via `TRADING_DATA_DIR`) and a snapshot dir
+    over `Backtest.Runner.all_snapshot_symbols`, a 2-fold WF run in each
+    mode yields byte-identical `aggregate` + `fold_actuals`; (2) flag-off
+    backward-compat: `?bar_data_source:None` is byte-identical to omitting
+    it at the executor seam.
+  - Verify:
+    `dune exec trading/backtest/walk_forward/test/test_walk_forward_snapshot_parity.exe`.
 
 - **[x] P3 — time-underwater + antifragility convexity prototypes**
   (branch `feat/rolling-start-time-underwater`). P3 ("prototype, hold

--- a/trading/trading/backtest/walk_forward/bin/walk_forward_runner.ml
+++ b/trading/trading/backtest/walk_forward/bin/walk_forward_runner.ml
@@ -16,8 +16,16 @@
     {v
       walk_forward_runner.exe --spec <spec.sexp> --out-dir <dir>
                               [--fixtures-root <path>]
-                              [--parallel N]    (default 1, max 16)
+                              [--parallel N]          (default 1, max 16)
+                              [--snapshot-dir <path>] (default: CSV bars)
     v}
+
+    [--snapshot-dir], when given, points every fold's backtest at a pre-built
+    snapshot warehouse (via {!Scenario_lib.Bar_source_resolver}) instead of the
+    default CSV bar store. This is what makes broad-universe (N >= 1000) WF-CV
+    tractable: CSV mode is superlinear and OOMs at N >= 1000, whereas snapshot
+    mode reads streamed bars at bounded RSS. With the flag omitted, behaviour is
+    byte-identical to the pre-snapshot CSV path.
 
     This binary is the integration seam for Phase 3: the Bayesian optimizer
     consumes the same harness with variant-overrides chosen by the BO loop
@@ -28,6 +36,7 @@
 open Core
 module Scenario = Scenario_lib.Scenario
 module Fixtures_root = Scenario_lib.Fixtures_root
+module Bar_source_resolver = Scenario_lib.Bar_source_resolver
 module WS = Walk_forward.Window_spec
 module Report = Walk_forward.Walk_forward_report
 module Spec = Walk_forward.Spec
@@ -44,11 +53,12 @@ type cli_args = {
   out_dir : string;
   fixtures_root : string option;
   parallel : int;
+  snapshot_dir : string option;
 }
 
 let _usage_msg =
   "Usage: walk_forward_runner.exe --spec <spec.sexp> --out-dir <dir> \
-   [--fixtures-root <path>] [--parallel N]"
+   [--fixtures-root <path>] [--parallel N] [--snapshot-dir <path>]"
 
 (** Parse and validate the [--parallel N] flag at CLI time. Out-of-range values
     would otherwise surface from inside [Fork_pool.run_parallel] as an
@@ -70,7 +80,7 @@ let _parse_parallel raw =
   n
 
 let _parse_args argv =
-  let rec loop spec out fixtures parallel = function
+  let rec loop spec out fixtures parallel snapshot = function
     | [] -> (
         match (spec, out) with
         | Some s, Some o ->
@@ -79,15 +89,20 @@ let _parse_args argv =
               out_dir = o;
               fixtures_root = fixtures;
               parallel = Option.value parallel ~default:_default_parallel;
+              snapshot_dir = snapshot;
             }
         | _ ->
             eprintf "%s\n" _usage_msg;
             Stdlib.exit 1)
-    | "--spec" :: p :: rest -> loop (Some p) out fixtures parallel rest
-    | "--out-dir" :: p :: rest -> loop spec (Some p) fixtures parallel rest
-    | "--fixtures-root" :: p :: rest -> loop spec out (Some p) parallel rest
+    | "--spec" :: p :: rest -> loop (Some p) out fixtures parallel snapshot rest
+    | "--out-dir" :: p :: rest ->
+        loop spec (Some p) fixtures parallel snapshot rest
+    | "--fixtures-root" :: p :: rest ->
+        loop spec out (Some p) parallel snapshot rest
     | "--parallel" :: n :: rest ->
-        loop spec out fixtures (Some (_parse_parallel n)) rest
+        loop spec out fixtures (Some (_parse_parallel n)) snapshot rest
+    | "--snapshot-dir" :: p :: rest ->
+        loop spec out fixtures parallel (Some p) rest
     | ("--help" | "-h") :: _ ->
         printf "%s\n" _usage_msg;
         Stdlib.exit 0
@@ -95,7 +110,7 @@ let _parse_args argv =
         eprintf "Error: unknown argument %S\n%s\n" unknown _usage_msg;
         Stdlib.exit 1
   in
-  loop None None None None argv
+  loop None None None None None argv
 
 (* -------------- output writers -------------- *)
 
@@ -140,16 +155,19 @@ let _main () =
     Fixtures_root.resolve ?fixtures_root:args.fixtures_root ()
   in
   let base = Scenario.load spec.base_scenario in
+  let bar_data_source = Bar_source_resolver.resolve args.snapshot_dir in
   eprintf
-    "[walk_forward] spec=%s base=%s baseline=%s variants=%d folds=%d parallel=%d\n\
+    "[walk_forward] spec=%s base=%s baseline=%s variants=%d folds=%d \
+     parallel=%d bars=%s\n\
      %!"
     args.spec_path spec.base_scenario spec.baseline_label
     (List.length spec.variants)
     (List.length (WS.generate spec.window_spec))
-    args.parallel;
+    args.parallel
+    (match args.snapshot_dir with Some d -> "snapshot:" ^ d | None -> "csv");
   let result =
     Executor.execute_spec ~base ~spec ~fixtures_root ~progress:_stderr_progress
-      ~parallel:args.parallel ()
+      ~parallel:args.parallel ?bar_data_source ()
   in
   _write_fold_actuals ~out_dir:args.out_dir result.fold_actuals;
   _write_report ~out_dir:args.out_dir ~spec result.fold_actuals;

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_executor.ml
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_executor.ml
@@ -36,8 +36,8 @@ let _test_days (period : Scenario.period) =
     back into {!_run_one}, which would keep [result] live as a stack root across
     the [Gc.compact] call. See
     [dev/notes/bayesian-int-rounding-bug-2026-05-19.md]. *)
-let[@inline never] _extract_fold ~fixtures_root (s : Scenario.t) :
-    Report.fold_actual =
+let[@inline never] _extract_fold ~fixtures_root ~bar_data_source
+    (s : Scenario.t) : Report.fold_actual =
   let resolved = Filename.concat fixtures_root s.universe_path in
   let sector_map_override =
     Universe_file.to_sector_map_override (Universe_file.load resolved)
@@ -46,7 +46,7 @@ let[@inline never] _extract_fold ~fixtures_root (s : Scenario.t) :
     Backtest.Runner.run_backtest ~start_date:s.period.start_date
       ~end_date:s.period.end_date ~overrides:s.config_overrides
       ?sector_map_override ~strategy_choice:s.strategy
-      ?slippage_bps:s.slippage_bps ()
+      ?slippage_bps:s.slippage_bps ?bar_data_source ()
   in
   let summary = result.summary in
   let get k = Map.find summary.metrics k |> Option.value ~default:Float.nan in
@@ -67,8 +67,9 @@ let[@inline never] _extract_fold ~fixtures_root (s : Scenario.t) :
     avg_holding_days = get AvgHoldingDays;
   }
 
-let _run_one ~fixtures_root (s : Scenario.t) : Report.fold_actual =
-  let fold = _extract_fold ~fixtures_root s in
+let _run_one ~fixtures_root ~bar_data_source (s : Scenario.t) :
+    Report.fold_actual =
+  let fold = _extract_fold ~fixtures_root ~bar_data_source s in
   (* Partial bandaid for cumulative-state OOM (2026-05-19): each
      [Backtest.Runner.run_backtest] call leaks ~90 MB to the OCaml major
      heap. Forcing [Gc.compact] here reduces that to ~25 MB/backtest by
@@ -148,9 +149,12 @@ let _evaluate_all ~run_one ~base ~(spec : Spec.t) ~progress ~parallel =
   Array.to_list results
 
 let execute_spec ~base ~(spec : Spec.t) ~fixtures_root
-    ?(progress = noop_progress) ?(parallel = 1) ?run_one () : result =
+    ?(progress = noop_progress) ?(parallel = 1) ?bar_data_source ?run_one () :
+    result =
   let run_one =
-    match run_one with Some f -> f | None -> _run_one ~fixtures_root
+    match run_one with
+    | Some f -> f
+    | None -> _run_one ~fixtures_root ~bar_data_source
   in
   let fold_actuals = _evaluate_all ~run_one ~base ~spec ~progress ~parallel in
   let aggregate =

--- a/trading/trading/backtest/walk_forward/lib/walk_forward_executor.mli
+++ b/trading/trading/backtest/walk_forward/lib/walk_forward_executor.mli
@@ -62,11 +62,12 @@ val execute_spec :
   fixtures_root:string ->
   ?progress:progress_callback ->
   ?parallel:int ->
+  ?bar_data_source:Backtest.Bar_data_source.t ->
   ?run_one:fold_runner ->
   unit ->
   result
-(** [execute_spec ~base ~spec ~fixtures_root ?progress ?parallel ?run_one ()]
-    runs the full walk-forward CV grid:
+(** [execute_spec ~base ~spec ~fixtures_root ?progress ?parallel
+     ?bar_data_source ?run_one ()] runs the full walk-forward CV grid:
 
     + For each [variant] in [spec.variants] (outer loop), and for each [fold] in
       [Window_spec.generate spec.window_spec] (inner loop):
@@ -94,6 +95,17 @@ val execute_spec :
     runs in a forked child; the parent reassembles results in canonical (variant
     outer, fold inner) order, so {!Walk_forward_report.compute} sees a
     byte-identical input list regardless of [parallel]. See plan #1197 §7 PR-2.
+
+    [?bar_data_source] selects the OHLCV backend each fold's
+    {!Backtest.Runner.run_backtest} reads from. Omitted (the default) leaves
+    [run_backtest] on [Bar_data_source.Csv] — byte-identical to the pre-snapshot
+    behaviour. Pass [Some (Snapshot {...})] (resolved from a [--snapshot-dir]
+    via {!Scenario_lib.Bar_source_resolver.resolve}) to read from a pre-built
+    snapshot warehouse instead; this is the only tractable backend for
+    broad-universe (N >= 1000) WF-CV, where CSV mode is superlinear and OOMs.
+    Snapshot is purely a faster bar backend — per-fold metrics are identical to
+    CSV mode on the same input bars. Ignored when [?run_one] is supplied (the
+    test stub bypasses the real backtest).
 
     [?run_one] (default {!Backtest.Runner.run_backtest}-backed) is a test seam
     for substituting a deterministic per-scenario evaluator. Production callers

--- a/trading/trading/backtest/walk_forward/test/dune
+++ b/trading/trading/backtest/walk_forward/test/dune
@@ -5,6 +5,7 @@
   test_walk_forward_runner
   test_walk_forward_report
   test_walk_forward_executor_parallel
+  test_walk_forward_snapshot_parity
   test_spec
   test_variant_matrix
   test_variant_ranking
@@ -12,12 +13,18 @@
  (libraries
   ounit2
   core
+  core_unix
+  core_unix.filename_unix
   matchers
   backtest
   backtest_cost_model
   fork_pool
   scenario_lib
-  walk_forward)
+  walk_forward
+  weinstein.snapshot_pipeline
+  trading.data_panel.snapshot
+  types
+  status)
  (preprocess
   (pps ppx_sexp_conv))
  (deps

--- a/trading/trading/backtest/walk_forward/test/test_walk_forward_snapshot_parity.ml
+++ b/trading/trading/backtest/walk_forward/test/test_walk_forward_snapshot_parity.ml
@@ -1,0 +1,312 @@
+(** Walk-forward snapshot-mode parity gate.
+
+    [walk_forward_runner.exe --snapshot-dir] threads a
+    [Backtest.Bar_data_source.t] through {!Walk_forward.Walk_forward_executor}
+    into every fold's {!Backtest.Runner.run_backtest}, so broad-universe (N >=
+    1000) WF-CV can read OHLCV from a pre-built snapshot warehouse instead of
+    building the whole universe's bars in-process from CSVs (the latter is
+    superlinear and OOMs at N >= 1000). Snapshot is purely a faster bar backend:
+    on the same input bars it must produce per-fold metrics identical to CSV
+    mode.
+
+    Two properties are pinned here:
+
+    + {b End-to-end parity.} Build the same synthetic OHLCV stream into BOTH a
+      CSV directory (pointed at via [TRADING_DATA_DIR]) and a snapshot
+      directory, then run the same 2-fold walk-forward spec in CSV mode (no bar
+      source) and snapshot mode ([Some (Snapshot {...})]). The two runs'
+      [aggregate] and [fold_actuals] must be byte-identical (sexp round-trip
+      preserves IEEE 754 bit patterns). The synthetic stream covers every symbol
+      a default run reads — universe + index + SPDR ETFs + global indices, via
+      {!Backtest.Runner.all_snapshot_symbols} — so neither mode degenerates on a
+      missing macro column.
+
+    + {b Flag-off backward-compat.} At the {!Walk_forward.Walk_forward_executor}
+      seam, passing [?bar_data_source:None] explicitly is byte-identical to
+      omitting it. Pins that adding the optional argument did not change the CSV
+      default path. Exercised with a deterministic stub runner so it needs no
+      backtest. *)
+
+open OUnit2
+open Core
+open Matchers
+module Executor = Walk_forward.Walk_forward_executor
+module Spec = Walk_forward.Spec
+module WS = Walk_forward.Window_spec
+module WFR = Walk_forward.Walk_forward_runner
+module Report = Walk_forward.Walk_forward_report
+module Fold_gate = Walk_forward.Fold_gate
+module Scenario = Scenario_lib.Scenario
+module Bar_data_source = Backtest.Bar_data_source
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Pipeline = Snapshot_pipeline.Pipeline
+
+(* ---- Test tunables (named so the magic-number linter sees no surprises) ---- *)
+
+let _baseline_label = "baseline"
+let _universe_symbols = [ "AAPL"; "MSFT"; "JPM" ]
+let _fixture_n_days = 420
+
+(* ---- Date helpers ------------------------------------------------- *)
+
+let _ymd y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+let _fixture_start = _ymd 2020 1 2
+
+(* ---- Synthetic OHLCV fixtures ------------------------------------- *)
+
+(* Deterministic per-(symbol, day_index) bars: a gentle uptrend with a small
+   per-symbol offset. Identical generation for both the CSV and snapshot writers
+   so any drift is a backend mismatch, not a data mismatch. Volumes stay well
+   under 2^53 so the float round-trip is exact. *)
+let _make_bar ~symbol ~day_index : Types.Daily_price.t =
+  let date = Date.add_days _fixture_start day_index in
+  let base = 100.0 +. (Float.of_int (String.hash symbol mod 40) *. 0.25) in
+  let drift = Float.of_int day_index *. 0.05 in
+  let close = base +. drift in
+  {
+    date;
+    open_price = close -. 0.10;
+    high_price = close +. 0.20;
+    low_price = close -. 0.30;
+    close_price = close;
+    volume = 1_000_000 + (day_index * 1000);
+    adjusted_close = close;
+    active_through = None;
+  }
+
+let _bars_for ~symbol =
+  List.init _fixture_n_days ~f:(fun i -> _make_bar ~symbol ~day_index:i)
+
+let _make_tmp_dir prefix = Filename_unix.temp_dir ~in_dir:"/tmp" prefix ""
+
+(* CSV writer: emits the canonical 7-column schema [Csv_storage] reads, in the
+   nested data_dir/<F>/<L>/<SYM>/data.csv layout the CSV [Market_data_adapter]
+   expects. [%.17g] is round-trip-exact for IEEE 754 doubles so the CSV-read
+   bars equal the snapshot-carried bars bit-for-bit. *)
+let _write_csv_dir ~data_dir bars_by_symbol =
+  List.iter bars_by_symbol ~f:(fun (symbol, bars) ->
+      let f = String.sub symbol ~pos:0 ~len:1 in
+      let l = String.sub symbol ~pos:(String.length symbol - 1) ~len:1 in
+      let dir = Filename.of_parts [ data_dir; f; l; symbol ] in
+      Core_unix.mkdir_p dir;
+      let path = Filename.concat dir "data.csv" in
+      Out_channel.with_file path ~f:(fun oc ->
+          Out_channel.output_string oc
+            "date,open,high,low,close,adjusted_close,volume\n";
+          List.iter bars ~f:(fun (b : Types.Daily_price.t) ->
+              Out_channel.output_string oc
+                (sprintf "%s,%.17g,%.17g,%.17g,%.17g,%.17g,%d\n"
+                   (Date.to_string b.date) b.open_price b.high_price b.low_price
+                   b.close_price b.adjusted_close b.volume))))
+
+(* Snapshot writer: one [.snap] per symbol via the Phase B pipeline + Phase A
+   file format, plus the directory manifest (returned for the test to hand to
+   [Bar_data_source.Snapshot]). *)
+let _write_snapshot_dir ~snapshot_dir bars_by_symbol =
+  let schema = Snapshot_schema.default in
+  let entries =
+    List.map bars_by_symbol ~f:(fun (symbol, bars) ->
+        let rows =
+          match Pipeline.build_for_symbol ~symbol ~bars ~schema () with
+          | Ok r -> r
+          | Error err ->
+              assert_failure ("Pipeline.build_for_symbol: " ^ Status.show err)
+        in
+        let path = Filename.concat snapshot_dir (symbol ^ ".snap") in
+        (match Snapshot_format.write ~path rows with
+        | Ok () -> ()
+        | Error err ->
+            assert_failure ("Snapshot_format.write: " ^ Status.show err));
+        let stat = Core_unix.stat path in
+        ({
+           symbol;
+           path;
+           byte_size = Int64.to_int_exn stat.st_size;
+           payload_md5 = "ignored";
+           csv_mtime = stat.st_mtime;
+           active_through = None;
+         }
+          : Snapshot_manifest.file_metadata))
+  in
+  Snapshot_manifest.create ~schema ~entries
+
+(* Build BOTH a CSV directory and a snapshot directory from the same synthetic
+   bar stream, covering every symbol a default Weinstein run reads (universe +
+   index + ETFs + global indices). Returns [(data_dir, snapshot_dir, manifest)].
+*)
+let _setup_dual_fixtures () =
+  let symbols =
+    Backtest.Runner.all_snapshot_symbols ~universe:_universe_symbols
+  in
+  let data_dir = _make_tmp_dir "wf_parity_csv_" in
+  let snapshot_dir = _make_tmp_dir "wf_parity_snap_" in
+  let bars_by_symbol =
+    List.map symbols ~f:(fun s -> (s, _bars_for ~symbol:s))
+  in
+  _write_csv_dir ~data_dir bars_by_symbol;
+  let manifest = _write_snapshot_dir ~snapshot_dir bars_by_symbol in
+  (data_dir, snapshot_dir, manifest)
+
+(* ---- Universe file + scenario ------------------------------------- *)
+
+(* Write a [Pinned] universe sexp under the fixtures root and return the path
+   relative to that root (what [Scenario.universe_path] holds). Each symbol maps
+   to its own sector so [to_sector_map_override] yields exactly these keys as the
+   backtest universe (bypassing [Sector_map.load]). *)
+let _write_universe ~fixtures_root : string =
+  let rel = Filename.of_parts [ "universes"; "wf-parity.sexp" ] in
+  let abs = Filename.concat fixtures_root rel in
+  Core_unix.mkdir_p (Filename.dirname abs);
+  let entries =
+    List.map _universe_symbols ~f:(fun s ->
+        sprintf "((symbol %s) (sector %s))" s s)
+    |> String.concat ~sep:" "
+  in
+  Out_channel.write_all abs ~data:(sprintf "(Pinned (%s))" entries);
+  rel
+
+let _wide_expected : Scenario.expected =
+  {
+    total_return_pct = { min_f = -100.0; max_f = 1000.0 };
+    total_trades = { min_f = 0.0; max_f = 10000.0 };
+    win_rate = { min_f = 0.0; max_f = 100.0 };
+    sharpe_ratio = { min_f = -5.0; max_f = 5.0 };
+    max_drawdown_pct = { min_f = 0.0; max_f = 100.0 };
+    avg_holding_days = { min_f = 0.0; max_f = 1000.0 };
+    open_positions_value = None;
+    unrealized_pnl = None;
+    sortino_ratio_annualized = None;
+    calmar_ratio = None;
+    ulcer_index = None;
+    wall_seconds = None;
+  }
+
+let _make_base ~universe_path : Scenario.t =
+  {
+    name = "wf-parity-base";
+    description = "synthetic dual-fixture base scenario";
+    period = { start_date = _fixture_start; end_date = _ymd 2021 1 1 };
+    universe_path;
+    config_overrides = [];
+    strategy = Backtest.Strategy_choice.default;
+    slippage_bps = None;
+    cost_model = None;
+    expected = _wide_expected;
+  }
+
+(* Two adjacent test folds inside the fixture window. [Explicit] folds keep the
+   test independent of the rolling generator's arithmetic. The single
+   [baseline] variant runs each fold once — exactly what we compare across
+   backends. *)
+let _make_spec : Spec.t =
+  let folds : WS.explicit_fold list =
+    [
+      {
+        name = "fold-000";
+        train_period = None;
+        test_period = { start_date = _ymd 2020 4 1; end_date = _ymd 2020 8 1 };
+      };
+      {
+        name = "fold-001";
+        train_period = None;
+        test_period = { start_date = _ymd 2020 8 1; end_date = _ymd 2020 12 1 };
+      };
+    ]
+  in
+  {
+    base_scenario = "wf-parity-base";
+    window_spec = WS.Explicit folds;
+    variants = [ { WFR.label = _baseline_label; overrides = [] } ];
+    baseline_label = _baseline_label;
+    gate = { metric = Fold_gate.Sharpe; m = 1; n = 2; worst_delta = 1.0 };
+  }
+
+(* ---- §1 End-to-end snapshot/CSV parity ---------------------------- *)
+
+let _run_mode ~fixtures_root ~base ?bar_data_source () : Executor.result =
+  Executor.execute_spec ~base ~spec:_make_spec ~fixtures_root ~parallel:1
+    ?bar_data_source ()
+
+(* CSV mode reads bars from [TRADING_DATA_DIR]. Point it at [data_dir] for the
+   duration of [f], then restore the prior value so OUnit's end-of-test
+   environment-stability guard does not flag the mutation. *)
+let _with_data_dir data_dir ~f =
+  let key = "TRADING_DATA_DIR" in
+  let prior = Sys.getenv key in
+  Core_unix.putenv ~key ~data:data_dir;
+  Exn.protect ~f ~finally:(fun () ->
+      match prior with
+      | Some v -> Core_unix.putenv ~key ~data:v
+      | None -> Core_unix.unsetenv key)
+
+let test_snapshot_csv_aggregate_parity _ =
+  let data_dir, snapshot_dir, manifest = _setup_dual_fixtures () in
+  let fixtures_root = _make_tmp_dir "wf_parity_fixtures_" in
+  let universe_path = _write_universe ~fixtures_root in
+  let base = _make_base ~universe_path in
+  let csv_sexp, snap_sexp =
+    _with_data_dir data_dir ~f:(fun () ->
+        let csv_result = _run_mode ~fixtures_root ~base () in
+        let snap_result =
+          _run_mode ~fixtures_root ~base
+            ~bar_data_source:
+              (Bar_data_source.Snapshot { snapshot_dir; manifest })
+            ()
+        in
+        let to_sexp (r : Executor.result) =
+          ( Report.sexp_of_aggregate r.aggregate,
+            Sexp.List (List.map r.fold_actuals ~f:Report.sexp_of_fold_actual) )
+        in
+        (to_sexp csv_result, to_sexp snap_result))
+  in
+  (* Aggregate AND fold_actuals must be byte-identical: snapshot is just a
+     faster bar backend over the same series. *)
+  assert_that (snd snap_sexp) (equal_to (snd csv_sexp));
+  assert_that (fst snap_sexp) (equal_to (fst csv_sexp))
+
+(* ---- §2 Flag-off backward-compat (executor seam, no backtest) ----- *)
+
+(** Deterministic stub: maps a scenario name to a fixed [fold_actual] so the
+    flag-off comparison runs in milliseconds without a real backtest. The stub
+    ignores [?bar_data_source] entirely (production wiring captures it; the stub
+    seam does not), which is exactly the contract we pin: at this seam, omitting
+    vs. explicitly passing [None] must be identical. *)
+let _stub_runner (s : Scenario.t) : Report.fold_actual =
+  let f = Float.of_int (String.hash s.name mod 1000) in
+  {
+    fold_name = "";
+    variant_label = "";
+    total_return_pct = f;
+    sharpe_ratio = f /. 100.0;
+    max_drawdown_pct = (f /. 10.0) +. 1.0;
+    calmar_ratio = (f /. 50.0) +. 0.1;
+    cagr_pct = (f /. 2.0) +. 0.5;
+    avg_holding_days = (f /. 5.0) +. 7.0;
+  }
+
+let _stub_aggregate ?bar_data_source () : Sexp.t =
+  let base = _make_base ~universe_path:"unused-by-stub" in
+  let result =
+    Executor.execute_spec ~base ~spec:_make_spec
+      ~fixtures_root:"/tmp/unused-by-stub" ~parallel:1 ?bar_data_source
+      ~run_one:_stub_runner ()
+  in
+  Report.sexp_of_aggregate result.aggregate
+
+let test_flag_off_is_byte_identical_to_none _ =
+  let omitted = _stub_aggregate () in
+  let explicit_none = _stub_aggregate ?bar_data_source:None () in
+  assert_that explicit_none (equal_to omitted)
+
+let suite =
+  "Walk_forward_snapshot_parity"
+  >::: [
+         "test_snapshot_csv_aggregate_parity"
+         >:: test_snapshot_csv_aggregate_parity;
+         "test_flag_off_is_byte_identical_to_none"
+         >:: test_flag_off_is_byte_identical_to_none;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

Adds `--snapshot-dir` to `walk_forward_runner.exe`, threading a
`Backtest.Bar_data_source.t` through `Walk_forward.Walk_forward_executor`
into every fold's `Backtest.Runner.run_backtest`. This makes broad-universe
(N≥1000) walk-forward CV tractable: CSV mode is superlinear and OOMs at N≥1000
(`feedback_large_n_needs_snapshot_mode`), so WF-CV on top-3000 PIT was previously
impossible. Snapshot mode reads OHLCV from a pre-built warehouse at bounded RSS.

**Default-off.** Omitting `--snapshot-dir` is byte-identical to the prior CSV path.

## Why

Infrastructure that unblocks the broad-PIT WF-CV experiment agenda. The executor
previously called `run_backtest` without `?bar_data_source`, so every fold used
the default `Bar_data_source.Csv` regardless of universe size.

## How

- **`walk_forward_executor.{ml,mli}`** — `execute_spec` gains
  `?bar_data_source:Backtest.Bar_data_source.t`, threaded down through
  `_run_one` → `_extract_fold` → `run_backtest`. The `[@inline never]` +
  `Gc.compact` memory discipline is kept intact.
- **`bin/walk_forward_runner.ml`** — `--snapshot-dir <path>` flag parsed
  alongside the existing flags, resolved via the shared
  `Scenario_lib.Bar_source_resolver.resolve` (the same resolver
  `rolling_start_eval` and `scenario_runner` use; reads `<dir>/manifest.sexp`,
  exits non-zero on a missing/corrupt manifest at parse time).

No dune dependency changes were needed for lib/bin — `walk_forward` already
depends on `scenario_lib` + `backtest`.

## Test plan

New `test_walk_forward_snapshot_parity.ml`:

1. **End-to-end snapshot/CSV parity** (the key test) — build the same synthetic
   OHLCV stream into both a CSV dir (pointed at via `TRADING_DATA_DIR`) and a
   snapshot dir over `Backtest.Runner.all_snapshot_symbols` (universe + index +
   SPDR ETFs + global indices), then run a 2-fold WF spec in CSV mode and
   snapshot mode. The two runs' `aggregate` and `fold_actuals` are byte-identical.
2. **Flag-off backward-compat** — at the executor seam, `?bar_data_source:None`
   is byte-identical to omitting it.

`dune build @fmt && dune build && dune runtest` all green (full suite, linters
included). Verify the new test alone:
`dune exec trading/backtest/walk_forward/test/test_walk_forward_snapshot_parity.exe`.

## Notes

- One concern per PR; no `dev/status/_index.md` change. Status recorded in
  `dev/status/backtest-perf.md`.
- Pure infra / harness PR — no domain-logic change; the Weinstein spine is
  untouched (this only swaps the bar backend each fold reads from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)