### PR TITLE
docs: redate priorities doc to 2026-06-17

### DIFF
--- a/dev/notes/next-session-priorities-2026-06-17.md
+++ b/dev/notes/next-session-priorities-2026-06-17.md
@@ -1,6 +1,7 @@
-# Next-session priorities — 2026-06-16 (PM2 / late continuation)
+# Next-session priorities — 2026-06-17
 
-**Supersedes** `next-session-priorities-2026-06-16-PM.md`. Check main CI green first.
+**Supersedes** `next-session-priorities-2026-06-16-PM2.md` (renamed from it; the
+overnight run carried it into 06-17). Check main CI green first.
 
 ---
 


### PR DESCRIPTION
Renames next-session-priorities-2026-06-16-PM2.md → -2026-06-17.md (the overnight run carried it past midnight; content is the 06-17 morning handoff). Docs-only.