### PR TITLE
feat(snapshot): S2 Daily_panels format-detecting mmap cache

### DIFF
--- a/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.ml
@@ -1,34 +1,23 @@
 open Core
 module Snapshot = Data_panel_snapshot.Snapshot
-module Snapshot_format = Data_panel_snapshot.Snapshot_format
 module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
 module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Backing = Daily_panels_backing
 
 (* 1 MiB. Used to convert [max_cache_mb] to a byte budget. *)
 let _bytes_per_mb = 1_048_576
 
-(* Width of one Float64 cell on disk and on heap. *)
-let _bytes_per_float = 8
+(* Hard cap on resident [Mmap] backings, each of which holds an open fd. Sits
+   comfortably under a typical 1024 fd ulimit so the cache never exhausts file
+   descriptors even when the byte budget alone would admit far more mmap
+   entries (their heap footprint is tiny). The eviction loop closes the LRU
+   reader once this is exceeded. *)
+let _max_open_mmap_handles = 256
 
-(* Per-row byte estimate. The on-heap size of a [Snapshot.t] is dominated by
-   the [values] float array ([n_fields * _bytes_per_float] bytes) plus
-   per-record header / pointers; this constant captures the per-record
-   overhead so the cache budget tracks GC-resident memory more honestly than
-   counting only float bytes. Empirically the OCaml record header + symbol
-   string dominate. *)
-let _per_row_overhead_bytes = 64
-
-(* One-time cost of holding a symbol's entry in the cache (linked-list node +
-   hashtable bucket). Tiny next to the row payload but pinned out separately
-   so the math stays explicit. *)
-let _per_symbol_overhead_bytes = 128
-
-(* Cached, decoded snapshot file for one symbol. [rows] is held by date order
-   (the writer enumerates dates chronologically) as an array so [read_today] /
-   [read_history] can binary-search by date in O(log N) instead of walking the
-   list. [bytes] is the cache-budget contribution recomputed at insert time and
-   never revised. *)
-type cache_entry = { symbol : string; rows : Snapshot.t array; bytes : int }
+(* Cached file for one symbol. [backing] is the format-detected store (mmap
+   reader for v2, decoded rows for v1); [bytes] is the cache-budget
+   contribution recomputed at insert time and never revised. *)
+type cache_entry = { symbol : string; backing : Backing.t; bytes : int }
 
 type stats = { hits : int; misses : int; evictions : int }
 [@@deriving sexp, equal]
@@ -43,6 +32,9 @@ type t = {
      tail = LRU. Eviction pops from tail. *)
   lru : cache_entry Doubly_linked.t;
   mutable bytes : int;
+  (* Count of resident [Mmap] backings (= open fds). Capped at
+     [_max_open_mmap_handles]; eviction closes readers to keep this bounded. *)
+  mutable mmap_open : int;
   (* Cumulative cache-access counters since [create]. Surfaced via [cache_stats]
      for thrash diagnosis; never reset, not even by [close]. *)
   mutable hits : int;
@@ -56,20 +48,18 @@ let _resolve_path ~snapshot_dir (entry : Snapshot_manifest.file_metadata) =
   if Filename.is_absolute entry.path then entry.path
   else Filename.concat snapshot_dir entry.path
 
