### PR TITLE
ops(budget): recover 4 orphan run records (~$44.36)

### DIFF
--- a/dev/budget/2026-06-09-27193801425.json
+++ b/dev/budget/2026-06-09-27193801425.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-06-09-27193801425",
+  "timestamp": "2026-06-09T08:36:01Z",
+  "commit_sha": "4306e4dc2b4242e75e117704559bcd18b2f9999d",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 2.8051570000000003,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-06-11-27354267295.json
+++ b/dev/budget/2026-06-11-27354267295.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-06-11-27354267295",
+  "timestamp": "2026-06-11T15:08:45Z",
+  "commit_sha": "bbd788793cad58fe91f96ecdf068acd07e33cf37",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 14.563065900000007,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-06-12-27389683009.json
+++ b/dev/budget/2026-06-12-27389683009.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-06-12-27389683009",
+  "timestamp": "2026-06-12T02:48:17Z",
+  "commit_sha": "cd95034271c7d9fdc5a58d4045c06c9deede3bfd",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 17.505466849999976,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-06-12-27405019134.json
+++ b/dev/budget/2026-06-12-27405019134.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-06-12-27405019134",
+  "timestamp": "2026-06-12T09:13:10Z",
+  "commit_sha": "4e4c0e1a5e2c4f3e861a7fdee459af64d025139e",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 9.481263450000004,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}


### PR DESCRIPTION
Recovers 4 budget JSONs pushed to `ops/budget-*` branches by overnight orchestrator runs but never bundled into a daily-summary PR (the no-op-skip-daily-PR path from #1336 dropped them along with the summary).

| run-id | $ |
|---|---|
| 2026-06-09-27193801425 | 2.81 |
| 2026-06-11-27354267295 | 14.56 |
| 2026-06-12-27389683009 | 17.51 |
| 2026-06-12-27405019134 | 9.48 |

Total ~$44.36, previously unrecorded on main. The 4 orphan branches are deleted after this lands. Ops-data only (no code) → admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)