### PR TITLE
docs: screen-rigor skill + harvest-rotate rigorous-test plan

### DIFF
--- a/.claude/skills/screen-rigor/SKILL.md
+++ b/.claude/skills/screen-rigor/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: screen-rigor
+description: Walk a read-only "validate-before-build" screen through the 7 rigor checks and calibrate its verdict, BEFORE concluding build/no-build or promote/reject on a strategy mechanism. Use when an autopsy / opportunity-cost probe / forward-return study / "is there alpha in X" screen is about to produce a decision, when you're tempted to write "REJECTED" or "the mechanism doesn't work" off a cheap analysis, or when the user asks to validate a mechanism, screen a hypothesis, or sanity-check a no-build call. Pairs with experiment-gap-closing (the real WF-CV test this screen decides whether to enter).
+---
+
+# Screen rigor — make a cheap read-only screen honest before it decides anything
+
+A read-only screen run *before* building a mechanism is good discipline. But a
+screen reports on a **proxy**, so it can only support a narrow class of claims.
+This skill is the procedure; the spec it enforces is
+`.claude/rules/mechanism-validation-rigor.md`. It exists because the 2026-06-10
+harvest-rotate screen wrote **"REJECTED, both fail decisively"** off point-estimate
+medians when the distributions said **"coin-flip, no edge, mild tail-risk"** — same
+data, wrong verdict shape. (`dev/experiments/harvest-rotate-validation-2026-06-10/`.)
+
+This is the **gate before** `experiment-gap-closing`: the screen decides whether a
+hypothesis is worth the real WF-CV test, and reports what it found without
+overclaiming. It does **not** replace that test — a screen never rejects a
+mechanism, only its prioritization.
+
+## When to run this
+
+You're about to conclude a build/no-build or promote/reject from a read-only
+analysis (no new mechanism implemented, no WF-CV). The moment you find yourself
+typing a verdict sentence about a mechanism, stop and run the checklist.
+
+## The procedure
+
+### Step 1 — State the estimand, then the proxy, then the gap
+
+Write one sentence: *"The mechanism changes <realized-P&L quantity> by <how>."*
+Then: *"My screen measures <statistic>."* Then name the gap explicitly. If the
+statistic is a cross-sectional forward-return average and the mechanism is a rule
+that trades with stops and a real-time information set, the gap is large — the
+proxy can fail to find an edge that the real rule would capture, or vice-versa.
+Bound it: which direction does the proxy bias?
+
+### Step 2 — Run the seven checks (all must be answered in the writeup)
+
+1. **Estimand fidelity** — does the statistic track the realized-P&L the mechanism
+   moves? (Step 1.)
+2. **Distribution, not point estimate** — report n, mean, median, p10/p25/p75/p90
+   (or a histogram) for every headline number. Overlapping distributions with a
+   median gap = not an edge. A sign that flips under winsorization = a *tail*
+   statement; name the tail.
+3. **Economic magnitude, scaled** — annualize / express per-unit-capital. Don't
+   call a raw horizon fraction tiny or decisive.
+4. **Selection / survivorship bias** — what is each bucket conditioned on? "Mature
+   winner" buckets are survivor-selected. Use the info set the rule has *at
+   decision time*, not hindsight membership.
+5. **Surface, not boolean** — sweep the knob(s) (fraction k, threshold, pick-rank,
+   horizon) and show the response shape. One point can't reject — only fail to find
+   a free lunch at that point.
+6. **Paired / event-level** — when the decision is "at moment t, X vs Y," compute
+   the per-event difference, its sign-rate, and its distribution; trace a few
+   events end-to-end.
+7. **Uncertainty + power** — small n / wide spread → wide CI. Can the sample even
+   distinguish the hypotheses? (A bootstrap or sign-test beats an eyeballed median.)
+
+### Step 3 — Calibrate the verdict to what a proxy can claim
+
+A screen MAY conclude one of:
+- **"No obvious free lunch at the tested point → don't prioritize a build"** — a
+  *decision*, which may lean on a standing prior
+  (`feedback_strategy_mechanic_changes_too_explorative`, `weinstein-faithful-core.md`).
+  State the prior explicitly; don't dress it up as a data verdict.
+- **"Promising signal → escalate to the real test"** → hand off to
+  `experiment-gap-closing` (mechanism as a default-off surface, WF-CV, DSR/Pareto,
+  confirmation grid per `promotion-confirmation.md`).
+
+A screen may NOT conclude **"decisively rejected / the mechanism doesn't work."**
+Only the real WF-CV test rejects. Write *"no-build decision (citing the prior)"*,
+never *"rejected because the data proves it fails,"* when the data only shows
+no-edge-at-one-point.
+
+### Step 4 — Record it honestly
+
+Writeup includes: the estimand+gap sentence, the distributions (not just medians),
+the annualized magnitude, the selection-bias note, the knob sweep (or an explicit
+"single-point screen — cannot reject" caveat), and a verdict that matches Step 3.
+If the signal is promising, open the `experiment-gap-closing` loop; if it's a
+no-build decision, say which prior it leans on.
+
+## The one-line self-check
+
+> *Did I state the estimand gap, show the distribution, scale it economically, name
+> the selection bias, sweep the knob, and calibrate the verdict to what a proxy can
+> claim?* Any "no" → it's a draft, not a verdict.
+
+## Relationship to the other tools
+
+- `.claude/rules/mechanism-validation-rigor.md` — the spec (auto-loaded every
+  session); this skill is the procedure that applies it.
+- `experiment-gap-closing` skill — the **real** test the screen decides whether to
+  enter.
+- `promotion-confirmation.md` / `experiment-flag-discipline.md` — the gates *after*
+  the real test earns an ACCEPT.