-(* --- Byte estimation -------------------------------------------------- *)
-
-let _estimate_bytes ~(schema : Snapshot_schema.t) (rows : Snapshot.t array) =
-  let n_rows = Array.length rows in
-  let row_value_bytes = Snapshot_schema.n_fields schema * _bytes_per_float in
-  _per_symbol_overhead_bytes
-  + (n_rows * (row_value_bytes + _per_row_overhead_bytes))
-
 (* --- LRU helpers ------------------------------------------------------ *)
 
 (* Promote an existing [elt] to MRU position. The elt remains valid, so the
    hashtable's stored elt pointer stays good. *)
 let _promote_to_mru t (elt : cache_entry Doubly_linked.Elt.t) =
   Doubly_linked.move_to_front t.lru elt
+
+(* Release the OS resources an entry holds. Only [Mmap] backings own an fd;
+   closing one unmaps its columns and decrements the handle count. *)
+let _release_entry t (entry : cache_entry) =
+  if Backing.is_mmap entry.backing then t.mmap_open <- t.mmap_open - 1;
+  Backing.close entry.backing
 
 (* Evict the LRU symbol (linked-list tail). Returns [true] if anything was
    evicted; [false] when the cache is empty. *)
@@ -81,17 +71,23 @@ let _evict_one t =
       Doubly_linked.remove t.lru elt;
       Hashtbl.remove t.cache entry.symbol;
       t.bytes <- t.bytes - entry.bytes;
+      _release_entry t entry;
       t.evictions <- t.evictions + 1;
       true
 
-(* Drop entries until the budget is restored. Always leaves at least one
-   entry resident if it was just inserted — i.e. the just-inserted entry is
-   at the head and the loop walks from the tail. A single oversized entry
-   (one symbol's bytes > budget) stays resident; the cap is best-effort, not
-   a hard upper bound on a single symbol's memory. *)
-let _enforce_budget t =
+(* True while the cache is over either limit: the byte budget OR the open-fd
+   handle cap. *)
+let _over_limits t =
+  t.bytes > t.max_cache_bytes || t.mmap_open > _max_open_mmap_handles
+
+(* Drop entries until both limits are satisfied. Always leaves at least one
+   entry resident if it was just inserted — the just-inserted entry sits at the
+   head and the loop walks from the tail. A single oversized entry stays
+   resident; the byte cap is best-effort, not a hard upper bound on one
+   symbol's memory. *)
+let _enforce_limits t =
   let rec loop () =
-    if t.bytes <= t.max_cache_bytes then ()
+    if not (_over_limits t) then ()
     else if Doubly_linked.length t.lru <= 1 then ()
     else if _evict_one t then loop ()
     else ()
@@ -100,32 +96,19 @@ let _enforce_budget t =
 
 (* --- File loading ----------------------------------------------------- *)
 
-let _load_symbol_file t (entry : Snapshot_manifest.file_metadata) =
-  let path = _resolve_path ~snapshot_dir:t.snapshot_dir entry in
-  Snapshot_format.read_with_expected_schema ~path ~expected:t.expected_schema
-
-let _insert_into_cache t ~symbol ~rows =
-  let bytes = _estimate_bytes ~schema:t.expected_schema rows in
-  let entry = { symbol; rows; bytes } in
+let _insert_into_cache t ~symbol ~backing =
+  let bytes = Backing.estimate_bytes ~schema:t.expected_schema backing in
+  if Backing.is_mmap backing then t.mmap_open <- t.mmap_open + 1;
+  let entry = { symbol; backing; bytes } in
   let elt = Doubly_linked.insert_first t.lru entry in
   Hashtbl.set t.cache ~key:symbol ~data:elt;
   t.bytes <- t.bytes + bytes;
-  _enforce_budget t;
+  _enforce_limits t;
   entry
 
-(* Cache miss: look up the manifest entry, load + insert. The on-disk row
-   list is converted to an array on insert (and sorted chronologically by
-   date) so subsequent reads can binary-search by date. The writer is
-   expected to emit rows in chronological order; the explicit sort is
-   defensive. *)
-let _sort_rows_by_date (rows : Snapshot.t array) =
-  Array.sort rows ~compare:(fun a b -> Date.compare a.date b.date)
-
-(* Convert a decoded row list into a sorted array and insert into cache. *)
-let _insert_rows t ~symbol rows_list =
-  let rows = Array.of_list rows_list in
-  _sort_rows_by_date rows;
-  _insert_into_cache t ~symbol ~rows
+let _load_symbol_file t (entry : Snapshot_manifest.file_metadata) =
+  let path = _resolve_path ~snapshot_dir:t.snapshot_dir entry in
+  Backing.load ~path ~expected:t.expected_schema
 
 let _load_and_insert t ~symbol =
   t.misses <- t.misses + 1;
@@ -134,7 +117,8 @@ let _load_and_insert t ~symbol =
       Status.error_not_found
         (Printf.sprintf "Daily_panels: symbol %s not in manifest" symbol)
   | Some metadata ->
-      Result.map (_load_symbol_file t metadata) ~f:(_insert_rows t ~symbol)
+      Result.map (_load_symbol_file t metadata) ~f:(fun backing ->
+          _insert_into_cache t ~symbol ~backing)
 
 (* Cache hit: promote to MRU and return the resident entry. *)
 let _hit_path t (elt : cache_entry Doubly_linked.Elt.t) =
@@ -159,6 +143,7 @@ let _empty_cache ~snapshot_dir ~manifest ~max_cache_bytes =
     cache = Hashtbl.create (module String);
     lru = Doubly_linked.create ();
     bytes = 0;
+    mmap_open = 0;
     hits = 0;
     misses = 0;
     evictions = 0;
@@ -175,43 +160,15 @@ let create ~snapshot_dir ~manifest ~max_cache_mb =
 
 let schema t = t.expected_schema
 
-(* --- Binary search over chronologically-ordered rows ----------------- *)
-
-(* Compare a [Snapshot.t] row to a target [Date.t] by date — the comparator
-   shape Core's [Array.binary_search] expects. *)
-let _compare_row_date (r : Snapshot.t) (d : Date.t) = Date.compare r.date d
-
 let read_today t ~symbol ~date =
   let open Result.Let_syntax in
   let%bind entry = _ensure_loaded t ~symbol in
-  match
-    Array.binary_search entry.rows ~compare:_compare_row_date `First_equal_to
-      date
-  with
-  | Some i -> Ok entry.rows.(i)
-  | None ->
-      Status.error_not_found
-        (Printf.sprintf "Daily_panels.read_today: %s has no row for %s" symbol
-           (Date.to_string date))
+  Backing.read_today entry.backing ~symbol ~date
 
 let read_history t ~symbol ~from ~until =
   let open Result.Let_syntax in
   let%bind entry = _ensure_loaded t ~symbol in
-  let n = Array.length entry.rows in
-  if Date.( > ) from until || n = 0 then Ok []
-  else
-    let lo =
-      Array.binary_search entry.rows ~compare:_compare_row_date
-        `First_greater_than_or_equal_to from
-      |> Option.value ~default:n
-    in
-    let hi =
-      Array.binary_search entry.rows ~compare:_compare_row_date
-        `First_strictly_greater_than until
-      |> Option.value ~default:n
-    in
-    if hi <= lo then Ok []
-    else Ok (Array.to_list (Array.sub entry.rows ~pos:lo ~len:(hi - lo)))
+  Backing.read_history entry.backing ~from ~until
 
 let active_through_for t ~symbol =
   Option.bind (Snapshot_manifest.find t.manifest ~symbol)
@@ -223,6 +180,10 @@ let cache_stats t =
   { hits = t.hits; misses = t.misses; evictions = t.evictions }
 
 let close t =
+  (* Release every resident entry first (closes [Mmap] fds), then clear the
+     bookkeeping. Walking the list before clearing it ensures no fd leaks. *)
+  Doubly_linked.iter t.lru ~f:(fun entry -> _release_entry t entry);
   Doubly_linked.clear t.lru;
   Hashtbl.clear t.cache;
-  t.bytes <- 0
+  t.bytes <- 0;
+  t.mmap_open <- 0

--- a/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.mli
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels.mli
@@ -18,26 +18,48 @@
     symbol; a per-date file would force [N] file reads to serve a 30-day history
     for one symbol.
 
-    {2 "mmap" in Phase C}
+    {2 Dual backing: mmap (v2) and decoded (v1 fallback)}
 
-    Phase A's file format is sexp-encoded ([Snapshot_format] header docstring),
-    so the cache cannot literally [Bigarray.map_file] cells today. Phase C uses
-    "mmap-style" semantics in spirit — the entire file is decoded into a
-    [Snapshot.t list] on first access for a symbol, held in the cache until
-    evicted. Plan §C5 calls out the eventual upgrade to a raw-bytes payload with
-    [Bigarray.Array2.map_file] (Phase F); the API surface here is shaped so that
-    swap is local to {!Daily_panels} — [read_today] / [read_history] callers
-    don't see the difference. Until then, eviction is via dropping the
-    OCaml-heap rows and letting the GC reclaim them.
+    A cache entry is one of two backings, chosen by {b format-detecting} each
+    file's first bytes against the v2 columnar magic
+    ([Snapshot_columnar_codec.magic]):
 
-    {2 Memory budget}
+    - {b Mmap (v2)} — a columnar {!Data_panel_snapshot.Snapshot_columnar}
+      reader. The file's columns are memory-mapped once at open; each read
+      {b slices} the mapped columns over the requested date range. The OCaml
+      heap holds only the reader handle (fd + header + the int32 date index +
+      column descriptors); the float-column cells live in the OS page cache and
+      fault in lazily, so a resident entry is cheap. This is the path the
+      snapshot-format-v2 migration (S3/S4) moves the warehouses to.
+    - {b Decoded (v1 fallback)} — for files still in the v1 sexp format
+      ([Snapshot_format]), the entire file is decoded into a sorted
+      [Snapshot.t array] on first access and held until evicted. This is the
+      pre-v2 behaviour, preserved bit-for-bit so existing goldens are unaffected
+      until the warehouse is regenerated in v2.
 
-    Plan §C5: at N=10K symbols × 30-day window, ~22 MB of snapshot rows live in
-    the cache window. {!create}'s [max_cache_mb] sets a hard ceiling; once
-    inserting a new symbol's rows would push total tracked bytes above the cap,
-    the LRU symbol is evicted. The byte estimate is conservative (each row is
-    [Snapshot_schema.n_fields schema * 8] bytes plus per-row OCaml overhead), so
-    the actual memory pressure stays at or below the configured cap.
+    Both backings are transparent to {!read_today} / {!read_history} callers —
+    they see the same row-level results. A single cache may hold a mix of v1 and
+    v2 files (e.g. during a partial migration).
+
+    {2 Memory budget + open-handle cap}
+
+    Two limits bound resident state, enforced by the same LRU eviction loop:
+
+    - {b Byte budget.} {!create}'s [max_cache_mb] sets the heap-byte ceiling. A
+      [Decoded] entry's bytes ≈ [n_rows * (n_fields * 8 + overhead)]; an [Mmap]
+      entry's bytes is small (the int32 date array + a fixed per-handle constant
+      — the column pages are page-cache resident, not counted). Once inserting a
+      new symbol pushes tracked bytes above the cap, the LRU symbol is evicted.
+    - {b Open-handle cap.} Each [Mmap] entry holds an open fd. An internal cap
+      ([_max_open_mmap_handles], well under a typical 1024 fd ulimit) bounds the
+      number of resident [Mmap] readers; the eviction loop closes the LRU
+      reader's fd once the cap is exceeded, even if the byte budget alone would
+      admit more. This is the "LRU for handle count" the v2 plan calls for and
+      is {b not} a {!create} parameter.
+
+    Evicting an [Mmap] entry {!Data_panel_snapshot.Snapshot_columnar.close}s its
+    reader (releasing the fd + unmapping). {!close} closes every resident
+    reader.
 
     {2 Concurrency}
 
@@ -52,9 +74,10 @@ type t
 
     - the directory's manifest (read at {!create} time),
     - the schema the manifest was written under,
-    - a byte-budget cap, and
-    - an internal per-symbol cache that maps symbol → loaded snapshot rows,
-      ordered by recency for LRU eviction. *)
+    - a byte-budget cap + an open-handle cap, and
+    - an internal per-symbol cache that maps symbol → its loaded backing (an
+      mmap reader for v2 files, decoded rows for v1), ordered by recency for LRU
+      eviction. *)
 
 val create :
   snapshot_dir:string ->
@@ -151,9 +174,11 @@ val cache_stats : t -> stats
     caller can read them after the run to diagnose cache thrash. *)
 
 val close : t -> unit
-(** [close t] drops every cached symbol. After {!close}, [t] is logically empty;
+(** [close t] drops every cached symbol, closing every resident mmap reader's fd
+    (so no file descriptors leak). After {!close}, [t] is logically empty;
     subsequent {!read_today} / {!read_history} calls will reload from disk on
     demand. The handle is otherwise still usable.
 
     Provided so callers (notably the simulator in Phase D) can release snapshot
-    memory at well-defined points (e.g. between scenarios). *)
+    memory + file descriptors at well-defined points (e.g. between scenarios).
+*)

--- a/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels_backing.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels_backing.ml
@@ -1,0 +1,159 @@
+open Core
+module Snapshot = Data_panel_snapshot.Snapshot
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_columnar = Data_panel_snapshot.Snapshot_columnar
+module Snapshot_columnar_codec = Data_panel_snapshot.Snapshot_columnar_codec
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+
+(* Width of one Float64 cell — a [Decoded] row's per-field byte cost. *)
+let _bytes_per_float = 8
+
+(* Width of one int32 date cell — the only mapped block an [Mmap] backing's
+   byte estimate counts (the float columns are OS-page-cache resident). *)
+let _bytes_per_date = 4
+
+(* Per-row OCaml-heap overhead for a [Decoded] row (record header + symbol
+   string + array header) beyond the raw float bytes. *)
+let _per_row_overhead_bytes = 64
+
+(* Fixed per-backing constant folded into every estimate. *)
+let _per_backing_overhead_bytes = 128
+
+(* Fixed [Mmap] handle cost: the open fd, reader record, header, and column
+   bigarray descriptors. The mapped cells are NOT counted (page-cache
+   resident). *)
+let _per_mmap_handle_bytes = 256
+
+type t = Mmap of Snapshot_columnar.reader | Decoded of Snapshot.t array
+
+let is_mmap = function Mmap _ -> true | Decoded _ -> false
+
+(* --- format detection ------------------------------------------------- *)
+
+let _read_magic_prefix ic =
+  let magic_len = String.length Snapshot_columnar_codec.magic in
+  let buf = Bytes.create magic_len in
+  match In_channel.really_input ic ~buf ~pos:0 ~len:magic_len with
+  | Some () -> Some (Bytes.to_string buf)
+  | None -> None
+
+let is_columnar_file path =
+  try
+    let prefix = In_channel.with_file path ~f:_read_magic_prefix in
+    Option.value_map prefix ~default:false
+      ~f:(String.equal Snapshot_columnar_codec.magic)
+  with _ -> false
+
+(* --- loading ---------------------------------------------------------- *)
+
+let _schema_skew_error ~file_hash ~expected_hash ~path =
+  let message =
+    Printf.sprintf "Daily_panels: schema hash skew (file=%s expected=%s) for %s"
+      file_hash expected_hash path
+  in
+  Error Status.{ code = Failed_precondition; message }
+
+(* Open a v2 file, gating on the schema hash; close the reader on skew. *)
+let _load_mmap ~path ~(expected : Snapshot_schema.t) : t Status.status_or =
+  let open Result.Let_syntax in
+  let%bind reader = Snapshot_columnar.open_reader ~path in
+  let file_hash = Snapshot_columnar.schema_hash reader in
+  if String.equal file_hash expected.schema_hash then Ok (Mmap reader)
+  else (
+    Snapshot_columnar.close reader;
+    _schema_skew_error ~file_hash ~expected_hash:expected.schema_hash ~path)
+
+let _sort_by_date (rows : Snapshot.t array) =
+  Array.sort rows ~compare:(fun (a : Snapshot.t) b ->
+      Date.compare a.date b.date)
+
+(* Decode a v1 sexp file into a sorted [Decoded] array. *)
+let _load_decoded ~path ~expected : t Status.status_or =
+  Result.map (Snapshot_format.read_with_expected_schema ~path ~expected)
+    ~f:(fun rows_list ->
+      let rows = Array.of_list rows_list in
+      _sort_by_date rows;
+      Decoded rows)
+
+let load ~path ~expected =
+  if is_columnar_file path then _load_mmap ~path ~expected
+  else _load_decoded ~path ~expected
+
+(* --- byte estimation -------------------------------------------------- *)
+
+let _decoded_bytes ~(schema : Snapshot_schema.t) (rows : Snapshot.t array) =
+  let n_rows = Array.length rows in
+  let row_value_bytes = Snapshot_schema.n_fields schema * _bytes_per_float in
+  _per_backing_overhead_bytes
+  + (n_rows * (row_value_bytes + _per_row_overhead_bytes))
+
+let _mmap_bytes ~n_rows =
+  _per_backing_overhead_bytes + _per_mmap_handle_bytes
+  + (n_rows * _bytes_per_date)
+
+let estimate_bytes ~schema = function
+  | Decoded rows -> _decoded_bytes ~schema rows
+  | Mmap reader -> _mmap_bytes ~n_rows:(Snapshot_columnar.n_rows reader)
+
+(* --- reads ------------------------------------------------------------ *)
+
+let _not_found ~symbol ~date =
+  Status.error_not_found
+    (Printf.sprintf "Daily_panels.read_today: %s has no row for %s" symbol
+       (Date.to_string date))
+
+(* Comparator shape Core's [Array.binary_search] expects. *)
+let _compare_row_date (r : Snapshot.t) (d : Date.t) = Date.compare r.date d
+
+let _decoded_read_today rows ~symbol ~date =
+  match
+    Array.binary_search rows ~compare:_compare_row_date `First_equal_to date
+  with
+  | Some i -> Ok rows.(i)
+  | None -> _not_found ~symbol ~date
+
+let _mmap_read_today reader ~symbol ~date =
+  let open Result.Let_syntax in
+  let%bind rows = Snapshot_columnar.read_range reader ~from:date ~until:date in
+  match rows with row :: _ -> Ok row | [] -> _not_found ~symbol ~date
+
+let read_today b ~symbol ~date =
+  match b with
+  | Decoded rows -> _decoded_read_today rows ~symbol ~date
+  | Mmap reader -> _mmap_read_today reader ~symbol ~date
+
+(* Half-open [lo, hi) index range of [rows] within [[from, until]], clamped. *)
+let _decoded_range rows ~from ~until =
+  let n = Array.length rows in
+  let lo =
+    Array.binary_search rows ~compare:_compare_row_date
+      `First_greater_than_or_equal_to from
+    |> Option.value ~default:n
+  in
+  let hi =
+    Array.binary_search rows ~compare:_compare_row_date
+      `First_strictly_greater_than until
+    |> Option.value ~default:n
+  in
+  (lo, hi)
+
+(* The rows in [[from, until]] as a chronological list ([Ok []] when the range
+   selects nothing). Pulled out so [_decoded_read_history]'s guard has no
+   nested else. *)
+let _decoded_slice rows ~from ~until =
+  let lo, hi = _decoded_range rows ~from ~until in
+  if hi <= lo then Ok []
+  else Ok (Array.to_list (Array.sub rows ~pos:lo ~len:(hi - lo)))
+
+let _decoded_read_history rows ~from ~until =
+  if Date.( > ) from until || Array.is_empty rows then Ok []
+  else _decoded_slice rows ~from ~until
+
+let read_history b ~from ~until =
+  match b with
+  | Decoded rows -> _decoded_read_history rows ~from ~until
+  | Mmap reader -> Snapshot_columnar.read_range reader ~from ~until
+
+let close = function
+  | Decoded _ -> ()
+  | Mmap reader -> Snapshot_columnar.close reader

--- a/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels_backing.mli
+++ b/trading/analysis/weinstein/snapshot_runtime/lib/daily_panels_backing.mli
@@ -1,0 +1,74 @@
+(** The per-symbol backing store for {!Daily_panels}, with format detection.
+
+    A cached symbol's data lives in one of two backings, chosen by inspecting
+    the file's leading bytes against the v2 columnar magic
+    ([Data_panel_snapshot.Snapshot_columnar_codec.magic]):
+
+    - {b Mmap (v2)} — a {!Data_panel_snapshot.Snapshot_columnar} reader whose
+      columns are memory-mapped once at open; reads slice the mapped columns on
+      demand. Holds an open fd, so the cache caps the number of resident mmap
+      backings.
+    - {b Decoded (v1 fallback)} — the whole v1 sexp file decoded into a sorted
+      [Snapshot.t array] on load, binary-searched by date.
+
+    This module isolates the format-specific load + read logic so
+    {!Daily_panels} stays the cache/LRU coordinator. It is intentionally
+    counter-free: the open-handle accounting lives in {!Daily_panels.t}, which
+    uses {!is_mmap} to know when a backing holds an fd. *)
+
+type t =
+  | Mmap of Data_panel_snapshot.Snapshot_columnar.reader
+  | Decoded of Data_panel_snapshot.Snapshot.t array
+
+val is_columnar_file : string -> bool
+(** [is_columnar_file path] is [true] iff [path]'s leading bytes equal the v2
+    columnar magic. A short, absent, or unreadable file reads as non-v2 (so the
+    v1 decoder then surfaces the real error). *)
+
+val load :
+  path:string ->
+  expected:Data_panel_snapshot.Snapshot_schema.t ->
+  t Status.status_or
+(** [load ~path ~expected] format-detects [path] and loads the matching backing,
+    gating both formats on the schema hash:
+
+    - v2 magic → an {!Mmap} reader; [Error Failed_precondition] on schema-hash
+      skew (the reader is closed before returning).
+    - otherwise → a {!Decoded} array via
+      [Snapshot_format.read_with_expected_schema] (its own loud schema gate).
+
+    [Error Internal] / [Error NotFound] propagate from the underlying reader on
+    I/O or decode failure. *)
+
+val is_mmap : t -> bool
+(** [is_mmap b] is [true] for an {!Mmap} backing (which owns an open fd). The
+    cache uses this to maintain its open-handle count. *)
+
+val read_today :
+  t ->
+  symbol:string ->
+  date:Core.Date.t ->
+  Data_panel_snapshot.Snapshot.t Status.status_or
+(** [read_today b ~symbol ~date] returns the row dated [date], or
+    [Error NotFound] when the symbol has no row for that date (same message
+    shape for both backings). *)
+
+val read_history :
+  t ->
+  from:Core.Date.t ->
+  until:Core.Date.t ->
+  Data_panel_snapshot.Snapshot.t list Status.status_or
+(** [read_history b ~from ~until] returns the rows whose date is in the
+    inclusive range [[from, until]], chronological. An empty / inverted range
+    yields [Ok []], never an error. *)
+
+val estimate_bytes : schema:Data_panel_snapshot.Snapshot_schema.t -> t -> int
+(** [estimate_bytes ~schema b] is the heap-byte contribution of [b] to the cache
+    budget. A {!Decoded} backing's estimate scales with its row count; an
+    {!Mmap} backing's is small (the mapped int32 date array + a fixed per-handle
+    constant — the float-column pages are OS-page-cache resident, not counted).
+*)
+
+val close : t -> unit
+(** [close b] releases the OS resources [b] holds. For {!Mmap} it closes the
+    reader's fd (unmapping its columns); for {!Decoded} it is a no-op. *)

--- a/trading/analysis/weinstein/snapshot_runtime/test/test_daily_panels.ml
+++ b/trading/analysis/weinstein/snapshot_runtime/test/test_daily_panels.ml
@@ -4,6 +4,7 @@ open Matchers
 module Daily_panels = Snapshot_runtime.Daily_panels
 module Snapshot = Data_panel_snapshot.Snapshot
 module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_columnar = Data_panel_snapshot.Snapshot_columnar
 module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
 module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
 
@@ -57,7 +58,7 @@ let _make_tmp_dir () = Filename_unix.temp_dir ~in_dir:"/tmp" "daily_panels_" ""
    [max_cache_mb]). All series start at [_default_start]. *)
 let _default_start = _ymd 2024 1 2
 
-let _setup ~symbols ~n_days ~max_cache_mb =
+let _setup ~symbols ~n_days ~max_cache_mb () =
   let dir = _make_tmp_dir () in
   let entries =
     List.map symbols ~f:(fun symbol ->
@@ -66,6 +67,64 @@ let _setup ~symbols ~n_days ~max_cache_mb =
         metadata)
   in
   let manifest = Snapshot_manifest.create ~schema:_test_schema ~entries in
+  match Daily_panels.create ~snapshot_dir:dir ~manifest ~max_cache_mb with
+  | Ok t -> (dir, t)
+  | Error err -> assert_failure ("Daily_panels.create: " ^ Status.show err)
+
+(* --- v2 fixtures (must use the canonical default schema) -------------- *)
+
+(* The columnar reader can only reconstruct rows under [Snapshot_schema.default]
+   (it stores the schema hash + field count, not the ordered field list), so v2
+   fixtures use the default 13-field schema. Fields 0 and 1 carry the same
+   deterministic 100+i / 200+i series the v1 fixtures use, so the same value
+   assertions read across both formats; the remaining fields are deterministic
+   filler. *)
+let _v2_make_row ~symbol ~date ~day =
+  let n = Snapshot_schema.n_fields Snapshot_schema.default in
+  let values =
+    Array.init n ~f:(fun c ->
+        match c with
+        | 0 -> 100.0 +. Float.of_int day
+        | 1 -> 200.0 +. Float.of_int day
+        | _ -> Float.of_int ((day * 10) + c))
+  in
+  match
+    Snapshot.create ~schema:Snapshot_schema.default ~symbol ~date ~values
+  with
+  | Ok r -> r
+  | Error err -> assert_failure ("Snapshot.create: " ^ Status.show err)
+
+let _v2_series ~symbol ~n =
+  List.init n ~f:(fun i ->
+      _v2_make_row ~symbol ~date:(Date.add_days _default_start i) ~day:i)
+
+let _v2_write_symbol ~dir ~symbol rows =
+  let path = Filename.concat dir (symbol ^ ".snap") in
+  match Snapshot_columnar.write ~path rows with
+  | Ok () ->
+      let stat = Core_unix.stat path in
+      ({
+         Snapshot_manifest.symbol;
+         path;
+         byte_size = Int64.to_int_exn stat.st_size;
+         payload_md5 = "ignored";
+         csv_mtime = stat.st_mtime;
+         active_through = None;
+       }
+        : Snapshot_manifest.file_metadata)
+  | Error err -> assert_failure ("Snapshot_columnar.write: " ^ Status.show err)
+
+(* Build a directory of v2 columnar files (one per symbol) and a manifest under
+   the default schema; return the resulting [Daily_panels.t]. *)
+let _v2_setup ~symbols ~n_days ~max_cache_mb =
+  let dir = _make_tmp_dir () in
+  let entries =
+    List.map symbols ~f:(fun symbol ->
+        _v2_write_symbol ~dir ~symbol (_v2_series ~symbol ~n:n_days))
+  in
+  let manifest =
+    Snapshot_manifest.create ~schema:Snapshot_schema.default ~entries
+  in
   match Daily_panels.create ~snapshot_dir:dir ~manifest ~max_cache_mb with
   | Ok t -> (dir, t)
   | Error err -> assert_failure ("Daily_panels.create: " ^ Status.show err)
@@ -80,14 +139,14 @@ let test_create_rejects_nonpositive_cap _ =
     (is_error_with Status.Invalid_argument)
 
 let test_schema_returns_manifest_schema _ =
-  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 () in
   assert_that (Daily_panels.schema t).schema_hash
     (equal_to _test_schema.schema_hash)
 
 (* --- read_today ----------------------------------------------------- *)
 
 let test_read_today_returns_correct_row _ =
-  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 () in
   let date = Date.add_days _default_start 2 in
   assert_that
     (Daily_panels.read_today t ~symbol:"AAPL" ~date)
@@ -101,13 +160,13 @@ let test_read_today_returns_correct_row _ =
           ]))
 
 let test_read_today_unknown_symbol_returns_not_found _ =
