### PR TITLE
feat(rolling_start): screener-based factor columns (lens stage 5b)

### DIFF
--- a/dev/status/rolling-start-lens.md
+++ b/dev/status/rolling-start-lens.md
@@ -30,7 +30,7 @@ existing columns/ordering preserved as a strict superset. `Rolling_start_runner`
 gains `bench_max_dd_pct` and a `?benchmark_max_dd_pct` param on
 `per_start_of_summary`.
 
-Stage 5b (PR (feat/rolling-start-lens-5b)) adds two new modules — `Rolling_start_factors`
+Stage 5b (PR #1607) adds two new modules — `Rolling_start_factors`
 (the pure factor projections) and `Rolling_start_factor_reader` (the thin
 snapshot-warehouse I/O that feeds them; split out so the runner stays under the
 file-length limit) — and a `factors : Rolling_start_factors.factors` field on
@@ -55,7 +55,7 @@ churn for non-readers.
       Files: `trading/trading/backtest/rolling_start/lib/rolling_start_{types,runner}.{ml,mli}`,
       `trading/trading/backtest/rolling_start/test/test_rolling_start_{types,runner}.ml`.
 
-- [x] **Screener-based factor columns (stage 5b)** (PR (feat/rolling-start-lens-5b)). New pure module
+- [x] **Screener-based factor columns (stage 5b)** (PR #1607). New pure module
       `Rolling_start_factors` + four per-start factor columns, all read from the
       *precomputed* snapshot-warehouse fields (cheap point reads, no classifier
       re-run): (1) **SPY/macro stage at start** — decodes the benchmark index's
@@ -80,7 +80,7 @@ churn for non-readers.
 
 ### In-progress
 
-- (none — PR (feat/rolling-start-lens-5b) awaiting QC)
+- (none — PR #1607 awaiting QC)
 
 ### Next steps (data-gated / local-session — NOT GHA)
 
@@ -98,4 +98,4 @@ when a downstream decision starts to depend on them.
 
 - Plan: `dev/plans/rolling-start-realized-edge-lens-2026-06-14.md`
 - PR #1586 `feat/rolling-start-realized-edge-lens`
-- PR (feat/rolling-start-lens-5b) `feat/rolling-start-lens-5b` (screener-based factor columns)
+- PR #1607 `feat/rolling-start-lens-5b` (screener-based factor columns)

--- a/dev/status/rolling-start-lens.md
+++ b/dev/status/rolling-start-lens.md
@@ -1,6 +1,6 @@
 # Status: rolling-start-lens
 
-## Last updated: 2026-06-14
+## Last updated: 2026-06-15
 
 ## Status
 IN_PROGRESS
@@ -30,6 +30,15 @@ existing columns/ordering preserved as a strict superset. `Rolling_start_runner`
 gains `bench_max_dd_pct` and a `?benchmark_max_dd_pct` param on
 `per_start_of_summary`.
 
+Stage 5b (PR (feat/rolling-start-lens-5b)) adds two new modules — `Rolling_start_factors`
+(the pure factor projections) and `Rolling_start_factor_reader` (the thin
+snapshot-warehouse I/O that feeds them; split out so the runner stays under the
+file-length limit) — and a `factors : Rolling_start_factors.factors` field on
+`per_start` (default `Rolling_start_factors.empty` via the new `?factors` param
+on `per_start_of_summary`). Four detail-table columns appended (SPY stage /
+Macro composite / Stage-2 count / Sector-RS dispersion) — strict superset, no
+churn for non-readers.
+
 ### Completed
 
 - [x] **Realized-edge + forward-index-DD lens columns** (PR #1586). Adds the
@@ -46,9 +55,32 @@ gains `bench_max_dd_pct` and a `?benchmark_max_dd_pct` param on
       Files: `trading/trading/backtest/rolling_start/lib/rolling_start_{types,runner}.{ml,mli}`,
       `trading/trading/backtest/rolling_start/test/test_rolling_start_{types,runner}.ml`.
 
+- [x] **Screener-based factor columns (stage 5b)** (PR (feat/rolling-start-lens-5b)). New pure module
+      `Rolling_start_factors` + four per-start factor columns, all read from the
+      *precomputed* snapshot-warehouse fields (cheap point reads, no classifier
+      re-run): (1) **SPY/macro stage at start** — decodes the benchmark index's
+      `Stage` cell as-of `start_date` (1/2/3/4); (2) **Macro_composite at start**
+      — the benchmark's `Macro_composite` cell verbatim; (3) **Stage-2 candidate
+      count** — counts universe symbols whose `Stage` cell decodes to 2 as-of
+      `start_date`; (4) **sector-RS dispersion** — IQR of per-sector mean
+      `RS_line` across the universe as-of `start_date`. Factors are resolved once
+      in the parent over a single shared `Daily_panels` handle, then threaded into
+      each forked start's row. Unavailable factors emit `None`/`nan` (the report
+      renders blank) — universe-scan factors are blank for a `Full_sector_map`
+      universe (sectors.csv fallback not resolved here — documented gap) and for
+      CSV mode (no panels handle). The pure projections (stage decode, Stage-2
+      count, sector-RS IQR) are pinned by `test_rolling_start_factors.ml`
+      (known input → expected value); the superset render is pinned by
+      `test_rolling_start_types.ml`.
+      Verify: `dev/lib/run-in-env.sh dune runtest trading/backtest/rolling_start/`.
+      Files: `trading/trading/backtest/rolling_start/lib/rolling_start_{factors,factor_reader}.{ml,mli}`,
+      `.../rolling_start/lib/rolling_start_{types,runner}.{ml,mli}`,
+      `.../rolling_start/test/test_rolling_start_factors.ml`,
+      `.../rolling_start/test/{test_rolling_start_types.ml,dune}`.
+
 ### In-progress
 
-- (none — PR #1586 awaiting QC)
+- (none — PR (feat/rolling-start-lens-5b) awaiting QC)
 
 ### Next steps (data-gated / local-session — NOT GHA)
 
@@ -56,13 +88,6 @@ These need the top-3000 PIT snapshot warehouse + screener, so they are
 maintainer-local, not GHA-dispatchable. Tag `[blocking: by warehouse build]`
 when a downstream decision starts to depend on them.
 
-- [ ] **Macro-stage-at-start column** — stage classifier on GSPC at each
-      `start_date` (1/2/3/4) + `Macro_composite` continuous value (already in the
-      snapshot warehouse per date).
-- [ ] **Stage-2-candidate-count-at-start column** — screener candidate count on
-      `start_date` (the H3 fresh-supply factor).
-- [ ] **Sector-RS-dispersion-at-start column** — spread of sector relative
-      strength on `start_date`.
 - [ ] **31-start causal analysis** — per-factor Spearman vs realized-edge +
       tercile contingency, 3-4 traced starts (one clean beat, one melt-up miss,
       one bear-start), confirm/refute H1/H2/H3, and the resulting deployment
@@ -73,3 +98,4 @@ when a downstream decision starts to depend on them.
 
 - Plan: `dev/plans/rolling-start-realized-edge-lens-2026-06-14.md`
 - PR #1586 `feat/rolling-start-realized-edge-lens`
+- PR (feat/rolling-start-lens-5b) `feat/rolling-start-lens-5b` (screener-based factor columns)

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_factor_reader.ml
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_factor_reader.ml
@@ -1,0 +1,117 @@
+open Core
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot = Data_panel_snapshot.Snapshot
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+
+(* The calendar-day lookback window for an "as-of [date]" snapshot read. Snapshot
+   rows exist on trading days only, so [date] (a start date, possibly a weekend
+   or holiday) may have no exact row; we read [date - window .. date] and take
+   the latest row on/before [date]. ~10 days comfortably spans any holiday gap.
+*)
+let _as_of_lookback_days = 10
+
+(* The latest snapshot row for [symbol] on/before [date] (within the lookback
+   window), or [None] when the symbol has no row there / the read fails. Used
+   for every "factor as-of the start date" read. *)
+let _row_as_of ~panels ~symbol ~date =
+  let from = Date.add_days date (-_as_of_lookback_days) in
+  match Daily_panels.read_history panels ~symbol ~from ~until:date with
+  | Error _ | Ok [] -> None
+  | Ok rows ->
+      List.max_elt rows ~compare:(fun (a : Snapshot.t) b ->
+          Date.compare a.date b.date)
+
+(* The [field] cell of [symbol]'s as-of-[date] row, as [Some v] (v may be nan)
+   or [None] when there is no row / the field is absent. *)
+let _field_as_of ~panels ~symbol ~date ~field =
+  Option.bind (_row_as_of ~panels ~symbol ~date) ~f:(fun row ->
+      Snapshot.get row field)
+
+(* The [field] cell of [symbol]'s as-of-[date] row, defaulting an absent
+   row/field to [nan] — the "skip me" marker the universe-scan factors expect. *)
+let _field_or_nan ~panels ~symbol ~date ~field =
+  _field_as_of ~panels ~symbol ~date ~field |> Option.value ~default:Float.nan
+
+(* The benchmark index's decoded stage as-of [date], or [None] for no symbol /
+   no row / nan cell. *)
+let _benchmark_stage ~panels ~benchmark_symbol ~date =
+  Option.bind benchmark_symbol ~f:(fun symbol ->
+      Option.bind
+        (_field_as_of ~panels ~symbol ~date ~field:Snapshot_schema.Stage)
+        ~f:Rolling_start_factors.macro_stage_of_value)
+
+(* The benchmark index's stage + macro-composite as-of [date]. Both unavailable
+   ([None] / [nan]) when there is no benchmark symbol or no as-of row. *)
+let _benchmark_factors ~panels ~benchmark_symbol ~date =
+  let stage = _benchmark_stage ~panels ~benchmark_symbol ~date in
+  let macro_composite =
+    match benchmark_symbol with
+    | None -> Float.nan
+    | Some symbol ->
+        _field_or_nan ~panels ~symbol ~date
+          ~field:Snapshot_schema.Macro_composite
+  in
+  (stage, macro_composite)
+
+(* One universe symbol's [(stage_value, (sector, rs_value))] as-of [date]: the
+   raw [Stage] scalar (nan when absent, so {!Rolling_start_factors} skips it) and
+   the symbol's sector paired with its [RS_line] scalar. *)
+let _cell_as_of ~panels ~date (symbol, sector) =
+  let stage_value =
+    _field_or_nan ~panels ~symbol ~date ~field:Snapshot_schema.Stage
+  in
+  let rs_value =
+    _field_or_nan ~panels ~symbol ~date ~field:Snapshot_schema.RS_line
+  in
+  (stage_value, (sector, rs_value))
+
+(* Per universe symbol, its as-of-[date] cell ({!_cell_as_of}). *)
+let _universe_cells_as_of ~panels ~universe ~date =
+  List.map universe ~f:(_cell_as_of ~panels ~date)
+
+let factors_as_of ~panels ~benchmark_symbol ~universe ~date :
+    Rolling_start_factors.factors =
+  let spy_stage_at_start, macro_composite_at_start =
+    _benchmark_factors ~panels ~benchmark_symbol ~date
+  in
+  let cells = _universe_cells_as_of ~panels ~universe ~date in
+  let stage2_candidate_count =
+    match universe with
+    | [] -> None
+    | _ ->
+        Some
+          (Rolling_start_factors.stage2_candidate_count (List.map cells ~f:fst))
+  in
+  let sector_rs_dispersion_at_start =
+    Rolling_start_factors.sector_rs_dispersion (List.map cells ~f:snd)
+  in
+  {
+    Rolling_start_factors.spy_stage_at_start;
+    macro_composite_at_start;
+    stage2_candidate_count;
+    sector_rs_dispersion_at_start;
+  }
+
+(* Fold every start's {!factors_as_of} into a [start_date -> factors] map over
+   one already-open [panels] handle. *)
+let _fold_factors ~panels ~benchmark_symbol ~universe starts =
+  List.fold starts
+    ~init:(Map.empty (module Date))
+    ~f:(fun acc date ->
+      Map.set acc ~key:date
+        ~data:(factors_as_of ~panels ~benchmark_symbol ~universe ~date))
+
+(* Build the shared panels, fold the per-start factors over it, close it, and
+   return the map; the empty map on any panels failure. *)
+let _resolve_via_panels ~src ~benchmark_symbol ~universe ~starts =
+  match Backtest.Bar_data_source.build_shared_panels src with
+  | Ok (Some panels) ->
+      let result = _fold_factors ~panels ~benchmark_symbol ~universe starts in
+      Backtest.Bar_data_source.close_shared_panels panels;
+      result
+  | Ok None | Error _ -> Map.empty (module Date)
+
+let resolve_per_start ~bar_data_source ~benchmark_symbol ~universe ~starts =
+  match bar_data_source with
+  | None -> Map.empty (module Date)
+  | Some src -> _resolve_via_panels ~src ~benchmark_symbol ~universe ~starts

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_factor_reader.mli
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_factor_reader.mli
@@ -1,0 +1,64 @@
+(** Snapshot-warehouse reader for the rolling-start screener-based factors.
+
+    The I/O layer between the snapshot warehouse
+    ({!Snapshot_runtime.Daily_panels}) and the pure {!Rolling_start_factors}
+    projections. {!Rolling_start_runner} calls {!factors_as_of} once per start
+    (over a single shared panels handle) to fill each row's
+    {!Rolling_start_types.per_start.factors} — the factor-decomposition lens
+    stage 5b.
+
+    Kept separate from the runner so the runner stays a thin orchestrator and
+    the "read the precomputed cells as-of a date" logic is independently
+    readable. It is impure (reads panels) — unlike {!Rolling_start_factors},
+    which is the pure arithmetic the reader feeds. *)
+
+open Core
+
+val factors_as_of :
+  panels:Snapshot_runtime.Daily_panels.t ->
+  benchmark_symbol:string option ->
+  universe:(string * string) list ->
+  date:Date.t ->
+  Rolling_start_factors.factors
+(** [factors_as_of ~panels ~benchmark_symbol ~universe ~date] builds the four
+    screener-based factor columns as-of [date], all from the {b precomputed}
+    snapshot-warehouse fields (cheap point reads — no classifier re-run):
+
+    - {b SPY/macro stage} + {b macro composite}: the benchmark index's [Stage]
+      cell (decoded via {!Rolling_start_factors.macro_stage_of_value}) and
+      [Macro_composite] cell as-of [date]. Both unavailable ([None] / [nan])
+      when [benchmark_symbol] is [None] or it has no row on/before [date].
+    - {b Stage-2 candidate count}: the number of [universe] symbols whose
+      [Stage] cell decodes to Stage 2 as-of [date]
+      ({!Rolling_start_factors.stage2_candidate_count}). [None] for an empty
+      [universe] (could not scan); [Some 0] is a real "no setups" reading.
+    - {b sector-RS dispersion}: the IQR of per-sector mean [RS_line] across
+      [universe] as-of [date] ({!Rolling_start_factors.sector_rs_dispersion}).
+
+    Each as-of read takes the latest row on/before [date] within a short
+    lookback window (snapshot rows exist on trading days only, so [date] may be
+    a weekend / holiday with no exact row). A missing row or absent field reads
+    as unavailable ([nan] for the universe scan so {!Rolling_start_factors}
+    skips it, [None] for the benchmark stage). [universe] is the
+    [(symbol, sector)] list; an empty list leaves the two universe-scan factors
+    unavailable. *)
+
+val resolve_per_start :
+  bar_data_source:Backtest.Bar_data_source.t option ->
+  benchmark_symbol:string option ->
+  universe:(string * string) list ->
+  starts:Date.t list ->
+  (Date.t, Rolling_start_factors.factors, Date.comparator_witness) Map.t
+(** [resolve_per_start ~bar_data_source ~benchmark_symbol ~universe ~starts]
+    computes every start's {!factors_as_of} once, reusing a {b single} shared
+    {!Snapshot_runtime.Daily_panels} handle (built from [bar_data_source])
+    across all starts — each symbol file decodes once and stays LRU-cached, so
+    the whole sweep's factor reads are cheap. Returns a [start_date -> factors]
+    map for {!Rolling_start_runner.run} to join onto its forked per-start jobs.
+
+    Returns the {b empty} map (every start falls back to
+    {!Rolling_start_factors.empty}) when [bar_data_source] is [None] (CSV mode —
+    no shared-panels handle), or when
+    {!Backtest.Bar_data_source.build_shared_panels} yields no panels / errors.
+    The panels handle is opened and closed within this call; the parent owns the
+    lifecycle. *)

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_factors.ml
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_factors.ml
@@ -1,0 +1,56 @@
+open Core
+
+(* The four stage codes the snapshot [Stage] scalar encodes (1.0..4.0). A cell
+   is decoded by rounding to the nearest integer and accepting only 1..4 — any
+   nan or out-of-range value is "not classifiable" (None). *)
+let _min_stage = 1
+let _max_stage = 4
+
+let macro_stage_of_value v =
+  if Float.is_nan v then None
+  else
+    let rounded = Float.round_nearest v |> Int.of_float in
+    Option.some_if (rounded >= _min_stage && rounded <= _max_stage) rounded
+
+(* Stage 2 is the confirmed-breakout-eligible stage. *)
+let _stage2 = 2
+
+let stage2_candidate_count stage_values =
+  List.count stage_values ~f:(fun v ->
+      match macro_stage_of_value v with
+      | Some stage -> stage = _stage2
+      | None -> false)
+
+(* The IQR of <2 distinct sectors is undefined — report nan rather than 0.0 so a
+   degenerate single-sector universe is not read as "zero dispersion". *)
+let _min_sectors_for_spread = 2
+
+let _mean = function
+  | [] -> Float.nan
+  | xs -> List.sum (module Float) xs ~f:Fn.id /. Float.of_int (List.length xs)
+
+let sector_rs_dispersion sector_rs =
+  let defined =
+    List.filter sector_rs ~f:(fun (_, rs) -> not (Float.is_nan rs))
+  in
+  let sector_means =
+    Map.of_alist_multi (module String) defined |> Map.data |> List.map ~f:_mean
+  in
+  if List.length sector_means < _min_sectors_for_spread then Float.nan
+  else Dispersion_stats.iqr sector_means
+
+type factors = {
+  spy_stage_at_start : int option;
+  macro_composite_at_start : float;
+  stage2_candidate_count : int option;
+  sector_rs_dispersion_at_start : float;
+}
+[@@deriving sexp, equal]
+
+let empty =
+  {
+    spy_stage_at_start = None;
+    macro_composite_at_start = Float.nan;
+    stage2_candidate_count = None;
+    sector_rs_dispersion_at_start = Float.nan;
+  }

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_factors.mli
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_factors.mli
@@ -1,0 +1,93 @@
+(** Pure screener-based factor projections for the rolling-start lens (stage
+    5b).
+
+    The factor-decomposition lens (design:
+    [dev/notes/factor-decomposition-lens-design-2026-06-14.md] §"Factor
+    columns") joins each rolling-start row to candidate {b causes} so we can
+    explain {b why} the strategy beats (or loses to) the benchmark from a given
+    start, not just report a bare aggregate. Stage (a) — the cheap outcome
+    columns ([realized_edge_pct], [forward_index_max_dd_pct]) — shipped in
+    #1586. This module is stage (b): the {b screener-based} factors evaluated
+    {b as-of each start date}.
+
+    All four factors are computed from the {b precomputed} snapshot-warehouse
+    fields ([Snapshot_schema.Stage], [Macro_composite], [RS_line]) rather than
+    by re-running the classifiers — the offline pipeline is the single source of
+    truth for those scalars (see [snapshot_schema.mli]). That keeps the factors
+    a cheap point-read per (symbol, date) and keeps this module {b pure}: it
+    takes already-read field values and returns the factor, so it is unit-tested
+    against hand-computed inputs without any panels handle or I/O.
+
+    Every factor uses [Float.nan] / [None] as the explicit "not available"
+    marker, mirroring the nan discipline of {!Rolling_start_types.per_start};
+    the renderer / downstream stats decide how to surface "no data" rather than
+    this module inventing a sentinel. *)
+
+val macro_stage_of_value : float -> int option
+(** [macro_stage_of_value v] decodes the snapshot [Stage] scalar (encoded as
+    [1.0 | 2.0 | 3.0 | 4.0], with [Float.nan] = "not yet classifiable") into the
+    integer stage [1 | 2 | 3 | 4]. Returns [None] for [Float.nan] or any value
+    that does not round to one of those four stages (defensive against a
+    malformed cell). The "SPY/macro stage at start" factor — run on the
+    benchmark index's [Stage] cell as-of the start date. *)
+
+val stage2_candidate_count : float list -> int
+(** [stage2_candidate_count stage_values] counts how many of the universe's
+    [Stage] scalars (one per symbol, read as-of the start date) decode to
+    {b Stage 2} — the confirmed-breakout-eligible stage. [Float.nan] cells (a
+    symbol not yet classifiable on that date, e.g. pre-IPO) are skipped, not
+    counted. The "Stage-2 candidate count at start" factor (design H3 /
+    "fresh-supply"). *)
+
+val sector_rs_dispersion : (string * float) list -> float
+(** [sector_rs_dispersion sector_rs] is the cross-sector {b spread} of relative
+    strength as-of the start date — the IQR (75th − 25th percentile, via
+    {!Dispersion_stats.iqr}) of the {b per-sector mean} [RS_line].
+
+    Input is one [(sector, rs_value)] pair per universe symbol (the symbol's
+    snapshot [RS_line] cell as-of the start date, tagged with its sector). The
+    computation: drop pairs whose [rs_value] is [Float.nan], group the rest by
+    sector, take each sector's mean RS, then take the IQR across those sector
+    means. A wide dispersion means strongly-divergent sector leadership (the
+    "stronger/weaker sectors" question); a tight one means the sectors moved
+    together.
+
+    Returns [Float.nan] when, after dropping nan cells, fewer than two distinct
+    sectors remain (the spread of <2 sectors is undefined). IQR is chosen over
+    stdev for consistency with the rest of the rolling-start report, which keys
+    its dispersion on quartiles. *)
+
+type factors = {
+  spy_stage_at_start : int option;
+      (** The benchmark index's Weinstein stage ([1 | 2 | 3 | 4]) as-of the
+          start date, via {!macro_stage_of_value} on the benchmark's [Stage]
+          cell. [None] when no benchmark is configured, the benchmark has no
+          snapshot row on/before the start, or its [Stage] cell is [nan]. Design
+          H3: edge is expected worse when this is [3] (toppy start). *)
+  macro_composite_at_start : float;
+      (** The benchmark index's [Macro_composite] scalar as-of the start date —
+          continuous macro-tape strength at entry. [Float.nan] when no benchmark
+          is configured, no row priced the date, or the cell is [nan]. *)
+  stage2_candidate_count : int option;
+      (** Count of universe symbols in Stage 2 as-of the start date
+          ({!stage2_candidate_count}). [None] only when the universe could not
+          be scanned at all (no panels handle / empty universe); [Some 0] is a
+          real "no Stage-2 setups" reading, distinct from "could not compute".
+      *)
+  sector_rs_dispersion_at_start : float;
+      (** Cross-sector IQR of mean [RS_line] as-of the start date
+          ({!sector_rs_dispersion}). [Float.nan] when fewer than two sectors had
+          a defined RS, or the universe could not be scanned. *)
+}
+[@@deriving sexp, equal]
+(** The four screener-based factor columns for one rolling start. Appended to
+    {!Rolling_start_types.per_start} as a strict superset: a row carries these
+    alongside the existing outcome columns, and consumers that don't read them
+    are unaffected. *)
+
+val empty : factors
+(** [empty] is the all-unavailable factor set ([spy_stage_at_start = None],
+    [macro_composite_at_start = nan], [stage2_candidate_count = None],
+    [sector_rs_dispersion_at_start = nan]) — the value for a start that ran with
+    no snapshot warehouse to read factors from (e.g. CSV mode, or no benchmark).
+*)

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_runner.ml
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_runner.ml
@@ -88,8 +88,9 @@ let _realized_return_pct ~initial_cash ~final_value ~unrealized_pnl =
   else (final_value -. unrealized_pnl -. initial_cash) /. initial_cash *. 100.0
 
 let per_start_of_summary ?(benchmark_cagr_pct = Float.nan)
-    ?(benchmark_max_dd_pct = Float.nan) ?(equity_curve = []) ~start_date
-    ~end_date (summary : Backtest.Summary.t) : Rolling_start_types.per_start =
+    ?(benchmark_max_dd_pct = Float.nan) ?(equity_curve = [])
+    ?(factors = Rolling_start_factors.empty) ~start_date ~end_date
+    (summary : Backtest.Summary.t) : Rolling_start_types.per_start =
   let get k = Map.find summary.metrics k |> Option.value ~default:Float.nan in
   let total_return_pct =
     (summary.final_portfolio_value -. summary.initial_cash)
@@ -127,6 +128,7 @@ let per_start_of_summary ?(benchmark_cagr_pct = Float.nan)
     sharpe = get Metric_types.SharpeRatio;
     time_underwater_pct = Convexity_stats.time_underwater_pct equity_curve;
     realized_return_pct;
+    factors;
   }
 
 type config = {
@@ -189,8 +191,12 @@ let _sector_map_override ~fixtures_root (scenario : Scenario.t) =
     scenario's overrides / strategy / cost knobs and the shared sector-map
     override + optional snapshot source, and project the terminal summary into a
     {!Rolling_start_types.per_start}. [benchmark_series] is the (once-resolved)
-    benchmark close series; this start's benchmark CAGR is projected from it. *)
-let _run_one ~config ~sector_map_override ~benchmark_series ~start_date =
+    benchmark close series; this start's benchmark CAGR is projected from it.
+    [factors] is this start's precomputed screener-based factor columns
+    (resolved in the parent via {!_resolve_factors_per_start}); they ride along
+    into the projected row. *)
+let _run_one ~config ~sector_map_override ~benchmark_series ~factors ~start_date
+    =
   let result =
     Backtest.Runner.run_backtest ~start_date ~end_date:config.end_date
       ~overrides:config.scenario.config_overrides ?sector_map_override
@@ -216,7 +222,39 @@ let _run_one ~config ~sector_map_override ~benchmark_series ~start_date =
         s.portfolio_value)
   in
   per_start_of_summary ~benchmark_cagr_pct ~benchmark_max_dd_pct ~equity_curve
-    ~start_date ~end_date:config.end_date result.summary
+    ~factors ~start_date ~end_date:config.end_date result.summary
+
+(* The [(symbol, sector)] universe for the universe-scan factors. A [Pinned]
+   universe yields [Some tbl] -> its symbol list; [Full_sector_map] yields
+   [None] -> [[]], leaving the universe-scan factors unavailable (the sectors.csv
+   fallback is not resolved here — a documented gap). *)
+let _universe_of_override = function
+  | Some tbl -> Hashtbl.to_alist tbl
+  | None -> []
+
+(* One forked-job thunk: look this start's factors out of [factors_by_start]
+   (defaulting to the empty factors), then run + project its backtest. *)
+let _job_for_start ~config ~sector_map_override ~benchmark_series
+    ~factors_by_start start_date () =
+  let factors =
+    Map.find factors_by_start start_date
+    |> Option.value ~default:Rolling_start_factors.empty
+  in
+  _run_one ~config ~sector_map_override ~benchmark_series ~factors ~start_date
+
+(* The benchmark close series for the sweep: resolved once from the earliest
+   start, or [] when there are no starts (so every benchmark CAGR is nan). *)
+let _benchmark_series_for ~config ~starts =
+  match List.min_elt starts ~compare:Date.compare with
+  | Some earliest_start -> _resolve_benchmark_series ~config ~earliest_start
+  | None -> []
+
+(* Run the per-start jobs: forked one-at-a-time at [parallel <= 1] (the
+   memory-safe broad-universe path), else up to [parallel] children at once.
+   Result order is input order in both cases (see Fork_pool). *)
+let _run_jobs ~parallel ~jobs =
+  if parallel <= 1 then Fork_pool.run_each_forked ~jobs
+  else Fork_pool.run_parallel ~parallel ~jobs
 
 (* The start dates to sweep: jittered when [jitter_seed] is set, the fixed grid
    otherwise. Both share the same base grid. *)
@@ -235,25 +273,25 @@ let run config =
   let sector_map_override =
     _sector_map_override ~fixtures_root:config.fixtures_root config.scenario
   in
-  let benchmark_series =
-    match List.min_elt starts ~compare:Date.compare with
-    | Some earliest_start -> _resolve_benchmark_series ~config ~earliest_start
-    | None -> []
+  let benchmark_series = _benchmark_series_for ~config ~starts in
+  (* Every start's factor columns, resolved once in the parent over a single
+     open panels handle (cheap point reads), then handed to the matching forked
+     job. Empty map (CSV / no benchmark) -> every job uses the empty factors. *)
+  let factors_by_start =
+    Rolling_start_factor_reader.resolve_per_start
+      ~bar_data_source:config.bar_data_source
+      ~benchmark_symbol:config.benchmark_symbol
+      ~universe:(_universe_of_override sector_map_override)
+      ~starts
   in
   (* One job per start. Each job is a self-contained backtest of marshallable
      inputs/outputs (a per_start record of floats + a Date), so it forks
-     cleanly. parallel=1 forks each job one-at-a-time (memory-safe broad-universe
-     path); parallel>1 keeps up to [parallel] children alive. Result order is
-     input order in both cases — see Fork_pool. *)
-  let jobs =
-    Array.of_list
-      (List.map starts ~f:(fun start_date () ->
-           _run_one ~config ~sector_map_override ~benchmark_series ~start_date))
+     cleanly. *)
+  let job_of =
+    _job_for_start ~config ~sector_map_override ~benchmark_series
+      ~factors_by_start
   in
-  let per_starts =
-    (if config.parallel <= 1 then Fork_pool.run_each_forked ~jobs
-     else Fork_pool.run_parallel ~parallel:config.parallel ~jobs)
-    |> Array.to_list
-  in
+  let jobs = Array.of_list (List.map starts ~f:job_of) in
+  let per_starts = _run_jobs ~parallel:config.parallel ~jobs |> Array.to_list in
   Rolling_start_types.build ~min_window_days:config.min_window_days
     ~end_date:config.end_date per_starts

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_runner.mli
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_runner.mli
@@ -118,6 +118,7 @@ val per_start_of_summary :
   ?benchmark_cagr_pct:float ->
   ?benchmark_max_dd_pct:float ->
   ?equity_curve:float list ->
+  ?factors:Rolling_start_factors.factors ->
   start_date:Date.t ->
   end_date:Date.t ->
   Backtest.Summary.t ->
@@ -155,7 +156,12 @@ val per_start_of_summary :
       over the run.
     - [time_underwater_pct] is {!Convexity_stats.time_underwater_pct} over
       [equity_curve] (default [[]] -> [0.0]); pass the run's per-step NAV series
-      (chronological). *)
+      (chronological).
+    - [factors] (default {!Rolling_start_factors.empty}) is recorded verbatim as
+      the row's screener-based factor columns (factor-decomposition lens stage
+      5b), computed by the runner from the snapshot warehouse as-of
+      [start_date]. The default leaves every factor unavailable, so a summary
+      projected without factors is backward-compatible. *)
 
 type config = {
   scenario : Scenario_lib.Scenario.t;
@@ -221,6 +227,17 @@ val run : config -> Rolling_start_types.report
     projects each result via {!per_start_of_summary} (with the benchmark CAGR
     for that start's window via {!bah_cagr_pct}), and assembles the
     {!Rolling_start_types.report} via {!Rolling_start_types.build}.
+
+    When a snapshot [bar_data_source] is configured, it also resolves each
+    start's screener-based factor columns (factor-decomposition lens stage 5b:
+    SPY/macro stage + macro composite from [benchmark_symbol], Stage-2 candidate
+    count + sector-RS dispersion across the scenario's universe, all as-of the
+    start date) once in the parent over a single shared panels handle, and
+    threads each into the matching row's
+    {!Rolling_start_types.per_start.factors}. The universe-scan factors are
+    unavailable (left [None] / nan) for a [Full_sector_map] universe (the
+    sectors.csv fallback is not resolved here) and for CSV mode (no
+    shared-panels handle).
 
     Sequential — each backtest is run in-process, one after another. The cost is
     N backtests, so callers should keep the cadence coarse and only sweep on PIT

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_types.ml
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_types.ml
@@ -12,6 +12,7 @@ type per_start = {
   sharpe : float;
   time_underwater_pct : float;
   realized_return_pct : float;
+  factors : Rolling_start_factors.factors;
 }
 [@@deriving sexp, equal]
 
@@ -115,6 +116,10 @@ let _row cells = "| " ^ String.concat ~sep:" | " cells ^ " |"
 
 let _f2 x = Printf.sprintf "%.2f" x
 
+(** An optional integer factor cell: the integer, or a blank for [None] (the
+    "not available" marker, mirroring how a [nan] float renders empty-ish). *)
+let _opt_int = function Some n -> Int.to_string n | None -> ""
+
 (** One dispersion-summary line in the per-metric table. *)
 let _summary_row ~label (s : Dispersion_stats.summary) =
   _row
@@ -188,10 +193,17 @@ let _start_row ~min_window_days ~end_date (s : per_start) =
       _f2 s.max_drawdown_pct;
       _f2 s.forward_index_max_dd_pct;
       _f2 s.realized_return_pct;
+      _opt_int s.factors.spy_stage_at_start;
+      _f2 s.factors.macro_composite_at_start;
+      _opt_int s.factors.stage2_candidate_count;
+      _f2 s.factors.sector_rs_dispersion_at_start;
       note;
     ]
 
-(* Column titles of the per-start detail table, in {!_start_row} order. *)
+(* Column titles of the per-start detail table, in {!_start_row} order. The
+   factor columns (SPY stage / macro composite / Stage-2 count / sector-RS
+   dispersion) are appended after the outcome columns as a strict superset —
+   the factor-decomposition lens stage 5b. *)
 let _starts_header_cells =
   [
     "start";
@@ -205,6 +217,10 @@ let _starts_header_cells =
     "MaxDrawdown %";
     "Forward index max-DD %";
     "Realized return %";
+    "SPY stage";
+    "Macro composite";
+    "Stage-2 count";
+    "Sector-RS dispersion";
     "note";
   ]
 

--- a/trading/trading/backtest/rolling_start/lib/rolling_start_types.mli
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_types.mli
@@ -83,6 +83,15 @@ type per_start = {
           monster cannot flatter a recent-start row — the simplest honest
           realized number. Equals the raw total return when nothing is held at
           end. [Float.nan] only if [initial_cash] is non-positive. *)
+  factors : Rolling_start_factors.factors;
+      (** The screener-based factor columns evaluated as-of [start_date] — the
+          factor-decomposition lens stage 5b candidate {b causes} (SPY/macro
+          stage, macro composite, Stage-2 candidate count, sector-RS dispersion)
+          that the analysis step correlates against [realized_edge_pct]. See
+          {!Rolling_start_factors.factors}. {!Rolling_start_factors.empty}
+          (all-unavailable) for a run with no snapshot warehouse to read from
+          (CSV mode / no benchmark). Appended as a strict superset: pre-existing
+          consumers that don't read it are unaffected. *)
 }
 [@@deriving sexp, equal]
 (** One backtest's terminal outcome, tagged with the start date it ran from. *)
@@ -172,4 +181,9 @@ val to_markdown : report -> string
     per metric: median / 10th-pct / IQR / min / max / n), and a per-start detail
     table. Mirrors the [walk_forward_render] table style. Floats are formatted
     to two decimals; an empty report renders the header with a "no starts" note.
-*)
+
+    The per-start detail table's columns are a strict superset: the outcome
+    columns, then the four factor-decomposition lens columns ([SPY stage] /
+    [Macro composite] / [Stage-2 count] / [Sector-RS dispersion], from each
+    row's {!per_start.factors}), then the [note] cell. An unavailable factor
+    ([None] / [nan]) renders blank / [nan]. *)

