### PR TITLE
feat(backtest): wire Fold_health.check_divergence into runner (#1557)

### DIFF
--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -64,19 +64,23 @@ Tier 3) tracked separately at `dev/status/incremental-indicators.md`.
     `Holding` state (still under stop evaluation) at end of run, populated in
     `Simulator._build_run_result` via `_count_stop_eligible t.positions`.
     Threaded through `Runner.result.n_stop_eligible_positions` in
-    `_assemble_result`. `Runner.open_position_count` counts
+    `_assemble_result`. `Fold_health_runner.open_position_count` counts
     `final_portfolio.positions` (closed positions already dropped, matching the
-    `open_positions.csv` per-row semantics); `Runner.divergence_findings`
+    `open_positions.csv` per-row semantics); `Fold_health_runner.divergence_findings`
     derives both counts and calls `check_divergence`. `scenario_runner`'s
     `_emit_fold_health` unions the result with the existing `check` findings.
+    The divergence bridge lives in its own tiny lib module
+    `fold_health_runner.{ml,mli}` — extracted from `runner.ml` so both
+    `runner.ml` (493) and `simulator.ml` (500) stay under the 500-line
+    file-length hard limit.
   - **Additive / default-0:** a non-empty divergence finding only WARNs to
     stderr + lands in `fold_health.sexp` (same contract as the #1549 signatures
     — never fails the run). On healthy runs every open position is `Holding`, so
     the count equals the open-position count and the check is silent.
   - **Lives at:** `simulator.ml` (+`simulator_types.{ml,mli}`),
-    `runner.{ml,mli}`, `scenario_runner.ml`.
+    `runner.{ml,mli}`, `fold_health_runner.{ml,mli}` (new), `scenario_runner.ml`.
   - **Tests:** `test_fold_health_runner.ml` (+3, runner path):
-    divergence fires through `Runner.divergence_findings` on a 2-open/1-eligible
+    divergence fires through `Fold_health_runner.divergence_findings` on a 2-open/1-eligible
     gap; silent when aligned (2/2); silent when flat (0/0). Existing 12
     `test_fold_health` pure tests + `test_result_writer` / `test_trade_audit_report`
     (result-fixture field added) stay green.

--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -51,6 +51,38 @@ Tier 3) tracked separately at `dev/status/incremental-indicators.md`.
     baseline shifts with the flag ON, then walk-forward CV + confirmation grid
     before any promotion (P0 analysis step, `experiment-flag-discipline` R3).
 