-  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 () in
   assert_that
     (Daily_panels.read_today t ~symbol:"XYZ" ~date:_default_start)
     (is_error_with Status.NotFound)
 
 let test_read_today_unknown_date_returns_not_found _ =
-  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 () in
   let outside = Date.add_days _default_start 100 in
   assert_that
     (Daily_panels.read_today t ~symbol:"AAPL" ~date:outside)
@@ -116,7 +175,7 @@ let test_read_today_unknown_date_returns_not_found _ =
 (* --- read_history --------------------------------------------------- *)
 
 let test_read_history_returns_ordered_subset _ =
-  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:10 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:10 ~max_cache_mb:1 () in
   let from = Date.add_days _default_start 2 in
   let until = Date.add_days _default_start 5 in
   let dates_in_result rows =
@@ -135,7 +194,7 @@ let test_read_history_returns_ordered_subset _ =
              ])))
 
 let test_read_history_empty_range_returns_empty_list _ =
-  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 () in
   let future_from = Date.add_days _default_start 100 in
   let future_until = Date.add_days _default_start 110 in
   assert_that
@@ -155,7 +214,7 @@ let test_lru_evicts_when_over_budget _ =
   (* Each symbol: 5000 rows × (16 bytes values + 64 overhead) ≈ 400 KB.
      With max_cache_mb = 1 (1 MB = 1,048,576 bytes), at most 2 symbols
      fully fit; loading all 6 should evict at least the earliest 2. *)
