### PR TITLE
docs: rename handoff to 2026-06-12-PM (date correction) + #1553 pointer

### DIFF
--- a/dev/notes/next-session-priorities-2026-06-12-PM.md
+++ b/dev/notes/next-session-priorities-2026-06-12-PM.md
@@ -1,4 +1,4 @@
-# Next-session priorities — 2026-06-13
+# Next-session priorities — 2026-06-12 (PM)
 
 **Supersedes** `next-session-priorities-2026-06-12.md`. Check main CI green
 before dispatching.
@@ -40,6 +40,11 @@ before dispatching.
    (net-negative, margin-free, incl. an unstopped THM zombie at −240%).
 
 ## P0 — Act on the warmup-trading discovery (the deepest finding)
+
+**See also issue #1553** (filed post-handoff): an open THM short rode a 4x
+adverse move unstopped with CONTINUOUS bars — no audit entry record, no stop
+registration. Suspected same warmup-entry path; P0 and the P1 short-hygiene
+item are likely the same bug family.
 
 A2's root cause is bigger than one fold: **every backtest trades for 210 days
 before its measurement window and inherits the resulting portfolio.** Decide


### PR DESCRIPTION
It's still 2026-06-12 — the overnight handoff was misdated as -06-13. Renamed to next-session-priorities-2026-06-12-PM.md (matching the -PM convention), header fixed, and added the post-handoff issue #1553 pointer (THM stop-registration escape) under P0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)