### PR TITLE
feat(decision-grading): insurance decomposition — disaster-dodged vs upside-foregone

### DIFF
--- a/dev/experiments/decision-grading-deep-2026-06-18/FINDINGS.md
+++ b/dev/experiments/decision-grading-deep-2026-06-18/FINDINGS.md
@@ -1,0 +1,98 @@
+# Decision-grading — deep multi-regime read + the stop-insurance question (2026-06-18)
+
+Follow-on to `dev/experiments/decision-grading-first-report-2026-06-18/`. Two things:
+1. Upgraded the lens to **decompose the exit's net continuation into its benefit
+   (disaster dodged = post-exit max-adverse) and cost (upside foregone =
+   post-exit max-favorable)** — the mean-continuation number alone can't tell a
+   pure tax from cheap insurance.
+2. Ran it across two regimes to answer: **does stop-loss earn its keep by
+   avoiding disasters?**
+
+Runs (same Cell-E config, only the window differs):
+- **2011-26 bull** — top-3000 PIT-2011, `/tmp/snap_top3000_2011_v2`, +790.5% / 671 trades / 29.2% MaxDD.
+- **1998-26 deep** — top-3000 PIT-1998 (adds dot-com bust + GFC), `/tmp/snap_top3000_1998_2026_v2`, +1934.5% / 1061 trades / 48.7% MaxDD.
+
+Grade horizon 26w (the longer horizon captures more of the avoided decline than 13w; deep disasters still run past 26w, so the benefit below is if anything *under*-counted).
+
+## The stop-loss decision, both regimes (grade horizon 26w)
+
+| metric | 2011-26 bull | 1998-26 deep |
+|---|---|---|
+| n stops | 440 | 746 |
+| mean realized | −2.8% | −1.2% |
+| mean disaster dodged (max-adverse) | −18.9% | −19.5% |
+| mean upside foregone (max-favorable) | +32.7% | +29.9% |
+| mean post-exit continuation | +9.4% | +6.2% |
+| **mean net value-add (= −cont)** | **−9.4%** | **−6.2%** |
+| disaster-dodge rate (≤−20% drop dodged) | 40% | 36% |
+| continuation p10 / p90 | −24.5% / +36.4% | −29.5% / +41.4% |
+
+### Answer to "did we grade the disaster-avoidance benefit?"
+
+Now yes. And the answer is nuanced:
+
+- **Stops do avoid real disasters, regime-robustly.** ~36-40% of stops sat out a
+  ≥20% further drop; the average stopped name fell ~−19% below the exit at its
+  worst over the next 26 weeks (p10 −24% to −30%). The insurance is real, not
+  imagined.
+- **But the per-decision opportunity cost exceeds the per-decision benefit in
+  BOTH regimes.** Net value-add is −9.4% (bull) / −6.2% (deep): on average,
+  holding 26 more weeks would have beaten stopping. The benefit (−19% dodged) is
+  outweighed by the upside foregone (+30-33%), because broad-universe names
+  *recover* — the stop mostly fires on temporary dips, not permanent losses.
+- **The bear-heavy regime narrows the gap but does NOT flip it** (−9.4% → −6.2%).
+  Dot-com+GFC makes more of the dodged drops "stick," so stops look better than
+  in a pure bull tape — but the fat-tail recovery still dominates the mean. This
+  re-derives `project_edge_is_the_fat_tail` from the exit side: the broad-universe
+  return is the right-tail recoverers, and a stop taxes them.
+
+## The load-bearing caveat — why this is NOT "remove/loosen stops"
+
+The lens measures **per-decision, equal-weight** opportunity cost. It is blind to
+the **portfolio-path** role of a stop: capping one position's loss so a single
+Stage-4 collapse can't take the whole NAV down. "Stops cost −6.2% per decision on
+average" says nothing about the left tail of the *portfolio* return, which is the
+actual reason stops exist. A per-trade equal-weight mean cannot price portfolio
+ruin-avoidance. So:
+
+- **Do NOT conclude "remove stops."** That changes the portfolio left tail this
+  lens does not observe. It is a winner-/risk-touching strategy mechanic →
+  `weinstein-faithful-core` (stop-below-base is spine item #5; only the *buffer*
+  is a dial) + `experiment-flag-discipline` + WF-CV + the confirmation grid.
+- **"Tune stops better" is a legitimate but low-priority hypothesis.** The
+  decomposition says stops fire on recoverers (whipsaw-dominated), so a *looser/
+  later* stop or a *post-stop re-entry* would recapture foregone upside. But
+  stop-distance is already tuned (`installed_stop_min_pct = 0.08`, axis-1 winner)
+  — expected marginal gain is small, and it touches the spine. Per
+  `project_accuracy_is_unreachable_diversify_instead`, the better use of effort is
+  a *diversifying layer* (long-short), not more exit-tuning.
+
+## Other decision types (deep, 26w)
+
+| exit_reason | n | mean realized | net value-add | disaster dodged | upside foregone | dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 296 | +16.9% | −4.7% | −15.9% | +21.6% | 29% |
+| stage3_force_exit | 16 | +0.1% | +2.2% | −22.0% | +14.0% | 38% |
+| stop_loss | 746 | −1.2% | −6.2% | −19.5% | +29.9% | 36% |
+
+- **laggard_rotation** still houses the fat-tail winners (mean realized +16.9%);
+  its net value-add went slightly negative deep (−4.7%) — rotating out of names
+  that then ran — but it remains the profit channel by realized P&L.
+- **stage3_force_exit** is the only net-positive exit decision (+2.2%), with the
+  largest mean disaster dodged (−22.0%) and smallest upside foregone (+14.0%) —
+  i.e. it fires on genuine Stage-3 tops that roll over, exactly as intended.
+  Small n (16) but directionally Weinstein-faithful and the cleanest "good exit"
+  in the book.
+
+## Forward guidance (the transferable why)
+
+1. The strategy's edge is the right-tail recoverers; **every winner-touching exit
+   taxes it**, which is why stops and laggard-rotation both show negative
+   per-decision net value-add. stage3_force_exit is the exception because it
+   targets the *left*-tail rollovers specifically.
+2. **Stop-tuning is near-exhausted and spine-constrained** — deprioritize.
+3. **Bias the next lever to a diversifying layer (long-short, Initiative B)** that
+   adds an offsetting return stream rather than re-touching the long exits.
+4. Lens limitation to fix if exits become the focus: add a **portfolio-path /
+   ruin-weighted** exit metric so the stop's true (tail-insurance) value is
+   measurable, not just the per-decision opportunity cost.