-  let _dir, t = _setup ~symbols ~n_days:5000 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols ~n_days:5000 ~max_cache_mb:1 () in
   let date = _default_start in
   List.iter symbols ~f:(fun symbol ->
       match Daily_panels.read_today t ~symbol ~date with
@@ -170,7 +229,7 @@ let test_lru_evicts_when_over_budget _ =
 
 let test_lru_keeps_recently_used_symbol_resident _ =
   let symbols = [ "A"; "B"; "C"; "D"; "E"; "F" ] in
-  let _dir, t = _setup ~symbols ~n_days:5000 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols ~n_days:5000 ~max_cache_mb:1 () in
   let date = _default_start in
   (* Touch symbol A first, then load B-F. A should be the LRU and likely
      evicted; touching it again would reload from disk. We assert this
@@ -197,7 +256,7 @@ let test_lru_keeps_recently_used_symbol_resident _ =
    persistence is the source of truth). Verifies that close doesn't corrupt
    the manifest's file pointers. *)
 let test_close_then_read_reloads _ =
-  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 () in
   let date = _default_start in
   let _ =
     match Daily_panels.read_today t ~symbol:"AAPL" ~date with
@@ -266,7 +325,7 @@ let test_round_trip_30d_10sym _ =
     [ "S0"; "S1"; "S2"; "S3"; "S4"; "S5"; "S6"; "S7"; "S8"; "S9" ]
   in
   let n_days = 30 in
-  let _dir, t = _setup ~symbols ~n_days ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols ~n_days ~max_cache_mb:1 () in
   let s7_date_5 = Date.add_days _default_start 5 in
   let s7_full =
     match
@@ -287,7 +346,7 @@ let test_round_trip_30d_10sym _ =
 (* A first read of a fresh symbol is a miss (one disk decode), no hit, no
    eviction. *)
 let test_cache_stats_first_read_is_a_miss _ =
-  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 () in
   let _ =
     match Daily_panels.read_today t ~symbol:"AAPL" ~date:_default_start with
     | Ok r -> r
@@ -300,7 +359,7 @@ let test_cache_stats_first_read_is_a_miss _ =
 (* A second read of the same resident symbol is a hit; the miss count stays
    at one. *)
 let test_cache_stats_second_read_is_a_hit _ =
-  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 () in
   let read () =
     match Daily_panels.read_today t ~symbol:"AAPL" ~date:_default_start with
     | Ok _ -> ()
@@ -316,7 +375,7 @@ let test_cache_stats_second_read_is_a_hit _ =
    least one eviction; each first-touch is a miss and none are hits. *)
 let test_cache_stats_counts_evictions_under_pressure _ =
   let symbols = [ "A"; "B"; "C"; "D"; "E"; "F" ] in
