### PR TITLE
fix(backtest): degenerate-fold guard (A2) + simulated entry_date (G1)

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -1,9 +1,69 @@
 # Status: backtest-perf
 
-## Last updated: 2026-06-11
+## Last updated: 2026-06-12
 
 ## Status
 IN_PROGRESS
+
+### Recent activity (2026-06-12) — runner fold-correctness fixes
+
+Branch `feat/runner-fold-fixes` (READY_FOR_REVIEW). Root-causes + fixes
+the silently-broken backtest fold (A2) surfaced by the rolling-start
+matrix, plus the G1 entry-date fix and a G2 investigation. Diagnosed
+from `dev/experiments/rolling-start-matrix-2026-06-11/ANALYSIS.md`.
+(A1 min-window guard was shipped in parallel by PR #1546
+`feat/backtest-perf-matrix-guards`; dropped from this branch to avoid
+the collision.)
+
+- **[x] A2 — degenerate-fold guard** (`trading/trading/backtest/lib/fold_health.{ml,mli}`,
+  wired into `scenarios/scenario_runner.ml`). **Root cause (deterministic,
+  start-date-specific):** the simulator runs from `warmup_start` (start − 210d)
+  with daily cadence, so the Weinstein strategy trades during the warmup window.
+  For the 2009-06-26 (Friday) start, the 2008-11-28→2009-06-26 warmup spans the
+  GFC bottom; warmup-window trades blow the portfolio down to ~35% of initial
+  cash *before* the measurement window opens. The in-window equity curve is then
+  flat (held positions frozen on cached/avg-cost marks) and `n_round_trips = 0`
+  (warmup entries can't pair with in-window exits in `extract_round_trips`),
+  while `align_summary_metrics` leaves the trade-stat metrics (numtrades 26,
+  largestlossdollar −556955, worstweekpct −60.6) warmup-inclusive — so the run
+  reports −64.78% as if it were in-window. The sibling Monday start (2009-06-29,
+  warmup 3 days later) is healthy: +30.88%, 68 round-trips, 512 distinct equity
+  values. Same class as the origin's "MaxDD 190.4%" (warmup drawdown folded in).
+  **Fix:** a pure `Fold_health.check` reads a run's terminal facts (initial/final
+  cash, n_round_trips, n_steps, equity curve) and returns findings for the
+  three degenerate signatures (zero in-window round-trips over a long window;
+  flat equity curve; unexplained terminal move with zero round-trips). The
+  scenario runner calls it after every run, prints each finding loudly to stderr
+  (`WARN: fold-health: …`), and writes `fold_health.sexp` per scenario. Purely
+  additive/diagnostic — changes no metric, every threshold config-routed via
+  `Fold_health.default_config` (no magic numbers). Verify:
+  `dune exec trading/backtest/test/test_fold_health.exe` (9 tests pin the A2
+  signature + each guard + the healthy-run silence).
+- **A1 — rolling-start min-window guard — shipped elsewhere.** Implemented in
+  parallel by PR #1546 (`feat/backtest-perf-matrix-guards`), which filters
+  short windows out of the report aggregate summary. Dropped from this branch
+  to avoid the collision.
+- **[x] G1 — open_positions.csv entry_date = simulated date**
+  (`trading/trading/simulation/lib/simulator.ml`). **Root cause:** the engine
+  stamps every fill with `Time_ns_unix.now ()` (`engine.ml:161`); the portfolio
+  builds each lot's `acquisition_date` from `trade.timestamp`, and
+  `reconciler_writer` derives `open_positions.csv`'s `entry_date` from the lot —
+  so every open-position row showed the *run* date. **Fix:** the simulator
+  re-stamps each fill's timestamp to the simulated `current_date` (UTC
+  start-of-day) at `_process_fills_and_cancels`, the single point backtest fills
+  enter the portfolio — no engine/portfolio core-module change. Round-trip
+  extraction is unaffected (it keys off `step.date`, not `trade.timestamp`).
+  Verify: `dune exec trading/simulation/test/test_simulator.exe` (new
+  `test_fill_lot_acquisition_date_is_simulated_date` pins the lot date to the
+  simulated fill date).
+- **G2 — investigated only** (no code change). The THM divergence (audit closed
+  a short with no `trades.csv` row, while `open_positions.csv` holds an open THM
+  short with no audit record) is the same warmup-leak class as A2: a short
+  *entered in warmup* and covered in-window is dropped from `trades.csv` by
+  `extract_round_trips` (entry not in `steps_in_range`) yet its close survives
+  in the audit (recorded from `warmup_start`); a *second* THM short opened
+  in-window and still open at run end is the `open_positions.csv` row. The A2
+  fold-health guard flags exactly the folds where this accounting splits.
 
 ### Recent activity (2026-06-11)
 

