### PR TITLE
feat(position): strategy-agnostic partial-exit transition (Holding→Exiting→Holding)

### DIFF
--- a/trading/trading/backtest/lib/stop_log.ml
+++ b/trading/trading/backtest/lib/stop_log.ml
@@ -104,7 +104,7 @@ let _process_transition t (trans : Position.transition) =
   | UpdateRiskParams { new_risk_params } ->
       let record = _ensure_record t ~position_id:trans.position_id ~symbol:"" in
       record.pos_current_stop <- new_risk_params.stop_loss_price
-  | TriggerExit { exit_reason; _ } ->
+  | TriggerExit { exit_reason; _ } | TriggerPartialExit { exit_reason; _ } ->
       let record = _ensure_record t ~position_id:trans.position_id ~symbol:"" in
       record.pos_exit_trigger <- Some (exit_trigger_of_reason exit_reason)
   | ExitComplete ->

--- a/trading/trading/simulation/lib/order_generator.ml
+++ b/trading/trading/simulation/lib/order_generator.ml
@@ -44,10 +44,12 @@ let _create_order ~id ~symbol ~side ~quantity =
 let _exit_order_for_position ~id position =
   let open Trading_strategy.Position in
   match get_state position with
-  | Exiting { quantity; _ } ->
+  | Exiting { target_quantity; _ } ->
+      (* Size the exit order at [target_quantity], not the full held [quantity]:
+         the two are equal for a full exit but differ for a partial trim. *)
       _create_order ~id ~symbol:position.symbol
         ~side:(_exit_order_side position.side)
-        ~quantity
+        ~quantity:target_quantity
   | _ -> Ok None
 
 let _transition_to_order ~id ~positions
@@ -57,9 +59,9 @@ let _transition_to_order ~id ~positions
   | CreateEntering { symbol; side; target_quantity; _ } ->
       _create_order ~id ~symbol ~side:(_entry_order_side side)
         ~quantity:target_quantity
-  | TriggerExit _ ->
+  | TriggerExit _ | TriggerPartialExit _ ->
       (* After _apply_transitions, the position is in Exiting state, not Holding.
-         We look up the Exiting position to get the quantity and side. *)
+         We look up the Exiting position to get the target quantity and side. *)
       Map.find positions transition.position_id
       |> Option.value_map ~default:(Ok None) ~f:(_exit_order_for_position ~id)
   | EntryFill _ | EntryComplete _ | CancelEntry _ | UpdateRiskParams _

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -314,7 +314,7 @@ let _apply_transitions ~positions ~transitions =
       | CreateEntering _ ->
           let%bind pos = Trading_strategy.Position.create_entering trans in
           Ok (Map.set acc ~key:pos.id ~data:pos)
-      | TriggerExit _ -> _apply_trigger_exit acc trans
+      | TriggerExit _ | TriggerPartialExit _ -> _apply_trigger_exit acc trans
       | CancelEntry _ -> Cancel_handler.apply_to_positions acc trans
       | _ -> Ok acc)
 

--- a/trading/trading/simulation/lib/split_handler.ml
+++ b/trading/trading/simulation/lib/split_handler.ml
@@ -32,7 +32,7 @@ let _scale_holding_state factor quantity entry_price entry_date risk_params =
     }
 
 let _scale_exiting_state factor quantity entry_price entry_date target_quantity
-    exit_price filled_quantity started_date =
+    exit_price filled_quantity started_date risk_params =
   Trading_strategy.Position.Exiting
     {
       quantity = quantity *. factor;
@@ -42,6 +42,8 @@ let _scale_exiting_state factor quantity entry_price entry_date target_quantity
       exit_price = exit_price /. factor;
       filled_quantity = filled_quantity *. factor;
       started_date;
+      (* [risk_params] left unchanged, mirroring [_scale_holding_state]. *)
+      risk_params;
     }
 
 let _compute_scaled_state factor
@@ -60,9 +62,10 @@ let _compute_scaled_state factor
         exit_price;
         filled_quantity;
         started_date;
+        risk_params;
       } ->
       _scale_exiting_state factor quantity entry_price entry_date
-        target_quantity exit_price filled_quantity started_date
+        target_quantity exit_price filled_quantity started_date risk_params
   | (Entering _ | Closed _) as s -> s
 
 let apply_to_position (factor : float) (pos : Trading_strategy.Position.t) :

--- a/trading/trading/simulation/test/test_order_generator.ml
+++ b/trading/trading/simulation/test/test_order_generator.ml
@@ -153,17 +153,17 @@ let test_create_entering_generates_buy_order _ =
     (is_ok_and_holds
        (elements_are
           [
-            (fun o ->
-              assert_that (order_essentials o)
-                (equal_to
-                   ({
-                      symbol = "AAPL";
-                      side = Buy;
-                      order_type = Market;
-                      quantity = 100.0;
-                      time_in_force = Day;
-                    }
-                     : order_essentials)));
+            field
+              (fun o -> order_essentials o)
+              (equal_to
+                 ({
+                    symbol = "AAPL";
+                    side = Buy;
+                    order_type = Market;
+                    quantity = 100.0;
+                    time_in_force = Day;
+                  }
+                   : order_essentials));
           ]))
 
 let test_trigger_exit_no_position_returns_empty _ =
