### PR TITLE
feat(stops): weekly-close stop trigger (default-off flag)

### DIFF
--- a/trading/trading/weinstein/stops/lib/stop_nudge.ml
+++ b/trading/trading/weinstein/stops/lib/stop_nudge.ml
@@ -1,0 +1,23 @@
+open Core
+open Trading_base.Types
+
+(* Nearest half-dollar (or whole dollar) to [price] — the round-number reference
+   stops are nudged away from. *)
+let _nearest_half price =
+  let floor_half = Float.round_down (price /. 0.5) *. 0.5 in
+  let ceil_half = floor_half +. 0.5 in
+  if
+    Float.( < )
+      (Float.abs (price -. ceil_half))
+      (Float.abs (price -. floor_half))
+  then ceil_half
+  else floor_half
+
+let nudge_round_number ~nudge ~side price =
+  let candidate = _nearest_half price in
+  if Float.( <= ) (Float.abs (price -. candidate)) nudge then
+    match side with
+    | Long when Float.( >= ) price candidate -> candidate -. nudge
+    | Short when Float.( <= ) price candidate -> candidate +. nudge
+    | _ -> price
+  else price

--- a/trading/trading/weinstein/stops/lib/stop_nudge.mli
+++ b/trading/trading/weinstein/stops/lib/stop_nudge.mli
@@ -1,0 +1,14 @@
+(** Round-number stop nudging.
+
+    Round numbers and half-dollars attract heavy order flow, so stops placed
+    right at those levels are more likely to be triggered by noise. This steps a
+    raw stop just outside the nearest level. Extracted from [weinstein_stops.ml]
+    to keep that coordinator module under the file-length cap. *)
+
+val nudge_round_number :
+  nudge:float -> side:Trading_base.Types.position_side -> float -> float
+(** [nudge_round_number ~nudge ~side price] returns [price] stepped just outside
+    the nearest half-dollar when it lands within [nudge] of one: for a [Long]
+    the stop moves {b below} the level (by [nudge]), for a [Short] {b above} it.
+    When [price] is farther than [nudge] from the nearest half-dollar, it is
+    returned unchanged. *)

--- a/trading/trading/weinstein/stops/lib/stop_types.ml
+++ b/trading/trading/weinstein/stops/lib/stop_types.ml
@@ -37,6 +37,7 @@ type config = {
   tightened_stop_buffer_pct : float;
   support_floor_lookback_bars : int;
   max_stop_distance_pct : float;
+  trigger_on_weekly_close : bool; [@sexp.default false]
 }
 [@@deriving show, eq, sexp]
 
@@ -50,4 +51,5 @@ let default_config =
     tightened_stop_buffer_pct = 0.005;
     support_floor_lookback_bars = 90;
     max_stop_distance_pct = 0.15;
+    trigger_on_weekly_close = false;
   }

--- a/trading/trading/weinstein/stops/lib/stop_types.mli
+++ b/trading/trading/weinstein/stops/lib/stop_types.mli
@@ -102,6 +102,19 @@ type config = {
           fix was driven by short candidates whose support-floor-derived stop
           sat 16%+ above entry (AOS, HOOD; see
           [dev/notes/g15-stops-diagnostic-aos-hood-2026-05-01.md]). *)
