### PR TITLE
feat(universe): composition-policy filter pipeline + drop report (PR-B)

### DIFF
--- a/trading/analysis/data/universe/lib/composition_policy.ml
+++ b/trading/analysis/data/universe/lib/composition_policy.ml
@@ -1,0 +1,112 @@
+open Core
+open Composition_policy_types
+
+(* Stable filter names used in the drop reports. *)
+let _filter_dual_class = "dual_class_dedup"
+let _filter_reit = "reit_policy"
+let _filter_adr_floor = "adr_liquidity_floor"
+let _filter_preferred = "preferred_exclusion"
+
+(* A filter splits its input into (kept, dropped) preserving input order.
+   [run_filter] wraps that into a [filter_report] over the survivors. *)
+let _make_report ~filter ~kept ~dropped =
+  { filter; dropped; kept_count = List.length kept }
+
+(* Partition [candidates] by [classify], which tags each candidate as either
+   kept (returns [None]) or dropped with a reason (returns [Some reason]).
+   Returns [(kept, dropped)] with input order preserved in both. Avoids
+   [List.partition_map]'s [Either] argument-order subtleties. *)
+let _split (candidates : candidate list)
+    ~(classify : candidate -> drop_reason option) =
+  let kept_rev, dropped_rev =
+    List.fold candidates ~init:([], [])
+      ~f:(fun (kept, dropped) (c : candidate) ->
+        match classify c with
+        | None -> (c :: kept, dropped)
+        | Some reason -> (kept, { symbol = c.symbol; reason } :: dropped))
+  in
+  (List.rev kept_rev, List.rev dropped_rev)
+
+(* ------------------------------------------------------------------ *)
+(* Filter 1: dual-class dedup (always active)                          *)
+(* ------------------------------------------------------------------ *)
+
+(* For each economic entity (Dual_class.entity_key), keep the first candidate
+   encountered — input is rank order, so the first is the most liquid / highest
+   rank. Subsequent candidates of the same entity are dropped with a reference
+   to the kept symbol. *)
+let _dedup_dual_class candidates =
+  let seen = Hashtbl.create (module String) in
+  _split candidates ~classify:(fun c ->
+      let key = Dual_class.entity_key c.symbol in
+      match Hashtbl.find seen key with
+      | Some kept_symbol -> Some (Dual_class_duplicate { kept_symbol })
+      | None ->
+          Hashtbl.set seen ~key ~data:c.symbol;
+          None)
+
+(* ------------------------------------------------------------------ *)
+(* Filter 2: REIT include / exclude                                    *)
+(* ------------------------------------------------------------------ *)
+
+let _is_reit ~config c = String.equal c.sector config.reit_sector_label
+
+let _apply_reit_policy ~config candidates =
+  match config.reit_policy with
+  | Include -> (candidates, [])
+  | Exclude ->
+      _split candidates ~classify:(fun c ->
+          if _is_reit ~config c then Some Reit_excluded else None)
+
+(* ------------------------------------------------------------------ *)
+(* Filter 3: ADR / GDR liquidity floor                                 *)
+(* ------------------------------------------------------------------ *)
+
+let _is_adr_like c =
+  match c.asset_type with Eodhd.Asset_type.ADR | GDR -> true | _ -> false
+
+let _adr_floor_reason ~floor c =
+  if _is_adr_like c && Float.( < ) c.avg_dollar_volume floor then
+    Some
+      (Adr_below_liquidity_floor
+         { floor; avg_dollar_volume = c.avg_dollar_volume })
+  else None
+
+let _apply_adr_floor ~config candidates =
+  match config.adr_min_dollar_volume with
+  | None -> (candidates, [])
+  | Some floor -> _split candidates ~classify:(_adr_floor_reason ~floor)
+
+(* ------------------------------------------------------------------ *)
+(* Filter 4: preferred-stock exclusion                                 *)
+(* ------------------------------------------------------------------ *)
+
+let _is_preferred c =
+  match c.asset_type with
+  | Eodhd.Asset_type.Preferred_stock -> true
+  | _ -> false
+
+let _apply_preferred_policy ~config candidates =
+  if not config.exclude_preferred then (candidates, [])
+  else
+    _split candidates ~classify:(fun c ->
+        if _is_preferred c then Some Preferred_excluded else None)
+
+(* ------------------------------------------------------------------ *)
+(* Pipeline                                                            *)
+(* ------------------------------------------------------------------ *)
+
+let apply ~config candidates =
+  let kept1, dropped1 = _dedup_dual_class candidates in
+  let kept2, dropped2 = _apply_reit_policy ~config kept1 in
+  let kept3, dropped3 = _apply_adr_floor ~config kept2 in
+  let kept4, dropped4 = _apply_preferred_policy ~config kept3 in
+  let reports =
+    [
+      _make_report ~filter:_filter_dual_class ~kept:kept1 ~dropped:dropped1;
+      _make_report ~filter:_filter_reit ~kept:kept2 ~dropped:dropped2;
+      _make_report ~filter:_filter_adr_floor ~kept:kept3 ~dropped:dropped3;
+      _make_report ~filter:_filter_preferred ~kept:kept4 ~dropped:dropped4;
+    ]
+  in
+  { kept = kept4; reports }

--- a/trading/analysis/data/universe/lib/composition_policy.mli
+++ b/trading/analysis/data/universe/lib/composition_policy.mli
@@ -1,0 +1,41 @@
+(** Apply the explicit universe-composition policy to a candidate universe.
+
+    Takes a rank-ordered list of {!Composition_policy_types.candidate}s and a
+    {!Composition_policy_types.config}, runs the policy filters in a fixed
+    order, and returns the surviving candidates plus a per-filter drop
+    {!Composition_policy_types.filter_report}. See the plan at
+    [dev/plans/universe-composition-policy-2026-06-11.md].
+
+    {1 Filter order}
+
+    Filters run in this order, each consuming the previous filter's survivors:
+
+    1. {b Dual-class dedup} — collapse share classes of one economic entity (per
+    {!Dual_class.entity_key}) to a single member, keeping the higher-ranked
+    (more-liquid) class. {b Always active}: holding two classes of one company
+    is a correctness bug, not a policy choice, so this filter is not gated by
+    any flag. 2. {b REIT policy} — when [config.reit_policy = Exclude], drop
+    every candidate whose [sector = config.reit_sector_label]. 3.
+    {b ADR liquidity floor} — when [config.adr_min_dollar_volume = Some floor],
+    drop [ADR] / [GDR] candidates whose [avg_dollar_volume < floor]. 4.
+    {b Preferred exclusion} — when [config.exclude_preferred = true], drop
+    [Preferred_stock] candidates.
+
+    {1 Default = current behaviour}
+
+    With {!Composition_policy_types.default_config}, filters 2-4 are no-ops, so
+    the only candidates removed are genuine dual-class duplicates. A candidate
+    pool with no dual-class pairs passes through unchanged — see {!apply}'s pin
+    in the test suite. *)
+
+open Composition_policy_types
+
+val apply : config:config -> candidate list -> result
+(** [apply ~config candidates] runs the policy filters described above over
+    [candidates] (assumed in rank order, most-liquid first) and returns the
+    {!result}: the surviving candidates in their original relative order, plus
+    one {!filter_report} per filter (always all four, even when a filter dropped
+    nothing) in application order.
+
+    Pure: same inputs -> same output. Each dropped candidate appears in exactly
+    one report, attributed to the first filter that removed it. *)

--- a/trading/analysis/data/universe/lib/dune
+++ b/trading/analysis/data/universe/lib/dune
@@ -9,6 +9,7 @@
   composition_bar_reader
   composition_policy_types
   dual_class
+  composition_policy
   cross_validation)
  (libraries core eodhd kenneth_french shiller status synthetic)
  (preprocess

--- a/trading/analysis/data/universe/test/dune
+++ b/trading/analysis/data/universe/test/dune
@@ -6,6 +6,7 @@
   test_build_synthetic_universes_runner
   test_build_composition_universes_runner
   test_dual_class
+  test_composition_policy
   test_cross_validation)
  (libraries
   build_composition_universes_runner_lib

--- a/trading/analysis/data/universe/test/test_composition_policy.ml
+++ b/trading/analysis/data/universe/test/test_composition_policy.ml
@@ -177,6 +177,53 @@ let test_preferred_exclusion_drops_preferred _ =
        ])
 
 (* ---------------------------------------------------------------------- *)