--- a/dev/plans/harvest-rotate-rigorous-test-2026-06-10.md
+++ b/dev/plans/harvest-rotate-rigorous-test-2026-06-10.md
@@ -1,0 +1,104 @@
+# Harvest-rotate — the rigorous test — plan — 2026-06-10
+
+The read-only screen (`dev/experiments/harvest-rotate-validation-2026-06-10/`) was
+**inconclusive, not a rejection** (coin-flip per decision, no exploitable edge,
+mild tail-risk). User decision 2026-06-10: run the **rigorous** test — the only
+thing that answers *"timing + picks, reliably hit-able."* This means implementing
+harvest-rotate as a default-off **surface** and backtesting it under WF-CV, per
+`.claude/rules/mechanism-validation-rigor.md` Step 3 ("escalate to the real test")
+and the `experiment-gap-closing` loop.
+
+## ⚠ Faithfulness tension to resolve FIRST (W1–W3, weinstein-faithful-core.md)
+
+Trimming a **still-advancing Stage-2** winner to free capital contradicts the spine
+item *"let winners run — sell in Stage 3/4, not on a capital-reallocation
+argument."* The only Weinstein-faithful moment to harvest a winner is when it shows
+**Stage-3 topping precursors** — at which point the normal Stage-3 exit
+(`enable_stage3_force_exit`) already fires. So the faithful niche for harvest-rotate
+is narrow and specific:
+
+> **Faithful trigger = the Stage-2 `late` flag** (MA deceleration; fires 7–26 wk
+> before tops, 6/7 episodes — `project_stage_late_flag_discarded`). The winner is
+> *beginning* to top but hasn't triggered the Stage-3 exit yet. Harvest a fraction
+> there and rotate into a fresh Stage-2 leader = the trader's "rotate into
+> leadership" (his, "The Trader's Way"), not an arbitrary trim of a healthy
+> advancer.
+
+This is the **only** variant we should test as W2-faithful. A raw
+extension-threshold trigger (trim any position >X% above the MA) is **not**
+faithful — it trims healthy advancers — and should at most be a non-faithful
+contrast arm, clearly labelled. Note: a late-flag **stop-tighten** was already
+REJECTED (#1446), but that was *risk*-framed; this is *allocation*-framed (trim to
+fund a specific better-ranked blocked candidate), a different and more principled
+use — which is exactly why it's worth the real test.
+
+## The mechanism (default-off config surface)
+
+On the weekly `on_market_close`, for each held position P, IF:
+- `harvest_rotate_enabled` (default false), AND
+- P's stage is `Stage2 {late=true}` (the faithful trigger), AND
+- the screener produced ≥1 candidate C that would be entered but was blocked by
+  insufficient cash (the existing `alternatives_considered` / `Insufficient_cash`
+  signal), AND C's cascade score ≥ P's "freshness" (a higher-forward-return
+  candidate),
+THEN partial-exit P by fraction `k` and enter C with the freed capital.
+
+### Config axis (Variant_matrix)
+
+- `harvest_rotate_enabled : bool [@sexp.default false]`
+- `harvest_fraction k ∈ {0.33, 0.5, 1.0}` — fraction of P trimmed (1.0 = full rotate)
+- trigger arm ∈ { `late_flag` (faithful), `extension>θ` (contrast, non-faithful) }
+- `harvest_min_candidate_score` — only rotate if the blocked C is at least this
+  good (avoid rotating into junk). ∈ {fixed 60, 70}
+- candidate pick = highest cascade-score blocked candidate (fixed initially)
+
+Baseline = `harvest_rotate_enabled=false` (today's behaviour, the no-op default).
+
+## Core change required (A1 — decision item, user-greenlit 2026-06-10)
+
+`TriggerExit` is **whole-position only**. Need a **partial-exit transition**:
+`target_quantity` on `TriggerExit` (or a new `TriggerPartialExit { target_quantity }`)
++ engine/simulator handling to reduce `Holding` to `quantity − trim` and keep the
+remainder `Holding` (not `Closed`). `ExitFill` already supports partial
+`filled_quantity`, so fill mechanics exist — the gap is the **initiating transition**
++ the post-fill "return to Holding." Touches the A1 core watch-list
+(`trading/trading/strategy/`, `engine`, `simulation`). Land it as its own small,
+**strategy-agnostic** PR (it's generally useful, not Weinstein-specific), with QC.
+
+## Build sequence (small PRs, each builds + tested)
+
+1. **Core partial-exit transition** (strategy-agnostic). `target_quantity` on the
+   exit transition + engine/simulator "reduce to Holding" path + tests asserting a
+   `Holding(q) → partial-trim → Holding(q−t)` round-trip with correct cash + stop
+   tracking on the remainder. ~A1 core. Behind no flag (it's a capability).
+2. **Harvest-rotate mechanism** behind `harvest_rotate_enabled` (default-off) in
+   the Weinstein strategy: late-flag trigger + blocked-candidate detection + emit
+   the partial-exit + the rotation entry. Default-off → zero backtest change on
+   merge (`experiment-flag-discipline.md` R1).
+3. **Variant_matrix axis wiring** so `((flag harvest_rotate_enabled) (values (true false)))`
+   + the k / trigger / score axes expand and validate (R2).
+4. **WF-CV** on top-3000 (the universe where concentration arises), 15 folds,
+   fork-per-fold parallel=1 (~4h). Variants = baseline ∪ {faithful late_flag × k ×
+   score grid} (+ a few non-faithful extension arms as contrast). Rank via
+   `Variant_ranking` (Pareto) + `Deflated_sharpe`.
+5. **Decision** via `experiment-gap-closing` step 7: if a faithful variant survives
+   DSR + per-fold gate → confirmation grid (`promotion-confirmation.md`, ≥3
+   period×universe cells incl. one macro-regime-diverse). Else record ACCEPT/REJECT
+   in the ledger and keep default-off.
+
+## Metrics that matter here
+
+Beyond return/Sharpe: **realised-vs-unrealised split** (harvest converts unrealised
+marks to realised + redeployed capital — the `project_broad_universe_790_mtm_inflated`
+concern), **max single-name NAV%** over the run, **capital-relative MaxDD / Ulcer**
+(does rotation cut the concentration tail?), and **turnover / cost** (each trim is a
+taxable, spread-paying partial sale — the cost model prices `bid_ask_spread_bps`).
+
+## Prior-belief honesty
+
+The screen + the standing prior both lean against this. We run it anyway because
+(a) the user asked for the rigorous answer, and (b) the screen was genuinely
+inconclusive (coin-flip), not a rejection — so the cheap evidence doesn't settle it.
+Expected outcome is "REJECT, kept default-off" — but now with a WF-CV-grade verdict
+we can cite, not a proxy overclaim. If it surprises us and a faithful late-flag
+variant survives the grid, that's a real, promotable finding.


### PR DESCRIPTION
Two artifacts following the harvest-rotate methodology review (#1523):

- **`.claude/skills/screen-rigor/SKILL.md`** — interactive procedure that walks a read-only validate-before-build screen through the 7 rigor checks (the rule from #1523) + verdict calibration, BEFORE concluding build/no-build. Pairs with experiment-gap-closing (the real WF-CV test the screen decides whether to enter).
- **`dev/plans/harvest-rotate-rigorous-test-2026-06-10.md`** — the rigorous test the user greenlit: harvest-rotate as a default-off surface under WF-CV. Surfaces the key faithfulness finding — the only Weinstein-faithful harvest trigger is the Stage-2 `late` flag (topping precursor), not a raw extension threshold — plus the required A1 core partial-exit transition + build sequence.

Docs/skill-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)