### PR TITLE
fix(simulation): revert cash-floor-rejected exit fills so stops retry (#1553)

### DIFF
--- a/dev/status/simulation.md
+++ b/dev/status/simulation.md
@@ -1,6 +1,45 @@
 # Status: simulation
 
-## Last updated: 2026-05-22
+## Last updated: 2026-06-12
+
+### 2026-06-12 — exit-fill-reject retry (#1553)
+
+Fixed the cash-floor-rejected exit-fill zombie (issue #1553): a position
+whose stop fired and moved to `Exiting`, but whose cover/sell fill was
+then rejected by the portfolio cash floor, was stranded in `Exiting`
+forever (the stop machinery only re-evaluates `Holding`), so it rode the
+adverse move unbounded (THM short −240% in the Nov-2022 bear).
+
+Three pieces, all simulation/backtest-layer (no core-module edit):
+- **Revert (M):** `Cancel_handler.revert_rejected_exits` reverts an
+  unfilled `Exiting` position back to `Holding` (reconstructed from the
+  `Exiting` state's carried fields, preserving the stop), so the stop
+  re-evaluates next cycle and re-triggers the exit — a natural retry
+  loop. Wired into `Simulator._process_fills_and_cancels` right after the
+  entry-side `transitions_for_rejected_trades`. Partially-filled exits are
+  deliberately not reverted (would desync the portfolio's booked partial
+  cover). Rejected-fill apply/bucket relocated to
+  `Cancel_handler.apply_trades_best_effort` (keeps `simulator.ml` under
+  the file-length limit).
+- **Observability (S):** `apply_trades_best_effort` now emits a loud
+  per-trade `WARN` (symbol/side/qty/price/reason) on every
+  portfolio-rejected fill — no more silent drops.
+- **Fold_health (S):** additive `Stuck_held_positions` finding +
+  `Fold_health.check_divergence` (config-thresholded
+  `max_stuck_held_positions`, default 0) flags portfolio↔strategy
+  divergence (open positions not under stop evaluation). Pure/additive;
+  runner-wiring (threading the strategy position count through
+  `Runner.result`) deferred to a harness follow-up to keep the PR in
+  budget.
+
+Verify: `dune runtest trading/simulation/test trading/backtest/test`
+(7 cancel_handler tests + 12 fold_health tests green).
+Decision items for review (PR body): (1) a core `CancelExit`
+(`Exiting -> Holding`) transition to replace the simulation-layer state
+reconstruction; (2) exempting risk-reducing (closing) trades from the
+portfolio cash floor.
+
+## Last updated (prior): 2026-05-22
 
 ## Status
 IN_PROGRESS

--- a/trading/trading/backtest/lib/fold_health.ml
+++ b/trading/trading/backtest/lib/fold_health.ml
@@ -6,6 +6,7 @@ type config = {
   min_steps_for_check : int;
   flat_equity_min_distinct_ratio : float;
   depleted_abs_return_threshold : float;
+  max_stuck_held_positions : int;
 }
 [@@deriving sexp, eq]
 
@@ -21,17 +22,23 @@ let _default_flat_equity_min_distinct_ratio = 0.05
    the warmup-leak signature. *)
 let _default_depleted_abs_return_threshold = 0.5
 
+(* 0 = every open portfolio position must be accounted for under stop
+   evaluation; any gap is a stuck/zombie position (#1553). *)
+let _default_max_stuck_held_positions = 0
+
 let default_config =
   {
     min_steps_for_check = _default_min_steps_for_check;
     flat_equity_min_distinct_ratio = _default_flat_equity_min_distinct_ratio;
     depleted_abs_return_threshold = _default_depleted_abs_return_threshold;
+    max_stuck_held_positions = _default_max_stuck_held_positions;
   }
 
 type finding =
   | Zero_round_trips_over_long_window of { n_steps : int }
   | Flat_equity_curve of { n_points : int; n_distinct : int }
   | Unexplained_terminal_move of { total_return_pct : float }
+  | Stuck_held_positions of { n_open_positions : int; n_stop_eligible : int }
 [@@deriving sexp, eq]
 
 let _zero_round_trips_msg n_steps =
@@ -52,6 +59,14 @@ let _terminal_move_msg total_return_pct =
      round-trips (likely warmup-window P&L leaked into the measurement window)"
     total_return_pct
 
+let _stuck_held_msg n_open_positions n_stop_eligible =
+  sprintf
+    "portfolio holds %d open position(s) but only %d are under active stop \
+     evaluation: %d unmonitored (likely stuck in Exiting after a rejected exit \
+     fill — see #1553)"
+    n_open_positions n_stop_eligible
+    (n_open_positions - n_stop_eligible)
+
 let finding_to_string = function
   | Zero_round_trips_over_long_window { n_steps } ->
       _zero_round_trips_msg n_steps
@@ -59,6 +74,8 @@ let finding_to_string = function
       _flat_equity_msg n_points n_distinct
   | Unexplained_terminal_move { total_return_pct } ->
       _terminal_move_msg total_return_pct
+  | Stuck_held_positions { n_open_positions; n_stop_eligible } ->
+      _stuck_held_msg n_open_positions n_stop_eligible
 
 (* Distinct count of the equity-curve values, with a float epsilon so two marks
    that differ only by floating noise are treated as the same NAV. *)
@@ -109,6 +126,12 @@ let check ~config ~initial_cash ~final_portfolio_value ~n_round_trips ~n_steps
       _terminal_move_finding ~config ~initial_cash ~final_portfolio_value
         ~n_round_trips;
     ]
+
+let check_divergence ~config ~n_open_positions ~n_stop_eligible =
+  let gap = n_open_positions - n_stop_eligible in
+  if gap > config.max_stuck_held_positions then
+    [ Stuck_held_positions { n_open_positions; n_stop_eligible } ]
+  else []
 
 let has_findings ~config ~initial_cash ~final_portfolio_value ~n_round_trips
     ~n_steps ~equity_curve =

--- a/trading/trading/backtest/lib/fold_health.mli
+++ b/trading/trading/backtest/lib/fold_health.mli
@@ -41,6 +41,17 @@ type config = {
           the starting stake). Combined with zero round-trips and a flat curve,
           a large terminal move that no in-window trade explains is the
           warmup-leak signature. A non-negative fraction. *)
+  max_stuck_held_positions : int;
+      (** Divergence guard (#1553): the largest tolerated gap between the count
+          of {e open portfolio positions} and the count of
+          {e strategy positions still under active stop evaluation}. A position
+          the portfolio holds but the strategy no longer monitors (e.g. stuck in
+          [Exiting] after a rejected exit fill, so the stop machinery — which
+          only re-evaluates [Holding] — never re-fires) is a terminally-stuck
+          zombie that rode an adverse move unbounded. A gap strictly greater
+          than this count trips {!Stuck_held_positions}. Default [0]: every open
+          position must be accounted for under stop evaluation. A non-negative
+          count. *)
 }
 [@@deriving sexp, eq]
 
@@ -48,9 +59,10 @@ val default_config : config
 (** Thresholds calibrated against the A2 repro (2009-06-26 start,
     top-3000-2000): [min_steps_for_check = 60] (≈ a quarter of trading days),
     [flat_equity_min_distinct_ratio = 0.05] (≤5% distinct NAV values = flat),
-    [depleted_abs_return_threshold = 0.5] (≥50% terminal move). These are the
-    defaults the scenario runner uses; callers may override for stricter or
-    looser gating. *)
+    [depleted_abs_return_threshold = 0.5] (≥50% terminal move),
+    [max_stuck_held_positions = 0] (every open position must be under stop
+    evaluation). These are the defaults the scenario runner uses; callers may
+    override for stricter or looser gating. *)
 
 type finding =
   | Zero_round_trips_over_long_window of { n_steps : int }
@@ -68,6 +80,14 @@ type finding =
           [depleted_abs_return_threshold]) while the run also showed zero
           in-window round-trips — i.e. a large P&L swing that no in-window trade
           accounts for (warmup-window leak). *)
