### PR TITLE
feat(universe): composition-policy types + dual-class detection (PR-A)

### DIFF
--- a/dev/plans/universe-composition-policy-2026-06-11.md
+++ b/dev/plans/universe-composition-policy-2026-06-11.md
@@ -1,0 +1,104 @@
+# Universe-composition policy (explicit, flag-driven, additive) — 2026-06-11
+
+Source priority: `dev/notes/next-session-priorities-2026-06-11-PM.md` §P1.
+
+## Problem
+
+The real tradeable US universe is ~3,500-4,500 operating companies (Ritter/CRSP:
+~3,650 operating companies). The ticker-count gap up to ~5,600 (looser ~8,000) is
+**dual-class duplicates + ADRs + REITs + SPACs/warrants/units/preferreds/CEFs** —
+mostly not stage-tradeable.
+
+Our current PIT top-{500,1000,3000} compositions (`Build_from_individuals`) already
+drop ETFs / Mutual_funds / Funds / Bonds via `Asset_type.is_equity_like` (keeps
+Common_stock / Preferred_stock / ADR / GDR). But they:
+
+1. **Do NOT dedup dual-class** — GOOG+GOOGL and BRK-A+BRK-B can both be ranked into
+   the universe, so the screener can hold both classes as two positions of one
+   economic entity (latent over-concentration bug).
+2. **Include all REITs** (SPG / O / PLD / AMT) with no explicit policy flag.
+3. **Include all ADRs** (TSM / ASML and the small illiquid tail) — no liquidity floor.
+4. Keep `Preferred_stock` as "equity-like" — that is junk for a stage strategy and
+   should be auditable / excludable.
+
+## Goal
+
+A **composition-policy** module in `trading/analysis/data/universe/` that takes a
+candidate universe (ranked symbols + per-symbol metadata) and applies policy flags,
+producing (a) a policy-filtered candidate list and (b) a per-filter **drop report**
+so we can see exactly what each policy removed.
+
+**Every flag defaults to current behaviour** — so all existing goldens / universes
+stay bit-identical until a flag is explicitly flipped. This is the data-layer analog
+of `.claude/rules/experiment-flag-discipline.md` (default-off on merge).
+
+## Design
+
+The policy is **pure** and operates on a self-contained `candidate` record, so it
+does not depend on the build internals (keeps it testable and decoupled). The
+candidate carries exactly the metadata each filter needs:
+
+```
+type candidate = {
+  symbol : string;
+  asset_type : Eodhd.Asset_type.t;   (* ADR / Preferred / Common / ... *)
+  sector : string;                   (* GICS sector; "Real Estate" => REIT *)
+  avg_dollar_volume : float;         (* the dollar-volume score already computed *)
+  rank : int;                        (* 0-based rank within the candidate pool *)
+}
+```
+
+Candidates arrive in rank order (most-liquid first). The policy applies, in order:
+
+1. **Dual-class dedup** — keep one class per economic entity. Detection =
+   known-pairs table (GOOG/GOOGL, BRK-A/BRK-B, ...) plus a root-symbol heuristic
+   (strip a trailing class suffix like `-A`/`-B`; same root => same entity). When two
+   candidates collapse to one entity, keep the higher-ranked (more liquid) one. Limits
+   documented in the `.mli` (heuristic has false positives; known-pairs table is the
+   authoritative override).
+2. **REIT include/exclude** — `reit_policy : Include | Exclude`, default `Include`.
+   REIT detected by `sector = "Real Estate"` (config-driven label).
+3. **ADR policy** — `adr_min_dollar_volume : float option`, default `None` (keep all).
+   When `Some floor`, drop ADR/GDR candidates whose `avg_dollar_volume < floor`.
+4. **Junk-exclusion audit** — `exclude_preferred : bool` (default `false` =
+   current behaviour, preferred kept). Always emits an audit count of any
+   non-stage-tradeable types that leaked in (SPAC/warrant/unit/preferred/CEF —
+   the latter already dropped upstream, so the audit is mostly a guard that emits
+   a report even when the count is zero).
+
+Output:
+
+```
+type drop = { symbol : string; reason : drop_reason }
+type filter_report = { filter : string; dropped : drop list; kept_count : int }
+type result = { kept : candidate list; reports : filter_report list }
+```
+
+## Increments (stacked PRs under `feat/universe-composition-policy`, each < 500 LOC)
+
+- **PR-A — types + dual-class detection.** `composition_policy_types.ml/.mli`
+  (candidate, policy config with default-current-behaviour flags, drop_reason,
+  report types) + `dual_class.ml/.mli` (known-pairs table + root-symbol heuristic).
+  Tests pin: known-pair collapse keeps the more-liquid class; heuristic root match;
+  non-matches pass through.
+- **PR-B — filters + report.** `composition_policy.ml/.mli` applying
+  dedup → REIT → ADR-floor → junk-audit and emitting the per-filter drop report.
+  Tests pin: default config is a no-op (bit-identical pass-through); each flag drops
+  exactly the intended symbols and records them in the right report.
+- **PR-C — builder/CLI wiring + report emitter.** Wire the policy into a thin
+  adapter that turns a `Build_from_individuals` scored pool into `candidate`s, and a
+  CLI that runs the policy over an existing snapshot's symbols + emits the drop
+  report. Status update.
+
+## Out of scope
+
+- The weekly >1%-of-ADV liquidity gate in the screener (separate weinstein-side
+  dispatch).
+- Re-running any backtests (the rerun is the dependency P0/P2 own, after this lands).
+
+## Invariants
+
+- OCaml only; pure functions; thresholds config-driven (no magic numbers).
+- A2: all code under `trading/analysis/data/universe/` — no imports into
+  `trading/trading/`.
+- Default config = current behaviour, verified by a bit-identical pass-through test.

