### PR TITLE
feat(stage): default-off Stage-2 MA-hold to stop pullback S3 oscillation

### DIFF
--- a/trading/analysis/scripts/stage_chart/bin/stage_chart.ml
+++ b/trading/analysis/scripts/stage_chart/bin/stage_chart.ml
@@ -4,7 +4,12 @@ module Mat = Owl.Dense.Matrix.D
 
 (* Render a symbol's weekly close coloured by its programmatic Weinstein stage,
    overlaid on the 30-week MA, so the classifier can be eyeballed against the
-   chart. Usage: stage_chart <SYMBOL> <START> <END> <DATA_DIR> <OUT.png> *)
+   chart. Usage:
+     stage_chart <SYMBOL> <START> <END> <DATA_DIR> <OUT.png> [stage2_ma_hold]
+   The optional 6th arg, when set to "true"/"1"/"on", enables the default-off
+   [Stage.enable_stage2_ma_hold] refinement (holds a Stage-2 pullback that keeps
+   the MA, instead of demoting it to Stage 3) so the before/after stage churn
+   can be compared from the emitted .csv (the [stage] column). *)
 
 let stage_rgb = function
   | Weinstein_types.Stage1 _ -> (40, 90, 220) (* blue: basing *)
@@ -64,9 +69,9 @@ let load_weekly ~data_dir ~symbol ~end_date =
 
 (* Rolling stage classification: per week, classify the prefix [0..i] threading
    the prior stage. Returns (stage option array, MA-value array). *)
-let classify_series arr =
+let classify_series ?(enable_stage2_ma_hold = false) arr =
   let n = Array.length arr in
-  let cfg = Stage.default_config in
+  let cfg = { Stage.default_config with Stage.enable_stage2_ma_hold } in
   let stages = Array.create ~len:n None in
   let mas = Array.create ~len:n Float.nan in
   let prior = ref None in
@@ -114,13 +119,20 @@ let () =
   let end_date = Date.of_string argv.(3) in
   let data_dir = Fpath.v argv.(4) in
   let out = argv.(5) in
+  let enable_stage2_ma_hold =
+    Array.length argv > 6
+    &&
+    match String.lowercase argv.(6) with
+    | "true" | "1" | "on" -> true
+    | _ -> false
+  in
   let weekly =
     load_weekly ~data_dir ~symbol ~end_date
     |> List.filter ~f:(fun b -> Date.( >= ) b.Types.Daily_price.date start_date)
   in
   let arr = Array.of_list weekly in
   let n = Array.length arr in
-  let stages, mas = classify_series arr in
+  let stages, mas = classify_series ~enable_stage2_ma_hold arr in
   emit_csv ~out ~arr ~stages ~mas;
   Core_unix.putenv ~key:"QT_QPA_PLATFORM" ~data:"offscreen";
   let h = Plot.create out in

--- a/trading/analysis/weinstein/stage/lib/stage.ml
+++ b/trading/analysis/weinstein/stage/lib/stage.ml
@@ -24,6 +24,7 @@ type config = {
   late_stage2_decel : float;
   stage_method : stage_method;
   early_admission_ma_period : int option; [@sexp.default None]
+  enable_stage2_ma_hold : bool; [@sexp.default false]
 }
 [@@deriving sexp]
 
@@ -37,6 +38,7 @@ let default_config =
     late_stage2_decel = 0.5;
     stage_method = MaSlope;
     early_admission_ma_period = None;
+    enable_stage2_ma_hold = false;
   }
 
 (* ------------------------------------------------------------------ *)
@@ -332,30 +334,8 @@ let _count_above_ma_callback ~get_ma ~get_close ~confirm_weeks ~ma_depth :
   in
   loop 0 0 0
 
