### PR TITLE
feat(decision-grading): Phase 5 — laggard-rotation paired counterfactual

### DIFF
--- a/dev/experiments/decision-grading-phase5-2026-06-18/FINDINGS.md
+++ b/dev/experiments/decision-grading-phase5-2026-06-18/FINDINGS.md
@@ -1,0 +1,75 @@
+# Phase 5 — did laggard-rotation pay? (paired counterfactual, 2026-06-18)
+
+Phase 5 of the decision-grading lens. Laggard-rotation sells a lagging name to
+free cash for the same-tick entry walk. The lens's per-decision view
+(`decision-grading-deep-2026-06-18`) showed laggard exits have high mean realized
+P&L (+12.8-16.9%) but slightly-negative net-value-add vs holding. Phase 5 asks
+the sharper question the swap actually poses: **did the names we bought with the
+freed cash beat the laggard we sold?**
+
+No 1:1 sold→bought link exists (the runner frees cash into a pool the entry walk
+draws from — `laggard_rotation_runner.mli`). So the pairing is per-event cohort:
+each rotation exit vs the new entries opened within a 10-day allocation window
+after it; both sides' forward return is the `Post_exit` continuation over the
+same horizon. Tool: `Decision_grading.Laggard_cf` + `laggard_cf` bin.
+
+## Result
+
+**1998-2026 deep (multi-regime, 296 events, 260 with redeployment):**
+
+| horizon | mean dumped fwd | mean funded fwd | mean paired diff | % paid | diff p10/p50/p90 |
+|---|---|---|---|---|---|
+| 4w | +1.0% | +0.7% | −0.3% | 53% | −16.5 / +0.8 / +12.7 |
+| 13w | +2.5% | +3.8% | +1.3% | 50% | −21.4 / −0.1 / +25.4 |
+| 26w | +5.2% | +6.0% | +0.8% | 51% | −39.4 / +1.0 / +35.7 |
+
+**2011-2026 bull (220 events, 198 with redeployment):**
+
+| horizon | mean paired diff | % paid | diff p10/p50/p90 |
+|---|---|---|---|
+| 13w | +5.6% | 57% | −20.8 / +3.1 / +30.3 |
+| 26w | +6.0% | 56% | −32.4 / +3.9 / +43.2 |
+
+## Verdict — the swap is a coin flip; the value is recycling, not selection
+
+- **Per-swap, laggard-rotation is ≈ a coin flip with a thin positive mean.**
+  Across the full multi-regime window the funded cohort beats the dumped laggard
+  only ~50-53% of the time, mean paired diff ≈ +1% over a quarter, with huge
+  dispersion (p10 −20 to −39%, p90 +13 to +36%). In the bull-only window it pays
+  more (+5-6%, 56-57%) — i.e. the modest edge is regime-dependent (fresher names
+  run in a bull tape) and **evaporates once dot-com+GFC are included**.
+- **This re-derives the harvest-rotate rejection** (`project_harvest_rotate_rejected`:
+  "per-event rotation diff ≈ coin flip with fat-left tail") from the *realized*
+  laggard mechanism — independent confirmation, not the same data.
+- **Reconciliation with "laggard = profit engine":** the +12.8-16.9% mean realized
+  of laggard-exited trades is the gain those names had *already accumulated*
+  before stalling; rotation harvests it and keeps capital deployed. The rotation
+  *decision* (which name to swap into) adds ~nothing reliable on top. So
+  laggard-rotation's value is **capital-recycling / freshness** — not letting
+  capital rot in dead names, staying in the fat-tail game — **not** swap
+  selection.
+
+## Forward guidance (transferable why)
+
+1. **Do not tune the rotation selection** (which laggard, when, into what). It is
+   a coin flip per event; the same fat-tail-unpredictability that kills
+   entry-selection (`project_accuracy_is_unreachable_diversify_instead`) and
+   harvest-rotate kills swap-selection. Expected marginal gain ≈ 0.
+2. **Keep laggard-rotation on** — it is roughly neutral-to-positive per swap and
+   its recycling role is real; it is not a tax (unlike the stop's per-decision
+   whipsaw cost). This is the third winner-touching mechanism confirmed as
+   "neutral selection, value is elsewhere," tightening `project_edge_is_the_fat_tail`.
+3. **Bias the next lever to a diversifying layer (long-short, Initiative B)** — an
+   offsetting return stream — over any more entry/exit/rotation selection tuning.
+
+## Caveats (per `mechanism-validation-rigor`)
+
+- Cohort pairing, not strict 1:1 (no engine link exists); an entry may fund more
+  than one rotation event (shared pool). The paired diff is per rotation event vs
+  the redeployment pool available to it — the faithful proxy, not a controlled
+  swap.
+- Forward return = `Post_exit` continuation (price path), not realized P&L with
+  stops; it measures the names' market moves, the right quantity for "which name
+  was better," but not the strategy's actual realized capture on each.
+- 36/296 (deep) and 22/220 (2011) rotations had no redeployment in the 10-day
+  window (cash redeployed later or sat) — excluded from the paired stats.

