### PR TITLE
fix(trade-audit): resurrect trade_audit_report — blob-load + tolerant audit join

### DIFF
--- a/trading/trading/backtest/test/test_trade_audit_report.ml
+++ b/trading/trading/backtest/test/test_trade_audit_report.ml
@@ -747,9 +747,89 @@ let test_writer_reader_post_g2_round_trip _ =
               ]);
        ])
 
+(* --- Join tolerance + blob-format load (resurrection regression) -------
+
+   Two latent breaks kept this report from working on real runs:
+   (1) the loader read a bare [audit_record list] but the runner persists a
+       full [audit_blob] envelope; and
+   (2) the audit<->round-trip join was an exact (symbol, entry_date) match, but
+       the audit carries the Friday decision date while trades.csv carries the
+       next-trading-day fill, so ~every trade failed to join and the entire
+       analysis layer (ratings / behavioural / Weinstein) rendered empty.
+   These tests pin both fixes. *)
+
+let test_row_matches_audit_with_off_by_one_date _ =
+  (* trades.csv fill date (Mon) is 3 days after the audit's Friday decision
+     date; the tolerant join must still attach the audit fields. *)
+  let trade = make_trade ~symbol:"AAPL" ~entry_date:(_date "2024-01-15") () in
+  let entry =
+    make_entry_decision ~symbol:"AAPL" ~entry_date:(_date "2024-01-12")
+      ~cascade_grade:Weinstein_types.A ~cascade_score:75 ()
+  in
+  let record = make_record entry (make_exit_decision ()) in
+  let report = TAR.render ~trade_audit:[ record ] ~trades:[ trade ] () in
+  assert_that report.rows
+    (elements_are
+       [
+         field
+           (fun (r : TAR.per_trade_row) -> r.cascade_grade)
+           (is_some_and (equal_to Weinstein_types.A));
+       ])
+
+let test_analysis_nonempty_with_off_by_one_date _ =
+  (* The key regression: with the off-by-one fill date, [rate_all] must still
+     match the audit so [analysis] is populated (was silently [None]). *)
+  let trade = make_trade ~symbol:"AAPL" ~entry_date:(_date "2024-01-15") () in
+  let entry =
+    make_entry_decision ~symbol:"AAPL" ~entry_date:(_date "2024-01-12") ()
+  in
+  let record = make_record entry (make_exit_decision ()) in
+  let report = TAR.render ~trade_audit:[ record ] ~trades:[ trade ] () in
+  assert_that report.analysis
+    (is_some_and (field (fun (a : TAR.analysis) -> a.ratings) (size_is 1)))
+
+let _write_blob_audit_sexp path =
+  let aapl =
+    make_record
+      (make_entry_decision ~symbol:"AAPL" ~entry_date:(_date "2020-04-25")
+         ~position_id:"AAPL-1" ~cascade_grade:Weinstein_types.A
+         ~cascade_score:80 ())
+      (make_exit_decision ~symbol:"AAPL" ~exit_date:(_date "2020-08-01")
+         ~position_id:"AAPL-1" ())
+  in
+  let blob : TA.audit_blob =
+    { audit_records = [ aapl ]; cascade_summaries = [] }
+  in
+  Sexp.save_hum path (TA.sexp_of_audit_blob blob)
+
+let test_load_reads_blob_format_audit _ =
+  (* The runner persists the [audit_blob] envelope; the loader must parse it
+     (not only the legacy bare-list format). *)
+  let dir = Core_unix.mkdtemp "/tmp/trade_audit_report_" in
+  let scenario_dir = Filename.concat dir "blob-scenario" in
+  Core_unix.mkdir_p scenario_dir;
+  _write_trades_csv (Filename.concat scenario_dir "trades.csv");
+  _write_summary_sexp (Filename.concat scenario_dir "summary.sexp");
+  _write_blob_audit_sexp (Filename.concat scenario_dir "trade_audit.sexp");
+  let report = TAR.load ~scenario_dir in
+  assert_that report
+    (field
+       (fun (t : TAR.t) ->
+         List.find t.rows ~f:(fun (r : TAR.per_trade_row) ->
+             String.equal r.symbol "AAPL"))
+       (is_some_and
+          (field
+             (fun (r : TAR.per_trade_row) -> r.cascade_grade)
+             (is_some_and (equal_to Weinstein_types.A)))))
+
 let suite =
   "Trade_audit_report"
   >::: [
+         "row matches audit with off-by-one date"
+         >:: test_row_matches_audit_with_off_by_one_date;
+         "analysis non-empty with off-by-one date"
+         >:: test_analysis_nonempty_with_off_by_one_date;
+         "load reads blob-format audit" >:: test_load_reads_blob_format_audit;
          "header counts winners and losers"
          >:: test_header_counts_winners_and_losers;
          "header empty trades" >:: test_header_empty_trades;

--- a/trading/trading/backtest/trade_audit_report/trade_audit_ratings.ml
+++ b/trading/trading/backtest/trade_audit_report/trade_audit_ratings.ml
@@ -334,21 +334,40 @@ let rate ~config (record : TA.audit_record)
 
 (* Joining audit + trades -------------------------------------------------- *)
 
+(** Max calendar-day gap tolerated when joining a [trades.csv] round-trip to its
+    audit record (and back). The audit [entry_date] is the Friday decision date;
+    the round-trip [entry_date] is the actual fill (next trading day), so the
+    two differ by 1-3 days across a weekend. A week bridges that without
+    cross-matching a distinct re-entry of the same symbol. Kept in sync with
+    [Trade_audit_report]'s join tolerance. *)
+let _join_tolerance_days = 7
+
+(* From [candidates] sharing a symbol, return the one whose [date_of] is closest
+   to [entry_date], within [_join_tolerance_days]. *)
+let _nearest_within ~entry_date ~date_of candidates =
+  List.filter_map candidates ~f:(fun c ->
+      let gap = Int.abs (Date.diff (date_of c) entry_date) in
+      if gap <= _join_tolerance_days then Some (gap, c) else None)
+  |> List.min_elt ~compare:(fun (g1, _) (g2, _) -> Int.compare g1 g2)
+  |> Option.map ~f:snd
+
 let _audit_index audit =
   List.fold audit
     ~init:(Map.empty (module String))
     ~f:(fun acc (record : TA.audit_record) ->
-      let key =
-        record.entry.symbol ^ "|" ^ Date.to_string record.entry.entry_date
-      in
-      Map.set acc ~key ~data:record)
+      Map.add_multi acc ~key:record.entry.symbol ~data:record)
 
 let rate_all ~config ~audit ~trades =
   let idx = _audit_index audit in
   List.filter_map trades
     ~f:(fun (t : Trading_simulation.Metrics.trade_metrics) ->
-      let key = t.symbol ^ "|" ^ Date.to_string t.entry_date in
-      Option.map (Map.find idx key) ~f:(fun record -> rate ~config record t))
+      match Map.find idx t.symbol with
+      | None -> None
+      | Some records ->
+          _nearest_within ~entry_date:t.entry_date
+            ~date_of:(fun (r : TA.audit_record) -> r.entry.entry_date)
+            records
+          |> Option.map ~f:(fun record -> rate ~config record t))
 
 (* Behavioural metric (a) — over-trading ---------------------------------- *)
 
