### PR TITLE
feat(universe): eligibility-filter universe builder (no top-N cap)

### DIFF
--- a/dev/plans/eligible-universe-builder-2026-06-14.md
+++ b/dev/plans/eligible-universe-builder-2026-06-14.md
@@ -1,0 +1,85 @@
+# Eligibility-filter universe builder (live-universe track)
+
+## Last updated: 2026-06-14
+
+## Problem
+
+The existing `Build_from_individuals` produces a universe by **dollar-volume
+top-N rank** at an annual reconstitution date. For a *live* / current-dated
+universe we want a different selection rule: **every** current common-stock-like
+US listing that passes **absolute eligibility gates** — no size cap. The output
+must be the same `Universe.Snapshot.t` on-disk shape the screener / scenario
+runner already consume, so it drops straight into the backtest/live pipeline.
+
+## Design
+
+New sibling module `Build_eligible_universe` (lib) + a runner (bin). It reuses
+the existing building blocks rather than duplicating them:
+
+- `Composition_inputs.load_inventory` / `load_asset_type_lookup` / `load_sectors`
+  — the same on-disk artifacts (`inventory.sexp`, `symbol_types.sexp`,
+  `sectors.csv`).
+- `Composition_bar_reader.read_bars` — per-symbol CSV bars.
+- `Build_from_individuals.avg_dollar_volume_for_bars` /
+  `latest_close_for_bars` — the *exact* trailing-window scoring + latest-close
+  logic, exposed as pure helpers over a `bar list` so the eligibility builder
+  reads each symbol's CSV once and shares the windowing. (Two new pure exports
+  on the existing module; no behaviour change to `build`.)
+- `Composition_policy.apply` — the junk / asset-type filters (REIT exclude,
+  preferred exclude). Common + ADR + GDR survive.
+
+### Pipeline (per date)
+
+1. **Active filter** — inventory entries with
+   `data_start_date <= date - trailing_window_days` and `data_end_date >= date`.
+2. **Equity-like filter** — `load_equity_like_lookup` drops ETF / Mutual_fund /
+   Fund / Bond / Index / Currency / Commodity; keeps Common / Preferred / ADR /
+   GDR (`Eodhd.Asset_type.is_equity_like`).
+3. **Eligibility gates** (all config fields, defaults = no-op keep-all):
+   - `min_price` — latest close `< floor` ⇒ drop. Record default `0.0`; spec `5.0`.
+   - `min_avg_dollar_volume` — trailing-30d avg(close×volume) `< floor` ⇒ drop.
+     Record default `0.0`; spec `1_000_000.0`.
+   - `min_window_bars` — reuse the existing `>= 30`-weeks history gate (the
+     trailing-window-bar-count gate from `Build_from_individuals`). Default `30`.
+4. **Composition policy** — `reit_policy = Exclude`, `exclude_preferred = true`
+   (plus the always-on dual-class dedup). Drops Preferred + REIT; keeps Common +
+   ADR + GDR.
+5. **Emit** — equal weight `1.0 / K` for the `K` survivors. No top-N truncation.
+   `method_ = Composition_from_individuals` (same consumer-facing shape);
+   `size = K`; `aggregate_period_return = 0.0` (live build, forward window
+   unknown — not the diagnostic the rank-builder computes).
+
+### Eligibility config (experiment-flag-discipline R2)
+
+Every gate is a config field. The record defaults reproduce a keep-all no-op
+(`min_price = 0.0`, `min_avg_dollar_volume = 0.0`,
+`reit_policy = Include`, `exclude_preferred = false`) so a caller passing
+`default_config` is unaffected. The *live-universe spec* (a separate named
+constructor `spec_config`) passes `min_price = 5.0`,
+`min_avg_dollar_volume = 1_000_000.0`, `reit_policy = Exclude`,
+`exclude_preferred = true`.
+
+## Behavioral pins (fixture tests, no network)
+
+- below `min_price` dropped; at/above kept (boundary).
+- below `min_avg_dollar_volume` dropped; above kept.
+- `< min_window_bars` dropped.
+- preferred / REIT / ETF dropped; common-stock + ADR kept.
+- no top-N truncation: K eligible inputs ⇒ exactly K entries.
+- equal weight `1.0 / K`; total weight ≈ 1.0.
+
+## Runner
+
+`build_eligible_universe_runner` (bin) with single-dash Core flags:
+`-inventory-path -csv-data-dir -date -min-price -min-adv -output-path`.
+The dispatcher runs it later on freshly-fetched data; this PR is builder +
+fixture-test only, no live fetch.
+
+## Files
+
+- `lib/build_eligible_universe.{ml,mli}` (new)
+- `lib/build_from_individuals.{ml,mli}` (two pure-helper exports)
+- `test/test_build_eligible_universe.ml` (new)
+- `bin/build_eligible_universe_runner_lib.{ml,mli}` + `build_eligible_universe_runner.ml` (new)
+- dune wiring in `lib/`, `bin/`, `test/`
+- `dev/status/data-foundations.md`

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -273,6 +273,47 @@ Status carries forward from `hybrid-tier` track — that track stays IN_PROGRESS
 Synth-v1/v2/v3 all MERGED. EODHD multi-market MERGED. 15y memory-cliff
 fixes MERGED 2026-05-08. Only Norgate ingest remains — vendor-blocked.)
 
+### READY_FOR_REVIEW — Eligibility-filter universe builder (live-universe) — 2026-06-14
+
+- [x] **`Build_eligible_universe` — all-eligible (no top-N cap) current-dated
+  universe builder** (`feat/eligible-universe`,
+  `analysis/data/universe/lib/build_eligible_universe.{ml,mli}` + the two
+  pure-helper exports on `build_from_individuals.{ml,mli}` +
+  `bin/build_eligible_universe_runner{,_lib}.{ml,mli}` +
+  `test/test_build_eligible_universe.ml`). Plan:
+  `dev/plans/eligible-universe-builder-2026-06-14.md`.
+  - **What it does:** sibling of `Build_from_individuals` (top-N by rank);
+    instead emits **every** common-stock-like US listing passing absolute
+    eligibility gates, equal-weighted, no size cap. Output is the same
+    `Universe.Snapshot.t` shape the screener / scenario_runner consume
+    (`method_ = Composition_from_individuals`; `size = K` survivors, NOT a
+    cap; `aggregate_period_return = 0.0` for a live build).
+  - **Pipeline:** active filter -> equity-like filter (drops ETF/MF/Fund/Bond/
+    Index/etc.) -> eligibility gates (`min_price`, `min_avg_dollar_volume`,
+    `min_window_bars`) -> `Composition_policy.apply` with `reit_policy=Exclude`,
+    `exclude_preferred=true` (drops REIT + preferred; always-on dual-class
+    dedup). Net survivors: Common + ADR + GDR clearing every gate.
+  - **Reuse, no dup:** exposes `Build_from_individuals.avg_dollar_volume_for_bars`
+    + `latest_close_for_bars` (pure helpers over a `bar list`, factored out of
+    the existing private `_dollar_volume_score` — `build`'s behaviour
+    unchanged); reuses `Composition_inputs` loaders, `Composition_bar_reader`,
+    and `Composition_policy`.
+  - **experiment-flag-discipline R2:** every gate is a config field.
+    `default_config` is a keep-all no-op (`min_price=0.0`,
+    `min_avg_dollar_volume=0.0`, `reit_policy=Include`,
+    `exclude_preferred=false`); `spec_config` is the live-universe spec
+    (`min_price=5.0`, `min_avg_dollar_volume=1_000_000.0`, `Exclude`, `true`).
+  - **Tests (10, fixture-based, no network):** min_price boundary, min-ADV gate,
+    min-window-bars gate, asset-type/junk filters (ETF/preferred/REIT dropped,
+    common+ADR kept), no-size-cap (K in -> K out), equal-weight + total~1.0,
+    default-config keep-all, empty-universe -> Failed_precondition, determinism,
+    entry metadata.
+  - **Runner:** `build_eligible_universe_runner.exe` — single-dash Core flags
+    `-inventory-path -csv-data-dir -date -min-price -min-adv -output-path`.
+    Builder-only here; the dispatcher runs it later on freshly-fetched data.
+  - **Verify:** `dune build @fmt && dune build && dune runtest
+    analysis/data/universe/`.
+
 ### READY_FOR_REVIEW — Composition-golden volume enrichment + track inventory.sexp (2026-06-14)
 
 - [x] **Volume-only enrichment tool**