--- a/dev/experiments/decision-grading-phase5-2026-06-18/laggard-cf-2011.md
+++ b/dev/experiments/decision-grading-phase5-2026-06-18/laggard-cf-2011.md
@@ -1,0 +1,45 @@
+# Laggard-rotation paired counterfactual — cell-e-top3000-2011-15y-fresh
+
+Alloc window: 10 days. Forward returns are Post_exit continuation from each price/date.
+
+### Did laggard-rotation pay? (paired counterfactual, 4w forward)
+
+Per rotation event: forward return of the new entries the freed cash funded vs the laggard sold. Positive paired diff / >50% paid = rotation beat holding the laggard.
+
+| metric | value |
+|---|---|
+| rotation events | 220 |
+| with redeployment | 198 |
+| mean dumped-laggard forward | -0.8% |
+| mean funded-cohort forward | +1.4% |
+| mean paired diff (funded − dumped) | +2.2% |
+| % events rotation paid | 53% |
+| paired diff p10 / p50 / p90 | -12.3% / +0.7% / +14.7% |
+
+### Did laggard-rotation pay? (paired counterfactual, 13w forward)
+
+Per rotation event: forward return of the new entries the freed cash funded vs the laggard sold. Positive paired diff / >50% paid = rotation beat holding the laggard.
+
+| metric | value |
+|---|---|
+| rotation events | 220 |
+| with redeployment | 198 |
+| mean dumped-laggard forward | -1.8% |
+| mean funded-cohort forward | +3.8% |
+| mean paired diff (funded − dumped) | +5.6% |
+| % events rotation paid | 57% |
+| paired diff p10 / p50 / p90 | -20.8% / +3.1% / +30.3% |
+
+### Did laggard-rotation pay? (paired counterfactual, 26w forward)
+
+Per rotation event: forward return of the new entries the freed cash funded vs the laggard sold. Positive paired diff / >50% paid = rotation beat holding the laggard.
+
+| metric | value |
+|---|---|
+| rotation events | 220 |
+| with redeployment | 198 |
+| mean dumped-laggard forward | +0.1% |
+| mean funded-cohort forward | +6.2% |
+| mean paired diff (funded − dumped) | +6.0% |
+| % events rotation paid | 56% |
+| paired diff p10 / p50 / p90 | -32.4% / +3.9% / +43.2% |

--- a/dev/experiments/decision-grading-phase5-2026-06-18/laggard-cf-deep.md
+++ b/dev/experiments/decision-grading-phase5-2026-06-18/laggard-cf-deep.md
@@ -1,0 +1,45 @@
+# Laggard-rotation paired counterfactual — cell-e-top3000-1998-deep
+
+Alloc window: 10 days. Forward returns are Post_exit continuation from each price/date.
+
+### Did laggard-rotation pay? (paired counterfactual, 4w forward)
+
+Per rotation event: forward return of the new entries the freed cash funded vs the laggard sold. Positive paired diff / >50% paid = rotation beat holding the laggard.
+
+| metric | value |
+|---|---|
+| rotation events | 296 |
+| with redeployment | 260 |
+| mean dumped-laggard forward | +1.0% |
+| mean funded-cohort forward | +0.7% |
+| mean paired diff (funded − dumped) | -0.3% |
+| % events rotation paid | 53% |
+| paired diff p10 / p50 / p90 | -16.5% / +0.8% / +12.7% |
+
+### Did laggard-rotation pay? (paired counterfactual, 13w forward)
+
+Per rotation event: forward return of the new entries the freed cash funded vs the laggard sold. Positive paired diff / >50% paid = rotation beat holding the laggard.
+
+| metric | value |
+|---|---|
+| rotation events | 296 |
+| with redeployment | 260 |
+| mean dumped-laggard forward | +2.5% |
+| mean funded-cohort forward | +3.8% |
+| mean paired diff (funded − dumped) | +1.3% |
+| % events rotation paid | 50% |
+| paired diff p10 / p50 / p90 | -21.4% / -0.1% / +25.4% |
+
+### Did laggard-rotation pay? (paired counterfactual, 26w forward)
+
+Per rotation event: forward return of the new entries the freed cash funded vs the laggard sold. Positive paired diff / >50% paid = rotation beat holding the laggard.
+
+| metric | value |
+|---|---|
+| rotation events | 296 |
+| with redeployment | 260 |
+| mean dumped-laggard forward | +5.2% |
+| mean funded-cohort forward | +6.0% |
+| mean paired diff (funded − dumped) | +0.8% |
+| % events rotation paid | 51% |
+| paired diff p10 / p50 / p90 | -39.4% / +1.0% / +35.7% |

