### PR TITLE
fix(screener): w_early_stage2 must serialize to be overridable (@sexp.default None)

### DIFF
--- a/dev/plans/trade-realism-liquidity-2026-06-10.md
+++ b/dev/plans/trade-realism-liquidity-2026-06-10.md
@@ -1,0 +1,81 @@
+# Trade-realism / liquidity grading — plan — 2026-06-10
+
+**User directive (2026-06-10, overnight):** "I don't necessarily agree that
+top-3000 means illiquid… we are not trading millions of dollars — we should check
+the volume data and market cap etc of our trades, and grade them based on the
+'realistic-ness' of the trades and apply a score / discount as needed — but
+otherwise I don't think it's responsible to simply prefer top-1000 over top-3000."
+
+This corrects a standing assumption (`project_pit_survivorship_inflation`,
+`project_broad_universe_790_mtm_inflated`, the laggard/force-exit rejections) that
+top-3000 aggregate edges are "fat-tail artifacts" to be discounted. The principled
+test is **per-trade liquidity realism**, not universe size.
+
+## The question
+
+For each trade the backtest took, could we **realistically** have filled the entry
+and (more importantly) the exit at the modelled price, given the stock's actual
+traded volume — when deploying a *modest* book (not millions)? If yes, the trade's
+P&L is real and broad-universe breadth is a legitimate advantage. If the position
+is large vs the stock's daily dollar-volume (ADV), the fill is fantasy and that
+trade's contribution should be **discounted**.
+
+## Metric
+
+Per trade:
+- `position_usd = quantity × entry_price` (capital deployed; grows with NAV as the
+  book compounds — this is the crux, since a $100k book that compounds to $8M puts
+  $1M+ into single names).
+- `adv_usd` = trailing ~20-trading-day average of `close × volume` (raw shares),
+  computed **before** entry (and separately before exit, since exit liquidity is
+  what lets you realise the gain).
+- `liq_ratio = position_usd / adv_usd` = **days-of-ADV** the position represents.
+  - `< 0.1` trivially fillable (a fraction of one day's volume).
+  - `0.1–1` fine (fill over part of a day to a day).
+  - `1–5` marginal (needs several days to enter/exit without large impact).
+  - `> 5` unrealistic for a price-taker — exiting moves the market; the modelled
+    exit price is not achievable.
+
+Market cap is a secondary lens (size class), but **ADV dollar-volume is the
+load-bearing liquidity proxy** and we have it directly (bars carry `volume`).
+Shares-outstanding / market-cap is not in the bar store, so ADV is primary.
+
+## Two deliverables
+
+### (A) Realism evaluation lens (this session's focus)
+A per-run report: distribution of `liq_ratio`, the **PnL-weighted** share of
+return coming from each liquidity bucket, and a **discounted aggregate** that caps
+each trade's size at a realistic fraction of ADV (e.g. recompute return as if no
+position exceeded `K × adv_usd`, scaling the trade's dollar-PnL by
+`min(1, K·adv/position)` as a first-order impact-free haircut). Re-run the
+top-3000 / top-1000 / top-500 comparison under the discount. **Decision it
+informs:** does the top-3000 breadth edge survive realistic fills, or is it
+concentrated in unfillable thin names? Specifically re-check the AXTI-style monster
+winners (`project_broad_universe_790_mtm_inflated`).
+
+### (B) Liquidity-aware position sizing (candidate mechanism, follow-on)
+If (A) shows thin-name fills inflate the edge, the *fix* is Weinstein-faithful: cap
+position size at a fraction of ADV (a real liquidity constraint Weinstein
+respects — he trades liquid leaders). A new default-off config dial
+`max_position_adv_days` (or `max_position_pct_adv`) that clamps the order to a
+realistic size. Default-off / no-op per `experiment-flag-discipline`; tested via
+WF-CV. This could be a *better* lever than the cascade reweight, and it directly
+answers the user's "apply a score/discount as needed."
+
+## Build
+
+OCaml, no Python. Prototype is `/tmp/liq_analyze.sh` (awk over `data/<f>/<l>/<SYM>/
+data.csv`, columns `date,open,high,low,close,adjusted_close,volume,active_through`;
+$-vol = `close × volume`). Productionize as a forensics library
+`trade_liquidity` + bin under `trading/trading/backtest/`, joining `trades.csv`
+to the bar store, mirroring `trade_audit_report`'s structure (pure `render` +
+`to_markdown` + `load`), with tests. Fits the trade-forensics workstream
+(`dev/notes/trade-forensics-2026-06-09.md`).
+
+## Preliminary finding (top-1000, 2026-06-10)
+
+Top-1000 is liquidity-clean: **94% of trades < 0.01 days-of-ADV**, 98% < 0.1d,
+1 trade > 5d; every top-10 winner is in a liquid name (< 0.01d). So at top-1000
+the modelled returns are realistic — liquidity is not where the top-1000 vs
+top-3000 difference lives. The open question is whether **top-3000** introduces a
+meaningful tail of unfillable thin-name trades. (Top-3000 regen + analysis pending.)