--- a/trading/analysis/data/universe/bin/build_eligible_universe_runner.ml
+++ b/trading/analysis/data/universe/bin/build_eligible_universe_runner.ml
@@ -1,0 +1,86 @@
+(** CLI: build a single current-dated {b all-eligible} universe snapshot.
+
+    Unlike [build_composition_universes_runner] (top-N by dollar-volume rank
+    over an annual cadence), this emits {b every} eligible common-stock-like US
+    listing at one date — no size cap — applying the live-universe spec gates
+    (min-price, min-avg-dollar-volume, min-window-bars, REIT-exclude,
+    preferred-exclude). Output is the standard {!Universe.Snapshot.t} the
+    screener / scenario_runner consume.
+
+    Usage:
+    {v
+      dune exec analysis/data/universe/bin/build_eligible_universe_runner.exe -- \
+        -inventory-path /workspaces/trading-1/data/inventory.sexp \
+        -csv-data-dir   /workspaces/trading-1/data \
+        -date           2026-06-12 \
+        -min-price      5.0 \
+        -min-adv        1000000.0 \
+        -output-path    /workspaces/trading-1/data/eligible-2026-06-12.sexp
+    v}
+
+    [-csv-data-dir] is both the cached-bars root and the directory holding
+    [symbol_types.sexp] + [sectors.csv]. *)
+
+open! Core
+
+let _default_min_price = 5.0
+let _default_min_adv = 1_000_000.0
+
+let _print_result (result : Build_eligible_universe_runner_lib.result) =
+  Stdlib.Printf.printf
+    "build_eligible_universe_runner: wrote %d eligible symbols to %s\n"
+    result.entry_count result.written_path
+
+let _exit_with_error msg =
+  Stdlib.Printf.fprintf Stdlib.stderr "build_eligible_universe_runner: %s\n" msg;
+  Stdlib.flush Stdlib.stderr;
+  Stdlib.exit 1
+
+let _run ~inventory_path ~csv_data_dir ~date ~min_price ~min_avg_dollar_volume
+    ~output_path =
+  match
+    Build_eligible_universe_runner_lib.run ~inventory_path ~csv_data_dir ~date
+      ~min_price ~min_avg_dollar_volume ~output_path
+  with
+  | Ok result -> _print_result result
+  | Error err -> _exit_with_error (Status.show err)
+
+let command =
+  Command.basic
+    ~summary:
+      "Build a single current-dated all-eligible universe snapshot (every \
+       eligible common-stock-like listing, no size cap) from cached bars + \
+       inventory."
+    (let%map_open.Command inventory_path =
+       flag "-inventory-path" (required string)
+         ~doc:"PATH inventory.sexp from weinstein.data_source"
+     and csv_data_dir =
+       flag "-csv-data-dir" (required string)
+         ~doc:
+           "PATH cached-data root (bars + symbol_types.sexp + sectors.csv live \
+            here)"
+     and date =
+       flag "-date" (required string) ~doc:"YYYY-MM-DD universe anchor date"
+     and min_price =
+       flag "-min-price"
+         (optional_with_default _default_min_price float)
+         ~doc:
+           (Printf.sprintf "FLOAT min latest close (default: %.2f)"
+              _default_min_price)
+     and min_avg_dollar_volume =
+       flag "-min-adv"
+         (optional_with_default _default_min_adv float)
+         ~doc:
+           (Printf.sprintf
+              "FLOAT min trailing avg dollar volume (default: %.0f)"
+              _default_min_adv)
+     and output_path =
+       flag "-output-path" (required string)
+         ~doc:"PATH where to write the snapshot .sexp"
+     in
+     fun () ->
+       let date = Date.of_string date in
+       _run ~inventory_path ~csv_data_dir ~date ~min_price
+         ~min_avg_dollar_volume ~output_path)
+
+let () = Command_unix.run command

--- a/trading/analysis/data/universe/bin/build_eligible_universe_runner_lib.ml
+++ b/trading/analysis/data/universe/bin/build_eligible_universe_runner_lib.ml
@@ -1,0 +1,31 @@
+open Core
+module BEU = Universe.Build_eligible_universe
+
+type result = { written_path : string; entry_count : int } [@@deriving show, eq]
+
+let _symbol_types_path ~csv_data_dir =
+  Filename.concat csv_data_dir "symbol_types.sexp"
+
+let _sectors_csv_path ~csv_data_dir = Filename.concat csv_data_dir "sectors.csv"
+
+(* The live-universe spec config with the caller-supplied gate values. *)
+let _config ~inventory_path ~csv_data_dir ~min_price ~min_avg_dollar_volume =
+  {
+    (BEU.spec_config ~bars_root:csv_data_dir
+       ~symbol_types_path:(_symbol_types_path ~csv_data_dir)
+       ~sectors_csv_path:(_sectors_csv_path ~csv_data_dir)
+       ~inventory_path)
+    with
+    min_price;
+    min_avg_dollar_volume;
+  }
+
+let run ~inventory_path ~csv_data_dir ~date ~min_price ~min_avg_dollar_volume
+    ~output_path =
+  let open Result.Let_syntax in
+  let config =
+    _config ~inventory_path ~csv_data_dir ~min_price ~min_avg_dollar_volume
+  in
+  let%bind snapshot = BEU.build ~date ~config in
+  let%bind () = Universe.Snapshot.save snapshot ~path:output_path in
+  Ok { written_path = output_path; entry_count = List.length snapshot.entries }