@@ -194,17 +194,17 @@ let test_trigger_exit_with_position_generates_sell_order _ =
     (is_ok_and_holds
        (elements_are
           [
-            (fun o ->
-              assert_that (order_essentials o)
-                (equal_to
-                   ({
-                      symbol = "AAPL";
-                      side = Sell;
-                      order_type = Market;
-                      quantity = 100.0;
-                      time_in_force = Day;
-                    }
-                     : order_essentials)));
+            field
+              (fun o -> order_essentials o)
+              (equal_to
+                 ({
+                    symbol = "AAPL";
+                    side = Sell;
+                    order_type = Market;
+                    quantity = 100.0;
+                    time_in_force = Day;
+                  }
+                   : order_essentials));
           ]))
 
 (* A partial exit sizes the sell order at the trim quantity (40), not the full
@@ -228,17 +228,17 @@ let test_trigger_partial_exit_sizes_order_at_trim _ =
     (is_ok_and_holds
        (elements_are
           [
-            (fun o ->
-              assert_that (order_essentials o)
-                (equal_to
-                   ({
-                      symbol = "AAPL";
-                      side = Sell;
-                      order_type = Market;
-                      quantity = 40.0;
-                      time_in_force = Day;
-                    }
-                     : order_essentials)));
+            field
+              (fun o -> order_essentials o)
+              (equal_to
+                 ({
+                    symbol = "AAPL";
+                    side = Sell;
+                    order_type = Market;
+                    quantity = 40.0;
+                    time_in_force = Day;
+                  }
+                   : order_essentials));
           ]))
 
 let test_entry_fill_returns_no_orders _ =
@@ -279,28 +279,28 @@ let test_multiple_create_entering_generates_multiple_orders _ =
     (is_ok_and_holds
        (elements_are
           [
-            (fun o ->
-              assert_that (order_essentials o)
-                (equal_to
-                   ({
-                      symbol = "AAPL";
-                      side = Buy;
-                      order_type = Market;
-                      quantity = 100.0;
-                      time_in_force = Day;
-                    }
-                     : order_essentials)));
-            (fun o ->
-              assert_that (order_essentials o)
-                (equal_to
-                   ({
-                      symbol = "GOOGL";
-                      side = Buy;
-                      order_type = Market;
-                      quantity = 50.0;
-                      time_in_force = Day;
-                    }
-                     : order_essentials)));
+            field
+              (fun o -> order_essentials o)
+              (equal_to
+                 ({
+                    symbol = "AAPL";
+                    side = Buy;
+                    order_type = Market;
+                    quantity = 100.0;
+                    time_in_force = Day;
+                  }
+                   : order_essentials));
+            field
+              (fun o -> order_essentials o)
+              (equal_to
+                 ({
+                    symbol = "GOOGL";
+                    side = Buy;
+                    order_type = Market;
+                    quantity = 50.0;
+                    time_in_force = Day;
+                  }
+                   : order_essentials));
           ]))
 
 let test_mixed_transitions_filters_non_order_generating _ =
@@ -323,17 +323,17 @@ let test_mixed_transitions_filters_non_order_generating _ =
     (is_ok_and_holds
        (elements_are
           [
-            (fun o ->
-              assert_that (order_essentials o)
-                (equal_to
-                   ({
-                      symbol = "AAPL";
-                      side = Buy;
-                      order_type = Market;
-                      quantity = 100.0;
-                      time_in_force = Day;
-                    }
-                     : order_essentials)));
+            field
+              (fun o -> order_essentials o)
+              (equal_to
+                 ({
+                    symbol = "AAPL";
+                    side = Buy;
+                    order_type = Market;
+                    quantity = 100.0;
+                    time_in_force = Day;
+                  }
+                   : order_essentials));
           ]))
 
 (* ==================== Short Position Tests ==================== *)
@@ -353,17 +353,17 @@ let test_short_create_entering_generates_sell_order _ =
     (is_ok_and_holds
        (elements_are
           [
-            (fun o ->
-              assert_that (order_essentials o)
-                (equal_to
-                   ({
-                      symbol = "AAPL";
-                      side = Sell;
-                      order_type = Market;
-                      quantity = 100.0;
-                      time_in_force = Day;
-                    }
-                     : order_essentials)));
+            field
+              (fun o -> order_essentials o)
+              (equal_to
+                 ({
+                    symbol = "AAPL";
+                    side = Sell;
+                    order_type = Market;
+                    quantity = 100.0;
+                    time_in_force = Day;
+                  }
+                   : order_essentials));
           ]))
 
 let test_short_trigger_exit_generates_buy_order _ =
@@ -383,17 +383,17 @@ let test_short_trigger_exit_generates_buy_order _ =
     (is_ok_and_holds
        (elements_are
           [
-            (fun o ->
-              assert_that (order_essentials o)
-                (equal_to
-                   ({
-                      symbol = "AAPL";
-                      side = Buy;
-                      order_type = Market;
-                      quantity = 100.0;
-                      time_in_force = Day;
-                    }
-                     : order_essentials)));
+            field
+              (fun o -> order_essentials o)
+              (equal_to
+                 ({
+                    symbol = "AAPL";
+                    side = Buy;
+                    order_type = Market;
+                    quantity = 100.0;
+                    time_in_force = Day;
+                  }
+                   : order_essentials));
           ]))
 
 let suite =

--- a/trading/trading/simulation/test/test_order_generator.ml
+++ b/trading/trading/simulation/test/test_order_generator.ml
@@ -57,6 +57,20 @@ let make_trigger_exit_transition ~position_id ~exit_price =
         };
   }
 