--- a/trading/analysis/weinstein/screener/lib/screener_scoring.ml
+++ b/trading/analysis/weinstein/screener/lib/screener_scoring.ml
@@ -16,7 +16,7 @@ type sector_context = {
 
 type scoring_weights = {
   w_stage2_breakout : int;
-  w_early_stage2 : int option; [@sexp.option]
+  w_early_stage2 : int option; [@sexp.default None]
   w_strong_volume : int;
   w_adequate_volume : int;
   w_positive_rs : int;

--- a/trading/analysis/weinstein/screener/lib/screener_scoring.mli
+++ b/trading/analysis/weinstein/screener/lib/screener_scoring.mli
@@ -20,13 +20,23 @@ type sector_context = {
 type scoring_weights = {
   w_stage2_breakout : int;
       (** Weight for a clean Stage2 transition from Stage1. Default: 30. *)
-  w_early_stage2 : int option; [@sexp.option]
+  w_early_stage2 : int option; [@sexp.default None]
       (** Weight for an early-Stage2 entry ([weeks_advancing <= 4] without an
           observed Stage1→Stage2 breakout). [None] (default) preserves the
-          historical coupling [w_stage2_breakout / 2] — bit-identical to
-          pre-field behaviour. [Some v] decouples the early-entry weight from
-          the breakout weight, making the breakout/early {e ratio} configurable
-          rather than fixed at 2:1.
+          historical coupling [w_stage2_breakout / 2] — behaviourally
+          bit-identical to pre-field behaviour. [Some v] decouples the
+          early-entry weight from the breakout weight, making the breakout/early
+          {e ratio} configurable rather than fixed at 2:1.
+
+          {b Why [@sexp.default None] and not [@sexp.option]:}
+          [Backtest.Overlay_validator] derives the set of valid override
+          key-paths from the {e serialized} base config, so a field omitted from
+          [sexp_of_config] (which [@sexp.option] does when [None]) cannot be
+          targeted by a [config_overrides] / [Variant_matrix] axis — the runner
+          rejects [screening_config.weights.w_early_stage2] as an unresolvable
+          key. [@sexp.default None] keeps the field present in the serialized
+          form (so the axis resolves) while still parsing a missing field to
+          [None] (so older config sexps round-trip).
 
           Motivation: the breakout-vs-early ranking is invariant to
           [w_stage2_breakout]'s magnitude (both scale together via [/ 2]), so

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -1389,13 +1389,23 @@ let test_w_early_stage2_no_effect_on_breakout _ =
     (score { default_scoring_weights with w_early_stage2 = Some 30 })
     (equal_to (score default_scoring_weights))
 
-(** Backward-compat contract: with [w_early_stage2 = None] (default), the field
-    is omitted from the serialized [scoring_weights] sexp ([@sexp.option]) — so
-    existing config goldens are bit-identical — and a sexp carrying
+(** Override-resolution contract: with [@sexp.default None] the field is PRESENT
+    in the serialized [scoring_weights] sexp even when [None] — required so
+    [Backtest.Overlay_validator] (which derives valid override key-paths from
+    the serialized base config) can resolve a
+    [screening_config.weights.w_early_stage2] override. A sexp {e missing} the
+    field still parses to [None] (older configs round-trip); a sexp carrying
     [(w_early_stage2 (v))] round-trips to [Some v]. *)
-let test_w_early_stage2_sexp_omitted_when_none _ =
+let test_w_early_stage2_sexp_present_and_roundtrips _ =
   let default_str =
     Sexp.to_string (sexp_of_scoring_weights default_scoring_weights)
+  in
+  let parsed_missing =
+    scoring_weights_of_sexp
+      (Sexp.of_string
+         "((w_stage2_breakout 30)(w_strong_volume 20)(w_adequate_volume \
+          10)(w_positive_rs 20)(w_bullish_rs_crossover 10)(w_clean_resistance \
+          15)(w_sector_strong 10)(w_late_stage2_penalty -15))")
   in
   let roundtrip =
     scoring_weights_of_sexp
@@ -1404,16 +1414,17 @@ let test_w_early_stage2_sexp_omitted_when_none _ =
   in
   assert_that
     ( String.is_substring default_str ~substring:"w_early_stage2",
+      parsed_missing.w_early_stage2,
       roundtrip.w_early_stage2 )
-    (equal_to (false, Some 22))
+    (equal_to (true, None, Some 22))
 
 let suite =
   "screener_tests"
   >::: [
          "test_w_early_stage2_none_preserves_half"
          >:: test_w_early_stage2_none_preserves_half;
-         "test_w_early_stage2_sexp_omitted_when_none"
-         >:: test_w_early_stage2_sexp_omitted_when_none;
+         "test_w_early_stage2_sexp_present_and_roundtrips"
+         >:: test_w_early_stage2_sexp_present_and_roundtrips;
          "test_w_early_stage2_no_effect_on_breakout"
          >:: test_w_early_stage2_no_effect_on_breakout;
          "test_min_price_zero_admits_low_priced"


### PR DESCRIPTION
## Bug

PR #1512 added `w_early_stage2 : int option [@sexp.option]`. `[@sexp.option]` **omits the field from `sexp_of_config` when `None`**, and `Backtest.Overlay_validator` derives the set of valid override key-paths from the **serialized** base config. So the field was unresolvable — a `config_overrides` / `Variant_matrix` axis targeting `screening_config.weights.w_early_stage2` crashed the runner:

```
Runner overlay #6 contains key(s) that do not resolve to any field on the base [Weinstein_strategy.config] record:
  - screening_config.weights.w_early_stage2
```

The axis #1512 was supposed to add was **non-functional**. Caught by an actual in-sample reweight backtest (not the unit tests — they only checked type/serialization behaviour, not the runner overlay path).

## Fix

`[@sexp.option]` → `[@sexp.default None]`: the field is always present in the serialized form (so `Overlay_validator` resolves it), while a *missing* field still parses to `None` (older config sexps round-trip). Behaviour unchanged (`None` still ⇒ `w_stage2_breakout / 2`).

## Verify
- Serialization test updated: field is PRESENT in default sexp; a missing-field sexp parses to `None`; `Some v` round-trips.
- **Integration**: a top-1000 backtest with `((screening_config ((weights ((w_early_stage2 (30)))))))` now runs (previously crashed at overlay validation). The reweight produced Sharpe 0.36 vs baseline 0.19 in-sample — i.e. the axis is now live.
- Full `dune build` green; all `dune runtest` OUnit groups OK; all linters OK in-container.

Follow-up to #1512. Behavioural/structural impact identical to #1512 (still default-off, still bit-identical when None).

🤖 Generated with [Claude Code](https://claude.com/claude-code)