--- a/trading/analysis/data/universe/bin/build_eligible_universe_runner_lib.mli
+++ b/trading/analysis/data/universe/bin/build_eligible_universe_runner_lib.mli
@@ -1,0 +1,33 @@
+(** Runner core for [build_eligible_universe_runner.exe]: build a single
+    current-dated all-eligible universe snapshot and write it to disk.
+
+    Separated from the CLI shell so the [run] logic is unit-testable without
+    argument parsing. *)
+
+open Core
+
+type result = { written_path : string; entry_count : int } [@@deriving show, eq]
+(** Outcome of a successful run: where the snapshot was written and how many
+    eligible symbols it contains. *)
+
+val run :
+  inventory_path:string ->
+  csv_data_dir:string ->
+  date:Date.t ->
+  min_price:float ->
+  min_avg_dollar_volume:float ->
+  output_path:string ->
+  result Status.status_or
+(** [run ~inventory_path ~csv_data_dir ~date ~min_price ~min_avg_dollar_volume
+     ~output_path] builds the eligible universe at [date] from the inventory +
+    cached bars under [csv_data_dir], applying the live-universe spec gates
+    (REIT-exclude, preferred-exclude, the supplied [min_price] /
+    [min_avg_dollar_volume]), and writes the resulting {!Universe.Snapshot.t} to
+    [output_path].
+
+    [csv_data_dir] is both the bars root and the directory holding
+    [symbol_types.sexp] and [sectors.csv] (the standard cached-data layout).
+
+    Returns [Error] when the build or the on-disk write fails (propagating the
+    {!Universe.Build_eligible_universe.build} status), else
+    [Ok { written_path; entry_count }]. *)

--- a/trading/analysis/data/universe/bin/dune
+++ b/trading/analysis/data/universe/bin/dune
@@ -23,6 +23,24 @@
  (preprocess
   (pps ppx_let ppx_deriving.show ppx_deriving.eq)))
 
+(library
+ (name build_eligible_universe_runner_lib)
+ (modules build_eligible_universe_runner_lib)
+ (libraries core status universe)
+ (preprocess
+  (pps ppx_let ppx_deriving.show ppx_deriving.eq)))
+
+(executable
+ (name build_eligible_universe_runner)
+ (modules build_eligible_universe_runner)
+ (libraries
+  build_eligible_universe_runner_lib
+  core
+  core_unix.command_unix
+  status)
+ (preprocess
+  (pps ppx_jane)))
+
 (executable
  (name build_composition_universes_runner)
  (modules build_composition_universes_runner)

--- a/trading/analysis/data/universe/lib/build_eligible_universe.ml
+++ b/trading/analysis/data/universe/lib/build_eligible_universe.ml
@@ -85,26 +85,34 @@ let _is_equity_like ~equity_like_lookup symbol =
    snapshot's [avg_dollar_volume] field. *)
 type _eligible = { symbol : string; avg_dollar_volume : float }
 
-let _passes_price_gate ~config bars ~date =
+let _passes_price_gate ~config ~date bars =
   match BFI.latest_close_for_bars ~date bars with
   | None -> false
   | Some close -> Float.( >= ) close config.min_price
 
+(* The dollar-volume score, gated by [min_avg_dollar_volume] and the
+   min-window-bars requirement (the latter enforced inside
+   [avg_dollar_volume_for_bars]). [None] when either gate fails. *)
+let _passing_dollar_volume ~config ~date bars =
+  match
+    BFI.avg_dollar_volume_for_bars ~date
+      ~trailing_window_days:config.trailing_window_days
+      ~min_window_bars:config.min_window_bars bars
+  with
+  | Some score when Float.( >= ) score config.min_avg_dollar_volume ->
+      Some score
+  | _ -> None
+
+let _score_eligible_bars ~config ~date ~symbol bars : _eligible option =
+  if not (_passes_price_gate ~config ~date bars) then None
+  else
+    Option.map (_passing_dollar_volume ~config ~date bars) ~f:(fun score ->
+        { symbol; avg_dollar_volume = score })
+
 let _score_if_eligible ~date ~config symbol : _eligible option =
   match BR.read_bars ~bars_root:config.bars_root symbol with
   | None -> None
-  | Some bars -> (
-      if not (_passes_price_gate ~config bars ~date) then None
-      else
-        match
-          BFI.avg_dollar_volume_for_bars ~date
-            ~trailing_window_days:config.trailing_window_days
-            ~min_window_bars:config.min_window_bars bars
-        with
-        | None -> None
-        | Some score ->
-            if Float.( < ) score config.min_avg_dollar_volume then None
-            else Some { symbol; avg_dollar_volume = score })
+  | Some bars -> _score_eligible_bars ~config ~date ~symbol bars
 
 let _score_all ~date ~config symbols : _eligible list =
   List.filter_map symbols ~f:(_score_if_eligible ~date ~config)
@@ -161,15 +169,12 @@ let _make_entry ~uniform_weight (c : CPT.candidate) : Snapshot.entry =
   }
 
 let _empty_universe_error ~date =
-  Error
-    {
-      Status.code = Status.Failed_precondition;
-      message =
-        Printf.sprintf
-          "build_eligible_universe: no symbol survived the eligibility gates \
-           at %s"
-          (Date.to_string date);
-    }
+  let message =
+    Printf.sprintf
+      "build_eligible_universe: no symbol survived the eligibility gates at %s"
+      (Date.to_string date)
+  in
+  Error { Status.code = Status.Failed_precondition; message }
 
 let _make_snapshot ~date ~kept : Snapshot.t Status.status_or =
   let k = List.length kept in