-  let _dir, t = _setup ~symbols ~n_days:5000 ~max_cache_mb:1 in
+  let _dir, t = _setup ~symbols ~n_days:5000 ~max_cache_mb:1 () in
   List.iter symbols ~f:(fun symbol ->
       match Daily_panels.read_today t ~symbol ~date:_default_start with
       | Ok _ -> ()
@@ -333,6 +392,212 @@ let test_cache_stats_counts_evictions_under_pressure _ =
            (fun (s : Daily_panels.stats) -> s.evictions)
            (gt (module Int_ord) 0);
        ])
+
+(* --- v2 (Mmap) fixtures: same reads through the columnar backing ----- *)
+
+(* read_today on a v2 file returns the correct row (the Mmap path slices the
+   mapped columns). *)
+let test_v2_read_today_returns_correct_row _ =
+  let _dir, t = _v2_setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let date = Date.add_days _default_start 2 in
+  assert_that
+    (Daily_panels.read_today t ~symbol:"AAPL" ~date)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (r : Snapshot.t) -> r.symbol) (equal_to "AAPL");
+            field (fun (r : Snapshot.t) -> r.date) (equal_to date);
+            field (fun (r : Snapshot.t) -> r.values.(0)) (float_equal 102.0);
+            field (fun (r : Snapshot.t) -> r.values.(1)) (float_equal 202.0);
+          ]))
+
+(* read_today for a date absent from a v2 file is NotFound (empty range). *)
+let test_v2_read_today_unknown_date_returns_not_found _ =
+  let _dir, t = _v2_setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let outside = Date.add_days _default_start 100 in
+  assert_that
+    (Daily_panels.read_today t ~symbol:"AAPL" ~date:outside)
+    (is_error_with Status.NotFound)
+
+(* read_history on a v2 file returns the ordered subset over an inclusive
+   range, boundaries included. *)
+let test_v2_read_history_ordered_subset_inclusive _ =
+  let _dir, t = _v2_setup ~symbols:[ "AAPL" ] ~n_days:10 ~max_cache_mb:1 in
+  let from = Date.add_days _default_start 2 in
+  let until = Date.add_days _default_start 5 in
+  let dates_in_result rows =
+    List.map rows ~f:(fun (r : Snapshot.t) -> r.date)
+  in
+  assert_that
+    (Daily_panels.read_history t ~symbol:"AAPL" ~from ~until)
+    (is_ok_and_holds
+       (field dates_in_result
+          (equal_to
+             [
+               Date.add_days _default_start 2;
+               Date.add_days _default_start 3;
+               Date.add_days _default_start 4;
+               Date.add_days _default_start 5;
+             ])))
+
+(* An inverted (until < from) v2 range yields Ok []. *)
+let test_v2_read_history_inverted_range_is_empty _ =
+  let _dir, t = _v2_setup ~symbols:[ "AAPL" ] ~n_days:10 ~max_cache_mb:1 in
+  let from = Date.add_days _default_start 5 in
+  let until = Date.add_days _default_start 2 in
+  assert_that
+    (Daily_panels.read_history t ~symbol:"AAPL" ~from ~until)
+    (is_ok_and_holds (size_is 0))
+
+(* A v2 range entirely outside the data yields Ok []. *)
+let test_v2_read_history_empty_range_is_empty _ =
+  let _dir, t = _v2_setup ~symbols:[ "AAPL" ] ~n_days:5 ~max_cache_mb:1 in
+  let from = Date.add_days _default_start 100 in
+  let until = Date.add_days _default_start 110 in
+  assert_that
+    (Daily_panels.read_history t ~symbol:"AAPL" ~from ~until)
+    (is_ok_and_holds (size_is 0))
+
+(* The indicator floats round-trip exactly through the v2 columnar payload. *)
+let test_v2_values_round_trip _ =
+  let _dir, t = _v2_setup ~symbols:[ "AAPL" ] ~n_days:30 ~max_cache_mb:1 in
+  let date = Date.add_days _default_start 7 in
+  assert_that
+    (Daily_panels.read_today t ~symbol:"AAPL" ~date)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (r : Snapshot.t) -> r.values.(0)) (float_equal 107.0);
+            field (fun (r : Snapshot.t) -> r.values.(1)) (float_equal 207.0);
+          ]))
+
+(* A v2 file written under a different schema is rejected loudly when the
+   manifest declares [_test_schema] (same Failed_precondition contract as v1). *)
+let test_v2_schema_mismatch_fails_loud _ =
+  let dir = _make_tmp_dir () in
+  let other_schema =
+    Snapshot_schema.create ~fields:[ Snapshot_schema.RSI_14 ]
+  in
+  let other_row =
+    match
+      Snapshot.create ~schema:other_schema ~symbol:"AAPL" ~date:_default_start
+        ~values:[| 50.0 |]
+    with
+    | Ok r -> r
+    | Error err -> assert_failure ("Snapshot.create: " ^ Status.show err)
+  in
+  let path = Filename.concat dir "AAPL.snap" in
+  let () =
+    match Snapshot_columnar.write ~path [ other_row ] with
+    | Ok () -> ()
+    | Error err -> assert_failure ("Snapshot_columnar.write: " ^ Status.show err)
+  in
+  let metadata =
+    {
+      Snapshot_manifest.symbol = "AAPL";
+      path;
+      byte_size = 0;
+      payload_md5 = "ignored";
+      csv_mtime = 0.0;
+      active_through = None;
+    }
+  in
+  let manifest =
+    Snapshot_manifest.create ~schema:_test_schema ~entries:[ metadata ]
+  in
+  let t =
+    match Daily_panels.create ~snapshot_dir:dir ~manifest ~max_cache_mb:1 with
+    | Ok t -> t
+    | Error err -> assert_failure ("Daily_panels.create: " ^ Status.show err)
+  in
+  assert_that
+    (Daily_panels.read_today t ~symbol:"AAPL" ~date:_default_start)
+    (is_error_with Status.Failed_precondition)
+
+(* --- handle-cap eviction (v2-specific) ------------------------------- *)
+
+(* More v2 symbols than the internal open-handle cap (256). Tiny rows keep the
+   byte budget far below 1 MB, so the byte cap never fires — the open-handle
+   cap is the sole eviction driver. Reading every symbol must force at least
+   one eviction, and a re-read of an evicted symbol must reopen + return the
+   correct row (proves the reopen-after-evict path works). *)
+let test_v2_handle_cap_evicts_and_reopens _ =
+  let symbols = List.init 300 ~f:(fun i -> Printf.sprintf "S%03d" i) in
+  let _dir, t = _v2_setup ~symbols ~n_days:5 ~max_cache_mb:1 in
+  let read_first s =
+    match Daily_panels.read_today t ~symbol:s ~date:_default_start with
+    | Ok _ -> ()
+    | Error err -> assert_failure ("read_today " ^ s ^ ": " ^ Status.show err)
+  in
+  List.iter symbols ~f:read_first;
+  (* The open-handle cap (256) is below the 300 symbols, so eviction fired. *)
+  assert_that
+    (Daily_panels.cache_stats t)
+    (field
+       (fun (s : Daily_panels.stats) -> s.evictions)
+       (gt (module Int_ord) 0));
+  (* S000 was the very first loaded, so it is the LRU and has been evicted; a
+     re-read reopens it from disk and returns its row. *)
+  assert_that
+    (Daily_panels.read_today t ~symbol:"S000" ~date:_default_start)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (r : Snapshot.t) -> r.symbol) (equal_to "S000");
+            field (fun (r : Snapshot.t) -> r.values.(0)) (float_equal 100.0);
+          ]))
+
+(* --- mixed v1 + v2 in one cache -------------------------------------- *)
+
+(* One v1 file and one v2 file in the same manifest/dir must both read
+   correctly through the same [Daily_panels.t] (format detection per-file). *)
+let test_mixed_v1_and_v2_both_read _ =
+  let dir = _make_tmp_dir () in
+  (* Both files use the default schema (the v2 reader can only reconstruct
+     default-schema rows); OLD is written v1 sexp, NEW v2 columnar. *)
+  let v1_path = Filename.concat dir "OLD.snap" in
+  let m1 =
+    match
+      Snapshot_format.write ~path:v1_path (_v2_series ~symbol:"OLD" ~n:5)
+    with
+    | Ok () ->
+        ({
+           Snapshot_manifest.symbol = "OLD";
+           path = v1_path;
+           byte_size = 0;
+           payload_md5 = "ignored";
+           csv_mtime = 0.0;
+           active_through = None;
+         }
+          : Snapshot_manifest.file_metadata)
+    | Error err -> assert_failure ("Snapshot_format.write: " ^ Status.show err)
+  in
+  let m2 =
+    _v2_write_symbol ~dir ~symbol:"NEW" (_v2_series ~symbol:"NEW" ~n:5)
+  in
+  let manifest =
+    Snapshot_manifest.create ~schema:Snapshot_schema.default ~entries:[ m1; m2 ]
+  in
+  let t =
+    match Daily_panels.create ~snapshot_dir:dir ~manifest ~max_cache_mb:1 with
+    | Ok t -> t
+    | Error err -> assert_failure ("Daily_panels.create: " ^ Status.show err)
+  in
+  let date = Date.add_days _default_start 3 in
+  let check_symbol s =
+    assert_that
+      (Daily_panels.read_today t ~symbol:s ~date)
+      (is_ok_and_holds
+         (all_of
+            [
+              field (fun (r : Snapshot.t) -> r.symbol) (equal_to s);
+              field (fun (r : Snapshot.t) -> r.values.(0)) (float_equal 103.0);
+            ]))
+  in
+  (* OLD is read through the v1 Decoded path, NEW through the v2 Mmap path;
+     both must surface the same row shape. *)
+  check_symbol "OLD";
+  check_symbol "NEW"
 
 let suite =
   "Daily_panels tests"
