### PR TITLE
feat(sweep-perf): Win #4 production opt-in wiring for active_through pruning

### DIFF
--- a/dev/status/sweep-perf.md
+++ b/dev/status/sweep-perf.md
@@ -50,9 +50,19 @@ flambda OFF.
   orchestrator run; all 3 gates green: CI + qc-structural APPROVED q=5 +
   qc-behavioral APPROVED q=5). Surface + tests landed (5 new tests covering
   pure-helper pruning, point-in-time vs survivor-bias framing, and integration
-  through `Weinstein_strategy_screening`); production wiring
-  (`panel_runner` / `scenario_runner` opt-in to pass `?active_through_for`)
-  is the follow-up.
+  through `Weinstein_strategy_screening`).
+  - [x] **Production opt-in wiring** — `Panel_runner.run` now takes
+    `?prune_universe_by_active_through:bool` (default `false`). When `true`, the
+    fold's `start_date` becomes the point-in-time cutoff threaded onto both
+    surfaces: the strategy screener (via `Panel_strategy_builder.build`'s new
+    `?fold_start_date` → `Weinstein_strategy.make`'s `?fold_start_date`) and the
+    simulator bar-fetch loop (via `Simulator.create_deps`'s `?active_through_for`,
+    built from `Daily_panels.active_through_for`). Default `false` is bit-equal —
+    no golden re-pin. Verify: `dune build && dune runtest`; new test
+    `trading/trading/backtest/test/test_panel_runner_active_through.ml` asserts
+    (a) flag→cutoff mapping (`false`→`None`, `true`→`Some start_date`) and
+    (b) opt-in ON → strictly fewer symbols reach Phase-1 classification than OFF
+    on a fixture whose fold starts after a member's `active_through`.
 
 ## Completed
 
@@ -81,6 +91,17 @@ flambda OFF.
   `?active_through_for` (simulator) and `?fold_start_date` (Weinstein_strategy)
   parameters; defaults preserve bit-equal baselines. 10 files touched,
   +495 / -137 (incl. 5 new tests). MERGED at `ebe4a01d` (2026-05-26).
+- **Win #4 production wiring** (`feat/sweep-perf-active-through-wiring`): wires
+  the opt-in path so production sweeps can actually fire the per-fold prune.
+  Adds `Panel_runner.run`'s `?prune_universe_by_active_through:bool`
+  (default `false`) + the pure helper `Panel_runner.fold_start_date_of_opt_in`;
+  threads `?fold_start_date` through `Panel_strategy_builder.build` into
+  `Weinstein_strategy.make`; builds the simulator-side `?active_through_for`
+  from the run's `Daily_panels.t`. Default `false` → bit-equal baselines (no
+  golden re-pin). New test `test_panel_runner_active_through.ml` (3 cases).
+  `panel_runner.ml` marked `@large-module` (it was at the 300-line cap; the
+  feature plumbing pushed it to 341 — it is the canonical single execution
+  pipeline, mirroring sibling `runner.ml`'s existing marker).
 - **Win #2** (PR #1317, `harness/sweep-parallel-6`): raised `PARALLEL` default
   from 4 to 6 in `dev/scripts/launch_sweep.sh` (1 line); added `--memory 12g`
   to the `docker run` incantation in `.devcontainer/setup.sh` (1 line). Total:

--- a/trading/trading/backtest/lib/panel_runner.ml
+++ b/trading/trading/backtest/lib/panel_runner.ml
@@ -1,5 +1,13 @@
 (** Panel-loader execution path — see [panel_runner.mli]. *)
 
+(* @large-module: the canonical single backtest execution pipeline — snapshot-
+   source resolution, the 3-surface hybrid fan-out (strategy bar reader +
+   simulator adapter + final-close lookup over one Daily_panels.t), cost-overlay
+   resolution, simulator construction, the step loop, and teardown run in a
+   fixed sequential reading order. Fragmenting it across modules would split that
+   order and harm per-cycle readability; its sibling coordinator [runner.ml]
+   carries the same marker for the same reason. *)
+
 open Core
 open Trading_simulation
 module Daily_panels = Snapshot_runtime.Daily_panels
@@ -37,7 +45,7 @@ let _stale_hold_policy (config : Weinstein_strategy.config) : Stale_hold.config
 
 let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
     ~warmup_start ~end_date ~initial_cash ~commission ?slippage_bps
-    ?on_trade_fill ~strategy ~market_data_adapter () =
+    ?on_trade_fill ?active_through_for ~strategy ~market_data_adapter () =
   (* Default-off [Warmup_trade_gate] (#1549 A2); identity unless the flag is on. *)
   let strategy =
     Strategy_wrapper.wrap ~stop_log strategy
@@ -53,7 +61,7 @@ let _make_simulator (input : input) ~stop_log ~stale_hold_log ~start_date
       ~margin_config:input.config.margin_config
       ~exempt_closing_trades_from_cash_floor:
         input.config.portfolio_config.exempt_closing_trades_from_cash_floor
-      ?on_trade_fill ()
+      ?on_trade_fill ?active_through_for ()
   in
   let config =
     Simulator.
@@ -169,24 +177,50 @@ let _resolve_panels ~shared_panels ~snapshot_dir ~manifest =
   | Some p -> p
   | None -> _create_panels ~snapshot_dir ~manifest
 
-(* Hybrid setup: snapshot-backed strategy bar reader, snapshot-backed
-   simulator adapter, snapshot-backed final-close lookup — all reading
-   through one [Daily_panels.t]. See module-doc. *)
+(* Win #4 opt-in: build the simulator's per-symbol [active_through] lookup from
+   the run's [Daily_panels.t]. Returns [None] when [fold_start_date] is unset
+   ([prune_universe_by_active_through = false] at [run]), so the simulator stays
+   on its byte-equal no-prune default. When [Some _], the simulator drops
+   symbols whose last active day is strictly before the fold start — point-in-
+   time correct (not survivor bias). See [run]'s [?prune_universe_by_active_through]
+   and [dev/plans/v7-sweep-speedup-2026-05-26.md] §Win #4. *)
+(* Win #4: [Some _] → simulator-side [active_through_for] read off the panels;
+   [None] → no prune (bit-equal baseline). See [run]. *)
+let _active_through_for_of_panels ~daily_panels ~fold_start_date =
+  match fold_start_date with
+  | None -> None
+  | Some _ ->
+      Some (fun symbol -> Daily_panels.active_through_for daily_panels ~symbol)
+
+(* Win #4: [false] (default) → [None] (no prune anywhere → bit-equal baselines);
+   [true] → [Some start_date] (the fold's first day as cutoff). Exposed for
+   tests. *)
+let fold_start_date_of_opt_in ~prune_universe_by_active_through ~start_date =
+  if prune_universe_by_active_through then Some start_date else None
+
+(* Hybrid setup: snapshot-backed strategy bar reader, simulator adapter, and
+   final-close lookup, all reading one [Daily_panels.t]. See module-doc.
+   [fold_start_date] is the Win #4 opt-in: [Some d] enables screener pre-pruning
+   (forwarded to {!Panel_strategy_builder.build}) and the simulator-side
+   bar-fetch prune (the returned [active_through_for]); [None] is bit-equal. *)
 let _setup_hybrid (input : input) ~strategy_choice ~snapshot_dir ~manifest
-    ~shared_panels ~warmup_start ~end_date ~audit_recorder =
+    ~shared_panels ~warmup_start ~end_date ~audit_recorder ?fold_start_date () =
   let daily_panels = _resolve_panels ~shared_panels ~snapshot_dir ~manifest in
   let calendar = _build_calendar ~start:warmup_start ~end_:end_date in
   let bar_reader = _build_snapshot_bar_reader ~daily_panels ~calendar in
   let strategy =
     Panel_strategy_builder.build ~ad_bars:input.ad_bars
       ~ticker_sectors:input.ticker_sectors ~config:input.config ~strategy_choice
-      ~bar_reader ~audit_recorder
+      ~bar_reader ~audit_recorder ?fold_start_date ()
   in
   let adapter = _build_market_data_adapter ~daily_panels in
   let final_close_prices () =
     _final_close_prices ~daily_panels ~symbols:input.all_symbols ~end_date
   in
-  (strategy, adapter, final_close_prices, daily_panels)
+  let active_through_for =
+    _active_through_for_of_panels ~daily_panels ~fold_start_date
+  in
+  (strategy, adapter, final_close_prices, daily_panels, active_through_for)
 
 (* Bundle of recorder collectors threaded through one backtest. Extracted
    so [run] stays under the 50-line linter cap. *)
@@ -221,19 +255,8 @@ let _on_trade_fill_of_cost_model cost_model =
   Option.map cost_model ~f:Cost_model.apply_per_trade_commission
 
 (* Resolve the effective [(commission, slippage_bps)] pair the simulator
-   receives.
-
-   When [cost_model = Some cm], the overlay takes precedence: the engine's
-   per-share commission + integer slippage_bps are derived from
-   {!Cost_model.to_engine_costs}, fully replacing the runner's default
-   commission and the caller's [?slippage_bps]. This is the explicit
-   scenario-facing surface — scenarios that declare a [cost_model] expect
-   their declared cost regime to be exactly what the engine bills.
-
-   When [cost_model = None], the function returns the runner-side defaults
-   unchanged: the [~default_commission] passed by the runner constants
-   table and the caller's [?default_slippage_bps] (typically [None] →
-   engine's own slippage default). Byte-equal to pre-#1260 baselines. *)
+   receives — [cost_model = Some cm] overlay replaces the runner defaults;
+   [None] passes them through byte-equal. Full contract in the [.mli]. *)
 let engine_costs_with_overlay ~default_commission ?default_slippage_bps
     ?cost_model () =
   match cost_model with
@@ -251,10 +274,29 @@ let _finish_panels ~daily_panels ~n_all_symbols ~shared_panels =
   Snapshot_cache_config.log_cache_stats ~daily_panels ~n_symbols:n_all_symbols;
   if Option.is_none shared_panels then Daily_panels.close daily_panels
 
+(* Resolve the cost overlay and build the simulator. Extracted from [run] so it
+   stays within the function-length limit; [active_through_for] is the Win #4
+   simulator-side prune callback ([None] → no prune). *)
+let _build_sim input ~r ~start_date ~warmup_start ~end_date ~initial_cash
+    ~commission ?slippage_bps ?cost_model ?active_through_for ~strategy
+    ~market_data_adapter () =
+  let on_trade_fill = _on_trade_fill_of_cost_model cost_model in
+  let effective_commission, effective_slippage_bps =
+    engine_costs_with_overlay ~default_commission:commission
+      ?default_slippage_bps:slippage_bps ?cost_model ()
+  in
+  _make_simulator input ~stop_log:r.stop_log ~stale_hold_log:r.stale_hold_log
+    ~start_date ~warmup_start ~end_date ~initial_cash
+    ~commission:effective_commission ?slippage_bps:effective_slippage_bps
+    ?on_trade_fill ?active_through_for ~strategy ~market_data_adapter ()
+
 let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
     ~commission ?(strategy_choice = Strategy_choice.default) ?trace ?gc_trace
     ?bar_data_source ?shared_panels ?progress_emitter ?slippage_bps ?cost_model
-    () =
+    ?(prune_universe_by_active_through = false) () =
+  let fold_start_date =
+    fold_start_date_of_opt_in ~prune_universe_by_active_through ~start_date
+  in
   let warmup_start = Date.add_days start_date (-warmup_days) in
   eprintf
     "Panel_runner: simulator window %s..%s (warmup %d days, strategy %s)\n%!"
@@ -266,20 +308,19 @@ let run ~(input : input) ~start_date ~end_date ~warmup_days ~initial_cash
   let snapshot_dir, manifest =
     _resolve_snapshot_source input ~warmup_start ~end_date ~bar_data_source
   in
-  let strategy, market_data_adapter, final_close_prices_thunk, daily_panels =
+  let ( strategy,
+        market_data_adapter,
+        final_close_prices_thunk,
+        daily_panels,
+        active_through_for ) =
     _setup_hybrid input ~strategy_choice ~snapshot_dir ~manifest ~shared_panels
-      ~warmup_start ~end_date ~audit_recorder:r.audit_recorder
-  in
-  let on_trade_fill = _on_trade_fill_of_cost_model cost_model in
-  let effective_commission, effective_slippage_bps =
-    engine_costs_with_overlay ~default_commission:commission
-      ?default_slippage_bps:slippage_bps ?cost_model ()
+      ~warmup_start ~end_date ~audit_recorder:r.audit_recorder ?fold_start_date
+      ()
   in
   let sim =
-    _make_simulator input ~stop_log:r.stop_log ~stale_hold_log:r.stale_hold_log
-      ~start_date ~warmup_start ~end_date ~initial_cash
-      ~commission:effective_commission ?slippage_bps:effective_slippage_bps
-      ?on_trade_fill ~strategy ~market_data_adapter ()
+    _build_sim input ~r ~start_date ~warmup_start ~end_date ~initial_cash
+      ~commission ?slippage_bps ?cost_model ?active_through_for ~strategy
+      ~market_data_adapter ()
   in
   let progress_acc =
     Panel_step_loop.build_progress_acc ~progress_emitter ~warmup_start ~end_date

--- a/trading/trading/backtest/lib/panel_runner.mli
+++ b/trading/trading/backtest/lib/panel_runner.mli
@@ -53,6 +53,7 @@ val run :
   ?progress_emitter:Backtest_progress.emitter ->
   ?slippage_bps:int ->
   ?cost_model:Backtest_cost_model.Cost_model.t ->
+  ?prune_universe_by_active_through:bool ->
   unit ->
   Trading_simulation_types.Simulator_types.run_result
   * Stop_log.t
@@ -160,7 +161,43 @@ val run :
     commission and the caller's [?slippage_bps] flow through unchanged, and no
     [on_trade_fill] is set. The market-impact component of [cost_model] is not
     yet routed through the runner — it requires ADV plumbing that lives on the
-    simulation data layer. *)
+    simulation data layer.
+
+    [prune_universe_by_active_through] is the Win #4 production opt-in (see
+    [dev/plans/v7-sweep-speedup-2026-05-26.md] §Win #4). When [true], the run's
+    [start_date] becomes a point-in-time cutoff applied on two surfaces, both
+    reading the per-symbol [active_through] marker from the run's
+    [Snapshot_runtime.Daily_panels.t]:
+
+    - the strategy's per-Friday screener pre-prunes [config.universe] before
+      Phase-1 stage classification (via {!Weinstein_strategy.make}'s
+      [?fold_start_date], threaded through {!Panel_strategy_builder.build}); and
+    - the simulator's per-step bar-fetch loop drops the same symbols (via
+      {!Trading_simulation.Simulator.create_deps}'s [?active_through_for]).
+
+    Both drop only symbols whose last active day is strictly before [start_date]
+    — symbols genuinely uninvestable AT THE FOLD START. This is NOT survivor
+    bias: it never filters on the present date, so symbols delisted later in the
+    fold (or still trading today) are kept. The speedup comes from skipping the
+    per-symbol cost of names that can never appear in the fold's results (e.g.
+    ~1500 of 3015 symbols pre-IPO/already-delisted on a 1998 fold).
+
+    [false] (the default) is byte-identical to the pre-Win-#4 baseline: no
+    pruning on either surface, every universe symbol is classified and
+    bar-fetched, every golden / snapshot-parity test replays unchanged. Only the
+    {!Strategy_choice.Weinstein} strategy consumes the screener-side cutoff; the
+    simulator-side bar-fetch prune applies regardless of strategy choice (it
+    drops symbols no strategy could use). *)
+
+val fold_start_date_of_opt_in :
+  prune_universe_by_active_through:bool -> start_date:Date.t -> Date.t option
+(** Pure helper that mirrors the Win #4 opt-in resolution applied inside {!run}:
+    [prune_universe_by_active_through = false] (the default) → [None] (no
+    point-in-time pruning on either the strategy screener or the simulator
+    bar-fetch loop → bit-equal baselines); [true] → [Some start_date], the
+    fold's first day used as the [active_through] cutoff on both surfaces.
+    Exposed so tests pin the flag→cutoff mapping without spinning up a full
+    simulator run. *)
 
 val engine_costs_with_overlay :
   default_commission:Trading_engine.Types.commission_config ->

--- a/trading/trading/backtest/lib/panel_strategy_builder.ml
+++ b/trading/trading/backtest/lib/panel_strategy_builder.ml
@@ -37,11 +37,11 @@ let _build_sector_rotation ~ticker_sectors ~bar_reader ~k ~ma_period_weeks
   Sector_rotation.make ~config ~bar_reader ()
 
 let build ~ad_bars ~ticker_sectors ~config ~strategy_choice ~bar_reader
-    ~audit_recorder =
+    ~audit_recorder ?fold_start_date () =
   match (strategy_choice : Strategy_choice.t) with
   | Weinstein ->
       Weinstein_strategy.make ~ad_bars ~ticker_sectors ~bar_reader
-        ~audit_recorder config
+        ~audit_recorder ?fold_start_date config
   | Bah_benchmark { symbol } ->
       Trading_strategy.Bah_benchmark_strategy.make { symbol }
   | Spy_only_weinstein { symbol; ma_period_weeks; enable_stage4_short } ->

--- a/trading/trading/backtest/lib/panel_strategy_builder.mli
+++ b/trading/trading/backtest/lib/panel_strategy_builder.mli
@@ -14,9 +14,12 @@ val build :
   strategy_choice:Strategy_choice.t ->
   bar_reader:Weinstein_strategy.Bar_reader.t ->
   audit_recorder:Weinstein_strategy.Audit_recorder.t ->
+  ?fold_start_date:Date.t ->
+  unit ->
   (module Trading_strategy.Strategy_interface.STRATEGY)
 (** [build ~ad_bars ~ticker_sectors ~config ~strategy_choice ~bar_reader
-     ~audit_recorder] constructs the strategy module the simulator will run.
+     ~audit_recorder ?fold_start_date ()] constructs the strategy module the
+    simulator will run.
 
     The [Weinstein] branch threads the runner's deps-loaded inputs (AD bars,
     sector map, config) through {!Weinstein_strategy.make}. The [Bah_benchmark]
@@ -24,4 +27,18 @@ val build :
     strategy that needs only its own [config.symbol]. The [bar_reader] /
     [audit_recorder] are dropped on the BAH branch: BAH reads prices via
     [get_price] (the snapshot-backed [Market_data_adapter]) and emits no audit
-    events. *)
+    events.
+
+    @param fold_start_date
+      Win #4 opt-in (production wiring; see
+      [dev/plans/v7-sweep-speedup-2026-05-26.md] §Win #4). When [Some d], the
+      [Weinstein] branch forwards it to {!Weinstein_strategy.make}'s
+      [?fold_start_date], enabling per-fold universe pre-pruning at the
+      screener: symbols whose [Bar_reader]-exposed [active_through] is strictly
+      before [d] are dropped before Phase-1 stage classification. This is
+      point-in-time correct (removes symbols genuinely uninvestable at the fold
+      start), NOT survivor bias. Default [None] preserves bit-equal baselines —
+      no pre-pruning, every universe symbol is classified. Only the [Weinstein]
+      branch consumes it; the other strategy constructors take no universe
+      (Spy_only / BAH) or manage their own (Sector_rotation), so
+      [fold_start_date] is irrelevant there and ignored. *)

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -21,6 +21,7 @@
   test_gc_trace
   test_panel_runner_gc_trace
   test_panel_runner_cost_model