--- a/trading/analysis/data/universe/lib/build_eligible_universe.ml
+++ b/trading/analysis/data/universe/lib/build_eligible_universe.ml
@@ -1,0 +1,217 @@
+open Core
+module CI = Composition_inputs
+module BR = Composition_bar_reader
+module BFI = Build_from_individuals
+module CP = Composition_policy
+module CPT = Composition_policy_types
+
+(* Defaults documented in [build_eligible_universe.mli]. *)
+let _default_trailing_window_days = 60
+let _default_min_window_bars = 30
+
+(* Live-universe spec gate values (the spec, not the no-op record default). *)
+let _spec_min_price = 5.0
+let _spec_min_avg_dollar_volume = 1_000_000.0
+
+(* ------------------------------------------------------------------ *)
+(* Config                                                              *)
+(* ------------------------------------------------------------------ *)
+
+type config = {
+  min_price : float;
+  min_avg_dollar_volume : float;
+  trailing_window_days : int;
+  min_window_bars : int;
+  reit_policy : CPT.reit_policy;
+  exclude_preferred : bool;
+  bars_root : string;
+  symbol_types_path : string;
+  sectors_csv_path : string;
+  inventory_path : string;
+}
+[@@deriving sexp]
+
+let default_config ~bars_root ~symbol_types_path ~sectors_csv_path
+    ~inventory_path =
+  {
+    min_price = 0.0;
+    min_avg_dollar_volume = 0.0;
+    trailing_window_days = _default_trailing_window_days;
+    min_window_bars = _default_min_window_bars;
+    reit_policy = CPT.Include;
+    exclude_preferred = false;
+    bars_root;
+    symbol_types_path;
+    sectors_csv_path;
+    inventory_path;
+  }
+
+let spec_config ~bars_root ~symbol_types_path ~sectors_csv_path ~inventory_path
+    =
+  {
+    (default_config ~bars_root ~symbol_types_path ~sectors_csv_path
+       ~inventory_path)
+    with
+    min_price = _spec_min_price;
+    min_avg_dollar_volume = _spec_min_avg_dollar_volume;
+    reit_policy = CPT.Exclude;
+    exclude_preferred = true;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* Active + equity-like filtering                                      *)
+(* ------------------------------------------------------------------ *)
+
+let _is_active ~date ~required_start (entry : CI.inventory_entry) =
+  Date.( <= ) entry.data_start_date required_start
+  && Date.( >= ) entry.data_end_date date
+
+let _active_symbols ~date ~config (inventory : CI.inventory) =
+  let required_start = Date.add_days date (-config.trailing_window_days) in
+  List.filter_map inventory.symbols ~f:(fun e ->
+      if _is_active ~date ~required_start e then Some e.symbol else None)
+
+let _is_equity_like ~equity_like_lookup symbol =
+  match Hashtbl.find equity_like_lookup symbol with
+  | Some true -> true
+  | _ -> false
+
+(* ------------------------------------------------------------------ *)
+(* Per-symbol scoring + eligibility gates                              *)
+(* ------------------------------------------------------------------ *)
+
+(* A symbol that passes the price / dollar-volume / min-bars gates, carrying
+   the score needed downstream for the composition-policy ADR floor and the
+   snapshot's [avg_dollar_volume] field. *)
+type _eligible = { symbol : string; avg_dollar_volume : float }
+
+let _passes_price_gate ~config bars ~date =
+  match BFI.latest_close_for_bars ~date bars with
+  | None -> false
+  | Some close -> Float.( >= ) close config.min_price
+
+let _score_if_eligible ~date ~config symbol : _eligible option =
+  match BR.read_bars ~bars_root:config.bars_root symbol with
+  | None -> None
+  | Some bars -> (
+      if not (_passes_price_gate ~config bars ~date) then None
+      else
+        match
+          BFI.avg_dollar_volume_for_bars ~date
+            ~trailing_window_days:config.trailing_window_days
+            ~min_window_bars:config.min_window_bars bars
+        with
+        | None -> None
+        | Some score ->
+            if Float.( < ) score config.min_avg_dollar_volume then None
+            else Some { symbol; avg_dollar_volume = score })
+
+let _score_all ~date ~config symbols : _eligible list =
+  List.filter_map symbols ~f:(_score_if_eligible ~date ~config)
+
+(* ------------------------------------------------------------------ *)
+(* Composition policy (REIT / preferred / dual-class)                  *)
+(* ------------------------------------------------------------------ *)
+
+let _asset_type_for ~asset_type_lookup symbol =
+  (* Symbols absent from the lookup default to Common_stock (per
+     [Composition_inputs.load_asset_type_lookup] semantics). *)
+  match Hashtbl.find asset_type_lookup symbol with
+  | Some t -> t
+  | None -> Eodhd.Asset_type.Common_stock
+
+let _sector_for ~sector_lookup symbol =
+  match Hashtbl.find sector_lookup symbol with Some s -> s | None -> ""
+
+(* Build composition-policy candidates in descending dollar-volume order so the
+   dual-class dedup keeps the more-liquid class and [rank] is meaningful. *)
+let _to_candidates ~asset_type_lookup ~sector_lookup eligible :
+    CPT.candidate list =
+  let sorted =
+    List.sort eligible ~compare:(fun a b ->
+        Float.compare b.avg_dollar_volume a.avg_dollar_volume)
+  in
+  List.mapi sorted ~f:(fun rank e ->
+      {
+        CPT.symbol = e.symbol;
+        asset_type = _asset_type_for ~asset_type_lookup e.symbol;
+        sector = _sector_for ~sector_lookup e.symbol;
+        avg_dollar_volume = e.avg_dollar_volume;
+        rank;
+      })
+
+let _policy_config ~config : CPT.config =
+  {
+    CPT.default_config with
+    reit_policy = config.reit_policy;
+    exclude_preferred = config.exclude_preferred;
+  }
+
+(* ------------------------------------------------------------------ *)
+(* Snapshot assembly                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let _make_entry ~uniform_weight (c : CPT.candidate) : Snapshot.entry =
+  {
+    symbol = c.symbol;
+    weight = uniform_weight;
+    sector = c.sector;
+    synthetic = false;
+    avg_dollar_volume = Some c.avg_dollar_volume;
+  }
+
+let _empty_universe_error ~date =
+  Error
+    {
+      Status.code = Status.Failed_precondition;
+      message =
+        Printf.sprintf
+          "build_eligible_universe: no symbol survived the eligibility gates \
+           at %s"
+          (Date.to_string date);
+    }
+
+let _make_snapshot ~date ~kept : Snapshot.t Status.status_or =
+  let k = List.length kept in
+  if k = 0 then _empty_universe_error ~date
+  else
+    let uniform_weight = 1.0 /. Float.of_int k in
+    let entries = List.map kept ~f:(_make_entry ~uniform_weight) in
+    Ok
+      {
+        Snapshot.date;
+        method_ = Composition_from_individuals;
+        size = k;
+        entries;
+        aggregate_period_return = 0.0;
+      }
+
+(* ------------------------------------------------------------------ *)
+(* Build pipeline                                                      *)
+(* ------------------------------------------------------------------ *)
+
+let _build_validated ~date ~config ~inventory ~equity_like_lookup
+    ~asset_type_lookup ~sector_lookup =
+  let active = _active_symbols ~date ~config inventory in
+  let equity_like =
+    List.filter active ~f:(_is_equity_like ~equity_like_lookup)
+  in
+  let eligible = _score_all ~date ~config equity_like in
+  let candidates = _to_candidates ~asset_type_lookup ~sector_lookup eligible in
+  let { CPT.kept; reports = _ } =
+    CP.apply ~config:(_policy_config ~config) candidates
+  in
+  _make_snapshot ~date ~kept
+
+let build ~date ~config =
+  let open Result.Let_syntax in
+  let%bind inventory = CI.load_inventory config.inventory_path in
+  let%bind equity_like_lookup =
+    CI.load_equity_like_lookup config.symbol_types_path
+  in
+  let%bind asset_type_lookup =
+    CI.load_asset_type_lookup config.symbol_types_path
+  in
+  let%bind sector_lookup = CI.load_sectors config.sectors_csv_path in
+  _build_validated ~date ~config ~inventory ~equity_like_lookup
+    ~asset_type_lookup ~sector_lookup

--- a/trading/analysis/data/universe/lib/build_eligible_universe.mli
+++ b/trading/analysis/data/universe/lib/build_eligible_universe.mli
@@ -1,0 +1,122 @@
+(** Build a {!Snapshot.t} as the set of {b all} current eligible US listings —
+    no top-N size cap.
+
+    Sibling of {!Build_from_individuals}, which selects a fixed top-N by
+    dollar-volume {i rank} at an annual reconstitution date. This builder
+    instead keeps {b every} common-stock-like symbol that clears a set of
+    {b absolute eligibility gates}, equal-weighted, for a single current date.
+    The output is the same on-disk {!Snapshot.t} shape the screener /
+    scenario_runner consume, so it drops straight into the live / backtest
+    pipeline.
+
+    Use it to materialize a live, current-dated universe from freshly-fetched
+    bars rather than a historical reconstitution.
+
+    {1 Pipeline (per [date])}
+
+    1. {b Active filter} — keep inventory entries with
+    [data_start_date <= date - trailing_window_days] (enough trailing history to
+    score) and [data_end_date >= date] (actively trading).
+
+    2. {b Equity-like filter} — drop ETF / Mutual_fund / Fund / Bond / Index /
+    Currency / Commodity via {!Eodhd.Asset_type.is_equity_like}; keeps
+    Common_stock / Preferred_stock / ADR / GDR.
+
+    3. {b Eligibility gates} (all configurable, see {!config}): drop symbols
+    whose latest close is below [min_price], whose trailing-window average
+    [close * volume] is below [min_avg_dollar_volume], or that have fewer than
+    [min_window_bars] bars in the trailing window. A symbol with no on-disk bars
+    is dropped.
+
+    4. {b Composition policy} — run {!Composition_policy.apply} with
+    [reit_policy = Exclude] and [exclude_preferred = true] (plus the always-on
+    dual-class dedup), so REITs and preferred shares are removed and only one
+    class per economic entity survives. Net survivors: Common_stock / ADR / GDR
+    passing every gate.
+
+    5. {b Emit} — every survivor becomes a {!Snapshot.entry} with uniform weight
+    [1.0 /. K] for the [K] survivors (so [total_weight ≈ 1.0]), its real GICS
+    sector, [synthetic = false], and [avg_dollar_volume = Some score]. The
+    snapshot's [size = K] (the actual survivor count — {b not} a cap) and
+    [method_ = Composition_from_individuals] (same consumer-facing tag).
+    [aggregate_period_return = 0.0]: a live build has no realized forward
+    window.
+
+    {1 Defaults reproduce a keep-all no-op}
+
+    {!default_config}'s gates are all no-ops ([min_price = 0.0],
+    [min_avg_dollar_volume = 0.0], [reit_policy = Include],
+    [exclude_preferred = false]) — per
+    [.claude/rules/experiment-flag-discipline.md] R2, every gate is an explicit
+    config field defaulting to the pre-gate behaviour. {!spec_config} is the
+    live-universe spec: [min_price = 5.0],
+    [min_avg_dollar_volume = 1_000_000.0], [reit_policy = Exclude],
+    [exclude_preferred = true]. *)
+
+open Core
+
+type config = {
+  min_price : float;
+      (** Drop symbols whose latest close (on / before [date]) is strictly below
+          this floor. No-op default [0.0]; the live-universe spec uses [5.0]. *)
+  min_avg_dollar_volume : float;
+      (** Drop symbols whose trailing-window average [close * volume] is
+          strictly below this floor. No-op default [0.0]; the spec uses
+          [1_000_000.0]. *)
+  trailing_window_days : int;
+      (** Calendar days of trailing data used for the dollar-volume score and
+          activity gate. Default [60]. *)
+  min_window_bars : int;
+      (** Minimum bars that must fall in the trailing window for a symbol to be
+          eligible — reuses {!Build_from_individuals}'s history gate. Default
+          [30] (≈ 30 weeks via the active filter / data-coverage requirement),
+          dropping sparse / fresh names. *)
+  reit_policy : Composition_policy_types.reit_policy;
+      (** Passed through to {!Composition_policy}. No-op default [Include]; spec
+          uses [Exclude]. *)
+  exclude_preferred : bool;
+      (** Passed through to {!Composition_policy}. No-op default [false]; spec
+          uses [true]. *)
+  bars_root : string;
+      (** Root of cached bars ([<L1>/<L2>/<symbol>/data.csv]). *)
+  symbol_types_path : string;  (** Path to [symbol_types.sexp]. *)
+  sectors_csv_path : string;
+      (** Path to [sectors.csv] (header [symbol,sector]). *)
+  inventory_path : string;  (** Path to [inventory.sexp]. *)
+}
+[@@deriving sexp]
+
+val default_config :
+  bars_root:string ->
+  symbol_types_path:string ->
+  sectors_csv_path:string ->
+  inventory_path:string ->
+  config
+(** [default_config ...] is the keep-all no-op: [min_price = 0.0],
+    [min_avg_dollar_volume = 0.0], [trailing_window_days = 60],
+    [min_window_bars = 30], [reit_policy = Include],
+    [exclude_preferred = false]. A build through this config keeps every active
+    equity-like symbol (the only drop is the always-on dual-class dedup). *)
+
+val spec_config :
+  bars_root:string ->
+  symbol_types_path:string ->
+  sectors_csv_path:string ->
+  inventory_path:string ->
+  config
+(** [spec_config ...] is {!default_config} with the live-universe gates flipped
+    on: [min_price = 5.0], [min_avg_dollar_volume = 1_000_000.0],
+    [reit_policy = Exclude], [exclude_preferred = true]. *)
+
+val build : date:Date.t -> config:config -> Snapshot.t Status.status_or
+(** [build ~date ~config] runs the pipeline in the module docstring and returns
+    the equal-weighted snapshot of every eligible symbol at [date].
+
+    Returns:
+    - [Error Status.Internal] if [inventory_path], [symbol_types_path], or
+      [sectors_csv_path] cannot be read or parsed.
+    - [Error Status.Failed_precondition] if {b no} symbol survives every gate
+      (an empty universe is a build failure, not a valid snapshot).
+    - [Ok snapshot] otherwise, with [snapshot.size] equal to the survivor count
+      ({b not} truncated) and uniform per-entry weights. Symbols whose
+      per-symbol [data.csv] is missing / unreadable are silently dropped. *)

--- a/trading/analysis/data/universe/lib/build_from_individuals.ml
+++ b/trading/analysis/data/universe/lib/build_from_individuals.ml
@@ -62,22 +62,32 @@ let _filter_by_equity_like ~equity_like_lookup symbols =
 (* Dollar-volume scoring                                               *)
 (* ------------------------------------------------------------------ *)
 
-let _in_trailing_window ~date ~config (b : BR.bar) =
-  let start_d = _trailing_window_start ~date ~config in
+let _in_window ~date ~trailing_window_days (b : BR.bar) =
+  let start_d = Date.add_days date (-trailing_window_days) in
   Date.( >= ) b.date start_d && Date.( <= ) b.date date
 
-let _dollar_volume_score ~date ~config bars =
+(* Pure trailing-window dollar-volume score over an already-read [bar list].
+   Windows to [[date - trailing_window_days, date]] and averages
+   [close * volume]; [None] when fewer than [min_window_bars] bars fall in the
+   window. Both the config-based ranker and the eligibility builder share this. *)
+let avg_dollar_volume_for_bars ~date ~trailing_window_days ~min_window_bars bars
+    =
   let window =
-    List.filter bars ~f:(fun b -> _in_trailing_window ~date ~config b)
+    List.filter bars ~f:(fun b -> _in_window ~date ~trailing_window_days b)
   in
   let n = List.length window in
-  if n < config.min_window_bars then None
+  if n < min_window_bars then None
   else
     let total =
       List.fold window ~init:0.0 ~f:(fun acc (b : BR.bar) ->
           acc +. (b.close *. b.volume))
     in
     Some (total /. Float.of_int n)
+
+let _dollar_volume_score ~date ~config bars =
+  avg_dollar_volume_for_bars ~date
+    ~trailing_window_days:config.trailing_window_days
+    ~min_window_bars:config.min_window_bars bars
 
 (* ------------------------------------------------------------------ *)
 (* Forward-return calculation                                          *)
@@ -91,6 +101,9 @@ let _first_on_or_after ~date bars =
 let _last_on_or_before ~date bars =
   List.fold bars ~init:None ~f:(fun acc (b : BR.bar) ->
       if Date.( <= ) b.date date then Some b else acc)
+
+let latest_close_for_bars ~date bars =
+  Option.map (_last_on_or_before ~date bars) ~f:(fun (b : BR.bar) -> b.close)
 
 let _forward_return ~date bars =
   let end_date = _forward_window_end ~date in

--- a/trading/analysis/data/universe/lib/build_from_individuals.mli
+++ b/trading/analysis/data/universe/lib/build_from_individuals.mli
@@ -81,6 +81,29 @@ val default_config :
      ~inventory_path] sets [trailing_window_days = 60] and
     [min_window_bars = 30]. *)
 
