### PR TITLE
docs: refresh next-session priorities — forensics shipped + cascade lead + PR-3/4

### DIFF
--- a/dev/notes/next-session-priorities-2026-06-10.md
+++ b/dev/notes/next-session-priorities-2026-06-10.md
@@ -34,9 +34,42 @@ recurring lesson hardens: **top-3000 aggregate edges are mostly 1-2 monster fold
 the per-fold/cross-breadth evidence is what matters.** Single-dial *additions and
 removals* on the Cell-E base are exhausted as a source of durable wins.
 
+## ⚠ Update (later on 2026-06-09): trade-forensics workstream now active
+
+After the grid, the session pivoted (user direction) to **trade-level forensics**
+— move beyond aggregate Sharpe/MaxDD to per-trade analysis (capture vs chart,
+entry/exit stage-timing, loss anatomy, misstep taxonomy). Full status:
+`dev/notes/trade-forensics-2026-06-09.md`. Shipped this session:
+- **#1504** — resurrected `trade_audit_report` (was doubly bit-rotted: blob-load +
+  tolerant audit join). The per-trade ratings / behavioural / Weinstein-conformance
+  layer renders again. Run: `trade_audit_report_bin --scenario-dir <run-dir>`.
+- **#1506** — MFE/MAE excursions computed + **all exit paths audited** (stage3 /
+  laggard / force-liq were never audited → 60% of exits had MFE=0.0). Verified
+  avg-left-on-table −7.66→+7.05, max MFE 0.49→1.74.
+
+**This re-frames priorities.** The forensics tool already surfaced a real strategy
+lead (below), and it's the lever to find *where the strategy bleeds* instead of
+guessing dials.
+
 ## Priorities for next session
 
-**P0 — Continuation-buy re-check on top-3000** (carried from 2026-06-09 §P1; the
+**P0 (NEW) — Investigate the cascade-selection inversion.** The resurrected report
+shows, on Cell-E top-3000, **Q1 (best cascade grade) win-rate 29.3% < Q4 (worst)
+38.7%** — the score we *rank/select* on is anti-predictive. This is the first
+real strategy lead from the forensics and (if real) higher-value than any dial.
+First: validate it's not noise (167 trades/bucket) — re-check on the broad
+universe + a couple of windows, look at the cascade-quartile-vs-outcome table
+across runs. If it holds, the fix is in the cascade scoring (selection ≫ timing,
+per the breadth findings). **Build the eval on the now-working `trade_audit_report`.**
+
+**P1 — Finish the forensics tooling** (the user opted for the full build):
+- **PR-3** post-exit capture ratio — did the stock keep ripping *after* we sold
+  (N weeks post-exit vs exit price)? Now buildable (all exits audited). The other
+  half of "did we capture the gain"; in-trade MFE is done.
+- **PR-4** auto-render `stage_chart` for top-impact trades (entry/exit markers) +
+  wrap the workflow as a durable skill.
+
+**P2 — Continuation-buy re-check on top-3000** (carried from 2026-06-09 §P1; the
 last breadth-sensitive ledger verdict not yet re-checked on the broad universe).
 Same WF-CV recipe as laggard/force-exit: `enable_continuation_entry {false}` vs
 baseline on top-3000-2011 PIT 2011-2026, fork-per-fold. Given the pattern above,
@@ -44,7 +77,7 @@ baseline on top-3000-2011 PIT 2011-2026, fork-per-fold. Given the pattern above,
 the confirmation grid** (don't record it as a lever first). Recipe template:
 `dev/experiments/stage3-force-exit-grid-2026-06-09/spec_cellC.sexp`.
 
-**P1 — Pivot the search away from single-dial Cell-E tweaks.** Three rejections
+**P3 — Pivot the search away from single-dial Cell-E tweaks.** Three rejections
 in a row say the dial-by-dial surface is mined out. The Weinstein-faithful-core
 rule (`.claude/rules/weinstein-faithful-core.md`) points at **testing coherent
 PRESETS as wholes** (trader vs investor bundles) rather than grafting one dial at


### PR DESCRIPTION
Updates next-session-priorities-2026-06-10.md after the trade-forensics workstream: tooling shipped (#1504 resurrect, #1506 MFE/MAE+all-exit-audit), new P0 = investigate the cascade-selection inversion (Q1 win 29% < Q4 39%) surfaced by the now-working report, P1 = finish forensics tooling (PR-3 post-exit capture ratio, PR-4 chart+skill), P2/P3 = the prior strategy track. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)