--- a/trading/trading/backtest/rolling_start/test/dune
+++ b/trading/trading/backtest/rolling_start/test/dune
@@ -3,6 +3,7 @@
   test_dispersion_stats
   test_convexity_stats
   test_rolling_start_types
+  test_rolling_start_factors
   test_rolling_start_runner)
  (libraries
   ounit2

--- a/trading/trading/backtest/rolling_start/test/test_rolling_start_factors.ml
+++ b/trading/trading/backtest/rolling_start/test/test_rolling_start_factors.ml
@@ -1,0 +1,121 @@
+open Core
+open OUnit2
+open Matchers
+module F = Rolling_start.Rolling_start_factors
+
+(* A [float matcher] asserting the value is [Float.nan] — the "factor
+   unavailable" marker. Mirrors the local matcher in [test_dispersion_stats.ml]
+   (the Matchers library has no built-in nan matcher). *)
+let is_nan : float matcher =
+  matching ~msg:"Expected nan"
+    (fun x -> if Float.is_nan x then Some () else None)
+    (equal_to ())
+
+(* ----- macro_stage_of_value ----- *)
+
+(* Each in-range stage code decodes to its integer stage; values are rounded
+   defensively so a slightly-off cell (e.g. 2.0000001) still decodes. *)
+let test_macro_stage_decodes_each_stage _ =
+  assert_that
+    (List.map [ 1.0; 2.0; 3.0; 4.0 ] ~f:F.macro_stage_of_value)
+    (elements_are
+       [
+         equal_to (Some 1);
+         equal_to (Some 2);
+         equal_to (Some 3);
+         equal_to (Some 4);
+       ])
+
+let test_macro_stage_nan_is_none _ =
+  assert_that (F.macro_stage_of_value Float.nan) is_none
+
+(* Out-of-range codes (0, 5, negative) are "not a stage" -> None, not silently
+   clamped. *)
+let test_macro_stage_out_of_range_is_none _ =
+  assert_that
+    (List.map [ 0.0; 5.0; -1.0 ] ~f:F.macro_stage_of_value)
+    (elements_are [ is_none; is_none; is_none ])
+
+(* ----- stage2_candidate_count ----- *)
+
+(* Three of these five universe cells are Stage 2; one is nan (pre-IPO) and one
+   is Stage 4 — neither counts. *)
+let test_stage2_count_known_universe _ =
+  assert_that
+    (F.stage2_candidate_count [ 2.0; 1.0; 2.0; Float.nan; 2.0; 4.0 ])
+    (equal_to 3)
+
+let test_stage2_count_empty_is_zero _ =
+  assert_that (F.stage2_candidate_count []) (equal_to 0)
+
+let test_stage2_count_all_nan_is_zero _ =
+  assert_that (F.stage2_candidate_count [ Float.nan; Float.nan ]) (equal_to 0)
+
+(* ----- sector_rs_dispersion ----- *)
+
+(* Per-sector means: Tech = mean(1.0, 3.0) = 2.0; Energy = mean(-1.0, -3.0) =
+   -2.0; Health = 0.0. The three sector means are {2.0, 0.0, -2.0}; their IQR
+   (p75 - p25, type-7: sorted [-2; 0; 2] -> p25 = -1, p75 = 1) is 2.0. *)
+let test_sector_rs_dispersion_three_sectors _ =
+  assert_that
+    (F.sector_rs_dispersion
+       [
+         ("Tech", 1.0);
+         ("Tech", 3.0);
+         ("Energy", -1.0);
+         ("Energy", -3.0);
+         ("Health", 0.0);
+       ])
+    (float_equal 2.0)
+
+(* nan RS cells are dropped before grouping, so an otherwise-Energy nan does not
+   move the Energy mean. Two sectors {Tech mean 2.0, Energy mean -2.0}: IQR
+   (type-7 over sorted [-2; 2] -> p25 = -1, p75 = 1) is 2.0. *)
+let test_sector_rs_dispersion_drops_nan _ =
+  assert_that
+    (F.sector_rs_dispersion
+       [ ("Tech", 1.0); ("Tech", 3.0); ("Energy", -2.0); ("Energy", Float.nan) ])
+    (float_equal 2.0)
+
+(* Fewer than two distinct sectors -> dispersion is undefined (nan), not 0.0. *)
+let test_sector_rs_dispersion_single_sector_is_nan _ =
+  assert_that (F.sector_rs_dispersion [ ("Tech", 1.0); ("Tech", 3.0) ]) is_nan
+
+let test_sector_rs_dispersion_empty_is_nan _ =
+  assert_that (F.sector_rs_dispersion []) is_nan
+
+(* ----- empty ----- *)
+
+let test_empty_is_all_unavailable _ =
+  assert_that F.empty
+    (all_of
+       [
+         field (fun f -> f.F.spy_stage_at_start) is_none;
+         field (fun f -> f.F.macro_composite_at_start) is_nan;
+         field (fun f -> f.F.stage2_candidate_count) is_none;
+         field (fun f -> f.F.sector_rs_dispersion_at_start) is_nan;
+       ])
+
+let suite =
+  "rolling_start_factors"
+  >::: [
+         "macro_stage_decodes_each_stage"
+         >:: test_macro_stage_decodes_each_stage;
+         "macro_stage_nan_is_none" >:: test_macro_stage_nan_is_none;
+         "macro_stage_out_of_range_is_none"
+         >:: test_macro_stage_out_of_range_is_none;
+         "stage2_count_known_universe" >:: test_stage2_count_known_universe;
+         "stage2_count_empty_is_zero" >:: test_stage2_count_empty_is_zero;
+         "stage2_count_all_nan_is_zero" >:: test_stage2_count_all_nan_is_zero;
+         "sector_rs_dispersion_three_sectors"
+         >:: test_sector_rs_dispersion_three_sectors;
+         "sector_rs_dispersion_drops_nan"
+         >:: test_sector_rs_dispersion_drops_nan;
+         "sector_rs_dispersion_single_sector_is_nan"
+         >:: test_sector_rs_dispersion_single_sector_is_nan;
+         "sector_rs_dispersion_empty_is_nan"
+         >:: test_sector_rs_dispersion_empty_is_nan;
+         "empty_is_all_unavailable" >:: test_empty_is_all_unavailable;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/rolling_start/test/test_rolling_start_types.ml
+++ b/trading/trading/backtest/rolling_start/test/test_rolling_start_types.ml
@@ -6,8 +6,8 @@ module DS = Rolling_start.Dispersion_stats
 
 let make_start ~y ~m ~d ~cagr ~underwater ~maxdd ?(benchmark = Float.nan)
     ?(realized_edge = Float.nan) ?(forward_index_max_dd = Float.nan)
-    ?(sharpe = 1.0) ?(time_underwater = 0.0) ?(realized = 0.0) () : RT.per_start
-    =
+    ?(sharpe = 1.0) ?(time_underwater = 0.0) ?(realized = 0.0)
+    ?(factors = Rolling_start.Rolling_start_factors.empty) () : RT.per_start =
   {
     start_date = Date.create_exn ~y ~m ~d;
     cagr_pct = cagr;
@@ -20,6 +20,7 @@ let make_start ~y ~m ~d ~cagr ~underwater ~maxdd ?(benchmark = Float.nan)
     sharpe;
     time_underwater_pct = time_underwater;
     realized_return_pct = realized;
+    factors;
   }
 
 let sample_starts =
@@ -122,8 +123,43 @@ let test_to_markdown_contains_sections _ =
          contains_substring "TimeUnderwater %";
          contains_substring "Realized return %";
          contains_substring "MaxUnderwaterVsInitial %";
+         (* Factor-decomposition lens 5b columns are a strict superset: the
+            pre-existing outcome columns above still render, and the four factor
+            headers are appended. *)
+         contains_substring "SPY stage";
+         contains_substring "Macro composite";
+         contains_substring "Stage-2 count";
+         contains_substring "Sector-RS dispersion";
          contains_substring "2011-01-01";
          contains_substring "2020-12-31";
+       ])
+
+(* A row whose factors are populated renders the decoded values: SPY stage 2 as
+   the bare integer "2", the Stage-2 candidate count "42", and the macro
+   composite / sector-RS dispersion as two-decimal floats. Pins that the
+   per-start detail table carries the factor cells, not just the headers. *)
+let test_to_markdown_renders_factor_values _ =
+  let factors =
+    {
+      Rolling_start.Rolling_start_factors.spy_stage_at_start = Some 2;
+      macro_composite_at_start = 0.75;
+      stage2_candidate_count = Some 42;
+      sector_rs_dispersion_at_start = 1.25;
+    }
+  in
+  let md =
+    RT.to_markdown
+      (RT.build ~end_date
+         [
+           make_start ~y:2015 ~m:Month.Jun ~d:1 ~cagr:12.0 ~underwater:0.0
+             ~maxdd:(-10.0) ~factors ();
+         ])
+  in
+  assert_that md
+    (all_of
+       [
+         contains_substring "| 2 | 0.75 | 42 | 1.25 |";
+         contains_substring "2015-06-01";
        ])
 
 let test_to_markdown_empty _ =
