### PR TITLE
fix(snapshot): single mmap per file in Snapshot_columnar reader (Rosetta VMA fix)

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -5,6 +5,42 @@
 ## Status
 IN_PROGRESS
 
+### Recent activity (2026-06-16) — Snapshot_columnar reader: ONE mmap per file (Rosetta VMA fix)
+
+Branch `feat/snapshot-single-mmap`. Fixes the Rosetta VMA-exhaustion crash in
+the forked top-3000 backtest (`rolling_start_eval` forks per start; the child's
+Rosetta translator exhausts its mapping bookkeeping — NOT the Linux
+`vm.max_map_count` — and SIGTRAPs).
+
+- **[x] Single mmap per `.snap` file.** The `Snapshot_columnar` reader used to
+  map each file as ~14 separate mmaps (1 int32 date column + 13 float64 value
+  columns, via `Core_unix.map_file` per column). With `Daily_panels`' 256-handle
+  cap that is ~3,840 VMAs. The reader now maps each file ONCE as a whole-file
+  `Bigstring` (one VMA) via `Bigstring_unix.map_file ~shared:false` and reads
+  cells by little-endian byte offset (`Bigstring.get_int32_t_le` /
+  `get_int64_t_le` + `Int64.float_of_bits`). On-disk FORMAT and the public
+  `Snapshot_columnar.mli` are UNCHANGED — existing v2 files (incl.
+  `/tmp/snap_top3000_2000_v2`) still read bit-identically.
+- **Codec change** (`snapshot_columnar_codec.{ml,mli}`): replaced the per-column
+  mmap machinery (`dates_arr`, `col_arr`, `map_col`, `map_dates`, `Array1`-based
+  `lower_bound`) with byte-offset accessors over one `Bigstring`: `get_date`,
+  `get_cell` (stride `col*n_rows + i`), `lower_bound`. Added
+  `core_unix.bigstring_unix` to the lib `dune`. Empty/tiny files guarded before
+  mapping (`< magic_len + int32_bytes` → `Error Internal`, never `map_file` a
+  0-byte file).
+- **Reader** (`snapshot_columnar.ml`): `reader` holds `mutable map :
+  Bigstring.t option` + `dates_off` / `cols_off`; `close` sets `map <- None`
+  (GC unmaps) idempotently. `read_all` / `read_range` keep identical semantics
+  (inclusive `[from,until]`, empty→`Ok []`, full-row reconstruction).
+- **`Daily_panels` / `Daily_panels_backing` need NO changes** (same reader API);
+  their 24 `test_daily_panels` tests pass.
+- **Tests:** the 15 existing `test_snapshot_columnar` tests pass unchanged
+  (bit-identity incl. nan, range/boundary, bad-magic, schema-skew, empty) + 1
+  new test (`read_all reads every column at correct offset`) pins the
+  `col*n_rows + i` cell-offset math across 30 rows × all schema fields.
+- **Verify:** `dune runtest trading/data_panel/snapshot analysis/weinstein/snapshot_runtime`
+  (16 columnar + 24 daily-panels + io/format suites, all green).
+
 ### Recent activity (2026-06-16) — snapshot-format v2 S3: writers emit v2 + format-detecting verifier
 
 Branch `feat/snapshot-writers-v2` (READY_FOR_REVIEW). Plan:

--- a/trading/trading/data_panel/snapshot/lib/dune
+++ b/trading/trading/data_panel/snapshot/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name data_panel_snapshot)
  (public_name trading.data_panel.snapshot)
