### PR TITLE
feat(rolling-start): realized-edge + forward-index-DD lens columns

### DIFF
--- a/dev/plans/rolling-start-realized-edge-lens-2026-06-14.md
+++ b/dev/plans/rolling-start-realized-edge-lens-2026-06-14.md
@@ -1,0 +1,105 @@
+# Plan — rolling-start realized-edge + forward-index-DD lens (2026-06-14)
+
+## Context
+
+The factor-decomposition lens design (`dev/notes/factor-decomposition-lens-design-2026-06-14.md`)
+names **realized-edge** as the *primary* outcome column for the rolling-start
+matrix and **forward index max-DD** as the H1 ("dodge-a-correction") factor.
+Today the matrix emits MTM `edge_pct` (annualised strategy CAGR − benchmark
+CAGR) — contaminated by terminal mark-to-market on still-open positions
+(post-2020 starts show +MTM-edge with deeply −realized; the AXTI effect). It
+does NOT emit the design's honest primary outcome.
+
+Both new columns are *pure projections* of data the runner already owns: the
+`Summary.t` already yields `realized_return_pct` (MTM stripped), and the runner
+already resolves the full benchmark close series once and threads a scalar
+`benchmark_cagr_pct` per start. This increment adds the two columns as strict
+additions; it is GHA-buildable + GHA-testable with no external data (tests
+construct `Summary.t` directly and call `per_start_of_summary`).
+
+## Approach
+
+Add two fields to `Rolling_start_types.per_start`:
+
+1. **`realized_edge_pct : float`** — `annualized_realized_cagr − benchmark_cagr_pct`.
+   `annualized_realized_cagr` is `realized_return_pct` (a *total* realized return)
+   run through the **same** `Walk_forward_runner.cagr_pct ~test_days ~total_return_pct`
+   convention `cagr_pct`/`bah_cagr_pct` use, so it is directly comparable to
+   `benchmark_cagr_pct`. `Float.nan` when `benchmark_cagr_pct` is nan (mirror the
+   existing `edge_pct` nan discipline exactly). The honest counterpart to the
+   contaminated MTM `edge_pct`.
+
+2. **`forward_index_max_dd_pct : float`** — the benchmark's worst peak-to-trough
+   drawdown over `[start_date, end_date]`, as a **negative** percent (matching the
+   existing `max_drawdown_pct` sign convention: tests pin it negative, e.g.
+   `-42.0`). Computed from the benchmark close series clipped to the window.
+   `Float.nan` when no benchmark / unpriceable window (same nan discipline as
+   `bah_cagr_pct`).
+
+### Seam plumbing
+
+- New pure runner fn `bench_max_dd_pct ~start_date ~end_date ~close_series : float`
+  mirroring `bah_cagr_pct`: clip the series to `[start,end]`, compute worst
+  peak-to-trough decline as a negative percent, `nan` when fewer than 2 usable
+  bars in-window.
+- `per_start_of_summary` gains two optional params `?benchmark_cagr_pct` (exists)
+  + new `?benchmark_max_dd_pct` (default `Float.nan`). `realized_edge_pct` is
+  computed internally from the already-computed `realized_return_pct` + `test_days`.
+  `forward_index_max_dd_pct` is recorded verbatim from `?benchmark_max_dd_pct`.
+- `_run_one` computes the windowed max-DD via `bench_max_dd_pct` from the
+  already-resolved `benchmark_series` and passes it through.
+
+### Report superset
+
+- `Rolling_start_types.build` gains two new `Dispersion_stats.summary` columns
+  (`realized_edge`, `forward_index_max_dd`), computed over the same eligible
+  subset. `realized_edge` skips nan rows like `edge`.
+- Markdown: add the two columns to the per-start detail table + the dispersion
+  table + the robustness summary, all as ADDITIONS after the existing columns.
+- `[@@deriving sexp]` on `per_start`/`report` re-pins the *internal* sexp shape
+  (new fields appended) — acceptable per the dispatch (new-field reality). No
+  checked-in backtest golden consumes `rolling_start_types` sexp (verified:
+  `grep -r rolling_start trading/test_data/` empty), so this is backtest-golden
+  bit-equal.
+
+## Files to change
+
+- `trading/trading/backtest/rolling_start/lib/rolling_start_types.{mli,ml}` — two
+  new `per_start` fields + two new `report` summary fields + `build` + renderers.
+- `trading/trading/backtest/rolling_start/lib/rolling_start_runner.{mli,ml}` —
+  new `bench_max_dd_pct`; `per_start_of_summary` gains `?benchmark_max_dd_pct`;
+  `_run_one` threads the windowed max-DD.
+- `trading/trading/backtest/rolling_start/test/test_rolling_start_runner.ml` — new
+  cases (realized-edge value, nan-without-benchmark, forward-DD known peak→trough,
+  forward-DD nan empty window, realized-vs-MTM divergence).
+- `trading/trading/backtest/rolling_start/test/test_rolling_start_types.ml` —
+  extend `make_start`, sexp round-trip, markdown-contains-sections for new cols.
+- `dev/status/rolling-start-lens.md` (new), one new `dev/status/_index.md` row.
+
+## Risks
+
+- **Sign convention.** `forward_index_max_dd_pct` must match `max_drawdown_pct`
+  (negative). Pin with a test (100→120→90 → −25%).
+- **cagr_pct on negative realized return.** `realized_return_pct` ≥ −100% always
+  (can't lose more than the stake on a long-only banked basis), so
+  `1 + r/100 ≥ 0` and `cagr_pct` is well-defined. If a synthetic test pushes
+  below −100% the result is nan — not exercised here.
+- **Golden churn.** Mitigated: no golden consumes the sexp. If a hidden one
+  surfaces, STOP and report (do not re-pin a backtest golden).
+
+## Acceptance
+
+- `dune build && dune runtest` green, zero warnings; `dune fmt` clean.
+- New columns covered by domain-value tests (one `assert_that` per value,
+  composed via `field`/`all_of`/`float_equal`).
+- Backtest goldens bit-equal (verified by grep — no consumer).
+- `.mli` doc comments for every new public surface.
+
+## Out of scope (data-gated / local-session — NOT in this PR)
+
+- The three external-data factor columns: SPY/macro stage at start, Stage-2
+  candidate count at start, sector-RS dispersion at start (need the snapshot
+  warehouse + screener — maintainer-local / GHA-data-gated).
+- The actual 31-start causal analysis / hypothesis confirm-refute / deployment
+  rule (needs the top-3000 PIT warehouse — not in GHA).
+- Any new `bin/` driver beyond the existing `rolling_start_eval`. No Python.

--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -17,6 +17,7 @@ Each row: one line; deeper task detail in the linked status file.
 | [cash-floor-correctness](cash-floor-correctness.md) | IN_PROGRESS | feat-weinstein | — | NS1 impl+flip ON (#1567/#1582 correctness), NS2 design+NS3 MERGED (#1569/#1575); next: NS2 impl (human-gated), NS4 optional DD-validation (data-gated) |
 | [backtest-scale](backtest-scale.md) | MERGED | — | — | — |
 | [backtest-perf](backtest-perf.md) | IN_PROGRESS | feat-backtest | — | rolling-start v2 merged (#1536: jittered starts, edge-vs-SPY matrix, fork-per-start); next: run matrix on composition-policy universe |
+| [rolling-start-lens](rolling-start-lens.md) | IN_PROGRESS | feat-backtest | #1586 | realized-edge + forward-index-DD per-start columns (#1586); next: 3 data-gated factor cols (macro-stage, Stage-2 count, sector-RS) + 31-start causal analysis |
 | [sweep-perf](sweep-perf.md) | IN_PROGRESS | harness-maintainer | — | Win #4 production wiring MERGED (#1574, opt-in default-off); next: manual ghcr.io flambda rebuild + enable prune opt-in in sweeps |
 | [cost-model](cost-model.md) | MERGED | — | — | — |
 | [data-panels](data-panels.md) | MERGED | — | — | — |

--- a/dev/status/rolling-start-lens.md
+++ b/dev/status/rolling-start-lens.md
@@ -1,0 +1,75 @@
+# Status: rolling-start-lens
+
+## Last updated: 2026-06-14
+
+## Status
+IN_PROGRESS
+
+## Interface stable
+YES
+
+## Owner
+
+feat-backtest
+
+The factor-decomposition lens on the rolling-start matrix: decompose **when**
+and **why** the strategy beats the benchmark, per start, joining each start to
+causal factors that steer deployment. Design authority:
+`dev/notes/factor-decomposition-lens-design-2026-06-14.md`.
+
+First deliverable (the two GHA-buildable outcome/factor columns) in review as
+PR #1586. The data-gated factor columns + the causal analysis are
+maintainer-local follow-ups.
+
+### Interface
+
+`Rolling_start_types.per_start` gains two fields (`realized_edge_pct`,
+`forward_index_max_dd_pct`) and `Rolling_start_types.report` gains two
+dispersion summaries (`realized_edge`, `forward_index_max_dd`). Pure additions;
+existing columns/ordering preserved as a strict superset. `Rolling_start_runner`
+gains `bench_max_dd_pct` and a `?benchmark_max_dd_pct` param on
+`per_start_of_summary`.
+
+### Completed
+
+- [x] **Realized-edge + forward-index-DD lens columns** (PR #1586). Adds the
+      design's *primary* outcome (`realized_edge_pct` = annualised
+      MTM-stripped realized return − benchmark CAGR, the honest counterpart to
+      the contaminated MTM `edge_pct`) and the H1 "dodge-a-correction" factor
+      (`forward_index_max_dd_pct` = benchmark worst peak-to-trough over the
+      window, negative-percent sign convention). Both are pure projections of
+      data the runner already owns (`Summary.t` realized return + the
+      once-resolved benchmark close series). Superset additions to the sexp +
+      markdown report. Backtest goldens bit-equal (no golden consumes the
+      `rolling_start_types` sexp — verified by grep over `trading/test_data/`).
+      Verify: `dev/lib/run-in-env.sh dune runtest trading/backtest/rolling_start/test/`.
+      Files: `trading/trading/backtest/rolling_start/lib/rolling_start_{types,runner}.{ml,mli}`,
+      `trading/trading/backtest/rolling_start/test/test_rolling_start_{types,runner}.ml`.
+
+### In-progress
+
+- (none — PR #1586 awaiting QC)
+
+### Next steps (data-gated / local-session — NOT GHA)
+
+These need the top-3000 PIT snapshot warehouse + screener, so they are
+maintainer-local, not GHA-dispatchable. Tag `[blocking: by warehouse build]`
+when a downstream decision starts to depend on them.
+
+- [ ] **Macro-stage-at-start column** — stage classifier on GSPC at each
+      `start_date` (1/2/3/4) + `Macro_composite` continuous value (already in the
+      snapshot warehouse per date).
+- [ ] **Stage-2-candidate-count-at-start column** — screener candidate count on
+      `start_date` (the H3 fresh-supply factor).
+- [ ] **Sector-RS-dispersion-at-start column** — spread of sector relative
+      strength on `start_date`.
+- [ ] **31-start causal analysis** — per-factor Spearman vs realized-edge +
+      tercile contingency, 3-4 traced starts (one clean beat, one melt-up miss,
+      one bear-start), confirm/refute H1/H2/H3, and the resulting deployment
+      rule. Persist as a `project_*` memory + experiment writeup
+      (`dev/experiments/...`). Needs the top-3000 PIT warehouse.
+
+### Commits
+
+- Plan: `dev/plans/rolling-start-realized-edge-lens-2026-06-14.md`
+- PR #1586 `feat/rolling-start-realized-edge-lens`

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_runner.ml
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_runner.ml
@@ -55,6 +55,31 @@ let bah_cagr_pct ~start_date ~end_date ~close_series =
       Walk_forward.Walk_forward_runner.cagr_pct ~test_days ~total_return_pct
   | _ -> Float.nan
 
+(* Scan a chronological close list once: track the running peak, accumulate the
+   most-negative peak-to-trough decline as a negative percent (0.0 = no decline).
+   [first_close] seeds the running peak. *)
+let _worst_peak_to_trough ~first_close closes =
+  let _peak, worst_dd =
+    List.fold closes ~init:(first_close, 0.0)
+      ~f:(fun (peak, worst) (_, close) ->
+        let peak = Float.max peak close in
+        let dd = (close -. peak) /. peak *. 100.0 in
+        (peak, Float.min worst dd))
+  in
+  worst_dd
+
+let bench_max_dd_pct ~start_date ~end_date ~close_series =
+  (* Closes whose date is in [start_date .. end_date], chronological. *)
+  let in_window =
+    List.filter close_series ~f:(fun (d, _) ->
+        Date.( >= ) d start_date && Date.( <= ) d end_date)
+    |> List.sort ~compare:(fun (a, _) (b, _) -> Date.compare a b)
+  in
+  match in_window with
+  | (_, first_close) :: _ :: _ when Float.( > ) first_close 0.0 ->
+      _worst_peak_to_trough ~first_close in_window
+  | _ -> Float.nan
+
 (* Realized-basis return: strip the terminal unrealized mark on open positions
    so a single big paper winner cannot flatter the row. nan only when initial
    cash is non-positive (degenerate). *)
@@ -62,9 +87,9 @@ let _realized_return_pct ~initial_cash ~final_value ~unrealized_pnl =
   if Float.( <= ) initial_cash 0.0 then Float.nan
   else (final_value -. unrealized_pnl -. initial_cash) /. initial_cash *. 100.0
 
-let per_start_of_summary ?(benchmark_cagr_pct = Float.nan) ?(equity_curve = [])
-    ~start_date ~end_date (summary : Backtest.Summary.t) :
-    Rolling_start_types.per_start =
+let per_start_of_summary ?(benchmark_cagr_pct = Float.nan)
+    ?(benchmark_max_dd_pct = Float.nan) ?(equity_curve = []) ~start_date
+    ~end_date (summary : Backtest.Summary.t) : Rolling_start_types.per_start =
   let get k = Map.find summary.metrics k |> Option.value ~default:Float.nan in
   let total_return_pct =
     (summary.final_portfolio_value -. summary.initial_cash)
@@ -78,6 +103,18 @@ let per_start_of_summary ?(benchmark_cagr_pct = Float.nan) ?(equity_curve = [])
     Map.find summary.metrics Metric_types.UnrealizedPnl
     |> Option.value ~default:0.0
   in
+  let realized_return_pct =
+    _realized_return_pct ~initial_cash:summary.initial_cash
+      ~final_value:summary.final_portfolio_value ~unrealized_pnl
+  in
+  (* The honest edge: annualise the MTM-stripped realized return over the same
+     window via the same CAGR convention, then subtract the benchmark CAGR — so
+     it is directly comparable to (and the contamination-free counterpart of)
+     [edge_pct]. nan when no benchmark, mirroring [edge_pct]. *)
+  let realized_cagr_pct =
+    Walk_forward.Walk_forward_runner.cagr_pct ~test_days
+      ~total_return_pct:realized_return_pct
+  in
   {
     Rolling_start_types.start_date;
     cagr_pct;
@@ -85,11 +122,11 @@ let per_start_of_summary ?(benchmark_cagr_pct = Float.nan) ?(equity_curve = [])
     max_drawdown_pct = get Metric_types.MaxDrawdown;
     benchmark_cagr_pct;
     edge_pct = cagr_pct -. benchmark_cagr_pct;
+    realized_edge_pct = realized_cagr_pct -. benchmark_cagr_pct;
+    forward_index_max_dd_pct = benchmark_max_dd_pct;
     sharpe = get Metric_types.SharpeRatio;
     time_underwater_pct = Convexity_stats.time_underwater_pct equity_curve;
-    realized_return_pct =
-      _realized_return_pct ~initial_cash:summary.initial_cash
-        ~final_value:summary.final_portfolio_value ~unrealized_pnl;
+    realized_return_pct;
   }
 
 type config = {
@@ -166,6 +203,10 @@ let _run_one ~config ~sector_map_override ~benchmark_series ~start_date =
     bah_cagr_pct ~start_date ~end_date:config.end_date
       ~close_series:benchmark_series
   in
+  let benchmark_max_dd_pct =
+    bench_max_dd_pct ~start_date ~end_date:config.end_date
+      ~close_series:benchmark_series
+  in
   (* The run's per-step NAV series, chronological — the equity curve the
      time-underwater metric reads. [result.steps] is already filtered to
      trading days in [start_date .. end_date]. *)
@@ -174,8 +215,8 @@ let _run_one ~config ~sector_map_override ~benchmark_series ~start_date =
       ~f:(fun (s : Trading_simulation_types.Simulator_types.step_result) ->
         s.portfolio_value)
   in
-  per_start_of_summary ~benchmark_cagr_pct ~equity_curve ~start_date
-    ~end_date:config.end_date result.summary
+  per_start_of_summary ~benchmark_cagr_pct ~benchmark_max_dd_pct ~equity_curve
+    ~start_date ~end_date:config.end_date result.summary
 
 (* The start dates to sweep: jittered when [jitter_seed] is set, the fixed grid
    otherwise. Both share the same base grid. *)

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_runner.mli
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_runner.mli
@@ -87,8 +87,36 @@ val bah_cagr_pct :
     Designed to be benchmark-agnostic: any symbol's close series (SPY, BRK-B,
     GSPC.INDX) projects through the same function. *)
 
+val bench_max_dd_pct :
+  start_date:Date.t ->
+  end_date:Date.t ->
+  close_series:(Date.t * float) list ->
+  float
+(** [bench_max_dd_pct ~start_date ~end_date ~close_series] is the benchmark's
+    worst peak-to-trough drawdown over [start_date .. end_date], as a
+    {b negative} percent (matching the
+    {!Rolling_start_types.per_start.max_drawdown_pct} sign convention: [0.0] =
+    no decline, [-25.0] = a 25% peak-to-trough drop). The forward-index-DD
+    factor of the factor-decomposition lens (H1 "dodge-a-correction").
+
+    - Computed purely from the closes in [close_series] whose date lies in
+      [start_date .. end_date] (inclusive), processed in chronological order.
+      For each close, the running peak is the max close seen so far; the
+      drawdown at that bar is [(close -. peak) /. peak *. 100]; the result is
+      the minimum (most negative) such drawdown over the window.
+    - Returns [Float.nan] when the window cannot be priced: fewer than two
+      in-window closes (empty series, all dates outside the window, or a single
+      bar), or the first in-window close is [<= 0.0]. The caller renders [nan]
+      as a blank cell — the same nan discipline as {!bah_cagr_pct}.
+    - [close_series] need not be sorted; it is sorted by date internally before
+      the peak-to-trough scan.
+
+    Benchmark-agnostic: any symbol's close series projects through the same
+    function. *)
+
 val per_start_of_summary :
   ?benchmark_cagr_pct:float ->
+  ?benchmark_max_dd_pct:float ->
   ?equity_curve:float list ->
   start_date:Date.t ->
   end_date:Date.t ->
@@ -115,6 +143,16 @@ val per_start_of_summary :
     - [sharpe] is the summary [SharpeRatio] metric ([nan] if absent).
     - [realized_return_pct] strips the summary [UnrealizedPnl] metric from the
       terminal value: [(final -. unrealized -. initial) /. initial *. 100].
+    - [realized_edge_pct] is the {b honest} counterpart to [edge_pct]: the
+      [realized_return_pct] (a total realized return) annualised over the
+      inclusive window via the {b same} {!Walk_forward_runner.cagr_pct}
+      convention [cagr_pct] uses, minus [benchmark_cagr_pct]. [Float.nan] when
+      [benchmark_cagr_pct] is [nan] (mirrors [edge_pct]). Unlike [edge_pct] it
+      is not flattered by a single still-open paper monster (the AXTI effect).
+    - [forward_index_max_dd_pct] (default [Float.nan] = "no benchmark") is
+      recorded verbatim — pass {!bench_max_dd_pct} for the same window. The H1
+      "dodge-a-correction" factor: the benchmark's worst peak-to-trough drawdown
+      over the run.
     - [time_underwater_pct] is {!Convexity_stats.time_underwater_pct} over
       [equity_curve] (default [[]] -> [0.0]); pass the run's per-step NAV series
       (chronological). *)

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_types.ml
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_types.ml
@@ -7,6 +7,8 @@ type per_start = {
   max_drawdown_pct : float;
   benchmark_cagr_pct : float;
   edge_pct : float;
+  realized_edge_pct : float;
+  forward_index_max_dd_pct : float;
   sharpe : float;
   time_underwater_pct : float;
   realized_return_pct : float;
@@ -21,6 +23,8 @@ type report = {
   max_underwater_vs_initial : Dispersion_stats.summary;
   max_drawdown : Dispersion_stats.summary;
   edge : Dispersion_stats.summary;
+  realized_edge : Dispersion_stats.summary;
+  forward_index_max_dd : Dispersion_stats.summary;
 }
 [@@deriving sexp, equal]
 
@@ -38,6 +42,21 @@ let is_short_window ~min_window_days ~end_date (s : per_start) =
 let _defined_edges starts =
   List.filter_map starts ~f:(fun s ->
       if Float.is_nan s.edge_pct then None else Some s.edge_pct)
+
+(* Realized-edge can legitimately be nan (a start with no benchmark), exactly
+   like [edge_pct]; the summary is computed over only the defined values. *)
+let _defined_realized_edges starts =
+  List.filter_map starts ~f:(fun s ->
+      if Float.is_nan s.realized_edge_pct then None
+      else Some s.realized_edge_pct)
+
+(* Forward-index max-DD is nan when no benchmark series priced the window; drop
+   those rows from the summary so unbenchmarked starts neither poison the stats
+   nor inflate n. *)
+let _defined_forward_dds starts =
+  List.filter_map starts ~f:(fun s ->
+      if Float.is_nan s.forward_index_max_dd_pct then None
+      else Some s.forward_index_max_dd_pct)
 
 (* The long-enough subset of starts: a start is dropped only when
    [min_window_days > 0] and its inclusive window is shorter than that. With
@@ -73,6 +92,10 @@ let build ?(min_window_days = 0) ~end_date starts =
       Dispersion_stats.summarize
         (List.map eligible ~f:(fun s -> s.max_drawdown_pct));
     edge = Dispersion_stats.summarize (_defined_edges eligible);
+    realized_edge =
+      Dispersion_stats.summarize (_defined_realized_edges eligible);
+    forward_index_max_dd =
+      Dispersion_stats.summarize (_defined_forward_dds eligible);
   }
 
 let pct_beating_benchmark report =
@@ -117,19 +140,29 @@ let _dispersion_table report =
         report.max_underwater_vs_initial;
       _summary_row ~label:"MaxDrawdown %" report.max_drawdown;
       _summary_row ~label:"Edge vs benchmark %" report.edge;
+      _summary_row ~label:"Realized edge vs benchmark %" report.realized_edge;
+      _summary_row ~label:"Forward index max-DD %" report.forward_index_max_dd;
     ]
+
+(** One "- label: value %" bullet line in the robustness summary. *)
+let _bullet ~label value = Printf.sprintf "- %s: %s %%" label (_f2 value)
 
 (** The headline robustness summary: how often, and by how much, the strategy
     beat the benchmark across start dates. *)
 let _robustness_summary report =
+  let beating =
+    Printf.sprintf "- Starts beating benchmark: %s %% (of %d benchmarked)"
+      (_f2 (pct_beating_benchmark report))
+      report.edge.n
+  in
   String.concat ~sep:"\n"
     [
-      Printf.sprintf "- Median edge vs benchmark: %s %%"
-        (_f2 report.edge.median);
-      Printf.sprintf "- Worst-start edge: %s %%" (_f2 report.edge.min);
-      Printf.sprintf "- Starts beating benchmark: %s %% (of %d benchmarked)"
-        (_f2 (pct_beating_benchmark report))
-        report.edge.n;
+      _bullet ~label:"Median edge vs benchmark" report.edge.median;
+      _bullet ~label:"Worst-start edge" report.edge.min;
+      _bullet ~label:"Median realized edge vs benchmark"
+        report.realized_edge.median;
+      _bullet ~label:"Worst-start realized edge" report.realized_edge.min;
+      beating;
     ]
 
 (** One per-start detail row — the matrix row: start x
@@ -148,10 +181,12 @@ let _start_row ~min_window_days ~end_date (s : per_start) =
       _f2 s.cagr_pct;
       _f2 s.benchmark_cagr_pct;
       _f2 s.edge_pct;
+      _f2 s.realized_edge_pct;
       _f2 s.sharpe;
       _f2 s.max_underwater_vs_initial_pct;
       _f2 s.time_underwater_pct;
       _f2 s.max_drawdown_pct;
+      _f2 s.forward_index_max_dd_pct;
       _f2 s.realized_return_pct;
       note;
     ]
@@ -163,10 +198,12 @@ let _starts_header_cells =
     "CAGR %";
     "Benchmark CAGR %";
     "Edge %";
+    "Realized edge %";
     "Sharpe";
     "MaxUnderwaterVsInitial %";
     "TimeUnderwater %";
     "MaxDrawdown %";
+    "Forward index max-DD %";
     "Realized return %";
     "note";
   ]

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_types.mli
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_types.mli
@@ -42,8 +42,29 @@ type per_start = {
       (** [cagr_pct -. benchmark_cagr_pct] — the strategy's annualised
           out/under-performance versus buy-and-hold from this start. [Float.nan]
           when [benchmark_cagr_pct] is [nan]. Positive = strategy beat
-          buy-and-hold from this start; negative = lost to it. The primary
-          honest-evaluation column. *)
+          buy-and-hold from this start; negative = lost to it. {b Contaminated}
+          by terminal mark-to-market on still-open positions (a single
+          AXTI-style paper monster flatters it); kept for the realized-vs-MTM
+          gap diagnostic. The honest counterpart is [realized_edge_pct]. *)
+  realized_edge_pct : float;
+      (** The {b honest, primary} edge column (factor-decomposition lens primary
+          outcome): the {!realized_return_pct} annualised over the same window
+          via {!Rolling_start_runner.per_start_of_summary}'s CAGR convention,
+          minus [benchmark_cagr_pct]. Strips the terminal mark-to-market that
+          contaminates [edge_pct], so a still-open paper winner cannot flatter a
+          recent start. [Float.nan] when [benchmark_cagr_pct] is [nan] (mirrors
+          [edge_pct]). A large [edge_pct -. realized_edge_pct] gap flags a
+          mark-dependent start (concentration in unrealized winners). *)
+  forward_index_max_dd_pct : float;
+      (** The benchmark's worst peak-to-trough drawdown over this start's
+          [start_date .. end_date] window, as a {b negative} percent (same sign
+          convention as [max_drawdown_pct]: [0.0] = no decline, [-25.0] = a 25%
+          peak-to-trough drop). The factor-decomposition lens H1
+          ("dodge-a-correction") factor — a large forward index DD is the
+          correction the strategy's Stage-4 exits may sidestep. [Float.nan] when
+          no benchmark series priced the window (same nan discipline as
+          [benchmark_cagr_pct]). Computed via
+          {!Rolling_start_runner.bench_max_dd_pct}. *)
   sharpe : float;
       (** The run's Sharpe ratio (summary [SharpeRatio] metric); [Float.nan] if
           absent. The risk-adjusted lens alongside the raw CAGR — a high-CAGR
@@ -96,7 +117,16 @@ type report = {
           rows (starts with no benchmark). The headline distribution: median
           edge, worst-start edge ([min]), and spread directly answer "does the
           strategy robustly beat the benchmark across start dates?" An all-[nan]
-          / empty edge column yields a zero-[n] summary. *)
+          / empty edge column yields a zero-[n] summary. {b MTM-contaminated} —
+          see [realized_edge] for the honest version. *)
+  realized_edge : Dispersion_stats.summary;
+      (** Dispersion of {!per_start.realized_edge_pct} across [starts], skipping
+          [nan] rows (starts with no benchmark). The {b honest} headline
+          distribution — the MTM-stripped counterpart of [edge]. *)
+  forward_index_max_dd : Dispersion_stats.summary;
+      (** Dispersion of {!per_start.forward_index_max_dd_pct} across [starts],
+          skipping [nan] rows (starts whose window could not be priced). The H1
+          "dodge-a-correction" factor distribution. *)
 }
 [@@deriving sexp, equal]
 (** The full rolling-start dispersion report: the raw per-start rows plus one

--- a/trading/trading/backtest/rolling_start/test/test_rolling_start_runner.ml
+++ b/trading/trading/backtest/rolling_start/test/test_rolling_start_runner.ml
@@ -191,6 +191,67 @@ let test_bah_cagr_nan_when_unpriceable _ =
     (Float.is_nan nan_empty && Float.is_nan nan_single)
     (equal_to true)
 
+(* ----- bench_max_dd_pct ----- *)
+
+(* A benchmark that ran 100 -> 120 (new peak) -> 90 (trough) over the window: the
+   worst peak-to-trough drawdown is (90 - 120)/120 = -25%. Bars outside
+   [start, end] are ignored. *)
+let test_bench_max_dd_known_peak_trough _ =
+  let dd =
+    Runner.bench_max_dd_pct
+      ~start_date:(date ~y:2011 ~m:Month.Jan ~d:1)
+      ~end_date:(date ~y:2011 ~m:Month.Dec ~d:31)
+      ~close_series:
+        [
+          (date ~y:2010 ~m:Month.Dec ~d:31, 50.0);
+          (* before window: ignored *)
+          (date ~y:2011 ~m:Month.Jan ~d:3, 100.0);
+          (date ~y:2011 ~m:Month.Apr ~d:1, 120.0);
+          (* peak *)
+          (date ~y:2011 ~m:Month.Aug ~d:1, 90.0);
+          (* trough: -25% off the 120 peak *)
+          (date ~y:2011 ~m:Month.Dec ~d:30, 110.0);
+          (date ~y:2012 ~m:Month.Jan ~d:2, 30.0);
+          (* after window: ignored *)
+        ]
+  in
+  assert_that dd (float_equal (-25.0))
+
+(* A monotonically rising series has no peak-to-trough decline -> 0.0 (not nan,
+   not negative). *)
+let test_bench_max_dd_monotonic_is_zero _ =
+  let dd =
+    Runner.bench_max_dd_pct
+      ~start_date:(date ~y:2011 ~m:Month.Jan ~d:1)
+      ~end_date:(date ~y:2011 ~m:Month.Dec ~d:31)
+      ~close_series:
+        [
+          (date ~y:2011 ~m:Month.Jan ~d:3, 100.0);
+          (date ~y:2011 ~m:Month.Jun ~d:1, 150.0);
+          (date ~y:2011 ~m:Month.Dec ~d:30, 200.0);
+        ]
+  in
+  assert_that dd (float_equal 0.0)
+
+(* An empty series, or one with a single usable bar in the window, cannot be
+   priced -> nan (the caller renders a blank cell). *)
+let test_bench_max_dd_nan_when_unpriceable _ =
+  let nan_empty =
+    Runner.bench_max_dd_pct
+      ~start_date:(date ~y:2011 ~m:Month.Jan ~d:1)
+      ~end_date:(date ~y:2011 ~m:Month.Dec ~d:31)
+      ~close_series:[]
+  in
+  let nan_single =
+    Runner.bench_max_dd_pct
+      ~start_date:(date ~y:2011 ~m:Month.Jan ~d:1)
+      ~end_date:(date ~y:2011 ~m:Month.Dec ~d:31)
+      ~close_series:[ (date ~y:2011 ~m:Month.Jun ~d:1, 100.0) ]
+  in
+  assert_that
+    (Float.is_nan nan_empty && Float.is_nan nan_single)
+    (equal_to true)
+
 (* ----- per_start_of_summary ----- *)
 
 let make_summary ~start_date ~end_date ~initial_cash ~final_value ~metrics :
@@ -327,6 +388,104 @@ let test_per_start_realized_sharpe_and_underwater _ =
            (is_between (module Float_ord) ~low:33.0 ~high:33.4);
        ])
 