@@ -363,6 +628,21 @@ let suite =
          >:: test_cache_stats_second_read_is_a_hit;
          "cache stats counts evictions under pressure"
          >:: test_cache_stats_counts_evictions_under_pressure;
+         "v2 read_today returns correct row"
+         >:: test_v2_read_today_returns_correct_row;
+         "v2 read_today unknown date returns not_found"
+         >:: test_v2_read_today_unknown_date_returns_not_found;
+         "v2 read_history ordered subset inclusive"
+         >:: test_v2_read_history_ordered_subset_inclusive;
+         "v2 read_history inverted range is empty"
+         >:: test_v2_read_history_inverted_range_is_empty;
+         "v2 read_history empty range is empty"
+         >:: test_v2_read_history_empty_range_is_empty;
+         "v2 values round trip" >:: test_v2_values_round_trip;
+         "v2 schema mismatch fails loud" >:: test_v2_schema_mismatch_fails_loud;
+         "v2 handle cap evicts and reopens"
+         >:: test_v2_handle_cap_evicts_and_reopens;
+         "mixed v1 and v2 both read" >:: test_mixed_v1_and_v2_both_read;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar.ml
@@ -110,8 +110,14 @@ type reader = {
   header : Header.t;
   schema : Snapshot_schema.t;
   dates : C.dates_arr;
-  (* Byte offset of [col_0] (the first float64 column block) in the file. *)
-  cols_byte_pos : int;
+  (* All [n_fields] float64 column blocks, mapped once at [open_reader] as
+     zero-copy views. [read_range] / [read_all] slice these rather than
+     re-mapping per call (which, under a high read rate, would create
+     unbounded transient mappings). The OCaml-heap cost is one bigarray
+     descriptor per column; the cells live in the OS page cache and only page
+     in on access, so untouched columns never fault. Dropping the reader (via
+     [close] then GC) unmaps them. *)
+  mutable cols : C.col_arr array;
 }
 
 (* Reads exactly [len] bytes from [fd]; [Error Internal what] on a short read. *)