+  trigger_on_weekly_close : bool; [@sexp.default false]
+      (** When [true], a stop fires only when the bar's {b close} crosses the
+          stop level, not its intra-bar low (long) / high (short). On the weekly
+          strategy cadence the bar is a weekly bar, so this is Weinstein's
+          weekly-{e close} rule (book §Stop-Loss Rules, the qc-behavioral L3
+          contract): an intra-week shakeout wick below the stop does {b not}
+          trigger an exit if the week closes back above it.
+
+          Default [false] reproduces the prior intra-bar GTC-stop behaviour
+          bit-for-bit (longs trigger on [low ≤ stop], shorts on [high ≥ stop]),
+          so every existing golden replays unchanged. Default-off experiment
+          axis per [.claude/rules/experiment-flag-discipline.md]; design
+          [dev/plans/weekly-close-stop-2026-06-19.md]. *)
 }
 [@@deriving show, eq, sexp]
 (** Configuration for stop management behavior. All thresholds are configurable

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.ml
@@ -7,33 +7,11 @@ module Support_floor = Support_floor
 module Stop_split_adjust = Stop_split_adjust
 module Stop_widen = Stop_widen
 
-(* ---- Nudge functions ---- *)
-
-(* Round numbers and half-dollars attract heavy order flow, so stops placed right
-   at those levels are more likely to be triggered by noise. We step just outside
-   them when the raw stop lands within [config.round_number_nudge] of a level.
-   The nearest half-dollar (or whole dollar) is used as the reference point. *)
-
-let _nearest_half price =
-  let floor_half = Float.round_down (price /. 0.5) *. 0.5 in
-  let ceil_half = floor_half +. 0.5 in
-  if
-    Float.( < )
-      (Float.abs (price -. ceil_half))
-      (Float.abs (price -. floor_half))
-  then ceil_half
-  else floor_half
-
-(* For longs, nudge the stop below the nearest level; for shorts, above. *)
+(* Round-number nudging lives in {!Stop_nudge} (extracted to keep this
+   coordinator under the file-length cap). This adapts it to the stops config's
+   [round_number_nudge] distance. *)
 let nudge_round_number ~config ~side price =
-  let nudge = config.round_number_nudge in
-  let candidate = _nearest_half price in
-  if Float.( <= ) (Float.abs (price -. candidate)) nudge then
-    match side with
-    | Long when Float.( >= ) price candidate -> candidate -. nudge
-    | Short when Float.( <= ) price candidate -> candidate +. nudge
-    | _ -> price
-  else price
+  Stop_nudge.nudge_round_number ~nudge:config.round_number_nudge ~side price
 
 (* ---- Stop level extraction ---- *)
 
@@ -44,11 +22,25 @@ let get_stop_level = function
 
 (* ---- Stop hit check ---- *)
 
-let check_stop_hit ~state ~side ~bar =
+(* The price the stop trigger compares against the stop level: the intra-bar
+   extreme in the against-trend direction by default (low for longs, high for
+   shorts), or the bar [close] when [on_close] — Weinstein's weekly-close rule,
+   where an intra-bar wick beyond the stop is ignored unless the bar closes
+   beyond it. On the weekly strategy cadence the bar is a weekly bar, so
+   [on_close] = weekly close. *)
+let _trigger_price ~on_close ~side ~bar =
+  if on_close then bar.Types.Daily_price.close_price
+  else
+    match side with
+    | Long -> bar.Types.Daily_price.low_price
+    | Short -> bar.Types.Daily_price.high_price
+
+let check_stop_hit ?(on_close = false) ~state ~side ~bar () =
   let stop_level = get_stop_level state in
+  let price = _trigger_price ~on_close ~side ~bar in
   match side with
-  | Long -> Float.( <= ) bar.Types.Daily_price.low_price stop_level
-  | Short -> Float.( >= ) bar.Types.Daily_price.high_price stop_level
+  | Long -> Float.( <= ) price stop_level
+  | Short -> Float.( >= ) price stop_level
 
 (* ---- Initial stop computation ---- *)
 
@@ -192,8 +184,8 @@ let _should_tighten ~config ~side ~ma_direction ~stage : bool * string =
 
 (* ---- Shared transition builders ---- *)
 
-let _stop_hit_event ~side ~stop_level ~bar =
-  Stop_hit { trigger_price = _bar_extreme ~side ~bar; stop_level }
+let _stop_hit_event ?(on_close = false) ~side ~stop_level ~bar () =
+  Stop_hit { trigger_price = _trigger_price ~on_close ~side ~bar; stop_level }
 
 (* Transitions to Tightened state. Used by both Initial and Trailing handlers. *)
 let _to_tightened ~config ~side ~stop_level ~correction_extreme ~reason =
@@ -248,8 +240,9 @@ let _check_tighten ~config ~side ~stop_level ~correction_extreme ~ma_direction
 let _check_stop_or_tighten ~config ~side ~state ~bar ~correction_extreme
     ~ma_direction ~stage =
   let stop_level = get_stop_level state in
-  if check_stop_hit ~state ~side ~bar then
-    Some (state, _stop_hit_event ~side ~stop_level ~bar)
+  let on_close = config.trigger_on_weekly_close in
+  if check_stop_hit ~on_close ~state ~side ~bar () then
+    Some (state, _stop_hit_event ~on_close ~side ~stop_level ~bar ())
   else
     _check_tighten ~config ~side ~stop_level ~correction_extreme ~ma_direction
       ~stage
@@ -476,8 +469,9 @@ let _update_tightened ~config ~side ~state ~current_bar =
   let bar = current_bar in
   match state with
   | Tightened { stop_level; last_correction_extreme; reason } ->
-      if check_stop_hit ~state ~side ~bar then
-        (state, _stop_hit_event ~side ~stop_level ~bar)
+      let on_close = config.trigger_on_weekly_close in
+      if check_stop_hit ~on_close ~state ~side ~bar () then
+        (state, _stop_hit_event ~on_close ~side ~stop_level ~bar ())
       else
         _ratchet_tightened ~config ~side ~stop_level ~last_correction_extreme
           ~reason ~bar

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.mli
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.mli
@@ -116,11 +116,22 @@ val compute_initial_stop_with_floor_with_callbacks :
     inline. *)
 
 val check_stop_hit :