+(* realized_edge = annualised realized-return CAGR - benchmark CAGR. With no
+   open positions (no UnrealizedPnl), realized return == total return, so the run
+   that doubled over ~1y has a ~100% realized CAGR; benchmark 14 -> realized_edge
+   ~= 86, matching edge_pct exactly when there is nothing unrealized. *)
+let test_per_start_realized_edge_matches_edge_without_unrealized _ =
+  let start_date = date ~y:2011 ~m:Month.Jan ~d:1 in
+  let end_date = date ~y:2011 ~m:Month.Dec ~d:31 in
+  let summary =
+    make_summary ~start_date ~end_date ~initial_cash:1_000_000.0
+      ~final_value:2_000_000.0 ~metrics:[]
+  in
+  let per_start =
+    Runner.per_start_of_summary ~benchmark_cagr_pct:14.0 ~start_date ~end_date
+      summary
+  in
+  assert_that per_start
+    (all_of
+       [
+         field
+           (fun (p : RT.per_start) -> p.realized_edge_pct)
+           (is_between (module Float_ord) ~low:85.0 ~high:87.0);
+         (* No unrealized mark -> realized_edge == edge. *)
+         field
+           (fun (p : RT.per_start) -> p.realized_edge_pct -. p.edge_pct)
+           (float_equal 0.0);
+       ])
+
+(* realized_edge is nan (blank) when no benchmark is supplied, mirroring edge. *)
+let test_per_start_realized_edge_nan_without_benchmark _ =
+  let start_date = date ~y:2011 ~m:Month.Jan ~d:1 in
+  let end_date = date ~y:2011 ~m:Month.Dec ~d:31 in
+  let summary =
+    make_summary ~start_date ~end_date ~initial_cash:1_000_000.0
+      ~final_value:2_000_000.0 ~metrics:[]
+  in
+  let per_start = Runner.per_start_of_summary ~start_date ~end_date summary in
+  assert_that per_start
+    (field
+       (fun (p : RT.per_start) -> Float.is_nan p.realized_edge_pct)
+       (equal_to true))
+
+(* The design's realized-vs-MTM divergence diagnostic: a run whose terminal value
+   is inflated by a large still-open paper winner. final=2.0M, unrealized=0.9M,
+   initial=1.0M -> total return 100% (CAGR ~100, edge ~86 vs bench 14) but
+   realized return only (2.0-0.9-1.0)/1.0 = 10% (realized CAGR ~10, realized_edge
+   ~-4). The honest realized_edge sits materially below the MTM edge_pct, pinning
+   that they diverge when marks are concentrated in unrealized winners. *)
+let test_per_start_realized_edge_below_mtm_edge_when_unrealized _ =
+  let start_date = date ~y:2011 ~m:Month.Jan ~d:1 in
+  let end_date = date ~y:2011 ~m:Month.Dec ~d:31 in
+  let summary =
+    make_summary ~start_date ~end_date ~initial_cash:1_000_000.0
+      ~final_value:2_000_000.0
+      ~metrics:[ (Metric_types.UnrealizedPnl, 900_000.0) ]
+  in
+  let per_start =
+    Runner.per_start_of_summary ~benchmark_cagr_pct:14.0 ~start_date ~end_date
+      summary
+  in
+  assert_that per_start
+    (all_of
+       [
+         (* MTM edge unchanged by the unrealized mark: ~100% CAGR - 14 = ~86. *)
+         field
+           (fun (p : RT.per_start) -> p.edge_pct)
+           (is_between (module Float_ord) ~low:85.0 ~high:87.0);
+         (* Realized edge: ~10% realized CAGR - 14 -> negative, far below edge. *)
+         field
+           (fun (p : RT.per_start) -> p.realized_edge_pct)
+           (is_between (module Float_ord) ~low:(-5.0) ~high:(-3.0));
+         (* They differ by ~90 percentage points — the mark-dependence flag. *)
+         field
+           (fun (p : RT.per_start) -> p.edge_pct -. p.realized_edge_pct)
+           (gt (module Float_ord) 80.0);
+       ])
+
+(* forward_index_max_dd is recorded verbatim from the benchmark_max_dd argument,
+   and is nan (blank) when not supplied. *)
+let test_per_start_forward_index_max_dd _ =
+  let start_date = date ~y:2011 ~m:Month.Jan ~d:1 in
+  let end_date = date ~y:2011 ~m:Month.Dec ~d:31 in
+  let summary =
+    make_summary ~start_date ~end_date ~initial_cash:1_000_000.0
+      ~final_value:1_000_000.0 ~metrics:[]
+  in
+  let with_dd =
+    Runner.per_start_of_summary ~benchmark_max_dd_pct:(-18.5) ~start_date
+      ~end_date summary
+  in
+  let without_dd = Runner.per_start_of_summary ~start_date ~end_date summary in
+  assert_that
+    (with_dd.RT.forward_index_max_dd_pct, without_dd.RT.forward_index_max_dd_pct)
+    (all_of
+       [
+         field fst (float_equal (-18.5));
+         field (fun (_, x) -> Float.is_nan x) (equal_to true);
+       ])
+
 let suite =
   "rolling_start_runner"
   >::: [
@@ -348,12 +507,26 @@ let suite =
          >:: test_jitter_rejects_nonpositive_stride;
          "bah_cagr_full_year" >:: test_bah_cagr_full_year;
          "bah_cagr_nan_when_unpriceable" >:: test_bah_cagr_nan_when_unpriceable;
+         "bench_max_dd_known_peak_trough"
+         >:: test_bench_max_dd_known_peak_trough;
+         "bench_max_dd_monotonic_is_zero"
+         >:: test_bench_max_dd_monotonic_is_zero;
+         "bench_max_dd_nan_when_unpriceable"
+         >:: test_bench_max_dd_nan_when_unpriceable;
          "per_start_extracts_metrics" >:: test_per_start_extracts_metrics;
          "per_start_missing_metrics_are_nan"
          >:: test_per_start_missing_metrics_are_nan;
          "per_start_edge_from_benchmark" >:: test_per_start_edge_from_benchmark;
          "per_start_realized_sharpe_and_underwater"
          >:: test_per_start_realized_sharpe_and_underwater;
+         "per_start_realized_edge_matches_edge_without_unrealized"
+         >:: test_per_start_realized_edge_matches_edge_without_unrealized;
+         "per_start_realized_edge_nan_without_benchmark"
+         >:: test_per_start_realized_edge_nan_without_benchmark;
+         "per_start_realized_edge_below_mtm_edge_when_unrealized"
+         >:: test_per_start_realized_edge_below_mtm_edge_when_unrealized;
+         "per_start_forward_index_max_dd"
+         >:: test_per_start_forward_index_max_dd;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/rolling_start/test/test_rolling_start_types.ml
+++ b/trading/trading/backtest/rolling_start/test/test_rolling_start_types.ml
@@ -5,6 +5,7 @@ module RT = Rolling_start.Rolling_start_types
 module DS = Rolling_start.Dispersion_stats
 
 let make_start ~y ~m ~d ~cagr ~underwater ~maxdd ?(benchmark = Float.nan)
+    ?(realized_edge = Float.nan) ?(forward_index_max_dd = Float.nan)
     ?(sharpe = 1.0) ?(time_underwater = 0.0) ?(realized = 0.0) () : RT.per_start
     =
   {
@@ -14,6 +15,8 @@ let make_start ~y ~m ~d ~cagr ~underwater ~maxdd ?(benchmark = Float.nan)
     max_drawdown_pct = maxdd;
     benchmark_cagr_pct = benchmark;
     edge_pct = cagr -. benchmark;
+    realized_edge_pct = realized_edge;
+    forward_index_max_dd_pct = forward_index_max_dd;
     sharpe;
     time_underwater_pct = time_underwater;
     realized_return_pct = realized;
@@ -36,11 +39,14 @@ let sample_starts =
 let benchmarked_starts =
   [
     make_start ~y:2011 ~m:Month.Jan ~d:1 ~cagr:30.0 ~underwater:0.0
-      ~maxdd:(-20.0) ~benchmark:20.0 ();
+      ~maxdd:(-20.0) ~benchmark:20.0 ~realized_edge:5.0
+      ~forward_index_max_dd:(-15.0) ();
     make_start ~y:2011 ~m:Month.Jul ~d:1 ~cagr:10.0 ~underwater:(-5.0)
-      ~maxdd:(-40.0) ~benchmark:25.0 ();
+      ~maxdd:(-40.0) ~benchmark:25.0 ~realized_edge:(-20.0)
+      ~forward_index_max_dd:(-30.0) ();
     make_start ~y:2012 ~m:Month.Apr ~d:1 ~cagr:50.0 ~underwater:0.0
-      ~maxdd:(-10.0) ~benchmark:20.0 ();
+      ~maxdd:(-10.0) ~benchmark:20.0 ~realized_edge:25.0
+      ~forward_index_max_dd:(-8.0) ();
   ]
 
 let end_date = Date.create_exn ~y:2020 ~m:Month.Dec ~d:31
@@ -108,6 +114,10 @@ let test_to_markdown_contains_sections _ =
          contains_substring "CAGR %";
          contains_substring "Benchmark CAGR %";
          contains_substring "Edge %";
+         contains_substring "Realized edge %";
+         contains_substring "Forward index max-DD %";
+         contains_substring "Realized edge vs benchmark %";
+         contains_substring "Median realized edge vs benchmark";
          contains_substring "Sharpe";
          contains_substring "TimeUnderwater %";
          contains_substring "Realized return %";
@@ -136,6 +146,44 @@ let test_build_edge_summary _ =
          field (fun s -> s.DS.median) (float_equal 10.0);
          field (fun s -> s.DS.min) (float_equal (-15.0));
          field (fun s -> s.DS.max) (float_equal 30.0);
+       ])
+
+(* Realized-edge summary across benchmarked starts: realized edges [5;-20;25] ->
+   sorted [-20;5;25] -> median 5, min -20, max 25, n=3. Skips nan rows like
+   [edge]. *)
+let test_build_realized_edge_summary _ =
+  let report = RT.build ~end_date benchmarked_starts in
+  assert_that report.realized_edge
+    (all_of
+       [
+         field (fun s -> s.DS.n) (equal_to 3);
+         field (fun s -> s.DS.median) (float_equal 5.0);
+         field (fun s -> s.DS.min) (float_equal (-20.0));
+         field (fun s -> s.DS.max) (float_equal 25.0);
+       ])
+
+(* Forward-index max-DD summary: forward DDs [-15;-30;-8] -> sorted [-30;-15;-8]
+   -> median -15, min -30, max -8, n=3. *)
+let test_build_forward_index_max_dd_summary _ =
+  let report = RT.build ~end_date benchmarked_starts in
+  assert_that report.forward_index_max_dd
+    (all_of
+       [
+         field (fun s -> s.DS.n) (equal_to 3);
+         field (fun s -> s.DS.median) (float_equal (-15.0));
+         field (fun s -> s.DS.min) (float_equal (-30.0));
+         field (fun s -> s.DS.max) (float_equal (-8.0));
+       ])
+
+(* sample_starts have no benchmark -> realized_edge / forward DD are nan and the
+   summaries skip them entirely (n=0), like the edge summary. *)
+let test_realized_edge_and_forward_dd_skip_nan_starts _ =
+  let report = RT.build ~end_date sample_starts in
+  assert_that report
+    (all_of
+       [
+         field (fun r -> r.RT.realized_edge.DS.n) (equal_to 0);
+         field (fun r -> r.RT.forward_index_max_dd.DS.n) (equal_to 0);
        ])
 
 (* Two of three benchmarked starts have positive edge -> 66.67%. *)