- (libraries core core_unix status)
+ (libraries core core_unix core_unix.bigstring_unix status)
  (preprocess
   (pps ppx_compare ppx_deriving.eq ppx_deriving.show ppx_let ppx_sexp_conv)))

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar.ml
@@ -109,44 +109,37 @@ type reader = {
   mutable fd : Core_unix.File_descr.t option;
   header : Header.t;
   schema : Snapshot_schema.t;
-  dates : C.dates_arr;
-  (* All [n_fields] float64 column blocks, mapped once at [open_reader] as
-     zero-copy views. [read_range] / [read_all] slice these rather than
-     re-mapping per call (which, under a high read rate, would create
-     unbounded transient mappings). The OCaml-heap cost is one bigarray
-     descriptor per column; the cells live in the OS page cache and only page
-     in on access, so untouched columns never fault. Dropping the reader (via
-     [close] then GC) unmaps them. *)
-  mutable cols : C.col_arr array;
+  (* The whole file mapped as ONE [Bigstring] (one VMA). [read_range] /
+     [read_all] read cells out by computed byte offset rather than holding ~14
+     per-column [Bigarray] views; cells page in on access, so untouched columns
+     never fault. One VMA per reader keeps the count bounded under a high handle
+     cap — the per-column scheme exhausted the Rosetta x86-64 translator's
+     mapping bookkeeping in forked children. [close] then GC unmaps the file. *)
+  mutable map : Core.Bigstring.t option;
+  dates_off : int;
+  cols_off : int;
 }
 
-(* Reads exactly [len] bytes from [fd]; [Error Internal what] on a short read. *)
-let _read_exact fd ~len ~what : Bytes.t Status.status_or =
-  let buf = Stdlib.Bytes.create len in
-  let n = Core_unix.read fd ~buf ~pos:0 ~len in
-  if n < len then
-    Status.error_internal (Printf.sprintf "Snapshot_columnar: %s" what)
-  else Ok buf
-
-let _check_magic prefix =
-  if String.equal (Stdlib.Bytes.sub_string prefix 0 C.magic_len) C.magic then
-    Ok ()
+let _check_magic bs =
+  if String.equal (Bigstring.To_string.sub bs ~pos:0 ~len:C.magic_len) C.magic
+  then Ok ()
   else Status.error_internal "Snapshot_columnar: bad magic / not a v2 file"
 
-(* Reads the [magic] + [header_len] prefix and the header block, returning the
-   decoded [Header.t] and the byte offset where the date block begins. *)
-let _read_header fd : (Header.t * int) Status.status_or =
-  let open Result.Let_syntax in
-  let prefix_len = C.magic_len + C.int32_bytes in
-  let%bind prefix =
-    _read_exact fd ~len:prefix_len ~what:"file too short for header"
-  in
-  let%bind () = _check_magic prefix in
+(* Decodes the header block out of the whole-file mapping [bs], returning the
+   [Header.t] and the byte offset where the date block begins. The leading
+   [magic] is validated by {!_check_magic} before this is called. *)
+let _decode_header bs : (Header.t * int) Status.status_or =
   let header_len =
-    Int32.to_int_exn (Stdlib.Bytes.get_int32_le prefix C.magic_len)
+    Int32.to_int_exn (Bigstring.get_int32_t_le bs ~pos:C.magic_len)
   in
-  let%bind hbuf = _read_exact fd ~len:header_len ~what:"truncated header" in
-  Ok (Header.of_bytes hbuf, prefix_len + header_len)
+  let hbuf =
+    Bigstring.To_string.sub bs
+      ~pos:(C.magic_len + C.int32_bytes)
+      ~len:header_len
+    |> Bytes.of_string
+  in
+  let header = Header.of_bytes hbuf in
+  Ok (header, C.magic_len + C.int32_bytes + header_len)
 
 let _check_version (header : Header.t) =
   if header.format_version <> C.format_version then
@@ -155,33 +148,42 @@ let _check_version (header : Header.t) =
          header.format_version)
   else Ok ()
 