+(* Single-report attribution + reconciliation                              *)
+(* ---------------------------------------------------------------------- *)
+
+(* Count of input candidates accounted for by the result: survivors plus every
+   dropped record across all filter reports. *)
+let _kept_plus_total_dropped (r : CPT.result) =
+  List.length r.CPT.kept
+  + List.sum
+      (module Int)
+      r.CPT.reports
+      ~f:(fun rep -> List.length rep.CPT.dropped)
+
+(* A Real-Estate-sector ADR below the liquidity floor matches BOTH the REIT
+   filter and the ADR floor when both are active. Pins the .mli guarantee that
+   each dropped candidate appears in exactly one report, attributed to the
+   FIRST filter that removed it (reit_policy here), and that the reports
+   reconcile with the input: kept + total dropped = input size. *)
+let test_multi_criteria_drop_attributed_to_first_filter_only _ =
+  let candidates =
+    [
+      _candidate ~rank:0 "AAPL";
+      _candidate ~asset_type:Eodhd.Asset_type.ADR ~sector:"Real Estate"
+        ~avg_dollar_volume:1_000.0 ~rank:1 "RE-ADR";
+    ]
+  in
+  let config =
+    {
+      CPT.default_config with
+      reit_policy = CPT.Exclude;
+      adr_min_dollar_volume = Some 1_000_000.0;
+    }
+  in
+  let result = CP.apply ~config candidates in
+  assert_that result
+    (all_of
+       [
+         field _kept_symbols (elements_are [ equal_to "AAPL" ]);
+         field
+           (fun r -> _dropped_symbols (_report r "reit_policy"))
+           (elements_are [ equal_to "RE-ADR" ]);
+         field
+           (fun r -> _dropped_symbols (_report r "adr_liquidity_floor"))
+           (elements_are []);
+         field _kept_plus_total_dropped (equal_to 2);
+       ])
+
+(* ---------------------------------------------------------------------- *)
 (* Determinism                                                             *)
 (* ---------------------------------------------------------------------- *)
 