--- a/dev/experiments/decision-grading-deep-2026-06-18/grade-deep-26w.md
+++ b/dev/experiments/decision-grading-deep-2026-06-18/grade-deep-26w.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-top3000-1998-deep
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 1061 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 296 | +16.9% | +4.7% | 36% | 27% | -4.7% | -0.68 |
+| stage3_force_exit | 16 | +0.1% | -2.2% | 12% | 19% | +2.2% | -4.48 |
+| stop_loss | 746 | -1.2% | +6.2% | 36% | 30% | -6.2% | -3.64 |
+| unlabeled | 3 | -3.9% | +5.0% | 33% | 33% | -5.0% | -15.87 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 296 | -15.9% | +21.6% | -26.9% | +36.0% | 29% |
+| stage3_force_exit | 16 | -22.0% | +14.0% | -15.0% | +11.3% | 38% |
+| stop_loss | 746 | -19.5% | +29.9% | -29.5% | +41.4% | 36% |
+| unlabeled | 3 | -11.2% | +19.7% | -14.0% | +28.2% | 0% |

--- a/dev/experiments/decision-grading-deep-2026-06-18/scenario.sexp
+++ b/dev/experiments/decision-grading-deep-2026-06-18/scenario.sexp
@@ -1,0 +1,20 @@
+;; Cell-E top-3000 PIT-1998, 28y contiguous (1998-2026) — fresh run emitting
+;; trade_audit.sexp (MFE populated) for the decision-grading deep multi-regime
+;; read. Same config + cost model as the 2011 fresh run, so the two grades are
+;; apples-to-apples; only the window (adds dot-com bust + GFC) differs.
+((name "cell-e-top3000-1998-deep")
+ (description "Cell-E top-3000 PIT-1998, 28y contiguous, for decision-grading deep read.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 1000000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/trading/trading/backtest/decision_grading/bin/decision_grading_bin.ml
+++ b/trading/trading/backtest/decision_grading/bin/decision_grading_bin.ml
@@ -231,12 +231,11 @@ let _find_mfe mfe_index ~symbol ~entry_date =
       |> List.min_elt ~compare:(fun (g1, _) (g2, _) -> Int.compare g1 g2)
       |> Option.map ~f:snd
 
-(** Continuation at [grade_horizon] from a post-exit result list, or [0.0] when
-    that horizon is absent. *)
-let _continuation_at ~grade_horizon post_exit =
-  List.find_map post_exit ~f:(fun (h : DG.Post_exit.horizon_result) ->
-      if h.horizon_weeks = grade_horizon then Some h.continuation_pct else None)
-  |> Option.value ~default:0.0
+(** The {!DG.Post_exit.horizon_result} at [grade_horizon], or [None] when that
+    horizon was not computed. *)
+let _result_at ~grade_horizon post_exit =
+  List.find post_exit ~f:(fun (h : DG.Post_exit.horizon_result) ->
+      h.horizon_weeks = grade_horizon)
 
 (** Grade one round-trip row into a {!DG.Aggregate.graded_trade}. *)
 let _grade_row ~bar_reader ~mfe_index ~exit_reason_lookup ~horizons
@@ -269,12 +268,18 @@ let _grade_row ~bar_reader ~mfe_index ~exit_reason_lookup ~horizons
   let exit_reason =
     if String.is_empty exit_reason then "unlabeled" else exit_reason
   in
+  let at_grade = _result_at ~grade_horizon post_exit in
+  let field f = Option.value_map at_grade ~default:0.0 ~f in
   {
     DG.Aggregate.exit_reason;
     realized_pnl_pct;
-    continuation_pct = _continuation_at ~grade_horizon post_exit;
+    continuation_pct = field (fun h -> h.DG.Post_exit.continuation_pct);
     exit_grade = DG.Grade.grade_exit ~config:grade_config ~post_exit;
     entry_capture_ratio;
+    post_exit_max_adverse_pct =
+      field (fun h -> h.DG.Post_exit.post_exit_max_adverse_pct);
+    post_exit_max_favorable_pct =
+      field (fun h -> h.DG.Post_exit.post_exit_max_favorable_pct);
   }
 
 let _header (report : TAR.t) ~grade_horizon ~n =

--- a/trading/trading/backtest/decision_grading/lib/aggregate.ml
+++ b/trading/trading/backtest/decision_grading/lib/aggregate.ml
@@ -8,6 +8,8 @@ type graded_trade = {
   continuation_pct : float;
   exit_grade : Grade.exit_grade;
   entry_capture_ratio : float option;
+  post_exit_max_adverse_pct : float;
+  post_exit_max_favorable_pct : float;
 }
 [@@deriving show, eq, sexp]
 
@@ -20,8 +22,15 @@ type group_stats = {
   pct_good_exit : float;
   mean_net_value_add_pct : float;
   mean_entry_capture_ratio : float option;
+  mean_post_exit_max_adverse_pct : float;
+  mean_post_exit_max_favorable_pct : float;
+  continuation_p10 : float;
+  continuation_p90 : float;
+  disaster_dodge_rate : float;
 }
 [@@deriving show, eq, sexp]
+
+let default_disaster_threshold_pct = -0.20
 
 (** Arithmetic mean of [xs], or [0.0] for an empty list. *)
 let _mean xs =
@@ -44,14 +53,33 @@ let _fraction_graded trades ~grade =
     in
     Float.of_int matching /. Float.of_int n
 
+(** Nearest-rank [p]-th percentile (p in [[0,1]]) of [xs], or [0.0] when empty.
+    Sorts ascending and reads index [round (p *. (n-1))]. *)
+let _percentile ~p xs =
+  match List.sort xs ~compare:Float.compare with
+  | [] -> 0.0
+  | sorted ->
+      let n = List.length sorted in
+      let idx =
+        Float.round_nearest (p *. Float.of_int (n - 1)) |> Float.to_int
+      in
+      let idx = Int.max 0 (Int.min (n - 1) idx) in
+      List.nth_exn sorted idx
+
 (** Aggregate one non-empty group sharing [exit_reason]. *)
-let _stats_of_group ~exit_reason trades =
+let _stats_of_group ~exit_reason ~disaster_threshold_pct trades =
   let mean_continuation_pct =
     _mean (List.map trades ~f:(fun t -> t.continuation_pct))
   in
+  let continuations = List.map trades ~f:(fun t -> t.continuation_pct) in
+  let n = List.length trades in
+  let n_dodged =
+    List.count trades ~f:(fun t ->
+        Float.( <= ) t.post_exit_max_adverse_pct disaster_threshold_pct)
+  in
   {
     exit_reason;
-    n = List.length trades;
+    n;
     mean_realized_pnl_pct =
       _mean (List.map trades ~f:(fun t -> t.realized_pnl_pct));
     mean_continuation_pct;
@@ -62,16 +90,26 @@ let _stats_of_group ~exit_reason trades =
     mean_net_value_add_pct = -.mean_continuation_pct;
     mean_entry_capture_ratio =
       _mean_opt (List.map trades ~f:(fun t -> t.entry_capture_ratio));
+    mean_post_exit_max_adverse_pct =
+      _mean (List.map trades ~f:(fun t -> t.post_exit_max_adverse_pct));
+    mean_post_exit_max_favorable_pct =
+      _mean (List.map trades ~f:(fun t -> t.post_exit_max_favorable_pct));
+    continuation_p10 = _percentile ~p:0.10 continuations;
+    continuation_p90 = _percentile ~p:0.90 continuations;
+    disaster_dodge_rate = Float.of_int n_dodged /. Float.of_int n;
   }
 
-let aggregate_by_exit_reason trades =
+let aggregate_by_exit_reason
+    ?(disaster_threshold_pct = default_disaster_threshold_pct) trades =
   trades
   |> List.sort_and_group ~compare:(fun (a : graded_trade) (b : graded_trade) ->
       String.compare a.exit_reason b.exit_reason)
   |> List.filter_map ~f:(function
     | [] -> None
     | (first : graded_trade) :: _ as group ->
-        Some (_stats_of_group ~exit_reason:first.exit_reason group))
+        Some
+          (_stats_of_group ~exit_reason:first.exit_reason
+             ~disaster_threshold_pct group))
 
 (** A float formatted as a signed percentage with one decimal, e.g. ["+12.3%"].
 *)
@@ -81,9 +119,12 @@ let _pct1 x = Printf.sprintf "%+.1f%%" (x *. 100.0)
 *)
 let _ratio_cell = function None -> "n/a" | Some r -> Printf.sprintf "%.2f" r
 
