### PR TITLE
fix(decision-grading): read MFE from audit directly (capture ratio was always n/a)

### DIFF
--- a/dev/experiments/decision-grading-first-report-2026-06-18/FINDINGS.md
+++ b/dev/experiments/decision-grading-first-report-2026-06-18/FINDINGS.md
@@ -1,0 +1,35 @@
+# Decision-grading lens — first complete report (2026-06-18)
+
+First end-to-end run of the decision-grading lens (`trading/trading/backtest/decision_grading/`, PRs #1646/#1647/#1649) on a **fresh** Cell-E top-3000 PIT-2011 backtest (15y contiguous, 2011-01-01 .. 2026-04-30) so per-trade MFE — and therefore the entry-capture ratio — are populated (the prior smoke-test reused a pre-#1506 run with MFE=0).
+
+- Run: `dev/backtest/scenarios-2026-06-18-212152/cell-e-top3000-2011-15y-fresh/` (reproduces the known +790.5% / 671 trades / 29.2% MaxDD baseline, bit-identical).
+- Warehouse: `/tmp/snap_top3000_2011_v2` (3000 + 15 macro/ETF context symbols), `SNAPSHOT_CACHE_MB=1024`.
+- Grade horizon 13w; continuation horizons 4/13/26w.
+
+## The report
+
+| exit_reason | n | mean realized | post-exit cont. | % premature | % good exit | net value-add | capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 220 | +12.8% | −1.6% | 21% | 25% | +1.6% | −0.09 |
+| stage3_force_exit | 5 | +5.5% | −9.4% | 0% | 60% | +9.4% | −0.90 |
+| stop_loss | 440 | −2.8% | +8.1% | 28% | 24% | −8.1% | −2.83 |
+| unlabeled | 6 | −3.9% | +4.4% | 17% | 17% | −4.4% | −1.59 |
+
+Columns: **net value-add** = realized − counterfactual-if-held = −(mean post-exit continuation); positive means exiting helped. **capture** = group mean of per-trade `realized_pct / MFE_pct` (fraction of in-trade peak realized; negative = closed for a loss despite having been up at its peak). Note mean-of-ratios ≠ ratio-of-means: a group can have positive mean realized (fat-tail winners) yet negative mean capture (the typical trade gave its peak back).
+
+## Decision-level reading
+
+- **stop_loss is the value-destroying decision type, quantified.** Net value-add **−8.1%** (the average stopped name rose +8.1% over the quarter *after* we sold) and capture **−2.83** (the average stopped trade had been *up* at its peak, then closed for a loss — gave back the peak and more). This is the whipsaw / stop-too-tight signature: stops fire on names that had shown a gain, exit at a loss, and then recover. 28% premature vs 24% good-exit.
+- **laggard_rotation is net-positive on the exit decision (+1.6%)** and houses the fat-tail winners (mean realized +12.8%); capture ≈ 0 means the *typical* rotated-out name had stalled (captured ~none of its peak) — consistent with rotating capital out of laggards into fresher Stage-2 names. The mean is carried by a few monsters (the let-winners-run tail).
+- **stage3_force_exit dodges drops** (post-exit −9.4%, 60% good exits, net +9.4%) but n=5 — directionally Weinstein-faithful (exit as the Stage-3 top forms), too small to lean on.
+
+This re-derives `dev/experiments/trade-forensics-2026-06-12/` as a **repeatable instrument**: stops ≈ value-negative whipsaw premium, laggard-rotation = the profit channel. Consistent with the standing tail-preserving thesis (`project_edge_is_the_fat_tail`): stops are the tail-risk *insurance premium* the strategy pays; the lens now prices that premium per decision type.
+
+## Caveats (per `mechanism-validation-rigor`)
+
+- One window / one regime (2011-26 bull-dominated). Not a promotion verdict — a **descriptive** decision-level read on one surface. A multi-regime read (deep 1998-2026) and the paired laggard counterfactual (Phase 5) would sharpen it.
+- The stop "net −8.1%" is the post-exit *continuation* counterfactual (held-with-no-stop through the horizon); it does NOT net out the tail-risk the stop insures against. The right conclusion is "the stop premium is large and measurable," not "remove stops" — removing stops is a winner-touching / tail-risk change that must go through WF-CV + the confirmation grid.
+
+## Harness fix shipped alongside
+
+The Phase-4 CLI originally read MFE via `Trade_audit_report`'s ratings, keyed by the **audit** entry_date (Friday decision date) — which is ~1 day off the round-trip's `trades.csv` entry_date (fill date), so the join always missed and capture rendered `n/a`. Fixed to read `exit_decision.max_favorable_excursion_pct` straight from `trade_audit.sexp` with the same nearest-within-7-days join `Trade_audit_ratings` uses.

--- a/dev/experiments/decision-grading-first-report-2026-06-18/grade-2011.md
+++ b/dev/experiments/decision-grading-first-report-2026-06-18/grade-2011.md
@@ -1,0 +1,12 @@
+# Decision-grading report — cell-e-top3000-2011-15y-fresh
+
+Period: 2011-01-01 .. 2026-04-30 | round-trips graded: 671 | grade horizon: 13w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 220 | +12.8% | -1.6% | 21% | 25% | +1.6% | -0.09 |
+| stage3_force_exit | 5 | +5.5% | -9.4% | 0% | 60% | +9.4% | -0.90 |
+| stop_loss | 440 | -2.8% | +8.1% | 28% | 24% | -8.1% | -2.83 |
+| unlabeled | 6 | -3.9% | +4.4% | 17% | 17% | -4.4% | -1.59 |

--- a/dev/experiments/decision-grading-first-report-2026-06-18/scenario.sexp
+++ b/dev/experiments/decision-grading-first-report-2026-06-18/scenario.sexp
@@ -1,0 +1,19 @@
+;; Cell-E top-3000 PIT-2011, 15y contiguous — fresh post-#1506 run so MFE/MAE
+;; (and the decision-grading capture ratio) are populated. Same config as the
+;; 2026-06-08 run that the decision-grading lens was first smoke-tested on.
+((name "cell-e-top3000-2011-15y-fresh")
+ (description "Cell-E top-3000 PIT-2011, 15y contiguous, for decision-grading.")
+ (period ((start_date 2011-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-2011.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 100000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/trading/trading/backtest/decision_grading/bin/decision_grading_bin.ml
+++ b/trading/trading/backtest/decision_grading/bin/decision_grading_bin.ml
@@ -59,6 +59,12 @@ let _pct_scale = 100.0
    handful of weeks per closed trade, so a modest cap suffices. *)
 let _cache_mb = 512
 
+(* Max calendar-day gap when joining a trades.csv round-trip to its audit record
+   for MFE: the audit entry_date is the Friday decision date, the round-trip's is
+   the next-trading-day fill. Kept in sync with
+   [Trade_audit_ratings._join_tolerance_days]. *)
+let _join_tolerance_days = 7
+
 let _usage () =
   eprintf
     "Usage: decision_grading --scenario-dir <dir> --snapshot-dir <dir> \
@@ -185,15 +191,45 @@ let _exit_reason_lookup ~scenario_dir =
   | [] -> ());
   tbl
 
-(** Map [(symbol, entry_date) -> mfe_pct] from the report's per-trade ratings,
-    so a trade's in-trade peak (a fraction of entry price) is available for the
-    capture ratio. Trades without a matching audit record are absent. *)
-let _mfe_lookup (report : TAR.t) =
-  let tbl = Hashtbl.Poly.create () in
-  Option.iter report.analysis ~f:(fun (a : TAR.analysis) ->
-      List.iter a.ratings ~f:(fun (r : TAR.Trade_audit_ratings.rating) ->
-          Hashtbl.set tbl ~key:(r.symbol, r.entry_date) ~data:r.mfe_pct));
+(** Per-symbol MFE lookup built straight from [trade_audit.sexp]'s
+    [exit_decision.max_favorable_excursion_pct] (the in-trade peak as a fraction
+    of entry price).
+
+    Why not the report's ratings? The audit's [entry_date] is the Friday
+    decision date; the round-trip's [entry_date] in [trades.csv] is the actual
+    fill (next trading day), so the two differ by ~1 day. An exact
+    [(symbol, entry_date)] join therefore misses, so we replicate
+    {!Trade_audit_report.Trade_audit_ratings}'s nearest-within-tolerance join:
+    index audit MFEs by symbol, then at lookup time pick the audit record whose
+    [entry_date] is nearest the round-trip's, within [_join_tolerance_days]. *)
+let _mfe_index ~scenario_dir =
+  let path = Filename.concat scenario_dir "trade_audit.sexp" in
+  let records =
+    if not (Sys_unix.file_exists_exn path) then []
+    else
+      let sexp = Sexp.load_sexp path in
+      try (Backtest.Trade_audit.audit_blob_of_sexp sexp).audit_records
+      with _ -> Backtest.Trade_audit.audit_records_of_sexp sexp
+  in
+  let tbl = Hashtbl.create (module String) in
+  List.iter records ~f:(fun (r : Backtest.Trade_audit.audit_record) ->
+      Option.iter r.exit_ ~f:(fun (e : Backtest.Trade_audit.exit_decision) ->
+          Hashtbl.add_multi tbl ~key:r.entry.symbol
+            ~data:(r.entry.entry_date, e.max_favorable_excursion_pct)));
   tbl
+
+(** MFE for a round-trip: the audit record for [symbol] whose entry date is
+    nearest [entry_date], within [_join_tolerance_days]. [None] when the symbol
+    has no audit MFE within tolerance. *)
+let _find_mfe mfe_index ~symbol ~entry_date =
+  match Hashtbl.find mfe_index symbol with
+  | None -> None
+  | Some candidates ->
+      List.filter_map candidates ~f:(fun (d, mfe) ->
+          let gap = Int.abs (Date.diff d entry_date) in
+          if gap <= _join_tolerance_days then Some (gap, mfe) else None)
+      |> List.min_elt ~compare:(fun (g1, _) (g2, _) -> Int.compare g1 g2)
+      |> Option.map ~f:snd
 
 (** Continuation at [grade_horizon] from a post-exit result list, or [0.0] when
     that horizon is absent. *)
@@ -203,7 +239,7 @@ let _continuation_at ~grade_horizon post_exit =
   |> Option.value ~default:0.0
 
 (** Grade one round-trip row into a {!DG.Aggregate.graded_trade}. *)
-let _grade_row ~bar_reader ~mfe_lookup ~exit_reason_lookup ~horizons
+let _grade_row ~bar_reader ~mfe_index ~exit_reason_lookup ~horizons
     ~grade_config ~grade_horizon (row : TAR.per_trade_row) :
     DG.Aggregate.graded_trade =
   let max_horizon =
@@ -222,7 +258,7 @@ let _grade_row ~bar_reader ~mfe_lookup ~exit_reason_lookup ~horizons
   let realized_pnl_pct = row.pnl_percent /. _pct_scale in
   let entry_capture_ratio =
     Option.bind
-      (Hashtbl.find mfe_lookup (row.symbol, row.entry_date))
+      (_find_mfe mfe_index ~symbol:row.symbol ~entry_date:row.entry_date)
       ~f:(fun mfe ->
         DG.Grade.entry_capture_ratio ~realized_pnl_pct ~max_favorable_pct:mfe)
   in
@@ -275,14 +311,14 @@ let () =
   in
   let report = TAR.load ~scenario_dir in
   let bar_reader = _bar_reader_of_snapshot ~snapshot_dir in
-  let mfe_lookup = _mfe_lookup report in
+  let mfe_index = _mfe_index ~scenario_dir in
   let exit_reason_lookup = _exit_reason_lookup ~scenario_dir in
   eprintf "decision_grading: grading %d round-trips from %s\n%!"
     (List.length report.rows) scenario_dir;
   let graded =
     List.map report.rows
       ~f:
-        (_grade_row ~bar_reader ~mfe_lookup ~exit_reason_lookup ~horizons
+        (_grade_row ~bar_reader ~mfe_index ~exit_reason_lookup ~horizons
            ~grade_config ~grade_horizon)
   in
   let groups = DG.Aggregate.aggregate_by_exit_reason graded in

--- a/trading/trading/backtest/decision_grading/bin/dune
+++ b/trading/trading/backtest/decision_grading/bin/dune
@@ -3,7 +3,9 @@
  (modules decision_grading_bin)
  (libraries
   core
+  core_unix.sys_unix
   status
+  backtest
   decision_grading
   trade_audit_report
   trading.base


### PR DESCRIPTION
## What & why
Follow-up to #1649. The Phase-4 CLI read per-trade MFE via `Trade_audit_report`'s ratings, keyed by the **audit** `entry_date` (the Friday decision date) — which is ~1 day off the round-trip's `trades.csv` `entry_date` (the fill date). So the `(symbol, entry_date)` join always missed and the **capture-ratio column rendered `n/a` for every group**, on every run (not just the old MFE=0 run #1649 was smoke-tested on).

**Fix:** read `exit_decision.max_favorable_excursion_pct` straight from `trade_audit.sexp` and join each round-trip to its audit record by **nearest `entry_date` within 7 days** — the same tolerance `Trade_audit_ratings` itself uses for this exact skew. Adds `backtest` + `core_unix.sys_unix` deps.

## Verification — first complete report
Fresh post-#1506 Cell-E top-3000 PIT-2011 run (15y, reproduces +790.5% / 671 trades / 29.2% MaxDD bit-identical). Capture now populates:

| exit_reason | n | mean realized | post-exit cont. | net value-add | capture |
|---|---|---|---|---|---|
| laggard_rotation | 220 | +12.8% | −1.6% | +1.6% | −0.09 |
| stage3_force_exit | 5 | +5.5% | −9.4% | +9.4% | −0.90 |
| stop_loss | 440 | −2.8% | +8.1% | **−8.1%** | **−2.83** |

Decision-level read: stops are the value-destroying decision type (price recovers +8.1% after the stop; capture −2.83 = gave back the peak and then some — the whipsaw premium); laggard-rotation is net-positive and houses the fat-tail winners; stage3 dodges drops (small n). Re-derives `trade-forensics-2026-06-12` as a repeatable instrument. Full interpretation + caveats: `dev/experiments/decision-grading-first-report-2026-06-18/FINDINGS.md`.

## Test plan
- `dune build` + `dune runtest` clean (lib unit tests unchanged — the fix is in the I/O bin, which is exercised by the end-to-end run above).
- Read-only analysis lens; no strategy behaviour change. Mixed code+docs PR → full QC gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)