+let make_trigger_partial_exit_transition ~position_id ~exit_price
+    ~target_quantity =
+  {
+    position_id;
+    date = today;
+    kind =
+      TriggerPartialExit
+        {
+          exit_reason = SignalReversal { description = "rotate capital" };
+          exit_price;
+          target_quantity;
+        };
+  }
+
 let make_entry_fill_transition ~position_id ~quantity ~price =
   {
     position_id;
@@ -102,6 +116,18 @@ let make_exiting_position ?(side = Long) ~position_id ~symbol ~quantity ~price
     make_holding_position ~side ~position_id ~symbol ~quantity ~price ()
   in
   let exit_trans = make_trigger_exit_transition ~position_id ~exit_price in
+  apply_transition holding_pos exit_trans |> Result.ok |> Option.value_exn
+
+(** Helper to create a position in Exiting state from a partial-exit trigger. *)
+let make_partial_exiting_position ?(side = Long) ~position_id ~symbol ~quantity
+    ~price ~exit_price ~target_quantity () =
+  let holding_pos =
+    make_holding_position ~side ~position_id ~symbol ~quantity ~price ()
+  in
+  let exit_trans =
+    make_trigger_partial_exit_transition ~position_id ~exit_price
+      ~target_quantity
+  in
   apply_transition holding_pos exit_trans |> Result.ok |> Option.value_exn
 
 (* ==================== transitions_to_orders tests ==================== *)
@@ -176,6 +202,40 @@ let test_trigger_exit_with_position_generates_sell_order _ =
                       side = Sell;
                       order_type = Market;
                       quantity = 100.0;
+                      time_in_force = Day;
+                    }
+                     : order_essentials)));
+          ]))
+
+(* A partial exit sizes the sell order at the trim quantity (40), not the full
+   held quantity (100). *)
+let test_trigger_partial_exit_sizes_order_at_trim _ =
+  let position =
+    make_partial_exiting_position ~position_id:"AAPL-1" ~symbol:"AAPL"
+      ~quantity:100.0 ~price:150.0 ~exit_price:155.0 ~target_quantity:40.0 ()
+  in
+  let positions = String.Map.singleton "AAPL-1" position in
+  let transitions =
+    [
+      make_trigger_partial_exit_transition ~position_id:"AAPL-1"
+        ~exit_price:155.0 ~target_quantity:40.0;
+    ]
+  in
+  let result =
+    transitions_to_orders ~current_date:today ~positions transitions
+  in
+  assert_that result
+    (is_ok_and_holds
+       (elements_are
+          [
+            (fun o ->
+              assert_that (order_essentials o)
+                (equal_to
+                   ({
+                      symbol = "AAPL";
+                      side = Sell;
+                      order_type = Market;
+                      quantity = 40.0;
                       time_in_force = Day;
                     }
                      : order_essentials)));
@@ -347,6 +407,8 @@ let suite =
          >:: test_trigger_exit_no_position_returns_empty;
          "test_trigger_exit_with_position_generates_sell_order"
          >:: test_trigger_exit_with_position_generates_sell_order;
+         "test_trigger_partial_exit_sizes_order_at_trim"
+         >:: test_trigger_partial_exit_sizes_order_at_trim;
          "test_entry_fill_returns_no_orders"
          >:: test_entry_fill_returns_no_orders;
          "test_entry_complete_returns_no_orders"

--- a/trading/trading/strategy/lib/position.ml
+++ b/trading/trading/strategy/lib/position.ml
@@ -58,6 +58,7 @@ type position_state =
       exit_price : float;
       filled_quantity : float;
       started_date : Date.t;
+      risk_params : risk_params;
     }
   | Closed of {
       quantity : float;
@@ -101,6 +102,11 @@ type transition_kind =
   | EntryComplete of { risk_params : risk_params }
   | CancelEntry of { reason : string }
   | TriggerExit of { exit_reason : exit_reason; exit_price : float }
+  | TriggerPartialExit of {
+      exit_reason : exit_reason;
+      exit_price : float;
+      target_quantity : float;
+    }
   | UpdateRiskParams of { new_risk_params : risk_params }
   | ExitFill of { filled_quantity : float; fill_price : float }
   | ExitComplete
@@ -114,7 +120,9 @@ type transition = {
 [@@deriving show, eq]
 
 let trigger_of_kind = function
-  | CreateEntering _ | TriggerExit _ | UpdateRiskParams _ -> Strategy
+  | CreateEntering _ | TriggerExit _ | TriggerPartialExit _ | UpdateRiskParams _
+    ->
+      Strategy
   | EntryFill _ | EntryComplete _ | ExitFill _ | ExitComplete | CancelEntry _ ->
       Simulator
 
@@ -155,6 +163,21 @@ let _validate_no_fills filled =
     Error
       (Status.invalid_argument_error "Cannot cancel entry after fills occurred")
 
+(* A partial-exit target must lie in (0, held]. A target equal to [held] is a
+   full exit expressed via [TriggerPartialExit]; it closes on [ExitComplete]. *)
+let _validate_exit_target ~held target_quantity =
+  let in_range =
+    Float.(target_quantity > 0.0) && Float.(target_quantity <= held)
+  in
+  if in_range then Ok ()
+  else
+    let msg =
+      Printf.sprintf
+        "Exit target_quantity (%.2f) must be in (0, %.2f] (held quantity)"
+        target_quantity held
+    in
+    Error (Status.invalid_argument_error msg)
+
 let _validate_transition t transition =
   match (t.state, transition.kind) with
   | ( Entering { target_quantity; filled_quantity = curr_filled; _ },
@@ -171,6 +194,12 @@ let _validate_transition t transition =
       [ _validate_no_fills filled_quantity ]
   | Holding _, TriggerExit { exit_price; _ } ->
       [ _validate_positive "exit_price" exit_price ]
+  | ( Holding { quantity; _ },
+      TriggerPartialExit { exit_price; target_quantity; _ } ) ->
+      [
+        _validate_positive "exit_price" exit_price;
+        _validate_exit_target ~held:quantity target_quantity;
+      ]
   | Holding _, UpdateRiskParams _ -> []
   | ( Exiting { target_quantity; filled_quantity = curr_filled; _ },
       ExitFill { filled_quantity; fill_price } ) ->
@@ -298,18 +327,22 @@ let _apply_entering_transition t transition =
       _cancel_entry t ~date ~entry_price ~created_date
   | _, kind -> _invalid_transition kind
 
-let _trigger_exit t ~date ~quantity ~entry_price ~entry_date ~exit_reason
-    ~exit_price =
+(* Shared [Holding -> Exiting] builder. [target_quantity] is the resolved trim:
+   the full held [quantity] for a [TriggerExit], or the requested amount for a
+   [TriggerPartialExit]. *)
+let _trigger_exit t ~date ~quantity ~entry_price ~entry_date ~risk_params
+    ~exit_reason ~exit_price ~target_quantity =
   let state =
     Exiting
       {
         quantity;
         entry_price;
         entry_date;
-        target_quantity = quantity;
+        target_quantity;
         exit_price;
         filled_quantity = 0.0;
         started_date = date;
+        risk_params;
       }
   in
   Ok { t with state; exit_reason = Some exit_reason; last_updated = date }
@@ -328,10 +361,15 @@ let _update_risk_params t ~date ~quantity ~entry_price ~entry_date
 let _apply_holding_transition t transition =
   let date = transition.date in
   match (t.state, transition.kind) with
-  | ( Holding { quantity; entry_price; entry_date; _ },
+  | ( Holding { quantity; entry_price; entry_date; risk_params },
       TriggerExit { exit_reason; exit_price } ) ->
-      _trigger_exit t ~date ~quantity ~entry_price ~entry_date ~exit_reason
-        ~exit_price
+      (* Full exit: trim the whole held quantity. *)
+      _trigger_exit t ~date ~quantity ~entry_price ~entry_date ~risk_params
+        ~exit_reason ~exit_price ~target_quantity:quantity
+  | ( Holding { quantity; entry_price; entry_date; risk_params },
+      TriggerPartialExit { exit_reason; exit_price; target_quantity } ) ->
+      _trigger_exit t ~date ~quantity ~entry_price ~entry_date ~risk_params
+        ~exit_reason ~exit_price ~target_quantity
   | ( Holding { quantity; entry_price; entry_date; _ },
       UpdateRiskParams { new_risk_params } ) ->
       _update_risk_params t ~date ~quantity ~entry_price ~entry_date
@@ -339,7 +377,7 @@ let _apply_holding_transition t transition =
   | _, kind -> _invalid_transition kind
 
 let _exit_fill t ~date ~quantity ~entry_price ~entry_date ~target_quantity
-    ~exit_price ~curr ~started_date ~filled_quantity =
+    ~exit_price ~curr ~started_date ~risk_params ~filled_quantity =
   let state =
     Exiting
       {
@@ -350,27 +388,49 @@ let _exit_fill t ~date ~quantity ~entry_price ~entry_date ~target_quantity
         exit_price;
         filled_quantity = curr +. filled_quantity;
         started_date;
+        risk_params;
       }
   in
   Ok { t with state; last_updated = date }
 
-let _exit_complete t ~date ~filled_quantity ~entry_price ~exit_price ~entry_date
-    =
+let _closed_state ~date ~filled_quantity ~entry_price ~exit_price ~entry_date =
+  Closed
+    {
+      quantity = filled_quantity;
+      entry_price;
+      exit_price;
+      gross_pnl = None;
+      entry_date;
+      exit_date = date;
+      days_held = Date.diff date entry_date;
+    }
+
+let _holding_after_partial_exit ~quantity ~filled_quantity ~entry_price
+    ~entry_date ~risk_params =
+  Holding
+    {
+      quantity = quantity -. filled_quantity;
+      entry_price;
+      entry_date;
+      risk_params;
+    }
+
+(* On exit completion, a {b full} exit ([filled_quantity >= quantity], the held
+   amount) closes the position; a {b partial} exit returns to [Holding] with the
+   reduced quantity, preserving the original entry price/date and risk params so
+   the remainder keeps tracking its stop. *)
+let _exit_complete t ~date ~quantity ~filled_quantity ~entry_price ~exit_price
+    ~entry_date ~risk_params =
   let state =
-    Closed
-      {
-        quantity = filled_quantity;
-        entry_price;
-        exit_price;
-        gross_pnl = None;
-        entry_date;
-        exit_date = date;
-        days_held = Date.diff date entry_date;
-      }
+    if Float.(filled_quantity >= quantity) then
+      _closed_state ~date ~filled_quantity ~entry_price ~exit_price ~entry_date
+    else
+      _holding_after_partial_exit ~quantity ~filled_quantity ~entry_price
+        ~entry_date ~risk_params
   in
   Ok { t with state; last_updated = date }
 
-(* @nesting-ok: 7-field Exiting pattern forces multiline match; depth is structural *)
+(* @nesting-ok: 8-field Exiting pattern forces multiline match; depth is structural *)
 let _apply_exiting_transition t transition =
   let date = transition.date in
   match (t.state, transition.kind) with
@@ -383,14 +443,24 @@ let _apply_exiting_transition t transition =
           exit_price;
           filled_quantity = curr;
           started_date;
+          risk_params;
         },
       ExitFill { filled_quantity; _ } ) ->
       _exit_fill t ~date ~quantity ~entry_price ~entry_date ~target_quantity
-        ~exit_price ~curr ~started_date ~filled_quantity
-  | ( Exiting { filled_quantity; entry_price; exit_price; entry_date; _ },
+        ~exit_price ~curr ~started_date ~risk_params ~filled_quantity
+  | ( Exiting
+        {
+          quantity;
+          filled_quantity;
+          entry_price;
+          exit_price;
+          entry_date;
+          risk_params;
+          _;
+        },
       ExitComplete ) ->
-      _exit_complete t ~date ~filled_quantity ~entry_price ~exit_price
-        ~entry_date
+      _exit_complete t ~date ~quantity ~filled_quantity ~entry_price ~exit_price
+        ~entry_date ~risk_params
   | _, kind -> _invalid_transition kind
 
 (** {1 Transition Application} *)

--- a/trading/trading/strategy/lib/position.mli
+++ b/trading/trading/strategy/lib/position.mli
@@ -22,8 +22,17 @@
 
     - {b Entering}: Order placed, waiting for fills (partial fills allowed)
     - {b Holding}: Position open, monitoring for exit signals
-    - {b Exiting}: Exit triggered, waiting for fills to close
+    - {b Exiting}: Exit triggered, waiting for fills (full close or partial
+      trim)
     - {b Closed}: Position fully closed, P&L realized
+
+    A {b partial exit} (a [TriggerPartialExit] with [target_quantity] strictly
+    less than the held quantity) trims the position: it goes
+    [Holding -> Exiting] like a full exit, but on [ExitComplete] returns to
+    [Holding] with the reduced quantity (original entry price/date and risk
+    params preserved) instead of moving to [Closed]. A full exit ([TriggerExit],
+    or a [TriggerPartialExit] with [target_quantity] equal to the held quantity)
+    behaves exactly as before and ends in [Closed].
 
     {1 Transitions}
 
@@ -31,10 +40,12 @@
     - [EntryFill]: Entry order filled (partially or fully)
     - [EntryComplete]: Entry fully filled, move to Holding
     - [CancelEntry]: Cancel entry before any fills
-    - [TriggerExit]: Exit signal detected, start closing
+    - [TriggerExit]: Exit signal detected, start closing the whole position
+    - [TriggerPartialExit]: Trim part of the position, keeping the remainder
     - [UpdateRiskParams]: Modify stop loss / take profit while holding
     - [ExitFill]: Exit order filled (partially or fully)
-    - [ExitComplete]: Exit fully filled, position closed
+    - [ExitComplete]: Exit filled — closes a full exit, or returns a partial
+      exit to Holding on the reduced quantity
 
     Each transition is validated for:
     - State compatibility (can only apply valid transitions to current state)
@@ -189,14 +200,22 @@ type position_state =
       risk_params : risk_params;
     }  (** State: Position is open, monitoring for exit *)
   | Exiting of {
-      quantity : float;  (** Position quantity being exited *)
+      quantity : float;  (** Position quantity held when the exit started *)
       entry_price : float;  (** Original entry price *)
       entry_date : Date.t;  (** Original entry date *)
-      target_quantity : float;  (** Amount to exit *)
+      target_quantity : float;
+          (** Amount to exit. A {b partial} exit has
+              [target_quantity < quantity] (the remainder returns to {!Holding}
+              on [ExitComplete]); a {b full} exit has
+              [target_quantity = quantity] (closes on [ExitComplete]). *)
       exit_price : float;  (** Price for exit order *)
       filled_quantity : float;  (** Amount exited so far *)
       started_date : Date.t;  (** When exit started *)
-    }  (** State: Attempting to close position *)
+      risk_params : risk_params;
+          (** Risk parameters carried over from {!Holding}. Re-applied to the
+              remaining {!Holding} when a partial exit completes, so the trimmed
+              position keeps tracking its stop on the reduced quantity. *)
+    }  (** State: Attempting to close (or trim) a position *)
   | Closed of {
       quantity : float;  (** Final position quantity *)
       entry_price : float;  (** Average entry price *)
@@ -233,7 +252,7 @@ type t = {
 (** Who triggers a transition.
 
     - [Strategy]: Returned from strategy's on_market_close (e.g.,
-      CreateEntering, TriggerExit, UpdateRiskParams)
+      CreateEntering, TriggerExit, TriggerPartialExit, UpdateRiskParams)
     - [Simulator]: Applied by simulator in response to order fills or timeouts
       (e.g., EntryFill, EntryComplete, ExitFill, ExitComplete, CancelEntry) *)
 type transition_trigger = Strategy | Simulator [@@deriving show, eq]
@@ -255,7 +274,23 @@ type transition_kind =
       (** Entry fully filled, transition to holding *)
   | CancelEntry of { reason : string }  (** Cancel entry before any fills *)
   | TriggerExit of { exit_reason : exit_reason; exit_price : float }
-      (** Exit condition triggered *)
+      (** Exit the {b whole} position. Unchanged from before: goes
+          [Holding -> Exiting] and closes on [ExitComplete]. *)
+  | TriggerPartialExit of {
+      exit_reason : exit_reason;
+      exit_price : float;
+      target_quantity : float;
+          (** Quantity to trim. Must satisfy
+              [0.0 < target_quantity <= held_quantity] (validated on the
+              [Holding -> Exiting] step; otherwise the transition is rejected).
+              When [target_quantity] is strictly less than the held quantity the
+              remainder returns to {!Holding} on [ExitComplete]; when it equals
+              the held quantity the position closes, identically to
+              {!TriggerExit}. *)
+    }
+      (** Trim part of a held position. The remainder keeps tracking its stop
+          (risk params) on the reduced quantity. Strategy-agnostic: any strategy
+          can request a partial exit without the core knowing why. *)
   | UpdateRiskParams of { new_risk_params : risk_params }
       (** Update stop loss / take profit levels *)
   | ExitFill of { filled_quantity : float; fill_price : float }
@@ -274,9 +309,9 @@ type transition = {
 val trigger_of_kind : transition_kind -> transition_trigger
 (** Get the trigger type for a transition kind.
 
-    Strategy-triggered: CreateEntering, TriggerExit, UpdateRiskParams
-    Simulator-triggered: EntryFill, EntryComplete, ExitFill, ExitComplete,
-    CancelEntry *)
+    Strategy-triggered: CreateEntering, TriggerExit, TriggerPartialExit,
+    UpdateRiskParams Simulator-triggered: EntryFill, EntryComplete, ExitFill,
+    ExitComplete, CancelEntry *)
 
 (** {1 Position Operations} *)
 

--- a/trading/trading/strategy/test/test_position.ml
+++ b/trading/trading/strategy/test/test_position.ml
@@ -99,28 +99,27 @@ let test_create_entering _ =
   in
   assert_that
     (create_entering transition)
-    (is_ok_and_holds (fun pos ->
-         assert_that pos
-           (equal_to
-              ({
-                 id = "pos-1";
-                 symbol = "AAPL";
-                 side = Long;
-                 entry_reasoning =
-                   TechnicalSignal { indicator = "EMA"; description = "Test" };
-                 exit_reason = None;
-                 state =
-                   Entering
-                     {
-                       target_quantity = 100.0;
-                       entry_price = 150.0;
-                       filled_quantity = 0.0;
-                       created_date = date_of_string "2024-01-01";
-                     };
-                 last_updated = date_of_string "2024-01-01";
-                 portfolio_lot_ids = [];
-               }
-                : t))))
+    (is_ok_and_holds
+       (equal_to
+          ({
+             id = "pos-1";
+             symbol = "AAPL";
+             side = Long;
+             entry_reasoning =
+               TechnicalSignal { indicator = "EMA"; description = "Test" };
+             exit_reason = None;
+             state =
+               Entering
+                 {
+                   target_quantity = 100.0;
+                   entry_price = 150.0;
+                   filled_quantity = 0.0;
+                   created_date = date_of_string "2024-01-01";
+                 };
+             last_updated = date_of_string "2024-01-01";
+             portfolio_lot_ids = [];
+           }
+            : t)))
 
 (* ==================== Entry Transitions ==================== *)
 
@@ -135,11 +134,12 @@ let test_entry_fill_partial _ =
   in
   assert_that
     (apply_transition pos transition)
-    (is_ok_and_holds (fun pos' ->
-         match get_state pos' with
-         | Entering entering ->
-             assert_that entering.filled_quantity (float_equal 50.0)
-         | _ -> assert_failure "Expected Entering state"))
+    (is_ok_and_holds
+       (field
+          (fun pos' -> get_state pos')
+          (matching ~msg:"Expected Entering state"
+             (function Entering e -> Some e.filled_quantity | _ -> None)
+             (float_equal 50.0))))
 
 let test_entry_fill_multiple _ =
   let pos = make_entering () in
@@ -153,11 +153,12 @@ let test_entry_fill_multiple _ =
   in
   assert_that
     (apply_transition pos transition)
-    (is_ok_and_holds (fun pos' ->
-         match get_state pos' with
-         | Entering entering ->
-             assert_that entering.filled_quantity (float_equal 80.0)
-         | _ -> assert_failure "Expected Entering state"))
+    (is_ok_and_holds
+       (field
+          (fun pos' -> get_state pos')
+          (matching ~msg:"Expected Entering state"
+             (function Entering e -> Some e.filled_quantity | _ -> None)
+             (float_equal 80.0))))
 
 let test_entry_fill_exceeds_target _ =
   let pos = make_entering ~target:100.0 () in
@@ -210,22 +211,23 @@ let test_entry_complete _ =
   in
   assert_that
     (apply_transition pos transition)
-    (is_ok_and_holds (fun pos' ->
-         assert_that (get_state pos')
-           (equal_to
-              (Holding
-                 {
-                   quantity = 100.0;
-                   entry_price = 150.0;
-                   entry_date = date_of_string "2024-01-02";
-                   risk_params =
-                     {
-                       stop_loss_price = Some 142.5;
-                       take_profit_price = Some 165.0;
-                       max_hold_days = Some 30;
-                     };
-                 }
-                : position_state))))
+    (is_ok_and_holds
+       (field
+          (fun pos' -> get_state pos')
+          (equal_to
+             (Holding
+                {
+                  quantity = 100.0;
+                  entry_price = 150.0;
+                  entry_date = date_of_string "2024-01-02";
+                  risk_params =
+                    {
+                      stop_loss_price = Some 142.5;
+                      take_profit_price = Some 165.0;
+                      max_hold_days = Some 30;
+                    };
+                }
+               : position_state))))
 
 let test_entry_complete_no_fills _ =
   let pos = make_entering () in
@@ -260,11 +262,16 @@ let test_cancel_entry_no_fills _ =
   in
   assert_that
     (apply_transition pos transition)
-    (is_ok_and_holds (fun pos' ->
-         assert_that (is_closed pos') (equal_to true);
-         match get_state pos' with
-         | Closed closed -> assert_that closed.quantity (float_equal 0.0)
-         | _ -> assert_failure "Expected Closed state"))
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun pos' -> is_closed pos') (equal_to true);
+            field
+              (fun pos' -> get_state pos')
+              (matching ~msg:"Expected Closed state"
+                 (function Closed c -> Some c.quantity | _ -> None)
+                 (float_equal 0.0));
+          ]))
 
 let test_cancel_entry_with_fills _ =
   let pos = make_entering () in
@@ -304,36 +311,41 @@ let test_trigger_exit _ =
   in
   assert_that
     (apply_transition pos transition)
-    (is_ok_and_holds (fun pos' ->
-         assert_that (get_state pos')
-           (equal_to
-              (Exiting
-                 {
-                   quantity = 100.0;
-                   entry_price = 150.0;
-                   entry_date = date_of_string "2024-01-02";
-                   target_quantity = 100.0;
-                   exit_price = 165.0;
-                   filled_quantity = 0.0;
-                   started_date = date_of_string "2024-01-10";
-                   risk_params =
-                     {
-                       stop_loss_price = Some 142.5;
-                       take_profit_price = Some 165.0;
-                       max_hold_days = Some 30;
-                     };
-                 }
-                : position_state));
-         assert_that pos'.exit_reason
-           (is_some_and
+    (is_ok_and_holds
+       (all_of
+          [
+            field
+              (fun pos' -> get_state pos')
               (equal_to
-                 (TakeProfit
+                 (Exiting
                     {
-                      target_price = 165.0;
-                      actual_price = 165.5;
-                      profit_percent = 10.3;
+                      quantity = 100.0;
+                      entry_price = 150.0;
+                      entry_date = date_of_string "2024-01-02";
+                      target_quantity = 100.0;
+                      exit_price = 165.0;
+                      filled_quantity = 0.0;
+                      started_date = date_of_string "2024-01-10";
+                      risk_params =
+                        {
+                          stop_loss_price = Some 142.5;
+                          take_profit_price = Some 165.0;
+                          max_hold_days = Some 30;
+                        };
                     }
-                   : exit_reason)))))
+                   : position_state));
+            field
+              (fun pos' -> pos'.exit_reason)
+              (is_some_and
+                 (equal_to
+                    (TakeProfit
+                       {
+                         target_price = 165.0;
+                         actual_price = 165.5;
+                         profit_percent = 10.3;
+                       }
+                      : exit_reason)));
+          ]))
 
 let test_update_risk_params _ =
   let pos = make_holding () in
@@ -353,17 +365,18 @@ let test_update_risk_params _ =
   in
   assert_that
     (apply_transition pos transition)
-    (is_ok_and_holds (fun pos' ->
-         assert_that (get_state pos')
-           (equal_to
-              (Holding
-                 {
-                   quantity = 100.0;
-                   entry_price = 150.0;
-                   entry_date = date_of_string "2024-01-02";
-                   risk_params = new_params;
-                 }
-                : position_state))))
+    (is_ok_and_holds
+       (field
+          (fun pos' -> get_state pos')
+          (equal_to
+             (Holding
+                {
+                  quantity = 100.0;
+                  entry_price = 150.0;
+                  entry_date = date_of_string "2024-01-02";
+                  risk_params = new_params;
+                }
+               : position_state))))
 
 (* ==================== Exit Transitions ==================== *)
 
@@ -408,21 +421,22 @@ let test_exit_fill _ =
   in
   assert_that
     (apply_transition pos transition)
-    (is_ok_and_holds (fun pos' ->
-         assert_that (get_state pos')
-           (equal_to
-              (Exiting
-                 {
-                   quantity = 100.0;
-                   entry_price = 150.0;
-                   entry_date = date_of_string "2024-01-02";
-                   target_quantity = 100.0;
-                   exit_price = 165.0;
-                   filled_quantity = 100.0;
-                   started_date = date_of_string "2024-01-10";
-                   risk_params = no_risk_params;
-                 }
-                : position_state))))
+    (is_ok_and_holds
+       (field
+          (fun pos' -> get_state pos')
+          (equal_to
+             (Exiting
+                {
+                  quantity = 100.0;
+                  entry_price = 150.0;
+                  entry_date = date_of_string "2024-01-02";
+                  target_quantity = 100.0;
+                  exit_price = 165.0;
+                  filled_quantity = 100.0;
+                  started_date = date_of_string "2024-01-10";
+                  risk_params = no_risk_params;
+                }
+               : position_state))))
 
 let test_exit_complete _ =
   let pos =
@@ -465,21 +479,25 @@ let test_exit_complete _ =
   in
   assert_that
     (apply_transition pos transition)
-    (is_ok_and_holds (fun pos' ->
-         assert_that (is_closed pos') (equal_to true);
-         assert_that (get_state pos')
-           (equal_to
-              (Closed
-                 {
-                   quantity = 100.0;
-                   entry_price = 150.0;
-                   exit_price = 165.5;
-                   gross_pnl = None;
-                   entry_date = date_of_string "2024-01-02";
-                   exit_date = date_of_string "2024-01-10";
-                   days_held = 8;
-                 }
-                : position_state))))
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun pos' -> is_closed pos') (equal_to true);
+            field
+              (fun pos' -> get_state pos')
+              (equal_to
+                 (Closed
+                    {
+                      quantity = 100.0;
+                      entry_price = 150.0;
+                      exit_price = 165.5;
+                      gross_pnl = None;
+                      entry_date = date_of_string "2024-01-02";
+                      exit_date = date_of_string "2024-01-10";
+                      days_held = 8;
+                    }
+                   : position_state));
+          ]))
 
 (* ==================== Partial Exit Transitions ==================== *)
 
@@ -729,28 +747,26 @@ let test_create_entering_creates_position _ =
   in
   assert_that
     (create_entering transition)
-    (is_ok_and_holds (fun pos ->
-         assert_that pos
-           (equal_to
-              ({
-                 id = "AAPL-1";
-                 symbol = "AAPL";
-                 side = Long;
-                 entry_reasoning =
-                   ManualDecision { description = "Buy and hold" };
-                 exit_reason = None;
-                 state =
-                   Entering
-                     {
-                       target_quantity = 100.0;
-                       entry_price = 150.0;
-                       filled_quantity = 0.0;
-                       created_date = date_of_string "2024-01-01";
-                     };
-                 last_updated = date_of_string "2024-01-01";
-                 portfolio_lot_ids = [];
-               }
-                : t))))
+    (is_ok_and_holds
+       (equal_to
+          ({
+             id = "AAPL-1";
+             symbol = "AAPL";
+             side = Long;
+             entry_reasoning = ManualDecision { description = "Buy and hold" };
+             exit_reason = None;
+             state =
+               Entering
+                 {
+                   target_quantity = 100.0;
+                   entry_price = 150.0;
+                   filled_quantity = 0.0;
+                   created_date = date_of_string "2024-01-01";
+                 };
+             last_updated = date_of_string "2024-01-01";
+             portfolio_lot_ids = [];
+           }
+            : t)))
 
 (** Test: CreateEntering with different reasoning types *)
 let test_create_entering_with_various_reasoning _ =
@@ -772,8 +788,7 @@ let test_create_entering_with_various_reasoning _ =
     in
     assert_that
       (create_entering transition)
-      (is_ok_and_holds (fun pos ->
-           assert_that pos (equal_to (expected_pos : t))))
+      (is_ok_and_holds (equal_to (expected_pos : t)))
   in
 
   (* Test all reasoning types *)

--- a/trading/trading/strategy/test/test_position.ml
+++ b/trading/trading/strategy/test/test_position.ml
@@ -7,6 +7,9 @@ let date_of_string s = Date.of_string s
 
 (* Test helpers *)
 
+let no_risk_params =
+  { stop_loss_price = None; take_profit_price = None; max_hold_days = None }
+
 let make_entering ?(id = "pos-1") ?(symbol = "AAPL") ?(target = 100.0)
     ?(entry_price = 150.0) () =
   let transition =
@@ -40,6 +43,14 @@ let apply_entry_fill pos ~filled_quantity =
   match apply_transition pos transition with
   | Ok pos' -> pos'
   | Error err -> failwith ("Failed to apply fill: " ^ Status.show err)
+
+let apply_or_fail pos kind =
+  let transition =
+    { position_id = pos.id; date = date_of_string "2024-01-10"; kind }
+  in
+  match apply_transition pos transition with
+  | Ok pos' -> pos'
+  | Error err -> failwith ("Failed to apply transition: " ^ Status.show err)
 
 let make_holding ?(id = "pos-1") ?(symbol = "AAPL") ?(quantity = 100.0)
     ?(entry_price = 150.0) () =
@@ -305,6 +316,12 @@ let test_trigger_exit _ =
                    exit_price = 165.0;
                    filled_quantity = 0.0;
                    started_date = date_of_string "2024-01-10";
+                   risk_params =
+                     {
+                       stop_loss_price = Some 142.5;
+                       take_profit_price = Some 165.0;
+                       max_hold_days = Some 30;
+                     };
                  }
                 : position_state));
          assert_that pos'.exit_reason
