### PR TITLE
docs: trade-level forensics + changeable-vs-structural synthesis + margin research

### DIFF
--- a/dev/experiments/trade-forensics-2026-06-12/ANALYSIS.md
+++ b/dev/experiments/trade-forensics-2026-06-12/ANALYSIS.md
@@ -1,0 +1,200 @@
+# Trade-level forensics — broad universe, both regimes (2026-06-12)
+
+User request: deep trade-level analysis across the broad universe — good trades
+vs bad trades, impactful decisions, what works and what doesn't. Substrate: two
+single full-window Cell-E audit runs (652-trade bull ledger 2011-2026 on
+top-3000-2011; bear-decade ledger 2000-2011 on top-3000-2000), each with
+`trades.csv` + `trade_audit.sexp` (decision trail incl. MFE/MAE) + equity curve.
+
+Run artifacts: `dev/backtest/scenarios-2026-06-12-064232/cell-e-top3000-2011-15y/`
+and `dev/backtest/scenarios-2026-06-12-074543/cell-e-top3000-2000-regime/`
+(in-container/local; key tables reproduced here).
+
+## Part 1 — Bull ledger (2011-2026, 652 round-trips)
+
+Summary: win rate 33.1%, profit factor 1.43, realized P&L +$4.21M on $1M
+initial; terminal MTM $19.9M of which **AXTI alone ≈ $19.7M** (249,089 sh ×
+$79.22 — one ticket ≈ 100% of terminal NAV; position sized 14% at entry, never
+trimmed, ran 36×).
+
+### 1. Exit-channel decomposition (where money is made/lost)
+
+| exit channel | n | total realized | avg/trade | avg days |
+|---|---|---|---|---|
+| laggard_rotation | 192 | **+$10.98M** | +21.3% | 85 |
+| stop_loss | 450 | **−$7.01M** | −2.72% | 26 |
+| stage3_force_exit | 8 | +$0.24M | +1.3% | 62 |
+
+The P&L engine is: stops eat many small losses; the laggard-rotation channel
+(which exits relative-strength laggards to fund new entries) is the de-facto
+**profit-taking channel** — by the time a position fades enough to trigger
+`rs_13w_neg_weeks=2` it has usually banked a gain (median +2.7%, p90 +25%,
+mean +21% — right-tail dominated; 30% of rotations exit at a loss).
+
+### 2. Concentration (Bessembinder at trade level)
+
+Top 5 realized trades = **165%** of total realized P&L; top 10 = 203%; top 20
+= 242%. The other ~630 trades are NET NEGATIVE in aggregate. Add the
+unrealized side (AXTI = the entire terminal MTM) and the 15-year outcome is:
+a handful of right-tail rides pay for everything else.
+
+### 3. Win/loss anatomy — the machine works as designed
+
+Winners: n=216, avg +23.3%, held 87d. Losers: n=436, avg −4.9%, held 23d.
+Payoff ratio 4.7 at 33% win rate. Cut-losses-fast/let-winners-run is
+mechanically intact; there is no execution rot here.
+
+### 4. Entry-type decomposition — the realized edge is ~all in ONE entry type
+
+Audit rationale → score mapping: score 75/85 = **Stage1→2 breakout** entries;
+score 60/70 = **Early Stage2** entries.
+
+| entry type | n (share) | realized P&L (share) | avg/trade | win rate |
+|---|---|---|---|---|
+| Stage1→2 breakout (75/85) | 525 (80%) | ~+$0.30M (**7%**) | +1.9% | 33% |
+| Early Stage2 (60/70) | 86 (13%) | ~+$4.10M (**98%**) | +21.7% | 36% |
+| Other (shorts, low grades) | 41 | −$0.2M | — | — |
+
+Score=70 Early-Stage2 alone: n=57, avg **+34.6%**, +$4.75M (>100% of total).
+This is `project_cascade_selection_inversion` confirmed with realized dollars:
+the screener's highest-scored entry type (the textbook breakout, 80% of all
+capital deployments) is net-noise; the lower-scored early-Stage2 continuation
+entry is essentially the entire realized edge. The score=85 cohort stops out at
+73% rate (225/311 exits via stop) vs 56% for score-70.
+
+### 5. Give-back — first measurement (MFE/MAE fields now live)
+
+| cohort | n | avg MFE | avg realized | give-back |
+|---|---|---|---|---|
+| laggard_rotation exits | 188 | +51.8% | +21.6% | **30.1pp** |
+| stop_loss exits | 441 | +6.7% | −2.6% | 9.3pp |
+| MFE>20% cohort | 72 | +142% | +59.8% | **82pp** |
+
+Even stopped trades were up +6.7% on average at their peak. The big-winner
+cohort gives back over half its peak — that is the *designed* cost of holding
+for 36× tails (every exit-tightening variant has failed WF-CV; treat any
+"capture more MFE" proposal as winner-touching with the standing skeptical
+prior). The one candidate axis: laggard-rotation trigger latency
+(`rs_13w_neg_weeks`) — it fires ~30pp after the local peak; a faster RS
+trigger is *laggard*-touching rather than winner-touching, so it is at least
+eligible for a default-off surface test.
+
+### 6. Stop channel anatomy
+
+- 69% of all round-trips end at a stop; median stop-out dies **11 days** after
+  entry (p25=5d). Half the stop book is dead inside two weeks — entry timing
+  on breakouts is the weak link, consistent with §4.
+- **Gap-down stops** (313 of 450) cost −4.19% avg vs −1.79% for intraday stops:
+  ~2.4pp × 313 trades of unavoidable overnight-gap slippage. Structural cost of
+  weekly cadence + gaps; stop placement cannot remove it.
+- Whipsaw is minor: 444 symbols traded once; only 14 symbols traded 3+ times
+  (net −$51k). Re-entry churn is not a leak.
+
+### 7. By entry year (regime fingerprint)
+
+2020 (+$3.9M) and 2023 (+$2.8M) carry the ledger; 2022 (−$1.55M), 2024
+(−$0.80M), 2025 (−$1.80M, 6.7% win rate) bleed. CAVEAT: recent years are
+right-censored — their winners are still open (unrealized), so realized
+year-P&L overstates recent weakness. (The matrix's realized-vs-MTM columns
+showed the same censoring from the other side.)
+
+## Artifacts / process gaps found by this analysis (task 2 input)
+
+- **G1 — `open_positions.csv` writes the run date as `entry_date`** for every
+  open position (all rows say the run's end date). Writer bug; trivial.
+- **G2 — trades.csv ↔ audit reconciliation gap:** THM's 2022 short closed per
+  the audit (stop at 0.55, position THM-wein-8427) but has NO row in
+  trades.csv, while an OPEN 1.1M-share THM short (entry 0.69) sits in
+  open_positions with no audit entry record. At least one position's
+  round-trip accounting is inconsistent between the two artifacts.
+- **G3 — stale-hold zombies pollute the open book:** 23 of 24 open positions
+  are `stale_held_symbols` (e.g. CPKI held since 2011-07 at its delisting
+  close for 15 simulated years; THM short bleeding −240% unstopped because no
+  bars → no stop evaluation). Their NET value contribution here is small
+  (AXTI dominates), but audit runs should set the #1487 stale-exit flag ON so
+  the trade ledger closes these honestly.
+- **G4 — MFE/MAE memory was stale:** fields ARE populated now (fixed upstream,
+  likely #1525/#1528). Memory corrected; give-back analysis unlocked (§5).
+- **G5 — shorts present in a "long" baseline:** the Cell-E config trades
+  short-side entries (Stage3→4 breakdowns, score 65/55 cohort, n≈15, net
+  negative incl. the THM open disaster). Worth an explicit
+  `enable_short_entries` review — at minimum the per-share margin floors from
+  `dev/notes/long-short-margin-mechanics-2026-06-12.md` say sub-$17 shorts
+  (THM at $0.69!) are uneconomic to carry at 100%+ margin in reality.
+
+## Part 2 — Bear-decade ledger (2000-2011, 321 round-trips)
+
+Summary: +44.9% total over 11.5y, win rate 34.0%, MaxDD 31.2%. **Realized P&L
+is only +$61k** — final value $1.449M is ~all open-position value (unrealized
++$486k on the 2009-2011 recovery winners still open at window end; censoring).
+
+### Exit channels NET TO ZERO in the bear decade
+
+| exit channel | n | total realized | avg/trade | avg days |
+|---|---|---|---|---|
+| laggard_rotation | 67 | +$1.38M | +13.3% | 106 |
+| stop_loss | 246 | −$1.26M | −2.9% | 33 |
+| stage3_force_exit | 6 | −$0.05M | −5.1% | 67 |
+
+Same machine as the bull ledger, but the profit channel only just covers the
+stop channel. Payoff ratio collapses to 2.2 (vs 4.7) at the same ~34% win
+rate — chop makes winners half as big. All net return is terminal unrealized
+carry from the post-2009 leg.
+
+### Give-back is WORSE in chop
+
+| cohort | n | avg MFE | avg realized | give-back |
+|---|---|---|---|---|
+| stop_loss exits | 226 | **+12.7%** | −3.4% | **16.1pp** |
+| laggard_rotation exits | 64 | +37.5% | +13.3% | 24.1pp |
+
+Bear-decade stopped trades averaged +12.7% at peak before dying to −3.4%
+(bull: +6.7%→−2.6%). The wide trailing stop converts mid-size paper gains into
+losses when trends don't extend — this, not entry quality, is the bear-decade
+realized-P&L killer.
+
+### Entry-type edge INVERTS BACK across regimes
+
+| entry bucket | bull 2011-26 avg/trade | bear 2000-11 avg/trade |
+|---|---|---|
+| score 85 (Stage1→2 breakout) | +1.6% | +0.8% |
+| score 75 (Stage1→2 breakout) | +2.4% | −0.1% |
+| score 70 (Early Stage2) | **+34.6%** | **−1.9%** |
+
+The early-Stage2 dominance is a post-2011 phenomenon; in 2000-2011 it is mildly
+NEGATIVE. The cascade-inversion finding (`project_cascade_selection_inversion`)
+is regime-conditional — reweighting the cascade toward early-Stage2 on the
+post-2011 evidence would have been a regime bet, not a structural fix. (The
+inversion memory's "return edge non-stationary" caveat, now seen from the
+other side.)
+
+### Macro-gate protection = entry SUPPRESSION, not better entries
+
+2002: n=8 entries; 2008: n=11 (win rate 9%). The gate's value in crashes is
+keeping the strategy OUT (the matrix's halved drawdowns), not improving picks —
+the few entries it does allow in declining tape are awful. 2003-2005 recovery
+entries: +$0.53M realized, 40-47% win rates — the post-bear sweet spot in
+realized form (mirrors the matrix's 2003-04 start-date alpha).
+
+## Cross-regime synthesis — what works, what doesn't
+
+1. **What pays, everywhere:** a small number of long right-tail rides
+   (concentration: top-5 trades = 165% of bull realized P&L; AXTI = ~100% of
+   terminal bull NAV), entered disproportionately in post-bear recovery
+   windows (2003-05, 2011-13, 2020, 2023), held 80-110 days through the
+   laggard-rotation channel.
+2. **What loses, everywhere:** the stop channel (~70-77% of all trades), with
+   half of stop-outs dead within ~2 weeks of entry — breakout entries that
+   fail immediately. Gap-down slippage adds ~2.4pp per stop on 70% of stops.
+3. **What is regime-dependent (don't tune on it):** entry-type ranking
+   (early-Stage2 vs breakout flips sign across decades); per-trade payoff
+   (4.7 bull / 2.2 chop); the realized-vs-unrealized split.
+4. **What the machine does as designed (leave alone):** loss-cutting (avg
+   loser −5% in 23-31 days), winner-holding (the give-back is the price of
+   the 36× tail), low whipsaw.
+5. **Newly actionable candidates (default-off axes, skeptical priors):**
+   (a) laggard-rotation trigger latency (30/24pp give-back at exit;
+   laggard-touching, not winner-touching); (b) breakout-entry quality in
+   mid-bull regimes (the 2013-2018 / 2006-2007 entry cohorts are the bleed);
+   (c) short-side entries: disable or margin-model them (G5 — currently
+   unrealistic and net-negative).

--- a/dev/notes/changeable-vs-structural-2026-06-12.md
+++ b/dev/notes/changeable-vs-structural-2026-06-12.md
@@ -1,0 +1,83 @@
+# What we can change vs what we must design around (2026-06-12)
+
+Synthesis of: the two rolling-start matrices (`dev/experiments/
+rolling-start-matrix-2026-06-11/`), the trade-level forensics (`dev/
+experiments/trade-forensics-2026-06-12/`), the structural-bar frame
+(`memory/project_index_beating_structural_bar`), and the accumulated WF-CV
+rejection ledger. Task: separate actionable levers from structural facts so
+future sessions stop re-testing the unchangeable.
+
+## A. STRUCTURAL — cannot be changed; design around these
+
+1. **Sharpe's arithmetic / the skewness tax.** The strategy will not beat
+   total-return SPX on median CAGR in any regime (~+1pp median edge in both a
+   bull window and a bear decade, n=51 starts). Stage-based exits are
+   definitionally winner-touching; cap-weighted indexing holds every
+   mega-winner forever at zero cost. STOP proposing levers whose thesis is
+   "capture more of the index's upside" — six winner-touching mechanisms have
+   failed WF-CV; the matrices now show the ceiling itself.
+2. **Concentration IS the return.** Top-5 trades = 165% of bull realized P&L;
+   one ticket (AXTI) ≈ 100% of terminal bull NAV; bear-decade realized nets to
+   ~zero outside the recovery-leg carry. This is Bessembinder skewness flowing
+   through the strategy, not a sizing bug. Any mechanism that caps/trims/
+   rotates the right tail re-fails for the same reason.
+3. **Give-back is the price of the tail.** MFE>20% cohort gives back 82pp of a
+   142pp average peak. Tightening exits to "capture MFE" converts the one
+   thing that pays (36× rides) into mediocre banked gains — rejected
+   repeatedly (hysteresis, late-flag, harvest-rotate). Treat give-back as
+   COGS, not waste.
+4. **Gap risk through stops.** 70% of stop exits are gap-downs costing ~2.4pp
+   beyond intraday-stop fills. Weekly cadence + overnight gaps make this
+   unremovable by stop placement; only entry quality/size reduce its base.
+5. **Regime-dependence of per-trade edge.** Payoff ratio 4.7 (bull) vs 2.2
+   (chop) at identical ~34% win rates; entry-type ranking FLIPS across decades
+   (early-Stage2 +34.6%/trade post-2011, −1.9% in 2000-2011). Single-window
+   tuning of entry weights is regime-fitting — the confirmation-grid rule
+   exists for exactly this.
+6. **The strategy's real product is distribution compression** (worst-start
+   edge −4.9pp in the bear decade vs −28pp in the bull; DD halved through two
+   crashes; protection delivered by entry SUPPRESSION via the macro gate, not
+   by better picks). Sell it as that — a convex SPX-complement for the
+   barbell — not as an alpha engine.
+
+## B. CHANGEABLE — real levers, with priors
+
+1. **Universe composition (in flight).** Policy layer merged (#1537-#1540);
+   $-volume wired (#1542). Emit the ~top-4000 policy artifact; rerun baselines.
+   Known-positive prior (breadth robustly helps: realized 3×, DD tail capped).
+2. **Short-side hygiene (NEW, from forensics G5 + margin research).** The
+   "long" baseline carries Stage4-breakdown shorts that are (a) net-negative,
+   (b) unrealistic — no margin model, and sub-$17 shorts face 83-362%
+   capital requirements (FINRA tiers; THM at $0.69 is uncarryable). Lever:
+   default-off the short entries in long presets, or gate shorts on price
+   ≥ ~$17 + margin-aware sizing per
+   `dev/notes/long-short-margin-mechanics-2026-06-12.md` §4. LOW controversy.
+3. **Laggard-rotation trigger latency.** The de-facto profit channel exits
+   30/24pp below local peak (bull/bear). It is laggard-touching, not
+   winner-touching, so it escapes the standing prior — eligible for a
+   default-off `rs_neg_weeks` / RS-window surface under WF-CV. Skeptical
+   prior anyway (it already won a keep-ON verdict as-is).
+4. **Mid-regime entry bleed.** The bleed cohorts are specific: 2013-2018 and
+   2006-2007 ENTRY years (negative-edge start clusters + negative realized
+   year buckets). Half of stop-outs die in ≤11 days — failed breakouts.
+   Diagnostic lever, not a knob: characterize what distinguishes the
+   2003/2011/2020 entry vintages (post-bear base depth? breadth thrust?
+   sector dispersion?) and consider a REGIME-quality gate on the breakout
+   entry type only. This is entry-quality work — the one search direction the
+   fat-tail principle endorses.
+5. **Position-count / sizing interaction with the tail.** 14%-at-entry sizing
+   plus never trimming produced a 99%-NAV single position. The tail must be
+   kept, but the BARBELL (floor+engine, #1434/#1435) is the sanctioned way to
+   make the resulting NAV path survivable. Allocation-level lever, not
+   strategy-level.
+6. **Measurement honesty (cheap, compounding).** Stale-exit flag ON for audit
+   runs (G3); realized-basis + start-matrix as standard scoreboard; A1
+   min-window guard; A2 fold corruption fix; G1/G2 ledger bugs. All shipped or
+   queued this session.
+
+## C. The one-sentence operating thesis
+
+Run a breadth-maximal, entry-quality-gated Weinstein engine for its
+distribution-compression and post-bear convexity, sized inside a barbell
+against an index floor — and stop spending search budget on anything that
+touches winners, tightens exits, or tunes entry weights to a single regime.

--- a/dev/notes/long-short-margin-mechanics-2026-06-12.md
+++ b/dev/notes/long-short-margin-mechanics-2026-06-12.md
@@ -1,0 +1,115 @@
+# Long-short margin mechanics — broker/regulatory research (2026-06-12)
+
+Research for the long-short strategy track (user request 2026-06-12): how margin
+is actually computed for short and long-short equity portfolios, per the
+regulatory floor (Reg T + FINRA 4210) and the two target brokers (Schwab,
+IBKR). The goal is a faithful margin model for the backtest so long-short
+results reflect real capital requirements + carry costs.
+
+## 1. Regulatory floor (what every broker must at least require)
+
+### Initial margin (Reg T, 12 CFR 220)
+
+| Position | Initial requirement |
+|---|---|
+| Long stock | 50% of purchase price |
+| Short stock | **150% of short market value** = 100% (the short proceeds, held as collateral) + **50% additional cash/equity** |
+
+Practical meaning for sizing: opening a $10k short requires $5k of *new*
+equity; the $10k proceeds stay locked as collateral (credit balance $15k
+against a $10k short market value).
+
+### Maintenance margin (FINRA Rule 4210(c), verbatim tiers)
+
+| Position | Maintenance requirement |
+|---|---|
+| Long margin-eligible stock | 25% of current market value |
+| Short stock ≥ $5/share | **greater of $5.00/share or 30%** of current market value |
+| Short stock < $5/share | **greater of $2.50/share or 100%** of current market value |
+| Non-margin-eligible long | 100% |
+| Minimum account equity | $2,000 |
+
+Implications for the strategy's short leg:
+- The per-share dollar floors make **low-priced shorts brutally capital-hungry**
+  (a $3 stock shorted requires 100%+ — capital parity with the position itself;
+  a $6 stock requires $5/share ≈ 83%!). The 30% tier only binds cleanly above
+  ~$16.67/share ($5.00/0.30). **A short-side universe filter should require
+  price ≥ ~$17** to stay on the 30% tier — cheaper-priced shorts pay 83-100%+
+  margin, wrecking capital efficiency.
+- Equity of a short account = credit balance − short market value; the
+  requirement is recomputed daily on marked-to-market value, so shorts that
+  move AGAINST you both lose money and raise the requirement (30% of a larger
+  number) — margin spiral risk concentrates exactly in the squeeze scenario.
+
+## 2. Broker layers on top of the floor
+
+### Schwab
+- House maintenance generally ~30% on longs (vs 25% regulatory), higher on
+  concentrated or volatile names; short tiers track the FINRA schedule with
+  house add-ons. Schwab "may increase house maintenance requirements at any
+  time" without notice (disclosure doc, CRS 22760) — a margin model should
+  carry a house-buffer parameter, not hardcode the floor.
+- Schwab can force-liquidate without notice to meet calls; no entitlement to
+  call extensions. Borrowed-against dividend payments arrive as payments
+  in lieu (PIL), taxed as ordinary income — a small drag for long-margin and a
+  cost OWED on shorts (short seller pays the dividend to the lender; model
+  short positions as paying the full dividend on ex-date).
+
+### Interactive Brokers
+- Offers Reg-T accounts and **Portfolio Margin** (risk-based, OCC TIMS model:
+  requirement = largest theoretical loss across price/vol scenarios per
+  product class). PM can cut requirements well below Reg T for hedged books —
+  a long-short pairs book is exactly the case PM rewards (offsetting exposures
+  margined on net risk, not gross legs). PM needs $110k+ account minimum.
+- IBKR computes margin **in real time** and auto-liquidates on violation
+  (no margin-call grace at all) — tighter than Schwab's "attempt to involve
+  you." A backtest margin model for IBKR should enforce the requirement
+  intraday-continuously, not at day close.
+- House requirements on special names (corporate actions, hard-to-borrow)
+  override the schedule.
+
+## 3. Carry costs of the short leg
+
+- **Borrow fee**: annualized rate × short market value / 365, accrued daily on
+  settled positions. GC (general collateral / easy-to-borrow) large-caps ≈
+  0-0.5%/yr; hard-to-borrow names can run double-digit to triple-digit
+  annualized. Fee floats daily with lending-market supply/demand.
+- **Short rebate**: interest earned on the short proceeds ≈ short-term rate −
+  borrow fee (sign can flip negative for HTB). At IBKR, credit interest on
+  short proceeds is tiered and roughly benchmark-minus-spread for large
+  balances; retail at Schwab generally receives no rebate.
+- **Dividends**: short pays 100% of dividends on borrowed shares (plus the
+  lender's PIL treatment). For dividend-paying large-caps this is ~1.5-2%/yr
+  drag on the short leg before borrow fees.
+- **Buy-in risk**: HTB shorts can be force-recalled at the worst moment —
+  non-modelable as a fee; treat as a tail event / avoid HTB names outright.
+
+## 4. What the backtest margin model needs (spec sketch)
+
+1. Account-level state: cash, long market value, short market value, credit
+   balance; equity = cash + LMV − SMV.
+2. Requirement function (Reg-T mode):
+   `req = Σ_long max(0.25, house_long) × mv + Σ_short tier(price) × smv`
+   with `tier(p) = p<5 ? max(2.50/p, 1.0) : max(5.00/p, 0.30)` (+house buffer).
+3. Initial gate on entry: new short needs 50% additional equity over the
+   proceeds; reject orders that would breach.
+4. Daily mark: recompute on close; if equity < req → forced liquidation rule
+   (sell/cover in deterministic order) — this is the mechanism that turns
+   margin into PATH DEPENDENCE, the thing a naive "gross exposure cap" misses.
+5. Carry accrual: daily borrow fee + dividend payments on shorts; optional
+   rebate credit. Default parameters: GC fee 0.3%/yr, no rebate (retail),
+   dividends at actual historical rates (we have the data).
+6. Universe gate for the short side: price ≥ ~$17 (30%-tier), margin-eligible,
+   exclude HTB (proxy: avoid low-float/high-short-interest names — we lack
+   short-interest data; price+ADV floor is the practical stand-in).
+7. (Later) PM mode: net-risk margining for hedged books — only worth modeling
+   if the strategy actually runs balanced long-short.
+
+## Sources
+
+- [FINRA Rule 4210](https://www.finra.org/rules-guidance/rulebooks/finra-rules/4210) (maintenance tiers, verbatim)
+- [Reg T, 12 CFR Part 220](https://www.ecfr.gov/current/title-12/chapter-II/subchapter-A/part-220) (initial 50%/150%)
+- [Schwab margin disclosure (CRS 22760)](https://www.schwab.wallst.com/pdf/activetrader/marginriskdisclosure.pdf) + [Schwab margin rates page](https://www.schwab.com/margin/margin-rates-and-requirements) (house powers, PIL)
+- [IBKR margin requirements](https://www.interactivebrokers.com/en/trading/margin-requirements.php), [IBKR stock margin](https://www.interactivebrokers.com/en/trading/margin-stocks.php), [Portfolio Margin glossary](https://www.interactivebrokers.com/campus/glossary-terms/portfolio-margin-account/), [Short selling & margin lesson](https://www.interactivebrokers.com/campus/trading-lessons/short-selling-and-margin/)
+- [IBKR short sale cost](https://www.interactivebrokers.com/en/pricing/short-sale-cost.php), [IBKR borrow-fee risks](https://www.interactivebrokers.com/campus/traders-insight/securities/short-selling/the-risks-of-shorting-series-part-ii-borrow-fees/)
+- [Margin formulas reference](https://thismatter.com/money/stocks/margin.htm), [FINRA NtM 98-102](https://www.finra.org/rules-guidance/notices/98-102)


### PR DESCRIPTION
Docs-only, three deliverables from the 2026-06-12 overnight window:

1. **Trade forensics** (dev/experiments/trade-forensics-2026-06-12/): 652-trade bull + 321-trade bear-decade ledgers. Exit-channel decomposition (laggard rotation = the profit channel; stops = the loss eater, net-zero in chop), Bessembinder concentration (top-5 trades = 165% of realized; AXTI ≈ 100% of terminal NAV), entry-type edge regime-flip, first give-back measurement (MFE/MAE fields are live again), five process gaps G1-G5.
2. **Changeable vs structural** (dev/notes/changeable-vs-structural-2026-06-12.md): six structural facts to design around, six actionable levers with priors, one-sentence operating thesis.
3. **Long-short margin mechanics** (dev/notes/long-short-margin-mechanics-2026-06-12.md): FINRA 4210 tiers verbatim, Reg-T 150%, Schwab/IBKR house layers, borrow/rebate/dividend carry, backtest margin-model spec. Headline: sub-$17 shorts are uneconomic (83-362% margin) — the THM short in the current baseline is unrealistic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)