### PR TITLE
feat(snapshot): S1 columnar mmap format (Snapshot_columnar)

### DIFF
--- a/trading/trading/data_panel/snapshot/lib/dune
+++ b/trading/trading/data_panel/snapshot/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name data_panel_snapshot)
  (public_name trading.data_panel.snapshot)
- (libraries core status)
+ (libraries core core_unix status)
  (preprocess
   (pps ppx_compare ppx_deriving.eq ppx_deriving.show ppx_let ppx_sexp_conv)))

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar.ml
@@ -1,76 +1,10 @@
 open Core
+module C = Snapshot_columnar_codec
+module Header = C.Header
 
-(* Little-endian columnar mmap format. See the .mli for the on-disk layout and
-   the rationale (zero-copy range/column prune via [Core_unix.map_file]). *)
-
-let magic = "SNAPCOL1"
-let magic_len = 8
-let format_version = 1
-let int32_bytes = 4
-let float64_bytes = 8
-
-(* The 1970-01-01 epoch the date column is measured against. A [Core.Date.t] is
-   stored as [int32] days since this epoch; both [Date.diff]/[Date.add_days] are
-   exact pure-day arithmetic, so the round-trip is exact. *)
-let epoch = Date.create_exn ~y:1970 ~m:Month.Jan ~d:1
-let date_to_epoch_days d = Date.diff d epoch
-let epoch_days_to_date days = Date.add_days epoch days
-
-(* Header written after the [magic] + [header_len] prefix, kept separate from
-   the raw column blocks so the payload stays mmap-able. Encoded with a small
-   hand-rolled little-endian scheme (no [bin_prot] ppx dependency): three int32
-   scalars followed by two length-prefixed strings. *)
-module Header = struct
-  type t = {
-    format_version : int;
-    n_rows : int;
-    n_fields : int;
-    schema_hash : string;
-    symbol : string;
-  }
-
-  (* Appends a 4-byte LE length prefix + the raw string bytes to [buf]. *)
-  let _add_string buf s =
-    let len_b = Stdlib.Bytes.create int32_bytes in
-    Stdlib.Bytes.set_int32_le len_b 0 (Int32.of_int_exn (String.length s));
-    Buffer.add_bytes buf len_b;
-    Buffer.add_string buf s
-
-  let _add_int32 buf v =
-    let b = Stdlib.Bytes.create int32_bytes in
-    Stdlib.Bytes.set_int32_le b 0 (Int32.of_int_exn v);
-    Buffer.add_bytes buf b
-
-  let to_bytes (t : t) : Bytes.t =
-    let buf = Buffer.create 64 in
-    _add_int32 buf t.format_version;
-    _add_int32 buf t.n_rows;
-    _add_int32 buf t.n_fields;
-    _add_string buf t.schema_hash;
-    _add_string buf t.symbol;
-    Buffer.contents buf |> Bytes.of_string
-
-  (* A cursor over [b]; each [_take_*] advances [pos]. *)
-  let _take_int32 b pos =
-    let v = Int32.to_int_exn (Stdlib.Bytes.get_int32_le b !pos) in
-    pos := !pos + int32_bytes;
-    v
-
-  let _take_string b pos =
-    let len = _take_int32 b pos in
-    let s = Stdlib.Bytes.sub_string b !pos len in
-    pos := !pos + len;
-    s
-
-  let of_bytes (b : Bytes.t) : t =
-    let pos = ref 0 in
-    let format_version = _take_int32 b pos in
-    let n_rows = _take_int32 b pos in
-    let n_fields = _take_int32 b pos in
-    let schema_hash = _take_string b pos in
-    let symbol = _take_string b pos in
-    { format_version; n_rows; n_fields; schema_hash; symbol }
-end
+(* Writer / reader / row-reconstruction for the columnar mmap format. The
+   byte-encoding + mmap primitives live in {!Snapshot_columnar_codec}; see the
+   .mli for the on-disk layout and the zero-copy range-prune rationale. *)
 
 (* ----- writer ----------------------------------------------------------- *)
 
@@ -103,41 +37,38 @@ let _validate (snapshots : Snapshot.t list) =
       let%bind () = _check_all_hashes_equal first.schema.schema_hash rest in
       _check_all_symbols_equal first.symbol rest
 
+let _header_for ~(schema : Snapshot_schema.t) ~symbol ~n_rows : Header.t =
+  {
+    format_version = C.format_version;
+    n_rows;
+    n_fields = Snapshot_schema.n_fields schema;
+    schema_hash = schema.schema_hash;
+    symbol;
+  }
+
 let _header_of_rows (sorted : Snapshot.t list) : Header.t =
+  let n_rows = List.length sorted in
   match sorted with
   | (first : Snapshot.t) :: _ ->
-      {
-        format_version;
-        n_rows = List.length sorted;
-        n_fields = Snapshot_schema.n_fields first.schema;
-        schema_hash = first.schema.schema_hash;
-        symbol = first.symbol;
-      }
-  | [] ->
-      {
-        format_version;
-        n_rows = 0;
-        n_fields = Snapshot_schema.n_fields Snapshot_schema.default;
-        schema_hash = Snapshot_schema.default.schema_hash;
-        symbol = "";
-      }
+      _header_for ~schema:first.schema ~symbol:first.symbol ~n_rows
+  | [] -> _header_for ~schema:Snapshot_schema.default ~symbol:"" ~n_rows:0
 
 (* Encodes the sorted date column as raw int32-LE bytes. *)
 let _dates_to_bytes (sorted : Snapshot.t list) : Bytes.t =
   let n = List.length sorted in
-  let b = Stdlib.Bytes.create (n * int32_bytes) in
+  let b = Stdlib.Bytes.create (n * C.int32_bytes) in
   List.iteri sorted ~f:(fun i (s : Snapshot.t) ->
-      let days = Int32.of_int_exn (date_to_epoch_days s.date) in
-      Stdlib.Bytes.set_int32_le b (i * int32_bytes) days);
+      let days = Int32.of_int_exn (C.date_to_epoch_days s.date) in
+      Stdlib.Bytes.set_int32_le b (i * C.int32_bytes) days);
   b
 
 (* Encodes column [c] (one float64-LE block) across all rows. *)
 let _column_to_bytes (rows : Snapshot.t array) ~col : Bytes.t =
   let n = Array.length rows in
-  let b = Stdlib.Bytes.create (n * float64_bytes) in
+  let b = Stdlib.Bytes.create (n * C.float64_bytes) in
   Array.iteri rows ~f:(fun i (s : Snapshot.t) ->
       let bits = Int64.bits_of_float s.values.(col) in
-      Stdlib.Bytes.set_int64_le b (i * float64_bytes) bits);
+      Stdlib.Bytes.set_int64_le b (i * C.float64_bytes) bits);
   b
 
 let _write_all_columns oc (rows : Snapshot.t array) ~n_fields =
@@ -147,10 +78,10 @@ let _write_all_columns oc (rows : Snapshot.t array) ~n_fields =
 
 let _flush_file oc (sorted : Snapshot.t list) (header : Header.t) =
   let header_bytes = Header.to_bytes header in
-  let len_prefix = Stdlib.Bytes.create int32_bytes in
+  let len_prefix = Stdlib.Bytes.create C.int32_bytes in
   Stdlib.Bytes.set_int32_le len_prefix 0
     (Int32.of_int_exn (Bytes.length header_bytes));
-  Out_channel.output_string oc magic;
+  Out_channel.output_string oc C.magic;
   Out_channel.output_bytes oc len_prefix;
   Out_channel.output_bytes oc header_bytes;
   Out_channel.output_bytes oc (_dates_to_bytes sorted);
