### PR TITLE
feat(backtest): default-off suppress_warmup_trading flag (#1549 A2 root-fix surface)

### DIFF
--- a/dev/plans/warmup-trading-flag-2026-06-12.md
+++ b/dev/plans/warmup-trading-flag-2026-06-12.md
@@ -1,0 +1,151 @@
+# suppress_warmup_trading flag — 2026-06-12
+
+## Context
+
+PR #1549's A2 root-cause investigation found that the Weinstein strategy
+**trades during the 210-day warmup window**. The simulator runs from
+`warmup_start = start_date - warmup_days` (`Panel_runner._make_simulator`,
+`sim_config.start_date = warmup_start`), so every backtest inherits a
+portfolio that was built by warmup-window trading before its measurement
+`start_date`. The 2009-06-26 fold's warmup spanned the GFC bottom →
+portfolio depleted to ~35% of initial cash before measurement opened
+(`Backtest.Fold_health` now detects these degenerate folds at the
+reporting boundary, but does not prevent the trading).
+
+The likely design intent is **warmup = indicators/data only, no trading**.
+This PR adds a **default-off** flag that, when enabled, suppresses all new
+position entries (long and short) before the measurement `start_date` while
+indicators/data warm up normally. Default = current behaviour, byte-for-byte
+no-op on every golden/snapshot/scenario test.
+
+Per `.claude/rules/experiment-flag-discipline.md`: lands **default-off as a
+no-op** (`suppress_warmup_trading : bool [@sexp.default false]`), becomes a
+searchable `Variant_matrix` axis the day it lands, and is NOT wired into any
+default config or preset until a ledger ACCEPT justifies it.
+
+## Approach
+
+The strategy emits `Position.transition`s from `on_market_close`. The only
+transition that creates a *new* position is `CreateEntering` (it carries
+`side : position_side`, covering both long and short). Every `transition`
+carries `date : Date.t` (the simulated date). Suppressing warmup trading is
+therefore: drop `CreateEntering` transitions whose `transition.date <
+start_date`, leaving every other transition (exits, fills, risk-param
+updates, stops) untouched.
+
+The seam is the **strategy wrapper**. The production backtest path wraps the
+strategy exactly once, in `Panel_runner._make_simulator` (which already has
+`start_date` in scope), via `Strategy_wrapper.wrap`. We compose a second,
+optional wrapper there driven by `config.suppress_warmup_trading` and
+`start_date`.
+
+1. **Config field** `suppress_warmup_trading : bool [@sexp.default false]` on
+   `Weinstein_strategy.config` (`weinstein_strategy_config.{ml,mli}` +
+   `weinstein_strategy.mli`), defaulted to `false` in `default_config`.
+   `false` = current behaviour (warmup trading happens). This is the FLAG that
+   makes it an axis (R2): `Overlay_validator.apply_overrides` resolves it via
+   `config_of_sexp`, identical to `enable_short_side` / `enable_laggard_rotation`.
+
+2. **Pure gate** — a micro-lib `Warmup_trade_gate` under
+   `trading/trading/backtest/warmup_gate/lib/`:
+
+   ```ocaml
+   val filter_transitions :
+     suppress:bool -> start_date:Date.t ->
+     Position.transition list -> Position.transition list
+   ```
+
+   When `suppress = false` → identity (the no-op default). When `suppress =
+   true` → drops `CreateEntering` transitions dated strictly before
+   `start_date`; every non-`CreateEntering` transition and every
+   `CreateEntering` dated on/after `start_date` passes through unchanged. Pure,
+   `.mli`-documented, unit-tested.
+
+3. **Wrapper** — `Warmup_trade_gate.wrap_strategy ~suppress ~start_date
+   strategy` returns a `STRATEGY` module that runs the inner strategy then maps
+   the output transitions through `filter_transitions`. When `suppress = false`
+   the wrapper still delegates but returns the output unchanged (bit-identical).
+
+4. **Wire** in `Panel_runner._make_simulator`: after `Strategy_wrapper.wrap`,
+   apply `Warmup_trade_gate.wrap_strategy
+   ~suppress:input.config.suppress_warmup_trading ~start_date`. With the default
+   `false` the strategy module is behaviourally identical to today.
+
+## Why a runner-side gate (not strategy-side)
+
+The strategy only sees the simulation clock (which starts at `warmup_start`);
+it does not know the measurement `start_date`. The runner knows both. Keeping
+the gate in the runner means the strategy stays date-boundary-agnostic and the
+gate is a thin, testable transition filter. The FLAG is still a real
+`Weinstein_strategy.config` field (R2 satisfied) — the runner reads the flag
+off the resolved config and supplies its own `start_date`.
+
+## Suppression scope
+
+- **New positions only.** `CreateEntering` (long + short) before `start_date`
+  is dropped. With the flag on there will be no warmup-entered positions to
+  exit later, so the warmup window opens the measurement window with a clean
+  all-cash portfolio.
+- **Exits / stops / fills are never suppressed.** `TriggerExit`,
+  `TriggerPartialExit`, `UpdateRiskParams`, `EntryFill`, `EntryComplete`,
+  `ExitFill`, `ExitComplete`, `CancelEntry` all pass through regardless of
+  date. So even if a warmup-entered position somehow exists, its exit/stop
+  handling is never broken.
+
+## Files to change
+
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml` — field + default.
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli` — field + doc.
+- `trading/trading/weinstein/strategy/lib/weinstein_strategy.mli` — field + doc on the public config type.
+- `trading/trading/backtest/warmup_gate/lib/dune` — new micro-lib.
+- `trading/trading/backtest/warmup_gate/lib/warmup_trade_gate.{ml,mli}` — gate + wrapper.
+- `trading/trading/backtest/lib/dune` — depend on the micro-lib.
+- `trading/trading/backtest/lib/panel_runner.ml` — wire the wrapper.
+- `trading/trading/backtest/warmup_gate/test/{dune,test_warmup_trade_gate.ml}` — unit tests.
+- `trading/trading/backtest/walk_forward/test/test_variant_matrix.ml` — axis test.
+- `dev/status/backtest-infra.md` — dated status note.
+
+## No-op-default argument
+
+`suppress_warmup_trading` defaults to `false`. `Warmup_trade_gate.wrap_strategy`
+with `suppress = false` (and `filter_transitions ~suppress:false`) is the
+identity on the strategy's output — the same module behaviour, the same
+transition list, byte-for-byte. Existing sexps that omit the field decode to
+`false` via `[@sexp.default false]`. No golden / snapshot / scenario decodes or
+replays differently. `Backtest.Fold_health` signatures fire exactly as before
+(they observe terminal facts, which are unchanged with the flag off).
+
+## Axis-ability note (R2)
+
+`suppress_warmup_trading` is a top-level `bool` field with `[@sexp.default
+false]`, so `Variant_matrix` resolves it by sexp name through `Overlay_validator`
+with no overlay-validator change (identical mechanism to `enable_laggard_rotation`
+/ `enable_short_side`). Axis test added:
+`((flag suppress_warmup_trading) (values (true false)))` expands + validates.
+
+## Tests
+
+- `test_warmup_trade_gate.ml` (new):
+  - `suppress=false` → identity (no-op default); list returned unchanged.
+  - `suppress=true` → `CreateEntering` dated before `start_date` dropped.
+  - `suppress=true` → `CreateEntering` dated on `start_date` retained (boundary
+    is inclusive: `< start_date` drops, `>= start_date` keeps).
+  - `suppress=true` → `CreateEntering` dated after `start_date` retained.
+  - `suppress=true` → exit / fill / risk-param transitions dated in the warmup
+    window are NEVER dropped.
+  - `wrap_strategy` end-to-end: a stub strategy emitting a warmup-dated
+    `CreateEntering` + a warmup-dated `TriggerExit` → wrapped strategy drops the
+    entry, keeps the exit; with `suppress=false` keeps both.
+- `test_variant_matrix.ml`: `suppress_warmup_trading` flag axis expands +
+  validates.
+- `dune build @fmt`, `dune build && dune runtest` exit 0; all goldens unchanged.
+
+## Out of scope
+
+- Quantifying how every baseline shifts with the flag ON (the comparison run is
+  P0's analysis step, a separate experiment — not this code PR).
+- Flipping the default to `true` (forbidden without a ledger ACCEPT + the
+  promotion confirmation grid).
+- Segregating inherited-position metrics (the "running start is intentional"
+  alternative semantics) — orthogonal.
+- Any change to `Backtest.Fold_health`, the simulator, or core modules.

--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -12,6 +12,45 @@ moved to its own track at `dev/status/backtest-perf.md`. The 12-step
 incremental-indicators refactor (the follow-on architecture for
 Tier 3) tracked separately at `dev/status/incremental-indicators.md`.
 
+## 2026-06-12 — `suppress_warmup_trading` flag (warmup-leak root-fix surface)
+
+- [x] **Default-off warmup-trading gate (P0, PR #1549 A2 follow-up).** Added a
+  no-op-default `suppress_warmup_trading : bool [@sexp.default false]` config
+  field on `Weinstein_strategy.config` plus a pure runner-side gate
+  (`Warmup_trade_gate`) that drops the strategy's `CreateEntering` transitions
+  (long and short) dated before the measurement `start_date`. The simulator
+  runs from `warmup_start = start_date - warmup_days`, so absent the flag the
+  strategy trades during the 210-day warmup window and every backtest inherits
+  a warmup-built portfolio at measurement start (the #1549 A2 root cause: the
+  2009-06-26 fold's warmup spanned the GFC bottom → portfolio depleted to ~35%
+  before measurement opened).
+  - **Lives at:** `trading/trading/backtest/warmup_gate/lib/warmup_trade_gate.{ml,mli}`
+    (micro-lib `warmup_trade_gate`), wired in `panel_runner.ml`
+    `_make_simulator` after `Strategy_wrapper.wrap`.
+  - **R1 default-off:** `suppress = false` short-circuits both
+    `filter_transitions` and `wrap_strategy` to the identity, so every
+    golden/snapshot/scenario decodes (via `[@sexp.default false]`) and replays
+    bit-equal. Full `dune build && dune runtest` exits 0 with the flag absent.
+    `Backtest.Fold_health` signatures fire exactly as before (terminal facts
+    unchanged with the flag off).
+  - **R2 axis-able (verified):** top-level bool flag, so `Variant_matrix`
+    resolves it by sexp name through `Overlay_validator` with no
+    overlay-validator change (same mechanism as `neutral_blocks_longs`). Axis
+    test added to `test_variant_matrix.ml`
+    (`suppress_warmup_trading flag axis expands`).
+  - **R3:** not wired into any default config or preset (stays default-off).
+  - **Scope:** only new-position entries are suppressed; exits / partial exits
+    / risk-param updates / fills are never dropped (warmup-window exit/stop
+    handling is never broken).
+  - **Verify:** `dune runtest trading/backtest/warmup_gate/` (7 unit tests:
+    no-op at false, drop-warmup-entry, inclusive boundary, short-side, never
+    drop non-entries, `wrap_strategy` end-to-end both flag states).
+  - **Plan:** `dev/plans/warmup-trading-flag-2026-06-12.md`. Branch
+    `feat/warmup-trading-flag`.
+  - **Next (out of scope here):** the comparison run quantifying how every
+    baseline shifts with the flag ON, then walk-forward CV + confirmation grid
+    before any promotion (P0 analysis step, `experiment-flag-discipline` R3).
+
 ## QC
 
 Step 1 (PR #399, merged) — overall_qc APPROVED at e59f8d2 (both prior blockers U6/F1 and the BC4 advisory resolved; `_held_symbols` strategy fix domain-correct).

--- a/trading/trading/backtest/lib/dune
+++ b/trading/trading/backtest/lib/dune
@@ -17,6 +17,7 @@
   trading.simulation.types
   trading.strategy
   backtest_cost_model
+  warmup_trade_gate
   weinstein.snapshot_pipeline
   weinstein.snapshot_runtime
   weinstein_trading.strategy

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -38,17 +38,13 @@ let _stale_hold_policy (config : Weinstein_strategy.config) : Stale_hold.config
   }
 
 let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
-    ~end_date ~warmup_days ~initial_cash ~commission ?slippage_bps
+    ~warmup_start ~end_date ~initial_cash ~commission ?slippage_bps
     ?on_trade_fill ~strategy ~market_data_adapter () =
-  let warmup_start = Date.add_days start_date (-warmup_days) in
-  let strategy = Strategy_wrapper.wrap ~stop_log strategy in
-  (* Default-off warmup-trading gate (#1549 A2). With the flag [false] (the
-     default) this is the identity, so every existing backtest is byte-equal;
-     with it [true] the runner drops strategy entries dated before the
-     measurement [start_date] (the simulator runs from [warmup_start]). *)
+  (* Default-off [Warmup_trade_gate] (#1549 A2); identity unless the flag is on. *)
   let strategy =
-    Warmup_trade_gate.wrap_strategy
-      ~suppress:input.config.suppress_warmup_trading ~start_date strategy
+    Strategy_wrapper.wrap ~stop_log strategy
+    |> Warmup_trade_gate.wrap_strategy
+         ~suppress:input.config.suppress_warmup_trading ~start_date
   in
   let sim_deps =
     Simulator.create_deps ~symbols:input.all_symbols
@@ -58,7 +54,7 @@ let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
       ~stale_hold_policy:(_stale_hold_policy input.config)
       ~margin_config:input.config.margin_config ?on_trade_fill ()
   in
-  let sim_config =
+  let config =
     Simulator.
       {
         start_date = warmup_start;
@@ -68,12 +64,10 @@ let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
         strategy_cadence = Types.Cadence.Daily;
       }
   in
-  match Simulator.create ~config:sim_config ~deps:sim_deps with
-  | Ok s -> s
-  | Error e ->
-      failwith
-        (sprintf "Backtest.Panel_runner: failed to create simulator: %s"
-           (Status.show e))
+  Simulator.create ~config ~deps:sim_deps
+  |> Result.map_error ~f:(fun e ->
+      "Backtest.Panel_runner: failed to create simulator: " ^ Status.show e)
+  |> Result.ok_or_failwith
 
 (* Read one symbol's close on [date]. Returns [None] when the symbol is not
    present in the snapshot, the read errors, or the close is NaN. *)
@@ -160,14 +154,11 @@ let _build_snapshot_bar_reader ~daily_panels ~calendar =
   Weinstein_strategy.Bar_reader.of_snapshot_views ~calendar callbacks
 
 let _create_panels ~snapshot_dir ~manifest =
-  match
-    Daily_panels.create ~snapshot_dir ~manifest
-      ~max_cache_mb:(Snapshot_cache_config.resolve_cache_mb ())
-  with
-  | Ok p -> p
-  | Error err ->
-      failwithf "Panel_runner: Daily_panels.create failed: %s" (Status.show err)
-        ()
+  Daily_panels.create ~snapshot_dir ~manifest
+    ~max_cache_mb:(Snapshot_cache_config.resolve_cache_mb ())
+  |> Result.map_error ~f:(fun e ->
+      "Panel_runner: Daily_panels.create failed: " ^ Status.show e)
+  |> Result.ok_or_failwith
 
 (* Resolve the [Daily_panels.t] this run reads through. [Some p]: read through a
    caller-owned cache ([run] does not close it). [None]: a per-run cache [run]
@@ -285,7 +276,7 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
   in
   let sim =
     _make_simulator input ~stop_log:r.stop_log ~stale_hold_log:r.stale_hold_log
-      ~start_date ~end_date ~warmup_days ~initial_cash
+      ~start_date ~warmup_start ~end_date ~initial_cash
       ~commission:effective_commission ?slippage_bps:effective_slippage_bps
       ?on_trade_fill ~strategy ~market_data_adapter ()
   in

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -42,6 +42,14 @@ let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
     ?on_trade_fill ~strategy ~market_data_adapter () =
   let warmup_start = Date.add_days start_date (-warmup_days) in
   let strategy = Strategy_wrapper.wrap ~stop_log strategy in
+  (* Default-off warmup-trading gate (#1549 A2). With the flag [false] (the
+     default) this is the identity, so every existing backtest is byte-equal;
+     with it [true] the runner drops strategy entries dated before the
+     measurement [start_date] (the simulator runs from [warmup_start]). *)
+  let strategy =
+    Warmup_trade_gate.wrap_strategy
+      ~suppress:input.config.suppress_warmup_trading ~start_date strategy
+  in
   let sim_deps =
     Simulator.create_deps ~symbols:input.all_symbols
       ~data_dir:input.data_dir_fpath ~strategy ~commission

--- a/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
+++ b/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
@@ -240,6 +240,34 @@ let test_short_min_price_axis_expands _ =
            ];
        ])
 
+(* Proves R2 (experiment-flag-discipline) for the [suppress_warmup_trading]
+   warmup-trading gate (#1549 A2): it is a real top-level bool flag on
+   [Weinstein_strategy.config] (same mechanism as [neutral_blocks_longs]), so
+   the flag axis expands and passes [Overlay_validator] validation with no
+   overlay-validator change. The no-op default [false] and the experimental
+   [true] sit on the same axis. *)
+let test_suppress_warmup_trading_flag_axis_expands _ =
+  let axis =
+    VM.Flag
+      {
+        name = "suppress_warmup_trading";
+        values = Sexp.[ Atom "true"; Atom "false" ];
+      }
+  in
+  let t = { VM.axes = [ axis ]; expansion = VM.Cartesian } in
+  assert_that (VM.expand t)
+    (elements_are
+       [
+         field
+           (fun (v : WFR.variant) -> v.overrides)
+           (elements_are
+              [ equal_to (Sexp.of_string "((suppress_warmup_trading true))") ]);
+         field
+           (fun (v : WFR.variant) -> v.overrides)
+           (elements_are
+              [ equal_to (Sexp.of_string "((suppress_warmup_trading false))") ]);
+       ])
+
 (* ---------- Sampled determinism + fallback ---------- *)
 
 let test_sampled_determinism _ =
@@ -322,6 +350,8 @@ let suite =
          >:: test_macro_bearish_trim_axes_expand;
          "short_min_price float axis expands"
          >:: test_short_min_price_axis_expands;
+         "suppress_warmup_trading flag axis expands"
+         >:: test_suppress_warmup_trading_flag_axis_expands;
          "sampled determinism (same seed -> same labels)"
          >:: test_sampled_determinism;
          "sampled different seed -> different subset"

--- a/trading/trading/backtest/warmup_gate/lib/dune
+++ b/trading/trading/backtest/warmup_gate/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name warmup_trade_gate)
+ (libraries core trading.strategy)
+ (preprocess
+  (pps ppx_let ppx_deriving.show ppx_deriving.eq)))

--- a/trading/trading/backtest/warmup_gate/lib/warmup_trade_gate.ml
+++ b/trading/trading/backtest/warmup_gate/lib/warmup_trade_gate.ml
@@ -1,0 +1,37 @@
+(** Warmup-trading gate — see [warmup_trade_gate.mli]. *)
+
+open Core
+open Trading_strategy
+
+(* A transition creates a NEW position iff its kind is [CreateEntering]. That is
+   the only entry the strategy emits (both long and short — it carries [side]).
+   Everything else (exits, partial exits, risk-param updates, fills) manages an
+   already-existing position and must never be suppressed. *)
+let _is_warmup_entry ~start_date (transition : Position.transition) =
+  match transition.kind with
+  | Position.CreateEntering _ -> Date.( < ) transition.date start_date
+  | _ -> false
+
+let filter_transitions ~suppress ~start_date transitions =
+  if not suppress then transitions
+  else
+    List.filter transitions ~f:(fun t -> not (_is_warmup_entry ~start_date t))
+
+let wrap_strategy ~suppress ~start_date (module S : Strategy_interface.STRATEGY)
+    =
+  if not suppress then (module S : Strategy_interface.STRATEGY)
+  else
+    let module Wrapped = struct
+      let name = S.name
+
+      let on_market_close ~get_price ~get_indicator ~portfolio =
+        match S.on_market_close ~get_price ~get_indicator ~portfolio with
+        | Ok { transitions } ->
+            Ok
+              {
+                Strategy_interface.transitions =
+                  filter_transitions ~suppress ~start_date transitions;
+              }
+        | Error _ as e -> e
+    end in
+    (module Wrapped : Strategy_interface.STRATEGY)

--- a/trading/trading/backtest/warmup_gate/lib/warmup_trade_gate.ml
+++ b/trading/trading/backtest/warmup_gate/lib/warmup_trade_gate.ml
@@ -17,6 +17,23 @@ let filter_transitions ~suppress ~start_date transitions =
   else
     List.filter transitions ~f:(fun t -> not (_is_warmup_entry ~start_date t))
 
+(* Map an inner [on_market_close] result through {!filter_transitions} with
+   [suppress = true], leaving [Error] untouched. Extracted to a flat top-level
+   helper so [wrap_strategy]'s functor body stays shallow — the transform lives
+   here rather than nested inside the [module Wrapped] closure (keeps nesting
+   depth within the linter budget). *)
+let _filter_result ~start_date
+    (result : Strategy_interface.output Status.status_or) =
+  Result.map result ~f:(fun { Strategy_interface.transitions } ->
+      {
+        Strategy_interface.transitions =
+          filter_transitions ~suppress:true ~start_date transitions;
+      })
+
+let _filter_market_close ~start_date ~inner ~get_price ~get_indicator ~portfolio
+    =
+  inner ~get_price ~get_indicator ~portfolio |> _filter_result ~start_date
+
 let wrap_strategy ~suppress ~start_date (module S : Strategy_interface.STRATEGY)
     =
   if not suppress then (module S : Strategy_interface.STRATEGY)
@@ -24,14 +41,7 @@ let wrap_strategy ~suppress ~start_date (module S : Strategy_interface.STRATEGY)
     let module Wrapped = struct
       let name = S.name
 
-      let on_market_close ~get_price ~get_indicator ~portfolio =
-        match S.on_market_close ~get_price ~get_indicator ~portfolio with
-        | Ok { transitions } ->
-            Ok
-              {
-                Strategy_interface.transitions =
-                  filter_transitions ~suppress ~start_date transitions;
-              }
-        | Error _ as e -> e
+      let on_market_close =
+        _filter_market_close ~start_date ~inner:S.on_market_close
     end in
     (module Wrapped : Strategy_interface.STRATEGY)

--- a/trading/trading/backtest/warmup_gate/lib/warmup_trade_gate.mli
+++ b/trading/trading/backtest/warmup_gate/lib/warmup_trade_gate.mli
@@ -1,0 +1,51 @@
+(** The warmup-trading gate.
+
+    A default-off backtest mechanism (per
+    [.claude/rules/experiment-flag-discipline.md]) that suppresses all new
+    position entries before the measurement [start_date]. The simulator runs
+    from [start_date - warmup_days] so the Weinstein strategy trades during the
+    warmup window; PR #1549's A2 root-cause showed this leaks a warmup-built
+    portfolio into every measurement window (the 2009-06-26 fold's warmup
+    spanned the GFC bottom → portfolio depleted to ~35% before measurement
+    opened; see {!Backtest.Fold_health}).
+
+    The gate is keyed off the
+    [Weinstein_strategy_config.suppress_warmup_trading] flag, supplied by the
+    runner together with its [start_date]. The strategy itself stays
+    date-boundary-agnostic — it only ever sees the simulation clock, which
+    starts at the warmup boundary. *)
+
+open Trading_strategy
+
+val filter_transitions :
+  suppress:bool ->
+  start_date:Core.Date.t ->
+  Position.transition list ->
+  Position.transition list
+(** [filter_transitions ~suppress ~start_date transitions] drops every
+    [Position.CreateEntering] transition whose [transition.date] is strictly
+    before [start_date]; every other transition kind, and every [CreateEntering]
+    dated on/after [start_date], passes through unchanged.
+
+    No-op when [suppress = false] (the default): returns [transitions] unchanged
+    (bit-identical), so every existing golden/baseline replays unchanged.
+
+    Only new-position entries (both long and short — [CreateEntering] carries
+    the [side]) are suppressed. Exits, partial exits, risk-param updates, and
+    fills ([TriggerExit], [TriggerPartialExit], [UpdateRiskParams], [EntryFill],
+    [EntryComplete], [ExitFill], [ExitComplete], [CancelEntry]) are never
+    dropped, so warmup-window exit/stop handling is never broken. Pure. *)
+
+val wrap_strategy :
+  suppress:bool ->
+  start_date:Core.Date.t ->
+  (module Strategy_interface.STRATEGY) ->
+  (module Strategy_interface.STRATEGY)
+(** [wrap_strategy ~suppress ~start_date strategy] returns a strategy that
+    delegates to [strategy] and then passes the resulting output transitions
+    through {!filter_transitions}. The wrapper is purely a transition filter; it
+    does not otherwise alter the inner strategy's behaviour.
+
+    When [suppress = false] the wrapper is the identity on the inner strategy's
+    output (the gate short-circuits), so the wrapped strategy is behaviourally
+    bit-identical to [strategy] — the no-op default. *)

--- a/trading/trading/backtest/warmup_gate/test/dune
+++ b/trading/trading/backtest/warmup_gate/test/dune
@@ -1,0 +1,3 @@
+(tests
+ (names test_warmup_trade_gate)
+ (libraries ounit2 core matchers trading.strategy warmup_trade_gate))

--- a/trading/trading/backtest/warmup_gate/test/test_warmup_trade_gate.ml
+++ b/trading/trading/backtest/warmup_gate/test/test_warmup_trade_gate.ml
@@ -1,0 +1,219 @@
+(** Unit tests for {!Warmup_trade_gate}.
+
+    Pins the no-op-default contract and the suppression behaviour:
+
+    - [suppress = false] (default) → identity: the transition list is returned
+      unchanged, so every existing golden/baseline replays bit-identically.
+    - [suppress = true] → [CreateEntering] transitions dated strictly before
+      [start_date] are dropped (both long and short); those dated on/after
+      [start_date] are retained; non-entry transitions (exits, fills, risk-param
+      updates) are never dropped regardless of date.
+    - [wrap_strategy] threads the gate through a strategy's output. *)
+
+open OUnit2
+open Core
+open Trading_strategy
+open Matchers
+
+let start_date = Date.of_string "2010-01-01"
+let before = Date.of_string "2009-06-26" (* in the warmup window *)
+let after = Date.of_string "2010-03-01" (* in the measurement window *)
+
+(* ------------------------------------------------------------------ *)
+(* Transition builders — only the load-bearing fields vary.            *)
+(* ------------------------------------------------------------------ *)
+
+let entry ~position_id ~date ~side : Position.transition =
+  {
+    position_id;
+    date;
+    kind =
+      Position.CreateEntering
+        {
+          symbol = position_id;
+          side;
+          target_quantity = 100.0;
+          entry_price = 50.0;
+          reasoning = Position.ManualDecision { description = "test" };
+        };
+  }
+
+let exit_ ~position_id ~date : Position.transition =
+  {
+    position_id;
+    date;
+    kind =
+      Position.TriggerExit
+        {
+          exit_reason =
+            Position.StrategySignal { label = "exit"; detail = None };
+          exit_price = 60.0;
+        };
+  }
+
+let risk_update ~position_id ~date : Position.transition =
+  {
+    position_id;
+    date;
+    kind =
+      Position.UpdateRiskParams
+        {
+          new_risk_params =
+            {
+              stop_loss_price = Some 45.0;
+              take_profit_price = None;
+              max_hold_days = None;
+            };
+        };
+  }
+
+let ids ts = List.map ts ~f:(fun (t : Position.transition) -> t.position_id)
+
+(* ------------------------------------------------------------------ *)
+(* filter_transitions                                                   *)
+(* ------------------------------------------------------------------ *)
+
+(** Default [suppress = false] is a no-op: even a warmup-dated entry survives.
+*)
+let test_suppress_false_is_noop _ =
+  let transitions =
+    [
+      entry ~position_id:"WARMUP" ~date:before ~side:Long;
+      entry ~position_id:"INWINDOW" ~date:after ~side:Long;
+    ]
+  in
+  let result =
+    Warmup_trade_gate.filter_transitions ~suppress:false ~start_date transitions
+  in
+  assert_that (ids result)
+    (elements_are [ equal_to "WARMUP"; equal_to "INWINDOW" ])
+
+(** [suppress = true] drops a warmup-dated entry, keeps an in-window entry. *)
+let test_suppress_true_drops_warmup_entry _ =
+  let transitions =
+    [
+      entry ~position_id:"WARMUP" ~date:before ~side:Long;
+      entry ~position_id:"INWINDOW" ~date:after ~side:Long;
+    ]
+  in
+  let result =
+    Warmup_trade_gate.filter_transitions ~suppress:true ~start_date transitions
+  in
+  assert_that (ids result) (elements_are [ equal_to "INWINDOW" ])
+
+(** Boundary is inclusive: an entry dated exactly on [start_date] is retained
+    ([< start_date] drops, [>= start_date] keeps). *)
+let test_boundary_entry_is_retained _ =
+  let transitions =
+    [ entry ~position_id:"BOUNDARY" ~date:start_date ~side:Long ]
+  in
+  let result =
+    Warmup_trade_gate.filter_transitions ~suppress:true ~start_date transitions
+  in
+  assert_that (ids result) (elements_are [ equal_to "BOUNDARY" ])
+
+(** Short warmup entries are suppressed too — the gate is side-agnostic. *)
+let test_suppress_true_drops_warmup_short_entry _ =
+  let transitions =
+    [
+      entry ~position_id:"WARMUP_SHORT" ~date:before ~side:Short;
+      entry ~position_id:"INWINDOW_SHORT" ~date:after ~side:Short;
+    ]
+  in
+  let result =
+    Warmup_trade_gate.filter_transitions ~suppress:true ~start_date transitions
+  in
+  assert_that (ids result) (elements_are [ equal_to "INWINDOW_SHORT" ])
+
+(** Non-entry transitions (exits, risk-param updates) dated in the warmup window
+    are NEVER dropped — only [CreateEntering] is suppressed. *)
+let test_non_entry_transitions_are_never_dropped _ =
+  let transitions =
+    [
+      entry ~position_id:"WARMUP_ENTRY" ~date:before ~side:Long;
+      exit_ ~position_id:"HELD" ~date:before;
+      risk_update ~position_id:"HELD" ~date:before;
+    ]
+  in
+  let result =
+    Warmup_trade_gate.filter_transitions ~suppress:true ~start_date transitions
+  in
+  (* The warmup entry is dropped; the warmup-dated exit + risk-update survive. *)
+  assert_that (ids result) (elements_are [ equal_to "HELD"; equal_to "HELD" ])
+
+(* ------------------------------------------------------------------ *)
+(* wrap_strategy                                                        *)
+(* ------------------------------------------------------------------ *)
+
+let stub_strategy transitions =
+  (module struct
+    let name = "Stub"
+
+    let on_market_close ~get_price:_ ~get_indicator:_ ~portfolio:_ =
+      Ok { Strategy_interface.transitions }
+  end : Strategy_interface.STRATEGY)
+
+let empty_portfolio : Portfolio_view.t =
+  { Portfolio_view.cash = 100000.0; positions = Map.empty (module String) }
+
+let run_wrapped ~suppress transitions =
+  let module W =
+    (val Warmup_trade_gate.wrap_strategy ~suppress ~start_date
+           (stub_strategy transitions)
+        : Strategy_interface.STRATEGY)
+  in
+  W.on_market_close
+    ~get_price:(fun _ -> None)
+    ~get_indicator:(fun _ _ _ _ -> None)
+    ~portfolio:empty_portfolio
+
+(** With [suppress = true] the wrapped strategy drops the warmup-dated entry but
+    keeps the warmup-dated exit. *)
+let test_wrap_suppress_true_drops_entry_keeps_exit _ =
+  let transitions =
+    [
+      entry ~position_id:"WARMUP_ENTRY" ~date:before ~side:Long;
+      exit_ ~position_id:"HELD" ~date:before;
+    ]
+  in
+  assert_that
+    (run_wrapped ~suppress:true transitions)
+    (is_ok_and_holds
+       (field
+          (fun (o : Strategy_interface.output) -> ids o.transitions)
+          (elements_are [ equal_to "HELD" ])))
+
+(** With [suppress = false] the wrapped strategy is the identity: both the
+    warmup-dated entry and exit pass through (the no-op default). *)
+let test_wrap_suppress_false_is_identity _ =
+  let transitions =
+    [
+      entry ~position_id:"WARMUP_ENTRY" ~date:before ~side:Long;
+      exit_ ~position_id:"HELD" ~date:before;
+    ]
+  in
+  assert_that
+    (run_wrapped ~suppress:false transitions)
+    (is_ok_and_holds
+       (field
+          (fun (o : Strategy_interface.output) -> ids o.transitions)
+          (elements_are [ equal_to "WARMUP_ENTRY"; equal_to "HELD" ])))
+
+let () =
+  run_test_tt_main
+    ("warmup_trade_gate"
+    >::: [
+           "suppress=false is a no-op" >:: test_suppress_false_is_noop;
+           "suppress=true drops warmup entry"
+           >:: test_suppress_true_drops_warmup_entry;
+           "boundary entry on start_date is retained"
+           >:: test_boundary_entry_is_retained;
+           "suppress=true drops warmup short entry"
+           >:: test_suppress_true_drops_warmup_short_entry;
+           "non-entry transitions are never dropped"
+           >:: test_non_entry_transitions_are_never_dropped;
+           "wrap suppress=true drops entry keeps exit"
+           >:: test_wrap_suppress_true_drops_entry_keeps_exit;
+           "wrap suppress=false is identity"
+           >:: test_wrap_suppress_false_is_identity;
+         ])

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -251,6 +251,17 @@ type config = {
           ([dev/notes/long-short-margin-mechanics-2026-06-12.md]) as a
           default-off, searchable {!Walk_forward.Variant_matrix} axis. Not wired
           into any default config or preset. *)
+  suppress_warmup_trading : bool; [@sexp.default false]
+      (** When [true], the backtest runner suppresses all new position entries
+          (long and short) before the measurement [start_date], so the warmup
+          window builds indicators/data only and the measurement window opens
+          with an all-cash portfolio. Default [false] = prior behaviour (the
+          strategy trades during the warmup window). No-op default: existing
+          sexps decode to [false] and replay bit-identically. Motivated by PR
+          #1549's A2 warmup-leak root cause; implemented runner-side by
+          {!Backtest.Warmup_trade_gate}. A default-off, searchable
+          {!Walk_forward.Variant_matrix} axis. Not wired into any default config
+          or preset. *)
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
       (** Cadence at which the trailing-stop state machine advances (G11).

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -25,6 +25,7 @@ type config = {
   full_compute_tail_days : int option;
   enable_short_side : bool; [@sexp.default true]
   short_min_price : float; [@sexp.default 0.0]  (** See [.mli]. *)
+  suppress_warmup_trading : bool; [@sexp.default false]  (** See [.mli]. *)
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
       (** Cadence for trailing-stop trail advancement (G11). [Daily] preserves
@@ -134,6 +135,7 @@ let default_config ~universe ~index_symbol =
     full_compute_tail_days = None;
     enable_short_side = true;
     short_min_price = 0.0;
+    suppress_warmup_trading = false;
     stop_update_cadence = Stops_runner.Daily;
     stage3_force_exit_config = Stage3_force_exit.default_config;
     enable_stage3_force_exit = false;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -39,6 +39,27 @@ type config = {
           carry 83–362% maintenance margin) as a default-off, searchable
           {!Walk_forward.Variant_matrix} axis. Not wired into any default config
           or preset. *)
+  suppress_warmup_trading : bool; [@sexp.default false]
+      (** When [true], the backtest runner suppresses all new position entries
+          (long and short) before the measurement [start_date], so the warmup
+          window builds indicators/data only and the measurement window opens
+          with an all-cash portfolio.
+
+          Default [false] = prior behaviour: the simulator runs from
+          [start_date - warmup_days] and the strategy trades during the warmup
+          window, so every backtest inherits a warmup-built portfolio at
+          measurement start. This is a no-op default — existing
+          golden/baseline/snapshot/scenario sexps that omit the field decode to
+          [false] (via [@sexp.default false]) and replay bit-identically.
+
+          Motivated by PR #1549's A2 root-cause: warmup-window trading over the
+          GFC bottom depleted a fold's portfolio to ~35% before its measurement
+          window opened (see [Backtest.Fold_health]). The flag lets a spec test
+          the "warmup = indicators only" semantics. Implemented runner-side by
+          {!Backtest.Warmup_trade_gate}, which drops [CreateEntering]
+          transitions dated before [start_date]; exits/stops/fills are never
+          suppressed. A default-off, searchable {!Walk_forward.Variant_matrix}
+          axis. Not wired into any default config or preset. *)
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
   stage3_force_exit_config : Stage3_force_exit.config;


### PR DESCRIPTION
## What it does

Adds a **default-off** config flag `suppress_warmup_trading : bool [@sexp.default false]` that, when enabled, suppresses all new position entries (long and short) before the measurement `start_date`, so the 210-day warmup window builds indicators/data only. Default `false` = current behaviour (the strategy trades during warmup) — byte-for-byte no-op on every golden/snapshot/scenario test.

**Motivation (PR #1549 A2 root cause):** the simulator runs from `warmup_start = start_date - warmup_days` (`Panel_runner._make_simulator`, `sim_config.start_date = warmup_start`), so the Weinstein strategy trades *during* the warmup window and every backtest inherits a warmup-built portfolio at measurement start. The 2009-06-26 fold's warmup spanned the GFC bottom → portfolio depleted to ~35% before measurement opened (`Backtest.Fold_health` detects these degenerate folds but does not prevent the trading). The likely design intent is warmup = indicators only; this flag lets a spec test that semantics.

## Files

- `trading/trading/backtest/warmup_gate/lib/warmup_trade_gate.{ml,mli}` — new micro-lib: pure `filter_transitions` (drops `CreateEntering` dated `< start_date`) + `wrap_strategy`.
- `trading/trading/backtest/warmup_gate/lib/dune`, `.../test/{dune,test_warmup_trade_gate.ml}` — lib + 7 unit tests.
- `trading/trading/backtest/lib/dune`, `panel_runner.ml` — depend on the micro-lib; wire `Warmup_trade_gate.wrap_strategy` after `Strategy_wrapper.wrap` in `_make_simulator`.
- `trading/trading/weinstein/strategy/lib/weinstein_strategy_config.{ml,mli}`, `weinstein_strategy.mli` — config field + default + docs.
- `trading/trading/backtest/walk_forward/test/test_variant_matrix.ml` — axis test.
- `dev/plans/warmup-trading-flag-2026-06-12.md`, `dev/status/backtest-infra.md`.

## No-op-default argument

`suppress_warmup_trading` defaults to `false`. `Warmup_trade_gate.wrap_strategy` / `filter_transitions` with `suppress = false` short-circuit to the identity on the strategy's output — the same module behaviour, the same transition list, bit-for-bit. Existing sexps that omit the field decode to `false` via `[@sexp.default false]`. No golden / snapshot / scenario decodes or replays differently; `Backtest.Fold_health` signatures fire exactly as before (terminal facts unchanged with the flag off). Verified: `trading/backtest/test/` (panel-loader parity, snapshot-mode parity, determinism, scenario goldens), `trading/backtest/scenarios/`, and `trading/simulation/test/` all green.

## Axis test (R2)

`suppress_warmup_trading` is a top-level `bool` flag, so `Variant_matrix` resolves it by sexp name through `Overlay_validator` with no overlay-validator change (same mechanism as `neutral_blocks_longs`). `test_variant_matrix.ml` asserts `((flag suppress_warmup_trading) (values (true false)))` expands + validates.

## Experiment-flag-discipline

- **R1 default-off:** `[@sexp.default false]`; `false` = prior behaviour, no-op on merge.
- **R2 searchable:** real `Weinstein_strategy.config` field, expressible as a `Variant_matrix` axis (test added).
- **R3 no promotion:** not wired into any default config or preset. Out of scope here: the comparison run quantifying how every baseline shifts with the flag ON, then walk-forward CV + confirmation grid before any default flip.

## Tests

- `test_warmup_trade_gate.ml` (new, 7 cases): no-op at `false`; drop warmup `CreateEntering` (long); inclusive boundary (entry on `start_date` retained); short-side warmup entry dropped; non-entry transitions (exit / risk-param) in warmup never dropped; `wrap_strategy` end-to-end both flag states.
- `test_variant_matrix.ml`: flag axis expands.
- `dune build @fmt`, `dune build` exit 0. Full `dune runtest` was contended in the shared container; every directly-affected dir (`warmup_gate`, `walk_forward`, `weinstein/strategy`) plus the no-op parity/golden/determinism suite (`backtest`, `scenarios`, `simulation`) verified green.

> Do not modify `dev/status/_index.md` from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