-(** Detect late Stage 2 via callbacks. Reads MA at three offsets:
-    [old = 2*slope_lookback - 1], [mid = slope_lookback - 1], [cur = 0]. All
-    three must be defined; otherwise returns [false] (matches the
-    [n < slope_lookback * 2] guard in the bar-list version). *)
-let _is_late_stage2_callback ~get_ma ~decel_threshold ~slope_lookback : bool =
-  let old_off = (2 * slope_lookback) - 1 in
-  let mid_off = slope_lookback - 1 in
-  match
-    ( get_ma ~week_offset:old_off,
-      get_ma ~week_offset:mid_off,
-      get_ma ~week_offset:0 )
-  with
-  | Some old_ma, Some mid_ma, Some cur_ma ->
-      let old_slope =
-        if Float.(old_ma = 0.0) then 0.0
-        else (mid_ma -. old_ma) /. Float.abs old_ma
-      in
-      let new_slope =
-        if Float.(mid_ma = 0.0) then 0.0
-        else (cur_ma -. mid_ma) /. Float.abs mid_ma
-      in
-      Float.(old_slope > 0.0)
-      && Float.(new_slope < old_slope *. (1.0 -. decel_threshold))
-  | _ -> false
+(* Late-Stage-2 detection lives in [Stage2_late] (extracted to keep this
+   declared-large coordinator under its line cap). *)
 
 (* ------------------------------------------------------------------ *)
 (* Default result for the empty / no-MA case                            *)
@@ -379,13 +359,20 @@ let _stage1_default_result : result =
     [classify_with_callbacks] so the latter stays a flat sequence of
     let-bindings. *)
 let _build_result ~current_ma ~ma_dir ~ma_slope_pct ~prior_stage ~above_ma_count
-    ~below_ma_count ~is_late ~early_admit ~confirm_weeks : result =
+    ~below_ma_count ~is_late ~early_admit ~enable_stage2_ma_hold ~current_close
+    ~confirm_weeks : result =
   let standard_stage =
     _classify_new_stage ~ma_dir ~prior_stage ~above_ma_count ~below_ma_count
       ~is_late ~confirm_weeks
   in
-  let new_stage =
+  let admitted_stage =
     Early_admission.apply ~early_admit ~prior_stage ~standard_stage