-(* Maps all [n_fields] column blocks as zero-copy views, once at open time. *)
-let _map_all_cols fd ~cols_byte_pos ~n ~n_fields : C.col_arr array =
-  Array.init n_fields ~f:(fun c ->
-      C.map_col fd
-        ~byte_pos:(cols_byte_pos + (c * n * C.float64_bytes))
-        ~n_rows:n)
+(* Maps the whole file as one [Bigstring], or [Error Internal] if it is too
+   short to even hold the magic + length prefix (so we never [map_file] a
+   0-byte / truncated file). *)
+let _map_whole_file fd : Core.Bigstring.t Status.status_or =
+  let size = (Core_unix.fstat fd).st_size |> Int64.to_int_exn in
+  if size < C.magic_len + C.int32_bytes then
+    Status.error_internal "Snapshot_columnar: bad magic / file too short"
+  else Ok (Bigstring_unix.map_file ~shared:false fd size)
 
-let _build_reader fd (header : Header.t) ~dates_byte_pos : reader =
+let _build_reader fd (bs : Core.Bigstring.t) (header : Header.t) ~dates_off :
+    reader =
   let n = header.n_rows in
-  let dates = C.map_dates fd ~byte_pos:dates_byte_pos ~n_rows:n in
-  let cols_byte_pos = dates_byte_pos + (n * C.int32_bytes) in
-  let cols = _map_all_cols fd ~cols_byte_pos ~n ~n_fields:header.n_fields in
+  let cols_off = dates_off + (n * C.int32_bytes) in
   (* The header stores only [schema_hash] + [n_fields], not the ordered field
-     list, so row reconstruction uses the canonical [Snapshot_schema.default].
-     [read_all] / [read_range] gate on [header.schema_hash = default.hash]
-     before reconstructing, so a file under any other field order fails loudly
-     rather than reconstructing rows under the wrong schema. *)
-  { fd = Some fd; header; schema = Snapshot_schema.default; dates; cols }
+     list, so reconstruction uses the canonical [Snapshot_schema.default];
+     [read_all] / [read_range] gate on [schema_hash = default.hash] first
+     (see [_check_reconstructable]), so a foreign field order fails loudly. *)
+  {
+    fd = Some fd;
+    header;
+    schema = Snapshot_schema.default;
+    map = Some bs;
+    dates_off;
+    cols_off;
+  }
 
 let open_reader ~path =
   let open Result.Let_syntax in
   try
     let fd = Core_unix.openfile path ~mode:[ Core_unix.O_RDONLY ] in
     match
-      let%bind header, dates_byte_pos = _read_header fd in
+      let%bind bs = _map_whole_file fd in
+      let%bind () = _check_magic bs in
+      let%bind header, dates_off = _decode_header bs in
       let%bind () = _check_version header in
-      Ok (_build_reader fd header ~dates_byte_pos)
+      Ok (_build_reader fd bs header ~dates_off)
     with
     | Ok r -> Ok r
     | Error _ as e ->
@@ -196,9 +198,9 @@ let close r =
   | None -> ()
   | Some fd -> (
       r.fd <- None;
-      (* Drop the mapped column views so the GC can unmap them; the empty array
-         keeps the field well-typed without holding any mapping. *)
-      r.cols <- [||];
+      (* Drop the whole-file mapping so the GC can unmap it; [None] keeps the
+         field well-typed without holding any mapping. *)
+      r.map <- None;
       try Core_unix.close fd with _ -> ())
 
 let with_reader ~path ~f =
@@ -226,21 +228,30 @@ let _check_reconstructable (r : reader) =
           %s; cannot reconstruct rows"
          r.header.schema_hash Snapshot_schema.default.schema_hash)
 
-(* Reconstructs the single row at index [i] from the held mapped columns. *)
-let _row_at (r : reader) ~n_fields i =
-  let date = C.epoch_days_to_date (Int32.to_int_exn r.dates.{i}) in
-  let values = Array.init n_fields ~f:(fun c -> r.cols.(c).{i}) in
+(* Reconstructs the single row at index [i] by reading each cell out of the
+   whole-file mapping [bs] at its computed byte offset. *)
+let _row_at (r : reader) bs ~n_fields ~n_rows i =
+  let date = C.epoch_days_to_date (C.get_date bs ~dates_off:r.dates_off ~i) in
+  let values =
+    Array.init n_fields ~f:(fun col ->
+        C.get_cell bs ~cols_off:r.cols_off ~n_rows ~col ~i)
+  in
   Snapshot.create ~schema:r.schema ~symbol:r.header.symbol ~date ~values
 