--- a/trading/trading/backtest/lib/fold_health.ml
+++ b/trading/trading/backtest/lib/fold_health.ml
@@ -1,0 +1,118 @@
+(** Degenerate-fold detector. See [fold_health.mli]. *)
+
+open Core
+
+type config = {
+  min_steps_for_check : int;
+  flat_equity_min_distinct_ratio : float;
+  depleted_abs_return_threshold : float;
+}
+[@@deriving sexp, eq]
+
+(* ≈ a quarter of trading days: below this, a window is short enough that a
+   legitimately quiet fold can have zero round-trips, so the guard stays silent.
+*)
+let _default_min_steps_for_check = 60
+
+(* ≤5% distinct NAV values across the curve = effectively frozen. *)
+let _default_flat_equity_min_distinct_ratio = 0.05
+
+(* ≥50% terminal move from the starting stake, paired with zero round-trips, is
+   the warmup-leak signature. *)
+let _default_depleted_abs_return_threshold = 0.5
+
+let default_config =
+  {
+    min_steps_for_check = _default_min_steps_for_check;
+    flat_equity_min_distinct_ratio = _default_flat_equity_min_distinct_ratio;
+    depleted_abs_return_threshold = _default_depleted_abs_return_threshold;
+  }
+
+type finding =
+  | Zero_round_trips_over_long_window of { n_steps : int }
+  | Flat_equity_curve of { n_points : int; n_distinct : int }
+  | Unexplained_terminal_move of { total_return_pct : float }
+[@@deriving sexp, eq]
+
+let _zero_round_trips_msg n_steps =
+  sprintf
+    "zero in-window round-trips across %d steps (positions likely opened \
+     during warmup and never round-tripped in-window)"
+    n_steps
+
+let _flat_equity_msg n_points n_distinct =
+  sprintf
+    "flat equity curve: only %d distinct NAV value(s) across %d points (held \
+     positions likely frozen on cached / avg-cost marks)"
+    n_distinct n_points
+
+let _terminal_move_msg total_return_pct =
+  sprintf
+    "terminal NAV moved %.2f%% from the starting stake with zero in-window \
+     round-trips (likely warmup-window P&L leaked into the measurement window)"
+    total_return_pct
+
+let finding_to_string = function
+  | Zero_round_trips_over_long_window { n_steps } ->
+      _zero_round_trips_msg n_steps
+  | Flat_equity_curve { n_points; n_distinct } ->
+      _flat_equity_msg n_points n_distinct
+  | Unexplained_terminal_move { total_return_pct } ->
+      _terminal_move_msg total_return_pct
+
+(* Distinct count of the equity-curve values, with a float epsilon so two marks
+   that differ only by floating noise are treated as the same NAV. *)
+let _n_distinct equity_curve =
+  equity_curve
+  |> List.dedup_and_sort ~compare:(fun a b -> Float.robustly_compare a b)
+  |> List.length
+
+let _zero_round_trips_finding ~config ~n_round_trips ~n_steps =
+  if n_round_trips = 0 && n_steps >= config.min_steps_for_check then
+    Some (Zero_round_trips_over_long_window { n_steps })
+  else None
+
+let _flat_equity_finding ~config ~equity_curve =
+  match equity_curve with
+  | [] -> None
+  | _ ->
+      let n_points = List.length equity_curve in
+      let n_distinct = _n_distinct equity_curve in
+      let ratio = Float.of_int n_distinct /. Float.of_int n_points in
+      if Float.( <= ) ratio config.flat_equity_min_distinct_ratio then
+        Some (Flat_equity_curve { n_points; n_distinct })
+      else None
+
+(* Terminal return as a fraction of the starting stake, signed. *)
+let _terminal_return_fraction ~initial_cash ~final_portfolio_value =
+  (final_portfolio_value -. initial_cash) /. initial_cash
+
+let _terminal_move_finding ~config ~initial_cash ~final_portfolio_value
+    ~n_round_trips =
+  let undefined = n_round_trips <> 0 || Float.( <= ) initial_cash 0.0 in
+  let fraction =
+    if undefined then 0.0
+    else _terminal_return_fraction ~initial_cash ~final_portfolio_value
+  in
+  if
+    (not undefined)
+    && Float.( >= ) (Float.abs fraction) config.depleted_abs_return_threshold
+  then Some (Unexplained_terminal_move { total_return_pct = fraction *. 100.0 })
+  else None
+
+let check ~config ~initial_cash ~final_portfolio_value ~n_round_trips ~n_steps
+    ~equity_curve =
+  List.filter_opt
+    [
+      _zero_round_trips_finding ~config ~n_round_trips ~n_steps;
+      _flat_equity_finding ~config ~equity_curve;
+      _terminal_move_finding ~config ~initial_cash ~final_portfolio_value
+        ~n_round_trips;
+    ]
+
+let has_findings ~config ~initial_cash ~final_portfolio_value ~n_round_trips
+    ~n_steps ~equity_curve =
+  not
+    (List.is_empty
+       (check ~config ~initial_cash ~final_portfolio_value ~n_round_trips
+          ~n_steps ~equity_curve))