-let to_markdown groups =
+(** Value/grade table: realized, net opportunity cost vs hold, grade split,
+    capture. *)
+let _value_table groups =
   let header =
-    "| exit_reason | n | mean realized | mean post-exit cont. | % premature | \
+    "### Exit value vs hold-counterfactual\n\n\
+     | exit_reason | n | mean realized | mean post-exit cont. | % premature | \
      % good exit | mean net value-add | mean capture |\n\
      |---|---|---|---|---|---|---|---|\n"
   in
@@ -97,3 +138,24 @@ let to_markdown groups =
       (_ratio_cell g.mean_entry_capture_ratio)
   in
   header ^ String.concat (List.map groups ~f:row)
+
+(** Insurance table: the benefit (disaster dodged) vs cost (upside foregone)
+    decomposition the mean continuation hides, plus the continuation tails. *)
+let _insurance_table groups =
+  let header =
+    "### Disaster-avoidance vs upside-foregone (the insurance decomposition)\n\n\
+     | exit_reason | n | mean disaster dodged | mean upside foregone | cont \
+     p10 | cont p90 | disaster-dodge rate |\n\
+     |---|---|---|---|---|---|---|\n"
+  in
+  let row g =
+    Printf.sprintf "| %s | %d | %s | %s | %s | %s | %.0f%% |\n" g.exit_reason
+      g.n
+      (_pct1 g.mean_post_exit_max_adverse_pct)
+      (_pct1 g.mean_post_exit_max_favorable_pct)
+      (_pct1 g.continuation_p10) (_pct1 g.continuation_p90)
+      (g.disaster_dodge_rate *. 100.0)
+  in
+  header ^ String.concat (List.map groups ~f:row)
+
+let to_markdown groups = _value_table groups ^ "\n" ^ _insurance_table groups

