### PR TITLE
perf(rolling_start): Gc.compact before forking per-start backtests

### DIFF
--- a/trading/trading/backtest/rolling_start/lib/rolling_start_runner.ml
+++ b/trading/trading/backtest/rolling_start/lib/rolling_start_runner.ml
@@ -284,6 +284,9 @@ let run config =
       ~universe:(_universe_of_override sector_map_override)
       ~starts
   in
+  (* Free factor-precompute panels to the OS before forking: a Fork_pool child
+     COW-inherits parent RSS → a bloated parent OOMs at the fork (PR #1614). *)
+  Gc.compact ();
   (* One job per start. Each job is a self-contained backtest of marshallable
      inputs/outputs (a per_start record of floats + a Date), so it forks
      cleanly. *)


### PR DESCRIPTION
## What it does
Adds a single `Gc.compact ()` in `Rolling_start_runner.run`, between the `resolve_per_start` factor pre-computation and the `Fork_pool` per-start backtest fan-out.

## Why
On the 2000-2026 top-3000 rolling-start matrix, the run OOM'd the 7.8 GB dev container at any `SNAPSHOT_CACHE_MB >= 2048`. Root cause (measured): `resolve_per_start` builds a `Daily_panels` handle over the whole 3015-symbol universe (~3 GB resident); when it returns, that memory is unreferenced but the OCaml runtime keeps it in the process RSS. Every `Fork_pool` child COW-inherits the parent's RSS, so a bloated parent roughly **doubles** peak memory and OOMs at the fork before any backtest completes.

`Gc.compact` returns the freed blocks to the OS so children fork from a lean parent. **Verified**: with the fix, a cache=3072 probe forked and ran the backtest past the exact point an unpatched cache=3072 run OOM'd (parent dropped to ~1.3 GB post-compact). (Note: the snapshot cache byte-estimate undercounts actual RSS ~1.6×, so very large caches still exceed 7.8 GB even post-compact — this fix is necessary but the full broad-universe speedup also needs more container RAM or a window-pruned cache; tracked separately.)

## Scope / safety
- **Memory-only**; does not change any backtest result. `dune runtest trading/backtest/rolling_start/` → 23 tests pass unchanged; full `dune build` + `@fmt` clean.
- Pure infra/perf — no domain logic, no core-module change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)