--- a/trading/trading/backtest/decision_grading/bin/dune
+++ b/trading/trading/backtest/decision_grading/bin/dune
@@ -1,6 +1,6 @@
-(executable
- (name decision_grading_bin)
- (modules decision_grading_bin)
+(executables
+ (names decision_grading_bin laggard_cf_bin)
+ (modules decision_grading_bin laggard_cf_bin)
  (libraries
   core
   core_unix.sys_unix

--- a/trading/trading/backtest/decision_grading/bin/laggard_cf_bin.ml
+++ b/trading/trading/backtest/decision_grading/bin/laggard_cf_bin.ml
@@ -1,0 +1,246 @@
+(** [laggard_cf] — did laggard-rotation pay? (Phase 5 paired counterfactual)
+
+    For a scenario output dir, computes — per horizon — whether the names bought
+    with laggard-rotation's freed cash beat the laggards it sold, forward over
+    that horizon. Reads [trades.csv] for the laggard exits and the new entries,
+    fetches forward bars from a snapshot warehouse, computes each side's
+    {!Decision_grading.Post_exit} forward return, pairs them per rotation event
+    ({!Decision_grading.Laggard_cf}), and renders the summary.
+
+    Read-only analysis lens — no strategy behaviour change.
+
+    Usage:
+    {[
+      laggard_cf --scenario-dir <dir> --snapshot-dir <dir>
+        [--horizons 4,13,26] [--alloc-window-days 10] [--out report.md]
+    ]} *)
+
+open Core
+module DG = Decision_grading
+module Bar_reader = Weinstein_strategy.Bar_reader
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+
+let _default_horizons = [ 4; 13; 26 ]
+
+(* Trading days the freed cash may take to redeploy: a rotation frees cash on the
+   Friday decision tick; the funded entries fill over the following sessions, so
+   a ~2-week window catches them. *)
+let _default_alloc_window_days = 10
+let _days_per_week = 7
+let _horizon_buffer_weeks = 3
+let _cache_mb = 512
+
+let _usage () =
+  eprintf
+    "Usage: laggard_cf --scenario-dir <dir> --snapshot-dir <dir> [--horizons \
+     4,13,26] [--alloc-window-days 10] [--out report.md]\n";
+  Stdlib.exit 1
+
+type _acc = {
+  mutable scenario_dir : string option;
+  mutable snapshot_dir : string option;
+  mutable horizons : int list option;
+  mutable alloc_window_days : int option;
+  mutable out_path : string option;
+}
+
+let _parse_horizons s =
+  match
+    Or_error.try_with (fun () ->
+        String.split s ~on:','
+        |> List.map ~f:(fun x -> Int.of_string (String.strip x)))
+  with
+  | Ok hs when (not (List.is_empty hs)) && List.for_all hs ~f:(fun h -> h > 0)
+    ->
+      hs
+  | _ ->
+      eprintf "--horizons requires comma-separated positive ints, got %S\n" s;
+      Stdlib.exit 1
+
+let _parse_flag args =
+  let acc =
+    {
+      scenario_dir = None;
+      snapshot_dir = None;
+      horizons = None;
+      alloc_window_days = None;
+      out_path = None;
+    }
+  in
+  let rec loop = function
+    | [] -> acc
+    | "--scenario-dir" :: p :: rest ->
+        acc.scenario_dir <- Some p;
+        loop rest
+    | "--snapshot-dir" :: p :: rest ->
+        acc.snapshot_dir <- Some p;
+        loop rest
+    | "--horizons" :: s :: rest ->
+        acc.horizons <- Some (_parse_horizons s);
+        loop rest
+    | "--alloc-window-days" :: s :: rest ->
+        acc.alloc_window_days <- Some (Int.of_string s);
+        loop rest
+    | "--out" :: p :: rest ->
+        acc.out_path <- Some p;
+        loop rest
+    | _ -> _usage ()
+  in
+  loop args
+
+let _bar_reader_of_snapshot ~snapshot_dir =
+  let manifest_path = Filename.concat snapshot_dir "manifest.sexp" in
+  let manifest =
+    match Snapshot_manifest.read ~path:manifest_path with
+    | Ok m -> m
+    | Error err ->
+        eprintf "laggard_cf: cannot read %s: %s\n" manifest_path
+          (Status.show err);
+        Stdlib.exit 1
+  in
+  let panels =
+    match
+      Daily_panels.create ~snapshot_dir ~manifest ~max_cache_mb:_cache_mb
+    with
+    | Ok p -> p
+    | Error err ->
+        eprintf "laggard_cf: Daily_panels.create failed: %s\n" (Status.show err);
+        Stdlib.exit 1
+  in
+  Bar_reader.of_snapshot_views (Snapshot_callbacks.of_daily_panels panels)
+
+(* One round-trip's fields the counterfactual needs. *)
+type _row = {
+  symbol : string;
+  side : Trading_base.Types.position_side;
+  entry_date : Date.t;
+  entry_price : float;
+  exit_date : Date.t;
+  exit_price : float;
+  exit_trigger : string;
+}
+
+let _side_of_string = function
+  | "SHORT" -> Trading_base.Types.Short
+  | _ -> Trading_base.Types.Long
+
+(* Read [trades.csv] into [_row]s, by header name (robust to column drift). *)
+let _read_rows ~scenario_dir =
+  let path = Filename.concat scenario_dir "trades.csv" in
+  let lines =
+    In_channel.read_lines path
+    |> List.filter ~f:(fun l -> not (String.is_empty l))
+  in
+  match List.map lines ~f:(fun l -> String.split l ~on:',') with
+  | [] -> []
+  | header :: data ->
+      let idx name =
+        List.findi header ~f:(fun _ h -> String.equal h name)
+        |> Option.map ~f:fst
+      in
+      let i_sym = idx "symbol" and i_side = idx "side" in
+      let i_ed = idx "entry_date" and i_xd = idx "exit_date" in
+      let i_ep = idx "entry_price" and i_xp = idx "exit_price" in
+      let i_trig = idx "exit_trigger" in
+      let get row i = Option.bind i ~f:(fun i -> List.nth row i) in
+      List.filter_map data ~f:(fun row ->
+          match
+            ( get row i_sym,
+              get row i_side,
+              get row i_ed,
+              get row i_xd,
+              get row i_ep,
+              get row i_xp,
+              get row i_trig )
+          with
+          | Some s, Some side, Some ed, Some xd, Some ep, Some xp, Some trig ->
+              Some
+                {
+                  symbol = s;
+                  side = _side_of_string side;
+                  entry_date = Date.of_string ed;
+                  entry_price = Float.of_string ep;
+                  exit_date = Date.of_string xd;
+                  exit_price = Float.of_string xp;
+                  exit_trigger = trig;
+                }
+          | _ -> None)
+
+(* Forward return from [price] at [date] over [horizon_weeks], via the same
+   Post_exit continuation the rest of the lens uses. *)
+let _forward ~bar_reader ~horizon_weeks (symbol : string) ~side ~price ~date =
+  let as_of = Date.add_days date (horizon_weeks * _days_per_week) in
+  let bars =
+    Bar_reader.weekly_bars_for bar_reader ~symbol
+      ~n:(horizon_weeks + _horizon_buffer_weeks)
+      ~as_of
+  in
+  DG.Post_exit.post_exit_metrics ~side ~exit_price:price ~exit_date:date ~bars
+    ~horizons_weeks:[ horizon_weeks ]
+  |> List.hd
+  |> Option.value_map ~default:0.0 ~f:(fun (h : DG.Post_exit.horizon_result) ->
+      h.continuation_pct)
+
+let _summary_for ~bar_reader ~alloc_window_days ~horizon_weeks rows =
+  let laggard_exits =
+    List.filter_map rows ~f:(fun r ->
+        if String.equal r.exit_trigger "laggard_rotation" then
+          Some
+            ( r.symbol,
+              r.exit_date,
+              _forward ~bar_reader ~horizon_weeks r.symbol ~side:r.side
+                ~price:r.exit_price ~date:r.exit_date )
+        else None)
+  in
+  let entries =
+    List.map rows ~f:(fun r ->
+        ( r.entry_date,
+          _forward ~bar_reader ~horizon_weeks r.symbol ~side:r.side
+            ~price:r.entry_price ~date:r.entry_date ))
+  in
+  DG.Laggard_cf.build_events ~alloc_window_days ~laggard_exits ~entries
+  |> DG.Laggard_cf.summarize
+
+let () =
+  let acc = _parse_flag (List.tl_exn (Array.to_list (Sys.get_argv ()))) in
+  let scenario_dir =
+    Option.value_or_thunk acc.scenario_dir ~default:(fun () ->
+        eprintf "--scenario-dir is required\n";
+        _usage ())
+  in
+  let snapshot_dir =
+    Option.value_or_thunk acc.snapshot_dir ~default:(fun () ->
+        eprintf "--snapshot-dir is required\n";
+        _usage ())
+  in
+  let horizons = Option.value acc.horizons ~default:_default_horizons in
+  let alloc_window_days =
+    Option.value acc.alloc_window_days ~default:_default_alloc_window_days
+  in
+  let rows = _read_rows ~scenario_dir in
+  let bar_reader = _bar_reader_of_snapshot ~snapshot_dir in
+  eprintf "laggard_cf: %d round-trips, alloc window %dd\n%!" (List.length rows)
+    alloc_window_days;
+  let sections =
+    List.map horizons ~f:(fun h ->
+        let s =
+          _summary_for ~bar_reader ~alloc_window_days ~horizon_weeks:h rows
+        in
+        DG.Laggard_cf.to_markdown ~horizon_weeks:h s)
+  in
+  let header =
+    Printf.sprintf
+      "# Laggard-rotation paired counterfactual — %s\n\n\
+       Alloc window: %d days. Forward returns are Post_exit continuation from \
+       each price/date.\n\n"
+      (Filename.basename scenario_dir)
+      alloc_window_days
+  in
+  let markdown = header ^ String.concat ~sep:"\n" sections in
+  match acc.out_path with
+  | Some path ->
+      Out_channel.write_all path ~data:markdown;
+      eprintf "laggard_cf: wrote %s\n%!" path
+  | None -> print_string markdown

--- a/trading/trading/backtest/decision_grading/lib/laggard_cf.ml
+++ b/trading/trading/backtest/decision_grading/lib/laggard_cf.ml
@@ -1,0 +1,121 @@
+(** Laggard-rotation paired counterfactual. See [laggard_cf.mli]. *)
+
+open Core
+
+type event = {
+  dumped_symbol : string;
+  dumped_date : Date.t;
+  dumped_forward_pct : float;
+  funded_forward_pcts : float list;
+}
+[@@deriving show, eq, sexp]
+
+type summary = {
+  n_events : int;
+  n_with_redeploy : int;
+  mean_dumped_forward_pct : float;
+  mean_funded_forward_pct : float;
+  mean_paired_diff_pct : float;
+  pct_rotation_paid : float;
+  diff_p10 : float;
+  diff_p50 : float;
+  diff_p90 : float;
+}
+[@@deriving show, eq, sexp]
+
+(** Forward returns of the [entries] opened in [(dumped_date, dumped_date +
+    alloc_window_days]] — the redeployment cohort the freed cash plausibly
+    funded. Lifted out of {!build_events} to keep its pipeline flat (nesting). *)
+let _funded_in_window ~alloc_window_days ~dumped_date entries =
+  List.filter_map entries ~f:(fun (entry_date, fwd) ->
+      let gap = Date.diff entry_date dumped_date in
+      if gap > 0 && gap <= alloc_window_days then Some fwd else None)
+
+(** One {!event} from a [(symbol, exit_date, forward)] laggard exit, pairing it
+    with the redeployment cohort in its allocation window. *)
+let _event_of ~alloc_window_days ~entries
+    (dumped_symbol, dumped_date, dumped_forward_pct) =
+  {
+    dumped_symbol;
+    dumped_date;
+    dumped_forward_pct;
+    funded_forward_pcts =
+      _funded_in_window ~alloc_window_days ~dumped_date entries;
+  }
+
+let build_events ~alloc_window_days ~laggard_exits ~entries =
+  List.map laggard_exits ~f:(_event_of ~alloc_window_days ~entries)
+
+(** Arithmetic mean of [xs], or [0.0] for an empty list. *)
+let _mean xs =
+  match xs with
+  | [] -> 0.0
+  | _ -> List.sum (module Float) xs ~f:Fn.id /. Float.of_int (List.length xs)
+
+(** Nearest-rank [p]-th percentile of [xs], or [0.0] when empty. *)
+let _percentile ~p xs =
+  match List.sort xs ~compare:Float.compare with
+  | [] -> 0.0
+  | sorted ->
+      let n = List.length sorted in
+      let idx =
+        Float.round_nearest (p *. Float.of_int (n - 1)) |> Float.to_int
+      in
+      List.nth_exn sorted (Int.max 0 (Int.min (n - 1) idx))
+
+let _p10 = 0.10
+let _p50 = 0.50
+let _p90 = 0.90
+
+let summarize events =
+  let with_redeploy =
+    List.filter events ~f:(fun e -> not (List.is_empty e.funded_forward_pcts))
+  in
+  let diffs =
+    List.map with_redeploy ~f:(fun e ->
+        _mean e.funded_forward_pcts -. e.dumped_forward_pct)
+  in
+  let n_with_redeploy = List.length with_redeploy in
+  let pct_rotation_paid =
+    if n_with_redeploy = 0 then 0.0
+    else
+      let paid = List.count diffs ~f:(fun d -> Float.( > ) d 0.0) in
+      Float.of_int paid /. Float.of_int n_with_redeploy
+  in
+  {
+    n_events = List.length events;
+    n_with_redeploy;
+    mean_dumped_forward_pct =
+      _mean (List.map with_redeploy ~f:(fun e -> e.dumped_forward_pct));
+    mean_funded_forward_pct =
+      _mean (List.map with_redeploy ~f:(fun e -> _mean e.funded_forward_pcts));
+    mean_paired_diff_pct = _mean diffs;
+    pct_rotation_paid;
+    diff_p10 = _percentile ~p:_p10 diffs;
+    diff_p50 = _percentile ~p:_p50 diffs;
+    diff_p90 = _percentile ~p:_p90 diffs;
+  }
+
+let _pct1 x = Printf.sprintf "%+.1f%%" (x *. 100.0)
+
+let to_markdown ~horizon_weeks s =
+  Printf.sprintf
+    "### Did laggard-rotation pay? (paired counterfactual, %dw forward)\n\n\
+     Per rotation event: forward return of the new entries the freed cash \
+     funded vs the laggard sold. Positive paired diff / >50%% paid = rotation \
+     beat holding the laggard.\n\n\
+     | metric | value |\n\
+     |---|---|\n\
+     | rotation events | %d |\n\
+     | with redeployment | %d |\n\
+     | mean dumped-laggard forward | %s |\n\
+     | mean funded-cohort forward | %s |\n\
+     | mean paired diff (funded − dumped) | %s |\n\
+     | %% events rotation paid | %.0f%% |\n\
+     | paired diff p10 / p50 / p90 | %s / %s / %s |\n"
+    horizon_weeks s.n_events s.n_with_redeploy
+    (_pct1 s.mean_dumped_forward_pct)
+    (_pct1 s.mean_funded_forward_pct)
+    (_pct1 s.mean_paired_diff_pct)
+    (s.pct_rotation_paid *. 100.0)
+    (_pct1 s.diff_p10) (_pct1 s.diff_p50) (_pct1 s.diff_p90)

--- a/trading/trading/backtest/decision_grading/lib/laggard_cf.mli
+++ b/trading/trading/backtest/decision_grading/lib/laggard_cf.mli
@@ -1,0 +1,96 @@
+(** Laggard-rotation paired counterfactual — Phase 5 of the decision-grading
+    lens (plan [dev/plans/decision-grading-lens-2026-06-17.md] §Phase 5).
+
+    Laggard-rotation is the one exit type with a specific {b alternative}: it
+    sells a laggard to free cash for the same-tick entry walk. The right
+    question is therefore not "did the laggard recover after we sold?" (that is
+    the {!Aggregate} continuation view) but
+    {b "did the names we bought with the freed cash beat the laggard we sold?"}
+    — did rotation {e pay}?
+
+    There is no 1:1 sold→bought link in the engine (the runner frees cash into a
+    pool the entry walk draws from — see [laggard_rotation_runner.mli] §"Side &
+    ordering"). So the pairing is {b per-event cohort}: each rotation exit is
+    compared against the cohort of new entries opened within a short allocation
+    window after it. Both sides' "forward return" is the
+    {!Post_exit.horizon_result.continuation_pct} over the same horizon —
+    measured from the laggard's exit price forward, and from each new entry's
+    entry price forward.
+
+    Every function here is pure — it consumes caller-built forward returns (the
+    CLI computes them via [Post_exit] + a snapshot [Bar_reader]). No I/O. *)
+
+open Core
+
+type event = {
+  dumped_symbol : string;  (** The laggard that was rotated out. *)
+  dumped_date : Date.t;  (** Its exit date (the rotation event). *)
+  dumped_forward_pct : float;
+      (** The laggard's forward return over the horizon, from its exit price
+          (side-adjusted {!Post_exit} continuation): positive means it kept
+          running after we sold — rotation gave up a winner. *)
+  funded_forward_pcts : float list;
+      (** Forward returns (same horizon, from each entry price) of the new
+          entries opened in the allocation window after [dumped_date] — the
+          cohort the freed cash plausibly funded. Empty when nothing was bought
+          in the window (cash sat idle / was redeployed later). *)
+}
+[@@deriving show, eq, sexp]
+(** One rotation event paired with the redeployment cohort it plausibly funded.
+*)
+
+type summary = {
+  n_events : int;  (** Total rotation events considered. *)
+  n_with_redeploy : int;
+      (** Events with at least one funded entry in the window (the ones the
+          paired comparison is computed over). *)
+  mean_dumped_forward_pct : float;
+      (** Mean [dumped_forward_pct] over the redeploy events — what the sold
+          laggards did next, on average. *)
+  mean_funded_forward_pct : float;
+      (** Mean of each redeploy event's funded-cohort mean forward — what the
+          bought names did next, on average. *)
+  mean_paired_diff_pct : float;
+      (** Mean over redeploy events of
+          [(mean funded forward) - dumped_forward_pct]. Positive means rotation
+          paid: the cohort we bought beat the laggard we sold. This is the
+          {b paired, event-level} statistic (not two pooled population means).
+      *)
+  pct_rotation_paid : float;
+      (** Fraction of redeploy events whose funded-cohort mean forward exceeded
+          the dumped laggard's forward — the sign-rate of "rotation paid", in
+          [[0.0, 1.0]]. *)
+  diff_p10 : float;
+  diff_p50 : float;
+  diff_p90 : float;
+      (** Percentiles (nearest-rank) of the per-event paired diff across
+          redeploy events — the distribution, not just its mean. [0.0] when no
+          redeploy events. *)
+}
+[@@deriving show, eq, sexp]
+(** Aggregate verdict on whether laggard-rotation paid, over one horizon. *)
+
+val build_events :
+  alloc_window_days:int ->
+  laggard_exits:(string * Date.t * float) list ->
+  entries:(Date.t * float) list ->
+  event list
+(** [build_events ~alloc_window_days ~laggard_exits ~entries] pairs each
+    [(symbol, exit_date, forward)] laggard exit with the [(entry_date, forward)]
+    entries whose [entry_date] lies in [(exit_date, exit_date +
+    alloc_window_days]] (exclusive of the exit day itself, inclusive of the
+    window end). One {!event} per laggard exit, in input order. An entry may fund
+    more than one rotation event (the freed-cash pool is shared); that is
+    expected and not double-counted incorrectly — each event measures the
+    redeployment opportunity available to it. Pure. *)
+
+val summarize : event list -> summary
+(** [summarize events] computes the paired counterfactual {!summary}. Events
+    with an empty [funded_forward_pcts] are counted in [n_events] but excluded
+    from every mean / percentile / sign-rate (no redeployment to compare
+    against). All float fields are [0.0] when [n_with_redeploy = 0]. Pure: same
+    input -> same output. *)
+
+val to_markdown : horizon_weeks:int -> summary -> string
+(** [to_markdown ~horizon_weeks s] renders [s] as a markdown section labelled
+    with the horizon. Deterministic; trailing newline included. *)

--- a/trading/trading/backtest/decision_grading/test/dune
+++ b/trading/trading/backtest/decision_grading/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_post_exit test_grade test_aggregate)
+ (names test_post_exit test_grade test_aggregate test_laggard_cf)
  (libraries ounit2 core matchers decision_grading types trading.base)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_grading/test/test_laggard_cf.ml
+++ b/trading/trading/backtest/decision_grading/test/test_laggard_cf.ml
@@ -1,0 +1,157 @@
+open Core
+open OUnit2
+open Matchers
+module L = Decision_grading.Laggard_cf
+
+let date = Date.of_string
+
+(* build_events pairs each laggard exit with entries strictly after the exit
+   date and within the window. Exit on 2020-01-03, window 10d: an entry on
+   2020-01-08 (gap 5) is in; 2020-01-03 (gap 0, the exit day) is out;
+   2020-01-20 (gap 17) is out. *)
+let test_build_events_window _ =
+  let events =
+    L.build_events ~alloc_window_days:10
+      ~laggard_exits:[ ("X", date "2020-01-03", 0.30) ]
+      ~entries:
+        [
+          (date "2020-01-03", 0.99);
+          (* same day -> excluded *)
+          (date "2020-01-08", 0.10);
+          (* in window *)
+          (date "2020-01-20", 0.88);
+          (* past window -> excluded *)
+        ]
+  in
+  assert_that events
+    (elements_are
+       [
+         all_of
+           [
+             field (fun e -> e.L.dumped_symbol) (equal_to "X");
+             field
+               (fun e -> e.L.funded_forward_pcts)
+               (elements_are [ float_equal 0.10 ]);
+           ];
+       ])
+
+(* An event with no entries in the window -> empty funded cohort. *)
+let test_build_events_no_redeploy _ =
+  let events =
+    L.build_events ~alloc_window_days:5
+      ~laggard_exits:[ ("Y", date "2020-06-01", 0.05) ]
+      ~entries:[ (date "2020-07-01", 0.20) ]
+  in
+  assert_that events
+    (elements_are
+       [ field (fun e -> e.L.funded_forward_pcts) (elements_are []) ])
+
+(* summarize: one event, funded cohort {+0.10,+0.20} mean +0.15 vs dumped +0.30
+   -> paired diff -0.15 (rotation did NOT pay), pct_paid 0. *)
+let test_summarize_did_not_pay _ =
+  let events =
+    [
+      {
+        L.dumped_symbol = "X";
+        dumped_date = date "2020-01-03";
+        dumped_forward_pct = 0.30;
+        funded_forward_pcts = [ 0.10; 0.20 ];
+      };
+    ]
+  in
+  assert_that (L.summarize events)
+    (all_of
+       [
+         field (fun s -> s.L.n_events) (equal_to 1);
+         field (fun s -> s.L.n_with_redeploy) (equal_to 1);
+         field (fun s -> s.L.mean_dumped_forward_pct) (float_equal 0.30);
+         field (fun s -> s.L.mean_funded_forward_pct) (float_equal 0.15);
+         field (fun s -> s.L.mean_paired_diff_pct) (float_equal (-0.15));
+         field (fun s -> s.L.pct_rotation_paid) (float_equal 0.0);
+       ])
+
+(* Two events, one paid (+) one not (−): pct_rotation_paid 0.5. Event A funded
+   +0.40 vs dumped +0.10 -> +0.30 paid; event B funded +0.05 vs dumped +0.25 ->
+   -0.20 not paid. mean diff +0.05. *)
+let test_summarize_mixed _ =
+  let events =
+    [
+      {
+        L.dumped_symbol = "A";
+        dumped_date = date "2020-01-03";
+        dumped_forward_pct = 0.10;
+        funded_forward_pcts = [ 0.40 ];
+      };
+      {
+        L.dumped_symbol = "B";
+        dumped_date = date "2020-02-07";
+        dumped_forward_pct = 0.25;
+        funded_forward_pcts = [ 0.05 ];
+      };
+    ]
+  in
+  assert_that (L.summarize events)
+    (all_of
+       [
+         field (fun s -> s.L.pct_rotation_paid) (float_equal 0.5);
+         field (fun s -> s.L.mean_paired_diff_pct) (float_equal 0.05);
+       ])
+
+(* Events with empty funded cohort are counted in n_events but excluded from the
+   stats (n_with_redeploy and the means see only the real one). *)
+let test_summarize_skips_no_redeploy _ =
+  let events =
+    [
+      {
+        L.dumped_symbol = "A";
+        dumped_date = date "2020-01-03";
+        dumped_forward_pct = 0.10;
+        funded_forward_pcts = [ 0.40 ];
+      };
+      {
+        L.dumped_symbol = "Z";
+        dumped_date = date "2020-03-06";
+        dumped_forward_pct = 0.50;
+        funded_forward_pcts = [];
+      };
+    ]
+  in
+  assert_that (L.summarize events)
+    (all_of
+       [
+         field (fun s -> s.L.n_events) (equal_to 2);
+         field (fun s -> s.L.n_with_redeploy) (equal_to 1);
+         field (fun s -> s.L.mean_dumped_forward_pct) (float_equal 0.10);
+         field (fun s -> s.L.mean_paired_diff_pct) (float_equal 0.30);
+       ])
+
+(* Empty input -> all-zero summary. *)
+let test_summarize_empty _ =
+  assert_that (L.summarize [])
+    (all_of
+       [
+         field (fun s -> s.L.n_events) (equal_to 0);
+         field (fun s -> s.L.n_with_redeploy) (equal_to 0);
+         field (fun s -> s.L.mean_paired_diff_pct) (float_equal 0.0);
+         field (fun s -> s.L.pct_rotation_paid) (float_equal 0.0);
+       ])
+
+let test_to_markdown _ =
+  let s = L.summarize [] in
+  assert_that
+    (L.to_markdown ~horizon_weeks:13 s)
+    (contains_substring "Did laggard-rotation pay?")
+
+let suite =
+  "laggard_cf"
+  >::: [
+         "build_events_window" >:: test_build_events_window;
+         "build_events_no_redeploy" >:: test_build_events_no_redeploy;
+         "summarize_did_not_pay" >:: test_summarize_did_not_pay;
+         "summarize_mixed" >:: test_summarize_mixed;
+         "summarize_skips_no_redeploy" >:: test_summarize_skips_no_redeploy;
+         "summarize_empty" >:: test_summarize_empty;
+         "to_markdown" >:: test_to_markdown;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What & why
Final phase of the decision-grading lens. Laggard-rotation sells a laggard to fund the same-tick entry walk. Phase 5 asks the question the swap actually poses: **did the names bought with the freed cash beat the laggard sold?**

No 1:1 sold→bought link exists (cash → shared pool; `laggard_rotation_runner.mli`), so the pairing is **per-event cohort**: each rotation exit vs the new entries opened within a 10-day allocation window after it. Both sides' forward return is the `Post_exit` continuation over the same horizon. New pure lib `Decision_grading.Laggard_cf` (build_events + summarize + to_markdown, 7 tests) + `laggard_cf` bin. Read-only; no strategy change.

## Result — the swap is a coin flip; value is recycling, not selection
**1998-2026 deep (296 events, 260 redeployed):**
| horizon | mean paired diff (funded − dumped) | % paid | diff p10/p50/p90 |
|---|---|---|---|
| 13w | +1.3% | 50% | −21.4 / −0.1 / +25.4 |
| 26w | +0.8% | 51% | −39.4 / +1.0 / +35.7 |

**2011-26 bull:** +5.6% / 57% (13w), +6.0% / 56% (26w).

The funded cohort beats the dumped laggard only ~50-53% of the time across the full multi-regime window (mean diff ≈ +1%, huge dispersion); it pays more in a pure bull tape (+5-6%, 56-57%) but that **evaporates once dot-com+GFC are included**. Re-derives the harvest-rotate rejection (`project_harvest_rotate_rejected`: coin-flip per event) from the realized laggard mechanism.

**Reconciliation:** laggard-rotation's value is **capital-recycling / freshness** (harvesting accumulated gains, keeping capital in the fat-tail game), NOT swap selection — the rotation decision adds ~nothing reliable. So: keep it on, don't tune the selection. Tightens `project_edge_is_the_fat_tail`. Full writeup + caveats: `dev/experiments/decision-grading-phase5-2026-06-18/FINDINGS.md`.

## Test plan
- `dune build` + full `dune runtest` clean (nesting + magic-number linters pass).
- 7 `Laggard_cf` unit tests (window pairing incl/excl, paired-diff sign, % paid, skip-no-redeploy, empty, markdown).
- Bin verified end-to-end on both runs (tables above).

Mixed code+docs PR → full QC gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)