@@ -376,6 +393,7 @@ let test_exit_fill _ =
             exit_price = 165.0;
             filled_quantity = 0.0;
             started_date = date_of_string "2024-01-10";
+            risk_params = no_risk_params;
           };
       last_updated = date_of_string "2024-01-10";
       portfolio_lot_ids = [];
@@ -402,6 +420,7 @@ let test_exit_fill _ =
                    exit_price = 165.0;
                    filled_quantity = 100.0;
                    started_date = date_of_string "2024-01-10";
+                   risk_params = no_risk_params;
                  }
                 : position_state))))
 
@@ -431,6 +450,7 @@ let test_exit_complete _ =
             exit_price = 165.5;
             filled_quantity = 100.0;
             started_date = date_of_string "2024-01-10";
+            risk_params = no_risk_params;
           };
       last_updated = date_of_string "2024-01-10";
       portfolio_lot_ids = [];
@@ -460,6 +480,170 @@ let test_exit_complete _ =
                    days_held = 8;
                  }
                 : position_state))))
+
+(* ==================== Partial Exit Transitions ==================== *)
+
+(* risk_params that [make_holding] installs; the partial-exit path must carry
+   these through Exiting and back onto the trimmed Holding. *)
+let holding_risk_params =
+  {
+    stop_loss_price = Some 142.5;
+    take_profit_price = Some 165.0;
+    max_hold_days = Some 30;
+  }
+
+let take_profit_reason =
+  TakeProfit
+    { target_price = 165.0; actual_price = 165.5; profit_percent = 10.3 }
+
+let partial_exit_kind ?(exit_price = 165.0) target_quantity =
+  TriggerPartialExit
+    { exit_reason = take_profit_reason; exit_price; target_quantity }
+
+let exit_fill_kind ~filled_quantity =
+  ExitFill { filled_quantity; fill_price = 165.5 }
+
+(* A partial [TriggerPartialExit] puts the position into Exiting with
+   [target_quantity] = the requested trim (not the full held quantity), carrying
+   the holding's risk params and original entry price/date. *)
+let test_trigger_partial_exit _ =
+  let pos = make_holding () in
+  assert_that
+    (apply_transition pos
+       {
+         position_id = "pos-1";
+         date = date_of_string "2024-01-10";
+         kind = partial_exit_kind 40.0;
+       })
+    (is_ok_and_holds
+       (field
+          (fun p -> get_state p)
+          (equal_to
+             (Exiting
+                {
+                  quantity = 100.0;
+                  entry_price = 150.0;
+                  entry_date = date_of_string "2024-01-02";
+                  target_quantity = 40.0;
+                  exit_price = 165.0;
+                  filled_quantity = 0.0;
+                  started_date = date_of_string "2024-01-10";
+                  risk_params = holding_risk_params;
+                }
+               : position_state))))
+
+(* Full partial-exit round-trip: Holding(100) -> trim 40 -> ExitFill(40) ->
+   ExitComplete -> Holding(60) with original entry price/date and risk params
+   preserved on the reduced quantity. *)
+let test_partial_exit_returns_to_holding _ =
+  let pos = make_holding () in
+  let pos = apply_or_fail pos (partial_exit_kind 40.0) in
+  let pos = apply_or_fail pos (exit_fill_kind ~filled_quantity:40.0) in
+  assert_that
+    (apply_transition pos
+       {
+         position_id = "pos-1";
+         date = date_of_string "2024-01-12";
+         kind = ExitComplete;
+       })
+    (is_ok_and_holds
+       (field
+          (fun p -> get_state p)
+          (equal_to
+             (Holding
+                {
+                  quantity = 60.0;
+                  entry_price = 150.0;
+                  entry_date = date_of_string "2024-01-02";
+                  risk_params = holding_risk_params;
+                }
+               : position_state))))
+
+(* A [TriggerPartialExit] whose target equals the full held quantity closes the
+   position on ExitComplete, exactly like a [TriggerExit]. *)
+let test_partial_exit_full_target_closes _ =
+  let pos = make_holding () in
+  let pos = apply_or_fail pos (partial_exit_kind ~exit_price:165.5 100.0) in
+  let pos = apply_or_fail pos (exit_fill_kind ~filled_quantity:100.0) in
+  assert_that
+    (apply_transition pos
+       {
+         position_id = "pos-1";
+         date = date_of_string "2024-01-12";
+         kind = ExitComplete;
+       })
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun p -> is_closed p) (equal_to true);
+            field
+              (fun p -> get_state p)
+              (equal_to
+                 (Closed
+                    {
+                      quantity = 100.0;
+                      entry_price = 150.0;
+                      exit_price = 165.5;
+                      gross_pnl = None;
+                      entry_date = date_of_string "2024-01-02";
+                      exit_date = date_of_string "2024-01-12";
+                      days_held = 10;
+                    }
+                   : position_state));
+          ]))
+
+(* Two partial exits in sequence: Holding(100) -> trim 40 -> Holding(60) ->
+   trim 20 -> Holding(40). The remainder keeps tracking its stop each time. *)
+let test_second_partial_exit _ =
+  let pos = make_holding () in
+  let pos = apply_or_fail pos (partial_exit_kind 40.0) in
+  let pos = apply_or_fail pos (exit_fill_kind ~filled_quantity:40.0) in
+  let pos = apply_or_fail pos ExitComplete in
+  let pos = apply_or_fail pos (partial_exit_kind 20.0) in
+  let pos = apply_or_fail pos (exit_fill_kind ~filled_quantity:20.0) in
+  assert_that
+    (apply_transition pos
+       {
+         position_id = "pos-1";
+         date = date_of_string "2024-01-15";
+         kind = ExitComplete;
+       })
+    (is_ok_and_holds
+       (field
+          (fun p -> get_state p)
+          (equal_to
+             (Holding
+                {
+                  quantity = 40.0;
+                  entry_price = 150.0;
+                  entry_date = date_of_string "2024-01-02";
+                  risk_params = holding_risk_params;
+                }
+               : position_state))))
+
+(* A non-positive trim target is rejected. *)
+let test_partial_exit_target_not_positive _ =
+  let pos = make_holding () in
+  assert_that
+    (apply_transition pos
+       {
+         position_id = "pos-1";
+         date = date_of_string "2024-01-10";
+         kind = partial_exit_kind 0.0;
+       })
+    (is_error_with Status.Invalid_argument ~msg:"must be in")
+
+(* A trim target larger than the held quantity is rejected. *)
+let test_partial_exit_target_too_large _ =
+  let pos = make_holding () in
+  assert_that
+    (apply_transition pos
+       {
+         position_id = "pos-1";
+         date = date_of_string "2024-01-10";
+         kind = partial_exit_kind 150.0;
+       })
+    (is_error_with Status.Invalid_argument ~msg:"must be in")
 
 (* ==================== Invalid Transitions ==================== *)
 