--- a/trading/trading/backtest/lib/fold_health.mli
+++ b/trading/trading/backtest/lib/fold_health.mli
@@ -1,0 +1,110 @@
+(** Degenerate-fold detector for a single backtest run.
+
+    A backtest can complete "successfully" (no exception, a written
+    [summary.sexp]) yet produce a result that is silently garbage. The
+    motivating case (A2, 2026-06-12): a rolling-start fold whose 210-day warmup
+    window spanned the GFC crash entered positions {b during warmup}, took a
+    catastrophic loss before the measurement window opened, and then reported a
+    flat in-window equity curve pinned at ~35% of initial capital with
+    {b zero in-window round-trips} — because every entry/exit pair straddled the
+    warmup→window boundary and so could not be paired by the in-window
+    round-trip extractor. The run "passed" its scenario range checks while
+    describing nothing real.
+
+    This module is a {b pure, additive guard}: given a run's terminal facts it
+    returns a list of {!finding}s naming each tripped invariant. It changes no
+    strategy or simulator behaviour and computes no new backtest — it only reads
+    facts already in the {!Summary.t} (plus the equity-curve series). Callers
+    (the scenario runner) surface the findings loudly so the whole class of
+    silent-garbage folds is caught at the reporting boundary rather than
+    propagating into a dispersion matrix.
+
+    Every threshold is a field of {!config} (no magic numbers);
+    {!default_config} encodes the values calibrated against the A2 repro. *)
+
+type config = {
+  min_steps_for_check : int;
+      (** Only evaluate the zero-round-trip / flat-equity invariants on runs
+          with at least this many in-window steps. A genuinely short window (a
+          handful of trading days) can legitimately have no round-trips, so the
+          guard stays silent below this floor to avoid false positives on tiny
+          folds. *)
+  flat_equity_min_distinct_ratio : float;
+      (** A run is "flat" when the count of {e distinct} equity-curve values,
+          divided by the number of equity-curve points, is at or below this
+          ratio. A healthy multi-month run moves its NAV on most days; an
+          all-but-constant curve (the frozen-mark signature) sits near
+          [1 / n_points]. In [[0.0, 1.0]]. *)
+  depleted_abs_return_threshold : float;
+      (** A run is "depleted/inflated" when [|final/initial - 1|] meets or
+          exceeds this fraction (e.g. [0.5] = NAV ended at least 50% away from
+          the starting stake). Combined with zero round-trips and a flat curve,
+          a large terminal move that no in-window trade explains is the
+          warmup-leak signature. A non-negative fraction. *)
+}
+[@@deriving sexp, eq]
+
+val default_config : config
+(** Thresholds calibrated against the A2 repro (2009-06-26 start,
+    top-3000-2000): [min_steps_for_check = 60] (≈ a quarter of trading days),
+    [flat_equity_min_distinct_ratio = 0.05] (≤5% distinct NAV values = flat),
+    [depleted_abs_return_threshold = 0.5] (≥50% terminal move). These are the
+    defaults the scenario runner uses; callers may override for stricter or
+    looser gating. *)
+
+type finding =
+  | Zero_round_trips_over_long_window of { n_steps : int }
+      (** [n_steps] in-window steps (≥ [min_steps_for_check]) produced zero
+          round-trips: no entry/exit pair landed entirely inside the measurement
+          window. Strongly suggests positions were opened during the warmup
+          window and never cleanly round-tripped in-window. *)
+  | Flat_equity_curve of { n_points : int; n_distinct : int }
+      (** The equity curve has [n_distinct] distinct NAV values across
+          [n_points] points — at/below [flat_equity_min_distinct_ratio]. The NAV
+          is effectively frozen, the signature of held positions stuck on cached
+          / avg-cost marks. *)
+  | Unexplained_terminal_move of { total_return_pct : float }
+      (** Terminal NAV moved [total_return_pct]% from the starting stake (≥
+          [depleted_abs_return_threshold]) while the run also showed zero
+          in-window round-trips — i.e. a large P&L swing that no in-window trade
+          accounts for (warmup-window leak). *)
+[@@deriving sexp, eq]
+
+val finding_to_string : finding -> string
+(** A one-line human-readable rendering of [finding] for console / log output.
+*)
+
+val check :
+  config:config ->
+  initial_cash:float ->
+  final_portfolio_value:float ->
+  n_round_trips:int ->
+  n_steps:int ->
+  equity_curve:float list ->
+  finding list
+(** [check ~config ~initial_cash ~final_portfolio_value ~n_round_trips ~n_steps
+     ~equity_curve] returns every degenerate-fold invariant the run trips, in a
+    stable order (round-trips, flat-equity, terminal-move). An empty list means
+    the run looks healthy on these axes.
+
+    The three invariants and their guards:
+    - {e Zero round-trips}: emitted only when
+      [n_steps >= config.min_steps_for_check] and [n_round_trips = 0].
+    - {e Flat equity}: emitted when [equity_curve] is non-empty and its distinct
+      / total ratio is [<= config.flat_equity_min_distinct_ratio].
+    - {e Unexplained terminal move}: emitted only when [n_round_trips = 0]
+      {b and} [|final/initial - 1| >= config.depleted_abs_return_threshold] (so
+      a healthy run that legitimately moved NAV via in-window trades is never
+      flagged); a non-positive [initial_cash] suppresses it (return is
+      undefined). *)
+
+val has_findings :
+  config:config ->
+  initial_cash:float ->
+  final_portfolio_value:float ->
+  n_round_trips:int ->
+  n_steps:int ->
+  equity_curve:float list ->
+  bool
+(** [has_findings ...] is [not (List.is_empty (check ...))] — a convenience for
+    callers that only need the boolean "is this fold suspect?". *)

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -260,6 +260,35 @@ let _actual_path ~output_root (s : Scenario.t) =
 
 (* Run one scenario inside a child process *)
 