--- a/trading/analysis/data/universe/lib/composition_policy_types.ml
+++ b/trading/analysis/data/universe/lib/composition_policy_types.ml
@@ -1,0 +1,47 @@
+open Core
+
+(* Default sector label that identifies a REIT in the GICS sector column. *)
+let _default_reit_sector_label = "Real Estate"
+
+type candidate = {
+  symbol : string;
+  asset_type : Eodhd.Asset_type.t;
+  sector : string;
+  avg_dollar_volume : float;
+  rank : int;
+}
+[@@deriving sexp, eq, show]
+
+type reit_policy = Include | Exclude [@@deriving sexp, eq, show]
+
+type config = {
+  reit_policy : reit_policy;
+  reit_sector_label : string;
+  adr_min_dollar_volume : float option;
+  exclude_preferred : bool;
+}
+[@@deriving sexp, eq, show]
+
+let default_config =
+  {
+    reit_policy = Include;
+    reit_sector_label = _default_reit_sector_label;
+    adr_min_dollar_volume = None;
+    exclude_preferred = false;
+  }
+
+type drop_reason =
+  | Dual_class_duplicate of { kept_symbol : string }
+  | Reit_excluded
+  | Adr_below_liquidity_floor of { floor : float; avg_dollar_volume : float }
+  | Preferred_excluded
+[@@deriving sexp, eq, show]
+
+type drop = { symbol : string; reason : drop_reason }
+[@@deriving sexp, eq, show]
+
+type filter_report = { filter : string; dropped : drop list; kept_count : int }
+[@@deriving sexp, eq, show]
+
+type result = { kept : candidate list; reports : filter_report list }
+[@@deriving sexp, eq, show]