@@ -305,8 +341,24 @@ let test_min_window_markdown_flags_excluded _ =
    floats with [Float.equal], under which [nan <> nan], so a report carrying nan
    edges (unbenchmarked starts) would never compare equal to itself. The
    serializer is still exercised on the full field set. *)
+(* Fully-populated (no-nan) factors so the report's float fields are all
+   defined — [equal_report] uses [Float.equal], and [Float.equal nan nan] is
+   [false], which would spuriously break the roundtrip on the default
+   nan-bearing {!Rolling_start_factors.empty}. *)
+let populated_factors =
+  {
+    Rolling_start.Rolling_start_factors.spy_stage_at_start = Some 3;
+    macro_composite_at_start = 0.5;
+    stage2_candidate_count = Some 17;
+    sector_rs_dispersion_at_start = 2.0;
+  }
+
 let test_sexp_roundtrip _ =
-  let report = RT.build ~end_date benchmarked_starts in
+  let starts =
+    List.map benchmarked_starts ~f:(fun s ->
+        { s with RT.factors = populated_factors })
+  in
+  let report = RT.build ~end_date starts in
   let back = RT.report_of_sexp (RT.sexp_of_report report) in
   assert_that back (equal_to ~cmp:RT.equal_report report)
 
@@ -327,6 +379,8 @@ let suite =
          "pct_beating_benchmark" >:: test_pct_beating_benchmark;
          "edge_skips_nan_starts" >:: test_edge_skips_nan_starts;
          "to_markdown_contains_sections" >:: test_to_markdown_contains_sections;