+(** Run the {!Backtest.Fold_health} degenerate-fold guard over a completed run
+    and surface any findings loudly: each finding is printed to stderr with a
+    [WARN: fold-health] prefix and the full list is written to
+    [<scenario_dir>/fold_health.sexp]. A healthy run writes the empty list (so
+    the artefact's presence is uniform across runs) and prints nothing. The
+    equity-curve series is the per-step [portfolio_value] over the in-window
+    steps — the same series {!Backtest.Result_writer} writes to
+    [equity_curve.csv]. Purely diagnostic: no metric or return value changes. *)
+let _emit_fold_health ~scenario_dir ~(result : Backtest.Runner.result) =
+  let summary = result.summary in
+  let equity_curve =
+    List.map result.steps
+      ~f:(fun (st : Trading_simulation_types.Simulator_types.step_result) ->
+        st.portfolio_value)
+  in
+  let findings =
+    Backtest.Fold_health.check ~config:Backtest.Fold_health.default_config
+      ~initial_cash:summary.initial_cash
+      ~final_portfolio_value:summary.final_portfolio_value
+      ~n_round_trips:summary.n_round_trips ~n_steps:summary.n_steps
+      ~equity_curve
+  in
+  List.iter findings ~f:(fun f ->
+      eprintf "WARN: fold-health: %s\n%!"
+        (Backtest.Fold_health.finding_to_string f));
+  Sexp.save_hum
+    (Filename.concat scenario_dir "fold_health.sexp")
+    ([%sexp_of: Backtest.Fold_health.finding list] findings)
+
 let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
     ~emit_all_eligible ~bar_data_source ~scenario_path (s : Scenario.t) =
   eprintf "\n>>> Running %s: %s (%s to %s)\n%!" s.name s.description
@@ -286,6 +315,11 @@ let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
   Backtest.Result_writer.write ~output_dir:scenario_dir result;
   let a = _actual_of_result result in
   Sexp.save_hum (_actual_path ~output_root s) (sexp_of_actual a);
+  (* Degenerate-fold guard: surface the silent-garbage signature (zero in-window
+     round-trips + flat equity + an unexplained terminal move — the A2 warmup-
+     leak class) loudly to stderr and as [fold_health.sexp]. Purely a reporting
+     post-step; it changes no metric and never aborts the run. *)
+  _emit_fold_health ~scenario_dir ~result;
   (* Emit wall_seconds.txt — the canonical perf-report convention
      (release_report._read_optional_float). Goldens may pin
      [expected.wall_seconds] to catch runtime regressions; scenarios that

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -26,7 +26,8 @@
   test_determinism
   test_bah_runner_e2e
   test_macro_trend_writer
-  test_csv_snapshot_builder_cleanup)
+  test_csv_snapshot_builder_cleanup
+  test_fold_health)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/test/test_fold_health.ml
+++ b/trading/trading/backtest/test/test_fold_health.ml
@@ -1,0 +1,169 @@
+(** Unit tests for {!Backtest.Fold_health}. Pins the A2 degenerate-fold
+    signature (zero in-window round-trips + flat equity + an unexplained
+    terminal move all firing together — the 2009-06-26 warmup-leak repro), each
+    invariant's guard in isolation, and the healthy-run silence. Uses the public
+    [check] entry point with synthetic terminal facts so no backtest is run. *)
+
+open OUnit2
+open Core
+open Matchers
+module FH = Backtest.Fold_health
+
+let cfg = FH.default_config
+
+(* A flat equity curve of [n] copies of [v] — the frozen-mark signature: every
+   step marks the same NAV, so the distinct/total ratio is 1/n. *)
+let _flat_curve ~n ~v = List.init n ~f:(fun _ -> v)
+
+(* A healthy equity curve: [n] strictly increasing NAV values, so every point is
+   distinct and the flat-equity guard never trips. *)
+let _rising_curve ~n ~start ~step =
+  List.init n ~f:(fun i -> start +. (Float.of_int i *. step))
+
+(* The exact A2 repro terminal facts: 523 in-window steps, zero round-trips, a
+   flat equity curve pinned at 352220.30, and a -64.78% terminal return from
+   1,000,000 initial cash. All three invariants must fire. *)
+let test_a2_repro_trips_all_three _ =
+  let findings =
+    FH.check ~config:cfg ~initial_cash:1_000_000.0
+      ~final_portfolio_value:352_220.30 ~n_round_trips:0 ~n_steps:523
+      ~equity_curve:(_flat_curve ~n:523 ~v:352_220.30)
+  in
+  assert_that findings
+    (elements_are
+       [
+         matching ~msg:"Expected Zero_round_trips_over_long_window"
+           (function
+             | FH.Zero_round_trips_over_long_window { n_steps } -> Some n_steps
+             | _ -> None)
+           (equal_to 523);
+         matching ~msg:"Expected Flat_equity_curve"
+           (function
+             | FH.Flat_equity_curve { n_points; n_distinct } ->
+                 Some (n_points, n_distinct)
+             | _ -> None)
+           (equal_to (523, 1));
+         matching ~msg:"Expected Unexplained_terminal_move"
+           (function
+             | FH.Unexplained_terminal_move { total_return_pct } ->
+                 Some total_return_pct
+             | _ -> None)
+           (float_equal ~epsilon:0.01 (-64.778));
+       ])
+
+(* A healthy run: many round-trips, a rising distinct equity curve, and a modest
+   +30.88% terminal move (the sibling 2009-06-29 fold). No findings. *)
+let test_healthy_run_silent _ =
+  let findings =
+    FH.check ~config:cfg ~initial_cash:1_000_000.0
+      ~final_portfolio_value:1_308_774.21 ~n_round_trips:68 ~n_steps:522
+      ~equity_curve:(_rising_curve ~n:522 ~start:1_000_000.0 ~step:600.0)
+  in
+  assert_that findings (size_is 0)
+
+(* Zero round-trips below the step floor must NOT fire — a genuinely short window
+   can legitimately have no round-trips. *)
+let test_zero_round_trips_below_floor_silent _ =
+  let findings =
+    FH.check ~config:cfg ~initial_cash:1_000_000.0
+      ~final_portfolio_value:1_010_000.0 ~n_round_trips:0
+      ~n_steps:(cfg.min_steps_for_check - 1)
+      ~equity_curve:(_rising_curve ~n:30 ~start:1_000_000.0 ~step:300.0)
+  in
+  assert_that findings (size_is 0)
+
+(* Exactly at the step floor with zero round-trips: the zero-round-trips
+   invariant fires (boundary is inclusive). Equity rising + small terminal move,
+   so only that one finding. *)
+let test_zero_round_trips_at_floor_fires _ =
+  let findings =
+    FH.check ~config:cfg ~initial_cash:1_000_000.0
+      ~final_portfolio_value:1_010_000.0 ~n_round_trips:0
+      ~n_steps:cfg.min_steps_for_check
+      ~equity_curve:
+        (_rising_curve ~n:cfg.min_steps_for_check ~start:1_000_000.0 ~step:300.0)
+  in
+  assert_that findings
+    (elements_are
+       [
+         equal_to
+           (FH.Zero_round_trips_over_long_window
+              { n_steps = cfg.min_steps_for_check });
+       ])
+
+(* An empty equity curve never trips the flat-equity invariant (no data). With
+   round-trips present and a modest move, no findings at all. *)
+let test_empty_equity_curve_silent _ =
+  let findings =
+    FH.check ~config:cfg ~initial_cash:1_000_000.0
+      ~final_portfolio_value:1_050_000.0 ~n_round_trips:10 ~n_steps:200
+      ~equity_curve:[]
+  in
+  assert_that findings (size_is 0)
+
+(* A large terminal move that IS explained by in-window round-trips (n>0) must
+   NOT trip the unexplained-move invariant — a real +120% winner is healthy. The
+   rising curve keeps the flat-equity guard silent too. *)
+let test_large_move_with_round_trips_silent _ =
+  let findings =
+    FH.check ~config:cfg ~initial_cash:1_000_000.0
+      ~final_portfolio_value:2_200_000.0 ~n_round_trips:42 ~n_steps:400
+      ~equity_curve:(_rising_curve ~n:400 ~start:1_000_000.0 ~step:3_000.0)
+  in
+  assert_that findings (size_is 0)
+
+(* Non-positive initial cash suppresses the unexplained-move invariant (return
+   undefined) even with zero round-trips and a depleted final value. The flat
+   curve still trips its own invariant; zero round-trips trips its own. So two
+   findings, but NOT the terminal-move one. *)
+let test_nonpositive_initial_cash_suppresses_move _ =
+  let findings =
+    FH.check ~config:cfg ~initial_cash:0.0 ~final_portfolio_value:200_000.0
+      ~n_round_trips:0 ~n_steps:300
+      ~equity_curve:(_flat_curve ~n:300 ~v:200_000.0)
+  in
+  assert_that findings
+    (elements_are
+       [
+         equal_to (FH.Zero_round_trips_over_long_window { n_steps = 300 });
+         equal_to (FH.Flat_equity_curve { n_points = 300; n_distinct = 1 });
+       ])
+
+(* [has_findings] mirrors [check]: true for the A2 signature, false for a healthy
+   run. *)
+let test_has_findings_mirrors_check _ =
+  let suspect =
+    FH.has_findings ~config:cfg ~initial_cash:1_000_000.0
+      ~final_portfolio_value:352_220.30 ~n_round_trips:0 ~n_steps:523
+      ~equity_curve:(_flat_curve ~n:523 ~v:352_220.30)
+  in
+  assert_that suspect (equal_to true)
+
+let test_has_findings_false_when_healthy _ =
+  let suspect =
+    FH.has_findings ~config:cfg ~initial_cash:1_000_000.0
+      ~final_portfolio_value:1_308_774.21 ~n_round_trips:68 ~n_steps:522
+      ~equity_curve:(_rising_curve ~n:522 ~start:1_000_000.0 ~step:600.0)
+  in
+  assert_that suspect (equal_to false)
+
+let suite =
+  "fold_health"
+  >::: [
+         "a2_repro_trips_all_three" >:: test_a2_repro_trips_all_three;
+         "healthy_run_silent" >:: test_healthy_run_silent;
+         "zero_round_trips_below_floor_silent"
+         >:: test_zero_round_trips_below_floor_silent;
+         "zero_round_trips_at_floor_fires"
+         >:: test_zero_round_trips_at_floor_fires;
+         "empty_equity_curve_silent" >:: test_empty_equity_curve_silent;
+         "large_move_with_round_trips_silent"
+         >:: test_large_move_with_round_trips_silent;
+         "nonpositive_initial_cash_suppresses_move"
+         >:: test_nonpositive_initial_cash_suppresses_move;
+         "has_findings_mirrors_check" >:: test_has_findings_mirrors_check;
+         "has_findings_false_when_healthy"
+         >:: test_has_findings_false_when_healthy;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -12,6 +12,7 @@
   core)
  (modules
   simulator
+  fill_date_stamp
   split_handler
   cancel_handler
   order_generator

--- a/trading/trading/simulation/lib/fill_date_stamp.ml
+++ b/trading/trading/simulation/lib/fill_date_stamp.ml
@@ -1,0 +1,12 @@
+(** Re-stamp a backtest fill's timestamp with the simulated date. See
+    [fill_date_stamp.mli]. *)
+
+open Core
+
+let restamp ~date (trade : Trading_base.Types.trade) =
+  {
+    trade with
+    timestamp =
+      Time_ns_unix.of_date_ofday ~zone:Time_float.Zone.utc date
+        Time_ns.Ofday.start_of_day;
+  }

--- a/trading/trading/simulation/lib/fill_date_stamp.mli
+++ b/trading/trading/simulation/lib/fill_date_stamp.mli
@@ -1,0 +1,18 @@
+(** Re-stamp a backtest fill's timestamp with the simulated date.
+
+    The trading engine stamps every fill with wall-clock [Time_ns_unix.now ()] —
+    correct for live trading, but in a backtest it makes the portfolio's per-lot
+    [acquisition_date] the {b run} date rather than the {b simulated} date. That
+    in turn corrupts [open_positions.csv]'s [entry_date] column (derived from
+    the held lots' [acquisition_date]) — the G1 bug, where every open-position
+    row showed the run date. The simulator applies {!restamp} at the single
+    point backtest fills enter the portfolio, so the lot dates are the simulated
+    dates without touching the shared engine / portfolio modules. *)
+
+val restamp :
+  date:Core.Date.t -> Trading_base.Types.trade -> Trading_base.Types.trade
+(** [restamp ~date trade] returns [trade] with its [timestamp] set to [date] at
+    UTC start-of-day. All other fields are unchanged. Round-trip extraction is
+    unaffected: it keys trades off the per-step [step.date], not
+    [trade.timestamp], so only the portfolio lot [acquisition_date] (and the
+    [open_positions.csv] [entry_date] it feeds) changes. *)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -188,9 +188,11 @@ let _get_today_bars t =
   in
   List.filter_map t.deps.symbols ~f:get_bar
 
-(** Extract trades from execution reports *)
-let _extract_trades reports =
+(** Extract fills, re-stamped with the simulated [date] (G1;
+    {!Fill_date_stamp}). *)
+let _extract_trades ~date reports =
   List.concat_map reports ~f:(fun report -> report.Trading_engine.Types.trades)
+  |> List.map ~f:(Fill_date_stamp.restamp ~date)
 
 (** Create get_price function for strategy *)
 let _make_get_price t : Trading_strategy.Strategy_interface.get_price_fn =
@@ -416,7 +418,7 @@ let _process_fills_and_cancels t ~portfolio ~positions =
   let%bind execution_reports =
     Trading_engine.Engine.process_orders t.deps.engine t.deps.order_manager
   in
-  let all_trades = _extract_trades execution_reports in
+  let all_trades = _extract_trades ~date:t.current_date execution_reports in
   let portfolio, trades, rejected_trades =
     _apply_trades_best_effort ?on_trade_fill:t.deps.on_trade_fill portfolio
       all_trades

--- a/trading/trading/simulation/test/test_simulator.ml
+++ b/trading/trading/simulation/test/test_simulator.ml
@@ -1097,11 +1097,61 @@ let test_create_with_active_through_for_prunes_pre_fold_delisted _ =
       in
       assert_that kept (equal_to [ "AAPL"; "MSFT" ]))
 
