### PR TITLE
feat(snapshot): S3 writers emit v2 + format-detecting verifier

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -1,9 +1,44 @@
 # Status: backtest-perf
 
-## Last updated: 2026-06-12
+## Last updated: 2026-06-16
 
 ## Status
 IN_PROGRESS
+
+### Recent activity (2026-06-16) — snapshot-format v2 S3: writers emit v2 + format-detecting verifier
+
+Branch `feat/snapshot-writers-v2` (READY_FOR_REVIEW). Plan:
+`dev/plans/snapshot-format-research-2026-06-16.md` §S3. Follows S1 (#1624,
+the columnar mmap format) and S2 (#1626, the `Daily_panels` range/column
+cache), both merged.
+
+- **[x] S3 — warehouse writer emits v2.** `Build_runner` (the single write
+  site behind both `build_snapshots.exe` and `build_scenario_snapshots.exe`)
+  now writes per-symbol `.snap` files via `Snapshot_columnar.write` instead of
+  `Snapshot_format.write`. `Snapshot_columnar.write` validates single-symbol +
+  single-schema and sorts by date — the preconditions a per-symbol file already
+  meets, so it is a drop-in. New warehouses are v2; `Daily_panels` already
+  format-detects so a mixed v1/v2 warehouse reads fine during transition.
+  File: `trading/analysis/scripts/build_snapshots/build_runner.ml`.
+- **[x] S3 — coupled verifier format-detects.** `Snapshot_verifier._verify_one`
+  read every file via `Snapshot_format.read_with_expected_schema` (v1 only),
+  which would fail on every v2 file the writer now emits. It now reads via a
+  new format-detecting seam `Snapshot_io.read_with_expected_schema` (new module
+  in the `data_panel/snapshot` lib): peek the leading
+  `Snapshot_columnar_codec.magic` → v2 reader; else → v1 sexp reader. Chose the
+  shared-module option (b) over inline peek-and-dispatch: it is the reusable
+  seam future whole-file consumers want, and it has its own unit tests.
+  Files: `trading/trading/data_panel/snapshot/lib/snapshot_io.{ml,mli}`,
+  `trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_verifier.{ml,mli}`.
+- **Verify:** `dune runtest trading/data_panel/snapshot analysis/weinstein/snapshot_pipeline analysis/scripts/build_snapshots`
+  (9 new assertions: 4 `Snapshot_io` format-detect cases + 5 verifier cases
+  covering v2-pass, v1-pass, v2-schema-skew-fail, v1-corruption-fail,
+  manifest-missing). The verifier test asserts the built file's first bytes are
+  the v2 magic.
+- **Out of scope (follow-ons):** `bar_reader.ml`'s `of_in_memory_bars` writer
+  stays v1 (in-memory synthetic warehouses for tests/backtests; `Daily_panels`
+  reads v1 fine). S4 (regenerate real warehouses + bit-identical golden gate)
+  and removing v1 `Snapshot_format` are later steps.
 
 ### Recent activity (2026-06-12) — runner fold-correctness fixes
 

--- a/trading/analysis/scripts/build_snapshots/build_runner.ml
+++ b/trading/analysis/scripts/build_snapshots/build_runner.ml
@@ -2,7 +2,7 @@ open Core
 module Pipeline = Snapshot_pipeline.Pipeline
 module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
 module Snapshot_verifier = Snapshot_pipeline.Snapshot_verifier
-module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_columnar = Data_panel_snapshot.Snapshot_columnar
 module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
 
 let default_progress_every = 50
@@ -83,7 +83,11 @@ let _active_through_of_bars (bars : Types.Daily_price.t list) : Date.t option =
   |> Option.bind ~f:(fun (b : Types.Daily_price.t) -> b.active_through)
 
 let _write_and_checksum ~symbol ~path ~csv_mtime ~active_through rows =
-  match Snapshot_format.write ~path rows with
+  (* Emit the v2 columnar mmap format ({!Snapshot_columnar}); it validates
+     single-symbol + single-schema and sorts rows by date, exactly the
+     preconditions a per-symbol [.snap] file already satisfies. The verifier
+     ([Snapshot_verifier]) format-detects, so v2 round-trips on read-back. *)
+  match Snapshot_columnar.write ~path rows with
   | Error err -> Error err
   | Ok () -> Ok (_file_metadata ~symbol ~path ~csv_mtime ~active_through)
 

--- a/trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_verifier.ml
+++ b/trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_verifier.ml
@@ -1,5 +1,5 @@
 open Core
