### PR TITLE
feat(short-side): no-op-default short_min_price short-entry gate (P1 hygiene)

### DIFF
--- a/dev/plans/short-min-price-gate-2026-06-12.md
+++ b/dev/plans/short-min-price-gate-2026-06-12.md
@@ -1,0 +1,101 @@
+# short_min_price short-entry gate — 2026-06-12
+
+## Context
+
+Margin Phase 3 found shorts net-negative in 3 of 4 bear windows; the
+2026-06-12 long-short margin research
+(`dev/notes/long-short-margin-mechanics-2026-06-12.md`) established that
+**sub-$17 shorts are uneconomic** (83–362% maintenance margin). The
+2026-06-13 priorities doc (P1 "short-side hygiene") asks for a configurable
+minimum-price gate on short entries so that economic floor becomes an
+expressible experiment axis.
+
+Per `.claude/rules/experiment-flag-discipline.md` this lands **default-off
+as a no-op** (threshold `0.0` = no gating = current behaviour, all goldens
+bit-equal), becomes a searchable axis the day it lands, and is NOT wired
+into any default config.
+
+Current code: short candidates join the entry candidate list at
+`weinstein_strategy_screening.ml` ~line 399–404:
+
+```ocaml
+let combined_candidates =
+  if config.enable_short_side then
+    screen_result.Screener.buy_candidates
+    @ screen_result.Screener.short_candidates
+  else screen_result.Screener.buy_candidates
+```
+
+`Screener.scored_candidate` carries `suggested_entry : float` (the suggested
+buy/sell-stop entry price) and `side : position_side`.
+
+## Approach
+
+1. **Config field** `short_min_price : float; [@sexp.default 0.0]` on
+   `Weinstein_strategy.config` (`weinstein_strategy_config.{ml,mli}`),
+   defaulted to `0.0` in `default_config`. `0.0` = no gating.
+
+2. **Gate** — a pure helper
+   `filter_short_candidates_by_min_price ~short_min_price candidates` in
+   `weinstein_strategy_screening.ml`. When `short_min_price <= 0.0` it is the
+   identity; otherwise it drops candidates whose `suggested_entry <
+   short_min_price`. Applied to `screen_result.Screener.short_candidates`
+   before concatenation. Purely additive: with `0.0` the candidate list is
+   identical to today.
+
+   The module has no `.mli`, so the helper is exported automatically and is
+   unit-testable via `Weinstein_strategy.S.filter_short_candidates_by_min_price`.
+
+3. **Unit tests** (`test_short_min_price_gate.ml`, new): synthetic
+   `scored_candidate`s — (a) `0.0` → all retained (no-op); (b) `15.0` drops a
+   $10 short, retains a $20 short; (c) the gate does not touch Long candidates
+   (it only filters the short list).
+
+4. **Axis test** (cheap — done): mirror `test_single_component_override_shape`
+   in `test_variant_matrix.ml`, asserting `((short_min_price 0.0))` /
+   `((short_min_price 17.0))` resolve as a top-level float axis through
+   `Overlay_validator` (same path as `stage3_exit_margin_pct`).
+
+## Files to change
+
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml` — add field + default.
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli` — add field + doc.
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml` — helper + wire at seam.
+- `trading/trading/weinstein/strategy/test/test_short_min_price_gate.ml` — new test (+ dune names entry).
+- `trading/trading/backtest/walk_forward/test/test_variant_matrix.ml` — add axis test.
+- `dev/status/short-side-strategy.md` — status note.
+
+## No-op-default argument
+
+`short_min_price` defaults to `0.0`. The helper short-circuits to the identity
+when `short_min_price <= 0.0`, so `combined_candidates` is byte-for-byte the
+same list as before. No golden/baseline decodes differently (`[@sexp.default
+0.0]` means existing sexps that omit the field decode to `0.0`), and no
+emitted transition changes. `enable_short_side` default stays `true` —
+untouched.
+
+## Axis-ability note (R2)
+
+`short_min_price` is a top-level `float` field with `[@sexp.default 0.0]`, so
+`Variant_matrix` resolves it by sexp name with no `Overlay_validator` change
+(identical mechanism to `stage3_exit_margin_pct`). Axis test added.
+
+## Risks / unknowns
+
+- Correct entry-price field: confirmed `suggested_entry` on
+  `Screener.scored_candidate` (screener.mli line 214).
+- Helper must be a no-op at `0.0` to preserve goldens — guarded by the
+  `<= 0.0` short-circuit + a dedicated no-op test.
+
+## Acceptance
+
+- `dune build @fmt`, `dune build && dune runtest` exit 0.
+- New unit tests pass; goldens unchanged (no-op at `0.0`).
+- `short_min_price` resolves as a variant axis.
+
+## Out of scope
+
+- Building the margin model / touching the margin runner.
+- Flipping `enable_short_side` (forbidden without a ledger ACCEPT).
+- Wiring `short_min_price` into any default config or preset (stays default-off).
+- Core stop-machine / simulator changes.

--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -1,9 +1,36 @@
 # Status: short-side-strategy
 
-## Last updated: 2026-05-23
+## Last updated: 2026-06-12
 
 ## Status
 IN_PROGRESS
+
+## 2026-06-12 — `short_min_price` short-entry gate (default-off axis)
+
+Added a no-op-default `short_min_price : float [@sexp.default 0.0]` config
+field on `Weinstein_strategy.config` plus a pure gate
+(`Short_min_price_gate.filter`) that drops short candidates whose
+`Screener.scored_candidate.suggested_entry` is below the threshold, wired at
+the short-candidate seam in `weinstein_strategy_screening.ml`. Encodes the
+researched sub-$17 economic-margin floor on shorts
+(`dev/notes/long-short-margin-mechanics-2026-06-12.md`) as a searchable
+`Variant_matrix` axis.
+
+- **R1 default-off:** threshold `0.0` short-circuits the gate to the identity,
+  so every golden/baseline decodes (via `[@sexp.default 0.0]`) and replays
+  bit-equal. Full `dune build && dune runtest` exits 0 (all goldens/snapshots
+  unchanged). `enable_short_side` default unchanged (`true`).
+- **R2 axis-able (verified):** `short_min_price` is a top-level float field, so
+  `Variant_matrix` resolves it by sexp name with no `Overlay_validator` change
+  (same mechanism as `stage3_exit_margin_pct`). Axis test added to
+  `test_variant_matrix.ml` (`short_min_price float axis expands`).
+- **R3:** not wired into any default config or preset (stays default-off).
+- The gate lives in its own micro-lib
+  (`weinstein_trading.short_min_price_gate`) to keep the strategy coordinator
+  module under the file-length cap and give tests a direct dependency.
+- Tests: `test_short_min_price_gate.ml` (no-op at 0.0, drop-below/retain-above
+  at 15.0, boundary-inclusive, gate untouches the long list).
+- Branch `feat/short-side-min-price`.
 
 ## Interface stable
 YES

--- a/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
+++ b/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
@@ -200,6 +200,46 @@ let test_macro_bearish_trim_axes_expand _ =
               "enable_macro_bearish_exposure_trim=false__macro_bearish_max_long_exposure_pct=0.35");
        ])
 
+(* Proves R2 (experiment-flag-discipline) for the [short_min_price] short-entry
+   gate: it is a real top-level float key on [Weinstein_strategy.config] (same
+   mechanism as [stage3_exit_margin_pct]), so the axis expands and passes
+   [Overlay_validator] validation with no overlay-validator change. The no-op
+   default value [0.0] and the researched ~$17 economic floor sit on the same
+   axis. *)
+let test_short_min_price_axis_expands _ =
+  let axis =
+    VM.Key
+      {
+        path = [ "short_min_price" ];
+        values = Sexp.[ Atom "0.0"; Atom "17.0" ];
+      }
+  in
+  let t = { VM.axes = [ axis ]; expansion = VM.Cartesian } in
+  assert_that (VM.expand t)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (v : WFR.variant) -> v.label)
+               (equal_to "short_min_price=0.0");
+             field
+               (fun (v : WFR.variant) -> v.overrides)
+               (elements_are
+                  [ equal_to (Sexp.of_string "((short_min_price 0.0))") ]);
+           ];
+         all_of
+           [
+             field
+               (fun (v : WFR.variant) -> v.label)
+               (equal_to "short_min_price=17.0");
+             field
+               (fun (v : WFR.variant) -> v.overrides)
+               (elements_are
+                  [ equal_to (Sexp.of_string "((short_min_price 17.0))") ]);
+           ];
+       ])
+
 (* ---------- Sampled determinism + fallback ---------- *)
 
 let test_sampled_determinism _ =
@@ -280,6 +320,8 @@ let suite =
          >:: test_neutral_blocks_longs_flag_axis_expands;
          "macro-bearish trim flag + cap axes expand + validate"
          >:: test_macro_bearish_trim_axes_expand;
+         "short_min_price float axis expands"
+         >:: test_short_min_price_axis_expands;
          "sampled determinism (same seed -> same labels)"
          >:: test_sampled_determinism;
          "sampled different seed -> different subset"

--- a/trading/trading/weinstein/strategy/gate/lib/dune
+++ b/trading/trading/weinstein/strategy/gate/lib/dune
@@ -1,0 +1,4 @@
+(library
+ (name short_min_price_gate)
+ (public_name weinstein_trading.short_min_price_gate)
+ (libraries core weinstein.screener trading.base))

--- a/trading/trading/weinstein/strategy/gate/lib/short_min_price_gate.ml
+++ b/trading/trading/weinstein/strategy/gate/lib/short_min_price_gate.ml
@@ -1,0 +1,7 @@
+open Core
+
+let filter ~short_min_price (candidates : Screener.scored_candidate list) =
+  if Float.( <= ) short_min_price 0.0 then candidates
+  else
+    List.filter candidates ~f:(fun c ->
+        Float.( >= ) c.Screener.suggested_entry short_min_price)

--- a/trading/trading/weinstein/strategy/gate/lib/short_min_price_gate.mli
+++ b/trading/trading/weinstein/strategy/gate/lib/short_min_price_gate.mli
@@ -1,0 +1,19 @@
+(** The [short_min_price] short-entry gate.
+
+    A faithful Weinstein eligibility "dial" (default-off axis per
+    [.claude/rules/experiment-flag-discipline.md]) that encodes the researched
+    sub-$17 economic-margin floor on shorts
+    ([dev/notes/long-short-margin-mechanics-2026-06-12.md]). The spine is
+    untouched — this only narrows which short candidates are eligible. *)
+
+val filter :
+  short_min_price:float ->
+  Screener.scored_candidate list ->
+  Screener.scored_candidate list
+(** [filter ~short_min_price candidates] drops short candidates whose
+    {!Screener.scored_candidate.suggested_entry} is strictly below
+    [short_min_price].
+
+    No-op when [short_min_price <= 0.0] (the default): returns [candidates]
+    unchanged (bit-identical), so every existing golden/baseline replays
+    unchanged. Pure. See [Weinstein_strategy_config.short_min_price]. *)

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -22,6 +22,7 @@
   weinstein.rs
   weinstein.sector
   weinstein.screener
+  weinstein_trading.short_min_price_gate
   weinstein.stock_analysis
   weinstein.continuation
   indicators.types

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -242,6 +242,15 @@ type config = {
           Sell→Buy round-trips so shorts are invisible in [trades.csv], and the
           cash floor only triggers on Buy so unbounded short losses cannot
           force-liquidate. *)
+  short_min_price : float; [@sexp.default 0.0]
+      (** Minimum entry price for short candidates. Short candidates whose
+          {!Screener.scored_candidate.suggested_entry} is strictly below this
+          value are dropped before they join the entry candidate list. Default
+          [0.0] = no gating (no-op, preserves prior behaviour). Encodes the
+          researched sub-$17 economic-margin floor on shorts
+          ([dev/notes/long-short-margin-mechanics-2026-06-12.md]) as a
+          default-off, searchable {!Walk_forward.Variant_matrix} axis. Not wired
+          into any default config or preset. *)
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
       (** Cadence at which the trailing-stop state machine advances (G11).

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -24,6 +24,7 @@ type config = {
   universe_cap : int option;
   full_compute_tail_days : int option;
   enable_short_side : bool; [@sexp.default true]
+  short_min_price : float; [@sexp.default 0.0]  (** See [.mli]. *)
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
       (** Cadence for trailing-stop trail advancement (G11). [Daily] preserves
@@ -132,6 +133,7 @@ let default_config ~universe ~index_symbol =
     universe_cap = None;
     full_compute_tail_days = None;
     enable_short_side = true;
+    short_min_price = 0.0;
     stop_update_cadence = Stops_runner.Daily;
     stage3_force_exit_config = Stage3_force_exit.default_config;
     enable_stage3_force_exit = false;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -24,6 +24,21 @@ type config = {
   universe_cap : int option;
   full_compute_tail_days : int option;
   enable_short_side : bool; [@sexp.default true]
+  short_min_price : float; [@sexp.default 0.0]
+      (** Minimum entry price for short candidates. Short candidates whose
+          {!Screener.scored_candidate.suggested_entry} is strictly below this
+          value are dropped before they join the entry candidate list.
+
+          Default [0.0] = no gating: the gate short-circuits to the identity
+          when [short_min_price <= 0.0], so the candidate list is bit-identical
+          to the prior behaviour and every existing golden/baseline decodes and
+          replays unchanged.
+
+          Encodes the researched sub-$17 economic-margin floor on shorts
+          ([dev/notes/long-short-margin-mechanics-2026-06-12.md]: sub-$17 shorts
+          carry 83–362% maintenance margin) as a default-off, searchable
+          {!Walk_forward.Variant_matrix} axis. Not wired into any default config
+          or preset. *)
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
   stage3_force_exit_config : Stage3_force_exit.config;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -399,7 +399,8 @@ let screen_universe ?active_through_for ?fold_start_date ?membership_at ~config
   let combined_candidates =
     if config.enable_short_side then
       screen_result.Screener.buy_candidates
-      @ screen_result.Screener.short_candidates
+      @ Short_min_price_gate.filter ~short_min_price:config.short_min_price
+          screen_result.Screener.short_candidates
     else screen_result.Screener.buy_candidates
   in
   let entries =

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -13,6 +13,7 @@
   test_pi_filter_wiring
   test_sector_rotation_weinstein_strategy
   test_short_side_bear_window
+  test_short_min_price_gate
   test_spy_only_weinstein_strategy
   test_stage3_force_exit_runner
   test_late_stage2_stop_runner
@@ -45,6 +46,7 @@
   weinstein.snapshot_runtime
   weinstein.types
   weinstein.screener
+  weinstein_trading.short_min_price_gate
   weinstein.stage
   indicators.types
   indicators.sma

--- a/trading/trading/weinstein/strategy/test/test_short_min_price_gate.ml
+++ b/trading/trading/weinstein/strategy/test/test_short_min_price_gate.ml
@@ -1,0 +1,137 @@
+(** Unit tests for the [short_min_price] short-entry gate.
+
+    Pins the no-op-default contract and the gating behaviour of
+    {!Short_min_price_gate.filter}:
+
+    - [short_min_price = 0.0] (default) → identity: every short candidate is
+      retained, so the entry candidate list is bit-identical to the prior
+      behaviour and every existing golden/baseline replays unchanged.
+    - [short_min_price = 15.0] → short candidates with [suggested_entry < 15.0]
+      are dropped; those at/above are retained.
+    - The gate filters the short list only; it never touches Long candidates
+      (the seam applies it to [short_candidates] before concatenation, so a Long
+      candidate fed through it would only be dropped on price, never on side —
+      this test pins that the helper is side-agnostic but the wiring never
+      routes Longs through it). *)
+
+open OUnit2
+open Core
+open Matchers
+open Weinstein_types
+
+let filter_short_candidates_by_min_price = Short_min_price_gate.filter
+
+(* Minimal [scored_candidate] builder — only the fields the gate reads
+   ([suggested_entry], [side]) are load-bearing; the rest carry inert
+   placeholders. *)
+let _make_candidate ~ticker ~side ~suggested_entry : Screener.scored_candidate =
+  {
+    ticker;
+    analysis =
+      Stock_analysis.analyze ~config:Stock_analysis.default_config ~ticker
+        ~bars:[] ~benchmark_bars:[] ~prior_stage:None
+        ~as_of_date:(Date.of_string "2024-01-01");
+    side;
+    sector =
+      {
+        sector_name = "Test";
+        rating = Screener.Neutral;
+        stage = Stage2 { weeks_advancing = 5; late = false };
+      };
+    grade = C;
+    score = 0;
+    suggested_entry;
+    suggested_stop = suggested_entry *. 1.08;
+    risk_pct = 0.08;
+    swing_target = None;
+    rationale = [];
+  }
+
+let _short ~ticker ~suggested_entry =
+  _make_candidate ~ticker ~side:Trading_base.Types.Short ~suggested_entry
+
+(* ------------------------------------------------------------------ *)
+(* Tests                                                                *)
+(* ------------------------------------------------------------------ *)
+
+(** Default [0.0] is a no-op: all short candidates are retained, in order. *)
+let test_zero_threshold_is_noop _ =
+  let candidates =
+    [
+      _short ~ticker:"LOW" ~suggested_entry:10.0;
+      _short ~ticker:"HIGH" ~suggested_entry:20.0;
+    ]
+  in
+  let result =
+    filter_short_candidates_by_min_price ~short_min_price:0.0 candidates
+  in
+  assert_that
+    (List.map result ~f:(fun c -> c.Screener.ticker))
+    (elements_are [ equal_to "LOW"; equal_to "HIGH" ])
+
+(** Threshold 15.0 drops the $10 short and retains the $20 short. *)
+let test_threshold_drops_below_and_retains_above _ =
+  let candidates =
+    [
+      _short ~ticker:"LOW" ~suggested_entry:10.0;
+      _short ~ticker:"HIGH" ~suggested_entry:20.0;
+    ]
+  in
+  let result =
+    filter_short_candidates_by_min_price ~short_min_price:15.0 candidates
+  in
+  assert_that
+    (List.map result ~f:(fun c -> c.Screener.ticker))
+    (elements_are [ equal_to "HIGH" ])
+
+(** A candidate priced exactly at the threshold is retained (gate is [>=]). *)
+let test_threshold_boundary_is_inclusive _ =
+  let candidates = [ _short ~ticker:"EXACT" ~suggested_entry:15.0 ] in
+  let result =
+    filter_short_candidates_by_min_price ~short_min_price:15.0 candidates
+  in
+  assert_that (List.length result) (equal_to 1)
+
+(** The gate does not affect long/buy candidates: in the strategy seam the
+    helper is applied only to [short_candidates], never to the long list. Here
+    we assert the wiring's invariant directly — a list of Long candidates is
+    never passed through the gate, so the long list a strategy emits is
+    unaffected by [short_min_price]. We model that by filtering a list whose
+    Long member is below the threshold and confirming that the helper, given
+    ONLY the short list, leaves the (separate) long list untouched. *)
+let test_gate_does_not_touch_long_list _ =
+  let longs =
+    [
+      _make_candidate ~ticker:"LONG_CHEAP" ~side:Trading_base.Types.Long
+        ~suggested_entry:5.0;
+    ]
+  in
+  let shorts = [ _short ~ticker:"SHORT_CHEAP" ~suggested_entry:5.0 ] in
+  (* The seam only ever gates [shorts]; [longs] are concatenated untouched. *)
+  let gated_shorts =
+    filter_short_candidates_by_min_price ~short_min_price:15.0 shorts
+  in
+  assert_that
+    (List.length longs, List.length gated_shorts)
+    (all_of
+       [
+         field (fun (n_long, _) -> n_long) (equal_to 1);
+         field (fun (_, n_short) -> n_short) (equal_to 0);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                                *)
+(* ------------------------------------------------------------------ *)
+
+let () =
+  run_test_tt_main
+    ("short_min_price_gate"
+    >::: [
+           "zero threshold is a no-op" >:: test_zero_threshold_is_noop;
+           "threshold drops below, retains above"
+           >:: test_threshold_drops_below_and_retains_above;
+           "threshold boundary is inclusive"
+           >:: test_threshold_boundary_is_inclusive;
+           "gate does not touch long list"
+           >:: test_gate_does_not_touch_long_list;
+         ])


### PR DESCRIPTION
## What it does

Adds a **no-op-default** `short_min_price` gate on short entries so the researched ~$17 economic-margin floor on shorts (`dev/notes/long-short-margin-mechanics-2026-06-12.md`: sub-$17 shorts carry 83–362% maintenance margin) becomes an expressible experiment **axis**. Default `0.0` = no gating = current behavior.

Executes P1 "short-side hygiene" from `dev/notes/next-session-priorities-2026-06-13.md`, landed per `.claude/rules/experiment-flag-discipline.md` (R1 default-off, R2 axis-able, R3 not wired into any default).

## Files changed

- `weinstein_strategy_config.{ml,mli}` — new `short_min_price : float [@sexp.default 0.0]` + default `0.0`.
- `weinstein_strategy.mli` — mirror field in the duplicate `config` type (build requires it to match).
- `weinstein/strategy/gate/lib/short_min_price_gate.{ml,mli}` + `dune` — new micro-lib `weinstein_trading.short_min_price_gate` holding the pure gate `filter`.
- `weinstein_strategy_screening.ml` + `dune` — wired the gate at the short-candidate seam (~line 400).
- `test/test_short_min_price_gate.ml` + `dune` — 4 unit tests.
- `backtest/walk_forward/test/test_variant_matrix.ml` — axis-resolution test.
- `dev/status/short-side-strategy.md`, `dev/plans/short-min-price-gate-2026-06-12.md`.

## No-op-default argument (why goldens are unaffected)

`short_min_price` defaults to `0.0`; the gate (`Short_min_price_gate.filter`) short-circuits to the identity when `short_min_price <= 0.0`, so `combined_candidates` is byte-for-byte the prior list. Existing sexps that omit the field decode to `0.0` via `[@sexp.default 0.0]`. Full `dune build && dune runtest` exits 0 with zero `^FAIL:` lines — every golden/snapshot/scenario test replays unchanged. `enable_short_side` default unchanged (`true`).

## Axis test

`test_variant_matrix.ml` → `short_min_price float axis expands` asserts `((short_min_price 0.0))` / `((short_min_price 17.0))` resolve as a top-level float axis through `Overlay_validator`, same mechanism as `stage3_exit_margin_pct` — proves R2 with no overlay-validator change.

## Tests added (all passing)

`test_zero_threshold_is_noop`, `test_threshold_drops_below_and_retains_above`, `test_threshold_boundary_is_inclusive` (gate is `>=`), `test_gate_does_not_touch_long_list`; plus `test_short_min_price_axis_expands`.

## Design notes for the reviewer

- Gate extracted into its own micro-library rather than a re-export on `weinstein_strategy.ml` (that coordinator sits at the 500-line declared-large cap; a re-export tripped the file-length linter). No linter limits bumped, no exceptions added.
- `short_min_price` doc-comment in the `.ml` is a one-liner pointing to the `.mli` (verbose form tipped the `.ml` nesting-linter average to 2.53 > 2.5). Full doc lives in the `.mli`.

---
🤖 Dispatched by GHA orchestrator run [27421610137](https://github.com/dayfine/trading/actions/runs/27421610137) — feat-weinstein, P1 short-side hygiene.
