### PR TITLE
feat(portfolio): NS1 cash-floor closing-trade exemption (#1557#3)

### DIFF
--- a/dev/plans/cash-floor-closing-exempt-2026-06-13.md
+++ b/dev/plans/cash-floor-closing-exempt-2026-06-13.md
@@ -1,0 +1,199 @@
+# Plan: cash-floor closing-trade exemption (NS1, #1557#3)
+
+Date: 2026-06-13
+Track: `dev/status/cash-floor-correctness.md` (NS1)
+Branch: `feat/cash-floor-closing-exempt`
+
+## 1. Context
+
+The live cash floor is core `Portfolio._check_sufficient_cash`
+(`trading/trading/portfolio/lib/portfolio.ml:338-350`): an absolute-dollar
+solvency check `current_cash + cash_change + sum(min(0, unrealized_pnl)) >= 0`.
+It subtracts ALL negative unrealized P&L (stale paper-loss drag). It fires on
+both Buy and Sell sides — so it can reject a short **cover** (a `Buy` reducing a
+short) when the portfolio carries heavy paper losses, even though the cover is
+the one trade that *reduces* risk. That is the #1553 zombie: the THM cover was
+rejected, the position stranded into a −240% excursion.
+
+#1556 shipped a simulation-layer backstop (`revert_rejected_exits`): re-revert a
+rejected `Exiting` position to `Holding` so the stop re-fires. That's a retry
+loop, not a fix — the cover keeps getting rejected.
+
+NS1 is the **root** fix: let a genuinely-reducing trade (the closing portion)
+bypass the floor, behind a default-off flag, so the cover books first-try.
+#1556's revert becomes a pure backstop.
+
+### Current trade-application data flow (verified)
+
+```
+Simulator._process_fills_and_cancels
+  -> Cancel_handler.apply_trades_best_effort portfolio trades
+       -> Portfolio.apply_single_trade portfolio trade
+            -> _check_sufficient_cash portfolio cash_change   <-- the floor
+```
+
+The margin path (`Portfolio_margin.apply_single_trade_with_margin`) also calls
+`Portfolio.apply_single_trade` internally, so fixing the floor in core Portfolio
+covers both paths.
+
+`portfolio_config` in the spec = `Portfolio_risk.config`
+(`trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml:49`), which is
+a field of `Weinstein_strategy.config` (`portfolio_config : Portfolio_risk.config`,
+`weinstein_strategy_config.ml:17`). The backtest runner threads
+`input.config` (a `Weinstein_strategy.config`) into `Panel_runner._make_simulator`,
+which already derives `~margin_config:input.config.margin_config` for
+`Simulator.create_deps`. That is the precedent seam this plan mirrors.
+
+## 2. Approach
+
+Two-part wiring — config field for axis-ability, plain bool threaded to the
+core check for strategy-agnosticism.
+
+### (a) Axis-able config field (R1 + R2)
+
+Add to `Portfolio_risk.config`:
+
+```ocaml
+exempt_closing_trades_from_cash_floor : bool; [@sexp.default false]
+```
+
+Default `false` (R1: no-op on merge). Because `Portfolio_risk.config` is the
+`portfolio_config` field of `Weinstein_strategy.config`, the
+`Overlay_validator` sexp deep-merge resolves the dot-path
+`portfolio_config.exempt_closing_trades_from_cash_floor`, so a
+`Variant_matrix` axis
+`((flag portfolio_config.exempt_closing_trades_from_cash_floor) (values (true false)))`
+expands and validates (R2). Pinned by a `test_variant_matrix.ml` axis test
+mirroring `test_short_min_price_axis_expands` / the nested
+`hysteresis_weeks` key axis.
+
+### (b) Core Portfolio: strategy-agnostic plain-bool seam (A1, generalizable)
+
+Core Portfolio must NOT depend on `Portfolio_risk` (layering). So the flag
+reaches core Portfolio as a plain `bool`, stored on `Portfolio.t` exactly like
+`accounting_method`:
+
+- New field `exempt_closing_trades_from_cash_floor : bool` on `Portfolio.t`.
+- New optional param `?exempt_closing_trades_from_cash_floor` on `create`
+  (default `false`). All 29 existing `create` call sites keep the old behaviour.
+- `apply_single_trade` passes `~portfolio` (which carries the flag) +
+  the position context into `_check_sufficient_cash`.
+
+The simulator wires the value:
+`Portfolio.create ~exempt_closing_trades_from_cash_floor:
+  config.portfolio_config.exempt_closing_trades_from_cash_floor`.
+
+This keeps the floor logic entirely inside core Portfolio (where it lives),
+makes the change a generic boolean any strategy can set, and satisfies the
+qc-behavioral A1 generalizability check.
+
+### The reducing-portion split (the load-bearing detail)
+
+`_check_sufficient_cash` is extended to receive the existing position quantity
+and the signed trade quantity. The logic:
+
+1. Compute `existing_qty` = signed position quantity for the trade's symbol
+   (0.0 if none), `trade_qty_signed` = `+qty` for Buy, `-qty` for Sell.
+2. A trade is **reducing** when it is opposite-signed to the position and
+   `existing_qty <> 0`. The **closing portion** is
+   `closed = min(|trade_qty|, |existing_qty|)`; the **opening portion** is
+   `|trade_qty| - closed` (non-zero only on an over-cover / flip).
+   This mirrors `portfolio_margin.ml:_classify_trade`'s
+   `Float.min trade.quantity (Float.abs existing_qty)`.
+3. When the flag is on:
+   - **Genuinely reducing** (`|trade_qty| <= |existing_qty|`, opening portion
+     0): the whole trade is the closing portion. Skip the floor entirely —
+     return `Ok new_cash`.
+   - **Over-cover / flip** (opening portion > 0): the closing portion is exempt
+     but the new-opening portion still faces the floor. We check the floor
+     against a `cash_change` that *excludes* the released/neutral closing
+     portion: the opening portion's cash impact is
+     `opening_qty * price (+/- commission share)`. Concretely, compute the
+     opening-only cash change and require
+     `current_cash + opening_cash_change + unrealized_drag >= 0`.
+   - Non-reducing trades (opening / adding same-direction): floor unchanged.
+4. When the flag is off: behaviour is byte-identical to today (full
+   `cash_change`, no split). Verified by default-off no-op test + goldens.
+
+Rejected alternative: thread the bool as a parameter through
+`apply_single_trade` / `Cancel_handler.apply_trades_best_effort` instead of
+storing on `t`. Rejected because `apply_single_trade` has 29 call sites and the
+parameter would ripple through `Portfolio_margin`, `Cancel_handler`, and every
+test; storing on `t` (mirroring `accounting_method`) is the minimal,
+already-established pattern and keeps `apply_single_trade`'s arity stable.
+
+## 3. Files to change
+
+- `trading/trading/portfolio/lib/portfolio.ml`
+  - add `exempt_closing_trades_from_cash_floor : bool` to `t`
+  - `create`: optional `?exempt_closing_trades_from_cash_floor` (default false)
+  - `_check_sufficient_cash`: take position/trade context, implement the split
+  - `apply_single_trade`: pass context + portfolio to the check
+- `trading/trading/portfolio/lib/portfolio.mli`
+  - document the new field + `create` param + updated `apply_single_trade`
+    cash-floor semantics
+- `trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml` + `.mli`
+  - add the `exempt_closing_trades_from_cash_floor` config field +
+    `default_config` entry + .mli doc
+- `trading/trading/simulation/lib/simulator.ml` (and panel_runner if needed)
+  - wire `config.portfolio_config.exempt_closing_trades_from_cash_floor` into
+    `Portfolio.create`. NOTE: `Simulator._build_initial_state` only has the
+    run-`config` (initial_cash/dates), NOT the strategy config. The strategy
+    config is `Weinstein_strategy.config` held by `Panel_runner.input.config`.
+    So the bool must be threaded into the simulator deps (mirror `margin_config`):
+    add a field to `Simulator.dependencies` +
+    `?exempt_closing_trades_from_cash_floor` to `create_deps`, read it in
+    `_build_initial_state`, and `Panel_runner._make_simulator` passes
+    `input.config.portfolio_config.exempt_closing_trades_from_cash_floor`.
+- `trading/trading/portfolio/test/test_portfolio.ml` (or test_margin_accounting)
+  - new unit tests (see acceptance)
+- `trading/trading/backtest/walk_forward/test/test_variant_matrix.ml`
+  - new axis-expansion test for the nested portfolio_config flag path
+
+## 4. Risks / unknowns
+
+- **Sexp shape of `Portfolio.t`.** `t` is `[@@deriving sexp]`. Verified no
+  golden fixture and no sexp round-trip test serializes `Portfolio.t` (greps:
+  no `accounting_method`/`trade_history` in `test_data/`; no Portfolio
+  `t_of_sexp` test). Adding a field is safe.
+- **Threading the bool into the simulator.** `_build_initial_state` lacks the
+  strategy config; mitigated by adding it to deps (mirrors `margin_config`).
+  If the simulator wiring proves larger than expected, the core Portfolio +
+  Portfolio_risk + axis test still land independently (the flag is correct and
+  axis-able; only the live default-off wiring through the runner is the extra).
+- **Over-cover commission attribution.** Commission is per-trade, not
+  per-share. For the opening-portion floor check, attribute commission
+  pro-rata by share fraction (`opening_qty / |trade_qty|`). Documented in code.
+- **available_cash vs current_cash.** The floor uses `current_cash` (+drag),
+  not `available_cash`; this change does not touch margin collateral. Left
+  as-is.
+
+## 5. Acceptance criteria
+
+- `Portfolio_risk.config` has `exempt_closing_trades_from_cash_floor : bool
+  [@sexp.default false]`; `default_config` sets it `false`.
+- Default-off path is byte-identical: `dune runtest` exit 0, no golden re-pin.
+- Axis test in `test_variant_matrix.ml`: the nested key path
+  `portfolio_config.exempt_closing_trades_from_cash_floor` expands + validates
+  through `Overlay_validator` to override sexp
+  `((portfolio_config ((exempt_closing_trades_from_cash_floor true))))`.
+- Unit tests in portfolio test:
+  1. default-off no-op: a cover that the floor would reject is still rejected
+     when the flag is off (pins R1 backward-compat at the unit level).
+  2. genuinely-reducing exempt: with flag on + heavy unrealized drag, a short
+     cover with `|trade_qty| <= |position_qty|` is accepted where it was
+     rejected off.
+  3. over-cover split: with flag on, an over-cover that flips short->long
+     exempts the closing portion but the new-long portion still faces the floor
+     (rejected when the opening portion alone breaches; accepted otherwise).
+  4. long-sell reducing exempt: symmetry — a long sell (reducing) is also
+     exempted (proves strategy-agnostic / generalizes beyond shorts).
+- `dune build && dune runtest` exit 0; `dune fmt` clean.
+
+## 6. Out of scope
+
+- NS2/NS3/NS4 (short-sale proceeds, CancelExit core transition, WF-CV experiment).
+- Flipping the default to on (R3 — human-gated, after NS4).
+- `min_cash_pct` (dead code — do not touch).
+- Warmup-trading flag (fenced to backtest-infra).
+- Margin collateral accounting (`locked_collateral`) — untouched.

--- a/dev/status/cash-floor-correctness.md
+++ b/dev/status/cash-floor-correctness.md
@@ -8,8 +8,32 @@ IN_PROGRESS
 ## Interface stable
 NO
 
-No code shipped yet; this track is a scoped Next-Steps queue. Each NS lands a new
-default-off config field; interfaces firm up as NS1→NS4 ship.
+NS1 shipped (PR open on `feat/cash-floor-closing-exempt`); NS2–NS4 remain a
+scoped Next-Steps queue. Each NS lands a new default-off config field;
+interfaces firm up as NS2→NS4 ship.
+
+## Completed
+
+- **[NS1] #1557#3 — cash-floor closing-trade exemption** (branch
+  `feat/cash-floor-closing-exempt`). Added default-off
+  `Portfolio_risk.config.exempt_closing_trades_from_cash_floor : bool
+  [@sexp.default false]` (the `portfolio_config` seam of
+  `Weinstein_strategy.config`), threaded as a plain bool into
+  `Portfolio.create` via `Simulator.dependencies` /
+  `Panel_runner._make_simulator` so core `Portfolio` stays strategy-agnostic
+  (A1-generalizable). When on, `_check_sufficient_cash` (now delegating to the
+  new `Portfolio_cash_floor` module) skips the floor for the reducing portion of
+  a closing trade; an over-cover that flips short→long exempts only the closing
+  portion (`min(|trade_qty|, |existing_qty|)` split, mirroring
+  `portfolio_margin.ml:_classify_trade`), the new-opening portion still faces
+  the floor. Default-off ⇒ all goldens bit-equal (full `dune runtest` exit 0, no
+  re-pin). Plan: `dev/plans/cash-floor-closing-exempt-2026-06-13.md`. Axis-able:
+  pinned by `test_variant_matrix.ml` (`portfolio_config.exempt_closing_trades_from_cash_floor`
+  nested key). Unit tests in `test_portfolio.ml`: default-off no-op,
+  full/partial cover exempt, over-cover split (opening portion rejected /
+  accepted), long-sell reducing exempt (generalizability). File-length /
+  nesting linter pressure handled by extracting `Portfolio_cash_floor` +
+  `Simulator_metrics` modules (no limit bumps).
 
 ## Owner
 feat-weinstein (core Portfolio/Position edits authorized per the per-task notes
@@ -32,19 +56,8 @@ axis).
 
 ## Next Steps (ordered; each is a default-off flag → safe merge)
 