@@ -208,6 +255,8 @@ let suite =
          >:: test_adr_floor_drops_small_adr_only;
          "test_preferred_exclusion_drops_preferred"
          >:: test_preferred_exclusion_drops_preferred;
+         "test_multi_criteria_drop_attributed_to_first_filter_only"
+         >:: test_multi_criteria_drop_attributed_to_first_filter_only;
          "test_apply_is_deterministic" >:: test_apply_is_deterministic;
        ]
 

--- a/trading/analysis/data/universe/test/test_composition_policy.ml
+++ b/trading/analysis/data/universe/test/test_composition_policy.ml
@@ -1,0 +1,214 @@
+open Core
+open OUnit2
+open Matchers
+open Universe
+module CP = Composition_policy
+module CPT = Composition_policy_types
+
+(* ---------------------------------------------------------------------- *)
+(* Fixture builder                                                         *)
+(* ---------------------------------------------------------------------- *)
+
+let _candidate ?(asset_type = Eodhd.Asset_type.Common_stock) ?(sector = "Tech")
+    ?(avg_dollar_volume = 1_000_000.0) ~rank symbol : CPT.candidate =
+  { symbol; asset_type; sector; avg_dollar_volume; rank }
+
+(* Extract surviving symbols in order. *)
+let _kept_symbols (r : CPT.result) = List.map r.kept ~f:(fun c -> c.CPT.symbol)
+
+(* Find a report by filter name. *)
+let _report (r : CPT.result) name =
+  List.find_exn r.reports ~f:(fun rep -> String.equal rep.CPT.filter name)
+
+let _dropped_symbols (rep : CPT.filter_report) =
+  List.map rep.dropped ~f:(fun d -> d.CPT.symbol)
+
+(* ---------------------------------------------------------------------- *)
+(* Default config = no-op on a clean (no dual-class) pool                  *)
+(* ---------------------------------------------------------------------- *)
+
+(* A pool with no dual-class pairs, default config: every candidate survives
+   in input order; no filter dropped anything. *)
+let test_default_config_passes_clean_pool_through _ =
+  let candidates =
+    [
+      _candidate ~rank:0 "AAPL";
+      _candidate ~rank:1 "MSFT";
+      _candidate ~asset_type:Eodhd.Asset_type.ADR ~rank:2 "TSM";
+      _candidate ~sector:"Real Estate" ~rank:3 "SPG";
+      _candidate ~asset_type:Eodhd.Asset_type.Preferred_stock ~rank:4 "BAC-PL";
+    ]
+  in
+  let result = CP.apply ~config:CPT.default_config candidates in
+  assert_that result
+    (all_of
+       [
+         field _kept_symbols
+           (elements_are
+              [
+                equal_to "AAPL";
+                equal_to "MSFT";
+                equal_to "TSM";
+                equal_to "SPG";
+                equal_to "BAC-PL";
+              ]);
+         field
+           (fun r -> List.map r.CPT.reports ~f:(fun rep -> rep.CPT.filter))
+           (elements_are
+              [
+                equal_to "dual_class_dedup";
+                equal_to "reit_policy";
+                equal_to "adr_liquidity_floor";
+                equal_to "preferred_exclusion";
+              ]);
+       ])
+
+(* ---------------------------------------------------------------------- *)
+(* Filter 1: dual-class dedup (always active)                              *)
+(* ---------------------------------------------------------------------- *)
+
+(* GOOGL ranked above GOOG: keep GOOGL (higher rank / more liquid), drop GOOG
+   with a reference to the kept symbol. Active even under the default config. *)
+let test_dual_class_keeps_higher_ranked _ =
+  let candidates =
+    [
+      _candidate ~rank:0 ~avg_dollar_volume:5e8 "GOOGL";
+      _candidate ~rank:1 "AAPL";
+      _candidate ~rank:2 ~avg_dollar_volume:2e8 "GOOG";
+    ]
+  in
+  let result = CP.apply ~config:CPT.default_config candidates in
+  assert_that result
+    (all_of
+       [
+         field _kept_symbols
+           (elements_are [ equal_to "GOOGL"; equal_to "AAPL" ]);
+         field
+           (fun r -> _dropped_symbols (_report r "dual_class_dedup"))
+           (elements_are [ equal_to "GOOG" ]);
+       ])
+
+(* The drop reason records WHICH symbol the duplicate collapsed into. *)
+let test_dual_class_drop_reason_names_kept_symbol _ =
+  let candidates = [ _candidate ~rank:0 "BRK-B"; _candidate ~rank:1 "BRK-A" ] in
+  let result = CP.apply ~config:CPT.default_config candidates in
+  assert_that (_report result "dual_class_dedup").dropped
+    (elements_are
+       [
+         equal_to
+           ({
+              symbol = "BRK-A";
+              reason = CPT.Dual_class_duplicate { kept_symbol = "BRK-B" };
+            }
+             : CPT.drop);
+       ])
+
+(* ---------------------------------------------------------------------- *)
+(* Filter 2: REIT exclude                                                  *)
+(* ---------------------------------------------------------------------- *)
+
+let test_reit_exclude_drops_real_estate _ =
+  let candidates =
+    [
+      _candidate ~rank:0 "AAPL";
+      _candidate ~sector:"Real Estate" ~rank:1 "SPG";
+      _candidate ~sector:"Real Estate" ~rank:2 "O";
+    ]
+  in
+  let config = { CPT.default_config with reit_policy = CPT.Exclude } in
+  let result = CP.apply ~config candidates in
+  assert_that result
+    (all_of
+       [
+         field _kept_symbols (elements_are [ equal_to "AAPL" ]);
+         field
+           (fun r -> _dropped_symbols (_report r "reit_policy"))
+           (elements_are [ equal_to "SPG"; equal_to "O" ]);
+       ])
+
+(* ---------------------------------------------------------------------- *)
+(* Filter 3: ADR liquidity floor                                           *)
+(* ---------------------------------------------------------------------- *)
+
+(* Floor drops only ADR/GDR below it; a low-volume common stock is untouched. *)
+let test_adr_floor_drops_small_adr_only _ =
+  let candidates =
+    [
+      _candidate ~asset_type:Eodhd.Asset_type.ADR ~avg_dollar_volume:5e8 ~rank:0
+        "TSM";
+      _candidate ~asset_type:Eodhd.Asset_type.ADR ~avg_dollar_volume:1e5 ~rank:1
+        "SMLADR";
+      _candidate ~asset_type:Eodhd.Asset_type.Common_stock
+        ~avg_dollar_volume:1e5 ~rank:2 "SMLCOM";
+    ]
+  in
+  let config = { CPT.default_config with adr_min_dollar_volume = Some 1e6 } in
+  let result = CP.apply ~config candidates in
+  assert_that result
+    (all_of
+       [
+         field _kept_symbols
+           (elements_are [ equal_to "TSM"; equal_to "SMLCOM" ]);
+         field
+           (fun r -> _dropped_symbols (_report r "adr_liquidity_floor"))
+           (elements_are [ equal_to "SMLADR" ]);
+       ])
+
+(* ---------------------------------------------------------------------- *)
+(* Filter 4: preferred exclusion                                           *)
+(* ---------------------------------------------------------------------- *)
+
+let test_preferred_exclusion_drops_preferred _ =
+  let candidates =
+    [
+      _candidate ~rank:0 "AAPL";
+      _candidate ~asset_type:Eodhd.Asset_type.Preferred_stock ~rank:1 "BAC-PL";
+    ]
+  in
+  let config = { CPT.default_config with exclude_preferred = true } in
+  let result = CP.apply ~config candidates in
+  assert_that result
+    (all_of
+       [
+         field _kept_symbols (elements_are [ equal_to "AAPL" ]);
+         field
+           (fun r -> _dropped_symbols (_report r "preferred_exclusion"))
+           (elements_are [ equal_to "BAC-PL" ]);
+       ])
+
+(* ---------------------------------------------------------------------- *)
+(* Determinism                                                             *)
+(* ---------------------------------------------------------------------- *)
+
+let test_apply_is_deterministic _ =
+  let candidates =
+    [
+      _candidate ~rank:0 "GOOGL";
+      _candidate ~sector:"Real Estate" ~rank:1 "SPG";
+      _candidate ~rank:2 "GOOG";
+    ]
+  in
+  let config = { CPT.default_config with reit_policy = CPT.Exclude } in
+  let r1 = CP.apply ~config candidates in
+  let r2 = CP.apply ~config candidates in
+  assert_that r2 (equal_to r1)
+
+let suite =
+  "Composition_policy"
+  >::: [
+         "test_default_config_passes_clean_pool_through"
+         >:: test_default_config_passes_clean_pool_through;
+         "test_dual_class_keeps_higher_ranked"
+         >:: test_dual_class_keeps_higher_ranked;
+         "test_dual_class_drop_reason_names_kept_symbol"
+         >:: test_dual_class_drop_reason_names_kept_symbol;
+         "test_reit_exclude_drops_real_estate"
+         >:: test_reit_exclude_drops_real_estate;
+         "test_adr_floor_drops_small_adr_only"
+         >:: test_adr_floor_drops_small_adr_only;
+         "test_preferred_exclusion_drops_preferred"
+         >:: test_preferred_exclusion_drops_preferred;
+         "test_apply_is_deterministic" >:: test_apply_is_deterministic;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
PR-B of 3 — stacked on #1537. The pure filter pipeline.

## What it does
**`composition_policy.apply ~config candidates`** runs four filters in fixed order over a rank-ordered candidate list, returning the survivors (rank order preserved) + one `filter_report` per filter:

1. **dual-class dedup** — always active (keeps the higher-ranked / more-liquid class per `Dual_class.entity_key`); holding two classes of one company is a correctness bug, not a policy choice.
2. **REIT include/exclude** — `config.reit_policy`, default `Include`. Drops `sector = reit_sector_label` when `Exclude`.
3. **ADR/GDR liquidity floor** — `config.adr_min_dollar_volume`, default `None`. Drops ADR/GDR below the floor.
4. **preferred exclusion** — `config.exclude_preferred`, default `false`.

With `default_config`, filters 2-4 are no-ops, so a pool with no dual-class pairs passes through unchanged (data-layer analog of `experiment-flag-discipline.md` default-off).

## Test plan
`test_composition_policy.ml` (7 tests): default-config clean-pool pass-through (+ report-order pin), dual-class keeps-higher-ranked + drop-reason names kept symbol, REIT-exclude, ADR-floor (drops small ADR only, leaves low-vol common alone), preferred-exclusion, determinism. `dune build && dune runtest analysis/data/universe/` green; nesting linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)