--- a/trading/trading/backtest/decision_grading/lib/aggregate.ml
+++ b/trading/trading/backtest/decision_grading/lib/aggregate.ml
@@ -32,6 +32,12 @@ type group_stats = {
 
 let default_disaster_threshold_pct = -0.20
 
+(** Lower-tail quantile for the post-exit continuation distribution. *)
+let _continuation_p10_quantile = 0.10
+
+(** Upper-tail quantile for the post-exit continuation distribution. *)
+let _continuation_p90_quantile = 0.90
+
 (** Arithmetic mean of [xs], or [0.0] for an empty list. *)
 let _mean xs =
   match xs with
@@ -94,22 +100,26 @@ let _stats_of_group ~exit_reason ~disaster_threshold_pct trades =
       _mean (List.map trades ~f:(fun t -> t.post_exit_max_adverse_pct));
     mean_post_exit_max_favorable_pct =
       _mean (List.map trades ~f:(fun t -> t.post_exit_max_favorable_pct));
-    continuation_p10 = _percentile ~p:0.10 continuations;
-    continuation_p90 = _percentile ~p:0.90 continuations;
+    continuation_p10 = _percentile ~p:_continuation_p10_quantile continuations;
+    continuation_p90 = _percentile ~p:_continuation_p90_quantile continuations;
     disaster_dodge_rate = Float.of_int n_dodged /. Float.of_int n;
   }