-1. **[NS1] #1557#3 — cash-floor closing-trade exemption.** Add a default-off
-   `portfolio_config` field `exempt_closing_trades_from_cash_floor : bool
-   [@sexp.default false]`. When on, `Portfolio._check_sufficient_cash` skips the
-   floor for the **reducing portion** of a closing trade (long sell / short
-   cover). Precondition from the investigation: scope to genuinely-reducing
-   trades — `|trade_qty| ≤ |position_qty|`; an over-cover that flips short→long
-   exempts only the closing portion, the new-long portion still faces the floor
-   (mirror the `min(trade.qty, |existing_qty|)` split in
-   `portfolio_margin.ml:_classify_trade`). **A1 core-module change** (Portfolio
-   on the watch-list) — strategy-agnostic, so it should pass the qc-behavioral
-   generalizability check; cite this note. Default-off ⇒ all goldens bit-equal.
-   This is the *root* fix for #1553 (cover books first-try; #1556's revert
-   becomes a backstop). Make it `Variant_matrix`-axis-able.
+1. **[NS1] #1557#3 — cash-floor closing-trade exemption.** ✅ SHIPPED — see
+   §Completed. Branch `feat/cash-floor-closing-exempt`.
 
 2. **[NS2] #1563 — short-sale proceeds collateral.** FIRST deliverable is a
    short design-recommendation in `dev/notes/` (read-only analysis): backtests

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -16,12 +16,10 @@ type input = {
 }
 
 (* Wrap the runner's already-constructed [daily_panels] in the simulator's
-   callback adapter, sharing the LRU cache with the strategy bar reader.
-
-   The naive path of going through [Bar_data_source.build_adapter (Snapshot
-   {...})] would call [Daily_panels.create] a second time and produce a
-   parallel ~330 MB LRU at the 15y SP500 window — see
-   [dev/notes/15y-memory-cliff-2026-05-08.md] §"Cliff #2". *)
+   callback adapter, sharing the LRU cache with the strategy bar reader. Going
+   through [Bar_data_source.build_adapter (Snapshot {...})] would instead call
+   [Daily_panels.create] again and produce a parallel ~330 MB LRU at the 15y
+   SP500 window — see [dev/notes/15y-memory-cliff-2026-05-08.md] §"Cliff #2". *)
 let _build_market_data_adapter ~daily_panels =
   Bar_data_source.build_adapter_from_panels daily_panels
 