-  state:stop_state -> side:position_side -> bar:Types.Daily_price.t -> bool
+  ?on_close:bool ->
+  state:stop_state ->
+  side:position_side ->
+  bar:Types.Daily_price.t ->
+  unit ->
+  bool
 (** [true] if the bar's trigger price crossed the stop level.
 
-    Long: triggered by [low_price ≤ stop_level]. Short: triggered by
-    [high_price ≥ stop_level]. *)
+    Default ([on_close = false]) uses the intra-bar extreme — Long: triggered by
+    [low_price ≤ stop_level]; Short: [high_price ≥ stop_level].
+
+    With [on_close = true] the trigger uses the bar's [close_price] instead
+    (Long: [close ≤ stop_level]; Short: [close ≥ stop_level]) — Weinstein's
+    weekly-close rule: an intra-bar wick beyond the stop does not trigger unless
+    the bar closes beyond it. On the weekly strategy cadence the bar is a weekly
+    bar, so this is the weekly close. *)
 
 val get_stop_level : stop_state -> float
 (** Extract the current stop price from any state. *)

--- a/trading/trading/weinstein/stops/test/test_weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/test/test_weinstein_stops.ml
@@ -145,26 +145,66 @@ let test_compute_initial_stop_short _ =
 let test_check_stop_hit_long _ =
   let state = Initial { stop_level = 45.0; reference_level = 47.0 } in
   assert_that
-    (check_stop_hit ~state ~side:Long ~bar:(make_bar ~low_price:44.0 ()))
+    (check_stop_hit ~state ~side:Long ~bar:(make_bar ~low_price:44.0 ()) ())
     (equal_to true);
   assert_that
-    (check_stop_hit ~state ~side:Long ~bar:(make_bar ~low_price:45.0 ()))
+    (check_stop_hit ~state ~side:Long ~bar:(make_bar ~low_price:45.0 ()) ())
     (equal_to true);
   assert_that
-    (check_stop_hit ~state ~side:Long ~bar:(make_bar ~low_price:46.0 ()))
+    (check_stop_hit ~state ~side:Long ~bar:(make_bar ~low_price:46.0 ()) ())
     (equal_to false)
 
 let test_check_stop_hit_short _ =
   let state = Initial { stop_level = 55.0; reference_level = 53.0 } in
   assert_that
-    (check_stop_hit ~state ~side:Short ~bar:(make_bar ~high_price:56.0 ()))
+    (check_stop_hit ~state ~side:Short ~bar:(make_bar ~high_price:56.0 ()) ())
     (equal_to true);
   assert_that
-    (check_stop_hit ~state ~side:Short ~bar:(make_bar ~high_price:55.0 ()))
+    (check_stop_hit ~state ~side:Short ~bar:(make_bar ~high_price:55.0 ()) ())
     (equal_to true);
   assert_that
