### PR TITLE
feat(weinstein): harvest-rotate dial — trim Stage2-late winners via TriggerPartialExit (default-off)

### DIFF
--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -27,6 +27,7 @@ Each row: one line; deeper task detail in the linked status file.
 | [short-side-strategy](short-side-strategy.md) | IN_PROGRESS | feat-weinstein | — | track in steady state; Phase 3 verdict locked (marginal edge in 1 of 4 bear windows only) |
 | [spy-only-reference](spy-only-reference.md) | IN_PROGRESS | feat-weinstein | — | WF-CV on sector-rotation testbed; top-1000 bankability gate; long-short verification (human session) |
 | [stage-accuracy](stage-accuracy.md) | IN_PROGRESS | feat-weinstein | — | force_exit_off grid REJECTED (#1503); cascade-selection inversion documented (#1509 merged); broad-universe WF-CV re-run data-gated |
+| [harvest-rotate](harvest-rotate.md) | IN_PROGRESS | feat-weinstein | feat/harvest-rotate | Step 3: Variant_matrix axis; then step 4 WF-CV surface test |
 | [strategy-wiring](strategy-wiring.md) | MERGED | — | — | — |
 | [sector-data](sector-data.md) | MERGED | — | — | — |
 | [harness](harness.md) | IN_PROGRESS | harness-maintainer | — | Tier 1 fully checked off; T3-H low-priority; no active dispatch surface |

--- a/dev/status/harvest-rotate.md
+++ b/dev/status/harvest-rotate.md
@@ -1,0 +1,89 @@
+# Status: harvest-rotate
+
+## Last updated: 2026-06-10
+
+## Status
+IN_PROGRESS
+
+## Interface stable
+YES
+
+Step 2 of `dev/plans/harvest-rotate-rigorous-test-2026-06-10.md`: implement
+harvest-rotate as a **default-off config surface** so it can be backtested as a
+variant under WF-CV. The mechanism trims a fraction of every held long whose
+current stage is `Stage2 { late = true }` (the earliest Stage-3 topping
+precursor) and recycles the freed capital through the existing entry pipeline
+into a fresh Stage-2 leader.
+
+Background: the read-only screen
+(`dev/experiments/harvest-rotate-validation-2026-06-10/`) was **inconclusive**
+(coin-flip per decision, no exploitable edge, mild tail-risk) — not a rejection.
+Per `.claude/rules/mechanism-validation-rigor.md`, only the WF-CV surface test
+can reject the mechanism. This track builds that surface.
+
+## Completed
+
+- **Step 1 — core partial-exit transition** (MERGED via #1525). Strategy-agnostic
+  `TriggerPartialExit { exit_reason; exit_price; target_quantity }` on
+  `Position.t`: `Holding(q) → Exiting → Holding(q − trim)` round-trip, remainder
+  keeps tracking its stop on the reduced quantity.
+
+- **Step 2 — harvest-rotate mechanism** (default-off, 2026-06-10, this PR). New
+  module `Harvest_rotate_runner`
+  (`trading/trading/weinstein/strategy/lib/harvest_rotate_runner.{ml,mli}`): on a
+  screening (Friday) day, for every held **long** in `Stage2 { late = true }`,
+  emits a `TriggerPartialExit` trimming `held_quantity *. harvest_fraction` at the
+  current close. Decoupled MVP — the runner does NOT detect/pair a specific
+  cash-blocked candidate; freed capital recycles through the existing entry path
+  next cycle (the blocked-candidate entry-coupling is a deliberate later
+  refinement, deferred). Long-only (shorts never trimmed); non-`Holding` states
+  skipped. Wired into `weinstein_strategy.ml` `_process_market_day` as
+  `_run_harvest_rotate` (mirrors `_run_late_stage2_tighten`); transitions threaded
+  into `_assemble_output` (exit-side) and filtered against the full-exit skip-id
+  union so a position already being closed is not also trimmed.
+  - Config fields (both default to baseline no-op):
+    `enable_harvest_rotate : bool [@sexp.default false]`,
+    `harvest_fraction : float [@sexp.default 0.5]` (0.5 = sell half; 1.0 = full
+    rotate; ≤ 0.0 = no-op).
+  - Flag-discipline: default-off (R1, flag-off path bit-identical to baseline —
+    runner short-circuits to `[]`), real config fields routable through
+    `Overlay_validator` → `Variant_matrix` axis (R2), NOT promoted (R3).
+  - Weinstein-faithful: the **exit-aggressiveness** dial ("sell half as the
+    Stage-3 top forms") + **rotate-into-leadership**, both Weinstein's "The
+    Trader's Way" (book §Stage 3 detail, Ch. 2: "Investors: sell half, protect
+    remaining half"). Spine untouched (stage classification, Stage-2-only entries,
+    breakout+volume, macro/sector gate, RS all unaffected).
+  - Tests: `test_harvest_rotate_runner.ml` (13 cases) — trim half at close,
+    fraction plumbs through (0.33), full rotate at 1.0, no-trim for
+    early-Stage2 / Stage1 / Stage3 / Stage4, zero-fraction no-op, non-Friday
+    no-op, short-side no-trim, empty/missing-stage/missing-price no-ops.
+
+## In Progress
+
+- (none — Step 2 complete in this PR)
+
+## Next Steps
+
+1. **Step 3 — Variant_matrix axis wiring**: make `enable_harvest_rotate` +
+   `harvest_fraction` expressible as `Variant_matrix` axes via
+   `Overlay_validator.apply_overrides` / `config_override`, pinned in
+   `test_variant_matrix.ml`.
+2. **Step 4 — WF-CV** on top-3000, 15 folds, fork-per-fold parallel=1. Variants =
+   baseline ∪ {late_flag × `harvest_fraction` grid}. Rank via `Variant_ranking`
+   (Pareto) + `Deflated_sharpe`. Instrument the decomposition (timing / picks /
+   structural-tax / cost) per the plan's "primary deliverable is the *why*."
+3. **Step 5 — decision** via `experiment-gap-closing` step 7 + the confirmation
+   grid (`.claude/rules/promotion-confirmation.md`); record ACCEPT/REJECT in the
+   ledger and keep default-off until a grid-robust value is pinned.
+
+## Follow-ups
+
+- **Partial-exit audit capture.** `Exit_audit_capture.emit_exit_audit` currently
+  handles only `TriggerExit` (full exits); harvest-rotate `TriggerPartialExit`
+  transitions are piped through it but are a no-op there, so their MFE/MAE
+  excursion metrics default to 0.0. Extending the exit audit to partial exits
+  (a different, non-closing MFE/MAE semantics) is deferred to a separate change.
+- **Blocked-candidate entry coupling.** The MVP recycles freed capital through
+  the normal entry path; pairing the trim atomically to a specific blocked,
+  better-ranked candidate (the `alternatives_considered` / `Insufficient_cash`
+  signal) is the later refinement named in the plan.

--- a/trading/trading/weinstein/strategy/lib/harvest_rotate_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/harvest_rotate_runner.ml
@@ -1,0 +1,87 @@
+open Core
+open Trading_strategy
+
+(** Build the [TriggerPartialExit] transition that trims [target_quantity] of
+    [pos] at [exit_price = close]. The trim fires at the current bar's close —
+    same convention as {!Stage3_force_exit_runner._make_exit_transition}: for a
+    discretionary trim at the close, [close] is the most defensible fill marker.
+
+    The [exit_reason] uses the generic {!Position.exit_reason.StrategySignal}
+    variant with [label = "harvest_rotate"] — the value surfaced in the
+    [exit_trigger] column of [trades.csv]. *)
+let _make_trim_transition ~(pos : Position.t) ~current_date ~close
+    ~target_quantity =
+  let exit_reason =
+    Position.StrategySignal
+      {
+        label = "harvest_rotate";
+        detail = Some (Printf.sprintf "harvest_qty=%.4f" target_quantity);
+      }
+  in
+  {
+    Position.position_id = pos.id;
+    date = current_date;
+    kind =
+      Position.TriggerPartialExit
+        { exit_reason; exit_price = close; target_quantity };
+  }
+
+(** [true] iff [stage] is [Stage2 { late = true }] — the only stage that
+    triggers a harvest trim. Every other stage (incl. [Stage2 { late = false }])
+    is a no-op. *)
+let _is_late_stage2 = function
+  | Weinstein_types.Stage2 { late; _ } -> late
+  | Stage1 _ | Stage3 _ | Stage4 _ -> false
+
+(** Current close for [pos] when it is held in late Stage 2 — i.e. its stage
+    (read from [prior_stages]) is [Stage2 { late = true }] and [get_price] has a
+    bar; [None] otherwise. Mirrors {!Late_stage2_stop_runner._late_stage2_close}
+    so {!_trim_held_long} stays a shallow, flat match. *)
+let _late_stage2_close ~get_price ~prior_stages (pos : Position.t) =
+  match Hashtbl.find prior_stages pos.symbol with
+  | Some stage when _is_late_stage2 stage ->
+      Option.map (get_price pos.symbol) ~f:(fun bar ->
+          bar.Types.Daily_price.close_price)
+  | Some _ | None -> None
+
+(** Trim a held long [pos] when it is in late Stage 2 and a bar is available.
+    The trimmed quantity is [held_quantity *. effective_fraction] where
+    [effective_fraction = Float.min 1.0 harvest_fraction] (a fraction >= 1.0
+    trims the whole position, identical to a full exit). [held_quantity] is read
+    from the [Holding] state passed by {!_process_position}. *)
+let _trim_held_long ~effective_fraction ~get_price ~prior_stages ~current_date
+    ~held_quantity (pos : Position.t) =
+  match _late_stage2_close ~get_price ~prior_stages pos with
+  | Some close ->
+      let target_quantity = held_quantity *. effective_fraction in
+      Some (_make_trim_transition ~pos ~current_date ~close ~target_quantity)
+  | None -> None
+
+(** Process one position. Returns [Some transition] only for a held long
+    position whose current stage is [Stage2 { late = true }] and that has a bar
+    in [get_price]. Short positions and non-[Holding] states are skipped. *)
+let _process_position ~effective_fraction ~get_price ~prior_stages ~current_date
+    (pos : Position.t) =
+  match (pos.side, Position.get_state pos) with
+  | Trading_base.Types.Long, Position.Holding { quantity; _ } ->
+      _trim_held_long ~effective_fraction ~get_price ~prior_stages ~current_date
+        ~held_quantity:quantity pos
+  | _ -> None
+
+let _fold_position ~effective_fraction ~get_price ~prior_stages ~current_date
+    acc pos =
+  match
+    _process_position ~effective_fraction ~get_price ~prior_stages ~current_date
+      pos
+  with
+  | Some t -> t :: acc
+  | None -> acc
+
+let update ~harvest_fraction ~is_screening_day ~positions ~get_price
+    ~prior_stages ~current_date =
+  if (not is_screening_day) || Float.(harvest_fraction <= 0.0) then []
+  else
+    let effective_fraction = Float.min 1.0 harvest_fraction in
+    Map.fold positions ~init:[] ~f:(fun ~key:_ ~data:pos acc ->
+        _fold_position ~effective_fraction ~get_price ~prior_stages
+          ~current_date acc pos)

--- a/trading/trading/weinstein/strategy/lib/harvest_rotate_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/harvest_rotate_runner.mli
@@ -1,0 +1,110 @@
+(** Harvest-rotate runner — trims a fraction of held long winners that show the
+    earliest Stage-3 topping precursor, freeing capital to recycle into fresh
+    Stage-2 leaders through the existing entry pipeline.
+
+    {1 Motivation}
+
+    The [late] sub-flag of [Stage2 { late }] (MA-slope deceleration, the
+    earliest top-warning the classifier produces) is computed every week but
+    consumed only to gate new entries — never to act on a position already held.
+    The cross-regime diagnosis
+    [dev/notes/stage-lifecycle-pivot-diagnosis-2026-06-03.md] shows [late] fired
+    weeks-to-months before 6 of 7 major single-name / index tops.
+
+    This runner reads [late] for held long positions and {b trims a fraction}
+    [harvest_fraction] of the position (the book's "sell half as the Stage-3 top
+    forms"). The freed capital recycles through the existing entry pipeline on a
+    later cycle into a fresh Stage-2 leader — the trader's "rotate into
+    leadership."
+
+    {1 Decoupled MVP scope}
+
+    This runner only emits the {b trim} ([TriggerPartialExit]) transition. It
+    does {e not} detect, pair, or atomically execute a specific cash-blocked
+    entry candidate against the freed capital — the freed cash simply recycles
+    through the normal entry path next cycle. Coupling the trim to a specific
+    blocked, better-ranked candidate (the [alternatives_considered] /
+    [Insufficient_cash] signal) is a deliberate later refinement, out of scope
+    here. See [dev/plans/harvest-rotate-rigorous-test-2026-06-10.md].
+
+    {1 Weinstein authority (W1–W3)}
+
+    This is the {b exit-aggressiveness} dial (the trader preset — "get out as
+    the Stage-3 top starts forming") combined with {b rotate-into-leadership},
+    both Weinstein's ("The Trader's Way"). It is a faithful adaptation of
+    [docs/design/weinstein-book-reference.md] §Stage 3 detail (Ch. 2): "Traders:
+    exit with profits. Investors: sell half, protect remaining half with tight
+    sell-stop below support." The MA-deceleration [late] signal is the leading
+    edge of that topping process; trimming a fraction there is exactly the
+    book's "sell half" applied a beat earlier on the earliest topping precursor.
+
+    The trim is {b structural} — a fixed fraction of the position on a topping
+    signal — not an arbitrary profit target divorced from price/stage.
+
+    The strategy {b spine} is untouched: stage classification, the Stage-2-only
+    buy rule, breakout+volume entry, the macro/sector gate, and relative
+    strength are all unaffected. This runner only reduces the size of an
+    existing held long when it begins to top.
+
+    {1 Cadence & side}
+
+    Weekly cadence (Friday only), mirroring {!Late_stage2_stop_runner}: the
+    [late] flag is a weekly-MA property, so off-cadence ticks are a no-op to
+    avoid intra-week classification noise. Long positions only — this is a
+    long-only "trim the topping winner" dial; short-side topping semantics
+    differ (book §6.3) and are out of scope, so short positions are never
+    trimmed. *)
+
+open Core
+open Trading_strategy
+
+val update :
+  harvest_fraction:float ->
+  is_screening_day:bool ->
+  positions:Position.t Map.M(String).t ->
+  get_price:Strategy_interface.get_price_fn ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  current_date:Core.Date.t ->
+  Position.transition list
+(** [update ~harvest_fraction ~is_screening_day ~positions ~get_price
+     ~prior_stages ~current_date] returns one [TriggerPartialExit] transition
+    for every held long position whose current stage is
+    [Stage2 { late = true }].
+
+    Each emitted transition trims [held_quantity *. effective_fraction] of the
+    position at [exit_price = close] (the current bar's close from [get_price]),
+    with [exit_reason = StrategySignal { label = "harvest_rotate"; ... }] where
+    [effective_fraction = Float.min 1.0 harvest_fraction]. The runner reads the
+    position's current stage from [prior_stages] (written by
+    {!Stops_runner.update} earlier in the same tick).
+
+    {2 Behaviour}
+
+    {ul
+     {- Returns [[]] when [is_screening_day = false] (weekly cadence; the [late]
+        flag is a weekly property).
+     }
+     {- Returns [[]] when [positions] is empty. }
+     {- Returns [[]] when [harvest_fraction <= 0.0] (a non-positive fraction is
+        the no-op: nothing to trim).
+     }
+     {- For each held long position in the [Holding] state:
+        - Skips unless the stage in [prior_stages] is [Stage2 { late = true }].
+          A [Stage2 { late = false }] read, any other stage, or a missing stage
+          entry produces no transition.
+        - Skips when [get_price] has no bar for the symbol.
+        - Otherwise emits [TriggerPartialExit] with
+          [target_quantity = held_quantity *. effective_fraction] and
+          [exit_price = close]. [harvest_fraction] is clamped to [1.0] so a
+          fraction [>= 1.0] trims the whole position (equivalent to a full exit,
+          per {!Position.transition_kind.TriggerPartialExit}).
+     }
+     {- Short positions and non-[Holding] states are skipped without emitting. }
+    }
+
+    {2 No-op default}
+
+    This runner is gated entirely by its caller on
+    [config.enable_harvest_rotate]; it is only invoked when that flag is [true].
+    With the flag default-off the runner never runs, so behaviour is
+    bit-identical to baseline regardless of [harvest_fraction]. *)

--- a/trading/trading/weinstein/strategy/lib/harvest_rotate_wiring.ml
+++ b/trading/trading/weinstein/strategy/lib/harvest_rotate_wiring.ml
@@ -1,0 +1,35 @@
+(** Strategy-integration layer for {!Harvest_rotate_runner}. See
+    [harvest_rotate_wiring.mli]. *)
+
+open Core
+open Weinstein_strategy_config
+
+(** Emit the exit-side audit for harvest [TriggerPartialExit] trims, mirroring
+    the other exit runners. [emit_exit_audit] is currently a no-op on
+    [TriggerPartialExit] (partial-exit MFE/MAE capture is deferred); piping the
+    list through keeps the wiring uniform. Must run while [positions] still
+    holds the (un-trimmed) position. *)
+let _emit_audit ~config ~audit_recorder ~prior_macro_result ~bar_reader
+    ~prior_stages ~positions ts =
+  List.iter ts
+    ~f:
+      (Exit_audit_capture.emit_exit_audit ~audit_recorder ~prior_macro_result
+         ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
+         ~bar_reader ~prior_stages ~positions)
+
+let run ~config ~positions ~get_price ~prior_stages ~index_view ~audit_recorder
+    ~prior_macro_result ~bar_reader ~current_date =
+  if not config.enable_harvest_rotate then []
+  else begin
+    let is_friday =
+      Weinstein_strategy_screening.is_screening_day_view index_view
+    in
+    let ts =
+      Harvest_rotate_runner.update ~harvest_fraction:config.harvest_fraction
+        ~is_screening_day:is_friday ~positions ~get_price ~prior_stages
+        ~current_date
+    in
+    _emit_audit ~config ~audit_recorder ~prior_macro_result ~bar_reader
+      ~prior_stages ~positions ts;
+    ts
+  end

--- a/trading/trading/weinstein/strategy/lib/harvest_rotate_wiring.mli
+++ b/trading/trading/weinstein/strategy/lib/harvest_rotate_wiring.mli
@@ -1,0 +1,34 @@
+(** Strategy-integration layer for {!Harvest_rotate_runner}.
+
+    Builds the pure runner's inputs from the live strategy context — the
+    screening-day (Friday) gate and the [config.harvest_fraction] dial — and
+    emits the exit-side audit for the resulting trims. Extracted from
+    {!Weinstein_strategy} so the top-level strategy module stays within its
+    length budget (mirrors {!Macro_bearish_trim_wiring}). *)
+
+open Core
+open Trading_strategy
+
+val run :
+  config:Weinstein_strategy_config.config ->
+  positions:Position.t Map.M(String).t ->
+  get_price:Strategy_interface.get_price_fn ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  index_view:Snapshot_runtime.Snapshot_bar_views.weekly_view ->
+  audit_recorder:Audit_recorder.t ->
+  prior_macro_result:Macro.result option ref ->
+  bar_reader:Bar_reader.t ->
+  current_date:Date.t ->
+  Position.transition list
+(** Run the harvest-rotate pass. No-op [[]] unless
+    [config.enable_harvest_rotate] is set; otherwise, on a screening (Friday)
+    day, trims [config.harvest_fraction] of every held [Stage2 { late = true }]
+    long via {!Harvest_rotate_runner.update} (a [TriggerPartialExit] per
+    position) and emits the exit-side audit for the resulting transitions.
+
+    The exit audit ({!Exit_audit_capture.emit_exit_audit}) is currently a no-op
+    on [TriggerPartialExit] (partial-exit MFE/MAE capture is deferred); it is
+    piped through for uniformity with the other exit runners and must run while
+    [positions] still holds the (un-trimmed) position. Default-off preserves all
+    baselines — the disabled path is byte-identical to baseline regardless of
+    [config.harvest_fraction]. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -12,6 +12,8 @@ module Stops_split_runner = Stops_split_runner
 module Force_liquidation_runner = Force_liquidation_runner
 module Stage3_force_exit_runner = Stage3_force_exit_runner
 module Late_stage2_stop_runner = Late_stage2_stop_runner
+module Harvest_rotate_runner = Harvest_rotate_runner
+module Harvest_rotate_wiring = Harvest_rotate_wiring
 module Macro_bearish_trim_runner = Macro_bearish_trim_runner
 module Macro_bearish_trim_wiring = Macro_bearish_trim_wiring
 module Laggard_rotation_runner = Laggard_rotation_runner
@@ -247,6 +249,19 @@ let _run_late_stage2_tighten ~config ~positions ~get_price ~prior_stages
       ~buffer_pct:config.late_stage2_stop_buffer_pct ~is_screening_day:is_friday
       ~positions ~get_price ~prior_stages ~current_date
 
+(** The two weekly held-position dials (both Friday-gated, default-off):
+    late-Stage-2 stop-tighten ([UpdateRiskParams]) and harvest-rotate
+    ([TriggerPartialExit]). Returns [(late_tighten_ts, harvest_rotate_ts)].
+    Extracted so {!_process_market_day} stays within the function-length limit.
+*)
+let _run_held_position_dials ~config ~positions ~get_price ~prior_stages
+    ~index_view ~audit_recorder ~prior_macro_result ~bar_reader ~current_date =
+  ( _run_late_stage2_tighten ~config ~positions ~get_price ~prior_stages
+      ~index_view ~current_date,
+    Harvest_rotate_wiring.run ~config ~positions ~get_price ~prior_stages
+      ~index_view ~audit_recorder ~prior_macro_result ~bar_reader ~current_date
+  )
+
 (** Compute the macro result for [current_date] (Friday only) and run the
     halt-reset side effect. Returns [None] on non-screening days. Mutates
     [prior_macro] / [prior_macro_result] via {!run_macro_only}. Hoisted out of
@@ -313,8 +328,8 @@ let _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
 
 let _assemble_output ~exit_transitions ~stage3_force_exit_transitions
     ~laggard_rotation_transitions ~force_exit_transitions
-    ~macro_trim_transitions ~adjust_transitions ~entry_transitions
-    ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids =
+    ~macro_trim_transitions ~harvest_rotate_transitions ~adjust_transitions
+    ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids =
   let force_liq_exited_ids = _trigger_exit_ids_of force_exit_transitions in
   let macro_trim_exited_ids = _trigger_exit_ids_of macro_trim_transitions in
   let all_exited_ids =
@@ -331,12 +346,19 @@ let _assemble_output ~exit_transitions ~stage3_force_exit_transitions
   let adjust_transitions =
     _filter_out_exited_ids all_exited_ids adjust_transitions
   in
+  (* Drop a harvest-trim for any position already fully exited this tick (a stop
+     hit / Stage-3 / laggard / force-liq / macro-bearish exit) — that position is
+     closing, so there is nothing left to trim. *)
+  let harvest_rotate_transitions =
+    _filter_out_exited_ids all_exited_ids harvest_rotate_transitions
+  in
   Ok
     {
       Strategy_interface.transitions =
         exit_transitions @ stage3_force_exit_transitions
         @ laggard_rotation_transitions @ force_exit_transitions
-        @ macro_trim_transitions @ adjust_transitions @ entry_transitions;
+        @ macro_trim_transitions @ harvest_rotate_transitions
+        @ adjust_transitions @ entry_transitions;
     }
 
 let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
@@ -374,9 +396,9 @@ let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
       ~current_date ~index_view ~is_screening_day ~stop_exited_ids
       ~stage3_exited_ids ~laggard_exited_ids ~force_exit_transitions
   in
-  let late_tighten_transitions =
-    _run_late_stage2_tighten ~config ~positions ~get_price ~prior_stages
-      ~index_view ~current_date
+  let late_tighten_transitions, harvest_rotate_transitions =
+    _run_held_position_dials ~config ~positions ~get_price ~prior_stages
+      ~index_view ~audit_recorder ~prior_macro_result ~bar_reader ~current_date
   in
   let entry_transitions =
     _run_entries ~fold_start_date ~config ~stop_states ~last_stop_out_dates
@@ -386,7 +408,7 @@ let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
   in
   _assemble_output ~exit_transitions ~stage3_force_exit_transitions
     ~laggard_rotation_transitions ~force_exit_transitions
-    ~macro_trim_transitions
+    ~macro_trim_transitions ~harvest_rotate_transitions
     ~adjust_transitions:(adjust_transitions @ late_tighten_transitions)
     ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -85,6 +85,14 @@ module Late_stage2_stop_runner = Late_stage2_stop_runner
     transitions (never exits). Default-off preserves all baselines. See
     {!Late_stage2_stop_runner}. *)
 
+module Harvest_rotate_runner = Harvest_rotate_runner
+(** Harvest-rotate dial (default-off). Invoked on Friday ticks when
+    [config.enable_harvest_rotate = true]: trims [config.harvest_fraction] of
+    every held [Stage2 { late = true }] long via a [TriggerPartialExit] (the
+    book's "sell half as the Stage-3 top forms"), freeing capital to recycle
+    through the existing entry pipeline into a fresh Stage-2 leader. Default-off
+    preserves all baselines. See {!Harvest_rotate_runner}. *)
+
 module Macro_bearish_trim_runner = Macro_bearish_trim_runner
 (** Macro-bearish held-exposure trim runner (default-off). Invoked AFTER the
     special-exit passes on Friday ticks when
@@ -412,6 +420,17 @@ type config = {
           no-op (detector-only, byte-identical to pre-#1484). Threaded into the
           simulator's [Trading_simulation.Stale_hold.config]. Searchable as a
           [Variant_matrix] flag axis. See [Weinstein_strategy_config]. *)
+  enable_harvest_rotate : bool; [@sexp.default false]
+      (** Master switch for the harvest-rotate dial: trim [harvest_fraction] of
+          every held [Stage2 { late = true }] long via a [TriggerPartialExit] on
+          Friday ticks, recycling the freed capital through the existing entry
+          pipeline. Default [false] is a no-op (byte-identical to baseline).
+          Searchable as a [Variant_matrix] flag axis. See
+          [Weinstein_strategy_config] / {!Harvest_rotate_runner}. *)
+  harvest_fraction : float; [@sexp.default 0.5]
+      (** Fraction of a held [Stage2 { late }] long trimmed by the
+          harvest-rotate runner; [0.5] = sell half. Only consulted when
+          [enable_harvest_rotate = true]. See [Weinstein_strategy_config]. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -104,6 +104,13 @@ type config = {
       (** [Some n] force-sells a stale/delisted held position at its last close
           after an [n]-day bar gap; default [None] is a no-op (#1484). Threaded
           into the simulator's [Stale_hold.config]. See [.mli]. *)
+  enable_harvest_rotate : bool; [@sexp.default false]
+      (** Master switch for the harvest-rotate dial; default [false] is a no-op
+          (bit-identical to baseline). See [.mli]. *)
+  harvest_fraction : float; [@sexp.default 0.5]
+      (** Fraction of a held [Stage2 { late }] long trimmed by the
+          harvest-rotate runner; [0.5] = sell half. Only consulted when
+          [enable_harvest_rotate = true]. See [.mli]. *)
 }
 [@@deriving sexp]
 
@@ -143,6 +150,8 @@ let default_config ~universe ~index_symbol =
     enable_macro_bearish_exposure_trim = false;
     macro_bearish_max_long_exposure_pct = macro_bearish_no_op_cap;
     stale_exit_after_days = None;
+    enable_harvest_rotate = false;
+    harvest_fraction = 0.5;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -180,6 +180,43 @@ type config = {
           [None] keeps every existing backtest byte-identical (detector still
           records stale holds; no force-exit). Searchable as a [Variant_matrix]
           flag axis ([((flag stale_exit_after_days) (values (() (5))))]). *)
+  enable_harvest_rotate : bool; [@sexp.default false]
+      (** Master switch for the harvest-rotate dial ({!Harvest_rotate_runner},
+          plan [dev/plans/harvest-rotate-rigorous-test-2026-06-10.md]). When
+          [true], on a screening (Friday) day the runner trims a fraction
+          [harvest_fraction] of every held long whose current stage is
+          [Stage2 { late = true }] (the earliest Stage-3 topping precursor),
+          emitting a [TriggerPartialExit]; the freed capital recycles through
+          the existing entry pipeline into a fresh Stage-2 leader. Default
+          [false] preserves all existing baselines — the runner short-circuits
+          to [[]] before any work, so the disabled path is byte-identical to the
+          pre-feature strategy.
+
+          This is the {b exit-aggressiveness} dial ("sell half as the Stage-3
+          top forms") combined with {b rotate-into-leadership}, both Weinstein's
+          "The Trader's Way" — a faithful adaptation of
+          [docs/design/weinstein-book-reference.md] §Stage 3 detail (Ch. 2):
+          "Investors: sell half, protect remaining half." The strategy {b spine}
+          is untouched — stage classification, the Stage-2-only buy rule,
+          breakout+volume entry, the macro/sector gate, and relative strength
+          are all unaffected; only the size of an existing held long is reduced
+          when it begins to top. Searchable as a [Variant_matrix] flag axis
+          ([((flag enable_harvest_rotate) (values (true false)))]). Default-off
+          until an experiment-ledger ACCEPT (per
+          [.claude/rules/experiment-flag-discipline.md] +
+          [.claude/rules/promotion-confirmation.md]). See
+          {!Harvest_rotate_runner}. *)
+  harvest_fraction : float; [@sexp.default 0.5]
+      (** Fraction of a held long position trimmed by {!Harvest_rotate_runner}
+          when it enters [Stage2 { late = true }]: the trimmed quantity is
+          [held_quantity *. Float.min 1.0 harvest_fraction]. [0.5] = sell half
+          (the book's "sell half as the Stage-3 top forms"); [1.0] = full rotate
+          out of the topping name. Only consulted when
+          [enable_harvest_rotate = true]; because the runner is gated entirely
+          by the flag, the disabled path is byte-identical to baseline
+          regardless of this value. A value [<= 0.0] is itself a no-op (nothing
+          to trim). Searchable as a [Variant_matrix] axis. See
+          {!Harvest_rotate_runner}. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -16,6 +16,7 @@
   test_spy_only_weinstein_strategy
   test_stage3_force_exit_runner
   test_late_stage2_stop_runner
+  test_harvest_rotate_runner
   test_macro_bearish_trim_runner
   test_laggard_rotation_runner
   test_stops_runner

--- a/trading/trading/weinstein/strategy/test/test_harvest_rotate_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_harvest_rotate_runner.ml
@@ -1,0 +1,267 @@
+open OUnit2
+open Core
+open Matchers
+open Weinstein_strategy
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let make_bar date ~close =
+  {
+    Types.Daily_price.date = Date.of_string date;
+    open_price = close;
+    high_price = close *. 1.01;
+    low_price = close *. 0.99;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+    active_through = None;
+  }
+
+let late_stage2 = Weinstein_types.Stage2 { weeks_advancing = 12; late = true }
+let early_stage2 = Weinstein_types.Stage2 { weeks_advancing = 5; late = false }
+let stage1 = Weinstein_types.Stage1 { weeks_in_base = 4 }
+let stage3 = Weinstein_types.Stage3 { weeks_topping = 1 }
+let stage4 = Weinstein_types.Stage4 { weeks_declining = 2 }
+let friday = Date.of_string "2024-01-05" (* Friday *)
+let monday = Date.of_string "2024-01-08" (* Monday *)
+
+(** Build a Holding {!Position.t} for [ticker] with [qty] shares at [entry].
+    Mirrors the helper in [test_late_stage2_stop_runner.ml]. [qty] is exposed so
+    the trimmed [target_quantity = qty *. harvest_fraction] can be asserted. *)
+let make_holding_pos ?(side = Trading_base.Types.Long) ?(qty = 10.0) ticker
+    ~entry ~date =
+  let make_trans kind =
+    { Trading_strategy.Position.position_id = ticker; date; kind }
+  in
+  let unwrap = function
+    | Ok p -> p
+    | Error _ -> OUnit2.assert_failure "position setup failed"
+  in
+  let open Trading_strategy.Position in
+  let p =
+    create_entering
+      (make_trans
+         (CreateEntering
+            {
+              symbol = ticker;
+              side;
+              target_quantity = qty;
+              entry_price = entry;
+              reasoning = ManualDecision { description = "test" };
+            }))
+    |> unwrap
+  in
+  let p =
+    apply_transition p
+      (make_trans (EntryFill { filled_quantity = qty; fill_price = entry }))
+    |> unwrap
+  in
+  apply_transition p
+    (make_trans
+       (EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = None;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+let get_price_of bars symbol = List.Assoc.find bars symbol ~equal:String.equal
+
+(** Convenience wrapper: single-symbol position + stage + price, returns the
+    runner's transitions. [harvest_fraction] defaults to 0.5 (sell half). *)
+let run_single ?(harvest_fraction = 0.5) ?(is_screening_day = true)
+    ?(qty = 10.0) ~stage ~close ~current_date ?(side = Trading_base.Types.Long)
+    () =
+  let pos = make_holding_pos ~side ~qty "AAPL" ~entry:100.0 ~date:friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"AAPL" ~data:stage;
+  Harvest_rotate_runner.update ~harvest_fraction ~is_screening_day ~positions
+    ~get_price:(get_price_of [ ("AAPL", make_bar "2024-01-05" ~close) ])
+    ~prior_stages ~current_date
+
+(** Matcher for a [TriggerPartialExit] transition trimming [symbol] by
+    [expected_qty] at [expected_price]. *)
+let trims symbol ~expected_qty ~expected_price =
+  all_of
+    [
+      field
+        (fun (t : Trading_strategy.Position.transition) -> t.position_id)
+        (equal_to symbol);
+      matching ~msg:"Expected TriggerPartialExit"
+        (function
+          | Trading_strategy.Position.
+              {
+                kind = TriggerPartialExit { target_quantity; exit_price; _ };
+                _;
+              } ->
+              Some (target_quantity, exit_price)
+          | _ -> None)
+        (all_of
+           [
+             field (fun (q, _) -> q) (float_equal expected_qty);
+             field (fun (_, p) -> p) (float_equal expected_price);
+           ]);
+    ]
+
+(* ------------------------------------------------------------------ *)
+(* Test 1 — late Stage 2 long: trim qty*harvest_fraction at close       *)
+(* ------------------------------------------------------------------ *)
+
+(** A held late-Stage-2 long is trimmed by [harvest_fraction] at the current
+    close. With qty=10, close=120, harvest_fraction=0.5 the trim is 5.0 shares
+    at price 120. *)
+let test_late_stage2_trims_half _ =
+  let transitions =
+    run_single ~harvest_fraction:0.5 ~qty:10.0 ~stage:late_stage2 ~close:120.0
+      ~current_date:friday ()
+  in
+  assert_that transitions
+    (elements_are [ trims "AAPL" ~expected_qty:5.0 ~expected_price:120.0 ])
+
+(* ------------------------------------------------------------------ *)
+(* Test 1b — harvest_fraction plumbs from config (0.33 vs 0.5)          *)
+(* ------------------------------------------------------------------ *)
+
+(** A different [harvest_fraction] produces a proportionally different trim:
+    0.33 * 10 = 3.3 shares. *)
+let test_fraction_plumbs_through _ =
+  let transitions =
+    run_single ~harvest_fraction:0.33 ~qty:10.0 ~stage:late_stage2 ~close:120.0
+      ~current_date:friday ()
+  in
+  assert_that transitions
+    (elements_are
+       [ trims "AAPL" ~expected_qty:(10.0 *. 0.33) ~expected_price:120.0 ])
+
+(* ------------------------------------------------------------------ *)
+(* Test 1c — fraction >= 1.0 trims the whole position (full rotate)     *)
+(* ------------------------------------------------------------------ *)
+
+(** A [harvest_fraction] of 1.0 trims the entire position (10 shares) — a full
+    rotate out of the topping name. *)
+let test_full_rotate _ =
+  let transitions =
+    run_single ~harvest_fraction:1.0 ~qty:10.0 ~stage:late_stage2 ~close:120.0
+      ~current_date:friday ()
+  in
+  assert_that transitions
+    (elements_are [ trims "AAPL" ~expected_qty:10.0 ~expected_price:120.0 ])
+
+(* ------------------------------------------------------------------ *)
+(* Test 2 — control: non-late / other stages produce no transition      *)
+(* ------------------------------------------------------------------ *)
+
+let test_early_stage2_no_trim _ =
+  let transitions =
+    run_single ~stage:early_stage2 ~close:120.0 ~current_date:friday ()
+  in
+  assert_that transitions is_empty
+
+let test_stage1_no_trim _ =
+  let transitions =
+    run_single ~stage:stage1 ~close:120.0 ~current_date:friday ()
+  in
+  assert_that transitions is_empty
+
+let test_stage3_no_trim _ =
+  let transitions =
+    run_single ~stage:stage3 ~close:120.0 ~current_date:friday ()
+  in
+  assert_that transitions is_empty
+
+let test_stage4_no_trim _ =
+  let transitions =
+    run_single ~stage:stage4 ~close:120.0 ~current_date:friday ()
+  in
+  assert_that transitions is_empty
+
+(* ------------------------------------------------------------------ *)
+(* Test 3 — disabled path: non-positive fraction is a no-op             *)
+(* ------------------------------------------------------------------ *)
+
+(** [harvest_fraction <= 0.0] is the no-op (nothing to trim) — the bit-identical
+    disabled value path (the caller default-off flag short-circuits before this,
+    but the runner itself must also no-op on a non-positive fraction). *)
+let test_zero_fraction_no_op _ =
+  let transitions =
+    run_single ~harvest_fraction:0.0 ~stage:late_stage2 ~close:120.0
+      ~current_date:friday ()
+  in
+  assert_that transitions is_empty
+
+(* ------------------------------------------------------------------ *)
+(* Test 4 — cadence + side + empty controls                             *)
+(* ------------------------------------------------------------------ *)
+
+let test_non_friday_no_op _ =
+  let transitions =
+    run_single ~is_screening_day:false ~stage:late_stage2 ~close:120.0
+      ~current_date:monday ()
+  in
+  assert_that transitions is_empty
+
+let test_short_side_no_trim _ =
+  let transitions =
+    run_single ~side:Trading_base.Types.Short ~stage:late_stage2 ~close:120.0
+      ~current_date:friday ()
+  in
+  assert_that transitions is_empty
+
+let test_empty_positions_no_op _ =
+  let transitions =
+    Harvest_rotate_runner.update ~harvest_fraction:0.5 ~is_screening_day:true
+      ~positions:String.Map.empty ~get_price:(get_price_of [])
+      ~prior_stages:(Hashtbl.create (module String))
+      ~current_date:friday
+  in
+  assert_that transitions is_empty
+
+let test_missing_stage_no_op _ =
+  let pos = make_holding_pos "AAPL" ~entry:100.0 ~date:friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let transitions =
+    Harvest_rotate_runner.update ~harvest_fraction:0.5 ~is_screening_day:true
+      ~positions
+      ~get_price:(get_price_of [ ("AAPL", make_bar "2024-01-05" ~close:120.0) ])
+      ~prior_stages:(Hashtbl.create (module String))
+      ~current_date:friday
+  in
+  assert_that transitions is_empty
+
+let test_missing_price_no_op _ =
+  let pos = make_holding_pos "AAPL" ~entry:100.0 ~date:friday in
+  let positions = String.Map.singleton "AAPL" pos in
+  let prior_stages = Hashtbl.create (module String) in
+  Hashtbl.set prior_stages ~key:"AAPL" ~data:late_stage2;
+  let transitions =
+    Harvest_rotate_runner.update ~harvest_fraction:0.5 ~is_screening_day:true
+      ~positions ~get_price:(get_price_of []) ~prior_stages ~current_date:friday
+  in
+  assert_that transitions is_empty
+
+let suite =
+  "harvest_rotate_runner"
+  >::: [
+         "late_stage2_trims_half" >:: test_late_stage2_trims_half;
+         "fraction_plumbs_through" >:: test_fraction_plumbs_through;
+         "full_rotate" >:: test_full_rotate;
+         "early_stage2_no_trim" >:: test_early_stage2_no_trim;
+         "stage1_no_trim" >:: test_stage1_no_trim;
+         "stage3_no_trim" >:: test_stage3_no_trim;
+         "stage4_no_trim" >:: test_stage4_no_trim;
+         "zero_fraction_no_op" >:: test_zero_fraction_no_op;
+         "non_friday_no_op" >:: test_non_friday_no_op;
+         "short_side_no_trim" >:: test_short_side_no_trim;
+         "empty_positions_no_op" >:: test_empty_positions_no_op;
+         "missing_stage_no_op" >:: test_missing_stage_no_op;
+         "missing_price_no_op" >:: test_missing_price_no_op;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## Harvest-rotate dial — trim Stage2-late winners (default-off)

Step 2 of `dev/plans/harvest-rotate-rigorous-test-2026-06-10.md`. Step 1 (the core `TriggerPartialExit` transition) merged via #1525.

### What it does
New module `Harvest_rotate_runner`: on a screening (Friday) tick, when `config.enable_harvest_rotate = true`, trims `config.harvest_fraction` of every held **long** whose current stage is `Stage2 { late = true }` (the earliest Stage-3 topping precursor) by emitting `TriggerPartialExit { target_quantity = held_qty *. harvest_fraction; exit_price = close; exit_reason = StrategySignal "harvest_rotate" }`. Freed capital recycles through the existing entry pipeline next cycle.

Wired via `Harvest_rotate_wiring.run` (mirrors `Macro_bearish_trim_wiring`) into `weinstein_strategy.ml` `_process_market_day`; transitions are threaded into `_assemble_output` (exit-side) and filtered against the full-exit skip-id union so a position already being closed this tick is not also trimmed.

### Decoupled MVP scope (deferred refinements, noted in PR + status `## Follow-ups`)
- Does **not** detect/pair a specific cash-blocked entry candidate — freed cash recycles through the normal entry path. The blocked-candidate entry coupling (the `alternatives_considered` / `Insufficient_cash` signal) is a deliberate later refinement.
- Partial-exit exit-audit (MFE/MAE) capture is deferred: `Exit_audit_capture.emit_exit_audit` is currently a no-op on `TriggerPartialExit`; harvest trims are piped through it for uniformity (harmless no-op) but carry no excursion metrics yet.

### No backtest change on merge (experiment-flag-discipline R1/R2)
- `enable_harvest_rotate : bool [@sexp.default false]` and `harvest_fraction : float [@sexp.default 0.5]` both default to the baseline no-op; with the flag off the runner short-circuits to `[]`, **bit-identical to baseline** regardless of `harvest_fraction`.
- Both are real `config` fields (route through `Overlay_validator`) → become a `Variant_matrix` axis (step 3, follow-up). **NOT promoted** (R3) — default-off until a WF-CV/grid ACCEPT.

### Weinstein faithfulness (W1–W3)
- **W1 — spine intact**: stage classification, Stage-2-only entries, breakout+volume, macro/sector gate, RS all unaffected. Only the *size* of an existing held long is reduced when it begins to top.
- **W2 — a documented dial**: the exit-aggressiveness dial ("sell half as the Stage-3 top forms") + rotate-into-leadership, both Weinstein's "The Trader's Way". Authority: `docs/design/weinstein-book-reference.md` §Stage 3 detail (Ch. 2) — "Investors: sell half, protect remaining half with tight sell-stop below support." Config-expressed.
- **W3 — a faithful preset variant**, not an arbitrary knob.

### Tests
`test_harvest_rotate_runner.ml` (13 cases): trim half at close, fraction plumbs through (0.33), full rotate at 1.0, no-trim for early-Stage2 / Stage1 / Stage3 / Stage4, zero-fraction no-op, non-Friday no-op, short-side no-trim, empty / missing-stage / missing-price no-ops.

`dune build` + `dune runtest` green (full project, exit 0); fn-length + file-length + mli-coverage + `dune build @fmt` all pass.

Do not modify `dev/status/_index.md` from feature PRs is the standing rule; the new `harvest-rotate` row is the brand-new-tracked-item exception (orchestrator has no other signal to invent it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
