### PR TITLE
feat(decision-grading): Phase 2 — pure Grade exit classifier

### DIFF
--- a/trading/trading/backtest/decision_grading/lib/grade.ml
+++ b/trading/trading/backtest/decision_grading/lib/grade.ml
@@ -1,0 +1,41 @@
+(** Exit-decision grade. See [grade.mli]. *)
+
+open Core
+
+type exit_grade = Premature | Good_exit | Neutral [@@deriving show, eq, sexp]
+
+type grade_config = {
+  premature_threshold_pct : float;
+  good_exit_threshold_pct : float;
+  grade_horizon_weeks : int;
+}
+[@@deriving show, eq, sexp]
+
+let default_config =
+  {
+    premature_threshold_pct = 0.10;
+    good_exit_threshold_pct = 0.10;
+    grade_horizon_weeks = 13;
+  }
+
+(** The first post-exit result computed at [horizon_weeks], if any. *)
+let _result_at ~horizon_weeks post_exit =
+  List.find post_exit ~f:(fun (r : Post_exit.horizon_result) ->
+      Int.equal r.horizon_weeks horizon_weeks)
+
+(** Grade a single (already side-adjusted) continuation against the config
+    thresholds. *)
+let _grade_continuation ~config continuation_pct =
+  if Float.( >= ) continuation_pct config.premature_threshold_pct then Premature
+  else if Float.( <= ) continuation_pct (-.config.good_exit_threshold_pct) then
+    Good_exit
+  else Neutral
+
+let grade_exit ~config ~post_exit =
+  match _result_at ~horizon_weeks:config.grade_horizon_weeks post_exit with
+  | None -> Neutral
+  | Some r -> _grade_continuation ~config r.Post_exit.continuation_pct
+
+let entry_capture_ratio ~realized_pnl_pct ~max_favorable_pct =
+  if Float.( <= ) max_favorable_pct 0.0 then None
+  else Some (realized_pnl_pct /. max_favorable_pct)