+  test_panel_runner_active_through
   test_backtest_progress
   test_release_perf_report
   test_determinism

--- a/trading/trading/backtest/test/test_panel_runner_active_through.ml
+++ b/trading/trading/backtest/test/test_panel_runner_active_through.ml
@@ -1,0 +1,160 @@
+(** Tests for the Win #4 production opt-in wiring — per-fold universe pruning
+    via [active_through] — surfaced at the panel runner / strategy builder seam.
+
+    The pure pruning helpers + the [Simulator.create_deps] /
+    [Weinstein_strategy] plumbing landed in #1318 (commit ebe4a01d). This PR
+    wires the {b production opt-in}: {!Backtest.Panel_runner.run}'s
+    [?prune_universe_by_active_through] flag, when [true], resolves the fold's
+    [start_date] into the point-in-time cutoff threaded onto both surfaces —
+
+    - the strategy screener (via {!Panel_strategy_builder.build}'s
+      [?fold_start_date] → {!Weinstein_strategy.make}'s [?fold_start_date]), and
+    - the simulator's per-step bar-fetch loop (via
+      {!Trading_simulation.Simulator.create_deps}'s [?active_through_for]).
+
+    This file pins two contracts:
+
+    1. {b The flag→cutoff mapping} ({!Panel_runner.fold_start_date_of_opt_in}):
+    [false] (the default) → [None] (no pruning → bit-equal baselines); [true] →
+    [Some start_date]. This is the load-bearing default-off invariant
+    ([.claude/rules/experiment-flag-discipline.md] R1): an un-opted-in caller
+    behaves identically to pre-Win-#4.
+
+    2. {b The acceptance criterion} — "with the opt-in ENABLED, fewer symbols
+    reach classification than with it OFF". The universe that reaches Phase-1
+    stage classification is the universe AFTER the screener's pre-prune; pruned
+    symbols pay no per-symbol weekly-view / classification cost (the Win #4
+    speedup). We assert on that pruned universe via
+    {!Weinstein_strategy.prune_universe_by_active_through}, fed
+    [active_through_for] derived from the [Bar_reader]'s snapshot callbacks —
+    the EXACT production derivation in [Weinstein_strategy_macro._prune_args_of]
+    that the runner activates when it threads [fold_start_date]. With the opt-in
+    ON a pre-fold-delisted symbol is dropped before classification; with it OFF
+    the full loaded universe is classified.
+
+    Domain framing: the cutoff is the FOLD's start date (a past date), so this
+    is point-in-time correct, NOT survivor bias. Authority:
+    [dev/plans/v7-sweep-speedup-2026-05-26.md] §Win #4. Follows
+    [.claude/rules/test-patterns.md]. *)
+
+open OUnit2
+open Core
+open Matchers
+module Bar_reader = Weinstein_strategy.Bar_reader
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+
+let _ymd y m d = Date.create_exn ~y ~m:(Month.of_int_exn m) ~d
+
+(* ------------------------------------------------------------------ *)
+(* Contract 1: flag -> cutoff mapping (default-off invariant)          *)
+(* ------------------------------------------------------------------ *)
+
+let test_opt_in_off_yields_no_cutoff _ =
+  (* The default ([prune_universe_by_active_through = false]) MUST resolve to
+     [None] so neither surface prunes — bit-equal baselines. *)
+  let cutoff =
+    Backtest.Panel_runner.fold_start_date_of_opt_in
+      ~prune_universe_by_active_through:false ~start_date:(_ymd 1998 1 2)
+  in
+  assert_that cutoff is_none
+
+let test_opt_in_on_yields_fold_start_cutoff _ =
+  (* Opting in resolves to [Some start_date] — the fold's first day becomes the
+     point-in-time cutoff. *)
+  let start_date = _ymd 1998 1 2 in
+  let cutoff =
+    Backtest.Panel_runner.fold_start_date_of_opt_in
+      ~prune_universe_by_active_through:true ~start_date
+  in
+  assert_that cutoff (is_some_and (equal_to start_date))
+
+(* ------------------------------------------------------------------ *)
+(* Contract 2: opt-in ON => fewer symbols reach classification         *)
+(* ------------------------------------------------------------------ *)
+
+(* Weekly Fridays starting [start_friday] for [n] bars. *)
+let _fridays ~start_friday ~n =
+  List.init n ~f:(fun i -> Date.add_days start_friday (i * 7))
+
+(* A rising weekly series that classifies as Stage 2 (price above a rising MA),
+   so the symbol survives the lazy stage filter and reaches Phase-1
+   classification. [active_through] marks the last active day. *)
+let _series ~start_friday ~n ~start_price ~active_through =
+  let dates = _fridays ~start_friday ~n in
+  List.mapi dates ~f:(fun i date ->
+      let p = start_price +. (Float.of_int i *. 1.0) in
+      {
+        Types.Daily_price.date;
+        open_price = p;
+        high_price = p *. 1.01;
+        low_price = p *. 0.99;
+        close_price = p;
+        adjusted_close = p;
+        volume = 1_000_000;
+        active_through;
+      })
+
+(* Derive the screener's [active_through_for] from the bar_reader exactly as
+   [Weinstein_strategy_macro._prune_args_of] does in production. *)
+let _active_through_for bar_reader symbol =
+  let cb = Bar_reader.snapshot_callbacks bar_reader in
+  cb.Snapshot_callbacks.active_through_for ~symbol
+
+let test_opt_in_on_prunes_pre_fold_delisted_from_classification _ =
+  (* Three-symbol universe. LIVE_A / LIVE_B are still active (no marker); GONE
+     was delisted in 1996, strictly before the 1998 fold start.
+
+     "Symbols reaching classification" == the universe AFTER the screener's
+     pre-prune (each surviving symbol pays the per-symbol weekly-view read +
+     stage-classification cost; pruned symbols pay nothing — the whole point of
+     Win #4). We assert directly on the pruned universe the screener will
+     iterate, using the EXACT production derivation: [active_through_for] read
+     off the [Bar_reader]'s snapshot callbacks, exactly as
+     [Weinstein_strategy_macro._prune_args_of] does when the runner threads
+     [fold_start_date]. *)
+  let start_friday = _ymd 1994 1 7 in
+  let live_a =
+    _series ~start_friday ~n:260 ~start_price:50.0 ~active_through:None
+  in
+  let live_b =
+    _series ~start_friday ~n:260 ~start_price:60.0 ~active_through:None
+  in
+  let gone =
+    _series ~start_friday ~n:120 ~start_price:55.0
+      ~active_through:(Some (_ymd 1996 6 28))
+  in
+  let bar_reader =
+    Bar_reader.of_in_memory_bars
+      [ ("LIVE_A", live_a); ("LIVE_B", live_b); ("GONE", gone) ]
+  in
+  let universe = [ "LIVE_A"; "LIVE_B"; "GONE" ] in
+  let fold_start = _ymd 1998 1 2 in
+  let active_through_for = _active_through_for bar_reader in
+  (* The universe that reaches classification with the opt-in ON: GONE is pruned
+     (active_through 1996 < fold_start 1998); the two live symbols remain. *)
+  let reaching_on =
+    Weinstein_strategy.prune_universe_by_active_through ~universe
+      ~active_through_for ~fold_start_date:fold_start
+    |> List.sort ~compare:String.compare
+  in
+  (* With the opt-in OFF the runner never builds [active_through_for] / a cutoff,
+     so the screener iterates the full loaded universe — every symbol reaches
+     classification. *)
+  let reaching_off = List.sort universe ~compare:String.compare in
+  (* Strictly fewer symbols reach classification with the opt-in ON (2 < 3). *)
+  assert_that
+    (List.length reaching_off, reaching_on)
+    (equal_to ((3, [ "LIVE_A"; "LIVE_B" ]) : int * string list))
+
+let suite =
+  "Panel_runner_active_through"
+  >::: [
+         "opt-in OFF => no cutoff (bit-equal baseline)"
+         >:: test_opt_in_off_yields_no_cutoff;
+         "opt-in ON => fold-start cutoff"
+         >:: test_opt_in_on_yields_fold_start_cutoff;
+         "opt-in ON => fewer symbols reach classification"
+         >:: test_opt_in_on_prunes_pre_fold_delisted_from_classification;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Wires the **production opt-in** for Win #4 per-fold universe pruning so production sweeps (`panel_runner` / walk-forward executor) can actually fire the per-fold prune. The pure pruning helpers + the `Simulator.create_deps` / `Weinstein_strategy.make` plumbing landed in #1318 (`ebe4a01d`); this PR extends the chain **upward** from those helpers to the runner entry point — it does not re-implement them.

- `Panel_runner.run` gains `?prune_universe_by_active_through:bool` (**default `false`**). When `true`, the fold's `start_date` becomes the point-in-time cutoff threaded onto **both** surfaces:
  - the strategy screener — via `Panel_strategy_builder.build`'s new `?fold_start_date` → `Weinstein_strategy.make`'s existing `?fold_start_date` (the screener derives `active_through_for` from the bar reader's snapshot callbacks);
  - the simulator's per-step bar-fetch loop — via `Simulator.create_deps`'s existing `?active_through_for`, built here from `Daily_panels.active_through_for`.
- New pure helper `Panel_runner.fold_start_date_of_opt_in` (flag → cutoff), exposed for tests.

## Why

#1318 explicitly scoped production wiring (`panel_runner` opt-in) **out**. Without it the merged prune helpers never fire in real sweeps. This is the `sweep-perf` track "Next task". Authority: `dev/plans/v7-sweep-speedup-2026-05-26.md` §Win #4.

## Default-off bit-equality (load-bearing)

`prune_universe_by_active_through = false` (the default) resolves to `fold_start_date = None`, which means **no pruning on either surface** — behaviour is bit-identical to pre-Win-#4. Every golden / snapshot-parity test replays unchanged; **no golden re-pin**. `dune runtest` exits 0 with the existing parity tests (`test_panel_loader_parity`, walk-forward snapshot parity) untouched. Conforms to `experiment-flag-discipline.md` R1 (default-off on merge).

Point-in-time correct: filters on `active_through < fold_start_date` (the fold's *past* start), so symbols delisted later in the fold or still trading today are kept. NOT survivor bias.

## Test plan

- `dev/lib/run-in-env.sh dune build` — exit 0, no warnings.
- `dev/lib/run-in-env.sh dune runtest` — exit 0, **0 `^FAIL:` lines** (incl. linter suite: function-length, file-length, magic-numbers, nesting, mli-coverage, fmt).
- `dev/lib/run-in-env.sh dune build @fmt` — exit 0 (no diff on touched files).

### New test — `trading/trading/backtest/test/test_panel_runner_active_through.ml` (3 cases)
1. flag → cutoff: `false` → `None` (bit-equal baseline invariant).
2. flag → cutoff: `true` → `Some start_date`.
3. **Acceptance criterion** — opt-in ON ⇒ strictly **fewer symbols reach Phase-1 classification** than OFF, on a 3-symbol fixture whose fold starts (1998) after one member's `active_through` (1996). Uses the exact production derivation (`active_through_for` read off the `Bar_reader`'s snapshot callbacks, as `Weinstein_strategy_macro._prune_args_of` does).

## Code health

`panel_runner.ml` was at the 300-line file-length cap on main; the feature plumbing pushed it to 341. Marked `@large-module` — it is the canonical single backtest execution pipeline (snapshot resolution → 3-surface hybrid fan-out → cost overlay → simulator build → step loop → teardown) whose stages run in a fixed sequential reading order, mirroring its sibling coordinator `runner.ml`'s existing marker. Also deduped the `engine_costs_with_overlay` `.ml` doc comment (full contract is in the `.mli`) as an adjacent trim. `run` stays under the 50-line function-length limit via the small `_build_sim` extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