-    (check_stop_hit ~state ~side:Short ~bar:(make_bar ~high_price:54.0 ()))
+    (check_stop_hit ~state ~side:Short ~bar:(make_bar ~high_price:54.0 ()) ())
     (equal_to false)
+
+(* on_close=true: a long stop ignores an intra-bar wick below the stop and fires
+   only when the bar CLOSES below it (Weinstein weekly-close rule). Stop 45. *)
+let test_check_stop_hit_weekly_close_long _ =
+  let state = Initial { stop_level = 45.0; reference_level = 47.0 } in
+  (* wick below (low 44) but close back above (46) -> no trigger on close;
+     the default low-based check WOULD have triggered. *)
+  let shakeout = make_bar ~low_price:44.0 ~close_price:46.0 () in
+  assert_that
+    (check_stop_hit ~on_close:true ~state ~side:Long ~bar:shakeout ())
+    (equal_to false);
+  assert_that
+    (check_stop_hit ~state ~side:Long ~bar:shakeout ())
+    (equal_to true);
+  (* close at/below the stop -> trigger on close. *)
+  assert_that
+    (check_stop_hit ~on_close:true ~state ~side:Long
+       ~bar:(make_bar ~low_price:44.0 ~close_price:45.0 ())
+       ())
+    (equal_to true);
+  assert_that
+    (check_stop_hit ~on_close:true ~state ~side:Long
+       ~bar:(make_bar ~low_price:40.0 ~close_price:43.0 ())
+       ())
+    (equal_to true)
+
+(* on_close=true short: ignores an intra-bar high spike above the stop, fires
+   only when the bar closes above it. Stop 55. *)
+let test_check_stop_hit_weekly_close_short _ =
+  let state = Initial { stop_level = 55.0; reference_level = 53.0 } in
+  let spike = make_bar ~high_price:56.0 ~close_price:54.0 () in
+  assert_that
+    (check_stop_hit ~on_close:true ~state ~side:Short ~bar:spike ())
+    (equal_to false);
+  assert_that (check_stop_hit ~state ~side:Short ~bar:spike ()) (equal_to true);
+  assert_that
+    (check_stop_hit ~on_close:true ~state ~side:Short
+       ~bar:(make_bar ~high_price:56.0 ~close_price:55.0 ())
+       ())
+    (equal_to true)
 
 (* ---- get_stop_level tests ---- *)
 
@@ -570,6 +610,10 @@ let suite =
          "initial_stop_short" >:: test_compute_initial_stop_short;
          "check_stop_hit_long" >:: test_check_stop_hit_long;
          "check_stop_hit_short" >:: test_check_stop_hit_short;
+         "check_stop_hit_weekly_close_long"
+         >:: test_check_stop_hit_weekly_close_long;
+         "check_stop_hit_weekly_close_short"
+         >:: test_check_stop_hit_weekly_close_short;
          "get_stop_level_initial" >:: test_get_stop_level_initial;
          "get_stop_level_trailing" >:: test_get_stop_level_trailing;
          "get_stop_level_tightened" >:: test_get_stop_level_tightened;

--- a/trading/trading/weinstein/strategy/lib/sector_rotation_stops.ml
+++ b/trading/trading/weinstein/strategy/lib/sector_rotation_stops.ml
@@ -59,7 +59,7 @@ let step ~stops_config ~(stage_result : Stage.result option)
     ~(state : Weinstein_stops.stop_state) ~(pos : Position.t)
     ~(bar : Types.Daily_price.t) :
     Weinstein_stops.stop_state * Position.transition option =
-  if Weinstein_stops.check_stop_hit ~state ~side:Position.Long ~bar then
+  if Weinstein_stops.check_stop_hit ~state ~side:Position.Long ~bar () then
     let stop_level = Weinstein_stops.get_stop_level state in
     (state, Some (Spy_only_transitions.build_stop_exit ~pos ~bar ~stop_level))
   else if not (_is_weekly_close ~date:bar.date) then (state, None)

--- a/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/spy_only_weinstein_strategy.ml
@@ -159,7 +159,7 @@ let _step_stop ~config ~(side : Position.position_side)
     ~(stage_result : Stage.result option) ~(state : Weinstein_stops.stop_state)
     ~(pos : Position.t) ~(bar : Types.Daily_price.t) :
     Weinstein_stops.stop_state * Position.transition option =