+         "to_markdown_renders_factor_values"
+         >:: test_to_markdown_renders_factor_values;
          "to_markdown_empty" >:: test_to_markdown_empty;
          "min_window_default_counts_all" >:: test_min_window_default_counts_all;
          "min_window_excludes_short_from_summary"


### PR DESCRIPTION
## What it does

Adds the four **screener-based factor columns** to the rolling-start matrix — factor-decomposition lens **stage 5b**, per `dev/notes/factor-decomposition-lens-design-2026-06-14.md` §"Factor columns". They join each rolling-start row to candidate *causes* alongside #1586's `realized_edge_pct` / `forward_index_max_dd_pct` outcome columns, so the analysis can explain **why** the strategy beats (or loses to) the benchmark from a given start.

The four factors, all read from the **precomputed** snapshot-warehouse fields (cheap point reads — no classifier re-run), evaluated **as-of each start date**:
1. **SPY/macro stage** — the benchmark index's `Stage` cell decoded to 1/2/3/4.
2. **Macro_composite** — the benchmark's `Macro_composite` cell verbatim.
3. **Stage-2 candidate count** — universe symbols whose `Stage` cell decodes to 2 (H3 fresh-supply).
4. **sector-RS dispersion** — IQR of per-sector mean `RS_line` across the universe.