+  | Stuck_held_positions of { n_open_positions : int; n_stop_eligible : int }
+      (** Portfolio↔strategy divergence (#1553): the portfolio holds
+          [n_open_positions] open positions but only [n_stop_eligible] of them
+          are under active strategy stop evaluation (the gap exceeds
+          [max_stuck_held_positions]). The unmonitored remainder are terminally
+          stuck — e.g. positions left in [Exiting] after a rejected exit fill,
+          which the stop machinery never re-evaluates — and ride their adverse
+          move unbounded. *)
 [@@deriving sexp, eq]
 
 val finding_to_string : finding -> string
@@ -98,6 +118,24 @@ val check :
       flagged); a non-positive [initial_cash] suppresses it (return is
       undefined). *)
 
+val check_divergence :
+  config:config -> n_open_positions:int -> n_stop_eligible:int -> finding list
+(** [check_divergence ~config ~n_open_positions ~n_stop_eligible] returns a
+    singleton [Stuck_held_positions] finding when
+    [n_open_positions - n_stop_eligible > config.max_stuck_held_positions], else
+    the empty list (#1553). [n_open_positions] is the count of open positions in
+    the end-of-run portfolio; [n_stop_eligible] is the count of strategy
+    positions still under active stop evaluation (in the simulator's terms,
+    positions in the [Holding] state). The two diverge exactly when a position
+    the portfolio holds is no longer monitored by the strategy — the
+    stuck-[Exiting] zombie signature.
+
+    Kept separate from {!check} because the divergence inputs (the two position
+    counts) come from the end-of-run portfolio + strategy state rather than the
+    summary/equity-curve facts {!check} reads. Callers union the two finding
+    lists. A negative gap (more eligible than open — should not occur) never
+    trips. *)
+
 val has_findings :
   config:config ->
   initial_cash:float ->
@@ -107,4 +145,5 @@ val has_findings :
   equity_curve:float list ->
   bool
 (** [has_findings ...] is [not (List.is_empty (check ...))] — a convenience for
-    callers that only need the boolean "is this fold suspect?". *)
+    callers that only need the boolean "is this fold suspect?". Covers only the
+    {!check} invariants, not {!check_divergence}. *)