+
+(** Reduce one same-[exit_reason] group to its [group_stats], skipping empties.
+*)
+let _group_to_stats ~disaster_threshold_pct = function
+  | [] -> None
+  | (first : graded_trade) :: _ as group ->
+      Some
+        (_stats_of_group ~exit_reason:first.exit_reason ~disaster_threshold_pct
+           group)
 
 let aggregate_by_exit_reason
     ?(disaster_threshold_pct = default_disaster_threshold_pct) trades =
   trades
   |> List.sort_and_group ~compare:(fun (a : graded_trade) (b : graded_trade) ->
       String.compare a.exit_reason b.exit_reason)
-  |> List.filter_map ~f:(function
-    | [] -> None
-    | (first : graded_trade) :: _ as group ->
-        Some
-          (_stats_of_group ~exit_reason:first.exit_reason
-             ~disaster_threshold_pct group))
+  |> List.filter_map ~f:(_group_to_stats ~disaster_threshold_pct)
 
 (** A float formatted as a signed percentage with one decimal, e.g. ["+12.3%"].
 *)

--- a/trading/trading/backtest/decision_grading/lib/aggregate.mli
+++ b/trading/trading/backtest/decision_grading/lib/aggregate.mli
@@ -36,9 +36,27 @@ type graded_trade = {
   entry_capture_ratio : float option;
       (** {!Grade.entry_capture_ratio} for the trade — fraction of in-trade peak
           gain realized. [None] when the trade never showed an in-trade gain. *)
+  post_exit_max_adverse_pct : float;
+      (** Worst move {b against} the trade after the exit, at the grade horizon
+          ({!Post_exit.horizon_result.post_exit_max_adverse_pct}). For a long
+          this is how far price fell {b below} the exit — i.e.
+          {b the disaster dodged by being out} (typically [<= 0.0]). The benefit
+          side of a stop: a large negative value is a deep decline we sat out.
+      *)
+  post_exit_max_favorable_pct : float;
+      (** Best move {b in} the trade's direction after the exit, at the grade
+          horizon ({!Post_exit.horizon_result.post_exit_max_favorable_pct}). The
+          {b upside foregone} by exiting (typically [>= 0.0]). The cost side of
+          a stop: a large positive value is a recovery/run we missed. *)
 }
 [@@deriving show, eq, sexp]
