### PR TITLE
docs: P0 levers landed (#1659 + #1662) + next-session plan + memory refresh

### DIFF
--- a/dev/agent-memory/project_short_funnel_crowded_out.md
+++ b/dev/agent-memory/project_short_funnel_crowded_out.md
@@ -47,3 +47,17 @@ screen is the test. Do NOT re-conclude "shorts work" until the sleeve is screene
 **STATUS 2026-06-19:** diagnosis done (read-only). Reserved-short-sleeve = NOT
 built. Candidate next lever alongside vol-scaled stop ([[project_weekly_close_stop_lever]]
 §stop-quality-levers-beyond-weekly-close).
+
+**STATUS 2026-06-19: BUILT + MERGED #1659.** Default-off
+`Weinstein_strategy_config.short_sleeve_fraction : float [@sexp.default 0.0]`.
+When `> 0.0`, `entries_from_candidates` partitions the per-Friday cash budget into
+a reserved short-only budget (`fraction * portfolio_value`) walked independently
+of the long book (two `remaining_cash` refs, shared `short_notional_acc` /
+`sector_exposure_acc` so caps still bind); `<= 0.0` bit-identical. Tests confirm
+the crowd-out (3 longs exhaust cash → 0 shorts) flips to a short entering at
+fraction 0.3. Searchable nested `Variant_matrix` axis; NOT wired into any preset.
+**The build only proved shorts now ENTER — it did NOT prove they HELP.** NEXT =
+lens-screen `short_sleeve_fraction` ∈ {0.1,0.2,0.3} via `decision_grading`: do the
+now-numerous shorts add a real offsetting/DD-reducing leg, or churn at ~breakeven
+(the (c) symptom)? Real offset → WF-CV + grid; else record no-build-with-why
+(capital reserved for a non-paying leg = drag) and keep default-off.

--- a/dev/agent-memory/project_weekly_close_stop_lever.md
+++ b/dev/agent-memory/project_weekly_close_stop_lever.md
@@ -92,3 +92,17 @@ That does NOT exhaust stop quality. The lens-aligned levers it does not touch:
    incidental laggard/re-screen re-entry.
 Both UNTESTED. Vol-scaled is the better bet (the whipsaw is buffer-vs-volatility
 mismatch; weekly-close failed by changing WHEN not HOW-FAR).
+
+**STATUS 2026-06-19: vol-scaled stop BUILT + MERGED #1662.** Default-off
+`Weinstein_stops.config.vol_scaled_stop_atr_mult : float [@sexp.default 0.0]`
+(+ `vol_scaled_stop_atr_period [@sexp.default 14]`). When `> 0.0`, the minimum
+installed-stop distance becomes `Float.max(installed_stop_min_pct, mult *
+ATR/entry)` via new pure primitive `Weinstein_stops.Vol_scaled_stop`
+(ATR from `analysis/technical/indicators/atr`); only ever WIDENS the floor
+(never narrows below 8%, never loosens a trailing stop), `max_stop_distance_pct`
+15% cap still rejects after; `<= 0.0` bit-identical. Wired per-candidate via
+`entry_stop_distance.ml`. Searchable nested axis; NOT wired into any preset.
+NEXT = lens-screen `vol_scaled_stop_atr_mult` ∈ {1.0,1.5,2.0}: does stop
+upside-foregone shrink while disaster-dodged holds (the asymmetry weekly-close
+failed)? Promising → WF-CV + grid. **Weekly-close (`trigger_on_weekly_close`,
+#1655) stays REJECTED.** Post-stop re-entry still untested.

--- a/dev/notes/next-session-priorities-2026-06-19.md
+++ b/dev/notes/next-session-priorities-2026-06-19.md
@@ -1,0 +1,96 @@
+# Next-session priorities — 2026-06-20
+
+**Supersedes** `next-session-priorities-2026-06-18.md`. Check main CI green first
+(`.claude/rules/session-rampup.md`). This was an autonomous overnight run
+(2026-06-18/19) per `dev/notes/overnight-plan-2026-06-19.md` — user AFK.
+
+## What shipped overnight (all merged, main green)
+
+The **decision-grading lens** is complete and was used end-to-end to judge three
+strategy questions at the decision level (not by aggregate Sharpe). PRs this run:
+#1649 (lens Phases 3-4), #1650 (MFE-join fix), #1652 (insurance decomposition +
+deep stop read), #1653 (Phase-5 laggard counterfactual), #1654 (docs), #1655
+(weekly-close stop flag, default-off).
+
+### The a→b→c arc + the stop lever — all answered
+
+1. **(a) Stops are whipsaw-dominated** — forgo more upside (+30-33%) than disaster
+   dodged (−19%), net per-decision negative even through dot-com+GFC.
+2. **(b) Laggard-rotation swap is a coin flip** (~50%, ≈+1%); its value is
+   capital-recycling/freshness, not selection. Keep on, don't tune selection.
+3. **(c) Long-short short leg is anemic** (37 trades/28y, ~breakeven) — weak/
+   confounded DD diversifier → no-build; barbell remains the DD lever.
+4. **Weekly-close stop (the (a) follow-up lever) — BUILT + REJECTED.** Decisively
+   worse in BOTH regimes (deep −457pp; bull return halved + DD up). The whipsaw is
+   real but NOT recapturable by a looser trigger: the strategy already re-enters
+   recoverers, and weekly-close just holds genuine breakdowns deeper. **Closes the
+   stop-tuning thread.** `dev/experiments/weekly-close-screen-2026-06-19/`,
+   `project_weekly_close_stop_lever`.
+
+### The compounding meta-finding (drives the next lever)
+
+Every **selection / holding-discipline tweak** screened this month is a dead end:
+entry-selection (coin flip), cascade-reweight (WF-CV rejected), laggard swap (coin
+flip), short-pick (anemic), weekly-close stop (worse). The edge is the let-winners-
+run fat tail; mechanisms that touch *which names* or *cut-losers-fast* either
+coin-flip or backfire (`project_edge_is_the_fat_tail`,
+`project_accuracy_is_unreachable_diversify_instead`). **The only live levers are
+structural diversification (barbell: SPY-floor + engine, `project_barbell_on_stocks`)
+and possibly breadth/universe** — NOT selection or exit tuning.
+
+## P0 NEXT — two NEW levers surfaced 2026-06-19 (user review of the no-builds)
+
+The user pushed back on two of the no-builds and BOTH reframings hold up — these
+are the top levers now (not selection tweaks; both default-off → lens screen →
+WF-CV → grid):
+
+### P0a — RESERVED SHORT SLEEVE (reframes the (c) long-short no-build)
+`project_short_funnel_crowded_out`. The (c) "short leg anemic (37 trades/28y)"
+was the symptom, not the cause. The short cascade OFFERS 1,662 candidate-slots
+over 28y but only 37 ENTER (2%), with **0 short fills rejected** — shorts are
+**never reached**: candidates are appended after longs (`buy_candidates @
+short_candidates`) and the entry walk exhausts capital/`max_long_exposure 0.70`
+on longs first. Shorts are crowded out by ordering + the long budget, NOT signal
+rarity/quality. **Build a reserved short exposure budget** (dedicated short
+sleeve, sized + walked independently of the long book) default-off, then lens-
+screen: do the now-numerous shorts add a real offsetting/DD-reducing leg?
+Injection point scoped: `weinstein_strategy_screening.ml` `entries_from_candidates`
++ `_entry_walk_state` (short-notional accumulator infra already exists; add a
+short-exposure reservation/cap). Portfolio-allocation lever = structural
+diversification (the live class), distinct from loosening the Ch.11 cascade
+(spine — do NOT).
+
+### P0b — VOL-SCALED STOP DISTANCE (the stop-quality lever weekly-close didn't touch)
+`project_weekly_close_stop_lever` §stop-quality-levers. Weekly-close REJECTED
+(held breakdowns deeper). But the live stop is a FIXED 8% buffer regardless of a
+name's volatility — high-vol names get whipsawed by the same buffer that fits
+low-vol names (the code's own flagged TODO on `min_correction_pct`). Scale the
+stop buffer to the name's volatility (ATR) → cuts whipsaw at its SOURCE without
+holding breakdowns deeper (weekly-close's fatal flaw). Default-off `vol_scaled_stop`
+flag → lens screen (does stop upside-foregone shrink while disaster-dodged holds,
+unlike weekly-close?) → WF-CV. Secondary stop lever: post-stop re-entry.
+
+### P1 — barbell promotion (still valid, lower priority than the two above)
+`project_barbell_on_stocks`: SPY-timing floor + Cell-E engine NAV blend beat both
+legs on Calmar (deep + bull); never taken to a promotion grid. WF-CV +
+`promotion-confirmation.md`.
+
+Do NOT start another *selection* screen (entry/cascade/swap/short-pick) — that
+class is a dead end five times over. P0a/P0b/P1 are all structural/quality, not
+selection.
+
+## P1 — lens as standing instrument
+The `decision_grading` + `laggard_cf` bins are the repeatable instrument; grade any
+future candidate at the decision level before/after. Harness gap (non-blocking,
+carried): the bins' I/O glue (`_mfe_index`/`_find_mfe`, csv/forward extraction) is
+untested over the pinned libs — factor into a tested shared helper if the lens
+becomes more load-bearing.
+
+## State
+- All PRs merged, main green, 0 open PRs (verify at session start).
+- v2 warehouses at `/tmp/snap_top3000_{2000,2011,1998_2026}_v2`; backtests run
+  clean at `SNAPSHOT_CACHE_MB=1024`. Scenario-runner gotcha: `universe_path` is
+  resolved relative to `--fixtures-root`; use the leading-slash-stripped path +
+  `--fixtures-root /`.
+- Lens lives at `trading/trading/backtest/decision_grading/` (libs Post_exit /
+  Grade / Aggregate / Laggard_cf + bins decision_grading, laggard_cf).

--- a/dev/notes/next-session-priorities-2026-06-20.md
+++ b/dev/notes/next-session-priorities-2026-06-20.md
@@ -1,96 +1,98 @@
 # Next-session priorities — 2026-06-20
 
-**Supersedes** `next-session-priorities-2026-06-18.md`. Check main CI green first
-(`.claude/rules/session-rampup.md`). This was an autonomous overnight run
-(2026-06-18/19) per `dev/notes/overnight-plan-2026-06-19.md` — user AFK.
+**Supersedes** `next-session-priorities-2026-06-19.md`. Check main CI green first
+(`.claude/rules/session-rampup.md`). The 2026-06-19 session built + landed both P0
+levers the 06-19 doc surfaced.
 
-## What shipped overnight (all merged, main green)
+## What shipped 2026-06-19 (both default-off, per experiment-flag-discipline)
 
-The **decision-grading lens** is complete and was used end-to-end to judge three
-strategy questions at the decision level (not by aggregate Sharpe). PRs this run:
-#1649 (lens Phases 3-4), #1650 (MFE-join fix), #1652 (insurance decomposition +
-deep stop read), #1653 (Phase-5 laggard counterfactual), #1654 (docs), #1655
-(weekly-close stop flag, default-off).
+1. **P0a — RESERVED SHORT SLEEVE: MERGED #1659.** Default-off
+   `Weinstein_strategy_config.short_sleeve_fraction : float [@sexp.default 0.0]`.
+   When `> 0.0`, `entries_from_candidates` partitions the per-Friday cash budget
+   into a reserved short-only budget (`fraction * portfolio_value`) walked
+   independently of longs, fixing the diagnosed crowd-out
+   (`project_short_funnel_crowded_out`: 1,662 short slots offered / 37 entered /
+   0 rejected over 28y — shorts were never *reached*, not rejected). `<= 0.0` is
+   bit-identical. Searchable `Variant_matrix` nested axis. **Not wired into any
+   preset.**
 
-### The a→b→c arc + the stop lever — all answered
+2. **P0b — VOL-SCALED STOP DISTANCE: MERGED #1662.** Default-off
+   `Weinstein_stops.config.vol_scaled_stop_atr_mult : float [@sexp.default 0.0]`
+   (+ `vol_scaled_stop_atr_period [@sexp.default 14]`). When `> 0.0`, the minimum
+   installed-stop distance becomes
+   `Float.max(installed_stop_min_pct, mult * ATR/entry)` — volatile names get a
+   structurally wider stop floor (whipsaw reduction *at source*, the lever
+   weekly-close #1655 couldn't reach without holding breakdowns deeper). `<= 0.0`
+   bit-identical. New pure primitive `Weinstein_stops.Vol_scaled_stop`; ATR from
+   `analysis/technical/indicators/atr`; the `max_stop_distance_pct` 15% reject cap
+   still applies after the widened floor (pinned by test). Searchable nested axis.
+   **Not wired into any preset.**
 
-1. **(a) Stops are whipsaw-dominated** — forgo more upside (+30-33%) than disaster
-   dodged (−19%), net per-decision negative even through dot-com+GFC.
-2. **(b) Laggard-rotation swap is a coin flip** (~50%, ≈+1%); its value is
-   capital-recycling/freshness, not selection. Keep on, don't tune selection.
-3. **(c) Long-short short leg is anemic** (37 trades/28y, ~breakeven) — weak/
-   confounded DD diversifier → no-build; barbell remains the DD lever.
-4. **Weekly-close stop (the (a) follow-up lever) — BUILT + REJECTED.** Decisively
-   worse in BOTH regimes (deep −457pp; bull return halved + DD up). The whipsaw is
-   real but NOT recapturable by a looser trigger: the strategy already re-enters
-   recoverers, and weekly-close just holds genuine breakdowns deeper. **Closes the
-   stop-tuning thread.** `dev/experiments/weekly-close-screen-2026-06-19/`,
-   `project_weekly_close_stop_lever`.
+Both lands are SAFE (default = pre-existing no-op, every golden bit-identical);
+neither changes live/backtest behaviour until a spec flips the flag.
 
-### The compounding meta-finding (drives the next lever)
+## P0 NEXT — screen the two flags (the actual alpha question)
 
-Every **selection / holding-discipline tweak** screened this month is a dead end:
-entry-selection (coin flip), cascade-reweight (WF-CV rejected), laggard swap (coin
-flip), short-pick (anemic), weekly-close stop (worse). The edge is the let-winners-
-run fat tail; mechanisms that touch *which names* or *cut-losers-fast* either
-coin-flip or backfire (`project_edge_is_the_fat_tail`,
-`project_accuracy_is_unreachable_diversify_instead`). **The only live levers are
-structural diversification (barbell: SPY-floor + engine, `project_barbell_on_stocks`)
-and possibly breadth/universe** — NOT selection or exit tuning.
+Both levers are BUILT and searchable but UNPROVEN. The whole point of landing
+them default-off is to now *test* whether they help. Per
+`experiment-flag-discipline.md` R3 + `promotion-confirmation.md`, neither flips
+a default without a ledger ACCEPT + a confirmation grid.
 
-## P0 NEXT — two NEW levers surfaced 2026-06-19 (user review of the no-builds)
+### P0a-screen — reserved short sleeve
+Lens-screen the sleeve via the `decision_grading` instrument: with the sleeve
+funded (`short_sleeve_fraction` ∈ {0.1, 0.2, 0.3}), do the now-numerous shorts
+add a **real offsetting / DD-reducing** leg, or just churn at ~breakeven (the (c)
+symptom)? The build only proved shorts now *enter* — it did NOT prove they help.
+If the lens shows a genuine offset → WF-CV surface → confirmation grid. If it's
+still ~breakeven/coin-flip → record the no-build *with the why* (capital reserved
+for a leg that doesn't pay = drag) and keep default-off as an axis.
 
-The user pushed back on two of the no-builds and BOTH reframings hold up — these
-are the top levers now (not selection tweaks; both default-off → lens screen →
-WF-CV → grid):
+### P0b-screen — vol-scaled stop
+Lens-screen `vol_scaled_stop_atr_mult` ∈ {1.0, 1.5, 2.0}: does stop
+**upside-foregone shrink while disaster-dodged holds** (the asymmetry
+weekly-close failed)? The decision-grading stop lens already measures
+forgone-upside vs disaster-dodged per stop decision — re-run it with the flag on.
+Promising → WF-CV surface → grid. Secondary stop lever still open: post-stop
+re-entry.
 
-### P0a — RESERVED SHORT SLEEVE (reframes the (c) long-short no-build)
-`project_short_funnel_crowded_out`. The (c) "short leg anemic (37 trades/28y)"
-was the symptom, not the cause. The short cascade OFFERS 1,662 candidate-slots
-over 28y but only 37 ENTER (2%), with **0 short fills rejected** — shorts are
-**never reached**: candidates are appended after longs (`buy_candidates @
-short_candidates`) and the entry walk exhausts capital/`max_long_exposure 0.70`
-on longs first. Shorts are crowded out by ordering + the long budget, NOT signal
-rarity/quality. **Build a reserved short exposure budget** (dedicated short
-sleeve, sized + walked independently of the long book) default-off, then lens-
-screen: do the now-numerous shorts add a real offsetting/DD-reducing leg?
-Injection point scoped: `weinstein_strategy_screening.ml` `entries_from_candidates`
-+ `_entry_walk_state` (short-notional accumulator infra already exists; add a
-short-exposure reservation/cap). Portfolio-allocation lever = structural
-diversification (the live class), distinct from loosening the Ch.11 cascade
-(spine — do NOT).
+**Watch the estimand (`mechanism-validation-rigor`):** a lens screen rejects
+*prioritization*, not the mechanism; only WF-CV rejects the mechanism. Calibrate
+verdicts accordingly.
 
-### P0b — VOL-SCALED STOP DISTANCE (the stop-quality lever weekly-close didn't touch)
-`project_weekly_close_stop_lever` §stop-quality-levers. Weekly-close REJECTED
-(held breakdowns deeper). But the live stop is a FIXED 8% buffer regardless of a
-name's volatility — high-vol names get whipsawed by the same buffer that fits
-low-vol names (the code's own flagged TODO on `min_correction_pct`). Scale the
-stop buffer to the name's volatility (ATR) → cuts whipsaw at its SOURCE without
-holding breakdowns deeper (weekly-close's fatal flaw). Default-off `vol_scaled_stop`
-flag → lens screen (does stop upside-foregone shrink while disaster-dodged holds,
-unlike weekly-close?) → WF-CV. Secondary stop lever: post-stop re-entry.
-
-### P1 — barbell promotion (still valid, lower priority than the two above)
+## P1 — barbell promotion (unchanged, still valid)
 `project_barbell_on_stocks`: SPY-timing floor + Cell-E engine NAV blend beat both
 legs on Calmar (deep + bull); never taken to a promotion grid. WF-CV +
-`promotion-confirmation.md`.
+`promotion-confirmation.md`. Lower priority than screening the two just-built
+flags (those are hot — built this session, untested).
 
-Do NOT start another *selection* screen (entry/cascade/swap/short-pick) — that
-class is a dead end five times over. P0a/P0b/P1 are all structural/quality, not
-selection.
+## Guardrail (carried)
+Do NOT start another *selection* screen (entry/cascade/swap/short-pick) — dead
+end five times over (`project_edge_is_the_fat_tail`,
+`project_accuracy_is_unreachable_diversify_instead`). The live class is
+structural diversification + stop/holding quality. Both P0 levers are in that
+class; keep search there.
 
 ## P1 — lens as standing instrument
-The `decision_grading` + `laggard_cf` bins are the repeatable instrument; grade any
-future candidate at the decision level before/after. Harness gap (non-blocking,
-carried): the bins' I/O glue (`_mfe_index`/`_find_mfe`, csv/forward extraction) is
-untested over the pinned libs — factor into a tested shared helper if the lens
+The `decision_grading` + `laggard_cf` bins are the repeatable instrument; grade
+any candidate at the decision level before/after. Harness gap (non-blocking,
+carried): the bins' I/O glue (`_mfe_index`/`_find_mfe`, csv/forward extraction)
+is untested over the pinned libs — factor into a tested shared helper if the lens
 becomes more load-bearing.
 
 ## State
-- All PRs merged, main green, 0 open PRs (verify at session start).
+- Both P0 PRs merged (#1659, #1662), main green, 0 open PRs (verify at session start).
 - v2 warehouses at `/tmp/snap_top3000_{2000,2011,1998_2026}_v2`; backtests run
   clean at `SNAPSHOT_CACHE_MB=1024`. Scenario-runner gotcha: `universe_path` is
   resolved relative to `--fixtures-root`; use the leading-slash-stripped path +
   `--fixtures-root /`.
-- Lens lives at `trading/trading/backtest/decision_grading/` (libs Post_exit /
-  Grade / Aggregate / Laggard_cf + bins decision_grading, laggard_cf).
+- Lens lives at `trading/trading/backtest/decision_grading/`.
+- New surfaces to screen: `short_sleeve_fraction` (nested under
+  `Weinstein_strategy.config`) and `stops_config.vol_scaled_stop_atr_mult`.
+
+## Process note (this session)
+The P0b feat-agent died mid-run on a 401 (auth expiry); its work was complete on
+disk and recovered + finished dispatcher-side. Three dispatcher fixes followed:
+file-length extraction (real QC finding), magic-number on `[@sexp.default 14]`
+(CI-only catch the QC agent's build-only run missed — confirms CI is the only
+full-lint gate), and a behavioral CP4 test gap (the cap-after-vol-floor reject
+was undocumented-by-test). All resolved; both gates + CI green.


### PR DESCRIPTION
Docs-only. Records both P0 levers landed default-off this session (reserved short sleeve #1659, vol-scaled ATR stop #1662), corrects the next-session-priorities date (the 06-20 doc guided the 06-19 session → renamed to 06-19; new 06-20 plan added), and refreshes the two relevant memories + agent-memory snapshot. Next = lens-screen both new flag surfaces before any promotion grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)