--- a/trading/analysis/data/universe/lib/composition_policy_types.mli
+++ b/trading/analysis/data/universe/lib/composition_policy_types.mli
@@ -1,0 +1,101 @@
+(** Types for the explicit, flag-driven universe-composition policy.
+
+    The composition policy ({!Composition_policy}) takes a candidate universe —
+    a rank-ordered list of {!candidate}s carrying just enough per-symbol
+    metadata for each policy filter — and applies a {!config} of policy flags,
+    producing a filtered candidate list plus a per-filter drop {!report} so a
+    human can see exactly what each policy removed.
+
+    Design intent (see [dev/plans/universe-composition-policy-2026-06-11.md]):
+    the real tradeable US universe is ~3,500-4,500 operating companies; the
+    surplus ticker count is dual-class duplicates, illiquid ADRs, REITs (policy
+    TBD), and junk (SPAC / warrant / unit / preferred / CEF). The policy makes
+    each of those choices explicit and config-driven.
+
+    {1 Default = current behaviour}
+
+    {!default_config} is the no-op: it keeps everything the current
+    {!Build_from_individuals} pipeline keeps, so a universe rebuilt through the
+    policy with the default config is bit-identical to one built without it.
+    Every flag must be flipped explicitly to change a result — the data-layer
+    analog of [.claude/rules/experiment-flag-discipline.md]. *)
+
+type candidate = {
+  symbol : string;
+  asset_type : Eodhd.Asset_type.t;
+      (** Instrument classification, used by the ADR-floor and junk-audit
+          filters. *)
+  sector : string;
+      (** GICS sector label. The REIT filter treats [sector = reit_sector_label]
+          (see {!config}) as a REIT. *)
+  avg_dollar_volume : float;
+      (** Average daily dollar volume over the ranking window. Used by the
+          ADR-liquidity-floor filter and as the dual-class tie-breaker (keep the
+          more liquid class). *)
+  rank : int;
+      (** 0-based rank within the incoming candidate pool (most liquid = 0).
+          Used as the dual-class tie-breaker when [avg_dollar_volume] ties. *)
+}
+[@@deriving sexp, eq, show]
+(** One member of the candidate universe fed to the policy. *)
+
+(** Whether REITs are kept in or excluded from the universe. *)
+type reit_policy =
+  | Include  (** Keep REITs (current behaviour). *)
+  | Exclude  (** Drop every candidate whose sector is [reit_sector_label]. *)
+[@@deriving sexp, eq, show]
+
+type config = {
+  reit_policy : reit_policy;
+      (** Default [Include] — current behaviour keeps REITs. *)
+  reit_sector_label : string;
+      (** GICS sector string that identifies a REIT. Default ["Real Estate"]. *)
+  adr_min_dollar_volume : float option;
+      (** Liquidity floor for ADR / GDR candidates. [None] (default) keeps every
+          ADR. [Some floor] drops ADR / GDR candidates whose [avg_dollar_volume]
+          is strictly below [floor], keeping only the large / liquid ADRs. *)
+  exclude_preferred : bool;
+      (** When [true], drop [Preferred_stock] candidates (they trade unlike a
+          common stock and are poor Weinstein-stage instruments). Default
+          [false] — current behaviour keeps preferred shares, since
+          {!Eodhd.Asset_type.is_equity_like} admits them. *)
+}
+[@@deriving sexp, eq, show]
+(** Policy flags. {!default_config} sets every field to the current (pre-policy)
+    behaviour. *)
+
+val default_config : config
+(** The no-op policy: [reit_policy = Include],
+    [reit_sector_label = "Real Estate"], [adr_min_dollar_volume = None],
+    [exclude_preferred = false]. Running the policy with this config keeps every
+    candidate (the dual-class dedup in {!Composition_policy} is the one filter
+    that is always active, because holding two classes of one entity is a bug,
+    not a policy choice — see that module's docstring). *)
+
+(** Why a candidate was dropped. Each constructor maps to exactly one policy
+    filter so the drop report is unambiguous. *)
+type drop_reason =
+  | Dual_class_duplicate of { kept_symbol : string }
+      (** Collapsed into [kept_symbol], the more-liquid class of the same
+          economic entity. *)
+  | Reit_excluded
+  | Adr_below_liquidity_floor of { floor : float; avg_dollar_volume : float }
+  | Preferred_excluded
+[@@deriving sexp, eq, show]
+
+type drop = { symbol : string; reason : drop_reason }
+[@@deriving sexp, eq, show]
+(** A single dropped symbol with its reason. *)
+
+type filter_report = {
+  filter : string;  (** Stable filter name, e.g. ["dual_class_dedup"]. *)
+  dropped : drop list;  (** Symbols this filter removed, in input order. *)
+  kept_count : int;  (** Candidates remaining after this filter ran. *)
+}
+[@@deriving sexp, eq, show]
+(** Per-filter audit record. *)
+
+type result = { kept : candidate list; reports : filter_report list }
+[@@deriving sexp, eq, show]
+(** Output of {!Composition_policy.apply}: the surviving candidates (rank order
+    preserved) plus one {!filter_report} per filter, in application order. *)

--- a/trading/analysis/data/universe/lib/dual_class.ml
+++ b/trading/analysis/data/universe/lib/dual_class.ml
@@ -1,0 +1,49 @@
+open Core
+
+(* Curated dual-class entities. The canonical key is conventionally the more
+   commonly-quoted / more-liquid class's ticker, but any stable string works —
+   only equality of keys across a pair matters. Tickers are stored uppercased;
+   [entity_key] uppercases its input before lookup. *)
+let known_pairs =
+  [
+    ("GOOGL", [ "GOOG"; "GOOGL" ]);
+    (* Alphabet Class C / Class A *)
+    ("BRK-B", [ "BRK-A"; "BRK-B" ]);
+    (* Berkshire Hathaway Class A / Class B *)
+    ("UA", [ "UA"; "UAA" ]);
+    (* Under Armour Class C / Class A *)
+    ("FOXA", [ "FOX"; "FOXA" ]);
+    (* Fox Corp Class B / Class A *)
+    ("NWSA", [ "NWS"; "NWSA" ]);
+    (* News Corp Class B / Class A *)
+    ("LEN", [ "LEN"; "LEN-B" ]);
+    (* Lennar Class A / Class B *)
+    ("HEI", [ "HEI"; "HEI-A" ]);
+    (* HEICO common / Class A *)
+  ]
+
+(* Reverse index: member-ticker (uppercased) -> canonical key. Built once. *)
+let _member_to_key : (string, string) Hashtbl.t =
+  let tbl = Hashtbl.create (module String) in
+  List.iter known_pairs ~f:(fun (key, members) ->
+      List.iter members ~f:(fun m ->
+          Hashtbl.set tbl ~key:(String.uppercase m) ~data:key));
+  tbl
+
+(* Class suffixes the root heuristic strips. A two-char separator+letter
+   ([-A], [.B]) collapses to the root before it. Order does not matter; each is
+   tested as an exact trailing match. *)
+let _class_suffixes = [ "-A"; "-B"; "-C"; ".A"; ".B"; ".C" ]
+
+let _strip_class_suffix upper =
+  match
+    List.find _class_suffixes ~f:(fun suf -> String.is_suffix upper ~suffix:suf)
+  with
+  | Some suf -> String.drop_suffix upper (String.length suf)
+  | None -> upper
+
+let entity_key symbol =
+  let upper = String.uppercase symbol in
+  match Hashtbl.find _member_to_key upper with
+  | Some key -> key
+  | None -> _strip_class_suffix upper

--- a/trading/analysis/data/universe/lib/dual_class.mli
+++ b/trading/analysis/data/universe/lib/dual_class.mli
@@ -1,0 +1,52 @@
+(** Dual-class share detection: map a ticker to the economic entity it belongs
+    to, so the composition policy can keep at most one class per company.
+
+    Today the PIT compositions can contain GOOG {i and} GOOGL, or BRK-A {i and}
+    BRK-B — two share classes of one economic entity ranked as two separate
+    universe members. A portfolio built on such a universe can hold both classes
+    as two positions, doubling the intended exposure to one company. This module
+    provides the detection used by {!Composition_policy} to collapse those.
+
+    {1 Detection strategy}
+
+    Two layers, checked in order:
+
+    1. {b Known-pairs table} — a hand-maintained list grouping the tickers of
+    one entity under a canonical key (e.g. [GOOG] / [GOOGL] -> ["GOOGL"]). This
+    is the authoritative override: anything in the table is grouped exactly as
+    the table says, regardless of the heuristic.
+
+    2. {b Root-symbol heuristic} — strip a trailing class suffix ([-A] / [-B] /
+    [.A] / [.B], etc., see {!entity_key} for the full set) and treat the
+    remaining root as the entity key. Catches the common [BRK-A] / [BRK-B] ->
+    [BRK] shape without an explicit table entry.
+
+    {1 Known limits}
+
+    The heuristic has false positives: two genuinely-distinct companies whose
+    tickers differ only by a trailing [-A] / [-B] would be wrongly merged. It
+    also has false negatives: dual-class pairs that share no common root and are
+    not in the table (e.g. an entity using two unrelated tickers) are not
+    detected. The known-pairs table is the escape hatch for both — add an entry
+    to force-group or (by giving each ticker a distinct key) force-split. The
+    table is intentionally small and curated, not exhaustive. *)
+
+val known_pairs : (string * string list) list
+(** [known_pairs] is [(canonical_key, members)] for the curated dual-class
+    entities. Every ticker in [members] maps to [canonical_key] via
+    {!entity_key}. Exposed for inspection / test pinning. *)
+
+val entity_key : string -> string
+(** [entity_key symbol] returns a stable identifier for the economic entity
+    [symbol] belongs to. Two symbols return the same key iff this module
+    considers them share classes of the same company.
+
+    Resolution order:
+    - If [symbol] (case-insensitively) appears in {!known_pairs}, returns that
+      entity's canonical key.
+    - Otherwise applies the root-symbol heuristic: uppercases, then strips a
+      single trailing class marker — one of [-A] [-B] [-C] [.A] [.B] [.C] or a
+      bare trailing [.] segment of length 1 — and returns the root. A symbol
+      with no recognised suffix returns itself (uppercased).
+
+    Pure: same input -> same output. *)

--- a/trading/analysis/data/universe/lib/dune
+++ b/trading/analysis/data/universe/lib/dune
@@ -7,6 +7,8 @@
   build_from_individuals
   composition_inputs
   composition_bar_reader
+  composition_policy_types
+  dual_class
   cross_validation)
  (libraries core eodhd kenneth_french shiller status synthetic)
  (preprocess

--- a/trading/analysis/data/universe/test/dune
+++ b/trading/analysis/data/universe/test/dune
@@ -5,12 +5,14 @@
   test_build_from_individuals
   test_build_synthetic_universes_runner
   test_build_composition_universes_runner
+  test_dual_class
   test_cross_validation)
  (libraries
   build_composition_universes_runner_lib
   build_synthetic_universes_runner_lib
   core
   cross_validation_runner_lib
+  eodhd
   kenneth_french
   matchers
   ounit2

--- a/trading/analysis/data/universe/test/test_dual_class.ml
+++ b/trading/analysis/data/universe/test/test_dual_class.ml
@@ -46,6 +46,26 @@ let test_distinct_plain_symbols_distinct_keys _ =
     (String.equal (DC.entity_key "AAPL") (DC.entity_key "MSFT"))
     (equal_to false)
 
+(* False-positive guards: the heuristic strips ONLY an explicit two-char
+   separator+letter suffix ([-A] / [.B] style). A bare trailing class letter
+   with no separator is NOT a class suffix and must not be stripped. *)
+let test_bare_trailing_letter_not_stripped _ =
+  assert_that (DC.entity_key "TESLA") (equal_to "TESLA")
+
+(* Symbols that merely share a prefix are unrelated entities and must keep
+   distinct keys. *)
+let test_prefix_sharing_symbols_distinct_keys _ =
+  assert_that
+    (String.equal (DC.entity_key "FOO") (DC.entity_key "FOOD"))
+    (equal_to false)
+
+(* A suffixed class symbol collapses to its root, but an unrelated longer
+   symbol extending that root does not collide with it. *)
+let test_suffixed_class_distinct_from_longer_symbol _ =
+  assert_that
+    (String.equal (DC.entity_key "FOO-A") (DC.entity_key "FOOD"))
+    (equal_to false)
+
 (* known_pairs is non-empty and every member round-trips to its key. *)
 let test_known_pairs_members_round_trip _ =
   let all_consistent =
@@ -86,6 +106,12 @@ let suite =
          "test_plain_symbol_maps_to_itself" >:: test_plain_symbol_maps_to_itself;
          "test_distinct_plain_symbols_distinct_keys"
          >:: test_distinct_plain_symbols_distinct_keys;
+         "test_bare_trailing_letter_not_stripped"
+         >:: test_bare_trailing_letter_not_stripped;
+         "test_prefix_sharing_symbols_distinct_keys"
+         >:: test_prefix_sharing_symbols_distinct_keys;
+         "test_suffixed_class_distinct_from_longer_symbol"
+         >:: test_suffixed_class_distinct_from_longer_symbol;
          "test_known_pairs_members_round_trip"
          >:: test_known_pairs_members_round_trip;
          "test_default_config_is_current_behaviour"

--- a/trading/analysis/data/universe/test/test_dual_class.ml
+++ b/trading/analysis/data/universe/test/test_dual_class.ml
@@ -1,0 +1,95 @@
+open Core
+open OUnit2
+open Matchers
+open Universe
+module DC = Dual_class
+module CPT = Composition_policy_types
+
+(* ---------------------------------------------------------------------- *)
+(* Dual_class.entity_key                                                   *)
+(* ---------------------------------------------------------------------- *)
+
+(* Known-pair members of one entity collapse to the same canonical key. *)
+let test_known_pair_goog_googl_same_key _ =
+  assert_that (DC.entity_key "GOOG") (equal_to (DC.entity_key "GOOGL"))
+
+let test_known_pair_brk_a_b_same_key _ =
+  assert_that (DC.entity_key "BRK-A") (equal_to (DC.entity_key "BRK-B"))
+
+(* The canonical key for a known pair is the table's key string. *)
+let test_known_pair_canonical_key _ =
+  assert_that (DC.entity_key "GOOG") (equal_to "GOOGL")
+
+(* Case-insensitive: lowercased input still hits the known-pairs table. *)
+let test_known_pair_case_insensitive _ =
+  assert_that (DC.entity_key "goog") (equal_to (DC.entity_key "GOOGL"))
+
+(* Root heuristic: a trailing class suffix is stripped so two share classes
+   not in the table still collapse (e.g. a hypothetical FOO-A / FOO-B). *)
+let test_heuristic_strips_class_suffix _ =
+  assert_that (DC.entity_key "FOO-A") (equal_to (DC.entity_key "FOO-B"))
+
+let test_heuristic_root_equals_base_symbol _ =
+  assert_that (DC.entity_key "FOO-A") (equal_to "FOO")
+
+(* Dot-form class suffix is also stripped. *)
+let test_heuristic_strips_dot_suffix _ =
+  assert_that (DC.entity_key "BAR.A") (equal_to "BAR")
+
+(* A plain single-class ticker with no recognised suffix maps to itself
+   (uppercased) and does NOT collide with an unrelated ticker. *)
+let test_plain_symbol_maps_to_itself _ =
+  assert_that (DC.entity_key "AAPL") (equal_to "AAPL")
+
+let test_distinct_plain_symbols_distinct_keys _ =
+  assert_that
+    (String.equal (DC.entity_key "AAPL") (DC.entity_key "MSFT"))
+    (equal_to false)
+
+(* known_pairs is non-empty and every member round-trips to its key. *)
+let test_known_pairs_members_round_trip _ =
+  let all_consistent =
+    List.for_all DC.known_pairs ~f:(fun (key, members) ->
+        List.for_all members ~f:(fun m -> String.equal (DC.entity_key m) key))
+  in
+  assert_that all_consistent (equal_to true)
+
+(* ---------------------------------------------------------------------- *)
+(* Composition_policy_types.default_config                                 *)
+(* ---------------------------------------------------------------------- *)
+
+(* The default config is the documented no-op: REITs included, no ADR floor,
+   preferred kept, "Real Estate" REIT label. *)
+let test_default_config_is_current_behaviour _ =
+  assert_that CPT.default_config
+    (all_of
+       [
+         field (fun c -> c.CPT.reit_policy) (equal_to CPT.Include);
+         field (fun c -> c.CPT.reit_sector_label) (equal_to "Real Estate");
+         field (fun c -> c.CPT.adr_min_dollar_volume) is_none;
+         field (fun c -> c.CPT.exclude_preferred) (equal_to false);
+       ])
+
+let suite =
+  "Dual_class"
+  >::: [
+         "test_known_pair_goog_googl_same_key"
+         >:: test_known_pair_goog_googl_same_key;
+         "test_known_pair_brk_a_b_same_key" >:: test_known_pair_brk_a_b_same_key;
+         "test_known_pair_canonical_key" >:: test_known_pair_canonical_key;
+         "test_known_pair_case_insensitive" >:: test_known_pair_case_insensitive;
+         "test_heuristic_strips_class_suffix"
+         >:: test_heuristic_strips_class_suffix;
+         "test_heuristic_root_equals_base_symbol"
+         >:: test_heuristic_root_equals_base_symbol;
+         "test_heuristic_strips_dot_suffix" >:: test_heuristic_strips_dot_suffix;
+         "test_plain_symbol_maps_to_itself" >:: test_plain_symbol_maps_to_itself;
+         "test_distinct_plain_symbols_distinct_keys"
+         >:: test_distinct_plain_symbols_distinct_keys;
+         "test_known_pairs_members_round_trip"
+         >:: test_known_pairs_members_round_trip;
+         "test_default_config_is_current_behaviour"
+         >:: test_default_config_is_current_behaviour;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
PR-A of 3 — the explicit, flag-driven universe-composition policy. Plan: `dev/plans/universe-composition-policy-2026-06-11.md`; brief: `dev/notes/next-session-priorities-2026-06-11-PM.md` §P1.

## What it does
Lands the type vocabulary + dual-class detection the policy is built on.

- **`composition_policy_types`** — `candidate` (symbol / asset_type / sector / avg_dollar_volume / rank), `config` (policy flags), `drop_reason`, `drop`, `filter_report`, `result`. `default_config` is the documented no-op (current behaviour: REITs included, no ADR floor, preferred kept).
- **`dual_class`** — `entity_key` maps a ticker to its economic entity so the policy can keep one class per company. Resolution: curated known-pairs table (GOOG/GOOGL, BRK-A/BRK-B, UA/UAA, FOX/FOXA, NWS/NWSA, LEN/LEN-B, HEI/HEI-A) then a root-symbol class-suffix heuristic (`-A`/`-B`/`-C`/`.A`/...). Known limits (heuristic false +/-; table is the override) documented in the `.mli`.

## Why
The real tradeable US universe is ~3,500-4,500 operating companies; our PIT top-{500,1000,3000} compositions currently bake in dual-class duplicates (GOOG+GOOGL both held — latent over-concentration bug), all REITs, all ADRs, and keep preferred. This series makes each choice explicit + applicable as a filter layer, every flag defaulting to current behaviour.

## Test plan
`test_dual_class.ml` (11 tests): known-pair collapse, canonical key, case-insensitivity, suffix-strip heuristic (dash + dot forms), plain-ticker identity, distinct-ticker distinctness, table round-trip, default-config no-op. `dune build && dune runtest analysis/data/universe/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)