--- a/trading/trading/backtest/test/test_fold_health.ml
+++ b/trading/trading/backtest/test/test_fold_health.ml
@@ -147,6 +147,38 @@ let test_has_findings_false_when_healthy _ =
   in
   assert_that suspect (equal_to false)
 
+(* #1553 divergence guard: portfolio holds more open positions than the strategy
+   monitors under stop evaluation. The default [max_stuck_held_positions = 0]
+   means any positive gap trips a single [Stuck_held_positions] finding. *)
+let test_check_divergence_fires_on_gap _ =
+  let findings =
+    FH.check_divergence ~config:cfg ~n_open_positions:24 ~n_stop_eligible:23
+  in
+  assert_that findings
+    (elements_are
+       [
+         equal_to
+           (FH.Stuck_held_positions
+              { n_open_positions = 24; n_stop_eligible = 23 });
+       ])
+
+(* No gap (every open position is under stop evaluation): silent. *)
+let test_check_divergence_silent_when_aligned _ =
+  let findings =
+    FH.check_divergence ~config:cfg ~n_open_positions:10 ~n_stop_eligible:10
+  in
+  assert_that findings (size_is 0)
+
+(* A wider tolerance suppresses a small gap: gap of 1 with
+   [max_stuck_held_positions = 1] does not fire (boundary is strict-greater). *)
+let test_check_divergence_respects_tolerance _ =
+  let findings =
+    FH.check_divergence
+      ~config:{ cfg with max_stuck_held_positions = 1 }
+      ~n_open_positions:11 ~n_stop_eligible:10
+  in
+  assert_that findings (size_is 0)
+
 let suite =
   "fold_health"
   >::: [
@@ -164,6 +196,11 @@ let suite =
          "has_findings_mirrors_check" >:: test_has_findings_mirrors_check;
          "has_findings_false_when_healthy"
          >:: test_has_findings_false_when_healthy;
+         "check_divergence_fires_on_gap" >:: test_check_divergence_fires_on_gap;
+         "check_divergence_silent_when_aligned"
+         >:: test_check_divergence_silent_when_aligned;
+         "check_divergence_respects_tolerance"
+         >:: test_check_divergence_respects_tolerance;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/simulation/lib/cancel_handler.ml
+++ b/trading/trading/simulation/lib/cancel_handler.ml
@@ -1,4 +1,4 @@
-(** Cancel-entry transition builder + applier — see [cancel_handler.mli]. *)
+(** Cancel/revert transition builder + applier — see [cancel_handler.mli]. *)
 
 open Core
 module Position = Trading_strategy.Position
@@ -45,3 +45,91 @@ let apply_to_positions positions trans =
       let key = trans.position_id in
       if Position.is_closed updated then Ok (Map.remove positions key)
       else Ok (Map.set positions ~key ~data:updated)
+
+(** Reconstruct the [Holding] state from an [Exiting] position's carried fields
+    (quantity, entry price/date, risk params), so the position resumes stop
+    monitoring on its full pre-exit quantity. Returns [None] for any
+    non-[Exiting] state.
+
+    The core [Position] state machine has no [Exiting -> Holding] transition —
+    an asymmetry vs the entry side, where [CancelEntry] exists. We reconstruct
+    the [Holding] state here from the exposed [position_state] rather than add a
+    core transition variant, keeping the fix at the simulation layer (A1). A
+    future [CancelExit] core transition would let exit reversion route through
+    [apply_to_positions] like [CancelEntry]; see the cancel_handler.mli note. *)
+let _holding_from_exiting ~date (pos : Position.t) : Position.t option =
+  match pos.state with
+  | Exiting { quantity; entry_price; entry_date; risk_params; _ } ->
+      let state =
+        Position.Holding { quantity; entry_price; entry_date; risk_params }
+      in
+      Some { pos with state; last_updated = date }
+  | _ -> None
+
+(** True if [pos] is in the [Exiting] state for [symbol] with no partial fills
+    yet — the stuck-exit signature. A partially-filled exit is deliberately NOT
+    reverted: reverting would resurrect a [Holding] at the full pre-exit
+    quantity while the portfolio already booked the partial cover, desyncing
+    strategy and portfolio. Partial-fill recovery is out of scope; the common
+    (zero-fill) cash-floor rejection is what this handler targets. *)
+let _is_unfilled_exiting_for_symbol ~symbol (pos : Position.t) =
+  match pos.state with
+  | Exiting { filled_quantity; _ } ->
+      String.equal pos.symbol symbol && Float.equal filled_quantity 0.0
+  | _ -> false
+
+(* Revert the first unfilled [Exiting] position matching [symbol] in [acc] back
+   to [Holding], leaving [acc] unchanged when there is no such match. *)
+let _revert_one ~date ~acc ~symbol =
+  let target =
+    Map.to_alist acc
+    |> List.find ~f:(fun (_, pos) ->
+        _is_unfilled_exiting_for_symbol ~symbol pos)
+  in
+  match
+    Option.bind target ~f:(fun (id, pos) ->
+        Option.map (_holding_from_exiting ~date pos) ~f:(fun r -> (id, r)))
+  with
+  | Some (id, reverted) -> Map.set acc ~key:id ~data:reverted
+  | None -> acc
+
+let revert_rejected_exits ~date ~positions ~rejected_trades =
+  List.fold rejected_trades ~init:positions ~f:(fun acc trade ->
+      _revert_one ~date ~acc ~symbol:trade.Trading_base.Types.symbol)
+
+(* Apply one trade to the portfolio; tag it accepted (portfolio booked it) or
+   rejected (carrying the rejection [err] for the WARN). *)
+let _try_apply_trade portfolio trade =
+  match Trading_portfolio.Portfolio.apply_single_trade portfolio trade with
+  | Ok p -> (p, `Accepted trade)
+  | Error err -> (portfolio, `Rejected (trade, err))
+
+(* Loud, per-trade WARN on a portfolio-rejected fill. Silent drops here are how
+   issue #1553's stuck-[Exiting] zombie escaped notice — every rejected fill now
+   names symbol / side / qty / reason on stderr. *)
+let _warn_rejected_trade (trade : Trading_base.Types.trade) err =
+  eprintf
+    "WARN: portfolio rejected fill for %s (side=%s qty=%.4f price=%.4f): %s. \
+     Stranded position will be reverted for retry (see Cancel_handler).\n\
+     %!"
+    trade.symbol
+    (Trading_base.Types.show_side trade.side)
+    trade.quantity trade.price (Status.show err)
+
+(* One fold step: apply [trade] (after the [hook]) and bucket it accepted /
+   rejected, warning loudly on rejection. Extracted to keep the fold body flat
+   (nesting linter). *)
+let _bucket_trade ~hook (portfolio, accepted, rejected) trade =
+  let trade = hook trade in
+  match _try_apply_trade portfolio trade with
+  | portfolio, `Accepted t -> (portfolio, t :: accepted, rejected)
+  | portfolio, `Rejected (t, err) ->
+      _warn_rejected_trade t err;
+      (portfolio, accepted, t :: rejected)
+
+let apply_trades_best_effort ?on_trade_fill portfolio trades =
+  let hook = Option.value on_trade_fill ~default:Fn.id in
+  let portfolio, accepted_rev, rejected_rev =
+    List.fold trades ~init:(portfolio, [], []) ~f:(_bucket_trade ~hook)
+  in
+  (portfolio, List.rev accepted_rev, List.rev rejected_rev)

--- a/trading/trading/simulation/lib/cancel_handler.mli
+++ b/trading/trading/simulation/lib/cancel_handler.mli
@@ -1,18 +1,29 @@
-(** Cancel-entry transition builder + applier — extracted from the simulator so
+(** Cancel/revert transition builder + applier — extracted from the simulator so
     the file stays under its declared-large size limit.
 
-    When a fill is rejected by [Portfolio.apply_single_trade] (typically on
-    insufficient cash from a next-day-open gap-up that exceeds the strategy's
-    sizing headroom), the corresponding [Entering] position stays stuck with 0
-    fills. Strategies whose entry-idempotency check excludes only [Closed] (e.g.
-    BAH's [_has_position_for_symbol]) then never retry. The simulator works
-    around that by emitting a [CancelEntry] transition for each rejected trade
-    so the position transitions to [Closed] and the strategy can retry from a
-    clean slate on the next market close.
+    Handles the two ways a portfolio-rejected fill can strand a strategy
+    position:
 
-    See PR #1172 follow-up §"Option B" for the failure mode this handler
-    surfaces and the BAH gap-buffer fix (#1172) for the related sizing-side
-    workaround that closes the common (small-gap) case. *)
+    {b Entry side ([transitions_for_rejected_trades] + [apply_to_positions]).}
+    When an {e entry} fill is rejected by [Portfolio.apply_single_trade]
+    (typically on insufficient cash from a next-day-open gap-up that exceeds the
+    strategy's sizing headroom), the corresponding [Entering] position stays
+    stuck with 0 fills. Strategies whose entry-idempotency check excludes only
+    [Closed] (e.g. BAH's [_has_position_for_symbol]) then never retry. The
+    simulator works around that by emitting a [CancelEntry] transition for each
+    rejected trade so the position transitions to [Closed] and the strategy can
+    retry from a clean slate on the next market close. See PR #1172 follow-up
+    §"Option B".
+
+    {b Exit side ([revert_rejected_exits]).} The exit-side mirror, added for
+    issue #1553. When an {e exit} (cover/sell) fill is rejected by the portfolio
+    (the same cash floor can reject a short cover in a bear market — NAV with
+    heavy paper losses leaves effective cash below the cover cost), the position
+    is left stranded in [Exiting] forever: the stop machinery only re-evaluates
+    [Holding] positions, so the exit never re-fires and the (often short)
+    position rides the adverse move unbounded. [revert_rejected_exits] reverts
+    each such [Exiting] position back to [Holding], so the stop re-evaluates
+    next cycle and re-triggers the exit — a natural retry loop. *)
 
 open Core
 module Position = Trading_strategy.Position
@@ -40,3 +51,49 @@ val apply_to_positions :
     Returns the original map unchanged when the transition's position_id has no
     entry in [positions] (defensive — same shape as the simulator's
     [_apply_trigger_exit]). *)
+
+val apply_trades_best_effort :
+  ?on_trade_fill:(Trading_base.Types.trade -> Trading_base.Types.trade) ->
+  Trading_portfolio.Portfolio.t ->
+  Trading_base.Types.trade list ->
+  Trading_portfolio.Portfolio.t
+  * Trading_base.Types.trade list
+  * Trading_base.Types.trade list
+(** [apply_trades_best_effort ?on_trade_fill portfolio trades] applies each
+    trade to [portfolio] via [Portfolio.apply_single_trade], returning the
+    resulting [(portfolio, accepted, rejected)] triple (both lists in input
+    order). A portfolio-rejected fill is dropped from the portfolio and bucketed
+    into [rejected] — and a loud per-trade [WARN] (symbol / side / qty / price /
+    reason) is printed to stderr so the rejection is never silent (#1553). The
+    optional [on_trade_fill] hook transforms each trade before it is applied
+    (e.g. fill-date stamping). The caller routes [rejected] through
+    {!transitions_for_rejected_trades} (entry side) and {!revert_rejected_exits}
+    (exit side) to keep stranded positions from sticking. *)
+
+val revert_rejected_exits :
+  date:Date.t ->
+  positions:Position.t String.Map.t ->
+  rejected_trades:Trading_base.Types.trade list ->
+  Position.t String.Map.t
+(** [revert_rejected_exits ~date ~positions ~rejected_trades] reverts each
+    [Exiting] position whose exit fill was rejected back to [Holding], so the
+    stop machinery re-evaluates it next cycle and re-triggers the exit (issue
+    #1553). For each rejected trade it finds the first [Exiting] position
+    matching the trade's symbol {e with [filled_quantity = 0.0]} and rebuilds a
+    [Holding] state from the [Exiting] state's carried fields (quantity, entry
+    price/date, risk params); [last_updated] is set to [date].
+
+    A {e partially} filled [Exiting] position is deliberately left untouched:
+    reverting it would resurrect a [Holding] at the full pre-exit quantity while
+    the portfolio already booked the partial cover, desyncing strategy and
+    portfolio. Rejected trades with no matching unfilled-[Exiting] position are
+    silently skipped (defensive — covers the case where the same symbol's
+    [Entering] rejection is handled by [transitions_for_rejected_trades]).
+
+    No core [Position] transition is used: the state machine has no
+    [Exiting -> Holding] transition (an asymmetry vs the entry side's
+    [CancelEntry]). The [Holding] state is reconstructed here from the exposed
+    [position_state], keeping the fix at the simulation layer. A future
+    [CancelExit] core transition would let this route through
+    [apply_to_positions] like [CancelEntry]; that is a core-module (A1) change
+    deferred to a decision item on #1553. *)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -342,28 +342,6 @@ let _build_run_result t =
       !(t.valuation_failure_count);
   { steps; final_portfolio = t.portfolio; metrics }
 
-(* Apply trades; partition into accepted vs rejected by the portfolio.
-   Rejected trades are routed through {!Cancel_handler} so the
-   corresponding [Entering] positions don't stay stuck forever. See PR
-   #1172 follow-up §"Option B". *)
-let _try_apply_trade portfolio trade =
-  match Trading_portfolio.Portfolio.apply_single_trade portfolio trade with
-  | Ok p -> (p, `Accepted trade)
-  | Error _ -> (portfolio, `Rejected trade)
-
-let _apply_trades_best_effort ?on_trade_fill portfolio trades =
-  let hook = Option.value on_trade_fill ~default:Fn.id in
-  let portfolio, accepted_rev, rejected_rev =
-    List.fold trades ~init:(portfolio, [], [])
-      ~f:(fun (portfolio, accepted, rejected) trade ->
-        let trade = hook trade in
-        let portfolio, outcome = _try_apply_trade portfolio trade in
-        match outcome with
-        | `Accepted t -> (portfolio, t :: accepted, rejected)
-        | `Rejected t -> (portfolio, accepted, t :: rejected))
-  in
-  (portfolio, List.rev accepted_rev, List.rev rejected_rev)
-
 (** Apply split detection, update market state, record stale-held positions, and
     (when configured, default-off) force-exit stale/delisted positions at their
     last close. Returns the post-split / post-force-exit portfolio, positions,
@@ -420,8 +398,8 @@ let _process_fills_and_cancels t ~portfolio ~positions =
   in
   let all_trades = _extract_trades ~date:t.current_date execution_reports in
   let portfolio, trades, rejected_trades =
-    _apply_trades_best_effort ?on_trade_fill:t.deps.on_trade_fill portfolio
-      all_trades
+    Cancel_handler.apply_trades_best_effort ?on_trade_fill:t.deps.on_trade_fill
+      portfolio all_trades
   in
   let%bind positions =
     _update_positions_from_trades ~date:t.current_date ~positions ~trades
@@ -432,6 +410,13 @@ let _process_fills_and_cancels t ~portfolio ~positions =
   in
   let%bind positions =
     _apply_transitions ~positions ~transitions:cancel_transitions
+  in
+  (* Exit-side mirror (#1553): an [Exiting] position whose exit fill was rejected
+     would otherwise stay stuck forever (stops only re-evaluate [Holding]).
+     Revert it to [Holding] so the stop re-fires next cycle. *)
+  let positions =
+    Cancel_handler.revert_rejected_exits ~date:t.current_date ~positions
+      ~rejected_trades
   in
   Ok (portfolio, positions, trades)
 

--- a/trading/trading/simulation/test/test_cancel_handler.ml
+++ b/trading/trading/simulation/test/test_cancel_handler.ml
@@ -1,8 +1,10 @@
-(** Unit tests for {!Cancel_handler} — the bridge that emits [CancelEntry]
-    transitions for fills rejected by the portfolio, so positions don't stay
-    stuck in [Entering] forever. Pins the four contracts from
-    {!Cancel_handler.mli}: matched-symbol emit, no-match drop, Closed-removal,
-    and unknown-id identity. Each contract has one dedicated test below. *)
+(** Unit tests for {!Cancel_handler} — the bridge that handles
+    portfolio-rejected fills so positions don't stay stuck. Pins the entry-side
+    contracts (matched-symbol [CancelEntry] emit, no-match drop, Closed-removal,
+    unknown-id identity) and the exit-side [revert_rejected_exits] contracts
+    (#1553): unfilled [Exiting] reverts to [Holding] preserving the stop,
+    partially-filled [Exiting] is left untouched, and a non-[Exiting] match is a
+    no-op. Each contract has one dedicated test below. *)
 
 open OUnit2
 open Core
@@ -55,6 +57,43 @@ let _make_holding_position ~id ~symbol : Position.t =
             };
         };
     last_updated = _date ~y:2024 ~m:Month.Jan ~d:10;
+    portfolio_lot_ids = [];
+  }
+
+(** Build an [Exiting] position for [symbol] keyed by [id]. [filled_quantity]
+    defaults to 0.0 (the stuck-exit signature #1553 targets); pass a positive
+    value to model a partially-filled exit that must NOT be reverted. The
+    carried [entry_date]/[risk_params] are the fields the revert reconstructs
+    [Holding] from. *)
+let _make_exiting_position ~id ~symbol ?(filled_quantity = 0.0) () : Position.t
+    =
+  {
+    id;
+    symbol;
+    side = Position.Short;
+    entry_reasoning = Position.ManualDecision { description = "test fixture" };
+    exit_reason =
+      Some
+        (Position.StopLoss
+           { stop_price = 0.53; actual_price = 0.55; loss_percent = -2.4 });
+    state =
+      Position.Exiting
+        {
+          quantity = 1000.0;
+          entry_price = 0.72;
+          entry_date = _date ~y:2022 ~m:Month.May ~d:27;
+          target_quantity = 1000.0;
+          exit_price = 0.55;
+          filled_quantity;
+          started_date = _date ~y:2022 ~m:Month.Nov ~d:10;
+          risk_params =
+            {
+              stop_loss_price = Some 0.53;
+              take_profit_price = None;
+              max_hold_days = None;
+            };
+        };
+    last_updated = _date ~y:2022 ~m:Month.Nov ~d:10;
     portfolio_lot_ids = [];
   }
 
@@ -157,6 +196,91 @@ let test_apply_to_positions_unknown_id_is_noop _ =
                  (field (fun (p : Position.t) -> p.symbol) (equal_to "SPY")));
           ]))
 
+(** Contract 5 (#1553): [revert_rejected_exits] reverts an unfilled [Exiting]
+    position whose exit fill was rejected back to [Holding], preserving the
+    pre-exit quantity / entry price / entry date / risk params (so the stop
+    keeps tracking on retry). This is the fix for the stuck-[Exiting] zombie. *)
+let test_revert_rejected_exits_reverts_unfilled_exiting _ =
+  let positions =
+    _positions_with
+      ~entries:[ _make_exiting_position ~id:"THM-pos-1" ~symbol:"THM" () ]
+  in
+  let rejected = [ _make_trade ~symbol:"THM" ] in
+  let positions =
+    Cancel_handler.revert_rejected_exits ~date:_build_date ~positions
+      ~rejected_trades:rejected
+  in
+  assert_that
+    (Map.find positions "THM-pos-1")
+    (is_some_and
+       (field
+          (fun (p : Position.t) -> p.state)
+          (matching ~msg:"Expected Holding after revert"
+             (function
+               | Position.Holding { quantity; entry_price; risk_params; _ } ->
+                   Some (quantity, entry_price, risk_params.stop_loss_price)
+               | _ -> None)
+             (all_of
+                [
+                  field (fun (q, _, _) -> q) (float_equal 1000.0);
+                  field (fun (_, ep, _) -> ep) (float_equal 0.72);
+                  field
+                    (fun (_, _, stop) -> stop)
+                    (is_some_and (float_equal 0.53));
+                ]))))
+
+(** Contract 6 (#1553): a {e partially} filled [Exiting] position is NOT
+    reverted — reverting would resurrect a [Holding] at the full pre-exit
+    quantity while the portfolio already booked the partial cover. The position
+    stays [Exiting]. *)
+let test_revert_rejected_exits_skips_partially_filled _ =
+  let positions =
+    _positions_with
+      ~entries:
+        [
+          _make_exiting_position ~id:"THM-pos-1" ~symbol:"THM"
+            ~filled_quantity:300.0 ();
+        ]
+  in
+  let rejected = [ _make_trade ~symbol:"THM" ] in
+  let positions =
+    Cancel_handler.revert_rejected_exits ~date:_build_date ~positions
+      ~rejected_trades:rejected
+  in
+  assert_that
+    (Map.find positions "THM-pos-1")
+    (is_some_and
+       (field
+          (fun (p : Position.t) -> p.state)
+          (matching ~msg:"Expected position to stay Exiting"
+             (function
+               | Position.Exiting { filled_quantity; _ } -> Some filled_quantity
+               | _ -> None)
+             (float_equal 300.0))))
+
+(** Contract 7 (#1553): a rejected trade whose symbol matches only a [Holding]
+    (not [Exiting]) position is a no-op — the map is returned unchanged. Guards
+    against reverting positions that were never exiting. *)
+let test_revert_rejected_exits_ignores_non_exiting _ =
+  let positions =
+    _positions_with
+      ~entries:[ _make_holding_position ~id:"SPY-pos-1" ~symbol:"SPY" ]
+  in
+  let rejected = [ _make_trade ~symbol:"SPY" ] in
+  let positions =
+    Cancel_handler.revert_rejected_exits ~date:_build_date ~positions
+      ~rejected_trades:rejected
+  in
+  assert_that
+    (Map.find positions "SPY-pos-1")
+    (is_some_and
+       (field
+          (fun (p : Position.t) -> p.state)
+          (matching ~msg:"Expected Holding unchanged"
+             (function
+               | Position.Holding { quantity; _ } -> Some quantity | _ -> None)
+             (float_equal 100.0))))
+
 let suite =
   "Cancel_handler"
   >::: [
@@ -169,6 +293,12 @@ let suite =
          >:: test_apply_to_positions_removes_on_closed;
          "apply_to_positions returns input unchanged for unknown position_id"
          >:: test_apply_to_positions_unknown_id_is_noop;
+         "revert_rejected_exits reverts an unfilled Exiting position to Holding"
+         >:: test_revert_rejected_exits_reverts_unfilled_exiting;
+         "revert_rejected_exits skips a partially-filled Exiting position"
+         >:: test_revert_rejected_exits_skips_partially_filled;
+         "revert_rejected_exits ignores a non-Exiting (Holding) position"
+         >:: test_revert_rejected_exits_ignores_non_exiting;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/simulation/test/test_simulator_cost_model.ml
+++ b/trading/trading/simulation/test/test_simulator_cost_model.ml
@@ -3,7 +3,8 @@
     Three variants exercise the wiring contract:
 
     1. [on_trade_fill = None] — byte-equal to the pre-PR baseline (the
-    [_apply_trades_best_effort] path takes the identity branch). 2.
+    [Cancel_handler.apply_trades_best_effort] path takes the identity branch).
+    2.
     [on_trade_fill = Some Cost_model.apply_per_trade_commission retail_default]
     — [retail_default.per_trade_commission = 0.0], so cash matches the baseline
     byte-for-byte even though the hook is wired. 3.


### PR DESCRIPTION
## Fix #1553 — cash-floor-rejected exit fill no longer strands a position in `Exiting` forever

Closes #1553.

### The bug

A position whose stop fired (→ `Exiting`, cover/sell order submitted) but whose
exit fill was then **rejected by the portfolio cash floor** was left stranded in
`Exiting` forever. The stop machinery (`Stops_runner._process_stop`) only
re-evaluates `Holding` positions, so the exit never re-fired; `held_symbols`
blocked re-entry. The THM short in the Nov-2022 bear rode 0.69 → 2.35 (−240%).
This is the silent third failure class from the issue investigation:
registered → fired → **exit-fill rejected → no retry, no revert, no log**.

PR #1172 (Option B) fixed the *entry* side (`CancelEntry` for rejected entry
fills); this PR adds the missing *exit*-side mirror.

### Three pieces (all simulation / backtest layer — no core-module edit)

**(1) Revert [M] — `Cancel_handler.revert_rejected_exits`.**
Reverts an unfilled `Exiting` position back to `Holding`, reconstructed from the
`Exiting` state's carried fields (quantity, entry price/date, risk params — so
the stop is preserved). The stop re-evaluates next cycle and re-triggers the
exit: a natural retry loop. Wired into `Simulator._process_fills_and_cancels`
right after the entry-side `transitions_for_rejected_trades`.
- Partially-filled `Exiting` positions are deliberately **not** reverted (would
  resurrect a `Holding` at the full pre-exit quantity while the portfolio
  already booked the partial cover). Out of scope; the common (zero-fill)
  cash-floor rejection is what this targets.

**(2) Observability [S] — WARN on dropped fills.**
The rejected-fill apply/bucket path (relocated from `simulator.ml` into
`Cancel_handler.apply_trades_best_effort` to keep `simulator.ml` under the
file-length limit) now emits a loud per-trade stderr `WARN`
(symbol / side / qty / price / reason) on every portfolio-rejected fill. No more
silent drops.

**(3) Fold_health [S] — additive divergence signature.**
New additive `Stuck_held_positions` finding + `Fold_health.check_divergence`
(config-thresholded `max_stuck_held_positions`, default `0`), flagging a
portfolio↔strategy divergence: open positions not under active stop evaluation.
Pure + additive + config-thresholded, matching the existing three signatures.
**Runner-wiring descoped** (see below).

### Tests (TDD)

- `test_cancel_handler.ml` (+3): unfilled `Exiting` reverts to `Holding`
  preserving the stop; partially-filled `Exiting` untouched; non-`Exiting`
  match is a no-op. 7/7 green.
- `test_fold_health.ml` (+3): divergence fires on a gap, silent when aligned,
  respects the tolerance. 12/12 green.
- The relocation of `apply_trades_best_effort` is exercised end-to-end by the
  existing green simulation suite (it sits in the hot `_process_fills_and_cancels`
  path); the new WARN fires correctly in `test_insufficient_cash_trade_is_skipped`.

Verify: `dune runtest trading/simulation/test trading/backtest/test`.

### Golden / scenario shift

No golden re-pin. The revert only changes behaviour on runs that actually hit a
cash-floor-rejected exit fill — a bear-window event the committed goldens do not
contain (`dune runtest` green, no shifts). When a bear-window multi-symbol golden
does exercise this path the shift is correct by construction: a fired stop that
previously rode unbounded now completes via retry, reducing the adverse
excursion. Large/widespread shifts would be reported rather than blanket-re-pinned;
none observed.

### Descoped — harness follow-up

`Fold_health.check_divergence` is pure and tested but **not yet wired into the
scenario runner**: surfacing it needs the count of strategy positions still under
stop evaluation threaded through `Runner.result` / `Summary`, which is real
plumbing across the backtest lib and would push this PR past budget. The
signature + function land now so the runner wiring is a small additive change
later.

### Decision items for reviewers (NOT executed here — core-module A1)

1. **Core `CancelExit` (`Exiting → Holding`) transition** mirroring the entry
   side's `CancelEntry`. Touches `trading/strategy/lib/position.ml` (core, A1),
   so proposed rather than executed: this PR reconstructs `Holding` from the
   exposed `position_state` at the simulation layer instead. If approved,
   `revert_rejected_exits` would route through `apply_to_positions` like
   `CancelEntry`.
2. **Exempt risk-reducing (closing) trades from the portfolio cash floor.**
   Rejecting a short cover for insufficient cash is economically wrong — a real
   broker force-liquidates. A core `Portfolio` semantic change, deliberately
   **not** done here (the cash-floor logic is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