@@ -436,15 +455,22 @@ let _exit_winners ~config ~ratings ~trades : exit_winners_too_early =
     List.fold trades
       ~init:(Map.empty (module String))
       ~f:(fun acc (t : Trading_simulation.Metrics.trade_metrics) ->
-        Map.set acc ~key:(t.symbol ^ "|" ^ Date.to_string t.entry_date) ~data:t)
+        Map.add_multi acc ~key:t.symbol ~data:t)
   in
   let winners = List.filter ratings ~f:(fun r -> equal_outcome r.outcome Win) in
   let realized_pct (r : rating) =
-    let key = r.symbol ^ "|" ^ Date.to_string r.entry_date in
-    match Map.find trade_idx key with
-    | Some (t : Trading_simulation.Metrics.trade_metrics) ->
-        t.pnl_percent /. 100.0
+    match Map.find trade_idx r.symbol with
     | None -> 0.0
+    | Some trades -> (
+        match
+          _nearest_within ~entry_date:r.entry_date
+            ~date_of:(fun (t : Trading_simulation.Metrics.trade_metrics) ->
+              t.entry_date)
+            trades
+        with
+        | Some (t : Trading_simulation.Metrics.trade_metrics) ->
+            t.pnl_percent /. 100.0
+        | None -> 0.0)
   in
   let gaps = List.map winners ~f:(fun r -> (r, r.mfe_pct -. realized_pct r)) in
   let flagged =
@@ -541,8 +567,14 @@ let _quartile_assignments_by_score ~audit (ratings : rating list) :
   let idx = _audit_index audit in
   let with_score =
     List.filter_map ratings ~f:(fun (r : rating) ->
-        let key = r.symbol ^ "|" ^ Date.to_string r.entry_date in
-        Option.map (Map.find idx key) ~f:(fun a -> (r, a.entry.cascade_score)))
+        match Map.find idx r.symbol with
+        | None -> None
+        | Some records ->
+            _nearest_within ~entry_date:r.entry_date
+              ~date_of:(fun (a : TA.audit_record) -> a.entry.entry_date)
+              records
+            |> Option.map ~f:(fun (a : TA.audit_record) ->
+                (r, a.entry.cascade_score)))
   in
   let sorted_desc =
     List.sort with_score ~compare:(fun (_, sa) (_, sb) -> Int.compare sb sa)