--- a/trading/trading/backtest/decision_grading/lib/grade.mli
+++ b/trading/trading/backtest/decision_grading/lib/grade.mli
@@ -1,0 +1,89 @@
+(** Exit-decision grade — the headline of the decision-grading lens (plan
+    [dev/plans/decision-grading-lens-2026-06-17.md] §Phase 2).
+
+    Phase 1 ([Post_exit]) measures how a stock moved {b after} an exit. This
+    module turns that measurement into a verdict on the exit {b decision}: by
+    selling, did we leave money on the table (price kept running in our
+    direction = {!Premature}) or dodge a drop (price reversed against us =
+    {!Good_exit})?
+
+    Every function here is pure — it depends only on {!Post_exit} and the
+    standard library. No [Bar_reader], no I/O, no engine state; whoever has the
+    {!Post_exit.horizon_result} list (CLI, report) calls in. Phase 4 wires the
+    real data source. *)
+
+type exit_grade =
+  | Premature
+      (** The stock continued in the trade's direction past the threshold after
+          we exited — we gave up a winner. *)
+  | Good_exit
+      (** The stock reversed against the trade past the threshold after we
+          exited — we dodged a drop. *)
+  | Neutral
+      (** The post-exit move stayed inside the threshold band (or no graded
+          horizon was available) — the exit was neither clearly premature nor
+          clearly good. *)
+[@@deriving show, eq, sexp]
+
+type grade_config = {
+  premature_threshold_pct : float;
+      (** Continuation at the grade horizon [>=] this fraction grades the exit
+          {!Premature} (we gave up a winner). Expressed as a fraction, e.g.
+          [0.10] = +10%. *)
+  good_exit_threshold_pct : float;
+      (** Continuation at the grade horizon [<=] the negation of this fraction
+          grades the exit {!Good_exit} (we dodged a drop). Expressed as a
+          positive fraction, e.g. [0.10] means continuation [<= -0.10]. *)
+  grade_horizon_weeks : int;
+      (** Which {!Post_exit.horizon_result} (by its [horizon_weeks]) to grade
+          on. *)
+}
+[@@deriving show, eq, sexp]
+
+val default_config : grade_config
+(** Faithful defaults: [premature_threshold_pct = 0.10],
+    [good_exit_threshold_pct = 0.10], [grade_horizon_weeks = 13] (one quarter).
+    A long that kept rising +10% over the quarter after we sold is {!Premature};
+    one that fell -10% is {!Good_exit}. *)
+
+val grade_exit :
+  config:grade_config -> post_exit:Post_exit.horizon_result list -> exit_grade
+(** [grade_exit ~config ~post_exit] grades an exit from its post-exit
+    continuation.
+
+    It selects the {!Post_exit.horizon_result} whose [horizon_weeks] equals
+    [config.grade_horizon_weeks] (the first such, if duplicated). Its
+    [continuation_pct] is {b already side-adjusted} by {!Post_exit} — positive
+    means the price moved in the trade's favour after the exit (we left gains on
+    the table), negative means it moved against us (we dodged a drop) — so no
+    [side] argument is needed here. The grade is then:
+
+    - [continuation_pct >= config.premature_threshold_pct] -> {!Premature}
+    - [continuation_pct <= -. config.good_exit_threshold_pct] -> {!Good_exit}
+    - otherwise -> {!Neutral}
+
+    If no result in [post_exit] matches [config.grade_horizon_weeks] (e.g. the
+    horizon was never computed, or [post_exit] is empty) the exit is graded
+    {!Neutral} — there is no evidence on which to call it premature or good.
+
+    The thresholds are compared on the {b same} sign convention as
+    {!Post_exit.horizon_result.continuation_pct}. Boundary values land on the
+    decisive side: exactly [premature_threshold_pct] is {!Premature}, exactly
+    [-. good_exit_threshold_pct] is {!Good_exit}. Pure: same inputs -> same
+    output. *)
+
+val entry_capture_ratio :
+  realized_pnl_pct:float -> max_favorable_pct:float -> float option
+(** [entry_capture_ratio ~realized_pnl_pct ~max_favorable_pct] is the fraction
+    of the trade's peak in-trade gain that the trade actually realized:
+    [realized_pnl_pct /. max_favorable_pct].
+
+    [max_favorable_pct] is the maximum favourable excursion {b during} the trade
+    (a fraction, e.g. [0.20] for a peak +20% unrealized gain). A ratio of [1.0]
+    means the trade captured its entire peak; [0.5] means it gave back half; a
+    {b negative} ratio means the trade closed for a loss despite having been in
+    the money at its peak.
+
+    Returns [None] when [max_favorable_pct <= 0.0] — the trade never showed an
+    in-trade gain, so "fraction of the peak captured" is undefined (no positive
+    peak to measure against). Pure: same inputs -> same output. *)

--- a/trading/trading/backtest/decision_grading/test/dune
+++ b/trading/trading/backtest/decision_grading/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_post_exit)
+ (names test_post_exit test_grade)
  (libraries ounit2 core matchers decision_grading types trading.base)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_grading/test/test_grade.ml
