### PR TITLE
docs: redate priorities 2026-06-17 -> 2026-06-16-PM2 (it's still 06-16)

### DIFF
--- a/dev/notes/next-session-priorities-2026-06-16-PM2.md
+++ b/dev/notes/next-session-priorities-2026-06-16-PM2.md
@@ -1,4 +1,4 @@
-# Next-session priorities — 2026-06-17
+# Next-session priorities — 2026-06-16 (PM2 / late continuation)
 
 **Supersedes** `next-session-priorities-2026-06-16-PM.md`. Check main CI green first.
 


### PR DESCRIPTION
Docs-only. The priorities doc was misdated 06-17 but it's still 2026-06-16. Renamed to next-session-priorities-2026-06-16-PM2.md + fixed the title. Content (snapshot-format-v2 P0 plan + state) unchanged.