### PR TITLE
feat(trade-audit): compute MFE/MAE excursions + audit all exit paths

### DIFF
--- a/trading/trading/backtest/lib/trade_audit_recorder.ml
+++ b/trading/trading/backtest/lib/trade_audit_recorder.ml
@@ -75,13 +75,14 @@ let _entry_decision_of_event (e : AR.entry_event) : Trade_audit.entry_decision =
 
 (** Translate one {!AR.exit_event} into a {!Trade_audit.exit_decision}.
 
-    The during-hold counters ([max_favorable_excursion_pct],
-    [max_adverse_excursion_pct], [weeks_macro_was_bearish],
-    [weeks_stage_left_2]) are filled with sensible defaults — populating them
-    requires per-step instrumentation through the simulator's step stream, which
-    is deferred to a follow-up PR. The state-at-decision fields (macro / stage /
-    rs / distance_from_ma) are populated from the strategy's snapshot captured
-    at the moment the [TriggerExit] fired. *)
+    [max_favorable_excursion_pct] / [max_adverse_excursion_pct] are now computed
+    at exit-capture time (over the hold's weekly-bar high/low vs entry price)
+    and threaded through verbatim. The remaining during-hold counters
+    ([weeks_macro_was_bearish], [weeks_stage_left_2]) still require per-step
+    instrumentation through the simulator's step stream and stay at [0] until a
+    follow-up wires them. The state-at-decision fields (macro / stage / rs /
+    distance_from_ma) are populated from the strategy's snapshot captured at the
+    moment the [TriggerExit] fired. *)
 let _exit_decision_of_event (e : AR.exit_event) : Trade_audit.exit_decision =
   {
     symbol = e.symbol;
@@ -93,8 +94,8 @@ let _exit_decision_of_event (e : AR.exit_event) : Trade_audit.exit_decision =
     stage_at_exit = e.stage_at_exit;
     rs_trend_at_exit = e.rs_trend_at_exit;
     distance_from_ma_pct = e.distance_from_ma_pct;
-    max_favorable_excursion_pct = 0.0;
-    max_adverse_excursion_pct = 0.0;
+    max_favorable_excursion_pct = e.max_favorable_excursion_pct;
+    max_adverse_excursion_pct = e.max_adverse_excursion_pct;
     weeks_macro_was_bearish = 0;
     weeks_stage_left_2 = 0;
   }