@@ -149,22 +155,24 @@ let _check_version (header : Header.t) =
          header.format_version)
   else Ok ()
 
+(* Maps all [n_fields] column blocks as zero-copy views, once at open time. *)
+let _map_all_cols fd ~cols_byte_pos ~n ~n_fields : C.col_arr array =
+  Array.init n_fields ~f:(fun c ->
+      C.map_col fd
+        ~byte_pos:(cols_byte_pos + (c * n * C.float64_bytes))
+        ~n_rows:n)
+
 let _build_reader fd (header : Header.t) ~dates_byte_pos : reader =
   let n = header.n_rows in
   let dates = C.map_dates fd ~byte_pos:dates_byte_pos ~n_rows:n in
   let cols_byte_pos = dates_byte_pos + (n * C.int32_bytes) in
+  let cols = _map_all_cols fd ~cols_byte_pos ~n ~n_fields:header.n_fields in
   (* The header stores only [schema_hash] + [n_fields], not the ordered field
      list, so row reconstruction uses the canonical [Snapshot_schema.default].
      [read_all] / [read_range] gate on [header.schema_hash = default.hash]
      before reconstructing, so a file under any other field order fails loudly
      rather than reconstructing rows under the wrong schema. *)
-  {
-    fd = Some fd;
-    header;
-    schema = Snapshot_schema.default;
-    dates;
-    cols_byte_pos;
-  }
+  { fd = Some fd; header; schema = Snapshot_schema.default; dates; cols }
 
 let open_reader ~path =
   let open Result.Let_syntax in
@@ -188,12 +196,21 @@ let close r =
   | None -> ()
   | Some fd -> (
       r.fd <- None;
+      (* Drop the mapped column views so the GC can unmap them; the empty array
+         keeps the field well-typed without holding any mapping. *)
+      r.cols <- [||];
       try Core_unix.close fd with _ -> ())
 
 let with_reader ~path ~f =
   match open_reader ~path with
   | Error _ as e -> e
   | Ok r -> Exn.protect ~f:(fun () -> f r) ~finally:(fun () -> close r)
+
+(* ----- header accessors ------------------------------------------------- *)
+
+let schema_hash r = r.header.schema_hash
+let symbol r = r.header.symbol
+let n_rows r = r.header.n_rows
 
 (* ----- row reconstruction ----------------------------------------------- *)
 
@@ -209,27 +226,20 @@ let _check_reconstructable (r : reader) =
           %s; cannot reconstruct rows"
          r.header.schema_hash Snapshot_schema.default.schema_hash)
 
-(* Maps all [n_fields] column blocks as zero-copy views. *)
-let _map_all_cols fd ~cols_byte_pos ~n ~n_fields : C.col_arr array =
-  Array.init n_fields ~f:(fun c ->
-      C.map_col fd
-        ~byte_pos:(cols_byte_pos + (c * n * C.float64_bytes))
-        ~n_rows:n)
-
-(* Reconstructs the single row at index [i] from the mapped columns. *)
-let _row_at (r : reader) (cols : C.col_arr array) ~n_fields i =
+(* Reconstructs the single row at index [i] from the held mapped columns. *)
+let _row_at (r : reader) ~n_fields i =
   let date = C.epoch_days_to_date (Int32.to_int_exn r.dates.{i}) in
-  let values = Array.init n_fields ~f:(fun c -> cols.(c).{i}) in
+  let values = Array.init n_fields ~f:(fun c -> r.cols.(c).{i}) in
   Snapshot.create ~schema:r.schema ~symbol:r.header.symbol ~date ~values
 
-(* Reconstructs the rows in [[lo, hi)] (0-based, half-open), chronological. *)
+(* Reconstructs the rows in [[lo, hi)] (0-based, half-open), chronological.
+   Slices the columns mapped once at [open_reader] — no per-call re-mapping. *)
 let _reconstruct_rows (r : reader) ~lo ~hi : Snapshot.t list Status.status_or =
   match r.fd with
   | None -> Status.error_internal "Snapshot_columnar: reader is closed"