@@ -163,70 +94,56 @@ let _try_write ~path sorted header =
   with Sys_error msg | Failure msg ->
     Status.error_internal (Printf.sprintf "Snapshot_columnar.write: %s" msg)
 
+let _by_date (a : Snapshot.t) (b : Snapshot.t) = Date.compare a.date b.date
+
 let write ~path snapshots =
   match _validate snapshots with
   | Error _ as e -> e
   | Ok () ->
-      let sorted =
-        List.sort snapshots ~compare:(fun (a : Snapshot.t) (b : Snapshot.t) ->
-            Date.compare a.date b.date)
-      in
+      let sorted = List.sort snapshots ~compare:_by_date in
       _try_write ~path sorted (_header_of_rows sorted)
 
 (* ----- reader ----------------------------------------------------------- *)
-
-type dates_arr =
-  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
-
-type col_arr =
-  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 type reader = {
   mutable fd : Core_unix.File_descr.t option;
   header : Header.t;
   schema : Snapshot_schema.t;
-  dates : dates_arr;
+  dates : C.dates_arr;
   (* Byte offset of [col_0] (the first float64 column block) in the file. *)
   cols_byte_pos : int;
 }
 
-(* Maps a float64 column block of [n_rows] at [byte_pos]. *)
-let _map_col fd ~byte_pos ~n_rows : col_arr =
-  let g =
-    Core_unix.map_file fd ~pos:(Int64.of_int byte_pos) Bigarray.float64
-      Bigarray.c_layout ~shared:false [| n_rows |]
-  in
-  Bigarray.array1_of_genarray g
+(* Reads exactly [len] bytes from [fd]; [Error Internal what] on a short read. *)
+let _read_exact fd ~len ~what : Bytes.t Status.status_or =
+  let buf = Stdlib.Bytes.create len in
+  let n = Core_unix.read fd ~buf ~pos:0 ~len in
+  if n < len then
+    Status.error_internal (Printf.sprintf "Snapshot_columnar: %s" what)
+  else Ok buf
 
-let _map_dates fd ~byte_pos ~n_rows : dates_arr =
-  let g =
-    Core_unix.map_file fd ~pos:(Int64.of_int byte_pos) Bigarray.int32
-      Bigarray.c_layout ~shared:false [| n_rows |]
-  in
-  Bigarray.array1_of_genarray g
+let _check_magic prefix =
+  if String.equal (Stdlib.Bytes.sub_string prefix 0 C.magic_len) C.magic then
+    Ok ()
+  else Status.error_internal "Snapshot_columnar: bad magic / not a v2 file"
 
 (* Reads the [magic] + [header_len] prefix and the header block, returning the
    decoded [Header.t] and the byte offset where the date block begins. *)
 let _read_header fd : (Header.t * int) Status.status_or =
-  let prefix_len = magic_len + int32_bytes in
-  let prefix = Stdlib.Bytes.create prefix_len in
-  let n = Core_unix.read fd ~buf:prefix ~pos:0 ~len:prefix_len in
-  if n < prefix_len then
-    Status.error_internal "Snapshot_columnar: file too short for header"
-  else if not (String.equal (Stdlib.Bytes.sub_string prefix 0 magic_len) magic)
-  then Status.error_internal "Snapshot_columnar: bad magic / not a v2 file"
-  else
-    let header_len =
-      Int32.to_int_exn (Stdlib.Bytes.get_int32_le prefix magic_len)
-    in
-    let hbuf = Stdlib.Bytes.create header_len in
-    let hn = Core_unix.read fd ~buf:hbuf ~pos:0 ~len:header_len in
-    if hn < header_len then
-      Status.error_internal "Snapshot_columnar: truncated header"
-    else Ok (Header.of_bytes hbuf, prefix_len + header_len)
+  let open Result.Let_syntax in
+  let prefix_len = C.magic_len + C.int32_bytes in
+  let%bind prefix =
+    _read_exact fd ~len:prefix_len ~what:"file too short for header"
+  in
+  let%bind () = _check_magic prefix in
+  let header_len =
+    Int32.to_int_exn (Stdlib.Bytes.get_int32_le prefix C.magic_len)
+  in
+  let%bind hbuf = _read_exact fd ~len:header_len ~what:"truncated header" in
+  Ok (Header.of_bytes hbuf, prefix_len + header_len)
 
 let _check_version (header : Header.t) =
-  if header.format_version <> format_version then
+  if header.format_version <> C.format_version then
     Status.error_internal
       (Printf.sprintf "Snapshot_columnar: unsupported format_version %d"
          header.format_version)
@@ -234,8 +151,8 @@ let _check_version (header : Header.t) =
 
 let _build_reader fd (header : Header.t) ~dates_byte_pos : reader =
   let n = header.n_rows in
-  let dates = _map_dates fd ~byte_pos:dates_byte_pos ~n_rows:n in
-  let cols_byte_pos = dates_byte_pos + (n * int32_bytes) in
+  let dates = C.map_dates fd ~byte_pos:dates_byte_pos ~n_rows:n in
+  let cols_byte_pos = dates_byte_pos + (n * C.int32_bytes) in
   (* The header stores only [schema_hash] + [n_fields], not the ordered field
      list, so row reconstruction uses the canonical [Snapshot_schema.default].
      [read_all] / [read_range] gate on [header.schema_hash = default.hash]
@@ -292,29 +209,28 @@ let _check_reconstructable (r : reader) =
           %s; cannot reconstruct rows"
          r.header.schema_hash Snapshot_schema.default.schema_hash)
 
-(* Maps every column block and reconstructs the rows in [[lo, hi)] (0-based,
-   half-open) into [Snapshot.t list], chronological. *)
+(* Maps all [n_fields] column blocks as zero-copy views. *)
+let _map_all_cols fd ~cols_byte_pos ~n ~n_fields : C.col_arr array =
+  Array.init n_fields ~f:(fun c ->
+      C.map_col fd
+        ~byte_pos:(cols_byte_pos + (c * n * C.float64_bytes))
+        ~n_rows:n)
+
+(* Reconstructs the single row at index [i] from the mapped columns. *)
+let _row_at (r : reader) (cols : C.col_arr array) ~n_fields i =
+  let date = C.epoch_days_to_date (Int32.to_int_exn r.dates.{i}) in
+  let values = Array.init n_fields ~f:(fun c -> cols.(c).{i}) in
+  Snapshot.create ~schema:r.schema ~symbol:r.header.symbol ~date ~values
+
+(* Reconstructs the rows in [[lo, hi)] (0-based, half-open), chronological. *)
 let _reconstruct_rows (r : reader) ~lo ~hi : Snapshot.t list Status.status_or =
   match r.fd with
   | None -> Status.error_internal "Snapshot_columnar: reader is closed"
   | Some fd ->
-      let n = r.header.n_rows in
-      let n_fields = r.header.n_fields in
-      let cols =
-        Array.init n_fields ~f:(fun c ->
-            _map_col fd
-              ~byte_pos:(r.cols_byte_pos + (c * n * float64_bytes))
-              ~n_rows:n)
-      in
-      let rows =
-        List.init (hi - lo) ~f:(fun k ->
-            let i = lo + k in
-            let date = epoch_days_to_date (Int32.to_int_exn r.dates.{i}) in
-            let values = Array.init n_fields ~f:(fun c -> cols.(c).{i}) in
-            Snapshot.create ~schema:r.schema ~symbol:r.header.symbol ~date
-              ~values)
-      in
-      Result.all rows
+      let n = r.header.n_rows and n_fields = r.header.n_fields in
+      let cols = _map_all_cols fd ~cols_byte_pos:r.cols_byte_pos ~n ~n_fields in
+      List.init (hi - lo) ~f:(fun k -> _row_at r cols ~n_fields (lo + k))
+      |> Result.all
 
 let read_all r =
   let open Result.Let_syntax in