+## 2026-06-12 — Fold_health divergence runner wiring (#1557 item 1)
+
+- [x] **`Fold_health.check_divergence` wired into the runner path.** PR #1556
+  landed the pure `Stuck_held_positions` finding + `check_divergence`
+  (config-thresholded `max_stuck_held_positions`, default 0) but descoped the
+  runner wiring — nothing fed it the two position counts. This wires it as a
+  tripwire so the finding can fire in real runs (the #1553 THM zombie: portfolio
+  held it, strategy state terminally `Exiting`, stop never re-evaluated).
+  - **Seam (additive, no core-module edit):** `run_result` gains
+    `n_stop_eligible_positions : int` — the count of strategy positions in the
+    `Holding` state (still under stop evaluation) at end of run, populated in
+    `Simulator._build_run_result` via `_count_stop_eligible t.positions`.
+    Threaded through `Runner.result.n_stop_eligible_positions` in
+    `_assemble_result`. `Runner.open_position_count` counts
+    `final_portfolio.positions` (closed positions already dropped, matching the
+    `open_positions.csv` per-row semantics); `Runner.divergence_findings`
+    derives both counts and calls `check_divergence`. `scenario_runner`'s
+    `_emit_fold_health` unions the result with the existing `check` findings.
+  - **Additive / default-0:** a non-empty divergence finding only WARNs to
+    stderr + lands in `fold_health.sexp` (same contract as the #1549 signatures
+    — never fails the run). On healthy runs every open position is `Holding`, so
+    the count equals the open-position count and the check is silent.
+  - **Lives at:** `simulator.ml` (+`simulator_types.{ml,mli}`),
+    `runner.{ml,mli}`, `scenario_runner.ml`.
+  - **Tests:** `test_fold_health_runner.ml` (+3, runner path):
+    divergence fires through `Runner.divergence_findings` on a 2-open/1-eligible
+    gap; silent when aligned (2/2); silent when flat (0/0). Existing 12
+    `test_fold_health` pure tests + `test_result_writer` / `test_trade_audit_report`
+    (result-fixture field added) stay green.
+  - **Verify:** `dune runtest trading/backtest/test trading/simulation/test`.
+  - **Branch:** `feat/fold-health-runner-wiring`. Links #1557.
+
 ## QC
 
 Step 1 (PR #399, merged) — overall_qc APPROVED at e59f8d2 (both prior blockers U6/F1 and the BC4 advisory resolved; `_held_symbols` strategy fix domain-correct).

--- a/trading/trading/backtest/lib/fold_health_runner.ml
+++ b/trading/trading/backtest/lib/fold_health_runner.ml
@@ -1,0 +1,12 @@
+(** Runner-path bridge for the {!Fold_health} divergence guard. See
+    [fold_health_runner.mli]. *)
+
+open Core
+
+let open_position_count (portfolio : Trading_portfolio.Portfolio.t) =
+  List.length portfolio.positions
+
+let divergence_findings ~config (result : Runner.result) =
+  Fold_health.check_divergence ~config
+    ~n_open_positions:(open_position_count result.final_portfolio)
+    ~n_stop_eligible:result.n_stop_eligible_positions

--- a/trading/trading/backtest/lib/fold_health_runner.mli
+++ b/trading/trading/backtest/lib/fold_health_runner.mli
@@ -1,0 +1,26 @@
+(** Runner-path bridge for the {!Fold_health} divergence guard (#1553/#1557).
+
+    {!Fold_health.check_divergence} is pure over two counts; this module derives
+    those counts from a completed {!Runner.result} and surfaces the finding.
+    Kept out of {!Runner} itself so the wiring (open-position counting +
+    divergence union) has its own home and {!Runner} stays at its module
+    boundary. *)
+
+val open_position_count : Trading_portfolio.Portfolio.t -> int
+(** Count of open positions in [portfolio] — the length of
+    [portfolio.positions]. Fully-closed positions are already dropped from that
+    list by {!Trading_portfolio.Portfolio.apply_trades}, so every element is a
+    genuinely-open position (matching the per-row semantics
+    {!Reconciler_writer.write_open_positions} uses for [open_positions.csv]). *)
+
+val divergence_findings :
+  config:Fold_health.config -> Runner.result -> Fold_health.finding list
+(** [divergence_findings ~config result] runs {!Fold_health.check_divergence}
+    over [result] — deriving the open-position count from
+    [result.final_portfolio] via {!open_position_count} and the stop-eligible
+    count from [result.n_stop_eligible_positions]. Returns a singleton
+    [Stuck_held_positions] finding when the portfolio holds more open positions
+    than the strategy still monitors under stop evaluation (the gap exceeds
+    [config.max_stuck_held_positions]), else the empty list (#1553). The
+    runner-path bridge the scenario runner unions with the {!Fold_health.check}
+    findings; additive and purely diagnostic. *)

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -65,17 +65,6 @@ type result = {
           picked). *)
 }
 
-(* Divergence guard (#1553): open portfolio positions vs strategy positions
-   still under stop evaluation. Fully-closed positions are already dropped from
-   [portfolio.positions], so its length is the open-position count. *)
-let open_position_count (portfolio : Trading_portfolio.Portfolio.t) =
-  List.length portfolio.positions
-
-let divergence_findings ~config result =
-  Fold_health.check_divergence ~config
-    ~n_open_positions:(open_position_count result.final_portfolio)
-    ~n_stop_eligible:result.n_stop_eligible_positions
-
 (* Trading-day filter *)
 
 (** True if [step] represents a real trading day — i.e. the simulator saw at

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -40,6 +40,7 @@ type result = {
   round_trips : Metrics.trade_metrics list;
   steps : Trading_simulation_types.Simulator_types.step_result list;
   final_portfolio : Trading_portfolio.Portfolio.t;
+  n_stop_eligible_positions : int;
   overrides : Sexp.t list;
   stop_infos : Stop_log.stop_info list;
   audit : Trade_audit.audit_record list;
@@ -63,6 +64,17 @@ type result = {
           ~10k-symbol set, which over-states what the strategy could have
           picked). *)
 }
+
+(* Divergence guard (#1553): open portfolio positions vs strategy positions
+   still under stop evaluation. Fully-closed positions are already dropped from
+   [portfolio.positions], so its length is the open-position count. *)
+let open_position_count (portfolio : Trading_portfolio.Portfolio.t) =
+  List.length portfolio.positions
+
+let divergence_findings ~config result =
+  Fold_health.check_divergence ~config
+    ~n_open_positions:(open_position_count result.final_portfolio)
+    ~n_stop_eligible:result.n_stop_eligible_positions
 
 (* Trading-day filter *)
 
@@ -455,6 +467,7 @@ let _assemble_result ~start_date ~end_date ~deps ~overrides ~sim_result
     round_trips;
     steps;
     final_portfolio;
+    n_stop_eligible_positions = sim_result.n_stop_eligible_positions;
     overrides;
     stop_infos;
     audit;

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -55,6 +55,14 @@ type result = {
           {!Portfolio_summary.t} projection that omits these details to keep
           [step_history] memory bounded; reconciler consumers must read this
           field instead. *)
+  n_stop_eligible_positions : int;
+      (** Count of strategy positions still under active stop evaluation (in the
+          [Holding] state) at the end of the run, threaded straight through from
+          {!Trading_simulation_types.Simulator_types.run_result}. Paired with
+          the open-position count of [final_portfolio] by {!divergence_findings}
+          to surface the portfolio↔strategy divergence the stuck-[Exiting]
+          zombie produces (#1553). In a healthy run this equals the
+          open-position count and the divergence check is silent. *)
   overrides : Sexp.t list;
       (** The override sexps used for this run, echoed into params.sexp *)
   stop_infos : Stop_log.stop_info list;
@@ -110,6 +118,26 @@ type result = {
           ~10k-symbol set, which over-states what the strategy could have
           picked). *)
 }
+
+val open_position_count : Trading_portfolio.Portfolio.t -> int
+(** Count of open positions in [portfolio] — the length of
+    [portfolio.positions]. Fully-closed positions are already dropped from that
+    list by {!Trading_portfolio.Portfolio.apply_trades}, so every element is a
+    genuinely-open position (matching the per-row semantics
+    {!Reconciler_writer.write_open_positions} uses for [open_positions.csv]).
+    Exposed for the divergence check ({!divergence_findings}) and its tests. *)
+
+val divergence_findings :
+  config:Fold_health.config -> result -> Fold_health.finding list
+(** [divergence_findings ~config result] runs {!Fold_health.check_divergence}
+    over [result] — deriving the open-position count from
+    [result.final_portfolio] via {!open_position_count} and the stop-eligible
+    count from [result.n_stop_eligible_positions]. Returns a singleton
+    [Stuck_held_positions] finding when the portfolio holds more open positions
+    than the strategy still monitors under stop evaluation (the gap exceeds
+    [config.max_stuck_held_positions]), else the empty list (#1553). The
+    runner-path bridge the scenario runner unions with the {!Fold_health.check}
+    findings; additive and purely diagnostic. *)
 
 val filter_stop_infos_in_window :
   Stop_log.stop_info list -> start_date:Date.t -> Stop_log.stop_info list

--- a/trading/trading/backtest/lib/runner.mli
+++ b/trading/trading/backtest/lib/runner.mli
@@ -119,26 +119,6 @@ type result = {
           picked). *)
 }
 
-val open_position_count : Trading_portfolio.Portfolio.t -> int
-(** Count of open positions in [portfolio] — the length of
-    [portfolio.positions]. Fully-closed positions are already dropped from that
-    list by {!Trading_portfolio.Portfolio.apply_trades}, so every element is a
-    genuinely-open position (matching the per-row semantics
-    {!Reconciler_writer.write_open_positions} uses for [open_positions.csv]).
-    Exposed for the divergence check ({!divergence_findings}) and its tests. *)
-
-val divergence_findings :
-  config:Fold_health.config -> result -> Fold_health.finding list
-(** [divergence_findings ~config result] runs {!Fold_health.check_divergence}
-    over [result] — deriving the open-position count from
-    [result.final_portfolio] via {!open_position_count} and the stop-eligible
-    count from [result.n_stop_eligible_positions]. Returns a singleton
-    [Stuck_held_positions] finding when the portfolio holds more open positions
-    than the strategy still monitors under stop evaluation (the gap exceeds
-    [config.max_stuck_held_positions]), else the empty list (#1553). The
-    runner-path bridge the scenario runner unions with the {!Fold_health.check}
-    findings; additive and purely diagnostic. *)
-
 val filter_stop_infos_in_window :
   Stop_log.stop_info list -> start_date:Date.t -> Stop_log.stop_info list
 (** Drop [stop_info]s whose [entry_date] is before [start_date] — i.e. positions

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -284,7 +284,7 @@ let _emit_fold_health ~scenario_dir ~(result : Backtest.Runner.result) =
     (* Divergence guard (#1553): a position the portfolio holds but the strategy
        no longer monitors under stop evaluation (stuck-[Exiting] zombie). Unioned
        with the [check] invariants; in a healthy run this adds nothing. *)
-    @ Backtest.Runner.divergence_findings ~config result
+    @ Backtest.Fold_health_runner.divergence_findings ~config result
   in
   List.iter findings ~f:(fun f ->
       eprintf "WARN: fold-health: %s\n%!"

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -275,12 +275,16 @@ let _emit_fold_health ~scenario_dir ~(result : Backtest.Runner.result) =
       ~f:(fun (st : Trading_simulation_types.Simulator_types.step_result) ->
         st.portfolio_value)
   in
+  let config = Backtest.Fold_health.default_config in
   let findings =
-    Backtest.Fold_health.check ~config:Backtest.Fold_health.default_config
-      ~initial_cash:summary.initial_cash
+    Backtest.Fold_health.check ~config ~initial_cash:summary.initial_cash
       ~final_portfolio_value:summary.final_portfolio_value
       ~n_round_trips:summary.n_round_trips ~n_steps:summary.n_steps
       ~equity_curve
+    (* Divergence guard (#1553): a position the portfolio holds but the strategy
+       no longer monitors under stop evaluation (stuck-[Exiting] zombie). Unioned
+       with the [check] invariants; in a healthy run this adds nothing. *)
+    @ Backtest.Runner.divergence_findings ~config result
   in
   List.iter findings ~f:(fun f ->
       eprintf "WARN: fold-health: %s\n%!"

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -27,7 +27,8 @@
   test_bah_runner_e2e
   test_macro_trend_writer
   test_csv_snapshot_builder_cleanup
-  test_fold_health)
+  test_fold_health
+  test_fold_health_runner)
  (libraries
   ounit2
   core

--- a/trading/trading/backtest/test/test_fold_health_runner.ml
+++ b/trading/trading/backtest/test/test_fold_health_runner.ml
@@ -1,8 +1,9 @@
 (** Runner-path tests for the {!Backtest.Fold_health} divergence guard (#1557
-    item 1). Exercises the wiring that {!Backtest.Runner.divergence_findings}
-    threads — open portfolio positions ([final_portfolio]) vs strategy positions
-    still under stop evaluation ([n_stop_eligible_positions]) — rather than the
-    pure {!Backtest.Fold_health.check_divergence} (already pinned by
+    item 1). Exercises the wiring that
+    {!Backtest.Fold_health_runner.divergence_findings} threads — open portfolio
+    positions ([final_portfolio]) vs strategy positions still under stop
+    evaluation ([n_stop_eligible_positions]) — rather than the pure
+    {!Backtest.Fold_health.check_divergence} (already pinned by
     [test_fold_health.ml]).
 
     The motivating specimen (#1553): a position the portfolio holds whose
@@ -68,7 +69,7 @@ let _empty_summary : Backtest.Summary.t =
 (** [Runner.result] with [n_open] open portfolio positions and [n_stop_eligible]
     strategy positions still under stop evaluation. Only the two divergence
     inputs are meaningful; the remaining fields are empty since
-    {!Backtest.Runner.divergence_findings} reads none of them. *)
+    {!Backtest.Fold_health_runner.divergence_findings} reads none of them. *)
 let _make_result ~n_open ~n_stop_eligible : Backtest.Runner.result =
   let positions =
     List.init n_open ~f:(fun i -> _make_position ~symbol:(sprintf "SYM%d" i))
@@ -97,10 +98,10 @@ let config = Backtest.Fold_health.default_config
 let test_divergence_fires_through_runner _ =
   let result = _make_result ~n_open:2 ~n_stop_eligible:1 in
   assert_that
-    (Backtest.Runner.open_position_count result.final_portfolio)
+    (Backtest.Fold_health_runner.open_position_count result.final_portfolio)
     (equal_to 2);
   assert_that
-    (Backtest.Runner.divergence_findings ~config result)
+    (Backtest.Fold_health_runner.divergence_findings ~config result)
     (elements_are
        [
          equal_to
@@ -112,12 +113,16 @@ let test_divergence_fires_through_runner _ =
    The tripwire stays quiet on healthy runs. *)
 let test_no_divergence_when_aligned _ =
   let result = _make_result ~n_open:2 ~n_stop_eligible:2 in
-  assert_that (Backtest.Runner.divergence_findings ~config result) (size_is 0)
+  assert_that
+    (Backtest.Fold_health_runner.divergence_findings ~config result)
+    (size_is 0)
 
 (* No open positions and none eligible → trivially aligned → silent. *)
 let test_no_divergence_when_flat _ =
   let result = _make_result ~n_open:0 ~n_stop_eligible:0 in
-  assert_that (Backtest.Runner.divergence_findings ~config result) (size_is 0)
+  assert_that
+    (Backtest.Fold_health_runner.divergence_findings ~config result)
+    (size_is 0)
 
 let suite =
   "fold_health_runner"

--- a/trading/trading/backtest/test/test_fold_health_runner.ml
+++ b/trading/trading/backtest/test/test_fold_health_runner.ml
@@ -1,0 +1,131 @@
+(** Runner-path tests for the {!Backtest.Fold_health} divergence guard (#1557
+    item 1). Exercises the wiring that {!Backtest.Runner.divergence_findings}
+    threads — open portfolio positions ([final_portfolio]) vs strategy positions
+    still under stop evaluation ([n_stop_eligible_positions]) — rather than the
+    pure {!Backtest.Fold_health.check_divergence} (already pinned by
+    [test_fold_health.ml]).
+
+    The motivating specimen (#1553): a position the portfolio holds whose
+    strategy state is terminally [Exiting] after a rejected exit fill — the stop
+    machinery only re-evaluates [Holding], so it rode an adverse move unbounded.
+    The runner surfaces it as the gap between the two counts.
+
+    - {b Firing}: a [Runner.result] with two open portfolio positions but only
+      one stop-eligible → [open_position_count = 2] and a single
+      [Stuck_held_positions { n_open_positions = 2; n_stop_eligible = 1 }]
+      finding.
+    - {b Healthy}: two open positions, two stop-eligible → no divergence finding
+      (the default-0 tolerance is exactly met, gap = 0). *)
+
+open OUnit2
+open Core
+open Matchers
+
+let _date = Date.create_exn ~y:2024 ~m:Month.Jan ~d:15
+
+(** Single-lot open position keyed by [symbol]. Quantity is positive (long); the
+    divergence guard counts positions, not direction. *)
+let _make_position ~symbol : Trading_portfolio.Types.portfolio_position =
+  {
+    symbol;
+    accounting_method = Trading_portfolio.Types.AverageCost;
+    lots =
+      [
+        {
+          lot_id = symbol ^ "-1";
+          quantity = 100.0;
+          cost_basis = 5_000.0;
+          acquisition_date = _date;
+        };
+      ];
+  }
+
+let _make_portfolio ~positions : Trading_portfolio.Portfolio.t =
+  {
+    initial_cash = 100_000.0;
+    trade_history = [];
+    current_cash = 50_000.0;
+    positions;
+    accounting_method = Trading_portfolio.Types.AverageCost;
+    unrealized_pnl_per_position = [];
+    locked_collateral = 0.0;
+    accrued_borrow_fee = 0.0;
+  }
+
+let _empty_summary : Backtest.Summary.t =
+  {
+    start_date = _date;
+    end_date = _date;
+    universe_size = 1;
+    n_steps = 0;
+    initial_cash = 100_000.0;
+    final_portfolio_value = 100_000.0;
+    n_round_trips = 0;
+    stale_held_symbols = [];
+    metrics = Trading_simulation_types.Metric_types.empty;
+  }
+
+(** [Runner.result] with [n_open] open portfolio positions and [n_stop_eligible]
+    strategy positions still under stop evaluation. Only the two divergence
+    inputs are meaningful; the remaining fields are empty since
+    {!Backtest.Runner.divergence_findings} reads none of them. *)
+let _make_result ~n_open ~n_stop_eligible : Backtest.Runner.result =
+  let positions =
+    List.init n_open ~f:(fun i -> _make_position ~symbol:(sprintf "SYM%d" i))
+  in
+  {
+    summary = _empty_summary;
+    round_trips = [];
+    steps = [];
+    final_portfolio = _make_portfolio ~positions;
+    n_stop_eligible_positions = n_stop_eligible;
+    overrides = [];
+    stop_infos = [];
+    audit = [];
+    cascade_summaries = [];
+    force_liquidations = [];
+    stale_holds = [];
+    final_prices = [];
+    universe = [];
+  }
+
+let config = Backtest.Fold_health.default_config
+
+(* A held position the strategy no longer monitors (stuck-[Exiting] zombie) →
+   open count exceeds stop-eligible count → the divergence finding fires through
+   the runner bridge. *)
+let test_divergence_fires_through_runner _ =
+  let result = _make_result ~n_open:2 ~n_stop_eligible:1 in
+  assert_that
+    (Backtest.Runner.open_position_count result.final_portfolio)
+    (equal_to 2);
+  assert_that
+    (Backtest.Runner.divergence_findings ~config result)
+    (elements_are
+       [
+         equal_to
+           (Backtest.Fold_health.Stuck_held_positions
+              { n_open_positions = 2; n_stop_eligible = 1 });
+       ])
+
+(* Every open position is [Holding] (under stop evaluation) → no gap → silent.
+   The tripwire stays quiet on healthy runs. *)
+let test_no_divergence_when_aligned _ =
+  let result = _make_result ~n_open:2 ~n_stop_eligible:2 in
+  assert_that (Backtest.Runner.divergence_findings ~config result) (size_is 0)
+
+(* No open positions and none eligible → trivially aligned → silent. *)
+let test_no_divergence_when_flat _ =
+  let result = _make_result ~n_open:0 ~n_stop_eligible:0 in
+  assert_that (Backtest.Runner.divergence_findings ~config result) (size_is 0)
+
+let suite =
+  "fold_health_runner"
+  >::: [
+         "divergence fires through runner"
+         >:: test_divergence_fires_through_runner;
+         "no divergence when aligned" >:: test_no_divergence_when_aligned;
+         "no divergence when flat" >:: test_no_divergence_when_flat;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -93,7 +93,7 @@ let _make_result ?(steps = []) ?(final_prices = []) ?(stop_infos = [])
     steps;
     final_portfolio;
     n_stop_eligible_positions =
-      Backtest.Runner.open_position_count final_portfolio;
+      Backtest.Fold_health_runner.open_position_count final_portfolio;
     overrides = [];
     stop_infos;
     audit = [];

--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -92,6 +92,8 @@ let _make_result ?(steps = []) ?(final_prices = []) ?(stop_infos = [])
     round_trips;
     steps;
     final_portfolio;
+    n_stop_eligible_positions =
+      Backtest.Runner.open_position_count final_portfolio;
     overrides = [];
     stop_infos;
     audit = [];
@@ -665,6 +667,7 @@ let test_trades_csv_populates_context_from_audit_and_stop_log _ =
       steps = [];
       final_portfolio =
         Trading_portfolio.Portfolio.create ~initial_cash:100_000.0 ();
+      n_stop_eligible_positions = 0;
       overrides = [];
       stop_infos = [ stop_info ];
       audit;

--- a/trading/trading/backtest/test/test_trade_audit_report.ml
+++ b/trading/trading/backtest/test/test_trade_audit_report.ml
@@ -662,6 +662,7 @@ let _make_runner_result ~start_date ~end_date ~round_trips :
     steps = [];
     final_portfolio =
       Trading_portfolio.Portfolio.create ~initial_cash:10_000.0 ();
+    n_stop_eligible_positions = 0;
     overrides = [];
     stop_infos = [];
     audit = [];

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -276,12 +276,8 @@ let _is_holding_state = function
   | Trading_strategy.Position.Holding _ -> true
   | _ -> false
 
-(* Count strategy positions still under active stop evaluation — i.e. in the
-   [Holding] state. The stop machinery only re-evaluates [Holding] positions, so
-   a held portfolio position whose strategy state is not [Holding] (e.g. stuck
-   in [Exiting] after a rejected exit fill) is no longer monitored (#1553).
-   Surfaced via [run_result.n_stop_eligible_positions] for the divergence
-   guard. *)
+(* Count [Holding] positions = those still under stop evaluation; surfaced as
+   [run_result.n_stop_eligible_positions] for the divergence guard (#1553). *)
 let _count_stop_eligible positions =
   Map.count positions ~f:(fun pos ->
       _is_holding_state (Trading_strategy.Position.get_state pos))

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -272,6 +272,20 @@ let _is_exiting_state = function
   | Trading_strategy.Position.Exiting _ -> true
   | _ -> false
 
+let _is_holding_state = function
+  | Trading_strategy.Position.Holding _ -> true
+  | _ -> false
+
+(* Count strategy positions still under active stop evaluation — i.e. in the
+   [Holding] state. The stop machinery only re-evaluates [Holding] positions, so
+   a held portfolio position whose strategy state is not [Holding] (e.g. stuck
+   in [Exiting] after a rejected exit fill) is no longer monitored (#1553).
+   Surfaced via [run_result.n_stop_eligible_positions] for the divergence
+   guard. *)
+let _count_stop_eligible positions =
+  Map.count positions ~f:(fun pos ->
+      _is_holding_state (Trading_strategy.Position.get_state pos))
+
 let _find_fill_target acc symbol =
   let try_find state_match is_entry =
     _find_position_by_symbol_state acc ~symbol ~state_match
@@ -340,7 +354,12 @@ let _build_run_result t =
        coverage gaps.\n\
        %!"
       !(t.valuation_failure_count);
-  { steps; final_portfolio = t.portfolio; metrics }
+  {
+    steps;
+    final_portfolio = t.portfolio;
+    n_stop_eligible_positions = _count_stop_eligible t.positions;
+    metrics;
+  }
 
 (** Apply split detection, update market state, record stale-held positions, and
     (when configured, default-off) force-exit stale/delisted positions at their

--- a/trading/trading/simulation/lib/types/simulator_types.ml
+++ b/trading/trading/simulation/lib/types/simulator_types.ml
@@ -32,6 +32,8 @@ type step_result = {
 type run_result = {
   steps : step_result list;  (** Non-empty list of step results *)
   final_portfolio : Trading_portfolio.Portfolio.t;
+  n_stop_eligible_positions : int;
+      (** Count of strategy positions in the [Holding] state at end of run *)
   metrics : Metric_types.metric_set;
 }
 

--- a/trading/trading/simulation/lib/types/simulator_types.mli
+++ b/trading/trading/simulation/lib/types/simulator_types.mli
@@ -83,6 +83,17 @@ type run_result = {
           end-of-run audits read this rather than reconstructing from
           [step_result.portfolio] (which is the skinny projection). Always
           populated with the simulator's last [t.portfolio]. *)
+  n_stop_eligible_positions : int;
+      (** Count of strategy positions in the [Holding] state at the end of the
+          run — i.e. positions still under active stop evaluation (the stop
+          machinery only re-evaluates [Holding] positions). Compared against the
+          count of open portfolio positions in [final_portfolio] by
+          {!Backtest.Fold_health.check_divergence} (#1553): a position the
+          portfolio holds but that is no longer [Holding] (e.g. stuck in
+          [Exiting] after a rejected exit fill) is a terminally-stuck zombie
+          that rode an adverse move unbounded. In a healthy run every open
+          portfolio position is [Holding], so this equals the open-position
+          count. *)
   metrics : Metric_types.metric_set;  (** Computed metrics from the simulation *)
 }
 (** Complete result of running a simulation with metrics *)


### PR DESCRIPTION
## Wire `Fold_health.check_divergence` into the backtest runner (#1557 item 1)

Follow-up to #1556. That PR landed the pure `Stuck_held_positions` finding +
`Fold_health.check_divergence` (config-thresholded `max_stuck_held_positions`,
default `0`) but **descoped the runner wiring** — nothing fed it the two
position counts, so the finding could never fire in real runs. This wires it as
a tripwire for the portfolio↔strategy divergence the #1553 THM zombie produces:
the portfolio held the position, the strategy state was terminally `Exiting`
(after a rejected exit fill), and the stop machinery — which only re-evaluates
`Holding` — never re-fired.

### Seam (additive, no core-module edit)

The check needs (a) the count of open portfolio positions and (b) the count of
strategy positions still under active stop evaluation (`Holding`). (a) was
already on `Runner.result.final_portfolio`; (b) was internal to the simulator
and not surfaced.

- **`run_result`** (`simulator_types.{ml,mli}`) gains
  `n_stop_eligible_positions : int` — count of strategy positions in the
  `Holding` state at end of run, populated in `Simulator._build_run_result` via
  a new pure `_count_stop_eligible t.positions` helper.
- **`Runner.result`** gains the same field, threaded straight through in
  `_assemble_result` from `sim_result.n_stop_eligible_positions`.
- **`Runner.open_position_count`** counts `final_portfolio.positions`
  (fully-closed positions are already dropped by `Portfolio.apply_trades`, so
  this matches the per-row semantics of `open_positions.csv`).
- **`Runner.divergence_findings ~config result`** derives both counts and calls
  `Fold_health.check_divergence` — the runner-path bridge.
- **`scenario_runner._emit_fold_health`** unions the divergence finding with the
  existing `Fold_health.check` findings.

No core-module (`portfolio`/`orders`/`position`/`strategy`/`engine`) edit. The
`Holding`-count is obtained at the simulation layer from the simulator's
strategy-position map; the decision item to add a core `CancelExit` transition
(#1557 item 2) stays a human decision and is not touched here.

### Additive / default-0 — never fails a run

A non-empty divergence finding only WARNs to stderr (`WARN: fold-health: …`) and
lands in `fold_health.sexp` — the same contract as the #1549 signatures. The
default `max_stuck_held_positions = 0` stays. On healthy runs every open
position is `Holding`, so `n_stop_eligible_positions` equals the open-position
count and the divergence check is silent — exactly what #1556's
Exiting→Holding revert produces. The wiring is a tripwire for residual /
unknown stuck-state classes (e.g. partially-filled exits, which #1556
deliberately does not revert).

### Tests (TDD)

`test_fold_health_runner.ml` (+3, **runner path** — not the bare pure
function): divergence fires through `Runner.divergence_findings` on a
2-open/1-eligible gap (asserts both `open_position_count = 2` and the single
`Stuck_held_positions { n_open_positions = 2; n_stop_eligible = 1 }`); silent
when aligned (2/2); silent when flat (0/0). The existing 12 `test_fold_health`
pure tests stay green; the new mandatory field was added to the
`test_result_writer` / `test_trade_audit_report` result fixtures.

Verify: `dune runtest trading/backtest/test trading/simulation/test` (both
suites green, exit 0).

Links #1557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