@@ -745,6 +929,15 @@ let suite =
          "update risk params" >:: test_update_risk_params;
          "exit fill" >:: test_exit_fill;
          "exit complete" >:: test_exit_complete;
+         "trigger partial exit" >:: test_trigger_partial_exit;
+         "partial exit returns to holding"
+         >:: test_partial_exit_returns_to_holding;
+         "partial exit full target closes"
+         >:: test_partial_exit_full_target_closes;
+         "second partial exit" >:: test_second_partial_exit;
+         "partial exit target not positive"
+         >:: test_partial_exit_target_not_positive;
+         "partial exit target too large" >:: test_partial_exit_target_too_large;
          "invalid transition from closed"
          >:: test_invalid_transition_from_closed;
          "wrong position id" >:: test_wrong_position_id;

--- a/trading/trading/weinstein/order_gen/lib/weinstein_order_gen.ml
+++ b/trading/trading/weinstein/order_gen/lib/weinstein_order_gen.ml
@@ -90,7 +90,7 @@ let _translate_transition ~(transition : Position.transition)
      breach. In live trading the GTC Stop order sent via UpdateRiskParams is
      already working at the broker and will execute automatically — no
      additional order is needed here. *)
-  | Position.TriggerExit _
+  | Position.TriggerExit _ | Position.TriggerPartialExit _
   (* Simulator-internal transitions: not relevant to the live broker *)
   | Position.EntryFill _ | Position.EntryComplete _ | Position.CancelEntry _
   | Position.ExitFill _ | Position.ExitComplete ->

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -475,6 +475,12 @@ let _sample_exiting =
       exit_price = 110.0;
       filled_quantity = 0.0;
       started_date = Date.of_string "2024-01-10";