-(** One graded round-trip, the unit of aggregation. *)
+(** One graded round-trip, the unit of aggregation.
+
+    [continuation_pct] is the {b net} post-exit move (favorable minus adverse,
+    realized at the horizon close); [post_exit_max_adverse_pct] and
+    [post_exit_max_favorable_pct] split that net into the {b benefit} (disaster
+    dodged) and {b cost} (upside foregone) of the exit — the decomposition the
+    mean continuation alone hides. *)
 
 type group_stats = {
   exit_reason : string;  (** The reason all trades in this group share. *)
@@ -65,14 +83,50 @@ type group_stats = {
       (** Mean {!graded_trade.entry_capture_ratio} over the trades in the group
           that have [Some] ratio. [None] when {b no} trade in the group has a
           defined ratio (none ever showed an in-trade gain). *)
+  mean_post_exit_max_adverse_pct : float;
+      (** Mean {!graded_trade.post_exit_max_adverse_pct} — the
+          {b average disaster dodged} by exits in this group. For [stop_loss]
+          this is the benefit side of the stop: how far the average stopped name
+          fell after we were out. *)
+  mean_post_exit_max_favorable_pct : float;
+      (** Mean {!graded_trade.post_exit_max_favorable_pct} — the
+          {b average upside foregone} by exits in this group (the whipsaw/cost
+          side). *)
+  continuation_p10 : float;
+      (** 10th-percentile {!graded_trade.continuation_pct} in the group
+          (nearest- rank). The left tail: the most-adverse-continuation exits —
+          for a stop, the disasters it sat out (continuation deeply negative).
+          [0.0] for an empty group. *)
+  continuation_p90 : float;
+      (** 90th-percentile {!graded_trade.continuation_pct} (nearest-rank). The
+          right tail: the biggest runs given up by exiting. [0.0] for an empty
+          group. *)
+  disaster_dodge_rate : float;
+      (** Fraction of the group whose {!graded_trade.post_exit_max_adverse_pct}
+          is at or below the [disaster_threshold_pct] passed to
+          {!aggregate_by_exit_reason} — i.e. the share of exits that sat out a
+          drop of at least that magnitude. In [[0.0, 1.0]]. This is the
+          {b frequency} of disaster-avoidance, complementing the magnitude in
+          [mean_post_exit_max_adverse_pct]. *)
 }
 [@@deriving show, eq, sexp]
 (** Aggregate statistics for one exit-reason group. *)
 
-val aggregate_by_exit_reason : graded_trade list -> group_stats list
-(** [aggregate_by_exit_reason trades] partitions [trades] by
-    {!graded_trade.exit_reason} and computes one {!group_stats} per distinct
-    reason.
+val default_disaster_threshold_pct : float
+(** [-0.20] — the default cutoff for {!group_stats.disaster_dodge_rate}: a
+    post-exit drop of 20% or more (as a fraction of exit price) counts as a
+    disaster dodged. *)
+
+val aggregate_by_exit_reason :
+  ?disaster_threshold_pct:float -> graded_trade list -> group_stats list
+(** [aggregate_by_exit_reason ?disaster_threshold_pct trades] partitions
+    [trades] by {!graded_trade.exit_reason} and computes one {!group_stats} per
+    distinct reason.
+
+    [disaster_threshold_pct] (default {!default_disaster_threshold_pct}) is the
+    [post_exit_max_adverse_pct] cutoff at or below which an exit counts toward
+    {!group_stats.disaster_dodge_rate}. Expressed as a {b signed} fraction (e.g.
+    [-0.20]); a trade counts when its [post_exit_max_adverse_pct <=] this value.
 
     The result is sorted by [exit_reason] ascending for deterministic output.
     Empty input -> empty output. Every emitted group has [n >= 1]. Pure: same

--- a/trading/trading/backtest/decision_grading/test/test_aggregate.ml
+++ b/trading/trading/backtest/decision_grading/test/test_aggregate.ml
@@ -1,3 +1,4 @@
+open Core
 open OUnit2
 open Matchers
 module A = Decision_grading.Aggregate
@@ -6,13 +7,16 @@ module G = Decision_grading.Grade
 (* A graded_trade with sensible defaults; override only what a test cares about. *)
 let trade ?(exit_reason = "stop_loss") ?(realized_pnl_pct = 0.0)
     ?(continuation_pct = 0.0) ?(exit_grade = G.Neutral)
-    ?(entry_capture_ratio = None) () =
+    ?(entry_capture_ratio = None) ?(post_exit_max_adverse_pct = 0.0)
+    ?(post_exit_max_favorable_pct = 0.0) () =
   {
     A.exit_reason;
     realized_pnl_pct;
     continuation_pct;
     exit_grade;
     entry_capture_ratio;
+    post_exit_max_adverse_pct;
+    post_exit_max_favorable_pct;
   }
 
 (* Empty input -> empty output. *)
@@ -95,7 +99,76 @@ let test_capture_ratio_mixed _ =
            (is_some_and (float_equal 0.5));
        ])
 
-(* markdown: header + one row per group, in the order given. *)
+(* Insurance decomposition: mean disaster-dodged (max_adverse) + mean upside-
+   foregone (max_favorable) are the group means of those fields. Two trades with
+   adverse -0.40 / -0.10 and favorable +0.05 / +0.15 → means -0.25 / +0.10. *)
+let test_insurance_means _ =
+  let trades =
+    [
+      trade ~post_exit_max_adverse_pct:(-0.40) ~post_exit_max_favorable_pct:0.05
+        ();
+      trade ~post_exit_max_adverse_pct:(-0.10) ~post_exit_max_favorable_pct:0.15
+        ();
+    ]
+  in
+  assert_that
+    (A.aggregate_by_exit_reason trades)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun g -> g.A.mean_post_exit_max_adverse_pct)
+               (float_equal (-0.25));
+             field
+               (fun g -> g.A.mean_post_exit_max_favorable_pct)
+               (float_equal 0.10);
+           ];
+       ])
+
+(* disaster_dodge_rate counts trades with max_adverse <= threshold. Default
+   threshold -0.20: of adverse {-0.40,-0.25,-0.10,-0.05}, two clear it → 0.5. *)
+let test_disaster_dodge_rate_default _ =
+  let trades =
+    List.map [ -0.40; -0.25; -0.10; -0.05 ] ~f:(fun a ->
+        trade ~post_exit_max_adverse_pct:a ())
+  in
+  assert_that
+    (A.aggregate_by_exit_reason trades)
+    (elements_are
+       [ field (fun g -> g.A.disaster_dodge_rate) (float_equal 0.5) ])
+
+(* Custom (tighter) threshold -0.30: only -0.40 clears → 0.25. Boundary is
+   inclusive (<=), so exactly -0.30 would also count. *)
+let test_disaster_dodge_rate_custom _ =
+  let trades =
+    List.map [ -0.40; -0.25; -0.10; -0.05 ] ~f:(fun a ->
+        trade ~post_exit_max_adverse_pct:a ())
+  in
+  assert_that
+    (A.aggregate_by_exit_reason ~disaster_threshold_pct:(-0.30) trades)
+    (elements_are
+       [ field (fun g -> g.A.disaster_dodge_rate) (float_equal 0.25) ])
+
+(* Continuation p10/p90 (nearest-rank). For continuations 0.0..1.0 in 0.1 steps
+   (11 values), p10 = index round(0.1*10)=1 → 0.1; p90 = index 9 → 0.9. *)
+let test_continuation_percentiles _ =
+  let trades =
+    List.init 11 ~f:(fun i ->
+        trade ~continuation_pct:(Float.of_int i /. 10.0) ())
+  in
+  assert_that
+    (A.aggregate_by_exit_reason trades)
+    (elements_are
+       [
+         all_of
+           [
+             field (fun g -> g.A.continuation_p10) (float_equal 0.1);
+             field (fun g -> g.A.continuation_p90) (float_equal 0.9);
+           ];
+       ])
+
+(* markdown: both tables present, one row per group per table. *)
 let test_to_markdown _ =
   let groups =
     A.aggregate_by_exit_reason [ trade ~exit_reason:"stop_loss" () ]
