### PR TITLE
experiment(harvest-rotate): WF-CV surface spec + base (step 4a)

### DIFF
--- a/dev/experiments/harvest-rotate-wfcv-2026-06-11/base_top3000.sexp
+++ b/dev/experiments/harvest-rotate-wfcv-2026-06-11/base_top3000.sexp
@@ -1,0 +1,18 @@
+;; Cell-E top-3000-2011 base for the w_early_stage2 reweight WF-CV surface.
+;; Snapshot mode (snap_top3000_2011). window_spec in the spec drives fold periods.
+((name "cascade-rw-base-top3000")
+ (description "Cell-E top-3000 base; w_early_stage2 axis surface.")
+ (period ((start_date 2011-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-2011.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.0)(bid_ask_spread_bps 5.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 100000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/experiments/harvest-rotate-wfcv-2026-06-11/spec_top3000.sexp
+++ b/dev/experiments/harvest-rotate-wfcv-2026-06-11/spec_top3000.sexp
@@ -1,0 +1,18 @@
+;; Harvest-rotate WF-CV surface — Cell-E top-3000-2011, 2011-2026, fork-per-fold.
+;; baseline = enable_harvest_rotate=false (default). Variants flip it on and
+;; sweep harvest_fraction (the trim fraction; 0.5 = the book's "sell half").
+;; Step 4a of dev/plans/harvest-rotate-rigorous-test-2026-06-10.md.
+((base_scenario "/workspaces/trading-1/dev/experiments/harvest-rotate-wfcv-2026-06-11/base_top3000.sexp")
+ (window_spec
+  (Rolling
+   ((start_date 2011-01-01)(end_date 2026-04-30)(train_days 0)(test_days 365)(step_days 365))))
+ (variants
+  (((label "baseline") (overrides ()))
+   ((label "harvest_k033")
+    (overrides (((enable_harvest_rotate true)) ((harvest_fraction 0.33)))))
+   ((label "harvest_k050")
+    (overrides (((enable_harvest_rotate true)) ((harvest_fraction 0.5)))))
+   ((label "harvest_k100")
+    (overrides (((enable_harvest_rotate true)) ((harvest_fraction 1.0)))))))
+ (baseline_label "baseline")
+ (gate ((metric Sharpe)(m 8)(n 15)(worst_delta 0.30))))


### PR DESCRIPTION
Step 4a of the harvest-rotate rigorous test. WF-CV surface (Cell-E top-3000, 2011-2026, 15 folds): baseline (harvest off) vs harvest_fraction ∈ {0.33, 0.5, 1.0}. Run launched (~4h); results + the decomposed-why analysis (step 4b) follow. Experiment files only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)