+      risk_params =
+        {
+          stop_loss_price = None;
+          take_profit_price = None;
+          max_hold_days = None;
+        };
     }
 
 let _sample_closed =


### PR DESCRIPTION
## What

Adds a **strategy-agnostic partial-exit capability** to the core position state machine (Step 1 of `dev/plans/harvest-rotate-rigorous-test-2026-06-10.md`). A new `TriggerPartialExit` transition trims part of a held position instead of closing the whole thing:

- `Holding(q) → TriggerPartialExit{target_quantity=t}` → `Exiting{target_quantity=t, quantity=q, risk_params}` (sized at the trim, not the full holding).
- On `ExitComplete`, a **partial** exit (`filled < quantity`) returns to `Holding{quantity = q − filled}` with the original entry price/date and risk params preserved — the trimmed remainder keeps tracking its stop. A **full** exit still ends in `Closed`, exactly as before.

The order generator now sizes the exit order at `Exiting.target_quantity` (equal to the held quantity for a full exit, so unchanged there; the trim amount for a partial).

## Why

Harvest-rotate (and any future rotate-into-leadership / scale-out mechanism) needs to free part of a winner's capital without closing it. The exit path was whole-position only; this fills the gap in the initiating transition + the post-fill "return to Holding". Built strategy-agnostic — the core never learns *why* a strategy trims.