+++ b/trading/trading/backtest/decision_grading/test/test_grade.ml
@@ -1,0 +1,162 @@
+open OUnit2
+open Matchers
+module G = Decision_grading.Grade
+module PE = Decision_grading.Post_exit
+
+(* A Post_exit.horizon_result with only the fields the grader reads spelled out;
+   the excursion fields are irrelevant to grade_exit and fixed to 0.0. *)
+let result ~horizon_weeks ~continuation_pct =
+  {
+    PE.horizon_weeks;
+    continuation_pct;
+    post_exit_max_favorable_pct = 0.0;
+    post_exit_max_adverse_pct = 0.0;
+  }
+
+(* Grade on the default config (premature/good thresholds 0.10, horizon 13w). *)
+let config = G.default_config
+
+(* Continuation well above +threshold at the grade horizon -> gave up a winner. *)
+let test_premature _ =
+  assert_that
+    (G.grade_exit ~config
+       ~post_exit:[ result ~horizon_weeks:13 ~continuation_pct:0.25 ])
+    (equal_to G.Premature)
+
+(* Continuation well below -threshold -> dodged a drop. *)
+let test_good_exit _ =
+  assert_that
+    (G.grade_exit ~config
+       ~post_exit:[ result ~horizon_weeks:13 ~continuation_pct:(-0.25) ])
+    (equal_to G.Good_exit)
+
+(* Continuation inside the band -> neither. *)
+let test_neutral_in_band _ =
+  assert_that
+    (G.grade_exit ~config
+       ~post_exit:[ result ~horizon_weeks:13 ~continuation_pct:0.03 ])
+    (equal_to G.Neutral)
+
+(* Exactly at +premature_threshold -> Premature (boundary is decisive). *)
+let test_premature_boundary _ =
+  assert_that
+    (G.grade_exit ~config
+       ~post_exit:[ result ~horizon_weeks:13 ~continuation_pct:0.10 ])
+    (equal_to G.Premature)
+
+(* Exactly at -good_exit_threshold -> Good_exit (boundary is decisive). *)
+let test_good_exit_boundary _ =
+  assert_that
+    (G.grade_exit ~config
+       ~post_exit:[ result ~horizon_weeks:13 ~continuation_pct:(-0.10) ])
+    (equal_to G.Good_exit)
+
+(* Just inside each boundary -> Neutral. *)
+let test_just_inside_boundaries _ =
+  assert_that
+    (G.grade_exit ~config
+       ~post_exit:[ result ~horizon_weeks:13 ~continuation_pct:0.099 ])
+    (equal_to G.Neutral)
+
+(* The configured horizon is absent from the list -> Neutral, even when other
+   horizons would grade Premature. *)
+let test_missing_horizon_neutral _ =
+  assert_that
+    (G.grade_exit ~config
+       ~post_exit:
+         [
+           result ~horizon_weeks:4 ~continuation_pct:0.30;
+           result ~horizon_weeks:26 ~continuation_pct:0.40;
+         ])
+    (equal_to G.Neutral)
+
+(* Empty list -> Neutral. *)
+let test_empty_neutral _ =
+  assert_that (G.grade_exit ~config ~post_exit:[]) (equal_to G.Neutral)
+
+(* A multi-horizon list grades on the CONFIGURED horizon (13w, continuation
+   -0.20 = Good_exit), not the 4w (+0.30 = would be Premature) or 26w. *)
+let test_multi_horizon_picks_configured _ =
+  assert_that
+    (G.grade_exit ~config
+       ~post_exit:
+         [
+           result ~horizon_weeks:4 ~continuation_pct:0.30;
+           result ~horizon_weeks:13 ~continuation_pct:(-0.20);
+           result ~horizon_weeks:26 ~continuation_pct:0.05;
+         ])
+    (equal_to G.Good_exit)
+
+(* A non-default config: grade on the 4w horizon with a tighter +0.05
+   premature threshold -> the 4w +0.30 result is Premature. *)
+let test_custom_config_horizon _ =
+  let custom =
+    {
+      G.premature_threshold_pct = 0.05;
+      good_exit_threshold_pct = 0.05;
+      grade_horizon_weeks = 4;
+    }
+  in
+  assert_that
+    (G.grade_exit ~config:custom
+       ~post_exit:
+         [
+           result ~horizon_weeks:4 ~continuation_pct:0.30;
+           result ~horizon_weeks:13 ~continuation_pct:(-0.20);
+         ])
+    (equal_to G.Premature)
+
+(* Capture ratio, normal case: realized +10% against a +20% peak = 0.5 captured. *)
+let test_capture_ratio_normal _ =
+  assert_that
+    (G.entry_capture_ratio ~realized_pnl_pct:0.10 ~max_favorable_pct:0.20)
+    (is_some_and (float_equal 0.5))
+
+(* Realized loss despite an in-trade peak -> negative ratio (gave it all back
+   and then some). *)
+let test_capture_ratio_negative _ =
+  assert_that
+    (G.entry_capture_ratio ~realized_pnl_pct:(-0.05) ~max_favorable_pct:0.20)
+    (is_some_and (float_equal (-0.25)))
+
+(* Captured the entire peak -> 1.0. *)
+let test_capture_ratio_full _ =
+  assert_that
+    (G.entry_capture_ratio ~realized_pnl_pct:0.20 ~max_favorable_pct:0.20)
+    (is_some_and (float_equal 1.0))
+
+(* No in-trade gain (mfe = 0) -> undefined -> None. *)
+let test_capture_ratio_mfe_zero_none _ =
+  assert_that
+    (G.entry_capture_ratio ~realized_pnl_pct:0.10 ~max_favorable_pct:0.0)
+    is_none
+
+(* Negative mfe (should not occur, but guarded) -> None. *)
+let test_capture_ratio_mfe_negative_none _ =
+  assert_that
+    (G.entry_capture_ratio ~realized_pnl_pct:0.10 ~max_favorable_pct:(-0.05))
+    is_none
+
+let suite =
+  "grade"
+  >::: [
+         "premature" >:: test_premature;
+         "good_exit" >:: test_good_exit;
+         "neutral_in_band" >:: test_neutral_in_band;
+         "premature_boundary" >:: test_premature_boundary;
+         "good_exit_boundary" >:: test_good_exit_boundary;
+         "just_inside_boundaries" >:: test_just_inside_boundaries;
+         "missing_horizon_neutral" >:: test_missing_horizon_neutral;
+         "empty_neutral" >:: test_empty_neutral;
+         "multi_horizon_picks_configured"
+         >:: test_multi_horizon_picks_configured;
+         "custom_config_horizon" >:: test_custom_config_horizon;
+         "capture_ratio_normal" >:: test_capture_ratio_normal;
+         "capture_ratio_negative" >:: test_capture_ratio_negative;
+         "capture_ratio_full" >:: test_capture_ratio_full;
+         "capture_ratio_mfe_zero_none" >:: test_capture_ratio_mfe_zero_none;
+         "capture_ratio_mfe_negative_none"
+         >:: test_capture_ratio_mfe_negative_none;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
Phase 2 of the decision-grading lens (design `dev/plans/decision-grading-lens-2026-06-17.md`; Phase 1 = #1646). Pure `Decision_grading.Grade` module on top of `Post_exit`.

Grades an EXIT decision from its post-exit continuation: did selling leave money on the table (price kept running = **Premature**) or dodge a drop (**Good_exit**)?

API:
- `type exit_grade = Premature | Good_exit | Neutral`
- `type grade_config = { premature_threshold_pct; good_exit_threshold_pct; grade_horizon_weeks }` + `default_config` (0.10 / 0.10 / 13w)
- `grade_exit ~config ~post_exit:Post_exit.horizon_result list → exit_grade` (picks the horizon matching `grade_horizon_weeks`; continuation_pct is already side-adjusted upstream; missing horizon → Neutral)
- `entry_capture_ratio ~realized_pnl_pct ~max_favorable_pct → float option` (fraction of peak in-trade gain captured; None when MFE ≤ 0)

Pure (depends only on Post_exit + Core; no Bar_reader/IO/Trade_audit — Phase 4 wires real data). New files only: `lib/grade.{ml,mli}` + `test/test_grade.ml` (sibling test dir) + test/dune. Read-only analysis lib (no flag-discipline gate).

Verified locally: FULL `dune runtest` (repo-wide linters incl. nesting/magic-number/mli-coverage) exit 0; `dune build @fmt` exit 0. test_grade pins Premature/Good_exit/Neutral, boundaries, missing-horizon, multi-horizon, capture-ratio normal/mfe≤0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)