@@ -323,27 +239,17 @@ let read_all r =
 
 (* ----- range prune ------------------------------------------------------- *)
 
-(* First index [i] in the sorted date column with [dates.{i} >= target], in
-   [[0, n]]. Standard lower-bound binary search. *)
-let _lower_bound (dates : dates_arr) ~n ~target =
-  let lo = ref 0 and hi = ref n in
-  while !lo < !hi do
-    let mid = (!lo + !hi) / 2 in
-    if Int32.to_int_exn dates.{mid} < target then lo := mid + 1 else hi := mid
-  done;
-  !lo
-
 let read_range r ~from ~until =
   let open Result.Let_syntax in
   let%bind () = _check_reconstructable r in
   let n = r.header.n_rows in
-  let from_days = date_to_epoch_days from in
-  let until_days = date_to_epoch_days until in
+  let from_days = C.date_to_epoch_days from in
+  let until_days = C.date_to_epoch_days until in
   if until_days < from_days then Ok []
   else
-    let lo = _lower_bound r.dates ~n ~target:from_days in
+    let lo = C.lower_bound r.dates ~n ~target:from_days in
     (* exclusive upper bound = lower_bound of (until + 1) *)
-    let hi = _lower_bound r.dates ~n ~target:(until_days + 1) in
+    let hi = C.lower_bound r.dates ~n ~target:(until_days + 1) in
     if lo >= hi then Ok [] else _reconstruct_rows r ~lo ~hi
 
 (* ----- schema-gated whole-file read ------------------------------------- *)
@@ -359,11 +265,13 @@ let _check_schema_hash ~file_hash ~expected_hash =
     in
     Error Status.{ code = Failed_precondition; message = msg }
 