-  if Weinstein_stops.check_stop_hit ~state ~side ~bar then
+  if Weinstein_stops.check_stop_hit ~state ~side ~bar () then
     let stop_level = Weinstein_stops.get_stop_level state in
     (state, Some (Spy_only_transitions.build_stop_exit ~pos ~bar ~stop_level))
   else if not (_is_weekly_close ~date:bar.date) then (state, None)

--- a/trading/trading/weinstein/strategy/lib/stops_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.ml
@@ -88,13 +88,19 @@ let _compute_ma_and_stage ?ma_cache ?prior_stage_ma_values
     against profitable territory — the recorded actual price was the bar low,
     not the trigger price near the high. See G1 in
     [dev/notes/short-side-gaps-2026-04-29.md]. *)
-let _trigger_fill_price ~(side : Trading_base.Types.position_side) ~bar =
-  match side with
-  | Long -> bar.Types.Daily_price.low_price
-  | Short -> bar.Types.Daily_price.high_price
+let _trigger_fill_price ?(on_close = false)
+    ~(side : Trading_base.Types.position_side) ~bar () =
+  if on_close then bar.Types.Daily_price.close_price
+  else
+    match side with
+    | Long -> bar.Types.Daily_price.low_price
+    | Short -> bar.Types.Daily_price.high_price
 
-let _make_exit_transition ~(pos : Position.t) ~current_date ~state ~bar =
-  let actual_price = _trigger_fill_price ~side:pos.Position.side ~bar in
+let _make_exit_transition ?(on_close = false) ~(pos : Position.t) ~current_date
+    ~state ~bar () =
+  let actual_price =
+    _trigger_fill_price ~on_close ~side:pos.Position.side ~bar ()
+  in
   let exit_reason =
     Position.StopLoss
       {
@@ -131,19 +137,25 @@ let _make_adjust_transition ~(pos : Position.t) ~current_date
     placement re-evaluation is weekly. If the bar's high/low crosses the
     existing stop level, an exit transition is emitted at the same actual_price
     the daily path would have used (bar low for longs, bar high for shorts). *)