+  in
+  (* Stage-2 MA-hold refinement (default-off): a pullback that holds the MA
+     (close >= MA) stays Stage 2 rather than being demoted to Stage 3. *)
+  let new_stage =
+    Stage2_ma_hold.apply ~enabled:enable_stage2_ma_hold ~prior_stage
+      ~standard_stage:admitted_stage ~current_close ~current_ma
   in
   let transition = _detect_transition ~prior_stage ~new_stage in
   {
@@ -415,7 +402,7 @@ let _classify_signals ~config ~get_ma ~get_close ~prior_stage ~current_ma :
   in
   let below_ma_count = examined - above_ma_count in
   let is_late =
-    _is_late_stage2_callback ~get_ma ~decel_threshold:config.late_stage2_decel
+    Stage2_late.is_late_stage2 ~get_ma ~decel_threshold:config.late_stage2_decel
       ~slope_lookback:config.slope_lookback
   in
   let early_admit =
@@ -424,8 +411,11 @@ let _classify_signals ~config ~get_ma ~get_close ~prior_stage ~current_ma :
       ~slope_threshold:config.slope_threshold
       ~slope_lookback:config.slope_lookback
   in
+  let current_close = get_close ~week_offset:0 in
   _build_result ~current_ma ~ma_dir ~ma_slope_pct ~prior_stage ~above_ma_count
-    ~below_ma_count ~is_late ~early_admit ~confirm_weeks:config.confirm_weeks
+    ~below_ma_count ~is_late ~early_admit
+    ~enable_stage2_ma_hold:config.enable_stage2_ma_hold ~current_close
+    ~confirm_weeks:config.confirm_weeks
 
 let classify_with_callbacks ~config ~get_ma ~get_close ~prior_stage : result =
   match get_ma ~week_offset:0 with

--- a/trading/analysis/weinstein/stage/lib/stage.mli
+++ b/trading/analysis/weinstein/stage/lib/stage.mli
@@ -71,6 +71,31 @@ type config = {
           is expressible as a [Variant_matrix] axis. Not wired into any default
           config; awaits a surface-sweep ACCEPT per the experiment-flag
           discipline. *)
+  enable_stage2_ma_hold : bool; [@sexp.default false]
+      (** Default-off Stage-2 MA-hold refinement (see {!Stage2_ma_hold}).
+
+          [false] (default): no behavioural change — [classify] is bit-identical
+          to the pre-flag classifier on every input.
+
+          [true]: a held [Stage2] whose standard classification would demote to
+          [Stage3] (the "topping" flag the flat-MA branch raises on a normal
+          pullback) is held as a continued [Stage2]
+          {b while the current close is at/above the current MA}. This fixes a
+          diagnosed oscillation defect where a pullback that merely flattens the
+          30-week MA fragments one continuous Stage-2 advance into many short
+          stages with dozens of spurious transitions (KO 2010-2018). A genuine
+          break {b below} the MA still transitions out normally, so legitimate
+          Stage-3 / Stage-4 exits are preserved.
+
+          Faithful Weinstein, not a new mechanic: Stage 2 IS "price above a
+          rising 30-week MA" (docs/design/weinstein-book-reference.md §Stage 2:
+          Advancing); a pullback that holds the MA is still Stage 2, not a top.
+
+          Wired as a config field so it routes through [Overlay_validator] and
+          is expressible as a [Variant_matrix] axis (nested key path
+          [stage_config.enable_stage2_ma_hold]). Not wired into any default
+          config; awaits a surface-sweep ACCEPT per the experiment-flag
+          discipline. *)
 }
 [@@deriving sexp]
 (** Configuration for stage classification. All thresholds are configurable to

--- a/trading/analysis/weinstein/stage/lib/stage2_late.ml
+++ b/trading/analysis/weinstein/stage/lib/stage2_late.ml
@@ -1,0 +1,27 @@
+open Core
+
+(** Late-Stage-2 detection (MA-deceleration warning) — see [stage2_late.mli].
+    Extracted from [stage.ml] (a declared-large coordinator at its line cap) as
+    a self-contained Stage-2 held-position signal, sibling to [Stage2_ma_hold].
+*)
+
+let is_late_stage2 ~get_ma ~decel_threshold ~slope_lookback : bool =
+  let old_off = (2 * slope_lookback) - 1 in
+  let mid_off = slope_lookback - 1 in
+  match
+    ( get_ma ~week_offset:old_off,
+      get_ma ~week_offset:mid_off,
+      get_ma ~week_offset:0 )
+  with
+  | Some old_ma, Some mid_ma, Some cur_ma ->
+      let old_slope =
+        if Float.(old_ma = 0.0) then 0.0
+        else (mid_ma -. old_ma) /. Float.abs old_ma
+      in
+      let new_slope =
+        if Float.(mid_ma = 0.0) then 0.0
+        else (cur_ma -. mid_ma) /. Float.abs mid_ma
+      in
+      Float.(old_slope > 0.0)
+      && Float.(new_slope < old_slope *. (1.0 -. decel_threshold))
+  | _ -> false

--- a/trading/analysis/weinstein/stage/lib/stage2_late.mli
+++ b/trading/analysis/weinstein/stage/lib/stage2_late.mli
@@ -1,0 +1,15 @@
+(** Late-Stage-2 detection: the MA-deceleration warning that fires while a
+    position is still in Stage 2 but the 30-week MA's slope is decelerating — an
+    early top-warning consumed by held-position risk logic. Pure; extracted from
+    [stage.ml] to keep that declared-large coordinator under its line cap. *)
+
+val is_late_stage2 :
+  get_ma:(week_offset:int -> float option) ->
+  decel_threshold:float ->
+  slope_lookback:int ->
+  bool
+(** [is_late_stage2 ~get_ma ~decel_threshold ~slope_lookback] reads the MA at
+    offsets [2*slope_lookback-1] (old), [slope_lookback-1] (mid), and [0] (cur);
+    returns [true] when the MA was rising (old slope > 0) and the recent slope
+    has decelerated below [old_slope * (1 - decel_threshold)]. Returns [false]
+    if any of the three MA reads is undefined. *)

--- a/trading/analysis/weinstein/stage/lib/stage2_ma_hold.ml
+++ b/trading/analysis/weinstein/stage/lib/stage2_ma_hold.ml
@@ -1,0 +1,14 @@
+open Core
+open Weinstein_types
+
+let apply ~enabled ~prior_stage ~standard_stage ~current_close ~current_ma =
+  if not enabled then standard_stage
+  else
+    match (prior_stage, standard_stage, current_close) with
+    | Some (Stage2 { weeks_advancing; late }), Stage3 _, Some close
+      when Float.( >= ) close current_ma ->
+        (* Pullback that holds the MA: faithful Weinstein keeps this Stage 2
+           rather than demoting to Stage 3. Continue the prior advancing count;
+           preserve the prior [late] warning flag. *)
+        Stage2 { weeks_advancing = weeks_advancing + 1; late }
+    | _ -> standard_stage

--- a/trading/analysis/weinstein/stage/lib/stage2_ma_hold.mli
+++ b/trading/analysis/weinstein/stage/lib/stage2_ma_hold.mli
@@ -1,0 +1,50 @@
+open Weinstein_types
+
+(** Stage-2 MA-hold refinement (default-off mechanism).
+
+    Fixes a diagnosed oscillation defect in the stage classifier: on a steady
+    uptrend, a normal pullback that merely flattens the 30-week MA flips a held
+    [Stage2] to [Stage3] ("topping"), then flips back to [Stage2] when the
+    advance resumes. A human reads the whole move as one continuous Stage 2; the
+    classifier fragments it into many short stages with dozens of spurious
+    transitions (KO 2010-2018: ~45 transitions, 7+ Stage-2 pieces). The churn
+    drives the whipsaw / late-reentry the trade-autopsy ranked #1 for missed
+    gain (see [memory/project_stage_chart_visual_diagnostic]).
+
+    This is faithful Weinstein, not a new mechanic. Stage 2 IS "price above a
+    rising 30-week MA" (docs/design/weinstein-book-reference.md §Stage 2:
+    Advancing); a pullback that holds the MA (close still at/above it) is still
+    Stage 2, not a top. The refinement only blocks the {b S2 → S3} demotion
+    while price holds the MA; a genuine break {b below} the MA still transitions
+    out normally, so legitimate Stage-3 / Stage-4 exits are preserved.
+
+    All functions are pure. The mechanism is a strict no-op when
+    [enabled = false] (see {!apply}). *)
+
+val apply :
+  enabled:bool ->
+  prior_stage:stage option ->
+  standard_stage:stage ->
+  current_close:float option ->
+  current_ma:float ->
+  stage
+(** [apply ~enabled ~prior_stage ~standard_stage ~current_close ~current_ma]
+    post-processes the standard classifier output with the MA-hold override.
+
+    When [enabled = false] this is the identity ([standard_stage] is returned
+    unchanged) — the proof that the mechanism is a no-op when off.
+
+    When [enabled = true]: holds a prior [Stage2] advancing (rather than letting
+    the standard logic demote it to [Stage3]) iff {b all} of:
+
+    - the prior stage is a [Stage2];
+    - the standard classifier output is a [Stage3] (the topping demotion this
+      refinement targets — a [Stage4] below-MA break is left untouched);
+    - the current close is defined and at/above the current MA
+      ([current_close >= current_ma]).
+
+    The held stage is a [Stage2] whose [weeks_advancing] continues from the
+    prior Stage-2 count (incremented by one) and preserves the prior [late]
+    flag. In every other case [standard_stage] is returned unchanged — the
+    refinement never blocks a legitimate below-MA exit and never forces a
+    Stage-2 entry. *)