+val avg_dollar_volume_for_bars :
+  date:Date.t ->
+  trailing_window_days:int ->
+  min_window_bars:int ->
+  Composition_bar_reader.bar list ->
+  float option
+(** [avg_dollar_volume_for_bars ~date ~trailing_window_days ~min_window_bars
+     bars] is the trailing-window dollar-volume score over [bars]: it windows to
+    [[date - trailing_window_days, date]] and returns
+    [Some (avg (close * volume))] across that window when at least
+    [min_window_bars] bars fall inside it, else [None] (the same condition under
+    which {!build} drops a symbol). Pure helper over an already-read [bar list]
+    so a caller that needs both this score and {!latest_close_for_bars} reads
+    the CSV once. This is the exact scoring {!avg_dollar_volume_for_symbol} and
+    {!build}'s ranker apply. *)
+
+val latest_close_for_bars :
+  date:Date.t -> Composition_bar_reader.bar list -> float option
+(** [latest_close_for_bars ~date bars] is the [close] of the most recent bar on
+    or before [date], or [None] when no bar falls on / before [date]. Used by
+    the eligibility builder's [min_price] gate. Pure helper over an already-read
+    [bar list]. *)
+
 val avg_dollar_volume_for_symbol :
   date:Date.t -> config:config -> string -> float option
 (** [avg_dollar_volume_for_symbol ~date ~config symbol] computes the single

--- a/trading/analysis/data/universe/lib/dune
+++ b/trading/analysis/data/universe/lib/dune
@@ -5,6 +5,7 @@
   snapshot
   build_from_index
   build_from_individuals
+  build_eligible_universe
   composition_inputs
   composition_bar_reader
   composition_policy_types

--- a/trading/analysis/data/universe/test/dune
+++ b/trading/analysis/data/universe/test/dune
@@ -3,6 +3,7 @@
   test_snapshot
   test_build_from_index
   test_build_from_individuals
+  test_build_eligible_universe
   test_build_synthetic_universes_runner
   test_build_composition_universes_runner
   test_dual_class

--- a/trading/analysis/data/universe/test/test_build_eligible_universe.ml
+++ b/trading/analysis/data/universe/test/test_build_eligible_universe.ml
@@ -1,0 +1,355 @@
+open Core
+open OUnit2
+open Matchers
+open Universe
+open Universe.Snapshot
+module BEU = Build_eligible_universe
+
+(* ---------------------------------------------------------------------- *)
+(* Fixture builders                                                        *)
+(* ---------------------------------------------------------------------- *)
+
+(* All fixtures anchor at 2020-05-31. The trailing dollar-volume window is
+   the default 60 calendar days back ([2020-04-01, 2020-05-31]). *)
+let _build_date = Date.create_exn ~y:2020 ~m:Month.May ~d:31
+
+let _make_tmp_dir suffix =
+  let dir = Stdlib.Filename.temp_file "beu_test_" ("_" ^ suffix ^ ".d") in
+  (try Stdlib.Sys.remove dir with _ -> ());
+  ignore
+    (Stdlib.Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote dir))
+      : int);
+  dir
+
+let _cleanup_dir dir =
+  ignore
+    (Stdlib.Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)) : int)
+
+(* Mirror the production sharding rule: data/<L1>/<L2>/<symbol>/data.csv. *)
+let _bars_path ~root sym =
+  let l1 = String.prefix sym 1 in
+  let l2 =
+    if String.length sym >= 2 then
+      String.sub sym ~pos:(String.length sym - 1) ~len:1
+    else l1
+  in
+  let dir =
+    Filename.concat (Filename.concat (Filename.concat root l1) l2) sym
+  in
+  ignore
+    (Stdlib.Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote dir))
+      : int);
+  Filename.concat dir "data.csv"
+
+(* Write [n_bars] daily trailing bars at constant (close, volume), stepping
+   back from 2020-05-29. Score = close * volume; latest close = close. *)
+let _write_bars ~root sym ~close ~volume ~n_bars =
+  let path = _bars_path ~root sym in
+  let anchor = Date.create_exn ~y:2020 ~m:Month.May ~d:29 in
+  let buf = Buffer.create 1024 in
+  Buffer.add_string buf "date,open,high,low,close,adjusted_close,volume\n";
+  List.iter (List.init n_bars ~f:Fn.id) ~f:(fun i ->
+      let date = Date.add_days anchor (-i) in
+      Buffer.add_string buf
+        (Printf.sprintf "%s,%.2f,%.2f,%.2f,%.2f,%.2f,%d\n" (Date.to_string date)
+           close close close close close volume));
+  Out_channel.write_all path ~data:(Buffer.contents buf)
+
+let _symbol_types_sexp_of entries =
+  let body_lines =
+    List.map entries ~f:(fun (sym, asset_type_sexp) ->
+        Printf.sprintf "    ((symbol %s) (asset_type %s) (exchange \"\"))" sym
+          asset_type_sexp)
+  in
+  "((generated_at 2020-05-30)\n (source_endpoints ())\n (symbols (\n"
+  ^ String.concat ~sep:"\n" body_lines
+  ^ ")))\n"
+
+let _write_symbol_types ~root entries =
+  let path = Filename.concat root "symbol_types.sexp" in
+  Out_channel.write_all path ~data:(_symbol_types_sexp_of entries);
+  path
+
+let _write_sectors_csv ~root entries =
+  let path = Filename.concat root "sectors.csv" in
+  let buf = Buffer.create 256 in
+  Buffer.add_string buf "symbol,sector\n";
+  List.iter entries ~f:(fun (sym, sector) ->
+      Buffer.add_string buf (Printf.sprintf "%s,%s\n" sym sector));
+  Out_channel.write_all path ~data:(Buffer.contents buf);
+  path
+
+let _write_inventory ~root symbols =
+  let path = Filename.concat root "inventory.sexp" in
+  let body_lines =
+    List.map symbols ~f:(fun sym ->
+        Printf.sprintf
+          "  ((symbol %s) (data_start_date 2010-01-01) (data_end_date \
+           2022-01-01))"
+          sym)
+  in
+  let sexp =
+    "((generated_at 2020-05-30)\n (symbols (\n"
+    ^ String.concat ~sep:"\n" body_lines
+    ^ ")))\n"
+  in
+  Out_channel.write_all path ~data:sexp;
+  path
+
+(* Asset-type literals for symbol_types.sexp. *)
+let _common = "(Listed \"Common Stock\")"
+let _etf = "(Listed ETF)"
+let _preferred = "(Listed \"Preferred Stock\")"
+let _adr = "(Listed ADR)"
+
+(* A symbol spec: name, close, volume, n_bars, asset-type literal, sector. *)
+type spec = {
+  sym : string;
+  close : float;
+  volume : int;
+  n_bars : int;
+  asset_type : string;
+  sector : string;
+}
+
+let _spec ?(close = 50.0) ?(volume = 1_000_000) ?(n_bars = 60)
+    ?(asset_type = _common) ?(sector = "Tech") sym =
+  { sym; close; volume; n_bars; asset_type; sector }
+
+(* Materialize the fixture from a spec list and return [(root, config)] using
+   the live-universe spec_config gates. Caller must [_cleanup_dir root]. *)
+let _setup ~specs =
+  let root = _make_tmp_dir "fix" in
+  let bars_root = Filename.concat root "bars" in
+  ignore
+    (Stdlib.Sys.command
+       (Printf.sprintf "mkdir -p %s" (Filename.quote bars_root))
+      : int);
+  List.iter specs ~f:(fun s ->
+      _write_bars ~root:bars_root s.sym ~close:s.close ~volume:s.volume
+        ~n_bars:s.n_bars);
+  let symbol_types_path =
+    _write_symbol_types ~root
+      (List.map specs ~f:(fun s -> (s.sym, s.asset_type)))
+  in
+  let sectors_csv_path =
+    _write_sectors_csv ~root (List.map specs ~f:(fun s -> (s.sym, s.sector)))
+  in
+  let inventory_path =
+    _write_inventory ~root (List.map specs ~f:(fun s -> s.sym))
+  in
+  let config =
+    BEU.spec_config ~bars_root ~symbol_types_path ~sectors_csv_path
+      ~inventory_path
+  in
+  (root, config)
+
+let _build_or_fail ~config =
+  match BEU.build ~date:_build_date ~config with
+  | Ok snapshot -> snapshot
+  | Error err -> assert_failure ("build failed: " ^ Status.show err)
+
+let _symbols snapshot = List.map snapshot.entries ~f:(fun e -> e.symbol)
+
+(* ---------------------------------------------------------------------- *)
+(* Tests                                                                   *)
+(* ---------------------------------------------------------------------- *)
+
+(* min_price boundary: spec floor is 5.0. A symbol at exactly 5.0 is kept; a
+   symbol at 4.99 is dropped. Both clear the dollar-volume floor (high volume).
+   KEEP at 5.0 needs 5.0 * volume >= 1M ⇒ volume 1M gives 5M. *)
+let test_min_price_boundary _ =
+  let specs =
+    [
+      _spec "ATFLOOR" ~close:5.0 ~volume:1_000_000;
+      _spec "BELOW" ~close:4.99 ~volume:1_000_000;
+    ]
+  in
+  let root, config = _setup ~specs in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that (_symbols snapshot) (elements_are [ equal_to "ATFLOOR" ])
+
+(* min_avg_dollar_volume: spec floor is 1_000_000.0. ABOVE (50 * 100k = 5M)
+   kept; BELOW (50 * 10k = 500k) dropped. Both clear the price floor. *)
+let test_min_dollar_volume_gate _ =
+  let specs =
+    [
+      _spec "ABOVE" ~close:50.0 ~volume:100_000;
+      _spec "BELOWADV" ~close:50.0 ~volume:10_000;
+    ]
+  in
+  let root, config = _setup ~specs in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that (_symbols snapshot) (elements_are [ equal_to "ABOVE" ])
+
+(* min_window_bars: a symbol with only 5 trailing bars is dropped even though
+   its per-bar dollar volume clears the floor. *)
+let test_min_window_bars_gate _ =
+  let specs =
+    [
+      _spec "DENSE" ~close:50.0 ~volume:1_000_000 ~n_bars:60;
+      _spec "SPARSE" ~close:50.0 ~volume:1_000_000 ~n_bars:5;
+    ]
+  in
+  let root, config = _setup ~specs in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that (_symbols snapshot) (elements_are [ equal_to "DENSE" ])
+
+(* Asset-type / junk filters: a common stock and an ADR are kept; an ETF, a
+   preferred share, and a REIT (sector = "Real Estate") are dropped. Output is
+   rank-ordered by dollar volume; CMN (close 80) ranks above the ADR (close 50). *)
+let test_asset_type_and_junk_filters _ =
+  let specs =
+    [
+      _spec "CMN" ~close:80.0 ~volume:1_000_000 ~asset_type:_common;
+      _spec "ADRX" ~close:50.0 ~volume:1_000_000 ~asset_type:_adr;
+      _spec "ETFX" ~close:90.0 ~volume:1_000_000 ~asset_type:_etf;
+      _spec "PFD" ~close:70.0 ~volume:1_000_000 ~asset_type:_preferred;
+      _spec "REITX" ~close:60.0 ~volume:1_000_000 ~asset_type:_common
+        ~sector:"Real Estate";
+    ]
+  in
+  let root, config = _setup ~specs in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that (_symbols snapshot)
+    (elements_are [ equal_to "CMN"; equal_to "ADRX" ])
+
+(* No top-N truncation: K eligible common stocks ⇒ exactly K entries, all of
+   them, regardless of count. Here K = 6. *)
+let test_no_size_cap _ =
+  let specs =
+    List.init 6 ~f:(fun i ->
+        _spec (Printf.sprintf "SYM%d" i)
+          ~close:(Float.of_int (10 + i))
+          ~volume:1_000_000)
+  in
+  let root, config = _setup ~specs in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that snapshot
+    (all_of
+       [
+         field (fun s -> s.size) (equal_to 6);
+         field (fun s -> List.length s.entries) (equal_to 6);
+       ])
+
+(* Equal weight 1/K and total weight ≈ 1.0 (K = 4). *)
+let test_equal_weight _ =
+  let specs =
+    List.init 4 ~f:(fun i ->
+        _spec (Printf.sprintf "EQ%d" i)
+          ~close:(Float.of_int (20 + i))
+          ~volume:1_000_000)
+  in
+  let root, config = _setup ~specs in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that snapshot
+    (all_of
+       [
+         field
+           (fun s -> List.map s.entries ~f:(fun e -> e.weight))
+           (elements_are
+              [
+                float_equal ~epsilon:1e-9 0.25;
+                float_equal ~epsilon:1e-9 0.25;
+                float_equal ~epsilon:1e-9 0.25;
+                float_equal ~epsilon:1e-9 0.25;
+              ]);
+         field
+           (fun s -> Snapshot.total_weight s)
+           (float_equal ~epsilon:1e-9 1.0);
+       ])
+
+(* default_config is a keep-all no-op: with min_price = 0 and
+   min_avg_dollar_volume = 0 and reit_policy = Include and
+   exclude_preferred = false, a penny stock + a preferred + a REIT all survive
+   (only the equity-like filter, which drops ETFs, still applies). K = 3. *)
+let test_default_config_keeps_all _ =
+  let specs =
+    [
+      _spec "PENNY" ~close:0.10 ~volume:1;
+      _spec "PFD2" ~close:70.0 ~volume:1 ~asset_type:_preferred;
+      _spec "REIT2" ~close:60.0 ~volume:1 ~sector:"Real Estate";
+    ]
+  in
+  let root, _spec_cfg = _setup ~specs in
+  let bars_root = Filename.concat root "bars" in
+  let config =
+    BEU.default_config ~bars_root
+      ~symbol_types_path:(Filename.concat root "symbol_types.sexp")
+      ~sectors_csv_path:(Filename.concat root "sectors.csv")
+      ~inventory_path:(Filename.concat root "inventory.sexp")
+  in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that snapshot (field (fun s -> s.size) (equal_to 3))
+
+(* Empty universe (every symbol dropped by the gates) is a Failed_precondition
+   error, not an empty snapshot. All symbols are sub-price penny stocks. *)
+let test_empty_universe_is_error _ =
+  let specs =
+    [
+      _spec "P1" ~close:1.0 ~volume:1_000_000;
+      _spec "P2" ~close:2.0 ~volume:1_000_000;
+    ]
+  in
+  let root, config = _setup ~specs in
+  let result = BEU.build ~date:_build_date ~config in
+  _cleanup_dir root;
+  assert_that result (is_error_with Status.Failed_precondition)
+
+(* Determinism: two builds of the same fixture are identical. *)
+let test_determinism _ =
+  let specs =
+    [
+      _spec "AAA" ~close:80.0 ~volume:1_000_000;
+      _spec "BBB" ~close:50.0 ~volume:1_000_000;
+    ]
+  in
+  let root, config = _setup ~specs in
+  let s1 = _build_or_fail ~config in
+  let s2 = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that s2 (equal_to s1)
+
+(* Entries carry avg_dollar_volume = Some (close * volume) and the live-build
+   tag: synthetic = false, aggregate_period_return = 0.0. *)
+let test_entry_metadata _ =
+  let specs = [ _spec "ONE" ~close:50.0 ~volume:1_000_000 ] in
+  let root, config = _setup ~specs in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that snapshot
+    (all_of
+       [
+         field
+           (fun s -> List.map s.entries ~f:(fun e -> e.avg_dollar_volume))
+           (elements_are
+              [ is_some_and (float_equal ~epsilon:1.0 50_000_000.0) ]);
+         field
+           (fun s -> List.map s.entries ~f:(fun e -> e.synthetic))
+           (elements_are [ equal_to false ]);
+         field (fun s -> s.aggregate_period_return) (float_equal 0.0);
+       ])
+
+let suite =
+  "Build_eligible_universe"
+  >::: [
+         "test_min_price_boundary" >:: test_min_price_boundary;
+         "test_min_dollar_volume_gate" >:: test_min_dollar_volume_gate;
+         "test_min_window_bars_gate" >:: test_min_window_bars_gate;
+         "test_asset_type_and_junk_filters" >:: test_asset_type_and_junk_filters;
+         "test_no_size_cap" >:: test_no_size_cap;
+         "test_equal_weight" >:: test_equal_weight;
+         "test_default_config_keeps_all" >:: test_default_config_keeps_all;
+         "test_empty_universe_is_error" >:: test_empty_universe_is_error;
+         "test_determinism" >:: test_determinism;
+         "test_entry_metadata" >:: test_entry_metadata;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Adds `Build_eligible_universe` (under `analysis/data/universe/`): produces a
current-dated universe = **every** common-stock-like US listing that passes
**absolute eligibility gates**, equal-weighted, with **no top-N size cap**.

Sibling of `Build_from_individuals` (which takes a fixed top-N by dollar-volume
*rank*). Output is the same `Universe.Snapshot.t` shape the screener /
scenario_runner already consume (`method_ = Composition_from_individuals`;
`size = K` = the survivor count, **not** a cap; `aggregate_period_return = 0.0`
for a live build with no realized forward window).

### Pipeline (per date)
1. Active filter (inventory `data_start_date <= date - trailing_window_days`, `data_end_date >= date`).
2. Equity-like filter — drops ETF / Mutual_fund / Fund / Bond / Index / Currency / Commodity via `Eodhd.Asset_type.is_equity_like`.
3. Eligibility gates — `min_price` (latest close), `min_avg_dollar_volume` (trailing-window avg close×volume), `min_window_bars` (history gate).
4. `Composition_policy.apply` with `reit_policy = Exclude`, `exclude_preferred = true` (+ the always-on dual-class dedup). Net survivors: Common + ADR + GDR.
5. Emit equal weight `1.0 / K` for the `K` survivors (`total_weight ≈ 1.0`).

## Reuse (no duplication)

Factors the trailing-window dollar-volume score and latest-close logic out of
`Build_from_individuals`'s private `_dollar_volume_score` / `_last_on_or_before`
into two pure exported helpers over a `bar list`
(`avg_dollar_volume_for_bars` / `latest_close_for_bars`) — `build`'s behaviour
is unchanged. Reuses `Composition_inputs` loaders, `Composition_bar_reader`, and
`Composition_policy`.

## experiment-flag-discipline R2

Every gate is a config field. `default_config` is a keep-all no-op
(`min_price=0.0`, `min_avg_dollar_volume=0.0`, `reit_policy=Include`,
`exclude_preferred=false`) so existing callers are unaffected; `spec_config` is
the live-universe spec (`5.0` / `1_000_000.0` / `Exclude` / `true`).

## Runner

`build_eligible_universe_runner.exe` — single-dash Core flags
`-inventory-path -csv-data-dir -date -min-price -min-adv -output-path`. Builder
+ fixture-test only here; the dispatcher runs it later on freshly-fetched data.

## Test plan

10 fixture-based tests (no network), in `test/test_build_eligible_universe.ml`:
min_price boundary (at/above kept, below dropped), min-ADV gate,
min-window-bars gate, asset-type/junk filters (ETF/preferred/REIT dropped,
common+ADR kept), **no-size-cap** (K in → exactly K out), equal-weight +
total≈1.0, default-config keep-all, empty-universe → `Failed_precondition`,
determinism, entry metadata (`avg_dollar_volume`, `synthetic=false`,
`aggregate_period_return=0.0`).

Verification (in container, against this worktree):
- `dune build` — exit 0 (full project)
- `dune runtest analysis/data/universe/` — exit 0 (10 new + all existing)
- `no_python_check.sh` — OK, no `*.py`
- ocamlformat (default profile, repo version 0.29.0) — all 8 touched `.ml`/`.mli` clean

Plan: `dev/plans/eligible-universe-builder-2026-06-14.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