@@ -52,7 +50,10 @@ let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
       ~metric_suite:(Metric_computers.default_metric_suite ~initial_cash ())
       ~market_data_adapter ~stale_hold_log ?slippage_bps
       ~stale_hold_policy:(_stale_hold_policy input.config)
-      ~margin_config:input.config.margin_config ?on_trade_fill ()
+      ~margin_config:input.config.margin_config
+      ~exempt_closing_trades_from_cash_floor:
+        input.config.portfolio_config.exempt_closing_trades_from_cash_floor
+      ?on_trade_fill ()
   in
   let config =
     Simulator.

--- a/trading/trading/backtest/test/test_fold_health_runner.ml
+++ b/trading/trading/backtest/test/test_fold_health_runner.ml
@@ -51,6 +51,7 @@ let _make_portfolio ~positions : Trading_portfolio.Portfolio.t =
     unrealized_pnl_per_position = [];
     locked_collateral = 0.0;
     accrued_borrow_fee = 0.0;
+    exempt_closing_trades_from_cash_floor = false;
   }
 
 let _empty_summary : Backtest.Summary.t =

--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -136,6 +136,7 @@ let _make_portfolio ~positions : Trading_portfolio.Portfolio.t =
     unrealized_pnl_per_position = [];
     locked_collateral = 0.0;
     accrued_borrow_fee = 0.0;
+    exempt_closing_trades_from_cash_floor = false;
   }
 
 (** Build a [step_result] with the supplied portfolio + splits_applied. The

--- a/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
+++ b/trading/trading/backtest/walk_forward/test/test_variant_matrix.ml
@@ -268,6 +268,47 @@ let test_suppress_warmup_trading_flag_axis_expands _ =
               [ equal_to (Sexp.of_string "((suppress_warmup_trading false))") ]);
        ])
 
