### PR TITLE
fix(backtest): flip suppress_warmup_trading default false->true (measurement-correctness)

### DIFF
--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -12,6 +12,51 @@ moved to its own track at `dev/status/backtest-perf.md`. The 12-step
 incremental-indicators refactor (the follow-on architecture for
 Tier 3) tracked separately at `dev/status/incremental-indicators.md`.
 
+## 2026-06-13 — `suppress_warmup_trading` default flipped false→true (measurement-correctness BUGFIX)
+
+- [x] **Flipped the default `false→true` per USER DIRECTIVE (2026-06-13:
+  "measured window = window only").** This is a **measurement-semantics
+  correction, not an alpha-mechanism promotion** — so `experiment-flag-discipline`
+  R1/R3 (the ledger-ACCEPT gate that governs flipping *alpha* defaults) do
+  **not** apply. The directive: a backtest's measured window must contain only
+  that window's activity — "a 210-day backtest has trades for 210 days, not 420."
+  Warmup exists only to form indicators; trading during it contaminates the
+  measured return with pre-window activity / inherited positions. Default-true
+  makes the number honest; default-false (legacy "running start") is kept as a
+  config escape hatch + searchable axis for reproducing pre-flip baselines and
+  measurement experiments.
+  - **Note vs the merged experiment:** `dev/experiments/warmup-comparison-2026-06-12/ANALYSIS.md`
+    concluded "DO NOT FLIP" on a *performance* axis (suppress lowers WF-CV
+    Sharpe/return/Calmar — warmup trading is a net-beneficial bull "running
+    start"). The user has **explicitly reframed** the flag as a *correctness*
+    invariant, where that very "running start" gain is the contamination to
+    remove (it belongs to the pre-window period). The two are different
+    epistemic objects; the directive governs.
+  - **Lives at:** `weinstein_strategy_config.{ml,mli}` (type field
+    `[@sexp.default true]` + `default_config` initializer `true`),
+    `weinstein_strategy.mli` (mirror field + docstring). Gate code (`Warmup_trade_gate`,
+    `panel_runner.ml`) unchanged — only the default value moved.
+  - **Live path unaffected (verified):** the gate is wired only in
+    `panel_runner.ml` (the backtest path), keyed off the measurement `start_date`,
+    and only drops `CreateEntering` transitions dated *strictly before* it. In
+    live/forward mode `start_date` = "now" and the strategy never emits entries
+    dated in the past, so the gate never fires — default-true is a no-op there.
+  - **Re-pin scale: ZERO goldens re-pinned.** Full `dune build && dune runtest`
+    passes **exit 0** with the flip. This matches the experiment's
+    estimand finding: warmup trading only bites at the **walk-forward fold**
+    level (`warmup_start = fold_start − 210d` sits mid-data with warm
+    indicators); for a **standalone scenario/snapshot golden**, `warmup_start`
+    IS the simulator's first day, so it carries **zero** warmup-built positions
+    into measurement → off == on, bit-identical for every golden in the suite.
+    (The two `trade #0 differs` log lines are the `Test_determinism` start-shift
+    test asserting *expected* divergence — `Ran: 6 tests ... OK`.)
+  - **Test:** `test_weinstein_strategy.ml` +1
+    (`default_config suppresses warmup trading` pins `default_config.suppress_warmup_trading = true`).
+    The existing `warmup_gate` unit tests + the `test_variant_matrix` axis test
+    stay green (gate logic unchanged).
+  - **Verify:** `dune build && dune runtest` (exit 0, zero golden diffs).
+  - **Branch:** `feat/warmup-trading-default-flip`.
+
 ## 2026-06-12 — `suppress_warmup_trading` flag (warmup-leak root-fix surface)
 
 - [x] **Default-off warmup-trading gate (P0, PR #1549 A2 follow-up).** Added a

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -251,17 +251,18 @@ type config = {
           ([dev/notes/long-short-margin-mechanics-2026-06-12.md]) as a
           default-off, searchable {!Walk_forward.Variant_matrix} axis. Not wired
           into any default config or preset. *)
-  suppress_warmup_trading : bool; [@sexp.default false]
-      (** When [true], the backtest runner suppresses all new position entries
-          (long and short) before the measurement [start_date], so the warmup
-          window builds indicators/data only and the measurement window opens
-          with an all-cash portfolio. Default [false] = prior behaviour (the
-          strategy trades during the warmup window). No-op default: existing
-          sexps decode to [false] and replay bit-identically. Motivated by PR
-          #1549's A2 warmup-leak root cause; implemented runner-side by
-          {!Backtest.Warmup_trade_gate}. A default-off, searchable
-          {!Walk_forward.Variant_matrix} axis. Not wired into any default config
-          or preset. *)
+  suppress_warmup_trading : bool; [@sexp.default true]
+      (** When [true] (the default), the backtest runner suppresses all new
+          position entries (long and short) before the measurement [start_date],
+          so the warmup window builds indicators/data only and the measurement
+          window opens with an all-cash portfolio. Default [true] =
+          measurement-correctness invariant (user directive 2026-06-13:
+          "measured window = window only"); warmup forms indicators only.
+          [false] = legacy "running start" (the strategy trades during warmup),
+          kept as an escape hatch / searchable axis. No-op in live/forward mode.
+          Motivated by PR #1549's A2 warmup-leak root cause; implemented
+          runner-side by {!Backtest.Warmup_trade_gate}. Remains a searchable
+          {!Walk_forward.Variant_matrix} axis. *)
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
       (** Cadence at which the trailing-stop state machine advances (G11).

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -25,7 +25,7 @@ type config = {
   full_compute_tail_days : int option;
   enable_short_side : bool; [@sexp.default true]
   short_min_price : float; [@sexp.default 0.0]  (** See [.mli]. *)
-  suppress_warmup_trading : bool; [@sexp.default false]  (** See [.mli]. *)
+  suppress_warmup_trading : bool; [@sexp.default true]  (** See [.mli]. *)
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
       (** Cadence for trailing-stop trail advancement (G11). [Daily] preserves
@@ -135,7 +135,7 @@ let default_config ~universe ~index_symbol =
     full_compute_tail_days = None;
     enable_short_side = true;
     short_min_price = 0.0;
-    suppress_warmup_trading = false;
+    suppress_warmup_trading = true;
     stop_update_cadence = Stops_runner.Daily;
     stage3_force_exit_config = Stage3_force_exit.default_config;
     enable_stage3_force_exit = false;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -39,27 +39,37 @@ type config = {
           carry 83–362% maintenance margin) as a default-off, searchable
           {!Walk_forward.Variant_matrix} axis. Not wired into any default config
           or preset. *)
-  suppress_warmup_trading : bool; [@sexp.default false]
-      (** When [true], the backtest runner suppresses all new position entries
-          (long and short) before the measurement [start_date], so the warmup
-          window builds indicators/data only and the measurement window opens
-          with an all-cash portfolio.
+  suppress_warmup_trading : bool; [@sexp.default true]
+      (** When [true] (the default), the backtest runner suppresses all new
+          position entries (long and short) before the measurement [start_date],
+          so the warmup window builds indicators/data only and the measurement
+          window opens with an all-cash portfolio.
 
-          Default [false] = prior behaviour: the simulator runs from
+          Default [true] = measurement-correctness invariant (user directive
+          2026-06-13: "measured window = window only"). A backtest's measured
+          window must contain only that window's activity — a 210-day backtest
+          has trades for 210 days, not 420. Warmup exists solely to form
+          indicators; trading during it contaminates the measured return with
+          pre-window activity and inherited positions. This is the canonical
+          backtest semantics; in live/forward mode it is a no-op (there are no
+          entries dated before "now", so the gate never fires).
+
+          [false] = legacy "running start": the simulator runs from
           [start_date - warmup_days] and the strategy trades during the warmup
-          window, so every backtest inherits a warmup-built portfolio at
-          measurement start. This is a no-op default — existing
-          golden/baseline/snapshot/scenario sexps that omit the field decode to
-          [false] (via [@sexp.default false]) and replay bit-identically.
+          window, so the backtest inherits a warmup-built portfolio at
+          measurement start. Kept as an explicit escape hatch / searchable axis
+          for measurement experiments and for reproducing pre-flip baselines.
 
           Motivated by PR #1549's A2 root-cause: warmup-window trading over the
           GFC bottom depleted a fold's portfolio to ~35% before its measurement
-          window opened (see [Backtest.Fold_health]). The flag lets a spec test
-          the "warmup = indicators only" semantics. Implemented runner-side by
+          window opened (see [Backtest.Fold_health]). Implemented runner-side by
           {!Backtest.Warmup_trade_gate}, which drops [CreateEntering]
           transitions dated before [start_date]; exits/stops/fills are never
-          suppressed. A default-off, searchable {!Walk_forward.Variant_matrix}
-          axis. Not wired into any default config or preset. *)
+          suppressed. Remains a searchable {!Walk_forward.Variant_matrix} axis.
+
+          This is a measurement-semantics correction, not an alpha mechanism, so
+          {!experiment-flag-discipline} R1/R3 (the ledger-ACCEPT gate for
+          promoting alpha-mechanism defaults) do not apply. *)
   stop_update_cadence : Stops_runner.stop_update_cadence;
       [@sexp.default Stops_runner.Daily]
   stage3_force_exit_config : Stage3_force_exit.config;

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -1317,8 +1317,7 @@ let test_record_force_exit_label_mismatch_is_noop _ =
    [true] — warmup forms indicators only, no trading during warmup, so a
    backtest's measured window contains only that window's activity. *)
 let test_default_config_suppresses_warmup_trading _ =
-  assert_that cfg
-    (field (fun c -> c.suppress_warmup_trading) (equal_to true))
+  assert_that cfg (field (fun c -> c.suppress_warmup_trading) (equal_to true))
 
 (* ------------------------------------------------------------------ *)
 (* Suite                                                                *)

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -1310,6 +1310,17 @@ let test_record_force_exit_label_mismatch_is_noop _ =
   assert_that (Hashtbl.length last_stop_out_dates) (equal_to 0)
 
 (* ------------------------------------------------------------------ *)
+(* suppress_warmup_trading default (measurement-correctness invariant)  *)
+(* ------------------------------------------------------------------ *)
+
+(* Pins the user-directive 2026-06-13 flip: the canonical default is
+   [true] — warmup forms indicators only, no trading during warmup, so a
+   backtest's measured window contains only that window's activity. *)
+let test_default_config_suppresses_warmup_trading _ =
+  assert_that cfg
+    (field (fun c -> c.suppress_warmup_trading) (equal_to true))
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -1317,6 +1328,8 @@ let () =
   run_test_tt_main
     ("weinstein_strategy"
     >::: [
+           "default_config suppresses warmup trading"
+           >:: test_default_config_suppresses_warmup_trading;
            "record_force_exit: zero cooldown is no-op"
            >:: test_record_force_exit_zero_cooldown_is_noop;
            "record_force_exit: positive cooldown records date"


### PR DESCRIPTION
## What & why — measurement-correctness BUGFIX (user directive)

Flips `Weinstein_strategy.config.suppress_warmup_trading` default **`false → true`**.

Per **user directive 2026-06-13: "measured window = window only."** A backtest's
measured window must contain only that window's activity — *"a 1-day backtest has
a 1-day return, not a 211-day backtest; a 210-day backtest has trades for 210 days,
not 420."* Warmup exists solely to form indicators; trading during the 210-day
warmup contaminates the measured return with pre-window activity and inherited
positions. Suppressing it makes the number honest.

This is the **FIX**; the prior default (warmup trades = "running start") is the
**bug**. Default-`false` is retained as a config field / searchable
`Variant_matrix` axis so the legacy behavior is reproducible for measurement
experiments and pre-flip baselines.

## R3-NA rationale (pre-empting a mechanical QC flag)

This is a **measurement-semantics correction, not an alpha-mechanism promotion**,
so `.claude/rules/experiment-flag-discipline.md` **R1/R3** — and
`promotion-confirmation.md`'s confirmation grid — **do not apply**. Those gates
govern flipping the default of an *alpha mechanism* on a ledger ACCEPT; this flip
changes *what the backtest measures*, on explicit human direction, not *which
strategy is better*.

**Note vs the merged experiment.** `dev/experiments/warmup-comparison-2026-06-12/ANALYSIS.md`
concluded "DO NOT FLIP" — but on a **performance** axis (suppress lowers WF-CV
Sharpe/return/Calmar; warmup trading is a net-beneficial bull "running start").
The user has **explicitly reframed** the flag as a **correctness** invariant: the
very "running start" gain the experiment credited is the contamination to remove
(those gains belong to the pre-window period, not the measured window). Different
epistemic objects; the directive governs.

## Re-pin scale — ZERO goldens re-pinned

Full `dune build && dune runtest` passes **exit 0** with the flip — **no golden,
scenario, or snapshot moved.**

This is the expected result and matches the experiment's estimand finding: warmup
trading only bites at the **walk-forward fold** level, where `warmup_start =
fold_start − 210d` sits mid-data with fully-warm indicators. For a **standalone
scenario / snapshot golden**, `warmup_start` IS the simulator's first day, so the
210-day warmup is the indicator-formation period and the portfolio carries **zero**
warmup-built positions across the measurement boundary → **off == on, bit-identical
for every golden in the suite.**

| measure | before | after | Δ |
|---|---|---|---|
| goldens re-pinned | — | — | **0** |
| `dune runtest` | exit 0 | exit 0 | unchanged |

(The two `trade #0 differs` lines in the test log are the `Test_determinism`
start-shift test asserting *expected* divergence — its suite reports `Ran: 6
tests … OK`.)

## Live path unaffected (verified)

The gate (`Warmup_trade_gate`) is wired only in `panel_runner.ml` (the backtest
path), keyed off the measurement `start_date`, dropping only `CreateEntering`
transitions dated **strictly before** it. In live/forward mode `start_date` =
"now" and the strategy never emits entries dated in the past, so the gate never
fires — default-true is a no-op for live trading.

## Changes

- `weinstein_strategy_config.mli` / `.ml`: `[@sexp.default true]` + `default_config`
  initializer `true`; docstring rewritten (default-true = indicators-only;
  false = legacy running-start escape hatch; R1/R3-NA noted).
- `weinstein_strategy.mli`: mirror field `[@sexp.default true]` + docstring.
- `test_weinstein_strategy.ml`: +1 test
  (`default_config suppresses warmup trading`) pinning `default_config.suppress_warmup_trading = true`.
- `dev/status/backtest-infra.md`: completion entry.

Gate logic, `panel_runner.ml`, and the `warmup_gate` unit tests / axis test are
unchanged — only the default value moved.

## Test plan

- `dune build && dune runtest` — **exit 0**, zero golden diffs (full suite,
  including sp500-historical / broad / custom-universe goldens).
- `dune build @fmt` — clean.
- New unit test pins the flipped default; existing `warmup_gate` + `variant_matrix`
  axis tests stay green (gate behavior unchanged by a default-value move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
