### PR TITLE
fix(portfolio): flip exempt_closing_trades_from_cash_floor default -> ON (correctness)

### DIFF
--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.ml
@@ -62,7 +62,7 @@ type config = {
   big_winner_multiplier : float;
   force_liquidation : Force_liquidation.config;
       [@sexp.default Force_liquidation.default_config]
-  exempt_closing_trades_from_cash_floor : bool; [@sexp.default false]
+  exempt_closing_trades_from_cash_floor : bool; [@sexp.default true]
 }
 [@@deriving show, eq, sexp]
 
@@ -82,7 +82,7 @@ let default_config =
     max_unknown_sector_positions = 2;
     big_winner_multiplier = 1.5;
     force_liquidation = Force_liquidation.default_config;
-    exempt_closing_trades_from_cash_floor = false;
+    exempt_closing_trades_from_cash_floor = true;
   }
 
 (* ---- Snapshot helpers ---- *)

--- a/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
+++ b/trading/trading/weinstein/portfolio_risk/lib/portfolio_risk.mli
@@ -202,7 +202,7 @@ type config = {
       [@sexp.default Force_liquidation.default_config]
       (** Force-liquidation thresholds — see {!Force_liquidation}. Default: 50%
           per-position loss, 40% portfolio-of-peak floor. *)
-  exempt_closing_trades_from_cash_floor : bool; [@sexp.default false]
+  exempt_closing_trades_from_cash_floor : bool; [@sexp.default true]
       (** NS1 (#1557#3): when [true], the core [Portfolio] cash floor
           ([Portfolio._check_sufficient_cash]) skips the solvency check for the
           {b reducing portion} of a closing trade (a long sell or short cover),
@@ -211,15 +211,20 @@ type config = {
           short->long exempts only the closing portion; the new-long portion
           still faces the floor.
 
-          Default-off ([false]) ⇒ the floor behaves exactly as before (the full
-          trade faces the check). This field is the [portfolio_config] seam of
-          [Weinstein_strategy.config], so it is expressible as a
-          [Variant_matrix] axis on the dot-path
+          Default-ON ([true]) as of 2026-06-14 (#1557#3 promotion). This is a
+          {b correctness invariant}, not an alpha promotion: a closing/reducing
+          trade improves solvency by construction, so a solvency floor must
+          never block it — the #1553 −240% zombie is the concrete failure of the
+          old default-off behaviour. Promoted on that correctness basis
+          (experiment-flag-discipline R3-NA, mirroring the warmup-flip #1566),
+          not on an NS4 WF-CV ACCEPT. Set [false] to restore the legacy
+          behaviour (full trade faces the check). This field is the
+          [portfolio_config] seam of [Weinstein_strategy.config], so it is
+          expressible as a [Variant_matrix] axis on the dot-path
           [portfolio_config.exempt_closing_trades_from_cash_floor]. Strategy
           code does not read it directly; the simulator threads its value into
           [Portfolio.create] as a plain bool, keeping core [Portfolio]
-          strategy-agnostic. Promotion to default-on is human-gated, pending the
-          NS4 WF-CV experiment (experiment-flag-discipline R3). *)
+          strategy-agnostic. *)
 }
 [@@deriving show, eq, sexp]
 (** All risk management parameters — nothing hardcoded. *)

--- a/trading/trading/weinstein/portfolio_risk/test/test_portfolio_risk.ml
+++ b/trading/trading/weinstein/portfolio_risk/test/test_portfolio_risk.ml
@@ -623,6 +623,14 @@ let test_deriving _ =
   let _ = show_limit_violation (Max_positions_exceeded 20) in
   assert_that default_config (equal_to ~cmp:equal_config default_config)
 
+(* Pins the 2026-06-14 promotion (#1557#3): the cash-floor closing-trade
+   exemption is ON by default — a correctness invariant (a risk-reducing close
+   must never be blocked by the cash floor; the #1553 zombie was the failure of
+   the old default-off). A refactor must not silently revert this default. *)
+let test_cash_floor_exemption_on_by_default _ =
+  assert_that default_config.exempt_closing_trades_from_cash_floor
+    (equal_to true)
+
 let suite =
   "portfolio_risk"
   >::: [
@@ -686,6 +694,8 @@ let suite =
          "snapshot_buckets_missing_sectors_as_unknown"
          >:: test_snapshot_buckets_missing_sectors_as_unknown;
          "deriving" >:: test_deriving;
+         "cash_floor_exemption_on_by_default"
+         >:: test_cash_floor_exemption_on_by_default;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
Promotes the NS1 cash-floor closing-trade exemption (#1567) to **default-ON**.

## Why — correctness invariant, not alpha promotion (R3-NA)
A closing/reducing trade improves solvency by construction, so the absolute cash-floor solvency check must never block it. The old default-off behaviour is what produced the **#1553 −240% zombie** (a short *cover* — risk-reducing — was rejected, stranding the position). Same correctness framing as the warmup-flip #1566; promoted on that basis, not on an NS4 WF-CV ACCEPT.

## Blast radius: zero golden re-pins
Full `dune runtest` exits 0 — **bit-equal across the entire suite**. The exemption only fires on a blocked cover, which no committed golden exercises, so flipping the default changes no backtest result. It is a pure safety-net for the live/edge-case path.

## Changes
- `portfolio_risk.{ml,mli}`: `[@sexp.default false] -> true` + `default_config` value; docstring rewritten to the correctness framing.
- `test_portfolio_risk.ml`: pins `default_config.exempt_closing_trades_from_cash_floor = true` so a refactor can't silently revert the default.

Not core `trading/portfolio/` (the field lives in the Weinstein `portfolio_risk` config seam; the already-merged+approved logic in core `Portfolio` is unchanged). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)