+(* Proves R2 (experiment-flag-discipline) for the NS1 cash-floor closing-trade
+   exemption (#1557#3): [exempt_closing_trades_from_cash_floor] is a real bool
+   field on [Portfolio_risk.config], which is the [portfolio_config] field of
+   [Weinstein_strategy.config]. So the nested key path
+   [portfolio_config.exempt_closing_trades_from_cash_floor] expands and passes
+   [Overlay_validator] validation (same nesting mechanism as
+   [stage3_force_exit_config.hysteresis_weeks]) with no overlay-validator
+   change. The no-op default [false] and the experimental [true] sit on the same
+   axis. *)
+let test_cash_floor_exemption_nested_axis_expands _ =
+  let axis =
+    VM.Key
+      {
+        path = [ "portfolio_config"; "exempt_closing_trades_from_cash_floor" ];
+        values = Sexp.[ Atom "true"; Atom "false" ];
+      }
+  in
+  let t = { VM.axes = [ axis ]; expansion = VM.Cartesian } in
+  assert_that (VM.expand t)
+    (elements_are
+       [
+         field
+           (fun (v : WFR.variant) -> v.overrides)
+           (elements_are
+              [
+                equal_to
+                  (Sexp.of_string
+                     "((portfolio_config \
+                      ((exempt_closing_trades_from_cash_floor true))))");
+              ]);
+         field
+           (fun (v : WFR.variant) -> v.overrides)
+           (elements_are
+              [
+                equal_to
+                  (Sexp.of_string
+                     "((portfolio_config \
+                      ((exempt_closing_trades_from_cash_floor false))))");
+              ]);
+       ])
+
 (* ---------- Sampled determinism + fallback ---------- *)
 
 let test_sampled_determinism _ =
@@ -352,6 +393,8 @@ let suite =
          >:: test_short_min_price_axis_expands;
          "suppress_warmup_trading flag axis expands"
          >:: test_suppress_warmup_trading_flag_axis_expands;
+         "cash-floor exemption nested axis expands + validates"
+         >:: test_cash_floor_exemption_nested_axis_expands;
          "sampled determinism (same seed -> same labels)"
          >:: test_sampled_determinism;
          "sampled different seed -> different subset"

--- a/trading/trading/portfolio/lib/dune
+++ b/trading/trading/portfolio/lib/dune
@@ -5,6 +5,7 @@
  (modules
   types
   portfolio
+  portfolio_cash_floor
   portfolio_margin
   calculations
   split_event

--- a/trading/trading/portfolio/lib/portfolio.ml
+++ b/trading/trading/portfolio/lib/portfolio.ml
@@ -25,10 +25,15 @@ type t = {
       (* Running total of borrow fees debited from current_cash. 0.0 unless
          accrue_daily_borrow_fee has been called with Margin_config.enabled
          = true. Audit-only field; not consumed by trading logic. *)
+  exempt_closing_trades_from_cash_floor : bool;
+      (* NS1 (#1557#3): when true, the cash floor exempts the reducing portion of
+         a closing trade. A plain bool so core Portfolio stays strategy-agnostic.
+         Default false ⇒ byte-identical to prior behaviour. See .mli + create. *)
 }
 [@@deriving show, eq, sexp]
 
-let create ?(accounting_method = AverageCost) ~initial_cash () =
+let create ?(accounting_method = AverageCost)
+    ?(exempt_closing_trades_from_cash_floor = false) ~initial_cash () =
   {
     initial_cash;
     trade_history = [];
@@ -38,6 +43,7 @@ let create ?(accounting_method = AverageCost) ~initial_cash () =
     unrealized_pnl_per_position = [];
     locked_collateral = 0.0;
     accrued_borrow_fee = 0.0;
+    exempt_closing_trades_from_cash_floor;
   }
 
 let _find_position_in_list positions symbol =
@@ -335,19 +341,15 @@ let _negative_unrealized_pnl_total portfolio =
   List.fold portfolio.unrealized_pnl_per_position ~init:0.0
     ~f:(fun acc (_symbol, pnl) -> acc +. Float.min 0.0 pnl)
 
-let _check_sufficient_cash portfolio cash_change =
-  let new_cash = portfolio.current_cash +. cash_change in
-  let unrealized_drag = _negative_unrealized_pnl_total portfolio in
-  let effective_cash = new_cash +. unrealized_drag in
-  if Float.(effective_cash < 0.0) then
-    error_invalid_argument
-      ("Insufficient cash for trade. Required: "
-      ^ Float.to_string (-.cash_change)
-      ^ ", Available: "
-      ^ Float.to_string portfolio.current_cash
-      ^ ", Unrealized loss drag: "
-      ^ Float.to_string unrealized_drag)
-  else Result.Ok new_cash
+(* Cash floor solvency check. Delegates to {!Portfolio_cash_floor.check} with
+   the portfolio's cash, paper-loss drag, and the NS1 closing-trade exemption
+   flag; flag-off is byte-identical to the prior behaviour. *)
+let _check_sufficient_cash ~existing_qty ~trade portfolio cash_change =
+  Portfolio_cash_floor.check
+    ~exempt:portfolio.exempt_closing_trades_from_cash_floor
+    ~current_cash:portfolio.current_cash
+    ~negative_unrealized_pnl:(_negative_unrealized_pnl_total portfolio)
+    ~existing_qty ~trade ~cash_change
 
 (* After a trade, prune the unrealized-pnl accumulator. Positions that no
    longer exist (fully closed) are dropped. New positions get a 0.0 seed,
@@ -367,9 +369,17 @@ let _refresh_unrealized_after_trade ~old_accumulator ~new_positions =
 let apply_single_trade (portfolio : t) (trade : Trading_base.Types.trade) :
     t status_or =
   let cash_change = _calculate_cash_change trade in
-  let%bind new_cash = _check_sufficient_cash portfolio cash_change in
+  let existing_position = get_position portfolio trade.symbol in
+  let existing_qty =
+    match existing_position with
+    | None -> 0.0
+    | Some p -> Calculations.position_quantity p
+  in
+  let%bind new_cash =
+    _check_sufficient_cash ~existing_qty ~trade portfolio cash_change
+  in
   let realized_pnl =
-    match get_position portfolio trade.symbol with
+    match existing_position with
     | None -> 0.0 (* New position - no realized P&L *)
     | Some existing_position -> _calculate_realized_pnl trade existing_position
   in

--- a/trading/trading/portfolio/lib/portfolio.mli
+++ b/trading/trading/portfolio/lib/portfolio.mli
@@ -13,6 +13,7 @@ type t = {
   unrealized_pnl_per_position : (symbol * float) list;
   locked_collateral : cash_value;
   accrued_borrow_fee : cash_value;
+  exempt_closing_trades_from_cash_floor : bool;
 }
 [@@deriving show, eq, sexp]
 (** Portfolio type. All fields are accessible for pattern matching and direct
@@ -46,13 +47,28 @@ type t = {
       [current_cash] over the portfolio's lifetime (issue #859 Phase 1). [0.0]
       unless [Margin_config.enabled = true] and [accrue_daily_borrow_fee] has
       been called. Exposed for audit reporting and tests — not consumed by
-      trading logic. *)
+      trading logic.
+    - [exempt_closing_trades_from_cash_floor]: NS1 (#1557#3). When [true],
+      [apply_single_trade]'s cash floor skips the solvency check for the
+      reducing portion of a closing trade (long sell / short cover). [false]
+      (the [create] default) reproduces the prior behaviour exactly. A plain
+      bool so this module stays strategy-agnostic; the strategy layer sets it
+      from [Portfolio_risk.config.exempt_closing_trades_from_cash_floor]. See
+      [apply_single_trade] for the exact semantics. *)
 
 val create :
-  ?accounting_method:accounting_method -> initial_cash:cash_value -> unit -> t
+  ?accounting_method:accounting_method ->
+  ?exempt_closing_trades_from_cash_floor:bool ->
+  initial_cash:cash_value ->
+  unit ->
+  t
 (** Create a new portfolio with initial cash balance and optional accounting
     method (default: AverageCost). This is the only safe way to construct a
-    valid portfolio. *)
+    valid portfolio.
+
+    [exempt_closing_trades_from_cash_floor] (default: [false]) controls the
+    cash-floor exemption for closing trades — see the field doc above and
+    [apply_single_trade]. The default preserves the legacy floor behaviour. *)
 
 val get_position : t -> symbol -> portfolio_position option
 (** Find a position by symbol. Returns None if no position exists for the
@@ -70,6 +86,20 @@ val apply_single_trade : t -> trade -> t status_or
     reducing a short) both go through the same effective cash floor. This bounds
     the unrealized paper loss a portfolio can carry on shorts before further
     activity is rejected.
+
+    NS1 (#1557#3) closing-trade exemption: when
+    [exempt_closing_trades_from_cash_floor = true] on the portfolio, the floor
+    is applied only to the {b opening portion} of a closing trade. A closing
+    trade is one opposite-signed to a non-flat existing position (a long sell or
+    a short cover). A {e genuinely-reducing} trade
+    ([|trade_qty| <= |existing_qty|]) has no opening portion and is therefore
+    always accepted — covering reduces risk and must not be blocked by stale
+    paper-loss drag (the #1553 zombie root cause). An {e over-cover} that flips
+    short->long exempts the closing portion but still applies the floor to the
+    new-opening portion's cash change ([opening_qty * price] + pro-rata
+    commission), mirroring [Portfolio_margin._classify_trade]'s
+    [min(|trade_qty|, |existing_qty|)] split. When the flag is [false] (the
+    default), the full trade faces the floor exactly as before.
 
     Strict broker-margin semantics (collateral pre-locked at short entry,
     refunded on cover) are deliberately deferred — see

--- a/trading/trading/portfolio/lib/portfolio_cash_floor.ml
+++ b/trading/trading/portfolio/lib/portfolio_cash_floor.ml
@@ -1,0 +1,86 @@
+open Core
+open Status
+open Trading_base.Types
+
+let _negligible_quantity_epsilon = 1e-9
+
+let _is_quantity_negligible (qty : float) : bool =
+  Float.(abs qty < _negligible_quantity_epsilon)
+
+(* A trade is closing when it is opposite-signed to a non-flat position. *)
+let _is_closing ~existing_qty ~trade_qty_signed : bool =
+  (not (_is_quantity_negligible existing_qty))
+  && not
+       (Bool.equal
+          Float.O.(existing_qty >= 0.0)
+          Float.O.(trade_qty_signed >= 0.0))
+
+let _signed_trade_quantity (trade : trade) : float =
+  match trade.side with Buy -> trade.quantity | Sell -> -.trade.quantity
+
+(* Cash outflow of the opening [opening_qty] shares of a flip, with commission
+   attributed pro-rata by the opening share fraction. The opening portion of a
+   short-cover flip is always a Buy growing a new long, so the change is a cash
+   outflow (negative). [opening_qty] is 0.0 for a genuinely-reducing trade, in
+   which case the result is 0.0 (no new cash exposure). *)
+let _opening_cash_outflow ~trade_qty_abs ~opening_qty (trade : trade) : float =
+  if _is_quantity_negligible opening_qty then 0.0
+  else
+    let opening_fraction = opening_qty /. trade_qty_abs in
+    let opening_commission = trade.commission *. opening_fraction in
+    -.((opening_qty *. trade.price) +. opening_commission)
+
+(* The cash impact attributable to the *opening* portion of a closing trade.
+   [None] when the trade is not a closing trade against a non-flat position
+   (caller applies the floor to the full [cash_change]). [Some opening_change]
+   otherwise: 0.0 for a genuinely-reducing trade, or the opening-portion cash
+   change for an over-cover. Mirrors [Portfolio_margin._classify_trade]'s
+   [Float.min trade.quantity (Float.abs existing_qty)] split. *)
+let _opening_portion_cash_change ~existing_qty (trade : trade) : float option =
+  let trade_qty_signed = _signed_trade_quantity trade in
+  if not (_is_closing ~existing_qty ~trade_qty_signed) then None
+  else
+    let trade_qty_abs = Float.abs trade.quantity in
+    let closed_qty = Float.min trade_qty_abs (Float.abs existing_qty) in
+    let opening_qty = trade_qty_abs -. closed_qty in
+    Some (_opening_cash_outflow ~trade_qty_abs ~opening_qty trade)
+
+let _floor_error ~current_cash ~cash_change ~negative_unrealized_pnl =
+  error_invalid_argument
+    ("Insufficient cash for trade. Required: "
+    ^ Float.to_string (-.cash_change)
+    ^ ", Available: "
+    ^ Float.to_string current_cash
+    ^ ", Unrealized loss drag: "
+    ^ Float.to_string negative_unrealized_pnl)
+
+(* Apply the absolute-dollar floor against [checked_change]:
+   [current_cash + checked_change + negative_unrealized_pnl >= 0]. Returns the
+   post-trade balance [new_cash] on success. *)
+let _floor_check ~current_cash ~negative_unrealized_pnl ~new_cash ~cash_change
+    ~checked_change =
+  let effective_cash =
+    current_cash +. checked_change +. negative_unrealized_pnl
+  in
+  if Float.(effective_cash < 0.0) then
+    _floor_error ~current_cash ~cash_change ~negative_unrealized_pnl
+  else Result.Ok new_cash
+
+let check ~exempt ~current_cash ~negative_unrealized_pnl ~existing_qty ~trade
+    ~cash_change =
+  let new_cash = current_cash +. cash_change in
+  let exemption =
+    if exempt then _opening_portion_cash_change ~existing_qty trade else None
+  in
+  match exemption with
+  | None ->
+      _floor_check ~current_cash ~negative_unrealized_pnl ~new_cash ~cash_change
+        ~checked_change:cash_change
+  | Some opening_change ->
+      if _is_quantity_negligible opening_change then
+        (* Genuinely-reducing closing trade: exempt from the floor entirely. *)
+        Result.Ok new_cash
+      else
+        (* Over-cover: only the new-opening portion faces the floor. *)
+        _floor_check ~current_cash ~negative_unrealized_pnl ~new_cash
+          ~cash_change ~checked_change:opening_change

--- a/trading/trading/portfolio/lib/portfolio_cash_floor.mli
+++ b/trading/trading/portfolio/lib/portfolio_cash_floor.mli
@@ -1,0 +1,44 @@
+(** Cash-floor solvency check for {!Portfolio.apply_single_trade}, extracted so
+    [portfolio.ml] stays under the file-length limit.
+
+    The floor is an absolute-dollar solvency check:
+    [current_cash + checked_change + negative_unrealized_pnl >= 0], where
+    [negative_unrealized_pnl] is the (non-positive) sum of paper losses on open
+    positions. [checked_change] is normally the full trade cash change.
+
+    NS1 (#1557#3) closing-trade exemption: when [exempt = true], the reducing
+    portion of a closing trade (long sell / short cover) bypasses the floor,
+    because it reduces risk and must not be blocked by stale paper-loss drag
+    (the #1553 zombie root cause). A genuinely-reducing trade
+    ([|trade_qty| <= |existing_qty|]) is accepted unconditionally; an over-cover
+    that flips direction exempts the closing portion but still applies the floor
+    to the new-opening portion's cash change. The split mirrors
+    [Portfolio_margin._classify_trade]'s [min(|trade_qty|, |existing_qty|)]. *)
+
+open Trading_base.Types
+open Status
+open Types
+
+val check :
+  exempt:bool ->
+  current_cash:cash_value ->
+  negative_unrealized_pnl:float ->
+  existing_qty:float ->
+  trade:trade ->
+  cash_change:cash_value ->
+  cash_value status_or
+(** [check ~exempt ~current_cash ~negative_unrealized_pnl ~existing_qty ~trade
+     ~cash_change] returns [Ok new_cash] (where
+    [new_cash = current_cash +. cash_change]) when the floor is satisfied, or an
+    [Error] describing the shortfall.
+
+    @param exempt
+      NS1 closing-trade exemption flag. [false] reproduces the legacy floor (the
+      full [cash_change] faces the check) exactly.
+    @param current_cash Cash balance before the trade.
+    @param negative_unrealized_pnl
+      Sum of [min 0.0 pnl] over open positions (a non-positive paper-loss drag).
+    @param existing_qty
+      Signed quantity of the existing position in [trade.symbol] (0.0 if none).
+    @param trade The trade being applied.
+    @param cash_change Full cash change of [trade] (negative for a Buy). *)

--- a/trading/trading/portfolio/test/test_portfolio.ml
+++ b/trading/trading/portfolio/test/test_portfolio.ml
@@ -42,6 +42,7 @@ let test_create_portfolio _ accounting_method =
       unrealized_pnl_per_position = [];
       locked_collateral = 0.0;
       accrued_borrow_fee = 0.0;
+      exempt_closing_trades_from_cash_floor = false;
     }
   in
   assert_equal expected portfolio ~msg:"Portfolio should match expected state"
@@ -753,6 +754,162 @@ let test_positive_unrealized_pnl_does_not_inflate_floor _ accounting_method =
   assert_that (apply_single_trade portfolio oversized_buy) is_error
 
 (* ========================================================================== *)
+(* NS1 (#1557#3): cash-floor closing-trade exemption                          *)
+(* ========================================================================== *)
+
+(* A short whose paper loss has pushed the effective floor below zero. Covering
+   it (a Buy reducing the short) is exactly the trade the floor wrongly rejects
+   (#1553). [exempt_closing_trades_from_cash_floor] lets the closing portion
+   bypass the floor. The helper builds: short 100 @ $50 (cash → +5000), mark @
+   $200 (unrealized −15000), so the floor is deeply negative before the cover. *)
+let _stranded_short_portfolio ~accounting_method ~exempt =
+  let portfolio =
+    create ~accounting_method ~exempt_closing_trades_from_cash_floor:exempt
+      ~initial_cash:1_000.0 ()
+  in
+  let portfolio =
+    apply_trades_exn portfolio
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"Short entry should succeed"
+  in
+  (* Cash now $6000. Mark AAPL @ $200 → unrealized = (200 - 50) * -100 =
+     -15000. Effective floor: 6000 - 15000 = -9000 (already below zero). *)
+  mark_to_market portfolio [ ("AAPL", 200.0) ]
+
+(* Default-off (flag false): the floor still rejects the risk-reducing cover —
+   pins R1 backward-compat at the unit level. Cover cost is 100 * 200 = 20000;
+   effective floor 6000 - 20000 - 15000 < 0. *)
+let test_cover_rejected_when_exemption_off _ accounting_method =
+  let portfolio = _stranded_short_portfolio ~accounting_method ~exempt:false in
+  let cover =
+    make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAPL" ~side:Buy ~quantity:100.0
+      ~price:200.0 ()
+  in
+  assert_that (apply_single_trade portfolio cover) is_error
+
+(* Flag on: a genuinely-reducing cover (|trade_qty| = |position_qty|) is
+   accepted despite the deeply-negative floor, because the reducing portion is
+   exempt. Cash after cover: 6000 - 100 * 200 = -14000 (negative cash is
+   permitted — the position is being closed, reducing risk). *)
+let test_full_cover_exempt_when_flag_on _ accounting_method =
+  let portfolio = _stranded_short_portfolio ~accounting_method ~exempt:true in
+  let cover =
+    make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAPL" ~side:Buy ~quantity:100.0
+      ~price:200.0 ()
+  in
+  assert_that
+    (apply_single_trade portfolio cover)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun p -> p.current_cash) (float_equal (-14_000.0));
+            (* Position fully closed → accumulator pruned. *)
+            field (fun p -> p.unrealized_pnl_per_position) is_empty;
+          ]))
+
+(* Flag on, partial cover (|trade_qty| < |position_qty|): still genuinely
+   reducing (no opening portion), so exempt and accepted. The position is
+   reduced from -100 to -50, the accumulator keeps the (stale) entry. *)
+let test_partial_cover_exempt_when_flag_on _ accounting_method =
+  let portfolio = _stranded_short_portfolio ~accounting_method ~exempt:true in
+  let partial_cover =
+    make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAPL" ~side:Buy ~quantity:40.0
+      ~price:200.0 ()
+  in
+  assert_that
+    (apply_single_trade portfolio partial_cover)
+    (is_ok_and_holds
+       (* Cash: 6000 - 40 * 200 = -2000; position now -60 shares. *)
+       (all_of
+          [
+            field (fun p -> p.current_cash) (float_equal (-2_000.0));
+            field
+              (fun p -> position_quantity (List.hd_exn p.positions))
+              (float_equal (-60.0));
+          ]))
+
+(* Flag on, over-cover that flips short→long: the closing portion (100 shares)
+   is exempt, but the new-long portion (50 shares) still faces the floor. Here
+   the new-long cash outflow alone (50 * 200 = 10000) against cash 6000 and the
+   -15000 drag breaches the floor (6000 - 10000 - 15000 < 0) → rejected. This
+   proves the split: an over-cover is NOT blanket-exempt. *)
+let test_over_cover_opening_portion_faces_floor _ accounting_method =
+  let portfolio = _stranded_short_portfolio ~accounting_method ~exempt:true in
+  let over_cover =
+    make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAPL" ~side:Buy ~quantity:150.0
+      ~price:200.0 ()
+  in
+  assert_that (apply_single_trade portfolio over_cover) is_error
+
+(* Flag on, over-cover whose new-long portion is small enough to clear the
+   floor: the closing portion is exempt and the opening portion passes, so the
+   flip is accepted. Drag is small here so the opening-portion check passes.
+   Short 100 @ $50 (cash → 6000 from a $1000 start), mark @ $52 (unrealized
+   -200). Over-cover 120 @ $52: closing 100 exempt; opening 20 * 52 = 1040
+   outflow; floor check 1000 + 5000 - 1040 - 200 = 4760 >= 0 → accepted. *)
+let test_over_cover_small_opening_portion_accepted _ accounting_method =
+  let portfolio =
+    create ~accounting_method ~exempt_closing_trades_from_cash_floor:true
+      ~initial_cash:1_000.0 ()
+  in
+  let portfolio =
+    apply_trades_exn portfolio
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"Short entry should succeed"
+  in
+  let portfolio = mark_to_market portfolio [ ("AAPL", 52.0) ] in
+  let over_cover =
+    make_trade ~id:"t2" ~order_id:"o2" ~symbol:"AAPL" ~side:Buy ~quantity:120.0
+      ~price:52.0 ()
+  in
+  assert_that
+    (apply_single_trade portfolio over_cover)
+    (is_ok_and_holds
+       (* Position flips to +20 long. *)
+       (field
+          (fun p -> position_quantity (List.hd_exn p.positions))
+          (float_equal 20.0)))
+
+(* Symmetry / generalizability: the exemption is NOT short-specific. A long sell
+   that reduces a long position is also a closing trade and is exempt. With a
+   deeply-negative floor from an unrelated marked loss, the reducing long sell
+   is accepted under the flag. Buy 100 AAPL @ $50 (cash 10000 → 5000), open a
+   losing short on B to drag the floor, then sell the AAPL long. *)
+let test_long_sell_reducing_is_exempt _ accounting_method =
+  let portfolio =
+    create ~accounting_method ~exempt_closing_trades_from_cash_floor:true
+      ~initial_cash:10_000.0 ()
+  in
+  let portfolio =
+    apply_trades_exn portfolio
+      [
+        make_trade ~id:"t1" ~order_id:"o1" ~symbol:"AAPL" ~side:Buy
+          ~quantity:100.0 ~price:50.0 ();
+        make_trade ~id:"t2" ~order_id:"o2" ~symbol:"B" ~side:Sell
+          ~quantity:100.0 ~price:50.0 ();
+      ]
+      ~error_msg:"Long buy + short B should succeed"
+  in
+  (* Cash: 10000 - 5000 + 5000 = 10000. Mark B @ $200 → unrealized -15000.
+     Effective floor: 10000 - 15000 = -5000 (below zero). *)
+  let portfolio = mark_to_market portfolio [ ("AAPL", 50.0); ("B", 200.0) ] in
+  let long_sell =
+    make_trade ~id:"t3" ~order_id:"o3" ~symbol:"AAPL" ~side:Sell ~quantity:100.0
+      ~price:50.0 ()
+  in
+  assert_that
+    (apply_single_trade portfolio long_sell)
+    (is_ok_and_holds
+       (* Cash rises by 100 * 50 = 5000 → 15000; AAPL closed. *)
+       (field (fun p -> p.current_cash) (float_equal 15_000.0)))
+
+(* ========================================================================== *)
 (* Test suite organization                                                   *)
 (* ========================================================================== *)
 
@@ -803,6 +960,19 @@ let suite =
            make_parameterized_tests
              "positive_unrealized_pnl_does_not_inflate_floor"
              test_positive_unrealized_pnl_does_not_inflate_floor;
+           (* NS1: cash-floor closing-trade exemption *)
+           make_parameterized_tests "cover_rejected_when_exemption_off"
+             test_cover_rejected_when_exemption_off;
+           make_parameterized_tests "full_cover_exempt_when_flag_on"
+             test_full_cover_exempt_when_flag_on;
+           make_parameterized_tests "partial_cover_exempt_when_flag_on"
+             test_partial_cover_exempt_when_flag_on;
+           make_parameterized_tests "over_cover_opening_portion_faces_floor"
+             test_over_cover_opening_portion_faces_floor;
+           make_parameterized_tests "over_cover_small_opening_portion_accepted"
+             test_over_cover_small_opening_portion_accepted;
+           make_parameterized_tests "long_sell_reducing_is_exempt"
+             test_long_sell_reducing_is_exempt;
            (* FIFO-specific tests - only run for FIFO *)
            [
              "fifo_basic_buy_sell" >:: test_fifo_basic_buy_sell;

--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -12,6 +12,7 @@
   core)
  (modules
   simulator
+  simulator_metrics
   fill_date_stamp
   split_handler
   cancel_handler

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -4,21 +4,6 @@
 open Core
 include Trading_simulation_types.Simulator_types
 
-(** Internal: compute metrics by running all step-based computers *)
-let _compute_metrics ~computers ~config ~steps =
-  List.fold computers ~init:Trading_simulation_types.Metric_types.empty
-    ~f:(fun acc (computer : any_metric_computer) ->
-      Trading_simulation_types.Metric_types.merge acc
-        (computer.run ~config ~steps))
-
-(** Internal: compute derived metrics. Folded in list order — callers must
-    pre-sort by dependency. *)
-let _compute_derived ~derived_computers ~config ~base_metrics =
-  List.fold derived_computers ~init:base_metrics
-    ~f:(fun acc (dc : derived_metric_computer) ->
-      Trading_simulation_types.Metric_types.merge acc
-        (dc.compute ~config ~base_metrics:acc))
-
 (** {1 Dependencies} *)
 
 type dependencies = {
@@ -33,6 +18,7 @@ type dependencies = {
   stale_hold_policy : Stale_hold.config;
   stale_hold_log : Stale_hold.Log.t;
   margin_config : Trading_portfolio.Margin_config.t;  (** See .mli. *)
+  exempt_closing_trades_from_cash_floor : bool;  (** See .mli. *)
   on_trade_fill : (Trading_base.Types.trade -> Trading_base.Types.trade) option;
   active_through_for : (string -> Core.Date.t option) option;  (** See .mli. *)
 }
@@ -42,7 +28,8 @@ let create_deps ~symbols ~data_dir ~strategy ~commission
     ?market_data_adapter ?(stale_hold_policy = Stale_hold.default_config)
     ?stale_hold_log ?(slippage_bps = 0)
     ?(margin_config = Trading_portfolio.Margin_config.default_config)
-    ?on_trade_fill ?active_through_for () =
+    ?(exempt_closing_trades_from_cash_floor = false) ?on_trade_fill
+    ?active_through_for () =
   let engine_config = { Trading_engine.Types.commission; slippage_bps } in
   let engine = Trading_engine.Engine.create engine_config in
   let order_manager = Trading_orders.Manager.create () in
@@ -66,6 +53,7 @@ let create_deps ~symbols ~data_dir ~strategy ~commission
     stale_hold_policy;
     stale_hold_log;
     margin_config;
+    exempt_closing_trades_from_cash_floor;
     on_trade_fill;
     active_through_for;
   }
@@ -115,7 +103,9 @@ let _maybe_prune_deps ~fold_start_date deps =
 let _build_initial_state ~config ~deps =
   let deps = _maybe_prune_deps ~fold_start_date:config.start_date deps in
   let portfolio =
-    Trading_portfolio.Portfolio.create ~initial_cash:config.initial_cash ()
+    Trading_portfolio.Portfolio.create ~initial_cash:config.initial_cash
+      ~exempt_closing_trades_from_cash_floor:
+        deps.exempt_closing_trades_from_cash_floor ()
   in
   {
     config;
@@ -335,12 +325,13 @@ let _apply_transitions ~positions ~transitions =
 let _build_run_result t =
   let steps = List.rev t.step_history in
   let base_metrics =
-    _compute_metrics ~computers:t.deps.metric_suite.computers ~config:t.config
-      ~steps
+    Simulator_metrics.compute_base ~computers:t.deps.metric_suite.computers
+      ~config:t.config ~steps
   in
   let metrics =
-    _compute_derived ~derived_computers:t.deps.metric_suite.derived
-      ~config:t.config ~base_metrics
+    Simulator_metrics.compute_derived
+      ~derived_computers:t.deps.metric_suite.derived ~config:t.config
+      ~base_metrics
   in
   if !(t.valuation_failure_count) > 0 then
     eprintf

--- a/trading/trading/simulation/lib/simulator.mli
+++ b/trading/trading/simulation/lib/simulator.mli
@@ -42,6 +42,12 @@ type dependencies = {
       (** Phase-2 margin-accounting parameters (issue #859). When
           [enabled = false] (the default), every margin code path is a no-op and
           existing baselines are bit-equal. *)
+  exempt_closing_trades_from_cash_floor : bool;
+      (** NS1 (#1557#3): passed to [Portfolio.create] when the run's portfolio
+          is built. When [true], the cash floor skips the reducing portion of a
+          closing trade (long sell / short cover). [false] (the default)
+          preserves byte-equal baselines. The backtest runner threads this from
+          [config.portfolio_config.exempt_closing_trades_from_cash_floor]. *)
   on_trade_fill : (Trading_base.Types.trade -> Trading_base.Types.trade) option;
       (** Optional post-fill per-trade adjustment, applied inside the
           simulator's accept-trades path before the portfolio accounts for each
@@ -83,6 +89,7 @@ val create_deps :
   ?stale_hold_log:Stale_hold.Log.t ->
   ?slippage_bps:int ->
   ?margin_config:Trading_portfolio.Margin_config.t ->
+  ?exempt_closing_trades_from_cash_floor:bool ->
   ?on_trade_fill:(Trading_base.Types.trade -> Trading_base.Types.trade) ->
   ?active_through_for:(string -> Core.Date.t option) ->
   unit ->
@@ -119,6 +126,11 @@ val create_deps :
       {!Trading_portfolio.Margin_config.default_config} — disabled, so the
       simulator's per-step margin code paths are no-ops and existing baselines
       are bit-equal.
+    @param exempt_closing_trades_from_cash_floor
+      NS1 (#1557#3) cash-floor closing-trade exemption, passed to
+      [Portfolio.create]. Default [false] — the floor faces every full trade
+      exactly as before, so existing baselines are bit-equal. See the field doc
+      on {!dependencies.exempt_closing_trades_from_cash_floor}.
     @param on_trade_fill
       Optional per-trade adjustment applied to every accepted fill before the
       portfolio accounts for it. Default [None] — preserves byte-equal

--- a/trading/trading/simulation/lib/simulator_metrics.ml
+++ b/trading/trading/simulation/lib/simulator_metrics.ml
@@ -1,0 +1,14 @@
+open Core
+open Trading_simulation_types.Simulator_types
+
+let compute_base ~computers ~config ~steps =
+  List.fold computers ~init:Trading_simulation_types.Metric_types.empty
+    ~f:(fun acc (computer : any_metric_computer) ->
+      Trading_simulation_types.Metric_types.merge acc
+        (computer.run ~config ~steps))
+
+let compute_derived ~derived_computers ~config ~base_metrics =
+  List.fold derived_computers ~init:base_metrics
+    ~f:(fun acc (dc : derived_metric_computer) ->
+      Trading_simulation_types.Metric_types.merge acc
+        (dc.compute ~config ~base_metrics:acc))

--- a/trading/trading/simulation/lib/simulator_metrics.mli
+++ b/trading/trading/simulation/lib/simulator_metrics.mli
@@ -1,0 +1,21 @@
+(** Metric aggregation helpers for the simulator's [_build_run_result] —
+    extracted from [simulator.ml] to keep that coordinator under the file-length
+    limit. Pure folds over the configured metric computers. *)
+
+open Trading_simulation_types.Simulator_types
+
+val compute_base :
+  computers:any_metric_computer list ->
+  config:config ->
+  steps:step_result list ->
+  Trading_simulation_types.Metric_types.metric_set
+(** Run every step-based computer over [steps] and merge their metric sets,
+    seeded from {!Trading_simulation_types.Metric_types.empty}. *)
+
+val compute_derived :
+  derived_computers:derived_metric_computer list ->
+  config:config ->
+  base_metrics:Trading_simulation_types.Metric_types.metric_set ->
+  Trading_simulation_types.Metric_types.metric_set
+(** Fold the derived computers over [base_metrics] in list order — callers must
+    pre-sort by dependency. *)

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
@@ -62,6 +62,7 @@ type config = {
   big_winner_multiplier : float;
   force_liquidation : Force_liquidation.config;
       [@sexp.default Force_liquidation.default_config]
+  exempt_closing_trades_from_cash_floor : bool; [@sexp.default false]
 }
 [@@deriving show, eq, sexp]
 
@@ -81,6 +82,7 @@ let default_config =
     max_unknown_sector_positions = 2;
     big_winner_multiplier = 1.5;
     force_liquidation = Force_liquidation.default_config;
+    exempt_closing_trades_from_cash_floor = false;
   }
 
 (* ---- Snapshot helpers ---- *)

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
@@ -202,6 +202,24 @@ type config = {
       [@sexp.default Force_liquidation.default_config]
       (** Force-liquidation thresholds — see {!Force_liquidation}. Default: 50%
           per-position loss, 40% portfolio-of-peak floor. *)
+  exempt_closing_trades_from_cash_floor : bool; [@sexp.default false]
+      (** NS1 (#1557#3): when [true], the core [Portfolio] cash floor
+          ([Portfolio._check_sufficient_cash]) skips the solvency check for the
+          {b reducing portion} of a closing trade (a long sell or short cover),
+          so a cover that {e reduces} risk is never rejected by stale paper-loss
+          drag — the #1553 zombie root cause. An over-cover that flips
+          short->long exempts only the closing portion; the new-long portion
+          still faces the floor.
+
+          Default-off ([false]) ⇒ the floor behaves exactly as before (the full
+          trade faces the check). This field is the [portfolio_config] seam of
+          [Weinstein_strategy.config], so it is expressible as a
+          [Variant_matrix] axis on the dot-path
+          [portfolio_config.exempt_closing_trades_from_cash_floor]. Strategy
+          code does not read it directly; the simulator threads its value into
+          [Portfolio.create] as a plain bool, keeping core [Portfolio]
+          strategy-agnostic. Promotion to default-on is human-gated, pending the
+          NS4 WF-CV experiment (experiment-flag-discipline R3). *)
 }
 [@@deriving show, eq, sexp]
 (** All risk management parameters — nothing hardcoded. *)


### PR DESCRIPTION
## NS1 (#1557#3) — cash-floor closing-trade exemption

Root fix for the #1553 zombie: the live cash floor in core `Portfolio._check_sufficient_cash` is an absolute-dollar solvency check that subtracts ALL negative unrealized P&L (stale drag). It fires on Buy and Sell, so it can reject a short **cover** — the one trade that *reduces* risk — stranding the position into a -240% excursion. This adds a default-off exemption so a genuinely-reducing closing trade bypasses the floor.

### What it does
- New default-off field `Portfolio_risk.config.exempt_closing_trades_from_cash_floor : bool [@sexp.default false]` — the `portfolio_config` seam of `Weinstein_strategy.config`.
- Threaded as a **plain bool** into `Portfolio.create` via `Simulator.dependencies` / `create_deps` and `Panel_runner._make_simulator` (`config.portfolio_config....`). Core `Portfolio` never sees `Portfolio_risk` — it stays **strategy-agnostic** (A1-generalizable).
- When on, the floor (now delegated to the new `Portfolio_cash_floor` module) exempts the **reducing portion** of a closing trade (long sell / short cover). A genuinely-reducing trade (`|trade_qty| <= |position_qty|`) is accepted unconditionally; an over-cover that flips short->long exempts only the closing portion (`min(|trade_qty|, |position_qty|)` split, mirroring `portfolio_margin.ml:_classify_trade`) — the new-opening portion still faces the floor.

### Experiment-flag-discipline
- **R1 default-off**: `[@sexp.default false]`; all goldens bit-equal (full `dune runtest` exit 0, no re-pin).
- **R2 axis-able**: pinned by a new `test_variant_matrix.ml` test on the nested key path `portfolio_config.exempt_closing_trades_from_cash_floor` (expands + validates through `Overlay_validator`).
- **R3**: default stays `false`; promotion to on is human-gated after the NS4 WF-CV experiment.

### A1 authorization
Core `Portfolio` edit is authorized for this track per `dev/status/cash-floor-correctness.md` §Owner. The change is strategy-agnostic (a plain bool any strategy can set), so it passes the qc-behavioral A1 generalizability check.

### Test plan
- `test_portfolio.ml` (parameterized over AverageCost + FIFO): default-off no-op (cover still rejected), full cover exempt when flag on, partial cover exempt, over-cover opening-portion faces floor (rejected) / small opening portion accepted, **long-sell reducing is exempt** (proves generalization beyond shorts).
- `test_variant_matrix.ml`: nested axis expands + validates.
- Full `dune build && dune runtest && dune build @fmt` all exit 0.

### Code health
File-length / nesting linter pressure from the additions handled by **extracting** two modules (`Portfolio_cash_floor`, `Simulator_metrics`) — no limit bumps, no `@large-module` additions.

Plan: `dev/plans/cash-floor-closing-exempt-2026-06-13.md`. Next: NS2 (short-sale proceeds collateral design doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)