-  | Some fd ->
-      let n = r.header.n_rows and n_fields = r.header.n_fields in
-      let cols = _map_all_cols fd ~cols_byte_pos:r.cols_byte_pos ~n ~n_fields in
-      List.init (hi - lo) ~f:(fun k -> _row_at r cols ~n_fields (lo + k))
+  | Some _ ->
+      let n_fields = r.header.n_fields in
+      List.init (hi - lo) ~f:(fun k -> _row_at r ~n_fields (lo + k))
       |> Result.all
 
 let read_all r =

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar.mli
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar.mli
@@ -90,6 +90,18 @@ val with_reader :
     leaking fds. If {!open_reader} fails, [f] is not run and the error is
     returned. *)
 
+val schema_hash : reader -> string
+(** [schema_hash r] is the [schema_hash] recorded in the file header. The
+    runtime gates on this to refuse a file produced under a different indicator
+    set before reading any rows. *)
+
+val symbol : reader -> string
+(** [symbol r] is the single symbol this file holds (the header's [symbol]). *)
+
+val n_rows : reader -> int
+(** [n_rows r] is the number of dated rows in the file (the header's [n_rows]).
+*)
+
 val read_all : reader -> Snapshot.t list Status.status_or
 (** [read_all r] returns every row in the file, ordered chronologically (oldest
     first). Reconstructs full {!Snapshot.t} rows (all schema fields). *)

--- a/trading/trading/data_panel/snapshot/test/test_snapshot_columnar.ml
+++ b/trading/trading/data_panel/snapshot/test/test_snapshot_columnar.ml
@@ -228,6 +228,59 @@ let test_empty_list_round_trip _ =
   let path = _tmp_path () in
   assert_that (_write_then_read path []) (is_ok_and_holds is_empty)
 
+(* ----- map-once regression: many sequential read_range on one reader ----- *)
+
+(* The reader maps all columns once at [open_reader]; [read_range] slices the
+   held views. This guards that change: one opened reader must serve many
+   sequential [read_range] calls, each returning the correct subset, with no
+   per-call re-mapping and no cross-call state corruption. We issue one
+   single-day [read_range] per row and check every result against the rows
+   sharing that date. *)
+let test_reader_serves_many_sequential_read_ranges _ =
+  let path = _tmp_path () in
+  let sorted = _sorted_sample () in
+  let n = List.length sorted in
+  let expected_at i =
+    let d = (List.nth_exn sorted i).date in
+    _dates_of_rows
+      (List.filter sorted ~f:(fun (s : Snapshot.t) -> Date.equal s.date d))
+  in
+  let read_each_day () =
+    Result.bind
+      (Snapshot_columnar.write ~path (_sample_rows ()))
+      ~f:(fun () ->
+        Snapshot_columnar.with_reader ~path ~f:(fun r ->
+            Result.all
+              (List.init n ~f:(fun i ->
+                   let d = (List.nth_exn sorted i).date in
+                   Result.map
+                     (Snapshot_columnar.read_range r ~from:d ~until:d)
+                     ~f:_dates_of_rows))))
+  in
+  assert_that (read_each_day ())
+    (is_ok_and_holds
+       (elements_are (List.init n ~f:(fun i -> equal_to (expected_at i)))))
+
+(* ----- header accessors ----- *)
+
+let test_header_accessors _ =
+  let path = _tmp_path () in
+  let sorted = _sorted_sample () in
+  let read () =
+    Result.bind
+      (Snapshot_columnar.write ~path (_sample_rows ()))
+      ~f:(fun () ->
+        Snapshot_columnar.with_reader ~path ~f:(fun r ->
+            Ok
+              ( Snapshot_columnar.symbol r,
+                Snapshot_columnar.schema_hash r,
+                Snapshot_columnar.n_rows r )))
+  in
+  assert_that (read ())
+    (is_ok_and_holds
+       (equal_to
+          ("AAPL", Snapshot_schema.default.schema_hash, List.length sorted)))
+
 (* ----- date <-> int round-trip ----- *)
 
 let test_date_round_trips_through_epoch_days _ =
@@ -271,6 +324,9 @@ let suite =
          "schema hash match succeeds" >:: test_schema_hash_match_succeeds;
          "bad magic rejected" >:: test_bad_magic_rejected;
          "empty list round trip" >:: test_empty_list_round_trip;
+         "reader serves many sequential read_ranges"
+         >:: test_reader_serves_many_sequential_read_ranges;
+         "header accessors" >:: test_header_accessors;
          "date round trips through epoch days"
          >:: test_date_round_trips_through_epoch_days;
        ]


### PR DESCRIPTION
## What this does (S2 of snapshot-format-v2)

Plan: `dev/plans/snapshot-format-research-2026-06-16.md` §S2. Builds on S1 (#1624: `Snapshot_columnar` + codec).

### Part A — `Snapshot_columnar` reader maps columns once at open
`_reconstruct_rows` previously called `_map_all_cols` on **every** `read_range`/`read_all` (unbounded transient mappings under a high call rate). The reader now maps all column blocks once at `open_reader` (held in `reader.cols`); reads slice the held views. `close` drops the cols refs so the GC unmaps. Adds `schema_hash`/`symbol`/`n_rows` accessors (needed by Daily_panels). On-disk format + `read_range`/`read_all`/`write` signatures unchanged; results bit-identical (regression test added: one reader serves many sequential `read_range` calls).

### Part B — `Daily_panels` format-detecting dual-backing mmap cache
A cache entry is now one of two backings, chosen by sniffing the first 8 bytes against the v2 magic:
- **`Mmap`** — a v2 `Snapshot_columnar` reader; reads slice mapped columns on demand. Cheap on the OCaml heap (columns live in OS page cache).
- **`Decoded`** — the v1 sexp fallback (whole-file decode → sorted array, exactly today's path).

The on-disk warehouses are still v1 until S3/S4, so the v1 fallback is the central back-compat constraint — every existing golden/test exercises it unchanged.

- **Schema-skew gate** preserved on both paths (`Error Failed_precondition`).
- **Eviction** now enforces the byte budget **and** an open-handle cap (`_max_open_mmap_handles = 256`, internal constant — no `create` param change) so resident `Mmap` readers never exhaust fds. Evicting an `Mmap` entry closes its reader; `close t` closes every resident reader.
- Backing/load/read logic extracted to a new `Daily_panels_backing` module to keep both `.ml` files under the 300-line limit (code-health, not a workaround).
- `Daily_panels` public API signatures (`create`/`schema`/`read_today`/`read_history`/`active_through_for`/`cache_bytes`/`cache_stats`/`close`) are **identical** — all ~20 consumers compile + test green.

## Test plan
- `trading/data_panel/snapshot`: 15 columnar tests (was 13; +map-once regression, +header accessors). Green.
- `analysis/weinstein/snapshot_runtime`: 24 `daily_panels` tests (was 15; +9 v2). Covers v2 read_today hit/miss, v2 read_history boundary/inverted/empty → `Ok []`, value round-trip, v2 schema-skew → `Failed_precondition`, **handle-cap eviction** (300 v2 symbols > 256 cap → evictions>0 + reopen-after-evict returns correct data), and a **mixed v1+v2** manifest read through one `Daily_panels.t`. Existing byte-budget eviction test (v1) still green.
- Full `dune build` (all consumers), strategy consumer tests, nesting linter (both lib dirs OK), file-length (all lib `.ml` ≤ 300), `dune fmt` idempotent. All exit 0.

## Design note
The columnar reader can only reconstruct rows under `Snapshot_schema.default` (S1 stores the schema hash + field count, not the ordered field list). So v2 fixtures use the default 13-field schema; v1 fixtures keep the tiny 2-field test schema via the Decoded path. This matches production (the warehouse uses the default schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