--- a/trading/trading/weinstein/strategy/lib/audit_recorder.ml
+++ b/trading/trading/weinstein/strategy/lib/audit_recorder.ml
@@ -41,6 +41,8 @@ type exit_event = {
   stage_at_exit : Weinstein_types.stage;
   rs_trend_at_exit : Weinstein_types.rs_trend option;
   distance_from_ma_pct : float;
+  max_favorable_excursion_pct : float;
+  max_adverse_excursion_pct : float;
 }
 
 type cascade_event = {

--- a/trading/trading/weinstein/strategy/lib/audit_recorder.mli
+++ b/trading/trading/weinstein/strategy/lib/audit_recorder.mli
@@ -110,6 +110,16 @@ type exit_event = {
       (** [(exit_price - ma_value) / ma_value] at exit time. Positive if exit
           was above the MA, negative if below. [0.0] when the MA could not be
           read. *)
+  max_favorable_excursion_pct : float;
+      (** Largest favourable move during the hold, as a fraction of entry price,
+          over the hold's {b weekly} bars. For a long:
+          [(max weekly high - entry_price) / entry_price]; for a short, mirrored
+          on the low. [0.0] when bars for the hold window are unavailable. *)
+  max_adverse_excursion_pct : float;
+      (** Largest adverse move during the hold, as a fraction of entry price
+          (typically negative), over the hold's {b weekly} bars. For a long:
+          [(min weekly low - entry_price) / entry_price]; for a short, mirrored
+          on the high. [0.0] when bars are unavailable. *)
 }
 (** Event captured at exit-decision time. *)
 

--- a/trading/trading/weinstein/strategy/lib/exit_audit_capture.ml
+++ b/trading/trading/weinstein/strategy/lib/exit_audit_capture.ml
@@ -45,10 +45,72 @@ let _distance_from_ma_pct ?ma_cache ~stage_config ~lookback_bars ~bar_reader
     in
     _pct_distance_from_callbacks ~callbacks ~stage_config ~prior_stage
 
+(** Entry [(price, date)] for an open/closing position. [None] for [Entering]
+    (not yet filled) — no hold window to measure excursions over. *)
+let _entry_info (pos : Position.t) =
+  match pos.state with
+  | Position.Holding h -> Some (h.entry_price, h.entry_date)
+  | Position.Exiting e -> Some (e.entry_price, e.entry_date)
+  | Position.Closed c -> Some (c.entry_price, c.entry_date)
+  | Position.Entering _ -> None
+
+(** Number of weekly bars to request to span a hold of [entry_date..exit_date],
+    with slack for the partial entry/exit weeks. *)
+let _hold_weeks ~entry_date ~exit_date =
+  Int.max 1 ((Date.diff exit_date entry_date / 7) + 5)
+
+let _in_window ~entry_date ~exit_date (b : Types.Daily_price.t) =
+  Date.( >= ) b.date entry_date && Date.( <= ) b.date exit_date
+
+(** [(max weekly high, min weekly low)] over the hold window, or [None] when no
+    weekly bar falls inside [[entry_date, exit_date]]. *)
+let _hold_high_low ~bar_reader ~symbol ~entry_date ~exit_date =
+  let n = _hold_weeks ~entry_date ~exit_date in
+  let hold =
+    Bar_reader.weekly_bars_for bar_reader ~symbol ~n ~as_of:exit_date
+    |> List.filter ~f:(_in_window ~entry_date ~exit_date)
+  in
+  match hold with
+  | [] -> None
+  | _ ->
+      let highs =
+        List.map hold ~f:(fun (b : Types.Daily_price.t) -> b.high_price)
+      in
+      let lows =
+        List.map hold ~f:(fun (b : Types.Daily_price.t) -> b.low_price)
+      in
+      Some
+        (List.reduce_exn highs ~f:Float.max, List.reduce_exn lows ~f:Float.min)
+
+(** Max favourable / adverse excursion over the hold window
+    [[entry_date, exit_date]], as a fraction of entry price. Favourable is in
+    the trade's direction (high for long, low for short); adverse is against it
+    (typically negative). Returns [(0.0, 0.0)] when entry price is non-positive
+    or no bars cover the window.
+
+    Uses {b weekly} bars (the strategy's native granularity): weekly highs/lows
+    are the week's true intra-week extremes, and [weekly_bars_for ~n] reaches
+    back a controlled [n] weeks regardless of the daily reader's bounded
+    resident window — [daily_bars_for] only returns a recent fixed-width window,
+    which truncated long holds to a few bars near the exit. *)
+let _excursions ~bar_reader ~symbol ~(side : Position.position_side)
+    ~entry_price ~entry_date ~exit_date =
+  if Float.( <= ) entry_price 0.0 then (0.0, 0.0)
+  else
+    match _hold_high_low ~bar_reader ~symbol ~entry_date ~exit_date with
+    | None -> (0.0, 0.0)
+    | Some (max_high, min_low) -> (
+        let pct from = (from -. entry_price) /. entry_price in
+        match side with
+        | Trading_base.Types.Long -> (pct max_high, pct min_low)
+        (* Short: favourable is a drop, adverse a rise — mirror around entry. *)
+        | Trading_base.Types.Short -> (-.pct min_low, -.pct max_high))
+
 (** Construct the [exit_event] record from the position and computed fields. *)
 let _make_exit_event ~(trans : Position.transition) ~(pos : Position.t)
     ~exit_reason ~exit_price ~macro_trend ~macro_confidence ~stage_at_exit
-    ~distance_from_ma_pct : Audit_recorder.exit_event =
+    ~distance_from_ma_pct ~max_favorable_excursion_pct
+    ~max_adverse_excursion_pct : Audit_recorder.exit_event =
   {
     position_id = trans.position_id;
     symbol = pos.symbol;
@@ -60,7 +122,18 @@ let _make_exit_event ~(trans : Position.transition) ~(pos : Position.t)
     stage_at_exit;
     rs_trend_at_exit = None;
     distance_from_ma_pct;
+    max_favorable_excursion_pct;
+    max_adverse_excursion_pct;
   }
+
+(** [(MFE, MAE)] for [pos]'s hold ending at [exit_date]; [(0.0, 0.0)] when the
+    position has no fill yet. *)
+let _pos_excursions ~bar_reader ~(pos : Position.t) ~exit_date =
+  match _entry_info pos with
+  | None -> (0.0, 0.0)
+  | Some (entry_price, entry_date) ->
+      _excursions ~bar_reader ~symbol:pos.symbol ~side:pos.side ~entry_price
+        ~entry_date ~exit_date
 
 (** Look up [pos] in [positions] for a [TriggerExit] transition and, if found,
     compute exit-time state and record the audit event. *)
@@ -83,9 +156,13 @@ let _handle_trigger_exit ~audit_recorder ~prior_macro_result ~stage_config
         |> Option.value ~default:(Weinstein_types.Stage1 { weeks_in_base = 0 })
       in
       let distance_from_ma_pct = _dist ~symbol:pos.symbol ~as_of:trans.date in
+      let max_favorable_excursion_pct, max_adverse_excursion_pct =
+        _pos_excursions ~bar_reader ~pos ~exit_date:trans.date
+      in
       let event =
         _make_exit_event ~trans ~pos ~exit_reason ~exit_price ~macro_trend
           ~macro_confidence ~stage_at_exit ~distance_from_ma_pct
+          ~max_favorable_excursion_pct ~max_adverse_excursion_pct
       in
       audit_recorder.Audit_recorder.record_exit event
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -152,22 +152,9 @@ let _run_laggard_rotation ~config ~positions ~last_stop_out_dates ~bar_reader
          ~label:"laggard_rotation");
   laggard_ts
 
-let _run_special_exits ~config ~positions ~last_stop_out_dates
-    ~(portfolio : Portfolio_view.t) ~get_price ~peak_tracker ~audit_recorder
-    ~prior_stages ~prior_stage_ma_values ~stage3_streaks ~laggard_streaks
-    ~bar_reader ~index_view ~exit_transitions ~current_date =
-  let raw_force_exit_ts =
-    Force_liquidation_runner.update
-      ~config:config.portfolio_config.force_liquidation ~positions ~get_price
-      ~cash:portfolio.cash ~current_date ~peak_tracker ~audit_recorder
-  in
-  let stop_exited_ids = _trigger_exit_ids_of exit_transitions in
-  let force_exit_ts =
-    _filter_out_exited_ids stop_exited_ids raw_force_exit_ts
-  in
-  let is_friday =
-    Weinstein_strategy_screening.is_screening_day_view index_view
-  in
+let _run_stage3_force_exit ~config ~positions ~last_stop_out_dates
+    ~prior_stage_ma_values ~stage3_streaks ~get_price ~prior_stages ~is_friday
+    ~stop_exited_ids ~current_date =
   let stage3_ts =
     if config.enable_stage3_force_exit then
       Stage3_force_exit_runner.update ~config:config.stage3_force_exit_config
@@ -182,6 +169,48 @@ let _run_special_exits ~config ~positions ~last_stop_out_dates
       (_record_force_exit ~last_stop_out_dates ~positions ~current_date
          ~cooldown_weeks:config.stage3_reentry_cooldown_weeks
          ~label:"stage3_force_exit");
+  stage3_ts
+
+(* Emit the exit-side audit (incl. MFE/MAE) for a list of [TriggerExit]
+   transitions, mirroring the stops pass. Without this, stage3-force-exit,
+   laggard-rotation, and force-liquidation exits carry no [exit_decision] and
+   their excursion metrics default to 0.0 (a no-op on non-[TriggerExit]
+   transitions, so it is safe to pipe any list through). Must run while
+   [positions] still holds the position (before the exit transition applies). *)
+let _emit_exit_audit_for ~config ~audit_recorder ~prior_macro_result ~bar_reader
+    ~prior_stages ~positions ts =
+  List.iter ts
+    ~f:
+      (Exit_audit_capture.emit_exit_audit ~audit_recorder ~prior_macro_result
+         ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
+         ~bar_reader ~prior_stages ~positions)
+
+let _run_special_exits ~config ~positions ~last_stop_out_dates
+    ~(portfolio : Portfolio_view.t) ~get_price ~peak_tracker ~audit_recorder
+    ~prior_macro_result ~prior_stages ~prior_stage_ma_values ~stage3_streaks
+    ~laggard_streaks ~bar_reader ~index_view ~exit_transitions ~current_date =
+  let emit_audit =
+    _emit_exit_audit_for ~config ~audit_recorder ~prior_macro_result ~bar_reader
+      ~prior_stages ~positions
+  in
+  let raw_force_exit_ts =
+    Force_liquidation_runner.update
+      ~config:config.portfolio_config.force_liquidation ~positions ~get_price
+      ~cash:portfolio.cash ~current_date ~peak_tracker ~audit_recorder
+  in
+  let stop_exited_ids = _trigger_exit_ids_of exit_transitions in
+  let force_exit_ts =
+    _filter_out_exited_ids stop_exited_ids raw_force_exit_ts
+  in
+  let is_friday =
+    Weinstein_strategy_screening.is_screening_day_view index_view
+  in
+  let stage3_ts =
+    _run_stage3_force_exit ~config ~positions ~last_stop_out_dates
+      ~prior_stage_ma_values ~stage3_streaks ~get_price ~prior_stages ~is_friday
+      ~stop_exited_ids ~current_date
+  in
+  emit_audit stage3_ts;
   let stage3_exited_ids = _trigger_exit_ids_of stage3_ts in
   let force_exit_ts = _filter_out_exited_ids stage3_exited_ids force_exit_ts in
   let laggard_ts =
@@ -190,8 +219,10 @@ let _run_special_exits ~config ~positions ~last_stop_out_dates
       ~skip_ids:(Set.union stop_exited_ids stage3_exited_ids)
       ~current_date
   in
+  emit_audit laggard_ts;
   let laggard_exited_ids = _trigger_exit_ids_of laggard_ts in
   let force_exit_ts = _filter_out_exited_ids laggard_exited_ids force_exit_ts in
+  emit_audit force_exit_ts;
   ( force_exit_ts,
     stage3_ts,
     laggard_ts,
@@ -330,7 +361,7 @@ let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
         stage3_exited_ids,
         laggard_exited_ids ) =
     _run_special_exits ~config ~positions ~last_stop_out_dates ~portfolio
-      ~get_price ~peak_tracker ~audit_recorder ~prior_stages
+      ~get_price ~peak_tracker ~audit_recorder ~prior_macro_result ~prior_stages
       ~prior_stage_ma_values ~stage3_streaks ~laggard_streaks ~bar_reader
       ~index_view ~exit_transitions ~current_date
   in

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -5,6 +5,7 @@
   test_ad_bars_weekly_e2e
   test_bar_reader
   test_entry_audit_capture
+  test_exit_audit_capture
   test_force_liquidation_runner
   test_force_liquidation_strategy
   test_macro_inputs

--- a/trading/trading/weinstein/strategy/test/test_exit_audit_capture.ml
+++ b/trading/trading/weinstein/strategy/test/test_exit_audit_capture.ml
@@ -1,0 +1,154 @@
+(** Pin [Exit_audit_capture]'s MFE/MAE contract: the max favourable / adverse
+    excursion fields on the recorded [exit_event] are computed from the hold
+    window's weekly high/low vs the position's entry price (mirrored for
+    shorts), not left at the placeholder [0.0] the bridge used before this
+    change.
+
+    The recorder is a callback bundle, so the test captures the emitted
+    [exit_event] via a custom [record_exit] rather than wiring a backtest
+    collector. *)
+
+open OUnit2
+open Core
+open Matchers
+open Weinstein_strategy
+module Position = Trading_strategy.Position
+module AR = Audit_recorder
+
+let _ticker = "ZZZZ"
+let _entry_date = Date.of_string "2024-01-08"
+let _exit_date = Date.of_string "2024-01-11"
+
+(** Daily path over the hold: entry at $100, an intraday high of $120 (→ +20%
+    favourable for a long) and an intraday low of $90 (→ -10% adverse). *)
+let _bar ~date ~high ~low : Types.Daily_price.t =
+  {
+    date;
+    open_price = 100.0;
+    high_price = high;
+    low_price = low;
+    close_price = 100.0;
+    adjusted_close = 100.0;
+    volume = 1_000_000;
+    active_through = None;
+  }
+
+let _bar_reader () : Bar_reader.t =
+  Bar_reader.of_in_memory_bars
+    [
+      ( _ticker,
+        [
+          _bar ~date:_entry_date ~high:100.0 ~low:100.0;
+          _bar ~date:(Date.of_string "2024-01-09") ~high:120.0 ~low:95.0;
+          _bar ~date:(Date.of_string "2024-01-10") ~high:110.0 ~low:90.0;
+          _bar ~date:_exit_date ~high:105.0 ~low:100.0;
+        ] );
+    ]
+
+(** Build a Holding {!Position.t} at $100 entry on [_entry_date]. *)
+let _holding_pos ~side : Position.t =
+  let make_trans kind =
+    { Position.position_id = _ticker; date = _entry_date; kind }
+  in
+  let unwrap = function
+    | Ok p -> p
+    | Error _ -> assert_failure "position setup failed"
+  in
+  let open Position in
+  create_entering
+    (make_trans
+       (CreateEntering
+          {
+            symbol = _ticker;
+            side;
+            target_quantity = 10.0;
+            entry_price = 100.0;
+            reasoning = ManualDecision { description = "test" };
+          }))
+  |> unwrap
+  |> fun p ->
+  apply_transition p
+    (make_trans (EntryFill { filled_quantity = 10.0; fill_price = 100.0 }))
+  |> unwrap
+  |> fun p ->
+  apply_transition p
+    (make_trans
+       (EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = None;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+let _exit_transition : Position.transition =
+  {
+    position_id = _ticker;
+    date = _exit_date;
+    kind =
+      Position.TriggerExit
+        {
+          exit_reason = Position.SignalReversal { description = "test exit" };
+          exit_price = 100.0;
+        };
+  }
+
+(** Run [emit_exit_audit] against a capturing recorder and return the emitted
+    [exit_event]. *)
+let _emit_and_capture ~side =
+  let captured = ref None in
+  let recorder =
+    { AR.noop with AR.record_exit = (fun e -> captured := Some e) }
+  in
+  let pos = _holding_pos ~side in
+  let positions = Map.singleton (module String) _ticker pos in
+  Exit_audit_capture.emit_exit_audit ~audit_recorder:recorder
+    ~prior_macro_result:(ref None) ~stage_config:Stage.default_config
+    ~lookback_bars:300 ~bar_reader:(_bar_reader ())
+    ~prior_stages:(Hashtbl.create (module String))
+    ~positions _exit_transition;
+  !captured
+
+(* For a LONG at $100: favourable = high $120 → +0.20; adverse = low $90 →
+   -0.10. *)
+let test_excursions_long _ =
+  assert_that
+    (_emit_and_capture ~side:Trading_base.Types.Long)
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (e : AR.exit_event) -> e.max_favorable_excursion_pct)
+              (float_equal 0.20);
+            field
+              (fun (e : AR.exit_event) -> e.max_adverse_excursion_pct)
+              (float_equal (-0.10));
+          ]))
+
+(* For a SHORT at $100 the direction mirrors: favourable = low $90 → +0.10;
+   adverse = high $120 → -0.20. *)
+let test_excursions_short _ =
+  assert_that
+    (_emit_and_capture ~side:Trading_base.Types.Short)
+    (is_some_and
+       (all_of
+          [
+            field
+              (fun (e : AR.exit_event) -> e.max_favorable_excursion_pct)
+              (float_equal 0.10);
+            field
+              (fun (e : AR.exit_event) -> e.max_adverse_excursion_pct)
+              (float_equal (-0.20));
+          ]))
+
+let suite =
+  "Exit_audit_capture"
+  >::: [
+         "excursions long" >:: test_excursions_long;
+         "excursions short" >:: test_excursions_short;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What
The trade-audit **MFE/MAE excursion** fields (max favorable/adverse move during a hold) were hardcoded to `0.0` at the `exit_event`→`exit_decision` bridge — a known-deferred gap — so the report's in-trade capture metrics (`exit-winners-too-early`, etc.) produced nonsense. Follow-up to PR #1504 (resurrecting the report).

## Two parts
1. **Compute the excursions.** Added `max_favorable/adverse_excursion_pct` to `Audit_recorder.exit_event`; `exit_audit_capture._excursions` computes them over the hold's **weekly** bars (week high/low vs entry price, mirrored for shorts). Weekly because `weekly_bars_for ~n` reaches back a controlled `n` weeks, unlike `daily_bars_for`'s bounded resident window (which truncated long holds). Threaded through `trade_audit_recorder`.
2. **Audit ALL exit paths.** `emit_exit_audit` was only wired into the stops pass; **stage3-force-exit, laggard-rotation, and force-liquidation exits (all `TriggerExit`) were never audited** → ~60% of exits (70/112 winners on bull-crash) had no `exit_decision` and defaulted to MFE=0.0, dragging `avg left on the table` to a provably-impossible **−7.66pp**. `_run_special_exits` now emits the exit audit for all three lists (no-op on non-`TriggerExit`).

## Behaviour
**Pure observer** — no strategy or backtest behaviour change. Only `trade_audit.sexp` (a diagnostic artifact) gains records + real MFE/MAE. Note: `weinstein_strategy.ml` is touched (the exit-orchestration wiring) — qc-structural A1 will flag it, but the change only *emits more audit events*; trades are byte-identical.

## Verification (goldens-small/bull-crash-2015-2020)
- avg-left-on-table **−7.66 → +7.05** (correct sign for longs: MFE ≥ realized)
- max MFE **0.49 → 1.74** (matches BA winner's true ~1.76)
- BA's laggard exits now carry audit records + correct MFE

## Tests
`test_exit_audit_capture.ml` pins long + short excursion math via a capturing recorder. Strategy + backtest test suites pass (audit-output change breaks nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)