--- a/trading/analysis/weinstein/stage/test/test_stage.ml
+++ b/trading/analysis/weinstein/stage/test/test_stage.ml
@@ -646,6 +646,68 @@ let test_default_config_early_admission_none _ =
   assert_that default_config.early_admission_ma_period is_none
 
 (* ------------------------------------------------------------------ *)
+(* Stage-2 MA-hold refinement (default-off flag)                       *)
+(*                                                                      *)
+(* Drives [classify_with_callbacks] with a FLAT slow MA so the standard *)
+(* classifier reads a prior [Stage2] as a [Stage3] topping demotion     *)
+(* (the [_classify_flat_ma] path the refinement targets). The contract  *)
+(* is the CONTRAST between [enable_stage2_ma_hold = false] (default) and *)
+(* [true] on the SAME callbacks: when the close holds the MA the flag    *)
+(* keeps [Stage2]; when the close is below the MA the flag is inert and  *)
+(* the legitimate below-MA exit to [Stage3] still happens.              *)
+(* ------------------------------------------------------------------ *)
+
+let cfg_ma_hold = { default_config with enable_stage2_ma_hold = true }
+
+(** Pullback that HOLDS the MA: the close series ends at 110 (above the flat 100
+    MA). With the flag off the flat MA demotes a prior [Stage2] to [Stage3];
+    with the flag on it stays [Stage2] (advancing count incremented, prior
+    [late] flag preserved). The contrast IS the contract. *)
+let test_stage2_ma_hold_holds_pullback_above_ma _ =
+  let closes_above = Array.create ~len:40 110.0 in
+  let get_ma = make_get_ma_arr flat_slow_ma in
+  let get_close = make_get_close_arr closes_above in
+  let prior = Some (Stage2 { weeks_advancing = 9; late = true }) in
+  let off =
+    classify_with_callbacks ~config:default_config ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  let on =
+    classify_with_callbacks ~config:cfg_ma_hold ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  assert_that (off.stage, on.stage)
+    (all_of
+       [
+         field fst is_stage3;
+         field snd
+           (equal_to (Stage2 { weeks_advancing = 10; late = true } : stage));
+       ])
+
+(** Genuine below-MA break: the close series ends at 90 (below the flat 100 MA).
+    The flag is inert — both [false] and [true] demote the prior [Stage2] to
+    [Stage3], so the refinement never blocks a legitimate below-MA exit. *)
+let test_stage2_ma_hold_allows_below_ma_exit _ =
+  let closes_below = Array.create ~len:40 90.0 in
+  let get_ma = make_get_ma_arr flat_slow_ma in
+  let get_close = make_get_close_arr closes_below in
+  let prior = Some (Stage2 { weeks_advancing = 9; late = false }) in
+  let off =
+    classify_with_callbacks ~config:default_config ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  let on =
+    classify_with_callbacks ~config:cfg_ma_hold ~get_ma ~get_close
+      ~prior_stage:prior
+  in
+  assert_that (off.stage, on.stage)
+    (all_of [ field fst is_stage3; field snd (equal_to (off.stage : stage)) ])
+
+(** Default config leaves the flag off. *)
+let test_default_config_stage2_ma_hold_off _ =
+  assert_that default_config.enable_stage2_ma_hold (equal_to false)
+
+(* ------------------------------------------------------------------ *)
 (* Sexp round-trip: defaulted field tolerates omission                 *)
 (* ------------------------------------------------------------------ *)
 