-let _handle_stop_trigger_only ~(pos : Position.t) ~state ~bar ~current_date =
-  if Weinstein_stops.check_stop_hit ~state ~side:pos.Position.side ~bar then
-    (Some (_make_exit_transition ~pos ~current_date ~state ~bar), None)
+let _handle_stop_trigger_only ~on_close ~(pos : Position.t) ~state ~bar
+    ~current_date =
+  if
+    Weinstein_stops.check_stop_hit ~on_close ~state ~side:pos.Position.side ~bar
+      ()
+  then
+    ( Some (_make_exit_transition ~on_close ~pos ~current_date ~state ~bar ()),
+      None )
   else (None, None)
 
 (** Translate a {!Weinstein_stops.stop_event} into the (exit, adjust) transition
     pair the runner emits to the strategy. Pure mapping — extracted from
     [_handle_stop] to keep that function within the nesting linter's limits. *)
-let _transitions_of_stop_event ~(pos : Position.t)
+let _transitions_of_stop_event ~on_close ~(pos : Position.t)
     ~(risk_params : Position.risk_params) ~state ~bar ~current_date ~event =
   match event with
   | Weinstein_stops.Stop_hit _ ->
-      (Some (_make_exit_transition ~pos ~current_date ~state ~bar), None)
+      ( Some (_make_exit_transition ~on_close ~pos ~current_date ~state ~bar ()),
+        None )
   | Weinstein_stops.Stop_raised { new_level; _ } ->
       ( None,
         Some
@@ -169,7 +181,9 @@ let _handle_stop_full ?ma_cache ?prior_stage_ma_values ~stops_config
       ~current_bar:bar ~ma_value ~ma_direction ~stage
   in
   stop_states := Map.set !stop_states ~key:ticker ~data:new_state;
-  _transitions_of_stop_event ~pos ~risk_params ~state ~bar ~current_date ~event
+  _transitions_of_stop_event
+    ~on_close:stops_config.Weinstein_stops.trigger_on_weekly_close ~pos
+    ~risk_params ~state ~bar ~current_date ~event
 
 (** Process stop logic for one held position. Returns (exit_transition option,
     adjust_transition option).
@@ -189,7 +203,9 @@ let _handle_stop ?ma_cache ?prior_stage_ma_values ?(stop_update_cadence = Daily)
     | Weekly -> _is_weekly_close ~as_of
   in
   if not advance_state_machine then
-    _handle_stop_trigger_only ~pos ~state ~bar ~current_date
+    _handle_stop_trigger_only
+      ~on_close:stops_config.Weinstein_stops.trigger_on_weekly_close ~pos ~state
+      ~bar ~current_date
   else
     _handle_stop_full ?ma_cache ?prior_stage_ma_values ~stops_config
       ~stage_config ~lookback_bars ~pos ~risk_params ~state ~bar ~stop_states

--- a/trading/trading/weinstein/strategy/test/test_stops_split_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_split_runner.ml
@@ -244,7 +244,7 @@ let test_split_day_no_spurious_stop_hit _ =
   let scaled = Map.find_exn !stop_states symbol in
   assert_that
     (Weinstein_stops.check_stop_hit ~state:scaled ~side:Trading_base.Types.Long
-       ~bar:split_day_bar)
+       ~bar:split_day_bar ())
     (equal_to false)
 
 (* Control case: same scenario, but the post-split bar drops below the
@@ -291,7 +291,7 @@ let test_real_adverse_move_after_split_still_triggers _ =
   let scaled = Map.find_exn !stop_states symbol in
   assert_that
     (Weinstein_stops.check_stop_hit ~state:scaled ~side:Trading_base.Types.Long
-       ~bar:adverse_bar)
+       ~bar:adverse_bar ())
     (equal_to true)
 
 (* Pin: when the position has no entry in [stop_states], adjust is a


### PR DESCRIPTION
## What & why
The decision-grading lens showed `stop_loss` is **whipsaw-dominated** — it forgoes more upside (+30-33% mean) than the disaster it dodges (−19% mean), net per-decision negative even through dot-com+GFC (`dev/experiments/decision-grading-deep-2026-06-18/`). Root cause: the live stop is a **GTC broker stop checked on the bar low**, so an intra-week shakeout *wick* below the stop triggers an exit even when the week closes back above it.

This adds Weinstein's **L3 weekly-close rule** as a **default-off dial**: `stop_types.config.trigger_on_weekly_close` (`bool [@sexp.default false]`). When true, the stop trigger + fill use the bar **close** (long: `close ≤ stop`; short: `close ≥ stop`) instead of the intra-bar low/high. On the weekly strategy cadence the bar is a weekly bar, so this is the weekly close.

- Threaded via `Weinstein_stops.check_stop_hit ?on_close` + `_stop_hit_event` + `stops_runner` (`_trigger_fill_price` / `_handle_stop_trigger_only` / `_transitions_of_stop_event`).
- Extracted the round-number nudge helpers to a new `Stop_nudge` module to keep `weinstein_stops.ml` under the file-length cap (code-health; no behaviour change — thin `~config` adapter retained).

## Default-off invariant (load-bearing)
Default `false` reproduces the prior intra-bar GTC behaviour bit-for-bit. **Full `dune build && dune runtest` green, all goldens bit-identical.** Spine-faithful dial (`weinstein-faithful-core` W1/W2 — Weinstein L3, stop placement untouched); default-off experiment axis (`experiment-flag-discipline` R1/R2). Not wired into any default config — stays an axis until WF-CV + the promotion grid.

## Test plan
- 2 new `check_stop_hit` weekly-close tests (long+short): an intra-bar wick beyond the stop does NOT trigger unless the bar closes beyond it; default-off path unchanged. 33 stops tests pass.
- Full `dune runtest` clean (nesting + magic-number + file-length linters pass after the Stop_nudge extraction).

A1 note: touches `weinstein/stops` + `weinstein/strategy` (Weinstein-specific, not the core `trading/strategy` interface). Plan: `dev/plans/weekly-close-stop-2026-06-19.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)