## Design

- **New pure module `Rolling_start_factors`** — `macro_stage_of_value`, `stage2_candidate_count`, `sector_rs_dispersion`, the `factors` record + `empty`. Pure arithmetic, unit-tested against hand-computed inputs (no panels handle).
- **New I/O module `Rolling_start_factor_reader`** — reads the warehouse cells as-of a date and feeds the pure projections; `resolve_per_start` computes every start's factors once over a **single shared `Daily_panels` handle** (each symbol file decodes once, LRU-cached). Split out from the runner so the runner stays under the file-length limit (the runner was the obvious home but would have pushed it >300 lines).
- `per_start` gains a `factors` field (default `Rolling_start_factors.empty` via a new `?factors` param on `per_start_of_summary`); four detail-table columns are **appended** — a strict superset, no churn for consumers that don't read them.
- Unavailable factors emit `None`/`nan` (rendered blank): the universe-scan factors are blank for a `Full_sector_map` universe (the sectors.csv fallback is not resolved here — a documented gap, flagged as a follow-up) and for CSV mode (no shared-panels handle).

## Scope note

This PR delivers the **columns + tests** only. The analytical correlation of the factors against `realized_edge_pct` (testing H1/H2/H3) is a separate read-only step gated on the top-3000 PIT warehouse — tracked in `dev/status/rolling-start-lens.md` §"Next steps".

Two new modules land together because the reader exists only to feed the pure projections and was split off purely for the file-length limit (the code-health-discipline answer to a tripped linter); they are one logical unit.

## Test plan

- `test_rolling_start_factors.ml` — pins each pure projection with known input → expected value (stage decode incl. nan/out-of-range → `None`; Stage-2 count skipping nan; sector-RS IQR incl. the <2-sector → nan case; `empty` all-unavailable).
- `test_rolling_start_types.ml` — pins the superset render: the four factor headers appear, and a row with populated factors renders the decoded cells (`| 2 | 0.75 | 42 | 1.25 |`).
- `dune runtest trading/backtest/rolling_start/` → exit 0 (34 tests). Full `dune build` clean; nesting / file-length / mli-coverage linters pass; ocamlformat clean.

> Note: the local full `dune runtest` timed out on the `linter_magic_numbers.sh` shell check, which is pathologically slow in this worktree's `_build/.sandbox` (concurrent sibling-worktree activity), not a code/lint failure — my numeric literals are all `let _x = N` constant bindings (the linter's `= <num>` exception) and comments. CI runs the authoritative full linter suite in a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)