@@ -658,7 +720,24 @@ let test_config_sexp_omitted_field_defaults_none _ =
        4) (confirm_weeks 6) (late_stage2_decel 0.5) (stage_method MaSlope))"
   in
   let cfg = config_of_sexp sexp in
-  assert_that cfg.early_admission_ma_period is_none
+  assert_that cfg
+    (all_of
+       [
+         field (fun c -> c.early_admission_ma_period) is_none;
+         field (fun c -> c.enable_stage2_ma_hold) (equal_to false);
+       ])
+
+(** A serialized [config] sexp that includes [(enable_stage2_ma_hold true)]
+    parses with the flag set. *)
+let test_config_sexp_stage2_ma_hold_parses _ =
+  let sexp =
+    Sexp.of_string
+      "((ma_period 30) (ma_type Wma) (slope_threshold 0.005) (slope_lookback \
+       4) (confirm_weeks 6) (late_stage2_decel 0.5) (stage_method MaSlope) \
+       (enable_stage2_ma_hold true))"
+  in
+  let cfg = config_of_sexp sexp in
+  assert_that cfg.enable_stage2_ma_hold (equal_to true)
 
 (** A serialized [config] sexp that includes [(early_admission_ma_period (13))]
     parses to [Some 13]. *)
@@ -722,8 +801,16 @@ let suite =
          >:: test_early_admission_slow_ma_stage2_unaffected;
          "test_default_config_early_admission_none"
          >:: test_default_config_early_admission_none;