-module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_io = Data_panel_snapshot.Snapshot_io
 
 type file_result = {
   symbol : string;
@@ -12,9 +12,7 @@ type t = { total : int; passed : int; failed : int; results : file_result list }
 let _verify_one ~(entry : Snapshot_manifest.file_metadata)
     ~(expected : Data_panel_snapshot.Snapshot_schema.t) : file_result =
   let status =
-    match
-      Snapshot_format.read_with_expected_schema ~path:entry.path ~expected
-    with
+    match Snapshot_io.read_with_expected_schema ~path:entry.path ~expected with
     | Ok rows -> Ok (List.length rows)
     | Error err -> Error err
   in

--- a/trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_verifier.mli
+++ b/trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_verifier.mli
@@ -1,10 +1,13 @@
 (** Round-trip verification for a snapshot directory built by Phase B.
 
     Walks every entry in a {!Snapshot_manifest.t}, opens the file via
-    {!Snapshot_format.read} (which already runs payload-md5 + schema-hash +
-    row-count integrity checks), and accumulates pass/fail counts. The
-    file-format layer is the source of truth for byte-level integrity; this
-    verifier adds the directory-level sweep + summary.
+    {!Snapshot_io.read_with_expected_schema} (which format-detects v1 sexp
+    {!Snapshot_format} vs v2 columnar {!Snapshot_columnar} and runs the matching
+    layer's md5 / schema-hash / row-count integrity checks), and accumulates
+    pass/fail counts. The file-format layer is the source of truth for
+    byte-level integrity; this verifier adds the directory-level sweep +
+    summary. Because detection is per-file, a warehouse mid-migration that mixes
+    both formats verifies correctly.
 
     The verifier does {b not} re-derive indicator values from the source CSV.
     Phase B's parity guarantee (plan §R2) is structural: the pipeline calls the
@@ -22,7 +25,7 @@ type file_result = {
   path : string;  (** Filesystem path that was checked. *)
   status : (int, Status.t) Result.t;
       (** [Ok n] when the file round-trips and produced [n] rows. [Error err]
-          when {!Snapshot_format.read} failed (md5, schema, parse). *)
+          when the format-detecting read failed (md5, schema, parse). *)
 }
 (** Per-file verification outcome. *)
 
@@ -37,8 +40,9 @@ type t = {
 val verify_directory : manifest_path:string -> t Status.status_or
 (** [verify_directory ~manifest_path] reads the manifest at [manifest_path],
     iterates every entry, and round-trips each file via
-    {!Snapshot_format.read_with_expected_schema} using the manifest's schema as
-    the expected schema. Returns a {!t} summarizing the sweep.
+    {!Snapshot_io.read_with_expected_schema} (format-detecting v1/v2) using the
+    manifest's schema as the expected schema. Returns a {!t} summarizing the
+    sweep.
 
     Returns [Error] only when the manifest itself cannot be loaded; per-file
     failures are reported in the [results] list (and counted in [failed]) so a

--- a/trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_verifier.ml
+++ b/trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_verifier.ml
@@ -5,6 +5,8 @@ module Pipeline = Snapshot_pipeline.Pipeline
 module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
 module Snapshot_verifier = Snapshot_pipeline.Snapshot_verifier
 module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_columnar = Data_panel_snapshot.Snapshot_columnar
+module Snapshot_columnar_codec = Data_panel_snapshot.Snapshot_columnar_codec
 module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
 
 (* The lib namespace [Snapshot_pipeline] holds three modules:
@@ -34,46 +36,62 @@ let _make_test_dir prefix =
   let path = Filename_unix.temp_dir prefix "" in
   path
 
-let _build_one_symbol_dir ~symbols =
+let _build_for_symbol symbol =
+  match
+    Pipeline.build_for_symbol ~symbol ~bars:(_ramp_bars ~n:10)
+      ~schema:Snapshot_schema.default ()
+  with
+  | Ok rs -> rs
+  | Error err -> assert_failure (Status.show err)
+
+let _write_entry ~dir ~write symbol =
+  let rows = _build_for_symbol symbol in
+  let path = Filename.concat dir (symbol ^ ".snap") in
+  (match write ~path rows with
+  | Ok () -> ()
+  | Error err -> assert_failure (Status.show err));
+  let bytes = In_channel.read_all path in
+  {
+    Snapshot_manifest.symbol;
+    path;
+    byte_size = String.length bytes;
+    payload_md5 = Stdlib.Digest.to_hex (Stdlib.Digest.string bytes);
+    csv_mtime = 0.0;
+    active_through = None;
+  }
+
+(* Build a one-symbol-per-file warehouse using [write] for the payload and
+   [manifest_schema] for the manifest's expected schema (defaults to the
+   builder's [default] schema; pass a different schema to provoke a skew). *)
+let _build_one_symbol_dir ?(write = Snapshot_columnar.write)
+    ?(manifest_schema = Snapshot_schema.default) ~symbols () =
   let dir = _make_test_dir "snapshot_verifier_test_" in
-  let entries =
-    List.map symbols ~f:(fun symbol ->
-        let bars = _ramp_bars ~n:10 in
-        let rows =
-          match
-            Pipeline.build_for_symbol ~symbol ~bars
-              ~schema:Snapshot_schema.default ()
-          with
-          | Ok rs -> rs
-          | Error err -> assert_failure (Status.show err)
-        in
-        let path = Filename.concat dir (symbol ^ ".snap") in
-        (match Snapshot_format.write ~path rows with
-        | Ok () -> ()
-        | Error err -> assert_failure (Status.show err));
-        let bytes = In_channel.read_all path in
-        {
-          Snapshot_manifest.symbol;
-          path;
-          byte_size = String.length bytes;
-          payload_md5 = Stdlib.Digest.to_hex (Stdlib.Digest.string bytes);
-          csv_mtime = 0.0;
-          active_through = None;
-        })
-  in
-  let manifest =
-    Snapshot_manifest.create ~schema:Snapshot_schema.default ~entries
-  in
+  let entries = List.map symbols ~f:(_write_entry ~dir ~write) in
+  let manifest = Snapshot_manifest.create ~schema:manifest_schema ~entries in
   let manifest_path = Filename.concat dir "manifest.sexp" in
   (match Snapshot_manifest.write ~path:manifest_path manifest with
   | Ok () -> ()
   | Error err -> assert_failure (Status.show err));
   (dir, manifest_path)
 
-let test_verify_passes_clean_directory _ =
-  let _, manifest_path =
-    _build_one_symbol_dir ~symbols:[ "AAPL"; "MSFT"; "GOOG" ]
+(* The first bytes of a [.snap] file written by [write]. *)
+let _magic_prefix path =
+  let len = Snapshot_columnar_codec.magic_len in
+  In_channel.with_file path ~f:(fun ic ->
+      let buf = Bytes.create len in
+      match In_channel.really_input ic ~buf ~pos:0 ~len with
+      | Some () -> Bytes.to_string buf
+      | None -> "")
+
+(* A v2 build writes the columnar magic; the verifier format-detects and
+   round-trips it. *)
+let test_verify_passes_v2_directory _ =
+  let dir, manifest_path =
+    _build_one_symbol_dir ~symbols:[ "AAPL"; "MSFT"; "GOOG" ] ()
   in
+  assert_that
+    (_magic_prefix (Filename.concat dir "AAPL.snap"))
+    (equal_to Snapshot_columnar_codec.magic);
   assert_that
     (Snapshot_verifier.verify_directory ~manifest_path)
     (is_ok_and_holds
@@ -84,7 +102,47 @@ let test_verify_passes_clean_directory _ =
             field (fun (r : Snapshot_verifier.t) -> r.failed) (equal_to 0);
           ]))
 
-(* Tampering: flip the last byte of a file to corrupt the payload md5. The
+(* A legacy v1 sexp warehouse still verifies (the other detection branch). *)
+let test_verify_passes_v1_directory _ =
+  let dir, manifest_path =
+    _build_one_symbol_dir ~write:Snapshot_format.write
+      ~symbols:[ "AAPL"; "MSFT" ] ()
+  in
+  assert_that
+    (not
+       (String.equal
+          (_magic_prefix (Filename.concat dir "AAPL.snap"))
+          Snapshot_columnar_codec.magic))
+    (equal_to true);
+  assert_that
+    (Snapshot_verifier.verify_directory ~manifest_path)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (r : Snapshot_verifier.t) -> r.total) (equal_to 2);
+            field (fun (r : Snapshot_verifier.t) -> r.passed) (equal_to 2);
+            field (fun (r : Snapshot_verifier.t) -> r.failed) (equal_to 0);
+          ]))
+
+(* A v2 file whose manifest declares a different schema fails the hash gate. *)
+let test_verify_detects_v2_schema_skew _ =
+  let _, manifest_path =
+    _build_one_symbol_dir
+      ~manifest_schema:
+        (Snapshot_schema.create ~fields:[ Snapshot_schema.EMA_50 ])
+      ~symbols:[ "AAPL" ] ()
+  in
+  assert_that
+    (Snapshot_verifier.verify_directory ~manifest_path)
+    (is_ok_and_holds
+       (all_of
+          [
+            field (fun (r : Snapshot_verifier.t) -> r.total) (equal_to 1);
+            field (fun (r : Snapshot_verifier.t) -> r.passed) (equal_to 0);
+            field (fun (r : Snapshot_verifier.t) -> r.failed) (equal_to 1);
+          ]))
+
+(* Tampering: flip the last byte of a file to corrupt the payload md5. The v1
    file's own integrity check fires, the verifier counts it as failed. *)
 let _corrupt_file path =
   let bytes = In_channel.read_all path |> Bytes.of_string in
@@ -94,7 +152,10 @@ let _corrupt_file path =
   Out_channel.write_all path ~data:(Bytes.to_string bytes)
 
 let test_verify_detects_corrupted_file _ =
-  let _, manifest_path = _build_one_symbol_dir ~symbols:[ "AAPL"; "MSFT" ] in
+  let _, manifest_path =
+    _build_one_symbol_dir ~write:Snapshot_format.write
+      ~symbols:[ "AAPL"; "MSFT" ] ()
+  in
   let manifest =
     match Snapshot_manifest.read ~path:manifest_path with
     | Ok m -> m
@@ -121,7 +182,9 @@ let test_verify_returns_error_when_manifest_missing _ =
 let suite =
   "Snapshot_verifier tests"
   >::: [
-         "verify passes clean directory" >:: test_verify_passes_clean_directory;
+         "verify passes v2 directory" >:: test_verify_passes_v2_directory;
+         "verify passes v1 directory" >:: test_verify_passes_v1_directory;
+         "verify detects v2 schema skew" >:: test_verify_detects_v2_schema_skew;
          "verify detects corrupted file" >:: test_verify_detects_corrupted_file;
          "verify returns error when manifest missing"
          >:: test_verify_returns_error_when_manifest_missing;

--- a/trading/trading/data_panel/snapshot/lib/snapshot_io.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_io.ml
@@ -1,0 +1,24 @@
+open Core
+
+(* Read the leading [magic_len] bytes of [ic], or [None] when the channel holds
+   fewer bytes than the magic (a short / empty file is not a v2 file). *)
+let _read_magic_prefix ic =
+  let buf = Bytes.create Snapshot_columnar_codec.magic_len in
+  match
+    In_channel.really_input ic ~buf ~pos:0
+      ~len:Snapshot_columnar_codec.magic_len
+  with
+  | Some () -> Some (Bytes.to_string buf)
+  | None -> None
+
+let is_columnar_file path =
+  try
+    let prefix = In_channel.with_file path ~f:_read_magic_prefix in
+    Option.value_map prefix ~default:false
+      ~f:(String.equal Snapshot_columnar_codec.magic)
+  with _ -> false
+
+let read_with_expected_schema ~path ~expected =
+  if is_columnar_file path then
+    Snapshot_columnar.read_with_expected_schema ~path ~expected
+  else Snapshot_format.read_with_expected_schema ~path ~expected

--- a/trading/trading/data_panel/snapshot/lib/snapshot_io.mli
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_io.mli
@@ -1,0 +1,29 @@
+(** Format-detecting reader over a single snapshot file — the seam that lets a
+    whole-file consumer read a warehouse that mixes v1 sexp ({!Snapshot_format})
+    and v2 columnar mmap ({!Snapshot_columnar}) files during the format
+    transition.
+
+    Detection peeks the leading {!Snapshot_columnar_codec.magic} bytes: a v2
+    file starts with that magic, anything else is treated as v1 sexp. This
+    mirrors the magic-peek {!Daily_panels} performs internally, but lives here
+    so consumers that want full-file decode (e.g. the build-time verifier) can
+    dispatch without a cross-library dependency. *)
+
+val is_columnar_file : string -> bool
+(** [is_columnar_file path] is [true] when [path] begins with the v2 magic
+    ({!Snapshot_columnar_codec.magic}). Returns [false] for a v1 sexp file, a
+    file shorter than the magic, or any path that cannot be opened — the
+    negative answer routes such inputs to the v1 reader, which then reports the
+    real error. *)
+
+val read_with_expected_schema :
+  path:string -> expected:Snapshot_schema.t -> Snapshot.t list Status.status_or
+(** [read_with_expected_schema ~path ~expected] reads every row of the file at
+    [path], detecting its format:
+    - v2 columnar → {!Snapshot_columnar.read_with_expected_schema};
+    - otherwise (v1 sexp) → {!Snapshot_format.read_with_expected_schema}.
+
+    Both paths gate on the schema hash, returning [Error Failed_precondition]
+    when the file's [schema_hash] differs from [expected.schema_hash]. The two
+    underlying readers preserve their own row ordering (v1 write order, v2
+    chronological). *)

--- a/trading/trading/data_panel/snapshot/test/dune
+++ b/trading/trading/data_panel/snapshot/test/dune
@@ -3,7 +3,8 @@
   test_snapshot_schema
   test_snapshot
   test_snapshot_format
-  test_snapshot_columnar)
+  test_snapshot_columnar
+  test_snapshot_io)
  (libraries
   core
   core_unix

--- a/trading/trading/data_panel/snapshot/test/test_snapshot_io.ml
+++ b/trading/trading/data_panel/snapshot/test/test_snapshot_io.ml
@@ -1,0 +1,86 @@
+open OUnit2
+open Core
+open Matchers
+module Snapshot_schema = Data_panel_snapshot.Snapshot_schema
+module Snapshot = Data_panel_snapshot.Snapshot
+module Snapshot_format = Data_panel_snapshot.Snapshot_format
+module Snapshot_columnar = Data_panel_snapshot.Snapshot_columnar
+module Snapshot_io = Data_panel_snapshot.Snapshot_io
+
+let _tmp_path () =
+  Filename_unix.temp_file ~in_dir:"/tmp" "snapshot_io_test_" ".snap"
+
+let _make_row ~date_seed =
+  let n = Snapshot_schema.n_fields Snapshot_schema.default in
+  let date = Date.add_days (Date.of_string "2024-01-01") date_seed in
+  let values = Array.init n ~f:(fun i -> Float.of_int ((date_seed * 10) + i)) in
+  match
+    Snapshot.create ~schema:Snapshot_schema.default ~symbol:"AAPL" ~date ~values
+  with
+  | Ok s -> s
+  | Error err -> failwith (Status.show err)
+
+let _rows () = List.init 5 ~f:(fun i -> _make_row ~date_seed:i)
+
+let _write_exn ~write ~path rows =
+  match write ~path rows with
+  | Ok () -> ()
+  | Error err -> assert_failure (Status.show err)
+
+(* The bit pattern of every cell, row by row — the round-trip invariant. *)
+let _bits rows =
+  List.map rows ~f:(fun (s : Snapshot.t) ->
+      Array.to_list s.values |> List.map ~f:Int64.bits_of_float)
+
+(* A v2 file is detected as columnar and round-trips through the detecting
+   reader. *)
+let test_v2_is_detected_and_round_trips _ =
+  let path = _tmp_path () in
+  let rows = _rows () in
+  _write_exn ~write:Snapshot_columnar.write ~path rows;
+  assert_that (Snapshot_io.is_columnar_file path) (equal_to true);
+  assert_that
+    (Snapshot_io.read_with_expected_schema ~path
+       ~expected:Snapshot_schema.default)
+    (is_ok_and_holds (field _bits (equal_to (_bits rows))))
+
+(* A v1 sexp file is NOT detected as columnar and round-trips through the v1
+   branch of the detecting reader. *)
+let test_v1_is_not_detected_and_round_trips _ =
+  let path = _tmp_path () in
+  let rows = _rows () in
+  _write_exn ~write:Snapshot_format.write ~path rows;
+  assert_that (Snapshot_io.is_columnar_file path) (equal_to false);
+  assert_that
+    (Snapshot_io.read_with_expected_schema ~path
+       ~expected:Snapshot_schema.default)
+    (is_ok_and_holds (field _bits (equal_to (_bits rows))))
+
+(* The schema-hash gate fires on the v2 branch. *)
+let test_v2_schema_skew_is_error _ =
+  let path = _tmp_path () in
+  _write_exn ~write:Snapshot_columnar.write ~path (_rows ());
+  assert_that
+    (Snapshot_io.read_with_expected_schema ~path
+       ~expected:(Snapshot_schema.create ~fields:[ Snapshot_schema.EMA_50 ]))
+    (is_error_with Status.Failed_precondition)
+
+(* A path that cannot be opened is reported as not-columnar, routing it to the
+   v1 reader (which then surfaces the real error). *)
+let test_missing_file_is_not_columnar _ =
+  assert_that
+    (Snapshot_io.is_columnar_file "/tmp/snapshot_io_no_such_file.snap")
+    (equal_to false)
+
+let suite =
+  "Snapshot_io tests"
+  >::: [
+         "v2 is detected and round-trips"
+         >:: test_v2_is_detected_and_round_trips;
+         "v1 is not detected and round-trips"
+         >:: test_v1_is_not_detected_and_round_trips;
+         "v2 schema skew is error" >:: test_v2_schema_skew_is_error;
+         "missing file is not columnar" >:: test_missing_file_is_not_columnar;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What this does (snapshot-format v2 — S3)

Plan: `dev/plans/snapshot-format-research-2026-06-16.md` §S3. Builds on S1
(#1624, the columnar mmap format `Snapshot_columnar`) and S2 (#1626, the
`Daily_panels` range/column cache), both merged.

1. **Warehouse writer emits v2.** `Build_runner._write_and_checksum` (the
   single per-symbol write site behind both `build_snapshots.exe` and
   `build_scenario_snapshots.exe`) now calls `Snapshot_columnar.write` instead
   of `Snapshot_format.write`. The v2 writer validates single-symbol +
   single-schema and sorts by date — preconditions a per-symbol `.snap` file
   already satisfies, so it is a near-drop-in. New warehouses are v2;
   `Daily_panels` already format-detects, so a mixed v1/v2 warehouse reads fine
   during transition.

2. **Coupled verifier format-detects.** `Snapshot_verifier._verify_one` read
   each file via `Snapshot_format.read_with_expected_schema` (v1 only), which
   would fail on every v2 file the writer now emits. It now reads via a new
   format-detecting seam, `Snapshot_io.read_with_expected_schema`.

## Design choice: (b) shared `Snapshot_io` module, not (a) inline peek

The brief offered (a) inline peek-and-dispatch in the verifier vs (b) a
format-detecting function in the `data_panel/snapshot` lib. I chose **(b)**:
a new `Snapshot_io` module exposing `is_columnar_file` + a
format-detecting `read_with_expected_schema`. It is the reusable seam future
whole-file consumers want (it lives in the snapshot lib alongside the two
underlying readers, so a consumer dispatches without a cross-lib dependency on
`Daily_panels`'s internal peek), and it carries its own unit tests. The
detection mirrors the magic-peek `daily_panels_backing.ml` already performs,
without sharing code across libs.

## Files changed

- `trading/trading/data_panel/snapshot/lib/snapshot_io.{ml,mli}` (new) — the
  format-detecting reader (peek `Snapshot_columnar_codec.magic` → v2 reader;
  else v1 sexp reader).
- `trading/analysis/scripts/build_snapshots/build_runner.ml` — writer flip to
  `Snapshot_columnar.write`.
- `trading/analysis/weinstein/snapshot_pipeline/lib/snapshot_verifier.{ml,mli}`
  — read via `Snapshot_io`; docstrings updated to describe per-file detection.
- `trading/trading/data_panel/snapshot/test/test_snapshot_io.ml` (new) +
  `test/dune` — 4 `Snapshot_io` tests.
- `trading/analysis/weinstein/snapshot_pipeline/test/test_snapshot_verifier.ml`
  — 5 verifier tests (v2-pass, v1-pass, v2-schema-skew-fail, v1-corruption-fail,
  manifest-missing); the v2-pass test asserts the built file's first bytes are
  the v2 magic.
- `dev/status/backtest-perf.md` — S3 completion note.

## Test plan

`dune build` (0) and
`dune runtest trading/data_panel/snapshot analysis/weinstein/snapshot_pipeline analysis/scripts/build_snapshots`
all pass (exit 0). New coverage: `Snapshot_io` round-trips v2 and v1, gates the
v2 schema hash, and reports an unopenable path as not-columnar; the verifier
passes a v2 directory, passes a legacy v1 directory, fails a v2 schema-skew
file, fails a corrupted v1 file, and errors on a missing manifest.

## Out of scope (follow-ons, noted in the plan)

- `bar_reader.ml`'s `of_in_memory_bars` writer stays v1 (in-memory synthetic
  warehouses for tests/backtests; `Daily_panels` reads v1 fine).
- S4 (regenerate real warehouses + bit-identical golden gate) and removing v1
  `Snapshot_format` are later steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
