### PR TITLE
docs(liquidity): trade-realism findings + cascade-reweight WF-CV scaffold

### DIFF
--- a/dev/experiments/cascade-reweight-wfcv-2026-06-10/README.md
+++ b/dev/experiments/cascade-reweight-wfcv-2026-06-10/README.md
@@ -1,0 +1,54 @@
+# cascade-reweight-wfcv-2026-06-10
+
+WF-CV surface over the **early-Stage2 scoring weight** (`w_early_stage2`), the axis
+shipped by PR #1512 + #1513. Tests the cascade-selection-inversion fix:
+confirmed `Stage1→2` breakouts (scored +30) under-perform `Early Stage2` entries
+(scored +15) on win-rate across breadths (`dev/notes/cascade-selection-inversion-2026-06-10.md`).
+
+## Hypothesis
+Raising `w_early_stage2` from the implicit 15 (`= w_stage2_breakout/2`, via
+default `None`) toward / past the breakout's 30 should let the higher-win-rate
+early entries out-rank (or tie) the breakouts in the cascade, improving
+risk-adjusted return — IF the in-sample edge generalises.
+
+## In-sample screen (already run, top-1000 full 2011-2026)
+| | baseline (None=15) | `w_early_stage2=30` |
+|---|---|---|
+| return | 29.6% | **187.4%** |
+| win% | 31.8% | 35.8% |
+| Sharpe | 0.19 | **0.36** |
+| MaxDD | 42% | 60% (worse) |
+
+Strong in-sample on return + risk-adjusted ratios; higher MaxDD. **But single-window
+in-sample — the 2019-26 era showed the early>breakout return edge collapses, so
+budget for a likely no-promote under WF-CV.**
+
+## Surface
+`spec_top3000.sexp`: axis `screening_config.weights.w_early_stage2 ∈ {Some 22, Some
+30, Some 38}` + `None` baseline, Rolling WF-CV on top-3000-2011 2011-2026
+(test_days 365, step 365 → ~15 folds), gate Sharpe m=8/n=15 worst_delta 0.30.
+
+## Launch (fork-per-fold for N=3000, per `project_laggard_broad_recheck`)
+```
+docker exec -d trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && \
+  nohup dune exec --no-build trading/backtest/walk_forward/bin/panel_runner.exe -- \
+    --spec dev/experiments/cascade-reweight-wfcv-2026-06-10/spec_top3000.sexp \
+    --snapshot-dir /tmp/snap_top3000_2011 --fixtures-root / \
+    --out-dir /tmp/sweeps/cascade-rw-wfcv --fork-per-fold \
+    > /tmp/sweeps/cascade-rw-wfcv.log 2>&1 &'
+```
+(Verify panel_runner's exact flag names before launch — `--fork-per-fold` /
+`--snapshot-dir` per the laggard re-check recipe.)
+
+## Decision
+Rank with Variant_ranking (Pareto) + Deflated_sharpe. If a value beats baseline on
+the frontier / positive-DSR across folds → confirmation grid (`.claude/rules/promotion-confirmation.md`:
+deep regime + different-breadth cells) before any default flip. Per
+`experiment-flag-discipline` R3, no default change without a ledger ACCEPT.
+
+## ⚠ Cross-check with the liquidity-realism work
+The cascade-inversion finding and the breadth question may both be **liquidity**
+stories (`dev/plans/trade-realism-liquidity-2026-06-10.md`). Before promoting any
+reweight, check whether A+/breakout entries are systematically in thinner names —
+if the inversion is a fill-realism artifact, a liquidity-aware position cap is the
+better lever than the scoring reweight.