+         "test_stage2_ma_hold_holds_pullback_above_ma"
+         >:: test_stage2_ma_hold_holds_pullback_above_ma;
+         "test_stage2_ma_hold_allows_below_ma_exit"
+         >:: test_stage2_ma_hold_allows_below_ma_exit;
+         "test_default_config_stage2_ma_hold_off"
+         >:: test_default_config_stage2_ma_hold_off;
          "test_config_sexp_omitted_field_defaults_none"
          >:: test_config_sexp_omitted_field_defaults_none;
+         "test_config_sexp_stage2_ma_hold_parses"
+         >:: test_config_sexp_stage2_ma_hold_parses;
          "test_config_sexp_present_field_parses"
          >:: test_config_sexp_present_field_parses;
        ]


### PR DESCRIPTION
## What
Default-off `Stage.config.enable_stage2_ma_hold`: while a position is in Stage 2 and price holds the 30-week MA (close ≥ MA), a pullback stays **Stage 2** rather than being demoted to **Stage 3**. A genuine break *below* the MA still transitions out normally (legitimate S3/S4 exits preserved).

## Why (chart-diagnosed, not blind tuning)
`stage_chart` visuals showed the classifier flips a held Stage-2 to Stage-3 on a normal pullback that merely flattens the MA, then flips back — fragmenting one advance into 7+ stages (KO 2010-18: ~45 transitions; a human reads it as one Stage 2). With the flag on, KO's 2010-13 advance collapses to a single ~160-week Stage 2. The churn drives the whipsaw/late-reentry the trade-autopsy ranked #1 for missed gain. **Faithful Weinstein** — Stage 2 *is* 'price above a rising 30-week MA' (weinstein-book-reference §Stage 2); a pullback holding the MA is still Stage 2, not a top.

## How
- New `Stage2_ma_hold` module (pure `apply`); wired into `Stage.classify` after early-admission.
- Extracted `Stage2_late` (the MA-deceleration warning) out of `stage.ml` to keep that declared-large coordinator **under the 500-line cap** (it would hit 511 otherwise) — per code-health-discipline, extract not bump.
- Default-off ⇒ all goldens byte-identical. Axis-able via `stage_config` (same nesting as `early_admission_ma_period`) for the planned WF-CV.

## Tests
`test_stage.ml`: flag-off byte-identical; flag-on holds Stage 2 on an above-MA pullback (vs Stage 3 off); still exits on a below-MA break. Full `dune runtest` green locally (build, fmt, nesting, file-length all pass).

Recovered + finished from the dispatched agent's worktree (the agent backgrounded its final verify and didn't push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)