@@ -104,7 +177,8 @@ let test_to_markdown _ =
   assert_that md
     (all_of
        [
-         contains_substring "| exit_reason | n |";
+         contains_substring "Exit value vs hold-counterfactual";
+         contains_substring "Disaster-avoidance vs upside-foregone";
          contains_substring "| stop_loss | 1 |";
        ])
 
@@ -116,6 +190,10 @@ let suite =
          "group_stats" >:: test_group_stats;
          "capture_ratio_all_none" >:: test_capture_ratio_all_none;
          "capture_ratio_mixed" >:: test_capture_ratio_mixed;
+         "insurance_means" >:: test_insurance_means;
+         "disaster_dodge_rate_default" >:: test_disaster_dodge_rate_default;
+         "disaster_dodge_rate_custom" >:: test_disaster_dodge_rate_custom;
+         "continuation_percentiles" >:: test_continuation_percentiles;
          "to_markdown" >:: test_to_markdown;
        ]
 


### PR DESCRIPTION
## What & why
Follow-up to #1649/#1650. The exit lens reported only **mean post-exit continuation** — which nets a stop's *benefit* (disaster dodged) against its *cost* (upside foregone) into one number, so it can't tell cheap insurance from a pure tax. This decomposes it.

Per exit_reason, `Aggregate` now also surfaces:
- **mean disaster dodged** (`post_exit_max_adverse_pct` — how far price fell after exit),
- **mean upside foregone** (`post_exit_max_favorable_pct` — the run given up),
- **continuation p10 / p90** (the tails),
- **disaster-dodge rate** (% of exits that sat out a ≥20% drop; threshold configurable via `?disaster_threshold_pct`).