--- a/dev/experiments/cascade-reweight-wfcv-2026-06-10/base_top3000.sexp
+++ b/dev/experiments/cascade-reweight-wfcv-2026-06-10/base_top3000.sexp
@@ -1,0 +1,18 @@
+;; Cell-E top-3000-2011 base for the w_early_stage2 reweight WF-CV surface.
+;; Snapshot mode (snap_top3000_2011). window_spec in the spec drives fold periods.
+((name "cascade-rw-base-top3000")
+ (description "Cell-E top-3000 base; w_early_stage2 axis surface.")
+ (period ((start_date 2011-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-2011.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.0)(bid_ask_spread_bps 5.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 100000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/experiments/cascade-reweight-wfcv-2026-06-10/spec_top3000.sexp
+++ b/dev/experiments/cascade-reweight-wfcv-2026-06-10/spec_top3000.sexp
@@ -1,0 +1,11 @@
+;; w_early_stage2 reweight surface, top-3000-2011 2011-2026, fork-per-fold.
+;; baseline = None (= w_stage2_breakout/2 = 15). axis values: Some 22/30/38.
+((base_scenario "dev/experiments/cascade-reweight-wfcv-2026-06-10/base_top3000.sexp")
+ (window_spec
+  (Rolling
+   ((start_date 2011-01-01)(end_date 2026-04-30)(train_days 0)(test_days 365)(step_days 365))))
+ (axes
+  (((key (screening_config weights w_early_stage2)) (values ((22) (30) (38))))))
+ (variants (((label "baseline") (overrides ()))))
+ (baseline_label "baseline")
+ (gate ((metric Sharpe) (m 8) (n 15) (worst_delta 0.30))))

--- a/dev/notes/trade-realism-liquidity-findings-2026-06-10.md
+++ b/dev/notes/trade-realism-liquidity-findings-2026-06-10.md
@@ -1,0 +1,110 @@
+# Trade-realism / liquidity findings — 2026-06-10
+
+**Directive (user, overnight 2026-06-10):** don't assume top-3000 = illiquid; we
+trade a modest book, not millions. Check actual volume / market-cap of our trades,
+grade realism, discount as needed — don't simply prefer top-1000 over top-3000.
+
+**Answer: liquidity is a non-issue at our position sizes, even at top-3000. The
+breadth edge is NOT a liquidity artifact, and neither is the cascade-selection
+inversion. Preferring top-1000 over top-3000 is not justified by liquidity.**
+
+## Method
+
+For each round-trip trade in a run, `position_usd = quantity × entry_price`, and
+`adv_usd` = trailing 20-trading-day mean of `close × volume` (raw shares) from the
+bar store (`data/<f>/<l>/<SYM>/data.csv`). `liq_ratio = position_usd / adv_usd` =
+**days-of-ADV** the position represents. Bucketed: `<0.1` trivial, `0.1–1` fine,
+`1–5` marginal, `>5` unrealistic for a price-taker. Discounted aggregate scales
+each trade's $-PnL by `min(1, K·adv/position)` (a first-order, impact-free haircut
+simulating a position cap at `K` days of ADV). Runs are the canonical Cell-E
+backtests (2011-2026, snapshot mode), `$1M` initial capital. Scripts:
+`/tmp/liq_analyze.sh`, `/tmp/liq_summary.sh`, `/tmp/liq_full.sh`.
+
+## Result 1 — realized trades are liquid on BOTH breadths
+
+| bucket (days-of-ADV) | top-1000 | top-3000 |
+|---|---|---|
+| `<0.1` (trivial) | 98% | 91% |
+| `0.1–1` | 1% | 7% |
+| `1–5` (marginal) | 1% | 2% |
+| `>5` (unrealistic) | 0% (1 trade) | 1% (6 trades) |
+| max ratio | 6.8 d | 41 d |
+
+Top-3000 has a slightly longer tail (6 unrealistic trades vs 1) but it is tiny.
+**Discounted aggregate** (cap each position at K days of ADV):
+
+| cap | top-1000 | top-3000 |
+|---|---|---|
+| K=0.1d | 191% of realized | 105% of realized |
+| K=1.0d | 152% | 105% |
+| K=5.0d | 113% | 101% |
+
+Capping positions at a realistic fraction of ADV gives **≥100% of realized PnL on
+both breadths** — because the few illiquid trades were net *losers*. **The edge
+survives realistic fills; discounting does not threaten it — it slightly helps.**
+
+## Result 2 — the fat-tail winners are in LIQUID names
+
+Top-3000 top-12 winners by $-PnL, all with `liq_ratio < 0.04 days` (one at 0.77d):
+CALX (+$779k, 0.03d, $257k position), DEG (+$472k, 0.035d), BVN (+$328k, 0.029d),
+BKE, GPN, DQ, AUY, AMED, AMD ($421k position, 0.000d), … The monster winners are
+**not** thin-name fantasy — they are realistically fillable positions in names
+doing tens of millions to ~$1B/day.
+
+## Result 3 — the cascade-inversion is NOT a liquidity artifact
+
+| | breakout | early |
+|---|---|---|
+| median liq (days) | 0.010 | 0.0065 |
+| win% | 33.8 | 42.2 |
+
+Both stage-kinds are liquid; the win-rate gap is not a fill effect. By score: the
+**highest** cascade score (85 / A+) picks the **most liquid** names (mean 0.05d)
+yet has the **worst** win-rate (31.8%); score-70 (early) is *less* liquid (0.63d)
+but best win-rate (45.9%). So the scoring-reweight lever
+(`w_early_stage2`, PR #1512/#1513) stands on its own — it is a genuine selection
+signal, not a liquidity confound. The 6 `>5d` trades are all small losers (foreign
+ADRs CELJF/ASMIY, etc.).
+
+## Result 4 — the terminal MTM is REAL and exitable (reframes prior "inflation")
+
+The top-3000 run ends at **$8.6M equity** of which **one open position, AXTI, is
+$6.69M (78%)**. Prior conclusion (`project_broad_universe_790_mtm_inflated`) called
+the +790% "MTM-inflated artifact." The liquidity lens corrects this: **AXTI's bars
+are Verified** — it genuinely ran to ~$79 (→$96 by May 2026) on **~$983M/day**
+dollar-volume. The $6.69M position is **0.01 days of ADV** (0.7% of one day's
+volume) — trivially exitable. The terminal mark is a **real, capturable unrealized
+gain, not thin-name fantasy.**
+
+The genuine concerns about it are therefore **(a) single-name concentration** (78%
+of NAV in one name — the entry cap `max_position_pct_long 0.14` is applied at entry
+but not re-applied as a winner appreciates, so a 36× winner balloons to 78% of
+NAV), and **(b) it is unrealized** (the strategy held to the backtest end and never
+executed a Stage 3/4 exit). Both are position-management questions, not liquidity.
+
+## Implications
+
+1. **Do not prefer top-1000 over top-3000 on liquidity grounds.** Top-3000 returns
+   are realistic at our scale; breadth = more genuine opportunities.
+2. **Re-weight the "top-3000 edge = artifact" priors** that drove the
+   laggard / force-exit / stage2-ma-hold rejection framing. The breadth edge is
+   real on realized + liquid trades; rejections should rest on cross-breadth /
+   per-fold generalisation, not an implicit "illiquid" assumption.
+   (`project_pit_survivorship_inflation` is about *survivorship* in the SP500
+   composition golden — a separate, still-valid concern — not about *liquidity*.)
+3. **Liquidity-aware position sizing (deliverable B) is LOW priority** — there is
+   almost no unrealistic trade to clamp. A **concentration / winner-trim** guard
+   (cap ongoing single-name NAV %, or a Weinstein Stage-3 trim) is the more
+   relevant risk lever, and is its own experiment.
+4. **The cascade-reweight (`w_early_stage2`) WF-CV is still warranted** — the
+   inversion is a real selection signal, independent of liquidity.
+
+## Caveats / next
+
+- `liq_ratio` uses a 20-day trailing ADV; a stress version would use ADV *during*
+  the actual exit week and a participation cap (e.g. ≤10%/day → days-to-exit).
+- A productionised OCaml `trade_liquidity` tool (reads the snapshot/CSV bar store,
+  emits per-trade realism grades + a discounted aggregate, mirroring
+  `trade_audit_report`) is worth building to make this a repeatable lens — but
+  given liquidity is a non-issue at current scale, it is secondary to the
+  concentration/winner-management finding.


### PR DESCRIPTION
## Trade-realism / liquidity analysis (user directive)

Measured per-trade `position_usd / adv_usd` (days-of-ADV) across top-1000 / top-3000 Cell-E runs. **Liquidity is a non-issue at our position sizes; the breadth edge is NOT a liquidity artifact.**

- Top-3000 realized trades: 91% < 0.1 days-of-ADV, only 1% (6 trades) > 5d; discounted aggregate (cap at K days ADV) = **≥100% of realized PnL** (the illiquid trades were net losers).
- The 12 biggest winners are all in liquid names (liq < 0.04d).
- The cascade-selection inversion is **not** a liquidity artifact — A+/85 picks the *most* liquid names yet has the worst win-rate.
- The AXTI $6.69M terminal mark (78% of NAV) is on a Verified $983M/day name → real + exitable, not thin-name fantasy. **Reframes the prior "MTM-inflation = artifact" conclusion** — the real concern is single-name concentration + it being unrealized, not liquidity.

**Conclusion: do not prefer top-1000 over top-3000 on liquidity grounds.** Full writeup: `dev/notes/trade-realism-liquidity-findings-2026-06-10.md` (plan in `dev/plans/`, already on main).

Also scaffolds the `w_early_stage2` reweight WF-CV experiment (`dev/experiments/cascade-reweight-wfcv-2026-06-10/`) — axis functional post #1512/#1513; in-sample screen strong (top-1000 Sharpe 0.19→0.36).

Docs/experiment-specs only → admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)