-(* Reconstructs the rows in [[lo, hi)] (0-based, half-open), chronological.
-   Slices the columns mapped once at [open_reader] — no per-call re-mapping. *)
-let _reconstruct_rows (r : reader) ~lo ~hi : Snapshot.t list Status.status_or =
-  match r.fd with
+(* The live whole-file mapping, or [Error Internal] if the reader is closed. *)
+let _live_map (r : reader) : Core.Bigstring.t Status.status_or =
+  match r.map with
+  | Some bs -> Ok bs
   | None -> Status.error_internal "Snapshot_columnar: reader is closed"
-  | Some _ ->
-      let n_fields = r.header.n_fields in
-      List.init (hi - lo) ~f:(fun k -> _row_at r ~n_fields (lo + k))
-      |> Result.all
+
+(* Reconstructs the rows in [[lo, hi)] (0-based, half-open), chronological.
+   Reads cells out of the single whole-file mapping — no per-call re-mapping. *)
+let _reconstruct_rows (r : reader) ~lo ~hi : Snapshot.t list Status.status_or =
+  let open Result.Let_syntax in
+  let%bind bs = _live_map r in
+  let n_fields = r.header.n_fields and n_rows = r.header.n_rows in
+  List.init (hi - lo) ~f:(fun k -> _row_at r bs ~n_fields ~n_rows (lo + k))
+  |> Result.all
 
 let read_all r =
   let open Result.Let_syntax in
@@ -252,14 +263,16 @@ let read_all r =
 let read_range r ~from ~until =
   let open Result.Let_syntax in
   let%bind () = _check_reconstructable r in
+  let%bind bs = _live_map r in
   let n = r.header.n_rows in
   let from_days = C.date_to_epoch_days from in
   let until_days = C.date_to_epoch_days until in
   if until_days < from_days then Ok []
   else
-    let lo = C.lower_bound r.dates ~n ~target:from_days in
+    let bound target = C.lower_bound bs ~dates_off:r.dates_off ~n ~target in
+    let lo = bound from_days in
     (* exclusive upper bound = lower_bound of (until + 1) *)