## Additive variant vs optional field — why a new `TriggerPartialExit`

The plan allowed either adding `target_quantity : float option` to `TriggerExit` or a separate `TriggerPartialExit` variant. I chose the **separate variant**: in OCaml, adding a field to an existing record breaks **every** `TriggerExit { exit_reason; exit_price }` construction site (~40 across strategy/engine/simulation/backtest), whereas a new variant leaves all of them **bit-for-bit untouched** and reads more clearly. The `Exiting` state gains a `risk_params` field so the remainder can re-acquire its stop.

## No backtest change (experiment-flag-discipline R1)

This is a **capability behind no flag**. No caller emits `TriggerPartialExit` yet, so every existing exit still goes whole-position and **no backtest result changes** — default behaviour is preserved bit-for-bit. The harvest-rotate mechanism that uses this capability is a separate, default-off PR (Step 2 of the plan).

## Test plan

`trading/strategy/test/test_position.ml` (pure state machine):
- Partial `TriggerPartialExit(t<q)` → `Exiting(target=t)` with risk params + entry preserved.
- Full round-trip: trim → ExitFill → ExitComplete → **Holding(q−t)** (entry price/date/risk params preserved).
- `target_quantity = q` (full target) → **Closed** (regression, identical to TriggerExit).
- Two sequential partial exits: Holding(100)→trim40→Holding(60)→trim20→Holding(40).
- Validation: `target ≤ 0` and `target > held` → `Error`.

`trading/simulation/test/test_order_generator.ml`:
- A partial exit sizes the sell order at the **trim** quantity (40), not the held quantity (100).

## Verification

- `dune build` (whole project) — clean.
- `dune build @fmt` — clean.
- Nesting linter — OK, all 3293 functions within limits (the two new helpers were extracted to stay under the limit).
- `dune runtest` on every affected dir (strategy, simulation, backtest, weinstein/order_gen, weinstein/strategy) — all OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)