--- a/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
+++ b/trading/trading/backtest/trade_audit_report/trade_audit_report.ml
@@ -68,14 +68,33 @@ type t = {
 
 (* Render ----------------------------------------------------------------- *)
 
+(** Max calendar-day gap tolerated when joining a [trades.csv] round-trip to its
+    audit record. The audit [entry_date] is the Friday decision date; the
+    round-trip [entry_date] is the actual fill (next trading day), so the two
+    differ by 1-3 days across a weekend. A week is wide enough to bridge that
+    without cross-matching a distinct re-entry of the same symbol. *)
+let _audit_join_tolerance_days = 7
+
+(* Group audit records by symbol so the join can match the round-trip's fill
+   date to the nearest decision date within [_audit_join_tolerance_days]. *)
 let _audit_index audit =
   List.fold audit
     ~init:(Map.empty (module String))
     ~f:(fun acc (record : TA.audit_record) ->
-      let key =
-        record.entry.symbol ^ "|" ^ Date.to_string record.entry.entry_date
-      in
-      Map.set acc ~key ~data:record)
+      Map.add_multi acc ~key:record.entry.symbol ~data:record)
+
+(* Find the audit record for [symbol] whose decision date is closest to the
+   round-trip [entry_date], within tolerance. Returns [None] when the symbol has
+   no audit record or the nearest one is too far away. *)
+let _find_audit audit_idx ~symbol ~entry_date =
+  match Map.find audit_idx symbol with
+  | None -> None
+  | Some records ->
+      List.filter_map records ~f:(fun (r : TA.audit_record) ->
+          let gap = Int.abs (Date.diff r.entry.entry_date entry_date) in
+          if gap <= _audit_join_tolerance_days then Some (gap, r) else None)
+      |> List.min_elt ~compare:(fun (g1, _) (g2, _) -> Int.compare g1 g2)
+      |> Option.map ~f:snd
 
 let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
   match trigger with
@@ -90,8 +109,9 @@ let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
 
 let _row_of_trade audit_idx (trade : Trading_simulation.Metrics.trade_metrics) :
     per_trade_row =
-  let key = trade.symbol ^ "|" ^ Date.to_string trade.entry_date in
-  let audit = Map.find audit_idx key in
+  let audit =
+    _find_audit audit_idx ~symbol:trade.symbol ~entry_date:trade.entry_date
+  in
   let entry = Option.map audit ~f:(fun (r : TA.audit_record) -> r.entry) in
   let exit_ = Option.bind audit ~f:(fun (r : TA.audit_record) -> r.exit_) in
   let side =
@@ -453,8 +473,15 @@ let load ~scenario_dir : t =
   let trades = _read_trades_csv trades_path in
   let audit_path = Filename.concat scenario_dir "trade_audit.sexp" in
   let trade_audit =
-    if Sys_unix.file_exists_exn audit_path then
-      TA.audit_records_of_sexp (Sexp.load_sexp audit_path)
+    if Sys_unix.file_exists_exn audit_path then begin
+      let sexp = Sexp.load_sexp audit_path in
+      (* The runner persists a full [audit_blob] envelope ([audit_records] +
+         [cascade_summaries]); older runs persisted a bare [audit_record list].
+         Parse as a blob first and fall back to the bare list so both on-disk
+         formats load. *)
+      try (TA.audit_blob_of_sexp sexp).audit_records
+      with _ -> TA.audit_records_of_sexp sexp
+    end
     else []
   in
   let summary =


### PR DESCRIPTION
## Problem

The trade-audit report (`trade_audit_report_bin --scenario-dir <dir>`) — per-trade ratings (R-multiple, MFE/MAE), behavioural metrics (over-trading, exit-too-early/late, entering-losers), and Weinstein R1–R8 conformance — was **doubly bit-rotted** and produced nothing on any modern run. Found while standing up trade-level forensics.

## Two breaks fixed

1. **Load.** The loader called `audit_records_of_sexp` expecting a bare `audit_record list`, but the runner persists a full `audit_blob` envelope (`audit_records` + `cascade_summaries`). Every modern run raised `invalid_sexp audit_records`. Now parses the blob, falls back to the bare list for legacy outputs.

2. **Join.** The audit↔round-trip join was an **exact `(symbol, entry_date)` match in 4 places** (report row + `rate_all` + exit-winners + cascade-quartile). The audit carries the Friday **decision** date; `trades.csv` carries the next-trading-day **fill** (1–3 days later) — so ~every trade failed to join and the whole analysis layer **silently rendered empty**. Replaced with a tolerant nearest-match within 7 calendar days.

## Verification
Before: `load` raised on every Cell-E run. After: report renders all sections (ratings / behavioural / Weinstein / decision-quality) on the top-3000 Cell-E run (671 round-trips).

## Tests
3 regression tests: tolerant-join row fields, **analysis-layer non-empty under an off-by-one fill date** (the core regression), blob-format on-disk load. Existing 35 tests still pass.

## Scope
Report tooling only — **no change to strategy or backtest behaviour.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)