-    let hi = C.lower_bound r.dates ~n ~target:(until_days + 1) in
+    let hi = bound (until_days + 1) in
     if lo >= hi then Ok [] else _reconstruct_rows r ~lo ~hi
 
 (* ----- schema-gated whole-file read ------------------------------------- *)

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar.mli
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar.mli
@@ -48,8 +48,9 @@
 
 type reader
 (** An opaque open handle over a memory-mapped v2 file. Holds the open fd, the
-    decoded header, and the mapped (zero-copy) date index. Must be released with
-    {!close} (or use {!with_reader}). *)
+    decoded header, and a single whole-file [Bigstring] mapping (one
+    virtual-memory area) that cells are read out of by byte offset. Must be
+    released with {!close} (or use {!with_reader}). *)
 
 val write : path:string -> Snapshot.t list -> unit Status.status_or
 (** [write ~path rows] serializes [rows] to [path] in the v2 columnar layout,
@@ -114,11 +115,11 @@ val read_range :
 (** [read_range r ~from ~until] returns the rows whose date is in the inclusive
     range [[from, until]], ordered chronologically.
 
-    The date index is binary-searched and only the matching row range is mapped
-    ([Array1.sub]) — the prune is real. An empty range (including
-    [until < from], a window entirely before the first date, or entirely after
-    the last date) yields [Ok []], not an error — mirroring
-    {!Daily_panels.read_history}.
+    The date index is binary-searched and only the matching row range is
+    reconstructed (cells read by byte offset out of the whole-file mapping) —
+    the prune is real. An empty range (including [until < from], a window
+    entirely before the first date, or entirely after the last date) yields
+    [Ok []], not an error — mirroring {!Daily_panels.read_history}.
 
     For S1, reconstructs full rows over the matching range; field-column pruning
     is a later step. *)

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar_codec.ml
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar_codec.ml
@@ -66,30 +66,18 @@ module Header = struct
     { format_version; n_rows; n_fields; schema_hash; symbol }
 end
 
-type dates_arr =
-  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
+let get_date (bs : Bigstring.t) ~dates_off ~i : int =
+  Int32.to_int_exn
+    (Bigstring.get_int32_t_le bs ~pos:(dates_off + (i * int32_bytes)))
 
-type col_arr =
-  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
+let get_cell (bs : Bigstring.t) ~cols_off ~n_rows ~col ~i : float =
+  let pos = cols_off + (((col * n_rows) + i) * float64_bytes) in
+  Int64.float_of_bits (Bigstring.get_int64_t_le bs ~pos)
 
-let map_col fd ~byte_pos ~n_rows : col_arr =
-  let g =
-    Core_unix.map_file fd ~pos:(Int64.of_int byte_pos) Bigarray.float64
-      Bigarray.c_layout ~shared:false [| n_rows |]
-  in
-  Bigarray.array1_of_genarray g
-
-let map_dates fd ~byte_pos ~n_rows : dates_arr =
-  let g =
-    Core_unix.map_file fd ~pos:(Int64.of_int byte_pos) Bigarray.int32
-      Bigarray.c_layout ~shared:false [| n_rows |]
-  in
-  Bigarray.array1_of_genarray g
-
-let lower_bound (dates : dates_arr) ~n ~target =
+let lower_bound (bs : Bigstring.t) ~dates_off ~n ~target =
   let lo = ref 0 and hi = ref n in
   while !lo < !hi do
     let mid = (!lo + !hi) / 2 in
-    if Int32.to_int_exn dates.{mid} < target then lo := mid + 1 else hi := mid
+    if get_date bs ~dates_off ~i:mid < target then lo := mid + 1 else hi := mid
   done;
   !lo

--- a/trading/trading/data_panel/snapshot/lib/snapshot_columnar_codec.mli
+++ b/trading/trading/data_panel/snapshot/lib/snapshot_columnar_codec.mli
@@ -2,12 +2,19 @@
     ({!Snapshot_columnar}).
 
     Holds the layout constants, the date-to-epoch-days layer, the file [Header]
-    block codec, and the [map_file] helpers producing zero-copy [Bigarray]
-    views.
+    block codec, and the little-endian {b byte-offset accessors} that read
+    individual cells out of a whole-file [Bigstring] mapping.
+
+    The reader maps each file as {b one} [Bigstring] (one virtual-memory area)
+    and slices cells out by computed byte offset — rather than mapping each
+    column as its own typed [Bigarray] view. Collapsing the ~14 per-column maps
+    to one whole-file map keeps the VMA count bounded under a high handle count
+    (the Rosetta x86-64 translator exhausts its mapping bookkeeping well before
+    the Linux [vm.max_map_count] limit).
 
     Split out of {!Snapshot_columnar} so the latter reads as the
     writer/reader/reconstruction logic and stays within the file-length limit;
-    this module is the mechanical byte/mmap layer it builds on. See the
+    this module is the mechanical byte layer it builds on. See the
     {!Snapshot_columnar} docstring for the full on-disk layout. *)
 
 val magic : string
@@ -55,24 +62,22 @@ module Header : sig
       so a well-formed file never trips this). *)
 end
 
