### PR TITLE
ops(orchestrator): 8x daily cadence + raise per-run cap (Max-20x headroom)

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -27,11 +27,9 @@
 #     - CLAUDE_CODE_OAUTH_TOKEN   (claude-code-action auth)
 #     - GITHUB_TOKEN              (auto-provided by GHA; used for ghcr login)
 #
-#   cron_slots:              "17 7 * * *"   (00:17 PT / 07:17 UTC)
-#                            "17 13 * * *"  (06:17 PT / 13:17 UTC)
-#                            "17 19 * * *"  (12:17 PT / 19:17 UTC)
-#                            "17 1 * * *"   (18:17 PT / 01:17 UTC)
-#                            (UTC times — GitHub cron is UTC-only, no DST)
+#   cron_slots:              every 3h at :17 — 8 slots/day
+#                            00:17/03:17/06:17/09:17/12:17/15:17/18:17/21:17 PT
+#                            (07/10/13/16/19/22/01/04 UTC; cron UTC-only, no DST)
 #
 #   branch_patterns:         feat/, harness/, cleanup/, data/, fix/, ops/
 #   daily_summary_branch:    ops/daily-<date>-runN
@@ -75,19 +73,26 @@
 name: Daily orchestrator
 
 on:
-  # Four daily runs spaced 6h apart so routine agent work progresses
-  # through the day and overnight. Expanded from 2x to 4x on 2026-05-26
-  # to allow the orchestrator to pick up new tasks (e.g. v7 sweep speedup
-  # wins from `dev/status/sweep-perf.md`) more promptly between local
-  # sessions. Minute `:17` avoids top-of-hour GHA scheduler load
-  # (scheduled jobs at :00 – :05 get delayed or silently dropped).
-  # GitHub cron is UTC-only, no DST awareness — PT comments are
-  # informational (UTC-7 PDT; shift +1h during PST months).
+  # Eight daily runs spaced 3h apart. Progression: 2x (2026-04-26) -> 4x
+  # (2026-05-26) -> 8x (2026-06-13). Measured runs are 6-99 min (<2h), so a
+  # 3h gap leaves >1h margin; the concurrency guard below SKIPS (never
+  # parallelizes) the rare overrun, keeping the tighter cadence
+  # contamination-safe. Rationale for 8x: auth is a Max-20x subscription
+  # (flat-rate) and weekly utilization was ~13% — the binding constraint is
+  # eligible-work availability + rate-limits, not $ cost, so poll more often
+  # to pick up rework/follow-ups promptly. Empty-queue slots no-op in ~6 min.
+  # Minute `:17` avoids top-of-hour GHA scheduler load (scheduled jobs at
+  # :00 – :05 get delayed or silently dropped). GitHub cron is UTC-only, no
+  # DST awareness — PT comments are informational (UTC-7 PDT; +1h during PST).
   schedule:
     - cron: "17 7 * * *"    # 00:17 PT / 07:17 UTC
+    - cron: "17 10 * * *"   # 03:17 PT / 10:17 UTC
     - cron: "17 13 * * *"   # 06:17 PT / 13:17 UTC
+    - cron: "17 16 * * *"   # 09:17 PT / 16:17 UTC
     - cron: "17 19 * * *"   # 12:17 PT / 19:17 UTC
+    - cron: "17 22 * * *"   # 15:17 PT / 22:17 UTC
     - cron: "17 1 * * *"    # 18:17 PT / 01:17 UTC
+    - cron: "17 4 * * *"    # 21:17 PT / 04:17 UTC
   workflow_dispatch:
 
 # Queue, do not cancel, if a previous run is still executing when the

--- a/dev/config/merge-policy.json
+++ b/dev/config/merge-policy.json
@@ -2,9 +2,10 @@
   "followup_threshold": 10,
   "maintenance_cycle_ratio": 3,
   "auto_merge_enabled": true,
-  "max_daily_cost_usd": 50.0,
+  "_cost_note": "Auth is a Max-20x subscription (flat-rate, not per-token billing). The $ figures below are API-equivalent estimates only; they do not bill. max_daily_cost_usd is therefore a runaway-dispatch BACKSTOP, not a real budget — set high so it rarely gates, letting actual eligible-work availability + subscription rate-limits be the true constraint. Raised 50->200 on 2026-06-13 (weekly utilization was 13%).",
+  "max_daily_cost_usd": 200.0,
   "target_utilization_low": 0.60,
-  "target_utilization_high": 0.80,
+  "target_utilization_high": 0.95,
   "model_prices": {
     "_source": "https://claude.com/pricing — verified 2026-04-20",
     "_note": "Prices in USD per million tokens (MTok). cache_write is 5-minute TTL.",


### PR DESCRIPTION
Weekly subscription utilization was ~13% on a flat-rate Max-20x plan, so the $50 cost cap was throttling work already paid for.

**Changes:**
- Cron 4x (every 6h) → **8x (every 3h)**. Measured runs are 6-99 min (<2h), so a 3h gap keeps >1h margin; the `concurrency: cancel-in-progress: false` guard skips (never parallelizes) the rare overrun → tighter cadence stays contamination-safe.
- `max_daily_cost_usd` 50 → **200** (it is applied per-run, not daily-cumulative; under a flat subscription the $ figure is API-equivalent only and never bills, so it's now a runaway backstop, not a budget). `target_utilization_high` 0.80 → 0.95 so each run packs the dispatch queue fuller.

Binding constraint becomes eligible-work availability + subscription rate-limits, not $ cost. Empty-queue slots no-op in ~6 min. Infra/config only, no code → admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)