`to_markdown` now emits two tables (value-vs-hold + insurance decomposition). Lens-only change (Aggregate lib + the bin that populates the two new fields from `Post_exit`); read-only, no strategy behaviour change.

## Answering 'do stops earn their keep by avoiding disasters?' — deep multi-regime read
Two fresh runs, same Cell-E config, only the window differs (grade horizon 26w). Full writeup: `dev/experiments/decision-grading-deep-2026-06-18/FINDINGS.md`.

**stop_loss:**
| | disaster dodged | upside foregone | net value-add | dodge rate |
|---|---|---|---|---|
| 2011-26 bull | −18.9% | +32.7% | −9.4% | 40% |
| 1998-26 deep (dot-com+GFC) | −19.5% | +29.9% | −6.2% | 36% |

Stops **do** avoid real drops, regime-robustly (≈36-40% dodge a ≥20% decline; ≈−19% mean). But per-decision **upside-foregone exceeds it in both regimes** — broad-universe names recover (the fat-tail thesis). The bear-heavy window narrows the gap (−9.4→−6.2%) but never flips it positive.

**Key caveat (in the writeup):** this is a *per-decision, equal-weight* opportunity cost — blind to the *portfolio-path* ruin-insurance a stop provides (capping one position so a Stage-4 collapse can't sink the NAV). So this is **NOT** a remove-stops verdict; that's a winner/risk-touching spine change → WF-CV + confirmation grid. Stop-distance is already tuned (`installed_stop_min_pct=0.08`); forward guidance is to bias to a *diversifying layer* (long-short) over more exit-tuning.

## Test plan
- `dune build` + `dune runtest` clean; 10 `Aggregate` unit tests (4 new: insurance means, disaster-dodge rate default+custom threshold, continuation percentiles).
- Bin verified end-to-end on both runs (tables above).

Mixed code+docs PR → full QC gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)