+(* G1 (2026-06-12): a backtest fill must stamp the held lot's [acquisition_date]
+   with the simulated fill date, NOT the wall-clock run date. The engine stamps
+   fills with [Time_ns_unix.now ()]; the simulator re-stamps them to the
+   simulated date before they enter the portfolio. Without the re-stamp,
+   [open_positions.csv]'s [entry_date] (derived from the lot acquisition_date)
+   showed the run date for every open position. Here a market buy fills on
+   day 1 (2024-01-02); the resulting lot's acquisition_date must equal that
+   simulated date. *)
+let test_fill_lot_acquisition_date_is_simulated_date _ =
+  with_test_data "simulator_g1_acquisition_date"
+    [ ("AAPL", sample_aapl_prices) ]
+    ~f:(fun data_dir ->
+      let deps = make_deps data_dir in
+      let sim = Test_helpers.create_exn ~config:sample_config ~deps in
+      let order_params =
+        Trading_orders.Create_order.
+          {
+            symbol = "AAPL";
+            side = Trading_base.Types.Buy;
+            quantity = 10.0;
+            order_type = Trading_base.Types.Market;
+            time_in_force = Trading_orders.Types.GTC;
+          }
+      in
+      let order =
+        match Trading_orders.Create_order.create_order order_params with
+        | Ok o -> o
+        | Error err -> failwith ("Failed to create order: " ^ Status.show err)
+      in
+      Trading_orders.Manager.submit_orders deps.order_manager [ order ]
+      |> ignore;
+      assert_that (run sim)
+        (is_ok_and_holds (fun result ->
+             let aapl_lots =
+               List.find_map result.final_portfolio.positions
+                 ~f:(fun (p : Trading_portfolio.Types.portfolio_position) ->
+                   if String.equal p.symbol "AAPL" then Some p.lots else None)
+             in
+             assert_that aapl_lots
+               (is_some_and
+                  (elements_are
+                     [
+                       field
+                         (fun (l : Trading_portfolio.Types.position_lot) ->
+                           l.acquisition_date)
+                         (equal_to (date_of_string "2024-01-02"));
+                     ])))))
+
 (* ==================== Test Suite ==================== *)
 
 let suite =
   "Simulator Tests"
   >::: [
+         "G1: fill lot acquisition_date is the simulated fill date"
+         >:: test_fill_lot_acquisition_date_is_simulated_date;
          "create returns simulator" >:: test_create_returns_simulator;
          "create with empty symbols" >:: test_create_with_empty_symbols;
          "Win #4: prune_symbols_by_active_through drops pre-fold delistings"


### PR DESCRIPTION
## What this does

Root-causes and fixes the silently-broken backtest fold (A2) surfaced by the rolling-start matrix, plus the G1 entry-date fix and a G2 investigation. Findings come from `dev/experiments/rolling-start-matrix-2026-06-11/ANALYSIS.md`.

> **A1 (min-window guard) was implemented in parallel by PR #1546** and is dropped from this branch to avoid the collision.

### A2 (primary) — degenerate-fold guard

**Deterministic repro** (verified): Cell-E over `top-3000-2000`, start **2009-06-26** → end 2011-06-30 produces a garbage fold — `trades.csv` empty, `n_round_trips = 0`, equity curve flat at **352220.30 for all 523 steps** (35% of the 1M initial cash), `totalreturnpct −64.78`. The sibling **2009-06-29** start (warmup 3 days later) is healthy: +30.88%, 68 round-trips, 512 distinct equity values.

**Root cause:** the simulator runs from `warmup_start` (start − 210d) with daily cadence, so the Weinstein strategy trades *during* the warmup window. The 2009-06-26 start's warmup (2008-11-28→2009-06-26) spans the GFC bottom; warmup-window trades blow the portfolio down to ~35% of initial cash *before* the measurement window opens. The in-window equity curve is then frozen (held positions stuck on cached/avg-cost marks) and `n_round_trips = 0` (warmup entries can't pair with in-window exits in `extract_round_trips`), while `align_summary_metrics` leaves the trade-stat metrics (numtrades 26, largestlossdollar −556955, worstweekpct −60.6) warmup-inclusive — so the run reports −64.78% as if it were in-window performance. Same class as the origin's "MaxDD 190.4%" finding.