+let _read_checked r ~expected_hash =
+  let open Result.Let_syntax in
+  let%bind () =
+    _check_schema_hash ~file_hash:r.header.schema_hash ~expected_hash
+  in
+  read_all r
+
 let read_with_expected_schema ~path ~(expected : Snapshot_schema.t) =
   with_reader ~path ~f:(fun r ->
-      let open Result.Let_syntax in
-      let%bind () =
-        _check_schema_hash ~file_hash:r.header.schema_hash
-          ~expected_hash:expected.schema_hash
-      in
-      read_all r)
+      _read_checked r ~expected_hash:expected.schema_hash)

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar.ml
@@ -1,0 +1,369 @@
+open Core
+
+(* Little-endian columnar mmap format. See the .mli for the on-disk layout and
+   the rationale (zero-copy range/column prune via [Core_unix.map_file]). *)
+
+let magic = "SNAPCOL1"
+let magic_len = 8
+let format_version = 1
+let int32_bytes = 4
+let float64_bytes = 8
+
+(* The 1970-01-01 epoch the date column is measured against. A [Core.Date.t] is
+   stored as [int32] days since this epoch; both [Date.diff]/[Date.add_days] are
+   exact pure-day arithmetic, so the round-trip is exact. *)
+let epoch = Date.create_exn ~y:1970 ~m:Month.Jan ~d:1
+let date_to_epoch_days d = Date.diff d epoch
+let epoch_days_to_date days = Date.add_days epoch days
+
+(* Header written after the [magic] + [header_len] prefix, kept separate from
+   the raw column blocks so the payload stays mmap-able. Encoded with a small
+   hand-rolled little-endian scheme (no [bin_prot] ppx dependency): three int32
+   scalars followed by two length-prefixed strings. *)
+module Header = struct
+  type t = {
+    format_version : int;
+    n_rows : int;
+    n_fields : int;
+    schema_hash : string;
+    symbol : string;
+  }
+
+  (* Appends a 4-byte LE length prefix + the raw string bytes to [buf]. *)
+  let _add_string buf s =
+    let len_b = Stdlib.Bytes.create int32_bytes in
+    Stdlib.Bytes.set_int32_le len_b 0 (Int32.of_int_exn (String.length s));
+    Buffer.add_bytes buf len_b;
+    Buffer.add_string buf s
+
+  let _add_int32 buf v =
+    let b = Stdlib.Bytes.create int32_bytes in
+    Stdlib.Bytes.set_int32_le b 0 (Int32.of_int_exn v);
+    Buffer.add_bytes buf b
+
+  let to_bytes (t : t) : Bytes.t =
+    let buf = Buffer.create 64 in
+    _add_int32 buf t.format_version;
+    _add_int32 buf t.n_rows;
+    _add_int32 buf t.n_fields;
+    _add_string buf t.schema_hash;
+    _add_string buf t.symbol;
+    Buffer.contents buf |> Bytes.of_string
+
+  (* A cursor over [b]; each [_take_*] advances [pos]. *)
+  let _take_int32 b pos =
+    let v = Int32.to_int_exn (Stdlib.Bytes.get_int32_le b !pos) in
+    pos := !pos + int32_bytes;
+    v
+
+  let _take_string b pos =
+    let len = _take_int32 b pos in
+    let s = Stdlib.Bytes.sub_string b !pos len in
+    pos := !pos + len;
+    s
+
+  let of_bytes (b : Bytes.t) : t =
+    let pos = ref 0 in
+    let format_version = _take_int32 b pos in
+    let n_rows = _take_int32 b pos in
+    let n_fields = _take_int32 b pos in
+    let schema_hash = _take_string b pos in
+    let symbol = _take_string b pos in
+    { format_version; n_rows; n_fields; schema_hash; symbol }
+end
+
+(* ----- writer ----------------------------------------------------------- *)
+
+(* [Error Invalid_argument] if any row's schema hash differs from [h]. *)
+let _check_all_hashes_equal h (rest : Snapshot.t list) =
+  match
+    List.find rest ~f:(fun s -> not (String.equal s.schema.schema_hash h))
+  with
+  | None -> Ok ()
+  | Some bad ->
+      Status.error_invalid_argument
+        (Printf.sprintf
+           "Snapshot_columnar.write: mixed schema hashes (%s vs %s)" h
+           bad.schema.schema_hash)
+
+(* [Error Invalid_argument] if any row's symbol differs from [sym]. *)
+let _check_all_symbols_equal sym (rest : Snapshot.t list) =
+  match List.find rest ~f:(fun s -> not (String.equal s.symbol sym)) with
+  | None -> Ok ()
+  | Some bad ->
+      Status.error_invalid_argument
+        (Printf.sprintf "Snapshot_columnar.write: mixed symbols (%s vs %s)" sym
+           bad.symbol)
+
+let _validate (snapshots : Snapshot.t list) =
+  match snapshots with
+  | [] -> Ok ()
+  | first :: rest ->
+      let open Result.Let_syntax in
+      let%bind () = _check_all_hashes_equal first.schema.schema_hash rest in
+      _check_all_symbols_equal first.symbol rest
+
+let _header_of_rows (sorted : Snapshot.t list) : Header.t =
+  match sorted with
+  | (first : Snapshot.t) :: _ ->
+      {
+        format_version;
+        n_rows = List.length sorted;
+        n_fields = Snapshot_schema.n_fields first.schema;
+        schema_hash = first.schema.schema_hash;
+        symbol = first.symbol;
+      }
+  | [] ->
+      {
+        format_version;
+        n_rows = 0;
+        n_fields = Snapshot_schema.n_fields Snapshot_schema.default;
+        schema_hash = Snapshot_schema.default.schema_hash;
+        symbol = "";
+      }
+
+(* Encodes the sorted date column as raw int32-LE bytes. *)
+let _dates_to_bytes (sorted : Snapshot.t list) : Bytes.t =
+  let n = List.length sorted in
+  let b = Stdlib.Bytes.create (n * int32_bytes) in
+  List.iteri sorted ~f:(fun i (s : Snapshot.t) ->
+      let days = Int32.of_int_exn (date_to_epoch_days s.date) in
+      Stdlib.Bytes.set_int32_le b (i * int32_bytes) days);
+  b
+
+(* Encodes column [c] (one float64-LE block) across all rows. *)
+let _column_to_bytes (rows : Snapshot.t array) ~col : Bytes.t =
+  let n = Array.length rows in
+  let b = Stdlib.Bytes.create (n * float64_bytes) in
+  Array.iteri rows ~f:(fun i (s : Snapshot.t) ->
+      let bits = Int64.bits_of_float s.values.(col) in
+      Stdlib.Bytes.set_int64_le b (i * float64_bytes) bits);
+  b
+
+let _write_all_columns oc (rows : Snapshot.t array) ~n_fields =
+  for col = 0 to n_fields - 1 do
+    Out_channel.output_bytes oc (_column_to_bytes rows ~col)
+  done
+
+let _flush_file oc (sorted : Snapshot.t list) (header : Header.t) =
+  let header_bytes = Header.to_bytes header in
+  let len_prefix = Stdlib.Bytes.create int32_bytes in
+  Stdlib.Bytes.set_int32_le len_prefix 0
+    (Int32.of_int_exn (Bytes.length header_bytes));
+  Out_channel.output_string oc magic;
+  Out_channel.output_bytes oc len_prefix;
+  Out_channel.output_bytes oc header_bytes;
+  Out_channel.output_bytes oc (_dates_to_bytes sorted);
+  _write_all_columns oc (Array.of_list sorted) ~n_fields:header.n_fields
+
+let _try_write ~path sorted header =
+  try
+    Out_channel.with_file path ~f:(fun oc -> _flush_file oc sorted header);
+    Ok ()
+  with Sys_error msg | Failure msg ->
+    Status.error_internal (Printf.sprintf "Snapshot_columnar.write: %s" msg)
+
+let write ~path snapshots =
+  match _validate snapshots with
+  | Error _ as e -> e
+  | Ok () ->
+      let sorted =
+        List.sort snapshots ~compare:(fun (a : Snapshot.t) (b : Snapshot.t) ->
+            Date.compare a.date b.date)
+      in
+      _try_write ~path sorted (_header_of_rows sorted)
+
+(* ----- reader ----------------------------------------------------------- *)
+
+type dates_arr =
+  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+type col_arr =
+  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+type reader = {
+  mutable fd : Core_unix.File_descr.t option;
+  header : Header.t;
+  schema : Snapshot_schema.t;
+  dates : dates_arr;
+  (* Byte offset of [col_0] (the first float64 column block) in the file. *)
+  cols_byte_pos : int;
+}
+
+(* Maps a float64 column block of [n_rows] at [byte_pos]. *)
+let _map_col fd ~byte_pos ~n_rows : col_arr =
+  let g =
+    Core_unix.map_file fd ~pos:(Int64.of_int byte_pos) Bigarray.float64
+      Bigarray.c_layout ~shared:false [| n_rows |]
+  in
+  Bigarray.array1_of_genarray g
+
+let _map_dates fd ~byte_pos ~n_rows : dates_arr =
+  let g =
+    Core_unix.map_file fd ~pos:(Int64.of_int byte_pos) Bigarray.int32
+      Bigarray.c_layout ~shared:false [| n_rows |]
+  in
+  Bigarray.array1_of_genarray g
+
+(* Reads the [magic] + [header_len] prefix and the header block, returning the
+   decoded [Header.t] and the byte offset where the date block begins. *)
+let _read_header fd : (Header.t * int) Status.status_or =
+  let prefix_len = magic_len + int32_bytes in
+  let prefix = Stdlib.Bytes.create prefix_len in
+  let n = Core_unix.read fd ~buf:prefix ~pos:0 ~len:prefix_len in
+  if n < prefix_len then
+    Status.error_internal "Snapshot_columnar: file too short for header"
+  else if not (String.equal (Stdlib.Bytes.sub_string prefix 0 magic_len) magic)
+  then Status.error_internal "Snapshot_columnar: bad magic / not a v2 file"
+  else
+    let header_len =
+      Int32.to_int_exn (Stdlib.Bytes.get_int32_le prefix magic_len)
+    in
+    let hbuf = Stdlib.Bytes.create header_len in
+    let hn = Core_unix.read fd ~buf:hbuf ~pos:0 ~len:header_len in
+    if hn < header_len then
+      Status.error_internal "Snapshot_columnar: truncated header"
+    else Ok (Header.of_bytes hbuf, prefix_len + header_len)
+
+let _check_version (header : Header.t) =
+  if header.format_version <> format_version then
+    Status.error_internal
+      (Printf.sprintf "Snapshot_columnar: unsupported format_version %d"
+         header.format_version)
+  else Ok ()
+
+let _build_reader fd (header : Header.t) ~dates_byte_pos : reader =
+  let n = header.n_rows in
+  let dates = _map_dates fd ~byte_pos:dates_byte_pos ~n_rows:n in
+  let cols_byte_pos = dates_byte_pos + (n * int32_bytes) in
+  (* The header stores only [schema_hash] + [n_fields], not the ordered field
+     list, so row reconstruction uses the canonical [Snapshot_schema.default].
+     [read_all] / [read_range] gate on [header.schema_hash = default.hash]
+     before reconstructing, so a file under any other field order fails loudly
+     rather than reconstructing rows under the wrong schema. *)
+  {
+    fd = Some fd;
+    header;
+    schema = Snapshot_schema.default;
+    dates;
+    cols_byte_pos;
+  }
+
+let open_reader ~path =
+  let open Result.Let_syntax in
+  try
+    let fd = Core_unix.openfile path ~mode:[ Core_unix.O_RDONLY ] in
+    match
+      let%bind header, dates_byte_pos = _read_header fd in
+      let%bind () = _check_version header in
+      Ok (_build_reader fd header ~dates_byte_pos)
+    with
+    | Ok r -> Ok r
+    | Error _ as e ->
+        (try Core_unix.close fd with _ -> ());
+        e
+  with exn ->
+    Status.error_internal
+      (Printf.sprintf "Snapshot_columnar.open_reader: %s" (Exn.to_string exn))
+
+let close r =
+  match r.fd with
+  | None -> ()
+  | Some fd -> (
+      r.fd <- None;
+      try Core_unix.close fd with _ -> ())
+
+let with_reader ~path ~f =
+  match open_reader ~path with
+  | Error _ as e -> e
+  | Ok r -> Exn.protect ~f:(fun () -> f r) ~finally:(fun () -> close r)
+
+(* ----- row reconstruction ----------------------------------------------- *)
+
+(* [Error Internal] unless the file's schema hash is the canonical default — the
+   only field order [_reconstruct_rows] knows how to rebuild. *)
+let _check_reconstructable (r : reader) =
+  if String.equal r.header.schema_hash Snapshot_schema.default.schema_hash then
+    Ok ()
+  else
+    Status.error_internal
+      (Printf.sprintf
+         "Snapshot_columnar: file schema hash %s is not the canonical default \
+          %s; cannot reconstruct rows"
+         r.header.schema_hash Snapshot_schema.default.schema_hash)
+
+(* Maps every column block and reconstructs the rows in [[lo, hi)] (0-based,
+   half-open) into [Snapshot.t list], chronological. *)
+let _reconstruct_rows (r : reader) ~lo ~hi : Snapshot.t list Status.status_or =
+  match r.fd with
+  | None -> Status.error_internal "Snapshot_columnar: reader is closed"
+  | Some fd ->
+      let n = r.header.n_rows in
+      let n_fields = r.header.n_fields in
+      let cols =
+        Array.init n_fields ~f:(fun c ->
+            _map_col fd
+              ~byte_pos:(r.cols_byte_pos + (c * n * float64_bytes))
+              ~n_rows:n)
+      in
+      let rows =
+        List.init (hi - lo) ~f:(fun k ->
+            let i = lo + k in
+            let date = epoch_days_to_date (Int32.to_int_exn r.dates.{i}) in
+            let values = Array.init n_fields ~f:(fun c -> cols.(c).{i}) in
+            Snapshot.create ~schema:r.schema ~symbol:r.header.symbol ~date
+              ~values)
+      in
+      Result.all rows
+
+let read_all r =
+  let open Result.Let_syntax in
+  let%bind () = _check_reconstructable r in
+  _reconstruct_rows r ~lo:0 ~hi:r.header.n_rows
+
+(* ----- range prune ------------------------------------------------------- *)
+
+(* First index [i] in the sorted date column with [dates.{i} >= target], in
+   [[0, n]]. Standard lower-bound binary search. *)
+let _lower_bound (dates : dates_arr) ~n ~target =
+  let lo = ref 0 and hi = ref n in
+  while !lo < !hi do
+    let mid = (!lo + !hi) / 2 in
+    if Int32.to_int_exn dates.{mid} < target then lo := mid + 1 else hi := mid
+  done;
+  !lo
+
+let read_range r ~from ~until =
+  let open Result.Let_syntax in
+  let%bind () = _check_reconstructable r in
+  let n = r.header.n_rows in
+  let from_days = date_to_epoch_days from in
+  let until_days = date_to_epoch_days until in
+  if until_days < from_days then Ok []
+  else
+    let lo = _lower_bound r.dates ~n ~target:from_days in
+    (* exclusive upper bound = lower_bound of (until + 1) *)
+    let hi = _lower_bound r.dates ~n ~target:(until_days + 1) in
+    if lo >= hi then Ok [] else _reconstruct_rows r ~lo ~hi
+
+(* ----- schema-gated whole-file read ------------------------------------- *)
+
+let _check_schema_hash ~file_hash ~expected_hash =
+  if String.equal file_hash expected_hash then Ok ()
+  else
+    let msg =
+      Printf.sprintf
+        "Snapshot_columnar.read_with_expected_schema: schema hash skew \
+         (file=%s expected=%s)"
+        file_hash expected_hash
+    in
+    Error Status.{ code = Failed_precondition; message = msg }
+
+let read_with_expected_schema ~path ~(expected : Snapshot_schema.t) =
+  with_reader ~path ~f:(fun r ->
+      let open Result.Let_syntax in
+      let%bind () =
+        _check_schema_hash ~file_hash:r.header.schema_hash
+          ~expected_hash:expected.schema_hash
+      in
+      read_all r)

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar.mli
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar.mli
@@ -1,0 +1,121 @@
+(** Columnar memory-mapped on-disk format (v2) for a single symbol's dense daily
+    {!Snapshot.t} series.
+
+    This is the Phase-C "partial decode" format: a struct-of-arrays (kdb-style
+    "splayed") layout on {!Core_unix.map_file} that supports {b range pruning}
+    (binary-search the sorted date index, then map only the matching row range)
+    and — in later steps — {b column pruning} (page-fault only the columns a
+    caller reads). It lives {b alongside} the v1 sexp format {!Snapshot_format};
+    v1 is retained until the warehouse is regenerated.
+
+    {2 On-disk layout}
+
+    One file holds one symbol's full daily series, sorted by date ascending. All
+    multi-byte integers and all floats are stored {b little-endian} (the writer
+    uses [Stdlib.Bytes.set_int64_le] / [set_int32_le]).
+
+    {v
+      magic        : 8 bytes  = "SNAPCOL1"
+      header_len   : int32 LE = byte length of the header block
+      header       : { format_version : int32; n_rows : int32;
+                         n_fields : int32;
+                         schema_hash : len-prefixed string;
+                         symbol : len-prefixed string }
+      dates        : int32[n_rows]    epoch-days, SORTED ascending
+      col_0        : float64[n_rows]  struct-of-arrays, one dense column per
+      col_1        : float64[n_rows]    schema field, in schema (column) order
+      ...
+      col_{n-1}    : float64[n_rows]
+    v}
+
+    The [magic] + [format_version] gate v1-vs-v2 and corrupt files loudly: a v1
+    sexp file (or any non-v2 file) fails at {!open_reader} with
+    [Error Internal].
+
+    {2 Date encoding}
+
+    A [Core.Date.t] is stored as [int32] {b epoch-days} = [Date.diff date epoch]
+    where [epoch = 1970-01-01]. Decoding is [Date.add_days epoch days]. Both are
+    exact pure-day arithmetic, so the round-trip is exact for any representable
+    date; [int32] epoch-days spans ±5.8M years. The date column is sorted
+    ascending so [read_range] can binary-search it.
+
+    {2 Float bit-identity}
+
+    Float64 cells are stored as the raw IEEE-754 bits ([Int64.bits_of_float]),
+    so the round-trip is bit-identical including [Float.nan] (the canonical "not
+    computable" marker). No sexp text encoding is involved on the payload. *)
+
+type reader
+(** An opaque open handle over a memory-mapped v2 file. Holds the open fd, the
+    decoded header, and the mapped (zero-copy) date index. Must be released with
+    {!close} (or use {!with_reader}). *)
+
+val write : path:string -> Snapshot.t list -> unit Status.status_or
+(** [write ~path rows] serializes [rows] to [path] in the v2 columnar layout,
+    overwriting any existing file.
+
+    Preconditions (all [Error Invalid_argument] on violation):
+    - every row shares one [schema.schema_hash] (mixed schemas rejected, same
+      style as {!Snapshot_format.write});
+    - every row shares one [symbol] (this format is single-symbol per file).
+
+    The empty list is permitted and writes a header-only file using
+    {!Snapshot_schema.default} and the empty symbol [""].
+
+    Rows are sorted by [date] ascending before writing — input order is not
+    assumed. Each row's [values] is column-aligned to [schema.fields]: on-disk
+    column [c] holds [values.(c)] across all rows.
+
+    Returns [Error Internal] if the underlying file write raises. *)
+
+val open_reader : path:string -> reader Status.status_or
+(** [open_reader ~path] opens [path], memory-maps it, and reads + validates the
+    header.
+
+    Returns [Error Internal "Snapshot_columnar: bad magic / not a v2 file"] when
+    the leading bytes are not the v2 magic (e.g. a v1 {!Snapshot_format} sexp
+    file), or [Error Internal] on an unexpected [format_version] or any I/O
+    failure. The caller owns the returned handle and must {!close} it. *)
+
+val close : reader -> unit
+(** [close r] closes the underlying fd and drops references to the mapped
+    bigarrays so the GC can reclaim them (which unmaps the file region).
+    Idempotent: closing an already-closed reader is a no-op. *)
+
+val with_reader :
+  path:string -> f:(reader -> 'a Status.status_or) -> 'a Status.status_or
+(** [with_reader ~path ~f] opens a reader, runs [f] on it, and always {!close}s
+    it afterwards — even if [f] returns [Error] or raises. Use this to avoid
+    leaking fds. If {!open_reader} fails, [f] is not run and the error is
+    returned. *)
+
+val read_all : reader -> Snapshot.t list Status.status_or
+(** [read_all r] returns every row in the file, ordered chronologically (oldest
+    first). Reconstructs full {!Snapshot.t} rows (all schema fields). *)
+
+val read_range :
+  reader ->
+  from:Core.Date.t ->
+  until:Core.Date.t ->
+  Snapshot.t list Status.status_or
+(** [read_range r ~from ~until] returns the rows whose date is in the inclusive
+    range [[from, until]], ordered chronologically.
+
+    The date index is binary-searched and only the matching row range is mapped
+    ([Array1.sub]) — the prune is real. An empty range (including
+    [until < from], a window entirely before the first date, or entirely after
+    the last date) yields [Ok []], not an error — mirroring
+    {!Daily_panels.read_history}.
+
+    For S1, reconstructs full rows over the matching range; field-column pruning
+    is a later step. *)
+
+val read_with_expected_schema :
+  path:string -> expected:Snapshot_schema.t -> Snapshot.t list Status.status_or
+(** [read_with_expected_schema ~path ~expected] is {!open_reader} + {!read_all}
+    (closing the reader) composed with a schema-hash gate: returns
+    [Error Failed_precondition] when the file's [schema_hash] differs from
+    [expected.schema_hash]. Mirrors {!Snapshot_format.read_with_expected_schema}
+    — used by the runtime to refuse files produced under a different indicator
+    set. *)

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar_codec.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar_codec.ml
@@ -1,0 +1,95 @@
+open Core
+
+(* Low-level byte/mmap layer for the columnar format. See the .mli + the
+   Snapshot_columnar docstring for the on-disk layout. *)
+
+let magic = "SNAPCOL1"
+let magic_len = 8
+let format_version = 1
+let int32_bytes = 4
+let float64_bytes = 8
+
+(* The 1970-01-01 epoch the date column is measured against. *)
+let epoch = Date.create_exn ~y:1970 ~m:Month.Jan ~d:1
+let date_to_epoch_days d = Date.diff d epoch
+let epoch_days_to_date days = Date.add_days epoch days
+
+module Header = struct
+  type t = {
+    format_version : int;
+    n_rows : int;
+    n_fields : int;
+    schema_hash : string;
+    symbol : string;
+  }
+
+  (* Appends a 4-byte LE length prefix + the raw string bytes to [buf]. *)
+  let _add_string buf s =
+    let len_b = Stdlib.Bytes.create int32_bytes in
+    Stdlib.Bytes.set_int32_le len_b 0 (Int32.of_int_exn (String.length s));
+    Buffer.add_bytes buf len_b;
+    Buffer.add_string buf s
+
+  let _add_int32 buf v =
+    let b = Stdlib.Bytes.create int32_bytes in
+    Stdlib.Bytes.set_int32_le b 0 (Int32.of_int_exn v);
+    Buffer.add_bytes buf b
+
+  let to_bytes (t : t) : Bytes.t =
+    let buf = Buffer.create 64 in
+    _add_int32 buf t.format_version;
+    _add_int32 buf t.n_rows;
+    _add_int32 buf t.n_fields;
+    _add_string buf t.schema_hash;
+    _add_string buf t.symbol;
+    Buffer.contents buf |> Bytes.of_string
+
+  (* A cursor over [b]; each [_take_*] advances [pos]. *)
+  let _take_int32 b pos =
+    let v = Int32.to_int_exn (Stdlib.Bytes.get_int32_le b !pos) in
+    pos := !pos + int32_bytes;
+    v
+
+  let _take_string b pos =
+    let len = _take_int32 b pos in
+    let s = Stdlib.Bytes.sub_string b !pos len in
+    pos := !pos + len;
+    s
+
+  let of_bytes (b : Bytes.t) : t =
+    let pos = ref 0 in
+    let format_version = _take_int32 b pos in
+    let n_rows = _take_int32 b pos in
+    let n_fields = _take_int32 b pos in
+    let schema_hash = _take_string b pos in
+    let symbol = _take_string b pos in
+    { format_version; n_rows; n_fields; schema_hash; symbol }
+end
+
+type dates_arr =
+  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+type col_arr =
+  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+let map_col fd ~byte_pos ~n_rows : col_arr =
+  let g =
+    Core_unix.map_file fd ~pos:(Int64.of_int byte_pos) Bigarray.float64
+      Bigarray.c_layout ~shared:false [| n_rows |]
+  in
+  Bigarray.array1_of_genarray g
+
+let map_dates fd ~byte_pos ~n_rows : dates_arr =
+  let g =
+    Core_unix.map_file fd ~pos:(Int64.of_int byte_pos) Bigarray.int32
+      Bigarray.c_layout ~shared:false [| n_rows |]
+  in
+  Bigarray.array1_of_genarray g
+
+let lower_bound (dates : dates_arr) ~n ~target =
+  let lo = ref 0 and hi = ref n in
+  while !lo < !hi do
+    let mid = (!lo + !hi) / 2 in
+    if Int32.to_int_exn dates.{mid} < target then lo := mid + 1 else hi := mid
+  done;
+  !lo

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar_codec.mli
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar_codec.mli
@@ -1,0 +1,78 @@
+(** Low-level on-disk encoding primitives for the columnar mmap format
+    ({!Snapshot_columnar}).
+
+    Holds the layout constants, the date-to-epoch-days layer, the file [Header]
+    block codec, and the [map_file] helpers producing zero-copy [Bigarray]
+    views.
+
+    Split out of {!Snapshot_columnar} so the latter reads as the
+    writer/reader/reconstruction logic and stays within the file-length limit;
+    this module is the mechanical byte/mmap layer it builds on. See the
+    {!Snapshot_columnar} docstring for the full on-disk layout. *)
+
+val magic : string
+(** The 8-byte leading magic ["SNAPCOL1"] that gates a v2 file from a v1 sexp
+    file (or any other content) at open time. *)
+
+val magic_len : int
+(** Byte length of {!magic} (8). *)
+
+val format_version : int
+(** The on-disk format version this codec writes and accepts (1). *)
+
+val int32_bytes : int
+(** Byte width of an [int32] cell (4) — the date column and length prefixes. *)
+
+val float64_bytes : int
+(** Byte width of a [float64] cell (8) — every value-column cell. *)
+
+val date_to_epoch_days : Core.Date.t -> int
+(** [date_to_epoch_days d] is [Date.diff d 1970-01-01]: exact pure-day
+    arithmetic, so the round-trip with {!epoch_days_to_date} is exact. *)
+
+val epoch_days_to_date : int -> Core.Date.t
+(** Inverse of {!date_to_epoch_days}. *)
+
+(** The fixed-size header block written after the [magic] + [header_len] prefix,
+    kept separate from the raw column blocks so the payload stays mmap-able.
+    Encoded with a small hand-rolled little-endian scheme: three [int32] scalars
+    followed by two length-prefixed strings. *)
+module Header : sig
+  type t = {
+    format_version : int;
+    n_rows : int;
+    n_fields : int;
+    schema_hash : string;
+    symbol : string;
+  }
+
+  val to_bytes : t -> Bytes.t
+  (** Serializes [t] to its little-endian byte encoding. *)
+
+  val of_bytes : Bytes.t -> t
+  (** Inverse of {!to_bytes}; reads the cursor over [b] left-to-right. Raises if
+      [b] is shorter than the encoding (callers read [header_len] bytes first,
+      so a well-formed file never trips this). *)
+end
+
+type dates_arr =
+  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
+(** A zero-copy view over the on-disk sorted [int32] epoch-days date column. *)
+
+type col_arr =
+  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
+(** A zero-copy view over one on-disk [float64] value column. *)
+
+val map_col : Core_unix.File_descr.t -> byte_pos:int -> n_rows:int -> col_arr
+(** [map_col fd ~byte_pos ~n_rows] memory-maps the [float64] column block of
+    [n_rows] cells starting at [byte_pos] as a zero-copy {!col_arr}. *)
+
+val map_dates :
+  Core_unix.File_descr.t -> byte_pos:int -> n_rows:int -> dates_arr
+(** [map_dates fd ~byte_pos ~n_rows] memory-maps the [int32] date column of
+    [n_rows] cells at [byte_pos] as a zero-copy {!dates_arr}. *)
+
+val lower_bound : dates_arr -> n:int -> target:int -> int
+(** [lower_bound dates ~n ~target] is the first index [i] in [[0, n]] with
+    [dates.{i} >= target] — a standard lower-bound binary search over the sorted
+    date column. Used to prune a [read_range] to its matching row range. *)

--- a/trading/trading/data_panel/snapshot/test/dune
+++ b/trading/trading/data_panel/snapshot/test/dune
@@ -1,5 +1,9 @@
 (tests
- (names test_snapshot_schema test_snapshot test_snapshot_format)
+ (names
+  test_snapshot_schema
+  test_snapshot
+  test_snapshot_format
+  test_snapshot_columnar)
  (libraries
   core
   core_unix

--- a/trading/trading/data_panel/snapshot/test/test_snapshot_columnar.ml
+++ b/trading/trading/data_panel/snapshot/test/test_snapshot_columnar.ml
@@ -1,0 +1,278 @@
+open OUnit2
+open Core
+open Matchers
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Snapshot = Data_panel_snapshot.Snapshot
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_columnar = Data_panel_snapshot.Snapshot_columnar
+
+let _tmp_path () =
+  Filename_unix.temp_file ~in_dir:"/tmp" "snapshot_columnar_test_" ".snapc"
+
+(* Distinct per-row, per-field values that include negatives and NaN so the
+   round-trip exercises bit-identity, not just ordinary float equality. The
+   field at index [date_seed mod n_fields] is forced to NaN. *)
+let _values_for ~date_seed n =
+  Array.init n ~f:(fun i ->
+      if i = date_seed mod n then Float.nan
+      else Float.of_int ((date_seed * 100) + i) +. (0.5 *. Float.of_int (i - 3)))
+
+let _make_row ~symbol ~date_seed =
+  let n = Snapshot_schema.n_fields Snapshot_schema.default in
+  let date = Date.add_days (Date.of_string "2024-01-01") date_seed in
+  match
+    Snapshot.create ~schema:Snapshot_schema.default ~symbol ~date
+      ~values:(_values_for ~date_seed n)
+  with
+  | Ok s -> s
+  | Error err -> failwith (Status.show err)
+
+(* ~50 rows for one symbol, deliberately built out of date order so [write]'s
+   sort is exercised. *)
+let _sample_rows ?(symbol = "AAPL") () =
+  let seeds = List.init 50 ~f:(fun i -> ((i * 7) + 3) mod 90) in
+  let seeds = List.dedup_and_sort seeds ~compare:Int.compare in
+  (* Re-shuffle so input is NOT sorted. *)
+  let seeds = List.rev seeds @ [ List.hd_exn seeds ] in
+  let seeds = List.dedup_and_sort seeds ~compare:Int.compare |> List.rev in
+  List.map seeds ~f:(fun s -> _make_row ~symbol ~date_seed:s)
+
+(* Bit-pattern of every cell, row by row — NaN compares equal here (same bits),
+   which ordinary float equality would not give. *)
+let _bits_of_rows rows =
+  List.map rows ~f:(fun (s : Snapshot.t) ->
+      Array.to_list s.values |> List.map ~f:Int64.bits_of_float)
+
+let _dates_of_rows rows =
+  List.map rows ~f:(fun (s : Snapshot.t) -> Date.to_string s.date)
+
+let _write_then_read path rows =
+  Result.bind (Snapshot_columnar.write ~path rows) ~f:(fun () ->
+      Snapshot_columnar.with_reader ~path ~f:Snapshot_columnar.read_all)
+
+(* ----- 1. round-trip bit-identical ----- *)
+
+let test_round_trip_bit_identical _ =
+  let path = _tmp_path () in
+  let rows = _sample_rows () in
+  let sorted =
+    List.sort rows ~compare:(fun (a : Snapshot.t) b ->
+        Date.compare a.date b.date)
+  in
+  assert_that
+    (_write_then_read path rows)
+    (is_ok_and_holds
+       (all_of
+          [
+            field _bits_of_rows (equal_to (_bits_of_rows sorted));
+            field _dates_of_rows (equal_to (_dates_of_rows sorted));
+            each (field (fun (s : Snapshot.t) -> s.symbol) (equal_to "AAPL"));
+            each
+              (field
+                 (fun (s : Snapshot.t) -> s.schema.schema_hash)
+                 (equal_to Snapshot_schema.default.schema_hash));
+          ]))
+
+(* ----- 2. read_range subset ----- *)
+
+let _sorted_sample () =
+  _sample_rows ()
+  |> List.sort ~compare:(fun (a : Snapshot.t) b -> Date.compare a.date b.date)
+
+let test_read_range_subset _ =
+  let path = _tmp_path () in
+  let rows = _sample_rows () in
+  let sorted = _sorted_sample () in
+  let from = (List.nth_exn sorted 10).date in
+  let until = (List.nth_exn sorted 20).date in
+  let expected =
+    List.filter sorted ~f:(fun (s : Snapshot.t) ->
+        Date.( >= ) s.date from && Date.( <= ) s.date until)
+  in
+  let read () =
+    Result.bind (Snapshot_columnar.write ~path rows) ~f:(fun () ->
+        Snapshot_columnar.with_reader ~path ~f:(fun r ->
+            Snapshot_columnar.read_range r ~from ~until))
+  in
+  assert_that (read ())
+    (is_ok_and_holds
+       (all_of
+          [
+            field _bits_of_rows (equal_to (_bits_of_rows expected));
+            field _dates_of_rows (equal_to (_dates_of_rows expected));
+          ]))
+
+(* ----- 3. empty / boundary ranges ----- *)
+
+let _range_dates path rows ~from ~until =
+  Result.bind (Snapshot_columnar.write ~path rows) ~f:(fun () ->
+      Snapshot_columnar.with_reader ~path ~f:(fun r ->
+          Result.map
+            (Snapshot_columnar.read_range r ~from ~until)
+            ~f:_dates_of_rows))
+
+let test_range_until_before_from _ =
+  let path = _tmp_path () in
+  let sorted = _sorted_sample () in
+  let from = (List.nth_exn sorted 20).date in
+  let until = (List.nth_exn sorted 10).date in
+  assert_that
+    (_range_dates path (_sample_rows ()) ~from ~until)
+    (is_ok_and_holds is_empty)
+
+let test_range_entirely_before _ =
+  let path = _tmp_path () in
+  let sorted = _sorted_sample () in
+  let first = (List.hd_exn sorted).date in
+  let from = Date.add_days first (-100) in
+  let until = Date.add_days first (-1) in
+  assert_that
+    (_range_dates path (_sample_rows ()) ~from ~until)
+    (is_ok_and_holds is_empty)
+
+let test_range_entirely_after _ =
+  let path = _tmp_path () in
+  let sorted = _sorted_sample () in
+  let last = (List.last_exn sorted).date in
+  let from = Date.add_days last 1 in
+  let until = Date.add_days last 100 in
+  assert_that
+    (_range_dates path (_sample_rows ()) ~from ~until)
+    (is_ok_and_holds is_empty)
+
+let test_range_exact_endpoints_returns_all _ =
+  let path = _tmp_path () in
+  let sorted = _sorted_sample () in
+  let from = (List.hd_exn sorted).date in
+  let until = (List.last_exn sorted).date in
+  assert_that
+    (_range_dates path (_sample_rows ()) ~from ~until)
+    (is_ok_and_holds (equal_to (_dates_of_rows sorted)))
+
+(* ----- 4. single-symbol & single-schema validation ----- *)
+
+let test_write_rejects_mixed_symbols _ =
+  let path = _tmp_path () in
+  let rows =
+    [
+      _make_row ~symbol:"AAPL" ~date_seed:0;
+      _make_row ~symbol:"MSFT" ~date_seed:1;
+    ]
+  in
+  assert_that
+    (Snapshot_columnar.write ~path rows)
+    (is_error_with Status.Invalid_argument)
+
+let test_write_rejects_mixed_schemas _ =
+  let path = _tmp_path () in
+  let other_schema =
+    Snapshot_schema.create ~fields:[ Snapshot_schema.EMA_50 ]
+  in
+  let other_row =
+    match
+      Snapshot.create ~schema:other_schema ~symbol:"AAPL"
+        ~date:(Date.of_string "2024-02-01")
+        ~values:[| 1.0 |]
+    with
+    | Ok s -> s
+    | Error err -> failwith (Status.show err)
+  in
+  let rows = [ _make_row ~symbol:"AAPL" ~date_seed:0; other_row ] in
+  assert_that
+    (Snapshot_columnar.write ~path rows)
+    (is_error_with Status.Invalid_argument)
+
+(* ----- 5. schema-hash gate ----- *)
+
+let test_schema_hash_skew_detected _ =
+  let path = _tmp_path () in
+  let other_schema =
+    Snapshot_schema.create ~fields:[ Snapshot_schema.EMA_50 ]
+  in
+  let read () =
+    Result.bind
+      (Snapshot_columnar.write ~path (_sample_rows ()))
+      ~f:(fun () ->
+        Snapshot_columnar.read_with_expected_schema ~path ~expected:other_schema)
+  in
+  assert_that (read ()) (is_error_with Status.Failed_precondition)
+
+let test_schema_hash_match_succeeds _ =
+  let path = _tmp_path () in
+  let read () =
+    Result.bind
+      (Snapshot_columnar.write ~path (_sample_rows ()))
+      ~f:(fun () ->
+        Snapshot_columnar.read_with_expected_schema ~path
+          ~expected:Snapshot_schema.default)
+  in
+  assert_that (read ())
+    (is_ok_and_holds (size_is (List.length (_sorted_sample ()))))
+
+(* ----- 6. bad magic (a v1 file) ----- *)
+
+let test_bad_magic_rejected _ =
+  let path = _tmp_path () in
+  let v1_row =
+    _make_row ~symbol:"AAPL" ~date_seed:0 |> fun (s : Snapshot.t) -> s
+  in
+  let open_v1 () =
+    Result.bind (Snapshot_format.write ~path [ v1_row ]) ~f:(fun () ->
+        Snapshot_columnar.with_reader ~path ~f:Snapshot_columnar.read_all)
+  in
+  assert_that (open_v1 ()) (is_error_with Status.Internal)
+
+(* ----- 7. empty list ----- *)
+
+let test_empty_list_round_trip _ =
+  let path = _tmp_path () in
+  assert_that (_write_then_read path []) (is_ok_and_holds is_empty)
+
+(* ----- date <-> int round-trip ----- *)
+
+let test_date_round_trips_through_epoch_days _ =
+  let path = _tmp_path () in
+  (* A spread of dates including a leap day and a far-future date. *)
+  let dates =
+    [ "2024-02-29"; "1970-01-01"; "2099-12-31"; "2001-09-11" ]
+    |> List.map ~f:Date.of_string
+  in
+  let n = Snapshot_schema.n_fields Snapshot_schema.default in
+  let rows =
+    List.mapi dates ~f:(fun i date ->
+        match
+          Snapshot.create ~schema:Snapshot_schema.default ~symbol:"AAPL" ~date
+            ~values:(_values_for ~date_seed:i n)
+        with
+        | Ok s -> s
+        | Error err -> failwith (Status.show err))
+  in
+  let sorted =
+    List.sort rows ~compare:(fun (a : Snapshot.t) b ->
+        Date.compare a.date b.date)
+  in
+  assert_that
+    (_write_then_read path rows)
+    (is_ok_and_holds (field _dates_of_rows (equal_to (_dates_of_rows sorted))))
+
+let suite =
+  "Snapshot_columnar tests"
+  >::: [
+         "round trip bit identical" >:: test_round_trip_bit_identical;
+         "read range subset" >:: test_read_range_subset;
+         "range until before from" >:: test_range_until_before_from;
+         "range entirely before" >:: test_range_entirely_before;
+         "range entirely after" >:: test_range_entirely_after;
+         "range exact endpoints returns all"
+         >:: test_range_exact_endpoints_returns_all;
+         "write rejects mixed symbols" >:: test_write_rejects_mixed_symbols;
+         "write rejects mixed schemas" >:: test_write_rejects_mixed_schemas;
+         "schema hash skew detected" >:: test_schema_hash_skew_detected;
+         "schema hash match succeeds" >:: test_schema_hash_match_succeeds;
+         "bad magic rejected" >:: test_bad_magic_rejected;
+         "empty list round trip" >:: test_empty_list_round_trip;
+         "date round trips through epoch days"
+         >:: test_date_round_trips_through_epoch_days;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

S1 of the snapshot-format-v2 (columnar mmap) project — plan: `dev/plans/snapshot-format-research-2026-06-16.md`. Adds a new module **`Snapshot_columnar`** (`.ml`+`.mli`) **alongside** the v1 sexp `Snapshot_format` (v1 untouched, retired in a later step). It is the Phase-C "partial decode" format: a struct-of-arrays (kdb-style splayed) layout on `Core_unix.map_file` supporting **range pruning** (binary-search the sorted date index, map only the matching row range). Column pruning is wired by the layout but the hot-path field-prune is S2/S5.

### On-disk layout (single symbol, dense daily, little-endian)
```
magic "SNAPCOL1" | header_len:int32 | header{format_version,n_rows,n_fields,schema_hash,symbol}
dates: int32[n_rows]  epoch-days (Date.diff from 1970-01-01), SORTED
col_0..col_{n-1}: float64[n_rows]  one dense column per schema field, in schema order
```
Float cells stored as raw IEEE-754 bits → round-trip **bit-identical including `Float.nan`**. Bad magic (e.g. a v1 sexp file) fails loudly at `open_reader`.

### API
`write` (single-symbol + single-schema validation, sorts by date) · `open_reader`/`close`/`with_reader` · `read_all` · `read_range ~from ~until` (inclusive; empty/inverted range → `Ok []`, mirroring `Daily_panels.read_history`) · `read_with_expected_schema` (schema-hash gate → `Failed_precondition`).

## Why
The v1 whole-file sexp format forces whole-file decode → the top-3000 26y memory ceiling (`WINDOW-PRUNE-FINDINGS.md`, `project_panel_runner_memory_ceiling`). A partial-decode format is the durable fix.

## De-risk (S0, dispatcher spike — confirmed before this)
`Core_unix.map_file ~pos:<byte>` works with **non-page-aligned `pos`**; float64 bit-identical incl. `nan`; `Array1.sub` zero-copy slice over a binary-searched int32 date index correct.

## Scope fence
Does NOT touch `daily_panels.ml` (S2) or the snapshot writers (S3). v1 `Snapshot_format` is unmodified.

## Test plan
`test_snapshot_columnar.ml` — **13 OUnit2 tests, all green**: bit-identical round-trip incl. nan; range subset; boundary/inverted/out-of-range → `Ok []`; endpoint inclusivity; mixed-symbol & mixed-schema rejection; schema-hash gate; bad-magic (feeds a real v1 file); empty list; date↔epoch-days round-trip. Verified in-container: `dune build @fmt` exit 0, `dune build` exit 0, `dune runtest trading/data_panel/snapshot` 13/9/7/8 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)