-type dates_arr =
-  (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t
-(** A zero-copy view over the on-disk sorted [int32] epoch-days date column. *)
+val get_date : Core.Bigstring.t -> dates_off:int -> i:int -> int
+(** [get_date bs ~dates_off ~i] is the [i]-th epoch-days date, read as an
+    [int32] LE at byte offset [dates_off + i * int32_bytes] into the whole-file
+    mapping [bs]. *)
 
-type col_arr =
-  (float, Bigarray.float64_elt, Bigarray.c_layout) Bigarray.Array1.t
-(** A zero-copy view over one on-disk [float64] value column. *)
+val get_cell :
+  Core.Bigstring.t -> cols_off:int -> n_rows:int -> col:int -> i:int -> float
+(** [get_cell bs ~cols_off ~n_rows ~col ~i] is the [float64] cell at row [i] of
+    column [col], read by IEEE-754 bits (so [Float.nan] round-trips) at byte
+    offset [cols_off + (col * n_rows + i) * float64_bytes] into the whole-file
+    mapping [bs]. The struct-of-arrays layout stores all [n_rows] cells of a
+    column contiguously, hence the [col * n_rows] stride. *)
 
-val map_col : Core_unix.File_descr.t -> byte_pos:int -> n_rows:int -> col_arr
-(** [map_col fd ~byte_pos ~n_rows] memory-maps the [float64] column block of
-    [n_rows] cells starting at [byte_pos] as a zero-copy {!col_arr}. *)
-
-val map_dates :
-  Core_unix.File_descr.t -> byte_pos:int -> n_rows:int -> dates_arr
-(** [map_dates fd ~byte_pos ~n_rows] memory-maps the [int32] date column of
-    [n_rows] cells at [byte_pos] as a zero-copy {!dates_arr}. *)
-
-val lower_bound : dates_arr -> n:int -> target:int -> int
-(** [lower_bound dates ~n ~target] is the first index [i] in [[0, n]] with
-    [dates.{i} >= target] — a standard lower-bound binary search over the sorted
-    date column. Used to prune a [read_range] to its matching row range. *)
+val lower_bound :
+  Core.Bigstring.t -> dates_off:int -> n:int -> target:int -> int
+(** [lower_bound bs ~dates_off ~n ~target] is the first index [i] in [[0, n]]
+    with [get_date bs ~dates_off ~i >= target] — a standard lower-bound binary
+    search over the sorted date column at [dates_off]. Used to prune a
+    [read_range] to its matching row range. *)

--- a/trading/trading/data_panel/snapshot/test/test_snapshot_columnar.ml
+++ b/trading/trading/data_panel/snapshot/test/test_snapshot_columnar.ml
@@ -308,6 +308,42 @@ let test_date_round_trips_through_epoch_days _ =
     (_write_then_read path rows)
     (is_ok_and_holds (field _dates_of_rows (equal_to (_dates_of_rows sorted))))
 
+(* ----- column-offset math: every (row, col) cell read back exactly ----- *)
+
+(* Guards the [cols_off + (col * n_rows + i) * float64_bytes] offset arithmetic
+   in the single-mmap reader: an off-by-one in the [col * n_rows] stride would
+   read a neighbouring column's cell. We write rows whose cell at (row [i],
+   field [c]) is the distinct value [i * 1000 + c], [read_all], and assert each
+   cell equals exactly that. Crosses many columns and rows so a transposed or
+   shifted stride is caught. *)
+let test_read_all_reads_every_column_at_correct_offset _ =
+  let path = _tmp_path () in
+  let n_fields = Snapshot_schema.n_fields Snapshot_schema.default in
+  let n_rows = 30 in
+  let make_row i =
+    let date = Date.add_days (Date.of_string "2024-01-01") i in
+    let values =
+      Array.init n_fields ~f:(fun c -> Float.of_int ((i * 1000) + c))
+    in
+    match
+      Snapshot.create ~schema:Snapshot_schema.default ~symbol:"AAPL" ~date
+        ~values
+    with
+    | Ok s -> s
+    | Error err -> failwith (Status.show err)
+  in
+  let rows = List.init n_rows ~f:make_row in
+  (* Expected bit pattern, row by row — the writer sorts by date, but the seeds
+     are already ascending so the order is preserved. *)
+  let expected_bits =
+    List.init n_rows ~f:(fun i ->
+        List.init n_fields ~f:(fun c ->
+            Int64.bits_of_float (Float.of_int ((i * 1000) + c))))
+  in
+  assert_that
+    (_write_then_read path rows)
+    (is_ok_and_holds (field _bits_of_rows (equal_to expected_bits)))
+
 let suite =
   "Snapshot_columnar tests"
   >::: [
@@ -329,6 +365,8 @@ let suite =
          "header accessors" >:: test_header_accessors;
          "date round trips through epoch days"
          >:: test_date_round_trips_through_epoch_days;
+         "read_all reads every column at correct offset"
+         >:: test_read_all_reads_every_column_at_correct_offset;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Reworks the `Snapshot_columnar` reader to map each `.snap` file as **ONE** whole-file `Bigstring` (one virtual-memory area) instead of ~14 separate mmaps (1 int32 date column + 13 float64 value columns).

## Why (the bug this fixes)

The per-column reader mapped each file as ~14 VMAs via `Core_unix.map_file` per column. With `Daily_panels`' 256-handle cap that is ~3,840 VMAs. The forked top-3000 backtest (`rolling_start_eval` forks per start) crashed in the child: under Apple-Silicon **Rosetta** (x86-64 translation) the translator's mapping bookkeeping exhausts well before the Linux `vm.max_map_count` limit → `rosetta error: mmap_anonymous_rw mmap failed` → child SIGTRAP. Real memory was healthy; this is Rosetta-specific. Collapsing to one mmap per file fixes it (one VMA per open reader).

## The change

- **On-disk FORMAT and the public `Snapshot_columnar.mli` signatures are UNCHANGED.** Existing v2 files (incl. `/tmp/snap_top3000_2000_v2`) read bit-identically. The WRITER is untouched.
- **Codec** (`snapshot_columnar_codec.{ml,mli}`): replaced the per-column mmap machinery (`dates_arr`, `col_arr`, `map_col`, `map_dates`, `Array1`-based `lower_bound`) with little-endian byte-offset accessors over one `Bigstring`: `get_date`, `get_cell` (stride `col*n_rows + i`), `lower_bound`. Added `core_unix.bigstring_unix` to the lib `dune`.
- **Reader** (`snapshot_columnar.ml`): `reader` holds `mutable map : Bigstring.t option` + `dates_off` / `cols_off`. `open_reader` maps the whole file once via `Bigstring_unix.map_file ~shared:false` (size from `fstat`), guards tiny/empty files (`< magic_len + int32_bytes` → `Error Internal`, never `map_file` a 0-byte file), validates magic/version. `read_all` / `read_range` read cells by byte offset (`Bigstring.get_int32_t_le` / `get_int64_t_le` + `Int64.float_of_bits`); identical inclusive `[from,until]` / empty→`Ok []` semantics. `close` sets `map <- None` (GC unmaps) idempotently.
- **`Daily_panels` / `Daily_panels_backing` need NO changes** (same reader API).

## Test plan

- All 15 existing `test_snapshot_columnar` tests pass unchanged (bit-identity incl. NaN, range/boundary, bad-magic, schema-skew, empty list).
- Added 1 test (`read_all reads every column at correct offset`): writes 30 rows whose cell at (row i, field c) is the distinct value `i*1000 + c`, `read_all`, asserts each cell bit-pattern — pins the `col*n_rows + i` offset arithmetic across many rows × all schema fields.
- `analysis/weinstein/snapshot_runtime`: all 24 `test_daily_panels` tests + io/format suites pass (the consumer still builds + reads correctly).
- `dune build` exit 0; `dune runtest trading/data_panel/snapshot analysis/weinstein/snapshot_runtime` exit 0 (16 + 24 tests). devtools linters green: file-length (≤300), mli-coverage, nesting, magic-numbers. `ocamlformat` 0.29.0 clean on all changed files.

Pure infra / refactor PR — no domain-logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