**Fix:** a pure, additive `Backtest.Fold_health` module (`fold_health.{ml,mli}`) reads a completed run's terminal facts and returns findings for the three degenerate signatures: zero in-window round-trips over a long window, a flat equity curve, and an unexplained terminal move with zero round-trips. The scenario runner calls it after every run, prints each finding loudly to stderr (`WARN: fold-health: …`), and writes `fold_health.sexp` per scenario. Changes no metric or return value; every threshold is config-routed via `Fold_health.default_config` (no magic numbers). This guards the **whole class** of silent-garbage folds at the reporting boundary.

### G1 — open_positions.csv entry_date

**Root cause:** the engine stamps every fill with `Time_ns_unix.now ()`; the portfolio builds each lot's `acquisition_date` from `trade.timestamp`, and `reconciler_writer` derives `open_positions.csv`'s `entry_date` from the lot — so every open-position row showed the *run* date (e.g. 2026-06-12). **Fix:** the simulator re-stamps each fill's timestamp to the simulated `current_date` (UTC start-of-day) at the single point backtest fills enter the portfolio (`_process_fills_and_cancels`) — no engine/portfolio core-module change. Round-trip extraction is unaffected (keys off `step.date`, not `trade.timestamp`).

### G2 — investigated only (no code change)

The THM divergence (audit closed a short with no `trades.csv` row; `open_positions.csv` holds an open THM short with no audit record) is the same warmup-leak class as A2: a short entered in warmup and covered in-window is dropped from `trades.csv` by `extract_round_trips` (entry not in `steps_in_range`) while its close survives in the audit (recorded from `warmup_start`); a second THM short opened in-window and still open at run end is the open-positions row. The A2 guard flags exactly these folds.

## Test plan

- `dune exec trading/backtest/test/test_fold_health.exe` — 9 tests pin the A2 signature (all three findings fire together), each guard in isolation (step-floor boundary, empty curve, large-move-with-round-trips silence, non-positive cash), and the healthy-run silence.
- `dune exec trading/simulation/test/test_simulator.exe` — new `test_fill_lot_acquisition_date_is_simulated_date` pins the lot acquisition_date to the simulated fill date (would have caught G1).
- `dune build && dune runtest` green, `dune build @fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