@@ -271,6 +319,11 @@ let suite =
          "build_preserves_end_date" >:: test_build_preserves_end_date;
          "build_empty" >:: test_build_empty;
          "build_edge_summary" >:: test_build_edge_summary;
+         "build_realized_edge_summary" >:: test_build_realized_edge_summary;
+         "build_forward_index_max_dd_summary"
+         >:: test_build_forward_index_max_dd_summary;
+         "realized_edge_and_forward_dd_skip_nan_starts"
+         >:: test_realized_edge_and_forward_dd_skip_nan_starts;
          "pct_beating_benchmark" >:: test_pct_beating_benchmark;
          "edge_skips_nan_starts" >:: test_edge_skips_nan_starts;
          "to_markdown_contains_sections" >:: test_to_markdown_contains_sections;


### PR DESCRIPTION
First deliverable of the factor-decomposition lens. Adds two pure per-start columns to the rolling-start matrix:

1. **realized-edge** (primary outcome) = annualised realized return − benchmark CAGR. Honest counterpart to the MTM-contaminated edge.
2. **forward-index max-DD** (H1 dodge-a-correction factor) = benchmark worst peak-to-trough over the window.

Both are pure projections of data the runner already owns. Plan: dev/plans/rolling-start-realized-edge-lens-2026-06-14.md.

Out of scope (data-gated): the three external-data factor columns + the 31-start causal analysis.

🤖 Dispatched by GHA orchestrator run [27510198594](https://github.com/dayfine/trading/actions/runs/27510198594)