### PR TITLE
docs: (c) long-short screen verdict + weekly-close stop plan

### DIFF
--- a/dev/backtest/decision-grading-longshort-2026-06-18/cell-e-top3000-1998-longshort.sexp
+++ b/dev/backtest/decision-grading-longshort-2026-06-18/cell-e-top3000-1998-longshort.sexp
@@ -1,0 +1,24 @@
+;; Cell-E top-3000 PIT-1998 LONG-SHORT, 28y — read-only screen: does adding the
+;; Stage-4 short leg (margin Phase 1+2, the merged margin-phase3 long-short
+;; config) diversify/improve the long-only deep baseline? NOT a goldens re-pin;
+;; output graded with the decision-grading lens. Mirrors
+;; cell-e-top3000-1998-deep.sexp + enable_short_side true + margin enabled +
+;; short_min_price 17 (researched sub-$17 economic-margin floor).
+((name "cell-e-top3000-1998-longshort")
+ (description "Cell-E top-3000 PIT-1998 long-short (margin on), 28y, decision-grading screen.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side true))
+   ((short_min_price 17.0))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((margin_config ((enabled true))))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 1000000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/experiments/decision-grading-longshort-2026-06-18/FINDINGS.md
+++ b/dev/experiments/decision-grading-longshort-2026-06-18/FINDINGS.md
@@ -1,0 +1,66 @@
+# (c) Long-short screen — does the Stage-4 short leg diversify? (2026-06-18/19)
+
+Initiative-B read-only screen (NOT the human-gated Phase-5 promotion): run the
+deep 1998-2026 Cell-E with `enable_short_side=true` + `margin_config.enabled=true`
+(the merged margin-phase3 long-short config) + `short_min_price=17`, and compare
+to the long-only deep baseline. No goldens re-pinned; no default changed.
+
+## Top-level: short leg cuts drawdown but also cuts return
+
+| | return | trades | MaxDD | return/MaxDD |
+|---|---|---|---|---|
+| long-only deep | +1934.5% | 1061 | 48.7% | ~39.7 |
+| long-short deep | +1662.9% | 1164 | 36.9% | ~45.1 |
+
+Adding shorts cut MaxDD ~12pp (48.7 → 36.9%) at the cost of ~270pp return — a
+better return/MaxDD ratio, the classic diversifier signature.
+
+## But the short leg is anemic — the DD cut is mostly reduced long deployment
+
+Per-side P&L (28y):
+
+| side | n | win% | total P&L | avg/trade |
+|---|---|---|---|---|
+| LONG | 1127 | 33% | +$18,251,237 | +$16,195 |
+| SHORT | 37 | 24% | **+$38,275** | +$1,034 |
+
+- **Only 37 short trades in 28 years** across 3000 names — all exit via
+  `stop_loss`, 24% win, **lifetime P&L +$38k (~0.2% of the long book)**.
+- A near-breakeven 37-trade overlay cannot itself move MaxDD 12pp. The DD
+  reduction is therefore mostly **reduced long deployment** (short collateral
+  locks capital that would otherwise be long) plus a handful of crash-timed
+  shorts cushioning the GFC/dot-com troughs — **not a profitable short hedge**.
+- Reconciles with margin Phase-3 (`dev/notes/margin-phase3-bear-windows-2026-05-23.md`):
+  shorts only show positive edge in the GFC window; flat-to-losing elsewhere. The
+  Ch.11 short cascade (Stage-4 + negative RS + bearish macro) is so restrictive
+  that only 37 names qualify in 28 years.
+
+## Verdict — NO-BUILD (for now); barbell remains the DD lever
+
+A read-only screen rejects *prioritization*, not the mechanism (`mechanism-validation-rigor`).
+On this evidence:
+- **Do not pursue the human-gated long-short Phase-5 promotion.** The short leg as
+  built adds no meaningful return and is a weak DD-reducer largely explained by
+  capital displacement, not edge. The risk-adjusted gain is real but small and
+  confounded.
+- **If short-side is to matter, the lever is loosening short admission** (more
+  than 37 shorts/28y) — but the per-trade edge is weak (24% win, all stopped), so
+  expanding the cascade risks adding losers. That is a separate, lower-priority
+  exploration, not this screen's recommendation.
+- **The better-validated DD diversifier is the barbell** (SPY-timing floor +
+  Cell-E engine, `project_barbell_on_stocks`: pushes blended DD below the floor,
+  regime-robust) — prefer it over the short leg for drawdown control.
+
+## a→b→c synthesis (all three decision-level reads)
+- **(a) stops** — whipsaw-dominated: forgo more upside (+30-33%) than disaster
+  dodged (−19%); net per-decision negative even through dot-com+GFC. Improvement
+  room → the **weekly-close stop lever** (`dev/plans/weekly-close-stop-2026-06-19.md`).
+- **(b) laggard rotation** — the swap is a coin flip (~50%, ≈+1%); value is
+  capital-recycling/freshness, not selection. Keep on, don't tune selection.
+- **(c) long-short** — short leg anemic; weak/confounded DD diversifier; no-build.
+  Barbell is the DD lever.
+
+The transferable thread (tightens `project_edge_is_the_fat_tail`): selection
+levers (entry, swap, short-pick) are coin flips; the live levers are
+**holding-discipline** (the weekly-close stop) and **structural diversification**
+(barbell), not picking better names.

--- a/dev/experiments/decision-grading-longshort-2026-06-18/grade-longshort-26w.md
+++ b/dev/experiments/decision-grading-longshort-2026-06-18/grade-longshort-26w.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-top3000-1998-longshort
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 1164 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 312 | +16.2% | +5.2% | 38% | 22% | -5.2% | -1.03 |
+| stage3_force_exit | 19 | -1.1% | -3.7% | 21% | 32% | +3.7% | -1.33 |
+| stop_loss | 828 | -1.2% | +13.1% | 35% | 32% | -13.1% | -2.78 |
+| unlabeled | 5 | +45.4% | +2.2% | 40% | 20% | -2.2% | 0.49 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 312 | -15.7% | +20.8% | -22.9% | +28.8% | 27% |
+| stage3_force_exit | 19 | -22.7% | +19.0% | -17.6% | +11.3% | 53% |
+| stop_loss | 828 | -20.0% | +38.4% | -30.7% | +42.2% | 38% |
+| unlabeled | 5 | -16.1% | +23.0% | -17.3% | +22.5% | 20% |

--- a/dev/experiments/decision-grading-longshort-2026-06-18/scenario.sexp
+++ b/dev/experiments/decision-grading-longshort-2026-06-18/scenario.sexp
@@ -1,0 +1,24 @@
+;; Cell-E top-3000 PIT-1998 LONG-SHORT, 28y — read-only screen: does adding the
+;; Stage-4 short leg (margin Phase 1+2, the merged margin-phase3 long-short
+;; config) diversify/improve the long-only deep baseline? NOT a goldens re-pin;
+;; output graded with the decision-grading lens. Mirrors
+;; cell-e-top3000-1998-deep.sexp + enable_short_side true + margin enabled +
+;; short_min_price 17 (researched sub-$17 economic-margin floor).
+((name "cell-e-top3000-1998-longshort")
+ (description "Cell-E top-3000 PIT-1998 long-short (margin on), 28y, decision-grading screen.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side true))
+   ((short_min_price 17.0))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((margin_config ((enabled true))))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 1000000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/notes/overnight-plan-2026-06-19.md
+++ b/dev/notes/overnight-plan-2026-06-19.md
@@ -1,0 +1,72 @@
+# Overnight autonomous plan — 2026-06-19 (user AFK, ~6-8h)
+
+User left for the night, asked for ~6-8h of planned autonomous work. This is the
+queue + the discipline. Surfacing progress in-session; durable record here.
+
+## Invariants (apply to every step)
+- **Every change default-off** (`experiment-flag-discipline`); goldens stay
+  bit-identical; no default flip / no goldens re-pin (those are human-gated).
+- **Full `dune runtest` before every push** (the linter gate the scoped form
+  skips — cost 3 rework cycles already this session).
+- **3-gate merge** (CI + qc-structural + qc-behavioral) for code PRs; docs-only →
+  admin-merge. Verify `gh pr checks` green before every merge; main green before
+  the next.
+- **Serialize the container** — never two backtests/builds at once; never
+  `jj new`/`restore`/dispatch-agent while a backtest is writing (kills output,
+  `feedback_jj_restore_killed_sweep` / `feedback_no_parent_backtest_during_jj_agent`).
+- **Worktree isolation + docker dune** for any dispatched QC/feat agent.
+- Screens calibrated per `screen-rigor`/`mechanism-validation-rigor` (distribution
+  not point-estimate; a screen says promising/no-build, never "proven").
+
+## Phase 1 — close out (c) long-short screen  [~30 min, run already in flight]
+- Wait for `b24pd4vg0` (deep long-short, margin-on). Grade + compare top-level
+  (return/Sharpe/MaxDD) AND decision-level vs the long-only deep baseline
+  (+1934.5% / 1061 / 48.7% MaxDD). Does the Stage-4 short leg diversify/improve?
+- Write `dev/experiments/decision-grading-longshort-2026-06-18/FINDINGS.md` with a
+  calibrated verdict. Docs-only PR → admin-merge.
+- This completes a→b→c (all three measured at the decision level).
+
+## Phase 2 — build the weekly-close stop flag (default-off)  [~2h]
+Per `dev/plans/weekly-close-stop-2026-06-19.md` + `project_weekly_close_stop_lever`.
+- TDD: add `stop_trigger_on_weekly_close : bool [@sexp.default false]` to the
+  stops config; close-based trigger variant in `Weinstein_stops`; wire in
+  `stops_runner` (non-Friday = no intraday check; Friday = trigger on
+  `close_price`). The stop state machine's `update`/`Stop_hit` path needs the flag
+  too. Unit tests pin: default-off = current low-based behaviour bit-identical;
+  on = close-based, intra-week wick below stop does NOT trigger if the week closes
+  above.
+- FULL `dune runtest` (goldens replay bit-identical at default-off). PR → QC
+  (structural + behavioral; W1/W2 spine-faithful, R1/R2 flag-discipline) → merge.
+- Build with NO backtest running (container free post-Phase-1). Do it myself
+  (TDD, careful subsystem) rather than dispatch, to keep tight control; if it
+  balloons, dispatch one feat-weinstein agent with the plan as brief.
+
+## Phase 3 — lens screen the flag (before/after)  [~2.5h, serialized backtests]
+- Re-run deep 1998-2026 Cell-E with `stop_trigger_on_weekly_close=true` (~1h),
+  then 2011 (~30m). Serialize.
+- Re-grade both with `decision_grading`: does `stop_loss` mean upside-foregone
+  shrink, disaster-dodged hold, net value-add improve? Top-level return/Sharpe/
+  MaxDD vs the long-only deep/2011 baselines.
+- Write findings + calibrated verdict (promising → escalate to WF-CV / no-build).
+  Docs PR → admin-merge.
+
+## Phase 4 — WF-CV the flag IF Phase-3 promising  [~1.5h]
+- `Variant_matrix` axis `((flag stop_trigger_on_weekly_close)(values (true false)))`
+  under walk-forward CV on the deep window (fork-per-fold, N=3000 path). Deflated
+  Sharpe + Pareto.
+- Record ACCEPT/REJECT in `dev/experiments/_ledger/`. Docs PR.
+- **Do NOT flip the default** — that's the promotion grid + human oversight
+  (`promotion-confirmation.md`). Leave it default-off as an axis with the verdict.
+
+## If a phase is blocked / no-build verdict
+- If the long-short screen or the stop screen says "no edge", record the verdict +
+  the why (transferable) and STOP that thread — don't force it. Move to the next
+  phase. A clean no-build is a valid 6-8h outcome.
+- Hard cap: if QC returns NEEDS_REWORK twice on the same PR, leave it draft, note
+  in the handoff, move on (`feat-agent-dispatch` rework cap).
+
+## Morning handoff
+- Update `project_weekly_close_stop_lever` + write `next-session-priorities-2026-06-20.md`
+  with: what shipped, the stop-lever verdict, and the remaining promotion-grid
+  step (human-gated default flip).
+- Refresh `dev/agent-memory/` snapshot (`sh dev/scripts/export-memory.sh`).

--- a/dev/plans/weekly-close-stop-2026-06-19.md
+++ b/dev/plans/weekly-close-stop-2026-06-19.md
@@ -1,0 +1,76 @@
+# Weekly-close stop confirmation — a lens-driven stop improvement (2026-06-19)
+
+**Origin:** user insight 2026-06-19, off the decision-grading deep stop read
+(`dev/experiments/decision-grading-deep-2026-06-18/FINDINGS.md`). The
+insurance decomposition showed `stop_loss` forgoes **more** upside (+30-33% mean)
+than the disaster it dodges (−19% mean) → net per-decision value-add −6 to −9%.
+The user's point: *that gap is improvement room* — the stop is whipsaw-dominated,
+and a stop that fired less on noise would forgo less upside while still catching
+genuine Stage-4 rollovers.
+
+## Confirmed mechanism
+
+The live stop is a **GTC broker stop checked every day on the bar low**
+(`stops_runner._trigger_fill_price` → `bar.low_price` for longs;
+`Weinstein_stops.check_stop_hit` doc: "Long: triggered by `low_price ≤
+stop_level`"; the runner comment: "the GTC stop sits in the market every day").
+So an **intra-week shakeout wick** below the stop triggers an exit even when the
+week *closes* back above it — the classic shakeout. This is a deliberate
+broker-realism model, not a bug.
+
+Weinstein's actual rule (book §Stop-Loss Rules; the qc-behavioral **L3** contract
+"Stop triggers on weekly close below stop level, not intraday") is **weekly-close
+confirmation**: only act if the *Friday weekly close* is below the stop; ignore
+intra-week lows. That directly targets the foregone-upside the lens measured.
+
+## The dial (spine-faithful, default-off)
+
+Add `stop_trigger_on_weekly_close : bool [@sexp.default false]` to the stops
+config (`experiment-flag-discipline` R1: default reproduces the current
+intraday-GTC behaviour bit-for-bit; R2: a real config field → `Variant_matrix`
+axis). Spine item #5 (stop below base/MA) is untouched — only the *trigger
+confirmation* changes, which is itself the book's L3 rule, so this is a faithful
+dial, not a spine change (`weinstein-faithful-core` W1/W2).
+
+When true:
+- Non-Friday bars: no intraday trigger (skip `_handle_stop_trigger_only`'s check).
+- Friday bar: trigger on `close_price` vs stop (a close-based `check_stop_hit`
+  variant), not the week's low. Fill at the close (or next open), not the low.
+
+## The honest risk (what the test must measure)
+
+Weekly-close trades whipsaw-avoidance for **deeper fills on genuine breakdowns**:
+in a real Stage-4 collapse the Friday close can be well below where an intraday
+stop would have filled. So the lens's `disaster_dodged` (−19%) will change — that
+is exactly what re-grading measures. The foregone upside is *also* partly the
+fat-tail recovery, so a looser exit that recaptures it can also ride genuine
+collapses further down. Per-decision improvement need not be portfolio
+improvement.
+
+## Disciplined test arc
+
+1. **Implement** the default-off flag (TDD; feat-weinstein scope; `weinstein/stops`
+   + `stops_runner`). Default-off → all goldens replay bit-identical.
+2. **Lens screen** (read-only, the cheap before/after): re-run the deep 1998-2026
+   + 2011 Cell-E with the flag on, re-grade with `decision_grading` →
+   does `stop_loss` mean **upside-foregone shrink** while **disaster-dodged**
+   holds, and net value-add improve? Also top-level return/Sharpe/MaxDD vs
+   long-only deep. (`screen-rigor`: distribution, not point estimate; calibrate
+   the verdict — a screen can say "promising, escalate" or "no-build", not
+   "proven".)
+3. **If promising → WF-CV** (`experiment-gap-closing`) as a `Variant_matrix` axis
+   `((flag stop_trigger_on_weekly_close) (values (true false)))` with Deflated
+   Sharpe + Pareto.
+4. **Promotion-confirmation grid** (`promotion-confirmation.md`): robust across
+   ≥3 (period × universe) cells incl. a bear-dominated macro regime, before
+   flipping the default. Never promote on a single-window win.
+
+## Why this is a good lever (not the entry-selection dead end)
+
+Unlike entry/swap selection (which the lens + `project_accuracy_is_unreachable`
+show is a coin flip), the stop *trigger model* is a structural mechanic with a
+clear, faithful, book-backed alternative and a measurable whipsaw cost. It is a
+holding-discipline / tail-preserving lever (`project_edge_is_the_fat_tail`:
+"bias to tail-PRESERVING levers — holding discipline"), not a winner-touching
+tax. The decision-grading lens is the instrument that surfaced it and will judge
+it.


### PR DESCRIPTION
Docs-only. (c) Initiative-B read-only screen: deep long-short vs long-only — short leg cuts MaxDD 48.7→36.9% but cuts return ~270pp and is anemic (37 trades/28y, +$38k lifetime, all stopped) → **no-build for now**, barbell remains the DD lever. Completes a→b→c. Also: the weekly-close stop improvement plan + the overnight autonomous work plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)